### PR TITLE
fix(workflow): explain superseded re-review runs

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -411,6 +411,10 @@ jobs:
         run: |
           state="Failed"
           detail="The targeted re-review did not finish cleanly. Check the workflow run for details."
+          if [ "$REVIEW_OUTCOME" = "cancelled" ]; then
+            state="Superseded"
+            detail="A newer re-review for this item started before this run finished, so GitHub cancelled this older run. Check the latest ClawSweeper run for the current result."
+          fi
           if [ "$REVIEW_OUTCOME" = "success" ] && [ "$PUBLISH_OUTCOME" = "success" ] && [ "$ROUTE_OUTCOME" = "success" ]; then
             state="Complete"
             detail="The targeted re-review finished, the durable review comment was updated, and the synced verdict was routed."

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -6950,6 +6950,18 @@ test("event review completion removes ClawSweeper eyes reaction", () => {
   assert.doesNotMatch(block, /issues\/comments\/\$ITEM_NUMBER\/reactions/);
 });
 
+test("event re-review status explains superseded cancellations", () => {
+  const workflow = readFileSync(".github/workflows/sweep.yml", "utf8");
+  const block = workflow.slice(
+    workflow.indexOf("- name: Mark re-review complete"),
+    workflow.indexOf("- name: Commit event comment router ledger"),
+  );
+
+  assert.match(block, /\[ "\$REVIEW_OUTCOME" = "cancelled" \]/);
+  assert.match(block, /state="Superseded"/);
+  assert.match(block, /A newer re-review for this item started before this run finished/);
+});
+
 test("manual exact-item review dispatches avoid broad review concurrency", () => {
   const workflow = readFileSync(".github/workflows/sweep.yml", "utf8");
 


### PR DESCRIPTION
## Summary
- mark cancelled targeted re-review command statuses as Superseded
- explain that a newer same-item re-review cancelled the older run
- add workflow coverage for the superseded status message

## Validation
- pnpm exec node --test test/clawsweeper.test.ts
- pnpm run check