### PR TITLE
[codex] Add merge command alias

### DIFF
--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -1601,7 +1601,7 @@ function normalizeIntent(command: LooseRecord) {
   ) {
     return "automerge";
   }
-  if (["approve", "approve automerge", "approve merge"].includes(command)) {
+  if (["approve", "approve automerge", "approve merge", "merge"].includes(command)) {
     return "maintainer_approve_automerge";
   }
   if (command === "autoclose" || command.startsWith("autoclose ")) return "autoclose";

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -197,7 +197,12 @@ test("parseCommand recognizes maintainer slash commands", () => {
   assert.deepEqual(parseCommand("/clawsweeper merge"), {
     trigger: "slash",
     command: "merge",
-    intent: "help",
+    intent: "maintainer_approve_automerge",
+  });
+  assert.deepEqual(parseCommand("@clawsweeper merge"), {
+    trigger: "mention",
+    command: "merge",
+    intent: "maintainer_approve_automerge",
   });
   assert.deepEqual(parseCommand("/automerge"), {
     trigger: "slash",


### PR DESCRIPTION
## Summary
- Route /clawsweeper merge and @clawsweeper merge to the existing maintainer-approved automerge intent.
- Add parser coverage for slash and mention merge commands.

## Root Cause
/clawsweeper merge already parsed, but normalizeIntent() did not map merge to an executable merge intent, so it fell through to help.

## Validation
- pnpm install --frozen-lockfile
- pnpm run build:repair
- node --test test/repair/comment-router-core.test.ts
- pnpm run check

## Implementation Debt
None identified.