### PR TITLE
fix(repair): credit clawsweeper on automerge commits

### DIFF
--- a/src/repair/co-author-credit.ts
+++ b/src/repair/co-author-credit.ts
@@ -1,0 +1,14 @@
+export const CLAWSWEEPER_CO_AUTHOR = {
+  name: "clawsweeper[bot]",
+  email: "274271284+clawsweeper[bot]@users.noreply.github.com",
+} as const;
+
+export const CLAWSWEEPER_CO_AUTHOR_TRAILER = `Co-authored-by: ${CLAWSWEEPER_CO_AUTHOR.name} <${CLAWSWEEPER_CO_AUTHOR.email}>`;
+
+export function coAuthorKey(name: string, email: string) {
+  return `${name.trim().toLowerCase()} <${email.trim().toLowerCase()}>`;
+}
+
+export function clawsweeperCoAuthorKey() {
+  return coAuthorKey(CLAWSWEEPER_CO_AUTHOR.name, CLAWSWEEPER_CO_AUTHOR.email);
+}

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -1,4 +1,9 @@
 import type { JsonValue, LooseRecord } from "./json-types.js";
+import {
+  CLAWSWEEPER_CO_AUTHOR_TRAILER,
+  clawsweeperCoAuthorKey,
+  coAuthorKey,
+} from "./co-author-credit.js";
 import { renderJobIntentFrontmatter } from "./job-intent.js";
 import { compactText } from "./text-utils.js";
 export const REPAIR_INTENTS = new Set([
@@ -736,6 +741,10 @@ function automergeCreditTrailers({ command, commits }: LooseRecord): string[] {
   for (const trailer of coAuthorTrailersFromCommits(commits, coAuthorKeys)) {
     trailers.push(trailer);
   }
+  if (!coAuthorKeys.has(clawsweeperCoAuthorKey())) {
+    coAuthorKeys.add(clawsweeperCoAuthorKey());
+    trailers.push(CLAWSWEEPER_CO_AUTHOR_TRAILER);
+  }
 
   const maintainer = maintainerCredit(
     command.maintainer_attribution ?? automergeRequestedByFromBody(command.target?.body) ?? command,
@@ -794,10 +803,6 @@ export function automergeRequestedByFromBody(body: JsonValue): LooseRecord | nul
     author_id: attrs.id ?? attrs.author_id ?? null,
     author_name: attrs.name ?? attrs.author_name ?? null,
   };
-}
-
-function coAuthorKey(name: string, email: string) {
-  return `${name.trim().toLowerCase()} <${email.trim().toLowerCase()}>`;
 }
 
 function commitHeadline(commit: JsonValue): string {

--- a/src/repair/execute-fix-github.ts
+++ b/src/repair/execute-fix-github.ts
@@ -1,4 +1,9 @@
 import type { JsonValue, LooseRecord } from "./json-types.js";
+import {
+  CLAWSWEEPER_CO_AUTHOR,
+  CLAWSWEEPER_CO_AUTHOR_TRAILER,
+  coAuthorKey,
+} from "./co-author-credit.js";
 import { runCommand as run } from "./command-runner.js";
 import { parsePullRequestUrl } from "./github-ref.js";
 import { repoRoot } from "./lib.js";
@@ -81,9 +86,22 @@ export function sourceContributorCredits({
 }
 
 export function coAuthorTrailers(contributorCredits: LooseRecord[]): string[] {
-  return contributorCredits.map(
-    (credit: JsonValue) => `Co-authored-by: ${credit.name} <${credit.email}>`,
-  );
+  const seen = new Set<string>();
+  const trailers: string[] = [];
+  for (const credit of contributorCredits) {
+    const name = String(credit.name ?? "").trim();
+    const email = String(credit.email ?? "").trim();
+    if (!name || !email) continue;
+    const key = coAuthorKey(name, email);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    trailers.push(`Co-authored-by: ${name} <${email}>`);
+  }
+  const clawsweeperKey = coAuthorKey(CLAWSWEEPER_CO_AUTHOR.name, CLAWSWEEPER_CO_AUTHOR.email);
+  if (!seen.has(clawsweeperKey)) {
+    trailers.push(CLAWSWEEPER_CO_AUTHOR_TRAILER);
+  }
+  return trailers;
 }
 
 export function publicContributorCredit(credit: JsonValue): LooseRecord {

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -52,6 +52,7 @@ import {
   staleAutomergeActivationReason,
   usesSharedAutomergeStatus,
 } from "../../dist/repair/comment-router-core.js";
+import { CLAWSWEEPER_CO_AUTHOR_TRAILER } from "../../dist/repair/co-author-credit.js";
 import { parseSimpleYaml, validateJob } from "../../dist/repair/lib.js";
 
 test("parseCommand recognizes maintainer slash commands", () => {
@@ -1799,6 +1800,10 @@ test("automerge squash message credits the initiating maintainer with approval a
     message.body,
     /^Co-authored-by: Contributor <111\+contributor@users\.noreply\.github\.com>$/m,
   );
+  assert.match(
+    message.body,
+    /^Co-authored-by: clawsweeper\[bot\] <274271284\+clawsweeper\[bot\]@users\.noreply\.github\.com>$/m,
+  );
   assert.match(message.body, /^Approved-by: maintainer-user$/m);
   assert.match(
     message.body,
@@ -1843,6 +1848,41 @@ test("automerge squash message dedupes maintainer co-author trailer", () => {
   assert.match(message.body, /^Approved-by: maintainer-user$/m);
 });
 
+test("automerge squash message dedupes ClawSweeper co-author trailer", () => {
+  const message = buildAutomergeSquashMessage({
+    command: {
+      issue_number: 123,
+      expected_head_sha: "abc123",
+      target: { title: "fix: test" },
+      maintainer_attribution: {
+        author: "maintainer-user",
+        author_id: 123456,
+      },
+    },
+    target: { head_sha: "abc123", title: "fix: test" },
+    view: {
+      title: "fix: test",
+      commits: [
+        {
+          authors: [
+            {
+              name: "clawsweeper[bot]",
+              email: "274271284+clawsweeper[bot]@users.noreply.github.com",
+            },
+          ],
+        },
+      ],
+    },
+    comments: [],
+  });
+
+  assert.equal(
+    message.body.split("\n").filter((line) => line === CLAWSWEEPER_CO_AUTHOR_TRAILER).length,
+    1,
+  );
+  assert.match(message.body, /^Approved-by: maintainer-user$/m);
+});
+
 test("automerge squash message credits maintainer metadata carried by replacement PR body", () => {
   const body = [
     "Replacement PR body",
@@ -1869,6 +1909,10 @@ test("automerge squash message credits maintainer metadata carried by replacemen
   });
 
   assert.match(message.body, /^Approved-by: maintainer-user$/m);
+  assert.match(
+    message.body,
+    /^Co-authored-by: clawsweeper\[bot\] <274271284\+clawsweeper\[bot\]@users\.noreply\.github\.com>$/m,
+  );
   assert.match(
     message.body,
     /^Co-authored-by: maintainer-user <123456\+maintainer-user@users\.noreply\.github\.com>$/m,

--- a/test/repair/execute-fix-github.test.ts
+++ b/test/repair/execute-fix-github.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { CLAWSWEEPER_CO_AUTHOR_TRAILER } from "../../dist/repair/co-author-credit.js";
+import { coAuthorTrailers } from "../../dist/repair/execute-fix-github.js";
+
+test("replacement co-author trailers include contributor and ClawSweeper credit", () => {
+  assert.deepEqual(
+    coAuthorTrailers([
+      {
+        name: "Mona Octocat",
+        email: "1+octocat@users.noreply.github.com",
+      },
+    ]),
+    [
+      "Co-authored-by: Mona Octocat <1+octocat@users.noreply.github.com>",
+      CLAWSWEEPER_CO_AUTHOR_TRAILER,
+    ],
+  );
+});
+
+test("replacement co-author trailers dedupe ClawSweeper credit", () => {
+  assert.deepEqual(
+    coAuthorTrailers([
+      {
+        name: "clawsweeper[bot]",
+        email: "274271284+clawsweeper[bot]@users.noreply.github.com",
+      },
+    ]),
+    [CLAWSWEEPER_CO_AUTHOR_TRAILER],
+  );
+});


### PR DESCRIPTION
Summary
- Add a shared ClawSweeper co-author identity for repair commit trailers.
- Include ClawSweeper as a co-author in regular automerge squash messages.
- Include the same ClawSweeper co-author trailer in replacement PR checkpoint commits, with dedupe.

Verification
- pnpm run build:repair
- node --test test/repair/comment-router-core.test.ts test/repair/execute-fix-github.test.ts
- pnpm run format:check
- pnpm run check
