### PR TITLE
fix: enable protected-branch automerge requests

### DIFF
--- a/src/repair/automerge-shepherd.ts
+++ b/src/repair/automerge-shepherd.ts
@@ -1,4 +1,5 @@
 import type { JsonValue, LooseRecord } from "./json-types.js";
+import { automergeMergeStateAllowsAutoMerge } from "./comment-router-core.js";
 
 const DEFAULT_WAIT_MS = 10 * 60 * 1000;
 const DEFAULT_POLL_MS = 15 * 1000;
@@ -56,7 +57,7 @@ export function automergeShepherdReadiness({
   const mergeStateStatus = String(view.mergeStateStatus ?? "");
   if (
     mergeStateStatus &&
-    !["CLEAN", "HAS_HOOKS"].includes(mergeStateStatus) &&
+    !automergeMergeStateAllowsAutoMerge(mergeStateStatus) &&
     mergeStateStatus !== "UNSTABLE"
   ) {
     return { status: "waiting", reason: `merge state status is ${mergeStateStatus}` };

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -580,6 +580,13 @@ export function automergeReadinessRepairReason(reason: JsonValue): string | null
   return null;
 }
 
+export function automergeMergeStateAllowsAutoMerge(value: JsonValue): boolean {
+  const status = String(value ?? "")
+    .trim()
+    .toUpperCase();
+  return ["CLEAN", "HAS_HOOKS", "BLOCKED"].includes(status);
+}
+
 export function isCanonicalLandingNeedsHumanText(value: JsonValue) {
   const text = String(value ?? "");
   if (!text) return false;
@@ -704,10 +711,12 @@ export function buildAutomergeMergeArgs({
   issueNumber,
   repo,
   expectedHeadSha,
+  auto = false,
   subject = null,
   bodyFile = null,
 }: LooseRecord) {
   const args = ["pr", "merge", String(issueNumber), "--repo", repo, "--squash"];
+  if (auto) args.push("--auto");
   if (subject) args.push("--subject", String(subject));
   if (bodyFile) args.push("--body-file", String(bodyFile));
   if (expectedHeadSha && expectedHeadSha !== "unknown") {

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -28,6 +28,7 @@ import {
   automergeGateBlockReason,
   automergeClusterId,
   automergeJobPath,
+  automergeMergeStateAllowsAutoMerge,
   automergeMergeFailureRepairReason,
   automergeRequestedByFromBody,
   automergeReadinessRepairReason,
@@ -2354,11 +2355,16 @@ function executeAutomerge(command: LooseRecord) {
     comments: issueCommentsFor(command.issue_number),
   });
   const bodyFile = writeAutomergeMergeBody(command, latestTarget, mergeMessage.body);
+  const useGitHubAutoMerge =
+    String(latestTarget.mergeStateStatus ?? "")
+      .trim()
+      .toUpperCase() === "BLOCKED";
   const result = ghSpawn(
     buildAutomergeMergeArgs({
       issueNumber: command.issue_number,
       repo: command.repo,
       expectedHeadSha: command.expected_head_sha,
+      auto: useGitHubAutoMerge,
       subject: mergeMessage.subject,
       bodyFile,
     }),
@@ -2393,6 +2399,22 @@ function executeAutomerge(command: LooseRecord) {
     };
   }
   const merged = fetchPullRequestView(command.issue_number);
+  if (String(merged.state ?? "").toUpperCase() === "OPEN") {
+    return {
+      action: "merge",
+      status: "waiting",
+      reason: merged.autoMergeRequest
+        ? "GitHub auto-merge enabled"
+        : "GitHub merge command completed but PR remains open",
+      merge_method: "squash",
+      prepared_head_sha: latestTarget.head_sha ?? null,
+      commit_subject: mergeMessage.subject,
+      summary_lines: mergeMessage.summaryLines,
+      fixup_lines: mergeMessage.fixupLines,
+      transient_wait_ms: waitedMs,
+      transient_observations: transientObservations,
+    };
+  }
   return {
     action: "merge",
     status: "executed",
@@ -2482,7 +2504,7 @@ function validateAutomergeReadiness({ command, view, target }: LooseRecord) {
   if (checks.total === 0) return "no PR checks found";
   const mergeStateStatus = String(view.mergeStateStatus ?? "");
   if (
-    !["CLEAN", "HAS_HOOKS"].includes(mergeStateStatus) &&
+    !automergeMergeStateAllowsAutoMerge(mergeStateStatus) &&
     !(mergeStateStatus === "UNSTABLE" && checks.blockers.length === 0)
   ) {
     return `merge state status is ${view.mergeStateStatus || "unknown"}`;
@@ -2846,6 +2868,7 @@ function fetchPullRequestView(number: JsonValue) {
         "mergeCommit",
         "mergeStateStatus",
         "mergedAt",
+        "autoMergeRequest",
         "reviewDecision",
         "state",
         "statusCheckRollup",
@@ -2881,6 +2904,7 @@ function fetchPullRequestViewAsync(number: JsonValue) {
         "mergeCommit",
         "mergeStateStatus",
         "mergedAt",
+        "autoMergeRequest",
         "reviewDecision",
         "state",
         "statusCheckRollup",

--- a/test/repair/automerge-shepherd.test.ts
+++ b/test/repair/automerge-shepherd.test.ts
@@ -100,6 +100,29 @@ test("automerge shepherd treats head movement as terminal for the current repair
   );
 });
 
+test("automerge shepherd treats protected-branch BLOCKED as ready for router dispatch", () => {
+  const headSha = "abc123";
+  assert.deepEqual(
+    automergeShepherdReadiness({
+      view: {
+        state: "OPEN",
+        headRefOid: headSha,
+        mergeable: "MERGEABLE",
+        mergeStateStatus: "BLOCKED",
+        statusCheckRollup: [{ name: "check", status: "COMPLETED", conclusion: "SUCCESS" }],
+      },
+      comments: [
+        {
+          user: { login: "clawsweeper" },
+          body: "passed\n<!-- clawsweeper-verdict:pass sha=abc123 -->",
+        },
+      ],
+      headSha,
+    }),
+    { status: "ready", reason: "checks and exact-head review are ready" },
+  );
+});
+
 test("automerge shepherd stops on terminal check failures before review pass", () => {
   const headSha = "abc123";
   assert.deepEqual(

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -18,6 +18,7 @@ import {
   automergeGateBlockReason,
   automergeJobBranch,
   automergeJobPath,
+  automergeMergeStateAllowsAutoMerge,
   automergeReadinessRepairReason,
   automergeTransientWaitConfig,
   buildClawSweeperAssistDispatchPayload,
@@ -2243,6 +2244,31 @@ test("renderResponse reports maintainer-approved automerge completion", () => {
   assert.match(body, /automerge loop is complete/);
 });
 
+test("renderResponse reports maintainer-approved GitHub auto-merge enablement", () => {
+  const body = renderResponse(
+    {
+      comment_id: "791",
+      intent: "maintainer_approve_automerge",
+      repo: "openclaw/openclaw",
+      author: "steipete",
+      expected_head_sha: "abc791",
+      target: { head_sha: "abc791" },
+    },
+    {
+      merge: {
+        status: "waiting",
+        reason: "GitHub auto-merge enabled",
+        summary_lines: ["Enabled the protected-branch auto-merge request."],
+      },
+    },
+  );
+
+  assert.match(body, /Maintainer-approved ClawSweeper automerge is not merged yet/);
+  assert.match(body, /Merge status: GitHub auto-merge enabled/);
+  assert.match(body, /I left the PR open for the remaining gate instead of bypassing it/);
+  assert.doesNotMatch(body, /automerge loop is complete/);
+});
+
 test("repair intent set documents executable repair commands", () => {
   assert.deepEqual([...REPAIR_INTENTS].sort(), [
     "address_review",
@@ -2308,6 +2334,14 @@ test("automerge live readiness blocks become repair reasons", () => {
   assert.equal(automergeReadinessRepairReason("pull request is draft"), null);
 });
 
+test("automerge merge states allow protected-branch auto-merge setup", () => {
+  assert.equal(automergeMergeStateAllowsAutoMerge("CLEAN"), true);
+  assert.equal(automergeMergeStateAllowsAutoMerge("HAS_HOOKS"), true);
+  assert.equal(automergeMergeStateAllowsAutoMerge("BLOCKED"), true);
+  assert.equal(automergeMergeStateAllowsAutoMerge("DIRTY"), false);
+  assert.equal(automergeMergeStateAllowsAutoMerge("BEHIND"), false);
+});
+
 test("autoclose intent set documents destructive maintainer commands", () => {
   assert.deepEqual([...AUTOCLOSE_INTENTS], ["autoclose"]);
 });
@@ -2332,6 +2366,28 @@ test("automerge merge args pin the reviewed head SHA", () => {
       "fix: test (#123)",
       "--body-file",
       "/tmp/body.txt",
+      "--match-head-commit",
+      "abc123",
+    ],
+  );
+});
+
+test("automerge merge args use GitHub auto-merge only when requested", () => {
+  assert.deepEqual(
+    buildAutomergeMergeArgs({
+      issueNumber: 123,
+      repo: "openclaw/openclaw",
+      expectedHeadSha: "abc123",
+      auto: true,
+    }),
+    [
+      "pr",
+      "merge",
+      "123",
+      "--repo",
+      "openclaw/openclaw",
+      "--squash",
+      "--auto",
       "--match-head-commit",
       "abc123",
     ],


### PR DESCRIPTION
# Human written summary:
The intent of this change is, as written by a human:
> Well, wait a second. If ClawSweeper is broken, why aren't we creating a PR to fix it?

_The rest of this PR was written by GPT-5, running in the Codex desktop harness. Full environment + prompt history appear at the end._

# Changes
- Route protected-branch approved automerge through GitHub auto-merge with `gh pr merge --auto`.
- Share the `BLOCKED` merge-state allowance across the comment router and automerge shepherd so post-repair continuations can reach the router.
- Preserve the existing direct squash merge path for clean PRs; `--auto` is only added for `mergeStateStatus: BLOCKED`.
- Report an open PR with `autoMergeRequest` as waiting/enabled instead of claiming it merged.

# Tests
- `nix shell nixpkgs#nodejs_24 nixpkgs#pnpm -c pnpm run build:repair` - passed.
- `nix shell nixpkgs#nodejs_24 nixpkgs#pnpm -c pnpm run test:repair -- --test-name-pattern 'automerge shepherd|automerge merge args|automerge merge states|comment-router-core'` - passed; the runner executed the full repair suite, 437 tests passed.
- `nix shell nixpkgs#nodejs_24 nixpkgs#pnpm -c pnpm run format` - passed.
- `nix shell nixpkgs#nodejs_24 nixpkgs#pnpm -c pnpm run check` - passed.
- Live proof attempt: dispatched `repair-comment-router.yml` from this branch against `openclaw/telecrawl#4`; run https://github.com/openclaw/clawsweeper/actions/runs/26710838589 completed successfully with `CLAWSWEEPER_ALLOW_MERGE=1`, app credentials, `merge_state_status: BLOCKED`, and 6/6 green checks. It did not reach `gh pr merge --auto` because the Telecrawl automerge comments were not maintainer-authorized for that target: the router saw repository permission `read` and author association `CONTRIBUTOR`. That is an external authorization blocker for this proof target, not the merge-state bug fixed here.

# Risks
- Low/moderate: this changes the final approved automerge path for protected-branch PRs, but keeps existing readiness checks, preserves direct merge for clean PRs, and still uses `--match-head-commit`.

# Follow-ups
- Prove the final `autoMergeRequest` state on a maintainer-authorized protected-branch target before merging if ClawSweeper still requires live behavior proof.
- After this lands, re-run/verify Telecrawl #6 and only handle #7 after its author/security-boundary labels are resolved.

# Prompt History

## Environment
Harness: Codex desktop
Model: GPT-5
Thinking level: not exposed by harness
Terminal: zsh
System: macOS, local checkout `/Users/josh/code/research/clawsweeper`

## Prompts
| ISO-8601 | Prompt |
| --- | --- |
| 2026-05-31T12:45:05+02:00 | `Well, wait a second. If ClawSweeper is broken, why aren't we creating a PR to fix it?` |
