### PR TITLE
ci: remove timeout from skipped target event job

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -141,7 +141,6 @@ jobs:
     name: Skip disabled target event
     if: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.target_repo == 'openclaw/clawhub' && vars.CLAWSWEEPER_ENABLE_CLAWHUB != '1' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 5
     steps:
       - name: Explain skipped event
         run: |


### PR DESCRIPTION
## Summary
- remove the explicit timeout from the ClawHub-disabled skip job so the dirty workflow delta is shipped

## Verification
- pnpm run check
