### PR TITLE
Reduce priority prefix noise in PR comments

### DIFF
--- a/docs/pr-review-comments.md
+++ b/docs/pr-review-comments.md
@@ -74,13 +74,14 @@ report has:
 - `Remaining risk:` only when it is not a restatement of the required change or
   best solution
 
-Actionable bullets in risk, finding, next-step, merge-blocking proof guidance,
-acceptance criteria, and remaining-risk text may use plain priority prefixes
-such as `[P0]`, `[P1]`, or `[P2]`. Keep those prefixes unbolded and attached to
-plain-language consequences or required actions. Do not add priority prefixes to
-audit-only details such as label justifications, AGENTS.md notes,
-Mantis/workflow notes, model metadata, related people, PR stats, or generic
-evidence lists.
+Concrete blockers or required work in risk, finding, next-step,
+merge-blocking proof guidance, acceptance criteria, and remaining-risk text may
+use plain priority prefixes such as `[P0]`, `[P1]`, or `[P2]`. Keep those
+prefixes unbolded and attached to plain-language consequences or required
+actions. Do not add priority prefixes to non-actions such as `none`, routine
+maintainer review, normal CI/status-check follow-up, or audit-only details such
+as label justifications, AGENTS.md notes, Mantis/workflow notes, model metadata,
+related people, PR stats, or generic evidence lists.
 
 Full review comments, source links, owner routing, acceptance criteria, and
 evidence stay under the collapsed `Review details` block so the top-level PR

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -7075,6 +7075,31 @@ function publicPriorityBulletFromText(text: string, fallback: PublicPriority): s
   return publicPriorityBullet(publicPriorityFromText(text, fallback), text);
 }
 
+function publicPlainBullet(text: string): string {
+  return `- ${stripPriorityPrefix(sentence(text))}`;
+}
+
+function isActionablePriorityText(text: string): boolean {
+  const body = stripPriorityPrefix(text);
+  if (!body || isReportNoneList(body)) return false;
+  if (
+    /\b(?:no automated repair|no clawsweeper repair|normal maintainer review|maintainer review and ci|required checks|status checks|ready for maintainer review)\b/i.test(
+      body,
+    )
+  ) {
+    return false;
+  }
+  return /\b(?:add|block|blocked|break|fail(?:\s+|-)?closed|fix|implement|missing|must|need(?:s|ed)?|prove|reject|repair|required|validate|before merge)\b/i.test(
+    body,
+  );
+}
+
+function publicPriorityBulletIfActionable(text: string, fallback: PublicPriority): string {
+  return isActionablePriorityText(text)
+    ? publicPriorityBulletFromText(text, fallback)
+    : publicPlainBullet(text);
+}
+
 function publicPriorityBulletsFromText(text: string, fallback: PublicPriority): string {
   const lines = text
     .split("\n")
@@ -7241,12 +7266,17 @@ function publicMergeReadinessBlock(rating: PrRating, proof: RealBehaviorProof): 
     "Overall follows the weaker of proof and patch quality, so missing proof can cap an otherwise strong patch.",
   ];
   if (rating.nextSteps.length) {
+    const nextSteps = rating.nextSteps
+      .slice(0, 3)
+      .filter((step) => !isReportNoneList(stripPriorityPrefix(step)));
     lines.push(
       "",
       "Rank-up moves:",
-      ...rating.nextSteps
-        .slice(0, 3)
-        .map((step) => publicPriorityBulletFromText(step, proofGuidance ? "P1" : "P2")),
+      ...(nextSteps.length
+        ? nextSteps.map((step) =>
+            publicPriorityBulletIfActionable(step, proofGuidance ? "P1" : "P2"),
+          )
+        : ["- none"]),
     );
   }
   if (proofGuidance) {
@@ -11851,7 +11881,9 @@ function renderKeepOpenCommentFromReport(
     "Continue tracking this item until the missing behavior is implemented or a maintainer decides the product direction.";
   const nextStepLine = sentence(workReason || bestSolution || fallbackNextStep);
   const publicNextStepLine = isPullRequest
-    ? publicPriorityBulletFromText(nextStepLine, hasRealBehaviorProofBlocker ? "P1" : "P2")
+    ? hasRealBehaviorProofBlocker
+      ? publicPriorityBulletFromText(nextStepLine, "P1")
+      : publicPriorityBulletIfActionable(nextStepLine, "P2")
     : nextStepLine;
   const bestSolutionLine = sentence(bestSolution);
   const mergeRiskLine = isPullRequest

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -3114,9 +3114,50 @@ Land this docs-only PR after maintainer review.
 
   assert.match(
     comment,
-    /\*\*Next step before merge\*\*\n- \[P2\] Land this docs-only PR after maintainer review\./,
+    /\*\*Next step before merge\*\*\n- Land this docs-only PR after maintainer review\./,
   );
+  assert.doesNotMatch(comment, /\[P2\] Land this docs-only PR/);
   assert.doesNotMatch(comment, /Best possible solution:/);
+});
+
+test("pull request review comments do not priority-prefix routine no-op guidance", () => {
+  const comment = renderReviewCommentFromReport(
+    `${reportFrontMatter({
+      type: "pull_request",
+      number: "74269",
+      decision: "keep_open",
+      close_reason: "none",
+      work_candidate: "none",
+      pull_head_sha: "abc123def456",
+    })}
+
+## Summary
+
+Keep this narrow PR open for maintainer review.
+
+## PR Rating
+
+Overall tier: B
+Proof tier: B
+Patch tier: B
+Summary: Ready for review.
+Next rank-up steps:
+- none
+
+## Best Possible Solution
+
+No ClawSweeper repair lane is needed; the submitted PR is narrow and the remaining action is normal maintainer review and CI.
+`,
+    "none",
+  );
+
+  assert.match(comment, /Rank-up moves:\n- none/);
+  assert.match(
+    comment,
+    /\*\*Next step before merge\*\*\n- No ClawSweeper repair lane is needed; the submitted PR is narrow and the remaining action is normal maintainer review and CI\./,
+  );
+  assert.doesNotMatch(comment, /\[P2\] none/);
+  assert.doesNotMatch(comment, /\[P2\] No ClawSweeper repair lane is needed/);
 });
 
 test("pull request next-step priority prefixes classify fail-closed work as P1", () => {
@@ -3193,8 +3234,9 @@ Full review comments:
   assert.match(comment, /Codex review: passed\./);
   assert.match(
     comment,
-    /\*\*Next step before merge\*\*\n- \[P2\] Merge after required checks are green\./,
+    /\*\*Next step before merge\*\*\n- Merge after required checks are green\./,
   );
+  assert.doesNotMatch(comment, /\[P2\] Merge after required checks are green/);
   assert.doesNotMatch(comment, /Automerge follow-up:/);
   assert.match(comment, /<!-- clawsweeper-verdict:pass item=74453 sha=abc123def456/);
   assert.doesNotMatch(comment, /clawsweeper-verdict:needs-human/);
@@ -5346,8 +5388,9 @@ Full review comments:
   assert.match(comment, /Codex review: passed\./);
   assert.match(
     comment,
-    /\*\*Next step before merge\*\*\n- \[P2\] Leave this draft open after fixes are complete\./,
+    /\*\*Next step before merge\*\*\n- Leave this draft open after fixes are complete\./,
   );
+  assert.doesNotMatch(comment, /\[P2\] Leave this draft open after fixes are complete/);
   assert.doesNotMatch(comment, /Autofix follow-up:/);
   assert.match(comment, /<!-- clawsweeper-verdict:pass item=74610 sha=abc123def456/);
   assert.doesNotMatch(comment, /Codex review: passed for ClawSweeper automerge/);


### PR DESCRIPTION
## Summary
- Stop adding public [P2] prefixes to routine PR next steps like maintainer review, CI, required checks, or no-op repair guidance.
- Render rank-up sentinel values like none without priority prefixes.
- Document that priority prefixes are only for concrete blockers or required work, not routine follow-up.

## Rendered proof
Generated locally from the built renderer with the screenshot-style routine case:

```md
Codex review: needs maintainer review before merge.

**Summary**
Keep this narrow PR open for maintainer review.

**Merge readiness**
Overall: 🐚 platinum hermit
Proof: 🐚 platinum hermit
Patch quality: 🐚 platinum hermit
Result: ready for maintainer review.

Rank-up moves:
- none.

**Next step before merge**
- No ClawSweeper repair lane is needed; the submitted PR is narrow and the remaining action is normal maintainer review and CI.
```

Concrete blocker text still keeps a priority prefix:

```md
**Next step before merge**
- [P1] Prove the fail-closed compatibility break is handled before merge.
```

## Validation
- node --test --test-name-pattern "routine no-op|automerge review comments can emit pass verdicts|autofix review comments can emit pass verdicts|next-step priority|duplicate best solution|merge risk" test/clawsweeper.test.ts
- node_modules/.bin/tsgo -p tsconfig.json
- node_modules/.bin/oxfmt --check src/clawsweeper.ts test/clawsweeper.test.ts docs/pr-review-comments.md
- git diff --check
- node --test test/*.test.ts