### PR TITLE
fix(review): show durable comment freshness

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -5383,6 +5383,23 @@ function formatTimestamp(iso: string | undefined): string {
   }).format(date);
 }
 
+function formatReviewFreshnessTimestamp(iso: string | undefined): string {
+  if (!iso) return "";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  const utc = date.toISOString().slice(0, 16).replace("T", " ");
+  const eastern = new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+    timeZone: "America/New_York",
+  }).format(date);
+  return `${utc} UTC / ${eastern} ET`;
+}
+
 function workflowStatusBlock(options?: {
   state?: string | undefined;
   detail?: string | undefined;
@@ -9656,6 +9673,15 @@ function reviewWorkflowCallout(): string[] {
   ];
 }
 
+function reviewFreshnessCallout(markdown: string): string[] {
+  const timestamp = formatReviewFreshnessTimestamp(frontMatterValue(markdown, "reviewed_at"));
+  if (!timestamp) return [];
+  return [
+    `**Latest ClawSweeper review:** ${timestamp}. GitHub's header may show when this durable comment was first created.`,
+    "",
+  ];
+}
+
 function renderKeepOpenCommentFromReport(
   markdown: string,
   options: ReviewCommentRenderOptions = {},
@@ -9707,6 +9733,7 @@ function renderKeepOpenCommentFromReport(
               ? "Codex review: needs maintainer review before merge."
               : "Codex review: keeping this open for maintainer follow-up; there is still a little grit to resolve.",
     "",
+    ...reviewFreshnessCallout(markdown),
     ...reviewWorkflowCallout(),
   ];
   if (isPullRequest) {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2239,6 +2239,7 @@ test("pull request keep-open review comments label the change summary", () => {
       close_reason: "none",
       work_candidate: "none",
       pull_head_sha: "abc123def456",
+      reviewed_at: "2026-05-22T04:43:12.000Z",
     })}
 
 ## Summary
@@ -2281,6 +2282,10 @@ Reason: Maintainers should review the tests after the targeted lane is green.
   );
 
   assert.match(comment, /Codex review: needs maintainer review before merge\./);
+  assert.match(
+    comment,
+    /\*\*Latest ClawSweeper review:\*\* 2026-05-22 04:43 UTC \/ May 22, 2026, 12:43 AM ET\. GitHub's header may show when this durable comment was first created\./,
+  );
   assert.match(
     comment,
     /\*\*Workflow note:\*\* Future ClawSweeper reviews update this same comment in place\./,


### PR DESCRIPTION
Summary
- Add a visible latest-review line to durable ClawSweeper review comments when reviewed_at is present.
- Render UTC plus America/New_York time labeled ET, with a note explaining GitHub may show the original durable comment creation time.
- Cover the rendered line in the PR review comment unit test.

Verification
- pnpm install --frozen-lockfile
- pnpm run build
- pnpm run test:unit -- test/clawsweeper.test.ts
- pnpm run check