### PR TITLE
fix(pr-egg): report missing hatch records

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -47,6 +47,10 @@ on:
         description: "Only sync durable review comments; do not close items"
         required: false
         default: "false"
+      hatch_pr_egg_image:
+        description: "Generate a hatched PR egg image while syncing a selected PR comment"
+        required: false
+        default: "false"
       apply_comment_sync_min_age_days:
         description: "Minimum age in days before comment-only sync rewrites an existing review comment"
         required: false
@@ -1671,6 +1675,7 @@ jobs:
           min_age_minutes="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_min_age_minutes || '' }}"
           apply_kind="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_kind || 'all' }}"
           apply_close_reasons="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_close_reasons || 'all' }}"
+          hatch_pr_egg_image="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.hatch_pr_egg_image || 'false' }}"
           stale_min_age_days="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_stale_min_age_days || '60' }}"
           close_delay_ms="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_close_delay_ms || '2000' }}"
           progress_every="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_progress_every || '10' }}"
@@ -1681,6 +1686,10 @@ jobs:
           sync_comments_arg=()
           if [ "$sync_comments_only" = "true" ]; then
             sync_comments_arg=(--sync-comments-only)
+          fi
+          hatch_pr_egg_image_arg=()
+          if [ "$hatch_pr_egg_image" = "true" ]; then
+            hatch_pr_egg_image_arg=(--hatch-pr-egg-image)
           fi
           min_age_minutes_arg=()
           if [ -n "$min_age_minutes" ]; then
@@ -1773,6 +1782,7 @@ jobs:
               --processed-limit "$((checkpoint_size * 20))" \
               --comment-sync-min-age-days "$comment_sync_min_age_days" \
               "${item_numbers_arg[@]}" \
+              "${hatch_pr_egg_image_arg[@]}" \
               "${sync_comments_arg[@]}"
             cp apply-report.json ".artifacts/apply-reports/apply-report-$checkpoint.json"
             result_count="$(pnpm run --silent workflow -- count-report --report ".artifacts/apply-reports/apply-report-$checkpoint.json")"
@@ -1812,6 +1822,7 @@ jobs:
               --processed-limit "$((chunk_limit * 20))" \
               --comment-sync-min-age-days "$comment_sync_min_age_days" \
               "${item_numbers_arg[@]}" \
+              "${hatch_pr_egg_image_arg[@]}" \
               "${sync_comments_arg[@]}"
             cp apply-report.json ".artifacts/apply-reports/apply-report-$checkpoint.json"
             pnpm run workflow -- merge-apply-reports --dir .artifacts/apply-reports --output apply-report.json

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -4,7 +4,7 @@ run-name: ${{ github.event_name == 'repository_dispatch' && format('Review event
 
 on:
   repository_dispatch:
-    types: [clawsweeper_item]
+    types: [clawsweeper_item, clawsweeper_hatch]
   workflow_dispatch:
     inputs:
       target_repo:
@@ -45,10 +45,6 @@ on:
         default: ""
       apply_sync_comments_only:
         description: "Only sync durable review comments; do not close items"
-        required: false
-        default: "false"
-      hatch_pr_egg_image:
-        description: "Generate a hatched PR egg image while syncing a selected PR comment"
         required: false
         default: "false"
       apply_comment_sync_min_age_days:
@@ -153,7 +149,7 @@ jobs:
 
   event-review-apply:
     name: Review, comment, and apply event item
-    if: ${{ github.event_name == 'repository_dispatch' && !(github.event.client_payload.target_repo == 'openclaw/clawhub' && vars.CLAWSWEEPER_ENABLE_CLAWHUB != '1') }}
+    if: ${{ github.event_name == 'repository_dispatch' && github.event.action != 'clawsweeper_hatch' && !(github.event.client_payload.target_repo == 'openclaw/clawhub' && vars.CLAWSWEEPER_ENABLE_CLAWHUB != '1') }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
     permissions:
@@ -1598,7 +1594,7 @@ jobs:
 
   apply-existing:
     name: Apply close proposals
-    if: ${{ ((github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '3 * * * *' || github.event.schedule == '18 * * * *' || github.event.schedule == '33 * * * *' || github.event.schedule == '48 * * * *' || github.event.schedule == '8,23,38,53 * * * *'))) && !(github.event_name == 'schedule' && github.event.schedule == '8,23,38,53 * * * *' && vars.CLAWSWEEPER_ENABLE_CLAWHUB != '1') }}
+    if: ${{ ((github.event_name == 'repository_dispatch' && github.event.action == 'clawsweeper_hatch') || (github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '3 * * * *' || github.event.schedule == '18 * * * *' || github.event.schedule == '33 * * * *' || github.event.schedule == '48 * * * *' || github.event.schedule == '8,23,38,53 * * * *'))) && !(github.event_name == 'repository_dispatch' && github.event.client_payload.target_repo == 'openclaw/clawhub' && vars.CLAWSWEEPER_ENABLE_CLAWHUB != '1') && !(github.event_name == 'schedule' && github.event.schedule == '8,23,38,53 * * * *' && vars.CLAWSWEEPER_ENABLE_CLAWHUB != '1') }}
     runs-on: ubuntu-latest
     timeout-minutes: 360
     steps:
@@ -1610,7 +1606,7 @@ jobs:
       - name: Resolve target repository
         id: target
         run: |
-          target_repo="${{ github.event.inputs.target_repo || '' }}"
+          target_repo="${{ github.event_name == 'repository_dispatch' && github.event.client_payload.target_repo || github.event.inputs.target_repo || '' }}"
           if [ -z "$target_repo" ]; then
             case "${{ github.event.schedule || '' }}" in
               "8,23,38,53 * * * *")
@@ -1675,13 +1671,13 @@ jobs:
           min_age_minutes="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_min_age_minutes || '' }}"
           apply_kind="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_kind || 'all' }}"
           apply_close_reasons="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_close_reasons || 'all' }}"
-          hatch_pr_egg_image="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.hatch_pr_egg_image || 'false' }}"
+          hatch_pr_egg_image="${{ github.event_name == 'repository_dispatch' && github.event.action == 'clawsweeper_hatch' && github.event.client_payload.hatch_pr_egg_image == 'true' && 'true' || 'false' }}"
           stale_min_age_days="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_stale_min_age_days || '60' }}"
           close_delay_ms="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_close_delay_ms || '2000' }}"
           progress_every="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_progress_every || '10' }}"
           checkpoint_size="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_checkpoint_size || '50' }}"
-          item_numbers="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_item_numbers || '' }}"
-          sync_comments_only="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_sync_comments_only || 'false' }}"
+          item_numbers="${{ github.event_name == 'repository_dispatch' && github.event.client_payload.item_number || github.event.inputs.apply_item_numbers || '' }}"
+          sync_comments_only="${{ github.event_name == 'repository_dispatch' && github.event.action == 'clawsweeper_hatch' && 'true' || (github.event_name == 'workflow_dispatch' && github.event.inputs.apply_sync_comments_only || 'false') }}"
           comment_sync_min_age_days="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_comment_sync_min_age_days || '7' }}"
           sync_comments_arg=()
           if [ "$sync_comments_only" = "true" ]; then

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1259,6 +1259,7 @@ jobs:
         timeout-minutes: 15
         env:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           TARGET_REPO: ${{ needs.plan.outputs.target_repo }}
         run: |
           set -euo pipefail
@@ -1298,6 +1299,7 @@ jobs:
           pnpm run repair:publish-main -- \
             --message "chore: sync selected review comments" \
             --path "records/${target_slug}" \
+            --path assets/pr-eggs \
             --path apply-report.json \
             --path "results/sweep-status/${target_slug}.json" \
             --rebase-strategy theirs
@@ -1307,6 +1309,7 @@ jobs:
         timeout-minutes: 30
         env:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           TARGET_REPO: ${{ needs.plan.outputs.target_repo }}
         run: |
           set -euo pipefail
@@ -1351,6 +1354,7 @@ jobs:
           pnpm run repair:publish-main -- \
             --message "chore: apply selected sweep decisions" \
             --path "records/${target_slug}" \
+            --path assets/pr-eggs \
             --path apply-report.json \
             --path "results/sweep-status/${target_slug}.json" \
             --rebase-strategy theirs
@@ -1654,6 +1658,7 @@ jobs:
       - name: Apply unchanged proposed decisions with checkpoints
         env:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
           CLAWSWEEPER_PUBLISH_THROTTLE_STATUS: "true"
           CLAWSWEEPER_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -1772,7 +1777,7 @@ jobs:
             cp apply-report.json ".artifacts/apply-reports/apply-report-$checkpoint.json"
             result_count="$(pnpm run --silent workflow -- count-report --report ".artifacts/apply-reports/apply-report-$checkpoint.json")"
             synced_count="$(pnpm run --silent workflow -- count-actions --report ".artifacts/apply-reports/apply-report-$checkpoint.json" --action review_comment_synced)"
-            publish_changes "chore: sync sweep review comments checkpoint $checkpoint" records apply-report.json
+            publish_changes "chore: sync sweep review comments checkpoint $checkpoint" records assets/pr-eggs apply-report.json
             pnpm run status -- \
               --target-repo "$TARGET_REPO" \
               --state "Apply comments synced" \
@@ -1814,7 +1819,7 @@ jobs:
             result_count="$(pnpm run --silent workflow -- count-report --report ".artifacts/apply-reports/apply-report-$checkpoint.json")"
             closed_total=$((closed_total + closed_in_chunk))
             echo "Checkpoint $checkpoint result_count=$result_count closed_in_chunk=$closed_in_chunk closed_total=$closed_total/$limit"
-            publish_changes "chore: apply sweep decisions checkpoint $checkpoint" records apply-report.json
+            publish_changes "chore: apply sweep decisions checkpoint $checkpoint" records assets/pr-eggs apply-report.json
             pnpm run status -- \
               --target-repo "$TARGET_REPO" \
               --state "Apply in progress" \
@@ -1865,6 +1870,7 @@ jobs:
           pnpm run repair:publish-main -- \
             --message "chore: apply sweep decisions" \
             --path "records/${target_slug}" \
+            --path assets/pr-eggs \
             --path apply-report.json \
             --path "results/sweep-status/${target_slug}.json" \
             --rebase-strategy apply-records

--- a/scripts/hydrate-state.ts
+++ b/scripts/hydrate-state.ts
@@ -6,6 +6,7 @@ const GENERATED_PATHS = [
   "records",
   "jobs",
   "results",
+  "assets",
   "apply-report.json",
   "repair-apply-report.json",
 ];

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -173,6 +173,7 @@ type ActionTaken =
   | "skipped_maintainer_authored"
   | "skipped_protected_label"
   | "skipped_invalid_decision"
+  | "skipped_missing_record"
   | "skipped_runtime_budget";
 
 const MAINTAINER_AUTHOR_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
@@ -9471,6 +9472,39 @@ function ensureCloseAppliedComment(options: {
   return "posted close-applied comment";
 }
 
+function hatchMissingRecordMarker(number: number): string {
+  return `<!-- clawsweeper-hatch-missing-record:${number} -->`;
+}
+
+function renderHatchMissingRecordComment(number: number): string {
+  return [
+    "ClawSweeper could not hatch this PR egg yet.",
+    "",
+    "Reason: there is no current durable ClawSweeper review record for this PR, so there is no PR egg state record to update.",
+    "Ask for `@clawsweeper re-review` first, then retry `@clawsweeper hatch` after the ClawSweeper review comment appears.",
+    "",
+    hatchMissingRecordMarker(number),
+  ].join("\n");
+}
+
+function ensureHatchMissingRecordComment(number: number, dryRun: boolean): string {
+  const marker = hatchMissingRecordMarker(number);
+  if (issueCommentWithMarker(number, marker)) {
+    return "matching ClawSweeper hatch-missing-record comment already exists";
+  }
+  if (dryRun) return "dry-run: would post hatch-missing-record comment";
+  const payload = writeCommentPayload(number, renderHatchMissingRecordComment(number));
+  ghWithRetry([
+    "api",
+    `repos/${targetRepo()}/issues/${number}/comments`,
+    "--method",
+    "POST",
+    "--input",
+    payload,
+  ]);
+  return "posted hatch-missing-record comment";
+}
+
 function postReviewStartStatusComment(options: {
   item: Item;
   position: number;
@@ -10264,11 +10298,38 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
   const maybeLogProgress = (message: string): void => {
     if (processedCount % progressEvery === 0) logProgress(message);
   };
+  const recordMissingHatchResults = (existingNumbers: Set<number>): void => {
+    if (!hatchPrEggImage || requestedItemNumbers.length === 0) return;
+    for (const number of requestedItemNumbers) {
+      if (existingNumbers.has(number)) continue;
+      let commentReason = "no current durable ClawSweeper review record";
+      try {
+        commentReason = ensureHatchMissingRecordComment(number, dryRun);
+      } catch (error) {
+        console.error(
+          `[apply] ${new Date().toISOString()} failed to post PR egg missing-record notice for #${number}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+      results.push({
+        number,
+        action: "skipped_missing_record",
+        reason: `no current durable ClawSweeper review record; ${commentReason}`,
+      });
+      processedCount += 1;
+      maybeLogProgress(`skipped PR egg image #${number}: missing durable record`);
+      if (processedCount >= processedLimit) break;
+    }
+  };
   if (!existsSync(itemsDir)) {
     console.log("No items directory.");
+    recordMissingHatchResults(new Set());
+    ensureDir(dirname(reportPath));
+    writeFileSync(reportPath, JSON.stringify(results, null, 2), "utf8");
     return;
   }
-  const files = readdirSync(itemsDir)
+  const fileEntries = readdirSync(itemsDir)
     .filter((name) => parseReportFileName(name) !== null)
     .filter((name) => {
       const markdown = readFileSync(join(itemsDir, name), "utf8");
@@ -10291,11 +10352,17 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
         left.priority - right.priority ||
         left.applyCheckedAt - right.applyCheckedAt ||
         left.number - right.number,
-    )
-    .map((entry) => entry.name);
+    );
+  const files = fileEntries.map((entry) => entry.name);
   logProgress(
     `starting apply: files=${files.length} dry_run=${dryRun} apply_kind=${applyKind} min_age=${minAgeDescription} apply_close_reasons=${closeReasonFilterText(applyCloseReasons)} stale_min_age_days=${staleMinAgeDays} close_delay_ms=${closeDelayMs} sync_comments_only=${syncCommentsOnly} comment_sync_min_age_days=${commentSyncMinAgeDays} max_runtime_ms=${maxRuntimeMs} item_numbers=${requestedItemNumbers.join(",") || "all"}`,
   );
+  recordMissingHatchResults(new Set(fileEntries.map((entry) => entry.number)));
+  if (processedCount >= processedLimit) {
+    ensureDir(dirname(reportPath));
+    writeFileSync(reportPath, JSON.stringify(results, null, 2), "utf8");
+    return;
+  }
   for (const file of files) {
     if (runtimeBudgetExceeded(startedAtMs, maxRuntimeMs, Date.now())) {
       results.push({

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -5588,6 +5588,7 @@ function publicPrEggLine(
       "```",
       `Rarity: ${creature.rarityLabel}.`,
       `Trait: ${creature.trait}.`,
+      `Image traits: location ${creature.imageTraits.location}; accessory ${creature.imageTraits.accessory}; palette ${creature.imageTraits.palette}; mood ${creature.imageTraits.mood}; pose ${creature.imageTraits.pose}; shell ${creature.imageTraits.texture}; lighting ${creature.imageTraits.lighting}; background ${creature.imageTraits.backgroundDetail}.`,
       `Share on X: ${markdownLink("post this hatch", shareUrl)}`,
       `Copy: ${creature.shareText}`,
       ...explainer,
@@ -6319,6 +6320,126 @@ const PR_EGG_TRAITS = [
   "hums during re-review",
 ];
 
+const PR_EGG_LOCATIONS = [
+  "CI tidepool",
+  "merge queue dock",
+  "flaky test forest",
+  "release reef",
+  "review cove",
+  "branch lighthouse",
+  "artifact grotto",
+  "status garden",
+  "diff observatory",
+  "proof lagoon",
+  "workflow harbor",
+  "green-check meadow",
+];
+
+const PR_EGG_ACCESSORIES = [
+  "tiny test log scroll",
+  "green check lantern",
+  "miniature diff map",
+  "shell-shaped keyboard",
+  "review stamp",
+  "commit compass",
+  "proof snapshot camera",
+  "little merge flag",
+  "CI status badge",
+  "lint brush",
+  "rollback rope",
+  "release bell",
+];
+
+const PR_EGG_PALETTES = [
+  "pearl, teal, and neon green",
+  "moonlit blue and soft silver",
+  "coral, mint, and warm cream",
+  "charcoal, cyan, and signal green",
+  "sunrise gold and clean white",
+  "moss green and polished brass",
+  "violet, aqua, and starlight",
+  "rose quartz and slate",
+  "cobalt, lime, and pearl",
+  "amber, ink, and glacier blue",
+  "seafoam, black, and opal",
+  "plum, gold, and soft gray",
+];
+
+const PR_EGG_MOODS = [
+  "curious",
+  "proud",
+  "sleepy but ready",
+  "focused",
+  "celebratory",
+  "watchful",
+  "mischievous",
+  "calm",
+  "determined",
+  "sparkly",
+  "patient",
+  "bright-eyed",
+];
+
+const PR_EGG_POSES = [
+  "holding its accessory up for inspection",
+  "standing beside its cracked shell",
+  "peeking out from the egg shell",
+  "guarding a tiny green check",
+  "waving from a small platform",
+  "sitting proudly on a smooth stone",
+  "leaning over a miniature review desk",
+  "nestled inside a glowing shell",
+  "pointing at a small proof artifact",
+  "balancing on a branch marker",
+  "curling around a status light",
+  "stepping out of a freshly hatched shell",
+];
+
+const PR_EGG_TEXTURES = [
+  "smooth pearl shell",
+  "soft speckled shell",
+  "glossy opal shell",
+  "matte ceramic shell",
+  "translucent glimmer shell",
+  "brushed metal shell",
+  "soft velvet shell",
+  "polished stone shell",
+  "paper lantern shell",
+  "frosted glass shell",
+  "woven fiber shell",
+  "starlit enamel shell",
+];
+
+const PR_EGG_LIGHTING = [
+  "soft studio lighting",
+  "gentle morning glow",
+  "tiny status-light glow",
+  "moonlit rim light",
+  "warm desk-lamp glow",
+  "clean product lighting",
+  "subtle sparkle highlights",
+  "cool dashboard glow",
+  "soft underwater shimmer",
+  "golden review-room light",
+  "calm overcast light",
+  "bright celebratory glints",
+];
+
+const PR_EGG_BACKGROUND_DETAILS = [
+  "small green status lights",
+  "tiny shells and proof notes",
+  "subtle branch markers",
+  "miniature CI buoys",
+  "soft code-shaped tiles",
+  "little resolved-comment flags",
+  "smooth stones and checkmarks",
+  "tiny artifact crates",
+  "gentle dashboard dots",
+  "small review tokens",
+  "quiet workflow signs",
+  "delicate sparkle particles",
+];
+
 const PR_EGG_SPRITE_WIDTH = 29;
 const PR_EGG_SPRITE_HEIGHT = 12;
 
@@ -6432,6 +6553,16 @@ function prEggCreature(
   rarity: PrEggRarity;
   rarityLabel: string;
   trait: string;
+  imageTraits: {
+    location: string;
+    accessory: string;
+    palette: string;
+    mood: string;
+    pose: string;
+    texture: string;
+    lighting: string;
+    backgroundDetail: string;
+  };
   portrait: string;
   shareText: string;
 } {
@@ -6447,6 +6578,16 @@ function prEggCreature(
     rarity: rarity.rarity,
     rarityLabel: rarity.label,
     trait: pickSeeded(PR_EGG_TRAITS, identitySeed, "trait"),
+    imageTraits: {
+      location: pickSeeded(PR_EGG_LOCATIONS, identitySeed, "location"),
+      accessory: pickSeeded(PR_EGG_ACCESSORIES, identitySeed, "accessory"),
+      palette: pickSeeded(PR_EGG_PALETTES, identitySeed, "palette"),
+      mood: pickSeeded(PR_EGG_MOODS, identitySeed, "mood"),
+      pose: pickSeeded(PR_EGG_POSES, identitySeed, "pose"),
+      texture: pickSeeded(PR_EGG_TEXTURES, identitySeed, "texture"),
+      lighting: pickSeeded(PR_EGG_LIGHTING, identitySeed, "lighting"),
+      backgroundDetail: pickSeeded(PR_EGG_BACKGROUND_DETAILS, identitySeed, "background-detail"),
+    },
     portrait: composePrEggSprite(visualSeed, rarity.rarity),
     shareText,
   };

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -5588,6 +5588,7 @@ function publicPrEggLine(
     "- Eggs appear after the PR passes real-behavior proof. It is here for vibes, not verdicts: it does not change labels, ratings, merge decisions, or automation.",
     "- The shell reacts to review momentum: open follow-up work warms it up, re-review makes it wobble, and a clean final review lets it hatch.",
     "- How to hatch it: reach `status: 👀 ready for maintainer look` or `status: 🚀 automerge armed`; that usually means sufficient real-behavior proof, no blocking P0/P1/P2 findings, no security attention needed, and clean correctness.",
+    "- When the egg is hatchable, the PR author or a maintainer can comment `@clawsweeper hatch` to generate its image.",
     "- The hatch is seeded from this repository and PR number, so the same PR keeps the same creature; the reviewed head SHA can only change safe visual details.",
     "- Rarity is just collectible sparkle: 🥚 common, 🌱 uncommon, 💎 rare, ✨ glimmer, and 🌈 legendary.",
     "",

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -128,6 +128,16 @@ type PrStatusLabelKind =
   | "ready_for_maintainer_look";
 type PrEggState = "incubating" | "warming" | "wobbling" | "hatched";
 type PrEggRarity = "common" | "uncommon" | "rare" | "glimmer" | "legendary";
+type PrEggImageTraits = {
+  location: string;
+  accessory: string;
+  palette: string;
+  mood: string;
+  pose: string;
+  texture: string;
+  lighting: string;
+  backgroundDetail: string;
+};
 type TelegramVisibleProofStatus = "needed" | "not_needed";
 type MantisRecommendationStatus = "recommended" | "not_recommended";
 type MantisRecommendationScenario =
@@ -4868,6 +4878,14 @@ function markdownLink(label: string, url: string): string {
   return `[${label.replaceAll("|", "\\|")}](${url})`;
 }
 
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
 function linkedSha(sha: string): string {
   return markdownLink(shortSha(sha), commitUrl(sha));
 }
@@ -5577,12 +5595,21 @@ function publicPrEggLine(
   ];
   if (state === "hatched") {
     const creature = prEggCreature(identitySeed, visualSeed);
+    const imageUrl = frontMatterValue(markdown, "pr_egg_image_url");
+    const imageBlock =
+      imageUrl && imageUrl !== "unknown"
+        ? [
+            `<img src="${escapeHtmlAttribute(imageUrl)}" width="${PR_EGG_IMAGE_DISPLAY_SIZE}" height="${PR_EGG_IMAGE_DISPLAY_SIZE}" alt="${escapeHtmlAttribute(`Hatched PR egg: ${creature.rarityLabel} ${creature.name}`)}">`,
+            "",
+          ]
+        : [];
     const shareUrl = `https://x.com/intent/tweet?text=${encodeURIComponent(
       creature.shareText,
     )}&url=${encodeURIComponent(prEggShareTargetUrl(markdown))}`;
     return [
       `✨ Hatched: ${creature.rarityLabel} ${creature.name}`,
       "",
+      ...imageBlock,
       "```text",
       creature.portrait,
       "```",
@@ -5607,6 +5634,90 @@ function publicPrEggLine(
     "```",
     ...explainer,
   ].join("\n");
+}
+
+function prEggImageRelativePath(markdown: string): string {
+  const repo = markdownRepository(markdown);
+  const profile = repositoryProfileFor(repo);
+  const number = frontMatterValue(markdown, "number") ?? "unknown";
+  return `assets/pr-eggs/${profile.slug}/${number}.png`;
+}
+
+function prEggImagePublicUrl(relativePath: string): string {
+  const base =
+    process.env.CLAWSWEEPER_PR_EGG_IMAGE_BASE_URL ??
+    "https://raw.githubusercontent.com/openclaw/clawsweeper-state/state";
+  const encodedPath = relativePath.split("/").map(encodeURIComponent).join("/");
+  return `${base.replace(/\/+$/, "")}/${encodedPath}`;
+}
+
+function prEggImageGenerationEnabled(): boolean {
+  if (process.env.CLAWSWEEPER_PR_EGG_IMAGES === "0") return false;
+  return Boolean(process.env.OPENAI_API_KEY);
+}
+
+function prEggImageAlreadyRecorded(markdown: string): boolean {
+  const url = frontMatterValue(markdown, "pr_egg_image_url");
+  return Boolean(url && url !== "unknown");
+}
+
+function shouldEnsurePrEggImage(
+  markdown: string,
+  statusKind: PrStatusLabelKind | null | undefined,
+): boolean {
+  return (
+    frontMatterValue(markdown, "type") === "pull_request" &&
+    prEggProofUnlocked(reportRealBehaviorProof(markdown)) &&
+    prEggStateFromStatus(statusKind) === "hatched" &&
+    !prEggImageAlreadyRecorded(markdown)
+  );
+}
+
+async function ensurePrEggImage(markdown: string): Promise<string | null> {
+  if (prEggImageAlreadyRecorded(markdown)) return markdown;
+  const relativePath = prEggImageRelativePath(markdown);
+  const assetPath = resolve(ROOT, relativePath);
+  if (existsSync(assetPath)) {
+    return replaceFrontMatterValue(markdown, "pr_egg_image_url", prEggImagePublicUrl(relativePath));
+  }
+  if (!prEggImageGenerationEnabled()) return null;
+
+  const identitySeed = prEggIdentitySeedFromReport(markdown);
+  const visualSeed = prEggVisualSeedFromReport(markdown);
+  const image = await generatePrEggImage(prEggImagePrompt(prEggCreature(identitySeed, visualSeed)));
+  ensureDir(dirname(assetPath));
+  writeFileSync(assetPath, image);
+  return replaceFrontMatterValue(markdown, "pr_egg_image_url", prEggImagePublicUrl(relativePath));
+}
+
+async function generatePrEggImage(prompt: string): Promise<Buffer> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) throw new Error("OPENAI_API_KEY missing");
+  const response = await fetch("https://api.openai.com/v1/images/generations", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      model: process.env.CLAWSWEEPER_PR_EGG_IMAGE_MODEL ?? PR_EGG_IMAGE_MODEL,
+      prompt,
+      size: PR_EGG_IMAGE_SOURCE_SIZE,
+      quality: process.env.CLAWSWEEPER_PR_EGG_IMAGE_QUALITY ?? PR_EGG_IMAGE_QUALITY,
+      output_format: "png",
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `OpenAI PR egg image generation failed: HTTP ${response.status} ${await response.text()}`,
+    );
+  }
+  const body = (await response.json()) as {
+    data?: { b64_json?: string; url?: string }[];
+  };
+  const encoded = body.data?.[0]?.b64_json;
+  if (!encoded) throw new Error("OpenAI PR egg image response did not include b64_json");
+  return Buffer.from(encoded, "base64");
 }
 
 function publicMantisRecommendationBlock(recommendation: MantisRecommendation): string {
@@ -6440,6 +6551,11 @@ const PR_EGG_BACKGROUND_DETAILS = [
   "delicate sparkle particles",
 ];
 
+const PR_EGG_IMAGE_DISPLAY_SIZE = 256;
+const PR_EGG_IMAGE_SOURCE_SIZE = "1024x1024";
+const PR_EGG_IMAGE_MODEL = "gpt-image-1-mini";
+const PR_EGG_IMAGE_QUALITY = "low";
+
 const PR_EGG_SPRITE_WIDTH = 29;
 const PR_EGG_SPRITE_HEIGHT = 12;
 
@@ -6540,6 +6656,26 @@ function composePrEggSprite(seed: string, rarity: PrEggRarity): string {
   return decoratePrEggSprite(base, seed, rarity).join("\n");
 }
 
+function prEggImagePrompt(creature: {
+  name: string;
+  rarityLabel: string;
+  trait: string;
+  imageTraits: PrEggImageTraits;
+}): string {
+  const traits = creature.imageTraits;
+  return [
+    "Create a square collectible mascot badge for a GitHub pull request hatch.",
+    `Subject: a cute hatched PR egg creature named ${creature.name}.`,
+    `Rarity: ${creature.rarityLabel}. Personality trait: ${creature.trait}.`,
+    `Scene location: ${traits.location}. Accessory: ${traits.accessory}.`,
+    `Palette: ${traits.palette}. Mood: ${traits.mood}. Pose: ${traits.pose}.`,
+    `Shell material: ${traits.texture}. Lighting: ${traits.lighting}.`,
+    `Background detail: ${traits.backgroundDetail}.`,
+    "Style: polished modern product mascot illustration, clean readable silhouette, centered full-body character, crisp shapes that remain legible when displayed at 256x256.",
+    "Constraints: no text, no letters, no numbers, no logos, no UI chrome, no screenshots, no realistic people, no copyrighted characters.",
+  ].join(" ");
+}
+
 function prEggRarity(seed: string): { rarity: PrEggRarity; label: string } {
   const roll = hashNumber(seed, "rarity") % 10000;
   return PR_EGG_RARITIES.find((entry) => roll < entry.cutoff) ?? PR_EGG_RARITIES[0]!;
@@ -6553,16 +6689,7 @@ function prEggCreature(
   rarity: PrEggRarity;
   rarityLabel: string;
   trait: string;
-  imageTraits: {
-    location: string;
-    accessory: string;
-    palette: string;
-    mood: string;
-    pose: string;
-    texture: string;
-    lighting: string;
-    backgroundDetail: string;
-  };
+  imageTraits: PrEggImageTraits;
   portrait: string;
   shareText: string;
 } {
@@ -6598,6 +6725,10 @@ export function prEggCreatureForTest(
   visualSeed = identitySeed,
 ): ReturnType<typeof prEggCreature> {
   return prEggCreature(identitySeed, visualSeed);
+}
+
+export function prEggImagePromptForTest(identitySeed: string, visualSeed = identitySeed): string {
+  return prEggImagePrompt(prEggCreature(identitySeed, visualSeed));
 }
 
 export function prEggSpriteMetricsForTest(seed: string): { lines: string[]; width: number } {
@@ -10084,7 +10215,7 @@ function reviewCommand(args: Args): void {
   }
 }
 
-function applyDecisionsCommand(args: Args): void {
+async function applyDecisionsCommand(args: Args): Promise<void> {
   repoFromArgs(args);
   const itemsDir = resolve(stringArg(args.items_dir, defaultItemsDir()));
   const closedDir = resolve(stringArg(args.closed_dir, defaultClosedDir()));
@@ -10275,6 +10406,21 @@ function applyDecisionsCommand(args: Args): void {
       });
     }
     markdown = replaceFrontMatterValue(markdown, "labels", JSON.stringify(item.labels));
+    if (
+      !dryRun &&
+      item.kind === "pull_request" &&
+      shouldEnsurePrEggImage(markdown, currentPrStatusKind)
+    ) {
+      try {
+        markdown = (await ensurePrEggImage(markdown)) ?? markdown;
+      } catch (error) {
+        console.error(
+          `[apply] ${new Date().toISOString()} skipped PR egg image for #${number}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    }
     const reviewComment = renderReviewCommentFromReport(markdown, closeReason ?? "none", {
       prStatusKind: currentPrStatusKind,
     });
@@ -11962,13 +12108,13 @@ function checkCommand(): void {
   console.log("ok");
 }
 
-export function main(argv = process.argv.slice(2)): void {
+export async function main(argv = process.argv.slice(2)): Promise<void> {
   const args = parseArgs(argv);
   const command = args._[0] ?? "review";
   if (command === "plan") planCommand(args);
   else if (command === "review") reviewCommand(args);
   else if (command === "apply-artifacts") applyArtifactsCommand(args);
-  else if (command === "apply-decisions") applyDecisionsCommand(args);
+  else if (command === "apply-decisions") await applyDecisionsCommand(args);
   else if (command === "audit") auditCommand(args);
   else if (command === "reconcile") reconcileCommand(args);
   else if (command === "dashboard") {
@@ -11985,4 +12131,9 @@ export function main(argv = process.argv.slice(2)): void {
   }
 }
 
-if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main();
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.stack || error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -10234,6 +10234,7 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
   const progressEvery = Math.max(1, numberArg(args.progress_every, 10));
   const dryRun = boolArg(args.dry_run);
   const syncCommentsOnly = boolArg(args.sync_comments_only);
+  const hatchPrEggImage = boolArg(args.hatch_pr_egg_image);
   const commentSyncMinAgeDays = numberArg(args.comment_sync_min_age_days, 0);
   const maxRuntimeMs = numberArg(args.max_runtime_ms, 0);
   const reportPath = resolve(stringArg(args.report_path, join(ROOT, "apply-report.json")));
@@ -10408,6 +10409,7 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
     markdown = replaceFrontMatterValue(markdown, "labels", JSON.stringify(item.labels));
     if (
       !dryRun &&
+      hatchPrEggImage &&
       item.kind === "pull_request" &&
       shouldEnsurePrEggImage(markdown, currentPrStatusKind)
     ) {

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -647,7 +647,7 @@ export function isMaintainerCommandAllowed({
 
 export function isAuthorReadOnlyCommandAllowed({ command, target }: LooseRecord) {
   const intent = String(command?.intent ?? "");
-  if (intent !== "re_review") return false;
+  if (intent !== "re_review" && intent !== "hatch") return false;
   const author = normalizedLogin(command?.author);
   const targetAuthor = normalizedLogin(target?.author);
   return Boolean(author && targetAuthor && author === targetAuthor);
@@ -1181,7 +1181,7 @@ export function renderResponse(command: LooseRecord, dispatched: LooseRecord) {
       marker,
       "ClawSweeper is here and listening for maintainer commands.",
       "",
-      "Supported commands: `/review`, `/clawsweeper status`, `/clawsweeper re-review`, `/clawsweeper implement`, `@clawsweeper fix`, `/clawsweeper build`, `/clawsweeper fix ci`, `/clawsweeper address review`, `/clawsweeper rebase`, `/clawsweeper autofix`, `/clawsweeper automerge`, `/clawsweeper approve`, `/autoclose <reason>`, `/clawsweeper explain`, `/clawsweeper stop`.",
+      "Supported commands: `/review`, `/clawsweeper status`, `/clawsweeper re-review`, `@clawsweeper hatch`, `/clawsweeper implement`, `@clawsweeper fix`, `/clawsweeper build`, `/clawsweeper fix ci`, `/clawsweeper address review`, `/clawsweeper rebase`, `/clawsweeper autofix`, `/clawsweeper automerge`, `/clawsweeper approve`, `/autoclose <reason>`, `/clawsweeper explain`, `/clawsweeper stop`.",
       "",
       "I only act for maintainers, or for trusted ClawSweeper feedback on a ClawSweeper PR or PR opted into `clawsweeper:autofix` or `clawsweeper:automerge`.",
     ].join("\n");
@@ -1265,6 +1265,22 @@ export function renderResponse(command: LooseRecord, dispatched: LooseRecord) {
             "Result: the existing ClawSweeper review comment will be edited in place when the review finishes.",
           ].join("\n")
         : `Reason: ${command.reason ?? "re-review requires an open issue or PR"}.`,
+    ].join("\n");
+  }
+  if (command.intent === "hatch") {
+    return [
+      marker,
+      dispatched?.hatch
+        ? "ClawSweeper PR egg hatch requested."
+        : "ClawSweeper could not hatch this PR egg yet.",
+      "",
+      dispatched?.hatch
+        ? [
+            "I queued a comment sync for this PR. If the egg is hatchable, ClawSweeper will generate the image once and update the existing review comment.",
+            reviewDispatchLine(dispatched.hatch, "Action", "PR egg hatch queued"),
+            "The ASCII egg stays as the fallback.",
+          ].join("\n")
+        : `Reason: ${command.reason ?? "hatch requires an open pull request from the PR author or a maintainer"}.`,
     ].join("\n");
   }
   if (command.intent === "implement_issue") {
@@ -1533,6 +1549,7 @@ function normalizeIntent(command: LooseRecord) {
   if (!command || command === "status") return "status";
   if (["help", "?"].includes(command)) return "help";
   if (["explain", "why"].includes(command)) return "explain";
+  if (["hatch", "hatch egg", "pr egg hatch", "hatch pr egg"].includes(command)) return "hatch";
   if (["fix ci", "fix-ci", "ci", "repair ci", "repair checks", "fix checks"].includes(command))
     return "fix_ci";
   if (["address review", "address-review", "fix review"].includes(command)) return "address_review";

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -1923,31 +1923,21 @@ function dispatchClawSweeperReview(command: LooseRecord) {
 }
 
 function dispatchPrEggHatch(command: LooseRecord) {
+  const payload = JSON.stringify({
+    event_type: "clawsweeper_hatch",
+    client_payload: {
+      target_repo: command.repo,
+      item_number: String(command.issue_number),
+      item_kind: command.target?.kind ?? "pull_request",
+      hatch_pr_egg_image: "true",
+    },
+  });
   const result = ghSpawn(
-    [
-      "workflow",
-      "run",
-      reviewWorkflow,
-      "--repo",
-      reviewRepo,
-      "-f",
-      `target_repo=${command.repo}`,
-      "-f",
-      "apply_existing=true",
-      "-f",
-      "apply_sync_comments_only=true",
-      "-f",
-      `apply_item_numbers=${command.issue_number}`,
-      "-f",
-      "apply_limit=0",
-      "-f",
-      "apply_comment_sync_min_age_days=0",
-      "-f",
-      "apply_progress_every=1",
-      "-f",
-      "hatch_pr_egg_image=true",
-    ],
-    { env: dispatchTokenEnv() },
+    ["api", `repos/${reviewRepo}/dispatches`, "--method", "POST", "--input", "-"],
+    {
+      env: dispatchTokenEnv(),
+      input: payload,
+    },
   );
   if (result.status !== 0) {
     throw new Error(
@@ -1956,7 +1946,7 @@ function dispatchPrEggHatch(command: LooseRecord) {
   }
   return {
     workflow: reviewWorkflow,
-    event: "workflow_dispatch",
+    event: "repository_dispatch",
     repo: reviewRepo,
     item_number: command.issue_number,
   };

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -445,6 +445,36 @@ function classifyCommand(command: LooseRecord): JsonValue {
       ],
     };
   }
+  if (command.intent === "hatch") {
+    if (String(issue.state ?? "").toLowerCase() !== "open") {
+      return {
+        ...next,
+        status: "ready",
+        reason: "hatch requires an open pull request",
+        actions: [{ action: "comment", status: execute ? "pending" : "planned" }],
+      };
+    }
+    if (!pull) {
+      return {
+        ...next,
+        status: "ready",
+        reason: "hatch requires a pull request",
+        actions: [{ action: "comment", status: execute ? "pending" : "planned" }],
+      };
+    }
+    return {
+      ...next,
+      status: "ready",
+      actions: [
+        {
+          action: "dispatch_hatch",
+          workflow: reviewWorkflow,
+          status: execute ? "pending" : "planned",
+        },
+        { action: "comment", status: execute ? "pending" : "planned" },
+      ],
+    };
+  }
   if (command.intent === "implement_issue") {
     if (String(issue.state ?? "").toLowerCase() !== "open") {
       return {
@@ -1214,6 +1244,7 @@ function executeCommand(command: LooseRecord) {
       (action: JsonValue) => action.action === "dispatch_repair",
     );
     const shouldDispatchClawSweeper = commandHasAction(command, "dispatch_clawsweeper");
+    const shouldDispatchHatch = commandHasAction(command, "dispatch_hatch");
     const shouldMerge = commandHasAction(command, "merge");
     const shouldApplyHumanReviewLabel = commandHasAction(command, "label");
     if (!command.trusted_bot) reactToComment(command, "eyes");
@@ -1366,6 +1397,21 @@ function executeCommand(command: LooseRecord) {
             status: "executed",
             dispatched_at: new Date().toISOString(),
             ...clawsweeper,
+          };
+        }
+        return action;
+      });
+    }
+    if (command.intent === "hatch" && command.issue_number && shouldDispatchHatch) {
+      const hatch = dispatchPrEggHatch(command);
+      dispatched = { ...dispatched, hatch };
+      command.actions = command.actions.map((action: JsonValue) => {
+        if (action.action === "dispatch_hatch") {
+          return {
+            ...action,
+            status: "executed",
+            dispatched_at: new Date().toISOString(),
+            ...hatch,
           };
         }
         return action;
@@ -1871,6 +1917,46 @@ function dispatchClawSweeperReview(command: LooseRecord) {
   return {
     workflow: reviewWorkflow,
     event: "repository_dispatch",
+    repo: reviewRepo,
+    item_number: command.issue_number,
+  };
+}
+
+function dispatchPrEggHatch(command: LooseRecord) {
+  const result = ghSpawn(
+    [
+      "workflow",
+      "run",
+      reviewWorkflow,
+      "--repo",
+      reviewRepo,
+      "-f",
+      `target_repo=${command.repo}`,
+      "-f",
+      "apply_existing=true",
+      "-f",
+      "apply_sync_comments_only=true",
+      "-f",
+      `apply_item_numbers=${command.issue_number}`,
+      "-f",
+      "apply_limit=0",
+      "-f",
+      "apply_comment_sync_min_age_days=0",
+      "-f",
+      "apply_progress_every=1",
+      "-f",
+      "hatch_pr_egg_image=true",
+    ],
+    { env: dispatchTokenEnv() },
+  );
+  if (result.status !== 0) {
+    throw new Error(
+      `failed to dispatch PR egg hatch for #${command.issue_number}: ${result.stderr || result.stdout}`,
+    );
+  }
+  return {
+    workflow: reviewWorkflow,
+    event: "workflow_dispatch",
     repo: reviewRepo,
     item_number: command.issue_number,
   };

--- a/src/repair/comment-webhook.ts
+++ b/src/repair/comment-webhook.ts
@@ -158,7 +158,7 @@ function isAuthorReadOnlyWebhookCommand({
   issue: LooseRecord;
 }) {
   const parsed = parseCommand(String(comment.body ?? ""));
-  if (parsed?.intent !== "re_review") return false;
+  if (parsed?.intent !== "re_review" && parsed?.intent !== "hatch") return false;
   const commentAuthor = normalizedLogin(asRecord(comment.user).login);
   const issueAuthor = normalizedLogin(asRecord(issue.user).login);
   return Boolean(commentAuthor && issueAuthor && commentAuthor === issueAuthor);

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -38,6 +38,7 @@ const GENERATED_PUBLISH_PATHS = [
   "jobs",
   "records",
   "results",
+  "assets",
 ] as const;
 const SKIP_CI_DIRECTIVE_PATTERN =
   /\[(?:skip ci|ci skip|no ci|skip actions|actions skip)\]|^skip-checks:\s*true$/im;

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -4535,6 +4535,91 @@ if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
   }
 });
 
+test("apply-decisions reports hatch requests with no durable item record", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const logPath = join(root, "gh.log");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+
+    const ghMock = `
+const { appendFileSync, readFileSync } = require("fs");
+const logPath = ${JSON.stringify(logPath)};
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+appendFileSync(logPath, JSON.stringify(args) + "\\n");
+const path = args[1] || "";
+if (args[0] === "api" && /\\/issues\\/84244\\/comments(?:\\?|$)/.test(path)) {
+  if (args.includes("--method") && args.includes("POST")) {
+    const input = args[args.indexOf("--input") + 1];
+    appendFileSync(logPath, JSON.stringify(["comment-body", JSON.parse(readFileSync(input, "utf8")).body]) + "\\n");
+    console.log(JSON.stringify({
+      id: 984244,
+      html_url: "https://github.com/openclaw/clawsweeper/pull/84244#issuecomment-984244"
+    }));
+  } else {
+    console.log(JSON.stringify([[]]));
+  }
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: [
+          "--sync-comments-only",
+          "--hatch-pr-egg-image",
+          "--item-numbers",
+          "84244",
+          "--processed-limit",
+          "10",
+        ],
+      });
+    });
+
+    assert.deepEqual(JSON.parse(readFileSync(reportPath, "utf8")), [
+      {
+        number: 84244,
+        action: "skipped_missing_record",
+        reason: "no current durable ClawSweeper review record; posted hatch-missing-record comment",
+      },
+    ]);
+    const calls = readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as string[]);
+    assert.ok(
+      calls.some(
+        (args) =>
+          args[0] === "api" &&
+          args[1] === "repos/openclaw/clawsweeper/issues/84244/comments" &&
+          args.includes("POST"),
+      ),
+    );
+    assert.ok(
+      calls.some(
+        (args) =>
+          args[0] === "comment-body" &&
+          /no current durable ClawSweeper review record/.test(args[1]) &&
+          /@clawsweeper re-review/.test(args[1]) &&
+          /clawsweeper-hatch-missing-record:84244/.test(args[1]),
+      ),
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("apply-decisions does not advisory-label close proposals before close gates finish", () => {
   const root = mkdtempSync(tmpPrefix);
   try {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -3043,6 +3043,10 @@ Full review comments:
   assert.match(first, /Trait: [^.]+\./);
   assert.match(
     first,
+    /Image traits: location [^;]+; accessory [^;]+; palette [^;]+; mood [^;]+; pose [^;]+; shell [^;]+; lighting [^;]+; background [^.]+\./,
+  );
+  assert.match(
+    first,
     /Share on X: \[post this hatch\]\(https:\/\/x\.com\/intent\/tweet\?text=[^)]+&url=https%3A%2F%2Fgithub\.com%2Fopenclaw%2Fopenclaw%2Fpull%2F74471%23issuecomment-987654321\)/,
   );
   assert.match(first, /Copy: My PR egg hatched a [^\n]+ in ClawSweeper\./);
@@ -3115,8 +3119,30 @@ Full review comments:
   assert.equal(first.match(/✨ Hatched: [^\n]+/)?.[0], second.match(/✨ Hatched: [^\n]+/)?.[0]);
   assert.equal(first.match(/Rarity: [^\n]+/)?.[0], second.match(/Rarity: [^\n]+/)?.[0]);
   assert.equal(first.match(/Trait: [^\n]+/)?.[0], second.match(/Trait: [^\n]+/)?.[0]);
+  assert.equal(first.match(/Image traits: [^\n]+/)?.[0], second.match(/Image traits: [^\n]+/)?.[0]);
   assert.equal(first.match(/Copy: [^\n]+/)?.[0], second.match(/Copy: [^\n]+/)?.[0]);
   assert.match(first, /same PR keeps the same creature/);
+});
+
+test("PR egg creature exposes deterministic image traits", () => {
+  const first = prEggCreatureForTest("openclaw/openclaw#74471", "openclaw/openclaw#74471@abc123");
+  const second = prEggCreatureForTest("openclaw/openclaw#74471", "openclaw/openclaw#74471@def456");
+
+  assert.deepEqual(first.imageTraits, second.imageTraits);
+  assert.deepEqual(Object.keys(first.imageTraits).sort(), [
+    "accessory",
+    "backgroundDetail",
+    "lighting",
+    "location",
+    "mood",
+    "palette",
+    "pose",
+    "texture",
+  ]);
+  for (const value of Object.values(first.imageTraits)) {
+    assert.equal(typeof value, "string");
+    assert.ok(value.length > 0);
+  }
 });
 
 test("PR egg share link falls back to PR URL before durable comment metadata exists", () => {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -59,6 +59,7 @@ import {
   prRatingLabelsForTest,
   prRatingLabelSchemeForTest,
   prEggCreatureForTest,
+  prEggImagePromptForTest,
   prEggSpriteMetricsForTest,
   prStatusLabelsForTest,
   prStatusLabelSchemeForTest,
@@ -3143,6 +3144,84 @@ test("PR egg creature exposes deterministic image traits", () => {
     assert.equal(typeof value, "string");
     assert.ok(value.length > 0);
   }
+});
+
+test("PR egg image prompt uses deterministic hatch traits with badge constraints", () => {
+  const prompt = prEggImagePromptForTest(
+    "openclaw/openclaw#74471",
+    "openclaw/openclaw#74471@abc123",
+  );
+
+  assert.match(prompt, /square collectible mascot badge/);
+  assert.match(prompt, /GitHub pull request hatch/);
+  assert.match(prompt, /Scene location:/);
+  assert.match(prompt, /Accessory:/);
+  assert.match(prompt, /Palette:/);
+  assert.match(prompt, /displayed at 256x256/);
+  assert.match(prompt, /no text, no letters, no numbers, no logos/);
+});
+
+test("hatched PR egg embeds durable image URL above ASCII fallback", () => {
+  const report = `${reportFrontMatter({
+    type: "pull_request",
+    number: "74476",
+    decision: "keep_open",
+    close_reason: "none",
+    review_status: "complete",
+    confidence: "high",
+    author: "contributor",
+    author_association: "CONTRIBUTOR",
+    labels: JSON.stringify([]),
+    work_candidate: "none",
+    pull_head_sha: "abc123def456",
+    pr_egg_image_url:
+      "https://raw.githubusercontent.com/openclaw/clawsweeper-state/state/assets/pr-eggs/openclaw-openclaw/74476.png",
+  })}
+
+## Summary
+
+Keep this clean PR open for maintainer review.
+
+## What This Changes
+
+Fixes the gateway status output.
+
+## Best Possible Solution
+
+Merge after maintainer review.
+
+${realBehaviorProofReportSection()}
+
+${prRatingReportSection({
+  overallTier: "B",
+  proofTier: "A",
+  patchTier: "B",
+  summary: "This PR has strong proof and normal merge-ready implementation quality.",
+  nextSteps: "",
+})}
+
+## Review Findings
+
+Overall correctness: patch is correct
+
+Overall confidence: 0.9
+
+Full review comments:
+
+- none
+`;
+
+  const comment = renderReviewCommentFromReport(report, "none", {
+    prStatusKind: "ready_for_maintainer_look",
+  });
+  const eggSection = comment.match(/\*\*PR egg\*\*[\s\S]*?\*\*Real behavior proof\*\*/)?.[0] ?? "";
+
+  assert.match(
+    eggSection,
+    /<img src="https:\/\/raw\.githubusercontent\.com\/openclaw\/clawsweeper-state\/state\/assets\/pr-eggs\/openclaw-openclaw\/74476\.png" width="256" height="256" alt="Hatched PR egg: [^"]+">/,
+  );
+  assert.match(eggSection, /```text\n[\s\S]+?\n```/);
+  assert.ok(eggSection.indexOf("<img ") < eggSection.indexOf("```text"));
 });
 
 test("PR egg share link falls back to PR URL before durable comment metadata exists", () => {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2976,6 +2976,10 @@ Full review comments:
   );
   assert.match(eggSection, /sufficient real-behavior proof, no blocking P0\/P1\/P2 findings/);
   assert.match(eggSection, /no security attention needed, and clean correctness/);
+  assert.match(
+    eggSection,
+    /PR author or a maintainer can comment `@clawsweeper hatch` to generate its image/,
+  );
   assert.match(eggSection, /🥚 common, 🌱 uncommon, 💎 rare, ✨ glimmer, and 🌈 legendary/);
   assert.doesNotMatch(eggSection, /🎁 Pass real behavior proof/);
   assert.doesNotMatch(eggSection, /✨ Hatched:/);
@@ -3054,6 +3058,10 @@ Full review comments:
   assert.match(
     first,
     /How to hatch it: reach `status: 👀 ready for maintainer look` or `status: 🚀 automerge armed`/,
+  );
+  assert.match(
+    first,
+    /PR author or a maintainer can comment `@clawsweeper hatch` to generate its image/,
   );
   assert.match(first, /same PR keeps the same creature/);
   assert.equal(

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -7105,6 +7105,22 @@ test("manual exact-item review dispatches avoid broad review concurrency", () =>
   );
 });
 
+test("sweep workflow requires hatch command dispatch provenance for PR egg images", () => {
+  const workflow = readFileSync(".github/workflows/sweep.yml", "utf8");
+
+  assert.match(workflow, /types: \[clawsweeper_item, clawsweeper_hatch\]/);
+  assert.doesNotMatch(workflow, /^\s+hatch_pr_egg_image:\s*$/m);
+  assert.match(
+    workflow,
+    /github\.event_name == 'repository_dispatch' && github\.event\.action == 'clawsweeper_hatch'/,
+  );
+  assert.match(
+    workflow,
+    /hatch_pr_egg_image="\$\{\{ github\.event_name == 'repository_dispatch' && github\.event\.action == 'clawsweeper_hatch' && github\.event\.client_payload\.hatch_pr_egg_image == 'true' && 'true' \|\| 'false' \}\}"/,
+  );
+  assert.doesNotMatch(workflow, /github\.event\.inputs\.hatch_pr_egg_image/);
+});
+
 test("sweep workflow publishes target-scoped state paths", () => {
   const workflow = readFileSync(".github/workflows/sweep.yml", "utf8");
 

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -140,6 +140,11 @@ test("parseCommand recognizes maintainer slash commands", () => {
     command: "re-run",
     intent: "re_review",
   });
+  assert.deepEqual(parseCommand("/clawsweeper hatch"), {
+    trigger: "slash",
+    command: "hatch",
+    intent: "hatch",
+  });
   assert.deepEqual(parseCommand("/review"), {
     trigger: "slash",
     command: "review",
@@ -766,6 +771,11 @@ test("parseCommand recognizes ClawSweeper bot mentions", () => {
     trigger: "mention",
     command: "review",
     intent: "re_review",
+  });
+  assert.deepEqual(parseCommand("@clawsweeper hatch"), {
+    trigger: "mention",
+    command: "hatch",
+    intent: "hatch",
   });
   assert.deepEqual(parseCommand("@clawsweeper implement"), {
     trigger: "mention",
@@ -1560,6 +1570,29 @@ test("renderResponse reports maintainer re-review dispatches", () => {
   assert.doesNotMatch(body, /repair worker/);
 });
 
+test("renderResponse reports PR egg hatch dispatches", () => {
+  const body = renderResponse(
+    {
+      comment_id: "462",
+      intent: "hatch",
+      issue_number: 74108,
+      target: { head_sha: "def462" },
+    },
+    {
+      hatch: {
+        workflow: "sweep.yml",
+        event: "workflow_dispatch",
+      },
+    },
+  );
+
+  assert.match(body, /PR egg hatch requested/);
+  assert.match(body, /If the egg is hatchable/);
+  assert.match(body, /Action: PR egg hatch queued/);
+  assert.match(body, /ASCII egg stays as the fallback/);
+  assert.match(body, /clawsweeper-command-status:74108:hatch:def462/);
+});
+
 test("renderResponse reports issue implementation repair dispatches", () => {
   const body = renderResponse(
     {
@@ -2219,10 +2252,17 @@ test("maintainer command authorization requires maintainer repository permission
   );
 });
 
-test("author read-only command authorization only allows own re-review", () => {
+test("author read-only command authorization allows own re-review and hatch", () => {
   assert.equal(
     isAuthorReadOnlyCommandAllowed({
       command: { intent: "re_review", author: "NickMOpen" },
+      target: { kind: "pull_request", author: "nickmopen" },
+    }),
+    true,
+  );
+  assert.equal(
+    isAuthorReadOnlyCommandAllowed({
+      command: { intent: "hatch", author: "NickMOpen" },
       target: { kind: "pull_request", author: "nickmopen" },
     }),
     true,
@@ -2236,7 +2276,7 @@ test("author read-only command authorization only allows own re-review", () => {
   );
   assert.equal(
     isAuthorReadOnlyCommandAllowed({
-      command: { intent: "re_review", author: "somebody-else" },
+      command: { intent: "hatch", author: "somebody-else" },
       target: { kind: "pull_request", author: "nickmopen" },
     }),
     false,

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -1581,7 +1581,7 @@ test("renderResponse reports PR egg hatch dispatches", () => {
     {
       hatch: {
         workflow: "sweep.yml",
-        event: "workflow_dispatch",
+        event: "repository_dispatch",
       },
     },
   );

--- a/test/repair/comment-webhook.test.ts
+++ b/test/repair/comment-webhook.test.ts
@@ -81,6 +81,33 @@ test("comment webhook accepts author read-only re-review commands", () => {
   });
 });
 
+test("comment webhook accepts author read-only hatch commands", () => {
+  const result = classifyIssueCommentWebhook({
+    event: "issue_comment",
+    payload: {
+      action: "created",
+      repository: { full_name: "openclaw/openclaw" },
+      issue: { number: 76992, user: { login: "nickmopen" } },
+      installation: { id: 123 },
+      comment: {
+        id: 457,
+        body: "@clawsweeper hatch",
+        author_association: "CONTRIBUTOR",
+        user: { login: "NickMOpen" },
+      },
+    },
+  });
+
+  assert.deepEqual(result, {
+    accepted: true,
+    targetRepo: "openclaw/openclaw",
+    itemNumber: 76992,
+    commentId: 457,
+    installationId: 123,
+    sourceAction: "created",
+  });
+});
+
 test("comment webhook rejects non-author read-only re-review commands", () => {
   const result = classifyIssueCommentWebhook({
     event: "issue_comment",

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -23,6 +23,7 @@ test("commitMessageForPublishedPaths skips CI for generated-only publishes", () 
   assert.equal(
     commitMessageForPublishedPaths("chore: update sweep records", [
       "records",
+      "assets/pr-eggs",
       "results/sweep-status",
     ]),
     "chore: update sweep records\n\n[skip ci]",


### PR DESCRIPTION
## Summary
- make hatch comment-sync requests fail visibly when the requested PR has no durable item record
- post an idempotent PR comment explaining that ClawSweeper needs a current review record before hatch image generation can run
- add regression coverage for the live `files=0` missing-record path

## Root Cause
The hatch command dispatch succeeded, but `apply-decisions --hatch-pr-egg-image --sync-comments-only --item-numbers 84244` builds its worklist only from durable `items/*.md` records. For openclaw/openclaw#84244 there was no `records/openclaw-openclaw/items/84244.md`, so the apply run saw `files=0`, processed nothing, and produced no image or explanatory comment.

## Validation
- pnpm run build
- pnpm run test:unit -- test/clawsweeper.test.ts
- pnpm run check