### PR TITLE
fix(review): shorten freshness line

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -9676,10 +9676,7 @@ function reviewWorkflowCallout(): string[] {
 function reviewFreshnessCallout(markdown: string): string[] {
   const timestamp = formatReviewFreshnessTimestamp(frontMatterValue(markdown, "reviewed_at"));
   if (!timestamp) return [];
-  return [
-    `**Latest ClawSweeper review:** ${timestamp}. GitHub's header may show when this durable comment was first created.`,
-    "",
-  ];
+  return [`**Latest ClawSweeper review:** ${timestamp}.`, ""];
 }
 
 function renderKeepOpenCommentFromReport(

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2284,7 +2284,7 @@ Reason: Maintainers should review the tests after the targeted lane is green.
   assert.match(comment, /Codex review: needs maintainer review before merge\./);
   assert.match(
     comment,
-    /\*\*Latest ClawSweeper review:\*\* 2026-05-22 04:43 UTC \/ May 22, 2026, 12:43 AM ET\. GitHub's header may show when this durable comment was first created\./,
+    /\*\*Latest ClawSweeper review:\*\* 2026-05-22 04:43 UTC \/ May 22, 2026, 12:43 AM ET\./,
   );
   assert.match(
     comment,


### PR DESCRIPTION
Summary
- Remove the explanatory GitHub-header sentence from the durable review freshness line.
- Keep the UTC / ET latest-review timestamp visible.
- Update focused review comment test coverage.

Verification
- pnpm install --frozen-lockfile
- pnpm run build
- pnpm run test:unit -- test/clawsweeper.test.ts
- pnpm run check