### PR TITLE
fix(hatch): clarify proof-passed egg status

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -5933,7 +5933,8 @@ function publicPrEggLine(
   }
   const stateLines: Record<Exclude<PrEggState, "hatched">, string> = {
     incubating: "🥚 Incubating: this PR egg is tucked into the review nest.",
-    warming: "🔥 Warming up: proof, findings, or rank-up moves are still in progress.",
+    warming:
+      "🔥 Warming up: real-behavior proof passed; findings, security review, or rank-up moves are still in progress.",
     wobbling: "🔁 Wobbling: a re-review loop is active, so the shell is rattling.",
   };
   return [stateLines[state], "", hatchInstruction, ...explainer].join("\n");

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -3122,7 +3122,10 @@ Full review comments:
 
   assert.doesNotMatch(comment, /\*\*PR egg\*\*/);
   assert.match(eggComment, /ClawSweeper PR egg/);
-  assert.match(eggComment, /🔥 Warming up:/);
+  assert.match(
+    eggComment,
+    /🔥 Warming up: real-behavior proof passed; findings, security review, or rank-up moves are still in progress\./,
+  );
   assert.doesNotMatch(eggComment, /```text/);
   assert.match(eggComment, /<summary>What is this egg doing here\?<\/summary>/);
   assert.match(eggComment, /Eggs appear after the PR passes real-behavior proof/);
@@ -3139,6 +3142,7 @@ Full review comments:
   assert.match(eggComment, /Comment `@clawsweeper hatch` when this PR is/);
   assert.match(eggComment, /🥚 common, 🌱 uncommon, 💎 rare, ✨ glimmer, and 🌈 legendary/);
   assert.doesNotMatch(eggComment, /🎁 Pass real behavior proof/);
+  assert.doesNotMatch(eggComment, /proof, findings, or rank-up moves are still in progress/);
   assert.doesNotMatch(eggComment, /✨ Hatched:/);
   assert.doesNotMatch(eggComment, /Share on X:/);
 });
@@ -3647,9 +3651,18 @@ Full review comments:
     ["automerge_armed", /✨ Hatched:/],
     ["ready_for_maintainer_look", /✨ Hatched:/],
     ["re_review_loop", /🔁 Wobbling:/],
-    ["actively_grinding", /🔥 Warming up:/],
-    ["waiting_on_author", /🔥 Warming up:/],
-    ["needs_proof", /🔥 Warming up:/],
+    [
+      "actively_grinding",
+      /🔥 Warming up: real-behavior proof passed; findings, security review, or rank-up moves are still in progress\./,
+    ],
+    [
+      "waiting_on_author",
+      /🔥 Warming up: real-behavior proof passed; findings, security review, or rank-up moves are still in progress\./,
+    ],
+    [
+      "needs_proof",
+      /🔥 Warming up: real-behavior proof passed; findings, security review, or rank-up moves are still in progress\./,
+    ],
     [null, /🥚 Incubating:/],
   ] as const;
 


### PR DESCRIPTION
## Summary

- Clarifies the PR egg warming state after real-behavior proof has already passed.
- Adds regression coverage so proof-passed waiting states do not imply proof is still missing.

## Validation

- pnpm test -- --test-name-pattern="PR egg"
- pnpm run check