### PR TITLE
Publish audit health in README

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -63,8 +63,13 @@ on:
         description: "Run the low-latency intake lane for new/active issues and PRs"
         required: false
         default: "false"
+      audit_dashboard:
+        description: "Refresh README Audit Health without running review or apply work"
+        required: false
+        default: "false"
   schedule:
     - cron: "*/5 * * * *"
+    - cron: "7 */6 * * *"
     - cron: "17 * * * *"
     - cron: "37 * * * *"
 
@@ -75,12 +80,12 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true' && github.event.inputs.apply_sync_comments_only == 'true') && 'clawsweeper-comment-sync' || ((github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true') || (github.event_name == 'schedule' && github.event.schedule == '37 * * * *')) && 'clawsweeper-apply' || ((github.event_name == 'workflow_dispatch' && github.event.inputs.hot_intake == 'true') || (github.event_name == 'schedule' && github.event.schedule == '*/5 * * * *')) && 'clawsweeper-intake' || 'clawsweeper-review' }}
+  group: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true' && github.event.inputs.apply_sync_comments_only == 'true') && 'clawsweeper-comment-sync' || ((github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true') || (github.event_name == 'schedule' && github.event.schedule == '37 * * * *')) && 'clawsweeper-apply' || ((github.event_name == 'workflow_dispatch' && github.event.inputs.hot_intake == 'true') || (github.event_name == 'schedule' && github.event.schedule == '*/5 * * * *')) && 'clawsweeper-intake' || ((github.event_name == 'workflow_dispatch' && github.event.inputs.audit_dashboard == 'true') || (github.event_name == 'schedule' && github.event.schedule == '7 */6 * * *')) && 'clawsweeper-audit' || 'clawsweeper-review' }}
   cancel-in-progress: false
 
 jobs:
   plan:
-    if: ${{ !((github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true') || (github.event_name == 'schedule' && github.event.schedule == '37 * * * *')) }}
+    if: ${{ !((github.event_name == 'workflow_dispatch' && (github.event.inputs.apply_existing == 'true' || github.event.inputs.audit_dashboard == 'true')) || (github.event_name == 'schedule' && (github.event.schedule == '37 * * * *' || github.event.schedule == '7 */6 * * *'))) }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -358,7 +363,7 @@ jobs:
 
   publish:
     needs: [plan, review]
-    if: ${{ always() && !((github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true') || (github.event_name == 'schedule' && github.event.schedule == '37 * * * *')) }}
+    if: ${{ always() && !((github.event_name == 'workflow_dispatch' && (github.event.inputs.apply_existing == 'true' || github.event.inputs.audit_dashboard == 'true')) || (github.event_name == 'schedule' && (github.event.schedule == '37 * * * *' || github.event.schedule == '7 */6 * * *'))) }}
     runs-on: ubuntu-latest
     env:
       CLAWSWEEPER_APP_ID: ${{ secrets.CLAWSWEEPER_APP_ID }}
@@ -481,6 +486,70 @@ jobs:
             -f batch_size="${{ needs.plan.outputs.batch_size }}" \
             -f shard_count="${{ needs.plan.outputs.shard_count }}" \
             -f codex_timeout_ms="${{ needs.plan.outputs.codex_timeout_ms }}"
+
+  audit-dashboard:
+    if: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.audit_dashboard == 'true') || (github.event_name == 'schedule' && github.event.schedule == '7 */6 * * *') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      CLAWSWEEPER_APP_ID: ${{ secrets.CLAWSWEEPER_APP_ID }}
+      CLAWSWEEPER_APP_PRIVATE_KEY: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create OpenClaw read token
+        id: openclaw-read-token
+        if: ${{ env.CLAWSWEEPER_APP_ID != '' && env.CLAWSWEEPER_APP_PRIVATE_KEY != '' }}
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ env.CLAWSWEEPER_APP_ID }}
+          private-key: ${{ env.CLAWSWEEPER_APP_PRIVATE_KEY }}
+          owner: openclaw
+          repositories: openclaw
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build ClawSweeper
+        run: npm run build
+
+      - name: Refresh Audit Health
+        env:
+          GH_TOKEN: ${{ steps.openclaw-read-token.outputs.token || secrets.OPENCLAW_GH_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+          git pull --rebase
+          npm run audit -- --max-pages 250 --sample-limit 25 --output /tmp/clawsweeper-audit.json --update-dashboard
+          npm run status -- \
+            --state "Audit finished" \
+            --detail "Refreshed README Audit Health from a full live OpenClaw state audit. Normal review/apply dashboard heartbeats preserve this block without rerunning the audit scan." \
+            --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+      - name: Commit Audit Health
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          if git diff --cached --quiet; then
+            echo "No audit health changes"
+          else
+            git commit -m "chore: update sweep audit health"
+            for _attempt in 1 2 3; do
+              if git push; then
+                exit 0
+              fi
+              git fetch origin main
+              git rebase -X theirs origin/main
+            done
+            git push
+          fi
 
   apply-existing:
     if: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true') || (github.event_name == 'schedule' && github.event.schedule == '37 * * * *') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ checkpoint, and status-only commits are intentionally omitted.
   installation token so GitHub attributes automated comments to the bot.
 - Added Latest Run Activity dashboard counters for recent reviews, close
   decisions, comment syncs, apply skips, and close actions.
+- Added a README Audit Health section plus a separate scheduled/manual workflow
+  path to refresh it without making normal dashboard heartbeats scan GitHub.
+  Thanks @stainlu.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ or recently created so strict audit mode can flag actionable drift without
 treating expected queue lag or excluded items as failures.
 Use `--update-dashboard` to publish the latest audit health into this README
 without making every normal dashboard heartbeat scan all open GitHub items.
+The workflow refreshes Audit Health on a separate six-hour schedule, and it can
+be run manually with `audit_dashboard=true`.
 
 ## Local Run
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ Run: [https://github.com/openclaw/clawsweeper/actions/runs/24949172948](https://
 | Weekly older issue cadence | 1992/1994 current (2 due, 99.9%) |
 | Due now by cadence | 1000 |
 
+### Audit Health
+
+<!-- clawsweeper-audit:start -->
+No audit has been published yet. Run `npm run audit -- --update-dashboard` to refresh this section.
+<!-- clawsweeper-audit:end -->
+
 ### Latest Run Activity
 
 Latest review: Apr 26, 2026, 05:41 UTC. Latest close: Apr 26, 2026, 05:28 UTC. Latest comment sync: Apr 26, 2026, 05:43 UTC.
@@ -162,6 +168,8 @@ duplicates, protected-label proposed closes, and stale review-status records.
 Missing open records are classified as eligible, maintainer-authored, protected,
 or recently created so strict audit mode can flag actionable drift without
 treating expected queue lag or excluded items as failures.
+Use `--update-dashboard` to publish the latest audit health into this README
+without making every normal dashboard heartbeat scan all open GitHub items.
 
 ## Local Run
 
@@ -174,7 +182,7 @@ npm run build
 npm run plan -- --batch-size 5 --shard-count 50 --max-pages 250 --codex-model gpt-5.5 --codex-reasoning-effort high --codex-service-tier fast
 npm run review -- --openclaw-dir ../openclaw --batch-size 5 --max-pages 250 --artifact-dir artifacts/reviews --codex-model gpt-5.5 --codex-reasoning-effort high --codex-service-tier fast --codex-timeout-ms 600000
 npm run apply-artifacts -- --artifact-dir artifacts/reviews
-npm run audit -- --max-pages 250 --sample-limit 25
+npm run audit -- --max-pages 250 --sample-limit 25 --update-dashboard
 npm run reconcile -- --dry-run
 ```
 

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -352,6 +352,8 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 const RECENT_MISSING_OPEN_MS = DAY_MS;
 const STATUS_START = "<!-- clawsweeper-status:start -->";
 const STATUS_END = "<!-- clawsweeper-status:end -->";
+const AUDIT_HEALTH_START = "<!-- clawsweeper-audit:start -->";
+const AUDIT_HEALTH_END = "<!-- clawsweeper-audit:end -->";
 const DEFAULT_CODEX_MODEL = "gpt-5.5";
 const DEFAULT_REASONING_EFFORT = "high";
 const DEFAULT_SERVICE_TIER = "fast";
@@ -3535,6 +3537,119 @@ export function auditHasStrictFailures(result: AuditResult): boolean {
   );
 }
 
+function auditHealthStatus(result: AuditResult): string {
+  return auditHasStrictFailures(result) ? "Action needed" : "Passing";
+}
+
+function auditFindingCategory(category: keyof AuditResult["findings"]): string {
+  switch (category) {
+    case "missingEligibleOpen":
+      return "Missing eligible open";
+    case "openArchived":
+      return "Open archived";
+    case "staleItemRecords":
+      return "Stale item record";
+    case "duplicateRecords":
+      return "Duplicate record";
+    case "protectedProposed":
+      return "Protected proposed close";
+    case "staleReviews":
+      return "Stale review";
+    case "missingOpen":
+      return "Missing open";
+    case "missingMaintainerOpen":
+      return "Missing maintainer open";
+    case "missingProtectedOpen":
+      return "Missing protected open";
+    case "missingRecentOpen":
+      return "Missing recent open";
+  }
+}
+
+function auditFindingDetail(finding: AuditFinding): string {
+  if (finding.closedPath) return finding.closedPath;
+  if (finding.itemPath) return finding.itemPath;
+  if (finding.missingReason) return finding.missingReason;
+  if (finding.action) return finding.action;
+  return "-";
+}
+
+function actionableAuditFindings(result: AuditResult, limit = 3): string {
+  const categories: (keyof AuditResult["findings"])[] = [
+    "missingEligibleOpen",
+    "protectedProposed",
+    "openArchived",
+    "duplicateRecords",
+    "staleReviews",
+    "staleItemRecords",
+  ];
+  const rows: string[] = [];
+  for (const category of categories) {
+    for (const finding of result.findings[category]) {
+      rows.push(
+        `| ${markdownLink(`#${finding.number}`, itemUrl(finding.number, finding.kind ?? "issue"))} | ${auditFindingCategory(category)} | ${displayTitle(finding.title ?? "").replaceAll("|", "\\|")} | ${auditFindingDetail(finding).replaceAll("|", "\\|")} |`,
+      );
+      if (rows.length >= limit) return rows.join("\n");
+    }
+  }
+  return "| _None_ |  |  |  |";
+}
+
+export function auditHealthSection(result: AuditResult | null): string {
+  if (!result) {
+    return `### Audit Health
+
+${AUDIT_HEALTH_START}
+No audit has been published yet. Run \`npm run audit -- --update-dashboard\` to refresh this section.
+${AUDIT_HEALTH_END}`;
+  }
+  return `### Audit Health
+
+${AUDIT_HEALTH_START}
+Last audit: ${formatTimestamp(result.generatedAt)}
+
+Status: **${auditHealthStatus(result)}**
+
+| Metric | Count |
+| --- | ---: |
+| Scan complete | ${result.scan.complete ? "yes" : "no"} |
+| Open items seen | ${result.scan.openItemsSeen} |
+| Missing eligible open records | ${result.counts.missingEligibleOpen} |
+| Missing maintainer-authored open records | ${result.counts.missingMaintainerOpen} |
+| Missing protected open records | ${result.counts.missingProtectedOpen} |
+| Missing recently-created open records | ${result.counts.missingRecentOpen} |
+| Archived records that are open again | ${result.counts.openArchived} |
+| Stale item records | ${result.counts.staleItemRecords} |
+| Duplicate records | ${result.counts.duplicateRecords} |
+| Protected proposed closes | ${result.counts.protectedProposed} |
+| Stale reviews | ${result.counts.staleReviews} |
+
+| Item | Category | Title | Detail |
+| --- | --- | --- | --- |
+${actionableAuditFindings(result)}
+${AUDIT_HEALTH_END}`;
+}
+
+function currentAuditHealthSection(readme: string): string {
+  const match = readme.match(
+    new RegExp(`### Audit Health\\n\\n${AUDIT_HEALTH_START}[\\s\\S]*?${AUDIT_HEALTH_END}`),
+  );
+  return match?.[0] ?? auditHealthSection(null);
+}
+
+function updateAuditHealthDashboard(result: AuditResult): void {
+  const readmePath = join(ROOT, "README.md");
+  const readme = readFileSync(readmePath, "utf8");
+  const section = auditHealthSection(result);
+  const existingPattern = new RegExp(
+    `### Audit Health\\n\\n${AUDIT_HEALTH_START}[\\s\\S]*?${AUDIT_HEALTH_END}`,
+  );
+  const updated = existingPattern.test(readme)
+    ? readme.replace(existingPattern, section)
+    : readme.replace(/\n### Latest Run Activity/, `\n${section}\n\n### Latest Run Activity`);
+  writeFileSync(readmePath, updated, "utf8");
+}
+
 function markReconciledState(markdown: string, state: "open" | "closed"): string {
   let nextMarkdown = replaceFrontMatterValue(markdown, "current_state", state);
   nextMarkdown = replaceFrontMatterValue(nextMarkdown, "reconciled_at", new Date().toISOString());
@@ -3623,6 +3738,7 @@ function auditCommand(args: Args): void {
   const sampleLimit = numberArg(args.sample_limit, 25);
   const output = typeof args.output === "string" ? resolve(args.output) : undefined;
   const strict = boolArg(args.strict);
+  const updateDashboard = boolArg(args.update_dashboard);
   const openItems = fetchOpenItems(maxPages);
   const result = auditFromSnapshot({
     openItems: openItems.items,
@@ -3635,6 +3751,7 @@ function auditCommand(args: Args): void {
     ensureDir(dirname(output));
     writeFileSync(output, `${JSON.stringify(result, null, 2)}\n`, "utf8");
   }
+  if (updateDashboard) updateAuditHealthDashboard(result);
   console.log(JSON.stringify(limitAuditFindings(result, sampleLimit), null, 2));
   if (strict && auditHasStrictFailures(result)) process.exit(1);
 }
@@ -3798,6 +3915,7 @@ function updateDashboard(itemsDir = join(ROOT, "items"), closedDir = join(ROOT, 
   const readme = readFileSync(readmePath, "utf8");
   const stats = dashboardStats(itemsDir, closedDir);
   const status = currentWorkflowStatusBlock(readme);
+  const auditHealth = currentAuditHealthSection(readme);
   const recent =
     stats.recent
       .slice(0, 10)
@@ -3853,6 +3971,8 @@ ${status}
 | Daily new issue cadence (<${RECENT_ISSUE_DAYS}d) | ${formatCadenceBucket(stats.cadence.dailyNewIssues)} |
 | Weekly older issue cadence | ${formatCadenceBucket(stats.cadence.weekly)} |
 | Due now by cadence | ${stats.cadence.due} |
+
+${auditHealth}
 
 ### Latest Run Activity
 

--- a/test/clawsweeper.test.mjs
+++ b/test/clawsweeper.test.mjs
@@ -5,6 +5,7 @@ import {
   applyDecisionPriority,
   auditFromSnapshot,
   auditHasStrictFailures,
+  auditHealthSection,
   ghRetryKind,
   isCodexReviewCommentBody,
   isProtectedItem,
@@ -456,6 +457,44 @@ test("audit classifies missing open records by actionable reason", () => {
   assert.equal(actionableDrift.counts.missingEligibleOpen, 1);
   assert.equal(actionableDrift.findings.missingEligibleOpen[0].missingReason, "eligible");
   assert.equal(auditHasStrictFailures(actionableDrift), true);
+});
+
+test("audit health section summarizes strict status and actionable findings", () => {
+  const result = auditFromSnapshot({
+    openItems: [
+      item({
+        number: 10,
+        title: "eligible missing",
+        createdAt: "2026-04-24T00:00:00.000Z",
+      }),
+      item({ number: 11, title: "reopened archived" }),
+    ],
+    itemRecords: [
+      auditRecord(12, { title: "stale local" }),
+      auditRecord(13, {
+        title: "protected close",
+        labels: ["security"],
+        action: "proposed_close",
+      }),
+    ],
+    closedRecords: [auditRecord(11, { location: "closed", path: "closed/11.md" })],
+    scanComplete: true,
+    pagesScanned: 1,
+    generatedAt: "2026-04-26T12:00:00.000Z",
+  });
+  const section = auditHealthSection(result);
+
+  assert.match(section, /### Audit Health/);
+  assert.match(section, /<!-- clawsweeper-audit:start -->/);
+  assert.match(section, /Status: \*\*Action needed\*\*/);
+  assert.match(section, /\| Missing eligible open records \| 1 \|/);
+  assert.match(section, /\[#10\]\(https:\/\/github\.com\/openclaw\/openclaw\/issues\/10\)/);
+  assert.match(section, /Missing eligible open/);
+  assert.match(section, /\[#13\]\(https:\/\/github\.com\/openclaw\/openclaw\/issues\/13\)/);
+  assert.match(section, /Protected proposed close/);
+  assert.match(section, /\[#11\]\(https:\/\/github\.com\/openclaw\/openclaw\/issues\/11\)/);
+  assert.match(section, /Open archived/);
+  assert.doesNotMatch(section, /\[#12\]\(https:\/\/github\.com\/openclaw\/openclaw\/issues\/12\)/);
 });
 
 test("audit defers stale item drift until the open scan is complete", () => {


### PR DESCRIPTION
## Summary
- add a generated Audit Health section to the README dashboard with stable markers
- let `npm run audit -- --update-dashboard` publish strict audit status, classified missing-open counts, and top actionable findings
- preserve the latest Audit Health block during normal `npm run dashboard` updates so apply/review heartbeats do not need full GitHub scans
- document the update flag and add unit coverage for the rendered section

## Dependency
- Stacked on #8 (`Classify missing open audit findings`); this PR uses the classified audit buckets from that change.

## Verification
- npm run check
- npm run audit -- --max-pages 250 --sample-limit 0 --output /tmp/clawsweeper-audit-health.json
- rendered `auditHealthSection` from the live audit report without committing live dashboard churn

## Live render signal
The live audit completed with 9,136 open items across 92 pages. The rendered Audit Health block showed `Status: **Action needed**`, `missingEligibleOpen: 0`, `missingMaintainerOpen: 41`, `missingProtectedOpen: 34`, `missingRecentOpen: 100`, `openArchived: 2`, `staleItemRecords: 252`, `protectedProposed: 2`, and `staleReviews: 18`.