### PR TITLE
Fit priority label descriptions to GitHub limit

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -683,32 +683,28 @@ const PRIORITY_LABELS = [
     triagePriority: "P0",
     name: "P0",
     color: "B60205",
-    description:
-      "Critical: production-breaking, data-loss, security-impacting, or blocks core project operation; needs immediate maintainer attention.",
+    description: "Critical impact; needs immediate maintainer attention.",
   },
   {
     priority: 1,
     triagePriority: "P1",
     name: "P1",
     color: "D93F0B",
-    description:
-      "High: important user-facing bug, serious regression, broken major workflow, or urgent maintainer-priority work; should be handled soon.",
+    description: "High-priority user-facing bug, regression, or broken workflow.",
   },
   {
     priority: 2,
     triagePriority: "P2",
     name: "P2",
     color: "FBCA04",
-    description:
-      "Medium: meaningful bug, incomplete behavior, polish issue, or useful improvement with limited blast radius; normal backlog priority.",
+    description: "Normal backlog priority with limited blast radius.",
   },
   {
     priority: 3,
     triagePriority: "P3",
     name: "P3",
     color: "0E8A16",
-    description:
-      "Low: minor cleanup, documentation, cosmetic polish, small ergonomics issue, or speculative improvement; handle when convenient.",
+    description: "Low-priority cleanup, docs, polish, ergonomics, or speculative work.",
   },
 ] as const;
 const PRIORITY_LABEL_NAMES: ReadonlySet<string> = new Set(

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -3558,28 +3558,33 @@ test("ClawSweeper priority label scheme exposes P0 through P3 labels", () => {
     {
       name: "P0",
       color: "B60205",
-      description:
-        "Critical: production-breaking, data-loss, security-impacting, or blocks core project operation; needs immediate maintainer attention.",
+      description: "Critical impact; needs immediate maintainer attention.",
     },
     {
       name: "P1",
       color: "D93F0B",
-      description:
-        "High: important user-facing bug, serious regression, broken major workflow, or urgent maintainer-priority work; should be handled soon.",
+      description: "High-priority user-facing bug, regression, or broken workflow.",
     },
     {
       name: "P2",
       color: "FBCA04",
-      description:
-        "Medium: meaningful bug, incomplete behavior, polish issue, or useful improvement with limited blast radius; normal backlog priority.",
+      description: "Normal backlog priority with limited blast radius.",
     },
     {
       name: "P3",
       color: "0E8A16",
-      description:
-        "Low: minor cleanup, documentation, cosmetic polish, small ergonomics issue, or speculative improvement; handle when convenient.",
+      description: "Low-priority cleanup, docs, polish, ergonomics, or speculative work.",
     },
   ]);
+});
+
+test("ClawSweeper priority label descriptions fit GitHub label limits", () => {
+  for (const label of priorityLabelSchemeForTest()) {
+    assert.ok(
+      label.description.length <= 100,
+      `${label.name} description is ${label.description.length} characters`,
+    );
+  }
 });
 
 test("ClawSweeper priority labels follow triage priority", () => {


### PR DESCRIPTION
## Summary
- Shorten the ClawSweeper P0-P3 GitHub label descriptions so each is at or below GitHub's 100-character limit.
- Add a focused unit test that enforces the GitHub label description limit for the priority label scheme.
- Keeps triagePriority-driven P0-P3 label syncing behavior unchanged.

## Root cause
GitHub label descriptions are limited to 100 characters. The newly added priority label descriptions exceeded that limit, so apply-decisions failed while creating labels, as seen in the ClawSweeper run for openclaw/openclaw#82625.

## Validation
- `pnpm run format`
- `pnpm run build`
- `node --test test/clawsweeper.test.ts`
- `git diff --check`
- `pnpm run check`