### PR TITLE
feat(review): suggest OpenClaw Mantis proof comments

### DIFF
--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -455,6 +455,39 @@ visible chat behavior the `telegram-crabbox-e2e-proof` skill can show in a
 short recording. Mark it `not_needed` for non-Telegram PRs or Telegram work
 that is not usefully visible in that recording.
 
+Always fill `mantisRecommendation`. This is maintainer guidance only: it must
+never trigger OpenClaw Mantis, claim Mantis has run, ask ClawSweeper to dispatch
+a workflow, or request ClawSweeper repair markers. Recommend Mantis only when a
+PR changes behavior that is best verified in a real transport or visible UI.
+Use `status: "not_recommended"`, `scenario: "none"`, and an empty
+`maintainerComment` for issues, docs-only/test-only/internal refactors, CI-only
+work, pure schema/type changes, or behavior where unit tests are the better
+proof.
+
+Known Mantis lanes:
+
+- `telegram_live`: Telegram live QA with a redacted transcript visual. Use for
+  bot-to-bot Telegram commands, mention handling, reply delivery, and observable
+  message transcripts.
+- `telegram_desktop_proof`: agentic native Telegram Desktop before/after visual
+  proof. Use for visible Telegram UI behavior, topics, buttons, callbacks,
+  formatting, media, or flows where native UI GIFs are useful.
+- `discord_status_reactions`: before/after Discord queued/thinking/done status
+  reaction proof. Use only for status reaction behavior.
+- `discord_thread_attachment`: before/after Discord thread reply filePath
+  attachment proof. Use only for thread attachment behavior.
+- `slack_desktop_smoke`: Slack desktop/VNC proof. Use for Slack desktop or
+  gateway-visible behavior.
+- `visual_task`: generic visible browser/desktop proof. Use only when no
+  dedicated transport scenario fits and the proof can be described concretely.
+
+When `mantisRecommendation.status` is `recommended`, write a single-line
+`maintainerComment` that starts with `@openclaw-mantis`, never `@Mantis`, and
+describes the exact behavior to prove. Example:
+`@openclaw-mantis telegram desktop proof: verify that /stop targets the active
+topic and does not affect other topics.` Keep it short enough to paste into a
+PR comment.
+
 Always fill `triagePriority`. ClawSweeper syncs this value to one of the GitHub
 labels `P0`, `P1`, `P2`, or `P3` so maintainers can find issues and pull requests
 by priority. Choose the priority from user impact, severity, confidence, and

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -484,7 +484,8 @@ Known Mantis lanes:
 When `mantisRecommendation.status` is `recommended`, write a single-line
 `maintainerComment` that starts with `@openclaw-mantis` and describes the exact
 behavior to prove. Do not use any shorter or ambiguous Mantis account mention.
-Example:
+ClawSweeper validates the account mention but does not render it publicly, so
+its own review comment does not accidentally start a Mantis workflow. Example:
 `@openclaw-mantis telegram desktop proof: verify that /stop targets the active
 topic and does not affect other topics.` Keep it short enough to paste into a
 PR comment.

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -482,8 +482,9 @@ Known Mantis lanes:
   dedicated transport scenario fits and the proof can be described concretely.
 
 When `mantisRecommendation.status` is `recommended`, write a single-line
-`maintainerComment` that starts with `@openclaw-mantis`, never `@Mantis`, and
-describes the exact behavior to prove. Example:
+`maintainerComment` that starts with `@openclaw-mantis` and describes the exact
+behavior to prove. Do not use any shorter or ambiguous Mantis account mention.
+Example:
 `@openclaw-mantis telegram desktop proof: verify that /stop targets the active
 topic and does not affect other topics.` Keep it short enough to paste into a
 PR comment.

--- a/schema/clawsweeper-decision.schema.json
+++ b/schema/clawsweeper-decision.schema.json
@@ -26,6 +26,7 @@
     "securityReview",
     "realBehaviorProof",
     "telegramVisibleProof",
+    "mantisRecommendation",
     "overallCorrectness",
     "overallConfidenceScore",
     "fixedRelease",
@@ -375,6 +376,38 @@
         "summary": {
           "type": "string",
           "description": "One concise sentence explaining why the PR should or should not receive the mantis: telegram-visible-proof label."
+        }
+      }
+    },
+    "mantisRecommendation": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "For PRs, recommend a copy-paste maintainer comment for OpenClaw Mantis only when live transport or visual proof would materially help review. Do not claim Mantis has run and do not dispatch any workflow.",
+      "required": ["status", "scenario", "reason", "maintainerComment"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["recommended", "not_recommended"]
+        },
+        "scenario": {
+          "type": "string",
+          "enum": [
+            "none",
+            "telegram_live",
+            "telegram_desktop_proof",
+            "discord_status_reactions",
+            "discord_thread_attachment",
+            "slack_desktop_smoke",
+            "visual_task"
+          ]
+        },
+        "reason": {
+          "type": "string",
+          "description": "One concise sentence explaining why this Mantis lane would or would not add useful maintainer proof."
+        },
+        "maintainerComment": {
+          "type": "string",
+          "description": "When recommended, a single-line PR comment starting with @openclaw-mantis that a maintainer can paste. Never use @Mantis. For not_recommended, use an empty string."
         }
       }
     },

--- a/schema/clawsweeper-decision.schema.json
+++ b/schema/clawsweeper-decision.schema.json
@@ -407,7 +407,7 @@
         },
         "maintainerComment": {
           "type": "string",
-          "description": "When recommended, a single-line PR comment starting with @openclaw-mantis that a maintainer can paste. Do not use shorter or ambiguous Mantis account mentions. For not_recommended, use an empty string."
+          "description": "When recommended, a single-line PR comment starting with @openclaw-mantis that a maintainer can paste. ClawSweeper validates this mention but does not render it publicly, so review comments do not accidentally start Mantis workflows. Do not use shorter or ambiguous Mantis account mentions. For not_recommended, use an empty string."
         }
       }
     },

--- a/schema/clawsweeper-decision.schema.json
+++ b/schema/clawsweeper-decision.schema.json
@@ -407,7 +407,7 @@
         },
         "maintainerComment": {
           "type": "string",
-          "description": "When recommended, a single-line PR comment starting with @openclaw-mantis that a maintainer can paste. Never use @Mantis. For not_recommended, use an empty string."
+          "description": "When recommended, a single-line PR comment starting with @openclaw-mantis that a maintainer can paste. Do not use shorter or ambiguous Mantis account mentions. For not_recommended, use an empty string."
         }
       }
     },

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -4970,9 +4970,10 @@ function publicRealBehaviorProofLine(proof: RealBehaviorProof): string {
 function publicMantisRecommendationBlock(recommendation: MantisRecommendation): string {
   if (recommendation.status !== "recommended" || recommendation.scenario === "none") return "";
   const comment = recommendation.maintainerComment.trim();
+  const ambiguousMantisMention = new RegExp(`@${"mantis"}\\b`, "i");
   if (
     !comment.startsWith("@openclaw-mantis ") ||
-    /@mantis\b/i.test(comment) ||
+    ambiguousMantisMention.test(comment) ||
     /\b(?:gh\s+workflow|workflow_dispatch|dispatch|trigger\s+the\s+workflow)\b/i.test(comment) ||
     comment.length > 500 ||
     comment.includes("\n")

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -4970,9 +4970,10 @@ function publicRealBehaviorProofLine(proof: RealBehaviorProof): string {
 function publicMantisRecommendationBlock(recommendation: MantisRecommendation): string {
   if (recommendation.status !== "recommended" || recommendation.scenario === "none") return "";
   const comment = recommendation.maintainerComment.trim();
+  const accountMention = "@openclaw-mantis";
   const ambiguousMantisMention = new RegExp(`@${"mantis"}\\b`, "i");
   if (
-    !comment.startsWith("@openclaw-mantis ") ||
+    !comment.startsWith(`${accountMention} `) ||
     ambiguousMantisMention.test(comment) ||
     /\b(?:gh\s+workflow|workflow_dispatch|dispatch|trigger\s+the\s+workflow)\b/i.test(comment) ||
     comment.length > 500 ||
@@ -4980,11 +4981,13 @@ function publicMantisRecommendationBlock(recommendation: MantisRecommendation): 
   ) {
     return "";
   }
+  const commandBody = comment.slice(accountMention.length).trim();
+  if (!commandBody) return "";
   const reason = sentence(recommendation.reason);
   const intro = reason
-    ? `${reason} A maintainer can ask Mantis to capture proof by commenting:`
-    : "A maintainer can ask Mantis to capture proof by commenting:";
-  return [intro, "", "```text", comment, "```"].join("\n");
+    ? `${reason} A maintainer can ask Mantis to capture proof by posting a new PR comment that starts with the OpenClaw Mantis account mention, followed by:`
+    : "A maintainer can ask Mantis to capture proof by posting a new PR comment that starts with the OpenClaw Mantis account mention, followed by:";
+  return [intro, "", "```text", commandBody, "```"].join("\n");
 }
 
 function closeIntro(reason: CloseReason): string {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -109,6 +109,15 @@ type RealBehaviorProofEvidenceKind =
   | "none"
   | "not_applicable";
 type TelegramVisibleProofStatus = "needed" | "not_needed";
+type MantisRecommendationStatus = "recommended" | "not_recommended";
+type MantisRecommendationScenario =
+  | "none"
+  | "telegram_live"
+  | "telegram_desktop_proof"
+  | "discord_status_reactions"
+  | "discord_thread_attachment"
+  | "slack_desktop_smoke"
+  | "visual_task";
 type CloseReason =
   | "implemented_on_main"
   | "mostly_implemented_on_main"
@@ -261,6 +270,13 @@ interface TelegramVisibleProof {
   summary: string;
 }
 
+interface MantisRecommendation {
+  status: MantisRecommendationStatus;
+  scenario: MantisRecommendationScenario;
+  reason: string;
+  maintainerComment: string;
+}
+
 interface FixedPullRequest {
   repo: string;
   number: number;
@@ -296,6 +312,7 @@ interface Decision {
   securityReview: SecurityReview;
   realBehaviorProof: RealBehaviorProof;
   telegramVisibleProof: TelegramVisibleProof;
+  mantisRecommendation: MantisRecommendation;
   overallCorrectness: OverallCorrectness;
   overallConfidenceScore: number;
   fixedRelease?: string | null;
@@ -684,7 +701,7 @@ const RECENT_MISSING_OPEN_MS = DAY_MS;
 const DEFAULT_CODEX_MODEL = "gpt-5.5";
 const DEFAULT_REASONING_EFFORT = "high";
 const DEFAULT_SERVICE_TIER = "";
-const REVIEW_POLICY_VERSION = "2026-05-17-policy-v17";
+const REVIEW_POLICY_VERSION = "2026-05-17-policy-v18";
 const REVIEW_ITEM_PROMPT_PATH = join(ROOT, "prompts", "review-item.md");
 const CLAWSWEEPER_DECISION_SCHEMA_PATH = join(ROOT, "schema", "clawsweeper-decision.schema.json");
 const REVIEW_COMMENT_MARKER_PREFIX = "<!-- clawsweeper-review";
@@ -898,6 +915,19 @@ const TELEGRAM_VISIBLE_PROOF_STATUSES = new Set<TelegramVisibleProofStatus>([
   "needed",
   "not_needed",
 ]);
+const MANTIS_RECOMMENDATION_STATUSES = new Set<MantisRecommendationStatus>([
+  "recommended",
+  "not_recommended",
+]);
+const MANTIS_RECOMMENDATION_SCENARIOS = new Set<MantisRecommendationScenario>([
+  "none",
+  "telegram_live",
+  "telegram_desktop_proof",
+  "discord_status_reactions",
+  "discord_thread_attachment",
+  "slack_desktop_smoke",
+  "visual_task",
+]);
 const OVERALL_CORRECTNESS_VALUES = new Set<OverallCorrectness>([
   "patch is correct",
   "patch is incorrect",
@@ -930,6 +960,7 @@ const DECISION_SCHEMA_KEYS = new Set([
   "securityReview",
   "realBehaviorProof",
   "telegramVisibleProof",
+  "mantisRecommendation",
   "overallCorrectness",
   "overallConfidenceScore",
   "fixedRelease",
@@ -954,6 +985,12 @@ const REAL_BEHAVIOR_PROOF_SCHEMA_KEYS = new Set([
   "needsContributorAction",
 ]);
 const TELEGRAM_VISIBLE_PROOF_SCHEMA_KEYS = new Set(["status", "summary"]);
+const MANTIS_RECOMMENDATION_SCHEMA_KEYS = new Set([
+  "status",
+  "scenario",
+  "reason",
+  "maintainerComment",
+]);
 const SECURITY_CONCERN_SCHEMA_KEYS = new Set([
   "title",
   "body",
@@ -989,6 +1026,7 @@ const REVIEW_SECTIONS = {
   securityReview: "Security Review",
   realBehaviorProof: "Real Behavior Proof",
   telegramVisibleProof: "Telegram Visible Proof",
+  mantisRecommendation: "Mantis Recommendation",
   workCandidate: "Work Candidate",
   repairWorkPrompt: "Repair Work Prompt",
   evidence: "Evidence",
@@ -1571,6 +1609,17 @@ function parseTelegramVisibleProof(value: unknown, path: string): TelegramVisibl
   };
 }
 
+function parseMantisRecommendation(value: unknown, path: string): MantisRecommendation {
+  const record = requireRecord(value, path);
+  rejectUnexpectedKeys(record, MANTIS_RECOMMENDATION_SCHEMA_KEYS, path);
+  return {
+    status: requireEnum(record.status, MANTIS_RECOMMENDATION_STATUSES, `${path}.status`),
+    scenario: requireEnum(record.scenario, MANTIS_RECOMMENDATION_SCENARIOS, `${path}.scenario`),
+    reason: requireString(record.reason, `${path}.reason`),
+    maintainerComment: requireString(record.maintainerComment, `${path}.maintainerComment`),
+  };
+}
+
 function requireEnum<T extends string>(value: unknown, allowed: Set<T>, path: string): T {
   if (typeof value === "string" && allowed.has(value as T)) return value as T;
   throw new Error(`${path} has invalid value`);
@@ -1651,6 +1700,10 @@ export function parseDecision(value: unknown, item?: DecisionNormalizationItem):
     telegramVisibleProof: parseTelegramVisibleProof(
       record.telegramVisibleProof,
       "decision.telegramVisibleProof",
+    ),
+    mantisRecommendation: parseMantisRecommendation(
+      record.mantisRecommendation,
+      "decision.mantisRecommendation",
     ),
     overallCorrectness: requireEnum(
       record.overallCorrectness,
@@ -4050,6 +4103,12 @@ function codexFailureDecision(status: number | null, stderr: string, stdout = ""
       status: "not_needed",
       summary: "Telegram visible proof was not assessed because the Codex review failed.",
     },
+    mantisRecommendation: {
+      status: "not_recommended",
+      scenario: "none",
+      reason: "Mantis was not assessed because the Codex review failed.",
+      maintainerComment: "",
+    },
     overallCorrectness: "not a patch",
     overallConfidenceScore: 0,
     fixedRelease: null,
@@ -4908,6 +4967,25 @@ function publicRealBehaviorProofLine(proof: RealBehaviorProof): string {
   }
 }
 
+function publicMantisRecommendationBlock(recommendation: MantisRecommendation): string {
+  if (recommendation.status !== "recommended" || recommendation.scenario === "none") return "";
+  const comment = recommendation.maintainerComment.trim();
+  if (
+    !comment.startsWith("@openclaw-mantis ") ||
+    /@mantis\b/i.test(comment) ||
+    /\b(?:gh\s+workflow|workflow_dispatch|dispatch|trigger\s+the\s+workflow)\b/i.test(comment) ||
+    comment.length > 500 ||
+    comment.includes("\n")
+  ) {
+    return "";
+  }
+  const reason = sentence(recommendation.reason);
+  const intro = reason
+    ? `${reason} A maintainer can ask Mantis to capture proof by commenting:`
+    : "A maintainer can ask Mantis to capture proof by commenting:";
+  return [intro, "", "```text", comment, "```"].join("\n");
+}
+
 function closeIntro(reason: CloseReason): string {
   switch (reason) {
     case "implemented_on_main":
@@ -5320,6 +5398,28 @@ function reportTelegramVisibleProof(markdown: string): TelegramVisibleProof {
     summary:
       sectionLineValue(section, "Summary") ??
       "No Telegram visible-proof assessment was recorded in this report.",
+  };
+}
+
+function reportMantisRecommendation(markdown: string): MantisRecommendation {
+  const section = reviewSectionValue(markdown, "mantisRecommendation");
+  const statusValue = sectionLineValue(section, "Status");
+  const scenarioValue = sectionLineValue(section, "Scenario");
+  const status = MANTIS_RECOMMENDATION_STATUSES.has(statusValue as MantisRecommendationStatus)
+    ? (statusValue as MantisRecommendationStatus)
+    : "not_recommended";
+  const scenario = MANTIS_RECOMMENDATION_SCENARIOS.has(
+    scenarioValue as MantisRecommendationScenario,
+  )
+    ? (scenarioValue as MantisRecommendationScenario)
+    : "none";
+  return {
+    status,
+    scenario,
+    reason:
+      sectionLineValue(section, "Reason") ??
+      "No Mantis recommendation was recorded in this report.",
+    maintainerComment: sectionLineValue(section, "Maintainer comment") ?? "",
   };
 }
 
@@ -6025,6 +6125,7 @@ function reportDecision(markdown: string, closeReason: CloseReason): Decision {
     securityReview: reportSecurityReview(markdown),
     realBehaviorProof: reportRealBehaviorProof(markdown),
     telegramVisibleProof: reportTelegramVisibleProof(markdown),
+    mantisRecommendation: reportMantisRecommendation(markdown),
     overallCorrectness: reportOverallCorrectness(markdown),
     overallConfidenceScore: reportOverallConfidenceScore(markdown),
     fixedRelease: fixedRelease && fixedRelease !== "unknown" ? fixedRelease : null,
@@ -6562,6 +6663,7 @@ function renderKeepOpenCommentFromReport(markdown: string): string {
   const reviewFindings = reportReviewFindings(markdown);
   const securityReview = reportSecurityReview(markdown);
   const realBehaviorProof = reportRealBehaviorProof(markdown);
+  const mantisRecommendation = reportMantisRecommendation(markdown);
   const summary = reviewSectionValue(markdown, "summary");
   const changeSummary = reviewSectionValue(markdown, "changeSummary");
   const bestSolution = reviewSectionValue(markdown, "bestSolution");
@@ -6616,6 +6718,10 @@ function renderKeepOpenCommentFromReport(markdown: string): string {
       publicRealBehaviorProofLine(realBehaviorProof),
     );
   }
+  const mantisSuggestion = isPullRequest
+    ? publicMantisRecommendationBlock(mantisRecommendation)
+    : "";
+  if (mantisSuggestion) appendPublicSection(lines, "Mantis proof suggestion", mantisSuggestion);
   appendPublicSection(lines, isPullRequest ? "Next step before merge" : "Next step", nextStepLine);
   const securityLine = publicSecurityReviewLine(securityReview);
   if (securityLine) appendPublicSection(lines, "Security", securityLine);
@@ -7367,6 +7473,18 @@ function renderTelegramVisibleProofReportSection(decision: Decision): string {
   ].join("\n");
 }
 
+function renderMantisRecommendationReportSection(decision: Decision): string {
+  return [
+    `Status: ${decision.mantisRecommendation.status}`,
+    "",
+    `Scenario: ${decision.mantisRecommendation.scenario}`,
+    "",
+    `Reason: ${sentence(decision.mantisRecommendation.reason)}`,
+    "",
+    `Maintainer comment: ${decision.mantisRecommendation.maintainerComment.trim()}`,
+  ].join("\n");
+}
+
 export function pullRequestFilePathsFromContextForTest(context: {
   pullFiles?: unknown[];
 }): string[] {
@@ -7430,6 +7548,7 @@ function markdownFor(options: {
   const securityReview = renderSecurityReviewReportSection(options.decision);
   const realBehaviorProof = renderRealBehaviorProofReportSection(options.decision);
   const telegramVisibleProof = renderTelegramVisibleProofReportSection(options.decision);
+  const mantisRecommendation = renderMantisRecommendationReportSection(options.decision);
   const workCandidateSection = renderWorkCandidateReportSection(options.decision);
   const repairWorkPromptSection = renderRepairWorkPromptReportSection(options.decision);
   const pullFiles = pullRequestFilePathsFromContext(options.context);
@@ -7508,6 +7627,8 @@ real_behavior_proof_status: ${options.decision.realBehaviorProof.status}
 real_behavior_proof_evidence_kind: ${options.decision.realBehaviorProof.evidenceKind}
 real_behavior_proof_needs_contributor_action: ${options.decision.realBehaviorProof.needsContributorAction}
 telegram_visible_proof_status: ${options.decision.telegramVisibleProof.status}
+mantis_recommendation_status: ${options.decision.mantisRecommendation.status}
+mantis_recommendation_scenario: ${options.decision.mantisRecommendation.scenario}
 ---
 
 # ${markdownLink(`#${options.item.number}: ${options.item.title}`, options.item.url)}
@@ -7581,6 +7702,10 @@ ${realBehaviorProof}
 ## ${REVIEW_SECTIONS.telegramVisibleProof}
 
 ${telegramVisibleProof}
+
+## ${REVIEW_SECTIONS.mantisRecommendation}
+
+${mantisRecommendation}
 
 ## ${REVIEW_SECTIONS.workCandidate}
 

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -4528,8 +4528,9 @@ Reason: Maintainers should review the proof before merge.
   );
 
   assert.match(comment, /\*\*Mantis proof suggestion\*\*/);
-  assert.match(comment, /```text\n@openclaw-mantis telegram desktop proof:/);
-  assert.match(comment, /@openclaw-mantis/);
+  assert.match(comment, /starts with the OpenClaw Mantis account mention/);
+  assert.match(comment, /```text\ntelegram desktop proof:/);
+  assert.doesNotMatch(comment, /@openclaw-mantis/);
 });
 
 test("pull request review comments suppress unsafe Mantis recommendations", () => {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -4470,7 +4470,7 @@ test("review prompt classifies Telegram visible proof candidates", () => {
   assert.match(prompt, /mantis: telegram-visible-proof/);
   assert.match(prompt, /mantisRecommendation/);
   assert.match(prompt, /@openclaw-mantis/);
-  assert.match(prompt, /never `@Mantis`/);
+  assert.match(prompt, /ambiguous Mantis account mention/);
 });
 
 test("pull request review comments suggest copy-paste Mantis proof comments", () => {
@@ -4529,7 +4529,7 @@ Reason: Maintainers should review the proof before merge.
 
   assert.match(comment, /\*\*Mantis proof suggestion\*\*/);
   assert.match(comment, /```text\n@openclaw-mantis telegram desktop proof:/);
-  assert.doesNotMatch(comment, /@Mantis\b/);
+  assert.match(comment, /@openclaw-mantis/);
 });
 
 test("pull request review comments suppress unsafe Mantis recommendations", () => {
@@ -4555,7 +4555,7 @@ Scenario: telegram_desktop_proof
 
 Reason: This changes visible Telegram behavior.
 
-Maintainer comment: @Mantis telegram desktop proof
+Maintainer comment: @${"mantis"} telegram desktop proof
 
 ## Work Candidate
 
@@ -4573,7 +4573,7 @@ Reason: Maintainers should review the proof before merge.
   );
 
   assert.doesNotMatch(comment, /\*\*Mantis proof suggestion\*\*/);
-  assert.doesNotMatch(comment, /@Mantis\b/);
+  assert.doesNotMatch(comment, /@openclaw-mantis/);
 });
 
 test("ClawSweeper proof judgement controls the sufficient proof label", () => {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -197,6 +197,12 @@ function closeDecision(overrides = {}) {
       status: "not_needed",
       summary: "This non-PR issue triage does not need Telegram visible proof.",
     },
+    mantisRecommendation: {
+      status: "not_recommended",
+      scenario: "none",
+      reason: "Mantis proof is not useful for this issue triage.",
+      maintainerComment: "",
+    },
     overallCorrectness: "not a patch",
     overallConfidenceScore: 0.75,
     fixedRelease: null,
@@ -4462,6 +4468,112 @@ test("review prompt classifies Telegram visible proof candidates", () => {
   assert.match(prompt, /telegram-crabbox-e2e-proof/);
   assert.match(prompt, /message formatting/);
   assert.match(prompt, /mantis: telegram-visible-proof/);
+  assert.match(prompt, /mantisRecommendation/);
+  assert.match(prompt, /@openclaw-mantis/);
+  assert.match(prompt, /never `@Mantis`/);
+});
+
+test("pull request review comments suggest copy-paste Mantis proof comments", () => {
+  const comment = renderReviewCommentFromReport(
+    `${reportFrontMatter({
+      type: "pull_request",
+      number: "83140",
+      decision: "keep_open",
+      close_reason: "none",
+      work_candidate: "none",
+      pull_head_sha: "abc123def456",
+    })}
+
+## Summary
+
+Keep this Telegram PR open for maintainer review.
+
+## What This Changes
+
+Fixes Telegram topic stop targeting.
+
+## Real Behavior Proof
+
+Status: mock_only
+
+Evidence kind: none
+
+Needs contributor action: true
+
+Summary: Current proof is test-only for visible Telegram topic behavior.
+
+## Mantis Recommendation
+
+Status: recommended
+
+Scenario: telegram_desktop_proof
+
+Reason: This changes visible Telegram topic behavior that should be proven in native Telegram Desktop.
+
+Maintainer comment: @openclaw-mantis telegram desktop proof: verify that /stop targets the active topic and does not affect other topics.
+
+## Work Candidate
+
+Candidate: none
+
+Confidence: low
+
+Priority: low
+
+Status: none
+
+Reason: Maintainers should review the proof before merge.
+	`,
+    "none",
+  );
+
+  assert.match(comment, /\*\*Mantis proof suggestion\*\*/);
+  assert.match(comment, /```text\n@openclaw-mantis telegram desktop proof:/);
+  assert.doesNotMatch(comment, /@Mantis\b/);
+});
+
+test("pull request review comments suppress unsafe Mantis recommendations", () => {
+  const comment = renderReviewCommentFromReport(
+    `${reportFrontMatter({
+      type: "pull_request",
+      number: "83140",
+      decision: "keep_open",
+      close_reason: "none",
+      work_candidate: "none",
+      pull_head_sha: "abc123def456",
+    })}
+
+## Summary
+
+Keep this Telegram PR open for maintainer review.
+
+## Mantis Recommendation
+
+Status: recommended
+
+Scenario: telegram_desktop_proof
+
+Reason: This changes visible Telegram behavior.
+
+Maintainer comment: @Mantis telegram desktop proof
+
+## Work Candidate
+
+Candidate: none
+
+Confidence: low
+
+Priority: low
+
+Status: none
+
+Reason: Maintainers should review the proof before merge.
+	`,
+    "none",
+  );
+
+  assert.doesNotMatch(comment, /\*\*Mantis proof suggestion\*\*/);
+  assert.doesNotMatch(comment, /@Mantis\b/);
 });
 
 test("ClawSweeper proof judgement controls the sufficient proof label", () => {


### PR DESCRIPTION
## Summary

- Add an intelligent `mantisRecommendation` decision field to ClawSweeper review output.
- Teach the review prompt and schema to recommend maintainer-run OpenClaw Mantis proof commands when a PR would benefit from live visual or workflow evidence.
- Render maintainer instructions without placing the workflow trigger token in ClawSweeper’s own comment, so maintainers intentionally run Mantis from a separate PR comment.

## Validation

- `pnpm run check` passed after rebasing onto current `origin/main`.