### PR TITLE
fix: Add priority prefixes to review comments

### DIFF
--- a/docs/pr-review-comments.md
+++ b/docs/pr-review-comments.md
@@ -74,6 +74,14 @@ report has:
 - `Remaining risk:` only when it is not a restatement of the required change or
   best solution
 
+Actionable bullets in risk, finding, next-step, merge-blocking proof guidance,
+acceptance criteria, and remaining-risk text may use plain priority prefixes
+such as `[P0]`, `[P1]`, or `[P2]`. Keep those prefixes unbolded and attached to
+plain-language consequences or required actions. Do not add priority prefixes to
+audit-only details such as label justifications, AGENTS.md notes,
+Mantis/workflow notes, model metadata, related people, PR stats, or generic
+evidence lists.
+
 Full review comments, source links, owner routing, acceptance criteria, and
 evidence stay under the collapsed `Review details` block so the top-level PR
 comment reads like a concise review.

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -7009,6 +7009,13 @@ function publicPriorityFromText(text: string, fallback: PublicPriority): PublicP
   if (/\b(?:outage|data loss|security exposure|release blocker|widespread)\b/i.test(text)) {
     return "P0";
   }
+  if (
+    /\b(?:major regression|blocked workflow|compatibility(?:\s+|-)?break|fail(?:\s+|-)?closed|lifecycle break)\b/i.test(
+      text,
+    )
+  ) {
+    return "P1";
+  }
   if (/\b(?:localized|non-blocking|nonblocking|recoverable|fallback|timeout)\b/i.test(text)) {
     return "P2";
   }

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -7003,6 +7003,34 @@ function priorityLabel(priority: ReviewFinding["priority"]): string {
   return `P${priority}`;
 }
 
+type PublicPriority = "P0" | "P1" | "P2";
+
+function publicPriorityFromText(text: string, fallback: PublicPriority): PublicPriority {
+  if (/\b(?:outage|data loss|security exposure|release blocker|widespread)\b/i.test(text)) {
+    return "P0";
+  }
+  if (/\b(?:localized|non-blocking|nonblocking|recoverable|fallback|timeout)\b/i.test(text)) {
+    return "P2";
+  }
+  return fallback;
+}
+
+function stripPriorityPrefix(text: string): string {
+  return text
+    .trim()
+    .replace(/^[-*]\s+/, "")
+    .replace(/^(?:\*\*)?\[P[0-2]\](?:\*\*)?\s*/i, "")
+    .trim();
+}
+
+function publicPriorityBullet(priority: PublicPriority, text: string): string {
+  return `- [${priority}] ${stripPriorityPrefix(sentence(text))}`;
+}
+
+function publicPriorityBulletFromText(text: string, fallback: PublicPriority): string {
+  return publicPriorityBullet(publicPriorityFromText(text, fallback), text);
+}
+
 function confidenceText(score: number): string {
   return score.toFixed(2).replace(/0+$/, "").replace(/\.$/, "");
 }
@@ -7148,7 +7176,7 @@ function publicMergeReadinessBlock(rating: PrRating, proof: RealBehaviorProof): 
   const shiny = hasShinyProof(proof) ? " ✨ media proof bonus" : "";
   const proofGuidance =
     proof.status === "missing" || proof.status === "mock_only" || proof.status === "insufficient"
-      ? publicRealBehaviorProofLine(proof)
+      ? publicPriorityBullet("P1", publicRealBehaviorProofLine(proof))
       : "";
   const lines = [
     `Overall: ${themedRatingName(rating.overallTier)}`,
@@ -7159,7 +7187,13 @@ function publicMergeReadinessBlock(rating: PrRating, proof: RealBehaviorProof): 
     "Overall follows the weaker of proof and patch quality, so missing proof can cap an otherwise strong patch.",
   ];
   if (rating.nextSteps.length) {
-    lines.push("", "Rank-up moves:", ...rating.nextSteps.slice(0, 3).map((step) => `- ${step}`));
+    lines.push(
+      "",
+      "Rank-up moves:",
+      ...rating.nextSteps
+        .slice(0, 3)
+        .map((step) => publicPriorityBulletFromText(step, proofGuidance ? "P1" : "P2")),
+    );
   }
   if (proofGuidance) {
     lines.push("", "Proof guidance:", proofGuidance);
@@ -11575,7 +11609,10 @@ function publicMergeRiskLine(
   const choices = options.length
     ? mergeRiskOptionsLines(options)
     : mergeRiskFallbackOptionsLines(bestSolutionLine, nextStepLine);
-  return [risks, choices.length ? ["", "**Maintainer options:**", ...choices].join("\n") : ""]
+  return [
+    publicPriorityBulletFromText(risks, "P1"),
+    choices.length ? ["", "**Maintainer options:**", ...choices].join("\n") : "",
+  ]
     .filter(Boolean)
     .join("\n");
 }
@@ -11751,10 +11788,12 @@ function renderKeepOpenCommentFromReport(
   const reviewMetrics = reviewMetricsFromReport(markdown);
   const workReason = reportWorkCandidateReason(markdown);
   const workCandidate = frontMatterValue(markdown, "work_candidate");
+  const isPullRequest = frontMatterValue(markdown, "type") === "pull_request";
   const validation = frontMatterStringArray(markdown, "work_validation")
     .slice(0, 5)
-    .map((step) => `- ${step}`);
-  const isPullRequest = frontMatterValue(markdown, "type") === "pull_request";
+    .map((step) =>
+      isPullRequest ? publicPriorityBulletFromText(step, "P1") : `- ${stripPriorityPrefix(step)}`,
+    );
   const isRepairCandidate = workCandidate === "queue_fix_pr";
   const isRepairLoopPass = isPullRequest && Boolean(repairLoopPassModeFromReport(markdown));
   const hasRealBehaviorProofBlocker = isPullRequest && realBehaviorProofBlocksMerge(markdown);
@@ -11763,6 +11802,9 @@ function renderKeepOpenCommentFromReport(
   const fallbackNextStep =
     "Continue tracking this item until the missing behavior is implemented or a maintainer decides the product direction.";
   const nextStepLine = sentence(workReason || bestSolution || fallbackNextStep);
+  const publicNextStepLine = isPullRequest
+    ? publicPriorityBulletFromText(nextStepLine, hasRealBehaviorProofBlocker ? "P1" : "P2")
+    : nextStepLine;
   const bestSolutionLine = sentence(bestSolution);
   const mergeRiskLine = isPullRequest
     ? publicMergeRiskLine(risks, nextStepLine, bestSolutionLine, mergeRiskOptions)
@@ -11818,7 +11860,11 @@ function renderKeepOpenCommentFromReport(
     : "";
   if (mantisSuggestion) appendPublicSection(lines, "Mantis proof suggestion", mantisSuggestion);
   if (mergeRiskLine) appendPublicSection(lines, "Risk before merge", mergeRiskLine);
-  appendPublicSection(lines, isPullRequest ? "Next step before merge" : "Next step", nextStepLine);
+  appendPublicSection(
+    lines,
+    isPullRequest ? "Next step before merge" : "Next step",
+    publicNextStepLine,
+  );
   const securityLine = publicSecurityReviewLine(securityReview);
   if (securityLine) appendPublicSection(lines, "Security", securityLine);
   if (isPullRequest && reviewFindings.length) {
@@ -11906,7 +11952,7 @@ function renderKeepOpenCommentFromReport(
       ...(reviewDetails.length ? [""] : []),
       "Remaining risk / open question:",
       "",
-      risks,
+      isPullRequest ? publicPriorityBulletFromText(risks, "P2") : risks,
     );
   }
   const reviewLine = closeReviewLineFromReport(markdown);

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -7038,6 +7038,16 @@ function publicPriorityBulletFromText(text: string, fallback: PublicPriority): s
   return publicPriorityBullet(publicPriorityFromText(text, fallback), text);
 }
 
+function publicPriorityBulletsFromText(text: string, fallback: PublicPriority): string {
+  const lines = text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const bulletLines = lines.filter((line) => /^[-*]\s+/.test(line));
+  if (!bulletLines.length) return publicPriorityBulletFromText(text, fallback);
+  return bulletLines.map((line) => publicPriorityBulletFromText(line, fallback)).join("\n");
+}
+
 function confidenceText(score: number): string {
   return score.toFixed(2).replace(/0+$/, "").replace(/\.$/, "");
 }
@@ -11617,7 +11627,7 @@ function publicMergeRiskLine(
     ? mergeRiskOptionsLines(options)
     : mergeRiskFallbackOptionsLines(bestSolutionLine, nextStepLine);
   return [
-    publicPriorityBulletFromText(risks, "P1"),
+    publicPriorityBulletsFromText(risks, "P1"),
     choices.length ? ["", "**Maintainer options:**", ...choices].join("\n") : "",
   ]
     .filter(Boolean)
@@ -11959,7 +11969,7 @@ function renderKeepOpenCommentFromReport(
       ...(reviewDetails.length ? [""] : []),
       "Remaining risk / open question:",
       "",
-      isPullRequest ? publicPriorityBulletFromText(risks, "P2") : risks,
+      isPullRequest ? publicPriorityBulletsFromText(risks, "P2") : risks,
     );
   }
   const reviewLine = closeReviewLineFromReport(markdown);

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -3035,6 +3035,7 @@ Reason: The fix is narrow and can be made on the PR branch.
     comment,
     /\*\*Review findings\*\*\n- \[P1\] Validate replace paths — `src\/config\/apply\.ts:42-44`/,
   );
+  assert.doesNotMatch(comment, /\*\*\[P[0-2]\]\*\*/);
   assert.match(comment, /Full review comments:/);
   assert.match(comment, /A misspelled replace path is currently ignored/);
   assert.match(comment, /Overall correctness: patch is incorrect/);
@@ -3069,7 +3070,7 @@ Land this docs-only PR after maintainer review.
 
   assert.match(
     comment,
-    /\*\*Next step before merge\*\*\nLand this docs-only PR after maintainer review\./,
+    /\*\*Next step before merge\*\*\n- \[P2\] Land this docs-only PR after maintainer review\./,
   );
   assert.doesNotMatch(comment, /Best possible solution:/);
 });
@@ -3113,7 +3114,10 @@ Full review comments:
   );
 
   assert.match(comment, /Codex review: passed\./);
-  assert.match(comment, /\*\*Next step before merge\*\*\nMerge after required checks are green\./);
+  assert.match(
+    comment,
+    /\*\*Next step before merge\*\*\n- \[P2\] Merge after required checks are green\./,
+  );
   assert.doesNotMatch(comment, /Automerge follow-up:/);
   assert.match(comment, /<!-- clawsweeper-verdict:pass item=74453 sha=abc123def456/);
   assert.doesNotMatch(comment, /clawsweeper-verdict:needs-human/);
@@ -3466,7 +3470,7 @@ Full review comments:
     comment,
     /Overall follows the weaker of proof and patch quality, so missing proof can cap an otherwise strong patch\./,
   );
-  assert.match(comment, /Proof guidance:\nNeeds real behavior proof before merge:/);
+  assert.match(comment, /Proof guidance:\n- \[P1\] Needs real behavior proof before merge:/);
   assert.match(comment, /The PR has no real ingestion-run proof yet\./);
   assert.match(comment, /After adding proof, update the PR body/);
   assert.match(comment, /@clawsweeper re-review/);
@@ -5269,7 +5273,7 @@ Full review comments:
   assert.match(comment, /Codex review: passed\./);
   assert.match(
     comment,
-    /\*\*Next step before merge\*\*\nLeave this draft open after fixes are complete\./,
+    /\*\*Next step before merge\*\*\n- \[P2\] Leave this draft open after fixes are complete\./,
   );
   assert.doesNotMatch(comment, /Autofix follow-up:/);
   assert.match(comment, /<!-- clawsweeper-verdict:pass item=74610 sha=abc123def456/);
@@ -11159,7 +11163,7 @@ Reason: ${duplicateRisk}
     "none",
   );
 
-  assert.ok(comment.includes(`**Next step before merge**\n${duplicateRisk}`));
+  assert.ok(comment.includes(`**Next step before merge**\n- [P2] ${duplicateRisk}`));
   assert.doesNotMatch(comment, /Remaining risk \/ open question:/);
   assert.doesNotMatch(comment, /\*\*Risk before merge\*\*/);
   assert.equal(comment.split(duplicateRisk).length - 1, 1);

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -11202,6 +11202,43 @@ Reason: ${duplicateRisk}
   assert.equal(comment.split(duplicateRisk).length - 1, 1);
 });
 
+test("pull request keep-open review comments prefix each merge risk bullet", () => {
+  const comment = renderReviewCommentFromReport(
+    `${reportFrontMatter({
+      type: "pull_request",
+      number: "74269",
+      decision: "keep_open",
+      close_reason: "none",
+      work_candidate: "none",
+      pull_head_sha: "abc123def456",
+    })}
+
+## Summary
+
+Keep this multi-risk PR open for maintainer review.
+
+## What This Changes
+
+Changes generated review-comment formatting.
+
+## Best Possible Solution
+
+Confirm both merge risks before merge.
+
+## Risks / Open Questions
+
+- Blocked workflow actions must render as P1.
+- Timeout fallback wording should remain scannable.
+`,
+    "none",
+  );
+
+  assert.match(comment, /\*\*Risk before merge\*\*/);
+  assert.match(comment, /- \[P1\] Blocked workflow actions must render as P1\./);
+  assert.match(comment, /- \[P2\] Timeout fallback wording should remain scannable\./);
+  assert.doesNotMatch(comment, /- \[P1\] Blocked workflow actions.*\n- Timeout fallback/s);
+});
+
 test("OpenClaw pull request comments render PR surface inside evidence details", () => {
   const comment = renderReviewCommentFromReport(
     `${reportFrontMatter({

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -3075,6 +3075,39 @@ Land this docs-only PR after maintainer review.
   assert.doesNotMatch(comment, /Best possible solution:/);
 });
 
+test("pull request next-step priority prefixes classify fail-closed work as P1", () => {
+  const comment = renderReviewCommentFromReport(
+    `${reportFrontMatter({
+      type: "pull_request",
+      number: "74268",
+      decision: "keep_open",
+      close_reason: "none",
+      work_candidate: "none",
+      pull_head_sha: "abc123def456",
+    })}
+
+## Summary
+
+Keep this compatibility PR open for maintainer review.
+
+## What This Changes
+
+Changes relay restart handling.
+
+## Best Possible Solution
+
+Prove the fail-closed compatibility break is handled before merge.
+`,
+    "none",
+  );
+
+  assert.match(
+    comment,
+    /\*\*Next step before merge\*\*\n- \[P1\] Prove the fail-closed compatibility break is handled before merge\./,
+  );
+  assert.doesNotMatch(comment, /\*\*\[P1\]\*\*/);
+});
+
 test("pull request automerge review comments can emit pass verdicts", () => {
   const comment = renderReviewCommentFromReport(
     `${reportFrontMatter({


### PR DESCRIPTION
## Summary
- add plain [P0]/[P1]/[P2] prefixes to actionable PR review comment bullets
- keep audit-only details, labels, comment shape, and durable markers unchanged
- classify fail-closed, compatibility-break, blocked-workflow, major-regression, and lifecycle-break language as P1
- prefix each merge-risk/open-question bullet independently when a report has multiple risk bullets
- document the plain-prefix rule for review comments

Closes https://github.com/openclaw/clawsweeper/issues/211

## Rendered proof
Generated locally from the built renderer after the P1 classifier fix:

```md
**Merge readiness**
Overall: 🧂 unranked krab
Proof: 🧂 unranked krab
Patch quality: 🌊 off-meta tidepool
Result: blocked until real behavior proof is added.

Rank-up moves:
- [P1] Add after-fix proof from a real setup, such as a short recording, terminal output, linked artifact, or redacted logs.

Proof guidance:
- [P1] Needs real behavior proof before merge: No rendered-comment proof was supplied. After adding proof, update the PR body; ClawSweeper should re-review automatically.

**Next step before merge**
- [P1] Prove the fail-closed compatibility break is handled before merge.
```

## Validation
- node_modules/.bin/tsgo -p tsconfig.json
- node --test --test-name-pattern "review comments|real behavior proof|merge risk|next-step priority" test/clawsweeper.test.ts
- node --test test/*.test.ts
- node_modules/.bin/oxfmt --check src/clawsweeper.ts test/clawsweeper.test.ts docs/pr-review-comments.md
- git diff --check