### PR TITLE
[codex] Fix proof nudge schedule gate

### DIFF
--- a/.github/workflows/proof-nudges.yml
+++ b/.github/workflows/proof-nudges.yml
@@ -60,15 +60,17 @@ jobs:
           PROOF_NUDGES_SCHEDULE_TZ: America/Chicago
           PROOF_NUDGES_EVENT_SCHEDULE: ${{ github.event.schedule }}
         run: |
+          local_hour="$(TZ="$PROOF_NUDGES_SCHEDULE_TZ" date +%H)"
           local_time="$(TZ="$PROOF_NUDGES_SCHEDULE_TZ" date '+%Y-%m-%d %H:%M:%S %Z')"
           local_zone="$(TZ="$PROOF_NUDGES_SCHEDULE_TZ" date +%Z)"
-          if { [ "$PROOF_NUDGES_EVENT_SCHEDULE" = "0 10 * * *" ] && [ "$local_zone" = "CDT" ]; } ||
-             { [ "$PROOF_NUDGES_EVENT_SCHEDULE" = "0 11 * * *" ] && [ "$local_zone" = "CST" ]; }; then
+          if [ "$local_hour" = "05" ] &&
+             { { [ "$PROOF_NUDGES_EVENT_SCHEDULE" = "0 10 * * *" ] && [ "$local_zone" = "CDT" ]; } ||
+               { [ "$PROOF_NUDGES_EVENT_SCHEDULE" = "0 11 * * *" ] && [ "$local_zone" = "CST" ]; }; }; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "Scheduled proof nudges running for $PROOF_NUDGES_EVENT_SCHEDULE at $local_time."
           else
             echo "should_run=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Skipping scheduled proof nudges for $PROOF_NUDGES_EVENT_SCHEDULE at $local_time; waiting for the 5:00 AM America/Chicago cron candidate."
+            echo "::notice::Skipping scheduled proof nudges for $PROOF_NUDGES_EVENT_SCHEDULE at $local_time; waiting for the matching 5:00 AM America/Chicago cron candidate."
           fi
 
       - uses: actions/checkout@v6

--- a/docs/proof-nudges.md
+++ b/docs/proof-nudges.md
@@ -60,7 +60,7 @@ Useful options:
 
 The `ClawSweeper Proof Nudges` workflow exposes this as a manual `workflow_dispatch` lane. It defaults to dry-run. Use `execute=true` only after reviewing a dry-run report.
 
-The workflow also includes daily scheduled lanes at `0 10 * * *` and `0 11 * * *`, but it is off by default. Those UTC schedules are guarded by the scheduled cron string and the current `America/Chicago` timezone abbreviation, so only the 5:00 AM Central candidate continues across daylight saving time changes even if GitHub starts the run late.
+The workflow also includes daily scheduled lanes at `0 10 * * *` and `0 11 * * *`, but it is off by default. Those UTC schedules are guarded by the scheduled cron string, the current `America/Chicago` timezone abbreviation, and the current local hour, so only the matching 5:00 AM Central candidate continues across daylight saving time changes even if GitHub starts a run late. GitHub still creates a workflow run for each cron entry; the non-matching candidate should finish quickly before checkout and may appear in the Actions list as a short successful skipped run.
 
 Scheduled operation uses repository variables:
 

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -16089,7 +16089,9 @@ test("proof nudge workflow is manual-first and scheduled behind repo vars", () =
   assert.match(concurrency, /clawsweeper-proof-nudges/);
   assert.match(job, /PROOF_NUDGES_SCHEDULE_TZ: America\/Chicago/);
   assert.match(job, /PROOF_NUDGES_EVENT_SCHEDULE: \$\{\{ github\.event\.schedule \}\}/);
+  assert.match(job, /local_hour=.*date \+%H/);
   assert.match(job, /local_zone=.*date \+%Z/);
+  assert.match(job, /\[ "\$local_hour" = "05" \]/);
   assert.match(job, /PROOF_NUDGES_EVENT_SCHEDULE" = "0 10 \* \* \*"/);
   assert.match(job, /PROOF_NUDGES_EVENT_SCHEDULE" = "0 11 \* \* \*"/);
   assert.match(job, /steps\.central-time\.outputs\.should_run == 'true'/);


### PR DESCRIPTION
## Summary

Fixes the proof-nudge scheduled gate so the DST cron candidate must also be running during the actual 5:00 AM America/Chicago hour before it can continue past the guard.

## Root cause

`main` has two UTC cron entries for the same intended local schedule: `0 10 * * *` for CDT and `0 11 * * *` for CST. That part is intentional because GitHub Actions schedules are UTC-only. The latest delayed-schedule fix removed the local-hour check and only matched the cron string to the current timezone abbreviation, so a delayed `0 10 * * *` run during CDT could still execute after 5 AM Central instead of skipping. The alternate cron also still appears in Actions as a short successful run because GitHub creates a run for every schedule entry even when our guard exits before checkout.

## Changes

- Restore the `local_hour == 05` guard while preserving the cron-string and CDT/CST checks.
- Update the proof-nudge workflow test to pin the local-hour guard.
- Document why there are two cron candidates and why the skipped one may still be visible in the Actions list.

## Validation

- `pnpm exec oxfmt --check .github/workflows/proof-nudges.yml docs/proof-nudges.md test/clawsweeper.test.ts`
- `pnpm run build && node --test test/clawsweeper.test.ts --test-name-pattern "proof nudge workflow is manual-first"` (Node still ran the full `test/clawsweeper.test.ts`; 359 tests passed)
- Crabbox direct AWS attempt `cbx_f4cec2927105` reached sync but was a raw unhydrated box without `pnpm`, so it did not validate repo tests. Follow-up Actions hydration was blocked by runner-registration permissions; unused lease `cbx_7fdde2040b76` was released.


## Schedule guard proof

I ran the exact shell boolean now present in `.github/workflows/proof-nudges.yml` against representative schedule inputs. This covers the intended CDT/CST pass cases plus delayed or wrong-zone skip cases:

```text
0 10 * * *   local_hour=05 local_zone=CDT => should_run=true
0 10 * * *   local_hour=06 local_zone=CDT => should_run=false
0 11 * * *   local_hour=05 local_zone=CST => should_run=true
0 11 * * *   local_hour=06 local_zone=CDT => should_run=false
0 11 * * *   local_hour=05 local_zone=CDT => should_run=false
```

The important regression case is the delayed CDT `0 10 * * *` candidate at local hour `06`, which now skips instead of continuing past the guard.
