### PR TITLE
fix: include proof files in repair sparse checkouts

### DIFF
--- a/.github/workflows/repair-comment-router.yml
+++ b/.github/workflows/repair-comment-router.yml
@@ -85,9 +85,14 @@ jobs:
             .github
             config
             jobs
+            prompts/pr-close-coverage-proof.md
             results
+            schema/clawsweeper-pr-close-coverage-proof.schema.json
             scripts/hydrate-state.ts
+            src/clawsweeper-text.ts
+            src/codex-env.ts
             src/github-retry.ts
+            src/pr-close-coverage-proof.ts
             src/repair
             src/repository-profiles.ts
             package.json

--- a/.github/workflows/spam-comment-intake.yml
+++ b/.github/workflows/spam-comment-intake.yml
@@ -53,7 +53,12 @@ jobs:
           sparse-checkout: |
             .github/actions
             config/automation-limits.json
+            prompts/pr-close-coverage-proof.md
+            schema/clawsweeper-pr-close-coverage-proof.schema.json
+            src/clawsweeper-text.ts
+            src/codex-env.ts
             src/github-retry.ts
+            src/pr-close-coverage-proof.ts
             src/repair
             src/repository-profiles.ts
             package.json

--- a/.github/workflows/spam-scanner.yml
+++ b/.github/workflows/spam-scanner.yml
@@ -73,9 +73,14 @@ jobs:
           sparse-checkout: |
             .github
             config
+            prompts/pr-close-coverage-proof.md
             results
+            schema/clawsweeper-pr-close-coverage-proof.schema.json
             scripts/hydrate-state.ts
+            src/clawsweeper-text.ts
+            src/codex-env.ts
             src/github-retry.ts
+            src/pr-close-coverage-proof.ts
             src/repair
             src/repository-profiles.ts
             package.json

--- a/test/repair/workflow-sparse-checkout.test.ts
+++ b/test/repair/workflow-sparse-checkout.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const REPAIR_PROOF_RUNTIME_PATHS = [
+  "prompts/pr-close-coverage-proof.md",
+  "schema/clawsweeper-pr-close-coverage-proof.schema.json",
+  "src/clawsweeper-text.ts",
+  "src/codex-env.ts",
+  "src/pr-close-coverage-proof.ts",
+] as const;
+
+const SPARSE_REPAIR_BUILD_WORKFLOWS = [
+  ".github/workflows/repair-comment-router.yml",
+  ".github/workflows/spam-comment-intake.yml",
+  ".github/workflows/spam-scanner.yml",
+] as const;
+
+test("sparse repair build workflows include PR close proof runtime files", () => {
+  for (const workflowPath of SPARSE_REPAIR_BUILD_WORKFLOWS) {
+    const workflow = fs.readFileSync(path.join(process.cwd(), workflowPath), "utf8");
+    assert.match(workflow, /build-script: build:repair/);
+
+    const entries = sparseCheckoutEntries(workflow);
+    for (const requiredPath of REPAIR_PROOF_RUNTIME_PATHS) {
+      assert.ok(entries.has(requiredPath), `${workflowPath} missing ${requiredPath}`);
+    }
+  }
+});
+
+function sparseCheckoutEntries(workflow: string): Set<string> {
+  const entries = new Set<string>();
+  const lines = workflow.split(/\r?\n/);
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    if (!/^\s+sparse-checkout:\s*\|/.test(line)) continue;
+
+    const blockIndent = leadingSpaces(line);
+    for (index += 1; index < lines.length; index += 1) {
+      const entryLine = lines[index] ?? "";
+      if (!entryLine.trim()) continue;
+      if (leadingSpaces(entryLine) <= blockIndent) {
+        index -= 1;
+        break;
+      }
+      entries.add(entryLine.trim());
+    }
+  }
+
+  return entries;
+}
+
+function leadingSpaces(value: string): number {
+  return value.length - value.trimStart().length;
+}


### PR DESCRIPTION
# Human written summary:
The intent of this change is, as written by a human:
> Well, wait a second. If ClawSweeper is broken, why aren't we creating a PR to fix it?

_The rest of this PR was written by GPT-5-Codex, running in the Codex desktop harness. Full environment + prompt history appear at the end._

# Changes
- Fixes https://github.com/openclaw/clawsweeper/issues/234.
- Adds the PR close coverage proof module, helper modules, prompt, and schema to sparse repair workflow checkouts that run `build:repair`.
- Covers the sparse workflow dependency list with a repair regression test.

# Tests
- Passed: `nix shell nixpkgs#nodejs_24 nixpkgs#pnpm -c pnpm run build:repair`.
- Passed: `nix shell nixpkgs#nodejs_24 nixpkgs#pnpm -c pnpm run test:repair`.
- Passed: local sparse-checkout simulations for `.github/workflows/repair-comment-router.yml`, `.github/workflows/spam-comment-intake.yml`, and `.github/workflows/spam-scanner.yml`, each running `pnpm run build:repair`.
- Passed: `nix shell nixpkgs#nodejs_24 nixpkgs#pnpm -c pnpm run check`.
- Passed: `git diff --check`.

# Risks
- Low: workflow-only dependency-list change. The affected repair builds now receive the root files already required by `src/repair/apply-result.ts`.

# Follow-ups
- After merge, rerun or wait for the repair comment router so queued maintainer commands can be processed.

# Prompt History

## Environment
Harness: Codex desktop app
Model: GPT-5 Codex
Thinking level: Codex desktop default
Terminal: zsh
System: macOS arm64-darwin, Node 24.14.0 via Nix, pnpm 10.33.2 via Nix

## Prompts
| ISO-8601 | Prompt |
| --- | --- |
| 2026-05-31T12:19:31+02:00 | `Well, wait a second. If ClawSweeper is broken, why aren't we creating a PR to fix it?` |
