### PR TITLE
[codex] link fixing PRs in close comments

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -3711,9 +3711,50 @@ function fixedPullRequestFromContext(
   return candidates[0] ?? null;
 }
 
+function fixedPullRequestFromCommitPulls(
+  pulls: readonly unknown[],
+  source: string,
+): FixedPullRequest | null {
+  const candidates = pulls
+    .map((pull) => fixedPullRequestFromUnknown(pull, source))
+    .filter((pull): pull is FixedPullRequest => pull !== null)
+    .sort((left, right) => {
+      const leftTime = left.mergedAt ? Date.parse(left.mergedAt) : 0;
+      const rightTime = right.mergedAt ? Date.parse(right.mergedAt) : 0;
+      return rightTime - leftTime;
+    });
+  return candidates[0] ?? null;
+}
+
+export function fixedPullRequestFromCommitPullsForTest(
+  pulls: readonly unknown[],
+): FixedPullRequest | null {
+  return fixedPullRequestFromCommitPulls(pulls, "GitHub commit PR lookup");
+}
+
+function fixedPullRequestFromCommitSha(decision: Decision): FixedPullRequest | null {
+  if (decision.decision !== "close" || decision.confidence !== "high") return null;
+  const fixedSha = decision.fixedSha?.trim();
+  if (!fixedSha || fixedSha === "unknown") return null;
+  try {
+    const pulls = ghJson<unknown[]>([
+      "api",
+      `repos/${targetRepo()}/commits/${fixedSha}/pulls`,
+      "-H",
+      "Accept: application/vnd.github+json",
+    ]);
+    return fixedPullRequestFromCommitPulls(pulls, "GitHub commit PR lookup");
+  } catch (error) {
+    if (isGitHubNotFoundError(error)) return null;
+    throw error;
+  }
+}
+
 function attachFixedPullRequest(decision: Decision, item: Item, context: ItemContext): Decision {
   if (decision.fixedPullRequest) return decision;
-  const fixedPullRequest = fixedPullRequestFromContext(item, context, decision);
+  const fixedPullRequest =
+    fixedPullRequestFromContext(item, context, decision) ??
+    (item.kind === "issue" ? fixedPullRequestFromCommitSha(decision) : null);
   return fixedPullRequest ? { ...decision, fixedPullRequest } : decision;
 }
 

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -13,6 +13,7 @@ import {
   closingPullRequestReferenceTarget,
   codexEnv,
   dashboardClosedAt,
+  fixedPullRequestFromCommitPullsForTest,
   formatRecentClosedRows,
   ghRetryKind,
   hotIntakeRecencyMs,
@@ -399,6 +400,43 @@ test("close comments reference high-confidence merged fixing PRs", () => {
     action.closeComment,
     /fix evidence: merged PR \[#456\]\(https:\/\/github\.com\/openclaw\/openclaw\/pull\/456\), commit/,
   );
+});
+
+test("commit PR lookup selects the newest merged pull request", () => {
+  const fixedPullRequest = fixedPullRequestFromCommitPullsForTest([
+    {
+      number: 455,
+      html_url: "https://github.com/openclaw/openclaw/pull/455",
+      title: "fix: older candidate",
+      merged: true,
+      merged_at: "2026-04-27T12:00:00Z",
+      merge_commit_sha: "1111111111111111",
+    },
+    {
+      number: 456,
+      html_url: "https://github.com/openclaw/openclaw/pull/456",
+      title: "fix: wire the shell check",
+      merged_at: "2026-04-28T12:00:00Z",
+      merge_commit_sha: "fedcba9876543210",
+    },
+    {
+      number: 457,
+      html_url: "https://github.com/openclaw/openclaw/pull/457",
+      title: "open follow-up",
+      merged: false,
+    },
+  ]);
+
+  assert.deepEqual(fixedPullRequest, {
+    repo: "openclaw/openclaw",
+    number: 456,
+    url: "https://github.com/openclaw/openclaw/pull/456",
+    title: "fix: wire the shell check",
+    mergedAt: "2026-04-28T12:00:00Z",
+    sha: "fedcba9876543210",
+    confidence: "high",
+    source: "GitHub commit PR lookup",
+  });
 });
 
 test("report-rendered close comments keep merged fixing PR provenance", () => {


### PR DESCRIPTION
## Summary
- Resolve implemented-on-main fix SHAs back to merged PRs when applying ClawSweeper close proposals.
- Add a `Fixed by:` block to durable close comments before manual issue closure, with commit fallback for direct-push fixes.
- Cover PR-linked and commit-only rendering in unit tests.

## Why
When ClawSweeper manually closes an issue as already implemented on `main`, GitHub only shows a generic `closed this as completed` timeline event. This preserves a clear audit trail in the bot comment by naming the PR or commit that actually landed the fix.

## Verification
- `pnpm run check`