### PR TITLE
docs(review): flag plugin API compatibility risk

### DIFF
--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -206,6 +206,21 @@ finding should point to the existing supported path and explain why the
 duplicate implementation would create maintenance drift, conflicting behavior,
 or user confusion.
 
+Treat plugin API surface changes as compatibility-sensitive. If a PR adds,
+removes, renames, deprecates, changes behavior for, or adds new similar/parallel
+calls to a plugin API, require explicit maintainer-visible discussion, existing
+maintainer approval, or a narrow repair path before merge. Use
+`merge-risk: 🚨 compatibility`, name the plugin API concern in `risks`, and make
+`mergeRiskOptions` spell out the maintainer choices or repair path. Prefer a
+resolvable P1 review finding when the problem can be fixed mechanically by
+preserving the existing API, removing the duplicate/parallel call, adding a
+clear deprecation path, documenting the upgrade behavior, or adding focused
+compatibility tests. Choose `queue_fix_pr` for plugin API findings only when the
+repair is concrete and does not require choosing the API direction. Use
+`manual_review` when the unresolved blocker is whether the new API should exist,
+whether the old API may be removed, or what permanent plugin contract
+maintainers want.
+
 Treat compatibility and user settings as merge-critical. Look for changes that
 override existing preferences, persisted config, provider choices, auth/session
 state, local workspace state, generated files, shortcuts, routes, schemas, or

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -7513,6 +7513,31 @@ test("review prompt treats duplicated behavior as a P1 PR finding", () => {
   assert.match(prompt, /maintenance drift, conflicting behavior,\s+or user confusion/);
 });
 
+test("review prompt treats plugin API changes as compatibility-sensitive P1 repair work", () => {
+  const prompt = readFileSync("prompts/review-item.md", "utf8");
+
+  assert.match(prompt, /Treat plugin API surface changes as compatibility-sensitive/);
+  assert.match(prompt, /adds,\s+removes, renames, deprecates, changes behavior for/);
+  assert.match(prompt, /adds new similar\/parallel\s+calls to a plugin API/);
+  assert.match(prompt, /require explicit maintainer-visible discussion/);
+  assert.match(prompt, /Use\s+`merge-risk: 🚨 compatibility`/);
+  assert.match(prompt, /name the plugin API concern in `risks`/);
+  assert.match(prompt, /make\s+`mergeRiskOptions` spell out the maintainer choices or repair path/);
+  assert.match(prompt, /Prefer a\s+resolvable P1 review finding/);
+  assert.match(prompt, /preserving the existing API/);
+  assert.match(prompt, /removing the duplicate\/parallel call/);
+  assert.match(prompt, /clear deprecation path/);
+  assert.match(prompt, /focused\s+compatibility tests/);
+  assert.match(
+    prompt,
+    /Choose\s+`queue_fix_pr` for plugin API findings only when the\s+repair is concrete/,
+  );
+  assert.match(
+    prompt,
+    /Use\s+`manual_review` when the unresolved blocker is whether the new API should exist/,
+  );
+});
+
 test("review prompt requires upgrade and preference overwrite checks", () => {
   const prompt = readFileSync("prompts/review-item.md", "utf8");
 


### PR DESCRIPTION
## Summary
- make plugin API surface changes an explicit compatibility-sensitive PR review concern
- keep the existing merge-risk compatibility label path
- prefer resolvable P1 findings and queue_fix_pr for concrete mechanical repairs, with manual_review reserved for actual API direction decisions

## Validation
- pnpm run test:unit -- test/clawsweeper.test.ts
- pnpm run format:check
- pnpm run check