### PR TITLE
Publish targeted review inputs in Audit Health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ checkpoint, and status-only commits are intentionally omitted.
   Thanks @stainlu.
 - Added comma-separated targeted review dispatch so Audit Health findings can be
   reviewed together without waiting for normal batch selection. Thanks @stainlu.
+- Added copyable targeted review inputs to Audit Health for reviewable drift
+  findings. Thanks @stainlu.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ or recently created so strict audit mode can flag actionable drift without
 treating expected queue lag or excluded items as failures.
 Use `--update-dashboard` to publish the latest audit health into this README
 without making every normal dashboard heartbeat scan all open GitHub items.
+Audit Health includes a copyable `item_numbers` input for reviewable findings
+such as missing eligible records, reopened archived records, and stale reviews.
 The workflow refreshes Audit Health on a separate six-hour schedule, and it can
 be run manually with `audit_dashboard=true`.
 

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -3946,6 +3946,29 @@ function auditFindingDetail(finding: AuditFinding): string {
   return "-";
 }
 
+function auditReviewTargetNumbers(result: AuditResult, limit = 10): number[] {
+  const categories: (keyof AuditResult["findings"])[] = [
+    "missingEligibleOpen",
+    "openArchived",
+    "staleReviews",
+  ];
+  const numbers = new Set<number>();
+  for (const category of categories) {
+    for (const finding of result.findings[category]) {
+      if (category === "staleReviews" && finding.currentState === "closed") continue;
+      numbers.add(finding.number);
+      if (numbers.size >= limit) return [...numbers];
+    }
+  }
+  return [...numbers];
+}
+
+function auditReviewTargets(result: AuditResult): string {
+  const numbers = auditReviewTargetNumbers(result);
+  if (numbers.length === 0) return "Targeted review input: _none_";
+  return `Targeted review input: \`${numbers.join(",")}\``;
+}
+
 function actionableAuditFindings(result: AuditResult, limit = 3): string {
   const categories: (keyof AuditResult["findings"])[] = [
     "missingEligibleOpen",
@@ -3981,6 +4004,8 @@ ${AUDIT_HEALTH_START}
 Last audit: ${formatTimestamp(result.generatedAt)}
 
 Status: **${auditHealthStatus(result)}**
+
+${auditReviewTargets(result)}
 
 | Metric | Count |
 | --- | ---: |

--- a/test/clawsweeper.test.mjs
+++ b/test/clawsweeper.test.mjs
@@ -626,6 +626,7 @@ test("audit health section summarizes strict status and actionable findings", ()
         createdAt: "2026-04-24T00:00:00.000Z",
       }),
       item({ number: 11, title: "reopened archived" }),
+      item({ number: 14, title: "stale open review" }),
     ],
     itemRecords: [
       auditRecord(12, { title: "stale local" }),
@@ -633,6 +634,11 @@ test("audit health section summarizes strict status and actionable findings", ()
         title: "protected close",
         labels: ["security"],
         action: "proposed_close",
+      }),
+      auditRecord(14, {
+        title: "stale open review",
+        currentState: "open",
+        reviewStatus: "stale_reopened",
       }),
     ],
     closedRecords: [auditRecord(11, { location: "closed", path: "closed/11.md" })],
@@ -645,6 +651,7 @@ test("audit health section summarizes strict status and actionable findings", ()
   assert.match(section, /### Audit Health/);
   assert.match(section, /<!-- clawsweeper-audit:start -->/);
   assert.match(section, /Status: \*\*Action needed\*\*/);
+  assert.match(section, /Targeted review input: `10,11,14`/);
   assert.match(section, /\| Missing eligible open records \| 1 \|/);
   assert.match(section, /\[#10\]\(https:\/\/github\.com\/openclaw\/openclaw\/issues\/10\)/);
   assert.match(section, /Missing eligible open/);


### PR DESCRIPTION
## Summary
- add a copyable `item_numbers` line to README Audit Health for reviewable drift
- include missing eligible opens, reopened archived records, and stale open reviews as targeted review candidates
- avoid suggesting protected proposed close cleanup as a review target
- document the new Audit Health target line and cover it in the dashboard unit test

## Verification
- npm run check