### PR TITLE
Add bot-owned proof handling lane

### DIFF
--- a/.github/workflows/proof-nudges.yml
+++ b/.github/workflows/proof-nudges.yml
@@ -56,7 +56,7 @@ concurrency:
 jobs:
   proof-nudges:
     name: Proof nudges
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && vars.CLAWSWEEPER_PROOF_NUDGES_SCHEDULED == '1') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && (vars.CLAWSWEEPER_PROOF_NUDGES_SCHEDULED == '1' || vars.CLAWSWEEPER_BOT_PROOF_SCHEDULED == '1')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/proof-nudges.yml
+++ b/.github/workflows/proof-nudges.yml
@@ -29,6 +29,14 @@ on:
         description: "Optional comma-separated PR numbers to inspect first"
         required: false
         default: ""
+      bot_proof:
+        description: "Also inspect bot-owned PRs blocked on real behavior proof"
+        required: false
+        default: "false"
+      bot_proof_execute:
+        description: "Post bot-owned proof status comments and labels; false runs dry-run only"
+        required: false
+        default: "false"
   schedule:
     - cron: "0 10 * * *"
 
@@ -111,6 +119,8 @@ jobs:
           PROOF_NUDGES_LIMIT: ${{ github.event.inputs.limit || vars.CLAWSWEEPER_PROOF_NUDGES_LIMIT || '10' }}
           PROOF_NUDGES_MIN_AGE_DAYS: ${{ github.event.inputs.min_age_days || vars.CLAWSWEEPER_PROOF_NUDGES_MIN_AGE_DAYS || '5' }}
           PROOF_NUDGES_COOLDOWN_DAYS: ${{ github.event.inputs.cooldown_days || vars.CLAWSWEEPER_PROOF_NUDGES_COOLDOWN_DAYS || '7' }}
+          BOT_PROOF_ENABLED: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.bot_proof == 'true') || (github.event_name == 'schedule' && vars.CLAWSWEEPER_BOT_PROOF_SCHEDULED == '1') }}
+          BOT_PROOF_EXECUTE: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.bot_proof_execute == 'true') || (github.event_name == 'schedule' && vars.CLAWSWEEPER_BOT_PROOF_EXECUTE == '1') }}
         run: |
           set -euo pipefail
           for numeric_input in PROOF_NUDGES_LIMIT PROOF_NUDGES_MIN_AGE_DAYS PROOF_NUDGES_COOLDOWN_DAYS; do
@@ -141,9 +151,24 @@ jobs:
             "${item_numbers_arg[@]}" \
             "${execute_arg[@]}"
 
+          if [ "$BOT_PROOF_ENABLED" = "true" ]; then
+            bot_proof_execute_arg=()
+            if [ "$BOT_PROOF_EXECUTE" = "true" ]; then
+              bot_proof_execute_arg=(--execute)
+            fi
+            pnpm run bot-proof -- \
+              --target-repo "$TARGET_REPO" \
+              --limit "$PROOF_NUDGES_LIMIT" \
+              --report-path bot-proof-report.json \
+              "${item_numbers_arg[@]}" \
+              "${bot_proof_execute_arg[@]}"
+          fi
+
       - uses: actions/upload-artifact@v7
         if: ${{ always() }}
         with:
-          name: proof-nudge-report
-          path: proof-nudge-report.json
+          name: proof-handling-reports
+          path: |
+            proof-nudge-report.json
+            bot-proof-report.json
           if-no-files-found: ignore

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "apply-artifacts": "node dist/clawsweeper.js apply-artifacts",
     "apply-decisions": "node dist/clawsweeper.js apply-decisions",
     "proof-nudges": "node dist/clawsweeper.js proof-nudges",
+    "bot-proof": "node dist/clawsweeper.js bot-proof",
     "audit": "node dist/clawsweeper.js audit",
     "reconcile": "node dist/clawsweeper.js reconcile",
     "status": "node dist/clawsweeper.js status",

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -802,12 +802,6 @@ interface ProofLaneCandidate {
   sortAt: number;
 }
 
-interface ProofLaneProcessResult<Result> {
-  result: Result;
-  actionTaken: boolean;
-  progressMessage?: string | undefined;
-}
-
 interface ProofNudgeComment {
   author?: string | undefined;
   body?: string | undefined;
@@ -15693,66 +15687,6 @@ export function botProofCandidateRecordsForTest(
   return botProofCandidateRecords(itemsDir, requestedItemNumbers);
 }
 
-function runProofLaneCommand<
-  Result extends { action: string; number: number; reason: string },
->(options: {
-  laneName: string;
-  counterName: string;
-  limit: number;
-  processedLimit: number;
-  dryRun: boolean;
-  maxRuntimeMs: number;
-  reportPath: string;
-  candidates: readonly ProofLaneCandidate[];
-  startMessage: string;
-  stopMessage: string;
-  finishMessage: string;
-  makeRuntimeResult: (reason: string) => Result;
-  processCandidate: (candidate: ProofLaneCandidate) => ProofLaneProcessResult<Result>;
-}): void {
-  const startedAtMs = Date.now();
-  const results: Result[] = [];
-  let processedCount = 0;
-  let actionCount = 0;
-  const logProgress = (message: string): void => {
-    const counts = results.reduce<Record<string, number>>((accumulator, result) => {
-      accumulator[result.action] = (accumulator[result.action] ?? 0) + 1;
-      return accumulator;
-    }, {});
-    console.error(
-      [
-        `[${options.laneName}] ${new Date().toISOString()} ${message}`,
-        `${options.counterName}=${actionCount}/${options.limit}`,
-        `processed=${processedCount}/${options.processedLimit}`,
-        `dry_run=${options.dryRun}`,
-        `counts=${JSON.stringify(counts)}`,
-      ].join(" "),
-    );
-  };
-
-  logProgress(options.startMessage);
-  for (const candidate of options.candidates) {
-    if (actionCount >= options.limit) break;
-    if (processedCount >= options.processedLimit) break;
-    if (runtimeBudgetExceeded(startedAtMs, options.maxRuntimeMs, Date.now())) {
-      const reason = `max runtime ${options.maxRuntimeMs}ms reached`;
-      results.push(options.makeRuntimeResult(reason));
-      logProgress(`${options.stopMessage}: ${reason}`);
-      break;
-    }
-
-    const processed = options.processCandidate(candidate);
-    results.push(processed.result);
-    processedCount += 1;
-    if (processed.actionTaken) actionCount += 1;
-    if (processed.progressMessage) logProgress(processed.progressMessage);
-  }
-  ensureDir(dirname(options.reportPath));
-  writeFileSync(options.reportPath, JSON.stringify(results, null, 2), "utf8");
-  logProgress(options.finishMessage);
-  console.log(JSON.stringify(results, null, 2));
-}
-
 function proofNudgesCommand(args: Args): void {
   repoFromArgs(args);
   const itemsDir = resolve(stringArg(args.items_dir, defaultItemsDir()));
@@ -15778,144 +15712,156 @@ function proofNudgesCommand(args: Args): void {
   }
 
   const candidates = proofNudgeCandidateRecords(itemsDir, requestedItemNumbers);
-  runProofLaneCommand<ProofNudgeResult>({
-    laneName: "proof-nudges",
-    counterName: "nudges",
-    limit,
-    processedLimit,
-    dryRun,
-    maxRuntimeMs,
-    reportPath,
-    candidates,
-    startMessage: `starting proof nudges: candidates=${candidates.length} min_age_days=${minAgeDays} cooldown_days=${cooldownDays} item_numbers=${requestedItemNumbers.join(",") || "all"}`,
-    stopMessage: "stopping proof nudges",
-    finishMessage: "finished proof nudges",
-    makeRuntimeResult: (reason) => ({
-      repo: targetRepo(),
-      number: 0,
-      action: "skipped_runtime_budget",
-      reason,
-    }),
-    processCandidate: (candidate) => {
-      const resultBase = {
-        repo: markdownRepository(candidate.markdown, join(itemsDir, candidate.file)),
-        number: candidate.number,
-        reviewedAt: candidate.reviewedAt,
-      };
-      let item: Item;
-      let state: string;
-      try {
-        const fetched = fetchItem(candidate.number);
-        item = fetched.item;
-        state = fetched.state;
-      } catch (error) {
-        return {
-          result: {
-            ...resultBase,
-            action: "skipped_live_fetch_failed",
-            reason: proofNudgeLiveFetchFailureReason(error),
-          },
-          actionTaken: false,
-        };
-      }
-      if (state !== "open") {
-        return {
-          result: {
-            ...resultBase,
-            action: "skipped_not_open",
-            reason: `state is ${state}`,
-          },
-          actionTaken: false,
-        };
-      }
-      let pullDetails: Partial<ProofNudgePullRequestDetails> = {};
-      let comments: ProofNudgeComment[] = [];
-      let authorEditedAt: string | undefined;
-      let authorReviewActivityAt: string | undefined;
-      try {
-        pullDetails =
-          item.kind === "pull_request" ? fetchPullRequestProofNudgeDetails(candidate.number) : {};
-        comments = item.kind === "pull_request" ? proofNudgeComments(candidate.number) : [];
-        authorEditedAt =
-          item.kind === "pull_request"
-            ? latestAuthorPullRequestEditAt(candidate.number, item.author)
-            : undefined;
-        authorReviewActivityAt =
-          item.kind === "pull_request"
-            ? latestAuthorPullRequestReviewActivityAt(candidate.number, item.author)
-            : undefined;
-      } catch (error) {
-        return {
-          result: {
-            ...resultBase,
-            action: "skipped_live_fetch_failed",
-            reason: proofNudgeLiveFetchFailureReason(error),
-          },
-          actionTaken: false,
-        };
-      }
-      const eligibility = proofNudgeEligibility({
-        item,
-        markdown: candidate.markdown,
-        comments,
-        headSha: pullDetails.headSha,
-        headCommittedAt: pullDetails.headCommittedAt,
-        authorEditedAt,
-        authorReviewActivityAt,
-        minAgeDays,
-        cooldownDays,
-      });
-      if (!eligibility.eligible) {
-        return {
-          result: {
-            ...resultBase,
-            action: eligibility.action,
-            reason: eligibility.reason,
-            headSha: pullDetails.headSha,
-          },
-          actionTaken: false,
-        };
-      }
+  const startedAtMs = Date.now();
+  const results: ProofNudgeResult[] = [];
+  let processedCount = 0;
+  let nudgeCount = 0;
+  const logProgress = (message: string): void => {
+    const counts = results.reduce<Record<string, number>>((accumulator, result) => {
+      accumulator[result.action] = (accumulator[result.action] ?? 0) + 1;
+      return accumulator;
+    }, {});
+    console.error(
+      [
+        `[proof-nudges] ${new Date().toISOString()} ${message}`,
+        `nudges=${nudgeCount}/${limit}`,
+        `processed=${processedCount}/${processedLimit}`,
+        `dry_run=${dryRun}`,
+        `counts=${JSON.stringify(counts)}`,
+      ].join(" "),
+    );
+  };
 
-      const timestamp = new Date().toISOString();
-      const headSha = pullDetails.headSha;
-      if (!headSha) {
-        return {
-          result: {
-            ...resultBase,
-            action: "skipped_no_live_head",
-            reason: "live PR head SHA could not be inspected",
-          },
-          actionTaken: false,
-        };
-      }
-      const body = renderProofNudgeComment({ item, headSha, timestamp });
-      if (dryRun) {
-        return {
-          result: {
-            ...resultBase,
-            action: "proof_nudge_planned",
-            reason: eligibility.reason,
-            headSha,
-          },
-          actionTaken: true,
-          progressMessage: `planned proof nudge #${candidate.number}`,
-        };
-      }
+  logProgress(
+    `starting proof nudges: candidates=${candidates.length} min_age_days=${minAgeDays} cooldown_days=${cooldownDays} item_numbers=${requestedItemNumbers.join(",") || "all"}`,
+  );
+  for (const candidate of candidates) {
+    if (nudgeCount >= limit) break;
+    if (processedCount >= processedLimit) break;
+    if (runtimeBudgetExceeded(startedAtMs, maxRuntimeMs, Date.now())) {
+      results.push({
+        repo: targetRepo(),
+        number: 0,
+        action: "skipped_runtime_budget",
+        reason: `max runtime ${maxRuntimeMs}ms reached`,
+      });
+      logProgress(`stopping proof nudges: max runtime ${maxRuntimeMs}ms reached`);
+      break;
+    }
+
+    const resultBase = {
+      repo: markdownRepository(candidate.markdown, join(itemsDir, candidate.file)),
+      number: candidate.number,
+      reviewedAt: candidate.reviewedAt,
+    };
+    let item: Item;
+    let state: string;
+    try {
+      const fetched = fetchItem(candidate.number);
+      item = fetched.item;
+      state = fetched.state;
+    } catch (error) {
+      results.push({
+        ...resultBase,
+        action: "skipped_live_fetch_failed",
+        reason: proofNudgeLiveFetchFailureReason(error),
+      });
+      processedCount += 1;
+      continue;
+    }
+    if (state !== "open") {
+      results.push({
+        ...resultBase,
+        action: "skipped_not_open",
+        reason: `state is ${state}`,
+      });
+      processedCount += 1;
+      continue;
+    }
+    let pullDetails: Partial<ProofNudgePullRequestDetails> = {};
+    let comments: ProofNudgeComment[] = [];
+    let authorEditedAt: string | undefined;
+    let authorReviewActivityAt: string | undefined;
+    try {
+      pullDetails =
+        item.kind === "pull_request" ? fetchPullRequestProofNudgeDetails(candidate.number) : {};
+      comments = item.kind === "pull_request" ? proofNudgeComments(candidate.number) : [];
+      authorEditedAt =
+        item.kind === "pull_request"
+          ? latestAuthorPullRequestEditAt(candidate.number, item.author)
+          : undefined;
+      authorReviewActivityAt =
+        item.kind === "pull_request"
+          ? latestAuthorPullRequestReviewActivityAt(candidate.number, item.author)
+          : undefined;
+    } catch (error) {
+      results.push({
+        ...resultBase,
+        action: "skipped_live_fetch_failed",
+        reason: proofNudgeLiveFetchFailureReason(error),
+      });
+      processedCount += 1;
+      continue;
+    }
+    const eligibility = proofNudgeEligibility({
+      item,
+      markdown: candidate.markdown,
+      comments,
+      headSha: pullDetails.headSha,
+      headCommittedAt: pullDetails.headCommittedAt,
+      authorEditedAt,
+      authorReviewActivityAt,
+      minAgeDays,
+      cooldownDays,
+    });
+    if (!eligibility.eligible) {
+      results.push({
+        ...resultBase,
+        action: eligibility.action,
+        reason: eligibility.reason,
+        headSha: pullDetails.headSha,
+      });
+      processedCount += 1;
+      continue;
+    }
+
+    const timestamp = new Date().toISOString();
+    const headSha = pullDetails.headSha;
+    if (!headSha) {
+      results.push({
+        ...resultBase,
+        action: "skipped_no_live_head",
+        reason: "live PR head SHA could not be inspected",
+      });
+      processedCount += 1;
+      continue;
+    }
+    const body = renderProofNudgeComment({ item, headSha, timestamp });
+    if (dryRun) {
+      results.push({
+        ...resultBase,
+        action: "proof_nudge_planned",
+        reason: eligibility.reason,
+        headSha,
+      });
+    } else {
       const comment = postProofNudgeComment(candidate.number, body);
-      return {
-        result: {
-          ...resultBase,
-          action: "proof_nudge_posted",
-          reason: eligibility.reason,
-          url: commentUrl(comment) ?? undefined,
-          headSha,
-        },
-        actionTaken: true,
-        progressMessage: `posted proof nudge #${candidate.number}`,
-      };
-    },
-  });
+      results.push({
+        ...resultBase,
+        action: "proof_nudge_posted",
+        reason: eligibility.reason,
+        url: commentUrl(comment) ?? undefined,
+        headSha,
+      });
+    }
+    processedCount += 1;
+    nudgeCount += 1;
+    logProgress(`${dryRun ? "planned" : "posted"} proof nudge #${candidate.number}`);
+  }
+  ensureDir(dirname(reportPath));
+  writeFileSync(reportPath, JSON.stringify(results, null, 2), "utf8");
+  logProgress("finished proof nudges");
+  console.log(JSON.stringify(results, null, 2));
 }
 
 function botProofCommand(args: Args): void {
@@ -15938,128 +15884,141 @@ function botProofCommand(args: Args): void {
   }
 
   const candidates = botProofCandidateRecords(itemsDir, requestedItemNumbers);
-  runProofLaneCommand<BotProofResult>({
-    laneName: "bot-proof",
-    counterName: "actions",
-    limit,
-    processedLimit,
-    dryRun,
-    maxRuntimeMs,
-    reportPath,
-    candidates,
-    startMessage: `starting bot proof handling: candidates=${candidates.length} item_numbers=${requestedItemNumbers.join(",") || "all"}`,
-    stopMessage: "stopping bot proof handling",
-    finishMessage: "finished bot proof handling",
-    makeRuntimeResult: (reason) => ({
-      repo: targetRepo(),
-      number: 0,
-      action: "skipped_runtime_budget",
-      reason,
-    }),
-    processCandidate: (candidate) => {
-      const resultBase = {
-        repo: markdownRepository(candidate.markdown, join(itemsDir, candidate.file)),
-        number: candidate.number,
-        reviewedAt: candidate.reviewedAt,
-      };
-      let item: Item;
-      let state: string;
-      let pullDetails: Partial<ProofNudgePullRequestDetails> = {};
-      try {
-        const fetched = fetchItem(candidate.number);
-        item = fetched.item;
-        state = fetched.state;
-        pullDetails =
-          item.kind === "pull_request" ? fetchPullRequestProofNudgeDetails(candidate.number) : {};
-      } catch (error) {
-        return {
-          result: {
-            ...resultBase,
-            action: "skipped_live_fetch_failed",
-            reason: proofNudgeLiveFetchFailureReason(error),
-          },
-          actionTaken: false,
-        };
-      }
-      if (state !== "open") {
-        return {
-          result: {
-            ...resultBase,
-            action: "skipped_not_open",
-            reason: `state is ${state}`,
-          },
-          actionTaken: false,
-        };
-      }
-      const eligibility = botProofEligibility({
-        item,
-        markdown: candidate.markdown,
+  const startedAtMs = Date.now();
+  const results: BotProofResult[] = [];
+  let processedCount = 0;
+  let actionCount = 0;
+  const logProgress = (message: string): void => {
+    const counts = results.reduce<Record<string, number>>((accumulator, result) => {
+      accumulator[result.action] = (accumulator[result.action] ?? 0) + 1;
+      return accumulator;
+    }, {});
+    console.error(
+      [
+        `[bot-proof] ${new Date().toISOString()} ${message}`,
+        `actions=${actionCount}/${limit}`,
+        `processed=${processedCount}/${processedLimit}`,
+        `dry_run=${dryRun}`,
+        `counts=${JSON.stringify(counts)}`,
+      ].join(" "),
+    );
+  };
+
+  logProgress(
+    `starting bot proof handling: candidates=${candidates.length} item_numbers=${requestedItemNumbers.join(",") || "all"}`,
+  );
+  for (const candidate of candidates) {
+    if (actionCount >= limit) break;
+    if (processedCount >= processedLimit) break;
+    if (runtimeBudgetExceeded(startedAtMs, maxRuntimeMs, Date.now())) {
+      results.push({
+        repo: targetRepo(),
+        number: 0,
+        action: "skipped_runtime_budget",
+        reason: `max runtime ${maxRuntimeMs}ms reached`,
+      });
+      logProgress(`stopping bot proof handling: max runtime ${maxRuntimeMs}ms reached`);
+      break;
+    }
+
+    const resultBase = {
+      repo: markdownRepository(candidate.markdown, join(itemsDir, candidate.file)),
+      number: candidate.number,
+      reviewedAt: candidate.reviewedAt,
+    };
+    let item: Item;
+    let state: string;
+    let pullDetails: Partial<ProofNudgePullRequestDetails> = {};
+    try {
+      const fetched = fetchItem(candidate.number);
+      item = fetched.item;
+      state = fetched.state;
+      pullDetails =
+        item.kind === "pull_request" ? fetchPullRequestProofNudgeDetails(candidate.number) : {};
+    } catch (error) {
+      results.push({
+        ...resultBase,
+        action: "skipped_live_fetch_failed",
+        reason: proofNudgeLiveFetchFailureReason(error),
+      });
+      processedCount += 1;
+      continue;
+    }
+    if (state !== "open") {
+      results.push({
+        ...resultBase,
+        action: "skipped_not_open",
+        reason: `state is ${state}`,
+      });
+      processedCount += 1;
+      continue;
+    }
+    const eligibility = botProofEligibility({
+      item,
+      markdown: candidate.markdown,
+      headSha: pullDetails.headSha,
+      draft: pullDetails.draft,
+    });
+    if (!eligibility.eligible) {
+      results.push({
+        ...resultBase,
+        action: eligibility.action,
+        reason: eligibility.reason,
         headSha: pullDetails.headSha,
-        draft: pullDetails.draft,
       });
-      if (!eligibility.eligible) {
-        return {
-          result: {
-            ...resultBase,
-            action: eligibility.action,
-            reason: eligibility.reason,
-            headSha: pullDetails.headSha,
-          },
-          actionTaken: false,
-        };
-      }
-      const headSha = pullDetails.headSha;
-      if (!headSha) {
-        return {
-          result: {
-            ...resultBase,
-            action: "skipped_no_live_head",
-            reason: "live PR head SHA could not be inspected",
-          },
-          actionTaken: false,
-        };
-      }
-      const commentBody = renderBotProofDecisionComment({
-        item,
+      processedCount += 1;
+      continue;
+    }
+    const headSha = pullDetails.headSha;
+    if (!headSha) {
+      results.push({
+        ...resultBase,
+        action: "skipped_no_live_head",
+        reason: "live PR head SHA could not be inspected",
+      });
+      processedCount += 1;
+      continue;
+    }
+    const commentBody = renderBotProofDecisionComment({
+      item,
+      headSha,
+      markdown: candidate.markdown,
+      timestamp: new Date().toISOString(),
+      mantisRecommendation: eligibility.mantisRecommendation,
+    });
+    const labelResult = syncBotProofDecisionLabels({
+      number: candidate.number,
+      labels: item.labels,
+      dryRun,
+    });
+    if (dryRun) {
+      results.push({
+        ...resultBase,
+        action: eligibility.action,
+        reason: [eligibility.reason, labelResult.reason].filter(Boolean).join("; "),
         headSha,
-        markdown: candidate.markdown,
-        timestamp: new Date().toISOString(),
-        mantisRecommendation: eligibility.mantisRecommendation,
       });
-      const labelResult = syncBotProofDecisionLabels({
-        number: candidate.number,
-        labels: item.labels,
-        dryRun,
-      });
-      if (dryRun) {
-        return {
-          result: {
-            ...resultBase,
-            action: eligibility.action,
-            reason: [eligibility.reason, labelResult.reason].filter(Boolean).join("; "),
-            headSha,
-          },
-          actionTaken: true,
-          progressMessage: `planned bot proof handling #${candidate.number}`,
-        };
-      }
+    } else {
       const comment = upsertBotProofDecisionComment(candidate.number, headSha, commentBody);
-      return {
-        result: {
-          ...resultBase,
-          action:
-            eligibility.action === "bot_proof_mantis_request_planned"
-              ? "bot_proof_mantis_request_posted"
-              : "bot_proof_decision_posted",
-          reason: [eligibility.reason, labelResult.reason].filter(Boolean).join("; "),
-          url: commentUrl(comment) ?? undefined,
-          headSha,
-        },
-        actionTaken: true,
-        progressMessage: `posted bot proof handling #${candidate.number}`,
-      };
-    },
-  });
+      results.push({
+        ...resultBase,
+        action:
+          eligibility.action === "bot_proof_mantis_request_planned"
+            ? "bot_proof_mantis_request_posted"
+            : "bot_proof_decision_posted",
+        reason: [eligibility.reason, labelResult.reason].filter(Boolean).join("; "),
+        url: commentUrl(comment) ?? undefined,
+        headSha,
+      });
+    }
+    processedCount += 1;
+    actionCount += 1;
+    logProgress(`${dryRun ? "planned" : "posted"} bot proof handling #${candidate.number}`);
+  }
+  ensureDir(dirname(reportPath));
+  writeFileSync(reportPath, JSON.stringify(results, null, 2), "utf8");
+  logProgress("finished bot proof handling");
+  console.log(JSON.stringify(results, null, 2));
 }
 
 function applyArtifactsCommand(args: Args): void {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -10292,6 +10292,17 @@ function isClawSweeperAppAuthor(author: string | undefined): boolean {
   );
 }
 
+function hasDispatchableMantisScenario(recommendation: MantisRecommendation): boolean {
+  return (
+    recommendation.status === "recommended" &&
+    (recommendation.scenario === "telegram_live" ||
+      recommendation.scenario === "telegram_desktop_proof" ||
+      recommendation.scenario === "discord_status_reactions" ||
+      recommendation.scenario === "discord_thread_attachment" ||
+      recommendation.scenario === "slack_desktop_smoke")
+  );
+}
+
 function botProofEligibility(options: BotProofEligibilityOptions): BotProofEligibility {
   if (options.item.kind !== "pull_request") {
     return {
@@ -10347,7 +10358,7 @@ function botProofEligibility(options: BotProofEligibilityOptions): BotProofEligi
     };
   }
   const mantisRecommendation = reportMantisRecommendation(options.markdown);
-  if (mantisRecommendation.status === "recommended" && mantisRecommendation.scenario !== "none") {
+  if (hasDispatchableMantisScenario(mantisRecommendation)) {
     return {
       eligible: true,
       action: "bot_proof_mantis_request_planned",
@@ -10396,14 +10407,10 @@ function renderBotProofDecisionComment(options: {
     recommendation.scenario !== "none" &&
     recommendation.maintainerComment.trim()
   ) {
-    lines.push(
-      "",
-      "Mantis proof suggestion:",
-      "",
-      "```text",
-      recommendation.maintainerComment.trim(),
-      "```",
-    );
+    const heading = hasDispatchableMantisScenario(recommendation)
+      ? "Mantis proof suggestion:"
+      : "Possible manual Mantis/desktop proof suggestion:";
+    lines.push("", heading, "", "```text", recommendation.maintainerComment.trim(), "```");
   }
   lines.push("", marker);
   return lines.join("\n");

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -150,6 +150,7 @@ type PrStatusLabelKind =
   | "re_review_loop"
   | "actively_grinding"
   | "needs_proof"
+  | "needs_maintainer_proof_decision"
   | "waiting_on_author"
   | "ready_for_maintainer_look";
 type FeatureShowcaseStatus = "showcase" | "none";
@@ -756,10 +757,36 @@ type ProofNudgeAction =
   | "skipped_live_fetch_failed"
   | "skipped_runtime_budget";
 
+type BotProofAction =
+  | "bot_proof_mantis_request_posted"
+  | "bot_proof_mantis_request_planned"
+  | "bot_proof_decision_posted"
+  | "bot_proof_decision_planned"
+  | "skipped_not_pull_request"
+  | "skipped_not_open"
+  | "skipped_not_bot_authored"
+  | "skipped_draft"
+  | "skipped_policy_exempt"
+  | "skipped_stale_report_head"
+  | "skipped_no_live_head"
+  | "skipped_locked_conversation"
+  | "skipped_live_fetch_failed"
+  | "skipped_runtime_budget";
+
 interface ProofNudgeResult {
   repo?: string | undefined;
   number: number;
   action: ProofNudgeAction;
+  reason: string;
+  url?: string | undefined;
+  headSha?: string | undefined;
+  reviewedAt?: string | undefined;
+}
+
+interface BotProofResult {
+  repo?: string | undefined;
+  number: number;
+  action: BotProofAction;
   reason: string;
   url?: string | undefined;
   headSha?: string | undefined;
@@ -813,6 +840,30 @@ interface ProofNudgeEligibility {
   reason: string;
   latestActivityAt?: string | undefined;
   latestNudgeAt?: string | undefined;
+}
+
+interface BotProofEligibilityOptions {
+  item: Pick<
+    Item,
+    "kind" | "number" | "title" | "author" | "labels" | "locked" | "activeLockReason"
+  >;
+  markdown: string;
+  headSha?: string | undefined;
+  draft?: boolean | undefined;
+}
+
+interface BotProofEligibility {
+  eligible: boolean;
+  action: Exclude<
+    BotProofAction,
+    | "bot_proof_mantis_request_posted"
+    | "bot_proof_decision_posted"
+    | "skipped_not_open"
+    | "skipped_runtime_budget"
+    | "skipped_live_fetch_failed"
+  >;
+  reason: string;
+  mantisRecommendation?: MantisRecommendation | undefined;
 }
 
 interface ProofNudgePullRequestDetails {
@@ -945,6 +996,8 @@ const PROOF_SUPPLIED_LABEL = "proof: supplied";
 const REAL_BEHAVIOR_PROOF_REQUIRED_LABEL = "triage: needs-real-behavior-proof";
 const PROOF_NUDGE_MARKER_PREFIX = "<!-- clawsweeper-proof-nudge";
 const PROOF_NUDGE_MARKER_VERSION = "1";
+const BOT_PROOF_DECISION_MARKER_PREFIX = "<!-- clawsweeper-bot-proof-decision";
+const BOT_PROOF_DECISION_MARKER_VERSION = "1";
 const DEFAULT_PROOF_NUDGE_LIMIT = 10;
 const DEFAULT_PROOF_NUDGE_MIN_AGE_DAYS = 5;
 const DEFAULT_PROOF_NUDGE_COOLDOWN_DAYS = 7;
@@ -1049,6 +1102,12 @@ const PR_STATUS_LABELS = [
     color: "D93F0B",
     description:
       "The PR needs real behavior proof before ClawSweeper can clear the contributor ask.",
+  },
+  {
+    kind: "needs_maintainer_proof_decision",
+    name: "status: needs maintainer proof decision",
+    color: "D93F0B",
+    description: "A ClawSweeper-authored PR needs a maintainer proof capture or override decision.",
   },
   {
     kind: "waiting_on_author",
@@ -9808,6 +9867,21 @@ function realBehaviorProofNeedsContributorNudge(markdown: string): boolean {
   );
 }
 
+function realBehaviorProofBlocksBotOwnedMerge(markdown: string): boolean {
+  if (frontMatterValue(markdown, "review_status") !== "complete") return false;
+  if (frontMatterValue(markdown, "type") !== "pull_request") return false;
+  if (frontMatterStringArray(markdown, "labels").includes(PROOF_OVERRIDE_LABEL)) return false;
+  if (isDocsOnlyPullRequestReport(markdown)) return false;
+  const proof = reportRealBehaviorProof(markdown);
+  return (
+    proof.needsContributorAction ||
+    proof.status === "missing" ||
+    proof.status === "mock_only" ||
+    proof.status === "insufficient" ||
+    (proof.status !== "sufficient" && proof.status !== "override")
+  );
+}
+
 function normalizedLabelSet(labels: readonly string[]): Set<string> {
   return new Set(labels.map(normalizeLabelName));
 }
@@ -10193,6 +10267,154 @@ export function renderProofNudgeCommentForTest(options: {
     },
     headSha: options.headSha ?? "abc123def456",
     timestamp: options.timestamp ?? "2026-01-10T00:00:00.000Z",
+  });
+}
+
+function botProofDecisionMarker(options: { number: number; headSha: string }): string {
+  return `${BOT_PROOF_DECISION_MARKER_PREFIX} item="${options.number}" sha="${options.headSha}" v="${BOT_PROOF_DECISION_MARKER_VERSION}" -->`;
+}
+
+function isClawSweeperAppAuthor(author: string | undefined): boolean {
+  const normalized = author?.trim().toLowerCase();
+  return (
+    normalized === "app/clawsweeper" ||
+    normalized === "clawsweeper[bot]" ||
+    normalized === "openclaw-clawsweeper[bot]"
+  );
+}
+
+function botProofEligibility(options: BotProofEligibilityOptions): BotProofEligibility {
+  if (options.item.kind !== "pull_request") {
+    return {
+      eligible: false,
+      action: "skipped_not_pull_request",
+      reason: `type is ${options.item.kind}`,
+    };
+  }
+  if (!isClawSweeperAppAuthor(options.item.author)) {
+    return {
+      eligible: false,
+      action: "skipped_not_bot_authored",
+      reason: `author is ${options.item.author ?? "unknown"}`,
+    };
+  }
+  if (options.draft) {
+    return { eligible: false, action: "skipped_draft", reason: "pull request is draft" };
+  }
+  const lockedReason = lockedConversationApplyReason(options.item);
+  if (lockedReason) {
+    return { eligible: false, action: "skipped_locked_conversation", reason: lockedReason };
+  }
+  if (
+    hasNormalizedLabel(options.item.labels, PROOF_OVERRIDE_LABEL) ||
+    hasNormalizedLabel(options.item.labels, PROOF_SUFFICIENT_LABEL) ||
+    hasNormalizedLabel(options.item.labels, PROOF_SUPPLIED_LABEL)
+  ) {
+    return {
+      eligible: false,
+      action: "skipped_policy_exempt",
+      reason: "proof is already supplied, sufficient, or overridden",
+    };
+  }
+  if (!realBehaviorProofBlocksBotOwnedMerge(options.markdown)) {
+    return {
+      eligible: false,
+      action: "skipped_policy_exempt",
+      reason: "latest ClawSweeper review does not block merge on real behavior proof",
+    };
+  }
+  if (!options.headSha) {
+    return {
+      eligible: false,
+      action: "skipped_no_live_head",
+      reason: "live PR head SHA could not be inspected",
+    };
+  }
+  if (staleProofNudgeReportHead(options.markdown, options.headSha)) {
+    return {
+      eligible: false,
+      action: "skipped_stale_report_head",
+      reason: "live PR head SHA differs from the reviewed report",
+    };
+  }
+  const mantisRecommendation = reportMantisRecommendation(options.markdown);
+  if (mantisRecommendation.status === "recommended" && mantisRecommendation.scenario !== "none") {
+    return {
+      eligible: true,
+      action: "bot_proof_mantis_request_planned",
+      reason: "bot-authored PR is blocked on real behavior proof and has a Mantis proof suggestion",
+      mantisRecommendation,
+    };
+  }
+  return {
+    eligible: true,
+    action: "bot_proof_decision_planned",
+    reason: "bot-authored PR is blocked on real behavior proof and needs a maintainer decision",
+    mantisRecommendation,
+  };
+}
+
+export function botProofEligibilityForTest(
+  options: BotProofEligibilityOptions,
+): BotProofEligibility {
+  return botProofEligibility(options);
+}
+
+function renderBotProofDecisionComment(options: {
+  item: Pick<Item, "number" | "title">;
+  headSha: string;
+  markdown: string;
+  timestamp: string;
+  mantisRecommendation?: MantisRecommendation | undefined;
+}): string {
+  const marker = botProofDecisionMarker({ number: options.item.number, headSha: options.headSha });
+  const proof = reportRealBehaviorProof(options.markdown);
+  const lines = [
+    "ClawSweeper status: this ClawSweeper-authored replacement PR is blocked on real behavior proof.",
+    "",
+    `Reviewed head: \`${options.headSha}\``,
+    `Proof status: \`${proof.status}\``,
+    `Updated: ${options.timestamp}`,
+    "",
+    "Maintainer decision needed:",
+    "- capture real behavior proof for this head",
+    "- apply `proof: override` if the proof requirement should be waived",
+    "- pause or close the replacement if proof should not be pursued",
+  ];
+  const recommendation = options.mantisRecommendation;
+  if (
+    recommendation?.status === "recommended" &&
+    recommendation.scenario !== "none" &&
+    recommendation.maintainerComment.trim()
+  ) {
+    lines.push(
+      "",
+      "Mantis proof suggestion:",
+      "",
+      "```text",
+      recommendation.maintainerComment.trim(),
+      "```",
+    );
+  }
+  lines.push("", marker);
+  return lines.join("\n");
+}
+
+export function renderBotProofDecisionCommentForTest(options: {
+  number: number;
+  title?: string;
+  headSha?: string;
+  timestamp?: string;
+  markdown?: string;
+}): string {
+  return renderBotProofDecisionComment({
+    item: { number: options.number, title: options.title ?? "Bot proof sample" },
+    headSha: options.headSha ?? "abc123def456",
+    timestamp: options.timestamp ?? "2026-01-10T00:00:00.000Z",
+    markdown: options.markdown ?? "",
+    mantisRecommendation: options.markdown
+      ? reportMantisRecommendation(options.markdown)
+      : undefined,
   });
 }
 
@@ -15305,6 +15527,75 @@ function postProofNudgeComment(number: number, body: string): Record<string, unk
   ]);
 }
 
+function upsertBotProofDecisionComment(
+  number: number,
+  headSha: string,
+  body: string,
+): Record<string, unknown> {
+  const marker = botProofDecisionMarker({ number, headSha });
+  const existing = ghPaged<unknown>(`repos/${targetRepo()}/issues/${number}/comments?per_page=100`)
+    .map(asRecord)
+    .find((comment) => typeof comment.body === "string" && comment.body.includes(marker));
+  const payload = writeCommentPayload(number, body);
+  const existingId = commentId(existing);
+  if (existingId !== null && canPatchReviewComment(existing)) {
+    return ghJson<Record<string, unknown>>([
+      "api",
+      `repos/${targetRepo()}/issues/comments/${existingId}`,
+      "--method",
+      "PATCH",
+      "--input",
+      payload,
+      "--jq",
+      "{id,html_url}",
+    ]);
+  }
+  return ghJson<Record<string, unknown>>([
+    "api",
+    `repos/${targetRepo()}/issues/${number}/comments`,
+    "--method",
+    "POST",
+    "--input",
+    payload,
+    "--jq",
+    "{id,html_url}",
+  ]);
+}
+
+function syncBotProofDecisionLabels(options: {
+  number: number;
+  labels: readonly string[];
+  dryRun: boolean;
+}): { labels: string[]; changed: boolean; reason: string } {
+  const statusResult = syncPrStatusLabel({
+    number: options.number,
+    labels: options.labels,
+    statusKind: "needs_maintainer_proof_decision",
+    dryRun: options.dryRun,
+  });
+  const staleLabels = statusResult.labels.filter((label) => normalizeLabelName(label) === "stale");
+  const nextLabels = statusResult.labels.filter((label) => normalizeLabelName(label) !== "stale");
+  if (!options.dryRun) {
+    for (const label of staleLabels) {
+      ghWithRetry(["issue", "edit", String(options.number), "--remove-label", label]);
+    }
+  }
+  const changed = statusResult.changed || staleLabels.length > 0;
+  const reasons = [
+    statusResult.changed
+      ? options.dryRun
+        ? "would set maintainer proof decision status"
+        : "set maintainer proof decision status"
+      : null,
+    staleLabels.length > 0
+      ? options.dryRun
+        ? "would remove inherited stale label"
+        : "removed inherited stale label"
+      : null,
+  ].filter((reason): reason is string => Boolean(reason));
+  return { labels: nextLabels, changed, reason: reasons.join("; ") };
+}
+
 function proofNudgeCandidateRecords(
   itemsDir: string,
   requestedItemNumbers: readonly number[],
@@ -15344,6 +15635,49 @@ function proofNudgeCandidateRecords(
     );
 }
 
+function botProofCandidateRecords(
+  itemsDir: string,
+  requestedItemNumbers: readonly number[],
+): {
+  file: string;
+  markdown: string;
+  number: number;
+  likelyBotProof: boolean;
+  reviewedAt?: string | undefined;
+  sortAt: number;
+}[] {
+  const requested = new Set(requestedItemNumbers);
+  return markdownFiles(itemsDir)
+    .map((file) => {
+      const path = join(itemsDir, file);
+      const markdown = readFileSync(path, "utf8");
+      const number = numberForMarkdownFile(file);
+      const reviewedAt = frontMatterValue(markdown, "reviewed_at");
+      const sortAt =
+        timestampMs(reviewedAt) ??
+        timestampMs(frontMatterValue(markdown, "item_updated_at")) ??
+        Number.NEGATIVE_INFINITY;
+      const likelyBotProof =
+        frontMatterValue(markdown, "review_status") === "complete" &&
+        frontMatterValue(markdown, "type") === "pull_request" &&
+        isClawSweeperAppAuthor(frontMatterValue(markdown, "author")) &&
+        realBehaviorProofBlocksBotOwnedMerge(markdown);
+      return { file, markdown, number, likelyBotProof, reviewedAt, sortAt };
+    })
+    .filter(({ file, markdown, number }) => {
+      if (requested.size > 0 && !requested.has(number)) return false;
+      if (!isMarkdownForActiveRepo(markdown, join(itemsDir, file))) return false;
+      if (frontMatterValue(markdown, "type") !== "pull_request") return false;
+      return true;
+    })
+    .sort(
+      (left, right) =>
+        Number(right.likelyBotProof) - Number(left.likelyBotProof) ||
+        left.sortAt - right.sortAt ||
+        left.number - right.number,
+    );
+}
+
 function proofNudgeLiveFetchFailureReason(error: unknown): string {
   const rawMessage = error instanceof Error ? error.message : String(error);
   const lines = rawMessage
@@ -15360,6 +15694,13 @@ export function proofNudgeCandidateRecordsForTest(
   requestedItemNumbers: readonly number[] = [],
 ): ReturnType<typeof proofNudgeCandidateRecords> {
   return proofNudgeCandidateRecords(itemsDir, requestedItemNumbers);
+}
+
+export function botProofCandidateRecordsForTest(
+  itemsDir: string,
+  requestedItemNumbers: readonly number[] = [],
+): ReturnType<typeof botProofCandidateRecords> {
+  return botProofCandidateRecords(itemsDir, requestedItemNumbers);
 }
 
 function proofNudgesCommand(args: Args): void {
@@ -15535,6 +15876,162 @@ function proofNudgesCommand(args: Args): void {
   ensureDir(dirname(reportPath));
   writeFileSync(reportPath, JSON.stringify(results, null, 2), "utf8");
   logProgress("finished proof nudges");
+  console.log(JSON.stringify(results, null, 2));
+}
+
+function botProofCommand(args: Args): void {
+  repoFromArgs(args);
+  const itemsDir = resolve(stringArg(args.items_dir, defaultItemsDir()));
+  const limit = Math.max(0, numberArg(args.limit, DEFAULT_PROOF_NUDGE_LIMIT));
+  const processedLimit = Math.max(1, numberArg(args.processed_limit, Math.max(limit * 20, 50)));
+  const execute = boolArg(args.execute);
+  const dryRun = !execute;
+  const maxRuntimeMs = numberArg(args.max_runtime_ms, 0);
+  const reportPath = resolve(stringArg(args.report_path, join(ROOT, "bot-proof-report.json")));
+  const requestedItemNumbers = itemNumbersArg(args.item_numbers, args.item_number);
+  const startedAtMs = Date.now();
+  const results: BotProofResult[] = [];
+  let processedCount = 0;
+  let actionCount = 0;
+
+  if (!existsSync(itemsDir)) {
+    ensureDir(dirname(reportPath));
+    writeFileSync(reportPath, JSON.stringify(results, null, 2), "utf8");
+    console.log(JSON.stringify(results, null, 2));
+    return;
+  }
+
+  const candidates = botProofCandidateRecords(itemsDir, requestedItemNumbers);
+  const logProgress = (message: string): void => {
+    const counts = results.reduce<Record<string, number>>((accumulator, result) => {
+      accumulator[result.action] = (accumulator[result.action] ?? 0) + 1;
+      return accumulator;
+    }, {});
+    console.error(
+      [
+        `[bot-proof] ${new Date().toISOString()} ${message}`,
+        `actions=${actionCount}/${limit}`,
+        `processed=${processedCount}/${processedLimit}`,
+        `dry_run=${dryRun}`,
+        `counts=${JSON.stringify(counts)}`,
+      ].join(" "),
+    );
+  };
+
+  logProgress(
+    `starting bot proof handling: candidates=${candidates.length} item_numbers=${requestedItemNumbers.join(",") || "all"}`,
+  );
+  for (const candidate of candidates) {
+    if (actionCount >= limit) break;
+    if (processedCount >= processedLimit) break;
+    if (runtimeBudgetExceeded(startedAtMs, maxRuntimeMs, Date.now())) {
+      results.push({
+        repo: targetRepo(),
+        number: 0,
+        action: "skipped_runtime_budget",
+        reason: `max runtime ${maxRuntimeMs}ms reached`,
+      });
+      logProgress(`stopping bot proof handling: max runtime ${maxRuntimeMs}ms reached`);
+      break;
+    }
+
+    const resultBase = {
+      repo: markdownRepository(candidate.markdown, join(itemsDir, candidate.file)),
+      number: candidate.number,
+      reviewedAt: candidate.reviewedAt,
+    };
+    let item: Item;
+    let state: string;
+    let pullDetails: Partial<ProofNudgePullRequestDetails> = {};
+    try {
+      const fetched = fetchItem(candidate.number);
+      item = fetched.item;
+      state = fetched.state;
+      pullDetails =
+        item.kind === "pull_request" ? fetchPullRequestProofNudgeDetails(candidate.number) : {};
+    } catch (error) {
+      results.push({
+        ...resultBase,
+        action: "skipped_live_fetch_failed",
+        reason: proofNudgeLiveFetchFailureReason(error),
+      });
+      processedCount += 1;
+      continue;
+    }
+    if (state !== "open") {
+      results.push({
+        ...resultBase,
+        action: "skipped_not_open",
+        reason: `state is ${state}`,
+      });
+      processedCount += 1;
+      continue;
+    }
+    const eligibility = botProofEligibility({
+      item,
+      markdown: candidate.markdown,
+      headSha: pullDetails.headSha,
+      draft: pullDetails.draft,
+    });
+    if (!eligibility.eligible) {
+      results.push({
+        ...resultBase,
+        action: eligibility.action,
+        reason: eligibility.reason,
+        headSha: pullDetails.headSha,
+      });
+      processedCount += 1;
+      continue;
+    }
+    const headSha = pullDetails.headSha;
+    if (!headSha) {
+      results.push({
+        ...resultBase,
+        action: "skipped_no_live_head",
+        reason: "live PR head SHA could not be inspected",
+      });
+      processedCount += 1;
+      continue;
+    }
+    const commentBody = renderBotProofDecisionComment({
+      item,
+      headSha,
+      markdown: candidate.markdown,
+      timestamp: new Date().toISOString(),
+      mantisRecommendation: eligibility.mantisRecommendation,
+    });
+    const labelResult = syncBotProofDecisionLabels({
+      number: candidate.number,
+      labels: item.labels,
+      dryRun,
+    });
+    if (dryRun) {
+      results.push({
+        ...resultBase,
+        action: eligibility.action,
+        reason: [eligibility.reason, labelResult.reason].filter(Boolean).join("; "),
+        headSha,
+      });
+    } else {
+      const comment = upsertBotProofDecisionComment(candidate.number, headSha, commentBody);
+      results.push({
+        ...resultBase,
+        action:
+          eligibility.action === "bot_proof_mantis_request_planned"
+            ? "bot_proof_mantis_request_posted"
+            : "bot_proof_decision_posted",
+        reason: [eligibility.reason, labelResult.reason].filter(Boolean).join("; "),
+        url: commentUrl(comment) ?? undefined,
+        headSha,
+      });
+    }
+    processedCount += 1;
+    actionCount += 1;
+    logProgress(`${dryRun ? "planned" : "posted"} bot proof handling #${candidate.number}`);
+  }
+  ensureDir(dirname(reportPath));
+  writeFileSync(reportPath, JSON.stringify(results, null, 2), "utf8");
+  logProgress("finished bot proof handling");
   console.log(JSON.stringify(results, null, 2));
 }
 
@@ -16916,6 +17413,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
   else if (command === "apply-artifacts") applyArtifactsCommand(args);
   else if (command === "apply-decisions") await applyDecisionsCommand(args);
   else if (command === "proof-nudges") proofNudgesCommand(args);
+  else if (command === "bot-proof") botProofCommand(args);
   else if (command === "audit") auditCommand(args);
   else if (command === "reconcile") reconcileCommand(args);
   else if (command === "dashboard") {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -793,6 +793,21 @@ interface BotProofResult {
   reviewedAt?: string | undefined;
 }
 
+interface ProofLaneCandidate {
+  file: string;
+  markdown: string;
+  number: number;
+  likely: boolean;
+  reviewedAt?: string | undefined;
+  sortAt: number;
+}
+
+interface ProofLaneProcessResult<Result> {
+  result: Result;
+  actionTaken: boolean;
+  progressMessage?: string | undefined;
+}
+
 interface ProofNudgeComment {
   author?: string | undefined;
   body?: string | undefined;
@@ -15596,17 +15611,11 @@ function syncBotProofDecisionLabels(options: {
   return { labels: nextLabels, changed, reason: reasons.join("; ") };
 }
 
-function proofNudgeCandidateRecords(
+function proofLaneCandidateRecords(
   itemsDir: string,
   requestedItemNumbers: readonly number[],
-): {
-  file: string;
-  markdown: string;
-  number: number;
-  likelyProofNudge: boolean;
-  reviewedAt?: string | undefined;
-  sortAt: number;
-}[] {
+  likely: (markdown: string) => boolean,
+): ProofLaneCandidate[] {
   const requested = new Set(requestedItemNumbers);
   return markdownFiles(itemsDir)
     .map((file) => {
@@ -15618,8 +15627,7 @@ function proofNudgeCandidateRecords(
         timestampMs(reviewedAt) ??
         timestampMs(frontMatterValue(markdown, "item_updated_at")) ??
         Number.NEGATIVE_INFINITY;
-      const likelyProofNudge = realBehaviorProofNeedsContributorNudge(markdown);
-      return { file, markdown, number, likelyProofNudge, reviewedAt, sortAt };
+      return { file, markdown, number, likely: likely(markdown), reviewedAt, sortAt };
     })
     .filter(({ file, markdown, number }) => {
       if (requested.size > 0 && !requested.has(number)) return false;
@@ -15629,53 +15637,35 @@ function proofNudgeCandidateRecords(
     })
     .sort(
       (left, right) =>
-        Number(right.likelyProofNudge) - Number(left.likelyProofNudge) ||
+        Number(right.likely) - Number(left.likely) ||
         left.sortAt - right.sortAt ||
         left.number - right.number,
     );
 }
 
+function proofNudgeCandidateRecords(
+  itemsDir: string,
+  requestedItemNumbers: readonly number[],
+): (ProofLaneCandidate & { likelyProofNudge: boolean })[] {
+  return proofLaneCandidateRecords(
+    itemsDir,
+    requestedItemNumbers,
+    realBehaviorProofNeedsContributorNudge,
+  ).map((candidate) => ({ ...candidate, likelyProofNudge: candidate.likely }));
+}
+
 function botProofCandidateRecords(
   itemsDir: string,
   requestedItemNumbers: readonly number[],
-): {
-  file: string;
-  markdown: string;
-  number: number;
-  likelyBotProof: boolean;
-  reviewedAt?: string | undefined;
-  sortAt: number;
-}[] {
-  const requested = new Set(requestedItemNumbers);
-  return markdownFiles(itemsDir)
-    .map((file) => {
-      const path = join(itemsDir, file);
-      const markdown = readFileSync(path, "utf8");
-      const number = numberForMarkdownFile(file);
-      const reviewedAt = frontMatterValue(markdown, "reviewed_at");
-      const sortAt =
-        timestampMs(reviewedAt) ??
-        timestampMs(frontMatterValue(markdown, "item_updated_at")) ??
-        Number.NEGATIVE_INFINITY;
-      const likelyBotProof =
-        frontMatterValue(markdown, "review_status") === "complete" &&
-        frontMatterValue(markdown, "type") === "pull_request" &&
-        isClawSweeperAppAuthor(frontMatterValue(markdown, "author")) &&
-        realBehaviorProofBlocksBotOwnedMerge(markdown);
-      return { file, markdown, number, likelyBotProof, reviewedAt, sortAt };
-    })
-    .filter(({ file, markdown, number }) => {
-      if (requested.size > 0 && !requested.has(number)) return false;
-      if (!isMarkdownForActiveRepo(markdown, join(itemsDir, file))) return false;
-      if (frontMatterValue(markdown, "type") !== "pull_request") return false;
-      return true;
-    })
-    .sort(
-      (left, right) =>
-        Number(right.likelyBotProof) - Number(left.likelyBotProof) ||
-        left.sortAt - right.sortAt ||
-        left.number - right.number,
+): (ProofLaneCandidate & { likelyBotProof: boolean })[] {
+  return proofLaneCandidateRecords(itemsDir, requestedItemNumbers, (markdown) => {
+    return (
+      frontMatterValue(markdown, "review_status") === "complete" &&
+      frontMatterValue(markdown, "type") === "pull_request" &&
+      isClawSweeperAppAuthor(frontMatterValue(markdown, "author")) &&
+      realBehaviorProofBlocksBotOwnedMerge(markdown)
     );
+  }).map((candidate) => ({ ...candidate, likelyBotProof: candidate.likely }));
 }
 
 function proofNudgeLiveFetchFailureReason(error: unknown): string {
@@ -15703,6 +15693,66 @@ export function botProofCandidateRecordsForTest(
   return botProofCandidateRecords(itemsDir, requestedItemNumbers);
 }
 
+function runProofLaneCommand<
+  Result extends { action: string; number: number; reason: string },
+>(options: {
+  laneName: string;
+  counterName: string;
+  limit: number;
+  processedLimit: number;
+  dryRun: boolean;
+  maxRuntimeMs: number;
+  reportPath: string;
+  candidates: readonly ProofLaneCandidate[];
+  startMessage: string;
+  stopMessage: string;
+  finishMessage: string;
+  makeRuntimeResult: (reason: string) => Result;
+  processCandidate: (candidate: ProofLaneCandidate) => ProofLaneProcessResult<Result>;
+}): void {
+  const startedAtMs = Date.now();
+  const results: Result[] = [];
+  let processedCount = 0;
+  let actionCount = 0;
+  const logProgress = (message: string): void => {
+    const counts = results.reduce<Record<string, number>>((accumulator, result) => {
+      accumulator[result.action] = (accumulator[result.action] ?? 0) + 1;
+      return accumulator;
+    }, {});
+    console.error(
+      [
+        `[${options.laneName}] ${new Date().toISOString()} ${message}`,
+        `${options.counterName}=${actionCount}/${options.limit}`,
+        `processed=${processedCount}/${options.processedLimit}`,
+        `dry_run=${options.dryRun}`,
+        `counts=${JSON.stringify(counts)}`,
+      ].join(" "),
+    );
+  };
+
+  logProgress(options.startMessage);
+  for (const candidate of options.candidates) {
+    if (actionCount >= options.limit) break;
+    if (processedCount >= options.processedLimit) break;
+    if (runtimeBudgetExceeded(startedAtMs, options.maxRuntimeMs, Date.now())) {
+      const reason = `max runtime ${options.maxRuntimeMs}ms reached`;
+      results.push(options.makeRuntimeResult(reason));
+      logProgress(`${options.stopMessage}: ${reason}`);
+      break;
+    }
+
+    const processed = options.processCandidate(candidate);
+    results.push(processed.result);
+    processedCount += 1;
+    if (processed.actionTaken) actionCount += 1;
+    if (processed.progressMessage) logProgress(processed.progressMessage);
+  }
+  ensureDir(dirname(options.reportPath));
+  writeFileSync(options.reportPath, JSON.stringify(results, null, 2), "utf8");
+  logProgress(options.finishMessage);
+  console.log(JSON.stringify(results, null, 2));
+}
+
 function proofNudgesCommand(args: Args): void {
   repoFromArgs(args);
   const itemsDir = resolve(stringArg(args.items_dir, defaultItemsDir()));
@@ -15718,12 +15768,9 @@ function proofNudgesCommand(args: Args): void {
   const maxRuntimeMs = numberArg(args.max_runtime_ms, 0);
   const reportPath = resolve(stringArg(args.report_path, join(ROOT, "proof-nudge-report.json")));
   const requestedItemNumbers = itemNumbersArg(args.item_numbers, args.item_number);
-  const startedAtMs = Date.now();
-  const results: ProofNudgeResult[] = [];
-  let processedCount = 0;
-  let nudgeCount = 0;
 
   if (!existsSync(itemsDir)) {
+    const results: ProofNudgeResult[] = [];
     ensureDir(dirname(reportPath));
     writeFileSync(reportPath, JSON.stringify(results, null, 2), "utf8");
     console.log(JSON.stringify(results, null, 2));
@@ -15731,152 +15778,144 @@ function proofNudgesCommand(args: Args): void {
   }
 
   const candidates = proofNudgeCandidateRecords(itemsDir, requestedItemNumbers);
-  const logProgress = (message: string): void => {
-    const counts = results.reduce<Record<string, number>>((accumulator, result) => {
-      accumulator[result.action] = (accumulator[result.action] ?? 0) + 1;
-      return accumulator;
-    }, {});
-    console.error(
-      [
-        `[proof-nudges] ${new Date().toISOString()} ${message}`,
-        `nudges=${nudgeCount}/${limit}`,
-        `processed=${processedCount}/${processedLimit}`,
-        `dry_run=${dryRun}`,
-        `counts=${JSON.stringify(counts)}`,
-      ].join(" "),
-    );
-  };
-
-  logProgress(
-    `starting proof nudges: candidates=${candidates.length} min_age_days=${minAgeDays} cooldown_days=${cooldownDays} item_numbers=${requestedItemNumbers.join(",") || "all"}`,
-  );
-  for (const candidate of candidates) {
-    if (nudgeCount >= limit) break;
-    if (processedCount >= processedLimit) break;
-    if (runtimeBudgetExceeded(startedAtMs, maxRuntimeMs, Date.now())) {
-      results.push({
-        repo: targetRepo(),
-        number: 0,
-        action: "skipped_runtime_budget",
-        reason: `max runtime ${maxRuntimeMs}ms reached`,
-      });
-      logProgress(`stopping proof nudges: max runtime ${maxRuntimeMs}ms reached`);
-      break;
-    }
-
-    const resultBase = {
-      repo: markdownRepository(candidate.markdown, join(itemsDir, candidate.file)),
-      number: candidate.number,
-      reviewedAt: candidate.reviewedAt,
-    };
-    let item: Item;
-    let state: string;
-    try {
-      const fetched = fetchItem(candidate.number);
-      item = fetched.item;
-      state = fetched.state;
-    } catch (error) {
-      results.push({
-        ...resultBase,
-        action: "skipped_live_fetch_failed",
-        reason: proofNudgeLiveFetchFailureReason(error),
-      });
-      processedCount += 1;
-      continue;
-    }
-    if (state !== "open") {
-      results.push({
-        ...resultBase,
-        action: "skipped_not_open",
-        reason: `state is ${state}`,
-      });
-      processedCount += 1;
-      continue;
-    }
-    let pullDetails: Partial<ProofNudgePullRequestDetails> = {};
-    let comments: ProofNudgeComment[] = [];
-    let authorEditedAt: string | undefined;
-    let authorReviewActivityAt: string | undefined;
-    try {
-      pullDetails =
-        item.kind === "pull_request" ? fetchPullRequestProofNudgeDetails(candidate.number) : {};
-      comments = item.kind === "pull_request" ? proofNudgeComments(candidate.number) : [];
-      authorEditedAt =
-        item.kind === "pull_request"
-          ? latestAuthorPullRequestEditAt(candidate.number, item.author)
-          : undefined;
-      authorReviewActivityAt =
-        item.kind === "pull_request"
-          ? latestAuthorPullRequestReviewActivityAt(candidate.number, item.author)
-          : undefined;
-    } catch (error) {
-      results.push({
-        ...resultBase,
-        action: "skipped_live_fetch_failed",
-        reason: proofNudgeLiveFetchFailureReason(error),
-      });
-      processedCount += 1;
-      continue;
-    }
-    const eligibility = proofNudgeEligibility({
-      item,
-      markdown: candidate.markdown,
-      comments,
-      headSha: pullDetails.headSha,
-      headCommittedAt: pullDetails.headCommittedAt,
-      authorEditedAt,
-      authorReviewActivityAt,
-      minAgeDays,
-      cooldownDays,
-    });
-    if (!eligibility.eligible) {
-      results.push({
-        ...resultBase,
-        action: eligibility.action,
-        reason: eligibility.reason,
+  runProofLaneCommand<ProofNudgeResult>({
+    laneName: "proof-nudges",
+    counterName: "nudges",
+    limit,
+    processedLimit,
+    dryRun,
+    maxRuntimeMs,
+    reportPath,
+    candidates,
+    startMessage: `starting proof nudges: candidates=${candidates.length} min_age_days=${minAgeDays} cooldown_days=${cooldownDays} item_numbers=${requestedItemNumbers.join(",") || "all"}`,
+    stopMessage: "stopping proof nudges",
+    finishMessage: "finished proof nudges",
+    makeRuntimeResult: (reason) => ({
+      repo: targetRepo(),
+      number: 0,
+      action: "skipped_runtime_budget",
+      reason,
+    }),
+    processCandidate: (candidate) => {
+      const resultBase = {
+        repo: markdownRepository(candidate.markdown, join(itemsDir, candidate.file)),
+        number: candidate.number,
+        reviewedAt: candidate.reviewedAt,
+      };
+      let item: Item;
+      let state: string;
+      try {
+        const fetched = fetchItem(candidate.number);
+        item = fetched.item;
+        state = fetched.state;
+      } catch (error) {
+        return {
+          result: {
+            ...resultBase,
+            action: "skipped_live_fetch_failed",
+            reason: proofNudgeLiveFetchFailureReason(error),
+          },
+          actionTaken: false,
+        };
+      }
+      if (state !== "open") {
+        return {
+          result: {
+            ...resultBase,
+            action: "skipped_not_open",
+            reason: `state is ${state}`,
+          },
+          actionTaken: false,
+        };
+      }
+      let pullDetails: Partial<ProofNudgePullRequestDetails> = {};
+      let comments: ProofNudgeComment[] = [];
+      let authorEditedAt: string | undefined;
+      let authorReviewActivityAt: string | undefined;
+      try {
+        pullDetails =
+          item.kind === "pull_request" ? fetchPullRequestProofNudgeDetails(candidate.number) : {};
+        comments = item.kind === "pull_request" ? proofNudgeComments(candidate.number) : [];
+        authorEditedAt =
+          item.kind === "pull_request"
+            ? latestAuthorPullRequestEditAt(candidate.number, item.author)
+            : undefined;
+        authorReviewActivityAt =
+          item.kind === "pull_request"
+            ? latestAuthorPullRequestReviewActivityAt(candidate.number, item.author)
+            : undefined;
+      } catch (error) {
+        return {
+          result: {
+            ...resultBase,
+            action: "skipped_live_fetch_failed",
+            reason: proofNudgeLiveFetchFailureReason(error),
+          },
+          actionTaken: false,
+        };
+      }
+      const eligibility = proofNudgeEligibility({
+        item,
+        markdown: candidate.markdown,
+        comments,
         headSha: pullDetails.headSha,
+        headCommittedAt: pullDetails.headCommittedAt,
+        authorEditedAt,
+        authorReviewActivityAt,
+        minAgeDays,
+        cooldownDays,
       });
-      processedCount += 1;
-      continue;
-    }
+      if (!eligibility.eligible) {
+        return {
+          result: {
+            ...resultBase,
+            action: eligibility.action,
+            reason: eligibility.reason,
+            headSha: pullDetails.headSha,
+          },
+          actionTaken: false,
+        };
+      }
 
-    const timestamp = new Date().toISOString();
-    const headSha = pullDetails.headSha;
-    if (!headSha) {
-      results.push({
-        ...resultBase,
-        action: "skipped_no_live_head",
-        reason: "live PR head SHA could not be inspected",
-      });
-      processedCount += 1;
-      continue;
-    }
-    const body = renderProofNudgeComment({ item, headSha, timestamp });
-    if (dryRun) {
-      results.push({
-        ...resultBase,
-        action: "proof_nudge_planned",
-        reason: eligibility.reason,
-        headSha,
-      });
-    } else {
+      const timestamp = new Date().toISOString();
+      const headSha = pullDetails.headSha;
+      if (!headSha) {
+        return {
+          result: {
+            ...resultBase,
+            action: "skipped_no_live_head",
+            reason: "live PR head SHA could not be inspected",
+          },
+          actionTaken: false,
+        };
+      }
+      const body = renderProofNudgeComment({ item, headSha, timestamp });
+      if (dryRun) {
+        return {
+          result: {
+            ...resultBase,
+            action: "proof_nudge_planned",
+            reason: eligibility.reason,
+            headSha,
+          },
+          actionTaken: true,
+          progressMessage: `planned proof nudge #${candidate.number}`,
+        };
+      }
       const comment = postProofNudgeComment(candidate.number, body);
-      results.push({
-        ...resultBase,
-        action: "proof_nudge_posted",
-        reason: eligibility.reason,
-        url: commentUrl(comment) ?? undefined,
-        headSha,
-      });
-    }
-    processedCount += 1;
-    nudgeCount += 1;
-    logProgress(`${dryRun ? "planned" : "posted"} proof nudge #${candidate.number}`);
-  }
-  ensureDir(dirname(reportPath));
-  writeFileSync(reportPath, JSON.stringify(results, null, 2), "utf8");
-  logProgress("finished proof nudges");
-  console.log(JSON.stringify(results, null, 2));
+      return {
+        result: {
+          ...resultBase,
+          action: "proof_nudge_posted",
+          reason: eligibility.reason,
+          url: commentUrl(comment) ?? undefined,
+          headSha,
+        },
+        actionTaken: true,
+        progressMessage: `posted proof nudge #${candidate.number}`,
+      };
+    },
+  });
 }
 
 function botProofCommand(args: Args): void {
@@ -15889,12 +15928,9 @@ function botProofCommand(args: Args): void {
   const maxRuntimeMs = numberArg(args.max_runtime_ms, 0);
   const reportPath = resolve(stringArg(args.report_path, join(ROOT, "bot-proof-report.json")));
   const requestedItemNumbers = itemNumbersArg(args.item_numbers, args.item_number);
-  const startedAtMs = Date.now();
-  const results: BotProofResult[] = [];
-  let processedCount = 0;
-  let actionCount = 0;
 
   if (!existsSync(itemsDir)) {
+    const results: BotProofResult[] = [];
     ensureDir(dirname(reportPath));
     writeFileSync(reportPath, JSON.stringify(results, null, 2), "utf8");
     console.log(JSON.stringify(results, null, 2));
@@ -15902,137 +15938,128 @@ function botProofCommand(args: Args): void {
   }
 
   const candidates = botProofCandidateRecords(itemsDir, requestedItemNumbers);
-  const logProgress = (message: string): void => {
-    const counts = results.reduce<Record<string, number>>((accumulator, result) => {
-      accumulator[result.action] = (accumulator[result.action] ?? 0) + 1;
-      return accumulator;
-    }, {});
-    console.error(
-      [
-        `[bot-proof] ${new Date().toISOString()} ${message}`,
-        `actions=${actionCount}/${limit}`,
-        `processed=${processedCount}/${processedLimit}`,
-        `dry_run=${dryRun}`,
-        `counts=${JSON.stringify(counts)}`,
-      ].join(" "),
-    );
-  };
-
-  logProgress(
-    `starting bot proof handling: candidates=${candidates.length} item_numbers=${requestedItemNumbers.join(",") || "all"}`,
-  );
-  for (const candidate of candidates) {
-    if (actionCount >= limit) break;
-    if (processedCount >= processedLimit) break;
-    if (runtimeBudgetExceeded(startedAtMs, maxRuntimeMs, Date.now())) {
-      results.push({
-        repo: targetRepo(),
-        number: 0,
-        action: "skipped_runtime_budget",
-        reason: `max runtime ${maxRuntimeMs}ms reached`,
-      });
-      logProgress(`stopping bot proof handling: max runtime ${maxRuntimeMs}ms reached`);
-      break;
-    }
-
-    const resultBase = {
-      repo: markdownRepository(candidate.markdown, join(itemsDir, candidate.file)),
-      number: candidate.number,
-      reviewedAt: candidate.reviewedAt,
-    };
-    let item: Item;
-    let state: string;
-    let pullDetails: Partial<ProofNudgePullRequestDetails> = {};
-    try {
-      const fetched = fetchItem(candidate.number);
-      item = fetched.item;
-      state = fetched.state;
-      pullDetails =
-        item.kind === "pull_request" ? fetchPullRequestProofNudgeDetails(candidate.number) : {};
-    } catch (error) {
-      results.push({
-        ...resultBase,
-        action: "skipped_live_fetch_failed",
-        reason: proofNudgeLiveFetchFailureReason(error),
-      });
-      processedCount += 1;
-      continue;
-    }
-    if (state !== "open") {
-      results.push({
-        ...resultBase,
-        action: "skipped_not_open",
-        reason: `state is ${state}`,
-      });
-      processedCount += 1;
-      continue;
-    }
-    const eligibility = botProofEligibility({
-      item,
-      markdown: candidate.markdown,
-      headSha: pullDetails.headSha,
-      draft: pullDetails.draft,
-    });
-    if (!eligibility.eligible) {
-      results.push({
-        ...resultBase,
-        action: eligibility.action,
-        reason: eligibility.reason,
+  runProofLaneCommand<BotProofResult>({
+    laneName: "bot-proof",
+    counterName: "actions",
+    limit,
+    processedLimit,
+    dryRun,
+    maxRuntimeMs,
+    reportPath,
+    candidates,
+    startMessage: `starting bot proof handling: candidates=${candidates.length} item_numbers=${requestedItemNumbers.join(",") || "all"}`,
+    stopMessage: "stopping bot proof handling",
+    finishMessage: "finished bot proof handling",
+    makeRuntimeResult: (reason) => ({
+      repo: targetRepo(),
+      number: 0,
+      action: "skipped_runtime_budget",
+      reason,
+    }),
+    processCandidate: (candidate) => {
+      const resultBase = {
+        repo: markdownRepository(candidate.markdown, join(itemsDir, candidate.file)),
+        number: candidate.number,
+        reviewedAt: candidate.reviewedAt,
+      };
+      let item: Item;
+      let state: string;
+      let pullDetails: Partial<ProofNudgePullRequestDetails> = {};
+      try {
+        const fetched = fetchItem(candidate.number);
+        item = fetched.item;
+        state = fetched.state;
+        pullDetails =
+          item.kind === "pull_request" ? fetchPullRequestProofNudgeDetails(candidate.number) : {};
+      } catch (error) {
+        return {
+          result: {
+            ...resultBase,
+            action: "skipped_live_fetch_failed",
+            reason: proofNudgeLiveFetchFailureReason(error),
+          },
+          actionTaken: false,
+        };
+      }
+      if (state !== "open") {
+        return {
+          result: {
+            ...resultBase,
+            action: "skipped_not_open",
+            reason: `state is ${state}`,
+          },
+          actionTaken: false,
+        };
+      }
+      const eligibility = botProofEligibility({
+        item,
+        markdown: candidate.markdown,
         headSha: pullDetails.headSha,
+        draft: pullDetails.draft,
       });
-      processedCount += 1;
-      continue;
-    }
-    const headSha = pullDetails.headSha;
-    if (!headSha) {
-      results.push({
-        ...resultBase,
-        action: "skipped_no_live_head",
-        reason: "live PR head SHA could not be inspected",
-      });
-      processedCount += 1;
-      continue;
-    }
-    const commentBody = renderBotProofDecisionComment({
-      item,
-      headSha,
-      markdown: candidate.markdown,
-      timestamp: new Date().toISOString(),
-      mantisRecommendation: eligibility.mantisRecommendation,
-    });
-    const labelResult = syncBotProofDecisionLabels({
-      number: candidate.number,
-      labels: item.labels,
-      dryRun,
-    });
-    if (dryRun) {
-      results.push({
-        ...resultBase,
-        action: eligibility.action,
-        reason: [eligibility.reason, labelResult.reason].filter(Boolean).join("; "),
+      if (!eligibility.eligible) {
+        return {
+          result: {
+            ...resultBase,
+            action: eligibility.action,
+            reason: eligibility.reason,
+            headSha: pullDetails.headSha,
+          },
+          actionTaken: false,
+        };
+      }
+      const headSha = pullDetails.headSha;
+      if (!headSha) {
+        return {
+          result: {
+            ...resultBase,
+            action: "skipped_no_live_head",
+            reason: "live PR head SHA could not be inspected",
+          },
+          actionTaken: false,
+        };
+      }
+      const commentBody = renderBotProofDecisionComment({
+        item,
         headSha,
+        markdown: candidate.markdown,
+        timestamp: new Date().toISOString(),
+        mantisRecommendation: eligibility.mantisRecommendation,
       });
-    } else {
+      const labelResult = syncBotProofDecisionLabels({
+        number: candidate.number,
+        labels: item.labels,
+        dryRun,
+      });
+      if (dryRun) {
+        return {
+          result: {
+            ...resultBase,
+            action: eligibility.action,
+            reason: [eligibility.reason, labelResult.reason].filter(Boolean).join("; "),
+            headSha,
+          },
+          actionTaken: true,
+          progressMessage: `planned bot proof handling #${candidate.number}`,
+        };
+      }
       const comment = upsertBotProofDecisionComment(candidate.number, headSha, commentBody);
-      results.push({
-        ...resultBase,
-        action:
-          eligibility.action === "bot_proof_mantis_request_planned"
-            ? "bot_proof_mantis_request_posted"
-            : "bot_proof_decision_posted",
-        reason: [eligibility.reason, labelResult.reason].filter(Boolean).join("; "),
-        url: commentUrl(comment) ?? undefined,
-        headSha,
-      });
-    }
-    processedCount += 1;
-    actionCount += 1;
-    logProgress(`${dryRun ? "planned" : "posted"} bot proof handling #${candidate.number}`);
-  }
-  ensureDir(dirname(reportPath));
-  writeFileSync(reportPath, JSON.stringify(results, null, 2), "utf8");
-  logProgress("finished bot proof handling");
-  console.log(JSON.stringify(results, null, 2));
+      return {
+        result: {
+          ...resultBase,
+          action:
+            eligibility.action === "bot_proof_mantis_request_planned"
+              ? "bot_proof_mantis_request_posted"
+              : "bot_proof_decision_posted",
+          reason: [eligibility.reason, labelResult.reason].filter(Boolean).join("; "),
+          url: commentUrl(comment) ?? undefined,
+          headSha,
+        },
+        actionTaken: true,
+        progressMessage: `posted bot proof handling #${candidate.number}`,
+      };
+    },
+  });
 }
 
 function applyArtifactsCommand(args: Args): void {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -16269,7 +16269,13 @@ test("proof nudge workflow is manual-first and scheduled behind repo vars", () =
   assert.doesNotMatch(job, /steps\.central-time\.outputs\.should_run == 'true'/);
   assert.match(job, /github\.event_name == 'workflow_dispatch'/);
   assert.match(job, /vars\.CLAWSWEEPER_PROOF_NUDGES_SCHEDULED == '1'/);
+  assert.match(job, /vars\.CLAWSWEEPER_BOT_PROOF_SCHEDULED == '1'/);
   assert.match(job, /vars\.CLAWSWEEPER_PROOF_NUDGES_EXECUTE == '1'/);
+  assert.match(job, /vars\.CLAWSWEEPER_BOT_PROOF_EXECUTE == '1'/);
+  assert.match(
+    job,
+    /github\.event_name == 'schedule' && \(vars\.CLAWSWEEPER_PROOF_NUDGES_SCHEDULED == '1' \|\| vars\.CLAWSWEEPER_BOT_PROOF_SCHEDULED == '1'\)/,
+  );
   assert.match(job, /TARGET_REPO_INPUT:/);
   assert.match(job, /target_repo must be owner\/repo/);
   assert.match(job, /PROOF_NUDGES_ITEM_NUMBERS:/);

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -77,8 +77,11 @@ import {
   protectedLabels,
   realBehaviorProofMediaLabelsForTest,
   realBehaviorProofSufficientLabelsForTest,
+  botProofCandidateRecordsForTest,
+  botProofEligibilityForTest,
   relatedGitHubIssueSearchQueryForTest,
   relatedTitleSearchTerms,
+  renderBotProofDecisionCommentForTest,
   renderProofNudgeCommentForTest,
   renderReviewStartStatusComment,
   reviewArtifactDestination,
@@ -14693,6 +14696,10 @@ function proofNudgeReport(overrides = {}) {
     proofSummary: "The PR needs after-fix proof from a real setup.",
     securityReviewStatus: "cleared",
     securityReviewSummary: "No security-sensitive review is needed for this proof nudge.",
+    mantisStatus: "not_recommended",
+    mantisScenario: "none",
+    mantisReason: "Mantis proof is not useful for this sample.",
+    mantisComment: "",
     ...overrides,
   };
   return `---
@@ -14726,6 +14733,16 @@ Summary: ${values.proofSummary}
 Status: ${values.securityReviewStatus}
 
 Summary: ${values.securityReviewSummary}
+
+## Mantis Recommendation
+
+Status: ${values.mantisStatus}
+
+Scenario: ${values.mantisScenario}
+
+Reason: ${values.mantisReason}
+
+Maintainer comment: ${values.mantisComment}
 `;
 }
 
@@ -14742,6 +14759,146 @@ function proofNudgeItem(overrides = {}) {
     ...overrides,
   });
 }
+
+test("bot proof candidate scan prioritizes ClawSweeper proof blockers", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    writeFileSync(
+      join(root, "41.md"),
+      proofNudgeReport({
+        number: 41,
+        author: "contributor",
+        reviewedAt: "2026-01-05T00:00:00Z",
+      }),
+    );
+    writeFileSync(
+      join(root, "42.md"),
+      proofNudgeReport({
+        author: "app/clawsweeper",
+        reviewedAt: "2026-01-01T00:00:00Z",
+      }),
+    );
+
+    assert.deepEqual(
+      botProofCandidateRecordsForTest(root).map((candidate) => candidate.number),
+      [42, 41],
+    );
+    assert.deepEqual(
+      botProofCandidateRecordsForTest(root, [41]).map((candidate) => candidate.number),
+      [41],
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("bot proof handling selects maintainer or Mantis proof path for ClawSweeper PRs", () => {
+  const baseOptions = {
+    item: proofNudgeItem({
+      author: "app/clawsweeper",
+      labels: ["triage: needs-real-behavior-proof", "status: 📣 needs proof", "stale"],
+    }),
+    headSha: "abc123def456",
+  };
+  const decision = botProofEligibilityForTest({
+    ...baseOptions,
+    markdown: proofNudgeReport({ author: "app/clawsweeper" }),
+  });
+  assert.equal(decision.eligible, true);
+  assert.equal(decision.action, "bot_proof_decision_planned");
+
+  const mantis = botProofEligibilityForTest({
+    ...baseOptions,
+    markdown: proofNudgeReport({
+      author: "app/clawsweeper",
+      mantisStatus: "recommended",
+      mantisScenario: "visual_task",
+      mantisReason: "A visual proof task would show the fixed Control UI behavior.",
+      mantisComment: "@openclaw-mantis capture Control UI proof for this PR",
+    }),
+  });
+  assert.equal(mantis.eligible, true);
+  assert.equal(mantis.action, "bot_proof_mantis_request_planned");
+
+  assert.equal(
+    botProofEligibilityForTest({
+      item: proofNudgeItem({
+        author: "clawsweeper[bot]",
+        labels: ["status: 📣 needs proof"],
+      }),
+      markdown: proofNudgeReport({ author: "app/clawsweeper" }),
+      headSha: "abc123def456",
+    }).action,
+    "bot_proof_decision_planned",
+  );
+});
+
+test("bot proof handling skips overrides, stale heads, drafts, and non-ClawSweeper PRs", () => {
+  const baseItem = proofNudgeItem({
+    author: "app/clawsweeper",
+    labels: ["triage: needs-real-behavior-proof"],
+  });
+  assert.equal(
+    botProofEligibilityForTest({
+      item: proofNudgeItem({ author: "contributor" }),
+      markdown: proofNudgeReport(),
+      headSha: "abc123def456",
+    }).action,
+    "skipped_not_bot_authored",
+  );
+  assert.equal(
+    botProofEligibilityForTest({
+      item: baseItem,
+      markdown: proofNudgeReport({ author: "app/clawsweeper" }),
+      headSha: "abc123def456",
+      draft: true,
+    }).action,
+    "skipped_draft",
+  );
+  for (const label of ["proof: override", "proof: supplied", "proof: sufficient"] as const) {
+    assert.equal(
+      botProofEligibilityForTest({
+        item: proofNudgeItem({
+          author: "app/clawsweeper",
+          labels: ["triage: needs-real-behavior-proof", label],
+        }),
+        markdown: proofNudgeReport({ author: "app/clawsweeper" }),
+        headSha: "abc123def456",
+      }).action,
+      "skipped_policy_exempt",
+    );
+  }
+  assert.equal(
+    botProofEligibilityForTest({
+      item: baseItem,
+      markdown: proofNudgeReport({ author: "app/clawsweeper", headSha: "oldhead" }),
+      headSha: "newhead",
+    }).action,
+    "skipped_stale_report_head",
+  );
+});
+
+test("bot proof status comment asks maintainers without contributor nudge copy", () => {
+  const markdown = proofNudgeReport({
+    author: "app/clawsweeper",
+    mantisStatus: "recommended",
+    mantisScenario: "visual_task",
+    mantisReason: "A visual proof task would show the fixed Control UI behavior.",
+    mantisComment: "@openclaw-mantis capture Control UI proof for this PR",
+  });
+  const comment = renderBotProofDecisionCommentForTest({
+    number: 42,
+    headSha: "abc123def456",
+    markdown,
+  });
+
+  assert.match(comment, /ClawSweeper-authored replacement PR is blocked on real behavior proof/);
+  assert.match(comment, /proof: override/);
+  assert.match(comment, /@openclaw-mantis capture Control UI proof/);
+  assert.match(comment, /<!-- clawsweeper-bot-proof-decision item="42" sha="abc123def456"/);
+  assert.doesNotMatch(comment, /thanks for the PR/);
+  assert.doesNotMatch(comment, /Once proof is added/);
+});
 
 test("proof nudge candidate scan defers proof-label checks to live PR state", () => {
   const root = mkdtempSync(tmpPrefix);
@@ -15367,6 +15524,11 @@ test("ClawSweeper PR status label scheme exposes workflow states", () => {
       { kind: "re_review_loop", name: "status: 🔁 re-review loop", color: "8250DF" },
       { kind: "actively_grinding", name: "status: 🛠️ actively grinding", color: "0969DA" },
       { kind: "needs_proof", name: "status: 📣 needs proof", color: "D93F0B" },
+      {
+        kind: "needs_maintainer_proof_decision",
+        name: "status: needs maintainer proof decision",
+        color: "D93F0B",
+      },
       { kind: "waiting_on_author", name: "status: ⏳ waiting on author", color: "FBCA04" },
       {
         kind: "ready_for_maintainer_look",

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -14812,13 +14812,26 @@ test("bot proof handling selects maintainer or Mantis proof path for ClawSweeper
     markdown: proofNudgeReport({
       author: "app/clawsweeper",
       mantisStatus: "recommended",
+      mantisScenario: "telegram_desktop_proof",
+      mantisReason: "Native Telegram Desktop proof would show the visible topic behavior.",
+      mantisComment: "@openclaw-mantis telegram desktop proof: verify the topic behavior",
+    }),
+  });
+  assert.equal(mantis.eligible, true);
+  assert.equal(mantis.action, "bot_proof_mantis_request_planned");
+
+  const manualVisual = botProofEligibilityForTest({
+    ...baseOptions,
+    markdown: proofNudgeReport({
+      author: "app/clawsweeper",
+      mantisStatus: "recommended",
       mantisScenario: "visual_task",
       mantisReason: "A visual proof task would show the fixed Control UI behavior.",
       mantisComment: "@openclaw-mantis capture Control UI proof for this PR",
     }),
   });
-  assert.equal(mantis.eligible, true);
-  assert.equal(mantis.action, "bot_proof_mantis_request_planned");
+  assert.equal(manualVisual.eligible, true);
+  assert.equal(manualVisual.action, "bot_proof_decision_planned");
 
   assert.equal(
     botProofEligibilityForTest({
@@ -14894,6 +14907,7 @@ test("bot proof status comment asks maintainers without contributor nudge copy",
 
   assert.match(comment, /ClawSweeper-authored replacement PR is blocked on real behavior proof/);
   assert.match(comment, /proof: override/);
+  assert.match(comment, /Possible manual Mantis\/desktop proof suggestion/);
   assert.match(comment, /@openclaw-mantis capture Control UI proof/);
   assert.match(comment, /<!-- clawsweeper-bot-proof-decision item="42" sha="abc123def456"/);
   assert.doesNotMatch(comment, /thanks for the PR/);


### PR DESCRIPTION
## Summary
- add a separate `bot-proof` lane for ClawSweeper-owned PRs blocked on real behavior proof
- add a maintainer proof decision status label/comment path without changing contributor proof nudges
- keep bot-triggered Mantis requests limited to currently dispatchable Mantis scenarios, with `visual_task`/Control UI suggestions left as maintainer decisions
- wire the lane behind manual/scheduled workflow gates and add coverage for eligibility, skip cases, Mantis suggestions, and comment copy

## Why
Bot-authored replacement PRs like https://github.com/openclaw/openclaw/pull/90618 can be blocked on real behavior proof, while contributor proof nudges intentionally skip bot-authored PRs. This gives those PRs an auditable maintainer/proof path without posting contributor-style reminders to automation.

## Validation
- `pnpm run build`
- `node --test test/clawsweeper.test.ts --test-name-pattern "bot proof|proof nudge|ClawSweeper PR status label scheme"`
- `pnpm run bot-proof -- --target-repo openclaw/openclaw --items-dir .artifacts/bot-proof-dry-run/items --item-number 90618 --limit 1 --processed-limit 1 --report-path .artifacts/bot-proof-dry-run/report-mantis-scope.json` produced dry-run bot-proof output for head `ae868b7b18dfbd5e6a2422c8005501b57c52e15a`
- `pnpm run check`