### PR TITLE
fix(hatch): preserve exact records during reconcile

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1724,7 +1724,11 @@ jobs:
               git restore results/sweep-status || true
             fi
           }
-          pnpm run reconcile -- --target-repo "$TARGET_REPO" --skip-closed-at
+          reconcile_args=(--target-repo "$TARGET_REPO" --skip-closed-at)
+          if [ -n "$item_numbers" ]; then
+            reconcile_args+=(--item-numbers "$item_numbers")
+          fi
+          pnpm run reconcile -- "${reconcile_args[@]}"
           if [ "$sync_open_pr_batch" = "true" ] && [ -z "$item_numbers" ]; then
             batch_env=".artifacts/comment-sync-batch.env"
             pnpm run --silent workflow -- comment-sync-batch \

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -11751,6 +11751,7 @@ function reconcileFolders(options: {
   maxPages?: number;
   dryRun?: boolean;
   fetchClosedAt?: boolean;
+  preserveItemNumbers?: readonly number[];
 }): ReconcileResult {
   const maxPages = options.maxPages ?? 250;
   const dryRun = options.dryRun ?? false;
@@ -11759,6 +11760,10 @@ function reconcileFolders(options: {
   ensureDir(options.itemsDir);
   ensureDir(options.closedDir);
   const { numbers: openNumbers, pagesScanned } = fetchOpenItemNumbers(maxPages);
+  for (const number of options.preserveItemNumbers ?? []) {
+    const { state } = fetchItem(number);
+    if (state === "open") openNumbers.add(number);
+  }
   let movedToClosed = 0;
   let movedToItems = 0;
   let removedStaleClosedCopies = 0;
@@ -11830,6 +11835,7 @@ function reconcileCommand(args: Args): void {
   const maxPages = numberArg(args.max_pages, 250);
   const dryRun = boolArg(args.dry_run);
   const fetchClosedAt = !boolArg(args.skip_closed_at);
+  const preserveItemNumbers = itemNumbersArg(args.item_numbers, args.item_number);
   const result = reconcileFolders({
     itemsDir,
     closedDir,
@@ -11837,6 +11843,7 @@ function reconcileCommand(args: Args): void {
     maxPages,
     dryRun,
     fetchClosedAt,
+    preserveItemNumbers,
   });
   console.log(JSON.stringify(result, null, 2));
 }

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -4465,6 +4465,32 @@ function runApplyDecisionsForTest(options: {
   ]);
 }
 
+function runReconcileForTest(options: {
+  itemsDir: string;
+  closedDir: string;
+  plansDir: string;
+  extraArgs?: string[];
+}): string {
+  return execFileSync(
+    process.execPath,
+    [
+      "dist/clawsweeper.js",
+      "reconcile",
+      "--target-repo",
+      "openclaw/clawsweeper",
+      "--items-dir",
+      options.itemsDir,
+      "--closed-dir",
+      options.closedDir,
+      "--plans-dir",
+      options.plansDir,
+      "--skip-closed-at",
+      ...(options.extraArgs ?? []),
+    ],
+    { encoding: "utf8" },
+  );
+}
+
 test("renderWorkPlanFromReport renders dashboard plan artifacts for fresh queue_fix_pr candidates", () => {
   const plan = renderWorkPlanFromReport(workPlanCandidateReport(), {
     reportPath: "records/openclaw-clawsweeper/items/321.md",
@@ -4797,6 +4823,86 @@ if (args[0] === "api" && /\\/issues\\/84244\\/comments(?:\\?|$)/.test(path)) {
           /clawsweeper-hatch-missing-record:84244/.test(args[1]),
       ),
     );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("reconcile preserves exact open item records missed by the broad open scan", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const logPath = join(root, "gh.log");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(closedDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    writeFileSync(
+      join(itemsDir, "84347.md"),
+      `${reportFrontMatter({
+        repository: "openclaw/clawsweeper",
+        type: "pull_request",
+        number: "84347",
+        title: "Preserve exact PR",
+        url: "https://github.com/openclaw/clawsweeper/pull/84347",
+      })}
+
+## Summary
+
+Keep this open PR record.
+`,
+      "utf8",
+    );
+
+    const ghMock = `
+const { appendFileSync } = require("fs");
+const logPath = ${JSON.stringify(logPath)};
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+appendFileSync(logPath, JSON.stringify(args) + "\\n");
+const path = args[1] || "";
+if (args[0] === "api" && /\\/issues\\?state=open/.test(path)) {
+  console.log("");
+} else if (args[0] === "api" && /\\/issues\\/84347$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 84347,
+    title: "Preserve exact PR",
+    html_url: "https://github.com/openclaw/clawsweeper/pull/84347",
+    created_at: "2026-05-19T22:39:22Z",
+    updated_at: "2026-05-19T22:56:27Z",
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "contributor" },
+    labels: [],
+    pull_request: {}
+  }));
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+    withMockGh(root, ghMock, () => {
+      const output = runReconcileForTest({
+        itemsDir,
+        closedDir,
+        plansDir,
+        extraArgs: ["--item-numbers", "84347"],
+      });
+      assert.equal(JSON.parse(output).movedToClosed, 0);
+    });
+
+    assert.ok(existsSync(join(itemsDir, "84347.md")));
+    assert.equal(existsSync(join(closedDir, "84347.md")), false);
+    const calls = readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as string[]);
+    assert.ok(calls.some((args) => args[0] === "api" && args[1].endsWith("/issues/84347")));
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- pass exact hatch item numbers into the pre-apply reconcile step
- make reconcile verify and preserve those exact open records even when the broad open scan misses them
- add a regression test for PR 84347-style hatch runs

## Root Cause
The hatch workflow reconciled state before applying the hatch decision, but reconcile only trusted the broad open-item scan. For PR 84347, that scan missed the newly opened PR, so reconcile moved the durable review record out of items before apply-decisions ran. The hatch path then saw no durable record and posted the missing-record comment.

## Validation
- pnpm run check