### PR TITLE
fix: Refactor PR review comment layout

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -10825,6 +10825,20 @@ function publicSummaryBody(summaryLine: string, reproductionAssessment: string):
     .join("\n\n");
 }
 
+function publicPrSummaryBody(
+  summaryLine: string,
+  reproductionAssessment: string,
+  prSurfaceSummary: string,
+): string {
+  return [
+    summaryLine,
+    prSurfaceSummary ? `PR surface: ${prSurfaceSummary}` : "",
+    publicReproducibilityLine(reproductionAssessment),
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+}
+
 function publicMergeRiskLine(
   risks: string,
   nextStepLine: string,
@@ -11044,12 +11058,13 @@ function renderKeepOpenCommentFromReport(
             : "Codex review: keeping this open for maintainer follow-up; there is still a little grit to resolve.";
   const lines = [`${verdictLine}${reviewFreshnessText(markdown)}`, ""];
   const prSurface = renderOpenClawPrSurfaceFromReport(markdown);
+  const prSurfaceSummary = prSurface.split("\n\n", 1)[0]?.trim() ?? "";
   if (prSurface) evidenceDetails.push("PR surface:", "", prSurface);
   if (isPullRequest) {
     appendPublicSection(
       lines,
       "Summary",
-      publicSummaryBody(changeSummaryLine, reproductionAssessment),
+      publicPrSummaryBody(changeSummaryLine, reproductionAssessment, prSurfaceSummary),
     );
   } else {
     appendPublicSection(lines, "Summary", publicSummaryBody(summaryLine, reproductionAssessment));

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -6826,6 +6826,10 @@ function publicMergeReadinessResult(rating: PrRating, proof: RealBehaviorProof):
 
 function publicMergeReadinessBlock(rating: PrRating, proof: RealBehaviorProof): string {
   const shiny = hasShinyProof(proof) ? " ✨ media proof bonus" : "";
+  const proofGuidance =
+    proof.status === "missing" || proof.status === "mock_only" || proof.status === "insufficient"
+      ? publicRealBehaviorProofLine(proof)
+      : "";
   const lines = [
     `Overall: ${themedRatingName(rating.overallTier)}`,
     `Proof: ${themedRatingName(rating.proofTier)}${shiny}`,
@@ -6836,6 +6840,9 @@ function publicMergeReadinessBlock(rating: PrRating, proof: RealBehaviorProof): 
   ];
   if (rating.nextSteps.length) {
     lines.push("", "Rank-up moves:", ...rating.nextSteps.slice(0, 3).map((step) => `- ${step}`));
+  }
+  if (proofGuidance) {
+    lines.push("", "Proof guidance:", proofGuidance);
   }
   return lines.join("\n");
 }

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -2735,17 +2735,23 @@ function firstNonEmptyLine(value: string): string {
 }
 
 function previousReviewStatus(body: string): string {
-  return firstLineAfterPrefix(body, "Codex review:")
-    .replace(/\s*_Reviewed[^_]*_\s*$/i, "")
-    .trim();
+  const status = firstLineAfterPrefix(body, "Codex review:");
+  const reviewedIndex = status.toLowerCase().indexOf("_reviewed ");
+  return (reviewedIndex < 0 ? status : status.slice(0, reviewedIndex)).trim();
 }
 
 function previousReviewReviewedAt(body: string): string | null {
   const value = firstLineAfterPrefix(body, "**Latest ClawSweeper review:**");
   if (value) return value.replace(/\.$/, "").trim();
   const firstLine = body.split(/\r?\n/, 1)[0] ?? "";
-  const inline = firstLine.match(/_Reviewed\s+(.+?)\._/i);
-  return inline?.[1]?.trim() || null;
+  const lowerFirstLine = firstLine.toLowerCase();
+  const prefix = "_reviewed ";
+  const start = lowerFirstLine.indexOf(prefix);
+  if (start < 0) return null;
+  const valueStart = start + prefix.length;
+  const end = firstLine.indexOf("._", valueStart);
+  const inline = firstLine.slice(valueStart, end < 0 ? undefined : end).trim();
+  return inline || null;
 }
 
 function firstMergeReadinessLine(body: string, prefix: string): string {
@@ -2772,8 +2778,18 @@ function previousReviewProofStatus(body: string): string {
   if (oldProofStatus) return oldProofStatus;
   const readiness = markdownSection(body, "Merge readiness");
   if (!readiness) return "";
-  const proofGuidance = readiness.match(/(?:^|\n)Proof guidance:\s*\n+([^\n]+)/i);
-  return proofGuidance?.[1]?.trim() || firstMergeReadinessLine(body, "Proof:");
+  const lines = readiness.split(/\r?\n/);
+  const proofGuidanceIndex = lines.findIndex(
+    (line) => line.trim().toLowerCase() === "proof guidance:",
+  );
+  if (proofGuidanceIndex >= 0) {
+    const guidance = lines
+      .slice(proofGuidanceIndex + 1)
+      .map((line) => line.trim())
+      .find(Boolean);
+    if (guidance) return guidance;
+  }
+  return firstMergeReadinessLine(body, "Proof:");
 }
 
 function previousReviewFindings(body: string): Array<{ priority: string; title: string }> {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -2735,12 +2735,45 @@ function firstNonEmptyLine(value: string): string {
 }
 
 function previousReviewStatus(body: string): string {
-  return firstLineAfterPrefix(body, "Codex review:");
+  return firstLineAfterPrefix(body, "Codex review:")
+    .replace(/\s*_Reviewed[^_]*_\s*$/i, "")
+    .trim();
 }
 
 function previousReviewReviewedAt(body: string): string | null {
   const value = firstLineAfterPrefix(body, "**Latest ClawSweeper review:**");
-  return value ? value.replace(/\.$/, "").trim() : null;
+  if (value) return value.replace(/\.$/, "").trim();
+  const firstLine = body.split(/\r?\n/, 1)[0] ?? "";
+  const inline = firstLine.match(/_Reviewed\s+(.+?)\._/i);
+  return inline?.[1]?.trim() || null;
+}
+
+function firstMergeReadinessLine(body: string, prefix: string): string {
+  const readiness = markdownSection(body, "Merge readiness");
+  if (!readiness) return "";
+  const lowerPrefix = prefix.toLowerCase();
+  return (
+    readiness
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find((line) => line.toLowerCase().startsWith(lowerPrefix)) ?? ""
+  );
+}
+
+function previousReviewRating(body: string): string {
+  return (
+    firstNonEmptyLine(markdownSection(body, "PR rating")) ||
+    firstMergeReadinessLine(body, "Overall:")
+  );
+}
+
+function previousReviewProofStatus(body: string): string {
+  const oldProofStatus = firstNonEmptyLine(markdownSection(body, "Real behavior proof"));
+  if (oldProofStatus) return oldProofStatus;
+  const readiness = markdownSection(body, "Merge readiness");
+  if (!readiness) return "";
+  const proofGuidance = readiness.match(/(?:^|\n)Proof guidance:\s*\n+([^\n]+)/i);
+  return proofGuidance?.[1]?.trim() || firstMergeReadinessLine(body, "Proof:");
 }
 
 function previousReviewFindings(body: string): Array<{ priority: string; title: string }> {
@@ -2780,8 +2813,8 @@ function extractLatestClawSweeperReview(
     verdictMarker,
     actionMarker,
     summary: firstNonEmptyLine(markdownSection(body, "Summary")),
-    proofStatus: firstNonEmptyLine(markdownSection(body, "Real behavior proof")),
-    rating: firstNonEmptyLine(markdownSection(body, "PR rating")),
+    proofStatus: previousReviewProofStatus(body),
+    rating: previousReviewRating(body),
     nextStep:
       firstNonEmptyLine(markdownSection(body, "Next step before merge")) ||
       firstNonEmptyLine(markdownSection(body, "Next step")),

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -6217,17 +6217,19 @@ function formatReviewFreshnessTimestamp(iso: string | undefined): string {
   if (!iso) return "";
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return iso;
-  const utc = date.toISOString().slice(0, 16).replace("T", " ");
+  const utc = date.toISOString().slice(11, 16);
   const eastern = new Intl.DateTimeFormat("en-US", {
     year: "numeric",
-    month: "short",
+    month: "long",
     day: "numeric",
     hour: "numeric",
     minute: "2-digit",
     hour12: true,
     timeZone: "America/New_York",
-  }).format(date);
-  return `${utc} UTC / ${eastern} ET`;
+  })
+    .format(date)
+    .replace(" at ", ", ");
+  return `${eastern} ET / ${utc} UTC`;
 }
 
 function workflowStatusBlock(options?: {
@@ -6783,22 +6785,8 @@ function publicRealBehaviorProofLine(proof: RealBehaviorProof): string {
   }
 }
 
-function publicPrRatingLine(rating: PrRating, proof: RealBehaviorProof): string {
-  const shiny = hasShinyProof(proof) ? " ✨ media proof bonus" : "";
-  const lines = [
-    `Overall: ${themedRatingName(rating.overallTier)}`,
-    `Proof: ${themedRatingName(rating.proofTier)}${shiny}`,
-    `Patch quality: ${themedRatingName(rating.patchTier)}`,
-    `Summary: ${sentence(rating.summary)}`,
-  ];
-  if (rating.nextSteps.length) {
-    lines.push("", "Rank-up moves:", ...rating.nextSteps.slice(0, 3).map((step) => `- ${step}`));
-  }
-  lines.push(
-    "",
-    "<details>",
-    "<summary>What the crustacean ranks mean</summary>",
-    "",
+function publicRankDetailsBlock(): string {
+  return collapsedDetailsBlock("What the crustacean ranks mean", [
     "- 🦀 challenger crab: rare, exceptional readiness with strong proof, clean implementation, and convincing validation.",
     "- 🦞 diamond lobster: very strong readiness with only minor maintainer review expected.",
     "- 🐚 platinum hermit: good normal PR, likely mergeable with ordinary maintainer review.",
@@ -6808,9 +6796,47 @@ function publicPrRatingLine(rating: PrRating, proof: RealBehaviorProof): string 
     "- 🌊 off-meta tidepool: rating does not apply to this item.",
     "",
     "Shiny media proof means a screenshot, video, or linked artifact directly shows the changed behavior. Runtime, network, CSP, and security claims still need visible diagnostics.",
+  ]);
+}
+
+function publicMergeReadinessResult(rating: PrRating, proof: RealBehaviorProof): string {
+  if (rating.overallTier === "NA") return "rating does not apply to this item.";
+  switch (proof.status) {
+    case "missing":
+      return "blocked until real behavior proof is added.";
+    case "mock_only":
+      return "blocked until real behavior proof from a real setup is added.";
+    case "insufficient":
+      return "blocked until stronger real behavior proof is added.";
+    case "sufficient":
+    case "override":
+      if (rating.patchTier === "F" || rating.patchTier === "D") {
+        return "blocked by patch quality or review findings.";
+      }
+      if (rating.overallTier === "S" || rating.overallTier === "A" || rating.overallTier === "B") {
+        return "ready for maintainer review.";
+      }
+      return "needs maintainer review before merge.";
+    case "not_applicable":
+      return rating.patchTier === "F" || rating.patchTier === "D"
+        ? "blocked by patch quality or review findings."
+        : "ready for maintainer review.";
+  }
+}
+
+function publicMergeReadinessBlock(rating: PrRating, proof: RealBehaviorProof): string {
+  const shiny = hasShinyProof(proof) ? " ✨ media proof bonus" : "";
+  const lines = [
+    `Overall: ${themedRatingName(rating.overallTier)}`,
+    `Proof: ${themedRatingName(rating.proofTier)}${shiny}`,
+    `Patch quality: ${themedRatingName(rating.patchTier)}`,
+    `Result: ${publicMergeReadinessResult(rating, proof)}`,
     "",
-    "</details>",
-  );
+    "Overall follows the weaker of proof and patch quality, so missing proof can cap an otherwise strong patch.",
+  ];
+  if (rating.nextSteps.length) {
+    lines.push("", "Rank-up moves:", ...rating.nextSteps.slice(0, 3).map((step) => `- ${step}`));
+  }
   return lines.join("\n");
 }
 
@@ -10127,9 +10153,7 @@ function labelTransitionReason(
     const rating = reportPrRating(markdown);
     const current = ratingLabelForTier(rating.overallTier).name;
     return action === "add"
-      ? `Current PR rating is ${themedRatingName(rating.overallTier)} because proof is ${themedRatingName(
-          rating.proofTier,
-        )}, patch quality is ${themedRatingName(rating.patchTier)}, and ${sentence(rating.summary)}`
+      ? `Overall readiness is ${themedRatingName(rating.overallTier)}.`
       : `Current PR rating is ${inlineCode(current)}, so this older rating label is no longer current.`;
   }
   if (PR_STATUS_LABEL_NAMES.has(label)) {
@@ -10234,11 +10258,9 @@ function labelJustificationsFromPublicReport(
       : "";
     add(
       ratingLabel,
-      `Current PR rating is ${themedRatingName(rating.overallTier)} because proof is ${themedRatingName(
+      `Overall readiness is ${themedRatingName(rating.overallTier)}; proof is ${themedRatingName(
         rating.proofTier,
-      )}, patch quality is ${themedRatingName(rating.patchTier)}, and ${sentence(
-        rating.summary,
-      )}${changed}`,
+      )} and patch quality is ${themedRatingName(rating.patchTier)}.${changed}`,
     );
     const featureShowcase = reportFeatureShowcase(markdown);
     if (
@@ -10894,8 +10916,6 @@ function appendReviewQuestionDetails(
 
 function reviewWorkflowCallout(): string[] {
   return [
-    "**Workflow note:** Future ClawSweeper reviews update this same comment in place.",
-    "",
     collapsedDetailsBlock("How this review workflow works", [
       "- ClawSweeper keeps one durable marker-backed review comment per issue or PR.",
       "- Re-runs edit this comment so the latest verdict, findings, and automation markers stay together instead of adding duplicate bot comments.",
@@ -10910,10 +10930,9 @@ function reviewWorkflowCallout(): string[] {
   ];
 }
 
-function reviewFreshnessCallout(markdown: string): string[] {
+function reviewFreshnessText(markdown: string): string {
   const timestamp = formatReviewFreshnessTimestamp(frontMatterValue(markdown, "reviewed_at"));
-  if (!timestamp) return [];
-  return [`**Latest ClawSweeper review:** ${timestamp}.`, ""];
+  return timestamp ? ` _Reviewed ${timestamp}._` : "";
 }
 
 function renderKeepOpenCommentFromReport(
@@ -10952,26 +10971,24 @@ function renderKeepOpenCommentFromReport(
   const mergeRiskLine = isPullRequest
     ? publicMergeRiskLine(risks, nextStepLine, bestSolutionLine, mergeRiskOptions)
     : "";
-  const details: string[] = [];
+  const reviewDetails: string[] = [];
+  const labelDetails: string[] = [];
+  const evidenceDetails: string[] = [];
   const hasReviewFindings = isPullRequest && reviewFindings.length > 0;
-  const lines = [
-    hasRealBehaviorProofBlocker
-      ? "Codex review: needs real behavior proof before merge."
-      : isRepairLoopPass
-        ? "Codex review: passed."
-        : isPullRequest && isRepairCandidate
-          ? "Codex review: needs changes before merge."
-          : hasReviewFindings
-            ? "Codex review: found issues before merge."
-            : isPullRequest
-              ? "Codex review: needs maintainer review before merge."
-              : "Codex review: keeping this open for maintainer follow-up; there is still a little grit to resolve.",
-    "",
-    ...reviewFreshnessCallout(markdown),
-    ...reviewWorkflowCallout(),
-  ];
+  const verdictLine = hasRealBehaviorProofBlocker
+    ? "Codex review: needs real behavior proof before merge."
+    : isRepairLoopPass
+      ? "Codex review: passed."
+      : isPullRequest && isRepairCandidate
+        ? "Codex review: needs changes before merge."
+        : hasReviewFindings
+          ? "Codex review: found issues before merge."
+          : isPullRequest
+            ? "Codex review: needs maintainer review before merge."
+            : "Codex review: keeping this open for maintainer follow-up; there is still a little grit to resolve.";
+  const lines = [`${verdictLine}${reviewFreshnessText(markdown)}`, ""];
   const prSurface = renderOpenClawPrSurfaceFromReport(markdown);
-  if (prSurface) appendPublicSection(lines, "PR Surface", prSurface);
+  if (prSurface) evidenceDetails.push("PR surface:", "", prSurface);
   if (isPullRequest) {
     appendPublicSection(
       lines,
@@ -10992,11 +11009,10 @@ function renderKeepOpenCommentFromReport(
     }
   }
   if (isPullRequest) {
-    appendPublicSection(lines, "PR rating", publicPrRatingLine(prRating, realBehaviorProof));
     appendPublicSection(
       lines,
-      "Real behavior proof",
-      publicRealBehaviorProofLine(realBehaviorProof),
+      "Merge readiness",
+      publicMergeReadinessBlock(prRating, realBehaviorProof),
     );
   }
   const mantisSuggestion = isPullRequest
@@ -11011,9 +11027,9 @@ function renderKeepOpenCommentFromReport(
     lines.push("**Review findings**", ...reviewFindings.slice(0, 3).map(reviewFindingSummaryLine));
   }
   if (bestSolutionLine && publicReviewTextDiffers(bestSolutionLine, nextStepLine)) {
-    details.push("Best possible solution:", "", bestSolutionLine);
+    reviewDetails.push("Best possible solution:", "", bestSolutionLine);
   }
-  appendReviewQuestionDetails(details, reproductionAssessment, solutionAssessment);
+  appendReviewQuestionDetails(reviewDetails, reproductionAssessment, solutionAssessment);
   const labelJustifications = labelJustificationsFromPublicReport(markdown, options);
   const labelTransitionJustifications = labelTransitionJustificationsFromPublicReport(
     markdown,
@@ -11021,19 +11037,23 @@ function renderKeepOpenCommentFromReport(
     options,
   );
   if (labelTransitionJustifications.length) {
-    details.push(
-      "",
+    labelDetails.push(
       "Label changes:",
       "",
       labelTransitionJustificationsMarkdown(labelTransitionJustifications),
     );
   }
   if (labelJustifications.length) {
-    details.push("", "Label justifications:", "", labelJustificationsMarkdown(labelJustifications));
+    if (labelDetails.length) labelDetails.push("");
+    labelDetails.push(
+      "Label justifications:",
+      "",
+      labelJustificationsMarkdown(labelJustifications),
+    );
   }
   if (isPullRequest && reviewFindings.length) {
-    details.push(
-      "",
+    reviewDetails.push(
+      ...(reviewDetails.length ? [""] : []),
       "Full review comments:",
       "",
       ...reviewFindings.map(reviewFindingDetailedLine),
@@ -11043,28 +11063,60 @@ function renderKeepOpenCommentFromReport(
     );
   }
   if (securityReview.concerns.length) {
-    details.push(
-      "",
+    evidenceDetails.push(
+      ...(evidenceDetails.length ? [""] : []),
       "Security concerns:",
       "",
       ...securityReview.concerns.map(securityConcernDetailedLine),
     );
   }
-  if (validation.length) details.push("", "Acceptance criteria:", "", ...validation);
-  if (evidence.length) details.push("", "What I checked:", "", ...evidence);
-  if (likelyOwners.length) details.push("", "Likely related people:", "", ...likelyOwners);
+  if (validation.length) {
+    evidenceDetails.push(
+      ...(evidenceDetails.length ? [""] : []),
+      "Acceptance criteria:",
+      "",
+      ...validation,
+    );
+  }
+  if (evidence.length) {
+    evidenceDetails.push(
+      ...(evidenceDetails.length ? [""] : []),
+      "What I checked:",
+      "",
+      ...evidence,
+    );
+  }
+  if (likelyOwners.length) {
+    evidenceDetails.push(
+      ...(evidenceDetails.length ? [""] : []),
+      "Likely related people:",
+      "",
+      ...likelyOwners,
+    );
+  }
   if (
     !isReportNoneList(risks) &&
     !mergeRiskLine &&
     publicReviewTextDiffers(risks, nextStepLine) &&
     (!bestSolutionLine || publicReviewTextDiffers(risks, bestSolutionLine))
   ) {
-    details.push("", "Remaining risk / open question:", "", risks);
+    reviewDetails.push(
+      ...(reviewDetails.length ? [""] : []),
+      "Remaining risk / open question:",
+      "",
+      risks,
+    );
   }
   const reviewLine = closeReviewLineFromReport(markdown);
-  if (reviewLine) details.push("", reviewLine);
-  const detailsBlock = collapsedDetailsBlock("Review details", details);
+  if (reviewLine) reviewDetails.push(...(reviewDetails.length ? [""] : []), reviewLine);
+  const detailsBlock = collapsedDetailsBlock("Review details", reviewDetails);
   if (detailsBlock) lines.push("", detailsBlock);
+  const labelDetailsBlock = collapsedDetailsBlock("Label changes", labelDetails);
+  if (labelDetailsBlock) lines.push("", labelDetailsBlock);
+  const evidenceDetailsBlock = collapsedDetailsBlock("Evidence reviewed", evidenceDetails);
+  if (evidenceDetailsBlock) lines.push("", evidenceDetailsBlock);
+  if (isPullRequest) lines.push("", publicRankDetailsBlock());
+  lines.push("", ...reviewWorkflowCallout());
   return sanitizePublicSelfReferences(
     lines.join("\n"),
     Number(frontMatterValue(markdown, "number")),

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -742,6 +742,16 @@ ${values.nextSteps}
 `;
 }
 
+function detailsBody(markdown, summary) {
+  const marker = `<summary>${summary}</summary>`;
+  const markerIndex = markdown.indexOf(marker);
+  assert.notEqual(markerIndex, -1, `missing details summary ${summary}`);
+  const bodyStart = markerIndex + marker.length;
+  const bodyEnd = markdown.indexOf("</details>", bodyStart);
+  assert.notEqual(bodyEnd, -1, `missing details close for ${summary}`);
+  return markdown.slice(bodyStart, bodyEnd);
+}
+
 function auditRecord(number, overrides = {}) {
   return {
     repo: "openclaw/openclaw",
@@ -2564,15 +2574,16 @@ Reason: Maintainers should review the tests after the targeted lane is green.
     "none",
   );
 
-  assert.match(comment, /Codex review: needs maintainer review before merge\./);
   assert.match(
     comment,
-    /\*\*Latest ClawSweeper review:\*\* 2026-05-22 04:43 UTC \/ May 22, 2026, 12:43 AM ET\./,
+    /Codex review: needs maintainer review before merge\. _Reviewed May 22, 2026, 12:43 AM ET \/ 04:43 UTC\._/,
   );
+  assert.doesNotMatch(comment, /\*\*Latest ClawSweeper review:\*\*/);
   assert.match(
     comment,
-    /\*\*Workflow note:\*\* Future ClawSweeper reviews update this same comment in place\./,
+    /\*\*Summary\*\*\nAdds regression coverage for session-scoped model overrides\./,
   );
+  assert.doesNotMatch(comment, /\*\*Workflow note:\*\*/);
   assert.match(comment, /<summary>How this review workflow works<\/summary>/);
   assert.match(
     comment,
@@ -2602,10 +2613,6 @@ Reason: Maintainers should review the tests after the targeted lane is green.
     comment,
     /- Maintainers can comment `@clawsweeper explain` to ask for more context, or `@clawsweeper stop` to stop active automation\./,
   );
-  assert.match(
-    comment,
-    /\*\*Summary\*\*\nAdds regression coverage for session-scoped model overrides\./,
-  );
   assert.match(comment, /\*\*Next step before merge\*\*/);
   assert.match(comment, /Maintainers should review the tests after the targeted lane is green\./);
   assert.match(comment, /<details>\n<summary>Review details<\/summary>/);
@@ -2623,7 +2630,20 @@ Reason: Maintainers should review the tests after the targeted lane is green.
   );
   assert.ok(
     comment.indexOf("Is this the best way to solve the issue?") <
-      comment.indexOf("What I checked:"),
+      comment.indexOf("<summary>Evidence reviewed</summary>"),
+  );
+  assert.match(detailsBody(comment, "Evidence reviewed"), /What I checked:/);
+  assert.ok(
+    comment.indexOf("<summary>Review details</summary>") <
+      comment.indexOf("<summary>Evidence reviewed</summary>"),
+  );
+  assert.ok(
+    comment.indexOf("<summary>Evidence reviewed</summary>") <
+      comment.indexOf("<summary>What the crustacean ranks mean</summary>"),
+  );
+  assert.ok(
+    comment.indexOf("<summary>What the crustacean ranks mean</summary>") <
+      comment.indexOf("<summary>How this review workflow works</summary>"),
   );
   assert.match(comment, /<!-- clawsweeper-verdict:needs-human item=74265 sha=abc123def456/);
 });
@@ -2846,10 +2866,8 @@ Reason: The fix is narrow and can be made on the PR branch.
   );
 
   assert.match(comment, /Codex review: needs changes before merge\./);
-  assert.match(
-    comment,
-    /\*\*Workflow note:\*\* Future ClawSweeper reviews update this same comment in place\./,
-  );
+  assert.doesNotMatch(comment, /\*\*Workflow note:\*\*/);
+  assert.match(comment, /<summary>How this review workflow works<\/summary>/);
   assert.match(
     comment,
     /\*\*Review findings\*\*\n- \[P1\] Validate replace paths — `src\/config\/apply\.ts:42-44`/,
@@ -2983,14 +3001,84 @@ Full review comments:
   });
   const markers = reviewAutomationMarkersFromReport(report);
 
-  assert.match(comment, /\*\*PR rating\*\*\nOverall: 🦞 diamond lobster/);
+  assert.match(comment, /\*\*Merge readiness\*\*\nOverall: 🦞 diamond lobster/);
   assert.match(comment, /Proof: 🦞 diamond lobster/);
   assert.match(comment, /Patch quality: 🦞 diamond lobster/);
+  assert.match(comment, /Result: ready for maintainer review\./);
+  assert.match(
+    comment,
+    /Overall follows the weaker of proof and patch quality, so missing proof can cap an otherwise strong patch\./,
+  );
+  assert.doesNotMatch(comment, /\*\*PR rating\*\*/);
+  assert.doesNotMatch(comment, /\*\*Real behavior proof\*\*/);
   assert.match(comment, /<summary>What the crustacean ranks mean<\/summary>/);
+  assert.match(comment, /🦀 challenger crab: rare, exceptional readiness/);
   assert.match(comment, /🧂 unranked krab: not merge-ready/);
-  assert.match(comment, /\*\*Real behavior proof\*\*\nSufficient \(terminal\):/);
   assert.match(markers, /clawsweeper-verdict:pass/);
   assert.doesNotMatch(markers, /clawsweeper-verdict:needs-human/);
+});
+
+test("proof-blocked PR comments show proof cap while preserving patch quality", () => {
+  const report = `${reportFrontMatter({
+    type: "pull_request",
+    number: "74460",
+    decision: "keep_open",
+    close_reason: "none",
+    review_status: "complete",
+    confidence: "high",
+    author: "contributor",
+    author_association: "CONTRIBUTOR",
+    labels: JSON.stringify([]),
+    work_candidate: "none",
+    pull_head_sha: "abc123def456",
+  })}
+
+## Summary
+
+Keep this PR open until proof is added.
+
+## What This Changes
+
+Filters noisy review-context comments before prompting.
+
+## Best Possible Solution
+
+Add real ClawSweeper ingestion proof before merge.
+
+${realBehaviorProofReportSection({
+  status: "missing",
+  evidenceKind: "none",
+  needsContributorAction: true,
+  summary: "The PR has no real ingestion-run proof yet.",
+})}
+
+## Review Findings
+
+Overall correctness: patch is correct
+
+Overall confidence: 0.9
+
+Full review comments:
+
+- none
+`;
+
+  const comment = renderReviewCommentFromReport(report, "none");
+  const labelDetails = detailsBody(comment, "Label changes");
+
+  assert.match(comment, /\*\*Merge readiness\*\*\nOverall: 🧂 unranked krab/);
+  assert.match(comment, /Proof: 🧂 unranked krab/);
+  assert.match(comment, /Patch quality: 🦞 diamond lobster/);
+  assert.match(comment, /Result: blocked until real behavior proof is added\./);
+  assert.match(
+    comment,
+    /Overall follows the weaker of proof and patch quality, so missing proof can cap an otherwise strong patch\./,
+  );
+  assert.match(
+    labelDetails,
+    /- `rating: 🧂 unranked krab`: Overall readiness is 🧂 unranked krab; proof is 🧂 unranked krab and patch quality is 🦞 diamond lobster\./,
+  );
+  assert.doesNotMatch(labelDetails, /PR readiness rating was derived from proof quality/);
 });
 
 test("public PR review comments explain label changes without duplicate justifications", () => {
@@ -3059,20 +3147,35 @@ Full review comments:
 
   const comment = renderReviewCommentFromReport(report, "none");
 
-  assert.match(comment, /<details>\n<summary>Review details<\/summary>/);
-  assert.match(comment, /Label changes:/);
+  assert.match(comment, /<summary>Label changes<\/summary>/);
+  assert.ok(
+    comment.indexOf("<summary>Label changes</summary>") <
+      comment.indexOf("<summary>What the crustacean ranks mean</summary>"),
+  );
+  assert.ok(
+    comment.indexOf("<summary>What the crustacean ranks mean</summary>") <
+      comment.indexOf("<summary>How this review workflow works</summary>"),
+  );
+  if (comment.includes("<summary>Review details</summary>")) {
+    assert.doesNotMatch(detailsBody(comment, "Review details"), /Label changes:/);
+  }
+  const labelDetails = detailsBody(comment, "Label changes");
+  assert.match(labelDetails, /Label changes:/);
   assert.match(
-    comment,
+    labelDetails,
     /- add `P1`: The PR changes an active channel workflow affecting real users\./,
   );
   assert.match(
-    comment,
+    labelDetails,
     /- add `merge-risk: 🚨 compatibility`: Merging changes the default upgrade behavior for existing configs\./,
   );
-  assert.match(comment, /Label justifications:/);
-  assert.match(comment, /- `P1`: The PR changes an active channel workflow affecting real users\./);
+  assert.match(labelDetails, /Label justifications:/);
   assert.match(
-    comment,
+    labelDetails,
+    /- `P1`: The PR changes an active channel workflow affecting real users\./,
+  );
+  assert.match(
+    labelDetails,
     /- `impact:message-loss`: The diff touches message retry and delivery ordering\./,
   );
 });
@@ -3125,20 +3228,21 @@ Full review comments:
 `;
 
   const comment = renderReviewCommentFromReport(report, "none");
+  const labelDetails = detailsBody(comment, "Label changes");
 
-  assert.match(comment, /Label changes:/);
+  assert.match(labelDetails, /Label changes:/);
   assert.match(
-    comment,
-    /- add `rating: 🦪 silver shellfish`: Current PR rating is 🦪 silver shellfish because proof is 🦪 silver shellfish, patch quality is 🦞 diamond lobster, and PR readiness rating was derived from proof quality, review findings, security review, and reviewer confidence\./,
+    labelDetails,
+    /- add `rating: 🦪 silver shellfish`: Overall readiness is 🦪 silver shellfish; proof is 🦪 silver shellfish and patch quality is 🦞 diamond lobster\. Replaced prior `rating: 🦞 diamond lobster`\./,
   );
   assert.match(
-    comment,
+    labelDetails,
     /- remove `rating: 🦞 diamond lobster`: Current PR rating is `rating: 🦪 silver shellfish`, so this older rating label is no longer current\./,
   );
-  assert.match(comment, /Label justifications:/);
+  assert.match(labelDetails, /Label justifications:/);
   assert.match(
-    comment,
-    /- `rating: 🦪 silver shellfish`: Current PR rating is 🦪 silver shellfish because proof is 🦪 silver shellfish, patch quality is 🦞 diamond lobster, and PR readiness rating was derived from proof quality, review findings, security review, and reviewer confidence\. Replaced prior `rating: 🦞 diamond lobster`\./,
+    labelDetails,
+    /- `rating: 🦪 silver shellfish`: Overall readiness is 🦪 silver shellfish; proof is 🦪 silver shellfish and patch quality is 🦞 diamond lobster\. Replaced prior `rating: 🦞 diamond lobster`\./,
   );
 });
 
@@ -3276,20 +3380,21 @@ Full review comments:
 `;
 
   const comment = renderReviewCommentFromReport(report, "none");
+  const labelDetails = detailsBody(comment, "Label changes");
 
-  assert.match(comment, /Label changes:/);
+  assert.match(labelDetails, /Label changes:/);
   assert.match(
-    comment,
-    /- add `rating: 🦪 silver shellfish`: Current PR rating is 🦪 silver shellfish because proof is 🦪 silver shellfish, patch quality is 🦞 diamond lobster, and PR readiness rating was derived from proof quality, review findings, security review, and reviewer confidence\./,
+    labelDetails,
+    /- add `rating: 🦪 silver shellfish`: Overall readiness is 🦪 silver shellfish; proof is 🦪 silver shellfish and patch quality is 🦞 diamond lobster\. Replaced prior `rating: 🦞 diamond lobster`\./,
   );
   assert.match(
-    comment,
+    labelDetails,
     /- remove `rating: 🦞 diamond lobster`: Current PR rating is `rating: 🦪 silver shellfish`, so this older rating label is no longer current\./,
   );
-  assert.match(comment, /Label justifications:/);
+  assert.match(labelDetails, /Label justifications:/);
   assert.match(
-    comment,
-    /- `rating: 🦪 silver shellfish`: Current PR rating is 🦪 silver shellfish because proof is 🦪 silver shellfish, patch quality is 🦞 diamond lobster, and PR readiness rating was derived from proof quality, review findings, security review, and reviewer confidence\. Replaced prior `rating: 🦞 diamond lobster`\./,
+    labelDetails,
+    /- `rating: 🦪 silver shellfish`: Overall readiness is 🦪 silver shellfish; proof is 🦪 silver shellfish and patch quality is 🦞 diamond lobster\. Replaced prior `rating: 🦞 diamond lobster`\./,
   );
 });
 
@@ -3433,7 +3538,7 @@ Full review comments:
 
   const comment = renderReviewCommentFromReport(report, "none");
 
-  assert.match(comment, /\*\*PR rating\*\*\nOverall: 🦀 challenger crab/);
+  assert.match(comment, /\*\*Merge readiness\*\*\nOverall: 🦀 challenger crab/);
   assert.match(comment, /Proof: 🦀 challenger crab ✨ media proof bonus/);
   assert.match(comment, /Shiny media proof means a screenshot, video, or linked artifact/);
   assert.doesNotMatch(comment, /Rank-up moves:/);
@@ -3499,7 +3604,7 @@ Full review comments:
   const eggComment = renderPrEggCommentForTest(74470, report);
 
   assert.doesNotMatch(comment, /\*\*PR egg\*\*/);
-  assert.match(comment, /\*\*Real behavior proof\*\*/);
+  assert.match(comment, /\*\*Merge readiness\*\*/);
   assert.match(eggComment, /ClawSweeper PR egg/);
   assert.match(eggComment, /🎁 Pass real behavior proof/);
   assert.match(eggComment, /wake the egg and unlock a hatchable treat/);
@@ -4358,8 +4463,8 @@ Full review comments:
   const comment = renderReviewCommentFromReport(report, "none");
   const markers = reviewAutomationMarkersFromReport(report);
 
-  assert.match(comment, /\*\*Real behavior proof\*\*\nNot applicable:/);
-  assert.match(comment, /only changes files under docs\//);
+  assert.match(comment, /\*\*Merge readiness\*\*/);
+  assert.match(comment, /Proof: 🌊 off-meta tidepool/);
   assert.match(markers, /clawsweeper-verdict:pass/);
   assert.doesNotMatch(markers, /clawsweeper-verdict:needs-human/);
 });
@@ -4542,7 +4647,7 @@ Full review comments:
   const markers = reviewAutomationMarkersFromReport(report);
 
   assert.match(comment, /Codex review: needs real behavior proof before merge\./);
-  assert.match(comment, /\*\*Real behavior proof\*\*/);
+  assert.match(comment, /\*\*Merge readiness\*\*/);
   assert.match(comment, /terminal screenshots, console output, copied live output/);
   assert.match(comment, /update the PR body; ClawSweeper should re-review automatically/);
   assert.match(comment, /@clawsweeper re-review/);
@@ -9118,7 +9223,7 @@ Reason: ${duplicateRisk}
   assert.equal(comment.split(duplicateRisk).length - 1, 1);
 });
 
-test("OpenClaw pull request comments render PR surface before summary", () => {
+test("OpenClaw pull request comments render PR surface inside evidence details", () => {
   const comment = renderReviewCommentFromReport(
     `${reportFrontMatter({
       repository: "openclaw/openclaw",
@@ -9146,16 +9251,21 @@ Adds a small runtime change with tests and docs.
     "none",
   );
 
-  assert.match(
-    comment,
-    /\*\*PR Surface\*\*\nSource \+8, Tests \+6, Docs \+4\. Total \+18 across 3 files\./,
+  const evidenceDetails = detailsBody(comment, "Evidence reviewed");
+
+  assert.doesNotMatch(
+    comment.slice(0, comment.indexOf("<summary>Evidence reviewed</summary>")),
+    /\*\*PR Surface\*\*/,
   );
-  assert.match(comment, /<summary>View PR surface stats<\/summary>/);
   assert.match(
-    comment,
+    evidenceDetails,
+    /PR surface:\n\nSource \+8, Tests \+6, Docs \+4\. Total \+18 across 3 files\./,
+  );
+  assert.match(evidenceDetails, /<summary>View PR surface stats<\/summary>/);
+  assert.match(
+    evidenceDetails,
     /\| \*\*Total\*\* \| \*\*3\*\* \| \*\*21\*\* \| \*\*3\*\* \| \*\*\+18\*\* \|/,
   );
-  assert.ok(comment.indexOf("**PR Surface**") < comment.indexOf("**Summary**"));
 });
 
 test("PR surface is OpenClaw pull-request only", () => {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -9309,10 +9309,19 @@ Adds a small runtime change with tests and docs.
   );
 
   const evidenceDetails = detailsBody(comment, "Evidence reviewed");
+  const visibleBeforeEvidence = comment.slice(
+    0,
+    comment.indexOf("<summary>Evidence reviewed</summary>"),
+  );
 
+  assert.match(
+    visibleBeforeEvidence,
+    /PR surface: Source \+8, Tests \+6, Docs \+4\. Total \+18 across 3 files\./,
+  );
+  assert.doesNotMatch(visibleBeforeEvidence, /<summary>View PR surface stats<\/summary>/);
   assert.doesNotMatch(
-    comment.slice(0, comment.indexOf("<summary>Evidence reviewed</summary>")),
-    /\*\*PR Surface\*\*/,
+    visibleBeforeEvidence,
+    /\| \*\*Total\*\* \| \*\*3\*\* \| \*\*21\*\* \| \*\*3\*\* \| \*\*\+18\*\* \|/,
   );
   assert.match(
     evidenceDetails,
@@ -9357,8 +9366,8 @@ Keep this open.
     "none",
   );
 
-  assert.doesNotMatch(otherRepoComment, /\*\*PR Surface\*\*/);
-  assert.doesNotMatch(issueComment, /\*\*PR Surface\*\*/);
+  assert.doesNotMatch(otherRepoComment, /PR surface:/);
+  assert.doesNotMatch(issueComment, /PR surface:/);
 });
 
 function mergeRiskReviewComment({

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -3074,6 +3074,10 @@ Full review comments:
     comment,
     /Overall follows the weaker of proof and patch quality, so missing proof can cap an otherwise strong patch\./,
   );
+  assert.match(comment, /Proof guidance:\nNeeds real behavior proof before merge:/);
+  assert.match(comment, /The PR has no real ingestion-run proof yet\./);
+  assert.match(comment, /After adding proof, update the PR body/);
+  assert.match(comment, /@clawsweeper re-review/);
   assert.match(
     labelDetails,
     /- `rating: 🧂 unranked krab`: Overall readiness is 🧂 unranked krab; proof is 🧂 unranked krab and patch quality is 🦞 diamond lobster\./,

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -487,6 +487,59 @@ Needs real behavior proof before merge.
   assert.doesNotMatch(JSON.stringify(review), /How this review workflow works/);
 });
 
+test("latest ClawSweeper durable review parser supports compact merge readiness layout", () => {
+  const latest = issueComment(
+    2,
+    `Codex review: needs real behavior proof before merge. _Reviewed May 24, 2026, 8:34 AM ET / 12:34 UTC._
+
+**Summary**
+The PR changes review comment layout.
+
+**Merge readiness**
+Overall: 🧂 unranked krab
+Proof: 🧂 unranked krab
+Patch quality: 🦞 diamond lobster
+Result: blocked until real behavior proof is added.
+
+Overall follows the weaker of proof and patch quality, so missing proof can cap an otherwise strong patch.
+
+Proof guidance:
+Needs real behavior proof before merge: The PR has no real ingestion-run proof yet. After adding proof, update the PR body; ClawSweeper should re-review automatically.
+
+**Next step before merge**
+Add real behavior proof.
+
+**Review findings**
+- [P2] Keep prior-review extraction in sync — src/clawsweeper.ts:11021
+
+<details>
+<summary>Label changes</summary>
+
+- add \`P2\`
+
+</details>
+
+<!-- clawsweeper-verdict:needs-human item=123 sha=newsha confidence=high -->
+
+<!-- clawsweeper-review item=123 -->`,
+    "clawsweeper[bot]",
+    "2026-05-24T02:00:00Z",
+  );
+
+  const review = extractLatestClawSweeperReviewForTest([latest], 123);
+
+  assert.ok(review);
+  assert.equal(review.status, "needs real behavior proof before merge.");
+  assert.equal(review.reviewedAt, "May 24, 2026, 8:34 AM ET / 12:34 UTC");
+  assert.equal(review.reviewedSha, "newsha");
+  assert.equal(review.summary, "The PR changes review comment layout.");
+  assert.equal(review.rating, "Overall: 🧂 unranked krab");
+  assert.match(review.proofStatus, /^Needs real behavior proof before merge:/);
+  assert.equal(review.nextStep, "Add real behavior proof.");
+  assert.equal(review.findings[0]?.priority, "P2");
+  assert.equal(review.findings[0]?.title, "Keep prior-review extraction in sync");
+});
+
 test("githubContextWindowPlan includes prior page when the tail crosses a page boundary", () => {
   assert.deepEqual(githubContextWindowPlan(101, 80), {
     keepStart: 40,


### PR DESCRIPTION
## Summary
- Compress PR review freshness into the verdict line.
- Replace separate visible PR rating/proof blocks with compact `Merge readiness`.
- Restore a short top-level `PR surface: ...` line while keeping the detailed PR surface table under `Evidence reviewed`.
- Move label churn, evidence, rank explanations, workflow notes, and detailed PR surface stats into focused collapsibles.
- Keep proof-blocker guidance visible when proof is missing, mock-only, or insufficient.
- Keep previous-review extraction compatible with both old and new durable comment layouts.
- Replace CodeQL-flagged regex fallback parsing with bounded string/index and line scanning.

## What stayed unchanged
- Proof, rating, label, finding, marker, and sync semantics are unchanged.
- Audit content such as `What I checked` is still rendered, now under `Evidence reviewed`.
- The existing `publicRealBehaviorProofLine` guidance is reused rather than changing proof policy.
- Old durable comments with `Latest ClawSweeper review`, `PR rating`, and `Real behavior proof` sections still parse.

## Real behavior proof
Behavior addressed: PR review comments are reorganized for faster maintainer scanning without changing ClawSweeper decision semantics.

Real environment tested: Local ClawSweeper build/test environment in `/Users/takayukihoffman/github.com/openclaw/clawsweeper-pr-review-comment-ia`, GitHub PR CI/CodeQL, and read-only live OpenClaw PR renderer smoke checks.

Exact commands run:
- `node_modules/.bin/tsgo -p tsconfig.json`
- `node_modules/.bin/oxfmt --check src/clawsweeper.ts test/clawsweeper.test.ts`
- `node --test test/clawsweeper.test.ts`
- `/Users/takayukihoffman/github.com/openclaw/clawsweeper/node_modules/.bin/oxlint src/clawsweeper.ts test/clawsweeper.test.ts --deny-warnings --report-unused-disable-directives -D correctness`
- `git diff --check`
- `node /private/tmp/clawsweeper-pr183-proof.mjs`
- `node /private/tmp/clawsweeper-live-openclaw-pr-smoke.mjs`

Evidence after fix:
- Local focused test file passed: 281 tests, 0 failures.
- Latest pushed head `87904cd2820e0afe769183eed338f31ad8bcca4d` passed GitHub `pnpm check`, CodeQL JavaScript/TypeScript, CodeQL Actions, aggregate CodeQL, and Socket checks.
- Non-test render/extraction proof confirmed `Merge readiness`, visible proof guidance, top-level PR surface summary, `Label changes`, `Evidence reviewed`, detailed PR surface stats table, and previous-review extraction all work through the production renderer/parser.
- Read-only live OpenClaw PR smoke rendered 8 currently open `openclaw/openclaw` PRs through this branch’s production renderer. All passed: visible `PR surface:` line present, detailed PR surface table hidden inside `Evidence reviewed`, `Merge readiness` present, and rendered comments stayed below GitHub’s comment size limit. Sample included 2-file, 3-file, 5-file, 7-file, 10-file, 13-file, and 75-file PR surfaces.

Observed result after fix: Generated PR review comments keep the top-level surface concise while preserving label explanations, evidence, full findings, and the detailed PR surface table in collapsibles. Proof-blocked comments retain visible contributor instructions, compact durable comments can be parsed back into prior-review context, and the compact parser avoids the CodeQL regex finding.

What was not tested: A live durable PR comment write using this branch’s renderer was not performed outside ClawSweeper’s own review workflow.

## Verification
- Local validation listed above passed.
- GitHub checks on latest pushed head are green.
- Live OpenClaw PR renderer smoke passed against 8 read-only sampled PRs.
