### PR TITLE
test: exercise automerge repair smoke

### DIFF
--- a/test/clawsweeper.test.mjs
+++ b/test/clawsweeper.test.mjs
@@ -908,6 +908,39 @@ Land this docs-only PR after maintainer review.
   assert.doesNotMatch(comment, /Best possible solution:/);
 });
 
+test("pull request keep-open review comments suppress duplicate remaining risk text", () => {
+  const comment = renderReviewCommentFromReport(
+    `${reportFrontMatter({
+      type: "pull_request",
+      number: "74267",
+      decision: "keep_open",
+      close_reason: "none",
+      work_candidate: "none",
+      pull_head_sha: "abc123def456",
+    })}
+
+## Summary
+
+Keep this docs-only PR open for maintainer review.
+
+## What This Changes
+
+Documents ClawSweeper self-review smoke coverage.
+
+## Best Possible Solution
+
+Land this docs-only PR after maintainer review.
+
+## Risks / Open Questions
+
+Land this docs-only PR after maintainer review.
+`,
+    "none",
+  );
+
+  assert.match(comment, /Remaining risk \/ open question:/);
+});
+
 test("pull request review reports carry verdict and repair markers", () => {
   const markdown = `${reportFrontMatter({
     type: "pull_request",


### PR DESCRIPTION
Live ClawSweeper automerge smoke PR.

This intentionally starts red: the new regression test title says duplicate remaining-risk prose should be suppressed, but the assertion currently expects the duplicate risk section to be present. The expected ClawSweeper live flow is:

1. `/clawsweeper automerge` opts this PR into the bounded loop.
2. ClawSweeper reviews the current head and/or sees the failing unit test.
3. Repair mode updates this branch by changing the assertion to `assert.doesNotMatch(...)`.
4. ClawSweeper reviews the repaired head and automerges when checks are green.

The final merged state should keep the useful regression test and no intentional failure.