### PR TITLE
fix: run cluster intake daily

### DIFF
--- a/.github/workflows/repair-cluster-intake.yml
+++ b/.github/workflows/repair-cluster-intake.yml
@@ -40,9 +40,9 @@ on:
         type: boolean
   schedule:
     # gitcrawl-store refreshes openclaw/openclaw every 15 minutes. This intake
-    # runs hourly and records the processed portable DB SHA so a
+    # runs daily and records the processed portable DB SHA so a
     # delayed or duplicate tick does not enqueue work from the same store twice.
-    - cron: "8 * * * *"
+    - cron: "8 8 * * *"
 
 permissions:
   actions: write

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -21,7 +21,6 @@ const GITHUB_TIMEOUT_MS = 4500;
 const DEFAULT_STALE_QUEUED_WORKFLOW_MS = 6 * 60 * 60 * 1000;
 const CLAWSWEEPER_REVIEW_REPO = "openclaw/clawsweeper";
 const CLUSTER_REPAIR_INTAKE_WORKFLOW = "repair-cluster-intake.yml";
-const CLUSTER_REPAIR_INTAKE_CRON = "8 * * * *";
 const CLAWSWEEPER_COMMAND_PATTERN =
   /(^|[ \t\r\n])@(?:clawsweeper|openclaw-clawsweeper)\b(?:\[bot\])?|(^|[ \t\r\n])\/(?:clawsweeper|review|re-review|rerun[ -]?review|status|explain|fix|build|implement|create[ -]?pr|fix[ -]?issue|autofix|auto[ -]?fix|automerge|auto[ -]?merge|approve|stop|autoclose)\b/i;
 const CLAWSWEEPER_ALLOWED_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
@@ -2113,7 +2112,6 @@ async function clusterRepairStatus(env, repo, targetRepos, activeRuns) {
   const intakeRuns = Array.isArray(workflowRuns?.workflow_runs) ? workflowRuns.workflow_runs : [];
   return {
     workflow: CLUSTER_REPAIR_INTAKE_WORKFLOW,
-    schedule: CLUSTER_REPAIR_INTAKE_CRON,
     markers,
     latest_runs: intakeRuns.slice(0, 5).map(workflowRunSummary),
     active_intake_runs: activeRuns
@@ -2167,7 +2165,6 @@ async function readClusterRepairMarker(env, repo, targetRepo) {
 function emptyClusterRepairStatus(targetRepos) {
   return {
     workflow: CLUSTER_REPAIR_INTAKE_WORKFLOW,
-    schedule: CLUSTER_REPAIR_INTAKE_CRON,
     markers: targetRepos.map((targetRepo) => ({
       target_repo: targetRepo,
       marker_path: `results/cluster-repair-intake/${String(targetRepo).replace(/\//g, "-")}.json`,
@@ -3879,6 +3876,9 @@ a:hover { color: #89c8ff; text-decoration: underline; }
   align-items: center;
   padding: 12px 14px;
 }
+.cluster-marker-row {
+  grid-template-columns: minmax(0, 1fr) minmax(210px, 260px);
+}
 .side-row {
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: start;
@@ -4168,12 +4168,12 @@ function renderClusterRepair(cluster) {
   const markerRows = (cluster.markers || []).map(marker => {
     const jobs = (marker.generated_jobs || []).slice(0, 3).map(job => '<span class="pill mono">' + esc(job.split("/").pop() || job) + '</span>').join("");
     const jobText = marker.generated_count ? fmt.format(marker.generated_count) + " job" + (marker.generated_count === 1 ? "" : "s") : "no jobs";
-    return '<article class="work-row"><div class="work-main"><div class="row-top"><span class="pill">' + esc(marker.status || "unknown") + '</span><span class="item-link">' + esc(marker.target_repo || "unknown repo") + '</span></div><div class="muted work-title">store ' + esc(marker.last_processed_store_short_sha || "unknown") + " · " + esc(jobText) + (marker.last_processed_store_exported_at ? " · exported " + esc(since(marker.last_processed_store_exported_at)) : "") + '</div><div class="row-top">' + jobs + '</div></div><div class="work-state"><div class="stage-block"><strong>' + esc(marker.updated_at ? since(marker.updated_at) : "never") + '</strong><span class="muted">marker</span></div>' + linkClass(marker.run_url, "run", "pill run-link") + '</div><div class="timebox"><strong>60m</strong><span>tick</span></div></article>';
+    return '<article class="work-row cluster-marker-row"><div class="work-main"><div class="row-top"><span class="pill">' + esc(marker.status || "unknown") + '</span><span class="item-link">' + esc(marker.target_repo || "unknown repo") + '</span></div><div class="muted work-title">store ' + esc(marker.last_processed_store_short_sha || "unknown") + " · " + esc(jobText) + (marker.last_processed_store_exported_at ? " · exported " + esc(since(marker.last_processed_store_exported_at)) : "") + '</div><div class="row-top">' + jobs + '</div></div><div class="work-state"><div class="stage-block"><strong>' + esc(marker.updated_at ? since(marker.updated_at) : "never") + '</strong><span class="muted">marker</span></div>' + linkClass(marker.run_url, "run", "pill run-link") + '</div></article>';
   }).join("");
   const runRows = (cluster.latest_runs || []).slice(0, 3).map(run => '<article class="side-row"><div class="side-main">' + linkClass(run.url, compactText(run.title || run.workflow), "item-link") + '<div class="muted side-title">' + esc(run.status || "") + (run.conclusion ? " · " + esc(run.conclusion) : "") + '</div></div><div class="side-meta"><span>' + esc(run.started_at ? since(run.started_at) : "") + '</span></div></article>').join("");
   const activeText = fmt.format((cluster.active_intake_runs || []).length) + " intake · " + fmt.format((cluster.active_worker_runs || []).length) + " workers";
   target.innerHTML =
-    '<div class="split"><div class="pipeline-col"><div class="muted" style="margin-bottom:8px">Runs on ' + esc(cluster.workflow || "repair-cluster-intake.yml") + " at " + esc(cluster.schedule || "8 * * * *") + " · " + esc(activeText) + '</div><div class="work-list">' + (markerRows || '<div class="empty">No processed-store markers yet.</div>') + '</div></div><aside class="side-col"><div class="muted" style="margin-bottom:8px">Recent intake workflow runs</div><div class="side-list">' + (runRows || '<div class="empty">No intake runs found.</div>') + '</div></aside></div>';
+    '<div class="split"><div class="pipeline-col"><div class="muted" style="margin-bottom:8px">Runs on ' + esc(cluster.workflow || "repair-cluster-intake.yml") + " · " + esc(activeText) + '</div><div class="work-list">' + (markerRows || '<div class="empty">No processed-store markers yet.</div>') + '</div></div><aside class="side-col"><div class="muted" style="margin-bottom:8px">Recent intake workflow runs</div><div class="side-list">' + (runRows || '<div class="empty">No intake runs found.</div>') + '</div></aside></div>';
 }
 function renderAutomerge(rows) {
   if (!rows.length) {

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -144,8 +144,8 @@ hot intake `31`, and commit review `4`. Existing repair lanes keep their
   clusters with at least 75% closed members are skipped unless
   `--skip-closed-percent` is overridden.
 - `CLAWSWEEPER_CLUSTER_REPAIR_IMPORT_LIMIT` overrides the scheduled
-  `repair-cluster-intake.yml` import limit. The default is `1` cluster every
-  hour; the upstream gitcrawl-store refreshes every 15 minutes, and ClawSweeper
+  `repair-cluster-intake.yml` import limit. The default is `1` cluster per daily
+  run; the upstream gitcrawl-store refreshes every 15 minutes, and ClawSweeper
   records the processed store SHA so repeated ticks against the same snapshot
   skip.
 - `CLAWSWEEPER_MAX_LIVE_WORKERS` overrides the `job_intent`-derived repair

--- a/docs/repair/README.md
+++ b/docs/repair/README.md
@@ -250,7 +250,7 @@ pnpm run repair:import-gitcrawl -- --from-gitcrawl --limit 40 --mode autonomous 
 
 # Automatic imported-cluster intake runs through repair-cluster-intake.yml.
 # gitcrawl-store refreshes openclaw/openclaw every 15 minutes; the ClawSweeper
-# intake runs hourly, records the processed portable DB SHA in
+# intake runs daily, records the processed portable DB SHA in
 # results/cluster-repair-intake/<repo>.json, and skips repeated ticks for the
 # same store snapshot. It imports at most one cluster by default and dispatches
 # through the one-worker cluster_repair lane.
@@ -359,7 +359,7 @@ The workflow needs:
   75% closed members by default; pass `--skip-closed-percent` only for an
   intentional broader import.
 - optional `CLAWSWEEPER_CLUSTER_REPAIR_IMPORT_LIMIT` variable for the scheduled
-  imported-cluster intake; default is `1` cluster per hourly run.
+  imported-cluster intake; default is `1` cluster per daily run.
 - merge is separately gated by `CLAWSWEEPER_ALLOW_MERGE`, which defaults to `0`; merge-ready PRs are labeled `clawsweeper:human-review` and `clawsweeper:merge-ready` for a maintainer to merge manually when the global gate is closed
 - optional `CLAWSWEEPER_CODEX_CLI_VERSION` variable to pin and refresh the cached Codex CLI
 - optional `CLAWSWEEPER_MODEL` override for dispatch scripts; default Codex

--- a/docs/repair/internal-features.md
+++ b/docs/repair/internal-features.md
@@ -590,7 +590,7 @@ Important gates:
   75% closed members by default; `--skip-closed-percent` is the explicit
   override.
 - `CLAWSWEEPER_CLUSTER_REPAIR_IMPORT_LIMIT`: scheduled imported-cluster intake
-  limit; default `1` cluster per hourly `repair-cluster-intake.yml` run.
+  limit; default `1` cluster per daily `repair-cluster-intake.yml` run.
   The upstream `openclaw/gitcrawl-store` refreshes `openclaw/openclaw` every 15
   minutes, so the intake records the processed portable DB SHA in
   `results/cluster-repair-intake/<repo>.json` and skips duplicate ticks against

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -49,7 +49,6 @@ test("dashboard HTML preserves UTF-8 emoji labels", async () => {
   assert.match(html, /✅ Closed by ClawSweeper/);
   assert.match(html, /📡 Recent Activity/);
   assert.ok(html.indexOf("🔎 Cluster Intake") > html.indexOf("📡 Recent Activity"));
-  assert.match(html, /<strong>60m<\/strong><span>tick<\/span>/);
   assert.doesNotMatch(html, /ðŸ|â|âš|âœ/);
 });
 
@@ -121,7 +120,7 @@ test("dashboard exposes scheduled cluster intake markers and runs", async () => 
     assert.equal(response.status, 200);
     const status = await response.json();
     assert.equal(status.recent.cluster_repair.workflow, "repair-cluster-intake.yml");
-    assert.equal(status.recent.cluster_repair.schedule, "8 * * * *");
+    assert.equal("schedule" in status.recent.cluster_repair, false);
     assert.equal(status.recent.cluster_repair.markers[0].status, "imported");
     assert.equal(status.recent.cluster_repair.markers[0].generated_count, 1);
     assert.equal(

--- a/test/repair/gitcrawl-store.test.ts
+++ b/test/repair/gitcrawl-store.test.ts
@@ -52,13 +52,13 @@ test("scheduled cluster repair intake follows gitcrawl-store freshness cadence",
   const repairDocs = readFileSync("docs/repair/README.md", "utf8");
   const internalDocs = readFileSync("docs/repair/internal-features.md", "utf8");
 
-  assert.match(workflow, /cron: "8 \* \* \* \*"/);
+  assert.match(workflow, /cron: "8 8 \* \* \*"/);
   assert.match(workflow, /gitcrawl-store refreshes openclaw\/openclaw every 15 minutes/);
   assert.match(workflow, /last_processed_store_sha256/);
   assert.match(workflow, /CLAWSWEEPER_CLUSTER_REPAIR_IMPORT_LIMIT \|\| '1'/);
   assert.match(workflow, /pnpm run repair:dispatch/);
-  assert.match(limitsDocs, /default is `1` cluster every\s+hour/);
-  assert.match(repairDocs, /intake runs hourly/);
+  assert.match(limitsDocs, /default is `1` cluster per daily\s+run/);
+  assert.match(repairDocs, /intake runs daily/);
   assert.match(internalDocs, /refreshes `openclaw\/openclaw` every 15\s+minutes/);
 });
 


### PR DESCRIPTION
## Summary
- Change scheduled cluster repair intake from hourly to once per day at `8 8 * * *`.
- Remove the cluster intake cron from dashboard status and UI rendering so the cadence is not duplicated in dashboard code.
- Keep gitcrawl-store freshness docs focused on the store SHA duplicate guard while documenting the daily import limit.

## Verification
- `pnpm run build:all && node --test test/dashboard-worker.test.ts test/repair/gitcrawl-store.test.ts test/clawsweeper.test.ts`
- `pnpm run check`