### PR TITLE
Fix stale closed PR re-review command handling

### DIFF
--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -1665,13 +1665,13 @@ export function hasCommandResponseMarker(body: JsonValue, command: LooseRecord):
   return text.includes(commandResponseMarker(command));
 }
 
-export function staleAutomergeActivationReason({
+export function staleClosedItemCommandReason({
   command,
   issue,
   pull = null,
 }: LooseRecord): string | null {
   const intent = String(command?.intent ?? "");
-  if (!["autofix", "automerge"].includes(intent)) return null;
+  if (!["autofix", "automerge", "re_review"].includes(intent)) return null;
 
   const closedAt = pull?.mergedAt ?? pull?.merged_at ?? issue?.closed_at ?? issue?.closedAt;
   if (!closedAt) return null;
@@ -1689,6 +1689,8 @@ export function staleAutomergeActivationReason({
   }
   return `PR closed after this ${intent} command`;
 }
+
+export const staleAutomergeActivationReason = staleClosedItemCommandReason;
 
 export function repairLoopStopPauseReason({ command, entries = [] }: LooseRecord): string | null {
   const stopAt = latestRepairLoopControlTime(entries, command, ["stop"]);

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -61,7 +61,7 @@ import {
   renderIssueImplementationJob,
   renderResponse,
   sharedAutomergeStatusMarkerPrefix,
-  staleAutomergeActivationReason,
+  staleClosedItemCommandReason,
   shouldClearMaintainerCommandReaction,
   usesSharedAutomergeStatus,
 } from "./comment-router-core.js";
@@ -428,6 +428,8 @@ function classifyCommand(command: LooseRecord): JsonValue {
   }
   if (command.intent === "re_review") {
     if (String(issue.state ?? "").toLowerCase() !== "open") {
+      const staleReason = staleClosedItemCommandReason({ command: next, issue, pull });
+      if (staleReason) return { ...next, status: "skipped", reason: staleReason };
       return {
         ...next,
         status: "ready",
@@ -525,7 +527,7 @@ function classifyCommand(command: LooseRecord): JsonValue {
     const modeLabel = command.intent === "autofix" ? AUTOFIX_LABEL : AUTOMERGE_LABEL;
     const oppositeModeLabel = command.intent === "autofix" ? AUTOMERGE_LABEL : AUTOFIX_LABEL;
     if (String(issue.state ?? "").toLowerCase() !== "open") {
-      const staleReason = staleAutomergeActivationReason({ command: next, issue, pull });
+      const staleReason = staleClosedItemCommandReason({ command: next, issue, pull });
       if (staleReason) return { ...next, status: "skipped", reason: staleReason };
       if (command.automation_source === "repair_loop_label_sweep") {
         return { ...next, status: "skipped", reason: `${mode} label sweep requires an open PR` };

--- a/src/repair/comment-webhook.ts
+++ b/src/repair/comment-webhook.ts
@@ -4,7 +4,7 @@ import http from "node:http";
 
 import { repositoryProfileFor } from "../repository-profiles.js";
 import type { JsonValue, LooseRecord } from "./json-types.js";
-import { parseCommand } from "./comment-router-core.js";
+import { parseCommand, staleClosedItemCommandReason } from "./comment-router-core.js";
 
 const DEFAULT_PORT = 8787;
 const REVIEW_REPO = "openclaw/clawsweeper";
@@ -165,6 +165,7 @@ export function classifyIssueCommentWebhook({
   if (!COMMAND_PATTERN.test(String(comment.body ?? ""))) {
     return { accepted: false, reason: "no ClawSweeper command" };
   }
+  const parsedCommand = parseCommand(String(comment.body ?? ""));
   if (
     !ALLOWED_ASSOCIATIONS.has(association) &&
     !isAuthorReadOnlyWebhookCommand({ comment, issue })
@@ -179,9 +180,19 @@ export function classifyIssueCommentWebhook({
   if (!isEligibleRepositoryPayload(repo)) {
     return { accepted: false, reason: "repository not eligible" };
   }
-  if (parseCommand(String(comment.body ?? ""))?.intent === "hatch" && !isOpenClawRepo(targetRepo)) {
+  if (parsedCommand?.intent === "hatch" && !isOpenClawRepo(targetRepo)) {
     return { accepted: false, reason: "PR egg is disabled for this repo" };
   }
+  const staleReason = staleClosedItemCommandReason({
+    command: {
+      intent: parsedCommand?.intent,
+      comment_created_at: comment.created_at,
+      comment_updated_at: comment.updated_at,
+    },
+    issue,
+    pull: issue.pull_request,
+  });
+  if (staleReason) return { accepted: false, reason: staleReason };
   const itemNumber = Number(issue.number);
   const commentId = Number(comment.id);
   const installationId = Number(asRecord(payload.installation).id);

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -382,6 +382,20 @@ test("comment router side effects are driven by planned actions", () => {
   assert.match(body, /could not start a re-review/);
   assert.match(body, /re-review requires an open issue or PR/);
   assert.doesNotMatch(body, /re-review requested/);
+
+  const staleReReview = {
+    intent: "re_review",
+    status: "skipped",
+    reason: "PR closed after this re_review command",
+  };
+
+  assert.equal(commandHasAction(staleReReview, "dispatch_clawsweeper"), false);
+  assert.equal(commandHasAction(staleReReview, "comment"), false);
+
+  const staleBody = renderResponse(staleReReview, null);
+  assert.match(staleBody, /could not start a re-review/);
+  assert.match(staleBody, /PR closed after this re_review command/);
+  assert.doesNotMatch(staleBody, /re-review requested/);
 });
 
 test("force reprocess bypasses existing command status guards", () => {

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -51,6 +51,7 @@ import {
   renderResponse,
   sharedAutomergeStatusMarkerPrefix,
   staleAutomergeActivationReason,
+  staleClosedItemCommandReason,
   shouldClearMaintainerCommandReaction,
   usesSharedAutomergeStatus,
 } from "../../dist/repair/comment-router-core.js";
@@ -501,6 +502,31 @@ test("stale automerge activation commands after merge are skipped silently", () 
       },
       issue: { state: "closed", closed_at: "2026-05-01T01:49:03Z" },
       pull: { state: "MERGED", mergedAt: "2026-05-01T01:49:03Z" },
+    }),
+    null,
+  );
+});
+
+test("stale re-review commands before PR close are skipped silently", () => {
+  assert.equal(
+    staleClosedItemCommandReason({
+      command: {
+        intent: "re_review",
+        comment_created_at: "2026-05-18T19:30:48Z",
+      },
+      issue: { state: "closed", closed_at: "2026-05-19T05:02:03Z" },
+      pull: { state: "CLOSED" },
+    }),
+    "PR closed after this re_review command",
+  );
+  assert.equal(
+    staleClosedItemCommandReason({
+      command: {
+        intent: "re_review",
+        comment_created_at: "2026-05-19T05:03:00Z",
+      },
+      issue: { state: "closed", closed_at: "2026-05-19T05:02:03Z" },
+      pull: { state: "CLOSED" },
     }),
     null,
   );

--- a/test/repair/comment-webhook.test.ts
+++ b/test/repair/comment-webhook.test.ts
@@ -87,6 +87,72 @@ test("comment webhook accepts author read-only re-review commands", () => {
   });
 });
 
+test("comment webhook rejects stale re-review commands on closed PRs before fast ack", () => {
+  const result = classifyIssueCommentWebhook({
+    event: "issue_comment",
+    payload: {
+      action: "edited",
+      repository: { full_name: "openclaw/openclaw" },
+      issue: {
+        number: 76991,
+        state: "closed",
+        closed_at: "2026-05-19T05:02:03Z",
+        pull_request: {},
+      },
+      installation: { id: 123 },
+      comment: {
+        id: 456,
+        body: "@clawsweeper re-review",
+        created_at: "2026-05-18T19:30:48Z",
+        updated_at: "2026-05-23T18:14:04Z",
+        author_association: "MEMBER",
+        user: { login: "user" },
+      },
+    },
+  });
+
+  assert.deepEqual(result, {
+    accepted: false,
+    reason: "PR closed after this re_review command",
+  });
+});
+
+test("comment webhook still accepts post-close re-review commands for router response", () => {
+  const result = classifyIssueCommentWebhook({
+    event: "issue_comment",
+    payload: {
+      action: "created",
+      repository: { full_name: "openclaw/openclaw" },
+      issue: {
+        number: 76991,
+        state: "closed",
+        closed_at: "2026-05-19T05:02:03Z",
+        pull_request: {},
+      },
+      installation: { id: 123 },
+      comment: {
+        id: 456,
+        body: "@clawsweeper re-review",
+        created_at: "2026-05-19T05:03:00Z",
+        updated_at: "2026-05-19T05:03:00Z",
+        author_association: "MEMBER",
+        user: { login: "user" },
+      },
+    },
+  });
+
+  assert.deepEqual(result, {
+    accepted: true,
+    type: "issue_comment",
+    targetRepo: "openclaw/openclaw",
+    targetBranch: "main",
+    itemNumber: 76991,
+    commentId: 456,
+    installationId: 123,
+    sourceAction: "created",
+  });
+});
+
 test("comment webhook accepts author read-only hatch commands", () => {
   const result = classifyIssueCommentWebhook({
     event: "issue_comment",


### PR DESCRIPTION
## Summary
- skip pre-close re-review commands on closed PRs without scheduling router responses
- reject stale closed-PR re-review webhook events before fast ack creation
- add regression coverage for stale pre-close and post-close command behavior

Fixes https://github.com/openclaw/clawsweeper/issues/177

## Verification
- ./node_modules/.bin/tsgo -p tsconfig.repair.json
- node --test test/repair/comment-router-core.test.ts test/repair/comment-webhook.test.ts
- npx --yes --cache /private/tmp/clawsweeper-npm-cache pnpm@10.33.2 run check