### PR TITLE
fix: age-gate mostly implemented PR cleanup

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -36,9 +36,9 @@ on:
         required: false
         default: "all"
       apply_stale_min_age_days:
-        description: "Minimum item age in days before stale-insufficient-info issue closes"
+        description: "Minimum item age in days before age-gated stale or mostly-implemented closes"
         required: false
-        default: "30"
+        default: "60"
       apply_item_numbers:
         description: "Optional comma-separated item numbers to sync/apply first"
         required: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Added age-gated `mostly_implemented_on_main` PR cleanup so ClawSweeper can
+  close older pull requests when current `main` already contains the useful
+  change and the remaining diff is obsolete, minor, risky churn, or separately
+  tracked.
 - Rendered deterministic close comments during review even when the model omits
   `closeComment`, while keeping apply strict about requiring a stored usable
   close comment before mutating GitHub.

--- a/README.md
+++ b/README.md
@@ -274,9 +274,9 @@ Exact event runs skip the bulk planner, shard matrix, artifact upload, and
 separate publish job. They still use the same review and apply code paths, but
 only for the selected item number and only with immediate-safe reasons enabled
 by default: `implemented_on_main` and `duplicate_or_superseded`.
-`stale_insufficient_info` is never applied to young items; apply requires those
-issue reports to be at least 60 days old unless a manual run explicitly changes
-the threshold.
+`stale_insufficient_info` issue reports and `mostly_implemented_on_main` PR
+reports are never applied to young items; apply requires those reports to be at
+least 60 days old unless a manual run explicitly changes the threshold.
 
 The external state dashboard is fleet-scoped. Each configured repository gets
 its own record folder, status JSON, audit state, cadence counts, and recent

--- a/config/target-repositories.json
+++ b/config/target-repositories.json
@@ -6,30 +6,30 @@
       "display_name": "ClawHub",
       "checkout_dir": "clawhub",
       "community_url": "https://clawhub.ai/",
-      "prompt_note": "Use the ClawHub source tree and current main branch. Review every issue and PR with the same evidence standard, but only propose auto-close for pull requests that are certainly implemented on main. Keep everything else open.",
+      "prompt_note": "Use the ClawHub source tree and current main branch. Review every issue and PR with the same evidence standard, but only propose auto-close for pull requests that are certainly implemented on main or age-gated mostly implemented on main. Keep everything else open.",
       "apply_close_rules": {
         "issue": [],
-        "pull_request": ["implemented_on_main"]
+        "pull_request": ["implemented_on_main", "mostly_implemented_on_main"]
       }
     },
     {
       "target_repo": "openclaw/clawsweeper",
       "display_name": "ClawSweeper",
       "checkout_dir": "clawsweeper",
-      "prompt_note": "Use the ClawSweeper source tree and current main branch. Review bot automation, workflow, and documentation changes conservatively. Only propose auto-close for pull requests that are certainly implemented on main; keep issues open for maintainer triage.",
+      "prompt_note": "Use the ClawSweeper source tree and current main branch. Review bot automation, workflow, and documentation changes conservatively. Only propose auto-close for pull requests that are certainly implemented on main or age-gated mostly implemented on main; keep issues open for maintainer triage.",
       "apply_close_rules": {
         "issue": [],
-        "pull_request": ["implemented_on_main"]
+        "pull_request": ["implemented_on_main", "mostly_implemented_on_main"]
       }
     },
     {
       "target_repo": "openclaw/fs-safe",
       "display_name": "fs-safe",
       "checkout_dir": "fs-safe",
-      "prompt_note": "Use the fs-safe source tree and current main branch. Review filesystem-safety, path-handling, and package changes conservatively. Only propose auto-close for pull requests that are certainly implemented on main; keep issues open for maintainer triage.",
+      "prompt_note": "Use the fs-safe source tree and current main branch. Review filesystem-safety, path-handling, and package changes conservatively. Only propose auto-close for pull requests that are certainly implemented on main or age-gated mostly implemented on main; keep issues open for maintainer triage.",
       "apply_close_rules": {
         "issue": [],
-        "pull_request": ["implemented_on_main"]
+        "pull_request": ["implemented_on_main", "mostly_implemented_on_main"]
       }
     }
   ],
@@ -37,10 +37,10 @@
     "owner": "openclaw",
     "deny_repositories": ["openclaw/clawsweeper-state", "openclaw/.github"],
     "allow_repo_name_pattern": "^[A-Za-z0-9_.-]+$",
-    "prompt_note": "Use the {target_repo} source tree and current main branch. This repository is using the generic OpenClaw onboarding profile, so keep review conservative: issues are review/comment-only, and pull requests may be auto-closed only when the exact change is certainly already implemented on main.",
+    "prompt_note": "Use the {target_repo} source tree and current main branch. This repository is using the generic OpenClaw onboarding profile, so keep review conservative: issues are review/comment-only, and pull requests may be auto-closed only when the exact change is certainly already implemented on main or age-gated mostly implemented on main.",
     "apply_close_rules": {
       "issue": [],
-      "pull_request": ["implemented_on_main"]
+      "pull_request": ["implemented_on_main", "mostly_implemented_on_main"]
     }
   }
 }

--- a/docs/target-dispatcher.md
+++ b/docs/target-dispatcher.md
@@ -163,8 +163,8 @@ because the review always fetches the current live item state.
 The receiver keeps the review lane proposal-only, then runs exact apply for the
 selected item with only immediate-safe close reasons enabled:
 `implemented_on_main` and `duplicate_or_superseded`. Normal scheduled apply
-still handles the broader backlog, with `stale_insufficient_info` blocked until
-the item is at least 60 days old.
+still handles the broader backlog, with `stale_insufficient_info` and
+`mostly_implemented_on_main` blocked until the item is at least 60 days old.
 
 `openclaw/clawhub` dispatches are intentionally skipped while the receiver
 variable `CLAWSWEEPER_ENABLE_CLAWHUB` is not `1`. Enable it only after the

--- a/docs/target-repositories.md
+++ b/docs/target-repositories.md
@@ -24,7 +24,8 @@ without a TypeScript change. It is intentionally narrow:
 - repo name must match `allow_repo_name_pattern`
 - denied repositories are rejected
 - issues cannot be auto-closed
-- PRs can auto-close only for `implemented_on_main`
+- PRs can auto-close only for `implemented_on_main` or age-gated
+  `mostly_implemented_on_main`
 - scheduled dashboard/backfill rows are not added automatically
 
 This is enough for event-driven review after the target repo has the dispatcher

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -119,6 +119,14 @@ Use reason-specific anchors:
   release tag/version. If it is only on current `main`, say that and include the
   commit timestamp. If you cannot establish either the shipped release or the
   main-only timestamp with high confidence, keep the item open.
+- For `mostly_implemented_on_main`, use the same source/history/release
+  provenance standard as `implemented_on_main`, but only for pull requests older
+  than 60 days whose central useful change is already on current `main`.
+  Confirm that any leftover diff is minor, obsolete, risky churn, style-only,
+  superseded by current code, or already tracked by a narrower canonical item.
+  Also confirm there has been no recent substantive human response that changes
+  the decision. Keep the PR open when a meaningful unique fix, feature,
+  security hardening, test, doc, migration, or product decision remains.
 - For `clawhub`, inspect `VISION.md` and the relevant plugin/skill/MCP/channel/provider docs or APIs, then confirm the request can be satisfied outside core without a missing extension API.
 - For `duplicate_or_superseded`, read the canonical related report/PR from the provided context or `gh`, and explain whether it is open, closed, merged, or already shipped.
 - For `not_actionable_in_repo`, read enough discussion/context to confirm the action belongs to repo/project administration, third-party setup, external ownership, or historical cleanup rather than OpenClaw code/docs.
@@ -133,6 +141,7 @@ hedge for an otherwise policy-valid close.
 Close only when the evidence is strong and the repository policy allows it. Allowed close reasons:
 
 - `implemented_on_main`: current `main` already implements or fixes the request well enough.
+- `mostly_implemented_on_main`: an older PR is more than 60 days old, current `main` already implements the central useful part of the PR, and no meaningful unique remainder should be merged from the branch. Use only for pull requests, not issues. The close comment must say what part is already on `main`, what leftover part is minor/obsolete/superseded or separately tracked, and why keeping the stale branch open is not useful.
 - `cannot_reproduce`: you tried a reasonable reproduction path against current `main` and it does not reproduce, or the report is obsolete and no longer matches current behavior.
 - `clawhub`: useful idea, but it belongs as a ClawHub skill/plugin rather than OpenClaw core. Use `VISION.md` as the scope anchor. Prefer this when the requested capability is optional integration/provider/channel/skill/bundle/MCP work, can be built with current skill/MCP/plugin surfaces, has no concrete missing core extension API, and has no protected maintainer signal. This includes service-specific channels, providers, optional skills, and plugin-discovery/publishing ideas when the current plugin or bundle-style interface is sufficient. For OpenClaw PRs that only add bundled skills under paths like `skills/<vendor>/**`, set `itemCategory: "skill"` and prefer `closeReason: "clawhub"` with high confidence; the close comment should ask the contributor to upload or publish it through ClawHub.com instead of bundling it in OpenClaw core. Keep open when the item reports a regression in bundled core behavior, identifies a missing plugin API needed before external implementation is possible, involves security/core hardening, or clearly needs explicit maintainer product judgment.
 - `duplicate_or_superseded`: another issue/PR already tracks the same remaining work, or the linked discussion/PR clearly supersedes this item. Link the canonical item and explain whether it is open or closed/merged. For clusters with the same root cause, keep one canonical issue open and close satellites when their unique logs, platforms, or context can be preserved by linking them in the close comment. Unique evidence blocks duplicate close only when it implies a distinct root cause, platform-specific fix, or separate remaining product behavior.
@@ -140,9 +149,9 @@ Close only when the evidence is strong and the repository policy allows it. Allo
 - `incoherent`: the item is too unclear or internally contradictory after reading the title/body/comments.
 - `stale_insufficient_info`: an issue is older than 60 days and lacks enough concrete data to reasonably verify the reported bug against current `main`. Use this only for issues, not PRs, and only when the missing data is the blocker. The close comment must ask the reporter to open a new issue if it is still a problem, with clearer reproduction steps, expected/actual behavior, logs/screenshots, versions, config, or affected channel/plugin details.
 
-For `openclaw/clawhub`, review every issue and PR with the same depth, but only close PRs where current `main` definitely implements the PR’s intended change. For ClawHub, use `implemented_on_main` only for those PRs, and keep all issues plus all other PR outcomes open.
+For `openclaw/clawhub`, review every issue and PR with the same depth, but only close PRs where current `main` definitely implements the PR’s intended change or an older PR is mostly implemented on `main` under the `mostly_implemented_on_main` rules. For ClawHub, use `implemented_on_main` or `mostly_implemented_on_main` only for those PRs, and keep all issues plus all other PR outcomes open.
 
-Do a canonical-search pass before keeping an older issue open only because a
+Do a canonical-search pass before keeping an older item open only because a
 small part might remain. Start with the provided `relatedItems`, then search
 GitHub and local reports for the central user problem, not just exact title
 words. Useful checks include `gh issue list --repo <repo> --state all --search
@@ -153,16 +162,19 @@ one canonical issue or PR now owns the remaining work, close this item as
 `duplicate_or_superseded` and link that canonical item. If current `main` solves
 the central user problem and only minor unconfirmed leftovers remain, prefer
 `implemented_on_main` with fix provenance, or `duplicate_or_superseded` when a
-narrower follow-up tracks the leftovers. If the item is older than 60 days,
-partially addressed, and the only remaining blocker is missing reporter data to
-verify whether anything still fails on current `main`, `stale_insufficient_info`
-is acceptable for issues. Do not use stale age to close a clearly described
-remaining feature, config surface, security hardening task, or product decision;
-keep those open or route them to the canonical item.
+narrower follow-up tracks the leftovers. If the item is an issue older than 60
+days, partially addressed, and the only remaining blocker is missing reporter
+data to verify whether anything still fails on current `main`,
+`stale_insufficient_info` is acceptable. If the item is a pull request older
+than 60 days and the central useful change is already on `main`, use
+`mostly_implemented_on_main` when the leftover PR diff is minor, obsolete,
+superseded, risky churn, or separately tracked. Do not use stale age to close a
+clearly described remaining feature, config surface, security hardening task, or
+product decision; keep those open or route them to the canonical item.
 
-Close as implemented when current `main` solves the observable user problem well enough, even if it did not use the exact workflow, file split, or field names proposed in the item. For broad umbrella requests, weigh the title and central user problem first. If current `main` solves the central problem and any leftovers are already tracked by a narrower related item, close as `duplicate_or_superseded` or `implemented_on_main` as appropriate and link the canonical follow-up. Keep open when a meaningful requested capability remains missing and no narrower canonical follow-up exists.
+Close as implemented when current `main` solves the observable user problem well enough, even if it did not use the exact workflow, file split, or field names proposed in the item. For broad umbrella requests, weigh the title and central user problem first. If current `main` solves the central problem and any leftovers are already tracked by a narrower related item, close as `duplicate_or_superseded` or `implemented_on_main` as appropriate and link the canonical follow-up. For older PRs where current `main` covers most of the branch but not every line, use `mostly_implemented_on_main` instead of stretching `implemented_on_main`. Keep open when a meaningful requested capability remains missing and no narrower canonical follow-up exists.
 
-Keep open for everything else, including real bugs, unclear-but-salvageable reports, stale PRs that might still contain useful work, optional features that require a new core/plugin API first, or anything where the evidence is not high-confidence.
+Keep open for everything else, including real bugs, unclear-but-salvageable reports, stale PRs that still contain useful unique work, optional features that require a new core/plugin API first, or anything where the evidence is not high-confidence.
 
 For keep-open items, also decide whether this is a safe ClawSweeper repair
 candidate. This is not permission to mutate GitHub; it only marks a manual work

--- a/schema/clawsweeper-decision.schema.json
+++ b/schema/clawsweeper-decision.schema.json
@@ -47,6 +47,7 @@
       "type": "string",
       "enum": [
         "implemented_on_main",
+        "mostly_implemented_on_main",
         "cannot_reproduce",
         "clawhub",
         "duplicate_or_superseded",
@@ -354,7 +355,7 @@
     },
     "fixedAt": {
       "type": ["string", "null"],
-      "description": "ISO-8601 commit or merge timestamp for the fix/proof SHA when known. Required for implemented_on_main when fixedRelease is null so maintainers know when it became fixed on main."
+      "description": "ISO-8601 commit or merge timestamp for the fix/proof SHA when known. Required for implemented_on_main and mostly_implemented_on_main when fixedRelease is null so maintainers know when it became fixed on main."
     },
     "closeComment": {
       "type": "string"

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -102,6 +102,7 @@ type RealBehaviorProofEvidenceKind =
   | "not_applicable";
 type CloseReason =
   | "implemented_on_main"
+  | "mostly_implemented_on_main"
   | "cannot_reproduce"
   | "clawhub"
   | "duplicate_or_superseded"
@@ -664,6 +665,7 @@ const PROOF_SUFFICIENT_LABEL = "proof: sufficient";
 const PROTECTED_LABELS = new Set(["security", "beta-blocker", "release-blocker", "maintainer"]);
 const ALLOWED_REASONS = new Set<CloseReason>([
   "implemented_on_main",
+  "mostly_implemented_on_main",
   "cannot_reproduce",
   "clawhub",
   "duplicate_or_superseded",
@@ -1567,10 +1569,10 @@ export function closeReasonApplyAgeSkipReason(
 ): string | null {
   const now = options.now ?? Date.now();
   if (
-    closeReason === "stale_insufficient_info" &&
+    (closeReason === "stale_insufficient_info" || closeReason === "mostly_implemented_on_main") &&
     !isOlderThanDays(item.createdAt, options.staleMinAgeDays, now)
   ) {
-    return `stale_insufficient_info requires item older than ${options.staleMinAgeDays} days`;
+    return `${closeReason} requires item older than ${options.staleMinAgeDays} days`;
   }
   if (!isOlderThanMs(item.createdAt, options.minAgeMs, now)) {
     return `created less than or equal to ${options.minAgeDescription} ago`;
@@ -3828,6 +3830,8 @@ function closeReasonText(reason: CloseReason): string {
   switch (reason) {
     case "implemented_on_main":
       return "already implemented on main";
+    case "mostly_implemented_on_main":
+      return "mostly implemented on main";
     case "cannot_reproduce":
       return "cannot reproduce on current main";
     case "clawhub":
@@ -4487,6 +4491,8 @@ function closeIntro(reason: CloseReason): string {
   switch (reason) {
     case "implemented_on_main":
       return "Thanks for the context here. I did a careful shell check against current `main`, and this is already implemented.";
+    case "mostly_implemented_on_main":
+      return "Thanks for the context here. I did a careful shell check against current `main`, and the useful part of this older PR is already implemented there.";
     case "cannot_reproduce":
       return "Thanks for the report. I gave this a fresh shell check against current `main`, and I could not reproduce it anymore.";
     case "clawhub":
@@ -4508,6 +4514,8 @@ function closeOutro(reason: CloseReason): string {
   switch (reason) {
     case "implemented_on_main":
       return "So I’m closing this as already implemented rather than keeping a duplicate issue open.";
+    case "mostly_implemented_on_main":
+      return "So I’m closing this older PR as already covered on `main` rather than keeping a mostly-duplicated branch open.";
     case "clawhub":
       return `So I’m closing this as a scope-fit item for the plugin/community path. Please upload or publish it through ${markdownLink("ClawHub.com", targetProfile().communityUrl ?? "https://clawhub.ai/")} so it can live as an installable community skill instead of a bundled OpenClaw core change.`;
     case "duplicate_or_superseded":
@@ -5559,6 +5567,13 @@ export function validateCloseDecision(
       reason: `${decision.closeReason} is not allowed for ${profile.targetRepo} ${item.kind} apply policy`,
     };
   }
+  if (item.kind !== "pull_request" && decision.closeReason === "mostly_implemented_on_main") {
+    return {
+      ok: false,
+      actionTaken: "skipped_invalid_decision",
+      reason: "mostly_implemented_on_main is allowed only for pull requests",
+    };
+  }
   if (item.kind === "pull_request" && decision.closeReason === "stale_insufficient_info") {
     return {
       ok: false,
@@ -5580,65 +5595,69 @@ export function validateCloseDecision(
     return { ok: false, actionTaken: "skipped_invalid_decision", reason: "missing evidence" };
   }
   if (
-    decision.closeReason === "implemented_on_main" &&
+    isImplementationCloseReason(decision.closeReason) &&
     !hasImplementationSourceEvidence(decision)
   ) {
     return {
       ok: false,
       actionTaken: "skipped_invalid_decision",
-      reason: "implemented_on_main requires evidence with file and sha",
+      reason: `${decision.closeReason} requires evidence with file and sha`,
     };
   }
-  if (decision.closeReason === "implemented_on_main" && !decision.fixedSha?.trim()) {
+  if (isImplementationCloseReason(decision.closeReason) && !decision.fixedSha?.trim()) {
     return {
       ok: false,
       actionTaken: "skipped_invalid_decision",
-      reason: "implemented_on_main requires fixedSha",
+      reason: `${decision.closeReason} requires fixedSha`,
     };
   }
   if (
-    decision.closeReason === "implemented_on_main" &&
+    isImplementationCloseReason(decision.closeReason) &&
     decision.fixedAt &&
     !hasValidFixedAt(decision)
   ) {
     return {
       ok: false,
       actionTaken: "skipped_invalid_decision",
-      reason: "implemented_on_main fixedAt must be an ISO timestamp",
+      reason: `${decision.closeReason} fixedAt must be an ISO timestamp`,
     };
   }
   if (
-    decision.closeReason === "implemented_on_main" &&
+    isImplementationCloseReason(decision.closeReason) &&
     !decision.fixedRelease?.trim() &&
     !hasValidFixedAt(decision)
   ) {
     return {
       ok: false,
       actionTaken: "skipped_invalid_decision",
-      reason: "implemented_on_main requires fixedRelease or fixedAt",
+      reason: `${decision.closeReason} requires fixedRelease or fixedAt`,
     };
   }
   if (
-    decision.closeReason === "implemented_on_main" &&
+    isImplementationCloseReason(decision.closeReason) &&
     !hasImplementationHistoryEvidence(decision)
   ) {
     return {
       ok: false,
       actionTaken: "skipped_invalid_decision",
-      reason: "implemented_on_main requires git history provenance evidence",
+      reason: `${decision.closeReason} requires git history provenance evidence`,
     };
   }
   if (
-    decision.closeReason === "implemented_on_main" &&
+    isImplementationCloseReason(decision.closeReason) &&
     !hasImplementationReleaseStateEvidence(decision)
   ) {
     return {
       ok: false,
       actionTaken: "skipped_invalid_decision",
-      reason: "implemented_on_main requires release or main-only provenance evidence",
+      reason: `${decision.closeReason} requires release or main-only provenance evidence`,
     };
   }
   return { ok: true };
+}
+
+function isImplementationCloseReason(reason: CloseReason): boolean {
+  return reason === "implemented_on_main" || reason === "mostly_implemented_on_main";
 }
 
 function reviewCommentMarker(number: number): string {
@@ -5993,7 +6012,7 @@ function closeItem(options: { number: number; kind: ItemKind; reason: CloseReaso
   if (options.kind === "pull_request") {
     ghWithRetry(["pr", "close", String(options.number)]);
   } else {
-    const reason = options.reason === "implemented_on_main" ? "completed" : "not_planned";
+    const reason = isImplementationCloseReason(options.reason) ? "completed" : "not_planned";
     const closePayloadFile = join(ROOT, ".artifacts", `close-${options.number}.json`);
     writeFileSync(
       closePayloadFile,

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -257,6 +257,7 @@ export function proposedItemNumbers(options: ProposedItemOptions): number[] {
     "duplicate_or_superseded",
     "incoherent",
     "implemented_on_main",
+    "mostly_implemented_on_main",
     "not_actionable_in_repo",
     "stale_insufficient_info",
   ]);
@@ -289,7 +290,7 @@ export function proposedItemNumbers(options: ProposedItemOptions): number[] {
       if (!allowedForTarget(options.targetRepo, type, reason, allowedReasons)) return [];
       if (allowedCloseReasons && !allowedCloseReasons.has(reason)) return [];
       if (
-        reason === "stale_insufficient_info" &&
+        (reason === "stale_insufficient_info" || reason === "mostly_implemented_on_main") &&
         !olderThan(
           frontMatterValue(markdown, "item_created_at"),
           options.staleMinAgeDays * 24 * 60 * 60 * 1000,
@@ -420,8 +421,12 @@ function allowedForTarget(
   allowedReasons: ReadonlySet<string>,
 ): boolean {
   if (targetRepo === "openclaw/clawhub")
-    return type === "pull_request" && reason === "implemented_on_main";
+    return (
+      type === "pull_request" &&
+      (reason === "implemented_on_main" || reason === "mostly_implemented_on_main")
+    );
   if (type === "pull_request" && reason === "stale_insufficient_info") return false;
+  if (type !== "pull_request" && reason === "mostly_implemented_on_main") return false;
   return allowedReasons.has(reason);
 }
 

--- a/src/repository-profiles.ts
+++ b/src/repository-profiles.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 export type RepositoryItemKind = "issue" | "pull_request";
 export type RepositoryCloseReason =
   | "implemented_on_main"
+  | "mostly_implemented_on_main"
   | "cannot_reproduce"
   | "clawhub"
   | "duplicate_or_superseded"
@@ -50,6 +51,7 @@ interface OpenClawFallbackConfig {
 
 const OPENCLAW_CLOSE_REASONS: readonly RepositoryCloseReason[] = [
   "implemented_on_main",
+  "mostly_implemented_on_main",
   "cannot_reproduce",
   "clawhub",
   "duplicate_or_superseded",

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -846,7 +846,7 @@ test("skill-only OpenClaw PRs can close through ClawHub with upload guidance", (
   assert.match(action.closeComment, /installable community skill/);
 });
 
-test("ClawHub policy only allows implemented-on-main PR close proposals", () => {
+test("ClawHub policy only allows main-implemented PR close proposals", () => {
   const implementedPr = validateCloseDecision(
     item({
       repo: "openclaw/clawhub",
@@ -1277,6 +1277,17 @@ test("invalid close semantics are rejected", () => {
   assert.equal(stalePr.ok, false);
   assert.equal(stalePr.actionTaken, "skipped_invalid_decision");
 
+  const mostlyImplementedIssue = validateCloseDecision(
+    item({ kind: "issue" }),
+    closeDecision({ closeReason: "mostly_implemented_on_main" }),
+  );
+  assert.equal(mostlyImplementedIssue.ok, false);
+  assert.equal(mostlyImplementedIssue.actionTaken, "skipped_invalid_decision");
+  assert.equal(
+    mostlyImplementedIssue.reason,
+    "mostly_implemented_on_main is allowed only for pull requests",
+  );
+
   const missingEvidence = validateCloseDecision(item(), closeDecision({ evidence: [] }));
   assert.equal(missingEvidence.ok, false);
   assert.equal(missingEvidence.actionTaken, "skipped_invalid_decision");
@@ -1425,6 +1436,17 @@ test("implemented-on-main closes require fix provenance", () => {
     }),
   );
   assert.equal(blameAndMainTimestamp.ok, true);
+
+  const mostlyImplementedPr = validateCloseDecision(
+    item({ kind: "pull_request" }),
+    closeDecision({
+      closeReason: "mostly_implemented_on_main",
+      summary: "Current main implements the useful part of this older PR.",
+      closeComment:
+        "Closing this older PR because current main already covers the useful change and the remaining branch diff is obsolete.",
+    }),
+  );
+  assert.equal(mostlyImplementedPr.ok, true);
 });
 
 test("duplicate or superseded closes are allowed with evidence and comment", () => {
@@ -1461,15 +1483,16 @@ test("apply close reason filters support exact fast-close lanes", () => {
   assert.throws(() => closeReasonsArg("stale"), /Invalid apply close reason: stale/);
 });
 
-test("stale insufficient-info closes require older items while implemented closes can be immediate", () => {
+test("stale and mostly-implemented closes require older items while implemented closes can be immediate", () => {
   const now = Date.parse("2026-04-28T12:00:00Z");
   const freshItem = item({ createdAt: "2026-04-28T11:59:00Z" });
+  const oldItem = item({ createdAt: "2026-01-01T00:00:00Z" });
 
   assert.equal(
     closeReasonApplyAgeSkipReason(freshItem, "implemented_on_main", {
       minAgeMs: 0,
       minAgeDescription: "0 minutes",
-      staleMinAgeDays: 30,
+      staleMinAgeDays: 60,
       now,
     }),
     null,
@@ -1478,7 +1501,7 @@ test("stale insufficient-info closes require older items while implemented close
     closeReasonApplyAgeSkipReason(freshItem, "duplicate_or_superseded", {
       minAgeMs: 5 * 60 * 1000,
       minAgeDescription: "5 minutes",
-      staleMinAgeDays: 30,
+      staleMinAgeDays: 60,
       now,
     }),
     "created less than or equal to 5 minutes ago",
@@ -1487,10 +1510,28 @@ test("stale insufficient-info closes require older items while implemented close
     closeReasonApplyAgeSkipReason(freshItem, "stale_insufficient_info", {
       minAgeMs: 0,
       minAgeDescription: "0 minutes",
-      staleMinAgeDays: 30,
+      staleMinAgeDays: 60,
       now,
     }),
-    "stale_insufficient_info requires item older than 30 days",
+    "stale_insufficient_info requires item older than 60 days",
+  );
+  assert.equal(
+    closeReasonApplyAgeSkipReason(freshItem, "mostly_implemented_on_main", {
+      minAgeMs: 0,
+      minAgeDescription: "0 minutes",
+      staleMinAgeDays: 60,
+      now,
+    }),
+    "mostly_implemented_on_main requires item older than 60 days",
+  );
+  assert.equal(
+    closeReasonApplyAgeSkipReason(oldItem, "mostly_implemented_on_main", {
+      minAgeMs: 0,
+      minAgeDescription: "0 minutes",
+      staleMinAgeDays: 60,
+      now,
+    }),
+    null,
   );
 });
 

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -184,19 +184,64 @@ test("workflow utilities select eligible proposed close records", () => {
       "",
     ].join("\n"),
   );
+  write(
+    path.join(root, "records/openclaw-openclaw/items/openclaw-openclaw-12.md"),
+    [
+      "---",
+      "repository: openclaw/openclaw",
+      "type: pull_request",
+      "decision: close",
+      "confidence: high",
+      "action_taken: proposed_close",
+      "close_reason: mostly_implemented_on_main",
+      `item_created_at: ${oldDate}`,
+      "---",
+      "",
+    ].join("\n"),
+  );
+  write(
+    path.join(root, "records/openclaw-openclaw/items/openclaw-openclaw-13.md"),
+    [
+      "---",
+      "repository: openclaw/openclaw",
+      "type: issue",
+      "decision: close",
+      "confidence: high",
+      "action_taken: proposed_close",
+      "close_reason: mostly_implemented_on_main",
+      `item_created_at: ${oldDate}`,
+      "---",
+      "",
+    ].join("\n"),
+  );
+  write(
+    path.join(root, "records/openclaw-openclaw/items/openclaw-openclaw-14.md"),
+    [
+      "---",
+      "repository: openclaw/openclaw",
+      "type: pull_request",
+      "decision: close",
+      "confidence: high",
+      "action_taken: proposed_close",
+      "close_reason: mostly_implemented_on_main",
+      `item_created_at: ${new Date().toISOString()}`,
+      "---",
+      "",
+    ].join("\n"),
+  );
 
   const selected = withCwd(root, () =>
     proposedItemNumbers({
       targetRepo: "openclaw/openclaw",
       applyKind: "all",
       applyCloseReasons: "all",
-      staleMinAgeDays: 30,
+      staleMinAgeDays: 60,
       minAgeDays: 0,
       minAgeMinutes: null,
     }),
   );
 
-  assert.deepEqual(selected, [5]);
+  assert.deepEqual(selected, [5, 12]);
 });
 
 function withCwd(cwd, callback) {

--- a/test/repository-profiles.test.ts
+++ b/test/repository-profiles.test.ts
@@ -17,7 +17,10 @@ test("repositoryProfileFor supports fs-safe event reviews", () => {
   assert.equal(profile.slug, "openclaw-fs-safe");
   assert.equal(profile.checkoutDir, "fs-safe");
   assert.deepEqual(profile.applyCloseRules.issue, []);
-  assert.deepEqual(profile.applyCloseRules.pull_request, ["implemented_on_main"]);
+  assert.deepEqual(profile.applyCloseRules.pull_request, [
+    "implemented_on_main",
+    "mostly_implemented_on_main",
+  ]);
 });
 
 test("generic OpenClaw fallback supports conservative event-only onboarding", () => {
@@ -29,7 +32,10 @@ test("generic OpenClaw fallback supports conservative event-only onboarding", ()
   assert.equal(profile.checkoutDir, "example-tool");
   assert.match(profile.promptNote, /generic OpenClaw onboarding profile/);
   assert.deepEqual(profile.applyCloseRules.issue, []);
-  assert.deepEqual(profile.applyCloseRules.pull_request, ["implemented_on_main"]);
+  assert.deepEqual(profile.applyCloseRules.pull_request, [
+    "implemented_on_main",
+    "mostly_implemented_on_main",
+  ]);
 });
 
 test("generic OpenClaw fallback keeps denied repositories unsupported", () => {


### PR DESCRIPTION
## Summary
- add `mostly_implemented_on_main` as a PR-only age-gated close reason
- keep `stale_insufficient_info` issue-only and block it for PRs
- update repository close-rule allowlists, review prompt guidance, schema, docs, changelog, and workflow-dispatch default
- add regression coverage for age gates and type guards

## Verification
- pnpm run check
