### PR TITLE
profiles: add iambuddy829-del/harnes target (private adopter)

### DIFF
--- a/src/repository-profiles.ts
+++ b/src/repository-profiles.ts
@@ -72,6 +72,18 @@ export const REPOSITORY_PROFILES: readonly RepositoryProfile[] = [
       pull_request: ["implemented_on_main"],
     },
   },
+  {
+    targetRepo: "iambuddy829-del/harnes",
+    slug: "iambuddy829-del-harnes",
+    displayName: "Harnes",
+    checkoutDir: "harnes",
+    promptNote:
+      "Use the Harnes source tree (private CanTime ops audit/readiness harness) and current main branch. Conservative review like the ClawSweeper self-review profile. Codex-CLI generated PRs land here regularly; ClawSweeper is being adopted to gate trusted automerge for those.",
+    applyCloseRules: {
+      issue: [],
+      pull_request: ["implemented_on_main"],
+    },
+  },
 ];
 
 export function repositoryProfileFor(targetRepo: string): RepositoryProfile {


### PR DESCRIPTION
## Summary

Adds a fourth `RepositoryProfile` so ClawSweeper can review and (with App + labels) auto-merge trusted PRs on `iambuddy829-del/harnes`.

## Context

I'm adopting OpenClaw + Codex-CLI to manage Harnes, a defensive audit/readiness harness for our CanTime ops Mac. Codex-generated PRs land there frequently and currently get manually reviewed. The goal of adopting ClawSweeper is to gate those trusted PRs through the same exact-head review + bounded autofix/automerge loop you already run for `openclaw/openclaw`.

## Profile choice

Mirrors the `openclaw/clawsweeper` self-review profile (most conservative):

- `pull_request` close rules limited to `["implemented_on_main"]`
- `issue` close rules empty (no auto-close at all)
- No `docsUrl` / `communityUrl` (private project, no public docs)

## Open question for maintainers

Would you prefer a config-driven approach — e.g. a `CLAWSWEEPER_EXTRA_PROFILES_PATH` env var pointing to a JSON file — so external adopters can self-onboard without an upstream PR per repo? Happy to refactor along that line if it fits your roadmap better.

If you'd rather keep `REPOSITORY_PROFILES` as the canonical curated list, this PR adds Harnes as a maintainer-blessed entry (same model as the three existing profiles).

## Test plan

- [x] TypeScript shape compliant (`RepositoryProfile` interface satisfied)
- [x] Existing `test/repository-profiles.test.ts` still green (uses `REPOSITORY_PROFILES[0]` — unchanged)
- [ ] Maintainers: full `pnpm test` + `pnpm build:all` per CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
