### PR TITLE
fix: tune OpenClaw review metrics guidance

### DIFF
--- a/src/repository-profiles.ts
+++ b/src/repository-profiles.ts
@@ -76,7 +76,7 @@ const CORE_OPENCLAW_PROFILE: RepositoryProfile = {
   docsUrl: "https://docs.openclaw.ai",
   communityUrl: "https://clawhub.ai/",
   promptNote:
-    "Use the OpenClaw source tree, docs, changelog, and current main branch. Close proposals may use the normal OpenClaw stale/duplicate/not-in-repo/implemented-on-main policy when evidence is strong.",
+    "Use the OpenClaw source tree, docs, changelog, and current main branch. Close proposals may use the normal OpenClaw stale/duplicate/not-in-repo/implemented-on-main policy when evidence is strong. For OpenClaw PR reviews, ClawSweeper renders deterministic PR surface stats separately; do not repeat changed-file counts, additions/deletions, or area totals in Review metrics unless adding a new interpretation not present in the deterministic surface block. Use Review metrics for new review-relevant facts, especially user-facing configuration additions, new flags/options/env vars, new protocol/API params, default changes, migrations, persisted settings, or compatibility paths.",
   applyCloseRules: {
     issue: OPENCLAW_CLOSE_REASONS,
     pull_request: OPENCLAW_CLOSE_REASONS.filter((reason) => reason !== "stale_insufficient_info"),


### PR DESCRIPTION
## Summary

- Scope OpenClaw review-metrics guidance through the ClawSweeper repository profile.
- Tell OpenClaw PR reviews not to repeat deterministic PR surface stats in Review metrics.
- Preserve high-signal metrics for user-facing config/API/default additions and compatibility paths.

## Real behavior proof

After building the generated `dist` output, I checked the repository profile path that ClawSweeper injects into review prompts.

```text
$ node --input-type=module -e "import { repositoryProfileFor } from './dist/repository-profiles.js'; const openclaw = repositoryProfileFor('openclaw/openclaw').promptNote; const other = repositoryProfileFor('openclaw/clawsweeper').promptNote; console.log('openclaw_has_metrics_guidance:', openclaw.includes('do not repeat changed-file counts')); console.log('openclaw_has_config_additions_guidance:', openclaw.includes('user-facing configuration additions')); console.log('clawsweeper_has_metrics_guidance:', other.includes('do not repeat changed-file counts'));"
openclaw_has_metrics_guidance: true
openclaw_has_config_additions_guidance: true
clawsweeper_has_metrics_guidance: false
```

This shows the guidance is present for `openclaw/openclaw`, includes the user-facing configuration additions clause, and is not added to the `openclaw/clawsweeper` profile.

## Validation

- `./node_modules/.bin/tsgo -p tsconfig.json`
- `node --test test/repository-profiles.test.ts`
- `git diff --check -- src/repository-profiles.ts`
