### PR TITLE
fix: shallow fetch event state checkout

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -380,6 +380,7 @@ jobs:
       - uses: ./.github/actions/setup-state
         with:
           token: ${{ steps.state-token.outputs.token }}
+          fetch-depth: 1
 
       - name: Publish event result and apply safe close
         id: publish-event-result


### PR DESCRIPTION
## Summary
- Shallow-fetch ClawSweeper state in the targeted event-item publish path.
- Avoid full-history state repo fetches before publishing targeted re-review results.

## Validation
- /Users/takayukihoffman/.codex/worktrees/20f9/clawsweeper/node_modules/.bin/oxfmt --check .github/workflows/sweep.yml

Refs https://github.com/openclaw/clawsweeper/pull/204