### PR TITLE
[codex] Remove merge risk prefix

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -8619,10 +8619,7 @@ function publicMergeRiskLine(
   const choices = options.length
     ? mergeRiskOptionsLines(options)
     : mergeRiskFallbackOptionsLines(bestSolutionLine, nextStepLine);
-  return [
-    `Why this matters: ${risks}`,
-    choices.length ? ["", "**Maintainer options:**", ...choices].join("\n") : "",
-  ]
+  return [risks, choices.length ? ["", "**Maintainer options:**", ...choices].join("\n") : ""]
     .filter(Boolean)
     .join("\n");
 }

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -5875,6 +5875,7 @@ test("pull request keep-open review comments render repairable merge-risk option
 
   assert.match(comment, /\*\*Risk before merge\*\*/);
   assert.match(comment, new RegExp(escapeRegExpForTest(mergeRisk)));
+  assert.doesNotMatch(comment, /Why this matters:/);
   assert.match(
     comment,
     /\*\*Maintainer options:\*\*\n1\. \*\*Preserve existing behavior by default \(recommended\)\*\*/,


### PR DESCRIPTION
## Summary

Removes the hardcoded `Why this matters:` prefix from the public `Risk before merge` review section so the section starts directly with the risk text.

## Root cause

`publicMergeRiskLine` prepended the label before every merge-risk sentence, which made the rendered comment include redundant explanatory copy under the `Risk before merge` heading.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm run test:unit`
- `pnpm run format`
- `pnpm run check`