### PR TITLE
fix(review): show label justifications in comments

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -7069,6 +7069,14 @@ export function labelJustificationsMarkdownForTest(
   return labelJustificationsMarkdown(justifications);
 }
 
+function labelJustificationsFromPublicReport(markdown: string): LabelJustification[] {
+  return labelJustificationsFromReport(markdown, {
+    triagePriority: triagePriorityFromReport(markdown),
+    impactLabels: impactLabelsFromReport(markdown),
+    mergeRiskLabels: mergeRiskLabelsFromReport(markdown),
+  });
+}
+
 function inlineCode(value: string): string {
   return `\`${value.replaceAll("`", "\\`")}\``;
 }
@@ -7777,6 +7785,10 @@ function renderKeepOpenCommentFromReport(markdown: string): string {
     details.push("Best possible solution:", "", bestSolutionLine);
   }
   appendReviewQuestionDetails(details, reproductionAssessment, solutionAssessment);
+  const labelJustifications = labelJustificationsFromPublicReport(markdown);
+  if (labelJustifications.length) {
+    details.push("", "Label justifications:", "", labelJustificationsMarkdown(labelJustifications));
+  }
   if (isPullRequest && reviewFindings.length) {
     details.push(
       "",

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2659,6 +2659,85 @@ Full review comments:
   assert.doesNotMatch(markers, /clawsweeper-verdict:needs-human/);
 });
 
+test("public PR review comments include label justifications in review details", () => {
+  const report = `${reportFrontMatter({
+    type: "pull_request",
+    number: "74461",
+    decision: "keep_open",
+    close_reason: "none",
+    review_status: "complete",
+    confidence: "high",
+    author: "contributor",
+    author_association: "CONTRIBUTOR",
+    labels: JSON.stringify([]),
+    work_candidate: "none",
+    triage_priority: "P1",
+    impact_labels: JSON.stringify(["impact:message-loss"]),
+    merge_risk_labels: JSON.stringify(["merge-risk: 🚨 compatibility"]),
+    label_justifications: JSON.stringify([
+      {
+        label: "P1",
+        reason: "The PR changes an active channel workflow affecting real users.",
+      },
+      {
+        label: "impact:message-loss",
+        reason: "The diff touches message retry and delivery ordering.",
+      },
+      {
+        label: "merge-risk: 🚨 compatibility",
+        reason: "Merging changes the default upgrade behavior for existing configs.",
+      },
+    ]),
+  })}
+
+## Summary
+
+Keep this PR open for maintainer review.
+
+## What This Changes
+
+Changes message delivery behavior.
+
+## Best Possible Solution
+
+Review the compatibility impact before merge.
+
+## Risks
+
+Compatibility risk remains for existing configs.
+
+${realBehaviorProofReportSection({
+  status: "insufficient",
+  needsContributorAction: true,
+  summary: "The PR has tests but no real setup proof yet.",
+})}
+
+## Review Findings
+
+Overall correctness: patch is correct
+
+Overall confidence: 0.8
+
+Full review comments:
+
+- none
+`;
+
+  const comment = renderReviewCommentFromReport(report, "none");
+
+  assert.match(comment, /<details>\n<summary>Review details<\/summary>/);
+  assert.match(comment, /Label justifications:/);
+  assert.match(comment, /- `P1`: The PR changes an active channel workflow affecting real users\./);
+  assert.match(
+    comment,
+    /- `impact:message-loss`: The diff touches message retry and delivery ordering\./,
+  );
+  assert.match(
+    comment,
+    /- `merge-risk: 🚨 compatibility`: Merging changes the default upgrade behavior for existing configs\./,
+  );
+});
+
 test("media proof receives a shiny proof rating boost", () => {
   const report = `${reportFrontMatter({
     type: "pull_request",


### PR DESCRIPTION
## Summary
- render selected label justifications in the public ClawSweeper review comment details
- reuse the report frontmatter label parsing path for priority, impact, and merge-risk labels
- add a public comment regression test through renderReviewCommentFromReport

## Validation
- pnpm run build
- node --test --test-name-pattern "public PR review comments include label justifications|ClawSweeper label justifications render selected label reasons" test/clawsweeper.test.ts
- pnpm run check