### PR TITLE
feat(assist): add maintainer question lane

### DIFF
--- a/.github/workflows/assist.yml
+++ b/.github/workflows/assist.yml
@@ -71,7 +71,7 @@ jobs:
 
       - uses: ./.github/actions/setup-pnpm
         with:
-          build-script: build
+          build-script: build:repair
 
       - id: limit
         env:

--- a/.github/workflows/assist.yml
+++ b/.github/workflows/assist.yml
@@ -1,0 +1,168 @@
+name: ClawSweeper assist
+
+run-name: ${{ format('Assist {0}#{1}', github.event.client_payload.target_repo || 'openclaw/openclaw', github.event.client_payload.item_number || '?') }}
+
+on:
+  repository_dispatch:
+    types: [clawsweeper_assist]
+  workflow_dispatch:
+    inputs:
+      target_repo:
+        description: "Repository containing the issue or PR"
+        required: true
+        default: openclaw/openclaw
+        type: string
+      item_number:
+        description: "Issue or PR number"
+        required: true
+        type: string
+      question:
+        description: "Maintainer question to answer"
+        required: true
+        type: string
+      comment_id:
+        description: "Source issue comment id"
+        required: false
+        default: ""
+        type: string
+      comment_url:
+        description: "Source issue comment URL"
+        required: false
+        default: ""
+        type: string
+      author:
+        description: "Source comment author"
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  CLAWSWEEPER_APP_CLIENT_ID: Iv23liOECG0slfuhz093
+  CODEX_CLI_VERSION: ${{ vars.CLAWSWEEPER_CODEX_CLI_VERSION || '0.128.0' }}
+
+concurrency:
+  group: ${{ format('clawsweeper-assist-{0}-{1}-{2}', github.event.client_payload.target_repo || inputs.target_repo || 'openclaw/openclaw', github.event.client_payload.item_number || inputs.item_number || github.run_id, github.event.client_payload.comment_id || inputs.comment_id || github.run_id) }}
+  cancel-in-progress: false
+
+jobs:
+  capacity:
+    runs-on: ubuntu-latest
+    outputs:
+      proceed: ${{ steps.limit.outputs.proceed }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          filter: blob:none
+          sparse-checkout: |
+            config
+            src
+            package.json
+            pnpm-lock.yaml
+            tsconfig.json
+            tsconfig.repair.json
+          sparse-checkout-cone-mode: false
+
+      - uses: ./.github/actions/setup-pnpm
+        with:
+          build-script: build
+
+      - id: limit
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          cap="$(pnpm run --silent workflow -- worker-limit assist)"
+          active_assist_jobs() {
+            local runs total id jobs
+            total=0
+            runs="$(gh run list --repo "${{ github.repository }}" --status in_progress --limit 100 --json databaseId,workflowName \
+              | jq -r '.[] | select(.workflowName == "ClawSweeper assist") | .databaseId')"
+            while IFS= read -r id; do
+              if [ -z "$id" ]; then
+                continue
+              fi
+              jobs="$(gh run view "$id" --repo "${{ github.repository }}" --json jobs 2>/dev/null \
+                | jq '[.jobs[]? | select(.name == "assist") | select(.status == "in_progress" or .status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested")] | length' 2>/dev/null \
+                || printf '0')"
+              if [[ "$jobs" =~ ^[0-9]+$ ]]; then
+                total=$((total + jobs))
+              fi
+            done <<< "$runs"
+            printf '%s' "$total"
+          }
+
+          for attempt in $(seq 1 80); do
+            active="$(active_assist_jobs)"
+            if [ "$active" -lt "$cap" ]; then
+              echo "proceed=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "::notice::Assist lane is at capacity (${active}/${cap}); waiting for a slot."
+            sleep 15
+          done
+
+          echo "::warning::Assist lane stayed at capacity (${cap}) for 20 minutes; leaving this run without posting an answer."
+          echo "proceed=false" >> "$GITHUB_OUTPUT"
+
+  assist:
+    needs: capacity
+    if: ${{ needs.capacity.outputs.proceed == 'true' }}
+    runs-on: ${{ vars.CLAWSWEEPER_WORKER_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    timeout-minutes: 8
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          filter: blob:none
+
+      - name: Create GitHub App token
+        id: app_token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+          owner: ${{ vars.CLAWSWEEPER_ALLOWED_OWNER || github.repository_owner }}
+          permission-issues: write
+          permission-pull-requests: read
+
+      - uses: ./.github/actions/setup-pnpm
+        with:
+          build-script: build
+
+      - uses: ./.github/actions/setup-codex
+        with:
+          version: ${{ env.CODEX_CLI_VERSION }}
+
+      - name: Answer maintainer question
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          TARGET_REPO: ${{ github.event.client_payload.target_repo || inputs.target_repo }}
+          ITEM_NUMBER: ${{ github.event.client_payload.item_number || inputs.item_number }}
+          QUESTION: ${{ github.event.client_payload.question || inputs.question }}
+          COMMENT_ID: ${{ github.event.client_payload.comment_id || inputs.comment_id || '' }}
+          COMMENT_URL: ${{ github.event.client_payload.comment_url || inputs.comment_url || '' }}
+          AUTHOR: ${{ github.event.client_payload.author || inputs.author || '' }}
+          MODEL: ${{ github.event.client_payload.model || 'gpt-5.5' }}
+          REASONING_EFFORT: ${{ github.event.client_payload.reasoning_effort || 'low' }}
+          TIMEOUT_MS: ${{ github.event.client_payload.timeout_ms || '120000' }}
+        run: |
+          set -euo pipefail
+          node dist/clawsweeper.js assist \
+            --target-repo "$TARGET_REPO" \
+            --item-number "$ITEM_NUMBER" \
+            --question "$QUESTION" \
+            --comment-id "$COMMENT_ID" \
+            --comment-url "$COMMENT_URL" \
+            --author "$AUTHOR" \
+            --codex-model "$MODEL" \
+            --codex-reasoning-effort "$REASONING_EFFORT" \
+            --codex-sandbox read-only \
+            --codex-timeout-ms "$TIMEOUT_MS"

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Common commands:
 @clawsweeper automerge
 @clawsweeper approve
 @clawsweeper explain
+@clawsweeper ask is this blocked by flaky CI?
 @clawsweeper stop
 @clawsweeper why did automerge stop here?
 ```
@@ -173,9 +174,12 @@ Common commands:
   issue/PR, intent, and head SHA. The visible badge is one lobster plus the
   current state: `👀` for acknowledgement, `🧹` for review, `🔧` for repair, and
   `✅` for completed/paused work.
-- Freeform `@clawsweeper ...` mentions dispatch a read-only assist review that
-  answers the maintainer request in the next ClawSweeper comment. Action-looking
-  prose still maps through existing safe markers and deterministic gates.
+- Freeform `@clawsweeper ...` mentions and explicit `ask ...` questions dispatch
+  the maintainer-only assist lane. Assist runs `gpt-5.5` with low reasoning, a
+  120-second per-item timeout, and its own five-job cap. It posts a separate
+  non-durable answer comment and never edits the durable ClawSweeper review
+  comment, closes, merges, labels, pushes, repairs, or emits review/apply
+  markers.
 - `fix ci`, `address review`, and `rebase` dispatch the repair worker only for
   ClawSweeper PRs or PRs already opted into `clawsweeper:autofix` or
   `clawsweeper:automerge`.

--- a/config/automation-limits.json
+++ b/config/automation-limits.json
@@ -4,5 +4,10 @@
     "reserve_for_interactive": 10,
     "expansion_reserve": 20,
     "minimum_background": 10
+  },
+  "lanes": {
+    "assist": {
+      "max": 5
+    }
   }
 }

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -22,6 +22,8 @@ The mental model:
 - `workers.max` is the global Codex capacity budget.
 - Priority lanes are repair, issue implementation, and exact-item review.
 - Background lanes are normal review, hot intake, and commit review.
+- Assist has a small fixed cap because it is lightweight maintainer Q&A, not a
+  derived review or repair lane.
 - Background lanes shrink when priority work is already active.
 - Runtime overrides are escape hatches, not the normal tuning surface.
 
@@ -33,6 +35,7 @@ The mental model:
 | `workers.reserve_for_interactive` | 10 | Worker slots background lanes leave open for exact/manual/urgent work. |
 | `workers.expansion_reserve` | 20 | Extra slots background lanes leave open for independently planned matrix expansion. |
 | `workers.minimum_background` | 10 | Target floor for background progress when enough global capacity is available. |
+| `lanes.assist.max` | 5 | Maximum concurrent lightweight assist jobs. |
 
 ## Derived Limits
 
@@ -43,6 +46,7 @@ workers.
 
 | Name | Current | Meaning |
 | --- | ---: | --- |
+| `assist.default` | 5 | Maintainer assist job cap. |
 | `review_shards.normal_default` | 39 | Quiet-system normal review shard ceiling. |
 | `review_shards.normal_active_floor` | 17 | Minimum active normal review shards to keep queued for `openclaw/openclaw`. |
 | `review_shards.hot_intake_default` | 19 | Quiet-system broad hot-intake review shard ceiling. |

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -5195,7 +5195,7 @@ function runCodexAssist(options: {
     {
       cwd: ROOT,
       encoding: "utf8",
-      env: codexEnv({ ghToken: process.env.GH_TOKEN }),
+      env: codexEnv(),
       input: prompt,
       maxBuffer: 32 * 1024 * 1024,
       timeout: options.timeoutMs,

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -5103,6 +5103,153 @@ function runCodex(options: {
   }
 }
 
+function stripTextFence(markdown: string): string {
+  const trimmed = markdown.trim();
+  const match = trimmed.match(/^```(?:markdown|md|text)?\s*\n([\s\S]*?)\n```\s*$/i);
+  return match ? (match[1]?.trim() ?? trimmed) : trimmed;
+}
+
+function buildAssistPrompt(options: {
+  item: Item;
+  context: ItemContext;
+  question: string;
+  sourceCommentUrl: string;
+  author: string;
+}): string {
+  return [
+    "You are ClawSweeper assist, a lightweight read-only maintainer Q&A helper for GitHub issues and pull requests.",
+    "",
+    "Hard safety contract:",
+    "- Answer the maintainer's question concisely from the supplied context.",
+    "- Do not recommend closing, merging, labeling, pushing, rebasing, or repairing as an executed action.",
+    "- Do not emit hidden ClawSweeper verdict, action, security, or review markers.",
+    "- If the question needs a full correctness review, say that and suggest `@clawsweeper review`.",
+    "- If the question needs branch edits or CI repair, say that and suggest the existing repair command.",
+    "- Prefer concrete evidence: check names, comments, files, commit SHAs, timestamps, and URLs present in context.",
+    "",
+    "Response format:",
+    "- Start with `ClawSweeper assist:` followed by the direct answer.",
+    "- Include short `Evidence:` bullets when evidence exists.",
+    "- Include one `Suggested next action:` line.",
+    "",
+    "Request metadata:",
+    `- Repository: ${options.item.repo}`,
+    `- Item: #${options.item.number}`,
+    `- Type: ${options.item.kind}`,
+    `- Title: ${options.item.title}`,
+    `- URL: ${options.item.url}`,
+    `- Request author: ${options.author || "unknown"}`,
+    `- Source comment: ${options.sourceCommentUrl || "unknown"}`,
+    "",
+    "Maintainer question:",
+    options.question,
+    "",
+    "GitHub context JSON:",
+    "```json",
+    JSON.stringify(options.context, null, 2),
+    "```",
+  ].join("\n");
+}
+
+function runCodexAssist(options: {
+  item: Item;
+  context: ItemContext;
+  question: string;
+  sourceCommentUrl: string;
+  author: string;
+  model: string;
+  reasoningEffort: string;
+  sandboxMode: string;
+  timeoutMs: number;
+  workDir: string;
+}): string {
+  ensureDir(options.workDir);
+  const promptPath = join(options.workDir, `${options.item.number}.assist.prompt.md`);
+  const outputPath = join(options.workDir, `${options.item.number}.assist.md`);
+  const prompt = buildAssistPrompt({
+    item: options.item,
+    context: options.context,
+    question: options.question,
+    sourceCommentUrl: options.sourceCommentUrl,
+    author: options.author,
+  });
+  writeFileSync(promptPath, prompt, "utf8");
+  const codexConfig = [
+    `model_reasoning_effort="${options.reasoningEffort}"`,
+    'forced_login_method="api"',
+    'approval_policy="never"',
+  ];
+  const result = spawnSync(
+    "codex",
+    [
+      "exec",
+      "-m",
+      options.model,
+      ...codexConfig.flatMap((config) => ["-c", config]),
+      "--output-last-message",
+      outputPath,
+      "--sandbox",
+      options.sandboxMode,
+      "-",
+    ],
+    {
+      cwd: ROOT,
+      encoding: "utf8",
+      env: codexEnv({ ghToken: process.env.GH_TOKEN }),
+      input: prompt,
+      maxBuffer: 32 * 1024 * 1024,
+      timeout: options.timeoutMs,
+    },
+  );
+  if (result.error || result.status !== 0 || !existsSync(outputPath)) {
+    const detail =
+      result.error instanceof Error
+        ? result.error.message
+        : `exit ${result.status ?? "unknown"}: ${
+            safeOutputTail(result.stderr) || safeOutputTail(result.stdout) || "No output."
+          }`;
+    throw new Error(`Codex assist failed for #${options.item.number}: ${detail}`);
+  }
+  return stripTextFence(readFileSync(outputPath, "utf8"));
+}
+
+function assistCommentMarker(commentId: string): string {
+  return `<!-- clawsweeper-assist:${commentId || "unknown"} -->`;
+}
+
+function renderAssistComment(options: {
+  body: string;
+  model: string;
+  reasoningEffort: string;
+  sourceCommentUrl: string;
+  sourceCommentId: string;
+}): string {
+  const body = options.body.trim() || "ClawSweeper assist: I could not produce an answer.";
+  const sourceLine = options.sourceCommentUrl
+    ? `Source: ${options.sourceCommentUrl}`
+    : `Source comment: ${options.sourceCommentId || "unknown"}`;
+  return [
+    body,
+    "",
+    "---",
+    `${sourceLine}`,
+    `Assist model: ${options.model}, reasoning ${options.reasoningEffort}.`,
+    assistCommentMarker(options.sourceCommentId),
+  ].join("\n");
+}
+
+function postAssistComment(number: number, body: string): void {
+  const payload = writeCommentPayload(number, body);
+  ghWithRetry([
+    "api",
+    `repos/${targetRepo()}/issues/${number}/comments`,
+    "--method",
+    "POST",
+    "--input",
+    payload,
+  ]);
+}
+
 function closeReasonText(reason: CloseReason): string {
   switch (reason) {
     case "implemented_on_main":
@@ -13157,6 +13304,48 @@ function statusCommand(args: Args): void {
   console.log(JSON.stringify({ status_path: sweepStatusRelativePath(profile), state, detail }));
 }
 
+function assistCommand(args: Args): void {
+  repoFromArgs(args);
+  const itemNumber = numberArg(args.item_number, 0);
+  if (!itemNumber) throw new Error("--item-number is required for assist");
+  const question = stringArg(args.question, "").trim();
+  if (!question) throw new Error("--question is required for assist");
+  const model = stringArg(args.codex_model, "gpt-5.5");
+  const reasoningEffort = stringArg(args.codex_reasoning_effort, "low");
+  const sandboxMode = stringArg(args.codex_sandbox, "read-only");
+  const timeoutMs = numberArg(args.codex_timeout_ms, 120_000);
+  const workDir = resolve(stringArg(args.work_dir, join(ROOT, ".artifacts", "assist-codex")));
+  const sourceCommentId = stringArg(args.comment_id, "");
+  const sourceCommentUrl = stringArg(args.comment_url, "");
+  const author = stringArg(args.author, "");
+  const { item, state } = fetchItem(itemNumber);
+  if (state.toLowerCase() !== "open") {
+    throw new Error(`assist requires an open issue or PR; #${itemNumber} is ${state}`);
+  }
+  const context = collectItemContext(item);
+  const answer = runCodexAssist({
+    item,
+    context,
+    question,
+    sourceCommentUrl,
+    author,
+    model,
+    reasoningEffort,
+    sandboxMode,
+    timeoutMs,
+    workDir,
+  });
+  const comment = renderAssistComment({
+    body: answer,
+    model,
+    reasoningEffort,
+    sourceCommentUrl,
+    sourceCommentId,
+  });
+  postAssistComment(item.number, comment);
+  console.log(JSON.stringify({ posted: true, item: item.number, model, reasoningEffort }));
+}
+
 function checkCommand(): void {
   JSON.parse(reviewDecisionSchemaText());
   if (!existsSync(join(ROOT, ".github", "workflows", "sweep.yml")))
@@ -13180,6 +13369,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
       resolve(stringArg(args.closed_dir, defaultClosedDir())),
     );
   } else if (command === "status") statusCommand(args);
+  else if (command === "assist") assistCommand(args);
   else if (command === "check") checkCommand();
   else {
     console.error(`Unknown command: ${command}`);

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -1181,7 +1181,7 @@ export function renderResponse(command: LooseRecord, dispatched: LooseRecord) {
       marker,
       "ClawSweeper is here and listening for maintainer commands.",
       "",
-      "Supported commands: `/review`, `/clawsweeper status`, `/clawsweeper re-review`, `@clawsweeper hatch`, `/clawsweeper implement`, `@clawsweeper fix`, `/clawsweeper build`, `/clawsweeper fix ci`, `/clawsweeper address review`, `/clawsweeper rebase`, `/clawsweeper autofix`, `/clawsweeper automerge`, `/clawsweeper approve`, `/autoclose <reason>`, `/clawsweeper explain`, `/clawsweeper stop`.",
+      "Supported commands: `/review`, `/clawsweeper status`, `/clawsweeper re-review`, `@clawsweeper hatch`, `/clawsweeper implement`, `@clawsweeper fix`, `/clawsweeper build`, `/clawsweeper ask <question>`, `/clawsweeper fix ci`, `/clawsweeper address review`, `/clawsweeper rebase`, `/clawsweeper autofix`, `/clawsweeper automerge`, `/clawsweeper approve`, `/autoclose <reason>`, `/clawsweeper explain`, `/clawsweeper stop`.",
       "",
       "I only act for maintainers, or for trusted ClawSweeper feedback on a ClawSweeper PR or PR opted into `clawsweeper:autofix` or `clawsweeper:automerge`.",
     ].join("\n");
@@ -1193,11 +1193,11 @@ export function renderResponse(command: LooseRecord, dispatched: LooseRecord) {
     return [
       marker,
       dispatched?.clawsweeper
-        ? "ClawSweeper is taking a look at your question."
+        ? "ClawSweeper assist is taking a look at your question."
         : "ClawSweeper could not start a freeform assist pass for this item.",
       "",
       dispatched?.clawsweeper
-        ? "I asked ClawSweeper to answer this maintainer mention in the next review comment. Tiny claws, bounded scope: this is a read-only assist pass unless it produces one of the existing structured safe-action markers."
+        ? "I queued a lightweight read-only assist pass. It will post a separate answer comment and will not edit the durable ClawSweeper review comment or trigger close, merge, repair, label, or branch changes."
         : `Reason: ${command.reason ?? "freeform assist requires an open issue or PR"}.`,
       "",
       `Request: ${inlineQuote(command.freeform_prompt ?? command.command ?? "No request text provided.")}`,
@@ -1516,7 +1516,7 @@ function commandFromText(trigger: JsonValue, value: JsonValue) {
     intent === "freeform_assist" || intent === "autoclose" ? rawNormalized : command;
   const parsed: LooseRecord = { trigger, command: parsedCommand, intent };
   if (intent === "autoclose") parsed.autoclose_message = autocloseReasonFromCommand(rawCommand);
-  if (intent === "freeform_assist") parsed.freeform_prompt = rawCommand;
+  if (intent === "freeform_assist") parsed.freeform_prompt = assistPromptFromCommand(rawCommand);
   if (intent === "implement_issue")
     parsed.implementation_prompt = implementationPromptFromCommand(rawText);
   return parsed;
@@ -1541,6 +1541,11 @@ function implementationPromptFromCommand(command: LooseRecord) {
     .trim();
 }
 
+function assistPromptFromCommand(command: LooseRecord) {
+  const prompt = String(command ?? "").trim();
+  return prompt.replace(/^(?:ask|explain)\b[:\s-]*/i, "").trim() || prompt;
+}
+
 function issueImplementationRestPrefix(command: LooseRecord) {
   return command.command === "fix" ? "fix issue" : command.command;
 }
@@ -1549,6 +1554,14 @@ function normalizeIntent(command: LooseRecord) {
   if (!command || command === "status") return "status";
   if (["help", "?"].includes(command)) return "help";
   if (["explain", "why"].includes(command)) return "explain";
+  if (
+    command === "ask" ||
+    command.startsWith("ask ") ||
+    command.startsWith("explain ") ||
+    command.startsWith("why ")
+  ) {
+    return "freeform_assist";
+  }
   if (["hatch", "hatch egg", "pr egg hatch", "hatch pr egg"].includes(command)) return "hatch";
   if (["fix ci", "fix-ci", "ci", "repair ci", "repair checks", "fix checks"].includes(command))
     return "fix_ci";

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -415,8 +415,8 @@ function classifyCommand(command: LooseRecord): JsonValue {
       status: "ready",
       actions: [
         {
-          action: "dispatch_clawsweeper",
-          workflow: reviewWorkflow,
+          action: "dispatch_assist",
+          workflow: "assist.yml",
           status: execute ? "pending" : "planned",
         },
         { action: "comment", status: execute ? "pending" : "planned" },
@@ -1244,6 +1244,7 @@ function executeCommand(command: LooseRecord) {
       (action: JsonValue) => action.action === "dispatch_repair",
     );
     const shouldDispatchClawSweeper = commandHasAction(command, "dispatch_clawsweeper");
+    const shouldDispatchAssist = commandHasAction(command, "dispatch_assist");
     const shouldDispatchHatch = commandHasAction(command, "dispatch_hatch");
     const shouldMerge = commandHasAction(command, "merge");
     const shouldApplyHumanReviewLabel = commandHasAction(command, "label");
@@ -1383,11 +1384,22 @@ function executeCommand(command: LooseRecord) {
         return action;
       });
     }
-    if (
-      ["freeform_assist", "re_review"].includes(command.intent) &&
-      command.issue_number &&
-      shouldDispatchClawSweeper
-    ) {
+    if (command.intent === "freeform_assist" && command.issue_number && shouldDispatchAssist) {
+      const clawsweeper = dispatchClawSweeperAssist(command);
+      dispatched = { ...dispatched, clawsweeper };
+      command.actions = command.actions.map((action: JsonValue) => {
+        if (action.action === "dispatch_assist") {
+          return {
+            ...action,
+            status: "executed",
+            dispatched_at: new Date().toISOString(),
+            ...clawsweeper,
+          };
+        }
+        return action;
+      });
+    }
+    if (command.intent === "re_review" && command.issue_number && shouldDispatchClawSweeper) {
       const clawsweeper = dispatchClawSweeperReview(command);
       dispatched = { ...dispatched, clawsweeper };
       command.actions = command.actions.map((action: JsonValue) => {
@@ -1916,6 +1928,44 @@ function dispatchClawSweeperReview(command: LooseRecord) {
   }
   return {
     workflow: reviewWorkflow,
+    event: "repository_dispatch",
+    repo: reviewRepo,
+    item_number: command.issue_number,
+  };
+}
+
+function dispatchClawSweeperAssist(command: LooseRecord) {
+  const payload = JSON.stringify({
+    event_type: "clawsweeper_assist",
+    client_payload: {
+      target_repo: command.repo,
+      item_number: String(command.issue_number),
+      item_kind: command.target?.kind ?? "",
+      comment_id: String(command.comment_id ?? ""),
+      comment_url: String(command.comment_url ?? ""),
+      author: String(command.author ?? ""),
+      question: String(command.freeform_prompt ?? command.command ?? "").slice(0, 3000),
+      model: "gpt-5.5",
+      reasoning_effort: "low",
+      timeout_ms: "120000",
+    },
+  });
+  const result = ghSpawn(
+    ["api", `repos/${reviewRepo}/dispatches`, "--method", "POST", "--input", "-"],
+    {
+      env: dispatchTokenEnv(),
+      input: payload,
+    },
+  );
+  if (result.status !== 0) {
+    throw new Error(
+      `failed to dispatch ClawSweeper assist for #${command.issue_number}: ${
+        result.stderr || result.stdout
+      }`,
+    );
+  }
+  return {
+    workflow: "assist.yml",
     event: "repository_dispatch",
     repo: reviewRepo,
     item_number: command.issue_number,

--- a/src/repair/limits.ts
+++ b/src/repair/limits.ts
@@ -9,9 +9,17 @@ export type WorkerConfig = {
     expansion_reserve: number;
     minimum_background: number;
   };
+  lanes: {
+    assist: {
+      max: number;
+    };
+  };
 };
 
 export type AutomationLimits = {
+  assist: {
+    default: number;
+  };
   review_shards: {
     normal_default: number;
     normal_active_floor: number;
@@ -41,7 +49,8 @@ export type WorkerLane =
   | "repair"
   | "automerge_repair"
   | "issue_implementation"
-  | "exact_item";
+  | "exact_item"
+  | "assist";
 
 export const WORKER_CONFIG = readWorkerConfig();
 export const AUTOMATION_LIMITS = deriveAutomationLimits(WORKER_CONFIG);
@@ -56,6 +65,9 @@ export function readWorkerConfig(
 export function deriveAutomationLimits(config: WorkerConfig): AutomationLimits {
   const max = config.workers.max;
   return {
+    assist: {
+      default: Math.min(config.lanes.assist.max, max),
+    },
     review_shards: {
       normal_default: percent(max, 70),
       normal_active_floor: percent(max, 30),
@@ -94,6 +106,7 @@ export function workerLimit(
   } = {},
 ): number {
   if (lane === "exact_item") return limits.review_shards.exact_item_default;
+  if (lane === "assist") return priorityLimit(limits.assist.default, activeCritical);
   if (lane === "repair") return priorityLimit(limits.repair_live_runs.default, activeCritical);
   if (lane === "automerge_repair")
     return priorityLimit(limits.repair_live_runs.automerge_default, activeCritical);
@@ -140,6 +153,11 @@ function validateWorkerConfig(value: unknown): WorkerConfig {
       reserve_for_interactive: nonNegativeInteger(value, "workers.reserve_for_interactive"),
       expansion_reserve: nonNegativeInteger(value, "workers.expansion_reserve"),
       minimum_background: positiveInteger(value, "workers.minimum_background"),
+    },
+    lanes: {
+      assist: {
+        max: positiveInteger(value, "lanes.assist.max"),
+      },
     },
   };
 }

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -96,6 +96,7 @@ function requiredWorkerLane(value: string): WorkerLane {
     "automerge_repair",
     "issue_implementation",
     "exact_item",
+    "assist",
   ]);
   if (allowed.has(value as WorkerLane)) return value as WorkerLane;
   throw new Error(`unknown worker lane: ${value}`);

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -829,6 +829,18 @@ test("parseCommand recognizes ClawSweeper bot mentions", () => {
     intent: "freeform_assist",
     freeform_prompt: "why did automerge stop here?",
   });
+  assert.deepEqual(parseCommand("/clawsweeper ask is this blocked on flaky CI?"), {
+    trigger: "slash",
+    command: "ask is this blocked on flaky ci?",
+    intent: "freeform_assist",
+    freeform_prompt: "is this blocked on flaky CI?",
+  });
+  assert.deepEqual(parseCommand("/clawsweeper explain why this PR is not automerge-ready"), {
+    trigger: "slash",
+    command: "explain why this pr is not automerge-ready",
+    intent: "freeform_assist",
+    freeform_prompt: "why this PR is not automerge-ready",
+  });
   assert.deepEqual(parseCommand("@clawsweeper: why did automerge stop here?"), {
     trigger: "mention",
     command: "why did automerge stop here?",
@@ -1639,7 +1651,9 @@ test("renderResponse reports freeform assist dispatches as read-only", () => {
   );
 
   assert.match(body, /taking a look at your question/);
-  assert.match(body, /read-only assist pass/);
+  assert.match(body, /lightweight read-only assist pass/);
+  assert.match(body, /separate answer comment/);
+  assert.match(body, /will not edit the durable ClawSweeper review comment/);
   assert.match(body, /why did automerge stop here/);
   assert.doesNotMatch(body, /repair worker/);
 });

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -54,6 +54,9 @@ test("worker scheduler lets background lanes yield to active work", () => {
   assert.equal(workerLimit("commit_review"), AUTOMATION_LIMITS.commit_review.page_size_default);
   assert.equal(workerLimit("commit_review", { activeCritical: 49 }), 1);
   assert.equal(workerLimit("repair"), AUTOMATION_LIMITS.repair_live_runs.default);
+  assert.equal(AUTOMATION_LIMITS.assist.default, 5);
+  assert.equal(workerLimit("assist"), 5);
+  assert.equal(workerLimit("assist", { activeCritical: 55 }), 2);
 });
 
 test("workflow utilities derive artifact item numbers and action counts", () => {


### PR DESCRIPTION
## Summary
- add a maintainer-only ClawSweeper assist lane for lightweight question answering
- run assist with gpt-5.5 low reasoning, read-only sandbox, 120s timeout, and a five-job lane cap
- keep assist output in separate non-durable comments without touching durable review/apply markers

## Validation
- pnpm run build
- pnpm run build:repair
- node --test test/repair/comment-router-core.test.ts test/repair/workflow-utils.test.ts
- pnpm run format
- pnpm run check