### PR TITLE
feat: add visualize commands

### DIFF
--- a/.github/workflows/assist.yml
+++ b/.github/workflows/assist.yml
@@ -158,8 +158,8 @@ jobs:
           TARGET_REPO: ${{ github.event.client_payload.target_repo || inputs.target_repo }}
           ITEM_NUMBER: ${{ github.event.client_payload.item_number || inputs.item_number }}
           QUESTION: ${{ github.event.client_payload.question || inputs.question }}
-          MODE: ${{ github.event.client_payload.mode || 'assist' }}
-          LENS: ${{ github.event.client_payload.lens || 'auto' }}
+          MODE: ${{ github.event.client_payload.mode || inputs.mode || 'assist' }}
+          LENS: ${{ github.event.client_payload.lens || inputs.lens || 'auto' }}
           COMMENT_ID: ${{ github.event.client_payload.comment_id || inputs.comment_id || '' }}
           COMMENT_URL: ${{ github.event.client_payload.comment_url || inputs.comment_url || '' }}
           AUTHOR: ${{ github.event.client_payload.author || inputs.author || '' }}

--- a/.github/workflows/assist.yml
+++ b/.github/workflows/assist.yml
@@ -20,6 +20,16 @@ on:
         description: "Maintainer question to answer"
         required: true
         type: string
+      mode:
+        description: "Assist mode: assist or visual"
+        required: false
+        default: assist
+        type: string
+      lens:
+        description: "Visual lens when mode is visual"
+        required: false
+        default: auto
+        type: string
       comment_id:
         description: "Source issue comment id"
         required: false
@@ -148,6 +158,8 @@ jobs:
           TARGET_REPO: ${{ github.event.client_payload.target_repo || inputs.target_repo }}
           ITEM_NUMBER: ${{ github.event.client_payload.item_number || inputs.item_number }}
           QUESTION: ${{ github.event.client_payload.question || inputs.question }}
+          MODE: ${{ github.event.client_payload.mode || 'assist' }}
+          LENS: ${{ github.event.client_payload.lens || 'auto' }}
           COMMENT_ID: ${{ github.event.client_payload.comment_id || inputs.comment_id || '' }}
           COMMENT_URL: ${{ github.event.client_payload.comment_url || inputs.comment_url || '' }}
           AUTHOR: ${{ github.event.client_payload.author || inputs.author || '' }}
@@ -160,6 +172,8 @@ jobs:
             --target-repo "$TARGET_REPO" \
             --item-number "$ITEM_NUMBER" \
             --question "$QUESTION" \
+            --mode "$MODE" \
+            --lens "$LENS" \
             --comment-id "$COMMENT_ID" \
             --comment-url "$COMMENT_URL" \
             --author "$AUTHOR" \

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Common commands:
 @clawsweeper approve
 @clawsweeper explain
 @clawsweeper ask is this blocked by flaky CI?
+@clawsweeper visualize state
 @clawsweeper stop
 @clawsweeper why did automerge stop here?
 ```
@@ -198,6 +199,8 @@ Common commands:
   non-durable answer comment and never edits the durable ClawSweeper review
   comment, closes, merges, labels, pushes, repairs, or emits review/apply
   markers.
+- `visualize [lens]` dispatches the read-only visual assist lane and posts or
+  updates a marker-backed visual brief comment for the requested lens.
 - `fix ci`, `address review`, and `rebase` dispatch the repair worker only for
   ClawSweeper PRs or PRs already opted into `clawsweeper:autofix` or
   `clawsweeper:automerge`.

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -6290,9 +6290,7 @@ function assistCommentMarker(commentId: string): string {
 const VISUAL_LENSES = new Set(["ux", "flow", "state", "data", "proof", "risk", "maintainer"]);
 
 function normalizeVisualLens(value: unknown): string {
-  const lens = String(value ?? "auto")
-    .trim()
-    .toLowerCase();
+  const lens = typeof value === "string" ? value.trim().toLowerCase() : "auto";
   return VISUAL_LENSES.has(lens) ? lens : "auto";
 }
 
@@ -6362,7 +6360,7 @@ function itemHeadSha(item: Item, context: ItemContext): string {
   if (item.kind !== "pull_request") return "na";
   const pull = asRecord(context.pullRequest);
   const head = asRecord(pull.head);
-  return String(head.sha ?? "").trim() || "na";
+  return typeof head.sha === "string" ? head.sha.trim() || "na" : "na";
 }
 
 function postOrUpdateVisualComment(
@@ -6374,12 +6372,14 @@ function postOrUpdateVisualComment(
   const marker = visualCommentMarker(number, lens, headSha);
   const existing = ghPaged<unknown>(`repos/${targetRepo()}/issues/${number}/comments?per_page=100`)
     .map(asRecord)
-    .find((comment) => String(comment.body ?? "").includes(marker));
+    .find((comment) => typeof comment.body === "string" && comment.body.includes(marker));
   const payload = writeCommentPayload(number, body);
-  if (existing?.id) {
+  const existingId =
+    typeof existing?.id === "number" || typeof existing?.id === "string" ? existing.id : null;
+  if (existingId) {
     ghWithRetry([
       "api",
-      `repos/${targetRepo()}/issues/comments/${existing.id}`,
+      `repos/${targetRepo()}/issues/comments/${existingId}`,
       "--method",
       "PATCH",
       "--input",

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -2725,6 +2725,7 @@ function isClawSweeperNoiseComment(value: unknown, number: number): boolean {
   if (!body.trim() || !isClawSweeperComment(value)) return false;
   if (isClawSweeperDurableReviewComment(value, number)) return true;
   if (/clawsweeper-pr-egg-hatch:/i.test(body)) return true;
+  if (/clawsweeper-visual\s+item=/i.test(body)) return true;
   if (/clawsweeper-command(?:-status|-ack)?:/i.test(body)) return true;
   if (/clawsweeper-review-status:/i.test(body)) return true;
   if (/^ClawSweeper status: review started\./i.test(body)) return true;
@@ -6106,7 +6107,18 @@ function buildAssistPrompt(options: {
   question: string;
   sourceCommentUrl: string;
   author: string;
+  mode?: string;
+  lens?: string;
 }): string {
+  if (options.mode === "visual")
+    return buildVisualPrompt({
+      item: options.item,
+      context: options.context,
+      question: options.question,
+      sourceCommentUrl: options.sourceCommentUrl,
+      author: options.author,
+      ...(options.lens === undefined ? {} : { lens: options.lens }),
+    });
   return [
     "You are ClawSweeper assist, a lightweight read-only maintainer Q&A helper for GitHub issues and pull requests.",
     "",
@@ -6142,6 +6154,69 @@ function buildAssistPrompt(options: {
   ].join("\n");
 }
 
+function buildVisualPrompt(options: {
+  item: Item;
+  context: ItemContext;
+  question: string;
+  sourceCommentUrl: string;
+  author: string;
+  lens?: string;
+}): string {
+  const requestedLens = normalizeVisualLens(options.lens);
+  return [
+    "You are ClawSweeper visual brief, a read-only maintainer judgment helper for GitHub issues and pull requests.",
+    "",
+    "Hard safety contract:",
+    "- Create a compact GitHub-comment-friendly ASCII/text visual brief only from supplied context.",
+    "- Advisory only: maintainers remain the final judges.",
+    "- Do not recommend closing, merging, labeling, pushing, rebasing, or repairing as an executed action.",
+    "- Do not emit hidden ClawSweeper verdict, action, security, or review markers.",
+    "- Avoid Mermaid and generated images. Use ASCII boxes, arrows, split screens, state tables, and checklists.",
+    "- Use glyphs only in public markdown when they clarify states or transitions; include a legend when more than three glyphs appear.",
+    "",
+    "Lens guidance:",
+    "- ux: user/operator visible behavior.",
+    "- flow: routing, delivery, queues, providers, tools, or pipelines.",
+    "- state: sessions, locks, auth, config, identity, lifecycle, flags, or modes.",
+    "- data: payloads, protocol responses, redaction, projection, storage, schemas, or migrations.",
+    "- proof: missing, stale, disputed, or confusing behavior proof.",
+    "- risk: compatibility, operator impact, security boundary, availability, automation, or session-state tradeoff.",
+    "- maintainer: product, policy, API, UX, or architecture judgment.",
+    "",
+    "Response format:",
+    "- Start with `# Visual brief`.",
+    `- Requested lens: ${requestedLens}. If it is auto, choose the strongest lens and name it near the top.`,
+    "- Prefer compact visuals over long prose.",
+    "- Show before/after or current/proposed behavior when applicable.",
+    "- Show remaining risk or maintainer judgment when applicable.",
+    "- Clearly state that this is advisory and maintainers remain the final judges.",
+    "- End exactly with this footer:",
+    "",
+    "## Maintainer ruling",
+    "",
+    "Benefit:",
+    "Risk:",
+    "Proof needed:",
+    "Recommended next action:",
+    "Question presented:",
+    "",
+    "Request metadata:",
+    `- Repository: ${options.item.repo}`,
+    `- Item: #${options.item.number}`,
+    `- Type: ${options.item.kind}`,
+    `- Title: ${options.item.title}`,
+    `- URL: ${options.item.url}`,
+    `- Request author: ${options.author || "unknown"}`,
+    `- Source comment: ${options.sourceCommentUrl || "unknown"}`,
+    `- Maintainer request: ${options.question || `visualize ${requestedLens}`}`,
+    "",
+    "GitHub context JSON:",
+    "```json",
+    JSON.stringify(options.context, null, 2),
+    "```",
+  ].join("\n");
+}
+
 function runCodexAssist(options: {
   item: Item;
   context: ItemContext;
@@ -6153,6 +6228,8 @@ function runCodexAssist(options: {
   sandboxMode: string;
   timeoutMs: number;
   workDir: string;
+  mode?: string;
+  lens?: string;
 }): string {
   ensureDir(options.workDir);
   const promptPath = join(options.workDir, `${options.item.number}.assist.prompt.md`);
@@ -6163,6 +6240,8 @@ function runCodexAssist(options: {
     question: options.question,
     sourceCommentUrl: options.sourceCommentUrl,
     author: options.author,
+    ...(options.mode === undefined ? {} : { mode: options.mode }),
+    ...(options.lens === undefined ? {} : { lens: options.lens }),
   });
   writeFileSync(promptPath, prompt, "utf8");
   const codexConfig = [
@@ -6208,6 +6287,19 @@ function assistCommentMarker(commentId: string): string {
   return `<!-- clawsweeper-assist:${commentId || "unknown"} -->`;
 }
 
+const VISUAL_LENSES = new Set(["ux", "flow", "state", "data", "proof", "risk", "maintainer"]);
+
+function normalizeVisualLens(value: unknown): string {
+  const lens = String(value ?? "auto")
+    .trim()
+    .toLowerCase();
+  return VISUAL_LENSES.has(lens) ? lens : "auto";
+}
+
+function visualCommentMarker(number: number, lens: string, headSha: string): string {
+  return `<!-- clawsweeper-visual item=${number} lens=${normalizeVisualLens(lens)} sha=${headSha || "na"} -->`;
+}
+
 function renderAssistComment(options: {
   body: string;
   model: string;
@@ -6229,8 +6321,72 @@ function renderAssistComment(options: {
   ].join("\n");
 }
 
+function renderVisualComment(options: {
+  body: string;
+  item: Item;
+  context: ItemContext;
+  lens: string;
+  model: string;
+  reasoningEffort: string;
+  sourceCommentUrl: string;
+  sourceCommentId: string;
+}): string {
+  const body = options.body.trim() || "# Visual brief\n\nNo visual brief could be produced.";
+  const headSha = itemHeadSha(options.item, options.context);
+  const sourceLine = options.sourceCommentUrl
+    ? `Source: ${options.sourceCommentUrl}`
+    : `Source comment: ${options.sourceCommentId || "unknown"}`;
+  return [
+    visualCommentMarker(options.item.number, options.lens, headSha),
+    body,
+    "",
+    "---",
+    `${sourceLine}`,
+    `Visual model: ${options.model}, reasoning ${options.reasoningEffort}.`,
+  ].join("\n");
+}
+
 function postAssistComment(number: number, body: string): void {
   const payload = writeCommentPayload(number, body);
+  ghWithRetry([
+    "api",
+    `repos/${targetRepo()}/issues/${number}/comments`,
+    "--method",
+    "POST",
+    "--input",
+    payload,
+  ]);
+}
+
+function itemHeadSha(item: Item, context: ItemContext): string {
+  if (item.kind !== "pull_request") return "na";
+  const pull = asRecord(context.pullRequest);
+  const head = asRecord(pull.head);
+  return String(head.sha ?? "").trim() || "na";
+}
+
+function postOrUpdateVisualComment(
+  number: number,
+  lens: string,
+  headSha: string,
+  body: string,
+): void {
+  const marker = visualCommentMarker(number, lens, headSha);
+  const existing = ghPaged<unknown>(`repos/${targetRepo()}/issues/${number}/comments?per_page=100`)
+    .map(asRecord)
+    .find((comment) => String(comment.body ?? "").includes(marker));
+  const payload = writeCommentPayload(number, body);
+  if (existing?.id) {
+    ghWithRetry([
+      "api",
+      `repos/${targetRepo()}/issues/comments/${existing.id}`,
+      "--method",
+      "PATCH",
+      "--input",
+      payload,
+    ]);
+    return;
+  }
   ghWithRetry([
     "api",
     `repos/${targetRepo()}/issues/${number}/comments`,
@@ -15440,6 +15596,8 @@ function assistCommand(args: Args): void {
   const sourceCommentId = stringArg(args.comment_id, "");
   const sourceCommentUrl = stringArg(args.comment_url, "");
   const author = stringArg(args.author, "");
+  const mode = stringArg(args.mode, "assist") === "visual" ? "visual" : "assist";
+  const lens = normalizeVisualLens(stringArg(args.lens, "auto"));
   const { item, state } = fetchItem(itemNumber);
   if (state.toLowerCase() !== "open") {
     throw new Error(`assist requires an open issue or PR; #${itemNumber} is ${state}`);
@@ -15456,7 +15614,26 @@ function assistCommand(args: Args): void {
     sandboxMode,
     timeoutMs,
     workDir,
+    mode,
+    lens,
   });
+  if (mode === "visual") {
+    const comment = renderVisualComment({
+      body: answer,
+      item,
+      context,
+      lens,
+      model,
+      reasoningEffort,
+      sourceCommentUrl,
+      sourceCommentId,
+    });
+    postOrUpdateVisualComment(item.number, lens, itemHeadSha(item, context), comment);
+    console.log(
+      JSON.stringify({ posted: true, mode, item: item.number, lens, model, reasoningEffort }),
+    );
+    return;
+  }
   const comment = renderAssistComment({
     body: answer,
     model,
@@ -15465,7 +15642,7 @@ function assistCommand(args: Args): void {
     sourceCommentId,
   });
   postAssistComment(item.number, comment);
-  console.log(JSON.stringify({ posted: true, item: item.number, model, reasoningEffort }));
+  console.log(JSON.stringify({ posted: true, mode, item: item.number, model, reasoningEffort }));
 }
 
 function checkCommand(): void {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -6336,11 +6336,10 @@ function renderVisualComment(options: {
     : `Source comment: ${options.sourceCommentId || "unknown"}`;
   return [
     visualCommentMarker(options.item.number, options.lens, headSha),
-    body,
-    "",
-    "---",
     `${sourceLine}`,
     `Visual model: ${options.model}, reasoning ${options.reasoningEffort}.`,
+    "",
+    body,
   ].join("\n");
 }
 

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -6173,6 +6173,8 @@ function buildVisualPrompt(options: {
     "- Do not emit hidden ClawSweeper verdict, action, security, or review markers.",
     "- Avoid Mermaid and generated images. Use ASCII boxes, arrows, split screens, state tables, and checklists.",
     "- Use glyphs only in public markdown when they clarify states or transitions; include a legend when more than three glyphs appear.",
+    "- Standard glyph meanings: ✅ expected/preserved/working/proven; ❌ broken/dropped/failing/rejected path; ⚠️ maintainer risk/unresolved concern/tradeoff; 🐛 confirmed bug path or pre-fix broken behavior; 🔒 credential/security/privacy/trust boundary; 💾 persisted disk state/storage/file output; 🧠 runtime/in-memory/session/active process state; 🧑‍⚖️ maintainer judgment point.",
+    "- Do not decorate every noun. Prefer glyphs on important states, transitions, risks, proof markers, and maintainer judgment points.",
     "",
     "Lens guidance:",
     "- ux: user/operator visible behavior.",

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -1219,7 +1219,7 @@ export function renderResponse(command: LooseRecord, dispatched: LooseRecord) {
       marker,
       "ClawSweeper is here and listening for maintainer commands.",
       "",
-      "Supported commands: `/review`, `/clawsweeper status`, `/clawsweeper re-review`, `@clawsweeper hatch`, `/clawsweeper implement`, `@clawsweeper fix`, `/clawsweeper build`, `/clawsweeper ask <question>`, `/clawsweeper fix ci`, `/clawsweeper address review`, `/clawsweeper rebase`, `/clawsweeper autofix`, `/clawsweeper automerge`, `/clawsweeper approve`, `/autoclose <reason>`, `/clawsweeper explain`, `/clawsweeper stop`.",
+      "Supported commands: `/review`, `/clawsweeper status`, `/clawsweeper re-review`, `@clawsweeper hatch`, `/clawsweeper implement`, `@clawsweeper fix`, `/clawsweeper build`, `/clawsweeper ask <question>`, `/clawsweeper visualize [lens]`, `/clawsweeper fix ci`, `/clawsweeper address review`, `/clawsweeper rebase`, `/clawsweeper autofix`, `/clawsweeper automerge`, `/clawsweeper approve`, `/autoclose <reason>`, `/clawsweeper explain`, `/clawsweeper stop`.",
       "",
       "I only act for maintainers, or for trusted ClawSweeper feedback on a ClawSweeper PR or PR opted into `clawsweeper:autofix` or `clawsweeper:automerge`.",
     ].join("\n");

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -1227,18 +1227,27 @@ export function renderResponse(command: LooseRecord, dispatched: LooseRecord) {
   if (["status", "explain"].includes(command.intent)) {
     return [marker, renderStatusBody(command)].join("\n");
   }
-  if (command.intent === "freeform_assist") {
+  if (command.intent === "freeform_assist" || command.intent === "visualize") {
+    const isVisual = command.intent === "visualize";
     return [
       marker,
       dispatched?.clawsweeper
-        ? "ClawSweeper assist is taking a look at your question."
-        : "ClawSweeper could not start a freeform assist pass for this item.",
+        ? isVisual
+          ? "ClawSweeper visual brief is being prepared."
+          : "ClawSweeper assist is taking a look at your question."
+        : isVisual
+          ? "ClawSweeper could not start a visual brief for this item."
+          : "ClawSweeper could not start a freeform assist pass for this item.",
       "",
       dispatched?.clawsweeper
-        ? "I queued a lightweight read-only assist pass. It will post a separate answer comment and will not edit the durable ClawSweeper review comment or trigger close, merge, repair, label, or branch changes."
-        : `Reason: ${command.reason ?? "freeform assist requires an open issue or PR"}.`,
+        ? isVisual
+          ? "I queued a read-only visual pass. It will create or update one marker-backed visual brief comment and will not trigger close, merge, repair, label, or branch changes."
+          : "I queued a lightweight read-only assist pass. It will post a separate answer comment and will not edit the durable ClawSweeper review comment or trigger close, merge, repair, label, or branch changes."
+        : `Reason: ${command.reason ?? (isVisual ? "visualize requires an open issue or PR" : "freeform assist requires an open issue or PR")}.`,
       "",
-      `Request: ${inlineQuote(command.freeform_prompt ?? command.command ?? "No request text provided.")}`,
+      isVisual
+        ? `Lens: \`${command.visual_lens ?? "auto"}\``
+        : `Request: ${inlineQuote(command.freeform_prompt ?? command.command ?? "No request text provided.")}`,
     ].join("\n");
   }
   if (command.intent === "stop") {
@@ -1552,10 +1561,13 @@ function commandFromText(trigger: JsonValue, value: JsonValue) {
     intent = "freeform_assist";
   }
   const parsedCommand =
-    intent === "freeform_assist" || intent === "autoclose" ? rawNormalized : command;
+    intent === "freeform_assist" || intent === "autoclose" || intent === "visualize"
+      ? rawNormalized
+      : command;
   const parsed: LooseRecord = { trigger, command: parsedCommand, intent };
   if (intent === "autoclose") parsed.autoclose_message = autocloseReasonFromCommand(rawCommand);
   if (intent === "freeform_assist") parsed.freeform_prompt = assistPromptFromCommand(rawCommand);
+  if (intent === "visualize") parsed.visual_lens = visualLensFromCommand(rawCommand);
   if (intent === "implement_issue") {
     parsed.implementation_prompt = implementationPromptFromCommand(rawText);
     if (isIssueImplementationOverride(rawCommand)) parsed.operator_override = true;
@@ -1621,6 +1633,26 @@ function assistPromptFromCommand(command: LooseRecord) {
   return prompt.replace(/^(?:ask|explain)\b[:\s-]*/i, "").trim() || prompt;
 }
 
+export const VISUAL_LENSES = new Set([
+  "ux",
+  "flow",
+  "state",
+  "data",
+  "proof",
+  "risk",
+  "maintainer",
+]);
+
+function visualLensFromCommand(command: LooseRecord) {
+  const lens =
+    String(command ?? "")
+      .trim()
+      .toLowerCase()
+      .replace(/^visuali[sz]e\b[:\s-]*/i, "")
+      .split(/\s+/)[0] ?? "";
+  return VISUAL_LENSES.has(lens) ? lens : "auto";
+}
+
 function issueImplementationRestPrefix(command: LooseRecord) {
   return command.command === "fix" ? "fix issue" : command.command;
 }
@@ -1636,6 +1668,14 @@ function normalizeIntent(command: LooseRecord) {
     command.startsWith("why ")
   ) {
     return "freeform_assist";
+  }
+  if (
+    command === "visualize" ||
+    command === "visualise" ||
+    command.startsWith("visualize ") ||
+    command.startsWith("visualise ")
+  ) {
+    return "visualize";
   }
   if (["hatch", "hatch egg", "pr egg hatch", "hatch pr egg"].includes(command)) return "hatch";
   if (["fix ci", "fix-ci", "ci", "repair ci", "repair checks", "fix checks"].includes(command))

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -205,6 +205,7 @@ for (const comment of comments) {
       extractMarkdownSection(comment.body, "Automerge follow-up") ??
       extractMarkdownSection(comment.body, "Autofix follow-up"),
     freeform_prompt: parsed.freeform_prompt ?? null,
+    visual_lens: parsed.visual_lens ?? null,
     expected_head_sha: parsed.expected_head_sha ?? null,
     finding_id: parsed.finding_id ?? null,
     status: "pending",
@@ -405,12 +406,15 @@ function classifyCommand(command: LooseRecord): JsonValue {
       actions: [{ action: "comment", status: execute ? "pending" : "planned" }],
     };
   }
-  if (command.intent === "freeform_assist") {
+  if (command.intent === "freeform_assist" || command.intent === "visualize") {
     if (String(issue.state ?? "").toLowerCase() !== "open") {
       return {
         ...next,
         status: "ready",
-        reason: "freeform assist requires an open issue or PR",
+        reason:
+          command.intent === "visualize"
+            ? "visualize requires an open issue or PR"
+            : "freeform assist requires an open issue or PR",
         actions: [{ action: "comment", status: execute ? "pending" : "planned" }],
       };
     }
@@ -1394,7 +1398,11 @@ function executeCommand(command: LooseRecord) {
         return action;
       });
     }
-    if (command.intent === "freeform_assist" && command.issue_number && shouldDispatchAssist) {
+    if (
+      (command.intent === "freeform_assist" || command.intent === "visualize") &&
+      command.issue_number &&
+      shouldDispatchAssist
+    ) {
       const clawsweeper = dispatchClawSweeperAssist(command);
       dispatched = { ...dispatched, clawsweeper };
       command.actions = command.actions.map((action: JsonValue) => {
@@ -2025,6 +2033,8 @@ function dispatchClawSweeperAssist(command: LooseRecord) {
       comment_url: String(command.comment_url ?? ""),
       author: String(command.author ?? ""),
       question: String(command.freeform_prompt ?? command.command ?? "").slice(0, 3000),
+      mode: command.intent === "visualize" ? "visual" : "assist",
+      lens: String(command.visual_lens ?? "auto"),
       model: "gpt-5.5",
       reasoning_effort: "low",
       timeout_ms: "120000",

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -412,6 +412,11 @@ test("review context comment filter removes ClawSweeper self-noise and command-o
       "<!-- clawsweeper-command-status:123:re_review:abc -->\nQueued.",
       "clawsweeper",
     ),
+    issueComment(
+      7,
+      "<!-- clawsweeper-visual item=123 lens=state sha=abc -->\n# Visual brief",
+      "clawsweeper",
+    ),
     issueComment(4, "@clawsweeper re-review", "author"),
     issueComment(5, "Here is real behavior proof from my terminal.", "author"),
     issueComment(6, "Actionable file/line review feedback.", "chatgpt-codex-connector[bot]"),
@@ -419,7 +424,7 @@ test("review context comment filter removes ClawSweeper self-noise and command-o
 
   const result = filterReviewContextCommentsForTest(comments, 123);
 
-  assert.equal(result.filtered, 4);
+  assert.equal(result.filtered, 5);
   assert.deepEqual(
     result.included.map((comment) => (comment as { id: number }).id),
     [5, 6],

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -1541,6 +1541,7 @@ test("renderResponse gives command replies stateful lobster badges", () => {
   assert.match(repairBody, /\n🦞🔧\nClawSweeper issue implementation requested/);
   assert.match(doneBody, /\n🦞✅\nClawSweeper merged this PR/);
   assert.match(body, /@clawsweeper fix/);
+  assert.match(body, /\/clawsweeper visualize \[lens\]/);
 });
 
 test("renderResponse describes stop as revoking repair-loop labels", () => {

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -937,6 +937,18 @@ test("parseCommand recognizes ClawSweeper bot mentions", () => {
     intent: "freeform_assist",
     freeform_prompt: "why this PR is not automerge-ready",
   });
+  assert.deepEqual(parseCommand("@clawsweeper visualize state"), {
+    trigger: "mention",
+    command: "visualize state",
+    intent: "visualize",
+    visual_lens: "state",
+  });
+  assert.deepEqual(parseCommand("/clawsweeper visualize"), {
+    trigger: "slash",
+    command: "visualize",
+    intent: "visualize",
+    visual_lens: "auto",
+  });
   assert.deepEqual(parseCommand("@clawsweeper: why did automerge stop here?"), {
     trigger: "mention",
     command: "why did automerge stop here?",
@@ -1771,6 +1783,29 @@ test("renderResponse reports freeform assist dispatches as read-only", () => {
   assert.match(body, /separate answer comment/);
   assert.match(body, /will not edit the durable ClawSweeper review comment/);
   assert.match(body, /why did automerge stop here/);
+  assert.doesNotMatch(body, /repair worker/);
+});
+
+test("renderResponse reports visualize dispatches as marker-backed read-only briefs", () => {
+  const body = renderResponse(
+    {
+      comment_id: "463",
+      intent: "visualize",
+      visual_lens: "state",
+      target: { head_sha: "def463" },
+    },
+    {
+      clawsweeper: {
+        workflow: "assist.yml",
+        event: "repository_dispatch",
+      },
+    },
+  );
+
+  assert.match(body, /visual brief is being prepared/);
+  assert.match(body, /read-only visual pass/);
+  assert.match(body, /marker-backed visual brief comment/);
+  assert.match(body, /Lens: `state`/);
   assert.doesNotMatch(body, /repair worker/);
 });
 


### PR DESCRIPTION
## Summary
- add @clawsweeper visualize command parsing and dispatch through the read-only assist lane
- generate marker-backed visual brief comments that update in place by item/lens/head
- filter ClawSweeper visual comments out of later review context
- document standard glyph meanings for visual briefs and when to use them

Refs https://github.com/openclaw/clawsweeper/issues/202

Note: this is a command/comment slice and intentionally does not claim to close the full issue 202 review-hint acceptance matrix.

## ClawSweeper follow-up
- fixed visual footer ordering so metadata appears before the generated brief and the maintainer ruling footer remains final
- fixed workflow_dispatch fallback so manual mode/lens inputs are honored
- tightened unknown value handling for type-aware lint
- added explicit visual glyph guidance for expected, broken, risk, bug path, trust boundary, disk, runtime, and maintainer judgment markers
- documented the visualize command in built-in help and README command surfaces

## Real behavior proof
- Ran the real assist workflow on this PR branch with mode=visual and lens=state at current head 5765fb7212dcaf46d2c2a26fc7820518d7e25560: https://github.com/openclaw/clawsweeper/actions/runs/26432578950
- The workflow posted a marker-backed visual comment for PR 204 at that head: https://github.com/openclaw/clawsweeper/pull/204#issuecomment-4540091514
- The visual output includes glyph usage and a legend where useful.

## Validation
- npm run build:repair
- node --test test/repair/comment-router-core.test.ts --test-name-pattern "command replies stateful lobster badges"
- node_modules/.bin/oxfmt --check README.md src/repair/comment-router-core.ts test/repair/comment-router-core.test.ts
- node_modules/.bin/tsgo -p tsconfig.repair.json --pretty false
- GitHub CI on current head: pnpm check, CodeQL, and Socket passed
- node_modules/.bin/tsgo -p tsconfig.json --pretty false
- node_modules/.bin/tsgo -p tsconfig.dashboard.json --pretty false
- node_modules/.bin/oxfmt --check .github/workflows/assist.yml src/clawsweeper.ts src/repair/comment-router-core.ts src/repair/comment-router.ts test/clawsweeper.test.ts test/repair/comment-router-core.test.ts
- node --test test/repair/comment-router-core.test.ts --test-name-pattern visualize
- node --test test/clawsweeper.test.ts --test-name-pattern "review context comment filter"
- node_modules/.bin/oxlint src --ignore-pattern "src/repair/**" --tsconfig tsconfig.json --type-aware --deny-warnings --report-unused-disable-directives -D correctness