### PR TITLE
fix: disable scheduled repair routing

### DIFF
--- a/.github/workflows/repair-comment-router.yml
+++ b/.github/workflows/repair-comment-router.yml
@@ -55,8 +55,6 @@ on:
         required: true
         default: blacksmith-16vcpu-ubuntu-2404
         type: string
-  schedule:
-    - cron: "*/5 * * * *"
 
 permissions:
   contents: write
@@ -206,8 +204,7 @@ jobs:
             args+=(--force-reprocess)
           fi
           if { [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.execute }}" = "true" ]; } ||
-             { [ "${{ github.event_name }}" = "repository_dispatch" ]; } ||
-             { [ "${{ github.event_name }}" = "schedule" ] && [ "${{ vars.CLAWSWEEPER_COMMENT_ROUTER_EXECUTE || '0' }}" = "1" ]; }; then
+             { [ "${{ github.event_name }}" = "repository_dispatch" ]; }; then
             args+=(--execute)
           fi
           pnpm run repair:comment-router -- "${args[@]}"

--- a/.github/workflows/repair-self-heal.yml
+++ b/.github/workflows/repair-self-heal.yml
@@ -28,8 +28,6 @@ on:
         required: true
         default: blacksmith-16vcpu-ubuntu-2404
         type: string
-  schedule:
-    - cron: "17,47 * * * *"
 
 permissions:
   contents: write
@@ -90,8 +88,7 @@ jobs:
           max_age_hours="${{ github.event_name == 'workflow_dispatch' && inputs.max_age_hours || vars.CLAWSWEEPER_SELF_HEAL_MAX_AGE_HOURS || '6' }}"
           runner="${{ github.event_name == 'workflow_dispatch' && inputs.runner || vars.CLAWSWEEPER_WORKER_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}"
           execution_runner="${{ github.event_name == 'workflow_dispatch' && inputs.execution_runner || vars.CLAWSWEEPER_EXECUTION_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}"
-          if { [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.execute }}" = "true" ]; } ||
-             { [ "${{ github.event_name }}" = "schedule" ] && [ "${{ vars.CLAWSWEEPER_SELF_HEAL_EXECUTE || '0' }}" = "1" ]; }; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.execute }}" = "true" ]; then
             execute="true"
           fi
 
@@ -102,7 +99,7 @@ jobs:
           pnpm run repair:self-heal -- "${args[@]}"
 
       - name: Commit self-heal ledger
-        if: ${{ always() && ((github.event_name == 'workflow_dispatch' && inputs.execute) || (github.event_name == 'schedule' && vars.CLAWSWEEPER_SELF_HEAL_EXECUTE == '1')) }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && inputs.execute }}
         run: |
           if [ ! -f results/self-heal.json ]; then
             echo "No self-heal ledger"

--- a/README.md
+++ b/README.md
@@ -220,9 +220,9 @@ collaborator permission (`admin`, `maintain`, or `write`) and falls back to
 trusted `author_association` values when permission lookup is unavailable.
 Users with repository write access and issue/PR authors may ask
 `@clawsweeper re-review` or `@clawsweeper re-run` for a fresh read-only review.
-Other contributor commands are ignored without a reply. Scheduled comment routing is dry unless
-`CLAWSWEEPER_COMMENT_ROUTER_EXECUTE=1`; workflow dispatch with `execute=true`
-can be used for one-off live routing.
+Other contributor commands are ignored without a reply. Comment routing no
+longer has a scheduled repair sweep; exact `clawsweeper_comment` dispatches and
+workflow dispatch with `execute=true` are the live routing paths.
 For fast intake, the ClawSweeper GitHub App webhook can post the same queued
 status comment and dispatch exact `clawsweeper_comment` or `clawsweeper_item`
 runs from eligible public `openclaw/*` and `steipete/*` repositories. The

--- a/docs/repair/README.md
+++ b/docs/repair/README.md
@@ -202,15 +202,13 @@ It also removes repair-loop labels, so older automerge/autofix commands and
 trusted pass markers cannot continue the loop after the stop.
 
 The router writes an idempotency marker into each reply and records processed
-comments in `results/comment-router.json`. The scheduled workflow is dry by
-default; set `CLAWSWEEPER_COMMENT_ROUTER_EXECUTE=1` to let scheduled runs post
-replies and dispatch workers.
+comments in `results/comment-router.json`. Repair routing is no longer
+scheduled: exact `clawsweeper_comment` dispatches execute for the source
+comment, and workflow dispatch can be used for one-off dry or live routing.
 
-Scheduled runs also sweep open PRs with `clawsweeper:autofix` or
-`clawsweeper:automerge` labels. When a labelled PR is stale, failing checks, or
-dirty/behind its base branch, the router can synthesize an internal trusted
-repair-loop command and re-enter the normal repair path without waiting for a
-new GitHub comment. `clawsweeper:human-review` still pauses that path.
+The router can still synthesize an internal trusted repair-loop command for
+open PRs with `clawsweeper:autofix` or `clawsweeper:automerge` labels during
+explicit live routing. `clawsweeper:human-review` still pauses that path.
 
 ## Local Run
 
@@ -347,7 +345,7 @@ The workflow needs:
 - If a contributor branch changes while a repair is preparing its push, the
   executor records `requeue_required: true` and the same workflow dispatches a
   fresh repair run for the latest head after publishing the result. This keeps
-  the force-with-lease guard intact without waiting for a later scheduled sweep.
+  the force-with-lease guard intact without relying on a later broad sweep.
 - optional `CLAWSWEEPER_NETWORK_COMMAND_TIMEOUT_MS` variable; repair execution
   uses bounded Git/GitHub network calls so a stuck clone, fetch, push, or API
   request fails in time for the executor to write a blocked report and upload
@@ -363,9 +361,9 @@ The workflow needs:
 - In-flight branch repair workers re-fetch the live PR before mutation and block
   if `clawsweeper:human-review` is present, so a trusted needs-human verdict or
   maintainer stop wins over stale queued repair jobs.
-- optional `CLAWSWEEPER_COMMENT_ROUTER_EXECUTE=1` to let the scheduled comment
-  router respond to maintainer-only `/clawsweeper ...` and
-  `@clawsweeper ...` / `@openclaw-clawsweeper ...` commands. Without it,
-  scheduled runs only write a dry report.
+- exact `clawsweeper_comment` dispatches or workflow dispatch with
+  `execute=true` to let the comment router respond to maintainer-only
+  `/clawsweeper ...` and `@clawsweeper ...` /
+  `@openclaw-clawsweeper ...` commands.
 
 Keep exact secret names, token scopes, and execution-window procedures in private operations docs or repository settings notes. Do not put token values or live operational credentials in job files.

--- a/docs/repair/auto-update-prs.md
+++ b/docs/repair/auto-update-prs.md
@@ -117,7 +117,7 @@ The status comment is edited in place through the whole loop. Its progress
 section records review, repair, re-review, and merge rows with durations, run
 links, and linked commit hashes. A branch repair that pushes a new commit also
 dispatches the next exact-head review immediately from the repair worker, so the
-loop does not wait for the scheduled comment-router sweep before checking the
+loop does not rely on a broad repair sweep before checking the
 repaired head. For base-sync-only blockers, the executor first tries a
 deterministic rebase fast path and pushes that result without a Codex edit pass;
 if the rebase or known mechanical conflict resolvers cannot finish cleanly, it
@@ -230,9 +230,11 @@ ClawSweeper has three layers of duplicate protection:
 - the comment router writes an idempotency marker in its reply, records
   processed comment versions in `results/comment-router.json`, and edits one
   command-status reply in place per item, intent, and head SHA;
-- scheduled router scans synthesize an internal repair-loop command for open
-  PRs that still carry `clawsweeper:autofix` or `clawsweeper:automerge`, so
-  stale labelled PRs can be repaired or re-reviewed without a fresh comment;
+- explicit live router runs can synthesize an internal repair-loop command for
+  open PRs that still carry `clawsweeper:autofix` or
+  `clawsweeper:automerge`, so stale labelled PRs can be repaired or
+  re-reviewed without a fresh comment when a maintainer or exact event invokes
+  the router;
 - trusted ClawSweeper repairs are capped per PR and per PR head SHA.
 
 The default caps are ten automatic repair iterations per PR and two
@@ -348,7 +350,8 @@ Durable state:
 
 Important knobs:
 
-- `CLAWSWEEPER_COMMENT_ROUTER_EXECUTE=1` enables scheduled writes and dispatches;
+- exact `clawsweeper_comment` dispatches and workflow dispatch with
+  `execute=true` enable live writes and dispatches;
 - `CLAWSWEEPER_TRUSTED_BOTS` controls trusted automation authors;
 - `CLAWSWEEPER_MAX_REPAIRS_PER_PR` controls total automatic repair
   iterations per PR; default `10`.
@@ -376,5 +379,5 @@ pnpm run repair:comment-router -- \
   --max-comments 100
 ```
 
-The scheduled workflow remains dry unless `CLAWSWEEPER_COMMENT_ROUTER_EXECUTE=1`
-is set or a maintainer manually dispatches the workflow with `execute=true`.
+The workflow is not scheduled. Use an exact `clawsweeper_comment` dispatch or
+manual workflow dispatch with `execute=true` for live routing.

--- a/docs/repair/automerge-flow.md
+++ b/docs/repair/automerge-flow.md
@@ -128,7 +128,7 @@ Every automerge decision is bound to a concrete PR head SHA.
   accidentally.
 
 This is why repair workers dispatch an immediate exact-head review after a
-branch push instead of waiting for the normal scheduled sweep.
+branch push instead of relying on broad scheduled repair sweeps.
 
 ## Checks: Wait, Repair, Or Merge
 

--- a/docs/repair/internal-features.md
+++ b/docs/repair/internal-features.md
@@ -189,7 +189,7 @@ pushes, opens PRs, and comments using the GitHub token.
 For same-branch automerge repairs, the executor can stay alive after pushing a
 deterministic repair. It waits for the exact-head ClawSweeper verdict and GitHub
 checks on the new head, then dispatches the comment router immediately when the
-PR is ready so merge does not depend on the next scheduled sweep. See
+PR is ready so merge does not depend on a broad repair sweep. See
 [`automerge-flow.md`](automerge-flow.md) for the full wait and repair decision
 table.
 
@@ -518,9 +518,8 @@ the per-PR automerge authorization.
 Otherwise it leaves the PR open and labels it `clawsweeper:human-review` and
 `clawsweeper:merge-ready` when merge gates are closed.
 
-The scheduled workflow is dry by default. Set
-`CLAWSWEEPER_COMMENT_ROUTER_EXECUTE=1` to let scheduled runs post replies and
-dispatch workers. Manual workflow dispatch can also pass `execute=true`.
+The workflow is not scheduled. Exact `clawsweeper_comment` dispatches execute
+for the source comment, and manual workflow dispatch can pass `execute=true`.
 Branch mutation still requires the downstream `CLAWSWEEPER_ALLOW_EXECUTE=1` and
 `CLAWSWEEPER_ALLOW_FIX_PR=1` gates.
 
@@ -588,8 +587,8 @@ Important gates:
   Workflows treat any value except literal `1` as closed.
 - `CLAWSWEEPER_ALLOW_MERGE`: allows ClawSweeper to merge. Keep this `0` unless a
   maintainer explicitly opens it.
-- `CLAWSWEEPER_COMMENT_ROUTER_EXECUTE`: lets scheduled comment routing post
-  replies and dispatch workers.
+- exact `clawsweeper_comment` dispatch or workflow dispatch with `execute=true`
+  lets comment routing post replies and dispatch workers.
 
 Important defaults:
 

--- a/docs/repair/operations.md
+++ b/docs/repair/operations.md
@@ -257,8 +257,8 @@ comments get an immediate `eyes` reaction from the ClawSweeper app. Maintainer
 commands also get one queued status comment that the router edits in place after
 it classifies the command, so the visible reply is available as soon as the
 target dispatcher starts. Exact comment dispatches scan only the source comment
-and use per-comment receiver concurrency; the scheduled sweep remains a
-five-minute fallback.
+and use per-comment receiver concurrency; broad scheduled repair sweeps are
+disabled.
 The status comment itself uses one compact badge: `🦞👀` for acknowledgement,
 `🦞🧹` for review, `🦞🔧` for repair/build/fix work, and `🦞✅` for completed or
 paused work.
@@ -349,7 +349,7 @@ Use `--comment-id <id>`, `--comment-ids <a,b>`, `--item-number <number>`, or
 `--item-numbers <a,b>` to route only specific comments or specific open issue
 or PR comments. The event review workflow uses this targeted path after syncing
 its durable ClawSweeper verdict so automerge can act on a fresh `pass` marker
-without waiting for the scheduled comment-router sweep. No-op targeted
+without waiting for a broad repair sweep. No-op targeted
 acknowledgements, such as already-processed commands or already-enabled
 automerge commands, do not publish a durable ledger commit.
 
@@ -414,11 +414,10 @@ If `main` advanced after validation, the worker rebases again; any conflicts are
 handed back to Codex for resolution, then validation and Codex `/review` rerun
 before push.
 
-The scheduled workflow is dry by default. Set
-`CLAWSWEEPER_COMMENT_ROUTER_EXECUTE=1` in repo variables to let scheduled runs
-post replies and dispatch workers. Manual workflow dispatch can also pass
-`execute=true`. Branch mutation still requires the downstream execution gates,
-including `CLAWSWEEPER_ALLOW_EXECUTE=1` and `CLAWSWEEPER_ALLOW_FIX_PR=1`.
+The workflow is not scheduled. Exact `clawsweeper_comment` dispatches execute
+for the source comment, and manual workflow dispatch can pass `execute=true`.
+Branch mutation still requires the downstream execution gates, including
+`CLAWSWEEPER_ALLOW_EXECUTE=1` and `CLAWSWEEPER_ALLOW_FIX_PR=1`.
 
 ## Token Strategy
 

--- a/docs/target-dispatcher.md
+++ b/docs/target-dispatcher.md
@@ -190,10 +190,11 @@ exact source comment id and, when available, the queued status comment id. The
 router edits that queued comment in place instead of posting a second reply.
 Exact comment dispatches scan only that comment and use a per-comment receiver
 concurrency group, so one maintainer command does not wait behind an unrelated
-command on the same repository. The scheduled sweep remains a five-minute
-fallback. Bot-authored label churn is also ignored. Human
-label changes are debounced and may run after an active dispatcher, but they
-must not cancel a content-changing dispatch before it posts to ClawSweeper.
+command on the same repository. Broad scheduled repair sweeps are disabled, so
+the exact dispatch is the live fallback path. Bot-authored label churn is also
+ignored. Human label changes are debounced and may run after an active
+dispatcher, but they must not cancel a content-changing dispatch before it posts
+to ClawSweeper.
 Content-changing events such as issue edits and PR synchronizes cancel stale
 target-side dispatch jobs and mark their receiver dispatch as superseding. On
 the receiver, event-item runs are keyed by repository and item number and the


### PR DESCRIPTION
## Summary
- stop the scheduled repair comment-router sweep so PR repair only runs from exact comment dispatches or explicit workflow dispatch
- stop scheduled repair self-heal retries; self-heal remains manually dispatchable
- update repair docs to remove the old scheduled repair variable guidance

## Verification
- pnpm run check
- pnpm run format:check
- git diff --check