### PR TITLE
feat: add catch-all review labels

### DIFF
--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -150,10 +150,15 @@ the issue, and keep this separate from `triagePriority` and
 `impact:message-loss`: This issue is about lost, duplicated, misrouted, or suppressed channel messages.
 `impact:session-state`: This issue is about session, memory, transcript, context, or agent state drift.
 `impact:auth-provider`: This issue is about auth, provider routing, model choice, or SecretRef resolution.
-Use an empty array when no owned impact label applies. Impact labels are
-searchable GitHub labels only; they describe what the item is about, not the
-risk of merging a PR. They do not close, merge, block, or replace review
-findings.
+`impact:other`: This issue has meaningful maintainer-visible impact outside the owned taxonomy.
+Use `impact:other` only when the issue has a concrete maintainer-visible impact
+but none of the specific owned impact labels fit. Prefer a specific impact label
+over `impact:other`. Use an empty array when no meaningful owned impact signal
+applies. `impact:other` counts toward the same max of 3 labels and requires a
+matching `labelJustifications` entry that explains the actual impact. Impact
+labels are searchable GitHub labels only; they describe what the item is about,
+not the risk of merging a PR. They do not close, merge, block, or replace
+review findings.
 
 Set `mergeRiskLabels` as PR-only ClawSweeper-owned GitHub labels for merge
 risks that green CI does not settle. Use an empty array for issues. Keep these
@@ -169,6 +174,13 @@ discussion:
 `merge-risk: 🚨 security-boundary`: 🚨 Merging this PR could weaken sandboxing, authorization, credentials, or sensitive data.
 `merge-risk: 🚨 availability`: 🚨 Merging this PR could cause crashes, hangs, restart loops, stalls, or process outages.
 `merge-risk: 🚨 automation`: 🚨 Merging this PR could break CI, automerge, proof capture, label sync, or automation.
+`merge-risk: 🚨 other`: 🚨 Merging this PR has meaningful risk outside the owned taxonomy.
+Use `merge-risk: 🚨 other` only when merging the PR has a concrete risk that
+green CI does not settle but none of the specific owned merge-risk labels fit.
+Prefer a specific merge-risk label over `merge-risk: 🚨 other`. Use an empty
+array when no meaningful owned merge-risk signal applies. `merge-risk: 🚨 other`
+counts toward the same max of 3 labels and requires a matching
+`labelJustifications` entry that explains the actual risk.
 Do not treat a branch being behind the current base as proof that merging the
 PR will delete current-base-only files or commits. When GitHub reports the PR as
 mergeable or clean and the only concern is stale base drift, describe it as

--- a/schema/clawsweeper-decision.schema.json
+++ b/schema/clawsweeper-decision.schema.json
@@ -183,10 +183,11 @@
           "impact:crash-loop",
           "impact:message-loss",
           "impact:session-state",
-          "impact:auth-provider"
+          "impact:auth-provider",
+          "impact:other"
         ]
       },
-      "description": "ClawSweeper-owned GitHub impact labels for maintainers to find the affected problem class on issues. Use [] for pull requests. These describe what the issue is about, not PR merge risk. Use at most 3. impact:data-loss: This issue is about lost, corrupted, or silently dropped user/session/config data. impact:security: This issue is about security boundaries, credentials, authz, sandboxing, or sensitive data. impact:crash-loop: This issue is about crashes, hangs, restart loops, or process-level availability. impact:message-loss: This issue is about lost, duplicated, misrouted, or suppressed channel messages. impact:session-state: This issue is about session, memory, transcript, context, or agent state drift. impact:auth-provider: This issue is about auth, provider routing, model choice, or SecretRef resolution."
+      "description": "ClawSweeper-owned GitHub impact labels for maintainers to find the affected problem class on issues. Use [] for pull requests and when no meaningful owned impact signal applies. These describe what the issue is about, not PR merge risk. Use at most 3; impact:other counts toward this max and means meaningful maintainer-visible impact exists but no specific owned impact label fits. Prefer a specific impact label over impact:other. impact:data-loss: This issue is about lost, corrupted, or silently dropped user/session/config data. impact:security: This issue is about security boundaries, credentials, authz, sandboxing, or sensitive data. impact:crash-loop: This issue is about crashes, hangs, restart loops, or process-level availability. impact:message-loss: This issue is about lost, duplicated, misrouted, or suppressed channel messages. impact:session-state: This issue is about session, memory, transcript, context, or agent state drift. impact:auth-provider: This issue is about auth, provider routing, model choice, or SecretRef resolution. impact:other: This issue has meaningful maintainer-visible impact outside the owned taxonomy."
     },
     "mergeRiskLabels": {
       "type": "array",
@@ -200,10 +201,11 @@
           "merge-risk: 🚨 auth-provider",
           "merge-risk: 🚨 security-boundary",
           "merge-risk: 🚨 availability",
-          "merge-risk: 🚨 automation"
+          "merge-risk: 🚨 automation",
+          "merge-risk: 🚨 other"
         ]
       },
-      "description": "PR-only ClawSweeper-owned GitHub labels for merge risks that green CI does not settle. These describe what could go wrong specifically because this PR is merged, not the affected or solved problem class. Use at most 3 for pull requests and [] for issues. merge-risk: 🚨 compatibility: 🚨 Merging this PR could break existing users, config, migrations, defaults, or upgrades. merge-risk: 🚨 message-delivery: 🚨 Merging this PR could drop, duplicate, misroute, suppress, or wrongly target messages. merge-risk: 🚨 session-state: 🚨 Merging this PR could lose, corrupt, stale, or mis-associate session or agent state. merge-risk: 🚨 auth-provider: 🚨 Merging this PR could break OAuth, tokens, provider routing, model choice, or credentials. merge-risk: 🚨 security-boundary: 🚨 Merging this PR could weaken sandboxing, authorization, credentials, or sensitive data. merge-risk: 🚨 availability: 🚨 Merging this PR could cause crashes, hangs, restart loops, stalls, or process outages. merge-risk: 🚨 automation: 🚨 Merging this PR could break CI, automerge, proof capture, label sync, or automation."
+      "description": "PR-only ClawSweeper-owned GitHub labels for merge risks that green CI does not settle. These describe what could go wrong specifically because this PR is merged, not the affected or solved problem class. Use at most 3 for pull requests and [] for issues and when no meaningful owned merge-risk signal applies. merge-risk: 🚨 other counts toward this max and means meaningful merge risk exists but no specific owned merge-risk label fits. Prefer a specific merge-risk label over merge-risk: 🚨 other. merge-risk: 🚨 compatibility: 🚨 Merging this PR could break existing users, config, migrations, defaults, or upgrades. merge-risk: 🚨 message-delivery: 🚨 Merging this PR could drop, duplicate, misroute, suppress, or wrongly target messages. merge-risk: 🚨 session-state: 🚨 Merging this PR could lose, corrupt, stale, or mis-associate session or agent state. merge-risk: 🚨 auth-provider: 🚨 Merging this PR could break OAuth, tokens, provider routing, model choice, or credentials. merge-risk: 🚨 security-boundary: 🚨 Merging this PR could weaken sandboxing, authorization, credentials, or sensitive data. merge-risk: 🚨 availability: 🚨 Merging this PR could cause crashes, hangs, restart loops, stalls, or process outages. merge-risk: 🚨 automation: 🚨 Merging this PR could break CI, automerge, proof capture, label sync, or automation. merge-risk: 🚨 other: 🚨 Merging this PR has meaningful risk outside the owned taxonomy."
     },
     "mergeRiskOptions": {
       "type": "array",
@@ -280,13 +282,15 @@
               "impact:message-loss",
               "impact:session-state",
               "impact:auth-provider",
+              "impact:other",
               "merge-risk: 🚨 compatibility",
               "merge-risk: 🚨 message-delivery",
               "merge-risk: 🚨 session-state",
               "merge-risk: 🚨 auth-provider",
               "merge-risk: 🚨 security-boundary",
               "merge-risk: 🚨 availability",
-              "merge-risk: 🚨 automation"
+              "merge-risk: 🚨 automation",
+              "merge-risk: 🚨 other"
             ]
           },
           "reason": {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -78,7 +78,8 @@ type ImpactLabelName =
   | "impact:crash-loop"
   | "impact:message-loss"
   | "impact:session-state"
-  | "impact:auth-provider";
+  | "impact:auth-provider"
+  | "impact:other";
 type MergeRiskLabelName =
   | "merge-risk: 🚨 compatibility"
   | "merge-risk: 🚨 message-delivery"
@@ -86,7 +87,8 @@ type MergeRiskLabelName =
   | "merge-risk: 🚨 auth-provider"
   | "merge-risk: 🚨 security-boundary"
   | "merge-risk: 🚨 availability"
-  | "merge-risk: 🚨 automation";
+  | "merge-risk: 🚨 automation"
+  | "merge-risk: 🚨 other";
 type MergeRiskOptionCategory = "fix_before_merge" | "accept_risk" | "pause_or_close";
 type ReviewLabelName = Exclude<TriagePriority, "none"> | ImpactLabelName | MergeRiskLabelName;
 type ItemCategory =
@@ -1038,6 +1040,11 @@ const IMPACT_LABELS = [
     description:
       "This issue is about auth, provider routing, model choice, or SecretRef resolution.",
   },
+  {
+    name: "impact:other",
+    color: "C5DEF5",
+    description: "This issue has meaningful maintainer-visible impact outside the owned taxonomy.",
+  },
 ] as const satisfies readonly {
   name: ImpactLabelName;
   color: string;
@@ -1086,6 +1093,11 @@ const MERGE_RISK_LABELS = [
     color: "FBCA04",
     description:
       "🚨 Merging this PR could break CI, automerge, proof capture, label sync, or automation.",
+  },
+  {
+    name: "merge-risk: 🚨 other",
+    color: "C5DEF5",
+    description: "🚨 Merging this PR has meaningful risk outside the owned taxonomy.",
   },
 ] as const satisfies readonly {
   name: MergeRiskLabelName;

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -10277,6 +10277,52 @@ test("decision parser enforces required schema-shaped evidence", () => {
       }),
     /decision\.mergeRiskOptions\[0\]\.automergeInstruction requires a recommended option/,
   );
+  assert.deepEqual(
+    parseDecision(
+      closeDecision({
+        impactLabels: ["impact:other"],
+        labelJustifications: [
+          {
+            label: "P2",
+            reason: "Normal priority applies to this limited-scope implemented behavior check.",
+          },
+          {
+            label: "impact:other",
+            reason: "The issue has maintainer-visible impact outside the specific taxonomy.",
+          },
+        ],
+      }),
+    ).impactLabels,
+    ["impact:other"],
+  );
+  assert.deepEqual(
+    parseDecision(
+      closeDecision({
+        mergeRiskLabels: ["merge-risk: 🚨 other"],
+        mergeRiskOptions: [
+          {
+            title: "Validate the uncategorized risk",
+            body: "Run targeted validation for the maintainer-visible risk before merge.",
+            category: "fix_before_merge",
+            recommended: true,
+            automergeInstruction:
+              "Run targeted validation for the maintainer-visible risk before merge.",
+          },
+        ],
+        labelJustifications: [
+          {
+            label: "P2",
+            reason: "Normal priority applies to this limited-scope implemented behavior check.",
+          },
+          {
+            label: "merge-risk: 🚨 other",
+            reason: "The PR has a maintainer-visible merge risk outside the specific taxonomy.",
+          },
+        ],
+      }),
+    ).mergeRiskLabels,
+    ["merge-risk: 🚨 other"],
+  );
   assert.throws(() => {
     const decision = closeDecision();
     delete decision.labelJustifications;
@@ -11179,6 +11225,12 @@ test("ClawSweeper impact label scheme exposes owned impact labels", () => {
       description:
         "This issue is about auth, provider routing, model choice, or SecretRef resolution.",
     },
+    {
+      name: "impact:other",
+      color: "C5DEF5",
+      description:
+        "This issue has meaningful maintainer-visible impact outside the owned taxonomy.",
+    },
   ]);
 });
 
@@ -11266,6 +11318,11 @@ test("ClawSweeper merge-risk label scheme exposes PR-only merge warning labels",
       description:
         "🚨 Merging this PR could break CI, automerge, proof capture, label sync, or automation.",
     },
+    {
+      name: "merge-risk: 🚨 other",
+      color: "C5DEF5",
+      description: "🚨 Merging this PR has meaningful risk outside the owned taxonomy.",
+    },
   ]);
 });
 
@@ -11304,9 +11361,9 @@ test("ClawSweeper merge-risk labels remove stale owned labels and preserve unrel
   assert.deepEqual(
     mergeRiskLabelsForTest(
       ["bug", "merge-risk: 🚨 compatibility", "merge-risk: 🚨 availability", "impact:message-loss"],
-      ["merge-risk: 🚨 message-delivery", "merge-risk: 🚨 automation", "not-a-merge-risk-label"],
+      ["merge-risk: 🚨 message-delivery", "merge-risk: 🚨 other", "not-a-merge-risk-label"],
     ),
-    ["bug", "impact:message-loss", "merge-risk: 🚨 message-delivery", "merge-risk: 🚨 automation"],
+    ["bug", "impact:message-loss", "merge-risk: 🚨 message-delivery", "merge-risk: 🚨 other"],
   );
   assert.deepEqual(mergeRiskLabelsForTest(["bug", "merge-risk: 🚨 auth-provider"], []), ["bug"]);
 });
@@ -11315,9 +11372,9 @@ test("ClawSweeper impact labels remove stale owned labels and preserve unrelated
   assert.deepEqual(
     impactLabelsForTest(
       ["bug", "impact:data-loss", "impact:security", "proof: sufficient", "P1"],
-      ["impact:message-loss", "impact:session-state", "not-an-impact-label"],
+      ["impact:message-loss", "impact:other", "not-an-impact-label"],
     ),
-    ["bug", "proof: sufficient", "P1", "impact:message-loss", "impact:session-state"],
+    ["bug", "proof: sufficient", "P1", "impact:message-loss", "impact:other"],
   );
   assert.deepEqual(impactLabelsForTest(["bug", "impact:auth-provider"], []), ["bug"]);
 });


### PR DESCRIPTION
## Summary
- add catch-all impact and merge-risk labels to the owned label taxonomy
- allow both labels in the decision schema and label justifications
- document specific-label preference, empty-array semantics, and justification requirements in the review prompt
- add parser, scheme, and label sync coverage

Fixes https://github.com/openclaw/clawsweeper/issues/187

## Maintainer acceptance
- Maintainer acceptance recorded in this Codex thread on May 25, 2026: continue this PR until clean, then merge it.
- The catch-all labels are intended taxonomy additions, not a replacement for `[]` or for more specific labels.

## Real behavior proof
Focused parser and label-sync proof from the PR branch:

```text
$ node --test --test-name-pattern "decision parser enforces required schema-shaped evidence|ClawSweeper impact label scheme exposes owned impact labels|ClawSweeper merge-risk label scheme exposes PR-only merge warning labels|ClawSweeper impact labels remove stale owned labels and preserve unrelated labels|ClawSweeper merge-risk labels remove stale owned labels and preserve unrelated labels" test/clawsweeper.test.ts
✔ decision parser enforces required schema-shaped evidence (3.442958ms)
✔ ClawSweeper impact label scheme exposes owned impact labels (0.145458ms)
✔ ClawSweeper merge-risk label scheme exposes PR-only merge warning labels (0.075792ms)
✔ ClawSweeper merge-risk labels remove stale owned labels and preserve unrelated labels (0.087708ms)
✔ ClawSweeper impact labels remove stale owned labels and preserve unrelated labels (0.070375ms)
ℹ tests 5
ℹ suites 0
ℹ pass 5
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 168.775209
```

This proves the real decision parser accepts the new catch-all labels, the exported owned label schemes expose them, and the label replacement helpers sync them while preserving unrelated labels.

## Validation
- pnpm run check
