### PR TITLE
fix(repair): skip stale merged-source replacements

### DIFF
--- a/src/repair/execute-fix-artifact.ts
+++ b/src/repair/execute-fix-artifact.ts
@@ -1029,6 +1029,7 @@ function openReplacementPrFromPreparedRepairCheckout({
     targetDir,
     repo: result.repo,
   });
+  const mergedSource = mergedReplacementSourcePr({ fixArtifact, sourcePr, targetDir });
   const branch = replacementBranchName(result.cluster_id);
   const areaCapacityBlock = validateActivePrAreaCapacity({
     fixArtifact,
@@ -1052,6 +1053,17 @@ function openReplacementPrFromPreparedRepairCheckout({
 
   ghAuthSetupGit(targetDir);
   run("git", ["checkout", "-B", branch], { cwd: targetDir });
+  const mergedSourceSkip = skipMergedSourceReplacementWithoutDiff({
+    mergedSource,
+    targetDir,
+    baseBranch,
+    branch,
+    fallbackReason,
+    sourcePr,
+    prep,
+    contributorCredits,
+  });
+  if (mergedSourceSkip) return mergedSourceSkip;
   if (!branchHasBaseDiff({ targetDir, baseBranch })) {
     logProgress("prepared replacement branch has no changes versus base; skipping PR create", {
       branch,
@@ -1359,6 +1371,7 @@ function executeReplacementBranch({
     targetDir,
     repo: result.repo,
   });
+  const mergedSource = mergedReplacementSourcePr({ fixArtifact, targetDir });
   const branch = replacementBranchName(result.cluster_id);
   const areaCapacityBlock = validateActivePrAreaCapacity({
     fixArtifact,
@@ -1435,6 +1448,16 @@ function executeReplacementBranch({
   }
 
   if (!branchHasBaseDiff({ targetDir, baseBranch })) {
+    const mergedSourceSkip = skipMergedSourceReplacementWithoutDiff({
+      mergedSource,
+      targetDir,
+      baseBranch,
+      branch,
+      prep,
+      contributorCredits,
+      resumedBranch: branchState.resumed,
+    });
+    if (mergedSourceSkip) return mergedSourceSkip;
     logProgress("replacement branch has no changes versus base; skipping PR create", {
       branch,
       base_branch: baseBranch,
@@ -1534,6 +1557,70 @@ function executeReplacementBranch({
     superseded_sources: supersededSources,
     superseded_source_actions: supersededSourceActions,
     contributor_credit: contributorCredits.map(publicContributorCredit),
+  };
+}
+
+function mergedReplacementSourcePr({ fixArtifact, sourcePr = null, targetDir }: LooseRecord) {
+  const sources = [...(sourcePr?.url ? [sourcePr.url] : []), ...(fixArtifact.source_prs ?? [])];
+  for (const source of uniqueStrings(sources)) {
+    const parsed = parsePullRequestUrl(source);
+    if (!parsed || parsed.repo !== result.repo) continue;
+    const view = fetchSourcePullRequestView({
+      repo: result.repo,
+      number: parsed.number,
+      targetDir,
+    });
+    if (view.mergedAt || view.state === "MERGED") {
+      return {
+        source,
+        pr: `#${parsed.number}`,
+        merged_at: view.mergedAt ?? null,
+      };
+    }
+  }
+  return null;
+}
+
+function skipMergedSourceReplacementWithoutDiff({
+  mergedSource,
+  targetDir,
+  baseBranch,
+  branch,
+  fallbackReason = null,
+  sourcePr = null,
+  prep,
+  contributorCredits,
+  resumedBranch = null,
+}: LooseRecord) {
+  if (!mergedSource) return null;
+  if (branchHasBaseDiff({ targetDir, baseBranch })) return null;
+  logProgress(
+    "source PR already merged and replacement branch has no changes; skipping PR create",
+    {
+      branch,
+      base_branch: baseBranch,
+      source_pr: mergedSource.source,
+      merged_at: mergedSource.merged_at ?? null,
+    },
+  );
+  return {
+    action: "open_fix_pr",
+    status: "skipped",
+    branch,
+    ...(resumedBranch !== null ? { resumed_branch: resumedBranch } : {}),
+    repair_strategy: "replace_uneditable_branch",
+    ...(sourcePr ? { fallback_from: "repair_contributor_branch" } : {}),
+    ...(sourcePr?.url ? { fallback_source_pr: sourcePr.url } : {}),
+    ...(fallbackReason ? { fallback_reason: fallbackReason } : {}),
+    commit: prep.commit,
+    checkpoint_commits: prep.checkpoint_commits,
+    merge_preflight: prep.merge_preflight,
+    supersede_sources: [],
+    merged_source_pr: mergedSource.pr,
+    merged_source_url: mergedSource.source,
+    merged_source_at: mergedSource.merged_at ?? null,
+    contributor_credit: contributorCredits.map(publicContributorCredit),
+    reason: "source PR already merged and replacement branch has no changes versus base",
   };
 }
 

--- a/test/repair/execute-fix-artifact-source.test.ts
+++ b/test/repair/execute-fix-artifact-source.test.ts
@@ -50,3 +50,44 @@ test("repair source branch writability preflight runs before expensive repair pr
     "live source-branch writability must be resolved before checkout, validation planning, and Codex write preflight",
   );
 });
+
+test("merged source replacement skip runs before publishing replacement PRs", () => {
+  const sourcePath = path.join(process.cwd(), "src/repair/execute-fix-artifact.ts");
+  const source = fs.readFileSync(sourcePath, "utf8");
+
+  const preparedStart = source.indexOf("function openReplacementPrFromPreparedRepairCheckout(");
+  const preparedEnd = source.indexOf("function executeReplacementBranch(", preparedStart);
+  assert.notEqual(preparedStart, -1);
+  assert.notEqual(preparedEnd, -1);
+  const preparedReplacement = source.slice(preparedStart, preparedEnd);
+  assert.match(
+    preparedReplacement,
+    /mergedReplacementSourcePr\(\{ fixArtifact, sourcePr, targetDir \}\)/,
+  );
+  assert.match(preparedReplacement, /skipMergedSourceReplacementWithoutDiff\(\{/);
+
+  const preparedSkipIndex = preparedReplacement.indexOf("skipMergedSourceReplacementWithoutDiff({");
+  const preparedPushIndex = preparedReplacement.indexOf(
+    "pushRecoverableBranch({ targetDir, branch });",
+  );
+  const preparedCreateIndex = preparedReplacement.indexOf('"pr",\n        "create"');
+  assert.notEqual(preparedSkipIndex, -1);
+  assert.notEqual(preparedPushIndex, -1);
+  assert.notEqual(preparedCreateIndex, -1);
+  assert.ok(
+    preparedSkipIndex < preparedPushIndex && preparedPushIndex < preparedCreateIndex,
+    "merged-source no-diff replacement skip must run before branch push and PR creation",
+  );
+
+  const helperStart = source.indexOf("function skipMergedSourceReplacementWithoutDiff(");
+  const helperEnd = source.indexOf("function labelReplacementPullRequest(", helperStart);
+  assert.notEqual(helperStart, -1);
+  assert.notEqual(helperEnd, -1);
+  const helper = source.slice(helperStart, helperEnd);
+  assert.match(helper, /if \(!mergedSource\) return null;/);
+  assert.match(helper, /if \(branchHasBaseDiff\(\{ targetDir, baseBranch \}\)\) return null;/);
+  assert.match(
+    helper,
+    /reason: "source PR already merged and replacement branch has no changes versus base"/,
+  );
+});


### PR DESCRIPTION
## Summary
- re-fetch source PR state before publishing replacement PRs
- skip replacement creation when the source PR is already merged and the prepared branch has no delta beyond base
- add regression coverage proving the merged-source skip runs before branch push and PR creation

## Validation
- node --test test/repair/execute-fix-artifact-source.test.ts
- pnpm run build:repair
- pnpm run test:repair
- pnpm run check