### PR TITLE
Emphasize merge-risk maintainer options heading

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -7420,7 +7420,7 @@ function publicMergeRiskLine(
     : mergeRiskFallbackOptionsLines(bestSolutionLine, nextStepLine);
   return [
     `Why this matters: ${risks}`,
-    choices.length ? ["", "Maintainer options:", ...choices].join("\n") : "",
+    choices.length ? ["", "**Maintainer options:**", ...choices].join("\n") : "",
   ]
     .filter(Boolean)
     .join("\n");

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -4342,7 +4342,7 @@ test("pull request keep-open review comments render repairable merge-risk option
   assert.match(comment, new RegExp(escapeRegExpForTest(mergeRisk)));
   assert.match(
     comment,
-    /Maintainer options:\n1\. \*\*Preserve existing behavior by default \(recommended\)\*\*/,
+    /\*\*Maintainer options:\*\*\n1\. \*\*Preserve existing behavior by default \(recommended\)\*\*/,
   );
   assert.match(comment, /2\. \*\*Make the breaking change explicit\*\*/);
   assert.match(comment, /3\. \*\*Do not merge as-is\*\*/);


### PR DESCRIPTION
## Summary
- render the Risk before merge maintainer options subheading in bold
- update the public comment assertion for the emphasized heading

## Validation
- pnpm run build && pnpm run test:unit -- --test-name-pattern="pull request keep-open review comments render repairable merge-risk options"
- pnpm run check