### PR TITLE
fix(review): require human review for config surface changes

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -8940,6 +8940,168 @@ function pullRequestFilePathsFromReport(markdown: string): string[] {
   return frontMatterStringArray(markdown, "pull_files");
 }
 
+interface ConfigSurfaceChange {
+  change: boolean;
+  keys: string[];
+}
+
+function configSurfaceChangeFromContext(repo: string, context: ItemContext): ConfigSurfaceChange {
+  if (repo !== "openclaw/openclaw") {
+    return { change: false, keys: [] };
+  }
+
+  const keys = new Set<string>();
+  for (const entry of context.pullFiles ?? []) {
+    const file = asRecord(entry);
+    const path = typeof file.filename === "string" ? file.filename.trim() : "";
+    const previousPath =
+      typeof file.previous_filename === "string" ? file.previous_filename.trim() : "";
+    const configSurfacePath = [path, previousPath].find(isOpenClawConfigSurfacePath);
+    if (!configSurfacePath) continue;
+    const patch = typeof file.patch === "string" ? file.patch : null;
+    if (patch !== null && configSurfacePatchIsTruncated(patch)) {
+      keys.add("unknown-config-surface-change");
+    }
+    const lines = patch === null ? [] : changedPatchLines(patch);
+    if (patch === null || lines.length === 0) {
+      keys.add("unknown-config-surface-change");
+    }
+    for (const line of lines) {
+      const lineKeys = configSurfaceKeysFromPatchLine(configSurfacePath, line);
+      if (
+        lineKeys.length === 0 &&
+        !isMarkdownConfigSurfacePath(configSurfacePath) &&
+        configSurfaceLineNeedsUnknownMarker(line)
+      ) {
+        keys.add("unknown-config-surface-change");
+      }
+      for (const key of lineKeys) {
+        keys.add(key);
+      }
+    }
+  }
+
+  if (context.counts?.pullFilesTruncated) {
+    keys.add("unknown-truncated-pull-files");
+  }
+
+  return { change: keys.size > 0, keys: [...keys].sort() };
+}
+
+export function configSurfaceChangeFromPullFilesForTest(options: {
+  repo?: string;
+  pullFiles?: unknown[];
+  pullFilesTruncated?: boolean;
+}): ConfigSurfaceChange {
+  const counts: ItemContext["counts"] = { comments: 0, timeline: 0 };
+  if (options.pullFilesTruncated !== undefined)
+    counts.pullFilesTruncated = options.pullFilesTruncated;
+  const context: ItemContext = {
+    issue: {},
+    comments: [],
+    timeline: [],
+    counts,
+  };
+  if (options.pullFiles !== undefined) context.pullFiles = options.pullFiles;
+  return configSurfaceChangeFromContext(options.repo ?? "openclaw/openclaw", context);
+}
+
+function isOpenClawConfigSurfacePath(path: string): boolean {
+  return (
+    /^src\/config\/(?:zod-schema[^/]*|types[^/]*|schema(?:[-.][^/]*)?)\.ts$/.test(path) ||
+    /^src\/plugins\/manifest(?:-registry)?\.ts$/.test(path) ||
+    /^docs\/gateway\/configuration[^/]*\.md$/.test(path) ||
+    path === "docs/plugins/manifest.md"
+  );
+}
+
+function changedPatchLines(patch: string): string[] {
+  return patch
+    .split("\n")
+    .filter(
+      (line) =>
+        (line.startsWith("+") && !line.startsWith("+++")) ||
+        (line.startsWith("-") && !line.startsWith("---")),
+    )
+    .map((line) => line.slice(1).trim());
+}
+
+function configSurfaceLineNeedsUnknownMarker(line: string): boolean {
+  const trimmed = line.trim();
+  return Boolean(trimmed) && !/^\/\/|^\/\*|^\*/.test(trimmed);
+}
+
+function configSurfacePatchIsTruncated(patch: string): boolean {
+  return /\n\n\[truncated \d+ chars\]$/.test(patch);
+}
+
+function configSurfaceKeysFromPatchLine(path: string, line: string): string[] {
+  const trimmed = line.trim();
+  if (!trimmed || /^\/\/|^\/\*|^\*|^<!--/.test(trimmed)) return [];
+
+  const keys = new Set<string>();
+  for (const match of trimmed.matchAll(/`([^`]+)`/g)) {
+    const token = match[1]?.trim();
+    if (token && markdownConfigSurfaceTokenLooksSemantic(path, trimmed, token)) keys.add(token);
+  }
+
+  if (!isMarkdownConfigSurfacePath(path)) {
+    const property = trimmed.match(
+      /^(?:readonly\s+)?(?:"([^"]+)"|'([^']+)'|([A-Za-z_$][\w$.-]*))\??\s*:/,
+    );
+    const key = property?.[1] ?? property?.[2] ?? property?.[3];
+    if (key && isConfigSurfaceToken(key)) {
+      keys.add(pluginManifestConfigSurfaceKey(path, key));
+    }
+
+    if (/\b(?:z\.enum|Type\.Literal|enum)\b/.test(trimmed)) {
+      for (const match of trimmed.matchAll(/["']([A-Za-z0-9_.-]+)["']/g)) {
+        const token = match[1]?.trim();
+        if (token && isConfigSurfaceToken(token)) keys.add(token);
+      }
+    }
+  }
+
+  return [...keys];
+}
+
+function isMarkdownConfigSurfacePath(path: string): boolean {
+  return path.endsWith(".md") || path.endsWith(".mdx");
+}
+
+function markdownConfigSurfaceTokenLooksSemantic(
+  path: string,
+  line: string,
+  token: string,
+): boolean {
+  if (!isConfigSurfaceToken(token)) return false;
+  if (!isMarkdownConfigSurfacePath(path)) return true;
+  return /[.[\]]/.test(token) || /^[A-Z0-9_]{3,}$/.test(token) || /^\s*(?:\||[-*]\s+`)/.test(line);
+}
+
+function isConfigSurfaceToken(token: string): boolean {
+  return (
+    token.length >= 2 &&
+    token.length <= 120 &&
+    /^[A-Za-z0-9_.[\]-]+$/.test(token) &&
+    /[A-Za-z]/.test(token)
+  );
+}
+
+function pluginManifestConfigSurfaceKey(path: string, key: string): string {
+  if (!path.startsWith("src/plugins/manifest") || key.includes(".") || key === "contracts") {
+    return key;
+  }
+  return `contracts.${key}`;
+}
+
+function configSurfaceReviewRequired(markdown: string): boolean {
+  return (
+    frontMatterBoolean(markdown, "config_surface_change") ||
+    frontMatterStringArray(markdown, "config_surface_keys").length > 0
+  );
+}
+
 function prSurfaceFilesFromContext(context: ItemContext): PrSurfaceFile[] {
   if (context.counts?.pullFilesTruncated) return [];
   return (context.pullFiles ?? [])
@@ -11960,12 +12122,24 @@ export function reviewAutomationMarkersFromReport(markdown: string): string {
     `sha=${markerAttributeValue(headSha)}`,
     `confidence=${markerAttributeValue(confidence)}`,
   ].join(" ");
+  const securityNeedsAttention = reportSecurityReview(markdown).status === "needs_attention";
+  const humanReviewMarkers = (): string => {
+    const markers = [];
+    if (securityNeedsAttention) {
+      markers.push(`<!-- clawsweeper-security:security-sensitive ${baseAttrs} -->`);
+    }
+    markers.push(`<!-- clawsweeper-verdict:needs-human ${baseAttrs} -->`);
+    return markers.join("\n");
+  };
 
   if (frontMatterValue(markdown, "review_status") === "failed") {
-    return `<!-- clawsweeper-verdict:needs-human ${baseAttrs} -->`;
+    return humanReviewMarkers();
+  }
+  if (configSurfaceReviewRequired(markdown)) {
+    return humanReviewMarkers();
   }
   const hasRealBehaviorProofBlocker = realBehaviorProofBlocksMerge(markdown);
-  if (reportSecurityReview(markdown).status === "needs_attention") {
+  if (securityNeedsAttention) {
     const markers = [`<!-- clawsweeper-security:security-sensitive ${baseAttrs} -->`];
     if (!hasRealBehaviorProofBlocker && securitySensitiveRepairAllowed(markdown)) {
       markers.push(
@@ -12035,6 +12209,7 @@ function isRepairLoopPassReport(markdown: string): boolean {
     frontMatterValue(markdown, "review_status") === "complete" &&
     frontMatterValue(markdown, "confidence") === "high" &&
     frontMatterValue(markdown, "decision") === "keep_open" &&
+    !configSurfaceReviewRequired(markdown) &&
     !realBehaviorProofBlocksMerge(markdown) &&
     reportOverallCorrectness(markdown) === "patch is correct" &&
     reportReviewFindings(markdown).length === 0
@@ -12752,6 +12927,7 @@ function markdownFor(options: {
   const repairWorkPromptSection = renderRepairWorkPromptReportSection(options.decision);
   const pullFiles = pullRequestFilePathsFromContext(options.context);
   const pullFilesTruncated = Boolean(options.context.counts?.pullFilesTruncated);
+  const configSurfaceChange = configSurfaceChangeFromContext(options.item.repo, options.context);
   const prSurfaceFiles = prSurfaceFilesFromContext(options.context);
   return `---
 number: ${options.item.number}
@@ -12821,6 +12997,8 @@ review_metrics: ${JSON.stringify(options.decision.reviewMetrics)}
 label_justifications: ${JSON.stringify(options.decision.labelJustifications)}
 pull_files: ${jsonFrontMatterValue(pullFiles)}
 pull_files_truncated: ${pullFilesTruncated}
+config_surface_change: ${configSurfaceChange.change}
+config_surface_keys: ${jsonFrontMatterValue(configSurfaceChange.keys)}
 pr_surface_files: ${jsonFrontMatterValue(prSurfaceFiles)}
 pr_surface_files_truncated: ${pullFilesTruncated}
 item_category: ${options.decision.itemCategory}

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -29,6 +29,7 @@ import {
   compactMappedSlice,
   compactMappedWindow,
   compactPullRequestForTest,
+  configSurfaceChangeFromPullFilesForTest,
   codexEnv,
   dashboardClosedAt,
   extractLatestClawSweeperReviewForTest,
@@ -3105,6 +3106,235 @@ Full review comments:
   assert.doesNotMatch(comment, /Automerge follow-up:/);
   assert.match(comment, /<!-- clawsweeper-verdict:pass item=74453 sha=abc123def456/);
   assert.doesNotMatch(comment, /clawsweeper-verdict:needs-human/);
+});
+
+test("config surface reports force human review instead of automerge pass", () => {
+  const report = `${reportFrontMatter({
+    type: "pull_request",
+    number: "74454",
+    decision: "keep_open",
+    close_reason: "none",
+    review_status: "complete",
+    confidence: "high",
+    labels: JSON.stringify(["clawsweeper:automerge"]),
+    work_candidate: "none",
+    pull_head_sha: "abc123def456",
+    config_surface_change: "true",
+    config_surface_keys: JSON.stringify(["contracts.embeddingProviders"]),
+  })}
+
+## Summary
+
+Keep this config-surface PR open for maintainer review.
+
+## Review Findings
+
+Overall correctness: patch is correct
+
+Overall confidence: 0.9
+
+Full review comments:
+
+- none
+`;
+
+  const markers = reviewAutomationMarkersFromReport(report);
+
+  assert.match(markers, /clawsweeper-verdict:needs-human/);
+  assert.doesNotMatch(markers, /clawsweeper-verdict:pass/);
+  assert.doesNotMatch(markers, /clawsweeper-action:fix-required/);
+});
+
+test("config surface reports preserve security-sensitive markers", () => {
+  const report = `${reportFrontMatter({
+    type: "pull_request",
+    number: "74455",
+    decision: "keep_open",
+    close_reason: "none",
+    review_status: "complete",
+    confidence: "high",
+    labels: JSON.stringify(["clawsweeper:automerge"]),
+    work_candidate: "none",
+    pull_head_sha: "abc123def456",
+    config_surface_change: "true",
+    config_surface_keys: JSON.stringify(["unknown-config-surface-change"]),
+  })}
+
+## Summary
+
+Keep this security-sensitive config-surface PR open for maintainer review.
+
+## Security Review
+
+Status: needs_attention
+
+Summary: The config surface change may affect credential handling.
+
+Concerns:
+
+- **[high] Confirm credential scope:** \`src/config/zod-schema.ts:42\`
+  - body: The changed config default may alter credential routing.
+  - confidence: 0.91
+`;
+
+  const markers = reviewAutomationMarkersFromReport(report);
+
+  assert.match(markers, /clawsweeper-security:security-sensitive/);
+  assert.match(markers, /clawsweeper-verdict:needs-human/);
+  assert.doesNotMatch(markers, /clawsweeper-verdict:pass/);
+  assert.doesNotMatch(markers, /clawsweeper-action:fix-required/);
+});
+
+test("config surface detector finds schema and plugin manifest additions", () => {
+  const detection = configSurfaceChangeFromPullFilesForTest({
+    pullFiles: [
+      {
+        filename: "src/config/zod-schema.ts",
+        patch: "@@\n+  experimentalLocalModelLean: z.boolean().optional(),",
+      },
+      {
+        filename: "src/plugins/manifest.ts",
+        patch: "@@\n+    embeddingProviders?: PluginEmbeddingProviderContract[];",
+      },
+      {
+        filename: "docs/plugins/manifest.md",
+        patch: "@@\n+| `contracts.embeddingProviders` | Embedding provider contracts. |",
+      },
+    ],
+  });
+
+  assert.deepEqual(detection, {
+    change: true,
+    keys: ["contracts.embeddingProviders", "experimentalLocalModelLean"],
+  });
+});
+
+test("config surface detector ignores non-semantic docs wording", () => {
+  const detection = configSurfaceChangeFromPullFilesForTest({
+    pullFiles: [
+      {
+        filename: "docs/gateway/configuration.md",
+        patch: "@@\n+This section explains the existing `agents` config in clearer words.",
+      },
+      {
+        filename: "docs/plugins/manifest.md",
+        patch: "@@\n+This paragraph now describes plugin contracts more clearly.",
+      },
+    ],
+  });
+
+  assert.deepEqual(detection, { change: false, keys: [] });
+});
+
+test("config surface detector finds removed schema keys", () => {
+  const detection = configSurfaceChangeFromPullFilesForTest({
+    pullFiles: [
+      {
+        filename: "src/config/zod-schema.ts",
+        patch: "@@\n-  legacyModelProvider: z.string().optional(),",
+      },
+    ],
+  });
+
+  assert.deepEqual(detection, { change: true, keys: ["legacyModelProvider"] });
+});
+
+test("config surface detector finds schema assembly changes", () => {
+  const detection = configSurfaceChangeFromPullFilesForTest({
+    pullFiles: [
+      {
+        filename: "src/config/schema.ts",
+        patch: "@@\n+  allowedProviders: buildAllowedProviderSchema(),",
+      },
+    ],
+  });
+
+  assert.deepEqual(detection, { change: true, keys: ["allowedProviders"] });
+});
+
+test("config surface detector fails closed for schema continuation changes", () => {
+  const detection = configSurfaceChangeFromPullFilesForTest({
+    pullFiles: [
+      {
+        filename: "src/config/zod-schema.ts",
+        patch: "@@\n-    .min(1)\n+    .min(2)",
+      },
+    ],
+  });
+
+  assert.deepEqual(detection, {
+    change: true,
+    keys: ["unknown-config-surface-change"],
+  });
+});
+
+test("config surface detector fails closed for missing patches", () => {
+  const detection = configSurfaceChangeFromPullFilesForTest({
+    pullFiles: [
+      {
+        filename: "docs/plugins/manifest.md",
+      },
+      {
+        filename: "src/config/zod-schema.ts",
+        patch: "",
+      },
+    ],
+  });
+
+  assert.deepEqual(detection, {
+    change: true,
+    keys: ["unknown-config-surface-change"],
+  });
+});
+
+test("config surface detector fails closed for truncated file patches", () => {
+  const detection = configSurfaceChangeFromPullFilesForTest({
+    pullFiles: [
+      {
+        filename: "docs/gateway/configuration.md",
+        patch:
+          "@@\n+This section explains the existing `agents` config in clearer words.\n\n[truncated 120 chars]",
+      },
+    ],
+  });
+
+  assert.deepEqual(detection, {
+    change: true,
+    keys: ["unknown-config-surface-change"],
+  });
+});
+
+test("config surface detector fails closed for renamed config surface files", () => {
+  const detection = configSurfaceChangeFromPullFilesForTest({
+    pullFiles: [
+      {
+        filename: "src/legacy/zod-schema.ts",
+        previous_filename: "src/config/zod-schema.ts",
+      },
+    ],
+  });
+
+  assert.deepEqual(detection, {
+    change: true,
+    keys: ["unknown-config-surface-change"],
+  });
+});
+
+test("config surface detector fails closed for truncated pull files", () => {
+  const detection = configSurfaceChangeFromPullFilesForTest({
+    pullFilesTruncated: true,
+    pullFiles: [
+      {
+        filename: "src/config/schema.help.ts",
+        patch: '@@\n+  experimentalLocalModelLean: "Prefer lean local model routing.",',
+      },
+    ],
+  });
+
+  assert.deepEqual(detection, {
+    change: true,
+    keys: ["experimentalLocalModelLean", "unknown-truncated-pull-files"],
+  });
 });
 
 test("sufficient real behavior proof allows automerge pass markers", () => {


### PR DESCRIPTION
## Summary

ClawSweeper could still pass an automerge review after an OpenClaw PR added a public config surface.
This change records deterministic config-surface additions in the durable report and turns those reports into human-review pauses.
That makes new config keys and plugin manifest contract additions visible to maintainers before automation can merge them.

Fixes https://github.com/openclaw/clawsweeper/issues/171

## What Changed

The review report now inspects hydrated OpenClaw PR patches for additions in known config, manifest, and config-doc surfaces.
When a semantic key is detected, the report stores `config_surface_change` and `config_surface_keys` frontmatter.

- Added a conservative OpenClaw-only config-surface detector for schema, config type/help/label, plugin manifest, and relevant docs paths.
- Made review marker generation emit `clawsweeper-verdict:needs-human` when the durable config-surface flag is present.
- Blocked repair-loop pass reports from treating config-surface changes as a clean pass.
- Added regression coverage for config schema additions, plugin manifest contract additions, automerge pass blocking, and non-semantic docs wording.

## Testing

The full local check passed after installing the repo dependencies.

- `pnpm install`
- `pnpm run build`
- `node --test test/clawsweeper.test.ts`
- `pnpm run format`
- `pnpm run check`

## Risks

The detector is intentionally conservative and path-scoped to OpenClaw config surfaces.
It may pause a few borderline config-adjacent additions for maintainer review, which is safer than silently passing a new public config contract through automerge.

Live GitHub automerge was not exercised directly; the deterministic marker and pass-gate paths are covered by unit tests.
