### PR TITLE
[Fix] Guard likely owner commit links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Ignored non-SHA likely-owner provenance values when rendering public commit
+  links, avoiding broken `/commit/...` URLs in review comments. Thanks @samzong.
 - Gave manual exact-item review dispatches their own concurrency group so
   targeted maintainer reviews no longer wait behind broad normal backfill runs.
 - Downgraded screenshot-only browser runtime proof so ClawSweeper no longer accepts "no visible console/CSP violation" screenshots as sufficient real behavior proof. Thanks @BunsDev.

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -3606,6 +3606,10 @@ function shortSha(sha: string): string {
   return sha.slice(0, 12);
 }
 
+function isCommitSha(value: string): boolean {
+  return /^[0-9a-f]{7,40}$/i.test(value.trim());
+}
+
 function releaseUrl(tag: string): string {
   return repoUrl(`/releases/tag/${encodeURIComponent(tag)}`);
 }
@@ -4095,7 +4099,8 @@ function likelyOwnerLine(owner: LikelyOwner): string {
   const role = owner.role.trim();
   const reason = sentence(owner.reason.trim() || "Related by repository history.");
   const commits = owner.commits
-    .filter(Boolean)
+    .map((commit) => commit.trim())
+    .filter(isCommitSha)
     .slice(0, 3)
     .map((commit) => linkedSha(commit))
     .join(", ");

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -626,6 +626,32 @@ test("close comments suppress duplicate best solution text", () => {
   assert.doesNotMatch(action.closeComment, /Best possible solution:/);
 });
 
+test("likely owner commit links ignore non-sha values", () => {
+  const action = reviewActionForDecision({
+    item: item(),
+    decision: closeDecision({
+      likelyOwners: [
+        {
+          person: "@alice",
+          role: "feature contributor",
+          reason: "The changelog credits a pull request for this feature surface.",
+          commits: ["https://github.com/openclaw/openclaw/pull/76079", " abcdef1234567890 "],
+          files: ["CHANGELOG.md"],
+          confidence: "medium",
+        },
+      ],
+    }),
+    git,
+  });
+
+  assert.equal(action.actionTaken, "proposed_close");
+  assert.doesNotMatch(action.closeComment, /\/commit\/https:/);
+  assert.match(
+    action.closeComment,
+    /\[abcdef123456\]\(https:\/\/github\.com\/openclaw\/openclaw\/commit\/abcdef1234567890\)/,
+  );
+});
+
 test("skill-only OpenClaw PRs can close through ClawHub with upload guidance", () => {
   const decision = closeDecision({
     closeReason: "clawhub",


### PR DESCRIPTION
### What's changed?

- Trim likely owner commit entries before rendering them.
- Render only SHA-like values as commit links in `Likely related people`.
- Add unit coverage for mixed provenance where a PR URL is present alongside a valid commit SHA.

### Why

ClawSweeper public comments can receive non-SHA provenance strings in `likelyOwners[].commits`. Before this change, those values were passed directly to the commit-link renderer, producing invalid GitHub commit URLs in visible comments.

Evidence from existing public ClawSweeper comments:

- https://github.com/openclaw/openclaw/issues/78671#issuecomment-4393034158 rendered a PR URL as `/commit/https://github.com/openclaw/openclaw/pull/76079`.
- https://github.com/openclaw/openclaw/issues/72080#issuecomment-4345196944 rendered `#23580` as `/commit/#23580`.
- https://github.com/openclaw/openclaw/issues/77514#issuecomment-4374218024 rendered `#73046` and `#727` as commit links.
- https://github.com/openclaw/openclaw/pull/71158#issuecomment-4340797017 rendered `PR #67960` as `/commit/PR #67960`.
- https://github.com/openclaw/openclaw/issues/75176#issuecomment-4354588642 rendered several `PR #...` entries as commit links.
- https://github.com/openclaw/openclaw/issues/68033#issuecomment-4353976939 rendered `PR #64713`, `PR #67642`, and `PR #67704` as commit links.

### Validation

- `pnpm run check`
- `/pre-ship --committed`: 0 MUST-FIX findings, no deferred findings
