### PR TITLE
Normalize repository profile lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ checkpoint, and status-only commits are intentionally omitted.
   `docs.openclaw.ai` links where appropriate.
 - Clarified `incoherent` close-reason wording so rendered reports no longer
   collide with `not_actionable_in_repo` (#29). Thanks @xthunder0.
+- Normalized repository profile lookup against configured target repos so
+  mixed-case profile entries resolve correctly (#27). Thanks @xthunder0.
 - Made apply runs issue-only by default, with no age floor, while still excluding
   maintainer-authored items.
 - Made apply runs checkpoint their progress, publish dashboard heartbeats, and

--- a/src/repository-profiles.ts
+++ b/src/repository-profiles.ts
@@ -76,7 +76,9 @@ export const REPOSITORY_PROFILES: readonly RepositoryProfile[] = [
 
 export function repositoryProfileFor(targetRepo: string): RepositoryProfile {
   const normalized = normalizeRepo(targetRepo);
-  const profile = REPOSITORY_PROFILES.find((candidate) => candidate.targetRepo === normalized);
+  const profile = REPOSITORY_PROFILES.find(
+    (candidate) => normalizeRepo(candidate.targetRepo) === normalized,
+  );
   if (!profile) {
     throw new Error(
       `Unsupported target repo: ${targetRepo}. Known repos: ${REPOSITORY_PROFILES.map((candidate) => candidate.targetRepo).join(", ")}`,

--- a/test/repository-profiles.test.ts
+++ b/test/repository-profiles.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { REPOSITORY_PROFILES, repositoryProfileFor } from "../dist/repository-profiles.js";
+
+test("repositoryProfileFor matches mixed-case input against canonical profiles", () => {
+  const profile = repositoryProfileFor("OpenClaw/ClawHub");
+
+  assert.equal(profile.targetRepo, "openclaw/clawhub");
+  assert.equal(profile.slug, "openclaw-clawhub");
+});
+
+test("profile lookup normalizes candidate target repos as well as input", () => {
+  const mixedCaseProfile = {
+    ...REPOSITORY_PROFILES[0],
+    targetRepo: "Example-Org/Mixed-Case-Repo",
+    slug: "example-org-mixed-case-repo",
+  };
+  REPOSITORY_PROFILES.push(mixedCaseProfile);
+
+  try {
+    assert.equal(repositoryProfileFor("example-org/mixed-case-repo"), mixedCaseProfile);
+    assert.equal(repositoryProfileFor("EXAMPLE-ORG/MIXED-CASE-REPO"), mixedCaseProfile);
+  } finally {
+    REPOSITORY_PROFILES.pop();
+  }
+});


### PR DESCRIPTION
## Summary

- Normalize each configured `targetRepo` during `repositoryProfileFor()` lookup so mixed-case profile entries match normalized input.
- Add regression coverage for mixed-case caller input and mixed-case configured profile entries.

## Context

This routes the downstream stop-gap from cloverthe-ai/clover-sweeper#16 upstream for cloverthe-ai/clover-sweeper#15. The latent bug is that lookup normalized only the caller input, then compared it against raw `candidate.targetRepo`, so a mixed-case profile entry could fail to match itself and produce an unsupported-repo error that listed the same repo as known.

Once this lands upstream, the downstream patch can be retired on the next clover-sweeper re-vendor cycle.

## Verification

- `pnpm run build && node --test test/repository-profiles.test.ts`
- `pnpm run check`

Note: both checks ran on this machine with Node v22.22.1, which emits the repo's existing `>=24` engine warning. No live sweep/apply/close commands were run.
