### PR TITLE
Add targeted multi-item review dispatch

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -59,6 +59,10 @@ on:
         description: "Optional single issue/PR number to review"
         required: false
         default: ""
+      item_numbers:
+        description: "Optional comma-separated issue/PR numbers to review"
+        required: false
+        default: ""
       hot_intake:
         description: "Run the low-latency intake lane for new/active issues and PRs"
         required: false
@@ -186,6 +190,7 @@ jobs:
           BATCH_SIZE: ${{ steps.mode.outputs.batch_size }}
           HOT_INTAKE: ${{ steps.mode.outputs.hot_intake }}
           ITEM_NUMBER: ${{ github.event.inputs.item_number || '' }}
+          ITEM_NUMBERS: ${{ github.event.inputs.item_numbers || '' }}
           MAX_PAGES: ${{ steps.mode.outputs.max_pages }}
           GH_TOKEN: ${{ steps.openclaw-read-token.outputs.token || secrets.OPENCLAW_GH_TOKEN || github.token }}
         run: |
@@ -193,6 +198,9 @@ jobs:
           item_arg=()
           if [ -n "$ITEM_NUMBER" ]; then
             item_arg=(--item-number "$ITEM_NUMBER")
+          fi
+          if [ -n "$ITEM_NUMBERS" ]; then
+            item_arg+=("--item-numbers" "$ITEM_NUMBERS")
           fi
           hot_intake_arg=()
           if [ "$HOT_INTAKE" = "true" ]; then
@@ -475,7 +483,7 @@ jobs:
           fi
 
       - name: Continue sweep
-        if: ${{ success() && needs.plan.outputs.hot_intake != 'true' && needs.plan.outputs.apply_closures != 'true' && needs.plan.outputs.planned_count == needs.plan.outputs.planned_capacity && (github.event_name != 'workflow_dispatch' || github.event.inputs.item_number == '') }}
+        if: ${{ success() && needs.plan.outputs.hot_intake != 'true' && needs.plan.outputs.apply_closures != 'true' && needs.plan.outputs.planned_count == needs.plan.outputs.planned_capacity && (github.event_name != 'workflow_dispatch' || (github.event.inputs.item_number == '' && github.event.inputs.item_numbers == '')) }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ checkpoint, and status-only commits are intentionally omitted.
 - Added a README Audit Health section plus a separate scheduled/manual workflow
   path to refresh it without making normal dashboard heartbeats scan GitHub.
   Thanks @stainlu.
+- Added comma-separated targeted review dispatch so Audit Health findings can be
+  reviewed together without waiting for normal batch selection. Thanks @stainlu.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ ClawSweeper has two independent lanes.
 Review is proposal-only. It never closes items.
 
 - A planner scans open issues and PRs, then assigns exact item numbers to shards.
+- Manual runs can pass `item_number` or comma-separated `item_numbers` to review
+  exact Audit Health findings without scanning for a normal batch.
 - Each shard checks out `openclaw/openclaw` at `main`.
 - Codex reviews with `gpt-5.5`, high reasoning, fast service tier, and a
   10-minute per-item timeout.

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -1717,15 +1717,51 @@ function selectCandidates(options: {
   return { candidates, scannedPages };
 }
 
+function openExplicitItems(itemNumbers: readonly number[]): Item[] {
+  const seen = new Set<number>();
+  const candidates: Item[] = [];
+  for (const number of itemNumbers) {
+    if (seen.has(number)) continue;
+    seen.add(number);
+    const { item, state } = fetchItem(number);
+    if (state === "open") candidates.push(item);
+  }
+  return candidates;
+}
+
+export function shardItemNumbers(itemNumbers: readonly number[], shardCount: number): PlanShard[] {
+  const count = Math.max(1, Math.min(Math.max(1, shardCount), itemNumbers.length || 1));
+  const shards = Array.from({ length: count }, (_, shard) => ({
+    shard,
+    itemNumbers: [] as number[],
+  }));
+  itemNumbers.forEach((number, index) => {
+    shards[index % shards.length]?.itemNumbers.push(number);
+  });
+  return shards;
+}
+
 function planCandidates(options: {
   batchSize: number;
   maxPages: number;
   shardCount: number;
   itemsDir: string;
   itemNumber?: number;
+  itemNumbers?: number[];
   reviewPolicy: string;
   hotIntake?: boolean;
 }): { shards: PlanShard[]; scannedPages: number; candidates: Item[] } {
+  if (options.itemNumbers) {
+    const candidates = openExplicitItems(options.itemNumbers);
+    return {
+      shards: shardItemNumbers(
+        candidates.map((item) => item.number),
+        options.shardCount,
+      ),
+      scannedPages: 0,
+      candidates,
+    };
+  }
   if (options.itemNumber) {
     const { item, state } = fetchItem(options.itemNumber);
     const shouldReview = state === "open";
@@ -1775,14 +1811,14 @@ function planCandidates(options: {
     .slice(0, limit)
     .map(({ item }) => item);
 
-  const shards = Array.from(
-    { length: Math.max(1, Math.min(options.shardCount, candidates.length || 1)) },
-    (_, shard) => ({ shard, itemNumbers: [] as number[] }),
-  );
-  candidates.forEach((item, index) => {
-    shards[index % shards.length]?.itemNumbers.push(item.number);
-  });
-  return { shards, scannedPages, candidates };
+  return {
+    shards: shardItemNumbers(
+      candidates.map((item) => item.number),
+      options.shardCount,
+    ),
+    scannedPages,
+    candidates,
+  };
 }
 
 function collectItemContext(item: Item): ItemContext {
@@ -2873,7 +2909,8 @@ function planCommand(args: Args): void {
   const batchSize = numberArg(args.batch_size, 5);
   const maxPages = numberArg(args.max_pages, 250);
   const shardCount = numberArg(args.shard_count, 100);
-  const itemNumber = numberArg(args.item_number, 0) || undefined;
+  const itemNumbers = itemNumbersArg(args.item_numbers, args.item_number);
+  const hasItemNumbersInput = typeof args.item_numbers === "string" && args.item_numbers.trim();
   const hotIntake = boolArg(args.hot_intake);
   const model = stringArg(args.codex_model, DEFAULT_CODEX_MODEL);
   const reasoningEffort = stringArg(args.codex_reasoning_effort, DEFAULT_REASONING_EFFORT);
@@ -2887,7 +2924,7 @@ function planCommand(args: Args): void {
     itemsDir,
     reviewPolicy,
   };
-  if (itemNumber) planOptions.itemNumber = itemNumber;
+  if (hasItemNumbersInput || itemNumbers.length > 0) planOptions.itemNumbers = itemNumbers;
   if (hotIntake) planOptions.hotIntake = true;
   const plan = planCandidates(planOptions);
   console.log(
@@ -2921,13 +2958,10 @@ function reviewCommand(args: Args): void {
   const shardCount = numberArg(args.shard_count, 1);
   const itemNumber = numberArg(args.item_number, 0) || undefined;
   const hotIntake = boolArg(args.hot_intake);
-  const itemNumbers =
-    typeof args.item_numbers === "string" && args.item_numbers.trim()
-      ? args.item_numbers
-          .split(",")
-          .map((value) => Number(value.trim()))
-          .filter((value) => Number.isInteger(value) && value > 0)
-      : undefined;
+  const hasItemNumbersInput = typeof args.item_numbers === "string" && args.item_numbers.trim();
+  const itemNumbers = hasItemNumbersInput
+    ? itemNumbersArg(args.item_numbers, undefined)
+    : undefined;
   const readonlyOpenclaw = boolArg(args.readonly_openclaw);
   const requestedApplyClosures =
     boolArg(args.apply_closures) || process.env.CLAWSWEEPER_APPLY_CLOSURES === "true";

--- a/test/clawsweeper.test.mjs
+++ b/test/clawsweeper.test.mjs
@@ -15,6 +15,7 @@ import {
   relatedTitleSearchTerms,
   reviewActionForDecision,
   safeOutputTail,
+  shardItemNumbers,
   shouldReviewItem,
   shouldRetryGh,
   shouldPlanItem,
@@ -321,6 +322,18 @@ test("comment matcher recognizes old and new Codex review comments", () => {
 test("item number args merge and sort workflow inputs", () => {
   assert.deepEqual(itemNumbersArg("42, 7, nope, 42", "5"), [5, 7, 42]);
   assert.deepEqual(itemNumbersArg("", undefined), []);
+});
+
+test("explicit item numbers shard targeted review runs", () => {
+  assert.deepEqual(shardItemNumbers([5, 7, 42, 99], 2), [
+    { shard: 0, itemNumbers: [5, 42] },
+    { shard: 1, itemNumbers: [7, 99] },
+  ]);
+  assert.deepEqual(shardItemNumbers([5, 7], 50), [
+    { shard: 0, itemNumbers: [5] },
+    { shard: 1, itemNumbers: [7] },
+  ]);
+  assert.deepEqual(shardItemNumbers([], 50), [{ shard: 0, itemNumbers: [] }]);
 });
 
 test("apply mode prioritizes matching close proposals before comment sync", () => {


### PR DESCRIPTION
## Summary
- add an `item_numbers` workflow input for comma-separated targeted review runs
- teach planning to fetch explicit open items and shard them directly instead of waiting for normal batch selection
- prevent targeted multi-item dispatches from chaining broad continuation runs
- document the Audit Health targeting workflow and add focused sharding coverage

## Verification
- npm run check