### PR TITLE
Phase 1: sync advisory issue labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ checkpoint, and status-only commits are intentionally omitted.
   missing-info, product-decision, and security-review routing states, projected
   from existing review report fields without changing repair, merge, or close
   behavior. Label-only syncs now record `labels_synced_at` so scheduler cadence
-  ignores ClawSweeper-owned label `updated_at` churn.
+  ignores ClawSweeper-owned label `updated_at` churn. Thanks @brokemac79.
 - Added `config/automation-limits.json` plus docs and a drift check so review,
   commit-review, repair, and issue-implementation capacity defaults have one
   checked-in source of truth.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ checkpoint, and status-only commits are intentionally omitted.
 - Added a light privacy reminder and stronger screenshot-or-video nudge to real behavior proof review guidance.
 - Added agent-led real behavior proof judgement so ClawSweeper can inspect linked screenshots, videos, logs, and terminal output with a read-only GitHub token, explain the proof verdict in the review comment, tell contributors how to trigger a fresh review after adding proof, and sync `proof: sufficient` when the evidence is convincing.
 - Added a real behavior proof assessment to PR reviews so missing, mock-only, or insufficient contributor proof blocks pass/automerge markers and asks for screenshots, terminal output, redacted logs, recordings, linked artifacts, or copied live output instead.
+- Added advisory issue labels for reproduction, linked-PR, work-lane,
+  missing-info, product-decision, and security-review routing states, projected
+  from existing review report fields without changing repair, merge, or close
+  behavior. Label-only syncs now record `labels_synced_at` so scheduler cadence
+  ignores ClawSweeper-owned label `updated_at` churn.
 - Added `config/automation-limits.json` plus docs and a drift check so review,
   commit-review, repair, and issue-implementation capacity defaults have one
   checked-in source of truth.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ hidden verdict/action markers so trusted repair and automerge flows can continue
 without scraping visible prose. See
 [`docs/pr-review-comments.md`](docs/pr-review-comments.md).
 
+For open issues with complete, current kept-open reviews, ClawSweeper also
+projects selected structured review conclusions into advisory GitHub labels for
+maintainer filtering and project views. These labels expose states such as
+current-main reproduction, source reproduction, linked open PRs, queueable
+fixes, missing info, and product/security review needs. They are advisory only
+and do not trigger repair, merge, or close behavior. Label-only syncs record
+`labels_synced_at` in the durable report so GitHub `updated_at` changes caused
+by ClawSweeper-owned label writes do not look like fresh target-side activity to
+the scheduler. See
+[`docs/work-lane.md`](docs/work-lane.md).
+
 ### Apply and State
 
 Apply mode re-fetches live GitHub state, checks labels, maintainer authorship,

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -298,6 +298,13 @@ Review cadence:
 - older inactive issues: weekly
 - review policy hash changes: due immediately
 
+The activity check ignores ClawSweeper-owned GitHub mutations that are already
+recorded in durable report frontmatter. `review_comment_synced_at` covers public
+review comment writes, and `labels_synced_at` covers ClawSweeper label-only
+writes such as priority or advisory issue-label syncs. If GitHub `updated_at` is
+at or before either marker, the planner does not treat it as fresh reporter or
+maintainer activity.
+
 Selection uses weighted buckets so hot issues cannot starve pull requests and
 older issue backlog forever. The normal scheduler cycles through:
 

--- a/docs/work-lane.md
+++ b/docs/work-lane.md
@@ -23,6 +23,43 @@ dashboard links both the source report and the generated coding plan so
 maintainers can promote from a concise implementation view without editing the
 durable report.
 
+For open issues with complete, current kept-open reviews, apply/comment-sync
+also projects a small owned set of advisory GitHub labels from the same
+structured fields. Comments explain the evidence; labels expose routing state
+for GitHub issue lists, searches, and project views. These labels do not
+dispatch repair, merge, or close work, and they do not replace maintainer-owned
+action labels such as `clawsweeper:autofix` or `clawsweeper:automerge`.
+Failed or stale reports are skipped so outdated review conclusions do not mutate
+live issue labels.
+Close proposals are not label-mutated during apply, so advisory label writes do
+not advance an issue's `updated_at` before close eligibility gates have finished.
+When ClawSweeper does sync labels, the report frontmatter records
+`labels_synced_at`. The scheduler treats `updated_at` values up to that timestamp
+as ClawSweeper-owned churn, similar to durable review comment syncs, so a
+label-only apply pass does not immediately queue another review of the same item.
+
+| Label                                 | Source condition                                                                                                              |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `clawsweeper:current-main-repro`      | `type: issue`, `reproduction_status: reproduced`, and `reproduction_confidence: high`                                         |
+| `clawsweeper:source-repro`            | `type: issue`, `reproduction_status: source_reproducible`, and `reproduction_confidence: high`                                |
+| `clawsweeper:not-repro-on-main`       | `type: issue`, `reproduction_status: not_reproduced`, and `reproduction_confidence: high`                                     |
+| `clawsweeper:needs-live-repro`        | `type: issue`, `reproduction_status: source_reproducible`, and reproduction confidence below high                             |
+| `clawsweeper:needs-info`              | `type: issue`, `reproduction_status: unclear`, and reproduction confidence below high                                         |
+| `clawsweeper:linked-pr-open`          | the live issue has an open GitHub closing-PR reference                                                                        |
+| `clawsweeper:no-new-fix-pr`           | an open linked PR, manual-review lane, product decision, or security review means a new automated fix PR should not be queued |
+| `clawsweeper:queueable-fix`           | `work_candidate: queue_fix_pr`, `work_status: candidate`, and `work_confidence: high`                                         |
+| `clawsweeper:fix-shape-clear`         | high-confidence `queue_fix_pr` or `manual_review` work includes a repair prompt, likely files, or validation                  |
+| `clawsweeper:needs-maintainer-review` | `work_candidate: manual_review` or `work_status: manual_review`                                                               |
+| `clawsweeper:needs-product-decision`  | `requires_product_decision: true`                                                                                             |
+| `clawsweeper:needs-security-review`   | `item_category: security` or a `securityReview` status of `needs_attention`                                                   |
+
+The advisory-label sync owns only this label group. Reruns add labels that match
+the latest report, remove stale labels from this group, and preserve unrelated
+labels plus action/proof labels such as `clawsweeper:autofix`,
+`clawsweeper:automerge`, `clawsweeper:human-review`,
+`clawsweeper:merge-ready`, `proof: sufficient`, and
+`mantis: telegram-visible-proof`.
+
 Plan artifacts are generated state. They are removed when the item closes,
 archives, becomes stale, or is reclassified away from `queue_fix_pr`; regenerate
 them from the source report instead of editing them by hand.

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "check:active-surface": "node scripts/check-active-surface.ts",
     "check:limits": "node scripts/check-limits.ts",
     "lint": "pnpm run lint:src && pnpm run lint:repair && pnpm run lint:scripts",
-    "lint:src": "oxlint src/*.ts --tsconfig tsconfig.json --type-aware --deny-warnings --report-unused-disable-directives -D correctness",
+    "lint:src": "oxlint src --ignore-pattern \"src/repair/**\" --tsconfig tsconfig.json --type-aware --deny-warnings --report-unused-disable-directives -D correctness",
     "lint:repair": "oxlint src/repair --tsconfig tsconfig.repair.json --deny-warnings --report-unused-disable-directives -D correctness",
     "lint:scripts": "oxlint scripts test --deny-warnings --report-unused-disable-directives -D correctness",
     "format": "oxfmt --write src scripts test package.json tsconfig.json tsconfig.repair.json .oxfmtrc.json config schema .github/actions .github/workflows",

--- a/scripts/check-active-surface.ts
+++ b/scripts/check-active-surface.ts
@@ -90,7 +90,8 @@ function scan(absolute: string): void {
   }
   if (!stat.isFile() || !isTextFile(absolute)) return;
   const relative = path.relative(root, absolute);
-  if (relative === "scripts/check-active-surface.ts") return;
+  const canonicalRelative = relative.split(path.sep).join("/");
+  if (canonicalRelative === "scripts/check-active-surface.ts") return;
   const text = fs.readFileSync(absolute, "utf8");
   const lines = text.split(/\r?\n/);
   lines.forEach((line, index) => {
@@ -98,7 +99,7 @@ function scan(absolute: string): void {
       const match = retired.pattern.exec(line);
       if (!match) continue;
       findings.push({
-        file: relative,
+        file: canonicalRelative,
         line: index + 1,
         column: match.index + 1,
         label: retired.label,

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -180,6 +180,7 @@ interface ExistingReview {
   reviewedAt: string | undefined;
   itemUpdatedAt: string | undefined;
   reviewCommentSyncedAt: string | undefined;
+  labelsSyncedAt: string | undefined;
   decision: string | undefined;
   reviewStatus: string | undefined;
   reviewPolicy: string | undefined;
@@ -713,6 +714,73 @@ const PRIORITY_LABELS = [
 ] as const;
 const PRIORITY_LABEL_NAMES: ReadonlySet<string> = new Set(
   PRIORITY_LABELS.map((label) => label.name),
+);
+const ISSUE_ADVISORY_LABELS = [
+  {
+    name: "clawsweeper:current-main-repro",
+    color: "1D76DB",
+    description: "ClawSweeper found a high-confidence current-main issue reproduction.",
+  },
+  {
+    name: "clawsweeper:source-repro",
+    color: "1D76DB",
+    description: "ClawSweeper found a high-confidence source-level issue reproduction.",
+  },
+  {
+    name: "clawsweeper:not-repro-on-main",
+    color: "C2E0C6",
+    description:
+      "ClawSweeper found high-confidence evidence that this issue no longer reproduces on main.",
+  },
+  {
+    name: "clawsweeper:needs-live-repro",
+    color: "FBCA04",
+    description:
+      "ClawSweeper needs live local, crabbox, or manual validation to confirm this issue.",
+  },
+  {
+    name: "clawsweeper:needs-info",
+    color: "D876E3",
+    description: "ClawSweeper needs more reporter information before it can verify this issue.",
+  },
+  {
+    name: "clawsweeper:linked-pr-open",
+    color: "5319E7",
+    description: "ClawSweeper found an open linked pull request for this issue.",
+  },
+  {
+    name: "clawsweeper:no-new-fix-pr",
+    color: "BFDADC",
+    description: "ClawSweeper does not recommend queueing a new automated fix PR for this issue.",
+  },
+  {
+    name: "clawsweeper:queueable-fix",
+    color: "0E8A16",
+    description: "ClawSweeper marked this issue as an existing queue_fix_pr work candidate.",
+  },
+  {
+    name: "clawsweeper:fix-shape-clear",
+    color: "0E8A16",
+    description: "ClawSweeper found a clear likely implementation shape for this issue.",
+  },
+  {
+    name: "clawsweeper:needs-maintainer-review",
+    color: "FBCA04",
+    description: "ClawSweeper marked this issue as needing maintainer review before automation.",
+  },
+  {
+    name: "clawsweeper:needs-product-decision",
+    color: "FBCA04",
+    description: "ClawSweeper marked this issue as needing a product or behavior decision.",
+  },
+  {
+    name: "clawsweeper:needs-security-review",
+    color: "B60205",
+    description: "ClawSweeper marked this issue as needing security-sensitive review.",
+  },
+] as const;
+const ISSUE_ADVISORY_LABEL_NAMES = new Set(
+  ISSUE_ADVISORY_LABELS.map((label) => label.name.toLowerCase()),
 );
 const PROTECTED_LABELS = new Set(["security", "beta-blocker", "release-blocker", "maintainer"]);
 const ALLOWED_REASONS = new Set<CloseReason>([
@@ -2459,6 +2527,7 @@ function existingReview(
     reviewedAt: frontMatterValue(markdown, "reviewed_at"),
     itemUpdatedAt: frontMatterValue(markdown, "item_updated_at"),
     reviewCommentSyncedAt: frontMatterValue(markdown, "review_comment_synced_at"),
+    labelsSyncedAt: frontMatterValue(markdown, "labels_synced_at"),
     decision: frontMatterValue(markdown, "decision"),
     reviewStatus: effectiveReviewStatus(markdown),
     reviewPolicy: frontMatterValue(markdown, "review_policy"),
@@ -2486,6 +2555,7 @@ function buildExistingReviewIndex(itemsDir: string): ExistingReviewIndex {
       reviewedAt: frontMatterValue(markdown, "reviewed_at"),
       itemUpdatedAt: frontMatterValue(markdown, "item_updated_at"),
       reviewCommentSyncedAt: frontMatterValue(markdown, "review_comment_synced_at"),
+      labelsSyncedAt: frontMatterValue(markdown, "labels_synced_at"),
       decision: frontMatterValue(markdown, "decision"),
       reviewStatus: effectiveReviewStatus(markdown),
       reviewPolicy: frontMatterValue(markdown, "review_policy"),
@@ -2563,13 +2633,18 @@ function hasActivitySinceReview(item: Item, review: ExistingReview | null): bool
   const updatedAt = Date.parse(item.updatedAt);
   const reviewedAt = reviewedAtMs(review);
   const reviewCommentSyncedAt = timestampMs(review.reviewCommentSyncedAt);
+  const labelsSyncedAt = timestampMs(review.labelsSyncedAt);
+  const botOwnedSyncedAt = Math.max(
+    reviewCommentSyncedAt ?? -Infinity,
+    labelsSyncedAt ?? -Infinity,
+  );
   if (review.itemUpdatedAt) {
     if (item.updatedAt === review.itemUpdatedAt) return false;
     if (Number.isFinite(updatedAt) && reviewedAt !== null && updatedAt <= reviewedAt) return false;
     if (
       Number.isFinite(updatedAt) &&
-      reviewCommentSyncedAt !== null &&
-      updatedAt <= reviewCommentSyncedAt
+      Number.isFinite(botOwnedSyncedAt) &&
+      updatedAt <= botOwnedSyncedAt
     ) {
       return false;
     }
@@ -2577,8 +2652,8 @@ function hasActivitySinceReview(item: Item, review: ExistingReview | null): bool
   }
   if (
     Number.isFinite(updatedAt) &&
-    reviewCommentSyncedAt !== null &&
-    updatedAt <= reviewCommentSyncedAt
+    Number.isFinite(botOwnedSyncedAt) &&
+    updatedAt <= botOwnedSyncedAt
   ) {
     return false;
   }
@@ -5135,12 +5210,161 @@ function ensurePriorityLabel(label: PriorityLabelSpec): void {
   }
 }
 
+interface IssueAdvisoryLabelState {
+  type: string | undefined;
+  itemCategory: string | undefined;
+  reproductionStatus: string | undefined;
+  reproductionConfidence: string | undefined;
+  requiresProductDecision: boolean;
+  securityReviewStatus: string | undefined;
+  workCandidate: string | undefined;
+  workStatus: string | undefined;
+  workConfidence: string | undefined;
+  hasWorkShape: boolean;
+  hasOpenLinkedPullRequest: boolean;
+}
+
+function isIssueAdvisoryLabel(label: string): boolean {
+  return ISSUE_ADVISORY_LABEL_NAMES.has(label.toLowerCase());
+}
+
+function wantedIssueAdvisoryLabels(state: IssueAdvisoryLabelState): Set<string> {
+  const labels = new Set<string>();
+  if (state.type !== "issue") return labels;
+  if (state.reproductionConfidence === "high") {
+    if (state.reproductionStatus === "reproduced") labels.add("clawsweeper:current-main-repro");
+    if (state.reproductionStatus === "source_reproducible") labels.add("clawsweeper:source-repro");
+    if (state.reproductionStatus === "not_reproduced") labels.add("clawsweeper:not-repro-on-main");
+  }
+  if (
+    state.reproductionStatus === "source_reproducible" &&
+    state.reproductionConfidence !== "high"
+  ) {
+    labels.add("clawsweeper:needs-live-repro");
+  }
+  if (state.reproductionStatus === "unclear" && state.reproductionConfidence !== "high") {
+    labels.add("clawsweeper:needs-info");
+  }
+  if (state.hasOpenLinkedPullRequest) {
+    labels.add("clawsweeper:linked-pr-open");
+  }
+  if (
+    state.workCandidate === "queue_fix_pr" &&
+    state.workStatus === "candidate" &&
+    state.workConfidence === "high"
+  ) {
+    labels.add("clawsweeper:queueable-fix");
+  }
+  if (
+    state.workConfidence === "high" &&
+    state.hasWorkShape &&
+    (state.workCandidate === "queue_fix_pr" || state.workCandidate === "manual_review")
+  ) {
+    labels.add("clawsweeper:fix-shape-clear");
+  }
+  if (state.workCandidate === "manual_review" || state.workStatus === "manual_review") {
+    labels.add("clawsweeper:needs-maintainer-review");
+  }
+  if (state.requiresProductDecision) {
+    labels.add("clawsweeper:needs-product-decision");
+  }
+  if (state.itemCategory === "security" || state.securityReviewStatus === "needs_attention") {
+    labels.add("clawsweeper:needs-security-review");
+  }
+  if (
+    state.hasOpenLinkedPullRequest ||
+    state.workCandidate === "manual_review" ||
+    state.workStatus === "manual_review" ||
+    state.requiresProductDecision ||
+    state.itemCategory === "security" ||
+    state.securityReviewStatus === "needs_attention"
+  ) {
+    labels.add("clawsweeper:no-new-fix-pr");
+  }
+  return labels;
+}
+
+function nextIssueAdvisoryLabels(
+  labels: readonly string[],
+  state: IssueAdvisoryLabelState,
+): string[] {
+  const wantedLabels = wantedIssueAdvisoryLabels(state);
+  const nextLabels = labels.filter((label) => !isIssueAdvisoryLabel(label));
+  for (const label of ISSUE_ADVISORY_LABELS) {
+    if (wantedLabels.has(label.name)) nextLabels.push(label.name);
+  }
+  return nextLabels;
+}
+
+export function issueAdvisoryLabelsForTest(
+  labels: readonly string[],
+  state: Partial<IssueAdvisoryLabelState>,
+): string[] {
+  return nextIssueAdvisoryLabels(labels, {
+    type: state.type,
+    itemCategory: state.itemCategory,
+    reproductionStatus: state.reproductionStatus,
+    reproductionConfidence: state.reproductionConfidence,
+    requiresProductDecision: state.requiresProductDecision ?? false,
+    securityReviewStatus: state.securityReviewStatus,
+    workCandidate: state.workCandidate,
+    workStatus: state.workStatus,
+    workConfidence: state.workConfidence,
+    hasWorkShape: state.hasWorkShape ?? false,
+    hasOpenLinkedPullRequest: state.hasOpenLinkedPullRequest ?? false,
+  });
+}
+
+function issueAdvisoryLabelStateFromReport(
+  markdown: string,
+  options: { hasOpenLinkedPullRequest?: boolean } = {},
+): IssueAdvisoryLabelState {
+  const workLikelyFiles = frontMatterStringArray(markdown, "work_likely_files");
+  const workValidation = frontMatterStringArray(markdown, "work_validation");
+  const workPrompt = reviewSectionValue(markdown, "repairWorkPrompt").trim();
+  return {
+    type: frontMatterValue(markdown, "type"),
+    itemCategory: frontMatterValue(markdown, "item_category"),
+    reproductionStatus: frontMatterValue(markdown, "reproduction_status"),
+    reproductionConfidence: frontMatterValue(markdown, "reproduction_confidence"),
+    requiresProductDecision: frontMatterValue(markdown, "requires_product_decision") === "true",
+    securityReviewStatus: reportSecurityReview(markdown).status,
+    workCandidate: frontMatterValue(markdown, "work_candidate"),
+    workStatus: frontMatterValue(markdown, "work_status"),
+    workConfidence: frontMatterValue(markdown, "work_confidence"),
+    hasWorkShape: Boolean(workPrompt || workLikelyFiles.length || workValidation.length),
+    hasOpenLinkedPullRequest: options.hasOpenLinkedPullRequest === true,
+  };
+}
+
+function ensureIssueAdvisoryLabel(name: string): void {
+  const definition = ISSUE_ADVISORY_LABELS.find((label) => label.name === name);
+  if (!definition) return;
+  try {
+    ghWithRetry(
+      [
+        "label",
+        "create",
+        definition.name,
+        "--color",
+        definition.color,
+        "--description",
+        definition.description,
+      ],
+      2,
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!/already exists/i.test(message)) throw error;
+  }
+}
+
 function syncPriorityLabel(options: {
   number: number;
   labels: readonly string[];
   triagePriority: TriagePriority;
   dryRun: boolean;
-}): string[] {
+}): { labels: string[]; changed: boolean } {
   const nextLabels = nextPriorityLabels(options.labels, options.triagePriority);
   const labelsToRemove = options.labels.filter(
     (label) => PRIORITY_LABEL_NAMES.has(label) && !nextLabels.includes(label),
@@ -5148,8 +5372,9 @@ function syncPriorityLabel(options: {
   const labelToAdd = nextLabels.find(
     (label) => PRIORITY_LABEL_NAMES.has(label) && !options.labels.includes(label),
   );
-  if (labelsToRemove.length === 0 && !labelToAdd) return nextLabels;
-  if (options.dryRun) return nextLabels;
+  const changed = labelsToRemove.length > 0 || Boolean(labelToAdd);
+  if (!changed) return { labels: nextLabels, changed };
+  if (options.dryRun) return { labels: nextLabels, changed };
   if (labelToAdd) {
     const priorityLabel = PRIORITY_LABELS.find((label) => label.name === labelToAdd);
     if (priorityLabel) ensurePriorityLabel(priorityLabel);
@@ -5160,7 +5385,35 @@ function syncPriorityLabel(options: {
   if (labelToAdd) {
     ghWithRetry(["issue", "edit", String(options.number), "--add-label", labelToAdd]);
   }
-  return nextLabels;
+  return { labels: nextLabels, changed };
+}
+
+function syncIssueAdvisoryLabels(options: {
+  number: number;
+  labels: readonly string[];
+  state: IssueAdvisoryLabelState;
+  dryRun: boolean;
+}): { labels: string[]; changed: boolean } {
+  const nextLabels = nextIssueAdvisoryLabels(options.labels, options.state);
+  const currentLabelKeys = new Set(options.labels.map((label) => label.toLowerCase()));
+  const nextLabelKeys = new Set(nextLabels.map((label) => label.toLowerCase()));
+  const labelsToAdd = nextLabels.filter(
+    (label) => isIssueAdvisoryLabel(label) && !currentLabelKeys.has(label.toLowerCase()),
+  );
+  const labelsToRemove = options.labels.filter(
+    (label) => isIssueAdvisoryLabel(label) && !nextLabelKeys.has(label.toLowerCase()),
+  );
+  const changed = labelsToAdd.length > 0 || labelsToRemove.length > 0;
+  if (!changed) return { labels: nextLabels, changed };
+  if (options.dryRun) return { labels: nextLabels, changed };
+  for (const label of labelsToAdd) {
+    ensureIssueAdvisoryLabel(label);
+    ghWithRetry(["issue", "edit", String(options.number), "--add-label", label]);
+  }
+  for (const label of labelsToRemove) {
+    ghWithRetry(["issue", "edit", String(options.number), "--remove-label", label]);
+  }
+  return { labels: nextLabels, changed };
 }
 
 function syncTelegramVisibleProofLabel(options: {
@@ -7234,6 +7487,9 @@ function applyDecisionsCommand(args: Args): void {
     }
     const { item, state } = fetchItem(number);
     let currentContext: ItemContext | undefined;
+    let currentClosingPullRequests: unknown[] | undefined;
+    let clawSweeperLabelsChanged = false;
+    let issueAdvisoryLabelsChanged = false;
     const currentItemContext = (): ItemContext => {
       currentContext ??= collectItemContext(item);
       return currentContext;
@@ -7256,14 +7512,6 @@ function applyDecisionsCommand(args: Args): void {
         number,
         labels: item.labels,
         proof: reportTelegramVisibleProof(markdown),
-        dryRun,
-      });
-    }
-    if (state === "open") {
-      item.labels = syncPriorityLabel({
-        number,
-        labels: item.labels,
-        triagePriority: triagePriorityFromReport(markdown),
         dryRun,
       });
     }
@@ -7309,6 +7557,9 @@ function applyDecisionsCommand(args: Args): void {
     }
     const updatedSinceReview = Boolean(storedUpdatedAt && item.updatedAt !== storedUpdatedAt);
     const reviewCommentOnlyUpdate = item.updatedAt === commentUpdatedAt(existingReviewComment);
+    const unchangedSinceReview = storedUpdatedAt
+      ? !updatedSinceReview || reviewCommentOnlyUpdate
+      : false;
     if (state !== "open") {
       if (item.closedAt) {
         markdown = replaceFrontMatterValue(markdown, "current_item_closed_at", item.closedAt);
@@ -7383,9 +7634,39 @@ function applyDecisionsCommand(args: Args): void {
         continue;
       }
     }
+    const isCurrentCompleteReport =
+      frontMatterValue(markdown, "review_status") === "complete" && unchangedSinceReview;
+    if (state === "open" && isCurrentCompleteReport) {
+      const syncResult = syncPriorityLabel({
+        number,
+        labels: item.labels,
+        triagePriority: triagePriorityFromReport(markdown),
+        dryRun,
+      });
+      item.labels = syncResult.labels;
+      clawSweeperLabelsChanged ||= syncResult.changed;
+      markdown = replaceFrontMatterValue(markdown, "labels", JSON.stringify(item.labels));
+    }
+    if (state === "open" && item.kind === "issue" && !isCloseProposal && isCurrentCompleteReport) {
+      currentClosingPullRequests = closingPullRequestsForIssue(number);
+      const syncResult = syncIssueAdvisoryLabels({
+        number,
+        labels: item.labels,
+        state: issueAdvisoryLabelStateFromReport(markdown, {
+          hasOpenLinkedPullRequest:
+            openClosingPullRequestApplyReason(currentClosingPullRequests) !== null,
+        }),
+        dryRun,
+      });
+      item.labels = syncResult.labels;
+      issueAdvisoryLabelsChanged = syncResult.changed;
+      clawSweeperLabelsChanged ||= syncResult.changed;
+      markdown = replaceFrontMatterValue(markdown, "labels", JSON.stringify(item.labels));
+    }
     if (isCloseProposal && item.kind === "issue") {
+      currentClosingPullRequests ??= closingPullRequestsForIssue(number);
       const openClosingPullRequestReason = openClosingPullRequestApplyReason(
-        closingPullRequestsForIssue(number),
+        currentClosingPullRequests,
       );
       if (openClosingPullRequestReason) {
         if (markApplySkipped("skipped_open_closing_pr", openClosingPullRequestReason)) break;
@@ -7423,6 +7704,19 @@ function applyDecisionsCommand(args: Args): void {
       needsReviewCommentHashSync,
       needsReviewCommentReferenceSync,
     });
+    if (clawSweeperLabelsChanged && !dryRun) {
+      markdown = replaceFrontMatterValue(markdown, "labels_synced_at", new Date().toISOString());
+    }
+    const labelSyncReason = issueAdvisoryLabelsChanged
+      ? dryRun
+        ? "dry-run: would sync advisory issue labels"
+        : "synced advisory issue labels"
+      : dryRun
+        ? "dry-run: would sync ClawSweeper labels"
+        : "synced ClawSweeper labels";
+    const labelSyncProgressMessage = issueAdvisoryLabelsChanged
+      ? `synced advisory issue labels #${number}`
+      : `synced ClawSweeper labels #${number}`;
     if (needsReviewCommentSync) {
       const lockedReason = needsReviewCommentBodySync ? lockedConversationApplyReason(item) : null;
       if (lockedReason) {
@@ -7463,6 +7757,21 @@ function applyDecisionsCommand(args: Args): void {
       });
       processedCount += 1;
       maybeLogProgress(`synced review comment #${number}`);
+      if (processedCount >= processedLimit) break;
+    }
+    if (
+      clawSweeperLabelsChanged &&
+      !needsReviewCommentSync &&
+      (!isCloseProposal || syncCommentsOnly)
+    ) {
+      if (!dryRun) writeFileSync(path, markdown, "utf8");
+      results.push({
+        number,
+        action: "kept_open",
+        reason: labelSyncReason,
+      });
+      processedCount += 1;
+      maybeLogProgress(labelSyncProgressMessage);
       if (processedCount >= processedLimit) break;
     }
     if (syncCommentsOnly) continue;

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -684,32 +684,28 @@ const PRIORITY_LABELS = [
     triagePriority: "P0",
     name: "P0",
     color: "B60205",
-    description:
-      "Critical: production-breaking, data-loss, security-impacting, or blocks core project operation; needs immediate maintainer attention.",
+    description: "Critical impact; needs immediate maintainer attention.",
   },
   {
     priority: 1,
     triagePriority: "P1",
     name: "P1",
     color: "D93F0B",
-    description:
-      "High: important user-facing bug, serious regression, broken major workflow, or urgent maintainer-priority work; should be handled soon.",
+    description: "High-priority user-facing bug, regression, or broken workflow.",
   },
   {
     priority: 2,
     triagePriority: "P2",
     name: "P2",
     color: "FBCA04",
-    description:
-      "Medium: meaningful bug, incomplete behavior, polish issue, or useful improvement with limited blast radius; normal backlog priority.",
+    description: "Normal backlog priority with limited blast radius.",
   },
   {
     priority: 3,
     triagePriority: "P3",
     name: "P3",
     color: "0E8A16",
-    description:
-      "Low: minor cleanup, documentation, cosmetic polish, small ergonomics issue, or speculative improvement; handle when convenient.",
+    description: "Low-priority cleanup, docs, polish, ergonomics, or speculative work.",
   },
 ] as const;
 const PRIORITY_LABEL_NAMES: ReadonlySet<string> = new Set(

--- a/src/command.ts
+++ b/src/command.ts
@@ -19,7 +19,8 @@ export function runText(
     trim = "end",
   }: RunTextOptions = {},
 ): string {
-  const text = execFileSync(resolveExecutable(command), args, {
+  const resolved = resolveCommand(command, args);
+  const text = execFileSync(resolved.command, resolved.args, {
     cwd,
     encoding: "utf8",
     env: { ...process.env, GIT_OPTIONAL_LOCKS: "0", ...env },
@@ -31,6 +32,26 @@ export function runText(
   return text;
 }
 
+function resolveCommand(command: string, args: string[]): { command: string; args: string[] } {
+  if (command === "gh" && process.env.GH_BIN) {
+    return {
+      command: process.env.GH_BIN,
+      args: [...envArgs("GH_BIN_ARGS"), ...args],
+    };
+  }
+  return { command: resolveExecutable(command), args };
+}
+
 function resolveExecutable(command: string): string {
   return command === "git" ? (process.env.GIT_BIN ?? "/usr/bin/git") : command;
+}
+
+function envArgs(name: string): string[] {
+  const value = process.env[name];
+  if (!value) return [];
+  const parsed = JSON.parse(value) as unknown;
+  if (!Array.isArray(parsed) || !parsed.every((entry) => typeof entry === "string")) {
+    throw new Error(`${name} must be a JSON string array`);
+  }
+  return parsed;
 }

--- a/src/commit-sweeper.ts
+++ b/src/commit-sweeper.ts
@@ -58,7 +58,7 @@ function repoSlug(targetRepo: string): string {
 }
 
 export function commitReportRelativePath(targetRepo: string, sha: string): string {
-  return join("records", repoSlug(targetRepo), "commits", `${assertSha(sha)}.md`);
+  return `records/${repoSlug(targetRepo)}/commits/${assertSha(sha)}.md`;
 }
 
 function artifactReportRelativePath(targetRepo: string, sha: string): string {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -32,6 +33,7 @@ import {
   isGitHubRequiresAuthenticationError,
   isLockedConversationCommentError,
   isMissingGitHubLabelErrorForTest,
+  issueAdvisoryLabelsForTest,
   isProtectedItem,
   itemNumbersArg,
   lockedConversationApplyReason,
@@ -1056,6 +1058,30 @@ test("scheduler ignores ClawSweeper-owned updated_at churn after review", () => 
       "current",
     ),
     false,
+  );
+  assert.equal(
+    shouldReviewItem(
+      item({
+        createdAt: "2026-03-01T11:12:04Z",
+        updatedAt: "2026-04-30T13:04:58Z",
+      }),
+      { ...review, labelsSyncedAt: "2026-04-30T13:04:59Z" },
+      now,
+      "current",
+    ),
+    false,
+  );
+  assert.equal(
+    shouldReviewItem(
+      item({
+        createdAt: "2026-03-01T11:12:04Z",
+        updatedAt: "2026-04-30T13:05:00Z",
+      }),
+      { ...review, labelsSyncedAt: "2026-04-30T13:04:59Z" },
+      now,
+      "current",
+    ),
+    true,
   );
 });
 
@@ -2903,6 +2929,88 @@ Render generated plan markdown from existing report fields.
 `;
 }
 
+function markedReviewCommentForTest(number: number, body: string): string {
+  return `${body.trimEnd()}\n\n<!-- clawsweeper-review item=${number} -->`;
+}
+
+function sha256ForTest(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}
+
+function reportWithSyncedReviewComment(
+  report: string,
+  number: number,
+  reason = "none",
+): {
+  report: string;
+  comment: string;
+} {
+  const comment = markedReviewCommentForTest(number, renderReviewCommentFromReport(report, reason));
+  return {
+    report: report.replace(
+      /^---\n/,
+      [
+        "---",
+        `review_comment_sha256: ${sha256ForTest(comment)}`,
+        `review_comment_id: ${9000 + number}`,
+        `review_comment_url: https://github.com/openclaw/clawsweeper/issues/${number}#issuecomment-${9000 + number}`,
+        "review_comment_synced_at: 2026-05-01T01:00:00Z",
+        "",
+      ].join("\n"),
+    ),
+    comment,
+  };
+}
+
+function withMockGh(root: string, script: string, run: () => void): void {
+  const originalGhBin = process.env.GH_BIN;
+  const originalGhBinArgs = process.env.GH_BIN_ARGS;
+  const binDir = join(root, "bin");
+  mkdirSync(binDir, { recursive: true });
+  const ghPath = join(binDir, "gh.js");
+  writeFileSync(ghPath, script, { mode: 0o755 });
+  try {
+    process.env.GH_BIN = process.execPath;
+    process.env.GH_BIN_ARGS = JSON.stringify([ghPath]);
+    run();
+  } finally {
+    if (originalGhBin === undefined) delete process.env.GH_BIN;
+    else process.env.GH_BIN = originalGhBin;
+    if (originalGhBinArgs === undefined) delete process.env.GH_BIN_ARGS;
+    else process.env.GH_BIN_ARGS = originalGhBinArgs;
+  }
+}
+
+function runApplyDecisionsForTest(options: {
+  itemsDir: string;
+  closedDir: string;
+  plansDir: string;
+  reportPath: string;
+  extraArgs?: string[];
+}): void {
+  execFileSync(process.execPath, [
+    "dist/clawsweeper.js",
+    "apply-decisions",
+    "--target-repo",
+    "openclaw/clawsweeper",
+    "--items-dir",
+    options.itemsDir,
+    "--closed-dir",
+    options.closedDir,
+    "--plans-dir",
+    options.plansDir,
+    "--report-path",
+    options.reportPath,
+    "--limit",
+    "10",
+    "--processed-limit",
+    "1",
+    "--close-delay-ms",
+    "0",
+    ...(options.extraArgs ?? []),
+  ]);
+}
+
 test("renderWorkPlanFromReport renders dashboard plan artifacts for fresh queue_fix_pr candidates", () => {
   const plan = renderWorkPlanFromReport(workPlanCandidateReport(), {
     reportPath: "records/openclaw-clawsweeper/items/321.md",
@@ -2986,7 +3094,8 @@ test("apply-artifacts writes and removes generated work plans", () => {
 
 test("apply-decisions removes archived work plans from the scoped plans directory", () => {
   const root = mkdtempSync(tmpPrefix);
-  const originalPath = process.env.PATH;
+  const originalGhBin = process.env.GH_BIN;
+  const originalGhBinArgs = process.env.GH_BIN_ARGS;
   const defaultPlanDir = join(process.cwd(), "records", "openclaw-clawsweeper", "plans");
   const defaultPlanPath = join(defaultPlanDir, "321.md");
   try {
@@ -2998,9 +3107,7 @@ test("apply-decisions removes archived work plans from the scoped plans director
     mkdirSync(itemsDir, { recursive: true });
     mkdirSync(plansDir, { recursive: true });
     mkdirSync(defaultPlanDir, { recursive: true });
-    writeFileSync(
-      join(binDir, "gh"),
-      `#!/usr/bin/env node
+    const ghMock = `#!/usr/bin/env node
 const args = process.argv.slice(2).join(" ");
 if (args.includes("/comments")) {
   console.log(JSON.stringify([[]]));
@@ -3021,9 +3128,8 @@ if (args.includes("/comments")) {
     pull_request: null
   }));
 }
-`,
-      { mode: 0o755 },
-    );
+`;
+    writeFileSync(join(binDir, "gh.js"), ghMock, { mode: 0o755 });
     writeFileSync(
       join(itemsDir, "321.md"),
       workPlanCandidateReport({
@@ -3035,7 +3141,8 @@ if (args.includes("/comments")) {
     writeFileSync(join(plansDir, "321.md"), "scoped generated plan\n", "utf8");
     writeFileSync(defaultPlanPath, "default generated plan\n", "utf8");
 
-    process.env.PATH = `${binDir}:${originalPath ?? ""}`;
+    process.env.GH_BIN = process.execPath;
+    process.env.GH_BIN_ARGS = JSON.stringify([join(binDir, "gh.js")]);
     execFileSync(process.execPath, [
       "dist/clawsweeper.js",
       "apply-decisions",
@@ -3059,9 +3166,524 @@ if (args.includes("/comments")) {
     assert.ok(existsSync(defaultPlanPath));
     assert.ok(existsSync(join(closedDir, "321.md")));
   } finally {
-    process.env.PATH = originalPath;
+    if (originalGhBin === undefined) delete process.env.GH_BIN;
+    else process.env.GH_BIN = originalGhBin;
+    if (originalGhBinArgs === undefined) delete process.env.GH_BIN_ARGS;
+    else process.env.GH_BIN_ARGS = originalGhBinArgs;
     rmSync(root, { recursive: true, force: true });
     rmSync(defaultPlanPath, { force: true });
+  }
+});
+
+test("apply-decisions skips advisory label sync when a close report changed since review", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const logPath = join(root, "gh.log");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    writeFileSync(
+      join(itemsDir, "321.md"),
+      workPlanCandidateReport({
+        decision: "close",
+        action_taken: "proposed_close",
+        close_reason: "implemented_on_main",
+        confidence: "high",
+        item_snapshot_hash: "reviewed-snapshot",
+        item_updated_at: "2026-05-01T00:00:00Z",
+        reproduction_status: "reproduced",
+        reproduction_confidence: "high",
+      }),
+      "utf8",
+    );
+
+    const ghMock = `
+const { appendFileSync } = require("fs");
+const logPath = ${JSON.stringify(logPath)};
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+appendFileSync(logPath, JSON.stringify(args) + "\\n");
+const path = args[1] || "";
+if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 321,
+    title: "Render work plans",
+    html_url: "https://github.com/openclaw/clawsweeper/issues/321",
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-03T00:00:00Z",
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "reporter" },
+    labels: [],
+    pull_request: null
+  }));
+} else if (args[0] === "issue" && args[1] === "view") {
+  console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
+} else if (args[0] === "label" || args[0] === "issue") {
+  console.log("");
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({ itemsDir, closedDir, plansDir, reportPath });
+    });
+
+    const calls = readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as string[]);
+    assert.equal(
+      calls.some((args) => args[0] === "issue" && args[1] === "edit"),
+      false,
+    );
+    assert.equal(
+      calls.some((args) => args[0] === "label" && args[1] === "create"),
+      false,
+    );
+    assert.deepEqual(JSON.parse(readFileSync(reportPath, "utf8")), [
+      {
+        number: 321,
+        action: "skipped_changed_since_review",
+        reason: "updated_at changed",
+      },
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions does not advisory-label close proposals before close gates finish", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const logPath = join(root, "gh.log");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const closeReport = workPlanCandidateReport({
+      decision: "close",
+      action_taken: "proposed_close",
+      close_reason: "implemented_on_main",
+      confidence: "high",
+      item_snapshot_hash: "reviewed-snapshot",
+      item_updated_at: "2026-05-01T00:00:00Z",
+      reproduction_status: "reproduced",
+      reproduction_confidence: "high",
+    });
+    const synced = reportWithSyncedReviewComment(closeReport, 321, "implemented_on_main");
+    writeFileSync(join(itemsDir, "321.md"), synced.report, "utf8");
+
+    const ghMock = `
+const { appendFileSync } = require("fs");
+const logPath = ${JSON.stringify(logPath)};
+const comment = ${JSON.stringify(synced.comment)};
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+appendFileSync(logPath, JSON.stringify(args) + "\\n");
+const path = args[1] || "";
+if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[{
+    id: 9321,
+    html_url: "https://github.com/openclaw/clawsweeper/issues/321#issuecomment-9321",
+    created_at: "2026-05-01T01:00:00Z",
+    updated_at: "2026-05-01T01:00:00Z",
+    user: { login: "clawsweeper[bot]" },
+    body: comment
+  }]]));
+} else if (args[0] === "api" && /\\/issues\\/321\\/timeline(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 321,
+    title: "Render work plans",
+    html_url: "https://github.com/openclaw/clawsweeper/issues/321",
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "reporter" },
+    labels: [],
+    comments: 0,
+    pull_request: null
+  }));
+} else if (args[0] === "issue" && args[1] === "view") {
+  console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
+} else if (args[0] === "label" || args[0] === "issue") {
+  console.log("");
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: ["--apply-close-reasons", "stale_insufficient_info"],
+      });
+    });
+
+    const calls = readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as string[]);
+    assert.equal(
+      calls.some((args) => args[0] === "issue" && args[1] === "edit"),
+      false,
+    );
+    assert.equal(
+      calls.some((args) => args[0] === "label" && args[1] === "create"),
+      false,
+    );
+    assert.deepEqual(JSON.parse(readFileSync(reportPath, "utf8")), [
+      {
+        number: 321,
+        action: "kept_open",
+        reason: "close reason implemented_on_main is not enabled for this apply run",
+      },
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions skips advisory labels for failed or stale kept-open reports", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const logPath = join(root, "gh.log");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+
+    const failed = reportWithSyncedReviewComment(
+      workPlanCandidateReport({
+        number: 321,
+        review_status: "failed",
+        item_snapshot_hash: "reviewed-snapshot-321",
+        item_updated_at: "2026-05-01T00:00:00Z",
+        reproduction_status: "unclear",
+        reproduction_confidence: "low",
+        work_candidate: "none",
+        work_status: "none",
+        work_confidence: "low",
+      }),
+      321,
+    );
+    const stale = reportWithSyncedReviewComment(
+      workPlanCandidateReport({
+        number: 322,
+        item_snapshot_hash: "reviewed-snapshot-322",
+        item_updated_at: "2026-05-01T00:00:00Z",
+        triage_priority: "P1",
+        reproduction_status: "reproduced",
+        reproduction_confidence: "high",
+      }),
+      322,
+    );
+    writeFileSync(join(itemsDir, "321.md"), failed.report, "utf8");
+    writeFileSync(join(itemsDir, "322.md"), stale.report, "utf8");
+
+    const ghMock = `
+const { appendFileSync } = require("fs");
+const logPath = ${JSON.stringify(logPath)};
+const comments = ${JSON.stringify({ 321: failed.comment, 322: stale.comment })};
+const updatedAt = { 321: "2026-05-01T00:00:00Z", 322: "2026-05-02T00:00:00Z" };
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+appendFileSync(logPath, JSON.stringify(args) + "\\n");
+const path = args[1] || "";
+const commentMatch = path.match(/\\/issues\\/(\\d+)\\/comments(?:\\?|$)/);
+const issueMatch = path.match(/\\/issues\\/(\\d+)$/);
+if (args[0] === "api" && commentMatch) {
+  const number = Number(commentMatch[1]);
+  console.log(JSON.stringify([[{
+    id: 9000 + number,
+    html_url: "https://github.com/openclaw/clawsweeper/issues/" + number + "#issuecomment-" + (9000 + number),
+    created_at: "2026-05-01T01:00:00Z",
+    updated_at: "2026-05-01T01:00:00Z",
+    user: { login: "clawsweeper[bot]" },
+    body: comments[number]
+  }]]));
+} else if (args[0] === "api" && issueMatch) {
+  const number = Number(issueMatch[1]);
+  console.log(JSON.stringify({
+    number,
+    title: "Render work plans",
+    html_url: "https://github.com/openclaw/clawsweeper/issues/" + number,
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: updatedAt[number],
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "reporter" },
+    labels: [],
+    pull_request: null
+  }));
+} else if (args[0] === "issue" && args[1] === "view") {
+  console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
+} else if (args[0] === "label" || args[0] === "issue") {
+  console.log("");
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({ itemsDir, closedDir, plansDir, reportPath });
+    });
+
+    const calls = readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as string[]);
+    assert.equal(
+      calls.some((args) => args[0] === "issue" && args[1] === "edit"),
+      false,
+    );
+    assert.equal(
+      calls.some((args) => args[0] === "label" && args[1] === "create"),
+      false,
+    );
+    assert.deepEqual(JSON.parse(readFileSync(reportPath, "utf8")), []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions counts advisory label-only syncs against the processed limit", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const logPath = join(root, "gh.log");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+
+    const first = reportWithSyncedReviewComment(
+      workPlanCandidateReport({
+        number: 321,
+        reviewed_at: "2026-05-01T00:00:00Z",
+        item_snapshot_hash: "reviewed-snapshot-321",
+        item_updated_at: "2026-05-01T00:00:00Z",
+      }),
+      321,
+    );
+    const second = reportWithSyncedReviewComment(
+      workPlanCandidateReport({
+        number: 322,
+        reviewed_at: "2026-05-01T00:00:00Z",
+        item_snapshot_hash: "reviewed-snapshot-322",
+        item_updated_at: "2026-05-01T00:00:00Z",
+      }),
+      322,
+    );
+    writeFileSync(join(itemsDir, "321.md"), first.report, "utf8");
+    writeFileSync(join(itemsDir, "322.md"), second.report, "utf8");
+
+    const ghMock = `
+const { appendFileSync } = require("fs");
+const logPath = ${JSON.stringify(logPath)};
+const comments = ${JSON.stringify({ 321: first.comment, 322: second.comment })};
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+appendFileSync(logPath, JSON.stringify(args) + "\\n");
+const path = args[1] || "";
+const commentMatch = path.match(/\\/issues\\/(\\d+)\\/comments(?:\\?|$)/);
+const issueMatch = path.match(/\\/issues\\/(\\d+)$/);
+if (args[0] === "api" && commentMatch) {
+  const number = Number(commentMatch[1]);
+  const body = comments[number];
+  console.log(JSON.stringify([[{
+    id: 9000 + number,
+    html_url: "https://github.com/openclaw/clawsweeper/issues/" + number + "#issuecomment-" + (9000 + number),
+    created_at: "2026-05-01T01:00:00Z",
+    updated_at: "2026-05-01T01:00:00Z",
+    user: { login: "clawsweeper[bot]" },
+    body
+  }]]));
+} else if (args[0] === "api" && issueMatch) {
+  const number = Number(issueMatch[1]);
+  console.log(JSON.stringify({
+    number,
+    title: "Render work plans",
+    html_url: "https://github.com/openclaw/clawsweeper/issues/" + number,
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "reporter" },
+    labels: [],
+    pull_request: null
+  }));
+} else if (args[0] === "issue" && args[1] === "view") {
+  console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
+} else if (args[0] === "label" && args[1] === "create") {
+  console.log("");
+} else if (args[0] === "issue" && args[1] === "edit") {
+  console.log("");
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({ itemsDir, closedDir, plansDir, reportPath });
+    });
+
+    const calls = readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as string[]);
+    const editCalls = calls.filter((args) => args[0] === "issue" && args[1] === "edit");
+    assert.ok(editCalls.length > 0);
+    assert.deepEqual([...new Set(editCalls.map((args) => args[2]))], ["321"]);
+    assert.equal(
+      calls.some((args) => args.some((arg) => arg.includes("/issues/322"))),
+      false,
+    );
+    assert.deepEqual(JSON.parse(readFileSync(reportPath, "utf8")), [
+      {
+        number: 321,
+        action: "kept_open",
+        reason: "synced advisory issue labels",
+      },
+    ]);
+    assert.match(readFileSync(join(itemsDir, "321.md"), "utf8"), /^labels_synced_at: /m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions dry-run computes advisory labels without mutating GitHub labels", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const logPath = join(root, "gh.log");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+
+    const synced = reportWithSyncedReviewComment(
+      workPlanCandidateReport({
+        number: 321,
+        reviewed_at: "2026-05-01T00:00:00Z",
+        item_snapshot_hash: "reviewed-snapshot-321",
+        item_updated_at: "2026-05-01T00:00:00Z",
+      }),
+      321,
+    );
+    const itemPath = join(itemsDir, "321.md");
+    writeFileSync(itemPath, synced.report, "utf8");
+
+    const ghMock = `
+const { appendFileSync } = require("fs");
+const logPath = ${JSON.stringify(logPath)};
+const comment = ${JSON.stringify(synced.comment)};
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+appendFileSync(logPath, JSON.stringify(args) + "\\n");
+const path = args[1] || "";
+if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[{
+    id: 9321,
+    html_url: "https://github.com/openclaw/clawsweeper/issues/321#issuecomment-9321",
+    created_at: "2026-05-01T01:00:00Z",
+    updated_at: "2026-05-01T01:00:00Z",
+    user: { login: "clawsweeper[bot]" },
+    body: comment
+  }]]));
+} else if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 321,
+    title: "Render work plans",
+    html_url: "https://github.com/openclaw/clawsweeper/issues/321",
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "reporter" },
+    labels: [],
+    pull_request: null
+  }));
+} else if (args[0] === "issue" && args[1] === "view") {
+  console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
+} else if (args[0] === "label" || args[0] === "issue") {
+  console.log("");
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: ["--dry-run"],
+      });
+    });
+
+    const calls = readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as string[]);
+    assert.equal(
+      calls.some((args) => args[0] === "issue" && args[1] === "edit"),
+      false,
+    );
+    assert.equal(
+      calls.some((args) => args[0] === "label" && args[1] === "create"),
+      false,
+    );
+    assert.deepEqual(JSON.parse(readFileSync(reportPath, "utf8")), [
+      {
+        number: 321,
+        action: "kept_open",
+        reason: "dry-run: would sync advisory issue labels",
+      },
+    ]);
+    assert.doesNotMatch(readFileSync(itemPath, "utf8"), /clawsweeper:queueable-fix/);
+    assert.doesNotMatch(readFileSync(itemPath, "utf8"), /^labels_synced_at: /m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
   }
 });
 
@@ -3588,6 +4210,183 @@ test("ClawSweeper priority labels follow triage priority", () => {
   assert.deepEqual(priorityLabelsForTest(["P0", "bug"], "none"), ["bug"]);
 });
 
+test("ClawSweeper issue advisory labels expose high-confidence reproduction state", () => {
+  assert.deepEqual(
+    issueAdvisoryLabelsForTest(["bug"], {
+      type: "issue",
+      reproductionStatus: "reproduced",
+      reproductionConfidence: "high",
+    }),
+    ["bug", "clawsweeper:current-main-repro"],
+  );
+  assert.deepEqual(
+    issueAdvisoryLabelsForTest(["bug"], {
+      type: "issue",
+      reproductionStatus: "source_reproducible",
+      reproductionConfidence: "high",
+    }),
+    ["bug", "clawsweeper:source-repro"],
+  );
+  assert.deepEqual(
+    issueAdvisoryLabelsForTest(["bug"], {
+      type: "issue",
+      reproductionStatus: "reproduced",
+      reproductionConfidence: "medium",
+    }),
+    ["bug"],
+  );
+  assert.deepEqual(
+    issueAdvisoryLabelsForTest(["bug"], {
+      type: "issue",
+      reproductionStatus: "not_reproduced",
+      reproductionConfidence: "high",
+    }),
+    ["bug", "clawsweeper:not-repro-on-main"],
+  );
+  assert.deepEqual(
+    issueAdvisoryLabelsForTest(["bug"], {
+      type: "issue",
+      reproductionStatus: "source_reproducible",
+      reproductionConfidence: "medium",
+    }),
+    ["bug", "clawsweeper:needs-live-repro"],
+  );
+  assert.deepEqual(
+    issueAdvisoryLabelsForTest(["bug"], {
+      type: "issue",
+      reproductionStatus: "unclear",
+      reproductionConfidence: "low",
+    }),
+    ["bug", "clawsweeper:needs-info"],
+  );
+});
+
+test("ClawSweeper issue advisory labels expose work-lane routing state", () => {
+  assert.deepEqual(
+    issueAdvisoryLabelsForTest(["clawsweeper"], {
+      type: "issue",
+      workCandidate: "queue_fix_pr",
+      workStatus: "candidate",
+      workConfidence: "high",
+      hasWorkShape: true,
+    }),
+    ["clawsweeper", "clawsweeper:queueable-fix", "clawsweeper:fix-shape-clear"],
+  );
+  assert.deepEqual(
+    issueAdvisoryLabelsForTest(["clawsweeper"], {
+      type: "issue",
+      workCandidate: "queue_fix_pr",
+      workStatus: "candidate",
+      workConfidence: "medium",
+    }),
+    ["clawsweeper"],
+  );
+  assert.deepEqual(
+    issueAdvisoryLabelsForTest(["clawsweeper"], {
+      type: "issue",
+      workCandidate: "manual_review",
+    }),
+    ["clawsweeper", "clawsweeper:no-new-fix-pr", "clawsweeper:needs-maintainer-review"],
+  );
+  assert.deepEqual(
+    issueAdvisoryLabelsForTest(["clawsweeper"], {
+      type: "issue",
+      workStatus: "manual_review",
+    }),
+    ["clawsweeper", "clawsweeper:no-new-fix-pr", "clawsweeper:needs-maintainer-review"],
+  );
+});
+
+test("ClawSweeper issue advisory labels expose linked PR and human decision blockers", () => {
+  assert.deepEqual(
+    issueAdvisoryLabelsForTest(["bug"], {
+      type: "issue",
+      hasOpenLinkedPullRequest: true,
+    }),
+    ["bug", "clawsweeper:linked-pr-open", "clawsweeper:no-new-fix-pr"],
+  );
+  assert.deepEqual(
+    issueAdvisoryLabelsForTest(["bug"], {
+      type: "issue",
+      requiresProductDecision: true,
+    }),
+    ["bug", "clawsweeper:no-new-fix-pr", "clawsweeper:needs-product-decision"],
+  );
+  assert.deepEqual(
+    issueAdvisoryLabelsForTest(["bug"], {
+      type: "issue",
+      securityReviewStatus: "needs_attention",
+    }),
+    ["bug", "clawsweeper:no-new-fix-pr", "clawsweeper:needs-security-review"],
+  );
+  assert.deepEqual(
+    issueAdvisoryLabelsForTest(["bug"], {
+      type: "issue",
+      itemCategory: "security",
+    }),
+    ["bug", "clawsweeper:no-new-fix-pr", "clawsweeper:needs-security-review"],
+  );
+});
+
+test("ClawSweeper issue advisory labels remove stale owned labels and preserve other labels", () => {
+  assert.deepEqual(
+    issueAdvisoryLabelsForTest(
+      [
+        "bug",
+        "clawsweeper:source-repro",
+        "clawsweeper:not-repro-on-main",
+        "clawsweeper:needs-live-repro",
+        "clawsweeper:needs-info",
+        "clawsweeper:linked-pr-open",
+        "clawsweeper:no-new-fix-pr",
+        "clawsweeper:queueable-fix",
+        "clawsweeper:fix-shape-clear",
+        "clawsweeper:needs-product-decision",
+        "clawsweeper:needs-security-review",
+        "clawsweeper:autofix",
+        "clawsweeper:automerge",
+        "clawsweeper:human-review",
+        "clawsweeper:merge-ready",
+        "proof: sufficient",
+        "mantis: telegram-visible-proof",
+      ],
+      {
+        type: "issue",
+        reproductionStatus: "reproduced",
+        reproductionConfidence: "high",
+      },
+    ),
+    [
+      "bug",
+      "clawsweeper:autofix",
+      "clawsweeper:automerge",
+      "clawsweeper:human-review",
+      "clawsweeper:merge-ready",
+      "proof: sufficient",
+      "mantis: telegram-visible-proof",
+      "clawsweeper:current-main-repro",
+    ],
+  );
+});
+
+test("ClawSweeper issue advisory labels do not apply to pull requests", () => {
+  assert.deepEqual(
+    issueAdvisoryLabelsForTest(["bug"], {
+      type: "pull_request",
+      reproductionStatus: "reproduced",
+      reproductionConfidence: "high",
+      workCandidate: "queue_fix_pr",
+      workStatus: "candidate",
+      workConfidence: "high",
+      hasOpenLinkedPullRequest: true,
+      requiresProductDecision: true,
+      securityReviewStatus: "needs_attention",
+      hasWorkShape: true,
+    }),
+    ["bug"],
+  );
+});
+
 test("review workflow gives Codex a read-only inspection token", () => {
   const workflow = readFileSync(".github/workflows/sweep.yml", "utf8");
 
@@ -3791,7 +4590,10 @@ test("sweep target write tokens can merge pull requests", () => {
 test("sweep review recovery uses explicit failed shard artifacts", () => {
   const workflow = readFileSync(".github/workflows/sweep.yml", "utf8");
 
-  assert.match(workflow, /- name: Review shard\n\s+id: review-shard\n\s+continue-on-error: true/);
+  assert.match(
+    workflow,
+    /- name: Review shard\r?\n\s+id: review-shard\r?\n\s+continue-on-error: true/,
+  );
   assert.match(workflow, /- name: Record failed review shard/);
   assert.match(workflow, /steps\.review-shard\.outcome == 'failure'/);
   assert.match(workflow, /name: review-failed-shard-\$\{\{ matrix\.shard \}\}/);

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -4180,28 +4180,33 @@ test("ClawSweeper priority label scheme exposes P0 through P3 labels", () => {
     {
       name: "P0",
       color: "B60205",
-      description:
-        "Critical: production-breaking, data-loss, security-impacting, or blocks core project operation; needs immediate maintainer attention.",
+      description: "Critical impact; needs immediate maintainer attention.",
     },
     {
       name: "P1",
       color: "D93F0B",
-      description:
-        "High: important user-facing bug, serious regression, broken major workflow, or urgent maintainer-priority work; should be handled soon.",
+      description: "High-priority user-facing bug, regression, or broken workflow.",
     },
     {
       name: "P2",
       color: "FBCA04",
-      description:
-        "Medium: meaningful bug, incomplete behavior, polish issue, or useful improvement with limited blast radius; normal backlog priority.",
+      description: "Normal backlog priority with limited blast radius.",
     },
     {
       name: "P3",
       color: "0E8A16",
-      description:
-        "Low: minor cleanup, documentation, cosmetic polish, small ergonomics issue, or speculative improvement; handle when convenient.",
+      description: "Low-priority cleanup, docs, polish, ergonomics, or speculative work.",
     },
   ]);
+});
+
+test("ClawSweeper priority label descriptions fit GitHub label limits", () => {
+  for (const label of priorityLabelSchemeForTest()) {
+    assert.ok(
+      label.description.length <= 100,
+      `${label.name} description is ${label.description.length} characters`,
+    );
+  }
 });
 
 test("ClawSweeper priority labels follow triage priority", () => {


### PR DESCRIPTION
## Summary

This PR implements Phase 1 of #66: ClawSweeper now projects selected issue-review conclusions into GitHub advisory labels during the existing apply/comment-sync path.

Functionally, this means maintainers can filter and route reviewed open issues from the GitHub issue list or project views without reading every full ClawSweeper comment first. The detailed comment remains the explanation and evidence. The labels are only routing signals.

This branch has been rebased on current `main`, including the priority-label work from #76.

## What Changed

- Adds an owned advisory issue-label group for reproduction, missing-info, linked-PR, work-lane, product-decision, and security-review states.
- Syncs advisory labels only for open issues with complete, current kept-open ClawSweeper reports.
- Removes stale labels from that owned advisory group when the report state changes.
- Preserves unrelated labels and existing action/proof labels, including `clawsweeper:autofix`, `clawsweeper:automerge`, `clawsweeper:human-review`, `clawsweeper:merge-ready`, `proof: sufficient`, and `mantis: telegram-visible-proof`.
- Records `labels_synced_at` after current ClawSweeper label-only syncs, so bot-owned label writes do not look like fresh reporter/maintainer activity to the scheduler.
- Gates label sync on complete/current reports so stale reports do not mask real post-review activity.
- Leaves close proposals alone for advisory issue labels so advisory label writes cannot update `updated_at` before close eligibility gates finish.
- Keeps dry-run behavior non-mutating while still reporting that advisory labels would be synced.
- Updates README, work-lane docs, scheduler docs, and changelog notes for the label projection and `labels_synced_at` behavior.

## Phase 1 Scope

This covers Phase 1 of #66.

Included:

- Advisory labels derived from existing structured report/frontmatter data.
- Label creation using the existing best-effort GitHub label creation pattern.
- Label add/remove sync during the existing apply/comment-sync path.
- Documentation for how the label projection works.
- Focused tests for label mapping, stale-label removal, dry-run behavior, stale/failed report guards, processed-budget behavior, and scheduler handling of ClawSweeper-owned label churn.

Not included:

- No new workflow dispatch behavior.
- No repair PR creation behavior.
- No merge or close behavior changes.
- No maintainer action labels are auto-applied.
- No comment-prose scraping.

## Safety Notes

Advisory labels are synced only from reports that are both complete and current. Failed reports, stale reports, pull requests, and close proposals are skipped for this advisory label projection. This keeps the labels from becoming a source of accidental automation or stale routing state.

`labels_synced_at` is only written after current report label syncs, and the scheduler treats GitHub `updated_at` values up to that marker as ClawSweeper-owned activity rather than reporter/maintainer activity.

## Validation

Passed locally on Node 24 / pnpm:

- `pnpm run build:all`
- `pnpm run lint:src`
- `pnpm run lint:scripts`
- `pnpm run check:active-surface`
- `pnpm run check:limits`
- `node --test --test-name-pattern "advisory|priority|scheduler ignores|failed or stale" test/clawsweeper.test.ts`
- `pnpm run test:unit` (163 tests)
- `pnpm exec oxfmt --check CHANGELOG.md README.md docs/work-lane.md docs/scheduler.md package.json scripts/check-active-surface.ts src/command.ts src/commit-sweeper.ts src/clawsweeper.ts test/clawsweeper.test.ts`
- `git diff --check`
- `codex review --base upstream/main` found no actionable bugs after fixes.
