### PR TITLE
Converge duplicate ClawSweeper command ack comments

### DIFF
--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -43,7 +43,7 @@ const CLAWSWEEPER_PULL_ITEM_ACTIONS = new Set([
   "labeled",
   "unlabeled",
 ]);
-const FAST_ACK_SETTLE_DELAYS_MS = [250, 1500];
+const DEFAULT_FAST_ACK_SETTLE_DELAYS_MS = [250, 1500, 10_000];
 const inFlightFastAcks = new Map();
 const CLAWSWEEPER_WEBHOOK_DENY_REPOS = new Set(["openclaw/clawsweeper-state", "openclaw/.github"]);
 const CLAWSWEEPER_AUTHOR_READ_ONLY_COMMAND =
@@ -484,6 +484,7 @@ async function githubWebhook(request, env, ctx) {
     repo: commentDecision.targetRepo,
     itemNumber: commentDecision.itemNumber,
     sourceCommentId: commentDecision.commentId,
+    delaysMs: fastAckSettleDelaysMs(env.CLAWSWEEPER_FAST_ACK_SETTLE_DELAYS_MS),
     waitUntil: ctx?.waitUntil?.bind(ctx),
   });
   return json({ ok: true, status_comment_id: statusCommentId }, 202);
@@ -692,9 +693,16 @@ async function createFastAckComment({ token, repo, itemNumber, sourceCommentId }
   );
 }
 
-function settleFastAckComments({ token, repo, itemNumber, sourceCommentId, waitUntil }) {
+function settleFastAckComments({
+  token,
+  repo,
+  itemNumber,
+  sourceCommentId,
+  delaysMs = DEFAULT_FAST_ACK_SETTLE_DELAYS_MS,
+  waitUntil,
+}) {
   const cleanup = async () => {
-    for (const delayMs of FAST_ACK_SETTLE_DELAYS_MS) {
+    for (const delayMs of delaysMs) {
       await sleep(delayMs);
       await pruneFastAckComments({ token, repo, itemNumber, sourceCommentId });
     }
@@ -703,6 +711,14 @@ function settleFastAckComments({ token, repo, itemNumber, sourceCommentId, waitU
     console.error(`ClawSweeper fast ack cleanup failed: ${error?.message || error}`);
   });
   if (waitUntil) waitUntil(promise);
+}
+
+function fastAckSettleDelaysMs(value) {
+  const delays = String(value || "")
+    .split(",")
+    .map((entry) => Number.parseInt(entry.trim(), 10))
+    .filter((delay) => Number.isFinite(delay) && delay >= 0);
+  return delays.length > 0 ? delays : DEFAULT_FAST_ACK_SETTLE_DELAYS_MS;
 }
 
 async function createFastAckCommentOnce({ token, repo, itemNumber, sourceCommentId }) {
@@ -730,18 +746,13 @@ function sleep(delayMs) {
 async function pruneFastAckComments({ token, repo, itemNumber, sourceCommentId }) {
   const comments = await listFastAckComments({ token, repo, itemNumber, sourceCommentId });
   if (!comments.length) return null;
-  comments.sort((left, right) => {
-    const leftCreated = String(objectValue(left).created_at || "");
-    const rightCreated = String(objectValue(right).created_at || "");
-    return (
-      leftCreated.localeCompare(rightCreated) ||
-      (Number(objectValue(left).id) || 0) - (Number(objectValue(right).id) || 0)
-    );
-  });
+  const hasStatusComment = comments.some(isStatusBearingFastAckComment);
+  comments.sort(compareFastAckKeepPriority);
   const keepId = Number(objectValue(comments[0]).id) || null;
-  for (const comment of comments.slice(1)) {
+  for (const comment of comments) {
     const id = Number(objectValue(comment).id) || 0;
     if (id <= 0 || id === keepId) continue;
+    if (hasStatusComment && isStatusBearingFastAckComment(comment)) continue;
     await githubTokenJson({
       token,
       path: `/repos/${repo}/issues/comments/${id}`,
@@ -754,6 +765,40 @@ async function pruneFastAckComments({ token, repo, itemNumber, sourceCommentId }
     });
   }
   return keepId;
+}
+
+function compareFastAckKeepPriority(left, right) {
+  const leftStatus = isStatusBearingFastAckComment(left) ? 1 : 0;
+  const rightStatus = isStatusBearingFastAckComment(right) ? 1 : 0;
+  if (leftStatus !== rightStatus) return rightStatus - leftStatus;
+  if (leftStatus > 0) return compareCommentsByUpdatedAtDesc(left, right);
+  return compareCommentsByCreatedAt(left, right);
+}
+
+function isStatusBearingFastAckComment(comment) {
+  const body = String(objectValue(comment).body || "");
+  return (
+    body.includes("clawsweeper-command-status:") ||
+    body.includes("<!-- clawsweeper-command-progress:start -->")
+  );
+}
+
+function compareCommentsByUpdatedAtDesc(left, right) {
+  const leftUpdated = String(objectValue(left).updated_at || objectValue(left).created_at || "");
+  const rightUpdated = String(objectValue(right).updated_at || objectValue(right).created_at || "");
+  return (
+    rightUpdated.localeCompare(leftUpdated) ||
+    (Number(objectValue(right).id) || 0) - (Number(objectValue(left).id) || 0)
+  );
+}
+
+function compareCommentsByCreatedAt(left, right) {
+  const leftCreated = String(objectValue(left).created_at || "");
+  const rightCreated = String(objectValue(right).created_at || "");
+  return (
+    leftCreated.localeCompare(rightCreated) ||
+    (Number(objectValue(left).id) || 0) - (Number(objectValue(right).id) || 0)
+  );
 }
 
 async function listFastAckComments({ token, repo, itemNumber, sourceCommentId }) {

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -1763,6 +1763,68 @@ export function commandStatusMarkerPrefix(command: LooseRecord) {
   return `<!-- clawsweeper-command-status:${command.issue_number ?? "unknown"}:${command.intent}:`;
 }
 
+export function commandStatusMarkerFromBody(body: JsonValue) {
+  return (
+    String(body ?? "").match(new RegExp("<!--\\s*clawsweeper-command-status:[^>]+-->"))?.[0] ?? null
+  );
+}
+
+export function planCommandAckConvergence(
+  comments: LooseRecord[],
+  requestedStatusMarker: string,
+): { keep: LooseRecord | null; prunable: LooseRecord[] } {
+  const scoped = comments.filter((comment) => {
+    const statusMarker = commandStatusMarkerFromBody(comment.body);
+    return !statusMarker || statusMarker === requestedStatusMarker;
+  });
+  const keep = selectCommandAckKeeper(scoped);
+  if (!keep) return { keep: null, prunable: [] };
+  const keepId = Number(keep.id ?? 0) || 0;
+  return {
+    keep,
+    prunable: scoped.filter((comment) => {
+      const id = Number(comment.id ?? 0) || 0;
+      return id > 0 && id !== keepId;
+    }),
+  };
+}
+
+function selectCommandAckKeeper(comments: LooseRecord[]) {
+  return [...comments].sort(compareCommandAckKeepPriority)[0] ?? null;
+}
+
+function compareCommandAckKeepPriority(left: LooseRecord, right: LooseRecord) {
+  const leftStatus = commandAckStatusScore(left);
+  const rightStatus = commandAckStatusScore(right);
+  if (leftStatus !== rightStatus) return rightStatus - leftStatus;
+  if (leftStatus > 0) return compareCommentsByUpdatedAtDesc(left, right);
+  return compareCommentsByCreatedAt(left, right);
+}
+
+function commandAckStatusScore(comment: LooseRecord) {
+  const body = String(comment.body ?? "");
+  return body.includes("clawsweeper-command-status:") ||
+    body.includes("<!-- clawsweeper-command-progress:start -->")
+    ? 1
+    : 0;
+}
+
+function compareCommentsByUpdatedAtDesc(left: LooseRecord, right: LooseRecord) {
+  const leftUpdated = String(left.updated_at ?? left.created_at ?? "");
+  const rightUpdated = String(right.updated_at ?? right.created_at ?? "");
+  return (
+    rightUpdated.localeCompare(leftUpdated) || (Number(right.id) || 0) - (Number(left.id) || 0)
+  );
+}
+
+function compareCommentsByCreatedAt(left: LooseRecord, right: LooseRecord) {
+  const leftCreated = String(left.created_at ?? "");
+  const rightCreated = String(right.created_at ?? "");
+  return (
+    leftCreated.localeCompare(rightCreated) || (Number(left.id) || 0) - (Number(right.id) || 0)
+  );
+}
+
 export function commandResponseMarker({ commentId, intent, headSha = "na" }: LooseRecord): string {
   return `<!-- clawsweeper-command:${commentId}:${intent}:${headSha ?? "na"} -->`;
 }

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -251,6 +251,7 @@ const report: LooseRecord = {
 if (execute) {
   await measureAsync("execute_commands", async () => {
     assertMutationActorIsClawsweeperBot();
+    for (const command of commands) convergePrecreatedCommandAckComments(command);
     for (const command of commands) acknowledgeSkippedMaintainerCommand(command);
     const capacityRequests = workerCapacityRequests(actionable);
     if (capacityRequests.length > 0) {
@@ -2968,13 +2969,15 @@ function hasExistingModeStatusResponse(number: JsonValue, intent: JsonValue) {
 function postComment(command: LooseRecord, body: string) {
   const existing =
     findExistingCommandStatusComment(command) ?? findPrecreatedCommandStatusComment(command);
+  const ackMarker = existing ? commandAckMarkerFromBody(existing.body) : null;
+  const responseBody = ackMarker && !body.includes(ackMarker) ? `${ackMarker}\n${body}` : body;
   const nextBody = usesSharedAutomergeStatus(command)
     ? mergeAutomergeTimelineSection({
-        body,
+        body: responseBody,
         existingBody: existing?.body,
         events: automergeTimelineEvents(command, body),
       })
-    : body;
+    : responseBody;
   const payloadPath = writePayload(repoRoot(), `comment-router-${command.comment_id}`, {
     body: nextBody,
   });
@@ -3001,15 +3004,99 @@ function postComment(command: LooseRecord, body: string) {
 }
 
 function findPrecreatedCommandStatusComment(command: LooseRecord) {
+  const converged = convergePrecreatedCommandAckComments(command);
+  if (converged) return converged;
   const statusCommentId = Number(command.status_comment_id ?? 0);
   if (!Number.isInteger(statusCommentId) || statusCommentId <= 0) return null;
   const comment = fetchIssueComment(statusCommentId);
   if (!comment || !isTrustedStatusComment(comment)) return null;
   if (issueNumberFromUrl(comment.issue_url) !== Number(command.issue_number)) return null;
-  if (!String(comment.body ?? "").includes(`clawsweeper-command-ack:${command.comment_id}`)) {
+  if (commandAckMarkerFromBody(comment.body) !== commandAckMarkerForCommentId(command.comment_id))
+    return null;
+  return comment;
+}
+
+function convergePrecreatedCommandAckComments(command: LooseRecord) {
+  if (!command.issue_number || !command.comment_id) return null;
+  try {
+    return convergePrecreatedCommandAckCommentsInner(command);
+  } catch (error) {
+    console.warn(
+      `[comment-router] warning: fast ack convergence failed for ${command.repo}#${command.issue_number}: ${compactText(ghErrorText(error), 160)}`,
+    );
     return null;
   }
-  return comment;
+}
+
+function convergePrecreatedCommandAckCommentsInner(command: LooseRecord) {
+  const marker = commandAckMarkerForCommentId(command.comment_id);
+  const comments = cachedIssueComments(command.issue_number)
+    .filter(
+      (comment: JsonValue) =>
+        isTrustedStatusComment(comment) && commandAckMarkerFromBody(comment.body) === marker,
+    )
+    .sort(compareCommentsByCreatedAt);
+  if (comments.length === 0) return null;
+  const keep = selectCommandAckKeeper(comments) as LooseRecord;
+  const keepId = Number(keep.id ?? 0) || 0;
+  let deleted = false;
+  for (const comment of comments) {
+    const id = Number(comment.id ?? 0) || 0;
+    if (id <= 0 || id === keepId) continue;
+    ghBestEffort(["api", `repos/${command.repo}/issues/comments/${id}`, "--method", "DELETE"]);
+    deleted = true;
+  }
+  if (deleted) issueCommentsCache.delete(Number(command.issue_number));
+  return keep;
+}
+
+function commandAckMarkerForCommentId(commentId: JsonValue) {
+  return `<!-- clawsweeper-command-ack:${commentId} -->`;
+}
+
+function commandAckMarkerFromBody(body: JsonValue) {
+  return String(body ?? "").match(/<!--\s*clawsweeper-command-ack:\d+\s*-->/)?.[0] ?? null;
+}
+
+function selectCommandAckKeeper(comments: JsonValue[]) {
+  return [...comments].sort(compareCommandAckKeepPriority)[0] ?? null;
+}
+
+function compareCommandAckKeepPriority(left: JsonValue, right: JsonValue) {
+  const leftRecord = left as LooseRecord;
+  const rightRecord = right as LooseRecord;
+  const leftStatus = commandAckStatusScore(leftRecord);
+  const rightStatus = commandAckStatusScore(rightRecord);
+  if (leftStatus !== rightStatus) return rightStatus - leftStatus;
+  if (leftStatus > 0) return compareCommentsByUpdatedAtDesc(leftRecord, rightRecord);
+  return compareCommentsByCreatedAt(leftRecord, rightRecord);
+}
+
+function commandAckStatusScore(comment: LooseRecord) {
+  const body = String(comment.body ?? "");
+  return body.includes("clawsweeper-command-status:") ||
+    body.includes("<!-- clawsweeper-command-progress:start -->")
+    ? 1
+    : 0;
+}
+
+function compareCommentsByUpdatedAtDesc(left: LooseRecord, right: LooseRecord) {
+  const leftUpdated = String(left.updated_at ?? left.created_at ?? "");
+  const rightUpdated = String(right.updated_at ?? right.created_at ?? "");
+  return (
+    rightUpdated.localeCompare(leftUpdated) || (Number(right.id) || 0) - (Number(left.id) || 0)
+  );
+}
+
+function compareCommentsByCreatedAt(left: JsonValue, right: JsonValue) {
+  const leftRecord = left as LooseRecord;
+  const rightRecord = right as LooseRecord;
+  const leftCreated = String(leftRecord.created_at ?? "");
+  const rightCreated = String(rightRecord.created_at ?? "");
+  return (
+    leftCreated.localeCompare(rightCreated) ||
+    (Number(leftRecord.id) || 0) - (Number(rightRecord.id) || 0)
+  );
 }
 
 function automergeTimelineEvents(command: LooseRecord, body: string) {

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -37,6 +37,7 @@ import {
   buildAutomergeMergeArgs,
   buildAutomergeSquashMessage,
   commandHasAction,
+  commandStatusMarkerFromBody,
   createCachedIssueCommentsLookup,
   createCachedIssueCommentsLookupAsync,
   createCachedLabelNumberLookup,
@@ -52,6 +53,7 @@ import {
   maintainerAutomergeOptInApprovesNeedsHuman as maintainerAutomergeOptInApprovesNeedsHumanReason,
   latestRepairLoopResumeTime,
   parseRoutedCommentCommand,
+  planCommandAckConvergence,
   pausedModeStatusBlocksReplay,
   parseTrustedAutomation,
   repairableCheckBlockers,
@@ -3013,6 +3015,8 @@ function findPrecreatedCommandStatusComment(command: LooseRecord) {
   if (issueNumberFromUrl(comment.issue_url) !== Number(command.issue_number)) return null;
   if (commandAckMarkerFromBody(comment.body) !== commandAckMarkerForCommentId(command.comment_id))
     return null;
+  const statusMarker = commandStatusMarkerFromBody(comment.body);
+  if (statusMarker && statusMarker !== commandStatusMarker(command)) return null;
   return comment;
 }
 
@@ -3030,19 +3034,20 @@ function convergePrecreatedCommandAckComments(command: LooseRecord) {
 
 function convergePrecreatedCommandAckCommentsInner(command: LooseRecord) {
   const marker = commandAckMarkerForCommentId(command.comment_id);
-  const comments = cachedIssueComments(command.issue_number)
-    .filter(
-      (comment: JsonValue) =>
-        isTrustedStatusComment(comment) && commandAckMarkerFromBody(comment.body) === marker,
-    )
-    .sort(compareCommentsByCreatedAt);
+  const comments = cachedIssueComments(command.issue_number).filter(
+    (comment: JsonValue) =>
+      isTrustedStatusComment(comment) && commandAckMarkerFromBody(comment.body) === marker,
+  );
   if (comments.length === 0) return null;
-  const keep = selectCommandAckKeeper(comments) as LooseRecord;
-  const keepId = Number(keep.id ?? 0) || 0;
+  const { keep, prunable } = planCommandAckConvergence(
+    comments as LooseRecord[],
+    commandStatusMarker(command),
+  );
+  if (!keep) return null;
   let deleted = false;
-  for (const comment of comments) {
+  for (const comment of prunable) {
     const id = Number(comment.id ?? 0) || 0;
-    if (id <= 0 || id === keepId) continue;
+    if (id <= 0) continue;
     ghBestEffort(["api", `repos/${command.repo}/issues/comments/${id}`, "--method", "DELETE"]);
     deleted = true;
   }
@@ -3056,47 +3061,6 @@ function commandAckMarkerForCommentId(commentId: JsonValue) {
 
 function commandAckMarkerFromBody(body: JsonValue) {
   return String(body ?? "").match(/<!--\s*clawsweeper-command-ack:\d+\s*-->/)?.[0] ?? null;
-}
-
-function selectCommandAckKeeper(comments: JsonValue[]) {
-  return [...comments].sort(compareCommandAckKeepPriority)[0] ?? null;
-}
-
-function compareCommandAckKeepPriority(left: JsonValue, right: JsonValue) {
-  const leftRecord = left as LooseRecord;
-  const rightRecord = right as LooseRecord;
-  const leftStatus = commandAckStatusScore(leftRecord);
-  const rightStatus = commandAckStatusScore(rightRecord);
-  if (leftStatus !== rightStatus) return rightStatus - leftStatus;
-  if (leftStatus > 0) return compareCommentsByUpdatedAtDesc(leftRecord, rightRecord);
-  return compareCommentsByCreatedAt(leftRecord, rightRecord);
-}
-
-function commandAckStatusScore(comment: LooseRecord) {
-  const body = String(comment.body ?? "");
-  return body.includes("clawsweeper-command-status:") ||
-    body.includes("<!-- clawsweeper-command-progress:start -->")
-    ? 1
-    : 0;
-}
-
-function compareCommentsByUpdatedAtDesc(left: LooseRecord, right: LooseRecord) {
-  const leftUpdated = String(left.updated_at ?? left.created_at ?? "");
-  const rightUpdated = String(right.updated_at ?? right.created_at ?? "");
-  return (
-    rightUpdated.localeCompare(leftUpdated) || (Number(right.id) || 0) - (Number(left.id) || 0)
-  );
-}
-
-function compareCommentsByCreatedAt(left: JsonValue, right: JsonValue) {
-  const leftRecord = left as LooseRecord;
-  const rightRecord = right as LooseRecord;
-  const leftCreated = String(leftRecord.created_at ?? "");
-  const rightCreated = String(rightRecord.created_at ?? "");
-  return (
-    leftCreated.localeCompare(rightCreated) ||
-    (Number(leftRecord.id) || 0) - (Number(rightRecord.id) || 0)
-  );
 }
 
 function automergeTimelineEvents(command: LooseRecord, body: string) {

--- a/src/repair/comment-webhook.ts
+++ b/src/repair/comment-webhook.ts
@@ -22,7 +22,7 @@ const PULL_ITEM_ACTIONS = new Set([
   "labeled",
   "unlabeled",
 ]);
-const FAST_ACK_SETTLE_DELAYS_MS = [250, 1500];
+const DEFAULT_FAST_ACK_SETTLE_DELAYS_MS = [250, 1500, 10_000];
 const inFlightFastAcks = new Map<string, Promise<number>>();
 
 type AcceptedIssueCommentWebhook = {
@@ -145,6 +145,7 @@ export async function handleGitHubWebhook({
     repo: accepted.targetRepo,
     itemNumber: accepted.itemNumber,
     sourceCommentId: accepted.commentId,
+    delaysMs: fastAckSettleDelaysMs(process.env.CLAWSWEEPER_FAST_ACK_SETTLE_DELAYS_MS),
   });
   return { statusCode: 202, body: { ok: true, status_comment_id: statusCommentId } };
 }
@@ -460,14 +461,16 @@ function settleFastAckComments({
   repo,
   itemNumber,
   sourceCommentId,
+  delaysMs = DEFAULT_FAST_ACK_SETTLE_DELAYS_MS,
 }: {
   token: string;
   repo: string;
   itemNumber: number;
   sourceCommentId: number;
+  delaysMs?: number[];
 }) {
   const cleanup = async () => {
-    for (const delayMs of FAST_ACK_SETTLE_DELAYS_MS) {
+    for (const delayMs of delaysMs) {
       await sleep(delayMs);
       await pruneFastAckComments({ token, repo, itemNumber, sourceCommentId });
     }
@@ -476,6 +479,14 @@ function settleFastAckComments({
     const message = error instanceof Error ? error.message : String(error);
     console.error(`[clawsweeper webhook] fast ack cleanup failed: ${message}`);
   });
+}
+
+function fastAckSettleDelaysMs(value: string | undefined) {
+  const delays = String(value ?? "")
+    .split(",")
+    .map((entry) => Number.parseInt(entry.trim(), 10))
+    .filter((delay) => Number.isFinite(delay) && delay >= 0);
+  return delays.length > 0 ? delays : DEFAULT_FAST_ACK_SETTLE_DELAYS_MS;
 }
 
 async function createFastAckCommentOnce({
@@ -531,17 +542,13 @@ async function pruneFastAckComments({
 }) {
   const comments = await listFastAckComments({ token, repo, itemNumber, sourceCommentId });
   if (comments.length === 0) return null;
-  comments.sort((left, right) => {
-    const leftCreated = String(left.created_at ?? "");
-    const rightCreated = String(right.created_at ?? "");
-    return (
-      leftCreated.localeCompare(rightCreated) || (Number(left.id) || 0) - (Number(right.id) || 0)
-    );
-  });
+  const hasStatusComment = comments.some(isStatusBearingFastAckComment);
+  comments.sort(compareFastAckKeepPriority);
   const keepId = Number(comments[0]?.id) || null;
-  for (const comment of comments.slice(1)) {
+  for (const comment of comments) {
     const id = Number(comment.id) || 0;
     if (id <= 0 || id === keepId) continue;
+    if (hasStatusComment && isStatusBearingFastAckComment(comment)) continue;
     await githubFetch({
       token,
       path: `/repos/${repo}/issues/comments/${id}`,
@@ -552,6 +559,38 @@ async function pruneFastAckComments({
     });
   }
   return keepId;
+}
+
+function compareFastAckKeepPriority(left: LooseRecord, right: LooseRecord) {
+  const leftStatus = isStatusBearingFastAckComment(left) ? 1 : 0;
+  const rightStatus = isStatusBearingFastAckComment(right) ? 1 : 0;
+  if (leftStatus !== rightStatus) return rightStatus - leftStatus;
+  if (leftStatus > 0) return compareCommentsByUpdatedAtDesc(left, right);
+  return compareCommentsByCreatedAt(left, right);
+}
+
+function isStatusBearingFastAckComment(comment: LooseRecord) {
+  const body = String(comment.body ?? "");
+  return (
+    body.includes("clawsweeper-command-status:") ||
+    body.includes("<!-- clawsweeper-command-progress:start -->")
+  );
+}
+
+function compareCommentsByUpdatedAtDesc(left: LooseRecord, right: LooseRecord) {
+  const leftUpdated = String(left.updated_at ?? left.created_at ?? "");
+  const rightUpdated = String(right.updated_at ?? right.created_at ?? "");
+  return (
+    rightUpdated.localeCompare(leftUpdated) || (Number(right.id) || 0) - (Number(left.id) || 0)
+  );
+}
+
+function compareCommentsByCreatedAt(left: LooseRecord, right: LooseRecord) {
+  const leftCreated = String(left.created_at ?? "");
+  const rightCreated = String(right.created_at ?? "");
+  return (
+    leftCreated.localeCompare(rightCreated) || (Number(left.id) || 0) - (Number(right.id) || 0)
+  );
 }
 
 async function listFastAckComments({

--- a/src/repair/update-command-status.ts
+++ b/src/repair/update-command-status.ts
@@ -58,7 +58,13 @@ async function findCommandStatusComment(options: Options): Promise<LooseRecord |
   let shouldContinue = true;
   while (shouldContinue) {
     const exact = fetchExactStatusComment(options);
-    if (exact && !commandAckMarkerFromBody(exact.body)) return exact;
+    if (
+      exact &&
+      !commandAckMarkerFromBody(exact.body) &&
+      !statusMarkerDiffersFromRequested(exact.body, options.marker)
+    ) {
+      return exact;
+    }
     let comments: LooseRecord[];
     try {
       comments = ghPagedWithRetry<LooseRecord>(
@@ -66,7 +72,7 @@ async function findCommandStatusComment(options: Options): Promise<LooseRecord |
         { attempts: 3 },
       );
     } catch (error) {
-      if (exact) return exact;
+      if (exact && !statusMarkerDiffersFromRequested(exact.body, options.marker)) return exact;
       throw error;
     }
     const match = selectCommandStatusComment(comments, options);
@@ -74,7 +80,7 @@ async function findCommandStatusComment(options: Options): Promise<LooseRecord |
       pruneDuplicateCommandAckComments({ comments, keep: match, options });
       return match;
     }
-    if (exact) return exact;
+    if (exact && !statusMarkerDiffersFromRequested(exact.body, options.marker)) return exact;
     shouldContinue = Date.now() < deadline;
     if (!shouldContinue) break;
     await sleep(5000);
@@ -109,7 +115,11 @@ export function selectCommandStatusComment(
         Number(comment.id ?? 0) === options.statusCommentId &&
         isTrustedStatusComment(comment, options.trustedBots),
     );
-    if (exact) return matchingAckCommentForStatus(comments, exact, options) ?? exact;
+    if (exact) {
+      const match = matchingAckCommentForStatus(comments, exact, options);
+      if (match) return match;
+      if (!statusMarkerDiffersFromRequested(exact.body, options.marker)) return exact;
+    }
   }
   if (!options.marker) return null;
   return (
@@ -136,7 +146,7 @@ function matchingAckCommentForStatus(
     ? matching.filter((comment) => String(comment.body ?? "").includes(options.marker))
     : [];
   if (sameStatus.length > 0) return selectCommandAckKeeper(sameStatus);
-  if (matching.some((comment) => commandStatusMarkerFromBody(comment.body))) return exact;
+  if (matching.some((comment) => commandStatusMarkerFromBody(comment.body))) return null;
   return selectCommandAckKeeper(matching);
 }
 
@@ -184,6 +194,11 @@ function commandStatusMarkerFromBody(body: JsonValue) {
   return (
     String(body ?? "").match(new RegExp("<!--\\s*clawsweeper-command-status:[^>]+-->"))?.[0] ?? null
   );
+}
+
+function statusMarkerDiffersFromRequested(body: JsonValue, requestedStatusMarker: string) {
+  const statusMarker = commandStatusMarkerFromBody(body);
+  return Boolean(requestedStatusMarker && statusMarker && statusMarker !== requestedStatusMarker);
 }
 
 function isPrunableCommandAckDuplicate(comment: LooseRecord, requestedStatusMarker: string) {

--- a/src/repair/update-command-status.ts
+++ b/src/repair/update-command-status.ts
@@ -58,13 +58,23 @@ async function findCommandStatusComment(options: Options): Promise<LooseRecord |
   let shouldContinue = true;
   while (shouldContinue) {
     const exact = fetchExactStatusComment(options);
-    if (exact) return exact;
-    const comments = ghPagedWithRetry<LooseRecord>(
-      `repos/${options.repo}/issues/${options.itemNumber}/comments?per_page=100`,
-      { attempts: 3 },
-    );
+    if (exact && !commandAckMarkerFromBody(exact.body)) return exact;
+    let comments: LooseRecord[];
+    try {
+      comments = ghPagedWithRetry<LooseRecord>(
+        `repos/${options.repo}/issues/${options.itemNumber}/comments?per_page=100`,
+        { attempts: 3 },
+      );
+    } catch (error) {
+      if (exact) return exact;
+      throw error;
+    }
     const match = selectCommandStatusComment(comments, options);
-    if (match) return match;
+    if (match) {
+      pruneDuplicateCommandAckComments({ comments, keep: match, options });
+      return match;
+    }
+    if (exact) return exact;
     shouldContinue = Date.now() < deadline;
     if (!shouldContinue) break;
     await sleep(5000);
@@ -99,7 +109,7 @@ export function selectCommandStatusComment(
         Number(comment.id ?? 0) === options.statusCommentId &&
         isTrustedStatusComment(comment, options.trustedBots),
     );
-    if (exact) return exact;
+    if (exact) return matchingAckCommentForStatus(comments, exact, options) ?? exact;
   }
   if (!options.marker) return null;
   return (
@@ -111,6 +121,106 @@ export function selectCommandStatusComment(
           comment.body.includes(options.marker),
       )
       .at(-1) ?? null
+  );
+}
+
+function matchingAckCommentForStatus(
+  comments: LooseRecord[],
+  exact: LooseRecord,
+  options: Pick<Options, "marker" | "trustedBots">,
+) {
+  const ackMarker = commandAckMarkerFromBody(exact.body);
+  if (!ackMarker) return null;
+  const matching = commandAckComments(comments, ackMarker, options.trustedBots);
+  const sameStatus = options.marker
+    ? matching.filter((comment) => String(comment.body ?? "").includes(options.marker))
+    : [];
+  if (sameStatus.length > 0) return selectCommandAckKeeper(sameStatus);
+  if (matching.some((comment) => commandStatusMarkerFromBody(comment.body))) return exact;
+  return selectCommandAckKeeper(matching);
+}
+
+function pruneDuplicateCommandAckComments({
+  comments,
+  keep,
+  options,
+}: {
+  comments: LooseRecord[];
+  keep: LooseRecord;
+  options: Pick<Options, "marker" | "repo" | "trustedBots">;
+}) {
+  const marker = commandAckMarkerFromBody(keep.body);
+  if (!marker) return;
+  const matching = commandAckComments(comments, marker, options.trustedBots);
+  const keepId = Number(keep.id ?? 0) || 0;
+  for (const comment of matching) {
+    const id = Number(comment.id ?? 0) || 0;
+    if (id <= 0 || id === keepId) continue;
+    if (!isPrunableCommandAckDuplicate(comment, options.marker)) continue;
+    try {
+      ghText(["api", `repos/${options.repo}/issues/comments/${id}`, "--method", "DELETE"]);
+    } catch (error) {
+      if (!/\b404\b|Not Found/i.test(String(error))) throw error;
+    }
+  }
+}
+
+function commandAckComments(comments: LooseRecord[], marker: string, trustedBots: Set<string>) {
+  return comments
+    .filter(
+      (comment) =>
+        isTrustedStatusComment(comment, trustedBots) &&
+        typeof comment.body === "string" &&
+        commandAckMarkerFromBody(comment.body) === marker,
+    )
+    .sort(compareCommentsByCreatedAt);
+}
+
+function commandAckMarkerFromBody(body: JsonValue) {
+  return String(body ?? "").match(/<!--\s*clawsweeper-command-ack:\d+\s*-->/)?.[0] ?? null;
+}
+
+function commandStatusMarkerFromBody(body: JsonValue) {
+  return (
+    String(body ?? "").match(new RegExp("<!--\\s*clawsweeper-command-status:[^>]+-->"))?.[0] ?? null
+  );
+}
+
+function isPrunableCommandAckDuplicate(comment: LooseRecord, requestedStatusMarker: string) {
+  const statusMarker = commandStatusMarkerFromBody(comment.body);
+  return !statusMarker || statusMarker === requestedStatusMarker;
+}
+
+function selectCommandAckKeeper(comments: LooseRecord[]) {
+  return [...comments].sort(compareCommandAckKeepPriority)[0] ?? null;
+}
+
+function compareCommandAckKeepPriority(left: LooseRecord, right: LooseRecord) {
+  const leftStatus = commandAckStatusScore(left);
+  const rightStatus = commandAckStatusScore(right);
+  if (leftStatus !== rightStatus) return rightStatus - leftStatus;
+  if (leftStatus > 0) return compareCommentsByUpdatedAtDesc(left, right);
+  return compareCommentsByCreatedAt(left, right);
+}
+
+function commandAckStatusScore(comment: LooseRecord) {
+  const body = String(comment.body ?? "");
+  return body.includes("clawsweeper-command-status:") || body.includes(PROGRESS_START) ? 1 : 0;
+}
+
+function compareCommentsByUpdatedAtDesc(left: LooseRecord, right: LooseRecord) {
+  const leftUpdated = String(left.updated_at ?? left.created_at ?? "");
+  const rightUpdated = String(right.updated_at ?? right.created_at ?? "");
+  return (
+    rightUpdated.localeCompare(leftUpdated) || (Number(right.id) || 0) - (Number(left.id) || 0)
+  );
+}
+
+function compareCommentsByCreatedAt(left: LooseRecord, right: LooseRecord) {
+  const leftCreated = String(left.created_at ?? "");
+  const rightCreated = String(right.created_at ?? "");
+  return (
+    leftCreated.localeCompare(rightCreated) || (Number(left.id) || 0) - (Number(right.id) || 0)
   );
 }
 

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -1628,6 +1628,7 @@ test("hosted webhook reuses existing fast ack comments on redelivery", async () 
         CLAWSWEEPER_APP_CLIENT_ID: "Iv23test",
         CLAWSWEEPER_APP_PRIVATE_KEY: privateKey,
         CLAWSWEEPER_WEBHOOK_SECRET: "test-secret",
+        CLAWSWEEPER_FAST_ACK_SETTLE_DELAYS_MS: "0",
       },
     );
 
@@ -1647,6 +1648,7 @@ test("hosted webhook reuses existing fast ack comments on redelivery", async () 
         max_comments: "1",
       },
     });
+    await new Promise((resolve) => setTimeout(resolve, 0));
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -1739,6 +1741,7 @@ test("hosted webhook coalesces concurrent duplicate fast ack comments", async ()
     CLAWSWEEPER_APP_CLIENT_ID: "Iv23test",
     CLAWSWEEPER_APP_PRIVATE_KEY: privateKey,
     CLAWSWEEPER_WEBHOOK_SECRET: "test-secret",
+    CLAWSWEEPER_FAST_ACK_SETTLE_DELAYS_MS: "0",
   };
 
   try {
@@ -1772,6 +1775,7 @@ test("hosted webhook coalesces concurrent duplicate fast ack comments", async ()
       ),
       [777, 777],
     );
+    await new Promise((resolve) => setTimeout(resolve, 0));
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -1865,6 +1869,7 @@ test("hosted webhook removes duplicate fast ack comments after concurrent redeli
         CLAWSWEEPER_APP_CLIENT_ID: "Iv23test",
         CLAWSWEEPER_APP_PRIVATE_KEY: privateKey,
         CLAWSWEEPER_WEBHOOK_SECRET: "test-secret",
+        CLAWSWEEPER_FAST_ACK_SETTLE_DELAYS_MS: "0",
       },
     );
 
@@ -1885,6 +1890,7 @@ test("hosted webhook removes duplicate fast ack comments after concurrent redeli
         max_comments: "1",
       },
     });
+    await new Promise((resolve) => setTimeout(resolve, 0));
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -1933,16 +1939,25 @@ test("hosted webhook schedules post-dispatch fast ack cleanup", async () => {
         {
           id: 888,
           created_at: "2026-05-28T13:00:01Z",
-          body: "<!-- clawsweeper-command-ack:456 -->\nClawSweeper picked this up.",
+          updated_at: "2026-05-28T13:00:02Z",
+          body: [
+            "<!-- clawsweeper-command-status:597:implement_issue:abc123 -->",
+            "<!-- clawsweeper-command-ack:456 -->",
+            "ClawSweeper issue implementation requested.",
+            "<!-- clawsweeper-command-progress:start -->",
+            "Implementation progress:",
+            "- State: In progress",
+            "<!-- clawsweeper-command-progress:end -->",
+          ].join("\n"),
           user: { login: "openclaw-clawsweeper[bot]" },
         },
       ]);
     }
     if (
-      url.pathname === "/repos/openclaw/gogcli/issues/comments/888" &&
+      url.pathname === "/repos/openclaw/gogcli/issues/comments/777" &&
       init?.method === "DELETE"
     ) {
-      deletedAck = 888;
+      deletedAck = 777;
       return new Response(null, { status: 204 });
     }
     if (url.pathname === "/repos/openclaw/gogcli/issues/comments/456/reactions") {
@@ -1983,6 +1998,7 @@ test("hosted webhook schedules post-dispatch fast ack cleanup", async () => {
         CLAWSWEEPER_APP_CLIENT_ID: "Iv23test",
         CLAWSWEEPER_APP_PRIVATE_KEY: privateKey,
         CLAWSWEEPER_WEBHOOK_SECRET: "test-secret",
+        CLAWSWEEPER_FAST_ACK_SETTLE_DELAYS_MS: "0,0,0",
       },
       {
         waitUntil(promise: Promise<unknown>) {
@@ -1995,7 +2011,7 @@ test("hosted webhook schedules post-dispatch fast ack cleanup", async () => {
     assert.deepEqual(await response.json(), { ok: true, status_comment_id: 777 });
     assert.equal(waitUntilPromises.length, 1);
     await Promise.all(waitUntilPromises);
-    assert.equal(deletedAck, 888);
+    assert.equal(deletedAck, 777);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -28,6 +28,7 @@ import {
   createCachedIssueCommentsLookupAsync,
   commandResponseMarker,
   commandResponseMarkerPrefix,
+  commandStatusMarkerFromBody,
   commandStatusMarkerPrefix,
   createCachedLabelNumberLookup,
   existingCommandStatusBlocksReplay,
@@ -43,6 +44,7 @@ import {
   maintainerAutomergeOptInApprovesNeedsHuman,
   parseCommand,
   parseRoutedCommentCommand,
+  planCommandAckConvergence,
   pausedModeStatusBlocksReplay,
   parseTrustedAutomation,
   repairableCheckBlockers,
@@ -60,6 +62,79 @@ import {
 } from "../../dist/repair/comment-router-core.js";
 import { CLAWSWEEPER_CO_AUTHOR_TRAILER } from "../../dist/repair/co-author-credit.js";
 import { parseSimpleYaml, validateJob } from "../../dist/repair/lib.js";
+
+test("planCommandAckConvergence scopes duplicate cleanup to the current status marker", () => {
+  const requestedStatus = "<!-- clawsweeper-command-status:81564:re_review:new -->";
+  const otherStatus = "<!-- clawsweeper-command-status:81564:re_review:old -->";
+  const comments = [
+    {
+      id: 101,
+      created_at: "2026-05-29T10:00:00Z",
+      updated_at: "2026-05-29T10:01:00Z",
+      body: `${otherStatus}\n<!-- clawsweeper-command-ack:456 -->\nOld status.`,
+    },
+    {
+      id: 102,
+      created_at: "2026-05-29T10:02:00Z",
+      updated_at: "2026-05-29T10:02:00Z",
+      body: "<!-- clawsweeper-command-ack:456 -->\nClawSweeper picked this up.",
+    },
+    {
+      id: 103,
+      created_at: "2026-05-29T10:03:00Z",
+      updated_at: "2026-05-29T10:05:00Z",
+      body: `${requestedStatus}\n<!-- clawsweeper-command-ack:456 -->\nCurrent status.`,
+    },
+    {
+      id: 104,
+      created_at: "2026-05-29T10:04:00Z",
+      updated_at: "2026-05-29T10:04:00Z",
+      body: "<!-- clawsweeper-command-ack:456 -->\nClawSweeper picked this up.",
+    },
+  ];
+
+  const plan = planCommandAckConvergence(comments, requestedStatus);
+
+  assert.equal(plan.keep?.id, 103);
+  assert.deepEqual(
+    plan.prunable.map((comment) => comment.id),
+    [102, 104],
+  );
+  assert.equal(commandStatusMarkerFromBody(comments[0].body), otherStatus);
+});
+
+test("planCommandAckConvergence keeps a new bare ack over an unrelated status comment", () => {
+  const requestedStatus = "<!-- clawsweeper-command-status:81564:re_review:new -->";
+  const otherStatus = "<!-- clawsweeper-command-status:81564:re_review:old -->";
+  const comments = [
+    {
+      id: 101,
+      created_at: "2026-05-29T10:00:00Z",
+      updated_at: "2026-05-29T10:01:00Z",
+      body: `${otherStatus}\n<!-- clawsweeper-command-ack:456 -->\nOld status.`,
+    },
+    {
+      id: 102,
+      created_at: "2026-05-29T10:02:00Z",
+      updated_at: "2026-05-29T10:02:00Z",
+      body: "<!-- clawsweeper-command-ack:456 -->\nClawSweeper picked this up.",
+    },
+    {
+      id: 103,
+      created_at: "2026-05-29T10:03:00Z",
+      updated_at: "2026-05-29T10:03:00Z",
+      body: "<!-- clawsweeper-command-ack:456 -->\nClawSweeper picked this up.",
+    },
+  ];
+
+  const plan = planCommandAckConvergence(comments, requestedStatus);
+
+  assert.equal(plan.keep?.id, 102);
+  assert.deepEqual(
+    plan.prunable.map((comment) => comment.id),
+    [103],
+  );
+});
 
 test("parseCommand recognizes maintainer slash commands", () => {
   assert.deepEqual(parseCommand("/clawsweeper fix ci"), {

--- a/test/repair/comment-webhook.test.ts
+++ b/test/repair/comment-webhook.test.ts
@@ -408,6 +408,7 @@ test("concurrent duplicate command webhooks converge on one fast ack comment", a
   const previousAppId = process.env.CLAWSWEEPER_APP_ID;
   const previousClientId = process.env.CLAWSWEEPER_APP_CLIENT_ID;
   const previousPrivateKey = process.env.CLAWSWEEPER_APP_PRIVATE_KEY;
+  const previousSettleDelays = process.env.CLAWSWEEPER_FAST_ACK_SETTLE_DELAYS_MS;
   const { privateKey } = crypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
   const comments: Array<{ id: number; body: string; created_at: string; user: { login: string } }> =
     [];
@@ -416,6 +417,7 @@ test("concurrent duplicate command webhooks converge on one fast ack comment", a
   let dispatches = 0;
   process.env.CLAWSWEEPER_APP_ID = "12345";
   delete process.env.CLAWSWEEPER_APP_CLIENT_ID;
+  process.env.CLAWSWEEPER_FAST_ACK_SETTLE_DELAYS_MS = "0,0,0";
   process.env.CLAWSWEEPER_APP_PRIVATE_KEY = privateKey
     .export({ type: "pkcs1", format: "pem" })
     .toString();
@@ -488,11 +490,13 @@ test("concurrent duplicate command webhooks converge on one fast ack comment", a
     assert.equal(dispatches, 2);
     assert.equal(comments.length, 1);
     assert.match(comments[0]?.body ?? "", /clawsweeper-command-ack:456/);
+    await new Promise((resolve) => setTimeout(resolve, 0));
   } finally {
     globalThis.fetch = previousFetch;
     restoreEnv("CLAWSWEEPER_APP_ID", previousAppId);
     restoreEnv("CLAWSWEEPER_APP_CLIENT_ID", previousClientId);
     restoreEnv("CLAWSWEEPER_APP_PRIVATE_KEY", previousPrivateKey);
+    restoreEnv("CLAWSWEEPER_FAST_ACK_SETTLE_DELAYS_MS", previousSettleDelays);
   }
 });
 
@@ -548,8 +552,17 @@ test("comment webhook settles duplicate fast ack comments after dispatch", async
         },
         {
           id: 9002,
-          body: "<!-- clawsweeper-command-ack:456 -->\nClawSweeper picked this up.",
+          body: [
+            "<!-- clawsweeper-command-status:71898:re_review:abc123 -->",
+            "<!-- clawsweeper-command-ack:456 -->",
+            "ClawSweeper re-review requested.",
+            "<!-- clawsweeper-command-progress:start -->",
+            "Re-review progress:",
+            "- State: In progress",
+            "<!-- clawsweeper-command-progress:end -->",
+          ].join("\n"),
           created_at: "2026-05-28T13:00:01Z",
+          updated_at: "2026-05-28T13:00:02Z",
           user: { login: "clawsweeper[bot]" },
         },
       ]);
@@ -560,8 +573,8 @@ test("comment webhook settles duplicate fast ack comments after dispatch", async
     if (path === "/repos/openclaw/clawsweeper/dispatches" && method === "POST") {
       return jsonResponse({});
     }
-    if (path === "/repos/openclaw/openclaw/issues/comments/9002" && method === "DELETE") {
-      deletedAck = 9002;
+    if (path === "/repos/openclaw/openclaw/issues/comments/9001" && method === "DELETE") {
+      deletedAck = 9001;
       resolveDeleted?.();
       return jsonResponse({});
     }
@@ -587,7 +600,7 @@ test("comment webhook settles duplicate fast ack comments after dispatch", async
 
     assert.deepEqual(result, { statusCode: 202, body: { ok: true, status_comment_id: 9001 } });
     await deleted;
-    assert.equal(deletedAck, 9002);
+    assert.equal(deletedAck, 9001);
   } finally {
     globalThis.fetch = previousFetch;
     restoreEnv("CLAWSWEEPER_APP_ID", previousAppId);

--- a/test/repair/update-command-status.test.ts
+++ b/test/repair/update-command-status.test.ts
@@ -111,6 +111,147 @@ test("selectCommandStatusComment prefers exact status comment ids", () => {
   assert.equal(selected?.id, 4466202000);
 });
 
+test("selectCommandStatusComment converges duplicate bare fast ack comments to the oldest", () => {
+  const marker = "<!-- clawsweeper-command-status:81564:re_review:320c867f -->";
+  const options = parseOptions(["--marker", marker, "--status-comment-id", "4466202000"]);
+  const selected = selectCommandStatusComment(
+    [
+      {
+        id: 4466202000,
+        created_at: "2026-05-29T19:19:48Z",
+        user: { login: "clawsweeper[bot]" },
+        body: "<!-- clawsweeper-command-ack:4466201487 -->\nClawSweeper picked this up.",
+      },
+      {
+        id: 4466201000,
+        created_at: "2026-05-29T19:19:39Z",
+        user: { login: "clawsweeper[bot]" },
+        body: "<!-- clawsweeper-command-ack:4466201487 -->\nClawSweeper picked this up.",
+      },
+    ],
+    {
+      marker: options.marker,
+      statusCommentId: options.statusCommentId,
+      trustedBots: options.trustedBots,
+    },
+  );
+
+  assert.equal(selected?.id, 4466201000);
+});
+
+test("selectCommandStatusComment preserves status-bearing fast ack comments", () => {
+  const marker = "<!-- clawsweeper-command-status:81564:re_review:320c867f -->";
+  const options = parseOptions(["--marker", marker, "--status-comment-id", "4466201000"]);
+  const selected = selectCommandStatusComment(
+    [
+      {
+        id: 4466201000,
+        created_at: "2026-05-29T19:19:39Z",
+        updated_at: "2026-05-29T19:19:39Z",
+        user: { login: "clawsweeper[bot]" },
+        body: "<!-- clawsweeper-command-ack:4466201487 -->\nClawSweeper picked this up.",
+      },
+      {
+        id: 4466202000,
+        created_at: "2026-05-29T19:19:48Z",
+        updated_at: "2026-05-29T19:21:00Z",
+        user: { login: "clawsweeper[bot]" },
+        body: [
+          "<!-- clawsweeper-command-status:81564:re_review:320c867f -->",
+          "<!-- clawsweeper-command-ack:4466201487 -->",
+          "ClawSweeper re-review requested.",
+          "<!-- clawsweeper-command-progress:start -->",
+          "Re-review progress:",
+          "- State: Complete",
+          "<!-- clawsweeper-command-progress:end -->",
+        ].join("\n"),
+      },
+    ],
+    {
+      marker: options.marker,
+      statusCommentId: options.statusCommentId,
+      trustedBots: options.trustedBots,
+    },
+  );
+
+  assert.equal(selected?.id, 4466202000);
+});
+
+test("selectCommandStatusComment scopes shared ack markers to the requested status marker", () => {
+  const oldMarker = "<!-- clawsweeper-command-status:81564:re_review:old -->";
+  const newMarker = "<!-- clawsweeper-command-status:81564:re_review:new -->";
+  const options = parseOptions(["--marker", oldMarker, "--status-comment-id", "4466201000"]);
+  const selected = selectCommandStatusComment(
+    [
+      {
+        id: 4466201000,
+        created_at: "2026-05-29T19:19:39Z",
+        updated_at: "2026-05-29T19:20:00Z",
+        user: { login: "clawsweeper[bot]" },
+        body: [
+          oldMarker,
+          "<!-- clawsweeper-command-ack:4466201487 -->",
+          "ClawSweeper re-review requested.",
+          "<!-- clawsweeper-command-progress:start -->",
+          "Re-review progress:",
+          "- State: In progress",
+          "<!-- clawsweeper-command-progress:end -->",
+        ].join("\n"),
+      },
+      {
+        id: 4466202000,
+        created_at: "2026-05-29T19:21:00Z",
+        updated_at: "2026-05-29T19:22:00Z",
+        user: { login: "clawsweeper[bot]" },
+        body: [
+          newMarker,
+          "<!-- clawsweeper-command-ack:4466201487 -->",
+          "ClawSweeper re-review requested.",
+          "<!-- clawsweeper-command-progress:start -->",
+          "Re-review progress:",
+          "- State: Complete",
+          "<!-- clawsweeper-command-progress:end -->",
+        ].join("\n"),
+      },
+    ],
+    {
+      marker: options.marker,
+      statusCommentId: options.statusCommentId,
+      trustedBots: options.trustedBots,
+    },
+  );
+
+  assert.equal(selected?.id, 4466201000);
+});
+
+test("selectCommandStatusComment matches full fast ack markers", () => {
+  const marker = "<!-- clawsweeper-command-status:81564:re_review:320c867f -->";
+  const options = parseOptions(["--marker", marker, "--status-comment-id", "12"]);
+  const selected = selectCommandStatusComment(
+    [
+      {
+        id: 12,
+        created_at: "2026-05-29T19:19:39Z",
+        user: { login: "clawsweeper[bot]" },
+        body: "<!-- clawsweeper-command-ack:12 -->\nClawSweeper picked this up.",
+      },
+      {
+        id: 123,
+        created_at: "2026-05-29T19:19:48Z",
+        user: { login: "clawsweeper[bot]" },
+        body: "<!-- clawsweeper-command-ack:123 -->\nClawSweeper picked this up.",
+      },
+    ],
+    {
+      marker: options.marker,
+      statusCommentId: options.statusCommentId,
+      trustedBots: options.trustedBots,
+    },
+  );
+
+  assert.equal(selected?.id, 12);
+});
+
 test("selectCommandStatusComment ignores human comments during marker fallback", () => {
   const marker = "<!-- clawsweeper-command-status:81564:re_review:320c867f -->";
   const options = parseOptions(["--marker", marker]);

--- a/test/repair/update-command-status.test.ts
+++ b/test/repair/update-command-status.test.ts
@@ -224,6 +224,45 @@ test("selectCommandStatusComment scopes shared ack markers to the requested stat
   assert.equal(selected?.id, 4466201000);
 });
 
+test("selectCommandStatusComment skips stale exact status-bearing ack comments", () => {
+  const oldMarker = "<!-- clawsweeper-command-status:81564:re_review:old -->";
+  const newMarker = "<!-- clawsweeper-command-status:81564:re_review:new -->";
+  const options = parseOptions(["--marker", newMarker, "--status-comment-id", "4466201000"]);
+  const selected = selectCommandStatusComment(
+    [
+      {
+        id: 4466201000,
+        created_at: "2026-05-29T19:19:39Z",
+        updated_at: "2026-05-29T19:20:00Z",
+        user: { login: "clawsweeper[bot]" },
+        body: [
+          oldMarker,
+          "<!-- clawsweeper-command-ack:4466201487 -->",
+          "ClawSweeper re-review requested.",
+          "<!-- clawsweeper-command-progress:start -->",
+          "Re-review progress:",
+          "- State: In progress",
+          "<!-- clawsweeper-command-progress:end -->",
+        ].join("\n"),
+      },
+      {
+        id: 4466202000,
+        created_at: "2026-05-29T19:21:00Z",
+        updated_at: "2026-05-29T19:22:00Z",
+        user: { login: "clawsweeper[bot]" },
+        body: [newMarker, "ClawSweeper re-review requested."].join("\n"),
+      },
+    ],
+    {
+      marker: options.marker,
+      statusCommentId: options.statusCommentId,
+      trustedBots: options.trustedBots,
+    },
+  );
+
+  assert.equal(selected?.id, 4466202000);
+});
+
 test("selectCommandStatusComment matches full fast ack markers", () => {
   const marker = "<!-- clawsweeper-command-status:81564:re_review:320c867f -->";
   const options = parseOptions(["--marker", marker, "--status-comment-id", "12"]);


### PR DESCRIPTION
## Summary

Fixes duplicate `clawsweeper-command-ack:<source-comment-id>` comments for a single command comment.

The previous mitigation relied on in-memory coalescing plus short delayed prune passes. The live evidence in #226 showed that was not deterministic enough across duplicate webhook delivery, delayed redelivery, Worker instances, or GitHub comment-list timing.

## What changed

- Add a longer default fast-ack settle window: `250ms`, `1500ms`, and `10000ms`.
- Allow the settle delays to be tuned with `CLAWSWEEPER_FAST_ACK_SETTLE_DELAYS_MS`.
- Make webhook/dashboard duplicate cleanup prefer status-bearing ack comments over bare fast-ack stubs.
- Avoid deleting status-bearing ack comments when a status-bearing command comment already exists.
- Add router-side convergence for precreated command ack comments before command handling and before skipped-command responses.
- Preserve the original fast-ack marker when the router updates the status comment.
- Add status-updater convergence using exact ack-marker matching, with status-marker scoping so an edited/reprocessed command cannot hijack another command version's progress comment.
- Add regression coverage for stale duplicate removal, status-bearing preservation, exact marker matching, and prefix collision cases.

## Coordination note

This is separate from the smaller #227 command parsing fix. Both touch `src/repair/comment-router.ts`; if #227 lands first I will rebase this branch so maintainers do not have to untangle it.

Fixes #226.

## Validation

Passed locally on Node `v24.13.0`:

- `pnpm run build:all`
- `pnpm run format:check`
- `pnpm run lint:repair`
- `pnpm run lint:dashboard`
- `pnpm run lint:scripts`
- `node --test test/repair/comment-webhook.test.ts test/repair/update-command-status.test.ts`
- `node --test --test-name-pattern "hosted webhook|dashboard shares in-flight|fast ack" test/dashboard-worker.test.ts`
- `git diff --check`
- `codex review --uncommitted` returned no actionable correctness issues

Also attempted:

- `pnpm run check` currently fails in this Windows local environment on two existing platform assumptions: `/usr/bin/git` is missing and a Unix file-mode assertion differs on Windows.
- `pnpm run test:repair` also has unrelated Windows/local harness failures around mocked `gh`/shell shims, local auth/API assumptions, and local process spawning. The focused changed-surface tests above pass.