### PR TITLE
Label Telegram visible proof candidates

### DIFF
--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -92,6 +92,8 @@ For PRs, include a dedicated security review pass in addition to the functional 
 
 For PRs, include a dedicated `realBehaviorProof` assessment before any pass, automerge, or repair verdict. External PRs must show that the contributor ran the changed behavior after the fix in a real setup. Unit tests, mocks, snapshots, lint, typechecks, and CI are supplemental only; they are not real behavior proof by themselves. Treat screenshots, recordings, terminal screenshots, console output, copied live output, linked artifacts, and redacted runtime logs as valid proof, including for non-visual CLI, console, text, or error-message changes. Prefer asking for screenshots or videos when they can show the behavior, including terminal screenshots for text or console changes, while keeping logs and live output acceptable. Remind contributors to redact private information like IP addresses, API keys, phone numbers, non-public endpoints, and other private details before posting evidence. A plain app screenshot is sufficient only for behavior it directly shows. Do not mark screenshot-only proof sufficient for browser runtime, CSP, CORS, `connect-src`, auth callback, network, or security changes when the proof only says no console error, warning, or violation is visible; require console output, a network trace, terminal/live output, logs, a recording with diagnostics, or a linked artifact that actually shows the runtime path. Use your tools and best judgement: inspect the PR body, comments, links, screenshots, videos, logs, terminal output, and changed behavior context; you may download/open GitHub attachment links, generate stills or contact sheets from videos, inspect terminal screenshots and logs, and compare the proof against the PR diff. Use the provided scratch directory for downloaded artifacts and keep the target checkout read-only. Use `status: "sufficient"` only when the evidence convincingly shows after-fix real behavior and an observed improved result. Use `status: "missing"` when proof is absent, `status: "mock_only"` when proof is only tests/mocks/CI, `status: "insufficient"` when the evidence is unrelated, unviewable, too weak, or does not show the changed real behavior after the fix, `status: "override"` when the PR has `proof: override`, and `status: "not_applicable"` for non-PR items or maintainer/bot PRs where the gate does not apply. When proof is missing, mock-only, or insufficient, set `needsContributorAction: true`, make the PR a human-only merge blocker, and do not request ClawSweeper repair markers because automation cannot prove the contributor's setup for them.
 
+For PRs, always fill `telegramVisibleProof`. Use `status: "needed"` only when the PR touches Telegram behavior and the user-visible change can be easily demonstrated by the `telegram-crabbox-e2e-proof` skill, such as message formatting, slash-command output, reply text, attachments, reactions, threading, mentions, or other visible Telegram chat behavior. Use `status: "not_needed"` for non-Telegram PRs and for Telegram changes that are internal-only, test-only, docs-only, logging-only, retry/network reliability only, auth/secret plumbing only, or otherwise not meaningfully visible in a short Telegram Desktop recording.
+
 For PRs, also emit Codex `/review`-style findings in `reviewFindings`.
 Review the diff as another engineer's proposed patch and list every discrete,
 actionable bug the author would likely fix. Findings must be introduced by the
@@ -386,6 +388,12 @@ it does not, they can ask a maintainer to comment `@clawsweeper re-review`. Use
 `evidenceKind: "none"` when proof is absent or mock-only, and set
 `needsContributorAction: false` only for `sufficient`, `override`, or
 `not_applicable`.
+
+Always fill `telegramVisibleProof`. This only controls the
+`mantis: telegram-visible-proof` label. Mark it `needed` when a Telegram PR has
+visible chat behavior the `telegram-crabbox-e2e-proof` skill can show in a
+short recording. Mark it `not_needed` for non-Telegram PRs or Telegram work
+that is not usefully visible in that recording.
 
 Always fill the work-lane fields too. For non-candidates, use
 `workCandidate: "none"`, low confidence/priority, an empty `workPrompt`, and

--- a/schema/clawsweeper-decision.schema.json
+++ b/schema/clawsweeper-decision.schema.json
@@ -23,6 +23,7 @@
     "reviewFindings",
     "securityReview",
     "realBehaviorProof",
+    "telegramVisibleProof",
     "overallCorrectness",
     "overallConfidenceScore",
     "fixedRelease",
@@ -335,6 +336,22 @@
         "needsContributorAction": {
           "type": "boolean",
           "description": "True when the contributor must add or improve real behavior proof before merge. This must be false for sufficient, override, and not_applicable statuses."
+        }
+      }
+    },
+    "telegramVisibleProof": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "For Telegram PRs, classify whether the change is user-visible and easy to demonstrate with the telegram-crabbox-e2e-proof skill.",
+      "required": ["status", "summary"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["needed", "not_needed"]
+        },
+        "summary": {
+          "type": "string",
+          "description": "One concise sentence explaining why the PR should or should not receive the mantis: telegram-visible-proof label."
         }
       }
     },

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -100,6 +100,7 @@ type RealBehaviorProofEvidenceKind =
   | "linked_artifact"
   | "none"
   | "not_applicable";
+type TelegramVisibleProofStatus = "needed" | "not_needed";
 type CloseReason =
   | "implemented_on_main"
   | "mostly_implemented_on_main"
@@ -246,6 +247,11 @@ interface RealBehaviorProof {
   needsContributorAction: boolean;
 }
 
+interface TelegramVisibleProof {
+  status: TelegramVisibleProofStatus;
+  summary: string;
+}
+
 interface FixedPullRequest {
   repo: string;
   number: number;
@@ -278,6 +284,7 @@ interface Decision {
   reviewFindings: ReviewFinding[];
   securityReview: SecurityReview;
   realBehaviorProof: RealBehaviorProof;
+  telegramVisibleProof: TelegramVisibleProof;
   overallCorrectness: OverallCorrectness;
   overallConfidenceScore: number;
   fixedRelease?: string | null;
@@ -662,6 +669,9 @@ const AUTOMERGE_LABEL = "clawsweeper:automerge";
 const AUTOFIX_LABEL = "clawsweeper:autofix";
 const PROOF_OVERRIDE_LABEL = "proof: override";
 const PROOF_SUFFICIENT_LABEL = "proof: sufficient";
+const TELEGRAM_VISIBLE_PROOF_LABEL = "mantis: telegram-visible-proof";
+const TELEGRAM_VISIBLE_PROOF_LABEL_COLOR = "5319e7";
+const TELEGRAM_VISIBLE_PROOF_LABEL_DESCRIPTION = "Mantis should capture Telegram visible proof.";
 const PROTECTED_LABELS = new Set(["security", "beta-blocker", "release-blocker", "maintainer"]);
 const ALLOWED_REASONS = new Set<CloseReason>([
   "implemented_on_main",
@@ -719,6 +729,10 @@ const REAL_BEHAVIOR_PROOF_EVIDENCE_KINDS = new Set<RealBehaviorProofEvidenceKind
   "none",
   "not_applicable",
 ]);
+const TELEGRAM_VISIBLE_PROOF_STATUSES = new Set<TelegramVisibleProofStatus>([
+  "needed",
+  "not_needed",
+]);
 const OVERALL_CORRECTNESS_VALUES = new Set<OverallCorrectness>([
   "patch is correct",
   "patch is incorrect",
@@ -748,6 +762,7 @@ const DECISION_SCHEMA_KEYS = new Set([
   "reviewFindings",
   "securityReview",
   "realBehaviorProof",
+  "telegramVisibleProof",
   "overallCorrectness",
   "overallConfidenceScore",
   "fixedRelease",
@@ -771,6 +786,7 @@ const REAL_BEHAVIOR_PROOF_SCHEMA_KEYS = new Set([
   "evidenceKind",
   "needsContributorAction",
 ]);
+const TELEGRAM_VISIBLE_PROOF_SCHEMA_KEYS = new Set(["status", "summary"]);
 const SECURITY_CONCERN_SCHEMA_KEYS = new Set([
   "title",
   "body",
@@ -805,6 +821,7 @@ const REVIEW_SECTIONS = {
   reviewFindings: "Review Findings",
   securityReview: "Security Review",
   realBehaviorProof: "Real Behavior Proof",
+  telegramVisibleProof: "Telegram Visible Proof",
   workCandidate: "Work Candidate",
   repairWorkPrompt: "Repair Work Prompt",
   evidence: "Evidence",
@@ -1362,6 +1379,15 @@ function parseRealBehaviorProof(value: unknown, path: string): RealBehaviorProof
   };
 }
 
+function parseTelegramVisibleProof(value: unknown, path: string): TelegramVisibleProof {
+  const record = requireRecord(value, path);
+  rejectUnexpectedKeys(record, TELEGRAM_VISIBLE_PROOF_SCHEMA_KEYS, path);
+  return {
+    status: requireEnum(record.status, TELEGRAM_VISIBLE_PROOF_STATUSES, `${path}.status`),
+    summary: requireString(record.summary, `${path}.summary`),
+  };
+}
+
 function requireEnum<T extends string>(value: unknown, allowed: Set<T>, path: string): T {
   if (typeof value === "string" && allowed.has(value as T)) return value as T;
   throw new Error(`${path} has invalid value`);
@@ -1432,6 +1458,10 @@ export function parseDecision(value: unknown, item?: DecisionNormalizationItem):
     realBehaviorProof: parseRealBehaviorProof(
       record.realBehaviorProof,
       "decision.realBehaviorProof",
+    ),
+    telegramVisibleProof: parseTelegramVisibleProof(
+      record.telegramVisibleProof,
+      "decision.telegramVisibleProof",
     ),
     overallCorrectness: requireEnum(
       record.overallCorrectness,
@@ -3671,6 +3701,10 @@ function codexFailureDecision(status: number | null, stderr: string, stdout = ""
       evidenceKind: "not_applicable",
       needsContributorAction: false,
     },
+    telegramVisibleProof: {
+      status: "not_needed",
+      summary: "Telegram visible proof was not assessed because the Codex review failed.",
+    },
     overallCorrectness: "not a patch",
     overallConfidenceScore: 0,
     fixedRelease: null,
@@ -4777,6 +4811,20 @@ function reportRealBehaviorProof(markdown: string): RealBehaviorProof {
   });
 }
 
+function reportTelegramVisibleProof(markdown: string): TelegramVisibleProof {
+  const section = reviewSectionValue(markdown, "telegramVisibleProof");
+  const statusValue = sectionLineValue(section, "Status");
+  const status = TELEGRAM_VISIBLE_PROOF_STATUSES.has(statusValue as TelegramVisibleProofStatus)
+    ? (statusValue as TelegramVisibleProofStatus)
+    : "not_needed";
+  return {
+    status,
+    summary:
+      sectionLineValue(section, "Summary") ??
+      "No Telegram visible-proof assessment was recorded in this report.",
+  };
+}
+
 function screenshotProofNeedsRuntimeOutput(summary: string): boolean {
   if (
     /\b(?:no|without|absence of|zero|none)\b[^.]{0,120}\b(?:visible\s+)?(?:console|network|error|warning|violation|csp|cors)\b/i.test(
@@ -4831,6 +4879,67 @@ export function realBehaviorProofSufficientLabelsForTest(
     ? (status as RealBehaviorProofStatus)
     : "not_applicable";
   return nextRealBehaviorProofSufficientLabels(labels, { status: proofStatus });
+}
+
+function nextTelegramVisibleProofLabels(
+  labels: readonly string[],
+  proof: Pick<TelegramVisibleProof, "status">,
+): string[] {
+  const nextLabels = labels.filter((label) => label !== TELEGRAM_VISIBLE_PROOF_LABEL);
+  if (proof.status === "needed") nextLabels.push(TELEGRAM_VISIBLE_PROOF_LABEL);
+  return nextLabels;
+}
+
+export function telegramVisibleProofLabelsForTest(
+  labels: readonly string[],
+  status: string,
+): string[] {
+  const proofStatus = TELEGRAM_VISIBLE_PROOF_STATUSES.has(status as TelegramVisibleProofStatus)
+    ? (status as TelegramVisibleProofStatus)
+    : "not_needed";
+  return nextTelegramVisibleProofLabels(labels, { status: proofStatus });
+}
+
+function syncTelegramVisibleProofLabel(options: {
+  number: number;
+  labels: readonly string[];
+  proof: Pick<TelegramVisibleProof, "status">;
+  dryRun: boolean;
+}): string[] {
+  const nextLabels = nextTelegramVisibleProofLabels(options.labels, options.proof);
+  const hadLabel = options.labels.includes(TELEGRAM_VISIBLE_PROOF_LABEL);
+  const wantsLabel = nextLabels.includes(TELEGRAM_VISIBLE_PROOF_LABEL);
+  if (hadLabel === wantsLabel) return nextLabels;
+  if (options.dryRun) return nextLabels;
+  if (wantsLabel) ensureTelegramVisibleProofLabel();
+  ghWithRetry([
+    "issue",
+    "edit",
+    String(options.number),
+    wantsLabel ? "--add-label" : "--remove-label",
+    TELEGRAM_VISIBLE_PROOF_LABEL,
+  ]);
+  return nextLabels;
+}
+
+function ensureTelegramVisibleProofLabel(): void {
+  try {
+    ghWithRetry(
+      [
+        "label",
+        "create",
+        TELEGRAM_VISIBLE_PROOF_LABEL,
+        "--color",
+        TELEGRAM_VISIBLE_PROOF_LABEL_COLOR,
+        "--description",
+        TELEGRAM_VISIBLE_PROOF_LABEL_DESCRIPTION,
+      ],
+      2,
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!/already exists/i.test(message)) throw error;
+  }
 }
 
 function syncRealBehaviorProofSufficientLabel(options: {
@@ -5029,6 +5138,7 @@ function reportDecision(markdown: string, closeReason: CloseReason): Decision {
     reviewFindings: reportReviewFindings(markdown),
     securityReview: reportSecurityReview(markdown),
     realBehaviorProof: reportRealBehaviorProof(markdown),
+    telegramVisibleProof: reportTelegramVisibleProof(markdown),
     overallCorrectness: reportOverallCorrectness(markdown),
     overallConfidenceScore: reportOverallConfidenceScore(markdown),
     fixedRelease: fixedRelease && fixedRelease !== "unknown" ? fixedRelease : null,
@@ -6175,6 +6285,14 @@ function renderRealBehaviorProofReportSection(decision: Decision): string {
   ].join("\n");
 }
 
+function renderTelegramVisibleProofReportSection(decision: Decision): string {
+  return [
+    `Status: ${decision.telegramVisibleProof.status}`,
+    "",
+    `Summary: ${sentence(decision.telegramVisibleProof.summary)}`,
+  ].join("\n");
+}
+
 function markdownFor(options: {
   item: Item;
   context: ItemContext;
@@ -6227,6 +6345,7 @@ function markdownFor(options: {
   const reviewFindings = renderReviewFindingsReportSection(options.decision);
   const securityReview = renderSecurityReviewReportSection(options.decision);
   const realBehaviorProof = renderRealBehaviorProofReportSection(options.decision);
+  const telegramVisibleProof = renderTelegramVisibleProofReportSection(options.decision);
   const workCandidateSection = renderWorkCandidateReportSection(options.decision);
   const repairWorkPromptSection = renderRepairWorkPromptReportSection(options.decision);
   return `---
@@ -6298,6 +6417,7 @@ requires_product_decision: ${options.decision.requiresProductDecision}
 real_behavior_proof_status: ${options.decision.realBehaviorProof.status}
 real_behavior_proof_evidence_kind: ${options.decision.realBehaviorProof.evidenceKind}
 real_behavior_proof_needs_contributor_action: ${options.decision.realBehaviorProof.needsContributorAction}
+telegram_visible_proof_status: ${options.decision.telegramVisibleProof.status}
 ---
 
 # ${markdownLink(`#${options.item.number}: ${options.item.title}`, options.item.url)}
@@ -6367,6 +6487,10 @@ ${securityReview}
 ## ${REVIEW_SECTIONS.realBehaviorProof}
 
 ${realBehaviorProof}
+
+## ${REVIEW_SECTIONS.telegramVisibleProof}
+
+${telegramVisibleProof}
 
 ## ${REVIEW_SECTIONS.workCandidate}
 
@@ -6775,6 +6899,12 @@ function applyDecisionsCommand(args: Args): void {
         number,
         labels: item.labels,
         proof: reportRealBehaviorProof(markdown),
+        dryRun,
+      });
+      item.labels = syncTelegramVisibleProofLabel({
+        number,
+        labels: item.labels,
+        proof: reportTelegramVisibleProof(markdown),
         dryRun,
       });
     }

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -63,6 +63,7 @@ import {
   shouldReviewItem,
   shouldRetryGh,
   shouldPlanItem,
+  telegramVisibleProofLabelsForTest,
   validateCloseDecision,
 } from "../dist/clawsweeper.js";
 import { checkConclusionForFrontMatter } from "../dist/commit-checks.js";
@@ -165,6 +166,10 @@ function closeDecision(overrides = {}) {
       summary: "Real behavior proof is not required for non-PR issue triage.",
       evidenceKind: "not_applicable",
       needsContributorAction: false,
+    },
+    telegramVisibleProof: {
+      status: "not_needed",
+      summary: "This non-PR issue triage does not need Telegram visible proof.",
     },
     overallCorrectness: "not a patch",
     overallConfidenceScore: 0.75,
@@ -3148,6 +3153,15 @@ test("review prompt requires real behavior proof for PR reviews", () => {
   assert.match(prompt, /do not request ClawSweeper repair markers/);
 });
 
+test("review prompt classifies Telegram visible proof candidates", () => {
+  const prompt = readFileSync("prompts/review-item.md", "utf8");
+
+  assert.match(prompt, /telegramVisibleProof/);
+  assert.match(prompt, /telegram-crabbox-e2e-proof/);
+  assert.match(prompt, /message formatting/);
+  assert.match(prompt, /mantis: telegram-visible-proof/);
+});
+
 test("ClawSweeper proof judgement controls the sufficient proof label", () => {
   assert.deepEqual(realBehaviorProofSufficientLabelsForTest(["proof: supplied"], "sufficient"), [
     "proof: supplied",
@@ -3161,6 +3175,20 @@ test("ClawSweeper proof judgement controls the sufficient proof label", () => {
     ["proof: supplied"],
   );
   assert.deepEqual(realBehaviorProofSufficientLabelsForTest(["proof: sufficient"], "missing"), []);
+});
+
+test("ClawSweeper Telegram proof judgement controls the Mantis proof label", () => {
+  assert.deepEqual(telegramVisibleProofLabelsForTest(["channel: telegram"], "needed"), [
+    "channel: telegram",
+    "mantis: telegram-visible-proof",
+  ]);
+  assert.deepEqual(
+    telegramVisibleProofLabelsForTest(
+      ["channel: telegram", "mantis: telegram-visible-proof"],
+      "not_needed",
+    ),
+    ["channel: telegram"],
+  );
 });
 
 test("review workflow gives Codex a read-only inspection token", () => {


### PR DESCRIPTION
Summary:
- add a tiny `telegramVisibleProof` review decision for Telegram PRs whose visible chat behavior can be shown by `telegram-crabbox-e2e-proof`
- sync that decision to `mantis: telegram-visible-proof`, creating the label on first use
- cover the prompt and label-sync behavior in tests

Verification:
- `pnpm run build && node --test test/clawsweeper.test.ts`
- `pnpm run check`
