### PR TITLE
Limit protected audit failures to live records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ checkpoint, and status-only commits are intentionally omitted.
 ### Changed
 
 - Switched review runs to GPT-5.5 with high reasoning.
+- Limited protected-proposed audit failures to active item records so archived
+  historical reports do not keep Audit Health in action-needed state.
 - Increased sweep throughput over time with larger worker batches, 100 shards,
   chained continuation runs, and 50-review checkpoints.
 - Renamed workflow run and job displays so review, apply, comment-sync, and

--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ are checked immediately before mutation.
 `npm run audit` compares live GitHub state with generated records without moving
 files. It reports missing open records, archived open records, stale records,
 duplicates, protected-label proposed closes, and stale review-status records.
+Protected proposed closes are reported only for active `items/` records because
+archived `closed/` records are historical and cannot be applied.
 Missing open records are classified as eligible, maintainer-authored, protected,
 or recently created so strict audit mode can flag actionable drift without
 treating expected queue lag or excluded items as failures.

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -3841,7 +3841,7 @@ export function auditFromSnapshot(options: {
       const closedRecord = closedByNumber.get(record.number);
       return recordFinding(record, closedRecord ? { closedPath: closedRecord.path } : {});
     });
-  const protectedProposed = [...options.itemRecords, ...options.closedRecords]
+  const protectedProposed = options.itemRecords
     .filter((record) => record.action === "proposed_close" && isProtectedItem(record))
     .map((record) => recordFinding(record));
   const staleReviews = options.itemRecords

--- a/test/clawsweeper.test.mjs
+++ b/test/clawsweeper.test.mjs
@@ -553,6 +553,12 @@ test("audit detects live/local state drift and unsafe proposed records", () => {
     closedRecords: [
       auditRecord(3, { location: "closed", path: "closed/3.md" }),
       auditRecord(5, { location: "closed", path: "closed/5.md" }),
+      auditRecord(8, {
+        location: "closed",
+        path: "closed/8.md",
+        labels: ["security"],
+        action: "proposed_close",
+      }),
     ],
     scanComplete: true,
     pagesScanned: 1,
@@ -572,6 +578,7 @@ test("audit detects live/local state drift and unsafe proposed records", () => {
   assert.equal(result.counts.staleItemRecords, 4);
   assert.equal(result.counts.duplicateRecords, 1);
   assert.equal(result.counts.protectedProposed, 1);
+  assert.equal(result.findings.protectedProposed[0].number, 6);
   assert.equal(result.counts.staleReviews, 1);
 });
 


### PR DESCRIPTION
## Summary
- count protected proposed close audit failures only from active `items/` records
- stop archived `closed/` records from keeping Audit Health in action-needed state
- document that archived protected proposals are historical and not applyable
- cover the distinction in the audit unit test

## Verification
- npm run check