### PR TITLE
fix(review): surface upgrade-sensitive PR risks

### DIFF
--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -57,6 +57,16 @@ one short sentence for `changeSummary`, `workReason`, `bestSolution`, and
 `changeSummary` or `workReason` into an automerge/autofix status update; merge
 automation is reported by the command/status comment and hidden markers.
 
+For PRs, do not let labels be the only place that merger risk is visible. If a
+merge can intentionally make an existing user's setup stop working, fail closed,
+lose a fallback path, require a migration, or require operator action, state that
+plainly in `risks` and make `workReason`/`bestSolution` name the maintainer
+decision or upgrade proof needed before merge. This applies even when the PR is
+otherwise correct and the behavior change is deliberate. Use `reviewFindings`
+for defects introduced by the patch; use `risks` for valid but merge-relevant
+upgrade, compatibility, or operator-impact uncertainty that maintainers must
+see before landing.
+
 Classify issue type conservatively. Set `itemCategory: "bug"` only when the
 item reports broken existing behavior and the expected behavior is already
 defined by current docs, tests, CLI/API contract, or established behavior. Do
@@ -156,6 +166,12 @@ state, local workspace state, generated files, shortcuts, routes, schemas, or
 documented defaults. A new default must not change an existing user's stored
 value during upgrade unless the PR includes an explicit, narrow, tested
 migration and the behavior is clearly intentional.
+
+Treat provider fallback removal, fail-closed routing, missing-harness behavior,
+startup/install checks, and strict config validation as upgrade-sensitive even
+when they fix a real bug. If current users may only discover the change because
+an existing workflow stops at runtime, call out the user-visible failure mode and
+the required maintainer choice before merge.
 
 Call out upgrade and settings breakage directly in `reviewFindings`: use P1
 when existing setups can break, existing config/preferences can be overwritten,

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -171,7 +171,12 @@ Treat provider fallback removal, fail-closed routing, missing-harness behavior,
 startup/install checks, and strict config validation as upgrade-sensitive even
 when they fix a real bug. If current users may only discover the change because
 an existing workflow stops at runtime, call out the user-visible failure mode and
-the required maintainer choice before merge.
+the required maintainer choice before merge. When preserving the existing
+behavior as the default plus adding an explicit strict config option would avoid
+breaking current users, recommend that path in `bestSolution` or `workReason`
+instead of treating unconditional fail-closed behavior as the only acceptable
+fix. Require tests or proof for both the default compatibility mode and the
+opt-in strict mode.
 
 Call out upgrade and settings breakage directly in `reviewFindings`: use P1
 when existing setups can break, existing config/preferences can be overwritten,

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -4915,6 +4915,12 @@ function publicReviewTextDiffers(left: string, right: string): boolean {
   );
 }
 
+function publicReviewTextIsSame(left: string, right: string): boolean {
+  const normalizedLeft = normalizePublicReviewText(left);
+  const normalizedRight = normalizePublicReviewText(right);
+  return Boolean(normalizedLeft) && normalizedLeft === normalizedRight;
+}
+
 function isReportNoneList(value: string): boolean {
   return !value.trim() || value.trim() === "- none";
 }
@@ -7116,6 +7122,17 @@ function publicSummaryBody(summaryLine: string, reproductionAssessment: string):
     .join("\n\n");
 }
 
+function publicMergeRiskLine(
+  risks: string,
+  nextStepLine: string,
+  bestSolutionLine: string,
+): string {
+  if (isReportNoneList(risks)) return "";
+  if (publicReviewTextIsSame(risks, nextStepLine)) return "";
+  if (bestSolutionLine && publicReviewTextIsSame(risks, bestSolutionLine)) return "";
+  return risks;
+}
+
 function issueReproductionHelpSuggestions(markdown: string): string[] {
   if (frontMatterValue(markdown, "type") !== "issue") return [];
   const reproductionStatus = frontMatterValue(markdown, "reproduction_status");
@@ -7226,6 +7243,9 @@ function renderKeepOpenCommentFromReport(markdown: string): string {
     "Continue tracking this item until the missing behavior is implemented or a maintainer decides the product direction.";
   const nextStepLine = sentence(workReason || bestSolution || fallbackNextStep);
   const bestSolutionLine = sentence(bestSolution);
+  const mergeRiskLine = isPullRequest
+    ? publicMergeRiskLine(risks, nextStepLine, bestSolutionLine)
+    : "";
   const details: string[] = [];
   const hasReviewFindings = isPullRequest && reviewFindings.length > 0;
   const lines = [
@@ -7274,6 +7294,7 @@ function renderKeepOpenCommentFromReport(markdown: string): string {
     ? publicMantisRecommendationBlock(mantisRecommendation)
     : "";
   if (mantisSuggestion) appendPublicSection(lines, "Mantis proof suggestion", mantisSuggestion);
+  if (mergeRiskLine) appendPublicSection(lines, "Risk before merge", mergeRiskLine);
   appendPublicSection(lines, isPullRequest ? "Next step before merge" : "Next step", nextStepLine);
   const securityLine = publicSecurityReviewLine(securityReview);
   if (securityLine) appendPublicSection(lines, "Security", securityLine);
@@ -7308,6 +7329,7 @@ function renderKeepOpenCommentFromReport(markdown: string): string {
   if (likelyOwners.length) details.push("", "Likely related people:", "", ...likelyOwners);
   if (
     !isReportNoneList(risks) &&
+    !mergeRiskLine &&
     publicReviewTextDiffers(risks, nextStepLine) &&
     (!bestSolutionLine || publicReviewTextDiffers(risks, bestSolutionLine))
   ) {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -4697,6 +4697,9 @@ test("review prompt requires upgrade and preference overwrite checks", () => {
   );
   assert.match(prompt, /Call out upgrade and settings breakage directly in `reviewFindings`/);
   assert.match(prompt, /existing config\/preferences can be overwritten/);
+  assert.match(prompt, /preserving the existing\s+behavior as the default/);
+  assert.match(prompt, /explicit strict config option/);
+  assert.match(prompt, /default compatibility mode and the\s+opt-in strict mode/);
   assert.match(prompt, /require evidence for both fresh-install behavior and upgrade\s+behavior/);
   assert.match(prompt, /If upgrade behavior is ambiguous, mark the PR incorrect/);
 });

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -4245,8 +4245,62 @@ Reason: ${duplicateRisk}
 
   assert.ok(comment.includes(`**Next step before merge**\n${duplicateRisk}`));
   assert.doesNotMatch(comment, /Remaining risk \/ open question:/);
+  assert.doesNotMatch(comment, /\*\*Risk before merge\*\*/);
   assert.equal(comment.split(duplicateRisk).length - 1, 1);
 });
+
+test("pull request keep-open review comments surface distinct merge risks", () => {
+  const mergeRisk =
+    "Existing users configured with a missing Codex harness would fail closed instead of continuing through their fallback model.";
+  const comment = renderReviewCommentFromReport(
+    `${reportFrontMatter({
+      type: "pull_request",
+      number: "83400",
+      decision: "keep_open",
+      close_reason: "none",
+      work_candidate: "none",
+      pull_head_sha: "abc123def456",
+    })}
+
+## Summary
+
+Keep this fail-closed provider-routing PR open for maintainer review.
+
+## What This Changes
+
+Changes missing Codex harness selection from fallback-tolerant behavior to a typed fail-closed error.
+
+## Best Possible Solution
+
+Land only after maintainers accept the upgrade behavior for configured fallback users.
+
+## Risks / Open Questions
+
+${mergeRisk}
+
+## Work Candidate
+
+Candidate: none
+
+Confidence: low
+
+Priority: low
+
+Status: none
+
+Reason: Confirm whether this intentional fail-closed behavior is acceptable for existing fallback users.
+`,
+    "none",
+  );
+
+  assert.match(comment, /\*\*Risk before merge\*\*/);
+  assert.match(comment, new RegExp(escapeRegExpForTest(mergeRisk)));
+  assert.doesNotMatch(comment, /Remaining risk \/ open question:/);
+});
+
+function escapeRegExpForTest(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
 
 test("pull request review reports carry verdict and repair markers", () => {
   const markdown = `${reportFrontMatter({


### PR DESCRIPTION
## Summary

- surface distinct PR merge risks in the public ClawSweeper review comment instead of leaving them only in collapsed details
- teach review guidance to call out upgrade-sensitive fail-closed behavior and recommend preserving current behavior by default with an explicit strict config opt-in when that avoids breaking existing users
- add regression coverage for visible merge-risk comments and prompt guidance

## Validation

- pnpm run build
- pnpm run test:unit -- test/clawsweeper.test.ts
- pnpm run check
- git diff --check

## Notes

This is aimed at reviews like openclaw/openclaw#83400, where labels can be correct but maintainers still need a visible pre-merge warning that existing fallback users may hard-fail after upgrade.