### PR TITLE
[codex] Clarify likely owner maintainer roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ checkpoint, and status-only commits are intentionally omitted.
 - Suppressed changelog-only OpenClaw PR review findings after model output so
   contributor PRs do not get needs-changes or fix-required markers solely for
   maintainer-owned release notes. Thanks @rubencu.
+- Clarified likely-owner role wording in generated review comments and reports
+  so history-based routing does not imply official maintainer status. Thanks
+  @rubencu.
 - Added explicit timeouts for disabled-target workflow guard jobs and
   concurrency groups for write-side repair workflows. Thanks @ds4psb-ai.
 - Gave manual exact-item review dispatches their own concurrency group so

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -21,15 +21,17 @@ shortlog`, `git show`, and nearby commit/PR history against the concrete files,
 symbols, docs, workflow steps, or tests involved. Follow old names, renamed
 files, moved helpers, and refactored call sites when the current code is a
 wrapper around older behavior. Identify likely authors, mergers, reviewers,
-recent maintainers, or adjacent owners; include multiple people when the trail
-is shared or ambiguous. If the item is broad, sample the most central files
-rather than skipping provenance. If history is ambiguous, say so and mark
+recent area contributors, or adjacent owners; include multiple people when the
+trail is shared or ambiguous. If the item is broad, sample the most central
+files rather than skipping provenance. If history is ambiguous, say so and mark
 confidence low. Phrase it neutrally in public prose: say `the behavior appears
 to date to commit ...` or `likely related by recent work on ...`, not `person X
-broke it`. The goal is maintainer routing, not blame. Do not include email
-addresses in `likelyOwners`, `person`, reasons, summaries, or public comments.
-Prefer GitHub handles from PR/commit metadata; otherwise use a display name
-without the `<email>` part.
+broke it`. The goal is maintainer routing, not blame. Do not use `maintainer`
+as a role unless official repository status is explicit; prefer roles like
+`recent area contributor`, `feature owner`, `reviewer`, or `merger` for history
+signals. Do not include email addresses in `likelyOwners`, `person`, reasons,
+summaries, or public comments. Prefer GitHub handles from PR/commit metadata;
+otherwise use a display name without the `<email>` part.
 
 For PRs, set `changeSummary` to a neutral one-sentence summary of what the PR
 branch changes, based on the title, body, diff, files, and commits. Describe the
@@ -78,7 +80,7 @@ the issue, or authored the proposed branch. `likelyOwners` should point to
 people connected to the current `main` history and merged feature history for
 the affected code path: original introducers, heavy contributors, major
 refactor authors, reviewers/mergers of the feature, or recent adjacent
-maintainers. Include the PR author only when they also show up in prior merged
+contributors. Include the PR author only when they also show up in prior merged
 history, current-main ownership, maintainer review context, or clear domain
 ownership beyond this PR. If the PR author is only the proposer/reporter, you
 may mention that in evidence or summary when useful, but do not make them a
@@ -283,7 +285,9 @@ shortlog`, `git show`, PR metadata, and recent touches to the central files.
 Use GitHub handles when available; otherwise use names without email addresses.
 For PRs, route to feature-history owners from current `main`, not to the PR
 author merely for writing the proposal. Include at least one likely owner for
-every review; when the trail is weak, use low confidence and explain why.
+every review; when the trail is weak, use low confidence and explain why. Do
+not use `maintainer` as a likely-owner role unless the evidence proves official
+repository status.
 
 If you choose `close`, set
 `confidence` to `high`, include at least one evidence entry, and write a

--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -97,31 +97,34 @@ function llmsTxt() {
   const origin = docsOrigin();
   const source = docsSourceUrl();
   const name = typeof productName !== "undefined" ? productName : path.basename(root);
-  const description = typeof productDescription !== "undefined" ? productDescription : `${name} documentation index.`;
+  const description =
+    typeof productDescription !== "undefined" ? productDescription : `${name} documentation index.`;
   const install = docsInstallHint();
-  const docPages = docsLlmsPages().map((page) => `- ${page.title}: ${pageUrl(origin, page.outRel)}`);
-  const lines = [
-    `# ${name}`,
-    "",
-    description,
-    "",
-    "Canonical documentation:",
-    ...docPages,
-  ];
+  const docPages = docsLlmsPages().map(
+    (page) => `- ${page.title}: ${pageUrl(origin, page.outRel)}`,
+  );
+  const lines = [`# ${name}`, "", description, "", "Canonical documentation:", ...docPages];
   if (install) {
     lines.push("", "Install:", `- ${install}`);
   }
   if (source) {
     lines.push("", `Source: ${source}`);
   }
-  lines.push("", "Guidance for agents:", "- Prefer the canonical documentation URLs above over README excerpts or package metadata.", "- Fetch only the pages needed for the current task; this is an index, not a full-site corpus.");
+  lines.push(
+    "",
+    "Guidance for agents:",
+    "- Prefer the canonical documentation URLs above over README excerpts or package metadata.",
+    "- Fetch only the pages needed for the current task; this is an index, not a full-site corpus.",
+  );
   return `${lines.join("\n")}\n`;
 }
 
 function docsLlmsPages() {
   const seen = new Set();
   const ordered = typeof orderedPages !== "undefined" ? orderedPages : [];
-  return [...ordered, ...pages].filter((page) => page.outRel && !seen.has(page.outRel) && seen.add(page.outRel));
+  return [...ordered, ...pages].filter(
+    (page) => page.outRel && !seen.has(page.outRel) && seen.add(page.outRel),
+  );
 }
 
 function docsOrigin() {
@@ -135,7 +138,8 @@ function docsOrigin() {
 function docsSourceUrl() {
   if (typeof repoBase !== "undefined") return repoBase;
   if (typeof repoUrl !== "undefined") return repoUrl;
-  if (typeof repoEditBase !== "undefined") return repoEditBase.replace(/\/edit\/main\/docs\/?$/, "");
+  if (typeof repoEditBase !== "undefined")
+    return repoEditBase.replace(/\/edit\/main\/docs\/?$/, "");
   return "";
 }
 
@@ -149,7 +153,10 @@ function docsInstallHint() {
 }
 
 function pageUrl(origin, outRel) {
-  const normalized = outRel === "index.html" ? "" : outRel.replace(/(?:^|\/)index\.html$/, (match) => match === "index.html" ? "" : "/");
+  const normalized =
+    outRel === "index.html"
+      ? ""
+      : outRel.replace(/(?:^|\/)index\.html$/, (match) => (match === "index.html" ? "" : "/"));
   if (!origin) return normalized || "index.html";
   return normalized ? `${origin}/${normalized}` : `${origin}/`;
 }

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -4357,9 +4357,20 @@ function closeEvidenceLine(evidence: Evidence): string {
   return `- ${prefix}${detail}${evidenceLocation(evidence)}`;
 }
 
+function publicLikelyOwnerRole(role: string): string {
+  return role
+    .trim()
+    .replace(/\brecent workflow maintainers\b/gi, "recent workflow contributors")
+    .replace(/\brecent workflow maintainer\b/gi, "recent workflow contributor")
+    .replace(/\brecent adjacent maintainers\b/gi, "recent adjacent contributors")
+    .replace(/\brecent adjacent maintainer\b/gi, "recent adjacent contributor")
+    .replace(/\brecent maintainers\b/gi, "recent area contributors")
+    .replace(/\brecent maintainer\b/gi, "recent area contributor");
+}
+
 function likelyOwnerLine(owner: LikelyOwner): string {
   const person = owner.person.trim() || "unknown";
-  const role = owner.role.trim();
+  const role = publicLikelyOwnerRole(owner.role);
   const reason = sentence(owner.reason.trim() || "Related by repository history.");
   const commits = owner.commits
     .map((commit) => commit.trim())
@@ -6200,7 +6211,7 @@ function markdownFor(options: {
   const likelyOwners = options.decision.likelyOwners.length
     ? options.decision.likelyOwners
         .map((owner) => {
-          const bits = [`- **${owner.person}:** ${owner.role}`];
+          const bits = [`- **${owner.person}:** ${publicLikelyOwnerRole(owner.role)}`];
           bits.push(`  - reason: ${owner.reason}`);
           bits.push(`  - confidence: ${owner.confidence}`);
           if (owner.commits.length) bits.push(`  - commits: ${owner.commits.join(", ")}`);

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -612,6 +612,8 @@ test("review actions only propose valid closes and never apply directly", () => 
   assert.match(action.closeComment, /Likely related people:/);
   assert.match(action.closeComment, /@alice/);
   assert.match(action.closeComment, /@bob/);
+  assert.doesNotMatch(action.closeComment, /role: recent maintainer/);
+  assert.match(action.closeComment, /role: recent area contributor/);
   assert.match(action.closeComment, /Codex review notes: model gpt-5\.5, reasoning high;/);
 });
 
@@ -1910,6 +1912,8 @@ Reason: Normal maintainer review is sufficient.
   assert.match(comment, /Needs attention:/);
   assert.match(comment, /Confirm issue write scope/);
   assert.match(comment, /Review details/);
+  assert.doesNotMatch(comment, /recent workflow maintainer/);
+  assert.match(comment, /recent workflow contributor/);
   assert.match(comment, /<!-- clawsweeper-security:security-sensitive item=74265 sha=abc123def456/);
   assert.match(comment, /<!-- clawsweeper-verdict:needs-human item=74265 sha=abc123def456/);
 });
@@ -3101,6 +3105,7 @@ test("review prompt routes PR likely owners through feature history", () => {
   assert.match(prompt, /git log --follow -- <file>/);
   assert.match(prompt, /do not list the PR author solely/);
   assert.match(prompt, /not to the PR\s+author merely for writing the proposal/);
+  assert.match(prompt, /Do\s+not use `maintainer` as a likely-owner role/);
   assert.match(prompt, /Do not include email\s+addresses in `likelyOwners`/);
   assert.match(prompt, /use names without email addresses/);
 });


### PR DESCRIPTION
## Summary

- Avoid ambiguous `maintainer` wording in public likely-owner roles unless official repository status is explicit.
- Normalize legacy/model-generated likely-owner roles such as `recent maintainer` to contributor-oriented wording in rendered comments and stored reports.
- Add regression coverage for close comments, PR review comments, and prompt guidance.

## Why

ClawSweeper likely-owner routing is based on git/history provenance. A role like `recent maintainer` can read as an official status claim even when the evidence only shows recent area ownership or contribution history.

## Bug proof

- In https://github.com/openclaw/openclaw/pull/70884#issuecomment-4323357445, ClawSweeper listed `@rubencu` under “Likely related people” with `role: recent maintainer`, even though the evidence was current-main blame/history rather than confirmed official maintainer status.

## Validation

- `pnpm run check` ran through build, lint, unit tests, repair tests, and coverage gates, then failed only at the final `format:check` step on upstream-only `scripts/build-docs-site.mjs`.
- `git diff origin/main -- scripts/build-docs-site.mjs` is empty.
- `pnpm exec oxfmt --check src/clawsweeper.ts test/clawsweeper.test.ts` passed.
