### PR TITLE
fix(repair): clarify human-review next steps

### DIFF
--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -1433,7 +1433,7 @@ export function renderResponse(command: LooseRecord, dispatched: LooseRecord) {
       "",
       "Why human review is needed:",
       humanReviewJustification(reason),
-      ...(nextAction ? ["", "Recommended next action:", nextAction] : []),
+      ...(nextAction ? ["", "What the maintainer can do as a next step:", nextAction] : []),
       "",
       `I added \`${HUMAN_REVIEW_LABEL}\` and left the final call with a maintainer.`,
     ].join("\n");
@@ -1832,27 +1832,33 @@ function humanReviewJustification(reason: JsonValue) {
 
 function humanReviewNextAction(reason: JsonValue) {
   const text = String(reason ?? "");
+  const approveInstruction =
+    "If the maintainer accepts the current risk and wants ClawSweeper to continue merge gates, comment `@clawsweeper approve`.";
   if (/proof-label automation|proof[- ]label|proof gate|proof sufficien/i.test(text)) {
     return [
-      "Add redacted real behavior proof for the affected proof-label workflow, then comment",
-      "`@clawsweeper automerge` to ask ClawSweeper to re-review and continue.",
+      approveInstruction,
+      "If proof is still missing, add redacted real behavior proof for the affected proof-label workflow, then comment `@clawsweeper automerge` to re-review and continue.",
+      "If automation should not continue, leave `clawsweeper:human-review` in place or comment `@clawsweeper stop`.",
     ].join(" ");
   }
   if (/protected maintainer|maintainer validation|maintainer label/i.test(text)) {
     return [
-      "Have a maintainer review the flagged decision, then either add the missing proof and re-run",
-      "ClawSweeper or merge manually if the maintainer accepts the remaining risk.",
+      approveInstruction,
+      "If the flagged decision needs more evidence first, add the missing proof or resolve the maintainer-owned blocker, then comment `@clawsweeper automerge`.",
+      "If the maintainer wants to own landing outside automation, merge manually after repository gates pass.",
     ].join(" ");
   }
   if (/security|secret|credential|permission/i.test(text)) {
     return [
-      "Have a maintainer review the security-sensitive detail and provide an explicit safe path",
-      "before asking ClawSweeper to continue.",
+      approveInstruction,
+      "If the security-sensitive detail still needs changes, describe the safe path or push the fix, then comment `@clawsweeper automerge`.",
+      "If the risk should not be automated, keep the PR paused for manual review or comment `@clawsweeper stop`.",
     ].join(" ");
   }
   return [
-    "Review the reason above, resolve the blocker or explicitly accept the risk, then ask",
-    "ClawSweeper to continue if automation is still appropriate.",
+    approveInstruction,
+    "If more work is needed, resolve the blocker first, then comment `@clawsweeper automerge` to re-review and continue.",
+    "If automation should stay paused, leave `clawsweeper:human-review` in place or comment `@clawsweeper stop`.",
   ].join(" ");
 }
 

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -1773,9 +1773,11 @@ test("renderResponse reports explicit human-review pause actions", () => {
   assert.match(body, /pausing this repair loop/);
   assert.match(body, /Why human review is needed:/);
   assert.match(body, /proof-label or proof-gate automation/);
-  assert.match(body, /Recommended next action:/);
-  assert.match(body, /Add redacted real behavior proof/);
+  assert.match(body, /What the maintainer can do as a next step:/);
+  assert.match(body, /@clawsweeper approve/);
+  assert.match(body, /add redacted real behavior proof/);
   assert.match(body, /@clawsweeper automerge/);
+  assert.match(body, /@clawsweeper stop/);
   assert.match(body, /`clawsweeper:human-review`/);
   assert.doesNotMatch(body, /did not dispatch/);
 });
@@ -1794,8 +1796,11 @@ test("renderResponse gives generic human-review pauses a next action", () => {
 
   assert.match(body, /Why human review is needed:/);
   assert.match(body, /resolved or accepted by a maintainer/);
-  assert.match(body, /Recommended next action:/);
-  assert.match(body, /resolve the blocker or explicitly accept the risk/);
+  assert.match(body, /What the maintainer can do as a next step:/);
+  assert.match(body, /@clawsweeper approve/);
+  assert.match(body, /resolve the blocker first/);
+  assert.match(body, /@clawsweeper automerge/);
+  assert.match(body, /@clawsweeper stop/);
   assert.match(body, /`clawsweeper:human-review`/);
 });
 


### PR DESCRIPTION
## Summary
- Rename the human-review pause section to make it maintainer-focused
- Add explicit maintainer choices: approve, add proof/fix then rerun automerge, stop/keep paused, or manual landing where applicable
- Update router tests for the new guidance

## Validation
- pnpm test test/repair/comment-router-core.test.ts