### PR TITLE
fix(repair): carry replacement automerge requester credit

### DIFF
--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -81,6 +81,10 @@ export function repoSlug(repo: string) {
     .replace(/^-+|-+$/g, "");
 }
 
+function yamlScalar(value: JsonValue): string {
+  return JSON.stringify(String(value ?? ""));
+}
+
 export function automergeClusterId(repo: string, issueNumber: JsonValue) {
   return `automerge-${repoSlug(repo)}-${Number(issueNumber)}`;
 }
@@ -183,6 +187,9 @@ export function renderAutomergeJob({
   issueNumber,
   title = null,
   repairMode: rawRepairMode = "automerge",
+  author = null,
+  authorId = null,
+  commentUrl = null,
 }: LooseRecord) {
   const clusterId = automergeClusterId(repo, issueNumber);
   const branch = automergeJobBranch(repo, issueNumber);
@@ -190,6 +197,17 @@ export function renderAutomergeJob({
   const prUrl = `https://github.com/${repo}/pull/${Number(issueNumber)}`;
   const safeTitle = String(title ?? `PR ${ref}`).trim() || `PR ${ref}`;
   const repairMode = String(rawRepairMode) === "autofix" ? "autofix" : "automerge";
+  const maintainerFrontmatter = [
+    author ? `requested_by: ${yamlScalar(author)}` : null,
+    authorId ? `requested_by_id: ${yamlScalar(authorId)}` : null,
+    commentUrl ? `request_comment_url: ${yamlScalar(commentUrl)}` : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
+  const maintainerContext = [
+    author ? `Requested by: ${author}` : null,
+    commentUrl ? `Request comment: ${commentUrl}` : null,
+  ].filter(Boolean);
   const finalMergeLine =
     repairMode === "autofix"
       ? "Final merge is disabled for autofix. Keep the PR open after a passing ClawSweeper verdict unless a maintainer explicitly changes mode."
@@ -226,11 +244,12 @@ security_policy: central_security_only
 security_sensitive: false
 target_branch: ${branch}
 source: ${AUTOMERGE_JOB_SOURCE}
----
+${maintainerFrontmatter ? `${maintainerFrontmatter}\n` : ""}---
 
 # ClawSweeper adopted PR repair candidate
 
 Maintainer opted ${ref} into ClawSweeper ${repairMode}.
+${maintainerContext.length > 0 ? `\n${maintainerContext.join("\n")}\n` : ""}
 
 Source PR: ${prUrl}
 Title: ${safeTitle}
@@ -704,7 +723,9 @@ function automergeCreditTrailers({ command, commits }: LooseRecord): string[] {
     trailers.push(trailer);
   }
 
-  const maintainer = maintainerCredit(command.maintainer_attribution ?? command);
+  const maintainer = maintainerCredit(
+    command.maintainer_attribution ?? automergeRequestedByFromBody(command.target?.body) ?? command,
+  );
   if (!maintainer) return trailers;
   trailers.push(`Approved-by: ${maintainer.login}`);
   if (!coAuthorKeys.has(maintainer.coAuthorKey)) {
@@ -743,6 +764,21 @@ function maintainerCredit(value: LooseRecord): LooseRecord | null {
     name,
     email,
     coAuthorKey: coAuthorKey(name, email),
+  };
+}
+
+export function automergeRequestedByFromBody(body: JsonValue): LooseRecord | null {
+  const marker = String(body ?? "").match(
+    /<!--\s*clawsweeper-automerge-requested-by\s+([^>]*)-->/i,
+  );
+  if (!marker) return null;
+  const attrs = markerAttributes(marker[1] ?? "");
+  const author = attrs.login ?? attrs.author ?? attrs.requested_by;
+  if (!author) return null;
+  return {
+    author,
+    author_id: attrs.id ?? attrs.author_id ?? null,
+    author_name: attrs.name ?? attrs.author_name ?? null,
   };
 }
 

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -1545,6 +1545,9 @@ function ensureAutomergeJob(command: LooseRecord) {
         issueNumber: command.issue_number,
         title: command.target.title,
         repairMode: repairJobModeForCommand(command),
+        author: command.author,
+        authorId: command.author_id,
+        commentUrl: command.comment_url,
       }),
     );
     statusDetail = "written";
@@ -2242,6 +2245,7 @@ function classifyPullTarget(pull: LooseRecord, issueNumber: JsonValue): JsonValu
   return {
     kind: "pull_request",
     title: pull.title ?? null,
+    body: pull.body ?? null,
     branch,
     head_sha: pull.headRefOid ?? null,
     author,

--- a/src/repair/execute-fix-artifact.ts
+++ b/src/repair/execute-fix-artifact.ts
@@ -1017,6 +1017,7 @@ function openReplacementPrFromPreparedRepairCheckout({
     clusterId: result.cluster_id,
     provenance,
     contributorCredits,
+    maintainerAttribution: jobMaintainerAttribution(),
   });
   const bodyPath = path.join(workRoot, "replacement-pr-body.md");
   fs.writeFileSync(bodyPath, body);
@@ -1347,6 +1348,7 @@ function executeReplacementBranch({
     clusterId: result.cluster_id,
     provenance,
     contributorCredits,
+    maintainerAttribution: jobMaintainerAttribution(),
   });
   if (dryRun) {
     return {
@@ -2975,6 +2977,16 @@ function githubRepoCloneUrl(repo: string) {
 function setupGitIdentity(cwd: JsonValue) {
   run("git", ["config", "user.name", clawsweeperGitUserName()], { cwd });
   run("git", ["config", "user.email", clawsweeperGitUserEmail()], { cwd });
+}
+
+function jobMaintainerAttribution() {
+  const author = String(job.frontmatter.requested_by ?? "").trim();
+  if (!author) return null;
+  return {
+    author,
+    author_id: job.frontmatter.requested_by_id ?? null,
+    comment_url: job.frontmatter.request_comment_url ?? null,
+  };
 }
 
 function firstSourcePullRequest(fixArtifact: LooseRecord) {

--- a/src/repair/external-messages.ts
+++ b/src/repair/external-messages.ts
@@ -395,6 +395,7 @@ export function replacementPrBody({
   clusterId,
   provenance,
   contributorCredits,
+  maintainerAttribution = null,
 }: LooseRecord) {
   const lines = [
     fixArtifact.pr_body.trim(),
@@ -406,11 +407,37 @@ export function replacementPrBody({
     `- Validation: ${listOrNone(fixArtifact.validation_commands)}`,
     "- Replacement reason: ClawSweeper could not update the source PR branch directly, so it opened a writable replacement PR instead.",
   ];
+  const maintainer = automergeMaintainerAttribution(maintainerAttribution);
+  if (maintainer) {
+    lines.push(`- Automerge requested by: @${maintainer.login}`);
+    lines.push(
+      `<!-- clawsweeper-automerge-requested-by login="${escapeHtmlAttribute(
+        maintainer.login,
+      )}" id="${escapeHtmlAttribute(maintainer.id)}" -->`,
+    );
+  }
   if (fallbackReason) lines.push(`- Repair fallback: ${fallbackReason}`);
   const creditLines = contributorCreditLines(contributorCredits);
   if (creditLines.length > 0) lines.push("", ...creditLines);
   lines.push("", fishNotes(provenance));
   return `${lines.join("\n")}\n`;
+}
+
+function automergeMaintainerAttribution(value: LooseRecord): LooseRecord | null {
+  const login = String(value?.author ?? value?.login ?? value?.requested_by ?? "").trim();
+  if (!login || login.includes("[bot]")) return null;
+  return {
+    login,
+    id: String(value?.author_id ?? value?.id ?? value?.requested_by_id ?? "").trim(),
+  };
+}
+
+function escapeHtmlAttribute(value: JsonValue) {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }
 
 export function defaultCloseComment({

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -12,6 +12,7 @@ import {
   automergeChangelogBlockReason,
   automergeFailedChecksRepairReason,
   automergeClusterId,
+  automergeRequestedByFromBody,
   automergeGateBlockReason,
   automergeJobBranch,
   automergeJobPath,
@@ -503,6 +504,9 @@ test("renderAutomergeJob validates and keeps merge owned by router", () => {
     repo: "openclaw/openclaw",
     issueNumber: 74112,
     title: "Tighten cross-session message handling",
+    author: "maintainer-user",
+    authorId: 123456,
+    commentUrl: "https://github.com/openclaw/openclaw/pull/74112#issuecomment-1",
   });
   const match = raw.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
   assert.ok(match);
@@ -514,6 +518,12 @@ test("renderAutomergeJob validates and keeps merge owned by router", () => {
   assert.deepEqual(validateJob(job), []);
   assert.equal(job.frontmatter.job_intent, "automerge_pr");
   assert.equal(job.frontmatter.source, "pr_automerge");
+  assert.equal(job.frontmatter.requested_by, "maintainer-user");
+  assert.equal(job.frontmatter.requested_by_id, "123456");
+  assert.equal(
+    job.frontmatter.request_comment_url,
+    "https://github.com/openclaw/openclaw/pull/74112#issuecomment-1",
+  );
   assert.equal(job.frontmatter.allow_fix_pr, true);
   assert.equal(job.frontmatter.allow_merge, false);
   assert.deepEqual(job.frontmatter.blocked_actions, ["close", "merge"]);
@@ -525,6 +535,7 @@ test("renderAutomergeJob validates and keeps merge owned by router", () => {
   assert.match(job.body, /add a changelog entry when required/);
   assert.match(job.body, /Never add forbidden changelog credit lines/);
   assert.match(job.body, /router owns final merge/);
+  assert.match(job.body, /Requested by: maintainer-user/);
 });
 
 test("renderIssueImplementationJob validates and opens one non-closing fix PR lane", () => {
@@ -1786,6 +1797,38 @@ test("automerge squash message dedupes maintainer co-author trailer", () => {
     1,
   );
   assert.match(message.body, /^Approved-by: maintainer-user$/m);
+});
+
+test("automerge squash message credits maintainer metadata carried by replacement PR body", () => {
+  const body = [
+    "Replacement PR body",
+    '<!-- clawsweeper-automerge-requested-by login="maintainer-user" id="123456" -->',
+  ].join("\n");
+  assert.deepEqual(automergeRequestedByFromBody(body), {
+    author: "maintainer-user",
+    author_id: "123456",
+    author_name: null,
+  });
+
+  const message = buildAutomergeSquashMessage({
+    command: {
+      issue_number: 124,
+      expected_head_sha: "def456",
+      target: { title: "fix: replacement", body },
+    },
+    target: { head_sha: "def456", title: "fix: replacement", body },
+    view: {
+      title: "fix: replacement",
+      commits: [],
+    },
+    comments: [],
+  });
+
+  assert.match(message.body, /^Approved-by: maintainer-user$/m);
+  assert.match(
+    message.body,
+    /^Co-authored-by: maintainer-user <123456\+maintainer-user@users\.noreply\.github\.com>$/m,
+  );
 });
 
 test("automerge gate block only reports the global merge policy gate", () => {

--- a/test/repair/external-messages.test.ts
+++ b/test/repair/external-messages.test.ts
@@ -108,6 +108,10 @@ test("replacement PR body records replacement reason and co-author credit", () =
         co_authored_by: "Co-authored-by: Mona Octocat <1+octocat@users.noreply.github.com>",
       },
     ],
+    maintainerAttribution: {
+      author: "maintainer-user",
+      author_id: 123456,
+    },
     provenance: { model: "gpt-test", reasoning: "medium", reviewedSha: "abcdef1234567890" },
   });
 
@@ -116,6 +120,11 @@ test("replacement PR body records replacement reason and co-author credit", () =
   assert.match(
     body,
     /@octocat: Co-authored-by: Mona Octocat <1\+octocat@users\.noreply\.github\.com>/,
+  );
+  assert.match(body, /Automerge requested by: @maintainer-user/);
+  assert.match(
+    body,
+    /<!-- clawsweeper-automerge-requested-by login="maintainer-user" id="123456" -->/,
   );
 });
 


### PR DESCRIPTION
## Summary
- carry the source automerge requester into adopted automerge job frontmatter
- include replacement PR metadata that records the requester for later label-sweep merges
- teach automerge squash messages to credit requester metadata carried by replacement PR bodies

## Root Cause
A maintainer automerge request can happen on a source PR, but ClawSweeper may open a replacement PR when it cannot push to the source branch. The replacement PR can later be merged by the label-sweep automerge path, which only sees bot-originated replacement state unless the original requester metadata is explicitly carried forward. That is why openclaw/openclaw#83191 credited the contributor and ClawSweeper bot but not the maintainer who initiated automerge on the source PR.

## Validation
- pnpm run build:repair && pnpm exec node --test test/repair/comment-router-core.test.ts test/repair/external-messages.test.ts test/repair/comment-router-utils.test.ts
- pnpm run check