### PR TITLE
fix(review): suppress changelog-only PR findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ checkpoint, and status-only commits are intentionally omitted.
 - Ignored non-SHA likely-owner provenance values when rendering public commit
   links, avoiding broken `/commit/...` URLs in review comments. Thanks @samzong.
 - Kept missing changelog entries as maintainer-owned ClawSweeper repair work instead of asking PR authors to add them. Thanks @obviyus.
+- Suppressed changelog-only OpenClaw PR review findings after model output so
+  contributor PRs do not get needs-changes or fix-required markers solely for
+  maintainer-owned release notes. Thanks @rubencu.
 - Gave manual exact-item review dispatches their own concurrency group so
   targeted maintainer reviews no longer wait behind broad normal backfill runs.
 - Downgraded screenshot-only browser runtime proof so ClawSweeper no longer accepts "no visible console/CSP violation" screenshots as sufficient real behavior proof. Thanks @BunsDev.

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -234,10 +234,10 @@ Keep open any item with a protected label: `security`, `beta-blocker`, `release-
 For OpenClaw PR changelog review, repo policy requires user-facing `fix`,
 `feat`, and `perf` changes to have a `CHANGELOG.md` entry, but forbidden bot or
 maintainer handles must not be forced into a `Thanks @...` line. Do not create a
-review finding, contributor action, or public author request for a missing
-changelog entry. Changelog entries are maintainer-owned: use `workPrompt` or the
-automerge repair lane to tell ClawSweeper to add or repair the entry. Do not ask
-the PR author to add one. Also do not create a review finding merely because a
+review finding, needs-changes verdict, contributor action, public author request,
+or next-step blocker solely because a contributor PR lacks a changelog entry.
+Changelog entries are maintainer-owned landing/release work; do not ask the PR
+author to add one. Also do not create a review finding merely because a
 changelog entry lacks `Thanks @steipete`, `Thanks @openclaw`, or `Thanks
 @codex`; if those are the only known source authors, preserving credit in PR
 history/source links is sufficient.

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -652,7 +652,7 @@ const RECENT_MISSING_OPEN_MS = DAY_MS;
 const DEFAULT_CODEX_MODEL = "gpt-5.5";
 const DEFAULT_REASONING_EFFORT = "high";
 const DEFAULT_SERVICE_TIER = "";
-const REVIEW_POLICY_VERSION = "2026-05-05-policy-v14";
+const REVIEW_POLICY_VERSION = "2026-05-09-policy-v15";
 const REVIEW_ITEM_PROMPT_PATH = join(ROOT, "prompts", "review-item.md");
 const CLAWSWEEPER_DECISION_SCHEMA_PATH = join(ROOT, "schema", "clawsweeper-decision.schema.json");
 const REVIEW_COMMENT_MARKER_PREFIX = "<!-- clawsweeper-review";
@@ -1248,6 +1248,68 @@ function parseReviewFinding(value: unknown, path: string): ReviewFinding {
   };
 }
 
+type DecisionNormalizationItem = Pick<Item, "repo" | "kind" | "authorAssociation">;
+
+const CHANGELOG_ENTRY_REVIEW_PATTERN = /\b(?:changelog\.md|changelog\s+entry|release[- ]?note)\b/i;
+const MISSING_CHANGELOG_ACTION_PATTERN =
+  /\b(?:add|include|missing|no|lacks?|needs?|requires?|required|without)\b/i;
+const CHANGELOG_TOOLING_PATTERN =
+  /\b(?:coverage|duplicate|generator|malformed|parser|validation|validator|wrong\s+section)\b/i;
+
+function isOpenClawContributorPullRequest(item: DecisionNormalizationItem | undefined): boolean {
+  return (
+    item !== undefined &&
+    normalizeRepo(item.repo) === DEFAULT_TARGET_REPO &&
+    item.kind === "pull_request" &&
+    !isMaintainerAuthorAssociation(item.authorAssociation)
+  );
+}
+
+function isContributorChangelogEntryFinding(
+  item: DecisionNormalizationItem | undefined,
+  finding: ReviewFinding,
+): boolean {
+  const text = `${finding.title}\n${finding.body}`;
+  return (
+    isOpenClawContributorPullRequest(item) &&
+    CHANGELOG_ENTRY_REVIEW_PATTERN.test(text) &&
+    MISSING_CHANGELOG_ACTION_PATTERN.test(text) &&
+    !CHANGELOG_TOOLING_PATTERN.test(text)
+  );
+}
+
+const CLEAN_OPENCLAW_PR_REVIEW_NEXT_STEP =
+  "Continue normal maintainer review; ClawSweeper found no patch-correctness issue.";
+
+function normalizeDecisionForItem(
+  decision: Decision,
+  item: DecisionNormalizationItem | undefined,
+): Decision {
+  const reviewFindings = decision.reviewFindings.filter(
+    (finding) => !isContributorChangelogEntryFinding(item, finding),
+  );
+  if (reviewFindings.length === decision.reviewFindings.length) return decision;
+  if (reviewFindings.length > 0) return { ...decision, reviewFindings };
+
+  return {
+    ...decision,
+    reviewFindings,
+    bestSolution: CLEAN_OPENCLAW_PR_REVIEW_NEXT_STEP,
+    overallCorrectness:
+      decision.overallCorrectness === "patch is incorrect"
+        ? "patch is correct"
+        : decision.overallCorrectness,
+    workCandidate: "none",
+    workConfidence: "low",
+    workPriority: "low",
+    workReason: "",
+    workPrompt: "",
+    workClusterRefs: [],
+    workValidation: [],
+    workLikelyFiles: [],
+  };
+}
+
 function parseSecurityConcern(value: unknown, path: string): SecurityConcern {
   const record = requireRecord(value, path);
   rejectUnexpectedKeys(record, SECURITY_CONCERN_SCHEMA_KEYS, path);
@@ -1303,7 +1365,7 @@ function requireEnum<T extends string>(value: unknown, allowed: Set<T>, path: st
   throw new Error(`${path} has invalid value`);
 }
 
-export function parseDecision(value: unknown): Decision {
+export function parseDecision(value: unknown, item?: DecisionNormalizationItem): Decision {
   const record = requireRecord(value, "decision");
   rejectUnexpectedKeys(record, DECISION_SCHEMA_KEYS, "decision");
   const evidence = Array.isArray(record.evidence)
@@ -1326,7 +1388,7 @@ export function parseDecision(value: unknown): Decision {
     : (() => {
         throw new Error("decision.reviewFindings must be an array");
       })();
-  return {
+  const decision: Decision = {
     decision: requireEnum(record.decision, DECISIONS, "decision.decision"),
     closeReason: requireEnum(record.closeReason, ALL_REASONS, "decision.closeReason"),
     confidence: requireEnum(record.confidence, CONFIDENCES, "decision.confidence"),
@@ -1391,6 +1453,7 @@ export function parseDecision(value: unknown): Decision {
     workValidation: requireStringArray(record.workValidation, "decision.workValidation"),
     workLikelyFiles: requireStringArray(record.workLikelyFiles, "decision.workLikelyFiles"),
   };
+  return normalizeDecisionForItem(decision, item);
 }
 
 function login(value: unknown): string | undefined {
@@ -3744,7 +3807,7 @@ function runCodex(options: {
     );
   }
   try {
-    return parseDecision(JSON.parse(readFileSync(outputPath, "utf8").trim()));
+    return parseDecision(JSON.parse(readFileSync(outputPath, "utf8").trim()), options.item);
   } catch (error) {
     const decision = codexFailureDecision(
       result.status,

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -184,6 +184,37 @@ function closeDecision(overrides = {}) {
   };
 }
 
+function reviewFinding(overrides = {}) {
+  return {
+    title: "Missing changelog entry",
+    body: "This user-facing fix needs a CHANGELOG.md entry.",
+    priority: 3,
+    confidenceScore: 0.9,
+    file: "src/runtime.ts",
+    lineStart: 12,
+    lineEnd: 12,
+    ...overrides,
+  };
+}
+
+function changelogReviewDecision(overrides = {}) {
+  return closeDecision({
+    decision: "keep_open",
+    closeReason: "none",
+    confidence: "high",
+    bestSolution: "Add the required changelog entry before merge.",
+    reviewFindings: [reviewFinding({ title: "Add the required changelog entry" })],
+    overallCorrectness: "patch is incorrect",
+    workCandidate: "queue_fix_pr",
+    workConfidence: "high",
+    workPriority: "medium",
+    workReason: "Add the required changelog entry.",
+    workPrompt: "Add a CHANGELOG.md entry.",
+    workLikelyFiles: ["CHANGELOG.md"],
+    ...overrides,
+  });
+}
+
 test("githubPaginatedPath requests maximum REST page size by default", () => {
   assert.equal(
     githubPaginatedPath("repos/openclaw/openclaw/issues/123/comments"),
@@ -2174,6 +2205,91 @@ Full review comments:
   assert.doesNotMatch(markers, /clawsweeper-verdict:needs-changes/);
 });
 
+test("OpenClaw contributor changelog-entry findings are normalized", () => {
+  const decision = parseDecision(
+    changelogReviewDecision(),
+    item({ repo: "openclaw/openclaw", kind: "pull_request" }),
+  );
+
+  assert.deepEqual(decision.reviewFindings, []);
+  assert.equal(decision.overallCorrectness, "patch is correct");
+  assert.equal(decision.workCandidate, "none");
+  assert.equal(decision.workReason, "");
+});
+
+test("OpenClaw maintainer changelog-entry findings stay actionable", () => {
+  const decision = parseDecision(
+    changelogReviewDecision(),
+    item({ repo: "openclaw/openclaw", kind: "pull_request", authorAssociation: "MEMBER" }),
+  );
+
+  assert.deepEqual(
+    decision.reviewFindings.map((finding) => finding.title),
+    ["Add the required changelog entry"],
+  );
+  assert.equal(decision.overallCorrectness, "patch is incorrect");
+  assert.equal(decision.workCandidate, "queue_fix_pr");
+});
+
+test("OpenClaw changelog normalization keeps real findings actionable", () => {
+  const decision = parseDecision(
+    changelogReviewDecision({
+      reviewFindings: [
+        reviewFinding({ file: "CHANGELOG.md" }),
+        reviewFinding({
+          title: "Preserve the existing option value",
+          body: "The patch resets configured values when the dialog is reopened.",
+          priority: 1,
+          confidenceScore: 0.89,
+          file: "src/options.ts",
+          lineStart: 42,
+          lineEnd: 42,
+        }),
+      ],
+      workReason: "Fix the option reset bug.",
+      workPrompt: "Fix src/options.ts and add a regression test.",
+      workLikelyFiles: ["src/options.ts"],
+    }),
+    item({ repo: "openclaw/openclaw", kind: "pull_request" }),
+  );
+
+  assert.deepEqual(
+    decision.reviewFindings.map((finding) => finding.title),
+    ["Preserve the existing option value"],
+  );
+  assert.equal(decision.overallCorrectness, "patch is incorrect");
+  assert.equal(decision.workCandidate, "queue_fix_pr");
+});
+
+test("OpenClaw changelog normalization keeps changelog tooling findings actionable", () => {
+  const decision = parseDecision(
+    changelogReviewDecision({
+      reviewFindings: [
+        reviewFinding({
+          title: "Missing CHANGELOG.md entry validation",
+          body: "The parser accepts malformed changelog entries.",
+          priority: 2,
+          confidenceScore: 0.82,
+          file: "src/clawsweeper.ts",
+          lineStart: 42,
+          lineEnd: 42,
+        }),
+      ],
+      workReason: "Add changelog parser coverage.",
+      workPrompt: "Add parser coverage.",
+      workLikelyFiles: ["test/clawsweeper.test.ts"],
+    }),
+    item({ repo: "openclaw/openclaw", kind: "pull_request" }),
+  );
+
+  assert.deepEqual(
+    decision.reviewFindings.map((finding) => finding.title),
+    ["Missing CHANGELOG.md entry validation"],
+  );
+  assert.equal(decision.overallCorrectness, "patch is incorrect");
+  assert.equal(decision.workCandidate, "queue_fix_pr");
+});
+
 test("pull request automerge pass is not blocked by generic protected labels", () => {
   const comment = renderReviewCommentFromReport(
     `${reportFrontMatter({
@@ -3025,8 +3141,9 @@ test("review prompt keeps automerge opt-in from becoming generic manual review",
   assert.match(prompt, /large `size:\*` label/);
   assert.match(prompt, /choose `queue_fix_pr` even when the\s+finding is process-only or P3/);
   assert.match(prompt, /Changelog entries are maintainer-owned/);
-  assert.match(prompt, /Do not ask\s+the PR author to add one/);
-  assert.doesNotMatch(prompt, /Examples include a missing required changelog\s+entry/);
+  assert.match(prompt, /do not create a\s+review finding,\s+needs-changes\s+verdict/i);
+  assert.match(prompt, /do not ask the PR\s+author to add one/);
+  assert.doesNotMatch(prompt, /missing required changelog\s+entry/);
   assert.match(prompt, /does not by itself block a clean automerge verdict/);
 });
 


### PR DESCRIPTION
## Summary

- Stop ordinary OpenClaw PR review from treating a missing `CHANGELOG.md` entry as a contributor-facing review finding.
- Normalize model decisions for OpenClaw PRs before report rendering so changelog-only findings cannot produce review findings, repair work plans, or fix-required markers.
- Keep maintainer-owned landing/automerge changelog handling separate from patch-correctness review.

## Context

ClawSweeper flagged openclaw/openclaw#77533 with a P3 changelog finding, but contributors are not expected to add changelog entries. This keeps the review verdict focused on code/test/docs correctness, proof, security, checks, and mergeability while preserving the existing maintainer-side changelog gate.

## Validation

- `pnpm run check`
- `git diff --check`
