### PR TITLE
fix(repair): credit automerge maintainers

### DIFF
--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -1,5 +1,6 @@
 import type { JsonValue, LooseRecord } from "./json-types.js";
 import { renderJobIntentFrontmatter } from "./job-intent.js";
+import { compactText } from "./text-utils.js";
 export const REPAIR_INTENTS = new Set([
   "fix_ci",
   "address_review",
@@ -625,6 +626,147 @@ export function buildAutomergeMergeArgs({
     args.push("--match-head-commit", expectedHeadSha);
   }
   return args;
+}
+
+export function buildAutomergeSquashMessage({
+  command,
+  view,
+  target,
+  comments,
+}: LooseRecord): LooseRecord {
+  const number = Number(command.issue_number);
+  const rawTitle = String(view.title ?? target.title ?? `PR #${number}`).trim();
+  const subject = rawTitle.includes(`#${number}`) ? rawTitle : `${rawTitle} (#${number})`;
+  const summaryLines = reviewSummaryLines(command);
+  const fixupLines = automergeFixupLines({ view, comments });
+  const validationLines = [
+    `ClawSweeper review passed for head ${target.head_sha ?? command.expected_head_sha ?? "unknown"}.`,
+    "Required merge gates passed before the squash merge.",
+  ];
+  const body = [
+    "Summary:",
+    ...summaryLines.map((line: string) => `- ${line}`),
+    "",
+    "Automerge notes:",
+    ...fixupLines.map((line: string) => `- ${line}`),
+    "",
+    "Validation:",
+    ...validationLines.map((line: string) => `- ${line}`),
+    "",
+    `Prepared head SHA: ${target.head_sha ?? command.expected_head_sha ?? "unknown"}`,
+    ...(command.comment_url ? [`Review: ${command.comment_url}`] : []),
+    "",
+    ...automergeCreditTrailers({ command, commits: view.commits ?? [] }),
+  ].join("\n");
+  return { subject, body: body.trimEnd(), summaryLines, fixupLines };
+}
+
+function reviewSummaryLines(command: LooseRecord): string[] {
+  const lines = linesFromMarkdownSection(command.review_summary);
+  if (lines.length > 0) return lines.slice(0, 4);
+  return [
+    `Merged ${command.target?.title ?? `PR #${command.issue_number}`} after ClawSweeper review.`,
+  ];
+}
+
+function automergeFixupLines({ view, comments }: LooseRecord): string[] {
+  const lines: string[] = [];
+  const safeComments = Array.isArray(comments) ? comments : [];
+  const commits = Array.isArray(view.commits) ? view.commits : [];
+  const sawRepair = safeComments.some((comment: JsonValue) =>
+    String(comment.body ?? "").includes("clawsweeper_auto_repair"),
+  );
+  const sawFinding = safeComments.some((comment: JsonValue) =>
+    /Codex review: found issues before merge|clawsweeper-action:fix-required/i.test(
+      String(comment.body ?? ""),
+    ),
+  );
+  if (sawRepair) lines.push("Ran the ClawSweeper repair loop before final review.");
+  if (sawFinding) lines.push("Addressed earlier ClawSweeper review findings before merge.");
+  const followupCommits = commits.slice(1).map(commitHeadline).filter(Boolean);
+  const followupPrefix =
+    sawRepair || sawFinding
+      ? "Included post-review commit in the final squash"
+      : "PR branch already contained follow-up commit before automerge";
+  for (const headline of followupCommits.slice(0, 6)) {
+    lines.push(`${followupPrefix}: ${headline}`);
+  }
+  const uniqueLines = unique(lines).slice(0, 8);
+  return uniqueLines.length > 0
+    ? uniqueLines
+    : ["No ClawSweeper repair was needed after automerge opt-in."];
+}
+
+function automergeCreditTrailers({ command, commits }: LooseRecord): string[] {
+  const trailers: string[] = [];
+  const coAuthorKeys = new Set<string>();
+  for (const trailer of coAuthorTrailersFromCommits(commits, coAuthorKeys)) {
+    trailers.push(trailer);
+  }
+
+  const maintainer = maintainerCredit(command.maintainer_attribution ?? command);
+  if (!maintainer) return trailers;
+  trailers.push(`Approved-by: ${maintainer.login}`);
+  if (!coAuthorKeys.has(maintainer.coAuthorKey)) {
+    trailers.push(`Co-authored-by: ${maintainer.name} <${maintainer.email}>`);
+  }
+  return trailers;
+}
+
+function coAuthorTrailersFromCommits(commits: JsonValue, seen: Set<string>): string[] {
+  if (!Array.isArray(commits)) return [];
+  const trailers: string[] = [];
+  for (const commit of commits) {
+    for (const author of commit?.authors ?? []) {
+      const name = String(author?.name ?? author?.login ?? "").trim();
+      const email = String(author?.email ?? "").trim();
+      if (!name || !email) continue;
+      const key = coAuthorKey(name, email);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      trailers.push(`Co-authored-by: ${name} <${email}>`);
+    }
+  }
+  return trailers;
+}
+
+function maintainerCredit(value: LooseRecord): LooseRecord | null {
+  const login = normalizedLogin(value.author ?? value.login);
+  if (!login || login.includes("[bot]")) return null;
+  const id = String(value.author_id ?? value.id ?? "").trim();
+  const name = String(value.author_name ?? value.name ?? login).trim() || login;
+  const email = id
+    ? `${id}+${login}@users.noreply.github.com`
+    : `${login}@users.noreply.github.com`;
+  return {
+    login,
+    name,
+    email,
+    coAuthorKey: coAuthorKey(name, email),
+  };
+}
+
+function coAuthorKey(name: string, email: string) {
+  return `${name.trim().toLowerCase()} <${email.trim().toLowerCase()}>`;
+}
+
+function commitHeadline(commit: JsonValue): string {
+  return compactText(commit?.messageHeadline ?? commit?.headline ?? commit?.message ?? "", 160);
+}
+
+function linesFromMarkdownSection(section: JsonValue): string[] {
+  const text = String(section ?? "").trim();
+  if (!text) return [];
+  const bulletLines = text
+    .split(/\n+/)
+    .map((line: string) => line.replace(/^\s*[-*]\s+/, "").trim())
+    .filter(Boolean);
+  if (bulletLines.length > 1) return bulletLines.map((line) => compactText(line, 220));
+  return [compactText(text, 320)];
+}
+
+function unique<T>(items: T[]): T[] {
+  return [...new Set(items)];
 }
 
 export function reviewedHeadShaBlockReason({

--- a/src/repair/comment-router-utils.ts
+++ b/src/repair/comment-router-utils.ts
@@ -187,6 +187,8 @@ export function appendLedger(current: LooseRecord, entries: LooseRecord[]) {
         repo: entry.repo,
         issue_number: entry.issue_number,
         author: entry.author,
+        author_id: entry.author_id ?? null,
+        author_name: entry.author_name ?? null,
         author_association: entry.author_association,
         trigger: entry.trigger,
         command: entry.command,

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -1049,6 +1049,17 @@ function latestAutomergeMaintainerAttribution(command: LooseRecord) {
     if (!["executed", "waiting"].includes(String(entry.status ?? ""))) continue;
     candidates.push(entry);
   }
+  for (const entry of commands ?? []) {
+    if (entry === command) continue;
+    if (entry.repo !== command.repo) continue;
+    if (Number(entry.issue_number) !== Number(command.issue_number)) continue;
+    if (!["automerge", "maintainer_approve_automerge"].includes(String(entry.intent ?? ""))) {
+      continue;
+    }
+    if (entry.trusted_bot) continue;
+    if (!["ready", "executed", "waiting"].includes(String(entry.status ?? ""))) continue;
+    candidates.push(entry);
+  }
   const latest = candidates
     .map((entry) => ({
       entry,

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -33,6 +33,7 @@ import {
   automergeRebaseRepairReason,
   automergeTransientWaitConfig,
   buildAutomergeMergeArgs,
+  buildAutomergeSquashMessage,
   commandHasAction,
   createCachedIssueCommentsLookup,
   createCachedIssueCommentsLookupAsync,
@@ -172,6 +173,7 @@ for (const comment of comments) {
     repo: targetRepo,
     issue_number: issueNumber,
     author: comment.user?.login ?? null,
+    author_id: comment.user?.id ?? null,
     author_association: String(comment.author_association ?? "").toUpperCase(),
     comment_created_at: comment.created_at,
     comment_updated_at: comment.updated_at,
@@ -1027,6 +1029,38 @@ function latestAutomergeResumeAt(command: LooseRecord) {
     }
   }
   return latest;
+}
+
+function latestAutomergeMaintainerAttribution(command: LooseRecord) {
+  const candidates: LooseRecord[] = [];
+  if (
+    !command.trusted_bot &&
+    ["automerge", "maintainer_approve_automerge"].includes(command.intent)
+  ) {
+    candidates.push(command);
+  }
+  for (const entry of ledger.commands ?? []) {
+    if (entry.repo !== command.repo) continue;
+    if (Number(entry.issue_number) !== Number(command.issue_number)) continue;
+    if (!["automerge", "maintainer_approve_automerge"].includes(String(entry.intent ?? ""))) {
+      continue;
+    }
+    if (entry.trusted_bot) continue;
+    if (!["executed", "waiting"].includes(String(entry.status ?? ""))) continue;
+    candidates.push(entry);
+  }
+  const latest = candidates
+    .map((entry) => ({
+      entry,
+      at: Date.parse(String(entry.comment_updated_at ?? entry.comment_created_at ?? "")) || 0,
+    }))
+    .sort((left, right) => right.at - left.at)[0]?.entry;
+  if (!latest?.author) return null;
+  return {
+    author: latest.author,
+    author_id: latest.author_id,
+    author_name: latest.author_name,
+  };
 }
 
 function repairLoopStoppedReason(command: LooseRecord) {
@@ -1991,7 +2025,10 @@ function executeAutomerge(command: LooseRecord) {
     return { action: "merge", status: "blocked", reason: gateBlock, merge_method: "squash" };
   }
   const mergeMessage = buildAutomergeSquashMessage({
-    command,
+    command: {
+      ...command,
+      maintainer_attribution: latestAutomergeMaintainerAttribution(command),
+    },
     view,
     target: latestTarget,
     comments: issueCommentsFor(command.issue_number),
@@ -2085,96 +2122,6 @@ function sleepMs(ms: number) {
   if (ms <= 0) return;
   const buffer = new SharedArrayBuffer(4);
   Atomics.wait(new Int32Array(buffer), 0, 0, ms);
-}
-
-function buildAutomergeSquashMessage({
-  command,
-  view,
-  target,
-  comments,
-}: LooseRecord): LooseRecord {
-  const number = Number(command.issue_number);
-  const rawTitle = String(view.title ?? target.title ?? `PR #${number}`).trim();
-  const subject = rawTitle.includes(`#${number}`) ? rawTitle : `${rawTitle} (#${number})`;
-  const summaryLines = reviewSummaryLines(command);
-  const fixupLines = automergeFixupLines({ view, comments });
-  const validationLines = [
-    `ClawSweeper review passed for head ${target.head_sha ?? command.expected_head_sha ?? "unknown"}.`,
-    "Required merge gates passed before the squash merge.",
-  ];
-  const body = [
-    "Summary:",
-    ...summaryLines.map((line: string) => `- ${line}`),
-    "",
-    "Automerge notes:",
-    ...fixupLines.map((line: string) => `- ${line}`),
-    "",
-    "Validation:",
-    ...validationLines.map((line: string) => `- ${line}`),
-    "",
-    `Prepared head SHA: ${target.head_sha ?? command.expected_head_sha ?? "unknown"}`,
-    ...(command.comment_url ? [`Review: ${command.comment_url}`] : []),
-    "",
-    ...coAuthorTrailersFromCommits(view.commits ?? []),
-  ].join("\n");
-  return { subject, body: body.trimEnd(), summaryLines, fixupLines };
-}
-
-function reviewSummaryLines(command: LooseRecord): string[] {
-  const lines = linesFromMarkdownSection(command.review_summary);
-  if (lines.length > 0) return lines.slice(0, 4);
-  return [
-    `Merged ${command.target?.title ?? `PR #${command.issue_number}`} after ClawSweeper review.`,
-  ];
-}
-
-function automergeFixupLines({ view, comments }: LooseRecord): string[] {
-  const lines: string[] = [];
-  const commits = Array.isArray(view.commits) ? view.commits : [];
-  const sawRepair = comments.some((comment: JsonValue) =>
-    String(comment.body ?? "").includes("clawsweeper_auto_repair"),
-  );
-  const sawFinding = comments.some((comment: JsonValue) =>
-    /Codex review: found issues before merge|clawsweeper-action:fix-required/i.test(
-      String(comment.body ?? ""),
-    ),
-  );
-  if (sawRepair) lines.push("Ran the ClawSweeper repair loop before final review.");
-  if (sawFinding) lines.push("Addressed earlier ClawSweeper review findings before merge.");
-  const followupCommits = commits.slice(1).map(commitHeadline).filter(Boolean);
-  const followupPrefix =
-    sawRepair || sawFinding
-      ? "Included post-review commit in the final squash"
-      : "PR branch already contained follow-up commit before automerge";
-  for (const headline of followupCommits.slice(0, 6)) {
-    lines.push(`${followupPrefix}: ${headline}`);
-  }
-  const uniqueLines = unique(lines).slice(0, 8);
-  return uniqueLines.length > 0
-    ? uniqueLines
-    : ["No ClawSweeper repair was needed after automerge opt-in."];
-}
-
-function coAuthorTrailersFromCommits(commits: JsonValue): string[] {
-  if (!Array.isArray(commits)) return [];
-  const trailers: string[] = [];
-  const seen = new Set<string>();
-  for (const commit of commits) {
-    for (const author of commit?.authors ?? []) {
-      const name = String(author?.name ?? author?.login ?? "").trim();
-      const email = String(author?.email ?? "").trim();
-      if (!name || !email) continue;
-      const key = `${name.toLowerCase()} <${email.toLowerCase()}>`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-      trailers.push(`Co-authored-by: ${name} <${email}>`);
-    }
-  }
-  return trailers;
-}
-
-function commitHeadline(commit: JsonValue): string {
-  return compactText(commit?.messageHeadline ?? commit?.headline ?? commit?.message ?? "", 160);
 }
 
 function writeAutomergeMergeBody(command: LooseRecord, target: LooseRecord, body: string) {
@@ -2364,17 +2311,6 @@ function extractMarkdownSection(body: JsonValue, heading: string): string | null
     "i",
   );
   return pattern.exec(text)?.[1]?.trim() || null;
-}
-
-function linesFromMarkdownSection(section: JsonValue): string[] {
-  const text = String(section ?? "").trim();
-  if (!text) return [];
-  const bulletLines = text
-    .split(/\n+/)
-    .map((line: string) => line.replace(/^\s*[-*]\s+/, "").trim())
-    .filter(Boolean);
-  if (bulletLines.length > 1) return bulletLines.map((line) => compactText(line, 220));
-  return [compactText(text, 320)];
 }
 
 function issueCommentsFor(number: JsonValue): JsonValue[] {

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -18,6 +18,7 @@ import {
   automergeReadinessRepairReason,
   automergeTransientWaitConfig,
   buildAutomergeMergeArgs,
+  buildAutomergeSquashMessage,
   commandHasAction,
   createCachedIssueCommentsLookup,
   createCachedIssueCommentsLookupAsync,
@@ -1709,6 +1710,82 @@ test("automerge merge args pin the reviewed head SHA", () => {
       "abc123",
     ],
   );
+});
+
+test("automerge squash message credits the initiating maintainer with approval and co-author trailers", () => {
+  const message = buildAutomergeSquashMessage({
+    command: {
+      issue_number: 123,
+      expected_head_sha: "abc123",
+      target: { title: "fix: test" },
+      maintainer_attribution: {
+        author: "maintainer-user",
+        author_id: 123456,
+      },
+    },
+    target: { head_sha: "abc123", title: "fix: test" },
+    view: {
+      title: "fix: test",
+      commits: [
+        {
+          authors: [
+            {
+              name: "Contributor",
+              email: "111+contributor@users.noreply.github.com",
+            },
+          ],
+        },
+      ],
+    },
+    comments: [],
+  });
+
+  assert.match(
+    message.body,
+    /^Co-authored-by: Contributor <111\+contributor@users\.noreply\.github\.com>$/m,
+  );
+  assert.match(message.body, /^Approved-by: maintainer-user$/m);
+  assert.match(
+    message.body,
+    /^Co-authored-by: maintainer-user <123456\+maintainer-user@users\.noreply\.github\.com>$/m,
+  );
+});
+
+test("automerge squash message dedupes maintainer co-author trailer", () => {
+  const message = buildAutomergeSquashMessage({
+    command: {
+      issue_number: 123,
+      expected_head_sha: "abc123",
+      target: { title: "fix: test" },
+      maintainer_attribution: {
+        author: "maintainer-user",
+        author_id: 123456,
+      },
+    },
+    target: { head_sha: "abc123", title: "fix: test" },
+    view: {
+      title: "fix: test",
+      commits: [
+        {
+          authors: [
+            {
+              name: "maintainer-user",
+              email: "123456+maintainer-user@users.noreply.github.com",
+            },
+          ],
+        },
+      ],
+    },
+    comments: [],
+  });
+
+  assert.equal(
+    message.body.match(
+      /^Co-authored-by: maintainer-user <123456\+maintainer-user@users\.noreply\.github\.com>$/gm,
+    )?.length,
+    1,
+  );
+  assert.match(message.body, /^Approved-by: maintainer-user$/m);
 });
 
 test("automerge gate block only reports the global merge policy gate", () => {

--- a/test/repair/comment-router-utils.test.ts
+++ b/test/repair/comment-router-utils.test.ts
@@ -112,6 +112,30 @@ test("appendLedger reports compact executed writes", () => {
   assert.equal(ledger.commands.length, 1);
 });
 
+test("appendLedger preserves maintainer identity fields for automerge attribution", () => {
+  const ledger = { updated_at: null, commands: [] };
+
+  appendLedger(ledger, [
+    {
+      idempotency_key: "automerge-opt-in",
+      comment_id: "126",
+      comment_version_key: "126:2026-04-29T03:02:00Z",
+      comment_updated_at: "2026-04-29T03:02:00Z",
+      status: "executed",
+      intent: "automerge",
+      issue_number: 74499,
+      repo: "openclaw/openclaw",
+      author: "maintainer-user",
+      author_id: 123456,
+      author_name: "Maintainer User",
+    },
+  ]);
+
+  assert.equal(ledger.commands[0].author, "maintainer-user");
+  assert.equal(ledger.commands[0].author_id, 123456);
+  assert.equal(ledger.commands[0].author_name, "Maintainer User");
+});
+
 test("appendLedger preserves compact executed actions for repair caps", () => {
   const ledger = { updated_at: null, commands: [] };
 


### PR DESCRIPTION
## Summary
- add automerge squash-message Approved-by and deduped Co-authored-by trailers for the initiating maintainer
- preserve maintainer GitHub identity fields in the comment-router ledger for later automerge continuations
- cover merge-message trailer rendering, dedupe, and ledger identity persistence

## Validation
- pnpm run build:repair && pnpm exec node --test test/repair/comment-router-core.test.ts test/repair/comment-router-utils.test.ts
- pnpm run check