### PR TITLE
Require AGENTS.md in review prompts

### DIFF
--- a/prompts/review-commit.md
+++ b/prompts/review-commit.md
@@ -3,13 +3,14 @@
 You are reviewing one commit on the target repository's `main` branch for
 potential regressions, bugs, and security issues.
 
-Work in the checked-out target repository. The checkout is current target
-`main`, not the commit snapshot. Review the commit SHA and base range provided
-in the prompt with commands such as `git show <sha>` and
-`git diff <base>..<sha>`, then read current `main` source around the touched
-paths to decide whether the issue still matters. Be token-efficient in the final
-report: write a short clean report when nothing is found, and expand only when
-there are concrete findings.
+Work in the checked-out target repository. Before reviewing, read the target
+repository's `AGENTS.md` if present and follow its repository-specific
+instructions when they do not conflict with this prompt or higher-priority
+system/developer instructions. The checkout is current target `main`, not the commit snapshot. Review the commit SHA and base range provided in the prompt with
+commands such as `git show <sha>` and `git diff <base>..<sha>`, then read current
+`main` source around the touched paths to decide whether the issue still matters.
+Be token-efficient in the final report: write a short clean report when nothing
+is found, and expand only when there are concrete findings.
 
 Be exhaustive about actionable issues. Do not cap findings at the first few
 problems, and do not stop after finding one or two plausible bugs. Continue

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -2,7 +2,17 @@
 
 You are reviewing one open item from the target repository for conservative maintainer cleanup.
 
-Work in the checked-out target repository. Inspect the current `main` code, docs, tests, and history as needed. The provided GitHub context includes compact related issue/PR data extracted before the review, including explicit mentions and best-effort local title-search matches from existing ClawSweeper reports. You may use unauthenticated `gh` only if it works; do not lower confidence just because authenticated `gh` is unavailable. Do not list `gh` auth, `GH_TOKEN`, shallow-clone, or unavailable-authenticated-GitHub caveats as risks when the provided context plus local checkout are enough to decide.
+Work in the checked-out target repository. Before reviewing, read the target
+repository's `AGENTS.md` if present and follow its repository-specific
+instructions when they do not conflict with this prompt or higher-priority
+system/developer instructions. Inspect the current `main` code, docs, tests, and
+history as needed. The provided GitHub context includes compact related issue/PR
+data extracted before the review, including explicit mentions and best-effort
+local title-search matches from existing ClawSweeper reports. You may use
+unauthenticated `gh` only if it works; do not lower confidence just because
+authenticated `gh` is unavailable. Do not list `gh` auth, `GH_TOKEN`,
+shallow-clone, or unavailable-authenticated-GitHub caveats as risks when the
+provided context plus local checkout are enough to decide.
 
 Treat the issue/PR discussion as evidence, not just background. Read the provided comments, timeline, and related item context before deciding. If commenters already linked a related plugin, extension, workaround, reproduction, prior PR, or external implementation, reflect that positively in the summary/evidence when it affects the decision. For `clawhub` closes, explicitly mention and link an already-posted plugin/extension when one exists, while still explaining why the OpenClaw core item can close.
 

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -9705,6 +9705,23 @@ test("review prompt reads maintainer notes before PR diffs", () => {
   assert.match(prompt, /do not publish raw internal note contents/);
 });
 
+test("review prompts read target AGENTS instructions before reviewing", () => {
+  const itemPrompt = readFileSync("prompts/review-item.md", "utf8");
+  const commitPrompt = readFileSync("prompts/review-commit.md", "utf8");
+
+  for (const prompt of [itemPrompt, commitPrompt]) {
+    assert.match(
+      prompt,
+      /Before reviewing, read the target\s+repository's `AGENTS\.md` if present/,
+    );
+    assert.match(prompt, /follow its repository-specific\s+instructions/);
+    assert.match(
+      prompt,
+      /do not conflict with this prompt or higher-priority\s+system\/developer instructions/,
+    );
+  }
+});
+
 test("review prompt requires a dedicated securityReview section", () => {
   const prompt = readFileSync("prompts/review-item.md", "utf8");
 


### PR DESCRIPTION
## Summary
- instruct item/PR review workers to read target AGENTS.md before reviewing
- add the same instruction to commit reviews
- add prompt-preservation tests for both durable prompts

## Validation
- git diff --check
- node prompt assertion over prompts/review-item.md and prompts/review-commit.md

## Notes
- Full pnpm test run was not executed locally because pnpm/corepack are unavailable in this shell.