### PR TITLE
fix(assist): retry visual explainer sanitizer failures

### DIFF
--- a/.github/workflows/assist.yml
+++ b/.github/workflows/assist.yml
@@ -45,7 +45,7 @@ on:
           - visual
 
 permissions:
-  contents: read
+  contents: write
   issues: write
   pull-requests: read
 
@@ -146,6 +146,14 @@ jobs:
           owner: ${{ vars.CLAWSWEEPER_ALLOWED_OWNER || github.repository_owner }}
           permission-issues: write
           permission-pull-requests: write
+          permission-contents: write
+
+      - name: Create state repository token
+        id: state_token
+        uses: ./.github/actions/create-state-token
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
 
       - uses: ./.github/actions/setup-pnpm
         with:
@@ -158,6 +166,10 @@ jobs:
       - name: Answer maintainer question
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          CLAWSWEEPER_VISUAL_PUBLISH_TOKEN: ${{ steps.state_token.outputs.token }}
+          CLAWSWEEPER_VISUAL_PUBLISH_REPO: openclaw/clawsweeper-state
+          CLAWSWEEPER_VISUAL_PUBLISH_BRANCH: state
+          CLAWSWEEPER_VISUAL_PUBLISH_BASE_URL: https://openclaw.github.io/clawsweeper-state
           TARGET_REPO: ${{ github.event.client_payload.target_repo || inputs.target_repo }}
           ITEM_NUMBER: ${{ github.event.client_payload.item_number || inputs.item_number }}
           QUESTION: ${{ github.event.client_payload.question || inputs.question }}

--- a/.github/workflows/assist.yml
+++ b/.github/workflows/assist.yml
@@ -167,7 +167,7 @@ jobs:
           AUTHOR: ${{ github.event.client_payload.author || inputs.author || '' }}
           MODEL: ${{ github.event.client_payload.model || 'gpt-5.5' }}
           REASONING_EFFORT: ${{ github.event.client_payload.reasoning_effort || 'low' }}
-          TIMEOUT_MS: ${{ github.event.client_payload.timeout_ms || '120000' }}
+          TIMEOUT_MS: ${{ github.event.client_payload.timeout_ms || ((github.event.client_payload.mode || inputs.mode || 'text') == 'visual' && '480000') || '120000' }}
         run: |
           set -euo pipefail
           node dist/clawsweeper.js assist \

--- a/config/automation-limits.json
+++ b/config/automation-limits.json
@@ -12,5 +12,17 @@
     "assist_visual": {
       "max": 2
     }
+  },
+  "assist_visual": {
+    "publish": {
+      "enabled": true,
+      "provider": "github_pages",
+      "repository": "openclaw/clawsweeper-state",
+      "branch": "state",
+      "base_url": "https://openclaw.github.io/clawsweeper-state",
+      "public_only": true,
+      "retention_days": 30,
+      "required": false
+    }
   }
 }

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -39,6 +39,12 @@ The mental model:
 | `workers.minimum_background` | 10 | Target floor for background progress when enough global capacity is available. |
 | `lanes.assist.max` | 5 | Maximum concurrent lightweight assist jobs. |
 | `lanes.assist_visual.max` | 2 | Maximum concurrent visual assist explainer jobs. |
+| `assist_visual.publish.enabled` | true | Enables direct GitHub Pages publishing for visual explainers. |
+| `assist_visual.publish.repository` | openclaw/clawsweeper-state | Generated-state repository that stores hosted visual explainer HTML. |
+| `assist_visual.publish.branch` | state | Generated-state branch used as the GitHub Pages source. |
+| `assist_visual.publish.base_url` | https://openclaw.github.io/clawsweeper-state | Public base URL for hosted visual explainer pages. |
+| `assist_visual.publish.public_only` | true | Publishes hosted pages only for public target repositories. |
+| `assist_visual.publish.retention_days` | 30 | Intended retention window for generated visual explainer pages. |
 
 ## Derived Limits
 

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -15,9 +15,22 @@ ClawSweeper should stay simple at the orchestration boundary:
    not independent sources of truth.
 
 Visual assist explainers are read-only generated artifacts. They may use an LLM
-to render self-contained HTML/CSS/inline-JS from deterministic PR context, but
-the sanitizer, artifact publication, permissions, and GitHub comments remain
-deterministic ClawSweeper responsibilities.
+to render self-contained HTML/CSS from deterministic PR context, but the
+sanitizer, hosted-page publication, artifact fallback, permissions, and GitHub
+comments remain deterministic ClawSweeper responsibilities.
+
+Visual explainers publish a directly clickable GitHub Pages URL through the
+generated state repository (`openclaw/clawsweeper-state`) when
+`assist_visual.publish.enabled` is true and the target repository is public.
+The workflow writes sanitized HTML to the state repo's `state` branch; it does
+not mutate the main ClawSweeper repository's Pages source or generated content.
+The canonical path shape is
+`visual/<owner>/<repo>/pr-<number>/<head-sha-short>/<comment-id>.html`, with
+`visual/<owner>/<repo>/pr-<number>/latest.html` updated to the newest generated
+page. Workflow artifacts remain the fallback/debug copy. Private target
+repositories, disabled publishing, missing Pages configuration, or publish
+errors must not block the read-only assist response; ClawSweeper posts the
+artifact link and a short hosted-page failure reason instead.
 
 ## Canonical Job Intent
 

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -1560,6 +1560,10 @@ function gh(args: string[]): string {
   return run("gh", ["--repo", targetRepo(), ...args]);
 }
 
+function ghWithToken(args: string[], token: string): string {
+  return run("gh", args, { env: { ...process.env, GH_TOKEN: token } });
+}
+
 function sleepMs(milliseconds: number): void {
   if (milliseconds <= 0) return;
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
@@ -5219,6 +5223,98 @@ function visualExplainerArtifactName(repo: string, number: number, headSha: stri
   return `${slug}-${number}-${sha}.html`;
 }
 
+function visualExplainerPathSegment(value: string): string {
+  const segment = value.toLowerCase().replace(/[^a-z0-9_.-]+/g, "-");
+  return segment.replace(/^-+|-+$/g, "") || "unknown";
+}
+
+export function visualExplainerPublishPathsForTest(options: {
+  targetRepo: string;
+  itemNumber: number;
+  headSha: string;
+  commentId: string;
+}): { versionPath: string; latestPath: string } {
+  const [owner = "unknown", repo = "unknown"] = options.targetRepo.split("/");
+  const sha = /^[0-9a-f]{7,40}$/i.test(options.headSha)
+    ? options.headSha.slice(0, 12).toLowerCase()
+    : "unknown";
+  const commentId = visualExplainerPathSegment(options.commentId || "unknown");
+  const base = [
+    "visual",
+    visualExplainerPathSegment(owner),
+    visualExplainerPathSegment(repo),
+    `pr-${Math.max(0, Math.trunc(options.itemNumber)) || 0}`,
+  ].join("/");
+  return {
+    versionPath: `${base}/${sha}/${commentId}.html`,
+    latestPath: `${base}/latest.html`,
+  };
+}
+
+function visualExplainerPublishBaseUrl(): string {
+  const configured = process.env.CLAWSWEEPER_VISUAL_PUBLISH_BASE_URL?.trim();
+  if (configured) return configured.replace(/\/+$/g, "");
+  const repository = visualExplainerPublishRepo();
+  const [owner, repo] = repository.split("/");
+  if (!owner || !repo) return "";
+  return `https://${owner}.github.io/${repo}`;
+}
+
+export function visualExplainerHostedUrlForTest(baseUrl: string, path: string): string {
+  const base = baseUrl.trim().replace(/\/+$/g, "");
+  const cleanPath = path.replace(/^\/+/g, "");
+  return base && cleanPath ? `${base}/${cleanPath}` : "";
+}
+
+type VisualExplainerHostedUrlProbe = (url: string) => { ok: boolean; detail: string };
+
+function defaultVisualExplainerHostedUrlProbe(url: string): { ok: boolean; detail: string } {
+  const result = spawnSync("curl", ["-fsSIL", "--max-time", "10", url], {
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024,
+  });
+  if (result.status === 0) return { ok: true, detail: "" };
+  const detail = safeOutputTail(result.stderr) || safeOutputTail(result.stdout);
+  return { ok: false, detail: detail || `curl exited ${result.status ?? "unknown"}` };
+}
+
+function sleepSync(ms: number): void {
+  if (ms <= 0) return;
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function visualExplainerHostedUrlIsAvailable(
+  url: string,
+  options: {
+    attempts?: number;
+    delayMs?: number;
+    probe?: VisualExplainerHostedUrlProbe;
+  } = {},
+): { ok: boolean; detail: string } {
+  const attempts = Math.max(1, Math.trunc(options.attempts ?? 8));
+  const delayMs = Math.max(0, Math.trunc(options.delayMs ?? 3_000));
+  const probe = options.probe ?? defaultVisualExplainerHostedUrlProbe;
+  let lastDetail = "";
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const result = probe(url);
+    if (result.ok) return { ok: true, detail: "" };
+    lastDetail = result.detail;
+    if (attempt < attempts) sleepSync(delayMs);
+  }
+  return { ok: false, detail: lastDetail };
+}
+
+export function visualExplainerHostedUrlIsAvailableForTest(
+  url: string,
+  options: {
+    attempts?: number;
+    delayMs?: number;
+    probe?: VisualExplainerHostedUrlProbe;
+  } = {},
+): { ok: boolean; detail: string } {
+  return visualExplainerHostedUrlIsAvailable(url, options);
+}
+
 function visualExplainerRunUrl(): string {
   const server = process.env.GITHUB_SERVER_URL || "https://github.com";
   const repository = process.env.GITHUB_REPOSITORY || "";
@@ -5231,6 +5327,204 @@ function visualExplainerHeadSha(context: ItemContext): string {
   const head = asRecord(pull.head);
   const sha = head.sha;
   return typeof sha === "string" && sha ? sha : "unknown";
+}
+
+function visualExplainerPublishEnabled(): boolean {
+  return process.env.CLAWSWEEPER_VISUAL_PUBLISH_ENABLED !== "false";
+}
+
+function visualExplainerPublishPublicOnly(): boolean {
+  return process.env.CLAWSWEEPER_VISUAL_PUBLISH_PUBLIC_ONLY !== "false";
+}
+
+function visualExplainerPublishRepo(): string {
+  return process.env.CLAWSWEEPER_VISUAL_PUBLISH_REPO || "openclaw/clawsweeper-state";
+}
+
+function visualExplainerPublishBranch(): string {
+  return process.env.CLAWSWEEPER_VISUAL_PUBLISH_BRANCH || "state";
+}
+
+function visualExplainerPublishRetentionDays(): number {
+  const parsed = Number(process.env.CLAWSWEEPER_VISUAL_PUBLISH_RETENTION_DAYS ?? "30");
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 30;
+}
+
+function visualExplainerPublishToken(): string {
+  return process.env.CLAWSWEEPER_VISUAL_PUBLISH_TOKEN || process.env.GH_TOKEN || "";
+}
+
+function fetchTargetRepoIsPrivate(): boolean {
+  const repo = ghJson<{ private?: boolean }>([
+    "api",
+    `repos/${targetRepo()}`,
+    "--jq",
+    "{private:.private}",
+  ]);
+  return repo.private === true;
+}
+
+function visualPublishGh(args: string[], token: string): string {
+  return token ? ghWithToken(args, token) : ghWithRetry(args);
+}
+
+function visualPublishJson<T>(args: string[], token: string): T {
+  const output = visualPublishGh(args, token);
+  return parseGhJson<T>(output, args);
+}
+
+function visualPublishContentSha(
+  repo: string,
+  path: string,
+  branch: string,
+  token: string,
+): string | null {
+  try {
+    const result = visualPublishJson<{ sha?: string }>(
+      [
+        "api",
+        `repos/${repo}/contents/${path}?ref=${encodeURIComponent(branch)}`,
+        "--jq",
+        "{sha:(.sha // null)}",
+      ],
+      token,
+    );
+    return typeof result.sha === "string" && result.sha ? result.sha : null;
+  } catch {
+    return null;
+  }
+}
+
+function visualPublishBranchExists(repo: string, branch: string, token: string): boolean {
+  try {
+    visualPublishGh(["api", `repos/${repo}/git/ref/heads/${branch}`], token);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function ensureVisualPublishBranch(repo: string, branch: string, token: string): void {
+  if (visualPublishBranchExists(repo, branch, token)) return;
+  const repository = visualPublishJson<{ default_branch?: string }>(
+    ["api", `repos/${repo}`, "--jq", "{default_branch:.default_branch}"],
+    token,
+  );
+  const defaultBranch = repository.default_branch || "main";
+  const base = visualPublishJson<{ object?: { sha?: string } }>(
+    ["api", `repos/${repo}/git/ref/heads/${defaultBranch}`, "--jq", "{object:{sha:.object.sha}}"],
+    token,
+  );
+  const sha = base.object?.sha;
+  if (!sha)
+    throw new Error(`could not resolve ${defaultBranch} SHA for visual publish branch creation`);
+  visualPublishGh(
+    [
+      "api",
+      `repos/${repo}/git/refs`,
+      "--method",
+      "POST",
+      "-f",
+      `ref=refs/heads/${branch}`,
+      "-f",
+      `sha=${sha}`,
+    ],
+    token,
+  );
+}
+
+function putVisualPublishFile(options: {
+  repo: string;
+  path: string;
+  content: string;
+  branch: string;
+  message: string;
+  token: string;
+}): void {
+  const args = [
+    "api",
+    `repos/${options.repo}/contents/${options.path}`,
+    "--method",
+    "PUT",
+    "-f",
+    `message=${options.message}`,
+    "-f",
+    `branch=${options.branch}`,
+    "-f",
+    `content=${Buffer.from(options.content, "utf8").toString("base64")}`,
+  ];
+  const sha = visualPublishContentSha(options.repo, options.path, options.branch, options.token);
+  if (sha) args.push("-f", `sha=${sha}`);
+  visualPublishGh(args, options.token);
+}
+
+function pruneExpiredVisualExplainers(paths: readonly string[], now = Date.now()): string[] {
+  const retentionMs = visualExplainerPublishRetentionDays() * 24 * 60 * 60 * 1000;
+  const cutoff = now - retentionMs;
+  return paths.filter((path) => {
+    const normalized = path.replaceAll("\\", "/");
+    if (!normalized.startsWith("visual/")) return false;
+    const match = normalized.match(/\/(\d{4}-\d{2}-\d{2})\//);
+    if (!match?.[1]) return false;
+    const timestamp = Date.parse(`${match[1]}T00:00:00Z`);
+    return Number.isFinite(timestamp) && timestamp < cutoff;
+  });
+}
+
+export function pruneExpiredVisualExplainersForTest(
+  paths: readonly string[],
+  now?: number,
+): string[] {
+  return pruneExpiredVisualExplainers(paths, now);
+}
+
+function publishVisualExplainerHtml(options: {
+  item: Item;
+  context: ItemContext;
+  sourceCommentId: string;
+  html: string;
+}): { url: string; versionPath: string; latestPath: string } | null {
+  if (!visualExplainerPublishEnabled()) return null;
+  if (visualExplainerPublishPublicOnly() && fetchTargetRepoIsPrivate()) return null;
+  const baseUrl = visualExplainerPublishBaseUrl();
+  if (!baseUrl) throw new Error("visual explainer Pages base URL is unavailable");
+  const paths = visualExplainerPublishPathsForTest({
+    targetRepo: options.item.repo,
+    itemNumber: options.item.number,
+    headSha: visualExplainerHeadSha(options.context),
+    commentId: options.sourceCommentId,
+  });
+  const publishRepo = visualExplainerPublishRepo();
+  const branch = visualExplainerPublishBranch();
+  const token = visualExplainerPublishToken();
+  ensureVisualPublishBranch(publishRepo, branch, token);
+  const message = `chore: publish visual explainer for ${options.item.repo}#${options.item.number} [skip ci]`;
+  putVisualPublishFile({
+    repo: publishRepo,
+    path: paths.versionPath,
+    content: options.html,
+    branch,
+    message,
+    token,
+  });
+  putVisualPublishFile({
+    repo: publishRepo,
+    path: paths.latestPath,
+    content: options.html,
+    branch,
+    message,
+    token,
+  });
+  const url = visualExplainerHostedUrlForTest(baseUrl, paths.latestPath);
+  const available = visualExplainerHostedUrlIsAvailable(url);
+  if (!available.ok) {
+    throw new Error(`hosted visual explainer URL is not available: ${available.detail}`);
+  }
+  return {
+    url,
+    versionPath: paths.versionPath,
+    latestPath: paths.latestPath,
+  };
 }
 
 function buildVisualExplainerPrompt(options: {
@@ -5616,6 +5910,8 @@ function renderAssistComment(options: {
 function renderVisualExplainerComment(options: {
   artifactName: string;
   runUrl: string;
+  hostedUrl?: string | null;
+  publishError?: string | null;
   model: string;
   reasoningEffort: string;
   sourceCommentUrl: string;
@@ -5628,19 +5924,33 @@ function renderVisualExplainerComment(options: {
   const artifactLine = options.runUrl
     ? `Artifact: [${options.artifactName}](${options.runUrl})`
     : `Artifact: ${options.artifactName}`;
+  const openLine = options.hostedUrl ? `Open visual explainer: ${options.hostedUrl}` : null;
+  const publishLine = options.publishError
+    ? `Hosted page: unavailable (${truncateText(options.publishError, 220)}).`
+    : null;
   return [
-    "ClawSweeper visual assist: I generated a read-only interactive HTML explainer for this PR.",
+    "ClawSweeper visual assist: I generated a read-only HTML explainer for this PR.",
     "",
+    openLine,
+    publishLine,
     artifactLine,
     `Focus: ${options.focusPrompt || "default maintainer overview"}`,
     "",
-    "This artifact is explanatory only. It is not a ClawSweeper review verdict and it does not close, merge, label, push, repair, or approve this PR.",
+    "This explainer is explanatory only. It is not a ClawSweeper review verdict and it does not close, merge, label, push, repair, or approve this PR.",
     "",
     "---",
     `${sourceLine}`,
     `Visual assist model: ${options.model}, reasoning ${options.reasoningEffort}.`,
     assistCommentMarker(options.sourceCommentId),
-  ].join("\n");
+  ]
+    .filter((line) => line !== null)
+    .join("\n");
+}
+
+export function renderVisualExplainerCommentForTest(
+  options: Parameters<typeof renderVisualExplainerComment>[0],
+): string {
+  return renderVisualExplainerComment(options);
 }
 
 function renderVisualExplainerFallbackComment(options: {
@@ -13830,9 +14140,24 @@ function assistCommand(args: Args): void {
       );
       const artifactPath = join(outputDir, artifactName);
       writeFileSync(artifactPath, html, "utf8");
+      let hostedUrl: string | null = null;
+      let publishError: string | null = null;
+      try {
+        const published = publishVisualExplainerHtml({
+          item,
+          context,
+          sourceCommentId,
+          html,
+        });
+        hostedUrl = published?.url ?? null;
+      } catch (error) {
+        publishError = error instanceof Error ? error.message : String(error);
+      }
       const comment = renderVisualExplainerComment({
         artifactName,
         runUrl: visualExplainerRunUrl(),
+        hostedUrl,
+        publishError,
         model,
         reasoningEffort,
         sourceCommentUrl,
@@ -13848,6 +14173,8 @@ function assistCommand(args: Args): void {
           model,
           reasoningEffort,
           artifact: artifactPath,
+          hostedUrl,
+          publishError,
         }),
       );
       return;

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -5271,7 +5271,7 @@ function buildVisualExplainerPrompt(options: {
     "HTML contract:",
     "- Return only the complete HTML document, starting with <!doctype html> or <html>.",
     "- Inline CSS is allowed.",
-    "- Inline JavaScript is allowed only for local interactions such as filters, tabs, collapsible sections, sorting, and toggles.",
+    "- JavaScript is not allowed in the first visual explainer version. Do not include script tags or event-handler attributes.",
     "- Do not load external scripts, stylesheets, fonts, iframes, images, or other assets.",
     "- Do not make network requests.",
     "- Do not use eval, Function, dynamic import, workers, cookies, localStorage, sessionStorage, forms, or navigation-changing JavaScript.",
@@ -5285,7 +5285,7 @@ function buildVisualExplainerPrompt(options: {
     "- CI/check summary if available",
     "- review-comment grouping",
     "- timeline or commit list",
-    "- filters or toggles that help large PRs become skimmable",
+    "- static sections and tables that help large PRs become skimmable",
     "",
     "Maintainer focus prompt:",
     options.focusPrompt || "Create a balanced maintainer overview of this PR.",
@@ -5297,10 +5297,49 @@ function buildVisualExplainerPrompt(options: {
   ].join("\n");
 }
 
+function buildVisualExplainerRepairPrompt(options: {
+  originalPrompt: string;
+  html: string;
+  violations: readonly string[];
+}): string {
+  return [
+    "The previous ClawSweeper visual assist HTML did not pass safety checks.",
+    "",
+    "Rewrite it as one complete self-contained HTML document that preserves the same PR explanation and focus while fixing every violation.",
+    "",
+    "Safety violations to fix:",
+    ...options.violations.map((violation) => `- ${violation}`),
+    "",
+    "Hard requirements:",
+    "- Return only the complete HTML document, starting with <!doctype html> or <html>.",
+    "- Do not use script tags, event-handler attributes, external assets, network APIs, forms, storage, navigation-changing JavaScript, workers, dynamic imports, eval, or Function.",
+    "- Inline CSS is allowed. JavaScript is not allowed in the first visual explainer version.",
+    "- Keep the footer metadata from the original request.",
+    "",
+    "Original request:",
+    "```markdown",
+    options.originalPrompt,
+    "```",
+    "",
+    "Rejected HTML:",
+    "```html",
+    options.html,
+    "```",
+  ].join("\n");
+}
+
+export function buildVisualExplainerRepairPromptForTest(
+  options: Parameters<typeof buildVisualExplainerRepairPrompt>[0],
+): string {
+  return buildVisualExplainerRepairPrompt(options);
+}
+
 export function validateVisualExplainerHtml(html: string): string[] {
   const text = String(html ?? "");
   const violations: string[] = [];
   const checks: Array<[RegExp, string]> = [
+    [/<script\b/i, "scripts are not allowed"],
+    [/\s+on[a-z]+\s*=/i, "event-handler attributes are not allowed"],
     [/<script\b[^>]*\bsrc\s*=/i, "external script sources are not allowed"],
     [/<link\b[^>]*\bhref\s*=/i, "external stylesheets or linked resources are not allowed"],
     [/<iframe\b/i, "iframes are not allowed"],
@@ -5333,9 +5372,131 @@ export function visualExplainerCspMeta(): string {
   return `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:; base-uri 'none'; form-action 'none'; connect-src 'none'; frame-ancestors 'none'">`;
 }
 
+function isAsciiWhitespace(char: string): boolean {
+  return char === " " || char === "\n" || char === "\r" || char === "\t" || char === "\f";
+}
+
+function isScriptOpenTagAt(lowerHtml: string, index: number): boolean {
+  if (!lowerHtml.startsWith("<script", index)) return false;
+  const next = lowerHtml[index + "<script".length] ?? "";
+  return next === "" || next === ">" || next === "/" || isAsciiWhitespace(next);
+}
+
+function stripScriptElements(html: string): string {
+  const lowerHtml = html.toLowerCase();
+  let cursor = 0;
+  let output = "";
+  while (cursor < html.length) {
+    const tagStart = lowerHtml.indexOf("<script", cursor);
+    if (tagStart < 0) return output + html.slice(cursor);
+    if (!isScriptOpenTagAt(lowerHtml, tagStart)) {
+      output += html.slice(cursor, tagStart + 1);
+      cursor = tagStart + 1;
+      continue;
+    }
+    output += html.slice(cursor, tagStart);
+    const openTagEnd = html.indexOf(">", tagStart);
+    if (openTagEnd < 0) return output;
+    const closeTagStart = lowerHtml.indexOf("</script", openTagEnd + 1);
+    if (closeTagStart < 0) return output;
+    const closeTagEnd = html.indexOf(">", closeTagStart);
+    if (closeTagEnd < 0) return output;
+    cursor = closeTagEnd + 1;
+  }
+  return output;
+}
+
+function stripEventHandlerAttributesFromTag(tag: string): string {
+  if (tag.startsWith("</") || tag.startsWith("<!") || tag.startsWith("<?")) return tag;
+  let cursor = 1;
+  while (cursor < tag.length && !isAsciiWhitespace(tag[cursor] ?? "") && tag[cursor] !== ">") {
+    cursor += 1;
+  }
+  let output = tag.slice(0, cursor);
+  while (cursor < tag.length) {
+    const attrStart = cursor;
+    while (cursor < tag.length && isAsciiWhitespace(tag[cursor] ?? "")) cursor += 1;
+    const leadingWhitespace = tag.slice(attrStart, cursor);
+    if (cursor >= tag.length || tag[cursor] === ">" || tag[cursor] === "/") {
+      output += tag.slice(attrStart);
+      break;
+    }
+    const nameStart = cursor;
+    while (
+      cursor < tag.length &&
+      !isAsciiWhitespace(tag[cursor] ?? "") &&
+      tag[cursor] !== "=" &&
+      tag[cursor] !== ">" &&
+      tag[cursor] !== "/"
+    ) {
+      cursor += 1;
+    }
+    const attrName = tag.slice(nameStart, cursor);
+    while (cursor < tag.length && isAsciiWhitespace(tag[cursor] ?? "")) cursor += 1;
+    if (tag[cursor] === "=") {
+      cursor += 1;
+      while (cursor < tag.length && isAsciiWhitespace(tag[cursor] ?? "")) cursor += 1;
+      const quote = tag[cursor];
+      if (quote === '"' || quote === "'") {
+        cursor += 1;
+        const valueEnd = tag.indexOf(quote, cursor);
+        cursor = valueEnd < 0 ? tag.length : valueEnd + 1;
+      } else {
+        while (
+          cursor < tag.length &&
+          !isAsciiWhitespace(tag[cursor] ?? "") &&
+          tag[cursor] !== ">"
+        ) {
+          cursor += 1;
+        }
+      }
+    }
+    if (!attrName.toLowerCase().startsWith("on"))
+      output += leadingWhitespace + tag.slice(nameStart, cursor);
+  }
+  return output;
+}
+
+function stripEventHandlerAttributes(html: string): string {
+  let cursor = 0;
+  let output = "";
+  while (cursor < html.length) {
+    const tagStart = html.indexOf("<", cursor);
+    if (tagStart < 0) return output + html.slice(cursor);
+    const tagEnd = html.indexOf(">", tagStart + 1);
+    if (tagEnd < 0) return output + html.slice(cursor);
+    output += html.slice(cursor, tagStart);
+    output += stripEventHandlerAttributesFromTag(html.slice(tagStart, tagEnd + 1));
+    cursor = tagEnd + 1;
+  }
+  return output;
+}
+
+function neutralizeDynamicCodeText(html: string): string {
+  let text = html;
+  for (const token of [
+    "eval(",
+    "Function(",
+    "importScripts(",
+    "import(",
+    "Worker(",
+    "SharedWorker(",
+    "ServiceWorker(",
+  ]) {
+    text = text.split(token).join(`${token.slice(0, -1)} call `);
+  }
+  return text;
+}
+
+export function sanitizeVisualExplainerHtmlForTest(html: string): string {
+  return neutralizeDynamicCodeText(
+    stripEventHandlerAttributes(stripScriptElements(String(html ?? ""))),
+  );
+}
+
 export function applyVisualExplainerCsp(html: string): string {
   const meta = visualExplainerCspMeta();
-  const withoutGeneratedCsp = html.replace(
+  const withoutGeneratedCsp = sanitizeVisualExplainerHtmlForTest(html).replace(
     /<meta\b[^>]*\bhttp-equiv\s*=\s*(?:"Content-Security-Policy"|'Content-Security-Policy'|Content-Security-Policy)[^>]*>\s*/gi,
     "",
   );
@@ -5347,23 +5508,20 @@ export function applyVisualExplainerCsp(html: string): string {
   );
 }
 
-function runCodexVisualExplainer(options: {
+function runCodexVisualExplainerAttempt(options: {
   item: Item;
-  context: ItemContext;
-  focusPrompt: string;
-  sourceCommentUrl: string;
-  author: string;
+  prompt: string;
+  outputStem: string;
   model: string;
   reasoningEffort: string;
   sandboxMode: string;
   timeoutMs: number;
   workDir: string;
-  generatedAt: string;
 }): string {
   ensureDir(options.workDir);
-  const promptPath = join(options.workDir, `${options.item.number}.visual.prompt.md`);
-  const outputPath = join(options.workDir, `${options.item.number}.visual.html`);
-  const prompt = buildVisualExplainerPrompt(options);
+  const promptPath = join(options.workDir, `${options.outputStem}.prompt.md`);
+  const outputPath = join(options.workDir, `${options.outputStem}.html`);
+  const prompt = options.prompt;
   writeFileSync(promptPath, prompt, "utf8");
   const codexConfig = [
     `model_reasoning_effort="${options.reasoningEffort}"`,
@@ -5402,6 +5560,32 @@ function runCodexVisualExplainer(options: {
     throw new Error(`Codex visual explainer failed for #${options.item.number}: ${detail}`);
   }
   return stripTextFence(readFileSync(outputPath, "utf8"));
+}
+
+function runCodexVisualExplainer(options: {
+  item: Item;
+  context: ItemContext;
+  focusPrompt: string;
+  sourceCommentUrl: string;
+  author: string;
+  model: string;
+  reasoningEffort: string;
+  sandboxMode: string;
+  timeoutMs: number;
+  workDir: string;
+  generatedAt: string;
+}): string {
+  const prompt = buildVisualExplainerPrompt(options);
+  return runCodexVisualExplainerAttempt({
+    item: options.item,
+    prompt,
+    outputStem: `${options.item.number}.visual`,
+    model: options.model,
+    reasoningEffort: options.reasoningEffort,
+    sandboxMode: options.sandboxMode,
+    timeoutMs: options.timeoutMs,
+    workDir: options.workDir,
+  });
 }
 
 function assistCommentMarker(commentId: string): string {
@@ -13608,8 +13792,34 @@ function assistCommand(args: Args): void {
         workDir,
         generatedAt,
       });
-      const html = applyVisualExplainerCsp(rawHtml);
-      const violations = validateVisualExplainerHtml(html);
+      let html = applyVisualExplainerCsp(rawHtml);
+      let violations = validateVisualExplainerHtml(html);
+      if (violations.length > 0) {
+        const repairPrompt = buildVisualExplainerRepairPrompt({
+          originalPrompt: buildVisualExplainerPrompt({
+            item,
+            context,
+            focusPrompt: question,
+            sourceCommentUrl,
+            author,
+            generatedAt,
+          }),
+          html,
+          violations,
+        });
+        const repairedHtml = runCodexVisualExplainerAttempt({
+          item,
+          prompt: repairPrompt,
+          outputStem: `${item.number}.visual.repair`,
+          model,
+          reasoningEffort,
+          sandboxMode,
+          timeoutMs: Math.max(30_000, Math.floor(timeoutMs / 2)),
+          workDir,
+        });
+        html = applyVisualExplainerCsp(repairedHtml);
+        violations = validateVisualExplainerHtml(html);
+      }
       if (violations.length > 0) {
         throw new Error(`generated HTML did not pass safety checks: ${violations.join("; ")}`);
       }

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -1581,7 +1581,7 @@ export function assistDispatchClientPayload(command: LooseRecord): LooseRecord {
       visual ? (command.visual_prompt ?? "") : (command.freeform_prompt ?? command.command ?? ""),
     ).slice(0, 3000),
     model: "gpt-5.5",
-    reasoning_effort: visual ? "medium" : "low",
+    reasoning_effort: "low",
     timeout_ms: visual ? "480000" : "120000",
   };
 }

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -205,6 +205,7 @@ for (const comment of comments) {
       extractMarkdownSection(comment.body, "Automerge follow-up") ??
       extractMarkdownSection(comment.body, "Autofix follow-up"),
     freeform_prompt: parsed.freeform_prompt ?? null,
+    visual_prompt: parsed.visual_prompt ?? null,
     expected_head_sha: parsed.expected_head_sha ?? null,
     finding_id: parsed.finding_id ?? null,
     status: "pending",

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -82,6 +82,7 @@ import {
   reviewPromptForTest,
   renderReviewCommentFromReport,
   renderReviewContextBudgetForTest,
+  renderVisualExplainerCommentForTest,
   renderWorkPlanFromReport,
   restoreTreeModesForTest,
   reviewContextLedgerForTest,
@@ -110,6 +111,10 @@ import {
   validateVisualExplainerHtml,
   visualExplainerCspMeta,
   validateCloseDecision,
+  visualExplainerHostedUrlIsAvailableForTest,
+  visualExplainerHostedUrlForTest,
+  visualExplainerPublishPathsForTest,
+  pruneExpiredVisualExplainersForTest,
 } from "../dist/clawsweeper.js";
 import { checkConclusionForFrontMatter } from "../dist/commit-checks.js";
 import { skippedNonCodeReport } from "../dist/commit-classifier.js";
@@ -9538,11 +9543,117 @@ test("visual explainer repair prompt feeds sanitizer violations back without wea
   assert.match(prompt, /Return only the complete HTML document/);
 });
 
+test("visual explainer publish paths are deterministic and avoid prompt text", () => {
+  const paths = visualExplainerPublishPathsForTest({
+    targetRepo: "OpenClaw/OpenClaw",
+    itemNumber: 72343,
+    headSha: "DAE18659D42DCF2613990CA4895070BB94F63B1B",
+    commentId: "4512657637",
+  });
+  assert.equal(paths.versionPath, "visual/openclaw/openclaw/pr-72343/dae18659d42d/4512657637.html");
+  assert.equal(paths.latestPath, "visual/openclaw/openclaw/pr-72343/latest.html");
+  assert.doesNotMatch(JSON.stringify(paths), /eli5|fresh install|Tak/i);
+  assert.equal(
+    visualExplainerHostedUrlForTest(
+      "https://openclaw.github.io/clawsweeper-state/",
+      paths.latestPath,
+    ),
+    "https://openclaw.github.io/clawsweeper-state/visual/openclaw/openclaw/pr-72343/latest.html",
+  );
+});
+
+test("visual explainer success comment prefers hosted URL and keeps artifact fallback", () => {
+  const comment = renderVisualExplainerCommentForTest({
+    artifactName: "openclaw-openclaw-72343-dae18659d42d.html",
+    runUrl: "https://github.com/openclaw/clawsweeper/actions/runs/1",
+    hostedUrl:
+      "https://openclaw.github.io/clawsweeper-state/visual/openclaw/openclaw/pr-72343/latest.html",
+    model: "gpt-5.5",
+    reasoningEffort: "low",
+    sourceCommentUrl: "https://github.com/openclaw/openclaw/pull/72343#issuecomment-4512657637",
+    sourceCommentId: "4512657637",
+    focusPrompt: "eli5",
+  });
+  assert.match(comment, /Open visual explainer: https:\/\/openclaw\.github\.io/);
+  assert.match(comment, /Artifact: \[openclaw-openclaw-72343-dae18659d42d\.html\]/);
+  assert.match(comment, /Focus: eli5/);
+  assert.match(comment, /Visual assist model: gpt-5\.5, reasoning low/);
+});
+
+test("visual explainer success comment reports publish fallback without losing artifact", () => {
+  const comment = renderVisualExplainerCommentForTest({
+    artifactName: "openclaw-openclaw-72343-dae18659d42d.html",
+    runUrl: "https://github.com/openclaw/clawsweeper/actions/runs/1",
+    hostedUrl: null,
+    publishError: "state branch is unavailable",
+    model: "gpt-5.5",
+    reasoningEffort: "low",
+    sourceCommentUrl: "",
+    sourceCommentId: "4512657637",
+    focusPrompt: "eli5",
+  });
+  assert.match(comment, /Hosted page: unavailable \(state branch is unavailable\)/);
+  assert.match(comment, /Artifact:/);
+  assert.doesNotMatch(comment, /Open visual explainer:/);
+});
+
+test("visual explainer hosted URL probe retries before falling back", () => {
+  const attempts: string[] = [];
+  const available = visualExplainerHostedUrlIsAvailableForTest("https://example.test/visual.html", {
+    attempts: 2,
+    delayMs: 0,
+    probe: (url) => {
+      attempts.push(url);
+      return attempts.length === 2 ? { ok: true, detail: "" } : { ok: false, detail: "HTTP 404" };
+    },
+  });
+  assert.deepEqual(attempts, [
+    "https://example.test/visual.html",
+    "https://example.test/visual.html",
+  ]);
+  assert.deepEqual(available, { ok: true, detail: "" });
+});
+
+test("visual explainer hosted URL probe exposes final failure detail", () => {
+  const unavailable = visualExplainerHostedUrlIsAvailableForTest(
+    "https://example.test/missing.html",
+    {
+      attempts: 2,
+      delayMs: 0,
+      probe: () => ({ ok: false, detail: "HTTP 404" }),
+    },
+  );
+  assert.deepEqual(unavailable, { ok: false, detail: "HTTP 404" });
+});
+
+test("visual explainer cleanup candidates stay scoped to visual paths", () => {
+  const now = Date.parse("2026-05-21T12:00:00Z");
+  const expired = pruneExpiredVisualExplainersForTest(
+    [
+      "visual/openclaw/openclaw/pr-1/2026-04-01/abc.html",
+      "visual/openclaw/openclaw/pr-1/latest.html",
+      "assets/2026-04-01/abc.html",
+      "visual/openclaw/openclaw/pr-2/2026-05-20/abc.html",
+    ],
+    now,
+  );
+  assert.deepEqual(expired, ["visual/openclaw/openclaw/pr-1/2026-04-01/abc.html"]);
+});
+
 test("assist workflow leaves timeout buffer around visual Codex generation", () => {
   const workflow = readFileSync(".github/workflows/assist.yml", "utf8");
   const routerCore = readFileSync("src/repair/comment-router-core.ts", "utf8");
   const router = readFileSync("src/repair/comment-router.ts", "utf8");
   assert.match(workflow, /timeout-minutes:\s+12/);
+  assert.doesNotMatch(workflow, /pages:\s+write/);
+  assert.match(workflow, /uses:\s+\.\/\.github\/actions\/create-state-token/);
+  assert.match(workflow, /CLAWSWEEPER_VISUAL_PUBLISH_REPO:\s+openclaw\/clawsweeper-state/);
+  assert.match(workflow, /CLAWSWEEPER_VISUAL_PUBLISH_BRANCH:\s+state/);
+  assert.match(
+    workflow,
+    /CLAWSWEEPER_VISUAL_PUBLISH_BASE_URL:\s+https:\/\/openclaw\.github\.io\/clawsweeper-state/,
+  );
+  assert.doesNotMatch(workflow, /CLAWSWEEPER_PAGES_TOKEN/);
   assert.match(routerCore, /timeout_ms:\s+visual \? "480000" : "120000"/);
   assert.match(
     workflow,

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -22,6 +22,7 @@ import {
   auditFromSnapshot,
   auditHasStrictFailures,
   auditHealthSection,
+  buildVisualExplainerRepairPromptForTest,
   canPatchReviewComment,
   closeReasonApplyAgeSkipReason,
   closeReasonsArg,
@@ -94,6 +95,7 @@ import {
   safeOutputTail,
   sameAuthorCounterpartApplyReason,
   sanitizePublicSelfReferences,
+  sanitizeVisualExplainerHtmlForTest,
   appendFloorBackfillCandidateNumbersForTest,
   applyVisualExplainerCsp,
   pullRequestFilePathsFromContextForTest,
@@ -9480,8 +9482,8 @@ test("safeOutputTail tolerates missing process output", () => {
   assert.equal(safeOutputTail("abcdef", 3), "def");
 });
 
-test("visual explainer sanitizer allows self-contained inline interactions", () => {
-  const html = `<!doctype html><html><head>${visualExplainerCspMeta()}<style>button{color:blue}</style></head><body><button id="toggle">Toggle</button><section hidden>Risk map</section><script>document.getElementById("toggle").addEventListener("click",()=>{document.querySelector("section").hidden=false;});</script></body></html>`;
+test("visual explainer sanitizer allows self-contained static HTML and CSS", () => {
+  const html = `<!doctype html><html><head>${visualExplainerCspMeta()}<style>button{color:blue}</style></head><body><section>Risk map</section><table><tr><td>CLI</td></tr></table></body></html>`;
   assert.deepEqual(validateVisualExplainerHtml(html), []);
 });
 
@@ -9499,15 +9501,56 @@ test("visual explainer sanitizer rejects network and external resources", () => 
   const html =
     '<!doctype html><html><head><script src="https://example.com/app.js"></script></head><body><img src="https://example.com/a.png"><script>fetch("https://example.com"); localStorage.setItem("x","y");</script></body></html>';
   const violations = validateVisualExplainerHtml(html);
+  assert.match(violations.join("\n"), /scripts are not allowed/);
   assert.match(violations.join("\n"), /external script sources/);
   assert.match(violations.join("\n"), /network APIs/);
   assert.match(violations.join("\n"), /browser storage/);
   assert.match(violations.join("\n"), /external resources/);
 });
 
+test("visual explainer sanitizer strips scripts before validation", () => {
+  const html = applyVisualExplainerCsp(
+    '<!doctype html><html><head></head><body><h1>PR</h1><p>Do not call Function("x").</p><button onclick="alert(1)" onmouseover=alert(2)>Open</button><script>const make = new Function("return 1");</script><script>document.body.dataset.ready="true";</script >Tail</body></html>',
+  );
+  assert.doesNotMatch(html, /<script\b/i);
+  assert.doesNotMatch(html, /onclick=/);
+  assert.doesNotMatch(html, /onmouseover=/);
+  assert.doesNotMatch(html, /new Function/);
+  assert.doesNotMatch(html, /Function\("/);
+  assert.match(html, /Tail/);
+  assert.deepEqual(validateVisualExplainerHtml(html), []);
+});
+
+test("visual explainer sanitizer helper neutralizes dynamic-code text tokens", () => {
+  assert.equal(sanitizeVisualExplainerHtmlForTest("Function("), "Function call ");
+  assert.equal(sanitizeVisualExplainerHtmlForTest("import("), "import call ");
+});
+
+test("visual explainer repair prompt feeds sanitizer violations back without weakening policy", () => {
+  const prompt = buildVisualExplainerRepairPromptForTest({
+    originalPrompt: "Focus: eli5",
+    html: '<!doctype html><html><body><script>new Function("return 1")()</script></body></html>',
+    violations: ["dynamic code execution is not allowed"],
+  });
+  assert.match(prompt, /dynamic code execution is not allowed/);
+  assert.match(prompt, /Focus: eli5/);
+  assert.match(prompt, /JavaScript is not allowed/);
+  assert.match(prompt, /Return only the complete HTML document/);
+});
+
 test("assist workflow leaves timeout buffer around visual Codex generation", () => {
   const workflow = readFileSync(".github/workflows/assist.yml", "utf8");
   const routerCore = readFileSync("src/repair/comment-router-core.ts", "utf8");
+  const router = readFileSync("src/repair/comment-router.ts", "utf8");
   assert.match(workflow, /timeout-minutes:\s+12/);
   assert.match(routerCore, /timeout_ms:\s+visual \? "480000" : "120000"/);
+  assert.match(
+    workflow,
+    /TIMEOUT_MS:\s+\$\{\{ github\.event\.client_payload\.timeout_ms \|\| \(\(github\.event\.client_payload\.mode \|\| inputs\.mode \|\| 'text'\) == 'visual' && '480000'\) \|\| '120000' \}\}/,
+  );
+  assert.match(
+    workflow,
+    /REASONING_EFFORT:\s+\$\{\{ github\.event\.client_payload\.reasoning_effort \|\| 'low' \}\}/,
+  );
+  assert.match(router, /visual_prompt:\s+parsed\.visual_prompt \?\? null/);
 });

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -879,7 +879,7 @@ test("parseCommand recognizes ClawSweeper bot mentions", () => {
   assert.equal(Object.keys(visualPayload).length, 10);
   assert.equal(visualPayload.mode, "visual");
   assert.equal(visualPayload.question, "eli5");
-  assert.equal(visualPayload.reasoning_effort, "medium");
+  assert.equal(visualPayload.reasoning_effort, "low");
   assert.equal(visualPayload.timeout_ms, "480000");
   assert.deepEqual(parseCommand("/clawsweeper explain why this PR is not automerge-ready"), {
     trigger: "slash",


### PR DESCRIPTION
## Summary
- preserve parsed visual focus prompts through the comment router command object
- add a one-shot visual HTML repair retry when sanitizer checks reject generated output
- tighten the visual prompt contract around dynamic-code tokens and add focused regression coverage

## Validation
- pnpm run build:repair
- pnpm run build
- pnpm run format:check
- node --test test/repair/comment-router-core.test.ts
- node --test test/clawsweeper.test.ts
- pnpm run check