### PR TITLE
Fix Codex review subprocess output handling

### DIFF
--- a/.github/actions/setup-codex/action.yml
+++ b/.github/actions/setup-codex/action.yml
@@ -1,6 +1,12 @@
 name: Setup Codex CLI
 description: Cache, install, and authenticate the OpenAI Codex CLI.
 inputs:
+  codex-version:
+    description: Exact Codex CLI npm package version.
+    default: "0.139.0"
+  proxy-version:
+    description: Exact Codex Responses proxy npm package version.
+    default: "0.139.0"
   auth-mode:
     description: Authentication mode. Use proxy to keep OPENAI_API_KEY out of Codex subprocesses, or login for legacy codex login.
     default: "proxy"
@@ -23,9 +29,9 @@ runs:
           ~/.npm
           ~/.cache/node/corepack
           ~/.clawsweeper-repair/codex
-        key: ${{ runner.os }}-node24-codex-latest-${{ inputs['cache-suffix'] || 'default' }}-v3
+        key: ${{ runner.os }}-node24-codex-${{ inputs['codex-version'] }}-proxy-${{ inputs['proxy-version'] }}-${{ inputs['cache-suffix'] || 'default' }}-v4
         restore-keys: |
-          ${{ runner.os }}-node24-codex-latest-
+          ${{ runner.os }}-node24-codex-${{ inputs['codex-version'] }}-proxy-${{ inputs['proxy-version'] }}-
           ${{ runner.os }}-node24-codex-
 
     - name: Install Codex CLI
@@ -38,10 +44,10 @@ runs:
         export PATH="$HOME/.clawsweeper-repair/codex/bin:$PATH"
 
         install_env=(env -u OPENAI_API_KEY -u CODEX_API_KEY -u PROXY_API_KEY -u CLAWSWEEPER_INTERNAL_MODEL)
-        "${install_env[@]}" npm install -g "@openai/codex@latest" \
+        "${install_env[@]}" npm install -g "@openai/codex@${{ inputs['codex-version'] }}" \
           --prefer-online --no-audit --no-fund --ignore-scripts
         if [[ "${{ inputs['auth-mode'] }}" == "proxy" ]]; then
-          "${install_env[@]}" npm install -g "@openai/codex-responses-api-proxy@latest" \
+          "${install_env[@]}" npm install -g "@openai/codex-responses-api-proxy@${{ inputs['proxy-version'] }}" \
             --prefer-online --no-audit --no-fund --ignore-scripts
         fi
         codex --version

--- a/.github/workflows/repair-comment-router.yml
+++ b/.github/workflows/repair-comment-router.yml
@@ -91,6 +91,9 @@ jobs:
             scripts/hydrate-state.ts
             src/clawsweeper-text.ts
             src/codex-env.ts
+            src/codex-output-capture.ts
+            src/codex-process-worker.ts
+            src/codex-process.ts
             src/codex-transient.ts
             src/github-retry.ts
             src/pr-close-coverage-proof.ts

--- a/.github/workflows/spam-comment-intake.yml
+++ b/.github/workflows/spam-comment-intake.yml
@@ -57,6 +57,9 @@ jobs:
             schema/clawsweeper-pr-close-coverage-proof.schema.json
             src/clawsweeper-text.ts
             src/codex-env.ts
+            src/codex-output-capture.ts
+            src/codex-process-worker.ts
+            src/codex-process.ts
             src/codex-transient.ts
             src/github-retry.ts
             src/pr-close-coverage-proof.ts

--- a/.github/workflows/spam-scanner.yml
+++ b/.github/workflows/spam-scanner.yml
@@ -80,6 +80,9 @@ jobs:
             scripts/hydrate-state.ts
             src/clawsweeper-text.ts
             src/codex-env.ts
+            src/codex-output-capture.ts
+            src/codex-process-worker.ts
+            src/codex-process.ts
             src/codex-transient.ts
             src/github-retry.ts
             src/pr-close-coverage-proof.ts

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -30,7 +30,14 @@ import {
   PUBLIC_CODEX_MODEL,
   redactInternalCodexModel,
 } from "./codex-env.js";
-import { codexRetryDelayMs, isRetryableCodexTransportError } from "./codex-transient.js";
+import { codexProcessErrorCode, runCodexProcess } from "./codex-process.js";
+import {
+  codexJsonlFailureDetail,
+  codexRetryDelayMs,
+  isRetryableCodexErrorMessage,
+  isRetryableCodexTransportError,
+  isTerminalCodexErrorMessage,
+} from "./codex-transient.js";
 import {
   ghRetryKind,
   ghRetryWaitMs,
@@ -445,6 +452,7 @@ interface Decision {
   featureShowcase: FeatureShowcase;
   overallCorrectness: OverallCorrectness;
   overallConfidenceScore: number;
+  codexTerminalFailure?: boolean;
   fixedRelease?: string | null;
   fixedSha?: string | null;
   fixedAt?: string | null;
@@ -4661,6 +4669,7 @@ export function isInfrastructureFailedReviewForTest(markdown: string): boolean {
 
 function isInfrastructureFailedReview(markdown: string): boolean {
   const detail = failedReviewFailureDetail(markdown);
+  if (frontMatterBoolean(markdown, "review_terminal_failure")) return false;
   return (
     isRetryableCodexTransportError(detail) ||
     /\b(?:ETIMEDOUT|ECONNRESET|EAI_AGAIN|ENOTFOUND|socket hang up|fetch failed|transport failure|codex transport|Codex worker timed out|Codex review failed: timeout|timed out after|shard timeout|workflow timeout|cancelledByParent)\b/i.test(
@@ -6347,11 +6356,12 @@ export function reviewPromptForTest(
   return buildReviewPrompt(item, context, git, additionalPrompt, runtimeHints).text;
 }
 
-function codexFailureReason(detail: string): string {
+function codexFailureReason(detail: string, errorCode?: string | null): string {
   if (detail.includes("Codex dirtied the OpenClaw checkout")) return "dirty checkout";
   if (detail.includes("did not produce output")) return "missing structured output";
   if (detail.includes("invalid JSON")) return "invalid structured output";
-  if (detail.includes("ENOBUFS") || detail.includes("maxBuffer")) return "output buffer overflow";
+  if (errorCode === "ENOBUFS") return "output buffer overflow";
+  if (isTerminalCodexErrorMessage(detail)) return "model unavailable or access denied";
   if (detail.includes("timed out") || detail.includes("ETIMEDOUT")) return "timeout";
   if (
     /rate limit reached|tokens per min|\bTPM\b|requests per min|\b429\b|temporarily unavailable|overloaded|please try again in \d+(?:ms|s)/i.test(
@@ -6373,11 +6383,15 @@ function codexFailureDecision(
   detail: string,
   stdout = "",
   stderr = "",
+  processResult: { errorCode?: string | null; signal?: NodeJS.Signals | null } = {},
 ): Decision {
   const failureDetail = redactInternalCodexModel(detail || "No failure detail.");
   const safeStdout = redactedOutputTail(stdout || "No stdout captured.");
   const safeStderr = redactedOutputTail(stderr || "No stderr captured.");
-  const reason = codexFailureReason(`${failureDetail}\n${safeStderr}\n${safeStdout}`);
+  const structuredError = redactInternalCodexModel(codexJsonlFailureDetail(stdout));
+  const processFailureDetail = [failureDetail, structuredError].filter(Boolean).join("\n");
+  const reason = codexFailureReason(processFailureDetail, processResult.errorCode);
+  const terminalError = isTerminalCodexErrorMessage(structuredError) ? structuredError : "";
   return {
     decision: "keep_open",
     closeReason: "none",
@@ -6395,6 +6409,15 @@ function codexFailureDecision(
         label: "codex stdout",
         detail: trimMiddle(safeStdout, 2000),
       }),
+      ...(terminalError
+        ? [evidenceEntry({ label: "codex terminal error", detail: terminalError })]
+        : []),
+      ...(processResult.errorCode
+        ? [evidenceEntry({ label: "process error code", detail: processResult.errorCode })]
+        : []),
+      ...(processResult.signal
+        ? [evidenceEntry({ label: "process signal", detail: processResult.signal })]
+        : []),
     ],
     likelyOwners: [
       {
@@ -6471,6 +6494,7 @@ function codexFailureDecision(
     },
     overallCorrectness: "not a patch",
     overallConfidenceScore: 0,
+    codexTerminalFailure: Boolean(terminalError),
     fixedRelease: null,
     fixedSha: null,
     fixedAt: null,
@@ -6492,8 +6516,9 @@ export function codexFailureDecisionForTest(
   detail: string,
   stdout = "",
   stderr = "",
+  processResult: { errorCode?: string | null; signal?: NodeJS.Signals | null } = {},
 ): Decision {
-  return codexFailureDecision(status, detail, stdout, stderr);
+  return codexFailureDecision(status, detail, stdout, stderr, processResult);
 }
 
 function redactedOutputTail(value: string | Buffer | null | undefined, maxLength = 6000): string {
@@ -6517,18 +6542,24 @@ class CodexReviewError extends Error {
   readonly status: number | null;
   readonly stdout: string;
   readonly stderr: string;
+  readonly errorCode: string | null;
+  readonly signal: NodeJS.Signals | null;
 
   constructor(options: {
     message: string;
     status: number | null;
     stdout?: string;
     stderr?: string;
+    errorCode?: string | null;
+    signal?: NodeJS.Signals | null;
   }) {
     super(options.message);
     this.name = "CodexReviewError";
     this.status = options.status;
     this.stdout = options.stdout ?? "";
     this.stderr = options.stderr ?? "";
+    this.errorCode = options.errorCode ?? null;
+    this.signal = options.signal ?? null;
   }
 }
 
@@ -6644,9 +6675,8 @@ function runCodex(options: {
         `Codex review timed out for #${options.item.number} after ${options.timeoutMs}ms.`,
       );
     }
-    const result = spawnSync(
-      "codex",
-      [
+    const result = runCodexProcess({
+      args: [
         "exec",
         ...codexModelArgs(options.model),
         ...codexConfig.flatMap((config) => ["-c", config]),
@@ -6656,24 +6686,21 @@ function runCodex(options: {
         CLAWSWEEPER_DECISION_SCHEMA_PATH,
         "--output-last-message",
         outputPath,
+        "--json",
         "--sandbox",
         options.sandboxMode,
         "--add-dir",
         proofScratchDir,
         "-",
       ],
-      {
-        cwd: options.openclawDir,
-        encoding: "utf8",
-        env: {
-          ...codexEnv({ ghToken: process.env.CLAWSWEEPER_PROOF_INSPECTION_TOKEN }),
-          CLAWSWEEPER_PROOF_SCRATCH_DIR: proofScratchDir,
-        },
-        input: prompt,
-        maxBuffer: 128 * 1024 * 1024,
-        timeout: remainingMs,
+      cwd: options.openclawDir,
+      env: {
+        ...codexEnv({ ghToken: process.env.CLAWSWEEPER_PROOF_INSPECTION_TOKEN }),
+        CLAWSWEEPER_PROOF_SCRATCH_DIR: proofScratchDir,
       },
-    );
+      input: prompt,
+      timeoutMs: remainingMs,
+    });
     const dirtyAfter = openclawDirtyStatus(options.openclawDir);
     if (dirtyAfter) {
       throw new Error(
@@ -6682,6 +6709,7 @@ function runCodex(options: {
     }
     const stderr = redactedOutputTail(result.stderr);
     const stdout = redactedOutputTail(result.stdout);
+    const errorCode = codexProcessErrorCode(result.error);
     let failureDetail = "";
     if (result.error) {
       failureDetail = `Codex review failed for #${options.item.number}: ${redactInternalCodexModel(result.error.message)}`;
@@ -6711,19 +6739,22 @@ function runCodex(options: {
     } else if (!result.error) {
       failureDetail =
         result.status === 0
-          ? `Codex review did not produce output for #${options.item.number}: Codex exited successfully but did not write ${outputPath}.\n${stdout || "No stdout."}`
+          ? `Codex review did not produce output for #${options.item.number}: Codex exited successfully but did not write ${outputPath}.`
           : `Codex review failed for #${options.item.number} with exit ${result.status ?? "unknown"}.`;
     }
-    const diagnosticDetail = `${failureDetail}\n${stderr}\n${stdout}`;
+    const structuredError = redactInternalCodexModel(codexJsonlFailureDetail(result.stdout));
+    const processFailureDetail = [failureDetail, structuredError].filter(Boolean).join("\n");
+    const terminalFailure = isTerminalCodexErrorMessage(processFailureDetail);
     const retryable =
-      result.signal !== null ||
-      (result.status === 0 && !hasOutput) ||
-      isRetryableCodexTransportError(diagnosticDetail) ||
-      /\b(?:ETIMEDOUT|ECONNRESET|EAI_AGAIN|ENOTFOUND|socket hang up|fetch failed|transport failure)\b/i.test(
-        diagnosticDetail,
-      );
+      !terminalFailure &&
+      (result.signal !== null ||
+        (result.status === 0 && !hasOutput) ||
+        isRetryableCodexErrorMessage(processFailureDetail) ||
+        /\b(?:ETIMEDOUT|ECONNRESET|EAI_AGAIN|ENOTFOUND|socket hang up|fetch failed|transport failure)\b/i.test(
+          processFailureDetail,
+        ));
     if (retryable && attempt < maxAttempts) {
-      const delayMs = codexRetryDelayMs(diagnosticDetail, attempt);
+      const delayMs = codexRetryDelayMs(processFailureDetail, attempt);
       if (Date.now() - startedAt + delayMs < options.timeoutMs) {
         console.error(
           `[review] ${new Date().toISOString()} codex-retry #${options.item.number} attempt=${
@@ -6739,6 +6770,8 @@ function runCodex(options: {
       status: result.status,
       stdout,
       stderr,
+      errorCode,
+      signal: result.signal,
     });
   }
   throw new Error(`Codex review failed for #${options.item.number}.`);
@@ -6900,9 +6933,8 @@ function runCodexAssist(options: {
     'forced_login_method="api"',
     'approval_policy="never"',
   ];
-  const result = spawnSync(
-    "codex",
-    [
+  const result = runCodexProcess({
+    args: [
       "exec",
       ...codexModelArgs(options.model),
       ...codexConfig.flatMap((config) => ["-c", config]),
@@ -6912,15 +6944,11 @@ function runCodexAssist(options: {
       options.sandboxMode,
       "-",
     ],
-    {
-      cwd: ROOT,
-      encoding: "utf8",
-      env: codexEnv(),
-      input: prompt,
-      maxBuffer: 32 * 1024 * 1024,
-      timeout: options.timeoutMs,
-    },
-  );
+    cwd: ROOT,
+    env: codexEnv(),
+    input: prompt,
+    timeoutMs: options.timeoutMs,
+  });
   if (result.error || result.status !== 0 || !existsSync(outputPath)) {
     const detail =
       result.error instanceof Error
@@ -14621,6 +14649,7 @@ review_context_elapsed_ms: ${reviewTelemetryNumber(options.runtime.contextElapse
 review_codex_elapsed_ms: ${reviewTelemetryNumber(options.runtime.codexElapsedMs)}
 review_mode: ${options.reviewMode}
 review_status: ${options.decision.summary.startsWith("Codex review failed") ? "failed" : "complete"}
+review_terminal_failure: ${options.decision.codexTerminalFailure === true}
 local_checkout_access: verified
 item_snapshot_hash: ${options.snapshotHash}
 close_comment_sha256: ${options.action.closeComment ? sha256(options.action.closeComment) : "none"}
@@ -15001,7 +15030,10 @@ function reviewCommand(args: Args): void {
       } catch (error) {
         codexFailures += 1;
         if (error instanceof CodexReviewError) {
-          decision = codexFailureDecision(error.status, error.message, error.stdout, error.stderr);
+          decision = codexFailureDecision(error.status, error.message, error.stdout, error.stderr, {
+            errorCode: error.errorCode,
+            signal: error.signal,
+          });
         } else {
           decision = codexFailureDecision(
             null,

--- a/src/codex-output-capture.ts
+++ b/src/codex-output-capture.ts
@@ -1,0 +1,98 @@
+import { closeSync, ftruncateSync, openSync, writeSync } from "node:fs";
+
+export const DEFAULT_CODEX_OUTPUT_FILE_BYTES = 128 * 1024 * 1024;
+export const DEFAULT_CODEX_OUTPUT_TAIL_BYTES = 64 * 1024;
+
+const TRUNCATION_MARKER = Buffer.from(
+  "\n...[Codex output truncated; final tail follows]...\n",
+  "utf8",
+);
+
+export interface CodexOutputCapture {
+  file: number;
+  maxFileBytes: number;
+  tailBytes: number;
+  writtenBytes: number;
+  truncated: boolean;
+  tail: Buffer<ArrayBufferLike>;
+}
+
+export function openCodexOutputCapture(
+  filePath: string,
+  options: { maxFileBytes?: number; tailBytes?: number } = {},
+): CodexOutputCapture {
+  return {
+    file: openSync(filePath, "w"),
+    maxFileBytes: normalizedMaxFileBytes(options.maxFileBytes),
+    tailBytes: normalizedTailBytes(options.tailBytes),
+    writtenBytes: 0,
+    truncated: false,
+    tail: Buffer.alloc(0),
+  };
+}
+
+export function appendCodexOutputCapture(capture: CodexOutputCapture, chunk: Buffer): void {
+  capture.tail = appendTail(capture.tail, chunk, capture.tailBytes);
+  const remaining = capture.maxFileBytes - capture.writtenBytes;
+  const retained = chunk.subarray(0, Math.max(0, remaining));
+  writeAll(capture.file, retained);
+  capture.writtenBytes += retained.length;
+  if (chunk.length > retained.length) capture.truncated = true;
+}
+
+export function closeCodexOutputCapture(capture: CodexOutputCapture): void {
+  try {
+    if (capture.truncated) {
+      const tail = capture.tail.subarray(
+        Math.max(0, capture.tail.length - availableTailBytes(capture.maxFileBytes)),
+      );
+      const headBytes = capture.maxFileBytes - TRUNCATION_MARKER.length - tail.length;
+      ftruncateSync(capture.file, headBytes);
+      writeAll(capture.file, TRUNCATION_MARKER, headBytes);
+      writeAll(capture.file, tail, headBytes + TRUNCATION_MARKER.length);
+    }
+  } finally {
+    closeSync(capture.file);
+  }
+}
+
+export function codexOutputTail(capture: CodexOutputCapture): string {
+  return capture.tail.toString("utf8");
+}
+
+function appendTail(current: Buffer, chunk: Buffer, maxBytes: number): Buffer {
+  if (maxBytes <= 0) return Buffer.alloc(0);
+  if (chunk.length >= maxBytes) return chunk.subarray(chunk.length - maxBytes);
+  const combined = Buffer.concat([current, chunk]);
+  return combined.length > maxBytes ? combined.subarray(combined.length - maxBytes) : combined;
+}
+
+function normalizedMaxFileBytes(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_CODEX_OUTPUT_FILE_BYTES;
+  const normalized = Number.isFinite(value) ? Math.floor(value) : DEFAULT_CODEX_OUTPUT_FILE_BYTES;
+  return Math.max(TRUNCATION_MARKER.length, normalized);
+}
+
+function normalizedTailBytes(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_CODEX_OUTPUT_TAIL_BYTES;
+  return Math.max(0, Number.isFinite(value) ? Math.floor(value) : DEFAULT_CODEX_OUTPUT_TAIL_BYTES);
+}
+
+function availableTailBytes(maxFileBytes: number): number {
+  return Math.max(0, maxFileBytes - TRUNCATION_MARKER.length);
+}
+
+function writeAll(file: number, value: Buffer, position?: number): void {
+  let offset = 0;
+  while (offset < value.length) {
+    const written = writeSync(
+      file,
+      value,
+      offset,
+      value.length - offset,
+      position === undefined ? undefined : position + offset,
+    );
+    if (written === 0) throw new Error("Codex output file write made no progress.");
+    offset += written;
+  }
+}

--- a/src/codex-process-worker.ts
+++ b/src/codex-process-worker.ts
@@ -1,0 +1,84 @@
+import { spawn } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import {
+  appendCodexOutputCapture,
+  closeCodexOutputCapture,
+  codexOutputTail,
+  openCodexOutputCapture,
+} from "./codex-output-capture.js";
+
+interface WorkerOptions {
+  args: string[];
+  resultPath: string;
+  stdoutPath: string;
+  stderrPath: string;
+  tailBytes: number;
+  maxOutputFileBytes: number;
+}
+
+const options = JSON.parse(readFileSync(process.argv[2] ?? "", "utf8")) as WorkerOptions;
+const stdout = openCodexOutputCapture(options.stdoutPath, {
+  maxFileBytes: options.maxOutputFileBytes,
+  tailBytes: options.tailBytes,
+});
+const stderr = openCodexOutputCapture(options.stderrPath, {
+  maxFileBytes: options.maxOutputFileBytes,
+  tailBytes: options.tailBytes,
+});
+const child = spawn("codex", options.args, {
+  cwd: process.cwd(),
+  env: process.env,
+  stdio: ["pipe", "pipe", "pipe"],
+});
+let spawnError: Error | undefined;
+let terminating = false;
+let forceKillTimer: NodeJS.Timeout | undefined;
+
+child.stdout.on("data", (chunk: Buffer) => {
+  appendCodexOutputCapture(stdout, chunk);
+});
+child.stderr.on("data", (chunk: Buffer) => {
+  appendCodexOutputCapture(stderr, chunk);
+});
+child.stdin.on("error", () => {});
+process.stdin.pipe(child.stdin);
+
+child.once("error", (error) => {
+  spawnError = error;
+});
+child.once("close", (status, signal) => {
+  if (forceKillTimer) clearTimeout(forceKillTimer);
+  closeCodexOutputCapture(stdout);
+  closeCodexOutputCapture(stderr);
+  writeFileSync(
+    options.resultPath,
+    JSON.stringify({
+      status,
+      signal,
+      ...(spawnError ? { error: serializedError(spawnError) } : {}),
+      stdout: codexOutputTail(stdout),
+      stderr: codexOutputTail(stderr),
+    }),
+    "utf8",
+  );
+  process.exit(0);
+});
+
+for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
+  process.once(signal, () => {
+    if (terminating) return;
+    terminating = true;
+    process.stdin.unpipe(child.stdin);
+    child.stdin.end();
+    child.kill(signal);
+    forceKillTimer = setTimeout(() => child.kill("SIGKILL"), 1000);
+  });
+}
+
+function serializedError(error: Error): { message: string; code?: string } {
+  const code = "code" in error ? (error as NodeJS.ErrnoException).code : undefined;
+  return {
+    message: error.message,
+    ...(typeof code === "string" ? { code } : {}),
+  };
+}

--- a/src/codex-process.ts
+++ b/src/codex-process.ts
@@ -1,0 +1,127 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  DEFAULT_CODEX_OUTPUT_FILE_BYTES,
+  DEFAULT_CODEX_OUTPUT_TAIL_BYTES,
+} from "./codex-output-capture.js";
+
+export interface CodexProcessResult {
+  status: number | null;
+  signal: NodeJS.Signals | null;
+  error?: Error;
+  stdout: string;
+  stderr: string;
+}
+
+interface SerializedCodexProcessResult {
+  status: number | null;
+  signal: NodeJS.Signals | null;
+  error?: {
+    message: string;
+    code?: string;
+  };
+  stdout: string;
+  stderr: string;
+}
+
+const CODEX_PROCESS_WORKER_PATH = fileURLToPath(
+  new URL("./codex-process-worker.js", import.meta.url),
+);
+
+export function runCodexProcess(options: {
+  args: readonly string[];
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  input: string;
+  timeoutMs: number;
+  tailBytes?: number;
+  outputFileBytes?: number;
+  stdoutPath?: string;
+  stderrPath?: string;
+}): CodexProcessResult {
+  const workDir = mkdtempSync(join(tmpdir(), "clawsweeper-codex-process-"));
+  const optionsPath = join(workDir, "options.json");
+  const resultPath = join(workDir, "result.json");
+  const stdoutPath = options.stdoutPath ?? join(workDir, "stdout.log");
+  const stderrPath = options.stderrPath ?? join(workDir, "stderr.log");
+  try {
+    writeFileSync(
+      optionsPath,
+      JSON.stringify({
+        args: [...options.args],
+        resultPath,
+        stdoutPath,
+        stderrPath,
+        tailBytes: normalizedTailBytes(options.tailBytes),
+        maxOutputFileBytes: normalizedOutputFileBytes(options.outputFileBytes),
+      }),
+      "utf8",
+    );
+    const worker = spawnSync(process.execPath, [CODEX_PROCESS_WORKER_PATH, optionsPath], {
+      cwd: options.cwd,
+      env: options.env,
+      input: options.input,
+      stdio: ["pipe", "ignore", "ignore"],
+      timeout: options.timeoutMs,
+    });
+    if (existsSync(resultPath)) {
+      const result = deserializeProcessResult(JSON.parse(readFileSync(resultPath, "utf8")));
+      return worker.error ? { ...result, error: worker.error } : result;
+    }
+    if (worker.error) return failedProcessResult(worker.error, worker.status, worker.signal);
+    return failedProcessResult(
+      new Error(
+        `Codex process worker failed with exit ${worker.status ?? "unknown"} and did not write a result.`,
+      ),
+      worker.status,
+      worker.signal,
+    );
+  } catch (error) {
+    return failedProcessResult(error instanceof Error ? error : new Error(String(error)));
+  } finally {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+}
+
+export function codexProcessErrorCode(error: Error | undefined): string | null {
+  if (!error || !("code" in error)) return null;
+  const code = (error as NodeJS.ErrnoException).code;
+  return typeof code === "string" ? code : null;
+}
+
+function normalizedTailBytes(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_CODEX_OUTPUT_TAIL_BYTES;
+  return Math.max(0, Number.isFinite(value) ? Math.floor(value) : DEFAULT_CODEX_OUTPUT_TAIL_BYTES);
+}
+
+function normalizedOutputFileBytes(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_CODEX_OUTPUT_FILE_BYTES;
+  return Math.max(0, Number.isFinite(value) ? Math.floor(value) : DEFAULT_CODEX_OUTPUT_FILE_BYTES);
+}
+
+function failedProcessResult(
+  error: Error,
+  status: number | null = null,
+  signal: NodeJS.Signals | null = null,
+): CodexProcessResult {
+  return { status, signal, error, stdout: "", stderr: "" };
+}
+
+function deserializeProcessResult(value: SerializedCodexProcessResult): CodexProcessResult {
+  return {
+    status: value.status,
+    signal: value.signal,
+    ...(value.error ? { error: deserializeError(value.error) } : {}),
+    stdout: value.stdout,
+    stderr: value.stderr,
+  };
+}
+
+function deserializeError(value: { message: string; code?: string }): Error {
+  const error = new Error(value.message);
+  if (value.code) (error as NodeJS.ErrnoException).code = value.code;
+  return error;
+}

--- a/src/codex-transient.ts
+++ b/src/codex-transient.ts
@@ -1,4 +1,5 @@
-const CODEX_MODEL_ACCESS_ERROR = /the model .+ does not exist or you do not have access to it/i;
+const CODEX_MODEL_ACCESS_PREFIX = "the model ";
+const CODEX_MODEL_ACCESS_SUFFIX = " does not exist or you do not have access to it";
 
 export function isRetryableCodexTransportError(value: string | null | undefined): boolean {
   const message = value ?? "";
@@ -18,7 +19,11 @@ export function isTerminalCodexErrorMessage(value: string | null | undefined): b
       .map((line) => line.trim())
       .filter(Boolean)
       .at(-1) ?? "";
-  return CODEX_MODEL_ACCESS_ERROR.test(finalLine);
+  const normalized = finalLine.toLowerCase();
+  const prefixIndex = normalized.indexOf(CODEX_MODEL_ACCESS_PREFIX);
+  if (prefixIndex === -1) return false;
+  const modelStart = prefixIndex + CODEX_MODEL_ACCESS_PREFIX.length;
+  return normalized.indexOf(CODEX_MODEL_ACCESS_SUFFIX, modelStart) > modelStart;
 }
 
 export function codexJsonlFailureDetail(value: string | null | undefined): string {

--- a/src/codex-transient.ts
+++ b/src/codex-transient.ts
@@ -1,8 +1,44 @@
+const CODEX_MODEL_ACCESS_ERROR = /the model .+ does not exist or you do not have access to it/i;
+
 export function isRetryableCodexTransportError(value: string | null | undefined): boolean {
   const message = value ?? "";
   return /write_stdin failed: stdin is closed|stdin is closed for this session|rate limit reached|tokens per min|\bTPM\b|requests per min|\b429\b|temporarily unavailable|overloaded|stream disconnected|reconnecting|please try again in \d+(?:\.\d+)?(?:ms|s)/i.test(
     message,
   );
+}
+
+export function isRetryableCodexErrorMessage(value: string | null | undefined): boolean {
+  return !isTerminalCodexErrorMessage(value) && isRetryableCodexTransportError(value);
+}
+
+export function isTerminalCodexErrorMessage(value: string | null | undefined): boolean {
+  const finalLine =
+    (value ?? "")
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .at(-1) ?? "";
+  return CODEX_MODEL_ACCESS_ERROR.test(finalLine);
+}
+
+export function codexJsonlFailureDetail(value: string | null | undefined): string {
+  const messages: string[] = [];
+  for (const line of (value ?? "").split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    let event;
+    try {
+      event = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (event?.type === "error" && typeof event.message === "string") {
+      messages.push(event.message);
+    }
+    if (event?.type === "turn.failed" && typeof event.error?.message === "string") {
+      messages.push(event.error.message);
+    }
+  }
+  return messages.at(-1) ?? "";
 }
 
 export function isCodexContextLimitError(value: string | null | undefined): boolean {

--- a/src/commit-sweeper.ts
+++ b/src/commit-sweeper.ts
@@ -12,6 +12,7 @@ import { publishCheckFromReport, splitFrontMatter } from "./commit-checks.js";
 import { argBool, argNumber, argString, parseArgs, type Args } from "./clawsweeper-args.js";
 import { safeOutputTail } from "./clawsweeper-text.js";
 import { codexEnv, codexModelArgs, PUBLIC_CODEX_MODEL } from "./codex-env.js";
+import { codexProcessErrorCode, runCodexProcess } from "./codex-process.js";
 import { runText } from "./command.js";
 import { ghRetryKind, ghRetryWaitMs } from "./github-retry.js";
 import { DEFAULT_TARGET_REPO, repositoryProfileFor } from "./repository-profiles.js";
@@ -300,9 +301,8 @@ function runCodex(options: {
     'approval_policy="never"',
   ];
   if (options.serviceTier) codexConfig.splice(1, 0, `service_tier="${options.serviceTier}"`);
-  const result = spawnSync(
-    "codex",
-    [
+  const result = runCodexProcess({
+    args: [
       "exec",
       ...codexModelArgs(options.model),
       ...codexConfig.flatMap((config) => ["-c", config]),
@@ -314,21 +314,13 @@ function runCodex(options: {
       options.sandboxMode,
       "-",
     ],
-    {
-      cwd: options.targetDir,
-      encoding: "utf8",
-      env: codexEnv({ ghToken: process.env.COMMIT_SWEEPER_TARGET_GH_TOKEN }),
-      input: readFileSync(promptPath, "utf8"),
-      maxBuffer: 128 * 1024 * 1024,
-      timeout: options.timeoutMs,
-    },
-  );
+    cwd: options.targetDir,
+    env: codexEnv({ ghToken: process.env.COMMIT_SWEEPER_TARGET_GH_TOKEN }),
+    input: readFileSync(promptPath, "utf8"),
+    timeoutMs: options.timeoutMs,
+  });
   if (result.error || result.status !== 0 || !existsSync(outputPath)) {
-    const timeout = Boolean(
-      result.error &&
-      "code" in result.error &&
-      (result.error as NodeJS.ErrnoException).code === "ETIMEDOUT",
-    );
+    const timeout = codexProcessErrorCode(result.error) === "ETIMEDOUT";
     const detail =
       result.error instanceof Error
         ? `${result.error.message}\n${safeOutputTail(result.stderr) || safeOutputTail(result.stdout)}`

--- a/src/pr-close-coverage-proof.ts
+++ b/src/pr-close-coverage-proof.ts
@@ -1,8 +1,8 @@
-import { spawnSync } from "node:child_process";
 import { codexModelArgs } from "./codex-env.js";
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { codexEnv } from "./codex-env.js";
+import { runCodexProcess } from "./codex-process.js";
 import { safeOutputTail, truncateText } from "./clawsweeper-text.js";
 
 export type PrCloseCoverageProofModelDecision = "covered" | "keep_open";
@@ -259,9 +259,8 @@ export function runPrCloseCoverageProofModel(options: {
   if (options.runtime.serviceTier) {
     codexConfig.splice(1, 0, `service_tier="${options.runtime.serviceTier}"`);
   }
-  const result = spawnSync(
-    "codex",
-    [
+  const result = runCodexProcess({
+    args: [
       "exec",
       ...codexModelArgs(options.runtime.model),
       ...codexConfig.flatMap((config) => ["-c", config]),
@@ -275,15 +274,11 @@ export function runPrCloseCoverageProofModel(options: {
       options.runtime.sandboxMode,
       "-",
     ],
-    {
-      cwd: options.runtime.rootDir,
-      encoding: "utf8",
-      env: codexEnv({ ghToken: options.runtime.ghToken }),
-      input: prompt,
-      maxBuffer: 64 * 1024 * 1024,
-      timeout: options.runtime.timeoutMs,
-    },
-  );
+    cwd: options.runtime.rootDir,
+    env: codexEnv({ ghToken: options.runtime.ghToken }),
+    input: prompt,
+    timeoutMs: options.runtime.timeoutMs,
+  });
   if (result.error) {
     throw new Error(
       `Codex PR close coverage proof failed for #${options.source.number}: ${

--- a/src/repair/execute-fix-artifact.ts
+++ b/src/repair/execute-fix-artifact.ts
@@ -21,10 +21,14 @@ import {
 } from "./external-messages.js";
 import { runCommand as run } from "./command-runner.js";
 import {
+  codexJsonlFailureDetail,
   codexRetryDelayMs,
   isCodexContextLimitError,
+  isRetryableCodexErrorMessage,
   isRetryableCodexTransportError,
+  isTerminalCodexErrorMessage,
 } from "../codex-transient.js";
+import { runCodexProcess } from "../codex-process.js";
 import {
   branchHasBaseDiff,
   completeRebaseIfResolved,
@@ -151,8 +155,6 @@ const codexPreflightTimeoutMs = Number(
 const codexReasoningEffort = repairCodexReasoningEffort();
 const scriptStartedAt = new Date();
 const codexServiceTier = repairCodexServiceTier();
-const codexStdioMaxBuffer =
-  Math.max(1, Number(process.env.CLAWSWEEPER_CODEX_STDIO_MAX_BUFFER_MB ?? 128)) * 1024 * 1024;
 const codexHeartbeatMs = Math.max(
   10_000,
   Number(process.env.CLAWSWEEPER_CODEX_HEARTBEAT_MS ?? 60_000),
@@ -316,11 +318,22 @@ function currentCodexTimeoutMs() {
 function spawnCodexSyncWithHeartbeat(
   label: string,
   args: string[],
-  options: SpawnSyncOptionsWithStringEncoding,
+  options: SpawnSyncOptionsWithStringEncoding & { stdoutPath?: string; stderrPath?: string },
 ) {
   const heartbeat = startCodexHeartbeat(label);
   try {
-    return spawnSync("codex", args, options);
+    if (typeof options.cwd !== "string" || typeof options.input !== "string") {
+      throw new Error(`${label} requires string cwd and input.`);
+    }
+    return runCodexProcess({
+      args,
+      cwd: options.cwd,
+      env: options.env ?? process.env,
+      input: options.input,
+      timeoutMs: options.timeout ?? currentCodexTimeoutMs(),
+      ...(options.stdoutPath ? { stdoutPath: options.stdoutPath } : {}),
+      ...(options.stderrPath ? { stderrPath: options.stderrPath } : {}),
+    });
   } finally {
     stopCodexHeartbeat(heartbeat);
   }
@@ -670,7 +683,9 @@ updateAutomergeProgressStatus({
 });
 
 function isRetryableCodexFailure(...values: JsonValue[]) {
-  const message = values.flat().map(String).join("\n");
+  const messages = values.flat().map(String);
+  const message = messages.join("\n");
+  if (messages.some((value) => isTerminalCodexErrorMessage(value))) return false;
   return (
     isRetryableCodexTransportError(message) ||
     /Codex .*(?:timed out|failed|exited)|Codex produced no structured result/i.test(message)
@@ -680,7 +695,7 @@ function isRetryableCodexFailure(...values: JsonValue[]) {
 function isBlockedFixError(error: JsonValue) {
   if (isRepairBranchPushRace(error)) return true;
   if (isRepairBranchPushBlocked(error)) return true;
-  if (isRetryableCodexTransportError(String(error?.message ?? error))) return true;
+  if (isRetryableCodexErrorMessage(String(error?.message ?? error))) return true;
   if (isCodexContextLimitError(String(error?.message ?? error))) return true;
   return /Codex produced no target repo changes|Codex \/review did not pass|Codex (?:fix worker|review-fix worker|\/review) timed out|Codex (?:fix worker|review-fix worker|\/review) failed|validation command failed|command timed out after \d+ms: git (?:fetch|push)|rebase (?:conflicts remain unresolved|produced additional conflicts)/i.test(
     String(error?.message ?? error),
@@ -1982,18 +1997,10 @@ function editValidatePrepareMerge({
           encoding: "utf8",
           env: codexEnv(),
           timeout: workerTimeoutMs,
-          maxBuffer: codexStdioMaxBuffer,
+          stdoutPath: path.join(workRoot, `${mode}-codex-${attempt}.jsonl`),
+          stderrPath: path.join(workRoot, `${mode}-codex-${attempt}.stderr.log`),
         },
       );
-      fs.writeFileSync(
-        path.join(workRoot, `${mode}-codex-${attempt}.jsonl`),
-        codexResult.stdout ?? "",
-      );
-      if (codexResult.stderr)
-        fs.writeFileSync(
-          path.join(workRoot, `${mode}-codex-${attempt}.stderr.log`),
-          codexResult.stderr,
-        );
       if ((codexResult.error as JsonValue)?.code === "ETIMEDOUT") {
         throw new Error(`Codex fix worker timed out after ${workerTimeoutMs}ms`);
       }
@@ -2002,7 +2009,7 @@ function editValidatePrepareMerge({
           codexResult,
           codexResult.error.message || String(codexResult.error),
         );
-        if (attempt < maxEditAttempts && isRetryableCodexTransportError(errorDetail)) {
+        if (attempt < maxEditAttempts && isRetryableCodexErrorMessage(errorDetail)) {
           previousSummary = compactText(errorDetail, 360);
           const retryDelayMs = codexRetryDelayMs(errorDetail, attempt);
           logProgress("retrying Codex edit pass after transient transport error", {
@@ -2025,7 +2032,7 @@ function editValidatePrepareMerge({
       }
       if (codexResult.status !== 0) {
         const errorDetail = codexFailureDetail(codexResult, "Codex fix worker failed");
-        if (attempt < maxEditAttempts && isRetryableCodexTransportError(errorDetail)) {
+        if (attempt < maxEditAttempts && isRetryableCodexErrorMessage(errorDetail)) {
           previousSummary = compactText(errorDetail, 360);
           const retryDelayMs = codexRetryDelayMs(errorDetail, attempt);
           logProgress("retrying Codex edit pass after transient transport error", {
@@ -2325,18 +2332,16 @@ function runCodexBaseReconcile({
         encoding: "utf8",
         env: codexEnv(),
         timeout: reconcileTimeoutMs,
-        maxBuffer: codexStdioMaxBuffer,
+        stdoutPath: path.join(
+          workRoot,
+          `${mode}-final-base-reconcile-${attempt}-${codexAttempt}.jsonl`,
+        ),
+        stderrPath: path.join(
+          workRoot,
+          `${mode}-final-base-reconcile-${attempt}-${codexAttempt}.stderr.log`,
+        ),
       },
     );
-    fs.writeFileSync(
-      path.join(workRoot, `${mode}-final-base-reconcile-${attempt}-${codexAttempt}.jsonl`),
-      codexResult.stdout ?? "",
-    );
-    if (codexResult.stderr)
-      fs.writeFileSync(
-        path.join(workRoot, `${mode}-final-base-reconcile-${attempt}-${codexAttempt}.stderr.log`),
-        codexResult.stderr,
-      );
     if ((codexResult.error as JsonValue)?.code === "ETIMEDOUT") {
       throw new Error(`Codex final rebase worker timed out after ${reconcileTimeoutMs}ms`);
     }
@@ -2409,12 +2414,10 @@ function runCodexWritePreflight() {
       encoding: "utf8",
       env: codexEnv(),
       timeout: codexPreflightTimeoutMs,
-      maxBuffer: 16 * 1024 * 1024,
+      stdoutPath: path.join(workRoot, "codex-write-preflight.jsonl"),
+      stderrPath: path.join(workRoot, "codex-write-preflight.stderr.log"),
     },
   );
-  fs.writeFileSync(path.join(workRoot, "codex-write-preflight.jsonl"), child.stdout ?? "");
-  if (child.stderr)
-    fs.writeFileSync(path.join(workRoot, "codex-write-preflight.stderr.log"), child.stderr);
 
   if ((child.error as JsonValue)?.code === "ETIMEDOUT") {
     return blockedCodexWritePreflight(
@@ -2454,34 +2457,14 @@ function blockedCodexWritePreflight(reason: string, detail: string) {
 
 function codexFailureDetail(child: LooseRecord, fallback: string) {
   const detail =
-    extractCodexJsonlFailure(child.stdout) ??
-    extractCodexJsonlFailure(child.stderr) ??
+    codexJsonlFailureDetail(String(child.stdout ?? "")) ||
+    codexJsonlFailureDetail(String(child.stderr ?? "")) ||
     stripAnsi(String(child.stderr ?? child.stdout ?? "")).trim();
   return detail || fallback;
 }
 
 function codexFailureMessage(label: string, detail: string) {
   return `${label}: ${compactText(stripAnsi(detail || "no Codex output"), 900)}`;
-}
-
-function extractCodexJsonlFailure(value: JsonValue) {
-  const messages: string[] = [];
-  for (const line of String(value ?? "").split(/\r?\n/)) {
-    if (!line.trim()) continue;
-    let event;
-    try {
-      event = JSON.parse(line);
-    } catch {
-      continue;
-    }
-    if (event?.type === "error" && typeof event.message === "string") {
-      messages.push(event.message);
-    }
-    if (event?.type === "turn.failed" && typeof event.error?.message === "string") {
-      messages.push(event.error.message);
-    }
-  }
-  return messages.length > 0 ? messages[messages.length - 1] : null;
 }
 
 function stripAnsi(value: string) {
@@ -2781,18 +2764,10 @@ function runCodexReview({
       encoding: "utf8",
       env: codexEnv(),
       timeout: reviewTimeoutMs,
-      maxBuffer: codexStdioMaxBuffer,
+      stdoutPath: path.join(workRoot, `${mode}-codex-review-${attempt}.jsonl`),
+      stderrPath: path.join(workRoot, `${mode}-codex-review-${attempt}.stderr.log`),
     },
   );
-  fs.writeFileSync(
-    path.join(workRoot, `${mode}-codex-review-${attempt}.jsonl`),
-    child.stdout ?? "",
-  );
-  if (child.stderr)
-    fs.writeFileSync(
-      path.join(workRoot, `${mode}-codex-review-${attempt}.stderr.log`),
-      child.stderr,
-    );
   if ((child.error as JsonValue)?.code === "ETIMEDOUT")
     throw new Error(`Codex /review timed out after ${reviewTimeoutMs}ms`);
   if (child.error) throw new Error(child.error.message || String(child.error));
@@ -2902,18 +2877,10 @@ function runCodexReviewFix({ fixArtifact, targetDir, mode, review, attempt }: Lo
       encoding: "utf8",
       env: codexEnv(),
       timeout: reviewFixTimeoutMs,
-      maxBuffer: codexStdioMaxBuffer,
+      stdoutPath: path.join(workRoot, `${mode}-codex-review-fix-${attempt}.jsonl`),
+      stderrPath: path.join(workRoot, `${mode}-codex-review-fix-${attempt}.stderr.log`),
     },
   );
-  fs.writeFileSync(
-    path.join(workRoot, `${mode}-codex-review-fix-${attempt}.jsonl`),
-    child.stdout ?? "",
-  );
-  if (child.stderr)
-    fs.writeFileSync(
-      path.join(workRoot, `${mode}-codex-review-fix-${attempt}.stderr.log`),
-      child.stderr,
-    );
   if ((child.error as JsonValue)?.code === "ETIMEDOUT")
     throw new Error(`Codex review-fix worker timed out after ${reviewFixTimeoutMs}ms`);
   if (child.error) throw new Error(child.error.message || String(child.error));
@@ -2989,18 +2956,10 @@ function runCodexValidationFix({
       encoding: "utf8",
       env: codexEnv(),
       timeout: validationFixTimeoutMs,
-      maxBuffer: codexStdioMaxBuffer,
+      stdoutPath: path.join(workRoot, `${mode}-codex-validation-fix-${attempt}.jsonl`),
+      stderrPath: path.join(workRoot, `${mode}-codex-validation-fix-${attempt}.stderr.log`),
     },
   );
-  fs.writeFileSync(
-    path.join(workRoot, `${mode}-codex-validation-fix-${attempt}.jsonl`),
-    child.stdout ?? "",
-  );
-  if (child.stderr)
-    fs.writeFileSync(
-      path.join(workRoot, `${mode}-codex-validation-fix-${attempt}.stderr.log`),
-      child.stderr,
-    );
   if ((child.error as JsonValue)?.code === "ETIMEDOUT")
     throw new Error(`Codex validation-fix worker timed out after ${validationFixTimeoutMs}ms`);
   if (child.error) throw new Error(child.error.message || String(child.error));

--- a/src/repair/run-worker.ts
+++ b/src/repair/run-worker.ts
@@ -4,6 +4,12 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { spawn, spawnSync } from "node:child_process";
+import {
+  appendCodexOutputCapture,
+  closeCodexOutputCapture,
+  codexOutputTail,
+  openCodexOutputCapture,
+} from "../codex-output-capture.js";
 import { deterministicAutomergeResult } from "./deterministic-automerge-result.js";
 import {
   assertAllowedOwner,
@@ -37,8 +43,6 @@ const resultRepairTimeoutMs = Number(
 );
 const codexReasoningEffort = repairCodexReasoningEffort();
 const codexServiceTier = repairCodexServiceTier();
-const codexStdioMaxBuffer =
-  Math.max(1, Number(process.env.CLAWSWEEPER_CODEX_STDIO_MAX_BUFFER_MB ?? 128)) * 1024 * 1024;
 const codexHeartbeatMs = Math.max(
   10_000,
   Number(process.env.CLAWSWEEPER_CODEX_HEARTBEAT_MS ?? 60_000),
@@ -247,22 +251,16 @@ function spawnCodexWithHeartbeat({
 }: LooseRecord): Promise<LooseRecord> {
   return new Promise((resolve) => {
     const startedAt = Date.now();
-    let stdout = "";
-    let stderr = "";
-    let stdoutBytes = 0;
-    let stderrBytes = 0;
     let settled = false;
     let timeoutError: Error | null = null;
-    let bufferError: Error | null = null;
+    const stdout = openCodexOutputCapture(codexTranscriptPath);
+    const stderr = openCodexOutputCapture(stderrPath);
 
     const child = spawn("codex", commandArgs, {
       cwd,
       env: codexEnv(),
       stdio: ["pipe", "pipe", "pipe"],
     });
-
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
 
     const heartbeat = setInterval(() => {
       const elapsedSeconds = Math.round((Date.now() - startedAt) / 1000);
@@ -284,40 +282,36 @@ function spawnCodexWithHeartbeat({
       settled = true;
       clearInterval(heartbeat);
       clearTimeout(timeout);
-      fs.writeFileSync(codexTranscriptPath, stdout);
-      if (stderr) fs.writeFileSync(stderrPath, stderr);
+      closeCodexOutputCapture(stdout);
+      closeCodexOutputCapture(stderr);
       resolve(result);
     };
 
-    const append = (stream: "stdout" | "stderr", chunk: JsonValue) => {
-      const text = String(chunk ?? "");
-      const bytes = Buffer.byteLength(text);
+    const append = (stream: "stdout" | "stderr", chunk: Buffer) => {
       if (stream === "stdout") {
-        stdout += text;
-        stdoutBytes += bytes;
+        appendCodexOutputCapture(stdout, chunk);
       } else {
-        stderr += text;
-        stderrBytes += bytes;
-      }
-      if (stdoutBytes + stderrBytes > codexStdioMaxBuffer && !bufferError) {
-        bufferError = new Error(`Codex output exceeded ${codexStdioMaxBuffer} bytes`);
-        (bufferError as LooseRecord).code = "ENOBUFS";
-        child.kill("SIGTERM");
+        appendCodexOutputCapture(stderr, chunk);
       }
     };
 
     child.stdout.on("data", (chunk) => append("stdout", chunk));
     child.stderr.on("data", (chunk) => append("stderr", chunk));
     child.on("error", (error) => {
-      finish({ status: null, stdout, stderr, error });
+      finish({
+        status: null,
+        stdout: codexOutputTail(stdout),
+        stderr: codexOutputTail(stderr),
+        error,
+      });
     });
     child.on("close", (status, signal) => {
       finish({
         status,
         signal,
-        stdout,
-        stderr,
-        error: timeoutError ?? bufferError ?? undefined,
+        stdout: codexOutputTail(stdout),
+        stderr: codexOutputTail(stderr),
+        error: timeoutError ?? undefined,
       });
     });
     child.stdin.end(input);

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -5553,7 +5553,63 @@ test("failed review retry eligibility treats Codex rate limits as infrastructure
     number: 250,
   }).replace(
     "Codex worker timed out after 600000ms with ETIMEDOUT.",
-    "stream disconnected: Rate limit reached for hidden-model (for limit test) on tokens per min (TPM). Please try again in 581ms.",
+    [
+      "stream disconnected: Rate limit reached for hidden-model (for limit test) on tokens per min (TPM). Please try again in 581ms.",
+      "ERROR: The model quoted-model does not exist or you do not have access to it.",
+    ].join("\n"),
+  );
+
+  assert.equal(isInfrastructureFailedReviewForTest(markdown), true);
+});
+
+test("failed review retry eligibility treats model access failures as terminal", () => {
+  const markdown = failedReviewReport({ review_terminal_failure: true })
+    .replaceAll(
+      "Codex review failed: timeout.",
+      "Codex review failed: model unavailable or access denied.",
+    )
+    .replaceAll(
+      "Codex worker timed out after 600000ms with ETIMEDOUT.",
+      [
+        "ERROR: stream disconnected before completion: The model hidden-model does not exist or you do not have access to it.",
+        "- **codex terminal error:** ERROR: stream disconnected before completion: The model hidden-model does not exist or you do not have access to it.",
+      ].join("\n"),
+    );
+
+  assert.equal(isInfrastructureFailedReviewForTest(markdown), false);
+  assert.equal(
+    failedReviewRetryEligibilityForTest({
+      markdown,
+      liveState: "open",
+      liveHeadSha: "abc123def456",
+      now: Date.parse("2026-06-05T20:00:00Z"),
+      maxAttempts: 2,
+      cooldownMs: 45 * 60 * 1000,
+    }).action,
+    "skipped_non_infrastructure_failure",
+  );
+});
+
+test("failed review retry ignores terminal-looking text outside dedicated evidence", () => {
+  const markdown = failedReviewReport().replace(
+    "## Summary",
+    [
+      "Contributor-controlled text: ERROR: The model hidden-model does not exist or you do not have access to it.",
+      "",
+      "## Summary",
+    ].join("\n"),
+  );
+
+  assert.equal(isInfrastructureFailedReviewForTest(markdown), true);
+});
+
+test("failed review retry ignores terminal-looking text injected into rendered evidence", () => {
+  const markdown = failedReviewReport().replace(
+    "Codex worker timed out after 600000ms with ETIMEDOUT.",
+    [
+      "Codex worker timed out after 600000ms with ETIMEDOUT.",
+      "- **codex terminal error:** ERROR: The model fake does not exist or you do not have access to it.",
+    ].join("\n"),
   );
 
   assert.equal(isInfrastructureFailedReviewForTest(markdown), true);
@@ -14671,11 +14727,13 @@ process.exit(1);
 });
 
 test("codex failure decisions expose stderr and stdout separately", () => {
+  const errorMessage =
+    "Rate limit reached for gpt-test on tokens per min (TPM). Please try again in 1ms.";
   const decision = codexFailureDecisionForTest(
     1,
     "Codex review failed for #278 with exit 1.",
-    "startup banner",
-    "Rate limit reached for gpt-test on tokens per min (TPM)",
+    JSON.stringify({ type: "turn.failed", error: { message: errorMessage } }),
+    "user\nThe reviewed prompt discusses rate limits.",
   );
 
   assert.equal(
@@ -14684,12 +14742,69 @@ test("codex failure decisions expose stderr and stdout separately", () => {
   );
   assert.equal(
     decision.evidence.find((entry) => entry.label === "codex stderr")?.detail,
-    "Rate limit reached for [REDACTED_INTERNAL_MODEL] on tokens per min (TPM)",
+    "user\nThe reviewed prompt discusses rate limits.",
+  );
+  assert.match(
+    decision.evidence.find((entry) => entry.label === "codex stdout")?.detail ?? "",
+    /"type":"turn.failed"/,
+  );
+});
+
+test("codex failure decisions do not infer buffer overflow from reviewed content", () => {
+  const terminalError =
+    "stream disconnected before completion: The model secret-model-for-test does not exist or you do not have access to it.";
+  const decision = codexFailureDecisionForTest(
+    1,
+    "Codex review failed for #89041 with exit 1.",
+    JSON.stringify({ type: "turn.failed", error: { message: terminalError } }),
+    "user\nThe reviewed PR discusses maxBufferedChunks and maxBuffer behavior.",
+  );
+
+  assert.equal(
+    decision.summary,
+    "Codex review failed: model unavailable or access denied (exit 1).",
   );
   assert.equal(
-    decision.evidence.find((entry) => entry.label === "codex stdout")?.detail,
-    "startup banner",
+    decision.evidence.find((entry) => entry.label === "codex terminal error")?.detail,
+    terminalError,
   );
+  assert.equal(decision.codexTerminalFailure, true);
+});
+
+test("codex failure decisions classify structured ENOBUFS as output overflow", () => {
+  const decision = codexFailureDecisionForTest(
+    null,
+    "Codex review failed before producing output.",
+    "",
+    "",
+    { errorCode: "ENOBUFS", signal: "SIGTERM" },
+  );
+
+  assert.equal(decision.summary, "Codex review failed: output buffer overflow.");
+  assert.equal(
+    decision.evidence.find((entry) => entry.label === "process error code")?.detail,
+    "ENOBUFS",
+  );
+  assert.equal(
+    decision.evidence.find((entry) => entry.label === "process signal")?.detail,
+    "SIGTERM",
+  );
+});
+
+test("codex failure decisions ignore unstructured output and prompt stderr", () => {
+  const decision = codexFailureDecisionForTest(
+    1,
+    "Codex review failed for #92565 with exit 1.",
+    "ERROR: The model quoted-model does not exist or you do not have access to it.",
+    "ERROR: fetch failed",
+  );
+
+  assert.equal(decision.summary, "Codex review failed: codex execution failed (exit 1).");
+  assert.equal(
+    decision.evidence.find((entry) => entry.label === "codex terminal error"),
+    undefined,
+  );
+  assert.equal(decision.codexTerminalFailure, false);
 });
 
 test("runCodex retries a transient failure in a fresh process", () => {
@@ -14713,7 +14828,13 @@ const attemptsPath = process.env.CODEX_ATTEMPTS_PATH;
 const attempt = fs.existsSync(attemptsPath) ? Number(fs.readFileSync(attemptsPath, "utf8")) + 1 : 1;
 fs.writeFileSync(attemptsPath, String(attempt));
 if (attempt === 1) {
-  process.stderr.write("stream disconnected: Rate limit reached for secret-model-for-test (for limit test) on tokens per min (TPM). Please try again in 1ms.\\n");
+  process.stderr.write("user\\nERROR: The model contributor-quoted-model does not exist or you do not have access to it.\\n");
+  process.stdout.write(JSON.stringify({
+    type: "turn.failed",
+    error: {
+      message: "stream disconnected: Rate limit reached for secret-model-for-test (for limit test) on tokens per min (TPM). Please try again in 1ms."
+    }
+  }) + "\\n");
   process.exit(1);
 }
 const outputIndex = process.argv.indexOf("--output-last-message");
@@ -14762,6 +14883,75 @@ fs.writeFileSync(process.argv[outputIndex + 1], process.env.CODEX_DECISION_JSON)
 
     assert.equal(readFileSync(attemptsPath, "utf8"), "2");
     assert.equal(decision.summary, "Review completed after a fresh Codex process.");
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("runCodex does not retry terminal model access failures", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const openclawDir = join(root, "openclaw");
+  const workDir = join(root, "codex-work");
+  const binDir = join(root, "bin");
+  const attemptsPath = join(root, "attempts");
+  mkdirSync(openclawDir, { recursive: true });
+  mkdirSync(binDir, { recursive: true });
+  execFileSync("git", ["init"], { cwd: openclawDir, stdio: "ignore" });
+  const codexPath = join(binDir, "codex");
+  writeFileSync(
+    codexPath,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const attemptsPath = process.env.CODEX_ATTEMPTS_PATH;
+const attempt = fs.existsSync(attemptsPath) ? Number(fs.readFileSync(attemptsPath, "utf8")) + 1 : 1;
+fs.writeFileSync(attemptsPath, String(attempt));
+process.stdout.write(JSON.stringify({
+  type: "turn.failed",
+  error: {
+    message: "stream disconnected before completion: The model secret-model-for-test does not exist or you do not have access to it."
+  }
+}) + "\\n");
+process.exit(1);
+`,
+  );
+  chmodSync(codexPath, 0o755);
+  const previous = {
+    PATH: process.env.PATH,
+    CODEX_ATTEMPTS_PATH: process.env.CODEX_ATTEMPTS_PATH,
+    CLAWSWEEPER_CODEX_REVIEW_ATTEMPTS: process.env.CLAWSWEEPER_CODEX_REVIEW_ATTEMPTS,
+    CLAWSWEEPER_CODEX_REVIEW_RETRY_DELAY_MS: process.env.CLAWSWEEPER_CODEX_REVIEW_RETRY_DELAY_MS,
+  };
+  process.env.PATH = `${binDir}${delimiter}${process.env.PATH ?? ""}`;
+  process.env.CODEX_ATTEMPTS_PATH = attemptsPath;
+  process.env.CLAWSWEEPER_CODEX_REVIEW_ATTEMPTS = "3";
+  process.env.CLAWSWEEPER_CODEX_REVIEW_RETRY_DELAY_MS = "1";
+  try {
+    assert.throws(
+      () =>
+        runCodexForTest({
+          item: item({ number: 89041 }),
+          context: { issue: {}, comments: [], timeline: [] },
+          git: { mainSha: "abc123", latestRelease: null },
+          model: "internal",
+          openclawDir,
+          reasoningEffort: "high",
+          sandboxMode: "read-only",
+          serviceTier: "",
+          timeoutMs: 10_000,
+          workDir,
+          prompt: "Return a review decision.",
+        }),
+      (error: unknown) => {
+        const reviewError = error as Error & { stdout?: string };
+        assert.match(reviewError.stdout ?? "", /does not exist or you do not have access/);
+        return true;
+      },
+    );
+    assert.equal(readFileSync(attemptsPath, "utf8"), "1");
   } finally {
     for (const [key, value] of Object.entries(previous)) {
       if (value === undefined) delete process.env[key];
@@ -17778,7 +17968,7 @@ test("sweep workflow runs exact event reviews without a global worker gate", () 
   assert.doesNotMatch(eventReviewBlock, /Waiting for review capacity/);
 });
 
-test("Codex workflows install latest CLI and keep the actual model secret", () => {
+test("Codex workflows install pinned CLI releases and keep the model secret", () => {
   const action = readFileSync(".github/actions/setup-codex/action.yml", "utf8");
   const workflows = [
     ".github/workflows/assist.yml",
@@ -17789,11 +17979,13 @@ test("Codex workflows install latest CLI and keep the actual model secret", () =
     ".github/workflows/sweep.yml",
   ].map((file) => readFileSync(file, "utf8"));
 
-  assert.match(action, /@openai\/codex@latest/);
-  assert.match(action, /@openai\/codex-responses-api-proxy@latest/);
+  assert.match(action, /codex-version:[\s\S]*default: "0\.139\.0"/);
+  assert.match(action, /proxy-version:[\s\S]*default: "0\.139\.0"/);
+  assert.match(action, /@openai\/codex@\$\{\{ inputs\['codex-version'\] \}\}/);
+  assert.match(action, /@openai\/codex-responses-api-proxy@\$\{\{ inputs\['proxy-version'\] \}\}/);
+  assert.doesNotMatch(action, /@latest/);
   assert.match(action, /env -u OPENAI_API_KEY[\s\S]*-u CLAWSWEEPER_INTERNAL_MODEL/);
   assert.equal(action.match(/--ignore-scripts/g)?.length, 2);
-  assert.doesNotMatch(action, /inputs\['version'\]/);
   for (const workflow of workflows) {
     assert.match(workflow, /CLAWSWEEPER_MODEL: internal/);
     assert.match(workflow, /CLAWSWEEPER_INTERNAL_MODEL: \$\{\{ secrets\.CLAWSWEEPER_MODEL \}\}/);
@@ -17806,11 +17998,45 @@ test("Codex workflows install latest CLI and keep the actual model secret", () =
   }
 });
 
+test("background review fanout keeps per-review transient recovery", () => {
+  const workflow = readFileSync(".github/workflows/sweep.yml", "utf8");
+  const reviewStart = workflow.indexOf("\n  review:");
+  const publishStart = workflow.indexOf("\n  publish:", reviewStart);
+  const reviewJob = workflow.slice(reviewStart, publishStart);
+
+  assert.doesNotMatch(workflow, /\n  codex-smoke:/);
+  assert.match(reviewJob, /needs: plan/);
+  assert.doesNotMatch(reviewJob, /smoke-test/);
+  assert.match(workflow, /publish:[\s\S]*needs: \[plan, review\]/);
+});
+
+test("synchronous Codex review surfaces use the shared bounded runner", () => {
+  for (const file of [
+    "src/clawsweeper.ts",
+    "src/commit-sweeper.ts",
+    "src/pr-close-coverage-proof.ts",
+  ]) {
+    const source = readFileSync(file, "utf8");
+    assert.match(source, /runCodexProcess/);
+    assert.doesNotMatch(source, /spawnSync\(\s*"codex"/);
+  }
+  assert.match(
+    readFileSync("src/clawsweeper.ts", "utf8"),
+    /"--output-last-message",\s*outputPath,\s*"--json"/,
+  );
+});
+
 test("failed Codex workers use bounded automatic retry paths", () => {
   const worker = readFileSync("src/repair/run-worker.ts", "utf8");
+  const outputCapture = readFileSync("src/codex-output-capture.ts", "utf8");
   const executor = readFileSync("src/repair/execute-fix-artifact.ts", "utf8");
   const selfHeal = readFileSync("src/repair/self-heal-failed-runs.ts", "utf8");
 
+  assert.match(worker, /appendCodexOutputCapture/);
+  assert.match(worker, /openCodexOutputCapture\(codexTranscriptPath\)/);
+  assert.match(outputCapture, /DEFAULT_CODEX_OUTPUT_FILE_BYTES = 128 \* 1024 \* 1024/);
+  assert.match(outputCapture, /Codex output truncated; final tail follows/);
+  assert.doesNotMatch(worker, /Codex output exceeded|CLAWSWEEPER_CODEX_STDIO_MAX_BUFFER_MB/);
   assert.match(worker, /Codex worker timed out[\s\S]*process\.exit\(1\)/);
   assert.match(
     worker,

--- a/test/codex-process.test.ts
+++ b/test/codex-process.test.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import test from "node:test";
+
+import { codexProcessErrorCode, runCodexProcess } from "../dist/codex-process.js";
+
+const tmpPrefix = join(tmpdir(), "clawsweeper-codex-process-test-");
+
+test("Codex process captures bounded rolling tails without terminating large output", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const binDir = join(root, "bin");
+  const stdoutPath = join(root, "codex.stdout.log");
+  const stderrPath = join(root, "codex.stderr.log");
+  mkdirSync(binDir, { recursive: true });
+  const codexPath = join(binDir, "codex");
+  writeFileSync(
+    codexPath,
+    `#!/usr/bin/env node
+process.stdout.write("s".repeat(16 * 1024 * 1024) + "stdout-tail-marker");
+process.stderr.write("e".repeat(16 * 1024 * 1024) + "stderr-tail-marker");
+`,
+  );
+  chmodSync(codexPath, 0o755);
+
+  try {
+    const result = runCodexProcess({
+      args: [],
+      cwd: root,
+      env: { ...process.env, PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}` },
+      input: "",
+      timeoutMs: 10_000,
+      tailBytes: 4096,
+      stdoutPath,
+      stderrPath,
+    });
+
+    assert.equal(result.status, 0);
+    assert.equal(result.signal, null);
+    assert.equal(result.error, undefined);
+    assert.ok(Buffer.byteLength(result.stdout) <= 4096);
+    assert.ok(Buffer.byteLength(result.stderr) <= 4096);
+    assert.match(result.stdout, /stdout-tail-marker$/);
+    assert.match(result.stderr, /stderr-tail-marker$/);
+    assert.equal(readFileSync(stdoutPath, "utf8").length, 16 * 1024 * 1024 + 18);
+    assert.equal(readFileSync(stderrPath, "utf8").length, 16 * 1024 * 1024 + 18);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("Codex process caps durable logs while preserving the final output tail", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const binDir = join(root, "bin");
+  const stdoutPath = join(root, "codex.stdout.log");
+  const stderrPath = join(root, "codex.stderr.log");
+  mkdirSync(binDir, { recursive: true });
+  const codexPath = join(binDir, "codex");
+  writeFileSync(
+    codexPath,
+    `#!/usr/bin/env node
+process.stdout.write("s".repeat(2 * 1024 * 1024) + "stdout-tail-marker");
+process.stderr.write("e".repeat(2 * 1024 * 1024) + "stderr-tail-marker");
+`,
+  );
+  chmodSync(codexPath, 0o755);
+
+  try {
+    const outputFileBytes = 1024 * 1024;
+    const result = runCodexProcess({
+      args: [],
+      cwd: root,
+      env: { ...process.env, PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}` },
+      input: "",
+      timeoutMs: 10_000,
+      tailBytes: 4096,
+      outputFileBytes,
+      stdoutPath,
+      stderrPath,
+    });
+
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /stdout-tail-marker$/);
+    assert.match(result.stderr, /stderr-tail-marker$/);
+    for (const [filePath, tailMarker] of [
+      [stdoutPath, "stdout-tail-marker"],
+      [stderrPath, "stderr-tail-marker"],
+    ] as const) {
+      const output = readFileSync(filePath);
+      assert.equal(output.length, outputFileBytes);
+      assert.match(output.toString("utf8"), /Codex output truncated; final tail follows/);
+      assert.match(output.toString("utf8"), new RegExp(`${tailMarker}$`));
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("Codex process preserves timeout errors and kills a child that ignores SIGTERM", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const binDir = join(root, "bin");
+  const pidPath = join(root, "codex.pid");
+  mkdirSync(binDir, { recursive: true });
+  const codexPath = join(binDir, "codex");
+  writeFileSync(
+    codexPath,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+fs.writeFileSync(process.env.CODEX_TEST_PID_PATH, String(process.pid));
+process.stderr.write("timeout-tail-marker\\n");
+process.on("SIGTERM", () => {});
+setInterval(() => {}, 1000);
+`,
+  );
+  chmodSync(codexPath, 0o755);
+
+  try {
+    const result = runCodexProcess({
+      args: [],
+      cwd: root,
+      env: {
+        ...process.env,
+        CODEX_TEST_PID_PATH: pidPath,
+        PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}`,
+      },
+      input: "",
+      timeoutMs: 1000,
+    });
+
+    assert.equal(codexProcessErrorCode(result.error), "ETIMEDOUT");
+    assert.match(result.stderr, /timeout-tail-marker/);
+    const pid = Number(readFileSync(pidPath, "utf8"));
+    assert.throws(
+      () => process.kill(pid, 0),
+      (error: unknown) => (error as NodeJS.ErrnoException).code === "ESRCH",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/repair/codex-transient.test.ts
+++ b/test/repair/codex-transient.test.ts
@@ -1,9 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  codexJsonlFailureDetail,
   codexRetryDelayMs,
   isCodexContextLimitError,
+  isRetryableCodexErrorMessage,
   isRetryableCodexTransportError,
+  isTerminalCodexErrorMessage,
 } from "../../dist/codex-transient.js";
 
 test("Codex closed-stdin tool transport errors are retryable", () => {
@@ -28,6 +31,36 @@ test("Codex TPM rate-limit errors are retryable transport failures", () => {
     "stream disconnected before completion: Rate limit reached for gpt-5.5 on tokens per min (TPM): Limit 40000000, Used 40000000, Requested 126092. Please try again in 189ms.";
   assert.equal(isRetryableCodexTransportError(message), true);
   assert.equal(isCodexContextLimitError(message), false);
+});
+
+test("Codex model access failures are terminal even when the stream disconnects", () => {
+  const message =
+    "ERROR: stream disconnected before completion: The model secret-model-for-test does not exist or you do not have access to it.";
+  assert.equal(isRetryableCodexTransportError(message), true);
+  assert.equal(isRetryableCodexErrorMessage(message), false);
+});
+
+test("Codex JSONL model access errors are trusted terminal failures", () => {
+  const message =
+    "stream disconnected before completion: The model secret-model-for-test does not exist or you do not have access to it.";
+  const jsonl = [
+    JSON.stringify({ type: "error", message: "fetch failed" }),
+    JSON.stringify({ type: "turn.failed", error: { message } }),
+  ].join("\n");
+
+  assert.equal(codexJsonlFailureDetail(jsonl), message);
+  assert.equal(isTerminalCodexErrorMessage(message), true);
+  assert.equal(isRetryableCodexErrorMessage(message), false);
+});
+
+test("quoted model access failures do not override the final Codex error", () => {
+  const message = [
+    "user",
+    "ERROR: stream disconnected before completion: The model quoted-model does not exist or you do not have access to it.",
+    "ERROR: stream disconnected before completion: fetch failed",
+  ].join("\n");
+  assert.equal(isRetryableCodexTransportError(message), true);
+  assert.equal(isRetryableCodexErrorMessage(message), true);
 });
 
 test("Codex context-limit errors are blocked automation outcomes", () => {

--- a/test/repair/codex-transient.test.ts
+++ b/test/repair/codex-transient.test.ts
@@ -63,6 +63,14 @@ test("quoted model access failures do not override the final Codex error", () =>
   assert.equal(isRetryableCodexErrorMessage(message), true);
 });
 
+test("Codex terminal classification stays bounded on repeated model prefixes", () => {
+  const message = `${"the model ".repeat(20_000)}missing suffix`;
+  const startedAt = performance.now();
+
+  assert.equal(isTerminalCodexErrorMessage(message), false);
+  assert.ok(performance.now() - startedAt < 500);
+});
+
 test("Codex context-limit errors are blocked automation outcomes", () => {
   assert.equal(
     isCodexContextLimitError("Error: Requested 142470. Please try again with a smaller input."),

--- a/test/repair/execute-fix-artifact-source.test.ts
+++ b/test/repair/execute-fix-artifact-source.test.ts
@@ -91,3 +91,42 @@ test("merged source replacement skip runs before publishing replacement PRs", ()
     /reason: "source PR already merged and replacement branch has no changes versus base"/,
   );
 });
+
+test("terminal Codex failures do not request repair requeue", () => {
+  const sourcePath = path.join(process.cwd(), "src/repair/execute-fix-artifact.ts");
+  const source = fs.readFileSync(sourcePath, "utf8");
+  const helperStart = source.indexOf("function isRetryableCodexFailure(");
+  const helperEnd = source.indexOf("function isBlockedFixError(", helperStart);
+
+  assert.notEqual(helperStart, -1);
+  assert.notEqual(helperEnd, -1);
+  const helper = source.slice(helperStart, helperEnd);
+  const terminalGuardIndex = helper.indexOf(
+    "if (messages.some((value) => isTerminalCodexErrorMessage(value))) return false;",
+  );
+  const broadFallbackIndex = helper.indexOf("/Codex .*(?:timed out|failed|exited)");
+
+  assert.notEqual(terminalGuardIndex, -1);
+  assert.notEqual(broadFallbackIndex, -1);
+  assert.ok(
+    terminalGuardIndex < broadFallbackIndex,
+    "terminal model-access failures must be rejected before the broad Codex failure fallback",
+  );
+});
+
+test("repair Codex heartbeat wrapper uses bounded process capture", () => {
+  const sourcePath = path.join(process.cwd(), "src/repair/execute-fix-artifact.ts");
+  const source = fs.readFileSync(sourcePath, "utf8");
+  const helperStart = source.indexOf("function spawnCodexSyncWithHeartbeat(");
+  const helperEnd = source.indexOf("function startCodexHeartbeat(", helperStart);
+
+  assert.notEqual(helperStart, -1);
+  assert.notEqual(helperEnd, -1);
+  const helper = source.slice(helperStart, helperEnd);
+  assert.match(helper, /return runCodexProcess\(\{/);
+  assert.match(helper, /\{ stdoutPath: options\.stdoutPath \}/);
+  assert.match(helper, /\{ stderrPath: options\.stderrPath \}/);
+  assert.doesNotMatch(helper, /spawnSync\("codex"/);
+  assert.doesNotMatch(source, /CLAWSWEEPER_CODEX_STDIO_MAX_BUFFER_MB/);
+  assert.doesNotMatch(source, /writeFileSync\([^)]*codexResult\.stdout/);
+});

--- a/test/repair/run-worker.test.ts
+++ b/test/repair/run-worker.test.ts
@@ -57,7 +57,9 @@ test("run-worker starts Codex in the target checkout when one is available", () 
       "  fix_artifact: null,",
       "};",
       "fs.writeFileSync(outputPath, `${JSON.stringify(result, null, 2)}\\n`);",
+      'process.stdout.write("s".repeat(2 * 1024 * 1024));',
       'process.stdout.write(\'{"type":"fake"}\\n\');',
+      'process.stderr.write("e".repeat(2 * 1024 * 1024));',
     ].join("\n"),
     { mode: 0o755 },
   );
@@ -90,6 +92,7 @@ test("run-worker starts Codex in the target checkout when one is available", () 
         FAKE_CODEX_CWD_FILE: cwdFile,
         FAKE_CODEX_ARGS_FILE: argsFile,
         CLAWSWEEPER_INTERNAL_MODEL: "secret-model-for-test",
+        CLAWSWEEPER_CODEX_STDIO_MAX_BUFFER_MB: "1",
         PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
       },
       stdio: "pipe",
@@ -100,6 +103,14 @@ test("run-worker starts Codex in the target checkout when one is available", () 
     assert.equal(args[args.indexOf("--cd") + 1], targetCheckout);
     assert.equal(args.includes("--model"), false);
     assert.equal(args.includes("secret-model-for-test"), false);
+    const runDirs = fs.globSync(
+      path.join(repoRoot, ".clawsweeper-repair/runs/run-worker-target-checkout-plan-*"),
+    );
+    assert.equal(runDirs.length, 1);
+    const runDir = runDirs[0];
+    assert.ok(runDir);
+    assert.ok(fs.statSync(path.join(runDir, "codex.jsonl")).size > 2 * 1024 * 1024);
+    assert.equal(fs.statSync(path.join(runDir, "codex.stderr.log")).size, 2 * 1024 * 1024);
   } finally {
     for (const runDir of fs.globSync(
       path.join(repoRoot, ".clawsweeper-repair/runs/run-worker-target-checkout-plan-*"),

--- a/test/repair/workflow-sparse-checkout.test.ts
+++ b/test/repair/workflow-sparse-checkout.test.ts
@@ -8,6 +8,9 @@ const REPAIR_PROOF_RUNTIME_PATHS = [
   "schema/clawsweeper-pr-close-coverage-proof.schema.json",
   "src/clawsweeper-text.ts",
   "src/codex-env.ts",
+  "src/codex-output-capture.ts",
+  "src/codex-process-worker.ts",
+  "src/codex-process.ts",
   "src/codex-transient.ts",
   "src/pr-close-coverage-proof.ts",
 ] as const;
@@ -28,6 +31,14 @@ test("sparse repair build workflows include PR close proof runtime files", () =>
       assert.ok(entries.has(requiredPath), `${workflowPath} missing ${requiredPath}`);
     }
   }
+});
+
+test("repair build emits the bounded Codex process worker", () => {
+  const config = JSON.parse(fs.readFileSync("tsconfig.repair.json", "utf8")) as {
+    include?: string[];
+  };
+  assert.ok(config.include?.includes("src/codex-output-capture.ts"));
+  assert.ok(config.include?.includes("src/codex-process-worker.ts"));
 });
 
 function sparseCheckoutEntries(workflow: string): Set<string> {

--- a/tsconfig.repair.json
+++ b/tsconfig.repair.json
@@ -15,5 +15,10 @@
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true
   },
-  "include": ["src/repair/**/*.ts", "src/repository-profiles.ts"]
+  "include": [
+    "src/repair/**/*.ts",
+    "src/repository-profiles.ts",
+    "src/codex-output-capture.ts",
+    "src/codex-process-worker.ts"
+  ]
 }


### PR DESCRIPTION
## Summary

- stream Codex stdout/stderr into capped durable files while retaining bounded diagnostic tails
- use typed Codex JSONL failures for terminal model-access handling and require structured `ENOBUFS` for overflow classification
- preserve real subprocess failure details in durable review reports and stop retrying terminal review/repair failures
- pin the Codex CLI and Responses API proxy to exact `0.139.0` releases

## Root cause

ClawSweeper's synchronous Codex review surfaces buffered subprocess output. Large Codex output could terminate the process at the buffer limit, while later diagnostics only retained an incomplete failure. The overflow classifier also matched arbitrary reviewed text containing `maxBuffer`, producing false overflow reports. Separately, structured model-access failures were retried as transport failures.

## Verification

- `pnpm run check` on Node `24.14.0`
  - 463 unit tests passed
  - 501 repair tests passed
  - changed and full coverage gates passed
  - build, lint, and format checks passed
- clean repair-only compile verified the process worker and repair worker artifacts
- focused subprocess scenarios passed:
  - large stdout and stderr complete without buffer termination
  - capped durable logs preserve the final tail
  - timeout diagnostics survive and a SIGTERM-ignoring child is force-killed
  - reviewed `maxBuffer` text does not classify as overflow
  - structured `ENOBUFS` still classifies as overflow
  - terminal model-access errors stop retries/requeues while transient errors retry
- fresh local autoreview completed with no actionable findings

## Real behavior proof

Behavior addressed: Codex review and repair subprocesses no longer fail or lose diagnostics when stdout/stderr exceeds Node's buffered subprocess limit, and terminal failures are classified from trusted structured output.

Real environment tested: Local ClawSweeper checkout on macOS with Node 24.14.0, using fake Codex subprocesses that reproduce large-output, timeout, terminal-error, transient-error, and signal-handling cases.

Exact steps or command run after this patch: `pnpm run check`; clean `tsgo -p tsconfig.repair.json` compile into a temporary output directory; fresh local autoreview.

Evidence after fix: The large-output tests write 16 MiB to both stdout and stderr without terminating, cap durable test logs at the configured limit while retaining the final tail, and preserve timeout/error evidence while killing an unresponsive child.

Observed result after fix: All ClawSweeper gates and focused apparent-failure scenarios pass. Overflow classification now requires structured `ENOBUFS`, and trusted terminal model-access failures stop automatic retries.

What was not tested: An authenticated GitHub Actions review run using repository workflow secrets.


## Maintainer live smoke

Run this from a maintainer checkout with write access to `openclaw/clawsweeper`. A temporary upstream branch is required because `workflow_dispatch` executes the workflow from a ref in the target repository, while the fork PR does not receive repository Codex/App secrets.

The default smoke reviews PR #284 itself. Exact-item sweeps publish state and may refresh the durable ClawSweeper review comment on the selected PR. Both close/apply paths are explicitly disabled.

```bash
set -euo pipefail
repo=openclaw/clawsweeper
upstream=https://github.com/openclaw/clawsweeper.git
smoke_branch="smoke/pr-284-codex-review-runner-$(date -u +%Y%m%d%H%M%S)"
artifact_dir=""
cleanup() {
  test -z "$artifact_dir" || rm -rf "$artifact_dir"
  git push "$upstream" --delete "$smoke_branch" >/dev/null 2>&1 || true
}
trap cleanup EXIT

# Put the exact PR head on a temporary upstream ref without switching branches.
git fetch "$upstream" refs/pull/284/head
git push "$upstream" FETCH_HEAD:refs/heads/$smoke_branch

# Run one real review using this PR's workflow plus repository secrets.
gh workflow run sweep.yml --repo "$repo" --ref "$smoke_branch" \
  -f target_repo=openclaw/clawsweeper \
  -f item_number=284 \
  -f batch_size=1 \
  -f shard_count=1 \
  -f codex_timeout_ms=900000 \
  -f hot_intake=false \
  -f apply_existing=false \
  -f apply_after_review=false

run_id=""
for _ in {1..12}; do
  run_id="$(gh run list --repo "$repo" --workflow sweep.yml --event workflow_dispatch \
    --branch "$smoke_branch" --limit 1 --json databaseId --jq '.[0].databaseId // empty')"
  test -n "$run_id" && break
  sleep 5
done
test -n "$run_id"

watch_status=0
gh run watch "$run_id" --repo "$repo" --exit-status || watch_status=$?

# Inspect the real report and retry/classification logs even if the run failed.
artifact_dir="$(mktemp -d)"
gh run download "$run_id" --repo "$repo" --dir "$artifact_dir"
rg -n '^review_status:|^review_terminal_failure:|Codex review failed|output buffer overflow|ENOBUFS' "$artifact_dir" || true
gh run view "$run_id" --repo "$repo" --log \
  | rg 'codex-cli 0\.139\.0|codex-retry|output buffer overflow|ENOBUFS|does not exist or you do not have access' || true

echo "Run: https://github.com/$repo/actions/runs/$run_id"
exit "$watch_status"
```

Acceptance criteria:

- The setup log installs/runs Codex CLI `0.139.0` from this PR's pinned setup action.
- The report has `review_status: complete` and `review_terminal_failure: false` when repository model access is healthy.
- The review log/report does not contain `ENOBUFS` or `output buffer overflow`.
- The workflow may refresh PR #284's durable review comment/state, but it must not close, repair, or merge anything.
- Keep the Actions run URL as live proof; the cleanup trap deletes the temporary upstream branch.

Optional apparent-failure replay, only when maintainers approve refreshing the durable review comments on openclaw/openclaw#89041 and openclaw/openclaw#92565:

```bash
gh workflow run sweep.yml --repo openclaw/clawsweeper --ref "$smoke_branch" \
  -f target_repo=openclaw/openclaw \
  -f item_numbers=89041,92565 \
  -f batch_size=1 \
  -f shard_count=2 \
  -f codex_timeout_ms=900000 \
  -f hot_intake=false \
  -f apply_existing=false \
  -f apply_after_review=false
```

For that optional replay, #89041 must not be classified as overflow merely because reviewed content contains `maxBuffer`/`maxBufferedChunks`. If #92565 still hits the known model-access failure, its durable report must contain the real failure reason and `review_terminal_failure: true`, with no `codex-retry` for that terminal failure.