### PR TITLE
Add proof nudge reminders for PRs missing behavior proof

### DIFF
--- a/.github/workflows/proof-nudges.yml
+++ b/.github/workflows/proof-nudges.yml
@@ -1,0 +1,129 @@
+name: ClawSweeper Proof Nudges
+
+run-name: ${{ github.event_name == 'schedule' && 'Scheduled proof nudges' || 'Manual proof nudges' }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_repo:
+        description: "Repository to inspect for proof nudges"
+        required: false
+        default: "openclaw/openclaw"
+      execute:
+        description: "Post proof-nudge comments; false runs dry-run only"
+        required: false
+        default: "false"
+      limit:
+        description: "Maximum proof nudges to plan or post"
+        required: false
+        default: "10"
+      min_age_days:
+        description: "Minimum age in days since review/author activity before first proof nudge"
+        required: false
+        default: "5"
+      cooldown_days:
+        description: "Same-head cooldown in days between proof nudges"
+        required: false
+        default: "7"
+      item_numbers:
+        description: "Optional comma-separated PR numbers to inspect first"
+        required: false
+        default: ""
+  schedule:
+    - cron: "44 9 * * *"
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  CLAWSWEEPER_APP_CLIENT_ID: Iv23liOECG0slfuhz093
+
+concurrency:
+  group: ${{ format('clawsweeper-proof-nudges-{0}', github.event.inputs.target_repo || vars.CLAWSWEEPER_PROOF_NUDGES_TARGET_REPO || 'openclaw/openclaw') }}
+  cancel-in-progress: false
+
+jobs:
+  proof-nudges:
+    name: Proof nudges
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && vars.CLAWSWEEPER_PROOF_NUDGES_SCHEDULED == '1') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          filter: blob:none
+          fetch-depth: 0
+
+      - name: Resolve target repository
+        id: target
+        run: |
+          target_repo="${{ github.event.inputs.target_repo || vars.CLAWSWEEPER_PROOF_NUDGES_TARGET_REPO || 'openclaw/openclaw' }}"
+          target_owner="${target_repo%%/*}"
+          target_name="${target_repo#*/}"
+          {
+            echo "target_repo=$target_repo"
+            echo "target_repo_owner=$target_owner"
+            echo "target_repo_name=$target_name"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create target proof-nudge token
+        id: target-proof-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+          owner: ${{ steps.target.outputs.target_repo_owner }}
+          repositories: ${{ steps.target.outputs.target_repo_name }}
+          permission-contents: read
+          permission-issues: write
+          permission-pull-requests: read
+
+      - name: Create state token
+        id: state-token
+        uses: ./.github/actions/create-state-token
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+
+      - uses: ./.github/actions/setup-state
+        with:
+          token: ${{ steps.state-token.outputs.token }}
+
+      - uses: ./.github/actions/setup-pnpm
+        with:
+          build-script: build:all
+
+      - name: Run proof nudges
+        env:
+          GH_TOKEN: ${{ steps.target-proof-token.outputs.token }}
+          TARGET_REPO: ${{ steps.target.outputs.target_repo }}
+        run: |
+          set -euo pipefail
+          execute="${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.execute == 'true') || (github.event_name == 'schedule' && vars.CLAWSWEEPER_PROOF_NUDGES_EXECUTE == '1') }}"
+          execute_arg=()
+          if [ "$execute" = "true" ]; then
+            execute_arg=(--execute)
+          fi
+          item_numbers="${{ github.event.inputs.item_numbers || '' }}"
+          item_numbers_arg=()
+          if [ -n "$item_numbers" ]; then
+            item_numbers_arg=(--item-numbers "$item_numbers")
+          fi
+          pnpm run proof-nudges -- \
+            --target-repo "$TARGET_REPO" \
+            --limit "${{ github.event.inputs.limit || vars.CLAWSWEEPER_PROOF_NUDGES_LIMIT || '10' }}" \
+            --min-age-days "${{ github.event.inputs.min_age_days || vars.CLAWSWEEPER_PROOF_NUDGES_MIN_AGE_DAYS || '5' }}" \
+            --cooldown-days "${{ github.event.inputs.cooldown_days || vars.CLAWSWEEPER_PROOF_NUDGES_COOLDOWN_DAYS || '7' }}" \
+            --report-path proof-nudge-report.json \
+            "${item_numbers_arg[@]}" \
+            "${execute_arg[@]}"
+
+      - uses: actions/upload-artifact@v7
+        if: ${{ always() }}
+        with:
+          name: proof-nudge-report
+          path: proof-nudge-report.json
+          if-no-files-found: ignore

--- a/.github/workflows/proof-nudges.yml
+++ b/.github/workflows/proof-nudges.yml
@@ -59,8 +59,14 @@ jobs:
 
       - name: Resolve target repository
         id: target
+        env:
+          TARGET_REPO_INPUT: ${{ github.event.inputs.target_repo || vars.CLAWSWEEPER_PROOF_NUDGES_TARGET_REPO || 'openclaw/openclaw' }}
         run: |
-          target_repo="${{ github.event.inputs.target_repo || vars.CLAWSWEEPER_PROOF_NUDGES_TARGET_REPO || 'openclaw/openclaw' }}"
+          target_repo="$TARGET_REPO_INPUT"
+          if [[ ! "$target_repo" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+            echo "::error::target_repo must be owner/repo with GitHub-safe characters"
+            exit 1
+          fi
           target_owner="${target_repo%%/*}"
           target_name="${target_repo#*/}"
           {
@@ -100,23 +106,37 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.target-proof-token.outputs.token }}
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
+          PROOF_NUDGES_EXECUTE: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.execute == 'true') || (github.event_name == 'schedule' && vars.CLAWSWEEPER_PROOF_NUDGES_EXECUTE == '1') }}
+          PROOF_NUDGES_ITEM_NUMBERS: ${{ github.event.inputs.item_numbers || '' }}
+          PROOF_NUDGES_LIMIT: ${{ github.event.inputs.limit || vars.CLAWSWEEPER_PROOF_NUDGES_LIMIT || '10' }}
+          PROOF_NUDGES_MIN_AGE_DAYS: ${{ github.event.inputs.min_age_days || vars.CLAWSWEEPER_PROOF_NUDGES_MIN_AGE_DAYS || '5' }}
+          PROOF_NUDGES_COOLDOWN_DAYS: ${{ github.event.inputs.cooldown_days || vars.CLAWSWEEPER_PROOF_NUDGES_COOLDOWN_DAYS || '7' }}
         run: |
           set -euo pipefail
-          execute="${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.execute == 'true') || (github.event_name == 'schedule' && vars.CLAWSWEEPER_PROOF_NUDGES_EXECUTE == '1') }}"
+          for numeric_input in PROOF_NUDGES_LIMIT PROOF_NUDGES_MIN_AGE_DAYS PROOF_NUDGES_COOLDOWN_DAYS; do
+            if [[ ! "${!numeric_input}" =~ ^[0-9]+$ ]]; then
+              echo "::error::$numeric_input must be a non-negative integer"
+              exit 1
+            fi
+          done
+
           execute_arg=()
-          if [ "$execute" = "true" ]; then
+          if [ "$PROOF_NUDGES_EXECUTE" = "true" ]; then
             execute_arg=(--execute)
           fi
-          item_numbers="${{ github.event.inputs.item_numbers || '' }}"
           item_numbers_arg=()
-          if [ -n "$item_numbers" ]; then
-            item_numbers_arg=(--item-numbers "$item_numbers")
+          if [ -n "$PROOF_NUDGES_ITEM_NUMBERS" ]; then
+            if [[ ! "$PROOF_NUDGES_ITEM_NUMBERS" =~ ^[0-9]+([[:space:]]*,[[:space:]]*[0-9]+)*$ ]]; then
+              echo "::error::item_numbers must be a comma-separated list of pull request numbers"
+              exit 1
+            fi
+            item_numbers_arg=(--item-numbers "$PROOF_NUDGES_ITEM_NUMBERS")
           fi
           pnpm run proof-nudges -- \
             --target-repo "$TARGET_REPO" \
-            --limit "${{ github.event.inputs.limit || vars.CLAWSWEEPER_PROOF_NUDGES_LIMIT || '10' }}" \
-            --min-age-days "${{ github.event.inputs.min_age_days || vars.CLAWSWEEPER_PROOF_NUDGES_MIN_AGE_DAYS || '5' }}" \
-            --cooldown-days "${{ github.event.inputs.cooldown_days || vars.CLAWSWEEPER_PROOF_NUDGES_COOLDOWN_DAYS || '7' }}" \
+            --limit "$PROOF_NUDGES_LIMIT" \
+            --min-age-days "$PROOF_NUDGES_MIN_AGE_DAYS" \
+            --cooldown-days "$PROOF_NUDGES_COOLDOWN_DAYS" \
             --report-path proof-nudge-report.json \
             "${item_numbers_arg[@]}" \
             "${execute_arg[@]}"

--- a/README.md
+++ b/README.md
@@ -238,6 +238,12 @@ proof, supplied-but-not-sufficient proof, mock-only proof, and proof label
 mismatches. See
 [`docs/pr-proof-triage-dashboard.md`](docs/pr-proof-triage-dashboard.md).
 
+The optional proof-nudge lane can dry-run or post polite reminder comments for
+open PRs that remain blocked on `triage: needs-real-behavior-proof`. It uses
+comment-body cooldown markers, never closes PRs, and keeps scheduled operation
+behind default-off repository variables. See
+[`docs/proof-nudges.md`](docs/proof-nudges.md).
+
 ## How It Works
 
 ClawSweeper is split into four operational lanes:

--- a/docs/proof-nudges.md
+++ b/docs/proof-nudges.md
@@ -1,0 +1,80 @@
+# ClawSweeper Proof Nudges
+
+Read when changing the ClawSweeper lane that reminds pull request authors to add real behavior proof.
+
+## Scope
+
+The proof-nudge lane is read-mostly triage hygiene. It can post a polite reminder comment on open pull requests that are stuck on `triage: needs-real-behavior-proof`, but it does not close pull requests, merge pull requests, change labels, request reviews, or modify review records.
+
+The lane uses the latest ClawSweeper review report plus the live pull request state. It does not scrape the visible review comment for policy.
+
+## Eligibility
+
+A pull request is eligible only when all of these are true:
+
+- The live item is an open pull request.
+- The live pull request still has `triage: needs-real-behavior-proof`.
+- The latest report still says real behavior proof blocks merge.
+- The report head SHA matches the live pull request head SHA.
+- The pull request is past the first-nudge age gate, defaulting to 5 days.
+- The author has not commented recently and the head commit is not recent.
+- There is no same-head proof nudge inside the cooldown window, defaulting to 7 days.
+
+The lane skips maintainer-authored, bot-authored, security-sensitive, and release-style pull requests. It also skips pull requests with `proof: supplied`, `proof: sufficient`, or `proof: override`, because those need review or policy handling rather than another contributor reminder.
+
+## Marker
+
+Cooldown state lives in the reminder comment body:
+
+```html
+<!-- clawsweeper-proof-nudge item="123" sha="abc123" at="2026-05-18T12:00:00.000Z" v="1" -->
+```
+
+The marker records the pull request number, reviewed head SHA, timestamp, and marker version. This avoids label churn and keeps the reminder state tied to the exact head that was nudged.
+
+## Command
+
+Dry-run is the default:
+
+```bash
+pnpm run proof-nudges -- --target-repo openclaw/openclaw
+```
+
+Post comments only with an explicit execute flag:
+
+```bash
+pnpm run proof-nudges -- --target-repo openclaw/openclaw --execute --limit 10
+```
+
+Useful options:
+
+- `--limit`: maximum nudges to plan or post, default `10`.
+- `--processed-limit`: maximum records to inspect in one run.
+- `--min-age-days`: first-nudge age gate, default `5`.
+- `--cooldown-days`: same-head cooldown, default `7`.
+- `--item-numbers`: comma-separated pull request numbers for a targeted dry-run or execute run.
+- `--report-path`: JSON output path, default `proof-nudge-report.json`.
+- `--max-runtime-ms`: optional hard runtime stop.
+
+## Workflow Use
+
+The `ClawSweeper Proof Nudges` workflow exposes this as a manual `workflow_dispatch` lane. It defaults to dry-run. Use `execute=true` only after reviewing a dry-run report.
+
+The workflow also includes a daily scheduled lane at `44 9 * * *`, but it is off by default. This lets maintainers enable scheduled proof nudges later without another code change.
+
+Scheduled operation uses repository variables:
+
+- `CLAWSWEEPER_PROOF_NUDGES_SCHEDULED=1`: enable the scheduled lane. Without this, the daily schedule is skipped.
+- `CLAWSWEEPER_PROOF_NUDGES_EXECUTE=1`: allow the scheduled lane to post comments. Without this, scheduled runs remain dry-run only.
+- `CLAWSWEEPER_PROOF_NUDGES_TARGET_REPO`: optional target repo, default `openclaw/openclaw`.
+- `CLAWSWEEPER_PROOF_NUDGES_LIMIT`: optional scheduled batch size, default `10`.
+- `CLAWSWEEPER_PROOF_NUDGES_MIN_AGE_DAYS`: optional first-nudge age gate, default `5`.
+- `CLAWSWEEPER_PROOF_NUDGES_COOLDOWN_DAYS`: optional same-head cooldown, default `7`.
+
+Suggested rollout:
+
+1. Run the proof-nudge workflow manually with `execute=false`.
+2. Set `CLAWSWEEPER_PROOF_NUDGES_SCHEDULED=1` to collect scheduled dry-run reports.
+3. Set `CLAWSWEEPER_PROOF_NUDGES_EXECUTE=1` only after the scheduled reports look correct.
+
+This first version intentionally has no auto-close behavior. Any escalation after repeated proof nudges needs a separate maintainer policy decision.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "review": "node dist/clawsweeper.js review",
     "apply-artifacts": "node dist/clawsweeper.js apply-artifacts",
     "apply-decisions": "node dist/clawsweeper.js apply-decisions",
+    "proof-nudges": "node dist/clawsweeper.js proof-nudges",
     "audit": "node dist/clawsweeper.js audit",
     "reconcile": "node dist/clawsweeper.js reconcile",
     "status": "node dist/clawsweeper.js status",

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -697,6 +697,88 @@ interface ApplyResult {
   reason: string;
 }
 
+type ProofNudgeAction =
+  | "proof_nudge_posted"
+  | "proof_nudge_planned"
+  | "skipped_not_pull_request"
+  | "skipped_not_open"
+  | "skipped_missing_label"
+  | "skipped_policy_exempt"
+  | "skipped_stale_report_head"
+  | "skipped_recent_author_activity"
+  | "skipped_recent_review"
+  | "skipped_recent_nudge"
+  | "skipped_maintainer_authored"
+  | "skipped_bot_authored"
+  | "skipped_protected_label"
+  | "skipped_locked_conversation"
+  | "skipped_no_live_head"
+  | "skipped_runtime_budget";
+
+interface ProofNudgeResult {
+  repo?: string | undefined;
+  number: number;
+  action: ProofNudgeAction;
+  reason: string;
+  url?: string | undefined;
+  headSha?: string | undefined;
+  reviewedAt?: string | undefined;
+}
+
+interface ProofNudgeComment {
+  author?: string | undefined;
+  body?: string | undefined;
+  createdAt?: string | undefined;
+  updatedAt?: string | undefined;
+}
+
+interface ProofNudgeMarker {
+  item?: number;
+  sha?: string;
+  at?: string;
+  v?: string;
+}
+
+interface ProofNudgeEligibilityOptions {
+  item: Pick<
+    Item,
+    | "kind"
+    | "number"
+    | "title"
+    | "author"
+    | "authorAssociation"
+    | "updatedAt"
+    | "labels"
+    | "locked"
+    | "activeLockReason"
+  >;
+  markdown: string;
+  comments?: readonly ProofNudgeComment[];
+  headSha?: string | undefined;
+  headCommittedAt?: string | undefined;
+  now?: number;
+  minAgeDays?: number;
+  cooldownDays?: number;
+}
+
+interface ProofNudgeEligibility {
+  eligible: boolean;
+  action: Exclude<
+    ProofNudgeAction,
+    "proof_nudge_posted" | "skipped_not_open" | "skipped_runtime_budget"
+  >;
+  reason: string;
+  latestActivityAt?: string | undefined;
+  latestNudgeAt?: string | undefined;
+}
+
+interface ProofNudgePullRequestDetails {
+  headSha?: string | undefined;
+  headRepo?: string | undefined;
+  headCommittedAt?: string | undefined;
+  draft?: boolean;
+}
+
 interface ReconcileResult {
   openItemsSeen: number;
   pagesScanned: number;
@@ -810,6 +892,13 @@ const AUTOMERGE_LABEL = "clawsweeper:automerge";
 const AUTOFIX_LABEL = "clawsweeper:autofix";
 const PROOF_OVERRIDE_LABEL = "proof: override";
 const PROOF_SUFFICIENT_LABEL = "proof: sufficient";
+const PROOF_SUPPLIED_LABEL = "proof: supplied";
+const REAL_BEHAVIOR_PROOF_REQUIRED_LABEL = "triage: needs-real-behavior-proof";
+const PROOF_NUDGE_MARKER_PREFIX = "<!-- clawsweeper-proof-nudge";
+const PROOF_NUDGE_MARKER_VERSION = "1";
+const DEFAULT_PROOF_NUDGE_LIMIT = 10;
+const DEFAULT_PROOF_NUDGE_MIN_AGE_DAYS = 5;
+const DEFAULT_PROOF_NUDGE_COOLDOWN_DAYS = 7;
 const PROOF_SUFFICIENT_LABEL_COLOR = "1A7F37";
 const PROOF_SUFFICIENT_LABEL_DESCRIPTION = "Contributor real behavior proof is sufficient.";
 const FEATURE_SHOWCASE_LABEL = "feature: ✨ showcase";
@@ -8785,6 +8874,356 @@ function realBehaviorProofBlocksMerge(markdown: string): boolean {
   );
 }
 
+function realBehaviorProofNeedsContributorNudge(markdown: string): boolean {
+  if (frontMatterValue(markdown, "review_status") !== "complete") return false;
+  if (!isExternalPullRequestReport(markdown)) return false;
+  if (frontMatterStringArray(markdown, "labels").includes(PROOF_OVERRIDE_LABEL)) return false;
+  if (isDocsOnlyPullRequestReport(markdown)) return false;
+  const proof = reportRealBehaviorProof(markdown);
+  return (
+    proof.needsContributorAction ||
+    proof.status === "missing" ||
+    proof.status === "mock_only" ||
+    proof.status === "insufficient"
+  );
+}
+
+function normalizedLabelSet(labels: readonly string[]): Set<string> {
+  return new Set(labels.map(normalizeLabelName));
+}
+
+function hasNormalizedLabel(labels: readonly string[], label: string): boolean {
+  return normalizedLabelSet(labels).has(normalizeLabelName(label));
+}
+
+function proofNudgeProtectedLabels(labels: readonly string[]): string[] {
+  return labels.map(normalizeLabelName).filter((label, index, normalized) => {
+    if (normalized.indexOf(label) !== index) return false;
+    return (
+      label === "maintainer" ||
+      label === "security" ||
+      label === "beta-blocker" ||
+      label === "release-blocker" ||
+      label === "clawsweeper:needs-security-review" ||
+      label.startsWith("release") ||
+      label.includes("security")
+    );
+  });
+}
+
+function isReleaseTitle(title: string | undefined): boolean {
+  return /^(?:release|chore\(release\)|version bump)(?=\b|:)/i.test(title?.trim() ?? "");
+}
+
+function proofNudgeMarker(options: { number: number; headSha: string; timestamp: string }): string {
+  return `${PROOF_NUDGE_MARKER_PREFIX} item="${options.number}" sha="${options.headSha}" at="${options.timestamp}" v="${PROOF_NUDGE_MARKER_VERSION}" -->`;
+}
+
+function isProofNudgeMarkerWhitespace(char: string | undefined): boolean {
+  return char === " " || char === "\n" || char === "\r" || char === "\t" || char === "\f";
+}
+
+function parseProofNudgeMarkerAttributes(text: string): ProofNudgeMarker {
+  const marker: ProofNudgeMarker = {};
+  const attributes = text.slice(0, 512);
+  let index = 0;
+  while (index < attributes.length) {
+    while (index < attributes.length && isProofNudgeMarkerWhitespace(attributes[index])) index += 1;
+    const keyStart = index;
+    const first = attributes.charCodeAt(index);
+    if (!((first >= 65 && first <= 90) || (first >= 97 && first <= 122))) {
+      index += 1;
+      continue;
+    }
+    index += 1;
+    while (index < attributes.length) {
+      const char = attributes.charCodeAt(index);
+      const isAttributeKeyChar =
+        (char >= 65 && char <= 90) ||
+        (char >= 97 && char <= 122) ||
+        (char >= 48 && char <= 57) ||
+        char === 45 ||
+        char === 95;
+      if (!isAttributeKeyChar) break;
+      index += 1;
+    }
+    const key = attributes.slice(keyStart, index).toLowerCase();
+    while (index < attributes.length && isProofNudgeMarkerWhitespace(attributes[index])) index += 1;
+    if (attributes[index] !== "=") continue;
+    index += 1;
+    while (index < attributes.length && isProofNudgeMarkerWhitespace(attributes[index])) index += 1;
+    let value = "";
+    if (attributes[index] === '"') {
+      index += 1;
+      const valueStart = index;
+      while (index < attributes.length && attributes[index] !== '"') index += 1;
+      value = attributes.slice(valueStart, index);
+      if (attributes[index] === '"') index += 1;
+    } else {
+      const valueStart = index;
+      while (
+        index < attributes.length &&
+        attributes[index] !== ">" &&
+        !isProofNudgeMarkerWhitespace(attributes[index])
+      ) {
+        index += 1;
+      }
+      value = attributes.slice(valueStart, index);
+    }
+    if (key === "item") {
+      const item = Number(value);
+      if (Number.isInteger(item) && item > 0) marker.item = item;
+    } else if (key === "sha") {
+      marker.sha = value;
+    } else if (key === "at") {
+      marker.at = value;
+    } else if (key === "v") {
+      marker.v = value;
+    }
+  }
+  return marker;
+}
+
+function proofNudgeMarkersFromCommentBody(body: string | undefined): ProofNudgeMarker[] {
+  if (!body?.includes(PROOF_NUDGE_MARKER_PREFIX)) return [];
+  const markers: ProofNudgeMarker[] = [];
+  let index = 0;
+  while (index < body.length && markers.length < 20) {
+    const markerStart = body.indexOf(PROOF_NUDGE_MARKER_PREFIX, index);
+    if (markerStart < 0) break;
+    const attributesStart = markerStart + PROOF_NUDGE_MARKER_PREFIX.length;
+    const markerEnd = body.indexOf("-->", attributesStart);
+    if (markerEnd < 0) break;
+    markers.push(parseProofNudgeMarkerAttributes(body.slice(attributesStart, markerEnd)));
+    index = markerEnd + 3;
+  }
+  return markers;
+}
+
+function isProofNudgeMarkerCommentAuthor(author: string | undefined): boolean {
+  const login = author?.trim();
+  return Boolean(login && PATCHABLE_REVIEW_COMMENT_AUTHORS.has(login));
+}
+
+function proofNudgeMarkersFromComments(comments: readonly ProofNudgeComment[]): ProofNudgeMarker[] {
+  return comments
+    .filter((comment) => isProofNudgeMarkerCommentAuthor(comment.author))
+    .flatMap((comment) => proofNudgeMarkersFromCommentBody(comment.body));
+}
+
+function latestIsoTimestamp(values: readonly (string | undefined)[]): string | undefined {
+  let latest: string | undefined;
+  for (const value of values) latest = latestTimestamp(latest, value);
+  return latest;
+}
+
+function latestAuthorCommentAt(
+  comments: readonly ProofNudgeComment[],
+  author: string | undefined,
+): string | undefined {
+  const normalizedAuthor = author?.trim().toLowerCase();
+  if (!normalizedAuthor) return undefined;
+  return latestIsoTimestamp(
+    comments
+      .filter((comment) => comment.author?.toLowerCase() === normalizedAuthor)
+      .map((comment) => comment.updatedAt ?? comment.createdAt),
+  );
+}
+
+function latestProofNudgeAt(
+  comments: readonly ProofNudgeComment[],
+  options: { number: number; headSha: string },
+): string | undefined {
+  return latestIsoTimestamp(
+    proofNudgeMarkersFromComments(comments)
+      .filter(
+        (marker) =>
+          marker.item === options.number &&
+          marker.sha === options.headSha &&
+          timestampMs(marker.at) !== null,
+      )
+      .map((marker) => marker.at),
+  );
+}
+
+function staleProofNudgeReportHead(markdown: string, headSha: string | undefined): boolean {
+  if (!headSha) return false;
+  const reportHeadSha = frontMatterValue(markdown, "pull_head_sha");
+  const normalizedReportHeadSha = reportHeadSha?.trim() ?? "";
+  if (!normalizedReportHeadSha || normalizedReportHeadSha.toLowerCase() === "unknown") return true;
+  return normalizedReportHeadSha !== headSha.trim();
+}
+
+function proofNudgeEligibility(options: ProofNudgeEligibilityOptions): ProofNudgeEligibility {
+  const now = options.now ?? Date.now();
+  const minAgeMs = Math.max(0, options.minAgeDays ?? DEFAULT_PROOF_NUDGE_MIN_AGE_DAYS) * DAY_MS;
+  const cooldownMs =
+    Math.max(0, options.cooldownDays ?? DEFAULT_PROOF_NUDGE_COOLDOWN_DAYS) * DAY_MS;
+  const comments = options.comments ?? [];
+  if (options.item.kind !== "pull_request") {
+    return {
+      eligible: false,
+      action: "skipped_not_pull_request",
+      reason: `type is ${options.item.kind}`,
+    };
+  }
+  if (!hasNormalizedLabel(options.item.labels, REAL_BEHAVIOR_PROOF_REQUIRED_LABEL)) {
+    return {
+      eligible: false,
+      action: "skipped_missing_label",
+      reason: `${REAL_BEHAVIOR_PROOF_REQUIRED_LABEL} is not present`,
+    };
+  }
+  const lockedReason = lockedConversationApplyReason(options.item);
+  if (lockedReason) {
+    return {
+      eligible: false,
+      action: "skipped_locked_conversation",
+      reason: lockedReason,
+    };
+  }
+  if (
+    hasNormalizedLabel(options.item.labels, PROOF_OVERRIDE_LABEL) ||
+    hasNormalizedLabel(options.item.labels, PROOF_SUFFICIENT_LABEL) ||
+    hasNormalizedLabel(options.item.labels, PROOF_SUPPLIED_LABEL)
+  ) {
+    return {
+      eligible: false,
+      action: "skipped_policy_exempt",
+      reason: "proof is already supplied, sufficient, or overridden",
+    };
+  }
+  if (isMaintainerAuthored(options.item)) {
+    return {
+      eligible: false,
+      action: "skipped_maintainer_authored",
+      reason: `author association is ${normalizeAuthorAssociation(options.item.authorAssociation)}`,
+    };
+  }
+  if (isAutomationReportAuthor(options.item.author)) {
+    return {
+      eligible: false,
+      action: "skipped_bot_authored",
+      reason: `author is ${options.item.author}`,
+    };
+  }
+  const protectedLabelsForNudge = proofNudgeProtectedLabels(options.item.labels);
+  if (protectedLabelsForNudge.length > 0 || isReleaseTitle(options.item.title)) {
+    const reason = protectedLabelsForNudge.length
+      ? `protected label: ${protectedLabelsForNudge.join(", ")}`
+      : "release-style PR title";
+    return { eligible: false, action: "skipped_protected_label", reason };
+  }
+  if (!realBehaviorProofNeedsContributorNudge(options.markdown)) {
+    return {
+      eligible: false,
+      action: "skipped_policy_exempt",
+      reason: "latest ClawSweeper proof policy does not require contributor action",
+    };
+  }
+  if (!options.headSha) {
+    return {
+      eligible: false,
+      action: "skipped_no_live_head",
+      reason: "live PR head SHA could not be inspected",
+    };
+  }
+  if (staleProofNudgeReportHead(options.markdown, options.headSha)) {
+    return {
+      eligible: false,
+      action: "skipped_stale_report_head",
+      reason: "live PR head SHA differs from the reviewed report",
+    };
+  }
+  const reviewedAt = frontMatterValue(options.markdown, "reviewed_at");
+  if (reviewedAt && !isOlderThanMs(reviewedAt, minAgeMs, now)) {
+    return {
+      eligible: false,
+      action: "skipped_recent_review",
+      reason: `latest ClawSweeper review is newer than ${options.minAgeDays ?? DEFAULT_PROOF_NUDGE_MIN_AGE_DAYS} day(s)`,
+      latestActivityAt: reviewedAt,
+    };
+  }
+  const latestActivityAt = latestIsoTimestamp([
+    latestAuthorCommentAt(comments, options.item.author),
+    options.item.updatedAt,
+    options.headCommittedAt,
+  ]);
+  if (latestActivityAt && !isOlderThanMs(latestActivityAt, minAgeMs, now)) {
+    return {
+      eligible: false,
+      action: "skipped_recent_author_activity",
+      reason: `author comment, PR update, or head commit is newer than ${options.minAgeDays ?? DEFAULT_PROOF_NUDGE_MIN_AGE_DAYS} day(s)`,
+      latestActivityAt,
+    };
+  }
+  const latestNudgeAt = latestProofNudgeAt(comments, {
+    number: options.item.number,
+    headSha: options.headSha,
+  });
+  if (latestNudgeAt && !isOlderThanMs(latestNudgeAt, cooldownMs, now)) {
+    return {
+      eligible: false,
+      action: "skipped_recent_nudge",
+      reason: `same-head nudge is inside the ${options.cooldownDays ?? DEFAULT_PROOF_NUDGE_COOLDOWN_DAYS} day cooldown`,
+      latestNudgeAt,
+    };
+  }
+  return {
+    eligible: true,
+    action: "proof_nudge_planned",
+    reason: "needs real behavior proof and is past the nudge age/cooldown gates",
+    latestActivityAt,
+    latestNudgeAt,
+  };
+}
+
+export function proofNudgeEligibilityForTest(
+  options: ProofNudgeEligibilityOptions,
+): ProofNudgeEligibility {
+  return proofNudgeEligibility(options);
+}
+
+function renderProofNudgeComment(options: {
+  item: Pick<Item, "number" | "author">;
+  headSha: string;
+  timestamp: string;
+}): string {
+  const mention =
+    options.item.author && !isAutomationReportAuthor(options.item.author)
+      ? `@${options.item.author} `
+      : "";
+  return [
+    `${mention}thanks for the PR. ClawSweeper is still waiting on real behavior proof before this can move forward.`,
+    "",
+    "Useful proof can be a screenshot, short video, terminal output, copied live output, linked artifact, or redacted logs that show the changed behavior after the fix. Please redact private tokens, phone numbers, private endpoints, customer data, and anything else sensitive.",
+    "",
+    "Once proof is added to the PR body or a comment, ClawSweeper or a maintainer can re-check it.",
+    "",
+    proofNudgeMarker({
+      number: options.item.number,
+      headSha: options.headSha,
+      timestamp: options.timestamp,
+    }),
+  ].join("\n");
+}
+
+export function renderProofNudgeCommentForTest(options: {
+  number: number;
+  author?: string;
+  headSha?: string;
+  timestamp?: string;
+}): string {
+  return renderProofNudgeComment({
+    item: {
+      number: options.number,
+      author: options.author ?? "contributor",
+    },
+    headSha: options.headSha ?? "abc123def456",
+    timestamp: options.timestamp ?? "2026-01-10T00:00:00.000Z",
+  });
+}
+
 function parseBoldListHeading(line: string): { label: string; detail: string } | null {
   const prefix = "- **";
   if (!line.startsWith(prefix)) return null;
@@ -12847,6 +13286,251 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
   console.log(JSON.stringify(results, null, 2));
 }
 
+function proofNudgeComments(number: number): ProofNudgeComment[] {
+  return ghPaged<unknown>(`repos/${targetRepo()}/issues/${number}/comments`).map((comment) => {
+    const record = asRecord(comment);
+    return {
+      author: login(record.user),
+      body: stringOrUndefined(record.body),
+      createdAt: stringOrUndefined(record.created_at),
+      updatedAt: stringOrUndefined(record.updated_at),
+    };
+  });
+}
+
+function fetchPullRequestProofNudgeDetails(number: number): ProofNudgePullRequestDetails {
+  const pull = ghJson<Record<string, unknown>>([
+    "api",
+    `repos/${targetRepo()}/pulls/${number}`,
+    "--jq",
+    "{draft,head:{sha:.head.sha,repo:{full_name:(.head.repo.full_name // null)}}}",
+  ]);
+  const head = asRecord(pull.head);
+  const headRepo = stringOrUndefined(asRecord(head.repo).full_name);
+  const headSha = stringOrUndefined(head.sha);
+  const details: ProofNudgePullRequestDetails = {
+    headSha,
+    headRepo,
+    draft: pull.draft === true,
+  };
+  if (!headRepo || !headSha) return details;
+  try {
+    const commit = ghJson<Record<string, unknown>>([
+      "api",
+      `repos/${headRepo}/commits/${headSha}`,
+      "--jq",
+      "{authorDate:.commit.author.date,committerDate:.commit.committer.date}",
+    ]);
+    details.headCommittedAt = latestIsoTimestamp([
+      stringOrUndefined(commit.authorDate),
+      stringOrUndefined(commit.committerDate),
+    ]);
+  } catch (error) {
+    console.warn(
+      `Skipping head commit date for #${number}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  return details;
+}
+
+function postProofNudgeComment(number: number, body: string): Record<string, unknown> {
+  const payload = writeCommentPayload(number, body);
+  return ghJson<Record<string, unknown>>([
+    "api",
+    `repos/${targetRepo()}/issues/${number}/comments`,
+    "--method",
+    "POST",
+    "--input",
+    payload,
+    "--jq",
+    "{id,html_url}",
+  ]);
+}
+
+function proofNudgeCandidateRecords(
+  itemsDir: string,
+  requestedItemNumbers: readonly number[],
+): {
+  file: string;
+  markdown: string;
+  number: number;
+  likelyProofNudge: boolean;
+  reviewedAt?: string | undefined;
+  sortAt: number;
+}[] {
+  const requested = new Set(requestedItemNumbers);
+  return markdownFiles(itemsDir)
+    .map((file) => {
+      const path = join(itemsDir, file);
+      const markdown = readFileSync(path, "utf8");
+      const number = numberForMarkdownFile(file);
+      const reviewedAt = frontMatterValue(markdown, "reviewed_at");
+      const sortAt =
+        timestampMs(reviewedAt) ??
+        timestampMs(frontMatterValue(markdown, "item_updated_at")) ??
+        Number.NEGATIVE_INFINITY;
+      const likelyProofNudge = realBehaviorProofNeedsContributorNudge(markdown);
+      return { file, markdown, number, likelyProofNudge, reviewedAt, sortAt };
+    })
+    .filter(({ file, markdown, number }) => {
+      if (requested.size > 0 && !requested.has(number)) return false;
+      if (!isMarkdownForActiveRepo(markdown, join(itemsDir, file))) return false;
+      if (frontMatterValue(markdown, "type") !== "pull_request") return false;
+      return true;
+    })
+    .sort(
+      (left, right) =>
+        Number(right.likelyProofNudge) - Number(left.likelyProofNudge) ||
+        left.sortAt - right.sortAt ||
+        left.number - right.number,
+    );
+}
+
+export function proofNudgeCandidateRecordsForTest(
+  itemsDir: string,
+  requestedItemNumbers: readonly number[] = [],
+): ReturnType<typeof proofNudgeCandidateRecords> {
+  return proofNudgeCandidateRecords(itemsDir, requestedItemNumbers);
+}
+
+function proofNudgesCommand(args: Args): void {
+  repoFromArgs(args);
+  const itemsDir = resolve(stringArg(args.items_dir, defaultItemsDir()));
+  const limit = Math.max(0, numberArg(args.limit, DEFAULT_PROOF_NUDGE_LIMIT));
+  const processedLimit = Math.max(1, numberArg(args.processed_limit, Math.max(limit * 20, 50)));
+  const minAgeDays = Math.max(0, numberArg(args.min_age_days, DEFAULT_PROOF_NUDGE_MIN_AGE_DAYS));
+  const cooldownDays = Math.max(
+    0,
+    numberArg(args.cooldown_days, DEFAULT_PROOF_NUDGE_COOLDOWN_DAYS),
+  );
+  const execute = boolArg(args.execute);
+  const dryRun = !execute;
+  const maxRuntimeMs = numberArg(args.max_runtime_ms, 0);
+  const reportPath = resolve(stringArg(args.report_path, join(ROOT, "proof-nudge-report.json")));
+  const requestedItemNumbers = itemNumbersArg(args.item_numbers, args.item_number);
+  const startedAtMs = Date.now();
+  const results: ProofNudgeResult[] = [];
+  let processedCount = 0;
+  let nudgeCount = 0;
+
+  if (!existsSync(itemsDir)) {
+    ensureDir(dirname(reportPath));
+    writeFileSync(reportPath, JSON.stringify(results, null, 2), "utf8");
+    console.log(JSON.stringify(results, null, 2));
+    return;
+  }
+
+  const candidates = proofNudgeCandidateRecords(itemsDir, requestedItemNumbers);
+  const logProgress = (message: string): void => {
+    const counts = results.reduce<Record<string, number>>((accumulator, result) => {
+      accumulator[result.action] = (accumulator[result.action] ?? 0) + 1;
+      return accumulator;
+    }, {});
+    console.error(
+      [
+        `[proof-nudges] ${new Date().toISOString()} ${message}`,
+        `nudges=${nudgeCount}/${limit}`,
+        `processed=${processedCount}/${processedLimit}`,
+        `dry_run=${dryRun}`,
+        `counts=${JSON.stringify(counts)}`,
+      ].join(" "),
+    );
+  };
+
+  logProgress(
+    `starting proof nudges: candidates=${candidates.length} min_age_days=${minAgeDays} cooldown_days=${cooldownDays} item_numbers=${requestedItemNumbers.join(",") || "all"}`,
+  );
+  for (const candidate of candidates) {
+    if (nudgeCount >= limit) break;
+    if (processedCount >= processedLimit) break;
+    if (runtimeBudgetExceeded(startedAtMs, maxRuntimeMs, Date.now())) {
+      results.push({
+        repo: targetRepo(),
+        number: 0,
+        action: "skipped_runtime_budget",
+        reason: `max runtime ${maxRuntimeMs}ms reached`,
+      });
+      logProgress(`stopping proof nudges: max runtime ${maxRuntimeMs}ms reached`);
+      break;
+    }
+
+    const resultBase = {
+      repo: markdownRepository(candidate.markdown, join(itemsDir, candidate.file)),
+      number: candidate.number,
+      reviewedAt: candidate.reviewedAt,
+    };
+    const { item, state } = fetchItem(candidate.number);
+    if (state !== "open") {
+      results.push({
+        ...resultBase,
+        action: "skipped_not_open",
+        reason: `state is ${state}`,
+      });
+      processedCount += 1;
+      continue;
+    }
+    const pullDetails =
+      item.kind === "pull_request" ? fetchPullRequestProofNudgeDetails(candidate.number) : {};
+    const comments = item.kind === "pull_request" ? proofNudgeComments(candidate.number) : [];
+    const eligibility = proofNudgeEligibility({
+      item,
+      markdown: candidate.markdown,
+      comments,
+      headSha: pullDetails.headSha,
+      headCommittedAt: pullDetails.headCommittedAt,
+      minAgeDays,
+      cooldownDays,
+    });
+    if (!eligibility.eligible) {
+      results.push({
+        ...resultBase,
+        action: eligibility.action,
+        reason: eligibility.reason,
+        headSha: pullDetails.headSha,
+      });
+      processedCount += 1;
+      continue;
+    }
+
+    const timestamp = new Date().toISOString();
+    const headSha = pullDetails.headSha;
+    if (!headSha) {
+      results.push({
+        ...resultBase,
+        action: "skipped_no_live_head",
+        reason: "live PR head SHA could not be inspected",
+      });
+      processedCount += 1;
+      continue;
+    }
+    const body = renderProofNudgeComment({ item, headSha, timestamp });
+    if (dryRun) {
+      results.push({
+        ...resultBase,
+        action: "proof_nudge_planned",
+        reason: eligibility.reason,
+        headSha,
+      });
+    } else {
+      const comment = postProofNudgeComment(candidate.number, body);
+      results.push({
+        ...resultBase,
+        action: "proof_nudge_posted",
+        reason: eligibility.reason,
+        url: commentUrl(comment) ?? undefined,
+        headSha,
+      });
+    }
+    processedCount += 1;
+    nudgeCount += 1;
+    logProgress(`${dryRun ? "planned" : "posted"} proof nudge #${candidate.number}`);
+  }
+  ensureDir(dirname(reportPath));
+  writeFileSync(reportPath, JSON.stringify(results, null, 2), "utf8");
+  logProgress("finished proof nudges");
+  console.log(JSON.stringify(results, null, 2));
+}
+
 function applyArtifactsCommand(args: Args): void {
   repoFromArgs(args);
   const artifactDir = resolve(stringArg(args.artifact_dir, "artifacts"));
@@ -14203,6 +14887,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
   else if (command === "review") reviewCommand(args);
   else if (command === "apply-artifacts") applyArtifactsCommand(args);
   else if (command === "apply-decisions") await applyDecisionsCommand(args);
+  else if (command === "proof-nudges") proofNudgesCommand(args);
   else if (command === "audit") auditCommand(args);
   else if (command === "reconcile") reconcileCommand(args);
   else if (command === "dashboard") {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -756,6 +756,7 @@ interface ProofNudgeEligibilityOptions {
   comments?: readonly ProofNudgeComment[];
   headSha?: string | undefined;
   headCommittedAt?: string | undefined;
+  authorEditedAt?: string | undefined;
   now?: number;
   minAgeDays?: number;
   cooldownDays?: number;
@@ -9040,6 +9041,22 @@ function latestAuthorCommentAt(
   );
 }
 
+function latestAuthorPullRequestEditAt(
+  number: number,
+  author: string | undefined,
+): string | undefined {
+  const normalizedAuthor = author?.trim().toLowerCase();
+  if (!normalizedAuthor) return undefined;
+  return latestIsoTimestamp(
+    ghPaged<unknown>(`repos/${targetRepo()}/issues/${number}/timeline`)
+      .filter((event) => {
+        const record = asRecord(event);
+        return record.event === "edited" && login(record.actor)?.toLowerCase() === normalizedAuthor;
+      })
+      .map((event) => stringOrUndefined(asRecord(event).created_at)),
+  );
+}
+
 function latestProofNudgeAt(
   comments: readonly ProofNudgeComment[],
   options: { number: number; headSha: string },
@@ -9160,13 +9177,14 @@ function proofNudgeEligibility(options: ProofNudgeEligibilityOptions): ProofNudg
   }
   const latestActivityAt = latestIsoTimestamp([
     latestAuthorCommentAt(comments, options.item.author),
+    options.authorEditedAt,
     options.headCommittedAt,
   ]);
   if (latestActivityAt && !isOlderThanMs(latestActivityAt, minAgeMs, now)) {
     return {
       eligible: false,
       action: "skipped_recent_author_activity",
-      reason: `author comment or head commit is newer than ${options.minAgeDays ?? DEFAULT_PROOF_NUDGE_MIN_AGE_DAYS} day(s)`,
+      reason: `author comment, PR body edit, or head commit is newer than ${options.minAgeDays ?? DEFAULT_PROOF_NUDGE_MIN_AGE_DAYS} day(s)`,
       latestActivityAt,
     };
   }
@@ -13485,12 +13503,17 @@ function proofNudgesCommand(args: Args): void {
     const pullDetails =
       item.kind === "pull_request" ? fetchPullRequestProofNudgeDetails(candidate.number) : {};
     const comments = item.kind === "pull_request" ? proofNudgeComments(candidate.number) : [];
+    const authorEditedAt =
+      item.kind === "pull_request"
+        ? latestAuthorPullRequestEditAt(candidate.number, item.author)
+        : undefined;
     const eligibility = proofNudgeEligibility({
       item,
       markdown: candidate.markdown,
       comments,
       headSha: pullDetails.headSha,
       headCommittedAt: pullDetails.headCommittedAt,
+      authorEditedAt,
       minAgeDays,
       cooldownDays,
     });

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -757,6 +757,7 @@ interface ProofNudgeEligibilityOptions {
   headSha?: string | undefined;
   headCommittedAt?: string | undefined;
   authorEditedAt?: string | undefined;
+  authorReviewActivityAt?: string | undefined;
   now?: number;
   minAgeDays?: number;
   cooldownDays?: number;
@@ -9057,6 +9058,27 @@ function latestAuthorPullRequestEditAt(
   );
 }
 
+function latestAuthorPullRequestReviewActivityAt(
+  number: number,
+  author: string | undefined,
+): string | undefined {
+  const normalizedAuthor = author?.trim().toLowerCase();
+  if (!normalizedAuthor) return undefined;
+  const reviewCommentActivity = ghPaged<unknown>(`repos/${targetRepo()}/pulls/${number}/comments`)
+    .filter((comment) => login(asRecord(comment).user)?.toLowerCase() === normalizedAuthor)
+    .map((comment) => {
+      const record = asRecord(comment);
+      return stringOrUndefined(record.updated_at) ?? stringOrUndefined(record.created_at);
+    });
+  const submittedReviewActivity = ghPaged<unknown>(`repos/${targetRepo()}/pulls/${number}/reviews`)
+    .filter((review) => login(asRecord(review).user)?.toLowerCase() === normalizedAuthor)
+    .map((review) => {
+      const record = asRecord(review);
+      return stringOrUndefined(record.submitted_at) ?? stringOrUndefined(record.submittedAt);
+    });
+  return latestIsoTimestamp([...reviewCommentActivity, ...submittedReviewActivity]);
+}
+
 function latestProofNudgeAt(
   comments: readonly ProofNudgeComment[],
   options: { number: number; headSha: string },
@@ -9178,13 +9200,14 @@ function proofNudgeEligibility(options: ProofNudgeEligibilityOptions): ProofNudg
   const latestActivityAt = latestIsoTimestamp([
     latestAuthorCommentAt(comments, options.item.author),
     options.authorEditedAt,
+    options.authorReviewActivityAt,
     options.headCommittedAt,
   ]);
   if (latestActivityAt && !isOlderThanMs(latestActivityAt, minAgeMs, now)) {
     return {
       eligible: false,
       action: "skipped_recent_author_activity",
-      reason: `author comment, PR body edit, or head commit is newer than ${options.minAgeDays ?? DEFAULT_PROOF_NUDGE_MIN_AGE_DAYS} day(s)`,
+      reason: `author comment, PR review activity, PR body edit, or head commit is newer than ${options.minAgeDays ?? DEFAULT_PROOF_NUDGE_MIN_AGE_DAYS} day(s)`,
       latestActivityAt,
     };
   }
@@ -13507,6 +13530,10 @@ function proofNudgesCommand(args: Args): void {
       item.kind === "pull_request"
         ? latestAuthorPullRequestEditAt(candidate.number, item.author)
         : undefined;
+    const authorReviewActivityAt =
+      item.kind === "pull_request"
+        ? latestAuthorPullRequestReviewActivityAt(candidate.number, item.author)
+        : undefined;
     const eligibility = proofNudgeEligibility({
       item,
       markdown: candidate.markdown,
@@ -13514,6 +13541,7 @@ function proofNudgesCommand(args: Args): void {
       headSha: pullDetails.headSha,
       headCommittedAt: pullDetails.headCommittedAt,
       authorEditedAt,
+      authorReviewActivityAt,
       minAgeDays,
       cooldownDays,
     });

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -8915,6 +8915,16 @@ function isReleaseTitle(title: string | undefined): boolean {
   return /^(?:release|chore\(release\)|version bump)(?=\b|:)/i.test(title?.trim() ?? "");
 }
 
+function proofNudgeReportProtectedReason(markdown: string): string | undefined {
+  if (frontMatterValue(markdown, "item_category") === "security") {
+    return "latest report item category is security";
+  }
+  if (reportSecurityReview(markdown).status === "needs_attention") {
+    return "latest report security review needs attention";
+  }
+  return undefined;
+}
+
 function proofNudgeMarker(options: { number: number; headSha: string; timestamp: string }): string {
   return `${PROOF_NUDGE_MARKER_PREFIX} item="${options.number}" sha="${options.headSha}" at="${options.timestamp}" v="${PROOF_NUDGE_MARKER_VERSION}" -->`;
 }
@@ -9113,6 +9123,10 @@ function proofNudgeEligibility(options: ProofNudgeEligibilityOptions): ProofNudg
       ? `protected label: ${protectedLabelsForNudge.join(", ")}`
       : "release-style PR title";
     return { eligible: false, action: "skipped_protected_label", reason };
+  }
+  const reportProtectedReason = proofNudgeReportProtectedReason(options.markdown);
+  if (reportProtectedReason) {
+    return { eligible: false, action: "skipped_protected_label", reason: reportProtectedReason };
   }
   if (!realBehaviorProofNeedsContributorNudge(options.markdown)) {
     return {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -9160,14 +9160,13 @@ function proofNudgeEligibility(options: ProofNudgeEligibilityOptions): ProofNudg
   }
   const latestActivityAt = latestIsoTimestamp([
     latestAuthorCommentAt(comments, options.item.author),
-    options.item.updatedAt,
     options.headCommittedAt,
   ]);
   if (latestActivityAt && !isOlderThanMs(latestActivityAt, minAgeMs, now)) {
     return {
       eligible: false,
       action: "skipped_recent_author_activity",
-      reason: `author comment, PR update, or head commit is newer than ${options.minAgeDays ?? DEFAULT_PROOF_NUDGE_MIN_AGE_DAYS} day(s)`,
+      reason: `author comment or head commit is newer than ${options.minAgeDays ?? DEFAULT_PROOF_NUDGE_MIN_AGE_DAYS} day(s)`,
       latestActivityAt,
     };
   }

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -69,10 +69,13 @@ import {
   prStatusLabelSchemeForTest,
   priorityLabelsForTest,
   priorityLabelSchemeForTest,
+  proofNudgeCandidateRecordsForTest,
+  proofNudgeEligibilityForTest,
   protectedLabels,
   realBehaviorProofMediaLabelsForTest,
   realBehaviorProofSufficientLabelsForTest,
   relatedTitleSearchTerms,
+  renderProofNudgeCommentForTest,
   renderReviewStartStatusComment,
   reviewArtifactDestination,
   reviewAutomationMarkersFromReport,
@@ -10232,6 +10235,333 @@ test("ClawSweeper proof label sync recognizes missing optional labels", () => {
   );
 });
 
+function proofNudgeReport(overrides = {}) {
+  const values = {
+    labels: JSON.stringify(["triage: needs-real-behavior-proof"]),
+    authorAssociation: "CONTRIBUTOR",
+    author: "contributor",
+    reviewStatus: "complete",
+    headSha: "abc123def456",
+    reviewedAt: "2026-01-01T00:00:00Z",
+    pullFiles: JSON.stringify(["src/app.ts"]),
+    proofStatus: "missing",
+    evidenceKind: "none",
+    needsContributorAction: "true",
+    proofSummary: "The PR needs after-fix proof from a real setup.",
+    ...overrides,
+  };
+  return `---
+repository: openclaw/openclaw
+number: 42
+type: pull_request
+title: Proof nudge sample
+author: ${values.author}
+author_association: ${values.authorAssociation}
+labels: ${values.labels}
+review_status: ${values.reviewStatus}
+pull_files: ${values.pullFiles}
+pull_files_truncated: false
+pull_head_sha: ${values.headSha}
+reviewed_at: ${values.reviewedAt}
+---
+
+## Real Behavior Proof
+
+Status: ${values.proofStatus}
+
+Evidence kind: ${values.evidenceKind}
+
+Needs contributor action: ${values.needsContributorAction}
+
+Summary: ${values.proofSummary}
+`;
+}
+
+function proofNudgeItem(overrides = {}) {
+  return item({
+    kind: "pull_request",
+    number: 42,
+    title: "Proof nudge sample",
+    author: "contributor",
+    authorAssociation: "CONTRIBUTOR",
+    labels: ["triage: needs-real-behavior-proof"],
+    locked: false,
+    activeLockReason: null,
+    ...overrides,
+  });
+}
+
+test("proof nudge candidate scan defers proof-label checks to live PR state", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    writeFileSync(join(root, "41.md"), proofNudgeReport({ reviewedAt: "2026-01-05T00:00:00Z" }));
+    writeFileSync(
+      join(root, "42.md"),
+      `---
+repository: openclaw/openclaw
+number: 42
+type: pull_request
+labels: []
+review_status: complete
+reviewed_at: 2026-01-01T00:00:00Z
+---
+
+## Summary
+
+Stored report label snapshots can be older than the live PR labels.
+`,
+    );
+
+    const requestedCandidates = proofNudgeCandidateRecordsForTest(root, [42]);
+    const allCandidates = proofNudgeCandidateRecordsForTest(root);
+
+    assert.deepEqual(
+      requestedCandidates.map((candidate) => candidate.number),
+      [42],
+    );
+    assert.deepEqual(
+      allCandidates.map((candidate) => candidate.number),
+      [41, 42],
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("proof nudges become eligible only after proof policy and age gates pass", () => {
+  const result = proofNudgeEligibilityForTest({
+    item: proofNudgeItem(),
+    markdown: proofNudgeReport(),
+    headSha: "abc123def456",
+    headCommittedAt: "2026-01-01T00:00:00Z",
+    now: Date.parse("2026-01-10T00:00:00Z"),
+    minAgeDays: 5,
+    cooldownDays: 7,
+  });
+
+  assert.equal(result.eligible, true);
+  assert.equal(result.action, "proof_nudge_planned");
+});
+
+test("proof nudges skip recent reviews and recent author activity", () => {
+  assert.equal(
+    proofNudgeEligibilityForTest({
+      item: proofNudgeItem(),
+      markdown: proofNudgeReport({ reviewedAt: "2026-01-08T00:00:00Z" }),
+      headSha: "abc123def456",
+      headCommittedAt: "2026-01-01T00:00:00Z",
+      now: Date.parse("2026-01-10T00:00:00Z"),
+      minAgeDays: 5,
+      cooldownDays: 7,
+    }).action,
+    "skipped_recent_review",
+  );
+  assert.equal(
+    proofNudgeEligibilityForTest({
+      item: proofNudgeItem(),
+      markdown: proofNudgeReport(),
+      comments: [
+        {
+          author: "contributor",
+          body: "I'll add proof later.",
+          updatedAt: "2026-01-09T00:00:00Z",
+        },
+      ],
+      headSha: "abc123def456",
+      headCommittedAt: "2026-01-01T00:00:00Z",
+      now: Date.parse("2026-01-10T00:00:00Z"),
+      minAgeDays: 5,
+      cooldownDays: 7,
+    }).action,
+    "skipped_recent_author_activity",
+  );
+  assert.equal(
+    proofNudgeEligibilityForTest({
+      item: proofNudgeItem({ updatedAt: "2026-01-09T00:00:00Z" }),
+      markdown: proofNudgeReport(),
+      headSha: "abc123def456",
+      headCommittedAt: "2026-01-01T00:00:00Z",
+      now: Date.parse("2026-01-10T00:00:00Z"),
+      minAgeDays: 5,
+      cooldownDays: 7,
+    }).action,
+    "skipped_recent_author_activity",
+  );
+});
+
+test("proof nudges use same-head cooldown markers instead of label churn", () => {
+  const comment = renderProofNudgeCommentForTest({
+    number: 42,
+    author: "contributor",
+    headSha: "abc123def456",
+    timestamp: "2026-01-08T00:00:00.000Z",
+  });
+  const result = proofNudgeEligibilityForTest({
+    item: proofNudgeItem(),
+    markdown: proofNudgeReport(),
+    comments: [{ author: "clawsweeper[bot]", body: comment, updatedAt: "2026-01-08T00:00:00Z" }],
+    headSha: "abc123def456",
+    headCommittedAt: "2026-01-01T00:00:00Z",
+    now: Date.parse("2026-01-10T00:00:00Z"),
+    minAgeDays: 5,
+    cooldownDays: 7,
+  });
+
+  assert.equal(result.eligible, false);
+  assert.equal(result.action, "skipped_recent_nudge");
+  assert.match(comment, /<!-- clawsweeper-proof-nudge item="42" sha="abc123def456"/);
+
+  const spoofedMarker = proofNudgeEligibilityForTest({
+    item: proofNudgeItem(),
+    markdown: proofNudgeReport(),
+    comments: [{ author: "someoneelse", body: comment, updatedAt: "2026-01-08T00:00:00Z" }],
+    headSha: "abc123def456",
+    headCommittedAt: "2026-01-01T00:00:00Z",
+    now: Date.parse("2026-01-10T00:00:00Z"),
+    minAgeDays: 5,
+    cooldownDays: 7,
+  });
+
+  assert.equal(spoofedMarker.eligible, true);
+  assert.equal(spoofedMarker.action, "proof_nudge_planned");
+
+  const malformedMarker = proofNudgeEligibilityForTest({
+    item: proofNudgeItem(),
+    markdown: proofNudgeReport(),
+    comments: [
+      {
+        author: "clawsweeper[bot]",
+        body: `<!-- clawsweeper-proof-nudge ${"a".repeat(5000)} -->`,
+        updatedAt: "2026-01-08T00:00:00Z",
+      },
+    ],
+    headSha: "abc123def456",
+    headCommittedAt: "2026-01-01T00:00:00Z",
+    now: Date.parse("2026-01-10T00:00:00Z"),
+    minAgeDays: 5,
+    cooldownDays: 7,
+  });
+
+  assert.equal(malformedMarker.eligible, true);
+  assert.equal(malformedMarker.action, "proof_nudge_planned");
+});
+
+test("proof nudges skip stale report heads and proof-policy exemptions", () => {
+  assert.equal(
+    proofNudgeEligibilityForTest({
+      item: proofNudgeItem(),
+      markdown: proofNudgeReport({ headSha: "oldhead" }),
+      headSha: "newhead",
+      headCommittedAt: "2026-01-01T00:00:00Z",
+      now: Date.parse("2026-01-10T00:00:00Z"),
+    }).action,
+    "skipped_stale_report_head",
+  );
+  assert.equal(
+    proofNudgeEligibilityForTest({
+      item: proofNudgeItem(),
+      markdown: proofNudgeReport({ headSha: "unknown" }),
+      headSha: "abc123def456",
+      headCommittedAt: "2026-01-01T00:00:00Z",
+      now: Date.parse("2026-01-10T00:00:00Z"),
+    }).action,
+    "skipped_stale_report_head",
+  );
+  assert.equal(
+    proofNudgeEligibilityForTest({
+      item: proofNudgeItem({ labels: ["triage: needs-real-behavior-proof", "proof: override"] }),
+      markdown: proofNudgeReport({
+        labels: JSON.stringify(["triage: needs-real-behavior-proof", "proof: override"]),
+      }),
+      headSha: "abc123def456",
+      headCommittedAt: "2026-01-01T00:00:00Z",
+      now: Date.parse("2026-01-10T00:00:00Z"),
+    }).action,
+    "skipped_policy_exempt",
+  );
+  assert.equal(
+    proofNudgeEligibilityForTest({
+      item: proofNudgeItem(),
+      markdown: proofNudgeReport({
+        proofStatus: "not_applicable",
+        needsContributorAction: "false",
+        reviewStatus: "failed",
+      }),
+      headSha: "abc123def456",
+      headCommittedAt: "2026-01-01T00:00:00Z",
+      now: Date.parse("2026-01-10T00:00:00Z"),
+    }).action,
+    "skipped_policy_exempt",
+  );
+  assert.equal(
+    proofNudgeEligibilityForTest({
+      item: proofNudgeItem({ labels: ["triage: needs-real-behavior-proof", "proof: supplied"] }),
+      markdown: proofNudgeReport(),
+      headSha: "abc123def456",
+      headCommittedAt: "2026-01-01T00:00:00Z",
+      now: Date.parse("2026-01-10T00:00:00Z"),
+    }).action,
+    "skipped_policy_exempt",
+  );
+});
+
+test("proof nudges skip maintainer, bot, security, and release PRs", () => {
+  for (const [input, expected] of [
+    [proofNudgeItem({ authorAssociation: "MEMBER" }), "skipped_maintainer_authored"],
+    [proofNudgeItem({ author: "dependabot[bot]" }), "skipped_bot_authored"],
+    [
+      proofNudgeItem({
+        labels: ["triage: needs-real-behavior-proof", "clawsweeper:needs-security-review"],
+      }),
+      "skipped_protected_label",
+    ],
+    [proofNudgeItem({ title: "Release 1.2.3" }), "skipped_protected_label"],
+    [proofNudgeItem({ title: "chore(release): 1.2.3" }), "skipped_protected_label"],
+  ] as const) {
+    assert.equal(
+      proofNudgeEligibilityForTest({
+        item: input,
+        markdown: proofNudgeReport({
+          author: input.author,
+          authorAssociation: input.authorAssociation,
+          labels: JSON.stringify(input.labels),
+        }),
+        headSha: "abc123def456",
+        headCommittedAt: "2026-01-01T00:00:00Z",
+        now: Date.parse("2026-01-10T00:00:00Z"),
+      }).action,
+      expected,
+    );
+  }
+});
+
+test("proof nudges skip locked PR conversations before posting", () => {
+  const result = proofNudgeEligibilityForTest({
+    item: proofNudgeItem({ locked: true, activeLockReason: "resolved" }),
+    markdown: proofNudgeReport(),
+    headSha: "abc123def456",
+    headCommittedAt: "2026-01-01T00:00:00Z",
+    now: Date.parse("2026-01-10T00:00:00Z"),
+  });
+
+  assert.equal(result.eligible, false);
+  assert.equal(result.action, "skipped_locked_conversation");
+  assert.match(result.reason, /conversation is locked \(resolved\)/);
+});
+
+test("proof nudge copy asks for evidence without promising author-only re-review access", () => {
+  const comment = renderProofNudgeCommentForTest({
+    number: 42,
+    author: "contributor",
+    headSha: "abc123def456",
+  });
+
+  assert.match(comment, /^@contributor thanks for the PR\./);
+  assert.match(comment, /screenshot, short video, terminal output/);
+  assert.match(comment, /ClawSweeper or a maintainer can re-check it/);
+  assert.doesNotMatch(comment, /@clawsweeper re-review/);
+});
+
 test("ClawSweeper PR rating labels use one themed overall label", () => {
   assert.deepEqual(prRatingLabelsForTest(["bug"], "A"), ["bug", "rating: 🦞 diamond lobster"]);
   assert.deepEqual(
@@ -11058,6 +11388,25 @@ test("sweep target tokens fall back when an org app installation is missing", ()
     ),
   );
   assert.doesNotMatch(workflow, new RegExp("OPENCLAW_" + "GH_TOKEN"));
+});
+
+test("proof nudge workflow is manual-first and scheduled behind repo vars", () => {
+  const sweepWorkflow = readFileSync(".github/workflows/sweep.yml", "utf8");
+  const workflow = readFileSync(".github/workflows/proof-nudges.yml", "utf8");
+  const job = workflow.slice(workflow.indexOf("  proof-nudges:"), workflow.length);
+  const concurrency = workflow.slice(workflow.indexOf("concurrency:"), workflow.indexOf("\njobs:"));
+
+  assert.doesNotMatch(sweepWorkflow, /proof_nudges/);
+  assert.match(workflow, /execute:[\s\S]*?default: "false"/);
+  assert.match(workflow, /cron: "44 9 \* \* \*"/);
+  assert.match(concurrency, /clawsweeper-proof-nudges/);
+  assert.match(job, /github\.event_name == 'workflow_dispatch'/);
+  assert.match(job, /vars\.CLAWSWEEPER_PROOF_NUDGES_SCHEDULED == '1'/);
+  assert.match(job, /vars\.CLAWSWEEPER_PROOF_NUDGES_EXECUTE == '1'/);
+  assert.match(job, /execute_arg=\(\)/);
+  assert.match(job, /if \[ "\$execute" = "true" \]/);
+  assert.match(job, /pnpm run proof-nudges/);
+  assert.match(job, /vars\.CLAWSWEEPER_PROOF_NUDGES_LIMIT/);
 });
 
 test("read-only checkout mode restores file modes and leaves git metadata writable", () => {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -11403,8 +11403,16 @@ test("proof nudge workflow is manual-first and scheduled behind repo vars", () =
   assert.match(job, /github\.event_name == 'workflow_dispatch'/);
   assert.match(job, /vars\.CLAWSWEEPER_PROOF_NUDGES_SCHEDULED == '1'/);
   assert.match(job, /vars\.CLAWSWEEPER_PROOF_NUDGES_EXECUTE == '1'/);
+  assert.match(job, /TARGET_REPO_INPUT:/);
+  assert.match(job, /target_repo must be owner\/repo/);
+  assert.match(job, /PROOF_NUDGES_ITEM_NUMBERS:/);
+  assert.match(job, /item_numbers must be a comma-separated list/);
+  assert.match(job, /PROOF_NUDGES_LIMIT:/);
+  assert.match(job, /PROOF_NUDGES_MIN_AGE_DAYS:/);
+  assert.match(job, /PROOF_NUDGES_COOLDOWN_DAYS:/);
+  assert.match(job, /numeric_input in PROOF_NUDGES_LIMIT PROOF_NUDGES_MIN_AGE_DAYS PROOF_NUDGES_COOLDOWN_DAYS/);
   assert.match(job, /execute_arg=\(\)/);
-  assert.match(job, /if \[ "\$execute" = "true" \]/);
+  assert.match(job, /if \[ "\$PROOF_NUDGES_EXECUTE" = "true" \]/);
   assert.match(job, /pnpm run proof-nudges/);
   assert.match(job, /vars\.CLAWSWEEPER_PROOF_NUDGES_LIMIT/);
 });

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -10385,6 +10385,19 @@ test("proof nudges skip recent reviews and recent author activity", () => {
     }).action,
     "skipped_recent_author_activity",
   );
+  assert.equal(
+    proofNudgeEligibilityForTest({
+      item: proofNudgeItem(),
+      markdown: proofNudgeReport(),
+      headSha: "abc123def456",
+      headCommittedAt: "2026-01-01T00:00:00Z",
+      authorEditedAt: "2026-01-09T00:00:00Z",
+      now: Date.parse("2026-01-10T00:00:00Z"),
+      minAgeDays: 5,
+      cooldownDays: 7,
+    }).action,
+    "skipped_recent_author_activity",
+  );
   const maintainerActivity = proofNudgeEligibilityForTest({
     item: proofNudgeItem({ updatedAt: "2026-01-09T00:00:00Z" }),
     markdown: proofNudgeReport(),

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -10243,11 +10243,14 @@ function proofNudgeReport(overrides = {}) {
     reviewStatus: "complete",
     headSha: "abc123def456",
     reviewedAt: "2026-01-01T00:00:00Z",
+    itemCategory: "feature",
     pullFiles: JSON.stringify(["src/app.ts"]),
     proofStatus: "missing",
     evidenceKind: "none",
     needsContributorAction: "true",
     proofSummary: "The PR needs after-fix proof from a real setup.",
+    securityReviewStatus: "cleared",
+    securityReviewSummary: "No security-sensitive review is needed for this proof nudge.",
     ...overrides,
   };
   return `---
@@ -10258,6 +10261,7 @@ title: Proof nudge sample
 author: ${values.author}
 author_association: ${values.authorAssociation}
 labels: ${values.labels}
+item_category: ${values.itemCategory}
 review_status: ${values.reviewStatus}
 pull_files: ${values.pullFiles}
 pull_files_truncated: false
@@ -10274,6 +10278,12 @@ Evidence kind: ${values.evidenceKind}
 Needs contributor action: ${values.needsContributorAction}
 
 Summary: ${values.proofSummary}
+
+## Security Review
+
+Status: ${values.securityReviewStatus}
+
+Summary: ${values.securityReviewSummary}
 `;
 }
 
@@ -10532,6 +10542,32 @@ test("proof nudges skip maintainer, bot, security, and release PRs", () => {
       }).action,
       expected,
     );
+  }
+
+  for (const [markdown, expectedReason] of [
+    [
+      proofNudgeReport({
+        itemCategory: "security",
+      }),
+      "latest report item category is security",
+    ],
+    [
+      proofNudgeReport({
+        securityReviewStatus: "needs_attention",
+        securityReviewSummary: "The patch changes token handling and needs maintainer review.",
+      }),
+      "latest report security review needs attention",
+    ],
+  ] as const) {
+    const result = proofNudgeEligibilityForTest({
+      item: proofNudgeItem(),
+      markdown,
+      headSha: "abc123def456",
+      headCommittedAt: "2026-01-01T00:00:00Z",
+      now: Date.parse("2026-01-10T00:00:00Z"),
+    });
+    assert.equal(result.action, "skipped_protected_label");
+    assert.equal(result.reason, expectedReason);
   }
 });
 

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -11410,7 +11410,10 @@ test("proof nudge workflow is manual-first and scheduled behind repo vars", () =
   assert.match(job, /PROOF_NUDGES_LIMIT:/);
   assert.match(job, /PROOF_NUDGES_MIN_AGE_DAYS:/);
   assert.match(job, /PROOF_NUDGES_COOLDOWN_DAYS:/);
-  assert.match(job, /numeric_input in PROOF_NUDGES_LIMIT PROOF_NUDGES_MIN_AGE_DAYS PROOF_NUDGES_COOLDOWN_DAYS/);
+  assert.match(
+    job,
+    /numeric_input in PROOF_NUDGES_LIMIT PROOF_NUDGES_MIN_AGE_DAYS PROOF_NUDGES_COOLDOWN_DAYS/,
+  );
   assert.match(job, /execute_arg=\(\)/);
   assert.match(job, /if \[ "\$PROOF_NUDGES_EXECUTE" = "true" \]/);
   assert.match(job, /pnpm run proof-nudges/);

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -10398,6 +10398,19 @@ test("proof nudges skip recent reviews and recent author activity", () => {
     }).action,
     "skipped_recent_author_activity",
   );
+  assert.equal(
+    proofNudgeEligibilityForTest({
+      item: proofNudgeItem(),
+      markdown: proofNudgeReport(),
+      headSha: "abc123def456",
+      headCommittedAt: "2026-01-01T00:00:00Z",
+      authorReviewActivityAt: "2026-01-09T00:00:00Z",
+      now: Date.parse("2026-01-10T00:00:00Z"),
+      minAgeDays: 5,
+      cooldownDays: 7,
+    }).action,
+    "skipped_recent_author_activity",
+  );
   const maintainerActivity = proofNudgeEligibilityForTest({
     item: proofNudgeItem({ updatedAt: "2026-01-09T00:00:00Z" }),
     markdown: proofNudgeReport(),

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -10385,18 +10385,21 @@ test("proof nudges skip recent reviews and recent author activity", () => {
     }).action,
     "skipped_recent_author_activity",
   );
-  assert.equal(
-    proofNudgeEligibilityForTest({
-      item: proofNudgeItem({ updatedAt: "2026-01-09T00:00:00Z" }),
-      markdown: proofNudgeReport(),
-      headSha: "abc123def456",
-      headCommittedAt: "2026-01-01T00:00:00Z",
-      now: Date.parse("2026-01-10T00:00:00Z"),
-      minAgeDays: 5,
-      cooldownDays: 7,
-    }).action,
-    "skipped_recent_author_activity",
-  );
+  const maintainerActivity = proofNudgeEligibilityForTest({
+    item: proofNudgeItem({ updatedAt: "2026-01-09T00:00:00Z" }),
+    markdown: proofNudgeReport(),
+    comments: [
+      { author: "maintainer", body: "Queued for review.", updatedAt: "2026-01-09T00:00:00Z" },
+    ],
+    headSha: "abc123def456",
+    headCommittedAt: "2026-01-01T00:00:00Z",
+    now: Date.parse("2026-01-10T00:00:00Z"),
+    minAgeDays: 5,
+    cooldownDays: 7,
+  });
+
+  assert.equal(maintainerActivity.eligible, true);
+  assert.equal(maintainerActivity.action, "proof_nudge_planned");
 });
 
 test("proof nudges use same-head cooldown markers instead of label churn", () => {


### PR DESCRIPTION
﻿## Summary

Adds a phase 1 proof-followup lane for pull requests that are stuck on `triage: needs-real-behavior-proof`.

This is intentionally v1 nudges only:

- no dashboard work
- no auto-close behavior
- no label churn for cooldowns
- no repair or merge behavior
- dry-run by default for manual runs
- scheduled operation is present but off by default behind repository variables

## What This Does

Adds a new `proof-nudges` ClawSweeper command that finds open PRs which still have the live `triage: needs-real-behavior-proof` label and are old enough to deserve a polite reminder.

The nudge asks for real behavior evidence, gives examples of acceptable proof, and points contributors toward maintainer re-review after they update the PR.

## Safety Rules

The nudge lane skips PRs when any of these apply:

- PR is closed, locked, stale relative to the report head, or missing the live proof-needed label
- proof is already supplied, sufficient, overridden, or the proof policy is not applicable
- author has commented recently
- PR body or head commit was updated recently
- ClawSweeper reviewed the PR recently
- a same-head ClawSweeper cooldown marker already exists in a prior bot comment
- PR is authored by a maintainer or bot
- PR appears to be security-sensitive, release-related, or otherwise protected

Cooldown state is kept in a hidden marker in ClawSweeper's own comment body rather than by adding/removing labels.

## Workflow

Adds a separate `ClawSweeper Proof Nudges` workflow at `.github/workflows/proof-nudges.yml`.

Manual use:

- run the `ClawSweeper Proof Nudges` workflow with `workflow_dispatch`
- `execute` defaults to `false`, so manual runs are dry-run by default
- set `execute=true` only when comments should actually be posted
- `limit` controls the batch size, default `10`
- optional inputs can set `target_repo`, `item_numbers`, `min_age_days`, and `cooldown_days`

Scheduled use is also wired, but deliberately disabled by default:

- the workflow includes a daily cron at `44 9 * * *`
- scheduled runs do nothing unless `CLAWSWEEPER_PROOF_NUDGES_SCHEDULED=1` is set
- scheduled runs remain dry-run only unless `CLAWSWEEPER_PROOF_NUDGES_EXECUTE=1` is also set
- optional vars can tune `CLAWSWEEPER_PROOF_NUDGES_TARGET_REPO`, `CLAWSWEEPER_PROOF_NUDGES_LIMIT`, `CLAWSWEEPER_PROOF_NUDGES_MIN_AGE_DAYS`, and `CLAWSWEEPER_PROOF_NUDGES_COOLDOWN_DAYS`

Suggested rollout is manual dry-run first, then scheduled dry-run, then scheduled execute only once maintainers are happy with the reports.

## Docs

Adds `docs/proof-nudges.md` and links it from the README. The docs include the manual command, workflow inputs, default-off scheduled vars, and rollout path.

## Real Behavior Proof

Dry-run proof was run locally against live `openclaw/openclaw` PR state using `pnpm run proof-nudges`. The run did not include `--execute`, so no GitHub comments were posted.

Environment:

- branch head: `6920996b6ca13e2922a405e7ca77c3cac24f90f1`
- Node: `v24.13.0`
- pnpm: `10.33.2`
- target repo: `openclaw/openclaw`

The temporary report records were generated from live GitHub PR metadata, then the command fetched live PR state/comments/head SHAs through the GitHub API. Public PR numbers and commit SHAs are shown; no tokens or private values are included.

Dry-run command exercising planned and skip paths:

```bash
pnpm run proof-nudges -- \
  --target-repo openclaw/openclaw \
  --items-dir <temp>/items \
  --item-numbers "39349,18860,39644" \
  --limit 3 \
  --processed-limit 10 \
  --min-age-days 0 \
  --cooldown-days 7 \
  --report-path <temp>/proof-nudge-report-planned-and-skips.json
```

Output:

```json
[
  {
    "repo": "openclaw/openclaw",
    "number": 18860,
    "reviewedAt": "2026-05-01T00:00:00Z",
    "action": "skipped_policy_exempt",
    "reason": "proof is already supplied, sufficient, or overridden",
    "headSha": "4531fb1b29c8310a2694b94daac4295009561497"
  },
  {
    "repo": "openclaw/openclaw",
    "number": 39349,
    "reviewedAt": "2026-05-01T00:00:00Z",
    "action": "proof_nudge_planned",
    "reason": "needs real behavior proof and is past the nudge age/cooldown gates",
    "headSha": "77db5716d200eb73b9d1342840d38ccbaf4aa6cf"
  },
  {
    "repo": "openclaw/openclaw",
    "number": 39644,
    "reviewedAt": "2026-05-01T00:00:00Z",
    "action": "skipped_stale_report_head",
    "reason": "live PR head SHA differs from the reviewed report",
    "headSha": "77ce6361f2dda2b71eca4ad40aaf331f61e4d250"
  }
]
```

A second dry-run used the normal 5-day first-nudge age gate to verify that recent author/head/PR activity blocks a nudge:

```bash
pnpm run proof-nudges -- \
  --target-repo openclaw/openclaw \
  --items-dir <temp>/items \
  --item-numbers "39349" \
  --limit 1 \
  --processed-limit 5 \
  --min-age-days 5 \
  --cooldown-days 7 \
  --report-path <temp>/proof-nudge-report-age-gate.json
```

Output:

```json
[
  {
    "repo": "openclaw/openclaw",
    "number": 39349,
    "reviewedAt": "2026-05-01T00:00:00Z",
    "action": "skipped_recent_author_activity",
    "reason": "author comment, PR update, or head commit is newer than 5 day(s)",
    "headSha": "77db5716d200eb73b9d1342840d38ccbaf4aa6cf"
  }
]
```

Same-head cooldown behavior is covered by the targeted unit test because the feature has not posted any production nudge comments yet, so there is no live cooldown marker to find in `openclaw/openclaw` comments.

## Validation

- `pnpm run build:all`
- `pnpm run lint:src`
- `pnpm run lint:scripts`
- `node --test --test-name-pattern "proof nudge|sweep target tokens" test/clawsweeper.test.ts`
- GitHub CI after rebase: `pnpm check`, CodeQL, and Socket checks passed
