### PR TITLE
perf: request larger GitHub pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ checkpoint, and status-only commits are intentionally omitted.
   replayed automerge commands.
 - Updated targeted re-review command comments with live progress while the review
   workflow runs.
+- Requested 100-item REST pages for paginated GitHub list calls, reducing
+  review and repair API page fan-out on large issues and pull requests.
 
 ## 0.2.0 - 2026-05-03
 

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -1921,8 +1921,17 @@ function compactPullCommit(value: unknown): unknown {
   };
 }
 
+export function githubPaginatedPath(path: string): string {
+  const [basePart, query = ""] = path.split("?", 2);
+  const base = basePart ?? path;
+  const params = new URLSearchParams(query);
+  if (!params.has("per_page")) params.set("per_page", "100");
+  const serialized = params.toString();
+  return serialized ? `${base}?${serialized}` : base;
+}
+
 function ghPaged<T>(path: string): T[] {
-  const pages = ghJson<unknown[]>(["api", path, "--paginate", "--slurp"]);
+  const pages = ghJson<unknown[]>(["api", githubPaginatedPath(path), "--paginate", "--slurp"]);
   if (!Array.isArray(pages)) return [];
   return pages.flatMap((page) => (Array.isArray(page) ? (page as T[]) : []));
 }

--- a/src/repair/github-cli.ts
+++ b/src/repair/github-cli.ts
@@ -47,8 +47,20 @@ export function ghJsonBestEffort<T = JsonValue>(
   }
 }
 
+export function githubPaginatedPath(apiPath: string): string {
+  const [basePart, query = ""] = apiPath.split("?", 2);
+  const base = basePart ?? apiPath;
+  const params = new URLSearchParams(query);
+  if (!params.has("per_page")) params.set("per_page", "100");
+  const serialized = params.toString();
+  return serialized ? `${base}?${serialized}` : base;
+}
+
 export function ghPaged<T = JsonValue>(apiPath: string, options: GhRunOptions = {}): T[] {
-  const pages = ghJson<JsonValue[]>(["api", apiPath, "--paginate", "--slurp"], options);
+  const pages = ghJson<JsonValue[]>(
+    ["api", githubPaginatedPath(apiPath), "--paginate", "--slurp"],
+    options,
+  );
   if (!Array.isArray(pages)) return [];
   return pages.flatMap((page: JsonValue) => (Array.isArray(page) ? (page as T[]) : []));
 }
@@ -57,7 +69,10 @@ export function ghPagedWithRetry<T = JsonValue>(
   apiPath: string,
   options: GhRetryOptions | number = {},
 ): T[] {
-  const pages = ghJsonWithRetry<JsonValue[]>(["api", apiPath, "--paginate", "--slurp"], options);
+  const pages = ghJsonWithRetry<JsonValue[]>(
+    ["api", githubPaginatedPath(apiPath), "--paginate", "--slurp"],
+    options,
+  );
   if (!Array.isArray(pages)) return [];
   return pages.flatMap((page: JsonValue) => (Array.isArray(page) ? (page as T[]) : []));
 }
@@ -67,7 +82,7 @@ export async function ghPagedWithRetryAsync<T = JsonValue>(
   options: GhRetryOptions | number = {},
 ): Promise<T[]> {
   const pages = await ghJsonWithRetryAsync<JsonValue[]>(
-    ["api", apiPath, "--paginate", "--slurp"],
+    ["api", githubPaginatedPath(apiPath), "--paginate", "--slurp"],
     options,
   );
   if (!Array.isArray(pages)) return [];

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -15,6 +15,7 @@ import {
   dashboardClosedAt,
   fixedPullRequestFromCommitPullsForTest,
   formatRecentClosedRows,
+  githubPaginatedPath,
   ghRetryKind,
   hotIntakeRecencyMs,
   isCodexReviewCommentBody,
@@ -162,6 +163,21 @@ function closeDecision(overrides = {}) {
     ...overrides,
   };
 }
+
+test("githubPaginatedPath requests maximum REST page size by default", () => {
+  assert.equal(
+    githubPaginatedPath("repos/openclaw/openclaw/issues/123/comments"),
+    "repos/openclaw/openclaw/issues/123/comments?per_page=100",
+  );
+  assert.equal(
+    githubPaginatedPath("repos/openclaw/openclaw/issues?state=open&sort=created"),
+    "repos/openclaw/openclaw/issues?state=open&sort=created&per_page=100",
+  );
+  assert.equal(
+    githubPaginatedPath("repos/openclaw/openclaw/issues?per_page=50&state=open"),
+    "repos/openclaw/openclaw/issues?per_page=50&state=open",
+  );
+});
 
 test("main CLI args ignore package-manager double dash separators", () => {
   assert.deepEqual(parseClawsweeperArgs(["apply-decisions", "--", "--dry-run"]), {

--- a/test/repair/github-cli.test.ts
+++ b/test/repair/github-cli.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { githubPaginatedPath } from "../../dist/repair/github-cli.js";
+
+test("githubPaginatedPath requests maximum REST page size by default", () => {
+  assert.equal(
+    githubPaginatedPath("repos/openclaw/openclaw/issues/123/comments"),
+    "repos/openclaw/openclaw/issues/123/comments?per_page=100",
+  );
+  assert.equal(
+    githubPaginatedPath("repos/openclaw/openclaw/issues?state=open&sort=created"),
+    "repos/openclaw/openclaw/issues?state=open&sort=created&per_page=100",
+  );
+  assert.equal(
+    githubPaginatedPath("repos/openclaw/openclaw/issues?per_page=50&state=open"),
+    "repos/openclaw/openclaw/issues?per_page=50&state=open",
+  );
+});


### PR DESCRIPTION
## Summary
- normalize paginated GitHub REST paths to request per_page=100 by default
- apply the same behavior to the review CLI and repair GitHub helper wrappers
- add unit coverage for default page sizing and preserving explicit per_page values

## Validation
- pnpm run build:all
- node --test test/clawsweeper.test.ts test/repair/github-cli.test.ts
- pnpm run lint
- pnpm run format:check
- git diff --check
- pnpm run check (local Node v22.22.0 fails existing notifier tests that require the repo's Node >=24 runtime: test/repair/notify-events.test.ts and test/repair/notify-github-activity.test.ts)