### PR TITLE
fix(repair): gracefully handle open-but-locked issues and PRs during apply runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Skipped open-but-locked repair apply targets before close or merge mutations and converted GitHub locked-conversation write denials into terminal skipped records. Thanks @AsishKumarDalal.
 - Required OpenClaw config-surface changes to pause automerge for maintainer review instead of emitting pass markers, with durable config-surface report metadata. Thanks @osolmaz.
 - Disabled automatic push-triggered commit review while keeping manual commit-review workflow dispatch available.
 - Treated target `AGENTS.md` files as optional repository-authored review policy

--- a/src/repair/apply-locks.test.ts
+++ b/src/repair/apply-locks.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  lockedConversationReason,
+  lockedConversationSkip,
+  lockedConversationSkipIfLocked,
+} from "./apply-locks.js";
+
+test("locked apply skip includes live lock state and active reason", () => {
+  assert.deepEqual(
+    lockedConversationSkip(
+      { target: "#123", action: "close_duplicate" },
+      {
+        locked: true,
+        state: "open",
+        updated_at: "2026-05-29T12:00:00Z",
+        active_lock_reason: "resolved",
+      },
+    ),
+    {
+      target: "#123",
+      action: "close_duplicate",
+      status: "skipped",
+      reason: "target is locked (resolved)",
+      live_state: "open",
+      live_updated_at: "2026-05-29T12:00:00Z",
+      active_lock_reason: "resolved",
+    },
+  );
+});
+
+test("locked apply skip marks terminal GitHub write errors", () => {
+  assert.equal(
+    lockedConversationReason(
+      { locked: true, active_lock_reason: "spam" },
+      { terminalWriteError: true },
+    ),
+    "target is locked (spam); GitHub rejected the write",
+  );
+});
+
+test("locked apply skip helper ignores unlocked targets", () => {
+  assert.equal(
+    lockedConversationSkipIfLocked({ target: "#123" }, { locked: false, state: "open" }),
+    null,
+  );
+});

--- a/src/repair/apply-locks.ts
+++ b/src/repair/apply-locks.ts
@@ -1,0 +1,35 @@
+import type { LooseRecord } from "./json-types.js";
+
+export function lockedConversationSkipIfLocked(base: LooseRecord, live: LooseRecord) {
+  if (live?.locked !== true) return null;
+  return lockedConversationSkip(base, live);
+}
+
+export function lockedConversationSkip(
+  base: LooseRecord,
+  live: LooseRecord,
+  options: { terminalWriteError?: boolean } = {},
+) {
+  return {
+    ...base,
+    status: "skipped",
+    reason: lockedConversationReason(live, options),
+    live_state: live?.state ?? null,
+    live_updated_at: live?.updated_at ?? null,
+    ...(normalizedLockReason(live) ? { active_lock_reason: normalizedLockReason(live) } : {}),
+  };
+}
+
+export function lockedConversationReason(
+  live: LooseRecord,
+  options: { terminalWriteError?: boolean } = {},
+) {
+  const activeLockReason = normalizedLockReason(live);
+  const reason = activeLockReason ? `target is locked (${activeLockReason})` : "target is locked";
+  return options.terminalWriteError ? `${reason}; GitHub rejected the write` : reason;
+}
+
+function normalizedLockReason(live: LooseRecord) {
+  const reason = live?.active_lock_reason;
+  return typeof reason === "string" && reason.trim() ? reason.trim() : "";
+}

--- a/src/repair/apply-result.ts
+++ b/src/repair/apply-result.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import type { JsonValue, LooseRecord } from "./json-types.js";
 import fs from "node:fs";
 import path from "node:path";
@@ -20,6 +21,7 @@ import {
 } from "./github-cli.js";
 import { issueNumberFromRef } from "./github-ref.js";
 import { isLockedConversationCommentError } from "../github-retry.js";
+import { lockedConversationSkip, lockedConversationSkipIfLocked } from "./apply-locks.js";
 import {
   CLAWSWEEPER_LABEL,
   CLAWSWEEPER_LABEL_COLOR,
@@ -154,7 +156,6 @@ function findLatestResultPath() {
   return candidates[0].path;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function readFixExecutionReport(_result?: JsonValue) {
   const reportPath = path.join(path.dirname(resultPath), "fix-execution-report.json");
   if (!fs.existsSync(reportPath)) return null;
@@ -297,14 +298,6 @@ function applyCloseAction({
     return { ...base, status: "blocked", reason: replacementCloseoutBlock };
 
   const live = fetchIssue(result.repo, target);
-  if (live.locked === true) {
-    return {
-      ...base,
-      status: "skipped",
-      reason: "target is locked",
-      live_state: live.state,
-    };
-  }
   const kind = live.pull_request ? "pull_request" : "issue";
   const authorAssociation = normalizeAuthorAssociation(live.author_association);
   if (hasSecuritySignal(live)) {
@@ -372,6 +365,8 @@ function applyCloseAction({
       live_state: live.state,
     };
   }
+  const lockedSkip = lockedConversationSkipIfLocked(base, live);
+  if (lockedSkip) return lockedSkip;
 
   if (dryRun) {
     return {
@@ -391,12 +386,7 @@ function applyCloseAction({
     closeIssueOrPullRequest(result.repo, target, kind, classification);
   } catch (error) {
     if (isLockedConversationCommentError(error)) {
-      return {
-        ...base,
-        status: "skipped",
-        reason: "target is locked (terminal 403)",
-        live_state: live.state,
-      };
+      return lockedConversationSkip(base, live, { terminalWriteError: true });
     }
     throw error;
   }
@@ -430,14 +420,6 @@ function applyMergeAction({
   }
 
   const live = fetchIssue(result.repo, target);
-  if (live.locked === true) {
-    return {
-      ...base,
-      status: "skipped",
-      reason: "target is locked",
-      live_state: live.state,
-    };
-  }
   if (!live.pull_request) {
     return {
       ...base,
@@ -490,6 +472,8 @@ function applyMergeAction({
       merge_commit_sha: pullRequest.merge_commit_sha ?? view.mergeCommit?.oid ?? null,
     };
   }
+  const lockedSkip = lockedConversationSkipIfLocked(base, live);
+  if (lockedSkip) return { ...lockedSkip, merge_method: "squash" };
 
   const mergeBlock = validateMergeablePullRequest({ pullRequest, view });
   if (mergeBlock) {
@@ -562,10 +546,8 @@ function applyMergeAction({
   } catch (error) {
     if (isLockedConversationCommentError(error)) {
       return {
-        ...base,
-        status: "skipped",
-        reason: "target is locked (terminal 403)",
-        live_state: live.state,
+        ...lockedConversationSkip(base, live, { terminalWriteError: true }),
+        merge_method: "squash",
       };
     }
     throw error;
@@ -975,7 +957,6 @@ function fetchIssue(repo: string, number: JsonValue) {
   return ghJson(["api", `repos/${repo}/issues/${number}`]);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function fetchPullRequest(repo: string, number: JsonValue) {
   return ghJson(["api", `repos/${repo}/pulls/${number}`]);
 }

--- a/src/repair/apply-result.ts
+++ b/src/repair/apply-result.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 import type { JsonValue, LooseRecord } from "./json-types.js";
 import fs from "node:fs";
 import path from "node:path";
@@ -20,6 +19,7 @@ import {
   ghTextWithRetry as ghWithRetry,
 } from "./github-cli.js";
 import { issueNumberFromRef } from "./github-ref.js";
+import { isLockedConversationCommentError } from "../github-retry.js";
 import {
   CLAWSWEEPER_LABEL,
   CLAWSWEEPER_LABEL_COLOR,
@@ -154,6 +154,7 @@ function findLatestResultPath() {
   return candidates[0].path;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function readFixExecutionReport(_result?: JsonValue) {
   const reportPath = path.join(path.dirname(resultPath), "fix-execution-report.json");
   if (!fs.existsSync(reportPath)) return null;
@@ -296,6 +297,14 @@ function applyCloseAction({
     return { ...base, status: "blocked", reason: replacementCloseoutBlock };
 
   const live = fetchIssue(result.repo, target);
+  if (live.locked === true) {
+    return {
+      ...base,
+      status: "skipped",
+      reason: "target is locked",
+      live_state: live.state,
+    };
+  }
   const kind = live.pull_request ? "pull_request" : "issue";
   const authorAssociation = normalizeAuthorAssociation(live.author_association);
   if (hasSecuritySignal(live)) {
@@ -375,10 +384,22 @@ function applyCloseAction({
     };
   }
 
-  if (!existingComment) {
-    postIssueComment(result.repo, target, body);
+  try {
+    if (!existingComment) {
+      postIssueComment(result.repo, target, body);
+    }
+    closeIssueOrPullRequest(result.repo, target, kind, classification);
+  } catch (error) {
+    if (isLockedConversationCommentError(error)) {
+      return {
+        ...base,
+        status: "skipped",
+        reason: "target is locked (terminal 403)",
+        live_state: live.state,
+      };
+    }
+    throw error;
   }
-  closeIssueOrPullRequest(result.repo, target, kind, classification);
 
   return {
     ...base,
@@ -403,11 +424,20 @@ function applyMergeAction({
   if (!allowedRefs.has(target)) {
     return { ...base, status: "blocked", reason: "merge target is not listed in job refs" };
   }
+
   if (action.target_kind !== "pull_request") {
     return { ...base, status: "blocked", reason: "merge action requires pull_request target_kind" };
   }
 
   const live = fetchIssue(result.repo, target);
+  if (live.locked === true) {
+    return {
+      ...base,
+      status: "skipped",
+      reason: "target is locked",
+      live_state: live.state,
+    };
+  }
   if (!live.pull_request) {
     return {
       ...base,
@@ -527,7 +557,19 @@ function applyMergeAction({
     bodyFile,
   ];
   if (pullRequest.head?.sha) mergeArgs.push("--match-head-commit", String(pullRequest.head.sha));
-  ghWithRetry(mergeArgs);
+  try {
+    ghWithRetry(mergeArgs);
+  } catch (error) {
+    if (isLockedConversationCommentError(error)) {
+      return {
+        ...base,
+        status: "skipped",
+        reason: "target is locked (terminal 403)",
+        live_state: live.state,
+      };
+    }
+    throw error;
+  }
   const merged = fetchPullRequest(result.repo, target);
   return {
     ...base,
@@ -552,6 +594,7 @@ function validateClosePolicy({ job, actionName }: LooseRecord) {
     return "close is blocked by job frontmatter";
   if ((job.frontmatter.blocked_actions ?? []).includes("comment"))
     return "comment is blocked by job frontmatter";
+
   if (
     !["close_low_signal", "post_merge_close"].includes(actionName) &&
     job.frontmatter.allow_instant_close !== true
@@ -932,6 +975,7 @@ function fetchIssue(repo: string, number: JsonValue) {
   return ghJson(["api", `repos/${repo}/issues/${number}`]);
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function fetchPullRequest(repo: string, number: JsonValue) {
   return ghJson(["api", `repos/${repo}/pulls/${number}`]);
 }


### PR DESCRIPTION
### 🚀 Overview of Changes

This PR resolves a critical resilience issue in the automated applicator worker (`scripts/apply-result.ts`). Currently, when automated cleanup scripts run on stale or duplicate issues/PRs, they can fail catastrophically if they attempt to interact with **locked** conversations. 

#### 🔍 The Problem
1. **Open-but-Locked Edge Case**: If stale automation previously locked a closed issue/PR, and the original author subsequently reopened it, the item becomes "open-but-locked". 
2. **Crash Vulnerability**: When the applicator attempts to post a closure/merging comment or close the locked item, the GitHub API throws a terminal `403 Forbidden` error indicating the conversation is locked. Because these exceptions are not handled, they bubble up and crash the entire apply run.

#### 🛠️ Solution Implementation
We have introduced both **proactive** and **reactive** guards to handle locked conversations gracefully:

1. **Proactive Lock Detection**:
   - In `applyCloseAction` and `applyMergeAction`, we now inspect `live.locked` immediately after fetching the target.
   - If `live.locked === true`, we gracefully skip the action, returning status `"skipped"` and reason `"target is locked"`.

2. **Reactive Lock Resilience**:
   - In `applyCloseAction`, we wrap `postIssueComment` and `closeIssueOrPullRequest` inside a `try-catch` block.
   - In `applyMergeAction`, we wrap the `ghWithRetry(mergeArgs)` call in a `try-catch` block.
   - If a call fails, we evaluate the error using the existing `isLockedConversationCommentError(error)` safety utility. If matched, we gracefully transform the 403 failure into a terminal `"skipped"` status and reason `"target is locked (terminal 403)"`, preventing the entire script from crashing.

This guarantees robust, non-crashing execution for scheduled workflow sweeps.