### PR TITLE
Fix issue-author re-review commands with trailing context

### DIFF
--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -1586,6 +1586,10 @@ function commandFromText(trigger: JsonValue, value: JsonValue) {
   const parsed: LooseRecord = { trigger, command: parsedCommand, intent };
   if (intent === "autoclose") parsed.autoclose_message = autocloseReasonFromCommand(rawCommand);
   if (intent === "freeform_assist") parsed.freeform_prompt = assistPromptFromCommand(rawCommand);
+  if (intent === "re_review") {
+    const prompt = reviewPromptFromCommand(rawText);
+    if (prompt) parsed.freeform_prompt = prompt;
+  }
   if (intent === "visualize") parsed.visual_lens = visualLensFromCommand(rawCommand);
   if (intent === "implement_issue") {
     parsed.implementation_prompt = implementationPromptFromCommand(rawText);
@@ -1652,6 +1656,16 @@ function assistPromptFromCommand(command: LooseRecord) {
   return prompt.replace(/^(?:ask|explain)\b[:\s-]*/i, "").trim() || prompt;
 }
 
+function reviewPromptFromCommand(command: LooseRecord) {
+  return String(command ?? "")
+    .trim()
+    .replace(
+      /^(?:review(?:\s+again)?|re-?review|rereview|re-?run(?:\s+review)?|rerun(?:\s+review)?|run\s+(?:review|again))\b[:\s-]*/i,
+      "",
+    )
+    .trim();
+}
+
 export const VISUAL_LENSES = new Set([
   "ux",
   "flow",
@@ -1715,18 +1729,19 @@ function normalizeIntent(command: LooseRecord) {
     return "implement_issue";
   }
   if (
-    [
-      "review",
-      "re-review",
-      "rereview",
-      "review again",
-      "rerun",
-      "re-run",
-      "rerun review",
-      "re-run review",
-      "run review",
-      "run again",
-    ].includes(command)
+    command === "review" ||
+    command === "re-review" ||
+    command === "rereview" ||
+    command === "review again" ||
+    command === "rerun" ||
+    command === "re-run" ||
+    command === "rerun review" ||
+    command === "re-run review" ||
+    command === "run review" ||
+    command === "run again" ||
+    /^(?:review(?:\s+again)?|re-?review|rereview|re-?run(?:\s+review)?|rerun(?:\s+review)?|run\s+(?:review|again))\b[:\s-]+\S/i.test(
+      command,
+    )
   )
     return "re_review";
   if (["rebase", "update branch", "sync"].includes(command)) return "rebase";

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -364,13 +364,18 @@ function classifyCommand(command: LooseRecord): JsonValue {
   const target = pull
     ? classifyPullTarget(pull, command.issue_number)
     : classifyIssueTarget(issue, command.issue_number);
-  const next = { ...command, target };
-  if (
+  const authorReadOnlyAllowed =
     !command.trusted_bot &&
     authorization &&
     !authorization.allowed &&
-    !isAuthorReadOnlyCommandAllowed({ command, target })
-  ) {
+    isAuthorReadOnlyCommandAllowed({ command, target });
+  const next = {
+    ...command,
+    target,
+    maintainer_authorized: Boolean(authorization?.allowed),
+    author_readonly_authorized: Boolean(authorReadOnlyAllowed),
+  };
+  if (!command.trusted_bot && authorization && !authorization.allowed && !authorReadOnlyAllowed) {
     return {
       ...next,
       status: "ignored",
@@ -1995,6 +2000,20 @@ function dispatchClawSweeperAssist(command: LooseRecord) {
 function freeformReviewPrompt(command: LooseRecord): string {
   const prompt = String(command.freeform_prompt ?? "").trim();
   if (!prompt) return "";
+  if (command.intent === "re_review") {
+    if (command.maintainer_authorized !== true) return "";
+    return [
+      "Maintainer context from an @clawsweeper re-review command.",
+      "",
+      `Author: ${command.author ?? "unknown"}`,
+      `Comment: ${command.comment_url ?? "unknown"}`,
+      "",
+      "Requested focus:",
+      prompt.slice(0, 3000),
+      "",
+      "Use this only as read-only review context. Do not merge, close, label, or push code from the model.",
+    ].join("\n");
+  }
   return [
     "Maintainer freeform @clawsweeper request.",
     "",

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -12484,6 +12484,23 @@ test("event re-review status explains superseded cancellations", () => {
   assert.match(block, /A newer re-review for this item started before this run finished/);
 });
 
+test("comment commands keep the router-to-sweep dispatch contract", () => {
+  const routerWorkflow = readFileSync(".github/workflows/repair-comment-router.yml", "utf8");
+  const sweepWorkflow = readFileSync(".github/workflows/sweep.yml", "utf8");
+  const routerSource = readFileSync("src/repair/comment-router.ts", "utf8");
+
+  assert.match(routerWorkflow, /types:\s*\[clawsweeper_comment\]/);
+  assert.match(routerWorkflow, /pnpm run repair:comment-router/);
+  assert.match(
+    routerWorkflow,
+    /status_comment_id="\$\{\{ github\.event\.client_payload\.status_comment_id \|\| '' \}\}"/,
+  );
+  assert.match(routerWorkflow, /--status-comment-id "\$status_comment_id"/);
+  assert.match(routerSource, /event_type:\s*"clawsweeper_item"/);
+  assert.match(sweepWorkflow, /types:\s*\[clawsweeper_item,\s*clawsweeper_target_sweep\]/);
+  assert.doesNotMatch(sweepWorkflow, /types:\s*\[[^\]]*clawsweeper_comment/);
+});
+
 test("manual exact-item review dispatches avoid broad review concurrency", () => {
   const workflow = readFileSync(".github/workflows/sweep.yml", "utf8");
 

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -39,6 +39,7 @@ import {
   issueImplementationJobPath,
   isCanonicalLandingNeedsHumanText,
   latestRepairLoopResumeTime,
+  isAuthorReadOnlyCommandAllowed,
   isMaintainerCommandAllowed,
   maintainerAutomergeOptInApprovesNeedsHuman,
   parseCommand,
@@ -869,6 +870,30 @@ test("parseCommand recognizes ClawSweeper bot mentions", () => {
     trigger: "mention",
     command: "review",
     intent: "re_review",
+  });
+  assert.deepEqual(parseCommand("@clawsweeper re-review based on latest comments"), {
+    trigger: "mention",
+    command: "re-review based on latest comments",
+    intent: "re_review",
+    freeform_prompt: "based on latest comments",
+  });
+  assert.deepEqual(parseCommand("@clawsweeper re-review: focus on CI"), {
+    trigger: "mention",
+    command: "re-review: focus on ci",
+    intent: "re_review",
+    freeform_prompt: "focus on CI",
+  });
+  assert.deepEqual(parseCommand("@clawsweeper review based on full details in the issue."), {
+    trigger: "mention",
+    command: "review based on full details in the issue",
+    intent: "re_review",
+    freeform_prompt: "based on full details in the issue.",
+  });
+  assert.deepEqual(parseCommand("/clawsweeper re-run after my last comment"), {
+    trigger: "slash",
+    command: "re-run after my last comment",
+    intent: "re_review",
+    freeform_prompt: "after my last comment",
   });
   assert.deepEqual(parseCommand("@clawsweeper implement"), {
     trigger: "mention",
@@ -2539,5 +2564,27 @@ test("maintainer command authorization requires maintainer repository permission
       allowedAssociations,
     }),
     true,
+  );
+});
+
+test("issue authors can request read-only re-review with trailing context", () => {
+  const command = {
+    ...parseCommand("@clawsweeper re-review based on latest comments"),
+    author: "issue-author",
+  };
+
+  assert.equal(
+    isAuthorReadOnlyCommandAllowed({
+      command,
+      target: { author: "issue-author" },
+    }),
+    true,
+  );
+  assert.equal(
+    isAuthorReadOnlyCommandAllowed({
+      command,
+      target: { author: "someone-else" },
+    }),
+    false,
   );
 });


### PR DESCRIPTION
## Summary

Fixes issue-author `@clawsweeper review` / `@clawsweeper re-review` commands that include trailing context, such as:

```text
@clawsweeper re-review based on latest comments
@clawsweeper re-review: focus on the latest CI result
```

The existing workflow is a two-hop path:

```text
comment webhook -> clawsweeper_comment -> repair-comment-router.yml -> clawsweeper_item -> sweep.yml
```

This keeps that contract intact rather than wiring `clawsweeper_comment` directly into `sweep.yml`.

## What changed

- Parse `review`, `re-review`, `re-run`, and related aliases even when they have trailing context.
- Preserve trailing review context only for maintainer-authorized commands.
- Let issue/PR authors request a read-only fresh review with trailing words, while preventing those trailing words from being elevated into maintainer instructions.
- Add a regression test documenting the router-to-sweep dispatch contract so this does not regress into a direct workflow mismatch later.

## Coordination note

This is the smaller fix for #227. I have a separate PR for #226 because that one is about duplicate ack convergence and touches some of the same router surface. If this lands first, I will rebase the #226 branch if needed.

Fixes #227.

## Validation

Passed locally on Node `v24.13.0`:

- `pnpm run build:all`
- `pnpm run format:check`
- `pnpm run lint:repair`
- `pnpm run lint:scripts`
- `node --test test/repair/comment-router-core.test.ts`
- `node --test --test-name-pattern "comment commands keep the router-to-sweep dispatch contract" test/clawsweeper.test.ts`
- `git diff --check`
- `codex review --uncommitted` returned no actionable correctness issues

Also attempted:

- `pnpm run check` currently fails in this Windows local environment on two existing platform assumptions: `/usr/bin/git` is missing and a Unix file-mode assertion differs on Windows.
- `pnpm run test:repair` also has unrelated Windows/local harness failures around mocked `gh`/shell shims and local process spawning. The focused changed-surface tests above pass.