### PR TITLE
Classify missing open audit findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ checkpoint, and status-only commits are intentionally omitted.
 - Reduced the default apply close delay from 5 seconds to 2 seconds.
 - Prioritized matching close proposals ahead of broad comment sync during apply
   runs so close batches do not stall on keep-open comment backfill.
+- Classified missing-open audit findings so strict mode reports only actionable
+  missing-open drift while preserving total visibility. Thanks @stainlu.
 - Added transient GitHub API/network retries with short backoff while preserving
   long secondary-rate-limit backoff and throttle heartbeats. Thanks @stainlu.
 - Split the README dashboard into focused sections and collapsed the recent

--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ another apply run with the same settings.
 `npm run audit` compares live GitHub state with generated records without moving
 files. It reports missing open records, archived open records, stale records,
 duplicates, protected-label proposed closes, and stale review-status records.
+Missing open records are classified as eligible, maintainer-authored, protected,
+or recently created so strict audit mode can flag actionable drift without
+treating expected queue lag or excluded items as failures.
 
 ## Local Run
 

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -263,6 +263,11 @@ interface ReconcileResult {
 }
 
 type AuditRecordLocation = "items" | "closed";
+type MissingOpenReason =
+  | "eligible"
+  | "maintainer_authored"
+  | "protected_label"
+  | "recently_created";
 
 interface AuditRecord {
   number: number;
@@ -283,6 +288,10 @@ interface AuditFinding {
   kind?: ItemKind;
   title?: string;
   labels?: string[];
+  authorAssociation?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  missingReason?: MissingOpenReason;
   itemPath?: string;
   closedPath?: string;
   action?: string;
@@ -304,6 +313,10 @@ interface AuditResult {
     itemRecords: number;
     closedRecords: number;
     missingOpen: number;
+    missingEligibleOpen: number;
+    missingMaintainerOpen: number;
+    missingProtectedOpen: number;
+    missingRecentOpen: number;
     openArchived: number;
     staleItemRecords: number;
     duplicateRecords: number;
@@ -312,6 +325,10 @@ interface AuditResult {
   };
   findings: {
     missingOpen: AuditFinding[];
+    missingEligibleOpen: AuditFinding[];
+    missingMaintainerOpen: AuditFinding[];
+    missingProtectedOpen: AuditFinding[];
+    missingRecentOpen: AuditFinding[];
     openArchived: AuditFinding[];
     staleItemRecords: AuditFinding[];
     duplicateRecords: AuditFinding[];
@@ -332,6 +349,7 @@ const HOURLY_REVIEW_MS = 60 * 60 * 1000;
 const DAILY_REVIEW_DAYS = 1;
 const WEEKLY_REVIEW_DAYS = 7;
 const DAY_MS = 24 * 60 * 60 * 1000;
+const RECENT_MISSING_OPEN_MS = DAY_MS;
 const STATUS_START = "<!-- clawsweeper-status:start -->";
 const STATUS_END = "<!-- clawsweeper-status:end -->";
 const DEFAULT_CODEX_MODEL = "gpt-5.5";
@@ -3359,8 +3377,23 @@ function openItemFinding(item: Item, extra: Partial<AuditFinding> = {}): AuditFi
     kind: item.kind,
     title: item.title,
     labels: item.labels,
+    authorAssociation: item.authorAssociation,
+    createdAt: item.createdAt,
+    updatedAt: item.updatedAt,
     ...extra,
   };
+}
+
+function isRecentlyCreatedMissingOpen(item: Item, generatedAtMs: number): boolean {
+  const createdAt = Date.parse(item.createdAt);
+  return Number.isFinite(createdAt) && generatedAtMs - createdAt < RECENT_MISSING_OPEN_MS;
+}
+
+function missingOpenReason(item: Item, generatedAtMs: number): MissingOpenReason {
+  if (isMaintainerAuthored(item)) return "maintainer_authored";
+  if (isProtectedItem(item)) return "protected_label";
+  if (isRecentlyCreatedMissingOpen(item, generatedAtMs)) return "recently_created";
+  return "eligible";
 }
 
 function recordFinding(record: AuditRecord, extra: Partial<AuditFinding> = {}): AuditFinding {
@@ -3395,10 +3428,16 @@ export function auditFromSnapshot(options: {
   pagesScanned: number;
   generatedAt?: string;
 }): AuditResult {
+  const generatedAt = options.generatedAt ?? new Date().toISOString();
+  const generatedAtMs = Date.parse(generatedAt);
   const openByNumber = firstByNumber(options.openItems);
   const itemByNumber = firstByNumber(options.itemRecords);
   const closedByNumber = firstByNumber(options.closedRecords);
   const missingOpen: AuditFinding[] = [];
+  const missingEligibleOpen: AuditFinding[] = [];
+  const missingMaintainerOpen: AuditFinding[] = [];
+  const missingProtectedOpen: AuditFinding[] = [];
+  const missingRecentOpen: AuditFinding[] = [];
   const openArchived: AuditFinding[] = [];
 
   for (const item of options.openItems) {
@@ -3407,7 +3446,13 @@ export function auditFromSnapshot(options: {
     if (closedRecord) {
       openArchived.push(openItemFinding(item, { closedPath: closedRecord.path }));
     } else {
-      missingOpen.push(openItemFinding(item));
+      const missingReason = missingOpenReason(item, generatedAtMs);
+      const finding = openItemFinding(item, { missingReason });
+      missingOpen.push(finding);
+      if (missingReason === "maintainer_authored") missingMaintainerOpen.push(finding);
+      else if (missingReason === "protected_label") missingProtectedOpen.push(finding);
+      else if (missingReason === "recently_created") missingRecentOpen.push(finding);
+      else missingEligibleOpen.push(finding);
     }
   }
 
@@ -3430,7 +3475,7 @@ export function auditFromSnapshot(options: {
     .map((record) => recordFinding(record));
 
   return {
-    generatedAt: options.generatedAt ?? new Date().toISOString(),
+    generatedAt,
     targetRepo: TARGET_REPO,
     scan: {
       complete: options.scanComplete,
@@ -3441,6 +3486,10 @@ export function auditFromSnapshot(options: {
       itemRecords: options.itemRecords.length,
       closedRecords: options.closedRecords.length,
       missingOpen: missingOpen.length,
+      missingEligibleOpen: missingEligibleOpen.length,
+      missingMaintainerOpen: missingMaintainerOpen.length,
+      missingProtectedOpen: missingProtectedOpen.length,
+      missingRecentOpen: missingRecentOpen.length,
       openArchived: openArchived.length,
       staleItemRecords: staleItemRecords.length,
       duplicateRecords: duplicateRecords.length,
@@ -3449,6 +3498,10 @@ export function auditFromSnapshot(options: {
     },
     findings: {
       missingOpen,
+      missingEligibleOpen,
+      missingMaintainerOpen,
+      missingProtectedOpen,
+      missingRecentOpen,
       openArchived,
       staleItemRecords,
       duplicateRecords,
@@ -3471,10 +3524,10 @@ function limitAuditFindings(result: AuditResult, limit: number): AuditResult {
   };
 }
 
-function auditHasStrictFailures(result: AuditResult): boolean {
+export function auditHasStrictFailures(result: AuditResult): boolean {
   return (
     !result.scan.complete ||
-    result.counts.missingOpen > 0 ||
+    result.counts.missingEligibleOpen > 0 ||
     result.counts.openArchived > 0 ||
     result.counts.staleItemRecords > 0 ||
     result.counts.duplicateRecords > 0 ||

--- a/test/clawsweeper.test.mjs
+++ b/test/clawsweeper.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   applyDecisionPriority,
   auditFromSnapshot,
+  auditHasStrictFailures,
   ghRetryKind,
   isCodexReviewCommentBody,
   isProtectedItem,
@@ -400,13 +401,61 @@ test("audit detects live/local state drift and unsafe proposed records", () => {
   });
 
   assert.equal(result.counts.missingOpen, 1);
+  assert.equal(result.counts.missingEligibleOpen, 1);
+  assert.equal(result.counts.missingMaintainerOpen, 0);
+  assert.equal(result.counts.missingProtectedOpen, 0);
+  assert.equal(result.counts.missingRecentOpen, 0);
   assert.equal(result.findings.missingOpen[0].number, 2);
+  assert.equal(result.findings.missingOpen[0].missingReason, "eligible");
+  assert.equal(result.findings.missingEligibleOpen[0].number, 2);
   assert.equal(result.counts.openArchived, 1);
   assert.equal(result.findings.openArchived[0].closedPath, "closed/3.md");
   assert.equal(result.counts.staleItemRecords, 4);
   assert.equal(result.counts.duplicateRecords, 1);
   assert.equal(result.counts.protectedProposed, 1);
   assert.equal(result.counts.staleReviews, 1);
+});
+
+test("audit classifies missing open records by actionable reason", () => {
+  const base = {
+    itemRecords: [],
+    closedRecords: [],
+    scanComplete: true,
+    pagesScanned: 1,
+    generatedAt: "2026-04-26T12:00:00.000Z",
+  };
+  const expectedQueueLag = auditFromSnapshot({
+    ...base,
+    openItems: [
+      item({ number: 1, authorAssociation: "MEMBER" }),
+      item({ number: 2, labels: ["beta-blocker"] }),
+      item({
+        number: 3,
+        createdAt: "2026-04-26T11:30:00.000Z",
+        updatedAt: "2026-04-26T11:30:00.000Z",
+      }),
+    ],
+  });
+
+  assert.equal(expectedQueueLag.counts.missingOpen, 3);
+  assert.equal(expectedQueueLag.counts.missingEligibleOpen, 0);
+  assert.equal(expectedQueueLag.counts.missingMaintainerOpen, 1);
+  assert.equal(expectedQueueLag.counts.missingProtectedOpen, 1);
+  assert.equal(expectedQueueLag.counts.missingRecentOpen, 1);
+  assert.deepEqual(
+    expectedQueueLag.findings.missingOpen.map((finding) => finding.missingReason),
+    ["maintainer_authored", "protected_label", "recently_created"],
+  );
+  assert.equal(auditHasStrictFailures(expectedQueueLag), false);
+
+  const actionableDrift = auditFromSnapshot({
+    ...base,
+    openItems: [item({ number: 4, createdAt: "2026-04-24T00:00:00.000Z" })],
+  });
+
+  assert.equal(actionableDrift.counts.missingEligibleOpen, 1);
+  assert.equal(actionableDrift.findings.missingEligibleOpen[0].missingReason, "eligible");
+  assert.equal(auditHasStrictFailures(actionableDrift), true);
 });
 
 test("audit defers stale item drift until the open scan is complete", () => {


### PR DESCRIPTION
## Summary
- keep `missingOpen` as the total audit count while adding classified missing-open buckets
- classify missing open records as eligible, maintainer-authored, protected-label, or recently-created queue lag
- make strict audit mode fail on actionable missing-eligible drift instead of expected protected/maintainer/recent misses
- include author association and timestamps in live missing/open-archived audit findings

## Verification
- npm run check
- npm run audit -- --max-pages 250 --sample-limit 3 --output /tmp/clawsweeper-classified-audit.json

## Live audit signal
The classified audit completed against openclaw/openclaw with 9,334 live open items across 94 pages. It reported `missingOpen: 169` but `missingEligibleOpen: 0`; the missing records were `missingMaintainerOpen: 41`, `missingProtectedOpen: 34`, and `missingRecentOpen: 94`. That keeps the total visibility while removing false strict failures from expected queue lag and excluded items.