### PR TITLE
fix: guard missing Codex process output

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -1666,6 +1666,15 @@ function trimMiddle(text: string, maxLength: number): string {
   return `${text.slice(0, edge)}\n\n... truncated ${text.length - edge * 2} chars ...\n\n${text.slice(-edge)}`;
 }
 
+export function safeOutputTail(
+  value: string | Buffer | null | undefined,
+  maxLength = 6000,
+): string {
+  if (value == null) return "";
+  const text = typeof value === "string" ? value : value.toString("utf8");
+  return text.slice(-maxLength);
+}
+
 function codexFailureReason(detail: string): string {
   if (detail.includes("Codex dirtied the OpenClaw checkout")) return "dirty checkout";
   if (detail.includes("did not produce output")) return "missing structured output";
@@ -1787,7 +1796,7 @@ function runCodex(options: {
   if (result.error) {
     throw new Error(
       `Codex review failed for #${options.item.number}: ${result.error.message}\n${
-        result.stderr.slice(-6000) || result.stdout.slice(-6000) || "No output."
+        safeOutputTail(result.stderr) || safeOutputTail(result.stdout) || "No output."
       }`,
     );
   }
@@ -1795,7 +1804,7 @@ function runCodex(options: {
     throw new Error(
       `Codex review failed for #${options.item.number} with exit ${
         result.status ?? "unknown"
-      }.\n${result.stderr.slice(-6000) || result.stdout.slice(-6000) || "No output."}`,
+      }.\n${safeOutputTail(result.stderr) || safeOutputTail(result.stdout) || "No output."}`,
     );
   }
   if (!existsSync(outputPath)) {

--- a/test/clawsweeper.test.mjs
+++ b/test/clawsweeper.test.mjs
@@ -9,6 +9,7 @@ import {
   protectedLabels,
   relatedTitleSearchTerms,
   reviewActionForDecision,
+  safeOutputTail,
   shouldReviewItem,
   shouldRetryGh,
   shouldPlanItem,
@@ -330,4 +331,10 @@ test("GitHub retry classifier distinguishes throttle and transient failures", ()
     { stderr: "gh: HTTP 401: Bad credentials" },
   );
   assert.equal(ghRetryKind(authFailureForIssue502), "none");
+});
+
+test("safeOutputTail tolerates missing process output", () => {
+  assert.equal(safeOutputTail(undefined), "");
+  assert.equal(safeOutputTail(null), "");
+  assert.equal(safeOutputTail("abcdef", 3), "def");
 });


### PR DESCRIPTION
## Summary
- add a `safeOutputTail` helper for Codex child-process output
- avoid calling `.slice(...)` on missing `stdout`/`stderr` in ClawSweeper review failures
- add a regression test covering missing process output

## Why
Local review runs could crash while formatting Codex failure details if `spawnSync` returned missing `stdout` or `stderr`. That secondary crash hides the real Codex failure and breaks review artifact generation.

## Verification
- `npm run check`
