### PR TITLE
fix: filter inherited replacement PR labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "repair:execute-fix": "node dist/repair/execute-fix-artifact.js",
     "repair:post-flight": "node dist/repair/post-flight.js",
     "repair:finalize-open-prs": "node dist/repair/finalize-open-prs.js",
+    "repair:cleanup-replacement-labels": "node dist/repair/cleanup-replacement-labels.js",
     "repair:comment-router": "node dist/repair/comment-router.js",
     "repair:comment-webhook": "node dist/repair/comment-webhook.js",
     "repair:commit-finding-intake": "node dist/repair/commit-finding-intake.js",

--- a/src/repair/cleanup-replacement-labels.ts
+++ b/src/repair/cleanup-replacement-labels.ts
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+import type { JsonValue, LooseRecord } from "./json-types.js";
+import fs from "node:fs";
+import path from "node:path";
+import { DEFAULT_TARGET_REPO } from "./constants.js";
+import { ghJsonWithRetry, ghTextWithRetry } from "./github-cli.js";
+import { parseArgs, repoRoot } from "./lib.js";
+import { replacementSourceLabelCopyable } from "./replacement-labels.js";
+
+const DEFAULT_HEAD_PREFIX = "clawsweeper/";
+
+const args = parseArgs(process.argv.slice(2));
+const repo = String(args.repo ?? process.env.CLAWSWEEPER_TARGET_REPO ?? DEFAULT_TARGET_REPO);
+const headPrefix = String(args["head-prefix"] ?? DEFAULT_HEAD_PREFIX);
+const execute = Boolean(args.execute);
+const limit = Number(args.limit ?? 200);
+const reportPath = path.resolve(
+  String(args.report ?? path.join(repoRoot(), ".artifacts", "replacement-label-cleanup.json")),
+);
+
+if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) {
+  throw new Error(`repo must be owner/repo, got ${repo}`);
+}
+if (!Number.isInteger(limit) || limit < 1 || limit > 1000) {
+  throw new Error("--limit must be an integer from 1 through 1000");
+}
+if (execute && process.env.CLAWSWEEPER_ALLOW_EXECUTE !== "1") {
+  throw new Error("refusing to remove labels: CLAWSWEEPER_ALLOW_EXECUTE must be 1");
+}
+
+const pulls = listOpenReplacementPullRequests();
+const rows = pulls.map(classifyPullRequest);
+if (execute) {
+  for (const row of rows) {
+    removeLabels(row);
+  }
+}
+
+const report = {
+  status: execute ? "applied" : "dry_run",
+  repo,
+  head_prefix: headPrefix,
+  generated_at: new Date().toISOString(),
+  execute,
+  totals: {
+    open_replacement_prs: rows.length,
+    prs_with_denied_source_labels: rows.filter((row) => row.denied_source_labels.length > 0).length,
+    prs_with_lifecycle_cleanup: rows.filter((row) => row.lifecycle_cleanup_labels.length > 0)
+      .length,
+    labels_removed: rows.reduce((sum, row) => sum + row.removed_labels.length, 0),
+    remove_failures: rows.reduce((sum, row) => sum + row.remove_failures.length, 0),
+  },
+  prs: rows,
+};
+
+fs.mkdirSync(path.dirname(reportPath), { recursive: true });
+fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`);
+console.log(JSON.stringify(report, null, 2));
+
+function listOpenReplacementPullRequests(): LooseRecord[] {
+  const fields = ["number", "title", "url", "author", "headRefName", "labels"].join(",");
+  const pulls = ghJsonWithRetry<JsonValue[]>([
+    "pr",
+    "list",
+    "--repo",
+    repo,
+    "--state",
+    "open",
+    "--limit",
+    String(limit),
+    "--json",
+    fields,
+  ]);
+  return pulls.filter(
+    (pull) =>
+      isRecord(pull) &&
+      String(pull.headRefName ?? "").startsWith(headPrefix) &&
+      String((pull.author as LooseRecord | undefined)?.login ?? "") === "app/clawsweeper",
+  ) as LooseRecord[];
+}
+
+function classifyPullRequest(pull: LooseRecord) {
+  const labels = labelNames(pull.labels);
+  const denied = labels.filter((label) => !replacementSourceLabelCopyable(label));
+  return {
+    number: Number(pull.number),
+    url: String(pull.url ?? ""),
+    title: String(pull.title ?? ""),
+    head_ref: String(pull.headRefName ?? ""),
+    labels,
+    denied_source_labels: denied,
+    lifecycle_cleanup_labels: denied.filter(isLifecycleCleanupLabel),
+    removed_labels: [] as string[],
+    remove_failures: [] as LooseRecord[],
+  };
+}
+
+function removeLabels(row: ReturnType<typeof classifyPullRequest>) {
+  for (const label of row.lifecycle_cleanup_labels) {
+    try {
+      ghTextWithRetry(["pr", "edit", String(row.number), "--repo", repo, "--remove-label", label]);
+      row.removed_labels.push(label);
+    } catch (error) {
+      row.remove_failures.push({
+        label,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+}
+
+function labelNames(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((label) =>
+      isRecord(label) ? String(label.name ?? "").trim() : String(label ?? "").trim(),
+    )
+    .filter(Boolean);
+}
+
+function isLifecycleCleanupLabel(label: string): boolean {
+  const key = label.trim().toLowerCase();
+  return key === "stale" || key.startsWith("close:");
+}
+
+function isRecord(value: unknown): value is LooseRecord {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}

--- a/src/repair/replacement-labels.ts
+++ b/src/repair/replacement-labels.ts
@@ -21,13 +21,38 @@ export function replacementLabelsToCopy(
   const labels = new Map<string, string>();
   for (const sourceLabels of sourceLabelSets) {
     for (const label of sourceLabels) {
-      addLabel(labels, label);
+      addSourceLabel(labels, label);
     }
   }
   for (const label of requiredLabels) {
     addLabel(labels, label);
   }
   return [...labels.values()];
+}
+
+export function replacementSourceLabelCopyable(value: string): boolean {
+  const label = String(value ?? "").trim();
+  if (!label) return false;
+  const key = label.toLowerCase();
+  if (key === "stale") return false;
+  if (
+    key.startsWith("close:") ||
+    key.startsWith("merge-risk:") ||
+    key.startsWith("proof:") ||
+    key.startsWith("rating:") ||
+    key.startsWith("size:") ||
+    key.startsWith("status:")
+  ) {
+    return false;
+  }
+  if (key === "triage: needs-real-behavior-proof") return false;
+  if (/^p[0-3]$/.test(key)) return false;
+  return true;
+}
+
+function addSourceLabel(labels: Map<string, string>, value: string) {
+  if (!replacementSourceLabelCopyable(value)) return;
+  addLabel(labels, value);
 }
 
 function addLabel(labels: Map<string, string>, value: string) {

--- a/test/repair/replacement-labels.test.ts
+++ b/test/repair/replacement-labels.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   replacementAutomationLabel,
   replacementLabelsToCopy,
+  replacementSourceLabelCopyable,
 } from "../../dist/repair/replacement-labels.js";
 
 test("replacement PRs inherit autofix intent from source PR labels", () => {
@@ -24,15 +25,70 @@ test("replacement PRs without source automation labels stay unlabeled", () => {
   assert.equal(replacementAutomationLabel([["docs"], ["clawsweeper"]]), null);
 });
 
-test("replacement PRs preserve source labels and required labels without duplicates", () => {
+test("replacement PRs preserve durable source labels and required labels without duplicates", () => {
   assert.deepEqual(
     replacementLabelsToCopy(
       [
-        ["gateway", "maintainer", "size: S", "clawsweeper:automerge"],
+        ["app: web-ui", "component: gateway", "impact:message-loss", "clawsweeper:automerge"],
         ["Gateway", "bug"],
       ],
       ["clawsweeper"],
     ),
-    ["gateway", "maintainer", "size: S", "clawsweeper:automerge", "bug", "clawsweeper"],
+    [
+      "app: web-ui",
+      "component: gateway",
+      "impact:message-loss",
+      "clawsweeper:automerge",
+      "Gateway",
+      "bug",
+      "clawsweeper",
+    ],
   );
+});
+
+test("replacement PRs do not copy source close or stale labels", () => {
+  assert.deepEqual(
+    replacementLabelsToCopy(
+      [["close:superseded", "close:stale", "stale", "component: gateway"]],
+      ["clawsweeper"],
+    ),
+    ["component: gateway", "clawsweeper"],
+  );
+});
+
+test("replacement PRs do not copy source review, proof, status, risk, size, or priority labels", () => {
+  assert.deepEqual(
+    replacementLabelsToCopy(
+      [
+        [
+          "rating: 🧂 unranked krab",
+          "status: 📣 needs proof",
+          "proof: missing",
+          "triage: needs-real-behavior-proof",
+          "merge-risk: 🚨 compatibility",
+          "size: M",
+          "P1",
+          "app: web-ui",
+        ],
+      ],
+      ["P2", "status: explicit repair decision"],
+    ),
+    ["app: web-ui", "P2", "status: explicit repair decision"],
+  );
+});
+
+test("replacement source label filter documents denied classes", () => {
+  for (const label of [
+    "close:superseded",
+    "stale",
+    "rating: 🧂 unranked krab",
+    "status: 📣 needs proof",
+    "proof: missing",
+    "triage: needs-real-behavior-proof",
+    "merge-risk: 🚨 compatibility",
+    "size: M",
+    "P3",
+  ]) {
+    assert.equal(replacementSourceLabelCopyable(label), false, label);
+  }
 });


### PR DESCRIPTION
## Summary
- filter source PR labels before copying them onto replacement PRs
- drop inherited lifecycle/review/proof/status/risk/size/priority labels while preserving durable routing and repair-loop labels
- add a conservative dry-run cleanup helper for open ClawSweeper replacement PRs

## Validation
- pnpm run build:repair
- node --test test/repair/replacement-labels.test.ts
- pnpm run repair:cleanup-replacement-labels -- --repo openclaw/openclaw --limit 200 --report .artifacts/replacement-label-cleanup-dry-run.json
- pnpm run check

## Dry-run cleanup findings
- https://github.com/openclaw/openclaw/pull/90618: lifecycle cleanup candidate stale
- https://github.com/openclaw/openclaw/pull/90284: lifecycle cleanup candidate close:superseded

No cleanup mutation was performed.