### PR TITLE
fix(repair): credit automerge requester after repair

### DIFF
--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -708,7 +708,7 @@ export function buildAutomergeSquashMessage({
     `Prepared head SHA: ${target.head_sha ?? command.expected_head_sha ?? "unknown"}`,
     ...(command.comment_url ? [`Review: ${command.comment_url}`] : []),
     "",
-    ...automergeCreditTrailers({ command, commits: view.commits ?? [] }),
+    ...automergeCreditTrailers({ command, comments, commits: view.commits ?? [] }),
   ].join("\n");
   return { subject, body: body.trimEnd(), summaryLines, fixupLines };
 }
@@ -749,7 +749,7 @@ function automergeFixupLines({ view, comments }: LooseRecord): string[] {
     : ["No ClawSweeper repair was needed after automerge opt-in."];
 }
 
-function automergeCreditTrailers({ command, commits }: LooseRecord): string[] {
+function automergeCreditTrailers({ command, comments, commits }: LooseRecord): string[] {
   const trailers: string[] = [];
   const coAuthorKeys = new Set<string>();
   for (const trailer of coAuthorTrailersFromCommits(commits, coAuthorKeys)) {
@@ -761,7 +761,10 @@ function automergeCreditTrailers({ command, commits }: LooseRecord): string[] {
   }
 
   const maintainer = maintainerCredit(
-    command.maintainer_attribution ?? automergeRequestedByFromBody(command.target?.body) ?? command,
+    command.maintainer_attribution ??
+      automergeRequestedByFromComments(comments) ??
+      automergeRequestedByFromBody(command.target?.body) ??
+      command,
   );
   if (!maintainer) return trailers;
   trailers.push(`Approved-by: ${maintainer.login}`);
@@ -769,6 +772,42 @@ function automergeCreditTrailers({ command, commits }: LooseRecord): string[] {
     trailers.push(`Co-authored-by: ${maintainer.name} <${maintainer.email}>`);
   }
   return trailers;
+}
+
+export function automergeRequestedByFromComments(comments: JsonValue): LooseRecord | null {
+  if (!Array.isArray(comments)) return null;
+  const byId = new Map<string, LooseRecord>();
+  for (const comment of comments) {
+    const id = String(comment?.id ?? "").trim();
+    if (id) byId.set(id, comment);
+  }
+  const candidates: Array<{ at: number; comment: LooseRecord }> = [];
+  for (const statusComment of comments) {
+    const body = String(statusComment?.body ?? "");
+    for (const marker of body.matchAll(
+      /<!--\s*clawsweeper-command:([^:\s>]+):(.+?):(automerge|maintainer_approve_automerge):([^>\s]+)\s*-->/gi,
+    )) {
+      const [, commentId, createdAt, intent] = marker;
+      if (!["automerge", "maintainer_approve_automerge"].includes(String(intent))) continue;
+      const original = byId.get(String(commentId ?? "").trim());
+      if (!original || original === statusComment) continue;
+      if (String(original?.user?.login ?? original?.author ?? "").includes("[bot]")) continue;
+      const parsed = parseCommand(String(original?.body ?? ""));
+      if (!["automerge", "maintainer_approve_automerge"].includes(String(parsed.intent))) continue;
+      candidates.push({
+        at: Date.parse(String(createdAt ?? original?.created_at ?? original?.createdAt ?? "")) || 0,
+        comment: original,
+      });
+    }
+  }
+  const latest = candidates.sort((left, right) => right.at - left.at)[0]?.comment;
+  const author = latest?.user?.login ?? latest?.author;
+  if (!author) return null;
+  return {
+    author,
+    author_id: latest?.user?.id ?? latest?.author_id ?? null,
+    author_name: latest?.user?.name ?? latest?.author_name ?? null,
+  };
 }
 
 function coAuthorTrailersFromCommits(commits: JsonValue, seen: Set<string>): string[] {

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -12,6 +12,7 @@ import {
   automergeChangelogBlockReason,
   automergeFailedChecksRepairReason,
   automergeClusterId,
+  automergeRequestedByFromComments,
   automergeRequestedByFromBody,
   automergeGateBlockReason,
   automergeJobBranch,
@@ -2022,6 +2023,65 @@ test("automerge squash message credits maintainer metadata carried by replacemen
     message.body,
     /^Co-authored-by: clawsweeper\[bot\] <274271284\+clawsweeper\[bot\]@users\.noreply\.github\.com>$/m,
   );
+  assert.match(
+    message.body,
+    /^Co-authored-by: maintainer-user <123456\+maintainer-user@users\.noreply\.github\.com>$/m,
+  );
+});
+
+test("automerge squash message credits requester from earlier automerge status marker", () => {
+  const comments = [
+    {
+      id: 4479302465,
+      user: {
+        login: "maintainer-user",
+        id: 123456,
+      },
+      created_at: "2026-05-18T15:39:35Z",
+      body: "@clawsweeper automerge",
+    },
+    {
+      id: 4479324116,
+      user: {
+        login: "clawsweeper[bot]",
+        id: 274271284,
+      },
+      created_at: "2026-05-18T15:42:14Z",
+      body: [
+        "<!-- clawsweeper-command-status:83614:automerge:2239f3ec0c513b0e7b467331c11ab75a6656617d -->",
+        "<!-- clawsweeper-command:4479302465:2026-05-18T15:39:35Z:automerge:2239f3ec0c513b0e7b467331c11ab75a6656617d -->",
+        "ClawSweeper automerge is enabled.",
+      ].join("\n"),
+    },
+  ];
+
+  assert.deepEqual(automergeRequestedByFromComments(comments), {
+    author: "maintainer-user",
+    author_id: 123456,
+    author_name: null,
+  });
+
+  const message = buildAutomergeSquashMessage({
+    command: {
+      issue_number: 83614,
+      expected_head_sha: "9f19a96427f9dbb50e69ea310518984e776eb48d",
+      target: { title: "fix: two phase" },
+      author: "clawsweeper[bot]",
+      author_id: 274271284,
+      trusted_bot: true,
+    },
+    target: {
+      head_sha: "9f19a96427f9dbb50e69ea310518984e776eb48d",
+      title: "fix: two phase",
+    },
+    view: {
+      title: "fix: two phase",
+      commits: [],
+    },
+    comments,
+  });
+
+  assert.match(message.body, /^Approved-by: maintainer-user$/m);
   assert.match(
     message.body,
     /^Co-authored-by: maintainer-user <123456\+maintainer-user@users\.noreply\.github\.com>$/m,


### PR DESCRIPTION
## Summary
- recover the human automerge requester from ClawSweeper status comments when the final merge is driven by a later bot verdict
- include that requester in the squash message Approved-by and Co-authored-by trailers after repair/re-review head changes
- add a regression based on the PR #83614 two-phase automerge timeline shape

## Validation
- pnpm run build:repair && node --test test/repair/comment-router-core.test.ts
- pnpm run check