### PR TITLE
Fix PR merge drift review context

### DIFF
--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -169,6 +169,14 @@ discussion:
 `merge-risk: 🚨 security-boundary`: 🚨 Merging this PR could weaken sandboxing, authorization, credentials, or sensitive data.
 `merge-risk: 🚨 availability`: 🚨 Merging this PR could cause crashes, hangs, restart loops, stalls, or process outages.
 `merge-risk: 🚨 automation`: 🚨 Merging this PR could break CI, automerge, proof capture, label sync, or automation.
+Do not treat a branch being behind the current base as proof that merging the
+PR will delete current-base-only files or commits. When GitHub reports the PR as
+mergeable or clean and the only concern is stale base drift, describe it as
+needing rebase or review refresh in `risks`, `workReason`, or `bestSolution`,
+but leave `reviewFindings` and `mergeRiskLabels` focused on defects or risks
+that survive the actual three-way merge result. Use deletion/drop wording for
+current-base behavior only when a merge result, merge ref, conflict, or concrete
+patch evidence shows that the merged PR would remove or regress it.
 When merge risk is present, explain it in `risks` in maintainer-facing language
 and make `bestSolution` the best end state. Fill `mergeRiskOptions` with 1-3
 risk-specific maintainer options. Do not use a fixed menu. Each option needs a

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -2892,6 +2892,7 @@ function compactPullRequest(value: unknown): unknown {
     mergedAt: pull.merged_at,
     mergeCommitSha: pull.merge_commit_sha,
     mergeable: pull.mergeable,
+    mergeableState: pull.mergeable_state,
     author: login(pull.user),
     head: {
       ref: head.ref,
@@ -2908,6 +2909,10 @@ function compactPullRequest(value: unknown): unknown {
     updatedAt: pull.updated_at,
     body: truncateText(pull.body, 12000),
   };
+}
+
+export function compactPullRequestForTest(value: unknown): unknown {
+  return compactPullRequest(value);
 }
 
 interface ClosingPullRequestReference {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -28,6 +28,7 @@ import {
   closingPullRequestReferenceTarget,
   compactMappedSlice,
   compactMappedWindow,
+  compactPullRequestForTest,
   codexEnv,
   dashboardClosedAt,
   extractLatestClawSweeperReviewForTest,
@@ -865,6 +866,39 @@ test("review prompt includes compact previous review state without raw durable r
   assert.match(prompt, /"commentsFiltered": 2/);
   assert.doesNotMatch(prompt, /How this review workflow works/);
   assert.doesNotMatch(prompt, /clawsweeper-pr-egg-hatch/);
+});
+
+test("review prompt includes merge state and guards clean behind-branch drift", () => {
+  const compactPullRequest = compactPullRequestForTest({
+    number: 123,
+    title: "Sample PR",
+    html_url: "https://github.com/openclaw/openclaw/pull/123",
+    state: "open",
+    draft: false,
+    merged: false,
+    mergeable: true,
+    mergeable_state: "clean",
+    head: { ref: "feature", sha: "head123" },
+    base: { ref: "main", sha: "base123" },
+    user: { login: "contributor" },
+    additions: 10,
+    deletions: 2,
+    changed_files: 1,
+  });
+  const context = {
+    issue: { number: 123, title: "Sample PR" },
+    comments: [],
+    timeline: [],
+    pullRequest: compactPullRequest,
+    counts: { comments: 0, timeline: 0 },
+  };
+
+  const prompt = reviewPromptForTest(item({ kind: "pull_request", number: 123 }), context, git);
+
+  assert.deepEqual((compactPullRequest as { mergeableState?: unknown }).mergeableState, "clean");
+  assert.match(prompt, /"mergeableState": "clean"/);
+  assert.match(prompt, /Do not treat a branch being behind the current base as proof/);
+  assert.match(prompt, /actual three-way merge result/);
 });
 
 test("review context ledger records ordered section budgets", () => {


### PR DESCRIPTION
## Summary
- expose REST mergeable_state in compact PR review context
- tell PR review prompts not to treat clean behind-base drift as deleting current-base-only changes
- add regression coverage for the compact context and prompt guard

Fixes https://github.com/openclaw/clawsweeper/issues/119

## Validation
- pnpm run check
- node --test test/clawsweeper.test.ts --test-name-pattern 'review prompt includes merge state and guards clean behind-branch drift'

## Real behavior proof
Focused regression proof from the local terminal after the fix:

```text
$ node --test test/clawsweeper.test.ts --test-name-pattern 'review prompt includes merge state and guards clean behind-branch drift'
✔ review prompt includes merge state and guards clean behind-branch drift (0.129ms)
ℹ tests 282
ℹ pass 282
ℹ fail 0
```

Direct prompt/context generation proof from the built ClawSweeper code path after the fix:

```text
$ node --input-type=module -e 'import { compactPullRequestForTest, reviewPromptForTest } from ./dist/clawsweeper.js; /* render compact PR context into review prompt */'
compact pullRequest mergeableState: clean
prompt contains mergeableState clean: true
prompt contains behind-base drift guard: true
```

This compacts REST PR data with `mergeable_state: "clean"`, renders it through ClawSweeper's review prompt builder, and verifies the resulting prompt includes both `mergeableState: "clean"` and the clean behind-branch drift guard.