### PR TITLE
Clean merge-risk automerge copy block

### DIFF
--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -129,7 +129,9 @@ risk, and `category: "pause_or_close"` when the PR may need to pause or close as
 not worth the risk. Multiple fix-before-merge options are allowed when there are
 multiple valid repair paths. Set `automergeInstruction` only for a recommended
 `fix_before_merge` option that ClawSweeper automerge can reasonably execute;
-otherwise set it to an empty string.
+otherwise set it to an empty string. `automergeInstruction` must be only the
+special-instructions payload. Do not include a bot mention or command such as
+`@clawsweeper automerge`, `@clawsweeper autofix`, or `this PR:`.
 
 Fill `labelJustifications` with one object for every selected ClawSweeper-managed
 label. Include the selected `triagePriority` unless it is `none`, every selected

--- a/schema/clawsweeper-decision.schema.json
+++ b/schema/clawsweeper-decision.schema.json
@@ -222,11 +222,11 @@
           },
           "automergeInstruction": {
             "type": "string",
-            "description": "Only for a recommended fix_before_merge option suitable for automation; otherwise empty."
+            "description": "Only for a recommended fix_before_merge option suitable for automation; otherwise empty. This must be only the special-instructions payload, without @clawsweeper automerge, @clawsweeper autofix, or this PR command text."
           }
         }
       },
-      "description": "Risk-specific maintainer options for the Risk before merge section. Use [] when mergeRiskLabels is []. When mergeRiskLabels is non-empty, provide 1-3 prose-first options. Do not use a fixed menu: tailor titles and bodies to this PR. Mark at most one option recommended, and only when evidence supports a clear best path. Include pause_or_close when the PR may not be worth the risk. Put a copyable @clawsweeper automerge instruction only in automergeInstruction for a recommended fix_before_merge option suitable for automation."
+      "description": "Risk-specific maintainer options for the Risk before merge section. Use [] when mergeRiskLabels is []. When mergeRiskLabels is non-empty, provide 1-3 prose-first options. Do not use a fixed menu: tailor titles and bodies to this PR. Mark at most one option recommended, and only when evidence supports a clear best path. Include pause_or_close when the PR may not be worth the risk. Put only the special-instructions payload in automergeInstruction for a recommended fix_before_merge option suitable for automation; do not include @clawsweeper automerge, @clawsweeper autofix, or this PR command text."
     },
     "labelJustifications": {
       "type": "array",

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -7578,17 +7578,30 @@ function mergeRiskOptionsLines(options: readonly MergeRiskOption[]): string[] {
 }
 
 function mergeRiskAutomergeInstructionBlock(instruction: string): string {
+  const specialInstructions = normalizeMergeRiskAutomergeInstruction(instruction);
+  if (!specialInstructions) return "";
   return [
     "<details>",
-    "<summary>Copy recommended ClawSweeper instruction</summary>",
+    "<summary>Copy recommended automerge instruction</summary>",
     "",
     "```text",
     "@clawsweeper automerge",
-    `Special instructions: ${instruction}`,
+    "",
+    "Special instructions:",
+    specialInstructions,
     "```",
     "",
     "</details>",
   ].join("\n");
+}
+
+function normalizeMergeRiskAutomergeInstruction(instruction: string): string {
+  return instruction
+    .trim()
+    .replace(/^@clawsweeper\s+(?:automerge|autofix)\b[:\s-]*/i, "")
+    .replace(/^special instructions:\s*/i, "")
+    .replace(/^this PR:\s*/i, "")
+    .trim();
 }
 
 function issueReproductionHelpSuggestions(markdown: string): string[] {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -4355,9 +4355,33 @@ test("pull request keep-open review comments render repairable merge-risk option
   assert.match(comment, /3\. \*\*Do not merge as-is\*\*/);
   assert.match(
     comment,
-    /<summary>Copy recommended ClawSweeper instruction<\/summary>[\s\S]*@clawsweeper automerge\nSpecial instructions: Keep fallback behavior as the default and add a strict config option for the fail-closed behavior\./,
+    /<summary>Copy recommended automerge instruction<\/summary>[\s\S]*@clawsweeper automerge\n\nSpecial instructions:\nKeep fallback behavior as the default and add a strict config option for the fail-closed behavior\./,
   );
   assert.doesNotMatch(comment, /Remaining risk \/ open question:/);
+});
+
+test("pull request keep-open review comments strip nested ClawSweeper commands from copy block", () => {
+  const comment = mergeRiskReviewComment({
+    risk: "Delivery repair should not run with nested bot commands in the pasteable instruction.",
+    bestSolution: "Repair duplicate delivery and add regression coverage before merge.",
+    options: [
+      {
+        title: "Repair delivery before merge",
+        body: "Fix duplicate active-requester delivery and add regression coverage before merge.",
+        category: "fix_before_merge",
+        recommended: true,
+        automergeInstruction:
+          "@clawsweeper autofix this PR: prevent duplicate active-requester delivery and add focused regression coverage before merging.",
+      },
+    ],
+  });
+
+  assert.match(
+    comment,
+    /@clawsweeper automerge\n\nSpecial instructions:\nprevent duplicate active-requester delivery and add focused regression coverage before merging\./,
+  );
+  assert.doesNotMatch(comment, /Special instructions: @clawsweeper/);
+  assert.doesNotMatch(comment, /autofix this PR:/);
 });
 
 test("pull request keep-open review comments can recommend accepting intentional risk without a copy block", () => {


### PR DESCRIPTION
## Summary
- render merge-risk automerge copy blocks as one pasteable @clawsweeper automerge command
- put special instructions on their own body lines
- strip accidental nested @clawsweeper autofix/automerge prefixes from model-provided instructions

## Validation
- pnpm run check