### PR TITLE
fix: resolve Windows Codex spawn failures for local review runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,20 @@ jobs:
 
       - name: Run check
         run: pnpm run check
+
+  windows-codex-launch:
+    name: Windows Codex launcher
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup-pnpm
+
+      - name: Build process workers
+        run: |
+          pnpm run build
+          pnpm run build:repair
+
+      - name: Verify native Windows launcher
+        run: node --test --test-name-pattern "escaped Windows launchers|CODEX_BIN and preserves argv|timeout errors|app-server mode" test/codex-process.test.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
-- Made every Codex subprocess honor `CODEX_BIN` and launch npm-installed `codex.cmd` wrappers on native Windows. Thanks @anagnorisis2peripeteia.
+- Made every Codex subprocess honor `CODEX_BIN`, safely launch npm-installed `codex.cmd` wrappers on native Windows, and terminate their process trees on timeout. Thanks @anagnorisis2peripeteia.
 - Keep generated implementation PR bodies and terminal issue comments concise, avoid stale blocked states while PR checks are pending, and stop adding ClawSweeper itself as a commit co-author.
 - Prevented trusted ClawSweeper command status comments from re-entering GitHub activity handling and churning review automation. Thanks @ooiuuii.
 - Routed proof-sufficient security reviews that recommend maintainer risk acceptance to maintainer review instead of waiting on the contributor. Thanks @brokemac79.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Made every Codex subprocess honor `CODEX_BIN` and launch npm-installed `codex.cmd` wrappers on native Windows. Thanks @anagnorisis2peripeteia.
 - Keep generated implementation PR bodies and terminal issue comments concise, avoid stale blocked states while PR checks are pending, and stop adding ClawSweeper itself as a commit co-author.
 - Prevented trusted ClawSweeper command status comments from re-entering GitHub activity handling and churning review automation. Thanks @ooiuuii.
 - Routed proof-sufficient security reviews that recommend maintainer risk acceptance to maintainer review instead of waiting on the contributor. Thanks @brokemac79.

--- a/docs/repair/internal-features.md
+++ b/docs/repair/internal-features.md
@@ -619,6 +619,9 @@ Important defaults:
   to `fast`.
 - `CLAWSWEEPER_CODEX_HEARTBEAT_MS`: repair-worker and execute-side Codex
   subprocess heartbeat interval; default `60000`.
+- `CODEX_BIN`: optional Codex executable override. Native Windows runs use the
+  command shell so npm-installed `codex.cmd` launchers work; Unix runs keep
+  direct process spawning.
 - `CLAWSWEEPER_MAX_LIVE_WORKERS`: dispatch capacity guard. Existing repair
   lanes derive their checked-in default from `workers.max`; imported gitcrawl
   cluster jobs use `lanes.repair.cluster_max_live_runs`.

--- a/docs/repair/internal-features.md
+++ b/docs/repair/internal-features.md
@@ -619,9 +619,9 @@ Important defaults:
   to `fast`.
 - `CLAWSWEEPER_CODEX_HEARTBEAT_MS`: repair-worker and execute-side Codex
   subprocess heartbeat interval; default `60000`.
-- `CODEX_BIN`: optional Codex executable override. Native Windows runs use the
-  command shell so npm-installed `codex.cmd` launchers work; Unix runs keep
-  direct process spawning.
+- `CODEX_BIN`: optional Codex executable override. Native Windows runs resolve
+  npm-installed `codex.cmd` launchers through an escaped `cmd.exe` invocation;
+  native executables and Unix runs keep direct process spawning.
 - `CLAWSWEEPER_MAX_LIVE_WORKERS`: dispatch capacity guard. Existing repair
   lanes derive their checked-in default from `workers.max`; imported gitcrawl
   cluster jobs use `lanes.repair.cluster_max_live_runs`.

--- a/src/codex-app-server-worker.ts
+++ b/src/codex-app-server-worker.ts
@@ -1,4 +1,3 @@
-import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { createInterface } from "node:readline";
@@ -8,6 +7,7 @@ import {
   codexOutputTail,
   openCodexOutputCapture,
 } from "./codex-output-capture.js";
+import { spawnCodex, terminateCodexProcessTree } from "./codex-spawn.js";
 
 interface AppServerOptions {
   statePath: string;
@@ -20,7 +20,7 @@ interface AppServerOptions {
 interface WorkerOptions {
   args: string[];
   command: string;
-  shell: boolean;
+  timeoutMs: number;
   resultPath: string;
   stdoutPath: string;
   stderrPath: string;
@@ -69,11 +69,10 @@ const stderr = openCodexOutputCapture(options.stderrPath, {
   maxFileBytes: options.maxOutputFileBytes,
   tailBytes: options.tailBytes,
 });
-const child = spawn(options.command, ["app-server", "--listen", "stdio://"], {
+process.env.CODEX_BIN = options.command;
+const child = spawnCodex(["app-server", "--listen", "stdio://"], {
   cwd: execOptions.cwd,
   env: process.env,
-  shell: options.shell,
-  stdio: ["pipe", "pipe", "pipe"],
 });
 const pending = new Map<
   number,
@@ -94,6 +93,12 @@ let forceKillTimer: NodeJS.Timeout | undefined;
 let terminal: WebSocket | null = null;
 let terminalInput = "";
 let heartbeat: NodeJS.Timeout | undefined;
+const timeout = setTimeout(() => {
+  const error = new Error(`Codex app-server timed out after ${options.timeoutMs}ms`);
+  (error as NodeJS.ErrnoException).code = "ETIMEDOUT";
+  terminateCodexProcessTree(child);
+  void finish(1, null, error);
+}, options.timeoutMs);
 
 child.stderr.on("data", (chunk: Buffer) => appendCodexOutputCapture(stderr, chunk));
 child.once("error", (error) => {
@@ -116,8 +121,7 @@ lines.on("line", (line) => {
 for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
   process.once(signal, () => {
     if (settled) return;
-    child.kill(signal);
-    forceKillTimer = setTimeout(() => child.kill("SIGKILL"), 1_000);
+    forceKillTimer = terminateCodexProcessTree(child, signal);
   });
 }
 
@@ -364,6 +368,7 @@ function terminalWrite(value: string): void {
 async function finish(status: number, signal: NodeJS.Signals | null, error?: Error): Promise<void> {
   if (settled) return;
   settled = true;
+  clearTimeout(timeout);
   if (heartbeat) clearInterval(heartbeat);
   if (forceKillTimer) clearTimeout(forceKillTimer);
   for (const waiter of pending.values())
@@ -371,7 +376,7 @@ async function finish(status: number, signal: NodeJS.Signals | null, error?: Err
   pending.clear();
   if (child.exitCode === null && child.signalCode === null) {
     child.stdin.end();
-    child.kill("SIGTERM");
+    forceKillTimer = terminateCodexProcessTree(child);
   }
   terminal?.close(1000, "turn complete");
   closeCodexOutputCapture(stdout);

--- a/src/codex-app-server-worker.ts
+++ b/src/codex-app-server-worker.ts
@@ -7,7 +7,7 @@ import {
   codexOutputTail,
   openCodexOutputCapture,
 } from "./codex-output-capture.js";
-import { spawnCodex, terminateCodexProcessTree } from "./codex-spawn.js";
+import { spawnCodex, terminateCodexProcessTree, waitForCodexProcessExit } from "./codex-spawn.js";
 
 interface AppServerOptions {
   statePath: string;
@@ -83,6 +83,7 @@ const pending = new Map<
 >();
 let requestId = 0;
 let spawnError: Error | undefined;
+let timeoutError: Error | undefined;
 let threadId = "";
 let sessionId = "";
 let turnId = "";
@@ -94,10 +95,9 @@ let terminal: WebSocket | null = null;
 let terminalInput = "";
 let heartbeat: NodeJS.Timeout | undefined;
 const timeout = setTimeout(() => {
-  const error = new Error(`Codex app-server timed out after ${options.timeoutMs}ms`);
-  (error as NodeJS.ErrnoException).code = "ETIMEDOUT";
-  terminateCodexProcessTree(child);
-  void finish(1, null, error);
+  timeoutError = new Error(`Codex app-server timed out after ${options.timeoutMs}ms`);
+  (timeoutError as NodeJS.ErrnoException).code = "ETIMEDOUT";
+  forceKillTimer = terminateCodexProcessTree(child);
 }, options.timeoutMs);
 
 child.stderr.on("data", (chunk: Buffer) => appendCodexOutputCapture(stderr, chunk));
@@ -107,7 +107,11 @@ child.once("error", (error) => {
 });
 child.once("close", (status, signal) => {
   if (!settled) {
-    void finish(status ?? 1, signal, spawnError ?? new Error("Codex app-server exited early."));
+    void finish(
+      status ?? 1,
+      signal,
+      timeoutError ?? spawnError ?? new Error("Codex app-server exited early."),
+    );
   }
 });
 
@@ -242,6 +246,7 @@ async function handleRpcMessage(message: RpcMessage): Promise<void> {
   terminalWrite(
     `\r\n\r\n[ClawSweeper] Codex turn ${turnStatus || "finished"}. Deterministic repair gates continue in GitHub Actions.\r\n`,
   );
+  clearTimeout(timeout);
   await updateWorkState(
     failed ? "blocked" : "running",
     failed ? "codex_failed" : "validating",
@@ -377,6 +382,7 @@ async function finish(status: number, signal: NodeJS.Signals | null, error?: Err
   if (child.exitCode === null && child.signalCode === null) {
     child.stdin.end();
     forceKillTimer = terminateCodexProcessTree(child);
+    await waitForCodexProcessExit(child);
   }
   terminal?.close(1000, "turn complete");
   closeCodexOutputCapture(stdout);

--- a/src/codex-app-server-worker.ts
+++ b/src/codex-app-server-worker.ts
@@ -19,6 +19,8 @@ interface AppServerOptions {
 
 interface WorkerOptions {
   args: string[];
+  command: string;
+  shell: boolean;
   resultPath: string;
   stdoutPath: string;
   stderrPath: string;
@@ -67,9 +69,10 @@ const stderr = openCodexOutputCapture(options.stderrPath, {
   maxFileBytes: options.maxOutputFileBytes,
   tailBytes: options.tailBytes,
 });
-const child = spawn("codex", ["app-server", "--listen", "stdio://"], {
+const child = spawn(options.command, ["app-server", "--listen", "stdio://"], {
   cwd: execOptions.cwd,
   env: process.env,
+  shell: options.shell,
   stdio: ["pipe", "pipe", "pipe"],
 });
 const pending = new Map<

--- a/src/codex-process-worker.ts
+++ b/src/codex-process-worker.ts
@@ -9,6 +9,8 @@ import {
 
 interface WorkerOptions {
   args: string[];
+  command: string;
+  shell: boolean;
   resultPath: string;
   stdoutPath: string;
   stderrPath: string;
@@ -25,9 +27,10 @@ const stderr = openCodexOutputCapture(options.stderrPath, {
   maxFileBytes: options.maxOutputFileBytes,
   tailBytes: options.tailBytes,
 });
-const child = spawn("codex", options.args, {
+const child = spawn(options.command, options.args, {
   cwd: process.cwd(),
   env: process.env,
+  shell: options.shell,
   stdio: ["pipe", "pipe", "pipe"],
 });
 let spawnError: Error | undefined;

--- a/src/codex-process-worker.ts
+++ b/src/codex-process-worker.ts
@@ -1,4 +1,3 @@
-import { spawn } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 import {
   appendCodexOutputCapture,
@@ -6,11 +5,12 @@ import {
   codexOutputTail,
   openCodexOutputCapture,
 } from "./codex-output-capture.js";
+import { spawnCodex, terminateCodexProcessTree } from "./codex-spawn.js";
 
 interface WorkerOptions {
   args: string[];
   command: string;
-  shell: boolean;
+  timeoutMs: number;
   resultPath: string;
   stdoutPath: string;
   stderrPath: string;
@@ -27,15 +27,17 @@ const stderr = openCodexOutputCapture(options.stderrPath, {
   maxFileBytes: options.maxOutputFileBytes,
   tailBytes: options.tailBytes,
 });
-const child = spawn(options.command, options.args, {
-  cwd: process.cwd(),
-  env: process.env,
-  shell: options.shell,
-  stdio: ["pipe", "pipe", "pipe"],
-});
+process.env.CODEX_BIN = options.command;
+const child = spawnCodex(options.args, { cwd: process.cwd(), env: process.env });
 let spawnError: Error | undefined;
+let timeoutError: Error | undefined;
 let terminating = false;
 let forceKillTimer: NodeJS.Timeout | undefined;
+const timeout = setTimeout(() => {
+  timeoutError = new Error(`Codex process timed out after ${options.timeoutMs}ms`);
+  (timeoutError as NodeJS.ErrnoException).code = "ETIMEDOUT";
+  forceKillTimer = terminateCodexProcessTree(child);
+}, options.timeoutMs);
 
 child.stdout.on("data", (chunk: Buffer) => {
   appendCodexOutputCapture(stdout, chunk);
@@ -51,6 +53,7 @@ child.once("error", (error) => {
 });
 child.once("close", (status, signal) => {
   if (forceKillTimer) clearTimeout(forceKillTimer);
+  clearTimeout(timeout);
   closeCodexOutputCapture(stdout);
   closeCodexOutputCapture(stderr);
   writeFileSync(
@@ -58,7 +61,9 @@ child.once("close", (status, signal) => {
     JSON.stringify({
       status,
       signal,
-      ...(spawnError ? { error: serializedError(spawnError) } : {}),
+      ...(timeoutError || spawnError
+        ? { error: serializedError(timeoutError ?? spawnError!) }
+        : {}),
       stdout: codexOutputTail(stdout),
       stderr: codexOutputTail(stderr),
     }),
@@ -73,8 +78,7 @@ for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
     terminating = true;
     process.stdin.unpipe(child.stdin);
     child.stdin.end();
-    child.kill(signal);
-    forceKillTimer = setTimeout(() => child.kill("SIGKILL"), 1000);
+    forceKillTimer = terminateCodexProcessTree(child, signal);
   });
 }
 

--- a/src/codex-process.ts
+++ b/src/codex-process.ts
@@ -7,6 +7,9 @@ import {
   DEFAULT_CODEX_OUTPUT_FILE_BYTES,
   DEFAULT_CODEX_OUTPUT_TAIL_BYTES,
 } from "./codex-output-capture.js";
+import { codexProcessCommand } from "./codex-spawn.js";
+
+export { codexProcessCommand, codexSpawnInvocation } from "./codex-spawn.js";
 
 export interface CodexProcessResult {
   status: number | null;
@@ -40,14 +43,6 @@ export interface CodexAppServerProcessOptions {
   runnerPtyUrl?: string;
   workStateUrl?: string;
   agentToken?: string;
-}
-
-export function codexProcessCommand(env: NodeJS.ProcessEnv = process.env): string {
-  return env.CODEX_BIN?.trim() || "codex";
-}
-
-export function codexProcessUsesShell(platform: NodeJS.Platform = process.platform): boolean {
-  return platform === "win32";
 }
 
 export function codexAppServerProcessOptionsFromEnv(
@@ -96,7 +91,7 @@ export function runCodexProcess(options: {
       JSON.stringify({
         args: [...options.args],
         command: codexProcessCommand(options.env),
-        shell: codexProcessUsesShell(),
+        timeoutMs: options.timeoutMs,
         resultPath,
         stdoutPath,
         stderrPath,
@@ -112,7 +107,7 @@ export function runCodexProcess(options: {
       env: options.env,
       input: options.input,
       stdio: ["pipe", "ignore", "ignore"],
-      timeout: options.timeoutMs,
+      timeout: options.timeoutMs + 10_000,
     });
     if (existsSync(resultPath)) {
       const result = deserializeProcessResult(JSON.parse(readFileSync(resultPath, "utf8")));

--- a/src/codex-process.ts
+++ b/src/codex-process.ts
@@ -42,6 +42,14 @@ export interface CodexAppServerProcessOptions {
   agentToken?: string;
 }
 
+export function codexProcessCommand(env: NodeJS.ProcessEnv = process.env): string {
+  return env.CODEX_BIN?.trim() || "codex";
+}
+
+export function codexProcessUsesShell(platform: NodeJS.Platform = process.platform): boolean {
+  return platform === "win32";
+}
+
 export function codexAppServerProcessOptionsFromEnv(
   label: string,
   env: NodeJS.ProcessEnv = process.env,
@@ -87,6 +95,8 @@ export function runCodexProcess(options: {
       optionsPath,
       JSON.stringify({
         args: [...options.args],
+        command: codexProcessCommand(options.env),
+        shell: codexProcessUsesShell(),
         resultPath,
         stdoutPath,
         stderrPath,

--- a/src/codex-spawn.ts
+++ b/src/codex-spawn.ts
@@ -1,0 +1,121 @@
+import {
+  spawn,
+  spawnSync,
+  type ChildProcess,
+  type ChildProcessWithoutNullStreams,
+} from "node:child_process";
+import { existsSync } from "node:fs";
+import { delimiter, isAbsolute, normalize, resolve } from "node:path";
+
+export interface CodexSpawnInvocation {
+  command: string;
+  args: string[];
+  windowsVerbatimArguments?: boolean;
+}
+
+const windowsExecutablePattern = /\.(?:com|exe)$/i;
+const windowsCommandShimPattern = /node_modules[\\/]\.bin[\\/][^\\/]+\.cmd$/i;
+const windowsMetaCharacterPattern = /([()\][%!^"`<>&|;, *?])/g;
+
+export function codexProcessCommand(env: NodeJS.ProcessEnv = process.env): string {
+  return env.CODEX_BIN?.trim() || "codex";
+}
+
+export function codexSpawnInvocation(
+  args: readonly string[],
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+  cwd = process.cwd(),
+): CodexSpawnInvocation {
+  const configuredCommand = codexProcessCommand(env);
+  const command =
+    platform === "win32" ? resolveWindowsCommand(configuredCommand, env, cwd) : configuredCommand;
+  if (platform !== "win32" || windowsExecutablePattern.test(command)) {
+    return { command, args: [...args] };
+  }
+
+  const normalizedCommand = normalize(command);
+  const doubleEscapeMetaCharacters = windowsCommandShimPattern.test(normalizedCommand);
+  const shellCommand = [
+    escapeWindowsCommand(normalizedCommand),
+    ...args.map((arg) => escapeWindowsArgument(arg, doubleEscapeMetaCharacters)),
+  ].join(" ");
+  return {
+    command: env.ComSpec?.trim() || env.comspec?.trim() || "cmd.exe",
+    args: ["/d", "/s", "/c", `"${shellCommand}"`],
+    windowsVerbatimArguments: true,
+  };
+}
+
+export function terminateCodexProcessTree(
+  child: ChildProcess,
+  signal: NodeJS.Signals = "SIGTERM",
+  forceAfterMs = 1_000,
+): NodeJS.Timeout | undefined {
+  if (process.platform === "win32") {
+    if (child.pid) {
+      spawnSync("taskkill.exe", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: "ignore",
+        windowsHide: true,
+      });
+    }
+    return undefined;
+  }
+
+  child.kill(signal);
+  const timer = setTimeout(() => child.kill("SIGKILL"), forceAfterMs);
+  timer.unref();
+  return timer;
+}
+
+export function spawnCodex(
+  args: readonly string[],
+  options: {
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+  },
+): ChildProcessWithoutNullStreams {
+  const invocation = codexSpawnInvocation(args, options.env, process.platform, options.cwd);
+  return spawn(invocation.command, invocation.args, {
+    cwd: options.cwd,
+    env: options.env,
+    stdio: ["pipe", "pipe", "pipe"],
+    windowsHide: true,
+    ...(invocation.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
+  });
+}
+
+function resolveWindowsCommand(command: string, env: NodeJS.ProcessEnv, cwd: string): string {
+  if (isAbsolute(command) || /[\\/]/.test(command)) {
+    return command;
+  }
+  const extensions = (env.PATHEXT || ".COM;.EXE;.BAT;.CMD")
+    .split(";")
+    .filter(Boolean)
+    .map((extension) => extension.toLowerCase());
+  const candidates = extensions.includes("")
+    ? [command]
+    : [command, ...extensions.map((extension) => `${command}${extension}`)];
+  for (const directory of (env.PATH || "").split(delimiter).filter(Boolean)) {
+    for (const candidate of candidates) {
+      const filePath = resolve(cwd, directory, candidate);
+      if (existsSync(filePath)) return filePath;
+    }
+  }
+  return command;
+}
+
+function escapeWindowsCommand(value: string): string {
+  return value.replace(windowsMetaCharacterPattern, "^$1");
+}
+
+function escapeWindowsArgument(value: string, doubleEscapeMetaCharacters: boolean): string {
+  let escaped = value.replace(/(?=(\\+?)?)\1"/g, '$1$1\\"');
+  escaped = escaped.replace(/(?=(\\+?)?)\1$/, "$1$1");
+  escaped = `"${escaped}"`;
+  escaped = escaped.replace(windowsMetaCharacterPattern, "^$1");
+  if (doubleEscapeMetaCharacters) {
+    escaped = escaped.replace(windowsMetaCharacterPattern, "^$1");
+  }
+  return escaped;
+}

--- a/src/codex-spawn.ts
+++ b/src/codex-spawn.ts
@@ -5,7 +5,7 @@ import {
   type ChildProcessWithoutNullStreams,
 } from "node:child_process";
 import { existsSync } from "node:fs";
-import { delimiter, isAbsolute, normalize, resolve } from "node:path";
+import { delimiter, dirname, isAbsolute, join, normalize, resolve } from "node:path";
 
 export interface CodexSpawnInvocation {
   command: string;
@@ -41,7 +41,7 @@ export function codexSpawnInvocation(
     ...args.map((arg) => escapeWindowsArgument(arg, doubleEscapeMetaCharacters)),
   ].join(" ");
   return {
-    command: env.ComSpec?.trim() || env.comspec?.trim() || "cmd.exe",
+    command: windowsSystemExecutable("cmd.exe", env),
     args: ["/d", "/s", "/c", `"${shellCommand}"`],
     windowsVerbatimArguments: true,
   };
@@ -54,18 +54,34 @@ export function terminateCodexProcessTree(
 ): NodeJS.Timeout | undefined {
   if (process.platform === "win32") {
     if (child.pid) {
-      spawnSync("taskkill.exe", ["/pid", String(child.pid), "/t", "/f"], {
-        stdio: "ignore",
-        windowsHide: true,
-      });
+      spawnSync(
+        windowsSystemExecutable("taskkill.exe", process.env),
+        ["/pid", String(child.pid), "/t", "/f"],
+        {
+          stdio: "ignore",
+          windowsHide: true,
+        },
+      );
     }
     return undefined;
   }
 
-  child.kill(signal);
-  const timer = setTimeout(() => child.kill("SIGKILL"), forceAfterMs);
+  signalPosixProcessGroup(child, signal);
+  const timer = setTimeout(() => signalPosixProcessGroup(child, "SIGKILL"), forceAfterMs);
   timer.unref();
   return timer;
+}
+
+export function waitForCodexProcessExit(child: ChildProcess, timeoutMs = 2_000): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve();
+  return new Promise((resolveExit) => {
+    const timeout = setTimeout(resolveExit, timeoutMs);
+    timeout.unref();
+    child.once("close", () => {
+      clearTimeout(timeout);
+      resolveExit();
+    });
+  });
 }
 
 export function spawnCodex(
@@ -80,29 +96,55 @@ export function spawnCodex(
     cwd: options.cwd,
     env: options.env,
     stdio: ["pipe", "pipe", "pipe"],
+    detached: process.platform !== "win32",
     windowsHide: true,
     ...(invocation.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
   });
 }
 
+function signalPosixProcessGroup(child: ChildProcess, signal: NodeJS.Signals): void {
+  if (!child.pid) return;
+  try {
+    process.kill(-child.pid, signal);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+  }
+}
+
 function resolveWindowsCommand(command: string, env: NodeJS.ProcessEnv, cwd: string): string {
   if (isAbsolute(command) || /[\\/]/.test(command)) {
-    return command;
+    return resolve(cwd, command);
   }
-  const extensions = (env.PATHEXT || ".COM;.EXE;.BAT;.CMD")
+  const extensions = (windowsEnvironmentValue(env, "PATHEXT") || ".COM;.EXE;.BAT;.CMD")
     .split(";")
     .filter(Boolean)
     .map((extension) => extension.toLowerCase());
   const candidates = extensions.includes("")
     ? [command]
     : [command, ...extensions.map((extension) => `${command}${extension}`)];
-  for (const directory of (env.PATH || "").split(delimiter).filter(Boolean)) {
+  for (const directory of (windowsEnvironmentValue(env, "PATH") || "")
+    .split(delimiter)
+    .filter(Boolean)) {
     for (const candidate of candidates) {
       const filePath = resolve(cwd, directory, candidate);
       if (existsSync(filePath)) return filePath;
     }
   }
-  return command;
+  throw new Error(`Unable to resolve Windows Codex command: ${command}`);
+}
+
+function windowsSystemExecutable(name: string, env: NodeJS.ProcessEnv): string {
+  const systemRoot =
+    windowsEnvironmentValue(env, "SystemRoot") || windowsEnvironmentValue(env, "windir");
+  if (systemRoot) return join(systemRoot, "System32", name);
+  const comSpec = windowsEnvironmentValue(env, "ComSpec");
+  if (comSpec && isAbsolute(comSpec)) return join(dirname(comSpec), name);
+  throw new Error(`Unable to resolve Windows system executable: ${name}`);
+}
+
+function windowsEnvironmentValue(env: NodeJS.ProcessEnv, name: string): string | undefined {
+  const entry = Object.entries(env).find(([key]) => key.toLowerCase() === name.toLowerCase());
+  return entry?.[1]?.trim() || undefined;
 }
 
 function escapeWindowsCommand(value: string): string {

--- a/src/codex-spawn.ts
+++ b/src/codex-spawn.ts
@@ -14,7 +14,7 @@ export interface CodexSpawnInvocation {
 }
 
 const windowsExecutablePattern = /\.(?:com|exe)$/i;
-const windowsCommandShimPattern = /node_modules[\\/]\.bin[\\/][^\\/]+\.cmd$/i;
+const windowsBatchLauncherPattern = /\.(?:bat|cmd)$/i;
 const windowsMetaCharacterPattern = /([()\][%!^"`<>&|;, *?])/g;
 
 export function codexProcessCommand(env: NodeJS.ProcessEnv = process.env): string {
@@ -35,7 +35,7 @@ export function codexSpawnInvocation(
   }
 
   const normalizedCommand = normalize(command);
-  const doubleEscapeMetaCharacters = windowsCommandShimPattern.test(normalizedCommand);
+  const doubleEscapeMetaCharacters = windowsBatchLauncherPattern.test(normalizedCommand);
   const shellCommand = [
     escapeWindowsCommand(normalizedCommand),
     ...args.map((arg) => escapeWindowsArgument(arg, doubleEscapeMetaCharacters)),

--- a/src/repair/run-worker.ts
+++ b/src/repair/run-worker.ts
@@ -10,7 +10,12 @@ import {
   codexOutputTail,
   openCodexOutputCapture,
 } from "../codex-output-capture.js";
-import { codexAppServerProcessOptionsFromEnv, runCodexProcess } from "../codex-process.js";
+import {
+  codexAppServerProcessOptionsFromEnv,
+  codexProcessCommand,
+  codexProcessUsesShell,
+  runCodexProcess,
+} from "../codex-process.js";
 import { deterministicAutomergeResult } from "./deterministic-automerge-result.js";
 import {
   assertAllowedOwner,
@@ -272,9 +277,11 @@ function spawnCodexWithHeartbeat({
     const stdout = openCodexOutputCapture(codexTranscriptPath);
     const stderr = openCodexOutputCapture(stderrPath);
 
-    const child = spawn("codex", commandArgs, {
+    const childEnv = codexEnv();
+    const child = spawn(codexProcessCommand(childEnv), commandArgs, {
       cwd,
-      env: codexEnv(),
+      env: childEnv,
+      shell: codexProcessUsesShell(),
       stdio: ["pipe", "pipe", "pipe"],
     });
 

--- a/src/repair/run-worker.ts
+++ b/src/repair/run-worker.ts
@@ -10,12 +10,8 @@ import {
   codexOutputTail,
   openCodexOutputCapture,
 } from "../codex-output-capture.js";
-import {
-  codexAppServerProcessOptionsFromEnv,
-  codexProcessCommand,
-  codexProcessUsesShell,
-  runCodexProcess,
-} from "../codex-process.js";
+import { codexAppServerProcessOptionsFromEnv, runCodexProcess } from "../codex-process.js";
+import { spawnCodex, terminateCodexProcessTree } from "../codex-spawn.js";
 import { deterministicAutomergeResult } from "./deterministic-automerge-result.js";
 import {
   assertAllowedOwner,
@@ -278,12 +274,7 @@ function spawnCodexWithHeartbeat({
     const stderr = openCodexOutputCapture(stderrPath);
 
     const childEnv = codexEnv();
-    const child = spawn(codexProcessCommand(childEnv), commandArgs, {
-      cwd,
-      env: childEnv,
-      shell: codexProcessUsesShell(),
-      stdio: ["pipe", "pipe", "pipe"],
-    });
+    const child = spawnCodex(commandArgs, { cwd, env: childEnv });
 
     const heartbeat = setInterval(() => {
       const elapsedSeconds = Math.round((Date.now() - startedAt) / 1000);
@@ -294,10 +285,7 @@ function spawnCodexWithHeartbeat({
     const timeout = setTimeout(() => {
       timeoutError = new Error(`Codex worker timed out after ${timeoutMs}ms`);
       (timeoutError as LooseRecord).code = "ETIMEDOUT";
-      child.kill("SIGTERM");
-      setTimeout(() => {
-        if (!settled) child.kill("SIGKILL");
-      }, 5_000).unref();
+      terminateCodexProcessTree(child, "SIGTERM", 5_000);
     }, timeoutMs);
 
     const finish = (result: LooseRecord) => {

--- a/src/repair/run-worker.ts
+++ b/src/repair/run-worker.ts
@@ -3,7 +3,7 @@ import type { JsonValue, LooseRecord } from "./json-types.js";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { spawn, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import {
   appendCodexOutputCapture,
   closeCodexOutputCapture,

--- a/test/codex-process.test.ts
+++ b/test/codex-process.test.ts
@@ -76,7 +76,7 @@ test("Codex process resolves command overrides and escaped Windows launchers", (
 
 test("Codex process uses CODEX_BIN and preserves argv and stdin delivery", () => {
   const root = mkdtempSync(tmpPrefix);
-  const binDir = join(root, "custom codex bin", "node_modules", ".bin");
+  const binDir = join(root, "custom codex bin");
   const markerPath = join(root, "stdin.txt");
   const argvPath = join(root, "argv.json");
   const scriptPath = join(root, "fake-codex.js");
@@ -93,7 +93,7 @@ process.stdout.write("custom-codex-ok");
   const codexPath =
     process.platform === "win32" ? join(binDir, "custom-codex.cmd") : join(binDir, "custom-codex");
   if (process.platform === "win32") {
-    writeFileSync(codexPath, `@echo off\r\nnode "%~dp0\\..\\..\\..\\fake-codex.js" %*\r\n`);
+    writeFileSync(codexPath, `@echo off\r\nnode "%~dp0\\..\\fake-codex.js" %*\r\n`);
   } else {
     writeFileSync(codexPath, `#!/usr/bin/env node\n${readFileSync(scriptPath, "utf8")}`, {
       mode: 0o755,

--- a/test/codex-process.test.ts
+++ b/test/codex-process.test.ts
@@ -1,12 +1,80 @@
 import assert from "node:assert/strict";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import test from "node:test";
 
-import { codexProcessErrorCode, runCodexProcess } from "../dist/codex-process.js";
+import {
+  codexProcessCommand,
+  codexProcessErrorCode,
+  codexProcessUsesShell,
+  runCodexProcess,
+} from "../dist/codex-process.js";
 
 const tmpPrefix = join(tmpdir(), "clawsweeper-codex-process-test-");
+
+test("Codex process resolves command overrides and Windows shell policy", () => {
+  assert.equal(codexProcessCommand({}), "codex");
+  assert.equal(codexProcessCommand({ CODEX_BIN: "  custom-codex  " }), "custom-codex");
+  assert.equal(codexProcessUsesShell("darwin"), false);
+  assert.equal(codexProcessUsesShell("linux"), false);
+  assert.equal(codexProcessUsesShell("win32"), true);
+});
+
+test("Codex process uses CODEX_BIN and preserves stdin delivery", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const binDir = join(root, "custom codex bin");
+  const markerPath = join(root, "stdin.txt");
+  const scriptPath = join(binDir, "fake-codex.js");
+  mkdirSync(binDir, { recursive: true });
+  writeFileSync(
+    scriptPath,
+    `const fs = require("node:fs");
+const input = fs.readFileSync(0, "utf8");
+fs.writeFileSync(process.env.CODEX_TEST_STDIN_PATH, input);
+process.stdout.write("custom-codex-ok");
+`,
+  );
+  const codexPath =
+    process.platform === "win32" ? join(binDir, "custom-codex.cmd") : join(binDir, "custom-codex");
+  if (process.platform === "win32") {
+    writeFileSync(codexPath, `@echo off\r\nnode "%~dp0\\fake-codex.js" %*\r\n`);
+  } else {
+    writeFileSync(codexPath, `#!/usr/bin/env node\n${readFileSync(scriptPath, "utf8")}`, {
+      mode: 0o755,
+    });
+  }
+
+  try {
+    const result = runCodexProcess({
+      args: ["exec", "-"],
+      cwd: root,
+      env: {
+        ...process.env,
+        CODEX_BIN: codexPath,
+        CODEX_TEST_STDIN_PATH: markerPath,
+      },
+      input: "prompt over stdin",
+      timeoutMs: 10_000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.error, undefined);
+    assert.match(result.stdout, /custom-codex-ok/);
+    assert.equal(existsSync(markerPath), true);
+    assert.equal(readFileSync(markerPath, "utf8"), "prompt over stdin");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
 
 test("Codex process captures bounded rolling tails without terminating large output", () => {
   const root = mkdtempSync(tmpPrefix);

--- a/test/codex-process.test.ts
+++ b/test/codex-process.test.ts
@@ -15,38 +15,61 @@ import test from "node:test";
 import {
   codexProcessCommand,
   codexProcessErrorCode,
-  codexProcessUsesShell,
+  codexSpawnInvocation,
   runCodexProcess,
 } from "../dist/codex-process.js";
 
 const tmpPrefix = join(tmpdir(), "clawsweeper-codex-process-test-");
 
-test("Codex process resolves command overrides and Windows shell policy", () => {
+test("Codex process resolves command overrides and escaped Windows launchers", () => {
   assert.equal(codexProcessCommand({}), "codex");
   assert.equal(codexProcessCommand({ CODEX_BIN: "  custom-codex  " }), "custom-codex");
-  assert.equal(codexProcessUsesShell("darwin"), false);
-  assert.equal(codexProcessUsesShell("linux"), false);
-  assert.equal(codexProcessUsesShell("win32"), true);
+  assert.deepEqual(codexSpawnInvocation(["exec", "-"], { CODEX_BIN: "codex" }, "linux"), {
+    command: "codex",
+    args: ["exec", "-"],
+  });
+  assert.deepEqual(
+    codexSpawnInvocation(
+      ["space value", "a&b"],
+      {
+        CODEX_BIN: String.raw`C:\repo\node_modules\.bin\codex.cmd`,
+        ComSpec: String.raw`C:\Windows\System32\cmd.exe`,
+      },
+      "win32",
+    ),
+    {
+      command: String.raw`C:\Windows\System32\cmd.exe`,
+      args: [
+        "/d",
+        "/s",
+        "/c",
+        String.raw`"C:\repo\node_modules\.bin\codex.cmd ^^^"space^^^ value^^^" ^^^"a^^^&b^^^""`,
+      ],
+      windowsVerbatimArguments: true,
+    },
+  );
 });
 
-test("Codex process uses CODEX_BIN and preserves stdin delivery", () => {
+test("Codex process uses CODEX_BIN and preserves argv and stdin delivery", () => {
   const root = mkdtempSync(tmpPrefix);
-  const binDir = join(root, "custom codex bin");
+  const binDir = join(root, "custom codex bin", "node_modules", ".bin");
   const markerPath = join(root, "stdin.txt");
-  const scriptPath = join(binDir, "fake-codex.js");
+  const argvPath = join(root, "argv.json");
+  const scriptPath = join(root, "fake-codex.js");
   mkdirSync(binDir, { recursive: true });
   writeFileSync(
     scriptPath,
     `const fs = require("node:fs");
 const input = fs.readFileSync(0, "utf8");
 fs.writeFileSync(process.env.CODEX_TEST_STDIN_PATH, input);
+fs.writeFileSync(process.env.CODEX_TEST_ARGV_PATH, JSON.stringify(process.argv.slice(2)));
 process.stdout.write("custom-codex-ok");
 `,
   );
   const codexPath =
     process.platform === "win32" ? join(binDir, "custom-codex.cmd") : join(binDir, "custom-codex");
   if (process.platform === "win32") {
-    writeFileSync(codexPath, `@echo off\r\nnode "%~dp0\\fake-codex.js" %*\r\n`);
+    writeFileSync(codexPath, `@echo off\r\nnode "%~dp0\\..\\..\\..\\fake-codex.js" %*\r\n`);
   } else {
     writeFileSync(codexPath, `#!/usr/bin/env node\n${readFileSync(scriptPath, "utf8")}`, {
       mode: 0o755,
@@ -55,11 +78,12 @@ process.stdout.write("custom-codex-ok");
 
   try {
     const result = runCodexProcess({
-      args: ["exec", "-"],
+      args: ["exec", "--cd", join(root, "directory with spaces"), "a&b", "-"],
       cwd: root,
       env: {
         ...process.env,
         CODEX_BIN: codexPath,
+        CODEX_TEST_ARGV_PATH: argvPath,
         CODEX_TEST_STDIN_PATH: markerPath,
       },
       input: "prompt over stdin",
@@ -71,6 +95,13 @@ process.stdout.write("custom-codex-ok");
     assert.match(result.stdout, /custom-codex-ok/);
     assert.equal(existsSync(markerPath), true);
     assert.equal(readFileSync(markerPath, "utf8"), "prompt over stdin");
+    assert.deepEqual(JSON.parse(readFileSync(argvPath, "utf8")), [
+      "exec",
+      "--cd",
+      join(root, "directory with spaces"),
+      "a&b",
+      "-",
+    ]);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -167,13 +198,13 @@ process.stderr.write("e".repeat(2 * 1024 * 1024) + "stderr-tail-marker");
 
 test("Codex process preserves timeout errors and kills a child that ignores SIGTERM", () => {
   const root = mkdtempSync(tmpPrefix);
-  const binDir = join(root, "bin");
+  const binDir = join(root, "node_modules", ".bin");
   const pidPath = join(root, "codex.pid");
   mkdirSync(binDir, { recursive: true });
-  const codexPath = join(binDir, "codex");
+  const scriptPath = join(root, "timeout-codex.cjs");
   writeFileSync(
-    codexPath,
-    `#!/usr/bin/env node
+    scriptPath,
+    `
 const fs = require("node:fs");
 fs.writeFileSync(process.env.CODEX_TEST_PID_PATH, String(process.pid));
 process.stderr.write("timeout-tail-marker\\n");
@@ -181,7 +212,15 @@ process.on("SIGTERM", () => {});
 setInterval(() => {}, 1000);
 `,
   );
-  chmodSync(codexPath, 0o755);
+  const codexPath =
+    process.platform === "win32" ? join(binDir, "codex.cmd") : join(binDir, "codex");
+  if (process.platform === "win32") {
+    writeFileSync(codexPath, `@echo off\r\nnode "%~dp0\\..\\..\\timeout-codex.cjs" %*\r\n`);
+  } else {
+    writeFileSync(codexPath, `#!/usr/bin/env node\n${readFileSync(scriptPath, "utf8")}`, {
+      mode: 0o755,
+    });
+  }
 
   try {
     const result = runCodexProcess({
@@ -189,14 +228,14 @@ setInterval(() => {}, 1000);
       cwd: root,
       env: {
         ...process.env,
+        CODEX_BIN: codexPath,
         CODEX_TEST_PID_PATH: pidPath,
-        PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}`,
       },
       input: "",
       timeoutMs: 1000,
     });
 
-    assert.equal(codexProcessErrorCode(result.error), "ETIMEDOUT");
+    assert.equal(codexProcessErrorCode(result.error), "ETIMEDOUT", JSON.stringify(result));
     assert.match(result.stderr, /timeout-tail-marker/);
     const pid = Number(readFileSync(pidPath, "utf8"));
     assert.throws(
@@ -210,15 +249,15 @@ setInterval(() => {}, 1000);
 
 test("Codex app-server mode persists and resumes a thread", () => {
   const root = mkdtempSync(tmpPrefix);
-  const binDir = join(root, "bin");
+  const binDir = join(root, "node_modules", ".bin");
   const statePath = join(root, "session", "state.json");
   const outputPath = join(root, "last-message.json");
   const requestsPath = join(root, "requests.jsonl");
   mkdirSync(binDir, { recursive: true });
-  const codexPath = join(binDir, "codex");
+  const scriptPath = join(root, "app-server-codex.cjs");
   writeFileSync(
-    codexPath,
-    `#!/usr/bin/env node
+    scriptPath,
+    `
 const fs = require("node:fs");
 const readline = require("node:readline");
 const requestsPath = process.env.CODEX_TEST_REQUESTS_PATH;
@@ -251,11 +290,19 @@ rl.on("line", (line) => {
 });
 `,
   );
-  chmodSync(codexPath, 0o755);
+  const codexPath =
+    process.platform === "win32" ? join(binDir, "codex.cmd") : join(binDir, "codex");
+  if (process.platform === "win32") {
+    writeFileSync(codexPath, `@echo off\r\nnode "%~dp0\\..\\..\\app-server-codex.cjs" %*\r\n`);
+  } else {
+    writeFileSync(codexPath, `#!/usr/bin/env node\n${readFileSync(scriptPath, "utf8")}`, {
+      mode: 0o755,
+    });
+  }
   const env = {
     ...process.env,
+    CODEX_BIN: codexPath,
     CODEX_TEST_REQUESTS_PATH: requestsPath,
-    PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}`,
   };
 
   try {

--- a/test/codex-process.test.ts
+++ b/test/codex-process.test.ts
@@ -28,25 +28,49 @@ test("Codex process resolves command overrides and escaped Windows launchers", (
     command: "codex",
     args: ["exec", "-"],
   });
-  assert.deepEqual(
-    codexSpawnInvocation(
-      ["space value", "a&b"],
+  const escaped = codexSpawnInvocation(
+    ["space value", "a&b"],
+    {
+      CODEX_BIN: String.raw`C:\repo\node_modules\.bin\codex.cmd`,
+      systemroot: String.raw`C:\Windows`,
+    },
+    "win32",
+  );
+  assert.match(escaped.command, /C:\\Windows[\\/]System32[\\/]cmd\.exe/);
+  assert.deepEqual(escaped.args.slice(0, 3), ["/d", "/s", "/c"]);
+  assert.match(escaped.args[3] ?? "", /codex\.cmd/);
+  assert.match(escaped.args[3] ?? "", /\^\^\^"space\^\^\^ value\^\^\^"/);
+  assert.match(escaped.args[3] ?? "", /\^\^\^"a\^\^\^&b\^\^\^"/);
+  assert.equal(escaped.windowsVerbatimArguments, true);
+  const root = mkdtempSync(tmpPrefix);
+  const binDir = join(root, "bin");
+  mkdirSync(binDir);
+  writeFileSync(join(binDir, "codex.cmd"), "@echo off\r\n");
+  try {
+    const invocation = codexSpawnInvocation(
+      ["exec"],
       {
-        CODEX_BIN: String.raw`C:\repo\node_modules\.bin\codex.cmd`,
-        ComSpec: String.raw`C:\Windows\System32\cmd.exe`,
+        CODEX_BIN: "codex",
+        Path: binDir,
+        PATHEXT: ".CMD",
+        SystemRoot: String.raw`C:\Windows`,
       },
       "win32",
-    ),
-    {
-      command: String.raw`C:\Windows\System32\cmd.exe`,
-      args: [
-        "/d",
-        "/s",
-        "/c",
-        String.raw`"C:\repo\node_modules\.bin\codex.cmd ^^^"space^^^ value^^^" ^^^"a^^^&b^^^""`,
-      ],
-      windowsVerbatimArguments: true,
-    },
+      root,
+    );
+    assert.match(invocation.command, /C:\\Windows[\\/]System32[\\/]cmd\.exe/);
+    assert.match(invocation.args[3] ?? "", /codex\.cmd/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+  assert.throws(
+    () =>
+      codexSpawnInvocation(
+        ["exec"],
+        { CODEX_BIN: "codex", Path: "", SystemRoot: String.raw`C:\Windows` },
+        "win32",
+      ),
+    /Unable to resolve Windows Codex command/,
   );
 });
 
@@ -206,7 +230,14 @@ test("Codex process preserves timeout errors and kills a child that ignores SIGT
     scriptPath,
     `
 const fs = require("node:fs");
-fs.writeFileSync(process.env.CODEX_TEST_PID_PATH, String(process.pid));
+const { spawn } = require("node:child_process");
+const grandchild = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+  stdio: "ignore",
+});
+fs.writeFileSync(
+  process.env.CODEX_TEST_PID_PATH,
+  JSON.stringify({ child: process.pid, grandchild: grandchild.pid }),
+);
 process.stderr.write("timeout-tail-marker\\n");
 process.on("SIGTERM", () => {});
 setInterval(() => {}, 1000);
@@ -237,11 +268,16 @@ setInterval(() => {}, 1000);
 
     assert.equal(codexProcessErrorCode(result.error), "ETIMEDOUT", JSON.stringify(result));
     assert.match(result.stderr, /timeout-tail-marker/);
-    const pid = Number(readFileSync(pidPath, "utf8"));
-    assert.throws(
-      () => process.kill(pid, 0),
-      (error: unknown) => (error as NodeJS.ErrnoException).code === "ESRCH",
-    );
+    const pids = JSON.parse(readFileSync(pidPath, "utf8")) as {
+      child: number;
+      grandchild: number;
+    };
+    for (const pid of [pids.child, pids.grandchild]) {
+      assert.throws(
+        () => process.kill(pid, 0),
+        (error: unknown) => (error as NodeJS.ErrnoException).code === "ESRCH",
+      );
+    }
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/tsconfig.repair.json
+++ b/tsconfig.repair.json
@@ -19,6 +19,7 @@
     "src/repair/**/*.ts",
     "src/repository-profiles.ts",
     "src/codex-output-capture.ts",
+    "src/codex-spawn.ts",
     "src/codex-app-server-worker.ts",
     "src/codex-process-worker.ts"
   ]


### PR DESCRIPTION
## Summary

- route review, assist, app-server, and repair Codex launches through one cross-platform process helper
- resolve and safely invoke Windows `.cmd`/`.bat` launchers, including global npm shims and paths with spaces
- terminate complete Codex process trees on timeout and wait for shutdown before returning
- add native Windows CI coverage for launcher, stdin, timeout, and app-server behavior

## Validation

- `pnpm run check`
- AWS Crabbox Windows `m7i.large`, lease `cbx_247406f20340`, run `run_9197b924d445`: build, repair build, and four focused process tests passed
- Codex autoreview on the rewritten exact head: no accepted/actionable findings

Rewritten on current `main` while preserving contributor credit.
