### PR TITLE
ci(review): install ffmpeg for video proof inspection

### DIFF
--- a/.github/actions/setup-media-proof-tools/action.yml
+++ b/.github/actions/setup-media-proof-tools/action.yml
@@ -1,0 +1,24 @@
+name: Setup media proof tools
+description: Install ffmpeg/ffprobe for ClawSweeper video proof inspection.
+
+runs:
+  using: composite
+  steps:
+    - name: Install ffmpeg and ffprobe
+      shell: bash
+      run: |
+        set -euo pipefail
+        if command -v ffmpeg >/dev/null 2>&1 && command -v ffprobe >/dev/null 2>&1; then
+          ffmpeg -version | head -n 1
+          ffprobe -version | head -n 1
+          exit 0
+        fi
+        if command -v apt-get >/dev/null 2>&1; then
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ffmpeg
+        else
+          echo "ffmpeg/ffprobe are required for video proof inspection, and apt-get is unavailable on this runner." >&2
+          exit 1
+        fi
+        ffmpeg -version | head -n 1
+        ffprobe -version | head -n 1

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -258,6 +258,8 @@ jobs:
         with:
           build-script: build:all
 
+      - uses: ./.github/actions/setup-media-proof-tools
+
       - name: Mark re-review command in progress
         continue-on-error: true
         env:
@@ -921,6 +923,8 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         with:
           login-status: "true"
+
+      - uses: ./clawsweeper/.github/actions/setup-media-proof-tools
 
       - uses: actions/cache@v5
         with:


### PR DESCRIPTION
## Summary
- add a shared setup-media-proof-tools action that ensures ffmpeg and ffprobe are available
- run it in both exact event re-review and review shard jobs before video proof inspection
- fail fast on non-apt runners that do not already provide ffmpeg/ffprobe, instead of silently producing ENOENT media artifacts

## Validation
- pnpm run check:active-surface
- pnpm exec oxfmt --check .github/workflows/sweep.yml .github/actions/setup-media-proof-tools/action.yml
- pnpm run check

## Root cause
The ffmpeg video proof code was deployed, but GitHub review runners did not install ffprobe/ffmpeg before ClawSweeper prepared video proof artifacts, so media extraction reported spawnSync ffprobe ENOENT.