### PR TITLE
fix(review): explain label transitions

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -341,6 +341,18 @@ export interface LabelJustification {
   reason: string;
 }
 
+interface LabelTransitionJustification {
+  action: "add" | "remove";
+  label: string;
+  reason: string;
+}
+
+interface ReviewCommentRenderOptions {
+  prStatusKind?: PrStatusLabelKind | null;
+  previousLabels?: readonly string[];
+  hasOpenLinkedPullRequest?: boolean;
+}
+
 interface Decision {
   decision: DecisionKind;
   closeReason: CloseReason;
@@ -8143,15 +8155,185 @@ function labelJustificationsMarkdown(justifications: readonly LabelJustification
   return justifications.map((entry) => `- ${inlineCode(entry.label)}: ${entry.reason}`).join("\n");
 }
 
+function labelTransitionJustificationsMarkdown(
+  justifications: readonly LabelTransitionJustification[],
+): string {
+  if (!justifications.length) return "- none";
+  return justifications
+    .map((entry) => `- ${entry.action} ${inlineCode(entry.label)}: ${entry.reason}`)
+    .join("\n");
+}
+
 export function labelJustificationsMarkdownForTest(
   justifications: readonly LabelJustification[],
 ): string {
   return labelJustificationsMarkdown(justifications);
 }
 
+function isClawSweeperOwnedLabel(label: string): boolean {
+  return (
+    PRIORITY_LABEL_NAMES.has(label) ||
+    IMPACT_LABEL_NAMES.has(label) ||
+    MERGE_RISK_LABEL_NAMES.has(label) ||
+    PR_RATING_LABEL_NAMES.has(label) ||
+    PR_STATUS_LABEL_NAMES.has(label) ||
+    label === PROOF_SUFFICIENT_LABEL ||
+    PROOF_MEDIA_LABEL_NAMES.has(label) ||
+    label === TELEGRAM_VISIBLE_PROOF_LABEL ||
+    isIssueAdvisoryLabel(label)
+  );
+}
+
+function desiredClawSweeperLabelsFromPublicReport(
+  markdown: string,
+  currentLabels: readonly string[],
+  options: ReviewCommentRenderOptions = {},
+): string[] {
+  const isPullRequest = frontMatterValue(markdown, "type") === "pull_request";
+  let labels = nextPriorityLabels(currentLabels, triagePriorityFromReport(markdown));
+  labels = nextImpactLabels(labels, isPullRequest ? [] : impactLabelsFromReport(markdown));
+  if (isPullRequest) {
+    const realBehaviorProof = reportRealBehaviorProof(markdown);
+    labels = nextMergeRiskLabels(labels, mergeRiskLabelsFromReport(markdown));
+    labels = nextRealBehaviorProofSufficientLabels(labels, realBehaviorProof);
+    labels = nextRealBehaviorProofMediaLabels(labels, realBehaviorProof);
+    labels = nextPrRatingLabels(labels, reportPrRating(markdown));
+    labels = nextPrStatusLabels(
+      labels,
+      options.prStatusKind ?? prEggStatusLabelKindFromReportLabels(markdown),
+    );
+    labels = nextTelegramVisibleProofLabels(labels, reportTelegramVisibleProof(markdown));
+  } else {
+    const issueOptions: { hasOpenLinkedPullRequest?: boolean } = {};
+    if (options.hasOpenLinkedPullRequest !== undefined) {
+      issueOptions.hasOpenLinkedPullRequest = options.hasOpenLinkedPullRequest;
+    }
+    labels = nextIssueAdvisoryLabels(
+      labels,
+      issueAdvisoryLabelStateFromReport(markdown, issueOptions),
+    );
+  }
+  return labels;
+}
+
+function labelTransitionReason(
+  markdown: string,
+  label: string,
+  action: LabelTransitionJustification["action"],
+  finalJustifications: ReadonlyMap<string, string>,
+  options: ReviewCommentRenderOptions = {},
+): string {
+  const isPullRequest = frontMatterValue(markdown, "type") === "pull_request";
+  const realBehaviorProof = reportRealBehaviorProof(markdown);
+  if (action === "add") {
+    const finalReason = finalJustifications.get(label);
+    if (finalReason) return finalReason;
+  }
+  if (PRIORITY_LABEL_NAMES.has(label)) {
+    const priority = triagePriorityFromReport(markdown);
+    return action === "add"
+      ? `Current review triage priority is ${priority}.`
+      : priority === "none"
+        ? "Current review triage priority is none."
+        : `Current review triage priority is ${priority}, so this older priority label is no longer current.`;
+  }
+  if (IMPACT_LABEL_NAMES.has(label)) {
+    const labels = impactLabelsFromReport(markdown);
+    return action === "add"
+      ? "Current review selected this impact label."
+      : labels.length
+        ? `Current review impact labels are ${labels.map(inlineCode).join(", ")}.`
+        : "Current review selected no impact labels.";
+  }
+  if (MERGE_RISK_LABEL_NAMES.has(label)) {
+    const labels = mergeRiskLabelsFromReport(markdown);
+    return action === "add"
+      ? "Current PR review selected this merge-risk label."
+      : labels.length
+        ? `Current PR review merge-risk labels are ${labels.map(inlineCode).join(", ")}.`
+        : "Current PR review selected no merge-risk labels.";
+  }
+  if (PR_RATING_LABEL_NAMES.has(label)) {
+    const rating = reportPrRating(markdown);
+    const current = ratingLabelForTier(rating.overallTier).name;
+    return action === "add"
+      ? `Current PR rating is ${themedRatingName(rating.overallTier)} because proof is ${themedRatingName(
+          rating.proofTier,
+        )}, patch quality is ${themedRatingName(rating.patchTier)}, and ${sentence(rating.summary)}`
+      : `Current PR rating is ${inlineCode(current)}, so this older rating label is no longer current.`;
+  }
+  if (PR_STATUS_LABEL_NAMES.has(label)) {
+    const statusKind = options.prStatusKind ?? prEggStatusLabelKindFromReportLabels(markdown);
+    return action === "add" && statusKind
+      ? prStatusLabelForKind(statusKind).description
+      : statusKind
+        ? `Current PR status label is ${inlineCode(prStatusLabelForKind(statusKind).name)}.`
+        : "Current PR status no longer selects a status label.";
+  }
+  if (label === PROOF_SUFFICIENT_LABEL) {
+    return action === "add"
+      ? `${PROOF_SUFFICIENT_LABEL_DESCRIPTION} ${sentence(realBehaviorProof.summary)}`
+      : `Current real behavior proof status is ${realBehaviorProof.status}, not sufficient.`;
+  }
+  if (PROOF_MEDIA_LABEL_NAMES.has(label)) {
+    const mediaLabel = PROOF_MEDIA_LABELS.find(
+      (candidate) => candidate.evidenceKind === realBehaviorProof.evidenceKind,
+    );
+    return action === "add" && mediaLabel
+      ? `${mediaLabel.description} ${sentence(realBehaviorProof.summary)}`
+      : `Current real behavior proof evidence kind is ${realBehaviorProof.evidenceKind}.`;
+  }
+  if (label === TELEGRAM_VISIBLE_PROOF_LABEL) {
+    const proof = reportTelegramVisibleProof(markdown);
+    return action === "add"
+      ? `${TELEGRAM_VISIBLE_PROOF_LABEL_DESCRIPTION} ${sentence(proof.summary)}`
+      : `Current Telegram visible-proof status is ${proof.status}.`;
+  }
+  if (isIssueAdvisoryLabel(label)) {
+    return isPullRequest
+      ? "This advisory label applies only to issues, not pull requests."
+      : action === "add"
+        ? "Current issue advisory state selects this label."
+        : "Current issue advisory state no longer selects this label.";
+  }
+  return action === "add"
+    ? "Current ClawSweeper review state selects this label."
+    : "Current ClawSweeper review state no longer selects this label.";
+}
+
+function labelTransitionJustificationsFromPublicReport(
+  markdown: string,
+  finalJustifications: readonly LabelJustification[],
+  options: ReviewCommentRenderOptions = {},
+): LabelTransitionJustification[] {
+  const currentLabels = options.previousLabels ?? frontMatterStringArray(markdown, "labels");
+  const desiredLabels = desiredClawSweeperLabelsFromPublicReport(markdown, currentLabels, options);
+  const currentKeys = new Set(currentLabels.map((label) => label.toLowerCase()));
+  const desiredKeys = new Set(desiredLabels.map((label) => label.toLowerCase()));
+  const finalByLabel = new Map(finalJustifications.map((entry) => [entry.label, entry.reason]));
+  const transitions: LabelTransitionJustification[] = [];
+  for (const label of desiredLabels) {
+    if (!isClawSweeperOwnedLabel(label) || currentKeys.has(label.toLowerCase())) continue;
+    transitions.push({
+      action: "add",
+      label,
+      reason: labelTransitionReason(markdown, label, "add", finalByLabel, options),
+    });
+  }
+  for (const label of currentLabels) {
+    if (!isClawSweeperOwnedLabel(label) || desiredKeys.has(label.toLowerCase())) continue;
+    transitions.push({
+      action: "remove",
+      label,
+      reason: labelTransitionReason(markdown, label, "remove", finalByLabel, options),
+    });
+  }
+  return transitions;
+}
+
 function labelJustificationsFromPublicReport(
   markdown: string,
-  options: { prStatusKind?: PrStatusLabelKind | null } = {},
+  options: ReviewCommentRenderOptions = {},
 ): LabelJustification[] {
   const justifications = labelJustificationsFromReport(markdown, {
     triagePriority: triagePriorityFromReport(markdown),
@@ -8835,7 +9017,7 @@ function reviewWorkflowCallout(): string[] {
 
 function renderKeepOpenCommentFromReport(
   markdown: string,
-  _options: { prStatusKind?: PrStatusLabelKind | null } = {},
+  options: ReviewCommentRenderOptions = {},
 ): string {
   const evidence = reportEvidence(markdown).slice(0, 6).map(closeEvidenceLine);
   const likelyOwners = reportLikelyOwners(markdown).slice(0, 5).map(likelyOwnerLine);
@@ -8928,7 +9110,20 @@ function renderKeepOpenCommentFromReport(
     details.push("Best possible solution:", "", bestSolutionLine);
   }
   appendReviewQuestionDetails(details, reproductionAssessment, solutionAssessment);
-  const labelJustifications = labelJustificationsFromPublicReport(markdown);
+  const labelJustifications = labelJustificationsFromPublicReport(markdown, options);
+  const labelTransitionJustifications = labelTransitionJustificationsFromPublicReport(
+    markdown,
+    labelJustifications,
+    options,
+  );
+  if (labelTransitionJustifications.length) {
+    details.push(
+      "",
+      "Label changes:",
+      "",
+      labelTransitionJustificationsMarkdown(labelTransitionJustifications),
+    );
+  }
   if (labelJustifications.length) {
     details.push("", "Label justifications:", "", labelJustificationsMarkdown(labelJustifications));
   }
@@ -8976,7 +9171,7 @@ function renderKeepOpenCommentFromReport(
 export function renderReviewCommentFromReport(
   markdown: string,
   reason: CloseReason,
-  options: { prStatusKind?: PrStatusLabelKind | null } = {},
+  options: ReviewCommentRenderOptions = {},
 ): string {
   const decision = frontMatterValue(markdown, "decision");
   const body =
@@ -10554,6 +10749,7 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       continue;
     }
     const { item, state } = fetchItem(number);
+    const previousLabels = [...item.labels];
     let currentContext: ItemContext | undefined;
     let currentClosingPullRequests: unknown[] | undefined;
     let clawSweeperLabelsChanged = false;
@@ -10657,9 +10853,19 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
         );
       }
     }
-    const reviewComment = renderReviewCommentFromReport(markdown, closeReason ?? "none", {
+    const renderOptions: ReviewCommentRenderOptions = {
       prStatusKind: currentPrStatusKind,
-    });
+      previousLabels,
+    };
+    if (item.kind === "issue" && currentClosingPullRequests) {
+      renderOptions.hasOpenLinkedPullRequest =
+        openClosingPullRequestApplyReason(currentClosingPullRequests) !== null;
+    }
+    const reviewComment = renderReviewCommentFromReport(
+      markdown,
+      closeReason ?? "none",
+      renderOptions,
+    );
     const existingReviewComment = issueReviewComment(number, [
       reviewComment,
       reviewSectionValue(markdown, "closeComment"),

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -337,7 +337,7 @@ interface MergeRiskOption {
 }
 
 export interface LabelJustification {
-  label: ReviewLabelName;
+  label: string;
   reason: string;
 }
 
@@ -1842,7 +1842,7 @@ function validateLabelJustifications(
     "triagePriority" | "impactLabels" | "mergeRiskLabels" | "labelJustifications"
   >,
 ): void {
-  const selected = new Set(selectedReviewLabels(decision));
+  const selected = new Set<string>(selectedReviewLabels(decision));
   const justified = new Set(decision.labelJustifications.map((entry) => entry.label));
   const missing = [...selected].filter((label) => !justified.has(label));
   if (missing.length) {
@@ -6040,7 +6040,7 @@ function labelJustificationsFromReport(
   markdown: string,
   labels: Pick<Decision, "triagePriority" | "impactLabels" | "mergeRiskLabels">,
 ): LabelJustification[] {
-  const selected = new Set(selectedReviewLabels(labels));
+  const selected = new Set<string>(selectedReviewLabels(labels));
   const fromFrontMatter = frontMatterJsonArray(markdown, "label_justifications")
     .map((entry, index) => {
       try {
@@ -8149,12 +8149,72 @@ export function labelJustificationsMarkdownForTest(
   return labelJustificationsMarkdown(justifications);
 }
 
-function labelJustificationsFromPublicReport(markdown: string): LabelJustification[] {
-  return labelJustificationsFromReport(markdown, {
+function labelJustificationsFromPublicReport(
+  markdown: string,
+  options: { prStatusKind?: PrStatusLabelKind | null } = {},
+): LabelJustification[] {
+  const justifications = labelJustificationsFromReport(markdown, {
     triagePriority: triagePriorityFromReport(markdown),
     impactLabels: impactLabelsFromReport(markdown),
     mergeRiskLabels: mergeRiskLabelsFromReport(markdown),
   });
+  const byLabel = new Map(justifications.map((entry) => [entry.label, entry]));
+  const add = (label: string | null | undefined, reason: string): void => {
+    if (!label || byLabel.has(label)) return;
+    byLabel.set(label, { label, reason });
+  };
+  const isPullRequest = frontMatterValue(markdown, "type") === "pull_request";
+  const realBehaviorProof = reportRealBehaviorProof(markdown);
+  if (isPullRequest) {
+    const rating = reportPrRating(markdown);
+    const ratingLabel = ratingLabelForTier(rating.overallTier).name;
+    const previousRatingLabel = frontMatterStringArray(markdown, "labels").find(
+      (label) => PR_RATING_LABEL_NAMES.has(label) && label !== ratingLabel,
+    );
+    const changed = previousRatingLabel
+      ? ` Replaced prior ${inlineCode(previousRatingLabel)}.`
+      : "";
+    add(
+      ratingLabel,
+      `Current PR rating is ${themedRatingName(rating.overallTier)} because proof is ${themedRatingName(
+        rating.proofTier,
+      )}, patch quality is ${themedRatingName(rating.patchTier)}, and ${sentence(
+        rating.summary,
+      )}${changed}`,
+    );
+    const statusKind = options.prStatusKind ?? prEggStatusLabelKindFromReportLabels(markdown);
+    if (statusKind) {
+      add(
+        prStatusLabelForKind(statusKind).name,
+        `${prStatusLabelForKind(statusKind).description} ${publicRealBehaviorProofLine(
+          realBehaviorProof,
+        )}`,
+      );
+    }
+    if (realBehaviorProof.status === "sufficient") {
+      add(
+        PROOF_SUFFICIENT_LABEL,
+        `${PROOF_SUFFICIENT_LABEL_DESCRIPTION} ${sentence(realBehaviorProof.summary)}`,
+      );
+    }
+    const proofMediaLabel = PROOF_MEDIA_LABELS.find(
+      (label) => label.evidenceKind === realBehaviorProof.evidenceKind,
+    );
+    if (proofMediaLabel) {
+      add(
+        proofMediaLabel.name,
+        `${proofMediaLabel.description} ${sentence(realBehaviorProof.summary)}`,
+      );
+    }
+    const telegramProof = reportTelegramVisibleProof(markdown);
+    if (telegramProof.status === "needed") {
+      add(
+        TELEGRAM_VISIBLE_PROOF_LABEL,
+        `${TELEGRAM_VISIBLE_PROOF_LABEL_DESCRIPTION} ${sentence(telegramProof.summary)}`,
+      );
+    }
+  }
+  return [...byLabel.values()];
 }
 
 function inlineCode(value: string): string {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2764,6 +2764,15 @@ Full review comments:
   const comment = renderReviewCommentFromReport(report, "none");
 
   assert.match(comment, /<details>\n<summary>Review details<\/summary>/);
+  assert.match(comment, /Label changes:/);
+  assert.match(
+    comment,
+    /- add `P1`: The PR changes an active channel workflow affecting real users\./,
+  );
+  assert.match(
+    comment,
+    /- add `merge-risk: 🚨 compatibility`: Merging changes the default upgrade behavior for existing configs\./,
+  );
   assert.match(comment, /Label justifications:/);
   assert.match(comment, /- `P1`: The PR changes an active channel workflow affecting real users\./);
   assert.match(
@@ -2825,11 +2834,106 @@ Full review comments:
 
   const comment = renderReviewCommentFromReport(report, "none");
 
+  assert.match(comment, /Label changes:/);
+  assert.match(
+    comment,
+    /- add `rating: 🦪 silver shellfish`: Current PR rating is 🦪 silver shellfish because proof is 🦪 silver shellfish, patch quality is 🦞 diamond lobster, and PR readiness rating was derived from proof quality, review findings, security review, and reviewer confidence\./,
+  );
+  assert.match(
+    comment,
+    /- remove `rating: 🦞 diamond lobster`: Current PR rating is `rating: 🦪 silver shellfish`, so this older rating label is no longer current\./,
+  );
   assert.match(comment, /Label justifications:/);
   assert.match(
     comment,
     /- `rating: 🦪 silver shellfish`: Current PR rating is 🦪 silver shellfish because proof is 🦪 silver shellfish, patch quality is 🦞 diamond lobster, and PR readiness rating was derived from proof quality, review findings, security review, and reviewer confidence\. Replaced prior `rating: 🦞 diamond lobster`\./,
   );
+});
+
+test("public PR review details justify stale owned label removals", () => {
+  const report = `${reportFrontMatter({
+    type: "pull_request",
+    number: "84007",
+    decision: "keep_open",
+    close_reason: "none",
+    review_status: "complete",
+    confidence: "high",
+    author: "contributor",
+    author_association: "CONTRIBUTOR",
+    labels: JSON.stringify(["status: 📣 needs proof"]),
+    work_candidate: "none",
+    triage_priority: "none",
+    impact_labels: JSON.stringify([]),
+    merge_risk_labels: JSON.stringify([]),
+    label_justifications: JSON.stringify([]),
+  })}
+
+## Summary
+
+Keep this PR open for maintainer review.
+
+## What This Changes
+
+Updates an already-reviewed PR.
+
+## Best Possible Solution
+
+Add current real behavior proof before merge.
+
+${realBehaviorProofReportSection({
+  status: "insufficient",
+  evidenceKind: "none",
+  needsContributorAction: true,
+  summary: "The current review has no usable real behavior proof.",
+})}
+
+## Review Findings
+
+Overall correctness: patch is correct
+
+Overall confidence: 0.9
+
+Full review comments:
+
+- none
+`;
+
+  const comment = renderReviewCommentFromReport(report, "none", {
+    prStatusKind: "needs_proof",
+    previousLabels: [
+      "P1",
+      "impact:message-loss",
+      "merge-risk: 🚨 compatibility",
+      "proof: sufficient",
+      "proof: 🎥 video",
+      "mantis: telegram-visible-proof",
+      "status: 📣 needs proof",
+    ],
+  });
+
+  assert.match(comment, /Label changes:/);
+  assert.match(comment, /- remove `P1`: Current review triage priority is none\./);
+  assert.match(
+    comment,
+    /- remove `impact:message-loss`: Current review selected no impact labels\./,
+  );
+  assert.match(
+    comment,
+    /- remove `merge-risk: 🚨 compatibility`: Current PR review selected no merge-risk labels\./,
+  );
+  assert.match(
+    comment,
+    /- remove `proof: sufficient`: Current real behavior proof status is insufficient, not sufficient\./,
+  );
+  assert.match(
+    comment,
+    /- remove `proof: 🎥 video`: Current real behavior proof evidence kind is none\./,
+  );
+  assert.match(
+    comment,
+    /- remove `mantis: telegram-visible-proof`: Current Telegram visible-proof status is not_needed\./,
+  );
+  assert.doesNotMatch(comment, /remove `status: 📣 needs proof`/);
 });
 
 test("media proof receives a shiny proof rating boost", () => {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2776,6 +2776,62 @@ Full review comments:
   );
 });
 
+test("public PR review details justify derived rating label changes", () => {
+  const report = `${reportFrontMatter({
+    type: "pull_request",
+    number: "84006",
+    decision: "keep_open",
+    close_reason: "none",
+    review_status: "complete",
+    confidence: "high",
+    author: "contributor",
+    author_association: "CONTRIBUTOR",
+    labels: JSON.stringify(["rating: 🦞 diamond lobster"]),
+    work_candidate: "none",
+    triage_priority: "none",
+    impact_labels: JSON.stringify([]),
+    merge_risk_labels: JSON.stringify([]),
+    label_justifications: JSON.stringify([]),
+  })}
+
+## Summary
+
+Keep this PR open for maintainer review.
+
+## What This Changes
+
+Changes a PR under active review.
+
+## Best Possible Solution
+
+Add proof before merge.
+
+${realBehaviorProofReportSection({
+  status: "insufficient",
+  needsContributorAction: true,
+  summary: "The PR still needs current real-environment proof for the changed behavior.",
+})}
+
+## Review Findings
+
+Overall correctness: patch is correct
+
+Overall confidence: 0.9
+
+Full review comments:
+
+- none
+`;
+
+  const comment = renderReviewCommentFromReport(report, "none");
+
+  assert.match(comment, /Label justifications:/);
+  assert.match(
+    comment,
+    /- `rating: 🦪 silver shellfish`: Current PR rating is 🦪 silver shellfish because proof is 🦪 silver shellfish, patch quality is 🦞 diamond lobster, and PR readiness rating was derived from proof quality, review findings, security review, and reviewer confidence\. Replaced prior `rating: 🦞 diamond lobster`\./,
+  );
+});
+
 test("media proof receives a shiny proof rating boost", () => {
   const report = `${reportFrontMatter({
     type: "pull_request",


### PR DESCRIPTION
## Summary
- add review-detail label change entries for ClawSweeper-owned additions and removals
- derive transition reasons from the same label sync paths used by apply
- cover additions, rating replacement, and stale owned label removals in tests

## Validation
- pnpm run format
- pnpm run build
- pnpm run test:unit
- pnpm run check