### PR TITLE
Add sweep state audit command

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Recently reviewed:
 
 ## How It Works
 
-The normal workflow is proposal-only. It runs configurable parallel shards and never comments or closes unless `apply_closures=true` is explicitly set for a manual run.
+The normal workflow is proposal-only. It runs configurable parallel shards and never comments or closes during review. `apply_existing=true` is the only workflow mode that comments or closes items.
 
 Each review job:
 
@@ -95,6 +95,8 @@ To close later without rerunning Codex, dispatch the workflow with `apply_existi
 
 Maintainer-authored items are never auto-closed. Candidate planning and apply mode both read GitHub's `author_association` field and exclude `OWNER`, `MEMBER`, and `COLLABORATOR` items from automated close actions.
 
+`npm run audit` compares live open GitHub items with the generated `items/` and `closed/` records without moving files. It reports missing open records, open records still archived under `closed/`, stale `items/` records that no longer appear open, duplicate markdown records, protected-label proposed closes, and stale review-status records. Use `--output audit-report.json` for the full report, `--sample-limit N` to control console samples, and `--strict` to exit non-zero when state drift is present.
+
 ## Local Run
 
 Requires Node 24.
@@ -106,6 +108,7 @@ npm run build
 npm run plan -- --batch-size 5 --shard-count 40 --max-pages 250 --codex-model gpt-5.5 --codex-reasoning-effort medium --codex-service-tier fast
 npm run review -- --openclaw-dir ../openclaw --batch-size 5 --max-pages 250 --artifact-dir artifacts/reviews --codex-model gpt-5.5 --codex-reasoning-effort medium --codex-service-tier fast --codex-timeout-ms 600000
 npm run apply-artifacts -- --artifact-dir artifacts/reviews
+npm run audit -- --max-pages 250 --sample-limit 25
 npm run reconcile -- --dry-run
 ```
 
@@ -116,7 +119,7 @@ source ~/.profile
 npm run apply-decisions -- --limit 20
 ```
 
-Manual review runs can set `--apply-closures` or workflow input `apply_closures=true`, but the safer path is proposal first, then `apply_existing=true`.
+Manual review runs are proposal-only even if `--apply-closures` or workflow input `apply_closures=true` is set. Use `apply_existing=true` to apply unchanged proposals later.
 
 ## Checks
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "review": "node dist/clawsweeper.js review",
     "apply-artifacts": "node dist/clawsweeper.js apply-artifacts",
     "apply-decisions": "node dist/clawsweeper.js apply-decisions",
+    "audit": "node dist/clawsweeper.js audit",
     "reconcile": "node dist/clawsweeper.js reconcile",
     "dashboard": "node dist/clawsweeper.js dashboard",
     "status": "node dist/clawsweeper.js status",

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -12,7 +12,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from "node:fs";
-import { basename, dirname, join, resolve } from "node:path";
+import { basename, dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 type ItemKind = "issue" | "pull_request";
@@ -211,6 +211,64 @@ interface ReconcileResult {
   movedToClosed: number;
   movedToItems: number;
   removedStaleClosedCopies: number;
+}
+
+type AuditRecordLocation = "items" | "closed";
+
+interface AuditRecord {
+  number: number;
+  location: AuditRecordLocation;
+  path: string;
+  kind: ItemKind | undefined;
+  title: string;
+  labels: string[];
+  decision: string | undefined;
+  closeReason: string | undefined;
+  action: string | undefined;
+  reviewStatus: string;
+  currentState: string | undefined;
+}
+
+interface AuditFinding {
+  number: number;
+  kind?: ItemKind;
+  title?: string;
+  labels?: string[];
+  itemPath?: string;
+  closedPath?: string;
+  action?: string;
+  decision?: string;
+  closeReason?: string;
+  reviewStatus?: string;
+  currentState?: string;
+}
+
+interface AuditResult {
+  generatedAt: string;
+  targetRepo: string;
+  scan: {
+    complete: boolean;
+    pagesScanned: number;
+    openItemsSeen: number;
+  };
+  counts: {
+    itemRecords: number;
+    closedRecords: number;
+    missingOpen: number;
+    openArchived: number;
+    staleItemRecords: number;
+    duplicateRecords: number;
+    protectedProposed: number;
+    staleReviews: number;
+  };
+  findings: {
+    missingOpen: AuditFinding[];
+    openArchived: AuditFinding[];
+    staleItemRecords: AuditFinding[];
+    duplicateRecords: AuditFinding[];
+    protectedProposed: AuditFinding[];
+    staleReviews: AuditFinding[];
+  };
 }
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -949,19 +1007,35 @@ function fetchOpenItemPage(page: number): Item[] {
     .sort((a, b) => a.number - b.number);
 }
 
-function fetchOpenItemNumbers(maxPages: number): { numbers: Set<number>; pagesScanned: number } {
-  const numbers = new Set<number>();
+function fetchOpenItems(maxPages: number): {
+  items: Item[];
+  pagesScanned: number;
+  complete: boolean;
+} {
+  const items: Item[] = [];
   let pagesScanned = 0;
   for (let page = 1; page <= maxPages; page += 1) {
-    const items = fetchOpenItemPage(page);
+    const pageItems = fetchOpenItemPage(page);
     pagesScanned = page;
-    for (const item of items) numbers.add(item.number);
-    if (items.length === 0) return { numbers, pagesScanned };
-    if (items.length < 100) return { numbers, pagesScanned };
+    items.push(...pageItems);
+    if (pageItems.length === 0 || pageItems.length < 100) {
+      return { items, pagesScanned, complete: true };
+    }
   }
-  throw new Error(
-    `Open item scan reached max_pages=${maxPages} before the final page; refusing to reconcile folders from a partial scan.`,
-  );
+  return { items, pagesScanned, complete: false };
+}
+
+function fetchOpenItemNumbers(maxPages: number): { numbers: Set<number>; pagesScanned: number } {
+  const result = fetchOpenItems(maxPages);
+  if (!result.complete) {
+    throw new Error(
+      `Open item scan reached max_pages=${maxPages} before the final page; refusing to reconcile folders from a partial scan.`,
+    );
+  }
+  return {
+    numbers: new Set(result.items.map((item) => item.number)),
+    pagesScanned: result.pagesScanned,
+  };
 }
 
 function fetchItem(number: number): { item: Item; state: string } {
@@ -2458,6 +2532,165 @@ function numberForMarkdownFile(file: string): number {
   return Number(file.replace(/\.md$/, ""));
 }
 
+function repoRelativePath(path: string): string {
+  return relative(ROOT, path).replaceAll("\\", "/");
+}
+
+function markdownAuditRecord(
+  location: AuditRecordLocation,
+  dir: string,
+  file: string,
+): AuditRecord {
+  const path = join(dir, file);
+  const markdown = readFileSync(path, "utf8");
+  return {
+    number: numberForMarkdownFile(file),
+    location,
+    path: repoRelativePath(path),
+    kind: frontMatterValue(markdown, "type") as ItemKind | undefined,
+    title: frontMatterValue(markdown, "title") ?? "",
+    labels: frontMatterStringArray(markdown, "labels"),
+    decision: frontMatterValue(markdown, "decision"),
+    closeReason: frontMatterValue(markdown, "close_reason"),
+    action: frontMatterValue(markdown, "action_taken"),
+    reviewStatus: effectiveReviewStatus(markdown),
+    currentState: frontMatterValue(markdown, "current_state"),
+  };
+}
+
+function auditRecords(location: AuditRecordLocation, dir: string): AuditRecord[] {
+  return markdownFiles(dir).map((file) => markdownAuditRecord(location, dir, file));
+}
+
+function openItemFinding(item: Item, extra: Partial<AuditFinding> = {}): AuditFinding {
+  return {
+    number: item.number,
+    kind: item.kind,
+    title: item.title,
+    labels: item.labels,
+    ...extra,
+  };
+}
+
+function recordFinding(record: AuditRecord, extra: Partial<AuditFinding> = {}): AuditFinding {
+  return {
+    number: record.number,
+    ...(record.kind ? { kind: record.kind } : {}),
+    title: displayTitle(record.title),
+    labels: record.labels,
+    ...(record.action ? { action: record.action } : {}),
+    ...(record.decision ? { decision: record.decision } : {}),
+    ...(record.closeReason ? { closeReason: record.closeReason } : {}),
+    reviewStatus: record.reviewStatus,
+    ...(record.currentState ? { currentState: record.currentState } : {}),
+    ...(record.location === "items" ? { itemPath: record.path } : { closedPath: record.path }),
+    ...extra,
+  };
+}
+
+function firstByNumber<T extends { number: number }>(records: T[]): Map<number, T> {
+  const map = new Map<number, T>();
+  for (const record of records) {
+    if (!map.has(record.number)) map.set(record.number, record);
+  }
+  return map;
+}
+
+export function auditFromSnapshot(options: {
+  openItems: Item[];
+  itemRecords: AuditRecord[];
+  closedRecords: AuditRecord[];
+  scanComplete: boolean;
+  pagesScanned: number;
+  generatedAt?: string;
+}): AuditResult {
+  const openByNumber = firstByNumber(options.openItems);
+  const itemByNumber = firstByNumber(options.itemRecords);
+  const closedByNumber = firstByNumber(options.closedRecords);
+  const missingOpen: AuditFinding[] = [];
+  const openArchived: AuditFinding[] = [];
+
+  for (const item of options.openItems) {
+    if (itemByNumber.has(item.number)) continue;
+    const closedRecord = closedByNumber.get(item.number);
+    if (closedRecord) {
+      openArchived.push(openItemFinding(item, { closedPath: closedRecord.path }));
+    } else {
+      missingOpen.push(openItemFinding(item));
+    }
+  }
+
+  const staleItemRecords = options.scanComplete
+    ? options.itemRecords
+        .filter((record) => !openByNumber.has(record.number))
+        .map((record) => recordFinding(record))
+    : [];
+  const duplicateRecords = options.itemRecords
+    .filter((record) => closedByNumber.has(record.number))
+    .map((record) => {
+      const closedRecord = closedByNumber.get(record.number);
+      return recordFinding(record, closedRecord ? { closedPath: closedRecord.path } : {});
+    });
+  const protectedProposed = [...options.itemRecords, ...options.closedRecords]
+    .filter((record) => record.action === "proposed_close" && isProtectedItem(record))
+    .map((record) => recordFinding(record));
+  const staleReviews = options.itemRecords
+    .filter((record) => record.reviewStatus.startsWith("stale_"))
+    .map((record) => recordFinding(record));
+
+  return {
+    generatedAt: options.generatedAt ?? new Date().toISOString(),
+    targetRepo: TARGET_REPO,
+    scan: {
+      complete: options.scanComplete,
+      pagesScanned: options.pagesScanned,
+      openItemsSeen: options.openItems.length,
+    },
+    counts: {
+      itemRecords: options.itemRecords.length,
+      closedRecords: options.closedRecords.length,
+      missingOpen: missingOpen.length,
+      openArchived: openArchived.length,
+      staleItemRecords: staleItemRecords.length,
+      duplicateRecords: duplicateRecords.length,
+      protectedProposed: protectedProposed.length,
+      staleReviews: staleReviews.length,
+    },
+    findings: {
+      missingOpen,
+      openArchived,
+      staleItemRecords,
+      duplicateRecords,
+      protectedProposed,
+      staleReviews,
+    },
+  };
+}
+
+function limitAuditFindings(result: AuditResult, limit: number): AuditResult {
+  const boundedLimit = Math.max(0, limit);
+  return {
+    ...result,
+    findings: Object.fromEntries(
+      Object.entries(result.findings).map(([key, findings]) => [
+        key,
+        findings.slice(0, boundedLimit),
+      ]),
+    ) as AuditResult["findings"],
+  };
+}
+
+function auditHasStrictFailures(result: AuditResult): boolean {
+  return (
+    !result.scan.complete ||
+    result.counts.missingOpen > 0 ||
+    result.counts.openArchived > 0 ||
+    result.counts.staleItemRecords > 0 ||
+    result.counts.duplicateRecords > 0 ||
+    result.counts.protectedProposed > 0
+  );
+}
+
 function markReconciledState(markdown: string, state: "open" | "closed"): string {
   let nextMarkdown = replaceFrontMatterValue(markdown, "current_state", state);
   nextMarkdown = replaceFrontMatterValue(nextMarkdown, "reconciled_at", new Date().toISOString());
@@ -2537,6 +2770,29 @@ function reconcileCommand(args: Args): void {
   const dryRun = boolArg(args.dry_run);
   const result = reconcileFolders({ itemsDir, closedDir, maxPages, dryRun });
   console.log(JSON.stringify(result, null, 2));
+}
+
+function auditCommand(args: Args): void {
+  const itemsDir = resolve(stringArg(args.items_dir, join(ROOT, "items")));
+  const closedDir = resolve(stringArg(args.closed_dir, join(ROOT, "closed")));
+  const maxPages = numberArg(args.max_pages, 250);
+  const sampleLimit = numberArg(args.sample_limit, 25);
+  const output = typeof args.output === "string" ? resolve(args.output) : undefined;
+  const strict = boolArg(args.strict);
+  const openItems = fetchOpenItems(maxPages);
+  const result = auditFromSnapshot({
+    openItems: openItems.items,
+    itemRecords: auditRecords("items", itemsDir),
+    closedRecords: auditRecords("closed", closedDir),
+    scanComplete: openItems.complete,
+    pagesScanned: openItems.pagesScanned,
+  });
+  if (output) {
+    ensureDir(dirname(output));
+    writeFileSync(output, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+  }
+  console.log(JSON.stringify(limitAuditFindings(result, sampleLimit), null, 2));
+  if (strict && auditHasStrictFailures(result)) process.exit(1);
 }
 
 function cadenceBucketForReview(
@@ -2758,6 +3014,7 @@ export function main(argv = process.argv.slice(2)): void {
   else if (command === "review") reviewCommand(args);
   else if (command === "apply-artifacts") applyArtifactsCommand(args);
   else if (command === "apply-decisions") applyDecisionsCommand(args);
+  else if (command === "audit") auditCommand(args);
   else if (command === "reconcile") reconcileCommand(args);
   else if (command === "dashboard")
     updateDashboard(

--- a/test/clawsweeper.test.mjs
+++ b/test/clawsweeper.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  auditFromSnapshot,
   isProtectedItem,
   parseDecision,
   protectedLabels,
@@ -53,6 +54,23 @@ const git = {
   mainSha: "abcdef1234567890",
   latestRelease: null,
 };
+
+function auditRecord(number, overrides = {}) {
+  return {
+    number,
+    location: "items",
+    path: `items/${number}.md`,
+    kind: "issue",
+    title: `Item ${number}`,
+    labels: [],
+    decision: "keep_open",
+    closeReason: "none",
+    action: "kept_open",
+    reviewStatus: "complete",
+    currentState: undefined,
+    ...overrides,
+  };
+}
 
 test("protected labels are normalized and excluded from normal planning", () => {
   assert.deepEqual(protectedLabels(["Security", "bug", "maintainer", "SECURITY"]), [
@@ -132,4 +150,57 @@ test("decision parser enforces required schema-shaped evidence", () => {
       }),
     /decision\.evidence\[0\]\.file/,
   );
+});
+
+test("audit detects live/local state drift and unsafe proposed records", () => {
+  const result = auditFromSnapshot({
+    openItems: [
+      item({ number: 1, title: "tracked open" }),
+      item({ number: 2, title: "missing open" }),
+      item({ number: 3, title: "reopened archived" }),
+    ],
+    itemRecords: [
+      auditRecord(1),
+      auditRecord(4),
+      auditRecord(5),
+      auditRecord(6, {
+        labels: ["security"],
+        decision: "close",
+        closeReason: "implemented_on_main",
+        action: "proposed_close",
+      }),
+      auditRecord(7, { reviewStatus: "stale_local_checkout_blocked" }),
+    ],
+    closedRecords: [
+      auditRecord(3, { location: "closed", path: "closed/3.md" }),
+      auditRecord(5, { location: "closed", path: "closed/5.md" }),
+    ],
+    scanComplete: true,
+    pagesScanned: 1,
+    generatedAt: "2026-04-26T00:00:00.000Z",
+  });
+
+  assert.equal(result.counts.missingOpen, 1);
+  assert.equal(result.findings.missingOpen[0].number, 2);
+  assert.equal(result.counts.openArchived, 1);
+  assert.equal(result.findings.openArchived[0].closedPath, "closed/3.md");
+  assert.equal(result.counts.staleItemRecords, 4);
+  assert.equal(result.counts.duplicateRecords, 1);
+  assert.equal(result.counts.protectedProposed, 1);
+  assert.equal(result.counts.staleReviews, 1);
+});
+
+test("audit defers stale item drift until the open scan is complete", () => {
+  const result = auditFromSnapshot({
+    openItems: [item({ number: 1 })],
+    itemRecords: [auditRecord(1), auditRecord(2)],
+    closedRecords: [],
+    scanComplete: false,
+    pagesScanned: 1,
+    generatedAt: "2026-04-26T00:00:00.000Z",
+  });
+
+  assert.equal(result.scan.complete, false);
+  assert.equal(result.counts.staleItemRecords, 0);
+  assert.deepEqual(result.findings.staleItemRecords, []);
 });


### PR DESCRIPTION
## Summary
- add a read-only audit command that compares live open GitHub items against generated items/ and closed/ records
- report missing open records, reopened archived records, stale item records, duplicate markdown records, protected-label proposed closes, and stale review statuses
- document the proposal-only review/apply-existing flow and add audit usage to local run docs

## Verification
- npm run check
- npm run audit -- --max-pages 1 --sample-limit 2
- npm run audit -- --max-pages 250 --sample-limit 0 --output /tmp/clawsweeper-audit.json

## Live audit snapshot
- complete scan: 105 pages, 10,484 live open items
- drift detected: 78 missing open records, 7 reopened archived records, 142 stale item records, 3 protected-label proposed closes, 149 stale reviews
- full generated report kept local at /tmp/clawsweeper-audit.json