### PR TITLE
fix(repair): honor waiting automerge resume intent

### DIFF
--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -553,6 +553,20 @@ export function maintainerAutomergeOptInApprovesNeedsHuman({
   return Number.isFinite(verdictTime) && Number.isFinite(resumeTime) && resumeTime > 0;
 }
 
+export function latestRepairLoopResumeTime(entries: JsonValue, command: LooseRecord) {
+  if (!Array.isArray(entries)) return 0;
+  let latest = 0;
+  for (const entry of entries) {
+    if (!entry || typeof entry !== "object") continue;
+    if (entry.repo !== command.repo) continue;
+    if (Number(entry.issue_number) !== Number(command.issue_number)) continue;
+    if (!["autofix", "automerge"].includes(String(entry.intent ?? ""))) continue;
+    if (!["executed", "waiting"].includes(String(entry.status ?? ""))) continue;
+    latest = Math.max(latest, Date.parse(String(entry.comment_updated_at ?? "")) || 0);
+  }
+  return latest;
+}
+
 export function commandHasAction(command: LooseRecord, actionName: string): boolean {
   return (command.actions ?? []).some((action: JsonValue) => action.action === actionName);
 }

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -48,6 +48,7 @@ import {
   issueImplementationClusterId,
   issueImplementationJobPath,
   maintainerAutomergeOptInApprovesNeedsHuman as maintainerAutomergeOptInApprovesNeedsHumanReason,
+  latestRepairLoopResumeTime,
   parseCommand,
   pausedModeStatusBlocksReplay,
   parseTrustedAutomation,
@@ -1017,18 +1018,7 @@ function autoRepairAlreadyPlanned(command: LooseRecord) {
 }
 
 function latestAutomergeResumeAt(command: LooseRecord) {
-  let latest = 0;
-  for (const entry of ledger.commands ?? []) {
-    if (
-      entry.repo === command.repo &&
-      Number(entry.issue_number) === Number(command.issue_number) &&
-      ["autofix", "automerge"].includes(entry.intent) &&
-      entry.status === "executed"
-    ) {
-      latest = Math.max(latest, Date.parse(entry.comment_updated_at ?? "") || 0);
-    }
-  }
-  return latest;
+  return latestRepairLoopResumeTime(ledger.commands ?? [], command);
 }
 
 function latestAutomergeMaintainerAttribution(command: LooseRecord) {

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -35,6 +35,7 @@ import {
   issueImplementationJobPath,
   isAuthorReadOnlyCommandAllowed,
   isCanonicalLandingNeedsHumanText,
+  latestRepairLoopResumeTime,
   isMaintainerCommandAllowed,
   maintainerAutomergeOptInApprovesNeedsHuman,
   parseCommand,
@@ -898,6 +899,49 @@ test("canonical landing needs-human text can be approved by active automerge opt
       optInTime: 0,
     }),
     false,
+  );
+});
+
+test("canonical landing needs-human accepts waiting automerge opt-in as active resume intent", () => {
+  const optInTime = latestRepairLoopResumeTime(
+    [
+      {
+        repo: "openclaw/openclaw",
+        issue_number: 83186,
+        intent: "automerge",
+        status: "waiting",
+        comment_updated_at: "2026-05-17T17:09:01Z",
+      },
+      {
+        repo: "openclaw/openclaw",
+        issue_number: 83186,
+        intent: "automerge",
+        status: "blocked",
+        comment_updated_at: "2026-05-17T17:10:01Z",
+      },
+      {
+        repo: "openclaw/openclaw",
+        issue_number: 83186,
+        intent: "status",
+        status: "executed",
+        comment_updated_at: "2026-05-17T17:11:01Z",
+      },
+    ],
+    {
+      repo: "openclaw/openclaw",
+      issue_number: 83186,
+    },
+  );
+
+  assert.equal(optInTime, Date.parse("2026-05-17T17:09:01Z"));
+  assert.equal(
+    maintainerAutomergeOptInApprovesNeedsHuman({
+      reason:
+        "No repair lane is needed; the open PR already contains the focused implementation and this review found no actionable blocker for automation to fix.",
+      commentCreatedAt: "2026-05-17T16:54:05Z",
+      optInTime,
+    }),
+    true,
   );
 });
 


### PR DESCRIPTION
## Summary
- count waiting automerge/autofix ledger entries as active repair-loop resume intent
- route canonical needs-human reviews back to the merge path when a maintainer automerge command is in flight
- add regression coverage for the openclaw/openclaw#83186-shaped waiting automerge case

## Validation
- pnpm run build
- pnpm run build:repair
- node --test test/repair/comment-router-core.test.ts
- node --test dist/repair/comment-router-core.test.js
- git diff --check