### PR TITLE
perf: lazily compact review context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ checkpoint, and status-only commits are intentionally omitted.
   replayed automerge commands.
 - Updated targeted re-review command comments with live progress while the review
   workflow runs.
+- Compacted review prompt context lazily so large comment, timeline, file, and
+  commit lists no longer process entries that are omitted from Codex input.
 
 ## 0.2.0 - 2026-05-03
 

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -1397,14 +1397,19 @@ export function closeReasonApplyAgeSkipReason(
   return null;
 }
 
-function compactSlice<T>(items: T[], limit: number): unknown[] {
-  if (items.length <= limit) return items as unknown[];
-  const keepStart = Math.floor(limit / 2);
-  const keepEnd = Math.max(0, limit - keepStart);
+export function compactMappedSlice<T>(
+  items: readonly T[],
+  limit: number,
+  mapper: (item: T) => unknown,
+): unknown[] {
+  const boundedLimit = Math.max(0, Math.floor(limit));
+  if (items.length <= boundedLimit) return items.map(mapper);
+  const keepStart = Math.floor(boundedLimit / 2);
+  const keepEnd = Math.max(0, boundedLimit - keepStart);
   return [
-    ...items.slice(0, keepStart),
-    { omitted: items.length - limit, note: "middle entries omitted from prompt context" },
-    ...items.slice(items.length - keepEnd),
+    ...items.slice(0, keepStart).map(mapper),
+    { omitted: items.length - boundedLimit, note: "middle entries omitted from prompt context" },
+    ...(keepEnd > 0 ? items.slice(items.length - keepEnd).map(mapper) : []),
   ];
 }
 
@@ -3041,8 +3046,8 @@ function collectItemContext(item: Item): ItemContext {
   const timeline = ghPaged<unknown>(`repos/${targetRepo()}/issues/${item.number}/timeline`);
   const context: ItemContext = {
     issue: compactIssue(issue),
-    comments: compactSlice(comments.map(compactComment), 24),
-    timeline: compactSlice(timeline.map(compactTimelineEvent), 80),
+    comments: compactMappedSlice(comments, 24, compactComment),
+    timeline: compactMappedSlice(timeline, 80, compactTimelineEvent),
     counts: {
       comments: comments.length,
       timeline: timeline.length,
@@ -3053,7 +3058,7 @@ function collectItemContext(item: Item): ItemContext {
   if (item.kind === "issue") {
     const closingPullRequests = closingPullRequestsForIssue(item.number);
     if (closingPullRequests.length > 0) {
-      context.closingPullRequests = compactSlice(closingPullRequests.map(compactPullRequest), 12);
+      context.closingPullRequests = compactMappedSlice(closingPullRequests, 12, compactPullRequest);
       context.counts = {
         ...context.counts,
         comments: comments.length,
@@ -3068,9 +3073,9 @@ function collectItemContext(item: Item): ItemContext {
     const pullCommits = ghPaged<unknown>(`repos/${targetRepo()}/pulls/${item.number}/commits`);
     pullReviewComments = ghPaged<unknown>(`repos/${targetRepo()}/pulls/${item.number}/comments`);
     context.pullRequest = compactPullRequest(pullRequest);
-    context.pullFiles = compactSlice(pullFiles.map(compactPullFile), 80);
-    context.pullCommits = compactSlice(pullCommits.map(compactPullCommit), 80);
-    context.pullReviewComments = compactSlice(pullReviewComments.map(compactComment), 40);
+    context.pullFiles = compactMappedSlice(pullFiles, 80, compactPullFile);
+    context.pullCommits = compactMappedSlice(pullCommits, 80, compactPullCommit);
+    context.pullReviewComments = compactMappedSlice(pullReviewComments, 40, compactComment);
     context.counts = {
       ...context.counts,
       comments: comments.length,

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -11,6 +11,7 @@ import {
   closeReasonApplyAgeSkipReason,
   closeReasonsArg,
   closingPullRequestReferenceTarget,
+  compactMappedSlice,
   codexEnv,
   dashboardClosedAt,
   fixedPullRequestFromCommitPullsForTest,
@@ -162,6 +163,32 @@ function closeDecision(overrides = {}) {
     ...overrides,
   };
 }
+
+test("compactMappedSlice maps only retained prompt entries", () => {
+  const mapped: number[] = [];
+  const result = compactMappedSlice([1, 2, 3, 4, 5, 6], 4, (value) => {
+    mapped.push(value);
+    return value * 10;
+  });
+  assert.deepEqual(result, [
+    10,
+    20,
+    { omitted: 2, note: "middle entries omitted from prompt context" },
+    50,
+    60,
+  ]);
+  assert.deepEqual(mapped, [1, 2, 5, 6]);
+});
+
+test("compactMappedSlice maps every entry when no compaction is needed", () => {
+  const mapped: number[] = [];
+  const result = compactMappedSlice([1, 2, 3], 3, (value) => {
+    mapped.push(value);
+    return value * 10;
+  });
+  assert.deepEqual(result, [10, 20, 30]);
+  assert.deepEqual(mapped, [1, 2, 3]);
+});
 
 test("main CLI args ignore package-manager double dash separators", () => {
   assert.deepEqual(parseClawsweeperArgs(["apply-decisions", "--", "--dry-run"]), {


### PR DESCRIPTION
## Summary
- replace eager map-then-compact prompt context handling with lazy compact-and-map helper
- avoid compacting middle comments, timeline events, PR files, commits, and review comments that are omitted from Codex prompt input
- add unit coverage proving only retained entries are mapped

## Validation
- pnpm run build
- node --test test/clawsweeper.test.ts
- pnpm run lint:src
- pnpm run lint:scripts
- pnpm run format:check
- git diff --check