### PR TITLE
feat: add polymarket bot review profile

### DIFF
--- a/src/repository-profiles.ts
+++ b/src/repository-profiles.ts
@@ -72,6 +72,18 @@ export const REPOSITORY_PROFILES: readonly RepositoryProfile[] = [
       pull_request: ["implemented_on_main"],
     },
   },
+  {
+    targetRepo: "Barenhvrd/polymarket-bot",
+    slug: "barenhvrd-polymarket-bot",
+    displayName: "Polymarket Bot",
+    checkoutDir: "polymarket-bot",
+    promptNote:
+      "Use the Polymarket bot source tree and current main branch. This is a live-trading automation repository, so review issues and PRs conservatively for correctness, safety, operational risk, and reproducibility. Keep apply disabled for both issues and pull requests until maintainers explicitly opt into close automation.",
+    applyCloseRules: {
+      issue: [],
+      pull_request: [],
+    },
+  },
 ];
 
 export function repositoryProfileFor(targetRepo: string): RepositoryProfile {

--- a/test/repository-profiles.test.ts
+++ b/test/repository-profiles.test.ts
@@ -10,6 +10,15 @@ test("repositoryProfileFor matches mixed-case input against canonical profiles",
   assert.equal(profile.slug, "openclaw-clawhub");
 });
 
+test("polymarket-bot profile is review-only", () => {
+  const profile = repositoryProfileFor("barenhvrd/polymarket-bot");
+
+  assert.equal(profile.slug, "barenhvrd-polymarket-bot");
+  assert.equal(profile.checkoutDir, "polymarket-bot");
+  assert.deepEqual(profile.applyCloseRules.issue, []);
+  assert.deepEqual(profile.applyCloseRules.pull_request, []);
+});
+
 test("profile lookup normalizes candidate target repos as well as input", () => {
   const mixedCaseProfile = {
     ...REPOSITORY_PROFILES[0],


### PR DESCRIPTION
## Summary
- Add a conservative ClawSweeper repository profile for `Barenhvrd/polymarket-bot`.
- Keep apply/auto-close disabled for both issues and PRs.
- Add coverage that the profile is review-only.

## Why
I want to use ClawSweeper for review-only backlog and PR triage on a live-trading bot repo without enabling close automation.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `node --test test/repository-profiles.test.ts`
- `pnpm run format:check`
