### PR TITLE
perf(scheduler): raise normal review fanout to 100

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -74,7 +74,7 @@ on:
       shard_count:
         description: "Parallel shards (capped by config/automation-limits.json)"
         required: false
-        default: "70"
+        default: "100"
       item_number:
         description: "Optional single issue/PR number to review"
         required: false
@@ -637,7 +637,7 @@ jobs:
                 active_shards=0
               fi
               # Planning, publish, queued, and not-yet-expanded matrix runs still occupy
-              # scheduler attention, but they should not reserve a whole 35-70 shard lane.
+              # scheduler attention, but they should not reserve a whole 35-100 shard lane.
               if [ "$active_shards" -lt 1 ]; then
                 active_shards=1
               fi

--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ source ~/.profile
 corepack enable
 pnpm install
 pnpm run build
-pnpm run plan -- --target-repo openclaw/openclaw --batch-size 5 --shard-count 70 --max-pages 250 --codex-model gpt-5.5 --codex-reasoning-effort high
+pnpm run plan -- --target-repo openclaw/openclaw --batch-size 5 --shard-count 100 --max-pages 250 --codex-model gpt-5.5 --codex-reasoning-effort high
 pnpm run review -- --target-repo openclaw/openclaw --target-dir ../openclaw --batch-size 5 --max-pages 250 --artifact-dir artifacts/reviews --codex-model gpt-5.5 --codex-reasoning-effort high --codex-timeout-ms 600000
 pnpm run apply-artifacts -- --target-repo openclaw/openclaw --artifact-dir artifacts/reviews --skip-dashboard
 pnpm run audit -- --target-repo openclaw/openclaw --max-pages 250 --sample-limit 25 --update-dashboard
@@ -461,7 +461,7 @@ default, subject to the selected repository profile; pass `target_repo`,
 `apply_kind=issue`, or `apply_kind=pull_request` to narrow a manual run.
 
 Scheduled runs cover the configured product profiles. `openclaw/openclaw` runs
-normal backfill every 5 minutes with up to 70 review shards when the system is
+normal backfill every 5 minutes with up to 100 review shards when the system is
 quiet; `openclaw/clawhub` runs on offset review/apply/audit crons so its reports
 live under `records/openclaw-clawhub/` without colliding with default repo
 records. `openclaw/clawsweeper` has a scheduled read-only audit row and is
@@ -477,7 +477,7 @@ is active. Throughput defaults live in
 ClawSweeper has one main capacity knob:
 `config/automation-limits.json` -> `workers.max`. The current value is `100`.
 Quiet-system lane limits are derived from that number: normal review gets up to
-70 shards, hot intake up to 35 shards, commit review 5 commits per page, and
+100 shards, hot intake up to 35 shards, commit review 5 commits per page, and
 repair/issue implementation 40 live workers. Exact-item review, repair, and
 issue implementation are priority work; normal review, hot intake, and commit
 review are background work and automatically yield when priority work is active.

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -35,14 +35,15 @@ The mental model:
 
 ## Derived Limits
 
-Derived limits are intentionally percentages of `workers.max`. With
+Derived limits are intentionally percentages of `workers.max`, except normal
+review, which uses the full configured budget when explicitly requested. With
 `workers.max = 100`, the quiet-system ceilings are easy to read directly:
-normal review can use 70 workers, hot intake can use 35, commit review can use
+normal review can use 100 workers, hot intake can use 35, commit review can use
 5 commits per page, and repair lanes can dispatch 40 live workers.
 
 | Name | Current | Meaning |
 | --- | ---: | --- |
-| `review_shards.normal_default` | 70 | Quiet-system normal review shard ceiling. |
+| `review_shards.normal_default` | 100 | Quiet-system normal review shard ceiling. |
 | `review_shards.normal_active_floor` | 30 | Minimum active normal review shards to keep queued for `openclaw/openclaw`. |
 | `review_shards.hot_intake_default` | 35 | Quiet-system broad hot-intake review shard ceiling. |
 | `review_shards.exact_item_default` | 1 | Exact-item hot-intake shard count. |
@@ -57,7 +58,7 @@ normal review can use 70 workers, hot intake can use 35, commit review can use
 
 Formula summary:
 
-- normal review: 70% of `workers.max`
+- normal review: 100% of `workers.max`
 - normal active floor: 30% of `workers.max`
 - hot intake: 35% of `workers.max`
 - commit review page size: 5% of `workers.max`
@@ -88,7 +89,8 @@ priority work.
 
 Examples with the current config:
 
-- Quiet system: normal review gets 70, hot intake gets 35, commit review gets 5.
+- Quiet system: manual normal review can request 100 shards; scheduled normal
+  review gets 90 after reserving 10 slots for exact/manual/urgent work.
 - 30 active repair workers and 20 active background workers: normal review gets
   40 because `100 - 10 reserve - 30 priority - 20 background = 40`.
 - 90 active priority workers: commit review gets 1, so commit review yields but
@@ -104,8 +106,8 @@ pnpm run --silent workflow -- worker-limit commit_review --active-critical 90
 ```
 
 Change `workers.max` first when tuning rate-limit pressure. For example, setting
-`workers.max` to `80` automatically makes quiet normal review `56`, hot intake
-`28`, commit review `4`, repair `32`, and hard caps `80`.
+`workers.max` to `80` automatically makes normal review `80`, hot intake `28`,
+commit review `4`, repair `32`, and hard caps `80`.
 
 ## Runtime Overrides
 

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -16,7 +16,7 @@ ClawSweeper has three issue/PR scheduler paths:
 
 The lanes share report storage and apply rules, but they intentionally do not
 share throughput. Event review and hot intake keep new maintainer-visible work
-fast. Normal backfill keeps older records moving with up to 70 concurrent Codex
+fast. Normal backfill keeps older records moving with up to 100 concurrent Codex
 review shards when the system is quiet. Normal `openclaw/openclaw` review has an
 active floor of 30 shards for scheduled runs and workflow-dispatch
 continuations: due items win first, and if fewer than 30 items are due, the
@@ -177,12 +177,12 @@ Current defaults:
 - exact manual hot intake: 1 shard, 1 item
 - broad hot intake: up to 35 shards when quiet, batch size 1, scans up to 10
   GitHub pages
-- scheduled normal backfill: up to 70 shards when quiet, batch size 1, scans up
+- scheduled normal backfill: up to 100 shards when quiet, batch size 1, scans up
   to 250 GitHub pages
 - normal active floor: 30 shards for `openclaw/openclaw` scheduled runs and
   workflow-dispatch continuations; stale current-review backfill is eligible
   after 30 minutes
-- manual normal backfill: defaults to 70 shards, batch size 3, scans up to 250
+- manual normal backfill: defaults to 100 shards, batch size 3, scans up to 250
   GitHub pages unless overridden, and stops early once scanned due candidates
   fill planned capacity
 
@@ -193,7 +193,7 @@ Planning is also the runtime build point for matrix review. The plan job install
 with pinned Node 24 and `pnpm@10.33.2`, builds `dist/` once, and uploads that
 runtime artifact. Review shards download the built `dist/` and run
 `node dist/clawsweeper.js review` directly instead of running a per-shard pnpm
-install and build. This keeps 35-70 shard waves from stampeding the npm
+install and build. This keeps 35-100 shard waves from stampeding the npm
 registry or Corepack metadata endpoints.
 
 Each review shard also wraps the review command in a shell timeout derived from
@@ -211,7 +211,7 @@ because they may rebase and push generated records.
 Normal backfill now runs every 5 minutes for `openclaw/openclaw`. Because its
 concurrency group allows only one running normal backfill per target repo, the
 effect is a continuous drain loop: when due backlog exists, the active run can
-hold about 70 Codex review shards with one item per shard, and the next
+hold up to 100 Codex review shards with one item per shard, and the next
 scheduled tick is available as the backstop or pending continuation. Manual
 normal reviews keep the larger default batch size for targeted catch-up runs.
 
@@ -374,7 +374,7 @@ or syncs the durable ClawSweeper review comment.
 Broad normal review publishes records first, then dispatches durable review
 comment sync into the separate apply/comment-sync lane. This includes scheduled
 runs and workflow-dispatch continuations, so slow GitHub comment writes do not
-hold the normal review concurrency group or delay the next 70-shard backfill
+hold the normal review concurrency group or delay the next 100-shard backfill
 wave. Exact issue/PR reviews and repository-dispatch item runs still sync their
 selected comments inline before finishing.
 

--- a/scripts/check-limits.ts
+++ b/scripts/check-limits.ts
@@ -140,7 +140,7 @@ function deriveAutomationLimits(workerConfig: WorkerConfig): AutomationLimits {
   const max = workerConfig.workers.max;
   return {
     review_shards: {
-      normal_default: percent(max, 70),
+      normal_default: percent(max, 100),
       normal_active_floor: percent(max, 30),
       hot_intake_default: percent(max, 35),
       exact_item_default: 1,

--- a/src/repair/limits.ts
+++ b/src/repair/limits.ts
@@ -56,7 +56,7 @@ export function deriveAutomationLimits(config: WorkerConfig): AutomationLimits {
   const max = config.workers.max;
   return {
     review_shards: {
-      normal_default: percent(max, 70),
+      normal_default: percent(max, 100),
       normal_active_floor: percent(max, 30),
       hot_intake_default: percent(max, 35),
       exact_item_default: 1,

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -19,7 +19,7 @@ import {
 import { workerLimit } from "../../dist/repair/limits.js";
 
 test("workflow utilities expose automation limits", () => {
-  assert.equal(automationLimit("review_shards.normal_default"), 70);
+  assert.equal(automationLimit("review_shards.normal_default"), 100);
   assert.equal(automationLimit("repair_live_runs.default"), 40);
   assert.throws(() => automationLimit("missing.default"), /unknown automation limit/);
 });
@@ -30,11 +30,11 @@ test("workflow utilities accept positional automation limit CLI paths", () => {
     ["dist/repair/workflow-utils.js", "limit", "review_shards.normal_default"],
     { cwd: process.cwd(), encoding: "utf8" },
   );
-  assert.equal(output, "70");
+  assert.equal(output, "100");
 });
 
 test("worker scheduler lets background lanes yield to active work", () => {
-  assert.equal(workerLimit("normal_review"), 70);
+  assert.equal(workerLimit("normal_review"), 90);
   assert.equal(workerLimit("normal_review", { activeCritical: 30, activeBackground: 20 }), 40);
   assert.equal(workerLimit("commit_review"), 5);
   assert.equal(workerLimit("commit_review", { activeCritical: 90 }), 1);


### PR DESCRIPTION
## Summary
- raise normal review default shard ceiling from 70 to 100
- keep the dynamic scheduler reserve behavior, so scheduled quiet background review gets 90 after reserving 10 interactive slots
- update docs and limit drift checks

## Verification
- pnpm run check
