### PR TITLE
feat(labels): add ClawSweeper impact labels

### DIFF
--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -78,6 +78,19 @@ and is not limited to PR patch defects. Use the current GitHub label rubric:
 `P3`: Low-risk cleanup, docs, polish, ergonomics, or speculative feature.
 Use `none` only when ClawSweeper should intentionally leave priority labels absent.
 
+Set `riskLabels` as ClawSweeper-owned GitHub risk labels for maintainers to
+find risk classes on both issues and pull requests. Use no more than 3 labels,
+only when the risk is concretely supported by the item or diff, and keep this
+separate from `triagePriority` and `reviewFindings[].priority`:
+`risk:data-loss`: Can lose, corrupt, or silently drop user/session/config data.
+`risk:security`: Security boundary, credential, authz, sandbox, or sensitive-data risk.
+`risk:crash-loop`: Crash, hang, restart loop, or process-level availability failure.
+`risk:message-loss`: Channel message delivery can be lost, duplicated, or misrouted.
+`risk:session-state`: Session, memory, transcript, context, or agent state can drift or corrupt.
+`risk:auth-provider`: Auth, provider routing, model choice, or SecretRef resolution may break.
+Use an empty array when no owned risk label applies. Risk labels are searchable
+GitHub labels only; they do not close, merge, block, or replace review findings.
+
 Populate structured reproduction metadata separately from the public prose.
 Use `reproductionStatus: "reproduced"` only when there is a concrete,
 current-main reproduction path for the bug with high confidence. Use
@@ -409,6 +422,10 @@ labels `P0`, `P1`, `P2`, or `P3` so maintainers can find issues and pull request
 by priority. Choose the priority from user impact, severity, confidence, and
 maintainer urgency for the item as a whole, not just from PR review findings or
 whether ClawSweeper can automatically repair it.
+
+Always fill `riskLabels` with zero to three ClawSweeper-owned GitHub risk labels.
+These labels are only for maintainer search and triage; they do not replace
+`triagePriority`, `reviewFindings[].priority`, or the security review.
 
 Always fill the work-lane fields too. For non-candidates, use
 `workCandidate: "none"`, low confidence/priority, an empty `workPrompt`, and

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -78,18 +78,21 @@ and is not limited to PR patch defects. Use the current GitHub label rubric:
 `P3`: Low-risk cleanup, docs, polish, ergonomics, or speculative feature.
 Use `none` only when ClawSweeper should intentionally leave priority labels absent.
 
-Set `riskLabels` as ClawSweeper-owned GitHub risk labels for maintainers to
-find risk classes on both issues and pull requests. Use no more than 3 labels,
-only when the risk is concretely supported by the item or diff, and keep this
-separate from `triagePriority` and `reviewFindings[].priority`:
-`risk:data-loss`: Can lose, corrupt, or silently drop user/session/config data.
-`risk:security`: Security boundary, credential, authz, sandbox, or sensitive-data risk.
-`risk:crash-loop`: Crash, hang, restart loop, or process-level availability failure.
-`risk:message-loss`: Channel message delivery can be lost, duplicated, or misrouted.
-`risk:session-state`: Session, memory, transcript, context, or agent state can drift or corrupt.
-`risk:auth-provider`: Auth, provider routing, model choice, or SecretRef resolution may break.
-Use an empty array when no owned risk label applies. Risk labels are searchable
-GitHub labels only; they do not close, merge, block, or replace review findings.
+Set `impactLabels` as ClawSweeper-owned GitHub impact labels for maintainers to
+find the affected problem class on both issues and pull requests. Use no more
+than 3 labels, only when the impact area is concretely supported by the item or
+diff, and keep this separate from `triagePriority` and
+`reviewFindings[].priority`:
+`impact:data-loss`: Can lose, corrupt, or silently drop user/session/config data.
+`impact:security`: Security boundary, credential, authz, sandbox, or sensitive-data risk.
+`impact:crash-loop`: Crash, hang, restart loop, or process-level availability failure.
+`impact:message-loss`: Channel message delivery can be lost, duplicated, or misrouted.
+`impact:session-state`: Session, memory, transcript, context, or agent state can drift or corrupt.
+`impact:auth-provider`: Auth, provider routing, model choice, or SecretRef resolution may break.
+Use an empty array when no owned impact label applies. Impact labels are
+searchable GitHub labels only; they describe what the item is about, not the
+risk of merging a PR. They do not close, merge, block, or replace review
+findings.
 
 Populate structured reproduction metadata separately from the public prose.
 Use `reproductionStatus: "reproduced"` only when there is a concrete,
@@ -423,8 +426,9 @@ by priority. Choose the priority from user impact, severity, confidence, and
 maintainer urgency for the item as a whole, not just from PR review findings or
 whether ClawSweeper can automatically repair it.
 
-Always fill `riskLabels` with zero to three ClawSweeper-owned GitHub risk labels.
-These labels are only for maintainer search and triage; they do not replace
+Always fill `impactLabels` with zero to three ClawSweeper-owned GitHub impact
+labels. These labels are only for maintainer search and triage, and they
+describe the issue/PR impact area rather than merge risk. They do not replace
 `triagePriority`, `reviewFindings[].priority`, or the security review.
 
 Always fill the work-lane fields too. For non-candidates, use

--- a/schema/clawsweeper-decision.schema.json
+++ b/schema/clawsweeper-decision.schema.json
@@ -13,7 +13,7 @@
     "risks",
     "bestSolution",
     "triagePriority",
-    "riskLabels",
+    "impactLabels",
     "itemCategory",
     "reproductionStatus",
     "reproductionConfidence",
@@ -158,22 +158,22 @@
       "enum": ["P0", "P1", "P2", "P3", "none"],
       "description": "ClawSweeper-maintained triage priority for maintainers to sort issues and pull requests. P0: Emergency: data loss, security bypass, crash loop, or unusable core runtime. P1: Urgent regression or broken agent/channel workflow affecting real users now. P2: Normal priority bug or improvement with limited blast radius. P3: Low-risk cleanup, docs, polish, ergonomics, or speculative feature. Use none only when no priority label should be applied."
     },
-    "riskLabels": {
+    "impactLabels": {
       "type": "array",
       "maxItems": 3,
       "uniqueItems": true,
       "items": {
         "type": "string",
         "enum": [
-          "risk:data-loss",
-          "risk:security",
-          "risk:crash-loop",
-          "risk:message-loss",
-          "risk:session-state",
-          "risk:auth-provider"
+          "impact:data-loss",
+          "impact:security",
+          "impact:crash-loop",
+          "impact:message-loss",
+          "impact:session-state",
+          "impact:auth-provider"
         ]
       },
-      "description": "ClawSweeper-owned GitHub risk labels for maintainers to find risk classes on issues and pull requests. Use at most 3. risk:data-loss: Can lose, corrupt, or silently drop user/session/config data. risk:security: Security boundary, credential, authz, sandbox, or sensitive-data risk. risk:crash-loop: Crash, hang, restart loop, or process-level availability failure. risk:message-loss: Channel message delivery can be lost, duplicated, or misrouted. risk:session-state: Session, memory, transcript, context, or agent state can drift or corrupt. risk:auth-provider: Auth, provider routing, model choice, or SecretRef resolution may break."
+      "description": "ClawSweeper-owned GitHub impact labels for maintainers to find the affected problem class on issues and pull requests. These describe what the item is about, not PR merge risk. Use at most 3. impact:data-loss: Can lose, corrupt, or silently drop user/session/config data. impact:security: Security boundary, credential, authz, sandbox, or sensitive-data risk. impact:crash-loop: Crash, hang, restart loop, or process-level availability failure. impact:message-loss: Channel message delivery can be lost, duplicated, or misrouted. impact:session-state: Session, memory, transcript, context, or agent state can drift or corrupt. impact:auth-provider: Auth, provider routing, model choice, or SecretRef resolution may break."
     },
     "itemCategory": {
       "type": "string",

--- a/schema/clawsweeper-decision.schema.json
+++ b/schema/clawsweeper-decision.schema.json
@@ -13,6 +13,7 @@
     "risks",
     "bestSolution",
     "triagePriority",
+    "riskLabels",
     "itemCategory",
     "reproductionStatus",
     "reproductionConfidence",
@@ -156,6 +157,23 @@
       "type": "string",
       "enum": ["P0", "P1", "P2", "P3", "none"],
       "description": "ClawSweeper-maintained triage priority for maintainers to sort issues and pull requests. P0: Emergency: data loss, security bypass, crash loop, or unusable core runtime. P1: Urgent regression or broken agent/channel workflow affecting real users now. P2: Normal priority bug or improvement with limited blast radius. P3: Low-risk cleanup, docs, polish, ergonomics, or speculative feature. Use none only when no priority label should be applied."
+    },
+    "riskLabels": {
+      "type": "array",
+      "maxItems": 3,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": [
+          "risk:data-loss",
+          "risk:security",
+          "risk:crash-loop",
+          "risk:message-loss",
+          "risk:session-state",
+          "risk:auth-provider"
+        ]
+      },
+      "description": "ClawSweeper-owned GitHub risk labels for maintainers to find risk classes on issues and pull requests. Use at most 3. risk:data-loss: Can lose, corrupt, or silently drop user/session/config data. risk:security: Security boundary, credential, authz, sandbox, or sensitive-data risk. risk:crash-loop: Crash, hang, restart loop, or process-level availability failure. risk:message-loss: Channel message delivery can be lost, duplicated, or misrouted. risk:session-state: Session, memory, transcript, context, or agent state can drift or corrupt. risk:auth-provider: Auth, provider routing, model choice, or SecretRef resolution may break."
     },
     "itemCategory": {
       "type": "string",

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -65,13 +65,13 @@ type ApplyKind = ItemKind | "all";
 type DecisionKind = "close" | "keep_open";
 type WorkCandidateKind = "none" | "manual_review" | "queue_fix_pr";
 type TriagePriority = "P0" | "P1" | "P2" | "P3" | "none";
-type RiskLabelName =
-  | "risk:data-loss"
-  | "risk:security"
-  | "risk:crash-loop"
-  | "risk:message-loss"
-  | "risk:session-state"
-  | "risk:auth-provider";
+type ImpactLabelName =
+  | "impact:data-loss"
+  | "impact:security"
+  | "impact:crash-loop"
+  | "impact:message-loss"
+  | "impact:session-state"
+  | "impact:auth-provider";
 type ItemCategory =
   | "bug"
   | "regression"
@@ -283,7 +283,7 @@ interface Decision {
   risks: string[];
   bestSolution: string;
   triagePriority: TriagePriority;
-  riskLabels: RiskLabelName[];
+  impactLabels: ImpactLabelName[];
   itemCategory: ItemCategory;
   reproductionStatus: ReproductionStatus;
   reproductionConfidence: Confidence;
@@ -731,43 +731,43 @@ const PRIORITY_LABELS = [
 const PRIORITY_LABEL_NAMES: ReadonlySet<string> = new Set(
   PRIORITY_LABELS.map((label) => label.name),
 );
-const RISK_LABELS = [
+const IMPACT_LABELS = [
   {
-    name: "risk:data-loss",
+    name: "impact:data-loss",
     color: "B60205",
     description: "Can lose, corrupt, or silently drop user/session/config data.",
   },
   {
-    name: "risk:security",
+    name: "impact:security",
     color: "B60205",
     description: "Security boundary, credential, authz, sandbox, or sensitive-data risk.",
   },
   {
-    name: "risk:crash-loop",
+    name: "impact:crash-loop",
     color: "D93F0B",
     description: "Crash, hang, restart loop, or process-level availability failure.",
   },
   {
-    name: "risk:message-loss",
+    name: "impact:message-loss",
     color: "D93F0B",
     description: "Channel message delivery can be lost, duplicated, or misrouted.",
   },
   {
-    name: "risk:session-state",
+    name: "impact:session-state",
     color: "FBCA04",
     description: "Session, memory, transcript, context, or agent state can drift or corrupt.",
   },
   {
-    name: "risk:auth-provider",
+    name: "impact:auth-provider",
     color: "FBCA04",
     description: "Auth, provider routing, model choice, or SecretRef resolution may break.",
   },
 ] as const satisfies readonly {
-  name: RiskLabelName;
+  name: ImpactLabelName;
   color: string;
   description: string;
 }[];
-const RISK_LABEL_NAMES: ReadonlySet<string> = new Set(RISK_LABELS.map((label) => label.name));
+const IMPACT_LABEL_NAMES: ReadonlySet<string> = new Set(IMPACT_LABELS.map((label) => label.name));
 const ISSUE_ADVISORY_LABELS = [
   {
     name: "clawsweeper:current-main-repro",
@@ -875,7 +875,7 @@ const SECURITY_REVIEW_STATUSES = new Set<SecurityReviewStatus>([
   "not_applicable",
 ]);
 const SECURITY_CONCERN_SEVERITIES = new Set<SecurityConcernSeverity>(["high", "medium", "low"]);
-const RISK_LABEL_VALUES = new Set<RiskLabelName>(RISK_LABELS.map((label) => label.name));
+const IMPACT_LABEL_VALUES = new Set<ImpactLabelName>(IMPACT_LABELS.map((label) => label.name));
 const REAL_BEHAVIOR_PROOF_STATUSES = new Set<RealBehaviorProofStatus>([
   "sufficient",
   "missing",
@@ -917,7 +917,7 @@ const DECISION_SCHEMA_KEYS = new Set([
   "risks",
   "bestSolution",
   "triagePriority",
-  "riskLabels",
+  "impactLabels",
   "itemCategory",
   "reproductionStatus",
   "reproductionConfidence",
@@ -1390,11 +1390,11 @@ function requireEnumArray<T extends string>(value: unknown, allowed: Set<T>, pat
   );
 }
 
-function requireRiskLabels(value: unknown): RiskLabelName[] {
-  const labels = requireEnumArray(value, RISK_LABEL_VALUES, "decision.riskLabels");
-  if (labels.length > 3) throw new Error("decision.riskLabels must contain at most 3 labels");
+function requireImpactLabels(value: unknown): ImpactLabelName[] {
+  const labels = requireEnumArray(value, IMPACT_LABEL_VALUES, "decision.impactLabels");
+  if (labels.length > 3) throw new Error("decision.impactLabels must contain at most 3 labels");
   if (new Set(labels).size !== labels.length) {
-    throw new Error("decision.riskLabels must not contain duplicates");
+    throw new Error("decision.impactLabels must not contain duplicates");
   }
   return labels;
 }
@@ -1616,7 +1616,7 @@ export function parseDecision(value: unknown, item?: DecisionNormalizationItem):
       TRIAGE_PRIORITIES,
       "decision.triagePriority",
     ),
-    riskLabels: requireRiskLabels(record.riskLabels),
+    impactLabels: requireImpactLabels(record.impactLabels),
     itemCategory: requireEnum(record.itemCategory, ITEM_CATEGORIES, "decision.itemCategory"),
     reproductionStatus: requireEnum(
       record.reproductionStatus,
@@ -4015,7 +4015,7 @@ function codexFailureDecision(status: number | null, stderr: string, stdout = ""
     risks: ["No close action taken because the review did not complete."],
     bestSolution: "Retry the Codex review after fixing the execution failure.",
     triagePriority: "none",
-    riskLabels: [],
+    impactLabels: [],
     itemCategory: "unclear",
     reproductionStatus: "unclear",
     reproductionConfidence: "low",
@@ -5107,9 +5107,9 @@ function triagePriorityFromReport(markdown: string): TriagePriority {
   return TRIAGE_PRIORITIES.has(value as TriagePriority) ? (value as TriagePriority) : "none";
 }
 
-function riskLabelsFromReport(markdown: string): RiskLabelName[] {
-  return frontMatterStringArray(markdown, "risk_labels").filter((label): label is RiskLabelName =>
-    RISK_LABEL_NAMES.has(label),
+function impactLabelsFromReport(markdown: string): ImpactLabelName[] {
+  return frontMatterStringArray(markdown, "impact_labels").filter(
+    (label): label is ImpactLabelName => IMPACT_LABEL_NAMES.has(label),
   );
 }
 
@@ -5402,30 +5402,33 @@ export function priorityLabelsForTest(labels: readonly string[], triagePriority:
   return nextPriorityLabels(labels, priority);
 }
 
-function nextRiskLabels(labels: readonly string[], riskLabels: readonly RiskLabelName[]): string[] {
-  const nextLabels = labels.filter((label) => !RISK_LABEL_NAMES.has(label));
-  const uniqueRiskLabels = new Set(riskLabels);
-  for (const label of RISK_LABELS) {
-    if (uniqueRiskLabels.has(label.name)) nextLabels.push(label.name);
+function nextImpactLabels(
+  labels: readonly string[],
+  impactLabels: readonly ImpactLabelName[],
+): string[] {
+  const nextLabels = labels.filter((label) => !IMPACT_LABEL_NAMES.has(label));
+  const uniqueImpactLabels = new Set(impactLabels);
+  for (const label of IMPACT_LABELS) {
+    if (uniqueImpactLabels.has(label.name)) nextLabels.push(label.name);
   }
   return nextLabels;
 }
 
-export function riskLabelSchemeForTest(): {
+export function impactLabelSchemeForTest(): {
   name: string;
   color: string;
   description: string;
 }[] {
-  return RISK_LABELS.map(({ name, color, description }) => ({ name, color, description }));
+  return IMPACT_LABELS.map(({ name, color, description }) => ({ name, color, description }));
 }
 
-export function riskLabelsForTest(
+export function impactLabelsForTest(
   labels: readonly string[],
-  riskLabels: readonly string[],
+  impactLabels: readonly string[],
 ): string[] {
-  return nextRiskLabels(
+  return nextImpactLabels(
     labels,
-    riskLabels.filter((label): label is RiskLabelName => RISK_LABEL_NAMES.has(label)),
+    impactLabels.filter((label): label is ImpactLabelName => IMPACT_LABEL_NAMES.has(label)),
   );
 }
 
@@ -5441,8 +5444,8 @@ function ensurePriorityLabel(label: PriorityLabelSpec): void {
   }
 }
 
-function ensureRiskLabel(name: RiskLabelName): void {
-  const definition = RISK_LABELS.find((label) => label.name === name);
+function ensureImpactLabel(name: ImpactLabelName): void {
+  const definition = IMPACT_LABELS.find((label) => label.name === name);
   if (!definition) return;
   try {
     ghWithRetry(
@@ -5641,27 +5644,27 @@ function syncPriorityLabel(options: {
   return { labels: nextLabels, changed };
 }
 
-function syncRiskLabels(options: {
+function syncImpactLabels(options: {
   number: number;
   labels: readonly string[];
-  riskLabels: readonly RiskLabelName[];
+  impactLabels: readonly ImpactLabelName[];
   dryRun: boolean;
 }): { labels: string[]; changed: boolean } {
-  const nextLabels = nextRiskLabels(options.labels, options.riskLabels);
+  const nextLabels = nextImpactLabels(options.labels, options.impactLabels);
   const currentLabelKeys = new Set(options.labels.map((label) => label.toLowerCase()));
   const nextLabelKeys = new Set(nextLabels.map((label) => label.toLowerCase()));
   const labelsToAdd = nextLabels.filter(
-    (label): label is RiskLabelName =>
-      RISK_LABEL_NAMES.has(label) && !currentLabelKeys.has(label.toLowerCase()),
+    (label): label is ImpactLabelName =>
+      IMPACT_LABEL_NAMES.has(label) && !currentLabelKeys.has(label.toLowerCase()),
   );
   const labelsToRemove = options.labels.filter(
-    (label) => RISK_LABEL_NAMES.has(label) && !nextLabelKeys.has(label.toLowerCase()),
+    (label) => IMPACT_LABEL_NAMES.has(label) && !nextLabelKeys.has(label.toLowerCase()),
   );
   const changed = labelsToAdd.length > 0 || labelsToRemove.length > 0;
   if (!changed) return { labels: nextLabels, changed };
   if (options.dryRun) return { labels: nextLabels, changed };
   for (const label of labelsToAdd) {
-    ensureRiskLabel(label);
+    ensureImpactLabel(label);
     ghWithRetry(["issue", "edit", String(options.number), "--add-label", label]);
   }
   for (const label of labelsToRemove) {
@@ -5966,7 +5969,7 @@ function reportDecision(markdown: string, closeReason: CloseReason): Decision {
     risks: [],
     bestSolution: reviewSectionValue(markdown, "bestSolution"),
     triagePriority: triagePriorityFromReport(markdown),
-    riskLabels: riskLabelsFromReport(markdown),
+    impactLabels: impactLabelsFromReport(markdown),
     itemCategory:
       (frontMatterValue(markdown, "item_category") as ItemCategory | undefined) ?? "unclear",
     reproductionStatus:
@@ -7434,7 +7437,7 @@ work_cluster_refs: ${jsonFrontMatterValue(options.decision.workClusterRefs)}
 work_validation: ${jsonFrontMatterValue(options.decision.workValidation)}
 work_likely_files: ${jsonFrontMatterValue(options.decision.workLikelyFiles)}
 triage_priority: ${options.decision.triagePriority}
-risk_labels: ${jsonFrontMatterValue(options.decision.riskLabels)}
+impact_labels: ${jsonFrontMatterValue(options.decision.impactLabels)}
 pull_files: ${jsonFrontMatterValue(pullFiles)}
 pull_files_truncated: ${pullFilesTruncated}
 item_category: ${options.decision.itemCategory}
@@ -8082,14 +8085,14 @@ function applyDecisionsCommand(args: Args): void {
       item.labels = syncResult.labels;
       clawSweeperLabelsChanged ||= syncResult.changed;
       markdown = replaceFrontMatterValue(markdown, "labels", JSON.stringify(item.labels));
-      const riskSyncResult = syncRiskLabels({
+      const impactSyncResult = syncImpactLabels({
         number,
         labels: item.labels,
-        riskLabels: riskLabelsFromReport(markdown),
+        impactLabels: impactLabelsFromReport(markdown),
         dryRun,
       });
-      item.labels = riskSyncResult.labels;
-      clawSweeperLabelsChanged ||= riskSyncResult.changed;
+      item.labels = impactSyncResult.labels;
+      clawSweeperLabelsChanged ||= impactSyncResult.changed;
       markdown = replaceFrontMatterValue(markdown, "labels", JSON.stringify(item.labels));
     }
     if (state === "open" && item.kind === "issue" && !isCloseProposal && isCurrentCompleteReport) {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -65,6 +65,13 @@ type ApplyKind = ItemKind | "all";
 type DecisionKind = "close" | "keep_open";
 type WorkCandidateKind = "none" | "manual_review" | "queue_fix_pr";
 type TriagePriority = "P0" | "P1" | "P2" | "P3" | "none";
+type RiskLabelName =
+  | "risk:data-loss"
+  | "risk:security"
+  | "risk:crash-loop"
+  | "risk:message-loss"
+  | "risk:session-state"
+  | "risk:auth-provider";
 type ItemCategory =
   | "bug"
   | "regression"
@@ -276,6 +283,7 @@ interface Decision {
   risks: string[];
   bestSolution: string;
   triagePriority: TriagePriority;
+  riskLabels: RiskLabelName[];
   itemCategory: ItemCategory;
   reproductionStatus: ReproductionStatus;
   reproductionConfidence: Confidence;
@@ -723,6 +731,43 @@ const PRIORITY_LABELS = [
 const PRIORITY_LABEL_NAMES: ReadonlySet<string> = new Set(
   PRIORITY_LABELS.map((label) => label.name),
 );
+const RISK_LABELS = [
+  {
+    name: "risk:data-loss",
+    color: "B60205",
+    description: "Can lose, corrupt, or silently drop user/session/config data.",
+  },
+  {
+    name: "risk:security",
+    color: "B60205",
+    description: "Security boundary, credential, authz, sandbox, or sensitive-data risk.",
+  },
+  {
+    name: "risk:crash-loop",
+    color: "D93F0B",
+    description: "Crash, hang, restart loop, or process-level availability failure.",
+  },
+  {
+    name: "risk:message-loss",
+    color: "D93F0B",
+    description: "Channel message delivery can be lost, duplicated, or misrouted.",
+  },
+  {
+    name: "risk:session-state",
+    color: "FBCA04",
+    description: "Session, memory, transcript, context, or agent state can drift or corrupt.",
+  },
+  {
+    name: "risk:auth-provider",
+    color: "FBCA04",
+    description: "Auth, provider routing, model choice, or SecretRef resolution may break.",
+  },
+] as const satisfies readonly {
+  name: RiskLabelName;
+  color: string;
+  description: string;
+}[];
+const RISK_LABEL_NAMES: ReadonlySet<string> = new Set(RISK_LABELS.map((label) => label.name));
 const ISSUE_ADVISORY_LABELS = [
   {
     name: "clawsweeper:current-main-repro",
@@ -830,6 +875,7 @@ const SECURITY_REVIEW_STATUSES = new Set<SecurityReviewStatus>([
   "not_applicable",
 ]);
 const SECURITY_CONCERN_SEVERITIES = new Set<SecurityConcernSeverity>(["high", "medium", "low"]);
+const RISK_LABEL_VALUES = new Set<RiskLabelName>(RISK_LABELS.map((label) => label.name));
 const REAL_BEHAVIOR_PROOF_STATUSES = new Set<RealBehaviorProofStatus>([
   "sufficient",
   "missing",
@@ -871,6 +917,7 @@ const DECISION_SCHEMA_KEYS = new Set([
   "risks",
   "bestSolution",
   "triagePriority",
+  "riskLabels",
   "itemCategory",
   "reproductionStatus",
   "reproductionConfidence",
@@ -1337,6 +1384,21 @@ function requireStringArray(value: unknown, path: string): string[] {
   return value.map((entry, index) => requireString(entry, `${path}[${index}]`));
 }
 
+function requireEnumArray<T extends string>(value: unknown, allowed: Set<T>, path: string): T[] {
+  return requireStringArray(value, path).map((entry, index) =>
+    requireEnum(entry, allowed, `${path}[${index}]`),
+  );
+}
+
+function requireRiskLabels(value: unknown): RiskLabelName[] {
+  const labels = requireEnumArray(value, RISK_LABEL_VALUES, "decision.riskLabels");
+  if (labels.length > 3) throw new Error("decision.riskLabels must contain at most 3 labels");
+  if (new Set(labels).size !== labels.length) {
+    throw new Error("decision.riskLabels must not contain duplicates");
+  }
+  return labels;
+}
+
 function isEnvironmentAccessCaveat(value: string): boolean {
   return /(?:GH_TOKEN|GITHUB_TOKEN|authenticated gh|gh (?:was |is )?unavailable|unauthenticated gh|shallow clone|GitHub auth(?:entication)? (?:was |is )?unavailable|could not use authenticated GitHub)/i.test(
     value,
@@ -1554,6 +1616,7 @@ export function parseDecision(value: unknown, item?: DecisionNormalizationItem):
       TRIAGE_PRIORITIES,
       "decision.triagePriority",
     ),
+    riskLabels: requireRiskLabels(record.riskLabels),
     itemCategory: requireEnum(record.itemCategory, ITEM_CATEGORIES, "decision.itemCategory"),
     reproductionStatus: requireEnum(
       record.reproductionStatus,
@@ -3952,6 +4015,7 @@ function codexFailureDecision(status: number | null, stderr: string, stdout = ""
     risks: ["No close action taken because the review did not complete."],
     bestSolution: "Retry the Codex review after fixing the execution failure.",
     triagePriority: "none",
+    riskLabels: [],
     itemCategory: "unclear",
     reproductionStatus: "unclear",
     reproductionConfidence: "low",
@@ -5043,6 +5107,12 @@ function triagePriorityFromReport(markdown: string): TriagePriority {
   return TRIAGE_PRIORITIES.has(value as TriagePriority) ? (value as TriagePriority) : "none";
 }
 
+function riskLabelsFromReport(markdown: string): RiskLabelName[] {
+  return frontMatterStringArray(markdown, "risk_labels").filter((label): label is RiskLabelName =>
+    RISK_LABEL_NAMES.has(label),
+  );
+}
+
 function reportReviewFindings(markdown: string): ReviewFinding[] {
   const section = reviewSectionValue(markdown, "reviewFindings");
   const findings: ReviewFinding[] = [];
@@ -5332,10 +5402,59 @@ export function priorityLabelsForTest(labels: readonly string[], triagePriority:
   return nextPriorityLabels(labels, priority);
 }
 
+function nextRiskLabels(labels: readonly string[], riskLabels: readonly RiskLabelName[]): string[] {
+  const nextLabels = labels.filter((label) => !RISK_LABEL_NAMES.has(label));
+  const uniqueRiskLabels = new Set(riskLabels);
+  for (const label of RISK_LABELS) {
+    if (uniqueRiskLabels.has(label.name)) nextLabels.push(label.name);
+  }
+  return nextLabels;
+}
+
+export function riskLabelSchemeForTest(): {
+  name: string;
+  color: string;
+  description: string;
+}[] {
+  return RISK_LABELS.map(({ name, color, description }) => ({ name, color, description }));
+}
+
+export function riskLabelsForTest(
+  labels: readonly string[],
+  riskLabels: readonly string[],
+): string[] {
+  return nextRiskLabels(
+    labels,
+    riskLabels.filter((label): label is RiskLabelName => RISK_LABEL_NAMES.has(label)),
+  );
+}
+
 function ensurePriorityLabel(label: PriorityLabelSpec): void {
   try {
     ghWithRetry(
       ["label", "create", label.name, "--color", label.color, "--description", label.description],
+      2,
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!/already exists/i.test(message)) throw error;
+  }
+}
+
+function ensureRiskLabel(name: RiskLabelName): void {
+  const definition = RISK_LABELS.find((label) => label.name === name);
+  if (!definition) return;
+  try {
+    ghWithRetry(
+      [
+        "label",
+        "create",
+        definition.name,
+        "--color",
+        definition.color,
+        "--description",
+        definition.description,
+      ],
       2,
     );
   } catch (error) {
@@ -5518,6 +5637,35 @@ function syncPriorityLabel(options: {
   }
   if (labelToAdd) {
     ghWithRetry(["issue", "edit", String(options.number), "--add-label", labelToAdd]);
+  }
+  return { labels: nextLabels, changed };
+}
+
+function syncRiskLabels(options: {
+  number: number;
+  labels: readonly string[];
+  riskLabels: readonly RiskLabelName[];
+  dryRun: boolean;
+}): { labels: string[]; changed: boolean } {
+  const nextLabels = nextRiskLabels(options.labels, options.riskLabels);
+  const currentLabelKeys = new Set(options.labels.map((label) => label.toLowerCase()));
+  const nextLabelKeys = new Set(nextLabels.map((label) => label.toLowerCase()));
+  const labelsToAdd = nextLabels.filter(
+    (label): label is RiskLabelName =>
+      RISK_LABEL_NAMES.has(label) && !currentLabelKeys.has(label.toLowerCase()),
+  );
+  const labelsToRemove = options.labels.filter(
+    (label) => RISK_LABEL_NAMES.has(label) && !nextLabelKeys.has(label.toLowerCase()),
+  );
+  const changed = labelsToAdd.length > 0 || labelsToRemove.length > 0;
+  if (!changed) return { labels: nextLabels, changed };
+  if (options.dryRun) return { labels: nextLabels, changed };
+  for (const label of labelsToAdd) {
+    ensureRiskLabel(label);
+    ghWithRetry(["issue", "edit", String(options.number), "--add-label", label]);
+  }
+  for (const label of labelsToRemove) {
+    ghWithRetry(["issue", "edit", String(options.number), "--remove-label", label]);
   }
   return { labels: nextLabels, changed };
 }
@@ -5818,6 +5966,7 @@ function reportDecision(markdown: string, closeReason: CloseReason): Decision {
     risks: [],
     bestSolution: reviewSectionValue(markdown, "bestSolution"),
     triagePriority: triagePriorityFromReport(markdown),
+    riskLabels: riskLabelsFromReport(markdown),
     itemCategory:
       (frontMatterValue(markdown, "item_category") as ItemCategory | undefined) ?? "unclear",
     reproductionStatus:
@@ -7285,6 +7434,7 @@ work_cluster_refs: ${jsonFrontMatterValue(options.decision.workClusterRefs)}
 work_validation: ${jsonFrontMatterValue(options.decision.workValidation)}
 work_likely_files: ${jsonFrontMatterValue(options.decision.workLikelyFiles)}
 triage_priority: ${options.decision.triagePriority}
+risk_labels: ${jsonFrontMatterValue(options.decision.riskLabels)}
 pull_files: ${jsonFrontMatterValue(pullFiles)}
 pull_files_truncated: ${pullFilesTruncated}
 item_category: ${options.decision.itemCategory}
@@ -7931,6 +8081,15 @@ function applyDecisionsCommand(args: Args): void {
       });
       item.labels = syncResult.labels;
       clawSweeperLabelsChanged ||= syncResult.changed;
+      markdown = replaceFrontMatterValue(markdown, "labels", JSON.stringify(item.labels));
+      const riskSyncResult = syncRiskLabels({
+        number,
+        labels: item.labels,
+        riskLabels: riskLabelsFromReport(markdown),
+        dryRun,
+      });
+      item.labels = riskSyncResult.labels;
+      clawSweeperLabelsChanged ||= riskSyncResult.changed;
       markdown = replaceFrontMatterValue(markdown, "labels", JSON.stringify(item.labels));
     }
     if (state === "open" && item.kind === "issue" && !isCloseProposal && isCurrentCompleteReport) {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -60,8 +60,8 @@ import {
   reviewDecisionSchemaText,
   reviewPromptTelemetryForTest,
   reviewPromptTemplate,
-  riskLabelsForTest,
-  riskLabelSchemeForTest,
+  impactLabelsForTest,
+  impactLabelSchemeForTest,
   runtimeBudgetExceeded,
   safeOutputTail,
   sameAuthorCounterpartApplyReason,
@@ -159,7 +159,7 @@ function closeDecision(overrides = {}) {
     risks: [],
     bestSolution: "Keep the implementation as-is.",
     triagePriority: "P2",
-    riskLabels: [],
+    impactLabels: [],
     itemCategory: "bug",
     reproductionStatus: "reproduced",
     reproductionConfidence: "high",
@@ -4206,17 +4206,22 @@ test("decision parser enforces required schema-shaped evidence", () => {
     () =>
       parseDecision({
         ...closeDecision(),
-        riskLabels: ["risk:unknown"],
+        impactLabels: ["impact:unknown"],
       }),
-    /decision\.riskLabels\[0\]/,
+    /decision\.impactLabels\[0\]/,
   );
   assert.throws(
     () =>
       parseDecision({
         ...closeDecision(),
-        riskLabels: ["risk:data-loss", "risk:security", "risk:crash-loop", "risk:message-loss"],
+        impactLabels: [
+          "impact:data-loss",
+          "impact:security",
+          "impact:crash-loop",
+          "impact:message-loss",
+        ],
       }),
-    /decision\.riskLabels must contain at most 3 labels/,
+    /decision\.impactLabels must contain at most 3 labels/,
   );
   assert.throws(
     () =>
@@ -4427,43 +4432,43 @@ test("ClawSweeper priority labels follow triage priority", () => {
   assert.deepEqual(priorityLabelsForTest(["P0", "bug"], "none"), ["bug"]);
 });
 
-test("ClawSweeper risk label scheme exposes owned risk labels", () => {
-  assert.deepEqual(riskLabelSchemeForTest(), [
+test("ClawSweeper impact label scheme exposes owned impact labels", () => {
+  assert.deepEqual(impactLabelSchemeForTest(), [
     {
-      name: "risk:data-loss",
+      name: "impact:data-loss",
       color: "B60205",
       description: "Can lose, corrupt, or silently drop user/session/config data.",
     },
     {
-      name: "risk:security",
+      name: "impact:security",
       color: "B60205",
       description: "Security boundary, credential, authz, sandbox, or sensitive-data risk.",
     },
     {
-      name: "risk:crash-loop",
+      name: "impact:crash-loop",
       color: "D93F0B",
       description: "Crash, hang, restart loop, or process-level availability failure.",
     },
     {
-      name: "risk:message-loss",
+      name: "impact:message-loss",
       color: "D93F0B",
       description: "Channel message delivery can be lost, duplicated, or misrouted.",
     },
     {
-      name: "risk:session-state",
+      name: "impact:session-state",
       color: "FBCA04",
       description: "Session, memory, transcript, context, or agent state can drift or corrupt.",
     },
     {
-      name: "risk:auth-provider",
+      name: "impact:auth-provider",
       color: "FBCA04",
       description: "Auth, provider routing, model choice, or SecretRef resolution may break.",
     },
   ]);
 });
 
-test("ClawSweeper risk label descriptions fit GitHub label limits", () => {
-  for (const label of riskLabelSchemeForTest()) {
+test("ClawSweeper impact label descriptions fit GitHub label limits", () => {
+  for (const label of impactLabelSchemeForTest()) {
     assert.ok(
       label.description.length <= 100,
       `${label.name} description is ${label.description.length} characters`,
@@ -4471,17 +4476,17 @@ test("ClawSweeper risk label descriptions fit GitHub label limits", () => {
   }
 });
 
-test("ClawSweeper risk label descriptions stay aligned with prompt and schema", () => {
+test("ClawSweeper impact label descriptions stay aligned with prompt and schema", () => {
   const schema = JSON.parse(reviewDecisionSchemaText()) as {
     properties?: {
-      riskLabels?: {
+      impactLabels?: {
         description?: string;
       };
     };
   };
-  const schemaDescription = schema.properties?.riskLabels?.description ?? "";
+  const schemaDescription = schema.properties?.impactLabels?.description ?? "";
   const prompt = reviewPromptTemplate();
-  for (const label of riskLabelSchemeForTest()) {
+  for (const label of impactLabelSchemeForTest()) {
     assert.ok(
       prompt.includes(`\`${label.name}\`: ${label.description}`),
       `${label.name} description is missing from the review prompt`,
@@ -4493,25 +4498,25 @@ test("ClawSweeper risk label descriptions stay aligned with prompt and schema", 
   }
 });
 
-test("ClawSweeper risk labels remove stale owned labels and preserve unrelated labels", () => {
+test("ClawSweeper impact labels remove stale owned labels and preserve unrelated labels", () => {
   assert.deepEqual(
-    riskLabelsForTest(
-      ["bug", "risk:data-loss", "risk:security", "proof: sufficient", "P1"],
-      ["risk:message-loss", "risk:session-state", "not-a-risk-label"],
+    impactLabelsForTest(
+      ["bug", "impact:data-loss", "impact:security", "proof: sufficient", "P1"],
+      ["impact:message-loss", "impact:session-state", "not-an-impact-label"],
     ),
-    ["bug", "proof: sufficient", "P1", "risk:message-loss", "risk:session-state"],
+    ["bug", "proof: sufficient", "P1", "impact:message-loss", "impact:session-state"],
   );
-  assert.deepEqual(riskLabelsForTest(["bug", "risk:auth-provider"], []), ["bug"]);
+  assert.deepEqual(impactLabelsForTest(["bug", "impact:auth-provider"], []), ["bug"]);
 });
 
-test("ClawSweeper risk labels do not alter PR review finding priorities", () => {
+test("ClawSweeper impact labels do not alter PR review finding priorities", () => {
   const decision = parseDecision(
     closeDecision({
-      riskLabels: ["risk:data-loss", "risk:security"],
+      impactLabels: ["impact:data-loss", "impact:security"],
       reviewFindings: [
         {
           title: "A concrete review finding",
-          body: "This remains a PR review finding priority, not a triage risk label.",
+          body: "This remains a PR review finding priority, not an impact label.",
           priority: 1,
           confidenceScore: 0.9,
           file: "src/example.ts",
@@ -4521,7 +4526,7 @@ test("ClawSweeper risk labels do not alter PR review finding priorities", () => 
       ],
     }),
   );
-  assert.deepEqual(decision.riskLabels, ["risk:data-loss", "risk:security"]);
+  assert.deepEqual(decision.impactLabels, ["impact:data-loss", "impact:security"]);
   assert.equal(decision.reviewFindings[0]?.priority, 1);
 });
 

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -60,6 +60,8 @@ import {
   reviewDecisionSchemaText,
   reviewPromptTelemetryForTest,
   reviewPromptTemplate,
+  riskLabelsForTest,
+  riskLabelSchemeForTest,
   runtimeBudgetExceeded,
   safeOutputTail,
   sameAuthorCounterpartApplyReason,
@@ -157,6 +159,7 @@ function closeDecision(overrides = {}) {
     risks: [],
     bestSolution: "Keep the implementation as-is.",
     triagePriority: "P2",
+    riskLabels: [],
     itemCategory: "bug",
     reproductionStatus: "reproduced",
     reproductionConfidence: "high",
@@ -4203,6 +4206,22 @@ test("decision parser enforces required schema-shaped evidence", () => {
     () =>
       parseDecision({
         ...closeDecision(),
+        riskLabels: ["risk:unknown"],
+      }),
+    /decision\.riskLabels\[0\]/,
+  );
+  assert.throws(
+    () =>
+      parseDecision({
+        ...closeDecision(),
+        riskLabels: ["risk:data-loss", "risk:security", "risk:crash-loop", "risk:message-loss"],
+      }),
+    /decision\.riskLabels must contain at most 3 labels/,
+  );
+  assert.throws(
+    () =>
+      parseDecision({
+        ...closeDecision(),
         requiresNewConfigOption: "false",
       }),
     /decision\.requiresNewConfigOption/,
@@ -4406,6 +4425,104 @@ test("ClawSweeper priority labels follow triage priority", () => {
   assert.deepEqual(priorityLabelsForTest(["bug"], "P2"), ["bug", "P2"]);
   assert.deepEqual(priorityLabelsForTest(["bug", "P3"], "P1"), ["bug", "P1"]);
   assert.deepEqual(priorityLabelsForTest(["P0", "bug"], "none"), ["bug"]);
+});
+
+test("ClawSweeper risk label scheme exposes owned risk labels", () => {
+  assert.deepEqual(riskLabelSchemeForTest(), [
+    {
+      name: "risk:data-loss",
+      color: "B60205",
+      description: "Can lose, corrupt, or silently drop user/session/config data.",
+    },
+    {
+      name: "risk:security",
+      color: "B60205",
+      description: "Security boundary, credential, authz, sandbox, or sensitive-data risk.",
+    },
+    {
+      name: "risk:crash-loop",
+      color: "D93F0B",
+      description: "Crash, hang, restart loop, or process-level availability failure.",
+    },
+    {
+      name: "risk:message-loss",
+      color: "D93F0B",
+      description: "Channel message delivery can be lost, duplicated, or misrouted.",
+    },
+    {
+      name: "risk:session-state",
+      color: "FBCA04",
+      description: "Session, memory, transcript, context, or agent state can drift or corrupt.",
+    },
+    {
+      name: "risk:auth-provider",
+      color: "FBCA04",
+      description: "Auth, provider routing, model choice, or SecretRef resolution may break.",
+    },
+  ]);
+});
+
+test("ClawSweeper risk label descriptions fit GitHub label limits", () => {
+  for (const label of riskLabelSchemeForTest()) {
+    assert.ok(
+      label.description.length <= 100,
+      `${label.name} description is ${label.description.length} characters`,
+    );
+  }
+});
+
+test("ClawSweeper risk label descriptions stay aligned with prompt and schema", () => {
+  const schema = JSON.parse(reviewDecisionSchemaText()) as {
+    properties?: {
+      riskLabels?: {
+        description?: string;
+      };
+    };
+  };
+  const schemaDescription = schema.properties?.riskLabels?.description ?? "";
+  const prompt = reviewPromptTemplate();
+  for (const label of riskLabelSchemeForTest()) {
+    assert.ok(
+      prompt.includes(`\`${label.name}\`: ${label.description}`),
+      `${label.name} description is missing from the review prompt`,
+    );
+    assert.ok(
+      schemaDescription.includes(`${label.name}: ${label.description}`),
+      `${label.name} description is missing from the schema`,
+    );
+  }
+});
+
+test("ClawSweeper risk labels remove stale owned labels and preserve unrelated labels", () => {
+  assert.deepEqual(
+    riskLabelsForTest(
+      ["bug", "risk:data-loss", "risk:security", "proof: sufficient", "P1"],
+      ["risk:message-loss", "risk:session-state", "not-a-risk-label"],
+    ),
+    ["bug", "proof: sufficient", "P1", "risk:message-loss", "risk:session-state"],
+  );
+  assert.deepEqual(riskLabelsForTest(["bug", "risk:auth-provider"], []), ["bug"]);
+});
+
+test("ClawSweeper risk labels do not alter PR review finding priorities", () => {
+  const decision = parseDecision(
+    closeDecision({
+      riskLabels: ["risk:data-loss", "risk:security"],
+      reviewFindings: [
+        {
+          title: "A concrete review finding",
+          body: "This remains a PR review finding priority, not a triage risk label.",
+          priority: 1,
+          confidenceScore: 0.9,
+          file: "src/example.ts",
+          lineStart: 10,
+          lineEnd: 10,
+        },
+      ],
+    }),
+  );
+  assert.deepEqual(decision.riskLabels, ["risk:data-loss", "risk:security"]);
+  assert.equal(decision.reviewFindings[0]?.priority, 1);
 });
 
 test("ClawSweeper issue advisory labels expose high-confidence reproduction state", () => {


### PR DESCRIPTION
## Summary

- add `impactLabels` to ClawSweeper decisions for issues and PRs
- sync ClawSweeper-owned `impact:*` GitHub labels as searchable affected-problem-class labels
- clarify in prompt/schema that impact labels describe what an item is about, not PR merge risk
- keep PR merge risk, `reviewFindings[].priority`, and security review behavior unchanged

## Labels

ClawSweeper can now emit and sync:

- `impact:data-loss`
- `impact:security`
- `impact:crash-loop`
- `impact:message-loss`
- `impact:session-state`
- `impact:auth-provider`

## Validation

- `pnpm run build`
- `node --test test/clawsweeper.test.ts`
- `pnpm run format`
- `pnpm run check`
- `git diff --check`
