### PR TITLE
Require proof before superseded PR closeout

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1815,6 +1815,13 @@ jobs:
         with:
           build-script: build:all
 
+      - uses: ./.github/actions/setup-codex
+        if: ${{ !((github.event_name == 'repository_dispatch' && github.event.action == 'clawsweeper_hatch') || (github.event_name == 'workflow_dispatch' && github.event.inputs.apply_sync_comments_only == 'true') || (github.event_name == 'schedule' && github.event.schedule == '6,21,36,51 * * * *')) }}
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        with:
+          login-status: "true"
+
       - name: Sync before applying decisions
         run: git pull --rebase
 

--- a/prompts/repair/replacement-closeout-proof.md
+++ b/prompts/repair/replacement-closeout-proof.md
@@ -10,7 +10,7 @@ Hard rules:
 - Do not require exact patch-line equality. A replacement can cover the same behavior with different code shape.
 - Return `superseded` only when PR B clearly covers PR A's useful work and PR A has no unique behavior, file concern, proof, discussion, or review point needing separate maintainer review.
 - Return `keep_open` for anything else, including related PRs, incomplete proof, thin context, or uncertainty.
-- If PR A looks security-sensitive, set `securityBlocked: true` and return `keep_open`.
+- If PR A looks security-sensitive, include that in your comparison. Set `securityBlocked: true` only when security-sensitive context prevents proving that PR B covers PR A.
 - Do not ask for more context.
 
 Return only JSON matching the supplied schema.

--- a/prompts/repair/replacement-closeout-proof.md
+++ b/prompts/repair/replacement-closeout-proof.md
@@ -1,0 +1,16 @@
+You are ClawSweeper's read-only replacement closeout proof checker.
+
+Decide whether PR B can safely close PR A as superseded.
+
+Hard rules:
+- You only have two decisions: `superseded` or `keep_open`.
+- PR B may be user-authored and may have a different author from PR A.
+- A source list or `supersedes #A` text is only a candidate signal.
+- Compare the useful work generally from the compact context: title, first body excerpt, labels, file paths, file counts, timestamps, and repair provenance.
+- Do not require exact patch-line equality. A replacement can cover the same behavior with different code shape.
+- Return `superseded` only when PR B clearly covers PR A's useful work and PR A has no unique behavior, file concern, proof, discussion, or review point needing separate maintainer review.
+- Return `keep_open` for anything else, including related PRs, incomplete proof, thin context, or uncertainty.
+- If PR A looks security-sensitive, set `securityBlocked: true` and return `keep_open`.
+- Do not ask for more context.
+
+Return only JSON matching the supplied schema.

--- a/prompts/repair/replacement-closeout-proof.md
+++ b/prompts/repair/replacement-closeout-proof.md
@@ -10,7 +10,8 @@ Hard rules:
 - Do not require exact patch-line equality. A replacement can cover the same behavior with different code shape.
 - Return `superseded` only when PR B clearly covers PR A's useful work and PR A has no unique behavior, file concern, proof, discussion, or review point needing separate maintainer review.
 - Return `keep_open` for anything else, including related PRs, incomplete proof, thin context, or uncertainty.
-- If PR A looks security-sensitive, include that in your comparison. Set `securityBlocked: true` only when security-sensitive context prevents proving that PR B covers PR A.
+- Security-sensitive work is not a separate close blocker. Treat security labels, CVE/GHSA text, and ClawSweeper security markers as PR A content to compare. If PR B proves it covers that content, PR A can be `superseded`.
+- Use `securityBlocked: true` only when PR A has security-sensitive content that PR B does not prove it covers. Also list that uncovered content in `uniqueSourceWork`.
 - Do not ask for more context.
 
 Return only JSON matching the supplied schema.

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -169,6 +169,14 @@ discussion:
 `merge-risk: 🚨 security-boundary`: 🚨 Merging this PR could weaken sandboxing, authorization, credentials, or sensitive data.
 `merge-risk: 🚨 availability`: 🚨 Merging this PR could cause crashes, hangs, restart loops, stalls, or process outages.
 `merge-risk: 🚨 automation`: 🚨 Merging this PR could break CI, automerge, proof capture, label sync, or automation.
+Do not treat a branch being behind the current base as proof that merging the
+PR will delete current-base-only files or commits. When GitHub reports the PR as
+mergeable or clean and the only concern is stale base drift, describe it as
+needing rebase or review refresh in `risks`, `workReason`, or `bestSolution`,
+but leave `reviewFindings` and `mergeRiskLabels` focused on defects or risks
+that survive the actual three-way merge result. Use deletion/drop wording for
+current-base behavior only when a merge result, merge ref, conflict, or concrete
+patch evidence shows that the merged PR would remove or regress it.
 When merge risk is present, explain it in `risks` in maintainer-facing language
 and make `bestSolution` the best end state. Fill `mergeRiskOptions` with 1-3
 risk-specific maintainer options. Do not use a fixed menu. Each option needs a

--- a/prompts/supersession-proof.md
+++ b/prompts/supersession-proof.md
@@ -10,7 +10,7 @@ Hard rules:
 - Do not require exact patch-line equality. A replacement can cover the same behavior with different code shape.
 - Return `superseded` only when PR B clearly covers PR A's useful work and PR A has no unique behavior, file concern, proof, discussion, or review point needing separate maintainer review.
 - Return `keep_open` for anything else, including related PRs, incomplete proof, thin context, or uncertainty.
-- If PR A looks security-sensitive, including security labels, CVE/GHSA text, or ClawSweeper security markers, set `securityBlocked: true` and return `keep_open`.
+- If PR A looks security-sensitive, including security labels, CVE/GHSA text, or ClawSweeper security markers, include that in your comparison. Set `securityBlocked: true` only when security-sensitive context prevents proving that PR B covers PR A.
 - `coveredWork` must describe concrete PR A work that PR B covers.
 - `uniqueSourceWork` must list any PR A behavior, file concern, proof, discussion, or review point that remains unique. Use an empty array only when none remains.
 - Do not ask for more context.

--- a/prompts/supersession-proof.md
+++ b/prompts/supersession-proof.md
@@ -1,0 +1,18 @@
+You are ClawSweeper's read-only supersession proof checker.
+
+Decide whether PR B can safely supersede PR A.
+
+Hard rules:
+- You only have two decisions: `superseded` or `keep_open`.
+- PR B may be user-authored and may have a different author from PR A.
+- Text such as `supersedes #A` is only a candidate signal.
+- Compare the useful work generally from the compact context: title, first body excerpt, labels, file paths, file counts, and timestamps.
+- Do not require exact patch-line equality. A replacement can cover the same behavior with different code shape.
+- Return `superseded` only when PR B clearly covers PR A's useful work and PR A has no unique behavior, file concern, proof, discussion, or review point needing separate maintainer review.
+- Return `keep_open` for anything else, including related PRs, incomplete proof, thin context, or uncertainty.
+- If PR A looks security-sensitive, including security labels, CVE/GHSA text, or ClawSweeper security markers, set `securityBlocked: true` and return `keep_open`.
+- `coveredWork` must describe concrete PR A work that PR B covers.
+- `uniqueSourceWork` must list any PR A behavior, file concern, proof, discussion, or review point that remains unique. Use an empty array only when none remains.
+- Do not ask for more context.
+
+Return only JSON matching the supplied schema.

--- a/prompts/supersession-proof.md
+++ b/prompts/supersession-proof.md
@@ -10,7 +10,8 @@ Hard rules:
 - Do not require exact patch-line equality. A replacement can cover the same behavior with different code shape.
 - Return `superseded` only when PR B clearly covers PR A's useful work and PR A has no unique behavior, file concern, proof, discussion, or review point needing separate maintainer review.
 - Return `keep_open` for anything else, including related PRs, incomplete proof, thin context, or uncertainty.
-- If PR A looks security-sensitive, including security labels, CVE/GHSA text, or ClawSweeper security markers, include that in your comparison. Set `securityBlocked: true` only when security-sensitive context prevents proving that PR B covers PR A.
+- Security-sensitive work is not a separate close blocker. Treat security labels, CVE/GHSA text, and ClawSweeper security markers as PR A content to compare. If PR B proves it covers that content, PR A can be `superseded`.
+- Use `securityBlocked: true` only when PR A has security-sensitive content that PR B does not prove it covers. Also list that uncovered content in `uniqueSourceWork`.
 - `coveredWork` must describe concrete PR A work that PR B covers.
 - `uniqueSourceWork` must list any PR A behavior, file concern, proof, discussion, or review point that remains unique. Use an empty array only when none remains.
 - Do not ask for more context.

--- a/schema/clawsweeper-supersession-proof.schema.json
+++ b/schema/clawsweeper-supersession-proof.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "sourceSummary",
+    "replacementSummary",
+    "coveredWork",
+    "uniqueSourceWork",
+    "securityBlocked",
+    "decision",
+    "reason"
+  ],
+  "properties": {
+    "sourceSummary": {
+      "type": "string",
+      "description": "Concrete summary of the useful work in PR A."
+    },
+    "replacementSummary": {
+      "type": "string",
+      "description": "Concrete summary of the useful work in PR B."
+    },
+    "coveredWork": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Concrete PR A behavior, file concerns, proof, or review points that PR B covers."
+    },
+    "uniqueSourceWork": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Any PR A work that PR B does not cover and still needs separate review."
+    },
+    "securityBlocked": {
+      "type": "boolean",
+      "description": "True when PR A has security-sensitive context and must not be auto-closed."
+    },
+    "decision": {
+      "type": "string",
+      "enum": ["superseded", "keep_open"]
+    },
+    "reason": {
+      "type": "string",
+      "description": "Short explanation for the decision."
+    }
+  }
+}

--- a/schema/clawsweeper-supersession-proof.schema.json
+++ b/schema/clawsweeper-supersession-proof.schema.json
@@ -32,7 +32,7 @@
     },
     "securityBlocked": {
       "type": "boolean",
-      "description": "True when PR A has security-sensitive context and must not be auto-closed."
+      "description": "True only when PR A has security-sensitive content that PR B does not prove it covers. Security-sensitive content is not a standalone close blocker when coverage is proven."
     },
     "decision": {
       "type": "string",

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -44,12 +44,10 @@ import {
   renderOpenClawPrSurfaceTable,
   type PrSurfaceFile,
 } from "./pr-surface-stats.js";
-import { hasSecuritySignal } from "./repair/security-signals.js";
 import {
   compactSupersessionProofView,
   normalizedSupersessionProofModelResult,
   parseSupersessionProofModelResult,
-  supersessionProofViewContextTruncated,
   type SupersessionProofModelResult,
 } from "./supersession-proof.js";
 import {
@@ -9936,10 +9934,6 @@ interface SupersessionProof {
   reason: string;
   replacementUrl: string;
   replacementStateText: string;
-  replacementState: string;
-  replacementMergedAt: string | null;
-  replacementHeadSha: string | null;
-  replacementUpdatedAt: string | null;
 }
 
 interface SupersessionProofRuntime {
@@ -10129,40 +10123,6 @@ function formatProofDetailList(values: readonly string[]): string {
   return values.map((value) => `  - ${value}`).join("\n");
 }
 
-function labelRecords(labels: readonly string[]): Array<Record<string, string>> {
-  return labels.map((name) => ({ name }));
-}
-
-function sourcePullRequestHasSecuritySignal(
-  item: Item,
-  context: ItemContext,
-  markdown: string,
-): boolean {
-  if (reportSecurityReview(markdown).status === "needs_attention") return true;
-  if (
-    mergeRiskLabelsFromReport(markdown).some(
-      (label) =>
-        label === "merge-risk: 🚨 security-boundary" || label === "merge-risk: 🚨 auth-provider",
-    )
-  ) {
-    return true;
-  }
-  return hasSecuritySignal({
-    labels: labelRecords(item.labels),
-    comments: [
-      ...context.comments,
-      ...(context.pullReviews ?? []),
-      ...(context.pullReviewComments ?? []),
-    ],
-    text: [
-      context.issue,
-      context.pullRequest,
-      reviewSectionValue(markdown, "summary"),
-      reviewSectionValue(markdown, "securityReview"),
-    ],
-  });
-}
-
 function hydratedSourceSupersessionPullRequest(
   item: Item,
   context: ItemContext,
@@ -10289,10 +10249,6 @@ function linkOnlySupersessionProof(options: {
     replacementStateText: options.replacement
       ? supersessionReplacementStateText(options.replacement)
       : "candidate replacement",
-    replacementState: options.replacement?.state ?? "",
-    replacementMergedAt: options.replacement?.mergedAt ?? null,
-    replacementHeadSha: options.replacement?.headSha ?? null,
-    replacementUpdatedAt: options.replacement?.updatedAt ?? null,
   };
 }
 
@@ -10447,11 +10403,7 @@ function supersessionProof(options: {
   runtime: SupersessionProofRuntime;
 }): SupersessionProof {
   const source = hydratedSourceSupersessionPullRequest(options.item, options.context);
-  const securityBlocked = sourcePullRequestHasSecuritySignal(
-    options.item,
-    options.context,
-    options.markdown,
-  );
+  const securityBlocked = false;
   let replacement: HydratedSupersessionPullRequest;
   try {
     replacement = hydrateReplacementSupersessionPullRequest(options.linkedNumber);
@@ -10473,26 +10425,6 @@ function supersessionProof(options: {
     });
   }
 
-  if (securityBlocked) {
-    return linkOnlySupersessionProof({
-      source,
-      replacement,
-      replacementNumber: options.linkedNumber,
-      securityBlocked,
-      reason: "source PR has security-sensitive labels, comments, or advisory markers",
-    });
-  }
-
-  if (source.filesTruncated || replacement.filesTruncated) {
-    return linkOnlySupersessionProof({
-      source,
-      replacement,
-      replacementNumber: options.linkedNumber,
-      securityBlocked,
-      reason: "source or replacement file context is truncated",
-    });
-  }
-
   if (source.filePaths.length === 0 || replacement.filePaths.length === 0) {
     return linkOnlySupersessionProof({
       source,
@@ -10500,19 +10432,6 @@ function supersessionProof(options: {
       replacementNumber: options.linkedNumber,
       securityBlocked,
       reason: "source or replacement file context is missing",
-    });
-  }
-
-  if (
-    supersessionProofViewContextTruncated(source) ||
-    supersessionProofViewContextTruncated(replacement)
-  ) {
-    return linkOnlySupersessionProof({
-      source,
-      replacement,
-      replacementNumber: options.linkedNumber,
-      securityBlocked,
-      reason: "source or replacement proof context is truncated",
     });
   }
 
@@ -10536,14 +10455,6 @@ function supersessionProof(options: {
     });
   }
 
-  if (modelProof.securityBlocked) {
-    modelProof = {
-      ...modelProof,
-      decision: "keep_open",
-      reason: modelProof.reason || "model found source PR security-sensitive context",
-    };
-  }
-
   return {
     sourceSummary: modelProof.sourceSummary,
     replacementSummary: modelProof.replacementSummary,
@@ -10554,23 +10465,7 @@ function supersessionProof(options: {
     reason: modelProof.reason,
     replacementUrl: replacement.url,
     replacementStateText: supersessionReplacementStateText(replacement),
-    replacementState: replacement.state,
-    replacementMergedAt: replacement.mergedAt,
-    replacementHeadSha: replacement.headSha,
-    replacementUpdatedAt: replacement.updatedAt,
   };
-}
-
-function supersessionReplacementChangedAfterProof(
-  proof: SupersessionProof,
-  replacement: HydratedSupersessionPullRequest,
-): boolean {
-  return (
-    replacement.state !== proof.replacementState ||
-    replacement.mergedAt !== proof.replacementMergedAt ||
-    replacement.headSha !== proof.replacementHeadSha ||
-    replacement.updatedAt !== proof.replacementUpdatedAt
-  );
 }
 
 function recommendedPauseOrCloseOption(markdown: string): MergeRiskOption | null {
@@ -10645,30 +10540,6 @@ function linkedPullRequestSupersessionPromotion(
     runtime,
   });
   if (proof.decision !== "close") return { candidateFound: true, promotion: null };
-  const refreshed = fetchItem(item.number);
-  if (refreshed.state !== "open") return { candidateFound: true, promotion: null };
-  const refreshedContext = collectItemContext(refreshed.item, { fullTimelineForRelations: true });
-  if (refreshed.item.updatedAt !== item.updatedAt) {
-    return { candidateFound: true, promotion: null };
-  }
-  if (closePromotionHasNonAutomationActivityAfterReview(markdown, refreshedContext)) {
-    return { candidateFound: true, promotion: null };
-  }
-  if (itemSnapshotHash(refreshed.item, refreshedContext) !== itemSnapshotHash(item, context)) {
-    return { candidateFound: true, promotion: null };
-  }
-  let refreshedReplacement: HydratedSupersessionPullRequest;
-  try {
-    refreshedReplacement = hydrateReplacementSupersessionPullRequest(linkedPull.number);
-  } catch {
-    return { candidateFound: true, promotion: null };
-  }
-  if (supersessionReplacementChangedAfterProof(proof, refreshedReplacement)) {
-    return { candidateFound: true, promotion: null };
-  }
-  if (!supersessionReplacementCanClose(refreshedReplacement)) {
-    return { candidateFound: true, promotion: null };
-  }
   return {
     candidateFound: true,
     promotion: {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -44,6 +44,13 @@ import {
   renderOpenClawPrSurfaceTable,
   type PrSurfaceFile,
 } from "./pr-surface-stats.js";
+import { hasSecuritySignal } from "./repair/security-signals.js";
+import {
+  compactSupersessionProofView,
+  normalizedSupersessionProofModelResult,
+  parseSupersessionProofModelResult,
+  type SupersessionProofModelResult,
+} from "./supersession-proof.js";
 import {
   boolArg,
   itemNumbersArg,
@@ -818,6 +825,12 @@ const DEFAULT_SERVICE_TIER = "";
 const REVIEW_POLICY_VERSION = "2026-05-17-policy-v18";
 const REVIEW_ITEM_PROMPT_PATH = join(ROOT, "prompts", "review-item.md");
 const CLAWSWEEPER_DECISION_SCHEMA_PATH = join(ROOT, "schema", "clawsweeper-decision.schema.json");
+const CLAWSWEEPER_SUPERSESSION_PROOF_SCHEMA_PATH = join(
+  ROOT,
+  "schema",
+  "clawsweeper-supersession-proof.schema.json",
+);
+const SUPERSESSION_PROOF_PROMPT_PATH = join(ROOT, "prompts", "supersession-proof.md");
 const REVIEW_COMMENT_MARKER_PREFIX = "<!-- clawsweeper-review";
 const REVIEW_START_STATUS_MARKER_PREFIX = "<!-- clawsweeper-review-status";
 const AUTOMERGE_LABEL = "clawsweeper:automerge";
@@ -1769,6 +1782,7 @@ function sha256(text: string): string {
 
 let reviewPromptTemplateCache: string | undefined;
 let reviewDecisionSchemaCache: string | undefined;
+let supersessionProofPromptTemplateCache: string | undefined;
 
 function itemSnapshotHash(item: Item, context: ItemContext): string {
   const snapshotItem = {
@@ -5351,6 +5365,11 @@ function reviewTargetBranch(openclawDir: string): string {
 export function reviewPromptTemplate(): string {
   reviewPromptTemplateCache ??= readFileSync(REVIEW_ITEM_PROMPT_PATH, "utf8");
   return reviewPromptTemplateCache;
+}
+
+function supersessionProofPromptTemplate(): string {
+  supersessionProofPromptTemplateCache ??= readFileSync(SUPERSESSION_PROOF_PROMPT_PATH, "utf8");
+  return supersessionProofPromptTemplateCache;
 }
 
 export function reviewDecisionSchemaText(): string {
@@ -9820,6 +9839,44 @@ interface PullRequestClosePromotion {
   closeComment: string;
 }
 
+interface HydratedSupersessionPullRequest {
+  number: number;
+  title: string;
+  url: string;
+  state: string;
+  mergedAt: string | null;
+  body: string;
+  labels: string[];
+  headSha: string | null;
+  updatedAt: string | null;
+  filePaths: string[];
+  filesHydrated: number;
+  filesTruncated: boolean;
+}
+
+type SupersessionProofDecision = "close" | "link_only" | "keep_open";
+
+interface SupersessionProof {
+  sourceSummary: string;
+  replacementSummary: string;
+  coveredWork: string[];
+  uniqueSourceWork: string[];
+  securityBlocked: boolean;
+  decision: SupersessionProofDecision;
+  reason: string;
+  replacementUrl: string;
+  replacementStateText: string;
+}
+
+interface SupersessionProofRuntime {
+  model: string;
+  reasoningEffort: string;
+  sandboxMode: string;
+  serviceTier: string;
+  timeoutMs: number;
+  workDir: string;
+}
+
 function upgradePullRequestClosePromotionReport(
   markdown: string,
   item: Item,
@@ -9975,6 +10032,364 @@ function linkedPullRequestSupersession(
   return null;
 }
 
+function compactProofText(value: unknown, limit = 200): string {
+  if (typeof value !== "string") return "";
+  return truncateText(value.replace(/\s+/g, " ").trim(), limit);
+}
+
+function uniqueFilePaths(values: readonly string[]): string[] {
+  return [...new Set(values.filter((value) => value.trim()).map((value) => value.trim()))].sort();
+}
+
+function formatProofFileList(paths: readonly string[]): string {
+  if (!paths.length) return "no hydrated files";
+  const shown = paths.slice(0, 8).map((path) => `\`${path}\``);
+  const remaining = paths.length - shown.length;
+  return remaining > 0 ? `${shown.join(", ")} and ${remaining} more` : shown.join(", ");
+}
+
+function formatProofDetailList(values: readonly string[]): string {
+  if (!values.length) return "  - none";
+  return values.map((value) => `  - ${value}`).join("\n");
+}
+
+function labelRecords(labels: readonly string[]): Array<Record<string, string>> {
+  return labels.map((name) => ({ name }));
+}
+
+function sourcePullRequestHasSecuritySignal(
+  item: Item,
+  context: ItemContext,
+  markdown: string,
+): boolean {
+  return hasSecuritySignal({
+    labels: labelRecords(item.labels),
+    comments: [...context.comments, ...(context.pullReviewComments ?? [])],
+    text: [
+      context.issue,
+      context.pullRequest,
+      reviewSectionValue(markdown, "summary"),
+      reviewSectionValue(markdown, "securityReview"),
+    ],
+  });
+}
+
+function hydratedSourceSupersessionPullRequest(
+  item: Item,
+  context: ItemContext,
+): HydratedSupersessionPullRequest {
+  const issue = asRecord(context.issue);
+  const pull = asRecord(context.pullRequest);
+  return {
+    number: item.number,
+    title: item.title,
+    url: item.url,
+    state: "open",
+    mergedAt: null,
+    body: stringOrUndefined(pull.body) ?? stringOrUndefined(issue.body) ?? "",
+    labels: item.labels,
+    headSha: stringOrUndefined(asRecord(pull.head).sha) ?? null,
+    updatedAt: item.updatedAt,
+    filePaths: uniqueFilePaths(pullRequestFilePathsFromContext(context)),
+    filesHydrated: context.counts?.pullFilesHydrated ?? context.pullFiles?.length ?? 0,
+    filesTruncated: Boolean(context.counts?.pullFilesTruncated),
+  };
+}
+
+function hydrateReplacementSupersessionPullRequest(
+  number: number,
+): HydratedSupersessionPullRequest {
+  const pull = asRecord(ghJson<unknown>(["api", `repos/${targetRepo()}/pulls/${number}`]));
+  const issue = asRecord(ghJson<unknown>(["api", `repos/${targetRepo()}/issues/${number}`]));
+  const changedFiles = numberOrUndefined(pull.changed_files);
+  const filesWindow = ghPagedContextWindow<unknown>(
+    `repos/${targetRepo()}/pulls/${number}/files`,
+    changedFiles,
+    80,
+  );
+  return {
+    number,
+    title: stringOrUndefined(pull.title) ?? stringOrUndefined(issue.title) ?? `PR #${number}`,
+    url:
+      stringOrUndefined(pull.html_url) ??
+      stringOrUndefined(issue.html_url) ??
+      pullRequestUrlForNumber(number),
+    state: stringOrUndefined(pull.state)?.toLowerCase() ?? "",
+    mergedAt: stringOrUndefined(pull.merged_at) ?? null,
+    body: stringOrUndefined(pull.body) ?? stringOrUndefined(issue.body) ?? "",
+    labels: labelNames(issue.labels),
+    headSha: stringOrUndefined(asRecord(pull.head).sha) ?? null,
+    updatedAt: stringOrUndefined(pull.updated_at) ?? stringOrUndefined(issue.updated_at) ?? null,
+    filePaths: uniqueFilePaths(filesWindow.items.flatMap(compactPullFilePaths)),
+    filesHydrated: filesWindow.hydrated,
+    filesTruncated: filesWindow.truncated,
+  };
+}
+
+function summarizeSupersessionPullRequest(pull: HydratedSupersessionPullRequest): string {
+  const body = compactProofText(pull.body);
+  const bodyText = body ? ` Body: ${body}` : "";
+  const headText = pull.headSha ? ` Head: ${pull.headSha}.` : "";
+  const labelsText = pull.labels.length ? ` Labels: ${pull.labels.join(", ")}.` : "";
+  return `#${pull.number} ${pull.title}. Files: ${formatProofFileList(pull.filePaths)}.${headText}${labelsText}${bodyText}`;
+}
+
+function supersessionReplacementStateText(
+  replacement: Pick<HydratedSupersessionPullRequest, "mergedAt">,
+): string {
+  return replacement.mergedAt
+    ? `merged at ${replacement.mergedAt}`
+    : "still open as the candidate replacement";
+}
+
+function linkOnlySupersessionProof(options: {
+  source: HydratedSupersessionPullRequest;
+  replacementNumber: number;
+  replacement?: HydratedSupersessionPullRequest;
+  securityBlocked: boolean;
+  reason: string;
+  decision?: SupersessionProofDecision;
+  coveredWork?: string[];
+  uniqueSourceWork?: string[];
+}): SupersessionProof {
+  return {
+    sourceSummary: summarizeSupersessionPullRequest(options.source),
+    replacementSummary: options.replacement
+      ? summarizeSupersessionPullRequest(options.replacement)
+      : `#${options.replacementNumber} could not be hydrated from GitHub.`,
+    coveredWork: options.coveredWork ?? [],
+    uniqueSourceWork: options.uniqueSourceWork ?? options.source.filePaths,
+    securityBlocked: options.securityBlocked,
+    decision: options.decision ?? "link_only",
+    reason: options.reason,
+    replacementUrl: options.replacement?.url ?? pullRequestUrlForNumber(options.replacementNumber),
+    replacementStateText: options.replacement
+      ? supersessionReplacementStateText(options.replacement)
+      : "candidate replacement",
+  };
+}
+
+function supersessionSignalSnippets(
+  markdown: string,
+  currentNumber: number,
+  linkedNumber: number,
+): string[] {
+  const texts = [
+    ...frontMatterStringArray(markdown, "work_cluster_refs"),
+    ...mergeRiskOptionsFromReport(markdown).flatMap((option) => [option.title, option.body]),
+    reviewSectionValue(markdown, "bestSolution"),
+    reviewSectionValue(markdown, "evidence"),
+  ];
+  return texts
+    .filter((text) => textHasLinkedPullRequest(text, currentNumber, linkedNumber))
+    .map((text) => compactProofText(text, 500))
+    .filter(Boolean)
+    .slice(0, 4);
+}
+
+function buildSupersessionProofPrompt(options: {
+  source: HydratedSupersessionPullRequest;
+  replacement: HydratedSupersessionPullRequest;
+  reportMarkdown: string;
+}): string {
+  return [
+    supersessionProofPromptTemplate().trimEnd(),
+    "",
+    "Candidate report signal snippets:",
+    "```json",
+    JSON.stringify(
+      supersessionSignalSnippets(
+        options.reportMarkdown,
+        options.source.number,
+        options.replacement.number,
+      ),
+      null,
+      2,
+    ),
+    "```",
+    "",
+    "Compact hydrated PR context:",
+    "```json",
+    JSON.stringify(
+      {
+        sourcePrA: compactSupersessionProofView(options.source),
+        replacementPrB: compactSupersessionProofView(options.replacement),
+      },
+      null,
+      2,
+    ),
+    "```",
+  ].join("\n");
+}
+
+function runSupersessionProofModel(options: {
+  source: HydratedSupersessionPullRequest;
+  replacement: HydratedSupersessionPullRequest;
+  markdown: string;
+  runtime: SupersessionProofRuntime;
+}): SupersessionProofModelResult {
+  ensureDir(options.runtime.workDir);
+  const prefix = `${options.source.number}-${options.replacement.number}`;
+  const promptPath = join(options.runtime.workDir, `${prefix}.prompt.md`);
+  const outputPath = join(options.runtime.workDir, `${prefix}.json`);
+  const prompt = buildSupersessionProofPrompt({
+    source: options.source,
+    replacement: options.replacement,
+    reportMarkdown: options.markdown,
+  });
+  writeFileSync(promptPath, prompt, "utf8");
+  const codexConfig = [
+    `model_reasoning_effort="${options.runtime.reasoningEffort}"`,
+    'forced_login_method="api"',
+    'approval_policy="never"',
+  ];
+  if (options.runtime.serviceTier) {
+    codexConfig.splice(1, 0, `service_tier="${options.runtime.serviceTier}"`);
+  }
+  const result = spawnSync(
+    "codex",
+    [
+      "exec",
+      "-m",
+      options.runtime.model,
+      ...codexConfig.flatMap((config) => ["-c", config]),
+      "-C",
+      ROOT,
+      "--output-schema",
+      CLAWSWEEPER_SUPERSESSION_PROOF_SCHEMA_PATH,
+      "--output-last-message",
+      outputPath,
+      "--sandbox",
+      options.runtime.sandboxMode,
+      "-",
+    ],
+    {
+      cwd: ROOT,
+      encoding: "utf8",
+      env: codexEnv({ ghToken: process.env.CLAWSWEEPER_PROOF_INSPECTION_TOKEN }),
+      input: prompt,
+      maxBuffer: 64 * 1024 * 1024,
+      timeout: options.runtime.timeoutMs,
+    },
+  );
+  if (result.error) {
+    throw new Error(
+      `Codex supersession proof failed for #${options.source.number}: ${
+        result.error.message
+      }\n${safeOutputTail(result.stderr) || safeOutputTail(result.stdout) || "No output."}`,
+    );
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `Codex supersession proof failed for #${options.source.number} with exit ${
+        result.status ?? "unknown"
+      }.\n${safeOutputTail(result.stderr) || safeOutputTail(result.stdout) || "No output."}`,
+    );
+  }
+  if (!existsSync(outputPath)) {
+    throw new Error(`Codex supersession proof did not write ${outputPath}.`);
+  }
+  return normalizedSupersessionProofModelResult(
+    parseSupersessionProofModelResult(JSON.parse(readFileSync(outputPath, "utf8").trim())),
+  );
+}
+
+function supersessionProof(options: {
+  markdown: string;
+  item: Item;
+  context: ItemContext;
+  linkedNumber: number;
+  runtime: SupersessionProofRuntime;
+}): SupersessionProof {
+  const source = hydratedSourceSupersessionPullRequest(options.item, options.context);
+  const securityBlocked = sourcePullRequestHasSecuritySignal(
+    options.item,
+    options.context,
+    options.markdown,
+  );
+  let replacement: HydratedSupersessionPullRequest;
+  try {
+    replacement = hydrateReplacementSupersessionPullRequest(options.linkedNumber);
+  } catch {
+    return linkOnlySupersessionProof({
+      source,
+      replacementNumber: options.linkedNumber,
+      securityBlocked,
+      reason: "replacement PR context could not be fetched",
+    });
+  }
+
+  if (securityBlocked) {
+    return linkOnlySupersessionProof({
+      source,
+      replacement,
+      replacementNumber: options.linkedNumber,
+      securityBlocked,
+      reason: "source PR has security-sensitive labels, comments, or advisory markers",
+    });
+  }
+
+  if (source.filesTruncated || replacement.filesTruncated) {
+    return linkOnlySupersessionProof({
+      source,
+      replacement,
+      replacementNumber: options.linkedNumber,
+      securityBlocked,
+      reason: "source or replacement file context is truncated",
+    });
+  }
+
+  if (source.filePaths.length === 0 || replacement.filePaths.length === 0) {
+    return linkOnlySupersessionProof({
+      source,
+      replacement,
+      replacementNumber: options.linkedNumber,
+      securityBlocked,
+      reason: "source or replacement file context is missing",
+    });
+  }
+
+  let modelProof: SupersessionProofModelResult;
+  try {
+    modelProof = runSupersessionProofModel({
+      source,
+      replacement,
+      markdown: options.markdown,
+      runtime: options.runtime,
+    });
+  } catch (error) {
+    return linkOnlySupersessionProof({
+      source,
+      replacement,
+      replacementNumber: options.linkedNumber,
+      securityBlocked,
+      reason: `model supersession proof failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    });
+  }
+
+  if (modelProof.securityBlocked) {
+    modelProof = {
+      ...modelProof,
+      decision: "keep_open",
+      reason: modelProof.reason || "model found source PR security-sensitive context",
+    };
+  }
+
+  return {
+    sourceSummary: modelProof.sourceSummary,
+    replacementSummary: modelProof.replacementSummary,
+    coveredWork: modelProof.coveredWork,
+    uniqueSourceWork: modelProof.uniqueSourceWork,
+    securityBlocked: modelProof.securityBlocked,
+    decision: modelProof.decision === "superseded" ? "close" : "keep_open",
+    reason: modelProof.reason,
+    replacementUrl: replacement.url,
+    replacementStateText: supersessionReplacementStateText(replacement),
+  };
+}
+
 function recommendedPauseOrCloseOption(markdown: string): MergeRiskOption | null {
   return (
     mergeRiskOptionsFromReport(markdown).find(
@@ -10034,20 +10449,33 @@ function pauseOrClosePromotion(
 function linkedPullRequestSupersessionPromotion(
   markdown: string,
   item: Item,
-): PullRequestClosePromotion | null {
+  context: ItemContext,
+  runtime: SupersessionProofRuntime,
+): { candidateFound: boolean; promotion: PullRequestClosePromotion | null } {
   const linkedPull = linkedPullRequestSupersession(markdown, item);
-  if (!linkedPull) return null;
-  const stateText = linkedPull.mergedAt
-    ? `merged at ${linkedPull.mergedAt}`
-    : "still open as the canonical replacement";
+  if (!linkedPull) return { candidateFound: false, promotion: null };
+  const proof = supersessionProof({
+    markdown,
+    item,
+    context,
+    linkedNumber: linkedPull.number,
+    runtime,
+  });
+  if (proof.decision !== "close") return { candidateFound: true, promotion: null };
   return {
-    bestSolution: `Close this PR as superseded by ${linkedPull.url}.`,
-    evidence: [
-      `- **linked superseding PR:** ${linkedPull.url} (${linkedPull.title}) is ${stateText}.`,
-      "- **cluster evidence:** the durable review links that PR in the work cluster or recommended risk path.",
-      "- **no human follow-up:** live comments and timeline hydrated by apply contain no non-automation activity after the ClawSweeper review.",
-    ].join("\n"),
-    closeComment: `Thanks for the contribution. I’m closing this PR as superseded by ${linkedPull.url}, which is ${stateText}.`,
+    candidateFound: true,
+    promotion: {
+      bestSolution: `Close this PR as superseded by ${proof.replacementUrl}.`,
+      evidence: [
+        `- **source PR work:** ${proof.sourceSummary}`,
+        `- **replacement PR work:** ${proof.replacementSummary}`,
+        `- **coverage proof:** ${proof.reason}.\n${formatProofDetailList(proof.coveredWork)}`,
+        "- **unique source work:** none. PR A has no unique hydrated behavior, file, or proof that needs separate review.",
+        `- **linked superseding PR:** ${proof.replacementUrl} is ${proof.replacementStateText}.`,
+        "- **no human follow-up:** live comments and timeline hydrated by apply contain no non-automation activity after the ClawSweeper review.",
+      ].join("\n"),
+      closeComment: `Thanks for the contribution. I’m closing this PR as superseded by ${proof.replacementUrl}, which is ${proof.replacementStateText}.`,
+    },
   };
 }
 
@@ -10056,14 +10484,21 @@ function pullRequestClosePromotion(
   item: Item,
   context: ItemContext,
   staleMinAgeDays: number,
+  runtime: SupersessionProofRuntime,
 ): PullRequestClosePromotion | null {
   if (item.kind !== "pull_request") return null;
   if (frontMatterValue(markdown, "decision") !== "keep_open") return null;
   if (frontMatterValue(markdown, "action_taken") !== "kept_open") return null;
   if (frontMatterValue(markdown, "review_status") !== "complete") return null;
   if (closePromotionHasNonAutomationActivityAfterReview(markdown, context)) return null;
+  const linkedSupersession = linkedPullRequestSupersessionPromotion(
+    markdown,
+    item,
+    context,
+    runtime,
+  );
+  if (linkedSupersession.candidateFound) return linkedSupersession.promotion;
   return (
-    linkedPullRequestSupersessionPromotion(markdown, item) ??
     pauseOrClosePromotion(markdown, item, staleMinAgeDays) ??
     staleFRatedPullRequestPromotion(markdown, item, staleMinAgeDays)
   );
@@ -12690,6 +13125,15 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
   const commentSyncMinAgeDays = numberArg(args.comment_sync_min_age_days, 0);
   const maxRuntimeMs = numberArg(args.max_runtime_ms, 0);
   const reportPath = resolve(stringArg(args.report_path, join(ROOT, "apply-report.json")));
+  const artifactDir = resolve(stringArg(args.artifact_dir, join(ROOT, "artifacts", "apply")));
+  const supersessionProofRuntime: SupersessionProofRuntime = {
+    model: stringArg(args.codex_model, DEFAULT_CODEX_MODEL),
+    reasoningEffort: stringArg(args.codex_reasoning_effort, DEFAULT_REASONING_EFFORT),
+    sandboxMode: stringArg(args.codex_sandbox, "read-only"),
+    serviceTier: stringArg(args.codex_service_tier, DEFAULT_SERVICE_TIER),
+    timeoutMs: numberArg(args.codex_timeout_ms, 600_000),
+    workDir: join(artifactDir, "supersession-proof"),
+  };
   const startedAtMs = Date.now();
   const requestedItemNumbers = itemNumbersArg(args.item_numbers, args.item_number);
   const requestedItemNumberSet = new Set(requestedItemNumbers);
@@ -13143,6 +13587,7 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
         item,
         promotionContext,
         staleMinAgeDays,
+        supersessionProofRuntime,
       );
       if (promotion) {
         markdown = upgradePullRequestClosePromotionReport(

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -49,6 +49,7 @@ import {
   compactSupersessionProofView,
   normalizedSupersessionProofModelResult,
   parseSupersessionProofModelResult,
+  supersessionProofViewContextTruncated,
   type SupersessionProofModelResult,
 } from "./supersession-proof.js";
 import {
@@ -439,6 +440,7 @@ interface ItemContext {
   pullRequest?: unknown;
   pullFiles?: unknown[];
   pullCommits?: unknown[];
+  pullReviews?: unknown[];
   pullReviewComments?: unknown[];
   counts?: {
     comments: number;
@@ -457,6 +459,11 @@ interface ItemContext {
     pullCommits?: number;
     pullCommitsHydrated?: number;
     pullCommitsTruncated?: boolean;
+    pullReviews?: number;
+    pullReviewsHydrated?: number;
+    pullReviewsTruncated?: boolean;
+    pullReviewsIncluded?: number;
+    pullReviewsFiltered?: number;
     pullReviewComments?: number;
     pullReviewCommentsHydrated?: number;
     pullReviewCommentsTruncated?: boolean;
@@ -2595,6 +2602,21 @@ function compactComment(value: unknown): unknown {
   };
 }
 
+function compactReview(value: unknown): unknown {
+  const review = asRecord(value);
+  return {
+    id: review.id,
+    author: login(review.user),
+    authorAssociation: normalizeAuthorAssociation(review.author_association),
+    state: review.state,
+    url: review.html_url,
+    createdAt: review.submitted_at,
+    updatedAt: review.submitted_at,
+    submittedAt: review.submitted_at,
+    body: truncateText(review.body, 6000),
+  };
+}
+
 const CLAWSWEEPER_BOT_AUTHORS = new Set(
   [
     "clawsweeper",
@@ -2906,6 +2928,7 @@ function compactPullRequest(value: unknown): unknown {
     mergedAt: pull.merged_at,
     mergeCommitSha: pull.merge_commit_sha,
     mergeable: pull.mergeable,
+    mergeableState: pull.mergeable_state,
     author: login(pull.user),
     head: {
       ref: head.ref,
@@ -3014,6 +3037,7 @@ function collectRelatedMentions(options: {
   comments: unknown[];
   timeline: unknown[];
   pullRequest?: unknown;
+  pullReviews?: unknown[];
   pullReviewComments?: unknown[];
 }): Map<number, string[]> {
   const mentions = new Map<number, string[]>();
@@ -3045,6 +3069,10 @@ function collectRelatedMentions(options: {
 
   options.pullReviewComments?.forEach((comment, index) => {
     scanText(asRecord(comment).body, `pull review comment ${index + 1}`);
+  });
+
+  options.pullReviews?.forEach((review, index) => {
+    scanText(asRecord(review).body, `pull review ${index + 1}`);
   });
 
   if (options.pullRequest) {
@@ -3572,6 +3600,7 @@ function relatedItemsContext(options: {
   comments: unknown[];
   timeline: unknown[];
   pullRequest?: unknown;
+  pullReviews?: unknown[];
   pullReviewComments?: unknown[];
 }): unknown[] {
   const mentions = collectRelatedMentions(options);
@@ -5183,6 +5212,8 @@ function collectItemContext(
   };
   if (previousClawSweeperReview) context.previousClawSweeperReview = previousClawSweeperReview;
   let pullRequest: unknown = null;
+  let pullReviews: unknown[] | null = null;
+  let filteredPullReviews: { included: unknown[]; filtered: number } | null = null;
   let pullReviewComments: unknown[] | null = null;
   let filteredPullReviewComments: { included: unknown[]; filtered: number } | null = null;
   if (item.kind === "issue") {
@@ -5218,6 +5249,12 @@ function collectItemContext(
       80,
     );
     const pullCommits = pullCommitsWindow.items;
+    const pullReviewsWindow = ghPagedLinkHeaderContextWindow<unknown>(
+      `repos/${targetRepo()}/pulls/${item.number}/reviews`,
+      40,
+    );
+    pullReviews = pullReviewsWindow.items;
+    filteredPullReviews = filterReviewContextComments(pullReviews, item.number);
     const pullReviewCommentsWindow = ghPagedContextWindow<unknown>(
       `repos/${targetRepo()}/pulls/${item.number}/comments`,
       pullRecord.review_comments,
@@ -5232,6 +5269,12 @@ function collectItemContext(
       pullCommitsWindow.total,
       80,
       compactPullCommit,
+    );
+    context.pullReviews = compactMappedWindow(
+      filteredPullReviews.included,
+      filteredPullReviews.included.length,
+      40,
+      compactReview,
     );
     context.pullReviewComments = compactMappedWindow(
       filteredPullReviewComments.included,
@@ -5255,6 +5298,11 @@ function collectItemContext(
       pullCommits: pullCommitsWindow.total,
       pullCommitsHydrated: pullCommitsWindow.hydrated,
       pullCommitsTruncated: pullCommitsWindow.truncated,
+      pullReviews: pullReviewsWindow.total,
+      pullReviewsHydrated: pullReviewsWindow.hydrated,
+      pullReviewsTruncated: pullReviewsWindow.truncated,
+      pullReviewsIncluded: filteredPullReviews.included.length,
+      pullReviewsFiltered: filteredPullReviews.filtered,
       pullReviewComments: pullReviewCommentsWindow.total,
       pullReviewCommentsHydrated: pullReviewCommentsWindow.hydrated,
       pullReviewCommentsTruncated: pullReviewCommentsWindow.truncated,
@@ -5273,6 +5321,7 @@ function collectItemContext(
     timeline: relationTimeline,
   };
   if (pullRequest) relatedOptions.pullRequest = pullRequest;
+  if (filteredPullReviews) relatedOptions.pullReviews = filteredPullReviews.included;
   if (filteredPullReviewComments)
     relatedOptions.pullReviewComments = filteredPullReviewComments.included;
   const relatedItems = relatedItemsContext(relatedOptions);
@@ -5301,6 +5350,15 @@ function collectItemContext(
       counts.pullCommitsHydrated = context.counts.pullCommitsHydrated;
     if (context.counts?.pullCommitsTruncated !== undefined)
       counts.pullCommitsTruncated = context.counts.pullCommitsTruncated;
+    if (context.counts?.pullReviews !== undefined) counts.pullReviews = context.counts.pullReviews;
+    if (context.counts?.pullReviewsHydrated !== undefined)
+      counts.pullReviewsHydrated = context.counts.pullReviewsHydrated;
+    if (context.counts?.pullReviewsTruncated !== undefined)
+      counts.pullReviewsTruncated = context.counts.pullReviewsTruncated;
+    if (context.counts?.pullReviewsIncluded !== undefined)
+      counts.pullReviewsIncluded = context.counts.pullReviewsIncluded;
+    if (context.counts?.pullReviewsFiltered !== undefined)
+      counts.pullReviewsFiltered = context.counts.pullReviewsFiltered;
     if (context.counts?.pullReviewComments !== undefined)
       counts.pullReviewComments = context.counts.pullReviewComments;
     if (context.counts?.pullReviewCommentsHydrated !== undefined)
@@ -9839,6 +9897,11 @@ interface PullRequestClosePromotion {
   closeComment: string;
 }
 
+interface PullRequestClosePromotionResult {
+  promotion: PullRequestClosePromotion | null;
+  checkedLinkedSupersession: boolean;
+}
+
 interface HydratedSupersessionPullRequest {
   number: number;
   title: string;
@@ -9850,8 +9913,15 @@ interface HydratedSupersessionPullRequest {
   headSha: string | null;
   updatedAt: string | null;
   filePaths: string[];
+  files: unknown[];
   filesHydrated: number;
   filesTruncated: boolean;
+  comments: unknown[];
+  commentsTruncated: boolean;
+  reviews: unknown[];
+  reviewsTruncated: boolean;
+  reviewComments: unknown[];
+  reviewCommentsTruncated: boolean;
 }
 
 type SupersessionProofDecision = "close" | "link_only" | "keep_open";
@@ -9866,6 +9936,10 @@ interface SupersessionProof {
   reason: string;
   replacementUrl: string;
   replacementStateText: string;
+  replacementState: string;
+  replacementMergedAt: string | null;
+  replacementHeadSha: string | null;
+  replacementUpdatedAt: string | null;
 }
 
 interface SupersessionProofRuntime {
@@ -9911,6 +9985,7 @@ function closePromotionHasNonAutomationActivityAfterReview(
   if (
     context.counts?.commentsTruncated ||
     context.counts?.timelineTruncated ||
+    context.counts?.pullReviewsTruncated ||
     context.counts?.pullReviewCommentsTruncated
   ) {
     return true;
@@ -9931,6 +10006,7 @@ function closePromotionHasNonAutomationActivityAfterReview(
   };
   return (
     context.comments.some(hasNonAutomationComment) ||
+    (context.pullReviews ?? []).some(hasNonAutomationComment) ||
     (context.pullReviewComments ?? []).some(hasNonAutomationComment) ||
     context.timeline.some(hasNonAutomationEvent)
   );
@@ -10062,9 +10138,22 @@ function sourcePullRequestHasSecuritySignal(
   context: ItemContext,
   markdown: string,
 ): boolean {
+  if (reportSecurityReview(markdown).status === "needs_attention") return true;
+  if (
+    mergeRiskLabelsFromReport(markdown).some(
+      (label) =>
+        label === "merge-risk: 🚨 security-boundary" || label === "merge-risk: 🚨 auth-provider",
+    )
+  ) {
+    return true;
+  }
   return hasSecuritySignal({
     labels: labelRecords(item.labels),
-    comments: [...context.comments, ...(context.pullReviewComments ?? [])],
+    comments: [
+      ...context.comments,
+      ...(context.pullReviews ?? []),
+      ...(context.pullReviewComments ?? []),
+    ],
     text: [
       context.issue,
       context.pullRequest,
@@ -10091,8 +10180,15 @@ function hydratedSourceSupersessionPullRequest(
     headSha: stringOrUndefined(asRecord(pull.head).sha) ?? null,
     updatedAt: item.updatedAt,
     filePaths: uniqueFilePaths(pullRequestFilePathsFromContext(context)),
+    files: context.pullFiles ?? [],
     filesHydrated: context.counts?.pullFilesHydrated ?? context.pullFiles?.length ?? 0,
     filesTruncated: Boolean(context.counts?.pullFilesTruncated),
+    comments: context.comments,
+    commentsTruncated: Boolean(context.counts?.commentsTruncated),
+    reviews: context.pullReviews ?? [],
+    reviewsTruncated: Boolean(context.counts?.pullReviewsTruncated),
+    reviewComments: context.pullReviewComments ?? [],
+    reviewCommentsTruncated: Boolean(context.counts?.pullReviewCommentsTruncated),
   };
 }
 
@@ -10106,6 +10202,20 @@ function hydrateReplacementSupersessionPullRequest(
     `repos/${targetRepo()}/pulls/${number}/files`,
     changedFiles,
     80,
+  );
+  const commentsWindow = ghPagedContextWindow<unknown>(
+    `repos/${targetRepo()}/issues/${number}/comments`,
+    numberOrUndefined(issue.comments),
+    40,
+  );
+  const reviewCommentsWindow = ghPagedContextWindow<unknown>(
+    `repos/${targetRepo()}/pulls/${number}/comments`,
+    numberOrUndefined(pull.review_comments),
+    40,
+  );
+  const reviewsWindow = ghPagedLinkHeaderContextWindow<unknown>(
+    `repos/${targetRepo()}/pulls/${number}/reviews`,
+    40,
   );
   return {
     number,
@@ -10121,8 +10231,15 @@ function hydrateReplacementSupersessionPullRequest(
     headSha: stringOrUndefined(asRecord(pull.head).sha) ?? null,
     updatedAt: stringOrUndefined(pull.updated_at) ?? stringOrUndefined(issue.updated_at) ?? null,
     filePaths: uniqueFilePaths(filesWindow.items.flatMap(compactPullFilePaths)),
+    files: filesWindow.items,
     filesHydrated: filesWindow.hydrated,
     filesTruncated: filesWindow.truncated,
+    comments: commentsWindow.items,
+    commentsTruncated: commentsWindow.truncated,
+    reviews: reviewsWindow.items,
+    reviewsTruncated: reviewsWindow.truncated,
+    reviewComments: reviewCommentsWindow.items,
+    reviewCommentsTruncated: reviewCommentsWindow.truncated,
   };
 }
 
@@ -10140,6 +10257,12 @@ function supersessionReplacementStateText(
   return replacement.mergedAt
     ? `merged at ${replacement.mergedAt}`
     : "still open as the candidate replacement";
+}
+
+function supersessionReplacementCanClose(
+  replacement: Pick<HydratedSupersessionPullRequest, "state" | "mergedAt">,
+): boolean {
+  return replacement.state === "open" || Boolean(replacement.mergedAt);
 }
 
 function linkOnlySupersessionProof(options: {
@@ -10166,6 +10289,10 @@ function linkOnlySupersessionProof(options: {
     replacementStateText: options.replacement
       ? supersessionReplacementStateText(options.replacement)
       : "candidate replacement",
+    replacementState: options.replacement?.state ?? "",
+    replacementMergedAt: options.replacement?.mergedAt ?? null,
+    replacementHeadSha: options.replacement?.headSha ?? null,
+    replacementUpdatedAt: options.replacement?.updatedAt ?? null,
   };
 }
 
@@ -10238,6 +10365,7 @@ function runSupersessionProofModel(options: {
     reportMarkdown: options.markdown,
   });
   writeFileSync(promptPath, prompt, "utf8");
+  if (existsSync(outputPath)) unlinkSync(outputPath);
   const codexConfig = [
     `model_reasoning_effort="${options.runtime.reasoningEffort}"`,
     'forced_login_method="api"',
@@ -10280,6 +10408,19 @@ function runSupersessionProofModel(options: {
     );
   }
   if (result.status !== 0) {
+    if (existsSync(outputPath)) {
+      try {
+        return readSupersessionProofModelOutput(outputPath);
+      } catch (error) {
+        throw new Error(
+          `Codex supersession proof failed for #${options.source.number} with exit ${
+            result.status ?? "unknown"
+          } and wrote invalid JSON or schema-invalid output to ${outputPath}: ${
+            error instanceof Error ? error.message : String(error)
+          }.\n${safeOutputTail(result.stderr) || safeOutputTail(result.stdout) || "No output."}`,
+        );
+      }
+    }
     throw new Error(
       `Codex supersession proof failed for #${options.source.number} with exit ${
         result.status ?? "unknown"
@@ -10289,6 +10430,10 @@ function runSupersessionProofModel(options: {
   if (!existsSync(outputPath)) {
     throw new Error(`Codex supersession proof did not write ${outputPath}.`);
   }
+  return readSupersessionProofModelOutput(outputPath);
+}
+
+function readSupersessionProofModelOutput(outputPath: string): SupersessionProofModelResult {
   return normalizedSupersessionProofModelResult(
     parseSupersessionProofModelResult(JSON.parse(readFileSync(outputPath, "utf8").trim())),
   );
@@ -10316,6 +10461,15 @@ function supersessionProof(options: {
       replacementNumber: options.linkedNumber,
       securityBlocked,
       reason: "replacement PR context could not be fetched",
+    });
+  }
+  if (!supersessionReplacementCanClose(replacement)) {
+    return linkOnlySupersessionProof({
+      source,
+      replacement,
+      replacementNumber: options.linkedNumber,
+      securityBlocked,
+      reason: "replacement PR is closed without being merged",
     });
   }
 
@@ -10346,6 +10500,19 @@ function supersessionProof(options: {
       replacementNumber: options.linkedNumber,
       securityBlocked,
       reason: "source or replacement file context is missing",
+    });
+  }
+
+  if (
+    supersessionProofViewContextTruncated(source) ||
+    supersessionProofViewContextTruncated(replacement)
+  ) {
+    return linkOnlySupersessionProof({
+      source,
+      replacement,
+      replacementNumber: options.linkedNumber,
+      securityBlocked,
+      reason: "source or replacement proof context is truncated",
     });
   }
 
@@ -10387,7 +10554,23 @@ function supersessionProof(options: {
     reason: modelProof.reason,
     replacementUrl: replacement.url,
     replacementStateText: supersessionReplacementStateText(replacement),
+    replacementState: replacement.state,
+    replacementMergedAt: replacement.mergedAt,
+    replacementHeadSha: replacement.headSha,
+    replacementUpdatedAt: replacement.updatedAt,
   };
+}
+
+function supersessionReplacementChangedAfterProof(
+  proof: SupersessionProof,
+  replacement: HydratedSupersessionPullRequest,
+): boolean {
+  return (
+    replacement.state !== proof.replacementState ||
+    replacement.mergedAt !== proof.replacementMergedAt ||
+    replacement.headSha !== proof.replacementHeadSha ||
+    replacement.updatedAt !== proof.replacementUpdatedAt
+  );
 }
 
 function recommendedPauseOrCloseOption(markdown: string): MergeRiskOption | null {
@@ -10462,6 +10645,30 @@ function linkedPullRequestSupersessionPromotion(
     runtime,
   });
   if (proof.decision !== "close") return { candidateFound: true, promotion: null };
+  const refreshed = fetchItem(item.number);
+  if (refreshed.state !== "open") return { candidateFound: true, promotion: null };
+  const refreshedContext = collectItemContext(refreshed.item, { fullTimelineForRelations: true });
+  if (refreshed.item.updatedAt !== item.updatedAt) {
+    return { candidateFound: true, promotion: null };
+  }
+  if (closePromotionHasNonAutomationActivityAfterReview(markdown, refreshedContext)) {
+    return { candidateFound: true, promotion: null };
+  }
+  if (itemSnapshotHash(refreshed.item, refreshedContext) !== itemSnapshotHash(item, context)) {
+    return { candidateFound: true, promotion: null };
+  }
+  let refreshedReplacement: HydratedSupersessionPullRequest;
+  try {
+    refreshedReplacement = hydrateReplacementSupersessionPullRequest(linkedPull.number);
+  } catch {
+    return { candidateFound: true, promotion: null };
+  }
+  if (supersessionReplacementChangedAfterProof(proof, refreshedReplacement)) {
+    return { candidateFound: true, promotion: null };
+  }
+  if (!supersessionReplacementCanClose(refreshedReplacement)) {
+    return { candidateFound: true, promotion: null };
+  }
   return {
     candidateFound: true,
     promotion: {
@@ -10485,23 +10692,34 @@ function pullRequestClosePromotion(
   context: ItemContext,
   staleMinAgeDays: number,
   runtime: SupersessionProofRuntime,
-): PullRequestClosePromotion | null {
-  if (item.kind !== "pull_request") return null;
-  if (frontMatterValue(markdown, "decision") !== "keep_open") return null;
-  if (frontMatterValue(markdown, "action_taken") !== "kept_open") return null;
-  if (frontMatterValue(markdown, "review_status") !== "complete") return null;
-  if (closePromotionHasNonAutomationActivityAfterReview(markdown, context)) return null;
+): PullRequestClosePromotionResult {
+  const noPromotion = {
+    promotion: null,
+    checkedLinkedSupersession: false,
+  };
+  if (item.kind !== "pull_request") return noPromotion;
+  if (frontMatterValue(markdown, "decision") !== "keep_open") return noPromotion;
+  if (frontMatterValue(markdown, "action_taken") !== "kept_open") return noPromotion;
+  if (frontMatterValue(markdown, "review_status") !== "complete") return noPromotion;
+  if (closePromotionHasNonAutomationActivityAfterReview(markdown, context)) return noPromotion;
   const linkedSupersession = linkedPullRequestSupersessionPromotion(
     markdown,
     item,
     context,
     runtime,
   );
-  if (linkedSupersession.candidateFound) return linkedSupersession.promotion;
-  return (
-    pauseOrClosePromotion(markdown, item, staleMinAgeDays) ??
-    staleFRatedPullRequestPromotion(markdown, item, staleMinAgeDays)
-  );
+  if (linkedSupersession.candidateFound) {
+    return {
+      promotion: linkedSupersession.promotion,
+      checkedLinkedSupersession: true,
+    };
+  }
+  return {
+    promotion:
+      pauseOrClosePromotion(markdown, item, staleMinAgeDays) ??
+      staleFRatedPullRequestPromotion(markdown, item, staleMinAgeDays),
+    checkedLinkedSupersession: false,
+  };
 }
 
 function workPlanPathForReport(file: string, plansDir = defaultPlansDir()): string {
@@ -11019,6 +11237,15 @@ function reviewContextLedger(context: ItemContext): ReviewContextLedgerEntry[] {
       total: counts?.pullCommits,
       hydrated: counts?.pullCommitsHydrated,
       truncated: counts?.pullCommitsTruncated,
+    }),
+    reviewContextLedgerEntry({
+      section: "pullReviews",
+      label: "PR reviews",
+      value: context.pullReviews ?? [],
+      entries: arrayEntries(context.pullReviews),
+      total: counts?.pullReviews,
+      hydrated: counts?.pullReviewsHydrated,
+      truncated: counts?.pullReviewsTruncated,
     }),
     reviewContextLedgerEntry({
       section: "pullReviewComments",
@@ -12869,6 +13096,12 @@ ${options.action.closeComment ? options.action.closeComment : "_No close comment
     options.context.counts?.pullCommitsHydrated,
     options.context.counts?.pullCommitsTruncated,
   )}
+- PR reviews: ${contextCountText(
+    options.context.counts?.pullReviews,
+    options.context.pullReviews?.length ?? 0,
+    options.context.counts?.pullReviewsHydrated,
+    options.context.counts?.pullReviewsTruncated,
+  )}
 - PR review comments: ${contextCountText(
     options.context.counts?.pullReviewComments,
     options.context.pullReviewComments?.length ?? 0,
@@ -13582,24 +13815,36 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       action === "kept_open"
     ) {
       const promotionContext = currentItemContext();
-      const promotion = pullRequestClosePromotion(
+      const promotionResult = pullRequestClosePromotion(
         markdown,
         item,
         promotionContext,
         staleMinAgeDays,
         supersessionProofRuntime,
       );
-      if (promotion) {
+      if (promotionResult.promotion) {
         markdown = upgradePullRequestClosePromotionReport(
           markdown,
           item,
           promotionContext,
-          promotion,
+          promotionResult.promotion,
         );
         storedUpdatedAt = item.updatedAt;
         storedHash = itemSnapshotHash(item, promotionContext);
         closeReason = "duplicate_or_superseded";
         isCloseProposal = true;
+      } else if (promotionResult.checkedLinkedSupersession) {
+        markdown = replaceFrontMatterValue(markdown, "apply_checked_at", new Date().toISOString());
+        if (!dryRun) writeFileSync(path, markdown, "utf8");
+        results.push({
+          number,
+          action: "kept_open",
+          reason: "linked supersession proof did not allow close",
+        });
+        processedCount += 1;
+        maybeLogProgress(`kept open #${number}: linked supersession proof did not allow close`);
+        if (processedCount >= processedLimit) break;
+        continue;
       }
     }
     let currentPrStatusKind: PrStatusLabelKind | null = null;

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -11791,7 +11791,7 @@ function canClose(decision: Decision): boolean {
 export function validateCloseDecision(
   item: Pick<Item, "kind" | "labels"> & Partial<Pick<Item, "repo">>,
   decision: Decision,
-  options: { requireCloseComment?: boolean } = {},
+  options: { requireCloseComment?: boolean; allowProtectedLabels?: boolean } = {},
 ): { ok: true } | { ok: false; actionTaken: ActionTaken; reason: string } {
   const requireCloseComment = options.requireCloseComment !== false;
   const profile = repositoryProfileFor(item.repo ?? targetRepo());
@@ -11802,7 +11802,10 @@ export function validateCloseDecision(
       reason: "not a close decision",
     };
   }
-  if (applyBlockingProtectedLabels(item.labels, decision.closeReason).length > 0) {
+  if (
+    !options.allowProtectedLabels &&
+    applyBlockingProtectedLabels(item.labels, decision.closeReason).length > 0
+  ) {
     return {
       ok: false,
       actionTaken: "skipped_protected_label",
@@ -13437,6 +13440,7 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
     let currentClosingPullRequests: unknown[] | undefined;
     let clawSweeperLabelsChanged = false;
     let issueAdvisoryLabelsChanged = false;
+    let closeProposalHasSupersessionProof = false;
     const currentItemContext = (): ItemContext => {
       currentContext ??= collectItemContext(item, { fullTimelineForRelations: true });
       return currentContext;
@@ -13451,6 +13455,7 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
           reportDecision(markdown, closeReason),
           {
             requireCloseComment: !isRetryableSkippedClose,
+            allowProtectedLabels: closeProposalHasSupersessionProof,
           },
         ).ok
       ) {
@@ -13704,6 +13709,7 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
         storedHash = itemSnapshotHash(item, promotionContext);
         closeReason = "duplicate_or_superseded";
         isCloseProposal = true;
+        closeProposalHasSupersessionProof = true;
       } else if (promotionResult.checkedLinkedSupersession) {
         markdown = replaceFrontMatterValue(markdown, "apply_checked_at", new Date().toISOString());
         if (!dryRun) writeFileSync(path, markdown, "utf8");
@@ -13824,7 +13830,10 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
         ? issueCommentWithMarker(number, hatchCommentMarker(number))
         : undefined;
     const protectedApplyReason = applyProtectedLabelReason(item.labels, closeReason);
-    if (applyBlockingProtectedLabels(item.labels, closeReason).length > 0) {
+    if (
+      !closeProposalHasSupersessionProof &&
+      applyBlockingProtectedLabels(item.labels, closeReason).length > 0
+    ) {
       if (isCloseProposal) {
         if (markApplySkipped("skipped_protected_label", protectedApplyReason)) break;
       }
@@ -14176,7 +14185,10 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
     const currentReportValidation = validateCloseDecision(
       { repo, kind: item.kind, labels: item.labels },
       reportDecision(markdown, closeReason),
-      { requireCloseComment: !isRetryableSkippedClose },
+      {
+        requireCloseComment: !isRetryableSkippedClose,
+        allowProtectedLabels: closeProposalHasSupersessionProof,
+      },
     );
     if (!currentReportValidation.ok && currentReportValidation.actionTaken !== "kept_open") {
       if (markApplySkipped(currentReportValidation.actionTaken, currentReportValidation.reason))

--- a/src/repair/execute-fix-artifact.ts
+++ b/src/repair/execute-fix-artifact.ts
@@ -109,14 +109,9 @@ import {
   fetchSourcePullRequestView,
   prepareReviewThreadsForMerge,
   publicContributorCredit,
-  pullRequestCloseoutDriftBlockReason,
   pullRequestFileContextBlockReason,
-  pullRequestIssueCommentContextBlockReason,
-  pullRequestReviewContextBlockReason,
-  pullRequestReviewCommentContextBlockReason,
   sourceClosingReferences,
   sourceContributorCredits,
-  sourcePullRequestSecurityBlockReason,
   supersededReplacementSources,
 } from "./execute-fix-github.js";
 import {
@@ -124,7 +119,6 @@ import {
   compactSupersessionProofView,
   parseSupersessionProofModelResult,
   supersessionProofCloseDecision,
-  supersessionProofViewContextTruncated,
 } from "../supersession-proof.js";
 
 const FIX_ACTIONS = new Set(["fix_needed", "build_fix_artifact", "open_fix_pr"]);
@@ -1758,32 +1752,6 @@ function replacementCloseoutProofAllowsClose({
   if (sourceFileContextBlock) return { close: false, reason: sourceFileContextBlock };
   const replacementFileContextBlock = pullRequestFileContextBlockReason(replacementView);
   if (replacementFileContextBlock) return { close: false, reason: replacementFileContextBlock };
-  const sourceIssueCommentContextBlock = pullRequestIssueCommentContextBlockReason(sourceView);
-  if (sourceIssueCommentContextBlock) {
-    return { close: false, reason: sourceIssueCommentContextBlock };
-  }
-  const replacementIssueCommentContextBlock =
-    pullRequestIssueCommentContextBlockReason(replacementView);
-  if (replacementIssueCommentContextBlock) {
-    return { close: false, reason: replacementIssueCommentContextBlock };
-  }
-  const sourceReviewContextBlock = pullRequestReviewContextBlockReason(sourceView);
-  if (sourceReviewContextBlock) {
-    return { close: false, reason: sourceReviewContextBlock };
-  }
-  const replacementReviewContextBlock = pullRequestReviewContextBlockReason(replacementView);
-  if (replacementReviewContextBlock) {
-    return { close: false, reason: replacementReviewContextBlock };
-  }
-  const sourceReviewCommentContextBlock = pullRequestReviewCommentContextBlockReason(sourceView);
-  if (sourceReviewCommentContextBlock) {
-    return { close: false, reason: sourceReviewCommentContextBlock };
-  }
-  const replacementReviewCommentContextBlock =
-    pullRequestReviewCommentContextBlockReason(replacementView);
-  if (replacementReviewCommentContextBlock) {
-    return { close: false, reason: replacementReviewCommentContextBlock };
-  }
   if (replacementView.state === "CLOSED" && !replacementView.mergedAt) {
     return { close: false, reason: "replacement PR is closed without being merged" };
   }
@@ -1829,12 +1797,6 @@ function replacementCloseoutProofAllowsClose({
     reviewComments: replacementView.reviewComments,
     reviewCommentsTruncated: replacementView.reviewCommentsTruncated,
   };
-  if (
-    supersessionProofViewContextTruncated(sourceProofView) ||
-    supersessionProofViewContextTruncated(replacementProofView)
-  ) {
-    return { close: false, reason: "source or replacement proof context is truncated" };
-  }
   const prompt = [
     fs.readFileSync(replacementCloseoutProofPromptPath, "utf8").trimEnd(),
     "",
@@ -1978,21 +1940,6 @@ function closeSupersededSourcePr({
   if (view.state === "CLOSED") {
     return { ...base, status: "skipped", reason: "already closed" };
   }
-  const securityBlock = sourcePullRequestSecurityBlockReason(view);
-  if (securityBlock) {
-    return {
-      ...linkReplacementSourcePr({
-        source,
-        parsed,
-        replacementPrUrl,
-        targetDir,
-        contributorCredits,
-        provenance,
-        sourceView: view,
-      }),
-      reason: securityBlock,
-    };
-  }
   const replacementNumber = pullRequestNumberFromUrl(String(replacementPrUrl));
   if (!replacementNumber) {
     return {
@@ -2052,112 +1999,6 @@ function closeSupersededSourcePr({
       reason: proof.reason,
     };
   }
-  let postProofView: LooseRecord;
-  try {
-    postProofView = fetchSourcePullRequestView({
-      repo: result.repo,
-      number: parsed.number,
-      targetDir,
-    });
-  } catch (error) {
-    return {
-      ...linkReplacementSourcePr({
-        source,
-        parsed,
-        replacementPrUrl,
-        targetDir,
-        contributorCredits,
-        provenance,
-        sourceView: view,
-      }),
-      reason: `source PR context could not be re-fetched after proof: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    };
-  }
-  if (postProofView.mergedAt || postProofView.state === "MERGED") {
-    return {
-      ...base,
-      status: "skipped",
-      reason: "already merged",
-      merged_at: postProofView.mergedAt ?? null,
-    };
-  }
-  if (postProofView.state === "CLOSED") {
-    return { ...base, status: "skipped", reason: "already closed" };
-  }
-  const postProofDriftBlock = pullRequestCloseoutDriftBlockReason(view, postProofView);
-  if (postProofDriftBlock) {
-    return {
-      ...linkReplacementSourcePr({
-        source,
-        parsed,
-        replacementPrUrl,
-        targetDir,
-        contributorCredits,
-        provenance,
-        sourceView: postProofView,
-      }),
-      reason: postProofDriftBlock,
-    };
-  }
-  let postProofReplacementView: LooseRecord;
-  try {
-    postProofReplacementView = fetchSourcePullRequestView({
-      repo: result.repo,
-      number: replacementNumber,
-      targetDir,
-    });
-  } catch (error) {
-    return {
-      ...linkReplacementSourcePr({
-        source,
-        parsed,
-        replacementPrUrl,
-        targetDir,
-        contributorCredits,
-        provenance,
-        sourceView: postProofView,
-      }),
-      reason: `replacement PR context could not be re-fetched after proof: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    };
-  }
-  const postProofReplacementDriftBlock = pullRequestCloseoutDriftBlockReason(
-    replacementView,
-    postProofReplacementView,
-    "replacement PR",
-  );
-  if (postProofReplacementDriftBlock) {
-    return {
-      ...linkReplacementSourcePr({
-        source,
-        parsed,
-        replacementPrUrl,
-        targetDir,
-        contributorCredits,
-        provenance,
-        sourceView: postProofView,
-      }),
-      reason: postProofReplacementDriftBlock,
-    };
-  }
-  if (postProofReplacementView.state === "CLOSED" && !postProofReplacementView.mergedAt) {
-    return {
-      ...linkReplacementSourcePr({
-        source,
-        parsed,
-        replacementPrUrl,
-        targetDir,
-        contributorCredits,
-        provenance,
-        sourceView: postProofView,
-      }),
-      reason: "replacement PR is closed without being merged",
-    };
-  }
-
   const comment = replacementSourceCloseComment({
     replacementPrUrl,
     sourcePrUrl: source,

--- a/src/repair/execute-fix-artifact.ts
+++ b/src/repair/execute-fix-artifact.ts
@@ -111,8 +111,15 @@ import {
   publicContributorCredit,
   sourceClosingReferences,
   sourceContributorCredits,
+  sourcePullRequestSecurityBlockReason,
   supersededReplacementSources,
 } from "./execute-fix-github.js";
+import {
+  compactSupersessionFilePaths,
+  compactSupersessionProofView,
+  parseSupersessionProofModelResult,
+  supersessionProofCloseDecision,
+} from "../supersession-proof.js";
 
 const FIX_ACTIONS = new Set(["fix_needed", "build_fix_artifact", "open_fix_pr"]);
 const NON_EXECUTABLE_REPAIR_STRATEGIES = new Set(["already_fixed_on_main", "needs_human"]);
@@ -156,6 +163,12 @@ const installTargetDeps = process.env.CLAWSWEEPER_INSTALL_TARGET_DEPS !== "0";
 const allowBroadFixArtifacts = process.env.CLAWSWEEPER_ALLOW_BROAD_FIX_ARTIFACTS === "1";
 const closeSupersededSourcePrs = shouldCloseSupersededSourcePrs(
   process.env.CLAWSWEEPER_CLOSE_SUPERSEDED_SOURCE_PRS,
+);
+const replacementCloseoutProofPromptPath = path.join(
+  repoRoot(),
+  "prompts",
+  "repair",
+  "replacement-closeout-proof.md",
 );
 const maxAutonomousFixFiles = Math.max(
   1,
@@ -1727,6 +1740,109 @@ function addLabel(repo: string, number: JsonValue, name: string, targetDir: stri
   });
 }
 
+function replacementCloseoutProofAllowsClose({
+  sourceView,
+  replacementView,
+  sourcePrUrl,
+  replacementPrUrl,
+  provenance,
+}: LooseRecord) {
+  if (!Array.isArray(sourceView.files) || !Array.isArray(replacementView.files)) {
+    return { close: false, reason: "source or replacement PR file context is missing" };
+  }
+  const prompt = [
+    fs.readFileSync(replacementCloseoutProofPromptPath, "utf8").trimEnd(),
+    "",
+    "Hydrated PR context:",
+    "```json",
+    JSON.stringify(
+      {
+        sourcePrA: compactSupersessionProofView({
+          title: sourceView.title,
+          url: sourceView.url,
+          state: sourceView.state,
+          mergedAt: sourceView.mergedAt,
+          body: sourceView.body,
+          labels: sourceView.labels,
+          headRefOid: sourceView.headRefOid,
+          updatedAt: sourceView.updatedAt,
+          filePaths: compactSupersessionFilePaths(sourceView.files),
+        }),
+        replacementPrB: compactSupersessionProofView({
+          title: replacementView.title,
+          url: replacementView.url,
+          state: replacementView.state,
+          mergedAt: replacementView.mergedAt,
+          body: replacementView.body,
+          labels: replacementView.labels,
+          headRefOid: replacementView.headRefOid,
+          updatedAt: replacementView.updatedAt,
+          filePaths: compactSupersessionFilePaths(replacementView.files),
+        }),
+        sourcePrUrl,
+        replacementPrUrl,
+        provenance,
+      },
+      null,
+      2,
+    ),
+    "```",
+  ].join("\n");
+  const proofDir = path.join(workRoot, "replacement-closeout-proof");
+  fs.mkdirSync(proofDir, { recursive: true });
+  const sourceNumber = pullRequestNumberFromUrl(String(sourcePrUrl));
+  const replacementNumber = pullRequestNumberFromUrl(String(replacementPrUrl));
+  const proofName = `${sourceNumber ?? "source"}-${replacementNumber ?? "replacement"}`;
+  const promptPath = path.join(proofDir, `${proofName}.prompt.md`);
+  const outputPath = path.join(proofDir, `${proofName}.json`);
+  fs.writeFileSync(promptPath, prompt);
+  const child = spawnCodexSyncWithHeartbeat(
+    "replacement closeout proof",
+    [
+      "exec",
+      "-m",
+      model,
+      "--sandbox",
+      codexReviewSandbox,
+      ...codexReviewSandboxConfigArgs(),
+      ...codexConfigArgs(),
+      "-C",
+      targetDir,
+      "--output-schema",
+      path.join(repoRoot(), "schema", "clawsweeper-supersession-proof.schema.json"),
+      "--output-last-message",
+      outputPath,
+      "-",
+    ],
+    {
+      cwd: targetDir,
+      encoding: "utf8",
+      env: codexEnv(),
+      input: prompt,
+      maxBuffer: codexStdioMaxBuffer,
+      timeout: currentCodexTimeoutMs(),
+    },
+  );
+  if (child.error) {
+    return { close: false, reason: `replacement closeout proof failed: ${child.error.message}` };
+  }
+  if (child.status !== 0) {
+    return { close: false, reason: "replacement closeout proof failed" };
+  }
+  if (!fs.existsSync(outputPath)) {
+    return { close: false, reason: "replacement closeout proof did not produce output" };
+  }
+  let proofClose;
+  try {
+    proofClose = supersessionProofCloseDecision(
+      parseSupersessionProofModelResult(JSON.parse(fs.readFileSync(outputPath, "utf8"))),
+    );
+  } catch {
+    return { close: false, reason: "replacement closeout proof output was invalid JSON" };
+  }
+  return proofClose;
+}
+
 function linkReplacementSourcePr({
   source,
   parsed,
@@ -1734,9 +1850,12 @@ function linkReplacementSourcePr({
   targetDir,
   contributorCredits,
   provenance,
+  sourceView,
 }: LooseRecord) {
   const base = { source, pr: `#${parsed.number}`, action: "link_replacement_source" };
-  const view = fetchSourcePullRequestView({ repo: result.repo, number: parsed.number, targetDir });
+  const view =
+    sourceView ??
+    fetchSourcePullRequestView({ repo: result.repo, number: parsed.number, targetDir });
   if (view.mergedAt || view.state === "MERGED") {
     return {
       ...base,
@@ -1783,6 +1902,80 @@ function closeSupersededSourcePr({
   }
   if (view.state === "CLOSED") {
     return { ...base, status: "skipped", reason: "already closed" };
+  }
+  const securityBlock = sourcePullRequestSecurityBlockReason(view);
+  if (securityBlock) {
+    return {
+      ...linkReplacementSourcePr({
+        source,
+        parsed,
+        replacementPrUrl,
+        targetDir,
+        contributorCredits,
+        provenance,
+        sourceView: view,
+      }),
+      reason: securityBlock,
+    };
+  }
+  const replacementNumber = pullRequestNumberFromUrl(String(replacementPrUrl));
+  if (!replacementNumber) {
+    return {
+      ...linkReplacementSourcePr({
+        source,
+        parsed,
+        replacementPrUrl,
+        targetDir,
+        contributorCredits,
+        provenance,
+        sourceView: view,
+      }),
+      reason: "replacement PR context could not be fetched",
+    };
+  }
+  let replacementView: LooseRecord;
+  try {
+    replacementView = fetchSourcePullRequestView({
+      repo: result.repo,
+      number: replacementNumber,
+      targetDir,
+    });
+  } catch (error) {
+    return {
+      ...linkReplacementSourcePr({
+        source,
+        parsed,
+        replacementPrUrl,
+        targetDir,
+        contributorCredits,
+        provenance,
+        sourceView: view,
+      }),
+      reason: `replacement PR context could not be fetched: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    };
+  }
+  const proof = replacementCloseoutProofAllowsClose({
+    sourceView: view,
+    replacementView,
+    sourcePrUrl: source,
+    replacementPrUrl,
+    provenance,
+  });
+  if (!proof.close) {
+    return {
+      ...linkReplacementSourcePr({
+        source,
+        parsed,
+        replacementPrUrl,
+        targetDir,
+        contributorCredits,
+        provenance,
+        sourceView: view,
+      }),
+      reason: proof.reason,
+    };
   }
 
   const comment = replacementSourceCloseComment({

--- a/src/repair/execute-fix-artifact.ts
+++ b/src/repair/execute-fix-artifact.ts
@@ -109,6 +109,11 @@ import {
   fetchSourcePullRequestView,
   prepareReviewThreadsForMerge,
   publicContributorCredit,
+  pullRequestCloseoutDriftBlockReason,
+  pullRequestFileContextBlockReason,
+  pullRequestIssueCommentContextBlockReason,
+  pullRequestReviewContextBlockReason,
+  pullRequestReviewCommentContextBlockReason,
   sourceClosingReferences,
   sourceContributorCredits,
   sourcePullRequestSecurityBlockReason,
@@ -119,6 +124,7 @@ import {
   compactSupersessionProofView,
   parseSupersessionProofModelResult,
   supersessionProofCloseDecision,
+  supersessionProofViewContextTruncated,
 } from "../supersession-proof.js";
 
 const FIX_ACTIONS = new Set(["fix_needed", "build_fix_artifact", "open_fix_pr"]);
@@ -213,6 +219,7 @@ const defaultCodexReviewSandbox =
 const codexReviewSandbox = String(
   process.env.CLAWSWEEPER_CODEX_REVIEW_SANDBOX ?? defaultCodexReviewSandbox,
 );
+const replacementCloseoutProofSandbox = "read-only";
 const codexWriteNetworkAccess = parseBooleanEnv(
   process.env.CLAWSWEEPER_CODEX_WRITE_NETWORK_ACCESS,
   process.env.GITHUB_ACTIONS === "true",
@@ -1747,8 +1754,86 @@ function replacementCloseoutProofAllowsClose({
   replacementPrUrl,
   provenance,
 }: LooseRecord) {
-  if (!Array.isArray(sourceView.files) || !Array.isArray(replacementView.files)) {
-    return { close: false, reason: "source or replacement PR file context is missing" };
+  const sourceFileContextBlock = pullRequestFileContextBlockReason(sourceView);
+  if (sourceFileContextBlock) return { close: false, reason: sourceFileContextBlock };
+  const replacementFileContextBlock = pullRequestFileContextBlockReason(replacementView);
+  if (replacementFileContextBlock) return { close: false, reason: replacementFileContextBlock };
+  const sourceIssueCommentContextBlock = pullRequestIssueCommentContextBlockReason(sourceView);
+  if (sourceIssueCommentContextBlock) {
+    return { close: false, reason: sourceIssueCommentContextBlock };
+  }
+  const replacementIssueCommentContextBlock =
+    pullRequestIssueCommentContextBlockReason(replacementView);
+  if (replacementIssueCommentContextBlock) {
+    return { close: false, reason: replacementIssueCommentContextBlock };
+  }
+  const sourceReviewContextBlock = pullRequestReviewContextBlockReason(sourceView);
+  if (sourceReviewContextBlock) {
+    return { close: false, reason: sourceReviewContextBlock };
+  }
+  const replacementReviewContextBlock = pullRequestReviewContextBlockReason(replacementView);
+  if (replacementReviewContextBlock) {
+    return { close: false, reason: replacementReviewContextBlock };
+  }
+  const sourceReviewCommentContextBlock = pullRequestReviewCommentContextBlockReason(sourceView);
+  if (sourceReviewCommentContextBlock) {
+    return { close: false, reason: sourceReviewCommentContextBlock };
+  }
+  const replacementReviewCommentContextBlock =
+    pullRequestReviewCommentContextBlockReason(replacementView);
+  if (replacementReviewCommentContextBlock) {
+    return { close: false, reason: replacementReviewCommentContextBlock };
+  }
+  if (replacementView.state === "CLOSED" && !replacementView.mergedAt) {
+    return { close: false, reason: "replacement PR is closed without being merged" };
+  }
+  const sourceProofView = {
+    title: sourceView.title,
+    url: sourceView.url,
+    state: sourceView.state,
+    mergedAt: sourceView.mergedAt,
+    body: sourceView.body,
+    labels: sourceView.labels,
+    headRefOid: sourceView.headRefOid,
+    updatedAt: sourceView.updatedAt,
+    changedFiles: sourceView.changedFiles,
+    filePaths: compactSupersessionFilePaths(sourceView.files),
+    files: sourceView.files,
+    filesHydrated: sourceView.filesHydrated,
+    filesTruncated: sourceView.filesTruncated,
+    comments: sourceView.comments,
+    commentsTruncated: sourceView.commentsTruncated,
+    reviews: sourceView.reviews,
+    reviewsTruncated: sourceView.reviewsTruncated,
+    reviewComments: sourceView.reviewComments,
+    reviewCommentsTruncated: sourceView.reviewCommentsTruncated,
+  };
+  const replacementProofView = {
+    title: replacementView.title,
+    url: replacementView.url,
+    state: replacementView.state,
+    mergedAt: replacementView.mergedAt,
+    body: replacementView.body,
+    labels: replacementView.labels,
+    headRefOid: replacementView.headRefOid,
+    updatedAt: replacementView.updatedAt,
+    changedFiles: replacementView.changedFiles,
+    filePaths: compactSupersessionFilePaths(replacementView.files),
+    files: replacementView.files,
+    filesHydrated: replacementView.filesHydrated,
+    filesTruncated: replacementView.filesTruncated,
+    comments: replacementView.comments,
+    commentsTruncated: replacementView.commentsTruncated,
+    reviews: replacementView.reviews,
+    reviewsTruncated: replacementView.reviewsTruncated,
+    reviewComments: replacementView.reviewComments,
+    reviewCommentsTruncated: replacementView.reviewCommentsTruncated,
+  };
+  if (
+    supersessionProofViewContextTruncated(sourceProofView) ||
+    supersessionProofViewContextTruncated(replacementProofView)
+  ) {
+    return { close: false, reason: "source or replacement proof context is truncated" };
   }
   const prompt = [
     fs.readFileSync(replacementCloseoutProofPromptPath, "utf8").trimEnd(),
@@ -1757,28 +1842,8 @@ function replacementCloseoutProofAllowsClose({
     "```json",
     JSON.stringify(
       {
-        sourcePrA: compactSupersessionProofView({
-          title: sourceView.title,
-          url: sourceView.url,
-          state: sourceView.state,
-          mergedAt: sourceView.mergedAt,
-          body: sourceView.body,
-          labels: sourceView.labels,
-          headRefOid: sourceView.headRefOid,
-          updatedAt: sourceView.updatedAt,
-          filePaths: compactSupersessionFilePaths(sourceView.files),
-        }),
-        replacementPrB: compactSupersessionProofView({
-          title: replacementView.title,
-          url: replacementView.url,
-          state: replacementView.state,
-          mergedAt: replacementView.mergedAt,
-          body: replacementView.body,
-          labels: replacementView.labels,
-          headRefOid: replacementView.headRefOid,
-          updatedAt: replacementView.updatedAt,
-          filePaths: compactSupersessionFilePaths(replacementView.files),
-        }),
+        sourcePrA: compactSupersessionProofView(sourceProofView),
+        replacementPrB: compactSupersessionProofView(replacementProofView),
         sourcePrUrl,
         replacementPrUrl,
         provenance,
@@ -1796,6 +1861,7 @@ function replacementCloseoutProofAllowsClose({
   const promptPath = path.join(proofDir, `${proofName}.prompt.md`);
   const outputPath = path.join(proofDir, `${proofName}.json`);
   fs.writeFileSync(promptPath, prompt);
+  if (fs.existsSync(outputPath)) fs.unlinkSync(outputPath);
   const child = spawnCodexSyncWithHeartbeat(
     "replacement closeout proof",
     [
@@ -1803,8 +1869,8 @@ function replacementCloseoutProofAllowsClose({
       "-m",
       model,
       "--sandbox",
-      codexReviewSandbox,
-      ...codexReviewSandboxConfigArgs(),
+      replacementCloseoutProofSandbox,
+      ...codexWorkspaceSandboxConfigArgs(replacementCloseoutProofSandbox, codexReviewNetworkAccess),
       ...codexConfigArgs(),
       "-C",
       targetDir,
@@ -1827,20 +1893,29 @@ function replacementCloseoutProofAllowsClose({
     return { close: false, reason: `replacement closeout proof failed: ${child.error.message}` };
   }
   if (child.status !== 0) {
+    if (fs.existsSync(outputPath)) {
+      try {
+        return replacementCloseoutProofDecisionFromOutput(outputPath);
+      } catch {
+        return { close: false, reason: "replacement closeout proof output was invalid JSON" };
+      }
+    }
     return { close: false, reason: "replacement closeout proof failed" };
   }
   if (!fs.existsSync(outputPath)) {
     return { close: false, reason: "replacement closeout proof did not produce output" };
   }
-  let proofClose;
   try {
-    proofClose = supersessionProofCloseDecision(
-      parseSupersessionProofModelResult(JSON.parse(fs.readFileSync(outputPath, "utf8"))),
-    );
+    return replacementCloseoutProofDecisionFromOutput(outputPath);
   } catch {
     return { close: false, reason: "replacement closeout proof output was invalid JSON" };
   }
-  return proofClose;
+}
+
+function replacementCloseoutProofDecisionFromOutput(outputPath: string) {
+  return supersessionProofCloseDecision(
+    parseSupersessionProofModelResult(JSON.parse(fs.readFileSync(outputPath, "utf8"))),
+  );
 }
 
 function linkReplacementSourcePr({
@@ -1975,6 +2050,111 @@ function closeSupersededSourcePr({
         sourceView: view,
       }),
       reason: proof.reason,
+    };
+  }
+  let postProofView: LooseRecord;
+  try {
+    postProofView = fetchSourcePullRequestView({
+      repo: result.repo,
+      number: parsed.number,
+      targetDir,
+    });
+  } catch (error) {
+    return {
+      ...linkReplacementSourcePr({
+        source,
+        parsed,
+        replacementPrUrl,
+        targetDir,
+        contributorCredits,
+        provenance,
+        sourceView: view,
+      }),
+      reason: `source PR context could not be re-fetched after proof: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    };
+  }
+  if (postProofView.mergedAt || postProofView.state === "MERGED") {
+    return {
+      ...base,
+      status: "skipped",
+      reason: "already merged",
+      merged_at: postProofView.mergedAt ?? null,
+    };
+  }
+  if (postProofView.state === "CLOSED") {
+    return { ...base, status: "skipped", reason: "already closed" };
+  }
+  const postProofDriftBlock = pullRequestCloseoutDriftBlockReason(view, postProofView);
+  if (postProofDriftBlock) {
+    return {
+      ...linkReplacementSourcePr({
+        source,
+        parsed,
+        replacementPrUrl,
+        targetDir,
+        contributorCredits,
+        provenance,
+        sourceView: postProofView,
+      }),
+      reason: postProofDriftBlock,
+    };
+  }
+  let postProofReplacementView: LooseRecord;
+  try {
+    postProofReplacementView = fetchSourcePullRequestView({
+      repo: result.repo,
+      number: replacementNumber,
+      targetDir,
+    });
+  } catch (error) {
+    return {
+      ...linkReplacementSourcePr({
+        source,
+        parsed,
+        replacementPrUrl,
+        targetDir,
+        contributorCredits,
+        provenance,
+        sourceView: postProofView,
+      }),
+      reason: `replacement PR context could not be re-fetched after proof: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    };
+  }
+  const postProofReplacementDriftBlock = pullRequestCloseoutDriftBlockReason(
+    replacementView,
+    postProofReplacementView,
+    "replacement PR",
+  );
+  if (postProofReplacementDriftBlock) {
+    return {
+      ...linkReplacementSourcePr({
+        source,
+        parsed,
+        replacementPrUrl,
+        targetDir,
+        contributorCredits,
+        provenance,
+        sourceView: postProofView,
+      }),
+      reason: postProofReplacementDriftBlock,
+    };
+  }
+  if (postProofReplacementView.state === "CLOSED" && !postProofReplacementView.mergedAt) {
+    return {
+      ...linkReplacementSourcePr({
+        source,
+        parsed,
+        replacementPrUrl,
+        targetDir,
+        contributorCredits,
+        provenance,
+        sourceView: postProofView,
+      }),
+      reason: "replacement PR is closed without being merged",
     };
   }
 

--- a/src/repair/execute-fix-github.ts
+++ b/src/repair/execute-fix-github.ts
@@ -8,7 +8,6 @@ import { runCommand as run } from "./command-runner.js";
 import { parsePullRequestUrl } from "./github-ref.js";
 import { repoRoot } from "./lib.js";
 import { repairGhEnv as ghEnv } from "./process-env.js";
-import { hasDeterministicSecuritySignal, hasSecuritySignalText } from "./security-signals.js";
 import { uniqueStrings } from "./validation-command-utils.js";
 import { closingReferencesFromMarkdown } from "./external-messages.js";
 
@@ -92,85 +91,9 @@ export function fetchSourcePullRequestView({
   });
 }
 
-export function sourcePullRequestSecurityBlockReason(view: LooseRecord): string {
-  if (
-    hasDeterministicSecuritySignal({
-      labels: view.labels ?? [],
-      comments: [
-        ...(Array.isArray(view.comments) ? view.comments : []),
-        ...(Array.isArray(view.reviews) ? view.reviews : []),
-        ...(Array.isArray(view.reviewComments) ? view.reviewComments : []),
-      ],
-    }) ||
-    hasSecuritySignalText(view.title ?? "", view.body ?? "")
-  ) {
-    return "security-sensitive source PR requires maintainer security review";
-  }
-  return "";
-}
-
 export function pullRequestFileContextBlockReason(view: LooseRecord): string {
   if (!Array.isArray(view.files)) return "source or replacement PR file context is missing";
-  const changedFiles = finiteNumber(view.changedFiles);
-  const filesHydrated = finiteNumber(view.filesHydrated) ?? view.files.length;
-  if (view.filesTruncated === true || (changedFiles !== null && changedFiles > filesHydrated)) {
-    return "source or replacement PR file context is truncated";
-  }
   return "";
-}
-
-export function pullRequestReviewCommentContextBlockReason(view: LooseRecord): string {
-  if (!Array.isArray(view.reviewComments)) {
-    return "source or replacement PR review comment context is missing";
-  }
-  if (view.reviewCommentsTruncated === true) {
-    return "source or replacement PR review comment context is truncated";
-  }
-  return "";
-}
-
-export function pullRequestReviewContextBlockReason(view: LooseRecord): string {
-  if (!Array.isArray(view.reviews)) {
-    return "source or replacement PR review context is missing";
-  }
-  if (view.reviewsTruncated === true) {
-    return "source or replacement PR review context is truncated";
-  }
-  return "";
-}
-
-export function pullRequestIssueCommentContextBlockReason(view: LooseRecord): string {
-  if (!Array.isArray(view.comments)) {
-    return "source or replacement PR comment context is missing";
-  }
-  if (view.commentsTruncated === true) {
-    return "source or replacement PR comment context is truncated";
-  }
-  return "";
-}
-
-export function pullRequestCloseoutDriftBlockReason(
-  beforeProof: LooseRecord,
-  afterProof: LooseRecord,
-  subject = "source PR",
-): string {
-  if (String(afterProof.state ?? "") !== String(beforeProof.state ?? "")) {
-    return `${subject} changed during replacement closeout proof`;
-  }
-  if (String(afterProof.updatedAt ?? "") !== String(beforeProof.updatedAt ?? "")) {
-    return `${subject} changed during replacement closeout proof`;
-  }
-  if (String(afterProof.headRefOid ?? "") !== String(beforeProof.headRefOid ?? "")) {
-    return `${subject} changed during replacement closeout proof`;
-  }
-  const securityBlock = sourcePullRequestSecurityBlockReason(afterProof);
-  if (securityBlock) return securityBlock;
-  return (
-    pullRequestFileContextBlockReason(afterProof) ||
-    pullRequestIssueCommentContextBlockReason(afterProof) ||
-    pullRequestReviewContextBlockReason(afterProof) ||
-    pullRequestReviewCommentContextBlockReason(afterProof)
-  );
 }
 
 function pullRequestViewWithFileContext(view: LooseRecord): LooseRecord {

--- a/src/repair/execute-fix-github.ts
+++ b/src/repair/execute-fix-github.ts
@@ -8,6 +8,7 @@ import { runCommand as run } from "./command-runner.js";
 import { parsePullRequestUrl } from "./github-ref.js";
 import { repoRoot } from "./lib.js";
 import { repairGhEnv as ghEnv } from "./process-env.js";
+import { hasDeterministicSecuritySignal, hasSecuritySignalText } from "./security-signals.js";
 import { uniqueStrings } from "./validation-command-utils.js";
 import { closingReferencesFromMarkdown } from "./external-messages.js";
 
@@ -42,7 +43,15 @@ export function fetchSourcePullRequestView({
   return JSON.parse(
     run(
       "gh",
-      ["pr", "view", String(number), "--repo", repo, "--json", "author,state,mergedAt,title,url"],
+      [
+        "pr",
+        "view",
+        String(number),
+        "--repo",
+        repo,
+        "--json",
+        "author,state,mergedAt,title,url,body,labels,comments,files,headRefOid,updatedAt",
+      ],
       {
         cwd: targetDir,
         env: ghEnv(),
@@ -50,6 +59,19 @@ export function fetchSourcePullRequestView({
       },
     ),
   );
+}
+
+export function sourcePullRequestSecurityBlockReason(view: LooseRecord): string {
+  if (
+    hasDeterministicSecuritySignal({
+      labels: view.labels ?? [],
+      comments: view.comments ?? [],
+    }) ||
+    hasSecuritySignalText(view.title ?? "", view.body ?? "")
+  ) {
+    return "security-sensitive source PR requires maintainer security review";
+  }
+  return "";
 }
 
 export function sourceClosingReferences({

--- a/src/repair/execute-fix-github.ts
+++ b/src/repair/execute-fix-github.ts
@@ -31,6 +31,16 @@ export function fetchPullRequest(repo: string, number: JsonValue): LooseRecord {
   );
 }
 
+function fetchIssue(repo: string, number: JsonValue): LooseRecord {
+  return JSON.parse(
+    run("gh", ["api", `repos/${repo}/issues/${number}`], {
+      cwd: repoRoot(),
+      env: ghEnv(),
+      timeoutMs: ghCommandTimeoutMs,
+    }),
+  );
+}
+
 export function fetchSourcePullRequestView({
   repo,
   number,
@@ -40,7 +50,7 @@ export function fetchSourcePullRequestView({
   number: JsonValue;
   targetDir: string;
 }): LooseRecord {
-  return JSON.parse(
+  const view = JSON.parse(
     run(
       "gh",
       [
@@ -50,7 +60,7 @@ export function fetchSourcePullRequestView({
         "--repo",
         repo,
         "--json",
-        "author,state,mergedAt,title,url,body,labels,comments,files,headRefOid,updatedAt",
+        "author,state,mergedAt,title,url,body,labels,changedFiles,headRefOid,updatedAt",
       ],
       {
         cwd: targetDir,
@@ -59,19 +69,202 @@ export function fetchSourcePullRequestView({
       },
     ),
   );
+  const pull = fetchPullRequest(repo, number);
+  const issue = fetchIssue(repo, number);
+  const changedFiles = finiteNumber(pull.changed_files) ?? finiteNumber(view.changedFiles);
+  const issueCommentCount = finiteNumber(issue.comments);
+  const reviewCommentCount = finiteNumber(pull.review_comments);
+  const files = fetchPullRequestFiles({ repo, number, targetDir });
+  const comments = fetchIssueComments({ repo, number, targetDir });
+  const reviews = fetchPullRequestReviews({ repo, number, targetDir });
+  const reviewComments = fetchPullRequestReviewComments({ repo, number, targetDir });
+  return pullRequestViewWithFileContext({
+    ...view,
+    changedFiles,
+    comments,
+    commentsTruncated: issueCommentCount !== null && issueCommentCount > comments.length,
+    files,
+    reviews,
+    reviewsTruncated: false,
+    reviewComments,
+    reviewCommentsTruncated:
+      reviewCommentCount !== null && reviewCommentCount > reviewComments.length,
+  });
 }
 
 export function sourcePullRequestSecurityBlockReason(view: LooseRecord): string {
   if (
     hasDeterministicSecuritySignal({
       labels: view.labels ?? [],
-      comments: view.comments ?? [],
+      comments: [
+        ...(Array.isArray(view.comments) ? view.comments : []),
+        ...(Array.isArray(view.reviews) ? view.reviews : []),
+        ...(Array.isArray(view.reviewComments) ? view.reviewComments : []),
+      ],
     }) ||
     hasSecuritySignalText(view.title ?? "", view.body ?? "")
   ) {
     return "security-sensitive source PR requires maintainer security review";
   }
   return "";
+}
+
+export function pullRequestFileContextBlockReason(view: LooseRecord): string {
+  if (!Array.isArray(view.files)) return "source or replacement PR file context is missing";
+  const changedFiles = finiteNumber(view.changedFiles);
+  const filesHydrated = finiteNumber(view.filesHydrated) ?? view.files.length;
+  if (view.filesTruncated === true || (changedFiles !== null && changedFiles > filesHydrated)) {
+    return "source or replacement PR file context is truncated";
+  }
+  return "";
+}
+
+export function pullRequestReviewCommentContextBlockReason(view: LooseRecord): string {
+  if (!Array.isArray(view.reviewComments)) {
+    return "source or replacement PR review comment context is missing";
+  }
+  if (view.reviewCommentsTruncated === true) {
+    return "source or replacement PR review comment context is truncated";
+  }
+  return "";
+}
+
+export function pullRequestReviewContextBlockReason(view: LooseRecord): string {
+  if (!Array.isArray(view.reviews)) {
+    return "source or replacement PR review context is missing";
+  }
+  if (view.reviewsTruncated === true) {
+    return "source or replacement PR review context is truncated";
+  }
+  return "";
+}
+
+export function pullRequestIssueCommentContextBlockReason(view: LooseRecord): string {
+  if (!Array.isArray(view.comments)) {
+    return "source or replacement PR comment context is missing";
+  }
+  if (view.commentsTruncated === true) {
+    return "source or replacement PR comment context is truncated";
+  }
+  return "";
+}
+
+export function pullRequestCloseoutDriftBlockReason(
+  beforeProof: LooseRecord,
+  afterProof: LooseRecord,
+  subject = "source PR",
+): string {
+  if (String(afterProof.state ?? "") !== String(beforeProof.state ?? "")) {
+    return `${subject} changed during replacement closeout proof`;
+  }
+  if (String(afterProof.updatedAt ?? "") !== String(beforeProof.updatedAt ?? "")) {
+    return `${subject} changed during replacement closeout proof`;
+  }
+  if (String(afterProof.headRefOid ?? "") !== String(beforeProof.headRefOid ?? "")) {
+    return `${subject} changed during replacement closeout proof`;
+  }
+  const securityBlock = sourcePullRequestSecurityBlockReason(afterProof);
+  if (securityBlock) return securityBlock;
+  return (
+    pullRequestFileContextBlockReason(afterProof) ||
+    pullRequestIssueCommentContextBlockReason(afterProof) ||
+    pullRequestReviewContextBlockReason(afterProof) ||
+    pullRequestReviewCommentContextBlockReason(afterProof)
+  );
+}
+
+function pullRequestViewWithFileContext(view: LooseRecord): LooseRecord {
+  const files = Array.isArray(view.files) ? view.files : [];
+  const changedFiles = finiteNumber(view.changedFiles);
+  return {
+    ...view,
+    filesHydrated: files.length,
+    filesTruncated: changedFiles !== null && changedFiles > files.length,
+  };
+}
+
+function fetchPullRequestReviewComments({
+  repo,
+  number,
+  targetDir,
+}: {
+  repo: string;
+  number: JsonValue;
+  targetDir: string;
+}): JsonValue[] {
+  const value = JSON.parse(
+    run("gh", ["api", `repos/${repo}/pulls/${number}/comments?per_page=100`], {
+      cwd: targetDir,
+      env: ghEnv(),
+      timeoutMs: ghCommandTimeoutMs,
+    }),
+  );
+  return Array.isArray(value) ? value : [];
+}
+
+function fetchPullRequestReviews({
+  repo,
+  number,
+  targetDir,
+}: {
+  repo: string;
+  number: JsonValue;
+  targetDir: string;
+}): JsonValue[] {
+  const value = JSON.parse(
+    run(
+      "gh",
+      ["api", `repos/${repo}/pulls/${number}/reviews?per_page=100`, "--paginate", "--slurp"],
+      {
+        cwd: targetDir,
+        env: ghEnv(),
+        timeoutMs: ghCommandTimeoutMs,
+      },
+    ),
+  );
+  return Array.isArray(value) ? value.flatMap((page) => (Array.isArray(page) ? page : [])) : [];
+}
+
+function fetchIssueComments({
+  repo,
+  number,
+  targetDir,
+}: {
+  repo: string;
+  number: JsonValue;
+  targetDir: string;
+}): JsonValue[] {
+  const value = JSON.parse(
+    run("gh", ["api", `repos/${repo}/issues/${number}/comments?per_page=100`], {
+      cwd: targetDir,
+      env: ghEnv(),
+      timeoutMs: ghCommandTimeoutMs,
+    }),
+  );
+  return Array.isArray(value) ? value : [];
+}
+
+function fetchPullRequestFiles({
+  repo,
+  number,
+  targetDir,
+}: {
+  repo: string;
+  number: JsonValue;
+  targetDir: string;
+}): JsonValue[] {
+  const value = JSON.parse(
+    run("gh", ["api", `repos/${repo}/pulls/${number}/files?per_page=100`], {
+      cwd: targetDir,
+      env: ghEnv(),
+      timeoutMs: ghCommandTimeoutMs,
+    }),
+  );
+  return Array.isArray(value) ? value : [];
+}
+
+function finiteNumber(value: JsonValue): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
 export function sourceClosingReferences({

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -11,6 +11,8 @@ type ApplyAction = {
   action: string;
 };
 
+const LINKED_SUPERSESSION_RECHECK_MS = 6 * 60 * 60 * 1000;
+
 const args = parseArgs(process.argv.slice(2));
 
 if (isCliEntrypoint()) runCli();
@@ -302,6 +304,11 @@ export function proposedItemNumbers(options: ProposedItemOptions): number[] {
       if (repoFor(markdown, name) !== options.targetRepo) return [];
       const type = frontMatterValue(markdown, "type");
       if (options.applyKind !== "all" && type && type !== options.applyKind) return [];
+      if (
+        linkedSupersessionApplyCandidate(markdown, options, allowedReasons, allowedCloseReasons)
+      ) {
+        return [numberFor(name)];
+      }
       if (frontMatterValue(markdown, "decision") !== "close") return [];
       if (frontMatterValue(markdown, "confidence") !== "high") return [];
       if (frontMatterValue(markdown, "action_taken") !== "proposed_close") return [];
@@ -321,6 +328,44 @@ export function proposedItemNumbers(options: ProposedItemOptions): number[] {
       return [numberFor(name)];
     })
     .sort((left, right) => left - right);
+}
+
+function linkedSupersessionApplyCandidate(
+  markdown: string,
+  options: ProposedItemOptions,
+  allowedReasons: ReadonlySet<string>,
+  allowedCloseReasons: ReadonlySet<string> | null,
+): boolean {
+  const type = frontMatterValue(markdown, "type");
+  const reason = "duplicate_or_superseded";
+  if (type !== "pull_request") return false;
+  if (frontMatterValue(markdown, "decision") !== "keep_open") return false;
+  if (frontMatterValue(markdown, "confidence") !== "high") return false;
+  if (frontMatterValue(markdown, "action_taken") !== "kept_open") return false;
+  if (frontMatterValue(markdown, "review_status") !== "complete") return false;
+  if (!frontMatterValue(markdown, "item_snapshot_hash")) return false;
+  if (!allowedForTarget(options.targetRepo, type, reason, allowedReasons)) return false;
+  if (allowedCloseReasons && !allowedCloseReasons.has(reason)) return false;
+  if (!olderThan(frontMatterValue(markdown, "item_created_at"), minAgeMsFor(options))) return false;
+  const lastCheckedAt = frontMatterValue(markdown, "apply_checked_at");
+  if (lastCheckedAt && !olderThan(lastCheckedAt, LINKED_SUPERSESSION_RECHECK_MS)) return false;
+  return hasLinkedSupersessionSignal(markdown, options.targetRepo);
+}
+
+function minAgeMsFor(options: ProposedItemOptions): number {
+  return options.minAgeMinutes === null
+    ? options.minAgeDays * 24 * 60 * 60 * 1000
+    : options.minAgeMinutes * 60 * 1000;
+}
+
+function hasLinkedSupersessionSignal(markdown: string, targetRepo: string): boolean {
+  const escapedRepo = targetRepo.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const linkedPull = new RegExp(`https://github\\.com/${escapedRepo}/pull/\\d+\\b`, "i");
+  const supersessionSignal =
+    /\b(supersed(?:e|ed|es|ing)|replace(?:s|d|ment)?|duplicate|duplicated|canonical|covered by|landed in)\b/i;
+  return markdown
+    .split(/\r?\n/)
+    .some((line) => linkedPull.test(line) && supersessionSignal.test(line));
 }
 
 export function commentSyncBatchOutput(options: CommentSyncBatchOptions): Record<string, string> {

--- a/src/supersession-proof.ts
+++ b/src/supersession-proof.ts
@@ -255,13 +255,6 @@ export function normalizedSupersessionProofModelResult(
     uniqueSourceWork: proof.uniqueSourceWork.map((entry) => entry.trim()).filter(Boolean),
     reason: proof.reason.trim(),
   };
-  if (normalizedProof.securityBlocked) {
-    return {
-      ...normalizedProof,
-      decision: "keep_open",
-      reason: normalizedProof.reason || "model found source PR security-sensitive context",
-    };
-  }
   if (normalizedProof.decision !== "superseded") return normalizedProof;
   if (supersessionProofHasConcreteCloseEvidence(normalizedProof)) return normalizedProof;
   return {
@@ -290,8 +283,7 @@ function supersessionProofHasConcreteCloseEvidence(proof: SupersessionProofModel
     proof.replacementSummary.trim().length > 0 &&
     proof.coveredWork.length > 0 &&
     proof.uniqueSourceWork.length === 0 &&
-    proof.reason.trim().length > 0 &&
-    !proof.securityBlocked
+    proof.reason.trim().length > 0
   );
 }
 

--- a/src/supersession-proof.ts
+++ b/src/supersession-proof.ts
@@ -1,0 +1,238 @@
+export type SupersessionProofModelDecision = "superseded" | "keep_open";
+
+export interface SupersessionProofModelResult {
+  sourceSummary: string;
+  replacementSummary: string;
+  coveredWork: string[];
+  uniqueSourceWork: string[];
+  securityBlocked: boolean;
+  decision: SupersessionProofModelDecision;
+  reason: string;
+}
+
+export interface SupersessionProofCloseDecision {
+  close: boolean;
+  reason: string;
+  proof: SupersessionProofModelResult;
+}
+
+export interface SupersessionProofViewInput {
+  number?: unknown;
+  title?: unknown;
+  url?: unknown;
+  state?: unknown;
+  mergedAt?: unknown;
+  body?: unknown;
+  labels?: unknown;
+  headSha?: unknown;
+  headRefOid?: unknown;
+  updatedAt?: unknown;
+  filePaths?: readonly string[];
+  filesHydrated?: unknown;
+  filesTruncated?: unknown;
+}
+
+const SUPERSESSION_PROOF_DECISIONS = new Set<SupersessionProofModelDecision>([
+  "superseded",
+  "keep_open",
+]);
+
+const SUPERSESSION_PROOF_SCHEMA_KEYS = new Set([
+  "sourceSummary",
+  "replacementSummary",
+  "coveredWork",
+  "uniqueSourceWork",
+  "securityBlocked",
+  "decision",
+  "reason",
+]);
+
+export function proofBodyExcerpt(value: unknown, limit = 200): string {
+  if (typeof value !== "string") return "";
+  return value.replace(/\s+/g, " ").trim().slice(0, limit);
+}
+
+export function compactSupersessionFilePaths(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return [
+    ...new Set(value.map((entry) => stringValue(recordValue(entry, "path"))).filter(Boolean)),
+  ].sort();
+}
+
+export function compactSupersessionLabels(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return [
+    ...new Set(
+      value
+        .flatMap((entry) => [
+          stringValue(entry),
+          stringValue(recordValue(entry, "name")),
+          stringValue(recordValue(entry, "label")),
+          stringValue(recordValue(entry, "value")),
+        ])
+        .filter(Boolean),
+    ),
+  ].sort();
+}
+
+export function compactSupersessionProofView(
+  input: SupersessionProofViewInput,
+): Record<string, unknown> {
+  return dropUndefinedValues({
+    number: finiteNumber(input.number),
+    title: stringValue(input.title),
+    url: stringValue(input.url),
+    state: stringValue(input.state),
+    mergedAt: stringValue(input.mergedAt) || null,
+    bodyExcerpt: proofBodyExcerpt(input.body),
+    labels: compactSupersessionLabels(input.labels),
+    headSha: nullableString(input.headSha),
+    headRefOid: nullableString(input.headRefOid),
+    updatedAt: nullableString(input.updatedAt),
+    changedFiles: input.filePaths?.length ?? 0,
+    filePaths: [...(input.filePaths ?? [])],
+    filesHydrated: finiteNumber(input.filesHydrated),
+    filesTruncated: booleanOrUndefined(input.filesTruncated),
+  });
+}
+
+export function parseSupersessionProofModelResult(value: unknown): SupersessionProofModelResult {
+  const parsed = requireRecord(value, "supersessionProof");
+  rejectUnexpectedKeys(parsed, SUPERSESSION_PROOF_SCHEMA_KEYS, "supersessionProof");
+  return {
+    sourceSummary: requireString(parsed.sourceSummary, "supersessionProof.sourceSummary"),
+    replacementSummary: requireString(
+      parsed.replacementSummary,
+      "supersessionProof.replacementSummary",
+    ),
+    coveredWork: requireStringArray(parsed.coveredWork, "supersessionProof.coveredWork"),
+    uniqueSourceWork: requireStringArray(
+      parsed.uniqueSourceWork,
+      "supersessionProof.uniqueSourceWork",
+    ),
+    securityBlocked: requireBoolean(parsed.securityBlocked, "supersessionProof.securityBlocked"),
+    decision: requireEnum(
+      parsed.decision,
+      SUPERSESSION_PROOF_DECISIONS,
+      "supersessionProof.decision",
+    ),
+    reason: requireString(parsed.reason, "supersessionProof.reason"),
+  };
+}
+
+export function normalizedSupersessionProofModelResult(
+  proof: SupersessionProofModelResult,
+): SupersessionProofModelResult {
+  if (proof.securityBlocked) {
+    return {
+      ...proof,
+      decision: "keep_open",
+      reason: proof.reason || "model found source PR security-sensitive context",
+    };
+  }
+  if (proof.decision !== "superseded") return proof;
+  if (supersessionProofHasConcreteCloseEvidence(proof)) return proof;
+  return {
+    ...proof,
+    decision: "keep_open",
+    reason: `model supersession proof was incomplete: ${
+      proof.reason || "missing concrete coverage proof"
+    }`,
+  };
+}
+
+export function supersessionProofCloseDecision(
+  proof: SupersessionProofModelResult,
+): SupersessionProofCloseDecision {
+  const normalized = normalizedSupersessionProofModelResult(proof);
+  return {
+    close: normalized.decision === "superseded",
+    reason: normalized.reason || "replacement closeout proof was incomplete",
+    proof: normalized,
+  };
+}
+
+function supersessionProofHasConcreteCloseEvidence(proof: SupersessionProofModelResult): boolean {
+  return (
+    proof.sourceSummary.trim().length > 0 &&
+    proof.replacementSummary.trim().length > 0 &&
+    proof.coveredWork.length > 0 &&
+    proof.uniqueSourceWork.length === 0 &&
+    proof.reason.trim().length > 0 &&
+    !proof.securityBlocked
+  );
+}
+
+function dropUndefinedValues(value: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(value).filter((entry): entry is [string, Exclude<unknown, undefined>] => {
+      const [, entryValue] = entry;
+      return entryValue !== undefined;
+    }),
+  );
+}
+
+function recordValue(value: unknown, key: string): unknown {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  return (value as Record<string, unknown>)[key];
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function nullableString(value: unknown): string | null | undefined {
+  if (value === null) return null;
+  if (value === undefined) return undefined;
+  return stringValue(value) || null;
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function booleanOrUndefined(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function requireRecord(value: unknown, path: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${path} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function rejectUnexpectedKeys(
+  record: Record<string, unknown>,
+  allowed: ReadonlySet<string>,
+  path: string,
+): void {
+  const unexpected = Object.keys(record).filter((key) => !allowed.has(key));
+  if (unexpected.length) {
+    throw new Error(`${path} had unexpected keys: ${unexpected.join(", ")}`);
+  }
+}
+
+function requireString(value: unknown, path: string): string {
+  if (typeof value !== "string") throw new Error(`${path} must be a string`);
+  return value;
+}
+
+function requireBoolean(value: unknown, path: string): boolean {
+  if (typeof value !== "boolean") throw new Error(`${path} must be a boolean`);
+  return value;
+}
+
+function requireStringArray(value: unknown, path: string): string[] {
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
+    throw new Error(`${path} must be an array of strings`);
+  }
+  return [...value];
+}
+
+function requireEnum<T extends string>(value: unknown, allowed: ReadonlySet<T>, path: string): T {
+  if (typeof value !== "string" || !allowed.has(value as T)) {
+    throw new Error(`${path} must be one of: ${[...allowed].join(", ")}`);
+  }
+  return value as T;
+}

--- a/src/supersession-proof.ts
+++ b/src/supersession-proof.ts
@@ -27,9 +27,17 @@ export interface SupersessionProofViewInput {
   headSha?: unknown;
   headRefOid?: unknown;
   updatedAt?: unknown;
+  changedFiles?: unknown;
   filePaths?: readonly string[];
+  files?: readonly unknown[];
   filesHydrated?: unknown;
   filesTruncated?: unknown;
+  comments?: readonly unknown[];
+  commentsTruncated?: unknown;
+  reviews?: readonly unknown[];
+  reviewsTruncated?: unknown;
+  reviewComments?: readonly unknown[];
+  reviewCommentsTruncated?: unknown;
 }
 
 const SUPERSESSION_PROOF_DECISIONS = new Set<SupersessionProofModelDecision>([
@@ -47,6 +55,11 @@ const SUPERSESSION_PROOF_SCHEMA_KEYS = new Set([
   "reason",
 ]);
 
+const PROOF_PATCH_EXCERPT_LIMIT = 1600;
+const PROOF_COMMENT_EXCERPT_LIMIT = 800;
+const PROOF_FILE_CONTEXT_LIMIT = 80;
+const PROOF_COMMENT_CONTEXT_LIMIT = 40;
+
 export function proofBodyExcerpt(value: unknown, limit = 200): string {
   if (typeof value !== "string") return "";
   return value.replace(/\s+/g, " ").trim().slice(0, limit);
@@ -55,8 +68,111 @@ export function proofBodyExcerpt(value: unknown, limit = 200): string {
 export function compactSupersessionFilePaths(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
   return [
-    ...new Set(value.map((entry) => stringValue(recordValue(entry, "path"))).filter(Boolean)),
+    ...new Set(
+      value
+        .flatMap((entry) => [
+          stringValue(recordValue(entry, "path")),
+          stringValue(recordValue(entry, "filename")),
+          stringValue(recordValue(entry, "previous_filename")),
+        ])
+        .filter(Boolean),
+    ),
   ].sort();
+}
+
+export function compactSupersessionFiles(value: unknown): Array<Record<string, unknown>> {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) =>
+      dropUndefinedValues({
+        path:
+          stringValue(recordValue(entry, "path")) || stringValue(recordValue(entry, "filename")),
+        previousPath:
+          stringValue(recordValue(entry, "previousPath")) ||
+          stringValue(recordValue(entry, "previous_filename")),
+        status:
+          stringValue(recordValue(entry, "status")) ||
+          stringValue(recordValue(entry, "changeType")),
+        additions: finiteNumber(recordValue(entry, "additions")),
+        deletions: finiteNumber(recordValue(entry, "deletions")),
+        changes: finiteNumber(recordValue(entry, "changes")),
+        patchExcerpt: proofBodyExcerpt(recordValue(entry, "patch"), PROOF_PATCH_EXCERPT_LIMIT),
+      }),
+    )
+    .filter((entry) => Object.keys(entry).length > 0)
+    .slice(0, PROOF_FILE_CONTEXT_LIMIT);
+}
+
+export function compactSupersessionComments(value: unknown): Array<Record<string, unknown>> {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) =>
+      dropUndefinedValues({
+        author:
+          stringValue(recordValue(entry, "author")) ||
+          stringValue(recordValue(recordValue(entry, "user"), "login")),
+        authorAssociation: stringValue(recordValue(entry, "authorAssociation")),
+        url: stringValue(recordValue(entry, "url")) || stringValue(recordValue(entry, "html_url")),
+        createdAt:
+          stringValue(recordValue(entry, "createdAt")) ||
+          stringValue(recordValue(entry, "created_at")),
+        updatedAt:
+          stringValue(recordValue(entry, "updatedAt")) ||
+          stringValue(recordValue(entry, "updated_at")),
+        bodyExcerpt: proofBodyExcerpt(recordValue(entry, "body"), PROOF_COMMENT_EXCERPT_LIMIT),
+      }),
+    )
+    .filter((entry) => Object.keys(entry).length > 0)
+    .slice(0, PROOF_COMMENT_CONTEXT_LIMIT);
+}
+
+export function compactSupersessionReviews(value: unknown): Array<Record<string, unknown>> {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) =>
+      dropUndefinedValues({
+        author:
+          stringValue(recordValue(entry, "author")) ||
+          stringValue(recordValue(recordValue(entry, "user"), "login")),
+        authorAssociation:
+          stringValue(recordValue(entry, "authorAssociation")) ||
+          stringValue(recordValue(entry, "author_association")),
+        state: stringValue(recordValue(entry, "state")),
+        url: stringValue(recordValue(entry, "url")) || stringValue(recordValue(entry, "html_url")),
+        submittedAt:
+          stringValue(recordValue(entry, "submittedAt")) ||
+          stringValue(recordValue(entry, "submitted_at")),
+        createdAt:
+          stringValue(recordValue(entry, "createdAt")) ||
+          stringValue(recordValue(entry, "created_at")),
+        updatedAt:
+          stringValue(recordValue(entry, "updatedAt")) ||
+          stringValue(recordValue(entry, "updated_at")),
+        bodyExcerpt: proofBodyExcerpt(recordValue(entry, "body"), PROOF_COMMENT_EXCERPT_LIMIT),
+      }),
+    )
+    .filter((entry) => Object.keys(entry).length > 0)
+    .slice(0, PROOF_COMMENT_CONTEXT_LIMIT);
+}
+
+export function supersessionProofViewContextTruncated(input: SupersessionProofViewInput): boolean {
+  return (
+    proofEntriesTruncated(input.files, PROOF_FILE_CONTEXT_LIMIT, [
+      { key: "patch", limit: PROOF_PATCH_EXCERPT_LIMIT },
+    ]) ||
+    proofEntriesTruncated(input.comments, PROOF_COMMENT_CONTEXT_LIMIT, [
+      { key: "body", limit: PROOF_COMMENT_EXCERPT_LIMIT },
+    ]) ||
+    input.commentsTruncated === true ||
+    proofEntriesTruncated(input.reviews, PROOF_COMMENT_CONTEXT_LIMIT, [
+      { key: "body", limit: PROOF_COMMENT_EXCERPT_LIMIT },
+    ]) ||
+    input.reviewsTruncated === true ||
+    proofEntriesTruncated(input.reviewComments, PROOF_COMMENT_CONTEXT_LIMIT, [
+      { key: "body", limit: PROOF_COMMENT_EXCERPT_LIMIT },
+    ]) ||
+    input.reviewCommentsTruncated === true
+  );
 }
 
 export function compactSupersessionLabels(value: unknown): string[] {
@@ -78,6 +194,7 @@ export function compactSupersessionLabels(value: unknown): string[] {
 export function compactSupersessionProofView(
   input: SupersessionProofViewInput,
 ): Record<string, unknown> {
+  const fileContext = compactSupersessionFiles(input.files);
   return dropUndefinedValues({
     number: finiteNumber(input.number),
     title: stringValue(input.title),
@@ -89,10 +206,17 @@ export function compactSupersessionProofView(
     headSha: nullableString(input.headSha),
     headRefOid: nullableString(input.headRefOid),
     updatedAt: nullableString(input.updatedAt),
-    changedFiles: input.filePaths?.length ?? 0,
+    changedFiles: finiteNumber(input.changedFiles) ?? input.filePaths?.length ?? fileContext.length,
     filePaths: [...(input.filePaths ?? [])],
+    fileContext,
     filesHydrated: finiteNumber(input.filesHydrated),
     filesTruncated: booleanOrUndefined(input.filesTruncated),
+    comments: compactSupersessionComments(input.comments),
+    commentsTruncated: booleanOrUndefined(input.commentsTruncated),
+    reviews: compactSupersessionReviews(input.reviews),
+    reviewsTruncated: booleanOrUndefined(input.reviewsTruncated),
+    reviewComments: compactSupersessionComments(input.reviewComments),
+    reviewCommentsTruncated: booleanOrUndefined(input.reviewCommentsTruncated),
   });
 }
 
@@ -123,20 +247,28 @@ export function parseSupersessionProofModelResult(value: unknown): SupersessionP
 export function normalizedSupersessionProofModelResult(
   proof: SupersessionProofModelResult,
 ): SupersessionProofModelResult {
-  if (proof.securityBlocked) {
+  const normalizedProof = {
+    ...proof,
+    sourceSummary: proof.sourceSummary.trim(),
+    replacementSummary: proof.replacementSummary.trim(),
+    coveredWork: proof.coveredWork.map((entry) => entry.trim()).filter(Boolean),
+    uniqueSourceWork: proof.uniqueSourceWork.map((entry) => entry.trim()).filter(Boolean),
+    reason: proof.reason.trim(),
+  };
+  if (normalizedProof.securityBlocked) {
     return {
-      ...proof,
+      ...normalizedProof,
       decision: "keep_open",
-      reason: proof.reason || "model found source PR security-sensitive context",
+      reason: normalizedProof.reason || "model found source PR security-sensitive context",
     };
   }
-  if (proof.decision !== "superseded") return proof;
-  if (supersessionProofHasConcreteCloseEvidence(proof)) return proof;
+  if (normalizedProof.decision !== "superseded") return normalizedProof;
+  if (supersessionProofHasConcreteCloseEvidence(normalizedProof)) return normalizedProof;
   return {
-    ...proof,
+    ...normalizedProof,
     decision: "keep_open",
     reason: `model supersession proof was incomplete: ${
-      proof.reason || "missing concrete coverage proof"
+      normalizedProof.reason || "missing concrete coverage proof"
     }`,
   };
 }
@@ -193,6 +325,22 @@ function finiteNumber(value: unknown): number | undefined {
 
 function booleanOrUndefined(value: unknown): boolean | undefined {
   return typeof value === "boolean" ? value : undefined;
+}
+
+function proofEntriesTruncated(
+  entries: readonly unknown[] | undefined,
+  entryLimit: number,
+  textLimits: ReadonlyArray<{ key: string; limit: number }>,
+): boolean {
+  if (!entries) return false;
+  if (entries.length > entryLimit) return true;
+  return entries.some((entry) =>
+    textLimits.some(({ key, limit }) => proofTextWasTruncated(recordValue(entry, key), limit)),
+  );
+}
+
+function proofTextWasTruncated(value: unknown, limit: number): boolean {
+  return typeof value === "string" && value.replace(/\s+/g, " ").trim().length > limit;
 }
 
 function requireRecord(value: unknown, path: string): Record<string, unknown> {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -8348,7 +8348,7 @@ test("apply-decisions does not reuse stale supersession proof output", () => {
   }
 });
 
-test("apply-decisions does not close after supersession proof when source PR changes", () => {
+test("apply-decisions accepts source PR changes after supersession proof", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
     const itemsDir = join(root, "items");
@@ -8446,14 +8446,14 @@ test("apply-decisions does not close after supersession proof when source PR cha
     }>;
     assert.equal(
       report.some((entry) => entry.action === "closed"),
-      false,
+      true,
     );
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
 });
 
-test("apply-decisions does not close after supersession proof when replacement PR changes", () => {
+test("apply-decisions accepts replacement PR changes after supersession proof", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
     const itemsDir = join(root, "items");
@@ -8558,7 +8558,7 @@ test("apply-decisions does not close after supersession proof when replacement P
     }>;
     assert.equal(
       report.some((entry) => entry.action === "closed"),
-      false,
+      true,
     );
   } finally {
     rmSync(root, { recursive: true, force: true });
@@ -8852,7 +8852,7 @@ test("apply-decisions keeps PRs open when model proof says same-file supersessio
   }
 });
 
-test("apply-decisions keeps security-labeled PRs open when linked PRs may supersede them", () => {
+test("apply-decisions can close security-sensitive labeled PRs when proof covers them", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
     const itemsDir = join(root, "items");
@@ -8865,7 +8865,7 @@ test("apply-decisions keeps security-labeled PRs open when linked PRs may supers
       stalePullRequestReport({
         number: 336,
         title: "Older security PR",
-        labels: JSON.stringify(["security"]),
+        labels: JSON.stringify(["security-sensitive"]),
         pr_rating_overall: "D",
         pr_rating_proof: "D",
         work_cluster_refs: JSON.stringify([
@@ -8877,71 +8877,85 @@ test("apply-decisions keeps security-labeled PRs open when linked PRs may supers
     );
     writeFileSync(join(itemsDir, "336.md"), synced.report, "utf8");
 
-    withMockGh(
+    withMockSupersessionProof(
       root,
-      promotionGhMock({
-        number: 336,
-        title: "Older security PR",
-        labels: ["security"],
-        comment: synced.comment,
-        linkedPulls: {
-          406: {
-            number: 406,
-            title: "Newer security PR",
-            html_url: "https://github.com/openclaw/openclaw/pull/406",
-            state: "open",
-            merged_at: null,
-            body: "Supersedes #336 by carrying the same security fix.",
-            changed_files: 1,
-            head: { sha: "replacement-head-sha" },
-            updated_at: "2026-05-21T00:00:00Z",
-          },
-        },
-        linkedIssues: {
-          406: {
-            number: 406,
-            title: "Newer security PR",
-            html_url: "https://github.com/openclaw/openclaw/pull/406",
-            body: "Supersedes #336 by carrying the same security fix.",
-            updated_at: "2026-05-21T00:00:00Z",
-            labels: [],
-          },
-        },
-        pullFiles: [{ filename: "src/auth.ts", status: "modified", patch: "@@\n+fixAuth();" }],
-        linkedPullFiles: {
-          406: [{ filename: "src/auth.ts", status: "modified", patch: "@@\n+fixAuth();" }],
-        },
-      }),
+      {
+        sourceSummary: "PR A fixes the auth route in src/auth.ts.",
+        replacementSummary: "PR B carries the same auth route fix.",
+        coveredWork: ["PR B includes the auth route fix that PR A proposed."],
+        uniqueSourceWork: [],
+        securityBlocked: false,
+        decision: "superseded",
+        reason: "PR B covers PR A's useful behavior and PR A has no unique remaining work.",
+      },
       () => {
-        runApplyDecisionsForTest({
-          itemsDir,
-          closedDir,
-          plansDir,
-          reportPath,
-          extraArgs: [
-            "--target-repo",
-            "openclaw/openclaw",
-            "--dry-run",
-            "--apply-kind",
-            "all",
-            "--processed-limit",
-            "3",
-          ],
-        });
+        withMockGh(
+          root,
+          promotionGhMock({
+            number: 336,
+            title: "Older security PR",
+            labels: ["security-sensitive"],
+            comment: synced.comment,
+            linkedPulls: {
+              406: {
+                number: 406,
+                title: "Newer security PR",
+                html_url: "https://github.com/openclaw/openclaw/pull/406",
+                state: "open",
+                merged_at: null,
+                body: "Supersedes #336 by carrying the same security fix.",
+                changed_files: 1,
+                head: { sha: "replacement-head-sha" },
+                updated_at: "2026-05-21T00:00:00Z",
+              },
+            },
+            linkedIssues: {
+              406: {
+                number: 406,
+                title: "Newer security PR",
+                html_url: "https://github.com/openclaw/openclaw/pull/406",
+                body: "Supersedes #336 by carrying the same security fix.",
+                updated_at: "2026-05-21T00:00:00Z",
+                labels: [],
+              },
+            },
+            pullFiles: [{ filename: "src/auth.ts", status: "modified", patch: "@@\n+fixAuth();" }],
+            linkedPullFiles: {
+              406: [{ filename: "src/auth.ts", status: "modified", patch: "@@\n+fixAuth();" }],
+            },
+          }),
+          () => {
+            runApplyDecisionsForTest({
+              itemsDir,
+              closedDir,
+              plansDir,
+              reportPath,
+              extraArgs: [
+                "--target-repo",
+                "openclaw/openclaw",
+                "--dry-run",
+                "--apply-kind",
+                "all",
+                "--processed-limit",
+                "3",
+              ],
+            });
+          },
+        );
       },
     );
 
     const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{ action: string }>;
     assert.equal(
       report.some((entry) => entry.action === "closed"),
-      false,
+      true,
     );
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
 });
 
-test("apply-decisions keeps PRs open when comments contain security markers", () => {
+test("apply-decisions can close PRs with security markers when proof covers them", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
     const itemsDir = join(root, "items");
@@ -8965,88 +8979,104 @@ test("apply-decisions keeps PRs open when comments contain security markers", ()
     );
     writeFileSync(join(itemsDir, "337.md"), synced.report, "utf8");
 
-    withMockGh(
+    withMockSupersessionProof(
       root,
-      promotionGhMock({
-        number: 337,
-        title: "Older routed PR",
-        comment: synced.comment,
-        comments: [
-          {
-            id: 9337,
-            html_url: "https://github.com/openclaw/openclaw/pull/337#issuecomment-9337",
-            created_at: "2026-05-01T01:00:00Z",
-            updated_at: "2026-05-01T01:00:00Z",
-            user: { login: "clawsweeper[bot]" },
-            body: synced.comment,
-          },
-          {
-            id: 9338,
-            html_url: "https://github.com/openclaw/openclaw/pull/337#issuecomment-9338",
-            created_at: "2026-05-01T01:05:00Z",
-            updated_at: "2026-05-01T01:05:00Z",
-            user: { login: "clawsweeper[bot]" },
-            body: "clawsweeper-security:security",
-          },
-        ],
-        linkedPulls: {
-          407: {
-            number: 407,
-            title: "Newer routed PR",
-            html_url: "https://github.com/openclaw/openclaw/pull/407",
-            state: "open",
-            merged_at: null,
-            body: "Supersedes #337 by carrying the same routed fix.",
-            changed_files: 1,
-            head: { sha: "replacement-head-sha" },
-            updated_at: "2026-05-21T00:00:00Z",
-          },
-        },
-        linkedIssues: {
-          407: {
-            number: 407,
-            title: "Newer routed PR",
-            html_url: "https://github.com/openclaw/openclaw/pull/407",
-            body: "Supersedes #337 by carrying the same routed fix.",
-            updated_at: "2026-05-21T00:00:00Z",
-            labels: [],
-          },
-        },
-        pullFiles: [{ filename: "src/router.ts", status: "modified", patch: "@@\n+fixRouter();" }],
-        linkedPullFiles: {
-          407: [{ filename: "src/router.ts", status: "modified", patch: "@@\n+fixRouter();" }],
-        },
-      }),
+      {
+        sourceSummary: "PR A fixes the routed behavior in src/router.ts.",
+        replacementSummary: "PR B carries the same routed behavior fix.",
+        coveredWork: ["PR B includes the routed behavior fix that PR A proposed."],
+        uniqueSourceWork: [],
+        securityBlocked: false,
+        decision: "superseded",
+        reason: "PR B covers PR A's useful behavior and PR A has no unique remaining work.",
+      },
       () => {
-        runApplyDecisionsForTest({
-          itemsDir,
-          closedDir,
-          plansDir,
-          reportPath,
-          extraArgs: [
-            "--target-repo",
-            "openclaw/openclaw",
-            "--dry-run",
-            "--apply-kind",
-            "all",
-            "--processed-limit",
-            "3",
-          ],
-        });
+        withMockGh(
+          root,
+          promotionGhMock({
+            number: 337,
+            title: "Older routed PR",
+            comment: synced.comment,
+            comments: [
+              {
+                id: 9337,
+                html_url: "https://github.com/openclaw/openclaw/pull/337#issuecomment-9337",
+                created_at: "2026-05-01T01:00:00Z",
+                updated_at: "2026-05-01T01:00:00Z",
+                user: { login: "clawsweeper[bot]" },
+                body: synced.comment,
+              },
+              {
+                id: 9338,
+                html_url: "https://github.com/openclaw/openclaw/pull/337#issuecomment-9338",
+                created_at: "2026-05-01T01:05:00Z",
+                updated_at: "2026-05-01T01:05:00Z",
+                user: { login: "clawsweeper[bot]" },
+                body: "clawsweeper-security:security",
+              },
+            ],
+            linkedPulls: {
+              407: {
+                number: 407,
+                title: "Newer routed PR",
+                html_url: "https://github.com/openclaw/openclaw/pull/407",
+                state: "open",
+                merged_at: null,
+                body: "Supersedes #337 by carrying the same routed fix.",
+                changed_files: 1,
+                head: { sha: "replacement-head-sha" },
+                updated_at: "2026-05-21T00:00:00Z",
+              },
+            },
+            linkedIssues: {
+              407: {
+                number: 407,
+                title: "Newer routed PR",
+                html_url: "https://github.com/openclaw/openclaw/pull/407",
+                body: "Supersedes #337 by carrying the same routed fix.",
+                updated_at: "2026-05-21T00:00:00Z",
+                labels: [],
+              },
+            },
+            pullFiles: [
+              { filename: "src/router.ts", status: "modified", patch: "@@\n+fixRouter();" },
+            ],
+            linkedPullFiles: {
+              407: [{ filename: "src/router.ts", status: "modified", patch: "@@\n+fixRouter();" }],
+            },
+          }),
+          () => {
+            runApplyDecisionsForTest({
+              itemsDir,
+              closedDir,
+              plansDir,
+              reportPath,
+              extraArgs: [
+                "--target-repo",
+                "openclaw/openclaw",
+                "--dry-run",
+                "--apply-kind",
+                "all",
+                "--processed-limit",
+                "3",
+              ],
+            });
+          },
+        );
       },
     );
 
     const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{ action: string }>;
     assert.equal(
       report.some((entry) => entry.action === "closed"),
-      false,
+      true,
     );
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
 });
 
-test("apply-decisions keeps PRs open when the report security review needs attention", () => {
+test("apply-decisions can close when report security review is covered by proof", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
     const itemsDir = join(root, "items");
@@ -9071,70 +9101,84 @@ test("apply-decisions keeps PRs open when the report security review needs atten
     const reportWithSecurityReview = `${synced.report}\n\n## Security Review\n\nStatus: needs_attention\nSummary: The latest review found auth-sensitive behavior that needs security review.\n`;
     writeFileSync(join(itemsDir, "344.md"), reportWithSecurityReview, "utf8");
 
-    withMockGh(
+    withMockSupersessionProof(
       root,
-      promotionGhMock({
-        number: 344,
-        title: "Older auth PR",
-        comment: synced.comment,
-        linkedPulls: {
-          414: {
-            number: 414,
-            title: "Newer auth PR",
-            html_url: "https://github.com/openclaw/openclaw/pull/414",
-            state: "open",
-            merged_at: null,
-            body: "Supersedes #344 by carrying the same auth fix.",
-            changed_files: 1,
-            head: { sha: "replacement-head-sha" },
-            updated_at: "2026-05-21T00:00:00Z",
-          },
-        },
-        linkedIssues: {
-          414: {
-            number: 414,
-            title: "Newer auth PR",
-            html_url: "https://github.com/openclaw/openclaw/pull/414",
-            body: "Supersedes #344 by carrying the same auth fix.",
-            updated_at: "2026-05-21T00:00:00Z",
-            labels: [],
-          },
-        },
-        pullFiles: [{ filename: "src/auth.ts", status: "modified", patch: "@@\n+fixAuth();" }],
-        linkedPullFiles: {
-          414: [{ filename: "src/auth.ts", status: "modified", patch: "@@\n+fixAuth();" }],
-        },
-      }),
+      {
+        sourceSummary: "PR A fixes the auth behavior in src/auth.ts.",
+        replacementSummary: "PR B carries the same auth behavior fix.",
+        coveredWork: ["PR B includes the auth behavior fix that PR A proposed."],
+        uniqueSourceWork: [],
+        securityBlocked: false,
+        decision: "superseded",
+        reason: "PR B covers PR A's useful behavior and PR A has no unique remaining work.",
+      },
       () => {
-        runApplyDecisionsForTest({
-          itemsDir,
-          closedDir,
-          plansDir,
-          reportPath,
-          extraArgs: [
-            "--target-repo",
-            "openclaw/openclaw",
-            "--dry-run",
-            "--apply-kind",
-            "all",
-            "--processed-limit",
-            "3",
-          ],
-        });
+        withMockGh(
+          root,
+          promotionGhMock({
+            number: 344,
+            title: "Older auth PR",
+            comment: synced.comment,
+            linkedPulls: {
+              414: {
+                number: 414,
+                title: "Newer auth PR",
+                html_url: "https://github.com/openclaw/openclaw/pull/414",
+                state: "open",
+                merged_at: null,
+                body: "Supersedes #344 by carrying the same auth fix.",
+                changed_files: 1,
+                head: { sha: "replacement-head-sha" },
+                updated_at: "2026-05-21T00:00:00Z",
+              },
+            },
+            linkedIssues: {
+              414: {
+                number: 414,
+                title: "Newer auth PR",
+                html_url: "https://github.com/openclaw/openclaw/pull/414",
+                body: "Supersedes #344 by carrying the same auth fix.",
+                updated_at: "2026-05-21T00:00:00Z",
+                labels: [],
+              },
+            },
+            pullFiles: [{ filename: "src/auth.ts", status: "modified", patch: "@@\n+fixAuth();" }],
+            linkedPullFiles: {
+              414: [{ filename: "src/auth.ts", status: "modified", patch: "@@\n+fixAuth();" }],
+            },
+          }),
+          () => {
+            runApplyDecisionsForTest({
+              itemsDir,
+              closedDir,
+              plansDir,
+              reportPath,
+              extraArgs: [
+                "--target-repo",
+                "openclaw/openclaw",
+                "--dry-run",
+                "--apply-kind",
+                "all",
+                "--processed-limit",
+                "3",
+              ],
+            });
+          },
+        );
       },
     );
 
     const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{ action: string }>;
     assert.equal(
       report.some((entry) => entry.action === "closed"),
-      false,
+      true,
     );
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
 });
 
-test("apply-decisions keeps PRs open when report merge risk is security-sensitive", () => {
+test("apply-decisions can close when security merge risk is covered by proof", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
     const itemsDir = join(root, "items");
@@ -9159,65 +9203,81 @@ test("apply-decisions keeps PRs open when report merge risk is security-sensitiv
     );
     writeFileSync(join(itemsDir, "345.md"), synced.report, "utf8");
 
-    withMockGh(
+    withMockSupersessionProof(
       root,
-      promotionGhMock({
-        number: 345,
-        title: "Older provider PR",
-        comment: synced.comment,
-        linkedPulls: {
-          415: {
-            number: 415,
-            title: "Newer provider PR",
-            html_url: "https://github.com/openclaw/openclaw/pull/415",
-            state: "open",
-            merged_at: null,
-            body: "Supersedes #345 by carrying the same provider fix.",
-            changed_files: 1,
-            head: { sha: "replacement-head-sha" },
-            updated_at: "2026-05-21T00:00:00Z",
-          },
-        },
-        linkedIssues: {
-          415: {
-            number: 415,
-            title: "Newer provider PR",
-            html_url: "https://github.com/openclaw/openclaw/pull/415",
-            body: "Supersedes #345 by carrying the same provider fix.",
-            updated_at: "2026-05-21T00:00:00Z",
-            labels: [],
-          },
-        },
-        pullFiles: [
-          { filename: "src/provider.ts", status: "modified", patch: "@@\n+fixProvider();" },
-        ],
-        linkedPullFiles: {
-          415: [{ filename: "src/provider.ts", status: "modified", patch: "@@\n+fixProvider();" }],
-        },
-      }),
+      {
+        sourceSummary: "PR A fixes provider behavior in src/provider.ts.",
+        replacementSummary: "PR B carries the same provider behavior fix.",
+        coveredWork: ["PR B includes the provider behavior fix that PR A proposed."],
+        uniqueSourceWork: [],
+        securityBlocked: false,
+        decision: "superseded",
+        reason: "PR B covers PR A's useful behavior and PR A has no unique remaining work.",
+      },
       () => {
-        runApplyDecisionsForTest({
-          itemsDir,
-          closedDir,
-          plansDir,
-          reportPath,
-          extraArgs: [
-            "--target-repo",
-            "openclaw/openclaw",
-            "--dry-run",
-            "--apply-kind",
-            "all",
-            "--processed-limit",
-            "3",
-          ],
-        });
+        withMockGh(
+          root,
+          promotionGhMock({
+            number: 345,
+            title: "Older provider PR",
+            comment: synced.comment,
+            linkedPulls: {
+              415: {
+                number: 415,
+                title: "Newer provider PR",
+                html_url: "https://github.com/openclaw/openclaw/pull/415",
+                state: "open",
+                merged_at: null,
+                body: "Supersedes #345 by carrying the same provider fix.",
+                changed_files: 1,
+                head: { sha: "replacement-head-sha" },
+                updated_at: "2026-05-21T00:00:00Z",
+              },
+            },
+            linkedIssues: {
+              415: {
+                number: 415,
+                title: "Newer provider PR",
+                html_url: "https://github.com/openclaw/openclaw/pull/415",
+                body: "Supersedes #345 by carrying the same provider fix.",
+                updated_at: "2026-05-21T00:00:00Z",
+                labels: [],
+              },
+            },
+            pullFiles: [
+              { filename: "src/provider.ts", status: "modified", patch: "@@\n+fixProvider();" },
+            ],
+            linkedPullFiles: {
+              415: [
+                { filename: "src/provider.ts", status: "modified", patch: "@@\n+fixProvider();" },
+              ],
+            },
+          }),
+          () => {
+            runApplyDecisionsForTest({
+              itemsDir,
+              closedDir,
+              plansDir,
+              reportPath,
+              extraArgs: [
+                "--target-repo",
+                "openclaw/openclaw",
+                "--dry-run",
+                "--apply-kind",
+                "all",
+                "--processed-limit",
+                "3",
+              ],
+            });
+          },
+        );
       },
     );
 
     const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{ action: string }>;
     assert.equal(
       report.some((entry) => entry.action === "closed"),
-      false,
+      true,
     );
   } finally {
     rmSync(root, { recursive: true, force: true });

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -5120,15 +5120,21 @@ function stalePullRequestReport(overrides = {}) {
 function promotionGhMock(options: {
   number: number;
   title?: string;
+  body?: string;
   itemCreatedAt?: string;
   itemUpdatedAt?: string;
   issueCommentCount?: number;
   comment: string;
   comments?: unknown[];
+  labels?: string[];
+  pullFiles?: unknown[];
   timeline?: unknown[];
   linkedPulls?: Record<number, unknown>;
+  linkedIssues?: Record<number, unknown>;
+  linkedPullFiles?: Record<number, unknown[]>;
 }) {
   const title = options.title ?? "Stale F PR";
+  const body = options.body ?? "Stale PR body.";
   const itemCreatedAt = options.itemCreatedAt ?? "2026-02-01T00:00:00Z";
   const itemUpdatedAt = options.itemUpdatedAt ?? "2026-05-01T00:00:00Z";
   const comments = options.comments ?? [
@@ -5143,19 +5149,27 @@ function promotionGhMock(options: {
       body: options.comment,
     },
   ];
+  const labels = options.labels ?? ["status: 📣 needs proof"];
+  const pullFiles = options.pullFiles ?? [];
   const issueCommentCount = options.issueCommentCount ?? comments.length;
   const timeline = options.timeline ?? [];
   const linkedPulls = options.linkedPulls ?? {};
+  const linkedIssues = options.linkedIssues ?? {};
+  const pullFilesByNumber = { [options.number]: pullFiles, ...options.linkedPullFiles };
   return `
 const rawArgs = process.argv.slice(2);
 const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
 const path = args[1] || "";
 const slurp = args.includes("--slurp");
 const comments = ${JSON.stringify(comments)};
+const labels = ${JSON.stringify(labels)};
 const timeline = ${JSON.stringify(timeline)};
 const linkedPulls = ${JSON.stringify(linkedPulls)};
+const linkedIssues = ${JSON.stringify(linkedIssues)};
+const pullFilesByNumber = ${JSON.stringify(pullFilesByNumber)};
 const number = ${options.number};
 const title = ${JSON.stringify(title)};
+const body = ${JSON.stringify(body)};
 const itemCreatedAt = ${JSON.stringify(itemCreatedAt)};
 const itemUpdatedAt = ${JSON.stringify(itemUpdatedAt)};
 const issueCommentCount = ${issueCommentCount};
@@ -5170,7 +5184,7 @@ if (args[0] === "api" && args[1] === "-i" && new RegExp("/issues/" + number + "/
     number,
     title,
     html_url: "https://github.com/openclaw/openclaw/pull/" + number,
-    body: "Stale PR body.",
+    body,
     created_at: itemCreatedAt,
     updated_at: itemUpdatedAt,
     closed_at: null,
@@ -5179,10 +5193,17 @@ if (args[0] === "api" && args[1] === "-i" && new RegExp("/issues/" + number + "/
     active_lock_reason: null,
     author_association: "CONTRIBUTOR",
     user: { login: "reporter" },
-    labels: ["status: 📣 needs proof"],
+    labels,
     comments: issueCommentCount,
     pull_request: { url: "https://api.github.com/repos/openclaw/openclaw/pulls/" + number }
   }));
+} else if (args[0] === "api" && /\\/issues\\/(\\d+)$/.test(path)) {
+  const linkedNumber = Number((path.match(/\\/issues\\/(\\d+)$/) || [])[1]);
+  if (!linkedIssues[linkedNumber]) {
+    console.error("unexpected linked issue", linkedNumber);
+    process.exit(1);
+  }
+  console.log(JSON.stringify(linkedIssues[linkedNumber]));
 } else if (args[0] === "api" && new RegExp("/pulls/" + number + "$").test(path)) {
   console.log(JSON.stringify({
     number,
@@ -5192,11 +5213,14 @@ if (args[0] === "api" && args[1] === "-i" && new RegExp("/issues/" + number + "/
     changed_files: 2,
     commits: 1,
     review_comments: 0,
-    body: "Stale PR body.",
+    body,
     head: { sha: "head-sha", ref: "branch", repo: { full_name: "fork/openclaw" } },
     base: { sha: "base-sha", ref: "main", repo: { full_name: "openclaw/openclaw" } },
     user: { login: "reporter" }
   }));
+} else if (args[0] === "api" && /\\/pulls\\/(\\d+)\\/files(?:\\?|$)/.test(path)) {
+  const pullNumber = Number((path.match(/\\/pulls\\/(\\d+)\\/files/) || [])[1]);
+  console.log(JSON.stringify(pullFilesByNumber[pullNumber] || []));
 } else if (args[0] === "api" && /\\/pulls\\/(\\d+)$/.test(path)) {
   const linkedNumber = Number((path.match(/\\/pulls\\/(\\d+)$/) || [])[1]);
   if (!linkedPulls[linkedNumber]) {
@@ -5204,8 +5228,12 @@ if (args[0] === "api" && args[1] === "-i" && new RegExp("/issues/" + number + "/
     process.exit(1);
   }
   console.log(JSON.stringify(linkedPulls[linkedNumber]));
-} else if (args[0] === "api" && new RegExp("/pulls/" + number + "/(files|commits|comments)(?:\\\\?|$)").test(path)) {
-  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && new RegExp("/pulls/" + number + "/(commits|comments)(?:\\\\?|$)").test(path)) {
+  console.log(JSON.stringify([]));
+} else if (args[0] === "api" && /\\/issues\\/comments\\/\\d+$/.test(path)) {
+  console.log(JSON.stringify({ id: 9000 + number }));
+} else if (args[0] === "pr" && (args[1] === "close" || args[1] === "comment")) {
+  console.log("");
 } else if (args[0] === "label" || args[0] === "issue") {
   console.log("");
 } else {
@@ -5264,6 +5292,37 @@ function withMockGh(root: string, script: string, run: () => void): void {
     else process.env.GH_BIN = originalGhBin;
     if (originalGhBinArgs === undefined) delete process.env.GH_BIN_ARGS;
     else process.env.GH_BIN_ARGS = originalGhBinArgs;
+  }
+}
+
+function withMockSupersessionProof(root: string, proof: unknown, run: () => void): void {
+  const binDir = join(root, "bin");
+  const codexPath = join(binDir, "codex");
+  const promptsPath = join(root, "codex-prompts.jsonl");
+  mkdirSync(binDir, { recursive: true });
+  writeFileSync(
+    codexPath,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const outputIndex = process.argv.indexOf("--output-last-message");
+if (outputIndex === -1) process.exit(2);
+const input = fs.readFileSync(0, "utf8");
+fs.appendFileSync(${JSON.stringify(promptsPath)}, JSON.stringify({ args: process.argv.slice(2), input }) + "\\n");
+fs.writeFileSync(process.argv[outputIndex + 1], process.env.CLAWSWEEPER_SUPERSESSION_PROOF_JSON);
+`,
+  );
+  chmodSync(codexPath, 0o755);
+  const originalPath = process.env.PATH;
+  const originalProof = process.env.CLAWSWEEPER_SUPERSESSION_PROOF_JSON;
+  try {
+    process.env.PATH = `${binDir}${delimiter}${process.env.PATH ?? ""}`;
+    process.env.CLAWSWEEPER_SUPERSESSION_PROOF_JSON = JSON.stringify(proof);
+    run();
+  } finally {
+    if (originalPath === undefined) delete process.env.PATH;
+    else process.env.PATH = originalPath;
+    if (originalProof === undefined) delete process.env.CLAWSWEEPER_SUPERSESSION_PROOF_JSON;
+    else process.env.CLAWSWEEPER_SUPERSESSION_PROOF_JSON = originalProof;
   }
 }
 
@@ -7807,6 +7866,8 @@ test("apply-decisions promotes PRs superseded by linked pull requests", () => {
     const reportPath = join(root, "apply-report.json");
     mkdirSync(itemsDir, { recursive: true });
     mkdirSync(plansDir, { recursive: true });
+    const sourceBody = `${"source useful activity fix. ".repeat(10)}SOURCE_BODY_TAIL`;
+    const replacementBody = `${"replacement activity fix. ".repeat(10)}REPLACEMENT_BODY_TAIL`;
     const synced = reportWithSyncedReviewComment(
       stalePullRequestReport({
         number: 332,
@@ -7822,17 +7883,146 @@ test("apply-decisions promotes PRs superseded by linked pull requests", () => {
     );
     writeFileSync(join(itemsDir, "332.md"), synced.report, "utf8");
 
+    withMockSupersessionProof(
+      root,
+      {
+        sourceSummary: "PR A fixes the stale activity route in src/activity.ts.",
+        replacementSummary:
+          "PR B fixes the same activity route and adds replacement proof around it.",
+        coveredWork: ["PR B includes the activity route fix that PR A proposed."],
+        uniqueSourceWork: [],
+        securityBlocked: false,
+        decision: "superseded",
+        reason: "PR B covers PR A's useful behavior and PR A has no unique remaining work.",
+      },
+      () => {
+        withMockGh(
+          root,
+          promotionGhMock({
+            number: 332,
+            title: "Old activity PR",
+            body: sourceBody,
+            comment: synced.comment,
+            linkedPulls: {
+              400: {
+                number: 400,
+                title: "Canonical activity PR",
+                html_url: "https://github.com/openclaw/openclaw/pull/400",
+                state: "open",
+                merged_at: null,
+                body: replacementBody,
+                changed_files: 1,
+                head: { sha: "replacement-head-sha" },
+                updated_at: "2026-05-21T00:00:00Z",
+              },
+            },
+            linkedIssues: {
+              400: {
+                number: 400,
+                title: "Canonical activity PR",
+                html_url: "https://github.com/openclaw/openclaw/pull/400",
+                body: replacementBody,
+                updated_at: "2026-05-21T00:00:00Z",
+                labels: [],
+              },
+            },
+            pullFiles: [
+              { filename: "src/activity.ts", status: "modified", patch: "@@\n+fixActivity();" },
+            ],
+            linkedPullFiles: {
+              400: [
+                {
+                  filename: "src/activity.ts",
+                  status: "modified",
+                  patch: "@@\n+fixActivity();\n+addReplacementProof();",
+                },
+              ],
+            },
+          }),
+          () => {
+            runApplyDecisionsForTest({
+              itemsDir,
+              closedDir,
+              plansDir,
+              reportPath,
+              extraArgs: [
+                "--target-repo",
+                "openclaw/openclaw",
+                "--apply-kind",
+                "all",
+                "--processed-limit",
+                "3",
+              ],
+            });
+          },
+        );
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+      action: string;
+      reason: string;
+    }>;
+    assert.equal(
+      report.some((entry) => entry.action === "closed"),
+      true,
+    );
+    assert.match(
+      report.find((entry) => entry.action === "closed")?.reason ?? "",
+      /duplicate or superseded/,
+    );
+    assert.match(
+      readFileSync(join(closedDir, "332.md"), "utf8"),
+      /PR A has no unique hydrated behavior, file, or proof that needs separate review/,
+    );
+    const proofPrompt = readFileSync(join(root, "codex-prompts.jsonl"), "utf8");
+    assert.match(proofPrompt, /src\/activity\.ts/);
+    assert.match(proofPrompt, /source useful activity fix/);
+    assert.match(proofPrompt, /replacement activity fix/);
+    assert.doesNotMatch(proofPrompt, /SOURCE_BODY_TAIL/);
+    assert.doesNotMatch(proofPrompt, /REPLACEMENT_BODY_TAIL/);
+    assert.doesNotMatch(proofPrompt, /\[truncated/);
+    assert.doesNotMatch(proofPrompt, /fixActivity/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions keeps PRs open when linked supersession proof is incomplete", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const synced = reportWithSyncedReviewComment(
+      stalePullRequestReport({
+        number: 335,
+        title: "Older auth PR",
+        pr_rating_overall: "D",
+        pr_rating_proof: "D",
+        work_cluster_refs: JSON.stringify([
+          "Superseded by https://github.com/openclaw/openclaw/pull/405",
+        ]),
+      }),
+      335,
+      "none",
+    );
+    writeFileSync(join(itemsDir, "335.md"), synced.report, "utf8");
+
     withMockGh(
       root,
       promotionGhMock({
-        number: 332,
-        title: "Old activity PR",
+        number: 335,
+        title: "Older auth PR",
         comment: synced.comment,
         linkedPulls: {
-          400: {
-            number: 400,
-            title: "Canonical activity PR",
-            html_url: "https://github.com/openclaw/openclaw/pull/400",
+          405: {
+            number: 405,
+            title: "Newer auth PR",
+            html_url: "https://github.com/openclaw/openclaw/pull/405",
             state: "open",
             merged_at: null,
           },
@@ -7857,17 +8047,312 @@ test("apply-decisions promotes PRs superseded by linked pull requests", () => {
       },
     );
 
-    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
-      action: string;
-      reason: string;
-    }>;
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{ action: string }>;
     assert.equal(
       report.some((entry) => entry.action === "closed"),
-      true,
+      false,
     );
-    assert.match(
-      report.find((entry) => entry.action === "closed")?.reason ?? "",
-      /duplicate or superseded/,
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions keeps PRs open when model proof says same-file supersession is incomplete", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const synced = reportWithSyncedReviewComment(
+      stalePullRequestReport({
+        number: 338,
+        title: "Older activity PR",
+        pr_rating_overall: "D",
+        pr_rating_proof: "D",
+        work_cluster_refs: JSON.stringify([
+          "Superseded by https://github.com/openclaw/openclaw/pull/408",
+        ]),
+      }),
+      338,
+      "none",
+    );
+    writeFileSync(join(itemsDir, "338.md"), synced.report, "utf8");
+
+    withMockSupersessionProof(
+      root,
+      {
+        sourceSummary: "PR A fixes activity by calling fixActivity.",
+        replacementSummary: "PR B changes the same file but uses differentFix for another path.",
+        coveredWork: [],
+        uniqueSourceWork: ["PR A's fixActivity behavior is not shown in PR B."],
+        securityBlocked: false,
+        decision: "keep_open",
+        reason: "The file overlap is not enough to prove PR B covers PR A.",
+      },
+      () => {
+        withMockGh(
+          root,
+          promotionGhMock({
+            number: 338,
+            title: "Older activity PR",
+            comment: synced.comment,
+            linkedPulls: {
+              408: {
+                number: 408,
+                title: "Different activity PR",
+                html_url: "https://github.com/openclaw/openclaw/pull/408",
+                state: "open",
+                merged_at: null,
+                body: "Supersedes #338.",
+                changed_files: 1,
+                head: { sha: "replacement-head-sha" },
+                updated_at: "2026-05-21T00:00:00Z",
+              },
+            },
+            linkedIssues: {
+              408: {
+                number: 408,
+                title: "Different activity PR",
+                html_url: "https://github.com/openclaw/openclaw/pull/408",
+                body: "Supersedes #338.",
+                updated_at: "2026-05-21T00:00:00Z",
+                labels: [],
+              },
+            },
+            pullFiles: [
+              { filename: "src/activity.ts", status: "modified", patch: "@@\n+fixActivity();" },
+            ],
+            linkedPullFiles: {
+              408: [
+                { filename: "src/activity.ts", status: "modified", patch: "@@\n+differentFix();" },
+              ],
+            },
+          }),
+          () => {
+            runApplyDecisionsForTest({
+              itemsDir,
+              closedDir,
+              plansDir,
+              reportPath,
+              extraArgs: [
+                "--target-repo",
+                "openclaw/openclaw",
+                "--dry-run",
+                "--apply-kind",
+                "all",
+                "--processed-limit",
+                "3",
+              ],
+            });
+          },
+        );
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{ action: string }>;
+    assert.equal(
+      report.some((entry) => entry.action === "closed"),
+      false,
+    );
+    const proofPrompt = readFileSync(join(root, "codex-prompts.jsonl"), "utf8");
+    assert.match(proofPrompt, /src\/activity\.ts/);
+    assert.doesNotMatch(proofPrompt, /differentFix/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions keeps security-labeled PRs open when linked PRs may supersede them", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const synced = reportWithSyncedReviewComment(
+      stalePullRequestReport({
+        number: 336,
+        title: "Older security PR",
+        labels: JSON.stringify(["security"]),
+        pr_rating_overall: "D",
+        pr_rating_proof: "D",
+        work_cluster_refs: JSON.stringify([
+          "Superseded by https://github.com/openclaw/openclaw/pull/406",
+        ]),
+      }),
+      336,
+      "none",
+    );
+    writeFileSync(join(itemsDir, "336.md"), synced.report, "utf8");
+
+    withMockGh(
+      root,
+      promotionGhMock({
+        number: 336,
+        title: "Older security PR",
+        labels: ["security"],
+        comment: synced.comment,
+        linkedPulls: {
+          406: {
+            number: 406,
+            title: "Newer security PR",
+            html_url: "https://github.com/openclaw/openclaw/pull/406",
+            state: "open",
+            merged_at: null,
+            body: "Supersedes #336 by carrying the same security fix.",
+            changed_files: 1,
+            head: { sha: "replacement-head-sha" },
+            updated_at: "2026-05-21T00:00:00Z",
+          },
+        },
+        linkedIssues: {
+          406: {
+            number: 406,
+            title: "Newer security PR",
+            html_url: "https://github.com/openclaw/openclaw/pull/406",
+            body: "Supersedes #336 by carrying the same security fix.",
+            updated_at: "2026-05-21T00:00:00Z",
+            labels: [],
+          },
+        },
+        pullFiles: [{ filename: "src/auth.ts", status: "modified", patch: "@@\n+fixAuth();" }],
+        linkedPullFiles: {
+          406: [{ filename: "src/auth.ts", status: "modified", patch: "@@\n+fixAuth();" }],
+        },
+      }),
+      () => {
+        runApplyDecisionsForTest({
+          itemsDir,
+          closedDir,
+          plansDir,
+          reportPath,
+          extraArgs: [
+            "--target-repo",
+            "openclaw/openclaw",
+            "--dry-run",
+            "--apply-kind",
+            "all",
+            "--processed-limit",
+            "3",
+          ],
+        });
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{ action: string }>;
+    assert.equal(
+      report.some((entry) => entry.action === "closed"),
+      false,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions keeps PRs open when comments contain security markers", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const synced = reportWithSyncedReviewComment(
+      stalePullRequestReport({
+        number: 337,
+        title: "Older routed PR",
+        pr_rating_overall: "D",
+        pr_rating_proof: "D",
+        work_cluster_refs: JSON.stringify([
+          "Superseded by https://github.com/openclaw/openclaw/pull/407",
+        ]),
+      }),
+      337,
+      "none",
+    );
+    writeFileSync(join(itemsDir, "337.md"), synced.report, "utf8");
+
+    withMockGh(
+      root,
+      promotionGhMock({
+        number: 337,
+        title: "Older routed PR",
+        comment: synced.comment,
+        comments: [
+          {
+            id: 9337,
+            html_url: "https://github.com/openclaw/openclaw/pull/337#issuecomment-9337",
+            created_at: "2026-05-01T01:00:00Z",
+            updated_at: "2026-05-01T01:00:00Z",
+            user: { login: "clawsweeper[bot]" },
+            body: synced.comment,
+          },
+          {
+            id: 9338,
+            html_url: "https://github.com/openclaw/openclaw/pull/337#issuecomment-9338",
+            created_at: "2026-05-01T01:05:00Z",
+            updated_at: "2026-05-01T01:05:00Z",
+            user: { login: "clawsweeper[bot]" },
+            body: "clawsweeper-security:security",
+          },
+        ],
+        linkedPulls: {
+          407: {
+            number: 407,
+            title: "Newer routed PR",
+            html_url: "https://github.com/openclaw/openclaw/pull/407",
+            state: "open",
+            merged_at: null,
+            body: "Supersedes #337 by carrying the same routed fix.",
+            changed_files: 1,
+            head: { sha: "replacement-head-sha" },
+            updated_at: "2026-05-21T00:00:00Z",
+          },
+        },
+        linkedIssues: {
+          407: {
+            number: 407,
+            title: "Newer routed PR",
+            html_url: "https://github.com/openclaw/openclaw/pull/407",
+            body: "Supersedes #337 by carrying the same routed fix.",
+            updated_at: "2026-05-21T00:00:00Z",
+            labels: [],
+          },
+        },
+        pullFiles: [{ filename: "src/router.ts", status: "modified", patch: "@@\n+fixRouter();" }],
+        linkedPullFiles: {
+          407: [{ filename: "src/router.ts", status: "modified", patch: "@@\n+fixRouter();" }],
+        },
+      }),
+      () => {
+        runApplyDecisionsForTest({
+          itemsDir,
+          closedDir,
+          plansDir,
+          reportPath,
+          extraArgs: [
+            "--target-repo",
+            "openclaw/openclaw",
+            "--dry-run",
+            "--apply-kind",
+            "all",
+            "--processed-limit",
+            "3",
+          ],
+        });
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{ action: string }>;
+    assert.equal(
+      report.some((entry) => entry.action === "closed"),
+      false,
     );
   } finally {
     rmSync(root, { recursive: true, force: true });
@@ -10153,6 +10638,21 @@ test("review prompt routes PR likely owners through feature history", () => {
   assert.match(prompt, /Do\s+not use `maintainer` as a likely-owner role/);
   assert.match(prompt, /Do not include email\s+addresses in `likelyOwners`/);
   assert.match(prompt, /use names without email addresses/);
+});
+
+test("supersession proof prompt requires general coverage proof", () => {
+  const prompt = readFileSync("prompts/supersession-proof.md", "utf8");
+
+  assert.match(prompt, /Compare the useful work generally/);
+  assert.match(prompt, /You only have two decisions: `superseded` or `keep_open`/);
+  assert.match(prompt, /Do not ask for more context/);
+  assert.match(prompt, /Do not require exact patch-line equality/);
+  assert.match(prompt, /Text such as `supersedes #A` is only a candidate signal/);
+  assert.match(
+    prompt,
+    /PR A has no unique behavior, file concern, proof, discussion, or review point/,
+  );
+  assert.doesNotMatch(prompt, /patchSignature/);
 });
 
 test("review prompt reads maintainer notes before PR diffs", () => {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -5123,15 +5123,24 @@ function promotionGhMock(options: {
   body?: string;
   itemCreatedAt?: string;
   itemUpdatedAt?: string;
+  itemUpdatedAtAfterFirstFetch?: string;
+  itemUpdatedAtFetchCountPath?: string;
   issueCommentCount?: number;
   comment: string;
   comments?: unknown[];
   labels?: string[];
   pullFiles?: unknown[];
+  pullReviews?: unknown[];
   timeline?: unknown[];
   linkedPulls?: Record<number, unknown>;
   linkedIssues?: Record<number, unknown>;
   linkedPullFiles?: Record<number, unknown[]>;
+  linkedPullReviews?: Record<number, unknown[]>;
+  linkedIssueComments?: Record<number, unknown[]>;
+  linkedReviewComments?: Record<number, unknown[]>;
+  linkedPullAfterFirstFetch?: Record<number, unknown>;
+  linkedPullFetchCountDir?: string;
+  linkedPullAfterMarkerPath?: string;
 }) {
   const title = options.title ?? "Stale F PR";
   const body = options.body ?? "Stale PR body.";
@@ -5156,6 +5165,10 @@ function promotionGhMock(options: {
   const linkedPulls = options.linkedPulls ?? {};
   const linkedIssues = options.linkedIssues ?? {};
   const pullFilesByNumber = { [options.number]: pullFiles, ...options.linkedPullFiles };
+  const pullReviewsByNumber = {
+    [options.number]: options.pullReviews ?? [],
+    ...options.linkedPullReviews,
+  };
   return `
 const rawArgs = process.argv.slice(2);
 const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
@@ -5167,26 +5180,60 @@ const timeline = ${JSON.stringify(timeline)};
 const linkedPulls = ${JSON.stringify(linkedPulls)};
 const linkedIssues = ${JSON.stringify(linkedIssues)};
 const pullFilesByNumber = ${JSON.stringify(pullFilesByNumber)};
+const pullReviewsByNumber = ${JSON.stringify(pullReviewsByNumber)};
+const linkedIssueComments = ${JSON.stringify(options.linkedIssueComments ?? {})};
+const linkedReviewComments = ${JSON.stringify(options.linkedReviewComments ?? {})};
+const linkedPullAfterFirstFetch = ${JSON.stringify(options.linkedPullAfterFirstFetch ?? {})};
+const linkedPullFetchCountDir = ${JSON.stringify(options.linkedPullFetchCountDir ?? "")};
+const linkedPullAfterMarkerPath = ${JSON.stringify(options.linkedPullAfterMarkerPath ?? "")};
+const fs = require("node:fs");
 const number = ${options.number};
 const title = ${JSON.stringify(title)};
 const body = ${JSON.stringify(body)};
 const itemCreatedAt = ${JSON.stringify(itemCreatedAt)};
 const itemUpdatedAt = ${JSON.stringify(itemUpdatedAt)};
+const itemUpdatedAtAfterFirstFetch = ${JSON.stringify(options.itemUpdatedAtAfterFirstFetch ?? "")};
+const itemUpdatedAtFetchCountPath = ${JSON.stringify(options.itemUpdatedAtFetchCountPath ?? "")};
 const issueCommentCount = ${issueCommentCount};
+function nextSourceIssueFetchCount() {
+  if (!itemUpdatedAtFetchCountPath) return 1;
+  const previous = fs.existsSync(itemUpdatedAtFetchCountPath)
+    ? Number(fs.readFileSync(itemUpdatedAtFetchCountPath, "utf8"))
+    : 0;
+  const next = previous + 1;
+  fs.writeFileSync(itemUpdatedAtFetchCountPath, String(next));
+  return next;
+}
+function nextLinkedPullFetchCount(pullNumber) {
+  if (!linkedPullFetchCountDir) return 1;
+  fs.mkdirSync(linkedPullFetchCountDir, { recursive: true });
+  const countPath = linkedPullFetchCountDir + "/" + pullNumber;
+  const previous = fs.existsSync(countPath) ? Number(fs.readFileSync(countPath, "utf8")) : 0;
+  const next = previous + 1;
+  fs.writeFileSync(countPath, String(next));
+  return next;
+}
 if (args[0] === "api" && args[1] === "-i" && new RegExp("/issues/" + number + "/timeline(?:\\\\?|$)").test(args[2] || "")) {
   console.log("HTTP/2 200\\n\\n" + JSON.stringify(timeline));
+} else if (args[0] === "api" && args[1] === "-i" && /\\/pulls\\/(\\d+)\\/reviews(?:\\?|$)/.test(args[2] || "")) {
+  const pullNumber = Number(((args[2] || "").match(/\\/pulls\\/(\\d+)\\/reviews/) || [])[1]);
+  console.log("HTTP/2 200\\n\\n" + JSON.stringify(pullReviewsByNumber[pullNumber] || []));
 } else if (args[0] === "api" && new RegExp("/issues/" + number + "/comments(?:\\\\?|$)").test(path)) {
   console.log(JSON.stringify(slurp ? [comments] : comments));
 } else if (args[0] === "api" && new RegExp("/issues/" + number + "/timeline(?:\\\\?|$)").test(path)) {
   console.log(JSON.stringify(slurp ? [timeline] : timeline));
 } else if (args[0] === "api" && new RegExp("/issues/" + number + "$").test(path)) {
+  const sourceIssueFetches = nextSourceIssueFetchCount();
+  const currentUpdatedAt = itemUpdatedAtAfterFirstFetch && sourceIssueFetches > 1
+    ? itemUpdatedAtAfterFirstFetch
+    : itemUpdatedAt;
   console.log(JSON.stringify({
     number,
     title,
     html_url: "https://github.com/openclaw/openclaw/pull/" + number,
     body,
     created_at: itemCreatedAt,
-    updated_at: itemUpdatedAt,
+    updated_at: currentUpdatedAt,
     closed_at: null,
     state: "open",
     locked: false,
@@ -5204,6 +5251,9 @@ if (args[0] === "api" && args[1] === "-i" && new RegExp("/issues/" + number + "/
     process.exit(1);
   }
   console.log(JSON.stringify(linkedIssues[linkedNumber]));
+} else if (args[0] === "api" && /\\/issues\\/(\\d+)\\/comments(?:\\?|$)/.test(path)) {
+  const linkedNumber = Number((path.match(/\\/issues\\/(\\d+)\\/comments/) || [])[1]);
+  console.log(JSON.stringify(linkedIssueComments[linkedNumber] || []));
 } else if (args[0] === "api" && new RegExp("/pulls/" + number + "$").test(path)) {
   console.log(JSON.stringify({
     number,
@@ -5221,13 +5271,23 @@ if (args[0] === "api" && args[1] === "-i" && new RegExp("/issues/" + number + "/
 } else if (args[0] === "api" && /\\/pulls\\/(\\d+)\\/files(?:\\?|$)/.test(path)) {
   const pullNumber = Number((path.match(/\\/pulls\\/(\\d+)\\/files/) || [])[1]);
   console.log(JSON.stringify(pullFilesByNumber[pullNumber] || []));
+} else if (args[0] === "api" && /\\/pulls\\/(\\d+)\\/comments(?:\\?|$)/.test(path)) {
+  const pullNumber = Number((path.match(/\\/pulls\\/(\\d+)\\/comments/) || [])[1]);
+  if (pullNumber === number) {
+    console.log(JSON.stringify([]));
+  } else {
+    console.log(JSON.stringify(linkedReviewComments[pullNumber] || []));
+  }
 } else if (args[0] === "api" && /\\/pulls\\/(\\d+)$/.test(path)) {
   const linkedNumber = Number((path.match(/\\/pulls\\/(\\d+)$/) || [])[1]);
   if (!linkedPulls[linkedNumber]) {
     console.error("unexpected linked pull", linkedNumber);
     process.exit(1);
   }
-  console.log(JSON.stringify(linkedPulls[linkedNumber]));
+  const fetchCount = nextLinkedPullFetchCount(linkedNumber);
+  const afterFirst = linkedPullAfterFirstFetch[linkedNumber] || {};
+  const useAfterFirst = (linkedPullAfterMarkerPath && fs.existsSync(linkedPullAfterMarkerPath)) || fetchCount > 1;
+  console.log(JSON.stringify(useAfterFirst ? { ...linkedPulls[linkedNumber], ...afterFirst } : linkedPulls[linkedNumber]));
 } else if (args[0] === "api" && new RegExp("/pulls/" + number + "/(commits|comments)(?:\\\\?|$)").test(path)) {
   console.log(JSON.stringify([]));
 } else if (args[0] === "api" && /\\/issues\\/comments\\/\\d+$/.test(path)) {
@@ -5236,6 +5296,8 @@ if (args[0] === "api" && args[1] === "-i" && new RegExp("/issues/" + number + "/
   console.log("");
 } else if (args[0] === "label" || args[0] === "issue") {
   console.log("");
+} else if (args[0] === "api" && args[1] === "-i" && String(args[2] || "").includes("/pulls/") && String(args[2] || "").includes("/reviews")) {
+  console.log("HTTP/2 200\\n\\n[]");
 } else {
   console.error("unexpected gh args", JSON.stringify(args));
   process.exit(1);
@@ -5295,7 +5357,12 @@ function withMockGh(root: string, script: string, run: () => void): void {
   }
 }
 
-function withMockSupersessionProof(root: string, proof: unknown, run: () => void): void {
+function withMockSupersessionProof(
+  root: string,
+  proof: unknown,
+  run: () => void,
+  options: { exitCode?: number; skipWrite?: boolean; markerPath?: string } = {},
+): void {
   const binDir = join(root, "bin");
   const codexPath = join(binDir, "codex");
   const promptsPath = join(root, "codex-prompts.jsonl");
@@ -5308,21 +5375,43 @@ const outputIndex = process.argv.indexOf("--output-last-message");
 if (outputIndex === -1) process.exit(2);
 const input = fs.readFileSync(0, "utf8");
 fs.appendFileSync(${JSON.stringify(promptsPath)}, JSON.stringify({ args: process.argv.slice(2), input }) + "\\n");
-fs.writeFileSync(process.argv[outputIndex + 1], process.env.CLAWSWEEPER_SUPERSESSION_PROOF_JSON);
+if (process.env.CLAWSWEEPER_SUPERSESSION_PROOF_SKIP_WRITE !== "1") {
+  fs.writeFileSync(process.argv[outputIndex + 1], process.env.CLAWSWEEPER_SUPERSESSION_PROOF_JSON);
+}
+if (process.env.CLAWSWEEPER_SUPERSESSION_PROOF_MARKER_PATH) {
+  fs.writeFileSync(process.env.CLAWSWEEPER_SUPERSESSION_PROOF_MARKER_PATH, "done");
+}
+process.exit(Number(process.env.CLAWSWEEPER_SUPERSESSION_PROOF_EXIT_CODE || 0));
 `,
   );
   chmodSync(codexPath, 0o755);
   const originalPath = process.env.PATH;
   const originalProof = process.env.CLAWSWEEPER_SUPERSESSION_PROOF_JSON;
+  const originalExitCode = process.env.CLAWSWEEPER_SUPERSESSION_PROOF_EXIT_CODE;
+  const originalSkipWrite = process.env.CLAWSWEEPER_SUPERSESSION_PROOF_SKIP_WRITE;
+  const originalMarkerPath = process.env.CLAWSWEEPER_SUPERSESSION_PROOF_MARKER_PATH;
   try {
     process.env.PATH = `${binDir}${delimiter}${process.env.PATH ?? ""}`;
     process.env.CLAWSWEEPER_SUPERSESSION_PROOF_JSON = JSON.stringify(proof);
+    process.env.CLAWSWEEPER_SUPERSESSION_PROOF_EXIT_CODE = String(options.exitCode ?? 0);
+    process.env.CLAWSWEEPER_SUPERSESSION_PROOF_SKIP_WRITE = options.skipWrite ? "1" : "0";
+    if (options.markerPath)
+      process.env.CLAWSWEEPER_SUPERSESSION_PROOF_MARKER_PATH = options.markerPath;
+    else delete process.env.CLAWSWEEPER_SUPERSESSION_PROOF_MARKER_PATH;
     run();
   } finally {
     if (originalPath === undefined) delete process.env.PATH;
     else process.env.PATH = originalPath;
     if (originalProof === undefined) delete process.env.CLAWSWEEPER_SUPERSESSION_PROOF_JSON;
     else process.env.CLAWSWEEPER_SUPERSESSION_PROOF_JSON = originalProof;
+    if (originalExitCode === undefined) delete process.env.CLAWSWEEPER_SUPERSESSION_PROOF_EXIT_CODE;
+    else process.env.CLAWSWEEPER_SUPERSESSION_PROOF_EXIT_CODE = originalExitCode;
+    if (originalSkipWrite === undefined)
+      delete process.env.CLAWSWEEPER_SUPERSESSION_PROOF_SKIP_WRITE;
+    else process.env.CLAWSWEEPER_SUPERSESSION_PROOF_SKIP_WRITE = originalSkipWrite;
+    if (originalMarkerPath === undefined)
+      delete process.env.CLAWSWEEPER_SUPERSESSION_PROOF_MARKER_PATH;
+    else process.env.CLAWSWEEPER_SUPERSESSION_PROOF_MARKER_PATH = originalMarkerPath;
   }
 }
 
@@ -5601,6 +5690,8 @@ if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
 } else if (args[0] === "label" || args[0] === "issue") {
   console.log("");
+} else if (args[0] === "api" && args[1] === "-i" && String(args[2] || "").includes("/pulls/") && String(args[2] || "").includes("/reviews")) {
+  console.log("HTTP/2 200\\n\\n[]");
 } else {
   console.error("unexpected gh args", JSON.stringify(args));
   process.exit(1);
@@ -5664,6 +5755,8 @@ if (args[0] === "api" && /\\/issues\\/84244\\/comments(?:\\?|$)/.test(path)) {
   } else {
     console.log(JSON.stringify([[]]));
   }
+} else if (args[0] === "api" && args[1] === "-i" && String(args[2] || "").includes("/pulls/") && String(args[2] || "").includes("/reviews")) {
+  console.log("HTTP/2 200\\n\\n[]");
 } else {
   console.error("unexpected gh args", JSON.stringify(args));
   process.exit(1);
@@ -5772,6 +5865,8 @@ if (args[0] === "api" && /\\/issues\\?state=open/.test(path)) {
     labels: [],
     pull_request: {}
   }));
+} else if (args[0] === "api" && args[1] === "-i" && String(args[2] || "").includes("/pulls/") && String(args[2] || "").includes("/reviews")) {
+  console.log("HTTP/2 200\\n\\n[]");
 } else {
   console.error("unexpected gh args", JSON.stringify(args));
   process.exit(1);
@@ -5917,6 +6012,8 @@ if (args[0] === "api" && /\\/issues\\/74476$/.test(path)) {
 } else if (args[0] === "label" || args[0] === "issue") {
   appendFileSync(logPath, JSON.stringify(["unexpected-label-or-issue-command", ...args]) + "\\n");
   process.exit(1);
+} else if (args[0] === "api" && args[1] === "-i" && String(args[2] || "").includes("/pulls/") && String(args[2] || "").includes("/reviews")) {
+  console.log("HTTP/2 200\\n\\n[]");
 } else {
   console.error("unexpected gh args", JSON.stringify(args));
   process.exit(1);
@@ -6076,6 +6173,8 @@ if (args[0] === "api" && /\\/issues\\/74479$/.test(path)) {
     merged: true,
     merged_at: "2026-05-19T21:00:00Z"
   }));
+} else if (args[0] === "api" && args[1] === "-i" && String(args[2] || "").includes("/pulls/") && String(args[2] || "").includes("/reviews")) {
+  console.log("HTTP/2 200\\n\\n[]");
 } else {
   console.error("unexpected gh args", JSON.stringify(args));
   process.exit(1);
@@ -6311,6 +6410,8 @@ if (args[0] === "api" && /\\/issues\\/74477$/.test(path)) {
 } else if (args[0] === "label" || args[0] === "issue") {
   appendFileSync(logPath, JSON.stringify(["unexpected-label-or-issue-command", ...args]) + "\\n");
   process.exit(1);
+} else if (args[0] === "api" && args[1] === "-i" && String(args[2] || "").includes("/pulls/") && String(args[2] || "").includes("/reviews")) {
+  console.log("HTTP/2 200\\n\\n[]");
 } else {
   console.error("unexpected gh args", JSON.stringify(args));
   process.exit(1);
@@ -6474,6 +6575,8 @@ if (args[0] === "api" && /\\/issues\\/74478$/.test(path)) {
   console.log(JSON.stringify({ name: args[2] }));
 } else if (args[0] === "issue" && args[1] === "edit") {
   console.log("");
+} else if (args[0] === "api" && args[1] === "-i" && String(args[2] || "").includes("/pulls/") && String(args[2] || "").includes("/reviews")) {
+  console.log("HTTP/2 200\\n\\n[]");
 } else {
   console.error("unexpected gh args", JSON.stringify(args));
   process.exit(1);
@@ -6639,6 +6742,8 @@ if (args[0] === "api" && /\\/issues\\/74479$/.test(path)) {
   console.log(JSON.stringify({ name: args[2] }));
 } else if (args[0] === "issue" && args[1] === "edit") {
   console.log("");
+} else if (args[0] === "api" && args[1] === "-i" && String(args[2] || "").includes("/pulls/") && String(args[2] || "").includes("/reviews")) {
+  console.log("HTTP/2 200\\n\\n[]");
 } else {
   console.error("unexpected gh args", JSON.stringify(args));
   process.exit(1);
@@ -6749,6 +6854,8 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
   console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
 } else if (args[0] === "label" || args[0] === "issue") {
   console.log("");
+} else if (args[0] === "api" && args[1] === "-i" && String(args[2] || "").includes("/pulls/") && String(args[2] || "").includes("/reviews")) {
+  console.log("HTTP/2 200\\n\\n[]");
 } else {
   console.error("unexpected gh args", JSON.stringify(args));
   process.exit(1);
@@ -6895,6 +7002,8 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
   console.log("");
 } else if (args[0] === "label") {
   console.log("");
+} else if (args[0] === "api" && args[1] === "-i" && String(args[2] || "").includes("/pulls/") && String(args[2] || "").includes("/reviews")) {
+  console.log("HTTP/2 200\\n\\n[]");
 } else {
   console.error("unexpected gh args", JSON.stringify(args));
   process.exit(1);
@@ -7040,6 +7149,8 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/322\\/timeline(?:\\?|$
   console.log("");
 } else if (args[0] === "label") {
   console.log("");
+} else if (args[0] === "api" && args[1] === "-i" && String(args[2] || "").includes("/pulls/") && String(args[2] || "").includes("/reviews")) {
+  console.log("HTTP/2 200\\n\\n[]");
 } else {
   console.error("unexpected gh args", JSON.stringify(args));
   process.exit(1);
@@ -7168,6 +7279,8 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "label" || args[0] === "issue") {
   console.log("");
+} else if (args[0] === "api" && args[1] === "-i" && String(args[2] || "").includes("/pulls/") && String(args[2] || "").includes("/reviews")) {
+  console.log("HTTP/2 200\\n\\n[]");
 } else {
   console.error("unexpected gh args", JSON.stringify(args));
   process.exit(1);
@@ -7271,6 +7384,8 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "label" || args[0] === "issue") {
   console.log("");
+} else if (args[0] === "api" && args[1] === "-i" && String(args[2] || "").includes("/pulls/") && String(args[2] || "").includes("/reviews")) {
+  console.log("HTTP/2 200\\n\\n[]");
 } else {
   console.error("unexpected gh args", JSON.stringify(args));
   process.exit(1);
@@ -7416,6 +7531,8 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/(320|321)\\/timeline(?
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "label" || args[0] === "issue") {
   console.log("");
+} else if (args[0] === "api" && args[1] === "-i" && String(args[2] || "").includes("/pulls/") && String(args[2] || "").includes("/reviews")) {
+  console.log("HTTP/2 200\\n\\n[]");
 } else {
   console.error("unexpected gh args", JSON.stringify(args));
   process.exit(1);
@@ -7531,6 +7648,8 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/322\\/timeline(?:\\?|$
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "label" || args[0] === "issue") {
   console.log("");
+} else if (args[0] === "api" && args[1] === "-i" && String(args[2] || "").includes("/pulls/") && String(args[2] || "").includes("/reviews")) {
+  console.log("HTTP/2 200\\n\\n[]");
 } else {
   console.error("unexpected gh args", JSON.stringify(args));
   process.exit(1);
@@ -7651,7 +7770,6 @@ test("apply-decisions promotes stale PRs after automation-only drift", () => {
           extraArgs: [
             "--target-repo",
             "openclaw/openclaw",
-            "--dry-run",
             "--apply-kind",
             "all",
             "--processed-limit",
@@ -7709,7 +7827,6 @@ test("apply-decisions does not promote stale PRs from truncated activity", () =>
           extraArgs: [
             "--target-repo",
             "openclaw/openclaw",
-            "--dry-run",
             "--apply-kind",
             "all",
             "--processed-limit",
@@ -7774,7 +7891,6 @@ test("apply-decisions does not promote stale PRs after human follow-up", () => {
           extraArgs: [
             "--target-repo",
             "openclaw/openclaw",
-            "--dry-run",
             "--apply-kind",
             "all",
             "--processed-limit",
@@ -7903,6 +8019,12 @@ test("apply-decisions promotes PRs superseded by linked pull requests", () => {
             title: "Old activity PR",
             body: sourceBody,
             comment: synced.comment,
+            pullReviews: [
+              {
+                user: { login: "maintainer" },
+                body: "Source review says the activity route fix is the useful work.",
+              },
+            ],
             linkedPulls: {
               400: {
                 number: 400,
@@ -7924,7 +8046,24 @@ test("apply-decisions promotes PRs superseded by linked pull requests", () => {
                 body: replacementBody,
                 updated_at: "2026-05-21T00:00:00Z",
                 labels: [],
+                comments: 1,
               },
+            },
+            linkedIssueComments: {
+              400: [
+                {
+                  user: { login: "maintainer" },
+                  body: "Replacement discussion confirms fixActivity is included.",
+                },
+              ],
+            },
+            linkedPullReviews: {
+              400: [
+                {
+                  user: { login: "maintainer" },
+                  body: "Replacement review confirms the activity route stays covered.",
+                },
+              ],
             },
             pullFiles: [
               { filename: "src/activity.ts", status: "modified", patch: "@@\n+fixActivity();" },
@@ -7979,10 +8118,550 @@ test("apply-decisions promotes PRs superseded by linked pull requests", () => {
     assert.match(proofPrompt, /src\/activity\.ts/);
     assert.match(proofPrompt, /source useful activity fix/);
     assert.match(proofPrompt, /replacement activity fix/);
+    assert.match(proofPrompt, /fixActivity/);
+    assert.match(proofPrompt, /addReplacementProof/);
+    assert.match(proofPrompt, /Replacement discussion confirms fixActivity/);
+    assert.match(proofPrompt, /Source review says the activity route fix/);
+    assert.match(proofPrompt, /Replacement review confirms the activity route/);
     assert.doesNotMatch(proofPrompt, /SOURCE_BODY_TAIL/);
     assert.doesNotMatch(proofPrompt, /REPLACEMENT_BODY_TAIL/);
     assert.doesNotMatch(proofPrompt, /\[truncated/);
-    assert.doesNotMatch(proofPrompt, /fixActivity/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions accepts written supersession proof after nonzero Codex exit", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const synced = reportWithSyncedReviewComment(
+      stalePullRequestReport({
+        number: 339,
+        title: "Old activity PR",
+        pr_rating_overall: "D",
+        pr_rating_proof: "D",
+        work_cluster_refs: JSON.stringify([
+          "Superseded by https://github.com/openclaw/openclaw/pull/409",
+        ]),
+      }),
+      339,
+      "none",
+    );
+    writeFileSync(join(itemsDir, "339.md"), synced.report, "utf8");
+
+    withMockSupersessionProof(
+      root,
+      {
+        sourceSummary: "PR A fixes the stale activity route in src/activity.ts.",
+        replacementSummary:
+          "PR B fixes the same activity route and adds replacement proof around it.",
+        coveredWork: ["PR B includes the activity route fix that PR A proposed."],
+        uniqueSourceWork: [],
+        securityBlocked: false,
+        decision: "superseded",
+        reason: "PR B covers PR A's useful behavior and PR A has no unique remaining work.",
+      },
+      () => {
+        withMockGh(
+          root,
+          promotionGhMock({
+            number: 339,
+            title: "Old activity PR",
+            comment: synced.comment,
+            linkedPulls: {
+              409: {
+                number: 409,
+                title: "Canonical activity PR",
+                html_url: "https://github.com/openclaw/openclaw/pull/409",
+                state: "open",
+                merged_at: null,
+                changed_files: 1,
+                head: { sha: "replacement-head-sha" },
+                updated_at: "2026-05-21T00:00:00Z",
+              },
+            },
+            linkedIssues: {
+              409: {
+                number: 409,
+                title: "Canonical activity PR",
+                html_url: "https://github.com/openclaw/openclaw/pull/409",
+                body: "Replacement body.",
+                updated_at: "2026-05-21T00:00:00Z",
+                labels: [],
+              },
+            },
+            pullFiles: [{ filename: "src/activity.ts", status: "modified" }],
+            linkedPullFiles: {
+              409: [{ filename: "src/activity.ts", status: "modified" }],
+            },
+          }),
+          () => {
+            runApplyDecisionsForTest({
+              itemsDir,
+              closedDir,
+              plansDir,
+              reportPath,
+              extraArgs: [
+                "--target-repo",
+                "openclaw/openclaw",
+                "--apply-kind",
+                "all",
+                "--processed-limit",
+                "3",
+              ],
+            });
+          },
+        );
+      },
+      { exitCode: 1 },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+      action: string;
+      reason: string;
+    }>;
+    assert.equal(
+      report.some((entry) => entry.action === "closed"),
+      true,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions does not reuse stale supersession proof output", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const artifactDir = join(root, "artifacts");
+    const proofDir = join(artifactDir, "supersession-proof");
+    const reportPath = join(root, "apply-report.json");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    mkdirSync(proofDir, { recursive: true });
+    writeFileSync(
+      join(proofDir, "340-410.json"),
+      JSON.stringify({
+        sourceSummary: "Stale source summary.",
+        replacementSummary: "Stale replacement summary.",
+        coveredWork: ["Stale coverage from an earlier run."],
+        uniqueSourceWork: [],
+        securityBlocked: false,
+        decision: "superseded",
+        reason: "Stale proof from an earlier run.",
+      }),
+      "utf8",
+    );
+    const synced = reportWithSyncedReviewComment(
+      stalePullRequestReport({
+        number: 340,
+        title: "Old activity PR",
+        pr_rating_overall: "D",
+        pr_rating_proof: "D",
+        work_cluster_refs: JSON.stringify([
+          "Superseded by https://github.com/openclaw/openclaw/pull/410",
+        ]),
+      }),
+      340,
+      "none",
+    );
+    writeFileSync(join(itemsDir, "340.md"), synced.report, "utf8");
+
+    withMockSupersessionProof(
+      root,
+      { error: "new proof did not write output" },
+      () => {
+        withMockGh(
+          root,
+          promotionGhMock({
+            number: 340,
+            title: "Old activity PR",
+            comment: synced.comment,
+            linkedPulls: {
+              410: {
+                number: 410,
+                title: "Canonical activity PR",
+                html_url: "https://github.com/openclaw/openclaw/pull/410",
+                state: "open",
+                merged_at: null,
+                changed_files: 1,
+                head: { sha: "replacement-head-sha" },
+                updated_at: "2026-05-21T00:00:00Z",
+              },
+            },
+            linkedIssues: {
+              410: {
+                number: 410,
+                title: "Canonical activity PR",
+                html_url: "https://github.com/openclaw/openclaw/pull/410",
+                body: "Replacement body.",
+                updated_at: "2026-05-21T00:00:00Z",
+                labels: [],
+              },
+            },
+            pullFiles: [{ filename: "src/activity.ts", status: "modified" }],
+            linkedPullFiles: {
+              410: [{ filename: "src/activity.ts", status: "modified" }],
+            },
+          }),
+          () => {
+            runApplyDecisionsForTest({
+              itemsDir,
+              closedDir,
+              plansDir,
+              reportPath,
+              extraArgs: [
+                "--target-repo",
+                "openclaw/openclaw",
+                "--apply-kind",
+                "all",
+                "--processed-limit",
+                "3",
+                "--artifact-dir",
+                artifactDir,
+              ],
+            });
+          },
+        );
+      },
+      { exitCode: 1, skipWrite: true },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+      action: string;
+      reason: string;
+    }>;
+    assert.equal(
+      report.some((entry) => entry.action === "closed"),
+      false,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions does not close after supersession proof when source PR changes", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const synced = reportWithSyncedReviewComment(
+      stalePullRequestReport({
+        number: 341,
+        title: "Old activity PR",
+        pr_rating_overall: "D",
+        pr_rating_proof: "D",
+        work_cluster_refs: JSON.stringify([
+          "Superseded by https://github.com/openclaw/openclaw/pull/411",
+        ]),
+      }),
+      341,
+      "none",
+    );
+    writeFileSync(join(itemsDir, "341.md"), synced.report, "utf8");
+
+    withMockSupersessionProof(
+      root,
+      {
+        sourceSummary: "PR A fixes the stale activity route in src/activity.ts.",
+        replacementSummary:
+          "PR B fixes the same activity route and adds replacement proof around it.",
+        coveredWork: ["PR B includes the activity route fix that PR A proposed."],
+        uniqueSourceWork: [],
+        securityBlocked: false,
+        decision: "superseded",
+        reason: "PR B covers PR A's useful behavior and PR A has no unique remaining work.",
+      },
+      () => {
+        withMockGh(
+          root,
+          promotionGhMock({
+            number: 341,
+            title: "Old activity PR",
+            comment: synced.comment,
+            itemUpdatedAtAfterFirstFetch: "2026-05-01T00:10:00Z",
+            itemUpdatedAtFetchCountPath: join(root, "source-issue-fetch-count"),
+            linkedPulls: {
+              411: {
+                number: 411,
+                title: "Canonical activity PR",
+                html_url: "https://github.com/openclaw/openclaw/pull/411",
+                state: "open",
+                merged_at: null,
+                changed_files: 1,
+                head: { sha: "replacement-head-sha" },
+                updated_at: "2026-05-21T00:00:00Z",
+              },
+            },
+            linkedIssues: {
+              411: {
+                number: 411,
+                title: "Canonical activity PR",
+                html_url: "https://github.com/openclaw/openclaw/pull/411",
+                body: "Replacement body.",
+                updated_at: "2026-05-21T00:00:00Z",
+                labels: [],
+              },
+            },
+            pullFiles: [{ filename: "src/activity.ts", status: "modified" }],
+            linkedPullFiles: {
+              411: [{ filename: "src/activity.ts", status: "modified" }],
+            },
+          }),
+          () => {
+            runApplyDecisionsForTest({
+              itemsDir,
+              closedDir,
+              plansDir,
+              reportPath,
+              extraArgs: [
+                "--target-repo",
+                "openclaw/openclaw",
+                "--apply-kind",
+                "all",
+                "--processed-limit",
+                "3",
+              ],
+            });
+          },
+        );
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+      action: string;
+      reason: string;
+    }>;
+    assert.equal(
+      report.some((entry) => entry.action === "closed"),
+      false,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions does not close after supersession proof when replacement PR changes", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const proofMarkerPath = join(root, "supersession-proof-finished");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const synced = reportWithSyncedReviewComment(
+      stalePullRequestReport({
+        number: 342,
+        title: "Old activity PR",
+        pr_rating_overall: "D",
+        pr_rating_proof: "D",
+        work_cluster_refs: JSON.stringify([
+          "Superseded by https://github.com/openclaw/openclaw/pull/412",
+        ]),
+      }),
+      342,
+      "none",
+    );
+    writeFileSync(join(itemsDir, "342.md"), synced.report, "utf8");
+
+    withMockSupersessionProof(
+      root,
+      {
+        sourceSummary: "PR A fixes the stale activity route in src/activity.ts.",
+        replacementSummary:
+          "PR B fixes the same activity route and adds replacement proof around it.",
+        coveredWork: ["PR B includes the activity route fix that PR A proposed."],
+        uniqueSourceWork: [],
+        securityBlocked: false,
+        decision: "superseded",
+        reason: "PR B covers PR A's useful behavior and PR A has no unique remaining work.",
+      },
+      () => {
+        withMockGh(
+          root,
+          promotionGhMock({
+            number: 342,
+            title: "Old activity PR",
+            comment: synced.comment,
+            linkedPulls: {
+              412: {
+                number: 412,
+                title: "Canonical activity PR",
+                html_url: "https://github.com/openclaw/openclaw/pull/412",
+                state: "open",
+                merged_at: null,
+                changed_files: 1,
+                head: { sha: "replacement-head-sha" },
+                updated_at: "2026-05-21T00:00:00Z",
+              },
+            },
+            linkedPullAfterFirstFetch: {
+              412: {
+                head: { sha: "replacement-new-head-sha" },
+                updated_at: "2026-05-21T00:10:00Z",
+              },
+            },
+            linkedPullAfterMarkerPath: proofMarkerPath,
+            linkedIssues: {
+              412: {
+                number: 412,
+                title: "Canonical activity PR",
+                html_url: "https://github.com/openclaw/openclaw/pull/412",
+                body: "Replacement body.",
+                updated_at: "2026-05-21T00:00:00Z",
+                labels: [],
+              },
+            },
+            pullFiles: [{ filename: "src/activity.ts", status: "modified" }],
+            linkedPullFiles: {
+              412: [{ filename: "src/activity.ts", status: "modified" }],
+            },
+          }),
+          () => {
+            runApplyDecisionsForTest({
+              itemsDir,
+              closedDir,
+              plansDir,
+              reportPath,
+              extraArgs: [
+                "--target-repo",
+                "openclaw/openclaw",
+                "--apply-kind",
+                "all",
+                "--processed-limit",
+                "3",
+              ],
+            });
+          },
+        );
+      },
+      { markerPath: proofMarkerPath },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+      action: string;
+      reason: string;
+    }>;
+    assert.equal(
+      report.some((entry) => entry.action === "closed"),
+      false,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions does not close when replacement PR is closed unmerged", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const synced = reportWithSyncedReviewComment(
+      stalePullRequestReport({
+        number: 343,
+        title: "Old activity PR",
+        pr_rating_overall: "D",
+        pr_rating_proof: "D",
+        work_cluster_refs: JSON.stringify([
+          "Superseded by https://github.com/openclaw/openclaw/pull/413",
+        ]),
+      }),
+      343,
+      "none",
+    );
+    writeFileSync(join(itemsDir, "343.md"), synced.report, "utf8");
+
+    withMockSupersessionProof(
+      root,
+      {
+        sourceSummary: "PR A fixes the stale activity route in src/activity.ts.",
+        replacementSummary: "PR B had the same route fix.",
+        coveredWork: ["PR B includes the activity route fix that PR A proposed."],
+        uniqueSourceWork: [],
+        securityBlocked: false,
+        decision: "superseded",
+        reason: "PR B covers PR A's useful behavior and PR A has no unique remaining work.",
+      },
+      () => {
+        withMockGh(
+          root,
+          promotionGhMock({
+            number: 343,
+            title: "Old activity PR",
+            comment: synced.comment,
+            itemCreatedAt: "2026-05-20T00:00:00Z",
+            linkedPulls: {
+              413: {
+                number: 413,
+                title: "Closed replacement PR",
+                html_url: "https://github.com/openclaw/openclaw/pull/413",
+                state: "closed",
+                merged_at: null,
+                changed_files: 1,
+                head: { sha: "replacement-head-sha" },
+                updated_at: "2026-05-21T00:00:00Z",
+              },
+            },
+            linkedIssues: {
+              413: {
+                number: 413,
+                title: "Closed replacement PR",
+                html_url: "https://github.com/openclaw/openclaw/pull/413",
+                body: "Replacement body.",
+                updated_at: "2026-05-21T00:00:00Z",
+                labels: [],
+              },
+            },
+            pullFiles: [{ filename: "src/activity.ts", status: "modified" }],
+            linkedPullFiles: {
+              413: [{ filename: "src/activity.ts", status: "modified" }],
+            },
+          }),
+          () => {
+            runApplyDecisionsForTest({
+              itemsDir,
+              closedDir,
+              plansDir,
+              reportPath,
+              extraArgs: [
+                "--target-repo",
+                "openclaw/openclaw",
+                "--apply-kind",
+                "all",
+                "--processed-limit",
+                "3",
+              ],
+            });
+          },
+        );
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+      action: string;
+    }>;
+    assert.equal(
+      report.some((entry) => entry.action === "closed"),
+      false,
+    );
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -8037,7 +8716,6 @@ test("apply-decisions keeps PRs open when linked supersession proof is incomplet
           extraArgs: [
             "--target-repo",
             "openclaw/openclaw",
-            "--dry-run",
             "--apply-kind",
             "all",
             "--processed-limit",
@@ -8052,6 +8730,14 @@ test("apply-decisions keeps PRs open when linked supersession proof is incomplet
       report.some((entry) => entry.action === "closed"),
       false,
     );
+    assert.deepEqual(report, [
+      {
+        number: 335,
+        action: "kept_open",
+        reason: "linked supersession proof did not allow close",
+      },
+    ]);
+    assert.match(readFileSync(join(itemsDir, "335.md"), "utf8"), /^apply_checked_at: /m);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -8159,7 +8845,8 @@ test("apply-decisions keeps PRs open when model proof says same-file supersessio
     );
     const proofPrompt = readFileSync(join(root, "codex-prompts.jsonl"), "utf8");
     assert.match(proofPrompt, /src\/activity\.ts/);
-    assert.doesNotMatch(proofPrompt, /differentFix/);
+    assert.match(proofPrompt, /fixActivity/);
+    assert.match(proofPrompt, /differentFix/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -8328,6 +9015,184 @@ test("apply-decisions keeps PRs open when comments contain security markers", ()
         pullFiles: [{ filename: "src/router.ts", status: "modified", patch: "@@\n+fixRouter();" }],
         linkedPullFiles: {
           407: [{ filename: "src/router.ts", status: "modified", patch: "@@\n+fixRouter();" }],
+        },
+      }),
+      () => {
+        runApplyDecisionsForTest({
+          itemsDir,
+          closedDir,
+          plansDir,
+          reportPath,
+          extraArgs: [
+            "--target-repo",
+            "openclaw/openclaw",
+            "--dry-run",
+            "--apply-kind",
+            "all",
+            "--processed-limit",
+            "3",
+          ],
+        });
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{ action: string }>;
+    assert.equal(
+      report.some((entry) => entry.action === "closed"),
+      false,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions keeps PRs open when the report security review needs attention", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const synced = reportWithSyncedReviewComment(
+      stalePullRequestReport({
+        number: 344,
+        title: "Older auth PR",
+        pr_rating_overall: "D",
+        pr_rating_proof: "D",
+        work_cluster_refs: JSON.stringify([
+          "Superseded by https://github.com/openclaw/openclaw/pull/414",
+        ]),
+      }),
+      344,
+      "none",
+    );
+    const reportWithSecurityReview = `${synced.report}\n\n## Security Review\n\nStatus: needs_attention\nSummary: The latest review found auth-sensitive behavior that needs security review.\n`;
+    writeFileSync(join(itemsDir, "344.md"), reportWithSecurityReview, "utf8");
+
+    withMockGh(
+      root,
+      promotionGhMock({
+        number: 344,
+        title: "Older auth PR",
+        comment: synced.comment,
+        linkedPulls: {
+          414: {
+            number: 414,
+            title: "Newer auth PR",
+            html_url: "https://github.com/openclaw/openclaw/pull/414",
+            state: "open",
+            merged_at: null,
+            body: "Supersedes #344 by carrying the same auth fix.",
+            changed_files: 1,
+            head: { sha: "replacement-head-sha" },
+            updated_at: "2026-05-21T00:00:00Z",
+          },
+        },
+        linkedIssues: {
+          414: {
+            number: 414,
+            title: "Newer auth PR",
+            html_url: "https://github.com/openclaw/openclaw/pull/414",
+            body: "Supersedes #344 by carrying the same auth fix.",
+            updated_at: "2026-05-21T00:00:00Z",
+            labels: [],
+          },
+        },
+        pullFiles: [{ filename: "src/auth.ts", status: "modified", patch: "@@\n+fixAuth();" }],
+        linkedPullFiles: {
+          414: [{ filename: "src/auth.ts", status: "modified", patch: "@@\n+fixAuth();" }],
+        },
+      }),
+      () => {
+        runApplyDecisionsForTest({
+          itemsDir,
+          closedDir,
+          plansDir,
+          reportPath,
+          extraArgs: [
+            "--target-repo",
+            "openclaw/openclaw",
+            "--dry-run",
+            "--apply-kind",
+            "all",
+            "--processed-limit",
+            "3",
+          ],
+        });
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{ action: string }>;
+    assert.equal(
+      report.some((entry) => entry.action === "closed"),
+      false,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions keeps PRs open when report merge risk is security-sensitive", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const synced = reportWithSyncedReviewComment(
+      stalePullRequestReport({
+        number: 345,
+        title: "Older provider PR",
+        pr_rating_overall: "D",
+        pr_rating_proof: "D",
+        merge_risk_labels: JSON.stringify(["merge-risk: 🚨 security-boundary"]),
+        work_cluster_refs: JSON.stringify([
+          "Superseded by https://github.com/openclaw/openclaw/pull/415",
+        ]),
+      }),
+      345,
+      "none",
+    );
+    writeFileSync(join(itemsDir, "345.md"), synced.report, "utf8");
+
+    withMockGh(
+      root,
+      promotionGhMock({
+        number: 345,
+        title: "Older provider PR",
+        comment: synced.comment,
+        linkedPulls: {
+          415: {
+            number: 415,
+            title: "Newer provider PR",
+            html_url: "https://github.com/openclaw/openclaw/pull/415",
+            state: "open",
+            merged_at: null,
+            body: "Supersedes #345 by carrying the same provider fix.",
+            changed_files: 1,
+            head: { sha: "replacement-head-sha" },
+            updated_at: "2026-05-21T00:00:00Z",
+          },
+        },
+        linkedIssues: {
+          415: {
+            number: 415,
+            title: "Newer provider PR",
+            html_url: "https://github.com/openclaw/openclaw/pull/415",
+            body: "Supersedes #345 by carrying the same provider fix.",
+            updated_at: "2026-05-21T00:00:00Z",
+            labels: [],
+          },
+        },
+        pullFiles: [
+          { filename: "src/provider.ts", status: "modified", patch: "@@\n+fixProvider();" },
+        ],
+        linkedPullFiles: {
+          415: [{ filename: "src/provider.ts", status: "modified", patch: "@@\n+fixProvider();" }],
         },
       }),
       () => {
@@ -8610,6 +9475,8 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/(320|321)\\/timeline(?
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "label" || args[0] === "issue") {
   console.log("");
+} else if (args[0] === "api" && args[1] === "-i" && String(args[2] || "").includes("/pulls/") && String(args[2] || "").includes("/reviews")) {
+  console.log("HTTP/2 200\\n\\n[]");
 } else {
   console.error("unexpected gh args", JSON.stringify(args));
   process.exit(1);
@@ -8761,6 +9628,8 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/(320|321)\\/timeline(?
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "label" || args[0] === "issue") {
   console.log("");
+} else if (args[0] === "api" && args[1] === "-i" && String(args[2] || "").includes("/pulls/") && String(args[2] || "").includes("/reviews")) {
+  console.log("HTTP/2 200\\n\\n[]");
 } else {
   console.error("unexpected gh args", JSON.stringify(args));
   process.exit(1);
@@ -8908,6 +9777,8 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/(320|321)\\/timeline(?
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "label" || args[0] === "issue") {
   console.log("");
+} else if (args[0] === "api" && args[1] === "-i" && String(args[2] || "").includes("/pulls/") && String(args[2] || "").includes("/reviews")) {
+  console.log("HTTP/2 200\\n\\n[]");
 } else {
   console.error("unexpected gh args", JSON.stringify(args));
   process.exit(1);
@@ -9057,6 +9928,8 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "label" || args[0] === "issue") {
   console.log("");
+} else if (args[0] === "api" && args[1] === "-i" && String(args[2] || "").includes("/pulls/") && String(args[2] || "").includes("/reviews")) {
+  console.log("HTTP/2 200\\n\\n[]");
 } else {
   console.error("unexpected gh args", JSON.stringify(args));
   process.exit(1);
@@ -9136,6 +10009,8 @@ if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
     comments: 0,
     pull_request: null
   }));
+} else if (args[0] === "api" && args[1] === "-i" && String(args[2] || "").includes("/pulls/") && String(args[2] || "").includes("/reviews")) {
+  console.log("HTTP/2 200\\n\\n[]");
 } else {
   console.error("unexpected gh args", JSON.stringify(args));
   process.exit(1);
@@ -9244,6 +10119,8 @@ if (args[0] === "api" && commentMatch) {
   console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
 } else if (args[0] === "label" || args[0] === "issue") {
   console.log("");
+} else if (args[0] === "api" && args[1] === "-i" && String(args[2] || "").includes("/pulls/") && String(args[2] || "").includes("/reviews")) {
+  console.log("HTTP/2 200\\n\\n[]");
 } else {
   console.error("unexpected gh args", JSON.stringify(args));
   process.exit(1);
@@ -9406,6 +10283,8 @@ if (args[0] === "api" && commentMatch) {
   console.log("");
 } else if (args[0] === "issue" && args[1] === "edit") {
   console.log("");
+} else if (args[0] === "api" && args[1] === "-i" && String(args[2] || "").includes("/pulls/") && String(args[2] || "").includes("/reviews")) {
+  console.log("HTTP/2 200\\n\\n[]");
 } else {
   console.error("unexpected gh args", JSON.stringify(args));
   process.exit(1);
@@ -9500,6 +10379,8 @@ if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
 } else if (args[0] === "label" || args[0] === "issue") {
   console.log("");
+} else if (args[0] === "api" && args[1] === "-i" && String(args[2] || "").includes("/pulls/") && String(args[2] || "").includes("/reviews")) {
+  console.log("HTTP/2 200\\n\\n[]");
 } else {
   console.error("unexpected gh args", JSON.stringify(args));
   process.exit(1);
@@ -9606,6 +10487,8 @@ if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
 } else if (args[0] === "issue" && args[1] === "edit" && args.includes("impact:message-loss")) {
   console.error('error fetching labels: non-200 OK status code: 401 Unauthorized body: "{\\n  \\"message\\": \\"Requires authentication\\",\\n  \\"status\\": \\"401\\"\\n}"');
   process.exit(1);
+} else if (args[0] === "api" && args[1] === "-i" && String(args[2] || "").includes("/pulls/") && String(args[2] || "").includes("/reviews")) {
+  console.log("HTTP/2 200\\n\\n[]");
 } else {
   console.error("unexpected gh args", JSON.stringify(args));
   process.exit(1);
@@ -10653,6 +11536,13 @@ test("supersession proof prompt requires general coverage proof", () => {
     /PR A has no unique behavior, file concern, proof, discussion, or review point/,
   );
   assert.doesNotMatch(prompt, /patchSignature/);
+});
+
+test("review prompt prevents stale-base delete false positives", () => {
+  const prompt = readFileSync("prompts/review-item.md", "utf8");
+
+  assert.match(prompt, /Do not treat a branch being behind the current base as proof/);
+  assert.match(prompt, /actual three-way merge result/);
 });
 
 test("review prompt reads maintainer notes before PR diffs", () => {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -8852,7 +8852,7 @@ test("apply-decisions keeps PRs open when model proof says same-file supersessio
   }
 });
 
-test("apply-decisions can close security-sensitive labeled PRs when proof covers them", () => {
+test("apply-decisions can close security-labeled PRs when proof covers them", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
     const itemsDir = join(root, "items");
@@ -8865,7 +8865,7 @@ test("apply-decisions can close security-sensitive labeled PRs when proof covers
       stalePullRequestReport({
         number: 336,
         title: "Older security PR",
-        labels: JSON.stringify(["security-sensitive"]),
+        labels: JSON.stringify(["security"]),
         pr_rating_overall: "D",
         pr_rating_proof: "D",
         work_cluster_refs: JSON.stringify([
@@ -8894,7 +8894,7 @@ test("apply-decisions can close security-sensitive labeled PRs when proof covers
           promotionGhMock({
             number: 336,
             title: "Older security PR",
-            labels: ["security-sensitive"],
+            labels: ["security"],
             comment: synced.comment,
             linkedPulls: {
               406: {
@@ -11591,10 +11591,13 @@ test("supersession proof prompt requires general coverage proof", () => {
   assert.match(prompt, /Do not ask for more context/);
   assert.match(prompt, /Do not require exact patch-line equality/);
   assert.match(prompt, /Text such as `supersedes #A` is only a candidate signal/);
+  assert.match(prompt, /Security-sensitive work is not a separate close blocker/);
+  assert.match(prompt, /If PR B proves it covers that content, PR A can be `superseded`/);
   assert.match(
     prompt,
     /PR A has no unique behavior, file concern, proof, discussion, or review point/,
   );
+  assert.doesNotMatch(prompt, /must not be auto-closed/);
   assert.doesNotMatch(prompt, /patchSignature/);
 });
 

--- a/test/repair/execute-fix-artifact-source.test.ts
+++ b/test/repair/execute-fix-artifact-source.test.ts
@@ -92,7 +92,7 @@ test("merged source replacement skip runs before publishing replacement PRs", ()
   );
 });
 
-test("superseded source closeout checks source security before gh pr close", () => {
+test("superseded source closeout requires replacement proof before gh pr close", () => {
   const sourcePath = path.join(process.cwd(), "src/repair/execute-fix-artifact.ts");
   const source = fs.readFileSync(sourcePath, "utf8");
 
@@ -100,17 +100,15 @@ test("superseded source closeout checks source security before gh pr close", () 
   assert.notEqual(helperStart, -1);
   const helper = source.slice(helperStart);
 
-  const securityIndex = helper.indexOf("sourcePullRequestSecurityBlockReason(view)");
   const proofIndex = helper.indexOf("replacementCloseoutProofAllowsClose({");
   const linkIndex = helper.indexOf("linkReplacementSourcePr({");
   const closeIndex = helper.indexOf('"pr", "close"');
-  assert.notEqual(securityIndex, -1);
   assert.notEqual(proofIndex, -1);
   assert.notEqual(linkIndex, -1);
   assert.notEqual(closeIndex, -1);
   assert.ok(
-    securityIndex < linkIndex && proofIndex < closeIndex && linkIndex < closeIndex,
-    "source PRs must pass security and replacement proof checks before gh pr close can run",
+    proofIndex < closeIndex && linkIndex < closeIndex,
+    "source PRs must pass replacement proof checks before gh pr close can run",
   );
 });
 
@@ -136,9 +134,7 @@ test("superseded source closeout uses general proof instead of patch-line matchi
 
   assert.match(helper, /replacementCloseoutProofPromptPath/);
   assert.match(helper, /compactSupersessionProofView/);
-  assert.match(helper, /pullRequestReviewContextBlockReason/);
   assert.match(helper, /reviews: sourceView\.reviews/);
-  assert.match(helper, /pullRequestReviewCommentContextBlockReason/);
   assert.match(helper, /reviewComments: sourceView\.reviewComments/);
   assert.match(sharedProofSource, /export function proofBodyExcerpt/);
   assert.doesNotMatch(helper, /patchSignature/);

--- a/test/repair/execute-fix-artifact-source.test.ts
+++ b/test/repair/execute-fix-artifact-source.test.ts
@@ -91,3 +91,66 @@ test("merged source replacement skip runs before publishing replacement PRs", ()
     /reason: "source PR already merged and replacement branch has no changes versus base"/,
   );
 });
+
+test("superseded source closeout checks source security before gh pr close", () => {
+  const sourcePath = path.join(process.cwd(), "src/repair/execute-fix-artifact.ts");
+  const source = fs.readFileSync(sourcePath, "utf8");
+
+  const helperStart = source.indexOf("function closeSupersededSourcePr(");
+  assert.notEqual(helperStart, -1);
+  const helper = source.slice(helperStart);
+
+  const securityIndex = helper.indexOf("sourcePullRequestSecurityBlockReason(view)");
+  const proofIndex = helper.indexOf("replacementCloseoutProofAllowsClose({");
+  const linkIndex = helper.indexOf("linkReplacementSourcePr({");
+  const closeIndex = helper.indexOf('"pr", "close"');
+  assert.notEqual(securityIndex, -1);
+  assert.notEqual(proofIndex, -1);
+  assert.notEqual(linkIndex, -1);
+  assert.notEqual(closeIndex, -1);
+  assert.ok(
+    securityIndex < linkIndex && proofIndex < closeIndex && linkIndex < closeIndex,
+    "source PRs must pass security and replacement proof checks before gh pr close can run",
+  );
+});
+
+test("superseded source closeout uses general proof instead of patch-line matching", () => {
+  const prompt = fs.readFileSync(
+    path.join(process.cwd(), "prompts/repair/replacement-closeout-proof.md"),
+    "utf8",
+  );
+  assert.match(prompt, /Compare the useful work generally/);
+  assert.match(prompt, /Do not require exact patch-line equality/);
+
+  const sourcePath = path.join(process.cwd(), "src/repair/execute-fix-artifact.ts");
+  const source = fs.readFileSync(sourcePath, "utf8");
+  const helperStart = source.indexOf("function replacementCloseoutProofAllowsClose(");
+  const helperEnd = source.indexOf("function linkReplacementSourcePr(", helperStart);
+  assert.notEqual(helperStart, -1);
+  assert.notEqual(helperEnd, -1);
+  const helper = source.slice(helperStart, helperEnd);
+  const sharedProofSource = fs.readFileSync(
+    path.join(process.cwd(), "src/supersession-proof.ts"),
+    "utf8",
+  );
+
+  assert.match(helper, /replacementCloseoutProofPromptPath/);
+  assert.match(helper, /compactSupersessionProofView/);
+  assert.match(sharedProofSource, /export function proofBodyExcerpt/);
+  assert.doesNotMatch(helper, /patchSignature/);
+});
+
+test("source PR view hydrates labels comments and files for replacement closeout", () => {
+  const sourcePath = path.join(process.cwd(), "src/repair/execute-fix-github.ts");
+  const source = fs.readFileSync(sourcePath, "utf8");
+  const helperStart = source.indexOf("export function fetchSourcePullRequestView(");
+  const helperEnd = source.indexOf("export function sourceClosingReferences", helperStart);
+  assert.notEqual(helperStart, -1);
+  assert.notEqual(helperEnd, -1);
+  const helper = source.slice(helperStart, helperEnd);
+
+  assert.match(
+    helper,
+    /author,state,mergedAt,title,url,body,labels,comments,files,headRefOid,updatedAt/,
+  );
+});

--- a/test/repair/execute-fix-artifact-source.test.ts
+++ b/test/repair/execute-fix-artifact-source.test.ts
@@ -136,8 +136,65 @@ test("superseded source closeout uses general proof instead of patch-line matchi
 
   assert.match(helper, /replacementCloseoutProofPromptPath/);
   assert.match(helper, /compactSupersessionProofView/);
+  assert.match(helper, /pullRequestReviewContextBlockReason/);
+  assert.match(helper, /reviews: sourceView\.reviews/);
+  assert.match(helper, /pullRequestReviewCommentContextBlockReason/);
+  assert.match(helper, /reviewComments: sourceView\.reviewComments/);
   assert.match(sharedProofSource, /export function proofBodyExcerpt/);
   assert.doesNotMatch(helper, /patchSignature/);
+});
+
+test("replacement closeout proof uses a read-only Codex sandbox", () => {
+  const sourcePath = path.join(process.cwd(), "src/repair/execute-fix-artifact.ts");
+  const source = fs.readFileSync(sourcePath, "utf8");
+  const helperStart = source.indexOf("function replacementCloseoutProofAllowsClose(");
+  const helperEnd = source.indexOf("function linkReplacementSourcePr(", helperStart);
+  assert.notEqual(helperStart, -1);
+  assert.notEqual(helperEnd, -1);
+  const helper = source.slice(helperStart, helperEnd);
+
+  assert.match(source, /const replacementCloseoutProofSandbox = "read-only"/);
+  assert.match(helper, /"--sandbox",\s*replacementCloseoutProofSandbox/);
+  assert.doesNotMatch(helper, /"--sandbox",\s*codexReviewSandbox/);
+});
+
+test("replacement closeout proof accepts written output after nonzero Codex exit", () => {
+  const sourcePath = path.join(process.cwd(), "src/repair/execute-fix-artifact.ts");
+  const source = fs.readFileSync(sourcePath, "utf8");
+  const helperStart = source.indexOf("function replacementCloseoutProofAllowsClose(");
+  const helperEnd = source.indexOf("function linkReplacementSourcePr(", helperStart);
+  assert.notEqual(helperStart, -1);
+  assert.notEqual(helperEnd, -1);
+  const helper = source.slice(helperStart, helperEnd);
+  const statusIndex = helper.indexOf("if (child.status !== 0)");
+  const missingOutputIndex = helper.indexOf("if (!fs.existsSync(outputPath))");
+  assert.notEqual(statusIndex, -1);
+  assert.notEqual(missingOutputIndex, -1);
+  const nonzeroStatusBlock = helper.slice(statusIndex, missingOutputIndex);
+
+  assert.match(nonzeroStatusBlock, /fs\.existsSync\(outputPath\)/);
+  assert.match(nonzeroStatusBlock, /replacementCloseoutProofDecisionFromOutput\(outputPath\)/);
+});
+
+test("replacement closeout proof removes stale output before Codex runs", () => {
+  const sourcePath = path.join(process.cwd(), "src/repair/execute-fix-artifact.ts");
+  const source = fs.readFileSync(sourcePath, "utf8");
+  const helperStart = source.indexOf("function replacementCloseoutProofAllowsClose(");
+  const helperEnd = source.indexOf("function linkReplacementSourcePr(", helperStart);
+  assert.notEqual(helperStart, -1);
+  assert.notEqual(helperEnd, -1);
+  const helper = source.slice(helperStart, helperEnd);
+  const outputPathIndex = helper.indexOf("const outputPath =");
+  const spawnIndex = helper.indexOf("spawnCodexSyncWithHeartbeat(");
+  const unlinkIndex = helper.indexOf("fs.unlinkSync(outputPath)");
+
+  assert.notEqual(outputPathIndex, -1);
+  assert.notEqual(spawnIndex, -1);
+  assert.notEqual(unlinkIndex, -1);
+  assert.ok(
+    outputPathIndex < unlinkIndex && unlinkIndex < spawnIndex,
+    "stale replacement proof output must be removed before Codex can fail without writing",
+  );
 });
 
 test("source PR view hydrates labels comments and files for replacement closeout", () => {
@@ -151,6 +208,12 @@ test("source PR view hydrates labels comments and files for replacement closeout
 
   assert.match(
     helper,
-    /author,state,mergedAt,title,url,body,labels,comments,files,headRefOid,updatedAt/,
+    /author,state,mergedAt,title,url,body,labels,changedFiles,headRefOid,updatedAt/,
   );
+  assert.match(helper, /repos\/\$\{repo\}\/pulls\/\$\{number\}\/files\?per_page=100/);
+  assert.match(helper, /repos\/\$\{repo\}\/issues\/\$\{number\}\/comments\?per_page=100/);
+  assert.match(helper, /repos\/\$\{repo\}\/pulls\/\$\{number\}\/reviews\?per_page=100/);
+  assert.match(helper, /commentsTruncated/);
+  assert.match(helper, /reviewsTruncated/);
+  assert.match(helper, /filesTruncated/);
 });

--- a/test/repair/execute-fix-github.test.ts
+++ b/test/repair/execute-fix-github.test.ts
@@ -4,12 +4,7 @@ import test from "node:test";
 import { CLAWSWEEPER_CO_AUTHOR_TRAILER } from "../../dist/repair/co-author-credit.js";
 import {
   coAuthorTrailers,
-  pullRequestCloseoutDriftBlockReason,
   pullRequestFileContextBlockReason,
-  pullRequestIssueCommentContextBlockReason,
-  pullRequestReviewContextBlockReason,
-  pullRequestReviewCommentContextBlockReason,
-  sourcePullRequestSecurityBlockReason,
 } from "../../dist/repair/execute-fix-github.js";
 
 test("replacement co-author trailers include contributor and ClawSweeper credit", () => {
@@ -39,61 +34,7 @@ test("replacement co-author trailers dedupe ClawSweeper credit", () => {
   );
 });
 
-test("replacement source PR security gate allows ordinary source PRs", () => {
-  assert.equal(
-    sourcePullRequestSecurityBlockReason({
-      title: "Fix stale activity test",
-      body: "Regular bug fix.",
-      labels: [{ name: "bug" }],
-      comments: [{ body: "Looks good." }],
-    }),
-    "",
-  );
-});
-
-test("replacement source PR security gate blocks labels and comments", () => {
-  assert.match(
-    sourcePullRequestSecurityBlockReason({
-      title: "Fix auth bypass",
-      body: "Regular body.",
-      labels: [{ name: "security" }],
-      comments: [],
-    }),
-    /security-sensitive source PR/,
-  );
-  assert.match(
-    sourcePullRequestSecurityBlockReason({
-      title: "Fix auth bypass",
-      body: "Regular body.",
-      labels: [],
-      comments: [{ body: "clawsweeper-security:security" }],
-    }),
-    /security-sensitive source PR/,
-  );
-  assert.match(
-    sourcePullRequestSecurityBlockReason({
-      title: "Fix auth bypass",
-      body: "Regular body.",
-      labels: [],
-      comments: [],
-      reviews: [{ body: "clawsweeper-security:security" }],
-      reviewComments: [],
-    }),
-    /security-sensitive source PR/,
-  );
-  assert.match(
-    sourcePullRequestSecurityBlockReason({
-      title: "Fix auth bypass",
-      body: "Regular body.",
-      labels: [],
-      comments: [],
-      reviewComments: [{ body: "clawsweeper-security:security" }],
-    }),
-    /security-sensitive source PR/,
-  );
-});
-
-test("replacement source PR file context blocks truncated file lists", () => {
+test("replacement source PR file context only blocks missing file lists", () => {
   assert.equal(
     pullRequestFileContextBlockReason({
       changedFiles: 2,
@@ -101,131 +42,12 @@ test("replacement source PR file context blocks truncated file lists", () => {
     }),
     "",
   );
-  assert.match(
+  assert.equal(
     pullRequestFileContextBlockReason({
       changedFiles: 101,
       files: Array.from({ length: 100 }, (_, index) => ({ path: `src/${index}.ts` })),
     }),
-    /file context is truncated/,
-  );
-});
-
-test("replacement source PR review comment context blocks missing or truncated comments", () => {
-  assert.equal(
-    pullRequestReviewCommentContextBlockReason({
-      reviewComments: [{ body: "Keep this unique test." }],
-    }),
     "",
   );
-  assert.match(
-    pullRequestReviewCommentContextBlockReason({
-      reviewComments: [],
-      reviewCommentsTruncated: true,
-    }),
-    /review comment context is truncated/,
-  );
-  assert.match(pullRequestReviewCommentContextBlockReason({}), /review comment context is missing/);
-});
-
-test("replacement source PR review context blocks missing or truncated reviews", () => {
-  assert.equal(
-    pullRequestReviewContextBlockReason({
-      reviews: [{ body: "Changes requested: keep this unique test." }],
-    }),
-    "",
-  );
-  assert.match(
-    pullRequestReviewContextBlockReason({
-      reviews: [],
-      reviewsTruncated: true,
-    }),
-    /review context is truncated/,
-  );
-  assert.match(pullRequestReviewContextBlockReason({}), /review context is missing/);
-});
-
-test("replacement source PR issue comment context blocks missing or truncated comments", () => {
-  assert.equal(
-    pullRequestIssueCommentContextBlockReason({
-      comments: [{ body: "Keep this unique proof." }],
-    }),
-    "",
-  );
-  assert.match(
-    pullRequestIssueCommentContextBlockReason({
-      comments: [],
-      commentsTruncated: true,
-    }),
-    /comment context is truncated/,
-  );
-  assert.match(pullRequestIssueCommentContextBlockReason({}), /comment context is missing/);
-});
-
-test("replacement source PR closeout blocks post-proof drift", () => {
-  assert.match(
-    pullRequestCloseoutDriftBlockReason(
-      { state: "OPEN", updatedAt: "2026-05-01T00:00:00Z", files: [], reviewComments: [] },
-      { state: "OPEN", updatedAt: "2026-05-01T00:01:00Z", files: [], reviewComments: [] },
-    ),
-    /changed during replacement closeout proof/,
-  );
-  assert.match(
-    pullRequestCloseoutDriftBlockReason(
-      { state: "OPEN", updatedAt: "2026-05-01T00:00:00Z", files: [] },
-      {
-        state: "OPEN",
-        updatedAt: "2026-05-01T00:00:00Z",
-        files: [],
-        reviews: [],
-        reviewComments: [],
-        comments: [{ body: "<!-- clawsweeper-security:security-sensitive item=1 sha=abc -->" }],
-      },
-    ),
-    /security-sensitive source PR/,
-  );
-  assert.match(
-    pullRequestCloseoutDriftBlockReason(
-      {
-        state: "OPEN",
-        updatedAt: "2026-05-01T00:00:00Z",
-        headRefOid: "old-head",
-        files: [],
-        reviews: [],
-        reviewComments: [],
-      },
-      {
-        state: "OPEN",
-        updatedAt: "2026-05-01T00:00:00Z",
-        headRefOid: "new-head",
-        files: [],
-        reviews: [],
-        reviewComments: [],
-      },
-      "replacement PR",
-    ),
-    /replacement PR changed during replacement closeout proof/,
-  );
-});
-
-test("replacement source PR closeout blocks truncated issue comments", () => {
-  assert.match(
-    pullRequestCloseoutDriftBlockReason(
-      {
-        state: "OPEN",
-        updatedAt: "2026-05-01T00:00:00Z",
-        files: [],
-        reviewComments: [],
-      },
-      {
-        state: "OPEN",
-        updatedAt: "2026-05-01T00:00:00Z",
-        files: [],
-        comments: [{ body: "Visible comment." }],
-        commentsTruncated: true,
-        reviews: [],
-        reviewComments: [],
-      },
-    ),
-    /comment context is truncated/,
-  );
+  assert.match(pullRequestFileContextBlockReason({}), /file context is missing/);
 });

--- a/test/repair/execute-fix-github.test.ts
+++ b/test/repair/execute-fix-github.test.ts
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { CLAWSWEEPER_CO_AUTHOR_TRAILER } from "../../dist/repair/co-author-credit.js";
-import { coAuthorTrailers } from "../../dist/repair/execute-fix-github.js";
+import {
+  coAuthorTrailers,
+  sourcePullRequestSecurityBlockReason,
+} from "../../dist/repair/execute-fix-github.js";
 
 test("replacement co-author trailers include contributor and ClawSweeper credit", () => {
   assert.deepEqual(
@@ -28,5 +31,38 @@ test("replacement co-author trailers dedupe ClawSweeper credit", () => {
       },
     ]),
     [CLAWSWEEPER_CO_AUTHOR_TRAILER],
+  );
+});
+
+test("replacement source PR security gate allows ordinary source PRs", () => {
+  assert.equal(
+    sourcePullRequestSecurityBlockReason({
+      title: "Fix stale activity test",
+      body: "Regular bug fix.",
+      labels: [{ name: "bug" }],
+      comments: [{ body: "Looks good." }],
+    }),
+    "",
+  );
+});
+
+test("replacement source PR security gate blocks labels and comments", () => {
+  assert.match(
+    sourcePullRequestSecurityBlockReason({
+      title: "Fix auth bypass",
+      body: "Regular body.",
+      labels: [{ name: "security" }],
+      comments: [],
+    }),
+    /security-sensitive source PR/,
+  );
+  assert.match(
+    sourcePullRequestSecurityBlockReason({
+      title: "Fix auth bypass",
+      body: "Regular body.",
+      labels: [],
+      comments: [{ body: "clawsweeper-security:security" }],
+    }),
+    /security-sensitive source PR/,
   );
 });

--- a/test/repair/execute-fix-github.test.ts
+++ b/test/repair/execute-fix-github.test.ts
@@ -4,6 +4,11 @@ import test from "node:test";
 import { CLAWSWEEPER_CO_AUTHOR_TRAILER } from "../../dist/repair/co-author-credit.js";
 import {
   coAuthorTrailers,
+  pullRequestCloseoutDriftBlockReason,
+  pullRequestFileContextBlockReason,
+  pullRequestIssueCommentContextBlockReason,
+  pullRequestReviewContextBlockReason,
+  pullRequestReviewCommentContextBlockReason,
   sourcePullRequestSecurityBlockReason,
 } from "../../dist/repair/execute-fix-github.js";
 
@@ -64,5 +69,163 @@ test("replacement source PR security gate blocks labels and comments", () => {
       comments: [{ body: "clawsweeper-security:security" }],
     }),
     /security-sensitive source PR/,
+  );
+  assert.match(
+    sourcePullRequestSecurityBlockReason({
+      title: "Fix auth bypass",
+      body: "Regular body.",
+      labels: [],
+      comments: [],
+      reviews: [{ body: "clawsweeper-security:security" }],
+      reviewComments: [],
+    }),
+    /security-sensitive source PR/,
+  );
+  assert.match(
+    sourcePullRequestSecurityBlockReason({
+      title: "Fix auth bypass",
+      body: "Regular body.",
+      labels: [],
+      comments: [],
+      reviewComments: [{ body: "clawsweeper-security:security" }],
+    }),
+    /security-sensitive source PR/,
+  );
+});
+
+test("replacement source PR file context blocks truncated file lists", () => {
+  assert.equal(
+    pullRequestFileContextBlockReason({
+      changedFiles: 2,
+      files: [{ path: "src/a.ts" }, { path: "src/b.ts" }],
+    }),
+    "",
+  );
+  assert.match(
+    pullRequestFileContextBlockReason({
+      changedFiles: 101,
+      files: Array.from({ length: 100 }, (_, index) => ({ path: `src/${index}.ts` })),
+    }),
+    /file context is truncated/,
+  );
+});
+
+test("replacement source PR review comment context blocks missing or truncated comments", () => {
+  assert.equal(
+    pullRequestReviewCommentContextBlockReason({
+      reviewComments: [{ body: "Keep this unique test." }],
+    }),
+    "",
+  );
+  assert.match(
+    pullRequestReviewCommentContextBlockReason({
+      reviewComments: [],
+      reviewCommentsTruncated: true,
+    }),
+    /review comment context is truncated/,
+  );
+  assert.match(pullRequestReviewCommentContextBlockReason({}), /review comment context is missing/);
+});
+
+test("replacement source PR review context blocks missing or truncated reviews", () => {
+  assert.equal(
+    pullRequestReviewContextBlockReason({
+      reviews: [{ body: "Changes requested: keep this unique test." }],
+    }),
+    "",
+  );
+  assert.match(
+    pullRequestReviewContextBlockReason({
+      reviews: [],
+      reviewsTruncated: true,
+    }),
+    /review context is truncated/,
+  );
+  assert.match(pullRequestReviewContextBlockReason({}), /review context is missing/);
+});
+
+test("replacement source PR issue comment context blocks missing or truncated comments", () => {
+  assert.equal(
+    pullRequestIssueCommentContextBlockReason({
+      comments: [{ body: "Keep this unique proof." }],
+    }),
+    "",
+  );
+  assert.match(
+    pullRequestIssueCommentContextBlockReason({
+      comments: [],
+      commentsTruncated: true,
+    }),
+    /comment context is truncated/,
+  );
+  assert.match(pullRequestIssueCommentContextBlockReason({}), /comment context is missing/);
+});
+
+test("replacement source PR closeout blocks post-proof drift", () => {
+  assert.match(
+    pullRequestCloseoutDriftBlockReason(
+      { state: "OPEN", updatedAt: "2026-05-01T00:00:00Z", files: [], reviewComments: [] },
+      { state: "OPEN", updatedAt: "2026-05-01T00:01:00Z", files: [], reviewComments: [] },
+    ),
+    /changed during replacement closeout proof/,
+  );
+  assert.match(
+    pullRequestCloseoutDriftBlockReason(
+      { state: "OPEN", updatedAt: "2026-05-01T00:00:00Z", files: [] },
+      {
+        state: "OPEN",
+        updatedAt: "2026-05-01T00:00:00Z",
+        files: [],
+        reviews: [],
+        reviewComments: [],
+        comments: [{ body: "<!-- clawsweeper-security:security-sensitive item=1 sha=abc -->" }],
+      },
+    ),
+    /security-sensitive source PR/,
+  );
+  assert.match(
+    pullRequestCloseoutDriftBlockReason(
+      {
+        state: "OPEN",
+        updatedAt: "2026-05-01T00:00:00Z",
+        headRefOid: "old-head",
+        files: [],
+        reviews: [],
+        reviewComments: [],
+      },
+      {
+        state: "OPEN",
+        updatedAt: "2026-05-01T00:00:00Z",
+        headRefOid: "new-head",
+        files: [],
+        reviews: [],
+        reviewComments: [],
+      },
+      "replacement PR",
+    ),
+    /replacement PR changed during replacement closeout proof/,
+  );
+});
+
+test("replacement source PR closeout blocks truncated issue comments", () => {
+  assert.match(
+    pullRequestCloseoutDriftBlockReason(
+      {
+        state: "OPEN",
+        updatedAt: "2026-05-01T00:00:00Z",
+        files: [],
+        reviewComments: [],
+      },
+      {
+        state: "OPEN",
+        updatedAt: "2026-05-01T00:00:00Z",
+        files: [],
+        comments: [{ body: "Visible comment." }],
+        commentsTruncated: true,
+        reviews: [],
+        reviewComments: [],
+      },
+    ),
+    /comment context is truncated/,
   );
 });

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -277,6 +277,76 @@ test("workflow utilities select eligible proposed close records", () => {
       "",
     ].join("\n"),
   );
+  write(
+    path.join(root, "records/openclaw-openclaw/items/openclaw-openclaw-17.md"),
+    [
+      "---",
+      "repository: openclaw/openclaw",
+      "type: pull_request",
+      "decision: keep_open",
+      "confidence: high",
+      "action_taken: kept_open",
+      "review_status: complete",
+      "item_snapshot_hash: reviewed-snapshot",
+      `item_created_at: ${oldDate}`,
+      'work_cluster_refs: ["Superseded by https://github.com/openclaw/openclaw/pull/400"]',
+      "---",
+      "",
+    ].join("\n"),
+  );
+  write(
+    path.join(root, "records/openclaw-openclaw/items/openclaw-openclaw-18.md"),
+    [
+      "---",
+      "repository: openclaw/openclaw",
+      "type: pull_request",
+      "decision: keep_open",
+      "confidence: high",
+      "action_taken: kept_open",
+      "review_status: complete",
+      "item_snapshot_hash: reviewed-snapshot",
+      `item_created_at: ${oldDate}`,
+      'work_cluster_refs: ["Related to https://github.com/openclaw/openclaw/pull/401"]',
+      "---",
+      "",
+    ].join("\n"),
+  );
+  write(
+    path.join(root, "records/openclaw-openclaw/items/openclaw-openclaw-19.md"),
+    [
+      "---",
+      "repository: openclaw/openclaw",
+      "type: pull_request",
+      "decision: keep_open",
+      "confidence: high",
+      "action_taken: kept_open",
+      "review_status: complete",
+      "item_snapshot_hash: reviewed-snapshot",
+      `item_created_at: ${oldDate}`,
+      "apply_checked_at: 2099-01-01T00:00:00Z",
+      'work_cluster_refs: ["Superseded by https://github.com/openclaw/openclaw/pull/402"]',
+      "---",
+      "",
+    ].join("\n"),
+  );
+  write(
+    path.join(root, "records/openclaw-openclaw/items/openclaw-openclaw-20.md"),
+    [
+      "---",
+      "repository: openclaw/openclaw",
+      "type: pull_request",
+      "decision: keep_open",
+      "confidence: high",
+      "action_taken: kept_open",
+      "review_status: complete",
+      "item_snapshot_hash: reviewed-snapshot",
+      `item_created_at: ${oldDate}`,
+      "summary: Replacement work is still under review.",
+      'work_cluster_refs: ["Related to https://github.com/openclaw/openclaw/pull/403"]',
+      "---",
+      "",
+    ].join("\n"),
+  );
 
   const selected = withCwd(root, () =>
     proposedItemNumbers({
@@ -289,7 +359,7 @@ test("workflow utilities select eligible proposed close records", () => {
     }),
   );
 
-  assert.deepEqual(selected, [5, 12, 15]);
+  assert.deepEqual(selected, [5, 12, 15, 17]);
 });
 
 test("workflow utilities allow ClawHub implemented-on-main issue proposals", () => {

--- a/test/supersession-proof.test.ts
+++ b/test/supersession-proof.test.ts
@@ -23,6 +23,21 @@ test("supersession proof rejects blank covered work before closing", () => {
   assert.match(decision.reason, /incomplete/);
 });
 
+test("supersession proof can close security-sensitive work when coverage is concrete", () => {
+  const decision = supersessionProofCloseDecision({
+    sourceSummary: "PR A fixes the auth route.",
+    replacementSummary: "PR B fixes the same auth route.",
+    coveredWork: ["PR B includes the auth route fix that PR A proposed."],
+    uniqueSourceWork: [],
+    securityBlocked: true,
+    decision: "superseded",
+    reason: "PR B covers PR A's auth behavior and PR A has no unique remaining work.",
+  });
+
+  assert.equal(decision.close, true);
+  assert.equal(decision.proof.decision, "superseded");
+});
+
 test("supersession proof view includes bounded file and discussion context", () => {
   const view = compactSupersessionProofView({
     title: "Fix activity",

--- a/test/supersession-proof.test.ts
+++ b/test/supersession-proof.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  compactSupersessionProofView,
+  supersessionProofCloseDecision,
+  supersessionProofViewContextTruncated,
+} from "../dist/supersession-proof.js";
+
+test("supersession proof rejects blank covered work before closing", () => {
+  const decision = supersessionProofCloseDecision({
+    sourceSummary: "PR A fixes the activity route.",
+    replacementSummary: "PR B fixes the activity route.",
+    coveredWork: ["  "],
+    uniqueSourceWork: [],
+    securityBlocked: false,
+    decision: "superseded",
+    reason: "PR B covers PR A.",
+  });
+
+  assert.equal(decision.close, false);
+  assert.equal(decision.proof.decision, "keep_open");
+  assert.match(decision.reason, /incomplete/);
+});
+
+test("supersession proof view includes bounded file and discussion context", () => {
+  const view = compactSupersessionProofView({
+    title: "Fix activity",
+    body: "Adds the activity fix.",
+    changedFiles: 1,
+    filePaths: ["src/activity.ts"],
+    files: [
+      {
+        filename: "src/activity.ts",
+        status: "modified",
+        additions: 2,
+        deletions: 0,
+        patch: "@@\n+fixActivity();",
+      },
+    ],
+    comments: [{ user: { login: "maintainer" }, body: "This still needs fixActivity." }],
+    reviews: [
+      {
+        user: { login: "reviewer" },
+        author_association: "MEMBER",
+        state: "CHANGES_REQUESTED",
+        submitted_at: "2026-05-01T00:00:00Z",
+        body: "Changes requested: keep the route fix.",
+      },
+    ],
+    reviewComments: [{ author: "reviewer", body: "Please preserve the activity route." }],
+  });
+
+  assert.match(JSON.stringify(view), /fixActivity/);
+  assert.match(JSON.stringify(view), /This still needs fixActivity/);
+  assert.match(JSON.stringify(view), /CHANGES_REQUESTED/);
+  assert.match(JSON.stringify(view), /2026-05-01T00:00:00Z/);
+  assert.match(JSON.stringify(view), /Changes requested: keep the route fix/);
+  assert.match(JSON.stringify(view), /preserve the activity route/);
+});
+
+test("supersession proof view reports truncated proof context", () => {
+  assert.equal(
+    supersessionProofViewContextTruncated({
+      files: [{ filename: "src/activity.ts", patch: `@@\n+${"x".repeat(1700)}` }],
+    }),
+    true,
+  );
+  assert.equal(
+    supersessionProofViewContextTruncated({
+      files: Array.from({ length: 81 }, (_, index) => ({ filename: `src/${index}.ts` })),
+    }),
+    true,
+  );
+  assert.equal(
+    supersessionProofViewContextTruncated({
+      comments: [{ body: "Visible comment." }],
+      commentsTruncated: true,
+    }),
+    true,
+  );
+  assert.equal(
+    supersessionProofViewContextTruncated({
+      reviews: [{ body: "Visible review." }],
+      reviewsTruncated: true,
+    }),
+    true,
+  );
+  assert.equal(
+    supersessionProofViewContextTruncated({
+      reviewComments: [{ body: "Visible review comment." }],
+      reviewCommentsTruncated: true,
+    }),
+    true,
+  );
+  assert.equal(
+    supersessionProofViewContextTruncated({
+      comments: [{ body: "Looks covered." }],
+      files: [{ filename: "src/activity.ts", patch: "@@\n+fixActivity();" }],
+    }),
+    false,
+  );
+});


### PR DESCRIPTION
## Summary

- Require hydrated PR A / PR B proof before normal apply can close PR A as superseded.
- Add compact shared supersession proof helpers, prompt templates, and schema-backed model output checks.
- Gate repair replacement closeout on source PR security/context checks and fall back to link-only when proof is missing or blocked.

## Validation

- `fnm exec --using v24.14.1 pnpm run format`
- `fnm exec --using v24.14.1 pnpm run build:all`
- `fnm exec --using v24.14.1 node --test --test-name-pattern 'PRs superseded by linked pull requests|linked supersession proof is incomplete|same-file supersession is incomplete|security-labeled PRs open|comments contain security markers|supersession proof prompt' test/clawsweeper.test.ts`
- `fnm exec --using v24.14.1 node --test test/repair/execute-fix-artifact-source.test.ts test/repair/execute-fix-github.test.ts`
- `fnm exec --using v24.14.1 pnpm run check`
- `git diff --check --cached`