### PR TITLE
fix(review): accept valid Codex output after nonzero exit

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -4302,6 +4302,10 @@ export function restoreTreeModesForTest(snapshots: readonly FileModeSnapshot[]):
   restoreTreeModes(snapshots);
 }
 
+export function runCodexForTest(options: Parameters<typeof runCodex>[0]): Decision {
+  return runCodex(options);
+}
+
 function runCodex(options: {
   item: Item;
   context: ItemContext;
@@ -4386,6 +4390,28 @@ function runCodex(options: {
     );
   }
   if (result.status !== 0) {
+    if (existsSync(outputPath)) {
+      try {
+        const decision = parseDecision(
+          JSON.parse(readFileSync(outputPath, "utf8").trim()),
+          options.item,
+        );
+        console.error(
+          `[review] ${new Date().toISOString()} codex-exit-nonzero-output-accepted #${
+            options.item.number
+          } status=${result.status ?? "unknown"} stderr=${JSON.stringify(safeOutputTail(result.stderr))}`,
+        );
+        return decision;
+      } catch (error) {
+        throw new Error(
+          `Codex review failed for #${options.item.number} with exit ${
+            result.status ?? "unknown"
+          } and wrote invalid JSON or schema-invalid output to ${outputPath}: ${
+            error instanceof Error ? error.message : String(error)
+          }.\n${safeOutputTail(result.stderr) || safeOutputTail(result.stdout) || "No output."}`,
+        );
+      }
+    }
     throw new Error(
       `Codex review failed for #${options.item.number} with exit ${
         result.status ?? "unknown"

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -12,7 +12,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import test from "node:test";
 
 const tmpPrefix = join(tmpdir(), "clawsweeper-test-");
@@ -73,6 +73,7 @@ import {
   reviewDecisionSchemaText,
   reviewPromptTelemetryForTest,
   reviewPromptTemplate,
+  runCodexForTest,
   impactLabelsForTest,
   impactLabelSchemeForTest,
   runtimeBudgetExceeded,
@@ -4406,6 +4407,67 @@ test("runtime budget only trips after a positive elapsed limit", () => {
   assert.equal(runtimeBudgetExceeded(1000, 0, 100000), false);
   assert.equal(runtimeBudgetExceeded(1000, 5000, 5999), false);
   assert.equal(runtimeBudgetExceeded(1000, 5000, 6000), true);
+});
+
+test("runCodex accepts valid structured output after non-zero Codex exit", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const openclawDir = join(root, "openclaw");
+  const workDir = join(root, "codex-work");
+  const binDir = join(root, "bin");
+  mkdirSync(openclawDir, { recursive: true });
+  mkdirSync(binDir, { recursive: true });
+  execFileSync("git", ["init"], { cwd: openclawDir, stdio: "ignore" });
+  const codexPath = join(binDir, "codex");
+  writeFileSync(
+    codexPath,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const outputIndex = process.argv.indexOf("--output-last-message");
+if (outputIndex === -1) process.exit(2);
+fs.writeFileSync(process.argv[outputIndex + 1], process.env.CODEX_DECISION_JSON);
+process.stderr.write("wrote structured output before shutdown failure\\n");
+process.exit(1);
+`,
+  );
+  chmodSync(codexPath, 0o755);
+  const originalPath = process.env.PATH;
+  const originalDecision = process.env.CODEX_DECISION_JSON;
+  process.env.PATH = `${binDir}${delimiter}${process.env.PATH ?? ""}`;
+  process.env.CODEX_DECISION_JSON = JSON.stringify(
+    closeDecision({
+      decision: "keep_open",
+      closeReason: "none",
+      confidence: "medium",
+      summary: "Keep open for maintainer follow-up.",
+      bestSolution: "Review the routing invariant.",
+      closeComment: "",
+      workReason: "Maintainer review is required.",
+    }),
+  );
+  try {
+    const decision = runCodexForTest({
+      item: item({ number: 83393 }),
+      context: { issue: {}, comments: [], timeline: [] },
+      git: { mainSha: "abc123", latestRelease: null },
+      model: "gpt-test",
+      openclawDir,
+      reasoningEffort: "high",
+      sandboxMode: "read-only",
+      serviceTier: "",
+      timeoutMs: 10_000,
+      workDir,
+      prompt: "Return a review decision.",
+    });
+
+    assert.equal(decision.decision, "keep_open");
+    assert.equal(decision.summary, "Keep open for maintainer follow-up.");
+  } finally {
+    if (originalPath === undefined) delete process.env.PATH;
+    else process.env.PATH = originalPath;
+    if (originalDecision === undefined) delete process.env.CODEX_DECISION_JSON;
+    else process.env.CODEX_DECISION_JSON = originalDecision;
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("decision parser enforces required schema-shaped evidence", () => {


### PR DESCRIPTION
## Summary
- accept schema-valid Codex review output even when the Codex process exits non-zero after writing --output-last-message
- keep missing or invalid structured output on the existing failure path
- add regression coverage for the #83393 failure shape with a fake Codex binary that writes output and exits 1

## Context
ClawSweeper appeared broken on https://github.com/openclaw/openclaw/issues/83393 because the event review run produced a synthetic "Codex review failed" verdict. The original PR was accidentally opened from a branch with unrelated commits; this replacement branch is clean off origin/main and contains only the nonzero-exit fix commit.

Supersedes https://github.com/openclaw/clawsweeper/pull/102.

## Validation
- pnpm run check
