### PR TITLE
Allow proof nudges to comment on PRs

### DIFF
--- a/.github/workflows/proof-nudges.yml
+++ b/.github/workflows/proof-nudges.yml
@@ -85,7 +85,7 @@ jobs:
           repositories: ${{ steps.target.outputs.target_repo_name }}
           permission-contents: read
           permission-issues: write
-          permission-pull-requests: read
+          permission-pull-requests: write
 
       - name: Create state token
         id: state-token

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -16096,6 +16096,7 @@ test("proof nudge workflow is manual-first and scheduled behind repo vars", () =
   assert.match(job, /PROOF_NUDGES_LIMIT:/);
   assert.match(job, /PROOF_NUDGES_MIN_AGE_DAYS:/);
   assert.match(job, /PROOF_NUDGES_COOLDOWN_DAYS:/);
+  assert.match(job, /permission-pull-requests: write/);
   assert.match(
     job,
     /numeric_input in PROOF_NUDGES_LIMIT PROOF_NUDGES_MIN_AGE_DAYS PROOF_NUDGES_COOLDOWN_DAYS/,


### PR DESCRIPTION
## Summary
- request pull-requests write permission for the proof-nudge target App token
- assert the workflow keeps that permission in the proof-nudge workflow guard test

## Why
The targeted execute run for the planned proof nudges failed before posting the first comment with HTTP 403: Resource not accessible by integration on POST /repos/openclaw/openclaw/issues/71563/comments. The existing proof-nudge token had issues:write but only pull-requests:read, while the active comment-capable repair lanes request pull-requests:write for PR targets.

Failed execute run: https://github.com/openclaw/clawsweeper/actions/runs/26827458777

## Validation
- node --test --test-name-pattern "proof nudge workflow" test/clawsweeper.test.ts
- pnpm run format:check