### PR TITLE
Structure merge-risk maintainer options

### DIFF
--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -119,10 +119,17 @@ discussion:
 `merge-risk: 🚨 availability`: 🚨 Merging this PR could cause crashes, hangs, restart loops, stalls, or process outages.
 `merge-risk: 🚨 automation`: 🚨 Merging this PR could break CI, automerge, proof capture, label sync, or automation.
 When merge risk is present, explain it in `risks` in maintainer-facing language
-and make `bestSolution` the best mitigation path. Write it as an imperative
-instruction a maintainer can paste into another LLM or into `@clawsweeper
-automerge` as special instructions. The public review comment will turn that
-into 1-3 maintainer choices and mark the best option `(recommended)`.
+and make `bestSolution` the best end state. Fill `mergeRiskOptions` with 1-3
+risk-specific maintainer options. Do not use a fixed menu. Each option needs a
+short title and one concrete sentence. Mark exactly one option `recommended:
+true` only when the evidence supports a clear best path; otherwise leave every
+option `recommended: false`. Use `category: "fix_before_merge"` for repair
+paths, `category: "accept_risk"` when maintainers may intentionally own the
+risk, and `category: "pause_or_close"` when the PR may need to pause or close as
+not worth the risk. Multiple fix-before-merge options are allowed when there are
+multiple valid repair paths. Set `automergeInstruction` only for a recommended
+`fix_before_merge` option that ClawSweeper automerge can reasonably execute;
+otherwise set it to an empty string.
 
 Populate structured reproduction metadata separately from the public prose.
 Use `reproductionStatus: "reproduced"` only when there is a concrete,
@@ -570,9 +577,10 @@ Always fill `mergeRiskLabels` too. Use `[]` for issues and for PRs whose merge
 risk is adequately covered by normal review/CI. For PRs with non-obvious
 compatibility, delivery, session-state, auth-provider, security-boundary,
 availability, or automation risk, add the matching `merge-risk:*` labels,
-explain why the risk matters in `risks`, and put the preferred mitigation in
-`bestSolution` as a paste-ready instruction so maintainers see a recommended
-choice before merge.
+explain why the risk matters in `risks`, and fill `mergeRiskOptions` with
+decision-useful maintainer options. Use `mergeRiskOptions: []` whenever
+`mergeRiskLabels` is empty. Avoid making ClawSweeper sound more certain than the
+evidence supports.
 
 Always fill the work-lane fields too. For non-candidates, use
 `workCandidate: "none"`, low confidence/priority, an empty `workPrompt`, and

--- a/schema/clawsweeper-decision.schema.json
+++ b/schema/clawsweeper-decision.schema.json
@@ -15,6 +15,7 @@
     "triagePriority",
     "impactLabels",
     "mergeRiskLabels",
+    "mergeRiskOptions",
     "itemCategory",
     "reproductionStatus",
     "reproductionConfidence",
@@ -193,6 +194,38 @@
         ]
       },
       "description": "PR-only ClawSweeper-owned GitHub labels for merge risks that green CI does not settle. These describe what could go wrong specifically because this PR is merged, not the affected or solved problem class. Use at most 3 for pull requests and [] for issues. merge-risk: 🚨 compatibility: 🚨 Merging this PR could break existing users, config, migrations, defaults, or upgrades. merge-risk: 🚨 message-delivery: 🚨 Merging this PR could drop, duplicate, misroute, suppress, or wrongly target messages. merge-risk: 🚨 session-state: 🚨 Merging this PR could lose, corrupt, stale, or mis-associate session or agent state. merge-risk: 🚨 auth-provider: 🚨 Merging this PR could break OAuth, tokens, provider routing, model choice, or credentials. merge-risk: 🚨 security-boundary: 🚨 Merging this PR could weaken sandboxing, authorization, credentials, or sensitive data. merge-risk: 🚨 availability: 🚨 Merging this PR could cause crashes, hangs, restart loops, stalls, or process outages. merge-risk: 🚨 automation: 🚨 Merging this PR could break CI, automerge, proof capture, label sync, or automation."
+    },
+    "mergeRiskOptions": {
+      "type": "array",
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["title", "body", "category", "recommended", "automergeInstruction"],
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Short maintainer-facing option title."
+          },
+          "body": {
+            "type": "string",
+            "description": "One concrete sentence explaining this maintainer option."
+          },
+          "category": {
+            "type": "string",
+            "enum": ["fix_before_merge", "accept_risk", "pause_or_close"]
+          },
+          "recommended": {
+            "type": "boolean",
+            "description": "True for at most one option, only when the evidence supports a clear best path."
+          },
+          "automergeInstruction": {
+            "type": "string",
+            "description": "Only for a recommended fix_before_merge option suitable for automation; otherwise empty."
+          }
+        }
+      },
+      "description": "Risk-specific maintainer options for the Risk before merge section. Use [] when mergeRiskLabels is []. When mergeRiskLabels is non-empty, provide 1-3 prose-first options. Do not use a fixed menu: tailor titles and bodies to this PR. Mark at most one option recommended, and only when evidence supports a clear best path. Include pause_or_close when the PR may not be worth the risk. Put a copyable @clawsweeper automerge instruction only in automergeInstruction for a recommended fix_before_merge option suitable for automation."
     },
     "itemCategory": {
       "type": "string",

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -80,6 +80,7 @@ type MergeRiskLabelName =
   | "merge-risk: 🚨 security-boundary"
   | "merge-risk: 🚨 availability"
   | "merge-risk: 🚨 automation";
+type MergeRiskOptionCategory = "fix_before_merge" | "accept_risk" | "pause_or_close";
 type ItemCategory =
   | "bug"
   | "regression"
@@ -305,6 +306,14 @@ interface FixedPullRequest {
   source: string;
 }
 
+interface MergeRiskOption {
+  title: string;
+  body: string;
+  category: MergeRiskOptionCategory;
+  recommended: boolean;
+  automergeInstruction: string;
+}
+
 interface Decision {
   decision: DecisionKind;
   closeReason: CloseReason;
@@ -318,6 +327,7 @@ interface Decision {
   triagePriority: TriagePriority;
   impactLabels: ImpactLabelName[];
   mergeRiskLabels: MergeRiskLabelName[];
+  mergeRiskOptions: MergeRiskOption[];
   itemCategory: ItemCategory;
   reproductionStatus: ReproductionStatus;
   reproductionConfidence: Confidence;
@@ -1103,6 +1113,11 @@ const OVERALL_CORRECTNESS_VALUES = new Set<OverallCorrectness>([
 
 type ReviewArtifactDestination = "items" | "closed" | "skip_closed";
 const CONFIDENCES = new Set<Confidence>(["high", "medium", "low"]);
+const MERGE_RISK_OPTION_CATEGORIES = new Set<MergeRiskOptionCategory>([
+  "fix_before_merge",
+  "accept_risk",
+  "pause_or_close",
+]);
 const DECISION_SCHEMA_KEYS = new Set([
   "decision",
   "closeReason",
@@ -1116,6 +1131,7 @@ const DECISION_SCHEMA_KEYS = new Set([
   "triagePriority",
   "impactLabels",
   "mergeRiskLabels",
+  "mergeRiskOptions",
   "itemCategory",
   "reproductionStatus",
   "reproductionConfidence",
@@ -1166,6 +1182,13 @@ const MANTIS_RECOMMENDATION_SCHEMA_KEYS = new Set([
   "scenario",
   "reason",
   "maintainerComment",
+]);
+const MERGE_RISK_OPTION_SCHEMA_KEYS = new Set([
+  "title",
+  "body",
+  "category",
+  "recommended",
+  "automergeInstruction",
 ]);
 const SECURITY_CONCERN_SCHEMA_KEYS = new Set([
   "title",
@@ -1623,6 +1646,64 @@ function requireMergeRiskLabels(value: unknown): MergeRiskLabelName[] {
   return labels;
 }
 
+function parseMergeRiskOption(value: unknown, path: string): MergeRiskOption {
+  const record = requireRecord(value, path);
+  rejectUnexpectedKeys(record, MERGE_RISK_OPTION_SCHEMA_KEYS, path);
+  return {
+    title: requireString(record.title, `${path}.title`).trim(),
+    body: requireString(record.body, `${path}.body`).trim(),
+    category: requireEnum(record.category, MERGE_RISK_OPTION_CATEGORIES, `${path}.category`),
+    recommended: requireBoolean(record.recommended, `${path}.recommended`),
+    automergeInstruction: requireString(
+      record.automergeInstruction,
+      `${path}.automergeInstruction`,
+    ).trim(),
+  };
+}
+
+function requireMergeRiskOptions(value: unknown): MergeRiskOption[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) throw new Error("decision.mergeRiskOptions must be an array");
+  const options = value.map((entry, index) =>
+    parseMergeRiskOption(entry, `decision.mergeRiskOptions[${index}]`),
+  );
+  if (options.length > 3)
+    throw new Error("decision.mergeRiskOptions must contain at most 3 options");
+  const recommended = options.filter((option) => option.recommended);
+  if (recommended.length > 1) {
+    throw new Error("decision.mergeRiskOptions must not contain more than one recommended option");
+  }
+  for (const [index, option] of options.entries()) {
+    if (!option.title)
+      throw new Error(`decision.mergeRiskOptions[${index}].title must not be empty`);
+    if (!option.body) throw new Error(`decision.mergeRiskOptions[${index}].body must not be empty`);
+    if (option.automergeInstruction && option.category !== "fix_before_merge") {
+      throw new Error(
+        `decision.mergeRiskOptions[${index}].automergeInstruction requires fix_before_merge category`,
+      );
+    }
+    if (option.automergeInstruction && !option.recommended) {
+      throw new Error(
+        `decision.mergeRiskOptions[${index}].automergeInstruction requires a recommended option`,
+      );
+    }
+  }
+  return options;
+}
+
+function validateMergeRiskOptions(
+  decision: Pick<Decision, "mergeRiskLabels" | "mergeRiskOptions">,
+): void {
+  if (decision.mergeRiskLabels.length === 0 && decision.mergeRiskOptions.length > 0) {
+    throw new Error("decision.mergeRiskOptions must be empty when mergeRiskLabels is empty");
+  }
+  if (decision.mergeRiskLabels.length > 0 && decision.mergeRiskOptions.length === 0) {
+    throw new Error(
+      "decision.mergeRiskOptions must include 1-3 options when mergeRiskLabels is not empty",
+    );
+  }
+}
+
 function isEnvironmentAccessCaveat(value: string): boolean {
   return /(?:GH_TOKEN|GITHUB_TOKEN|authenticated gh|gh (?:was |is )?unavailable|unauthenticated gh|shallow clone|GitHub auth(?:entication)? (?:was |is )?unavailable|could not use authenticated GitHub)/i.test(
     value,
@@ -1721,6 +1802,7 @@ function normalizeDecisionForItem(
     reviewFindings,
     bestSolution: CLEAN_OPENCLAW_PR_REVIEW_NEXT_STEP,
     triagePriority: decision.triagePriority,
+    mergeRiskOptions: decision.mergeRiskOptions,
     overallCorrectness:
       decision.overallCorrectness === "patch is incorrect"
         ? "patch is correct"
@@ -1865,6 +1947,7 @@ export function parseDecision(value: unknown, item?: DecisionNormalizationItem):
     ),
     impactLabels: requireImpactLabels(record.impactLabels),
     mergeRiskLabels: requireMergeRiskLabels(record.mergeRiskLabels),
+    mergeRiskOptions: requireMergeRiskOptions(record.mergeRiskOptions),
     itemCategory: requireEnum(record.itemCategory, ITEM_CATEGORIES, "decision.itemCategory"),
     reproductionStatus: requireEnum(
       record.reproductionStatus,
@@ -1927,6 +2010,7 @@ export function parseDecision(value: unknown, item?: DecisionNormalizationItem):
     workValidation: requireStringArray(record.workValidation, "decision.workValidation"),
     workLikelyFiles: requireStringArray(record.workLikelyFiles, "decision.workLikelyFiles"),
   };
+  validateMergeRiskOptions(decision);
   return normalizeDecisionForItem(decision, item);
 }
 
@@ -2940,6 +3024,17 @@ function frontMatterStringArray(markdown: string, key: string): string[] {
     .split(",")
     .map((entry) => entry.trim())
     .filter(Boolean);
+}
+
+function frontMatterJsonArray(markdown: string, key: string): unknown[] {
+  const value = frontMatterValue(markdown, key);
+  if (!value || value === "none") return [];
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
 }
 
 function frontMatterBoolean(markdown: string, key: string): boolean {
@@ -4278,6 +4373,7 @@ function codexFailureDecision(status: number | null, stderr: string, stdout = ""
     triagePriority: "none",
     impactLabels: [],
     mergeRiskLabels: [],
+    mergeRiskOptions: [],
     itemCategory: "unclear",
     reproductionStatus: "unclear",
     reproductionConfidence: "low",
@@ -5509,6 +5605,18 @@ function mergeRiskLabelsFromReport(markdown: string): MergeRiskLabelName[] {
   return frontMatterStringArray(markdown, "merge_risk_labels").filter(
     (label): label is MergeRiskLabelName => MERGE_RISK_LABEL_NAMES.has(label),
   );
+}
+
+function mergeRiskOptionsFromReport(markdown: string): MergeRiskOption[] {
+  return frontMatterJsonArray(markdown, "merge_risk_options")
+    .map((entry, index) => {
+      try {
+        return parseMergeRiskOption(entry, `merge_risk_options[${index}]`);
+      } catch {
+        return null;
+      }
+    })
+    .filter((entry): entry is MergeRiskOption => Boolean(entry));
 }
 
 function reportReviewFindings(markdown: string): ReviewFinding[] {
@@ -6785,6 +6893,7 @@ function reportDecision(markdown: string, closeReason: CloseReason): Decision {
     triagePriority: triagePriorityFromReport(markdown),
     impactLabels: impactLabelsFromReport(markdown),
     mergeRiskLabels: mergeRiskLabelsFromReport(markdown),
+    mergeRiskOptions: mergeRiskOptionsFromReport(markdown),
     itemCategory:
       (frontMatterValue(markdown, "item_category") as ItemCategory | undefined) ?? "unclear",
     reproductionStatus:
@@ -7301,57 +7410,71 @@ function publicMergeRiskLine(
   risks: string,
   nextStepLine: string,
   bestSolutionLine: string,
+  options: readonly MergeRiskOption[],
 ): string {
   if (isReportNoneList(risks)) return "";
   if (publicReviewTextIsSame(risks, nextStepLine)) return "";
   if (bestSolutionLine && publicReviewTextIsSame(risks, bestSolutionLine)) return "";
-  const choices = mergeRiskResolutionChoices(bestSolutionLine, nextStepLine);
+  const choices = options.length
+    ? mergeRiskOptionsLines(options)
+    : mergeRiskFallbackOptionsLines(bestSolutionLine, nextStepLine);
   return [
     `Why this matters: ${risks}`,
-    choices.length ? ["", "Maintainer choices:", ...choices].join("\n") : "",
+    choices.length ? ["", "Maintainer options:", ...choices].join("\n") : "",
   ]
     .filter(Boolean)
     .join("\n");
 }
 
-function mergeRiskResolutionChoices(bestSolutionLine: string, nextStepLine: string): string[] {
+function mergeRiskFallbackOptionsLines(bestSolutionLine: string, nextStepLine: string): string[] {
   const recommended = sentence(bestSolutionLine) || sentence(nextStepLine);
   const instruction = recommended || "Decide whether the merge risk is acceptable before merging.";
-  return [
-    mergeRiskAutomergeChoice(instruction),
-    mergeRiskAcceptChoice(instruction),
-    mergeRiskHumanDecisionChoice(instruction),
-  ];
+  return mergeRiskOptionsLines([
+    {
+      title: "Decide the mitigation before merge",
+      body: instruction,
+      category: "fix_before_merge",
+      recommended: false,
+      automergeInstruction: "",
+    },
+    {
+      title: "Pause or close",
+      body: "Do not merge this PR until maintainers decide whether the risk is worth taking.",
+      category: "pause_or_close",
+      recommended: false,
+      automergeInstruction: "",
+    },
+  ]);
 }
 
-function mergeRiskAutomergeChoice(instruction: string): string {
+function mergeRiskOptionsLines(options: readonly MergeRiskOption[]): string[] {
+  const lines = options.flatMap((option, index) => [
+    `${index + 1}. **${option.title}${option.recommended ? " (recommended)" : ""}**  `,
+    `   ${option.body}`,
+  ]);
+  const recommendedRepair = options.find(
+    (option) =>
+      option.recommended &&
+      option.category === "fix_before_merge" &&
+      option.automergeInstruction.trim(),
+  );
+  if (recommendedRepair) {
+    lines.push("", mergeRiskAutomergeInstructionBlock(recommendedRepair.automergeInstruction));
+  }
+  return lines;
+}
+
+function mergeRiskAutomergeInstructionBlock(instruction: string): string {
   return [
-    "1. (recommended) Fix the PR before merge with ClawSweeper automerge:",
+    "<details>",
+    "<summary>Copy recommended ClawSweeper instruction</summary>",
     "",
     "```text",
     "@clawsweeper automerge",
     `Special instructions: ${instruction}`,
     "```",
-  ].join("\n");
-}
-
-function mergeRiskAcceptChoice(instruction: string): string {
-  return [
-    "2. Accept the merge risk explicitly:",
     "",
-    "```text",
-    `Merge as-is only if maintainers intentionally accept this risk: ${instruction}`,
-    "```",
-  ].join("\n");
-}
-
-function mergeRiskHumanDecisionChoice(instruction: string): string {
-  return [
-    "3. Stop automation and require a human merge decision:",
-    "",
-    "```text",
-    `Do not automerge this PR. Ask a maintainer to decide whether to require changes, merge anyway, or close the PR as not worth the risk: ${instruction}`,
-    "```",
+    "</details>",
   ].join("\n");
 }
 
@@ -7450,6 +7573,7 @@ function renderKeepOpenCommentFromReport(markdown: string): string {
   const reproductionAssessment = reviewSectionValue(markdown, "reproductionAssessment");
   const solutionAssessment = reviewSectionValue(markdown, "solutionAssessment");
   const risks = reviewSectionValue(markdown, "risks");
+  const mergeRiskOptions = mergeRiskOptionsFromReport(markdown);
   const workReason = reportWorkCandidateReason(markdown);
   const workCandidate = frontMatterValue(markdown, "work_candidate");
   const validation = frontMatterStringArray(markdown, "work_validation")
@@ -7466,7 +7590,7 @@ function renderKeepOpenCommentFromReport(markdown: string): string {
   const nextStepLine = sentence(workReason || bestSolution || fallbackNextStep);
   const bestSolutionLine = sentence(bestSolution);
   const mergeRiskLine = isPullRequest
-    ? publicMergeRiskLine(risks, nextStepLine, bestSolutionLine)
+    ? publicMergeRiskLine(risks, nextStepLine, bestSolutionLine, mergeRiskOptions)
     : "";
   const details: string[] = [];
   const hasReviewFindings = isPullRequest && reviewFindings.length > 0;
@@ -8439,6 +8563,7 @@ work_likely_files: ${jsonFrontMatterValue(options.decision.workLikelyFiles)}
 triage_priority: ${options.decision.triagePriority}
 impact_labels: ${jsonFrontMatterValue(options.decision.impactLabels)}
 merge_risk_labels: ${jsonFrontMatterValue(options.decision.mergeRiskLabels)}
+merge_risk_options: ${JSON.stringify(options.decision.mergeRiskOptions)}
 pull_files: ${jsonFrontMatterValue(pullFiles)}
 pull_files_truncated: ${pullFilesTruncated}
 item_category: ${options.decision.itemCategory}

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -177,6 +177,7 @@ function closeDecision(overrides = {}) {
     triagePriority: "P2",
     impactLabels: [],
     mergeRiskLabels: [],
+    mergeRiskOptions: [],
     itemCategory: "bug",
     reproductionStatus: "reproduced",
     reproductionConfidence: "high",
@@ -4252,10 +4253,16 @@ Reason: ${duplicateRisk}
   assert.equal(comment.split(duplicateRisk).length - 1, 1);
 });
 
-test("pull request keep-open review comments surface distinct merge risks", () => {
-  const mergeRisk =
-    "Existing users configured with a missing Codex harness would fail closed instead of continuing through their fallback model.";
-  const comment = renderReviewCommentFromReport(
+function mergeRiskReviewComment({
+  risk,
+  options,
+  bestSolution = "Resolve the merge risk before maintainers decide whether to land this PR.",
+}: {
+  risk: string;
+  options: readonly Record<string, unknown>[];
+  bestSolution?: string;
+}): string {
+  return renderReviewCommentFromReport(
     `${reportFrontMatter({
       type: "pull_request",
       number: "83400",
@@ -4263,6 +4270,7 @@ test("pull request keep-open review comments surface distinct merge risks", () =
       close_reason: "none",
       work_candidate: "none",
       pull_head_sha: "abc123def456",
+      merge_risk_options: JSON.stringify(options),
     })}
 
 ## Summary
@@ -4275,11 +4283,11 @@ Changes missing Codex harness selection from fallback-tolerant behavior to a typ
 
 ## Best Possible Solution
 
-Land only after maintainers accept the upgrade behavior for configured fallback users.
+${bestSolution}
 
 ## Risks / Open Questions
 
-${mergeRisk}
+${risk}
 
 ## Work Candidate
 
@@ -4295,26 +4303,162 @@ Reason: Confirm whether this intentional fail-closed behavior is acceptable for 
 `,
     "none",
   );
+}
+
+test("pull request keep-open review comments render repairable merge-risk options with one copy block", () => {
+  const mergeRisk =
+    "Existing users configured with a missing Codex harness would fail closed instead of continuing through their fallback model.";
+  const comment = mergeRiskReviewComment({
+    risk: mergeRisk,
+    bestSolution:
+      "Keep fallback behavior as the default and add a strict config option for the fail-closed behavior.",
+    options: [
+      {
+        title: "Preserve existing behavior by default",
+        body: "Keep fallback behavior as the default and add a strict config option for the fail-closed behavior.",
+        category: "fix_before_merge",
+        recommended: true,
+        automergeInstruction:
+          "Keep fallback behavior as the default and add a strict config option for the fail-closed behavior.",
+      },
+      {
+        title: "Make the breaking change explicit",
+        body: "Keep fail-closed behavior only if docs, tests, and release notes warn existing fallback users.",
+        category: "fix_before_merge",
+        recommended: false,
+        automergeInstruction: "",
+      },
+      {
+        title: "Do not merge as-is",
+        body: "Pause or close this PR if maintainers do not want to take this compatibility risk.",
+        category: "pause_or_close",
+        recommended: false,
+        automergeInstruction: "",
+      },
+    ],
+  });
 
   assert.match(comment, /\*\*Risk before merge\*\*/);
   assert.match(comment, new RegExp(escapeRegExpForTest(mergeRisk)));
   assert.match(
     comment,
-    /Maintainer choices:\n1\. \(recommended\) Fix the PR before merge with ClawSweeper automerge:/,
+    /Maintainer options:\n1\. \*\*Preserve existing behavior by default \(recommended\)\*\*/,
   );
+  assert.match(comment, /2\. \*\*Make the breaking change explicit\*\*/);
+  assert.match(comment, /3\. \*\*Do not merge as-is\*\*/);
   assert.match(
     comment,
-    /@clawsweeper automerge\nSpecial instructions: Land only after maintainers accept the upgrade behavior for configured fallback users\./,
-  );
-  assert.match(
-    comment,
-    /2\. Accept the merge risk explicitly:[\s\S]*Merge as-is only if maintainers intentionally accept this risk: Land only after maintainers accept the upgrade behavior for configured fallback users\./,
-  );
-  assert.match(
-    comment,
-    /3\. Stop automation and require a human merge decision:[\s\S]*Do not automerge this PR\. Ask a maintainer to decide whether to require changes, merge anyway, or close the PR as not worth the risk: Land only after maintainers accept the upgrade behavior for configured fallback users\./,
+    /<summary>Copy recommended ClawSweeper instruction<\/summary>[\s\S]*@clawsweeper automerge\nSpecial instructions: Keep fallback behavior as the default and add a strict config option for the fail-closed behavior\./,
   );
   assert.doesNotMatch(comment, /Remaining risk \/ open question:/);
+});
+
+test("pull request keep-open review comments can recommend accepting intentional risk without a copy block", () => {
+  const comment = mergeRiskReviewComment({
+    risk: "This hardening intentionally rejects requests that older integrations currently pass.",
+    bestSolution:
+      "Merge only if maintainers accept the compatibility break as intentional hardening.",
+    options: [
+      {
+        title: "Accept the behavior change explicitly",
+        body: "Merge only if maintainers agree the security hardening is worth the compatibility break.",
+        category: "accept_risk",
+        recommended: true,
+        automergeInstruction: "",
+      },
+      {
+        title: "Add migration guidance before merge",
+        body: "Document the rejected request shape and add release-note guidance for affected integrations.",
+        category: "fix_before_merge",
+        recommended: false,
+        automergeInstruction: "",
+      },
+    ],
+  });
+
+  assert.match(comment, /1\. \*\*Accept the behavior change explicitly \(recommended\)\*\*/);
+  assert.doesNotMatch(comment, /Copy recommended ClawSweeper instruction/);
+});
+
+test("pull request keep-open review comments do not force a recommendation for unclear merge risk", () => {
+  const comment = mergeRiskReviewComment({
+    risk: "The PR changes session ownership without proving how existing resumed sessions transition.",
+    options: [
+      {
+        title: "Require a maintainer design decision",
+        body: "Decide whether resumed sessions should migrate, fail fast, or continue using the old ownership model.",
+        category: "pause_or_close",
+        recommended: false,
+        automergeInstruction: "",
+      },
+      {
+        title: "Add migration proof before merge",
+        body: "Add tests or manual validation covering sessions created before this change.",
+        category: "fix_before_merge",
+        recommended: false,
+        automergeInstruction: "",
+      },
+    ],
+  });
+
+  assert.doesNotMatch(comment, /\(recommended\)/);
+  assert.doesNotMatch(comment, /Copy recommended ClawSweeper instruction/);
+});
+
+test("pull request keep-open review comments allow multiple fix-before-merge options", () => {
+  const comment = mergeRiskReviewComment({
+    risk: "The retry path may duplicate queued user messages after partial provider sends.",
+    bestSolution: "Guard retries with delivery state before merge.",
+    options: [
+      {
+        title: "Guard retries with delivery state",
+        body: "Track whether the user message was already sent before retrying provider fallback.",
+        category: "fix_before_merge",
+        recommended: true,
+        automergeInstruction:
+          "Track whether the user message was already sent before retrying provider fallback.",
+      },
+      {
+        title: "Disable fallback after partial sends",
+        body: "Fail fast once delivery starts instead of retrying through another provider.",
+        category: "fix_before_merge",
+        recommended: false,
+        automergeInstruction: "",
+      },
+    ],
+  });
+
+  assert.match(comment, /1\. \*\*Guard retries with delivery state \(recommended\)\*\*/);
+  assert.match(comment, /2\. \*\*Disable fallback after partial sends\*\*/);
+  assert.match(comment, /@clawsweeper automerge/);
+});
+
+test("pull request keep-open review comments include pause or close when risk may outweigh value", () => {
+  const comment = mergeRiskReviewComment({
+    risk: "The PR changes automation proof capture without proving failed paths still upload artifacts.",
+    options: [
+      {
+        title: "Prove artifact parity before merge",
+        body: "Show that artifacts upload on success, failure, and skipped-review paths.",
+        category: "fix_before_merge",
+        recommended: false,
+        automergeInstruction: "",
+      },
+      {
+        title: "Pause or close",
+        body: "Close this PR if maintainers decide the proof-capture regression risk outweighs the workflow cleanup.",
+        category: "pause_or_close",
+        recommended: false,
+        automergeInstruction: "",
+      },
+    ],
+  });
+
+  assert.match(
+    comment,
+    /2\. \*\*Pause or close\*\*  \n   Close this PR if maintainers decide the proof-capture regression risk outweighs the workflow cleanup\./,
+  );
+  assert.doesNotMatch(comment, /Copy recommended ClawSweeper instruction/);
 });
 
 function escapeRegExpForTest(value: string): string {
@@ -4651,6 +4795,95 @@ test("decision parser enforces required schema-shaped evidence", () => {
         mergeRiskLabels: ["merge-risk: 🚨 compatibility", "merge-risk: 🚨 compatibility"],
       }),
     /decision\.mergeRiskLabels must not contain duplicates/,
+  );
+  assert.equal(
+    parseDecision({
+      ...closeDecision(),
+      mergeRiskOptions: undefined,
+    }).mergeRiskOptions.length,
+    0,
+  );
+  assert.throws(
+    () =>
+      parseDecision({
+        ...closeDecision(),
+        mergeRiskOptions: [
+          {
+            title: "Accept the risk",
+            body: "Merge only if maintainers accept this risk.",
+            category: "accept_risk",
+            recommended: false,
+            automergeInstruction: "",
+          },
+        ],
+      }),
+    /decision\.mergeRiskOptions must be empty when mergeRiskLabels is empty/,
+  );
+  assert.throws(
+    () =>
+      parseDecision({
+        ...closeDecision(),
+        mergeRiskLabels: ["merge-risk: 🚨 compatibility"],
+      }),
+    /decision\.mergeRiskOptions must include 1-3 options when mergeRiskLabels is not empty/,
+  );
+  assert.throws(
+    () =>
+      parseDecision({
+        ...closeDecision(),
+        mergeRiskLabels: ["merge-risk: 🚨 compatibility"],
+        mergeRiskOptions: [
+          {
+            title: "Preserve behavior",
+            body: "Keep the existing default behavior before merge.",
+            category: "fix_before_merge",
+            recommended: true,
+            automergeInstruction: "Keep the existing default behavior before merge.",
+          },
+          {
+            title: "Accept risk",
+            body: "Merge only if maintainers accept the compatibility break.",
+            category: "accept_risk",
+            recommended: true,
+            automergeInstruction: "",
+          },
+        ],
+      }),
+    /decision\.mergeRiskOptions must not contain more than one recommended option/,
+  );
+  assert.throws(
+    () =>
+      parseDecision({
+        ...closeDecision(),
+        mergeRiskLabels: ["merge-risk: 🚨 security-boundary"],
+        mergeRiskOptions: [
+          {
+            title: "Accept risk",
+            body: "Merge only if maintainers accept the hardening tradeoff.",
+            category: "accept_risk",
+            recommended: true,
+            automergeInstruction: "Merge the intentional hardening change.",
+          },
+        ],
+      }),
+    /decision\.mergeRiskOptions\[0\]\.automergeInstruction requires fix_before_merge category/,
+  );
+  assert.throws(
+    () =>
+      parseDecision({
+        ...closeDecision(),
+        mergeRiskLabels: ["merge-risk: 🚨 message-delivery"],
+        mergeRiskOptions: [
+          {
+            title: "Guard delivery",
+            body: "Add delivery-state tests before merge.",
+            category: "fix_before_merge",
+            recommended: false,
+            automergeInstruction: "Add delivery-state tests before merge.",
+          },
+        ],
+      }),
+    /decision\.mergeRiskOptions\[0\]\.automergeInstruction requires a recommended option/,
   );
   assert.throws(
     () =>


### PR DESCRIPTION
## Summary
- add structured merge-risk maintainer options to the review decision schema and prompt
- render Risk before merge as prose-first maintainer options, with copyable automerge instructions only for recommended repair paths
- cover repair, accept-risk, unclear decision, multiple repair, and pause/close scenarios

## Validation
- pnpm run check