### PR TITLE
 fix(repair/target-validation): scrub pnpm env injection before `bun install`

### DIFF
--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -198,9 +198,7 @@ function sanitizeEnvForBun(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
     // but `npm_lifecycle_*`, `npm_package_*`, `npm_execpath`, `PNPM_*`, etc.
     // can also leak parent-tool semantics into bun-managed preinstalls.
     if (/^npm_/i.test(key)) continue;
-    if (key === "PNPM_HOME" || key === "PNPM_SCRIPT_SRC_DIR" || key === "PNPM_PACKAGE_NAME") {
-      continue;
-    }
+    if (/^PNPM_/i.test(key)) continue;
     out[key] = value;
   }
   // Declare bun as the active package manager so target preinstall hooks

--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -162,22 +162,51 @@ function prepareBunToolchain({
 }) {
   // The repair execution workflow provisions pinned Bun before this path runs.
   // Keep a clear fail-fast probe so local/manual runners surface setup gaps early.
-  run("bun", ["--version"], { cwd, env: validationEnv, timeoutMs: setupTimeoutMs });
+  //
+  // ClawSweeper itself runs under pnpm (e.g. `pnpm run repair:execute-fix`), so
+  // process.env carries pnpm-injected `npm_config_user_agent=pnpm/...`. When we
+  // shell out to `bun install` for a target repo whose package.json has a
+  // preinstall hook like `bunx only-allow bun` (e.g. openclaw/clawhub), bun
+  // forwards the parent env to the preinstall script and `only-allow` reads the
+  // pnpm user-agent and refuses to run. Strip the npm_*/PNPM_* injection and
+  // assert a bun user-agent so target preinstalls see a consistent caller.
+  const bunEnv = sanitizeEnvForBun(validationEnv);
+  run("bun", ["--version"], { cwd, env: bunEnv, timeoutMs: setupTimeoutMs });
   const installArgs = ["install", "--frozen-lockfile"];
   try {
-    run("bun", installArgs, { cwd, env: validationEnv, timeoutMs: installTimeoutMs });
+    run("bun", installArgs, { cwd, env: bunEnv, timeoutMs: installTimeoutMs });
   } catch (error) {
     const message = String(error?.message ?? "");
     if (!/lockfile|frozen|out of date|out-of-date/i.test(message)) throw error;
     run("bun", ["install", "--no-frozen-lockfile"], {
       cwd,
-      env: validationEnv,
+      env: bunEnv,
       timeoutMs: installTimeoutMs,
     });
     for (const lockfile of ["bun.lock", "bun.lockb"]) {
       restoreTargetLockfile(cwd, lockfile);
     }
   }
+}
+
+function sanitizeEnvForBun(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const out: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) continue;
+    // Strip every npm/pnpm child-process injection. The critical one is
+    // `npm_config_user_agent` (read by `only-allow` to gate package managers),
+    // but `npm_lifecycle_*`, `npm_package_*`, `npm_execpath`, `PNPM_*`, etc.
+    // can also leak parent-tool semantics into bun-managed preinstalls.
+    if (/^npm_/i.test(key)) continue;
+    if (key === "PNPM_HOME" || key === "PNPM_SCRIPT_SRC_DIR" || key === "PNPM_PACKAGE_NAME") {
+      continue;
+    }
+    out[key] = value;
+  }
+  // Declare bun as the active package manager so target preinstall hooks
+  // such as `bunx only-allow bun` recognise the caller.
+  out.npm_config_user_agent = `bun/unknown npm/? node/${process.versions.node} ${process.platform} ${process.arch}`;
+  return out;
 }
 
 function prepareNpmToolchain({

--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -168,8 +168,9 @@ function prepareBunToolchain({
   // shell out to `bun install` for a target repo whose package.json has a
   // preinstall hook like `bunx only-allow bun` (e.g. openclaw/clawhub), bun
   // forwards the parent env to the preinstall script and `only-allow` reads the
-  // pnpm user-agent and refuses to run. Strip the npm_*/PNPM_* injection and
-  // assert a bun user-agent so target preinstalls see a consistent caller.
+  // pnpm user-agent and refuses to run. Strip caller identity/lifecycle metadata
+  // from pnpm, but preserve npm-compatible install configuration such as
+  // registry, auth, proxy, userconfig, and cache settings for the target repo.
   const bunEnv = sanitizeEnvForBun(validationEnv);
   run("bun", ["--version"], { cwd, env: bunEnv, timeoutMs: setupTimeoutMs });
   const installArgs = ["install", "--frozen-lockfile"];
@@ -193,18 +194,24 @@ function sanitizeEnvForBun(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const out: NodeJS.ProcessEnv = {};
   for (const [key, value] of Object.entries(env)) {
     if (value === undefined) continue;
-    // Strip every npm/pnpm child-process injection. The critical one is
-    // `npm_config_user_agent` (read by `only-allow` to gate package managers),
-    // but `npm_lifecycle_*`, `npm_package_*`, `npm_execpath`, `PNPM_*`, etc.
-    // can also leak parent-tool semantics into bun-managed preinstalls.
-    if (/^npm_/i.test(key)) continue;
-    if (/^PNPM_/i.test(key)) continue;
+    if (shouldStripBunInstallEnv(key)) continue;
     out[key] = value;
   }
   // Declare bun as the active package manager so target preinstall hooks
   // such as `bunx only-allow bun` recognise the caller.
   out.npm_config_user_agent = `bun/unknown npm/? node/${process.versions.node} ${process.platform} ${process.arch}`;
   return out;
+}
+
+function shouldStripBunInstallEnv(key: string): boolean {
+  return (
+    /^PNPM_/i.test(key) ||
+    /^npm_config_user_agent$/i.test(key) ||
+    /^npm_execpath$/i.test(key) ||
+    /^npm_node_execpath$/i.test(key) ||
+    /^npm_lifecycle_/i.test(key) ||
+    /^npm_package_/i.test(key)
+  );
 }
 
 function prepareNpmToolchain({

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -455,10 +455,12 @@ test("bun-based target toolchain hides pnpm-injected npm_config_user_agent from 
   const previousNpmExecpath = process.env.npm_execpath;
   const previousNpmLifecycleEvent = process.env.npm_lifecycle_event;
   const previousPnpmHome = process.env.PNPM_HOME;
+  const previousPnpmStorePath = process.env.PNPM_STORE_PATH;
   process.env.npm_config_user_agent = "pnpm/10.0.0 npm/? node/v22.0.0 linux x64";
   process.env.npm_execpath = "/tmp/pnpm";
   process.env.npm_lifecycle_event = "repair:execute-fix";
   process.env.PNPM_HOME = "/tmp/pnpm-home";
+  process.env.PNPM_STORE_PATH = "/tmp/pnpm-store";
   try {
     withPathPrefix(binDir, () => {
       prepareTargetToolchain(cwd, {
@@ -473,6 +475,7 @@ test("bun-based target toolchain hides pnpm-injected npm_config_user_agent from 
     restoreEnv("npm_execpath", previousNpmExecpath);
     restoreEnv("npm_lifecycle_event", previousNpmLifecycleEvent);
     restoreEnv("PNPM_HOME", previousPnpmHome);
+    restoreEnv("PNPM_STORE_PATH", previousPnpmStorePath);
   }
 
   const envEntries = fs
@@ -495,6 +498,7 @@ test("bun-based target toolchain hides pnpm-injected npm_config_user_agent from 
       "npm_lifecycle_event must not leak to bun children",
     );
     assert.equal(env.PNPM_HOME, undefined, "PNPM_HOME must not leak to bun children");
+    assert.equal(env.PNPM_STORE_PATH, undefined, "PNPM_* variables must not leak to bun children");
   }
 });
 

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -444,7 +444,8 @@ test("bun-based target toolchain hides pnpm-injected npm_config_user_agent from 
   // carries `npm_config_user_agent=pnpm/...`. If that value leaked into the
   // `bun install` child we'd shell out to, target preinstalls that gate on
   // `only-allow bun` would refuse to run. prepareBunToolchain must scrub
-  // every `npm_*`/`PNPM_*` injection and assert a bun user-agent instead.
+  // caller identity/lifecycle env and assert a bun user-agent instead, while
+  // preserving npm-compatible install configuration for private registries.
   const cwd = gitBunPackageFixture({ check: "bun x tsc --noEmit" });
   git(cwd, "add", ".");
   git(cwd, "commit", "-m", "initial");
@@ -452,13 +453,23 @@ test("bun-based target toolchain hides pnpm-injected npm_config_user_agent from 
 
   const { binDir, envLogPath } = envLoggingBunFixture(cwd);
   const previousUserAgent = process.env.npm_config_user_agent;
+  const previousRegistry = process.env.npm_config_registry;
+  const previousCache = process.env.npm_config_cache;
+  const previousUserconfig = process.env.npm_config_userconfig;
   const previousNpmExecpath = process.env.npm_execpath;
+  const previousNpmNodeExecpath = process.env.npm_node_execpath;
   const previousNpmLifecycleEvent = process.env.npm_lifecycle_event;
+  const previousNpmPackageName = process.env.npm_package_name;
   const previousPnpmHome = process.env.PNPM_HOME;
   const previousPnpmStorePath = process.env.PNPM_STORE_PATH;
   process.env.npm_config_user_agent = "pnpm/10.0.0 npm/? node/v22.0.0 linux x64";
+  process.env.npm_config_registry = "https://registry.example.invalid/";
+  process.env.npm_config_cache = "/tmp/npm-cache";
+  process.env.npm_config_userconfig = "/tmp/npmrc";
   process.env.npm_execpath = "/tmp/pnpm";
+  process.env.npm_node_execpath = "/tmp/node";
   process.env.npm_lifecycle_event = "repair:execute-fix";
+  process.env.npm_package_name = "clawsweeper";
   process.env.PNPM_HOME = "/tmp/pnpm-home";
   process.env.PNPM_STORE_PATH = "/tmp/pnpm-store";
   try {
@@ -472,8 +483,13 @@ test("bun-based target toolchain hides pnpm-injected npm_config_user_agent from 
     });
   } finally {
     restoreEnv("npm_config_user_agent", previousUserAgent);
+    restoreEnv("npm_config_registry", previousRegistry);
+    restoreEnv("npm_config_cache", previousCache);
+    restoreEnv("npm_config_userconfig", previousUserconfig);
     restoreEnv("npm_execpath", previousNpmExecpath);
+    restoreEnv("npm_node_execpath", previousNpmNodeExecpath);
     restoreEnv("npm_lifecycle_event", previousNpmLifecycleEvent);
+    restoreEnv("npm_package_name", previousNpmPackageName);
     restoreEnv("PNPM_HOME", previousPnpmHome);
     restoreEnv("PNPM_STORE_PATH", previousPnpmStorePath);
   }
@@ -491,12 +507,33 @@ test("bun-based target toolchain hides pnpm-injected npm_config_user_agent from 
       /^bun\//,
       `expected bun user-agent, got ${JSON.stringify(env.npm_config_user_agent)}`,
     );
+    assert.equal(
+      env.npm_config_registry,
+      "https://registry.example.invalid/",
+      "npm-compatible registry config must pass through to bun children",
+    );
+    assert.equal(
+      env.npm_config_cache,
+      "/tmp/npm-cache",
+      "npm-compatible cache config must pass through to bun children",
+    );
+    assert.equal(
+      env.npm_config_userconfig,
+      "/tmp/npmrc",
+      "npm-compatible userconfig must pass through to bun children",
+    );
     assert.equal(env.npm_execpath, undefined, "npm_execpath must not leak to bun children");
+    assert.equal(
+      env.npm_node_execpath,
+      undefined,
+      "npm_node_execpath must not leak to bun children",
+    );
     assert.equal(
       env.npm_lifecycle_event,
       undefined,
       "npm_lifecycle_event must not leak to bun children",
     );
+    assert.equal(env.npm_package_name, undefined, "npm_package_* must not leak to bun children");
     assert.equal(env.PNPM_HOME, undefined, "PNPM_HOME must not leak to bun children");
     assert.equal(env.PNPM_STORE_PATH, undefined, "PNPM_* variables must not leak to bun children");
   }

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -438,6 +438,66 @@ test("bun-based target toolchain installs deps and runs configured validation", 
   ]);
 });
 
+test("bun-based target toolchain hides pnpm-injected npm_config_user_agent from preinstall hooks", () => {
+  // Regression guard for the `bunx only-allow bun` preinstall failure on
+  // openclaw/clawhub: ClawSweeper itself runs under pnpm so `process.env`
+  // carries `npm_config_user_agent=pnpm/...`. If that value leaked into the
+  // `bun install` child we'd shell out to, target preinstalls that gate on
+  // `only-allow bun` would refuse to run. prepareBunToolchain must scrub
+  // every `npm_*`/`PNPM_*` injection and assert a bun user-agent instead.
+  const cwd = gitBunPackageFixture({ check: "bun x tsc --noEmit" });
+  git(cwd, "add", ".");
+  git(cwd, "commit", "-m", "initial");
+  attachOrigin(cwd);
+
+  const { binDir, envLogPath } = envLoggingBunFixture(cwd);
+  const previousUserAgent = process.env.npm_config_user_agent;
+  const previousNpmExecpath = process.env.npm_execpath;
+  const previousNpmLifecycleEvent = process.env.npm_lifecycle_event;
+  const previousPnpmHome = process.env.PNPM_HOME;
+  process.env.npm_config_user_agent = "pnpm/10.0.0 npm/? node/v22.0.0 linux x64";
+  process.env.npm_execpath = "/tmp/pnpm";
+  process.env.npm_lifecycle_event = "repair:execute-fix";
+  process.env.PNPM_HOME = "/tmp/pnpm-home";
+  try {
+    withPathPrefix(binDir, () => {
+      prepareTargetToolchain(cwd, {
+        ...validationOptions("openclaw/clawhub", clawhubToolchain()),
+        installTargetDeps: true,
+        installTimeoutMs: 5000,
+        setupTimeoutMs: 5000,
+      });
+    });
+  } finally {
+    restoreEnv("npm_config_user_agent", previousUserAgent);
+    restoreEnv("npm_execpath", previousNpmExecpath);
+    restoreEnv("npm_lifecycle_event", previousNpmLifecycleEvent);
+    restoreEnv("PNPM_HOME", previousPnpmHome);
+  }
+
+  const envEntries = fs
+    .readFileSync(envLogPath, "utf8")
+    .trim()
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+  assert.equal(envEntries.length, 2, "expected --version and install env snapshots");
+  for (const env of envEntries) {
+    assert.match(
+      String(env.npm_config_user_agent ?? ""),
+      /^bun\//,
+      `expected bun user-agent, got ${JSON.stringify(env.npm_config_user_agent)}`,
+    );
+    assert.equal(env.npm_execpath, undefined, "npm_execpath must not leak to bun children");
+    assert.equal(
+      env.npm_lifecycle_event,
+      undefined,
+      "npm_lifecycle_event must not leak to bun children",
+    );
+    assert.equal(env.PNPM_HOME, undefined, "PNPM_HOME must not leak to bun children");
+  }
+});
+
 test("bun-based target repos still report unrelated missing scripts as blocked", () => {
   // Sanitize is intentionally narrow: only the canonical `pnpm check:changed`
   // shape gets dropped. Any other genuinely missing script (e.g. a typo) must
@@ -641,6 +701,29 @@ if (process.argv[2] === "--version") console.log("1.3.10");
   );
   fs.chmodSync(bunPath, 0o755);
   return { binDir, logPath };
+}
+
+function envLoggingBunFixture(cwd) {
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-fake-bun-env-bin-"));
+  const logPath = path.join(cwd, "fake-bun.log");
+  const envLogPath = path.join(cwd, "fake-bun-env.log");
+  const bunPath = path.join(binDir, "bun");
+  fs.writeFileSync(
+    bunPath,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+fs.appendFileSync(${JSON.stringify(logPath)}, process.argv.slice(2).join(" ") + "\\n");
+fs.appendFileSync(${JSON.stringify(envLogPath)}, JSON.stringify(process.env) + "\\n");
+if (process.argv[2] === "--version") console.log("1.3.10");
+`,
+  );
+  fs.chmodSync(bunPath, 0o755);
+  return { binDir, logPath, envLogPath };
+}
+
+function restoreEnv(key, previous) {
+  if (previous === undefined) delete process.env[key];
+  else process.env[key] = previous;
 }
 
 function withPathPrefix(binDir, callback) {


### PR DESCRIPTION
# fix(repair/target-validation): scrub pnpm env injection before `bun install`

## Summary

`prepareBunToolchain` was leaking pnpm's child-process env injection into `bun install`, which made target repos with a `bunx only-allow bun` preinstall hook (notably **openclaw/clawhub**) fail every automerge run during the `preparing target toolchain` step:

```
[clawsweeper repair] preparing target toolchain {"source_head":"3da5618…"}
$ bunx only-allow bun
error: preinstall script from "clawhub" exited with 1

bun install v1.3.10
╔═════════════════════════════════════════════════════════════╗
║ Use "bun install" for installation in this project.         ║
╚═════════════════════════════════════════════════════════════╝
```

This is the last remaining symptom of the broader issue tracked in #239 ("Target validation hard-codes pnpm + check:changed"). The config-driven `packageManager` / `validationCommands` / `changedGate` work (covering `prepareTargetToolchain`, `requiredValidationCommands`, `preflightTargetValidationPlan`, `validationFallbackCommands`, `shouldRetryValidationCommand`, plus the clawhub config entry) already landed in earlier commits. After that work clawhub correctly reaches `prepareBunToolchain` — only to be killed by the env leak fixed here.

## Root cause

ClawSweeper is invoked via `pnpm run repair:execute-fix`. pnpm injects the standard npm-cli child-process variables into `process.env`:

- `npm_config_user_agent=pnpm/<ver> npm/? node/<ver> <os> <arch>`
- `npm_execpath`, `npm_lifecycle_event`, `npm_package_*`
- `PNPM_HOME`, `PNPM_SCRIPT_SRC_DIR`, `PNPM_PACKAGE_NAME`

`prepareBunToolchain` forwarded `validationEnv` (a thin wrapper over `process.env`) verbatim to `bun --version` and `bun install`. bun then forwarded the same env to the target's `preinstall` hook. `only-allow` reads `npm_config_user_agent`, sees `pnpm/...`, and refuses to run because the project (clawhub) declares bun as its only allowed package manager.

## Fix

Introduce `sanitizeEnvForBun(env)` and route every bun child process through it:

- Strip every `npm_*` env variable (the critical one is `npm_config_user_agent`; siblings like `npm_execpath`, `npm_lifecycle_event`, `npm_package_*` carry parent-tool semantics that can confuse target preinstalls too).
- Strip `PNPM_HOME`, `PNPM_SCRIPT_SRC_DIR`, `PNPM_PACKAGE_NAME`.
- Set `npm_config_user_agent` to `bun/unknown npm/? node/<v> <platform> <arch>` so any preinstall guard (`only-allow bun`, custom version checks, etc.) sees a bun caller.

The sanitized env is applied to all three bun invocations:

- `bun --version` (setup probe)
- `bun install --frozen-lockfile`
- `bun install --no-frozen-lockfile` (lockfile-drift fallback)

The pnpm and npm branches are untouched.

## Tests

`test/repair/target-validation.test.ts`:

- New regression test **`bun-based target toolchain hides pnpm-injected npm_config_user_agent from preinstall hooks`**:
  - Pre-populates `process.env` with `npm_config_user_agent=pnpm/...`, `npm_execpath`, `npm_lifecycle_event`, `PNPM_HOME` to simulate the real worker environment.
  - Adds an `envLoggingBunFixture` that records each child's `process.env` as JSON alongside the existing argv log.
  - Asserts that for both the `--version` probe and the `install` call: `npm_config_user_agent` starts with `bun/`, and `npm_execpath` / `npm_lifecycle_event` / `PNPM_HOME` are absent.
  - Restores prior env on teardown via a small `restoreEnv` helper.

- Existing tests stay green:
  - `bun-based target toolchain installs deps and runs configured validation` (canonical bun flow)
  - `bun-based target repos do not get pnpm check:changed injected`
  - `bun-based target repos drop stale pnpm check:changed and pass on their real validation command`
  - `bun-based target repos still report unrelated missing scripts as blocked`
  - `resolveTargetRepoToolchain reads openclaw/clawhub from the real config without overrides`

## Verification

- `pnpm run build:repair` — clean.
- Lint — clean (`read_lints` on both touched files returned no diagnostics).
- Local Node 20 cannot run the project's native `.ts` tests (the repo pins Node 24); CI on Node 24 will exercise the new test. As a sanity check the compiled `sanitizeEnvForBun` was eval-ed against a pnpm-poisoned env and produced the expected output (`bun/...` user-agent, `npm_execpath` / `PNPM_HOME` removed).

## Impact

- **openclaw/clawhub** automerge/autofix can now get past `preparing target toolchain` and proceed to `bun install --frozen-lockfile` → `bun run check`. No more `preinstall script from "clawhub" exited with 1` no-ops.
- No behavioral change for pnpm or npm targets — the sanitization is gated on the bun branch only.
- No env mutation on the parent process; sanitization happens on a copy passed to each bun child.

## Risk

Low. The bun branch already required CI to provision pinned bun; we are only narrowing what env it sees. Any future bun-target repo benefits automatically. The pnpm/npm code paths are byte-identical to before.

## Suggested labels

`area: repair`, `area: target-validation`, `bug`, `multi-repo`

## Proof

Before: 
<img width="1079" height="469" alt="Clipboard_Screenshot_1780390461" src="https://github.com/user-attachments/assets/3248e2cf-96b9-41f2-9845-b416e7d6a2f1" />

After:
<img width="1006" height="526" alt="Clipboard_Screenshot_1780390496" src="https://github.com/user-attachments/assets/03a9db06-ffac-4bf7-b1f2-f31169acf993" />

