### PR TITLE
fix(review): hatch and share PR eggs from ready status

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -5468,6 +5468,21 @@ function prEggVisualSeedFromReport(markdown: string): string {
   return `${identitySeed}@${headSha}`;
 }
 
+function isContributorFacingRankUpStep(step: string): boolean {
+  const normalized = step
+    .trim()
+    .replace(/[.。]+$/u, "")
+    .toLowerCase();
+  if (!normalized || normalized === "none" || normalized === "n/a" || normalized === "na") {
+    return false;
+  }
+  return !/\bmaintainer\b/.test(normalized);
+}
+
+function hasContributorFacingRankUpSteps(rating: Pick<PrRating, "nextSteps">): boolean {
+  return rating.nextSteps.some(isContributorFacingRankUpStep);
+}
+
 function prEggStateFromReport(
   markdown: string,
   options: {
@@ -5479,18 +5494,11 @@ function prEggStateFromReport(
     statusKind?: PrStatusLabelKind | null;
   },
 ): PrEggState {
-  const isReady =
-    options.prRating.nextSteps.length === 0 &&
-    isReadyForMaintainerLook({
-      realBehaviorProof: options.realBehaviorProof,
-      reviewFindings: options.reviewFindings,
-      securityReview: options.securityReview,
-      overallCorrectness: options.overallCorrectness,
-    });
-  if (isReady) return "hatched";
+  const hasRankUpWork = hasContributorFacingRankUpSteps(options.prRating);
+  if (options.statusKind === "ready_for_maintainer_look") return "hatched";
   if (options.statusKind === "re_review_loop") return "wobbling";
   const hasUnresolvedWork =
-    options.prRating.nextSteps.length > 0 ||
+    hasRankUpWork ||
     hasUnresolvedContributorWork({
       realBehaviorProof: options.realBehaviorProof,
       reviewFindings: options.reviewFindings,

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -5468,6 +5468,14 @@ function prEggVisualSeedFromReport(markdown: string): string {
   return `${identitySeed}@${headSha}`;
 }
 
+function prEggShareTargetUrl(markdown: string): string {
+  const commentUrl = frontMatterValue(markdown, "review_comment_url");
+  if (commentUrl && commentUrl !== "unknown") return commentUrl;
+  const repo = markdownRepository(markdown);
+  const number = frontMatterValue(markdown, "number") ?? "unknown";
+  return `https://github.com/${repo}/pull/${number}`;
+}
+
 function isContributorFacingRankUpStep(step: string): boolean {
   const normalized = step
     .trim()
@@ -5559,13 +5567,16 @@ function publicPrEggLine(
   ];
   if (state === "hatched") {
     const creature = prEggCreature(identitySeed, visualSeed);
-    const shareUrl = `https://x.com/intent/tweet?text=${encodeURIComponent(creature.shareText)}`;
+    const shareUrl = `https://x.com/intent/tweet?text=${encodeURIComponent(
+      creature.shareText,
+    )}&url=${encodeURIComponent(prEggShareTargetUrl(markdown))}`;
     return [
       `✨ Hatched: ${creature.rarityLabel} ${creature.name}`,
       "",
       "```text",
       creature.portrait,
       "```",
+      `Rarity: ${creature.rarityLabel}.`,
       `Trait: ${creature.trait}.`,
       `Share on X: ${markdownLink("post this hatch", shareUrl)}`,
       `Copy: ${creature.shareText}`,

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2942,7 +2942,7 @@ ${prRatingReportSection({
   proofLabel: "🦀 challenger crab",
   patchLabel: "🐚 platinum hermit",
   summary: "Proof is present, but one follow-up remains.",
-  nextSteps: "- Resolve the remaining maintainer follow-up.",
+  nextSteps: "- Add after-fix validation output from the changed path.",
 })}
 
 ## Review Findings
@@ -3018,8 +3018,12 @@ Full review comments:
 - none
 `;
 
-  const first = renderReviewCommentFromReport(report, "none");
-  const second = renderReviewCommentFromReport(report, "none");
+  const first = renderReviewCommentFromReport(report, "none", {
+    prStatusKind: "ready_for_maintainer_look",
+  });
+  const second = renderReviewCommentFromReport(report, "none", {
+    prStatusKind: "ready_for_maintainer_look",
+  });
 
   assert.match(first, /\*\*PR egg\*\*\n✨ Hatched: [^\n]+/);
   assert.match(first, /```text\n[\s\S]+?\n```/);
@@ -3081,13 +3085,79 @@ Full review comments:
 - none
 `;
 
-  const first = renderReviewCommentFromReport(reportForHead("abc123def456"), "none");
-  const second = renderReviewCommentFromReport(reportForHead("def456abc123"), "none");
+  const first = renderReviewCommentFromReport(reportForHead("abc123def456"), "none", {
+    prStatusKind: "ready_for_maintainer_look",
+  });
+  const second = renderReviewCommentFromReport(reportForHead("def456abc123"), "none", {
+    prStatusKind: "ready_for_maintainer_look",
+  });
 
   assert.equal(first.match(/✨ Hatched: [^\n]+/)?.[0], second.match(/✨ Hatched: [^\n]+/)?.[0]);
   assert.equal(first.match(/Trait: [^\n]+/)?.[0], second.match(/Trait: [^\n]+/)?.[0]);
   assert.equal(first.match(/Copy: [^\n]+/)?.[0], second.match(/Copy: [^\n]+/)?.[0]);
   assert.match(first, /same PR keeps the same creature/);
+});
+
+test("PR egg hatches from ready status despite non-contributor rank-up sentinels", () => {
+  const reportForNextSteps = (nextSteps: string) => `${reportFrontMatter({
+    type: "pull_request",
+    number: "83606",
+    decision: "keep_open",
+    close_reason: "none",
+    review_status: "complete",
+    confidence: "high",
+    author: "contributor",
+    author_association: "CONTRIBUTOR",
+    labels: JSON.stringify([]),
+    work_candidate: "none",
+    pull_head_sha: "abc123def456",
+  })}
+
+## Summary
+
+Keep this proof-sufficient PR open for maintainer review.
+
+## What This Changes
+
+Fixes the gateway status output.
+
+## Best Possible Solution
+
+Merge after maintainer review.
+
+${realBehaviorProofReportSection()}
+
+${prRatingReportSection({
+  overallTier: "B",
+  proofTier: "A",
+  patchTier: "B",
+  summary: "This PR has strong proof and normal merge-ready implementation quality.",
+  nextSteps,
+})}
+
+## Review Findings
+
+Overall correctness: patch is correct
+
+Overall confidence: 0.9
+
+Full review comments:
+
+- none
+`;
+
+  for (const nextSteps of [
+    "- none",
+    "- n/a",
+    "- Maintainer accepts the relative details.reportPath contract change before merge.",
+  ]) {
+    const comment = renderReviewCommentFromReport(reportForNextSteps(nextSteps), "none", {
+      prStatusKind: "ready_for_maintainer_look",
+    });
+
+    assert.match(comment, /\*\*PR egg\*\*\n✨ Hatched: [^\n]+/);
+    assert.doesNotMatch(comment, /\*\*PR egg\*\*\n🔥 Warming up:/);
+  }
 });
 
 test("PR egg wobbling follows current re-review status signal", () => {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2983,6 +2983,7 @@ test("pull request review comments hatch deterministic collectible PR egg", () =
     labels: JSON.stringify(["protected: maintainer-authored"]),
     work_candidate: "none",
     pull_head_sha: "abc123def456",
+    review_comment_url: "https://github.com/openclaw/openclaw/pull/74471#issuecomment-987654321",
   })}
 
 ## Summary
@@ -3027,8 +3028,12 @@ Full review comments:
 
   assert.match(first, /\*\*PR egg\*\*\n✨ Hatched: [^\n]+/);
   assert.match(first, /```text\n[\s\S]+?\n```/);
+  assert.match(first, /Rarity: [^\n]+\./);
   assert.match(first, /Trait: [^.]+\./);
-  assert.match(first, /Share on X: \[post this hatch\]\(https:\/\/x\.com\/intent\/tweet\?text=/);
+  assert.match(
+    first,
+    /Share on X: \[post this hatch\]\(https:\/\/x\.com\/intent\/tweet\?text=[^)]+&url=https%3A%2F%2Fgithub\.com%2Fopenclaw%2Fopenclaw%2Fpull%2F74471%23issuecomment-987654321\)/,
+  );
   assert.match(first, /Copy: My PR egg hatched a [^\n]+ in ClawSweeper\./);
   assert.match(first, /same PR keeps the same creature/);
   assert.equal(
@@ -3093,9 +3098,68 @@ Full review comments:
   });
 
   assert.equal(first.match(/✨ Hatched: [^\n]+/)?.[0], second.match(/✨ Hatched: [^\n]+/)?.[0]);
+  assert.equal(first.match(/Rarity: [^\n]+/)?.[0], second.match(/Rarity: [^\n]+/)?.[0]);
   assert.equal(first.match(/Trait: [^\n]+/)?.[0], second.match(/Trait: [^\n]+/)?.[0]);
   assert.equal(first.match(/Copy: [^\n]+/)?.[0], second.match(/Copy: [^\n]+/)?.[0]);
   assert.match(first, /same PR keeps the same creature/);
+});
+
+test("PR egg share link falls back to PR URL before durable comment metadata exists", () => {
+  const report = `${reportFrontMatter({
+    type: "pull_request",
+    number: "74474",
+    decision: "keep_open",
+    close_reason: "none",
+    review_status: "complete",
+    confidence: "high",
+    author: "contributor",
+    author_association: "CONTRIBUTOR",
+    labels: JSON.stringify([]),
+    work_candidate: "none",
+    pull_head_sha: "abc123def456",
+  })}
+
+## Summary
+
+Keep this clean PR open for maintainer review.
+
+## What This Changes
+
+Fixes the gateway status output.
+
+## Best Possible Solution
+
+Merge after maintainer review.
+
+${realBehaviorProofReportSection()}
+
+${prRatingReportSection({
+  overallTier: "B",
+  proofTier: "A",
+  patchTier: "B",
+  summary: "This PR has strong proof and normal merge-ready implementation quality.",
+  nextSteps: "",
+})}
+
+## Review Findings
+
+Overall correctness: patch is correct
+
+Overall confidence: 0.9
+
+Full review comments:
+
+- none
+`;
+
+  const comment = renderReviewCommentFromReport(report, "none", {
+    prStatusKind: "ready_for_maintainer_look",
+  });
+
+  assert.match(
+    comment,
+    /Share on X: \[post this hatch\]\(https:\/\/x\.com\/intent\/tweet\?text=[^)]+&url=https%3A%2F%2Fgithub\.com%2Fopenclaw%2Fopenclaw%2Fpull%2F74474\)/,
+  );
 });
 
 test("PR egg hatches from ready status despite non-contributor rank-up sentinels", () => {


### PR DESCRIPTION
## Summary
- Hatch PR eggs from the current ready-for-maintainer status signal instead of a separate empty-nextSteps check.
- Keep sentinel and maintainer-only rank-up text from blocking hatch when the PR is otherwise ready.
- Show rarity explicitly in the hatched output.
- Make the X share intent include the hatch text plus a link to the durable PR review comment when available, falling back to the PR URL before comment metadata exists.

## Validation
- pnpm run build:all: passed
- pnpm run test:unit: passed
- pnpm run check: passed

## Notes
- Left unrelated untracked .worktrees/ directory untouched.