### PR TITLE
fix(labels): remove unsupported impact schema keyword

### DIFF
--- a/schema/clawsweeper-decision.schema.json
+++ b/schema/clawsweeper-decision.schema.json
@@ -161,7 +161,6 @@
     "impactLabels": {
       "type": "array",
       "maxItems": 3,
-      "uniqueItems": true,
       "items": {
         "type": "string",
         "enum": [

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -4227,6 +4227,14 @@ test("decision parser enforces required schema-shaped evidence", () => {
     () =>
       parseDecision({
         ...closeDecision(),
+        impactLabels: ["impact:data-loss", "impact:data-loss"],
+      }),
+    /decision\.impactLabels must not contain duplicates/,
+  );
+  assert.throws(
+    () =>
+      parseDecision({
+        ...closeDecision(),
         requiresNewConfigOption: "false",
       }),
     /decision\.requiresNewConfigOption/,
@@ -4496,6 +4504,15 @@ test("ClawSweeper impact label descriptions stay aligned with prompt and schema"
       `${label.name} description is missing from the schema`,
     );
   }
+});
+
+test("ClawSweeper impact label schema avoids unsupported response-format keywords", () => {
+  const schema = JSON.parse(reviewDecisionSchemaText()) as {
+    properties?: {
+      impactLabels?: Record<string, unknown>;
+    };
+  };
+  assert.equal(schema.properties?.impactLabels?.uniqueItems, undefined);
 });
 
 test("ClawSweeper impact labels remove stale owned labels and preserve unrelated labels", () => {


### PR DESCRIPTION
## Summary

- remove `uniqueItems` from the `impactLabels` response schema because Codex response_format rejects it
- keep duplicate protection in ClawSweeper parser/runtime validation
- add focused regression tests for duplicate rejection and unsupported schema keyword drift

## Root cause

Recent ClawSweeper reviews failed with `invalid_json_schema` because the response schema included `uniqueItems` under `impactLabels`. The response-format schema subset does not permit that keyword.

## Validation

- `pnpm run build`
- `node --test test/clawsweeper.test.ts`
- `pnpm run format`
- `pnpm run check`
