### PR TITLE
Improve ClawSweeper related issue context

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -346,6 +346,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
           ADDITIONAL_PROMPT: ${{ github.event.client_payload.additional_prompt || '' }}
+          CLAWSWEEPER_RELATED_GITHUB_SEARCH: ${{ vars.CLAWSWEEPER_RELATED_GITHUB_SEARCH || '1' }}
         run: |
           set -euo pipefail
           test -n "$GH_TOKEN"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Added
 
+- Added richer related issue context in review prompts from linked PRs, local reports, gitcrawl clusters, and exact-event GitHub issue search. Thanks @brokemac79.
 - Added the first Cloudflare live dashboard for ClawSweeper observability, with
   active worker counts, pipeline rows, CI state, automerge timing, and optional
   signed status-event ingest.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ hidden verdict/action markers so trusted repair and automerge flows can continue
 without scraping visible prose. See
 [`docs/pr-review-comments.md`](docs/pr-review-comments.md).
 
+Review prompts include compact related issue and PR context from explicit links,
+linked closing PRs, existing local ClawSweeper reports, optional gitcrawl
+clusters, and opt-in live GitHub issue search for exact event reviews. This is
+advisory context for duplicate/superseded reasoning, not a standalone close
+decision. See
+[`docs/related-issue-discovery.md`](docs/related-issue-discovery.md).
+
 For open issues with complete, current kept-open reviews, ClawSweeper also
 projects selected structured review conclusions into advisory GitHub labels for
 maintainer filtering and project views. These labels expose states such as

--- a/docs/related-issue-discovery.md
+++ b/docs/related-issue-discovery.md
@@ -1,0 +1,70 @@
+# Related Issue Discovery
+
+ClawSweeper includes compact related issue and PR context in each review prompt so
+the reviewer can spot duplicates, superseded work, adjacent reports, and already
+active fix paths. This context is advisory. It gives the review model evidence;
+it does not itself close issues, change labels, open PRs, or merge anything.
+
+## Sources
+
+Related item context is built from a small set of bounded sources:
+
+- Explicit links in the item body, comments, timeline, PR body, and PR review
+  comments, including `#123` references and same-repository GitHub issue or PR
+  URLs.
+- GitHub closing-PR references for issues, such as PRs that use `Fixes #123`.
+- Existing local ClawSweeper reports with overlapping title terms.
+- Optional local gitcrawl cluster data, when a gitcrawl SQLite database is
+  available.
+- Optional live GitHub issue search for exact event reviews.
+
+The review prompt still requires a conservative canonical-search pass before
+using `duplicate_or_superseded`. The related context is a starting point, not a
+standalone duplicate verdict.
+
+## Live GitHub Search
+
+Live GitHub Search is intentionally opt-in because the Search API has tighter
+rate limits than normal issue reads. Exact event reviews enable it by default in
+the ClawSweeper workflow:
+
+```text
+CLAWSWEEPER_RELATED_GITHUB_SEARCH=1
+```
+
+Set `CLAWSWEEPER_RELATED_GITHUB_SEARCH=0` in repository variables to disable the
+live search enrichment without changing code.
+
+The search is issue-only, scoped to the target repository, and based on a small
+set of non-generic title terms. Results are included in the prompt as candidate
+related items so the reviewer can decide whether they are truly duplicates,
+adjacent reports, or irrelevant matches.
+
+## Gitcrawl
+
+When a local gitcrawl database exists, ClawSweeper reads same-cluster issue
+siblings from the same target repository as the reviewed issue and adds them to
+the same related-item prompt section.
+
+The default database path is:
+
+```text
+~/.config/gitcrawl/gitcrawl.db
+```
+
+Use `CLAWSWEEPER_GITCRAWL_DB=/path/to/gitcrawl.db` to point at a different
+database. If the database or `sqlite3` is unavailable, this source is skipped
+silently and the review continues with the other context sources.
+
+Both current portable gitcrawl tables and the older legacy cluster tables are
+supported on a best-effort basis.
+
+## Guardrails
+
+- Related discovery does not create new labels.
+- Related discovery does not auto-close an item by itself.
+- Related discovery does not make repair or automerge decisions.
+- Duplicate or superseded close proposals still require concrete evidence in
+  the review and must pass the existing apply-time live-state checks.
+- GitHub Search is enabled only for exact one-item event reviews by default, not
+  broad scheduled sweeps.

--- a/docs/target-dispatcher.md
+++ b/docs/target-dispatcher.md
@@ -29,6 +29,11 @@ issues stay open, and PRs can auto-close only when already implemented on
 `main`. Add a config entry only when the repo should appear in the dashboard or
 needs repo-specific review guidance.
 
+Exact event reviews enable related issue GitHub Search by default so newly
+opened issues get stronger duplicate and adjacent-report context. Set repository
+variable `CLAWSWEEPER_RELATED_GITHUB_SEARCH=0` on `openclaw/clawsweeper` to turn
+that enrichment off without editing the target dispatcher.
+
 ```yaml
 name: ClawSweeper Dispatch
 

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -7,8 +7,10 @@ repository's `AGENTS.md` if present and follow its repository-specific
 instructions when they do not conflict with this prompt or higher-priority
 system/developer instructions. Inspect the current `main` code, docs, tests, and
 history as needed. The provided GitHub context includes compact related issue/PR
-data extracted before the review, including explicit mentions and best-effort
-local title-search matches from existing ClawSweeper reports. You may use
+data extracted before the review, including explicit mentions, linked closing
+PRs, best-effort local title-search matches from existing ClawSweeper reports,
+optional gitcrawl cluster siblings, and optional GitHub issue-search matches.
+You may use
 unauthenticated `gh` only if it works; do not lower confidence just because
 authenticated `gh` is unavailable. Do not list `gh` auth, `GH_TOKEN`,
 shallow-clone, or unavailable-authenticated-GitHub caveats as risks when the

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -13,6 +13,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { basename, dirname, join, relative, resolve } from "node:path";
+import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 import {
   DEFAULT_TARGET_REPO,
@@ -1594,6 +1595,37 @@ function gh(args: string[]): string {
   return run("gh", ["--repo", targetRepo(), ...args]);
 }
 
+function ghBinArgs(): string[] {
+  const value = process.env.GH_BIN_ARGS;
+  if (!value) return [];
+  const parsed = JSON.parse(value) as unknown;
+  if (!Array.isArray(parsed) || !parsed.every((entry) => typeof entry === "string")) {
+    throw new Error("GH_BIN_ARGS must be a JSON string array");
+  }
+  return parsed;
+}
+
+function ghOnce(args: string[], timeoutMs: number): string {
+  const command = process.env.GH_BIN ?? "gh";
+  const resolvedArgs = args[0] === "api" ? args : ["--repo", targetRepo(), ...args];
+  const result = spawnSync(command, [...ghBinArgs(), ...resolvedArgs], {
+    cwd: ROOT,
+    encoding: "utf8",
+    env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
+    maxBuffer: 8 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: timeoutMs,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const stderr = typeof result.stderr === "string" ? result.stderr.trim() : "";
+    throw new Error(
+      [`Command failed: gh ${resolvedArgs.join(" ")}`, stderr].filter(Boolean).join("\n"),
+    );
+  }
+  return (result.stdout ?? "").trim();
+}
+
 function sleepMs(milliseconds: number): void {
   if (milliseconds <= 0) return;
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
@@ -1684,6 +1716,10 @@ function ghWithRetry(args: string[], attempts = 12): string {
 
 function ghJson<T>(args: string[]): T {
   return parseGhJson<T>(ghWithRetry(args), args);
+}
+
+function ghJsonOnce<T>(args: string[], timeoutMs: number): T {
+  return parseGhJson<T>(ghOnce(args, timeoutMs), args);
 }
 
 function ghJsonLines<T>(args: string[]): T[] {
@@ -2764,6 +2800,13 @@ const RELATED_TITLE_STOP_WORDS = new Set([
 ]);
 
 let localRelatedTitleIndexCache: { repo: string; entries: LocalRelatedTitleEntry[] } | null = null;
+type GitcrawlClusterSource = "legacy" | "portable";
+let gitcrawlClusterSourceCache: { dbPath: string; source: GitcrawlClusterSource | null } | null =
+  null;
+const RELATED_ITEMS_LIMIT = 12;
+const RELATED_GITHUB_SEARCH_LIMIT = 5;
+const RELATED_GITCRAWL_LIMIT = 6;
+const RELATED_GITHUB_SEARCH_TIMEOUT_MS = 15_000;
 
 export function relatedTitleSearchTerms(title: string, limit = 6): string[] {
   const seen = new Set<string>();
@@ -2863,10 +2906,9 @@ function localRelatedTitleIndex(): LocalRelatedTitleEntry[] {
   return entries;
 }
 
-function compactRelatedSearchItems(item: Item, mentioned: Set<number>): unknown[] {
+function compactLocalRelatedTitleItems(item: Item, seen: ReadonlySet<number>): unknown[] {
   const terms = relatedTitleSearchTerms(item.title);
   if (terms.length < 2) return [];
-  const seen = new Set<number>([item.number, ...mentioned]);
   return localRelatedTitleIndex()
     .flatMap((entry) => {
       if (seen.has(entry.number)) return [];
@@ -2887,6 +2929,304 @@ function compactRelatedSearchItems(item: Item, mentioned: Set<number>): unknown[
     }));
 }
 
+function envFlagEnabled(value: string | undefined): boolean {
+  if (!value) return false;
+  return ["1", "true", "yes", "on"].includes(value.trim().toLowerCase());
+}
+
+function quoteGitHubSearchTerm(term: string): string {
+  return /^[a-z0-9_]+$/i.test(term) ? term : `"${term.replaceAll('"', "")}"`;
+}
+
+function relatedGitHubIssueSearchQuery(repo: string, title: string): string | null {
+  const terms = relatedTitleSearchTerms(title, 4);
+  if (terms.length < 2) return null;
+  return [`repo:${repo}`, "is:issue", "in:title,body", ...terms.map(quoteGitHubSearchTerm)].join(
+    " ",
+  );
+}
+
+export function relatedGitHubIssueSearchQueryForTest(repo: string, title: string): string | null {
+  return relatedGitHubIssueSearchQuery(repo, title);
+}
+
+function compactRelatedGitHubIssueSearchItems(item: Item, seen: ReadonlySet<number>): unknown[] {
+  if (item.kind !== "issue") return [];
+  if (!envFlagEnabled(process.env.CLAWSWEEPER_RELATED_GITHUB_SEARCH)) return [];
+  const query = relatedGitHubIssueSearchQuery(targetRepo(), item.title);
+  if (!query) return [];
+
+  try {
+    const response = asRecord(
+      ghJsonOnce<unknown>(
+        [
+          "api",
+          `search/issues?q=${encodeURIComponent(query)}&per_page=${RELATED_GITHUB_SEARCH_LIMIT}`,
+        ],
+        RELATED_GITHUB_SEARCH_TIMEOUT_MS,
+      ),
+    );
+    const items = Array.isArray(response.items) ? response.items : [];
+    return items
+      .map(asRecord)
+      .filter((candidate) => {
+        const number = candidate.number;
+        if (typeof number !== "number" || seen.has(number) || number === item.number) return false;
+        return !candidate.pull_request;
+      })
+      .slice(0, RELATED_GITHUB_SEARCH_LIMIT)
+      .map((candidate) => ({
+        mentionedIn: ["GitHub issue search"],
+        searchQuery: query,
+        searchScore: candidate.score,
+        issue: compactIssue(candidate),
+        commentCount: candidate.comments,
+      }));
+  } catch (error) {
+    console.error(
+      `Best-effort related issue GitHub search failed for #${item.number}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return [];
+  }
+}
+
+function parseJsonArrayBestEffort(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value;
+  if (typeof value !== "string" || !value.trim()) return [];
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function sqlSafeInteger(value: number): string {
+  if (!Number.isSafeInteger(value)) throw new Error(`unsafe SQL integer: ${value}`);
+  return String(value);
+}
+
+function sqlStringLiteral(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+function sqliteScalarBestEffort(dbPath: string, sql: string): string | null {
+  const result = spawnSync("sqlite3", [dbPath, sql], {
+    cwd: ROOT,
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024,
+    timeout: 10_000,
+  });
+  if (result.error || result.status !== 0) return null;
+  return result.stdout.trim();
+}
+
+function sqliteJsonBestEffort(dbPath: string, sql: string): unknown[] {
+  const result = spawnSync("sqlite3", ["-json", dbPath, sql], {
+    cwd: ROOT,
+    encoding: "utf8",
+    maxBuffer: 16 * 1024 * 1024,
+    timeout: 10_000,
+  });
+  if (result.error || result.status !== 0) return [];
+  try {
+    const parsed = JSON.parse(result.stdout.trim() || "[]") as unknown;
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function gitcrawlDbPath(): string | null {
+  const configured = process.env.CLAWSWEEPER_GITCRAWL_DB?.trim();
+  if (configured) {
+    const configuredPath = resolve(ROOT, configured);
+    return existsSync(configuredPath) ? configuredPath : null;
+  }
+  const fallback = join(homedir(), ".config", "gitcrawl", "gitcrawl.db");
+  return existsSync(fallback) ? fallback : null;
+}
+
+function gitcrawlTableRows(dbPath: string, table: "clusters" | "cluster_groups"): number {
+  const countSql =
+    table === "clusters"
+      ? "select count(*) from clusters;"
+      : "select count(*) from cluster_groups;";
+  const exists =
+    sqliteScalarBestEffort(
+      dbPath,
+      `select count(*) from sqlite_master where type = 'table' and name = '${table}';`,
+    ) ?? "0";
+  if (Number(exists) <= 0) return 0;
+  return Number(sqliteScalarBestEffort(dbPath, countSql) ?? "0");
+}
+
+function detectGitcrawlClusterSource(dbPath: string): GitcrawlClusterSource | null {
+  if (gitcrawlClusterSourceCache?.dbPath === dbPath) return gitcrawlClusterSourceCache.source;
+  let source: GitcrawlClusterSource | null = null;
+  if (gitcrawlTableRows(dbPath, "clusters") > 0) {
+    source = "legacy";
+  } else if (gitcrawlTableRows(dbPath, "cluster_groups") > 0) {
+    source = "portable";
+  }
+  gitcrawlClusterSourceCache = { dbPath, source };
+  return source;
+}
+
+function gitcrawlRelatedIssueSql(
+  source: GitcrawlClusterSource,
+  itemNumber: number,
+  limit: number,
+  repo: string,
+): string {
+  const number = sqlSafeInteger(itemNumber);
+  const cappedLimit = sqlSafeInteger(Math.max(1, Math.min(limit, RELATED_ITEMS_LIMIT)));
+  const repoFullName = sqlStringLiteral(repo);
+  if (source === "portable") {
+    return `
+      select
+        cg.id as cluster_id,
+        (
+          select count(*)
+          from cluster_memberships cm_count
+          where cm_count.cluster_id = cg.id
+            and cm_count.state = 'active'
+        ) as member_count,
+        rt.number as representative_number,
+        rt.kind as representative_kind,
+        rt.state as representative_state,
+        rt.title as representative_title,
+        t.number,
+        t.kind,
+        t.state,
+        t.title,
+        t.body_excerpt as body,
+        t.labels_json,
+        t.updated_at
+      from cluster_groups cg
+      join cluster_memberships cm_self on cm_self.cluster_id = cg.id and cm_self.state = 'active'
+      join threads self on self.id = cm_self.thread_id
+      join repositories self_repo on self_repo.id = self.repo_id
+      join cluster_memberships cm on cm.cluster_id = cg.id and cm.state = 'active'
+      join threads t on t.id = cm.thread_id
+      join repositories thread_repo on thread_repo.id = t.repo_id
+      left join threads rt on rt.id = cg.representative_thread_id
+      where cg.status = 'active'
+        and cg.repo_id = self.repo_id
+        and self_repo.full_name = ${repoFullName}
+        and self.number = ${number}
+        and self.kind = 'issue'
+        and thread_repo.full_name = ${repoFullName}
+        and t.number != ${number}
+        and t.kind = 'issue'
+      order by case when t.state = 'open' then 0 else 1 end, t.updated_at desc, t.number desc
+      limit ${cappedLimit};
+    `;
+  }
+  return `
+    select
+      c.id as cluster_id,
+      c.member_count,
+      rt.number as representative_number,
+      rt.kind as representative_kind,
+      rt.state as representative_state,
+      rt.title as representative_title,
+      t.number,
+      t.kind,
+      t.state,
+      t.title,
+      t.body,
+      t.labels_json,
+      t.updated_at
+    from clusters c
+    join cluster_members cm_self on cm_self.cluster_id = c.id
+    join threads self on self.id = cm_self.thread_id
+    join repositories self_repo on self_repo.id = self.repo_id
+    join cluster_members cm on cm.cluster_id = c.id
+    join threads t on t.id = cm.thread_id
+    join repositories thread_repo on thread_repo.id = t.repo_id
+    left join threads rt on rt.id = c.representative_thread_id
+    where c.closed_at_local is null
+      and c.repo_id = self.repo_id
+      and self_repo.full_name = ${repoFullName}
+      and self.number = ${number}
+      and self.kind = 'issue'
+      and thread_repo.full_name = ${repoFullName}
+      and t.number != ${number}
+      and t.kind = 'issue'
+    order by case when t.state = 'open' then 0 else 1 end, t.updated_at desc, t.number desc
+    limit ${cappedLimit};
+  `;
+}
+
+function compactRelatedGitcrawlItems(item: Item, seen: ReadonlySet<number>): unknown[] {
+  if (item.kind !== "issue") return [];
+  const dbPath = gitcrawlDbPath();
+  if (!dbPath) return [];
+  const source = detectGitcrawlClusterSource(dbPath);
+  if (!source) return [];
+
+  return sqliteJsonBestEffort(
+    dbPath,
+    gitcrawlRelatedIssueSql(source, item.number, RELATED_GITCRAWL_LIMIT, targetRepo()),
+  )
+    .map(asRecord)
+    .filter((row) => typeof row.number === "number" && !seen.has(row.number))
+    .map((row) => ({
+      mentionedIn: ["gitcrawl cluster"],
+      gitcrawlCluster: {
+        id: row.cluster_id,
+        source,
+        memberCount: row.member_count,
+        representative: {
+          number: row.representative_number,
+          kind: row.representative_kind,
+          state: row.representative_state,
+          title: row.representative_title,
+        },
+      },
+      gitcrawlThread: {
+        number: row.number,
+        kind: row.kind,
+        state: row.state,
+        title: row.title,
+        updatedAt: row.updated_at,
+        labels: parseJsonArrayBestEffort(row.labels_json),
+        body: truncateText(typeof row.body === "string" ? row.body : "", 800),
+      },
+    }));
+}
+
+function relatedItemNumber(value: unknown): number | null {
+  const record = asRecord(value);
+  const issueNumber = asRecord(record.issue).number;
+  if (typeof issueNumber === "number") return issueNumber;
+  const localNumber = asRecord(record.localReport).number;
+  if (typeof localNumber === "number") return localNumber;
+  const gitcrawlNumber = asRecord(record.gitcrawlThread).number;
+  if (typeof gitcrawlNumber === "number") return gitcrawlNumber;
+  const directNumber = record.number;
+  return typeof directNumber === "number" ? directNumber : null;
+}
+
+function appendUniqueRelatedItems(
+  target: unknown[],
+  seen: Set<number>,
+  candidates: readonly unknown[],
+): void {
+  for (const candidate of candidates) {
+    const number = relatedItemNumber(candidate);
+    if (number !== null) {
+      if (seen.has(number)) continue;
+      seen.add(number);
+    }
+    target.push(candidate);
+    if (target.length >= RELATED_ITEMS_LIMIT) return;
+  }
+}
+
 function relatedItemsContext(options: {
   item: Item;
   issue: unknown;
@@ -2901,8 +3241,23 @@ function relatedItemsContext(options: {
     .slice(0, 10)
     .map(([number, mentionedIn]) => compactRelatedItem(number, mentionedIn))
     .filter((entry) => entry !== null);
-  const searchedRelated = compactRelatedSearchItems(options.item, new Set(mentions.keys()));
-  return [...explicitRelated, ...searchedRelated].slice(0, 12);
+  const seen = new Set<number>([options.item.number]);
+  const related: unknown[] = [];
+  appendUniqueRelatedItems(related, seen, explicitRelated);
+  if (related.length < RELATED_ITEMS_LIMIT) {
+    appendUniqueRelatedItems(related, seen, compactLocalRelatedTitleItems(options.item, seen));
+  }
+  if (related.length < RELATED_ITEMS_LIMIT) {
+    appendUniqueRelatedItems(related, seen, compactRelatedGitcrawlItems(options.item, seen));
+  }
+  if (related.length < RELATED_ITEMS_LIMIT) {
+    appendUniqueRelatedItems(
+      related,
+      seen,
+      compactRelatedGitHubIssueSearchItems(options.item, seen),
+    );
+  }
+  return related.slice(0, RELATED_ITEMS_LIMIT);
 }
 
 function normalizeAuthorLogin(value: unknown): string | null {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -72,6 +72,7 @@ import {
   protectedLabels,
   realBehaviorProofMediaLabelsForTest,
   realBehaviorProofSufficientLabelsForTest,
+  relatedGitHubIssueSearchQueryForTest,
   relatedTitleSearchTerms,
   renderReviewStartStatusComment,
   reviewArtifactDestination,
@@ -11603,6 +11604,18 @@ test("related title search terms keep issue-specific words", () => {
     ["message", "before_send", "hook", "enable", "content-quality", "fallback"],
   );
 });
+
+test("related GitHub issue search query uses issue-only title terms", () => {
+  assert.equal(
+    relatedGitHubIssueSearchQueryForTest(
+      "openclaw/openclaw",
+      "[Bug] Telegram group photo-only messages do not trigger image understanding",
+    ),
+    'repo:openclaw/openclaw is:issue in:title,body telegram group "photo-only" messages',
+  );
+  assert.equal(relatedGitHubIssueSearchQueryForTest("openclaw/openclaw", "Bug"), null);
+});
+
 test("audit detects live/local state drift and unsafe proposed records", () => {
   const result = auditFromSnapshot({
     openItems: [


### PR DESCRIPTION
﻿## Summary

This improves ClawSweeper's related issue context for issue reviews, so new issue reviews get better evidence about likely duplicates, adjacent reports, superseded work, and already-active fix paths.

Main changes:

- Keeps the existing explicit mention / linked PR context.
- Preserves local ClawSweeper report title matches, which are already used by close/apply safety behavior.
- Adds optional same-cluster issue siblings from a local gitcrawl SQLite database.
- Adds optional live GitHub issue search for exact one-item event reviews.
- Updates the review prompt and docs for the expanded related context.

## Safety / behavior

This is advisory review context only. It does not add labels, close issues, open repair PRs, merge anything, or change apply policy.

Guardrails included here:

- Related items are capped to the existing compact prompt budget.
- Explicit/local ClawSweeper report matches stay ahead of new gitcrawl/Search enrichment.
- GitHub Search is issue-only, target-repo scoped, non-retrying, short-timeout, and skipped once the related-item budget is already full.
- Gitcrawl lookups are target-repo scoped and skipped silently if the DB or sqlite3 is unavailable.
- Exact event reviews enable GitHub Search by default, with an opt-out repo variable: `CLAWSWEEPER_RELATED_GITHUB_SEARCH=0`.

## Validation

- `codex review --uncommitted` clean: no discrete correctness issues found.
- `pnpm run build:all`
- `pnpm run lint:src`
- `pnpm run check:active-surface`
- `pnpm run check:limits`
- `pnpm exec oxfmt --check src/clawsweeper.ts test/clawsweeper.test.ts README.md docs/target-dispatcher.md docs/related-issue-discovery.md .github/workflows/sweep.yml prompts/review-item.md`
- `node --test --test-name-pattern "related title search|related GitHub issue search" test/clawsweeper.test.ts`
- GitHub Search smoke test for the generated query returned results.

`pnpm run test:unit` is still affected by the same two Windows-local failures seen before this change: `/usr/bin/git` missing in the runCodex test, and a POSIX file-mode assertion in read-only checkout mode. The rest of the suite passed: 307 passed, 2 failed.


## Live GitHub Search proof

I also ran a guarded live-GitHub exact issue review so the proof is no longer relying on mocked GitHub data.

Safety shape:

- Target: real open issue `openclaw/openclaw#85807`.
- `CLAWSWEEPER_RELATED_GITHUB_SEARCH=1` was enabled.
- `GH_BIN` was pointed at a thin guard wrapper that forwards read-only commands to the real GitHub CLI and blocks only write methods (`POST`, `PUT`, `PATCH`, `DELETE`). No GitHub comments, labels, closes, or edits were made.
- The review prompt was captured before model decision output. The behavior under proof is the upstream ClawSweeper context path: live GitHub Search related items being collected and carried into the review prompt/report flow.

Command shape:

```powershell
pnpm run review -- --target-repo openclaw/openclaw --target-dir . --item-number 85807 --artifact-dir $env:TEMP\clawsweeper-pr176-proof-live\artifacts-live-clean-85807 --codex-model fake-proof --codex-timeout-ms 30000
```

Terminal result:

```text
[review] 2026-05-23T19:48:21.223Z shard=0/1 selected=1 scanned_pages=0
[review] 2026-05-23T19:48:21.225Z shard=0/1 start #85807 (1/1)
[review] 2026-05-23T19:48:25.079Z shard=0/1 start-comment=existing #85807
[review] 2026-05-23T19:48:25.338Z shard=0/1 done #85807 (1/1) decision=keep_open confidence=medium action=kept_open
[review] 2026-05-23T19:48:25.338Z shard=0/1 complete reviewed=1
```

Generated report frontmatter included:

```yaml
review_prompt_chars: 86199
review_codex_elapsed_ms: 248
review_status: complete
decision: keep_open
confidence: medium
```

The guarded GitHub CLI log shows a real GitHub Search API call, not fixture data:

```json
{"mode":"real-gh","args":["api","search/issues?q=repo%3Aopenclaw%2Fopenclaw%20is%3Aissue%20in%3Atitle%2Cbody%20telegram%20preview%20message%20deleted&per_page=5"]}
{"mode":"real-gh-result","status":0,"stdoutBytes":32223,"stderr":""}
```

The captured review prompt then contained the live Search results as related context:

```json
{
  "counts": {
    "relatedItems": 5
  },
  "relatedItems": [
    {
      "mentionedIn": ["GitHub issue search"],
      "searchQuery": "repo:openclaw/openclaw is:issue in:title,body telegram preview message deleted",
      "searchScore": 1,
      "issue": {
        "number": 37816,
        "title": "[Feature]: Telegram — full agent activity visibility (Web UI parity)",
        "state": "open"
      }
    },
    {
      "mentionedIn": ["GitHub issue search"],
      "searchQuery": "repo:openclaw/openclaw is:issue in:title,body telegram preview message deleted",
      "searchScore": 1,
      "issue": {
        "number": 82210,
        "title": "Bug: Telegram tool-progress preview is retained after message_tool final reply in group chats",
        "state": "closed"
      }
    },
    {
      "mentionedIn": ["GitHub issue search"],
      "searchQuery": "repo:openclaw/openclaw is:issue in:title,body telegram preview message deleted",
      "searchScore": 1,
      "issue": {
        "number": 53124,
        "title": "Telegram streaming: preview deleted before media message confirmed sent (group chat)",
        "state": "closed"
      }
    }
  ]
}
```

So the live-path proof shows the exact review lane using real GitHub Search and passing those related issue results into the prompt/report context, while keeping the run read-only.
