### PR TITLE
Require routable ClawSweeper commands before fast ack

### DIFF
--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -1,3 +1,8 @@
+import {
+  commandTextForClawSweeperFastAck,
+  isClawSweeperReReviewCommandText,
+} from "../src/repair/comment-command-text.ts";
+
 const ACTIVE_RUN_STATUSES = new Set(["queued", "in_progress", "waiting", "requested", "pending"]);
 const QUEUED_RUN_STATUSES = new Set(["queued", "waiting", "requested", "pending"]);
 type DashboardEnv = Record<string, unknown>;
@@ -23,8 +28,6 @@ const CLAWSWEEPER_REVIEW_REPO = "openclaw/clawsweeper";
 const CLAWSWEEPER_STATE_REPO = "openclaw/clawsweeper-state";
 const CLAWSWEEPER_STATE_REF = "state";
 const CLUSTER_REPAIR_INTAKE_WORKFLOW = "repair-cluster-intake.yml";
-const CLAWSWEEPER_COMMAND_PATTERN =
-  /(^|[ \t\r\n])@(?:clawsweeper|openclaw-clawsweeper)\b(?:\[bot\])?|(^|[ \t\r\n])\/(?:clawsweeper|review|re-review|rerun[ -]?review|status|explain|fix|build|implement|create[ -]?pr|fix[ -]?issue|autofix|auto[ -]?fix|automerge|auto[ -]?merge|approve|stop|autoclose)\b/i;
 const CLAWSWEEPER_ALLOWED_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
 const CLAWSWEEPER_ISSUE_ITEM_ACTIONS = new Set([
   "opened",
@@ -46,8 +49,6 @@ const CLAWSWEEPER_PULL_ITEM_ACTIONS = new Set([
 const DEFAULT_FAST_ACK_SETTLE_DELAYS_MS = [250, 1500, 10_000];
 const inFlightFastAcks = new Map();
 const CLAWSWEEPER_WEBHOOK_DENY_REPOS = new Set(["openclaw/clawsweeper-state", "openclaw/.github"]);
-const CLAWSWEEPER_AUTHOR_READ_ONLY_COMMAND =
-  "(?:review|re-review|rerun|re-run|rerun[ -]?review|re-run[ -]?review|status|explain)";
 const OPTIONAL_SECTION_TIMEOUT_MS = 6000;
 const STALE_CACHE_TTL_SECONDS = 900;
 const CI_STATUS_TTL_SECONDS = 7200;
@@ -505,12 +506,11 @@ function classifyGithubIssueCommentWebhook({ event, payload }) {
   const issue = objectValue(payload.issue);
   const repo = objectValue(payload.repository);
   const association = String(comment.author_association || "").toUpperCase();
-  if (!CLAWSWEEPER_COMMAND_PATTERN.test(String(comment.body || ""))) {
-    return { accepted: false, reason: "no ClawSweeper command" };
-  }
+  const commandText = commandTextForClawSweeperFastAck(String(comment.body || ""));
+  if (!commandText) return { accepted: false, reason: "no routable ClawSweeper command" };
   if (
     !CLAWSWEEPER_ALLOWED_ASSOCIATIONS.has(association) &&
-    !isAuthorReadOnlyGithubWebhookCommand({ comment, issue })
+    !isAuthorReadOnlyGithubWebhookCommand({ comment, issue, commandText })
   ) {
     return {
       accepted: false,
@@ -634,19 +634,8 @@ function isClawsweeperGithubWebhookSender(sender) {
   return login === "clawsweeper[bot]" || login === "openclaw-clawsweeper[bot]";
 }
 
-function isAuthorReadOnlyGithubWebhookCommand({ comment, issue }) {
-  const body = String(comment.body || "");
-  const slashCommand = new RegExp(
-    `(^|[ \\t\\r\\n])/(?:clawsweeper\\s+)?${CLAWSWEEPER_AUTHOR_READ_ONLY_COMMAND}\\b`,
-    "i",
-  );
-  const mentionCommand = new RegExp(
-    `(^|[ \\t\\r\\n])@(?:clawsweeper|openclaw-clawsweeper)\\b(?:\\[bot\\])?\\s+${CLAWSWEEPER_AUTHOR_READ_ONLY_COMMAND}\\b`,
-    "i",
-  );
-  if (!slashCommand.test(body) && !mentionCommand.test(body)) {
-    return false;
-  }
+function isAuthorReadOnlyGithubWebhookCommand({ comment, issue, commandText }) {
+  if (!isClawSweeperReReviewCommandText(commandText)) return false;
   const commentAuthor = normalizedLogin(objectValue(comment.user).login);
   const issueAuthor = normalizedLogin(objectValue(issue.user).login);
   return Boolean(commentAuthor && issueAuthor && commentAuthor === issueAuthor);

--- a/src/repair/comment-command-text.ts
+++ b/src/repair/comment-command-text.ts
@@ -1,0 +1,92 @@
+export type ClawSweeperCommandTrigger = "slash" | "mention";
+
+export type ClawSweeperCommandLine = {
+  trigger: ClawSweeperCommandTrigger;
+  commandText: string;
+  rest: string;
+  supportsContinuation: boolean;
+};
+
+const MENTION_COMMAND_PATTERN =
+  /^\s*@(?:clawsweeper|openclaw-clawsweeper)(?:\[bot\])?(?:(?:\s*[:,]\s*|\s+)(.+))?\s*$/i;
+const RE_REVIEW_COMMAND_PATTERN =
+  /^(?:review(?:\s+again)?|re-?review|rereview|re-?run(?:\s+review)?|rerun(?:\s+review)?|run\s+(?:review|again))\b[:\s-]+\S/i;
+const RE_REVIEW_PROMPT_PREFIX_PATTERN =
+  /^(?:review(?:\s+again)?|re-?review|rereview|re-?run(?:\s+review)?|rerun(?:\s+review)?|run\s+(?:review|again))\b[:\s-]*/i;
+
+export function extractClawSweeperCommandLine(body: unknown): ClawSweeperCommandLine | null {
+  const lines = String(body ?? "").split(/\r?\n/);
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    if (/^\s*\/auto(?:-|\s+)?merge\s*$/i.test(line)) {
+      return commandLine("slash", "automerge", "", false);
+    }
+    const autoclose = line.match(/^\s*\/autoclose(?:\s+(.+))?\s*$/i);
+    if (autoclose) return commandLine("slash", `autoclose ${autoclose[1] ?? ""}`.trim(), "", false);
+    const review = line.match(/^\s*\/review(?:\s+(.+))?\s*$/i);
+    if (review)
+      return commandLine("slash", review[1] ? `review ${review[1]}` : "review", "", false);
+    const slash = line.match(/^\s*\/clawsweeper(?:\s+(.+))?\s*$/i);
+    if (slash) {
+      return commandLine("slash", slash[1] ?? "status", followingLines(lines, index), true);
+    }
+    const mention = line.match(MENTION_COMMAND_PATTERN);
+    if (mention) {
+      return commandLine("mention", mention[1] ?? "status", followingLines(lines, index), true);
+    }
+  }
+  return null;
+}
+
+export function commandTextForClawSweeperFastAck(body: unknown) {
+  const command = extractClawSweeperCommandLine(body);
+  if (!command) return "";
+  if (command.trigger === "mention" && command.commandText === "status" && command.rest) {
+    return command.rest;
+  }
+  return command.commandText;
+}
+
+export function isClawSweeperReReviewCommandText(commandText: unknown) {
+  const command = String(commandText ?? "")
+    .trim()
+    .replace(/\s+/g, " ")
+    .toLowerCase()
+    .replace(/[.!]+$/g, "");
+  return (
+    command === "review" ||
+    command === "re-review" ||
+    command === "rereview" ||
+    command === "review again" ||
+    command === "rerun" ||
+    command === "re-run" ||
+    command === "rerun review" ||
+    command === "re-run review" ||
+    command === "run review" ||
+    command === "run again" ||
+    RE_REVIEW_COMMAND_PATTERN.test(command)
+  );
+}
+
+export function reviewPromptFromClawSweeperCommandText(commandText: unknown) {
+  return String(commandText ?? "")
+    .trim()
+    .replace(RE_REVIEW_PROMPT_PREFIX_PATTERN, "")
+    .trim();
+}
+
+function commandLine(
+  trigger: ClawSweeperCommandTrigger,
+  commandText: string,
+  rest: string,
+  supportsContinuation: boolean,
+): ClawSweeperCommandLine {
+  return { trigger, commandText, rest, supportsContinuation };
+}
+
+function followingLines(lines: string[], index: number) {
+  return lines
+    .slice(index + 1)
+    .join("\n")
+    .trim();
+}

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -4,6 +4,11 @@ import {
   clawsweeperCoAuthorKey,
   coAuthorKey,
 } from "./co-author-credit.js";
+import {
+  extractClawSweeperCommandLine,
+  isClawSweeperReReviewCommandText,
+  reviewPromptFromClawSweeperCommandText,
+} from "./comment-command-text.js";
 import { renderJobIntentFrontmatter } from "./job-intent.js";
 import { compactText } from "./text-utils.js";
 export const REPAIR_INTENTS = new Set([
@@ -1023,59 +1028,30 @@ function isAfterAutoRepairResumeBoundary(entry: AutoRepairDispatchEntry, resumeB
 }
 
 export function parseCommand(body: string) {
-  const lines = String(body ?? "").split(/\r?\n/);
-  for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index] ?? "";
-    const automerge = line.match(/^\s*\/auto(?:-|\s+)?merge\s*$/i);
-    if (automerge) return commandFromText("slash", "automerge");
-    const autoclose = line.match(/^\s*\/autoclose(?:\s+(.+))?\s*$/i);
-    if (autoclose) return commandFromText("slash", `autoclose ${autoclose[1] ?? ""}`.trim());
-    const review = line.match(/^\s*\/review(?:\s+(.+))?\s*$/i);
-    if (review) return commandFromText("slash", review[1] ? `review ${review[1]}` : "review");
-    const slash = line.match(/^\s*\/clawsweeper(?:\s+(.+))?\s*$/i);
-    if (slash) {
-      const command = commandFromText("slash", slash[1] ?? "status");
-      const rest = lines
-        .slice(index + 1)
-        .join("\n")
-        .trim();
-      if (command.intent === "automerge" && rest) {
-        command.automerge_instructions = rest;
-        return command;
-      }
-      if (command.intent === "implement_issue") {
-        if (rest)
-          return commandFromText("slash", `${issueImplementationRestPrefix(command)}\n${rest}`);
-      }
+  const commandLine = extractClawSweeperCommandLine(body);
+  if (!commandLine) return null;
+  const command = commandFromText(commandLine.trigger, commandLine.commandText);
+  if (!commandLine.supportsContinuation) return command;
+  const rest = commandLine.rest;
+  if (command.intent !== "freeform_assist") {
+    if (command.intent === "implement_issue" && rest) {
+      return commandFromText(
+        commandLine.trigger,
+        `${issueImplementationRestPrefix(command)}\n${rest}`,
+      );
+    }
+    if (command.intent === "automerge" && rest) {
+      command.automerge_instructions = rest;
       return command;
     }
-    const mention = line.match(
-      /^\s*@(?:clawsweeper|openclaw-clawsweeper)(?:\[bot\])?(?:(?:\s*[:,]\s*|\s+)(.+))?\s*$/i,
-    );
-    if (mention) {
-      const command = commandFromText("mention", mention[1] ?? "status");
-      if (command.intent !== "freeform_assist") {
-        const rest = lines
-          .slice(index + 1)
-          .join("\n")
-          .trim();
-        if (command.intent === "implement_issue" && rest)
-          return commandFromText("mention", `${issueImplementationRestPrefix(command)}\n${rest}`);
-        if (command.intent === "automerge" && rest) {
-          command.automerge_instructions = rest;
-          return command;
-        }
-        if (command.command === "status" && rest) return commandFromText("mention", rest);
-        return command;
-      }
-      const rest = lines
-        .slice(index + 1)
-        .join("\n")
-        .trim();
-      return rest ? commandFromText("mention", `${mention[1]}\n${rest}`) : command;
+    if (commandLine.trigger === "mention" && command.command === "status" && rest) {
+      return commandFromText(commandLine.trigger, rest);
     }
+    return command;
   }
-  return null;
+  return commandLine.trigger === "mention" && rest
+    ? commandFromText(commandLine.trigger, `${commandLine.commandText}\n${rest}`)
+    : command;
 }
 
 export function parseTrustedAutomation(
@@ -1657,13 +1633,7 @@ function assistPromptFromCommand(command: LooseRecord) {
 }
 
 function reviewPromptFromCommand(command: LooseRecord) {
-  return String(command ?? "")
-    .trim()
-    .replace(
-      /^(?:review(?:\s+again)?|re-?review|rereview|re-?run(?:\s+review)?|rerun(?:\s+review)?|run\s+(?:review|again))\b[:\s-]*/i,
-      "",
-    )
-    .trim();
+  return reviewPromptFromClawSweeperCommandText(command);
 }
 
 export const VISUAL_LENSES = new Set([
@@ -1728,22 +1698,7 @@ function normalizeIntent(command: LooseRecord) {
   ) {
     return "implement_issue";
   }
-  if (
-    command === "review" ||
-    command === "re-review" ||
-    command === "rereview" ||
-    command === "review again" ||
-    command === "rerun" ||
-    command === "re-run" ||
-    command === "rerun review" ||
-    command === "re-run review" ||
-    command === "run review" ||
-    command === "run again" ||
-    /^(?:review(?:\s+again)?|re-?review|rereview|re-?run(?:\s+review)?|rerun(?:\s+review)?|run\s+(?:review|again))\b[:\s-]+\S/i.test(
-      command,
-    )
-  )
-    return "re_review";
+  if (isClawSweeperReReviewCommandText(command)) return "re_review";
   if (["rebase", "update branch", "sync"].includes(command)) return "rebase";
   if (["autofix", "auto fix", "fix when needed", "repair only", "autofix on"].includes(command)) {
     return "autofix";

--- a/src/repair/comment-webhook.ts
+++ b/src/repair/comment-webhook.ts
@@ -175,6 +175,7 @@ export function classifyIssueCommentWebhook({
     return { accepted: false, reason: "no ClawSweeper command" };
   }
   const parsedCommand = parseCommand(String(comment.body ?? ""));
+  if (!parsedCommand) return { accepted: false, reason: "no routable ClawSweeper command" };
   if (
     !ALLOWED_ASSOCIATIONS.has(association) &&
     !isAuthorReadOnlyWebhookCommand({ comment, issue })

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -15788,7 +15788,7 @@ test("review git info follows checked-out target branch", () => {
 });
 
 test("sweep workflow_dispatch input count stays under GitHub limit", () => {
-  const workflow = readFileSync(".github/workflows/sweep.yml", "utf8");
+  const workflow = readFileSync(".github/workflows/sweep.yml", "utf8").replace(/\r\n/g, "\n");
   const inputBlock = workflow.slice(
     workflow.indexOf("  workflow_dispatch:\n    inputs:"),
     workflow.indexOf("\n  schedule:"),
@@ -15799,7 +15799,7 @@ test("sweep workflow_dispatch input count stays under GitHub limit", () => {
 });
 
 test("sweep review continuations stay workflow-dispatch compatible", () => {
-  const workflow = readFileSync(".github/workflows/sweep.yml", "utf8");
+  const workflow = readFileSync(".github/workflows/sweep.yml", "utf8").replace(/\r\n/g, "\n");
   const continueBlock = workflow.slice(
     workflow.indexOf("- name: Continue sweep"),
     workflow.indexOf("\n\n  recover-review-failures:"),
@@ -15993,7 +15993,7 @@ test("repair workflows preserve existing dispatch while scheduled cluster intake
   const router = readFileSync(".github/workflows/repair-comment-router.yml", "utf8");
   const finalizer = readFileSync(".github/workflows/repair-finalize-open-prs.yml", "utf8");
   const selfHeal = readFileSync(".github/workflows/repair-self-heal.yml", "utf8");
-  const sweep = readFileSync(".github/workflows/sweep.yml", "utf8");
+  const sweep = readFileSync(".github/workflows/sweep.yml", "utf8").replace(/\r\n/g, "\n");
   const dispatchJobs = readFileSync("src/repair/dispatch-jobs.ts", "utf8");
   const importGitcrawl = readFileSync("src/repair/import-gitcrawl-clusters.ts", "utf8");
   const importLowSignal = readFileSync("src/repair/import-gitcrawl-low-signal-prs.ts", "utf8");

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -1337,7 +1337,11 @@ test("triage uses ClawSweeper GitHub App credentials when no static token is con
 });
 
 test("hosted webhook accepts author read-only mention commands", async () => {
-  for (const body of ["@clawsweeper Re-run"]) {
+  for (const body of [
+    "@clawsweeper Re-run",
+    "@clawsweeper\nre-review based on latest comments",
+    "The issue may already be fixed.\n@clawsweeper re-review based on latest comments\nThanks.",
+  ]) {
     const response = await worker.fetch(
       signedGithubWebhookRequest({
         event: "issue_comment",
@@ -1366,6 +1370,41 @@ test("hosted webhook accepts author read-only mention commands", async () => {
     assert.equal(response.status, 503, `${body} should pass classification before app config`);
     assert.deepEqual(await response.json(), { error: "github_app_not_configured" });
   }
+});
+
+test("hosted webhook ignores inline ClawSweeper mentions before fast ack", async () => {
+  const response = await worker.fetch(
+    signedGithubWebhookRequest({
+      event: "issue_comment",
+      secret: "test-secret",
+      payload: {
+        action: "created",
+        repository: {
+          full_name: "openclaw/openclaw",
+          private: false,
+          archived: false,
+          fork: false,
+          has_issues: true,
+        },
+        issue: { number: 87801, user: { login: "issue-author" } },
+        installation: { id: 123 },
+        comment: {
+          id: 456,
+          body: "the closed PR 87835 was closed as already implemented by PR 87890 @clawsweeper re-review and if necessary close this issue",
+          author_association: "MEMBER",
+          user: { login: "brokemac79" },
+        },
+      },
+    }),
+    { CLAWSWEEPER_WEBHOOK_SECRET: "test-secret" },
+  );
+
+  assert.equal(response.status, 202);
+  assert.deepEqual(await response.json(), {
+    ok: true,
+    accepted: false,
+    reason: "no routable ClawSweeper command",
+  });
 });
 
 test("hosted webhook returns invalid_json for signed malformed bodies", async () => {

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -1075,6 +1075,12 @@ test("parseCommand recognizes ClawSweeper bot mentions", () => {
 
 test("parseCommand ignores unrelated comments", () => {
   assert.equal(parseCommand("please fix ci when you get a chance"), null);
+  assert.equal(
+    parseCommand(
+      "the closed PR 87835 was closed as already implemented by PR 87890 @clawsweeper re-review and if necessary close this issue",
+    ),
+    null,
+  );
   assert.equal(parseCommand("/not-clawsweeper fix ci"), null);
 });
 

--- a/test/repair/comment-webhook.test.ts
+++ b/test/repair/comment-webhook.test.ts
@@ -39,6 +39,44 @@ test("comment webhook accepts maintainer ClawSweeper commands", () => {
   });
 });
 
+test("comment webhook rejects inline ClawSweeper mentions before visible ack", () => {
+  const result = classifyIssueCommentWebhook({
+    event: "issue_comment",
+    payload: {
+      action: "created",
+      repository: { full_name: "openclaw/openclaw", default_branch: "main" },
+      issue: { number: 87801 },
+      installation: { id: 123 },
+      comment: {
+        id: 456,
+        body: "the closed PR 87835 was closed as already implemented by PR 87890 @clawsweeper re-review and if necessary close this issue",
+        author_association: "MEMBER",
+      },
+    },
+  });
+
+  assert.deepEqual(result, { accepted: false, reason: "no routable ClawSweeper command" });
+});
+
+test("comment webhook accepts ClawSweeper mention commands on their own line", () => {
+  const result = classifyIssueCommentWebhook({
+    event: "issue_comment",
+    payload: {
+      action: "created",
+      repository: { full_name: "openclaw/openclaw", default_branch: "main" },
+      issue: { number: 87801 },
+      installation: { id: 123 },
+      comment: {
+        id: 456,
+        body: "The issue may already be fixed.\n@clawsweeper re-review based on the latest comments\nThanks.",
+        author_association: "MEMBER",
+      },
+    },
+  });
+
+  assert.equal(result.accepted, true);
+});
+
 test("comment webhook rejects contributor commands before visible ack", () => {
   const result = classifyIssueCommentWebhook({
     event: "issue_comment",


### PR DESCRIPTION
## Summary

Fixes openclaw/clawsweeper#232.

This makes the fast-ack paths reject comments that only mention `@clawsweeper` inline inside prose, unless the same comment is actually routable by the command parser.

Changes:

- gates the deterministic comment webhook on `parseCommand(...)` before posting the visible fast ack
- extracts the shared ClawSweeper command-line detector used by both the router parser and hosted dashboard worker
- replaces the hosted dashboard worker's loose mention regex with that shared parser-compatible detector
- keeps valid command forms working, including an own-line mention and the `@clawsweeper` then next-line `re-review` pattern used by issue authors
- adds regression coverage for inline mentions versus real command-line mentions
- normalizes a few workflow test reads so CRLF workflow files do not break unrelated assertions

## Testing

- `pnpm run build:all`
- `pnpm run lint`
- `node --test test\\repair\\comment-router-core.test.ts test\\repair\\comment-webhook.test.ts test\\dashboard-worker.test.ts`
- `node --test --test-name-pattern "sweep workflow_dispatch input count|sweep review continuations|repair workflows preserve" test\\clawsweeper.test.ts`
- `pnpm exec oxfmt --check src/repair/comment-command-text.ts src/repair/comment-router-core.ts dashboard/worker.ts`

Note: I also tried `pnpm run check` locally on Windows earlier. The relevant build/lint/regression parts pass, but the full suite still hits unrelated Windows/local-environment failures around spawning `codex` and POSIX file-mode assertions. A repository-wide `format:check` also reports existing unrelated formatting noise on this Windows checkout, while the touched files pass targeted format check.