### PR TITLE
fix(review): hatch PR eggs from status labels

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -5476,44 +5476,33 @@ function prEggShareTargetUrl(markdown: string): string {
   return `https://github.com/${repo}/pull/${number}`;
 }
 
-function isContributorFacingRankUpStep(step: string): boolean {
-  const normalized = step
-    .trim()
-    .replace(/[.。]+$/u, "")
-    .toLowerCase();
-  if (!normalized || normalized === "none" || normalized === "n/a" || normalized === "na") {
-    return false;
+function prStatusLabelKindFromLabels(labels: readonly string[]): PrStatusLabelKind | null {
+  for (const label of PR_STATUS_LABELS) {
+    if (labels.includes(label.name)) return label.kind;
   }
-  return !/\bmaintainer\b/.test(normalized);
+  return null;
 }
 
-function hasContributorFacingRankUpSteps(rating: Pick<PrRating, "nextSteps">): boolean {
-  return rating.nextSteps.some(isContributorFacingRankUpStep);
+function prEggStatusLabelKindFromReportLabels(markdown: string): PrStatusLabelKind | null {
+  const fromParsedLabels = prStatusLabelKindFromLabels(frontMatterStringArray(markdown, "labels"));
+  if (fromParsedLabels) return fromParsedLabels;
+  const rawLabels = frontMatterValue(markdown, "labels") ?? "";
+  return PR_STATUS_LABELS.find((label) => rawLabels.includes(label.name))?.kind ?? null;
 }
 
-function prEggStateFromReport(
-  markdown: string,
-  options: {
-    realBehaviorProof: RealBehaviorProof;
-    prRating: PrRating;
-    reviewFindings: readonly Pick<ReviewFinding, "priority">[];
-    securityReview: Pick<SecurityReview, "status">;
-    overallCorrectness: OverallCorrectness;
-    statusKind?: PrStatusLabelKind | null;
-  },
-): PrEggState {
-  const hasRankUpWork = hasContributorFacingRankUpSteps(options.prRating);
-  if (options.statusKind === "ready_for_maintainer_look") return "hatched";
-  if (options.statusKind === "re_review_loop") return "wobbling";
-  const hasUnresolvedWork =
-    hasRankUpWork ||
-    hasUnresolvedContributorWork({
-      realBehaviorProof: options.realBehaviorProof,
-      reviewFindings: options.reviewFindings,
-      securityReview: options.securityReview,
-      overallCorrectness: options.overallCorrectness,
-    });
-  return hasUnresolvedWork ? "warming" : "incubating";
+function prEggStateFromStatus(statusKind: PrStatusLabelKind | null | undefined): PrEggState {
+  if (statusKind === "ready_for_maintainer_look" || statusKind === "automerge_armed") {
+    return "hatched";
+  }
+  if (statusKind === "re_review_loop") return "wobbling";
+  if (
+    statusKind === "actively_grinding" ||
+    statusKind === "waiting_on_author" ||
+    statusKind === "needs_proof"
+  ) {
+    return "warming";
+  }
+  return "incubating";
 }
 
 function prEggProofUnlocked(proof: Pick<RealBehaviorProof, "status">): boolean {
@@ -5552,7 +5541,7 @@ function publicPrEggLine(
 
   const identitySeed = prEggIdentitySeedFromReport(markdown);
   const visualSeed = prEggVisualSeedFromReport(markdown);
-  const state = prEggStateFromReport(markdown, options);
+  const state = prEggStateFromStatus(options.statusKind);
   const explainer = [
     "",
     "<details>",
@@ -8407,6 +8396,7 @@ function renderKeepOpenCommentFromReport(
   const mergeRiskLine = isPullRequest
     ? publicMergeRiskLine(risks, nextStepLine, bestSolutionLine, mergeRiskOptions)
     : "";
+  const prEggStatusKind = options.prStatusKind ?? prEggStatusLabelKindFromReportLabels(markdown);
   const details: string[] = [];
   const hasReviewFindings = isPullRequest && reviewFindings.length > 0;
   const lines = [
@@ -8454,7 +8444,7 @@ function renderKeepOpenCommentFromReport(
         reviewFindings,
         securityReview,
         overallCorrectness: reportOverallCorrectness(markdown),
-        statusKind: options.prStatusKind ?? null,
+        statusKind: prEggStatusKind,
       }),
     );
     appendPublicSection(

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2679,7 +2679,9 @@ Full review comments:
 - none
 `;
 
-  const comment = renderReviewCommentFromReport(report, "none");
+  const comment = renderReviewCommentFromReport(report, "none", {
+    prStatusKind: "ready_for_maintainer_look",
+  });
   const markers = reviewAutomationMarkersFromReport(report);
 
   assert.match(comment, /\*\*PR rating\*\*\nOverall: 🦞 diamond lobster/);
@@ -2900,7 +2902,7 @@ Full review comments:
   assert.doesNotMatch(eggSection, /Share on X:/);
 });
 
-test("pull request review comments render warming PR egg after proof passes", () => {
+test("pull request review comments render warming PR egg from active status after proof passes", () => {
   const report = `${reportFrontMatter({
     type: "pull_request",
     number: "74470",
@@ -2956,7 +2958,9 @@ Full review comments:
 - none
 `;
 
-  const comment = renderReviewCommentFromReport(report, "none");
+  const comment = renderReviewCommentFromReport(report, "none", {
+    prStatusKind: "actively_grinding",
+  });
   const eggSection = comment.match(/\*\*PR egg\*\*[\s\S]*?\*\*Real behavior proof\*\*/)?.[0] ?? "";
 
   assert.match(eggSection, /\*\*PR egg\*\*\n🔥 Warming up:/);
@@ -3224,6 +3228,145 @@ Full review comments:
   }
 });
 
+test("PR egg hatches from ready status label when explicit status signal is absent", () => {
+  const report = `${reportFrontMatter({
+    type: "pull_request",
+    number: "83632",
+    decision: "keep_open",
+    close_reason: "none",
+    review_status: "complete",
+    confidence: "high",
+    author: "contributor",
+    author_association: "CONTRIBUTOR",
+    labels: JSON.stringify(["proof: sufficient", "status: 👀 ready for maintainer look"]),
+    work_candidate: "none",
+    pull_head_sha: "27d246732015a4ea4fc48dd828c121857f1e5124",
+    review_comment_url: "https://github.com/openclaw/openclaw/pull/83632#issuecomment-4478578658",
+  })}
+
+## Summary
+
+Focused patch with proof and maintainer-facing follow-up decisions.
+
+## What This Changes
+
+Improves Telegram proof capture.
+
+## Best Possible Solution
+
+Merge after maintainer review.
+
+${realBehaviorProofReportSection({
+  status: "sufficient",
+  evidenceKind: "terminal",
+  needsContributorAction: false,
+  summary: "The PR includes terminal output from a real setup.",
+})}
+
+${prRatingReportSection({
+  overallTier: "A",
+  proofTier: "A",
+  patchTier: "A",
+  overallLabel: "🐚 platinum hermit",
+  proofLabel: "🐚 platinum hermit",
+  patchLabel: "🐚 platinum hermit",
+  summary: "Proof is present, with maintainer policy decisions remaining.",
+  nextSteps: [
+    "- Decide whether `guest.enabled` should remain `auto` by default or require explicit opt-in.",
+    "- If keeping auto, add or run upgrade-safety proof for omitted guest config and account allowlist combinations.",
+  ].join("\n"),
+})}
+
+## Review Findings
+
+Overall correctness: patch is correct
+
+Overall confidence: 0.9
+
+Full review comments:
+
+- none
+`;
+
+  const comment = renderReviewCommentFromReport(report, "none");
+
+  assert.match(comment, /\*\*PR egg\*\*\n✨ Hatched: [^\n]+/);
+  assert.match(comment, /Rarity: [^\n]+\./);
+  assert.match(
+    comment,
+    /Share on X: \[post this hatch\]\(https:\/\/x\.com\/intent\/tweet\?text=[^)]+&url=https%3A%2F%2Fgithub\.com%2Fopenclaw%2Fopenclaw%2Fpull%2F83632%23issuecomment-4478578658\)/,
+  );
+  assert.doesNotMatch(comment, /\*\*PR egg\*\*\n🔥 Warming up:/);
+});
+
+test("PR egg lifecycle follows the current PR status signal", () => {
+  const report = `${reportFrontMatter({
+    type: "pull_request",
+    number: "74475",
+    decision: "keep_open",
+    close_reason: "none",
+    review_status: "complete",
+    confidence: "high",
+    author: "contributor",
+    author_association: "CONTRIBUTOR",
+    labels: JSON.stringify([]),
+    work_candidate: "none",
+    pull_head_sha: "abc123def456",
+  })}
+
+## Summary
+
+Keep this PR open for status-driven egg rendering.
+
+## What This Changes
+
+Fixes the gateway status output.
+
+## Best Possible Solution
+
+Follow the current PR status.
+
+${realBehaviorProofReportSection({
+  status: "sufficient",
+  evidenceKind: "terminal",
+  needsContributorAction: false,
+  summary: "The PR includes terminal output from a real setup.",
+})}
+
+${prRatingReportSection({
+  overallTier: "B",
+  proofTier: "A",
+  patchTier: "B",
+  summary: "Proof is present; lifecycle is status-driven.",
+  nextSteps: "",
+})}
+
+## Review Findings
+
+Overall correctness: patch is correct
+
+Overall confidence: 0.9
+
+Full review comments:
+
+- none
+`;
+
+  const cases = [
+    ["automerge_armed", /\*\*PR egg\*\*\n✨ Hatched:/],
+    ["ready_for_maintainer_look", /\*\*PR egg\*\*\n✨ Hatched:/],
+    ["re_review_loop", /\*\*PR egg\*\*\n🔁 Wobbling:/],
+    ["actively_grinding", /\*\*PR egg\*\*\n🔥 Warming up:/],
+    ["waiting_on_author", /\*\*PR egg\*\*\n🔥 Warming up:/],
+    ["needs_proof", /\*\*PR egg\*\*\n🔥 Warming up:/],
+    [null, /\*\*PR egg\*\*\n🥚 Incubating:/],
+  ] as const;
+
+  for (const [prStatusKind, expected] of cases) {
+    assert.match(renderReviewCommentFromReport(report, "none", { prStatusKind }), expected);
+  }
+});
+
 test("PR egg wobbling follows current re-review status signal", () => {
   const report = `${reportFrontMatter({
     type: "pull_request",
@@ -3284,7 +3427,7 @@ Full review comments:
     renderReviewCommentFromReport(report, "none", { prStatusKind: "re_review_loop" }),
     /\*\*PR egg\*\*\n🔁 Wobbling:/,
   );
-  assert.match(renderReviewCommentFromReport(report, "none"), /\*\*PR egg\*\*\n🔥 Warming up:/);
+  assert.match(renderReviewCommentFromReport(report, "none"), /\*\*PR egg\*\*\n🥚 Incubating:/);
 });
 
 test("issues do not render PR egg game", () => {


### PR DESCRIPTION
## Summary
- Derive PR egg lifecycle from the current ClawSweeper PR status signal instead of recomputing readiness from report internals.
- Fall back to known bot-owned status labels in report frontmatter when the explicit status signal is unavailable, fixing the #83632 ready-status hatch miss.
- Keep proof gating as display behavior: missing/insufficient proof still shows the teaser, while status controls warming, wobbling, incubating, and hatching once proof is unlocked.

## Validation
- `pnpm exec oxfmt --write src/clawsweeper.ts test/clawsweeper.test.ts`
- `pnpm run build:all`
- `pnpm run test:unit` (235/235 tests passed)