### PR TITLE
Fix paused automerge and re-review progress

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -257,6 +257,24 @@ jobs:
         with:
           build-script: build:all
 
+      - name: Mark re-review command in progress
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          TARGET_REPO: ${{ steps.target.outputs.target_repo }}
+          ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
+          COMMAND_STATUS_MARKER: ${{ github.event.client_payload.command_status_marker || '' }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          pnpm run repair:update-command-status -- \
+            --repo "$TARGET_REPO" \
+            --item-number "$ITEM_NUMBER" \
+            --marker "$COMMAND_STATUS_MARKER" \
+            --state "Review in progress" \
+            --detail "Targeted re-review run started; Codex is reviewing the item." \
+            --run-url "$RUN_URL" \
+            --wait-ms 120000
+
       - uses: ./.github/actions/setup-codex
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -293,6 +311,7 @@ jobs:
           git -C "$checkout_dir" rev-parse --short HEAD
 
       - name: Review exact event item
+        id: review-exact-event-item
         continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
@@ -330,6 +349,7 @@ jobs:
           token: ${{ steps.state-token.outputs.token }}
 
       - name: Publish event result and apply safe close
+        id: publish-event-result
         env:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
           REPO_TOKEN: ${{ github.token }}
@@ -340,6 +360,7 @@ jobs:
         run: pnpm run repair:publish-event-result
 
       - name: Route synced ClawSweeper verdict
+        id: route-synced-verdict
         timeout-minutes: 4
         env:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
@@ -360,6 +381,33 @@ jobs:
             --lookback-minutes "$CLAWSWEEPER_COMMENT_LOOKBACK_MINUTES" \
             --max-comments "$CLAWSWEEPER_COMMENT_MAX_COMMENTS" \
             --execute
+
+      - name: Mark re-review complete
+        if: ${{ always() && steps.setup-pnpm.outcome == 'success' }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          TARGET_REPO: ${{ steps.target.outputs.target_repo }}
+          ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
+          COMMAND_STATUS_MARKER: ${{ github.event.client_payload.command_status_marker || '' }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REVIEW_OUTCOME: ${{ steps.review-exact-event-item.outcome }}
+          PUBLISH_OUTCOME: ${{ steps.publish-event-result.outcome }}
+          ROUTE_OUTCOME: ${{ steps.route-synced-verdict.outcome }}
+        run: |
+          state="Failed"
+          detail="The targeted re-review did not finish cleanly. Check the workflow run for details."
+          if [ "$REVIEW_OUTCOME" = "success" ] && [ "$PUBLISH_OUTCOME" = "success" ] && [ "$ROUTE_OUTCOME" = "success" ]; then
+            state="Complete"
+            detail="The targeted re-review finished, the durable review comment was updated, and the synced verdict was routed."
+          fi
+          pnpm run repair:update-command-status -- \
+            --repo "$TARGET_REPO" \
+            --item-number "$ITEM_NUMBER" \
+            --marker "$COMMAND_STATUS_MARKER" \
+            --state "$state" \
+            --detail "$detail" \
+            --run-url "$RUN_URL"
 
       - name: Commit event comment router ledger
         if: ${{ !cancelled() && steps.setup-pnpm.outcome == 'success' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ checkpoint, and status-only commits are intentionally omitted.
 - Removed `actions/setup-node` from the high-volume GitHub activity lane and
   kept that notifier compatible with runner-provided Node 20+ so bursty
   activity forwarding is not blocked by codeload action download timeouts.
+- Kept human-review pauses from being cleared by stale trusted pass markers or
+  replayed automerge commands.
+- Updated targeted re-review command comments with live progress while the review
+  workflow runs.
 
 ## 0.2.0 - 2026-05-03
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "repair:notify-events": "node dist/repair/notify-events.js",
     "repair:notify-github-activity": "node dist/repair/notify-github-activity.js",
     "repair:publish-event-result": "node dist/repair/publish-event-result.js",
+    "repair:update-command-status": "node dist/repair/update-command-status.js",
     "workflow": "node dist/repair/workflow-utils.js",
     "repair:promote-stuck-jobs": "node dist/repair/promote-stuck-jobs.js",
     "repair:sweep-openclaw-jobs": "node dist/repair/sweep-openclaw-jobs.js",

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -446,6 +446,14 @@ export function existingModeStatusBlocksReplay({
   );
 }
 
+export function pausedModeStatusBlocksReplay({
+  hasPauseLabels,
+  hasExistingModeStatusResponse,
+  forceReprocess,
+}: LooseRecord = {}) {
+  return Boolean(hasPauseLabels) && Boolean(hasExistingModeStatusResponse) && !forceReprocess;
+}
+
 export function isMaintainerCommandAllowed({
   authorAssociation,
   repositoryPermission = null,
@@ -850,7 +858,7 @@ export function renderResponse(command: LooseRecord, dispatched: LooseRecord) {
             `- Label: \`${label}\`${clearedHumanReview ? " (pause labels cleared)" : ""}`,
             repairQueued
               ? repairDispatchLine(dispatched.repair, "- Action")
-              : "- Action: exact-head review queued.",
+              : reviewDispatchLine(dispatched.clawsweeper, "- Action", "exact-head review queued"),
             "- Flow: review this head, repair/rebase only if needed, then re-review the exact repaired head before merge.",
           ].join("\n")
         : `Reason: ${command.reason ?? `${mode} requires a pull request`}.`,
@@ -868,7 +876,11 @@ export function renderResponse(command: LooseRecord, dispatched: LooseRecord) {
         : "ClawSweeper could not start a re-review for this item.",
       "",
       dispatched?.clawsweeper
-        ? "I asked ClawSweeper to review this item again."
+        ? [
+            "I asked ClawSweeper to review this item again.",
+            reviewDispatchLine(dispatched.clawsweeper, "Action", "item re-review queued"),
+            "Result: the existing ClawSweeper review comment will be edited in place when the review finishes.",
+          ].join("\n")
         : `Reason: ${command.reason ?? "re-review requires an open issue or PR"}.`,
     ].join("\n");
   }
@@ -1061,6 +1073,17 @@ function repairDispatchLine(dispatched: LooseRecord, label: string): string {
   return runUrl
     ? `${label}: repair worker queued. Run: ${runUrl}`
     : `${label}: repair worker queued.`;
+}
+
+function reviewDispatchLine(dispatched: LooseRecord, label: string, action: string): string {
+  const runUrl = typeof dispatched.run_url === "string" ? dispatched.run_url : "";
+  const workflow = String(dispatched.workflow ?? "").trim();
+  const event = String(dispatched.event ?? "").trim();
+  const suffix = [workflow ? `workflow \`${workflow}\`` : "", event ? `event \`${event}\`` : ""]
+    .filter(Boolean)
+    .join(", ");
+  const detail = suffix ? ` (${suffix})` : "";
+  return runUrl ? `${label}: ${action}. Run: ${runUrl}` : `${label}: ${action}${detail}.`;
 }
 
 export function usesSharedAutomergeStatus(command: LooseRecord) {

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -42,6 +42,7 @@ import {
   issueImplementationClusterId,
   issueImplementationJobPath,
   parseCommand,
+  pausedModeStatusBlocksReplay,
   parseTrustedAutomation,
   repairableCheckBlockers,
   repairLoopStopPauseReason,
@@ -501,6 +502,22 @@ function classifyCommand(command: LooseRecord): JsonValue {
     ) {
       return { ...next, status: "skipped", reason: `${mode} already enabled for this PR` };
     }
+    if (
+      pausedModeStatusBlocksReplay({
+        hasPauseLabels: pauseLabels.length > 0,
+        hasExistingModeStatusResponse: hasExistingModeStatusResponse(
+          command.issue_number,
+          command.intent,
+        ),
+        forceReprocess,
+      })
+    ) {
+      return {
+        ...next,
+        status: "skipped",
+        reason: "PR is paused for human review",
+      };
+    }
     const actions: LooseRecord[] = [];
     if (!target.job_path) {
       actions.push({
@@ -734,11 +751,7 @@ function classifyAutomergePass(
   if (pauseLabels.length > 0) {
     return { ...command, status: "skipped", reason: "PR is paused for human review" };
   }
-  const pauseLabelActions = pauseLabelsOn(command.target).map((label) => ({
-    action: "remove_label",
-    label,
-    status: execute ? "pending" : "planned",
-  }));
+  const pauseLabelActions: LooseRecord[] = [];
   const failedCheckBlockers = repairableCheckBlockers(command.target?.checks);
   if (failedCheckBlockers.length > 0) {
     return classifyPassedAutomergeRepair(
@@ -1490,6 +1503,8 @@ function repairJobModeForCommand(command: LooseRecord) {
 }
 
 function dispatchClawSweeperReview(command: LooseRecord) {
+  const commandStatus =
+    command.intent === "re_review" ? { command_status_marker: commandStatusMarker(command) } : {};
   const payload = JSON.stringify({
     event_type: "clawsweeper_item",
     client_payload: {
@@ -1497,6 +1512,7 @@ function dispatchClawSweeperReview(command: LooseRecord) {
       item_number: String(command.issue_number),
       item_kind: command.target?.kind ?? "",
       additional_prompt: freeformReviewPrompt(command),
+      ...commandStatus,
     },
   });
   const result = ghSpawn(

--- a/src/repair/update-command-status.ts
+++ b/src/repair/update-command-status.ts
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+import { setTimeout as sleep } from "node:timers/promises";
+import { ghPagedWithRetry, ghText } from "./github-cli.js";
+import type { JsonValue, LooseRecord } from "./json-types.js";
+import { repoRoot } from "./paths.js";
+import { writePayload } from "./comment-router-utils.js";
+
+const PROGRESS_START = "<!-- clawsweeper-command-progress:start -->";
+const PROGRESS_END = "<!-- clawsweeper-command-progress:end -->";
+
+type Options = {
+  repo: string;
+  itemNumber: string;
+  marker: string;
+  state: string;
+  detail: string;
+  runUrl: string;
+  waitMs: number;
+};
+
+const options = parseOptions(process.argv.slice(2));
+await updateCommandStatus(options);
+
+async function updateCommandStatus(options: Options) {
+  if (!options.marker) return;
+  validateRepo(options.repo);
+  validateItemNumber(options.itemNumber);
+  const comment = await findCommandStatusComment(options);
+  if (!comment?.id || typeof comment.body !== "string") {
+    console.warn(`No command status comment found for ${options.repo}#${options.itemNumber}.`);
+    return;
+  }
+  const body = mergeCommandProgressSection(comment.body, options);
+  if (body === comment.body) return;
+  const payload = writePayload(repoRoot(), `command-status-progress-${comment.id}`, { body });
+  ghText([
+    "api",
+    `repos/${options.repo}/issues/comments/${comment.id}`,
+    "--method",
+    "PATCH",
+    "--input",
+    payload,
+  ]);
+}
+
+async function findCommandStatusComment(options: Options): Promise<LooseRecord | null> {
+  const deadline = Date.now() + Math.max(0, options.waitMs);
+  let shouldContinue = true;
+  while (shouldContinue) {
+    const comments = ghPagedWithRetry<LooseRecord>(
+      `repos/${options.repo}/issues/${options.itemNumber}/comments?per_page=100`,
+      { attempts: 3 },
+    );
+    const match = comments
+      .filter(
+        (comment) => typeof comment.body === "string" && comment.body.includes(options.marker),
+      )
+      .at(-1);
+    if (match) return match;
+    shouldContinue = Date.now() < deadline;
+    if (!shouldContinue) break;
+    await sleep(5000);
+  }
+  return null;
+}
+
+export function mergeCommandProgressSection(
+  body: string,
+  options: Pick<Options, "state" | "detail" | "runUrl">,
+) {
+  const section = renderCommandProgressSection(options);
+  const start = body.indexOf(PROGRESS_START);
+  const end = body.indexOf(PROGRESS_END);
+  if (start >= 0 && end > start) {
+    return `${body.slice(0, start).trimEnd()}\n\n${section}\n${body.slice(end + PROGRESS_END.length).trimStart()}`;
+  }
+  return `${body.trimEnd()}\n\n${section}`;
+}
+
+function renderCommandProgressSection(options: Pick<Options, "state" | "detail" | "runUrl">) {
+  const lines = [
+    PROGRESS_START,
+    "Re-review progress:",
+    `- State: ${options.state}`,
+    `- Detail: ${options.detail}`,
+  ];
+  if (options.runUrl) lines.push(`- Run: ${options.runUrl}`);
+  lines.push(`- Updated: ${new Date().toISOString()}`, PROGRESS_END);
+  return lines.join("\n");
+}
+
+function parseOptions(argv: string[]): Options {
+  const args: Record<string, string> = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index] ?? "";
+    if (!arg.startsWith("--")) continue;
+    const key = arg.slice(2);
+    const next = argv[index + 1];
+    if (!next || next.startsWith("--")) {
+      args[key] = "true";
+      continue;
+    }
+    args[key] = next;
+    index += 1;
+  }
+  return {
+    repo: args.repo ?? process.env.TARGET_REPO ?? "",
+    itemNumber: args["item-number"] ?? process.env.ITEM_NUMBER ?? "",
+    marker: args.marker ?? process.env.COMMAND_STATUS_MARKER ?? "",
+    state: args.state ?? process.env.COMMAND_STATUS_STATE ?? "",
+    detail: args.detail ?? process.env.COMMAND_STATUS_DETAIL ?? "",
+    runUrl: args["run-url"] ?? process.env.RUN_URL ?? "",
+    waitMs: Number.parseInt(args["wait-ms"] ?? process.env.COMMAND_STATUS_WAIT_MS ?? "0", 10) || 0,
+  };
+}
+
+function validateRepo(repo: string) {
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) {
+    throw new Error(`invalid repo: ${repo}`);
+  }
+}
+
+function validateItemNumber(itemNumber: JsonValue) {
+  if (!/^[0-9]+$/.test(String(itemNumber ?? ""))) {
+    throw new Error(`invalid item number: ${itemNumber}`);
+  }
+}

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -29,6 +29,7 @@ import {
   issueImplementationJobPath,
   isMaintainerCommandAllowed,
   parseCommand,
+  pausedModeStatusBlocksReplay,
   parseTrustedAutomation,
   repairableCheckBlockers,
   repairLoopStopPauseReason,
@@ -229,6 +230,22 @@ test("force reprocess bypasses existing command status guards", () => {
   };
   assert.equal(existingModeStatusBlocksReplay({ ...existingEnabled, forceReprocess: false }), true);
   assert.equal(existingModeStatusBlocksReplay({ ...existingEnabled, forceReprocess: true }), false);
+  assert.equal(
+    pausedModeStatusBlocksReplay({
+      hasPauseLabels: true,
+      hasExistingModeStatusResponse: true,
+      forceReprocess: false,
+    }),
+    true,
+  );
+  assert.equal(
+    pausedModeStatusBlocksReplay({
+      hasPauseLabels: true,
+      hasExistingModeStatusResponse: true,
+      forceReprocess: true,
+    }),
+    false,
+  );
 });
 
 test("automerge status marker prefix is stable across head changes", () => {
@@ -1154,6 +1171,8 @@ test("renderResponse reports maintainer re-review dispatches", () => {
 
   assert.match(body, /re-review requested/);
   assert.match(body, /review this item again/);
+  assert.match(body, /Action: item re-review queued/);
+  assert.match(body, /existing ClawSweeper review comment will be edited in place/);
   assert.match(body, /clawsweeper-command-status:74107:re_review:def461/);
   assert.doesNotMatch(body, /repair worker/);
 });


### PR DESCRIPTION
## Summary
- Keep `/clawsweeper stop` authoritative by blocking stale automerge/autofix replay while human review is active.
- Prevent trusted pass markers from clearing `clawsweeper:human-review`.
- Show `/clawsweeper re-review` progress in the command status comment until the durable review comment is updated.

## Validation
- `pnpm run check`
