### PR TITLE
fix: classify Vercel authorization blockers

### DIFF
--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -555,7 +555,13 @@ function positiveInt(value: JsonValue, fallback: number) {
 }
 
 export function repairableCheckBlockers(checks: LooseRecord = {}) {
+  const externalBlockers = new Set(
+    (checks.externalBlockers ?? checks.external_blockers ?? []).map((blocker: JsonValue) =>
+      String(blocker ?? ""),
+    ),
+  );
   return (checks.blockers ?? []).filter((blocker: JsonValue) => {
+    if (externalBlockers.has(String(blocker ?? ""))) return false;
     const conclusion = String(blocker ?? "")
       .split(":")
       .pop()

--- a/src/repair/comment-router-utils.ts
+++ b/src/repair/comment-router-utils.ts
@@ -19,15 +19,24 @@ export function summarizeChecks(checks: LooseRecord[]) {
   const blockers: LooseRecord[] = [];
   const pending: LooseRecord[] = [];
   const terminalBlockers: LooseRecord[] = [];
+  const externalBlockers: LooseRecord[] = [];
   for (const check of latestChecks) {
     const name = String(check.name ?? check.context ?? "unknown check");
     const workflow = String(check.workflowName ?? "");
     const ignoredCheck = ignored.has(name.toLowerCase()) || ignored.has(workflow.toLowerCase());
     const status = String(check.status ?? check.state ?? "").toUpperCase();
     const conclusion = String(check.conclusion ?? "").toUpperCase();
-    const key = conclusion || status || "UNKNOWN";
+    const externalActionRequired = isExternalActionRequiredCheck(check);
+    const key = externalActionRequired ? "ACTION_REQUIRED" : conclusion || status || "UNKNOWN";
     counts[key] = (counts[key] ?? 0) + 1;
     if (ignoredCheck) continue;
+    if (externalActionRequired) {
+      const blocker = `${name}:ACTION_REQUIRED`;
+      blockers.push(blocker);
+      terminalBlockers.push(blocker);
+      externalBlockers.push(blocker);
+      continue;
+    }
     if (status && !["COMPLETED", "SUCCESS"].includes(status)) {
       const blocker = `${name}:${status}`;
       blockers.push(blocker);
@@ -39,7 +48,22 @@ export function summarizeChecks(checks: LooseRecord[]) {
       terminalBlockers.push(blocker);
     }
   }
-  return { total: latestChecks.length, counts, blockers, pending, terminalBlockers };
+  return {
+    total: latestChecks.length,
+    counts,
+    blockers,
+    pending,
+    terminalBlockers,
+    externalBlockers,
+  };
+}
+
+function isExternalActionRequiredCheck(check: LooseRecord) {
+  const url = String(
+    check.targetUrl ?? check.target_url ?? check.detailsUrl ?? check.details_url ?? "",
+  );
+  if (/^https:\/\/vercel\.com\/git\/authorize\b/i.test(url)) return true;
+  return false;
 }
 
 function latestCheckRuns(checks: LooseRecord[]) {

--- a/src/repair/execute-fix-artifact.ts
+++ b/src/repair/execute-fix-artifact.ts
@@ -2526,6 +2526,13 @@ function parseCodexRetryAfterMs(message: string) {
 function classifyCodexFailure(detail: string) {
   const text = String(detail ?? "");
   if (
+    /can(?:not|'t|’t)\s+create\s+files?\s+in\s+this\s+mode|switch\s+to\s+execution\s+mode|create\s+`?preflight\.txt`?\s+containing/i.test(
+      text,
+    )
+  ) {
+    return "codex_execution_mode_unavailable";
+  }
+  if (
     /bwrap|loopback|uid map|sandbox wrapper|sandbox startup|operation not permitted/i.test(text)
   ) {
     return "sandbox_unavailable";

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -2308,6 +2308,16 @@ test("repairable check blockers only include completed failures", () => {
   );
 });
 
+test("repairable check blockers exclude external action-required checks", () => {
+  assert.deepEqual(
+    repairableCheckBlockers({
+      blockers: ["Vercel – clawhub:ACTION_REQUIRED", "checks-node-core:FAILURE"],
+      externalBlockers: ["Vercel – clawhub:ACTION_REQUIRED"],
+    }),
+    ["checks-node-core:FAILURE"],
+  );
+});
+
 test("automerge failed checks become repair reasons", () => {
   assert.equal(
     automergeFailedChecksRepairReason({

--- a/test/repair/comment-router-utils.test.ts
+++ b/test/repair/comment-router-utils.test.ts
@@ -295,6 +295,22 @@ test("summarizeChecks separates pending checks from terminal blockers", () => {
   assert.deepEqual(checks.terminalBlockers, ["failed-required:FAILURE"]);
 });
 
+test("summarizeChecks marks Vercel authorization checks as external action required", () => {
+  const checks = summarizeChecks([
+    {
+      context: "Vercel – clawhub",
+      state: "FAILURE",
+      targetUrl: "https://vercel.com/git/authorize?team=OpenClaw&type=github",
+    },
+  ]);
+
+  assert.deepEqual(checks.blockers, ["Vercel – clawhub:ACTION_REQUIRED"]);
+  assert.deepEqual(checks.pending, []);
+  assert.deepEqual(checks.terminalBlockers, ["Vercel – clawhub:ACTION_REQUIRED"]);
+  assert.deepEqual(checks.externalBlockers, ["Vercel – clawhub:ACTION_REQUIRED"]);
+  assert.equal(checks.counts.ACTION_REQUIRED, 1);
+});
+
 test("summarizeChecks uses the latest run for duplicate check names", () => {
   const checks = summarizeChecks([
     {


### PR DESCRIPTION
## Summary
- classify Vercel git authorization status contexts as external ACTION_REQUIRED blockers
- keep external action-required checks out of the repairable failed-check list so automerge does not dispatch a Codex write repair for them
- classify Codex preflight output that asks for execution mode as codex_execution_mode_unavailable instead of generic codex_unavailable

## Evidence
- openclaw/clawhub#2571 had a failing StatusContext named `Vercel – clawhub` with targetUrl `https://vercel.com/git/authorize?...`
- ClawSweeper treated that as repairable check failure and launched Codex repair
- Codex write preflight then returned: `I can’t create files in this mode. Please switch to execution mode...`

## Tests
Run with Node 24 available on PATH:
- `pnpm run build:repair`
- `pnpm exec oxlint src/repair/comment-router-utils.ts src/repair/comment-router-core.ts src/repair/execute-fix-artifact.ts test/repair/comment-router-utils.test.ts test/repair/comment-router-core.test.ts --deny-warnings --report-unused-disable-directives -D correctness`
- `node --test test/repair/comment-router-utils.test.ts test/repair/comment-router-core.test.ts`
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false pnpm run test:repair`

Note: the first full `pnpm run test:repair` failed because local Git commit signing was enabled in temporary test repos. Re-running with commit signing disabled for the test subprocess passed: 487/487.