### PR TITLE
Fix apply workflow sync before state hydration

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1866,6 +1866,9 @@ jobs:
             echo "target_repo_name=$target_name"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Sync source checkout before state hydration
+        run: git pull --rebase
+
       - name: Create target write token
         id: target-write-token
         continue-on-error: true
@@ -1893,9 +1896,6 @@ jobs:
       - uses: ./.github/actions/setup-pnpm
         with:
           build-script: build:all
-
-      - name: Sync before applying decisions
-        run: git pull --rebase
 
       - name: Reconcile before apply preselect
         env:

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -16366,7 +16366,7 @@ test("publish workflow installs Codex from the root checkout path", () => {
 });
 
 test("apply workflow installs Codex only when proof-eligible apply work can run", () => {
-  const workflow = readFileSync(".github/workflows/sweep.yml", "utf8");
+  const workflow = readFileSync(".github/workflows/sweep.yml", "utf8").replace(/\r\n/g, "\n");
   const applyJobStart = workflow.indexOf("\n  apply-existing:");
   assert.notEqual(applyJobStart, -1);
   const applyJob = workflow.slice(applyJobStart);
@@ -16394,8 +16394,10 @@ test("apply workflow installs Codex only when proof-eligible apply work can run"
   assert.match(preselectBlock, /comment-sync-batch/);
   assert.match(preselectBlock, /batch_count="\$\(awk -F=/);
   const syncOnlyStart = preselectBlock.indexOf('if [ "$sync_comments_only" = "true" ]; then');
-  const nonSyncStart = preselectBlock.indexOf("\n          else\n            proof_args=(");
   assert.ok(syncOnlyStart !== -1);
+  const nonSyncMatch = /\n\s+else\n\s+proof_args=\(/.exec(preselectBlock.slice(syncOnlyStart));
+  assert.ok(nonSyncMatch);
+  const nonSyncStart = syncOnlyStart + nonSyncMatch.index;
   assert.ok(nonSyncStart > syncOnlyStart);
   assert.doesNotMatch(preselectBlock.slice(syncOnlyStart, nonSyncStart), /needs_codex=true/);
   assert.match(preselectBlock, /\[ -n "\$item_numbers" \]/);
@@ -16404,6 +16406,25 @@ test("apply workflow installs Codex only when proof-eligible apply work can run"
   assert.match(preselectBlock, /if \[ -n "\$selected" \]; then\s+needs_codex=true/);
   assert.doesNotMatch(preselectBlock, /if \[ -n "\$item_numbers" \]; then\s+needs_codex=true/);
   assert.doesNotMatch(preselectBlock, /normalized_apply_close_reasons=/);
+});
+
+test("apply workflow syncs source checkout before state hydration", () => {
+  const workflow = readFileSync(".github/workflows/sweep.yml", "utf8").replace(/\r\n/g, "\n");
+  const applyJobStart = workflow.indexOf("\n  apply-existing:");
+  assert.notEqual(applyJobStart, -1);
+  const applyJob = workflow.slice(applyJobStart);
+  const resolveTargetStart = applyJob.indexOf("- name: Resolve target repository");
+  const syncStart = applyJob.indexOf("- name: Sync source checkout before state hydration");
+  const setupStateStart = applyJob.indexOf("- uses: ./.github/actions/setup-state");
+  const reconcileStart = applyJob.indexOf("- name: Reconcile before apply preselect");
+
+  assert.ok(resolveTargetStart !== -1);
+  assert.ok(syncStart > resolveTargetStart);
+  assert.ok(setupStateStart > syncStart);
+  assert.ok(reconcileStart > setupStateStart);
+  assert.equal(applyJob.indexOf("- name: Sync before applying decisions"), -1);
+  assert.match(applyJob.slice(syncStart, setupStateStart), /run: git pull --rebase/);
+  assert.doesNotMatch(applyJob.slice(setupStateStart, reconcileStart), /git pull --rebase/);
 });
 
 test("sweep target tokens fall back when an org app installation is missing", () => {


### PR DESCRIPTION
## Summary

- Move the apply-existing job's `git pull --rebase` before state hydration so the source checkout is still clean when it syncs.
- Remove the post-hydration pull that could fail after generated state copied tracked paths into the worktree.
- Add a regression assertion that the apply lane syncs before `setup-state` and does not rebase between hydration and reconcile.

Fixes #270.

## Validation

- `pnpm run build:all` passed
- `node --test --test-name-pattern "apply workflow" test/clawsweeper.test.ts` passed
- `pnpm run format:check` passed
- `pnpm run check` reached build and lint successfully, then failed during `test:unit` on this Windows host in unrelated environment-sensitive tests: Codex proof spawn returns `EPERM`, one test expects `/usr/bin/git`, and a POSIX file-mode assertion sees Windows modes.

## Runtime Proof

Generated from a fresh throwaway clone of this PR branch plus a fresh public state checkout. Paths are local temp paths and omitted here. No `apply-decisions`, close, or other mutation command was run.

```text
HEAD=eebe840
STATUS_BEFORE_SYNC=
git pull --rebase
Already up to date.
STATUS_AFTER_SYNC=

HYDRATE_START
{"hydrated":["records","jobs","results","assets","apply-report.json","repair-apply-report.json"],"source":"<temp>/clawsweeper-state","target":"<temp>/clawsweeper"}
HYDRATE_EXIT=0
STATUS_AFTER_HYDRATE_COUNT=1

RECONCILE_FULL_START
pnpm run reconcile -- --target-repo openclaw/openclaw --skip-closed-at
{
  "openItemsSeen": 7949,
  "pagesScanned": 80,
  "movedToClosed": 1885,
  "movedToItems": 3,
  "removedStaleClosedCopies": 0,
  "fetchedClosedAt": 0
}
RECONCILE_FULL_EXIT=0
```

This demonstrates the reordered apply-existing path can sync the source checkout before hydration, hydrate state, and reach/complete reconcile without the dirty-worktree rebase failure.