### PR TITLE
Require real behavior proof in PR reviews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Added
 
+- Added a real behavior proof assessment to PR reviews so missing, mock-only, or insufficient contributor proof blocks pass/automerge markers and asks for screenshots, terminal output, redacted logs, recordings, linked artifacts, or copied live output instead.
 - Added `config/automation-limits.json` plus docs and a drift check so review,
   commit-review, repair, and issue-implementation capacity defaults have one
   checked-in source of truth.

--- a/docs/pr-review-comments.md
+++ b/docs/pr-review-comments.md
@@ -38,12 +38,24 @@ For a PR that needs work, the visible comment starts with:
 Codex review: needs changes before merge.
 ```
 
+For an external PR that lacks after-fix real behavior proof, the visible comment
+starts with:
+
+```text
+Codex review: needs real behavior proof before merge.
+```
+
 The body should include the strongest actionable, non-overlapping sections the
 report has:
 
 - `**Summary**` from the typed `changeSummary` field, not from the
   merge verdict or maintainer follow-up summary; when `reproductionAssessment`
   is present, this section also includes a compact `Reproducibility:` line
+- `**Real behavior proof**` near the top for PRs, from the typed
+  `realBehaviorProof` field. When proof is missing, mock-only, or insufficient,
+  this section should tell contributors that terminal screenshots, console
+  output, copied live output, linked artifacts, recordings, and redacted logs
+  count even for non-visual CLI or text changes
 - `**Next step before merge**` for PRs, or `**Next step**` for issues, from the
   work-candidate reason or next action
 - `**Security**` from the typed `securityReview` field, so supply-chain,
@@ -98,6 +110,11 @@ hands, ClawSweeper emits a human-only verdict:
 ```html
 <!-- clawsweeper-verdict:needs-human item=<number> sha=<pull-head-sha> confidence=<confidence> -->
 ```
+
+Missing, mock-only, or insufficient `realBehaviorProof` is always human-only:
+ClawSweeper must not emit `clawsweeper-action:fix-required` or pass/automerge
+markers for proof-only blockers because automation cannot prove the
+contributor's real setup for them.
 
 Clean/close-style PR verdicts also stay human-only from the repair point of
 view. Closing remains outside the repair loop.

--- a/instructions/low-signal-prs.md
+++ b/instructions/low-signal-prs.md
@@ -29,6 +29,11 @@ owner discussion, green checks, or a focused fix that should be preserved.
   generated baselines, other extensions, runtime surfaces, or review artifacts.
 - Bot/review spam: repeated bot pings or copied bot output without author-owned
   fixes, especially when checks are still red.
+- Missing or mock-only real behavior proof: an external PR claims a behavior fix
+  but provides no after-fix evidence from a real setup, or only lists unit tests,
+  mocks, snapshots, lint, typechecks, or CI. Ask for screenshots, terminal
+  screenshots, console output, copied live output, linked artifacts, recordings,
+  or redacted runtime logs instead.
 
 ## Evidence bar
 
@@ -98,6 +103,8 @@ needed.
 - Security-sensitive PRs are not low-signal cleanup. Route them to central
   OpenClaw security handling instead of ClawSweeper Repair.
 - A green PR with a focused bug fix and clear reproduction.
+- A PR with sufficient after-fix real behavior proof from a real setup, even if
+  the proof is a terminal screenshot, console excerpt, or redacted runtime log.
 - A PR with recent maintainer review, assignment, or active author follow-up.
 - A unique bug report with reproduction detail, even if noisy.
 - Anything that would require technical judgment about correctness beyond the

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -84,6 +84,8 @@ likely owner.
 
 For PRs, include a dedicated security review pass in addition to the functional review. Inspect whether the diff could introduce a security or supply-chain regression, especially when it touches CI workflows, GitHub Action refs, dependency sources, lockfiles, install/build/release scripts, package publishing metadata, secrets handling, permissions, downloaded artifacts, generated/vendor/minified files, or other code execution paths. Check whether those changes are consistent with the PR title, body, discussion, and stated purpose before deciding. Be cautious when a small or unrelated functional change also introduces new third-party code execution, broadens secret or permission access, changes package resolution, adds lifecycle hooks, downloads and executes artifacts, or mixes infrastructure changes into otherwise cosmetic work. Do not infer malicious intent without concrete evidence. Always summarize this pass in `securityReview`; set `status: "cleared"` when the diff has no concrete security or supply-chain concern, `status: "needs_attention"` when there is a concrete concern, and `status: "not_applicable"` for non-PR items without a security-sensitive report. Put concrete security concerns in `securityReview.concerns` with file/line when possible, and also include blocking concerns in `risks` and `evidence` when they affect the merge/close decision.
 
+For PRs, include a dedicated `realBehaviorProof` assessment before any pass, automerge, or repair verdict. External PRs must show that the contributor ran the changed behavior after the fix in a real setup. Unit tests, mocks, snapshots, lint, typechecks, and CI are supplemental only; they are not real behavior proof by themselves. Treat screenshots, recordings, terminal screenshots, console output, copied live output, linked artifacts, and redacted runtime logs as valid proof, including for non-visual CLI, console, text, or error-message changes. Use `status: "sufficient"` only when the PR body or linked artifacts include after-fix real behavior evidence and an observed improved result. Use `status: "missing"` when proof is absent, `status: "mock_only"` when proof is only tests/mocks/CI, `status: "insufficient"` when the evidence does not show the changed real behavior after the fix, `status: "override"` when the PR has `proof: override`, and `status: "not_applicable"` for non-PR items or maintainer/bot PRs where the gate does not apply. When proof is missing, mock-only, or insufficient, set `needsContributorAction: true`, make the PR a human-only merge blocker, and do not request ClawSweeper repair markers because automation cannot prove the contributor's setup for them.
+
 For PRs, also emit Codex `/review`-style findings in `reviewFindings`.
 Review the diff as another engineer's proposed patch and list every discrete,
 actionable bug the author would likely fix. Findings must be introduced by the
@@ -317,6 +319,14 @@ security or supply-chain issue was found, `needs_attention` with one or more
 typed concerns when the patch or discussion raises a concrete security issue,
 and `not_applicable` for ordinary non-PR issue triage where no patch security
 review applies.
+
+Always fill `realBehaviorProof`. For external PRs, this is a merge gate, not a
+nice-to-have. Missing, mock-only, or insufficient proof should appear near the
+top of the public review as "needs real behavior proof before merge"; tell the
+contributor that terminal screenshots, console output, copied live output,
+linked artifacts, and redacted logs count. Use `evidenceKind: "none"` when proof
+is absent or mock-only, and set `needsContributorAction: false` only for
+`sufficient`, `override`, or `not_applicable`.
 
 Always fill the work-lane fields too. For non-candidates, use
 `workCandidate: "none"`, low confidence/priority, an empty `workPrompt`, and

--- a/schema/clawsweeper-decision.schema.json
+++ b/schema/clawsweeper-decision.schema.json
@@ -22,6 +22,7 @@
     "solutionAssessment",
     "reviewFindings",
     "securityReview",
+    "realBehaviorProof",
     "overallCorrectness",
     "overallConfidenceScore",
     "fixedRelease",
@@ -288,6 +289,46 @@
               }
             }
           }
+        }
+      }
+    },
+    "realBehaviorProof": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Dedicated PR proof assessment. For external PRs, after-fix evidence from a real setup is required; tests, mocks, snapshots, lint, typechecks, and CI are supplemental only.",
+      "required": ["status", "summary", "evidenceKind", "needsContributorAction"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "sufficient",
+            "missing",
+            "mock_only",
+            "insufficient",
+            "not_applicable",
+            "override"
+          ]
+        },
+        "summary": {
+          "type": "string",
+          "description": "One concise sentence explaining whether the PR body contains after-fix real behavior proof."
+        },
+        "evidenceKind": {
+          "type": "string",
+          "enum": [
+            "screenshot",
+            "recording",
+            "terminal",
+            "logs",
+            "live_output",
+            "linked_artifact",
+            "none",
+            "not_applicable"
+          ]
+        },
+        "needsContributorAction": {
+          "type": "boolean",
+          "description": "True when the contributor must add or improve real behavior proof before merge. This must be false for sufficient, override, and not_applicable statuses."
         }
       }
     },

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -83,6 +83,22 @@ type ReproductionStatus =
 type OverallCorrectness = "patch is correct" | "patch is incorrect" | "not a patch";
 type SecurityReviewStatus = "cleared" | "needs_attention" | "not_applicable";
 type SecurityConcernSeverity = "high" | "medium" | "low";
+type RealBehaviorProofStatus =
+  | "sufficient"
+  | "missing"
+  | "mock_only"
+  | "insufficient"
+  | "not_applicable"
+  | "override";
+type RealBehaviorProofEvidenceKind =
+  | "screenshot"
+  | "recording"
+  | "terminal"
+  | "logs"
+  | "live_output"
+  | "linked_artifact"
+  | "none"
+  | "not_applicable";
 type CloseReason =
   | "implemented_on_main"
   | "cannot_reproduce"
@@ -221,6 +237,13 @@ interface SecurityReview {
   concerns: SecurityConcern[];
 }
 
+interface RealBehaviorProof {
+  status: RealBehaviorProofStatus;
+  summary: string;
+  evidenceKind: RealBehaviorProofEvidenceKind;
+  needsContributorAction: boolean;
+}
+
 interface FixedPullRequest {
   repo: string;
   number: number;
@@ -252,6 +275,7 @@ interface Decision {
   solutionAssessment: string;
   reviewFindings: ReviewFinding[];
   securityReview: SecurityReview;
+  realBehaviorProof: RealBehaviorProof;
   overallCorrectness: OverallCorrectness;
   overallConfidenceScore: number;
   fixedRelease?: string | null;
@@ -594,11 +618,12 @@ const RECENT_MISSING_OPEN_MS = DAY_MS;
 const DEFAULT_CODEX_MODEL = "gpt-5.5";
 const DEFAULT_REASONING_EFFORT = "high";
 const DEFAULT_SERVICE_TIER = "";
-const REVIEW_POLICY_VERSION = "2026-04-29-policy-v12";
+const REVIEW_POLICY_VERSION = "2026-05-05-policy-v13";
 const REVIEW_COMMENT_MARKER_PREFIX = "<!-- clawsweeper-review";
 const REVIEW_START_STATUS_MARKER_PREFIX = "<!-- clawsweeper-review-status";
 const AUTOMERGE_LABEL = "clawsweeper:automerge";
 const AUTOFIX_LABEL = "clawsweeper:autofix";
+const PROOF_OVERRIDE_LABEL = "proof: override";
 const PROTECTED_LABELS = new Set(["security", "beta-blocker", "release-blocker", "maintainer"]);
 const ALLOWED_REASONS = new Set<CloseReason>([
   "implemented_on_main",
@@ -636,6 +661,24 @@ const SECURITY_REVIEW_STATUSES = new Set<SecurityReviewStatus>([
   "not_applicable",
 ]);
 const SECURITY_CONCERN_SEVERITIES = new Set<SecurityConcernSeverity>(["high", "medium", "low"]);
+const REAL_BEHAVIOR_PROOF_STATUSES = new Set<RealBehaviorProofStatus>([
+  "sufficient",
+  "missing",
+  "mock_only",
+  "insufficient",
+  "not_applicable",
+  "override",
+]);
+const REAL_BEHAVIOR_PROOF_EVIDENCE_KINDS = new Set<RealBehaviorProofEvidenceKind>([
+  "screenshot",
+  "recording",
+  "terminal",
+  "logs",
+  "live_output",
+  "linked_artifact",
+  "none",
+  "not_applicable",
+]);
 const OVERALL_CORRECTNESS_VALUES = new Set<OverallCorrectness>([
   "patch is correct",
   "patch is incorrect",
@@ -664,6 +707,7 @@ const DECISION_SCHEMA_KEYS = new Set([
   "solutionAssessment",
   "reviewFindings",
   "securityReview",
+  "realBehaviorProof",
   "overallCorrectness",
   "overallConfidenceScore",
   "fixedRelease",
@@ -681,6 +725,12 @@ const DECISION_SCHEMA_KEYS = new Set([
 ]);
 const EVIDENCE_SCHEMA_KEYS = new Set(["label", "detail", "file", "line", "command", "sha"]);
 const SECURITY_REVIEW_SCHEMA_KEYS = new Set(["status", "summary", "concerns"]);
+const REAL_BEHAVIOR_PROOF_SCHEMA_KEYS = new Set([
+  "status",
+  "summary",
+  "evidenceKind",
+  "needsContributorAction",
+]);
 const SECURITY_CONCERN_SCHEMA_KEYS = new Set([
   "title",
   "body",
@@ -714,6 +764,7 @@ const REVIEW_SECTIONS = {
   solutionAssessment: "Solution Assessment",
   reviewFindings: "Review Findings",
   securityReview: "Security Review",
+  realBehaviorProof: "Real Behavior Proof",
   workCandidate: "Work Candidate",
   repairWorkPrompt: "Repair Work Prompt",
   evidence: "Evidence",
@@ -1184,6 +1235,24 @@ function parseSecurityReview(value: unknown, path: string): SecurityReview {
   };
 }
 
+function parseRealBehaviorProof(value: unknown, path: string): RealBehaviorProof {
+  const record = requireRecord(value, path);
+  rejectUnexpectedKeys(record, REAL_BEHAVIOR_PROOF_SCHEMA_KEYS, path);
+  return {
+    status: requireEnum(record.status, REAL_BEHAVIOR_PROOF_STATUSES, `${path}.status`),
+    summary: requireString(record.summary, `${path}.summary`),
+    evidenceKind: requireEnum(
+      record.evidenceKind,
+      REAL_BEHAVIOR_PROOF_EVIDENCE_KINDS,
+      `${path}.evidenceKind`,
+    ),
+    needsContributorAction: requireBoolean(
+      record.needsContributorAction,
+      `${path}.needsContributorAction`,
+    ),
+  };
+}
+
 function requireEnum<T extends string>(value: unknown, allowed: Set<T>, path: string): T {
   if (typeof value === "string" && allowed.has(value as T)) return value as T;
   throw new Error(`${path} has invalid value`);
@@ -1251,6 +1320,10 @@ export function parseDecision(value: unknown): Decision {
     solutionAssessment: requireString(record.solutionAssessment, "decision.solutionAssessment"),
     reviewFindings,
     securityReview: parseSecurityReview(record.securityReview, "decision.securityReview"),
+    realBehaviorProof: parseRealBehaviorProof(
+      record.realBehaviorProof,
+      "decision.realBehaviorProof",
+    ),
     overallCorrectness: requireEnum(
       record.overallCorrectness,
       OVERALL_CORRECTNESS_VALUES,
@@ -3223,6 +3296,12 @@ function codexFailureDecision(status: number | null, stderr: string, stdout = ""
       summary: "Security review did not run because the Codex review failed before completion.",
       concerns: [],
     },
+    realBehaviorProof: {
+      status: "not_applicable",
+      summary: "Real behavior proof was not assessed because the Codex review failed.",
+      evidenceKind: "not_applicable",
+      needsContributorAction: false,
+    },
     overallCorrectness: "not a patch",
     overallConfidenceScore: 0,
     fixedRelease: null,
@@ -3982,6 +4061,33 @@ function publicSecurityReviewLine(review: SecurityReview): string {
   return `${prefix}: ${sentence(review.summary)}`;
 }
 
+function publicRealBehaviorProofLine(proof: RealBehaviorProof): string {
+  const summary = sentence(proof.summary);
+  switch (proof.status) {
+    case "sufficient":
+      return `Sufficient (${proof.evidenceKind}): ${summary}`;
+    case "override":
+      return `Override: ${summary || "A maintainer applied proof: override."}`;
+    case "missing":
+      return `Needs real behavior proof before merge: ${
+        summary ||
+        "the PR must include after-fix evidence from a real setup. Terminal screenshots, console output, copied live output, linked artifacts, and redacted logs count."
+      }`;
+    case "mock_only":
+      return `Needs real behavior proof before merge: ${
+        summary ||
+        "tests, mocks, snapshots, lint, typechecks, and CI are supplemental only. Terminal screenshots, console output, copied live output, linked artifacts, and redacted logs count."
+      }`;
+    case "insufficient":
+      return `Needs stronger real behavior proof before merge: ${
+        summary ||
+        "include after-fix evidence from a real setup. Terminal screenshots, console output, copied live output, linked artifacts, and redacted logs count."
+      }`;
+    case "not_applicable":
+      return summary ? `Not applicable: ${summary}` : "";
+  }
+}
+
 function closeIntro(reason: CloseReason): string {
   switch (reason) {
     case "implemented_on_main":
@@ -4199,6 +4305,89 @@ function reportSecurityReview(markdown: string): SecurityReview {
   return { status, summary, concerns };
 }
 
+function defaultRealBehaviorProof(markdown: string): RealBehaviorProof {
+  const type = frontMatterValue(markdown, "type");
+  if (frontMatterStringArray(markdown, "labels").includes(PROOF_OVERRIDE_LABEL)) {
+    return {
+      status: "override",
+      summary: "A maintainer applied proof: override for this PR.",
+      evidenceKind: "not_applicable",
+      needsContributorAction: false,
+    };
+  }
+  return {
+    status: "not_applicable",
+    summary:
+      type === "pull_request"
+        ? "No real behavior proof assessment was recorded in this older report."
+        : "Real behavior proof is not required for non-PR issue triage.",
+    evidenceKind: "not_applicable",
+    needsContributorAction: false,
+  };
+}
+
+function reportRealBehaviorProof(markdown: string): RealBehaviorProof {
+  const section = reviewSectionValue(markdown, "realBehaviorProof");
+  if (!section.trim()) {
+    const defaultProof = defaultRealBehaviorProof(markdown);
+    if (defaultProof.status === "override") return defaultProof;
+    if (isExternalPullRequestReport(markdown)) {
+      return {
+        status: "missing",
+        summary:
+          "No after-fix real behavior proof was recorded for this external PR; terminal screenshots, console output, copied live output, linked artifacts, recordings, and redacted logs count.",
+        evidenceKind: "none",
+        needsContributorAction: true,
+      };
+    }
+    return defaultProof;
+  }
+  const statusValue = sectionLineValue(section, "Status");
+  const evidenceKindValue = sectionLineValue(section, "Evidence kind");
+  const summary = sectionLineValue(section, "Summary");
+  const needsContributorActionValue = sectionLineValue(section, "Needs contributor action");
+  const status = REAL_BEHAVIOR_PROOF_STATUSES.has(statusValue as RealBehaviorProofStatus)
+    ? (statusValue as RealBehaviorProofStatus)
+    : undefined;
+  const evidenceKind = REAL_BEHAVIOR_PROOF_EVIDENCE_KINDS.has(
+    evidenceKindValue as RealBehaviorProofEvidenceKind,
+  )
+    ? (evidenceKindValue as RealBehaviorProofEvidenceKind)
+    : undefined;
+  if (!status || !evidenceKind || !summary) return defaultRealBehaviorProof(markdown);
+  return {
+    status,
+    summary,
+    evidenceKind,
+    needsContributorAction: /^true$/i.test(needsContributorActionValue ?? ""),
+  };
+}
+
+function isAutomationReportAuthor(author: string | undefined): boolean {
+  return Boolean(author && (/\[bot\]$/i.test(author) || author.startsWith("app/")));
+}
+
+function isExternalPullRequestReport(markdown: string): boolean {
+  if (frontMatterValue(markdown, "type") !== "pull_request") return false;
+  const authorAssociation = frontMatterValue(markdown, "author_association");
+  if (!authorAssociation) return false;
+  if (isMaintainerAuthorAssociation(authorAssociation)) return false;
+  return !isAutomationReportAuthor(frontMatterValue(markdown, "author"));
+}
+
+function realBehaviorProofBlocksMerge(markdown: string): boolean {
+  if (!isExternalPullRequestReport(markdown)) return false;
+  if (frontMatterStringArray(markdown, "labels").includes(PROOF_OVERRIDE_LABEL)) return false;
+  const proof = reportRealBehaviorProof(markdown);
+  return (
+    proof.needsContributorAction ||
+    proof.status === "missing" ||
+    proof.status === "mock_only" ||
+    proof.status === "insufficient" ||
+    (proof.status !== "sufficient" && proof.status !== "override")
+  );
+}
+
 function parseBoldListHeading(line: string): { label: string; detail: string } | null {
   const prefix = "- **";
   if (!line.startsWith(prefix)) return null;
@@ -4348,6 +4537,7 @@ function reportDecision(markdown: string, closeReason: CloseReason): Decision {
     solutionAssessment: reviewSectionValue(markdown, "solutionAssessment"),
     reviewFindings: reportReviewFindings(markdown),
     securityReview: reportSecurityReview(markdown),
+    realBehaviorProof: reportRealBehaviorProof(markdown),
     overallCorrectness: reportOverallCorrectness(markdown),
     overallConfidenceScore: reportOverallConfidenceScore(markdown),
     fixedRelease: fixedRelease && fixedRelease !== "unknown" ? fixedRelease : null,
@@ -4578,6 +4768,7 @@ function renderKeepOpenCommentFromReport(markdown: string): string {
   const likelyOwners = reportLikelyOwners(markdown).slice(0, 5).map(likelyOwnerLine);
   const reviewFindings = reportReviewFindings(markdown);
   const securityReview = reportSecurityReview(markdown);
+  const realBehaviorProof = reportRealBehaviorProof(markdown);
   const summary = reviewSectionValue(markdown, "summary");
   const changeSummary = reviewSectionValue(markdown, "changeSummary");
   const bestSolution = reviewSectionValue(markdown, "bestSolution");
@@ -4592,6 +4783,7 @@ function renderKeepOpenCommentFromReport(markdown: string): string {
   const isPullRequest = frontMatterValue(markdown, "type") === "pull_request";
   const isRepairCandidate = workCandidate === "queue_fix_pr";
   const isRepairLoopPass = isPullRequest && Boolean(repairLoopPassModeFromReport(markdown));
+  const hasRealBehaviorProofBlocker = isPullRequest && realBehaviorProofBlocksMerge(markdown);
   const summaryLine = sentence(summary) || "_No summary provided._";
   const changeSummaryLine = sentence(changeSummary || summary) || "_No change summary provided._";
   const fallbackNextStep =
@@ -4601,15 +4793,17 @@ function renderKeepOpenCommentFromReport(markdown: string): string {
   const details: string[] = [];
   const hasReviewFindings = isPullRequest && reviewFindings.length > 0;
   const lines = [
-    isRepairLoopPass
-      ? "Codex review: passed."
-      : isPullRequest && isRepairCandidate
-        ? "Codex review: needs changes before merge."
-        : hasReviewFindings
-          ? "Codex review: found issues before merge."
-          : isPullRequest
-            ? "Codex review: needs maintainer review before merge."
-            : "Codex review: keeping this open for maintainer follow-up; there is still a little grit to resolve.",
+    hasRealBehaviorProofBlocker
+      ? "Codex review: needs real behavior proof before merge."
+      : isRepairLoopPass
+        ? "Codex review: passed."
+        : isPullRequest && isRepairCandidate
+          ? "Codex review: needs changes before merge."
+          : hasReviewFindings
+            ? "Codex review: found issues before merge."
+            : isPullRequest
+              ? "Codex review: needs maintainer review before merge."
+              : "Codex review: keeping this open for maintainer follow-up; there is still a little grit to resolve.",
     "",
   ];
   if (isPullRequest) {
@@ -4620,6 +4814,13 @@ function renderKeepOpenCommentFromReport(markdown: string): string {
     );
   } else {
     appendPublicSection(lines, "Summary", publicSummaryBody(summaryLine, reproductionAssessment));
+  }
+  if (isPullRequest) {
+    appendPublicSection(
+      lines,
+      "Real behavior proof",
+      publicRealBehaviorProofLine(realBehaviorProof),
+    );
   }
   appendPublicSection(lines, isPullRequest ? "Next step before merge" : "Next step", nextStepLine);
   const securityLine = publicSecurityReviewLine(securityReview);
@@ -4878,9 +5079,10 @@ export function reviewAutomationMarkersFromReport(markdown: string): string {
   if (frontMatterValue(markdown, "review_status") === "failed") {
     return `<!-- clawsweeper-verdict:needs-human ${baseAttrs} -->`;
   }
+  const hasRealBehaviorProofBlocker = realBehaviorProofBlocksMerge(markdown);
   if (reportSecurityReview(markdown).status === "needs_attention") {
     const markers = [`<!-- clawsweeper-security:security-sensitive ${baseAttrs} -->`];
-    if (securitySensitiveRepairAllowed(markdown)) {
+    if (!hasRealBehaviorProofBlocker && securitySensitiveRepairAllowed(markdown)) {
       markers.push(
         `<!-- clawsweeper-verdict:needs-changes ${baseAttrs} -->`,
         `<!-- clawsweeper-action:fix-required ${baseAttrs} finding=security-review -->`,
@@ -4889,6 +5091,9 @@ export function reviewAutomationMarkersFromReport(markdown: string): string {
       markers.push(`<!-- clawsweeper-verdict:needs-human ${baseAttrs} -->`);
     }
     return markers.join("\n");
+  }
+  if (hasRealBehaviorProofBlocker) {
+    return `<!-- clawsweeper-verdict:needs-human ${baseAttrs} -->`;
   }
   if (decision === "keep_open") {
     if (repairLoopPassModeFromReport(markdown)) {
@@ -4933,6 +5138,7 @@ function repairLoopFindingRepairAllowed(markdown: string): boolean {
   const labels = frontMatterStringArray(markdown, "labels");
   return (
     (labels.includes(AUTOMERGE_LABEL) || labels.includes(AUTOFIX_LABEL)) &&
+    !realBehaviorProofBlocksMerge(markdown) &&
     reportReviewFindings(markdown).length > 0
   );
 }
@@ -4944,6 +5150,7 @@ function isRepairLoopPassReport(markdown: string): boolean {
     frontMatterValue(markdown, "review_status") === "complete" &&
     frontMatterValue(markdown, "confidence") === "high" &&
     frontMatterValue(markdown, "decision") === "keep_open" &&
+    !realBehaviorProofBlocksMerge(markdown) &&
     reportOverallCorrectness(markdown) === "patch is correct" &&
     reportReviewFindings(markdown).length === 0
   );
@@ -5323,6 +5530,18 @@ function renderSecurityReviewReportSection(decision: Decision): string {
   return lines.join("\n");
 }
 
+function renderRealBehaviorProofReportSection(decision: Decision): string {
+  return [
+    `Status: ${decision.realBehaviorProof.status}`,
+    "",
+    `Evidence kind: ${decision.realBehaviorProof.evidenceKind}`,
+    "",
+    `Needs contributor action: ${decision.realBehaviorProof.needsContributorAction}`,
+    "",
+    `Summary: ${sentence(decision.realBehaviorProof.summary)}`,
+  ].join("\n");
+}
+
 function markdownFor(options: {
   item: Item;
   context: ItemContext;
@@ -5374,6 +5593,7 @@ function markdownFor(options: {
   const solutionAssessment = options.decision.solutionAssessment.trim() || "_Not provided._";
   const reviewFindings = renderReviewFindingsReportSection(options.decision);
   const securityReview = renderSecurityReviewReportSection(options.decision);
+  const realBehaviorProof = renderRealBehaviorProofReportSection(options.decision);
   const workCandidateSection = renderWorkCandidateReportSection(options.decision);
   const repairWorkPromptSection = renderRepairWorkPromptReportSection(options.decision);
   return `---
@@ -5435,6 +5655,9 @@ reproduction_confidence: ${options.decision.reproductionConfidence}
 requires_new_feature: ${options.decision.requiresNewFeature}
 requires_new_config_option: ${options.decision.requiresNewConfigOption}
 requires_product_decision: ${options.decision.requiresProductDecision}
+real_behavior_proof_status: ${options.decision.realBehaviorProof.status}
+real_behavior_proof_evidence_kind: ${options.decision.realBehaviorProof.evidenceKind}
+real_behavior_proof_needs_contributor_action: ${options.decision.realBehaviorProof.needsContributorAction}
 ---
 
 # ${markdownLink(`#${options.item.number}: ${options.item.title}`, options.item.url)}
@@ -5500,6 +5723,10 @@ ${reviewFindings}
 ## ${REVIEW_SECTIONS.securityReview}
 
 ${securityReview}
+
+## ${REVIEW_SECTIONS.realBehaviorProof}
+
+${realBehaviorProof}
 
 ## ${REVIEW_SECTIONS.workCandidate}
 

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -145,6 +145,12 @@ function closeDecision(overrides = {}) {
       summary: "No patch security review is needed for this issue cleanup decision.",
       concerns: [],
     },
+    realBehaviorProof: {
+      status: "not_applicable",
+      summary: "Real behavior proof is not required for non-PR issue triage.",
+      evidenceKind: "not_applicable",
+      needsContributorAction: false,
+    },
     overallCorrectness: "not a patch",
     overallConfidenceScore: 0.75,
     fixedRelease: null,
@@ -195,6 +201,27 @@ ${Object.entries(values)
   .map(([key, value]) => `${key}: ${value}`)
   .join("\n")}
 ---
+`;
+}
+
+function realBehaviorProofReportSection(overrides = {}) {
+  const values = {
+    status: "sufficient",
+    evidenceKind: "terminal",
+    needsContributorAction: false,
+    summary:
+      "The PR includes a terminal transcript from a real OpenClaw setup showing the fixed behavior after the patch.",
+    ...overrides,
+  };
+  return `## Real Behavior Proof
+
+Status: ${values.status}
+
+Evidence kind: ${values.evidenceKind}
+
+Needs contributor action: ${values.needsContributorAction}
+
+Summary: ${values.summary}
 `;
 }
 
@@ -1682,6 +1709,157 @@ Full review comments:
   assert.doesNotMatch(comment, /clawsweeper-verdict:needs-human/);
 });
 
+test("sufficient real behavior proof allows automerge pass markers", () => {
+  const report = `${reportFrontMatter({
+    type: "pull_request",
+    number: "74459",
+    decision: "keep_open",
+    close_reason: "none",
+    review_status: "complete",
+    confidence: "high",
+    author: "contributor",
+    author_association: "CONTRIBUTOR",
+    labels: JSON.stringify(["clawsweeper:automerge"]),
+    work_candidate: "none",
+    pull_head_sha: "abc123def456",
+  })}
+
+## Summary
+
+Keep this focused PR open for automerge.
+
+## What This Changes
+
+Fixes the gateway status output.
+
+## Best Possible Solution
+
+Merge after required checks are green.
+
+${realBehaviorProofReportSection()}
+
+## Review Findings
+
+Overall correctness: patch is correct
+
+Overall confidence: 0.9
+
+Full review comments:
+
+- none
+`;
+
+  const comment = renderReviewCommentFromReport(report, "none");
+  const markers = reviewAutomationMarkersFromReport(report);
+
+  assert.match(comment, /\*\*Real behavior proof\*\*\nSufficient \(terminal\):/);
+  assert.match(markers, /clawsweeper-verdict:pass/);
+  assert.doesNotMatch(markers, /clawsweeper-verdict:needs-human/);
+});
+
+test("missing real behavior proof blocks pass and repair markers", () => {
+  const report = `${reportFrontMatter({
+    type: "pull_request",
+    number: "74460",
+    decision: "keep_open",
+    close_reason: "none",
+    review_status: "complete",
+    confidence: "high",
+    author: "contributor",
+    author_association: "CONTRIBUTOR",
+    labels: JSON.stringify(["clawsweeper:automerge"]),
+    work_candidate: "queue_fix_pr",
+    pull_head_sha: "abc123def456",
+  })}
+
+## Summary
+
+Keep this PR open until the contributor proves the fix in a real setup.
+
+## What This Changes
+
+Fixes the gateway status output.
+
+## Best Possible Solution
+
+Ask the contributor to add after-fix proof from their real setup.
+
+${realBehaviorProofReportSection({
+  status: "missing",
+  evidenceKind: "none",
+  needsContributorAction: true,
+  summary:
+    "The PR body does not include after-fix evidence from a real setup; terminal screenshots, console output, copied live output, linked artifacts, recordings, and redacted logs count.",
+})}
+
+## Review Findings
+
+Overall correctness: patch is correct
+
+Overall confidence: 0.9
+
+Full review comments:
+
+- none
+`;
+
+  const comment = renderReviewCommentFromReport(report, "none");
+  const markers = reviewAutomationMarkersFromReport(report);
+
+  assert.match(comment, /Codex review: needs real behavior proof before merge\./);
+  assert.match(comment, /\*\*Real behavior proof\*\*/);
+  assert.match(comment, /terminal screenshots, console output, copied live output/);
+  assert.match(markers, /clawsweeper-verdict:needs-human/);
+  assert.doesNotMatch(markers, /clawsweeper-verdict:pass/);
+  assert.doesNotMatch(markers, /clawsweeper-action:fix-required/);
+});
+
+test("mock-only real behavior proof blocks repair markers", () => {
+  const report = `${reportFrontMatter({
+    type: "pull_request",
+    number: "74461",
+    decision: "keep_open",
+    close_reason: "none",
+    confidence: "high",
+    author: "contributor",
+    author_association: "CONTRIBUTOR",
+    labels: JSON.stringify(["clawsweeper:autofix"]),
+    work_candidate: "queue_fix_pr",
+    pull_head_sha: "abc123def456",
+  })}
+
+## Summary
+
+Keep this PR open until proof covers real behavior.
+
+${realBehaviorProofReportSection({
+  status: "mock_only",
+  evidenceKind: "none",
+  needsContributorAction: true,
+  summary:
+    "The PR only cites unit tests and CI; the contributor needs a terminal screenshot, console output, copied live output, recording, linked artifact, or redacted runtime log from a real setup.",
+})}
+
+## Review Findings
+
+Overall correctness: patch is incorrect
+
+Overall confidence: 0.9
+
+Full review comments:
+
+- **[P3] Add a changelog entry:** \`CHANGELOG.md:12\`
+  - body: The PR changes user-visible behavior and needs a changelog entry.
+  - confidence: 0.8
+`;
+
+  const markers = reviewAutomationMarkersFromReport(report);
+
+  assert.match(markers, /clawsweeper-verdict:needs-human/);
+  assert.doesNotMatch(markers, /clawsweeper-action:fix-required/);
+  assert.doesNotMatch(markers, /clawsweeper-verdict:needs-changes/);
+});
+
 test("pull request automerge pass is not blocked by generic protected labels", () => {
   const comment = renderReviewCommentFromReport(
     `${reportFrontMatter({
@@ -2198,6 +2376,11 @@ test("decision parser enforces required schema-shaped evidence", () => {
     delete decision.securityReview;
     return parseDecision(decision);
   }, /decision\.securityReview/);
+  assert.throws(() => {
+    const decision = closeDecision();
+    delete decision.realBehaviorProof;
+    return parseDecision(decision);
+  }, /decision\.realBehaviorProof/);
   const workCandidate = parseDecision(
     closeDecision({
       decision: "keep_open",
@@ -2216,6 +2399,7 @@ test("decision parser enforces required schema-shaped evidence", () => {
   assert.equal(workCandidate.workCandidate, "queue_fix_pr");
   assert.equal(workCandidate.itemCategory, "bug");
   assert.equal(workCandidate.reproductionStatus, "reproduced");
+  assert.equal(workCandidate.realBehaviorProof.status, "not_applicable");
   assert.deepEqual(workCandidate.workClusterRefs, ["#123", "#456"]);
 });
 
@@ -2237,6 +2421,18 @@ test("review prompt requires a dedicated securityReview section", () => {
   assert.match(prompt, /Always summarize this pass in `securityReview`/);
   assert.match(prompt, /Always fill `securityReview`/);
   assert.match(prompt, /status: "needs_attention"/);
+});
+
+test("review prompt requires real behavior proof for PR reviews", () => {
+  const prompt = readFileSync("prompts/review-item.md", "utf8");
+
+  assert.match(prompt, /realBehaviorProof/);
+  assert.match(prompt, /Terminal screenshots|terminal screenshots/);
+  assert.match(
+    prompt,
+    /Unit tests, mocks, snapshots, lint, typechecks, and CI are supplemental only/,
+  );
+  assert.match(prompt, /do not request ClawSweeper repair markers/);
 });
 
 test("review prompt asks for concise public review fields", () => {


### PR DESCRIPTION
This teaches ClawSweeper to treat real behavior proof as a first-class PR review decision. The review schema now records status, evidence kind, and whether contributor action is needed; public comments show the proof verdict near the top; and missing, mock-only, or insufficient proof forces human-only markers so ClawSweeper cannot pass, automerge, or repair its way around proof that only the contributor can provide.

The prompt and low-signal guidance now explicitly ask for real setup evidence, including terminal screenshots, console output, redacted logs, recordings, linked artifacts, and copied live output, even for non-visual changes.