### PR TITLE
fix(review): gate exact reviews by provider lease

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -246,6 +246,13 @@ jobs:
           permission-issues: write
           permission-pull-requests: write
 
+      - name: Create state token
+        id: state-token
+        uses: ./.github/actions/create-state-token
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+
       - name: React to target item review start
         continue-on-error: true
         env:
@@ -274,9 +281,18 @@ jobs:
           }
           react "eyes"
 
+      - uses: actions/checkout@v6
+        with:
+          repository: openclaw/clawsweeper-state
+          ref: state
+          path: clawsweeper-provider-state
+          token: ${{ steps.state-token.outputs.token }}
+          fetch-depth: 0
+          sparse-checkout: provider-leases
+
       - uses: ./.github/actions/setup-media-proof-tools
 
-      - name: Mark re-review command in progress
+      - name: Mark re-review waiting for Codex capacity
         continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
@@ -291,8 +307,8 @@ jobs:
             --item-number "$ITEM_NUMBER" \
             --marker "$COMMAND_STATUS_MARKER" \
             --status-comment-id "$STATUS_COMMENT_ID" \
-            --state "Review in progress" \
-            --detail "Targeted re-review run started; Codex is reviewing the item." \
+            --state "Waiting for Codex capacity" \
+            --detail "Targeted re-review run started and is waiting for a global Codex provider slot." \
             --run-url "$RUN_URL" \
             --wait-ms 120000
 
@@ -343,14 +359,60 @@ jobs:
           fi
           git -C "$checkout_dir" rev-parse --short HEAD
 
+      - name: Acquire Codex provider lease
+        id: provider-lease
+        env:
+          PROVIDER_LEASE_ID: exact-${{ github.run_id }}-${{ github.run_attempt }}-${{ steps.target.outputs.target_repo_name }}-${{ steps.target.outputs.item_number }}
+        run: |
+          set -euo pipefail
+          pnpm run repair:provider-lease -- acquire \
+            --state-dir clawsweeper-provider-state \
+            --provider codex-internal-default \
+            --lease-id "$PROVIDER_LEASE_ID" \
+            --owner "${{ github.repository }}" \
+            --lane exact-review \
+            --item "${{ steps.target.outputs.target_repo }}#${{ steps.target.outputs.item_number }}" \
+            --run-id "${{ github.run_id }}" \
+            --capacity "${{ vars.CLAWSWEEPER_CODEX_PROVIDER_CAPACITY || '4' }}" \
+            --weight "${{ github.event.client_payload.provider_weight || '1' }}" \
+            --ttl-seconds "${{ vars.CLAWSWEEPER_CODEX_PROVIDER_LEASE_TTL_SECONDS || '900' }}" \
+            --wait-seconds "${{ vars.CLAWSWEEPER_CODEX_PROVIDER_WAIT_SECONDS || '1200' }}" \
+            --poll-seconds "${{ vars.CLAWSWEEPER_CODEX_PROVIDER_POLL_SECONDS || '15' }}"
+
+      - name: Mark re-review command in progress
+        if: ${{ steps.provider-lease.outputs.acquired == 'true' }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          TARGET_REPO: ${{ steps.target.outputs.target_repo }}
+          ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
+          COMMAND_STATUS_MARKER: ${{ github.event.client_payload.command_status_marker || '' }}
+          STATUS_COMMENT_ID: ${{ github.event.client_payload.status_comment_id || '' }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          pnpm run repair:update-command-status -- \
+            --repo "$TARGET_REPO" \
+            --item-number "$ITEM_NUMBER" \
+            --marker "$COMMAND_STATUS_MARKER" \
+            --status-comment-id "$STATUS_COMMENT_ID" \
+            --state "Review in progress" \
+            --detail "Targeted re-review acquired a global Codex provider slot; Codex is reviewing the item." \
+            --run-url "$RUN_URL" \
+            --wait-ms 120000
+
       - name: Review exact event item
         id: review-exact-event-item
+        if: ${{ steps.provider-lease.outputs.acquired == 'true' }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
           CLAWSWEEPER_PROOF_INSPECTION_TOKEN: ${{ steps.target-read-token.outputs.token || github.token }}
           ADDITIONAL_PROMPT: ${{ github.event.client_payload.additional_prompt || '' }}
           CLAWSWEEPER_RELATED_GITHUB_SEARCH: ${{ vars.CLAWSWEEPER_RELATED_GITHUB_SEARCH || '1' }}
+          PROVIDER_LEASE_ID: ${{ steps.provider-lease.outputs.lease_id }}
+          PROVIDER_LEASE_CAPACITY: ${{ vars.CLAWSWEEPER_CODEX_PROVIDER_CAPACITY || '4' }}
+          PROVIDER_LEASE_TTL_SECONDS: ${{ vars.CLAWSWEEPER_CODEX_PROVIDER_LEASE_TTL_SECONDS || '900' }}
+          PROVIDER_LEASE_RENEW_SECONDS: ${{ vars.CLAWSWEEPER_CODEX_PROVIDER_LEASE_RENEW_SECONDS || '' }}
         run: |
           set -euo pipefail
           test -n "$GH_TOKEN"
@@ -358,6 +420,50 @@ jobs:
           if [ -n "$ADDITIONAL_PROMPT" ]; then
             additional_prompt_arg=(--additional-prompt "$ADDITIONAL_PROMPT")
           fi
+
+          provider_lease_renew_seconds="$PROVIDER_LEASE_RENEW_SECONDS"
+          if [ -z "$provider_lease_renew_seconds" ]; then
+            provider_lease_renew_seconds=$(( PROVIDER_LEASE_TTL_SECONDS / 3 ))
+            if [ "$provider_lease_renew_seconds" -gt 60 ]; then
+              provider_lease_renew_seconds=60
+            fi
+          fi
+          if [ "$provider_lease_renew_seconds" -lt 5 ]; then
+            provider_lease_renew_seconds=5
+          fi
+          if [ "$provider_lease_renew_seconds" -ge "$PROVIDER_LEASE_TTL_SECONDS" ]; then
+            provider_lease_renew_seconds=$(( PROVIDER_LEASE_TTL_SECONDS / 2 ))
+            if [ "$provider_lease_renew_seconds" -lt 1 ]; then
+              provider_lease_renew_seconds=1
+            fi
+          fi
+
+          mkdir -p artifacts/event
+          provider_lease_renew_log="artifacts/event/provider-lease-renew.log"
+          (
+            while sleep "$provider_lease_renew_seconds"; do
+              date -u +"renewing provider lease at %Y-%m-%dT%H:%M:%SZ"
+              pnpm run repair:provider-lease -- renew \
+                --state-dir clawsweeper-provider-state \
+                --provider codex-internal-default \
+                --lease-id "$PROVIDER_LEASE_ID" \
+                --capacity "$PROVIDER_LEASE_CAPACITY" \
+                --ttl-seconds "$PROVIDER_LEASE_TTL_SECONDS"
+            done
+          ) > "$provider_lease_renew_log" 2>&1 &
+          provider_lease_renew_pid=$!
+
+          stop_provider_lease_renewal() {
+            if kill -0 "$provider_lease_renew_pid" 2>/dev/null; then
+              kill "$provider_lease_renew_pid" 2>/dev/null || true
+              wait "$provider_lease_renew_pid" 2>/dev/null || true
+            fi
+            if [ -s "$provider_lease_renew_log" ]; then
+              cat "$provider_lease_renew_log"
+            fi
+          }
+          trap stop_provider_lease_renewal EXIT
+
           timeout --kill-after=30s 12m pnpm run review -- \
             --target-repo "${{ steps.target.outputs.target_repo }}" \
             --target-dir "${{ steps.target.outputs.target_checkout_dir }}" \
@@ -372,14 +478,45 @@ jobs:
             --readonly-openclaw \
             --shard-index 0 \
             --shard-count 1 \
-            "${additional_prompt_arg[@]}"
+            "${additional_prompt_arg[@]}" &
+          review_pid=$!
 
-      - name: Create state token
-        id: state-token
-        uses: ./.github/actions/create-state-token
-        with:
-          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
-          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+          (
+            while kill -0 "$review_pid" 2>/dev/null; do
+              if ! kill -0 "$provider_lease_renew_pid" 2>/dev/null; then
+                echo "Provider lease renewal stopped before review completed." >&2
+                kill "$review_pid" 2>/dev/null || true
+                exit 1
+              fi
+              sleep 5
+            done
+          ) &
+          provider_lease_monitor_pid=$!
+
+          set +e
+          wait "$review_pid"
+          review_status=$?
+          kill "$provider_lease_monitor_pid" 2>/dev/null || true
+          wait "$provider_lease_monitor_pid" 2>/dev/null || true
+          set -e
+
+          if [ "$review_status" -eq 0 ] && ! kill -0 "$provider_lease_renew_pid" 2>/dev/null; then
+            echo "Provider lease renewal stopped before review completed." >&2
+            exit 1
+          fi
+          exit "$review_status"
+
+      - name: Release Codex provider lease
+        if: ${{ always() && steps.provider-lease.outputs.acquired == 'true' }}
+        env:
+          PROVIDER_LEASE_ID: ${{ steps.provider-lease.outputs.lease_id }}
+        run: |
+          set -euo pipefail
+          pnpm run repair:provider-lease -- release \
+            --state-dir clawsweeper-provider-state \
+            --provider codex-internal-default \
+            --lease-id "$PROVIDER_LEASE_ID" \
+            --capacity "${{ vars.CLAWSWEEPER_CODEX_PROVIDER_CAPACITY || '4' }}"
 
       - uses: ./.github/actions/setup-state
         with:
@@ -388,6 +525,7 @@ jobs:
 
       - name: Publish event result and apply safe close
         id: publish-event-result
+        if: ${{ steps.provider-lease.outputs.acquired == 'true' }}
         env:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
           REPO_TOKEN: ${{ github.token }}
@@ -398,7 +536,7 @@ jobs:
         run: pnpm run repair:publish-event-result
 
       - name: Dispatch viable issue implementation
-        if: ${{ success() && steps.target-write-token.outputs.token != '' && steps.target.outputs.target_repo != 'openclaw/openclaw' && steps.target.outputs.target_repo != 'openclaw/clawhub' }}
+        if: ${{ success() && steps.provider-lease.outputs.acquired == 'true' && steps.target-write-token.outputs.token != '' && steps.target.outputs.target_repo != 'openclaw/openclaw' && steps.target.outputs.target_repo != 'openclaw/clawhub' }}
         env:
           GH_TOKEN: ${{ github.token }}
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
@@ -436,6 +574,7 @@ jobs:
 
       - name: Route synced ClawSweeper verdict
         id: route-synced-verdict
+        if: ${{ steps.provider-lease.outputs.acquired == 'true' }}
         timeout-minutes: 4
         env:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
@@ -466,13 +605,22 @@ jobs:
           COMMAND_STATUS_MARKER: ${{ github.event.client_payload.command_status_marker || '' }}
           STATUS_COMMENT_ID: ${{ github.event.client_payload.status_comment_id || '' }}
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PROVIDER_LEASE_OUTCOME: ${{ steps.provider-lease.outcome }}
+          PROVIDER_LEASE_ACQUIRED: ${{ steps.provider-lease.outputs.acquired }}
+          PROVIDER_LEASE_REASON: ${{ steps.provider-lease.outputs.reason }}
           REVIEW_OUTCOME: ${{ steps.review-exact-event-item.outcome }}
           PUBLISH_OUTCOME: ${{ steps.publish-event-result.outcome }}
           ROUTE_OUTCOME: ${{ steps.route-synced-verdict.outcome }}
         run: |
           state="Failed"
           detail="The targeted re-review did not finish cleanly. Check the workflow run for details."
-          if [ "$REVIEW_OUTCOME" = "cancelled" ]; then
+          if [ "$PROVIDER_LEASE_OUTCOME" != "success" ]; then
+            state="Failed"
+            detail="The targeted re-review could not reserve global Codex provider capacity because the provider lease state update failed. Check the workflow run for details."
+          elif [ "$PROVIDER_LEASE_ACQUIRED" != "true" ]; then
+            state="Capacity timeout"
+            detail="The targeted re-review did not start because global Codex provider capacity stayed full until this workflow's wait deadline. Trigger a fresh re-review after capacity recovers. ${PROVIDER_LEASE_REASON}"
+          elif [ "$REVIEW_OUTCOME" = "cancelled" ]; then
             state="Superseded"
             detail="A newer re-review for this item started before this run finished, so GitHub cancelled this older run. Check the latest ClawSweeper run for the current result."
           fi
@@ -674,7 +822,7 @@ jobs:
 
   plan:
     name: Plan review candidates
-    if: ${{ (github.event_name != 'repository_dispatch' || github.event.action == 'clawsweeper_target_sweep') && !((github.event_name == 'workflow_dispatch' && (github.event.inputs.apply_existing == 'true' || github.event.inputs.audit_dashboard == 'true')) || (github.event_name == 'schedule' && ((github.event.schedule == '3 * * * *' || github.event.schedule == '18 * * * *' || github.event.schedule == '33 * * * *' || github.event.schedule == '48 * * * *' || github.event.schedule == '8,23,38,53 * * * *' || github.event.schedule == '6,21,36,51 * * * *') || (github.event.schedule == '7 */6 * * *' || github.event.schedule == '12 */6 * * *' || github.event.schedule == '17 */6 * * *') || (github.event.schedule == '4/15 * * * *' || github.event.schedule == '41 * * * *' || github.event.schedule == '37 */6 * * *') || github.event.schedule == '13 8,20 * * *'))) && !(github.event_name == 'schedule' && (github.event.schedule == '2/5 * * * *' || github.event.schedule == '22 * * * *') && vars.CLAWSWEEPER_ENABLE_CLAWHUB != '1') && !(github.event_name == 'repository_dispatch' && github.event.client_payload.target_repo == 'openclaw/clawhub' && vars.CLAWSWEEPER_ENABLE_CLAWHUB != '1') }}
+    if: ${{ !contains(github.event.inputs.additional_prompt || '', '[provider-lease-live-proof]') && (github.event_name != 'repository_dispatch' || github.event.action == 'clawsweeper_target_sweep') && !((github.event_name == 'workflow_dispatch' && (github.event.inputs.apply_existing == 'true' || github.event.inputs.audit_dashboard == 'true')) || (github.event_name == 'schedule' && ((github.event.schedule == '3 * * * *' || github.event.schedule == '18 * * * *' || github.event.schedule == '33 * * * *' || github.event.schedule == '48 * * * *' || github.event.schedule == '8,23,38,53 * * * *' || github.event.schedule == '6,21,36,51 * * * *') || (github.event.schedule == '7 */6 * * *' || github.event.schedule == '12 */6 * * *' || github.event.schedule == '17 */6 * * *') || (github.event.schedule == '4/15 * * * *' || github.event.schedule == '41 * * * *' || github.event.schedule == '37 */6 * * *') || github.event.schedule == '13 8,20 * * *'))) && !(github.event_name == 'schedule' && (github.event.schedule == '2/5 * * * *' || github.event.schedule == '22 * * * *') && vars.CLAWSWEEPER_ENABLE_CLAWHUB != '1') && !(github.event_name == 'repository_dispatch' && github.event.client_payload.target_repo == 'openclaw/clawhub' && vars.CLAWSWEEPER_ENABLE_CLAWHUB != '1') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     outputs:
@@ -1798,9 +1946,414 @@ jobs:
             --path records/openclaw-openclaw \
             --rebase-strategy theirs
 
+  provider-lease-live-proof-holder:
+    name: Provider lease live proof holder
+    if: ${{ github.event_name == 'workflow_dispatch' && contains(github.event.inputs.additional_prompt || '', '[provider-lease-live-proof]') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          filter: blob:none
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Create state token
+        id: state-token
+        uses: ./.github/actions/create-state-token
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+
+      - uses: ./.github/actions/setup-state
+        with:
+          token: ${{ steps.state-token.outputs.token }}
+          fetch-depth: 1
+
+      - uses: ./.github/actions/setup-pnpm
+        with:
+          build-script: build:repair
+
+      - name: Hold and renew provider lease
+        env:
+          PROOF_PROVIDER: codex-live-proof-${{ github.run_id }}
+          HOLDER_LEASE_ID: proof-holder-${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+          json_from_log() {
+            node -e '
+              const fs = require("fs");
+              const logPath = process.argv[1];
+              const text = fs.readFileSync(logPath, "utf8").trim();
+              for (let index = text.lastIndexOf("{"); index >= 0; index = text.lastIndexOf("{", index - 1)) {
+                try {
+                  console.log(JSON.stringify(JSON.parse(text.slice(index)), null, 2));
+                  process.exit(0);
+                } catch {
+                  // Keep looking for the outer JSON object; provider-lease output can include git logs first.
+                }
+              }
+              console.error(`No trailing JSON object found in ${logPath}`);
+              process.exit(1);
+            ' "$1"
+          }
+          state_dir="${CLAWSWEEPER_STATE_DIR:?}"
+          echo "Provider: $PROOF_PROVIDER"
+          echo "Holder lease: $HOLDER_LEASE_ID"
+          pnpm run --silent repair:provider-lease -- acquire \
+            --state-dir "$state_dir" \
+            --provider "$PROOF_PROVIDER" \
+            --lease-id "$HOLDER_LEASE_ID" \
+            --owner "$GITHUB_REPOSITORY" \
+            --lane live-proof-holder \
+            --item "$GITHUB_REPOSITORY#281" \
+            --run-id "$GITHUB_RUN_ID" \
+            --capacity 1 \
+            --weight 1 \
+            --ttl-seconds 30 \
+            --wait-seconds 0 \
+            --poll-seconds 2 2>&1 | tee acquire.log
+          acquire_json="$(json_from_log acquire.log)"
+          jq -e '.acquired == true and .activeWeight == 1 and .capacity == 1' <<<"$acquire_json"
+
+          for attempt in 1 2 3 4; do
+            sleep 10
+            echo "Renew attempt $attempt after original acquisition."
+            pnpm run --silent repair:provider-lease -- renew \
+              --state-dir "$state_dir" \
+              --provider "$PROOF_PROVIDER" \
+              --lease-id "$HOLDER_LEASE_ID" \
+              --capacity 1 \
+              --ttl-seconds 30 2>&1 | tee "renew-$attempt.log"
+            renew_json="$(json_from_log "renew-$attempt.log")"
+            jq -e '.renewed == true' <<<"$renew_json"
+          done
+
+          echo "Holder stayed active for more than the original 30s TTL; releasing now."
+          pnpm run --silent repair:provider-lease -- release \
+            --state-dir "$state_dir" \
+            --provider "$PROOF_PROVIDER" \
+            --lease-id "$HOLDER_LEASE_ID" \
+            --capacity 1 2>&1 | tee release.log
+          release_json="$(json_from_log release.log)"
+          jq -e '.released == true' <<<"$release_json"
+          {
+            echo "### Provider lease live proof holder"
+            echo
+            echo "- Acquired lease: \`$HOLDER_LEASE_ID\`"
+            echo "- Renewed lease four times over more than the original 30s TTL"
+            echo "- Released lease cleanly"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  provider-lease-live-proof-waiter:
+    name: Provider lease live proof concurrent waiter
+    if: ${{ github.event_name == 'workflow_dispatch' && contains(github.event.inputs.additional_prompt || '', '[provider-lease-live-proof]') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          filter: blob:none
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Create state token
+        id: state-token
+        uses: ./.github/actions/create-state-token
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+
+      - uses: ./.github/actions/setup-state
+        with:
+          token: ${{ steps.state-token.outputs.token }}
+          fetch-depth: 1
+
+      - uses: ./.github/actions/setup-pnpm
+        with:
+          build-script: build:repair
+
+      - name: Verify concurrent capacity timeout
+        env:
+          PROOF_PROVIDER: codex-live-proof-${{ github.run_id }}
+          HOLDER_LEASE_ID: proof-holder-${{ github.run_id }}-${{ github.run_attempt }}
+          WAITER_LEASE_ID: proof-waiter-${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+          json_from_log() {
+            node -e '
+              const fs = require("fs");
+              const logPath = process.argv[1];
+              const text = fs.readFileSync(logPath, "utf8").trim();
+              for (let index = text.lastIndexOf("{"); index >= 0; index = text.lastIndexOf("{", index - 1)) {
+                try {
+                  console.log(JSON.stringify(JSON.parse(text.slice(index)), null, 2));
+                  process.exit(0);
+                } catch {
+                  // Keep looking for the outer JSON object; provider-lease output can include git logs first.
+                }
+              }
+              console.error(`No trailing JSON object found in ${logPath}`);
+              process.exit(1);
+            ' "$1"
+          }
+          state_dir="${CLAWSWEEPER_STATE_DIR:?}"
+          lease_file="$state_dir/provider-leases/$PROOF_PROVIDER.json"
+          echo "Waiting for holder lease $HOLDER_LEASE_ID to appear in $lease_file."
+          saw_holder=false
+          for _ in $(seq 1 60); do
+            git -C "$state_dir" fetch --quiet origin state
+            git -C "$state_dir" reset --quiet --hard origin/state
+            if [ -f "$lease_file" ] && jq -e --arg id "$HOLDER_LEASE_ID" '.leases[]? | select(.id == $id)' "$lease_file" >/dev/null; then
+              saw_holder=true
+              break
+            fi
+            sleep 2
+          done
+          if [ "$saw_holder" != "true" ]; then
+            echo "Holder lease did not appear before timeout." >&2
+            exit 1
+          fi
+
+          echo "Holder is active in the real state repo; proving a concurrent waiter is blocked."
+          pnpm run --silent repair:provider-lease -- acquire \
+            --state-dir "$state_dir" \
+            --provider "$PROOF_PROVIDER" \
+            --lease-id "$WAITER_LEASE_ID" \
+            --owner "$GITHUB_REPOSITORY" \
+            --lane live-proof-waiter \
+            --item "$GITHUB_REPOSITORY#281" \
+            --run-id "$GITHUB_RUN_ID" \
+            --capacity 1 \
+            --weight 1 \
+            --ttl-seconds 30 \
+            --wait-seconds 20 \
+            --poll-seconds 5 2>&1 | tee waiter-acquire.log
+          acquire_json="$(json_from_log waiter-acquire.log)"
+          jq -e '.acquired == false and .activeWeight == 1 and .capacity == 1 and (.reason | test("provider capacity full"))' <<<"$acquire_json"
+          {
+            echo "### Provider lease live proof waiter"
+            echo
+            echo "- Observed holder lease in the real state repo"
+            echo "- Concurrent acquire waited 20s and returned \`provider capacity full\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  provider-lease-live-proof-release-check:
+    name: Provider lease live proof release check
+    needs:
+      - provider-lease-live-proof-holder
+      - provider-lease-live-proof-waiter
+    if: ${{ github.event_name == 'workflow_dispatch' && contains(github.event.inputs.additional_prompt || '', '[provider-lease-live-proof]') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          filter: blob:none
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Create state token
+        id: state-token
+        uses: ./.github/actions/create-state-token
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+
+      - uses: ./.github/actions/setup-state
+        with:
+          token: ${{ steps.state-token.outputs.token }}
+          fetch-depth: 1
+
+      - uses: ./.github/actions/setup-pnpm
+        with:
+          build-script: build:repair
+
+      - name: Verify acquisition after release
+        env:
+          PROOF_PROVIDER: codex-live-proof-${{ github.run_id }}
+          RELEASE_CHECK_LEASE_ID: proof-release-check-${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+          json_from_log() {
+            node -e '
+              const fs = require("fs");
+              const logPath = process.argv[1];
+              const text = fs.readFileSync(logPath, "utf8").trim();
+              for (let index = text.lastIndexOf("{"); index >= 0; index = text.lastIndexOf("{", index - 1)) {
+                try {
+                  console.log(JSON.stringify(JSON.parse(text.slice(index)), null, 2));
+                  process.exit(0);
+                } catch {
+                  // Keep looking for the outer JSON object; provider-lease output can include git logs first.
+                }
+              }
+              console.error(`No trailing JSON object found in ${logPath}`);
+              process.exit(1);
+            ' "$1"
+          }
+          state_dir="${CLAWSWEEPER_STATE_DIR:?}"
+          pnpm run --silent repair:provider-lease -- acquire \
+            --state-dir "$state_dir" \
+            --provider "$PROOF_PROVIDER" \
+            --lease-id "$RELEASE_CHECK_LEASE_ID" \
+            --owner "$GITHUB_REPOSITORY" \
+            --lane live-proof-release-check \
+            --item "$GITHUB_REPOSITORY#281" \
+            --run-id "$GITHUB_RUN_ID" \
+            --capacity 1 \
+            --weight 1 \
+            --ttl-seconds 30 \
+            --wait-seconds 0 \
+            --poll-seconds 2 2>&1 | tee release-check-acquire.log
+          acquire_json="$(json_from_log release-check-acquire.log)"
+          jq -e '.acquired == true and .activeWeight == 1 and .capacity == 1' <<<"$acquire_json"
+          pnpm run --silent repair:provider-lease -- release \
+            --state-dir "$state_dir" \
+            --provider "$PROOF_PROVIDER" \
+            --lease-id "$RELEASE_CHECK_LEASE_ID" \
+            --capacity 1 2>&1 | tee release-check-release.log
+          release_json="$(json_from_log release-check-release.log)"
+          jq -e '.released == true' <<<"$release_json"
+          {
+            echo "### Provider lease live proof release check"
+            echo
+            echo "- Acquired a new lease after the holder released"
+            echo "- Released the follow-up lease cleanly"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  provider-lease-live-proof-ttl-recovery:
+    name: Provider lease live proof TTL recovery
+    needs:
+      - provider-lease-live-proof-release-check
+    if: ${{ github.event_name == 'workflow_dispatch' && contains(github.event.inputs.additional_prompt || '', '[provider-lease-live-proof]') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          filter: blob:none
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Create state token
+        id: state-token
+        uses: ./.github/actions/create-state-token
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+
+      - uses: ./.github/actions/setup-state
+        with:
+          token: ${{ steps.state-token.outputs.token }}
+          fetch-depth: 1
+
+      - uses: ./.github/actions/setup-pnpm
+        with:
+          build-script: build:repair
+
+      - name: Verify abandoned lease TTL recovery
+        env:
+          PROOF_PROVIDER: codex-live-proof-${{ github.run_id }}
+          ABANDONED_LEASE_ID: proof-abandoned-${{ github.run_id }}-${{ github.run_attempt }}
+          RECOVERED_LEASE_ID: proof-recovered-${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+          json_from_log() {
+            node -e '
+              const fs = require("fs");
+              const logPath = process.argv[1];
+              const text = fs.readFileSync(logPath, "utf8").trim();
+              for (let index = text.lastIndexOf("{"); index >= 0; index = text.lastIndexOf("{", index - 1)) {
+                try {
+                  console.log(JSON.stringify(JSON.parse(text.slice(index)), null, 2));
+                  process.exit(0);
+                } catch {
+                  // Keep looking for the outer JSON object; provider-lease output can include git logs first.
+                }
+              }
+              console.error(`No trailing JSON object found in ${logPath}`);
+              process.exit(1);
+            ' "$1"
+          }
+          state_dir="${CLAWSWEEPER_STATE_DIR:?}"
+          pnpm run --silent repair:provider-lease -- acquire \
+            --state-dir "$state_dir" \
+            --provider "$PROOF_PROVIDER" \
+            --lease-id "$ABANDONED_LEASE_ID" \
+            --owner "$GITHUB_REPOSITORY" \
+            --lane live-proof-abandoned \
+            --item "$GITHUB_REPOSITORY#281" \
+            --run-id "$GITHUB_RUN_ID" \
+            --capacity 1 \
+            --weight 1 \
+            --ttl-seconds 15 \
+            --wait-seconds 0 \
+            --poll-seconds 2 2>&1 | tee abandoned-acquire.log
+          abandoned_json="$(json_from_log abandoned-acquire.log)"
+          jq -e '.acquired == true and .activeWeight == 1 and .capacity == 1' <<<"$abandoned_json"
+
+          echo "Simulating cancellation by not releasing $ABANDONED_LEASE_ID; waiting for TTL recovery."
+          sleep 20
+
+          pnpm run --silent repair:provider-lease -- acquire \
+            --state-dir "$state_dir" \
+            --provider "$PROOF_PROVIDER" \
+            --lease-id "$RECOVERED_LEASE_ID" \
+            --owner "$GITHUB_REPOSITORY" \
+            --lane live-proof-recovered \
+            --item "$GITHUB_REPOSITORY#281" \
+            --run-id "$GITHUB_RUN_ID" \
+            --capacity 1 \
+            --weight 1 \
+            --ttl-seconds 30 \
+            --wait-seconds 0 \
+            --poll-seconds 2 2>&1 | tee recovered-acquire.log
+          recovered_json="$(json_from_log recovered-acquire.log)"
+          jq -e '.acquired == true and .activeWeight == 1 and .capacity == 1' <<<"$recovered_json"
+
+          pnpm run --silent repair:provider-lease -- release \
+            --state-dir "$state_dir" \
+            --provider "$PROOF_PROVIDER" \
+            --lease-id "$RECOVERED_LEASE_ID" \
+            --capacity 1 2>&1 | tee recovered-release.log
+          release_json="$(json_from_log recovered-release.log)"
+          jq -e '.released == true' <<<"$release_json"
+
+          if (
+            set -euo pipefail
+            git -C "$state_dir" pull --rebase --autostash
+            rm -f "$state_dir/provider-leases/$PROOF_PROVIDER.json"
+            git -C "$state_dir" add -A -- provider-leases
+            if ! git -C "$state_dir" diff --cached --quiet; then
+              git -C "$state_dir" commit -m "chore: clean provider lease live proof $GITHUB_RUN_ID"
+              git -C "$state_dir" push
+            fi
+          ); then
+            echo "Cleaned proof provider state for $PROOF_PROVIDER."
+          else
+            echo "::warning::Proof provider cleanup failed; the isolated proof provider can be pruned by a later proof run."
+          fi
+
+          {
+            echo "### Provider lease live proof TTL recovery"
+            echo
+            echo "- Acquired an abandoned lease with 15s TTL and intentionally did not release it"
+            echo "- Waited past TTL and acquired a replacement lease, proving stale lease pruning"
+            echo "- Released the replacement lease and cleaned the proof provider file"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   audit-dashboard:
     name: Audit state
-    if: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.audit_dashboard == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '7 */6 * * *' || github.event.schedule == '12 */6 * * *' || github.event.schedule == '17 */6 * * *')) }}
+    if: ${{ !contains(github.event.inputs.additional_prompt || '', '[provider-lease-live-proof]') && ((github.event_name == 'workflow_dispatch' && github.event.inputs.audit_dashboard == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '7 */6 * * *' || github.event.schedule == '12 */6 * * *' || github.event.schedule == '17 */6 * * *'))) }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "repair:spam-scan": "node dist/repair/spam-scanner.js",
     "repair:publish-event-result": "node dist/repair/publish-event-result.js",
     "repair:update-command-status": "node dist/repair/update-command-status.js",
+    "repair:provider-lease": "node dist/repair/provider-lease.js",
     "workflow": "node dist/repair/workflow-utils.js",
     "repair:promote-stuck-jobs": "node dist/repair/promote-stuck-jobs.js",
     "repair:sweep-openclaw-jobs": "node dist/repair/sweep-openclaw-jobs.js",

--- a/src/repair/provider-lease.ts
+++ b/src/repair/provider-lease.ts
@@ -1,0 +1,487 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { parseArgs } from "./lib.js";
+import { clawsweeperGitUserEmail, clawsweeperGitUserName } from "./process-env.js";
+
+export type ProviderLease = {
+  id: string;
+  owner: string;
+  lane: string;
+  item: string;
+  runId: string;
+  weight: number;
+  acquiredAt: string;
+  expiresAt: string;
+};
+
+export type ProviderLeaseDocument = {
+  provider: string;
+  capacity: number;
+  updatedAt: string;
+  leases: ProviderLease[];
+};
+
+export type ProviderLeaseAcquireResult = {
+  acquired: boolean;
+  activeWeight: number;
+  capacity: number;
+  lease?: ProviderLease;
+  reason?: string;
+};
+
+type AcquireOptions = {
+  stateDir: string;
+  provider: string;
+  leaseId: string;
+  owner: string;
+  lane: string;
+  item: string;
+  runId: string;
+  capacity: number;
+  weight: number;
+  ttlMs: number;
+  waitMs: number;
+  pollMs: number;
+  now?: Date;
+};
+
+type ReleaseOptions = {
+  stateDir: string;
+  provider: string;
+  leaseId: string;
+  capacity: number;
+};
+
+type RenewOptions = ReleaseOptions & {
+  ttlMs: number;
+};
+
+type GitRunOptions = {
+  allowFailure?: boolean;
+};
+
+const DEFAULT_PROVIDER = "codex-internal-default";
+const DEFAULT_CAPACITY = 4;
+const DEFAULT_WEIGHT = 1;
+const DEFAULT_TTL_MS = 15 * 60 * 1000;
+const DEFAULT_WAIT_MS = 20 * 60 * 1000;
+const DEFAULT_POLL_MS = 15 * 1000;
+
+const args = parseArgs(process.argv.slice(2));
+
+export function providerLeasePath(stateDir: string, provider: string): string {
+  return resolve(stateDir, "provider-leases", `${safeProviderName(provider)}.json`);
+}
+
+export function safeProviderName(provider: string): string {
+  return provider.trim().replace(/[^A-Za-z0-9_.-]/g, "-") || DEFAULT_PROVIDER;
+}
+
+export function readProviderLeaseDocument(
+  stateDir: string,
+  provider: string,
+  capacity = DEFAULT_CAPACITY,
+  now = new Date(),
+): ProviderLeaseDocument {
+  const file = providerLeasePath(stateDir, provider);
+  if (!existsSync(file)) {
+    return { provider, capacity, updatedAt: now.toISOString(), leases: [] };
+  }
+  const parsed = JSON.parse(readFileSync(file, "utf8")) as unknown;
+  if (!isRecord(parsed)) {
+    return { provider, capacity, updatedAt: now.toISOString(), leases: [] };
+  }
+  return normalizeProviderLeaseDocument(parsed, provider, capacity, now);
+}
+
+export function normalizeProviderLeaseDocument(
+  value: Record<string, unknown>,
+  provider: string,
+  fallbackCapacity = DEFAULT_CAPACITY,
+  now = new Date(),
+): ProviderLeaseDocument {
+  const capacity = positiveInteger(fallbackCapacity, DEFAULT_CAPACITY);
+  const leases = Array.isArray(value.leases)
+    ? value.leases.flatMap((lease) => normalizeProviderLease(lease))
+    : [];
+  return {
+    provider:
+      typeof value.provider === "string" && value.provider.trim() ? value.provider : provider,
+    capacity,
+    updatedAt:
+      typeof value.updatedAt === "string" && value.updatedAt.trim()
+        ? value.updatedAt
+        : now.toISOString(),
+    leases,
+  };
+}
+
+export function pruneExpiredLeases(
+  document: ProviderLeaseDocument,
+  now = new Date(),
+): ProviderLeaseDocument {
+  const nowMs = now.getTime();
+  return {
+    ...document,
+    leases: document.leases.filter((lease) => Date.parse(lease.expiresAt) > nowMs),
+  };
+}
+
+export function tryAcquireProviderLease(
+  document: ProviderLeaseDocument,
+  options: {
+    leaseId: string;
+    owner: string;
+    lane: string;
+    item: string;
+    runId: string;
+    weight: number;
+    ttlMs: number;
+    now?: Date;
+  },
+): { document: ProviderLeaseDocument; result: ProviderLeaseAcquireResult } {
+  const now = options.now ?? new Date();
+  const pruned = pruneExpiredLeases(document, now);
+  const capacity = Math.max(1, Math.floor(pruned.capacity));
+  const weight = Math.max(1, Math.floor(options.weight));
+  const existing = pruned.leases.find((lease) => lease.id === options.leaseId);
+  const activeWeight = pruned.leases.reduce((sum, lease) => sum + Math.max(1, lease.weight), 0);
+  const expiresAt = new Date(now.getTime() + options.ttlMs).toISOString();
+
+  if (existing) {
+    const lease = { ...existing, expiresAt };
+    const leases = pruned.leases.map((entry) => (entry.id === lease.id ? lease : entry));
+    return {
+      document: { ...pruned, updatedAt: now.toISOString(), leases },
+      result: { acquired: true, activeWeight, capacity, lease },
+    };
+  }
+
+  if (activeWeight + weight > capacity) {
+    return {
+      document: { ...pruned, updatedAt: now.toISOString() },
+      result: {
+        acquired: false,
+        activeWeight,
+        capacity,
+        reason: `provider capacity full: active weight ${activeWeight}/${capacity}, requested ${weight}`,
+      },
+    };
+  }
+
+  const lease: ProviderLease = {
+    id: options.leaseId,
+    owner: options.owner,
+    lane: options.lane,
+    item: options.item,
+    runId: options.runId,
+    weight,
+    acquiredAt: now.toISOString(),
+    expiresAt,
+  };
+  return {
+    document: { ...pruned, updatedAt: now.toISOString(), leases: [...pruned.leases, lease] },
+    result: { acquired: true, activeWeight: activeWeight + weight, capacity, lease },
+  };
+}
+
+export function releaseProviderLeaseDocument(
+  document: ProviderLeaseDocument,
+  leaseId: string,
+  now = new Date(),
+): { document: ProviderLeaseDocument; released: boolean } {
+  const pruned = pruneExpiredLeases(document, now);
+  const leases = pruned.leases.filter((lease) => lease.id !== leaseId);
+  return {
+    document: { ...pruned, updatedAt: now.toISOString(), leases },
+    released: leases.length !== pruned.leases.length,
+  };
+}
+
+export function renewProviderLeaseDocument(
+  document: ProviderLeaseDocument,
+  leaseId: string,
+  ttlMs: number,
+  now = new Date(),
+): { document: ProviderLeaseDocument; renewed: boolean; lease?: ProviderLease } {
+  const pruned = pruneExpiredLeases(document, now);
+  const current = pruned.leases.find((lease) => lease.id === leaseId);
+  if (!current) {
+    return { document: { ...pruned, updatedAt: now.toISOString() }, renewed: false };
+  }
+  const lease = { ...current, expiresAt: new Date(now.getTime() + ttlMs).toISOString() };
+  return {
+    document: {
+      ...pruned,
+      updatedAt: now.toISOString(),
+      leases: pruned.leases.map((entry) => (entry.id === lease.id ? lease : entry)),
+    },
+    renewed: true,
+    lease,
+  };
+}
+
+export function writeProviderLeaseDocument(
+  stateDir: string,
+  document: ProviderLeaseDocument,
+): void {
+  const file = providerLeasePath(stateDir, document.provider);
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, `${JSON.stringify(document, null, 2)}\n`, "utf8");
+}
+
+export function acquireProviderLease(options: AcquireOptions): ProviderLeaseAcquireResult {
+  const deadline = Date.now() + Math.max(0, options.waitMs);
+  configureStateGit(options.stateDir);
+
+  for (;;) {
+    syncStateBranch(options.stateDir);
+    const now = new Date();
+    const current = readProviderLeaseDocument(
+      options.stateDir,
+      options.provider,
+      options.capacity,
+      now,
+    );
+    const { document, result } = tryAcquireProviderLease(current, { ...options, now });
+    writeProviderLeaseDocument(options.stateDir, document);
+    if (result.acquired && commitAndPushState(options.stateDir, "chore: acquire provider lease")) {
+      return result;
+    }
+    resetStateBranch(options.stateDir);
+    if (Date.now() >= deadline) {
+      if (result.acquired) {
+        throw new Error(
+          "failed to acquire provider lease: shared state push failed before accepting the lease",
+        );
+      }
+      return result;
+    }
+    sleep(jitter(options.pollMs));
+  }
+}
+
+export function releaseProviderLease(options: ReleaseOptions): boolean {
+  configureStateGit(options.stateDir);
+  for (let attempt = 1; attempt <= 5; attempt += 1) {
+    syncStateBranch(options.stateDir);
+    const current = readProviderLeaseDocument(options.stateDir, options.provider, options.capacity);
+    const { document, released } = releaseProviderLeaseDocument(current, options.leaseId);
+    writeProviderLeaseDocument(options.stateDir, document);
+    if (!released) return false;
+    if (commitAndPushState(options.stateDir, "chore: release provider lease")) return true;
+    sleep(jitter(1000 * attempt));
+  }
+  throw new Error(`failed to release provider lease ${options.leaseId}`);
+}
+
+export function renewProviderLease(options: RenewOptions): boolean {
+  configureStateGit(options.stateDir);
+  for (let attempt = 1; attempt <= 5; attempt += 1) {
+    syncStateBranch(options.stateDir);
+    const current = readProviderLeaseDocument(options.stateDir, options.provider, options.capacity);
+    const { document, renewed } = renewProviderLeaseDocument(
+      current,
+      options.leaseId,
+      options.ttlMs,
+    );
+    writeProviderLeaseDocument(options.stateDir, document);
+    if (commitAndPushState(options.stateDir, "chore: renew provider lease")) return renewed;
+    resetStateBranch(options.stateDir);
+    sleep(jitter(1000 * attempt));
+  }
+  throw new Error(`failed to renew provider lease ${options.leaseId}`);
+}
+
+function runCli(): void {
+  const command = String(args._[0] ?? "");
+  if (command === "acquire") {
+    const result = acquireProviderLease(acquireOptionsFromArgs());
+    printGithubOutput("acquired", result.acquired ? "true" : "false");
+    printGithubOutput("active_weight", String(result.activeWeight));
+    printGithubOutput("capacity", String(result.capacity));
+    printGithubOutput("reason", result.reason ?? "");
+    printGithubOutput("lease_id", stringArg("lease-id", defaultLeaseId()));
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+  if (command === "release") {
+    const released = releaseProviderLease(releaseOptionsFromArgs());
+    printGithubOutput("released", released ? "true" : "false");
+    console.log(JSON.stringify({ released }, null, 2));
+    return;
+  }
+  if (command === "renew") {
+    const renewed = renewProviderLease(renewOptionsFromArgs());
+    printGithubOutput("renewed", renewed ? "true" : "false");
+    console.log(JSON.stringify({ renewed }, null, 2));
+    if (!renewed) process.exitCode = 1;
+    return;
+  }
+  throw new Error("usage: provider-lease <acquire|renew|release> --state-dir DIR [options]");
+}
+
+function acquireOptionsFromArgs(): AcquireOptions {
+  return {
+    stateDir: requiredString("state-dir"),
+    provider: stringArg("provider", DEFAULT_PROVIDER),
+    leaseId: stringArg("lease-id", defaultLeaseId()),
+    owner: stringArg("owner", "clawsweeper"),
+    lane: stringArg("lane", "review"),
+    item: stringArg("item", ""),
+    runId: stringArg("run-id", process.env.GITHUB_RUN_ID ?? ""),
+    capacity: numberArg(
+      "capacity",
+      envNumber("CLAWSWEEPER_PROVIDER_LEASE_CAPACITY", DEFAULT_CAPACITY),
+    ),
+    weight: numberArg("weight", DEFAULT_WEIGHT),
+    ttlMs: numberArg("ttl-seconds", DEFAULT_TTL_MS / 1000) * 1000,
+    waitMs: numberArg("wait-seconds", DEFAULT_WAIT_MS / 1000) * 1000,
+    pollMs: numberArg("poll-seconds", DEFAULT_POLL_MS / 1000) * 1000,
+  };
+}
+
+function releaseOptionsFromArgs(): ReleaseOptions {
+  return {
+    stateDir: requiredString("state-dir"),
+    provider: stringArg("provider", DEFAULT_PROVIDER),
+    leaseId: stringArg("lease-id", defaultLeaseId()),
+    capacity: numberArg(
+      "capacity",
+      envNumber("CLAWSWEEPER_PROVIDER_LEASE_CAPACITY", DEFAULT_CAPACITY),
+    ),
+  };
+}
+
+function renewOptionsFromArgs(): RenewOptions {
+  return {
+    ...releaseOptionsFromArgs(),
+    ttlMs: numberArg("ttl-seconds", DEFAULT_TTL_MS / 1000) * 1000,
+  };
+}
+
+function commitAndPushState(stateDir: string, message: string): boolean {
+  runGit(stateDir, ["add", "-A", "--", "provider-leases"]);
+  if (runGit(stateDir, ["diff", "--cached", "--quiet"], { allowFailure: true }).status === 0) {
+    return true;
+  }
+  runGit(stateDir, ["commit", "-m", `${message}\n\n[skip ci]`]);
+  return runGit(stateDir, ["push", "origin", "HEAD:state"], { allowFailure: true }).status === 0;
+}
+
+function configureStateGit(stateDir: string): void {
+  runGit(stateDir, ["config", "user.name", clawsweeperGitUserName()]);
+  runGit(stateDir, ["config", "user.email", clawsweeperGitUserEmail()]);
+}
+
+function syncStateBranch(stateDir: string): void {
+  runGit(stateDir, ["fetch", "origin", "state"]);
+  runGit(stateDir, ["checkout", "-B", "state", "origin/state"]);
+}
+
+function resetStateBranch(stateDir: string): void {
+  runGit(stateDir, ["reset", "--hard", "origin/state"]);
+}
+
+function runGit(stateDir: string, gitArgs: readonly string[], options: GitRunOptions = {}) {
+  const child = spawnSync("git", gitArgs, {
+    cwd: stateDir,
+    env: process.env,
+    encoding: "utf8",
+  });
+  if (child.stdout) process.stdout.write(child.stdout);
+  if (child.stderr) process.stderr.write(child.stderr);
+  const status = child.status ?? 1;
+  if (status !== 0 && !options.allowFailure) {
+    throw new Error((child.stderr || child.stdout || `git ${gitArgs[0]} failed`).trim());
+  }
+  return { status, stdout: child.stdout ?? "", stderr: child.stderr ?? "" };
+}
+
+function normalizeProviderLease(value: unknown): ProviderLease[] {
+  if (!isRecord(value)) return [];
+  const id = stringValue(value.id);
+  if (!id) return [];
+  return [
+    {
+      id,
+      owner: stringValue(value.owner) || "unknown",
+      lane: stringValue(value.lane) || "unknown",
+      item: stringValue(value.item),
+      runId: stringValue(value.runId),
+      weight: positiveInteger(value.weight, DEFAULT_WEIGHT),
+      acquiredAt: stringValue(value.acquiredAt) || new Date(0).toISOString(),
+      expiresAt: stringValue(value.expiresAt) || new Date(0).toISOString(),
+    },
+  ];
+}
+
+function requiredString(name: string): string {
+  const value = stringArg(name, "");
+  if (!value) throw new Error(`--${name} is required`);
+  return value;
+}
+
+function stringArg(name: string, fallback: string): string {
+  const value = args[name];
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
+function numberArg(name: string, fallback: number): number {
+  const value = args[name];
+  const parsed = typeof value === "string" ? Number(value) : Number.NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function envNumber(name: string, fallback: number): number {
+  const parsed = Number(process.env[name]);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function positiveInteger(value: unknown, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function defaultLeaseId(): string {
+  return [
+    process.env.GITHUB_RUN_ID,
+    process.env.GITHUB_RUN_ATTEMPT,
+    process.env.GITHUB_JOB,
+    stringArg("item", ""),
+  ]
+    .filter(Boolean)
+    .join("-");
+}
+
+function printGithubOutput(name: string, value: string): void {
+  const output = process.env.GITHUB_OUTPUT;
+  if (!output) return;
+  writeFileSync(output, `${name}=${value}\n`, { flag: "a" });
+}
+
+function jitter(ms: number): number {
+  const base = Math.max(250, ms);
+  const spread = Math.floor(base * 0.3);
+  return base + Math.floor(Math.random() * Math.max(1, spread));
+}
+
+function sleep(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  runCli();
+}

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -17337,7 +17337,19 @@ test("event re-review status explains superseded cancellations", () => {
   assert.match(block, /state="Superseded"/);
   assert.match(block, /A newer re-review for this item started before this run finished/);
   assert.doesNotMatch(block, /CAPACITY_OUTCOME/);
-  assert.doesNotMatch(block, /Capacity wait timed out/);
+});
+
+test("event re-review status marks exhausted provider waits terminal", () => {
+  const workflow = readFileSync(".github/workflows/sweep.yml", "utf8");
+  const block = workflow.slice(
+    workflow.indexOf("- name: Mark re-review complete"),
+    workflow.indexOf("- name: Commit event comment router ledger"),
+  );
+
+  assert.match(block, /\[ "\$PROVIDER_LEASE_ACQUIRED" != "true" \]/);
+  assert.match(block, /state="Capacity timeout"/);
+  assert.match(block, /stayed full until this workflow's wait deadline/);
+  assert.doesNotMatch(block, /state="Waiting for Codex capacity"/);
 });
 
 test("event repair retries wait for active worker capacity", () => {
@@ -17741,7 +17753,7 @@ test("reviewed viable issues dispatch the existing implementation and automerge 
   assert.match(workflow, /steps\.target\.outputs\.target_repo != 'openclaw\/clawhub'/);
 });
 
-test("sweep workflow runs exact event reviews without a global worker gate", () => {
+test("sweep workflow runs exact event reviews behind provider capacity only", () => {
   const workflow = readFileSync(".github/workflows/sweep.yml", "utf8").replace(/\r\n/g, "\n");
   const eventReviewBlock = workflow.slice(
     workflow.indexOf("\n  event-review-apply:"),
@@ -17754,10 +17766,12 @@ test("sweep workflow runs exact event reviews without a global worker gate", () 
     "- name: Mark re-review command in progress",
   );
   const setupCodexIndex = eventReviewBlock.indexOf("- uses: ./.github/actions/setup-codex");
+  const acquireProviderIndex = eventReviewBlock.indexOf("- name: Acquire Codex provider lease");
   const exactReviewIndex = eventReviewBlock.indexOf("- name: Review exact event item");
+  const releaseProviderIndex = eventReviewBlock.indexOf("- name: Release Codex provider lease");
   const exactReviewStep = eventReviewBlock.slice(
     exactReviewIndex,
-    eventReviewBlock.indexOf("- name: Create state token", exactReviewIndex),
+    eventReviewBlock.indexOf("- name: Release Codex provider lease", exactReviewIndex),
   );
 
   assert.match(
@@ -17768,11 +17782,17 @@ test("sweep workflow runs exact event reviews without a global worker gate", () 
   assert.ok(setupPnpmIndex >= 0);
   assert.ok(readTokenIndex > setupPnpmIndex);
   assert.ok(writeTokenIndex > readTokenIndex);
-  assert.ok(inProgressStatusIndex > writeTokenIndex);
-  assert.ok(setupCodexIndex > inProgressStatusIndex);
-  assert.ok(exactReviewIndex > setupCodexIndex);
+  assert.ok(setupCodexIndex > writeTokenIndex);
+  assert.ok(acquireProviderIndex > setupCodexIndex);
+  assert.ok(inProgressStatusIndex > acquireProviderIndex);
+  assert.ok(exactReviewIndex > inProgressStatusIndex);
+  assert.ok(releaseProviderIndex > exactReviewIndex);
   assert.match(exactReviewStep, /--batch-size 1/);
   assert.match(exactReviewStep, /--shard-count 1/);
+  assert.match(exactReviewStep, /repair:provider-lease -- renew/);
+  assert.match(exactReviewStep, /Provider lease renewal stopped before review completed/);
+  assert.match(eventReviewBlock, /repair:provider-lease -- acquire/);
+  assert.match(eventReviewBlock, /steps\.provider-lease\.outputs\.acquired == 'true'/);
   assert.doesNotMatch(eventReviewBlock, /Wait for exact event review capacity/);
   assert.doesNotMatch(eventReviewBlock, /wait-exact-event-capacity/);
   assert.doesNotMatch(eventReviewBlock, /Waiting for review capacity/);
@@ -18459,4 +18479,56 @@ test("safeOutputTail tolerates missing process output", () => {
   assert.equal(safeOutputTail(undefined), "");
   assert.equal(safeOutputTail(null), "");
   assert.equal(safeOutputTail("abcdef", 3), "def");
+});
+
+test("exact event reviews acquire and release a provider lease around Codex", () => {
+  const workflow = readFileSync(".github/workflows/sweep.yml", "utf8");
+  const acquireIndex = workflow.indexOf("name: Acquire Codex provider lease");
+  const reviewIndex = workflow.indexOf("name: Review exact event item");
+  const releaseIndex = workflow.indexOf("name: Release Codex provider lease");
+  const publishIndex = workflow.indexOf("name: Publish event result and apply safe close");
+
+  assert.ok(acquireIndex > 0, "expected exact event workflow to acquire a provider lease");
+  assert.ok(acquireIndex < reviewIndex, "provider lease must be acquired before Codex review");
+  assert.ok(reviewIndex < releaseIndex, "provider lease must be released after Codex review");
+  assert.ok(releaseIndex < publishIndex, "provider lease should be released before state publish");
+  assert.match(workflow, /steps\.provider-lease\.outputs\.acquired == 'true'/);
+  assert.match(workflow, /repair:provider-lease -- renew/);
+  assert.match(workflow, /CLAWSWEEPER_CODEX_PROVIDER_LEASE_RENEW_SECONDS/);
+  assert.match(workflow, /Capacity timeout/);
+});
+
+test("sweep workflow exposes a real Actions provider lease live proof mode", () => {
+  const workflow = readFileSync(".github/workflows/sweep.yml", "utf8");
+  const marker = "[provider-lease-live-proof]";
+
+  assert.match(
+    workflow,
+    /name: Provider lease live proof holder[\s\S]*repair:provider-lease -- acquire[\s\S]*repair:provider-lease -- renew[\s\S]*repair:provider-lease -- release/,
+  );
+  assert.match(
+    workflow,
+    /name: Provider lease live proof concurrent waiter[\s\S]*Waiting for holder lease[\s\S]*--wait-seconds 20[\s\S]*provider capacity full/,
+  );
+  assert.match(
+    workflow,
+    /name: Provider lease live proof release check[\s\S]*Acquired a new lease after the holder released/,
+  );
+  assert.match(
+    workflow,
+    /name: Provider lease live proof TTL recovery[\s\S]*Simulating cancellation by not releasing[\s\S]*waiting for TTL recovery/i,
+  );
+  assert.match(
+    workflow,
+    new RegExp(
+      `Plan review candidates[\\s\\S]*!contains\\(github\\.event\\.inputs\\.additional_prompt \\|\\| '', '\\${marker}'\\)`,
+    ),
+  );
+  assert.match(
+    workflow,
+    new RegExp(
+      `Audit state[\\s\\S]*!contains\\(github\\.event\\.inputs\\.additional_prompt \\|\\| '', '\\${marker}'\\)`,
+    ),
+  );
+  assert.match(workflow, /PROOF_PROVIDER: codex-live-proof-\$\{\{ github\.run_id \}\}/);
 });

--- a/test/repair/provider-lease.test.ts
+++ b/test/repair/provider-lease.test.ts
@@ -1,0 +1,454 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  acquireProviderLease,
+  providerLeasePath,
+  readProviderLeaseDocument,
+  releaseProviderLease,
+  releaseProviderLeaseDocument,
+  renewProviderLease,
+  renewProviderLeaseDocument,
+  safeProviderName,
+  tryAcquireProviderLease,
+  writeProviderLeaseDocument,
+} from "../../dist/repair/provider-lease.js";
+
+test("provider lease acquisition respects weighted capacity", () => {
+  const now = new Date("2026-06-12T00:00:00Z");
+  const document = {
+    provider: "codex-internal-default",
+    capacity: 4,
+    updatedAt: now.toISOString(),
+    leases: [lease("a", 2, "2026-06-12T00:10:00Z"), lease("b", 1, "2026-06-12T00:10:00Z")],
+  };
+
+  const blocked = tryAcquireProviderLease(document, {
+    leaseId: "c",
+    owner: "openclaw/clawsweeper",
+    lane: "exact-review",
+    item: "openclaw/openclaw#1",
+    runId: "1",
+    weight: 2,
+    ttlMs: 900_000,
+    now,
+  });
+
+  assert.equal(blocked.result.acquired, false);
+  assert.equal(blocked.result.activeWeight, 3);
+  assert.equal(blocked.result.capacity, 4);
+  assert.match(blocked.result.reason ?? "", /provider capacity full/);
+
+  const acquired = tryAcquireProviderLease(document, {
+    leaseId: "c",
+    owner: "openclaw/clawsweeper",
+    lane: "exact-review",
+    item: "openclaw/openclaw#1",
+    runId: "1",
+    weight: 1,
+    ttlMs: 900_000,
+    now,
+  });
+
+  assert.equal(acquired.result.acquired, true);
+  assert.equal(acquired.document.leases.length, 3);
+  assert.equal(acquired.result.lease?.expiresAt, "2026-06-12T00:15:00.000Z");
+});
+
+test("provider lease acquisition prunes expired leases", () => {
+  const now = new Date("2026-06-12T00:00:00Z");
+  const acquired = tryAcquireProviderLease(
+    {
+      provider: "codex-internal-default",
+      capacity: 1,
+      updatedAt: now.toISOString(),
+      leases: [lease("expired", 1, "2026-06-11T23:59:00Z")],
+    },
+    {
+      leaseId: "fresh",
+      owner: "openclaw/clawsweeper",
+      lane: "exact-review",
+      item: "openclaw/openclaw#2",
+      runId: "2",
+      weight: 1,
+      ttlMs: 900_000,
+      now,
+    },
+  );
+
+  assert.equal(acquired.result.acquired, true);
+  assert.deepEqual(
+    acquired.document.leases.map((entry) => entry.id),
+    ["fresh"],
+  );
+});
+
+test("provider lease release removes only the requested lease", () => {
+  const now = new Date("2026-06-12T00:00:00Z");
+  const result = releaseProviderLeaseDocument(
+    {
+      provider: "codex-internal-default",
+      capacity: 4,
+      updatedAt: now.toISOString(),
+      leases: [lease("keep", 1, "2026-06-12T00:10:00Z"), lease("drop", 1, "2026-06-12T00:10:00Z")],
+    },
+    "drop",
+    now,
+  );
+
+  assert.equal(result.released, true);
+  assert.deepEqual(
+    result.document.leases.map((entry) => entry.id),
+    ["keep"],
+  );
+});
+
+test("provider lease renew extends only an active requested lease", () => {
+  const now = new Date("2026-06-12T00:00:00Z");
+  const renewed = renewProviderLeaseDocument(
+    {
+      provider: "codex-internal-default",
+      capacity: 4,
+      updatedAt: now.toISOString(),
+      leases: [lease("keep", 1, "2026-06-12T00:01:00Z")],
+    },
+    "keep",
+    900_000,
+    now,
+  );
+
+  assert.equal(renewed.renewed, true);
+  assert.equal(renewed.lease?.acquiredAt, "2026-06-12T00:00:00Z");
+  assert.equal(renewed.lease?.expiresAt, "2026-06-12T00:15:00.000Z");
+
+  const expired = renewProviderLeaseDocument(
+    {
+      provider: "codex-internal-default",
+      capacity: 4,
+      updatedAt: now.toISOString(),
+      leases: [lease("expired", 1, "2026-06-11T23:59:00Z")],
+    },
+    "expired",
+    900_000,
+    now,
+  );
+
+  assert.equal(expired.renewed, false);
+  assert.deepEqual(expired.document.leases, []);
+});
+
+test("provider lease documents round-trip in state repo layout", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-provider-lease-"));
+  const document = {
+    provider: "codex/internal default",
+    capacity: 4,
+    updatedAt: "2026-06-12T00:00:00Z",
+    leases: [lease("a", 1, "2026-06-12T00:10:00Z")],
+  };
+
+  writeProviderLeaseDocument(root, document);
+
+  assert.equal(safeProviderName(document.provider), "codex-internal-default");
+  assert.equal(
+    providerLeasePath(root, document.provider),
+    path.join(root, "provider-leases", "codex-internal-default.json"),
+  );
+  assert.deepEqual(readProviderLeaseDocument(root, document.provider), document);
+});
+
+test("provider lease reads use current configured capacity over stored capacity", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-provider-lease-capacity-"));
+  const provider = "codex-internal-default";
+  fs.mkdirSync(path.dirname(providerLeasePath(root, provider)), { recursive: true });
+  fs.writeFileSync(
+    providerLeasePath(root, provider),
+    `${JSON.stringify({
+      provider,
+      capacity: 10,
+      updatedAt: "2026-06-12T00:00:00Z",
+      leases: [],
+    })}\n`,
+    "utf8",
+  );
+
+  assert.equal(readProviderLeaseDocument(root, provider, 2).capacity, 2);
+});
+
+test("provider lease acquisition fails when push is rejected", () => {
+  const origin = seedStateOrigin();
+  const checkout = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-provider-lease-checkout-"));
+
+  const hook = path.join(origin, "hooks", "pre-receive");
+  fs.writeFileSync(hook, "#!/bin/sh\nexit 1\n", "utf8");
+  fs.chmodSync(hook, 0o755);
+
+  git(["clone", "--branch", "state", origin, checkout]);
+
+  assert.throws(
+    () =>
+      acquireProviderLease({
+        stateDir: checkout,
+        provider: "codex-internal-default",
+        leaseId: "rejected-push",
+        owner: "openclaw/clawsweeper",
+        lane: "exact-review",
+        item: "openclaw/openclaw#3",
+        runId: "3",
+        capacity: 1,
+        weight: 1,
+        ttlMs: 900_000,
+        waitMs: 0,
+        pollMs: 1,
+      }),
+    /shared state push failed/,
+  );
+});
+
+test("provider lease shared state gates timeout release and ttl recovery", async () => {
+  const origin = seedStateOrigin();
+  const first = cloneStateOrigin(origin);
+  const second = cloneStateOrigin(origin);
+  const provider = "codex-internal-default";
+
+  const acquired = acquireProviderLease({
+    stateDir: first,
+    provider,
+    leaseId: "capacity-holder",
+    owner: "openclaw/clawsweeper",
+    lane: "exact-review",
+    item: "openclaw/clawsweeper#281",
+    runId: "capacity-holder",
+    capacity: 1,
+    weight: 1,
+    ttlMs: 60_000,
+    waitMs: 0,
+    pollMs: 1,
+  });
+
+  assert.equal(acquired.acquired, true);
+  assert.equal(acquired.activeWeight, 1);
+
+  const blocked = acquireProviderLease({
+    stateDir: second,
+    provider,
+    leaseId: "capacity-waiter",
+    owner: "openclaw/clawsweeper",
+    lane: "exact-review",
+    item: "openclaw/clawsweeper#282",
+    runId: "capacity-waiter",
+    capacity: 1,
+    weight: 1,
+    ttlMs: 60_000,
+    waitMs: 0,
+    pollMs: 1,
+  });
+
+  assert.equal(blocked.acquired, false);
+  assert.equal(blocked.activeWeight, 1);
+  assert.match(blocked.reason ?? "", /provider capacity full/);
+
+  assert.equal(
+    releaseProviderLease({
+      stateDir: first,
+      provider,
+      leaseId: "capacity-holder",
+      capacity: 1,
+    }),
+    true,
+  );
+
+  const afterRelease = acquireProviderLease({
+    stateDir: second,
+    provider,
+    leaseId: "capacity-after-release",
+    owner: "openclaw/clawsweeper",
+    lane: "exact-review",
+    item: "openclaw/clawsweeper#283",
+    runId: "capacity-after-release",
+    capacity: 1,
+    weight: 1,
+    ttlMs: 60_000,
+    waitMs: 0,
+    pollMs: 1,
+  });
+
+  assert.equal(afterRelease.acquired, true);
+
+  const ttlHolder = cloneStateOrigin(origin);
+  const ttlWaiter = cloneStateOrigin(origin);
+  assert.equal(
+    releaseProviderLease({
+      stateDir: second,
+      provider,
+      leaseId: "capacity-after-release",
+      capacity: 1,
+    }),
+    true,
+  );
+
+  const stale = acquireProviderLease({
+    stateDir: ttlHolder,
+    provider,
+    leaseId: "ttl-holder",
+    owner: "openclaw/clawsweeper",
+    lane: "exact-review",
+    item: "openclaw/clawsweeper#284",
+    runId: "ttl-holder",
+    capacity: 1,
+    weight: 1,
+    ttlMs: 20,
+    waitMs: 0,
+    pollMs: 1,
+  });
+
+  assert.equal(stale.acquired, true);
+  await new Promise((resolve) => setTimeout(resolve, 80));
+
+  const recovered = acquireProviderLease({
+    stateDir: ttlWaiter,
+    provider,
+    leaseId: "ttl-recovered",
+    owner: "openclaw/clawsweeper",
+    lane: "exact-review",
+    item: "openclaw/clawsweeper#285",
+    runId: "ttl-recovered",
+    capacity: 1,
+    weight: 1,
+    ttlMs: 60_000,
+    waitMs: 0,
+    pollMs: 1,
+  });
+
+  assert.equal(recovered.acquired, true);
+  assert.deepEqual(
+    readProviderLeaseDocument(ttlWaiter, provider, 1).leases.map((entry) => entry.id),
+    ["ttl-recovered"],
+  );
+});
+
+test("provider lease renewal keeps a running holder past its original ttl", async () => {
+  const origin = seedStateOrigin();
+  const holder = cloneStateOrigin(origin);
+  const waiter = cloneStateOrigin(origin);
+  const provider = "codex-internal-default";
+
+  const acquired = acquireProviderLease({
+    stateDir: holder,
+    provider,
+    leaseId: "renewed-holder",
+    owner: "openclaw/clawsweeper",
+    lane: "exact-review",
+    item: "openclaw/clawsweeper#281",
+    runId: "renewed-holder",
+    capacity: 1,
+    weight: 1,
+    ttlMs: 800,
+    waitMs: 0,
+    pollMs: 1,
+  });
+
+  assert.equal(acquired.acquired, true);
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  assert.equal(
+    renewProviderLease({
+      stateDir: holder,
+      provider,
+      leaseId: "renewed-holder",
+      capacity: 1,
+      ttlMs: 1200,
+    }),
+    true,
+  );
+
+  await new Promise((resolve) => setTimeout(resolve, 850));
+  const blocked = acquireProviderLease({
+    stateDir: waiter,
+    provider,
+    leaseId: "blocked-by-renewal",
+    owner: "openclaw/clawsweeper",
+    lane: "exact-review",
+    item: "openclaw/clawsweeper#282",
+    runId: "blocked-by-renewal",
+    capacity: 1,
+    weight: 1,
+    ttlMs: 60_000,
+    waitMs: 0,
+    pollMs: 1,
+  });
+
+  assert.equal(blocked.acquired, false);
+  assert.match(blocked.reason ?? "", /provider capacity full/);
+
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  const recovered = acquireProviderLease({
+    stateDir: waiter,
+    provider,
+    leaseId: "after-renewal-stops",
+    owner: "openclaw/clawsweeper",
+    lane: "exact-review",
+    item: "openclaw/clawsweeper#283",
+    runId: "after-renewal-stops",
+    capacity: 1,
+    weight: 1,
+    ttlMs: 60_000,
+    waitMs: 0,
+    pollMs: 1,
+  });
+
+  assert.equal(recovered.acquired, true);
+  assert.deepEqual(
+    readProviderLeaseDocument(waiter, provider, 1).leases.map((entry) => entry.id),
+    ["after-renewal-stops"],
+  );
+});
+
+function lease(id: string, weight: number, expiresAt: string) {
+  return {
+    id,
+    owner: "openclaw/clawsweeper",
+    lane: "exact-review",
+    item: "openclaw/openclaw#1",
+    runId: id,
+    weight,
+    acquiredAt: "2026-06-12T00:00:00Z",
+    expiresAt,
+  };
+}
+
+function seedStateOrigin(): string {
+  const origin = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-provider-lease-origin-"));
+  const seed = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-provider-lease-seed-"));
+
+  git(["init", "--bare", origin]);
+  git(["init"], seed);
+  git(["config", "user.name", "ClawSweeper Test"], seed);
+  git(["config", "user.email", "clawsweeper-test@example.invalid"], seed);
+  fs.writeFileSync(path.join(seed, "README.md"), "state\n", "utf8");
+  git(["add", "README.md"], seed);
+  git(["commit", "-m", "seed state"], seed);
+  git(["checkout", "-B", "state"], seed);
+  git(["remote", "add", "origin", origin], seed);
+  git(["push", "origin", "state"], seed);
+
+  return origin;
+}
+
+function cloneStateOrigin(origin: string): string {
+  const checkout = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-provider-lease-checkout-"));
+  git(["clone", "--branch", "state", origin, checkout]);
+  return checkout;
+}
+
+function git(args: string[], cwd?: string) {
+  const child = spawnSync("git", args, { cwd, encoding: "utf8" });
+  assert.equal(
+    child.status,
+    0,
+    `git ${args.join(" ")} failed\nstdout:\n${child.stdout}\nstderr:\n${child.stderr}`,
+  );
+}


### PR DESCRIPTION
## Why
ClawSweeper exact reviews can run from many GitHub workflow instances at once. Worker sizing only controls local/shard concurrency; it does not protect the shared Codex provider/API-key capacity across independent runs. The important behavior change in this PR is to move overload handling from "start Codex, hit provider capacity, then retry/fail" to "reserve a global provider slot before starting Codex."

That gives us a controlled queue/backpressure point inside ClawSweeper: while global provider capacity is full, an exact review waits for a lease and reports `Waiting for Codex capacity` instead of stampeding the provider and amplifying transient transport/capacity failures. If capacity remains full until the configured wait deadline, the workflow now writes a terminal `Capacity timeout` command status instead of leaving the command looking like it is still waiting. If the provider-lease state update itself fails, the run fails explicitly rather than pretending capacity is merely full.

The lease is renewed while the exact review is running. Review runtime is not bounded by the original lease TTL in practice. A long-running review keeps its slot; if renewal stops or the lease disappears, the review step fails closed instead of continuing after its slot has expired.

## Summary
- add a state-repo-backed Codex provider lease tool with weighted capacity, TTL pruning, and acquire/release/renew commands
- gate exact event reviews on a global provider lease before invoking Codex, renew while Codex is running, then release before publishing state
- fail the review step if lease renewal stops before the review completes, avoiding silent overbooking after TTL expiry
- make current workflow capacity configuration authoritative over persisted lease state so emergency capacity changes take effect
- distinguish provider capacity waits, terminal capacity timeouts, and provider-lease state update failures in command status
- add a real GitHub Actions live proof mode that exercises the provider lease gate without calling Codex

## Testing
- `pnpm run build:repair`
- `node --test test/repair/provider-lease.test.ts`
- `node --test --test-name-pattern "provider lease|exact event reviews|live proof mode" test/clawsweeper.test.ts`
- `pnpm run check` on Node v24.15.0
- earlier on this branch: `pnpm run format:check`, `node --test --test-name-pattern "event re-review status|provider capacity|provider lease" test/clawsweeper.test.ts`, and `autoreview --mode local` clean after fixes

Observed local results on head `64760bcb6afa74b427c716f9aecb7eab87df73ea`:
- focused workflow/provider test passed: 3 tests, 3 pass.
- full `pnpm run check` passed: 454 unit tests, 504 repair tests, coverage checks, and format check.

## Code locations
Head: `64760bcb6afa74b427c716f9aecb7eab87df73ea`

- lease renewal document logic: [`src/repair/provider-lease.ts#L205-L225`](https://github.com/openclaw/clawsweeper/blob/64760bcb6afa74b427c716f9aecb7eab87df73ea/src/repair/provider-lease.ts#L205-L225)
- acquisition false-success guard when shared-state push fails: [`src/repair/provider-lease.ts#L237-L265`](https://github.com/openclaw/clawsweeper/blob/64760bcb6afa74b427c716f9aecb7eab87df73ea/src/repair/provider-lease.ts#L237-L265)
- shared-state renew command and CLI failure path: [`src/repair/provider-lease.ts#L282-L323`](https://github.com/openclaw/clawsweeper/blob/64760bcb6afa74b427c716f9aecb7eab87df73ea/src/repair/provider-lease.ts#L282-L323)
- exact-review renewal loop and fail-closed monitor: [`.github/workflows/sweep.yml#L424-L507`](https://github.com/openclaw/clawsweeper/blob/64760bcb6afa74b427c716f9aecb7eab87df73ea/.github/workflows/sweep.yml#L424-L507)
- exact-review release before publish: [`.github/workflows/sweep.yml#L509-L519`](https://github.com/openclaw/clawsweeper/blob/64760bcb6afa74b427c716f9aecb7eab87df73ea/.github/workflows/sweep.yml#L509-L519)
- real Actions proof jobs: [`.github/workflows/sweep.yml#L1949-L2335`](https://github.com/openclaw/clawsweeper/blob/64760bcb6afa74b427c716f9aecb7eab87df73ea/.github/workflows/sweep.yml#L1949-L2335)
- pure renewal unit test: [`test/repair/provider-lease.test.ts#L110-L142`](https://github.com/openclaw/clawsweeper/blob/64760bcb6afa74b427c716f9aecb7eab87df73ea/test/repair/provider-lease.test.ts#L110-L142)
- rejected push regression: [`test/repair/provider-lease.test.ts#L181-L209`](https://github.com/openclaw/clawsweeper/blob/64760bcb6afa74b427c716f9aecb7eab87df73ea/test/repair/provider-lease.test.ts#L181-L209)
- shared-state capacity, release, TTL recovery proof: [`test/repair/provider-lease.test.ts#L211-L331`](https://github.com/openclaw/clawsweeper/blob/64760bcb6afa74b427c716f9aecb7eab87df73ea/test/repair/provider-lease.test.ts#L211-L331)
- shared-state renewal proof: [`test/repair/provider-lease.test.ts#L333-L408`](https://github.com/openclaw/clawsweeper/blob/64760bcb6afa74b427c716f9aecb7eab87df73ea/test/repair/provider-lease.test.ts#L333-L408)
- temp bare state repo and independent checkout helpers: [`test/repair/provider-lease.test.ts#L423-L445`](https://github.com/openclaw/clawsweeper/blob/64760bcb6afa74b427c716f9aecb7eab87df73ea/test/repair/provider-lease.test.ts#L423-L445)
- workflow-shape assertions for renew/fail-closed/live-proof wiring: [`test/clawsweeper.test.ts#L17789-L17797`](https://github.com/openclaw/clawsweeper/blob/64760bcb6afa74b427c716f9aecb7eab87df73ea/test/clawsweeper.test.ts#L17789-L17797), [`test/clawsweeper.test.ts#L18491-L18498`](https://github.com/openclaw/clawsweeper/blob/64760bcb6afa74b427c716f9aecb7eab87df73ea/test/clawsweeper.test.ts#L18491-L18498), [`test/clawsweeper.test.ts#L18501-L18534`](https://github.com/openclaw/clawsweeper/blob/64760bcb6afa74b427c716f9aecb7eab87df73ea/test/clawsweeper.test.ts#L18501-L18534)

## Automated proof
The local provider-lease proof is CI-safe and deterministic. It uses a temporary local bare git repository as the shared state remote, then clones it into multiple independent checkouts to model multiple workflow runners racing on the same `state` branch.

What the shared-state proof executes:
- creates a temporary bare git origin and seeds its `state` branch
- clones that origin into separate working copies to simulate independent workflow runners
- acquires `capacity=1` from the first checkout and verifies `acquired=true` with `activeWeight=1`
- attempts a second acquisition from another checkout and verifies `acquired=false`, `activeWeight=1`, and a `provider capacity full` reason
- releases the first lease and verifies a later acquisition can succeed
- creates an unreleased short-TTL lease, waits past TTL, then verifies the next acquisition succeeds and prunes the stale lease
- renews a running holder before its original TTL expires, waits past the original TTL, and verifies another checkout is still blocked by `provider capacity full`
- waits past the renewed TTL after renewal stops, then verifies another checkout can acquire and the stale renewed holder is pruned
- installs a rejecting `pre-receive` hook on the bare origin and verifies a failed shared-state push throws `shared state push failed` instead of returning a false successful acquisition

## Live Actions proof
Run: https://github.com/openclaw/clawsweeper/actions/runs/27425442802

How it was triggered:

```bash
gh workflow run sweep.yml \
  --repo openclaw/clawsweeper \
  --ref codex/provider-lease-throttle \
  -f target_repo=openclaw/clawsweeper \
  -f additional_prompt='[provider-lease-live-proof]'
```

The marker `[provider-lease-live-proof]` skips normal review/planning/publish/shard jobs and runs only the proof jobs. This proof uses real GitHub Actions runners and the real `openclaw/clawsweeper-state` repository, but an isolated provider namespace `codex-live-proof-27425442802`; it does not invoke Codex.

Observed workflow metadata:
- event: `workflow_dispatch`
- head SHA: `64760bcb6afa74b427c716f9aecb7eab87df73ea`
- conclusion: `success`
- skipped Codex/review jobs: `Plan review candidates`, `Review shard ${{ matrix.shard }}`, `Review, comment, and apply event item`, `Publish review artifacts`, `Recover failed review shards`, `Apply close proposals`, `Audit state`

Observed real concurrency:
- `Provider lease live proof concurrent waiter` started at `2026-06-12T15:27:05Z`
- `Provider lease live proof holder` started at `2026-06-12T15:27:06Z`
- both jobs used the same real state repo provider file: `provider-leases/codex-live-proof-27425442802.json`

Observed holder/acquire/renew/release behavior:
- holder acquired `proof-holder-27425442802-1` at `2026-06-12T15:27:41Z` with JSON `acquired: true`, `activeWeight: 1`, `capacity: 1`
- holder renewed successfully four times at `15:27:52Z`, `15:28:04Z`, `15:28:16Z`, and `15:28:28Z`, each returning JSON `renewed: true`
- holder stayed active for more than the original 30s TTL and then released at `15:28:29Z` with JSON `released: true`

Observed concurrent capacity timeout:
- waiter saw the holder lease in the real state repo at `2026-06-12T15:27:42Z`
- waiter then attempted to acquire with `capacity=1`, `weight=1`, `wait-seconds=20`
- waiter completed at `2026-06-12T15:28:09Z` with JSON `acquired: false`, `activeWeight: 1`, `capacity: 1`, and reason `provider capacity full: active weight 1/1, requested 1`

Observed release recovery:
- after holder release, `Provider lease live proof release check` acquired `proof-release-check-27425442802-1` at `2026-06-12T15:29:08Z` with JSON `acquired: true`, `activeWeight: 1`, `capacity: 1`
- it released that follow-up lease at `15:29:10Z` with JSON `released: true`

Observed cancellation/TTL recovery:
- TTL job acquired abandoned lease `proof-abandoned-27425442802-1` at `2026-06-12T15:29:53Z` with `ttl-seconds=15`, JSON `acquired: true`, `activeWeight: 1`, `capacity: 1`
- the job intentionally did not release it, then waited 20s to simulate cancellation recovery
- recovered acquire `proof-recovered-27425442802-1` succeeded at `2026-06-12T15:30:15Z` with JSON `acquired: true`, `activeWeight: 1`, `capacity: 1`
- recovered lease released at `15:30:17Z` with JSON `released: true`
- isolated proof provider state was cleaned up at `15:30:19Z`

What this proof does not claim:
- it does not call the real Codex provider/API key; it proves ClawSweeper queues before invoking Codex when the configured shared lease capacity is full
- it does not prove the provider can never return 429; it reduces stampedes by adding a shared pre-Codex capacity gate
- if a workflow is cancelled after acquisition, recovery still depends on TTL expiry; the live proof demonstrates that TTL recovery works in the real Actions/state-repo path for the configured proof TTL
