### PR TITLE
Derive public PR status labels from report state

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -8110,6 +8110,18 @@ function prStatusLabelKindFromReportLabels(markdown: string): PrStatusLabelKind 
   return PR_STATUS_LABELS.find((label) => rawLabels.includes(label.name))?.kind ?? null;
 }
 
+function prStatusLabelKindFromPublicReport(
+  markdown: string,
+  currentLabels: readonly string[],
+): PrStatusLabelKind | null {
+  const derived = prStatusLabelKindFromReport(
+    markdown,
+    { issue: null, comments: [], timeline: [] },
+    currentLabels,
+  );
+  return derived ?? prStatusLabelKindFromReportLabels(markdown);
+}
+
 function publicMantisRecommendationBlock(recommendation: MantisRecommendation): string {
   if (recommendation.status !== "recommended" || recommendation.scenario === "none") return "";
   const comment = recommendation.maintainerComment.trim();
@@ -12541,7 +12553,7 @@ function desiredClawSweeperLabelsFromPublicReport(
     });
     labels = nextPrStatusLabels(
       labels,
-      options.prStatusKind ?? prStatusLabelKindFromReportLabels(markdown),
+      options.prStatusKind ?? prStatusLabelKindFromPublicReport(markdown, labels),
     );
     labels = nextTelegramVisibleProofLabels(labels, reportTelegramVisibleProof(markdown));
   } else {
@@ -12602,7 +12614,12 @@ function labelTransitionReason(
       : `Current PR rating is ${inlineCode(current)}, so this older rating label is no longer current.`;
   }
   if (PR_STATUS_LABEL_NAMES.has(label)) {
-    const statusKind = options.prStatusKind ?? prStatusLabelKindFromReportLabels(markdown);
+    const statusKind =
+      options.prStatusKind ??
+      prStatusLabelKindFromPublicReport(
+        markdown,
+        options.previousLabels ?? frontMatterStringArray(markdown, "labels"),
+      );
     return action === "add" && statusKind
       ? prStatusLabelForKind(statusKind).description
       : statusKind
@@ -12723,7 +12740,9 @@ function labelJustificationsFromPublicReport(
         `${FEATURE_SHOWCASE_LABEL_DESCRIPTION} ${sentence(featureShowcase.reason)}`,
       );
     }
-    const statusKind = options.prStatusKind ?? prStatusLabelKindFromReportLabels(markdown);
+    const statusKind =
+      options.prStatusKind ??
+      prStatusLabelKindFromPublicReport(markdown, frontMatterStringArray(markdown, "labels"));
     if (statusKind) {
       add(
         prStatusLabelForKind(statusKind).name,

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -4736,6 +4736,64 @@ Full review comments:
   assert.doesNotMatch(comment, /remove `status: 📣 needs proof`/);
 });
 
+test("public PR review details derive ready status instead of preserving stale waiting label", () => {
+  const report = `${reportFrontMatter({
+    type: "pull_request",
+    number: "84008",
+    decision: "keep_open",
+    close_reason: "none",
+    review_status: "complete",
+    confidence: "high",
+    author: "contributor",
+    author_association: "CONTRIBUTOR",
+    labels: JSON.stringify(["status: ⏳ waiting on author"]),
+    work_candidate: "none",
+    triage_priority: "none",
+    impact_labels: JSON.stringify([]),
+    merge_risk_labels: JSON.stringify([]),
+    label_justifications: JSON.stringify([]),
+  })}
+
+## Summary
+
+Keep this PR open for maintainer review.
+
+## What This Changes
+
+Updates an already-reviewed PR.
+
+## Best Possible Solution
+
+Merge after maintainer review.
+
+${realBehaviorProofReportSection({
+  status: "sufficient",
+  evidenceKind: "terminal",
+  needsContributorAction: false,
+  summary: "Terminal proof covers the changed behavior.",
+})}
+
+## Review Findings
+
+Overall correctness: patch is correct
+
+Overall confidence: 0.9
+
+Full review comments:
+
+- none
+`;
+
+  const labelDetails = detailsBody(renderReviewCommentFromReport(report, "none"), "Label changes");
+
+  assert.match(labelDetails, /- add `status: 👀 ready for maintainer look`:/);
+  assert.match(
+    labelDetails,
+    /- remove `status: ⏳ waiting on author`: Current PR status label is `status: 👀 ready for maintainer look`\./,
+  );
+  assert.doesNotMatch(labelDetails, /add `status: ⏳ waiting on author`/);
+});
+
 test("media proof receives a shiny proof rating boost", () => {
   const report = `${reportFrontMatter({
     type: "pull_request",


### PR DESCRIPTION
Fixes #280.

## Summary
- derive public PR status labels from the report content before falling back to stale frontmatter labels
- use that derived status for label changes, transition reasons, and justifications
- add a regression test for stale waiting-on-author labels moving to ready for maintainer look

## Validation
- pnpm run build && node --test test/clawsweeper.test.ts --test-name-pattern 'public PR review details derive ready status instead of preserving stale waiting label|ClawSweeper PR status labels use one current workflow status'\n- pnpm run build:all\n- pnpm run lint\n- pnpm run format:check -- src/clawsweeper.ts test/clawsweeper.test.ts\n- pnpm run check