### PR TITLE
config: add Horizon target profile

### DIFF
--- a/config/target-repositories.json
+++ b/config/target-repositories.json
@@ -43,6 +43,23 @@
       "package_manager": "pnpm",
       "validation_commands": [],
       "changed_gate": null
+    },
+    {
+      "target_repo": "valkyriweb/horizon",
+      "display_name": "Horizon",
+      "checkout_dir": "horizon",
+      "prompt_note": "Use the Horizon monorepo source tree and current main branch. It is a private product monorepo owned by Luke (@valkyriweb): packages/alerts plus apps/billing, apps/whatsapp, apps/mail-dashboard, and apps/mail-landing. For every PR review, include code-craft and agent-native-hardening passes: flag unnecessary complexity, poor naming/API shape, brittle agent-unfriendly structure, unsafe boundaries, and missing verification. Keep reviews conservative; do not auto-close issues or pull requests unless a future Horizon-specific policy explicitly enables that.",
+      "apply_close_rules": {
+        "issue": [],
+        "pull_request": []
+      },
+      "package_manager": "bun",
+      "validation_commands": [
+        "bun run --filter '*' build",
+        "bun run --filter '*' typecheck",
+        "bun run --filter '*' test"
+      ],
+      "changed_gate": null
     }
   ],
   "generic_fallbacks": [

--- a/test/repository-profiles.test.ts
+++ b/test/repository-profiles.test.ts
@@ -28,6 +28,18 @@ test("repositoryProfileFor supports fs-safe event reviews", () => {
   ]);
 });
 
+test("repositoryProfileFor supports Horizon PR review gates", () => {
+  const profile = repositoryProfileFor("Valkyriweb/Horizon");
+
+  assert.equal(profile.targetRepo, "valkyriweb/horizon");
+  assert.equal(profile.slug, "valkyriweb-horizon");
+  assert.equal(profile.checkoutDir, "horizon");
+  assert.match(profile.promptNote, /code-craft/);
+  assert.match(profile.promptNote, /agent-native-hardening/);
+  assert.deepEqual(profile.applyCloseRules.issue, []);
+  assert.deepEqual(profile.applyCloseRules.pull_request, []);
+});
+
 test("generic OpenClaw fallback supports conservative event-only onboarding", () => {
   const profile = repositoryProfileFor("OpenClaw/example-tool");
 


### PR DESCRIPTION
Adds valkyriweb/horizon as a ClawSweeper target profile so Horizon dispatches can resolve engine-side review configuration. The profile keeps auto-close disabled and asks PR reviews to include code-craft and agent-native-hardening passes.\n\nVerification:\n- pnpm run build\n- node --test test/repository-profiles.test.ts