### PR TITLE
Recover transport-exhausted re-reviews with a bounded lower-effort fallback (#282)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ checkpoint, and status-only commits are intentionally omitted.
 - Compacted completed ClawSweeper-generated replacement branches to one reviewed commit before publication, removing transient checkpoint and review-repair noise while preserving contributor branch history.
 - Skip optional ClawSweeper label additions when an issue or pull request already has GitHub's 100-label maximum, so one saturated item cannot abort a comment-sync batch.
 - Served stale dashboard status immediately while coalescing a background refresh, bounded job-detail fanout, and cached and parallelized historical GitHub lookups to reduce cold-load latency, diagnostic timeouts, and API usage.
+- Recover transport-exhausted reviews with one bounded lower-effort fallback while preserving the original failure classification when recovery also fails. Thanks @yetval. (#283)
 - Preserved records written by concurrent workers during generated-state publish races while retaining deliberate item-to-closed moves and plan cleanup.
 - Raised and unified Codex review timeouts at 20 minutes, including exact event reviews, so high-context reviews do not fall back at the previous 10-minute ceiling.
 - Deferred workflow utility CLI execution until module initialization completes, preventing apply preselection from crashing on close-action constants.

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -1040,6 +1040,7 @@ const DEFAULT_CODEX_MODEL = PUBLIC_CODEX_MODEL;
 const DEFAULT_REASONING_EFFORT = "high";
 const DEFAULT_SERVICE_TIER = "";
 const DEFAULT_REVIEW_CODEX_TIMEOUT_MS = 1_200_000;
+const DEFAULT_CODEX_FALLBACK_MIN_BUDGET_MS = 120_000;
 const REVIEW_POLICY_VERSION = "2026-05-30-policy-v19";
 const REVIEW_ITEM_PROMPT_PATH = join(ROOT, "prompts", "review-item.md");
 const CLAWSWEEPER_DECISION_SCHEMA_PATH = join(ROOT, "schema", "clawsweeper-decision.schema.json");
@@ -6423,6 +6424,61 @@ function codexFailureReason(detail: string, errorCode?: string | null): string {
   return "codex execution failed";
 }
 
+function codexFallbackMinBudgetMs(): number {
+  const configured = Number(process.env.CLAWSWEEPER_CODEX_FALLBACK_MIN_BUDGET_MS?.trim());
+  return Number.isFinite(configured) && configured > 0
+    ? configured
+    : DEFAULT_CODEX_FALLBACK_MIN_BUDGET_MS;
+}
+
+export function lowerCodexReasoningEffort(effort: string): string | null {
+  switch (effort.trim().toLowerCase()) {
+    case "high":
+    case "medium":
+      return "low";
+    case "low":
+      return "minimal";
+    default:
+      return null;
+  }
+}
+
+function annotateDegradedReview(
+  decision: Decision,
+  options: { item: Item; fromEffort: string; toEffort: string; transportError: CodexReviewError },
+): Decision {
+  const reason = codexFailureReason(
+    `${options.transportError.message}\n${options.transportError.stderr}\n${options.transportError.stdout}`,
+  );
+  const disclosure =
+    `Degraded review: Codex hit a ${reason} at ${options.fromEffort} reasoning effort, so ClawSweeper ` +
+    `completed this review with a single lower-effort (${options.toEffort}) fallback pass. ` +
+    `Treat the verdict as best-effort and re-run for a full-fidelity review once transport recovers.`;
+  const transportDetail =
+    trimMiddle(
+      redactInternalCodexModel(
+        `${options.transportError.message}\n${options.transportError.stderr}`.trim(),
+      ),
+      2000,
+    ) || "No transport detail captured.";
+  return {
+    ...decision,
+    confidence: decision.confidence === "high" ? "medium" : decision.confidence,
+    summary: `${disclosure}\n\n${decision.summary}`,
+    evidence: [
+      evidenceEntry({
+        label: "degraded review mode",
+        detail: `${options.fromEffort} → ${options.toEffort} reasoning effort fallback after ${reason}.`,
+      }),
+      evidenceEntry({
+        label: "original codex transport failure",
+        detail: transportDetail,
+      }),
+      ...decision.evidence,
+    ],
+  };
+}
+
 function codexFailureDecision(
   status: number | null,
   detail: string,
@@ -6593,6 +6649,7 @@ class CodexReviewError extends Error {
   readonly stderr: string;
   readonly errorCode: string | null;
   readonly signal: NodeJS.Signals | null;
+  readonly retryable: boolean;
 
   constructor(options: {
     message: string;
@@ -6601,6 +6658,7 @@ class CodexReviewError extends Error {
     stderr?: string;
     errorCode?: string | null;
     signal?: NodeJS.Signals | null;
+    retryable?: boolean;
   }) {
     super(options.message);
     this.name = "CodexReviewError";
@@ -6609,6 +6667,7 @@ class CodexReviewError extends Error {
     this.stderr = options.stderr ?? "";
     this.errorCode = options.errorCode ?? null;
     this.signal = options.signal ?? null;
+    this.retryable = options.retryable ?? false;
   }
 }
 
@@ -6704,129 +6763,170 @@ function runCodex(options: {
       `OpenClaw checkout is dirty before reviewing #${options.item.number}:\n${dirtyBefore}`,
     );
   }
-  const codexConfig = [
-    `model_reasoning_effort="${options.reasoningEffort}"`,
-    'forced_login_method="api"',
-    'approval_policy="never"',
-  ];
-  if (options.serviceTier) codexConfig.splice(1, 0, `service_tier="${options.serviceTier}"`);
   const configuredAttempts = Number(process.env.CLAWSWEEPER_CODEX_REVIEW_ATTEMPTS ?? 3);
   const maxAttempts = Math.min(
     5,
     Math.max(1, Number.isFinite(configuredAttempts) ? Math.floor(configuredAttempts) : 3),
   );
   const startedAt = Date.now();
-  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-    if (existsSync(outputPath)) unlinkSync(outputPath);
-    const remainingMs = options.timeoutMs - (Date.now() - startedAt);
-    if (remainingMs <= 0) {
-      throw new Error(
-        `Codex review timed out for #${options.item.number} after ${options.timeoutMs}ms.`,
-      );
-    }
-    const result = runCodexProcess({
-      args: [
-        "exec",
-        ...codexModelArgs(options.model),
-        ...codexConfig.flatMap((config) => ["-c", config]),
-        "-C",
-        options.openclawDir,
-        "--output-schema",
-        CLAWSWEEPER_DECISION_SCHEMA_PATH,
-        "--output-last-message",
-        outputPath,
-        "--json",
-        "--sandbox",
-        options.sandboxMode,
-        "--add-dir",
-        proofScratchDir,
-        "-",
-      ],
-      cwd: options.openclawDir,
-      env: {
-        ...codexEnv({ ghToken: process.env.CLAWSWEEPER_PROOF_INSPECTION_TOKEN }),
-        CLAWSWEEPER_PROOF_SCRATCH_DIR: proofScratchDir,
-      },
-      input: prompt,
-      stderrPath: join(options.workDir, `${options.item.number}.${attempt}.codex.stderr.log`),
-      stdoutPath: join(options.workDir, `${options.item.number}.${attempt}.codex.stdout.log`),
-      timeoutMs: remainingMs,
-    });
-    const dirtyAfter = openclawDirtyStatus(options.openclawDir);
-    if (dirtyAfter) {
-      throw new Error(
-        `Codex dirtied the OpenClaw checkout while reviewing #${options.item.number}:\n${dirtyAfter}`,
-      );
-    }
-    const stderr = redactedOutputTail(result.stderr);
-    const stdout = redactedOutputTail(result.stdout);
-    const errorCode = codexProcessErrorCode(result.error);
-    let failureDetail = "";
-    if (result.error) {
-      failureDetail = `Codex review failed for #${options.item.number}: ${redactInternalCodexModel(result.error.message)}`;
-    }
-    const hasOutput = existsSync(outputPath);
-    if (!result.error && hasOutput) {
-      try {
-        const decision = parseDecision(
-          JSON.parse(readFileSync(outputPath, "utf8").trim()),
-          options.item,
+  const runReviewPass = (reasoningEffort: string, passAttempts: number): Decision => {
+    const codexConfig = [
+      `model_reasoning_effort="${reasoningEffort}"`,
+      'forced_login_method="api"',
+      'approval_policy="never"',
+    ];
+    if (options.serviceTier) codexConfig.splice(1, 0, `service_tier="${options.serviceTier}"`);
+    for (let attempt = 1; attempt <= passAttempts; attempt += 1) {
+      if (existsSync(outputPath)) unlinkSync(outputPath);
+      const remainingMs = options.timeoutMs - (Date.now() - startedAt);
+      if (remainingMs <= 0) {
+        throw new CodexReviewError({
+          message: `Codex review timed out for #${options.item.number} after ${options.timeoutMs}ms.`,
+          status: null,
+          retryable: false,
+        });
+      }
+      const result = runCodexProcess({
+        args: [
+          "exec",
+          ...codexModelArgs(options.model),
+          ...codexConfig.flatMap((config) => ["-c", config]),
+          "-C",
+          options.openclawDir,
+          "--output-schema",
+          CLAWSWEEPER_DECISION_SCHEMA_PATH,
+          "--output-last-message",
+          outputPath,
+          "--json",
+          "--sandbox",
+          options.sandboxMode,
+          "--add-dir",
+          proofScratchDir,
+          "-",
+        ],
+        cwd: options.openclawDir,
+        env: {
+          ...codexEnv({ ghToken: process.env.CLAWSWEEPER_PROOF_INSPECTION_TOKEN }),
+          CLAWSWEEPER_PROOF_SCRATCH_DIR: proofScratchDir,
+        },
+        input: prompt,
+        stderrPath: join(options.workDir, `${options.item.number}.${attempt}.codex.stderr.log`),
+        stdoutPath: join(options.workDir, `${options.item.number}.${attempt}.codex.stdout.log`),
+        timeoutMs: remainingMs,
+      });
+      const dirtyAfter = openclawDirtyStatus(options.openclawDir);
+      if (dirtyAfter) {
+        throw new Error(
+          `Codex dirtied the OpenClaw checkout while reviewing #${options.item.number}:\n${dirtyAfter}`,
         );
-        if (result.status !== 0) {
-          console.error(
-            `[review] ${new Date().toISOString()} codex-exit-nonzero-output-accepted #${
-              options.item.number
-            } status=${result.status ?? "unknown"} stderr=${JSON.stringify(stderr)}`,
+      }
+      const stderr = redactedOutputTail(result.stderr);
+      const stdout = redactedOutputTail(result.stdout);
+      const errorCode = codexProcessErrorCode(result.error);
+      let failureDetail = "";
+      if (result.error) {
+        failureDetail = `Codex review failed for #${options.item.number}: ${redactInternalCodexModel(result.error.message)}`;
+      }
+      const hasOutput = existsSync(outputPath);
+      if (!result.error && hasOutput) {
+        try {
+          const decision = parseDecision(
+            JSON.parse(readFileSync(outputPath, "utf8").trim()),
+            options.item,
           );
+          if (result.status !== 0) {
+            console.error(
+              `[review] ${new Date().toISOString()} codex-exit-nonzero-output-accepted #${
+                options.item.number
+              } status=${result.status ?? "unknown"} stderr=${JSON.stringify(stderr)}`,
+            );
+          }
+          return decision;
+        } catch (error) {
+          failureDetail = `Codex review failed for #${options.item.number} with exit ${
+            result.status ?? "unknown"
+          } and wrote invalid JSON or schema-invalid output to ${outputPath}: ${
+            error instanceof Error ? error.message : String(error)
+          }.`;
         }
-        return decision;
-      } catch (error) {
-        failureDetail = `Codex review failed for #${options.item.number} with exit ${
-          result.status ?? "unknown"
-        } and wrote invalid JSON or schema-invalid output to ${outputPath}: ${
-          error instanceof Error ? error.message : String(error)
-        }.`;
+      } else if (!result.error) {
+        failureDetail =
+          result.status === 0
+            ? `Codex review did not produce output for #${options.item.number}: Codex exited successfully but did not write ${outputPath}.\n${stdout || "No stdout."}`
+            : `Codex review failed for #${options.item.number} with exit ${result.status ?? "unknown"}.`;
       }
-    } else if (!result.error) {
-      failureDetail =
-        result.status === 0
-          ? `Codex review did not produce output for #${options.item.number}: Codex exited successfully but did not write ${outputPath}.`
-          : `Codex review failed for #${options.item.number} with exit ${result.status ?? "unknown"}.`;
-    }
-    const structuredError = redactInternalCodexModel(codexJsonlFailureDetail(result.stdout));
-    const trustedProcessError = structuredError || stderr;
-    const processFailureDetail = [failureDetail, trustedProcessError].filter(Boolean).join("\n");
-    const terminalFailure = isTerminalCodexErrorMessage(processFailureDetail);
-    const retryable =
-      !terminalFailure &&
-      (result.signal !== null ||
-        (result.status === 0 && !hasOutput) ||
-        isRetryableCodexErrorMessage(processFailureDetail) ||
-        /\b(?:ETIMEDOUT|ECONNRESET|EAI_AGAIN|ENOTFOUND|socket hang up|fetch failed|transport failure)\b/i.test(
-          processFailureDetail,
-        ));
-    if (retryable && attempt < maxAttempts) {
-      const delayMs = codexRetryDelayMs(processFailureDetail, attempt);
-      if (Date.now() - startedAt + delayMs < options.timeoutMs) {
-        console.error(
-          `[review] ${new Date().toISOString()} codex-retry #${options.item.number} attempt=${
-            attempt + 1
-          }/${maxAttempts} delay_ms=${delayMs} reason=transient_transport`,
-        );
-        sleepMs(delayMs);
-        continue;
+      const structuredError = redactInternalCodexModel(codexJsonlFailureDetail(result.stdout));
+      const trustedProcessError = structuredError || stderr;
+      const processFailureDetail = [failureDetail, trustedProcessError].filter(Boolean).join("\n");
+      const terminalFailure = isTerminalCodexErrorMessage(processFailureDetail);
+      const retryable =
+        !terminalFailure &&
+        (result.signal !== null ||
+          (result.status === 0 && !hasOutput) ||
+          isRetryableCodexErrorMessage(processFailureDetail) ||
+          /\b(?:ETIMEDOUT|ECONNRESET|EAI_AGAIN|ENOTFOUND|socket hang up|fetch failed|transport failure)\b/i.test(
+            processFailureDetail,
+          ));
+      if (retryable && attempt < passAttempts) {
+        const delayMs = codexRetryDelayMs(processFailureDetail, attempt);
+        if (Date.now() - startedAt + delayMs < options.timeoutMs) {
+          console.error(
+            `[review] ${new Date().toISOString()} codex-retry #${options.item.number} attempt=${
+              attempt + 1
+            }/${passAttempts} delay_ms=${delayMs} reason=transient_transport`,
+          );
+          sleepMs(delayMs);
+          continue;
+        }
       }
+      throw new CodexReviewError({
+        message: processFailureDetail || `Codex review failed for #${options.item.number}.`,
+        status: result.status,
+        stdout,
+        stderr,
+        errorCode,
+        signal: result.signal,
+        retryable,
+      });
     }
     throw new CodexReviewError({
-      message: failureDetail,
-      status: result.status,
-      stdout,
-      stderr,
-      errorCode,
-      signal: result.signal,
+      message: `Codex review failed for #${options.item.number}.`,
+      status: null,
+      retryable: false,
     });
+  };
+
+  try {
+    return runReviewPass(options.reasoningEffort, maxAttempts);
+  } catch (error) {
+    if (!(error instanceof CodexReviewError) || !error.retryable) throw error;
+    const fallbackEffort = lowerCodexReasoningEffort(options.reasoningEffort);
+    const remainingMs = options.timeoutMs - (Date.now() - startedAt);
+    if (fallbackEffort === null || remainingMs < codexFallbackMinBudgetMs()) throw error;
+    console.error(
+      `[review] ${new Date().toISOString()} codex-fallback #${options.item.number} reason=transient_transport from_effort=${options.reasoningEffort} to_effort=${fallbackEffort} remaining_ms=${remainingMs}`,
+    );
+    try {
+      const decision = runReviewPass(fallbackEffort, 1);
+      return annotateDegradedReview(decision, {
+        item: options.item,
+        fromEffort: options.reasoningEffort,
+        toEffort: fallbackEffort,
+        transportError: error,
+      });
+    } catch (fallbackError) {
+      if (!(fallbackError instanceof CodexReviewError)) throw fallbackError;
+      throw new CodexReviewError({
+        message: `${error.message}\nLower-effort (${fallbackEffort}) fallback also failed: ${fallbackError.message}`,
+        status: fallbackError.status ?? error.status,
+        stdout: fallbackError.stdout || error.stdout,
+        stderr: error.stderr || fallbackError.stderr,
+        errorCode: error.errorCode ?? fallbackError.errorCode,
+        signal: error.signal ?? fallbackError.signal,
+        retryable: error.retryable,
+      });
+    }
   }
-  throw new Error(`Codex review failed for #${options.item.number}.`);
 }
 
 function stripTextFence(markdown: string): string {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -102,6 +102,7 @@ import {
   reviewPromptTelemetryForTest,
   reviewPromptTemplate,
   runCodexForTest,
+  lowerCodexReasoningEffort,
   impactLabelsForTest,
   impactLabelSchemeForTest,
   runtimeBudgetExceeded,
@@ -15051,6 +15052,234 @@ fs.writeFileSync(process.argv[outputIndex + 1], process.env.CODEX_DECISION_JSON)
 
     assert.equal(readFileSync(attemptsPath, "utf8"), "2");
     assert.equal(decision.summary, "Review completed after a fresh Codex process.");
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("lowerCodexReasoningEffort steps down one tier and stops at minimal", () => {
+  assert.equal(lowerCodexReasoningEffort("high"), "low");
+  assert.equal(lowerCodexReasoningEffort("HIGH"), "low");
+  assert.equal(lowerCodexReasoningEffort(" medium "), "low");
+  assert.equal(lowerCodexReasoningEffort("low"), "minimal");
+  assert.equal(lowerCodexReasoningEffort("minimal"), null);
+  assert.equal(lowerCodexReasoningEffort("unknown"), null);
+});
+
+test("runCodex completes via a lower-effort fallback after transport exhaustion", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const openclawDir = join(root, "openclaw");
+  const workDir = join(root, "codex-work");
+  const binDir = join(root, "bin");
+  const attemptsPath = join(root, "attempts");
+  mkdirSync(openclawDir, { recursive: true });
+  mkdirSync(binDir, { recursive: true });
+  execFileSync("git", ["init"], { cwd: openclawDir, stdio: "ignore" });
+  const codexPath = join(binDir, "codex");
+  writeFileSync(
+    codexPath,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const cfg = process.argv.find((a) => a.startsWith("model_reasoning_effort="));
+const effort = cfg ? cfg.split("=")[1].replace(/"/g, "") : "";
+const attemptsPath = process.env.CODEX_ATTEMPTS_PATH;
+const n = fs.existsSync(attemptsPath) ? Number(fs.readFileSync(attemptsPath, "utf8")) + 1 : 1;
+fs.writeFileSync(attemptsPath, String(n));
+if (effort !== "low") {
+  process.stderr.write("Rate limit reached on tokens per min (TPM). Please try again in 1ms.\\n");
+  process.exit(1);
+}
+const outputIndex = process.argv.indexOf("--output-last-message");
+fs.writeFileSync(process.argv[outputIndex + 1], process.env.CODEX_DECISION_JSON);
+`,
+  );
+  chmodSync(codexPath, 0o755);
+  const previous = {
+    PATH: process.env.PATH,
+    CODEX_ATTEMPTS_PATH: process.env.CODEX_ATTEMPTS_PATH,
+    CODEX_DECISION_JSON: process.env.CODEX_DECISION_JSON,
+    CLAWSWEEPER_CODEX_REVIEW_ATTEMPTS: process.env.CLAWSWEEPER_CODEX_REVIEW_ATTEMPTS,
+    CLAWSWEEPER_CODEX_REVIEW_RETRY_DELAY_MS: process.env.CLAWSWEEPER_CODEX_REVIEW_RETRY_DELAY_MS,
+    CLAWSWEEPER_CODEX_FALLBACK_MIN_BUDGET_MS: process.env.CLAWSWEEPER_CODEX_FALLBACK_MIN_BUDGET_MS,
+  };
+  process.env.PATH = `${binDir}${delimiter}${process.env.PATH ?? ""}`;
+  process.env.CODEX_ATTEMPTS_PATH = attemptsPath;
+  process.env.CODEX_DECISION_JSON = JSON.stringify(
+    closeDecision({
+      decision: "close",
+      closeReason: "duplicate_or_superseded",
+      confidence: "high",
+      summary: "Resolved on main already.",
+      bestSolution: "Close as superseded.",
+      closeComment: "Superseded by main.",
+      workReason: "No additional implementation is required.",
+    }),
+  );
+  process.env.CLAWSWEEPER_CODEX_REVIEW_ATTEMPTS = "2";
+  process.env.CLAWSWEEPER_CODEX_REVIEW_RETRY_DELAY_MS = "1";
+  process.env.CLAWSWEEPER_CODEX_FALLBACK_MIN_BUDGET_MS = "1";
+  try {
+    const decision = runCodexForTest({
+      item: item({ number: 92181 }),
+      context: { issue: {}, comments: [], timeline: [] },
+      git: { mainSha: "abc123", latestRelease: null },
+      model: "internal",
+      openclawDir,
+      reasoningEffort: "high",
+      sandboxMode: "read-only",
+      serviceTier: "",
+      timeoutMs: 10_000,
+      workDir,
+      prompt: "Return a review decision.",
+    });
+
+    assert.equal(readFileSync(attemptsPath, "utf8"), "3");
+    assert.equal(decision.decision, "close");
+    assert.equal(decision.confidence, "medium");
+    assert.match(decision.summary, /^Degraded review:/);
+    assert.match(decision.summary, /lower-effort \(low\) fallback pass/);
+    assert.match(decision.summary, /Resolved on main already\./);
+    assert.equal(decision.evidence[0]?.label, "degraded review mode");
+    assert.match(decision.evidence[0]?.detail ?? "", /high → low reasoning effort fallback/);
+    assert.equal(decision.evidence[1]?.label, "original codex transport failure");
+    assert.match(decision.evidence[1]?.detail ?? "", /Rate limit reached|tokens per min/i);
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("runCodex keeps the transport classification when the fallback also fails", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const openclawDir = join(root, "openclaw");
+  const workDir = join(root, "codex-work");
+  const binDir = join(root, "bin");
+  const attemptsPath = join(root, "attempts");
+  mkdirSync(openclawDir, { recursive: true });
+  mkdirSync(binDir, { recursive: true });
+  execFileSync("git", ["init"], { cwd: openclawDir, stdio: "ignore" });
+  const codexPath = join(binDir, "codex");
+  writeFileSync(
+    codexPath,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const attemptsPath = process.env.CODEX_ATTEMPTS_PATH;
+const n = fs.existsSync(attemptsPath) ? Number(fs.readFileSync(attemptsPath, "utf8")) + 1 : 1;
+fs.writeFileSync(attemptsPath, String(n));
+process.stderr.write("Rate limit reached on tokens per min (TPM). Please try again in 1ms.\\n");
+process.exit(1);
+`,
+  );
+  chmodSync(codexPath, 0o755);
+  const previous = {
+    PATH: process.env.PATH,
+    CODEX_ATTEMPTS_PATH: process.env.CODEX_ATTEMPTS_PATH,
+    CLAWSWEEPER_CODEX_REVIEW_ATTEMPTS: process.env.CLAWSWEEPER_CODEX_REVIEW_ATTEMPTS,
+    CLAWSWEEPER_CODEX_REVIEW_RETRY_DELAY_MS: process.env.CLAWSWEEPER_CODEX_REVIEW_RETRY_DELAY_MS,
+    CLAWSWEEPER_CODEX_FALLBACK_MIN_BUDGET_MS: process.env.CLAWSWEEPER_CODEX_FALLBACK_MIN_BUDGET_MS,
+  };
+  process.env.PATH = `${binDir}${delimiter}${process.env.PATH ?? ""}`;
+  process.env.CODEX_ATTEMPTS_PATH = attemptsPath;
+  process.env.CLAWSWEEPER_CODEX_REVIEW_ATTEMPTS = "2";
+  process.env.CLAWSWEEPER_CODEX_REVIEW_RETRY_DELAY_MS = "1";
+  process.env.CLAWSWEEPER_CODEX_FALLBACK_MIN_BUDGET_MS = "1";
+  try {
+    assert.throws(
+      () =>
+        runCodexForTest({
+          item: item({ number: 92181 }),
+          context: { issue: {}, comments: [], timeline: [] },
+          git: { mainSha: "abc123", latestRelease: null },
+          model: "internal",
+          openclawDir,
+          reasoningEffort: "high",
+          sandboxMode: "read-only",
+          serviceTier: "",
+          timeoutMs: 10_000,
+          workDir,
+          prompt: "Return a review decision.",
+        }),
+      (error: unknown) => {
+        const reviewError = error as Error;
+        assert.equal(readFileSync(attemptsPath, "utf8"), "3");
+        assert.match(reviewError.message, /Lower-effort \(low\) fallback also failed/);
+        const failure = codexFailureDecisionForTest(
+          1,
+          reviewError.message,
+          (reviewError as { stdout?: string }).stdout ?? "",
+          (reviewError as { stderr?: string }).stderr ?? "",
+        );
+        assert.match(failure.summary, /retryable codex transport failure \(capacity\)/);
+        return true;
+      },
+    );
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("runCodex skips the lower-effort fallback when the time budget is too small", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const openclawDir = join(root, "openclaw");
+  const workDir = join(root, "codex-work");
+  const binDir = join(root, "bin");
+  const attemptsPath = join(root, "attempts");
+  mkdirSync(openclawDir, { recursive: true });
+  mkdirSync(binDir, { recursive: true });
+  execFileSync("git", ["init"], { cwd: openclawDir, stdio: "ignore" });
+  const codexPath = join(binDir, "codex");
+  writeFileSync(
+    codexPath,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const attemptsPath = process.env.CODEX_ATTEMPTS_PATH;
+const n = fs.existsSync(attemptsPath) ? Number(fs.readFileSync(attemptsPath, "utf8")) + 1 : 1;
+fs.writeFileSync(attemptsPath, String(n));
+process.stderr.write("Rate limit reached on tokens per min (TPM). Please try again in 1ms.\\n");
+process.exit(1);
+`,
+  );
+  chmodSync(codexPath, 0o755);
+  const previous = {
+    PATH: process.env.PATH,
+    CODEX_ATTEMPTS_PATH: process.env.CODEX_ATTEMPTS_PATH,
+    CLAWSWEEPER_CODEX_REVIEW_ATTEMPTS: process.env.CLAWSWEEPER_CODEX_REVIEW_ATTEMPTS,
+    CLAWSWEEPER_CODEX_REVIEW_RETRY_DELAY_MS: process.env.CLAWSWEEPER_CODEX_REVIEW_RETRY_DELAY_MS,
+    CLAWSWEEPER_CODEX_FALLBACK_MIN_BUDGET_MS: process.env.CLAWSWEEPER_CODEX_FALLBACK_MIN_BUDGET_MS,
+  };
+  process.env.PATH = `${binDir}${delimiter}${process.env.PATH ?? ""}`;
+  process.env.CODEX_ATTEMPTS_PATH = attemptsPath;
+  process.env.CLAWSWEEPER_CODEX_REVIEW_ATTEMPTS = "2";
+  process.env.CLAWSWEEPER_CODEX_REVIEW_RETRY_DELAY_MS = "1";
+  process.env.CLAWSWEEPER_CODEX_FALLBACK_MIN_BUDGET_MS = "10000000";
+  try {
+    assert.throws(() =>
+      runCodexForTest({
+        item: item({ number: 92181 }),
+        context: { issue: {}, comments: [], timeline: [] },
+        git: { mainSha: "abc123", latestRelease: null },
+        model: "internal",
+        openclawDir,
+        reasoningEffort: "high",
+        sandboxMode: "read-only",
+        serviceTier: "",
+        timeoutMs: 10_000,
+        workDir,
+        prompt: "Return a review decision.",
+      }),
+    );
+    assert.equal(readFileSync(attemptsPath, "utf8"), "2");
   } finally {
     for (const [key, value] of Object.entries(previous)) {
       if (value === undefined) delete process.env[key];


### PR DESCRIPTION
## Problem

`@clawsweeper re-review` on PR openclaw/openclaw#92181 consistently exhausts the Codex transient-transport retry budget (`attempt 2/3`, `3/3`, `reason=transient_transport`) and then falls back to a low-confidence placeholder:

- `decision=keep_open confidence=low action=kept_open`
- routed verdict: `off-meta tidepool / [P1] Review did not complete (retryable codex transport failure)`

The high-reasoning-effort path produces long thinking streams; when the backend/proxy closes the stream early, every same-effort retry hits the same failure and the contributor has no path forward. See #282.

## Fix

`runCodex` now, after the transient-transport retries are exhausted, runs **one bounded lower-reasoning-effort fallback pass** when enough of the timeout budget remains:

- Effort step-down: `high`/`medium` -> `low`, `low` -> `minimal` (`minimal`/unknown -> no fallback).
- The fallback runs a single attempt and shares the original `--codex-timeout-ms` budget, so a re-review never becomes a stalled job.
- A successful fallback returns a real review, with:
  - degraded mode disclosed in the summary,
  - the original transport diagnostic preserved as evidence (`degraded review mode`, `original codex transport failure`),
  - `high` confidence capped to `medium`, so a degraded review can never trigger an auto-close (close actions require `confidence === "high"`).
- If the fallback also fails, the thrown `CodexReviewError` preserves the original transport classification, so the placeholder review still reads as a transport failure (capacity/network) rather than whatever the fallback surfaced last.

The minimum remaining-time budget for attempting the fallback is configurable via `CLAWSWEEPER_CODEX_FALLBACK_MIN_BUDGET_MS` (default `120000`).

## Real behavior proof

Driving the real `runCodex` code path end-to-end through the built `dist/` with a stubbed `codex` that reproduces #282 (stream closes at `high` effort, succeeds at lower effort), `CLAWSWEEPER_CODEX_REVIEW_ATTEMPTS=3`:

### BEFORE (origin/main @ 2e4282b, unpatched) — reproduces #282
```
[review] codex-retry #92181 attempt=2/3 delay_ms=5 reason=transient_transport
[review] codex-retry #92181 attempt=3/3 delay_ms=10 reason=transient_transport
reasoning-efforts-seen: high, high, high
codex-invocations: 3
{
  "threw": true,
  "errorHead": "Codex review failed for #92181 with exit 1.",
  "placeholderDecision": "keep_open",
  "placeholderConfidence": "low",
  "placeholderSummary": "Codex review failed: retryable codex transport failure (network) (exit 1).",
  "placeholderChangeSummary": "Review failed before ClawSweeper could summarize the requested change."
}
```

### AFTER (patched) — bounded lower-effort fallback
```
[review] codex-retry #92181 attempt=2/3 delay_ms=5 reason=transient_transport
[review] codex-retry #92181 attempt=3/3 delay_ms=10 reason=transient_transport
[review] codex-fallback #92181 reason=transient_transport from_effort=high to_effort=low remaining_ms=599702
reasoning-efforts-seen: high, high, high, low
codex-invocations: 4
{
  "threw": false,
  "decision": "close",
  "confidence": "medium",
  "summaryHead": "Degraded review: Codex hit a retryable codex transport failure (network) at high reasoning effort, so ClawSweeper completed this review with...",
  "changeSummary": "Adds the retry-classification helper plus regression coverage.",
  "evidenceLabels": ["degraded review mode", "original codex transport failure", "implementation"]
}
```

The unpatched build dead-ends at the placeholder; the patched build runs exactly one extra `low`-effort pass, returns a real verdict, discloses degraded mode, and caps the fixture's `high` confidence to `medium`.

## Tests

Added to `test/clawsweeper.test.ts` (all pass under `node --test ... --test-name-pattern 'Codex|transient|retry|fallback|failure'`):

- `lowerCodexReasoningEffort steps down one tier and stops at minimal`
- `runCodex completes via a lower-effort fallback after transport exhaustion`
- `runCodex keeps the transport classification when the fallback also fails`
- `runCodex skips the lower-effort fallback when the time budget is too small`

Verified locally: `pnpm run build`, `pnpm run lint:src`, `pnpm run lint:scripts`, `pnpm run check:active-surface`, `pnpm run check:limits`, `pnpm run format:check`, and the targeted test pattern (399 pass / 0 fail).

## Related issues (triage cross-reference)

`transient_transport` has no earlier hits in the tracker, so this failure mode is new. Distinct-but-adjacent issues:

- **#272** (Adaptive codex timeout for large/video PRs): same Codex-call seam, but #272 is about actually *hitting* the 10-minute `--codex-timeout-ms` on large/video PRs. Here every attempt returns `transient_transport` after roughly 2:46 of wall-clock and never reaches the timeout; the PR is moderate (~21 KB diff, no video proof), so #272's size-based mitigations would not trigger. This fix is self-contained in `runCodex` and does not depend on #272's dispatch-payload work; if #272 surfaces `codex_*` knobs in `dispatchItemReview()`, an opt-in flag for this fallback could live there later, but it is not required.
- **#170** (re-review reports "Complete" but durable marker not refreshed): same `re-review` workflow surface, different leg (verdict-sync path vs. this review-execution path).
- **#252** (re-review fails on `master` default branch): sibling re-review failure category, unrelated to Codex transport (repo fetch).
- **#266** (command-status edits re-enter activity handling and churn labels): text-search collision on "off-meta tidepool" only; underlying bug is label churn, not review failure.
