### PR TITLE
feat: support CLAWSWEEPER_CODEX_LOGIN_METHOD for local OAuth runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Added
 
+- Added a fail-closed `CLAWSWEEPER_CODEX_LOGIN_METHOD=chatgpt` override for local Codex OAuth runs while retaining API authentication by default. Thanks @anagnorisis2peripeteia.
 - Added repair-only PR intake that scans an author's open pull requests for actionable failures and creates durable PR-repair jobs. Thanks @Jhacarreiro.
 - Added automatic issue-build lifecycle comments and dashboard cards with issue titles, queued/planning/building/completed/blocked history, live worker links, Actions runs, and generated PR drill-down.
 - Show issue and pull request titles alongside target numbers on active dashboard worker cards and worker detail links.

--- a/docs/repair/internal-features.md
+++ b/docs/repair/internal-features.md
@@ -617,6 +617,9 @@ Important defaults:
   to keep automerge repair latency predictable.
 - `CLAWSWEEPER_CODEX_SERVICE_TIER`: Codex service tier. Repair workers default
   to `fast`.
+- `CLAWSWEEPER_CODEX_LOGIN_METHOD`: Codex login mode for local runs. Defaults
+  to `api`; set `chatgpt` to preserve an existing Codex OAuth session. Any other
+  non-empty value fails before Codex starts.
 - `CLAWSWEEPER_CODEX_HEARTBEAT_MS`: repair-worker and execute-side Codex
   subprocess heartbeat interval; default `60000`.
 - `CODEX_BIN`: optional Codex executable override. Native Windows runs resolve

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -26,6 +26,7 @@ import {
 } from "./repository-profiles.js";
 import {
   codexEnv,
+  codexLoginConfig,
   codexModelArgs,
   PUBLIC_CODEX_MODEL,
   redactInternalCodexModel,
@@ -79,7 +80,12 @@ import {
 } from "./clawsweeper-args.js";
 import { escapeRegExp, safeOutputTail, trimMiddle, truncateText } from "./clawsweeper-text.js";
 
-export { codexEnv, redactInternalCodexModel } from "./codex-env.js";
+export {
+  codexEnv,
+  codexLoginConfig,
+  codexLoginMethod,
+  redactInternalCodexModel,
+} from "./codex-env.js";
 export { parseGhJson, parseGhJsonLines } from "./github-json.js";
 export { itemNumbersArg } from "./clawsweeper-args.js";
 export { safeOutputTail } from "./clawsweeper-text.js";
@@ -6772,7 +6778,7 @@ function runCodex(options: {
   const runReviewPass = (reasoningEffort: string, passAttempts: number): Decision => {
     const codexConfig = [
       `model_reasoning_effort="${reasoningEffort}"`,
-      'forced_login_method="api"',
+      codexLoginConfig(),
       'approval_policy="never"',
     ];
     if (options.serviceTier) codexConfig.splice(1, 0, `service_tier="${options.serviceTier}"`);
@@ -7082,7 +7088,7 @@ function runCodexAssist(options: {
   writeFileSync(promptPath, prompt, "utf8");
   const codexConfig = [
     `model_reasoning_effort="${options.reasoningEffort}"`,
-    'forced_login_method="api"',
+    codexLoginConfig(),
     'approval_policy="never"',
   ];
   const result = runCodexProcess({

--- a/src/codex-app-server-worker.ts
+++ b/src/codex-app-server-worker.ts
@@ -33,6 +33,7 @@ interface ExecOptions {
   cwd: string;
   sandbox: "read-only" | "workspace-write" | "danger-full-access";
   networkAccess: boolean;
+  loginMethod?: "api" | "chatgpt";
   model?: string;
   effort?: string;
   serviceTier?: string;
@@ -70,10 +71,20 @@ const stderr = openCodexOutputCapture(options.stderrPath, {
   tailBytes: options.tailBytes,
 });
 process.env.CODEX_BIN = options.command;
-const child = spawnCodex(["app-server", "--listen", "stdio://"], {
-  cwd: execOptions.cwd,
-  env: process.env,
-});
+const child = spawnCodex(
+  [
+    ...(execOptions.loginMethod
+      ? ["-c", `forced_login_method=${JSON.stringify(execOptions.loginMethod)}`]
+      : []),
+    "app-server",
+    "--listen",
+    "stdio://",
+  ],
+  {
+    cwd: execOptions.cwd,
+    env: process.env,
+  },
+);
 const pending = new Map<
   number,
   {
@@ -405,6 +416,7 @@ function parseExecOptions(args: string[], fallbackCwd: string): ExecOptions {
   let cwd = fallbackCwd;
   let sandbox: ExecOptions["sandbox"] = "read-only";
   let networkAccess = false;
+  let loginMethod: ExecOptions["loginMethod"];
   let model: string | undefined;
   let effort: string | undefined;
   let serviceTier: string | undefined;
@@ -422,6 +434,12 @@ function parseExecOptions(args: string[], fallbackCwd: string): ExecOptions {
       const parsed = parseConfig(value);
       if (parsed.key === "model_reasoning_effort") effort = parsed.value;
       if (parsed.key === "service_tier") serviceTier = parsed.value;
+      if (
+        parsed.key === "forced_login_method" &&
+        (parsed.value === "api" || parsed.value === "chatgpt")
+      ) {
+        loginMethod = parsed.value;
+      }
       if (parsed.key === "sandbox_workspace_write.network_access") {
         networkAccess = parsed.value === "true";
       }
@@ -431,6 +449,7 @@ function parseExecOptions(args: string[], fallbackCwd: string): ExecOptions {
     cwd,
     sandbox,
     networkAccess,
+    ...(loginMethod ? { loginMethod } : {}),
     ...(model ? { model } : {}),
     ...(effort ? { effort } : {}),
     ...(serviceTier ? { serviceTier } : {}),

--- a/src/codex-env.ts
+++ b/src/codex-env.ts
@@ -6,7 +6,22 @@ export type CodexEnvOptions = {
   ghToken?: string | undefined;
 };
 
+export type CodexLoginMethod = "api" | "chatgpt";
+
 export const PUBLIC_CODEX_MODEL = "internal";
+
+export function codexLoginMethod(
+  value = process.env.CLAWSWEEPER_CODEX_LOGIN_METHOD,
+): CodexLoginMethod {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) return "api";
+  if (normalized === "api" || normalized === "chatgpt") return normalized;
+  throw new Error(`Invalid CLAWSWEEPER_CODEX_LOGIN_METHOD: ${value}. Expected "api" or "chatgpt".`);
+}
+
+export function codexLoginConfig(value?: string): string {
+  return `forced_login_method="${codexLoginMethod(value)}"`;
+}
 
 export function internalCodexModel(requestedModel: string): string {
   return process.env.CLAWSWEEPER_INTERNAL_MODEL?.trim() || requestedModel;

--- a/src/commit-sweeper.ts
+++ b/src/commit-sweeper.ts
@@ -11,7 +11,7 @@ import {
 import { publishCheckFromReport, splitFrontMatter } from "./commit-checks.js";
 import { argBool, argNumber, argString, parseArgs, type Args } from "./clawsweeper-args.js";
 import { safeOutputTail } from "./clawsweeper-text.js";
-import { codexEnv, codexModelArgs, PUBLIC_CODEX_MODEL } from "./codex-env.js";
+import { codexEnv, codexLoginConfig, codexModelArgs, PUBLIC_CODEX_MODEL } from "./codex-env.js";
 import { codexProcessErrorCode, runCodexProcess } from "./codex-process.js";
 import { runText } from "./command.js";
 import { ghRetryKind, ghRetryWaitMs } from "./github-retry.js";
@@ -297,7 +297,7 @@ function runCodex(options: {
   );
   const codexConfig = [
     `model_reasoning_effort="${options.reasoningEffort}"`,
-    'forced_login_method="api"',
+    codexLoginConfig(),
     'approval_policy="never"',
   ];
   if (options.serviceTier) codexConfig.splice(1, 0, `service_tier="${options.serviceTier}"`);

--- a/src/pr-close-coverage-proof.ts
+++ b/src/pr-close-coverage-proof.ts
@@ -1,4 +1,4 @@
-import { codexModelArgs } from "./codex-env.js";
+import { codexLoginConfig, codexModelArgs } from "./codex-env.js";
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { codexEnv } from "./codex-env.js";
@@ -253,7 +253,7 @@ export function runPrCloseCoverageProofModel(options: {
   if (existsSync(outputPath)) unlinkSync(outputPath);
   const codexConfig = [
     `model_reasoning_effort="${options.runtime.reasoningEffort}"`,
-    'forced_login_method="api"',
+    codexLoginConfig(),
     'approval_policy="never"',
   ];
   if (options.runtime.serviceTier) {

--- a/src/repair/execute-fix-artifact.ts
+++ b/src/repair/execute-fix-artifact.ts
@@ -52,6 +52,7 @@ import { parsePullRequestUrl, pullRequestNumberFromUrl } from "./github-ref.js";
 import {
   clawsweeperGitUserEmail,
   clawsweeperGitUserName,
+  codexLoginConfig,
   codexSubprocessEnv as codexEnv,
   codexModelArgs,
   repairCodexReasoningEffort,
@@ -2580,6 +2581,7 @@ function codexReviewSandboxConfigArgs() {
 function codexConfigArgs() {
   const configs = [
     'approval_policy="never"',
+    codexLoginConfig(),
     `model_reasoning_effort=${JSON.stringify(codexReasoningEffort)}`,
   ];
   if (codexServiceTier) configs.push(`service_tier=${JSON.stringify(codexServiceTier)}`);

--- a/src/repair/process-env.ts
+++ b/src/repair/process-env.ts
@@ -1,6 +1,6 @@
-import { codexModelArgs, internalCodexModel } from "../codex-env.js";
+import { codexLoginConfig, codexModelArgs, internalCodexModel } from "../codex-env.js";
 
-export { codexModelArgs, internalCodexModel };
+export { codexLoginConfig, codexModelArgs, internalCodexModel };
 
 export function ghCliEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   return withoutColor({ ...process.env, ...overrides });

--- a/src/repair/run-worker.ts
+++ b/src/repair/run-worker.ts
@@ -23,6 +23,7 @@ import {
   validateJob,
 } from "./lib.js";
 import {
+  codexLoginConfig,
   codexSubprocessEnv,
   codexModelArgs,
   repairCodexReasoningEffort,
@@ -335,6 +336,7 @@ function codexWorkspaceRoot(): string {
 function codexConfigArgs() {
   const configs = [
     'approval_policy="never"',
+    codexLoginConfig(),
     `model_reasoning_effort=${JSON.stringify(codexReasoningEffort)}`,
   ];
   if (codexServiceTier) configs.push(`service_tier=${JSON.stringify(codexServiceTier)}`);

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -35,6 +35,8 @@ import {
   configSurfaceChangeFromPullFilesForTest,
   dataModelChangeFromPullFilesForTest,
   codexEnv,
+  codexLoginConfig,
+  codexLoginMethod,
   dashboardClosedAt,
   extractLatestClawSweeperReviewForTest,
   failedReviewRetryEligibilityForTest,
@@ -19158,6 +19160,33 @@ test("review parser strips environment access caveats from risks", () => {
     }),
   );
   assert.deepEqual(parsed.risks, ["A real product uncertainty remains."]);
+});
+
+test("Codex login method defaults to API and accepts explicit local OAuth", () => {
+  assert.equal(codexLoginMethod(""), "api");
+  assert.equal(codexLoginMethod(" API "), "api");
+  assert.equal(codexLoginMethod(" chatgpt "), "chatgpt");
+  assert.equal(codexLoginConfig("chatgpt"), 'forced_login_method="chatgpt"');
+});
+
+test("Codex login method reads the environment without leaking test state", () => {
+  const original = process.env.CLAWSWEEPER_CODEX_LOGIN_METHOD;
+  try {
+    delete process.env.CLAWSWEEPER_CODEX_LOGIN_METHOD;
+    assert.equal(codexLoginMethod(), "api");
+    process.env.CLAWSWEEPER_CODEX_LOGIN_METHOD = "chatgpt";
+    assert.equal(codexLoginMethod(), "chatgpt");
+  } finally {
+    if (original === undefined) delete process.env.CLAWSWEEPER_CODEX_LOGIN_METHOD;
+    else process.env.CLAWSWEEPER_CODEX_LOGIN_METHOD = original;
+  }
+});
+
+test("Codex login method rejects invalid non-empty overrides", () => {
+  assert.throws(
+    () => codexLoginMethod("oauth"),
+    /Invalid CLAWSWEEPER_CODEX_LOGIN_METHOD: oauth\. Expected "api" or "chatgpt"\./,
+  );
 });
 
 test("codex subprocess env strips GitHub and App credentials", () => {

--- a/test/codex-process.test.ts
+++ b/test/codex-process.test.ts
@@ -289,6 +289,7 @@ test("Codex app-server mode persists and resumes a thread", () => {
   const statePath = join(root, "session", "state.json");
   const outputPath = join(root, "last-message.json");
   const requestsPath = join(root, "requests.jsonl");
+  const argsPath = join(root, "args.json");
   mkdirSync(binDir, { recursive: true });
   const scriptPath = join(root, "app-server-codex.cjs");
   writeFileSync(
@@ -297,6 +298,7 @@ test("Codex app-server mode persists and resumes a thread", () => {
 const fs = require("node:fs");
 const readline = require("node:readline");
 const requestsPath = process.env.CODEX_TEST_REQUESTS_PATH;
+fs.writeFileSync(process.env.CODEX_TEST_ARGS_PATH, JSON.stringify(process.argv.slice(2)));
 const rl = readline.createInterface({ input: process.stdin });
 function send(value) { process.stdout.write(JSON.stringify(value) + "\\n"); }
 rl.on("line", (line) => {
@@ -338,6 +340,7 @@ rl.on("line", (line) => {
   const env = {
     ...process.env,
     CODEX_BIN: codexPath,
+    CODEX_TEST_ARGS_PATH: argsPath,
     CODEX_TEST_REQUESTS_PATH: requestsPath,
   };
 
@@ -352,6 +355,8 @@ rl.on("line", (line) => {
           "workspace-write",
           "-c",
           "sandbox_workspace_write.network_access=false",
+          "-c",
+          'forced_login_method="chatgpt"',
           "--output-last-message",
           outputPath,
           "--json",
@@ -370,6 +375,13 @@ rl.on("line", (line) => {
 
     const state = JSON.parse(readFileSync(statePath, "utf8"));
     assert.equal(state.threadId, "thread-1");
+    assert.deepEqual(JSON.parse(readFileSync(argsPath, "utf8")), [
+      "-c",
+      'forced_login_method="chatgpt"',
+      "app-server",
+      "--listen",
+      "stdio://",
+    ]);
     const requests = readFileSync(requestsPath, "utf8")
       .trim()
       .split("\n")


### PR DESCRIPTION
## Summary

- add `CLAWSWEEPER_CODEX_LOGIN_METHOD=api|chatgpt` for local Codex authentication selection
- keep `api` as the default for CI and production
- validate overrides fail-closed instead of passing arbitrary Codex config
- apply the login method consistently to review, assist, commit review, close-coverage proof, repair workers, and persistent app-server execution
- preserve the Windows-safe Codex launcher introduced on current main
- document the local OAuth path and add an Unreleased changelog entry

## Rewrite notes

The original patch changed only two direct review call sites. This rewrite covers every synchronous and repair Codex surface, including app-server mode, while retaining current main's Windows process launcher and timeout fixes.

Contributor credit is preserved in commit `4a6a58d109`:

`Co-authored-by: Cameron Beeley <cameron.beeley@gmail.com>`

## Validation

- `pnpm run check` on rebased head: passed
  - 500 unit tests
  - 549 repair tests
  - 1,049 combined coverage tests
  - coverage thresholds and format check passed
- focused Codex login and app-server tests: 4 passed
- final Codex autoreview on the rebased branch: no accepted/actionable findings
- contributor's Windows 11 OAuth proof remains applicable: a full local review completed with `CLAWSWEEPER_CODEX_LOGIN_METHOD=chatgpt`

## Behavior

Default behavior is unchanged. Local OAuth users may set:

```text
CLAWSWEEPER_CODEX_LOGIN_METHOD=chatgpt
```

Invalid non-empty values stop before Codex is launched. This PR does not enable automerge or alter generated-PR merge policy.
