### PR TITLE
fix: autostash workflow rebases

### DIFF
--- a/.github/workflows/commit-review.yml
+++ b/.github/workflows/commit-review.yml
@@ -501,7 +501,7 @@ jobs:
       - name: Commit reports
         run: |
           set -euo pipefail
-          git pull --rebase
+          git pull --rebase --autostash
           node dist/commit-sweeper.js copy-artifacts --artifact-dir commit-artifacts --records-dir records
           pnpm run repair:publish-main -- \
             --message "chore: update commit review reports" \

--- a/.github/workflows/repair-issue-implementation-intake.yml
+++ b/.github/workflows/repair-issue-implementation-intake.yml
@@ -168,7 +168,7 @@ jobs:
           if [ -n "$MAX_LIVE_WORKERS" ]; then
             cap_args=(--max-live-workers "$MAX_LIVE_WORKERS")
           fi
-          git pull --rebase
+          git pull --rebase --autostash
           pnpm run repair:dispatch -- "${{ steps.prepare.outputs.job_path }}" \
             --mode autonomous \
             --wait-for-capacity \

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1226,7 +1226,7 @@ jobs:
           merge-multiple: true
 
       - name: Sync before applying artifacts
-        run: git pull --rebase
+        run: git pull --rebase --autostash
 
       - name: Apply review artifacts
         env:
@@ -1440,7 +1440,7 @@ jobs:
             echo "No review artifacts to sync comments for."
             exit 0
           fi
-          git pull --rebase
+          git pull --rebase --autostash
           pnpm run apply-decisions -- \
             --target-repo "$TARGET_REPO" \
             --skip-dashboard \
@@ -1492,7 +1492,7 @@ jobs:
           item_count="$(pnpm run --silent workflow -- count-csv --items "$item_numbers")"
           close_reasons="${{ github.event.inputs.apply_after_review_close_reasons || 'implemented_on_main,duplicate_or_superseded,low_signal_unmergeable_pr' }}"
           min_age_minutes="${{ github.event.inputs.apply_after_review_min_age_minutes || '0' }}"
-          git pull --rebase
+          git pull --rebase --autostash
           pnpm run apply-decisions -- \
             --target-repo "$TARGET_REPO" \
             --skip-dashboard \
@@ -1682,7 +1682,7 @@ jobs:
           CODEX_TIMEOUT_MS: ${{ vars.CLAWSWEEPER_FAILED_REVIEW_RETRY_CODEX_TIMEOUT_MS || vars.CLAWSWEEPER_CODEX_TIMEOUT_MS || '600000' }}
         run: |
           set -euo pipefail
-          git pull --rebase
+          git pull --rebase --autostash
           dry_run_arg=()
           if [ "$DRY_RUN" = "true" ]; then
             dry_run_arg=(--dry-run)
@@ -1798,7 +1798,7 @@ jobs:
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
         run: |
           set -euo pipefail
-          git pull --rebase
+          git pull --rebase --autostash
           reconcile_json="$(pnpm run --silent reconcile -- --target-repo "$TARGET_REPO" --max-pages 250 --skip-closed-at)"
           echo "$reconcile_json"
           moved_to_closed="$(jq -r '.movedToClosed' <<<"$reconcile_json")"
@@ -1895,7 +1895,7 @@ jobs:
           build-script: build:all
 
       - name: Sync before applying decisions
-        run: git pull --rebase
+        run: git pull --rebase --autostash
 
       - name: Reconcile before apply preselect
         env:


### PR DESCRIPTION
## Summary
- add `--autostash` to ClawSweeper workflow rebases that can run after generated state hydration
- cover scheduled sweep/apply/comment-sync, commit-review report publishing, and repair issue intake dispatch

## Why
The scheduled `Sync Codex review comments` run was failing at `git pull --rebase` with `cannot pull with rebase: You have unstaged changes` after `setup-state` hydrated generated state into the checkout. Autostash lets the workflow sync with `main` without losing the hydrated generated files that later steps use.

## Validation
- `git diff --check`
- `pnpm exec oxfmt --check .github/workflows/sweep.yml .github/workflows/commit-review.yml .github/workflows/repair-issue-implementation-intake.yml`
- `pnpm run build:all`