### PR TITLE
feat: close fixed-on-main issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ checkpoint, and status-only commits are intentionally omitted.
   Twitter metadata for the docs site.
 - Added target fanout so ClawSweeper can dispatch conservative scheduled review and audit batches across eligible `openclaw/*` and `steipete/*` repositories.
 - Added a PR-only low-signal close reason so ClawSweeper can automatically close net-negative branches whose useful part is tiny but whose diff is mostly unrelated or unmergeable churn.
+- Added current-main issue close policy for configured OpenClaw targets, so reviews can close issues that are proven fixed on `main` even before a release ships.
 - Added stronger ClawSweeper storm controls: exact event reviews now get job-level per-item cancellation, GitHub activity coalesces more aggressively, noncritical intake skips when GitHub core quota is low, hot target fanout is lower, and state hydration avoids partial-clone checkout auth failures by default.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -339,6 +339,8 @@ fresh GitHub snapshot, labels, maintainer-authorship, and unchanged item state
 are checked immediately before mutation. Maintainer-authored or
 `maintainer`-labeled items can still close when the only protected state is
 maintainer ownership and the close reason is verified `implemented_on_main`.
+Configured OpenClaw targets may close issues as `implemented_on_main` when the
+fix is proven on current `main`, even before the next release ships.
 
 ### Repair Lane
 

--- a/config/target-repositories.json
+++ b/config/target-repositories.json
@@ -6,9 +6,9 @@
       "display_name": "ClawHub",
       "checkout_dir": "clawhub",
       "community_url": "https://clawhub.ai/",
-      "prompt_note": "Use the ClawHub source tree and current main branch. Review every issue and PR with the same evidence standard, but only propose auto-close for pull requests that are certainly implemented on main or age-gated mostly implemented on main. Keep everything else open.",
+      "prompt_note": "Use the ClawHub source tree and current main branch. Review every issue and PR with the same evidence standard. Propose auto-close for issues and pull requests that are certainly implemented on main; for pull requests only, also allow age-gated mostly implemented on main. Keep everything else open.",
       "apply_close_rules": {
-        "issue": [],
+        "issue": ["implemented_on_main"],
         "pull_request": ["implemented_on_main", "mostly_implemented_on_main"]
       }
     },
@@ -16,9 +16,9 @@
       "target_repo": "openclaw/clawsweeper",
       "display_name": "ClawSweeper",
       "checkout_dir": "clawsweeper",
-      "prompt_note": "Use the ClawSweeper source tree and current main branch. Review bot automation, workflow, and documentation changes conservatively. Only propose auto-close for pull requests that are certainly implemented on main or age-gated mostly implemented on main; keep issues open for maintainer triage.",
+      "prompt_note": "Use the ClawSweeper source tree and current main branch. Review bot automation, workflow, and documentation changes conservatively. Propose auto-close for issues and pull requests that are certainly implemented on main; for pull requests only, also allow age-gated mostly implemented on main. Keep everything else open for maintainer triage.",
       "apply_close_rules": {
-        "issue": [],
+        "issue": ["implemented_on_main"],
         "pull_request": ["implemented_on_main", "mostly_implemented_on_main"]
       }
     },
@@ -26,9 +26,9 @@
       "target_repo": "openclaw/fs-safe",
       "display_name": "fs-safe",
       "checkout_dir": "fs-safe",
-      "prompt_note": "Use the fs-safe source tree and current main branch. Review filesystem-safety, path-handling, and package changes conservatively. Only propose auto-close for pull requests that are certainly implemented on main or age-gated mostly implemented on main; keep issues open for maintainer triage.",
+      "prompt_note": "Use the fs-safe source tree and current main branch. Review filesystem-safety, path-handling, and package changes conservatively. Propose auto-close for issues and pull requests that are certainly implemented on main; for pull requests only, also allow age-gated mostly implemented on main. Keep everything else open for maintainer triage.",
       "apply_close_rules": {
-        "issue": [],
+        "issue": ["implemented_on_main"],
         "pull_request": ["implemented_on_main", "mostly_implemented_on_main"]
       }
     }
@@ -38,9 +38,9 @@
       "owner": "openclaw",
       "deny_repositories": ["openclaw/clawsweeper-state", "openclaw/.github"],
       "allow_repo_name_pattern": "^[A-Za-z0-9_.-]+$",
-      "prompt_note": "Use the {target_repo} source tree and current default branch. This repository is using the generic OpenClaw onboarding profile, so keep review conservative: issues are review/comment-only, and pull requests may be auto-closed only when the exact change is certainly already implemented on the default branch or age-gated mostly implemented there.",
+      "prompt_note": "Use the {target_repo} source tree and current default branch. This repository is using the generic OpenClaw onboarding profile, so keep review conservative: issues and pull requests may be auto-closed only when the exact change is certainly already implemented on the default branch; pull requests may also be age-gated mostly implemented there.",
       "apply_close_rules": {
-        "issue": [],
+        "issue": ["implemented_on_main"],
         "pull_request": ["implemented_on_main", "mostly_implemented_on_main"]
       }
     },

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -24,6 +24,15 @@ The checkout must remain byte-for-byte clean. Use read-only inspection commands 
 
 Review deeply before closing. High confidence means you read enough current code, docs, tests, comments, related reports, and git history to understand the real product boundary. Do not decide from the issue title, one exact `rg` hit, or one nearby file. Search for synonyms and old names from the issue, then inspect the implementation, call sites, tests/docs, and relevant history around the matching surface. Prefer several independent checks over a single brittle match. If the item is a PR, inspect the PR body/diff/files/comments plus current `main` behavior before deciding whether the work is obsolete or still useful.
 
+Every review must answer whether the item is still necessary. For both issues
+and PRs, check whether current `main` already solves the central user problem,
+whether the fix is in the latest release or main-only, and whether a merged or
+open related PR now owns the work. When current `main` solves the issue with
+high-confidence source, history, and release/main-only evidence, prefer an
+`implemented_on_main` close even if the fix has not shipped in a release yet.
+If a meaningful requested behavior remains missing, keep the item open or link
+the canonical remaining work.
+
 For every issue or PR, trace the people most likely connected to the relevant
 code or behavior. Do a small feature-history hunt, not just latest-line blame:
 look for who introduced the feature, who spent the most time on that area, who
@@ -332,7 +341,7 @@ Close only when the evidence is strong and the repository policy allows it. Allo
 - `incoherent`: the item is too unclear or internally contradictory after reading the title/body/comments.
 - `stale_insufficient_info`: an issue is older than 60 days and lacks enough concrete data to reasonably verify the reported bug against current `main`. Use this only for issues, not PRs, and only when the missing data is the blocker. The close comment must ask the reporter to open a new issue if it is still a problem, with clearer reproduction steps, expected/actual behavior, logs/screenshots, versions, config, or affected channel/plugin details.
 
-For `openclaw/clawhub`, review every issue and PR with the same depth, but only close PRs where current `main` definitely implements the PR’s intended change or an older PR is mostly implemented on `main` under the `mostly_implemented_on_main` rules. For ClawHub, use `implemented_on_main` or `mostly_implemented_on_main` only for those PRs, and keep all issues plus all other PR outcomes open.
+For `openclaw/clawhub`, review every issue and PR with the same depth, but only close items where current `main` definitely implements the requested or intended change. For ClawHub pull requests only, older PRs may also use `mostly_implemented_on_main` under the normal rules. Keep all other ClawHub outcomes open.
 
 Do a canonical-search pass before keeping an older item open only because a
 small part might remain. Start with the provided `relatedItems`, then search

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -524,8 +524,8 @@ function allowedForTarget(
 ): boolean {
   if (targetRepo === "openclaw/clawhub")
     return (
-      type === "pull_request" &&
-      (reason === "implemented_on_main" || reason === "mostly_implemented_on_main")
+      reason === "implemented_on_main" ||
+      (type === "pull_request" && reason === "mostly_implemented_on_main")
     );
   if (type === "pull_request" && reason === "stale_insufficient_info") return false;
   if (type !== "pull_request" && reason === "mostly_implemented_on_main") return false;

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -1148,7 +1148,7 @@ test("skill-only OpenClaw PRs can close through ClawHub with upload guidance", (
   assert.match(action.closeComment, /installable community skill/);
 });
 
-test("ClawHub policy only allows main-implemented PR close proposals", () => {
+test("ClawHub policy allows main-implemented issue and PR close proposals", () => {
   const implementedPr = validateCloseDecision(
     item({
       repo: "openclaw/clawhub",
@@ -1167,8 +1167,7 @@ test("ClawHub policy only allows main-implemented PR close proposals", () => {
     }),
     closeDecision(),
   );
-  assert.equal(implementedIssue.ok, false);
-  assert.equal(implementedIssue.actionTaken, "skipped_invalid_decision");
+  assert.equal(implementedIssue.ok, true);
 
   const nonImplementedPr = validateCloseDecision(
     item({
@@ -1182,7 +1181,7 @@ test("ClawHub policy only allows main-implemented PR close proposals", () => {
   assert.equal(nonImplementedPr.actionTaken, "skipped_invalid_decision");
 });
 
-test("ClawSweeper policy allows self PR review without issue auto-close", () => {
+test("ClawSweeper policy allows self implemented-on-main issue and PR close proposals", () => {
   const implementedPr = validateCloseDecision(
     item({
       repo: "openclaw/clawsweeper",
@@ -1201,8 +1200,7 @@ test("ClawSweeper policy allows self PR review without issue auto-close", () => 
     }),
     closeDecision(),
   );
-  assert.equal(implementedIssue.ok, false);
-  assert.equal(implementedIssue.actionTaken, "skipped_invalid_decision");
+  assert.equal(implementedIssue.ok, true);
 });
 
 test("review policy changes force fresh complete reports back into planning", () => {

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -292,6 +292,53 @@ test("workflow utilities select eligible proposed close records", () => {
   assert.deepEqual(selected, [5, 12, 15]);
 });
 
+test("workflow utilities allow ClawHub implemented-on-main issue proposals", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  write(
+    path.join(root, "records/openclaw-clawhub/items/openclaw-clawhub-7.md"),
+    [
+      "---",
+      "repository: openclaw/clawhub",
+      "type: issue",
+      "decision: close",
+      "confidence: high",
+      "action_taken: proposed_close",
+      "close_reason: implemented_on_main",
+      "item_created_at: 2024-01-01T00:00:00Z",
+      "---",
+      "",
+    ].join("\n"),
+  );
+  write(
+    path.join(root, "records/openclaw-clawhub/items/openclaw-clawhub-8.md"),
+    [
+      "---",
+      "repository: openclaw/clawhub",
+      "type: issue",
+      "decision: close",
+      "confidence: high",
+      "action_taken: proposed_close",
+      "close_reason: duplicate_or_superseded",
+      "item_created_at: 2024-01-01T00:00:00Z",
+      "---",
+      "",
+    ].join("\n"),
+  );
+
+  const selected = withCwd(root, () =>
+    proposedItemNumbers({
+      targetRepo: "openclaw/clawhub",
+      applyKind: "all",
+      applyCloseReasons: "all",
+      staleMinAgeDays: 60,
+      minAgeDays: 0,
+      minAgeMinutes: null,
+    }),
+  );
+
+  assert.deepEqual(selected, [7]);
+});
+
 test("workflow utilities select cursor-based PR comment sync batches", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
   const cursorPath = path.join(root, "results/comment-sync-cursors/openclaw-openclaw.json");

--- a/test/repository-profiles.test.ts
+++ b/test/repository-profiles.test.ts
@@ -8,6 +8,11 @@ test("repositoryProfileFor matches mixed-case input against canonical profiles",
 
   assert.equal(profile.targetRepo, "openclaw/clawhub");
   assert.equal(profile.slug, "openclaw-clawhub");
+  assert.deepEqual(profile.applyCloseRules.issue, ["implemented_on_main"]);
+  assert.deepEqual(profile.applyCloseRules.pull_request, [
+    "implemented_on_main",
+    "mostly_implemented_on_main",
+  ]);
 });
 
 test("repositoryProfileFor supports fs-safe event reviews", () => {
@@ -16,7 +21,7 @@ test("repositoryProfileFor supports fs-safe event reviews", () => {
   assert.equal(profile.targetRepo, "openclaw/fs-safe");
   assert.equal(profile.slug, "openclaw-fs-safe");
   assert.equal(profile.checkoutDir, "fs-safe");
-  assert.deepEqual(profile.applyCloseRules.issue, []);
+  assert.deepEqual(profile.applyCloseRules.issue, ["implemented_on_main"]);
   assert.deepEqual(profile.applyCloseRules.pull_request, [
     "implemented_on_main",
     "mostly_implemented_on_main",
@@ -32,7 +37,7 @@ test("generic OpenClaw fallback supports conservative event-only onboarding", ()
   assert.equal(profile.checkoutDir, "example-tool");
   assert.match(profile.promptNote, /generic OpenClaw onboarding profile/);
   assert.match(profile.promptNote, /current default branch/);
-  assert.deepEqual(profile.applyCloseRules.issue, []);
+  assert.deepEqual(profile.applyCloseRules.issue, ["implemented_on_main"]);
   assert.deepEqual(profile.applyCloseRules.pull_request, [
     "implemented_on_main",
     "mostly_implemented_on_main",


### PR DESCRIPTION
## Summary

- make normal issue/PR review explicitly check whether the item is still needed or already fixed on current main
- allow configured OpenClaw targets to close issues as implemented_on_main when the fix is proven on main, even before release
- keep mostly_implemented_on_main PR-only and preserve existing apply evidence gates

Closes https://github.com/openclaw/clawsweeper/issues/179

## Validation

- autoreview --mode local
- autoreview --mode branch --base origin/main
- pnpm run check
