### PR TITLE
docs: document cluster fixer operations visibility

### DIFF
--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -1070,6 +1070,7 @@ async function statusSnapshot(env, ctx) {
       automerge: automerge.items,
       closed_items: closed.items,
       closed_stats: closed.stats,
+      operation_counts: operationEventCounts(storedEvents),
       events: recentActivityEvents(storedEvents, closed.items),
       failed_runs: failedRuns.slice(0, 10).map((run) => workflowRunSummary(run)),
     },
@@ -2349,6 +2350,70 @@ function recentActivityEvents(storedEvents, closedItems) {
         Date.parse(left.received_at || left.closed_at || ""),
     )
     .slice(0, 25);
+}
+
+function operationEventCounts(storedEvents) {
+  const counts = {
+    inherited_label_cleanups: 0,
+    self_heal_conflict_repairs: 0,
+    failed_review_retries: 0,
+    failed_review_retry_exhaustions: 0,
+    bot_owned_proof_decisions_requested: 0,
+    bot_owned_proof_dispatches: 0,
+  };
+  for (const event of Array.isArray(storedEvents) ? storedEvents : []) {
+    countOperationEvent(event, counts);
+  }
+  return counts;
+}
+
+function countOperationEvent(event, counts) {
+  const key = [event.event_type, event.mode, event.stage, event.status]
+    .map((value) =>
+      String(value || "")
+        .toLowerCase()
+        .replaceAll("-", "_"),
+    )
+    .join(" ");
+  if (
+    key.includes("inherited_label_cleanup") ||
+    key.includes("replacement_label_cleanup") ||
+    key.includes("removed_inherited_labels")
+  ) {
+    counts.inherited_label_cleanups += 1;
+  }
+  if (
+    key.includes("self_heal_conflict") ||
+    key.includes("conflict_self_heal") ||
+    key.includes("clawsweeper_self_rebase")
+  ) {
+    counts.self_heal_conflict_repairs += 1;
+  }
+  if (
+    key.includes("failed_review_retry_exhausted") ||
+    key.includes("failed_review_retries_exhausted")
+  ) {
+    counts.failed_review_retry_exhaustions += 1;
+  } else if (key.includes("failed_review_retry")) {
+    counts.failed_review_retries += 1;
+  }
+  if (
+    key.includes("bot_owned_proof_decision_requested") ||
+    key.includes("maintainer_proof_decision_requested") ||
+    key.includes("needs_maintainer_proof_decision") ||
+    key.includes("bot_proof_decision_planned") ||
+    key.includes("bot_proof_decision_posted")
+  ) {
+    counts.bot_owned_proof_decisions_requested += 1;
+  }
+  if (
+    key.includes("bot_owned_proof_dispatched") ||
+    key.includes("bot_owned_proof_capture_dispatched") ||
+    key.includes("bot_proof_mantis_request_planned") ||
+    key.includes("bot_proof_mantis_request_posted")
+  ) {
+    counts.bot_owned_proof_dispatches += 1;
+  }
 }
 
 function activityEventFromClosedItem(item) {
@@ -4100,6 +4165,8 @@ a:hover { color: #89c8ff; text-decoration: underline; }
       <h2>✅ Closed by ClawSweeper</h2>
       <div id="closed-stats"></div>
       <div id="closed"></div>
+      <h2>🧭 Operations</h2>
+      <div id="operations"></div>
       <h2>📡 Recent Activity</h2>
       <div id="events"></div>
     </aside>
@@ -4224,6 +4291,7 @@ function renderDashboard(data, note) {
   renderAutomerge(data.recent.automerge || []);
   renderClosedStats(data.recent.closed_stats);
   renderClosedItems(data.recent.closed_items || []);
+  renderOperations(data.recent.operation_counts);
   renderEvents(data.recent.events || []);
 }
 function renderPipeline(rows) {
@@ -4275,6 +4343,18 @@ function renderClosedItems(rows) {
 function renderClosedStats(stats) {
   const safe = stats || { total: 0, issues: 0, prs: 0, window_hours: 24 };
   document.getElementById("closed-stats").innerHTML = '<div class="closed-stats"><div class="closed-stat"><span>' + esc((safe.window_hours || 24) + "h total") + '</span><strong>' + fmt.format(safe.total || 0) + '</strong></div><div class="closed-stat"><span>Issues</span><strong>' + fmt.format(safe.issues || 0) + '</strong></div><div class="closed-stat"><span>PRs</span><strong>' + fmt.format(safe.prs || 0) + '</strong></div></div>';
+}
+function renderOperations(counts) {
+  const safe = counts || {};
+  const rows = [
+    ["Inherited labels", safe.inherited_label_cleanups || 0],
+    ["Conflict self-heal", safe.self_heal_conflict_repairs || 0],
+    ["Review retries", safe.failed_review_retries || 0],
+    ["Retry exhausted", safe.failed_review_retry_exhaustions || 0],
+    ["Proof decisions", safe.bot_owned_proof_decisions_requested || 0],
+    ["Proof dispatches", safe.bot_owned_proof_dispatches || 0]
+  ];
+  document.getElementById("operations").innerHTML = '<div class="closed-stats">' + rows.map(row => '<div class="closed-stat"><span>' + esc(row[0]) + '</span><strong>' + fmt.format(row[1]) + '</strong></div>').join("") + '</div>';
 }
 function renderEvents(rows) {
   if (!rows.length) {

--- a/docs/proof-nudges.md
+++ b/docs/proof-nudges.md
@@ -22,6 +22,31 @@ A pull request is eligible only when all of these are true:
 
 The lane skips maintainer-authored, bot-authored, security-sensitive, and release-style pull requests. It also skips pull requests with `proof: supplied`, `proof: sufficient`, or `proof: override`, because those need review or policy handling rather than another contributor reminder.
 
+## Bot-Owned Proof Handling
+
+Bot-owned replacement PRs are deliberately outside the contributor nudge lane.
+Do not make normal proof nudges comment on bot-authored PRs as if a contributor
+needs to respond. The `bot-proof` lane handles ClawSweeper-owned PRs that are
+blocked on real behavior proof.
+
+The bot-owned lane is status-only unless an approved Mantis proof suggestion is
+available. It is eligible only when the live PR is open and not draft, the
+author is the ClawSweeper GitHub App, the latest
+ClawSweeper review says real behavior proof blocks merge, and that review head
+SHA still matches the live head SHA. It must skip PRs with `proof: supplied`,
+`proof: sufficient`, or `proof: override`.
+
+When the review includes an approved Mantis-style proof suggestion, the lane
+posts a durable Mantis proof request comment. Otherwise it updates one durable
+status comment asking maintainers to choose proof capture, proof override, or
+pause. It does not post contributor reminders.
+
+For dashboard accounting, status-only maintainer requests use
+`bot_proof_decision_planned` or `bot_proof_decision_posted`. Mantis proof
+requests use `bot_proof_mantis_request_planned` or
+`bot_proof_mantis_request_posted`. Hosted dashboard events with those tokens are
+counted in the proof operation counters.
+
 ## Marker
 
 Cooldown state lives in the reminder comment body:
@@ -70,11 +95,16 @@ Scheduled operation uses repository variables:
 - `CLAWSWEEPER_PROOF_NUDGES_LIMIT`: optional scheduled batch size, default `10`.
 - `CLAWSWEEPER_PROOF_NUDGES_MIN_AGE_DAYS`: optional first-nudge age gate, default `5`.
 - `CLAWSWEEPER_PROOF_NUDGES_COOLDOWN_DAYS`: optional same-head cooldown, default `7`.
+- `CLAWSWEEPER_BOT_PROOF_SCHEDULED=1`: include the bot-owned proof lane in scheduled runs.
+- `CLAWSWEEPER_BOT_PROOF_EXECUTE=1`: allow scheduled bot-owned proof runs to post status comments and labels. Without this, scheduled bot-proof runs remain dry-run only.
 
 Suggested rollout:
 
 1. Run the proof-nudge workflow manually with `execute=false`.
 2. Set `CLAWSWEEPER_PROOF_NUDGES_SCHEDULED=1` to collect scheduled dry-run reports.
 3. Set `CLAWSWEEPER_PROOF_NUDGES_EXECUTE=1` only after the scheduled reports look correct.
+4. Run the bot-owned proof lane manually with `bot_proof=true` and `bot_proof_execute=false`.
+5. Set `CLAWSWEEPER_BOT_PROOF_SCHEDULED=1` only after dry-run reports look correct.
+6. Set `CLAWSWEEPER_BOT_PROOF_EXECUTE=1` only after generated comments and labels have been reviewed.
 
 This first version intentionally has no auto-close behavior. Any escalation after repeated proof nudges needs a separate maintainer policy decision.

--- a/docs/repair/auto-update-prs.md
+++ b/docs/repair/auto-update-prs.md
@@ -259,6 +259,66 @@ state is enough to dispatch repair. That lets Codex rebase or resolve conflicts
 before the next exact-head review instead of waiting for a later pass marker or
 new maintainer comment.
 
+## ClawSweeper-Owned Conflict Self-Heal
+
+The conflict self-heal lane is for open pull requests that ClawSweeper itself
+owns. When enabled, it may dispatch a bounded repair for a PR only when all of these
+are true:
+
+- the author is the ClawSweeper GitHub App;
+- the head branch is in the base repository and starts with `clawsweeper/`;
+- the PR is open and the live merge state is `CONFLICTING`, `DIRTY`, or
+  `BEHIND`;
+- the exact head SHA is captured before dispatch and still matches when the
+  worker starts;
+- no waiting or dispatched self-heal attempt already covers that PR/head;
+- the self-heal per-head and per-PR caps still allow another attempt.
+
+Self-heal is repair-only. It does not add `clawsweeper:automerge`, it does not
+request a merge, and it does not treat a successful rebase as approval. After a
+successful push, the next required step is an exact-item ClawSweeper review for
+the new head. The PR can merge only through the normal automerge gates or a
+human maintainer path.
+
+The self-heal scanner has dedicated attempt caps:
+
+```bash
+--max-attempts-per-pr 10
+--max-attempts-per-head 2
+```
+
+The durable status comment records the detected merge state, targeted head SHA,
+job path, repair run URL, and current status. The generated job uses
+`job_intent: clawsweeper_self_rebase`, blocks close/merge/label actions, and
+pins `expected_head_sha` so stale jobs stop without mutating. For dashboard
+accounting, emit a `/api/events` payload whose event type, mode, stage, or
+status contains `clawsweeper_self_rebase` or `conflict_self_heal`.
+
+## Replacement Label Cleanup
+
+Replacement PR labels must describe the replacement PR, not stale lifecycle
+state from a source PR. Replacement creation filters source labels so it does
+not copy `close:*`, `stale`, `rating:*`, `status:*`, `proof:*`,
+`triage: needs-real-behavior-proof`, `merge-risk:*`, `size:*`, or `P*`
+priority labels.
+
+Use the cleanup command to inspect existing open ClawSweeper replacement PRs
+for inherited source labels:
+
+```bash
+pnpm run repair:cleanup-replacement-labels -- --repo openclaw/openclaw
+```
+
+The command writes `.artifacts/replacement-label-cleanup.json` by default. It
+is dry-run by default. To remove lifecycle labels from matching PRs, pass
+`--execute` with `CLAWSWEEPER_ALLOW_EXECUTE=1`; execute mode removes only
+`stale` and `close:*` labels.
+
+For dashboard accounting, publish the cleanup total through `pnpm run status`
+with `--inherited-label-cleanups`, or send a `/api/events` payload whose event
+type, mode, stage, or status contains `replacement_label_cleanup` or
+`inherited_label_cleanup`.
+
 ClawSweeper edits one durable review comment in place. The router keys its
 ledger by comment id plus `updated_at`, and response markers include the target
 PR head SHA, so an edited ClawSweeper comment can trigger a new repair after

--- a/docs/repair/operations.md
+++ b/docs/repair/operations.md
@@ -7,6 +7,45 @@ commands, finalizers, self-heal, gates, and ledgers, see
 For the trusted ClawSweeper-to-ClawSweeper PR repair loop, see
 [`docs/repair/auto-update-prs.md`](auto-update-prs.md).
 
+## Cluster Repair Operations Counters
+
+The README dashboard and hosted live dashboard expose passive counters for the
+cluster repair lanes. These counters are observational only; they do not
+enable repair, merge, close, proof dispatch, or label mutation.
+
+Record-backed dashboard counters read recent markdown records and count these
+signals:
+
+- `replacement_label_cleanup` or `inherited_label_cleanup` for replacement-label cleanup;
+- `clawsweeper_self_rebase` or `conflict_self_heal` for ClawSweeper-owned conflict repair;
+- `failed_review_retry_status: dispatched` or an action containing
+  `failed_review_retry` for an exact failed-review retry dispatch;
+- `failed_review_retry_status: exhausted` or an action containing
+  `failed_review_retry_exhausted` for retry cap exhaustion;
+- `bot_proof_decision_planned`, `bot_proof_decision_posted`, or
+  `needs_maintainer_proof_decision` for status-only maintainer proof decisions;
+- `bot_proof_mantis_request_planned` or `bot_proof_mantis_request_posted` for
+  approved Mantis proof requests.
+
+The hosted dashboard counts the same names from `/api/events` payloads when the
+event type, mode, stage, or status contains the matching token. Lanes that
+mutate GitHub or dispatch another workflow should emit a durable record or
+status comment and a hosted-dashboard event when that hook is available.
+
+Manual workflow status updates can publish the same counters directly:
+
+```bash
+pnpm run status -- \
+  --state "Working" \
+  --detail "Cluster repair dry-run completed." \
+  --inherited-label-cleanups 3 \
+  --self-heal-conflict-repairs 1 \
+  --failed-review-retries 2 \
+  --failed-review-retry-exhaustions 1 \
+  --bot-owned-proof-decisions-requested 1 \
+  --bot-owned-proof-dispatches 0
+```
+
 For commit-review findings, ClawSweeper dispatches
 `clawsweeper_commit_finding` to this repository. ClawSweeper fetches the latest
 markdown report, writes `results/commit-findings/<repo-slug>/<sha>.md`, and

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -657,6 +657,12 @@ interface DashboardActivityBucket {
   closes: number;
   commentSyncs: number;
   applySkips: number;
+  inheritedLabelCleanups: number;
+  selfHealConflictRepairs: number;
+  failedReviewRetries: number;
+  failedReviewRetryExhaustions: number;
+  botOwnedProofDecisionsRequested: number;
+  botOwnedProofDispatches: number;
 }
 
 interface DashboardActivityStats {
@@ -699,6 +705,12 @@ interface WorkflowStatusSummary {
   dueBacklog: number | undefined;
   oldestUnreviewedAt: string | undefined;
   capacityReason: string | undefined;
+  inheritedLabelCleanups: number | undefined;
+  selfHealConflictRepairs: number | undefined;
+  failedReviewRetries: number | undefined;
+  failedReviewRetryExhaustions: number | undefined;
+  botOwnedProofDecisionsRequested: number | undefined;
+  botOwnedProofDispatches: number | undefined;
 }
 
 interface RepoDashboardSnapshot {
@@ -1769,6 +1781,12 @@ function writeSweepStatus(options: {
   dueBacklog?: number;
   oldestUnreviewedAt?: string;
   capacityReason?: string;
+  inheritedLabelCleanups?: number;
+  selfHealConflictRepairs?: number;
+  failedReviewRetries?: number;
+  failedReviewRetryExhaustions?: number;
+  botOwnedProofDecisionsRequested?: number;
+  botOwnedProofDispatches?: number;
 }): void {
   const profile = options.profile ?? targetProfile();
   const updatedAt = new Date().toISOString();
@@ -1787,6 +1805,12 @@ function writeSweepStatus(options: {
     due_backlog: options.dueBacklog ?? null,
     oldest_unreviewed_at: options.oldestUnreviewedAt ?? null,
     capacity_reason: options.capacityReason ?? null,
+    inherited_label_cleanups: options.inheritedLabelCleanups ?? null,
+    self_heal_conflict_repairs: options.selfHealConflictRepairs ?? null,
+    failed_review_retries: options.failedReviewRetries ?? null,
+    failed_review_retry_exhaustions: options.failedReviewRetryExhaustions ?? null,
+    bot_owned_proof_decisions_requested: options.botOwnedProofDecisionsRequested ?? null,
+    bot_owned_proof_dispatches: options.botOwnedProofDispatches ?? null,
     updated_at: updatedAt,
   };
   const outputPath = sweepStatusPath(profile);
@@ -5242,6 +5266,12 @@ function emptyDashboardActivityBucket(): DashboardActivityBucket {
     closes: 0,
     commentSyncs: 0,
     applySkips: 0,
+    inheritedLabelCleanups: 0,
+    selfHealConflictRepairs: 0,
+    failedReviewRetries: 0,
+    failedReviewRetryExhaustions: 0,
+    botOwnedProofDecisionsRequested: 0,
+    botOwnedProofDispatches: 0,
   };
 }
 
@@ -5322,6 +5352,9 @@ function recordDashboardActivity(
   const applyCheckedAtMs = timestampMs(applyCheckedAt);
   const decision = frontMatterValue(markdown, "decision") ?? "unknown";
   const action = frontMatterValue(markdown, "action_taken") ?? "unknown";
+  const failedReviewRetryStatus = frontMatterValue(markdown, "failed_review_retry_status");
+  const failedReviewRetryLastAt = frontMatterValue(markdown, "failed_review_retry_last_at");
+  const failedReviewRetryLastAtMs = timestampMs(failedReviewRetryLastAt);
   const reviewStatus = effectiveReviewStatus(markdown);
 
   activity.latestReviewAt = latestTimestamp(activity.latestReviewAt, reviewedAt);
@@ -5347,11 +5380,81 @@ function recordDashboardActivity(
     if (isWithinWindow(applyCheckedAtMs, now, windowMs) && action.startsWith("skipped_")) {
       bucket.applySkips += 1;
     }
+    if (isWithinWindow(applyCheckedAtMs ?? reviewedAtMs, now, windowMs)) {
+      recordOperationActivity(action, bucket);
+    }
+    if (
+      failedReviewRetryStatus &&
+      !normalizedOperationText(action).includes("failed_review_retry") &&
+      isWithinWindow(failedReviewRetryLastAtMs, now, windowMs)
+    ) {
+      recordFailedReviewRetryStatus(failedReviewRetryStatus, bucket);
+    }
   }
 }
 
 function formatActivityRow(label: string, bucket: DashboardActivityBucket): string {
   return `| ${label} | ${bucket.reviews} | ${bucket.closeDecisions} | ${bucket.keepOpenDecisions} | ${bucket.failedOrStaleReviews} | ${bucket.closes} | ${bucket.commentSyncs} | ${bucket.applySkips} |`;
+}
+
+function recordOperationActivity(action: string, bucket: DashboardActivityBucket): void {
+  const normalized = normalizedOperationText(action);
+  if (
+    normalized.includes("inherited_label_cleanup") ||
+    normalized.includes("replacement_label_cleanup") ||
+    normalized.includes("removed_inherited_labels")
+  ) {
+    bucket.inheritedLabelCleanups += 1;
+  }
+  if (
+    normalized.includes("self_heal_conflict") ||
+    normalized.includes("conflict_self_heal") ||
+    normalized.includes("clawsweeper_self_rebase")
+  ) {
+    bucket.selfHealConflictRepairs += 1;
+  }
+  if (
+    normalized.includes("failed_review_retry_exhausted") ||
+    normalized.includes("failed_review_retries_exhausted")
+  ) {
+    bucket.failedReviewRetryExhaustions += 1;
+  } else if (normalized.includes("failed_review_retry")) {
+    bucket.failedReviewRetries += 1;
+  }
+  if (
+    normalized.includes("bot_owned_proof_decision_requested") ||
+    normalized.includes("maintainer_proof_decision_requested") ||
+    normalized.includes("needs_maintainer_proof_decision") ||
+    normalized.includes("bot_proof_decision_planned") ||
+    normalized.includes("bot_proof_decision_posted")
+  ) {
+    bucket.botOwnedProofDecisionsRequested += 1;
+  }
+  if (
+    normalized.includes("bot_owned_proof_dispatched") ||
+    normalized.includes("bot_owned_proof_capture_dispatched") ||
+    normalized.includes("bot_proof_mantis_request_planned") ||
+    normalized.includes("bot_proof_mantis_request_posted")
+  ) {
+    bucket.botOwnedProofDispatches += 1;
+  }
+}
+
+function normalizedOperationText(value: string): string {
+  return value.toLowerCase().replaceAll("-", "_");
+}
+
+function recordFailedReviewRetryStatus(status: string, bucket: DashboardActivityBucket): void {
+  const normalized = normalizedOperationText(status);
+  if (normalized === "exhausted") {
+    bucket.failedReviewRetryExhaustions += 1;
+  } else if (normalized === "dispatched") {
+    bucket.failedReviewRetries += 1;
+  }
+}
+
+function formatOperationActivityRow(label: string, bucket: DashboardActivityBucket): string {
+  return `| ${label} | ${bucket.inheritedLabelCleanups} | ${bucket.selfHealConflictRepairs} | ${bucket.failedReviewRetries} | ${bucket.failedReviewRetryExhaustions} | ${bucket.botOwnedProofDecisionsRequested} | ${bucket.botOwnedProofDispatches} |`;
 }
 
 function selectCandidates(options: {
@@ -7050,6 +7153,12 @@ function workflowStatusBlock(options?: {
   dueBacklog?: number | undefined;
   oldestUnreviewedAt?: string | undefined;
   capacityReason?: string | undefined;
+  inheritedLabelCleanups?: number | undefined;
+  selfHealConflictRepairs?: number | undefined;
+  failedReviewRetries?: number | undefined;
+  failedReviewRetryExhaustions?: number | undefined;
+  botOwnedProofDecisionsRequested?: number | undefined;
+  botOwnedProofDispatches?: number | undefined;
 }): string {
   const profile = options?.profile ?? targetProfile();
   const updatedAt = formatTimestamp(options?.updatedAt ?? new Date().toISOString());
@@ -7079,6 +7188,12 @@ function workflowStatusMetricLines(options: {
   dueBacklog?: number | undefined;
   oldestUnreviewedAt?: string | undefined;
   capacityReason?: string | undefined;
+  inheritedLabelCleanups?: number | undefined;
+  selfHealConflictRepairs?: number | undefined;
+  failedReviewRetries?: number | undefined;
+  failedReviewRetryExhaustions?: number | undefined;
+  botOwnedProofDecisionsRequested?: number | undefined;
+  botOwnedProofDispatches?: number | undefined;
 }): string[] {
   const lines: string[] = [];
   if (
@@ -7104,6 +7219,32 @@ function workflowStatusMetricLines(options: {
   if (options.capacityReason) {
     lines.push(`Capacity reason: ${options.capacityReason}.`);
   }
+  if (options.inheritedLabelCleanups !== undefined) {
+    lines.push(`Inherited label cleanups: ${formatStatusNumber(options.inheritedLabelCleanups)}.`);
+  }
+  if (options.selfHealConflictRepairs !== undefined) {
+    lines.push(
+      `Self-heal conflict repairs: ${formatStatusNumber(options.selfHealConflictRepairs)}.`,
+    );
+  }
+  if (options.failedReviewRetries !== undefined) {
+    lines.push(`Failed-review retries: ${formatStatusNumber(options.failedReviewRetries)}.`);
+  }
+  if (options.failedReviewRetryExhaustions !== undefined) {
+    lines.push(
+      `Failed-review retry exhaustions: ${formatStatusNumber(options.failedReviewRetryExhaustions)}.`,
+    );
+  }
+  if (options.botOwnedProofDecisionsRequested !== undefined) {
+    lines.push(
+      `Bot-owned proof decisions requested: ${formatStatusNumber(options.botOwnedProofDecisionsRequested)}.`,
+    );
+  }
+  if (options.botOwnedProofDispatches !== undefined) {
+    lines.push(
+      `Bot-owned proof dispatches: ${formatStatusNumber(options.botOwnedProofDispatches)}.`,
+    );
+  }
   return lines;
 }
 
@@ -7128,6 +7269,14 @@ function readSweepStatusSummary(profile = targetProfile()): WorkflowStatusSummar
       dueBacklog: numberOrUndefined(parsed.due_backlog),
       oldestUnreviewedAt: stringOrUndefined(parsed.oldest_unreviewed_at),
       capacityReason: stringOrUndefined(parsed.capacity_reason),
+      inheritedLabelCleanups: numberOrUndefined(parsed.inherited_label_cleanups),
+      selfHealConflictRepairs: numberOrUndefined(parsed.self_heal_conflict_repairs),
+      failedReviewRetries: numberOrUndefined(parsed.failed_review_retries),
+      failedReviewRetryExhaustions: numberOrUndefined(parsed.failed_review_retry_exhaustions),
+      botOwnedProofDecisionsRequested: numberOrUndefined(
+        parsed.bot_owned_proof_decisions_requested,
+      ),
+      botOwnedProofDispatches: numberOrUndefined(parsed.bot_owned_proof_dispatches),
     };
   } catch {
     return null;
@@ -7169,7 +7318,7 @@ function workflowStatusSummary(block: string): WorkflowStatusSummary {
   const state = block.match(/^State: (.+)$/m)?.[1] ?? "Idle";
   const runUrl = block.match(/^Run: \[([^\]]+)\]\([^)]+\)$/m)?.[1];
   const detailMatch = block.match(
-    /^State: .+\n\n([\s\S]*?)(?:\n\nPlan: |\n\nActive Codex target: |\nRun: |\n<!-- clawsweeper-status)/m,
+    /^State: .+\n\n([\s\S]*?)(?:\n\nPlan: |\n\nActive Codex target: |\n\nDue backlog scanned: |\n\nOldest unreviewed: |\n\nCapacity reason: |\n\nInherited label cleanups: |\n\nSelf-heal conflict repairs: |\n\nFailed-review retries: |\n\nFailed-review retry exhaustions: |\n\nBot-owned proof decisions requested: |\n\nBot-owned proof dispatches: |\nRun: |\n<!-- clawsweeper-status)/m,
   );
   const detail = detailMatch?.[1]?.trim() || "No workflow status has been published yet.";
   const planMatch = block.match(/^Plan: (\d+) items across (\d+) shards \(capacity (\d+)\)\.$/m);
@@ -7177,6 +7326,24 @@ function workflowStatusSummary(block: string): WorkflowStatusSummary {
   const dueBacklog = numberOrUndefined(block.match(/^Due backlog scanned: (\d+)\.$/m)?.[1]);
   const oldestUnreviewedAt = block.match(/^Oldest unreviewed: (.+)\.$/m)?.[1];
   const capacityReason = block.match(/^Capacity reason: (.+)\.$/m)?.[1];
+  const inheritedLabelCleanups = numberOrUndefined(
+    block.match(/^Inherited label cleanups: (\d+)\.$/m)?.[1],
+  );
+  const selfHealConflictRepairs = numberOrUndefined(
+    block.match(/^Self-heal conflict repairs: (\d+)\.$/m)?.[1],
+  );
+  const failedReviewRetries = numberOrUndefined(
+    block.match(/^Failed-review retries: (\d+)\.$/m)?.[1],
+  );
+  const failedReviewRetryExhaustions = numberOrUndefined(
+    block.match(/^Failed-review retry exhaustions: (\d+)\.$/m)?.[1],
+  );
+  const botOwnedProofDecisionsRequested = numberOrUndefined(
+    block.match(/^Bot-owned proof decisions requested: (\d+)\.$/m)?.[1],
+  );
+  const botOwnedProofDispatches = numberOrUndefined(
+    block.match(/^Bot-owned proof dispatches: (\d+)\.$/m)?.[1],
+  );
   return {
     updatedAt,
     state,
@@ -7189,6 +7356,12 @@ function workflowStatusSummary(block: string): WorkflowStatusSummary {
     dueBacklog,
     oldestUnreviewedAt,
     capacityReason,
+    inheritedLabelCleanups,
+    selfHealConflictRepairs,
+    failedReviewRetries,
+    failedReviewRetryExhaustions,
+    botOwnedProofDecisionsRequested,
+    botOwnedProofDispatches,
   };
 }
 
@@ -17477,6 +17650,12 @@ function addActivityBucket(target: DashboardActivityBucket, source: DashboardAct
   target.closes += source.closes;
   target.commentSyncs += source.commentSyncs;
   target.applySkips += source.applySkips;
+  target.inheritedLabelCleanups += source.inheritedLabelCleanups;
+  target.selfHealConflictRepairs += source.selfHealConflictRepairs;
+  target.failedReviewRetries += source.failedReviewRetries;
+  target.failedReviewRetryExhaustions += source.failedReviewRetryExhaustions;
+  target.botOwnedProofDecisionsRequested += source.botOwnedProofDecisionsRequested;
+  target.botOwnedProofDispatches += source.botOwnedProofDispatches;
 }
 
 function aggregateActivity(snapshots: readonly RepoDashboardSnapshot[]): DashboardActivityStats {
@@ -17622,6 +17801,14 @@ ${formatActivityRow("Last 15 minutes", stats.activity.last15Minutes)}
 ${formatActivityRow("Last hour", stats.activity.lastHour)}
 ${formatActivityRow("Last 24 hours", stats.activity.last24Hours)}
 
+#### Operation Counters
+
+| Window | Inherited-label cleanups | Self-heal conflict repairs | Failed-review retries | Exhausted review retries | Bot proof decisions | Bot proof dispatches |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+${formatOperationActivityRow("Last 15 minutes", stats.activity.last15Minutes)}
+${formatOperationActivityRow("Last hour", stats.activity.lastHour)}
+${formatOperationActivityRow("Last 24 hours", stats.activity.last24Hours)}
+
 #### Recently Closed
 
 | Item | Title | Reason | Closed | Report |
@@ -17749,6 +17936,14 @@ ${formatActivityRow("Last 15 minutes", activity.last15Minutes)}
 ${formatActivityRow("Last hour", activity.lastHour)}
 ${formatActivityRow("Last 24 hours", activity.last24Hours)}
 
+### Fleet Operation Counters
+
+| Window | Inherited-label cleanups | Self-heal conflict repairs | Failed-review retries | Exhausted review retries | Bot proof decisions | Bot proof dispatches |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+${formatOperationActivityRow("Last 15 minutes", activity.last15Minutes)}
+${formatOperationActivityRow("Last hour", activity.lastHour)}
+${formatOperationActivityRow("Last 24 hours", activity.last24Hours)}
+
 ### Recently Closed Across Repos
 
 | Repository | Item | Title | Reason | Closed | Report |
@@ -17794,6 +17989,14 @@ function statusCommand(args: Args): void {
   const dueBacklog = optionalNumberArg(args.due_backlog);
   const oldestUnreviewedAt = stringArg(args.oldest_unreviewed_at, "");
   const capacityReason = stringArg(args.capacity_reason, "");
+  const inheritedLabelCleanups = optionalNumberArg(args.inherited_label_cleanups);
+  const selfHealConflictRepairs = optionalNumberArg(args.self_heal_conflict_repairs);
+  const failedReviewRetries = optionalNumberArg(args.failed_review_retries);
+  const failedReviewRetryExhaustions = optionalNumberArg(args.failed_review_retry_exhaustions);
+  const botOwnedProofDecisionsRequested = optionalNumberArg(
+    args.bot_owned_proof_decisions_requested,
+  );
+  const botOwnedProofDispatches = optionalNumberArg(args.bot_owned_proof_dispatches);
   const statusOptions: Parameters<typeof writeSweepStatus>[0] = {
     state,
     detail,
@@ -17807,6 +18010,17 @@ function statusCommand(args: Args): void {
   if (dueBacklog !== undefined) statusOptions.dueBacklog = dueBacklog;
   if (oldestUnreviewedAt) statusOptions.oldestUnreviewedAt = oldestUnreviewedAt;
   if (capacityReason) statusOptions.capacityReason = capacityReason;
+  if (inheritedLabelCleanups !== undefined)
+    statusOptions.inheritedLabelCleanups = inheritedLabelCleanups;
+  if (selfHealConflictRepairs !== undefined)
+    statusOptions.selfHealConflictRepairs = selfHealConflictRepairs;
+  if (failedReviewRetries !== undefined) statusOptions.failedReviewRetries = failedReviewRetries;
+  if (failedReviewRetryExhaustions !== undefined)
+    statusOptions.failedReviewRetryExhaustions = failedReviewRetryExhaustions;
+  if (botOwnedProofDecisionsRequested !== undefined)
+    statusOptions.botOwnedProofDecisionsRequested = botOwnedProofDecisionsRequested;
+  if (botOwnedProofDispatches !== undefined)
+    statusOptions.botOwnedProofDispatches = botOwnedProofDispatches;
   writeSweepStatus(statusOptions);
   console.log(JSON.stringify({ status_path: sweepStatusRelativePath(profile), state, detail }));
 }

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -347,6 +347,77 @@ test("dashboard preserves repeated untargeted activity events", async () => {
   }
 });
 
+test("dashboard counts cluster-fixer operation events", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalCaches = globalThis.caches;
+  Object.defineProperty(globalThis, "caches", {
+    configurable: true,
+    value: {
+      default: {
+        match: async () => undefined,
+        put: async () => undefined,
+      },
+    },
+  });
+  globalThis.fetch = activePrFetch;
+
+  try {
+    const env = {
+      INGEST_TOKEN: "test-token",
+      STATUS_STORE: new MemoryKv(),
+      CLAWSWEEPER_REPO: "openclaw/clawsweeper",
+      TARGET_REPOS: "openclaw/openclaw",
+      CACHE_TTL_SECONDS: "0",
+    };
+    const events = [
+      { event_type: "clawsweeper.replacement_label_cleanup", stage: "executed" },
+      { event_type: "clawsweeper.clawsweeper_self_rebase", stage: "dispatched" },
+      { event_type: "clawsweeper.dispatched_failed_review_retry", stage: "dispatched" },
+      { event_type: "clawsweeper.marked_failed_review_retry_exhausted", stage: "exhausted" },
+      { event_type: "clawsweeper.bot_proof_decision_posted", stage: "posted" },
+      { event_type: "clawsweeper.bot_proof_mantis_request_posted", stage: "posted" },
+    ];
+    for (const event of events) {
+      const ingest = await worker.fetch(
+        new Request("https://clawsweeper.openclaw.ai/api/events", {
+          method: "POST",
+          headers: {
+            Authorization: "Bearer test-token",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            mode: "operation",
+            status: "ok",
+            ...event,
+          }),
+        }),
+        env,
+      );
+      assert.equal(ingest.status, 200);
+    }
+
+    const response = await worker.fetch(
+      new Request("https://clawsweeper.openclaw.ai/api/status"),
+      env,
+      {
+        waitUntil: () => undefined,
+      },
+    );
+    const status = await response.json();
+    assert.deepEqual(status.recent.operation_counts, {
+      inherited_label_cleanups: 1,
+      self_heal_conflict_repairs: 1,
+      failed_review_retries: 1,
+      failed_review_retry_exhaustions: 1,
+      bot_owned_proof_decisions_requested: 1,
+      bot_owned_proof_dispatches: 1,
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+    Object.defineProperty(globalThis, "caches", { configurable: true, value: originalCaches });
+  }
+});
+
 test("dashboard keeps workflow CI status when live PR checks fail", async () => {
   const originalFetch = globalThis.fetch;
   const originalCaches = globalThis.caches;


### PR DESCRIPTION
## Summary
- Document the merged cluster repair behavior for conflict self-heal, replacement-label cleanup, failed-review retries, and bot-owned proof handling.
- Add passive README/dashboard and hosted-dashboard operation counters for the action markers emitted by those lanes.
- Add hosted dashboard coverage for `/api/events` operation counter aggregation.

## Validation
- `pnpm run check`

## Notes
- Rebased on current `main` after https://github.com/openclaw/clawsweeper/pull/259, https://github.com/openclaw/clawsweeper/pull/260, and https://github.com/openclaw/clawsweeper/pull/261 merged.
- Counter docs now use the concrete marker names from those merged lanes.