### PR TITLE
Restrict PR eggs to the OpenClaw product repo

### DIFF
--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -512,7 +512,7 @@ function classifyGithubIssueCommentWebhook({ event, payload }) {
   if (!isEligibleGithubWebhookRepository(repo)) {
     return { accepted: false, reason: "repository not eligible" };
   }
-  if (isGithubWebhookHatchCommand(comment) && !isOpenClawRepo(targetRepo)) {
+  if (isGithubWebhookHatchCommand(comment) && !isOpenClawProductRepo(targetRepo)) {
     return { accepted: false, reason: "PR egg is disabled for this repo" };
   }
   const itemNumber = Number(issue.number);
@@ -612,11 +612,12 @@ function isEligibleGithubWebhookRepository(repo) {
   return owner === "openclaw" || owner === "steipete";
 }
 
-function isOpenClawRepo(repo) {
-  return String(repo || "")
-    .trim()
-    .toLowerCase()
-    .startsWith("openclaw/");
+function isOpenClawProductRepo(repo) {
+  return (
+    String(repo || "")
+      .trim()
+      .toLowerCase() === "openclaw/openclaw"
+  );
 }
 
 function targetDefaultBranch(repo) {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -12589,8 +12589,15 @@ function upsertHatchComment(
   dryRun: boolean,
 ): Record<string, unknown> | undefined {
   const body = renderHatchComment(number, markdown, statusKind);
-  if (!body) return issueCommentWithMarker(number, hatchCommentMarker(number));
   const existing = issueCommentWithMarker(number, hatchCommentMarker(number));
+  if (!body) {
+    const id = commentId(existing);
+    if (!dryRun && id !== null && canPatchReviewComment(existing)) {
+      ghWithRetry(["api", `repos/${targetRepo()}/issues/comments/${id}`, "--method", "DELETE"]);
+      return undefined;
+    }
+    return existing;
+  }
   const id = commentId(existing);
   if (dryRun) return existing;
   const payload = writeCommentPayload(number, body);
@@ -14038,12 +14045,13 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       reviewSectionValue(markdown, "closeComment"),
     ]);
     const markedReviewComment = markedReviewCommentBody(number, reviewComment);
+    const prEggEnabled = item.kind === "pull_request" && isOpenClawProductRepo(repo);
     const prEggComment =
-      item.kind === "pull_request" && !isCloseProposal && isOpenClawProductRepo(repo)
+      item.kind === "pull_request" && !isCloseProposal && prEggEnabled
         ? renderHatchComment(number, markdown, currentPrStatusKind)
         : "";
     const existingPrEggComment =
-      item.kind === "pull_request" && !isCloseProposal && isOpenClawProductRepo(repo)
+      item.kind === "pull_request" && !isCloseProposal
         ? issueCommentWithMarker(number, hatchCommentMarker(number))
         : undefined;
     const protectedApplyReason = applyProtectedLabelReason(item.labels, closeReason);
@@ -14246,9 +14254,10 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       frontMatterValue(markdown, "review_comment_url") === "unknown";
     const needsPrEggCommentSync =
       item.kind === "pull_request" &&
-      isOpenClawProductRepo(repo) &&
       !isCloseProposal &&
-      !commentBodyMatches(existingPrEggComment, prEggComment);
+      (prEggEnabled
+        ? !commentBodyMatches(existingPrEggComment, prEggComment)
+        : Boolean(existingPrEggComment));
     const needsReviewCommentSync = shouldSyncReviewComment({
       syncCommentsOnly,
       isCloseProposal,
@@ -14327,13 +14336,17 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       if (needsPrEggCommentSync) {
         if (dryRun) {
           syncReasons.push(
-            existingPrEggComment
-              ? "would update durable PR egg comment"
-              : "would create durable PR egg comment",
+            prEggEnabled
+              ? existingPrEggComment
+                ? "would update durable PR egg comment"
+                : "would create durable PR egg comment"
+              : "would remove disabled PR egg comment",
           );
         } else {
           upsertHatchComment(number, markdown, currentPrStatusKind, dryRun);
-          syncReasons.push("synced durable PR egg comment");
+          syncReasons.push(
+            prEggEnabled ? "synced durable PR egg comment" : "removed disabled PR egg comment",
+          );
         }
       }
       if (needsReviewCommentSync) {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -1506,12 +1506,12 @@ function targetRepo(): string {
   return activeRepositoryProfile.targetRepo;
 }
 
-function isOpenClawRepo(repo: string | null | undefined): boolean {
-  return normalizeRepo(String(repo ?? "")).startsWith("openclaw/");
+function isOpenClawProductRepo(repo: string | null | undefined): boolean {
+  return normalizeRepo(String(repo ?? "")) === "openclaw/openclaw";
 }
 
 function prEggEnabledForMarkdown(markdown: string): boolean {
-  return isOpenClawRepo(markdownRepository(markdown));
+  return isOpenClawProductRepo(markdownRepository(markdown));
 }
 
 function setTargetRepo(targetRepoName: string): RepositoryProfile {
@@ -7257,14 +7257,13 @@ function publicPrEggLine(
 ): string {
   if (!prEggProofUnlocked(options.realBehaviorProof)) {
     return [
-      "🎁 Pass real behavior proof to wake the egg and unlock a hatchable treat.",
+      "ClawSweeper PR egg: 🎁 locked until real behavior proof passes.",
       "",
       "<details>",
-      "<summary>Where did the egg go?</summary>",
+      "<summary>Details</summary>",
       "",
-      "- The egg game starts only after the PR passes the real-behavior proof check.",
-      "- Before that, no creature or rarity is rolled. The treat waits for real proof.",
-      "- This is still just collectible flavor: proof affects review readiness, not creature quality.",
+      "- No creature or rarity is rolled until proof passes.",
+      "- Eggs are collectible flavor only; they do not affect labels, ratings, merge decisions, or automation.",
       "",
       "</details>",
     ].join("\n");
@@ -7274,24 +7273,19 @@ function publicPrEggLine(
   const visualSeed = prEggVisualSeedFromReport(markdown);
   const renderStatusKind = prEggRenderStatusKind(markdown, options.statusKind);
   const state = prEggStateFromStatus(renderStatusKind);
-  const hatchInstruction = [
-    "### Hatch command",
-    "",
-    "Comment `@clawsweeper hatch` when this PR is hatchable.",
-    "",
-    "Hatchability rules:",
-    "- Merged PRs are hatchable.",
-    "- Open PRs are hatchable when they are `status: 👀 ready for maintainer look`, `status: 🚀 automerge armed`, or labeled `clawsweeper:automerge`.",
-    "- Closed unmerged PRs are hatchable only when one of those hatchable labels is still present in the durable record.",
-  ].join("\n");
   const explainer = [
     "",
     "<details>",
-    "<summary>What is this egg doing here?</summary>",
+    "<summary>Rules and details</summary>",
     "",
-    "- Eggs appear after the PR passes real-behavior proof. It is here for vibes, not verdicts: it does not change labels, ratings, merge decisions, or automation.",
-    "- The shell reacts to review momentum: open follow-up work warms it up, re-review makes it wobble, and a clean final review lets it hatch.",
-    "- Hatchability usually comes from sufficient real-behavior proof, no blocking P0/P1/P2 findings, no security attention needed, and clean correctness. A merged PR is already final, so merge makes the egg hatchable independently.",
+    "Hatchability:",
+    "- Merged PRs are hatchable.",
+    "- Open PRs are hatchable when they are `status: 👀 ready for maintainer look`, `status: 🚀 automerge armed`, or labeled `clawsweeper:automerge`.",
+    "- Closed unmerged PRs are hatchable only when one of those hatchable labels is still present in the durable record.",
+    "",
+    "About:",
+    "- Eggs appear after real-behavior proof passes. They are collectible flavor only.",
+    "- Review momentum changes the shell state: follow-up work warms it, re-review makes it wobble, and a clean final review lets it hatch.",
     "- The hatch is seeded from this repository and PR number, so the same PR keeps the same creature; the reviewed head SHA can only change safe visual details.",
     "- Rarity is just collectible sparkle: 🥚 common, 🌱 uncommon, 💎 rare, ✨ glimmer, and 🌈 legendary.",
     "",
@@ -7311,26 +7305,26 @@ function publicPrEggLine(
       creature.shareText,
     )}&url=${encodeURIComponent(prEggShareTargetUrl(markdown))}`;
     return [
-      `✨ Hatched: ${creature.rarityLabel} ${creature.name}`,
+      `ClawSweeper PR egg: ✨ hatched ${creature.rarityLabel} ${creature.name}. Rarity: ${creature.rarityLabel}. Trait: ${creature.trait}.`,
+      "",
+      "<details>",
+      "<summary>Details</summary>",
       "",
       ...imageBlock,
-      hatchInstruction,
-      "",
-      `Rarity: ${creature.rarityLabel}.`,
-      `Trait: ${creature.trait}.`,
-      `Image traits: location ${creature.imageTraits.location}; accessory ${creature.imageTraits.accessory}; palette ${creature.imageTraits.palette}; mood ${creature.imageTraits.mood}; pose ${creature.imageTraits.pose}; shell ${creature.imageTraits.texture}; lighting ${creature.imageTraits.lighting}; background ${creature.imageTraits.backgroundDetail}.`,
       `Share on X: ${markdownLink("post this hatch", shareUrl)}`,
       `Copy: ${creature.shareText}`,
-      ...explainer,
+      ...explainer.slice(4),
     ].join("\n");
   }
   const stateLines: Record<Exclude<PrEggState, "hatched">, string> = {
-    incubating: "🥚 Incubating: this PR egg is tucked into the review nest.",
-    warming:
-      "🔥 Warming up: real-behavior proof passed; findings, security review, or rank-up moves are still in progress.",
-    wobbling: "🔁 Wobbling: a re-review loop is active, so the shell is rattling.",
+    incubating: "🥚 incubating until a hatchable PR state.",
+    warming: "🔥 warming; proof passed, review follow-up or readiness checks remain.",
+    wobbling: "🔁 wobbling during re-review.",
   };
-  return [stateLines[state], "", hatchInstruction, ...explainer].join("\n");
+  return [
+    `ClawSweeper PR egg: ${stateLines[state]} Hatch with \`@clawsweeper hatch\` when eligible.`,
+    ...explainer,
+  ].join("\n");
 }
 
 function publicPrEggLineFromReport(
@@ -7358,7 +7352,7 @@ function publicPrEggLineFromReport(
 
 function prEggImageRelativePath(markdown: string): string {
   const repo = markdownRepository(markdown);
-  if (!isOpenClawRepo(repo)) throw new Error(`PR egg is disabled for target repo: ${repo}`);
+  if (!isOpenClawProductRepo(repo)) throw new Error(`PR egg is disabled for target repo: ${repo}`);
   const profile = repositoryProfileFor(repo);
   const number = frontMatterValue(markdown, "number") ?? "unknown";
   return `assets/pr-eggs/${profile.slug}/${number}.png`;
@@ -12583,13 +12577,9 @@ function renderHatchComment(
   statusKind: PrStatusLabelKind | null | undefined,
 ): string {
   if (!prEggEnabledForMarkdown(markdown)) return "";
-  return [
-    "ClawSweeper PR egg",
-    "",
-    publicPrEggLineFromReport(markdown, statusKind),
-    "",
-    hatchCommentMarker(number),
-  ].join("\n");
+  return [publicPrEggLineFromReport(markdown, statusKind), "", hatchCommentMarker(number)].join(
+    "\n",
+  );
 }
 
 function upsertHatchComment(
@@ -13497,7 +13487,11 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
     if (processedCount % progressEvery === 0) logProgress(message);
   };
   const recordMissingHatchResults = (existingNumbers: Set<number>): void => {
-    if (!hatchPrEggImage || requestedItemNumbers.length === 0 || !isOpenClawRepo(targetRepo()))
+    if (
+      !hatchPrEggImage ||
+      requestedItemNumbers.length === 0 ||
+      !isOpenClawProductRepo(targetRepo())
+    )
       return;
     for (const number of requestedItemNumbers) {
       if (existingNumbers.has(number)) continue;
@@ -13845,7 +13839,7 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       return result;
     };
     if (hatchOnly) {
-      if (!isOpenClawRepo(repo)) {
+      if (!isOpenClawProductRepo(repo)) {
         results.push({ number, action: "kept_open", reason: "PR egg is disabled for this repo" });
         processedCount += 1;
         maybeLogProgress(`skipped PR egg image #${number}: disabled for repo ${repo}`);
@@ -14045,11 +14039,11 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
     ]);
     const markedReviewComment = markedReviewCommentBody(number, reviewComment);
     const prEggComment =
-      item.kind === "pull_request" && !isCloseProposal && isOpenClawRepo(repo)
+      item.kind === "pull_request" && !isCloseProposal && isOpenClawProductRepo(repo)
         ? renderHatchComment(number, markdown, currentPrStatusKind)
         : "";
     const existingPrEggComment =
-      item.kind === "pull_request" && !isCloseProposal && isOpenClawRepo(repo)
+      item.kind === "pull_request" && !isCloseProposal && isOpenClawProductRepo(repo)
         ? issueCommentWithMarker(number, hatchCommentMarker(number))
         : undefined;
     const protectedApplyReason = applyProtectedLabelReason(item.labels, closeReason);
@@ -14252,7 +14246,7 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       frontMatterValue(markdown, "review_comment_url") === "unknown";
     const needsPrEggCommentSync =
       item.kind === "pull_request" &&
-      isOpenClawRepo(repo) &&
+      isOpenClawProductRepo(repo) &&
       !isCloseProposal &&
       !commentBodyMatches(existingPrEggComment, prEggComment);
     const needsReviewCommentSync = shouldSyncReviewComment({

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -345,7 +345,7 @@ function classifyCommand(command: LooseRecord): JsonValue {
   if (command.comment_version_key && processedCommentVersions.has(command.comment_version_key)) {
     return { ...command, status: "skipped", reason: "comment version already processed in ledger" };
   }
-  if (command.intent === "hatch" && !isOpenClawRepo(String(command.repo ?? ""))) {
+  if (command.intent === "hatch" && !isOpenClawProductRepo(String(command.repo ?? ""))) {
     return { ...command, status: "ignored", reason: "PR egg is disabled for this repo" };
   }
   let authorization: LooseRecord | null = null;
@@ -783,8 +783,8 @@ function classifyCommand(command: LooseRecord): JsonValue {
   };
 }
 
-function isOpenClawRepo(repo: string): boolean {
-  return repo.trim().toLowerCase().startsWith("openclaw/");
+function isOpenClawProductRepo(repo: string): boolean {
+  return repo.trim().toLowerCase() === "openclaw/openclaw";
 }
 
 function classifyAutoclose(command: LooseRecord, issue: LooseRecord, pull: LooseRecord): JsonValue {

--- a/src/repair/comment-webhook.ts
+++ b/src/repair/comment-webhook.ts
@@ -180,7 +180,7 @@ export function classifyIssueCommentWebhook({
   if (!isEligibleRepositoryPayload(repo)) {
     return { accepted: false, reason: "repository not eligible" };
   }
-  if (parsedCommand?.intent === "hatch" && !isOpenClawRepo(targetRepo)) {
+  if (parsedCommand?.intent === "hatch" && !isOpenClawProductRepo(targetRepo)) {
     return { accepted: false, reason: "PR egg is disabled for this repo" };
   }
   const staleReason = staleClosedItemCommandReason({
@@ -290,8 +290,8 @@ function isEligibleRepositoryPayload(repo: LooseRecord) {
   }
 }
 
-function isOpenClawRepo(repo: string) {
-  return repo.trim().toLowerCase().startsWith("openclaw/");
+function isOpenClawProductRepo(repo: string) {
+  return repo.trim().toLowerCase() === "openclaw/openclaw";
 }
 
 function targetDefaultBranch(repo: LooseRecord) {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -6671,6 +6671,166 @@ if (args[0] === "api" && /\\/issues\\/74477$/.test(path)) {
     assert.match(eggBody, /^ClawSweeper PR egg: ✨ hatched [^\n]+/);
     assert.match(eggBody, /clawsweeper-pr-egg-hatch:74477/);
     assert.doesNotMatch(eggBody, /<img src=/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("normal PR comment sync removes disabled PR egg comments outside product repo", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const logPath = join(root, "gh.log");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    writeFileSync(
+      join(itemsDir, "74481.md"),
+      `${reportFrontMatter({
+        repository: "openclaw/clawsweeper",
+        type: "pull_request",
+        number: "74481",
+        title: "Remove disabled egg",
+        url: "https://github.com/openclaw/clawsweeper/pull/74481",
+        decision: "keep_open",
+        close_reason: "none",
+        confidence: "high",
+        action_taken: "kept_open",
+        review_status: "complete",
+        local_checkout_access: "verified",
+        author: "contributor",
+        author_association: "CONTRIBUTOR",
+        labels: JSON.stringify(["proof: sufficient"]),
+        item_snapshot_hash: "snapshot-a",
+        item_updated_at: "2026-05-19T20:00:00Z",
+        pull_head_sha: "abc123def456",
+      })}
+
+## Summary
+
+This PR should not keep an egg comment.
+
+${realBehaviorProofReportSection()}
+
+${prRatingReportSection()}
+
+## Review Findings
+
+Overall correctness: patch is correct
+
+Overall confidence: 0.9
+
+Full review comments:
+
+- none
+`,
+      "utf8",
+    );
+
+    const ghMock = `
+const { appendFileSync, readFileSync } = require("fs");
+const logPath = ${JSON.stringify(logPath)};
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+appendFileSync(logPath, JSON.stringify(args) + "\\n");
+const path = args[1] || "";
+if (args[0] === "api" && /\\/issues\\/74481$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 74481,
+    title: "Remove disabled egg",
+    html_url: "https://github.com/openclaw/clawsweeper/pull/74481",
+    created_at: "2026-05-19T19:00:00Z",
+    updated_at: "2026-05-19T20:00:00Z",
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "contributor" },
+    labels: ["proof: sufficient"],
+    pull_request: {}
+  }));
+} else if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/74481\\/timeline(?:\\?|$)/.test(args[2] || "")) {
+  console.log("HTTP/2 200\\n\\n[]");
+} else if (args[0] === "api" && /\\/issues\\/74481\\/timeline(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/pulls\\/74481$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 74481,
+    html_url: "https://github.com/openclaw/clawsweeper/pull/74481",
+    state: "open",
+    changed_files: 1,
+    commits: 1,
+    review_comments: 0,
+    head: { sha: "abc123def456", ref: "branch", repo: { full_name: "fork/clawsweeper" } },
+    base: { sha: "base-sha", ref: "main", repo: { full_name: "openclaw/clawsweeper" } },
+    user: { login: "contributor" }
+  }));
+} else if (args[0] === "api" && /\\/pulls\\/74481\\/(files|commits|comments)(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/issues\\/74481\\/comments(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[
+    {
+      id: 555,
+      html_url: "https://github.com/openclaw/clawsweeper/pull/74481#issuecomment-555",
+      body: "Codex review: stale body\\n\\n<!-- clawsweeper-review item=74481 -->",
+      user: { login: "clawsweeper" },
+      created_at: "2026-05-19T19:55:00Z",
+      updated_at: "2026-05-19T19:55:00Z"
+    },
+    {
+      id: 666,
+      html_url: "https://github.com/openclaw/clawsweeper/pull/74481#issuecomment-666",
+      body: "ClawSweeper PR egg\\n\\nold egg\\n\\n<!-- clawsweeper-pr-egg-hatch:74481 -->",
+      user: { login: "clawsweeper" },
+      created_at: "2026-05-19T19:56:00Z",
+      updated_at: "2026-05-19T19:56:00Z"
+    }
+  ]]));
+} else if (args[0] === "api" && /\\/issues\\/comments\\/555$/.test(path)) {
+  const input = args[args.indexOf("--input") + 1];
+  appendFileSync(logPath, JSON.stringify(["patched-review-body", JSON.parse(readFileSync(input, "utf8")).body]) + "\\n");
+  console.log(JSON.stringify({ id: 555, html_url: "https://github.com/openclaw/clawsweeper/pull/74481#issuecomment-555" }));
+} else if (args[0] === "api" && /\\/issues\\/comments\\/666$/.test(path)) {
+  appendFileSync(logPath, JSON.stringify(["deleted-egg-comment", args.includes("DELETE")]) + "\\n");
+  console.log("{}");
+} else if (args[0] === "label" || args[0] === "issue") {
+  appendFileSync(logPath, JSON.stringify(["label-or-issue-command", ...args]) + "\\n");
+  console.log("{}");
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        targetRepo: "openclaw/clawsweeper",
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: ["--sync-comments-only", "--item-numbers", "74481", "--processed-limit", "10"],
+      });
+    });
+
+    assert.deepEqual(JSON.parse(readFileSync(reportPath, "utf8")), [
+      {
+        number: 74481,
+        action: "review_comment_synced",
+        reason: "updated durable Codex review comment; removed disabled PR egg comment",
+      },
+    ]);
+    const calls = readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as string[]);
+    assert.equal(
+      calls.some((args) => args[0] === "deleted-egg-comment" && args[1] === true),
+      true,
+    );
     assert.equal(
       calls.some((args) => args[0] === "unexpected-label-or-issue-command"),
       false,

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -4002,17 +4002,16 @@ Full review comments:
   assert.doesNotMatch(comment, /\*\*PR egg\*\*/);
   assert.match(comment, /\*\*Merge readiness\*\*/);
   assert.match(eggComment, /ClawSweeper PR egg/);
-  assert.match(eggComment, /🎁 Pass real behavior proof/);
-  assert.match(eggComment, /wake the egg and unlock a hatchable treat/);
-  assert.match(eggComment, /<summary>Where did the egg go\?<\/summary>/);
-  assert.match(eggComment, /no creature or rarity is rolled/);
+  assert.match(eggComment, /ClawSweeper PR egg: 🎁 locked until real behavior proof passes\./);
+  assert.match(eggComment, /<summary>Details<\/summary>/);
+  assert.match(eggComment, /No creature or rarity is rolled until proof passes/);
   assert.doesNotMatch(eggComment, /```text/);
-  assert.doesNotMatch(eggComment, /🔥 Warming up:/);
-  assert.doesNotMatch(eggComment, /✨ Hatched:/);
+  assert.doesNotMatch(eggComment, /🔥 warming;/);
+  assert.doesNotMatch(eggComment, /✨ hatched/);
   assert.doesNotMatch(eggComment, /Share on X:/);
 });
 
-test("PR egg comment is hidden outside OpenClaw repositories", () => {
+test("PR egg comment is hidden outside the OpenClaw product repository", () => {
   const report = `${reportFrontMatter({
     repository: "steipete/summarize",
     type: "pull_request",
@@ -4064,6 +4063,12 @@ Full review comments:
   const eggComment = renderPrEggCommentForTest(74470, report, "ready_for_maintainer_look");
 
   assert.equal(eggComment, "");
+
+  const orgRepoReport = report.replace(
+    "repository: steipete/summarize",
+    "repository: openclaw/clawsweeper",
+  );
+  assert.equal(renderPrEggCommentForTest(74470, orgRepoReport, "ready_for_maintainer_look"), "");
 });
 
 test("PR egg comment renders warming PR egg from active status after proof passes", () => {
@@ -4131,26 +4136,24 @@ Full review comments:
   assert.match(eggComment, /ClawSweeper PR egg/);
   assert.match(
     eggComment,
-    /🔥 Warming up: real-behavior proof passed; findings, security review, or rank-up moves are still in progress\./,
+    /🔥 warming; proof passed, review follow-up or readiness checks remain\./,
   );
   assert.doesNotMatch(eggComment, /```text/);
-  assert.match(eggComment, /<summary>What is this egg doing here\?<\/summary>/);
-  assert.match(eggComment, /Eggs appear after the PR passes real-behavior proof/);
-  assert.match(eggComment, /It is here for vibes, not verdicts/);
+  assert.match(eggComment, /<summary>Rules and details<\/summary>/);
+  assert.match(eggComment, /Eggs appear after real-behavior proof passes/);
+  assert.match(eggComment, /collectible flavor only/);
   assert.match(
     eggComment,
-    /🔥 Warming up:[\s\S]+### Hatch command[\s\S]+Hatchability rules:[\s\S]+- Merged PRs are hatchable\.[\s\S]+- Open PRs are hatchable when they are `status: 👀 ready for maintainer look`, `status: 🚀 automerge armed`, or labeled `clawsweeper:automerge`\.[\s\S]+- Closed unmerged PRs are hatchable only when one of those hatchable labels is still present in the durable record\./,
+    /^ClawSweeper PR egg: 🔥 warming; proof passed, review follow-up or readiness checks remain\. Hatch with `@clawsweeper hatch` when eligible\./,
   );
   assert.match(
     eggComment,
-    /Hatchability usually comes from sufficient real-behavior proof, no blocking P0\/P1\/P2 findings/,
+    /Hatchability:[\s\S]+- Merged PRs are hatchable\.[\s\S]+- Open PRs are hatchable when they are `status: 👀 ready for maintainer look`, `status: 🚀 automerge armed`, or labeled `clawsweeper:automerge`\.[\s\S]+- Closed unmerged PRs are hatchable only when one of those hatchable labels is still present in the durable record\./,
   );
-  assert.match(eggComment, /no security attention needed, and clean correctness/);
-  assert.match(eggComment, /Comment `@clawsweeper hatch` when this PR is/);
   assert.match(eggComment, /🥚 common, 🌱 uncommon, 💎 rare, ✨ glimmer, and 🌈 legendary/);
-  assert.doesNotMatch(eggComment, /🎁 Pass real behavior proof/);
+  assert.doesNotMatch(eggComment, /🎁 Egg locked/);
   assert.doesNotMatch(eggComment, /proof, findings, or rank-up moves are still in progress/);
-  assert.doesNotMatch(eggComment, /✨ Hatched:/);
+  assert.doesNotMatch(eggComment, /✨ hatched/);
   assert.doesNotMatch(eggComment, /Share on X:/);
 });
 
@@ -4211,15 +4214,12 @@ Full review comments:
 
   assert.doesNotMatch(reviewComment, /\*\*PR egg\*\*/);
   assert.match(first, /ClawSweeper PR egg/);
-  assert.match(first, /✨ Hatched: [^\n]+/);
+  assert.match(first, /✨ hatched [^\n]+/);
   assert.doesNotMatch(first, /```text/);
-  assert.match(first, /### Hatch command/);
+  assert.match(first, /^ClawSweeper PR egg: ✨ hatched [^\n]+\. Rarity: [^\n]+\. Trait: [^\n]+\./);
   assert.match(first, /Rarity: [^\n]+\./);
   assert.match(first, /Trait: [^.]+\./);
-  assert.match(
-    first,
-    /Image traits: location [^;]+; accessory [^;]+; palette [^;]+; mood [^;]+; pose [^;]+; shell [^;]+; lighting [^;]+; background [^.]+\./,
-  );
+  assert.doesNotMatch(first, /Image traits:/);
   assert.match(
     first,
     /Share on X: \[post this hatch\]\(https:\/\/x\.com\/intent\/tweet\?text=[^)]+&url=https%3A%2F%2Fgithub\.com%2Fopenclaw%2Fopenclaw%2Fpull%2F74471%23issuecomment-987654321\)/,
@@ -4227,7 +4227,7 @@ Full review comments:
   assert.match(first, /Copy: My PR egg hatched a [^\n]+ in ClawSweeper\./);
   assert.match(
     first,
-    /### Hatch command[\s\S]+Merged PRs are hatchable\.[\s\S]+Closed unmerged PRs are hatchable only when one of those hatchable labels is still present in the durable record\.[\s\S]+Rarity:/,
+    /<summary>Details<\/summary>[\s\S]+Share on X:[\s\S]+Hatchability:[\s\S]+Merged PRs are hatchable\.[\s\S]+Closed unmerged PRs are hatchable only when one of those hatchable labels is still present in the durable record\./,
   );
   assert.match(first, /same PR keeps the same creature/);
   assert.equal(first, second);
@@ -4292,10 +4292,9 @@ Full review comments:
     "ready_for_maintainer_look",
   );
 
-  assert.equal(first.match(/✨ Hatched: [^\n]+/)?.[0], second.match(/✨ Hatched: [^\n]+/)?.[0]);
+  assert.equal(first.match(/✨ hatched [^\n]+/)?.[0], second.match(/✨ hatched [^\n]+/)?.[0]);
   assert.equal(first.match(/Rarity: [^\n]+/)?.[0], second.match(/Rarity: [^\n]+/)?.[0]);
   assert.equal(first.match(/Trait: [^\n]+/)?.[0], second.match(/Trait: [^\n]+/)?.[0]);
-  assert.equal(first.match(/Image traits: [^\n]+/)?.[0], second.match(/Image traits: [^\n]+/)?.[0]);
   assert.equal(first.match(/Copy: [^\n]+/)?.[0], second.match(/Copy: [^\n]+/)?.[0]);
   assert.match(first, /same PR keeps the same creature/);
 });
@@ -4397,7 +4396,7 @@ Full review comments:
     /<img src="https:\/\/raw\.githubusercontent\.com\/openclaw\/clawsweeper-state\/state\/assets\/pr-eggs\/openclaw-openclaw\/74476\.png" width="256" height="256" alt="Hatched PR egg: [^"]+">/,
   );
   assert.doesNotMatch(eggComment, /```text/);
-  assert.ok(eggComment.indexOf("<img ") < eggComment.indexOf("### Hatch command"));
+  assert.ok(eggComment.indexOf("<img ") > eggComment.indexOf("<summary>Details</summary>"));
 });
 
 test("PR egg share link falls back to PR URL before durable comment metadata exists", () => {
@@ -4523,8 +4522,8 @@ Full review comments:
     );
 
     assert.doesNotMatch(comment, /\*\*PR egg\*\*/);
-    assert.match(eggComment, /✨ Hatched: [^\n]+/);
-    assert.doesNotMatch(eggComment, /🔥 Warming up:/);
+    assert.match(eggComment, /✨ hatched [^\n]+/);
+    assert.doesNotMatch(eggComment, /🔥 warming;/);
   }
 });
 
@@ -4592,13 +4591,13 @@ Full review comments:
   const eggComment = renderPrEggCommentForTest(83632, report);
 
   assert.doesNotMatch(comment, /\*\*PR egg\*\*/);
-  assert.match(eggComment, /✨ Hatched: [^\n]+/);
+  assert.match(eggComment, /✨ hatched [^\n]+/);
   assert.match(eggComment, /Rarity: [^\n]+\./);
   assert.match(
     eggComment,
     /Share on X: \[post this hatch\]\(https:\/\/x\.com\/intent\/tweet\?text=[^)]+&url=https%3A%2F%2Fgithub\.com%2Fopenclaw%2Fopenclaw%2Fpull%2F83632%23issuecomment-4478578658\)/,
   );
-  assert.doesNotMatch(eggComment, /🔥 Warming up:/);
+  assert.doesNotMatch(eggComment, /🔥 warming;/);
 });
 
 test("PR egg lifecycle follows the current PR status signal", () => {
@@ -4655,22 +4654,19 @@ Full review comments:
 `;
 
   const cases = [
-    ["automerge_armed", /✨ Hatched:/],
-    ["ready_for_maintainer_look", /✨ Hatched:/],
-    ["re_review_loop", /🔁 Wobbling:/],
+    ["automerge_armed", /✨ hatched/],
+    ["ready_for_maintainer_look", /✨ hatched/],
+    ["re_review_loop", /🔁 wobbling/],
     [
       "actively_grinding",
-      /🔥 Warming up: real-behavior proof passed; findings, security review, or rank-up moves are still in progress\./,
+      /🔥 warming; proof passed, review follow-up or readiness checks remain\./,
     ],
     [
       "waiting_on_author",
-      /🔥 Warming up: real-behavior proof passed; findings, security review, or rank-up moves are still in progress\./,
+      /🔥 warming; proof passed, review follow-up or readiness checks remain\./,
     ],
-    [
-      "needs_proof",
-      /🔥 Warming up: real-behavior proof passed; findings, security review, or rank-up moves are still in progress\./,
-    ],
-    [null, /🥚 Incubating:/],
+    ["needs_proof", /🔥 warming; proof passed, review follow-up or readiness checks remain\./],
+    [null, /🥚 incubating/],
   ] as const;
 
   for (const [prStatusKind, expected] of cases) {
@@ -4737,12 +4733,12 @@ Full review comments:
 - none
 `;
 
-  assert.match(renderPrEggCommentForTest(74473, report, "re_review_loop"), /🔁 Wobbling:/);
+  assert.match(renderPrEggCommentForTest(74473, report, "re_review_loop"), /🔁 wobbling/);
   assert.doesNotMatch(
     renderReviewCommentFromReport(report, "none", { prStatusKind: "re_review_loop" }),
     /\*\*PR egg\*\*/,
   );
-  assert.match(renderPrEggCommentForTest(74473, report), /🥚 Incubating:/);
+  assert.match(renderPrEggCommentForTest(74473, report), /🥚 incubating/);
 });
 
 test("issues do not render PR egg game", () => {
@@ -5995,6 +5991,7 @@ if (args[0] === "api" && /\\/issues\\/84244\\/comments(?:\\?|$)/.test(path)) {
 `;
     withMockGh(root, ghMock, () => {
       runApplyDecisionsForTest({
+        targetRepo: "openclaw/openclaw",
         itemsDir,
         closedDir,
         plansDir,
@@ -6026,7 +6023,7 @@ if (args[0] === "api" && /\\/issues\\/84244\\/comments(?:\\?|$)/.test(path)) {
       calls.some(
         (args) =>
           args[0] === "api" &&
-          args[1] === "repos/openclaw/clawsweeper/issues/84244/comments" &&
+          args[1] === "repos/openclaw/openclaw/issues/84244/comments" &&
           args.includes("POST"),
       ),
     );
@@ -6057,7 +6054,7 @@ test("reconcile preserves exact open item records missed by the broad open scan"
     writeFileSync(
       join(itemsDir, "84347.md"),
       `${reportFrontMatter({
-        repository: "openclaw/clawsweeper",
+        repository: "openclaw/openclaw",
         type: "pull_request",
         number: "84347",
         title: "Preserve exact PR",
@@ -6137,11 +6134,11 @@ test("hatch sync posts PR egg comment without publishing stale review changes", 
     writeFileSync(
       join(itemsDir, "74476.md"),
       `${reportFrontMatter({
-        repository: "openclaw/clawsweeper",
+        repository: "openclaw/openclaw",
         type: "pull_request",
         number: "74476",
         title: "Keep hatch separate",
-        url: "https://github.com/openclaw/clawsweeper/pull/74476",
+        url: "https://github.com/openclaw/openclaw/pull/74476",
         decision: "keep_open",
         close_reason: "none",
         confidence: "high",
@@ -6159,7 +6156,7 @@ test("hatch sync posts PR egg comment without publishing stale review changes", 
         item_updated_at: "2026-05-19T20:00:00Z",
         pull_head_sha: "abc123def456",
         pr_egg_image_url:
-          "https://raw.githubusercontent.com/openclaw/clawsweeper-state/state/assets/pr-eggs/openclaw-clawsweeper/74476.png",
+          "https://raw.githubusercontent.com/openclaw/clawsweeper-state/state/assets/pr-eggs/openclaw-openclaw/74476.png",
       })}
 
 ## Summary
@@ -6203,7 +6200,7 @@ if (args[0] === "api" && /\\/issues\\/74476$/.test(path)) {
   console.log(JSON.stringify({
     number: 74476,
     title: "Keep hatch separate",
-    html_url: "https://github.com/openclaw/clawsweeper/pull/74476",
+    html_url: "https://github.com/openclaw/openclaw/pull/74476",
     created_at: "2026-05-19T19:00:00Z",
     updated_at: "2026-05-19T20:00:00Z",
     closed_at: null,
@@ -6221,13 +6218,13 @@ if (args[0] === "api" && /\\/issues\\/74476$/.test(path)) {
     appendFileSync(logPath, JSON.stringify(["comment-body", JSON.parse(readFileSync(input, "utf8")).body]) + "\\n");
     console.log(JSON.stringify({
       id: 987476,
-      html_url: "https://github.com/openclaw/clawsweeper/pull/74476#issuecomment-987476"
+      html_url: "https://github.com/openclaw/openclaw/pull/74476#issuecomment-987476"
     }));
   } else {
     console.log(JSON.stringify([[
       {
         id: 444,
-        html_url: "https://github.com/openclaw/clawsweeper/pull/74476#issuecomment-444",
+        html_url: "https://github.com/openclaw/openclaw/pull/74476#issuecomment-444",
         body: "Codex review: needs maintainer review before merge.\\n\\n<!-- clawsweeper-review item=74476 -->",
         user: { login: "clawsweeper" },
         created_at: "2026-05-19T19:55:00Z",
@@ -6248,6 +6245,7 @@ if (args[0] === "api" && /\\/issues\\/74476$/.test(path)) {
 `;
     withMockGh(root, ghMock, () => {
       runApplyDecisionsForTest({
+        targetRepo: "openclaw/openclaw",
         itemsDir,
         closedDir,
         plansDir,
@@ -6279,7 +6277,7 @@ if (args[0] === "api" && /\\/issues\\/74476$/.test(path)) {
       calls.some(
         (args) =>
           args[0] === "api" &&
-          args[1] === "repos/openclaw/clawsweeper/issues/74476/comments" &&
+          args[1] === "repos/openclaw/openclaw/issues/74476/comments" &&
           args.includes("POST"),
       ),
     );
@@ -6295,10 +6293,10 @@ if (args[0] === "api" && /\\/issues\\/74476$/.test(path)) {
     assert.match(hatchBody, /ClawSweeper PR egg/);
     assert.match(
       hatchBody,
-      /<img src="https:\/\/raw\.githubusercontent\.com\/openclaw\/clawsweeper-state\/state\/assets\/pr-eggs\/openclaw-clawsweeper\/74476\.png"/,
+      /<img src="https:\/\/raw\.githubusercontent\.com\/openclaw\/clawsweeper-state\/state\/assets\/pr-eggs\/openclaw-openclaw\/74476\.png"/,
     );
     assert.doesNotMatch(hatchBody, /```text/);
-    assert.match(hatchBody, /### Hatch command/);
+    assert.match(hatchBody, /^ClawSweeper PR egg: ✨ hatched [^\n]+/);
     assert.match(hatchBody, /clawsweeper-pr-egg-hatch:74476/);
     assert.doesNotMatch(hatchBody, /Pending stale finding/);
     assert.doesNotMatch(hatchBody, /Codex review: needs changes/);
@@ -6321,11 +6319,11 @@ test("hatch sync can use archived merged PR records without hatchable labels", (
     writeFileSync(
       join(closedDir, "74479.md"),
       `${reportFrontMatter({
-        repository: "openclaw/clawsweeper",
+        repository: "openclaw/openclaw",
         type: "pull_request",
         number: "74479",
         title: "Closed hatch",
-        url: "https://github.com/openclaw/clawsweeper/pull/74479",
+        url: "https://github.com/openclaw/openclaw/pull/74479",
         decision: "keep_open",
         close_reason: "none",
         confidence: "high",
@@ -6372,7 +6370,7 @@ if (args[0] === "api" && /\\/issues\\/74479$/.test(path)) {
   console.log(JSON.stringify({
     number: 74479,
     title: "Closed hatch",
-    html_url: "https://github.com/openclaw/clawsweeper/pull/74479",
+    html_url: "https://github.com/openclaw/openclaw/pull/74479",
     created_at: "2026-05-19T19:00:00Z",
     updated_at: "2026-05-19T21:00:00Z",
     closed_at: "2026-05-19T21:00:00Z",
@@ -6390,7 +6388,7 @@ if (args[0] === "api" && /\\/issues\\/74479$/.test(path)) {
     appendFileSync(logPath, JSON.stringify(["comment-body", JSON.parse(readFileSync(input, "utf8")).body]) + "\\n");
     console.log(JSON.stringify({
       id: 987479,
-      html_url: "https://github.com/openclaw/clawsweeper/pull/74479#issuecomment-987479"
+      html_url: "https://github.com/openclaw/openclaw/pull/74479#issuecomment-987479"
     }));
   } else {
     console.log(JSON.stringify([[]]));
@@ -6407,6 +6405,7 @@ if (args[0] === "api" && /\\/issues\\/74479$/.test(path)) {
 `;
     withMockGh(root, ghMock, () => {
       runApplyDecisionsForTest({
+        targetRepo: "openclaw/openclaw",
         itemsDir,
         closedDir,
         plansDir,
@@ -6435,8 +6434,8 @@ if (args[0] === "api" && /\\/issues\\/74479$/.test(path)) {
       .filter(Boolean)
       .map((line) => JSON.parse(line) as string[]);
     const hatchBody = calls.find((args) => args[0] === "comment-body")?.[1] ?? "";
-    assert.match(hatchBody, /✨ Hatched: [^\n]+/);
-    assert.match(hatchBody, /### Hatch command/);
+    assert.match(hatchBody, /✨ hatched [^\n]+/);
+    assert.match(hatchBody, /^ClawSweeper PR egg: ✨ hatched [^\n]+/);
     assert.match(hatchBody, /Merged PRs are hatchable/);
     assert.match(
       hatchBody,
@@ -6451,11 +6450,11 @@ if (args[0] === "api" && /\\/issues\\/74479$/.test(path)) {
 
 test("closed PR egg hatch still requires hatchable durable labels", () => {
   const report = `${reportFrontMatter({
-    repository: "openclaw/clawsweeper",
+    repository: "openclaw/openclaw",
     type: "pull_request",
     number: "74480",
     title: "Closed without hatch label",
-    url: "https://github.com/openclaw/clawsweeper/pull/74480",
+    url: "https://github.com/openclaw/openclaw/pull/74480",
     decision: "keep_open",
     close_reason: "none",
     confidence: "high",
@@ -6490,9 +6489,9 @@ Full review comments:
 `;
 
   const eggComment = renderPrEggCommentForTest(74480, report);
-  assert.match(eggComment, /🥚 Incubating:/);
+  assert.match(eggComment, /🥚 incubating/);
   assert.match(eggComment, /clawsweeper:automerge/);
-  assert.doesNotMatch(eggComment, /✨ Hatched:/);
+  assert.doesNotMatch(eggComment, /✨ hatched/);
 });
 
 test("normal PR comment sync moves PR egg into a separate marker-backed comment", () => {
@@ -6508,11 +6507,11 @@ test("normal PR comment sync moves PR egg into a separate marker-backed comment"
     writeFileSync(
       join(itemsDir, "74477.md"),
       `${reportFrontMatter({
-        repository: "openclaw/clawsweeper",
+        repository: "openclaw/openclaw",
         type: "pull_request",
         number: "74477",
         title: "Move egg comment",
-        url: "https://github.com/openclaw/clawsweeper/pull/74477",
+        url: "https://github.com/openclaw/openclaw/pull/74477",
         decision: "keep_open",
         close_reason: "none",
         confidence: "high",
@@ -6571,7 +6570,7 @@ if (args[0] === "api" && /\\/issues\\/74477$/.test(path)) {
   console.log(JSON.stringify({
     number: 74477,
     title: "Move egg comment",
-    html_url: "https://github.com/openclaw/clawsweeper/pull/74477",
+    html_url: "https://github.com/openclaw/openclaw/pull/74477",
     created_at: "2026-05-19T19:00:00Z",
     updated_at: "2026-05-19T20:00:00Z",
     closed_at: null,
@@ -6594,13 +6593,13 @@ if (args[0] === "api" && /\\/issues\\/74477$/.test(path)) {
 } else if (args[0] === "api" && /\\/pulls\\/74477$/.test(path)) {
   console.log(JSON.stringify({
     number: 74477,
-    html_url: "https://github.com/openclaw/clawsweeper/pull/74477",
+    html_url: "https://github.com/openclaw/openclaw/pull/74477",
     state: "open",
     changed_files: 1,
     commits: 1,
     review_comments: 0,
     head: { sha: "abc123def456", ref: "branch", repo: { full_name: "fork/clawsweeper" } },
-    base: { sha: "base-sha", ref: "main", repo: { full_name: "openclaw/clawsweeper" } },
+    base: { sha: "base-sha", ref: "main", repo: { full_name: "openclaw/openclaw" } },
     user: { login: "contributor" }
   }));
 } else if (args[0] === "api" && /\\/pulls\\/74477\\/(files|commits|comments)(?:\\?|$)/.test(path)) {
@@ -6611,13 +6610,13 @@ if (args[0] === "api" && /\\/issues\\/74477$/.test(path)) {
     appendFileSync(logPath, JSON.stringify(["posted-comment-body", JSON.parse(readFileSync(input, "utf8")).body]) + "\\n");
     console.log(JSON.stringify({
       id: 987477,
-      html_url: "https://github.com/openclaw/clawsweeper/pull/74477#issuecomment-987477"
+      html_url: "https://github.com/openclaw/openclaw/pull/74477#issuecomment-987477"
     }));
   } else {
     console.log(JSON.stringify([[
       {
         id: 555,
-        html_url: "https://github.com/openclaw/clawsweeper/pull/74477#issuecomment-555",
+        html_url: "https://github.com/openclaw/openclaw/pull/74477#issuecomment-555",
         body: "Codex review: stale body with old embedded pet.\\n\\n**PR egg**\\nold egg\\n\\n<!-- clawsweeper-review item=74477 -->",
         user: { login: "clawsweeper" },
         created_at: "2026-05-19T19:55:00Z",
@@ -6630,7 +6629,7 @@ if (args[0] === "api" && /\\/issues\\/74477$/.test(path)) {
   appendFileSync(logPath, JSON.stringify(["patched-review-body", JSON.parse(readFileSync(input, "utf8")).body]) + "\\n");
   console.log(JSON.stringify({
     id: 555,
-    html_url: "https://github.com/openclaw/clawsweeper/pull/74477#issuecomment-555"
+    html_url: "https://github.com/openclaw/openclaw/pull/74477#issuecomment-555"
   }));
 } else if (args[0] === "label" || args[0] === "issue") {
   appendFileSync(logPath, JSON.stringify(["unexpected-label-or-issue-command", ...args]) + "\\n");
@@ -6642,6 +6641,7 @@ if (args[0] === "api" && /\\/issues\\/74477$/.test(path)) {
 `;
     withMockGh(root, ghMock, () => {
       runApplyDecisionsForTest({
+        targetRepo: "openclaw/openclaw",
         itemsDir,
         closedDir,
         plansDir,
@@ -6667,8 +6667,8 @@ if (args[0] === "api" && /\\/issues\\/74477$/.test(path)) {
     assert.match(patchedReviewBody, /Codex review:/);
     assert.doesNotMatch(patchedReviewBody, /\*\*PR egg\*\*/);
     assert.match(eggBody, /ClawSweeper PR egg/);
-    assert.match(eggBody, /✨ Hatched: [^\n]+/);
-    assert.match(eggBody, /@clawsweeper hatch/);
+    assert.match(eggBody, /✨ hatched [^\n]+/);
+    assert.match(eggBody, /^ClawSweeper PR egg: ✨ hatched [^\n]+/);
     assert.match(eggBody, /clawsweeper-pr-egg-hatch:74477/);
     assert.doesNotMatch(eggBody, /<img src=/);
     assert.equal(
@@ -6999,7 +6999,7 @@ if (args[0] === "api" && /\\/issues\\/74479$/.test(path)) {
       {
         number: 74479,
         action: "review_comment_synced",
-        reason: "updated durable Codex review comment; synced durable PR egg comment",
+        reason: "updated durable Codex review comment",
       },
     ]);
   } finally {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -1351,13 +1351,13 @@ test("hosted webhook accepts author read-only mention commands", async () => {
             fork: false,
             has_issues: true,
           },
-          issue: { number: 76991, user: { login: "nickmopen" } },
+          issue: { number: 76991, user: { login: "contributor" } },
           installation: { id: 123 },
           comment: {
             id: 456,
             body,
             author_association: "CONTRIBUTOR",
-            user: { login: "NickMOpen" },
+            user: { login: "contributor" },
           },
         },
       }),
@@ -1368,39 +1368,41 @@ test("hosted webhook accepts author read-only mention commands", async () => {
   }
 });
 
-test("hosted webhook ignores hatch commands outside OpenClaw repositories", async () => {
-  const response = await worker.fetch(
-    signedGithubWebhookRequest({
-      event: "issue_comment",
-      secret: "test-secret",
-      payload: {
-        action: "created",
-        repository: {
-          full_name: "steipete/summarize",
-          private: false,
-          archived: false,
-          fork: false,
-          has_issues: true,
+test("hosted webhook ignores hatch commands outside the OpenClaw product repository", async () => {
+  for (const repo of ["steipete/summarize", "openclaw/clawsweeper"]) {
+    const response = await worker.fetch(
+      signedGithubWebhookRequest({
+        event: "issue_comment",
+        secret: "test-secret",
+        payload: {
+          action: "created",
+          repository: {
+            full_name: repo,
+            private: false,
+            archived: false,
+            fork: false,
+            has_issues: true,
+          },
+          issue: { number: 76991, user: { login: "contributor" } },
+          installation: { id: 123 },
+          comment: {
+            id: 456,
+            body: "@clawsweeper hatch",
+            author_association: "CONTRIBUTOR",
+            user: { login: "contributor" },
+          },
         },
-        issue: { number: 76991, user: { login: "nickmopen" } },
-        installation: { id: 123 },
-        comment: {
-          id: 456,
-          body: "@clawsweeper hatch",
-          author_association: "CONTRIBUTOR",
-          user: { login: "NickMOpen" },
-        },
-      },
-    }),
-    { CLAWSWEEPER_WEBHOOK_SECRET: "test-secret" },
-  );
+      }),
+      { CLAWSWEEPER_WEBHOOK_SECRET: "test-secret" },
+    );
 
-  assert.equal(response.status, 202);
-  assert.deepEqual(await response.json(), {
-    ok: true,
-    accepted: false,
-    reason: "PR egg is disabled for this repo",
-  });
+    assert.equal(response.status, 202);
+    assert.deepEqual(await response.json(), {
+      ok: true,
+      accepted: false,
+      reason: "PR egg is disabled for this repo",
+    });
+  }
 });
 
 test("hosted webhook returns invalid_json for signed malformed bodies", async () => {

--- a/test/repair/comment-webhook.test.ts
+++ b/test/repair/comment-webhook.test.ts
@@ -182,7 +182,7 @@ test("comment webhook accepts author read-only hatch commands", () => {
   });
 });
 
-test("comment webhook ignores hatch commands outside OpenClaw repositories", () => {
+test("comment webhook ignores hatch commands outside the OpenClaw product repository", () => {
   const result = classifyIssueCommentWebhook({
     event: "issue_comment",
     payload: {
@@ -200,6 +200,24 @@ test("comment webhook ignores hatch commands outside OpenClaw repositories", () 
   });
 
   assert.deepEqual(result, { accepted: false, reason: "PR egg is disabled for this repo" });
+
+  const orgRepoResult = classifyIssueCommentWebhook({
+    event: "issue_comment",
+    payload: {
+      action: "created",
+      repository: { full_name: "openclaw/clawsweeper" },
+      issue: { number: 76992, user: { login: "contributor" } },
+      installation: { id: 123 },
+      comment: {
+        id: 458,
+        body: "@clawsweeper hatch",
+        author_association: "CONTRIBUTOR",
+        user: { login: "contributor" },
+      },
+    },
+  });
+
+  assert.deepEqual(orgRepoResult, { accepted: false, reason: "PR egg is disabled for this repo" });
 });
 
 test("comment webhook rejects commands from ineligible repositories", () => {


### PR DESCRIPTION
## Summary
- restrict PR egg rendering, sync, hatch routing, and webhook handling to `openclaw/openclaw`
- mirror the same exact product-repo hatch gate in the hosted dashboard webhook
- make PR egg comments one visible line by default, with details collapsed
- remove existing marker-backed PR egg comments from non-product repos during comment sync so old eggs do not linger

## Product decision
- PR eggs are intentionally product-repo-only: `openclaw/openclaw` keeps the feature, while sibling repos such as `openclaw/clawsweeper` suppress and clean up PR egg comments.

## Validation
- Local worker proof from the PR branch, using a signed `/github/webhook` request with no GitHub app credentials:

  ```text
  openclaw/openclaw: status=503 body={
    "error": "github_app_not_configured"
  }
  openclaw/clawsweeper: status=202 body={
    "ok": true,
    "accepted": false,
    "reason": "PR egg is disabled for this repo"
  }
  steipete/summarize: status=202 body={
    "ok": true,
    "accepted": false,
    "reason": "PR egg is disabled for this repo"
  }
  ```

  This shows the product repo hatch path is accepted past classification and only stops at the expected local missing-app-config boundary, while non-product repos are rejected by the new PR egg gate.
- Live cleanup proof: removed the stale marker-backed ClawSweeper PR egg comment from this `openclaw/clawsweeper` PR (`issuecomment-4560504044`) after the branch added the non-product cleanup behavior.
- `npm_config_cache=/private/tmp/clawsweeper-npm-cache npm exec --yes pnpm@10.33.2 -- run build:dashboard && node --test test/dashboard-worker.test.ts`
  - after-fix proof: hosted webhook accepts `@clawsweeper hatch` for `openclaw/openclaw` and rejects hatch commands for both `steipete/summarize` and `openclaw/clawsweeper`
- `npm_config_cache=/private/tmp/clawsweeper-npm-cache npm exec --yes pnpm@10.33.2 -- run build && node --test test/clawsweeper.test.ts test/repair/comment-webhook.test.ts`
  - after-fix proof: 337 tests passed, including exact product-repo PR egg rendering/sync behavior, repair router handling, webhook rejection outside `openclaw/openclaw`, and stale non-product PR egg deletion
- `npm_config_cache=/private/tmp/clawsweeper-npm-cache npm exec --yes pnpm@10.33.2 -- run build && node --test --test-name-pattern='normal PR comment sync' test/clawsweeper.test.ts`
  - after-fix proof: 2 targeted apply-lane tests passed, including `normal PR comment sync removes disabled PR egg comments outside product repo`
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false npm_config_cache=/private/tmp/clawsweeper-npm-cache npm exec --yes pnpm@10.33.2 -- run check`
  - after-fix proof: build, lint, unit tests, repair tests, coverage gates, and format check passed; full coverage run reported 741/741 tests passed
  - signing is disabled only for this command because local temporary-commit tests otherwise inherit global GPG signing
- `git diff --check`
