### PR TITLE
fix: repair dirty automerge prs

### DIFF
--- a/src/repair/comment-router-core.test.ts
+++ b/src/repair/comment-router-core.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { automergeRebaseRepairReason } from "./comment-router-core.js";
+
+test("automerge rebase repair reason detects dirty merge state", () => {
+  assert.match(
+    automergeRebaseRepairReason({ merge_state_status: "DIRTY" }) ?? "",
+    /cloud rebase repair/,
+  );
+});
+
+test("automerge rebase repair reason detects behind merge state", () => {
+  assert.match(
+    automergeRebaseRepairReason({ mergeStateStatus: "BEHIND" }) ?? "",
+    /behind the base branch/,
+  );
+});
+
+test("automerge rebase repair reason detects conflicting mergeable state", () => {
+  assert.match(automergeRebaseRepairReason({ mergeable: "CONFLICTING" }) ?? "", /merge conflicts/);
+});
+
+test("automerge rebase repair reason ignores clean merge state", () => {
+  assert.equal(automergeRebaseRepairReason({ merge_state_status: "CLEAN" }), null);
+  assert.equal(automergeRebaseRepairReason({ mergeStateStatus: "HAS_HOOKS" }), null);
+});

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -163,6 +163,23 @@ export function repairableCheckBlockers(checks: LooseRecord = {}) {
   });
 }
 
+export function automergeRebaseRepairReason(target: LooseRecord = {}): string | null {
+  const mergeStateStatus = String(target.merge_state_status ?? target.mergeStateStatus ?? "")
+    .trim()
+    .toUpperCase();
+  if (mergeStateStatus === "DIRTY")
+    return "PR is behind or has merge conflicts and needs a cloud rebase repair before automerge";
+  if (mergeStateStatus === "BEHIND")
+    return "PR is behind the base branch and needs a cloud rebase repair before automerge";
+
+  const mergeable = String(target.mergeable ?? "")
+    .trim()
+    .toUpperCase();
+  if (mergeable === "CONFLICTING")
+    return "PR has merge conflicts and needs a cloud rebase repair before automerge";
+  return null;
+}
+
 export function commandHasAction(command: LooseRecord, actionName: string): boolean {
   return (command.actions ?? []).some((action: JsonValue) => action.action === actionName);
 }

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -25,6 +25,7 @@ import {
   automergeGateBlockReason,
   automergeClusterId,
   automergeJobPath,
+  automergeRebaseRepairReason,
   buildAutomergeMergeArgs,
   commandHasAction,
   commandStatusMarker,
@@ -555,34 +556,19 @@ function classifyAutomergePass(
   }));
   const failedCheckBlockers = repairableCheckBlockers(command.target?.checks);
   if (failedCheckBlockers.length > 0) {
-    const alreadyPlanned = autoRepairAlreadyPlanned(command);
-    if (alreadyPlanned) return { ...command, status: "skipped", reason: alreadyPlanned };
-    const repairJobPath = command.target?.job_path ?? command.target?.automerge_job_path;
-    return {
-      ...command,
-      repair_reason: `${command.repair_reason ?? "structured ClawSweeper verdict: pass"}; current checks are failing: ${failedCheckBlockers.slice(0, 5).join(", ")}`,
-      status: "ready",
-      actions: [
-        ...pauseLabelActions,
-        ...(command.target?.job_path
-          ? []
-          : [
-              {
-                action: "ensure_automerge_job",
-                job_path: repairJobPath,
-                status: execute ? "pending" : "planned",
-              },
-            ]),
-        {
-          action: "dispatch_repair",
-          workflow,
-          job_path: repairJobPath,
-          mode: command.target?.mode,
-          status: execute ? "pending" : "planned",
-        },
-        { action: "comment", status: execute ? "pending" : "planned" },
-      ],
-    };
+    return classifyPassedAutomergeRepair(
+      command,
+      pauseLabelActions,
+      `${command.repair_reason ?? "structured ClawSweeper verdict: pass"}; current checks are failing: ${failedCheckBlockers.slice(0, 5).join(", ")}`,
+    );
+  }
+  const rebaseRepairReason = automergeRebaseRepairReason(command.target);
+  if (rebaseRepairReason) {
+    return classifyPassedAutomergeRepair(
+      command,
+      pauseLabelActions,
+      `${command.repair_reason ?? "structured ClawSweeper verdict: pass"}; ${rebaseRepairReason}`,
+    );
   }
   return {
     ...command,
@@ -590,6 +576,41 @@ function classifyAutomergePass(
     actions: [
       ...pauseLabelActions,
       { action: "merge", status: execute ? "pending" : "planned" },
+      { action: "comment", status: execute ? "pending" : "planned" },
+    ],
+  };
+}
+
+function classifyPassedAutomergeRepair(
+  command: LooseRecord,
+  pauseLabelActions: LooseRecord[],
+  repairReason: string,
+): JsonValue {
+  const alreadyPlanned = autoRepairAlreadyPlanned(command);
+  if (alreadyPlanned) return { ...command, status: "skipped", reason: alreadyPlanned };
+  const repairJobPath = command.target?.job_path ?? command.target?.automerge_job_path;
+  return {
+    ...command,
+    repair_reason: repairReason,
+    status: "ready",
+    actions: [
+      ...pauseLabelActions,
+      ...(command.target?.job_path
+        ? []
+        : [
+            {
+              action: "ensure_automerge_job",
+              job_path: repairJobPath,
+              status: execute ? "pending" : "planned",
+            },
+          ]),
+      {
+        action: "dispatch_repair",
+        workflow,
+        job_path: repairJobPath,
+        mode: command.target?.mode,
+        status: execute ? "pending" : "planned",
+      },
       { action: "comment", status: execute ? "pending" : "planned" },
     ],
   };
@@ -1471,6 +1492,7 @@ function classifyPullTarget(pull: LooseRecord, issueNumber: JsonValue): JsonValu
     automerge_cluster_id: automergeCluster,
     automerge_job_path: adoptedJobPath ?? automergePath,
     mode: jobPath ? dispatchMode(jobPath) : "autonomous",
+    mergeable: pull.mergeable ?? null,
     merge_state_status: pull.mergeStateStatus ?? null,
     review_decision: pull.reviewDecision ?? null,
     checks: summarizeChecks(pull.statusCheckRollup ?? []),


### PR DESCRIPTION
## Summary
- route trusted automerge pass markers with dirty/behind/conflicting merge state into cloud repair instead of trying a blocked merge
- keep the existing failing-checks repair path on the same dispatch helper
- carry GitHub mergeable state into the PR target snapshot and cover the rebase trigger helper

## Validation
- pnpm run test:repair
- pnpm run lint
- pnpm exec oxfmt --check --threads=1 src/repair/comment-router.ts src/repair/comment-router-core.ts src/repair/comment-router-core.test.ts
- git diff --check