### PR TITLE
fix(review): note applied PR closes

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -7993,6 +7993,10 @@ function reviewCommentMarker(number: number): string {
   return `${REVIEW_COMMENT_MARKER_PREFIX} item=${number} -->`;
 }
 
+function closeAppliedCommentMarker(number: number): string {
+  return `<!-- clawsweeper-close-applied item=${number} -->`;
+}
+
 function pullHeadShaFromContext(context: ItemContext): string | null {
   const pull = asRecord(context.pullRequest);
   const head = asRecord(pull.head);
@@ -8306,6 +8310,76 @@ function upsertReviewComment(
     ]);
   }
   return issueReviewComment(number, [markedBody]);
+}
+
+function issueCommentWithMarker(
+  number: number,
+  marker: string,
+): Record<string, unknown> | undefined {
+  const comments = ghPaged<unknown>(`repos/${targetRepo()}/issues/${number}/comments`).map(
+    asRecord,
+  );
+  return comments.find((candidate) => {
+    const body = candidate.body;
+    return typeof body === "string" && body.includes(marker);
+  });
+}
+
+function closeAppliedEvidenceLink(markdown: string, itemUrl: string): string {
+  const reviewCommentUrl = frontMatterValue(markdown, "review_comment_url");
+  if (reviewCommentUrl && reviewCommentUrl !== "unknown") {
+    return markdownLink("durable ClawSweeper review", reviewCommentUrl);
+  }
+  const fixedPrUrl = frontMatterValue(markdown, "fixed_pr_url");
+  const fixedPrNumber = frontMatterValue(markdown, "fixed_pr_number");
+  if (fixedPrUrl && fixedPrUrl !== "unknown") {
+    const label =
+      fixedPrNumber && fixedPrNumber !== "unknown" ? `fix PR #${fixedPrNumber}` : "fix PR";
+    return markdownLink(label, fixedPrUrl);
+  }
+  return markdownLink("closed PR", itemUrl);
+}
+
+function renderCloseAppliedComment(options: {
+  number: number;
+  closeReason: CloseReason;
+  markdown: string;
+  itemUrl: string;
+}): string {
+  return [
+    "ClawSweeper applied the proposed close for this PR.",
+    "",
+    "- Action: closed this PR.",
+    `- Close reason: ${closeReasonText(options.closeReason)}.`,
+    `- Evidence: ${closeAppliedEvidenceLink(options.markdown, options.itemUrl)}.`,
+    "",
+    closeAppliedCommentMarker(options.number),
+  ].join("\n");
+}
+
+function ensureCloseAppliedComment(options: {
+  number: number;
+  closeReason: CloseReason;
+  markdown: string;
+  itemUrl: string;
+  dryRun: boolean;
+}): string {
+  const marker = closeAppliedCommentMarker(options.number);
+  if (issueCommentWithMarker(options.number, marker)) {
+    return "matching ClawSweeper close-applied comment already exists";
+  }
+  const body = renderCloseAppliedComment(options);
+  if (options.dryRun) return "dry-run: would post close-applied comment";
+  const payload = writeCommentPayload(options.number, body);
+  ghWithRetry([
+    "api",
+    `repos/${targetRepo()}/issues/${options.number}/comments`,
+    "--method",
+    "POST",
+    "--input",
+    payload,
+  ]);
+  return "posted close-applied comment";
 }
 
 function postReviewStartStatusComment(options: {
@@ -9557,17 +9631,42 @@ function applyDecisionsCommand(args: Args): void {
     }
     logProgress(`closing #${number}`);
     if (dryRun) {
+      const closeAppliedCommentReason =
+        item.kind === "pull_request"
+          ? ensureCloseAppliedComment({
+              number,
+              closeReason,
+              markdown,
+              itemUrl: item.url,
+              dryRun,
+            })
+          : null;
       closedCount += 1;
       processedCount += 1;
       results.push({
         number,
         action: "closed",
-        reason: `dry-run: would close as ${closeReasonText(closeReason)}`,
+        reason: [
+          `dry-run: would close as ${closeReasonText(closeReason)}`,
+          closeAppliedCommentReason,
+        ]
+          .filter(Boolean)
+          .join("; "),
       });
       logProgress(`would close #${number}`);
       if (processedCount >= processedLimit) break;
       continue;
     }
+    const closeAppliedCommentReason =
+      item.kind === "pull_request"
+        ? ensureCloseAppliedComment({
+            number,
+            closeReason,
+            markdown,
+            itemUrl: item.url,
+            dryRun,
+          })
+        : null;
     closeItem({ number, kind: item.kind, reason: closeReason });
     sleepMs(closeDelayMs);
     markdown = replaceSectionValue(markdown, REVIEW_SECTIONS.closeComment, reviewComment);
@@ -9577,7 +9676,11 @@ function applyDecisionsCommand(args: Args): void {
     archiveClosed(markdown);
     closedCount += 1;
     processedCount += 1;
-    results.push({ number, action: "closed", reason: closeReasonText(closeReason) });
+    results.push({
+      number,
+      action: "closed",
+      reason: [closeReasonText(closeReason), closeAppliedCommentReason].filter(Boolean).join("; "),
+    });
     logProgress(`closed #${number}`);
     if (processedCount >= processedLimit) break;
   }

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -3751,6 +3751,161 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
   }
 });
 
+test("apply-decisions posts an explicit close-time note before closing PR proposals", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const logPath = join(root, "gh.log");
+    const postedBodiesPath = join(root, "posted-bodies.jsonl");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const closeReport = `${workPlanCandidateReport({
+      type: "pull_request",
+      decision: "close",
+      action_taken: "proposed_close",
+      close_reason: "implemented_on_main",
+      confidence: "high",
+      item_snapshot_hash: "reviewed-snapshot",
+      item_updated_at: "2026-05-01T00:00:00Z",
+      reproduction_status: "reproduced",
+      reproduction_confidence: "high",
+      fixed_pr_url: "https://github.com/openclaw/clawsweeper/pull/900",
+      fixed_pr_number: "900",
+      fixed_sha: "1234567890abcdef1234567890abcdef12345678",
+      fixed_at: "2026-05-01T02:00:00Z",
+    })}\n\n## Evidence\n\n- **main fix:** git show confirms current main has the replacement implementation and it is not in the latest release yet\n  - file: [src/clawsweeper.ts](https://github.com/openclaw/clawsweeper/blob/1234567890abcdef1234567890abcdef12345678/src/clawsweeper.ts)\n  - sha: [1234567890ab](https://github.com/openclaw/clawsweeper/commit/1234567890abcdef1234567890abcdef12345678)\n\n## Close Comment\n\nClosing this PR because the fix is already on main.\n`;
+    const synced = reportWithSyncedReviewComment(closeReport, 321, "implemented_on_main");
+    writeFileSync(join(itemsDir, "321.md"), synced.report, "utf8");
+
+    const ghMock = `
+const { appendFileSync, readFileSync } = require("fs");
+const logPath = ${JSON.stringify(logPath)};
+const postedBodiesPath = ${JSON.stringify(postedBodiesPath)};
+const comment = ${JSON.stringify(synced.comment)};
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+appendFileSync(logPath, JSON.stringify(args) + "\\n");
+const path = args[1] || "";
+if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$)/.test(args[2] || "")) {
+  console.log("HTTP/2 200\\n\\n[]");
+} else if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
+  if (args.includes("--method") && args.includes("POST")) {
+    const input = args[args.indexOf("--input") + 1];
+    const payload = JSON.parse(readFileSync(input, "utf8"));
+    appendFileSync(postedBodiesPath, JSON.stringify(payload.body) + "\\n");
+    console.log(JSON.stringify({ id: 9322, html_url: "https://github.com/openclaw/clawsweeper/pull/321#issuecomment-9322" }));
+  } else {
+    console.log(JSON.stringify([[{
+      id: 9321,
+      html_url: "https://github.com/openclaw/clawsweeper/pull/321#issuecomment-9321",
+      created_at: "2026-05-01T01:00:00Z",
+      updated_at: "2026-05-01T01:00:00Z",
+      user: { login: "clawsweeper[bot]" },
+      body: comment
+    }]]));
+  }
+} else if (args[0] === "api" && /\\/issues\\/comments\\/9321$/.test(path)) {
+  console.log(JSON.stringify({ id: 9321, html_url: "https://github.com/openclaw/clawsweeper/pull/321#issuecomment-9321" }));
+} else if (args[0] === "api" && /\\/issues\\/321\\/timeline(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 321,
+    title: "Render work plans",
+    html_url: "https://github.com/openclaw/clawsweeper/pull/321",
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "reporter" },
+    labels: [],
+    comments: 1,
+    pull_request: { url: "https://api.github.com/repos/openclaw/clawsweeper/pulls/321" }
+  }));
+} else if (args[0] === "api" && /\\/pulls\\/321$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 321,
+    html_url: "https://github.com/openclaw/clawsweeper/pull/321",
+    state: "open",
+    changed_files: 0,
+    commits: 0,
+    review_comments: 0,
+    head: { sha: "head-sha", ref: "branch", repo: { full_name: "fork/clawsweeper" } },
+    base: { sha: "base-sha", ref: "main", repo: { full_name: "openclaw/clawsweeper" } },
+    user: { login: "reporter" }
+  }));
+} else if (args[0] === "api" && /\\/pulls\\/321\\/(files|commits|comments)(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "pr" && args[1] === "close" && args[2] === "321") {
+  console.log("");
+} else if (args[0] === "issue" && args[1] === "edit") {
+  console.log("");
+} else if (args[0] === "label") {
+  console.log("");
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: ["--apply-kind", "all", "--processed-limit", "2"],
+      });
+    });
+
+    const calls = readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as string[]);
+    const postIndex = calls.findIndex(
+      (args) =>
+        args[0] === "api" &&
+        (args[1] ?? "").endsWith("/issues/321/comments") &&
+        args.includes("POST"),
+    );
+    const closeIndex = calls.findIndex(
+      (args) => args[0] === "pr" && args[1] === "close" && args[2] === "321",
+    );
+    assert.ok(postIndex >= 0);
+    assert.ok(closeIndex > postIndex);
+    const postedBodies = readFileSync(postedBodiesPath, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as string);
+    assert.equal(postedBodies.length, 1);
+    assert.match(postedBodies[0], /ClawSweeper applied the proposed close for this PR/);
+    assert.match(postedBodies[0], /Close reason: already implemented on main/);
+    assert.match(postedBodies[0], /durable ClawSweeper review/);
+    assert.match(postedBodies[0], /clawsweeper-close-applied item=321/);
+    assert.ok(existsSync(join(closedDir, "321.md")));
+    assert.deepEqual(JSON.parse(readFileSync(reportPath, "utf8")), [
+      {
+        number: 321,
+        action: "review_comment_synced",
+        reason: "updated durable Codex review comment",
+      },
+      {
+        number: 321,
+        action: "closed",
+        reason: "already implemented on main; posted close-applied comment",
+      },
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("apply-decisions skips advisory labels for failed or stale kept-open reports", () => {
   const root = mkdtempSync(tmpPrefix);
   try {


### PR DESCRIPTION
## Summary
- post a marker-backed close-applied note before ClawSweeper closes a PR
- include the close action, close reason, and durable review/fix evidence link
- cover the close-before-note ordering with an apply-decisions regression test

## Validation
- pnpm run build && pnpm run test:unit -- --test-name-pattern="apply-decisions posts an explicit close-time note"
- pnpm run check