### PR TITLE
docs(repair): clarify Node 22 notifier test cancelledByParent is environmental

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,11 @@ pnpm run check
 
 Use `pnpm run check` before handoff for code/test/workflow changes.
 
+`engines.node` is `>=24`. Node 22 will install (no `engine-strict`) but the
+notifier tests' 5-second retry paths surface as `cancelledByParent` under the
+old `node:test` runner. Run on Node 24 or newer before reporting test
+failures.
+
 ## GitHub Checks
 
 Useful live probes:


### PR DESCRIPTION
## Summary
PR#53's body noted that two notifier tests fail with `cancelledByParent` under Node 22. The repo's `engines.node` is `>=24`, so Node 22 is unsupported, but `engine-strict` is not enforced — `pnpm install` succeeds with only a warning, then the failure surfaces at test time and looks like a regression. This PR documents that the failure is environmental, so the next contributor doesn't lose time chasing a phantom bug.

## Reproduction
- Node version checked: v24.14.0 and v25.6.1 (both `>=24`, both supported)
- Tests examined:
  - `test/repair/notify-events.test.ts` (5 tests, includes a 5s retry-path case)
  - `test/repair/notify-merge.test.ts` (9 tests)
  - `test/repair/notify-github-activity.test.ts` (8 tests, includes a 5s retry-path case)
- Result: all 22 notifier tests pass cleanly on Node 24 and 25 — `0 cancelled`, `0 failed`. Full `pnpm run test:repair` is also green at 242/242.

The two long-running tests (`runClawSweeperEventNotifier covers skip, config, dry-run, and strict failure paths` and `runGithubActivityNotifier covers skip, dry-run, deliver, and failure paths`) exercise retry+backoff paths that take ~5s end-to-end. The older `node:test` runner in Node 22 has known timing quirks for tests of this shape, which is what surfaced as `cancelledByParent` in PR#53's local run. On Node 24+ the runner handles them correctly.

## What changed
- `AGENTS.md`: added a one-paragraph note to the Commands section pointing out that Node 22 will install (no `engine-strict`) but trips the notifier tests' retry paths under the old `node:test` runner.

No source or test code is touched — verification confirmed there is no Node 24 bug to fix.

## Validation
- `node --test test/repair/notify-events.test.ts test/repair/notify-merge.test.ts test/repair/notify-github-activity.test.ts` on Node 24.14.0 and 25.6.1 → 22/22 pass, 0 cancelled
- `pnpm run test:repair` → 242/242 pass, 0 cancelled
- `pnpm run format:check` → clean

## Scope discipline
Touches only `AGENTS.md`. Does NOT modify `src/clawsweeper.ts`, `src/repair/comment-router*` (PR#50), `src/repair/github-cli.ts` / `plan-cluster.ts` (PR#49), or `src/policy-rfc/**`. No conflict with in-flight PRs.