### PR TITLE
fix(repair): coalesce duplicate command acks

### DIFF
--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -43,6 +43,7 @@ const CLAWSWEEPER_PULL_ITEM_ACTIONS = new Set([
   "labeled",
   "unlabeled",
 ]);
+const inFlightFastAcks = new Map();
 const CLAWSWEEPER_WEBHOOK_DENY_REPOS = new Set(["openclaw/clawsweeper-state", "openclaw/.github"]);
 const CLAWSWEEPER_AUTHOR_READ_ONLY_COMMAND =
   "(?:review|re-review|rerun|re-run|rerun[ -]?review|re-run[ -]?review|status|explain)";
@@ -460,7 +461,7 @@ async function githubWebhook(request, env) {
       pull_requests: "write",
     },
   });
-  const statusCommentId = await createFastAckComment({
+  const statusCommentId = await createFastAckCommentOnce({
     token: targetToken,
     repo: commentDecision.targetRepo,
     itemNumber: commentDecision.itemNumber,
@@ -681,6 +682,21 @@ async function createFastAckComment({ token, repo, itemNumber, sourceCommentId }
     Number(payload.id) ||
     null
   );
+}
+
+async function createFastAckCommentOnce({ token, repo, itemNumber, sourceCommentId }) {
+  const key = fastAckKey({ repo, itemNumber, sourceCommentId });
+  const pending = inFlightFastAcks.get(key);
+  if (pending) return pending;
+  const next = createFastAckComment({ token, repo, itemNumber, sourceCommentId }).finally(() => {
+    inFlightFastAcks.delete(key);
+  });
+  inFlightFastAcks.set(key, next);
+  return next;
+}
+
+function fastAckKey({ repo, itemNumber, sourceCommentId }) {
+  return `${String(repo).toLowerCase()}:${itemNumber}:${sourceCommentId}`;
 }
 
 async function pruneFastAckComments({ token, repo, itemNumber, sourceCommentId }) {

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -43,6 +43,7 @@ const CLAWSWEEPER_PULL_ITEM_ACTIONS = new Set([
   "labeled",
   "unlabeled",
 ]);
+const FAST_ACK_SETTLE_DELAYS_MS = [250, 1500];
 const inFlightFastAcks = new Map();
 const CLAWSWEEPER_WEBHOOK_DENY_REPOS = new Set(["openclaw/clawsweeper-state", "openclaw/.github"]);
 const CLAWSWEEPER_AUTHOR_READ_ONLY_COMMAND =
@@ -208,7 +209,7 @@ export default {
     if (url.pathname === "/github/webhook" && request.method === "GET")
       return json({ ok: true, service: "clawsweeper-github-webhook" });
     if (url.pathname === "/github/webhook" && request.method === "POST")
-      return githubWebhook(request, env);
+      return githubWebhook(request, env, ctx);
     if (url.pathname === "/api/status") return statusJson(request, env, ctx);
     if (url.pathname === "/api/triage") return triageJson(request, env, ctx);
     if (url.pathname === "/api/pr-proof-triage") return prProofTriageJson(request, env, ctx);
@@ -406,7 +407,7 @@ async function ingestEvent(request, env) {
   return json({ ok: true, event });
 }
 
-async function githubWebhook(request, env) {
+async function githubWebhook(request, env, ctx) {
   const secret = stringEnv(env.CLAWSWEEPER_WEBHOOK_SECRET);
   if (!secret) return json({ error: "webhook_not_configured" }, 503);
 
@@ -477,6 +478,13 @@ async function githubWebhook(request, env) {
     token: dispatchToken,
     decision: commentDecision,
     statusCommentId,
+  });
+  settleFastAckComments({
+    token: targetToken,
+    repo: commentDecision.targetRepo,
+    itemNumber: commentDecision.itemNumber,
+    sourceCommentId: commentDecision.commentId,
+    waitUntil: ctx?.waitUntil?.bind(ctx),
   });
   return json({ ok: true, status_comment_id: statusCommentId }, 202);
 }
@@ -684,6 +692,19 @@ async function createFastAckComment({ token, repo, itemNumber, sourceCommentId }
   );
 }
 
+function settleFastAckComments({ token, repo, itemNumber, sourceCommentId, waitUntil }) {
+  const cleanup = async () => {
+    for (const delayMs of FAST_ACK_SETTLE_DELAYS_MS) {
+      await sleep(delayMs);
+      await pruneFastAckComments({ token, repo, itemNumber, sourceCommentId });
+    }
+  };
+  const promise = cleanup().catch((error) => {
+    console.error(`ClawSweeper fast ack cleanup failed: ${error?.message || error}`);
+  });
+  if (waitUntil) waitUntil(promise);
+}
+
 async function createFastAckCommentOnce({ token, repo, itemNumber, sourceCommentId }) {
   const key = fastAckKey({ repo, itemNumber, sourceCommentId });
   const pending = inFlightFastAcks.get(key);
@@ -697,6 +718,13 @@ async function createFastAckCommentOnce({ token, repo, itemNumber, sourceComment
 
 function fastAckKey({ repo, itemNumber, sourceCommentId }) {
   return `${String(repo).toLowerCase()}:${itemNumber}:${sourceCommentId}`;
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, delayMs);
+    timer.unref?.();
+  });
 }
 
 async function pruneFastAckComments({ token, repo, itemNumber, sourceCommentId }) {

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -1160,6 +1160,15 @@ export function parseTrustedAutomation(
   return null;
 }
 
+export function parseRoutedCommentCommand(
+  comment: LooseRecord,
+  { trustedAuthors = new Set() }: LooseRecord = {},
+) {
+  const trusted = parseTrustedAutomation(comment, { trustedAuthors });
+  if (trusted) return trusted;
+  return parseCommand(String(comment?.body ?? ""));
+}
+
 function trustedCommentHasPriorityFinding(body: string) {
   return /(?:^|\n)\s*(?:[-*]\s*)?(?:\*\*)?\[P[0-3]\]/i.test(String(body ?? ""));
 }

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -51,7 +51,7 @@ import {
   issueImplementationJobPath,
   maintainerAutomergeOptInApprovesNeedsHuman as maintainerAutomergeOptInApprovesNeedsHumanReason,
   latestRepairLoopResumeTime,
-  parseCommand,
+  parseRoutedCommentCommand,
   pausedModeStatusBlocksReplay,
   parseTrustedAutomation,
   repairableCheckBlockers,
@@ -163,8 +163,7 @@ const comments = measure("list_candidate_comments", () => listCandidateComments(
 const rawCommands: LooseRecord[] = [];
 
 for (const comment of comments) {
-  const parsed: LooseRecord =
-    parseCommand(comment.body) ?? parseTrustedAutomation(comment, { trustedAuthors: trustedBots });
+  const parsed: LooseRecord = parseRoutedCommentCommand(comment, { trustedAuthors: trustedBots });
   if (!parsed) continue;
   const issueNumber = issueNumberFromUrl(comment.issue_url);
   const command: LooseRecord = {
@@ -1898,15 +1897,14 @@ function repairJobModeForCommand(command: LooseRecord) {
 }
 
 function dispatchClawSweeperReview(command: LooseRecord) {
-  const commandStatus =
-    command.intent === "re_review"
-      ? {
-          command_status_marker: commandStatusMarker(command),
-          ...(command.status_comment_id
-            ? { status_comment_id: String(command.status_comment_id) }
-            : {}),
-        }
-      : {};
+  const commandStatus = ["re_review", "autofix", "automerge"].includes(String(command.intent ?? ""))
+    ? {
+        command_status_marker: commandStatusMarker(command),
+        ...(command.status_comment_id
+          ? { status_comment_id: String(command.status_comment_id) }
+          : {}),
+      }
+    : {};
   const payload = JSON.stringify({
     event_type: "clawsweeper_item",
     client_payload: {

--- a/src/repair/comment-webhook.ts
+++ b/src/repair/comment-webhook.ts
@@ -22,6 +22,7 @@ const PULL_ITEM_ACTIONS = new Set([
   "labeled",
   "unlabeled",
 ]);
+const FAST_ACK_SETTLE_DELAYS_MS = [250, 1500];
 const inFlightFastAcks = new Map<string, Promise<number>>();
 
 type AcceptedIssueCommentWebhook = {
@@ -138,6 +139,12 @@ export async function handleGitHubWebhook({
     commentId: accepted.commentId,
     statusCommentId,
     sourceAction: accepted.sourceAction,
+  });
+  settleFastAckComments({
+    token: targetToken,
+    repo: accepted.targetRepo,
+    itemNumber: accepted.itemNumber,
+    sourceCommentId: accepted.commentId,
   });
   return { statusCode: 202, body: { ok: true, status_comment_id: statusCommentId } };
 }
@@ -448,6 +455,29 @@ async function createFastAckComment({
   return (await pruneFastAckComments({ token, repo, itemNumber, sourceCommentId })) ?? id;
 }
 
+function settleFastAckComments({
+  token,
+  repo,
+  itemNumber,
+  sourceCommentId,
+}: {
+  token: string;
+  repo: string;
+  itemNumber: number;
+  sourceCommentId: number;
+}) {
+  const cleanup = async () => {
+    for (const delayMs of FAST_ACK_SETTLE_DELAYS_MS) {
+      await sleep(delayMs);
+      await pruneFastAckComments({ token, repo, itemNumber, sourceCommentId });
+    }
+  };
+  void cleanup().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`[clawsweeper webhook] fast ack cleanup failed: ${message}`);
+  });
+}
+
 async function createFastAckCommentOnce({
   token,
   repo,
@@ -479,6 +509,13 @@ function fastAckKey({
   sourceCommentId: number;
 }) {
   return `${repo.toLowerCase()}:${itemNumber}:${sourceCommentId}`;
+}
+
+function sleep(delayMs: number) {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, delayMs);
+    timer.unref?.();
+  });
 }
 
 async function pruneFastAckComments({

--- a/src/repair/comment-webhook.ts
+++ b/src/repair/comment-webhook.ts
@@ -22,6 +22,7 @@ const PULL_ITEM_ACTIONS = new Set([
   "labeled",
   "unlabeled",
 ]);
+const inFlightFastAcks = new Map<string, Promise<number>>();
 
 type AcceptedIssueCommentWebhook = {
   accepted: true;
@@ -117,7 +118,7 @@ export async function handleGitHubWebhook({
       pull_requests: "write",
     },
   });
-  const statusCommentId = await createFastAckComment({
+  const statusCommentId = await createFastAckCommentOnce({
     token: targetToken,
     repo: accepted.targetRepo,
     itemNumber: accepted.itemNumber,
@@ -445,6 +446,39 @@ async function createFastAckComment({
   const id = Number(response.id);
   if (!Number.isInteger(id) || id <= 0) throw new Error("fast ack comment response missing id");
   return (await pruneFastAckComments({ token, repo, itemNumber, sourceCommentId })) ?? id;
+}
+
+async function createFastAckCommentOnce({
+  token,
+  repo,
+  itemNumber,
+  sourceCommentId,
+}: {
+  token: string;
+  repo: string;
+  itemNumber: number;
+  sourceCommentId: number;
+}) {
+  const key = fastAckKey({ repo, itemNumber, sourceCommentId });
+  const pending = inFlightFastAcks.get(key);
+  if (pending) return pending;
+  const next = createFastAckComment({ token, repo, itemNumber, sourceCommentId }).finally(() => {
+    inFlightFastAcks.delete(key);
+  });
+  inFlightFastAcks.set(key, next);
+  return next;
+}
+
+function fastAckKey({
+  repo,
+  itemNumber,
+  sourceCommentId,
+}: {
+  repo: string;
+  itemNumber: number;
+  sourceCommentId: number;
+}) {
+  return `${repo.toLowerCase()}:${itemNumber}:${sourceCommentId}`;
 }
 
 async function pruneFastAckComments({

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -1882,6 +1882,117 @@ test("hosted webhook removes duplicate fast ack comments after concurrent redeli
   }
 });
 
+test("hosted webhook schedules post-dispatch fast ack cleanup", async () => {
+  const originalFetch = globalThis.fetch;
+  const { privateKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  });
+  let commentLookups = 0;
+  let deletedAck = 0;
+  const waitUntilPromises: Promise<unknown>[] = [];
+  globalThis.fetch = async (input, init) => {
+    const url = new URL(String(input));
+    if (url.pathname === "/repos/openclaw/clawsweeper/installation") {
+      return jsonResponse({ id: 999 });
+    }
+    if (url.pathname === "/app/installations/999/access_tokens") {
+      return jsonResponse({ token: "dispatch-token" });
+    }
+    if (url.pathname === "/app/installations/123/access_tokens") {
+      return jsonResponse({ token: "target-token" });
+    }
+    if (url.pathname === "/repos/openclaw/gogcli/issues/597/comments" && init?.method === "GET") {
+      commentLookups += 1;
+      if (commentLookups <= 2) {
+        return jsonResponse([
+          {
+            id: 777,
+            created_at: "2026-05-28T13:00:00Z",
+            body: "<!-- clawsweeper-command-ack:456 -->\nClawSweeper picked this up.",
+            user: { login: "openclaw-clawsweeper[bot]" },
+          },
+        ]);
+      }
+      return jsonResponse([
+        {
+          id: 777,
+          created_at: "2026-05-28T13:00:00Z",
+          body: "<!-- clawsweeper-command-ack:456 -->\nClawSweeper picked this up.",
+          user: { login: "openclaw-clawsweeper[bot]" },
+        },
+        {
+          id: 888,
+          created_at: "2026-05-28T13:00:01Z",
+          body: "<!-- clawsweeper-command-ack:456 -->\nClawSweeper picked this up.",
+          user: { login: "openclaw-clawsweeper[bot]" },
+        },
+      ]);
+    }
+    if (
+      url.pathname === "/repos/openclaw/gogcli/issues/comments/888" &&
+      init?.method === "DELETE"
+    ) {
+      deletedAck = 888;
+      return new Response(null, { status: 204 });
+    }
+    if (url.pathname === "/repos/openclaw/gogcli/issues/comments/456/reactions") {
+      return jsonResponse({});
+    }
+    if (url.pathname === "/repos/openclaw/clawsweeper/dispatches") {
+      return new Response(null, { status: 204 });
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  };
+
+  try {
+    const response = await worker.fetch(
+      signedGithubWebhookRequest({
+        event: "issue_comment",
+        secret: "test-secret",
+        payload: {
+          action: "created",
+          repository: {
+            full_name: "openclaw/gogcli",
+            default_branch: "trunk",
+            private: false,
+            archived: false,
+            fork: false,
+            has_issues: true,
+          },
+          issue: { number: 597, user: { login: "steipete" } },
+          installation: { id: 123 },
+          comment: {
+            id: 456,
+            body: "@clawsweeper build",
+            author_association: "OWNER",
+            user: { login: "steipete" },
+          },
+        },
+      }),
+      {
+        CLAWSWEEPER_APP_CLIENT_ID: "Iv23test",
+        CLAWSWEEPER_APP_PRIVATE_KEY: privateKey,
+        CLAWSWEEPER_WEBHOOK_SECRET: "test-secret",
+      },
+      {
+        waitUntil(promise: Promise<unknown>) {
+          waitUntilPromises.push(promise);
+        },
+      },
+    );
+
+    assert.equal(response.status, 202);
+    assert.deepEqual(await response.json(), { ok: true, status_comment_id: 777 });
+    assert.equal(waitUntilPromises.length, 1);
+    await Promise.all(waitUntilPromises);
+    assert.equal(deletedAck, 888);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("dashboard shares in-flight GitHub App installation token across parallel requests", async () => {
   const originalFetch = globalThis.fetch;
   const originalCaches = globalThis.caches;

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -1764,6 +1764,14 @@ test("hosted webhook coalesces concurrent duplicate fast ack comments", async ()
     assert.equal(comments.length, 1);
     assert.match(comments[0]?.body || "", /clawsweeper-command-ack:456/);
     assert.equal(dispatchBodies.length, 2);
+    assert.deepEqual(
+      dispatchBodies.map(
+        (body) =>
+          (body as { client_payload?: { status_comment_id?: unknown } }).client_payload
+            ?.status_comment_id,
+      ),
+      [777, 777],
+    );
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -1652,6 +1652,123 @@ test("hosted webhook reuses existing fast ack comments on redelivery", async () 
   }
 });
 
+test("hosted webhook coalesces concurrent duplicate fast ack comments", async () => {
+  const originalFetch = globalThis.fetch;
+  const { privateKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  });
+  const comments: Array<{ id: number; body: string; created_at: string; user: { login: string } }> =
+    [];
+  const dispatchBodies: unknown[] = [];
+  let fastAckPosts = 0;
+  let reactions = 0;
+  let releaseAckPost: (() => void) | undefined;
+  let markAckPostStarted: (() => void) | undefined;
+  const ackPostRelease = new Promise<void>((resolve) => {
+    releaseAckPost = resolve;
+  });
+  const ackPostStarted = new Promise<void>((resolve) => {
+    markAckPostStarted = resolve;
+  });
+  globalThis.fetch = async (input, init) => {
+    const url = new URL(String(input));
+    const authorization = new Headers(init?.headers).get("authorization");
+    if (url.pathname === "/repos/openclaw/clawsweeper/installation") {
+      return jsonResponse({ id: 999 });
+    }
+    if (url.pathname === "/app/installations/999/access_tokens") {
+      return jsonResponse({ token: "dispatch-token" });
+    }
+    if (url.pathname === "/app/installations/123/access_tokens") {
+      return jsonResponse({ token: "target-token" });
+    }
+    if (url.pathname === "/repos/openclaw/gogcli/issues/597/comments" && init?.method === "GET") {
+      assert.equal(authorization, "Bearer target-token");
+      return jsonResponse([...comments]);
+    }
+    if (url.pathname === "/repos/openclaw/gogcli/issues/597/comments" && init?.method === "POST") {
+      assert.equal(authorization, "Bearer target-token");
+      fastAckPosts += 1;
+      markAckPostStarted?.();
+      await ackPostRelease;
+      const body = JSON.parse(String(init.body || "{}"));
+      const comment = {
+        id: 777,
+        body: String(body.body || ""),
+        created_at: "2026-05-28T13:00:00Z",
+        user: { login: "openclaw-clawsweeper[bot]" },
+      };
+      comments.push(comment);
+      return jsonResponse(comment);
+    }
+    if (url.pathname === "/repos/openclaw/gogcli/issues/comments/456/reactions") {
+      assert.equal(authorization, "Bearer target-token");
+      reactions += 1;
+      return jsonResponse({});
+    }
+    if (url.pathname === "/repos/openclaw/clawsweeper/dispatches") {
+      assert.equal(authorization, "Bearer dispatch-token");
+      dispatchBodies.push(JSON.parse(String(init?.body)));
+      return new Response(null, { status: 204 });
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  };
+
+  const payload = {
+    action: "created",
+    repository: {
+      full_name: "openclaw/gogcli",
+      default_branch: "trunk",
+      private: false,
+      archived: false,
+      fork: false,
+      has_issues: true,
+    },
+    issue: { number: 597, user: { login: "steipete" } },
+    installation: { id: 123 },
+    comment: {
+      id: 456,
+      body: "@clawsweeper build",
+      author_association: "OWNER",
+      user: { login: "steipete" },
+    },
+  };
+  const env = {
+    CLAWSWEEPER_APP_CLIENT_ID: "Iv23test",
+    CLAWSWEEPER_APP_PRIVATE_KEY: privateKey,
+    CLAWSWEEPER_WEBHOOK_SECRET: "test-secret",
+  };
+
+  try {
+    const left = worker.fetch(
+      signedGithubWebhookRequest({ event: "issue_comment", secret: "test-secret", payload }),
+      env,
+    );
+    const right = worker.fetch(
+      signedGithubWebhookRequest({ event: "issue_comment", secret: "test-secret", payload }),
+      env,
+    );
+    await ackPostStarted;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    releaseAckPost?.();
+    const [leftResponse, rightResponse] = await Promise.all([left, right]);
+
+    assert.equal(leftResponse.status, 202);
+    assert.equal(rightResponse.status, 202);
+    assert.deepEqual(await leftResponse.json(), { ok: true, status_comment_id: 777 });
+    assert.deepEqual(await rightResponse.json(), { ok: true, status_comment_id: 777 });
+    assert.equal(fastAckPosts, 1);
+    assert.equal(reactions, 2);
+    assert.equal(comments.length, 1);
+    assert.match(comments[0]?.body || "", /clawsweeper-command-ack:456/);
+    assert.equal(dispatchBodies.length, 2);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("hosted webhook removes duplicate fast ack comments after concurrent redelivery", async () => {
   const originalFetch = globalThis.fetch;
   const { privateKey } = generateKeyPairSync("rsa", {

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -42,6 +42,7 @@ import {
   isMaintainerCommandAllowed,
   maintainerAutomergeOptInApprovesNeedsHuman,
   parseCommand,
+  parseRoutedCommentCommand,
   pausedModeStatusBlocksReplay,
   parseTrustedAutomation,
   repairableCheckBlockers,
@@ -994,6 +995,37 @@ test("parseTrustedAutomation accepts only trusted ClawSweeper repair signals", (
     parseTrustedAutomation({ ...comment, user: { login: "random-user" } }, { trustedAuthors }),
     null,
   );
+});
+
+test("parseRoutedCommentCommand prefers trusted verdict markers over copyable commands", () => {
+  const trustedAuthors = new Set(["clawsweeper"]);
+  const parsed = parseRoutedCommentCommand(
+    {
+      user: { login: "clawsweeper" },
+      body: [
+        "Codex review: needs changes before merge.",
+        "",
+        "<details>",
+        "<summary>Copy recommended automerge instruction</summary>",
+        "",
+        "```text",
+        "@clawsweeper automerge",
+        "",
+        "Special instructions:",
+        "Only expose structured content to the model.",
+        "```",
+        "</details>",
+        "",
+        "<!-- clawsweeper-verdict:needs-changes item=87540 sha=380baaba8f4490cbb64ae36ba8cb0b78912c45f1 confidence=high -->",
+        "<!-- clawsweeper-action:fix-required item=87540 sha=380baaba8f4490cbb64ae36ba8cb0b78912c45f1 confidence=high finding=review-feedback -->",
+      ].join("\n"),
+    },
+    { trustedAuthors },
+  );
+
+  assert.equal(parsed.intent, "clawsweeper_auto_repair");
+  assert.equal(parsed.expected_head_sha, "380baaba8f4490cbb64ae36ba8cb0b78912c45f1");
+  assert.match(parsed.repair_reason, /fix-required/);
 });
 
 test("parseTrustedAutomation accepts trusted ClawSweeper pass verdicts for automerge", () => {

--- a/test/repair/comment-webhook.test.ts
+++ b/test/repair/comment-webhook.test.ts
@@ -496,6 +496,106 @@ test("concurrent duplicate command webhooks converge on one fast ack comment", a
   }
 });
 
+test("comment webhook settles duplicate fast ack comments after dispatch", async () => {
+  const previousFetch = globalThis.fetch;
+  const previousAppId = process.env.CLAWSWEEPER_APP_ID;
+  const previousClientId = process.env.CLAWSWEEPER_APP_CLIENT_ID;
+  const previousPrivateKey = process.env.CLAWSWEEPER_APP_PRIVATE_KEY;
+  const { privateKey } = crypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
+  let commentLookups = 0;
+  let deletedAck = 0;
+  let resolveDeleted: (() => void) | undefined;
+  const deleted = new Promise<void>((resolve) => {
+    resolveDeleted = resolve;
+  });
+  process.env.CLAWSWEEPER_APP_ID = "12345";
+  delete process.env.CLAWSWEEPER_APP_CLIENT_ID;
+  process.env.CLAWSWEEPER_APP_PRIVATE_KEY = privateKey
+    .export({ type: "pkcs1", format: "pem" })
+    .toString();
+
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(String(input));
+    const method = String(init?.method ?? "GET").toUpperCase();
+    const path = `${url.pathname}${url.search}`;
+    if (path === "/repos/openclaw/clawsweeper/installation" && method === "GET") {
+      return jsonResponse({ id: 999 });
+    }
+    if (path === "/app/installations/999/access_tokens" && method === "POST") {
+      return jsonResponse({ token: "dispatch-token" });
+    }
+    if (path === "/app/installations/123/access_tokens" && method === "POST") {
+      return jsonResponse({ token: "target-token" });
+    }
+    if (path.startsWith("/repos/openclaw/openclaw/issues/71898/comments?") && method === "GET") {
+      commentLookups += 1;
+      if (commentLookups <= 2) {
+        return jsonResponse([
+          {
+            id: 9001,
+            body: "<!-- clawsweeper-command-ack:456 -->\nClawSweeper picked this up.",
+            created_at: "2026-05-28T13:00:00Z",
+            user: { login: "clawsweeper[bot]" },
+          },
+        ]);
+      }
+      return jsonResponse([
+        {
+          id: 9001,
+          body: "<!-- clawsweeper-command-ack:456 -->\nClawSweeper picked this up.",
+          created_at: "2026-05-28T13:00:00Z",
+          user: { login: "clawsweeper[bot]" },
+        },
+        {
+          id: 9002,
+          body: "<!-- clawsweeper-command-ack:456 -->\nClawSweeper picked this up.",
+          created_at: "2026-05-28T13:00:01Z",
+          user: { login: "clawsweeper[bot]" },
+        },
+      ]);
+    }
+    if (path === "/repos/openclaw/openclaw/issues/comments/456/reactions" && method === "POST") {
+      return jsonResponse({ id: 1 });
+    }
+    if (path === "/repos/openclaw/clawsweeper/dispatches" && method === "POST") {
+      return jsonResponse({});
+    }
+    if (path === "/repos/openclaw/openclaw/issues/comments/9002" && method === "DELETE") {
+      deletedAck = 9002;
+      resolveDeleted?.();
+      return jsonResponse({});
+    }
+    throw new Error(`unexpected fetch ${method} ${path}`);
+  }) as typeof fetch;
+
+  try {
+    const result = await handleGitHubWebhook({
+      event: "issue_comment",
+      payload: {
+        action: "created",
+        repository: { full_name: "openclaw/openclaw" },
+        issue: { number: 71898 },
+        installation: { id: 123 },
+        comment: {
+          id: 456,
+          body: "@clawsweeper re-review",
+          author_association: "MEMBER",
+          user: { login: "user" },
+        },
+      },
+    });
+
+    assert.deepEqual(result, { statusCode: 202, body: { ok: true, status_comment_id: 9001 } });
+    await deleted;
+    assert.equal(deletedAck, 9002);
+  } finally {
+    globalThis.fetch = previousFetch;
+    restoreEnv("CLAWSWEEPER_APP_ID", previousAppId);
+    restoreEnv("CLAWSWEEPER_APP_CLIENT_ID", previousClientId);
+    restoreEnv("CLAWSWEEPER_APP_PRIVATE_KEY", previousPrivateKey);
+  }
+});
+
 test("webhook signature verification uses sha256 body hmac", () => {
   const secret = "test-secret";
   const body = JSON.stringify({ ok: true });

--- a/test/repair/comment-webhook.test.ts
+++ b/test/repair/comment-webhook.test.ts
@@ -6,6 +6,7 @@ import {
   classifyItemWebhook,
   classifyIssueCommentWebhook,
   classifyWebhook,
+  handleGitHubWebhook,
   renderFastAckComment,
   verifyGitHubSignature,
 } from "../../dist/repair/comment-webhook.js";
@@ -402,6 +403,99 @@ test("fast ack comment carries source comment marker", () => {
   assert.match(body, /ClawSweeper picked this up/);
 });
 
+test("concurrent duplicate command webhooks converge on one fast ack comment", async () => {
+  const previousFetch = globalThis.fetch;
+  const previousAppId = process.env.CLAWSWEEPER_APP_ID;
+  const previousClientId = process.env.CLAWSWEEPER_APP_CLIENT_ID;
+  const previousPrivateKey = process.env.CLAWSWEEPER_APP_PRIVATE_KEY;
+  const { privateKey } = crypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
+  const comments: Array<{ id: number; body: string; created_at: string; user: { login: string } }> =
+    [];
+  let nextCommentId = 9001;
+  let fastAckPosts = 0;
+  let dispatches = 0;
+  process.env.CLAWSWEEPER_APP_ID = "12345";
+  delete process.env.CLAWSWEEPER_APP_CLIENT_ID;
+  process.env.CLAWSWEEPER_APP_PRIVATE_KEY = privateKey
+    .export({ type: "pkcs1", format: "pem" })
+    .toString();
+
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(String(input));
+    const method = String(init?.method ?? "GET").toUpperCase();
+    const path = `${url.pathname}${url.search}`;
+    if (path === "/repos/openclaw/clawsweeper/installation" && method === "GET") {
+      return jsonResponse({ id: 999 });
+    }
+    if (path === "/app/installations/999/access_tokens" && method === "POST") {
+      return jsonResponse({ token: "dispatch-token" });
+    }
+    if (path === "/app/installations/123/access_tokens" && method === "POST") {
+      return jsonResponse({ token: "target-token" });
+    }
+    if (path.startsWith("/repos/openclaw/openclaw/issues/71898/comments?") && method === "GET") {
+      return jsonResponse([...comments]);
+    }
+    if (path === "/repos/openclaw/openclaw/issues/71898/comments" && method === "POST") {
+      const body = JSON.parse(String(init?.body ?? "{}"));
+      fastAckPosts += 1;
+      const comment = {
+        id: nextCommentId++,
+        body: String(body.body ?? ""),
+        created_at: `2026-05-28T13:00:0${fastAckPosts}Z`,
+        user: { login: "clawsweeper[bot]" },
+      };
+      comments.push(comment);
+      return jsonResponse(comment);
+    }
+    if (path === "/repos/openclaw/openclaw/issues/comments/456/reactions" && method === "POST") {
+      return jsonResponse({ id: 1 });
+    }
+    if (path === "/repos/openclaw/clawsweeper/dispatches" && method === "POST") {
+      dispatches += 1;
+      return jsonResponse({});
+    }
+    if (path.startsWith("/repos/openclaw/openclaw/issues/comments/") && method === "DELETE") {
+      const id = Number(path.split("/").pop());
+      const index = comments.findIndex((comment) => comment.id === id);
+      if (index >= 0) comments.splice(index, 1);
+      return jsonResponse({});
+    }
+    throw new Error(`unexpected fetch ${method} ${path}`);
+  }) as typeof fetch;
+
+  try {
+    const payload = {
+      action: "created",
+      repository: { full_name: "openclaw/openclaw" },
+      issue: { number: 71898 },
+      installation: { id: 123 },
+      comment: {
+        id: 456,
+        body: "@clawsweeper re-review",
+        author_association: "MEMBER",
+        user: { login: "user" },
+      },
+    };
+    const [left, right] = await Promise.all([
+      handleGitHubWebhook({ event: "issue_comment", payload }),
+      handleGitHubWebhook({ event: "issue_comment", payload }),
+    ]);
+
+    assert.deepEqual(left, { statusCode: 202, body: { ok: true, status_comment_id: 9001 } });
+    assert.deepEqual(right, { statusCode: 202, body: { ok: true, status_comment_id: 9001 } });
+    assert.equal(fastAckPosts, 1);
+    assert.equal(dispatches, 2);
+    assert.equal(comments.length, 1);
+    assert.match(comments[0]?.body ?? "", /clawsweeper-command-ack:456/);
+  } finally {
+    globalThis.fetch = previousFetch;
+    restoreEnv("CLAWSWEEPER_APP_ID", previousAppId);
+    restoreEnv("CLAWSWEEPER_APP_CLIENT_ID", previousClientId);
+    restoreEnv("CLAWSWEEPER_APP_PRIVATE_KEY", previousPrivateKey);
+  }
+});
+
 test("webhook signature verification uses sha256 body hmac", () => {
   const secret = "test-secret";
   const body = JSON.stringify({ ok: true });
@@ -413,3 +507,18 @@ test("webhook signature verification uses sha256 body hmac", () => {
     /invalid GitHub webhook signature/,
   );
 });
+
+function jsonResponse(value: unknown) {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function restoreEnv(name: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}


### PR DESCRIPTION
## Summary
- Fixes https://github.com/openclaw/clawsweeper/issues/220
- Coalesces concurrent fast-ack creation by repo, item number, and source command comment id
- Adds post-dispatch fast-ack settlement in both the repair webhook and hosted dashboard worker so duplicate visible ack comments from separate handlers converge on the oldest marker-backed ack
- Routes trusted ClawSweeper verdict/action markers before scanning trusted review comments for copyable maintainer commands
- Carries command status metadata through autofix/automerge exact-head review dispatches so status updates can target the originating progress comment

## Behavior proof
Live-like local harness proof for `b44bca0ad0` routed the real webhook code through a local fake GitHub API over HTTP, injected a duplicate ack after dispatch, then waited for delayed settlement:

```text
$ node /private/tmp/clawsweeper-fast-ack-live-like-proof.mjs
live-like fake GitHub API: http://127.0.0.1:54351

repair webhook:
  webhook result: {"statusCode":202,"body":{"ok":true,"status_comment_id":9001}}
  dispatches: 1
  reactions: 1
  deleted duplicate ids: 9002
  visible ack ids after settlement: 9001
  visible ack markers: clawsweeper-command-ack:456

hosted worker:
  webhook result: {"status":202,"body":{"ok":true,"status_comment_id":777}}
  dispatches: 1
  reactions: 1
  deleted duplicate ids: 888
  visible ack ids after settlement: 777
  visible ack markers: clawsweeper-command-ack:457
```

Focused regression output:

```text
$ node --test test/repair/comment-webhook.test.ts test/dashboard-worker.test.ts
✔ hosted webhook schedules post-dispatch fast ack cleanup (1762.391167ms)
✔ comment webhook settles duplicate fast ack comments after dispatch (256.634625ms)
ℹ tests 45
ℹ pass 45
ℹ fail 0
```

Full local validation:

```text
$ pnpm run check
Found 0 warnings and 0 errors.
ℹ tests 386
ℹ pass 386
ℹ fail 0
All matched files use the correct format.
```

## Validation
- pnpm run build:repair
- pnpm run build:all
- node --test test/repair/comment-webhook.test.ts
- node --test test/dashboard-worker.test.ts
- node --test test/repair/comment-webhook.test.ts test/dashboard-worker.test.ts
- node --test test/repair/comment-router-core.test.ts test/repair/comment-router-utils.test.ts
- pnpm run test:repair
- pnpm run format:check
- pnpm run check
