### PR TITLE
fix(repair): continue noop automerge repairs

### DIFF
--- a/src/repair/execute-fix-artifact.ts
+++ b/src/repair/execute-fix-artifact.ts
@@ -391,6 +391,7 @@ updateAutomergeProgressStatus({
 if (plannedFixActions.length === 0) {
   report.status = "skipped";
   report.reason = "no planned fix actions";
+  appendAutomergeRepairOutcomeComment(report, resultPath);
   writeReport(report, resultPath);
   process.exit(0);
 }

--- a/test/repair/execute-fix-artifact-source.test.ts
+++ b/test/repair/execute-fix-artifact-source.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+test("no-op automerge repair updates outcome and re-enters router before exit", () => {
+  const sourcePath = path.join(process.cwd(), "src/repair/execute-fix-artifact.ts");
+  const source = fs.readFileSync(sourcePath, "utf8");
+  const noPlannedBranch = source.match(
+    /if \(plannedFixActions\.length === 0\) \{(?<body>[\s\S]*?)\n\}/,
+  )?.groups?.body;
+
+  assert.ok(noPlannedBranch, "expected no planned fix actions branch");
+  assert.match(noPlannedBranch, /report\.reason = "no planned fix actions";/);
+
+  const continuationIndex = noPlannedBranch.indexOf(
+    "appendAutomergeRepairOutcomeComment(report, resultPath);",
+  );
+  const writeReportIndex = noPlannedBranch.indexOf("writeReport(report, resultPath);");
+  const exitIndex = noPlannedBranch.indexOf("process.exit(0);");
+
+  assert.notEqual(continuationIndex, -1);
+  assert.notEqual(writeReportIndex, -1);
+  assert.notEqual(exitIndex, -1);
+  assert.ok(
+    continuationIndex < writeReportIndex && writeReportIndex < exitIndex,
+    "no-op repair must update automerge continuation before writing the terminal report and exiting",
+  );
+});


### PR DESCRIPTION
## Summary
- continue automerge repair outcome handling before no-op fix execution exits
- cover the no-planned-fix branch with a regression test so ready canonical PRs re-enter the router-owned merge path

## Validation
- node --test test/repair/execute-fix-artifact-source.test.ts
- pnpm run build:repair
- pnpm run test:repair
- pnpm run check