### PR TITLE
fix(assist): include setup action in capacity checkout

### DIFF
--- a/.github/workflows/assist.yml
+++ b/.github/workflows/assist.yml
@@ -61,6 +61,7 @@ jobs:
         with:
           filter: blob:none
           sparse-checkout: |
+            .github/actions/setup-pnpm
             config
             src
             package.json


### PR DESCRIPTION
## Summary
- include the local setup-pnpm composite action in the assist capacity job sparse checkout
- unblock the assist workflow before it checks queue capacity

## Validation
- pnpm run check:active-surface
- pnpm run check:limits
- pnpm run check