### PR TITLE
perf: cache comment router issue comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ checkpoint, and status-only commits are intentionally omitted.
   immediate duplicate capacity probe in the dispatch loop.
 - Cached comment-router open-label issue lookups per run so repair-loop comment
   discovery and command synthesis do not repeat identical GitHub searches.
+- Cached comment-router issue comment lookups per run so targeted command routing
+  and replay/status checks do not repeat identical comment pagination.
 - Retried Codex edit workers after TPM/rate-limit exits and collapsed JSONL failure transcripts into concise repair status reasons.
 - Added deterministic merged closing-PR provenance to issue close reports and
   public close comments when GitHub exposes a high-confidence closing PR.

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -118,17 +118,43 @@ export function createCachedLabelNumberLookup(fetchNumbers: (label: string) => J
 
 export function createCachedIssueCommentsLookup<T = JsonValue>(
   fetchComments: (number: number) => T[],
+  cache = new Map<number, T[]>(),
 ) {
-  const cache = new Map<number, T[]>();
   return (number: JsonValue): T[] => {
     const key = Number(number);
     if (!Number.isInteger(key) || key <= 0) return [];
     const cached = cache.get(key);
     if (cached) return [...cached];
     const comments = fetchComments(key);
-    const safeComments = Array.isArray(comments) ? comments : [];
-    cache.set(key, safeComments);
-    return [...safeComments];
+    if (!Array.isArray(comments)) return [];
+    cache.set(key, comments);
+    return [...comments];
+  };
+}
+
+export function createCachedIssueCommentsLookupAsync<T = JsonValue>(
+  fetchComments: (number: number) => Promise<T[]>,
+  cache = new Map<number, T[]>(),
+) {
+  const inFlight = new Map<number, Promise<T[]>>();
+  return async (number: JsonValue): Promise<T[]> => {
+    const key = Number(number);
+    if (!Number.isInteger(key) || key <= 0) return [];
+    const cached = cache.get(key);
+    if (cached) return [...cached];
+    const pending = inFlight.get(key);
+    if (pending) return [...(await pending)];
+    const next = fetchComments(key)
+      .then((comments) => {
+        if (!Array.isArray(comments)) return [];
+        cache.set(key, comments);
+        return comments;
+      })
+      .finally(() => {
+        inFlight.delete(key);
+      });
+    inFlight.set(key, next);
+    return [...(await next)];
   };
 }
 

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -116,6 +116,22 @@ export function createCachedLabelNumberLookup(fetchNumbers: (label: string) => J
   };
 }
 
+export function createCachedIssueCommentsLookup<T = JsonValue>(
+  fetchComments: (number: number) => T[],
+) {
+  const cache = new Map<number, T[]>();
+  return (number: JsonValue): T[] => {
+    const key = Number(number);
+    if (!Number.isInteger(key) || key <= 0) return [];
+    const cached = cache.get(key);
+    if (cached) return [...cached];
+    const comments = fetchComments(key);
+    const safeComments = Array.isArray(comments) ? comments : [];
+    cache.set(key, safeComments);
+    return [...safeComments];
+  };
+}
+
 function uniquePositiveIntegers(values: JsonValue): number[] {
   if (!Array.isArray(values)) return [];
   return [

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -33,6 +33,7 @@ import {
   automergeTransientWaitConfig,
   buildAutomergeMergeArgs,
   commandHasAction,
+  createCachedIssueCommentsLookup,
   createCachedLabelNumberLookup,
   hasCommandResponseMarker,
   commandStatusMarker,
@@ -77,7 +78,6 @@ import {
   ghJsonWithRetry as ghJson,
   ghJsonWithRetryAsync as ghJsonAsync,
   ghPagedWithRetry as ghPaged,
-  ghPagedWithRetryAsync as ghPagedAsync,
   ghSpawn,
   ghTextWithRetry as ghText,
 } from "./github-cli.js";
@@ -132,7 +132,9 @@ let repairLoopControlEntriesCache: LooseRecord[] | null = null;
 const collaboratorPermissionCache = new Map();
 const activeRepairRunsByPrefix = new Map<string, LooseRecord[]>();
 const liveTargetCache = new Map<number, LooseRecord>();
-const issueCommentsCache = new Map<number, JsonValue[]>();
+const cachedIssueComments = createCachedIssueCommentsLookup((number) =>
+  ghPaged<JsonValue>(`repos/${targetRepo}/issues/${number}/comments?per_page=100`),
+);
 const openIssueNumbersByLabel = createCachedLabelNumberLookup((label) =>
   ghPaged<JsonValue>(
     `repos/${targetRepo}/issues?state=open&labels=${encodeURIComponent(label)}&per_page=100`,
@@ -306,7 +308,7 @@ async function prehydrateCommandLookups(commands: LooseRecord[]) {
       liveTargetCache.set(number, await fetchLiveTargetAsync(number));
     }),
     mapLimit(issueNumbers, lookupConcurrency, async (number) => {
-      issueCommentsCache.set(number, await fetchIssueCommentsAsync(number));
+      cachedIssueComments(number);
     }),
   ]);
 }
@@ -2317,10 +2319,7 @@ function linesFromMarkdownSection(section: JsonValue): string[] {
 }
 
 function issueCommentsFor(number: JsonValue): JsonValue[] {
-  return (
-    issueCommentsCache.get(Number(number)) ??
-    ghPaged<JsonValue>(`repos/${targetRepo}/issues/${number}/comments?per_page=100`)
-  );
+  return cachedIssueComments(number);
 }
 
 function listRepairLoopReviewComments() {
@@ -2586,9 +2585,7 @@ function hasExistingResponse(
   intent: JsonValue,
   headSha: JsonValue,
 ) {
-  const comments =
-    issueCommentsCache.get(Number(number)) ??
-    ghPaged(`repos/${targetRepo}/issues/${number}/comments?per_page=100`);
+  const comments = cachedIssueComments(number);
   return comments.some((comment: JsonValue) => {
     const body = String(comment.body ?? "");
     if (!hasCommandResponseMarker(body, { commentId, intent, headSha, matchAnyHead: true })) {
@@ -2611,18 +2608,12 @@ function hasExistingResponse(
 
 function hasExistingModeStatusResponse(number: JsonValue, intent: JsonValue) {
   const markerPrefix = commandStatusMarkerPrefix({ issue_number: number, intent });
-  const comments =
-    issueCommentsCache.get(Number(number)) ??
-    ghPaged(`repos/${targetRepo}/issues/${number}/comments?per_page=100`);
+  const comments = cachedIssueComments(number);
   return comments.some((comment: JsonValue) => {
     if (!isTrustedStatusComment(comment)) return false;
     const body = String(comment.body ?? "");
     return body.includes(markerPrefix) && !body.includes("could not enable");
   });
-}
-
-async function fetchIssueCommentsAsync(number: JsonValue) {
-  return ghPagedAsync<JsonValue>(`repos/${targetRepo}/issues/${number}/comments?per_page=100`);
 }
 
 function postComment(command: LooseRecord, body: string) {

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -34,6 +34,7 @@ import {
   buildAutomergeMergeArgs,
   commandHasAction,
   createCachedIssueCommentsLookup,
+  createCachedIssueCommentsLookupAsync,
   createCachedLabelNumberLookup,
   hasCommandResponseMarker,
   commandStatusMarker,
@@ -78,6 +79,7 @@ import {
   ghJsonWithRetry as ghJson,
   ghJsonWithRetryAsync as ghJsonAsync,
   ghPagedWithRetry as ghPaged,
+  ghPagedWithRetryAsync as ghPagedAsync,
   ghSpawn,
   ghTextWithRetry as ghText,
 } from "./github-cli.js";
@@ -132,8 +134,14 @@ let repairLoopControlEntriesCache: LooseRecord[] | null = null;
 const collaboratorPermissionCache = new Map();
 const activeRepairRunsByPrefix = new Map<string, LooseRecord[]>();
 const liveTargetCache = new Map<number, LooseRecord>();
-const cachedIssueComments = createCachedIssueCommentsLookup((number) =>
-  ghPaged<JsonValue>(`repos/${targetRepo}/issues/${number}/comments?per_page=100`),
+const issueCommentsCache = new Map<number, JsonValue[]>();
+const cachedIssueComments = createCachedIssueCommentsLookup(
+  (number) => ghPaged<JsonValue>(`repos/${targetRepo}/issues/${number}/comments?per_page=100`),
+  issueCommentsCache,
+);
+const cachedIssueCommentsAsync = createCachedIssueCommentsLookupAsync(
+  (number) => ghPagedAsync<JsonValue>(`repos/${targetRepo}/issues/${number}/comments?per_page=100`),
+  issueCommentsCache,
 );
 const openIssueNumbersByLabel = createCachedLabelNumberLookup((label) =>
   ghPaged<JsonValue>(
@@ -308,7 +316,7 @@ async function prehydrateCommandLookups(commands: LooseRecord[]) {
       liveTargetCache.set(number, await fetchLiveTargetAsync(number));
     }),
     mapLimit(issueNumbers, lookupConcurrency, async (number) => {
-      cachedIssueComments(number);
+      await cachedIssueCommentsAsync(number);
     }),
   ]);
 }

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -19,6 +19,7 @@ import {
   buildAutomergeMergeArgs,
   commandHasAction,
   createCachedIssueCommentsLookup,
+  createCachedIssueCommentsLookupAsync,
   commandResponseMarker,
   commandResponseMarkerPrefix,
   commandStatusMarkerPrefix,
@@ -221,6 +222,52 @@ test("cached issue comments lookup fetches each issue once and returns stable co
   assert.deepEqual(lookup(13), [{ id: 130 }, { id: 131 }]);
   assert.deepEqual(lookup(0), []);
   assert.deepEqual(calls, [12, 13]);
+});
+
+test("cached async issue comments lookup shares cache and in-flight fetches", async () => {
+  const cache = new Map<number, { id: number }[]>();
+  const calls: number[] = [];
+  const asyncLookup = createCachedIssueCommentsLookupAsync(async (number) => {
+    calls.push(number);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    return [{ id: number * 10 }];
+  }, cache);
+  const syncLookup = createCachedIssueCommentsLookup((number) => {
+    calls.push(number);
+    return [{ id: number * 100 }];
+  }, cache);
+
+  const [first, second] = await Promise.all([asyncLookup(12), asyncLookup("12")]);
+  first.push({ id: 999 });
+
+  assert.deepEqual(first, [{ id: 120 }, { id: 999 }]);
+  assert.deepEqual(second, [{ id: 120 }]);
+  assert.deepEqual(syncLookup(12), [{ id: 120 }]);
+  assert.deepEqual(await asyncLookup(0), []);
+  assert.deepEqual(calls, [12]);
+});
+
+test("cached issue comments lookup does not cache malformed fetch results", async () => {
+  const cache = new Map<number, { id: number }[]>();
+  let syncCalls = 0;
+  const syncLookup = createCachedIssueCommentsLookup(() => {
+    syncCalls += 1;
+    return "bad" as never;
+  }, cache);
+
+  assert.deepEqual(syncLookup(12), []);
+  assert.deepEqual(syncLookup(12), []);
+  assert.equal(syncCalls, 2);
+
+  let asyncCalls = 0;
+  const asyncLookup = createCachedIssueCommentsLookupAsync(async () => {
+    asyncCalls += 1;
+    return "bad" as never;
+  }, cache);
+
+  assert.deepEqual(await asyncLookup(12), []);
+  assert.deepEqual(await asyncLookup(12), []);
+  assert.equal(asyncCalls, 2);
 });
 
 test("autoclose reason parser preserves maintainer wording", () => {

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -18,6 +18,7 @@ import {
   automergeTransientWaitConfig,
   buildAutomergeMergeArgs,
   commandHasAction,
+  createCachedIssueCommentsLookup,
   commandResponseMarker,
   commandResponseMarkerPrefix,
   commandStatusMarkerPrefix,
@@ -203,6 +204,23 @@ test("cached label number lookup fetches each label once and returns stable copi
   assert.deepEqual(lookup("clawsweeper:automerge"), [20]);
   assert.deepEqual(lookup("clawsweeper:autofix"), [10, 11]);
   assert.deepEqual(calls, ["clawsweeper:autofix", "clawsweeper:automerge"]);
+});
+
+test("cached issue comments lookup fetches each issue once and returns stable copies", () => {
+  const calls: number[] = [];
+  const lookup = createCachedIssueCommentsLookup((number) => {
+    calls.push(number);
+    return [{ id: number * 10 }, { id: number * 10 + 1 }];
+  });
+
+  const first = lookup(12);
+  first.push({ id: 999 });
+
+  assert.deepEqual(first, [{ id: 120 }, { id: 121 }, { id: 999 }]);
+  assert.deepEqual(lookup("12"), [{ id: 120 }, { id: 121 }]);
+  assert.deepEqual(lookup(13), [{ id: 130 }, { id: 131 }]);
+  assert.deepEqual(lookup(0), []);
+  assert.deepEqual(calls, [12, 13]);
 });
 
 test("autoclose reason parser preserves maintainer wording", () => {


### PR DESCRIPTION
## Summary
- add a reusable cached issue-comments lookup with copied return arrays
- route comment-router targeted discovery, prehydration, and replay/status checks through the same per-run cache
- avoid repeated identical issue comment pagination without changing command classification or mutation behavior

## Validation
- npx --yes -p node@24 -c 'node -v && pnpm run check'
