### PR TITLE
Fix PR status routing for security owner review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Routed proof-sufficient security reviews that recommend maintainer risk acceptance to maintainer review instead of waiting on the contributor. Thanks @brokemac79.
 - Prevented automatic issue backfill from spending Codex workers on reports explicitly blocked by product-decision, no-new-fix-PR, or maintainer-review signals.
 - Kept issue-generated PRs out of automerge, migrated their labels to `clawsweeper:autofix`, and made clean exact-head autofix reviews wait for required checks to appear, settle green, and reach GitHub merge-state readiness before removing the repair-loop label instead of repeating blocked merge attempts.
 - Correlated active issue-build workers by workflow run when GitHub job titles omit the target, preserved source issue titles and generated PR links across repair lifecycle events, and stopped generic repository repairs from requiring a nonexistent `pnpm check:changed` script.

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -9162,16 +9162,31 @@ function hasBlockingReviewFindings(findings: readonly Pick<ReviewFinding, "prior
   return findings.some((finding) => finding.priority <= 2);
 }
 
+function recommendedMergeRiskOptionCategory(
+  options: readonly Pick<MergeRiskOption, "category" | "recommended">[],
+): MergeRiskOptionCategory | null {
+  return options.find((option) => option.recommended)?.category ?? null;
+}
+
+function securityReviewNeedsContributorWork(options: {
+  securityReview: Pick<SecurityReview, "status">;
+  mergeRiskOptions: readonly Pick<MergeRiskOption, "category" | "recommended">[];
+}): boolean {
+  if (options.securityReview.status !== "needs_attention") return false;
+  return recommendedMergeRiskOptionCategory(options.mergeRiskOptions) !== "accept_risk";
+}
+
 function hasUnresolvedContributorWork(options: {
   realBehaviorProof: Pick<RealBehaviorProof, "status">;
   reviewFindings: readonly Pick<ReviewFinding, "priority">[];
   securityReview: Pick<SecurityReview, "status">;
+  mergeRiskOptions: readonly Pick<MergeRiskOption, "category" | "recommended">[];
   overallCorrectness: OverallCorrectness;
 }): boolean {
   return (
     proofNeedsContributorAction(options.realBehaviorProof) ||
     hasBlockingReviewFindings(options.reviewFindings) ||
-    options.securityReview.status === "needs_attention" ||
+    securityReviewNeedsContributorWork(options) ||
     options.overallCorrectness === "patch is incorrect"
   );
 }
@@ -9180,11 +9195,12 @@ function isReadyForMaintainerLook(options: {
   realBehaviorProof: Pick<RealBehaviorProof, "status">;
   reviewFindings: readonly Pick<ReviewFinding, "priority">[];
   securityReview: Pick<SecurityReview, "status">;
+  mergeRiskOptions: readonly Pick<MergeRiskOption, "category" | "recommended">[];
   overallCorrectness: OverallCorrectness;
 }): boolean {
   return (
     !hasBlockingReviewFindings(options.reviewFindings) &&
-    options.securityReview.status !== "needs_attention" &&
+    !securityReviewNeedsContributorWork(options) &&
     (options.realBehaviorProof.status === "sufficient" ||
       options.realBehaviorProof.status === "override" ||
       options.realBehaviorProof.status === "not_applicable") &&
@@ -9196,6 +9212,7 @@ function prStatusLabelKind(options: {
   realBehaviorProof: Pick<RealBehaviorProof, "status">;
   reviewFindings: readonly Pick<ReviewFinding, "priority">[];
   securityReview: Pick<SecurityReview, "status">;
+  mergeRiskOptions: readonly Pick<MergeRiskOption, "category" | "recommended">[];
   overallCorrectness: OverallCorrectness;
   hasAutomergeLabel: boolean;
   hasRecentReReviewRequest: boolean;
@@ -9300,6 +9317,7 @@ function prStatusLabelKindFromReport(
     realBehaviorProof: reportRealBehaviorProof(markdown),
     reviewFindings: reportReviewFindings(markdown),
     securityReview: reportSecurityReview(markdown),
+    mergeRiskOptions: mergeRiskOptionsFromReport(markdown),
     overallCorrectness: reportOverallCorrectness(markdown),
     hasAutomergeLabel: currentLabels.includes(AUTOMERGE_LABEL),
     hasRecentReReviewRequest: hasRecentReReviewRequest(
@@ -9321,6 +9339,7 @@ export function prStatusLabelsForTest(
     proofStatus?: string;
     findingPriorities?: readonly number[];
     securityStatus?: string;
+    mergeRiskOptions?: readonly Pick<MergeRiskOption, "category" | "recommended">[];
     overallCorrectness?: string;
     hasAutomergeLabel?: boolean;
     hasRecentReReviewRequest?: boolean;
@@ -9355,6 +9374,7 @@ export function prStatusLabelsForTest(
         ? (options.securityStatus as SecurityReviewStatus)
         : "cleared",
     },
+    mergeRiskOptions: options.mergeRiskOptions ?? [],
     overallCorrectness: OVERALL_CORRECTNESS_VALUES.has(
       options.overallCorrectness as OverallCorrectness,
     )

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -5882,6 +5882,7 @@ function stripProofAndRatingFrontMatter(report: string): string {
 function promotionGhMock(options: {
   number: number;
   title?: string;
+  labels?: string[];
   itemCreatedAt?: string;
   itemUpdatedAt?: string;
   itemUpdatedAtAfterLabelSync?: string;
@@ -5934,6 +5935,7 @@ function promotionGhMock(options: {
 	const closeAppliedBodyLogPath = ${JSON.stringify(options.closeAppliedBodyLogPath ?? "")};
 	const number = ${options.number};
 		const title = ${JSON.stringify(title)};
+		const labels = ${JSON.stringify(options.labels ?? ["status: 📣 needs proof"])};
 		const itemCreatedAt = ${JSON.stringify(itemCreatedAt)};
 		const itemUpdatedAt = ${JSON.stringify(itemUpdatedAt)};
 		const itemUpdatedAtAfterLabelSync = ${JSON.stringify(
@@ -5993,7 +5995,7 @@ function promotionGhMock(options: {
     active_lock_reason: null,
     author_association: "CONTRIBUTOR",
     user: { login: "reporter" },
-    labels: ["status: 📣 needs proof"],
+    labels,
     comments: issueCommentCount,
     pull_request: { url: "https://api.github.com/repos/openclaw/openclaw/pulls/" + number }
   }));
@@ -6654,6 +6656,108 @@ if (args[0] === "api" && /\\/issues\\/74478$/.test(path)) {
           args.includes("feature: ✨ showcase"),
       ),
     );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions routes parsed security owner acceptance to maintainer review", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const labelLogPath = join(root, "label-sync.log");
+    const itemPath = join(itemsDir, "74480.md");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+
+    const sourceReport = `${reportFrontMatter({
+      repository: "openclaw/openclaw",
+      type: "pull_request",
+      number: "74480",
+      title: "Route owner security acceptance",
+      url: "https://github.com/openclaw/openclaw/pull/74480",
+      decision: "keep_open",
+      close_reason: "none",
+      confidence: "high",
+      action_taken: "kept_open",
+      review_status: "complete",
+      local_checkout_access: "verified",
+      author: "contributor",
+      author_association: "CONTRIBUTOR",
+      labels: JSON.stringify(["status: ⏳ waiting on author"]),
+      item_snapshot_hash: "reviewed-snapshot",
+      item_created_at: "2026-02-01T00:00:00Z",
+      item_updated_at: "2026-05-01T00:00:00Z",
+      pull_head_sha: "head-sha",
+      merge_risk_options: JSON.stringify([
+        {
+          title: "Accept the reviewed security tradeoff",
+          body: "A maintainer may accept this bounded security tradeoff before merge.",
+          category: "accept_risk",
+          recommended: true,
+          automergeInstruction: "",
+        },
+      ]),
+    })}
+
+## Summary
+
+The patch is correct and the remaining security decision belongs to a maintainer.
+
+${realBehaviorProofReportSection()}
+
+${prRatingReportSection()}
+
+## Security Review
+
+Status: needs_attention
+
+Summary: A maintainer must explicitly accept the bounded security tradeoff.
+
+## Review Findings
+
+Overall correctness: patch is correct
+
+Overall confidence: 0.95
+
+Full review comments:
+
+- none
+`;
+    const synced = reportWithSyncedReviewComment(sourceReport, 74480);
+    writeFileSync(itemPath, synced.report, "utf8");
+
+    withMockGh(
+      root,
+      promotionGhMock({
+        number: 74480,
+        title: "Route owner security acceptance",
+        labels: ["status: ⏳ waiting on author"],
+        comment: synced.comment,
+        itemUpdatedAtAfterLabelSync: "2026-05-01T00:01:00Z",
+        itemUpdatedAtAfterLabelSyncLogPath: labelLogPath,
+      }),
+      () => {
+        runApplyDecisionsForTest({
+          targetRepo: "openclaw/openclaw",
+          itemsDir,
+          closedDir,
+          plansDir,
+          reportPath,
+          extraArgs: ["--sync-comments-only", "--item-numbers", "74480"],
+        });
+      },
+    );
+
+    const updatedReport = readFileSync(itemPath, "utf8");
+    assert.match(updatedReport, /status: 👀 ready for maintainer look/);
+    assert.doesNotMatch(updatedReport, /status: ⏳ waiting on author/);
+    const labelCalls = readFileSync(labelLogPath, "utf8");
+    assert.match(labelCalls, /--remove-label status: ⏳ waiting on author/);
+    assert.match(labelCalls, /--add-label status: 👀 ready for maintainer look/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -16963,6 +16963,47 @@ test("ClawSweeper PR status labels use one current workflow status", () => {
   );
 });
 
+test("ClawSweeper PR status routes security owner acceptance to maintainer look", () => {
+  const ownerAcceptanceLabels = prStatusLabelsForTest([], {
+    proofStatus: "sufficient",
+    securityStatus: "needs_attention",
+    mergeRiskOptions: [{ category: "accept_risk", recommended: true }],
+    overallCorrectness: "patch is correct",
+  });
+
+  assert.equal(
+    ownerAcceptanceLabels.some((label) => label.endsWith("ready for maintainer look")),
+    true,
+  );
+  assert.equal(
+    ownerAcceptanceLabels.some((label) => label.endsWith("waiting on author")),
+    false,
+  );
+
+  const authorFixLabels = prStatusLabelsForTest([], {
+    proofStatus: "sufficient",
+    securityStatus: "needs_attention",
+    mergeRiskOptions: [{ category: "fix_before_merge", recommended: true }],
+    overallCorrectness: "patch is correct",
+  });
+
+  assert.equal(
+    authorFixLabels.some((label) => label.endsWith("waiting on author")),
+    true,
+  );
+
+  const ambiguousSecurityLabels = prStatusLabelsForTest([], {
+    proofStatus: "sufficient",
+    securityStatus: "needs_attention",
+    overallCorrectness: "patch is correct",
+  });
+
+  assert.equal(
+    ambiguousSecurityLabels.some((label) => label.endsWith("waiting on author")),
+    true,
+  );
+});
+
 test("ClawSweeper PR status labels preserve other label families", () => {
   assert.deepEqual(
     prStatusLabelsForTest(


### PR DESCRIPTION
## Summary

Fixes #263.

This changes PR status label routing so `securityReview.status: needs_attention` is not always treated as contributor-facing work.

When the durable review has:

- sufficient/override/not-applicable proof,
- a correct patch,
- no P0-P2 review findings, and
- a recommended merge-risk option of `accept_risk`,

ClawSweeper now routes the PR to the existing `status: 👀 ready for maintainer look` label instead of `status: ⏳ waiting on author`.

Security reviews that recommend `fix_before_merge`, or security reviews with no structured recommended `accept_risk` option, still route as unresolved contributor work. That preserves the safer default for real author-remediable security defects.

## Validation

- `pnpm run check`
  - 492 unit tests passed.
  - 533 repair tests passed.
  - Changed and full coverage gates passed.
- `node --test --test-name-pattern='security owner acceptance' test/clawsweeper.test.ts`
  - Parsed durable report and apply-path label sync passed.
  - Verified removal of `status: ⏳ waiting on author`.
  - Verified addition of `status: 👀 ready for maintainer look`.
- Codex autoreview: no accepted/actionable findings; patch correct at 0.93 confidence.
