### PR TITLE
fix(repair): scope automerge repair findings

### DIFF
--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -1170,7 +1170,8 @@ export function parseRoutedCommentCommand(
 }
 
 function trustedCommentHasPriorityFinding(body: string) {
-  return /(?:^|\n)\s*(?:[-*]\s*)?(?:\*\*)?\[P[0-3]\]/i.test(String(body ?? ""));
+  const reviewFindings = markdownSection(body, "Review findings");
+  return /(?:^|;|\n)\s*(?:[-*]\s*)?(?:\*\*)?\[P[0-3]\]/i.test(reviewFindings);
 }
 
 function trustedHumanReviewReason(body: string, verdict: LooseRecord | null) {

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -1077,6 +1077,32 @@ test("parseTrustedAutomation repairs trusted pass verdicts that still contain P 
   assert.match(parsed.repair_reason, /P-severity findings/);
 });
 
+test("parseTrustedAutomation does not treat pass verdict risk notes as repair findings", () => {
+  const trustedAuthors = new Set(["clawsweeper[bot]"]);
+  const parsed = parseTrustedAutomation(
+    {
+      user: { login: "clawsweeper[bot]" },
+      body: [
+        "Codex review: passed.",
+        "",
+        "**Risk before merge**",
+        "- [P1] Maintainers should accept the shared directory cleanup boundary.",
+        "- [P1] A bad predicate could remove a live bridge record.",
+        "",
+        "**Next step before merge**",
+        "- [P2] No repair lane is needed; the remaining action is landing risk acceptance.",
+        "",
+        "<!-- clawsweeper-verdict:pass item=87563 sha=613071ef179bd015ec9071d5dde2edc1ad3d9424 confidence=high -->",
+      ].join("\n"),
+    },
+    { trustedAuthors },
+  );
+
+  assert.equal(parsed.intent, "clawsweeper_auto_merge");
+  assert.equal(parsed.expected_head_sha, "613071ef179bd015ec9071d5dde2edc1ad3d9424");
+  assert.match(parsed.repair_reason, /verdict: pass/);
+});
+
 test("parseTrustedAutomation treats trusted ClawSweeper needs-human as a pause", () => {
   const trustedAuthors = new Set(["clawsweeper[bot]"]);
   const parsed = parseTrustedAutomation(


### PR DESCRIPTION
## Summary
- Limit trusted ClawSweeper P-finding detection to the Review findings section
- Keep advisory Risk before merge / Next step before merge P-bullets from converting pass verdicts into repair dispatches
- Add a regression test modeled on the PR 87563 automerge case

## Real behavior proof
Ran the built parser against two trusted ClawSweeper comment shapes on this branch:

```text
$ node --input-type=module - <<'NODEEOF'
import { parseTrustedAutomation } from './dist/repair/comment-router-core.js';
const trustedAuthors = new Set(['clawsweeper[bot]']);
const advisoryPass = [
  'Codex review: passed.',
  '',
  '**Risk before merge**',
  '- [P1] Maintainers should accept the shared directory cleanup boundary.',
  '',
  '**Next step before merge**',
  '- [P2] No repair lane is needed; the remaining action is landing risk acceptance.',
  '',
  '<!-- clawsweeper-verdict:pass item=87563 sha=613071ef179bd015ec9071d5dde2edc1ad3d9424 confidence=high -->',
].join('\n');
const reviewFindingPass = [
  'Codex review: passed.',
  '',
  '**Review findings**',
  '- [P2] Preserve queued delivery: `src/queue.ts:42`',
  '',
  '<!-- clawsweeper-verdict:pass item=87563 sha=abc123 confidence=high -->',
].join('\n');
for (const [name, body] of [['advisory-pass', advisoryPass], ['review-finding-pass', reviewFindingPass]]) {
  const parsed = parseTrustedAutomation({ user: { login: 'clawsweeper[bot]' }, body }, { trustedAuthors });
  console.log(`${name}: intent=${parsed?.intent} expected_head_sha=${parsed?.expected_head_sha}`);
}
NODEEOF
advisory-pass: intent=clawsweeper_auto_merge expected_head_sha=613071ef179bd015ec9071d5dde2edc1ad3d9424
review-finding-pass: intent=clawsweeper_auto_repair expected_head_sha=abc123
```

## Validation
- pnpm test -- test/repair/comment-router-core.test.ts
- pnpm run check
