### PR TITLE
fix: align command status comment trust config

### DIFF
--- a/src/repair/config.ts
+++ b/src/repair/config.ts
@@ -12,7 +12,7 @@ import {
 export { DEFAULT_HEAD_PREFIX, DEFAULT_TARGET_REPO } from "./constants.js";
 
 const DEFAULT_ALLOWED_ASSOCIATIONS = ["OWNER", "MEMBER", "COLLABORATOR"];
-const DEFAULT_TRUSTED_BOTS = ["clawsweeper[bot]", "openclaw-clawsweeper[bot]"];
+export const DEFAULT_TRUSTED_BOTS = ["clawsweeper[bot]", "openclaw-clawsweeper[bot]"];
 
 export type CommentRouterConfig = {
   targetRepo: string;

--- a/src/repair/update-command-status.ts
+++ b/src/repair/update-command-status.ts
@@ -3,17 +3,23 @@ import { setTimeout as sleep } from "node:timers/promises";
 import { ghJsonWithRetry, ghPagedWithRetry, ghText } from "./github-cli.js";
 import type { JsonValue, LooseRecord } from "./json-types.js";
 import { repoRoot } from "./paths.js";
-import { issueNumberFromUrl, normalizeGitHubActor, writePayload } from "./comment-router-utils.js";
+import { DEFAULT_TRUSTED_BOTS } from "./config.js";
+import {
+  commaSet,
+  isAllowedMutationActor,
+  issueNumberFromUrl,
+  writePayload,
+} from "./comment-router-utils.js";
 
 const PROGRESS_START = "<!-- clawsweeper-command-progress:start -->";
 const PROGRESS_END = "<!-- clawsweeper-command-progress:end -->";
-const TRUSTED_STATUS_COMMENT_ACTORS = new Set(["clawsweeper", "openclaw-clawsweeper"]);
 
 type Options = {
   repo: string;
   itemNumber: string;
   marker: string;
   statusCommentId: number | null;
+  trustedBots: Set<string>;
   state: string;
   detail: string;
   runUrl: string;
@@ -67,7 +73,7 @@ async function findCommandStatusComment(options: Options): Promise<LooseRecord |
 }
 
 function fetchExactStatusComment(
-  options: Pick<Options, "repo" | "itemNumber" | "statusCommentId">,
+  options: Pick<Options, "repo" | "itemNumber" | "statusCommentId" | "trustedBots">,
 ) {
   if (!options.statusCommentId) return null;
   try {
@@ -75,7 +81,7 @@ function fetchExactStatusComment(
       ["api", `repos/${options.repo}/issues/comments/${options.statusCommentId}`],
       { attempts: 3 },
     );
-    if (!isTrustedStatusComment(comment)) return null;
+    if (!isTrustedStatusComment(comment, options.trustedBots)) return null;
     if (issueNumberFromUrl(comment.issue_url) !== Number(options.itemNumber)) return null;
     return comment;
   } catch {
@@ -85,12 +91,13 @@ function fetchExactStatusComment(
 
 export function selectCommandStatusComment(
   comments: LooseRecord[],
-  options: Pick<Options, "marker" | "statusCommentId">,
+  options: Pick<Options, "marker" | "statusCommentId" | "trustedBots">,
 ) {
   if (options.statusCommentId) {
     const exact = comments.find(
       (comment) =>
-        Number(comment.id ?? 0) === options.statusCommentId && isTrustedStatusComment(comment),
+        Number(comment.id ?? 0) === options.statusCommentId &&
+        isTrustedStatusComment(comment, options.trustedBots),
     );
     if (exact) return exact;
   }
@@ -98,7 +105,7 @@ export function selectCommandStatusComment(
   return comments
     .filter(
       (comment) =>
-        isTrustedStatusComment(comment) &&
+        isTrustedStatusComment(comment, options.trustedBots) &&
         typeof comment.body === "string" &&
         comment.body.includes(options.marker),
     )
@@ -148,8 +155,11 @@ export function parseOptions(argv: string[]): Options {
     repo: args.repo ?? process.env.TARGET_REPO ?? "",
     itemNumber: args["item-number"] ?? process.env.ITEM_NUMBER ?? "",
     marker: args.marker ?? process.env.COMMAND_STATUS_MARKER ?? "",
-    statusCommentId: optionalNumber(
-      args["status-comment-id"] ?? process.env.CLAWSWEEPER_STATUS_COMMENT_ID,
+    statusCommentId: optionalNumber(args["status-comment-id"] ?? process.env.STATUS_COMMENT_ID),
+    trustedBots: commaSet(
+      args["trusted-bots"] ??
+        process.env.CLAWSWEEPER_TRUSTED_BOTS ??
+        DEFAULT_TRUSTED_BOTS.join(","),
     ),
     state: args.state ?? process.env.COMMAND_STATUS_STATE ?? "",
     detail: args.detail ?? process.env.COMMAND_STATUS_DETAIL ?? "",
@@ -179,6 +189,6 @@ function optionalNumber(value: JsonValue) {
   return number;
 }
 
-function isTrustedStatusComment(comment: LooseRecord) {
-  return TRUSTED_STATUS_COMMENT_ACTORS.has(normalizeGitHubActor(comment.user?.login));
+function isTrustedStatusComment(comment: LooseRecord, trustedBots: Set<string>) {
+  return isAllowedMutationActor(comment.user?.login, trustedBots);
 }

--- a/test/repair/update-command-status.test.ts
+++ b/test/repair/update-command-status.test.ts
@@ -7,6 +7,29 @@ import {
   selectCommandStatusComment,
 } from "../../dist/repair/update-command-status.js";
 
+function withEnv(values: Record<string, string | undefined>, run: () => void) {
+  const previous = new Map<string, string | undefined>();
+  for (const [name, value] of Object.entries(values)) {
+    previous.set(name, process.env[name]);
+    if (value === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = value;
+    }
+  }
+  try {
+    run();
+  } finally {
+    for (const [name, value] of previous) {
+      if (value === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
+    }
+  }
+}
+
 test("parseOptions preserves empty string arguments", () => {
   const options = parseOptions([
     "--repo",
@@ -21,6 +44,14 @@ test("parseOptions preserves empty string arguments", () => {
 
   assert.equal(options.marker, "");
   assert.equal(options.statusCommentId, null);
+});
+
+test("parseOptions reads STATUS_COMMENT_ID env fallback", () => {
+  withEnv({ STATUS_COMMENT_ID: "4466202000" }, () => {
+    const options = parseOptions(["--repo", "openclaw/openclaw", "--item-number", "81564"]);
+
+    assert.equal(options.statusCommentId, 4466202000);
+  });
 });
 
 test("empty markers do not target human comments that mention true", () => {
@@ -47,6 +78,7 @@ test("empty markers do not target human comments that mention true", () => {
     {
       marker: options.marker,
       statusCommentId: options.statusCommentId,
+      trustedBots: options.trustedBots,
     },
   );
 
@@ -55,6 +87,7 @@ test("empty markers do not target human comments that mention true", () => {
 
 test("selectCommandStatusComment prefers exact status comment ids", () => {
   const marker = "<!-- clawsweeper-command-status:81564:re_review:320c867f -->";
+  const options = parseOptions(["--marker", marker, "--status-comment-id", "4466202000"]);
   const selected = selectCommandStatusComment(
     [
       {
@@ -69,8 +102,9 @@ test("selectCommandStatusComment prefers exact status comment ids", () => {
       },
     ],
     {
-      marker,
-      statusCommentId: 4466202000,
+      marker: options.marker,
+      statusCommentId: options.statusCommentId,
+      trustedBots: options.trustedBots,
     },
   );
 
@@ -79,6 +113,7 @@ test("selectCommandStatusComment prefers exact status comment ids", () => {
 
 test("selectCommandStatusComment ignores human comments during marker fallback", () => {
   const marker = "<!-- clawsweeper-command-status:81564:re_review:320c867f -->";
+  const options = parseOptions(["--marker", marker]);
   const selected = selectCommandStatusComment(
     [
       {
@@ -93,12 +128,69 @@ test("selectCommandStatusComment ignores human comments during marker fallback",
       },
     ],
     {
-      marker,
-      statusCommentId: null,
+      marker: options.marker,
+      statusCommentId: options.statusCommentId,
+      trustedBots: options.trustedBots,
     },
   );
 
   assert.equal(selected?.id, 4466202000);
+});
+
+test("selectCommandStatusComment honors custom trusted bots for exact ids", () => {
+  const marker = "<!-- clawsweeper-command-status:81564:re_review:320c867f -->";
+  const options = parseOptions([
+    "--marker",
+    marker,
+    "--status-comment-id",
+    "4466202000",
+    "--trusted-bots",
+    "custom-clawsweeper[bot]",
+  ]);
+  const selected = selectCommandStatusComment(
+    [
+      {
+        id: 4466202000,
+        user: { login: "custom-clawsweeper[bot]" },
+        body: "<!-- clawsweeper-command-ack:4466201487 -->\nClawSweeper picked this up.",
+      },
+    ],
+    {
+      marker: options.marker,
+      statusCommentId: options.statusCommentId,
+      trustedBots: options.trustedBots,
+    },
+  );
+
+  assert.equal(selected?.id, 4466202000);
+});
+
+test("selectCommandStatusComment honors custom trusted bots during marker fallback", () => {
+  const marker = "<!-- clawsweeper-command-status:81564:re_review:320c867f -->";
+  withEnv({ CLAWSWEEPER_TRUSTED_BOTS: "custom-clawsweeper[bot]" }, () => {
+    const options = parseOptions(["--marker", marker]);
+    const selected = selectCommandStatusComment(
+      [
+        {
+          id: 4465717559,
+          user: { login: "hxy91819" },
+          body: marker,
+        },
+        {
+          id: 4466202000,
+          user: { login: "custom-clawsweeper[bot]" },
+          body: `${marker}\nClawSweeper picked this up.`,
+        },
+      ],
+      {
+        marker: options.marker,
+        statusCommentId: options.statusCommentId,
+        trustedBots: options.trustedBots,
+      },
+    );
+
+    assert.equal(selected?.id, 4466202000);
+  });
 });
 
 test("mergeCommandProgressSection replaces existing progress blocks in place", () => {


### PR DESCRIPTION
## Problem

PR #75 fixed a real command-status targeting bug: ordinary event-item reviews and `/clawsweeper re-review` command runs share the same `clawsweeper_item` workflow, but only command-triggered re-reviews have a command status comment to update. When an ordinary PR/issue event had no `command_status_marker` or `status_comment_id`, the old parser could treat `--marker ""` as the string `"true"`, causing `update-command-status` to scan comments for `body.includes("true")` and potentially patch a human comment such as one containing `isError: true`.

That fix left two follow-up issues in the merged code:

- `update-command-status` hardcoded `clawsweeper` and `openclaw-clawsweeper` as trusted status comment authors, while the rest of the repair lane supports trusted bot overrides through `CLAWSWEEPER_TRUSTED_BOTS`.
- The direct env fallback for the status comment id read `CLAWSWEEPER_STATUS_COMMENT_ID`, but the workflow exports `STATUS_COMMENT_ID` and passes that value to `--status-comment-id`.

## Solution

This follow-up keeps PR #75's conservative behavior: `update-command-status` only updates a status comment that can be proven by exact comment id or full command marker, and the target must be authored by a trusted bot.

The changes are:

- Export the repair lane default trusted bot list from `src/repair/config.ts` so command status updates do not maintain a second copy of that policy.
- Parse `--trusted-bots` / `CLAWSWEEPER_TRUSTED_BOTS` in `src/repair/update-command-status.ts` and use `isAllowedMutationActor()` for the same `foo` / `foo[bot]` normalization used elsewhere in the repair lane.
- Align the env fallback with the workflow by reading `STATUS_COMMENT_ID` when `--status-comment-id` is not provided.
- Add regression tests for env-based status comment id parsing, custom trusted bot exact-id matching, custom trusted bot marker fallback, and the existing human-comment guard.

## Test plan

- `pnpm run build:repair && node --test test/repair/update-command-status.test.ts`
- `nvm use 24 && pnpm run check`