### PR TITLE
Refine priority label descriptions

### DIFF
--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -71,15 +71,12 @@ strict bug-fix automation candidate even if useful.
 
 Set `triagePriority` as ClawSweeper's maintainer-facing priority label for both
 issues and pull requests. This is not the same as `reviewFindings[].priority`
-and is not limited to PR patch defects. Use `P0` for critical production-breaking,
-data-loss, security-impacting, or core-operation-blocking work that needs
-immediate maintainer attention. Use `P1` for important user-facing bugs, serious
-regressions, broken major workflows, or urgent maintainer-priority work that
-should be handled soon. Use `P2` for meaningful bugs, incomplete behavior,
-polish issues, or useful improvements with limited blast radius and normal
-backlog priority. Use `P3` for minor cleanup, documentation, cosmetic polish,
-small ergonomics issues, or speculative improvements. Use `none` only when
-ClawSweeper should intentionally leave priority labels absent.
+and is not limited to PR patch defects. Use the current GitHub label rubric:
+`P0`: Emergency: data loss, security bypass, crash loop, or unusable core runtime.
+`P1`: Urgent regression or broken agent/channel workflow affecting real users now.
+`P2`: Normal priority bug or improvement with limited blast radius.
+`P3`: Low-risk cleanup, docs, polish, ergonomics, or speculative feature.
+Use `none` only when ClawSweeper should intentionally leave priority labels absent.
 
 Populate structured reproduction metadata separately from the public prose.
 Use `reproductionStatus: "reproduced"` only when there is a concrete,

--- a/schema/clawsweeper-decision.schema.json
+++ b/schema/clawsweeper-decision.schema.json
@@ -155,7 +155,7 @@
     "triagePriority": {
       "type": "string",
       "enum": ["P0", "P1", "P2", "P3", "none"],
-      "description": "ClawSweeper-maintained triage priority for maintainers to sort issues and pull requests. Use P0 for critical production-breaking, data-loss, security-impacting, or core-operation-blocking work; P1 for important user-facing bugs, serious regressions, broken major workflows, or urgent maintainer-priority work; P2 for meaningful bugs, incomplete behavior, polish issues, or useful improvements with limited blast radius; P3 for minor cleanup, documentation, cosmetic polish, small ergonomics issues, or speculative improvements; use none only when no priority label should be applied."
+      "description": "ClawSweeper-maintained triage priority for maintainers to sort issues and pull requests. P0: Emergency: data loss, security bypass, crash loop, or unusable core runtime. P1: Urgent regression or broken agent/channel workflow affecting real users now. P2: Normal priority bug or improvement with limited blast radius. P3: Low-risk cleanup, docs, polish, ergonomics, or speculative feature. Use none only when no priority label should be applied."
     },
     "itemCategory": {
       "type": "string",

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -710,7 +710,7 @@ const PRIORITY_LABELS = [
     triagePriority: "P2",
     name: "P2",
     color: "FBCA04",
-    description: "Normal backlog priority with limited blast radius.",
+    description: "Normal priority bug or improvement with limited blast radius.",
   },
   {
     priority: 3,

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -696,14 +696,14 @@ const PRIORITY_LABELS = [
     triagePriority: "P0",
     name: "P0",
     color: "B60205",
-    description: "Critical impact; needs immediate maintainer attention.",
+    description: "Emergency: data loss, security bypass, crash loop, or unusable core runtime.",
   },
   {
     priority: 1,
     triagePriority: "P1",
     name: "P1",
     color: "D93F0B",
-    description: "High-priority user-facing bug, regression, or broken workflow.",
+    description: "Urgent regression or broken agent/channel workflow affecting real users now.",
   },
   {
     priority: 2,
@@ -717,7 +717,7 @@ const PRIORITY_LABELS = [
     triagePriority: "P3",
     name: "P3",
     color: "0E8A16",
-    description: "Low-priority cleanup, docs, polish, ergonomics, or speculative work.",
+    description: "Low-risk cleanup, docs, polish, ergonomics, or speculative feature.",
   },
 ] as const;
 const PRIORITY_LABEL_NAMES: ReadonlySet<string> = new Set(

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -4361,7 +4361,7 @@ test("ClawSweeper priority label scheme exposes P0 through P3 labels", () => {
     {
       name: "P2",
       color: "FBCA04",
-      description: "Normal backlog priority with limited blast radius.",
+      description: "Normal priority bug or improvement with limited blast radius.",
     },
     {
       name: "P3",
@@ -4376,6 +4376,28 @@ test("ClawSweeper priority label descriptions fit GitHub label limits", () => {
     assert.ok(
       label.description.length <= 100,
       `${label.name} description is ${label.description.length} characters`,
+    );
+  }
+});
+
+test("ClawSweeper priority label descriptions stay aligned with prompt and schema", () => {
+  const schema = JSON.parse(reviewDecisionSchemaText()) as {
+    properties?: {
+      triagePriority?: {
+        description?: string;
+      };
+    };
+  };
+  const schemaDescription = schema.properties?.triagePriority?.description ?? "";
+  const prompt = reviewPromptTemplate();
+  for (const label of priorityLabelSchemeForTest()) {
+    assert.ok(
+      prompt.includes(`\`${label.name}\`: ${label.description}`),
+      `${label.name} description is missing from the review prompt`,
+    );
+    assert.ok(
+      schemaDescription.includes(`${label.name}: ${label.description}`),
+      `${label.name} description is missing from the schema`,
     );
   }
 });

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -4351,12 +4351,12 @@ test("ClawSweeper priority label scheme exposes P0 through P3 labels", () => {
     {
       name: "P0",
       color: "B60205",
-      description: "Critical impact; needs immediate maintainer attention.",
+      description: "Emergency: data loss, security bypass, crash loop, or unusable core runtime.",
     },
     {
       name: "P1",
       color: "D93F0B",
-      description: "High-priority user-facing bug, regression, or broken workflow.",
+      description: "Urgent regression or broken agent/channel workflow affecting real users now.",
     },
     {
       name: "P2",
@@ -4366,7 +4366,7 @@ test("ClawSweeper priority label scheme exposes P0 through P3 labels", () => {
     {
       name: "P3",
       color: "0E8A16",
-      description: "Low-priority cleanup, docs, polish, ergonomics, or speculative work.",
+      description: "Low-risk cleanup, docs, polish, ergonomics, or speculative feature.",
     },
   ]);
 });


### PR DESCRIPTION
## Summary
- Refine the P0-P3 GitHub label descriptions using the older OpenClaw issue and PR queue analysis.
- Keep the bare P0/P1/P2/P3 labels, colors, and sync behavior unchanged.
- Update the focused priority label scheme test expectations; the existing <=100 character guard still covers all descriptions.

## Descriptions
- P0: Emergency: data loss, security bypass, crash loop, or unusable core runtime.
- P1: Urgent regression or broken agent/channel workflow affecting real users now.
- P2: Normal priority bug or improvement with limited blast radius.
- P3: Low-risk cleanup, docs, polish, ergonomics, or speculative feature.

## Validation
- `pnpm run format`
- `pnpm run build`
- `node --test test/clawsweeper.test.ts`
- `git diff --check`
- `pnpm run check`