### PR TITLE
feat: schedule observable cluster repair intake

### DIFF
--- a/.github/workflows/repair-cluster-intake.yml
+++ b/.github/workflows/repair-cluster-intake.yml
@@ -1,0 +1,285 @@
+name: repair cluster intake
+
+on:
+  workflow_dispatch:
+    inputs:
+      enabled:
+        description: "Run cluster repair intake"
+        required: false
+        default: "1"
+        type: string
+      target_repo:
+        description: "Target repository"
+        required: true
+        default: "openclaw/openclaw"
+        type: string
+      limit:
+        description: "Maximum imported gitcrawl clusters per run"
+        required: false
+        default: "1"
+        type: string
+      runner:
+        description: "Runner label for repair planning/review work"
+        required: false
+        default: blacksmith-4vcpu-ubuntu-2404
+        type: string
+      execution_runner:
+        description: "Runner label for fix/apply execution work"
+        required: false
+        default: blacksmith-16vcpu-ubuntu-2404
+        type: string
+      model:
+        description: "Codex model for repair worker"
+        required: false
+        default: gpt-5.5
+        type: string
+      force_store:
+        description: "Ignore the processed-store ledger and retry the current gitcrawl-store snapshot"
+        required: false
+        default: false
+        type: boolean
+  schedule:
+    # gitcrawl-store refreshes openclaw/openclaw every 15 minutes. This intake
+    # runs hourly and records the processed portable DB SHA so a
+    # delayed or duplicate tick does not enqueue work from the same store twice.
+    - cron: "8 * * * *"
+
+permissions:
+  actions: write
+  contents: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  CLAWSWEEPER_APP_CLIENT_ID: Iv23liOECG0slfuhz093
+  CLAWSWEEPER_ALLOWED_OWNER: ${{ vars.CLAWSWEEPER_ALLOWED_OWNER || 'openclaw' }}
+  CLAWSWEEPER_MODEL: ${{ vars.CLAWSWEEPER_MODEL || 'gpt-5.5' }}
+  CLAWSWEEPER_GIT_USER_NAME: ${{ vars.CLAWSWEEPER_GIT_USER_NAME || 'clawsweeper[bot]' }}
+  CLAWSWEEPER_GIT_USER_EMAIL: ${{ vars.CLAWSWEEPER_GIT_USER_EMAIL || '274271284+clawsweeper[bot]@users.noreply.github.com' }}
+
+concurrency:
+  group: cluster-repair-intake-${{ github.event.inputs.target_repo || vars.CLAWSWEEPER_CLUSTER_REPAIR_TARGET_REPO || 'openclaw/openclaw' }}
+  cancel-in-progress: false
+
+jobs:
+  intake:
+    if: ${{ github.event_name != 'schedule' || vars.CLAWSWEEPER_FEATURE_CLUSTER_REPAIR_ENABLED == '1' }}
+    runs-on: ${{ github.event.inputs.runner || vars.CLAWSWEEPER_CLUSTER_REPAIR_INTAKE_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    timeout-minutes: 45
+    steps:
+      - name: Create central GitHub App token
+        id: central-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+          owner: openclaw
+          repositories: clawsweeper
+          permission-actions: write
+          permission-contents: write
+
+      - name: Create gitcrawl-store token
+        id: store-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+          owner: openclaw
+          repositories: gitcrawl-store
+          permission-contents: read
+
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ steps.central-token.outputs.token }}
+          filter: blob:none
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-pnpm
+        with:
+          build-script: build:repair
+
+      - name: Create state token
+        id: state-token
+        uses: ./.github/actions/create-state-token
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+
+      - uses: ./.github/actions/setup-state
+        with:
+          token: ${{ steps.state-token.outputs.token }}
+          fetch-depth: 1
+
+      - uses: actions/checkout@v6
+        with:
+          repository: openclaw/gitcrawl-store
+          token: ${{ steps.store-token.outputs.token }}
+          path: gitcrawl-store
+          fetch-depth: 1
+
+      - name: Ensure SQLite CLI
+        run: |
+          if ! command -v sqlite3 >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y sqlite3
+          fi
+
+      - name: Prepare intake
+        id: prepare
+        env:
+          ENABLED: ${{ github.event.inputs.enabled || '1' }}
+          SCHEDULE_ENABLED: ${{ vars.CLAWSWEEPER_FEATURE_CLUSTER_REPAIR_ENABLED == '1' && '1' || '0' }}
+          TARGET_REPO: ${{ github.event.inputs.target_repo || vars.CLAWSWEEPER_CLUSTER_REPAIR_TARGET_REPO || 'openclaw/openclaw' }}
+          FORCE_STORE: ${{ github.event.inputs.force_store == 'true' && '1' || '0' }}
+        run: |
+          set -euo pipefail
+          if [ "$ENABLED" != "1" ]; then
+            echo "should_import=false" >> "$GITHUB_OUTPUT"
+            echo "should_dispatch=false" >> "$GITHUB_OUTPUT"
+            echo "Cluster repair intake is disabled for this manual dispatch."
+            exit 0
+          fi
+          if [ "$GITHUB_EVENT_NAME" = "schedule" ] && [ "$SCHEDULE_ENABLED" != "1" ]; then
+            echo "should_import=false" >> "$GITHUB_OUTPUT"
+            echo "should_dispatch=false" >> "$GITHUB_OUTPUT"
+            echo "Scheduled cluster repair intake is disabled. Set CLAWSWEEPER_FEATURE_CLUSTER_REPAIR_ENABLED=1."
+            exit 0
+          fi
+
+          repo_slug="${TARGET_REPO//\//-}"
+          db_name="${TARGET_REPO,,}"
+          db_name="${db_name//\//__}.sync.db"
+          manifest_path="gitcrawl-store/data/${db_name}.manifest.json"
+          db_path="gitcrawl-store/data/${db_name}"
+          ledger_path="results/cluster-repair-intake/${repo_slug}.json"
+          if [ ! -f "$manifest_path" ]; then
+            echo "::error::Missing gitcrawl-store manifest: ${manifest_path}"
+            exit 1
+          fi
+          if [ ! -f "$db_path" ]; then
+            echo "::error::Missing gitcrawl-store DB: ${db_path}"
+            exit 1
+          fi
+
+          store_sha="$(node -e "const fs=require('fs'); const m=JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); console.log(m.sha256 || '')" "$manifest_path")"
+          exported_at="$(node -e "const fs=require('fs'); const m=JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); console.log(m.exportedAt || '')" "$manifest_path")"
+          previous_sha=""
+          if [ -f "$ledger_path" ]; then
+            previous_sha="$(node -e "const fs=require('fs'); const p=process.argv[1]; const r=JSON.parse(fs.readFileSync(p, 'utf8')); console.log(r.last_processed_store_sha256 || '')" "$ledger_path")"
+          fi
+
+          {
+            echo "target_repo=${TARGET_REPO}"
+            echo "repo_slug=${repo_slug}"
+            echo "db_path=${db_path}"
+            echo "manifest_path=${manifest_path}"
+            echo "ledger_path=${ledger_path}"
+            echo "store_sha=${store_sha}"
+            echo "exported_at=${exported_at}"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ "$FORCE_STORE" != "1" ] && [ -n "$store_sha" ] && [ "$store_sha" = "$previous_sha" ]; then
+            echo "should_import=false" >> "$GITHUB_OUTPUT"
+            echo "should_dispatch=false" >> "$GITHUB_OUTPUT"
+            echo "Already processed gitcrawl-store SHA ${store_sha}; skipping intake."
+            exit 0
+          fi
+          echo "should_import=true" >> "$GITHUB_OUTPUT"
+
+      - name: Import one cluster from gitcrawl-store
+        id: import
+        if: ${{ steps.prepare.outputs.should_import == 'true' }}
+        env:
+          TARGET_REPO: ${{ steps.prepare.outputs.target_repo }}
+          DB_PATH: ${{ steps.prepare.outputs.db_path }}
+          LIMIT: ${{ github.event.inputs.limit || vars.CLAWSWEEPER_CLUSTER_REPAIR_IMPORT_LIMIT || '1' }}
+        run: |
+          set -euo pipefail
+          mkdir -p .artifacts/cluster-repair-intake
+          generated_log=".artifacts/cluster-repair-intake/generated.txt"
+          pnpm run repair:import-gitcrawl -- \
+            --from-gitcrawl \
+            --repo "$TARGET_REPO" \
+            --db "$DB_PATH" \
+            --allow-empty \
+            --limit "$LIMIT" \
+            --mode autonomous \
+            --allow-fix-pr true \
+            --allow-merge false \
+            --allow-instant-close false \
+            --allow-post-merge-close true \
+            2> >(tee .artifacts/cluster-repair-intake/import-stderr.txt >&2) \
+            | tee "$generated_log"
+
+          mapfile -t generated < <(grep '^jobs/' "$generated_log" || true)
+          printf '%s\n' "${generated[@]}" > .artifacts/cluster-repair-intake/generated-paths.txt
+          {
+            echo "count=${#generated[@]}"
+            if [ "${#generated[@]}" -gt 0 ]; then
+              echo "should_dispatch=true"
+            else
+              echo "should_dispatch=false"
+            fi
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Record intake ledger
+        if: ${{ steps.prepare.outputs.should_import == 'true' }}
+        env:
+          LEDGER_PATH: ${{ steps.prepare.outputs.ledger_path }}
+          TARGET_REPO: ${{ steps.prepare.outputs.target_repo }}
+          STORE_SHA: ${{ steps.prepare.outputs.store_sha }}
+          EXPORTED_AT: ${{ steps.prepare.outputs.exported_at }}
+          MANIFEST_PATH: ${{ steps.prepare.outputs.manifest_path }}
+          GENERATED_COUNT: ${{ steps.import.outputs.count || '0' }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$(dirname "$LEDGER_PATH")"
+          node <<'NODE'
+          const fs = require("fs");
+          const generatedPath = ".artifacts/cluster-repair-intake/generated-paths.txt";
+          const generated = (fs.existsSync(generatedPath) ? fs.readFileSync(generatedPath, "utf8") : "")
+            .split(/\r?\n/)
+            .map((line) => line.trim())
+            .filter(Boolean);
+          const ledger = {
+            schema: "clawsweeper-cluster-repair-intake-v1",
+            target_repo: process.env.TARGET_REPO,
+            last_processed_store_sha256: process.env.STORE_SHA,
+            last_processed_store_exported_at: process.env.EXPORTED_AT,
+            manifest_path: process.env.MANIFEST_PATH,
+            generated_count: Number(process.env.GENERATED_COUNT || generated.length || 0),
+            generated_jobs: generated,
+            run_url: `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`,
+            updated_at: new Date().toISOString(),
+          };
+          fs.writeFileSync(process.env.LEDGER_PATH, `${JSON.stringify(ledger, null, 2)}\n`);
+          NODE
+
+      - name: Publish intake jobs and ledger
+        if: ${{ steps.prepare.outputs.should_import == 'true' }}
+        run: |
+          set -euo pipefail
+          pnpm run repair:publish-main -- \
+            --message "chore: record cluster repair intake" \
+            --path jobs \
+            --path results/cluster-repair-intake \
+            --max-attempts 12 \
+            --push-attempts 4
+
+      - name: Dispatch imported cluster repair
+        if: ${{ steps.import.outputs.should_dispatch == 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.central-token.outputs.token }}
+          RUNNER: ${{ github.event.inputs.runner || vars.CLAWSWEEPER_WORKER_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+          EXECUTION_RUNNER: ${{ github.event.inputs.execution_runner || vars.CLAWSWEEPER_EXECUTION_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
+          MODEL: ${{ github.event.inputs.model || vars.CLAWSWEEPER_MODEL || 'gpt-5.5' }}
+        run: |
+          set -euo pipefail
+          mapfile -t jobs < .artifacts/cluster-repair-intake/generated-paths.txt
+          git pull --rebase origin main
+          pnpm run repair:dispatch -- "${jobs[@]}" \
+            --mode autonomous \
+            --wait-for-capacity \
+            --runner "$RUNNER" \
+            --execution-runner "$EXECUTION_RUNNER" \
+            --model "$MODEL" \
+            --ref main

--- a/README.md
+++ b/README.md
@@ -549,12 +549,16 @@ ClawSweeper has one main capacity knob:
 `config/automation-limits.json` -> `workers.max`. The current value is `57`.
 Lane limits are derived from that number: normal review defaults to 39 shards
 for manual/backstop runs, scheduled normal review gets up to 27 after reserves,
-hot intake up to 19 shards, commit review 2 commits per page, and
-repair/issue implementation 22 live workers. Exact-item review, repair, and
-issue implementation are priority work; normal review, hot intake, and commit
-review are background work and automatically yield when priority work is active.
-Use `workers.max` first when turning total Codex usage up or down; use the
-individual environment overrides only for temporary lane-specific exceptions.
+hot intake up to 19 shards, commit review 2 commits per page, and existing
+repair/issue implementation lanes use 40% of `workers.max`, currently 22 live
+workers. Imported gitcrawl cluster repair stays at 1 live worker by default.
+Exact-item review, repair, and issue implementation are priority work; normal
+review, hot intake, and commit review are background work and automatically
+yield when priority work is active.
+Use `workers.max` first when turning total Codex usage up or down; use
+`lanes.repair.cluster_max_live_runs` to tune the imported legacy cluster-repair
+lane separately, and individual environment overrides only for temporary
+lane-specific exceptions.
 
 Target repositories can opt into event-level latency by installing the
 dispatcher workflow in [docs/target-dispatcher.md](docs/target-dispatcher.md).

--- a/config/automation-limits.json
+++ b/config/automation-limits.json
@@ -8,6 +8,9 @@
   "lanes": {
     "assist": {
       "max": 5
+    },
+    "repair": {
+      "cluster_max_live_runs": 1
     }
   }
 }

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -20,6 +20,8 @@ const DEFAULT_CLAWSWEEPER_BOT_LOGINS = ["clawsweeper[bot]", "openclaw-clawsweepe
 const GITHUB_TIMEOUT_MS = 4500;
 const DEFAULT_STALE_QUEUED_WORKFLOW_MS = 6 * 60 * 60 * 1000;
 const CLAWSWEEPER_REVIEW_REPO = "openclaw/clawsweeper";
+const CLUSTER_REPAIR_INTAKE_WORKFLOW = "repair-cluster-intake.yml";
+const CLUSTER_REPAIR_INTAKE_CRON = "8 * * * *";
 const CLAWSWEEPER_COMMAND_PATTERN =
   /(^|[ \t\r\n])@(?:clawsweeper|openclaw-clawsweeper)\b(?:\[bot\])?|(^|[ \t\r\n])\/(?:clawsweeper|review|re-review|rerun[ -]?review|status|explain|fix|build|implement|create[ -]?pr|fix[ -]?issue|autofix|auto[ -]?fix|automerge|auto[ -]?merge|approve|stop|autoclose)\b/i;
 const CLAWSWEEPER_ALLOWED_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
@@ -937,7 +939,7 @@ async function statusSnapshot(env, ctx) {
   const failedRuns = workflowRuns.filter(
     (run) => run.status === "completed" && TERMINAL_BAD_CONCLUSIONS.has(String(run.conclusion)),
   );
-  const [activeJobs, pipeline, automerge, closed, storedEvents] = await Promise.all([
+  const [activeJobs, pipeline, clusterRepair, automerge, closed, storedEvents] = await Promise.all([
     estimateActiveCodexJobs(workerRuns),
     withTimeout(
       pipelineItems(env, workerRuns.slice(0, 30)),
@@ -946,6 +948,14 @@ async function statusSnapshot(env, ctx) {
     ).catch((error) => {
       errors.push(error.message);
       return workerRuns.slice(0, 30).map((run) => classifyRun(run));
+    }),
+    withTimeout(
+      clusterRepairStatus(env, repo, targetRepos, activeRuns),
+      OPTIONAL_SECTION_TIMEOUT_MS,
+      "cluster repair intake",
+    ).catch((error) => {
+      errors.push(error.message);
+      return emptyClusterRepairStatus(targetRepos);
     }),
     withTimeout(
       recentAutomerge(env, targetRepos[0] || "openclaw/openclaw"),
@@ -994,6 +1004,7 @@ async function statusSnapshot(env, ctx) {
     },
     pipeline,
     recent: {
+      cluster_repair: clusterRepair,
       automerge: automerge.items,
       closed_items: closed.items,
       closed_stats: closed.stats,
@@ -2089,6 +2100,107 @@ async function recentAutomerge(env, repo) {
     samples: durations.length,
     items,
   };
+}
+
+async function clusterRepairStatus(env, repo, targetRepos, activeRuns) {
+  const [workflowRuns, markers] = await Promise.all([
+    githubJson(
+      env,
+      `/repos/${repo}/actions/workflows/${encodeURIComponent(CLUSTER_REPAIR_INTAKE_WORKFLOW)}/runs?per_page=5`,
+    ).catch(() => ({ workflow_runs: [] })),
+    Promise.all(targetRepos.map((targetRepo) => readClusterRepairMarker(env, repo, targetRepo))),
+  ]);
+  const intakeRuns = Array.isArray(workflowRuns?.workflow_runs) ? workflowRuns.workflow_runs : [];
+  return {
+    workflow: CLUSTER_REPAIR_INTAKE_WORKFLOW,
+    schedule: CLUSTER_REPAIR_INTAKE_CRON,
+    markers,
+    latest_runs: intakeRuns.slice(0, 5).map(workflowRunSummary),
+    active_intake_runs: activeRuns
+      .filter((run) => workflowRunNameIncludes(run, "repair cluster intake"))
+      .map(workflowRunSummary),
+    active_worker_runs: activeRuns
+      .filter((run) => workflowRunNameIncludes(run, "repair cluster worker"))
+      .map(workflowRunSummary),
+  };
+}
+
+async function readClusterRepairMarker(env, repo, targetRepo) {
+  const repoSlug = String(targetRepo || "").replace(/\//g, "-");
+  const markerPath = `results/cluster-repair-intake/${repoSlug}.json`;
+  try {
+    const content = await githubJson(
+      env,
+      `/repos/${repo}/contents/${githubPath(markerPath)}?ref=main`,
+    );
+    const marker = JSON.parse(decodeGithubContent(content?.content));
+    const generatedJobs = Array.isArray(marker.generated_jobs) ? marker.generated_jobs : [];
+    const storeSha = nullableString(marker.last_processed_store_sha256);
+    return {
+      target_repo: nullableString(marker.target_repo) || targetRepo,
+      marker_path: markerPath,
+      status: generatedJobs.length > 0 ? "imported" : "checked",
+      last_processed_store_sha256: storeSha,
+      last_processed_store_short_sha: storeSha ? storeSha.slice(0, 10) : null,
+      last_processed_store_exported_at: nullableString(marker.last_processed_store_exported_at),
+      generated_count: Math.max(0, numberOrNull(marker.generated_count) ?? generatedJobs.length),
+      generated_jobs: generatedJobs.slice(0, 8).map((job) => String(job)),
+      run_url: nullableString(marker.run_url),
+      updated_at: nullableString(marker.updated_at),
+    };
+  } catch {
+    return {
+      target_repo: targetRepo,
+      marker_path: markerPath,
+      status: "not_recorded",
+      last_processed_store_sha256: null,
+      last_processed_store_short_sha: null,
+      last_processed_store_exported_at: null,
+      generated_count: 0,
+      generated_jobs: [],
+      run_url: null,
+      updated_at: null,
+    };
+  }
+}
+
+function emptyClusterRepairStatus(targetRepos) {
+  return {
+    workflow: CLUSTER_REPAIR_INTAKE_WORKFLOW,
+    schedule: CLUSTER_REPAIR_INTAKE_CRON,
+    markers: targetRepos.map((targetRepo) => ({
+      target_repo: targetRepo,
+      marker_path: `results/cluster-repair-intake/${String(targetRepo).replace(/\//g, "-")}.json`,
+      status: "unavailable",
+      last_processed_store_sha256: null,
+      last_processed_store_short_sha: null,
+      last_processed_store_exported_at: null,
+      generated_count: 0,
+      generated_jobs: [],
+      run_url: null,
+      updated_at: null,
+    })),
+    latest_runs: [],
+    active_intake_runs: [],
+    active_worker_runs: [],
+  };
+}
+
+function workflowRunNameIncludes(run, needle) {
+  return `${run?.name || ""} ${run?.display_title || ""}`.toLowerCase().includes(needle);
+}
+
+function githubPath(value) {
+  return String(value).split("/").map(encodeURIComponent).join("/");
+}
+
+function decodeGithubContent(value) {
+  const binary = atob(String(value || "").replace(/\s/g, ""));
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return new TextDecoder().decode(bytes);
 }
 
 async function recentClawsweeperClosed(env, repos) {
@@ -3737,7 +3849,8 @@ a:hover { color: #89c8ff; text-decoration: underline; }
 .split > div,
 .split > aside { min-width: 0; }
 .pipeline-col { overflow: hidden; }
-.side-col { min-width: 0; }
+.cluster-col { grid-column: 1; }
+.side-col { grid-column: 2; grid-row: 1 / span 2; min-width: 0; }
 #pipeline,
 #automerge,
 #closed,
@@ -3879,7 +3992,7 @@ a:hover { color: #89c8ff; text-decoration: underline; }
   font-style: italic;
 }
 .empty::before { content: "🦀 "; opacity: 0.3; }
-@media (max-width: 1280px) { .grid { grid-template-columns: repeat(3, minmax(0, 1fr)); } .split { grid-template-columns: 1fr; } header { align-items: start; flex-direction: column; } .top-links { justify-content: flex-start; } }
+@media (max-width: 1280px) { .grid { grid-template-columns: repeat(3, minmax(0, 1fr)); } .split { grid-template-columns: 1fr; } .cluster-col, .side-col { grid-column: auto; grid-row: auto; } .side-col { order: 2; } .cluster-col { order: 3; } header { align-items: start; flex-direction: column; } .top-links { justify-content: flex-start; } }
 @media (max-width: 760px) { .grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } .work-row { grid-template-columns: 1fr; align-items: start; } .work-state, .stage-block, .timebox { justify-content: start; justify-items: start; } }
 @media (max-width: 560px) { main { width: min(100vw - 20px, 1440px); padding-top: 16px; } .grid, .closed-stats { grid-template-columns: 1fr; } .side-row { grid-template-columns: 1fr; } .side-meta { justify-content: flex-start; } }
 </style>
@@ -3912,6 +4025,10 @@ a:hover { color: #89c8ff; text-decoration: underline; }
       <h2>📡 Recent Activity</h2>
       <div id="events"></div>
     </aside>
+    <div class="cluster-col">
+      <h2>🔎 Cluster Intake</h2>
+      <div id="cluster-repair"></div>
+    </div>
   </section>
 </main>
 <script>
@@ -4024,6 +4141,7 @@ function renderDashboard(data, note) {
     metric("⚡ Merge Speed", data.averages.automerge_command_to_merge_ms ? elapsed(data.averages.automerge_command_to_merge_ms) : "n/a", data.averages.automerge_samples + " samples", 60, "var(--violet)"),
     metric("🎯 Capacity", fleet.budget_used_percent + "%", "fleet utilization", fleet.budget_used_percent, "var(--green)")
   ].join("");
+  renderClusterRepair(data.recent?.cluster_repair);
   renderPipeline(data.pipeline || []);
   renderAutomerge(data.recent.automerge || []);
   renderClosedStats(data.recent.closed_stats);
@@ -4039,6 +4157,23 @@ function renderPipeline(rows) {
     const detail = pipelineItemDetail(row);
     return '<article class="work-row"><div class="work-main" title="' + esc(compactText(row.title)) + '"><div class="row-top"><span class="pill" title="' + esc(row.mode) + '">' + esc(modeLabel(row.mode)) + '</span>' + pipelineItemLabel(row) + '</div>' + (detail ? '<div class="muted work-title">' + esc(detail) + '</div>' : "") + '</div><div class="work-state"><div class="stage-block"><strong>' + esc(row.stage) + '</strong><span class="muted">' + esc(row.status) + '</span></div>' + ciBadge(row.ci) + linkClass(row.run_url, "run", "pill run-link") + '</div><div class="timebox"><strong>' + elapsed(row.elapsed_ms) + '</strong><span>elapsed</span></div></article>';
   }).join("") + '</div>';
+}
+function renderClusterRepair(cluster) {
+  const target = document.getElementById("cluster-repair");
+  if (!target) return;
+  if (!cluster) {
+    target.innerHTML = '<div class="empty">No cluster intake telemetry in this snapshot.</div>';
+    return;
+  }
+  const markerRows = (cluster.markers || []).map(marker => {
+    const jobs = (marker.generated_jobs || []).slice(0, 3).map(job => '<span class="pill mono">' + esc(job.split("/").pop() || job) + '</span>').join("");
+    const jobText = marker.generated_count ? fmt.format(marker.generated_count) + " job" + (marker.generated_count === 1 ? "" : "s") : "no jobs";
+    return '<article class="work-row"><div class="work-main"><div class="row-top"><span class="pill">' + esc(marker.status || "unknown") + '</span><span class="item-link">' + esc(marker.target_repo || "unknown repo") + '</span></div><div class="muted work-title">store ' + esc(marker.last_processed_store_short_sha || "unknown") + " · " + esc(jobText) + (marker.last_processed_store_exported_at ? " · exported " + esc(since(marker.last_processed_store_exported_at)) : "") + '</div><div class="row-top">' + jobs + '</div></div><div class="work-state"><div class="stage-block"><strong>' + esc(marker.updated_at ? since(marker.updated_at) : "never") + '</strong><span class="muted">marker</span></div>' + linkClass(marker.run_url, "run", "pill run-link") + '</div><div class="timebox"><strong>60m</strong><span>tick</span></div></article>';
+  }).join("");
+  const runRows = (cluster.latest_runs || []).slice(0, 3).map(run => '<article class="side-row"><div class="side-main">' + linkClass(run.url, compactText(run.title || run.workflow), "item-link") + '<div class="muted side-title">' + esc(run.status || "") + (run.conclusion ? " · " + esc(run.conclusion) : "") + '</div></div><div class="side-meta"><span>' + esc(run.started_at ? since(run.started_at) : "") + '</span></div></article>').join("");
+  const activeText = fmt.format((cluster.active_intake_runs || []).length) + " intake · " + fmt.format((cluster.active_worker_runs || []).length) + " workers";
+  target.innerHTML =
+    '<div class="split"><div class="pipeline-col"><div class="muted" style="margin-bottom:8px">Runs on ' + esc(cluster.workflow || "repair-cluster-intake.yml") + " at " + esc(cluster.schedule || "8 * * * *") + " · " + esc(activeText) + '</div><div class="work-list">' + (markerRows || '<div class="empty">No processed-store markers yet.</div>') + '</div></div><aside class="side-col"><div class="muted" style="margin-bottom:8px">Recent intake workflow runs</div><div class="side-list">' + (runRows || '<div class="empty">No intake runs found.</div>') + '</div></aside></div>';
 }
 function renderAutomerge(rows) {
   if (!rows.length) {

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -4,9 +4,11 @@ Read when changing ClawSweeper throughput, Codex fan-out, commit review paging,
 or repair dispatch capacity.
 
 `config/automation-limits.json` is the source of truth for the global worker
-budget. It deliberately has only one main knob, `workers.max`, because that is
+budget. It deliberately has one main global knob, `workers.max`, because that is
 the number we normally tune when Codex or GitHub rate limits get tight. Most
-lane-specific limits are derived from that budget; safety thresholds such as
+lane-specific limits are derived from that budget; imported cluster repair has
+a separate explicit knob so it can stay at one live worker unless a maintainer
+intentionally opens it wider. Safety thresholds such as
 close age floors, apply delays, retry counts, and comment caps stay near the
 code that owns those decisions.
 
@@ -36,13 +38,16 @@ The mental model:
 | `workers.expansion_reserve` | 20 | Extra slots background lanes leave open for independently planned matrix expansion. |
 | `workers.minimum_background` | 10 | Target floor for background progress when enough global capacity is available. |
 | `lanes.assist.max` | 5 | Maximum concurrent lightweight assist jobs. |
+| `lanes.repair.cluster_max_live_runs` | 1 | Default live repair workflow cap for imported gitcrawl cluster dispatches. |
 
 ## Derived Limits
 
-Derived limits are intentionally percentages of `workers.max`. With
+Review, commit, and existing repair limits are intentionally percentages of
+`workers.max`; imported cluster repair has its own lane knob. With
 `workers.max = 57`, normal review can use 39 workers, hot intake can use 19,
-commit review can use 2 commits per page, and repair lanes can dispatch 22 live
-workers.
+commit review can use 2 commits per page, existing repair lanes dispatch 22
+live workers by default, and imported cluster repair dispatches one live worker
+by default.
 
 | Name | Current | Meaning |
 | --- | ---: | --- |
@@ -55,9 +60,10 @@ workers.
 | `commit_review.page_size_default` | 2 | Commits selected per commit-review page. |
 | `commit_review.page_size_hard_cap` | 57 | Maximum commit-review page size. |
 | `repair_live_runs.default` | 22 | Default live repair workflow run cap for manual dispatch/requeue/self-heal. |
-| `repair_live_runs.hard_cap` | 57 | Absolute live repair run cap accepted by the CLI. |
+| `repair_live_runs.hard_cap` | 57 | Absolute live repair run cap accepted by explicit CLI/env overrides with this config. |
 | `repair_live_runs.automerge_default` | 22 | Live repair run cap for automerge comment-router dispatches. |
 | `repair_live_runs.issue_implementation_default` | 22 | Live repair run cap for issue-to-PR implementation intake. |
+| `repair_live_runs.cluster_default` | 1 | Live repair run cap for imported gitcrawl cluster dispatches. |
 | `issue_implementation.dispatches_per_sweep_default` | 2 | Maximum implementation intake jobs queued from one review publish run. |
 
 Formula summary:
@@ -67,8 +73,11 @@ Formula summary:
 - hot intake: 35% of `workers.max`
 - commit review page size: 5% of `workers.max`
 - repair, automerge repair, and issue implementation: 40% of `workers.max`
+- imported cluster repair: `lanes.repair.cluster_max_live_runs`, clamped to
+  `workers.max`
 - issue implementation dispatches per sweep: 4% of `workers.max`
-- hard caps: `workers.max`
+- review/commit hard caps: `workers.max`
+- repair hard cap: `workers.max`
 
 ## Dynamic Scheduling
 
@@ -103,9 +112,9 @@ Examples with the current config:
 - Quiet system: manual normal review can request 39 shards; scheduled normal
   review gets 27 after reserving 10 slots for exact/manual/urgent work and 20
   slots for in-flight matrix expansion.
-- 21 active repair workers and 13 active background workers: normal review gets
-  1 because `57 - 10 interactive reserve - 20 expansion reserve - 21 priority
-  - 13 background = -7`, and enabled lanes keep a minimum of one worker.
+- 1 active repair worker and 13 active background workers: normal review gets
+  13 because `57 - 10 interactive reserve - 20 expansion reserve - 1 priority
+  - 13 background = 13`.
 - 49 active priority workers: commit review gets 1, so commit review yields but
   does not fully stall.
 
@@ -118,14 +127,27 @@ pnpm run --silent workflow -- worker-limit normal_review
 pnpm run --silent workflow -- worker-limit commit_review --active-critical 64
 ```
 
-Change `workers.max` first when tuning rate-limit pressure. For example, setting
-`workers.max` to `90` automatically makes normal review `63`, hot intake `31`,
-commit review `4`, repair `36`, and hard caps `90`.
+Change `workers.max` first when tuning review-side rate-limit pressure. For
+example, setting `workers.max` to `90` automatically makes normal review `63`,
+hot intake `31`, and commit review `4`. Existing repair lanes keep their
+40% derived caps, while imported cluster repair remains at one live worker until
+`lanes.repair.cluster_max_live_runs` is raised.
 
 ## Runtime Overrides
 
 - `CLAWSWEEPER_COMMIT_REVIEW_PAGE_SIZE` overrides
   `commit_review.page_size_default`.
+- `CLAWSWEEPER_FEATURE_CLUSTER_REPAIR_ENABLED=1` enables the scheduled
+  `repair-cluster-intake.yml` imported-cluster intake. Direct repair import and
+  dispatch commands are not blocked by this variable; they keep the existing
+  repair execution gates. Gitcrawl cluster import also drip-feeds by default:
+  clusters with at least 75% closed members are skipped unless
+  `--skip-closed-percent` is overridden.
+- `CLAWSWEEPER_CLUSTER_REPAIR_IMPORT_LIMIT` overrides the scheduled
+  `repair-cluster-intake.yml` import limit. The default is `1` cluster every
+  hour; the upstream gitcrawl-store refreshes every 15 minutes, and ClawSweeper
+  records the processed store SHA so repeated ticks against the same snapshot
+  skip.
 - `CLAWSWEEPER_MAX_LIVE_WORKERS` overrides the `job_intent`-derived repair
   dispatch cap.
 - `CLAWSWEEPER_AUTOMERGE_MAX_LIVE_WORKERS` overrides

--- a/docs/related-issue-discovery.md
+++ b/docs/related-issue-discovery.md
@@ -44,11 +44,15 @@ adjacent reports, or irrelevant matches.
 
 When a local gitcrawl database exists, ClawSweeper reads same-cluster issue
 siblings from the same target repository as the reviewed issue and adds them to
-the same related-item prompt section.
+the same related-item prompt section. ClawSweeper does not run a gitcrawl fetch
+or download issues during review; it only reads an existing SQLite database.
 
-The default database path is:
+Database lookup order is:
 
 ```text
+CLAWSWEEPER_GITCRAWL_DB
+../gitcrawl-store/data/<owner>__<repo>.sync.db
+~/.config/gitcrawl/stores/gitcrawl-store/data/<owner>__<repo>.sync.db
 ~/.config/gitcrawl/gitcrawl.db
 ```
 
@@ -56,8 +60,10 @@ Use `CLAWSWEEPER_GITCRAWL_DB=/path/to/gitcrawl.db` to point at a different
 database. If the database or `sqlite3` is unavailable, this source is skipped
 silently and the review continues with the other context sources.
 
-Both current portable gitcrawl tables and the older legacy cluster tables are
-supported on a best-effort basis.
+For portable gitcrawl-store checkouts, freshness is maintained by the store
+workflow and by refreshing the local checkout, for example with
+`git pull --ff-only` before a run. Both current portable gitcrawl tables and the
+older legacy cluster tables are supported on a best-effort basis.
 
 ## Guardrails
 

--- a/docs/repair/README.md
+++ b/docs/repair/README.md
@@ -37,6 +37,15 @@ vulnerabilities unless there is a real trust-boundary bypass.
 The repair lane is intentionally narrower than the sweep lanes. The sweepers scan OpenClaw commits and backlog items on a cadence; repair handles targeted clusters that were already grouped by a human, gitcrawl, or another dedupe tool.
 
 Cluster discovery currently comes from [openclaw/gitcrawl](https://github.com/openclaw/gitcrawl).
+ClawSweeper reads existing gitcrawl SQLite state; it does not crawl or download
+issues during repair import. By default, import scripts prefer a checked-out
+portable store at `../gitcrawl-store/data/<owner>__<repo>.sync.db`, then
+`~/.config/gitcrawl/stores/gitcrawl-store/data/<owner>__<repo>.sync.db`, then
+the legacy `~/.config/gitcrawl/gitcrawl.db`. Use `--db` or
+`CLAWSWEEPER_GITCRAWL_DB` to override. Store freshness is maintained outside
+ClawSweeper by the gitcrawl-store refresh workflow and by refreshing the local
+checkout, for example `git -C ../gitcrawl-store pull --ff-only`, before
+importing jobs.
 
 <img width="3582" height="2160" alt="image" src="https://github.com/user-attachments/assets/20b816cc-72ab-479e-bc18-84f5b2b53745" />
 
@@ -230,19 +239,36 @@ pnpm run repair:worker -- jobs/openclaw/inbox/cluster-example.md --mode plan --d
 pnpm run repair:build-fix-artifact -- jobs/openclaw/inbox/autonomous-example.md --offline
 
 # Stage low-signal PR sweep jobs from local gitcrawl data.
+# Uses --db/CLAWSWEEPER_GITCRAWL_DB, a local gitcrawl-store checkout, or the
+# legacy ~/.config/gitcrawl/gitcrawl.db; it never fetches GitHub issues itself.
 pnpm run repair:import-gitcrawl-low-signal -- --limit 20 --batch-size 5 --mode autonomous --sort stale
 
-# Stage the next largest active gitcrawl clusters, skipping already-imported and
-# fully security-sensitive clusters by default. Mixed clusters can route security
-# refs while continuing ordinary bug/dedupe work.
+# Stage the next largest active gitcrawl clusters, skipping already-imported,
+# security-sensitive, feature-request, and 75%+ closed clusters by default.
+# Mixed clusters can route security refs while continuing ordinary bug/dedupe work.
 pnpm run repair:import-gitcrawl -- --from-gitcrawl --limit 40 --mode autonomous --suffix autonomous-smoke --allow-instant-close --allow-merge --allow-fix-pr --allow-post-merge-close
 
+# Automatic imported-cluster intake runs through repair-cluster-intake.yml.
+# gitcrawl-store refreshes openclaw/openclaw every 15 minutes; the ClawSweeper
+# intake runs hourly, records the processed portable DB SHA in
+# results/cluster-repair-intake/<repo>.json, and skips repeated ticks for the
+# same store snapshot. It imports at most one cluster by default and dispatches
+# through the one-worker cluster_repair lane.
+
 # Dispatch reviewed jobs. Dispatch derives its default live-worker cap from the
-# job's job_intent and config/automation-limits.json. Tune the global budget
-# there first, or use CLAWSWEEPER_MAX_LIVE_WORKERS/--max-live-workers for a
-# one-lane override. With --wait-for-capacity, dispatch can drain a larger file
+# job's job_intent and config/automation-limits.json. Existing repair lanes
+# keep the normal 40%-of-workers.max cap, currently 22; imported gitcrawl
+# cluster jobs default to lanes.repair.cluster_max_live_runs, currently 1.
+# Use CLAWSWEEPER_MAX_LIVE_WORKERS/--max-live-workers for a one-lane override.
+# With --wait-for-capacity, dispatch can drain a larger file
 # list in capacity-sized waves instead of refusing the whole batch.
-CLAWSWEEPER_MAX_LIVE_WORKERS=22 pnpm run repair:dispatch -- jobs/openclaw/inbox/cluster-example.md \
+CLAWSWEEPER_MAX_LIVE_WORKERS=22 pnpm run repair:dispatch -- jobs/openclaw/inbox/ordinary-example.md \
+  --mode autonomous \
+  --runner blacksmith-4vcpu-ubuntu-2404 \
+  --execution-runner blacksmith-16vcpu-ubuntu-2404
+
+# Imported gitcrawl cluster jobs drip-feed by default.
+CLAWSWEEPER_MAX_LIVE_WORKERS=1 pnpm run repair:dispatch -- jobs/openclaw/inbox/cluster-example.md \
   --mode autonomous \
   --runner blacksmith-4vcpu-ubuntu-2404 \
   --execution-runner blacksmith-16vcpu-ubuntu-2404
@@ -326,13 +352,21 @@ The workflow needs:
 - a read-only GitHub token for worker inspection
 - a separate write-scoped GitHub token for the deterministic applicator
 - execution gates that default closed: set `CLAWSWEEPER_ALLOW_EXECUTE=1` and `CLAWSWEEPER_ALLOW_FIX_PR=1` only for an intentional execution window; otherwise execute/autonomous dispatches render plan-only output and skip mutation steps
+- `CLAWSWEEPER_FEATURE_CLUSTER_REPAIR_ENABLED=1` opt-in for the scheduled
+  `repair-cluster-intake.yml` imported-cluster intake. Direct repair import and
+  dispatch commands are not blocked by this variable; they keep the existing
+  repair execution gates. Gitcrawl cluster import skips clusters with at least
+  75% closed members by default; pass `--skip-closed-percent` only for an
+  intentional broader import.
+- optional `CLAWSWEEPER_CLUSTER_REPAIR_IMPORT_LIMIT` variable for the scheduled
+  imported-cluster intake; default is `1` cluster per hourly run.
 - merge is separately gated by `CLAWSWEEPER_ALLOW_MERGE`, which defaults to `0`; merge-ready PRs are labeled `clawsweeper:human-review` and `clawsweeper:merge-ready` for a maintainer to merge manually when the global gate is closed
 - optional `CLAWSWEEPER_CODEX_CLI_VERSION` variable to pin and refresh the cached Codex CLI
 - optional `CLAWSWEEPER_MODEL` override for dispatch scripts; default Codex
   model is `gpt-5.5`; repair workers default to high reasoning on the fast
   service tier, and accidental `xhigh` reasoning overrides are normalized back
   to `high`
-- optional `CLAWSWEEPER_MAX_LIVE_WORKERS` variable for dispatch/requeue/self-heal worker fan-out; dispatch defaults are derived from `job_intent` and `workers.max`
+- optional `CLAWSWEEPER_MAX_LIVE_WORKERS` variable for dispatch/requeue/self-heal worker fan-out; dispatch defaults are derived from `job_intent`, cluster-lane classification, `workers.max`, and `lanes.repair.cluster_max_live_runs`
 - optional `CLAWSWEEPER_MAX_ACTIVE_PRS_PER_AREA` variable for replacement PR backpressure; default is `50` open ClawSweeper PRs per touched area, `0` disables the area cap, and common changelog/release-note files are ignored for this check
 - ClawSweeper commit-finding repair PRs are labeled `clawsweeper:commit-finding`
 - optional `CLAWSWEEPER_CODEX_TIMEOUT_MS`, `CLAWSWEEPER_FIX_CODEX_TIMEOUT_MS`,

--- a/docs/repair/internal-features.md
+++ b/docs/repair/internal-features.md
@@ -39,6 +39,7 @@ Common creation paths:
 - `pnpm run repair:create-job -- --repo openclaw/openclaw --refs 123 --prompt-file /tmp/prompt.md`
 - `pnpm run repair:create-job -- --from-report ../clawsweeper/records/.../items/123.md`
 - gitcrawl import scripts for larger clustered backlog batches
+- `repair-cluster-intake.yml` for scheduled imported gitcrawl cluster drip-feed
 
 `create-job` checks for an existing matching PR or branch before writing a new
 job. That is the primary duplicate-PR guard.
@@ -582,6 +583,18 @@ PR directly.
 
 Important gates:
 
+- `CLAWSWEEPER_FEATURE_CLUSTER_REPAIR_ENABLED`: opt-in for the scheduled
+  `repair-cluster-intake.yml` imported-cluster intake. Direct repair import and
+  dispatch commands are not blocked by this variable; they keep the existing
+  repair execution gates. Gitcrawl cluster import skips clusters with at least
+  75% closed members by default; `--skip-closed-percent` is the explicit
+  override.
+- `CLAWSWEEPER_CLUSTER_REPAIR_IMPORT_LIMIT`: scheduled imported-cluster intake
+  limit; default `1` cluster per hourly `repair-cluster-intake.yml` run.
+  The upstream `openclaw/gitcrawl-store` refreshes `openclaw/openclaw` every 15
+  minutes, so the intake records the processed portable DB SHA in
+  `results/cluster-repair-intake/<repo>.json` and skips duplicate ticks against
+  the same store snapshot.
 - `CLAWSWEEPER_ALLOW_EXECUTE`: allows deterministic write lanes. Workflows treat
   any value except literal `1` as closed.
 - `CLAWSWEEPER_ALLOW_FIX_PR`: allows branch repair and replacement PR creation.
@@ -601,7 +614,9 @@ Important defaults:
   to `fast`.
 - `CLAWSWEEPER_CODEX_HEARTBEAT_MS`: repair-worker and execute-side Codex
   subprocess heartbeat interval; default `60000`.
-- `CLAWSWEEPER_MAX_LIVE_WORKERS`: dispatch capacity guard.
+- `CLAWSWEEPER_MAX_LIVE_WORKERS`: dispatch capacity guard. Existing repair
+  lanes derive their checked-in default from `workers.max`; imported gitcrawl
+  cluster jobs use `lanes.repair.cluster_max_live_runs`.
 - `CLAWSWEEPER_DISPATCH_RECHECK_MS`: short active-worker recheck before
   dispatching a repair worker; default `5000` to avoid duplicate queued workers
   when parallel routers race GitHub run visibility.

--- a/scripts/check-limits.ts
+++ b/scripts/check-limits.ts
@@ -9,6 +9,11 @@ type WorkerConfig = {
     expansion_reserve: number;
     minimum_background: number;
   };
+  lanes: {
+    repair: {
+      cluster_max_live_runs: number;
+    };
+  };
 };
 
 type AutomationLimits = {
@@ -28,6 +33,7 @@ type AutomationLimits = {
     hard_cap: number;
     automerge_default: number;
     issue_implementation_default: number;
+    cluster_default: number;
   };
   issue_implementation: {
     dispatches_per_sweep_default: number;
@@ -67,8 +73,15 @@ const expectations: { file: string; label: string; pattern: RegExp }[] = [
   },
   {
     file: "docs/repair/README.md",
-    label: "repair live run default",
+    label: "normal repair live run default",
     pattern: new RegExp(`CLAWSWEEPER_MAX_LIVE_WORKERS=${limits.repair_live_runs.default}\\b`),
+  },
+  {
+    file: "docs/repair/README.md",
+    label: "imported cluster repair live run example",
+    pattern: new RegExp(
+      `CLAWSWEEPER_MAX_LIVE_WORKERS=${limits.repair_live_runs.cluster_default}\\b`,
+    ),
   },
   {
     file: "docs/scheduler.md",
@@ -139,6 +152,7 @@ function flattenLimits(value: unknown, prefix = ""): Record<string, number> {
 
 function deriveAutomationLimits(workerConfig: WorkerConfig): AutomationLimits {
   const max = workerConfig.workers.max;
+  const clusterRepairMax = Math.min(workerConfig.lanes.repair.cluster_max_live_runs, max);
   return {
     review_shards: {
       normal_default: percent(max, 70),
@@ -156,6 +170,7 @@ function deriveAutomationLimits(workerConfig: WorkerConfig): AutomationLimits {
       hard_cap: max,
       automerge_default: percent(max, 40),
       issue_implementation_default: percent(max, 40),
+      cluster_default: clusterRepairMax,
     },
     issue_implementation: {
       dispatches_per_sweep_default: percent(max, 4),

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -3457,14 +3457,26 @@ function sqliteJsonBestEffort(dbPath: string, sql: string): unknown[] {
   }
 }
 
-function gitcrawlDbPath(): string | null {
+function gitcrawlStoreDbFileName(repo: string): string {
+  return `${repo
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_.-]+/g, "__")}.sync.db`;
+}
+
+function gitcrawlDbPath(repo = targetRepo()): string | null {
   const configured = process.env.CLAWSWEEPER_GITCRAWL_DB?.trim();
   if (configured) {
     const configuredPath = resolve(ROOT, configured);
     return existsSync(configuredPath) ? configuredPath : null;
   }
-  const fallback = join(homedir(), ".config", "gitcrawl", "gitcrawl.db");
-  return existsSync(fallback) ? fallback : null;
+  const storeDbFileName = gitcrawlStoreDbFileName(repo);
+  const candidates = [
+    join(ROOT, "..", "gitcrawl-store", "data", storeDbFileName),
+    join(homedir(), ".config", "gitcrawl", "stores", "gitcrawl-store", "data", storeDbFileName),
+    join(homedir(), ".config", "gitcrawl", "gitcrawl.db"),
+  ];
+  return candidates.find((candidate) => existsSync(candidate)) ?? null;
 }
 
 function gitcrawlTableRows(dbPath: string, table: "clusters" | "cluster_groups"): number {
@@ -3581,14 +3593,15 @@ function gitcrawlRelatedIssueSql(
 
 function compactRelatedGitcrawlItems(item: Item, seen: ReadonlySet<number>): unknown[] {
   if (item.kind !== "issue") return [];
-  const dbPath = gitcrawlDbPath();
+  const repo = targetRepo();
+  const dbPath = gitcrawlDbPath(repo);
   if (!dbPath) return [];
   const source = detectGitcrawlClusterSource(dbPath);
   if (!source) return [];
 
   return sqliteJsonBestEffort(
     dbPath,
-    gitcrawlRelatedIssueSql(source, item.number, RELATED_GITCRAWL_LIMIT, targetRepo()),
+    gitcrawlRelatedIssueSql(source, item.number, RELATED_GITCRAWL_LIMIT, repo),
   )
     .map(asRecord)
     .filter((row) => typeof row.number === "number" && !seen.has(row.number))

--- a/src/limits.ts
+++ b/src/limits.ts
@@ -9,6 +9,11 @@ export type WorkerConfig = {
     expansion_reserve: number;
     minimum_background: number;
   };
+  lanes: {
+    repair: {
+      cluster_max_live_runs: number;
+    };
+  };
 };
 
 export type AutomationLimits = {
@@ -28,6 +33,7 @@ export type AutomationLimits = {
     hard_cap: number;
     automerge_default: number;
     issue_implementation_default: number;
+    cluster_default: number;
   };
   issue_implementation: {
     dispatches_per_sweep_default: number;
@@ -41,6 +47,7 @@ export type WorkerLane =
   | "repair"
   | "automerge_repair"
   | "issue_implementation"
+  | "cluster_repair"
   | "exact_item";
 
 export const WORKER_CONFIG = readWorkerConfig();
@@ -55,6 +62,7 @@ export function readWorkerConfig(
 
 export function deriveAutomationLimits(config: WorkerConfig): AutomationLimits {
   const max = config.workers.max;
+  const clusterRepairMax = Math.min(config.lanes.repair.cluster_max_live_runs, max);
   return {
     review_shards: {
       normal_default: percent(max, 70),
@@ -72,6 +80,7 @@ export function deriveAutomationLimits(config: WorkerConfig): AutomationLimits {
       hard_cap: max,
       automerge_default: percent(max, 40),
       issue_implementation_default: percent(max, 40),
+      cluster_default: clusterRepairMax,
     },
     issue_implementation: {
       dispatches_per_sweep_default: percent(max, 4),
@@ -99,6 +108,8 @@ export function workerLimit(
     return priorityLimit(limits.repair_live_runs.automerge_default, activeCritical);
   if (lane === "issue_implementation")
     return priorityLimit(limits.repair_live_runs.issue_implementation_default, activeCritical);
+  if (lane === "cluster_repair")
+    return priorityLimit(limits.repair_live_runs.cluster_default, activeCritical);
   if (lane === "commit_review")
     return backgroundLimit(
       limits.commit_review.page_size_default,
@@ -141,6 +152,15 @@ function validateWorkerConfig(value: unknown): WorkerConfig {
       expansion_reserve: nonNegativeInteger(value, "workers.expansion_reserve"),
       minimum_background: positiveInteger(value, "workers.minimum_background"),
     },
+    lanes: {
+      repair: {
+        cluster_max_live_runs: optionalPositiveInteger(
+          value,
+          "lanes.repair.cluster_max_live_runs",
+          1,
+        ),
+      },
+    },
   };
 }
 
@@ -150,6 +170,19 @@ function percent(max: number, value: number): number {
 
 function positiveInteger(root: Record<string, unknown>, path: string): number {
   const value = getPath(root, path);
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1) {
+    throw new Error(`automation limit ${path} must be a positive integer`);
+  }
+  return value;
+}
+
+function optionalPositiveInteger(
+  root: Record<string, unknown>,
+  path: string,
+  fallback: number,
+): number {
+  const value = getOptionalPath(root, path);
+  if (value === undefined) return fallback;
   if (typeof value !== "number" || !Number.isInteger(value) || value < 1) {
     throw new Error(`automation limit ${path} must be a positive integer`);
   }
@@ -169,10 +202,16 @@ function nonNegative(value: number): number {
 }
 
 function getPath(root: Record<string, unknown>, path: string): unknown {
+  const value = getOptionalPath(root, path);
+  if (value === undefined) throw new Error(`automation limit ${path} is missing`);
+  return value;
+}
+
+function getOptionalPath(root: Record<string, unknown>, path: string): unknown {
   let cursor: unknown = root;
   for (const segment of path.split(".")) {
     if (!isRecord(cursor) || !(segment in cursor)) {
-      throw new Error(`automation limit ${path} is missing`);
+      return undefined;
     }
     cursor = cursor[segment];
   }

--- a/src/repair/dispatch-jobs.ts
+++ b/src/repair/dispatch-jobs.ts
@@ -17,13 +17,17 @@ import {
 import { sleepMs } from "./timing.js";
 import { REPAIR_CLUSTER_WORKFLOW } from "./constants.js";
 import { AUTOMATION_LIMITS, workerLimit, type WorkerLane } from "./limits.js";
-import { repairJobIntentForFrontmatter, workerLaneForRepairJobIntent } from "./job-intent.js";
+import {
+  repairJobIntentForFrontmatter,
+  repairJobUsesClusterLane,
+  workerLaneForRepairJobIntent,
+} from "./job-intent.js";
 
 const args = parseArgs(process.argv.slice(2));
 const defaultRunner = process.env.CLAWSWEEPER_WORKER_RUNNER ?? "blacksmith-4vcpu-ubuntu-2404";
 const defaultExecutionRunner =
   process.env.CLAWSWEEPER_EXECUTION_RUNNER ?? "blacksmith-16vcpu-ubuntu-2404";
-const mode = args.mode ?? "plan";
+const mode = String(args.mode ?? "plan");
 const runner = args.runner ?? defaultRunner;
 const executionRunner = args["execution-runner"] ?? args.execution_runner ?? defaultExecutionRunner;
 const workflow = args.workflow ?? REPAIR_CLUSTER_WORKFLOW;
@@ -171,7 +175,15 @@ function dispatchMaxLiveWorkers(jobPaths: JsonValue[]): number {
 }
 
 function strongestWorkerLane(jobPaths: JsonValue[]): WorkerLane {
-  const lanes = new Set(jobPaths.map((jobPath) => jobWorkerLanes.get(String(jobPath))));
+  const lanes = new Set(
+    jobPaths.map((jobPath) => {
+      const job = parseJob(String(jobPath));
+      return repairJobUsesClusterLane(job.frontmatter)
+        ? "cluster_repair"
+        : jobWorkerLanes.get(String(jobPath));
+    }),
+  );
+  if (lanes.has("cluster_repair")) return "cluster_repair";
   if (lanes.has("automerge_repair")) return "automerge_repair";
   if (lanes.has("issue_implementation")) return "issue_implementation";
   return "repair";

--- a/src/repair/execute-fix-artifact.ts
+++ b/src/repair/execute-fix-artifact.ts
@@ -1882,7 +1882,11 @@ function editValidatePrepareMerge({
     }
   }
   if (!producedChanges && !reconcileWithBase) {
-    const mechanicalFix = applyMechanicalChangelogFix({ fixArtifact, repo: result.repo, targetDir });
+    const mechanicalFix = applyMechanicalChangelogFix({
+      fixArtifact,
+      repo: result.repo,
+      targetDir,
+    });
     producedChanges = mechanicalFix?.status === "applied";
     if (producedChanges) logProgress("applied mechanical changelog fix");
   }

--- a/src/repair/import-gitcrawl-clusters.ts
+++ b/src/repair/import-gitcrawl-clusters.ts
@@ -9,15 +9,17 @@ import { renderJobIntentFrontmatter } from "./job-intent.js";
 
 const args = parseArgs(process.argv.slice(2));
 const repo = String(args.repo ?? "openclaw/openclaw");
-const dbPath = path.resolve(
-  String(args.db ?? path.join(os.homedir(), ".config", "gitcrawl", "gitcrawl.db")),
-);
+const mode = String(args.mode ?? "plan");
+if (!["plan", "execute", "autonomous"].includes(mode)) {
+  console.error("mode must be plan, execute, or autonomous");
+  process.exit(2);
+}
 const outDir = path.resolve(
   String(args.out ?? path.join(repoRoot(), "jobs", repo.split("/")[0] ?? "unknown", "inbox")),
 );
-const mode = String(args.mode ?? "plan");
+const dbPath = resolveGitcrawlDbPath(repo, typeof args.db === "string" ? args.db : undefined);
 const suffix = typeof args.suffix === "string" ? args.suffix : "";
-const allowInstantClose = Boolean(args["allow-instant-close"]);
+const allowInstantClose = booleanArg("allow-instant-close", false);
 const editEnabledByDefault = mode === "autonomous" || mode === "execute";
 const allowMerge = booleanArg("allow-merge", editEnabledByDefault);
 const allowFixPr = booleanArg("allow-fix-pr", editEnabledByDefault);
@@ -26,10 +28,12 @@ const skipExisting = args["skip-existing"] !== "false";
 const skipSecurity = args["include-security"] !== true && args["skip-security"] !== "false";
 const skipFeatureRequests =
   args["include-feature-requests"] !== true && args["skip-feature-requests"] !== "false";
+const allowEmpty = Boolean(args["allow-empty"]);
 const fromGitcrawl = Boolean(args["from-gitcrawl"] || args["from-ghcrawl"] || args.all);
 const limit = numberArg("limit", 40);
 const minSize = numberArg("min-size", 2);
 const minOpenMembers = numberArg("min-open-members", 1);
+const skipClosedPercent = percentArg("skip-closed-percent", 75);
 let clusterIds = args._.map((value: string) => Number(value)).filter(Boolean);
 const selectingFromGitcrawl = clusterIds.length === 0 && fromGitcrawl;
 const clusterSource = detectClusterSource();
@@ -39,14 +43,40 @@ if (selectingFromGitcrawl) {
 }
 
 if (clusterIds.length === 0) {
+  if (selectingFromGitcrawl && allowEmpty) {
+    console.error("no eligible gitcrawl clusters found");
+    process.exit(0);
+  }
   console.error(
-    "usage: node scripts/import-gitcrawl-clusters.ts <cluster-id> [...] [--from-gitcrawl] [--limit N] [--min-size N] [--min-open-members N] [--repo owner/repo] [--db path] [--out dir] [--mode plan|autonomous] [--suffix name] [--allow-instant-close] [--allow-merge true|false] [--allow-fix-pr true|false] [--allow-post-merge-close true|false]",
+    "usage: node scripts/import-gitcrawl-clusters.ts <cluster-id> [...] [--from-gitcrawl] [--allow-empty] [--limit N] [--min-size N] [--min-open-members N] [--skip-closed-percent N] [--repo owner/repo] [--db path] [--out dir] [--mode plan|autonomous] [--suffix name] [--allow-instant-close] [--allow-merge true|false] [--allow-fix-pr true|false] [--allow-post-merge-close true|false]",
   );
   process.exit(2);
 }
-if (!["plan", "execute", "autonomous"].includes(mode)) {
-  console.error("mode must be plan, execute, or autonomous");
-  process.exit(2);
+function gitcrawlStoreDbFileName(repoFullName: string): string {
+  return `${repoFullName
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_.-]+/g, "__")}.sync.db`;
+}
+
+function resolveGitcrawlDbPath(repoFullName: string, explicitDb?: string): string {
+  const configured = explicitDb?.trim() || process.env.CLAWSWEEPER_GITCRAWL_DB?.trim();
+  if (configured) return path.resolve(configured);
+  const storeDbFileName = gitcrawlStoreDbFileName(repoFullName);
+  const candidates = [
+    path.join(repoRoot(), "..", "gitcrawl-store", "data", storeDbFileName),
+    path.join(
+      os.homedir(),
+      ".config",
+      "gitcrawl",
+      "stores",
+      "gitcrawl-store",
+      "data",
+      storeDbFileName,
+    ),
+    path.join(os.homedir(), ".config", "gitcrawl", "gitcrawl.db"),
+  ];
+  return candidates.find((candidate) => fs.existsSync(candidate)) ?? candidates.at(-1)!;
 }
 
 fs.mkdirSync(outDir, { recursive: true });
@@ -114,8 +144,16 @@ for (const clusterId of clusterIds) {
     title: first.representative_title,
   };
   const openMembers = members.filter((member: JsonValue) => member.state === "open");
+  const closedMembers = members.filter((member: JsonValue) => member.state !== "open");
   if (openMembers.length === 0) {
     console.error(`skip closed-only cluster: ${clusterId} ${representative.title ?? ""}`);
+    continue;
+  }
+  const closedPercent = Math.floor((closedMembers.length * 100) / members.length);
+  if (closedPercent >= skipClosedPercent) {
+    console.error(
+      `skip mostly-closed cluster: ${clusterId} ${representative.title ?? ""} (${closedPercent}% closed >= ${skipClosedPercent}%)`,
+    );
     continue;
   }
   if (openMembers.length < minOpenMembers) {
@@ -124,7 +162,6 @@ for (const clusterId of clusterIds) {
     );
     continue;
   }
-  const closedMembers = members.filter((member: JsonValue) => member.state !== "open");
   const issueCount = members.filter((member: JsonValue) => member.kind === "issue").length;
   const pullRequestCount = members.filter(
     (member: JsonValue) => member.kind === "pull_request",
@@ -237,12 +274,17 @@ function selectClusterIds() {
     return sqliteJson(`
       select
         cg.id,
-        count(*) as member_count
+        count(*) as member_count,
+        sum(case when t.state = 'open' then 1 else 0 end) as open_count,
+        sum(case when t.state != 'open' then 1 else 0 end) as closed_count
       from cluster_groups cg
       join cluster_memberships cm on cm.cluster_id = cg.id and cm.state = 'active'
+      join threads t on t.id = cm.thread_id
       where cg.status = 'active'
       group by cg.id
       having member_count >= ${sqlNumber(minSize)}
+        and open_count >= ${sqlNumber(minOpenMembers)}
+        and ((closed_count * 100) / member_count) < ${sqlNumber(skipClosedPercent)}
       order by member_count desc, cg.id asc
     `)
       .map((row: JsonValue) => Number(row.id))
@@ -251,11 +293,18 @@ function selectClusterIds() {
   return sqliteJson(`
     select
       c.id,
-      c.member_count
+      count(*) as member_count,
+      sum(case when t.state = 'open' then 1 else 0 end) as open_count,
+      sum(case when t.state != 'open' then 1 else 0 end) as closed_count
     from clusters c
+    join cluster_members cm on cm.cluster_id = c.id
+    join threads t on t.id = cm.thread_id
     where c.closed_at_local is null
-      and c.member_count >= ${sqlNumber(minSize)}
-    order by c.member_count desc, c.id asc
+    group by c.id
+    having member_count >= ${sqlNumber(minSize)}
+      and open_count >= ${sqlNumber(minOpenMembers)}
+      and ((closed_count * 100) / member_count) < ${sqlNumber(skipClosedPercent)}
+    order by member_count desc, c.id asc
   `)
     .map((row: JsonValue) => Number(row.id))
     .filter(Boolean);
@@ -382,6 +431,14 @@ function numberArg(name: string, fallback: JsonValue) {
   const value = Number(args[name] ?? fallback);
   if (!Number.isInteger(value) || value < 1)
     throw new Error(`--${name} must be a positive integer`);
+  return value;
+}
+
+function percentArg(name: string, fallback: JsonValue) {
+  const value = Number(args[name] ?? fallback);
+  if (!Number.isInteger(value) || value < 1 || value > 100) {
+    throw new Error(`--${name} must be an integer from 1 to 100`);
+  }
   return value;
 }
 

--- a/src/repair/import-gitcrawl-low-signal-prs.ts
+++ b/src/repair/import-gitcrawl-low-signal-prs.ts
@@ -9,9 +9,7 @@ import { renderJobIntentFrontmatter } from "./job-intent.js";
 
 const args = parseArgs(process.argv.slice(2));
 const repo = String(args.repo ?? "openclaw/openclaw");
-const dbPath = path.resolve(
-  String(args.db ?? path.join(os.homedir(), ".config", "gitcrawl", "gitcrawl.db")),
-);
+const dbPath = resolveGitcrawlDbPath(repo, typeof args.db === "string" ? args.db : undefined);
 const outDir = path.resolve(
   String(args.out ?? path.join(repoRoot(), "jobs", repo.split("/")[0] ?? "unknown", "inbox")),
 );
@@ -32,6 +30,32 @@ if (!["plan", "execute", "autonomous"].includes(mode)) {
 if (!["stale", "recent", "score"].includes(sort)) {
   console.error("sort must be stale, recent, or score");
   process.exit(2);
+}
+function gitcrawlStoreDbFileName(repoFullName: string): string {
+  return `${repoFullName
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_.-]+/g, "__")}.sync.db`;
+}
+
+function resolveGitcrawlDbPath(repoFullName: string, explicitDb?: string): string {
+  const configured = explicitDb?.trim() || process.env.CLAWSWEEPER_GITCRAWL_DB?.trim();
+  if (configured) return path.resolve(configured);
+  const storeDbFileName = gitcrawlStoreDbFileName(repoFullName);
+  const candidates = [
+    path.join(repoRoot(), "..", "gitcrawl-store", "data", storeDbFileName),
+    path.join(
+      os.homedir(),
+      ".config",
+      "gitcrawl",
+      "stores",
+      "gitcrawl-store",
+      "data",
+      storeDbFileName,
+    ),
+    path.join(os.homedir(), ".config", "gitcrawl", "gitcrawl.db"),
+  ];
+  return candidates.find((candidate) => fs.existsSync(candidate)) ?? candidates.at(-1)!;
 }
 
 const candidates = selectCandidates();

--- a/src/repair/job-intent.ts
+++ b/src/repair/job-intent.ts
@@ -51,6 +51,16 @@ export function workerLaneForRepairJobIntent(intent: RepairJobIntent): WorkerLan
   return "repair";
 }
 
+export function repairJobUsesClusterLane(frontmatter: LooseRecord): boolean {
+  const intent = repairJobIntentForFrontmatter(frontmatter);
+  if (intent !== "repair_cluster") return false;
+
+  const clusterId = String(frontmatter.cluster_id ?? "")
+    .trim()
+    .toLowerCase();
+  return /^gitcrawl-\d+\b/.test(clusterId) || /^ghcrawl-\d+\b/.test(clusterId);
+}
+
 export function renderJobIntentFrontmatter(intent: RepairJobIntent): string {
   return `job_intent: ${intent}`;
 }

--- a/src/repair/limits.ts
+++ b/src/repair/limits.ts
@@ -13,6 +13,9 @@ export type WorkerConfig = {
     assist: {
       max: number;
     };
+    repair: {
+      cluster_max_live_runs: number;
+    };
   };
 };
 
@@ -36,6 +39,7 @@ export type AutomationLimits = {
     hard_cap: number;
     automerge_default: number;
     issue_implementation_default: number;
+    cluster_default: number;
   };
   issue_implementation: {
     dispatches_per_sweep_default: number;
@@ -49,6 +53,7 @@ export type WorkerLane =
   | "repair"
   | "automerge_repair"
   | "issue_implementation"
+  | "cluster_repair"
   | "exact_item"
   | "assist";
 
@@ -64,6 +69,7 @@ export function readWorkerConfig(
 
 export function deriveAutomationLimits(config: WorkerConfig): AutomationLimits {
   const max = config.workers.max;
+  const clusterRepairMax = Math.min(config.lanes.repair.cluster_max_live_runs, max);
   return {
     assist: {
       default: Math.min(config.lanes.assist.max, max),
@@ -84,6 +90,7 @@ export function deriveAutomationLimits(config: WorkerConfig): AutomationLimits {
       hard_cap: max,
       automerge_default: percent(max, 40),
       issue_implementation_default: percent(max, 40),
+      cluster_default: clusterRepairMax,
     },
     issue_implementation: {
       dispatches_per_sweep_default: percent(max, 4),
@@ -112,6 +119,8 @@ export function workerLimit(
     return priorityLimit(limits.repair_live_runs.automerge_default, activeCritical);
   if (lane === "issue_implementation")
     return priorityLimit(limits.repair_live_runs.issue_implementation_default, activeCritical);
+  if (lane === "cluster_repair")
+    return priorityLimit(limits.repair_live_runs.cluster_default, activeCritical);
   if (lane === "commit_review")
     return backgroundLimit(
       limits.commit_review.page_size_default,
@@ -158,6 +167,13 @@ function validateWorkerConfig(value: unknown): WorkerConfig {
       assist: {
         max: positiveInteger(value, "lanes.assist.max"),
       },
+      repair: {
+        cluster_max_live_runs: optionalPositiveInteger(
+          value,
+          "lanes.repair.cluster_max_live_runs",
+          1,
+        ),
+      },
     },
   };
 }
@@ -168,6 +184,19 @@ function percent(max: number, value: number): number {
 
 function positiveInteger(root: Record<string, unknown>, path: string): number {
   const value = getPath(root, path);
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1) {
+    throw new Error(`automation limit ${path} must be a positive integer`);
+  }
+  return value;
+}
+
+function optionalPositiveInteger(
+  root: Record<string, unknown>,
+  path: string,
+  fallback: number,
+): number {
+  const value = getOptionalPath(root, path);
+  if (value === undefined) return fallback;
   if (typeof value !== "number" || !Number.isInteger(value) || value < 1) {
     throw new Error(`automation limit ${path} must be a positive integer`);
   }
@@ -187,10 +216,16 @@ function nonNegative(value: number): number {
 }
 
 function getPath(root: Record<string, unknown>, path: string): unknown {
+  const value = getOptionalPath(root, path);
+  if (value === undefined) throw new Error(`automation limit ${path} is missing`);
+  return value;
+}
+
+function getOptionalPath(root: Record<string, unknown>, path: string): unknown {
   let cursor: unknown = root;
   for (const segment of path.split(".")) {
     if (!isRecord(cursor) || !(segment in cursor)) {
-      throw new Error(`automation limit ${path} is missing`);
+      return undefined;
     }
     cursor = cursor[segment];
   }

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -95,6 +95,7 @@ function requiredWorkerLane(value: string): WorkerLane {
     "repair",
     "automerge_repair",
     "issue_implementation",
+    "cluster_repair",
     "exact_item",
     "assist",
   ]);

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -13515,6 +13515,75 @@ test("issue implementation workflow lets job intent choose dispatch capacity", (
   assert.doesNotMatch(workflow, /worker-limit issue_implementation/);
 });
 
+test("repair workflows preserve existing dispatch while scheduled cluster intake stays gated", () => {
+  const cluster = readFileSync(".github/workflows/repair-cluster-worker.yml", "utf8");
+  const clusterIntake = readFileSync(".github/workflows/repair-cluster-intake.yml", "utf8");
+  const router = readFileSync(".github/workflows/repair-comment-router.yml", "utf8");
+  const finalizer = readFileSync(".github/workflows/repair-finalize-open-prs.yml", "utf8");
+  const selfHeal = readFileSync(".github/workflows/repair-self-heal.yml", "utf8");
+  const sweep = readFileSync(".github/workflows/sweep.yml", "utf8");
+  const dispatchJobs = readFileSync("src/repair/dispatch-jobs.ts", "utf8");
+  const importGitcrawl = readFileSync("src/repair/import-gitcrawl-clusters.ts", "utf8");
+  const importLowSignal = readFileSync("src/repair/import-gitcrawl-low-signal-prs.ts", "utf8");
+  const issueImplementation = readFileSync(
+    ".github/workflows/repair-issue-implementation-intake.yml",
+    "utf8",
+  );
+  const commitFinding = readFileSync(".github/workflows/repair-commit-finding-intake.yml", "utf8");
+  const existingRepairWorkflows = [
+    cluster,
+    router,
+    finalizer,
+    selfHeal,
+    sweep,
+    issueImplementation,
+    commitFinding,
+  ].join("\n");
+
+  assert.doesNotMatch(existingRepairWorkflows, /CLAWSWEEPER_FEATURE_REPAIR_ENABLED/);
+  assert.match(sweep, /pnpm run repair:comment-router -- \\\n[\s\S]*--execute/);
+  assert.match(router, /\{ \[ "\$\{\{ github\.event_name \}\}" = "repository_dispatch" \]; \}/);
+  assert.match(issueImplementation, /ENABLED: \$\{\{ github\.event\.inputs\.enabled/);
+  assert.match(commitFinding, /ENABLED: \$\{\{ github\.event\.inputs\.enabled/);
+  assert.match(clusterIntake, /SCHEDULE_ENABLED/);
+  assert.match(clusterIntake, /CLAWSWEEPER_FEATURE_CLUSTER_REPAIR_ENABLED/);
+  const intakeJobHeader = clusterIntake.slice(
+    clusterIntake.indexOf("  intake:"),
+    clusterIntake.indexOf("    steps:"),
+  );
+  assert.match(
+    intakeJobHeader,
+    /if: \$\{\{ github\.event_name != 'schedule' \|\| vars\.CLAWSWEEPER_FEATURE_CLUSTER_REPAIR_ENABLED == '1' \}\}/,
+  );
+  assert.ok(
+    clusterIntake.indexOf("vars.CLAWSWEEPER_FEATURE_CLUSTER_REPAIR_ENABLED") <
+      clusterIntake.indexOf("actions/create-github-app-token"),
+    "scheduled cluster intake gate must appear before token creation",
+  );
+  assert.match(dispatchJobs, /repairJobUsesClusterLane/);
+  assert.doesNotMatch(dispatchJobs, /CLAWSWEEPER_FEATURE_CLUSTER_REPAIR_ENABLED/);
+  assert.doesNotMatch(importGitcrawl, /CLAWSWEEPER_FEATURE_CLUSTER_REPAIR_ENABLED/);
+  assert.doesNotMatch(importLowSignal, /CLAWSWEEPER_FEATURE_CLUSTER_REPAIR_ENABLED/);
+});
+
+test("cluster intake publishes generated repair state through state repo", () => {
+  const workflow = readFileSync(".github/workflows/repair-cluster-intake.yml", "utf8");
+  const stateTokenIndex = workflow.indexOf("uses: ./.github/actions/create-state-token");
+  const setupStateIndex = workflow.indexOf("uses: ./.github/actions/setup-state");
+  const importIndex = workflow.indexOf("- name: Import one cluster from gitcrawl-store");
+  const publishIndex = workflow.indexOf("- name: Publish intake jobs and ledger");
+
+  assert.notEqual(stateTokenIndex, -1);
+  assert.notEqual(setupStateIndex, -1);
+  assert.notEqual(importIndex, -1);
+  assert.notEqual(publishIndex, -1);
+  assert.ok(stateTokenIndex < setupStateIndex, "state token must be created before setup-state");
+  assert.ok(setupStateIndex < importIndex, "state repo must be hydrated before job import");
+  assert.ok(setupStateIndex < publishIndex, "state repo must be configured before publish-main");
+  assert.match(workflow, /--path jobs/);
+  assert.match(workflow, /--path results\/cluster-repair-intake/);
+});
+
 test("review prompt asks for concise public review fields", () => {
   const prompt = readFileSync("prompts/review-item.md", "utf8");
 

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -44,10 +44,95 @@ test("dashboard HTML preserves UTF-8 emoji labels", async () => {
   assert.match(html, /⚡ Merge Speed/);
   assert.match(html, /🎯 Capacity/);
   assert.match(html, /🌊 Loading pipeline state/);
+  assert.match(html, /🔎 Cluster Intake/);
   assert.match(html, /🌀 Active Pipeline/);
   assert.match(html, /✅ Closed by ClawSweeper/);
   assert.match(html, /📡 Recent Activity/);
+  assert.ok(html.indexOf("🔎 Cluster Intake") > html.indexOf("📡 Recent Activity"));
+  assert.match(html, /<strong>60m<\/strong><span>tick<\/span>/);
   assert.doesNotMatch(html, /ðŸ|â|âš|âœ/);
+});
+
+test("dashboard exposes scheduled cluster intake markers and runs", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalCaches = globalThis.caches;
+  Object.defineProperty(globalThis, "caches", {
+    configurable: true,
+    value: {
+      default: {
+        match: async () => undefined,
+        put: async () => undefined,
+      },
+    },
+  });
+  const marker = {
+    target_repo: "openclaw/openclaw",
+    last_processed_store_sha256: "abc123def4567890",
+    last_processed_store_exported_at: "2026-05-25T12:00:00Z",
+    generated_count: 1,
+    generated_jobs: ["jobs/openclaw/inbox/gitcrawl-42-login-fix.md"],
+    run_url: "https://github.com/openclaw/clawsweeper/actions/runs/42",
+    updated_at: "2026-05-25T12:08:00Z",
+  };
+  globalThis.fetch = async (input) => {
+    const url = new URL(String(input));
+    if (url.pathname === "/repos/openclaw/clawsweeper/actions/runs") {
+      return jsonResponse({ workflow_runs: [] });
+    }
+    if (
+      url.pathname ===
+      "/repos/openclaw/clawsweeper/actions/workflows/repair-cluster-intake.yml/runs"
+    ) {
+      return jsonResponse({
+        workflow_runs: [
+          {
+            id: 42,
+            name: "repair cluster intake",
+            display_title: "repair cluster intake",
+            status: "completed",
+            conclusion: "success",
+            html_url: "https://github.com/openclaw/clawsweeper/actions/runs/42",
+            created_at: "2026-05-25T12:08:00Z",
+            updated_at: "2026-05-25T12:09:00Z",
+          },
+        ],
+      });
+    }
+    if (
+      url.pathname ===
+      "/repos/openclaw/clawsweeper/contents/results/cluster-repair-intake/openclaw-openclaw.json"
+    ) {
+      return jsonResponse({
+        content: Buffer.from(JSON.stringify(marker)).toString("base64"),
+      });
+    }
+    if (url.pathname === "/search/issues") return jsonResponse({ items: [] });
+    if (url.pathname === "/repos/openclaw/openclaw/issues") return jsonResponse([]);
+    throw new Error(`unexpected fetch ${url}`);
+  };
+
+  try {
+    const response = await worker.fetch(new Request("https://clawsweeper.openclaw.ai/api/status"), {
+      STATUS_STORE: new MemoryKv(),
+      CLAWSWEEPER_REPO: "openclaw/clawsweeper",
+      TARGET_REPOS: "openclaw/openclaw",
+      CACHE_TTL_SECONDS: "0",
+    });
+    assert.equal(response.status, 200);
+    const status = await response.json();
+    assert.equal(status.recent.cluster_repair.workflow, "repair-cluster-intake.yml");
+    assert.equal(status.recent.cluster_repair.schedule, "8 * * * *");
+    assert.equal(status.recent.cluster_repair.markers[0].status, "imported");
+    assert.equal(status.recent.cluster_repair.markers[0].generated_count, 1);
+    assert.equal(
+      status.recent.cluster_repair.markers[0].last_processed_store_short_sha,
+      "abc123def4",
+    );
+    assert.equal(status.recent.cluster_repair.latest_runs[0].url, marker.run_url);
+  } finally {
+    globalThis.fetch = originalFetch;
+    Object.defineProperty(globalThis, "caches", { configurable: true, value: originalCaches });
+  }
 });
 
 test("dashboard reads stored CI status for active PR rows", async () => {

--- a/test/repair/gitcrawl-store.test.ts
+++ b/test/repair/gitcrawl-store.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+test("gitcrawl readers prefer portable gitcrawl-store before legacy local DB", () => {
+  const sources = [
+    readFileSync("src/clawsweeper.ts", "utf8"),
+    readFileSync("src/repair/import-gitcrawl-clusters.ts", "utf8"),
+    readFileSync("src/repair/import-gitcrawl-low-signal-prs.ts", "utf8"),
+  ];
+
+  for (const source of sources) {
+    assert.match(source, /CLAWSWEEPER_GITCRAWL_DB/);
+    assert.match(source, /gitcrawl-store/);
+    assert.match(source, /\.sync\.db/);
+    assert.match(source, /replace\(/);
+    assert(source.indexOf("gitcrawl-store") < source.indexOf('.config", "gitcrawl", "gitcrawl.db'));
+  }
+});
+
+test("gitcrawl docs describe external store freshness instead of per-run crawling", () => {
+  const relatedDocs = readFileSync("docs/related-issue-discovery.md", "utf8");
+  const repairDocs = readFileSync("docs/repair/README.md", "utf8");
+
+  assert.match(relatedDocs, /does not run a gitcrawl fetch\s+or download issues during review/);
+  assert.match(relatedDocs, /git pull --ff-only/);
+  assert.match(repairDocs, /does not crawl or download\s+issues during repair import/);
+  assert.match(repairDocs, /git -C \.\.\/gitcrawl-store pull --ff-only/);
+});
+
+test("gitcrawl cluster import drip-feeds mostly open clusters by default", () => {
+  const source = readFileSync("src/repair/import-gitcrawl-clusters.ts", "utf8");
+  const limitsDocs = readFileSync("docs/limits.md", "utf8");
+  const repairDocs = readFileSync("docs/repair/README.md", "utf8");
+
+  assert.match(source, /const allowEmpty = Boolean\(args\["allow-empty"\]\)/);
+  assert.match(source, /const allowInstantClose = booleanArg\("allow-instant-close", false\)/);
+  assert.match(source, /const skipClosedPercent = percentArg\("skip-closed-percent", 75\)/);
+  assert.match(source, /skip mostly-closed cluster/);
+  assert.match(source, /closedPercent >= skipClosedPercent/);
+  assert.match(
+    source,
+    /\(\(closed_count \* 100\) \/ member_count\) < \$\{sqlNumber\(skipClosedPercent\)\}/,
+  );
+  assert.match(limitsDocs, /75% closed members are skipped/);
+  assert.match(repairDocs, /75%\+ closed clusters by default/);
+});
+
+test("scheduled cluster repair intake follows gitcrawl-store freshness cadence", () => {
+  const workflow = readFileSync(".github/workflows/repair-cluster-intake.yml", "utf8");
+  const limitsDocs = readFileSync("docs/limits.md", "utf8");
+  const repairDocs = readFileSync("docs/repair/README.md", "utf8");
+  const internalDocs = readFileSync("docs/repair/internal-features.md", "utf8");
+
+  assert.match(workflow, /cron: "8 \* \* \* \*"/);
+  assert.match(workflow, /gitcrawl-store refreshes openclaw\/openclaw every 15 minutes/);
+  assert.match(workflow, /last_processed_store_sha256/);
+  assert.match(workflow, /CLAWSWEEPER_CLUSTER_REPAIR_IMPORT_LIMIT \|\| '1'/);
+  assert.match(workflow, /pnpm run repair:dispatch/);
+  assert.match(limitsDocs, /default is `1` cluster every\s+hour/);
+  assert.match(repairDocs, /intake runs hourly/);
+  assert.match(internalDocs, /refreshes `openclaw\/openclaw` every 15\s+minutes/);
+});
+
+test("gitcrawl cluster import is not blocked by the scheduled intake gate", () => {
+  const source = readFileSync("src/repair/import-gitcrawl-clusters.ts", "utf8");
+  const lowSignalSource = readFileSync("src/repair/import-gitcrawl-low-signal-prs.ts", "utf8");
+  const dispatchJobs = readFileSync("src/repair/dispatch-jobs.ts", "utf8");
+
+  assert.doesNotMatch(source, /CLAWSWEEPER_FEATURE_CLUSTER_REPAIR_ENABLED/);
+  assert.doesNotMatch(lowSignalSource, /CLAWSWEEPER_FEATURE_CLUSTER_REPAIR_ENABLED/);
+  assert.doesNotMatch(dispatchJobs, /CLAWSWEEPER_FEATURE_CLUSTER_REPAIR_ENABLED/);
+});

--- a/test/repair/job-intent.test.ts
+++ b/test/repair/job-intent.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   repairJobIntentForFrontmatter,
   repairJobIntentFromSource,
+  repairJobUsesClusterLane,
   workerLaneForRepairJobIntent,
 } from "../../dist/repair/job-intent.js";
 
@@ -26,4 +27,30 @@ test("frontmatter job intent owns worker lane selection", () => {
   assert.equal(workerLaneForRepairJobIntent("automerge_pr"), "automerge_repair");
   assert.equal(workerLaneForRepairJobIntent("implement_issue"), "issue_implementation");
   assert.equal(workerLaneForRepairJobIntent("low_signal_pr_cleanup"), "repair");
+});
+
+test("imported cluster jobs use the cluster worker lane", () => {
+  assert.equal(
+    repairJobUsesClusterLane({ job_intent: "repair_cluster", cluster_id: "gitcrawl-123" }),
+    true,
+  );
+  assert.equal(repairJobUsesClusterLane({ job_intent: "low_signal_pr_cleanup" }), false);
+  assert.equal(
+    repairJobUsesClusterLane({
+      job_intent: "repair_cluster",
+      cluster_id: "low-signal-pr-sweep-20260427T0530-01",
+    }),
+    false,
+  );
+  assert.equal(
+    repairJobUsesClusterLane({ job_intent: "automerge_pr", cluster_id: "automerge-1" }),
+    false,
+  );
+  assert.equal(
+    repairJobUsesClusterLane({
+      job_intent: "implement_issue",
+      source: "issue_implementation",
+    }),
+    false,
+  );
 });

--- a/test/repair/live-worker-capacity.test.ts
+++ b/test/repair/live-worker-capacity.test.ts
@@ -12,7 +12,9 @@ import {
 
 test("live worker capacity refuses limits above the global Codex cap", () => {
   assert.equal(MAX_LIVE_WORKERS, 57);
-  assert.equal(readMaxLiveWorkers({ "max-live-workers": "57" }), 57);
+  assert.equal(readMaxLiveWorkers(), 22);
+  assert.equal(readMaxLiveWorkers({ "max-live-workers": "1" }), 1);
+  assert.equal(readMaxLiveWorkers({ "max-live-workers": "22" }), 22);
   assert.throws(
     () => readMaxLiveWorkers({ "max-live-workers": "58" }),
     /max-live-workers must be <= 57/,
@@ -21,9 +23,9 @@ test("live worker capacity refuses limits above the global Codex cap", () => {
 
 test("live worker capacity accepts env default within the global Codex cap", () => {
   const previous = process.env.CLAWSWEEPER_MAX_LIVE_WORKERS;
-  process.env.CLAWSWEEPER_MAX_LIVE_WORKERS = "55";
+  process.env.CLAWSWEEPER_MAX_LIVE_WORKERS = "1";
   try {
-    assert.equal(readMaxLiveWorkers(), 55);
+    assert.equal(readMaxLiveWorkers(), 1);
   } finally {
     if (previous === undefined) delete process.env.CLAWSWEEPER_MAX_LIVE_WORKERS;
     else process.env.CLAWSWEEPER_MAX_LIVE_WORKERS = previous;

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -18,7 +18,12 @@ import {
   proposedItemNumbers,
   writeCommentSyncCursor,
 } from "../../dist/repair/workflow-utils.js";
-import { AUTOMATION_LIMITS, WORKER_CONFIG, workerLimit } from "../../dist/repair/limits.js";
+import {
+  AUTOMATION_LIMITS,
+  WORKER_CONFIG,
+  readWorkerConfig,
+  workerLimit,
+} from "../../dist/repair/limits.js";
 
 test("workflow utilities expose automation limits", () => {
   assert.equal(
@@ -54,9 +59,36 @@ test("worker scheduler lets background lanes yield to active work", () => {
   assert.equal(workerLimit("commit_review"), AUTOMATION_LIMITS.commit_review.page_size_default);
   assert.equal(workerLimit("commit_review", { activeCritical: 49 }), 1);
   assert.equal(workerLimit("repair"), AUTOMATION_LIMITS.repair_live_runs.default);
+  assert.equal(workerLimit("repair"), 22);
+  assert.equal(workerLimit("automerge_repair"), 22);
+  assert.equal(workerLimit("issue_implementation"), 22);
+  assert.equal(workerLimit("cluster_repair"), 1);
   assert.equal(AUTOMATION_LIMITS.assist.default, 5);
   assert.equal(workerLimit("assist"), 5);
   assert.equal(workerLimit("assist", { activeCritical: 55 }), 2);
+});
+
+test("worker config defaults imported cluster repair capacity for older configs", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-limits-"));
+  const configPath = path.join(root, "automation-limits.json");
+  write(
+    configPath,
+    JSON.stringify({
+      workers: {
+        max: 55,
+        reserve_for_interactive: 8,
+        expansion_reserve: 4,
+        minimum_background: 1,
+      },
+      lanes: {
+        assist: {
+          max: 5,
+        },
+      },
+    }),
+  );
+
+  assert.equal(readWorkerConfig(configPath).lanes.repair.cluster_max_live_runs, 1);
 });
 
 test("workflow utilities derive artifact item numbers and action counts", () => {


### PR DESCRIPTION
## Summary
- Migrate the Clownfish-style cluster repair lane into ClawSweeper using gitcrawl/gitcrawl-store cluster data.
- Add `repair-cluster-intake.yml`, a scheduled intake that runs hourly, reads `openclaw/gitcrawl-store`, imports at most one eligible cluster by default, publishes generated jobs and the intake ledger through `openclaw/clawsweeper-state`, and dispatches through the one-worker `cluster_repair` lane.
- Gate only scheduled intake behind the repo variable `CLAWSWEEPER_FEATURE_CLUSTER_REPAIR_ENABLED=1`; direct/manual gitcrawl import and repair dispatch are not blocked by that variable, preserving compatibility for existing repair tooling.
- Put the scheduled gate on the intake job before App-token creation, checkout, setup, or dispatch, so default-off cron ticks skip before privileged setup.
- Add a responsive Cluster Intake dashboard section so maintainers can see the last processed gitcrawl-store marker, generated job count/path, recent intake workflow runs, and active cluster worker counts from `/api/status`.
- Keep cluster repair separate from the existing issue implementation solver: issue implementation handles individually triaged strict reproducible bugs, while cluster repair handles imported issue/PR clusters.
- Drip-feed imported gitcrawl cluster work by default: cluster import skips already-imported, security-sensitive, feature-request, and 75%+ closed clusters unless `--skip-closed-percent` is explicitly overridden.
- Preserve the existing repair/automerge/issue-implementation/low-signal cleanup 40%-of-`workers.max` capacity derivation; only imported gitcrawl cluster jobs use the new one-worker `cluster_repair` default lane.
- Prefer portable `gitcrawl-store` SQLite state before the legacy local gitcrawl DB.

## Duplicate Protection
- `openclaw/gitcrawl-store` refreshes `openclaw/openclaw` every 15 minutes; this intake runs hourly.
- The workflow records a small processed-store marker in `openclaw/clawsweeper-state` at `results/cluster-repair-intake/<repo>.json` with the last portable DB SHA, generated count, run URL, and update time.
- That marker prevents delayed or repeated ClawSweeper ticks against the same store snapshot from re-processing the same snapshot. It is intentionally earlier than the existing worker duplicate checks, which only skip active runs for an already-created job path.
- The importer also skips already-imported cluster IDs and overlapping member refs, so the marker is a cadence/load guard rather than the only duplicate-safety mechanism.
- Manual dispatch can override the processed-store skip with `force_store=true` for debugging.

## Maintainer Visibility
- The live dashboard now renders a `Cluster Intake` section below Active Pipeline on wide screens and at the bottom after recent activity on narrow screens.
- The section shows the marker status for each configured target repo, the gitcrawl-store short SHA, exported time, generated job count, generated job filename, marker run link, latest intake workflow runs, and current active intake/worker counts.
- Active cluster worker runs also continue to appear in the existing Active Pipeline list as repair work.

## Enablement
To enable automatic cluster intake in a target repo, add the Actions repository variable `CLAWSWEEPER_FEATURE_CLUSTER_REPAIR_ENABLED=1`.

Live mutation still also requires the existing gates, mainly `CLAWSWEEPER_ALLOW_EXECUTE=1` and `CLAWSWEEPER_ALLOW_FIX_PR=1`. Merge behavior remains separately gated by `CLAWSWEEPER_ALLOW_MERGE=1` where applicable.

The optional `CLAWSWEEPER_CLUSTER_REPAIR_IMPORT_LIMIT` variable controls scheduled intake volume; default is `1` cluster per hourly run. Manual dispatch remains available for debugging and can be disabled per run with `enabled=0`.

## Audit Notes
- Removed stale/self-contradicting docs that showed ordinary repair self-heal at the cluster one-worker limit; normal repair examples stay at the current 22-worker derived default and imported cluster examples use the 1-worker cluster default.
- Removed whitespace-only source churn from the PR diff. The remaining incidental source formatting in `execute-fix-artifact.ts` is required by `oxfmt`.
- `scripts/check-limits.ts` verifies both ordinary repair and imported-cluster examples, so the cluster docs check complements rather than replaces the normal repair docs check.
- `README.md` and `docs/limits.md` describe existing repair capacity as 40% of `workers.max`, not a fixed checked-in 22.
- Older or custom automation-limits configs that omit `lanes.repair.cluster_max_live_runs` now keep loading; cluster repair capacity defaults to 1 when that optional key is absent.

## Verification
- `pnpm run build:repair && node --test test/clawsweeper.test.ts`
- `pnpm run check`
- `pnpm run build:dashboard && node --test test/dashboard-worker.test.ts`
- `pnpm run check:limits`





