### PR TITLE
fix(repair): preflight unwritable automerge branches

### DIFF
--- a/src/repair/execute-fix-artifact.ts
+++ b/src/repair/execute-fix-artifact.ts
@@ -70,6 +70,7 @@ import { compactText, escapeRegExp } from "./text-utils.js";
 import {
   shouldCloseSupersededSourcePrs,
   shouldSeedReplacementBranchFromSource,
+  sourceBranchWriteBlockReason,
 } from "./execute-fix-policy.js";
 import { replacementLabelsToCopy } from "./replacement-labels.js";
 import {
@@ -426,7 +427,7 @@ if (NON_EXECUTABLE_REPAIR_STRATEGIES.has(repairStrategy)) {
   process.exit(0);
 }
 
-const fixArtifact = validateFixArtifact(executableFixArtifact);
+let fixArtifact = validateFixArtifact(executableFixArtifact);
 const securityBlock = validateFixSecurityScope({ job, resultPath, fixArtifact, plannedFixActions });
 if (securityBlock) {
   report.status = "skipped";
@@ -460,6 +461,29 @@ if (scopeBlock) {
   });
   writeReport(report, resultPath);
   process.exit(0);
+}
+
+const sourceBranchPreflight = preflightRepairSourceBranchWrite(fixArtifact);
+if (sourceBranchPreflight.status === "replace_uneditable_branch") {
+  report.source_branch_preflight = sourceBranchPreflight;
+  report.actions.push({
+    action: "repair_contributor_branch",
+    status: "blocked",
+    target: sourceBranchPreflight.source_pr,
+    repair_strategy: "repair_contributor_branch",
+    reason: sourceBranchPreflight.reason,
+    fallback: "open_fix_pr",
+  });
+  fixArtifact = {
+    ...fixArtifact,
+    repair_strategy: "replace_uneditable_branch",
+    branch_update_blockers: uniqueStrings([
+      ...(fixArtifact.branch_update_blockers ?? []),
+      sourceBranchPreflight.reason,
+    ]),
+  };
+} else if (sourceBranchPreflight.status !== "not_applicable") {
+  report.source_branch_preflight = sourceBranchPreflight;
 }
 
 workRoot =
@@ -711,6 +735,52 @@ function shouldPromoteNeedsHumanReplacement(fixArtifact: LooseRecord, workerResu
   return hasReplacementDecision && hasUneditableOrUnsafeSource && hasBlockedFixAction;
 }
 
+function preflightRepairSourceBranchWrite(fixArtifact: LooseRecord) {
+  if (fixArtifact.repair_strategy !== "repair_contributor_branch") {
+    return { status: "not_applicable" };
+  }
+  const sourcePr = firstSourcePullRequest(fixArtifact);
+  const pull = fetchPullRequest(result.repo, sourcePr.number);
+  if (pull.state !== "open") {
+    return {
+      status: "blocked",
+      source_pr: sourcePr.url,
+      reason: `source PR #${sourcePr.number} is ${pull.state}`,
+    };
+  }
+  const pauseBlock = liveRepairPauseBlock({
+    pull,
+    number: sourcePr.number,
+    target: sourcePr.url,
+  });
+  if (pauseBlock) {
+    return {
+      status: "blocked",
+      source_pr: sourcePr.url,
+      reason: pauseBlock.reason,
+    };
+  }
+  const branchBlock = sourceBranchWriteBlockReason(result.repo, pull);
+  if (!branchBlock) {
+    return {
+      status: "writable",
+      source_pr: sourcePr.url,
+      head_repo: pull.head.repo.full_name,
+      head_ref: pull.head.ref,
+      same_repo_branch: pull.head.repo.full_name === result.repo,
+      maintainer_can_modify: pull.maintainer_can_modify === true,
+    };
+  }
+  return {
+    status: "replace_uneditable_branch",
+    source_pr: sourcePr.url,
+    head_repo: pull.head?.repo?.full_name ?? null,
+    head_ref: pull.head?.ref ?? null,
+    maintainer_can_modify: pull.maintainer_can_modify === true,
+    reason: `source PR #${sourcePr.number} ${branchBlock}`,
+  };
+}
+
 function executeRepairBranch({ fixArtifact, targetDir }: LooseRecord) {
   const baseBranch = String(process.env.CLAWSWEEPER_FIX_BASE_BRANCH ?? DEFAULT_BASE_BRANCH);
   const sourcePr = firstSourcePullRequest(fixArtifact);
@@ -726,9 +796,8 @@ function executeRepairBranch({ fixArtifact, targetDir }: LooseRecord) {
   if (!pull.head?.repo?.full_name || !pull.head?.ref)
     throw new Error(`source PR #${sourcePr.number} is missing head repo/ref`);
   const sameRepoBranch = pull.head.repo.full_name === result.repo;
-  if (pull.maintainer_can_modify !== true && !sameRepoBranch) {
-    throw new Error(`source PR #${sourcePr.number} has maintainer_can_modify=false`);
-  }
+  const branchBlock = sourceBranchWriteBlockReason(result.repo, pull);
+  if (branchBlock) throw new Error(`source PR #${sourcePr.number} ${branchBlock}`);
 
   const branch = safeBranchName(
     `clawsweeper-repair/repair-${result.cluster_id}-${sourcePr.number}`,

--- a/src/repair/execute-fix-policy.ts
+++ b/src/repair/execute-fix-policy.ts
@@ -8,6 +8,15 @@ export function shouldSeedReplacementBranchFromSource(fixArtifact: JsonValue) {
   return String(fixArtifact?.repair_strategy ?? "") === "replace_uneditable_branch";
 }
 
+export function sourceBranchWriteBlockReason(repo: string, pullRequest: JsonValue) {
+  const headRepo = String(pullRequest?.head?.repo?.full_name ?? "");
+  const headRef = String(pullRequest?.head?.ref ?? "");
+  if (!headRepo || !headRef) return "source PR is missing head repo/ref";
+  if (headRepo === repo) return null;
+  if (pullRequest?.maintainer_can_modify === true) return null;
+  return "source PR branch is a fork with maintainer_can_modify=false";
+}
+
 function parseBooleanEnv(value: JsonValue, fallback: boolean) {
   if (value == null || value === "") return fallback;
   if (/^(1|true|yes|on)$/i.test(String(value))) return true;

--- a/test/repair/execute-fix-artifact-source.test.ts
+++ b/test/repair/execute-fix-artifact-source.test.ts
@@ -27,3 +27,26 @@ test("no-op automerge repair updates outcome and re-enters router before exit", 
     "no-op repair must update automerge continuation before writing the terminal report and exiting",
   );
 });
+
+test("repair source branch writability preflight runs before expensive repair preflights", () => {
+  const sourcePath = path.join(process.cwd(), "src/repair/execute-fix-artifact.ts");
+  const source = fs.readFileSync(sourcePath, "utf8");
+
+  const branchPreflightIndex = source.indexOf(
+    "const sourceBranchPreflight = preflightRepairSourceBranchWrite(fixArtifact);",
+  );
+  const checkoutIndex = source.indexOf("ensureTargetCheckout(result.repo, targetDir);");
+  const validationIndex = source.indexOf("preflightTargetValidationPlan(");
+  const codexPreflightIndex = source.indexOf("const writePreflight = runCodexWritePreflight();");
+
+  assert.notEqual(branchPreflightIndex, -1);
+  assert.notEqual(checkoutIndex, -1);
+  assert.notEqual(validationIndex, -1);
+  assert.notEqual(codexPreflightIndex, -1);
+  assert.ok(
+    branchPreflightIndex < checkoutIndex &&
+      checkoutIndex < validationIndex &&
+      validationIndex < codexPreflightIndex,
+    "live source-branch writability must be resolved before checkout, validation planning, and Codex write preflight",
+  );
+});

--- a/test/repair/execute-fix-policy.test.ts
+++ b/test/repair/execute-fix-policy.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   shouldCloseSupersededSourcePrs,
   shouldSeedReplacementBranchFromSource,
+  sourceBranchWriteBlockReason,
 } from "../../dist/repair/execute-fix-policy.js";
 
 test("superseded source PR closeout defaults on for replacement PRs", () => {
@@ -27,5 +28,54 @@ test("only replacement fixes seed the repair branch from a source PR head", () =
   assert.equal(
     shouldSeedReplacementBranchFromSource({ repair_strategy: "repair_contributor_branch" }),
     false,
+  );
+});
+
+test("sourceBranchWriteBlockReason allows same-repo branches despite maintainer flag", () => {
+  assert.equal(
+    sourceBranchWriteBlockReason("openclaw/openclaw", {
+      maintainer_can_modify: false,
+      head: {
+        ref: "feature",
+        repo: { full_name: "openclaw/openclaw" },
+      },
+    }),
+    null,
+  );
+});
+
+test("sourceBranchWriteBlockReason allows fork branches with maintainer edits", () => {
+  assert.equal(
+    sourceBranchWriteBlockReason("openclaw/openclaw", {
+      maintainer_can_modify: true,
+      head: {
+        ref: "feature",
+        repo: { full_name: "contributor/openclaw" },
+      },
+    }),
+    null,
+  );
+});
+
+test("sourceBranchWriteBlockReason blocks fork branches without maintainer edits", () => {
+  assert.equal(
+    sourceBranchWriteBlockReason("openclaw/openclaw", {
+      maintainer_can_modify: false,
+      head: {
+        ref: "feature",
+        repo: { full_name: "contributor/openclaw" },
+      },
+    }),
+    "source PR branch is a fork with maintainer_can_modify=false",
+  );
+});
+
+test("sourceBranchWriteBlockReason blocks missing head details", () => {
+  assert.equal(
+    sourceBranchWriteBlockReason("openclaw/openclaw", {
+      maintainer_can_modify: true,
+      head: { repo: { full_name: "contributor/openclaw" } },
+    }),
+    "source PR is missing head repo/ref",
   );
 });


### PR DESCRIPTION
## Summary
- add a shared source branch writability policy for repair execution
- preflight repair_contributor_branch source PRs before target checkout, validation planning, and Codex write preflight
- convert unwritable fork branches with maintainer_can_modify=false into explicit replacement-PR repair mode

## Validation
- pnpm run build
- pnpm run build:repair
- node --test test/repair/execute-fix-policy.test.ts
- node --test test/repair/execute-fix-artifact-source.test.ts
- pnpm run check