### PR TITLE
Gate proof nudges to 5am Central

### DIFF
--- a/.github/workflows/proof-nudges.yml
+++ b/.github/workflows/proof-nudges.yml
@@ -31,6 +31,7 @@ on:
         default: ""
   schedule:
     - cron: "0 10 * * *"
+    - cron: "0 11 * * *"
 
 permissions:
   contents: read
@@ -52,13 +53,31 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
+      - name: Check scheduled Central time
+        id: central-time
+        if: ${{ github.event_name == 'schedule' }}
+        env:
+          PROOF_NUDGES_SCHEDULE_TZ: America/Chicago
+        run: |
+          local_hour="$(TZ="$PROOF_NUDGES_SCHEDULE_TZ" date +%H)"
+          local_time="$(TZ="$PROOF_NUDGES_SCHEDULE_TZ" date '+%Y-%m-%d %H:%M:%S %Z')"
+          if [ "$local_hour" = "05" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "Scheduled proof nudges running at $local_time."
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping scheduled proof nudges at $local_time; waiting for 05:00 America/Chicago."
+          fi
+
       - uses: actions/checkout@v6
+        if: ${{ github.event_name != 'schedule' || steps.central-time.outputs.should_run == 'true' }}
         with:
           filter: blob:none
           fetch-depth: 0
 
       - name: Resolve target repository
         id: target
+        if: ${{ github.event_name != 'schedule' || steps.central-time.outputs.should_run == 'true' }}
         env:
           TARGET_REPO_INPUT: ${{ github.event.inputs.target_repo || vars.CLAWSWEEPER_PROOF_NUDGES_TARGET_REPO || 'openclaw/openclaw' }}
         run: |
@@ -77,6 +96,7 @@ jobs:
 
       - name: Create target proof-nudge token
         id: target-proof-token
+        if: ${{ github.event_name != 'schedule' || steps.central-time.outputs.should_run == 'true' }}
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
@@ -89,20 +109,24 @@ jobs:
 
       - name: Create state token
         id: state-token
+        if: ${{ github.event_name != 'schedule' || steps.central-time.outputs.should_run == 'true' }}
         uses: ./.github/actions/create-state-token
         with:
           client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
           private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
 
       - uses: ./.github/actions/setup-state
+        if: ${{ github.event_name != 'schedule' || steps.central-time.outputs.should_run == 'true' }}
         with:
           token: ${{ steps.state-token.outputs.token }}
 
       - uses: ./.github/actions/setup-pnpm
+        if: ${{ github.event_name != 'schedule' || steps.central-time.outputs.should_run == 'true' }}
         with:
           build-script: build:all
 
       - name: Run proof nudges
+        if: ${{ github.event_name != 'schedule' || steps.central-time.outputs.should_run == 'true' }}
         env:
           GH_TOKEN: ${{ steps.target-proof-token.outputs.token }}
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}

--- a/docs/proof-nudges.md
+++ b/docs/proof-nudges.md
@@ -60,7 +60,7 @@ Useful options:
 
 The `ClawSweeper Proof Nudges` workflow exposes this as a manual `workflow_dispatch` lane. It defaults to dry-run. Use `execute=true` only after reviewing a dry-run report.
 
-The workflow also includes a daily scheduled lane at `0 10 * * *`, which is 5:00 AM Central during daylight time, but it is off by default. This lets maintainers enable scheduled proof nudges later without another code change.
+The workflow also includes daily scheduled lanes at `0 10 * * *` and `0 11 * * *`, but it is off by default. Those UTC schedules are guarded by an `America/Chicago` local-time check so only the 5:00 AM Central run continues across daylight saving time changes.
 
 Scheduled operation uses repository variables:
 

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -16085,7 +16085,11 @@ test("proof nudge workflow is manual-first and scheduled behind repo vars", () =
   assert.doesNotMatch(sweepWorkflow, /proof_nudges/);
   assert.match(workflow, /execute:[\s\S]*?default: "false"/);
   assert.match(workflow, /cron: "0 10 \* \* \*"/);
+  assert.match(workflow, /cron: "0 11 \* \* \*"/);
   assert.match(concurrency, /clawsweeper-proof-nudges/);
+  assert.match(job, /PROOF_NUDGES_SCHEDULE_TZ: America\/Chicago/);
+  assert.match(job, /local_hour=.*date \+%H/);
+  assert.match(job, /steps\.central-time\.outputs\.should_run == 'true'/);
   assert.match(job, /github\.event_name == 'workflow_dispatch'/);
   assert.match(job, /vars\.CLAWSWEEPER_PROOF_NUDGES_SCHEDULED == '1'/);
   assert.match(job, /vars\.CLAWSWEEPER_PROOF_NUDGES_EXECUTE == '1'/);


### PR DESCRIPTION
## Summary
- add both UTC schedule candidates for 5:00 AM America/Chicago across daylight saving time
- gate scheduled proof-nudge execution to local hour 05 before checkout/token/setup work runs
- update the proof-nudge docs and workflow guard test for the timezone-aware schedule

## Real behavior proof
Local timezone proof for the two UTC schedule candidates:

```text
2026-07-01T10:00:00Z -> 05:00 CDT
2026-07-01T11:00:00Z -> 06:00 CDT
2026-12-01T10:00:00Z -> 04:00 CST
2026-12-01T11:00:00Z -> 05:00 CST
```

The workflow guard checks `TZ=America/Chicago date +%H` and only continues when the local hour is `05`, so the extra scheduled UTC event becomes a no-op in the opposite season.

## Validation
- node --test --test-name-pattern "proof nudge workflow" test/clawsweeper.test.ts
- pnpm run format:check
- node -e timezone mapping proof above