### PR TITLE
fix(hatch): emphasize hatch command

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -3751,6 +3751,16 @@ function fetchItem(number: number): { item: Item; state: string } {
   };
 }
 
+function fetchPullRequestMerged(number: number): boolean {
+  const pull = ghJson<{ merged?: boolean; merged_at?: string | null }>([
+    "api",
+    `repos/${targetRepo()}/pulls/${number}`,
+    "--jq",
+    "{merged:.merged,merged_at:.merged_at}",
+  ]);
+  return pull.merged === true || typeof pull.merged_at === "string";
+}
+
 function fetchOpenItemCounts(): OpenItemCounts {
   const [owner, name] = targetRepo().split("/");
   if (!owner || !name) throw new Error(`Invalid target repo: ${targetRepo()}`);
@@ -5536,17 +5546,33 @@ function prStatusLabelKindFromLabels(labels: readonly string[]): PrStatusLabelKi
 }
 
 function prEggStatusLabelKindFromReportLabels(markdown: string): PrStatusLabelKind | null {
-  const fromParsedLabels = prStatusLabelKindFromLabels(frontMatterStringArray(markdown, "labels"));
+  const parsedLabels = frontMatterStringArray(markdown, "labels");
+  const fromParsedLabels = prStatusLabelKindFromLabels(parsedLabels);
   if (fromParsedLabels) return fromParsedLabels;
+  if (parsedLabels.includes(AUTOMERGE_LABEL)) return "automerge_armed";
   const rawLabels = frontMatterValue(markdown, "labels") ?? "";
+  if (rawLabels.includes(AUTOMERGE_LABEL)) return "automerge_armed";
   return PR_STATUS_LABELS.find((label) => rawLabels.includes(label.name))?.kind ?? null;
 }
 
-function prEggStateFromStatus(
+function prEggIsMergedFromReport(markdown: string): boolean {
+  return (
+    nonUnknownFrontMatter(markdown, "merged_at") !== null ||
+    nonUnknownFrontMatter(markdown, "pull_merged_at") !== null ||
+    frontMatterValue(markdown, "merged") === "true"
+  );
+}
+
+function prEggRenderStatusKind(
+  markdown: string,
   statusKind: PrStatusLabelKind | null | undefined,
-  options: { hatchableAfterClose?: boolean } = {},
-): PrEggState {
-  if (options.hatchableAfterClose) return "hatched";
+): PrStatusLabelKind | null {
+  if (statusKind) return statusKind;
+  if (prEggIsMergedFromReport(markdown)) return "ready_for_maintainer_look";
+  return null;
+}
+
+function prEggStateFromStatus(statusKind: PrStatusLabelKind | null | undefined): PrEggState {
   if (statusKind === "ready_for_maintainer_look" || statusKind === "automerge_armed") {
     return "hatched";
   }
@@ -5578,7 +5604,6 @@ function publicPrEggLine(
     securityReview: Pick<SecurityReview, "status">;
     overallCorrectness: OverallCorrectness;
     statusKind?: PrStatusLabelKind | null;
-    hatchableAfterClose?: boolean;
   },
 ): string {
   if (!prEggProofUnlocked(options.realBehaviorProof)) {
@@ -5598,14 +5623,17 @@ function publicPrEggLine(
 
   const identitySeed = prEggIdentitySeedFromReport(markdown);
   const visualSeed = prEggVisualSeedFromReport(markdown);
-  const state = prEggStateFromStatus(
-    options.statusKind,
-    options.hatchableAfterClose ? { hatchableAfterClose: true } : {},
-  );
+  const renderStatusKind = prEggRenderStatusKind(markdown, options.statusKind);
+  const state = prEggStateFromStatus(renderStatusKind);
   const hatchInstruction = [
     "### Hatch command",
     "",
-    "Comment `@clawsweeper hatch` when this PR is `status: 👀 ready for maintainer look`, `status: 🚀 automerge armed`, opted into `clawsweeper:automerge`, merged, or closed.",
+    "Comment `@clawsweeper hatch` when this PR is hatchable.",
+    "",
+    "Hatchability rules:",
+    "- Merged PRs are hatchable.",
+    "- Open PRs are hatchable when they are `status: 👀 ready for maintainer look`, `status: 🚀 automerge armed`, or labeled `clawsweeper:automerge`.",
+    "- Closed unmerged PRs are hatchable only when one of those hatchable labels is still present in the durable record.",
   ].join("\n");
   const explainer = [
     "",
@@ -5614,7 +5642,7 @@ function publicPrEggLine(
     "",
     "- Eggs appear after the PR passes real-behavior proof. It is here for vibes, not verdicts: it does not change labels, ratings, merge decisions, or automation.",
     "- The shell reacts to review momentum: open follow-up work warms it up, re-review makes it wobble, and a clean final review lets it hatch.",
-    "- Hatchable usually means sufficient real-behavior proof, no blocking P0/P1/P2 findings, no security attention needed, and clean correctness.",
+    "- Hatchability usually comes from sufficient real-behavior proof, no blocking P0/P1/P2 findings, no security attention needed, and clean correctness. A merged PR is already final, so merge makes the egg hatchable independently.",
     "- The hatch is seeded from this repository and PR number, so the same PR keeps the same creature; the reviewed head SHA can only change safe visual details.",
     "- Rarity is just collectible sparkle: 🥚 common, 🌱 uncommon, 💎 rare, ✨ glimmer, and 🌈 legendary.",
     "",
@@ -5666,7 +5694,6 @@ function publicPrEggLineFromReport(
     securityReview: Pick<SecurityReview, "status">;
     overallCorrectness: OverallCorrectness;
     statusKind?: PrStatusLabelKind | null;
-    hatchableAfterClose?: boolean;
   } = {
     realBehaviorProof: reportRealBehaviorProof(markdown),
     prRating: reportPrRating(markdown),
@@ -5675,9 +5702,6 @@ function publicPrEggLineFromReport(
     overallCorrectness: reportOverallCorrectness(markdown),
     statusKind:
       statusKind === undefined ? prEggStatusLabelKindFromReportLabels(markdown) : statusKind,
-    hatchableAfterClose:
-      frontMatterValue(markdown, "current_state") === "closed" ||
-      Boolean(frontMatterValue(markdown, "current_item_closed_at")),
   };
   return publicPrEggLine(markdown, options);
 }
@@ -5710,12 +5734,11 @@ function prEggImageAlreadyRecorded(markdown: string): boolean {
 function shouldEnsurePrEggImage(
   markdown: string,
   statusKind: PrStatusLabelKind | null | undefined,
-  options: { hatchableAfterClose?: boolean } = {},
 ): boolean {
   return (
     frontMatterValue(markdown, "type") === "pull_request" &&
     prEggProofUnlocked(reportRealBehaviorProof(markdown)) &&
-    prEggStateFromStatus(statusKind, options) === "hatched" &&
+    prEggStateFromStatus(statusKind) === "hatched" &&
     !prEggImageAlreadyRecorded(markdown)
   );
 }
@@ -10783,8 +10806,6 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       return currentContext;
     };
     if (hatchOnly) {
-      const statusKind = prEggStatusLabelKindFromReportLabels(markdown);
-      const hatchableAfterClose = state !== "open";
       if (item.kind !== "pull_request") {
         results.push({ number, action: "kept_open", reason: "hatch requires a pull request" });
         processedCount += 1;
@@ -10792,7 +10813,11 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
         if (processedCount >= processedLimit) break;
         continue;
       }
-      if (!dryRun && shouldEnsurePrEggImage(markdown, statusKind, { hatchableAfterClose })) {
+      const merged = state !== "open" && fetchPullRequestMerged(number);
+      const statusKind = merged
+        ? "ready_for_maintainer_look"
+        : prEggStatusLabelKindFromReportLabels(markdown);
+      if (!dryRun && shouldEnsurePrEggImage(markdown, statusKind)) {
         try {
           markdown = (await ensurePrEggImage(markdown)) ?? markdown;
         } catch (error) {
@@ -10803,12 +10828,7 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
           );
         }
       }
-      upsertHatchComment(
-        number,
-        markdown,
-        hatchableAfterClose ? "ready_for_maintainer_look" : statusKind,
-        dryRun,
-      );
+      upsertHatchComment(number, markdown, statusKind, dryRun);
       if (!dryRun) writeFileSync(path, markdown, "utf8");
       results.push({
         number,

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -5542,7 +5542,11 @@ function prEggStatusLabelKindFromReportLabels(markdown: string): PrStatusLabelKi
   return PR_STATUS_LABELS.find((label) => rawLabels.includes(label.name))?.kind ?? null;
 }
 
-function prEggStateFromStatus(statusKind: PrStatusLabelKind | null | undefined): PrEggState {
+function prEggStateFromStatus(
+  statusKind: PrStatusLabelKind | null | undefined,
+  options: { hatchableAfterClose?: boolean } = {},
+): PrEggState {
+  if (options.hatchableAfterClose) return "hatched";
   if (statusKind === "ready_for_maintainer_look" || statusKind === "automerge_armed") {
     return "hatched";
   }
@@ -5574,6 +5578,7 @@ function publicPrEggLine(
     securityReview: Pick<SecurityReview, "status">;
     overallCorrectness: OverallCorrectness;
     statusKind?: PrStatusLabelKind | null;
+    hatchableAfterClose?: boolean;
   },
 ): string {
   if (!prEggProofUnlocked(options.realBehaviorProof)) {
@@ -5584,7 +5589,7 @@ function publicPrEggLine(
       "<summary>Where did the egg go?</summary>",
       "",
       "- The egg game starts only after the PR passes the real-behavior proof check.",
-      "- Before that, no creature, rarity, or ASCII portrait is rolled. The treat waits for real proof.",
+      "- Before that, no creature or rarity is rolled. The treat waits for real proof.",
       "- This is still just collectible flavor: proof affects review readiness, not creature quality.",
       "",
       "</details>",
@@ -5593,9 +5598,15 @@ function publicPrEggLine(
 
   const identitySeed = prEggIdentitySeedFromReport(markdown);
   const visualSeed = prEggVisualSeedFromReport(markdown);
-  const state = prEggStateFromStatus(options.statusKind);
-  const hatchInstruction =
-    "How to hatch it: once this PR reaches `status: 👀 ready for maintainer look` or `status: 🚀 automerge armed`, the PR author or a maintainer can comment `@clawsweeper hatch` to turn this ASCII egg into its generated creature image.";
+  const state = prEggStateFromStatus(
+    options.statusKind,
+    options.hatchableAfterClose ? { hatchableAfterClose: true } : {},
+  );
+  const hatchInstruction = [
+    "### Hatch command",
+    "",
+    "Comment `@clawsweeper hatch` when this PR is `status: 👀 ready for maintainer look`, `status: 🚀 automerge armed`, opted into `clawsweeper:automerge`, merged, or closed.",
+  ].join("\n");
   const explainer = [
     "",
     "<details>",
@@ -5626,13 +5637,11 @@ function publicPrEggLine(
       `✨ Hatched: ${creature.rarityLabel} ${creature.name}`,
       "",
       ...imageBlock,
-      "```text",
-      creature.portrait,
-      "```",
+      hatchInstruction,
+      "",
       `Rarity: ${creature.rarityLabel}.`,
       `Trait: ${creature.trait}.`,
       `Image traits: location ${creature.imageTraits.location}; accessory ${creature.imageTraits.accessory}; palette ${creature.imageTraits.palette}; mood ${creature.imageTraits.mood}; pose ${creature.imageTraits.pose}; shell ${creature.imageTraits.texture}; lighting ${creature.imageTraits.lighting}; background ${creature.imageTraits.backgroundDetail}.`,
-      hatchInstruction,
       `Share on X: ${markdownLink("post this hatch", shareUrl)}`,
       `Copy: ${creature.shareText}`,
       ...explainer,
@@ -5643,15 +5652,7 @@ function publicPrEggLine(
     warming: "🔥 Warming up: proof, findings, or rank-up moves are still in progress.",
     wobbling: "🔁 Wobbling: a re-review loop is active, so the shell is rattling.",
   };
-  return [
-    stateLines[state],
-    hatchInstruction,
-    "",
-    "```text",
-    pickSeeded(PR_EGG_ART, visualSeed, state),
-    "```",
-    ...explainer,
-  ].join("\n");
+  return [stateLines[state], "", hatchInstruction, ...explainer].join("\n");
 }
 
 function publicPrEggLineFromReport(
@@ -5665,6 +5666,7 @@ function publicPrEggLineFromReport(
     securityReview: Pick<SecurityReview, "status">;
     overallCorrectness: OverallCorrectness;
     statusKind?: PrStatusLabelKind | null;
+    hatchableAfterClose?: boolean;
   } = {
     realBehaviorProof: reportRealBehaviorProof(markdown),
     prRating: reportPrRating(markdown),
@@ -5673,6 +5675,9 @@ function publicPrEggLineFromReport(
     overallCorrectness: reportOverallCorrectness(markdown),
     statusKind:
       statusKind === undefined ? prEggStatusLabelKindFromReportLabels(markdown) : statusKind,
+    hatchableAfterClose:
+      frontMatterValue(markdown, "current_state") === "closed" ||
+      Boolean(frontMatterValue(markdown, "current_item_closed_at")),
   };
   return publicPrEggLine(markdown, options);
 }
@@ -5705,11 +5710,12 @@ function prEggImageAlreadyRecorded(markdown: string): boolean {
 function shouldEnsurePrEggImage(
   markdown: string,
   statusKind: PrStatusLabelKind | null | undefined,
+  options: { hatchableAfterClose?: boolean } = {},
 ): boolean {
   return (
     frontMatterValue(markdown, "type") === "pull_request" &&
     prEggProofUnlocked(reportRealBehaviorProof(markdown)) &&
-    prEggStateFromStatus(statusKind) === "hatched" &&
+    prEggStateFromStatus(statusKind, options) === "hatched" &&
     !prEggImageAlreadyRecorded(markdown)
   );
 }
@@ -6412,12 +6418,6 @@ function hasShinyProof(proof: Pick<RealBehaviorProof, "status" | "evidenceKind">
       proof.evidenceKind === "linked_artifact")
   );
 }
-
-const PR_EGG_ART = [
-  "       .-.\n     .'   '.\n    /       \\\n   |         |\n    \\       /\n     '.___.'",
-  "       .-.\n    .-'   '-.\n   /  .- -.  \\\n  |  /     \\  |\n   \\  '._.'  /\n    '-.___.-'",
-  "       .-.\n    .-'   '-.\n   /  _   _  \\\n  |  (_) (_)  |\n   \\   ___   /\n    '.___._.'",
-];
 
 const PR_EGG_RARITIES: { rarity: PrEggRarity; label: string; cutoff: number }[] = [
   { rarity: "common", label: "🥚 common", cutoff: 7000 },
@@ -10648,31 +10648,44 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       if (processedCount >= processedLimit) break;
     }
   };
-  if (!existsSync(itemsDir)) {
-    console.log("No items directory.");
-    recordMissingHatchResults(new Set());
-    ensureDir(dirname(reportPath));
-    writeFileSync(reportPath, JSON.stringify(results, null, 2), "utf8");
-    return;
-  }
-  const fileEntries = readdirSync(itemsDir)
-    .filter((name) => parseReportFileName(name) !== null)
-    .filter((name) => {
-      const markdown = readFileSync(join(itemsDir, name), "utf8");
-      if (!isMarkdownForActiveRepo(markdown, name)) return false;
-      return (
-        requestedItemNumberSet.size === 0 || requestedItemNumberSet.has(numberForMarkdownFile(name))
-      );
+  const reportEntriesForDir = (
+    dir: string,
+    location: "items" | "closed",
+  ): Array<{
+    name: string;
+    number: number;
+    path: string;
+    location: "items" | "closed";
+    priority: number;
+    applyCheckedAt: number;
+  }> => {
+    if (!existsSync(dir)) return [];
+    return readdirSync(dir)
+      .filter((name) => parseReportFileName(name) !== null)
+      .filter((name) => {
+        const markdown = readFileSync(join(dir, name), "utf8");
+        if (!isMarkdownForActiveRepo(markdown, name)) return false;
+        return (
+          requestedItemNumberSet.size === 0 ||
+          requestedItemNumberSet.has(numberForMarkdownFile(name))
+        );
+      })
+      .map((name) => ({
+        name,
+        number: numberForMarkdownFile(name),
+        path: join(dir, name),
+        location,
+        ...applyQueueSortFields(readFileSync(join(dir, name), "utf8"), syncCommentsOnly, applyKind),
+      }));
+  };
+  const fileEntries = [
+    ...reportEntriesForDir(itemsDir, "items"),
+    ...(hatchOnly ? reportEntriesForDir(closedDir, "closed") : []),
+  ]
+    .filter((entry, index, entries) => {
+      if (entry.location === "items") return true;
+      return entries.findIndex((candidate) => candidate.number === entry.number) === index;
     })
-    .map((name) => ({
-      name,
-      number: numberForMarkdownFile(name),
-      ...applyQueueSortFields(
-        readFileSync(join(itemsDir, name), "utf8"),
-        syncCommentsOnly,
-        applyKind,
-      ),
-    }))
     .sort(
       (left, right) =>
         left.priority - right.priority ||
@@ -10680,6 +10693,13 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
         left.number - right.number,
     );
   const files = fileEntries.map((entry) => entry.name);
+  if (fileEntries.length === 0 && !existsSync(itemsDir)) {
+    console.log("No items directory.");
+    recordMissingHatchResults(new Set());
+    ensureDir(dirname(reportPath));
+    writeFileSync(reportPath, JSON.stringify(results, null, 2), "utf8");
+    return;
+  }
   logProgress(
     `starting apply: files=${files.length} dry_run=${dryRun} apply_kind=${applyKind} min_age=${minAgeDescription} apply_close_reasons=${closeReasonFilterText(applyCloseReasons)} stale_min_age_days=${staleMinAgeDays} close_delay_ms=${closeDelayMs} sync_comments_only=${syncCommentsOnly} comment_sync_min_age_days=${commentSyncMinAgeDays} max_runtime_ms=${maxRuntimeMs} item_numbers=${requestedItemNumbers.join(",") || "all"}`,
   );
@@ -10689,7 +10709,12 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
     writeFileSync(reportPath, JSON.stringify(results, null, 2), "utf8");
     return;
   }
-  for (const file of files) {
+  for (const entry of fileEntries) {
+    const file = entry.name;
+    const path = entry.path;
+    if (entry.location === "closed" && !hatchOnly) continue;
+    if (entry.location === "closed" && requestedItemNumberSet.size === 0) continue;
+    if (entry.location === "closed" && !requestedItemNumberSet.has(entry.number)) continue;
     if (runtimeBudgetExceeded(startedAtMs, maxRuntimeMs, Date.now())) {
       results.push({
         number: 0,
@@ -10699,9 +10724,8 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       logProgress(`stopping apply: max runtime ${maxRuntimeMs}ms reached`);
       break;
     }
-    const path = join(itemsDir, file);
     let markdown = readFileSync(path, "utf8");
-    const repo = markdownRepository(markdown, join(itemsDir, file));
+    const repo = markdownRepository(markdown, path);
     const number = numberForMarkdownFile(file);
     const decision = frontMatterValue(markdown, "decision");
     const confidence = frontMatterValue(markdown, "confidence");
@@ -10735,6 +10759,9 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       continue;
     }
     if (!storedHash || (action !== "proposed_close" && action !== "kept_open")) {
+      if (!hatchOnly) continue;
+    }
+    if (!hatchOnly && !storedHash) {
       continue;
     }
     const isCloseProposal =
@@ -10742,7 +10769,7 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       confidence === "high" &&
       Boolean(closeReason && ALLOWED_REASONS.has(closeReason)) &&
       action === "proposed_close";
-    if (decision === "close" && !isCloseProposal) {
+    if (decision === "close" && !isCloseProposal && !hatchOnly) {
       continue;
     }
     const { item, state } = fetchItem(number);
@@ -10755,15 +10782,9 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       currentContext ??= collectItemContext(item, { fullTimelineForRelations: true });
       return currentContext;
     };
-    if (syncCommentsOnly && state !== "open") {
-      results.push({ number, action: "skipped_already_closed", reason: `state is ${state}` });
-      processedCount += 1;
-      maybeLogProgress(`skipped comment sync #${number}: already ${state}`);
-      if (processedCount >= processedLimit) break;
-      continue;
-    }
     if (hatchOnly) {
       const statusKind = prEggStatusLabelKindFromReportLabels(markdown);
+      const hatchableAfterClose = state !== "open";
       if (item.kind !== "pull_request") {
         results.push({ number, action: "kept_open", reason: "hatch requires a pull request" });
         processedCount += 1;
@@ -10771,7 +10792,7 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
         if (processedCount >= processedLimit) break;
         continue;
       }
-      if (!dryRun && shouldEnsurePrEggImage(markdown, statusKind)) {
+      if (!dryRun && shouldEnsurePrEggImage(markdown, statusKind, { hatchableAfterClose })) {
         try {
           markdown = (await ensurePrEggImage(markdown)) ?? markdown;
         } catch (error) {
@@ -10782,7 +10803,12 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
           );
         }
       }
-      upsertHatchComment(number, markdown, statusKind, dryRun);
+      upsertHatchComment(
+        number,
+        markdown,
+        hatchableAfterClose ? "ready_for_maintainer_look" : statusKind,
+        dryRun,
+      );
       if (!dryRun) writeFileSync(path, markdown, "utf8");
       results.push({
         number,
@@ -10791,6 +10817,13 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       });
       processedCount += 1;
       maybeLogProgress(`synced PR egg hatch comment #${number}`);
+      if (processedCount >= processedLimit) break;
+      continue;
+    }
+    if (syncCommentsOnly && state !== "open") {
+      results.push({ number, action: "skipped_already_closed", reason: `state is ${state}` });
+      processedCount += 1;
+      maybeLogProgress(`skipped comment sync #${number}: already ${state}`);
       if (processedCount >= processedLimit) break;
       continue;
     }

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -3138,11 +3138,11 @@ Full review comments:
   assert.match(eggComment, /It is here for vibes, not verdicts/);
   assert.match(
     eggComment,
-    /🔥 Warming up:[\s\S]+### Hatch command[\s\S]+Comment `@clawsweeper hatch` when this PR is `status: 👀 ready for maintainer look`, `status: 🚀 automerge armed`, opted into `clawsweeper:automerge`, merged, or closed\./,
+    /🔥 Warming up:[\s\S]+### Hatch command[\s\S]+Hatchability rules:[\s\S]+- Merged PRs are hatchable\.[\s\S]+- Open PRs are hatchable when they are `status: 👀 ready for maintainer look`, `status: 🚀 automerge armed`, or labeled `clawsweeper:automerge`\.[\s\S]+- Closed unmerged PRs are hatchable only when one of those hatchable labels is still present in the durable record\./,
   );
   assert.match(
     eggComment,
-    /Hatchable usually means sufficient real-behavior proof, no blocking P0\/P1\/P2 findings/,
+    /Hatchability usually comes from sufficient real-behavior proof, no blocking P0\/P1\/P2 findings/,
   );
   assert.match(eggComment, /no security attention needed, and clean correctness/);
   assert.match(eggComment, /Comment `@clawsweeper hatch` when this PR is/);
@@ -3225,7 +3225,7 @@ Full review comments:
   assert.match(first, /Copy: My PR egg hatched a [^\n]+ in ClawSweeper\./);
   assert.match(
     first,
-    /### Hatch command[\s\S]+Comment `@clawsweeper hatch` when this PR is `status: 👀 ready for maintainer look`, `status: 🚀 automerge armed`, opted into `clawsweeper:automerge`, merged, or closed\.[\s\S]+Rarity:/,
+    /### Hatch command[\s\S]+Merged PRs are hatchable\.[\s\S]+Closed unmerged PRs are hatchable only when one of those hatchable labels is still present in the durable record\.[\s\S]+Rarity:/,
   );
   assert.match(first, /same PR keeps the same creature/);
   assert.equal(first, second);
@@ -5089,7 +5089,7 @@ if (args[0] === "api" && /\\/issues\\/74476$/.test(path)) {
   }
 });
 
-test("hatch sync can use archived closed PR records", () => {
+test("hatch sync can use archived merged PR records without hatchable labels", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
     const itemsDir = join(root, "items");
@@ -5177,6 +5177,11 @@ if (args[0] === "api" && /\\/issues\\/74479$/.test(path)) {
   } else {
     console.log(JSON.stringify([[]]));
   }
+} else if (args[0] === "api" && /\\/pulls\\/74479$/.test(path)) {
+  console.log(JSON.stringify({
+    merged: true,
+    merged_at: "2026-05-19T21:00:00Z"
+  }));
 } else {
   console.error("unexpected gh args", JSON.stringify(args));
   process.exit(1);
@@ -5214,12 +5219,62 @@ if (args[0] === "api" && /\\/issues\\/74479$/.test(path)) {
     const hatchBody = calls.find((args) => args[0] === "comment-body")?.[1] ?? "";
     assert.match(hatchBody, /✨ Hatched: [^\n]+/);
     assert.match(hatchBody, /### Hatch command/);
-    assert.match(hatchBody, /merged, or closed/);
+    assert.match(hatchBody, /Merged PRs are hatchable/);
+    assert.match(
+      hatchBody,
+      /Closed unmerged PRs are hatchable only when one of those hatchable labels/,
+    );
     assert.doesNotMatch(hatchBody, /```text/);
     assert.match(hatchBody, /clawsweeper-pr-egg-hatch:74479/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+test("closed PR egg hatch still requires hatchable durable labels", () => {
+  const report = `${reportFrontMatter({
+    repository: "openclaw/clawsweeper",
+    type: "pull_request",
+    number: "74480",
+    title: "Closed without hatch label",
+    url: "https://github.com/openclaw/clawsweeper/pull/74480",
+    decision: "keep_open",
+    close_reason: "none",
+    confidence: "high",
+    action_taken: "kept_open",
+    review_status: "complete",
+    local_checkout_access: "verified",
+    author: "contributor",
+    author_association: "CONTRIBUTOR",
+    labels: JSON.stringify(["proof: sufficient"]),
+    current_state: "closed",
+    current_item_closed_at: "2026-05-19T21:00:00Z",
+    pull_head_sha: "abc123def456",
+  })}
+
+## Summary
+
+This PR closed after review.
+
+${realBehaviorProofReportSection()}
+
+${prRatingReportSection()}
+
+## Review Findings
+
+Overall correctness: patch is correct
+
+Overall confidence: 0.95
+
+Full review comments:
+
+- none
+`;
+
+  const eggComment = renderPrEggCommentForTest(74480, report);
+  assert.match(eggComment, /🥚 Incubating:/);
+  assert.match(eggComment, /clawsweeper:automerge/);
+  assert.doesNotMatch(eggComment, /✨ Hatched:/);
 });
 
 test("normal PR comment sync moves PR egg into a separate marker-backed comment", () => {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -3061,7 +3061,7 @@ Full review comments:
   assert.match(eggComment, /🎁 Pass real behavior proof/);
   assert.match(eggComment, /wake the egg and unlock a hatchable treat/);
   assert.match(eggComment, /<summary>Where did the egg go\?<\/summary>/);
-  assert.match(eggComment, /no creature, rarity, or ASCII portrait is rolled/);
+  assert.match(eggComment, /no creature or rarity is rolled/);
   assert.doesNotMatch(eggComment, /```text/);
   assert.doesNotMatch(eggComment, /🔥 Warming up:/);
   assert.doesNotMatch(eggComment, /✨ Hatched:/);
@@ -3132,23 +3132,20 @@ Full review comments:
   assert.doesNotMatch(comment, /\*\*PR egg\*\*/);
   assert.match(eggComment, /ClawSweeper PR egg/);
   assert.match(eggComment, /🔥 Warming up:/);
-  assert.match(eggComment, /```text\n[\s\S]+?\n```/);
+  assert.doesNotMatch(eggComment, /```text/);
   assert.match(eggComment, /<summary>What is this egg doing here\?<\/summary>/);
   assert.match(eggComment, /Eggs appear after the PR passes real-behavior proof/);
   assert.match(eggComment, /It is here for vibes, not verdicts/);
   assert.match(
     eggComment,
-    /🔥 Warming up:[^\n]+\nHow to hatch it: once this PR reaches `status: 👀 ready for maintainer look` or `status: 🚀 automerge armed`, the PR author or a maintainer can comment `@clawsweeper hatch` to turn this ASCII egg into its generated creature image\./,
+    /🔥 Warming up:[\s\S]+### Hatch command[\s\S]+Comment `@clawsweeper hatch` when this PR is `status: 👀 ready for maintainer look`, `status: 🚀 automerge armed`, opted into `clawsweeper:automerge`, merged, or closed\./,
   );
   assert.match(
     eggComment,
     /Hatchable usually means sufficient real-behavior proof, no blocking P0\/P1\/P2 findings/,
   );
   assert.match(eggComment, /no security attention needed, and clean correctness/);
-  assert.match(
-    eggComment,
-    /PR author or a maintainer can comment `@clawsweeper hatch` to turn this ASCII egg into its generated creature image/,
-  );
+  assert.match(eggComment, /Comment `@clawsweeper hatch` when this PR is/);
   assert.match(eggComment, /🥚 common, 🌱 uncommon, 💎 rare, ✨ glimmer, and 🌈 legendary/);
   assert.doesNotMatch(eggComment, /🎁 Pass real behavior proof/);
   assert.doesNotMatch(eggComment, /✨ Hatched:/);
@@ -3213,7 +3210,8 @@ Full review comments:
   assert.doesNotMatch(reviewComment, /\*\*PR egg\*\*/);
   assert.match(first, /ClawSweeper PR egg/);
   assert.match(first, /✨ Hatched: [^\n]+/);
-  assert.match(first, /```text\n[\s\S]+?\n```/);
+  assert.doesNotMatch(first, /```text/);
+  assert.match(first, /### Hatch command/);
   assert.match(first, /Rarity: [^\n]+\./);
   assert.match(first, /Trait: [^.]+\./);
   assert.match(
@@ -3227,7 +3225,7 @@ Full review comments:
   assert.match(first, /Copy: My PR egg hatched a [^\n]+ in ClawSweeper\./);
   assert.match(
     first,
-    /Image traits: [^\n]+\nHow to hatch it: once this PR reaches `status: 👀 ready for maintainer look` or `status: 🚀 automerge armed`, the PR author or a maintainer can comment `@clawsweeper hatch` to turn this ASCII egg into its generated creature image\./,
+    /### Hatch command[\s\S]+Comment `@clawsweeper hatch` when this PR is `status: 👀 ready for maintainer look`, `status: 🚀 automerge armed`, opted into `clawsweeper:automerge`, merged, or closed\.[\s\S]+Rarity:/,
   );
   assert.match(first, /same PR keeps the same creature/);
   assert.equal(first, second);
@@ -3336,7 +3334,7 @@ test("PR egg image prompt uses deterministic hatch traits with badge constraints
   assert.match(prompt, /no text, no letters, no numbers, no logos/);
 });
 
-test("hatched PR egg embeds durable image URL above ASCII fallback", () => {
+test("hatched PR egg embeds durable image URL above hatch metadata", () => {
   const report = `${reportFrontMatter({
     type: "pull_request",
     number: "74476",
@@ -3396,8 +3394,8 @@ Full review comments:
     eggComment,
     /<img src="https:\/\/raw\.githubusercontent\.com\/openclaw\/clawsweeper-state\/state\/assets\/pr-eggs\/openclaw-openclaw\/74476\.png" width="256" height="256" alt="Hatched PR egg: [^"]+">/,
   );
-  assert.match(eggComment, /```text\n[\s\S]+?\n```/);
-  assert.ok(eggComment.indexOf("<img ") < eggComment.indexOf("```text"));
+  assert.doesNotMatch(eggComment, /```text/);
+  assert.ok(eggComment.indexOf("<img ") < eggComment.indexOf("### Hatch command"));
 });
 
 test("PR egg share link falls back to PR URL before durable comment metadata exists", () => {
@@ -5081,10 +5079,144 @@ if (args[0] === "api" && /\\/issues\\/74476$/.test(path)) {
       hatchBody,
       /<img src="https:\/\/raw\.githubusercontent\.com\/openclaw\/clawsweeper-state\/state\/assets\/pr-eggs\/openclaw-clawsweeper\/74476\.png"/,
     );
-    assert.match(hatchBody, /```text\n[\s\S]+?\n```/);
+    assert.doesNotMatch(hatchBody, /```text/);
+    assert.match(hatchBody, /### Hatch command/);
     assert.match(hatchBody, /clawsweeper-pr-egg-hatch:74476/);
     assert.doesNotMatch(hatchBody, /Pending stale finding/);
     assert.doesNotMatch(hatchBody, /Codex review: needs changes/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("hatch sync can use archived closed PR records", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const logPath = join(root, "gh.log");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(closedDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    writeFileSync(
+      join(closedDir, "74479.md"),
+      `${reportFrontMatter({
+        repository: "openclaw/clawsweeper",
+        type: "pull_request",
+        number: "74479",
+        title: "Closed hatch",
+        url: "https://github.com/openclaw/clawsweeper/pull/74479",
+        decision: "keep_open",
+        close_reason: "none",
+        confidence: "high",
+        action_taken: "kept_open",
+        review_status: "complete",
+        local_checkout_access: "verified",
+        author: "contributor",
+        author_association: "CONTRIBUTOR",
+        labels: JSON.stringify(["proof: sufficient"]),
+        current_state: "closed",
+        current_item_closed_at: "2026-05-19T21:00:00Z",
+        pull_head_sha: "abc123def456",
+      })}
+
+## Summary
+
+This PR closed after review.
+
+${realBehaviorProofReportSection()}
+
+${prRatingReportSection()}
+
+## Review Findings
+
+Overall correctness: patch is correct
+
+Overall confidence: 0.95
+
+Full review comments:
+
+- none
+`,
+      "utf8",
+    );
+
+    const ghMock = `
+const { appendFileSync, readFileSync } = require("fs");
+const logPath = ${JSON.stringify(logPath)};
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+appendFileSync(logPath, JSON.stringify(args) + "\\n");
+const path = args[1] || "";
+if (args[0] === "api" && /\\/issues\\/74479$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 74479,
+    title: "Closed hatch",
+    html_url: "https://github.com/openclaw/clawsweeper/pull/74479",
+    created_at: "2026-05-19T19:00:00Z",
+    updated_at: "2026-05-19T21:00:00Z",
+    closed_at: "2026-05-19T21:00:00Z",
+    state: "closed",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "contributor" },
+    labels: [{ name: "proof: sufficient" }],
+    pull_request: {}
+  }));
+} else if (args[0] === "api" && /\\/issues\\/74479\\/comments(?:\\?|$)/.test(path)) {
+  if (args.includes("--method") && args.includes("POST")) {
+    const input = args[args.indexOf("--input") + 1];
+    appendFileSync(logPath, JSON.stringify(["comment-body", JSON.parse(readFileSync(input, "utf8")).body]) + "\\n");
+    console.log(JSON.stringify({
+      id: 987479,
+      html_url: "https://github.com/openclaw/clawsweeper/pull/74479#issuecomment-987479"
+    }));
+  } else {
+    console.log(JSON.stringify([[]]));
+  }
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: [
+          "--sync-comments-only",
+          "--hatch-pr-egg-image",
+          "--item-numbers",
+          "74479",
+          "--processed-limit",
+          "10",
+        ],
+      });
+    });
+
+    assert.deepEqual(JSON.parse(readFileSync(reportPath, "utf8")), [
+      {
+        number: 74479,
+        action: "hatch_comment_synced",
+        reason: "synced PR egg hatch comment",
+      },
+    ]);
+    const calls = readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as string[]);
+    const hatchBody = calls.find((args) => args[0] === "comment-body")?.[1] ?? "";
+    assert.match(hatchBody, /✨ Hatched: [^\n]+/);
+    assert.match(hatchBody, /### Hatch command/);
+    assert.match(hatchBody, /merged, or closed/);
+    assert.doesNotMatch(hatchBody, /```text/);
+    assert.match(hatchBody, /clawsweeper-pr-egg-hatch:74479/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- remove ASCII art from PR egg hatch comments and promote the hatch command
- document hatchability rules directly in the comment
- allow hatch-only sync to use archived closed records, with merged PRs independently hatchable and closed-unmerged PRs label-gated

## Validation
- pnpm run check