### PR TITLE
feat(labels): add PR status labels

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -6285,6 +6285,7 @@ function hasRecentReReviewRequest(
   const reviewedAtMs = timestampMs(reviewedAt);
   return context.comments.some((comment) => {
     const record = asRecord(comment);
+    if (isAutomationReportAuthor(stringOrUndefined(record.author))) return false;
     return isAfterReview(comment, reviewedAtMs) && isReReviewRequestText(record.body);
   });
 }
@@ -6321,6 +6322,7 @@ function hasRecentAuthorActivity(
 function prStatusLabelKindFromReport(
   markdown: string,
   context: ItemContext,
+  currentLabels: readonly string[],
 ): PrStatusLabelKind | null {
   if (frontMatterValue(markdown, "type") !== "pull_request") return null;
   return prStatusLabelKind({
@@ -6328,7 +6330,7 @@ function prStatusLabelKindFromReport(
     reviewFindings: reportReviewFindings(markdown),
     securityReview: reportSecurityReview(markdown),
     overallCorrectness: reportOverallCorrectness(markdown),
-    hasAutomergeLabel: frontMatterStringArray(markdown, "labels").includes(AUTOMERGE_LABEL),
+    hasAutomergeLabel: currentLabels.includes(AUTOMERGE_LABEL),
     hasRecentReReviewRequest: hasRecentReReviewRequest(
       context,
       frontMatterValue(markdown, "reviewed_at"),
@@ -6352,9 +6354,22 @@ export function prStatusLabelsForTest(
     hasAutomergeLabel?: boolean;
     hasRecentReReviewRequest?: boolean;
     hasRecentAuthorActivity?: boolean;
+    reviewedAt?: string;
+    comments?: readonly {
+      author?: string;
+      body?: string;
+      createdAt?: string;
+      updatedAt?: string;
+    }[];
   },
 ): string[] {
   if (options.isPullRequest === false) return nextPrStatusLabels(labels, null);
+  const hasRecentReReviewRequestValue =
+    options.hasRecentReReviewRequest ??
+    hasRecentReReviewRequest(
+      { comments: [...(options.comments ?? [])] },
+      options.reviewedAt ?? "2026-01-01T00:00:00Z",
+    );
   const statusKind = prStatusLabelKind({
     realBehaviorProof: {
       status: REAL_BEHAVIOR_PROOF_STATUSES.has(options.proofStatus as RealBehaviorProofStatus)
@@ -6374,8 +6389,8 @@ export function prStatusLabelsForTest(
     )
       ? (options.overallCorrectness as OverallCorrectness)
       : "patch is correct",
-    hasAutomergeLabel: options.hasAutomergeLabel === true,
-    hasRecentReReviewRequest: options.hasRecentReReviewRequest === true,
+    hasAutomergeLabel: options.hasAutomergeLabel ?? labels.includes(AUTOMERGE_LABEL),
+    hasRecentReReviewRequest: hasRecentReReviewRequestValue,
     hasRecentAuthorActivity: options.hasRecentAuthorActivity === true,
   });
   return nextPrStatusLabels(labels, statusKind);
@@ -9632,7 +9647,7 @@ function applyDecisionsCommand(args: Args): void {
       item.labels = syncPrStatusLabel({
         number,
         labels: item.labels,
-        statusKind: prStatusLabelKindFromReport(markdown, currentItemContext()),
+        statusKind: prStatusLabelKindFromReport(markdown, currentItemContext(), item.labels),
         dryRun,
       });
       item.labels = syncTelegramVisibleProofLabel({

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -119,6 +119,12 @@ type RealBehaviorProofEvidenceKind =
   | "none"
   | "not_applicable";
 type PrRatingTier = "S" | "A" | "B" | "C" | "D" | "F" | "NA";
+type PrStatusLabelKind =
+  | "re_review_loop"
+  | "actively_grinding"
+  | "needs_proof"
+  | "waiting_on_author"
+  | "ready_for_maintainer_look";
 type TelegramVisibleProofStatus = "needed" | "not_needed";
 type MantisRecommendationStatus = "recommended" | "not_recommended";
 type MantisRecommendationScenario =
@@ -798,6 +804,45 @@ const PR_RATING_LABELS = [
   description: string;
 }[];
 const PR_RATING_LABEL_NAMES = new Set<string>(PR_RATING_LABELS.map((label) => label.name));
+const PR_STATUS_LABELS = [
+  {
+    kind: "re_review_loop",
+    name: "status: 🔁 re-review loop",
+    color: "8250DF",
+    description: "A fresh ClawSweeper review was explicitly requested after the latest review.",
+  },
+  {
+    kind: "actively_grinding",
+    name: "status: 🛠️ actively grinding",
+    color: "BF8700",
+    description: "The PR author has acted after the latest ClawSweeper review and work remains.",
+  },
+  {
+    kind: "needs_proof",
+    name: "status: 📣 needs proof",
+    color: "D4C5F9",
+    description:
+      "The PR needs real behavior proof before ClawSweeper can clear the contributor ask.",
+  },
+  {
+    kind: "waiting_on_author",
+    name: "status: ⏳ waiting on author",
+    color: "FBCA04",
+    description: "ClawSweeper has contributor-facing work open and is waiting for author action.",
+  },
+  {
+    kind: "ready_for_maintainer_look",
+    name: "status: 👀 ready for maintainer look",
+    color: "0E8A16",
+    description: "ClawSweeper has no concrete contributor-facing blocker left for this PR.",
+  },
+] as const satisfies readonly {
+  kind: PrStatusLabelKind;
+  name: string;
+  color: string;
+  description: string;
+}[];
+const PR_STATUS_LABEL_NAMES = new Set<string>(PR_STATUS_LABELS.map((label) => label.name));
 const TELEGRAM_VISIBLE_PROOF_LABEL = "mantis: telegram-visible-proof";
 const TELEGRAM_VISIBLE_PROOF_LABEL_COLOR = "57606A";
 const TELEGRAM_VISIBLE_PROOF_LABEL_DESCRIPTION = "Mantis should capture Telegram visible proof.";
@@ -6129,6 +6174,222 @@ function nextPrRatingLabels(
   return nextLabels;
 }
 
+function proofNeedsContributorAction(proof: Pick<RealBehaviorProof, "status">): boolean {
+  return (
+    proof.status === "missing" || proof.status === "mock_only" || proof.status === "insufficient"
+  );
+}
+
+function hasBlockingReviewFindings(findings: readonly Pick<ReviewFinding, "priority">[]): boolean {
+  return findings.some((finding) => finding.priority <= 2);
+}
+
+function hasUnresolvedContributorWork(options: {
+  prRating: Pick<PrRating, "nextSteps">;
+  realBehaviorProof: Pick<RealBehaviorProof, "status">;
+  reviewFindings: readonly Pick<ReviewFinding, "priority">[];
+  securityReview: Pick<SecurityReview, "status">;
+  overallCorrectness: OverallCorrectness;
+}): boolean {
+  return (
+    options.prRating.nextSteps.length > 0 ||
+    proofNeedsContributorAction(options.realBehaviorProof) ||
+    hasBlockingReviewFindings(options.reviewFindings) ||
+    options.securityReview.status === "needs_attention" ||
+    options.overallCorrectness === "patch is incorrect"
+  );
+}
+
+function isReadyForMaintainerLook(options: {
+  prRating: Pick<PrRating, "nextSteps">;
+  realBehaviorProof: Pick<RealBehaviorProof, "status">;
+  reviewFindings: readonly Pick<ReviewFinding, "priority">[];
+  securityReview: Pick<SecurityReview, "status">;
+  overallCorrectness: OverallCorrectness;
+}): boolean {
+  return (
+    options.prRating.nextSteps.length === 0 &&
+    !hasBlockingReviewFindings(options.reviewFindings) &&
+    options.securityReview.status !== "needs_attention" &&
+    (options.realBehaviorProof.status === "sufficient" ||
+      options.realBehaviorProof.status === "override" ||
+      options.realBehaviorProof.status === "not_applicable") &&
+    options.overallCorrectness === "patch is correct"
+  );
+}
+
+function prStatusLabelKind(options: {
+  prRating: Pick<PrRating, "nextSteps">;
+  realBehaviorProof: Pick<RealBehaviorProof, "status">;
+  reviewFindings: readonly Pick<ReviewFinding, "priority">[];
+  securityReview: Pick<SecurityReview, "status">;
+  overallCorrectness: OverallCorrectness;
+  hasRecentReReviewRequest: boolean;
+  hasRecentAuthorActivity: boolean;
+}): PrStatusLabelKind | null {
+  const unresolvedWork = hasUnresolvedContributorWork(options);
+  if (options.hasRecentReReviewRequest) return "re_review_loop";
+  if (options.hasRecentAuthorActivity && unresolvedWork) return "actively_grinding";
+  if (proofNeedsContributorAction(options.realBehaviorProof)) return "needs_proof";
+  if (unresolvedWork) return "waiting_on_author";
+  if (isReadyForMaintainerLook(options)) return "ready_for_maintainer_look";
+  return null;
+}
+
+function prStatusLabelForKind(kind: PrStatusLabelKind): (typeof PR_STATUS_LABELS)[number] {
+  const label = PR_STATUS_LABELS.find((candidate) => candidate.kind === kind);
+  if (!label) throw new Error(`unknown PR status label kind: ${kind}`);
+  return label;
+}
+
+function nextPrStatusLabels(
+  labels: readonly string[],
+  statusKind: PrStatusLabelKind | null,
+): string[] {
+  const nextLabels = labels.filter((label) => !PR_STATUS_LABEL_NAMES.has(label));
+  if (statusKind) nextLabels.push(prStatusLabelForKind(statusKind).name);
+  return nextLabels;
+}
+
+function eventTimestampMs(value: unknown): number | null {
+  const record = asRecord(value);
+  return timestampMs(stringOrUndefined(record.updatedAt) ?? stringOrUndefined(record.createdAt));
+}
+
+function isAfterReview(value: unknown, reviewedAtMs: number | null): boolean {
+  if (reviewedAtMs === null) return false;
+  const eventMs = eventTimestampMs(value);
+  return eventMs !== null && eventMs > reviewedAtMs;
+}
+
+function isReReviewRequestText(text: unknown): boolean {
+  const body = stringOrUndefined(text)?.trim() ?? "";
+  if (!body) return false;
+  return (
+    /^\s*\/review(?:\s|$)/im.test(body) ||
+    /^\s*\/clawsweeper\s+(?:re-?review|rerun|re-run|run\s+review|review)(?:\s|$)/im.test(body) ||
+    /(?:^|\s)@clawsweeper(?:\[bot\])?\s+(?:re-?review|rerun|re-run|run\s+review|review)(?:\s|$)/im.test(
+      body,
+    )
+  );
+}
+
+function hasRecentReReviewRequest(
+  context: Pick<ItemContext, "comments">,
+  reviewedAt: string | undefined,
+): boolean {
+  const reviewedAtMs = timestampMs(reviewedAt);
+  return context.comments.some((comment) => {
+    const record = asRecord(comment);
+    return isAfterReview(comment, reviewedAtMs) && isReReviewRequestText(record.body);
+  });
+}
+
+function hasRecentAuthorActivity(
+  context: Pick<ItemContext, "comments" | "timeline">,
+  options: { reviewedAt: string | undefined; author: string | undefined },
+): boolean {
+  const author = String(options.author ?? "")
+    .trim()
+    .toLowerCase();
+  if (!author) return false;
+  const reviewedAtMs = timestampMs(options.reviewedAt);
+  return (
+    context.comments.some((comment) => {
+      const record = asRecord(comment);
+      return (
+        isAfterReview(comment, reviewedAtMs) &&
+        stringOrUndefined(record.author)?.toLowerCase() === author
+      );
+    }) ||
+    context.timeline.some((event) => {
+      const record = asRecord(event);
+      return (
+        isAfterReview(event, reviewedAtMs) &&
+        stringOrUndefined(record.actor)?.toLowerCase() === author &&
+        typeof record.commitId === "string" &&
+        record.commitId.length > 0
+      );
+    })
+  );
+}
+
+function prStatusLabelKindFromReport(
+  markdown: string,
+  context: ItemContext,
+): PrStatusLabelKind | null {
+  if (frontMatterValue(markdown, "type") !== "pull_request") return null;
+  return prStatusLabelKind({
+    prRating: reportPrRating(markdown),
+    realBehaviorProof: reportRealBehaviorProof(markdown),
+    reviewFindings: reportReviewFindings(markdown),
+    securityReview: reportSecurityReview(markdown),
+    overallCorrectness: reportOverallCorrectness(markdown),
+    hasRecentReReviewRequest: hasRecentReReviewRequest(
+      context,
+      frontMatterValue(markdown, "reviewed_at"),
+    ),
+    hasRecentAuthorActivity: hasRecentAuthorActivity(context, {
+      reviewedAt: frontMatterValue(markdown, "reviewed_at"),
+      author: frontMatterValue(markdown, "author"),
+    }),
+  });
+}
+
+export function prStatusLabelsForTest(
+  labels: readonly string[],
+  options: {
+    isPullRequest?: boolean;
+    nextSteps?: readonly string[];
+    proofStatus?: string;
+    findingPriorities?: readonly number[];
+    securityStatus?: string;
+    overallCorrectness?: string;
+    hasRecentReReviewRequest?: boolean;
+    hasRecentAuthorActivity?: boolean;
+  },
+): string[] {
+  if (options.isPullRequest === false) return nextPrStatusLabels(labels, null);
+  const statusKind = prStatusLabelKind({
+    prRating: { nextSteps: [...(options.nextSteps ?? [])] },
+    realBehaviorProof: {
+      status: REAL_BEHAVIOR_PROOF_STATUSES.has(options.proofStatus as RealBehaviorProofStatus)
+        ? (options.proofStatus as RealBehaviorProofStatus)
+        : "not_applicable",
+    },
+    reviewFindings: (options.findingPriorities ?? [])
+      .filter((priority): priority is 0 | 1 | 2 | 3 => [0, 1, 2, 3].includes(priority))
+      .map((priority) => ({ priority })),
+    securityReview: {
+      status: SECURITY_REVIEW_STATUSES.has(options.securityStatus as SecurityReviewStatus)
+        ? (options.securityStatus as SecurityReviewStatus)
+        : "cleared",
+    },
+    overallCorrectness: OVERALL_CORRECTNESS_VALUES.has(
+      options.overallCorrectness as OverallCorrectness,
+    )
+      ? (options.overallCorrectness as OverallCorrectness)
+      : "patch is correct",
+    hasRecentReReviewRequest: options.hasRecentReReviewRequest === true,
+    hasRecentAuthorActivity: options.hasRecentAuthorActivity === true,
+  });
+  return nextPrStatusLabels(labels, statusKind);
+}
+
+export function prStatusLabelSchemeForTest(): {
+  kind: PrStatusLabelKind;
+  name: string;
+  color: string;
+  description: string;
+}[] {
+  return PR_STATUS_LABELS.map(({ kind, name, color, description }) => ({
+    kind,
+    name,
+    color,
+    description,
+  }));
+}
+
 function pullRequestFilePathsFromReport(markdown: string): string[] {
   return frontMatterStringArray(markdown, "pull_files");
 }
@@ -6694,6 +6955,27 @@ function ensurePrRatingLabel(tier: PrRatingTier): void {
   }
 }
 
+function ensurePrStatusLabel(kind: PrStatusLabelKind): void {
+  const definition = prStatusLabelForKind(kind);
+  try {
+    ghWithRetry(
+      [
+        "label",
+        "create",
+        definition.name,
+        "--color",
+        definition.color,
+        "--description",
+        definition.description,
+      ],
+      2,
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!/already exists/i.test(message)) throw error;
+  }
+}
+
 function syncPrRatingLabel(options: {
   number: number;
   labels: readonly string[];
@@ -6712,6 +6994,33 @@ function syncPrRatingLabel(options: {
   if (!labelsToRemove.length && !labelToAdd) return nextLabels;
   if (options.dryRun) return nextLabels;
   if (labelToAdd) ensurePrRatingLabel(options.rating.overallTier);
+  for (const label of labelsToRemove) {
+    ghWithRetry(["issue", "edit", String(options.number), "--remove-label", label]);
+  }
+  if (labelToAdd) {
+    ghWithRetry(["issue", "edit", String(options.number), "--add-label", labelToAdd]);
+  }
+  return nextLabels;
+}
+
+function syncPrStatusLabel(options: {
+  number: number;
+  labels: readonly string[];
+  statusKind: PrStatusLabelKind | null;
+  dryRun: boolean;
+}): string[] {
+  const nextLabels = nextPrStatusLabels(options.labels, options.statusKind);
+  const currentLabelKeys = new Set(options.labels.map((label) => label.toLowerCase()));
+  const nextLabelKeys = new Set(nextLabels.map((label) => label.toLowerCase()));
+  const labelsToRemove = options.labels.filter(
+    (label) => PR_STATUS_LABEL_NAMES.has(label) && !nextLabelKeys.has(label.toLowerCase()),
+  );
+  const labelToAdd = nextLabels.find(
+    (label) => PR_STATUS_LABEL_NAMES.has(label) && !currentLabelKeys.has(label.toLowerCase()),
+  );
+  if (!labelsToRemove.length && !labelToAdd) return nextLabels;
+  if (options.dryRun) return nextLabels;
+  if (options.statusKind && labelToAdd) ensurePrStatusLabel(options.statusKind);
   for (const label of labelsToRemove) {
     ghWithRetry(["issue", "edit", String(options.number), "--remove-label", label]);
   }
@@ -9313,6 +9622,12 @@ function applyDecisionsCommand(args: Args): void {
         number,
         labels: item.labels,
         rating: reportPrRating(markdown),
+        dryRun,
+      });
+      item.labels = syncPrStatusLabel({
+        number,
+        labels: item.labels,
+        statusKind: prStatusLabelKindFromReport(markdown, currentItemContext()),
         dryRun,
       });
       item.labels = syncTelegramVisibleProofLabel({

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -120,6 +120,7 @@ type RealBehaviorProofEvidenceKind =
   | "not_applicable";
 type PrRatingTier = "S" | "A" | "B" | "C" | "D" | "F" | "NA";
 type PrStatusLabelKind =
+  | "automerge_armed"
   | "re_review_loop"
   | "actively_grinding"
   | "needs_proof"
@@ -806,6 +807,12 @@ const PR_RATING_LABELS = [
 const PR_RATING_LABEL_NAMES = new Set<string>(PR_RATING_LABELS.map((label) => label.name));
 const PR_STATUS_LABELS = [
   {
+    kind: "automerge_armed",
+    name: "status: 🚀 automerge armed",
+    color: "0E8A16",
+    description: "This PR is in ClawSweeper's automerge lane.",
+  },
+  {
     kind: "re_review_loop",
     name: "status: 🔁 re-review loop",
     color: "8250DF",
@@ -814,13 +821,13 @@ const PR_STATUS_LABELS = [
   {
     kind: "actively_grinding",
     name: "status: 🛠️ actively grinding",
-    color: "BF8700",
+    color: "0969DA",
     description: "The PR author has acted after the latest ClawSweeper review and work remains.",
   },
   {
     kind: "needs_proof",
     name: "status: 📣 needs proof",
-    color: "D4C5F9",
+    color: "D93F0B",
     description:
       "The PR needs real behavior proof before ClawSweeper can clear the contributor ask.",
   },
@@ -833,7 +840,7 @@ const PR_STATUS_LABELS = [
   {
     kind: "ready_for_maintainer_look",
     name: "status: 👀 ready for maintainer look",
-    color: "0E8A16",
+    color: "2DA44E",
     description: "ClawSweeper has no concrete contributor-facing blocker left for this PR.",
   },
 ] as const satisfies readonly {
@@ -6224,10 +6231,12 @@ function prStatusLabelKind(options: {
   reviewFindings: readonly Pick<ReviewFinding, "priority">[];
   securityReview: Pick<SecurityReview, "status">;
   overallCorrectness: OverallCorrectness;
+  hasAutomergeLabel: boolean;
   hasRecentReReviewRequest: boolean;
   hasRecentAuthorActivity: boolean;
 }): PrStatusLabelKind | null {
   const unresolvedWork = hasUnresolvedContributorWork(options);
+  if (options.hasAutomergeLabel) return "automerge_armed";
   if (options.hasRecentReReviewRequest) return "re_review_loop";
   if (options.hasRecentAuthorActivity && unresolvedWork) return "actively_grinding";
   if (proofNeedsContributorAction(options.realBehaviorProof)) return "needs_proof";
@@ -6325,6 +6334,7 @@ function prStatusLabelKindFromReport(
     reviewFindings: reportReviewFindings(markdown),
     securityReview: reportSecurityReview(markdown),
     overallCorrectness: reportOverallCorrectness(markdown),
+    hasAutomergeLabel: frontMatterStringArray(markdown, "labels").includes(AUTOMERGE_LABEL),
     hasRecentReReviewRequest: hasRecentReReviewRequest(
       context,
       frontMatterValue(markdown, "reviewed_at"),
@@ -6345,6 +6355,7 @@ export function prStatusLabelsForTest(
     findingPriorities?: readonly number[];
     securityStatus?: string;
     overallCorrectness?: string;
+    hasAutomergeLabel?: boolean;
     hasRecentReReviewRequest?: boolean;
     hasRecentAuthorActivity?: boolean;
   },
@@ -6370,6 +6381,7 @@ export function prStatusLabelsForTest(
     )
       ? (options.overallCorrectness as OverallCorrectness)
       : "patch is correct",
+    hasAutomergeLabel: options.hasAutomergeLabel === true,
     hasRecentReReviewRequest: options.hasRecentReReviewRequest === true,
     hasRecentAuthorActivity: options.hasRecentAuthorActivity === true,
   });

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -6192,14 +6192,12 @@ function hasBlockingReviewFindings(findings: readonly Pick<ReviewFinding, "prior
 }
 
 function hasUnresolvedContributorWork(options: {
-  prRating: Pick<PrRating, "nextSteps">;
   realBehaviorProof: Pick<RealBehaviorProof, "status">;
   reviewFindings: readonly Pick<ReviewFinding, "priority">[];
   securityReview: Pick<SecurityReview, "status">;
   overallCorrectness: OverallCorrectness;
 }): boolean {
   return (
-    options.prRating.nextSteps.length > 0 ||
     proofNeedsContributorAction(options.realBehaviorProof) ||
     hasBlockingReviewFindings(options.reviewFindings) ||
     options.securityReview.status === "needs_attention" ||
@@ -6208,14 +6206,12 @@ function hasUnresolvedContributorWork(options: {
 }
 
 function isReadyForMaintainerLook(options: {
-  prRating: Pick<PrRating, "nextSteps">;
   realBehaviorProof: Pick<RealBehaviorProof, "status">;
   reviewFindings: readonly Pick<ReviewFinding, "priority">[];
   securityReview: Pick<SecurityReview, "status">;
   overallCorrectness: OverallCorrectness;
 }): boolean {
   return (
-    options.prRating.nextSteps.length === 0 &&
     !hasBlockingReviewFindings(options.reviewFindings) &&
     options.securityReview.status !== "needs_attention" &&
     (options.realBehaviorProof.status === "sufficient" ||
@@ -6226,7 +6222,6 @@ function isReadyForMaintainerLook(options: {
 }
 
 function prStatusLabelKind(options: {
-  prRating: Pick<PrRating, "nextSteps">;
   realBehaviorProof: Pick<RealBehaviorProof, "status">;
   reviewFindings: readonly Pick<ReviewFinding, "priority">[];
   securityReview: Pick<SecurityReview, "status">;
@@ -6329,7 +6324,6 @@ function prStatusLabelKindFromReport(
 ): PrStatusLabelKind | null {
   if (frontMatterValue(markdown, "type") !== "pull_request") return null;
   return prStatusLabelKind({
-    prRating: reportPrRating(markdown),
     realBehaviorProof: reportRealBehaviorProof(markdown),
     reviewFindings: reportReviewFindings(markdown),
     securityReview: reportSecurityReview(markdown),
@@ -6362,7 +6356,6 @@ export function prStatusLabelsForTest(
 ): string[] {
   if (options.isPullRequest === false) return nextPrStatusLabels(labels, null);
   const statusKind = prStatusLabelKind({
-    prRating: { nextSteps: [...(options.nextSteps ?? [])] },
     realBehaviorProof: {
       status: REAL_BEHAVIOR_PROOF_STATUSES.has(options.proofStatus as RealBehaviorProofStatus)
         ? (options.proofStatus as RealBehaviorProofStatus)

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -5530,6 +5530,14 @@ test("ClawSweeper PR status labels respect priority ordering", () => {
   assert.deepEqual(
     prStatusLabelsForTest([], {
       proofStatus: "missing",
+      hasRecentReReviewRequest: true,
+      hasAutomergeLabel: true,
+    }),
+    ["status: 🚀 automerge armed"],
+  );
+  assert.deepEqual(
+    prStatusLabelsForTest([], {
+      proofStatus: "missing",
       hasRecentAuthorActivity: true,
       hasRecentReReviewRequest: true,
     }),
@@ -5570,14 +5578,15 @@ test("ClawSweeper PR status label scheme exposes workflow states", () => {
   assert.deepEqual(
     prStatusLabelSchemeForTest().map(({ kind, name, color }) => ({ kind, name, color })),
     [
+      { kind: "automerge_armed", name: "status: 🚀 automerge armed", color: "0E8A16" },
       { kind: "re_review_loop", name: "status: 🔁 re-review loop", color: "8250DF" },
-      { kind: "actively_grinding", name: "status: 🛠️ actively grinding", color: "BF8700" },
-      { kind: "needs_proof", name: "status: 📣 needs proof", color: "D4C5F9" },
+      { kind: "actively_grinding", name: "status: 🛠️ actively grinding", color: "0969DA" },
+      { kind: "needs_proof", name: "status: 📣 needs proof", color: "D93F0B" },
       { kind: "waiting_on_author", name: "status: ⏳ waiting on author", color: "FBCA04" },
       {
         kind: "ready_for_maintainer_look",
         name: "status: 👀 ready for maintainer look",
-        color: "0E8A16",
+        color: "2DA44E",
       },
     ],
   );

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -5528,12 +5528,11 @@ test("ClawSweeper PR status labels preserve other label families", () => {
 
 test("ClawSweeper PR status labels respect priority ordering", () => {
   assert.deepEqual(
-    prStatusLabelsForTest([], {
+    prStatusLabelsForTest(["clawsweeper:automerge"], {
       proofStatus: "missing",
       hasRecentReReviewRequest: true,
-      hasAutomergeLabel: true,
     }),
-    ["status: 🚀 automerge armed"],
+    ["clawsweeper:automerge", "status: 🚀 automerge armed"],
   );
   assert.deepEqual(
     prStatusLabelsForTest([], {
@@ -5561,6 +5560,37 @@ test("ClawSweeper PR status labels respect priority ordering", () => {
       findingPriorities: [2],
     }),
     ["status: ⏳ waiting on author"],
+  );
+});
+
+test("ClawSweeper PR status ignores bot-authored re-review guidance", () => {
+  assert.deepEqual(
+    prStatusLabelsForTest([], {
+      proofStatus: "missing",
+      reviewedAt: "2026-01-01T00:00:00Z",
+      comments: [
+        {
+          author: "openclaw-clawsweeper[bot]",
+          body: "After adding proof, comment `@clawsweeper re-review`.",
+          updatedAt: "2026-01-01T00:01:00Z",
+        },
+      ],
+    }),
+    ["status: 📣 needs proof"],
+  );
+  assert.deepEqual(
+    prStatusLabelsForTest([], {
+      proofStatus: "missing",
+      reviewedAt: "2026-01-01T00:00:00Z",
+      comments: [
+        {
+          author: "contributor",
+          body: "@clawsweeper re-review",
+          createdAt: "2026-01-01T00:01:00Z",
+        },
+      ],
+    }),
+    ["status: 🔁 re-review loop"],
   );
 });
 

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -58,6 +58,8 @@ import {
   mergeRiskLabelSchemeForTest,
   prRatingLabelsForTest,
   prRatingLabelSchemeForTest,
+  prStatusLabelsForTest,
+  prStatusLabelSchemeForTest,
   priorityLabelsForTest,
   priorityLabelSchemeForTest,
   protectedLabels,
@@ -5480,6 +5482,103 @@ test("ClawSweeper PR rating label scheme exposes boring internal tiers", () => {
       { tier: "D", name: "rating: 🦪 silver shellfish", color: "7A828E" },
       { tier: "F", name: "rating: 🧂 unranked krab", color: "8C2F39" },
       { tier: "NA", name: "rating: 🌊 off-meta tidepool", color: "6E7781" },
+    ],
+  );
+});
+
+test("ClawSweeper PR status labels use one current workflow status", () => {
+  assert.deepEqual(
+    prStatusLabelsForTest(["bug", "status: ⏳ waiting on author"], {
+      nextSteps: ["Add proof."],
+      hasRecentAuthorActivity: true,
+    }),
+    ["bug", "status: 🛠️ actively grinding"],
+  );
+  assert.deepEqual(
+    prStatusLabelsForTest(["bug", "status: 🛠️ actively grinding"], {
+      proofStatus: "sufficient",
+      overallCorrectness: "patch is correct",
+    }),
+    ["bug", "status: 👀 ready for maintainer look"],
+  );
+});
+
+test("ClawSweeper PR status labels preserve other label families", () => {
+  assert.deepEqual(
+    prStatusLabelsForTest(
+      [
+        "rating: 🦞 diamond lobster",
+        "merge-risk: 🚨 compatibility",
+        "proof: sufficient",
+        "status: custom-user-label",
+      ],
+      {
+        proofStatus: "missing",
+      },
+    ),
+    [
+      "rating: 🦞 diamond lobster",
+      "merge-risk: 🚨 compatibility",
+      "proof: sufficient",
+      "status: custom-user-label",
+      "status: 📣 needs proof",
+    ],
+  );
+});
+
+test("ClawSweeper PR status labels respect priority ordering", () => {
+  assert.deepEqual(
+    prStatusLabelsForTest([], {
+      proofStatus: "missing",
+      hasRecentAuthorActivity: true,
+      hasRecentReReviewRequest: true,
+    }),
+    ["status: 🔁 re-review loop"],
+  );
+  assert.deepEqual(
+    prStatusLabelsForTest([], {
+      proofStatus: "missing",
+      hasRecentAuthorActivity: true,
+    }),
+    ["status: 🛠️ actively grinding"],
+  );
+  assert.deepEqual(
+    prStatusLabelsForTest([], {
+      proofStatus: "missing",
+    }),
+    ["status: 📣 needs proof"],
+  );
+  assert.deepEqual(
+    prStatusLabelsForTest([], {
+      nextSteps: ["Address the review finding."],
+    }),
+    ["status: ⏳ waiting on author"],
+  );
+});
+
+test("ClawSweeper PR status labels are PR-only", () => {
+  assert.deepEqual(
+    prStatusLabelsForTest(["bug", "status: ⏳ waiting on author"], {
+      isPullRequest: false,
+      nextSteps: ["Add proof."],
+    }),
+    ["bug"],
+  );
+});
+
+test("ClawSweeper PR status label scheme exposes workflow states", () => {
+  assert.deepEqual(
+    prStatusLabelSchemeForTest().map(({ kind, name, color }) => ({ kind, name, color })),
+    [
+      { kind: "re_review_loop", name: "status: 🔁 re-review loop", color: "8250DF" },
+      { kind: "actively_grinding", name: "status: 🛠️ actively grinding", color: "BF8700" },
+      { kind: "needs_proof", name: "status: 📣 needs proof", color: "D4C5F9" },
+      { kind: "waiting_on_author", name: "status: ⏳ waiting on author", color: "FBCA04" },
+      {
+        kind: "ready_for_maintainer_look",
+        name: "status: 👀 ready for maintainer look",
+        color: "0E8A16",
+      },
     ],
   );
 });

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -5489,7 +5489,7 @@ test("ClawSweeper PR rating label scheme exposes boring internal tiers", () => {
 test("ClawSweeper PR status labels use one current workflow status", () => {
   assert.deepEqual(
     prStatusLabelsForTest(["bug", "status: ⏳ waiting on author"], {
-      nextSteps: ["Add proof."],
+      findingPriorities: [2],
       hasRecentAuthorActivity: true,
     }),
     ["bug", "status: 🛠️ actively grinding"],
@@ -5558,9 +5558,22 @@ test("ClawSweeper PR status labels respect priority ordering", () => {
   );
   assert.deepEqual(
     prStatusLabelsForTest([], {
-      nextSteps: ["Address the review finding."],
+      findingPriorities: [2],
     }),
     ["status: ⏳ waiting on author"],
+  );
+});
+
+test("ClawSweeper PR status treats maintainer-only rank-up moves as ready", () => {
+  assert.deepEqual(
+    prStatusLabelsForTest([], {
+      nextSteps: [
+        "Maintainer accepts the relative details.reportPath contract change before merge.",
+      ],
+      proofStatus: "sufficient",
+      overallCorrectness: "patch is correct",
+    }),
+    ["status: 👀 ready for maintainer look"],
   );
 });
 


### PR DESCRIPTION
## Summary
- add one-at-a-time PR-only `status:*` labels for ClawSweeper workflow state
- surface automerge with `status: 🚀 automerge armed`
- treat maintainer-only rank-up moves as ready for maintainer look when hard contributor blockers are clear
- preserve existing rating, merge-risk, proof, priority, impact, Mantis, and unknown user labels

## Validation
- `pnpm install --frozen-lockfile` passed
- `pnpm run build` passed
- `node --test test/clawsweeper.test.ts --test-name-pattern "PR status labels"` passed before follow-up changes
- `pnpm run format` passed
- `pnpm run check` passed
- after color/automerge/maintainer-ready follow-ups: `pnpm run build && node --test test/clawsweeper.test.ts --test-name-pattern "PR status labels|maintainer-only rank-up" && pnpm run format:check` passed