### PR TITLE
fix: repair automerge merge conflicts after merge race

### DIFF
--- a/src/repair/comment-router-core.test.ts
+++ b/src/repair/comment-router-core.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { automergeRebaseRepairReason } from "./comment-router-core.js";
+import {
+  automergeMergeFailureRepairReason,
+  automergeRebaseRepairReason,
+} from "./comment-router-core.js";
 
 test("automerge rebase repair reason detects dirty merge state", () => {
   assert.match(
@@ -24,4 +27,20 @@ test("automerge rebase repair reason detects conflicting mergeable state", () =>
 test("automerge rebase repair reason ignores clean merge state", () => {
   assert.equal(automergeRebaseRepairReason({ merge_state_status: "CLEAN" }), null);
   assert.equal(automergeRebaseRepairReason({ mergeStateStatus: "HAS_HOOKS" }), null);
+});
+
+test("automerge merge failure repair reason detects GitHub merge conflict errors", () => {
+  assert.match(
+    automergeMergeFailureRepairReason(
+      "merge command failed: GraphQL: Pull Request has merge conflicts (mergePullRequest)",
+    ) ?? "",
+    /cloud rebase repair/,
+  );
+});
+
+test("automerge merge failure repair reason ignores unrelated merge failures", () => {
+  assert.equal(
+    automergeMergeFailureRepairReason("merge command failed: GraphQL: Head sha mismatch"),
+    null,
+  );
 });

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -180,6 +180,23 @@ export function automergeRebaseRepairReason(target: LooseRecord = {}): string | 
   return null;
 }
 
+export function automergeMergeFailureRepairReason(reason: JsonValue): string | null {
+  const text = String(reason ?? "")
+    .trim()
+    .toLowerCase();
+  if (!text) return null;
+  if (text.includes("mergepullrequest") && text.includes("merge conflict")) {
+    return "PR has merge conflicts and needs a cloud rebase repair before automerge";
+  }
+  if (text.includes("pull request has merge conflicts")) {
+    return "PR has merge conflicts and needs a cloud rebase repair before automerge";
+  }
+  if (text.includes("merge command failed") && text.includes("merge conflict")) {
+    return "PR has merge conflicts and needs a cloud rebase repair before automerge";
+  }
+  return null;
+}
+
 export function commandHasAction(command: LooseRecord, actionName: string): boolean {
   return (command.actions ?? []).some((action: JsonValue) => action.action === actionName);
 }
@@ -542,7 +559,7 @@ export function renderResponse(command: LooseRecord, dispatched: LooseRecord) {
       const workflow = dispatchedWorkflowLink(dispatched.repair);
       return [
         marker,
-        "Thanks, ClawSweeper. ClawSweeper saw the passing review, but current checks are failing.",
+        "Thanks, ClawSweeper. ClawSweeper saw the passing review, but the PR needs another repair pass before merge.",
         "",
         `Source: \`${command.trusted_bot_author ?? command.author ?? "trusted automation"}\``,
         `Feedback: ${command.repair_reason ?? "ClawSweeper reported a passing review."}`,

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -25,6 +25,7 @@ import {
   automergeGateBlockReason,
   automergeClusterId,
   automergeJobPath,
+  automergeMergeFailureRepairReason,
   automergeRebaseRepairReason,
   buildAutomergeMergeArgs,
   commandHasAction,
@@ -952,6 +953,41 @@ function executeCommand(command: LooseRecord) {
       command.status = "waiting";
       return;
     }
+    if (merge.status === "repair_needed" && canRepairPullTarget(command.target)) {
+      const alreadyPlanned = autoRepairAlreadyPlanned(command);
+      if (alreadyPlanned) {
+        command.actions = command.actions.map((action: JsonValue) =>
+          action.action === "merge"
+            ? { ...action, status: "blocked", reason: alreadyPlanned }
+            : action,
+        );
+      } else {
+        command.repair_reason = `${command.repair_reason ?? "structured ClawSweeper verdict: pass"}; ${merge.repair_reason ?? merge.reason}`;
+        const job = ensureAutomergeJob(command);
+        if (job.status_detail === "written") {
+          command.actions.push({
+            action: "dispatch_repair",
+            workflow,
+            job_path: command.target.job_path,
+            mode: command.target.mode,
+            status: "waiting",
+            reason: "adopted job must be committed before worker dispatch",
+          });
+          command.status = "waiting";
+          return;
+        }
+        const repair = dispatchRepair(command);
+        dispatched = { ...dispatched, repair };
+        command.actions.push({
+          action: "dispatch_repair",
+          workflow,
+          job_path: command.target.job_path,
+          mode: command.target.mode,
+          status: "executed",
+          dispatched_at: new Date().toISOString(),
+        });
+      }
+    }
   }
   if (
     command.intent === "clawsweeper_needs_human" &&
@@ -1375,6 +1411,17 @@ function executeAutomerge(command: LooseRecord) {
     }),
   );
   if (result.status !== 0) {
+    const failure = stripAnsi(result.stderr || result.stdout).trim();
+    const repairReason = automergeMergeFailureRepairReason(failure);
+    if (repairReason) {
+      return {
+        action: "merge",
+        status: "repair_needed",
+        reason: `merge command failed: ${failure}`,
+        repair_reason: repairReason,
+        merge_method: "squash",
+      };
+    }
     ensureMergeReadyLabel(command.repo);
     ghBestEffort([
       "issue",
@@ -1388,7 +1435,7 @@ function executeAutomerge(command: LooseRecord) {
     return {
       action: "merge",
       status: "blocked",
-      reason: `merge command failed: ${stripAnsi(result.stderr || result.stdout).trim()}`,
+      reason: `merge command failed: ${failure}`,
       merge_method: "squash",
     };
   }


### PR DESCRIPTION
## Summary
- treat GitHub mergePullRequest merge-conflict failures as repairable automerge rebase work
- dispatch the existing ClawSweeper repair worker instead of leaving the automerge loop blocked after a merge race
- update public automerge repair wording so dirty/rebase repairs are not described as failing checks

## Validation
- pnpm run build:repair
- node --test dist/repair/comment-router-core.test.js
- pnpm exec oxfmt --check --threads=1 src/repair/comment-router.ts src/repair/comment-router-core.ts src/repair/comment-router-core.test.ts
- git diff --check
- pnpm run test:repair
- pnpm run lint