### PR TITLE
fix: support bare status comment commands

### DIFF
--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -616,6 +616,8 @@ export function parseCommand(body: string) {
     if (autoclose) return commandFromText("slash", `autoclose ${autoclose[1] ?? ""}`.trim());
     const review = line.match(/^\s*\/review(?:\s+(.+))?\s*$/i);
     if (review) return commandFromText("slash", review[1] ? `review ${review[1]}` : "review");
+    const status = line.match(/^\s*\/(status|help|explain)\s*$/i);
+    if (status) return commandFromText("slash", status[1] ?? line.replace(/^\s*\//, "").trim());
     const slash = line.match(/^\s*\/clawsweeper(?:\s+(.+))?\s*$/i);
     if (slash) {
       const command = commandFromText("slash", slash[1] ?? "status");

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -59,6 +59,21 @@ test("parseCommand recognizes maintainer slash commands", () => {
     command: "status",
     intent: "status",
   });
+  assert.deepEqual(parseCommand("/status"), {
+    trigger: "slash",
+    command: "status",
+    intent: "status",
+  });
+  assert.deepEqual(parseCommand("/help"), {
+    trigger: "slash",
+    command: "help",
+    intent: "help",
+  });
+  assert.deepEqual(parseCommand("/explain"), {
+    trigger: "slash",
+    command: "explain",
+    intent: "explain",
+  });
   assert.deepEqual(parseCommand("/clawsweeper automerge"), {
     trigger: "slash",
     command: "automerge",


### PR DESCRIPTION
## Summary
- recognize bare `/status`, `/help`, and `/explain` comments in the ClawSweeper comment router
- add parser coverage for the bare commands

## Validation
- `pnpm run build:repair`
- `pnpm run test:repair`
- `git diff --check`