### PR TITLE
fix(repair): inherit replacement PR closing refs

### DIFF
--- a/src/repair/execute-fix-artifact.ts
+++ b/src/repair/execute-fix-artifact.ts
@@ -108,6 +108,7 @@ import {
   fetchSourcePullRequestView,
   prepareReviewThreadsForMerge,
   publicContributorCredit,
+  sourceClosingReferences,
   sourceContributorCredits,
   supersededReplacementSources,
 } from "./execute-fix-github.js";
@@ -1100,6 +1101,11 @@ function openReplacementPrFromPreparedRepairCheckout({
     provenance,
     contributorCredits,
     maintainerAttribution: jobMaintainerAttribution(),
+    sourceClosingReferences: sourceClosingReferences({
+      fixArtifact,
+      targetDir,
+      repo: result.repo,
+    }),
   });
   const bodyPath = path.join(workRoot, "replacement-pr-body.md");
   fs.writeFileSync(bodyPath, body);
@@ -1432,6 +1438,11 @@ function executeReplacementBranch({
     provenance,
     contributorCredits,
     maintainerAttribution: jobMaintainerAttribution(),
+    sourceClosingReferences: sourceClosingReferences({
+      fixArtifact,
+      targetDir,
+      repo: result.repo,
+    }),
   });
   if (dryRun) {
     return {

--- a/src/repair/execute-fix-github.ts
+++ b/src/repair/execute-fix-github.ts
@@ -9,6 +9,7 @@ import { parsePullRequestUrl } from "./github-ref.js";
 import { repoRoot } from "./lib.js";
 import { repairGhEnv as ghEnv } from "./process-env.js";
 import { uniqueStrings } from "./validation-command-utils.js";
+import { closingReferencesFromMarkdown } from "./external-messages.js";
 
 const ghCommandTimeoutMs = Math.max(
   30_000,
@@ -49,6 +50,31 @@ export function fetchSourcePullRequestView({
       },
     ),
   );
+}
+
+export function sourceClosingReferences({
+  fixArtifact,
+  targetDir,
+  repo,
+}: {
+  fixArtifact: LooseRecord;
+  targetDir: string;
+  repo: string;
+}): string[] {
+  const references: string[] = [];
+  for (const source of fixArtifact.source_prs ?? []) {
+    const parsed = parsePullRequestUrl(source);
+    if (!parsed || parsed.repo !== repo) continue;
+    const view = JSON.parse(
+      run("gh", ["pr", "view", String(parsed.number), "--repo", repo, "--json", "body"], {
+        cwd: targetDir,
+        env: ghEnv(),
+        timeoutMs: ghCommandTimeoutMs,
+      }),
+    );
+    references.push(...closingReferencesFromMarkdown(view.body));
+  }
+  return uniqueStrings(references);
 }
 
 export function sourceContributorCredits({

--- a/src/repair/external-messages.ts
+++ b/src/repair/external-messages.ts
@@ -9,6 +9,29 @@ function listOrNone(items: JsonValue[]) {
   return items?.length ? items.join("; ") : "none";
 }
 
+const CLOSING_REFERENCE_PATTERN =
+  /\b(?<verb>close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+(?<targets>(?:https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/issues\/\d+|[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+#\d+|#\d+)(?:\s*,\s*(?:https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/issues\/\d+|[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+#\d+|#\d+))*)/gi;
+
+export function closingReferencesFromMarkdown(body: JsonValue) {
+  const seen = new Set<string>();
+  const references: string[] = [];
+  for (const match of String(body ?? "").matchAll(CLOSING_REFERENCE_PATTERN)) {
+    const verb = String(match.groups?.verb ?? "").trim();
+    const targets = String(match.groups?.targets ?? "")
+      .split(/\s*,\s*/)
+      .map((target) => target.trim())
+      .filter(Boolean);
+    for (const target of targets) {
+      const reference = `${verb} ${target}`.replace(/\s+/g, " ").trim();
+      const key = reference.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      references.push(reference);
+    }
+  }
+  return references;
+}
+
 function visibleSelfReference(value: JsonValue, target: JsonValue) {
   const text = String(value ?? "");
   const number = String(target ?? "").replace(/^#/, "");
@@ -396,6 +419,7 @@ export function replacementPrBody({
   provenance,
   contributorCredits,
   maintainerAttribution = null,
+  sourceClosingReferences = [],
 }: LooseRecord) {
   const lines = [
     fixArtifact.pr_body.trim(),
@@ -417,10 +441,34 @@ export function replacementPrBody({
     );
   }
   if (fallbackReason) lines.push(`- Repair fallback: ${fallbackReason}`);
+  const closingReferences = uniqueLines(sourceClosingReferences);
+  if (closingReferences.length > 0) {
+    lines.push(
+      "",
+      "Inherited issue-closing references from the source PR:",
+      ...closingReferences.map((reference) => `${reference}`),
+    );
+  }
   const creditLines = contributorCreditLines(contributorCredits);
   if (creditLines.length > 0) lines.push("", ...creditLines);
   lines.push("", fishNotes(provenance));
   return `${lines.join("\n")}\n`;
+}
+
+function uniqueLines(values: JsonValue[]) {
+  const seen = new Set<string>();
+  const lines: string[] = [];
+  for (const value of Array.isArray(values) ? values : []) {
+    const line = String(value ?? "")
+      .replace(/\s+/g, " ")
+      .trim();
+    if (!line) continue;
+    const key = line.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    lines.push(line);
+  }
+  return lines;
 }
 
 function automergeMaintainerAttribution(value: LooseRecord): LooseRecord | null {

--- a/test/repair/external-messages.test.ts
+++ b/test/repair/external-messages.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   automergeRepairOutcomeComment,
+  closingReferencesFromMarkdown,
   externalMessageProvenance,
   issueImplementationResultStatusComment,
   repairContributorBranchComment,
@@ -112,6 +113,7 @@ test("replacement PR body records replacement reason and co-author credit", () =
       author: "maintainer-user",
       author_id: 123456,
     },
+    sourceClosingReferences: ["Closes #74124", "closes #74124", "Fixes openclaw/openclaw#81234"],
     provenance: { model: "gpt-test", reasoning: "medium", reviewedSha: "abcdef1234567890" },
   });
 
@@ -124,7 +126,24 @@ test("replacement PR body records replacement reason and co-author credit", () =
   assert.match(body, /Automerge requested by: @maintainer-user/);
   assert.match(
     body,
+    /Inherited issue-closing references from the source PR:\nCloses #74124\nFixes openclaw\/openclaw#81234/,
+  );
+  assert.match(
+    body,
     /<!-- clawsweeper-automerge-requested-by login="maintainer-user" id="123456" -->/,
+  );
+});
+
+test("closingReferencesFromMarkdown extracts GitHub closing syntax", () => {
+  assert.deepEqual(
+    closingReferencesFromMarkdown(
+      "Context.\n\nCloses #74124, openclaw/openclaw#81234\nFixes https://github.com/openclaw/openclaw/issues/81235\ncloses #74124",
+    ),
+    [
+      "Closes #74124",
+      "Closes openclaw/openclaw#81234",
+      "Fixes https://github.com/openclaw/openclaw/issues/81235",
+    ],
   );
 });
 


### PR DESCRIPTION
## Summary
- fetch source PR bodies while rendering replacement PR bodies
- extract and dedupe GitHub issue-closing keywords from source PR markdown
- append inherited closing references to replacement PR bodies so linked issues auto-close on merge

Fixes https://github.com/openclaw/clawsweeper/issues/127

## Validation
- pnpm install --frozen-lockfile
- pnpm run check