### PR TITLE
ci(sweep): schedule cursor-based comment sync batches

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -51,10 +51,6 @@ on:
         description: "Select the next cursor-based open PR batch for no-LLM durable comment sync"
         required: false
         default: "false"
-      apply_sync_batch_size:
-        description: "Open PRs per cursor-based comment sync batch"
-        required: false
-        default: "25"
       apply_comment_sync_min_age_days:
         description: "Minimum age in days before comment-only sync rewrites an existing review comment"
         required: false
@@ -1685,7 +1681,7 @@ jobs:
           close_delay_ms="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_close_delay_ms || '2000' }}"
           progress_every="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_progress_every || '10' }}"
           checkpoint_size="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_checkpoint_size || '50' }}"
-          sync_batch_size="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_sync_batch_size || '25' }}"
+          sync_batch_size="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_limit || '25' }}"
           sync_open_pr_batch="${{ github.event_name == 'schedule' && github.event.schedule == '6,21,36,51 * * * *' && 'true' || (github.event_name == 'workflow_dispatch' && github.event.inputs.apply_sync_open_pr_batch || 'false') }}"
           item_numbers="${{ github.event_name == 'repository_dispatch' && github.event.client_payload.item_number || github.event.inputs.apply_item_numbers || '' }}"
           sync_comments_only="${{ github.event_name == 'repository_dispatch' && github.event.action == 'clawsweeper_hatch' && 'true' || (github.event_name == 'workflow_dispatch' && github.event.inputs.apply_sync_comments_only || 'false') }}"

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1,6 +1,6 @@
 name: ClawSweeper
 
-run-name: ${{ github.event_name == 'repository_dispatch' && format('Review event item {0}#{1}', github.event.client_payload.target_repo || 'openclaw/openclaw', github.event.client_payload.item_number || '?') || (github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true' && github.event.inputs.apply_sync_comments_only == 'true') && 'Sync Codex review comments' || ((github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '3 * * * *' || github.event.schedule == '18 * * * *' || github.event.schedule == '33 * * * *' || github.event.schedule == '48 * * * *' || github.event.schedule == '8,23,38,53 * * * *'))) && 'Apply ClawSweeper closures' || ((github.event_name == 'workflow_dispatch' && github.event.inputs.audit_dashboard == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '7 */6 * * *' || github.event.schedule == '12 */6 * * *' || github.event.schedule == '17 */6 * * *'))) && 'Audit ClawSweeper state' || ((github.event_name == 'workflow_dispatch' && github.event.inputs.hot_intake == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '*/5 * * * *' || github.event.schedule == '2/5 * * * *'))) && 'Review hot ClawSweeper items' || 'Review ClawSweeper items' }}
+run-name: ${{ github.event_name == 'repository_dispatch' && format('Review event item {0}#{1}', github.event.client_payload.target_repo || 'openclaw/openclaw', github.event.client_payload.item_number || '?') || ((github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true' && github.event.inputs.apply_sync_comments_only == 'true') || (github.event_name == 'schedule' && github.event.schedule == '6,21,36,51 * * * *')) && 'Sync Codex review comments' || ((github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '3 * * * *' || github.event.schedule == '18 * * * *' || github.event.schedule == '33 * * * *' || github.event.schedule == '48 * * * *' || github.event.schedule == '8,23,38,53 * * * *'))) && 'Apply ClawSweeper closures' || ((github.event_name == 'workflow_dispatch' && github.event.inputs.audit_dashboard == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '7 */6 * * *' || github.event.schedule == '12 */6 * * *' || github.event.schedule == '17 */6 * * *'))) && 'Audit ClawSweeper state' || ((github.event_name == 'workflow_dispatch' && github.event.inputs.hot_intake == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '*/5 * * * *' || github.event.schedule == '2/5 * * * *'))) && 'Review hot ClawSweeper items' || 'Review ClawSweeper items' }}
 
 on:
   repository_dispatch:
@@ -47,6 +47,14 @@ on:
         description: "Only sync durable review comments; do not close items"
         required: false
         default: "false"
+      apply_sync_open_pr_batch:
+        description: "Select the next cursor-based open PR batch for no-LLM durable comment sync"
+        required: false
+        default: "false"
+      apply_sync_batch_size:
+        description: "Open PRs per cursor-based comment sync batch"
+        required: false
+        default: "25"
       apply_comment_sync_min_age_days:
         description: "Minimum age in days before comment-only sync rewrites an existing review comment"
         required: false
@@ -121,6 +129,7 @@ on:
     - cron: "33 * * * *"
     - cron: "48 * * * *"
     - cron: "8,23,38,53 * * * *"
+    - cron: "6,21,36,51 * * * *"
 
 permissions:
   contents: write
@@ -133,7 +142,7 @@ env:
   CLAWSWEEPER_APP_CLIENT_ID: Iv23liOECG0slfuhz093
 
 concurrency:
-  group: ${{ github.event_name == 'repository_dispatch' && format('clawsweeper-event-{0}-{1}', github.event.client_payload.target_repo || 'openclaw/openclaw', github.event.client_payload.item_number || github.run_id) || format('{0}-{1}', (github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true' && github.event.inputs.apply_sync_comments_only == 'true') && 'clawsweeper-comment-sync' || ((github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '3 * * * *' || github.event.schedule == '18 * * * *' || github.event.schedule == '33 * * * *' || github.event.schedule == '48 * * * *' || github.event.schedule == '8,23,38,53 * * * *'))) && 'clawsweeper-apply' || (github.event_name == 'workflow_dispatch' && (github.event.inputs.item_number != '' || github.event.inputs.item_numbers != '')) && format('clawsweeper-intake-exact-{0}', github.event.inputs.item_number || github.event.inputs.item_numbers) || ((github.event_name == 'workflow_dispatch' && github.event.inputs.hot_intake == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '*/5 * * * *' || github.event.schedule == '2/5 * * * *'))) && 'clawsweeper-intake-v2' || ((github.event_name == 'workflow_dispatch' && github.event.inputs.audit_dashboard == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '7 */6 * * *' || github.event.schedule == '12 */6 * * *' || github.event.schedule == '17 */6 * * *'))) && 'clawsweeper-audit' || 'clawsweeper-review', github.event.inputs.target_repo || github.event.client_payload.target_repo || ((github.event.schedule == '17 */6 * * *') && 'openclaw/clawsweeper' || ((github.event.schedule == '2/5 * * * *' || github.event.schedule == '22 * * * *' || github.event.schedule == '8,23,38,53 * * * *' || github.event.schedule == '12 */6 * * *') && 'openclaw/clawhub' || 'openclaw/openclaw'))) }}
+  group: ${{ github.event_name == 'repository_dispatch' && format('clawsweeper-event-{0}-{1}', github.event.client_payload.target_repo || 'openclaw/openclaw', github.event.client_payload.item_number || github.run_id) || format('{0}-{1}', ((github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true' && github.event.inputs.apply_sync_comments_only == 'true') || (github.event_name == 'schedule' && github.event.schedule == '6,21,36,51 * * * *')) && 'clawsweeper-comment-sync' || ((github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '3 * * * *' || github.event.schedule == '18 * * * *' || github.event.schedule == '33 * * * *' || github.event.schedule == '48 * * * *' || github.event.schedule == '8,23,38,53 * * * *'))) && 'clawsweeper-apply' || (github.event_name == 'workflow_dispatch' && (github.event.inputs.item_number != '' || github.event.inputs.item_numbers != '')) && format('clawsweeper-intake-exact-{0}', github.event.inputs.item_number || github.event.inputs.item_numbers) || ((github.event_name == 'workflow_dispatch' && github.event.inputs.hot_intake == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '*/5 * * * *' || github.event.schedule == '2/5 * * * *'))) && 'clawsweeper-intake-v2' || ((github.event_name == 'workflow_dispatch' && github.event.inputs.audit_dashboard == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '7 */6 * * *' || github.event.schedule == '12 */6 * * *' || github.event.schedule == '17 */6 * * *'))) && 'clawsweeper-audit' || 'clawsweeper-review', github.event.inputs.target_repo || github.event.client_payload.target_repo || ((github.event.schedule == '17 */6 * * *') && 'openclaw/clawsweeper' || ((github.event.schedule == '2/5 * * * *' || github.event.schedule == '22 * * * *' || github.event.schedule == '8,23,38,53 * * * *' || github.event.schedule == '12 */6 * * *') && 'openclaw/clawhub' || 'openclaw/openclaw'))) }}
   cancel-in-progress: ${{ github.event_name == 'repository_dispatch' }}
 
 jobs:
@@ -542,7 +551,7 @@ jobs:
 
   plan:
     name: Plan review candidates
-    if: ${{ github.event_name != 'repository_dispatch' && !((github.event_name == 'workflow_dispatch' && (github.event.inputs.apply_existing == 'true' || github.event.inputs.audit_dashboard == 'true')) || (github.event_name == 'schedule' && ((github.event.schedule == '3 * * * *' || github.event.schedule == '18 * * * *' || github.event.schedule == '33 * * * *' || github.event.schedule == '48 * * * *' || github.event.schedule == '8,23,38,53 * * * *') || (github.event.schedule == '7 */6 * * *' || github.event.schedule == '12 */6 * * *' || github.event.schedule == '17 */6 * * *')))) && !(github.event_name == 'schedule' && (github.event.schedule == '2/5 * * * *' || github.event.schedule == '22 * * * *') && vars.CLAWSWEEPER_ENABLE_CLAWHUB != '1') }}
+    if: ${{ github.event_name != 'repository_dispatch' && !((github.event_name == 'workflow_dispatch' && (github.event.inputs.apply_existing == 'true' || github.event.inputs.audit_dashboard == 'true')) || (github.event_name == 'schedule' && ((github.event.schedule == '3 * * * *' || github.event.schedule == '18 * * * *' || github.event.schedule == '33 * * * *' || github.event.schedule == '48 * * * *' || github.event.schedule == '8,23,38,53 * * * *' || github.event.schedule == '6,21,36,51 * * * *') || (github.event.schedule == '7 */6 * * *' || github.event.schedule == '12 */6 * * *' || github.event.schedule == '17 */6 * * *')))) && !(github.event_name == 'schedule' && (github.event.schedule == '2/5 * * * *' || github.event.schedule == '22 * * * *') && vars.CLAWSWEEPER_ENABLE_CLAWHUB != '1') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     outputs:
@@ -638,7 +647,7 @@ jobs:
           retention-days: 1
 
       - name: Publish planning-started status
-        if: ${{ !((github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '3 * * * *' || github.event.schedule == '18 * * * *' || github.event.schedule == '33 * * * *' || github.event.schedule == '48 * * * *'))) && !((github.event_name == 'workflow_dispatch' && github.event.inputs.hot_intake == 'true' && github.event.inputs.item_number == '' && github.event.inputs.item_numbers == '') || (github.event_name == 'schedule' && (github.event.schedule == '*/5 * * * *' || github.event.schedule == '2/5 * * * *'))) }}
+        if: ${{ !((github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '3 * * * *' || github.event.schedule == '18 * * * *' || github.event.schedule == '33 * * * *' || github.event.schedule == '48 * * * *' || github.event.schedule == '6,21,36,51 * * * *'))) && !((github.event_name == 'workflow_dispatch' && github.event.inputs.hot_intake == 'true' && github.event.inputs.item_number == '' && github.event.inputs.item_numbers == '') || (github.event_name == 'schedule' && (github.event.schedule == '*/5 * * * *' || github.event.schedule == '2/5 * * * *'))) }}
         continue-on-error: true
         working-directory: clawsweeper
         run: |
@@ -1068,7 +1077,7 @@ jobs:
   publish:
     name: Publish review artifacts
     needs: [plan, review]
-    if: ${{ always() && needs.plan.result == 'success' && needs.review.result != 'cancelled' && needs.plan.outputs.target_repo != '' && github.event_name != 'repository_dispatch' && !((github.event_name == 'workflow_dispatch' && (github.event.inputs.apply_existing == 'true' || github.event.inputs.audit_dashboard == 'true')) || (github.event_name == 'schedule' && ((github.event.schedule == '3 * * * *' || github.event.schedule == '18 * * * *' || github.event.schedule == '33 * * * *' || github.event.schedule == '48 * * * *' || github.event.schedule == '8,23,38,53 * * * *') || (github.event.schedule == '7 */6 * * *' || github.event.schedule == '12 */6 * * *' || github.event.schedule == '17 */6 * * *')))) }}
+    if: ${{ always() && needs.plan.result == 'success' && needs.review.result != 'cancelled' && needs.plan.outputs.target_repo != '' && github.event_name != 'repository_dispatch' && !((github.event_name == 'workflow_dispatch' && (github.event.inputs.apply_existing == 'true' || github.event.inputs.audit_dashboard == 'true')) || (github.event_name == 'schedule' && ((github.event.schedule == '3 * * * *' || github.event.schedule == '18 * * * *' || github.event.schedule == '33 * * * *' || github.event.schedule == '48 * * * *' || github.event.schedule == '8,23,38,53 * * * *' || github.event.schedule == '6,21,36,51 * * * *') || (github.event.schedule == '7 */6 * * *' || github.event.schedule == '12 */6 * * *' || github.event.schedule == '17 */6 * * *')))) }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -1594,7 +1603,7 @@ jobs:
 
   apply-existing:
     name: Apply close proposals
-    if: ${{ ((github.event_name == 'repository_dispatch' && github.event.action == 'clawsweeper_hatch') || (github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '3 * * * *' || github.event.schedule == '18 * * * *' || github.event.schedule == '33 * * * *' || github.event.schedule == '48 * * * *' || github.event.schedule == '8,23,38,53 * * * *'))) && !(github.event_name == 'repository_dispatch' && github.event.client_payload.target_repo == 'openclaw/clawhub' && vars.CLAWSWEEPER_ENABLE_CLAWHUB != '1') && !(github.event_name == 'schedule' && github.event.schedule == '8,23,38,53 * * * *' && vars.CLAWSWEEPER_ENABLE_CLAWHUB != '1') }}
+    if: ${{ ((github.event_name == 'repository_dispatch' && github.event.action == 'clawsweeper_hatch') || (github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '3 * * * *' || github.event.schedule == '18 * * * *' || github.event.schedule == '33 * * * *' || github.event.schedule == '48 * * * *' || github.event.schedule == '8,23,38,53 * * * *' || github.event.schedule == '6,21,36,51 * * * *'))) && !(github.event_name == 'repository_dispatch' && github.event.client_payload.target_repo == 'openclaw/clawhub' && vars.CLAWSWEEPER_ENABLE_CLAWHUB != '1') && !(github.event_name == 'schedule' && github.event.schedule == '8,23,38,53 * * * *' && vars.CLAWSWEEPER_ENABLE_CLAWHUB != '1') }}
     runs-on: ubuntu-latest
     timeout-minutes: 360
     steps:
@@ -1676,9 +1685,20 @@ jobs:
           close_delay_ms="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_close_delay_ms || '2000' }}"
           progress_every="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_progress_every || '10' }}"
           checkpoint_size="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_checkpoint_size || '50' }}"
+          sync_batch_size="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_sync_batch_size || '25' }}"
+          sync_open_pr_batch="${{ github.event_name == 'schedule' && github.event.schedule == '6,21,36,51 * * * *' && 'true' || (github.event_name == 'workflow_dispatch' && github.event.inputs.apply_sync_open_pr_batch || 'false') }}"
           item_numbers="${{ github.event_name == 'repository_dispatch' && github.event.client_payload.item_number || github.event.inputs.apply_item_numbers || '' }}"
           sync_comments_only="${{ github.event_name == 'repository_dispatch' && github.event.action == 'clawsweeper_hatch' && 'true' || (github.event_name == 'workflow_dispatch' && github.event.inputs.apply_sync_comments_only || 'false') }}"
           comment_sync_min_age_days="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_comment_sync_min_age_days || '7' }}"
+          target_slug="$TARGET_REPO"
+          target_slug="${target_slug//\//-}"
+          cursor_path="results/comment-sync-cursors/${target_slug}.json"
+          next_cursor=""
+          if [ "$sync_open_pr_batch" = "true" ]; then
+            sync_comments_only="true"
+            apply_kind="pull_request"
+            comment_sync_min_age_days="0"
+          fi
           sync_comments_arg=()
           if [ "$sync_comments_only" = "true" ]; then
             sync_comments_arg=(--sync-comments-only)
@@ -1709,6 +1729,46 @@ jobs:
             fi
           }
           pnpm run reconcile -- --target-repo "$TARGET_REPO" --skip-closed-at
+          if [ "$sync_open_pr_batch" = "true" ] && [ -z "$item_numbers" ]; then
+            batch_env=".artifacts/comment-sync-batch.env"
+            pnpm run --silent workflow -- comment-sync-batch \
+              --target-repo "$TARGET_REPO" \
+              --apply-kind "$apply_kind" \
+              --batch-size "$sync_batch_size" \
+              --cursor-path "$cursor_path" > "$batch_env"
+            cat "$batch_env"
+            item_numbers="$(awk -F= '$1 == "item_numbers" { print $2 }' "$batch_env")"
+            next_cursor="$(awk -F= '$1 == "next_cursor" { print $2 }' "$batch_env")"
+            batch_count="$(awk -F= '$1 == "count" { print $2 }' "$batch_env")"
+            if [ "${batch_count:-0}" -eq 0 ]; then
+              pnpm run status -- \
+                --target-repo "$TARGET_REPO" \
+                --state "Apply comments idle" \
+                --detail "No open PR review records were available for cursor-based comment sync. Cursor remains ${next_cursor:-0}." \
+                --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              publish_status "chore: update idle sweep comment sync status"
+              {
+                echo "APPLY_CLOSED_TOTAL=0"
+                echo "APPLY_LIMIT=1"
+                echo "APPLY_MIN_AGE_DAYS=$min_age_days"
+                echo "APPLY_MIN_AGE_MINUTES=$min_age_minutes"
+                echo "APPLY_KIND=$apply_kind"
+                echo "APPLY_CLOSE_REASONS=$apply_close_reasons"
+                echo "APPLY_STALE_MIN_AGE_DAYS=$stale_min_age_days"
+                echo "APPLY_CLOSE_DELAY_MS=$close_delay_ms"
+                echo "APPLY_PROGRESS_EVERY=$progress_every"
+                echo "APPLY_CHECKPOINT_SIZE=$checkpoint_size"
+                echo "APPLY_ITEM_NUMBERS="
+                echo "APPLY_TARGET_REPO=$TARGET_REPO"
+                echo "APPLY_SYNC_COMMENTS_ONLY=true"
+                echo "APPLY_SYNC_OPEN_PR_BATCH=true"
+                echo "APPLY_COMMENT_SYNC_MIN_AGE_DAYS=$comment_sync_min_age_days"
+                echo "APPLY_NOOP=true"
+              } >> "$GITHUB_ENV"
+              exit 0
+            fi
+            echo "Selected cursor-based comment sync batch: $item_numbers"
+          fi
           if [ "$sync_comments_only" != "true" ] && [ -z "$item_numbers" ]; then
             item_numbers="$(pnpm run --silent workflow -- proposed-item-numbers \
               --target-repo "$TARGET_REPO" \
@@ -1783,11 +1843,17 @@ jobs:
             cp apply-report.json ".artifacts/apply-reports/apply-report-$checkpoint.json"
             result_count="$(pnpm run --silent workflow -- count-report --report ".artifacts/apply-reports/apply-report-$checkpoint.json")"
             synced_count="$(pnpm run --silent workflow -- count-actions --report ".artifacts/apply-reports/apply-report-$checkpoint.json" --action review_comment_synced)"
-            publish_changes "chore: sync sweep review comments checkpoint $checkpoint" records assets/pr-eggs apply-report.json
+            if [ "$sync_open_pr_batch" = "true" ]; then
+              pnpm run workflow -- write-comment-sync-cursor \
+                --cursor-path "$cursor_path" \
+                --next-cursor "$next_cursor" \
+                --target-repo "$TARGET_REPO"
+            fi
+            publish_changes "chore: sync sweep review comments checkpoint $checkpoint" records assets/pr-eggs apply-report.json results/comment-sync-cursors
             pnpm run status -- \
               --target-repo "$TARGET_REPO" \
               --state "Apply comments synced" \
-              --detail "Comment-only apply checkpoint $checkpoint finished. Synced durable review comments: $synced_count. Result records: $result_count. Item numbers: ${item_numbers:-all}." \
+              --detail "Comment-only apply checkpoint $checkpoint finished. Synced durable review comments: $synced_count. Result records: $result_count. Item numbers: ${item_numbers:-all}. Next cursor: ${next_cursor:-none}." \
               --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             publish_status "chore: update sweep comment sync status"
             echo "::endgroup::"
@@ -1863,6 +1929,7 @@ jobs:
             echo "APPLY_ITEM_NUMBERS=$item_numbers"
             echo "APPLY_TARGET_REPO=$TARGET_REPO"
             echo "APPLY_SYNC_COMMENTS_ONLY=$sync_comments_only"
+            echo "APPLY_SYNC_OPEN_PR_BATCH=$sync_open_pr_batch"
             echo "APPLY_COMMENT_SYNC_MIN_AGE_DAYS=$comment_sync_min_age_days"
           } >> "$GITHUB_ENV"
 
@@ -1874,13 +1941,18 @@ jobs:
           fi
           target_slug="$APPLY_TARGET_REPO"
           target_slug="${target_slug//\//-}"
-          pnpm run repair:publish-main -- \
-            --message "chore: apply sweep decisions" \
-            --path "records/${target_slug}" \
-            --path assets/pr-eggs \
-            --path apply-report.json \
-            --path "results/sweep-status/${target_slug}.json" \
+          publish_args=(
+            --message "chore: apply sweep decisions"
+            --path "records/${target_slug}"
+            --path assets/pr-eggs
+            --path apply-report.json
+            --path "results/sweep-status/${target_slug}.json"
             --rebase-strategy apply-records
+          )
+          if [ "${APPLY_SYNC_OPEN_PR_BATCH:-false}" = "true" ]; then
+            publish_args+=(--path results/comment-sync-cursors)
+          fi
+          pnpm run repair:publish-main -- "${publish_args[@]}"
 
       - name: Continue apply sweep
         if: ${{ success() }}

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -47,10 +47,6 @@ on:
         description: "Only sync durable review comments; do not close items"
         required: false
         default: "false"
-      apply_sync_open_pr_batch:
-        description: "Select the next cursor-based open PR batch for no-LLM durable comment sync"
-        required: false
-        default: "false"
       apply_comment_sync_min_age_days:
         description: "Minimum age in days before comment-only sync rewrites an existing review comment"
         required: false
@@ -1682,8 +1678,12 @@ jobs:
           progress_every="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_progress_every || '10' }}"
           checkpoint_size="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_checkpoint_size || '50' }}"
           sync_batch_size="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_limit || '25' }}"
-          sync_open_pr_batch="${{ github.event_name == 'schedule' && github.event.schedule == '6,21,36,51 * * * *' && 'true' || (github.event_name == 'workflow_dispatch' && github.event.inputs.apply_sync_open_pr_batch || 'false') }}"
           item_numbers="${{ github.event_name == 'repository_dispatch' && github.event.client_payload.item_number || github.event.inputs.apply_item_numbers || '' }}"
+          sync_open_pr_batch="${{ github.event_name == 'schedule' && github.event.schedule == '6,21,36,51 * * * *' && 'true' || 'false' }}"
+          if [ "$item_numbers" = "__cursor__" ]; then
+            sync_open_pr_batch="true"
+            item_numbers=""
+          fi
           sync_comments_only="${{ github.event_name == 'repository_dispatch' && github.event.action == 'clawsweeper_hatch' && 'true' || (github.event_name == 'workflow_dispatch' && github.event.inputs.apply_sync_comments_only || 'false') }}"
           comment_sync_min_age_days="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_comment_sync_min_age_days || '7' }}"
           target_slug="$TARGET_REPO"

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -164,6 +164,7 @@ type ActionTaken =
   | "kept_open"
   | "proposed_close"
   | "review_comment_synced"
+  | "hatch_comment_synced"
   | "skipped_comment_auth"
   | "skipped_locked_conversation"
   | "skipped_changed_since_review"
@@ -5638,6 +5639,28 @@ function publicPrEggLine(
   ].join("\n");
 }
 
+function publicPrEggLineFromReport(
+  markdown: string,
+  statusKind?: PrStatusLabelKind | null,
+): string {
+  const options: {
+    realBehaviorProof: RealBehaviorProof;
+    prRating: PrRating;
+    reviewFindings: readonly Pick<ReviewFinding, "priority">[];
+    securityReview: Pick<SecurityReview, "status">;
+    overallCorrectness: OverallCorrectness;
+    statusKind?: PrStatusLabelKind | null;
+  } = {
+    realBehaviorProof: reportRealBehaviorProof(markdown),
+    prRating: reportPrRating(markdown),
+    reviewFindings: reportReviewFindings(markdown),
+    securityReview: reportSecurityReview(markdown),
+    overallCorrectness: reportOverallCorrectness(markdown),
+  };
+  if (statusKind !== undefined) options.statusKind = statusKind;
+  return publicPrEggLine(markdown, options);
+}
+
 function prEggImageRelativePath(markdown: string): string {
   const repo = markdownRepository(markdown);
   const profile = repositoryProfileFor(repo);
@@ -9505,6 +9528,57 @@ function ensureHatchMissingRecordComment(number: number, dryRun: boolean): strin
   return "posted hatch-missing-record comment";
 }
 
+function hatchCommentMarker(number: number): string {
+  return `<!-- clawsweeper-pr-egg-hatch:${number} -->`;
+}
+
+function renderHatchComment(
+  number: number,
+  markdown: string,
+  statusKind: PrStatusLabelKind | null | undefined,
+): string {
+  return [
+    "ClawSweeper PR egg hatch",
+    "",
+    publicPrEggLineFromReport(markdown, statusKind),
+    "",
+    hatchCommentMarker(number),
+  ].join("\n");
+}
+
+function upsertHatchComment(
+  number: number,
+  markdown: string,
+  statusKind: PrStatusLabelKind | null | undefined,
+  dryRun: boolean,
+): Record<string, unknown> | undefined {
+  const body = renderHatchComment(number, markdown, statusKind);
+  const existing = issueCommentWithMarker(number, hatchCommentMarker(number));
+  const id = commentId(existing);
+  if (dryRun) return existing;
+  const payload = writeCommentPayload(number, body);
+  if (id !== null && canPatchReviewComment(existing)) {
+    ghWithRetry([
+      "api",
+      `repos/${targetRepo()}/issues/comments/${id}`,
+      "--method",
+      "PATCH",
+      "--input",
+      payload,
+    ]);
+  } else {
+    ghWithRetry([
+      "api",
+      `repos/${targetRepo()}/issues/${number}/comments`,
+      "--method",
+      "POST",
+      "--input",
+      payload,
+    ]);
+  }
+  return issueCommentWithMarker(number, hatchCommentMarker(number));
+}
+
 function postReviewStartStatusComment(options: {
   item: Item;
   position: number;
@@ -10270,6 +10344,7 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
   const dryRun = boolArg(args.dry_run);
   const syncCommentsOnly = boolArg(args.sync_comments_only);
   const hatchPrEggImage = boolArg(args.hatch_pr_egg_image);
+  const hatchOnly = syncCommentsOnly && hatchPrEggImage;
   const commentSyncMinAgeDays = numberArg(args.comment_sync_min_age_days, 0);
   const maxRuntimeMs = numberArg(args.max_runtime_ms, 0);
   const reportPath = resolve(stringArg(args.report_path, join(ROOT, "apply-report.json")));
@@ -10432,6 +10507,38 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       results.push({ number, action: "skipped_already_closed", reason: `state is ${state}` });
       processedCount += 1;
       maybeLogProgress(`skipped comment sync #${number}: already ${state}`);
+      if (processedCount >= processedLimit) break;
+      continue;
+    }
+    if (hatchOnly) {
+      const statusKind = prEggStatusLabelKindFromReportLabels(markdown);
+      if (item.kind !== "pull_request") {
+        results.push({ number, action: "kept_open", reason: "hatch requires a pull request" });
+        processedCount += 1;
+        maybeLogProgress(`skipped PR egg image #${number}: not a pull request`);
+        if (processedCount >= processedLimit) break;
+        continue;
+      }
+      if (!dryRun && shouldEnsurePrEggImage(markdown, statusKind)) {
+        try {
+          markdown = (await ensurePrEggImage(markdown)) ?? markdown;
+        } catch (error) {
+          console.error(
+            `[apply] ${new Date().toISOString()} skipped PR egg image for #${number}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        }
+      }
+      upsertHatchComment(number, markdown, statusKind, dryRun);
+      if (!dryRun) writeFileSync(path, markdown, "utf8");
+      results.push({
+        number,
+        action: "hatch_comment_synced",
+        reason: "synced PR egg hatch comment",
+      });
+      processedCount += 1;
+      maybeLogProgress(`synced PR egg hatch comment #${number}`);
       if (processedCount >= processedLimit) break;
       continue;
     }

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -5582,6 +5582,8 @@ function publicPrEggLine(
   const identitySeed = prEggIdentitySeedFromReport(markdown);
   const visualSeed = prEggVisualSeedFromReport(markdown);
   const state = prEggStateFromStatus(options.statusKind);
+  const hatchInstruction =
+    "How to hatch it: reach `status: 👀 ready for maintainer look` or `status: 🚀 automerge armed`, then the PR author or a maintainer can comment `@clawsweeper hatch` to generate its image.";
   const explainer = [
     "",
     "<details>",
@@ -5589,8 +5591,7 @@ function publicPrEggLine(
     "",
     "- Eggs appear after the PR passes real-behavior proof. It is here for vibes, not verdicts: it does not change labels, ratings, merge decisions, or automation.",
     "- The shell reacts to review momentum: open follow-up work warms it up, re-review makes it wobble, and a clean final review lets it hatch.",
-    "- How to hatch it: reach `status: 👀 ready for maintainer look` or `status: 🚀 automerge armed`; that usually means sufficient real-behavior proof, no blocking P0/P1/P2 findings, no security attention needed, and clean correctness.",
-    "- When the egg is hatchable, the PR author or a maintainer can comment `@clawsweeper hatch` to generate its image.",
+    "- Hatchable usually means sufficient real-behavior proof, no blocking P0/P1/P2 findings, no security attention needed, and clean correctness.",
     "- The hatch is seeded from this repository and PR number, so the same PR keeps the same creature; the reviewed head SHA can only change safe visual details.",
     "- Rarity is just collectible sparkle: 🥚 common, 🌱 uncommon, 💎 rare, ✨ glimmer, and 🌈 legendary.",
     "",
@@ -5619,6 +5620,7 @@ function publicPrEggLine(
       `Rarity: ${creature.rarityLabel}.`,
       `Trait: ${creature.trait}.`,
       `Image traits: location ${creature.imageTraits.location}; accessory ${creature.imageTraits.accessory}; palette ${creature.imageTraits.palette}; mood ${creature.imageTraits.mood}; pose ${creature.imageTraits.pose}; shell ${creature.imageTraits.texture}; lighting ${creature.imageTraits.lighting}; background ${creature.imageTraits.backgroundDetail}.`,
+      hatchInstruction,
       `Share on X: ${markdownLink("post this hatch", shareUrl)}`,
       `Copy: ${creature.shareText}`,
       ...explainer,
@@ -5631,6 +5633,7 @@ function publicPrEggLine(
   };
   return [
     stateLines[state],
+    hatchInstruction,
     "",
     "```text",
     pickSeeded(PR_EGG_ART, visualSeed, state),

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -5583,7 +5583,7 @@ function publicPrEggLine(
   const visualSeed = prEggVisualSeedFromReport(markdown);
   const state = prEggStateFromStatus(options.statusKind);
   const hatchInstruction =
-    "How to hatch it: reach `status: 👀 ready for maintainer look` or `status: 🚀 automerge armed`, then the PR author or a maintainer can comment `@clawsweeper hatch` to generate its image.";
+    "How to hatch it: once this PR reaches `status: 👀 ready for maintainer look` or `status: 🚀 automerge armed`, the PR author or a maintainer can comment `@clawsweeper hatch` to turn this ASCII egg into its generated creature image.";
   const explainer = [
     "",
     "<details>",

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -69,6 +69,16 @@ function runCli(): void {
     case "proposed-item-numbers":
       process.stdout.write(proposedItemNumbers(proposedItemOptions()).join(","));
       break;
+    case "comment-sync-batch":
+      printOutput(commentSyncBatchOutput(commentSyncBatchOptions()));
+      break;
+    case "write-comment-sync-cursor":
+      writeCommentSyncCursor(
+        requiredString("cursor-path"),
+        numberArg("next-cursor", 0),
+        requiredString("target-repo"),
+      );
+      break;
     case "merge-apply-reports":
       mergeApplyReports(requiredString("dir"), requiredString("output"));
       break;
@@ -243,6 +253,13 @@ type ProposedItemOptions = {
   minAgeMinutes: number | null;
 };
 
+type CommentSyncBatchOptions = {
+  targetRepo: string;
+  applyKind: string;
+  batchSize: number;
+  cursorPath: string;
+};
+
 export function proposedItemNumbers(options: ProposedItemOptions): number[] {
   const targetSlug = options.targetRepo
     .toLowerCase()
@@ -304,6 +321,47 @@ export function proposedItemNumbers(options: ProposedItemOptions): number[] {
     .sort((left, right) => left - right);
 }
 
+export function commentSyncBatchOutput(options: CommentSyncBatchOptions): Record<string, string> {
+  const candidates = commentSyncCandidates(options.targetRepo, options.applyKind);
+  const cursor = readCommentSyncCursor(options.cursorPath);
+  const afterCursor = candidates.filter((number) => number > cursor).slice(0, options.batchSize);
+  const selected =
+    afterCursor.length > 0
+      ? afterCursor
+      : candidates.filter((number) => number > 0).slice(0, options.batchSize);
+  const nextCursor = selected.length > 0 ? selected[selected.length - 1] : cursor;
+  return {
+    item_numbers: selected.join(","),
+    count: String(selected.length),
+    cursor: String(cursor),
+    next_cursor: String(nextCursor),
+    wrapped: String(candidates.length > 0 && afterCursor.length === 0),
+  };
+}
+
+export function writeCommentSyncCursor(
+  cursorPath: string,
+  nextCursor: number,
+  targetRepo: string,
+): void {
+  if (!Number.isInteger(nextCursor) || nextCursor < 0) {
+    throw new Error("--next-cursor must be a non-negative integer");
+  }
+  fs.mkdirSync(path.dirname(cursorPath), { recursive: true });
+  fs.writeFileSync(
+    cursorPath,
+    `${JSON.stringify(
+      {
+        target_repo: targetRepo,
+        next_after_number: nextCursor,
+        updated_at: new Date().toISOString(),
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
 function proposedItemOptions(): ProposedItemOptions {
   return {
     targetRepo: requiredString("target-repo"),
@@ -313,6 +371,48 @@ function proposedItemOptions(): ProposedItemOptions {
     minAgeDays: numberArg("min-age-days", 0),
     minAgeMinutes: optionalString("min-age-minutes") ? numberArg("min-age-minutes", 0) : null,
   };
+}
+
+function commentSyncBatchOptions(): CommentSyncBatchOptions {
+  return {
+    targetRepo: requiredString("target-repo"),
+    applyKind: optionalString("apply-kind") || "pull_request",
+    batchSize: numberArg("batch-size", 25),
+    cursorPath: requiredString("cursor-path"),
+  };
+}
+
+function commentSyncCandidates(targetRepo: string, applyKind: string): number[] {
+  const targetSlug = targetRepo
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+  const itemsDir = path.join("records", targetSlug, "items");
+  if (!fs.existsSync(itemsDir)) return [];
+
+  return fs
+    .readdirSync(itemsDir)
+    .filter((name) => /(?:^|[a-z0-9-]-)\d+\.md$/.test(name))
+    .flatMap((name) => {
+      const markdown = fs.readFileSync(path.join(itemsDir, name), "utf8");
+      if (repoFor(markdown, name) !== targetRepo) return [];
+      const type = frontMatterValue(markdown, "type");
+      if (applyKind !== "all" && type !== applyKind) return [];
+      if (frontMatterValue(markdown, "review_status") !== "complete") return [];
+      if (!frontMatterValue(markdown, "item_snapshot_hash")) return [];
+      const actionTaken = frontMatterValue(markdown, "action_taken");
+      if (actionTaken !== "kept_open" && actionTaken !== "proposed_close") return [];
+      return [numberFor(name)];
+    })
+    .sort((left, right) => left - right);
+}
+
+function readCommentSyncCursor(cursorPath: string): number {
+  if (!fs.existsSync(cursorPath)) return 0;
+  const parsed: unknown = JSON.parse(fs.readFileSync(cursorPath, "utf8"));
+  if (!isJsonObject(parsed)) return 0;
+  const cursor = Number(parsed.next_after_number);
+  return Number.isInteger(cursor) && cursor >= 0 ? cursor : 0;
 }
 
 function readApplyActions(reportPath: string): ApplyAction[] {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2972,7 +2972,7 @@ Full review comments:
   assert.match(eggSection, /It is here for vibes, not verdicts/);
   assert.match(
     eggSection,
-    /\*\*PR egg\*\*\n🔥 Warming up:[^\n]+\nHow to hatch it: reach `status: 👀 ready for maintainer look` or `status: 🚀 automerge armed`, then the PR author or a maintainer can comment `@clawsweeper hatch` to generate its image\./,
+    /\*\*PR egg\*\*\n🔥 Warming up:[^\n]+\nHow to hatch it: once this PR reaches `status: 👀 ready for maintainer look` or `status: 🚀 automerge armed`, the PR author or a maintainer can comment `@clawsweeper hatch` to turn this ASCII egg into its generated creature image\./,
   );
   assert.match(
     eggSection,
@@ -2981,7 +2981,7 @@ Full review comments:
   assert.match(eggSection, /no security attention needed, and clean correctness/);
   assert.match(
     eggSection,
-    /PR author or a maintainer can comment `@clawsweeper hatch` to generate its image/,
+    /PR author or a maintainer can comment `@clawsweeper hatch` to turn this ASCII egg into its generated creature image/,
   );
   assert.match(eggSection, /🥚 common, 🌱 uncommon, 💎 rare, ✨ glimmer, and 🌈 legendary/);
   assert.doesNotMatch(eggSection, /🎁 Pass real behavior proof/);
@@ -3060,7 +3060,7 @@ Full review comments:
   assert.match(first, /Copy: My PR egg hatched a [^\n]+ in ClawSweeper\./);
   assert.match(
     first,
-    /Image traits: [^\n]+\nHow to hatch it: reach `status: 👀 ready for maintainer look` or `status: 🚀 automerge armed`, then the PR author or a maintainer can comment `@clawsweeper hatch` to generate its image\./,
+    /Image traits: [^\n]+\nHow to hatch it: once this PR reaches `status: 👀 ready for maintainer look` or `status: 🚀 automerge armed`, the PR author or a maintainer can comment `@clawsweeper hatch` to turn this ASCII egg into its generated creature image\./,
   );
   assert.match(first, /same PR keeps the same creature/);
   assert.equal(

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -7229,7 +7229,10 @@ test("sweep workflow schedules cursor-based PR comment sync batches", () => {
 
   assert.match(workflow, /cron: "6,21,36,51 \* \* \* \*"/);
   assert.match(workflow, /apply_sync_open_pr_batch:/);
-  assert.match(workflow, /apply_sync_batch_size:/);
+  assert.match(
+    workflow,
+    /sync_batch_size="\$\{\{ github\.event_name == 'workflow_dispatch' && github\.event\.inputs\.apply_limit \|\| '25' \}\}"/,
+  );
   assert.match(workflow, /comment-sync-batch/);
   assert.match(workflow, /write-comment-sync-cursor/);
   assert.match(workflow, /results\/comment-sync-cursors\/\$\{target_slug\}\.json/);

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -7228,11 +7228,12 @@ test("sweep workflow schedules cursor-based PR comment sync batches", () => {
   const workflow = readFileSync(".github/workflows/sweep.yml", "utf8");
 
   assert.match(workflow, /cron: "6,21,36,51 \* \* \* \*"/);
-  assert.match(workflow, /apply_sync_open_pr_batch:/);
+  assert.doesNotMatch(workflow, /apply_sync_open_pr_batch:/);
   assert.match(
     workflow,
     /sync_batch_size="\$\{\{ github\.event_name == 'workflow_dispatch' && github\.event\.inputs\.apply_limit \|\| '25' \}\}"/,
   );
+  assert.match(workflow, /\$item_numbers" = "__cursor__"/);
   assert.match(workflow, /comment-sync-batch/);
   assert.match(workflow, /write-comment-sync-cursor/);
   assert.match(workflow, /results\/comment-sync-cursors\/\$\{target_slug\}\.json/);

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2972,9 +2972,12 @@ Full review comments:
   assert.match(eggSection, /It is here for vibes, not verdicts/);
   assert.match(
     eggSection,
-    /How to hatch it: reach `status: 👀 ready for maintainer look` or `status: 🚀 automerge armed`/,
+    /\*\*PR egg\*\*\n🔥 Warming up:[^\n]+\nHow to hatch it: reach `status: 👀 ready for maintainer look` or `status: 🚀 automerge armed`, then the PR author or a maintainer can comment `@clawsweeper hatch` to generate its image\./,
   );
-  assert.match(eggSection, /sufficient real-behavior proof, no blocking P0\/P1\/P2 findings/);
+  assert.match(
+    eggSection,
+    /Hatchable usually means sufficient real-behavior proof, no blocking P0\/P1\/P2 findings/,
+  );
   assert.match(eggSection, /no security attention needed, and clean correctness/);
   assert.match(
     eggSection,
@@ -3057,11 +3060,7 @@ Full review comments:
   assert.match(first, /Copy: My PR egg hatched a [^\n]+ in ClawSweeper\./);
   assert.match(
     first,
-    /How to hatch it: reach `status: 👀 ready for maintainer look` or `status: 🚀 automerge armed`/,
-  );
-  assert.match(
-    first,
-    /PR author or a maintainer can comment `@clawsweeper hatch` to generate its image/,
+    /Image traits: [^\n]+\nHow to hatch it: reach `status: 👀 ready for maintainer look` or `status: 🚀 automerge armed`, then the PR author or a maintainer can comment `@clawsweeper hatch` to generate its image\./,
   );
   assert.match(first, /same PR keeps the same creature/);
   assert.equal(

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -4620,6 +4620,188 @@ if (args[0] === "api" && /\\/issues\\/84244\\/comments(?:\\?|$)/.test(path)) {
   }
 });
 
+test("hatch sync posts PR egg comment without publishing stale review changes", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const logPath = join(root, "gh.log");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    writeFileSync(
+      join(itemsDir, "74476.md"),
+      `${reportFrontMatter({
+        repository: "openclaw/clawsweeper",
+        type: "pull_request",
+        number: "74476",
+        title: "Keep hatch separate",
+        url: "https://github.com/openclaw/clawsweeper/pull/74476",
+        decision: "keep_open",
+        close_reason: "none",
+        confidence: "high",
+        action_taken: "kept_open",
+        review_status: "complete",
+        local_checkout_access: "verified",
+        author: "contributor",
+        author_association: "CONTRIBUTOR",
+        labels: JSON.stringify([
+          "proof: sufficient",
+          "rating: 🐚 platinum hermit",
+          "status: 👀 ready for maintainer look",
+        ]),
+        item_snapshot_hash: "snapshot-a",
+        item_updated_at: "2026-05-19T20:00:00Z",
+        pull_head_sha: "abc123def456",
+        pr_egg_image_url:
+          "https://raw.githubusercontent.com/openclaw/clawsweeper-state/state/assets/pr-eggs/openclaw-clawsweeper/74476.png",
+      })}
+
+## Summary
+
+This newer durable record contains a stale pending P2 finding that must not be published by hatch.
+
+## What This Changes
+
+Keeps hatch isolated.
+
+## Best Possible Solution
+
+Merge after maintainer review.
+
+${realBehaviorProofReportSection()}
+
+${prRatingReportSection()}
+
+## Review Findings
+
+Overall correctness: patch is incorrect
+
+Overall confidence: 0.84
+
+Full review comments:
+
+- **[P2] Pending stale finding:** \`src/example.ts:1\`
+  - body: This finding should not appear in the existing review comment during hatch.
+`,
+      "utf8",
+    );
+
+    const ghMock = `
+const { appendFileSync, readFileSync } = require("fs");
+const logPath = ${JSON.stringify(logPath)};
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+appendFileSync(logPath, JSON.stringify(args) + "\\n");
+const path = args[1] || "";
+if (args[0] === "api" && /\\/issues\\/74476$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 74476,
+    title: "Keep hatch separate",
+    html_url: "https://github.com/openclaw/clawsweeper/pull/74476",
+    created_at: "2026-05-19T19:00:00Z",
+    updated_at: "2026-05-19T20:00:00Z",
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "contributor" },
+    labels: [{ name: "status: 👀 ready for maintainer look" }],
+    pull_request: {}
+  }));
+} else if (args[0] === "api" && /\\/issues\\/74476\\/comments(?:\\?|$)/.test(path)) {
+  if (args.includes("--method") && args.includes("POST")) {
+    const input = args[args.indexOf("--input") + 1];
+    appendFileSync(logPath, JSON.stringify(["comment-body", JSON.parse(readFileSync(input, "utf8")).body]) + "\\n");
+    console.log(JSON.stringify({
+      id: 987476,
+      html_url: "https://github.com/openclaw/clawsweeper/pull/74476#issuecomment-987476"
+    }));
+  } else {
+    console.log(JSON.stringify([[
+      {
+        id: 444,
+        html_url: "https://github.com/openclaw/clawsweeper/pull/74476#issuecomment-444",
+        body: "Codex review: needs maintainer review before merge.\\n\\n<!-- clawsweeper-review item=74476 -->",
+        user: { login: "clawsweeper" },
+        created_at: "2026-05-19T19:55:00Z",
+        updated_at: "2026-05-19T19:55:00Z"
+      }
+    ]]));
+  }
+} else if (args[0] === "api" && /\\/issues\\/comments\\/444$/.test(path)) {
+  appendFileSync(logPath, JSON.stringify(["patched-review-comment"]) + "\\n");
+  process.exit(1);
+} else if (args[0] === "label" || args[0] === "issue") {
+  appendFileSync(logPath, JSON.stringify(["unexpected-label-or-issue-command", ...args]) + "\\n");
+  process.exit(1);
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: [
+          "--sync-comments-only",
+          "--hatch-pr-egg-image",
+          "--item-numbers",
+          "74476",
+          "--processed-limit",
+          "10",
+        ],
+      });
+    });
+
+    assert.deepEqual(JSON.parse(readFileSync(reportPath, "utf8")), [
+      {
+        number: 74476,
+        action: "hatch_comment_synced",
+        reason: "synced PR egg hatch comment",
+      },
+    ]);
+    const calls = readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as string[]);
+    assert.ok(
+      calls.some(
+        (args) =>
+          args[0] === "api" &&
+          args[1] === "repos/openclaw/clawsweeper/issues/74476/comments" &&
+          args.includes("POST"),
+      ),
+    );
+    assert.equal(
+      calls.some((args) => args[0] === "patched-review-comment"),
+      false,
+    );
+    assert.equal(
+      calls.some((args) => args[0] === "unexpected-label-or-issue-command"),
+      false,
+    );
+    const hatchBody = calls.find((args) => args[0] === "comment-body")?.[1] ?? "";
+    assert.match(hatchBody, /ClawSweeper PR egg hatch/);
+    assert.match(
+      hatchBody,
+      /<img src="https:\/\/raw\.githubusercontent\.com\/openclaw\/clawsweeper-state\/state\/assets\/pr-eggs\/openclaw-clawsweeper\/74476\.png"/,
+    );
+    assert.match(hatchBody, /```text\n[\s\S]+?\n```/);
+    assert.match(hatchBody, /clawsweeper-pr-egg-hatch:74476/);
+    assert.doesNotMatch(hatchBody, /Pending stale finding/);
+    assert.doesNotMatch(hatchBody, /Codex review: needs changes/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("apply-decisions does not advisory-label close proposals before close gates finish", () => {
   const root = mkdtempSync(tmpPrefix);
   try {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -7224,6 +7224,19 @@ test("sweep workflow publishes target-scoped state paths", () => {
   assert.doesNotMatch(workflow, /--path results\/sweep-status\s*\\/);
 });
 
+test("sweep workflow schedules cursor-based PR comment sync batches", () => {
+  const workflow = readFileSync(".github/workflows/sweep.yml", "utf8");
+
+  assert.match(workflow, /cron: "6,21,36,51 \* \* \* \*"/);
+  assert.match(workflow, /apply_sync_open_pr_batch:/);
+  assert.match(workflow, /apply_sync_batch_size:/);
+  assert.match(workflow, /comment-sync-batch/);
+  assert.match(workflow, /write-comment-sync-cursor/);
+  assert.match(workflow, /results\/comment-sync-cursors\/\$\{target_slug\}\.json/);
+  assert.match(workflow, /APPLY_SYNC_OPEN_PR_BATCH/);
+  assert.match(workflow, /github\.event\.schedule == '6,21,36,51 \* \* \* \*'/);
+});
+
 test("sweep target checkouts retry without cached references", () => {
   const workflow = readFileSync(".github/workflows/sweep.yml", "utf8");
   const checkoutBlocks =

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -8,6 +8,7 @@ import test from "node:test";
 import {
   artifactItemNumbers,
   automationLimit,
+  commentSyncBatchOutput,
   countActions,
   countCommandActions,
   countRequeueRequired,
@@ -15,6 +16,7 @@ import {
   planOutputFields,
   plannedItemNumberCsv,
   proposedItemNumbers,
+  writeCommentSyncCursor,
 } from "../../dist/repair/workflow-utils.js";
 import { AUTOMATION_LIMITS, WORKER_CONFIG, workerLimit } from "../../dist/repair/limits.js";
 
@@ -257,6 +259,74 @@ test("workflow utilities select eligible proposed close records", () => {
   assert.deepEqual(selected, [5, 12]);
 });
 
+test("workflow utilities select cursor-based PR comment sync batches", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const cursorPath = path.join(root, "results/comment-sync-cursors/openclaw-openclaw.json");
+  writeCommentSyncRecord(root, 10, "pull_request", "kept_open");
+  writeCommentSyncRecord(root, 20, "pull_request", "proposed_close");
+  writeCommentSyncRecord(root, 30, "pull_request", "kept_open");
+  writeCommentSyncRecord(root, 40, "issue", "kept_open");
+  writeCommentSyncRecord(root, 50, "pull_request", "reviewed");
+
+  assert.deepEqual(
+    withCwd(root, () =>
+      commentSyncBatchOutput({
+        targetRepo: "openclaw/openclaw",
+        applyKind: "pull_request",
+        batchSize: 2,
+        cursorPath,
+      }),
+    ),
+    {
+      item_numbers: "10,20",
+      count: "2",
+      cursor: "0",
+      next_cursor: "20",
+      wrapped: "false",
+    },
+  );
+
+  writeCommentSyncCursor(cursorPath, 20, "openclaw/openclaw");
+
+  assert.deepEqual(
+    withCwd(root, () =>
+      commentSyncBatchOutput({
+        targetRepo: "openclaw/openclaw",
+        applyKind: "pull_request",
+        batchSize: 2,
+        cursorPath,
+      }),
+    ),
+    {
+      item_numbers: "30",
+      count: "1",
+      cursor: "20",
+      next_cursor: "30",
+      wrapped: "false",
+    },
+  );
+
+  writeCommentSyncCursor(cursorPath, 99, "openclaw/openclaw");
+
+  assert.deepEqual(
+    withCwd(root, () =>
+      commentSyncBatchOutput({
+        targetRepo: "openclaw/openclaw",
+        applyKind: "pull_request",
+        batchSize: 2,
+        cursorPath,
+      }),
+    ),
+    {
+      item_numbers: "10,20",
+      count: "2",
+      cursor: "99",
+      next_cursor: "20",
+      wrapped: "true",
+    },
+  );
+});
+
 function withCwd(cwd, callback) {
   const previous = process.cwd();
   process.chdir(cwd);
@@ -270,4 +340,20 @@ function withCwd(cwd, callback) {
 function write(file, content) {
   fs.mkdirSync(path.dirname(file), { recursive: true });
   fs.writeFileSync(file, content);
+}
+
+function writeCommentSyncRecord(root, number, type, actionTaken) {
+  write(
+    path.join(root, `records/openclaw-openclaw/items/openclaw-openclaw-${number}.md`),
+    [
+      "---",
+      "repository: openclaw/openclaw",
+      `type: ${type}`,
+      "review_status: complete",
+      "item_snapshot_hash: abc123",
+      `action_taken: ${actionTaken}`,
+      "---",
+      "",
+    ].join("\n"),
+  );
 }


### PR DESCRIPTION
## Summary
- add a scheduled no-LLM comment-sync lane for openclaw/openclaw open PR review records
- select bounded cursor-based batches from state records and persist the next cursor under results/comment-sync-cursors
- refresh app credentials on each scheduled apply job by running through the existing apply workflow setup

## Validation
- pnpm run check
- Live no-LLM one-item cursor batch: https://github.com/openclaw/clawsweeper/actions/runs/26124094899
  - selected PR #12581
  - synced durable review comments: 1
  - closed items: 0
  - next cursor: 12581

## Notes
Manual cursor-batch validation reuses the existing apply_item_numbers input with the sentinel __cursor__ so the workflow stays under GitHub's 25-input limit. Scheduled runs do not need the sentinel.