### PR TITLE
Add ClawSweeper triage priority labels e.g. P0, P1, P2, P3

### DIFF
--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -69,6 +69,18 @@ outside OpenClaw core. Set `requiresNewFeature`, `requiresNewConfigOption`, and
 `requiresProductDecision` independently. Any true value means the item is not a
 strict bug-fix automation candidate even if useful.
 
+Set `triagePriority` as ClawSweeper's maintainer-facing priority label for both
+issues and pull requests. This is not the same as `reviewFindings[].priority`
+and is not limited to PR patch defects. Use `P0` for critical production-breaking,
+data-loss, security-impacting, or core-operation-blocking work that needs
+immediate maintainer attention. Use `P1` for important user-facing bugs, serious
+regressions, broken major workflows, or urgent maintainer-priority work that
+should be handled soon. Use `P2` for meaningful bugs, incomplete behavior,
+polish issues, or useful improvements with limited blast radius and normal
+backlog priority. Use `P3` for minor cleanup, documentation, cosmetic polish,
+small ergonomics issues, or speculative improvements. Use `none` only when
+ClawSweeper should intentionally leave priority labels absent.
+
 Populate structured reproduction metadata separately from the public prose.
 Use `reproductionStatus: "reproduced"` only when there is a concrete,
 current-main reproduction path for the bug with high confidence. Use
@@ -394,6 +406,12 @@ Always fill `telegramVisibleProof`. This only controls the
 visible chat behavior the `telegram-crabbox-e2e-proof` skill can show in a
 short recording. Mark it `not_needed` for non-Telegram PRs or Telegram work
 that is not usefully visible in that recording.
+
+Always fill `triagePriority`. ClawSweeper syncs this value to one of
+`priority:P0`, `priority:P1`, `priority:P2`, or `priority:P3` so maintainers can
+find issues and pull requests by priority. Choose the priority from user impact,
+severity, confidence, and maintainer urgency for the item as a whole, not just
+from PR review findings or whether ClawSweeper can automatically repair it.
 
 Always fill the work-lane fields too. For non-candidates, use
 `workCandidate: "none"`, low confidence/priority, an empty `workPrompt`, and

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -407,11 +407,11 @@ visible chat behavior the `telegram-crabbox-e2e-proof` skill can show in a
 short recording. Mark it `not_needed` for non-Telegram PRs or Telegram work
 that is not usefully visible in that recording.
 
-Always fill `triagePriority`. ClawSweeper syncs this value to one of
-`priority:P0`, `priority:P1`, `priority:P2`, or `priority:P3` so maintainers can
-find issues and pull requests by priority. Choose the priority from user impact,
-severity, confidence, and maintainer urgency for the item as a whole, not just
-from PR review findings or whether ClawSweeper can automatically repair it.
+Always fill `triagePriority`. ClawSweeper syncs this value to one of the GitHub
+labels `P0`, `P1`, `P2`, or `P3` so maintainers can find issues and pull requests
+by priority. Choose the priority from user impact, severity, confidence, and
+maintainer urgency for the item as a whole, not just from PR review findings or
+whether ClawSweeper can automatically repair it.
 
 Always fill the work-lane fields too. For non-candidates, use
 `workCandidate: "none"`, low confidence/priority, an empty `workPrompt`, and

--- a/schema/clawsweeper-decision.schema.json
+++ b/schema/clawsweeper-decision.schema.json
@@ -12,6 +12,7 @@
     "likelyOwners",
     "risks",
     "bestSolution",
+    "triagePriority",
     "itemCategory",
     "reproductionStatus",
     "reproductionConfidence",
@@ -150,6 +151,11 @@
     "bestSolution": {
       "type": "string",
       "description": "The best possible product/code/docs direction for this item, whether the item should close or stay open. Do not repeat the change summary, workReason, or risk list."
+    },
+    "triagePriority": {
+      "type": "string",
+      "enum": ["P0", "P1", "P2", "P3", "none"],
+      "description": "ClawSweeper-maintained triage priority for maintainers to sort issues and pull requests. Use P0 for critical production-breaking, data-loss, security-impacting, or core-operation-blocking work; P1 for important user-facing bugs, serious regressions, broken major workflows, or urgent maintainer-priority work; P2 for meaningful bugs, incomplete behavior, polish issues, or useful improvements with limited blast radius; P3 for minor cleanup, documentation, cosmetic polish, small ergonomics issues, or speculative improvements; use none only when no priority label should be applied."
     },
     "itemCategory": {
       "type": "string",

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -64,6 +64,7 @@ type ItemKind = "issue" | "pull_request";
 type ApplyKind = ItemKind | "all";
 type DecisionKind = "close" | "keep_open";
 type WorkCandidateKind = "none" | "manual_review" | "queue_fix_pr";
+type TriagePriority = "P0" | "P1" | "P2" | "P3" | "none";
 type ItemCategory =
   | "bug"
   | "regression"
@@ -273,6 +274,7 @@ interface Decision {
   likelyOwners: LikelyOwner[];
   risks: string[];
   bestSolution: string;
+  triagePriority: TriagePriority;
   itemCategory: ItemCategory;
   reproductionStatus: ReproductionStatus;
   reproductionConfidence: Confidence;
@@ -678,6 +680,7 @@ const TELEGRAM_VISIBLE_PROOF_LABEL_DESCRIPTION = "Mantis should capture Telegram
 const PRIORITY_LABELS = [
   {
     priority: 0,
+    triagePriority: "P0",
     name: "priority:P0",
     color: "B60205",
     description:
@@ -685,6 +688,7 @@ const PRIORITY_LABELS = [
   },
   {
     priority: 1,
+    triagePriority: "P1",
     name: "priority:P1",
     color: "D93F0B",
     description:
@@ -692,6 +696,7 @@ const PRIORITY_LABELS = [
   },
   {
     priority: 2,
+    triagePriority: "P2",
     name: "priority:P2",
     color: "FBCA04",
     description:
@@ -699,6 +704,7 @@ const PRIORITY_LABELS = [
   },
   {
     priority: 3,
+    triagePriority: "P3",
     name: "priority:P3",
     color: "0E8A16",
     description:
@@ -722,6 +728,7 @@ const ALLOWED_REASONS = new Set<CloseReason>([
 const ALL_REASONS = new Set<CloseReason>([...ALLOWED_REASONS, "none"]);
 const DECISIONS = new Set<DecisionKind>(["close", "keep_open"]);
 const WORK_CANDIDATES = new Set<WorkCandidateKind>(["none", "manual_review", "queue_fix_pr"]);
+const TRIAGE_PRIORITIES = new Set<TriagePriority>(["P0", "P1", "P2", "P3", "none"]);
 const ITEM_CATEGORIES = new Set<ItemCategory>([
   "bug",
   "regression",
@@ -787,6 +794,7 @@ const DECISION_SCHEMA_KEYS = new Set([
   "likelyOwners",
   "risks",
   "bestSolution",
+  "triagePriority",
   "itemCategory",
   "reproductionStatus",
   "reproductionConfidence",
@@ -1350,6 +1358,7 @@ function normalizeDecisionForItem(
     ...decision,
     reviewFindings,
     bestSolution: CLEAN_OPENCLAW_PR_REVIEW_NEXT_STEP,
+    triagePriority: decision.triagePriority,
     overallCorrectness:
       decision.overallCorrectness === "patch is incorrect"
         ? "patch is correct"
@@ -1464,6 +1473,11 @@ export function parseDecision(value: unknown, item?: DecisionNormalizationItem):
       (risk) => !isEnvironmentAccessCaveat(risk),
     ),
     bestSolution: requireString(record.bestSolution, "decision.bestSolution"),
+    triagePriority: requireEnum(
+      record.triagePriority,
+      TRIAGE_PRIORITIES,
+      "decision.triagePriority",
+    ),
     itemCategory: requireEnum(record.itemCategory, ITEM_CATEGORIES, "decision.itemCategory"),
     reproductionStatus: requireEnum(
       record.reproductionStatus,
@@ -3728,6 +3742,7 @@ function codexFailureDecision(status: number | null, stderr: string, stdout = ""
     ],
     risks: ["No close action taken because the review did not complete."],
     bestSolution: "Retry the Codex review after fixing the execution failure.",
+    triagePriority: "none",
     itemCategory: "unclear",
     reproductionStatus: "unclear",
     reproductionConfidence: "low",
@@ -4814,6 +4829,11 @@ function reportOverallConfidenceScore(markdown: string): number {
   return Number.isFinite(score) && score >= 0 && score <= 1 ? score : 0;
 }
 
+function triagePriorityFromReport(markdown: string): TriagePriority {
+  const value = frontMatterValue(markdown, "triage_priority");
+  return TRIAGE_PRIORITIES.has(value as TriagePriority) ? (value as TriagePriority) : "none";
+}
+
 function reportReviewFindings(markdown: string): ReviewFinding[] {
   const section = reviewSectionValue(markdown, "reviewFindings");
   const findings: ReviewFinding[] = [];
@@ -5077,19 +5097,13 @@ export function telegramVisibleProofLabelsForTest(
 
 type PriorityLabelSpec = (typeof PRIORITY_LABELS)[number];
 
-function priorityLabelForFindings(
-  findings: readonly Pick<ReviewFinding, "priority">[],
-): PriorityLabelSpec | null {
-  const priority = Math.min(...findings.map((finding) => finding.priority));
-  return PRIORITY_LABELS.find((label) => label.priority === priority) ?? null;
+function priorityLabelForTriage(priority: TriagePriority): PriorityLabelSpec | null {
+  return PRIORITY_LABELS.find((label) => label.triagePriority === priority) ?? null;
 }
 
-function nextPriorityLabels(
-  labels: readonly string[],
-  findings: readonly Pick<ReviewFinding, "priority">[],
-): string[] {
+function nextPriorityLabels(labels: readonly string[], triagePriority: TriagePriority): string[] {
   const nextLabels = labels.filter((label) => !PRIORITY_LABEL_NAMES.has(label));
-  const priorityLabel = priorityLabelForFindings(findings);
+  const priorityLabel = priorityLabelForTriage(triagePriority);
   if (priorityLabel) nextLabels.push(priorityLabel.name);
   return nextLabels;
 }
@@ -5102,14 +5116,11 @@ export function priorityLabelSchemeForTest(): {
   return PRIORITY_LABELS.map(({ name, color, description }) => ({ name, color, description }));
 }
 
-export function priorityLabelsForTest(
-  labels: readonly string[],
-  priorities: readonly number[],
-): string[] {
-  const findings = priorities
-    .filter((priority): priority is ReviewFinding["priority"] => [0, 1, 2, 3].includes(priority))
-    .map((priority) => ({ priority }));
-  return nextPriorityLabels(labels, findings);
+export function priorityLabelsForTest(labels: readonly string[], triagePriority: string): string[] {
+  const priority = TRIAGE_PRIORITIES.has(triagePriority as TriagePriority)
+    ? (triagePriority as TriagePriority)
+    : "none";
+  return nextPriorityLabels(labels, priority);
 }
 
 function ensurePriorityLabel(label: PriorityLabelSpec): void {
@@ -5127,10 +5138,10 @@ function ensurePriorityLabel(label: PriorityLabelSpec): void {
 function syncPriorityLabel(options: {
   number: number;
   labels: readonly string[];
-  findings: readonly Pick<ReviewFinding, "priority">[];
+  triagePriority: TriagePriority;
   dryRun: boolean;
 }): string[] {
-  const nextLabels = nextPriorityLabels(options.labels, options.findings);
+  const nextLabels = nextPriorityLabels(options.labels, options.triagePriority);
   const labelsToRemove = options.labels.filter(
     (label) => PRIORITY_LABEL_NAMES.has(label) && !nextLabels.includes(label),
   );
@@ -5419,6 +5430,7 @@ function reportDecision(markdown: string, closeReason: CloseReason): Decision {
     likelyOwners: reportLikelyOwners(markdown),
     risks: [],
     bestSolution: reviewSectionValue(markdown, "bestSolution"),
+    triagePriority: triagePriorityFromReport(markdown),
     itemCategory:
       (frontMatterValue(markdown, "item_category") as ItemCategory | undefined) ?? "unclear",
     reproductionStatus:
@@ -6742,6 +6754,7 @@ work_prompt_sha256: ${options.decision.workPrompt ? sha256(options.decision.work
 work_cluster_refs: ${jsonFrontMatterValue(options.decision.workClusterRefs)}
 work_validation: ${jsonFrontMatterValue(options.decision.workValidation)}
 work_likely_files: ${jsonFrontMatterValue(options.decision.workLikelyFiles)}
+triage_priority: ${options.decision.triagePriority}
 pull_files: ${jsonFrontMatterValue(pullFiles)}
 pull_files_truncated: ${pullFilesTruncated}
 item_category: ${options.decision.itemCategory}
@@ -7245,10 +7258,12 @@ function applyDecisionsCommand(args: Args): void {
         proof: reportTelegramVisibleProof(markdown),
         dryRun,
       });
+    }
+    if (state === "open") {
       item.labels = syncPriorityLabel({
         number,
         labels: item.labels,
-        findings: reportReviewFindings(markdown),
+        triagePriority: triagePriorityFromReport(markdown),
         dryRun,
       });
     }

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -675,6 +675,39 @@ const PROOF_SUFFICIENT_LABEL_DESCRIPTION = "Contributor real behavior proof is s
 const TELEGRAM_VISIBLE_PROOF_LABEL = "mantis: telegram-visible-proof";
 const TELEGRAM_VISIBLE_PROOF_LABEL_COLOR = "5319e7";
 const TELEGRAM_VISIBLE_PROOF_LABEL_DESCRIPTION = "Mantis should capture Telegram visible proof.";
+const PRIORITY_LABELS = [
+  {
+    priority: 0,
+    name: "priority:P0",
+    color: "B60205",
+    description:
+      "Critical: production-breaking, data-loss, security-impacting, or blocks core project operation; needs immediate maintainer attention.",
+  },
+  {
+    priority: 1,
+    name: "priority:P1",
+    color: "D93F0B",
+    description:
+      "High: important user-facing bug, serious regression, broken major workflow, or urgent maintainer-priority work; should be handled soon.",
+  },
+  {
+    priority: 2,
+    name: "priority:P2",
+    color: "FBCA04",
+    description:
+      "Medium: meaningful bug, incomplete behavior, polish issue, or useful improvement with limited blast radius; normal backlog priority.",
+  },
+  {
+    priority: 3,
+    name: "priority:P3",
+    color: "0E8A16",
+    description:
+      "Low: minor cleanup, documentation, cosmetic polish, small ergonomics issue, or speculative improvement; handle when convenient.",
+  },
+] as const;
+const PRIORITY_LABEL_NAMES: ReadonlySet<string> = new Set(
+  PRIORITY_LABELS.map((label) => label.name),
+);
 const PROTECTED_LABELS = new Set(["security", "beta-blocker", "release-blocker", "maintainer"]);
 const ALLOWED_REASONS = new Set<CloseReason>([
   "implemented_on_main",
@@ -5042,6 +5075,83 @@ export function telegramVisibleProofLabelsForTest(
   return nextTelegramVisibleProofLabels(labels, { status: proofStatus });
 }
 
+type PriorityLabelSpec = (typeof PRIORITY_LABELS)[number];
+
+function priorityLabelForFindings(
+  findings: readonly Pick<ReviewFinding, "priority">[],
+): PriorityLabelSpec | null {
+  const priority = Math.min(...findings.map((finding) => finding.priority));
+  return PRIORITY_LABELS.find((label) => label.priority === priority) ?? null;
+}
+
+function nextPriorityLabels(
+  labels: readonly string[],
+  findings: readonly Pick<ReviewFinding, "priority">[],
+): string[] {
+  const nextLabels = labels.filter((label) => !PRIORITY_LABEL_NAMES.has(label));
+  const priorityLabel = priorityLabelForFindings(findings);
+  if (priorityLabel) nextLabels.push(priorityLabel.name);
+  return nextLabels;
+}
+
+export function priorityLabelSchemeForTest(): {
+  name: string;
+  color: string;
+  description: string;
+}[] {
+  return PRIORITY_LABELS.map(({ name, color, description }) => ({ name, color, description }));
+}
+
+export function priorityLabelsForTest(
+  labels: readonly string[],
+  priorities: readonly number[],
+): string[] {
+  const findings = priorities
+    .filter((priority): priority is ReviewFinding["priority"] => [0, 1, 2, 3].includes(priority))
+    .map((priority) => ({ priority }));
+  return nextPriorityLabels(labels, findings);
+}
+
+function ensurePriorityLabel(label: PriorityLabelSpec): void {
+  try {
+    ghWithRetry(
+      ["label", "create", label.name, "--color", label.color, "--description", label.description],
+      2,
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!/already exists/i.test(message)) throw error;
+  }
+}
+
+function syncPriorityLabel(options: {
+  number: number;
+  labels: readonly string[];
+  findings: readonly Pick<ReviewFinding, "priority">[];
+  dryRun: boolean;
+}): string[] {
+  const nextLabels = nextPriorityLabels(options.labels, options.findings);
+  const labelsToRemove = options.labels.filter(
+    (label) => PRIORITY_LABEL_NAMES.has(label) && !nextLabels.includes(label),
+  );
+  const labelToAdd = nextLabels.find(
+    (label) => PRIORITY_LABEL_NAMES.has(label) && !options.labels.includes(label),
+  );
+  if (labelsToRemove.length === 0 && !labelToAdd) return nextLabels;
+  if (options.dryRun) return nextLabels;
+  if (labelToAdd) {
+    const priorityLabel = PRIORITY_LABELS.find((label) => label.name === labelToAdd);
+    if (priorityLabel) ensurePriorityLabel(priorityLabel);
+  }
+  for (const label of labelsToRemove) {
+    ghWithRetry(["issue", "edit", String(options.number), "--remove-label", label]);
+  }
+  if (labelToAdd) {
+    ghWithRetry(["issue", "edit", String(options.number), "--add-label", labelToAdd]);
+  }
+  return nextLabels;
+}
+
 function syncTelegramVisibleProofLabel(options: {
   number: number;
   labels: readonly string[];
@@ -7133,6 +7243,12 @@ function applyDecisionsCommand(args: Args): void {
         number,
         labels: item.labels,
         proof: reportTelegramVisibleProof(markdown),
+        dryRun,
+      });
+      item.labels = syncPriorityLabel({
+        number,
+        labels: item.labels,
+        findings: reportReviewFindings(markdown),
         dryRun,
       });
     }

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -681,7 +681,7 @@ const PRIORITY_LABELS = [
   {
     priority: 0,
     triagePriority: "P0",
-    name: "priority:P0",
+    name: "P0",
     color: "B60205",
     description:
       "Critical: production-breaking, data-loss, security-impacting, or blocks core project operation; needs immediate maintainer attention.",
@@ -689,7 +689,7 @@ const PRIORITY_LABELS = [
   {
     priority: 1,
     triagePriority: "P1",
-    name: "priority:P1",
+    name: "P1",
     color: "D93F0B",
     description:
       "High: important user-facing bug, serious regression, broken major workflow, or urgent maintainer-priority work; should be handled soon.",
@@ -697,7 +697,7 @@ const PRIORITY_LABELS = [
   {
     priority: 2,
     triagePriority: "P2",
-    name: "priority:P2",
+    name: "P2",
     color: "FBCA04",
     description:
       "Medium: meaningful bug, incomplete behavior, polish issue, or useful improvement with limited blast radius; normal backlog priority.",
@@ -705,7 +705,7 @@ const PRIORITY_LABELS = [
   {
     priority: 3,
     triagePriority: "P3",
-    name: "priority:P3",
+    name: "P3",
     color: "0E8A16",
     description:
       "Low: minor cleanup, documentation, cosmetic polish, small ergonomics issue, or speculative improvement; handle when convenient.",

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -150,6 +150,7 @@ function closeDecision(overrides = {}) {
     ],
     risks: [],
     bestSolution: "Keep the implementation as-is.",
+    triagePriority: "P2",
     itemCategory: "bug",
     reproductionStatus: "reproduced",
     reproductionConfidence: "high",
@@ -3401,6 +3402,14 @@ test("decision parser enforces required schema-shaped evidence", () => {
     () =>
       parseDecision({
         ...closeDecision(),
+        triagePriority: "urgent",
+      }),
+    /decision\.triagePriority/,
+  );
+  assert.throws(
+    () =>
+      parseDecision({
+        ...closeDecision(),
         requiresNewConfigOption: "false",
       }),
     /decision\.requiresNewConfigOption/,
@@ -3431,6 +3440,7 @@ test("decision parser enforces required schema-shaped evidence", () => {
     }),
   );
   assert.equal(workCandidate.workCandidate, "queue_fix_pr");
+  assert.equal(workCandidate.triagePriority, "P2");
   assert.equal(workCandidate.itemCategory, "bug");
   assert.equal(workCandidate.reproductionStatus, "reproduced");
   assert.equal(workCandidate.realBehaviorProof.status, "not_applicable");
@@ -3572,10 +3582,10 @@ test("ClawSweeper priority label scheme exposes P0 through P3 labels", () => {
   ]);
 });
 
-test("ClawSweeper priority labels follow the highest-severity review finding", () => {
-  assert.deepEqual(priorityLabelsForTest(["bug"], [2]), ["bug", "priority:P2"]);
-  assert.deepEqual(priorityLabelsForTest(["bug", "priority:P3"], [1, 3]), ["bug", "priority:P1"]);
-  assert.deepEqual(priorityLabelsForTest(["priority:P0", "bug"], []), ["bug"]);
+test("ClawSweeper priority labels follow triage priority", () => {
+  assert.deepEqual(priorityLabelsForTest(["bug"], "P2"), ["bug", "priority:P2"]);
+  assert.deepEqual(priorityLabelsForTest(["bug", "priority:P3"], "P1"), ["bug", "priority:P1"]);
+  assert.deepEqual(priorityLabelsForTest(["priority:P0", "bug"], "none"), ["bug"]);
 });
 
 test("review workflow gives Codex a read-only inspection token", () => {
@@ -3737,6 +3747,9 @@ test("review prompts require reproduction and solution assessment details", () =
   assert.match(itemPrompt, /Always fill `reproductionAssessment`/);
   assert.match(itemPrompt, /itemCategory: "bug"/);
   assert.match(itemPrompt, /itemCategory: "skill"/);
+  assert.match(itemPrompt, /Always fill `triagePriority`/);
+  assert.match(itemPrompt, /maintainers can\s+find issues and pull requests by priority/);
+  assert.match(itemPrompt, /not just\s+from PR review findings/);
   assert.match(itemPrompt, /skills\/<vendor>/);
   assert.match(itemPrompt, /upload or publish it through ClawHub\.com/);
   assert.match(itemPrompt, /requiresNewConfigOption/);

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -3556,25 +3556,25 @@ test("ClawSweeper Telegram proof judgement controls the Mantis proof label", () 
 test("ClawSweeper priority label scheme exposes P0 through P3 labels", () => {
   assert.deepEqual(priorityLabelSchemeForTest(), [
     {
-      name: "priority:P0",
+      name: "P0",
       color: "B60205",
       description:
         "Critical: production-breaking, data-loss, security-impacting, or blocks core project operation; needs immediate maintainer attention.",
     },
     {
-      name: "priority:P1",
+      name: "P1",
       color: "D93F0B",
       description:
         "High: important user-facing bug, serious regression, broken major workflow, or urgent maintainer-priority work; should be handled soon.",
     },
     {
-      name: "priority:P2",
+      name: "P2",
       color: "FBCA04",
       description:
         "Medium: meaningful bug, incomplete behavior, polish issue, or useful improvement with limited blast radius; normal backlog priority.",
     },
     {
-      name: "priority:P3",
+      name: "P3",
       color: "0E8A16",
       description:
         "Low: minor cleanup, documentation, cosmetic polish, small ergonomics issue, or speculative improvement; handle when convenient.",
@@ -3583,9 +3583,9 @@ test("ClawSweeper priority label scheme exposes P0 through P3 labels", () => {
 });
 
 test("ClawSweeper priority labels follow triage priority", () => {
-  assert.deepEqual(priorityLabelsForTest(["bug"], "P2"), ["bug", "priority:P2"]);
-  assert.deepEqual(priorityLabelsForTest(["bug", "priority:P3"], "P1"), ["bug", "priority:P1"]);
-  assert.deepEqual(priorityLabelsForTest(["priority:P0", "bug"], "none"), ["bug"]);
+  assert.deepEqual(priorityLabelsForTest(["bug"], "P2"), ["bug", "P2"]);
+  assert.deepEqual(priorityLabelsForTest(["bug", "P3"], "P1"), ["bug", "P1"]);
+  assert.deepEqual(priorityLabelsForTest(["P0", "bug"], "none"), ["bug"]);
 });
 
 test("review workflow gives Codex a read-only inspection token", () => {
@@ -3748,7 +3748,7 @@ test("review prompts require reproduction and solution assessment details", () =
   assert.match(itemPrompt, /itemCategory: "bug"/);
   assert.match(itemPrompt, /itemCategory: "skill"/);
   assert.match(itemPrompt, /Always fill `triagePriority`/);
-  assert.match(itemPrompt, /maintainers can\s+find issues and pull requests by priority/);
+  assert.match(itemPrompt, /maintainers\s+can find issues and pull requests\s+by priority/);
   assert.match(itemPrompt, /not just\s+from PR review findings/);
   assert.match(itemPrompt, /skills\/<vendor>/);
   assert.match(itemPrompt, /upload or publish it through ClawHub\.com/);

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -39,6 +39,8 @@ import {
   parseGhJson,
   parseGhJsonLines,
   parseDecision,
+  priorityLabelsForTest,
+  priorityLabelSchemeForTest,
   protectedLabels,
   realBehaviorProofSufficientLabelsForTest,
   relatedTitleSearchTerms,
@@ -3539,6 +3541,41 @@ test("ClawSweeper Telegram proof judgement controls the Mantis proof label", () 
     ),
     ["channel: telegram"],
   );
+});
+
+test("ClawSweeper priority label scheme exposes P0 through P3 labels", () => {
+  assert.deepEqual(priorityLabelSchemeForTest(), [
+    {
+      name: "priority:P0",
+      color: "B60205",
+      description:
+        "Critical: production-breaking, data-loss, security-impacting, or blocks core project operation; needs immediate maintainer attention.",
+    },
+    {
+      name: "priority:P1",
+      color: "D93F0B",
+      description:
+        "High: important user-facing bug, serious regression, broken major workflow, or urgent maintainer-priority work; should be handled soon.",
+    },
+    {
+      name: "priority:P2",
+      color: "FBCA04",
+      description:
+        "Medium: meaningful bug, incomplete behavior, polish issue, or useful improvement with limited blast radius; normal backlog priority.",
+    },
+    {
+      name: "priority:P3",
+      color: "0E8A16",
+      description:
+        "Low: minor cleanup, documentation, cosmetic polish, small ergonomics issue, or speculative improvement; handle when convenient.",
+    },
+  ]);
+});
+
+test("ClawSweeper priority labels follow the highest-severity review finding", () => {
+  assert.deepEqual(priorityLabelsForTest(["bug"], [2]), ["bug", "priority:P2"]);
+  assert.deepEqual(priorityLabelsForTest(["bug", "priority:P3"], [1, 3]), ["bug", "priority:P1"]);
+  assert.deepEqual(priorityLabelsForTest(["priority:P0", "bug"], []), ["bug"]);
 });
 
 test("review workflow gives Codex a read-only inspection token", () => {


### PR DESCRIPTION
## Summary

- add `triagePriority` to ClawSweeper item review decisions for issues and PRs
- sync ClawSweeper-driven GitHub labels `P0`, `P1`, `P2`, or `P3` from that triage field
- keep `reviewFindings[].priority` unchanged for PR code-review finding severity

## Details

This makes priority labels a maintainer-facing triage output instead of deriving them from PR review findings. ClawSweeper stores the chosen priority in report frontmatter as `triage_priority`, then apply mode keeps exactly one bare priority label on each open issue or PR. If ClawSweeper emits `none`, stale `P0`-`P3` labels are removed.

The prompt and JSON schema now require ClawSweeper to choose triage priority separately from repair eligibility, close decisions, and PR finding severity.

## Validation

- `pnpm run format`
- `pnpm run build`
- `node --test test/clawsweeper.test.ts`
- `git diff --check`
- `pnpm run check`
