### PR TITLE
fix(repair): harden automerge continuation gates

### DIFF
--- a/src/repair/automerge-outcome.ts
+++ b/src/repair/automerge-outcome.ts
@@ -1,0 +1,30 @@
+import type { JsonValue, LooseRecord } from "./json-types.js";
+import { parsePullRequestUrl } from "./github-ref.js";
+
+export function automergeOutcomeReviewedShaFromResult({
+  result,
+  repo,
+  target,
+  targetView = null,
+}: {
+  result: LooseRecord;
+  repo: JsonValue;
+  target?: JsonValue;
+  targetView?: LooseRecord | null;
+}) {
+  const direct =
+    result.reviewed_sha ??
+    result.head_sha ??
+    result.canonical?.pull_request?.head_sha ??
+    result.canonical_item?.pull_request?.head_sha ??
+    null;
+  if (direct) return direct;
+
+  const canonicalPr = parsePullRequestUrl(result.canonical_pr);
+  if (!canonicalPr || canonicalPr.repo !== String(repo)) return null;
+  if (target !== undefined && Number(canonicalPr.number) !== Number(target)) return null;
+
+  return (
+    targetView?.headRefOid ?? targetView?.head_sha ?? targetView?.pull_request?.head_sha ?? null
+  );
+}

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -400,12 +400,11 @@ When code changes are appropriate, emit a fix artifact with
 `;
 }
 
-export function automergeChangelogBlockReason({ repo, title, files }: LooseRecord): string | null {
+export function automergeChangelogBlockReason({ repo, files }: LooseRecord): string | null {
   if (String(repo ?? "").toLowerCase() !== "openclaw/openclaw") return null;
 
   const paths = normalizeChangedPaths(files);
   if (paths.some(isChangelogPath)) return null;
-  if (!automergeTitleUsuallyNeedsChangelog(title)) return null;
   if (!paths.some(isPotentiallyUserFacingPath)) return null;
 
   return "CHANGELOG.md entry is required for user-facing ClawSweeper automerge changes";
@@ -421,10 +420,6 @@ function normalizeChangedPaths(files: JsonValue): string[] {
 
 function isChangelogPath(file: string): boolean {
   return /(^|\/)CHANGELOG\.md$/i.test(file);
-}
-
-function automergeTitleUsuallyNeedsChangelog(title: JsonValue): boolean {
-  return /^(?:feat|fix|perf)(?:\([^)]+\))?:/i.test(String(title ?? "").trim());
 }
 
 function isPotentiallyUserFacingPath(file: string): boolean {

--- a/src/repair/execute-fix-artifact.ts
+++ b/src/repair/execute-fix-artifact.ts
@@ -37,6 +37,7 @@ import {
   automergeShepherdWaitConfig,
   canUseAutomergeFastRebase,
 } from "./automerge-shepherd.js";
+import { automergeOutcomeReviewedShaFromResult } from "./automerge-outcome.js";
 import { isCanonicalLandingNeedsHumanText } from "./comment-router-core.js";
 import { parsePullRequestUrl, pullRequestNumberFromUrl } from "./github-ref.js";
 import {
@@ -3448,6 +3449,7 @@ function appendAutomergeRepairOutcomeComment(report: LooseRecord, resultPath: st
   }
 
   const continuation = continueAutomergeAfterNoopRepair({ target });
+  const reviewedSha = continuation.head_sha ?? automergeOutcomeReviewedSha();
   const body = automergeRepairOutcomeComment({
     marker,
     result,
@@ -3456,7 +3458,7 @@ function appendAutomergeRepairOutcomeComment(report: LooseRecord, resultPath: st
     provenance: externalMessageProvenance({
       model,
       reasoning: codexReasoningEffort,
-      reviewedSha: automergeOutcomeReviewedSha(),
+      reviewedSha,
     }),
   });
   const existingStatus = findAutomergeStatusComment(target);
@@ -3471,7 +3473,7 @@ function appendAutomergeRepairOutcomeComment(report: LooseRecord, resultPath: st
         completedAt: new Date().toISOString(),
         durationMs: Date.now() - scriptStartedAt.getTime(),
         runUrl: currentActionsRunUrl(),
-        headSha: automergeOutcomeReviewedSha(),
+        headSha: reviewedSha,
         status: "no branch change",
         details: report?.reason ?? "no executable fix action",
       },
@@ -3497,9 +3499,9 @@ function appendAutomergeRepairOutcomeComment(report: LooseRecord, resultPath: st
 }
 
 function continueAutomergeAfterNoopRepair({ target }: LooseRecord) {
-  const commit = automergeOutcomeReviewedSha();
-  if (!commit) return { status: "skipped", reason: "missing reviewed head SHA" };
   const view = fetchPullRequestViewForRepo({ repo: result.repo, number: target });
+  const commit = automergeOutcomeReviewedSha({ target, targetView: view });
+  if (!commit) return { status: "skipped", reason: "missing reviewed head SHA" };
   const comments = issueCommentsFor(target);
   const readiness = automergeShepherdReadiness({
     view,
@@ -3848,14 +3850,13 @@ function automergeOutcomeTargetPrNumber() {
   return clusterMatch ? Number(clusterMatch[1]) : 0;
 }
 
-function automergeOutcomeReviewedSha() {
-  return (
-    result.reviewed_sha ??
-    result.head_sha ??
-    result.canonical?.pull_request?.head_sha ??
-    result.canonical_item?.pull_request?.head_sha ??
-    null
-  );
+function automergeOutcomeReviewedSha({ target = undefined, targetView = null }: LooseRecord = {}) {
+  return automergeOutcomeReviewedShaFromResult({
+    result,
+    repo: result.repo,
+    target,
+    targetView,
+  });
 }
 
 function automergeOutcomeMarker({ target, resultPath }: LooseRecord) {

--- a/test/repair/automerge-outcome.test.ts
+++ b/test/repair/automerge-outcome.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { automergeOutcomeReviewedShaFromResult } from "../../dist/repair/automerge-outcome.js";
+
+test("automerge no-op continuation derives target head from matching canonical PR", () => {
+  const headSha = "92dca8fde03aee8da56a84a011fa387b9c1640fe";
+  const reviewedSha = automergeOutcomeReviewedShaFromResult({
+    repo: "openclaw/openclaw",
+    target: 83707,
+    result: {
+      repo: "openclaw/openclaw",
+      canonical_pr: "https://github.com/openclaw/openclaw/pull/83707",
+      fix_artifact: null,
+    },
+    targetView: {
+      headRefOid: headSha,
+    },
+  });
+
+  assert.equal(reviewedSha, headSha);
+});
+
+test("automerge no-op continuation does not borrow head from a different canonical PR", () => {
+  const reviewedSha = automergeOutcomeReviewedShaFromResult({
+    repo: "openclaw/openclaw",
+    target: 83707,
+    result: {
+      repo: "openclaw/openclaw",
+      canonical_pr: "https://github.com/openclaw/openclaw/pull/82166",
+      fix_artifact: null,
+    },
+    targetView: {
+      headRefOid: "92dca8fde03aee8da56a84a011fa387b9c1640fe",
+    },
+  });
+
+  assert.equal(reviewedSha, null);
+});

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -662,6 +662,18 @@ test("automerge changelog gate blocks user-facing OpenClaw changes without chang
   assert.equal(
     automergeChangelogBlockReason({
       repo: "openclaw/openclaw",
+      title: "Log Telegram outbound delivery success",
+      files: [
+        { path: "extensions/telegram/src/send.ts" },
+        { path: "extensions/telegram/src/send.test.ts" },
+      ],
+    }),
+    "CHANGELOG.md entry is required for user-facing ClawSweeper automerge changes",
+  );
+
+  assert.equal(
+    automergeChangelogBlockReason({
+      repo: "openclaw/openclaw",
       title: "fix(discord): cool down Cloudflare 429 responses",
       files: [{ path: "CHANGELOG.md" }, { path: "extensions/discord/src/api.ts" }],
     }),
@@ -693,7 +705,7 @@ test("automerge activation sends missing changelog directly to repair", () => {
     automergeActivationRepairReason({
       intent: "automerge",
       repo: "openclaw/openclaw",
-      title: "fix(memory): preserve session corpus labels",
+      title: "Preserve session corpus labels",
       files: [
         { path: "extensions/memory-core/src/tools.ts" },
         { path: "extensions/memory-core/src/tools.test.ts" },


### PR DESCRIPTION
## Summary
- require changelog coverage for user-facing automerge repair titles
- derive no-op automerge continuation heads from the matching canonical PR when result metadata lacks a reviewed SHA
- cover matching and mismatched canonical PR head derivation cases

## Validation
- pnpm run build:repair
- node --test test/repair/automerge-outcome.test.ts
- pnpm exec oxfmt --check src/repair/automerge-outcome.ts src/repair/execute-fix-artifact.ts test/repair/automerge-outcome.test.ts
- pnpm run test:repair
- pnpm run check