### PR TITLE
fix(repair): approve replacement automerge markers

### DIFF
--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -550,8 +550,12 @@ export function maintainerAutomergeOptInApprovesNeedsHuman({
   commentCreatedAt,
   commentUpdatedAt,
   optInTime,
+  replacementAutomergeRequestedBy,
 }: LooseRecord) {
   if (!isCanonicalLandingNeedsHumanText(reason)) return false;
+  if (replacementAutomergeRequestedBy && maintainerCredit(replacementAutomergeRequestedBy)) {
+    return true;
+  }
   const verdictTime = Date.parse(String(commentCreatedAt ?? commentUpdatedAt ?? ""));
   const resumeTime =
     typeof optInTime === "number" ? optInTime : Date.parse(String(optInTime ?? ""));

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -29,6 +29,7 @@ import {
   automergeClusterId,
   automergeJobPath,
   automergeMergeFailureRepairReason,
+  automergeRequestedByFromBody,
   automergeReadinessRepairReason,
   automergeRebaseRepairReason,
   automergeTransientWaitConfig,
@@ -963,6 +964,7 @@ function maintainerAutomergeOptInApprovesNeedsHuman(command: LooseRecord) {
     commentCreatedAt: command.comment_created_at,
     commentUpdatedAt: command.comment_updated_at,
     optInTime: latestAutomergeResumeAt(command),
+    replacementAutomergeRequestedBy: automergeRequestedByFromBody(command.target?.body),
   });
 }
 

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -946,6 +946,48 @@ test("canonical landing needs-human accepts waiting automerge opt-in as active r
   );
 });
 
+test("canonical landing needs-human accepts replacement PR automerge requester marker", () => {
+  const replacementBody = [
+    "Makes https://github.com/openclaw/openclaw/pull/83186 merge-ready for the ClawSweeper automerge loop.",
+    "",
+    "ClawSweeper replacement notes:",
+    '- Automerge requested by: @Takhoffman',
+    '<!-- clawsweeper-automerge-requested-by login="Takhoffman" id="781889" -->',
+  ].join("\n");
+
+  assert.deepEqual(automergeRequestedByFromBody(replacementBody), {
+    author: "Takhoffman",
+    author_id: "781889",
+    author_name: null,
+  });
+  assert.equal(
+    maintainerAutomergeOptInApprovesNeedsHuman({
+      reason:
+        "No repair lane is needed; this automerge-opted replacement PR should proceed through exact-head checks and normal merge gates.",
+      commentCreatedAt: "2026-05-17T18:03:35Z",
+      optInTime: 0,
+      replacementAutomergeRequestedBy: automergeRequestedByFromBody(replacementBody),
+    }),
+    true,
+  );
+});
+
+test("canonical landing needs-human ignores bot replacement PR automerge requester markers", () => {
+  assert.equal(
+    maintainerAutomergeOptInApprovesNeedsHuman({
+      reason:
+        "No repair lane is needed; this automerge-opted replacement PR should proceed through exact-head checks and normal merge gates.",
+      commentCreatedAt: "2026-05-17T18:03:35Z",
+      optInTime: 0,
+      replacementAutomergeRequestedBy: {
+        author: "clawsweeper[bot]",
+        author_id: "274271284",
+      },
+    }),
+    false,
+  );
+});
+
 test("parseTrustedAutomation explains security-sensitive human-review pauses", () => {
   const trustedAuthors = new Set(["clawsweeper[bot]"]);
   const parsed = parseTrustedAutomation(

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -951,7 +951,7 @@ test("canonical landing needs-human accepts replacement PR automerge requester m
     "Makes https://github.com/openclaw/openclaw/pull/83186 merge-ready for the ClawSweeper automerge loop.",
     "",
     "ClawSweeper replacement notes:",
-    '- Automerge requested by: @Takhoffman',
+    "- Automerge requested by: @Takhoffman",
     '<!-- clawsweeper-automerge-requested-by login="Takhoffman" id="781889" -->',
   ].join("\n");
 


### PR DESCRIPTION
## Summary
- treat a valid non-bot clawsweeper-automerge-requested-by marker on replacement PRs as active maintainer approval for canonical needs-human landing reviews
- preserve the existing canonical landing-text gate before allowing that approval path
- add regression coverage for the openclaw/openclaw#83214 replacement PR shape and a bot-requester negative case

## Root cause
Replacement PRs carried maintainer automerge approval as body attribution, but the canonical needs-human approval path only looked for same-PR automerge ledger resume intent. That caused replacement PRs such as openclaw/openclaw#83214 to pause on clawsweeper:human-review even when checks and proof were green.

## Validation
- pnpm run build:repair
- node --test test/repair/comment-router-core.test.ts
- node --test dist/repair/comment-router-core.test.js
- git diff --check