### PR TITLE
Handle delayed proof nudge schedules

### DIFF
--- a/.github/workflows/proof-nudges.yml
+++ b/.github/workflows/proof-nudges.yml
@@ -58,15 +58,17 @@ jobs:
         if: ${{ github.event_name == 'schedule' }}
         env:
           PROOF_NUDGES_SCHEDULE_TZ: America/Chicago
+          PROOF_NUDGES_EVENT_SCHEDULE: ${{ github.event.schedule }}
         run: |
-          local_hour="$(TZ="$PROOF_NUDGES_SCHEDULE_TZ" date +%H)"
           local_time="$(TZ="$PROOF_NUDGES_SCHEDULE_TZ" date '+%Y-%m-%d %H:%M:%S %Z')"
-          if [ "$local_hour" = "05" ]; then
+          local_zone="$(TZ="$PROOF_NUDGES_SCHEDULE_TZ" date +%Z)"
+          if { [ "$PROOF_NUDGES_EVENT_SCHEDULE" = "0 10 * * *" ] && [ "$local_zone" = "CDT" ]; } ||
+             { [ "$PROOF_NUDGES_EVENT_SCHEDULE" = "0 11 * * *" ] && [ "$local_zone" = "CST" ]; }; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
-            echo "Scheduled proof nudges running at $local_time."
+            echo "Scheduled proof nudges running for $PROOF_NUDGES_EVENT_SCHEDULE at $local_time."
           else
             echo "should_run=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Skipping scheduled proof nudges at $local_time; waiting for 05:00 America/Chicago."
+            echo "::notice::Skipping scheduled proof nudges for $PROOF_NUDGES_EVENT_SCHEDULE at $local_time; waiting for the 5:00 AM America/Chicago cron candidate."
           fi
 
       - uses: actions/checkout@v6

--- a/docs/proof-nudges.md
+++ b/docs/proof-nudges.md
@@ -60,7 +60,7 @@ Useful options:
 
 The `ClawSweeper Proof Nudges` workflow exposes this as a manual `workflow_dispatch` lane. It defaults to dry-run. Use `execute=true` only after reviewing a dry-run report.
 
-The workflow also includes daily scheduled lanes at `0 10 * * *` and `0 11 * * *`, but it is off by default. Those UTC schedules are guarded by an `America/Chicago` local-time check so only the 5:00 AM Central run continues across daylight saving time changes.
+The workflow also includes daily scheduled lanes at `0 10 * * *` and `0 11 * * *`, but it is off by default. Those UTC schedules are guarded by the scheduled cron string and the current `America/Chicago` timezone abbreviation, so only the 5:00 AM Central candidate continues across daylight saving time changes even if GitHub starts the run late.
 
 Scheduled operation uses repository variables:
 

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -16088,7 +16088,10 @@ test("proof nudge workflow is manual-first and scheduled behind repo vars", () =
   assert.match(workflow, /cron: "0 11 \* \* \*"/);
   assert.match(concurrency, /clawsweeper-proof-nudges/);
   assert.match(job, /PROOF_NUDGES_SCHEDULE_TZ: America\/Chicago/);
-  assert.match(job, /local_hour=.*date \+%H/);
+  assert.match(job, /PROOF_NUDGES_EVENT_SCHEDULE: \$\{\{ github\.event\.schedule \}\}/);
+  assert.match(job, /local_zone=.*date \+%Z/);
+  assert.match(job, /PROOF_NUDGES_EVENT_SCHEDULE" = "0 10 \* \* \*"/);
+  assert.match(job, /PROOF_NUDGES_EVENT_SCHEDULE" = "0 11 \* \* \*"/);
   assert.match(job, /steps\.central-time\.outputs\.should_run == 'true'/);
   assert.match(job, /github\.event_name == 'workflow_dispatch'/);
   assert.match(job, /vars\.CLAWSWEEPER_PROOF_NUDGES_SCHEDULED == '1'/);


### PR DESCRIPTION
## Summary
- make the scheduled proof-nudge guard tolerate delayed GitHub schedule starts
- use the triggering cron string plus the current America/Chicago zone abbreviation to choose the seasonal 5 AM Central candidate
- update docs and the workflow guard test for the delayed-schedule behavior

## Root cause
The 5 AM Central guard added in #246 checked the runner's actual local hour. GitHub started today's scheduled runs late, so both candidates skipped even though the feature was enabled:

- 0 10 * * * candidate: https://github.com/openclaw/clawsweeper/actions/runs/26882082381 started at 2026-06-03T11:34:59Z and logged 06:35 CDT
- 0 11 * * * candidate: https://github.com/openclaw/clawsweeper/actions/runs/26884954780 started at 2026-06-03T12:32:52Z and logged 07:32 CDT

## Real behavior proof
Local proof for the new decision rule, including today's delayed starts:

```text
0 10 * * * started 2026-06-03T11:35:03Z -> 06:35 CDT should_run=true
0 11 * * * started 2026-06-03T12:32:58Z -> 07:32 CDT should_run=false
0 10 * * * started 2026-12-03T11:35:03Z -> 05:35 CST should_run=false
0 11 * * * started 2026-12-03T12:32:58Z -> 06:32 CST should_run=true
```

This keeps exactly one seasonal candidate live even if GitHub queues the run late.

## Validation
- node --test --test-name-pattern "proof nudge workflow" test/clawsweeper.test.ts
- pnpm run format:check
- node -e delayed schedule decision proof above