### PR TITLE
Filter ClawSweeper command status activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Prevented trusted ClawSweeper command status comments from re-entering GitHub activity handling and churning review automation. Thanks @ooiuuii.
 - Routed proof-sufficient security reviews that recommend maintainer risk acceptance to maintainer review instead of waiting on the contributor. Thanks @brokemac79.
 - Prevented automatic issue backfill from spending Codex workers on reports explicitly blocked by product-decision, no-new-fix-PR, or maintainer-review signals.
 - Kept issue-generated PRs out of automerge, migrated their labels to `clawsweeper:autofix`, and made clean exact-head autofix reviews wait for required checks to appear, settle green, and reach GitHub merge-state readiness before removing the repair-loop label instead of repeating blocked merge attempts.

--- a/src/repair/notify-github-activity.ts
+++ b/src/repair/notify-github-activity.ts
@@ -378,6 +378,13 @@ export async function runGithubActivityNotifier(
 
 export function routineGithubActivityReason(activity: GithubActivity): string | null {
   const typeAction = `${activity.type}.${activity.action ?? "none"}`;
+  if (
+    activity.type === "issue_comment" &&
+    isBotActor(activity.actor) &&
+    hasCommandStatusMarker(activity)
+  ) {
+    return "routine GitHub activity filtered: ClawSweeper command status comment";
+  }
   const commandLike = activityContainsClawSweeperCommand(activity);
   if (typeAction === "issue_comment.edited" && !commandLike) {
     return "routine GitHub activity filtered: issue comment edit";
@@ -429,7 +436,15 @@ function successfulState(state: string | null): boolean {
 }
 
 function activityContainsClawSweeperCommand(activity: GithubActivity): boolean {
-  const text = [
+  return CLAWSWEEPER_COMMAND_RE.test(activityText(activity));
+}
+
+function hasCommandStatusMarker(activity: GithubActivity): boolean {
+  return /<!--\s*clawsweeper-command(?:-status|-ack|-progress)?:/i.test(activityText(activity));
+}
+
+function activityText(activity: GithubActivity): string {
+  return [
     activity.subject.title,
     stringOrNull(activity.payload.body_excerpt),
     stringOrNull(asJsonObject(activity.payload.comment).body_excerpt),
@@ -437,7 +452,6 @@ function activityContainsClawSweeperCommand(activity: GithubActivity): boolean {
   ]
     .filter((value): value is string => Boolean(value))
     .join("\n");
-  return CLAWSWEEPER_COMMAND_RE.test(text);
 }
 
 function normalizeRepositoryDispatch(

--- a/src/repair/notify-github-activity.ts
+++ b/src/repair/notify-github-activity.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { DEFAULT_TRUSTED_BOTS } from "./config.js";
 import type { JsonObject, JsonValue } from "./json-types.js";
 import { asJsonObject } from "./json-types.js";
 import { parseArgs, repoRoot } from "./lib.js";
@@ -50,6 +51,7 @@ export type GithubActivityNotifierRuntime = {
 
 const DEFAULT_REPORT_PATH = "notifications/github-activity-report.json";
 const BODY_EXCERPT_LIMIT = 1200;
+const TRUSTED_CLAWSWEEPER_BOTS = new Set(DEFAULT_TRUSTED_BOTS.map((login) => login.toLowerCase()));
 const CLAWSWEEPER_COMMAND_RE =
   /(^|\s)(@(clawsweeper|openclaw-clawsweeper)(\[bot\])?\b|\/(clawsweeper|review|re-review|re-run|rerun|automerge|autoclose)\b)/i;
 
@@ -380,8 +382,8 @@ export function routineGithubActivityReason(activity: GithubActivity): string | 
   const typeAction = `${activity.type}.${activity.action ?? "none"}`;
   if (
     activity.type === "issue_comment" &&
-    isBotActor(activity.actor) &&
-    hasCommandStatusMarker(activity)
+    isTrustedClawSweeperComment(activity) &&
+    hasCommandStatusMarker(asJsonObject(activity.payload.comment).body_excerpt)
   ) {
     return "routine GitHub activity filtered: ClawSweeper command status comment";
   }
@@ -439,8 +441,23 @@ function activityContainsClawSweeperCommand(activity: GithubActivity): boolean {
   return CLAWSWEEPER_COMMAND_RE.test(activityText(activity));
 }
 
-function hasCommandStatusMarker(activity: GithubActivity): boolean {
-  return /<!--\s*clawsweeper-command(?:-status|-ack|-progress)?:/i.test(activityText(activity));
+function isTrustedClawSweeperComment(activity: GithubActivity): boolean {
+  const commentAuthor = stringOrNull(asJsonObject(activity.payload.comment).author);
+  return isTrustedClawSweeperBot(activity.actor) && isTrustedClawSweeperBot(commentAuthor);
+}
+
+function isTrustedClawSweeperBot(login: string | null): boolean {
+  return typeof login === "string" && TRUSTED_CLAWSWEEPER_BOTS.has(login.toLowerCase());
+}
+
+function hasCommandStatusMarker(value: unknown): boolean {
+  const text = stringOrNull(value);
+  return (
+    typeof text === "string" &&
+    /<!--\s*clawsweeper-command(?:(?:-status|-ack):[^>]+|-progress:(?:start|end)|:[^>]+)\s*-->/i.test(
+      text,
+    )
+  );
 }
 
 function activityText(activity: GithubActivity): string {

--- a/test/repair/notify-github-activity.test.ts
+++ b/test/repair/notify-github-activity.test.ts
@@ -395,6 +395,37 @@ test("routineGithubActivityReason keeps explicit ClawSweeper commands visible", 
   assert.equal(routineGithubActivityReason(rerun!), null);
 });
 
+test("routineGithubActivityReason filters ClawSweeper command status comment edits", () => {
+  const activity = normalizeGithubActivity({
+    eventName: "issue_comment",
+    payload: {
+      action: "edited",
+      repository: { full_name: "openclaw/openclaw" },
+      sender: { login: "clawsweeper[bot]" },
+      issue: {
+        number: 90328,
+        title: "Expose model picker agent runtimes",
+        state: "open",
+        html_url: "https://github.com/openclaw/openclaw/pull/90328",
+        pull_request: {},
+      },
+      comment: {
+        id: 4643099431,
+        html_url: "https://github.com/openclaw/openclaw/pull/90328#issuecomment-4643099431",
+        body: [
+          "<!-- clawsweeper-command-status:90328:re_review:bc62b391bf7 -->",
+          "<!-- clawsweeper-command:4643099431:2026-06-07T15:28:02Z:re_review:bc62b391bf7 -->",
+          "🦞👀",
+          "ClawSweeper is reviewing @clawsweeper re-review.",
+        ].join("\n"),
+        user: { login: "clawsweeper[bot]" },
+      },
+    },
+  });
+
+  assert.match(routineGithubActivityReason(activity!) ?? "", /command status comment/);
+});
+
 test("routineGithubActivityReason filters duplicate PR synchronize and successful automation", () => {
   const synchronize = normalizeGithubActivity({
     eventName: "pull_request_target",

--- a/test/repair/notify-github-activity.test.ts
+++ b/test/repair/notify-github-activity.test.ts
@@ -395,35 +395,68 @@ test("routineGithubActivityReason keeps explicit ClawSweeper commands visible", 
   assert.equal(routineGithubActivityReason(rerun!), null);
 });
 
-test("routineGithubActivityReason filters ClawSweeper command status comment edits", () => {
-  const activity = normalizeGithubActivity({
-    eventName: "issue_comment",
-    payload: {
-      action: "edited",
-      repository: { full_name: "openclaw/openclaw" },
-      sender: { login: "clawsweeper[bot]" },
-      issue: {
-        number: 90328,
-        title: "Expose model picker agent runtimes",
-        state: "open",
-        html_url: "https://github.com/openclaw/openclaw/pull/90328",
-        pull_request: {},
+test("routineGithubActivityReason filters trusted ClawSweeper command status comments", () => {
+  for (const action of ["created", "edited"]) {
+    const activity = normalizeGithubActivity({
+      eventName: "issue_comment",
+      payload: {
+        action,
+        repository: { full_name: "openclaw/openclaw" },
+        sender: { login: "clawsweeper[bot]" },
+        issue: {
+          number: 90328,
+          title: "Expose model picker agent runtimes",
+          state: "open",
+          html_url: "https://github.com/openclaw/openclaw/pull/90328",
+          pull_request: {},
+        },
+        comment: {
+          id: 4643099431,
+          html_url: "https://github.com/openclaw/openclaw/pull/90328#issuecomment-4643099431",
+          body: [
+            "<!-- clawsweeper-command-status:90328:re_review:bc62b391bf7 -->",
+            "<!-- clawsweeper-command:4643099431:2026-06-07T15:28:02Z:re_review:bc62b391bf7 -->",
+            "🦞👀",
+            "ClawSweeper is reviewing @clawsweeper re-review.",
+          ].join("\n"),
+          user: { login: "clawsweeper[bot]" },
+        },
       },
-      comment: {
-        id: 4643099431,
-        html_url: "https://github.com/openclaw/openclaw/pull/90328#issuecomment-4643099431",
-        body: [
-          "<!-- clawsweeper-command-status:90328:re_review:bc62b391bf7 -->",
-          "<!-- clawsweeper-command:4643099431:2026-06-07T15:28:02Z:re_review:bc62b391bf7 -->",
-          "🦞👀",
-          "ClawSweeper is reviewing @clawsweeper re-review.",
-        ].join("\n"),
-        user: { login: "clawsweeper[bot]" },
-      },
-    },
-  });
+    });
 
-  assert.match(routineGithubActivityReason(activity!) ?? "", /command status comment/);
+    assert.match(routineGithubActivityReason(activity!) ?? "", /command status comment/);
+  }
+});
+
+test("routineGithubActivityReason preserves untrusted marker-backed commands", () => {
+  for (const login of ["contributor", "third-party[bot]"]) {
+    const activity = normalizeGithubActivity({
+      eventName: "issue_comment",
+      payload: {
+        action: "edited",
+        repository: { full_name: "openclaw/openclaw" },
+        sender: { login },
+        issue: {
+          number: 90328,
+          title: "<!-- clawsweeper-command-status:90328:re_review:abc -->",
+          state: "open",
+          html_url: "https://github.com/openclaw/openclaw/pull/90328",
+          pull_request: {},
+        },
+        comment: {
+          id: 4643099431,
+          html_url: "https://github.com/openclaw/openclaw/pull/90328#issuecomment-4643099431",
+          body: [
+            "<!-- clawsweeper-command-status:90328:re_review:bc62b391bf7 -->",
+            "@clawsweeper re-review",
+          ].join("\n"),
+          user: { login },
+        },
+      },
+    });
+
+    assert.equal(routineGithubActivityReason(activity!), null);
+  }
 });
 
 test("routineGithubActivityReason filters duplicate PR synchronize and successful automation", () => {


### PR DESCRIPTION
Fixes #266.

## Summary

- filter trusted ClawSweeper command ack/status/progress comment activity before command-like activity handling
- keep explicit human ClawSweeper commands visible to the activity lane
- preserve commands from human and third-party bot comments even when they quote ClawSweeper markers
- cover both created and edited comment events using the #90328 command-status marker shape

## Real Behavior Proof

Observed on openclaw/openclaw#90328 after the final manual `@clawsweeper re-review`: multiple `ClawSweeper Dispatch` runs were triggered by `issue_comment` events without new pushes or new manual commands, while ClawSweeper labels/rating/status churned. The status comment body contained marker-backed command/status text such as:

```text
<!-- clawsweeper-command-status:90328:re_review:bc62b391bf7 -->
<!-- clawsweeper-command:4643099431:2026-06-07T15:28:02Z:re_review:bc62b391bf7 -->
```

After this patch, `routineGithubActivityReason` treats marker-backed comments as routine only when both the event actor and comment author are trusted ClawSweeper bot identities. Marker detection is restricted to complete markers in the comment body, while human and third-party bot commands remain visible.

Supported-runtime after-fix notifier proof using Node 24 and the redacted #90328 marker-backed bot `issue_comment.edited` event shape:

```text
=== node24 version ===
v24.16.0
=== notifier proof: bot status comment edit is skipped ===
{"status":"skipped","sent":0,"failed":0,"exitCode":0,"reason":"routine GitHub activity filtered: ClawSweeper command status comment"}
=== report reason ===
routine GitHub activity filtered: ClawSweeper command status comment
issue_comment
edited
clawsweeper[bot]
90328
```

Focused Node 24 regression output, showing explicit commands still route while command-status bot edits are skipped:

```text
✔ routineGithubActivityReason keeps explicit ClawSweeper commands visible (2.931125ms)
✔ routineGithubActivityReason filters ClawSweeper command status comment edits (0.497237ms)
ℹ tests 2
ℹ suites 0
ℹ pass 2
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 202.139617
```

## Validation

- `pnpm run check`
  - 492 unit tests passed.
  - 535 repair tests passed.
  - Changed and full coverage gates passed.
- `node --test --test-name-pattern='routineGithubActivityReason' test/repair/notify-github-activity.test.ts`
  - Trusted ClawSweeper created and edited status comments are filtered.
  - Human and third-party bot marker-backed commands remain visible.
- Three parallel Codex reviews checked trust boundaries, current-main compatibility, and regression coverage.
- Final Codex autoreview: no accepted/actionable findings; patch correct at 0.86 confidence.
