### PR TITLE
fix(rating): keep draft workflow out of PR rank

### DIFF
--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -508,23 +508,28 @@ it does not, they can ask a maintainer to comment `@clawsweeper re-review`. Use
 
 Always fill `prRating` with boring internal tiers `S`, `A`, `B`, `C`, `D`, `F`,
 or `NA`; public output maps these to funny crustacean labels. Rate PR evidence
-and merge readiness, not the contributor. Use a calibrated
+and patch quality, not the contributor. Use a calibrated
 standard-distribution-style scale: `S` is rare and reserved for exceptional PRs
 with unusually strong proof, clean implementation, convincing validation, and no
 meaningful blockers; `A` is clearly above average; `B` is the normal good and
-likely mergeable rating; `C` means useful signal exists but confidence is
+likely mergeable quality rating; `C` means useful signal exists but confidence is
 limited; `D` means proof, validation, or implementation signal is thin; `F`
-means not merge-ready because proof is missing/unusable or the patch has serious
+means not quality-ready because proof is missing/unusable or the patch has serious
 correctness or safety concerns; `NA` is only for non-PR or not-applicable
 reviews. Set `proofTier` from real behavior proof quality, `patchTier` from
 implementation correctness, security review, scope, review findings, and
-validation, and `overallTier` from the weaker merge-readiness signal. Real
+validation, and `overallTier` from the weaker proof-or-patch quality signal. Real
 screenshots, recordings, or linked media that directly show the changed behavior
 are strong proof boosters and should be treated as shiny evidence; this does not
 override the browser runtime, network, CSP, or security rule above, where
 ordinary screenshots need visible diagnostics to be sufficient. Missing,
 mock-only, or insufficient proof must cap or lower the overall rating because
-real behavior proof remains a merge gate. Include `nextSteps` as 0-3 concrete
+real behavior proof remains a merge gate. Do not lower `proofTier`, `patchTier`,
+or `overallTier` solely because the PR is draft, has protected labels, is not
+automerge-eligible, or is waiting on a maintainer decision; those are workflow
+state signals, not proof or patch quality defects. Mention workflow blockers in
+the summary or `nextSteps` only when a contributor can materially act on them.
+Include `nextSteps` as 0-3 concrete
 rank-up moves only when they are merge-relevant and likely to improve reviewer
 confidence. Use an empty array for `S`, `A`, and `NA`, and usually for `B`
 unless one specific action materially reduces risk. Do not invent optional

--- a/schema/clawsweeper-decision.schema.json
+++ b/schema/clawsweeper-decision.schema.json
@@ -456,7 +456,7 @@
     "prRating": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Calibrated PR readiness rating. Use boring internal tiers S/A/B/C/D/F/NA; public rendering maps them to funny crustacean labels. Rate the PR evidence and merge readiness, not the contributor. S is rare and exceptional, A is clearly above average, B is the normal good/mergeable rating, C is useful but uncertain, D is weak/thin signal, F is not merge-ready, and NA is only for non-PR or not-applicable items. Real screenshots, recordings, or linked media that directly show the changed behavior are strong boosters, but screenshots alone are not enough for browser runtime, network, CSP, or security claims unless diagnostics are visible.",
+      "description": "Calibrated PR quality rating. Use boring internal tiers S/A/B/C/D/F/NA; public rendering maps them to funny crustacean labels. Rate the PR evidence and patch quality, not the contributor or workflow state. S is rare and exceptional, A is clearly above average, B is the normal good/mergeable quality rating, C is useful but uncertain, D is weak/thin signal, F is not quality-ready, and NA is only for non-PR or not-applicable items. Real screenshots, recordings, or linked media that directly show the changed behavior are strong boosters, but screenshots alone are not enough for browser runtime, network, CSP, or security claims unless diagnostics are visible. Do not lower any tier solely because the PR is draft, has protected labels, is not automerge-eligible, or is waiting on a maintainer decision.",
       "required": ["proofTier", "patchTier", "overallTier", "summary", "nextSteps"],
       "properties": {
         "proofTier": {
@@ -472,7 +472,7 @@
         "overallTier": {
           "type": "string",
           "enum": ["S", "A", "B", "C", "D", "F", "NA"],
-          "description": "Overall merge-readiness tier after combining proof and patch quality. Missing, mock-only, or insufficient proof must cap or lower the overall rating because real behavior proof remains a merge gate."
+          "description": "Overall PR quality tier after combining proof and patch quality. Missing, mock-only, or insufficient proof must cap or lower the overall rating because real behavior proof remains a merge gate. Draft, protected-label, automerge eligibility, and maintainer-waiting workflow states must not lower this tier by themselves."
         },
         "summary": {
           "type": "string",

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -5311,6 +5311,35 @@ test("review prompt requires real behavior proof for PR reviews", () => {
   assert.match(prompt, /do not request ClawSweeper repair markers/);
 });
 
+test("review prompt keeps draft and protected workflow state out of PR rank", () => {
+  const prompt = readFileSync("prompts/review-item.md", "utf8");
+
+  assert.match(prompt, /Rate PR evidence\s+and patch quality/);
+  assert.match(prompt, /weaker proof-or-patch quality signal/);
+  assert.match(
+    prompt,
+    /Do not lower `proofTier`, `patchTier`,\s+or `overallTier` solely because the PR is draft/,
+  );
+  assert.match(prompt, /has protected labels/);
+  assert.match(prompt, /not\s+automerge-eligible/);
+  assert.match(prompt, /workflow\s+state signals, not proof or patch quality defects/);
+});
+
+test("decision schema keeps draft and protected workflow state out of PR rank", () => {
+  const schema = JSON.parse(readFileSync("schema/clawsweeper-decision.schema.json", "utf8"));
+  const prRating = schema.properties.prRating;
+
+  assert.match(prRating.description, /Calibrated PR quality rating/);
+  assert.match(prRating.description, /Rate the PR evidence and patch quality/);
+  assert.match(prRating.description, /Do not lower any tier solely because the PR is draft/);
+  assert.match(prRating.description, /has protected labels/);
+  assert.match(prRating.description, /not automerge-eligible/);
+  assert.match(
+    prRating.properties.overallTier.description,
+    /Draft, protected-label, automerge eligibility, and maintainer-waiting workflow states must not lower this tier by themselves/,
+  );
+});
+
 test("review prompt classifies Telegram visible proof candidates", () => {
   const prompt = readFileSync("prompts/review-item.md", "utf8");
 


### PR DESCRIPTION
## Summary
- make PR rank quality-based instead of merge-workflow-based
- prevent draft/protected/automerge/maintainer-wait workflow states from lowering proof, patch, or overall tiers by themselves
- add prompt/schema regression tests for the draft/protected rank guard

## Validation
- `node --test test/clawsweeper.test.ts --test-name-pattern "draft and protected workflow state out of PR rank|real behavior proof for PR reviews"`: passed
- `pnpm run check`: failed once on `format:check` for `test/clawsweeper.test.ts`
- `pnpm exec oxfmt test/clawsweeper.test.ts`: applied formatting
- `pnpm run check`: passed