### PR TITLE
Run proof nudges at 5am Central

### DIFF
--- a/.github/workflows/proof-nudges.yml
+++ b/.github/workflows/proof-nudges.yml
@@ -30,7 +30,7 @@ on:
         required: false
         default: ""
   schedule:
-    - cron: "44 9 * * *"
+    - cron: "0 10 * * *"
 
 permissions:
   contents: read

--- a/docs/proof-nudges.md
+++ b/docs/proof-nudges.md
@@ -60,7 +60,7 @@ Useful options:
 
 The `ClawSweeper Proof Nudges` workflow exposes this as a manual `workflow_dispatch` lane. It defaults to dry-run. Use `execute=true` only after reviewing a dry-run report.
 
-The workflow also includes a daily scheduled lane at `44 9 * * *`, but it is off by default. This lets maintainers enable scheduled proof nudges later without another code change.
+The workflow also includes a daily scheduled lane at `0 10 * * *`, which is 5:00 AM Central during daylight time, but it is off by default. This lets maintainers enable scheduled proof nudges later without another code change.
 
 Scheduled operation uses repository variables:
 

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -16084,7 +16084,7 @@ test("proof nudge workflow is manual-first and scheduled behind repo vars", () =
 
   assert.doesNotMatch(sweepWorkflow, /proof_nudges/);
   assert.match(workflow, /execute:[\s\S]*?default: "false"/);
-  assert.match(workflow, /cron: "44 9 \* \* \*"/);
+  assert.match(workflow, /cron: "0 10 \* \* \*"/);
   assert.match(concurrency, /clawsweeper-proof-nudges/);
   assert.match(job, /github\.event_name == 'workflow_dispatch'/);
   assert.match(job, /vars\.CLAWSWEEPER_PROOF_NUDGES_SCHEDULED == '1'/);


### PR DESCRIPTION
## Summary
- move the proof-nudge scheduled workflow to 0 10 * * *, which is 5:00 AM Central during daylight time
- update the workflow guard test and proof-nudge docs for the new schedule

## Validation
- node --test --test-name-pattern "proof nudge workflow" test/clawsweeper.test.ts
- pnpm run format:check