### PR TITLE
fix: wrap JSON.parse in ghJson/ghJsonLines with contextual error messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@openclaw/clawsweeper",
       "version": "0.1.0",
+      "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
         "@typescript/native-preview": "7.0.0-dev.20260423.1",
@@ -144,9 +145,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -164,9 +162,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -184,9 +179,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -204,9 +196,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -224,9 +213,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -244,9 +230,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -264,9 +247,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -284,9 +264,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -491,9 +468,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -511,9 +485,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -531,9 +502,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -551,9 +519,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -571,9 +536,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -591,9 +553,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -611,9 +570,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -631,9 +587,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "@openclaw/clawsweeper",
       "version": "0.1.0",
-      "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
         "@typescript/native-preview": "7.0.0-dev.20260423.1",
@@ -145,6 +144,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -162,6 +164,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -179,6 +184,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -196,6 +204,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -213,6 +224,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -230,6 +244,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -247,6 +264,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -264,6 +284,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -468,6 +491,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -485,6 +511,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -502,6 +531,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -519,6 +551,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -536,6 +571,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -553,6 +591,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -570,6 +611,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -587,6 +631,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -564,7 +564,7 @@ function ghRetryWaitMs(kind: GhRetryKind, attempt: number): number {
   return 0;
 }
 
-function summarizeGhArgs(args: string[]): string {
+function summarizeGhArgs(args: readonly string[]): string {
   if (args[0] === "api" && args[1]) return `gh api ${args[1]}`;
   return `gh ${args.slice(0, 3).join(" ")}`;
 }
@@ -657,34 +657,42 @@ function ghWithRetry(args: string[], attempts = 12): string {
   throw lastError;
 }
 
-function ghJson<T>(args: string[]): T {
-  const text = ghWithRetry(args);
+function formatParseError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function parseGhJson<T>(text: string, args: readonly string[]): T {
   try {
     return JSON.parse(text) as T;
   } catch (error) {
     throw new Error(
-      `Failed to parse JSON from ${summarizeGhArgs(args)}: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
+      `Failed to parse JSON from ${summarizeGhArgs(args)}: ${formatParseError(error)}`,
     );
   }
 }
 
-function ghJsonLines<T>(args: string[]): T[] {
-  const text = ghWithRetry(args);
+export function parseGhJsonLines<T>(text: string, args: readonly string[]): T[] {
   if (!text) return [];
   return text
     .split("\n")
     .filter(Boolean)
-    .map((line) => {
+    .map((line, index) => {
       try {
         return JSON.parse(line) as T;
       } catch (error) {
         throw new Error(
-          `Failed to parse JSON line: ${error instanceof Error ? error.message : String(error)}`,
+          `Failed to parse JSON line ${index + 1} from ${summarizeGhArgs(args)}: ${formatParseError(error)}`,
         );
       }
     });
+}
+
+function ghJson<T>(args: string[]): T {
+  return parseGhJson<T>(ghWithRetry(args), args);
+}
+
+function ghJsonLines<T>(args: string[]): T[] {
+  return parseGhJsonLines<T>(ghWithRetry(args), args);
 }
 
 function sha256(text: string): string {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -659,7 +659,15 @@ function ghWithRetry(args: string[], attempts = 12): string {
 
 function ghJson<T>(args: string[]): T {
   const text = ghWithRetry(args);
-  return JSON.parse(text) as T;
+  try {
+    return JSON.parse(text) as T;
+  } catch (error) {
+    throw new Error(
+      `Failed to parse JSON from ${summarizeGhArgs(args)}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
 }
 
 function ghJsonLines<T>(args: string[]): T[] {
@@ -668,7 +676,15 @@ function ghJsonLines<T>(args: string[]): T[] {
   return text
     .split("\n")
     .filter(Boolean)
-    .map((line) => JSON.parse(line) as T);
+    .map((line) => {
+      try {
+        return JSON.parse(line) as T;
+      } catch (error) {
+        throw new Error(
+          `Failed to parse JSON line: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    });
 }
 
 function sha256(text: string): string {

--- a/test/clawsweeper.test.mjs
+++ b/test/clawsweeper.test.mjs
@@ -14,6 +14,8 @@ import {
   itemNumbersArg,
   lockedConversationApplyReason,
   openClosingPullRequestApplyReason,
+  parseGhJson,
+  parseGhJsonLines,
   parseDecision,
   protectedLabels,
   relatedTitleSearchTerms,
@@ -118,6 +120,20 @@ test("protected labels are normalized and excluded from normal planning", () => 
   assert.equal(isProtectedItem(item({ labels: ["release-blocker"] })), true);
   assert.equal(shouldPlanItem(item({ labels: ["beta-blocker"] })), false);
   assert.equal(shouldPlanItem(item({ labels: ["bug"] })), true);
+});
+
+test("parseGhJson adds gh command context to malformed JSON errors", () => {
+  assert.throws(
+    () => parseGhJson("{", ["api", "repos/openclaw/openclaw/issues"]),
+    /Failed to parse JSON from gh api repos\/openclaw\/openclaw\/issues:/,
+  );
+});
+
+test("parseGhJsonLines adds line number and command context to malformed JSONL errors", () => {
+  assert.throws(
+    () => parseGhJsonLines('{"ok":true}\nnot-json\n', ["issue", "list", "--json", "number"]),
+    /Failed to parse JSON line 2 from gh issue list --json:/,
+  );
 });
 
 test("protected labels block close proposals even for otherwise valid decisions", () => {


### PR DESCRIPTION
## Summary

- Wrap `JSON.parse` in `ghJson` with try-catch, re-throwing with command context
- Wrap `JSON.parse` in `ghJsonLines` per-line with try-catch, re-throwing with parse error context

## Motivation

Fixes [#15](https://github.com/openclaw/clawsweeper/issues/15)

If GitHub returns malformed JSON (e.g., HTML during an outage), the error now surfaces with context rather than crashing the run with an opaque parse error.