### PR TITLE
fix(review): render deterministic close comments

### DIFF
--- a/.github/workflows/commit-review.yml
+++ b/.github/workflows/commit-review.yml
@@ -169,12 +169,31 @@ jobs:
               || printf '0'
           }
           active_sweep_background_workers() {
-            local normal_limit hot_limit
-            normal_limit="$(pnpm --dir clawsweeper run --silent workflow -- limit review_shards.normal_default)"
-            hot_limit="$(pnpm --dir clawsweeper run --silent workflow -- limit review_shards.hot_intake_default)"
-            gh run list --repo "${{ github.repository }}" --limit 100 --json workflowName,displayTitle,status 2>/dev/null \
-              | NORMAL_LIMIT="$normal_limit" HOT_LIMIT="$hot_limit" jq '[.[] | select(.workflowName == "ClawSweeper") | select(.status == "in_progress" or .status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") | if .displayTitle == "Review ClawSweeper items" then (env.NORMAL_LIMIT | tonumber) elif .displayTitle == "Review hot ClawSweeper items" then (env.HOT_LIMIT | tonumber) else 0 end] | add // 0' 2>/dev/null \
-              || printf '0'
+            local runs total id title status active_shards
+            total=0
+            runs="$(gh run list --repo "${{ github.repository }}" --limit 100 --json databaseId,workflowName,displayTitle,status 2>/dev/null \
+              | jq -r '.[] | select(.workflowName == "ClawSweeper") | select(.status == "in_progress" or .status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") | select(.displayTitle == "Review ClawSweeper items" or .displayTitle == "Review hot ClawSweeper items") | [.databaseId, .displayTitle, .status] | @tsv' 2>/dev/null || true)"
+            while IFS=$'\t' read -r id title status; do
+              if [ -z "$id" ]; then
+                continue
+              fi
+              active_shards=0
+              if [ "$status" = "in_progress" ]; then
+                active_shards="$(gh run view "$id" --repo "${{ github.repository }}" --json jobs 2>/dev/null \
+                  | jq '[.jobs[]? | select(.name | startswith("Review shard ")) | select(.status == "in_progress" or .status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested")] | length' 2>/dev/null \
+                  || printf '0')"
+              fi
+              if ! [[ "$active_shards" =~ ^[0-9]+$ ]]; then
+                active_shards=0
+              fi
+              # Planning, publish, queued, and not-yet-expanded matrix runs still occupy
+              # scheduler attention, but they should not reserve a whole 35-70 shard lane.
+              if [ "$active_shards" -lt 1 ]; then
+                active_shards=1
+              fi
+              total=$((total + active_shards))
+            done <<< "$runs"
+            printf '%s' "$total"
           }
           active_sweep_exact_count() {
             gh run list --repo "${{ github.repository }}" --limit 100 --json workflowName,displayTitle,status 2>/dev/null \

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1561,7 +1561,7 @@ jobs:
           min_age_minutes="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_min_age_minutes || '' }}"
           apply_kind="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_kind || 'all' }}"
           apply_close_reasons="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_close_reasons || 'all' }}"
-          stale_min_age_days="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_stale_min_age_days || '30' }}"
+          stale_min_age_days="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_stale_min_age_days || '60' }}"
           close_delay_ms="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_close_delay_ms || '2000' }}"
           progress_every="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_progress_every || '10' }}"
           checkpoint_size="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_checkpoint_size || '50' }}"

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -618,12 +618,31 @@ jobs:
               || printf '0'
           }
           active_sweep_background_workers() {
-            local normal_limit hot_limit
-            normal_limit="$(limit review_shards.normal_default)"
-            hot_limit="$(limit review_shards.hot_intake_default)"
-            gh run list --repo "${{ github.repository }}" --limit 100 --json databaseId,workflowName,displayTitle,status 2>/dev/null \
-              | CURRENT_RUN_ID="${GITHUB_RUN_ID:-0}" NORMAL_LIMIT="$normal_limit" HOT_LIMIT="$hot_limit" jq '[.[] | select((.databaseId | tostring) != env.CURRENT_RUN_ID) | select(.workflowName == "ClawSweeper") | select(.status == "in_progress" or .status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") | if .displayTitle == "Review ClawSweeper items" then (env.NORMAL_LIMIT | tonumber) elif .displayTitle == "Review hot ClawSweeper items" then (env.HOT_LIMIT | tonumber) else 0 end] | add // 0' 2>/dev/null \
-              || printf '0'
+            local runs total id title status active_shards
+            total=0
+            runs="$(gh run list --repo "${{ github.repository }}" --limit 100 --json databaseId,workflowName,displayTitle,status 2>/dev/null \
+              | CURRENT_RUN_ID="${GITHUB_RUN_ID:-0}" jq -r '.[] | select((.databaseId | tostring) != env.CURRENT_RUN_ID) | select(.workflowName == "ClawSweeper") | select(.status == "in_progress" or .status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") | select(.displayTitle == "Review ClawSweeper items" or .displayTitle == "Review hot ClawSweeper items") | [.databaseId, .displayTitle, .status] | @tsv' 2>/dev/null || true)"
+            while IFS=$'\t' read -r id title status; do
+              if [ -z "$id" ]; then
+                continue
+              fi
+              active_shards=0
+              if [ "$status" = "in_progress" ]; then
+                active_shards="$(gh run view "$id" --repo "${{ github.repository }}" --json jobs 2>/dev/null \
+                  | jq '[.jobs[]? | select(.name | startswith("Review shard ")) | select(.status == "in_progress" or .status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested")] | length' 2>/dev/null \
+                  || printf '0')"
+              fi
+              if ! [[ "$active_shards" =~ ^[0-9]+$ ]]; then
+                active_shards=0
+              fi
+              # Planning, publish, queued, and not-yet-expanded matrix runs still occupy
+              # scheduler attention, but they should not reserve a whole 35-70 shard lane.
+              if [ "$active_shards" -lt 1 ]; then
+                active_shards=1
+              fi
+              total=$((total + active_shards))
+            done <<< "$runs"
+            printf '%s' "$total"
           }
           exact_item_shards="$(limit review_shards.exact_item_default)"
           normal_active_floor="$(limit review_shards.normal_active_floor)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Rendered deterministic close comments during review even when the model omits
+  `closeComment`, while keeping apply strict about requiring a stored usable
+  close comment before mutating GitHub.
 - Counted live normal and hot review capacity from active `Review shard` jobs
   instead of reserving an entire 35-70 shard lane for every planning or
   publishing background run, so saturated backlog runs keep using available

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Counted live normal and hot review capacity from active `Review shard` jobs
+  instead of reserving an entire 35-70 shard lane for every planning or
+  publishing background run, so saturated backlog runs keep using available
+  Codex capacity.
 - Ignored non-SHA likely-owner provenance values when rendering public commit
   links, avoiding broken `/commit/...` URLs in review comments. Thanks @samzong.
 - Kept missing changelog entries as maintainer-owned ClawSweeper repair work instead of asking PR authors to add them. Thanks @obviyus.

--- a/README.md
+++ b/README.md
@@ -56,10 +56,14 @@ commenting or closing anything. Closed or already-closed reports move to
 `records/<repo-slug>/closed/<number>.md`; reopened archived items move back to
 `items/` as stale work.
 
-Generated state lives in `openclaw/clawsweeper-state`: durable `records/`,
-`jobs/`, `results/`, audit output, workflow status JSON, repair ledgers, and the
-rendered dashboard. This repository stays focused on source, workflows, docs,
-and tests.
+Generated state lives on the `state` branch of `openclaw/clawsweeper-state`:
+durable `records/`, `jobs/`, `results/`, audit output, workflow status JSON,
+repair ledgers, and the rendered dashboard. The state repo `main` branch is the
+dashboard renderer source, so a checkout on `main` intentionally does not show
+`records/`. Hydrate this repo with `git -C ../clawsweeper-state switch state &&
+node scripts/hydrate-state.ts --state-dir ../clawsweeper-state` when local
+commands need generated records. This repository stays focused on source,
+workflows, docs, and tests.
 
 ### Repair and Automerge
 
@@ -271,7 +275,7 @@ separate publish job. They still use the same review and apply code paths, but
 only for the selected item number and only with immediate-safe reasons enabled
 by default: `implemented_on_main` and `duplicate_or_superseded`.
 `stale_insufficient_info` is never applied to young items; apply requires those
-issue reports to be at least 30 days old unless a manual run explicitly changes
+issue reports to be at least 60 days old unless a manual run explicitly changes
 the threshold.
 
 The external state dashboard is fleet-scoped. Each configured repository gets

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -40,6 +40,12 @@ Important source files:
 - `records/<repo-slug>/items/<number>.md`: open item reports
 - `records/<repo-slug>/closed/<number>.md`: archived closed reports
 
+Generated state is published to the `state` branch of
+`openclaw/clawsweeper-state`. Its `main` branch contains dashboard renderer
+source only. For local record inspection, switch that checkout to `state` or run
+`scripts/hydrate-state.ts` from a `state`-branch checkout before using
+`records/`.
+
 The workflow has one concurrency group per lane and target repository. Scheduled
 normal review cannot overlap another normal review for the same target repo.
 GitHub may keep one pending run for a concurrency group; newer scheduled runs

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -211,10 +211,12 @@ normal reviews keep the larger default batch size for targeted catch-up runs.
 
 The quiet-system ceiling is not a promise that every scheduled run dispatches
 that many shards. The `mode` step checks active repair workers, exact-item sweep
-runs, and commit-review pages, then asks `worker-limit normal_review` or
-`worker-limit hot_intake` for the current allowance. If repair/automerge is
-busy, background sweep dispatches fewer shards and leaves capacity for the
-specific work that is closest to a merge or maintainer request.
+runs, commit-review pages, and live normal/hot review shard jobs, then asks
+`worker-limit normal_review` or `worker-limit hot_intake` for the current
+allowance. Planning, publish, queued, and not-yet-expanded background runs
+reserve one worker slot instead of a whole quiet-system lane. If
+repair/automerge is busy, background sweep dispatches fewer shards and leaves
+capacity for the specific work that is closest to a merge or maintainer request.
 
 The active floor is not a separate lane and does not change close/apply safety.
 It only changes normal planning when due backlog is below the desired floor:
@@ -335,9 +337,10 @@ The live scheduler estimate happens before planning and is intentionally coarse:
 it counts active repair-cluster workflow runs as priority work, active exact-item
 sweep runs as priority work, active commit-review workflow runs as background
 work weighted by the configured commit page size, and other active normal/hot
-sweep runs as background work weighted by their quiet-system ceilings. GitHub
-Actions can start or finish jobs after that estimate, so the scheduler is a
-throttle, not a distributed lock.
+sweep runs by their live active `Review shard` jobs. Runs that are only
+planning, publishing, queued, or waiting for matrix expansion count as one
+background worker. GitHub Actions can start or finish jobs after that estimate,
+so the scheduler is a throttle, not a distributed lock.
 
 Planning status intentionally does not run `pnpm run reconcile`. Reconciliation
 can scan many live GitHub pages and has delayed review shard startup. The

--- a/docs/target-dispatcher.md
+++ b/docs/target-dispatcher.md
@@ -164,7 +164,7 @@ The receiver keeps the review lane proposal-only, then runs exact apply for the
 selected item with only immediate-safe close reasons enabled:
 `implemented_on_main` and `duplicate_or_superseded`. Normal scheduled apply
 still handles the broader backlog, with `stale_insufficient_info` blocked until
-the item is at least 30 days old.
+the item is at least 60 days old.
 
 `openclaw/clawhub` dispatches are intentionally skipped while the receiver
 variable `CLAWSWEEPER_ENABLE_CLAWHUB` is not `1`. Enable it only after the

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -142,6 +142,24 @@ Close only when the evidence is strong and the repository policy allows it. Allo
 
 For `openclaw/clawhub`, review every issue and PR with the same depth, but only close PRs where current `main` definitely implements the PR’s intended change. For ClawHub, use `implemented_on_main` only for those PRs, and keep all issues plus all other PR outcomes open.
 
+Do a canonical-search pass before keeping an older issue open only because a
+small part might remain. Start with the provided `relatedItems`, then search
+GitHub and local reports for the central user problem, not just exact title
+words. Useful checks include `gh issue list --repo <repo> --state all --search
+"<key terms>"`, `gh pr list --repo <repo> --state all --search "<key terms>"`,
+`gh search issues "<key terms> repo:<owner/repo>"`, and local report title terms
+from the prompt context. Follow synonyms, old product names, and linked PRs. If
+one canonical issue or PR now owns the remaining work, close this item as
+`duplicate_or_superseded` and link that canonical item. If current `main` solves
+the central user problem and only minor unconfirmed leftovers remain, prefer
+`implemented_on_main` with fix provenance, or `duplicate_or_superseded` when a
+narrower follow-up tracks the leftovers. If the item is older than 60 days,
+partially addressed, and the only remaining blocker is missing reporter data to
+verify whether anything still fails on current `main`, `stale_insufficient_info`
+is acceptable for issues. Do not use stale age to close a clearly described
+remaining feature, config surface, security hardening task, or product decision;
+keep those open or route them to the canonical item.
+
 Close as implemented when current `main` solves the observable user problem well enough, even if it did not use the exact workflow, file split, or field names proposed in the item. For broad umbrella requests, weigh the title and central user problem first. If current `main` solves the central problem and any leftovers are already tracked by a narrower related item, close as `duplicate_or_superseded` or `implemented_on_main` as appropriate and link the canonical follow-up. Keep open when a meaningful requested capability remains missing and no narrower canonical follow-up exists.
 
 Keep open for everything else, including real bugs, unclear-but-salvageable reports, stale PRs that might still contain useful work, optional features that require a new core/plugin API first, or anything where the evidence is not high-confidence.

--- a/scripts/hydrate-state.ts
+++ b/scripts/hydrate-state.ts
@@ -21,6 +21,16 @@ const stateRoot = path.resolve(
 );
 const worktreeRoot = path.resolve(args.worktree ?? process.cwd());
 
+if (!existsSync(stateRoot)) {
+  throw new Error(`State directory does not exist: ${stateRoot}`);
+}
+
+if (!GENERATED_PATHS.some((relativePath) => existsSync(path.join(stateRoot, relativePath)))) {
+  throw new Error(
+    `State directory has no generated paths: ${stateRoot}. Check out the generated state branch first, for example: git -C ${stateRoot} switch state`,
+  );
+}
+
 for (const relativePath of GENERATED_PATHS) {
   const source = path.join(stateRoot, relativePath);
   const destination = path.join(worktreeRoot, relativePath);

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -646,13 +646,13 @@ const RECENT_ISSUE_DAYS = 30;
 const HOURLY_REVIEW_MS = 60 * 60 * 1000;
 const DAILY_REVIEW_DAYS = 1;
 const WEEKLY_REVIEW_DAYS = 7;
-const STALE_INSUFFICIENT_INFO_MIN_AGE_DAYS = 30;
+const STALE_INSUFFICIENT_INFO_MIN_AGE_DAYS = 60;
 const DAY_MS = 24 * 60 * 60 * 1000;
 const RECENT_MISSING_OPEN_MS = DAY_MS;
 const DEFAULT_CODEX_MODEL = "gpt-5.5";
 const DEFAULT_REASONING_EFFORT = "high";
 const DEFAULT_SERVICE_TIER = "";
-const REVIEW_POLICY_VERSION = "2026-05-09-policy-v15";
+const REVIEW_POLICY_VERSION = "2026-05-09-policy-v16";
 const REVIEW_ITEM_PROMPT_PATH = join(ROOT, "prompts", "review-item.md");
 const CLAWSWEEPER_DECISION_SCHEMA_PATH = join(ROOT, "schema", "clawsweeper-decision.schema.json");
 const REVIEW_COMMENT_MARKER_PREFIX = "<!-- clawsweeper-review";
@@ -5527,7 +5527,9 @@ function canClose(decision: Decision): boolean {
 export function validateCloseDecision(
   item: Pick<Item, "kind" | "labels"> & Partial<Pick<Item, "repo">>,
   decision: Decision,
+  options: { requireCloseComment?: boolean } = {},
 ): { ok: true } | { ok: false; actionTaken: ActionTaken; reason: string } {
+  const requireCloseComment = options.requireCloseComment !== false;
   const profile = repositoryProfileFor(item.repo ?? targetRepo());
   if (decision.decision !== "close") {
     return {
@@ -5567,7 +5569,7 @@ export function validateCloseDecision(
   if (!decision.summary.trim()) {
     return { ok: false, actionTaken: "skipped_invalid_decision", reason: "missing summary" };
   }
-  if (!hasUsableCloseComment(decision.closeComment)) {
+  if (requireCloseComment && !hasUsableCloseComment(decision.closeComment)) {
     return {
       ok: false,
       actionTaken: "skipped_invalid_decision",
@@ -6019,9 +6021,14 @@ export function reviewActionForDecision(options: {
   if (isMaintainerAuthored(options.item)) {
     return { actionTaken: "skipped_maintainer_authored", closeComment: "" };
   }
-  const validation = validateCloseDecision(options.item, options.decision);
+  const validation = validateCloseDecision(options.item, options.decision, {
+    requireCloseComment: false,
+  });
   if (!validation.ok) return { actionTaken: validation.actionTaken, closeComment: "" };
   const closeComment = normalizeComment(options.decision, options.git, options.runtime);
+  if (!hasUsableCloseComment(closeComment)) {
+    return { actionTaken: "skipped_invalid_decision", closeComment: "" };
+  }
   return { actionTaken: "proposed_close", closeComment };
 }
 

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -308,7 +308,7 @@ function proposedItemOptions(): ProposedItemOptions {
     targetRepo: requiredString("target-repo"),
     applyKind: optionalString("apply-kind") || "all",
     applyCloseReasons: optionalString("apply-close-reasons") || "all",
-    staleMinAgeDays: numberArg("stale-min-age-days", 30),
+    staleMinAgeDays: numberArg("stale-min-age-days", 60),
     minAgeDays: numberArg("min-age-days", 0),
     minAgeMinutes: optionalString("min-age-minutes") ? numberArg("min-age-minutes", 0) : null,
   };

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -615,6 +615,24 @@ test("review actions only propose valid closes and never apply directly", () => 
   assert.match(action.closeComment, /Codex review notes: model gpt-5\.5, reasoning high;/);
 });
 
+test("review actions render deterministic close comments when model close comment is empty", () => {
+  const decision = closeDecision({ closeComment: "" });
+  const action = reviewActionForDecision({
+    item: item(),
+    decision,
+    git,
+    runtime: { model: "gpt-5.5", reasoningEffort: "high" },
+  });
+
+  assert.equal(action.actionTaken, "proposed_close");
+  assert.match(action.closeComment, /Thanks for the context here/);
+  assert.match(action.closeComment, /already implemented/);
+
+  const applyValidation = validateCloseDecision(item(), decision);
+  assert.equal(applyValidation.ok, false);
+  assert.equal(applyValidation.reason, "missing close comment");
+});
+
 test("close comments reference high-confidence merged fixing PRs", () => {
   const action = reviewActionForDecision({
     item: item(),


### PR DESCRIPTION
## Summary
- render deterministic close comments during review even when the model omits closeComment
- keep apply strict about stored usable close comments before GitHub mutation
- update stale close/backfill docs and scheduler capacity behavior already covered by the branch

## Verification
- pnpm run check
