### PR TITLE
feat: add OpenClaw PR surface stats

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -38,6 +38,12 @@ import { stableJson } from "./stable-json.js";
 import { runText } from "./command.js";
 import { AUTOMATION_LIMITS } from "./limits.js";
 import {
+  buildOpenClawPrSurfaceStats,
+  renderOpenClawPrSurfaceSummary,
+  renderOpenClawPrSurfaceTable,
+  type PrSurfaceFile,
+} from "./pr-surface-stats.js";
+import {
   boolArg,
   itemNumbersArg,
   numberArg,
@@ -7832,6 +7838,63 @@ function pullRequestFilePathsFromReport(markdown: string): string[] {
   return frontMatterStringArray(markdown, "pull_files");
 }
 
+function prSurfaceFilesFromContext(context: ItemContext): PrSurfaceFile[] {
+  if (context.counts?.pullFilesTruncated) return [];
+  return (context.pullFiles ?? [])
+    .map((entry) => {
+      const file = asRecord(entry);
+      const path = typeof file.filename === "string" ? file.filename.trim() : "";
+      if (!path) return null;
+      return {
+        path,
+        additions: nonNegativeInteger(file.additions),
+        deletions: nonNegativeInteger(file.deletions),
+      };
+    })
+    .filter((entry): entry is PrSurfaceFile => Boolean(entry));
+}
+
+function nonNegativeInteger(value: unknown): number {
+  const number = Number(value);
+  return Number.isInteger(number) && number > 0 ? number : 0;
+}
+
+function prSurfaceFilesFromReport(markdown: string): PrSurfaceFile[] {
+  if (frontMatterBoolean(markdown, "pr_surface_files_truncated")) return [];
+  return frontMatterJsonArray(markdown, "pr_surface_files")
+    .map((entry) => {
+      const file = asRecord(entry);
+      const path = typeof file.path === "string" ? file.path.trim() : "";
+      if (!path) return null;
+      return {
+        path,
+        additions: nonNegativeInteger(file.additions),
+        deletions: nonNegativeInteger(file.deletions),
+      };
+    })
+    .filter((entry): entry is PrSurfaceFile => Boolean(entry));
+}
+
+function shouldRenderOpenClawPrSurface(markdown: string): boolean {
+  return (
+    frontMatterValue(markdown, "type") === "pull_request" &&
+    normalizeRepo(markdownRepository(markdown)) === "openclaw/openclaw"
+  );
+}
+
+function renderOpenClawPrSurfaceFromReport(markdown: string): string {
+  if (!shouldRenderOpenClawPrSurface(markdown)) return "";
+  const files = prSurfaceFilesFromReport(markdown);
+  if (files.length === 0) return "";
+  const stats = buildOpenClawPrSurfaceStats(files);
+  const summary = renderOpenClawPrSurfaceSummary(stats);
+  if (!summary) return "";
+  const details = collapsedDetailsBlock("View PR surface stats", [
+    renderOpenClawPrSurfaceTable(stats),
+  ]);
+  return details ? `${summary}\n\n${details}` : summary;
+}
+
 function isDocsPath(file: string): boolean {
   return file.startsWith("docs/");
 }
@@ -10183,6 +10246,8 @@ function renderKeepOpenCommentFromReport(
     ...reviewFreshnessCallout(markdown),
     ...reviewWorkflowCallout(),
   ];
+  const prSurface = renderOpenClawPrSurfaceFromReport(markdown);
+  if (prSurface) appendPublicSection(lines, "PR Surface", prSurface);
   if (isPullRequest) {
     appendPublicSection(
       lines,
@@ -11272,6 +11337,7 @@ function markdownFor(options: {
   const repairWorkPromptSection = renderRepairWorkPromptReportSection(options.decision);
   const pullFiles = pullRequestFilePathsFromContext(options.context);
   const pullFilesTruncated = Boolean(options.context.counts?.pullFilesTruncated);
+  const prSurfaceFiles = prSurfaceFilesFromContext(options.context);
   return `---
 number: ${options.item.number}
 repository: ${options.item.repo}
@@ -11339,6 +11405,8 @@ merge_risk_options: ${JSON.stringify(options.decision.mergeRiskOptions)}
 label_justifications: ${JSON.stringify(options.decision.labelJustifications)}
 pull_files: ${jsonFrontMatterValue(pullFiles)}
 pull_files_truncated: ${pullFilesTruncated}
+pr_surface_files: ${jsonFrontMatterValue(prSurfaceFiles)}
+pr_surface_files_truncated: ${pullFilesTruncated}
 item_category: ${options.decision.itemCategory}
 reproduction_status: ${options.decision.reproductionStatus}
 reproduction_confidence: ${options.decision.reproductionConfidence}
@@ -13565,7 +13633,7 @@ function markdownTableCell(value: string): string {
   return value.replaceAll("|", "\\|");
 }
 
-function jsonFrontMatterValue(value: readonly string[]): string {
+function jsonFrontMatterValue(value: readonly unknown[]): string {
   return JSON.stringify(value);
 }
 

--- a/src/pr-surface-stats.ts
+++ b/src/pr-surface-stats.ts
@@ -1,0 +1,145 @@
+export type PrSurfaceBucket = "source" | "tests" | "docs" | "config" | "generated" | "other";
+
+export interface PrSurfaceFile {
+  path: string;
+  additions: number;
+  deletions: number;
+}
+
+export interface PrSurfaceStatsRow {
+  bucket: PrSurfaceBucket;
+  label: string;
+  files: number;
+  additions: number;
+  deletions: number;
+  net: number;
+}
+
+const BUCKETS: readonly { bucket: PrSurfaceBucket; label: string }[] = [
+  { bucket: "source", label: "Source" },
+  { bucket: "tests", label: "Tests" },
+  { bucket: "docs", label: "Docs" },
+  { bucket: "config", label: "Config" },
+  { bucket: "generated", label: "Generated" },
+  { bucket: "other", label: "Other" },
+];
+
+export function buildOpenClawPrSurfaceStats(files: readonly PrSurfaceFile[]): PrSurfaceStatsRow[] {
+  const rows = BUCKETS.map(({ bucket, label }) => ({
+    bucket,
+    label,
+    files: 0,
+    additions: 0,
+    deletions: 0,
+    net: 0,
+  }));
+  const byBucket = new Map(rows.map((row) => [row.bucket, row]));
+
+  for (const file of files) {
+    const bucket = openClawPrSurfaceBucket(file.path);
+    const row = byBucket.get(bucket);
+    if (!row) continue;
+    row.files += 1;
+    row.additions += file.additions;
+    row.deletions += file.deletions;
+    row.net += file.additions - file.deletions;
+  }
+
+  return rows;
+}
+
+export function openClawPrSurfaceBucket(file: string): PrSurfaceBucket {
+  const normalized = file.trim().replaceAll("\\", "/");
+  const basename = normalized.split("/").pop() ?? normalized;
+
+  if (isOpenClawGeneratedPath(normalized, basename)) return "generated";
+  if (isOpenClawTestPath(normalized)) return "tests";
+  if (isOpenClawDocsPath(normalized, basename)) return "docs";
+  if (isOpenClawConfigPath(normalized, basename)) return "config";
+  if (isOpenClawSourcePath(normalized)) return "source";
+  return "other";
+}
+
+export function renderOpenClawPrSurfaceSummary(stats: readonly PrSurfaceStatsRow[]): string {
+  const total = totalPrSurfaceStats(stats);
+  if (total.files === 0) return "";
+  const parts = stats
+    .filter((row) => row.files > 0 || row.additions > 0 || row.deletions > 0)
+    .map((row) => `${row.label} ${formatNet(row.net)}`);
+  return `${parts.join(", ")}. Total ${formatNet(total.net)} across ${total.files} ${pluralize("file", total.files)}.`;
+}
+
+export function renderOpenClawPrSurfaceTable(stats: readonly PrSurfaceStatsRow[]): string {
+  const total = totalPrSurfaceStats(stats);
+  return [
+    "| Area | Files | Added | Removed | Net |",
+    "|---|---:|---:|---:|---:|",
+    ...stats.map(
+      (row) =>
+        `| ${row.label} | ${row.files} | ${row.additions} | ${row.deletions} | ${formatNet(row.net)} |`,
+    ),
+    `| **Total** | **${total.files}** | **${total.additions}** | **${total.deletions}** | **${formatNet(total.net)}** |`,
+  ].join("\n");
+}
+
+function totalPrSurfaceStats(
+  stats: readonly PrSurfaceStatsRow[],
+): Omit<PrSurfaceStatsRow, "bucket" | "label"> {
+  return stats.reduce(
+    (total, row) => ({
+      files: total.files + row.files,
+      additions: total.additions + row.additions,
+      deletions: total.deletions + row.deletions,
+      net: total.net + row.net,
+    }),
+    { files: 0, additions: 0, deletions: 0, net: 0 },
+  );
+}
+
+function isOpenClawSourcePath(file: string): boolean {
+  return /^(?:src|ui|packages|extensions)\//.test(file);
+}
+
+function isOpenClawTestPath(file: string): boolean {
+  return (
+    /(?:^|\/)__tests__\//.test(file) ||
+    /^(?:test|tests)\//.test(file) ||
+    /\.(?:test|spec|e2e\.test)\.[cm]?[jt]sx?$/.test(file)
+  );
+}
+
+function isOpenClawDocsPath(file: string, basename: string): boolean {
+  return (
+    file.startsWith("docs/") ||
+    /^README(?:\.[A-Za-z0-9_-]+)?$/i.test(basename) ||
+    basename === "CHANGELOG.md" ||
+    /\.(?:md|mdx)$/i.test(file)
+  );
+}
+
+function isOpenClawConfigPath(file: string, basename: string): boolean {
+  return (
+    file.startsWith(".github/") ||
+    basename === "package.json" ||
+    basename === "pnpm-workspace.yaml" ||
+    /^tsconfig(?:\.[^.]+)?\.json$/i.test(basename)
+  );
+}
+
+function isOpenClawGeneratedPath(file: string, basename: string): boolean {
+  return (
+    file.startsWith("protocol-generated/") ||
+    file.startsWith("docs/.generated/") ||
+    basename.includes(".generated.") ||
+    /(?:^|\/)__snapshots__\//.test(file) ||
+    /\.(?:snap|snapshot)$/i.test(basename)
+  );
+}
+
+function formatNet(value: number): string {
+  return value > 0 ? `+${value}` : String(value);
+}
+
+function pluralize(word: string, count: number): string {
+  return count === 1 ? word : `${word}s`;
+}

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -8911,6 +8911,82 @@ Reason: ${duplicateRisk}
   assert.equal(comment.split(duplicateRisk).length - 1, 1);
 });
 
+test("OpenClaw pull request comments render PR surface before summary", () => {
+  const comment = renderReviewCommentFromReport(
+    `${reportFrontMatter({
+      repository: "openclaw/openclaw",
+      type: "pull_request",
+      number: "12345",
+      decision: "keep_open",
+      close_reason: "none",
+      work_candidate: "none",
+      pr_surface_files: JSON.stringify([
+        { path: "src/runtime.ts", additions: 10, deletions: 2 },
+        { path: "src/runtime.test.ts", additions: 7, deletions: 1 },
+        { path: "docs/usage.md", additions: 4, deletions: 0 },
+      ]),
+      pr_surface_files_truncated: "false",
+    })}
+
+## Summary
+
+Keep this PR open for maintainer review.
+
+## What This Changes
+
+Adds a small runtime change with tests and docs.
+`,
+    "none",
+  );
+
+  assert.match(
+    comment,
+    /\*\*PR Surface\*\*\nSource \+8, Tests \+6, Docs \+4\. Total \+18 across 3 files\./,
+  );
+  assert.match(comment, /<summary>View PR surface stats<\/summary>/);
+  assert.match(
+    comment,
+    /\| \*\*Total\*\* \| \*\*3\*\* \| \*\*21\*\* \| \*\*3\*\* \| \*\*\+18\*\* \|/,
+  );
+  assert.ok(comment.indexOf("**PR Surface**") < comment.indexOf("**Summary**"));
+});
+
+test("PR surface is OpenClaw pull-request only", () => {
+  const frontMatter = {
+    decision: "keep_open",
+    close_reason: "none",
+    work_candidate: "none",
+    pr_surface_files: JSON.stringify([{ path: "src/runtime.ts", additions: 10, deletions: 2 }]),
+    pr_surface_files_truncated: "false",
+  };
+  const body = `
+
+## Summary
+
+Keep this open.
+`;
+
+  const otherRepoComment = renderReviewCommentFromReport(
+    `${reportFrontMatter({
+      ...frontMatter,
+      repository: "example/project",
+      type: "pull_request",
+    })}${body}`,
+    "none",
+  );
+  const issueComment = renderReviewCommentFromReport(
+    `${reportFrontMatter({
+      ...frontMatter,
+      repository: "openclaw/openclaw",
+      type: "issue",
+    })}${body}`,
+    "none",
+  );
+
+  assert.doesNotMatch(otherRepoComment, /\*\*PR Surface\*\*/);
+  assert.doesNotMatch(issueComment, /\*\*PR Surface\*\*/);
+});
+
 function mergeRiskReviewComment({
   risk,
   options,

--- a/test/pr-surface-stats.test.ts
+++ b/test/pr-surface-stats.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildOpenClawPrSurfaceStats,
+  openClawPrSurfaceBucket,
+  renderOpenClawPrSurfaceSummary,
+  renderOpenClawPrSurfaceTable,
+} from "../dist/pr-surface-stats.js";
+
+test("OpenClaw PR surface buckets classify changed paths", () => {
+  assert.equal(openClawPrSurfaceBucket("src/agents/runtime.ts"), "source");
+  assert.equal(openClawPrSurfaceBucket("ui/components/App.tsx"), "source");
+  assert.equal(openClawPrSurfaceBucket("extensions/slack/src/index.ts"), "source");
+  assert.equal(openClawPrSurfaceBucket("src/agents/runtime.test.ts"), "tests");
+  assert.equal(openClawPrSurfaceBucket("tests/fixtures/session.json"), "tests");
+  assert.equal(openClawPrSurfaceBucket("docs/gateway/configuration.md"), "docs");
+  assert.equal(openClawPrSurfaceBucket("README.md"), "docs");
+  assert.equal(openClawPrSurfaceBucket(".github/workflows/check.yml"), "config");
+  assert.equal(openClawPrSurfaceBucket("package.json"), "config");
+  assert.equal(openClawPrSurfaceBucket("src/config/schema.base.generated.test.ts"), "generated");
+  assert.equal(openClawPrSurfaceBucket("protocol-generated/json/frame.json"), "generated");
+  assert.equal(openClawPrSurfaceBucket("fixtures/sample.txt"), "other");
+});
+
+test("OpenClaw PR surface stats aggregate rows and totals", () => {
+  const stats = buildOpenClawPrSurfaceStats([
+    { path: "src/runtime.ts", additions: 12, deletions: 2 },
+    { path: "src/runtime.test.ts", additions: 8, deletions: 1 },
+    { path: "docs/usage.md", additions: 5, deletions: 0 },
+    { path: ".github/workflows/check.yml", additions: 4, deletions: 6 },
+    { path: "protocol-generated/json/frame.json", additions: 3, deletions: 0 },
+    { path: "fixtures/sample.txt", additions: 2, deletions: 1 },
+  ]);
+
+  assert.deepEqual(
+    stats.map(({ label, files, additions, deletions, net }) => ({
+      label,
+      files,
+      additions,
+      deletions,
+      net,
+    })),
+    [
+      { label: "Source", files: 1, additions: 12, deletions: 2, net: 10 },
+      { label: "Tests", files: 1, additions: 8, deletions: 1, net: 7 },
+      { label: "Docs", files: 1, additions: 5, deletions: 0, net: 5 },
+      { label: "Config", files: 1, additions: 4, deletions: 6, net: -2 },
+      { label: "Generated", files: 1, additions: 3, deletions: 0, net: 3 },
+      { label: "Other", files: 1, additions: 2, deletions: 1, net: 1 },
+    ],
+  );
+
+  const summary = renderOpenClawPrSurfaceSummary(stats);
+  assert.equal(
+    summary,
+    "Source +10, Tests +7, Docs +5, Config -2, Generated +3, Other +1. Total +24 across 6 files.",
+  );
+
+  const table = renderOpenClawPrSurfaceTable(stats);
+  assert.match(table, /\| Source \| 1 \| 12 \| 2 \| \+10 \|/);
+  assert.match(table, /\| Config \| 1 \| 4 \| 6 \| -2 \|/);
+  assert.match(
+    table,
+    /\| \*\*Total\*\* \| \*\*6\*\* \| \*\*34\*\* \| \*\*10\*\* \| \*\*\+24\*\* \|/,
+  );
+});
+
+test("OpenClaw PR surface summary omits zero buckets but table keeps them", () => {
+  const stats = buildOpenClawPrSurfaceStats([
+    { path: "src/runtime.ts", additions: 3, deletions: 1 },
+  ]);
+
+  assert.equal(renderOpenClawPrSurfaceSummary(stats), "Source +2. Total +2 across 1 file.");
+
+  const table = renderOpenClawPrSurfaceTable(stats);
+  assert.match(table, /\| Tests \| 0 \| 0 \| 0 \| 0 \|/);
+  assert.match(table, /\| Other \| 0 \| 0 \| 0 \| 0 \|/);
+});


### PR DESCRIPTION
## Summary

- Adds an OpenClaw-only PR surface summary to ClawSweeper's durable public PR review comment.
- Persists compact per-file additions/deletions from hydrated PR file data so comment rendering does not fetch GitHub again.
- Renders a one-line summary plus expandable Source/Tests/Docs/Config/Generated/Other table before the public Summary section.

## Before / After

```text
Before

Codex review: found issues before merge.

**Latest ClawSweeper review:** ...

**Workflow note:** Future ClawSweeper reviews update this same comment in place.

**Summary**
...
```

```text
After

Codex review: found issues before merge.

**Latest ClawSweeper review:** ...

**Workflow note:** Future ClawSweeper reviews update this same comment in place.

**PR Surface**
Source +8, Tests +6, Docs +4. Total +18 across 3 files.

[expand] View PR surface stats
  Area       Files   Added   Removed   Net
  Source     1       10      2         +8
  Tests      1       7       1         +6
  Docs       1       4       0         +4
  Config     0       0       0          0
  Generated  0       0       0          0
  Other      0       0       0          0
  Total      3       21      3        +18

**Summary**
...
```

## Verification

Behavior addressed: OpenClaw PR review comments now show compact PR surface churn stats before the Summary section.
Real environment tested: Local ClawSweeper checkout from a clean branch based on origin/main.
Exact steps or command run after this patch: `./node_modules/.bin/tsgo -p tsconfig.json`; `node --test test/pr-surface-stats.test.ts test/clawsweeper.test.ts`; `./node_modules/.bin/oxfmt --check src/pr-surface-stats.ts src/clawsweeper.ts test/pr-surface-stats.test.ts test/clawsweeper.test.ts`; `git diff --check`.
Evidence after fix: TypeScript build passed; 274 focused tests passed; touched files passed formatting; diff check passed.
Observed result after fix: OpenClaw PR comments render the PR Surface section before Summary, while issues and non-OpenClaw repositories omit it.
What was not tested: Full ClawSweeper `pnpm run check`; `pnpm` was unavailable on PATH in this shell, so validation used repo-local binaries directly.
