### PR TITLE
fix(assist): allow target PR comment posting

### DIFF
--- a/.github/workflows/assist.yml
+++ b/.github/workflows/assist.yml
@@ -132,7 +132,7 @@ jobs:
           private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
           owner: ${{ vars.CLAWSWEEPER_ALLOWED_OWNER || github.repository_owner }}
           permission-issues: write
-          permission-pull-requests: read
+          permission-pull-requests: write
 
       - uses: ./.github/actions/setup-pnpm
         with:


### PR DESCRIPTION
## Summary
- grant the assist workflow app token pull-requests: write so it can post the separate assist answer comment on target PRs
- keep the assist lane read-only for Codex execution; this only aligns GitHub comment posting permissions with the existing comment router mutation path

## Validation
- pnpm run check:active-surface
- pnpm run check:limits
- pnpm run check