### PR TITLE
fix: Filter noisy PR ingestion comments

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -426,6 +426,7 @@ interface ItemContext {
   issue: unknown;
   comments: unknown[];
   timeline: unknown[];
+  previousClawSweeperReview?: unknown;
   closingPullRequests?: unknown[];
   relatedItems?: unknown[];
   pullRequest?: unknown;
@@ -436,6 +437,8 @@ interface ItemContext {
     comments: number;
     commentsHydrated?: number;
     commentsTruncated?: boolean;
+    commentsIncluded?: number;
+    commentsFiltered?: number;
     timeline: number;
     timelineHydrated?: number;
     timelineTruncated?: boolean;
@@ -450,6 +453,8 @@ interface ItemContext {
     pullReviewComments?: number;
     pullReviewCommentsHydrated?: number;
     pullReviewCommentsTruncated?: boolean;
+    pullReviewCommentsIncluded?: number;
+    pullReviewCommentsFiltered?: number;
   };
 }
 
@@ -2568,11 +2573,237 @@ function compactComment(value: unknown): unknown {
   return {
     id: comment.id,
     author: login(comment.user),
+    authorAssociation: normalizeAuthorAssociation(comment.author_association),
     url: comment.html_url,
     createdAt: comment.created_at,
     updatedAt: comment.updated_at,
     body: truncateText(comment.body, 6000),
   };
+}
+
+const CLAWSWEEPER_BOT_AUTHORS = new Set(
+  [
+    "clawsweeper",
+    "clawsweeper[bot]",
+    "openclaw-clawsweeper[bot]",
+    process.env.CLAWSWEEPER_COMMENT_AUTHOR_LOGIN,
+  ].filter((login): login is string => typeof login === "string" && login.length > 0),
+);
+const CLAWSWEEPER_COMMAND_ONLY_PATTERN = /^@clawsweeper\s+(?:re-review|re-run|review)\s*$/i;
+
+interface PreviousClawSweeperReview {
+  status: string;
+  reviewedAt: string | null;
+  reviewedSha: string | null;
+  verdictMarker: string | null;
+  actionMarker: string | null;
+  summary: string;
+  proofStatus: string;
+  rating: string;
+  nextStep: string;
+  findings: Array<{ priority: string; title: string }>;
+  commentId: unknown;
+  commentUrl: unknown;
+  commentUpdatedAt: unknown;
+}
+
+function rawCommentBody(value: unknown): string {
+  const body = asRecord(value).body;
+  return typeof body === "string" ? body : "";
+}
+
+function timestampValueMs(value: unknown): number {
+  return typeof value === "string" ? Date.parse(value) || 0 : 0;
+}
+
+function commentTimestampMs(value: unknown): number {
+  const comment = asRecord(value);
+  return timestampValueMs(comment.updated_at) || timestampValueMs(comment.created_at);
+}
+
+function isClawSweeperComment(value: unknown): boolean {
+  return CLAWSWEEPER_BOT_AUTHORS.has((login(asRecord(value).user) ?? "").toLowerCase());
+}
+
+function isClawSweeperDurableReviewComment(value: unknown, number: number): boolean {
+  return (
+    isClawSweeperComment(value) &&
+    rawCommentBody(value).includes(`${REVIEW_COMMENT_MARKER_PREFIX} item=${number} -->`)
+  );
+}
+
+function isClawSweeperNoiseComment(value: unknown, number: number): boolean {
+  const body = rawCommentBody(value);
+  if (!body.trim() || !isClawSweeperComment(value)) return false;
+  if (isClawSweeperDurableReviewComment(value, number)) return true;
+  if (/clawsweeper-pr-egg-hatch:/i.test(body)) return true;
+  if (/clawsweeper-command(?:-status|-ack)?:/i.test(body)) return true;
+  if (/clawsweeper-review-status:/i.test(body)) return true;
+  if (/^ClawSweeper status: review started\./i.test(body)) return true;
+  return false;
+}
+
+function isClawSweeperCommandOnlyComment(value: unknown): boolean {
+  return CLAWSWEEPER_COMMAND_ONLY_PATTERN.test(rawCommentBody(value).trim());
+}
+
+function shouldIncludeReviewContextComment(value: unknown, number: number): boolean {
+  if (isClawSweeperNoiseComment(value, number)) return false;
+  if (isClawSweeperCommandOnlyComment(value)) return false;
+  return true;
+}
+
+function filterReviewContextComments(
+  comments: readonly unknown[],
+  number: number,
+): { included: unknown[]; filtered: number } {
+  const included = comments.filter((comment) => shouldIncludeReviewContextComment(comment, number));
+  return { included, filtered: comments.length - included.length };
+}
+
+function minNonNegative(values: number[]): number {
+  const candidates = values.filter((value) => value >= 0);
+  return candidates.length ? Math.min(...candidates) : -1;
+}
+
+function markdownSection(body: string, heading: string): string {
+  const marker = `**${heading.toLowerCase()}**`;
+  const lowerBody = body.toLowerCase();
+  const markerIndex = lowerBody.indexOf(marker);
+  if (markerIndex < 0) return "";
+  const sectionStart = body.indexOf("\n", markerIndex + marker.length);
+  if (sectionStart < 0) return "";
+  const contentStart = sectionStart + 1;
+  const relative = body.slice(contentStart);
+  const end = minNonNegative([
+    relative.indexOf("\n**"),
+    relative.indexOf("\n<details"),
+    relative.indexOf("\n<!--"),
+  ]);
+  return (end < 0 ? relative : relative.slice(0, end)).trim();
+}
+
+function firstLineAfterPrefix(body: string, prefix: string): string {
+  const lowerBody = body.toLowerCase();
+  const lowerPrefix = prefix.toLowerCase();
+  const index = lowerBody.indexOf(lowerPrefix);
+  if (index < 0) return "";
+  const start = index + prefix.length;
+  const end = body.indexOf("\n", start);
+  return body.slice(start, end < 0 ? undefined : end).trim();
+}
+
+function htmlMarkerWithPrefix(body: string, prefix: string): string | null {
+  const lowerPrefix = prefix.toLowerCase();
+  let searchFrom = 0;
+  while (searchFrom < body.length) {
+    const start = body.indexOf("<!--", searchFrom);
+    if (start < 0) return null;
+    const end = body.indexOf("-->", start + 4);
+    if (end < 0) return null;
+    const marker = body.slice(start, end + 3);
+    const inner = body
+      .slice(start + 4, end)
+      .trim()
+      .toLowerCase();
+    if (inner.startsWith(lowerPrefix)) return marker;
+    searchFrom = end + 3;
+  }
+  return null;
+}
+
+function markerAttribute(marker: string | null, name: string): string | null {
+  if (!marker) return null;
+  const inner = marker.slice(4, -3).trim();
+  for (const part of inner.split(/\s+/)) {
+    const separator = part.indexOf("=");
+    if (separator <= 0) continue;
+    if (part.slice(0, separator).toLowerCase() === name.toLowerCase()) {
+      return part.slice(separator + 1) || null;
+    }
+  }
+  return null;
+}
+
+function firstNonEmptyLine(value: string): string {
+  return (
+    value
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean) ?? ""
+  );
+}
+
+function previousReviewStatus(body: string): string {
+  return firstLineAfterPrefix(body, "Codex review:");
+}
+
+function previousReviewReviewedAt(body: string): string | null {
+  const value = firstLineAfterPrefix(body, "**Latest ClawSweeper review:**");
+  return value ? value.replace(/\.$/, "").trim() : null;
+}
+
+function previousReviewFindings(body: string): Array<{ priority: string; title: string }> {
+  return body
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .flatMap((line) => {
+      if (!line.startsWith("- [P")) return [];
+      const close = line.indexOf("]");
+      if (close < 5) return [];
+      const priority = line.slice(3, close);
+      if (!/^P[0-3]$/.test(priority)) return [];
+      const rest = line.slice(close + 1).trim();
+      const dash = minNonNegative([rest.indexOf(" - "), rest.indexOf(" — ")]);
+      const title = (dash < 0 ? rest : rest.slice(0, dash)).trim();
+      return title ? [{ priority, title }] : [];
+    });
+}
+
+function extractLatestClawSweeperReview(
+  comments: readonly unknown[],
+  number: number,
+): PreviousClawSweeperReview | null {
+  const latest = comments
+    .filter((comment) => isClawSweeperDurableReviewComment(comment, number))
+    .sort((left, right) => commentTimestampMs(right) - commentTimestampMs(left))[0];
+  if (!latest) return null;
+  const comment = asRecord(latest);
+  const body = rawCommentBody(latest);
+  const verdictMarker = htmlMarkerWithPrefix(body, "clawsweeper-verdict:");
+  const actionMarker = htmlMarkerWithPrefix(body, "clawsweeper-action:");
+  const reviewedSha = markerAttribute(verdictMarker, "sha") ?? markerAttribute(actionMarker, "sha");
+  return {
+    status: previousReviewStatus(body),
+    reviewedAt: previousReviewReviewedAt(body),
+    reviewedSha,
+    verdictMarker,
+    actionMarker,
+    summary: firstNonEmptyLine(markdownSection(body, "Summary")),
+    proofStatus: firstNonEmptyLine(markdownSection(body, "Real behavior proof")),
+    rating: firstNonEmptyLine(markdownSection(body, "PR rating")),
+    nextStep:
+      firstNonEmptyLine(markdownSection(body, "Next step before merge")) ||
+      firstNonEmptyLine(markdownSection(body, "Next step")),
+    findings: previousReviewFindings(body),
+    commentId: comment.id,
+    commentUrl: comment.html_url,
+    commentUpdatedAt: comment.updated_at,
+  };
+}
+
+export function filterReviewContextCommentsForTest(
+  comments: readonly unknown[],
+  number: number,
+): { included: unknown[]; filtered: number } {
+  return filterReviewContextComments(comments, number);
+}
+
+export function extractLatestClawSweeperReviewForTest(
+  comments: readonly unknown[],
+  number: number,
+): PreviousClawSweeperReview | null {
+  return extractLatestClawSweeperReview(comments, number);
 }
 
 function compactTimelineEvent(value: unknown): unknown {
@@ -4860,6 +5091,8 @@ function collectItemContext(
     24,
   );
   const comments = commentsWindow.items;
+  const filteredComments = filterReviewContextComments(comments, item.number);
+  const previousClawSweeperReview = extractLatestClawSweeperReview(comments, item.number);
   const timelineWindow = ghPagedLinkHeaderContextWindow<unknown>(
     `repos/${targetRepo()}/issues/${item.number}/timeline`,
     80,
@@ -4867,19 +5100,28 @@ function collectItemContext(
   const timeline = timelineWindow.items;
   const context: ItemContext = {
     issue: compactIssue(issue),
-    comments: compactMappedWindow(comments, commentsWindow.total, 24, compactComment),
+    comments: compactMappedWindow(
+      filteredComments.included,
+      filteredComments.included.length,
+      24,
+      compactComment,
+    ),
     timeline: compactMappedWindow(timeline, timelineWindow.total, 80, compactTimelineEvent),
     counts: {
       comments: commentsWindow.total,
       commentsHydrated: commentsWindow.hydrated,
       commentsTruncated: commentsWindow.truncated,
+      commentsIncluded: filteredComments.included.length,
+      commentsFiltered: filteredComments.filtered,
       timeline: timelineWindow.total,
       timelineHydrated: timelineWindow.hydrated,
       timelineTruncated: timelineWindow.truncated,
     },
   };
+  if (previousClawSweeperReview) context.previousClawSweeperReview = previousClawSweeperReview;
   let pullRequest: unknown = null;
   let pullReviewComments: unknown[] | null = null;
+  let filteredPullReviewComments: { included: unknown[]; filtered: number } | null = null;
   if (item.kind === "issue") {
     const closingPullRequests = closingPullRequestsForIssue(item.number);
     if (closingPullRequests.length > 0) {
@@ -4889,6 +5131,8 @@ function collectItemContext(
         comments: commentsWindow.total,
         commentsHydrated: commentsWindow.hydrated,
         commentsTruncated: commentsWindow.truncated,
+        commentsIncluded: filteredComments.included.length,
+        commentsFiltered: filteredComments.filtered,
         timeline: timelineWindow.total,
         timelineHydrated: timelineWindow.hydrated,
         timelineTruncated: timelineWindow.truncated,
@@ -4917,6 +5161,7 @@ function collectItemContext(
       40,
     );
     pullReviewComments = pullReviewCommentsWindow.items;
+    filteredPullReviewComments = filterReviewContextComments(pullReviewComments, item.number);
     context.pullRequest = compactPullRequest(pullRequest);
     context.pullFiles = compactMappedWindow(pullFiles, pullFilesWindow.total, 80, compactPullFile);
     context.pullCommits = compactMappedWindow(
@@ -4926,8 +5171,8 @@ function collectItemContext(
       compactPullCommit,
     );
     context.pullReviewComments = compactMappedWindow(
-      pullReviewComments,
-      pullReviewCommentsWindow.total,
+      filteredPullReviewComments.included,
+      filteredPullReviewComments.included.length,
       40,
       compactComment,
     );
@@ -4936,6 +5181,8 @@ function collectItemContext(
       comments: commentsWindow.total,
       commentsHydrated: commentsWindow.hydrated,
       commentsTruncated: commentsWindow.truncated,
+      commentsIncluded: filteredComments.included.length,
+      commentsFiltered: filteredComments.filtered,
       timeline: timelineWindow.total,
       timelineHydrated: timelineWindow.hydrated,
       timelineTruncated: timelineWindow.truncated,
@@ -4948,6 +5195,8 @@ function collectItemContext(
       pullReviewComments: pullReviewCommentsWindow.total,
       pullReviewCommentsHydrated: pullReviewCommentsWindow.hydrated,
       pullReviewCommentsTruncated: pullReviewCommentsWindow.truncated,
+      pullReviewCommentsIncluded: filteredPullReviewComments.included.length,
+      pullReviewCommentsFiltered: filteredPullReviewComments.filtered,
     };
   }
   const relationTimeline =
@@ -4957,11 +5206,12 @@ function collectItemContext(
   const relatedOptions: Parameters<typeof relatedItemsContext>[0] = {
     item,
     issue,
-    comments,
+    comments: filteredComments.included,
     timeline: relationTimeline,
   };
   if (pullRequest) relatedOptions.pullRequest = pullRequest;
-  if (pullReviewComments) relatedOptions.pullReviewComments = pullReviewComments;
+  if (filteredPullReviewComments)
+    relatedOptions.pullReviewComments = filteredPullReviewComments.included;
   const relatedItems = relatedItemsContext(relatedOptions);
   if (relatedItems.length) {
     context.relatedItems = relatedItems;
@@ -4969,6 +5219,8 @@ function collectItemContext(
       comments: context.counts?.comments ?? commentsWindow.total,
       commentsHydrated: context.counts?.commentsHydrated ?? commentsWindow.hydrated,
       commentsTruncated: context.counts?.commentsTruncated ?? commentsWindow.truncated,
+      commentsIncluded: filteredComments.included.length,
+      commentsFiltered: filteredComments.filtered,
       timeline: context.counts?.timeline ?? timeline.length,
       relatedItems: relatedItems.length,
     };
@@ -4992,6 +5244,10 @@ function collectItemContext(
       counts.pullReviewCommentsHydrated = context.counts.pullReviewCommentsHydrated;
     if (context.counts?.pullReviewCommentsTruncated !== undefined)
       counts.pullReviewCommentsTruncated = context.counts.pullReviewCommentsTruncated;
+    if (context.counts?.pullReviewCommentsIncluded !== undefined)
+      counts.pullReviewCommentsIncluded = context.counts.pullReviewCommentsIncluded;
+    if (context.counts?.pullReviewCommentsFiltered !== undefined)
+      counts.pullReviewCommentsFiltered = context.counts.pullReviewCommentsFiltered;
     if (context.counts?.closingPullRequests !== undefined)
       counts.closingPullRequests = context.counts.closingPullRequests;
     context.counts = counts;
@@ -10206,6 +10462,12 @@ function reviewContextLedger(context: ItemContext): ReviewContextLedgerEntry[] {
       total: counts?.timeline,
       hydrated: counts?.timelineHydrated,
       truncated: counts?.timelineTruncated,
+    }),
+    reviewContextLedgerEntry({
+      section: "previousClawSweeperReview",
+      label: "previous ClawSweeper review",
+      value: context.previousClawSweeperReview ?? null,
+      entries: context.previousClawSweeperReview === undefined ? 0 : 1,
     }),
     reviewContextLedgerEntry({
       section: "closingPullRequests",

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -30,6 +30,8 @@ import {
   compactMappedWindow,
   codexEnv,
   dashboardClosedAt,
+  extractLatestClawSweeperReviewForTest,
+  filterReviewContextCommentsForTest,
   fixedPullRequestFromCommitPullsForTest,
   featureShowcaseLabelsForTest,
   formatRecentClosedRows,
@@ -367,6 +369,124 @@ test("compactMappedWindow keeps bounded hydrated context when total is larger th
   assert.deepEqual(mapped, [1, 2, 99, 100]);
 });
 
+function issueComment(
+  id: number,
+  body: string,
+  login = "contributor",
+  updatedAt = "2026-05-24T00:00:00Z",
+) {
+  return {
+    id,
+    body,
+    html_url: `https://github.com/openclaw/openclaw/pull/123#issuecomment-${id}`,
+    updated_at: updatedAt,
+    created_at: updatedAt,
+    user: { login },
+    author_association: "CONTRIBUTOR",
+  };
+}
+
+test("review context comment filter removes ClawSweeper self-noise and command-only comments", () => {
+  const comments = [
+    issueComment(
+      1,
+      "Codex review: needs maintainer review.\n\n<!-- clawsweeper-review item=123 -->",
+      "clawsweeper[bot]",
+    ),
+    issueComment(
+      2,
+      "ClawSweeper PR egg\n\n<!-- clawsweeper-pr-egg-hatch:123 -->",
+      "openclaw-clawsweeper[bot]",
+    ),
+    issueComment(
+      3,
+      "<!-- clawsweeper-command-status:123:re_review:abc -->\nQueued.",
+      "clawsweeper",
+    ),
+    issueComment(4, "@clawsweeper re-review", "author"),
+    issueComment(5, "Here is real behavior proof from my terminal.", "author"),
+    issueComment(6, "Actionable file/line review feedback.", "chatgpt-codex-connector[bot]"),
+  ];
+
+  const result = filterReviewContextCommentsForTest(comments, 123);
+
+  assert.equal(result.filtered, 4);
+  assert.deepEqual(
+    result.included.map((comment) => (comment as { id: number }).id),
+    [5, 6],
+  );
+});
+
+test("review context comment filter keeps contributor text that only quotes markers", () => {
+  const comments = [
+    issueComment(
+      1,
+      "I pasted a prior marker while debugging: <!-- clawsweeper-review item=123 -->",
+      "contributor",
+    ),
+  ];
+
+  const result = filterReviewContextCommentsForTest(comments, 123);
+
+  assert.equal(result.filtered, 0);
+  assert.equal(result.included.length, 1);
+  assert.equal(extractLatestClawSweeperReviewForTest(comments, 123), null);
+});
+
+test("latest ClawSweeper durable review is extracted as compact previous review state", () => {
+  const older = issueComment(
+    1,
+    `Codex review: needs real behavior proof before merge.
+
+**Latest ClawSweeper review:** 2026-05-24 01:00 UTC.
+
+**Summary**
+Old summary.
+
+<!-- clawsweeper-verdict:needs-human item=123 sha=oldsha confidence=high -->
+
+<!-- clawsweeper-review item=123 -->`,
+    "clawsweeper[bot]",
+    "2026-05-24T01:00:00Z",
+  );
+  const latest = issueComment(
+    2,
+    `Codex review: found issues before merge.
+
+**Latest ClawSweeper review:** 2026-05-24 02:00 UTC.
+
+**Summary**
+The PR changes routing behavior.
+
+**PR rating**
+Overall: unranked.
+
+**Real behavior proof**
+Needs real behavior proof before merge.
+
+**Review findings**
+- [P1] Preserve session state - src/file.ts:10
+
+<!-- clawsweeper-verdict:needs-human item=123 sha=newsha confidence=high -->
+<!-- clawsweeper-action:fix-required item=123 sha=newsha confidence=high finding=review-feedback -->
+
+<!-- clawsweeper-review item=123 -->`,
+    "clawsweeper[bot]",
+    "2026-05-24T02:00:00Z",
+  );
+
+  const review = extractLatestClawSweeperReviewForTest([older, latest], 123);
+
+  assert.ok(review);
+  assert.equal(review.status, "found issues before merge.");
+  assert.equal(review.reviewedSha, "newsha");
+  assert.equal(review.summary, "The PR changes routing behavior.");
+  assert.equal(review.proofStatus, "Needs real behavior proof before merge.");
+  assert.equal(review.findings[0]?.priority, "P1");
+  assert.equal(review.findings[0]?.title, "Preserve session state");
+  assert.doesNotMatch(JSON.stringify(review), /How this review workflow works/);
+});
+
 test("githubContextWindowPlan includes prior page when the tail crosses a page boundary", () => {
   assert.deepEqual(githubContextWindowPlan(101, 80), {
     keepStart: 40,
@@ -662,11 +782,38 @@ test("review prompt telemetry records durable cost proxies", () => {
   assert.equal(telemetry.additionalPromptChars, "keep extra instructions visible".length);
 });
 
+test("review prompt includes compact previous review state without raw durable review body", () => {
+  const context = {
+    issue: { number: 123, title: "Sample PR" },
+    comments: [{ author: "contributor", body: "After-fix proof is attached." }],
+    timeline: [],
+    previousClawSweeperReview: {
+      status: "found issues before merge.",
+      reviewedSha: "abc123",
+      summary: "Prior review found one blocker.",
+    },
+    counts: { comments: 3, commentsIncluded: 1, commentsFiltered: 2, timeline: 0 },
+  };
+
+  const prompt = reviewPromptForTest(item({ kind: "pull_request", number: 123 }), context, git);
+
+  assert.match(prompt, /"previousClawSweeperReview"/);
+  assert.match(prompt, /Prior review found one blocker/);
+  assert.match(prompt, /"commentsFiltered": 2/);
+  assert.doesNotMatch(prompt, /How this review workflow works/);
+  assert.doesNotMatch(prompt, /clawsweeper-pr-egg-hatch/);
+});
+
 test("review context ledger records ordered section budgets", () => {
   const context = {
     issue: { number: 123, title: "Sample PR" },
     comments: [{ author: "alice", body: "Please review this." }],
     timeline: [{ event: "committed", sha: "abc123" }],
+    previousClawSweeperReview: {
+      status: "found issues before merge.",
+      reviewedSha: "abc123",
+      summary: "Prior review found one blocker.",
+    },
     relatedItems: [{ number: 122, title: "Related issue" }],
     pullRequest: { number: 123, additions: 12 },
     pullFiles: [
@@ -709,6 +856,7 @@ test("review context ledger records ordered section budgets", () => {
       ["issue", 1, undefined, undefined, undefined],
       ["comments", 1, 10, 1, true],
       ["timeline", 1, 1, 1, false],
+      ["previousClawSweeperReview", 1, undefined, undefined, undefined],
       ["relatedItems", 1, 1, undefined, undefined],
       ["pullRequest", 1, undefined, undefined, undefined],
       ["pullFiles", 2, 120, 2, true],
@@ -725,6 +873,7 @@ test("review context ledger records ordered section budgets", () => {
     /- PR files: 2\/120 hydrated, truncated, \d+ chars/,
   );
   assert.match(renderReviewContextBudgetForTest(context), /- timeline events: 1\/1 hydrated/);
+  assert.match(renderReviewContextBudgetForTest(context), /- previous ClawSweeper review: 1 entry/);
 });
 
 test("protected labels are normalized and only maintainer-only items stay plannable", () => {


### PR DESCRIPTION
## Summary
- filter ClawSweeper self-noise and exact command-only comments out of review context
- extract the latest ClawSweeper durable review as compact previous-review state
- pass filtered comments into related-item discovery and expose filtered counts in context telemetry

## Validation
- node_modules/.bin/tsgo -p tsconfig.json
- node_modules/.bin/oxlint src --ignore-pattern "src/repair/**" --tsconfig tsconfig.json --type-aware --deny-warnings --report-unused-disable-directives -D correctness
- node_modules/.bin/oxfmt --check src/clawsweeper.ts test/clawsweeper.test.ts
- node --test test/clawsweeper.test.ts

## Live ingestion proof
Ran a local ClawSweeper review-context ingestion against this PR with Codex intentionally time-limited after prompt generation. The generated review prompt showed the filter operating on live GitHub comment shapes:

```json
{
  "comments": 2,
  "commentsHydrated": 2,
  "commentsIncluded": 0,
  "commentsFiltered": 2,
  "pullReviewComments": 4,
  "pullReviewCommentsHydrated": 4,
  "pullReviewCommentsIncluded": 4,
  "pullReviewCommentsFiltered": 0,
  "previousClawSweeperReview": {
    "status": "needs real behavior proof before merge.",
    "reviewedSha": "527a2c193e5d3a61b1818a85d825e9f745e0b58e",
    "summary": "The branch filters ClawSweeper self-noise and exact review-command comments from collected issue/PR context, extracts compact previous-review state, adds filtered-count telemetry, and covers the behavior in unit tests."
  }
}
```

This confirms the two ClawSweeper-owned issue comments on the PR were excluded from normal comment context, the four inline PR review comments remained available, and the latest durable ClawSweeper review was preserved as compact structured state instead of raw rendered comment text.