### PR TITLE
Add conflict self-heal repair lane

### DIFF
--- a/.github/workflows/repair-cluster-worker.yml
+++ b/.github/workflows/repair-cluster-worker.yml
@@ -167,8 +167,16 @@ jobs:
           CLAWSWEEPER_ALLOWED_OWNER: ${{ steps.target.outputs.target_owner }}
         run: pnpm run repair:validate-job -- "${{ inputs.job }}"
 
-      - name: Run worker
+      - name: Verify self-heal head
+        id: self_heal_head
         if: ${{ steps.check_job.outputs.job_exists == '1' }}
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          CLAWSWEEPER_ALLOWED_OWNER: ${{ steps.target.outputs.target_owner }}
+        run: pnpm run repair:conflict-self-heal -- --verify-job-head "${{ inputs.job }}"
+
+      - name: Run worker
+        if: ${{ steps.check_job.outputs.job_exists == '1' && steps.self_heal_head.outputs.matched != 'false' }}
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           CLAWSWEEPER_ALLOWED_OWNER: ${{ steps.target.outputs.target_owner }}
@@ -357,8 +365,16 @@ jobs:
           CLAWSWEEPER_ALLOWED_OWNER: ${{ steps.target.outputs.target_owner }}
         run: pnpm run repair:validate-job -- "${{ inputs.job }}"
 
+      - name: Verify self-heal head
+        id: self_heal_head
+        if: ${{ steps.check_job.outputs.job_exists == '1' }}
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          CLAWSWEEPER_ALLOWED_OWNER: ${{ steps.target.outputs.target_owner }}
+        run: pnpm run repair:conflict-self-heal -- --verify-job-head "${{ inputs.job }}"
+
       - name: Execute credited fix artifact
-        if: ${{ steps.check_job.outputs.job_exists == '1' && env.CLAWSWEEPER_ALLOW_EXECUTE == '1' && env.CLAWSWEEPER_ALLOW_FIX_PR == '1' }}
+        if: ${{ steps.check_job.outputs.job_exists == '1' && steps.self_heal_head.outputs.matched != 'false' && env.CLAWSWEEPER_ALLOW_EXECUTE == '1' && env.CLAWSWEEPER_ALLOW_FIX_PR == '1' }}
         timeout-minutes: 40
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
@@ -366,28 +382,28 @@ jobs:
         run: pnpm run repair:execute-fix -- "${{ inputs.job }}" --latest
 
       - name: Apply safe closure actions
-        if: ${{ steps.check_job.outputs.job_exists == '1' && env.CLAWSWEEPER_ALLOW_EXECUTE == '1' }}
+        if: ${{ steps.check_job.outputs.job_exists == '1' && steps.self_heal_head.outputs.matched != 'false' && env.CLAWSWEEPER_ALLOW_EXECUTE == '1' }}
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           CLAWSWEEPER_ALLOWED_OWNER: ${{ steps.target.outputs.target_owner }}
         run: pnpm run repair:apply-result -- "${{ inputs.job }}" --latest
 
       - name: Post-flight finalize fix PRs
-        if: ${{ steps.check_job.outputs.job_exists == '1' && env.CLAWSWEEPER_ALLOW_EXECUTE == '1' && env.CLAWSWEEPER_ALLOW_FIX_PR == '1' }}
+        if: ${{ steps.check_job.outputs.job_exists == '1' && steps.self_heal_head.outputs.matched != 'false' && env.CLAWSWEEPER_ALLOW_EXECUTE == '1' && env.CLAWSWEEPER_ALLOW_FIX_PR == '1' }}
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           CLAWSWEEPER_ALLOWED_OWNER: ${{ steps.target.outputs.target_owner }}
         run: pnpm run repair:post-flight -- "${{ inputs.job }}" --latest
 
       - name: Apply post-flight closeouts
-        if: ${{ steps.check_job.outputs.job_exists == '1' && env.CLAWSWEEPER_ALLOW_EXECUTE == '1' }}
+        if: ${{ steps.check_job.outputs.job_exists == '1' && steps.self_heal_head.outputs.matched != 'false' && env.CLAWSWEEPER_ALLOW_EXECUTE == '1' }}
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           CLAWSWEEPER_ALLOWED_OWNER: ${{ steps.target.outputs.target_owner }}
         run: pnpm run repair:apply-result -- "${{ inputs.job }}" --latest
 
       - name: Tag ClawSweeper targets
-        if: ${{ always() && steps.check_job.outputs.job_exists == '1' && env.CLAWSWEEPER_ALLOW_EXECUTE == '1' }}
+        if: ${{ always() && steps.check_job.outputs.job_exists == '1' && steps.self_heal_head.outputs.matched != 'false' && env.CLAWSWEEPER_ALLOW_EXECUTE == '1' }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
@@ -396,7 +412,7 @@ jobs:
 
       - name: Detect repair requeue requests
         id: repair_requeue
-        if: ${{ always() && steps.check_job.outputs.job_exists == '1' && env.CLAWSWEEPER_ALLOW_EXECUTE == '1' && env.CLAWSWEEPER_ALLOW_FIX_PR == '1' }}
+        if: ${{ always() && steps.check_job.outputs.job_exists == '1' && steps.self_heal_head.outputs.matched != 'false' && env.CLAWSWEEPER_ALLOW_EXECUTE == '1' && env.CLAWSWEEPER_ALLOW_FIX_PR == '1' }}
         run: |
           set -euo pipefail
           count="$(pnpm run --silent workflow -- count-requeue-required --dir .clawsweeper-repair/runs)"

--- a/.github/workflows/repair-conflict-self-heal.yml
+++ b/.github/workflows/repair-conflict-self-heal.yml
@@ -1,0 +1,120 @@
+name: repair conflict self-heal
+
+on:
+  workflow_dispatch:
+    inputs:
+      execute:
+        description: "Dispatch repair jobs instead of printing candidates"
+        required: true
+        default: false
+        type: boolean
+      target_repo:
+        description: "Repository to scan"
+        required: true
+        default: openclaw/openclaw
+        type: string
+      max_prs:
+        description: "Maximum PRs to dispatch"
+        required: true
+        default: "5"
+        type: string
+      runner:
+        description: "Runner label for repair workers"
+        required: true
+        default: blacksmith-4vcpu-ubuntu-2404
+        type: string
+      execution_runner:
+        description: "Runner label for fix/apply execution work"
+        required: true
+        default: blacksmith-16vcpu-ubuntu-2404
+        type: string
+  schedule:
+    - cron: "27 * * * *"
+
+permissions:
+  contents: write
+  actions: write
+  issues: write
+  pull-requests: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  CLAWSWEEPER_APP_CLIENT_ID: Iv23liOECG0slfuhz093
+
+concurrency:
+  group: clawsweeper-conflict-self-heal-${{ github.event_name == 'workflow_dispatch' && inputs.target_repo || vars.CLAWSWEEPER_TARGET_REPO || 'openclaw/openclaw' }}
+  cancel-in-progress: false
+
+jobs:
+  self-heal:
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner || vars.CLAWSWEEPER_WORKER_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    timeout-minutes: 20
+    steps:
+      - name: Create GitHub App token
+        id: app_token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+          owner: ${{ vars.CLAWSWEEPER_ALLOWED_OWNER || github.repository_owner }}
+          permission-actions: write
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+
+      - uses: actions/checkout@v5
+        with:
+          filter: blob:none
+          fetch-depth: 0
+          token: ${{ steps.app_token.outputs.token }}
+
+      - name: Create state token
+        id: state-token
+        uses: ./.github/actions/create-state-token
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+
+      - uses: ./.github/actions/setup-state
+        with:
+          token: ${{ steps.state-token.outputs.token }}
+
+      - uses: ./.github/actions/setup-pnpm
+        with:
+          build-script: build:repair
+
+      - name: Plan conflict self-heal
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          CLAWSWEEPER_ALLOW_EXECUTE: ${{ vars.CLAWSWEEPER_ALLOW_EXECUTE || '0' }}
+          CLAWSWEEPER_ALLOW_FIX_PR: ${{ vars.CLAWSWEEPER_ALLOW_FIX_PR || '0' }}
+        run: |
+          execute="false"
+          target_repo="${{ github.event_name == 'workflow_dispatch' && inputs.target_repo || vars.CLAWSWEEPER_TARGET_REPO || 'openclaw/openclaw' }}"
+          max_prs="${{ github.event_name == 'workflow_dispatch' && inputs.max_prs || vars.CLAWSWEEPER_CONFLICT_SELF_HEAL_MAX_PRS || '5' }}"
+          runner="${{ github.event_name == 'workflow_dispatch' && inputs.runner || vars.CLAWSWEEPER_WORKER_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}"
+          execution_runner="${{ github.event_name == 'workflow_dispatch' && inputs.execution_runner || vars.CLAWSWEEPER_EXECUTION_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}"
+          if { [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.execute }}" = "true" ]; } ||
+             { [ "${{ github.event_name }}" = "schedule" ] && [ "${{ vars.CLAWSWEEPER_CONFLICT_SELF_HEAL_EXECUTE || '0' }}" = "1" ]; }; then
+            execute="true"
+          fi
+
+          args=(--repo "$target_repo" --max-prs "$max_prs" --runner "$runner" --execution-runner "$execution_runner" --wait-for-capacity)
+          if [ "$execute" = "true" ]; then
+            args+=(--execute)
+          fi
+          pnpm run repair:conflict-self-heal -- "${args[@]}"
+
+      - name: Commit conflict self-heal ledger
+        if: ${{ always() && ((github.event_name == 'workflow_dispatch' && inputs.execute) || (github.event_name == 'schedule' && vars.CLAWSWEEPER_CONFLICT_SELF_HEAL_EXECUTE == '1')) }}
+        run: |
+          if [ ! -f results/conflict-self-heal-dispatch.json ]; then
+            echo "No conflict self-heal ledger"
+            exit 0
+          fi
+          pnpm run repair:publish-main -- \
+            --message "chore: record conflict self-heal dispatch" \
+            --path results/conflict-self-heal-dispatch.json \
+            --path results/conflict-self-heal.json \
+            --path results/conflict-self-heal.md \
+            --rebase-strategy theirs

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "repair:dispatch": "node dist/repair/dispatch-jobs.js",
     "repair:requeue": "node dist/repair/requeue-job.js",
     "repair:self-heal": "node dist/repair/self-heal-failed-runs.js",
+    "repair:conflict-self-heal": "node dist/repair/conflict-self-heal.js",
     "repair:publish-result": "node dist/repair/publish-result.js",
     "repair:review-results": "node dist/repair/review-results.js",
     "repair:message-samples": "node dist/repair/render-message-samples.js",

--- a/scripts/restore-repair-job.sh
+++ b/scripts/restore-repair-job.sh
@@ -171,6 +171,71 @@ When code changes are appropriate, emit a fix artifact with \`repair_strategy: "
 EOF
 }
 
+restore_self_heal_job() {
+  case "$JOB_PATH" in
+    jobs/*/inbox/self-heal-*.md) ;;
+    *) return 1 ;;
+  esac
+  local filename stem rest number repo_slug owner repo_name repo ref branch
+  filename="${JOB_PATH##*/}"
+  stem="${filename%.md}"
+  rest="${stem#self-heal-}"
+  number="${rest##*-}"
+  repo_slug="${rest%-${number}}"
+  owner="${JOB_PATH#jobs/}"
+  owner="${owner%%/*}"
+  repo_name="${repo_slug#${owner}-}"
+  if [ -z "$number" ] || [ "$number" = "$rest" ] || [ -z "$repo_name" ] || [ "$repo_name" = "$repo_slug" ]; then
+    return 1
+  fi
+  repo="$owner/$repo_name"
+  ref="#$number"
+  branch="clawsweeper/self-heal-$repo_slug-$number"
+  mkdir -p "$(dirname "$JOB_PATH")"
+  cat > "$JOB_PATH" <<EOF
+---
+repo: $repo
+cluster_id: self-heal-$repo_slug-$number
+mode: autonomous
+job_intent: clawsweeper_self_rebase
+allowed_actions:
+  - comment
+  - fix
+blocked_actions:
+  - close
+  - merge
+  - label
+require_human_for:
+  - close
+  - merge
+canonical:
+  - $ref
+candidates:
+  - $ref
+cluster_refs:
+  - $ref
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: false
+allow_unmerged_fix_close: false
+allow_post_merge_close: false
+require_fix_before_close: true
+security_policy: central_security_only
+security_sensitive: false
+target_branch: $branch
+source: clawsweeper_self_rebase
+self_heal_target_pr: "$number"
+expected_head_sha: "unknown"
+self_heal_merge_state: "restored missing self-heal job"
+---
+
+# ClawSweeper self-heal PR rebase
+
+This restored placeholder cannot safely mutate because the original target head SHA is unavailable.
+The self-heal exact-head verifier will skip this job unless the durable state file is restored with a concrete expected_head_sha.
+EOF
+}
+
 if [ -f "$JOB_PATH" ]; then
   write_output job_exists 1
 elif restore_automerge_job; then
@@ -179,6 +244,9 @@ elif restore_automerge_job; then
 elif restore_issue_implementation_job; then
   write_output job_exists 1
   echo "::notice title=Restored issue implementation job::Job file '$JOB_PATH' was missing from the state checkout; reconstructed it from the workflow input."
+elif restore_self_heal_job; then
+  write_output job_exists 1
+  echo "::notice title=Restored self-heal repair job::Job file '$JOB_PATH' was missing from the state checkout; reconstructed a non-mutating placeholder from the workflow input."
 else
   write_output job_exists 0
   echo "::notice title=Stale repair dispatch::Job file '$JOB_PATH' no longer exists on the current state checkout; skipping $SKIP_TARGET."

--- a/src/repair/conflict-self-heal-core.ts
+++ b/src/repair/conflict-self-heal-core.ts
@@ -1,0 +1,215 @@
+import type { JsonValue, LooseRecord } from "./json-types.js";
+import { renderJobIntentFrontmatter } from "./job-intent.js";
+import { repoSlug } from "./comment-router-core.js";
+
+export const CLAWSWEEPER_SELF_REBASE_SOURCE = "clawsweeper_self_rebase";
+export const CLAWSWEEPER_SELF_REBASE_INTENT = "clawsweeper_self_rebase";
+export const DEFAULT_SELF_HEAL_HEAD_PREFIX = "clawsweeper/";
+export const SELF_HEAL_STATUS_MARKER_INTENT = "clawsweeper_self_rebase";
+export const SELF_HEAL_PAUSE_LABELS = new Set([
+  "clawsweeper:human-review",
+  "clawsweeper:merge-ready",
+]);
+
+export function selfHealClusterId(repo: string, issueNumber: JsonValue) {
+  return `self-heal-${repoSlug(repo)}-${Number(issueNumber)}`;
+}
+
+export function selfHealJobPath(repo: string, issueNumber: JsonValue) {
+  const owner = String(repo ?? "").split("/")[0] || "openclaw";
+  return `jobs/${owner}/inbox/${selfHealClusterId(repo, issueNumber)}.md`;
+}
+
+export function selfHealStatusMarker(issueNumber: JsonValue, headSha: JsonValue) {
+  return `<!-- clawsweeper-command-status:${Number(issueNumber) || "unknown"}:${SELF_HEAL_STATUS_MARKER_INTENT}:${String(headSha ?? "na") || "na"} -->`;
+}
+
+export function selfHealMergeStateReason(target: LooseRecord = {}): string | null {
+  const mergeStateStatus = String(target.merge_state_status ?? target.mergeStateStatus ?? "")
+    .trim()
+    .toUpperCase();
+  if (mergeStateStatus === "DIRTY") return "mergeStateStatus is DIRTY";
+  if (mergeStateStatus === "BEHIND") return "mergeStateStatus is BEHIND";
+
+  const mergeable = String(target.mergeable ?? "")
+    .trim()
+    .toUpperCase();
+  if (mergeable === "CONFLICTING") return "mergeable is CONFLICTING";
+  return null;
+}
+
+export function selfHealEligibility({
+  pull,
+  repo,
+  headPrefix = DEFAULT_SELF_HEAL_HEAD_PREFIX,
+}: {
+  pull: LooseRecord;
+  repo: string;
+  headPrefix?: string;
+}) {
+  const labels = normalizedLabelSet(pull.labels ?? []);
+  const author = normalizedAuthor(pull.author);
+  const branch = String(pull.headRefName ?? pull.branch ?? "");
+  const headRepo = String(
+    pull.headRepository?.nameWithOwner ??
+      pull.headRepositoryNameWithOwner ??
+      pull.head_repo ??
+      pull.headRepo ??
+      "",
+  );
+  const headSha = String(pull.headRefOid ?? pull.head_sha ?? pull.headSha ?? "").trim();
+  const state = String(pull.state ?? "OPEN").toUpperCase();
+  const mergeState = selfHealMergeStateReason(pull);
+
+  if (state !== "OPEN") return { eligible: false, reason: "PR is not open" };
+  if (!isClawSweeperAppAuthor(author)) {
+    return { eligible: false, reason: `author is ${author || "unknown"}` };
+  }
+  if (!branch.startsWith(headPrefix)) {
+    return { eligible: false, reason: `head branch does not start with ${headPrefix}` };
+  }
+  if (headRepo && headRepo.toLowerCase() !== repo.toLowerCase()) {
+    return { eligible: false, reason: `head repo is ${headRepo}` };
+  }
+  if (!headRepo) return { eligible: false, reason: "head repository is unknown" };
+  if (!headSha) return { eligible: false, reason: "head SHA is unknown" };
+  if (!mergeState) return { eligible: false, reason: "merge state is clean or unknown" };
+  for (const label of SELF_HEAL_PAUSE_LABELS) {
+    if (labels.has(label)) return { eligible: false, reason: `paused by ${label}` };
+  }
+  return { eligible: true, reason: mergeState };
+}
+
+export function renderSelfHealJob({
+  repo,
+  issueNumber,
+  title = null,
+  branch,
+  headSha,
+  mergeState,
+  runUrl = null,
+}: LooseRecord) {
+  const ref = `#${Number(issueNumber)}`;
+  const prUrl = `https://github.com/${repo}/pull/${Number(issueNumber)}`;
+  const safeTitle = String(title ?? `PR ${ref}`).trim() || `PR ${ref}`;
+  const clusterId = selfHealClusterId(String(repo), issueNumber);
+  return `---
+repo: ${repo}
+cluster_id: ${clusterId}
+mode: autonomous
+${renderJobIntentFrontmatter(CLAWSWEEPER_SELF_REBASE_INTENT)}
+allowed_actions:
+  - comment
+  - fix
+blocked_actions:
+  - close
+  - merge
+  - label
+require_human_for:
+  - close
+  - merge
+canonical:
+  - ${ref}
+candidates:
+  - ${ref}
+cluster_refs:
+  - ${ref}
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: false
+allow_unmerged_fix_close: false
+allow_post_merge_close: false
+require_fix_before_close: true
+security_policy: central_security_only
+security_sensitive: false
+target_branch: ${branch}
+source: ${CLAWSWEEPER_SELF_REBASE_SOURCE}
+self_heal_target_pr: "${String(issueNumber)}"
+expected_head_sha: "${String(headSha)}"
+self_heal_merge_state: ${JSON.stringify(String(mergeState ?? ""))}
+${runUrl ? `self_heal_run_url: ${JSON.stringify(String(runUrl))}\n` : ""}---
+
+# ClawSweeper self-heal PR rebase
+
+ClawSweeper detected that ${ref} is a ClawSweeper-owned PR whose same-repo branch needs a rebase or conflict repair.
+
+Source PR: ${prUrl}
+Title: ${safeTitle}
+Target branch: \`${branch}\`
+Target head SHA: \`${headSha}\`
+Detected state: ${mergeState}
+${runUrl ? `Repair run: ${runUrl}\n` : ""}
+Use this job only for bounded conflict/behind self-heal:
+
+- Before changing anything, verify that ${prUrl} is still open and its head SHA is exactly \`${headSha}\`; if it changed, stop without editing or pushing.
+- Emit a fix artifact with \`repair_strategy: "repair_contributor_branch"\`, \`deterministic_rebase_only: true\`, and \`source_prs: ["${prUrl}"]\` for a pure rebase/base-sync repair.
+- Rebase the existing same-repo branch onto latest \`main\`, resolve conflicts only when the resolution is directly required by the rebase, and run the narrow validation available for the touched surface.
+- Do not add \`clawsweeper:automerge\`, \`clawsweeper:merge-ready\`, or any merge-ready labels.
+- Do not merge or close this PR. A fresh exact-head ClawSweeper review is required after any successful push.
+`;
+}
+
+export function renderSelfHealStatusComment({
+  repo,
+  issueNumber,
+  headSha,
+  mergeState,
+  jobPath,
+  runUrl = null,
+  status = "planned",
+}: LooseRecord) {
+  const prUrl = `https://github.com/${repo}/pull/${Number(issueNumber)}`;
+  return [
+    selfHealStatusMarker(issueNumber, headSha),
+    "ClawSweeper conflict self-heal is queued.",
+    "",
+    `Detected state: ${mergeState || "unknown"}.`,
+    `Target head: ${markdownCommitLink(repo, headSha)}.`,
+    runUrl ? `Repair run: ${runUrl}.` : `Repair job: \`${jobPath ?? "pending"}\`.`,
+    `Status: ${status}.`,
+    "",
+    `This lane will only try to rebase or repair the ClawSweeper-owned branch for ${prUrl}. It will not merge the PR or add automerge/merge-ready labels.`,
+  ].join("\n");
+}
+
+export function selfHealStatusMarkerPrefix(issueNumber: JsonValue) {
+  return `<!-- clawsweeper-command-status:${Number(issueNumber) || "unknown"}:${SELF_HEAL_STATUS_MARKER_INTENT}:`;
+}
+
+function normalizedAuthor(author: JsonValue) {
+  if (typeof author === "string") return author.toLowerCase();
+  if (!author || typeof author !== "object") return "";
+  const record = author as LooseRecord;
+  const type = String(record.__typename ?? record.type ?? "").toLowerCase();
+  const login = String(record.login ?? record.name ?? "").toLowerCase();
+  return type && login ? `${type}/${login}` : login;
+}
+
+function isClawSweeperAppAuthor(author: string) {
+  return (
+    author === "app/clawsweeper" ||
+    author === "bot/clawsweeper" ||
+    author === "clawsweeper" ||
+    author === "clawsweeper[bot]" ||
+    author === "bot/clawsweeper[bot]"
+  );
+}
+
+function normalizedLabelSet(labels: JsonValue) {
+  const names = Array.isArray(labels) ? labels : [];
+  return new Set(
+    names
+      .map((label: JsonValue) =>
+        typeof label === "string" ? label : String((label as LooseRecord)?.name ?? ""),
+      )
+      .map((label: string) => label.trim().toLowerCase())
+      .filter(Boolean),
+  );
+}
+
+function markdownCommitLink(repo: JsonValue, sha: JsonValue): string {
+  const full = String(sha ?? "").trim();
+  if (!/^[0-9a-f]{7,40}$/i.test(full)) return full ? `\`${full}\`` : "`unknown`";
+  const short = full.slice(0, 12);
+  return `[\`${short}\`](https://github.com/${repo}/commit/${full})`;
+}

--- a/src/repair/conflict-self-heal.ts
+++ b/src/repair/conflict-self-heal.ts
@@ -1,0 +1,609 @@
+#!/usr/bin/env node
+import type { JsonValue, LooseRecord } from "./json-types.js";
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import {
+  activeRepairWorkflowRunForJobAfterDispatchRecheck,
+  assertLiveWorkerCapacity,
+  currentProjectRepo,
+  parseArgs,
+  parseJob,
+  readMaxLiveWorkers,
+  repoRoot,
+  validateJob,
+  waitForLiveWorkerCapacity,
+} from "./lib.js";
+import { publishMainCommit, publishRoot } from "./git-publish.js";
+import { ghJson, ghJsonWithRetry, ghPaged, ghText } from "./github-cli.js";
+import { DEFAULT_TARGET_REPO, REPAIR_CLUSTER_WORKFLOW } from "./constants.js";
+import { writePayload } from "./comment-router-utils.js";
+import {
+  DEFAULT_SELF_HEAL_HEAD_PREFIX,
+  CLAWSWEEPER_SELF_REBASE_SOURCE,
+  renderSelfHealJob,
+  renderSelfHealStatusComment,
+  selfHealEligibility,
+  selfHealJobPath,
+  selfHealStatusMarkerPrefix,
+} from "./conflict-self-heal-core.js";
+
+const args = parseArgs(process.argv.slice(2));
+
+if (args["verify-job-head"]) {
+  verifyJobHead(String(args["verify-job-head"]));
+  process.exit(0);
+}
+
+const repo = String(args.repo ?? process.env.CLAWSWEEPER_TARGET_REPO ?? DEFAULT_TARGET_REPO);
+const repairRepo = String(
+  args["repair-repo"] ?? args.repair_repo ?? process.env.CLAWSWEEPER_REPO ?? currentProjectRepo(),
+);
+const workflow = String(args.workflow ?? REPAIR_CLUSTER_WORKFLOW);
+const headPrefix = String(args["head-prefix"] ?? args.head_prefix ?? DEFAULT_SELF_HEAL_HEAD_PREFIX);
+const runner = String(
+  args.runner ?? process.env.CLAWSWEEPER_WORKER_RUNNER ?? "blacksmith-4vcpu-ubuntu-2404",
+);
+const executionRunner = String(
+  args["execution-runner"] ??
+    args.execution_runner ??
+    process.env.CLAWSWEEPER_EXECUTION_RUNNER ??
+    "blacksmith-16vcpu-ubuntu-2404",
+);
+const model = String(args.model ?? process.env.CLAWSWEEPER_MODEL ?? "gpt-5.5");
+const maxPrs = Number(args["max-prs"] ?? args.max_prs ?? args.limit ?? 5);
+const maxRepairsPerHead = Number(
+  args["max-repairs-per-head"] ??
+    args.max_repairs_per_head ??
+    process.env.CLAWSWEEPER_MAX_REPAIRS_PER_HEAD ??
+    2,
+);
+const maxRepairsPerPr = Number(
+  args["max-repairs-per-pr"] ??
+    args.max_repairs_per_pr ??
+    process.env.CLAWSWEEPER_MAX_REPAIRS_PER_PR ??
+    10,
+);
+const maxLiveWorkers = readMaxLiveWorkers(args);
+const execute = Boolean(args.execute);
+const writeReport = Boolean(args["write-report"] ?? true);
+const waitForCapacity = Boolean(args["wait-for-capacity"]);
+const allowRepeat = Boolean(args["allow-repeat"]);
+const activeRepairRunsByPrefix = new Map<string, LooseRecord[]>();
+
+validateRepo(repo, "repo");
+validateRepo(repairRepo, "repair repo");
+const positiveIntegerOptions: Array<[string, number]> = [
+  ["--max-prs", maxPrs],
+  ["--max-repairs-per-head", maxRepairsPerHead],
+  ["--max-repairs-per-pr", maxRepairsPerPr],
+];
+for (const [name, value] of positiveIntegerOptions) {
+  if (!Number.isInteger(value) || value < 1) throw new Error(`${name} must be a positive integer`);
+}
+
+const openPulls = listOpenPullRequests(repo);
+const ledger = readLedger();
+const plannedHeads = new Set<string>();
+const classified = openPulls.map((pull) => classifyCandidate(pull, plannedHeads, ledger));
+const candidates = classified
+  .filter((candidate) => candidate.status === "candidate")
+  .slice(0, maxPrs);
+const dispatchSummary = {
+  enabled: execute,
+  workflow,
+  repair_repo: repairRepo,
+  runner,
+  execution_runner: executionRunner,
+  model,
+  max_prs: maxPrs,
+  max_repairs_per_head: maxRepairsPerHead,
+  max_repairs_per_pr: maxRepairsPerPr,
+  candidates: candidates.map(summarizeCandidate),
+  attempts: [],
+};
+const report: LooseRecord = {
+  repo,
+  head_prefix: headPrefix,
+  generated_at: new Date().toISOString(),
+  summary: summarize(classified),
+  dispatch: dispatchSummary,
+  prs: classified,
+};
+
+if (execute) {
+  report.dispatch = executeDispatches(candidates, dispatchSummary, ledger);
+}
+
+if (writeReport) writeReports(report);
+console.log(JSON.stringify(report, null, 2));
+
+function listOpenPullRequests(targetRepo: string): LooseRecord[] {
+  const searchResults = ghJsonWithRetry<LooseRecord[]>(
+    [
+      "search",
+      "prs",
+      "--repo",
+      targetRepo,
+      "--author",
+      "app/clawsweeper",
+      "--state",
+      "open",
+      "--json",
+      "number,title,url,author,updatedAt",
+      "--limit",
+      "100",
+    ],
+    { attempts: 4 },
+  );
+  return searchResults.map((pull: LooseRecord) => ({
+    ...pull,
+    ...fetchPullRequestView(targetRepo, pull.number),
+  }));
+}
+
+function fetchPullRequestView(targetRepo: string, number: JsonValue) {
+  return ghJsonWithRetry<LooseRecord>(
+    [
+      "pr",
+      "view",
+      String(number),
+      "--repo",
+      targetRepo,
+      "--json",
+      [
+        "author",
+        "baseRefName",
+        "headRefName",
+        "headRefOid",
+        "headRepository",
+        "isDraft",
+        "labels",
+        "mergeable",
+        "mergeStateStatus",
+        "state",
+        "title",
+        "url",
+      ].join(","),
+    ],
+    { attempts: 4 },
+  );
+}
+
+function classifyCandidate(
+  pull: LooseRecord,
+  plannedHeads: Set<string>,
+  currentLedger: LooseRecord,
+) {
+  const headSha = String(pull.headRefOid ?? "");
+  const jobPath = selfHealJobPath(repo, pull.number);
+  const base = {
+    number: pull.number,
+    title: pull.title,
+    url: pull.url,
+    author: pull.author?.login ?? pull.author ?? null,
+    branch: pull.headRefName,
+    head_repo: pull.headRepository?.nameWithOwner ?? null,
+    head_sha: headSha || null,
+    mergeable: pull.mergeable ?? null,
+    merge_state_status: pull.mergeStateStatus ?? null,
+    labels: (pull.labels ?? []).map((label: JsonValue) =>
+      typeof label === "string" ? label : (label as LooseRecord).name,
+    ),
+    job_path: jobPath,
+  };
+  const eligibility = selfHealEligibility({ pull, repo, headPrefix });
+  if (!eligibility.eligible) return { ...base, status: "skipped", reason: eligibility.reason };
+
+  const capBlock = repairCapBlockReason({
+    ledger: currentLedger,
+    pr: pull.number,
+    headSha,
+    plannedHeads,
+  });
+  if (capBlock) return { ...base, status: "skipped", reason: capBlock };
+
+  const active = activeRepairWorkflowRunForJobAfterDispatchRecheck({
+    repo: repairRepo,
+    workflow,
+    jobPath,
+    activeRunsByPrefix: activeRepairRunsByPrefix,
+  });
+  if (active) {
+    return {
+      ...base,
+      status: "waiting",
+      reason: "repair worker already active for this self-heal job",
+      active_run_url: active.url ?? null,
+      active_run_id: active.databaseId ?? active.id ?? null,
+    };
+  }
+
+  const headKey = `${repo}#${pull.number}:${headSha}`;
+  plannedHeads.add(headKey);
+  return { ...base, status: "candidate", reason: eligibility.reason };
+}
+
+function repairCapBlockReason({
+  ledger,
+  pr,
+  headSha,
+  plannedHeads,
+}: {
+  ledger: LooseRecord;
+  pr: JsonValue;
+  headSha: string;
+  plannedHeads: Set<string>;
+}) {
+  const headKey = `${repo}#${pr}:${headSha}`;
+  if (plannedHeads.has(headKey)) return "repair already planned for this PR head in this scan";
+  const attempts = (ledger.attempts ?? []).filter(
+    (attempt: JsonValue) =>
+      String(attempt.target_repo ?? "") === repo &&
+      Number(attempt.pr) === Number(pr) &&
+      ["dispatched", "waiting"].includes(String(attempt.status ?? "")),
+  );
+  if (!allowRepeat && attempts.length >= maxRepairsPerPr) {
+    return `self-heal already dispatched ${attempts.length} total time(s) for this PR`;
+  }
+  const headAttempts = attempts.filter(
+    (attempt: JsonValue) => String(attempt.head_sha ?? "") === headSha,
+  );
+  if (!allowRepeat && headAttempts.length >= maxRepairsPerHead) {
+    return `self-heal already dispatched ${headAttempts.length} time(s) for this PR head`;
+  }
+  return null;
+}
+
+function executeDispatches(
+  candidates: LooseRecord[],
+  dispatchSummary: LooseRecord,
+  currentLedger: LooseRecord,
+) {
+  const summary = {
+    ...dispatchSummary,
+    status: candidates.length === 0 ? "no_candidates" : "dispatching",
+    dispatched_at: new Date().toISOString(),
+    attempts: [],
+  };
+  if (candidates.length === 0) return summary;
+  if (process.env.CLAWSWEEPER_ALLOW_EXECUTE !== "1") {
+    throw new Error("refusing conflict self-heal dispatch: CLAWSWEEPER_ALLOW_EXECUTE must be 1");
+  }
+  if (process.env.CLAWSWEEPER_ALLOW_FIX_PR !== "1") {
+    throw new Error("refusing conflict self-heal dispatch: CLAWSWEEPER_ALLOW_FIX_PR must be 1");
+  }
+  summary.live_worker_capacity_before_dispatch = waitForCapacity
+    ? waitForLiveWorkerCapacity({
+        repo: repairRepo,
+        workflow,
+        requested: candidates.length,
+        maxLiveWorkers,
+      })
+    : assertLiveWorkerCapacity({
+        repo: repairRepo,
+        workflow,
+        requested: candidates.length,
+        maxLiveWorkers,
+      });
+
+  const batchId = `conflict-self-heal-${new Date().toISOString().replace(/[:.]/g, "-")}`;
+  const prepared: Array<{ candidate: LooseRecord; attempt: LooseRecord }> = [];
+  for (const candidate of candidates) {
+    const latest = fetchPullHead(repo, candidate.number);
+    const attempt: LooseRecord = {
+      batch_id: batchId,
+      target_repo: repo,
+      repair_repo: repairRepo,
+      pr: candidate.number,
+      url: candidate.url,
+      branch: candidate.branch,
+      head_sha: candidate.head_sha,
+      latest_head_sha: latest.head_sha,
+      merge_state: candidate.reason,
+      job_path: candidate.job_path,
+      workflow,
+      runner,
+      execution_runner: executionRunner,
+      model,
+      dispatched_at: new Date().toISOString(),
+      status: "pending",
+    };
+    if (latest.head_sha !== candidate.head_sha) {
+      attempt.status = "skipped";
+      attempt.reason = "head SHA changed before dispatch";
+    } else {
+      writeSelfHealJob(candidate);
+      attempt.status = "prepared";
+      prepared.push({ candidate, attempt });
+    }
+    summary.attempts.push(attempt);
+    currentLedger.attempts = [...(currentLedger.attempts ?? []), attempt];
+  }
+  if (prepared.length > 0) publishSelfHealJobs();
+  for (const item of prepared) {
+    const { candidate, attempt } = item;
+    const latest = fetchPullHead(repo, candidate.number);
+    attempt.latest_head_sha_after_publish = latest.head_sha;
+    if (latest.head_sha !== candidate.head_sha) {
+      attempt.status = "skipped";
+      attempt.reason = "head SHA changed after state publish";
+      continue;
+    }
+    postSelfHealStatus(candidate, { status: "dispatching" });
+    dispatchRepair(candidate);
+    attempt.status = "dispatched";
+  }
+  currentLedger.updated_at = new Date().toISOString();
+  writeLedger(currentLedger);
+  summary.status = "dispatched";
+  return summary;
+}
+
+function publishSelfHealJobs() {
+  if (!publishRoot()) {
+    throw new Error("refusing conflict self-heal dispatch: CLAWSWEEPER_STATE_DIR is required");
+  }
+  const result = publishMainCommit({
+    message: "chore: publish conflict self-heal jobs",
+    paths: ["jobs"],
+    maxAttempts: 12,
+    pushAttempts: 4,
+  });
+  console.log(`Published conflict self-heal jobs before dispatch: ${result}`);
+}
+
+function writeSelfHealJob(candidate: LooseRecord) {
+  const absolute = path.join(repoRoot(), candidate.job_path);
+  fs.mkdirSync(path.dirname(absolute), { recursive: true });
+  fs.writeFileSync(
+    absolute,
+    renderSelfHealJob({
+      repo,
+      issueNumber: candidate.number,
+      title: candidate.title,
+      branch: candidate.branch,
+      headSha: candidate.head_sha,
+      mergeState: candidate.reason,
+      runUrl: currentActionsRunUrl(),
+    }),
+    "utf8",
+  );
+  const job = parseJob(candidate.job_path);
+  const errors = validateJob(job);
+  if (errors.length > 0) throw new Error(`invalid self-heal job ${candidate.job_path}: ${errors}`);
+}
+
+function postSelfHealStatus(candidate: LooseRecord, { status }: { status: string }) {
+  const body = renderSelfHealStatusComment({
+    repo,
+    issueNumber: candidate.number,
+    headSha: candidate.head_sha,
+    mergeState: candidate.reason,
+    jobPath: candidate.job_path,
+    runUrl: currentActionsRunUrl(),
+    status,
+  });
+  const existing = findSelfHealStatusComment(candidate.number);
+  const payload = writePayload(
+    repoRoot(),
+    `conflict-self-heal-status-${candidate.number}-${candidate.head_sha}`,
+    { body },
+  );
+  if (existing?.id) {
+    ghText([
+      "api",
+      `repos/${repo}/issues/comments/${existing.id}`,
+      "--method",
+      "PATCH",
+      "--input",
+      payload,
+    ]);
+  } else {
+    ghText(["api", `repos/${repo}/issues/${candidate.number}/comments`, "--input", payload]);
+  }
+}
+
+function findSelfHealStatusComment(number: JsonValue) {
+  const prefix = selfHealStatusMarkerPrefix(number);
+  const comments = ghPaged<LooseRecord>(`repos/${repo}/issues/${number}/comments?per_page=100`);
+  return comments
+    .reverse()
+    .find(
+      (comment) => String(comment.body ?? "").includes(prefix) && isTrustedStatusComment(comment),
+    );
+}
+
+function dispatchRepair(candidate: LooseRecord) {
+  const result = spawnSync(
+    "gh",
+    [
+      "workflow",
+      "run",
+      workflow,
+      "--repo",
+      repairRepo,
+      "-f",
+      `job=${candidate.job_path}`,
+      "-f",
+      "mode=autonomous",
+      "-f",
+      `runner=${runner}`,
+      "-f",
+      `execution_runner=${executionRunner}`,
+      "-f",
+      `model=${model}`,
+    ],
+    { cwd: repoRoot(), encoding: "utf8", stdio: "pipe" },
+  );
+  if (result.status !== 0) {
+    throw new Error(`failed to dispatch ${candidate.job_path}: ${result.stderr || result.stdout}`);
+  }
+}
+
+function verifyJobHead(jobPath: string) {
+  const job = parseJob(jobPath);
+  let matched = true;
+  let reason = "not a self-heal job";
+  if (job.frontmatter.source === CLAWSWEEPER_SELF_REBASE_SOURCE) {
+    const target = Number(job.frontmatter.self_heal_target_pr);
+    const expected = String(job.frontmatter.expected_head_sha ?? "");
+    const live = fetchPullHead(String(job.frontmatter.repo ?? ""), target);
+    matched = live.state === "OPEN" && live.head_sha === expected;
+    reason = matched
+      ? "self-heal head matches"
+      : `self-heal head mismatch: expected ${expected || "unknown"}, got ${live.head_sha || "unknown"} (${live.state || "unknown"})`;
+  }
+  writeGithubOutput({ matched: matched ? "true" : "false", reason });
+  if (!matched) {
+    console.log(`::notice title=Skipped stale self-heal job::${reason}`);
+  }
+}
+
+function fetchPullHead(targetRepo: string, number: JsonValue) {
+  const view = ghJson<LooseRecord>([
+    "pr",
+    "view",
+    String(number),
+    "--repo",
+    targetRepo,
+    "--json",
+    "headRefOid,state",
+  ]);
+  return {
+    head_sha: String(view.headRefOid ?? ""),
+    state: String(view.state ?? ""),
+  };
+}
+
+function summarize(prs: LooseRecord[]) {
+  return {
+    open_clawsweeper_prs: prs.filter((pr) => String(pr.branch ?? "").startsWith(headPrefix)).length,
+    candidates: prs.filter((pr) => pr.status === "candidate").length,
+    waiting: prs.filter((pr) => pr.status === "waiting").length,
+    skipped: prs.filter((pr) => pr.status === "skipped").length,
+    conflicting_or_dirty: prs.filter(
+      (pr) => pr.status !== "skipped" || /mergeState|mergeable/.test(String(pr.reason)),
+    ).length,
+  };
+}
+
+function summarizeCandidate(candidate: LooseRecord) {
+  return {
+    pr: candidate.number,
+    url: candidate.url,
+    branch: candidate.branch,
+    head_sha: candidate.head_sha,
+    merge_state: candidate.reason,
+    job_path: candidate.job_path,
+  };
+}
+
+function readLedger() {
+  const file = ledgerPath();
+  if (!fs.existsSync(file)) return { updated_at: null, attempts: [] };
+  try {
+    const data = JSON.parse(fs.readFileSync(file, "utf8"));
+    return { updated_at: data.updated_at ?? null, attempts: data.attempts ?? [] };
+  } catch {
+    return { updated_at: null, attempts: [] };
+  }
+}
+
+function writeLedger(ledger: LooseRecord) {
+  fs.mkdirSync(path.dirname(ledgerPath()), { recursive: true });
+  fs.writeFileSync(ledgerPath(), `${JSON.stringify(ledger, null, 2)}\n`);
+}
+
+function ledgerPath() {
+  return path.join(repoRoot(), "results", "conflict-self-heal-dispatch.json");
+}
+
+function writeReports(report: LooseRecord) {
+  const resultsDir = path.join(repoRoot(), "results");
+  fs.mkdirSync(resultsDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(resultsDir, "conflict-self-heal.json"),
+    `${JSON.stringify(report, null, 2)}\n`,
+  );
+  fs.writeFileSync(path.join(resultsDir, "conflict-self-heal.md"), renderMarkdown(report));
+}
+
+function renderMarkdown(report: LooseRecord) {
+  const rows = (report.prs ?? [])
+    .map((pr: JsonValue) =>
+      [
+        markdownLink(`#${pr.number}`, pr.url),
+        tableCell(pr.title ?? ""),
+        tableCell(pr.branch ?? ""),
+        tableCell(pr.mergeable ?? ""),
+        tableCell(pr.merge_state_status ?? ""),
+        tableCell(pr.status ?? ""),
+        tableCell(pr.reason ?? ""),
+      ].join(" | "),
+    )
+    .map((row: string) => `| ${row} |`);
+  return [
+    "# ClawSweeper Conflict Self-Heal",
+    "",
+    `Generated: ${report.generated_at}`,
+    `Repository: ${report.repo}`,
+    "",
+    "## Summary",
+    "",
+    "| Metric | Count |",
+    "| --- | ---: |",
+    ...Object.entries(report.summary ?? {}).map(
+      ([key, value]) => `| ${tableCell(key)} | ${value} |`,
+    ),
+    "",
+    "## Pull Requests",
+    "",
+    "| PR | Title | Branch | Mergeable | Merge State | Status | Reason |",
+    "| --- | --- | --- | --- | --- | --- | --- |",
+    ...(rows.length > 0 ? rows : ["| none |  |  |  |  |  |  |"]),
+    "",
+  ].join("\n");
+}
+
+function markdownLink(label: JsonValue, url: JsonValue) {
+  return url ? `[${label}](${url})` : String(label ?? "");
+}
+
+function tableCell(value: JsonValue) {
+  return String(value ?? "")
+    .replace(/\\/g, "\\\\")
+    .replace(/\|/g, "\\|")
+    .replace(/\r?\n/g, " ");
+}
+
+function currentActionsRunUrl() {
+  const server = process.env.GITHUB_SERVER_URL;
+  const repository = process.env.GITHUB_REPOSITORY;
+  const runId = process.env.GITHUB_RUN_ID;
+  return server && repository && runId ? `${server}/${repository}/actions/runs/${runId}` : null;
+}
+
+function isTrustedStatusComment(comment: LooseRecord) {
+  const author = String(comment.user?.login ?? "").toLowerCase();
+  return (
+    author === "clawsweeper" ||
+    author === "clawsweeper[bot]" ||
+    author === "openclaw-clawsweeper[bot]"
+  );
+}
+
+function writeGithubOutput(values: Record<string, string>) {
+  const lines = Object.entries(values).map(([key, value]) => `${key}=${value}`);
+  if (process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `${lines.join("\n")}\n`);
+  } else {
+    console.log(lines.join("\n"));
+  }
+}
+
+function validateRepo(value: string, name: string) {
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(value)) {
+    throw new Error(`${name} must be owner/repo, got ${value}`);
+  }
+}

--- a/src/repair/execute-fix-artifact.ts
+++ b/src/repair/execute-fix-artifact.ts
@@ -823,7 +823,7 @@ function executeRepairBranch({ fixArtifact, targetDir }: LooseRecord) {
   logProgress("preparing target toolchain", { source_head: sourceHead });
   prepareTargetToolchain(targetDir, currentTargetValidationOptions());
   const codexOwnsInitialRebase =
-    isAutomergeRepairJob() && fixArtifact.deterministic_rebase_only !== true;
+    isBranchRepairStatusJob() && fixArtifact.deterministic_rebase_only !== true;
   let rebaseResult = null;
   let fastRepair: LooseRecord = {
     status: "disabled",
@@ -2164,7 +2164,7 @@ function updateAutomergeProgressStatus({
   details = null,
   headSha = null,
 }: LooseRecord) {
-  if (!isAutomergeRepairJob() || dryRun) return false;
+  if (!isBranchRepairStatusJob() || dryRun) return false;
   const target = automergeOutcomeTargetPrNumber();
   if (!target) return false;
   try {
@@ -3616,7 +3616,7 @@ function updateAutomergeStatusCommentForBranchRepair({
   commit,
   fastRepair = null,
 }: LooseRecord) {
-  if (!isAutomergeRepairJob()) return false;
+  if (!isBranchRepairStatusJob()) return false;
   if (Number(target) !== Number(automergeOutcomeTargetPrNumber())) return false;
   const existingStatus = findAutomergeStatusComment(target);
   const runUrl = currentActionsRunUrl();
@@ -3849,6 +3849,18 @@ function isAutomergeRepairJob() {
   );
 }
 
+function isSelfHealRepairJob() {
+  return (
+    job.frontmatter.source === "clawsweeper_self_rebase" ||
+    job.frontmatter.job_intent === "clawsweeper_self_rebase" ||
+    String(result.cluster_id ?? "").startsWith("self-heal-")
+  );
+}
+
+function isBranchRepairStatusJob() {
+  return isAutomergeRepairJob() || isSelfHealRepairJob();
+}
+
 function hasSuccessfulFixMutation(report: LooseRecord) {
   return (report.actions ?? []).some((action: JsonValue) => {
     const name = String(action.action ?? "");
@@ -3958,7 +3970,7 @@ function hasAutomergeStatusMarker(body: JsonValue, number: JsonValue) {
   const prefix = `<!-- clawsweeper-command-status:${Number.isFinite(issueNumber) ? issueNumber : "unknown"}:`;
   return (
     String(body ?? "").includes(prefix) &&
-    /clawsweeper-command-status:\d+:(?:automerge|clawsweeper_auto_repair|clawsweeper_auto_merge|maintainer_approve_automerge):/i.test(
+    /clawsweeper-command-status:\d+:(?:automerge|clawsweeper_auto_repair|clawsweeper_auto_merge|maintainer_approve_automerge|clawsweeper_self_rebase):/i.test(
       String(body ?? ""),
     )
   );

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -253,7 +253,7 @@ function preserveStateOnlyFiles({
 }
 
 function shouldPreserveStateOnlyFile(path: string, rel: string): boolean {
-  if (path === "jobs") return /^[^/]+\/inbox\/automerge-.+\.md$/.test(rel);
+  if (path === "jobs") return /^[^/]+\/inbox\/(?:automerge|self-heal)-.+\.md$/.test(rel);
   return false;
 }
 

--- a/src/repair/job-intent.ts
+++ b/src/repair/job-intent.ts
@@ -4,6 +4,7 @@ import type { JsonValue, LooseRecord } from "./json-types.js";
 export const REPAIR_JOB_INTENTS = [
   "repair_cluster",
   "automerge_pr",
+  "clawsweeper_self_rebase",
   "implement_issue",
   "commit_finding",
   "low_signal_pr_cleanup",
@@ -47,6 +48,7 @@ export function repairJobIntentForFrontmatter(frontmatter: LooseRecord): RepairJ
 
 export function workerLaneForRepairJobIntent(intent: RepairJobIntent): WorkerLane {
   if (intent === "automerge_pr") return "automerge_repair";
+  if (intent === "clawsweeper_self_rebase") return "automerge_repair";
   if (intent === "implement_issue") return "issue_implementation";
   return "repair";
 }

--- a/src/repair/lib.ts
+++ b/src/repair/lib.ts
@@ -193,6 +193,10 @@ export function validateJob(job: ParsedJob | LooseRecord) {
     "commit_sha",
     "clawsweeper_report_repo",
     "clawsweeper_report_path",
+    "expected_head_sha",
+    "self_heal_merge_state",
+    "self_heal_run_url",
+    "self_heal_target_pr",
   ]) {
     if (fm[key] !== undefined && typeof fm[key] !== "string") {
       errors.push(`${key} must be a string`);

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -16559,6 +16559,21 @@ test("cluster intake publishes generated repair state through state repo", () =>
   assert.match(workflow, /--path results\/cluster-repair-intake/);
 });
 
+test("conflict self-heal publishes exact-head jobs before worker dispatch", () => {
+  const source = readFileSync("src/repair/conflict-self-heal.ts", "utf8");
+  const writeIndex = source.indexOf("writeSelfHealJob(candidate);");
+  const publishIndex = source.indexOf("publishSelfHealJobs();");
+  const dispatchIndex = source.indexOf("dispatchRepair(candidate);");
+
+  assert.notEqual(writeIndex, -1);
+  assert.notEqual(publishIndex, -1);
+  assert.notEqual(dispatchIndex, -1);
+  assert.ok(writeIndex < publishIndex, "self-heal jobs must be written before state publish");
+  assert.ok(publishIndex < dispatchIndex, "self-heal jobs must be durable before worker dispatch");
+  assert.match(source, /CLAWSWEEPER_STATE_DIR is required/);
+  assert.match(source, /head SHA changed after state publish/);
+});
+
 test("review prompt asks for concise public review fields", () => {
   const prompt = readFileSync("prompts/review-item.md", "utf8");
 

--- a/test/repair/conflict-self-heal-core.test.ts
+++ b/test/repair/conflict-self-heal-core.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  renderSelfHealJob,
+  renderSelfHealStatusComment,
+  selfHealEligibility,
+  selfHealJobPath,
+  selfHealMergeStateReason,
+} from "../../dist/repair/conflict-self-heal-core.js";
+import { parseSimpleYaml, validateJob } from "../../dist/repair/lib.js";
+
+test("self-heal eligibility accepts ClawSweeper-owned dirty same-repo PRs", () => {
+  const result = selfHealEligibility({
+    repo: "openclaw/openclaw",
+    pull: {
+      state: "OPEN",
+      author: { __typename: "App", login: "clawsweeper" },
+      headRefName: "clawsweeper/repair-123",
+      headRefOid: "abc123",
+      headRepository: { nameWithOwner: "openclaw/openclaw" },
+      mergeStateStatus: "DIRTY",
+      labels: [],
+    },
+  });
+
+  assert.equal(result.eligible, true);
+  assert.equal(result.reason, "mergeStateStatus is DIRTY");
+});
+
+test("self-heal eligibility accepts conflicting mergeable state", () => {
+  assert.equal(
+    selfHealMergeStateReason({ mergeable: "CONFLICTING", mergeStateStatus: "CLEAN" }),
+    "mergeable is CONFLICTING",
+  );
+});
+
+test("self-heal eligibility skips paused, stale-owned, and fork PRs", () => {
+  const base = {
+    state: "OPEN",
+    author: { __typename: "App", login: "clawsweeper" },
+    headRefName: "clawsweeper/repair-123",
+    headRefOid: "abc123",
+    headRepository: { nameWithOwner: "openclaw/openclaw" },
+    mergeStateStatus: "BEHIND",
+  };
+
+  assert.match(
+    selfHealEligibility({
+      repo: "openclaw/openclaw",
+      pull: { ...base, labels: [{ name: "clawsweeper:human-review" }] },
+    }).reason,
+    /paused/,
+  );
+  assert.match(
+    selfHealEligibility({
+      repo: "openclaw/openclaw",
+      pull: { ...base, author: { __typename: "User", login: "octocat" }, labels: [] },
+    }).reason,
+    /author/,
+  );
+  assert.match(
+    selfHealEligibility({
+      repo: "openclaw/openclaw",
+      pull: { ...base, headRepository: { nameWithOwner: "octocat/openclaw" }, labels: [] },
+    }).reason,
+    /head repo/,
+  );
+});
+
+test("self-heal job path and rendered job validate with exact-head frontmatter", () => {
+  assert.equal(
+    selfHealJobPath("openclaw/openclaw", 89790),
+    "jobs/openclaw/inbox/self-heal-openclaw-openclaw-89790.md",
+  );
+  const job = renderSelfHealJob({
+    repo: "openclaw/openclaw",
+    issueNumber: 89790,
+    title: "fix conflict",
+    branch: "clawsweeper/fix-conflict",
+    headSha: "abc123",
+    mergeState: "mergeStateStatus is DIRTY",
+    runUrl: "https://github.com/openclaw/clawsweeper/actions/runs/1",
+  });
+  const frontmatter = parseSimpleYaml(job.match(/^---\n([\s\S]*?)\n---/)?.[1] ?? "");
+
+  assert.equal(frontmatter.job_intent, "clawsweeper_self_rebase");
+  assert.equal(frontmatter.source, "clawsweeper_self_rebase");
+  assert.equal(frontmatter.expected_head_sha, "abc123");
+  assert.equal(frontmatter.allow_merge, false);
+  assert.deepEqual(validateJob({ frontmatter }), []);
+  assert.match(job, /Do not merge or close this PR/);
+  assert.match(job, /clawsweeper:automerge/);
+});
+
+test("self-heal status comment is durable and says merge is not attempted", () => {
+  const body = renderSelfHealStatusComment({
+    repo: "openclaw/openclaw",
+    issueNumber: 90284,
+    headSha: "def456",
+    mergeState: "mergeable is CONFLICTING",
+    jobPath: "jobs/openclaw/inbox/self-heal-openclaw-openclaw-90284.md",
+    status: "dispatching",
+  });
+
+  assert.match(body, /clawsweeper-command-status:90284:clawsweeper_self_rebase:def456/);
+  assert.match(body, /mergeable is CONFLICTING/);
+  assert.match(body, /will not merge the PR/);
+  assert.match(body, /automerge\/merge-ready labels/);
+});

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -231,7 +231,7 @@ test("publishMainCommit publishes generated paths to state branch when state roo
   assert.throws(() => run("git", ["--git-dir", origin, "show", "main:results/ledger.txt"], root));
 });
 
-test("publishMainCommit preserves state-only automerge jobs on broad jobs publishes", () => {
+test("publishMainCommit preserves state-only queued jobs on broad jobs publishes", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
   const origin = path.join(root, "origin.git");
   const work = path.join(root, "work");
@@ -242,6 +242,10 @@ test("publishMainCommit preserves state-only automerge jobs on broad jobs publis
   write(
     path.join(state, "jobs/openclaw/inbox/automerge-openclaw-openclaw-75589.md"),
     "state automerge job\n",
+  );
+  write(
+    path.join(state, "jobs/openclaw/inbox/self-heal-openclaw-openclaw-85116.md"),
+    "state self-heal job\n",
   );
   write(path.join(state, "jobs/openclaw/inbox/ordinary.md"), "state ordinary job\n");
   run("git", ["add", "."], state);
@@ -277,6 +281,19 @@ test("publishMainCommit preserves state-only automerge jobs on broad jobs publis
       root,
     ),
     "state automerge job\n",
+  );
+  assert.equal(
+    run(
+      "git",
+      [
+        "--git-dir",
+        origin,
+        "show",
+        "state:jobs/openclaw/inbox/self-heal-openclaw-openclaw-85116.md",
+      ],
+      root,
+    ),
+    "state self-heal job\n",
   );
   assert.equal(
     run("git", ["--git-dir", origin, "show", "state:jobs/openclaw/inbox/new.md"], root),


### PR DESCRIPTION
## Summary

Adds a conservative self-heal lane for ClawSweeper-owned PR branches that are stuck behind or conflicting.

- Adds a conflict self-heal scanner/workflow for open same-repo `app/clawsweeper` PRs on `clawsweeper/` branches.
- Generates exact-head pinned repair jobs with `job_intent: clawsweeper_self_rebase` and durable marker-backed status comments.
- Verifies the live PR head SHA before repair worker execution, skipping stale jobs instead of mutating.
- Keeps self-heal non-merge/non-close: no automerge labels, no merge-ready labels, no loosened merge gates.
- Extends branch repair status/re-review behavior to self-heal jobs without enabling automerge outcome behavior.

## Safety

- Dry-run by default.
- Execute mode requires both `CLAWSWEEPER_ALLOW_EXECUTE=1` and `CLAWSWEEPER_ALLOW_FIX_PR=1`.
- Eligible only for open, same-repo, ClawSweeper-authored PRs with known exact head SHA.
- Skips `clawsweeper:human-review` and `clawsweeper:merge-ready`.
- Restored missing self-heal jobs are non-mutating placeholders with `expected_head_sha: "unknown"`.

## Validation

- `pnpm run format`
- `pnpm run build:repair`
- `node --test test/repair/conflict-self-heal-core.test.ts test/repair/comment-router-core.test.ts`
- `pnpm run repair:conflict-self-heal -- --repo openclaw/openclaw --max-prs 10` dry-run
- `pnpm run test:repair`
- `pnpm run check`
