### PR TITLE
fix: target re-review status comment updates

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -264,12 +264,14 @@ jobs:
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
           ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
           COMMAND_STATUS_MARKER: ${{ github.event.client_payload.command_status_marker || '' }}
+          STATUS_COMMENT_ID: ${{ github.event.client_payload.status_comment_id || '' }}
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           pnpm run repair:update-command-status -- \
             --repo "$TARGET_REPO" \
             --item-number "$ITEM_NUMBER" \
             --marker "$COMMAND_STATUS_MARKER" \
+            --status-comment-id "$STATUS_COMMENT_ID" \
             --state "Review in progress" \
             --detail "Targeted re-review run started; Codex is reviewing the item." \
             --run-url "$RUN_URL" \
@@ -391,6 +393,7 @@ jobs:
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
           ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
           COMMAND_STATUS_MARKER: ${{ github.event.client_payload.command_status_marker || '' }}
+          STATUS_COMMENT_ID: ${{ github.event.client_payload.status_comment_id || '' }}
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           REVIEW_OUTCOME: ${{ steps.review-exact-event-item.outcome }}
           PUBLISH_OUTCOME: ${{ steps.publish-event-result.outcome }}
@@ -406,6 +409,7 @@ jobs:
             --repo "$TARGET_REPO" \
             --item-number "$ITEM_NUMBER" \
             --marker "$COMMAND_STATUS_MARKER" \
+            --status-comment-id "$STATUS_COMMENT_ID" \
             --state "$state" \
             --detail "$detail" \
             --run-url "$RUN_URL"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Kept event re-review progress updates scoped to ClawSweeper-owned status
+  comments, so empty command markers cannot cause unrelated human comments to be
+  edited. Thanks @hxy91819.
 - Added live spam comment intake for GitHub activity events so deterministic
   spam candidates dispatch exact comment scans immediately instead of waiting
   for the hourly audit sweep.

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -1581,7 +1581,14 @@ function repairJobModeForCommand(command: LooseRecord) {
 
 function dispatchClawSweeperReview(command: LooseRecord) {
   const commandStatus =
-    command.intent === "re_review" ? { command_status_marker: commandStatusMarker(command) } : {};
+    command.intent === "re_review"
+      ? {
+          command_status_marker: commandStatusMarker(command),
+          ...(command.status_comment_id
+            ? { status_comment_id: String(command.status_comment_id) }
+            : {}),
+        }
+      : {};
   const payload = JSON.stringify({
     event_type: "clawsweeper_item",
     client_payload: {

--- a/src/repair/update-command-status.ts
+++ b/src/repair/update-command-status.ts
@@ -1,28 +1,32 @@
 #!/usr/bin/env node
 import { setTimeout as sleep } from "node:timers/promises";
-import { ghPagedWithRetry, ghText } from "./github-cli.js";
+import { ghJsonWithRetry, ghPagedWithRetry, ghText } from "./github-cli.js";
 import type { JsonValue, LooseRecord } from "./json-types.js";
 import { repoRoot } from "./paths.js";
-import { writePayload } from "./comment-router-utils.js";
+import { issueNumberFromUrl, normalizeGitHubActor, writePayload } from "./comment-router-utils.js";
 
 const PROGRESS_START = "<!-- clawsweeper-command-progress:start -->";
 const PROGRESS_END = "<!-- clawsweeper-command-progress:end -->";
+const TRUSTED_STATUS_COMMENT_ACTORS = new Set(["clawsweeper", "openclaw-clawsweeper"]);
 
 type Options = {
   repo: string;
   itemNumber: string;
   marker: string;
+  statusCommentId: number | null;
   state: string;
   detail: string;
   runUrl: string;
   waitMs: number;
 };
 
-const options = parseOptions(process.argv.slice(2));
-await updateCommandStatus(options);
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const options = parseOptions(process.argv.slice(2));
+  await updateCommandStatus(options);
+}
 
 async function updateCommandStatus(options: Options) {
-  if (!options.marker) return;
+  if (!options.marker && !options.statusCommentId) return;
   validateRepo(options.repo);
   validateItemNumber(options.itemNumber);
   const comment = await findCommandStatusComment(options);
@@ -47,21 +51,58 @@ async function findCommandStatusComment(options: Options): Promise<LooseRecord |
   const deadline = Date.now() + Math.max(0, options.waitMs);
   let shouldContinue = true;
   while (shouldContinue) {
+    const exact = fetchExactStatusComment(options);
+    if (exact) return exact;
     const comments = ghPagedWithRetry<LooseRecord>(
       `repos/${options.repo}/issues/${options.itemNumber}/comments?per_page=100`,
       { attempts: 3 },
     );
-    const match = comments
-      .filter(
-        (comment) => typeof comment.body === "string" && comment.body.includes(options.marker),
-      )
-      .at(-1);
+    const match = selectCommandStatusComment(comments, options);
     if (match) return match;
     shouldContinue = Date.now() < deadline;
     if (!shouldContinue) break;
     await sleep(5000);
   }
   return null;
+}
+
+function fetchExactStatusComment(
+  options: Pick<Options, "repo" | "itemNumber" | "statusCommentId">,
+) {
+  if (!options.statusCommentId) return null;
+  try {
+    const comment = ghJsonWithRetry<LooseRecord>(
+      ["api", `repos/${options.repo}/issues/comments/${options.statusCommentId}`],
+      { attempts: 3 },
+    );
+    if (!isTrustedStatusComment(comment)) return null;
+    if (issueNumberFromUrl(comment.issue_url) !== Number(options.itemNumber)) return null;
+    return comment;
+  } catch {
+    return null;
+  }
+}
+
+export function selectCommandStatusComment(
+  comments: LooseRecord[],
+  options: Pick<Options, "marker" | "statusCommentId">,
+) {
+  if (options.statusCommentId) {
+    const exact = comments.find(
+      (comment) =>
+        Number(comment.id ?? 0) === options.statusCommentId && isTrustedStatusComment(comment),
+    );
+    if (exact) return exact;
+  }
+  if (!options.marker) return null;
+  return comments
+    .filter(
+      (comment) =>
+        isTrustedStatusComment(comment) &&
+        typeof comment.body === "string" &&
+        comment.body.includes(options.marker),
+    )
+    .at(-1);
 }
 
 export function mergeCommandProgressSection(
@@ -89,14 +130,14 @@ function renderCommandProgressSection(options: Pick<Options, "state" | "detail" 
   return lines.join("\n");
 }
 
-function parseOptions(argv: string[]): Options {
+export function parseOptions(argv: string[]): Options {
   const args: Record<string, string> = {};
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index] ?? "";
     if (!arg.startsWith("--")) continue;
     const key = arg.slice(2);
     const next = argv[index + 1];
-    if (!next || next.startsWith("--")) {
+    if (next === undefined || next.startsWith("--")) {
       args[key] = "true";
       continue;
     }
@@ -107,6 +148,9 @@ function parseOptions(argv: string[]): Options {
     repo: args.repo ?? process.env.TARGET_REPO ?? "",
     itemNumber: args["item-number"] ?? process.env.ITEM_NUMBER ?? "",
     marker: args.marker ?? process.env.COMMAND_STATUS_MARKER ?? "",
+    statusCommentId: optionalNumber(
+      args["status-comment-id"] ?? process.env.CLAWSWEEPER_STATUS_COMMENT_ID,
+    ),
     state: args.state ?? process.env.COMMAND_STATUS_STATE ?? "",
     detail: args.detail ?? process.env.COMMAND_STATUS_DETAIL ?? "",
     runUrl: args["run-url"] ?? process.env.RUN_URL ?? "",
@@ -124,4 +168,17 @@ function validateItemNumber(itemNumber: JsonValue) {
   if (!/^[0-9]+$/.test(String(itemNumber ?? ""))) {
     throw new Error(`invalid item number: ${itemNumber}`);
   }
+}
+
+function optionalNumber(value: JsonValue) {
+  if (value === undefined || value === null || value === "") return null;
+  const number = Number(value);
+  if (!Number.isInteger(number) || number <= 0) {
+    throw new Error(`invalid status comment id: ${value}`);
+  }
+  return number;
+}
+
+function isTrustedStatusComment(comment: LooseRecord) {
+  return TRUSTED_STATUS_COMMENT_ACTORS.has(normalizeGitHubActor(comment.user?.login));
 }

--- a/test/repair/update-command-status.test.ts
+++ b/test/repair/update-command-status.test.ts
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  mergeCommandProgressSection,
+  parseOptions,
+  selectCommandStatusComment,
+} from "../../dist/repair/update-command-status.js";
+
+test("parseOptions preserves empty string arguments", () => {
+  const options = parseOptions([
+    "--repo",
+    "openclaw/openclaw",
+    "--item-number",
+    "81564",
+    "--marker",
+    "",
+    "--status-comment-id",
+    "",
+  ]);
+
+  assert.equal(options.marker, "");
+  assert.equal(options.statusCommentId, null);
+});
+
+test("empty markers do not target human comments that mention true", () => {
+  const options = parseOptions([
+    "--repo",
+    "openclaw/openclaw",
+    "--item-number",
+    "81564",
+    "--marker",
+    "",
+  ]);
+  const selected = selectCommandStatusComment(
+    [
+      {
+        id: 4465717559,
+        user: { login: "hxy91819" },
+        body: [
+          "## Maintainer additions on top of this PR",
+          "",
+          "This maintainer note mentions `isError: true` twice.",
+        ].join("\n"),
+      },
+    ],
+    {
+      marker: options.marker,
+      statusCommentId: options.statusCommentId,
+    },
+  );
+
+  assert.equal(selected, null);
+});
+
+test("selectCommandStatusComment prefers exact status comment ids", () => {
+  const marker = "<!-- clawsweeper-command-status:81564:re_review:320c867f -->";
+  const selected = selectCommandStatusComment(
+    [
+      {
+        id: 4465717559,
+        user: { login: "hxy91819" },
+        body: marker,
+      },
+      {
+        id: 4466202000,
+        user: { login: "clawsweeper[bot]" },
+        body: "<!-- clawsweeper-command-ack:4466201487 -->\nClawSweeper picked this up.",
+      },
+    ],
+    {
+      marker,
+      statusCommentId: 4466202000,
+    },
+  );
+
+  assert.equal(selected?.id, 4466202000);
+});
+
+test("selectCommandStatusComment ignores human comments during marker fallback", () => {
+  const marker = "<!-- clawsweeper-command-status:81564:re_review:320c867f -->";
+  const selected = selectCommandStatusComment(
+    [
+      {
+        id: 4465717559,
+        user: { login: "hxy91819" },
+        body: marker,
+      },
+      {
+        id: 4466202000,
+        user: { login: "openclaw-clawsweeper[bot]" },
+        body: `${marker}\nClawSweeper picked this up.`,
+      },
+    ],
+    {
+      marker,
+      statusCommentId: null,
+    },
+  );
+
+  assert.equal(selected?.id, 4466202000);
+});
+
+test("mergeCommandProgressSection replaces existing progress blocks in place", () => {
+  const body = mergeCommandProgressSection(
+    [
+      "<!-- clawsweeper-command-ack:4466201487 -->",
+      "Queued.",
+      "",
+      "<!-- clawsweeper-command-progress:start -->",
+      "Re-review progress:",
+      "- State: Review in progress",
+      "- Detail: Old detail",
+      "<!-- clawsweeper-command-progress:end -->",
+    ].join("\n"),
+    {
+      state: "Complete",
+      detail: "Updated detail",
+      runUrl: "https://github.com/openclaw/clawsweeper/actions/runs/25957571980",
+    },
+  );
+
+  assert.match(body, /- State: Complete/);
+  assert.match(body, /- Detail: Updated detail/);
+  assert.equal((body.match(/clawsweeper-command-progress:start/g) ?? []).length, 1);
+});


### PR DESCRIPTION
## Summary

Fix re-review status comment updates so ClawSweeper only patches its own status comment instead of accidentally editing unrelated human comments.

## Problem

ClawSweeper updates re-review progress through `src/repair/update-command-status.ts`.

The bad behavior came from two issues:

1. `parseOptions()` treated empty CLI values as missing flags, so `--marker ""` was parsed as `"true"`.
2. Marker fallback scanned issue comments with a plain `body.includes(marker)` match.

That combination could make the updater patch the last comment containing the word `true`, even if it was a maintainer comment rather than a ClawSweeper status comment.

Actual incident:

- PR: https://github.com/openclaw/openclaw/pull/81564
- Mis-edited comment: https://github.com/openclaw/openclaw/pull/81564#issuecomment-4465717559

## Fix

This change makes the updater target only ClawSweeper-owned status comments:

1. Preserve empty CLI values correctly so `--marker ""` stays empty instead of becoming `"true"`.
2. Pass `status_comment_id` from the comment-router dispatch into the sweep workflow.
3. Prefer exact `status_comment_id` targeting when updating progress comments.
4. Keep marker matching only as a fallback, and only across trusted ClawSweeper bot comments.
5. If neither exact id nor trusted marker fallback finds a status comment, log a warning and skip the update instead of editing any other comment.

## Tests

- Added regression tests for empty-marker parsing and the reported human-comment mis-targeting path.
- Added tests for exact `status_comment_id` preference and trusted-bot-only marker fallback.
