### PR TITLE
Add label justifications to review details

### DIFF
--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -131,6 +131,13 @@ multiple valid repair paths. Set `automergeInstruction` only for a recommended
 `fix_before_merge` option that ClawSweeper automerge can reasonably execute;
 otherwise set it to an empty string.
 
+Fill `labelJustifications` with one object for every selected ClawSweeper-managed
+label. Include the selected `triagePriority` unless it is `none`, every selected
+`impactLabels` entry, and every selected `mergeRiskLabels` entry. Do not include
+labels that were not selected. Each `reason` should be one concise
+maintainer-facing sentence grounded in the item, diff, current behavior, or
+discussion.
+
 Populate structured reproduction metadata separately from the public prose.
 Use `reproductionStatus: "reproduced"` only when there is a concrete,
 current-main reproduction path for the bug with high confidence. Use
@@ -581,6 +588,10 @@ explain why the risk matters in `risks`, and fill `mergeRiskOptions` with
 decision-useful maintainer options. Use `mergeRiskOptions: []` whenever
 `mergeRiskLabels` is empty. Avoid making ClawSweeper sound more certain than the
 evidence supports.
+
+Always fill `labelJustifications` too. There must be exactly one justification
+for each selected triage priority label, impact label, and merge-risk label, and
+zero justifications for labels ClawSweeper did not select.
 
 Always fill the work-lane fields too. For non-candidates, use
 `workCandidate: "none"`, low confidence/priority, an empty `workPrompt`, and

--- a/schema/clawsweeper-decision.schema.json
+++ b/schema/clawsweeper-decision.schema.json
@@ -16,6 +16,7 @@
     "impactLabels",
     "mergeRiskLabels",
     "mergeRiskOptions",
+    "labelJustifications",
     "itemCategory",
     "reproductionStatus",
     "reproductionConfidence",
@@ -226,6 +227,43 @@
         }
       },
       "description": "Risk-specific maintainer options for the Risk before merge section. Use [] when mergeRiskLabels is []. When mergeRiskLabels is non-empty, provide 1-3 prose-first options. Do not use a fixed menu: tailor titles and bodies to this PR. Mark at most one option recommended, and only when evidence supports a clear best path. Include pause_or_close when the PR may not be worth the risk. Put a copyable @clawsweeper automerge instruction only in automergeInstruction for a recommended fix_before_merge option suitable for automation."
+    },
+    "labelJustifications": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["label", "reason"],
+        "properties": {
+          "label": {
+            "type": "string",
+            "enum": [
+              "P0",
+              "P1",
+              "P2",
+              "P3",
+              "impact:data-loss",
+              "impact:security",
+              "impact:crash-loop",
+              "impact:message-loss",
+              "impact:session-state",
+              "impact:auth-provider",
+              "merge-risk: 🚨 compatibility",
+              "merge-risk: 🚨 message-delivery",
+              "merge-risk: 🚨 session-state",
+              "merge-risk: 🚨 auth-provider",
+              "merge-risk: 🚨 security-boundary",
+              "merge-risk: 🚨 availability",
+              "merge-risk: 🚨 automation"
+            ]
+          },
+          "reason": {
+            "type": "string",
+            "description": "One concise maintainer-facing sentence explaining why this exact selected label applies."
+          }
+        }
+      },
+      "description": "One justification for every selected ClawSweeper-managed triage, impact, and merge-risk label. Include the selected triagePriority unless it is none, every selected impactLabels entry, and every selected mergeRiskLabels entry. Do not include labels that were not selected."
     },
     "itemCategory": {
       "type": "string",

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -81,6 +81,7 @@ type MergeRiskLabelName =
   | "merge-risk: 🚨 availability"
   | "merge-risk: 🚨 automation";
 type MergeRiskOptionCategory = "fix_before_merge" | "accept_risk" | "pause_or_close";
+type ReviewLabelName = Exclude<TriagePriority, "none"> | ImpactLabelName | MergeRiskLabelName;
 type ItemCategory =
   | "bug"
   | "regression"
@@ -314,6 +315,11 @@ interface MergeRiskOption {
   automergeInstruction: string;
 }
 
+export interface LabelJustification {
+  label: ReviewLabelName;
+  reason: string;
+}
+
 interface Decision {
   decision: DecisionKind;
   closeReason: CloseReason;
@@ -328,6 +334,7 @@ interface Decision {
   impactLabels: ImpactLabelName[];
   mergeRiskLabels: MergeRiskLabelName[];
   mergeRiskOptions: MergeRiskOption[];
+  labelJustifications: LabelJustification[];
   itemCategory: ItemCategory;
   reproductionStatus: ReproductionStatus;
   reproductionConfidence: Confidence;
@@ -1069,6 +1076,14 @@ const IMPACT_LABEL_VALUES = new Set<ImpactLabelName>(IMPACT_LABELS.map((label) =
 const MERGE_RISK_LABEL_VALUES = new Set<MergeRiskLabelName>(
   MERGE_RISK_LABELS.map((label) => label.name),
 );
+const REVIEW_LABEL_VALUES = new Set<ReviewLabelName>([
+  "P0",
+  "P1",
+  "P2",
+  "P3",
+  ...IMPACT_LABELS.map((label) => label.name),
+  ...MERGE_RISK_LABELS.map((label) => label.name),
+]);
 const REAL_BEHAVIOR_PROOF_STATUSES = new Set<RealBehaviorProofStatus>([
   "sufficient",
   "missing",
@@ -1132,6 +1147,7 @@ const DECISION_SCHEMA_KEYS = new Set([
   "impactLabels",
   "mergeRiskLabels",
   "mergeRiskOptions",
+  "labelJustifications",
   "itemCategory",
   "reproductionStatus",
   "reproductionConfidence",
@@ -1190,6 +1206,7 @@ const MERGE_RISK_OPTION_SCHEMA_KEYS = new Set([
   "recommended",
   "automergeInstruction",
 ]);
+const LABEL_JUSTIFICATION_SCHEMA_KEYS = new Set(["label", "reason"]);
 const SECURITY_CONCERN_SCHEMA_KEYS = new Set([
   "title",
   "body",
@@ -1704,6 +1721,55 @@ function validateMergeRiskOptions(
   }
 }
 
+function parseLabelJustification(value: unknown, path: string): LabelJustification {
+  const record = requireRecord(value, path);
+  rejectUnexpectedKeys(record, LABEL_JUSTIFICATION_SCHEMA_KEYS, path);
+  const label = requireEnum(record.label, REVIEW_LABEL_VALUES, `${path}.label`);
+  const reason = requireString(record.reason, `${path}.reason`).trim();
+  if (!reason) throw new Error(`${path}.reason must not be empty`);
+  return { label, reason };
+}
+
+function requireLabelJustifications(value: unknown): LabelJustification[] {
+  if (!Array.isArray(value)) throw new Error("decision.labelJustifications must be an array");
+  const justifications = value.map((entry, index) =>
+    parseLabelJustification(entry, `decision.labelJustifications[${index}]`),
+  );
+  const labels = justifications.map((entry) => entry.label);
+  if (new Set(labels).size !== labels.length) {
+    throw new Error("decision.labelJustifications must not contain duplicate labels");
+  }
+  return justifications;
+}
+
+function selectedReviewLabels(
+  decision: Pick<Decision, "triagePriority" | "impactLabels" | "mergeRiskLabels">,
+): ReviewLabelName[] {
+  return [
+    ...(decision.triagePriority === "none" ? [] : [decision.triagePriority]),
+    ...decision.impactLabels,
+    ...decision.mergeRiskLabels,
+  ];
+}
+
+function validateLabelJustifications(
+  decision: Pick<
+    Decision,
+    "triagePriority" | "impactLabels" | "mergeRiskLabels" | "labelJustifications"
+  >,
+): void {
+  const selected = new Set(selectedReviewLabels(decision));
+  const justified = new Set(decision.labelJustifications.map((entry) => entry.label));
+  const missing = [...selected].filter((label) => !justified.has(label));
+  if (missing.length) {
+    throw new Error(`decision.labelJustifications missing selected labels: ${missing.join(", ")}`);
+  }
+  const extra = [...justified].filter((label) => !selected.has(label));
+  if (extra.length) {
+    throw new Error(`decision.labelJustifications contains unselected labels: ${extra.join(", ")}`);
+  }
+}
+
 function isEnvironmentAccessCaveat(value: string): boolean {
   return /(?:GH_TOKEN|GITHUB_TOKEN|authenticated gh|gh (?:was |is )?unavailable|unauthenticated gh|shallow clone|GitHub auth(?:entication)? (?:was |is )?unavailable|could not use authenticated GitHub)/i.test(
     value,
@@ -1803,6 +1869,7 @@ function normalizeDecisionForItem(
     bestSolution: CLEAN_OPENCLAW_PR_REVIEW_NEXT_STEP,
     triagePriority: decision.triagePriority,
     mergeRiskOptions: decision.mergeRiskOptions,
+    labelJustifications: decision.labelJustifications,
     overallCorrectness:
       decision.overallCorrectness === "patch is incorrect"
         ? "patch is correct"
@@ -1948,6 +2015,7 @@ export function parseDecision(value: unknown, item?: DecisionNormalizationItem):
     impactLabels: requireImpactLabels(record.impactLabels),
     mergeRiskLabels: requireMergeRiskLabels(record.mergeRiskLabels),
     mergeRiskOptions: requireMergeRiskOptions(record.mergeRiskOptions),
+    labelJustifications: requireLabelJustifications(record.labelJustifications),
     itemCategory: requireEnum(record.itemCategory, ITEM_CATEGORIES, "decision.itemCategory"),
     reproductionStatus: requireEnum(
       record.reproductionStatus,
@@ -2011,6 +2079,7 @@ export function parseDecision(value: unknown, item?: DecisionNormalizationItem):
     workLikelyFiles: requireStringArray(record.workLikelyFiles, "decision.workLikelyFiles"),
   };
   validateMergeRiskOptions(decision);
+  validateLabelJustifications(decision);
   return normalizeDecisionForItem(decision, item);
 }
 
@@ -4374,6 +4443,7 @@ function codexFailureDecision(status: number | null, stderr: string, stdout = ""
     impactLabels: [],
     mergeRiskLabels: [],
     mergeRiskOptions: [],
+    labelJustifications: [],
     itemCategory: "unclear",
     reproductionStatus: "unclear",
     reproductionConfidence: "low",
@@ -5617,6 +5687,30 @@ function mergeRiskOptionsFromReport(markdown: string): MergeRiskOption[] {
       }
     })
     .filter((entry): entry is MergeRiskOption => Boolean(entry));
+}
+
+function labelJustificationsFromReport(
+  markdown: string,
+  labels: Pick<Decision, "triagePriority" | "impactLabels" | "mergeRiskLabels">,
+): LabelJustification[] {
+  const selected = new Set(selectedReviewLabels(labels));
+  const fromFrontMatter = frontMatterJsonArray(markdown, "label_justifications")
+    .map((entry, index) => {
+      try {
+        return parseLabelJustification(entry, `label_justifications[${index}]`);
+      } catch {
+        return null;
+      }
+    })
+    .filter((entry): entry is LabelJustification => Boolean(entry))
+    .filter((entry) => selected.has(entry.label));
+  const byLabel = new Map(fromFrontMatter.map((entry) => [entry.label, entry]));
+  return selectedReviewLabels(labels).map((label) => ({
+    label,
+    reason:
+      byLabel.get(label)?.reason ??
+      "Older review report did not store a label-specific justification.",
+  }));
 }
 
 function reportReviewFindings(markdown: string): ReviewFinding[] {
@@ -6890,10 +6984,15 @@ function reportDecision(markdown: string, closeReason: CloseReason): Decision {
     likelyOwners: reportLikelyOwners(markdown),
     risks: [],
     bestSolution: reviewSectionValue(markdown, "bestSolution"),
-    triagePriority: triagePriorityFromReport(markdown),
-    impactLabels: impactLabelsFromReport(markdown),
-    mergeRiskLabels: mergeRiskLabelsFromReport(markdown),
+    triagePriority,
+    impactLabels,
+    mergeRiskLabels,
     mergeRiskOptions: mergeRiskOptionsFromReport(markdown),
+    labelJustifications: labelJustificationsFromReport(markdown, {
+      triagePriority,
+      impactLabels,
+      mergeRiskLabels,
+    }),
     itemCategory:
       (frontMatterValue(markdown, "item_category") as ItemCategory | undefined) ?? "unclear",
     reproductionStatus:
@@ -6954,6 +7053,17 @@ function formattedMarkdownList(
   formatter: (value: string) => string,
 ): string {
   return values.length ? values.map((value) => `- ${formatter(value)}`).join("\n") : "- none";
+}
+
+function labelJustificationsMarkdown(justifications: readonly LabelJustification[]): string {
+  if (!justifications.length) return "- none";
+  return justifications.map((entry) => `- ${inlineCode(entry.label)}: ${entry.reason}`).join("\n");
+}
+
+export function labelJustificationsMarkdownForTest(
+  justifications: readonly LabelJustification[],
+): string {
+  return labelJustificationsMarkdown(justifications);
 }
 
 function inlineCode(value: string): string {
@@ -8564,6 +8674,7 @@ triage_priority: ${options.decision.triagePriority}
 impact_labels: ${jsonFrontMatterValue(options.decision.impactLabels)}
 merge_risk_labels: ${jsonFrontMatterValue(options.decision.mergeRiskLabels)}
 merge_risk_options: ${JSON.stringify(options.decision.mergeRiskOptions)}
+label_justifications: ${JSON.stringify(options.decision.labelJustifications)}
 pull_files: ${jsonFrontMatterValue(pullFiles)}
 pull_files_truncated: ${pullFilesTruncated}
 item_category: ${options.decision.itemCategory}
@@ -8618,6 +8729,10 @@ ${options.decision.decision === "close" ? "Close" : "Keep open"}: ${closeReasonT
 Confidence: ${options.decision.confidence}
 
 Action taken: ${options.action.actionTaken}
+
+## Label Justifications
+
+${labelJustificationsMarkdown(options.decision.labelJustifications)}
 
 ## ${REVIEW_SECTIONS.summary}
 

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -6974,6 +6974,9 @@ function reportDecision(markdown: string, closeReason: CloseReason): Decision {
   const fixedRelease = frontMatterValue(markdown, "fixed_release");
   const fixedSha = frontMatterValue(markdown, "fixed_sha");
   const fixedAt = frontMatterValue(markdown, "fixed_at");
+  const triagePriority = triagePriorityFromReport(markdown);
+  const impactLabels = impactLabelsFromReport(markdown);
+  const mergeRiskLabels = mergeRiskLabelsFromReport(markdown);
   return {
     decision: "close",
     closeReason,

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -46,6 +46,7 @@ import {
   isMissingGitHubLabelErrorForTest,
   issueAdvisoryLabelsForTest,
   isProtectedItem,
+  labelJustificationsMarkdownForTest,
   itemNumbersArg,
   lockedConversationApplyReason,
   makeTreeReadOnlyForTest,
@@ -178,6 +179,12 @@ function closeDecision(overrides = {}) {
     impactLabels: [],
     mergeRiskLabels: [],
     mergeRiskOptions: [],
+    labelJustifications: [
+      {
+        label: "P2",
+        reason: "Normal priority applies to this limited-scope implemented behavior check.",
+      },
+    ],
     itemCategory: "bug",
     reproductionStatus: "reproduced",
     reproductionConfidence: "high",
@@ -4885,6 +4892,44 @@ test("decision parser enforces required schema-shaped evidence", () => {
       }),
     /decision\.mergeRiskOptions\[0\]\.automergeInstruction requires a recommended option/,
   );
+  assert.throws(() => {
+    const decision = closeDecision();
+    delete decision.labelJustifications;
+    return parseDecision(decision);
+  }, /decision\.labelJustifications must be an array/);
+  assert.throws(
+    () =>
+      parseDecision({
+        ...closeDecision({
+          impactLabels: ["impact:message-loss"],
+          labelJustifications: [
+            {
+              label: "P2",
+              reason: "Normal priority applies to this limited-scope implemented behavior check.",
+            },
+          ],
+        }),
+      }),
+    /decision\.labelJustifications missing selected labels: impact:message-loss/,
+  );
+  assert.throws(
+    () =>
+      parseDecision({
+        ...closeDecision({
+          labelJustifications: [
+            {
+              label: "P2",
+              reason: "Normal priority applies to this limited-scope implemented behavior check.",
+            },
+            {
+              label: "impact:data-loss",
+              reason: "The selected labels did not include this impact area.",
+            },
+          ],
+        }),
+      }),
+    /decision\.labelJustifications contains unselected labels: impact:data-loss/,
+  );
   assert.throws(
     () =>
       parseDecision({
@@ -5257,6 +5302,30 @@ test("ClawSweeper priority labels follow triage priority", () => {
   assert.deepEqual(priorityLabelsForTest(["P0", "bug"], "none"), ["bug"]);
 });
 
+test("ClawSweeper label justifications render selected label reasons", () => {
+  assert.equal(
+    labelJustificationsMarkdownForTest([
+      {
+        label: "P1",
+        reason: "The PR changes an active channel workflow affecting real users.",
+      },
+      {
+        label: "impact:message-loss",
+        reason: "The diff touches message retry and delivery ordering.",
+      },
+      {
+        label: "merge-risk: 🚨 compatibility",
+        reason: "Merging changes the default upgrade behavior for existing configs.",
+      },
+    ]),
+    [
+      "- `P1`: The PR changes an active channel workflow affecting real users.",
+      "- `impact:message-loss`: The diff touches message retry and delivery ordering.",
+      "- `merge-risk: 🚨 compatibility`: Merging changes the default upgrade behavior for existing configs.",
+    ].join("\n"),
+  );
+});
+
 test("ClawSweeper impact label scheme exposes owned impact labels", () => {
   assert.deepEqual(impactLabelSchemeForTest(), [
     {
@@ -5442,6 +5511,20 @@ test("ClawSweeper impact labels do not alter PR review finding priorities", () =
   const decision = parseDecision(
     closeDecision({
       impactLabels: ["impact:data-loss", "impact:security"],
+      labelJustifications: [
+        {
+          label: "P2",
+          reason: "Normal priority applies to this limited-scope implemented behavior check.",
+        },
+        {
+          label: "impact:data-loss",
+          reason: "The selected labels include a data-loss impact classification.",
+        },
+        {
+          label: "impact:security",
+          reason: "The selected labels include a security impact classification.",
+        },
+      ],
       reviewFindings: [
         {
           title: "A concrete review finding",


### PR DESCRIPTION
## Summary
- require review decisions to include one label justification for each selected ClawSweeper-managed priority, impact, and merge-risk label
- store label justifications in report frontmatter and render them in review details
- add parser/rendering tests for the new invariant

## Validation
- pnpm run check