### PR TITLE
fix: adapt codex timeout for PR webhooks

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -181,7 +181,7 @@ jobs:
           target_branch="${{ github.event.client_payload.target_branch || 'main' }}"
           item_number="${{ github.event.client_payload.item_number || '' }}"
           item_kind="${{ github.event.client_payload.item_kind || '' }}"
-          codex_timeout_ms="${{ github.event.client_payload.codex_timeout_ms || '600000' }}"
+          codex_timeout_ms="${{ github.event.client_payload.codex_timeout_ms || vars.CLAWSWEEPER_CODEX_TIMEOUT_MS || '1200000' }}"
           if ! printf '%s' "$target_repo" | grep -Eq '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'; then
             echo "Invalid target_repo: $target_repo" >&2
             exit 1
@@ -202,8 +202,8 @@ jobs:
               ;;
           esac
           if ! printf '%s' "$codex_timeout_ms" | grep -Eq '^[0-9]+$'; then
-            echo "::warning::Invalid codex_timeout_ms payload '$codex_timeout_ms'; using 600000."
-            codex_timeout_ms="600000"
+            echo "::warning::Invalid codex_timeout_ms payload '$codex_timeout_ms'; using 1200000."
+            codex_timeout_ms="1200000"
           fi
           if [ "$codex_timeout_ms" -lt 600000 ]; then
             codex_timeout_ms="600000"

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -181,6 +181,7 @@ jobs:
           target_branch="${{ github.event.client_payload.target_branch || 'main' }}"
           item_number="${{ github.event.client_payload.item_number || '' }}"
           item_kind="${{ github.event.client_payload.item_kind || '' }}"
+          codex_timeout_ms="${{ github.event.client_payload.codex_timeout_ms || '600000' }}"
           if ! printf '%s' "$target_repo" | grep -Eq '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'; then
             echo "Invalid target_repo: $target_repo" >&2
             exit 1
@@ -200,6 +201,16 @@ jobs:
               exit 1
               ;;
           esac
+          if ! printf '%s' "$codex_timeout_ms" | grep -Eq '^[0-9]+$'; then
+            echo "::warning::Invalid codex_timeout_ms payload '$codex_timeout_ms'; using 600000."
+            codex_timeout_ms="600000"
+          fi
+          if [ "$codex_timeout_ms" -lt 600000 ]; then
+            codex_timeout_ms="600000"
+          fi
+          if [ "$codex_timeout_ms" -gt 1800000 ]; then
+            codex_timeout_ms="1800000"
+          fi
           target_owner="${target_repo%%/*}"
           target_name="${target_repo#*/}"
           target_checkout_dir="$target_name"
@@ -213,6 +224,7 @@ jobs:
             echo "target_branch=$target_branch"
             echo "target_checkout_dir=$target_checkout_dir"
             echo "item_number=$item_number"
+            echo "codex_timeout_ms=$codex_timeout_ms"
           } >> "$GITHUB_OUTPUT"
 
       - uses: ./.github/actions/setup-pnpm
@@ -355,16 +367,24 @@ jobs:
         run: |
           set -euo pipefail
           test -n "$GH_TOKEN"
-          if ! [[ "$CODEX_TIMEOUT_MS" =~ ^[0-9]+$ ]] || [ "$CODEX_TIMEOUT_MS" -lt 1 ]; then
-            echo "Invalid Codex timeout: $CODEX_TIMEOUT_MS" >&2
+          codex_timeout_ms="${{ steps.target.outputs.codex_timeout_ms }}"
+          if ! [[ "$codex_timeout_ms" =~ ^[0-9]+$ ]] || [ "$codex_timeout_ms" -lt 1 ]; then
+            echo "Invalid Codex timeout: $codex_timeout_ms" >&2
             exit 1
           fi
           additional_prompt_arg=()
           if [ -n "$ADDITIONAL_PROMPT" ]; then
             additional_prompt_arg=(--additional-prompt "$ADDITIONAL_PROMPT")
           fi
-          codex_timeout_seconds=$(((CODEX_TIMEOUT_MS + 999) / 1000))
+          codex_timeout_seconds=$(((codex_timeout_ms + 999) / 1000))
           review_timeout_seconds=$((codex_timeout_seconds + 180))
+          if [ "$review_timeout_seconds" -lt 300 ]; then
+            review_timeout_seconds=300
+          fi
+          if [ "$review_timeout_seconds" -gt 4200 ]; then
+            review_timeout_seconds=4200
+          fi
+          echo "::notice::Exact event review timeout is ${review_timeout_seconds}s for per-item Codex timeout ${codex_timeout_seconds}s."
           timeout --kill-after=30s "${review_timeout_seconds}s" pnpm run review -- \
             --target-repo "${{ steps.target.outputs.target_repo }}" \
             --target-dir "${{ steps.target.outputs.target_checkout_dir }}" \
@@ -374,7 +394,7 @@ jobs:
             --codex-model internal \
             --codex-reasoning-effort high \
             --codex-sandbox danger-full-access \
-            --codex-timeout-ms "$CODEX_TIMEOUT_MS" \
+            --codex-timeout-ms "$codex_timeout_ms" \
             --item-numbers "${{ steps.target.outputs.item_number }}" \
             --readonly-openclaw \
             --shard-index 0 \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ checkpoint, and status-only commits are intentionally omitted.
 - Served stale dashboard status immediately while coalescing a background refresh, bounded job-detail fanout, and cached and parallelized historical GitHub lookups to reduce cold-load latency, diagnostic timeouts, and API usage.
 - Preserved records written by concurrent workers during generated-state publish races while retaining deliberate item-to-closed moves and plan cleanup.
 - Raised and unified Codex review timeouts at 20 minutes, including exact event reviews, so high-context reviews do not fall back at the previous 10-minute ceiling.
+- Scale pull request review timeouts for large diffs and video proofs while preserving the configured exact-event fallback for dispatches without adaptive payloads. Thanks @TurboTheTurtle.
 - Deferred workflow utility CLI execution until module initialization completes, preventing apply preselection from crashing on close-action constants.
 - Prevented verbose Codex review and repair subprocess output from overflowing memory, retained capped durable logs and bounded redacted diagnostic tails, stopped retrying terminal model-access failures, and pinned the CLI/proxy pair to compatible version 0.139.0. Thanks @fuller-stack-dev.
 - Hydrated generated pull request review findings into automerge repair jobs instead of routing repairs through the original issue-only artifact.

--- a/src/repair/comment-webhook.ts
+++ b/src/repair/comment-webhook.ts
@@ -27,6 +27,17 @@ const PULL_ITEM_ACTIONS = new Set([
   "unlabeled",
 ]);
 const DEFAULT_FAST_ACK_SETTLE_DELAYS_MS = [250, 1500, 10_000];
+const DEFAULT_CODEX_TIMEOUT_MS = 600_000;
+const MAX_ADAPTIVE_CODEX_TIMEOUT_MS = 1_800_000;
+const PR_SIZE_BASELINE_FILES = 20;
+const PR_SIZE_FILE_STEP_MS = 10_000;
+const PR_SIZE_BASELINE_LINES = 1_000;
+const PR_SIZE_LINE_STEP_MS = 50;
+const MAX_PR_FILE_TIMEOUT_BONUS_MS = 600_000;
+const MAX_PR_LINE_TIMEOUT_BONUS_MS = 300_000;
+const MEDIA_PROOF_TIMEOUT_BONUS_MS = 120_000;
+const MAX_MEDIA_PROOF_URLS = 4;
+const VIDEO_PROOF_EXTENSIONS = new Set([".mov", ".mp4", ".m4v", ".webm", ".avi", ".mkv"]);
 const inFlightFastAcks = new Map<string, Promise<number>>();
 
 type AcceptedIssueCommentWebhook = {
@@ -51,6 +62,7 @@ type AcceptedItemWebhook = {
   sourceEvent: "issues" | "pull_request";
   sourceAction: string;
   supersedesInProgress: boolean;
+  codexTimeoutMs?: number;
 };
 
 type AcceptedWebhook = AcceptedIssueCommentWebhook | AcceptedItemWebhook;
@@ -285,10 +297,81 @@ export function classifyItemWebhook({ event, payload }: { event: string; payload
       sourceEvent: "pull_request",
       sourceAction: action,
       supersedesInProgress: ["edited", "synchronize", "ready_for_review"].includes(action),
+      codexTimeoutMs: adaptiveCodexTimeoutMsForPullRequest(pull),
     };
   }
 
   return { accepted: false, reason: "unsupported event" };
+}
+
+export function adaptiveCodexTimeoutMsForTest(pull: LooseRecord) {
+  return adaptiveCodexTimeoutMsForPullRequest(pull);
+}
+
+function adaptiveCodexTimeoutMsForPullRequest(pull: LooseRecord) {
+  const changedFiles = nonNegativeInteger(pull.changed_files);
+  const changedLines = nonNegativeInteger(pull.additions) + nonNegativeInteger(pull.deletions);
+  const mediaProofUrls = videoProofUrlsFromText(
+    [String(pull.title ?? ""), String(pull.body ?? "")].join("\n"),
+  );
+  const fileBonusMs = clamp(
+    (changedFiles - PR_SIZE_BASELINE_FILES) * PR_SIZE_FILE_STEP_MS,
+    0,
+    MAX_PR_FILE_TIMEOUT_BONUS_MS,
+  );
+  const lineBonusMs = clamp(
+    (changedLines - PR_SIZE_BASELINE_LINES) * PR_SIZE_LINE_STEP_MS,
+    0,
+    MAX_PR_LINE_TIMEOUT_BONUS_MS,
+  );
+  const mediaBonusMs = mediaProofUrls.length * MEDIA_PROOF_TIMEOUT_BONUS_MS;
+  return clamp(
+    DEFAULT_CODEX_TIMEOUT_MS + fileBonusMs + lineBonusMs + mediaBonusMs,
+    DEFAULT_CODEX_TIMEOUT_MS,
+    MAX_ADAPTIVE_CODEX_TIMEOUT_MS,
+  );
+}
+
+function videoProofUrlsFromText(text: string) {
+  const matches = text.match(/https?:\/\/[^\s<>"'\\)]+/g) ?? [];
+  const urls: string[] = [];
+  const seen = new Set<string>();
+  for (const raw of matches) {
+    const cleaned = trimTrailingUrlPunctuation(raw);
+    let parsed: URL;
+    try {
+      parsed = new URL(cleaned);
+    } catch {
+      continue;
+    }
+    const pathname = parsed.pathname.toLowerCase();
+    const isVideo = [...VIDEO_PROOF_EXTENSIONS].some((extension) => pathname.endsWith(extension));
+    if (!isVideo || seen.has(parsed.href)) continue;
+    seen.add(parsed.href);
+    urls.push(parsed.href);
+    if (urls.length >= MAX_MEDIA_PROOF_URLS) break;
+  }
+  return urls;
+}
+
+function trimTrailingUrlPunctuation(raw: string): string {
+  let end = raw.length;
+  while (end > 0) {
+    const char = raw.charCodeAt(end - 1);
+    if (char !== 44 && char !== 46 && char !== 58 && char !== 59) break;
+    end -= 1;
+  }
+  return raw.slice(0, end);
+}
+
+function nonNegativeInteger(value: JsonValue) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 0;
+  return Math.floor(parsed);
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
 }
 
 function isEligibleRepositoryPayload(repo: LooseRecord) {
@@ -680,6 +763,7 @@ async function dispatchItemReview({
         source_event: accepted.sourceEvent,
         source_action: accepted.sourceAction,
         supersedes_in_progress: accepted.supersedesInProgress,
+        ...(accepted.codexTimeoutMs ? { codex_timeout_ms: accepted.codexTimeoutMs } : {}),
       },
     },
   });

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -18118,6 +18118,36 @@ test("setup-state defaults to an auth-safe shallow checkout", () => {
   assert.match(action, /ref: state/);
 });
 
+test("sweep exact event reviews consume adaptive Codex timeout payload", () => {
+  const workflow = readFileSync(".github/workflows/sweep.yml", "utf8");
+  const resolveBlock = workflow.slice(
+    workflow.indexOf("- name: Resolve event payload"),
+    workflow.indexOf("- name: Create target read token"),
+  );
+  const reviewBlock = workflow.slice(
+    workflow.indexOf("- name: Review exact event item"),
+    workflow.indexOf("- name: Create state token"),
+  );
+
+  assert.match(
+    resolveBlock,
+    /codex_timeout_ms="\$\{\{ github\.event\.client_payload\.codex_timeout_ms \|\| '600000' \}\}"/,
+  );
+  assert.match(resolveBlock, /Invalid codex_timeout_ms payload/);
+  assert.match(resolveBlock, /\[ "\$codex_timeout_ms" -lt 600000 \]/);
+  assert.match(resolveBlock, /\[ "\$codex_timeout_ms" -gt 1800000 \]/);
+  assert.match(resolveBlock, /echo "codex_timeout_ms=\$codex_timeout_ms"/);
+  assert.match(
+    reviewBlock,
+    /codex_timeout_ms="\$\{\{ steps\.target\.outputs\.codex_timeout_ms \}\}"/,
+  );
+  assert.match(reviewBlock, /review_timeout_seconds=\$\(\(codex_timeout_seconds \+ 180\)\)/);
+  assert.match(reviewBlock, /timeout --kill-after=30s "\$\{review_timeout_seconds\}s"/);
+  assert.match(reviewBlock, /--codex-timeout-ms "\$codex_timeout_ms"/);
+  assert.doesNotMatch(reviewBlock, /timeout --kill-after=30s 12m/);
+  assert.doesNotMatch(reviewBlock, /--codex-timeout-ms 600000/);
+});
+
 test("github activity workflow coalesces noisy observer runs", () => {
   const workflow = readFileSync(".github/workflows/github-activity.yml", "utf8");
   const concurrencyBlock = workflow.slice(
@@ -18290,7 +18320,7 @@ test("sweep workflow runs exact event reviews without a global worker gate", () 
     /CODEX_TIMEOUT_MS: \$\{\{ github\.event\.client_payload\.codex_timeout_ms \|\| vars\.CLAWSWEEPER_CODEX_TIMEOUT_MS \|\| '1200000' \}\}/,
   );
   assert.match(exactReviewStep, /review_timeout_seconds=\$\(\(codex_timeout_seconds \+ 180\)\)/);
-  assert.match(exactReviewStep, /--codex-timeout-ms "\$CODEX_TIMEOUT_MS"/);
+  assert.match(exactReviewStep, /--codex-timeout-ms "\$codex_timeout_ms"/);
   assert.doesNotMatch(exactReviewStep, /--codex-timeout-ms 600000/);
   assert.doesNotMatch(eventReviewBlock, /Wait for exact event review capacity/);
   assert.doesNotMatch(eventReviewBlock, /wait-exact-event-capacity/);

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -18131,7 +18131,7 @@ test("sweep exact event reviews consume adaptive Codex timeout payload", () => {
 
   assert.match(
     resolveBlock,
-    /codex_timeout_ms="\$\{\{ github\.event\.client_payload\.codex_timeout_ms \|\| '600000' \}\}"/,
+    /codex_timeout_ms="\$\{\{ github\.event\.client_payload\.codex_timeout_ms \|\| vars\.CLAWSWEEPER_CODEX_TIMEOUT_MS \|\| '1200000' \}\}"/,
   );
   assert.match(resolveBlock, /Invalid codex_timeout_ms payload/);
   assert.match(resolveBlock, /\[ "\$codex_timeout_ms" -lt 600000 \]/);
@@ -18146,6 +18146,24 @@ test("sweep exact event reviews consume adaptive Codex timeout payload", () => {
   assert.match(reviewBlock, /--codex-timeout-ms "\$codex_timeout_ms"/);
   assert.doesNotMatch(reviewBlock, /timeout --kill-after=30s 12m/);
   assert.doesNotMatch(reviewBlock, /--codex-timeout-ms 600000/);
+});
+
+test("sweep exact event reviews preserve the configured fallback without an adaptive payload", () => {
+  const workflow = readFileSync(".github/workflows/sweep.yml", "utf8");
+  const resolveBlock = workflow.slice(
+    workflow.indexOf("- name: Resolve event payload"),
+    workflow.indexOf("- name: Create target read token"),
+  );
+
+  assert.match(
+    resolveBlock,
+    /github\.event\.client_payload\.codex_timeout_ms \|\| vars\.CLAWSWEEPER_CODEX_TIMEOUT_MS \|\| '1200000'/,
+  );
+  assert.match(resolveBlock, /using 1200000/);
+  assert.doesNotMatch(
+    resolveBlock,
+    /codex_timeout_ms="\$\{\{ github\.event\.client_payload\.codex_timeout_ms \|\| '600000' \}\}"/,
+  );
 });
 
 test("github activity workflow coalesces noisy observer runs", () => {

--- a/test/repair/comment-webhook.test.ts
+++ b/test/repair/comment-webhook.test.ts
@@ -3,6 +3,7 @@ import crypto from "node:crypto";
 import test from "node:test";
 
 import {
+  adaptiveCodexTimeoutMsForTest,
   classifyItemWebhook,
   classifyIssueCommentWebhook,
   classifyWebhook,
@@ -319,7 +320,129 @@ test("webhook accepts eligible pull request events for generic steipete reposito
     sourceEvent: "pull_request",
     sourceAction: "synchronize",
     supersedesInProgress: true,
+    codexTimeoutMs: 600_000,
   });
+});
+
+test("adaptive Codex timeout preserves the default for small non-media PRs", () => {
+  assert.equal(
+    adaptiveCodexTimeoutMsForTest({
+      changed_files: 4,
+      additions: 120,
+      deletions: 30,
+      body: "Small cleanup without proof assets.",
+    }),
+    600_000,
+  );
+});
+
+test("adaptive Codex timeout scales for large PRs with video proofs", () => {
+  assert.equal(
+    adaptiveCodexTimeoutMsForTest({
+      changed_files: 71,
+      additions: 4176,
+      deletions: 0,
+      body: [
+        "Proof:",
+        "https://uploads.example.invalid/proof-a.mov",
+        "https://uploads.example.invalid/proof-b.mp4.",
+      ].join("\n"),
+    }),
+    1_508_800,
+  );
+});
+
+test("adaptive Codex timeout stays capped within review shard limits", () => {
+  assert.equal(
+    adaptiveCodexTimeoutMsForTest({
+      changed_files: 1000,
+      additions: 50_000,
+      deletions: 10_000,
+      body: [
+        "https://uploads.example.invalid/one.mov",
+        "https://uploads.example.invalid/two.mp4",
+        "https://uploads.example.invalid/three.webm",
+        "https://uploads.example.invalid/four.mkv",
+        "https://uploads.example.invalid/five.avi",
+      ].join("\n"),
+    }),
+    1_800_000,
+  );
+});
+
+test("pull request webhooks dispatch adaptive Codex timeout payload", async () => {
+  const previousFetch = globalThis.fetch;
+  const previousAppId = process.env.CLAWSWEEPER_APP_ID;
+  const previousClientId = process.env.CLAWSWEEPER_APP_CLIENT_ID;
+  const previousPrivateKey = process.env.CLAWSWEEPER_APP_PRIVATE_KEY;
+  const { privateKey } = crypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
+  let dispatchedBody: Record<string, unknown> | undefined;
+  process.env.CLAWSWEEPER_APP_ID = "12345";
+  delete process.env.CLAWSWEEPER_APP_CLIENT_ID;
+  process.env.CLAWSWEEPER_APP_PRIVATE_KEY = privateKey
+    .export({ type: "pkcs1", format: "pem" })
+    .toString();
+
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(String(input));
+    const method = String(init?.method ?? "GET").toUpperCase();
+    const path = `${url.pathname}${url.search}`;
+    if (path === "/repos/openclaw/clawsweeper/installation" && method === "GET") {
+      return jsonResponse({ id: 999 });
+    }
+    if (path === "/app/installations/999/access_tokens" && method === "POST") {
+      return jsonResponse({ token: "dispatch-token" });
+    }
+    if (path === "/repos/openclaw/clawsweeper/dispatches" && method === "POST") {
+      dispatchedBody = JSON.parse(String(init?.body ?? "{}"));
+      return jsonResponse({});
+    }
+    throw new Error(`unexpected fetch ${method} ${path}`);
+  }) as typeof fetch;
+
+  try {
+    const result = await handleGitHubWebhook({
+      event: "pull_request",
+      payload: {
+        action: "synchronize",
+        repository: {
+          full_name: "openclaw/openclaw",
+          default_branch: "main",
+          private: false,
+          archived: false,
+          fork: false,
+          has_issues: true,
+        },
+        pull_request: {
+          number: 91093,
+          changed_files: 71,
+          additions: 4176,
+          deletions: 0,
+          body: [
+            "Proof:",
+            "https://uploads.example.invalid/proof-a.mov",
+            "https://uploads.example.invalid/proof-b.mp4",
+          ].join("\n"),
+        },
+        installation: { id: 123 },
+      },
+    });
+
+    assert.deepEqual(result, {
+      statusCode: 202,
+      body: { ok: true, dispatched: "clawsweeper_item" },
+    });
+    assert.equal(dispatchedBody?.event_type, "clawsweeper_item");
+    assert.equal(
+      (dispatchedBody?.client_payload as Record<string, unknown>)?.codex_timeout_ms,
+      1_508_800,
+    );
+  } finally {
+    globalThis.fetch = previousFetch;
+    restoreEnv("CLAWSWEEPER_APP_ID", previousAppId);
+    restoreEnv("CLAWSWEEPER_APP_CLIENT_ID", previousClientId);
+    restoreEnv("CLAWSWEEPER_APP_PRIVATE_KEY", previousPrivateKey);
+  }
 });
 
 test("webhook preserves valid repository default branch for item dispatch", () => {


### PR DESCRIPTION
## Summary
- Add a bounded adaptive Codex timeout for pull request webhook dispatches.
- Scale the timeout from changed-file count, total additions/deletions, and video proof URLs in the PR title/body while preserving the 600000ms default for small non-media PRs.
- Include the calculated `codex_timeout_ms` in the `clawsweeper_item` repository_dispatch payload.
- Teach the exact-event `sweep.yml` path to validate/cap that payload and apply it to both `--codex-timeout-ms` and the outer review shard timeout.

Fixes #272.

## Validation
- `pnpm run build:repair && node --test test/repair/comment-webhook.test.ts`
- `pnpm run format`
- `pnpm run build:repair && node --test test/repair/comment-webhook.test.ts && pnpm run build && node --test test/clawsweeper.test.ts --test-name-pattern "sweep exact event reviews consume adaptive Codex timeout payload|sweep event reviews and target fanout avoid storm amplification"`
- `pnpm run check`

## Runtime proof
Repository dispatch workflows run from the default branch, so the changed `sweep.yml` cannot execute in a live `repository_dispatch` run until this PR lands. The following terminal proof was run from PR head `d664d12a50ffce99a1c45cdf88702b9bba1956fc` and exercises the after-fix webhook payload plus the exact-event workflow timeout math with redacted target values.

```console
$ node --input-type=module <<'NODE'
import { adaptiveCodexTimeoutMsForTest } from './dist/repair/comment-webhook.js';
const representativePull = {
  title: 'Large UI repair with attached video proof',
  body: 'Before/after proof: https://example.invalid/proofs/fix.mov and https://example.invalid/proofs/regression.webm',
  changed_files: 71,
  additions: 3600,
  deletions: 576,
};
const codexTimeoutMs = adaptiveCodexTimeoutMsForTest(representativePull);
console.log(JSON.stringify({ event_type: 'clawsweeper_item', client_payload: { target_repo: 'openclaw/example-target', target_branch: 'main', item_kind: 'pull_request', item_number: 12345, codex_timeout_ms: codexTimeoutMs } }, null, 2));
NODE
{
  "event_type": "clawsweeper_item",
  "client_payload": {
    "target_repo": "openclaw/example-target",
    "target_branch": "main",
    "item_kind": "pull_request",
    "item_number": 12345,
    "codex_timeout_ms": 1508800
  }
}

$ codex_timeout_ms=1508800 # then run the same validation/cap and command-budget math from sweep.yml
workflow output codex_timeout_ms=1508800
workflow review command: timeout --kill-after=30s 1689s pnpm run review -- --codex-timeout-ms 1508800
```

Live ClawSweeper re-review on this PR completed successfully after the workflow-consumer fix: https://github.com/openclaw/clawsweeper/actions/runs/27253667856. Because that repository_dispatch run used the current default-branch workflow, its command still shows the pre-merge 600000ms default; the PR-head proof above demonstrates the changed workflow path that will run after merge.


<!-- notify-refresh: 2026-06-10T06:28:58Z -->
