### PR TITLE
Keep proof-nudge comments inert

### DIFF
--- a/docs/target-dispatcher.md
+++ b/docs/target-dispatcher.md
@@ -132,6 +132,10 @@ jobs:
           fi
           body_file="$RUNNER_TEMP/clawsweeper-comment-body.txt"
           printf '%s\n' "$COMMENT_BODY" > "$body_file"
+          if grep -Eiq '<!--[[:space:]]*clawsweeper-proof-nudge([[:space:]]|-->)' "$body_file"; then
+            echo "Ignoring ClawSweeper proof-nudge comment."
+            exit 0
+          fi
           if ! grep -Eiq '(^|[[:space:]])@clawsweeper\b|(^|[[:space:]])/(clawsweeper|review|re-review|rerun[ -]?review|status|explain|fix|build|implement|create[ -]?pr|fix[ -]?issue|autofix|auto[ -]?fix|automerge|auto[ -]?merge|approve|stop|autoclose)\b' "$body_file"; then
             echo "No ClawSweeper command found in comment."
             exit 0
@@ -181,13 +185,14 @@ jobs:
 ```
 
 Comments are a lightweight trigger only when the body contains a ClawSweeper
-command. The target workflow reacts with `eyes` and creates one visible queued
+command, and generated proof-nudge comments are explicitly ignored before command
+matching. The target workflow reacts with `eyes` and creates one visible queued
 status comment for maintainer-authored commands when target write permission is
-available, but both acknowledgement writes are best-effort. It must still
-dispatch `clawsweeper_comment` to the comment router when acknowledgement or
-queued-comment creation gets a target-repository 403. The dispatch carries the
-exact source comment id and, when available, the queued status comment id. The
-router edits that queued comment in place instead of posting a second reply.
+available, but both acknowledgement writes are best-effort. It must still dispatch
+`clawsweeper_comment` to the comment router when acknowledgement or queued-comment
+creation gets a target-repository 403. The dispatch carries the exact source
+comment id and, when available, the queued status comment id. The router edits
+that queued comment in place instead of posting a second reply.
 Exact comment dispatches scan only that comment and use a per-comment receiver
 concurrency group, so one maintainer command does not wait behind an unrelated
 command on the same repository. The scheduled sweep remains a five-minute

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -753,6 +753,7 @@ type ProofNudgeAction =
   | "skipped_protected_label"
   | "skipped_locked_conversation"
   | "skipped_no_live_head"
+  | "skipped_live_fetch_failed"
   | "skipped_runtime_budget";
 
 interface ProofNudgeResult {
@@ -15343,6 +15344,17 @@ function proofNudgeCandidateRecords(
     );
 }
 
+function proofNudgeLiveFetchFailureReason(error: unknown): string {
+  const rawMessage = error instanceof Error ? error.message : String(error);
+  const lines = rawMessage
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const detail =
+    lines.find((line) => !line.startsWith("Command failed:")) ?? lines[0] ?? "unknown error";
+  return `live GitHub state could not be fetched: ${detail.slice(0, 300)}`;
+}
+
 export function proofNudgeCandidateRecordsForTest(
   itemsDir: string,
   requestedItemNumbers: readonly number[] = [],
@@ -15416,7 +15428,21 @@ function proofNudgesCommand(args: Args): void {
       number: candidate.number,
       reviewedAt: candidate.reviewedAt,
     };
-    const { item, state } = fetchItem(candidate.number);
+    let item: Item;
+    let state: string;
+    try {
+      const fetched = fetchItem(candidate.number);
+      item = fetched.item;
+      state = fetched.state;
+    } catch (error) {
+      results.push({
+        ...resultBase,
+        action: "skipped_live_fetch_failed",
+        reason: proofNudgeLiveFetchFailureReason(error),
+      });
+      processedCount += 1;
+      continue;
+    }
     if (state !== "open") {
       results.push({
         ...resultBase,
@@ -15426,17 +15452,31 @@ function proofNudgesCommand(args: Args): void {
       processedCount += 1;
       continue;
     }
-    const pullDetails =
-      item.kind === "pull_request" ? fetchPullRequestProofNudgeDetails(candidate.number) : {};
-    const comments = item.kind === "pull_request" ? proofNudgeComments(candidate.number) : [];
-    const authorEditedAt =
-      item.kind === "pull_request"
-        ? latestAuthorPullRequestEditAt(candidate.number, item.author)
-        : undefined;
-    const authorReviewActivityAt =
-      item.kind === "pull_request"
-        ? latestAuthorPullRequestReviewActivityAt(candidate.number, item.author)
-        : undefined;
+    let pullDetails: Partial<ProofNudgePullRequestDetails> = {};
+    let comments: ProofNudgeComment[] = [];
+    let authorEditedAt: string | undefined;
+    let authorReviewActivityAt: string | undefined;
+    try {
+      pullDetails =
+        item.kind === "pull_request" ? fetchPullRequestProofNudgeDetails(candidate.number) : {};
+      comments = item.kind === "pull_request" ? proofNudgeComments(candidate.number) : [];
+      authorEditedAt =
+        item.kind === "pull_request"
+          ? latestAuthorPullRequestEditAt(candidate.number, item.author)
+          : undefined;
+      authorReviewActivityAt =
+        item.kind === "pull_request"
+          ? latestAuthorPullRequestReviewActivityAt(candidate.number, item.author)
+          : undefined;
+    } catch (error) {
+      results.push({
+        ...resultBase,
+        action: "skipped_live_fetch_failed",
+        reason: proofNudgeLiveFetchFailureReason(error),
+      });
+      processedCount += 1;
+      continue;
+    }
     const eligibility = proofNudgeEligibility({
       item,
       markdown: candidate.markdown,

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -1028,6 +1028,7 @@ function isAfterAutoRepairResumeBoundary(entry: AutoRepairDispatchEntry, resumeB
 }
 
 export function parseCommand(body: string) {
+  if (isProofNudgeCommentBody(body)) return null;
   const commandLine = extractClawSweeperCommandLine(body);
   if (!commandLine) return null;
   const command = commandFromText(commandLine.trigger, commandLine.commandText);
@@ -1062,6 +1063,7 @@ export function parseTrustedAutomation(
   if (!trustedAuthors.has(author)) return null;
 
   const body = String(comment?.body ?? "");
+  if (isProofNudgeCommentBody(body)) return null;
   const verdict = clawsweeperMarker(body, "verdict");
   const actionMarker = clawsweeperMarker(body, "action");
   const securityMarker = clawsweeperMarker(body, "security");
@@ -1143,6 +1145,10 @@ export function parseRoutedCommentCommand(
   const trusted = parseTrustedAutomation(comment, { trustedAuthors });
   if (trusted) return trusted;
   return parseCommand(String(comment?.body ?? ""));
+}
+
+export function isProofNudgeCommentBody(body: string) {
+  return /<!--\s*clawsweeper-proof-nudge(?:\s|-->)/i.test(String(body ?? ""));
 }
 
 function trustedCommentHasPriorityFinding(body: string) {

--- a/src/repair/comment-webhook.ts
+++ b/src/repair/comment-webhook.ts
@@ -4,7 +4,11 @@ import http from "node:http";
 
 import { repositoryProfileFor } from "../repository-profiles.js";
 import type { JsonValue, LooseRecord } from "./json-types.js";
-import { parseCommand, staleClosedItemCommandReason } from "./comment-router-core.js";
+import {
+  isProofNudgeCommentBody,
+  parseCommand,
+  staleClosedItemCommandReason,
+} from "./comment-router-core.js";
 
 const DEFAULT_PORT = 8787;
 const REVIEW_REPO = "openclaw/clawsweeper";
@@ -171,6 +175,9 @@ export function classifyIssueCommentWebhook({
   const issue = asRecord(payload.issue);
   const repo = asRecord(payload.repository);
   const association = String(comment.author_association ?? "").toUpperCase();
+  if (isProofNudgeCommentBody(String(comment.body ?? ""))) {
+    return { accepted: false, reason: "proof nudge comment" };
+  }
   if (!COMMAND_PATTERN.test(String(comment.body ?? ""))) {
     return { accepted: false, reason: "no ClawSweeper command" };
   }

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -14780,6 +14780,78 @@ Stored report label snapshots can be older than the live PR labels.
   }
 });
 
+test("proof nudges skip stale targeted PRs when live GitHub state cannot be fetched", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const reportPath = join(root, "proof-nudge-report.json");
+    mkdirSync(itemsDir, { recursive: true });
+    writeFileSync(join(itemsDir, "42.md"), proofNudgeReport({ number: 42 }));
+    writeFileSync(join(itemsDir, "43.md"), proofNudgeReport({ number: 43 }));
+    withMockGh(
+      root,
+      `#!/usr/bin/env node
+const args = process.argv.slice(2);
+const path = args[1] || "";
+if (path.endsWith("/issues/42")) {
+  console.error("Not Found");
+  process.exit(1);
+}
+if (path.endsWith("/issues/43")) {
+  console.log(JSON.stringify({
+    number: 43,
+    title: "Closed proof nudge sample",
+    html_url: "https://github.com/openclaw/openclaw/pull/43",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-02T00:00:00Z",
+    closed_at: "2026-01-03T00:00:00Z",
+    state: "closed",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "contributor" },
+    labels: ["triage: needs-real-behavior-proof"],
+    pull_request: {}
+  }));
+  process.exit(0);
+}
+console.error("unexpected gh args: " + args.join(" "));
+process.exit(1);
+`,
+      () => {
+        execFileSync(process.execPath, [
+          "dist/clawsweeper.js",
+          "proof-nudges",
+          "--target-repo",
+          "openclaw/openclaw",
+          "--items-dir",
+          itemsDir,
+          "--item-numbers",
+          "42,43",
+          "--limit",
+          "10",
+          "--processed-limit",
+          "10",
+          "--report-path",
+          reportPath,
+        ]);
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    assert.deepEqual(
+      report.map((entry: { number: number; action: string }) => [entry.number, entry.action]),
+      [
+        [42, "skipped_live_fetch_failed"],
+        [43, "skipped_not_open"],
+      ],
+    );
+    assert.match(report[0].reason, /live GitHub state could not be fetched/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("proof nudges become eligible only after proof policy and age gates pass", () => {
   const result = proofNudgeEligibilityForTest({
     item: proofNudgeItem(),

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -1103,6 +1103,24 @@ test("parseTrustedAutomation accepts only trusted ClawSweeper repair signals", (
   );
 });
 
+test("parseRoutedCommentCommand ignores proof-nudge marker comments", () => {
+  const trustedAuthors = new Set(["clawsweeper[bot]"]);
+  const comment = {
+    user: { login: "clawsweeper[bot]" },
+    body: [
+      "@contributor thanks for the PR. ClawSweeper is still waiting on real behavior proof.",
+      "",
+      "Once proof is added, @clawsweeper re-review can check it.",
+      "",
+      '<!-- clawsweeper-proof-nudge item="86422" sha="abc123" at="2026-06-02T00:00:00.000Z" v="1" -->',
+    ].join("\n"),
+  };
+
+  assert.equal(parseRoutedCommentCommand(comment, { trustedAuthors }), null);
+  assert.equal(parseTrustedAutomation(comment, { trustedAuthors }), null);
+  assert.equal(parseCommand(comment.body), null);
+});
+
 test("parseRoutedCommentCommand prefers trusted verdict markers over copyable commands", () => {
   const trustedAuthors = new Set(["clawsweeper"]);
   const parsed = parseRoutedCommentCommand(

--- a/test/repair/comment-webhook.test.ts
+++ b/test/repair/comment-webhook.test.ts
@@ -39,6 +39,32 @@ test("comment webhook accepts maintainer ClawSweeper commands", () => {
   });
 });
 
+test("comment webhook ignores ClawSweeper proof-nudge comments", () => {
+  const result = classifyIssueCommentWebhook({
+    event: "issue_comment",
+    payload: {
+      action: "created",
+      repository: { full_name: "openclaw/openclaw", default_branch: "main" },
+      issue: { number: 86422 },
+      installation: { id: 123 },
+      comment: {
+        id: 456,
+        body: [
+          "@contributor thanks for the PR. ClawSweeper is still waiting on real behavior proof.",
+          "",
+          "Once proof is added, @clawsweeper re-review can check it.",
+          "",
+          '<!-- clawsweeper-proof-nudge item="86422" sha="abc123" at="2026-06-02T00:00:00.000Z" v="1" -->',
+        ].join("\n"),
+        author_association: "MEMBER",
+        user: { login: "clawsweeper[bot]" },
+      },
+    },
+  });
+
+  assert.deepEqual(result, { accepted: false, reason: "proof nudge comment" });
+});
+
 test("comment webhook rejects inline ClawSweeper mentions before visible ack", () => {
   const result = classifyIssueCommentWebhook({
     event: "issue_comment",


### PR DESCRIPTION
## Summary

- ignore proof-nudge marker comments in the webhook classifier and repair comment router so ClawSweeper does not react to its own nudge comments
- keep targeted proof-nudge dry runs resilient when live GitHub state for a sampled PR cannot be fetched
- document the target dispatcher proof-nudge ignore before command matching

## Real Behavior Proof

Representative runtime proof from the compiled webhook/router code on this branch. The marker-bearing proof-nudge comment includes an otherwise routable `@clawsweeper re-review` line, but the proof-nudge marker makes it inert; a normal command still routes.

```text
proof-nudge webhook classification: {"accepted":false,"reason":"proof nudge comment"}
proof-nudge router parse: null
normal command webhook classification: {"accepted":true,"type":"issue_comment","targetRepo":"openclaw/openclaw","targetBranch":"main","itemNumber":86422,"commentId":457,"installationId":123,"sourceAction":"created"}
normal command router parse: {"trigger":"mention","command":"re-review","intent":"re_review"}
```

## Validation

- pnpm run format:check
- pnpm run build:all
- node --test test/repair/comment-webhook.test.ts test/repair/comment-router-core.test.ts
- pnpm run lint:repair
- pnpm run lint:scripts
- node --test --test-name-pattern "proof nudge|proof-nudge|proof nudges" test/clawsweeper.test.ts
- representative runtime proof command above