### PR TITLE
Protect queueable issues from stale automation

### DIFF
--- a/docs/work-lane.md
+++ b/docs/work-lane.md
@@ -55,9 +55,18 @@ label-only apply pass does not immediately queue another review of the same item
 | `clawsweeper:needs-product-decision`  | `requires_product_decision: true`                                                                                             |
 | `clawsweeper:needs-security-review`   | `item_category: security` or a `securityReview` status of `needs_attention`                                                   |
 
-The advisory-label sync owns only this label group. Reruns add labels that match
-the latest report, remove stale labels from this group, and preserve unrelated
-labels plus action/proof labels such as `clawsweeper:autofix`,
+When the advisory sync marks an issue `clawsweeper:queueable-fix`, it also adds
+the target repository's durable `no-stale` exemption and removes an existing
+`stale` label. Lower-confidence, manual-review, or otherwise non-queueable
+advisory states do not receive stale protection from this sync. If a later sync
+clears an existing `clawsweeper:queueable-fix` advisory label, it also clears
+the `no-stale` exemption added for that queueable state; existing `no-stale`
+labels without prior queueable advisory state are preserved as unrelated labels.
+
+Except for that queueable-issue stale transition, the advisory-label sync owns
+only this label group. Reruns add labels that match the latest report, remove
+stale labels from this group, and preserve unrelated labels plus action/proof
+labels such as `clawsweeper:autofix`,
 `clawsweeper:automerge`, `clawsweeper:human-review`,
 `clawsweeper:merge-ready`, `proof: sufficient`, and
 `mantis: telegram-visible-proof`.

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -1311,6 +1311,14 @@ const ISSUE_ADVISORY_LABELS = [
 const ISSUE_ADVISORY_LABEL_NAMES = new Set(
   ISSUE_ADVISORY_LABELS.map((label) => label.name.toLowerCase()),
 );
+const STALE_LABEL = "stale";
+const NO_STALE_LABEL = "no-stale";
+const QUEUEABLE_FIX_LABEL = "clawsweeper:queueable-fix";
+const ISSUE_STALE_PROTECTION_LABEL = {
+  name: NO_STALE_LABEL,
+  color: "6E7781",
+  description: "Exempts this issue from stale automation.",
+} as const;
 const PROTECTED_LABELS = new Set(["security", "beta-blocker", "release-blocker", "maintainer"]);
 const ALLOWED_REASONS = new Set<CloseReason>([
   "implemented_on_main",
@@ -9233,7 +9241,7 @@ function wantedIssueAdvisoryLabels(state: IssueAdvisoryLabelState): Set<string> 
     state.workStatus === "candidate" &&
     state.workConfidence === "high"
   ) {
-    labels.add("clawsweeper:queueable-fix");
+    labels.add(QUEUEABLE_FIX_LABEL);
   }
   if (
     state.workConfidence === "high" &&
@@ -9264,12 +9272,35 @@ function wantedIssueAdvisoryLabels(state: IssueAdvisoryLabelState): Set<string> 
   return labels;
 }
 
+function issueAdvisoryStateNeedsStaleProtection(state: IssueAdvisoryLabelState): boolean {
+  return (
+    state.type === "issue" &&
+    state.workCandidate === "queue_fix_pr" &&
+    state.workStatus === "candidate" &&
+    state.workConfidence === "high"
+  );
+}
+
+function issueAdvisoryLabelsHadQueueableProtection(labels: readonly string[]): boolean {
+  return labels.some((label) => label.toLowerCase() === QUEUEABLE_FIX_LABEL);
+}
+
 function nextIssueAdvisoryLabels(
   labels: readonly string[],
   state: IssueAdvisoryLabelState,
 ): string[] {
   const wantedLabels = wantedIssueAdvisoryLabels(state);
-  const nextLabels = labels.filter((label) => !isIssueAdvisoryLabel(label));
+  const needsStaleProtection = issueAdvisoryStateNeedsStaleProtection(state);
+  const hadQueueableProtection = issueAdvisoryLabelsHadQueueableProtection(labels);
+  const nextLabels = labels.filter(
+    (label) =>
+      !isIssueAdvisoryLabel(label) &&
+      !(needsStaleProtection && label.toLowerCase() === STALE_LABEL) &&
+      !(!needsStaleProtection && hadQueueableProtection && label.toLowerCase() === NO_STALE_LABEL),
+  );
+  if (needsStaleProtection && !nextLabels.some((label) => label.toLowerCase() === NO_STALE_LABEL)) {
+    nextLabels.push(NO_STALE_LABEL);
+  }
   for (const label of ISSUE_ADVISORY_LABELS) {
     if (wantedLabels.has(label.name)) nextLabels.push(label.name);
   }
@@ -9317,8 +9348,12 @@ function issueAdvisoryLabelStateFromReport(
   };
 }
 
-function ensureIssueAdvisoryLabel(name: string): void {
-  const definition = ISSUE_ADVISORY_LABELS.find((label) => label.name === name);
+function ensureIssueAdvisorySyncLabel(name: string): void {
+  const definition =
+    ISSUE_ADVISORY_LABELS.find((label) => label.name === name) ??
+    (name.toLowerCase() === ISSUE_STALE_PROTECTION_LABEL.name
+      ? ISSUE_STALE_PROTECTION_LABEL
+      : undefined);
   if (!definition) return;
   try {
     ghWithRetry(
@@ -9436,16 +9471,22 @@ function syncIssueAdvisoryLabels(options: {
   const currentLabelKeys = new Set(options.labels.map((label) => label.toLowerCase()));
   const nextLabelKeys = new Set(nextLabels.map((label) => label.toLowerCase()));
   const labelsToAdd = nextLabels.filter(
-    (label) => isIssueAdvisoryLabel(label) && !currentLabelKeys.has(label.toLowerCase()),
+    (label) =>
+      (isIssueAdvisoryLabel(label) || label.toLowerCase() === NO_STALE_LABEL) &&
+      !currentLabelKeys.has(label.toLowerCase()),
   );
   const labelsToRemove = options.labels.filter(
-    (label) => isIssueAdvisoryLabel(label) && !nextLabelKeys.has(label.toLowerCase()),
+    (label) =>
+      (isIssueAdvisoryLabel(label) ||
+        label.toLowerCase() === STALE_LABEL ||
+        label.toLowerCase() === NO_STALE_LABEL) &&
+      !nextLabelKeys.has(label.toLowerCase()),
   );
   const changed = labelsToAdd.length > 0 || labelsToRemove.length > 0;
   if (!changed) return { labels: nextLabels, changed };
   if (options.dryRun) return { labels: nextLabels, changed };
   for (const label of labelsToAdd) {
-    ensureIssueAdvisoryLabel(label);
+    ensureIssueAdvisorySyncLabel(label);
     ghWithRetry(["issue", "edit", String(options.number), "--add-label", label]);
   }
   for (const label of labelsToRemove) {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -12463,6 +12463,7 @@ test("apply-decisions counts advisory label-only syncs against the processed lim
         reviewed_at: "2026-05-01T00:00:00Z",
         item_snapshot_hash: "reviewed-snapshot-321",
         item_updated_at: "2026-05-01T00:00:00Z",
+        labels: JSON.stringify(["stale"]),
       }),
       321,
     );
@@ -12513,7 +12514,7 @@ if (args[0] === "api" && commentMatch) {
     active_lock_reason: null,
     author_association: "CONTRIBUTOR",
     user: { login: "reporter" },
-    labels: [],
+    labels: number === 321 ? ["stale"] : [],
     pull_request: null
   }));
 } else if (args[0] === "issue" && args[1] === "view") {
@@ -12539,6 +12540,14 @@ if (args[0] === "api" && commentMatch) {
     const editCalls = calls.filter((args) => args[0] === "issue" && args[1] === "edit");
     assert.ok(editCalls.length > 0);
     assert.deepEqual([...new Set(editCalls.map((args) => args[2]))], ["321"]);
+    assert.ok(
+      calls.some((args) => args[0] === "label" && args[1] === "create" && args[2] === "no-stale"),
+    );
+    assert.ok(editCalls.some((args) => args.includes("--add-label") && args.includes("no-stale")));
+    assert.ok(
+      editCalls.some((args) => args.includes("--remove-label") && args.includes("stale")),
+      JSON.stringify(editCalls),
+    );
     assert.equal(
       calls.some((args) => args.some((arg) => arg.includes("/issues/322"))),
       false,
@@ -15806,6 +15815,7 @@ test("ClawSweeper issue advisory labels expose work-lane routing state", () => {
     }),
     [
       "clawsweeper",
+      "no-stale",
       "issue-rating: 🧂 unranked krab",
       "clawsweeper:queueable-fix",
       "clawsweeper:fix-shape-clear",
@@ -15844,6 +15854,90 @@ test("ClawSweeper issue advisory labels expose work-lane routing state", () => {
       "clawsweeper:needs-maintainer-review",
     ],
   );
+});
+
+test("ClawSweeper issue advisory labels protect queueable issues from stale automation", () => {
+  const queueableLabels = issueAdvisoryLabelsForTest(["bug", "stale"], {
+    type: "issue",
+    workCandidate: "queue_fix_pr",
+    workStatus: "candidate",
+    workConfidence: "high",
+    hasWorkShape: true,
+  });
+
+  assert.equal(queueableLabels.includes("stale"), false);
+  assert.equal(queueableLabels.includes("no-stale"), true);
+  assert.equal(queueableLabels.includes("clawsweeper:queueable-fix"), true);
+  assert.equal(queueableLabels.includes("clawsweeper:fix-shape-clear"), true);
+
+  const alreadyProtectedLabels = issueAdvisoryLabelsForTest(["bug", "no-stale"], {
+    type: "issue",
+    workCandidate: "queue_fix_pr",
+    workStatus: "candidate",
+    workConfidence: "high",
+  });
+
+  assert.equal(alreadyProtectedLabels.includes("stale"), false);
+  assert.equal(alreadyProtectedLabels.filter((label) => label === "no-stale").length, 1);
+  assert.equal(alreadyProtectedLabels.includes("clawsweeper:queueable-fix"), true);
+});
+
+test("ClawSweeper issue advisory labels do not stale-proof non-queueable issues", () => {
+  const lowerConfidenceLabels = issueAdvisoryLabelsForTest(["bug", "stale"], {
+    type: "issue",
+    workCandidate: "queue_fix_pr",
+    workStatus: "candidate",
+    workConfidence: "medium",
+    hasWorkShape: true,
+  });
+
+  assert.equal(lowerConfidenceLabels.includes("stale"), true);
+  assert.equal(lowerConfidenceLabels.includes("no-stale"), false);
+  assert.equal(lowerConfidenceLabels.includes("clawsweeper:queueable-fix"), false);
+
+  const manualReviewLabels = issueAdvisoryLabelsForTest(["bug", "stale"], {
+    type: "issue",
+    workCandidate: "manual_review",
+    workConfidence: "high",
+    hasWorkShape: true,
+  });
+
+  assert.equal(manualReviewLabels.includes("stale"), true);
+  assert.equal(manualReviewLabels.includes("no-stale"), false);
+  assert.equal(manualReviewLabels.includes("clawsweeper:queueable-fix"), false);
+  assert.equal(manualReviewLabels.includes("clawsweeper:fix-shape-clear"), true);
+  assert.equal(manualReviewLabels.includes("clawsweeper:needs-maintainer-review"), true);
+
+  const demotedQueueableLabels = issueAdvisoryLabelsForTest(
+    ["bug", "no-stale", "clawsweeper:queueable-fix"],
+    {
+      type: "issue",
+      workCandidate: "queue_fix_pr",
+      workStatus: "candidate",
+      workConfidence: "medium",
+    },
+  );
+
+  assert.equal(demotedQueueableLabels.includes("no-stale"), false);
+  assert.equal(demotedQueueableLabels.includes("clawsweeper:queueable-fix"), false);
+
+  const manuallyProtectedLabels = issueAdvisoryLabelsForTest(["bug", "no-stale"], {
+    type: "issue",
+    workCandidate: "manual_review",
+  });
+
+  assert.equal(manuallyProtectedLabels.includes("no-stale"), true);
+  assert.equal(manuallyProtectedLabels.includes("clawsweeper:needs-maintainer-review"), true);
+
+  const pullRequestLabels = issueAdvisoryLabelsForTest(["bug", "stale"], {
+    type: "pull_request",
+    workCandidate: "queue_fix_pr",
+    workStatus: "candidate",
+    workConfidence: "high",
+    hasWorkShape: true,
+  });
+
+  assert.deepEqual(pullRequestLabels, ["bug", "stale"]);
 });
 
 test("ClawSweeper issue advisory labels expose linked PR and human decision blockers", () => {


### PR DESCRIPTION
## Summary

- Add ClawSweeper-side stale protection for high-confidence queueable issue advisory syncs.
- When ClawSweeper marks an issue `clawsweeper:queueable-fix`, it now removes `stale` and adds the target repo's durable `no-stale` exemption.
- Preserve existing manually-applied `no-stale` labels, but clear the `no-stale` exemption if a later advisory sync removes a previously queueable ClawSweeper state.
- Document the advisory-label stale transition in `docs/work-lane.md`.

Fixes openclaw/clawsweeper#247.

Companion OpenClaw stale-workflow fix: https://github.com/openclaw/openclaw/pull/89572

## Real behavior proof

- Behavior addressed: ClawSweeper queueable/actionable issue labels should protect actionable OpenClaw issues from stale automation instead of leaving `stale` attached.
- Real environment tested: Local `openclaw/clawsweeper` source checkout on Node `v24.13.0`, branch `fix/issue-247-queueable-stale-protection`, head `ddbee54177`, based on upstream `9c50a95427c21d5e0e33e57295e68b1548cc9953`.
- Exact steps run after this patch:
  - `git diff --check`
  - `node --test --test-name-pattern "issue advisory labels" test/clawsweeper.test.ts`
  - `node --test --test-name-pattern "apply-decisions counts advisory label-only syncs" test/clawsweeper.test.ts`
  - `pnpm run build:all`
  - `pnpm run lint`
  - `pnpm exec oxfmt --check docs/work-lane.md src/clawsweeper.ts test/clawsweeper.test.ts`
  - `codex review --uncommitted` before committing the patch
- Evidence after fix:
  - Advisory label tests passed: queueable issue state removes `stale`, adds `no-stale`, keeps `clawsweeper:queueable-fix`, and does not stale-proof lower-confidence/manual-review/PR states.
  - Apply-decisions label-only sync test passed and now asserts the live sync path creates `no-stale`, adds it, and removes `stale` for the queueable candidate.
  - Build and lint passed.
  - Changed-file formatting passed.
  - Codex review reported no actionable correctness issues.
- What was not tested: No live GitHub labels were mutated from this local run.
- Proof limitation: Full `pnpm run check` was attempted. It passed active-surface, limits, build, and lint, then failed in broad `test:unit` on this Windows desktop because unrelated tests spawn local Codex or `/usr/bin/git` paths (`spawnSync codex EPERM`, `spawnSync /usr/bin/git ENOENT`) and one Windows file-mode expectation differs. The focused tests requested by ClawSweeper for this issue passed.

## Verification

```text
git diff --check
node --test --test-name-pattern "issue advisory labels" test/clawsweeper.test.ts
node --test --test-name-pattern "apply-decisions counts advisory label-only syncs" test/clawsweeper.test.ts
pnpm run build:all
pnpm run lint
pnpm exec oxfmt --check docs/work-lane.md src/clawsweeper.ts test/clawsweeper.test.ts
codex review --uncommitted
```

Duplicate scan before opening PR found no open matching implementation PRs in `openclaw/clawsweeper` for queueable/stale/no-stale protection.


## Additional controlled dry-run proof

After ClawSweeper review asked for a non-mocked live/dry-run label-sync proof, I ran a controlled dry-run against live GitHub issue metadata from https://github.com/openclaw/openclaw/issues/78640. This issue currently has `stale`, `clawsweeper:queueable-fix`, `clawsweeper:source-repro`, and `clawsweeper:fix-shape-clear`.

No live label mutation was performed. The dry-run used a temporary local `items/78640.md` report with `work_candidate: queue_fix_pr`, `work_status: candidate`, `work_confidence: high`, and the issue's current `item_updated_at` from GitHub.

Command run:

```text
node dist/clawsweeper.js apply-decisions --target-repo openclaw/openclaw --items-dir C:\oc-work\proof-248-20260602200913\items --closed-dir C:\oc-work\proof-248-20260602200913\closed --plans-dir C:\oc-work\proof-248-20260602200913\plans --report-path C:\oc-work\proof-248-20260602200913\apply-report.json --limit 1 --processed-limit 1 --close-delay-ms 0 --item-numbers 78640 --apply-kind issue --dry-run --progress-every 1
```

Live labels before the dry-run:

```json
[
  "stale",
  "P1",
  "clawsweeper:fix-shape-clear",
  "clawsweeper:queueable-fix",
  "clawsweeper:source-repro",
  "impact:session-state",
  "impact:data-loss",
  "issue-rating: ?? diamond lobster"
]
```

Built ClawSweeper label transition computed from those live labels and the queueable issue state:

```json
{
  "beforeContainsStale": true,
  "beforeContainsNoStale": false,
  "afterContainsStale": false,
  "afterContainsNoStale": true,
  "added": ["no-stale"],
  "removed": ["stale"],
  "afterLabels": [
    "P1",
    "impact:session-state",
    "impact:data-loss",
    "no-stale",
    "issue-rating: ?? diamond lobster",
    "clawsweeper:source-repro",
    "clawsweeper:queueable-fix",
    "clawsweeper:fix-shape-clear"
  ]
}
```

Dry-run apply output:

```text
[apply] 2026-06-02T19:09:16.148Z starting apply: files=1 dry_run=true apply_kind=issue min_age=0 days apply_close_reasons=all stale_min_age_days=60 close_delay_ms=0 sync_comments_only=false comment_sync_min_age_days=0 max_runtime_ms=0 item_numbers=78640 closed=0/1 processed=0/1 counts={}
[apply] 2026-06-02T19:09:17.317Z synced review comment #78640 closed=0/1 processed=1/1 counts={"review_comment_synced":1}
[apply] 2026-06-02T19:09:17.318Z finished apply closed=0/1 processed=1/1 counts={"review_comment_synced":1}
[
  {
    "number": 78640,
    "action": "review_comment_synced",
    "reason": "would update durable Codex review comment"
  }
]
```

Live labels after the dry-run matched the before labels exactly, so `liveMutationsPerformed: false`.

The apply result reports the durable-comment dry-run action first because the synthetic local report did not match the existing durable ClawSweeper comment body on the live issue. The label transition above is from the built PR code using the live issue labels and the same queueable issue advisory state used by the apply path; it shows the intended label mutation precisely: add `no-stale`, remove `stale`.
