### PR TITLE
fix(repair): sanitize non-github URLs out of result.json evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ checkpoint, and status-only commits are intentionally omitted.
 ### Fixed
 
 - Restored UTF-8 emoji labels on the live dashboard after mojibake slipped into the Worker HTML template.
+- Sanitized non-`github.com` URLs out of repair worker `result.json` evidence (including `actions[].evidence`, `needs_human`, and every `merge_preflight` evidence list) before review so deploy-preview and other external links no longer trip the `evidence contains non-GitHub external URL` deterministic gate; deterministic automerge results, dry-run/blocked fallbacks, the Codex-written result, the result-repair retry, and synthetic commit-finding-intake results all share a single `src/repair/url-safety.ts` allow-list. The intake also rejects dispatched `report_url` overrides that are not on `github.com` and falls back to the canonical report path.
 - Kept scheduled target fanout covering public `steipete/*` repositories when the ClawSweeper GitHub App is not installed for that owner.
 - Reduced the shared Codex worker budget from 72 to 57 so background review, commit-review, repair, and issue-implementation lanes run about 20% fewer parallel workers.
 - Clarified re-review guidance so PR/issue authors and users with repository write access can request a fresh read-only review without a maintainer relay.

--- a/src/repair/commit-finding-intake.ts
+++ b/src/repair/commit-finding-intake.ts
@@ -20,6 +20,7 @@ import { readJsonFileIfExists as readJsonIfExists } from "./json-file.js";
 import { renderJobIntentFrontmatter } from "./job-intent.js";
 import { commitFindingPrTitle } from "./pr-title.js";
 import { escapeRegExp, slug } from "./text-utils.js";
+import { isGithubUrl, sanitizeResultEvidence } from "./url-safety.js";
 
 const args = parseArgs(process.argv.slice(2));
 const command = args._[0] ?? "prepare";
@@ -37,9 +38,9 @@ function prepare() {
     "report-path",
     stringArg("report_path", `records/${repoSlug(targetRepo)}/commits/${sha}.md`),
   );
-  const reportUrl =
-    stringArg("report-url", stringArg("report_url", "")) ||
-    `https://github.com/${reportRepo}/blob/main/${reportPath}`;
+  const defaultReportUrl = `https://github.com/${reportRepo}/blob/main/${reportPath}`;
+  const dispatchReportUrl = stringArg("report-url", stringArg("report_url", ""));
+  const reportUrl = isGithubUrl(dispatchReportUrl) ? dispatchReportUrl : defaultReportUrl;
   const active = truthy(enabled);
   const reportRead: CommitFindingReportReadResult = active
     ? readReport({ reportRepo, reportPath })
@@ -353,6 +354,7 @@ function writeSyntheticRun(context: LooseRecord) {
     `${JSON.stringify(result.fix_artifact, null, 2)}\n`,
     "utf8",
   );
+  sanitizeResultEvidence(result);
   fs.writeFileSync(
     path.join(context.runDir, "result.json"),
     `${JSON.stringify(result, null, 2)}\n`,

--- a/src/repair/deterministic-automerge-result.ts
+++ b/src/repair/deterministic-automerge-result.ts
@@ -1,5 +1,6 @@
 import { automergeChangelogBlockReason } from "./comment-router-core.js";
 import type { JsonValue, LooseRecord } from "./json-types.js";
+import { sanitizeCheckLink, sanitizeEvidenceList } from "./url-safety.js";
 
 export function deterministicAutomergeResult({
   job,
@@ -35,18 +36,20 @@ export function deterministicAutomergeResult({
   ].join(" ");
   const likelyFiles = likelyRepairFiles(files, Boolean(changelogReason));
   const failedChecks = failingCheckEvidence(canonical);
-  const evidence = [
-    `Source PR: ${prUrl}`,
-    canonical.pull_request?.head_sha ? `Current head: ${canonical.pull_request.head_sha}` : null,
-    ...failedChecks,
-    canonical.pull_request?.branch_writable === false
-      ? `Branch writable: false (${canonical.pull_request?.branch_write_reason ?? "unknown"})`
-      : "Branch writable: true or executor will fall back safely",
-    canonical.pull_request?.files_truncated > 0
-      ? `Changed files truncated by ${canonical.pull_request.files_truncated}; Codex must inspect live diff before editing`
-      : null,
-    changelogReason,
-  ].filter(Boolean);
+  const evidence = sanitizeEvidenceList(
+    [
+      `Source PR: ${prUrl}`,
+      canonical.pull_request?.head_sha ? `Current head: ${canonical.pull_request.head_sha}` : null,
+      ...failedChecks,
+      canonical.pull_request?.branch_writable === false
+        ? `Branch writable: false (${canonical.pull_request?.branch_write_reason ?? "unknown"})`
+        : "Branch writable: true or executor will fall back safely",
+      canonical.pull_request?.files_truncated > 0
+        ? `Changed files truncated by ${canonical.pull_request.files_truncated}; Codex must inspect live diff before editing`
+        : null,
+      changelogReason,
+    ].filter(Boolean),
+  );
   const reason =
     "Maintainer opted this PR into ClawSweeper automerge/autofix repair; run the direct Codex edit loop after live hydration instead of a separate read-only planning pass.";
   const fixArtifact = {
@@ -150,19 +153,20 @@ function failingCheckEvidence(item: LooseRecord): string[] {
     .map((check: JsonValue) => {
       const name = String(check?.name ?? "unnamed check").trim();
       const state = String(check?.state ?? check?.conclusion ?? check?.status ?? "unknown").trim();
-      const details = safeCheckDetails(check?.link ?? check?.html_url);
-      return `Failing check: ${name}:${state}${details ? ` (${details})` : ""}`;
+      const rawLink = String(check?.link ?? check?.html_url ?? "").trim();
+      const safeLink = sanitizeCheckLink(rawLink);
+      const hint = safeLink ? safeLink : safeCheckHostHint(rawLink);
+      return `Failing check: ${name}:${state}${hint ? ` (${hint})` : ""}`;
     })
     .filter(Boolean)
     .slice(0, 12);
 }
 
-function safeCheckDetails(value: JsonValue): string {
-  const link = String(value ?? "").trim();
-  if (!link) return "";
+function safeCheckHostHint(rawLink: string): string {
+  if (!rawLink) return "";
   try {
-    const url = new URL(link);
-    if (url.hostname === "github.com") return link;
+    const url = new URL(rawLink);
+    if (url.hostname === "github.com") return "";
     return `external check details on ${url.hostname}`;
   } catch {
     return "";

--- a/src/repair/run-worker.ts
+++ b/src/repair/run-worker.ts
@@ -19,6 +19,7 @@ import {
   repairCodexReasoningEffort,
   repairCodexServiceTier,
 } from "./process-env.js";
+import { sanitizeResultEvidence } from "./url-safety.js";
 
 const args = parseArgs(process.argv.slice(2));
 const jobPath = args._[0];
@@ -106,6 +107,7 @@ if (!dryRun) {
     clusterPlanPath: promptContext.clusterPlanPath,
   });
   if (deterministicResult) {
+    sanitizeResultEvidence(deterministicResult);
     fs.writeFileSync(resultPath, `${JSON.stringify(deterministicResult, null, 2)}\n`);
     console.log(`result: ${path.relative(repoRoot(), resultPath)}`);
     process.exit(0);
@@ -145,6 +147,7 @@ if (dryRun) {
     actions: [],
     prompt_path: path.relative(repoRoot(), promptPath),
   };
+  sanitizeResultEvidence(dryResult);
   fs.writeFileSync(resultPath, `${JSON.stringify(dryResult, null, 2)}\n`);
   console.log(JSON.stringify(dryResult, null, 2));
   process.exit(0);
@@ -181,7 +184,9 @@ if (child.status !== 0) {
 if (!fs.existsSync(resultPath)) {
   writeBlockedResult("Codex worker completed without a structured result.json artifact.");
 }
+sanitizeResultFile(resultPath);
 await repairResultIfNeeded();
+sanitizeResultFile(resultPath);
 
 console.log(`result: ${path.relative(repoRoot(), resultPath)}`);
 
@@ -383,6 +388,7 @@ async function repairResultIfNeeded() {
       );
       return;
     }
+    sanitizeResultFile(resultPath);
   }
 }
 
@@ -450,5 +456,19 @@ function writeBlockedResult(summary: LooseRecord) {
     canonical_pr: null,
     fix_artifact: null,
   };
+  sanitizeResultEvidence(result);
   fs.writeFileSync(resultPath, `${JSON.stringify(result, null, 2)}\n`);
+}
+
+function sanitizeResultFile(filePath: string) {
+  if (!fs.existsSync(filePath)) return;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    return;
+  }
+  if (!parsed || typeof parsed !== "object") return;
+  sanitizeResultEvidence(parsed as LooseRecord);
+  fs.writeFileSync(filePath, `${JSON.stringify(parsed, null, 2)}\n`);
 }

--- a/src/repair/url-safety.ts
+++ b/src/repair/url-safety.ts
@@ -1,0 +1,97 @@
+import type { JsonValue, LooseRecord } from "./json-types.js";
+
+// IMPORTANT: keep this character class identical to the one used by
+// evidenceHasExternalUrl in review-results.ts. If the validator ever
+// expands the terminator set, expand it here first so this sanitizer
+// never produces output that the validator then rejects.
+const URL_PATTERN = /https?:\/\/[^\s)\]"']+/g;
+const ALLOWED_HOSTS = new Set(["github.com"]);
+const PLACEHOLDER = "<external link>";
+
+export function isGithubUrl(value: unknown): boolean {
+  const text = typeof value === "string" ? value.trim() : "";
+  if (!text) return false;
+  try {
+    return ALLOWED_HOSTS.has(new URL(text).hostname);
+  } catch {
+    return false;
+  }
+}
+
+// Used for single-URL fields such as a check `details_url`. Returns the URL
+// when it points at github.com; otherwise returns "" so callers can decide to
+// fall back to a hostname-free description.
+export function sanitizeCheckLink(value: unknown): string {
+  const text = typeof value === "string" ? value.trim() : "";
+  if (!text) return "";
+  try {
+    const url = new URL(text);
+    return ALLOWED_HOSTS.has(url.hostname) ? text : "";
+  } catch {
+    return "";
+  }
+}
+
+// Replaces every non-github http(s) URL inside a free-form string with the
+// PLACEHOLDER token. The placeholder intentionally contains no `http(s)://`
+// so it cannot trigger evidenceHasExternalUrl in review-results.ts.
+export function sanitizeEvidenceText(value: unknown): string {
+  const text = typeof value === "string" ? value : String(value ?? "");
+  if (!text) return "";
+  return text.replace(URL_PATTERN, (match: string) => {
+    try {
+      return ALLOWED_HOSTS.has(new URL(match).hostname) ? match : PLACEHOLDER;
+    } catch {
+      return PLACEHOLDER;
+    }
+  });
+}
+
+export function sanitizeEvidenceList(list: unknown): string[] {
+  if (!Array.isArray(list)) return [];
+  return list.map((item: JsonValue) =>
+    typeof item === "string"
+      ? sanitizeEvidenceText(item)
+      : sanitizeEvidenceText(JSON.stringify(item)),
+  );
+}
+
+// Mutates the well-known evidence-bearing fields on a worker result.json.
+// Covers actions[i].evidence, needs_human, and merge_preflight entries
+// (security_evidence / comments_evidence / bot_comments_evidence /
+// codex_review.evidence). Unknown fields are left untouched.
+export function sanitizeResultEvidence<T extends LooseRecord | null | undefined>(result: T): T {
+  if (!result || typeof result !== "object") return result;
+  const target = result as LooseRecord;
+
+  if (Array.isArray(target.actions)) {
+    for (const action of target.actions) {
+      if (action && typeof action === "object" && Array.isArray(action.evidence)) {
+        action.evidence = sanitizeEvidenceList(action.evidence);
+      }
+    }
+  }
+
+  if (Array.isArray(target.needs_human)) {
+    target.needs_human = sanitizeEvidenceList(target.needs_human);
+  }
+
+  if (Array.isArray(target.merge_preflight)) {
+    for (const preflight of target.merge_preflight) {
+      if (!preflight || typeof preflight !== "object") continue;
+      for (const key of ["security_evidence", "comments_evidence", "bot_comments_evidence"]) {
+        if (Array.isArray(preflight[key])) {
+          preflight[key] = sanitizeEvidenceList(preflight[key]);
+        }
+      }
+      const codexReview = preflight.codex_review;
+      if (codexReview && typeof codexReview === "object" && Array.isArray(codexReview.evidence)) {
+        codexReview.evidence = sanitizeEvidenceList(codexReview.evidence);
+      }
+    }
+  }
+
+  return result;
+}
+
+export const EVIDENCE_URL_PLACEHOLDER = PLACEHOLDER;

--- a/test/repair/url-safety.test.ts
+++ b/test/repair/url-safety.test.ts
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  isGithubUrl,
+  sanitizeCheckLink,
+  sanitizeEvidenceList,
+  sanitizeEvidenceText,
+  sanitizeResultEvidence,
+} from "../../dist/repair/url-safety.js";
+
+test("isGithubUrl accepts only github.com host", () => {
+  assert.equal(isGithubUrl("https://github.com/foo/bar"), true);
+  assert.equal(isGithubUrl("http://github.com/foo/bar"), true);
+  assert.equal(isGithubUrl("https://gist.github.com/x/y"), false);
+  assert.equal(isGithubUrl("https://raw.githubusercontent.com/x/y"), false);
+  assert.equal(isGithubUrl("https://vercel.com/foo"), false);
+  assert.equal(isGithubUrl(""), false);
+  assert.equal(isGithubUrl("not a url"), false);
+  assert.equal(isGithubUrl(null), false);
+});
+
+test("sanitizeCheckLink keeps github.com URLs verbatim", () => {
+  assert.equal(
+    sanitizeCheckLink("https://github.com/openclaw/openclaw/runs/123"),
+    "https://github.com/openclaw/openclaw/runs/123",
+  );
+});
+
+test("sanitizeCheckLink drops non-github URLs", () => {
+  assert.equal(sanitizeCheckLink("https://vercel.com/openclaw/preview/abc"), "");
+  assert.equal(sanitizeCheckLink("https://gist.github.com/x/y"), "");
+  assert.equal(sanitizeCheckLink("not-a-url"), "");
+  assert.equal(sanitizeCheckLink(""), "");
+  assert.equal(sanitizeCheckLink(null), "");
+});
+
+test("sanitizeEvidenceText replaces non-github URLs with hostname-free placeholder", () => {
+  const cleaned = sanitizeEvidenceText(
+    "Failing check: vercel:failure (https://vercel.com/openclaw/preview/abc)",
+  );
+  assert.equal(cleaned, "Failing check: vercel:failure (<external link>)");
+  assert.match(cleaned, /<external link>/);
+  assert.doesNotMatch(cleaned, /https?:\/\//);
+});
+
+test("sanitizeEvidenceText keeps github.com URLs but replaces sibling external URLs", () => {
+  const cleaned = sanitizeEvidenceText(
+    "PR https://github.com/openclaw/openclaw/pull/2353 references https://vercel.com/openclaw/preview/abc and https://raw.githubusercontent.com/openclaw/openclaw/main/x.md",
+  );
+  assert.match(cleaned, /https:\/\/github\.com\/openclaw\/openclaw\/pull\/2353/);
+  assert.doesNotMatch(cleaned, /vercel\.com/);
+  assert.doesNotMatch(cleaned, /raw\.githubusercontent\.com/);
+});
+
+test("sanitizeEvidenceText is idempotent", () => {
+  const once = sanitizeEvidenceText(
+    "see https://github.com/x/y and https://vercel.com/z for details",
+  );
+  const twice = sanitizeEvidenceText(once);
+  assert.equal(once, twice);
+});
+
+test("sanitizeEvidenceList stringifies non-string entries safely", () => {
+  const out = sanitizeEvidenceList([
+    "https://vercel.com/x",
+    { url: "https://gist.github.com/x" },
+    "https://github.com/o/r/pull/1",
+  ]);
+  assert.equal(out.length, 3);
+  assert.doesNotMatch(out[0]!, /vercel\.com/);
+  assert.doesNotMatch(out[1]!, /gist\.github\.com/);
+  assert.match(out[2]!, /https:\/\/github\.com\/o\/r\/pull\/1/);
+});
+
+test("sanitizeResultEvidence cleans actions[].evidence in place", () => {
+  const result = {
+    actions: [
+      {
+        target: "#1",
+        evidence: [
+          "Source PR: https://github.com/o/r/pull/1",
+          "external preview at https://vercel.com/o/r",
+        ],
+      },
+    ],
+  };
+  sanitizeResultEvidence(result);
+  assert.match(result.actions[0]!.evidence[0]!, /https:\/\/github\.com\/o\/r\/pull\/1/);
+  assert.equal(result.actions[0]!.evidence[1]!, "external preview at <external link>");
+});
+
+test("sanitizeResultEvidence cleans needs_human and merge_preflight evidence", () => {
+  const result = {
+    needs_human: ["see https://vercel.com/x for the deploy"],
+    merge_preflight: [
+      {
+        target: "#2",
+        security_evidence: ["https://github.com/o/r/pull/2", "https://example.com/scan"],
+        comments_evidence: ["resolved at https://gist.github.com/x"],
+        bot_comments_evidence: ["bot ack at https://app.codecov.io/foo"],
+        codex_review: {
+          command: "/review",
+          status: "passed",
+          findings_addressed: true,
+          evidence: [
+            "/review run https://github.com/o/r/pull/2#issuecomment-1",
+            "details https://vercel.com/o/preview",
+          ],
+        },
+      },
+    ],
+  };
+  sanitizeResultEvidence(result);
+  assert.doesNotMatch(JSON.stringify(result), /vercel\.com/);
+  assert.doesNotMatch(JSON.stringify(result), /gist\.github\.com/);
+  assert.doesNotMatch(JSON.stringify(result), /codecov\.io/);
+  assert.doesNotMatch(JSON.stringify(result), /example\.com/);
+  assert.match(
+    result.merge_preflight[0]!.codex_review.evidence[0]!,
+    /https:\/\/github\.com\/o\/r\/pull\/2#issuecomment-1/,
+  );
+});
+
+test("sanitizeResultEvidence handles null/undefined safely", () => {
+  assert.equal(sanitizeResultEvidence(null), null);
+  assert.equal(sanitizeResultEvidence(undefined), undefined);
+});
+
+test("sanitized evidence does not trigger evidenceHasExternalUrl regex", () => {
+  // Mirror the regex used in review-results.ts evidenceHasExternalUrl.
+  const URL_PATTERN = /https?:\/\/[^\s)\]"']+/g;
+  const cleaned = sanitizeEvidenceList([
+    "Source PR: https://github.com/o/r/pull/2353",
+    "Failing check: vercel:failure (https://vercel.com/o/preview/abc)",
+    "see https://gist.github.com/foo for snippet",
+  ]);
+  for (const line of cleaned) {
+    const urls = line.match(URL_PATTERN) ?? [];
+    for (const url of urls) {
+      assert.equal(new URL(url).hostname, "github.com", `unexpected external URL: ${url}`);
+    }
+  }
+});


### PR DESCRIPTION
## Summary

Fixes the recurring `#<n> evidence contains non-GitHub external URL` deterministic-validator failure on automerge repairs (most recently observed on **PR #2353**, where Codex embedded a `https://vercel.com/...` deploy-preview link into `actions[].evidence`).

Until now, the strict allow-list in [`src/repair/review-results.ts`](src/repair/review-results.ts) (`evidenceHasExternalUrl`) was the **only** thing checking evidence URLs, and several writers of `result.json` had no symmetric sanitizer. Any time Codex (or even our own `failingCheckEvidence`) copied a third-party check URL — Vercel previews, Netlify, Codecov, raw.githubusercontent.com, gist.github.com, etc. — into evidence, automerge would block on a 100% deterministic gate that nobody could fix from inside the repair loop.

This PR introduces a single shared github.com allow-list and applies it on **every** `result.json` write path, while leaving the strict review gate untouched as a hard backstop.

> Note: there is already a vague entry in `CHANGELOG.md` 0.2.1 ("Fixed automerge repair evidence so third-party check detail URLs are summarized without tripping ClawSweeper's strict GitHub-only evidence validator."). That entry described the original partial fix (only `failingCheckEvidence` was hardened); this PR is the complete generalization across **all** evidence-bearing fields and writers, plus the matching `Fixed` entry.

## Why one more layer is needed

Today's flow:

```
runCodex → writes result.json → reviewResult() → if fail, repairResultIfNeeded()
                                       │
                                       └── evidenceHasExternalUrl(line) → BLOCK
```

The block is correct, but irrecoverable from the worker's perspective: Codex frequently re-emits the same external URL in the repair pass, so the loop just burns budget. The right place to fix this is at every **producer / writer** of `result.json`, not at the validator.

## Changes

### New module — [`src/repair/url-safety.ts`](src/repair/url-safety.ts)

Single source of truth. Hostname allow-list = `{ "github.com" }`.

| Export | Purpose |
|---|---|
| `isGithubUrl(value)` | Strict check used by intake to reject dispatched `report_url` overrides. |
| `sanitizeCheckLink(value)` | Single-URL fields (e.g. a check `details_url`). Returns the URL if github.com, else `""`. |
| `sanitizeEvidenceText(value)` | Free-form string. Replaces every non-github `http(s)://...` token with `<external link>`. The placeholder intentionally contains no `http(s)://` so it cannot re-trigger `evidenceHasExternalUrl`. |
| `sanitizeEvidenceList(list)` | Array form, also stringifies non-string entries safely. |
| `sanitizeResultEvidence(result)` | In-place sanitize of the canonical evidence-bearing fields on `result.json` (see below). |

Fields cleaned by `sanitizeResultEvidence`:

- `actions[].evidence`
- `needs_human`
- `merge_preflight[].security_evidence`
- `merge_preflight[].comments_evidence`
- `merge_preflight[].bot_comments_evidence`
- `merge_preflight[].codex_review.evidence`

github.com URLs are preserved verbatim, so debugging is unaffected.

### Producer hardening — [`src/repair/deterministic-automerge-result.ts`](src/repair/deterministic-automerge-result.ts)

- `failingCheckEvidence` now uses the shared `sanitizeCheckLink`.
- The local `safeCheckDetails` helper is removed (dedup).
- For non-github URLs we fall back to `external check details on <hostname>` (a hostname **fragment** without `http(s)://`, so the strict gate is satisfied while the human still gets useful context).
- The full `evidence` array is wrapped in `sanitizeEvidenceList` as a final defense-in-depth.

### Writer hardening — [`src/repair/run-worker.ts`](src/repair/run-worker.ts)

Sanitize at every place `result.json` is written or modified:

| Site | Before write |
|---|---|
| Deterministic automerge result | `sanitizeResultEvidence(deterministicResult)` |
| Dry-run synthetic result | `sanitizeResultEvidence(dryResult)` |
| `writeBlockedResult(...)` | `sanitizeResultEvidence(result)` |
| After Codex direct-write | `sanitizeResultFile(resultPath)` |
| Inside `repairResultIfNeeded` (each retry) | `sanitizeResultFile(resultPath)` after the repair Codex returns |
| After `repairResultIfNeeded` returns | `sanitizeResultFile(resultPath)` |

`sanitizeResultFile` reads, parses, sanitizes, and re-writes the file. Parse failures are tolerated (treated as no-op) because malformed result.json is already handled elsewhere.

### Intake hardening — [`src/repair/commit-finding-intake.ts`](src/repair/commit-finding-intake.ts)

- `report_url` from dispatch input is now validated with `isGithubUrl`. If it does not point at `github.com`, we silently fall back to the canonical `https://github.com/<reportRepo>/blob/main/<reportPath>` default. This closes the obvious "attacker-controlled dispatch input could land an external URL in evidence" injection vector.
- The synthetic `result.json` is run through `sanitizeResultEvidence` before being written to disk.

### Tests — [`test/repair/url-safety.test.ts`](test/repair/url-safety.test.ts)

Nine `node:test` cases, all reading from the compiled `dist/repair/url-safety.js` (matching the project test convention):

1. `isGithubUrl` only accepts `github.com` (rejects `gist.github.com`, `raw.githubusercontent.com`, non-URLs, null).
2. `sanitizeCheckLink` keeps github.com URLs verbatim.
3. `sanitizeCheckLink` drops non-github URLs.
4. `sanitizeEvidenceText` replaces non-github URLs with the hostname-free placeholder.
5. Mixed-URL strings: github.com is preserved, sibling external URLs are scrubbed.
6. Idempotency.
7. `sanitizeEvidenceList` stringifies non-string entries safely.
8. `sanitizeResultEvidence` cleans `actions[].evidence` in place.
9. `sanitizeResultEvidence` cleans `needs_human`, `merge_preflight.{security,comments,bot_comments}_evidence`, and `merge_preflight.codex_review.evidence`.
10. Null/undefined safety.
11. Parity check: sanitized output never matches the same regex shape used by `evidenceHasExternalUrl`.

### CHANGELOG

Adds a precise entry to `0.2.1 - Unreleased` › `Fixed`.

## Explicit non-goals

- **`review-results.ts` is unchanged.** The strict `evidenceHasExternalUrl` gate stays as the hard backstop. If a new writer is ever added without going through `sanitizeResultEvidence`, this PR's fix degrades back to today's blocking behavior — which is the desired failure mode (visible, deterministic) rather than silent acceptance of external links in evidence.
- **No allow-list expansion.** Only `github.com` is allowed. Subdomains (`gist.`, `raw.`, `api.`) are deliberately excluded because the public review/PR comments rendered from this evidence are GitHub-only by contract.

## How to verify

1. Local: `pnpm run build:repair && node --test test/repair/url-safety.test.ts dist/repair/*.test.js` (requires Node ≥ 24 per `package.json` engines).
2. Replay PR through `repair:worker` in dry-run mode and confirm the resulting `result.json` no longer contains any `https://vercel.com/...` strings inside evidence arrays, and that `review:results` exits 0.
3. Spot-check a deterministic automerge run where one failing check's `link` is on a third-party host: the evidence line should read `Failing check: <name>:<state> (external check details on <hostname>)` instead of containing the raw URL.

## Risk

- Very low. The change is additive (new module + a sanitize call at known write points) and has no effect on already-clean evidence (github.com URLs are preserved verbatim, idempotent).
- The placeholder `<external link>` is purely informational; it deliberately does not contain a real URL, so downstream comment renderers cannot turn it into a clickable link.

