### PR TITLE
fix(assist): keep visual dispatch payload within GitHub limit

### DIFF
--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -1568,6 +1568,24 @@ function visualPromptFromCommand(command: LooseRecord) {
     .trim();
 }
 
+export function assistDispatchClientPayload(command: LooseRecord): LooseRecord {
+  const visual = command.intent === "visual_assist";
+  return {
+    target_repo: command.repo,
+    item_number: String(command.issue_number),
+    mode: visual ? "visual" : "text",
+    comment_id: String(command.comment_id ?? ""),
+    comment_url: String(command.comment_url ?? ""),
+    author: String(command.author ?? ""),
+    question: String(
+      visual ? (command.visual_prompt ?? "") : (command.freeform_prompt ?? command.command ?? ""),
+    ).slice(0, 3000),
+    model: "gpt-5.5",
+    reasoning_effort: visual ? "medium" : "low",
+    timeout_ms: visual ? "480000" : "120000",
+  };
+}
+
 function issueImplementationRestPrefix(command: LooseRecord) {
   return command.command === "fix" ? "fix issue" : command.command;
 }

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -33,6 +33,7 @@ import {
   automergeReadinessRepairReason,
   automergeRebaseRepairReason,
   automergeTransientWaitConfig,
+  assistDispatchClientPayload,
   buildAutomergeMergeArgs,
   buildAutomergeSquashMessage,
   commandHasAction,
@@ -1951,24 +1952,9 @@ function dispatchClawSweeperReview(command: LooseRecord) {
 }
 
 function dispatchClawSweeperAssist(command: LooseRecord) {
-  const visual = command.intent === "visual_assist";
   const payload = JSON.stringify({
     event_type: "clawsweeper_assist",
-    client_payload: {
-      target_repo: command.repo,
-      item_number: String(command.issue_number),
-      item_kind: command.target?.kind ?? "",
-      mode: visual ? "visual" : "text",
-      comment_id: String(command.comment_id ?? ""),
-      comment_url: String(command.comment_url ?? ""),
-      author: String(command.author ?? ""),
-      question: String(
-        visual ? (command.visual_prompt ?? "") : (command.freeform_prompt ?? command.command ?? ""),
-      ).slice(0, 3000),
-      model: "gpt-5.5",
-      reasoning_effort: visual ? "medium" : "low",
-      timeout_ms: visual ? "480000" : "120000",
-    },
+    client_payload: assistDispatchClientPayload(command),
   });
   const result = ghSpawn(
     ["api", `repos/${reviewRepo}/dispatches`, "--method", "POST", "--input", "-"],

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -9507,7 +9507,7 @@ test("visual explainer sanitizer rejects network and external resources", () => 
 
 test("assist workflow leaves timeout buffer around visual Codex generation", () => {
   const workflow = readFileSync(".github/workflows/assist.yml", "utf8");
-  const router = readFileSync("src/repair/comment-router.ts", "utf8");
+  const routerCore = readFileSync("src/repair/comment-router-core.ts", "utf8");
   assert.match(workflow, /timeout-minutes:\s+12/);
-  assert.match(router, /timeout_ms:\s+visual \? "480000" : "120000"/);
+  assert.match(routerCore, /timeout_ms:\s+visual \? "480000" : "120000"/);
 });

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -19,6 +19,7 @@ import {
   automergeJobPath,
   automergeReadinessRepairReason,
   automergeTransientWaitConfig,
+  assistDispatchClientPayload,
   buildAutomergeMergeArgs,
   buildAutomergeSquashMessage,
   commandHasAction,
@@ -853,6 +854,33 @@ test("parseCommand recognizes ClawSweeper bot mentions", () => {
     intent: "visual_assist",
     visual_prompt: "CI failures",
   });
+  const visualPayload = assistDispatchClientPayload({
+    intent: "visual_assist",
+    repo: "openclaw/openclaw",
+    issue_number: 72343,
+    comment_id: "4512657637",
+    comment_url: "https://github.com/openclaw/openclaw/pull/72343#issuecomment-4512657637",
+    author: "maintainer",
+    target: { kind: "pull_request" },
+    visual_prompt: "eli5",
+  });
+  assert.deepEqual(Object.keys(visualPayload).sort(), [
+    "author",
+    "comment_id",
+    "comment_url",
+    "item_number",
+    "mode",
+    "model",
+    "question",
+    "reasoning_effort",
+    "target_repo",
+    "timeout_ms",
+  ]);
+  assert.equal(Object.keys(visualPayload).length, 10);
+  assert.equal(visualPayload.mode, "visual");
+  assert.equal(visualPayload.question, "eli5");
+  assert.equal(visualPayload.reasoning_effort, "medium");
+  assert.equal(visualPayload.timeout_ms, "480000");
   assert.deepEqual(parseCommand("/clawsweeper explain why this PR is not automerge-ready"), {
     trigger: "slash",
     command: "explain why this pr is not automerge-ready",


### PR DESCRIPTION
## Summary
- remove the unused assist dispatch item_kind payload field so repository_dispatch stays within GitHub's 10-property limit
- centralize assist dispatch payload construction for text and visual assist
- add regression coverage for the visual payload property count

## Validation
- pnpm run build:repair
- node --test test/repair/comment-router-core.test.ts
- pnpm run format:check
- pnpm run check