### PR TITLE
docs: document clawsweeper self smoke target

### DIFF
--- a/docs/repair/operations.md
+++ b/docs/repair/operations.md
@@ -153,6 +153,9 @@ Every merge action must carry `merge_preflight`. Missing security clearance, unr
 ## Runner Strategy
 
 Use `ubuntu-latest` for ClawSweeper parity and correctness smoke tests.
+Use `openclaw/clawsweeper` as the target repo when you need a self-contained
+event, review, comment-router, or automerge smoke that should not touch product
+repositories.
 
 Use Blacksmith labels only when you intentionally want a non-parity hosted runner for bulk planning/execution:
 


### PR DESCRIPTION
## Summary
- documents `openclaw/clawsweeper` as the self-contained target for ClawSweeper event/review/comment-router/automerge smoke tests

## Verification
- `pnpm exec oxfmt --check --threads=1 .github/workflows/sweep.yml docs/repair/operations.md`

This PR is the end-to-end live smoke for default-branch event review, manual review, comment-router commands, and guarded automerge.
