### PR TITLE
Hide PR egg outside OpenClaw repos

### DIFF
--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -509,6 +509,9 @@ function classifyGithubIssueCommentWebhook({ event, payload }) {
   if (!isEligibleGithubWebhookRepository(repo)) {
     return { accepted: false, reason: "repository not eligible" };
   }
+  if (isGithubWebhookHatchCommand(comment) && !isOpenClawRepo(targetRepo)) {
+    return { accepted: false, reason: "PR egg is disabled for this repo" };
+  }
   const itemNumber = Number(issue.number);
   const commentId = Number(comment.id);
   const installationId = Number(objectValue(payload.installation).id);
@@ -606,9 +609,23 @@ function isEligibleGithubWebhookRepository(repo) {
   return owner === "openclaw" || owner === "steipete";
 }
 
+function isOpenClawRepo(repo) {
+  return String(repo || "")
+    .trim()
+    .toLowerCase()
+    .startsWith("openclaw/");
+}
+
 function targetDefaultBranch(repo) {
   const branch = String(repo.default_branch || "main").trim() || "main";
   return /^[A-Za-z0-9_./-]+$/.test(branch) ? branch : "main";
+}
+
+function isGithubWebhookHatchCommand(comment) {
+  const body = String(comment.body || "");
+  return /(^|[ \t\r\n])@(?:clawsweeper|openclaw-clawsweeper)\b(?:\[bot\])?\s+(?:hatch|hatch egg|pr egg hatch|hatch pr egg)\b/i.test(
+    body,
+  );
 }
 
 function isIgnoredGithubWebhookLabelMutation({ action, payload }) {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -1410,6 +1410,14 @@ function targetRepo(): string {
   return activeRepositoryProfile.targetRepo;
 }
 
+function isOpenClawRepo(repo: string | null | undefined): boolean {
+  return normalizeRepo(String(repo ?? "")).startsWith("openclaw/");
+}
+
+function prEggEnabledForMarkdown(markdown: string): boolean {
+  return isOpenClawRepo(markdownRepository(markdown));
+}
+
 function setTargetRepo(targetRepoName: string): RepositoryProfile {
   activeRepositoryProfile = repositoryProfileFor(targetRepoName);
   return activeRepositoryProfile;
@@ -6330,6 +6338,7 @@ function publicPrEggLineFromReport(
 
 function prEggImageRelativePath(markdown: string): string {
   const repo = markdownRepository(markdown);
+  if (!isOpenClawRepo(repo)) throw new Error(`PR egg is disabled for target repo: ${repo}`);
   const profile = repositoryProfileFor(repo);
   const number = frontMatterValue(markdown, "number") ?? "unknown";
   return `assets/pr-eggs/${profile.slug}/${number}.png`;
@@ -6358,6 +6367,7 @@ function shouldEnsurePrEggImage(
   statusKind: PrStatusLabelKind | null | undefined,
 ): boolean {
   return (
+    prEggEnabledForMarkdown(markdown) &&
     frontMatterValue(markdown, "type") === "pull_request" &&
     prEggProofUnlocked(reportRealBehaviorProof(markdown)) &&
     prEggStateFromStatus(statusKind) === "hatched" &&
@@ -10913,6 +10923,7 @@ function renderHatchComment(
   markdown: string,
   statusKind: PrStatusLabelKind | null | undefined,
 ): string {
+  if (!prEggEnabledForMarkdown(markdown)) return "";
   return [
     "ClawSweeper PR egg",
     "",
@@ -10929,6 +10940,7 @@ function upsertHatchComment(
   dryRun: boolean,
 ): Record<string, unknown> | undefined {
   const body = renderHatchComment(number, markdown, statusKind);
+  if (!body) return issueCommentWithMarker(number, hatchCommentMarker(number));
   const existing = issueCommentWithMarker(number, hatchCommentMarker(number));
   const id = commentId(existing);
   if (dryRun) return existing;
@@ -11774,7 +11786,8 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
     if (processedCount % progressEvery === 0) logProgress(message);
   };
   const recordMissingHatchResults = (existingNumbers: Set<number>): void => {
-    if (!hatchPrEggImage || requestedItemNumbers.length === 0) return;
+    if (!hatchPrEggImage || requestedItemNumbers.length === 0 || !isOpenClawRepo(targetRepo()))
+      return;
     for (const number of requestedItemNumbers) {
       if (existingNumbers.has(number)) continue;
       let commentReason = "no current durable ClawSweeper review record";
@@ -12113,6 +12126,13 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       return result;
     };
     if (hatchOnly) {
+      if (!isOpenClawRepo(repo)) {
+        results.push({ number, action: "kept_open", reason: "PR egg is disabled for this repo" });
+        processedCount += 1;
+        maybeLogProgress(`skipped PR egg image #${number}: disabled for repo ${repo}`);
+        if (processedCount >= processedLimit) break;
+        continue;
+      }
       if (item.kind !== "pull_request") {
         results.push({ number, action: "kept_open", reason: "hatch requires a pull request" });
         processedCount += 1;
@@ -12305,11 +12325,11 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
     ]);
     const markedReviewComment = markedReviewCommentBody(number, reviewComment);
     const prEggComment =
-      item.kind === "pull_request" && !isCloseProposal
+      item.kind === "pull_request" && !isCloseProposal && isOpenClawRepo(repo)
         ? renderHatchComment(number, markdown, currentPrStatusKind)
         : "";
     const existingPrEggComment =
-      item.kind === "pull_request" && !isCloseProposal
+      item.kind === "pull_request" && !isCloseProposal && isOpenClawRepo(repo)
         ? issueCommentWithMarker(number, hatchCommentMarker(number))
         : undefined;
     const protectedApplyReason = applyProtectedLabelReason(item.labels, closeReason);
@@ -12512,6 +12532,7 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       frontMatterValue(markdown, "review_comment_url") === "unknown";
     const needsPrEggCommentSync =
       item.kind === "pull_request" &&
+      isOpenClawRepo(repo) &&
       !isCloseProposal &&
       !commentBodyMatches(existingPrEggComment, prEggComment);
     const needsReviewCommentSync = shouldSyncReviewComment({

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -343,6 +343,9 @@ function classifyCommand(command: LooseRecord): JsonValue {
   if (command.comment_version_key && processedCommentVersions.has(command.comment_version_key)) {
     return { ...command, status: "skipped", reason: "comment version already processed in ledger" };
   }
+  if (command.intent === "hatch" && !isOpenClawRepo(String(command.repo ?? ""))) {
+    return { ...command, status: "ignored", reason: "PR egg is disabled for this repo" };
+  }
   let authorization: LooseRecord | null = null;
   if (command.trusted_bot) {
     if (!trustedBots.has(String(command.author ?? "").toLowerCase())) {
@@ -771,6 +774,10 @@ function classifyCommand(command: LooseRecord): JsonValue {
       { action: "comment", status: execute ? "pending" : "planned" },
     ],
   };
+}
+
+function isOpenClawRepo(repo: string): boolean {
+  return repo.trim().toLowerCase().startsWith("openclaw/");
 }
 
 function classifyAutoclose(command: LooseRecord, issue: LooseRecord, pull: LooseRecord): JsonValue {

--- a/src/repair/comment-webhook.ts
+++ b/src/repair/comment-webhook.ts
@@ -179,6 +179,9 @@ export function classifyIssueCommentWebhook({
   if (!isEligibleRepositoryPayload(repo)) {
     return { accepted: false, reason: "repository not eligible" };
   }
+  if (parseCommand(String(comment.body ?? ""))?.intent === "hatch" && !isOpenClawRepo(targetRepo)) {
+    return { accepted: false, reason: "PR egg is disabled for this repo" };
+  }
   const itemNumber = Number(issue.number);
   const commentId = Number(comment.id);
   const installationId = Number(asRecord(payload.installation).id);
@@ -274,6 +277,10 @@ function isEligibleRepositoryPayload(repo: LooseRecord) {
   } catch {
     return false;
   }
+}
+
+function isOpenClawRepo(repo: string) {
+  return repo.trim().toLowerCase().startsWith("openclaw/");
 }
 
 function targetDefaultBranch(repo: LooseRecord) {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -3358,6 +3358,60 @@ Full review comments:
   assert.doesNotMatch(eggComment, /Share on X:/);
 });
 
+test("PR egg comment is hidden outside OpenClaw repositories", () => {
+  const report = `${reportFrontMatter({
+    repository: "steipete/summarize",
+    type: "pull_request",
+    number: "74470",
+    decision: "keep_open",
+    close_reason: "none",
+    review_status: "complete",
+    confidence: "high",
+    author: "contributor",
+    author_association: "CONTRIBUTOR",
+    labels: JSON.stringify(["status: 👀 ready for maintainer look"]),
+    work_candidate: "none",
+    pull_head_sha: "abc123def456",
+  })}
+
+## Summary
+
+Keep this PR open.
+
+${realBehaviorProofReportSection({
+  status: "sufficient",
+  evidenceKind: "terminal",
+  needsContributorAction: false,
+  summary: "The PR has sufficient proof.",
+})}
+
+${prRatingReportSection({
+  overallTier: "A",
+  proofTier: "A",
+  patchTier: "A",
+  overallLabel: "🦀 challenger crab",
+  proofLabel: "🦀 challenger crab",
+  patchLabel: "🦀 challenger crab",
+  summary: "Ready for maintainer review.",
+  nextSteps: "none",
+})}
+
+## Review Findings
+
+Overall correctness: patch is correct
+
+Overall confidence: 0.9
+
+Full review comments:
+
+- none
+`;
+
+  const eggComment = renderPrEggCommentForTest(74470, report, "ready_for_maintainer_look");
+
+  assert.equal(eggComment, "");
+});
+
 test("PR egg comment renders warming PR egg from active status after proof passes", () => {
   const report = `${reportFrontMatter({
     type: "pull_request",

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -1284,6 +1284,41 @@ test("hosted webhook accepts author read-only mention commands", async () => {
   }
 });
 
+test("hosted webhook ignores hatch commands outside OpenClaw repositories", async () => {
+  const response = await worker.fetch(
+    signedGithubWebhookRequest({
+      event: "issue_comment",
+      secret: "test-secret",
+      payload: {
+        action: "created",
+        repository: {
+          full_name: "steipete/summarize",
+          private: false,
+          archived: false,
+          fork: false,
+          has_issues: true,
+        },
+        issue: { number: 76991, user: { login: "nickmopen" } },
+        installation: { id: 123 },
+        comment: {
+          id: 456,
+          body: "@clawsweeper hatch",
+          author_association: "CONTRIBUTOR",
+          user: { login: "NickMOpen" },
+        },
+      },
+    }),
+    { CLAWSWEEPER_WEBHOOK_SECRET: "test-secret" },
+  );
+
+  assert.equal(response.status, 202);
+  assert.deepEqual(await response.json(), {
+    ok: true,
+    accepted: false,
+    reason: "PR egg is disabled for this repo",
+  });
+});
+
 test("hosted webhook returns invalid_json for signed malformed bodies", async () => {
   const response = await worker.fetch(
     signedGithubWebhookBodyRequest({

--- a/test/repair/comment-webhook.test.ts
+++ b/test/repair/comment-webhook.test.ts
@@ -116,6 +116,26 @@ test("comment webhook accepts author read-only hatch commands", () => {
   });
 });
 
+test("comment webhook ignores hatch commands outside OpenClaw repositories", () => {
+  const result = classifyIssueCommentWebhook({
+    event: "issue_comment",
+    payload: {
+      action: "created",
+      repository: { full_name: "steipete/summarize" },
+      issue: { number: 76992, user: { login: "nickmopen" } },
+      installation: { id: 123 },
+      comment: {
+        id: 457,
+        body: "@clawsweeper hatch",
+        author_association: "CONTRIBUTOR",
+        user: { login: "NickMOpen" },
+      },
+    },
+  });
+
+  assert.deepEqual(result, { accepted: false, reason: "PR egg is disabled for this repo" });
+});
+
 test("comment webhook rejects commands from ineligible repositories", () => {
   const result = classifyIssueCommentWebhook({
     event: "issue_comment",


### PR DESCRIPTION
## Summary
- suppress PR egg comments, images, and hatch missing-record notices outside openclaw/* repos
- ignore non-OpenClaw hatch commands at webhook and router intake
- cover non-OpenClaw rendering and webhook hatch suppression with regressions

## Tests
- npm_config_cache=/private/tmp/clawsweeper-npm-cache npx pnpm@10.33.2 run build:all
- node --test test/clawsweeper.test.ts test/dashboard-worker.test.ts
- node --test test/repair/comment-router-core.test.ts test/repair/comment-webhook.test.ts
- npm_config_cache=/private/tmp/clawsweeper-npm-cache npx pnpm@10.33.2 run format:check
- git diff --check