### PR TITLE
feat(review): add PR egg game🥚

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -5511,12 +5511,12 @@ function publicPrEggLine(
   const explainer = [
     "",
     "<details>",
-    "<summary>How the PR egg works</summary>",
+    "<summary>What is this egg doing here?</summary>",
     "",
-    "- The egg is cosmetic and PR-only; it does not affect labels, ratings, merge decisions, or automation.",
-    "- Egg states come from the same review signals ClawSweeper already reports: unresolved proof or findings, re-review loops, and clean final-review readiness.",
-    "- Hatches are deterministic from this repository, PR number, and reviewed head SHA, so the same PR revision gets the same creature.",
-    "- Rarity is collectible flavor only: 🥚 common, 🌱 uncommon, 💎 rare, ✨ glimmer, and 🌈 legendary.",
+    "- Every PR gets a tiny egg. It is here for vibes, not verdicts: it does not change labels, ratings, merge decisions, or automation.",
+    "- The shell reacts to review momentum: missing proof warms it up, re-review makes it wobble, and a clean final review lets it hatch.",
+    "- The hatch is seeded from this repository, PR number, and reviewed head SHA, so the same PR revision gets the same little creature every time.",
+    "- Rarity is just collectible sparkle: 🥚 common, 🌱 uncommon, 💎 rare, ✨ glimmer, and 🌈 legendary.",
     "",
     "</details>",
   ];

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -5646,7 +5646,9 @@ function closeOutro(reason: CloseReason, canonicalLinks: string[] = []): string 
 
 function issueOrPullReferenceNumbers(value: string): string[] {
   return [
-    ...value.matchAll(/https:\/\/github\.com\/[^\s)]+\/(?:issues|pull)\/(\d+)|#(\d+)\b/g),
+    ...value.matchAll(
+      /https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/(?:issues|pull)\/(\d+)|#(\d+)\b/g,
+    ),
   ].map((match) => match[1] ?? match[2] ?? "");
 }
 

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -126,6 +126,8 @@ type PrStatusLabelKind =
   | "needs_proof"
   | "waiting_on_author"
   | "ready_for_maintainer_look";
+type PrEggState = "incubating" | "warming" | "wobbling" | "hatched";
+type PrEggRarity = "common" | "uncommon" | "rare" | "glimmer" | "legendary";
 type TelegramVisibleProofStatus = "needed" | "not_needed";
 type MantisRecommendationStatus = "recommended" | "not_recommended";
 type MantisRecommendationScenario =
@@ -5454,6 +5456,79 @@ function publicPrRatingLine(rating: PrRating, proof: RealBehaviorProof): string 
   return lines.join("\n");
 }
 
+function prEggSeedFromReport(markdown: string): string {
+  const repo = markdownRepository(markdown);
+  const number = frontMatterValue(markdown, "number") ?? "unknown";
+  const headSha = frontMatterValue(markdown, "pull_head_sha") ?? "unknown";
+  return `${repo}#${number}@${headSha}`;
+}
+
+function prEggStateFromReport(
+  markdown: string,
+  options: {
+    realBehaviorProof: RealBehaviorProof;
+    prRating: PrRating;
+    reviewFindings: readonly Pick<ReviewFinding, "priority">[];
+    securityReview: Pick<SecurityReview, "status">;
+    overallCorrectness: OverallCorrectness;
+  },
+): PrEggState {
+  const isReady =
+    options.prRating.nextSteps.length === 0 &&
+    isReadyForMaintainerLook({
+      realBehaviorProof: options.realBehaviorProof,
+      reviewFindings: options.reviewFindings,
+      securityReview: options.securityReview,
+      overallCorrectness: options.overallCorrectness,
+    });
+  if (isReady) return "hatched";
+  const labels = frontMatterStringArray(markdown, "labels");
+  if (labels.includes("status: 🔁 re-review loop")) return "wobbling";
+  const hasUnresolvedWork =
+    options.prRating.nextSteps.length > 0 ||
+    hasUnresolvedContributorWork({
+      realBehaviorProof: options.realBehaviorProof,
+      reviewFindings: options.reviewFindings,
+      securityReview: options.securityReview,
+      overallCorrectness: options.overallCorrectness,
+    });
+  return hasUnresolvedWork ? "warming" : "incubating";
+}
+
+function publicPrEggLine(
+  markdown: string,
+  options: {
+    realBehaviorProof: RealBehaviorProof;
+    prRating: PrRating;
+    reviewFindings: readonly Pick<ReviewFinding, "priority">[];
+    securityReview: Pick<SecurityReview, "status">;
+    overallCorrectness: OverallCorrectness;
+  },
+): string {
+  const seed = prEggSeedFromReport(markdown);
+  const state = prEggStateFromReport(markdown, options);
+  if (state === "hatched") {
+    const creature = prEggCreature(seed);
+    const shareUrl = `https://x.com/intent/tweet?text=${encodeURIComponent(creature.shareText)}`;
+    return [
+      `✨ Hatched: ${creature.rarityLabel} ${creature.name}`,
+      "",
+      "```text",
+      creature.portrait,
+      "```",
+      `Trait: ${creature.trait}.`,
+      `Share on X: ${markdownLink("post this hatch", shareUrl)}`,
+      `Copy: ${creature.shareText}`,
+    ].join("\n");
+  }
+  const stateLines: Record<Exclude<PrEggState, "hatched">, string> = {
+    incubating: "🥚 Incubating: this PR egg is tucked into the review nest.",
+    warming: "🔥 Warming up: proof, findings, or rank-up moves are still in progress.",
+    wobbling: "🔁 Wobbling: a re-review loop is active, so the shell is rattling.",
+  };
+  return [stateLines[state], "", "```text", pickSeeded(PR_EGG_ART, seed, state), "```"].join("\n");
+}
+
 function publicMantisRecommendationBlock(recommendation: MantisRecommendation): string {
   if (recommendation.status !== "recommended" || recommendation.scenario === "none") return "";
   const comment = recommendation.maintainerComment.trim();
@@ -6102,6 +6177,116 @@ function hasShinyProof(proof: Pick<RealBehaviorProof, "status" | "evidenceKind">
       proof.evidenceKind === "screenshot" ||
       proof.evidenceKind === "linked_artifact")
   );
+}
+
+const PR_EGG_ART = [
+  "       .-.\n     .'   '.\n    /       \\\n   |         |\n    \\       /\n     '.___.'",
+  "       .-.\n    .-'   '-.\n   /  .- -.  \\\n  |  /     \\  |\n   \\  '._.'  /\n    '-.___.-'",
+  "       .-.\n    .-'   '-.\n   /  _   _  \\\n  |  (_) (_)  |\n   \\   ___   /\n    '.___._.'",
+];
+
+const PR_EGG_RARITIES: { rarity: PrEggRarity; label: string; cutoff: number }[] = [
+  { rarity: "common", label: "🥚 common", cutoff: 7000 },
+  { rarity: "uncommon", label: "🌱 uncommon", cutoff: 9000 },
+  { rarity: "rare", label: "💎 rare", cutoff: 9800 },
+  { rarity: "glimmer", label: "✨ glimmer", cutoff: 9990 },
+  { rarity: "legendary", label: "🌈 legendary", cutoff: 10000 },
+];
+
+const PR_EGG_ADJECTIVES = [
+  "Gilded",
+  "Moonlit",
+  "Velvet",
+  "Neon",
+  "Tiny",
+  "Brave",
+  "Clockwork",
+  "Pearl",
+  "Mossy",
+  "Cosmic",
+  "Sunspot",
+  "Frosted",
+];
+
+const PR_EGG_SPECIES = [
+  "Shellbean",
+  "Clawlet",
+  "Lint Imp",
+  "Merge Sprite",
+  "Proofling",
+  "Diff Drake",
+  "Patch Peep",
+  "Review Wisp",
+  "Branchling",
+  "Test Hopper",
+  "Crabkin",
+  "Signal Puff",
+];
+
+const PR_EGG_TRAITS = [
+  "keeps receipts",
+  "sniffs out flaky tests",
+  "guards the happy path",
+  "collects tiny proofs",
+  "purrs at green checks",
+  "stacks clean commits",
+  "polishes edge cases",
+  "watches the merge queue",
+  "finds missing screenshots",
+  "sleeps inside passing CI",
+  "sparkles near resolved comments",
+  "hums during re-review",
+];
+
+const PR_EGG_PORTRAITS = [
+  "     /\\_/\\\\\n   ~( o.o )~\n    /| ^ |\\\\\n   (_|___|_)",
+  "     .-^-.\n   .' o o '.\n  /  \\_-_/  \\\n   '._/ \\_.'",
+  "    __/\\__\n  .'  oo  '.\n <   \\__/   >\n   `-.__.-'",
+  "    .--.\n  .'_\\/_'.\n  |  o o |\n  |  \\_/ |\n   '.___.'",
+  "    /\\   /\\\n   (  'v'  )\n  /|  ___  |\\\\\n    `-----'",
+  "     .---.\n   .' ^ ^ '.\n  (   \\_/   )\n   '-.___.-'",
+];
+
+function hashNumber(seed: string, salt: string): number {
+  return Number.parseInt(sha256(`${salt}:${seed}`).slice(0, 12), 16);
+}
+
+function pickSeeded<T>(values: readonly T[], seed: string, salt: string): T {
+  return values[hashNumber(seed, salt) % values.length]!;
+}
+
+function prEggRarity(seed: string): { rarity: PrEggRarity; label: string } {
+  const roll = hashNumber(seed, "rarity") % 10000;
+  return PR_EGG_RARITIES.find((entry) => roll < entry.cutoff) ?? PR_EGG_RARITIES[0]!;
+}
+
+function prEggCreature(seed: string): {
+  name: string;
+  rarity: PrEggRarity;
+  rarityLabel: string;
+  trait: string;
+  portrait: string;
+  shareText: string;
+} {
+  const rarity = prEggRarity(seed);
+  const name = `${pickSeeded(PR_EGG_ADJECTIVES, seed, "adjective")} ${pickSeeded(
+    PR_EGG_SPECIES,
+    seed,
+    "species",
+  )}`;
+  const shareText = `My PR egg hatched a ${rarity.label} ${name} in ClawSweeper.`;
+  return {
+    name,
+    rarity: rarity.rarity,
+    rarityLabel: rarity.label,
+    trait: pickSeeded(PR_EGG_TRAITS, seed, "trait"),
+    portrait: pickSeeded(PR_EGG_PORTRAITS, seed, "portrait"),
+    shareText,
+  };
+}
+
+export function prEggCreatureForTest(seed: string): ReturnType<typeof prEggCreature> {
+  return prEggCreature(seed);
 }
 
 function defaultRatingNextSteps(options: {
@@ -8092,6 +8277,17 @@ function renderKeepOpenCommentFromReport(markdown: string): string {
   }
   if (isPullRequest) {
     appendPublicSection(lines, "PR rating", publicPrRatingLine(prRating, realBehaviorProof));
+    appendPublicSection(
+      lines,
+      "PR egg",
+      publicPrEggLine(markdown, {
+        realBehaviorProof,
+        prRating,
+        reviewFindings,
+        securityReview,
+        overallCorrectness: reportOverallCorrectness(markdown),
+      }),
+    );
     appendPublicSection(
       lines,
       "Real behavior proof",

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -5507,6 +5507,18 @@ function publicPrEggLine(
 ): string {
   const seed = prEggSeedFromReport(markdown);
   const state = prEggStateFromReport(markdown, options);
+  const explainer = [
+    "",
+    "<details>",
+    "<summary>How the PR egg works</summary>",
+    "",
+    "- The egg is cosmetic and PR-only; it does not affect labels, ratings, merge decisions, or automation.",
+    "- Egg states come from the same review signals ClawSweeper already reports: unresolved proof or findings, re-review loops, and clean final-review readiness.",
+    "- Hatches are deterministic from this repository, PR number, and reviewed head SHA, so the same PR revision gets the same creature.",
+    "- Rarity is collectible flavor only: 🥚 common, 🌱 uncommon, 💎 rare, ✨ glimmer, and 🌈 legendary.",
+    "",
+    "</details>",
+  ];
   if (state === "hatched") {
     const creature = prEggCreature(seed);
     const shareUrl = `https://x.com/intent/tweet?text=${encodeURIComponent(creature.shareText)}`;
@@ -5519,6 +5531,7 @@ function publicPrEggLine(
       `Trait: ${creature.trait}.`,
       `Share on X: ${markdownLink("post this hatch", shareUrl)}`,
       `Copy: ${creature.shareText}`,
+      ...explainer,
     ].join("\n");
   }
   const stateLines: Record<Exclude<PrEggState, "hatched">, string> = {
@@ -5526,7 +5539,14 @@ function publicPrEggLine(
     warming: "🔥 Warming up: proof, findings, or rank-up moves are still in progress.",
     wobbling: "🔁 Wobbling: a re-review loop is active, so the shell is rattling.",
   };
-  return [stateLines[state], "", "```text", pickSeeded(PR_EGG_ART, seed, state), "```"].join("\n");
+  return [
+    stateLines[state],
+    "",
+    "```text",
+    pickSeeded(PR_EGG_ART, seed, state),
+    "```",
+    ...explainer,
+  ].join("\n");
 }
 
 function publicMantisRecommendationBlock(recommendation: MantisRecommendation): string {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -128,7 +128,7 @@ type PrStatusLabelKind =
   | "ready_for_maintainer_look";
 type PrEggState = "incubating" | "warming" | "wobbling" | "hatched";
 type PrEggRarity = "common" | "uncommon" | "rare" | "glimmer" | "legendary";
-type PrEggSpriteLayer = readonly [string, string, string, string, string, string, string];
+type PrEggSpriteLayer = readonly string[];
 type TelegramVisibleProofStatus = "needed" | "not_needed";
 type MantisRecommendationStatus = "recommended" | "not_recommended";
 type MantisRecommendationScenario =
@@ -6282,183 +6282,212 @@ const PR_EGG_TRAITS = [
   "hums during re-review",
 ];
 
-const PR_EGG_SPRITE_WIDTH = 19;
+const PR_EGG_SPRITE_WIDTH = 31;
+const PR_EGG_SPRITE_HEIGHT = 11;
+
+function prEggSpriteLayer(lines: readonly string[]): PrEggSpriteLayer {
+  return Array.from({ length: PR_EGG_SPRITE_HEIGHT }, (_value, index) =>
+    (lines[index] ?? "").padEnd(PR_EGG_SPRITE_WIDTH, " ").slice(0, PR_EGG_SPRITE_WIDTH),
+  );
+}
 
 const PR_EGG_AURAS: PrEggSpriteLayer[] = [
-  [
-    "                   ",
-    "                   ",
-    "                   ",
-    "                   ",
-    "                   ",
-    "                   ",
-    "                   ",
-  ],
-  [
-    "  *             *  ",
-    "       .           ",
-    "                   ",
-    "                   ",
-    "                   ",
-    "           .       ",
-    "  *             *  ",
-  ],
-  [
-    "   .-.       .-.   ",
-    "  (   )     (   )  ",
-    "   `-'       `-'   ",
-    "                   ",
-    "   .-.       .-.   ",
-    "  (   )     (   )  ",
-    "   `-'       `-'   ",
-  ],
+  prEggSpriteLayer([]),
+  prEggSpriteLayer([
+    " *                         * ",
+    "       .             .       ",
+    "                             ",
+    "   .                     .   ",
+    "                             ",
+    "                             ",
+    "                             ",
+    "     .                 .     ",
+    "                             ",
+    "       .             .       ",
+    " *                         * ",
+  ]),
+  prEggSpriteLayer([
+    " .                           .",
+    "      *                 *     ",
+    "                             ",
+    "                             ",
+    " .                         . ",
+    "                             ",
+    " .                         . ",
+    "                             ",
+    "      *                 *     ",
+    " .                           .",
+  ]),
+  prEggSpriteLayer([
+    "    /\\                 /\\    ",
+    "   /  \\               /  \\   ",
+    "   \\__/               \\__/   ",
+    "                             ",
+    "  .--.                 .--.  ",
+    " (    )               (    ) ",
+    "  '--'                 '--'  ",
+    "        .          .        ",
+    "    /\\                /\\    ",
+    "   /__\\              /__\\   ",
+  ]),
 ];
 
 const PR_EGG_TOPS: PrEggSpriteLayer[] = [
-  [
-    "       .---.       ",
-    "     .'     '.     ",
-    "                   ",
-    "                   ",
-    "                   ",
-    "                   ",
-    "                   ",
-  ],
-  [
-    "       /\\_/\\       ",
-    "     .'     '.     ",
-    "                   ",
-    "                   ",
-    "                   ",
-    "                   ",
-    "                   ",
-  ],
-  [
-    "     _/     \\_     ",
-    "   .'         '.   ",
-    "                   ",
-    "                   ",
-    "                   ",
-    "                   ",
-    "                   ",
-  ],
-  [
-    "       .-^-.       ",
-    "    .-'     '-.    ",
-    "                   ",
-    "                   ",
-    "                   ",
-    "                   ",
-    "                   ",
-  ],
+  prEggSpriteLayer([
+    "             .---.             ",
+    "          .-'     '-.          ",
+    "        .'  .---.    '.        ",
+  ]),
+  prEggSpriteLayer([
+    "          /\\       /\\          ",
+    "        _/  \\_.-._/  \\_        ",
+    "       /                 \\      ",
+  ]),
+  prEggSpriteLayer([
+    "            _..---.._           ",
+    "        _.-'  .---.  '-._       ",
+    "      .'     /     \\     '.     ",
+  ]),
+  prEggSpriteLayer([
+    "        .--.   .^.   .--.       ",
+    "       /    \\_/   \\_/    \\      ",
+    "      /                   \\     ",
+  ]),
+  prEggSpriteLayer([
+    "           __/\\___/\\__          ",
+    "        .-'  _     _  '-.       ",
+    "      .'    (_)   (_)    '.     ",
+  ]),
 ];
 
 const PR_EGG_FACES: PrEggSpriteLayer[] = [
-  [
-    "                   ",
-    "                   ",
-    "    /  o   o  \\    ",
-    "   |     v     |   ",
-    "                   ",
-    "                   ",
-    "                   ",
-  ],
-  [
-    "                   ",
-    "                   ",
-    "    /  -   -  \\    ",
-    "   |    ._.    |   ",
-    "                   ",
-    "                   ",
-    "                   ",
-  ],
-  [
-    "                   ",
-    "                   ",
-    "    /  *   *  \\    ",
-    "   |    \\_/    |   ",
-    "                   ",
-    "                   ",
-    "                   ",
-  ],
-  [
-    "                   ",
-    "                   ",
-    "    /  >   <  \\    ",
-    "   |    \\w/    |   ",
-    "                   ",
-    "                   ",
-    "                   ",
-  ],
+  prEggSpriteLayer([
+    "",
+    "",
+    "",
+    "           o       o           ",
+    "               v               ",
+  ]),
+  prEggSpriteLayer([
+    "",
+    "",
+    "",
+    "           -       -           ",
+    "              ._.              ",
+  ]),
+  prEggSpriteLayer([
+    "",
+    "",
+    "",
+    "           *       *           ",
+    "              \\_/              ",
+  ]),
+  prEggSpriteLayer([
+    "",
+    "",
+    "",
+    "           >       <           ",
+    "              \\w/              ",
+  ]),
+  prEggSpriteLayer(["", "", "", "         {o}     {o}         ", "              .-.            "]),
 ];
 
 const PR_EGG_BODIES: PrEggSpriteLayer[] = [
-  [
-    "                   ",
-    "                   ",
-    "                   ",
-    "                   ",
-    "    \\   ___   /    ",
-    "     '.___.'       ",
-    "                   ",
-  ],
-  [
-    "                   ",
-    "                   ",
-    "                   ",
-    "                   ",
-    "    \\  \\___/  /    ",
-    "   <_'-----'_>     ",
-    "                   ",
-  ],
-  [
-    "                   ",
-    "                   ",
-    "                   ",
-    "                   ",
-    "    \\  /___\\  /    ",
-    "     '(____)'      ",
-    "                   ",
-  ],
-  [
-    "                   ",
-    "                   ",
-    "                   ",
-    "                   ",
-    "    \\  .---.  /    ",
-    "     `-(___)-'     ",
-    "                   ",
-  ],
+  prEggSpriteLayer([
+    "",
+    "",
+    "",
+    "",
+    "    |      .-----'.      |     ",
+    "     \\    /  ___  \\    /      ",
+    "      '.  \\______/  .'        ",
+    "        '-.______.-'          ",
+  ]),
+  prEggSpriteLayer([
+    "",
+    "",
+    "",
+    "",
+    "    |    _/|     |\\_    |     ",
+    "   <|   /  |_____|  \\   |>    ",
+    "     \\  \\_.-----._/  /       ",
+    "      '._  `---'  _.'        ",
+  ]),
+  prEggSpriteLayer([
+    "",
+    "",
+    "",
+    "",
+    "    |    .-._____.-.    |     ",
+    "     \\  (   \\___/   )  /      ",
+    "      '. \\  /___\\  / .'       ",
+    "        '-`-.___.-'-'         ",
+  ]),
+  prEggSpriteLayer([
+    "",
+    "",
+    "",
+    "",
+    "    |    /\\  ___  /\\    |     ",
+    "   /|   /  \\/___\\/  \\   |\\    ",
+    "  <_|   \\  /_____\\  /   |_>   ",
+    "        '-._____.-'          ",
+  ]),
 ];
 
 const PR_EGG_FEET: PrEggSpriteLayer[] = [
-  [
-    "                   ",
-    "                   ",
-    "                   ",
-    "                   ",
-    "                   ",
-    "                   ",
-    "       /|_|\\       ",
-  ],
-  [
-    "                   ",
-    "                   ",
-    "                   ",
-    "                   ",
-    "                   ",
-    "                   ",
-    "      _/|_|\\_      ",
-  ],
-  [
-    "                   ",
-    "                   ",
-    "                   ",
-    "                   ",
-    "                   ",
-    "                   ",
-    "       ~~~~~       ",
-  ],
+  prEggSpriteLayer([
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "          /|_|\\   /|_|\\       ",
+    "         /_| |_\\ /_| |_\\      ",
+    "        '---'     '---'       ",
+  ]),
+  prEggSpriteLayer([
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "        _/|_|\\_ _/|_|\\_       ",
+    "       /__| |__X__| |__\\      ",
+    "          ' '     ' '         ",
+  ]),
+  prEggSpriteLayer([
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "         ~~~/|_|\\~~~~         ",
+    "       ~~~~/_| |_\\~~~~        ",
+    "          ~~~~~~~~~           ",
+  ]),
+  prEggSpriteLayer([
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "        __     _     __       ",
+    "       /  \\___/ \\___/  \\      ",
+    "       \\__/         \\__/      ",
+  ]),
 ];
 
 function hashNumber(seed: string, salt: string): number {
@@ -6477,7 +6506,7 @@ function composePrEggSprite(seed: string): string {
     pickSeeded(PR_EGG_BODIES, seed, "body"),
     pickSeeded(PR_EGG_FEET, seed, "feet"),
   ];
-  return Array.from({ length: 7 }, (_value, lineIndex) =>
+  return Array.from({ length: PR_EGG_SPRITE_HEIGHT }, (_value, lineIndex) =>
     layers
       .map((layer) => layer[lineIndex]!)
       .reduce((composed, layerLine) =>

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -128,7 +128,6 @@ type PrStatusLabelKind =
   | "ready_for_maintainer_look";
 type PrEggState = "incubating" | "warming" | "wobbling" | "hatched";
 type PrEggRarity = "common" | "uncommon" | "rare" | "glimmer" | "legendary";
-type PrEggSpriteLayer = readonly string[];
 type TelegramVisibleProofStatus = "needed" | "not_needed";
 type MantisRecommendationStatus = "recommended" | "not_recommended";
 type MantisRecommendationScenario =
@@ -6282,211 +6281,63 @@ const PR_EGG_TRAITS = [
   "hums during re-review",
 ];
 
-const PR_EGG_SPRITE_WIDTH = 31;
-const PR_EGG_SPRITE_HEIGHT = 11;
+const PR_EGG_SPRITE_WIDTH = 29;
+const PR_EGG_SPRITE_HEIGHT = 12;
 
-function prEggSpriteLayer(lines: readonly string[]): PrEggSpriteLayer {
+function prEggSpriteLines(lines: readonly string[]): string[] {
   return Array.from({ length: PR_EGG_SPRITE_HEIGHT }, (_value, index) =>
     (lines[index] ?? "").padEnd(PR_EGG_SPRITE_WIDTH, " ").slice(0, PR_EGG_SPRITE_WIDTH),
   );
 }
 
-const PR_EGG_AURAS: PrEggSpriteLayer[] = [
-  prEggSpriteLayer([]),
-  prEggSpriteLayer([
-    " *                         * ",
-    "       .             .       ",
-    "                             ",
-    "   .                     .   ",
-    "                             ",
-    "                             ",
-    "                             ",
-    "     .                 .     ",
-    "                             ",
-    "       .             .       ",
-    " *                         * ",
+const PR_EGG_BASE_SPRITES = [
+  prEggSpriteLines([
+    "        /\\     /\\        ",
+    "      _/  \\___/  \\_      ",
+    "     /  ( o   o )  \\     ",
+    "    |      \\_/      |    ",
+    "    |   /\\  ===  /\\ |    ",
+    "     \\_/  \\_____/  \\_/   ",
+    "        _/|_| |_|\\_      ",
+    "       /__| | | |__\\     ",
+    "          ' ' ' '        ",
+    "         /_/     \\_\\     ",
   ]),
-  prEggSpriteLayer([
-    " .                           .",
-    "      *                 *     ",
-    "                             ",
-    "                             ",
-    " .                         . ",
-    "                             ",
-    " .                         . ",
-    "                             ",
-    "      *                 *     ",
-    " .                           .",
+  prEggSpriteLines([
+    "        .--^^^^--.       ",
+    "     .-'  o    o  '-.    ",
+    "    /       \\__/      \\   ",
+    "   |    /\\  ____  /\\   |  ",
+    "   |   /  \\/____\\/  \\  |  ",
+    "    \\  \\_.------._/  /  ",
+    "     '._  `----'  _.'   ",
+    "        '-.____.-'      ",
+    "       _/|_|  |_|\\_     ",
+    "      /__|      |__\\    ",
   ]),
-  prEggSpriteLayer([
-    "    /\\                 /\\    ",
-    "   /  \\               /  \\   ",
-    "   \\__/               \\__/   ",
-    "                             ",
-    "  .--.                 .--.  ",
-    " (    )               (    ) ",
-    "  '--'                 '--'  ",
-    "        .          .        ",
-    "    /\\                /\\    ",
-    "   /__\\              /__\\   ",
+  prEggSpriteLines([
+    "       _..------.._      ",
+    "    .-'  .-.  .-.  '-.   ",
+    "   /    ( * )( * )    \\  ",
+    "  |        .--.        | ",
+    "  |   <\\   ====   />   | ",
+    "   \\    '.______.'    /  ",
+    "    '-._   ____   _.-'   ",
+    "        `-.____.-'       ",
+    "       __/|_||_|\\__      ",
+    "      /__.'    '.__\\     ",
   ]),
-];
-
-const PR_EGG_TOPS: PrEggSpriteLayer[] = [
-  prEggSpriteLayer([
-    "             .---.             ",
-    "          .-'     '-.          ",
-    "        .'  .---.    '.        ",
-  ]),
-  prEggSpriteLayer([
-    "          /\\       /\\          ",
-    "        _/  \\_.-._/  \\_        ",
-    "       /                 \\      ",
-  ]),
-  prEggSpriteLayer([
-    "            _..---.._           ",
-    "        _.-'  .---.  '-._       ",
-    "      .'     /     \\     '.     ",
-  ]),
-  prEggSpriteLayer([
-    "        .--.   .^.   .--.       ",
-    "       /    \\_/   \\_/    \\      ",
-    "      /                   \\     ",
-  ]),
-  prEggSpriteLayer([
-    "           __/\\___/\\__          ",
-    "        .-'  _     _  '-.       ",
-    "      .'    (_)   (_)    '.     ",
-  ]),
-];
-
-const PR_EGG_FACES: PrEggSpriteLayer[] = [
-  prEggSpriteLayer([
-    "",
-    "",
-    "",
-    "           o       o           ",
-    "               v               ",
-  ]),
-  prEggSpriteLayer([
-    "",
-    "",
-    "",
-    "           -       -           ",
-    "              ._.              ",
-  ]),
-  prEggSpriteLayer([
-    "",
-    "",
-    "",
-    "           *       *           ",
-    "              \\_/              ",
-  ]),
-  prEggSpriteLayer([
-    "",
-    "",
-    "",
-    "           >       <           ",
-    "              \\w/              ",
-  ]),
-  prEggSpriteLayer(["", "", "", "         {o}     {o}         ", "              .-.            "]),
-];
-
-const PR_EGG_BODIES: PrEggSpriteLayer[] = [
-  prEggSpriteLayer([
-    "",
-    "",
-    "",
-    "",
-    "    |      .-----'.      |     ",
-    "     \\    /  ___  \\    /      ",
-    "      '.  \\______/  .'        ",
-    "        '-.______.-'          ",
-  ]),
-  prEggSpriteLayer([
-    "",
-    "",
-    "",
-    "",
-    "    |    _/|     |\\_    |     ",
-    "   <|   /  |_____|  \\   |>    ",
-    "     \\  \\_.-----._/  /       ",
-    "      '._  `---'  _.'        ",
-  ]),
-  prEggSpriteLayer([
-    "",
-    "",
-    "",
-    "",
-    "    |    .-._____.-.    |     ",
-    "     \\  (   \\___/   )  /      ",
-    "      '. \\  /___\\  / .'       ",
-    "        '-`-.___.-'-'         ",
-  ]),
-  prEggSpriteLayer([
-    "",
-    "",
-    "",
-    "",
-    "    |    /\\  ___  /\\    |     ",
-    "   /|   /  \\/___\\/  \\   |\\    ",
-    "  <_|   \\  /_____\\  /   |_>   ",
-    "        '-._____.-'          ",
-  ]),
-];
-
-const PR_EGG_FEET: PrEggSpriteLayer[] = [
-  prEggSpriteLayer([
-    "",
-    "",
-    "",
-    "",
-    "",
-    "",
-    "",
-    "",
-    "          /|_|\\   /|_|\\       ",
-    "         /_| |_\\ /_| |_\\      ",
-    "        '---'     '---'       ",
-  ]),
-  prEggSpriteLayer([
-    "",
-    "",
-    "",
-    "",
-    "",
-    "",
-    "",
-    "",
-    "        _/|_|\\_ _/|_|\\_       ",
-    "       /__| |__X__| |__\\      ",
-    "          ' '     ' '         ",
-  ]),
-  prEggSpriteLayer([
-    "",
-    "",
-    "",
-    "",
-    "",
-    "",
-    "",
-    "",
-    "         ~~~/|_|\\~~~~         ",
-    "       ~~~~/_| |_\\~~~~        ",
-    "          ~~~~~~~~~           ",
-  ]),
-  prEggSpriteLayer([
-    "",
-    "",
-    "",
-    "",
-    "",
-    "",
-    "",
-    "",
-    "        __     _     __       ",
-    "       /  \\___/ \\___/  \\      ",
-    "       \\__/         \\__/      ",
+  prEggSpriteLines([
+    "       /\\  .---.  /\\     ",
+    "      /  \\/     \\/  \\    ",
+    "     /   ( -   - )   \\   ",
+    "    |       ._.       |  ",
+    "    |   /|  ===  |\\   |  ",
+    "     \\  \\|______/|/  /   ",
+    "      '._  `--'  _.'     ",
+    "         '-.__.-'        ",
+    "       _/|_|  |_|\\_      ",
+    "      /__|      |__\\     ",
   ]),
 ];
 
@@ -6498,24 +6349,36 @@ function pickSeeded<T>(values: readonly T[], seed: string, salt: string): T {
   return values[hashNumber(seed, salt) % values.length]!;
 }
 
-function composePrEggSprite(seed: string): string {
-  const layers = [
-    pickSeeded(PR_EGG_AURAS, seed, "aura"),
-    pickSeeded(PR_EGG_TOPS, seed, "top"),
-    pickSeeded(PR_EGG_FACES, seed, "face"),
-    pickSeeded(PR_EGG_BODIES, seed, "body"),
-    pickSeeded(PR_EGG_FEET, seed, "feet"),
-  ];
-  return Array.from({ length: PR_EGG_SPRITE_HEIGHT }, (_value, lineIndex) =>
-    layers
-      .map((layer) => layer[lineIndex]!)
-      .reduce((composed, layerLine) =>
-        Array.from({ length: PR_EGG_SPRITE_WIDTH }, (_char, charIndex) => {
-          const overlay = layerLine[charIndex] ?? " ";
-          return overlay === " " ? (composed[charIndex] ?? " ") : overlay;
-        }).join(""),
-      ),
-  ).join("\n");
+function decoratePrEggSprite(
+  lines: readonly string[],
+  seed: string,
+  rarity: PrEggRarity,
+): string[] {
+  const body = lines.filter((line) => line.trim().length > 0);
+  const sigil = pickSeeded(["*", "+", "=", "~"], seed, "sprite-sigil");
+  if (rarity === "legendary") {
+    return prEggSpriteLines(["*====[ LEGENDARY ]====*", ...body, "*=====================*"]);
+  }
+  if (rarity === "glimmer") {
+    return prEggSpriteLines([
+      ...body,
+      "       `-----------'       ",
+      `.${sigil}~~~~~~~~~~~~~~~~~~~${sigil}.`,
+    ]);
+  }
+  if (rarity === "rare") {
+    return prEggSpriteLines([
+      ...body,
+      "       `-----------'       ",
+      ` ${sigil}===================${sigil}`,
+    ]);
+  }
+  return prEggSpriteLines([...body, "       .-----------.       ", "      '-------------'      "]);
+}
+
+function composePrEggSprite(seed: string, rarity: PrEggRarity): string {
+  const base = pickSeeded(PR_EGG_BASE_SPRITES, seed, "base-sprite");
+  return decoratePrEggSprite(base, seed, rarity).join("\n");
 }
 
 function prEggRarity(seed: string): { rarity: PrEggRarity; label: string } {
@@ -6543,7 +6406,7 @@ function prEggCreature(seed: string): {
     rarity: rarity.rarity,
     rarityLabel: rarity.label,
     trait: pickSeeded(PR_EGG_TRAITS, seed, "trait"),
-    portrait: composePrEggSprite(seed),
+    portrait: composePrEggSprite(seed, rarity.rarity),
     shareText,
   };
 }
@@ -6553,7 +6416,7 @@ export function prEggCreatureForTest(seed: string): ReturnType<typeof prEggCreat
 }
 
 export function prEggSpriteMetricsForTest(seed: string): { lines: string[]; width: number } {
-  const lines = composePrEggSprite(seed).split("\n");
+  const lines = composePrEggSprite(seed, "common").split("\n");
   return { lines, width: PR_EGG_SPRITE_WIDTH };
 }
 

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -128,6 +128,7 @@ type PrStatusLabelKind =
   | "ready_for_maintainer_look";
 type PrEggState = "incubating" | "warming" | "wobbling" | "hatched";
 type PrEggRarity = "common" | "uncommon" | "rare" | "glimmer" | "legendary";
+type PrEggSpriteLayer = readonly [string, string, string, string, string, string, string];
 type TelegramVisibleProofStatus = "needed" | "not_needed";
 type MantisRecommendationStatus = "recommended" | "not_recommended";
 type MantisRecommendationScenario =
@@ -6258,13 +6259,183 @@ const PR_EGG_TRAITS = [
   "hums during re-review",
 ];
 
-const PR_EGG_PORTRAITS = [
-  "     /\\_/\\\\\n   ~( o.o )~\n    /| ^ |\\\\\n   (_|___|_)",
-  "     .-^-.\n   .' o o '.\n  /  \\_-_/  \\\n   '._/ \\_.'",
-  "    __/\\__\n  .'  oo  '.\n <   \\__/   >\n   `-.__.-'",
-  "    .--.\n  .'_\\/_'.\n  |  o o |\n  |  \\_/ |\n   '.___.'",
-  "    /\\   /\\\n   (  'v'  )\n  /|  ___  |\\\\\n    `-----'",
-  "     .---.\n   .' ^ ^ '.\n  (   \\_/   )\n   '-.___.-'",
+const PR_EGG_SPRITE_WIDTH = 19;
+
+const PR_EGG_AURAS: PrEggSpriteLayer[] = [
+  [
+    "                   ",
+    "                   ",
+    "                   ",
+    "                   ",
+    "                   ",
+    "                   ",
+    "                   ",
+  ],
+  [
+    "  *             *  ",
+    "       .           ",
+    "                   ",
+    "                   ",
+    "                   ",
+    "           .       ",
+    "  *             *  ",
+  ],
+  [
+    "   .-.       .-.   ",
+    "  (   )     (   )  ",
+    "   `-'       `-'   ",
+    "                   ",
+    "   .-.       .-.   ",
+    "  (   )     (   )  ",
+    "   `-'       `-'   ",
+  ],
+];
+
+const PR_EGG_TOPS: PrEggSpriteLayer[] = [
+  [
+    "       .---.       ",
+    "     .'     '.     ",
+    "                   ",
+    "                   ",
+    "                   ",
+    "                   ",
+    "                   ",
+  ],
+  [
+    "       /\\_/\\       ",
+    "     .'     '.     ",
+    "                   ",
+    "                   ",
+    "                   ",
+    "                   ",
+    "                   ",
+  ],
+  [
+    "     _/     \\_     ",
+    "   .'         '.   ",
+    "                   ",
+    "                   ",
+    "                   ",
+    "                   ",
+    "                   ",
+  ],
+  [
+    "       .-^-.       ",
+    "    .-'     '-.    ",
+    "                   ",
+    "                   ",
+    "                   ",
+    "                   ",
+    "                   ",
+  ],
+];
+
+const PR_EGG_FACES: PrEggSpriteLayer[] = [
+  [
+    "                   ",
+    "                   ",
+    "    /  o   o  \\    ",
+    "   |     v     |   ",
+    "                   ",
+    "                   ",
+    "                   ",
+  ],
+  [
+    "                   ",
+    "                   ",
+    "    /  -   -  \\    ",
+    "   |    ._.    |   ",
+    "                   ",
+    "                   ",
+    "                   ",
+  ],
+  [
+    "                   ",
+    "                   ",
+    "    /  *   *  \\    ",
+    "   |    \\_/    |   ",
+    "                   ",
+    "                   ",
+    "                   ",
+  ],
+  [
+    "                   ",
+    "                   ",
+    "    /  >   <  \\    ",
+    "   |    \\w/    |   ",
+    "                   ",
+    "                   ",
+    "                   ",
+  ],
+];
+
+const PR_EGG_BODIES: PrEggSpriteLayer[] = [
+  [
+    "                   ",
+    "                   ",
+    "                   ",
+    "                   ",
+    "    \\   ___   /    ",
+    "     '.___.'       ",
+    "                   ",
+  ],
+  [
+    "                   ",
+    "                   ",
+    "                   ",
+    "                   ",
+    "    \\  \\___/  /    ",
+    "   <_'-----'_>     ",
+    "                   ",
+  ],
+  [
+    "                   ",
+    "                   ",
+    "                   ",
+    "                   ",
+    "    \\  /___\\  /    ",
+    "     '(____)'      ",
+    "                   ",
+  ],
+  [
+    "                   ",
+    "                   ",
+    "                   ",
+    "                   ",
+    "    \\  .---.  /    ",
+    "     `-(___)-'     ",
+    "                   ",
+  ],
+];
+
+const PR_EGG_FEET: PrEggSpriteLayer[] = [
+  [
+    "                   ",
+    "                   ",
+    "                   ",
+    "                   ",
+    "                   ",
+    "                   ",
+    "       /|_|\\       ",
+  ],
+  [
+    "                   ",
+    "                   ",
+    "                   ",
+    "                   ",
+    "                   ",
+    "                   ",
+    "      _/|_|\\_      ",
+  ],
+  [
+    "                   ",
+    "                   ",
+    "                   ",
+    "                   ",
+    "                   ",
+    "                   ",
+    "       ~~~~~       ",
+  ],
 ];
 
 function hashNumber(seed: string, salt: string): number {
@@ -6273,6 +6444,26 @@ function hashNumber(seed: string, salt: string): number {
 
 function pickSeeded<T>(values: readonly T[], seed: string, salt: string): T {
   return values[hashNumber(seed, salt) % values.length]!;
+}
+
+function composePrEggSprite(seed: string): string {
+  const layers = [
+    pickSeeded(PR_EGG_AURAS, seed, "aura"),
+    pickSeeded(PR_EGG_TOPS, seed, "top"),
+    pickSeeded(PR_EGG_FACES, seed, "face"),
+    pickSeeded(PR_EGG_BODIES, seed, "body"),
+    pickSeeded(PR_EGG_FEET, seed, "feet"),
+  ];
+  return Array.from({ length: 7 }, (_value, lineIndex) =>
+    layers
+      .map((layer) => layer[lineIndex]!)
+      .reduce((composed, layerLine) =>
+        Array.from({ length: PR_EGG_SPRITE_WIDTH }, (_char, charIndex) => {
+          const overlay = layerLine[charIndex] ?? " ";
+          return overlay === " " ? (composed[charIndex] ?? " ") : overlay;
+        }).join(""),
+      ),
+  ).join("\n");
 }
 
 function prEggRarity(seed: string): { rarity: PrEggRarity; label: string } {
@@ -6300,13 +6491,18 @@ function prEggCreature(seed: string): {
     rarity: rarity.rarity,
     rarityLabel: rarity.label,
     trait: pickSeeded(PR_EGG_TRAITS, seed, "trait"),
-    portrait: pickSeeded(PR_EGG_PORTRAITS, seed, "portrait"),
+    portrait: composePrEggSprite(seed),
     shareText,
   };
 }
 
 export function prEggCreatureForTest(seed: string): ReturnType<typeof prEggCreature> {
   return prEggCreature(seed);
+}
+
+export function prEggSpriteMetricsForTest(seed: string): { lines: string[]; width: number } {
+  const lines = composePrEggSprite(seed).split("\n");
+  return { lines, width: PR_EGG_SPRITE_WIDTH };
 }
 
 function defaultRatingNextSteps(options: {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -5456,11 +5456,16 @@ function publicPrRatingLine(rating: PrRating, proof: RealBehaviorProof): string 
   return lines.join("\n");
 }
 
-function prEggSeedFromReport(markdown: string): string {
+function prEggIdentitySeedFromReport(markdown: string): string {
   const repo = markdownRepository(markdown);
   const number = frontMatterValue(markdown, "number") ?? "unknown";
+  return `${repo}#${number}`;
+}
+
+function prEggVisualSeedFromReport(markdown: string): string {
+  const identitySeed = prEggIdentitySeedFromReport(markdown);
   const headSha = frontMatterValue(markdown, "pull_head_sha") ?? "unknown";
-  return `${repo}#${number}@${headSha}`;
+  return `${identitySeed}@${headSha}`;
 }
 
 function prEggStateFromReport(
@@ -5471,6 +5476,7 @@ function prEggStateFromReport(
     reviewFindings: readonly Pick<ReviewFinding, "priority">[];
     securityReview: Pick<SecurityReview, "status">;
     overallCorrectness: OverallCorrectness;
+    statusKind?: PrStatusLabelKind | null;
   },
 ): PrEggState {
   const isReady =
@@ -5482,8 +5488,7 @@ function prEggStateFromReport(
       overallCorrectness: options.overallCorrectness,
     });
   if (isReady) return "hatched";
-  const labels = frontMatterStringArray(markdown, "labels");
-  if (labels.includes("status: 🔁 re-review loop")) return "wobbling";
+  if (options.statusKind === "re_review_loop") return "wobbling";
   const hasUnresolvedWork =
     options.prRating.nextSteps.length > 0 ||
     hasUnresolvedContributorWork({
@@ -5511,6 +5516,7 @@ function publicPrEggLine(
     reviewFindings: readonly Pick<ReviewFinding, "priority">[];
     securityReview: Pick<SecurityReview, "status">;
     overallCorrectness: OverallCorrectness;
+    statusKind?: PrStatusLabelKind | null;
   },
 ): string {
   if (!prEggProofUnlocked(options.realBehaviorProof)) {
@@ -5528,7 +5534,8 @@ function publicPrEggLine(
     ].join("\n");
   }
 
-  const seed = prEggSeedFromReport(markdown);
+  const identitySeed = prEggIdentitySeedFromReport(markdown);
+  const visualSeed = prEggVisualSeedFromReport(markdown);
   const state = prEggStateFromReport(markdown, options);
   const explainer = [
     "",
@@ -5537,13 +5544,13 @@ function publicPrEggLine(
     "",
     "- Eggs appear after the PR passes real-behavior proof. It is here for vibes, not verdicts: it does not change labels, ratings, merge decisions, or automation.",
     "- The shell reacts to review momentum: open follow-up work warms it up, re-review makes it wobble, and a clean final review lets it hatch.",
-    "- The hatch is seeded from this repository, PR number, and reviewed head SHA, so the same PR revision gets the same little creature every time.",
+    "- The hatch is seeded from this repository and PR number, so the same PR keeps the same creature; the reviewed head SHA can only change safe visual details.",
     "- Rarity is just collectible sparkle: 🥚 common, 🌱 uncommon, 💎 rare, ✨ glimmer, and 🌈 legendary.",
     "",
     "</details>",
   ];
   if (state === "hatched") {
-    const creature = prEggCreature(seed);
+    const creature = prEggCreature(identitySeed, visualSeed);
     const shareUrl = `https://x.com/intent/tweet?text=${encodeURIComponent(creature.shareText)}`;
     return [
       `✨ Hatched: ${creature.rarityLabel} ${creature.name}`,
@@ -5566,7 +5573,7 @@ function publicPrEggLine(
     stateLines[state],
     "",
     "```text",
-    pickSeeded(PR_EGG_ART, seed, state),
+    pickSeeded(PR_EGG_ART, visualSeed, state),
     "```",
     ...explainer,
   ].join("\n");
@@ -6386,7 +6393,10 @@ function prEggRarity(seed: string): { rarity: PrEggRarity; label: string } {
   return PR_EGG_RARITIES.find((entry) => roll < entry.cutoff) ?? PR_EGG_RARITIES[0]!;
 }
 
-function prEggCreature(seed: string): {
+function prEggCreature(
+  identitySeed: string,
+  visualSeed = identitySeed,
+): {
   name: string;
   rarity: PrEggRarity;
   rarityLabel: string;
@@ -6394,10 +6404,10 @@ function prEggCreature(seed: string): {
   portrait: string;
   shareText: string;
 } {
-  const rarity = prEggRarity(seed);
-  const name = `${pickSeeded(PR_EGG_ADJECTIVES, seed, "adjective")} ${pickSeeded(
+  const rarity = prEggRarity(identitySeed);
+  const name = `${pickSeeded(PR_EGG_ADJECTIVES, identitySeed, "adjective")} ${pickSeeded(
     PR_EGG_SPECIES,
-    seed,
+    identitySeed,
     "species",
   )}`;
   const shareText = `My PR egg hatched a ${rarity.label} ${name} in ClawSweeper.`;
@@ -6405,14 +6415,17 @@ function prEggCreature(seed: string): {
     name,
     rarity: rarity.rarity,
     rarityLabel: rarity.label,
-    trait: pickSeeded(PR_EGG_TRAITS, seed, "trait"),
-    portrait: composePrEggSprite(seed, rarity.rarity),
+    trait: pickSeeded(PR_EGG_TRAITS, identitySeed, "trait"),
+    portrait: composePrEggSprite(visualSeed, rarity.rarity),
     shareText,
   };
 }
 
-export function prEggCreatureForTest(seed: string): ReturnType<typeof prEggCreature> {
-  return prEggCreature(seed);
+export function prEggCreatureForTest(
+  identitySeed: string,
+  visualSeed = identitySeed,
+): ReturnType<typeof prEggCreature> {
+  return prEggCreature(identitySeed, visualSeed);
 }
 
 export function prEggSpriteMetricsForTest(seed: string): { lines: string[]; width: number } {
@@ -8337,7 +8350,10 @@ function reviewWorkflowCallout(): string[] {
   ];
 }
 
-function renderKeepOpenCommentFromReport(markdown: string): string {
+function renderKeepOpenCommentFromReport(
+  markdown: string,
+  options: { prStatusKind?: PrStatusLabelKind | null } = {},
+): string {
   const evidence = reportEvidence(markdown).slice(0, 6).map(closeEvidenceLine);
   const likelyOwners = reportLikelyOwners(markdown).slice(0, 5).map(likelyOwnerLine);
   const reviewFindings = reportReviewFindings(markdown);
@@ -8417,6 +8433,7 @@ function renderKeepOpenCommentFromReport(markdown: string): string {
         reviewFindings,
         securityReview,
         overallCorrectness: reportOverallCorrectness(markdown),
+        statusKind: options.prStatusKind ?? null,
       }),
     );
     appendPublicSection(
@@ -8485,12 +8502,16 @@ function renderKeepOpenCommentFromReport(markdown: string): string {
   );
 }
 
-export function renderReviewCommentFromReport(markdown: string, reason: CloseReason): string {
+export function renderReviewCommentFromReport(
+  markdown: string,
+  reason: CloseReason,
+  options: { prStatusKind?: PrStatusLabelKind | null } = {},
+): string {
   const decision = frontMatterValue(markdown, "decision");
   const body =
     decision === "close" && reason !== "none"
       ? renderCloseCommentFromReport(markdown, reason)
-      : renderKeepOpenCommentFromReport(markdown);
+      : renderKeepOpenCommentFromReport(markdown, options);
   const markers = reviewAutomationMarkersFromReport(markdown);
   return markers ? `${body.trimEnd()}\n\n${markers}` : body;
 }
@@ -9958,6 +9979,7 @@ function applyDecisionsCommand(args: Args): void {
       if (processedCount >= processedLimit) break;
       continue;
     }
+    let currentPrStatusKind: PrStatusLabelKind | null = null;
     if (state === "open" && item.kind === "pull_request") {
       item.labels = syncRealBehaviorProofSufficientLabel({
         number,
@@ -9971,10 +9993,15 @@ function applyDecisionsCommand(args: Args): void {
         rating: reportPrRating(markdown),
         dryRun,
       });
+      currentPrStatusKind = prStatusLabelKindFromReport(
+        markdown,
+        currentItemContext(),
+        item.labels,
+      );
       item.labels = syncPrStatusLabel({
         number,
         labels: item.labels,
-        statusKind: prStatusLabelKindFromReport(markdown, currentItemContext(), item.labels),
+        statusKind: currentPrStatusKind,
         dryRun,
       });
       item.labels = syncTelegramVisibleProofLabel({
@@ -9985,7 +10012,9 @@ function applyDecisionsCommand(args: Args): void {
       });
     }
     markdown = replaceFrontMatterValue(markdown, "labels", JSON.stringify(item.labels));
-    const reviewComment = renderReviewCommentFromReport(markdown, closeReason ?? "none");
+    const reviewComment = renderReviewCommentFromReport(markdown, closeReason ?? "none", {
+      prStatusKind: currentPrStatusKind,
+    });
     const existingReviewComment = issueReviewComment(number, [
       reviewComment,
       reviewSectionValue(markdown, "closeComment"),

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -5496,6 +5496,14 @@ function prEggStateFromReport(
   return hasUnresolvedWork ? "warming" : "incubating";
 }
 
+function prEggProofUnlocked(proof: Pick<RealBehaviorProof, "status">): boolean {
+  return (
+    proof.status === "sufficient" ||
+    proof.status === "override" ||
+    proof.status === "not_applicable"
+  );
+}
+
 function publicPrEggLine(
   markdown: string,
   options: {
@@ -5506,6 +5514,21 @@ function publicPrEggLine(
     overallCorrectness: OverallCorrectness;
   },
 ): string {
+  if (!prEggProofUnlocked(options.realBehaviorProof)) {
+    return [
+      "🎁 Pass real behavior proof to wake the egg and unlock a hatchable treat.",
+      "",
+      "<details>",
+      "<summary>Where did the egg go?</summary>",
+      "",
+      "- The egg game starts only after the PR passes the real-behavior proof check.",
+      "- Before that, no creature, rarity, or ASCII portrait is rolled. The treat waits for real proof.",
+      "- This is still just collectible flavor: proof affects review readiness, not creature quality.",
+      "",
+      "</details>",
+    ].join("\n");
+  }
+
   const seed = prEggSeedFromReport(markdown);
   const state = prEggStateFromReport(markdown, options);
   const explainer = [
@@ -5513,8 +5536,8 @@ function publicPrEggLine(
     "<details>",
     "<summary>What is this egg doing here?</summary>",
     "",
-    "- Every PR gets a tiny egg. It is here for vibes, not verdicts: it does not change labels, ratings, merge decisions, or automation.",
-    "- The shell reacts to review momentum: missing proof warms it up, re-review makes it wobble, and a clean final review lets it hatch.",
+    "- Eggs appear after the PR passes real-behavior proof. It is here for vibes, not verdicts: it does not change labels, ratings, merge decisions, or automation.",
+    "- The shell reacts to review momentum: open follow-up work warms it up, re-review makes it wobble, and a clean final review lets it hatch.",
     "- The hatch is seeded from this repository, PR number, and reviewed head SHA, so the same PR revision gets the same little creature every time.",
     "- Rarity is just collectible sparkle: 🥚 common, 🌱 uncommon, 💎 rare, ✨ glimmer, and 🌈 legendary.",
     "",

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2861,6 +2861,9 @@ Full review comments:
 
   assert.match(comment, /\*\*PR egg\*\*\n🔥 Warming up:/);
   assert.match(comment, /```text\n[\s\S]+?\n```/);
+  assert.match(comment, /<summary>How the PR egg works<\/summary>/);
+  assert.match(comment, /The egg is cosmetic and PR-only/);
+  assert.match(comment, /🥚 common, 🌱 uncommon, 💎 rare, ✨ glimmer, and 🌈 legendary/);
   assert.doesNotMatch(comment, /✨ Hatched:/);
   assert.doesNotMatch(comment, /Share on X:/);
 });
@@ -2921,6 +2924,10 @@ Full review comments:
   assert.match(first, /Trait: [^.]+\./);
   assert.match(first, /Share on X: \[post this hatch\]\(https:\/\/x\.com\/intent\/tweet\?text=/);
   assert.match(first, /Copy: My PR egg hatched a [^\n]+ in ClawSweeper\./);
+  assert.match(
+    first,
+    /Hatches are deterministic from this repository, PR number, and reviewed head SHA/,
+  );
   assert.equal(
     first.match(/\*\*PR egg\*\*[\s\S]*?\*\*Real behavior proof\*\*/)?.[0],
     second.match(/\*\*PR egg\*\*[\s\S]*?\*\*Real behavior proof\*\*/)?.[0],

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -59,6 +59,7 @@ import {
   prRatingLabelsForTest,
   prRatingLabelSchemeForTest,
   prEggCreatureForTest,
+  prEggSpriteMetricsForTest,
   prStatusLabelsForTest,
   prStatusLabelSchemeForTest,
   priorityLabelsForTest,
@@ -2976,6 +2977,24 @@ test("PR egg creature generation exposes emoji rarity collectibles", () => {
   assert.ok(glimmerOrLegendary);
   assert.match(glimmerOrLegendary.rarityLabel, /^(✨ glimmer|🌈 legendary)$/);
   assert.match(glimmerOrLegendary.shareText, /^My PR egg hatched a .+ in ClawSweeper\.$/);
+});
+
+test("PR egg ASCII sprites compose fixed-width deterministic layers", () => {
+  const first = prEggSpriteMetricsForTest("openclaw/openclaw#74471@abc123def456");
+  const second = prEggSpriteMetricsForTest("openclaw/openclaw#74471@abc123def456");
+  const other = prEggSpriteMetricsForTest("openclaw/openclaw#74471@def456abc123");
+
+  assert.deepEqual(first, second);
+  assert.equal(first.lines.length, 7);
+  assert.ok(first.lines.some((line) => /[^\s]/.test(line)));
+  for (const line of first.lines) {
+    assert.equal(line.length, first.width);
+    assert.doesNotMatch(line, /[\p{Extended_Pictographic}]/u);
+  }
+  assert.ok(
+    first.lines.some((line, index) => line !== other.lines[index]),
+    "different head SHAs should alter at least one composed sprite layer",
+  );
 });
 
 test("docs-only external PRs do not require real behavior proof", () => {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -3054,7 +3054,8 @@ test("PR egg ASCII sprites compose fixed-width deterministic layers", () => {
   const other = prEggSpriteMetricsForTest("openclaw/openclaw#74471@def456abc123");
 
   assert.deepEqual(first, second);
-  assert.equal(first.lines.length, 7);
+  assert.equal(first.lines.length, 11);
+  assert.equal(first.width, 31);
   assert.ok(first.lines.some((line) => /[^\s]/.test(line)));
   for (const line of first.lines) {
     assert.equal(line.length, first.width);

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2802,7 +2802,7 @@ Full review comments:
   assert.doesNotMatch(comment, /Rank-up moves:/);
 });
 
-test("pull request review comments render warming PR egg for unresolved work", () => {
+test("pull request review comments tease PR egg until proof passes", () => {
   const report = `${reportFrontMatter({
     type: "pull_request",
     number: "74470",
@@ -2859,15 +2859,86 @@ Full review comments:
 `;
 
   const comment = renderReviewCommentFromReport(report, "none");
+  const eggSection = comment.match(/\*\*PR egg\*\*[\s\S]*?\*\*Real behavior proof\*\*/)?.[0] ?? "";
 
-  assert.match(comment, /\*\*PR egg\*\*\n🔥 Warming up:/);
-  assert.match(comment, /```text\n[\s\S]+?\n```/);
-  assert.match(comment, /<summary>What is this egg doing here\?<\/summary>/);
-  assert.match(comment, /Every PR gets a tiny egg/);
-  assert.match(comment, /It is here for vibes, not verdicts/);
-  assert.match(comment, /🥚 common, 🌱 uncommon, 💎 rare, ✨ glimmer, and 🌈 legendary/);
-  assert.doesNotMatch(comment, /✨ Hatched:/);
-  assert.doesNotMatch(comment, /Share on X:/);
+  assert.match(eggSection, /\*\*PR egg\*\*\n🎁 Pass real behavior proof/);
+  assert.match(eggSection, /wake the egg and unlock a hatchable treat/);
+  assert.match(eggSection, /<summary>Where did the egg go\?<\/summary>/);
+  assert.match(eggSection, /no creature, rarity, or ASCII portrait is rolled/);
+  assert.doesNotMatch(eggSection, /```text/);
+  assert.doesNotMatch(eggSection, /🔥 Warming up:/);
+  assert.doesNotMatch(eggSection, /✨ Hatched:/);
+  assert.doesNotMatch(eggSection, /Share on X:/);
+});
+
+test("pull request review comments render warming PR egg after proof passes", () => {
+  const report = `${reportFrontMatter({
+    type: "pull_request",
+    number: "74470",
+    decision: "keep_open",
+    close_reason: "none",
+    review_status: "complete",
+    confidence: "high",
+    author: "contributor",
+    author_association: "CONTRIBUTOR",
+    labels: JSON.stringify([]),
+    work_candidate: "none",
+    pull_head_sha: "abc123def456",
+  })}
+
+## Summary
+
+Keep this PR open until the follow-up is resolved.
+
+## What This Changes
+
+Fixes the gateway status output.
+
+## Best Possible Solution
+
+Resolve the remaining review follow-up.
+
+${realBehaviorProofReportSection({
+  status: "sufficient",
+  evidenceKind: "terminal",
+  needsContributorAction: false,
+  summary: "The PR includes terminal output from a real setup.",
+})}
+
+${prRatingReportSection({
+  overallTier: "B",
+  proofTier: "A",
+  patchTier: "B",
+  overallLabel: "🐚 platinum hermit",
+  proofLabel: "🦀 challenger crab",
+  patchLabel: "🐚 platinum hermit",
+  summary: "Proof is present, but one follow-up remains.",
+  nextSteps: "- Resolve the remaining maintainer follow-up.",
+})}
+
+## Review Findings
+
+Overall correctness: patch is correct
+
+Overall confidence: 0.9
+
+Full review comments:
+
+- none
+`;
+
+  const comment = renderReviewCommentFromReport(report, "none");
+  const eggSection = comment.match(/\*\*PR egg\*\*[\s\S]*?\*\*Real behavior proof\*\*/)?.[0] ?? "";
+
+  assert.match(eggSection, /\*\*PR egg\*\*\n🔥 Warming up:/);
+  assert.match(eggSection, /```text\n[\s\S]+?\n```/);
+  assert.match(eggSection, /<summary>What is this egg doing here\?<\/summary>/);
+  assert.match(eggSection, /Eggs appear after the PR passes real-behavior proof/);
+  assert.match(eggSection, /It is here for vibes, not verdicts/);
+  assert.match(eggSection, /🥚 common, 🌱 uncommon, 💎 rare, ✨ glimmer, and 🌈 legendary/);
+  assert.doesNotMatch(eggSection, /🎁 Pass real behavior proof/);
+  assert.doesNotMatch(eggSection, /✨ Hatched:/);
+  assert.doesNotMatch(eggSection, /Share on X:/);
 });
 
 test("pull request review comments hatch deterministic collectible PR egg", () => {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2862,8 +2862,9 @@ Full review comments:
 
   assert.match(comment, /\*\*PR egg\*\*\n🔥 Warming up:/);
   assert.match(comment, /```text\n[\s\S]+?\n```/);
-  assert.match(comment, /<summary>How the PR egg works<\/summary>/);
-  assert.match(comment, /The egg is cosmetic and PR-only/);
+  assert.match(comment, /<summary>What is this egg doing here\?<\/summary>/);
+  assert.match(comment, /Every PR gets a tiny egg/);
+  assert.match(comment, /It is here for vibes, not verdicts/);
   assert.match(comment, /🥚 common, 🌱 uncommon, 💎 rare, ✨ glimmer, and 🌈 legendary/);
   assert.doesNotMatch(comment, /✨ Hatched:/);
   assert.doesNotMatch(comment, /Share on X:/);
@@ -2925,10 +2926,7 @@ Full review comments:
   assert.match(first, /Trait: [^.]+\./);
   assert.match(first, /Share on X: \[post this hatch\]\(https:\/\/x\.com\/intent\/tweet\?text=/);
   assert.match(first, /Copy: My PR egg hatched a [^\n]+ in ClawSweeper\./);
-  assert.match(
-    first,
-    /Hatches are deterministic from this repository, PR number, and reviewed head SHA/,
-  );
+  assert.match(first, /same PR revision gets the same little creature every time/);
   assert.equal(
     first.match(/\*\*PR egg\*\*[\s\S]*?\*\*Real behavior proof\*\*/)?.[0],
     second.match(/\*\*PR egg\*\*[\s\S]*?\*\*Real behavior proof\*\*/)?.[0],

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -1931,6 +1931,35 @@ test("duplicate or superseded close sentence filters current item URLs", () => {
   );
 });
 
+test("duplicate or superseded reference extraction ignores repeated malformed GitHub URLs", () => {
+  const repeatedMalformedUrl = Array.from({ length: 100 }, () => "https://github.com/").join("");
+  const action = reviewActionForDecision({
+    item: item({ number: 123 }),
+    decision: closeDecision({
+      closeReason: "duplicate_or_superseded",
+      summary: `Close as duplicate after checking ${repeatedMalformedUrl}.`,
+      bestSolution: "Keep remaining work on https://github.com/openclaw/openclaw/issues/456.",
+      evidence: [
+        {
+          label: "Malformed URL noise",
+          detail: repeatedMalformedUrl,
+        },
+        {
+          label: "Canonical issue",
+          detail: "https://github.com/openclaw/openclaw/issues/456 tracks the same work.",
+        },
+      ],
+    }),
+    git,
+  });
+
+  assert.equal(action.actionTaken, "proposed_close");
+  assert.match(
+    action.closeComment,
+    /So I’m closing this here and keeping the remaining discussion on https:\/\/github\.com\/openclaw\/openclaw\/issues\/456\./,
+  );
+});
+
 test("duplicate or superseded close sentence includes duplicate-labeled canonical URL", () => {
   const action = reviewActionForDecision({
     item: item({ number: 123 }),

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -58,6 +58,7 @@ import {
   mergeRiskLabelSchemeForTest,
   prRatingLabelsForTest,
   prRatingLabelSchemeForTest,
+  prEggCreatureForTest,
   prStatusLabelsForTest,
   prStatusLabelSchemeForTest,
   priorityLabelsForTest,
@@ -2798,6 +2799,176 @@ Full review comments:
   assert.match(comment, /Proof: 🦀 challenger crab ✨ media proof bonus/);
   assert.match(comment, /Shiny media proof means a screenshot, video, or linked artifact/);
   assert.doesNotMatch(comment, /Rank-up moves:/);
+});
+
+test("pull request review comments render warming PR egg for unresolved work", () => {
+  const report = `${reportFrontMatter({
+    type: "pull_request",
+    number: "74470",
+    decision: "keep_open",
+    close_reason: "none",
+    review_status: "complete",
+    confidence: "high",
+    author: "contributor",
+    author_association: "CONTRIBUTOR",
+    labels: JSON.stringify([]),
+    work_candidate: "none",
+    pull_head_sha: "abc123def456",
+  })}
+
+## Summary
+
+Keep this PR open until proof is added.
+
+## What This Changes
+
+Fixes the gateway status output.
+
+## Best Possible Solution
+
+Add proof and re-review.
+
+${realBehaviorProofReportSection({
+  status: "missing",
+  evidenceKind: "none",
+  needsContributorAction: true,
+  summary: "The PR has no real behavior proof yet.",
+})}
+
+${prRatingReportSection({
+  overallTier: "F",
+  proofTier: "F",
+  patchTier: "B",
+  overallLabel: "🧂 unranked krab",
+  proofLabel: "🧂 unranked krab",
+  patchLabel: "🐚 platinum hermit",
+  summary: "Proof is missing, so this PR is not ready yet.",
+  nextSteps: "- Add after-fix proof from a real setup.",
+})}
+
+## Review Findings
+
+Overall correctness: patch is correct
+
+Overall confidence: 0.9
+
+Full review comments:
+
+- none
+`;
+
+  const comment = renderReviewCommentFromReport(report, "none");
+
+  assert.match(comment, /\*\*PR egg\*\*\n🔥 Warming up:/);
+  assert.match(comment, /```text\n[\s\S]+?\n```/);
+  assert.doesNotMatch(comment, /✨ Hatched:/);
+  assert.doesNotMatch(comment, /Share on X:/);
+});
+
+test("pull request review comments hatch deterministic collectible PR egg", () => {
+  const report = `${reportFrontMatter({
+    type: "pull_request",
+    number: "74471",
+    decision: "keep_open",
+    close_reason: "none",
+    review_status: "complete",
+    confidence: "high",
+    author: "contributor",
+    author_association: "CONTRIBUTOR",
+    labels: JSON.stringify(["protected: maintainer-authored"]),
+    work_candidate: "none",
+    pull_head_sha: "abc123def456",
+  })}
+
+## Summary
+
+Keep this clean PR open for maintainer review.
+
+## What This Changes
+
+Fixes the gateway status output.
+
+## Best Possible Solution
+
+Merge after maintainer review.
+
+${realBehaviorProofReportSection()}
+
+${prRatingReportSection({
+  overallTier: "B",
+  proofTier: "A",
+  patchTier: "B",
+  summary: "This PR has strong proof and normal merge-ready implementation quality.",
+  nextSteps: "",
+})}
+
+## Review Findings
+
+Overall correctness: patch is correct
+
+Overall confidence: 0.9
+
+Full review comments:
+
+- none
+`;
+
+  const first = renderReviewCommentFromReport(report, "none");
+  const second = renderReviewCommentFromReport(report, "none");
+
+  assert.match(first, /\*\*PR egg\*\*\n✨ Hatched: [^\n]+/);
+  assert.match(first, /```text\n[\s\S]+?\n```/);
+  assert.match(first, /Trait: [^.]+\./);
+  assert.match(first, /Share on X: \[post this hatch\]\(https:\/\/x\.com\/intent\/tweet\?text=/);
+  assert.match(first, /Copy: My PR egg hatched a [^\n]+ in ClawSweeper\./);
+  assert.equal(
+    first.match(/\*\*PR egg\*\*[\s\S]*?\*\*Real behavior proof\*\*/)?.[0],
+    second.match(/\*\*PR egg\*\*[\s\S]*?\*\*Real behavior proof\*\*/)?.[0],
+  );
+});
+
+test("issues do not render PR egg game", () => {
+  const report = `${reportFrontMatter({
+    type: "issue",
+    number: "74472",
+    decision: "keep_open",
+    close_reason: "none",
+    review_status: "complete",
+    confidence: "medium",
+    work_candidate: "none",
+  })}
+
+## Summary
+
+Keep this issue open for more reproduction detail.
+
+## Best Possible Solution
+
+Ask for reproduction details.
+`;
+
+  const comment = renderReviewCommentFromReport(report, "none");
+
+  assert.doesNotMatch(comment, /\*\*PR egg\*\*/);
+});
+
+test("PR egg creature generation exposes emoji rarity collectibles", () => {
+  const stable = prEggCreatureForTest("openclaw/openclaw#74471@abc123def456");
+  assert.deepEqual(stable, prEggCreatureForTest("openclaw/openclaw#74471@abc123def456"));
+  assert.match(stable.rarityLabel, /^(🥚 common|🌱 uncommon|💎 rare|✨ glimmer|🌈 legendary)$/);
+
+  let glimmerOrLegendary: ReturnType<typeof prEggCreatureForTest> | null = null;
+  for (let index = 0; index < 50000; index += 1) {
+    const candidate = prEggCreatureForTest(`rarity-seed-${index}`);
+    if (candidate.rarity === "glimmer" || candidate.rarity === "legendary") {
+      glimmerOrLegendary = candidate;
+      break;
+    }
+  }
+
+  assert.ok(glimmerOrLegendary);
+  assert.match(glimmerOrLegendary.rarityLabel, /^(✨ glimmer|🌈 legendary)$/);
+  assert.match(glimmerOrLegendary.shareText, /^My PR egg hatched a .+ in ClawSweeper\.$/);
 });
 
 test("docs-only external PRs do not require real behavior proof", () => {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -3048,18 +3048,19 @@ test("PR egg creature generation exposes emoji rarity collectibles", () => {
   assert.match(glimmerOrLegendary.shareText, /^My PR egg hatched a .+ in ClawSweeper\.$/);
 });
 
-test("PR egg ASCII sprites compose fixed-width deterministic layers", () => {
+test("PR egg ASCII sprites render fixed-width deterministic silhouettes", () => {
   const first = prEggSpriteMetricsForTest("openclaw/openclaw#74471@abc123def456");
   const second = prEggSpriteMetricsForTest("openclaw/openclaw#74471@abc123def456");
   const other = prEggSpriteMetricsForTest("openclaw/openclaw#74471@def456abc123");
 
   assert.deepEqual(first, second);
-  assert.equal(first.lines.length, 11);
-  assert.equal(first.width, 31);
+  assert.equal(first.lines.length, 12);
+  assert.equal(first.width, 29);
   assert.ok(first.lines.some((line) => /[^\s]/.test(line)));
   for (const line of first.lines) {
     assert.equal(line.length, first.width);
     assert.doesNotMatch(line, /[\p{Extended_Pictographic}]/u);
+    assert.match(line, /\S/, "sprite lines should stay visually dense");
   }
   assert.ok(
     first.lines.some((line, index) => line !== other.lines[index]),

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2997,11 +2997,131 @@ Full review comments:
   assert.match(first, /Trait: [^.]+\./);
   assert.match(first, /Share on X: \[post this hatch\]\(https:\/\/x\.com\/intent\/tweet\?text=/);
   assert.match(first, /Copy: My PR egg hatched a [^\n]+ in ClawSweeper\./);
-  assert.match(first, /same PR revision gets the same little creature every time/);
+  assert.match(first, /same PR keeps the same creature/);
   assert.equal(
     first.match(/\*\*PR egg\*\*[\s\S]*?\*\*Real behavior proof\*\*/)?.[0],
     second.match(/\*\*PR egg\*\*[\s\S]*?\*\*Real behavior proof\*\*/)?.[0],
   );
+});
+
+test("PR egg hatch identity stays stable across reviewed PR revisions", () => {
+  const reportForHead = (headSha: string) => `${reportFrontMatter({
+    type: "pull_request",
+    number: "74471",
+    decision: "keep_open",
+    close_reason: "none",
+    review_status: "complete",
+    confidence: "high",
+    author: "contributor",
+    author_association: "CONTRIBUTOR",
+    labels: JSON.stringify(["protected: maintainer-authored"]),
+    work_candidate: "none",
+    pull_head_sha: headSha,
+  })}
+
+## Summary
+
+Keep this clean PR open for maintainer review.
+
+## What This Changes
+
+Fixes the gateway status output.
+
+## Best Possible Solution
+
+Merge after maintainer review.
+
+${realBehaviorProofReportSection()}
+
+${prRatingReportSection({
+  overallTier: "B",
+  proofTier: "A",
+  patchTier: "B",
+  summary: "This PR has strong proof and normal merge-ready implementation quality.",
+  nextSteps: "",
+})}
+
+## Review Findings
+
+Overall correctness: patch is correct
+
+Overall confidence: 0.9
+
+Full review comments:
+
+- none
+`;
+
+  const first = renderReviewCommentFromReport(reportForHead("abc123def456"), "none");
+  const second = renderReviewCommentFromReport(reportForHead("def456abc123"), "none");
+
+  assert.equal(first.match(/✨ Hatched: [^\n]+/)?.[0], second.match(/✨ Hatched: [^\n]+/)?.[0]);
+  assert.equal(first.match(/Trait: [^\n]+/)?.[0], second.match(/Trait: [^\n]+/)?.[0]);
+  assert.equal(first.match(/Copy: [^\n]+/)?.[0], second.match(/Copy: [^\n]+/)?.[0]);
+  assert.match(first, /same PR keeps the same creature/);
+});
+
+test("PR egg wobbling follows current re-review status signal", () => {
+  const report = `${reportFrontMatter({
+    type: "pull_request",
+    number: "74473",
+    decision: "keep_open",
+    close_reason: "none",
+    review_status: "complete",
+    confidence: "high",
+    author: "contributor",
+    author_association: "CONTRIBUTOR",
+    labels: JSON.stringify([]),
+    work_candidate: "none",
+    pull_head_sha: "abc123def456",
+  })}
+
+## Summary
+
+Keep this PR open during the requested re-review loop.
+
+## What This Changes
+
+Fixes the gateway status output.
+
+## Best Possible Solution
+
+Re-review the latest author update.
+
+${realBehaviorProofReportSection({
+  status: "sufficient",
+  evidenceKind: "terminal",
+  needsContributorAction: false,
+  summary: "The PR includes terminal output from a real setup.",
+})}
+
+${prRatingReportSection({
+  overallTier: "B",
+  proofTier: "A",
+  patchTier: "B",
+  overallLabel: "🐚 platinum hermit",
+  proofLabel: "🦀 challenger crab",
+  patchLabel: "🐚 platinum hermit",
+  summary: "Proof is present, but one follow-up remains.",
+  nextSteps: "- Wait for the requested re-review result.",
+})}
+
+## Review Findings
+
+Overall correctness: patch is correct
+
+Overall confidence: 0.9
+
+Full review comments:
+
+- none
+`;
+
+  assert.match(
+    renderReviewCommentFromReport(report, "none", { prStatusKind: "re_review_loop" }),
+    /\*\*PR egg\*\*\n🔁 Wobbling:/,
+  );
+  assert.match(renderReviewCommentFromReport(report, "none"), /\*\*PR egg\*\*\n🔥 Warming up:/);
 });
 
 test("issues do not render PR egg game", () => {


### PR DESCRIPTION
## Summary
- add a PR-only ClawSweeper egg game section to review comments after real behavior proof is available
- hatch deterministic collectible ASCII creatures when PRs reach a clean final-review state
- keep creature identity stable per PR while allowing reviewed-revision visual variation
- derive the re-review wobble state from the current PR status signal

## Validation
- pnpm run build: passed
- node --test test/clawsweeper.test.ts --test-name-pattern "PR egg": passed
- pnpm run check: passed after formatting touched files with pnpm exec oxfmt src/clawsweeper.ts test/clawsweeper.test.ts

## Notes
- PR-only behavior is covered by focused tests.
- No labels or image generation are added.