### PR TITLE
fix: stabilize workflow status publishing

### DIFF
--- a/.github/workflows/github-activity.yml
+++ b/.github/workflows/github-activity.yml
@@ -48,7 +48,7 @@ on:
       - completed
 
 permissions:
-  contents: read
+  contents: write
   actions: read
   issues: read
   pull-requests: read
@@ -90,6 +90,52 @@ jobs:
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Dispatch spam comment intake candidates
+        if: steps.core-budget.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          payload_path="$RUNNER_TEMP/spam-comment-intake-dispatch.json"
+          if ! node <<'NODE' > "$payload_path"; then
+            echo "No spam comment intake candidate for this activity."
+            exit 0
+          fi
+          const fs = require("fs");
+          const eventName = process.env.GITHUB_EVENT_NAME || "";
+          const root = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"));
+          const clientPayload = root.client_payload || {};
+          const activity = clientPayload.activity || clientPayload || {};
+          const type = activity.type || clientPayload.event_name || (eventName === "repository_dispatch" ? "" : eventName);
+          const action = activity.action || clientPayload.action || root.action || "";
+          if (!["issue_comment", "pull_request_review_comment"].includes(type)) process.exit(1);
+          if (!["created", "edited"].includes(action)) process.exit(1);
+          const repo =
+            activity.target_repo ||
+            activity.repo ||
+            (activity.repository && activity.repository.full_name) ||
+            (typeof activity.repository === "string" && activity.repository) ||
+            clientPayload.target_repo ||
+            clientPayload.repo ||
+            (clientPayload.repository && clientPayload.repository.full_name) ||
+            (typeof clientPayload.repository === "string" && clientPayload.repository) ||
+            (root.repository && root.repository.full_name) ||
+            process.env.GITHUB_REPOSITORY;
+          process.stdout.write(JSON.stringify({
+            event_type: "clawsweeper_spam_comment_intake",
+            client_payload: {
+              target_repo: repo,
+              event_name: type,
+              action,
+              activity: { ...activity, type, action, repo },
+            },
+          }));
+          NODE
+          gh api "repos/${GITHUB_REPOSITORY}/dispatches" \
+            --method POST \
+            --input "$payload_path"
 
       - uses: actions/checkout@v6
         if: steps.core-budget.outputs.skip != 'true'

--- a/.github/workflows/spam-comment-intake.yml
+++ b/.github/workflows/spam-comment-intake.yml
@@ -2,7 +2,7 @@ name: spam comment intake
 
 on:
   repository_dispatch:
-    types: [github_activity]
+    types: [clawsweeper_spam_comment_intake]
 
 permissions:
   contents: read

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1501,12 +1501,6 @@ jobs:
           done
           echo "::warning::Unable to dispatch background comment sync after three attempts; apply/comment-sync backstops can pick it up later."
 
-      - uses: ./.github/actions/setup-codex
-        if: ${{ success() && steps.target-write-token.outputs.token != '' && (((github.event_name == 'repository_dispatch' && github.event.action != 'clawsweeper_target_sweep') || github.event.inputs.item_number != '' || github.event.inputs.item_numbers != '') || github.event.inputs.apply_after_review == 'true') }}
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          CLAWSWEEPER_INTERNAL_MODEL: ${{ secrets.CLAWSWEEPER_MODEL }}
-
       - name: Sync selected review comments
         if: ${{ success() && steps.target-write-token.outputs.token != '' && ((github.event_name == 'repository_dispatch' && github.event.action != 'clawsweeper_target_sweep') || github.event.inputs.item_number != '' || github.event.inputs.item_numbers != '') }}
         timeout-minutes: 15
@@ -1554,6 +1548,12 @@ jobs:
             --path apply-report.json \
             --path "results/sweep-status/${target_slug}.json" \
             --rebase-strategy theirs
+
+      - uses: ./.github/actions/setup-codex
+        if: ${{ success() && steps.target-write-token.outputs.token != '' && github.event.inputs.apply_after_review == 'true' }}
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          CLAWSWEEPER_INTERNAL_MODEL: ${{ secrets.CLAWSWEEPER_MODEL }}
 
       - name: Apply selected safe close proposals
         if: ${{ success() && steps.target-write-token.outputs.token != '' && github.event.inputs.apply_after_review == 'true' }}

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -6344,12 +6344,29 @@ function codexFailureReason(detail: string): string {
   if (detail.includes("invalid JSON")) return "invalid structured output";
   if (detail.includes("ENOBUFS") || detail.includes("maxBuffer")) return "output buffer overflow";
   if (detail.includes("timed out") || detail.includes("ETIMEDOUT")) return "timeout";
+  if (
+    /rate limit reached|tokens per min|\bTPM\b|requests per min|\b429\b|temporarily unavailable|overloaded|please try again in \d+(?:ms|s)/i.test(
+      detail,
+    )
+  ) {
+    return "retryable codex transport failure";
+  }
+  if (
+    /ECONNRESET|EAI_AGAIN|ENOTFOUND|socket hang up|fetch failed|transport failure/i.test(detail)
+  ) {
+    return "retryable codex transport failure";
+  }
   return "codex execution failed";
 }
 
-function codexFailureDecision(status: number | null, stderr: string, stdout = ""): Decision {
-  const detail = stderr || "No stderr.";
-  const reason = codexFailureReason(detail);
+function codexFailureDecision(
+  status: number | null,
+  detail: string,
+  stdout = "",
+  stderr = "",
+): Decision {
+  const failureDetail = detail || "No failure detail.";
+  const reason = codexFailureReason(`${failureDetail}\n${stderr}\n${stdout}`);
   return {
     decision: "keep_open",
     closeReason: "none",
@@ -6358,8 +6375,15 @@ function codexFailureDecision(status: number | null, stderr: string, stdout = ""
     changeSummary: "Review failed before ClawSweeper could summarize the requested change.",
     evidence: [
       evidenceEntry({ label: "failure reason", detail: reason }),
-      evidenceEntry({ label: "codex failure detail", detail: trimMiddle(detail, 4000) }),
-      evidenceEntry({ label: "codex stdout", detail: trimMiddle(stdout || "No stdout.", 2000) }),
+      evidenceEntry({ label: "codex failure detail", detail: trimMiddle(failureDetail, 4000) }),
+      evidenceEntry({
+        label: "codex stderr",
+        detail: trimMiddle(stderr || "No stderr captured.", 3000),
+      }),
+      evidenceEntry({
+        label: "codex stdout",
+        detail: trimMiddle(stdout || "No stdout captured.", 2000),
+      }),
     ],
     likelyOwners: [
       {
@@ -6450,6 +6474,46 @@ function codexFailureDecision(status: number | null, stderr: string, stdout = ""
     workValidation: [],
     workLikelyFiles: [],
   };
+}
+
+export function codexFailureDecisionForTest(
+  status: number | null,
+  detail: string,
+  stdout = "",
+  stderr = "",
+): Decision {
+  return codexFailureDecision(status, detail, stdout, stderr);
+}
+
+function redactedOutputTail(value: string | Buffer | null | undefined, maxLength = 6000): string {
+  return safeOutputTail(value, maxLength)
+    .replace(/\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b/g, "[REDACTED_OPENAI_KEY]")
+    .replace(/\bgithub_pat_[A-Za-z0-9_]{20,}\b/g, "[REDACTED_GITHUB_TOKEN]")
+    .replace(/\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g, "[REDACTED_GITHUB_TOKEN]")
+    .replace(/\b(OPENAI_API_KEY|CODEX_API_KEY|GH_TOKEN|GITHUB_TOKEN)=([^\s"']+)/g, "$1=[REDACTED]")
+    .replace(
+      /"((?:OPENAI_API_KEY|CODEX_API_KEY|GH_TOKEN|GITHUB_TOKEN))"\s*:\s*"[^"]*"/g,
+      '"$1":"[REDACTED]"',
+    );
+}
+
+class CodexReviewError extends Error {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+
+  constructor(options: {
+    message: string;
+    status: number | null;
+    stdout?: string;
+    stderr?: string;
+  }) {
+    super(options.message);
+    this.name = "CodexReviewError";
+    this.status = options.status;
+    this.stdout = options.stdout ?? "";
+    this.stderr = options.stderr ?? "";
+  }
 }
 
 function openclawDirtyStatus(openclawDir: string): string {
@@ -6587,11 +6651,12 @@ function runCodex(options: {
     );
   }
   if (result.error) {
-    throw new Error(
-      `Codex review failed for #${options.item.number}: ${result.error.message}\n${
-        safeOutputTail(result.stderr) || safeOutputTail(result.stdout) || "No output."
-      }`,
-    );
+    throw new CodexReviewError({
+      message: `Codex review failed for #${options.item.number}: ${result.error.message}`,
+      status: result.status,
+      stdout: redactedOutputTail(result.stdout),
+      stderr: redactedOutputTail(result.stderr),
+    });
   }
   if (result.status !== 0) {
     if (existsSync(outputPath)) {
@@ -6607,32 +6672,32 @@ function runCodex(options: {
         );
         return decision;
       } catch (error) {
-        throw new Error(
-          `Codex review failed for #${options.item.number} with exit ${
+        throw new CodexReviewError({
+          message: `Codex review failed for #${options.item.number} with exit ${
             result.status ?? "unknown"
           } and wrote invalid JSON or schema-invalid output to ${outputPath}: ${
             error instanceof Error ? error.message : String(error)
-          }.\n${safeOutputTail(result.stderr) || safeOutputTail(result.stdout) || "No output."}`,
-        );
+          }.`,
+          status: result.status,
+          stdout: redactedOutputTail(result.stdout),
+          stderr: redactedOutputTail(result.stderr),
+        });
       }
     }
-    throw new Error(
-      `Codex review failed for #${options.item.number} with exit ${
-        result.status ?? "unknown"
-      }.\n${safeOutputTail(result.stderr) || safeOutputTail(result.stdout) || "No output."}`,
-    );
+    throw new CodexReviewError({
+      message: `Codex review failed for #${options.item.number} with exit ${result.status ?? "unknown"}.`,
+      status: result.status,
+      stdout: redactedOutputTail(result.stdout),
+      stderr: redactedOutputTail(result.stderr),
+    });
   }
   if (!existsSync(outputPath)) {
-    const decision = codexFailureDecision(
-      result.status,
-      `Codex exited successfully but did not write ${outputPath}.`,
-      result.stdout,
-    );
-    throw new Error(
-      `Codex review did not produce output for #${options.item.number}: ${decision.evidence
-        .map((entry) => entry.detail)
-        .join("\n")}`,
-    );
+    throw new CodexReviewError({
+      message: `Codex exited successfully but did not write ${outputPath}.`,
+      status: result.status,
+      stdout: redactedOutputTail(result.stdout),
+      stderr: redactedOutputTail(result.stderr),
+    });
   }
   try {
     return parseDecision(JSON.parse(readFileSync(outputPath, "utf8").trim()), options.item);
@@ -6642,13 +6707,17 @@ function runCodex(options: {
       `Codex wrote invalid JSON or schema-invalid output to ${outputPath}: ${
         error instanceof Error ? error.message : String(error)
       }`,
-      result.stdout,
+      redactedOutputTail(result.stdout),
+      redactedOutputTail(result.stderr),
     );
-    throw new Error(
-      `Codex review wrote invalid JSON for #${options.item.number}: ${decision.evidence
+    throw new CodexReviewError({
+      message: `Codex review wrote invalid JSON for #${options.item.number}: ${decision.evidence
         .map((entry) => entry.detail)
         .join("\n")}`,
-    );
+      status: result.status,
+      stdout: redactedOutputTail(result.stdout),
+      stderr: redactedOutputTail(result.stderr),
+    });
   }
 }
 
@@ -14549,11 +14618,15 @@ function reviewCommand(args: Args): void {
         });
       } catch (error) {
         codexFailures += 1;
-        decision = codexFailureDecision(
-          null,
-          error instanceof Error ? error.message : String(error),
-          "Per-item Codex failure; continuing with the rest of the shard.",
-        );
+        if (error instanceof CodexReviewError) {
+          decision = codexFailureDecision(error.status, error.message, error.stdout, error.stderr);
+        } else {
+          decision = codexFailureDecision(
+            null,
+            error instanceof Error ? error.message : String(error),
+            "Per-item Codex failure; continuing with the rest of the shard.",
+          );
+        }
       } finally {
         codexElapsedMs = Date.now() - codexStartedAt;
       }

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -3100,8 +3100,9 @@ function hasExistingModeStatusResponse(number: JsonValue, intent: JsonValue) {
 }
 
 function postComment(command: LooseRecord, body: string) {
-  const existing =
-    findExistingCommandStatusComment(command) ?? findPrecreatedCommandStatusComment(command);
+  const existingStatus = findExistingCommandStatusComment(command);
+  const precreated = findPrecreatedCommandStatusComment(command);
+  const existing = existingStatus ?? precreated;
   const ackMarker = existing ? commandAckMarkerFromBody(existing.body) : null;
   const responseBody = ackMarker && !body.includes(ackMarker) ? `${ackMarker}\n${body}` : body;
   const nextBody = usesSharedAutomergeStatus(command)
@@ -3123,7 +3124,24 @@ function postComment(command: LooseRecord, body: string) {
       "--input",
       payloadPath,
     ]);
-    return { mode: "updated", comment_id: String(existing.id) };
+    const precreatedId = Number(precreated?.id ?? 0) || 0;
+    const existingId = Number(existing.id ?? 0) || 0;
+    if (existingStatus && precreatedId > 0 && precreatedId !== existingId) {
+      ghBestEffort([
+        "api",
+        `repos/${command.repo}/issues/comments/${precreatedId}`,
+        "--method",
+        "DELETE",
+      ]);
+      issueCommentsCache.delete(Number(command.issue_number));
+    }
+    return {
+      mode: "updated",
+      comment_id: String(existing.id),
+      ...(precreatedId > 0 && precreatedId !== existingId
+        ? { pruned_ack_comment_id: String(precreatedId) }
+        : {}),
+    };
   }
   ghText([
     "api",

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -107,6 +107,7 @@ import {
   sameAuthorCounterpartApplyReason,
   sanitizePublicSelfReferences,
   appendFloorBackfillCandidateNumbersForTest,
+  codexFailureDecisionForTest,
   pullRequestFilePathsFromContextForTest,
   selectDueCandidateNumbersForTest,
   shardItemNumbers,
@@ -14081,6 +14082,87 @@ process.exit(1);
     else process.env.CODEX_DECISION_JSON = originalDecision;
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+test("runCodex preserves redacted process output when Codex exits without a decision", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const openclawDir = join(root, "openclaw");
+  const workDir = join(root, "codex-work");
+  const binDir = join(root, "bin");
+  mkdirSync(openclawDir, { recursive: true });
+  mkdirSync(binDir, { recursive: true });
+  execFileSync("git", ["init"], { cwd: openclawDir, stdio: "ignore" });
+  const codexPath = join(binDir, "codex");
+  writeFileSync(
+    codexPath,
+    `#!/usr/bin/env node
+process.stdout.write("startup banner GH_TOKEN=ghp_abcdefghijklmnopqrstuvwxyz123456\\n");
+process.stderr.write("Rate limit reached for gpt-test on tokens per min (TPM); OPENAI_API_KEY=sk-proj-abcdefghijklmnopqrstuvwxyz123456\\n");
+process.exit(1);
+`,
+  );
+  chmodSync(codexPath, 0o755);
+  const originalPath = process.env.PATH;
+  process.env.PATH = `${binDir}${delimiter}${process.env.PATH ?? ""}`;
+  try {
+    assert.throws(
+      () =>
+        runCodexForTest({
+          item: item({ number: 83394 }),
+          context: { issue: {}, comments: [], timeline: [] },
+          git: { mainSha: "abc123", latestRelease: null },
+          model: "gpt-test",
+          openclawDir,
+          reasoningEffort: "high",
+          sandboxMode: "read-only",
+          serviceTier: "",
+          timeoutMs: 10_000,
+          workDir,
+          prompt: "Return a review decision.",
+        }),
+      (error: unknown) => {
+        const reviewError = error as Error & {
+          status?: number | null;
+          stderr?: string;
+          stdout?: string;
+        };
+        assert.equal(reviewError.status, 1);
+        assert.match(reviewError.stderr ?? "", /Rate limit reached/);
+        assert.match(reviewError.stderr ?? "", /OPENAI_API_KEY=\[REDACTED\]/);
+        assert.doesNotMatch(reviewError.stderr ?? "", /sk-proj-/);
+        assert.match(reviewError.stdout ?? "", /startup banner/);
+        assert.match(reviewError.stdout ?? "", /GH_TOKEN=\[REDACTED\]/);
+        assert.doesNotMatch(reviewError.stdout ?? "", /ghp_/);
+        return true;
+      },
+    );
+  } finally {
+    if (originalPath === undefined) delete process.env.PATH;
+    else process.env.PATH = originalPath;
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("codex failure decisions expose stderr and stdout separately", () => {
+  const decision = codexFailureDecisionForTest(
+    1,
+    "Codex review failed for #278 with exit 1.",
+    "startup banner",
+    "Rate limit reached for gpt-test on tokens per min (TPM)",
+  );
+
+  assert.equal(
+    decision.summary,
+    "Codex review failed: retryable codex transport failure (exit 1).",
+  );
+  assert.equal(
+    decision.evidence.find((entry) => entry.label === "codex stderr")?.detail,
+    "Rate limit reached for gpt-test on tokens per min (TPM)",
+  );
+  assert.equal(
+    decision.evidence.find((entry) => entry.label === "codex stdout")?.detail,
+    "startup banner",
+  );
 });
 
 test("decision parser enforces required schema-shaped evidence", () => {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -16372,6 +16372,15 @@ test("publish workflow installs Codex from the root checkout path", () => {
 
   assert.match(publishJob, /uses: \.\/\.github\/actions\/setup-codex/);
   assert.doesNotMatch(publishJob, /uses: \.\/clawsweeper\/\.github\/actions\/setup-codex/);
+  const setupCodexStart = publishJob.indexOf("- uses: ./.github/actions/setup-codex");
+  const syncCommentsStart = publishJob.indexOf("- name: Sync selected review comments");
+  const applySelectedStart = publishJob.indexOf("- name: Apply selected safe close proposals");
+  assert.ok(setupCodexStart > syncCommentsStart);
+  assert.ok(applySelectedStart > setupCodexStart);
+  assert.match(
+    publishJob.slice(setupCodexStart, applySelectedStart),
+    /if: \$\{\{ success\(\) && steps\.target-write-token\.outputs\.token != '' && github\.event\.inputs\.apply_after_review == 'true' \}\}/,
+  );
 });
 
 test("apply workflow installs Codex only when proof-eligible apply work can run", () => {
@@ -16590,6 +16599,25 @@ test("comment commands keep the router-to-sweep dispatch contract", () => {
   assert.match(routerSource, /event_type:\s*"clawsweeper_item"/);
   assert.match(sweepWorkflow, /types:\s*\[clawsweeper_item,\s*clawsweeper_target_sweep\]/);
   assert.doesNotMatch(sweepWorkflow, /types:\s*\[[^\]]*clawsweeper_comment/);
+});
+
+test("comment router prunes bare ack comments after updating shared automerge status", () => {
+  const routerSource = readFileSync("src/repair/comment-router.ts", "utf8");
+  const postComment = routerSource.slice(
+    routerSource.indexOf("function postComment("),
+    routerSource.indexOf("\nfunction findExistingCommandStatusComment"),
+  );
+
+  assert.match(postComment, /const existingStatus = findExistingCommandStatusComment\(command\);/);
+  assert.match(postComment, /const precreated = findPrecreatedCommandStatusComment\(command\);/);
+  assert.match(postComment, /const existing = existingStatus \?\? precreated;/);
+  assert.match(
+    postComment,
+    /if \(existingStatus && precreatedId > 0 && precreatedId !== existingId\)/,
+  );
+  assert.match(postComment, /issues\/comments\/\$\{precreatedId\}/);
+  assert.match(postComment, /"DELETE"/);
+  assert.match(postComment, /pruned_ack_comment_id: String\(precreatedId\)/);
 });
 
 test("manual exact-item review dispatches avoid broad review concurrency", () => {
@@ -16845,6 +16873,11 @@ test("github activity workflow coalesces noisy observer runs", () => {
   assert.match(concurrencyBlock, /github\.event_name == 'workflow_run'/);
   assert.match(workflow, /Check core API budget/);
   assert.match(workflow, /CLAWSWEEPER_MIN_CORE_REMAINING/);
+  assert.match(workflow, /contents: write/);
+  assert.match(workflow, /Dispatch spam comment intake candidates/);
+  assert.match(workflow, /clawsweeper_spam_comment_intake/);
+  assert.match(workflow, /\["issue_comment", "pull_request_review_comment"\]/);
+  assert.match(workflow, /\["created", "edited"\]/);
   assert.match(concurrencyBlock, /cancel-in-progress: true/);
   assert.doesNotMatch(
     concurrencyBlock,
@@ -16860,6 +16893,8 @@ test("github activity workflow coalesces noisy observer runs", () => {
 test("spam comment intake coalesces duplicate comment deliveries", () => {
   const workflow = readFileSync(".github/workflows/spam-comment-intake.yml", "utf8");
 
+  assert.match(workflow, /types: \[clawsweeper_spam_comment_intake\]/);
+  assert.doesNotMatch(workflow, /types: \[github_activity\]/);
   assert.match(workflow, /group: >-/);
   assert.match(workflow, /spam-comment-intake-\$\{\{ github\.event\.client_payload\.target_repo/);
   assert.match(workflow, /github\.event\.client_payload\.activity\.issue\.number/);


### PR DESCRIPTION
## Summary

- route spam-comment intake through a dedicated repository_dispatch event instead of subscribing it to every `github_activity` run
- let exact-item review comment sync publish before any Codex setup needed only for immediate safe-close apply work
- prune stale bare command-router ack comments when shared automerge status comments are updated

## Root Cause

- GitHub creates workflow runs before job-level `if` conditions are evaluated, so `spam-comment-intake` subscribing to broad `github_activity` events still queued/skipped a run for unrelated activity.
- Exact-item publish/comment sync did not need Codex, but Codex setup ran before comment sync; a setup/auth/model failure could strand completed review artifacts before they reached the target PR.
- Shared automerge status updates reused the durable automerge status comment, while fresh per-command ack comments could remain behind forever saying the router would update them later.

## Validation

- `pnpm run build:repair`
- `pnpm exec oxlint src/repair/comment-router.ts test/clawsweeper.test.ts --deny-warnings --report-unused-disable-directives -D correctness`
- `node --test test/repair/spam-comment-intake.test.ts test/repair/notify-github-activity.test.ts`
- `pnpm run build`
- `node --test test/clawsweeper.test.ts`
- `pnpm run test:repair`

## Notes

This is aimed at the infrastructure symptoms seen on ClawHub PRs where command-router acks or review status publication became inconsistent. It reduces storm amplification and makes terminal status publication more reliable, but it does not attempt to resolve target-repository merge conflicts, Vercel authorization failures, or genuine Codex review execution failures.