### PR TITLE
fix: dispatch cluster intake after state publish

### DIFF
--- a/.github/workflows/repair-cluster-intake.yml
+++ b/.github/workflows/repair-cluster-intake.yml
@@ -275,7 +275,6 @@ jobs:
         run: |
           set -euo pipefail
           mapfile -t jobs < .artifacts/cluster-repair-intake/generated-paths.txt
-          git pull --rebase origin main
           pnpm run repair:dispatch -- "${jobs[@]}" \
             --mode autonomous \
             --wait-for-capacity \

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -20,6 +20,8 @@ const DEFAULT_CLAWSWEEPER_BOT_LOGINS = ["clawsweeper[bot]", "openclaw-clawsweepe
 const GITHUB_TIMEOUT_MS = 4500;
 const DEFAULT_STALE_QUEUED_WORKFLOW_MS = 6 * 60 * 60 * 1000;
 const CLAWSWEEPER_REVIEW_REPO = "openclaw/clawsweeper";
+const CLAWSWEEPER_STATE_REPO = "openclaw/clawsweeper-state";
+const CLAWSWEEPER_STATE_REF = "state";
 const CLUSTER_REPAIR_INTAKE_WORKFLOW = "repair-cluster-intake.yml";
 const CLAWSWEEPER_COMMAND_PATTERN =
   /(^|[ \t\r\n])@(?:clawsweeper|openclaw-clawsweeper)\b(?:\[bot\])?|(^|[ \t\r\n])\/(?:clawsweeper|review|re-review|rerun[ -]?review|status|explain|fix|build|implement|create[ -]?pr|fix[ -]?issue|autofix|auto[ -]?fix|automerge|auto[ -]?merge|approve|stop|autoclose)\b/i;
@@ -2107,7 +2109,7 @@ async function clusterRepairStatus(env, repo, targetRepos, activeRuns) {
       env,
       `/repos/${repo}/actions/workflows/${encodeURIComponent(CLUSTER_REPAIR_INTAKE_WORKFLOW)}/runs?per_page=5`,
     ).catch(() => ({ workflow_runs: [] })),
-    Promise.all(targetRepos.map((targetRepo) => readClusterRepairMarker(env, repo, targetRepo))),
+    Promise.all(targetRepos.map((targetRepo) => readClusterRepairMarker(env, targetRepo))),
   ]);
   const intakeRuns = Array.isArray(workflowRuns?.workflow_runs) ? workflowRuns.workflow_runs : [];
   return {
@@ -2123,13 +2125,15 @@ async function clusterRepairStatus(env, repo, targetRepos, activeRuns) {
   };
 }
 
-async function readClusterRepairMarker(env, repo, targetRepo) {
+async function readClusterRepairMarker(env, targetRepo) {
+  const stateRepo = String(env.CLAWSWEEPER_STATE_REPO || CLAWSWEEPER_STATE_REPO);
+  const stateRef = String(env.CLAWSWEEPER_STATE_REF || CLAWSWEEPER_STATE_REF);
   const repoSlug = String(targetRepo || "").replace(/\//g, "-");
   const markerPath = `results/cluster-repair-intake/${repoSlug}.json`;
   try {
     const content = await githubJson(
       env,
-      `/repos/${repo}/contents/${githubPath(markerPath)}?ref=main`,
+      `/repos/${stateRepo}/contents/${githubPath(markerPath)}?ref=${encodeURIComponent(stateRef)}`,
     );
     const marker = JSON.parse(decodeGithubContent(content?.content));
     const generatedJobs = Array.isArray(marker.generated_jobs) ? marker.generated_jobs : [];

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -99,8 +99,9 @@ test("dashboard exposes scheduled cluster intake markers and runs", async () => 
     }
     if (
       url.pathname ===
-      "/repos/openclaw/clawsweeper/contents/results/cluster-repair-intake/openclaw-openclaw.json"
+      "/repos/openclaw/clawsweeper-state/contents/results/cluster-repair-intake/openclaw-openclaw.json"
     ) {
+      assert.equal(url.searchParams.get("ref"), "state");
       return jsonResponse({
         content: Buffer.from(JSON.stringify(marker)).toString("base64"),
       });

--- a/test/repair/gitcrawl-store.test.ts
+++ b/test/repair/gitcrawl-store.test.ts
@@ -57,6 +57,7 @@ test("scheduled cluster repair intake follows gitcrawl-store freshness cadence",
   assert.match(workflow, /last_processed_store_sha256/);
   assert.match(workflow, /CLAWSWEEPER_CLUSTER_REPAIR_IMPORT_LIMIT \|\| '1'/);
   assert.match(workflow, /pnpm run repair:dispatch/);
+  assert.doesNotMatch(workflow, /git pull --rebase origin main/);
   assert.match(limitsDocs, /default is `1` cluster per daily\s+run/);
   assert.match(repairDocs, /intake runs daily/);
   assert.match(internalDocs, /refreshes `openclaw\/openclaw` every 15\s+minutes/);


### PR DESCRIPTION
## Summary
- remove the post-publish git rebase from cluster intake dispatch so generated job files do not block dispatch
- read cluster intake dashboard markers from openclaw/clawsweeper-state@state, where intake publishes them
- add regression coverage for both the state marker location and dispatch workflow behavior

## Testing
- pnpm run check