### PR TITLE
feat(assist): add visual PR explainer

### DIFF
--- a/.github/workflows/assist.yml
+++ b/.github/workflows/assist.yml
@@ -129,7 +129,7 @@ jobs:
     needs: capacity
     if: ${{ needs.capacity.outputs.proceed == 'true' }}
     runs-on: ${{ vars.CLAWSWEEPER_WORKER_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
-    timeout-minutes: 8
+    timeout-minutes: 12
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     steps:

--- a/.github/workflows/assist.yml
+++ b/.github/workflows/assist.yml
@@ -35,6 +35,14 @@ on:
         required: false
         default: ""
         type: string
+      mode:
+        description: "Assist mode: text or visual"
+        required: false
+        default: "text"
+        type: choice
+        options:
+          - text
+          - visual
 
 permissions:
   contents: read
@@ -61,6 +69,7 @@ jobs:
         with:
           filter: blob:none
           sparse-checkout: |
+            .github/actions/setup-pnpm
             config
             src
             package.json
@@ -76,9 +85,14 @@ jobs:
       - id: limit
         env:
           GH_TOKEN: ${{ github.token }}
+          MODE: ${{ github.event.client_payload.mode || inputs.mode || 'text' }}
         run: |
           set -euo pipefail
-          cap="$(pnpm run --silent workflow -- worker-limit assist)"
+          lane="assist"
+          if [ "$MODE" = "visual" ]; then
+            lane="assist_visual"
+          fi
+          cap="$(pnpm run --silent workflow -- worker-limit "$lane")"
           active_assist_jobs() {
             local runs total id jobs
             total=0
@@ -147,6 +161,7 @@ jobs:
           TARGET_REPO: ${{ github.event.client_payload.target_repo || inputs.target_repo }}
           ITEM_NUMBER: ${{ github.event.client_payload.item_number || inputs.item_number }}
           QUESTION: ${{ github.event.client_payload.question || inputs.question }}
+          MODE: ${{ github.event.client_payload.mode || inputs.mode || 'text' }}
           COMMENT_ID: ${{ github.event.client_payload.comment_id || inputs.comment_id || '' }}
           COMMENT_URL: ${{ github.event.client_payload.comment_url || inputs.comment_url || '' }}
           AUTHOR: ${{ github.event.client_payload.author || inputs.author || '' }}
@@ -158,6 +173,7 @@ jobs:
           node dist/clawsweeper.js assist \
             --target-repo "$TARGET_REPO" \
             --item-number "$ITEM_NUMBER" \
+            --mode "$MODE" \
             --question "$QUESTION" \
             --comment-id "$COMMENT_ID" \
             --comment-url "$COMMENT_URL" \
@@ -165,4 +181,13 @@ jobs:
             --codex-model "$MODEL" \
             --codex-reasoning-effort "$REASONING_EFFORT" \
             --codex-sandbox read-only \
-            --codex-timeout-ms "$TIMEOUT_MS"
+            --codex-timeout-ms "$TIMEOUT_MS" \
+            --output-dir artifacts/assist
+
+      - name: Upload visual explainer artifact
+        if: ${{ always() && (github.event.client_payload.mode || inputs.mode || 'text') == 'visual' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: clawsweeper-visual-${{ github.event.client_payload.item_number || inputs.item_number }}
+          path: artifacts/assist
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Common commands:
 @clawsweeper approve
 @clawsweeper explain
 @clawsweeper ask is this blocked by flaky CI?
+@clawsweeper visual focus on risky files
 @clawsweeper stop
 @clawsweeper why did automerge stop here?
 ```
@@ -180,6 +181,13 @@ Common commands:
   non-durable answer comment and never edits the durable ClawSweeper review
   comment, closes, merges, labels, pushes, repairs, or emits review/apply
   markers.
+- `visual`, `viz`, and `visualize` dispatch a maintainer-only, PR-only visual
+  assist lane. The trailing text becomes the focus prompt for an LLM-generated
+  self-contained HTML/CSS/inline-JS explainer. ClawSweeper validates the page
+  against a no-network/no-external-assets policy, uploads it as a workflow
+  artifact, and posts a separate link comment. It is explanatory only and does
+  not edit durable review comments or trigger close, merge, repair, label, or
+  branch changes.
 - `fix ci`, `address review`, and `rebase` dispatch the repair worker only for
   ClawSweeper PRs or PRs already opted into `clawsweeper:autofix` or
   `clawsweeper:automerge`.

--- a/config/automation-limits.json
+++ b/config/automation-limits.json
@@ -8,6 +8,9 @@
   "lanes": {
     "assist": {
       "max": 5
+    },
+    "assist_visual": {
+      "max": 2
     }
   }
 }

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -24,6 +24,8 @@ The mental model:
 - Background lanes are normal review, hot intake, and commit review.
 - Assist has a small fixed cap because it is lightweight maintainer Q&A, not a
   derived review or repair lane.
+- Visual assist has a smaller fixed cap because it generates and validates
+  larger PR explainer artifacts.
 - Background lanes shrink when priority work is already active.
 - Runtime overrides are escape hatches, not the normal tuning surface.
 
@@ -36,6 +38,7 @@ The mental model:
 | `workers.expansion_reserve` | 20 | Extra slots background lanes leave open for independently planned matrix expansion. |
 | `workers.minimum_background` | 10 | Target floor for background progress when enough global capacity is available. |
 | `lanes.assist.max` | 5 | Maximum concurrent lightweight assist jobs. |
+| `lanes.assist_visual.max` | 2 | Maximum concurrent visual assist explainer jobs. |
 
 ## Derived Limits
 
@@ -47,6 +50,7 @@ workers.
 | Name | Current | Meaning |
 | --- | ---: | --- |
 | `assist.default` | 5 | Maintainer assist job cap. |
+| `assist_visual.default` | 2 | Maintainer visual assist artifact job cap. |
 | `review_shards.normal_default` | 39 | Quiet-system normal review shard ceiling. |
 | `review_shards.normal_active_floor` | 17 | Minimum active normal review shards to keep queued for `openclaw/openclaw`. |
 | `review_shards.hot_intake_default` | 19 | Quiet-system broad hot-intake review shard ceiling. |

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -14,6 +14,11 @@ ClawSweeper should stay simple at the orchestration boundary:
 5. Comments, records, ledgers, and dashboards are generated status surfaces,
    not independent sources of truth.
 
+Visual assist explainers are read-only generated artifacts. They may use an LLM
+to render self-contained HTML/CSS/inline-JS from deterministic PR context, but
+the sanitizer, artifact publication, permissions, and GitHub comments remain
+deterministic ClawSweeper responsibilities.
+
 ## Canonical Job Intent
 
 Repair jobs carry `job_intent` in frontmatter. This is the durable routing

--- a/docs/repair/internal-features.md
+++ b/docs/repair/internal-features.md
@@ -449,6 +449,7 @@ Supported commands:
 /clawsweeper automerge
 /clawsweeper approve
 /clawsweeper explain
+@clawsweeper visual focus on risky files
 /clawsweeper stop
 @clawsweeper re-review
 @clawsweeper re-run
@@ -467,6 +468,13 @@ Behavior:
   review with the mention text as one-off instructions. The model can answer or
   recommend existing structured safe actions, but cannot directly merge, close,
   label, or push code.
+- `visual`, `viz`, and `visualize`: dispatch a maintainer-only, PR-only visual
+  assist lane. The trailing command text becomes the LLM focus prompt. The lane
+  generates one self-contained HTML/CSS/inline-JS explainer from deterministic PR
+  context, validates it with a no-network/no-external-assets sanitizer, uploads
+  it as a workflow artifact, and posts a separate link comment. It is
+  explanatory only and never edits durable review comments, emits review/apply
+  markers, closes, merges, labels, pushes, or repairs.
 - `fix ci`: dispatch the existing ClawSweeper PR's job for repair.
 - `address review`: dispatch the existing ClawSweeper PR's job for repair.
 - `rebase`: dispatch the existing ClawSweeper PR's job for repair.

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -5335,10 +5335,16 @@ export function visualExplainerCspMeta(): string {
 
 export function applyVisualExplainerCsp(html: string): string {
   const meta = visualExplainerCspMeta();
-  if (/http-equiv=["']Content-Security-Policy["']/i.test(html)) return html;
-  if (/<head\b[^>]*>/i.test(html))
-    return html.replace(/<head\b[^>]*>/i, (match) => `${match}\n${meta}`);
-  return html.replace(/<html\b[^>]*>/i, (match) => `${match}\n<head>\n${meta}\n</head>`);
+  const withoutGeneratedCsp = html.replace(
+    /<meta\b[^>]*\bhttp-equiv\s*=\s*(?:"Content-Security-Policy"|'Content-Security-Policy'|Content-Security-Policy)[^>]*>\s*/gi,
+    "",
+  );
+  if (/<head\b[^>]*>/i.test(withoutGeneratedCsp))
+    return withoutGeneratedCsp.replace(/<head\b[^>]*>/i, (match) => `${match}\n${meta}`);
+  return withoutGeneratedCsp.replace(
+    /<html\b[^>]*>/i,
+    (match) => `${match}\n<head>\n${meta}\n</head>`,
+  );
 }
 
 function runCodexVisualExplainer(options: {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -5213,6 +5213,191 @@ function runCodexAssist(options: {
   return stripTextFence(readFileSync(outputPath, "utf8"));
 }
 
+function visualExplainerArtifactName(repo: string, number: number, headSha: string): string {
+  const slug = repo.replace(/[^A-Za-z0-9_.-]+/g, "-");
+  const sha = /^[0-9a-f]{7,40}$/i.test(headSha) ? headSha.slice(0, 12) : "unknown";
+  return `${slug}-${number}-${sha}.html`;
+}
+
+function visualExplainerRunUrl(): string {
+  const server = process.env.GITHUB_SERVER_URL || "https://github.com";
+  const repository = process.env.GITHUB_REPOSITORY || "";
+  const runId = process.env.GITHUB_RUN_ID || "";
+  return repository && runId ? `${server}/${repository}/actions/runs/${runId}` : "";
+}
+
+function visualExplainerHeadSha(context: ItemContext): string {
+  const pull = asRecord(context.pullRequest);
+  const head = asRecord(pull.head);
+  const sha = head.sha;
+  return typeof sha === "string" && sha ? sha : "unknown";
+}
+
+function buildVisualExplainerPrompt(options: {
+  item: Item;
+  context: ItemContext;
+  focusPrompt: string;
+  sourceCommentUrl: string;
+  author: string;
+  generatedAt: string;
+}): string {
+  const packet = {
+    metadata: {
+      repository: options.item.repo,
+      itemNumber: options.item.number,
+      itemType: options.item.kind,
+      itemUrl: options.item.url,
+      sourceCommentUrl: options.sourceCommentUrl || null,
+      requestAuthor: options.author || null,
+      generatedAt: options.generatedAt,
+      focusPrompt: options.focusPrompt || "default maintainer overview",
+      artifactKind: "interactive_pr_visual_explainer",
+    },
+    item: options.item,
+    context: options.context,
+  };
+  return [
+    "You are ClawSweeper visual assist, a read-only PR explainer generator for maintainers.",
+    "",
+    "Generate one self-contained HTML document that makes this pull request easier to review visually.",
+    "",
+    "Hard safety contract:",
+    "- This is an explanatory visualization, not a ClawSweeper review verdict.",
+    "- Do not recommend or imply that ClawSweeper has closed, merged, labeled, pushed, rebased, repaired, approved, or rejected the PR.",
+    "- Do not emit hidden ClawSweeper verdict, action, security, or review markers.",
+    "- Use only the supplied PR_CONTEXT JSON. Do not invent files, checks, commits, comments, screenshots, labels, or behavior.",
+    "- Mark uncertainty and truncation explicitly when the context is incomplete.",
+    "",
+    "HTML contract:",
+    "- Return only the complete HTML document, starting with <!doctype html> or <html>.",
+    "- Inline CSS is allowed.",
+    "- Inline JavaScript is allowed only for local interactions such as filters, tabs, collapsible sections, sorting, and toggles.",
+    "- Do not load external scripts, stylesheets, fonts, iframes, images, or other assets.",
+    "- Do not make network requests.",
+    "- Do not use eval, Function, dynamic import, workers, cookies, localStorage, sessionStorage, forms, or navigation-changing JavaScript.",
+    "- Include a clear footer with repository, PR URL, head SHA when present, generated timestamp, and source comment URL when present.",
+    "",
+    "Useful visual structures:",
+    "- maintainer summary",
+    "- file/subsystem map",
+    "- changed-file table with additions/deletions/status",
+    "- risk and proof callouts",
+    "- CI/check summary if available",
+    "- review-comment grouping",
+    "- timeline or commit list",
+    "- filters or toggles that help large PRs become skimmable",
+    "",
+    "Maintainer focus prompt:",
+    options.focusPrompt || "Create a balanced maintainer overview of this PR.",
+    "",
+    "PR_CONTEXT JSON:",
+    "```json",
+    JSON.stringify(packet, null, 2),
+    "```",
+  ].join("\n");
+}
+
+export function validateVisualExplainerHtml(html: string): string[] {
+  const text = String(html ?? "");
+  const violations: string[] = [];
+  const checks: Array<[RegExp, string]> = [
+    [/<script\b[^>]*\bsrc\s*=/i, "external script sources are not allowed"],
+    [/<link\b[^>]*\bhref\s*=/i, "external stylesheets or linked resources are not allowed"],
+    [/<iframe\b/i, "iframes are not allowed"],
+    [/<object\b/i, "objects are not allowed"],
+    [/<embed\b/i, "embeds are not allowed"],
+    [/<form\b/i, "forms are not allowed"],
+    [/\b(?:fetch|XMLHttpRequest|WebSocket|EventSource)\s*\(/i, "network APIs are not allowed"],
+    [/\b(?:eval|Function|importScripts)\s*\(/i, "dynamic code execution is not allowed"],
+    [/\bimport\s*\(/i, "dynamic imports are not allowed"],
+    [/\b(?:Worker|SharedWorker|ServiceWorker)\s*\(/i, "workers are not allowed"],
+    [/\b(?:localStorage|sessionStorage|document\.cookie)\b/i, "browser storage is not allowed"],
+    [/\blocation\.(?:href|assign|replace)\b/i, "navigation-changing JavaScript is not allowed"],
+    [/\bwindow\.open\s*\(/i, "window.open is not allowed"],
+    [/\b(?:src|href)\s*=\s*["'](?:https?:)?\/\//i, "external resources are not allowed"],
+    [/\b(?:src|href)\s*=\s*["']data:(?!image\/)/i, "only data image URLs are allowed"],
+  ];
+  for (const [pattern, message] of checks) {
+    if (pattern.test(text)) violations.push(message);
+  }
+  if (!/<(?:!doctype\s+html|html)\b/i.test(text.slice(0, 200))) {
+    violations.push("HTML document must start with <!doctype html> or <html>");
+  }
+  if (Buffer.byteLength(text, "utf8") > 2_000_000) {
+    violations.push("HTML document exceeds the 2 MB size limit");
+  }
+  return [...new Set(violations)];
+}
+
+export function visualExplainerCspMeta(): string {
+  return `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:; base-uri 'none'; form-action 'none'; connect-src 'none'; frame-ancestors 'none'">`;
+}
+
+export function applyVisualExplainerCsp(html: string): string {
+  const meta = visualExplainerCspMeta();
+  if (/http-equiv=["']Content-Security-Policy["']/i.test(html)) return html;
+  if (/<head\b[^>]*>/i.test(html))
+    return html.replace(/<head\b[^>]*>/i, (match) => `${match}\n${meta}`);
+  return html.replace(/<html\b[^>]*>/i, (match) => `${match}\n<head>\n${meta}\n</head>`);
+}
+
+function runCodexVisualExplainer(options: {
+  item: Item;
+  context: ItemContext;
+  focusPrompt: string;
+  sourceCommentUrl: string;
+  author: string;
+  model: string;
+  reasoningEffort: string;
+  sandboxMode: string;
+  timeoutMs: number;
+  workDir: string;
+  generatedAt: string;
+}): string {
+  ensureDir(options.workDir);
+  const promptPath = join(options.workDir, `${options.item.number}.visual.prompt.md`);
+  const outputPath = join(options.workDir, `${options.item.number}.visual.html`);
+  const prompt = buildVisualExplainerPrompt(options);
+  writeFileSync(promptPath, prompt, "utf8");
+  const codexConfig = [
+    `model_reasoning_effort="${options.reasoningEffort}"`,
+    'forced_login_method="api"',
+    'approval_policy="never"',
+  ];
+  const result = spawnSync(
+    "codex",
+    [
+      "exec",
+      "-m",
+      options.model,
+      ...codexConfig.flatMap((config) => ["-c", config]),
+      "--output-last-message",
+      outputPath,
+      "--sandbox",
+      options.sandboxMode,
+      "-",
+    ],
+    {
+      cwd: ROOT,
+      encoding: "utf8",
+      env: codexEnv({ ghToken: process.env.GH_TOKEN }),
+      input: prompt,
+      maxBuffer: 64 * 1024 * 1024,
+      timeout: options.timeoutMs,
+    },
+  );
+  if (result.error || result.status !== 0 || !existsSync(outputPath)) {
+    const detail =
+      result.error instanceof Error
+        ? result.error.message
+        : `exit ${result.status ?? "unknown"}: ${
+            safeOutputTail(result.stderr) || safeOutputTail(result.stdout) || "No output."
+          }`;
+    throw new Error(`Codex visual explainer failed for #${options.item.number}: ${detail}`);
+  }
+  return stripTextFence(readFileSync(outputPath, "utf8"));
+}
+
 function assistCommentMarker(commentId: string): string {
   return `<!-- clawsweeper-assist:${commentId || "unknown"} -->`;
 }
@@ -5234,6 +5419,63 @@ function renderAssistComment(options: {
     "---",
     `${sourceLine}`,
     `Assist model: ${options.model}, reasoning ${options.reasoningEffort}.`,
+    assistCommentMarker(options.sourceCommentId),
+  ].join("\n");
+}
+
+function renderVisualExplainerComment(options: {
+  artifactName: string;
+  runUrl: string;
+  model: string;
+  reasoningEffort: string;
+  sourceCommentUrl: string;
+  sourceCommentId: string;
+  focusPrompt: string;
+}): string {
+  const sourceLine = options.sourceCommentUrl
+    ? `Source: ${options.sourceCommentUrl}`
+    : `Source comment: ${options.sourceCommentId || "unknown"}`;
+  const artifactLine = options.runUrl
+    ? `Artifact: [${options.artifactName}](${options.runUrl})`
+    : `Artifact: ${options.artifactName}`;
+  return [
+    "ClawSweeper visual assist: I generated a read-only interactive HTML explainer for this PR.",
+    "",
+    artifactLine,
+    `Focus: ${options.focusPrompt || "default maintainer overview"}`,
+    "",
+    "This artifact is explanatory only. It is not a ClawSweeper review verdict and it does not close, merge, label, push, repair, or approve this PR.",
+    "",
+    "---",
+    `${sourceLine}`,
+    `Visual assist model: ${options.model}, reasoning ${options.reasoningEffort}.`,
+    assistCommentMarker(options.sourceCommentId),
+  ].join("\n");
+}
+
+function renderVisualExplainerFallbackComment(options: {
+  error: unknown;
+  model: string;
+  reasoningEffort: string;
+  sourceCommentUrl: string;
+  sourceCommentId: string;
+  focusPrompt: string;
+}): string {
+  const detail = options.error instanceof Error ? options.error.message : String(options.error);
+  const sourceLine = options.sourceCommentUrl
+    ? `Source: ${options.sourceCommentUrl}`
+    : `Source comment: ${options.sourceCommentId || "unknown"}`;
+  return [
+    "ClawSweeper visual assist: I could not safely generate the interactive HTML explainer this time.",
+    "",
+    `Reason: ${truncateText(detail, 700)}`,
+    `Focus: ${options.focusPrompt || "default maintainer overview"}`,
+    "",
+    "No review, repair, close, merge, label, or branch action was taken.",
+    "",
+    "---",
+    `${sourceLine}`,
+    `Visual assist model: ${options.model}, reasoning ${options.reasoningEffort}.`,
     assistCommentMarker(options.sourceCommentId),
   ].join("\n");
 }
@@ -13308,13 +13550,18 @@ function assistCommand(args: Args): void {
   repoFromArgs(args);
   const itemNumber = numberArg(args.item_number, 0);
   if (!itemNumber) throw new Error("--item-number is required for assist");
+  const mode = stringArg(args.mode, "text").trim().toLowerCase();
   const question = stringArg(args.question, "").trim();
-  if (!question) throw new Error("--question is required for assist");
+  if (!question && mode !== "visual") throw new Error("--question is required for assist");
   const model = stringArg(args.codex_model, "gpt-5.5");
-  const reasoningEffort = stringArg(args.codex_reasoning_effort, "low");
+  const reasoningEffort = stringArg(
+    args.codex_reasoning_effort,
+    mode === "visual" ? "medium" : "low",
+  );
   const sandboxMode = stringArg(args.codex_sandbox, "read-only");
-  const timeoutMs = numberArg(args.codex_timeout_ms, 120_000);
+  const timeoutMs = numberArg(args.codex_timeout_ms, mode === "visual" ? 480_000 : 120_000);
   const workDir = resolve(stringArg(args.work_dir, join(ROOT, ".artifacts", "assist-codex")));
+  const outputDir = resolve(stringArg(args.output_dir, join(ROOT, "artifacts", "assist")));
   const sourceCommentId = stringArg(args.comment_id, "");
   const sourceCommentUrl = stringArg(args.comment_url, "");
   const author = stringArg(args.author, "");
@@ -13323,6 +13570,92 @@ function assistCommand(args: Args): void {
     throw new Error(`assist requires an open issue or PR; #${itemNumber} is ${state}`);
   }
   const context = collectItemContext(item);
+  if (mode === "visual") {
+    if (item.kind !== "pull_request") {
+      const comment = renderVisualExplainerFallbackComment({
+        error: new Error("visual explainers are currently PR-only"),
+        model,
+        reasoningEffort,
+        sourceCommentUrl,
+        sourceCommentId,
+        focusPrompt: question,
+      });
+      postAssistComment(item.number, comment);
+      console.log(
+        JSON.stringify({ posted: true, item: item.number, mode, fallback: "not_pull_request" }),
+      );
+      return;
+    }
+    try {
+      ensureDir(outputDir);
+      const generatedAt = new Date().toISOString();
+      const rawHtml = runCodexVisualExplainer({
+        item,
+        context,
+        focusPrompt: question,
+        sourceCommentUrl,
+        author,
+        model,
+        reasoningEffort,
+        sandboxMode,
+        timeoutMs,
+        workDir,
+        generatedAt,
+      });
+      const html = applyVisualExplainerCsp(rawHtml);
+      const violations = validateVisualExplainerHtml(html);
+      if (violations.length > 0) {
+        throw new Error(`generated HTML did not pass safety checks: ${violations.join("; ")}`);
+      }
+      const artifactName = visualExplainerArtifactName(
+        item.repo,
+        item.number,
+        visualExplainerHeadSha(context),
+      );
+      const artifactPath = join(outputDir, artifactName);
+      writeFileSync(artifactPath, html, "utf8");
+      const comment = renderVisualExplainerComment({
+        artifactName,
+        runUrl: visualExplainerRunUrl(),
+        model,
+        reasoningEffort,
+        sourceCommentUrl,
+        sourceCommentId,
+        focusPrompt: question,
+      });
+      postAssistComment(item.number, comment);
+      console.log(
+        JSON.stringify({
+          posted: true,
+          item: item.number,
+          mode,
+          model,
+          reasoningEffort,
+          artifact: artifactPath,
+        }),
+      );
+      return;
+    } catch (error) {
+      const comment = renderVisualExplainerFallbackComment({
+        error,
+        model,
+        reasoningEffort,
+        sourceCommentUrl,
+        sourceCommentId,
+        focusPrompt: question,
+      });
+      postAssistComment(item.number, comment);
+      console.log(
+        JSON.stringify({
+          posted: true,
+          item: item.number,
+          mode,
+          fallback: "generation_failed",
+        }),
+      );
+      return;
+    }
+  }
   const answer = runCodexAssist({
     item,
     context,
@@ -13343,7 +13676,7 @@ function assistCommand(args: Args): void {
     sourceCommentId,
   });
   postAssistComment(item.number, comment);
-  console.log(JSON.stringify({ posted: true, item: item.number, model, reasoningEffort }));
+  console.log(JSON.stringify({ posted: true, item: item.number, mode, model, reasoningEffort }));
 }
 
 function checkCommand(): void {

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -1181,7 +1181,7 @@ export function renderResponse(command: LooseRecord, dispatched: LooseRecord) {
       marker,
       "ClawSweeper is here and listening for maintainer commands.",
       "",
-      "Supported commands: `/review`, `/clawsweeper status`, `/clawsweeper re-review`, `@clawsweeper hatch`, `/clawsweeper implement`, `@clawsweeper fix`, `/clawsweeper build`, `/clawsweeper ask <question>`, `/clawsweeper fix ci`, `/clawsweeper address review`, `/clawsweeper rebase`, `/clawsweeper autofix`, `/clawsweeper automerge`, `/clawsweeper approve`, `/autoclose <reason>`, `/clawsweeper explain`, `/clawsweeper stop`.",
+      "Supported commands: `/review`, `/clawsweeper status`, `/clawsweeper re-review`, `@clawsweeper hatch`, `/clawsweeper implement`, `@clawsweeper fix`, `/clawsweeper build`, `/clawsweeper ask <question>`, `@clawsweeper visual <prompt>`, `/clawsweeper fix ci`, `/clawsweeper address review`, `/clawsweeper rebase`, `/clawsweeper autofix`, `/clawsweeper automerge`, `/clawsweeper approve`, `/autoclose <reason>`, `/clawsweeper explain`, `/clawsweeper stop`.",
       "",
       "I only act for maintainers, or for trusted ClawSweeper feedback on a ClawSweeper PR or PR opted into `clawsweeper:autofix` or `clawsweeper:automerge`.",
     ].join("\n");
@@ -1201,6 +1201,20 @@ export function renderResponse(command: LooseRecord, dispatched: LooseRecord) {
         : `Reason: ${command.reason ?? "freeform assist requires an open issue or PR"}.`,
       "",
       `Request: ${inlineQuote(command.freeform_prompt ?? command.command ?? "No request text provided.")}`,
+    ].join("\n");
+  }
+  if (command.intent === "visual_assist") {
+    return [
+      marker,
+      dispatched?.clawsweeper
+        ? "ClawSweeper visual explainer is being generated."
+        : "ClawSweeper could not start a visual explainer for this PR.",
+      "",
+      dispatched?.clawsweeper
+        ? "I queued a read-only visual pass. It will post a separate artifact link comment and will not edit the durable ClawSweeper review comment or trigger close, merge, repair, label, or branch changes."
+        : `Reason: ${command.reason ?? "visual explainers require an open pull request and maintainer permission"}.`,
+      "",
+      `Focus: ${inlineQuote(command.visual_prompt ?? "default maintainer overview")}`,
     ].join("\n");
   }
   if (command.intent === "stop") {
@@ -1517,6 +1531,7 @@ function commandFromText(trigger: JsonValue, value: JsonValue) {
   const parsed: LooseRecord = { trigger, command: parsedCommand, intent };
   if (intent === "autoclose") parsed.autoclose_message = autocloseReasonFromCommand(rawCommand);
   if (intent === "freeform_assist") parsed.freeform_prompt = assistPromptFromCommand(rawCommand);
+  if (intent === "visual_assist") parsed.visual_prompt = visualPromptFromCommand(rawCommand);
   if (intent === "implement_issue")
     parsed.implementation_prompt = implementationPromptFromCommand(rawText);
   return parsed;
@@ -1546,6 +1561,13 @@ function assistPromptFromCommand(command: LooseRecord) {
   return prompt.replace(/^(?:ask|explain)\b[:\s-]*/i, "").trim() || prompt;
 }
 
+function visualPromptFromCommand(command: LooseRecord) {
+  return String(command ?? "")
+    .trim()
+    .replace(/^(?:visual|viz|visualize)\b[:\s-]*/i, "")
+    .trim();
+}
+
 function issueImplementationRestPrefix(command: LooseRecord) {
   return command.command === "fix" ? "fix issue" : command.command;
 }
@@ -1561,6 +1583,16 @@ function normalizeIntent(command: LooseRecord) {
     command.startsWith("why ")
   ) {
     return "freeform_assist";
+  }
+  if (
+    command === "visual" ||
+    command.startsWith("visual ") ||
+    command === "viz" ||
+    command.startsWith("viz ") ||
+    command === "visualize" ||
+    command.startsWith("visualize ")
+  ) {
+    return "visual_assist";
   }
   if (["hatch", "hatch egg", "pr egg hatch", "hatch pr egg"].includes(command)) return "hatch";
   if (["fix ci", "fix-ci", "ci", "repair ci", "repair checks", "fix checks"].includes(command))

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -1433,7 +1433,7 @@ export function renderResponse(command: LooseRecord, dispatched: LooseRecord) {
       "",
       "Why human review is needed:",
       humanReviewJustification(reason),
-      ...(nextAction ? ["", "Recommended next action:", nextAction] : []),
+      ...(nextAction ? ["", "What the maintainer can do as a next step:", nextAction] : []),
       "",
       `I added \`${HUMAN_REVIEW_LABEL}\` and left the final call with a maintainer.`,
     ].join("\n");
@@ -1832,27 +1832,33 @@ function humanReviewJustification(reason: JsonValue) {
 
 function humanReviewNextAction(reason: JsonValue) {
   const text = String(reason ?? "");
+  const approveInstruction =
+    "If the maintainer accepts the current risk and wants ClawSweeper to continue merge gates, comment `@clawsweeper approve`.";
   if (/proof-label automation|proof[- ]label|proof gate|proof sufficien/i.test(text)) {
     return [
-      "Add redacted real behavior proof for the affected proof-label workflow, then comment",
-      "`@clawsweeper automerge` to ask ClawSweeper to re-review and continue.",
+      approveInstruction,
+      "If proof is still missing, add redacted real behavior proof for the affected proof-label workflow, then comment `@clawsweeper automerge` to re-review and continue.",
+      "If automation should not continue, leave `clawsweeper:human-review` in place or comment `@clawsweeper stop`.",
     ].join(" ");
   }
   if (/protected maintainer|maintainer validation|maintainer label/i.test(text)) {
     return [
-      "Have a maintainer review the flagged decision, then either add the missing proof and re-run",
-      "ClawSweeper or merge manually if the maintainer accepts the remaining risk.",
+      approveInstruction,
+      "If the flagged decision needs more evidence first, add the missing proof or resolve the maintainer-owned blocker, then comment `@clawsweeper automerge`.",
+      "If the maintainer wants to own landing outside automation, merge manually after repository gates pass.",
     ].join(" ");
   }
   if (/security|secret|credential|permission/i.test(text)) {
     return [
-      "Have a maintainer review the security-sensitive detail and provide an explicit safe path",
-      "before asking ClawSweeper to continue.",
+      approveInstruction,
+      "If the security-sensitive detail still needs changes, describe the safe path or push the fix, then comment `@clawsweeper automerge`.",
+      "If the risk should not be automated, keep the PR paused for manual review or comment `@clawsweeper stop`.",
     ].join(" ");
   }
   return [
-    "Review the reason above, resolve the blocker or explicitly accept the risk, then ask",
-    "ClawSweeper to continue if automation is still appropriate.",
+    approveInstruction,
+    "If more work is needed, resolve the blocker first, then comment `@clawsweeper automerge` to re-review and continue.",
+    "If automation should stay paused, leave `clawsweeper:human-review` in place or comment `@clawsweeper stop`.",
   ].join(" ");
 }
 

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -401,12 +401,23 @@ function classifyCommand(command: LooseRecord): JsonValue {
       actions: [{ action: "comment", status: execute ? "pending" : "planned" }],
     };
   }
-  if (command.intent === "freeform_assist") {
+  if (command.intent === "freeform_assist" || command.intent === "visual_assist") {
+    const isVisualAssist = command.intent === "visual_assist";
     if (String(issue.state ?? "").toLowerCase() !== "open") {
       return {
         ...next,
         status: "ready",
-        reason: "freeform assist requires an open issue or PR",
+        reason: isVisualAssist
+          ? "visual explainers require an open pull request"
+          : "freeform assist requires an open issue or PR",
+        actions: [{ action: "comment", status: execute ? "pending" : "planned" }],
+      };
+    }
+    if (isVisualAssist && target.kind !== "pull_request") {
+      return {
+        ...next,
+        status: "ready",
+        reason: "visual explainers are currently PR-only",
         actions: [{ action: "comment", status: execute ? "pending" : "planned" }],
       };
     }
@@ -417,6 +428,7 @@ function classifyCommand(command: LooseRecord): JsonValue {
         {
           action: "dispatch_assist",
           workflow: "assist.yml",
+          mode: isVisualAssist ? "visual" : "text",
           status: execute ? "pending" : "planned",
         },
         { action: "comment", status: execute ? "pending" : "planned" },
@@ -1384,7 +1396,11 @@ function executeCommand(command: LooseRecord) {
         return action;
       });
     }
-    if (command.intent === "freeform_assist" && command.issue_number && shouldDispatchAssist) {
+    if (
+      (command.intent === "freeform_assist" || command.intent === "visual_assist") &&
+      command.issue_number &&
+      shouldDispatchAssist
+    ) {
       const clawsweeper = dispatchClawSweeperAssist(command);
       dispatched = { ...dispatched, clawsweeper };
       command.actions = command.actions.map((action: JsonValue) => {
@@ -1935,19 +1951,23 @@ function dispatchClawSweeperReview(command: LooseRecord) {
 }
 
 function dispatchClawSweeperAssist(command: LooseRecord) {
+  const visual = command.intent === "visual_assist";
   const payload = JSON.stringify({
     event_type: "clawsweeper_assist",
     client_payload: {
       target_repo: command.repo,
       item_number: String(command.issue_number),
       item_kind: command.target?.kind ?? "",
+      mode: visual ? "visual" : "text",
       comment_id: String(command.comment_id ?? ""),
       comment_url: String(command.comment_url ?? ""),
       author: String(command.author ?? ""),
-      question: String(command.freeform_prompt ?? command.command ?? "").slice(0, 3000),
+      question: String(
+        visual ? (command.visual_prompt ?? "") : (command.freeform_prompt ?? command.command ?? ""),
+      ).slice(0, 3000),
       model: "gpt-5.5",
-      reasoning_effort: "low",
-      timeout_ms: "120000",
+      reasoning_effort: visual ? "medium" : "low",
+      timeout_ms: visual ? "480000" : "120000",
     },
   });
   const result = ghSpawn(

--- a/src/repair/comment-webhook.ts
+++ b/src/repair/comment-webhook.ts
@@ -7,7 +7,7 @@ import { parseCommand } from "./comment-router-core.js";
 
 const DEFAULT_PORT = 8787;
 const COMMAND_PATTERN =
-  /(^|[ \t\r\n])@(?:clawsweeper|openclaw-clawsweeper)\b(?:\[bot\])?|(^|[ \t\r\n])\/(?:clawsweeper|review|re-review|rerun[ -]?review|status|explain|fix|build|implement|create[ -]?pr|fix[ -]?issue|autofix|auto[ -]?fix|automerge|auto[ -]?merge|approve|stop|autoclose)\b/i;
+  /(^|[ \t\r\n])@(?:clawsweeper|openclaw-clawsweeper)\b(?:\[bot\])?|(^|[ \t\r\n])\/(?:clawsweeper|review|re-review|rerun[ -]?review|status|explain|visual|viz|visualize|fix|build|implement|create[ -]?pr|fix[ -]?issue|autofix|auto[ -]?fix|automerge|auto[ -]?merge|approve|stop|autoclose)\b/i;
 const ALLOWED_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
 
 type AcceptedIssueCommentWebhook = {

--- a/src/repair/limits.ts
+++ b/src/repair/limits.ts
@@ -13,11 +13,17 @@ export type WorkerConfig = {
     assist: {
       max: number;
     };
+    assist_visual: {
+      max: number;
+    };
   };
 };
 
 export type AutomationLimits = {
   assist: {
+    default: number;
+  };
+  assist_visual: {
     default: number;
   };
   review_shards: {
@@ -50,7 +56,8 @@ export type WorkerLane =
   | "automerge_repair"
   | "issue_implementation"
   | "exact_item"
-  | "assist";
+  | "assist"
+  | "assist_visual";
 
 export const WORKER_CONFIG = readWorkerConfig();
 export const AUTOMATION_LIMITS = deriveAutomationLimits(WORKER_CONFIG);
@@ -67,6 +74,9 @@ export function deriveAutomationLimits(config: WorkerConfig): AutomationLimits {
   return {
     assist: {
       default: Math.min(config.lanes.assist.max, max),
+    },
+    assist_visual: {
+      default: Math.min(config.lanes.assist_visual.max, max),
     },
     review_shards: {
       normal_default: percent(max, 70),
@@ -107,6 +117,7 @@ export function workerLimit(
 ): number {
   if (lane === "exact_item") return limits.review_shards.exact_item_default;
   if (lane === "assist") return priorityLimit(limits.assist.default, activeCritical);
+  if (lane === "assist_visual") return priorityLimit(limits.assist_visual.default, activeCritical);
   if (lane === "repair") return priorityLimit(limits.repair_live_runs.default, activeCritical);
   if (lane === "automerge_repair")
     return priorityLimit(limits.repair_live_runs.automerge_default, activeCritical);
@@ -157,6 +168,9 @@ function validateWorkerConfig(value: unknown): WorkerConfig {
     lanes: {
       assist: {
         max: positiveInteger(value, "lanes.assist.max"),
+      },
+      assist_visual: {
+        max: positiveInteger(value, "lanes.assist_visual.max"),
       },
     },
   };

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -97,6 +97,7 @@ function requiredWorkerLane(value: string): WorkerLane {
     "issue_implementation",
     "exact_item",
     "assist",
+    "assist_visual",
   ]);
   if (allowed.has(value as WorkerLane)) return value as WorkerLane;
   throw new Error(`unknown worker lane: ${value}`);

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -104,6 +104,8 @@ import {
   shouldRetryGh,
   shouldPlanItem,
   telegramVisibleProofLabelsForTest,
+  validateVisualExplainerHtml,
+  visualExplainerCspMeta,
   validateCloseDecision,
 } from "../dist/clawsweeper.js";
 import { checkConclusionForFrontMatter } from "../dist/commit-checks.js";
@@ -9475,4 +9477,19 @@ test("safeOutputTail tolerates missing process output", () => {
   assert.equal(safeOutputTail(undefined), "");
   assert.equal(safeOutputTail(null), "");
   assert.equal(safeOutputTail("abcdef", 3), "def");
+});
+
+test("visual explainer sanitizer allows self-contained inline interactions", () => {
+  const html = `<!doctype html><html><head>${visualExplainerCspMeta()}<style>button{color:blue}</style></head><body><button id="toggle">Toggle</button><section hidden>Risk map</section><script>document.getElementById("toggle").addEventListener("click",()=>{document.querySelector("section").hidden=false;});</script></body></html>`;
+  assert.deepEqual(validateVisualExplainerHtml(html), []);
+});
+
+test("visual explainer sanitizer rejects network and external resources", () => {
+  const html =
+    '<!doctype html><html><head><script src="https://example.com/app.js"></script></head><body><img src="https://example.com/a.png"><script>fetch("https://example.com"); localStorage.setItem("x","y");</script></body></html>';
+  const violations = validateVisualExplainerHtml(html);
+  assert.match(violations.join("\n"), /external script sources/);
+  assert.match(violations.join("\n"), /network APIs/);
+  assert.match(violations.join("\n"), /browser storage/);
+  assert.match(violations.join("\n"), /external resources/);
 });

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -95,6 +95,7 @@ import {
   sameAuthorCounterpartApplyReason,
   sanitizePublicSelfReferences,
   appendFloorBackfillCandidateNumbersForTest,
+  applyVisualExplainerCsp,
   pullRequestFilePathsFromContextForTest,
   selectDueCandidateNumbersForTest,
   shardItemNumbers,
@@ -9484,6 +9485,16 @@ test("visual explainer sanitizer allows self-contained inline interactions", () 
   assert.deepEqual(validateVisualExplainerHtml(html), []);
 });
 
+test("visual explainer CSP overrides model-provided policies", () => {
+  const loose =
+    '<!doctype html><html><head><meta http-equiv="Content-Security-Policy" content="default-src *"><title>PR</title></head><body></body></html>';
+  const html = applyVisualExplainerCsp(loose);
+  assert.equal((html.match(/Content-Security-Policy/g) ?? []).length, 1);
+  assert.doesNotMatch(html, /default-src \*/);
+  assert.match(html, /default-src 'none'/);
+  assert.match(html, /connect-src 'none'/);
+});
+
 test("visual explainer sanitizer rejects network and external resources", () => {
   const html =
     '<!doctype html><html><head><script src="https://example.com/app.js"></script></head><body><img src="https://example.com/a.png"><script>fetch("https://example.com"); localStorage.setItem("x","y");</script></body></html>';
@@ -9492,4 +9503,11 @@ test("visual explainer sanitizer rejects network and external resources", () => 
   assert.match(violations.join("\n"), /network APIs/);
   assert.match(violations.join("\n"), /browser storage/);
   assert.match(violations.join("\n"), /external resources/);
+});
+
+test("assist workflow leaves timeout buffer around visual Codex generation", () => {
+  const workflow = readFileSync(".github/workflows/assist.yml", "utf8");
+  const router = readFileSync("src/repair/comment-router.ts", "utf8");
+  assert.match(workflow, /timeout-minutes:\s+12/);
+  assert.match(router, /timeout_ms:\s+visual \? "480000" : "120000"/);
 });

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -835,6 +835,24 @@ test("parseCommand recognizes ClawSweeper bot mentions", () => {
     intent: "freeform_assist",
     freeform_prompt: "is this blocked on flaky CI?",
   });
+  assert.deepEqual(parseCommand("@clawsweeper visual focus on risky files"), {
+    trigger: "mention",
+    command: "visual focus on risky files",
+    intent: "visual_assist",
+    visual_prompt: "focus on risky files",
+  });
+  assert.deepEqual(parseCommand("/clawsweeper viz"), {
+    trigger: "slash",
+    command: "viz",
+    intent: "visual_assist",
+    visual_prompt: "",
+  });
+  assert.deepEqual(parseCommand("@clawsweeper visualize CI failures"), {
+    trigger: "mention",
+    command: "visualize ci failures",
+    intent: "visual_assist",
+    visual_prompt: "CI failures",
+  });
   assert.deepEqual(parseCommand("/clawsweeper explain why this PR is not automerge-ready"), {
     trigger: "slash",
     command: "explain why this pr is not automerge-ready",
@@ -1655,6 +1673,30 @@ test("renderResponse reports freeform assist dispatches as read-only", () => {
   assert.match(body, /separate answer comment/);
   assert.match(body, /will not edit the durable ClawSweeper review comment/);
   assert.match(body, /why did automerge stop here/);
+  assert.doesNotMatch(body, /repair worker/);
+});
+
+test("renderResponse reports visual assist dispatches as read-only artifacts", () => {
+  const body = renderResponse(
+    {
+      comment_id: "463",
+      intent: "visual_assist",
+      visual_prompt: "focus on risky files",
+      target: { head_sha: "def463" },
+    },
+    {
+      clawsweeper: {
+        workflow: "assist.yml",
+        event: "repository_dispatch",
+      },
+    },
+  );
+
+  assert.match(body, /visual explainer is being generated/);
+  assert.match(body, /read-only visual pass/);
+  assert.match(body, /artifact link comment/);
+  assert.match(body, /will not edit the durable ClawSweeper review comment/);
+  assert.match(body, /focus on risky files/);
   assert.doesNotMatch(body, /repair worker/);
 });
 

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -1773,9 +1773,11 @@ test("renderResponse reports explicit human-review pause actions", () => {
   assert.match(body, /pausing this repair loop/);
   assert.match(body, /Why human review is needed:/);
   assert.match(body, /proof-label or proof-gate automation/);
-  assert.match(body, /Recommended next action:/);
-  assert.match(body, /Add redacted real behavior proof/);
+  assert.match(body, /What the maintainer can do as a next step:/);
+  assert.match(body, /@clawsweeper approve/);
+  assert.match(body, /add redacted real behavior proof/);
   assert.match(body, /@clawsweeper automerge/);
+  assert.match(body, /@clawsweeper stop/);
   assert.match(body, /`clawsweeper:human-review`/);
   assert.doesNotMatch(body, /did not dispatch/);
 });
@@ -1794,8 +1796,11 @@ test("renderResponse gives generic human-review pauses a next action", () => {
 
   assert.match(body, /Why human review is needed:/);
   assert.match(body, /resolved or accepted by a maintainer/);
-  assert.match(body, /Recommended next action:/);
-  assert.match(body, /resolve the blocker or explicitly accept the risk/);
+  assert.match(body, /What the maintainer can do as a next step:/);
+  assert.match(body, /@clawsweeper approve/);
+  assert.match(body, /resolve the blocker first/);
+  assert.match(body, /@clawsweeper automerge/);
+  assert.match(body, /@clawsweeper stop/);
   assert.match(body, /`clawsweeper:human-review`/);
 });
 

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -55,8 +55,11 @@ test("worker scheduler lets background lanes yield to active work", () => {
   assert.equal(workerLimit("commit_review", { activeCritical: 49 }), 1);
   assert.equal(workerLimit("repair"), AUTOMATION_LIMITS.repair_live_runs.default);
   assert.equal(AUTOMATION_LIMITS.assist.default, 5);
+  assert.equal(AUTOMATION_LIMITS.assist_visual.default, 2);
   assert.equal(workerLimit("assist"), 5);
+  assert.equal(workerLimit("assist_visual"), 2);
   assert.equal(workerLimit("assist", { activeCritical: 55 }), 2);
+  assert.equal(workerLimit("assist_visual", { activeCritical: 56 }), 1);
 });
 
 test("workflow utilities derive artifact item numbers and action counts", () => {


### PR DESCRIPTION
## Summary
- add the `@clawsweeper visual <prompt>` PR explainer command with `viz` and `visualize` aliases
- route visual requests through the read-only HTML explainer assist lane and publish the generated HTML as a workflow artifact
- harden first-version execution by adding workflow timeout buffer and always enforcing ClawSweeper strict CSP

## Validation
- `pnpm run check`