### PR TITLE
perf: skip untargeted repair snippet scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ checkpoint, and status-only commits are intentionally omitted.
   replayed automerge commands.
 - Updated targeted re-review command comments with live progress while the review
   workflow runs.
+- Avoided full-file token scans for repair repository snippets when no discovery
+  tokens exist, keeping untargeted fix prompts cheaper to build.
 
 ## 0.2.0 - 2026-05-03
 

--- a/src/repair/fix-prompt-builder.test.ts
+++ b/src/repair/fix-prompt-builder.test.ts
@@ -281,6 +281,23 @@ test("repository context handles missing candidates, huge files, and invalid pac
   assert.match(context, /package_scripts: none/);
 });
 
+test("repository context renders first lines when discovery has no tokens", () => {
+  const tmp = makeGitRepo({
+    "package.json": JSON.stringify({ private: true }),
+    "README.md": Array.from({ length: 120 }, (_, index) => `line ${index + 1}`).join("\n"),
+  });
+
+  const context = buildRepositoryContext({
+    targetDir: tmp,
+    fixArtifact: {},
+  });
+
+  assert.match(context, /--- README\.md ---/);
+  assert.match(context, /1: line 1/);
+  assert.match(context, /80: line 80/);
+  assert.doesNotMatch(context, /120: line 120/);
+});
+
 test("repository context reports no candidates when nothing scores", () => {
   const tmp = makeGitRepo({
     "notes.bin": "no supported extension\n",

--- a/src/repair/fix-prompt-builder.ts
+++ b/src/repair/fix-prompt-builder.ts
@@ -319,6 +319,7 @@ export function buildRepositoryContext({ fixArtifact, targetDir }: LooseRecord) 
 function buildRepositorySnippets({ targetDir, candidates, fixArtifact }: LooseRecord) {
   const tokens = discoveryTokens(fixArtifact).slice(0, 40);
   const out: JsonValue[] = [];
+  let renderedLength = 0;
   for (const candidate of candidates) {
     const pathname = path.join(targetDir, candidate.file);
     if (!fs.existsSync(pathname)) continue;
@@ -327,8 +328,10 @@ function buildRepositorySnippets({ targetDir, candidates, fixArtifact }: LooseRe
     const content = fs.readFileSync(pathname, "utf8");
     const excerpt = focusedFileExcerpt(content, tokens);
     if (!excerpt) continue;
-    out.push(`--- ${candidate.file} ---\n${excerpt}`);
-    if (out.join("\n\n").length > REPOSITORY_SNIPPET_LIMIT) break;
+    const rendered = `--- ${candidate.file} ---\n${excerpt}`;
+    renderedLength += rendered.length + (out.length > 0 ? 2 : 0);
+    out.push(rendered);
+    if (renderedLength > REPOSITORY_SNIPPET_LIMIT) break;
   }
   return out.join("\n\n").slice(0, REPOSITORY_SNIPPET_LIMIT);
 }
@@ -339,6 +342,8 @@ function focusedFileExcerpt(content: string, tokens: string[]) {
   const lowerTokens = tokens
     .map((token) => token.toLowerCase())
     .filter((token) => token.length >= 4);
+  if (lowerTokens.length === 0)
+    return renderSelectedExcerptLines(lines, firstLineIndexes(lines, 80));
   for (let index = 0; index < lines.length; index += 1) {
     const lower = lines[index]!.toLowerCase();
     if (lowerTokens.some((token) => lower.includes(token))) {
@@ -354,14 +359,25 @@ function focusedFileExcerpt(content: string, tokens: string[]) {
   const selected =
     matched.size > 0
       ? [...matched].sort((left, right) => left - right)
-      : lines.map((_, index) => index).slice(0, 80);
+      : firstLineIndexes(lines, 80);
+  return renderSelectedExcerptLines(lines, selected);
+}
+
+function firstLineIndexes(lines: readonly string[], limit: number) {
+  return Array.from({ length: Math.min(lines.length, limit) }, (_, index) => index);
+}
+
+function renderSelectedExcerptLines(lines: readonly string[], selected: readonly number[]) {
   const rendered: string[] = [];
   let previous = -2;
+  let renderedLength = 0;
   for (const line of selected) {
     if (line !== previous + 1) rendered.push("...");
-    rendered.push(`${line + 1}: ${lines[line]}`);
+    const renderedLine = `${line + 1}: ${lines[line]}`;
+    rendered.push(renderedLine);
+    renderedLength += renderedLine.length + 1;
     previous = line;
-    if (rendered.join("\n").length > 3_200) break;
+    if (renderedLength > 3_200) break;
   }
   return rendered.join("\n");
 }


### PR DESCRIPTION
## Summary
- skip full-file token matching when repair repository snippets have no discovery tokens and will fall back to the first 80 lines
- avoid repeated string joins while enforcing repair snippet length limits
- add focused coverage for untargeted repository snippets

## Validation
- pnpm run build:repair
- node --test dist/repair/fix-prompt-builder.test.js
- pnpm run lint:repair
- pnpm run format:check
- git diff --check