### PR TITLE
Offer merge-risk maintainer decision alternatives

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -7315,24 +7315,18 @@ function publicMergeRiskLine(
 }
 
 function mergeRiskResolutionChoices(bestSolutionLine: string, nextStepLine: string): string[] {
-  const choices: string[] = [];
   const recommended = sentence(bestSolutionLine) || sentence(nextStepLine);
-  if (recommended) choices.push(mergeRiskAutomergeChoice(recommended, true));
-  const alternate = sentence(nextStepLine);
-  if (alternate && !publicReviewTextIsSame(alternate, recommended)) {
-    choices.push(mergeRiskAgentChoice(alternate));
-  }
-  if (choices.length === 0) {
-    choices.push(
-      mergeRiskAutomergeChoice("Decide whether the merge risk is acceptable before merging.", true),
-    );
-  }
-  return choices.slice(0, 3);
+  const instruction = recommended || "Decide whether the merge risk is acceptable before merging.";
+  return [
+    mergeRiskAutomergeChoice(instruction),
+    mergeRiskAcceptChoice(instruction),
+    mergeRiskHumanDecisionChoice(instruction),
+  ];
 }
 
-function mergeRiskAutomergeChoice(instruction: string, recommended: boolean): string {
+function mergeRiskAutomergeChoice(instruction: string): string {
   return [
-    `1. ${recommended ? "(recommended) " : ""}Start ClawSweeper automerge with special instructions:`,
+    "1. (recommended) Fix the PR before merge with ClawSweeper automerge:",
     "",
     "```text",
     "@clawsweeper automerge",
@@ -7341,12 +7335,22 @@ function mergeRiskAutomergeChoice(instruction: string, recommended: boolean): st
   ].join("\n");
 }
 
-function mergeRiskAgentChoice(instruction: string): string {
+function mergeRiskAcceptChoice(instruction: string): string {
   return [
-    "2. Ask an LLM or repair agent to update the PR before merge:",
+    "2. Accept the merge risk explicitly:",
     "",
     "```text",
-    `Fix this PR before merge: ${instruction}`,
+    `Merge as-is only if maintainers intentionally accept this risk: ${instruction}`,
+    "```",
+  ].join("\n");
+}
+
+function mergeRiskHumanDecisionChoice(instruction: string): string {
+  return [
+    "3. Stop automation and require a human merge decision:",
+    "",
+    "```text",
+    `Do not automerge this PR. Ask a maintainer to decide whether to require changes, merge anyway, or close the PR as not worth the risk: ${instruction}`,
     "```",
   ].join("\n");
 }

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -4300,7 +4300,7 @@ Reason: Confirm whether this intentional fail-closed behavior is acceptable for 
   assert.match(comment, new RegExp(escapeRegExpForTest(mergeRisk)));
   assert.match(
     comment,
-    /Maintainer choices:\n1\. \(recommended\) Start ClawSweeper automerge with special instructions:/,
+    /Maintainer choices:\n1\. \(recommended\) Fix the PR before merge with ClawSweeper automerge:/,
   );
   assert.match(
     comment,
@@ -4308,7 +4308,11 @@ Reason: Confirm whether this intentional fail-closed behavior is acceptable for 
   );
   assert.match(
     comment,
-    /Fix this PR before merge: Confirm whether this intentional fail-closed behavior is acceptable for existing fallback users\./,
+    /2\. Accept the merge risk explicitly:[\s\S]*Merge as-is only if maintainers intentionally accept this risk: Land only after maintainers accept the upgrade behavior for configured fallback users\./,
+  );
+  assert.match(
+    comment,
+    /3\. Stop automation and require a human merge decision:[\s\S]*Do not automerge this PR\. Ask a maintainer to decide whether to require changes, merge anyway, or close the PR as not worth the risk: Land only after maintainers accept the upgrade behavior for configured fallback users\./,
   );
   assert.doesNotMatch(comment, /Remaining risk \/ open question:/);
 });


### PR DESCRIPTION
## Summary
- render merge-risk maintainer choices as three explicit paths: repair before merge, accept the risk, or stop automation for a human decision
- include the option to close the PR as not worth the risk in the human-decision path
- update public review comment coverage for the expanded choices

## Validation
- pnpm run check