### PR TITLE
fix: suppress empty visual ruling fields

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -6192,7 +6192,7 @@ function buildVisualPrompt(options: {
     "- Show before/after or current/proposed behavior when applicable.",
     "- Show remaining risk or maintainer judgment when applicable.",
     "- Clearly state that this is advisory and maintainers remain the final judges.",
-    "- End exactly with this footer:",
+    "- End with this footer only when it has concrete content. Omit empty fields.",
     "",
     "## Maintainer ruling",
     "",
@@ -6300,6 +6300,41 @@ function visualCommentMarker(number: number, lens: string, headSha: string): str
   return `<!-- clawsweeper-visual item=${number} lens=${normalizeVisualLens(lens)} sha=${headSha || "na"} -->`;
 }
 
+const MAINTAINER_RULING_FIELDS = new Set([
+  "Benefit",
+  "Risk",
+  "Proof needed",
+  "Recommended next action",
+  "Question presented",
+]);
+
+export function stripEmptyMaintainerRulingFieldsForTest(body: string): string {
+  const lines = body.split(/\r?\n/);
+  const headingIndex = lines.findIndex((line) => /^##\s+Maintainer ruling\s*$/i.test(line.trim()));
+  if (headingIndex === -1) return body;
+
+  let endIndex = lines.length;
+  for (let index = headingIndex + 1; index < lines.length; index += 1) {
+    if (/^##\s+\S/.test(lines[index]?.trim() ?? "")) {
+      endIndex = index;
+      break;
+    }
+  }
+
+  const sectionLines = lines.slice(headingIndex + 1, endIndex);
+  const keptSectionLines = sectionLines.filter((line) => {
+    const match = line.trim().match(/^([^:]+):\s*$/);
+    return !match || !MAINTAINER_RULING_FIELDS.has(match[1]?.trim() ?? "");
+  });
+  const hasConcreteContent = keptSectionLines.some((line) => line.trim().length > 0);
+  const replacement = hasConcreteContent ? [lines[headingIndex]!, ...keptSectionLines] : [];
+
+  return [...lines.slice(0, headingIndex), ...replacement, ...lines.slice(endIndex)]
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
 function renderAssistComment(options: {
   body: string;
   model: string;
@@ -6331,7 +6366,9 @@ function renderVisualComment(options: {
   sourceCommentUrl: string;
   sourceCommentId: string;
 }): string {
-  const body = options.body.trim() || "# Visual brief\n\nNo visual brief could be produced.";
+  const body =
+    stripEmptyMaintainerRulingFieldsForTest(options.body).trim() ||
+    "# Visual brief\n\nNo visual brief could be produced.";
   const headSha = itemHeadSha(options.item, options.context);
   const sourceLine = options.sourceCommentUrl
     ? `Source: ${options.sourceCommentUrl}`

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -108,6 +108,7 @@ import {
   shouldReviewItem,
   shouldRetryGh,
   shouldPlanItem,
+  stripEmptyMaintainerRulingFieldsForTest,
   telegramVisibleProofLabelsForTest,
   validateCloseDecision,
 } from "../dist/clawsweeper.js";
@@ -430,6 +431,49 @@ test("review context comment filter removes ClawSweeper self-noise and command-o
     result.included.map((comment) => (comment as { id: number }).id),
     [5, 6],
   );
+});
+
+test("visual brief sanitizer removes empty maintainer ruling template fields", () => {
+  const body = [
+    "# Visual brief",
+    "",
+    "The routing path is working.",
+    "",
+    "## Maintainer ruling",
+    "",
+    "Benefit:",
+    "Risk:",
+    "Proof needed:",
+    "Recommended next action:",
+    "Question presented:",
+  ].join("\n");
+
+  const sanitized = stripEmptyMaintainerRulingFieldsForTest(body);
+
+  assert.equal(sanitized, "# Visual brief\n\nThe routing path is working.");
+});
+
+test("visual brief sanitizer keeps concrete maintainer ruling fields", () => {
+  const body = [
+    "# Visual brief",
+    "",
+    "## Maintainer ruling",
+    "",
+    "Benefit: Reduces operator confusion.",
+    "Risk:",
+    "Proof needed: Live router and assist smoke.",
+    "Recommended next action:",
+    "Question presented: Should maintainers accept this proof?",
+  ].join("\n");
+
+  const sanitized = stripEmptyMaintainerRulingFieldsForTest(body);
+
+  assert.match(sanitized, /## Maintainer ruling/);
+  assert.match(sanitized, /Benefit: Reduces operator confusion\./);
+  assert.doesNotMatch(sanitized, /^Risk:$/m);
+  assert.doesNotMatch(sanitized, /^Recommended next action:$/m);
+  assert.match(sanitized, /Proof needed: Live router and assist smoke\./);
+  assert.match(sanitized, /Question presented: Should maintainers accept this proof\?/);
 });
 
 test("review context comment filter keeps contributor text that only quotes markers", () => {


### PR DESCRIPTION
## Summary

- suppress empty maintainer-ruling fields before posting visual brief comments
- keep concrete maintainer-ruling fields when the visual output actually fills them
- update the visual prompt so the footer is only requested when it has concrete content

Fixes https://github.com/openclaw/clawsweeper/issues/215

## Validation

- ./node_modules/.bin/tsgo -p tsconfig.json
- ./node_modules/.bin/oxfmt --check src/clawsweeper.ts test/clawsweeper.test.ts
- node --test test/clawsweeper.test.ts
- GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false npm_config_cache=/private/tmp/clawsweeper-npm-cache npx pnpm@10.33.2 run check

## Real behavior proof

- Live visual workflow run: https://github.com/openclaw/clawsweeper/actions/runs/26553700850
- Ref: codex/suppress-empty-visual-ruling at ed4a672aa217c93465ae727a69bf4f00c75e381b
- Target: https://github.com/openclaw/clawsweeper/pull/216
- Posted visual comment: https://github.com/openclaw/clawsweeper/pull/216#issuecomment-4560713697
- Log proof from the Answer maintainer question step:
  - MODE: visual
  - LENS: auto
  - {"posted":true,"mode":"visual","item":216,"lens":"auto","model":"gpt-5.5","reasoningEffort":"low"}
- Observed output after fix: the posted visual comment includes concrete maintainer-ruling fields but does not include the empty `Recommended next action:` field, demonstrating empty maintainer-ruling template fields are suppressed in the live visual posting path.
