### PR TITLE
Treat failed Codex reviews as infra-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ checkpoint, and status-only commits are intentionally omitted.
 - Preserved records written by concurrent workers during generated-state publish races while retaining deliberate item-to-closed moves and plan cleanup.
 - Raised and unified Codex review timeouts at 20 minutes, including exact event reviews, so high-context reviews do not fall back at the previous 10-minute ceiling.
 - Scale pull request review timeouts for large diffs and video proofs while preserving the configured exact-event fallback for dispatches without adaptive payloads. Thanks @TurboTheTurtle.
+- Treat failed Codex reviews as infrastructure failures, suppress readiness verdicts, and remove stale PR rating labels until a fresh review completes. Thanks @SYU8384.
 - Deferred workflow utility CLI execution until module initialization completes, preventing apply preselection from crashing on close-action constants.
 - Prevented verbose Codex review and repair subprocess output from overflowing memory, retained capped durable logs and bounded redacted diagnostic tails, stopped retrying terminal model-access failures, and pinned the CLI/proxy pair to compatible version 0.139.0. Thanks @fuller-stack-dev.
 - Hydrated generated pull request review findings into automerge repair jobs instead of routing repairs through the original issue-only artifact.

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -9089,8 +9089,10 @@ function derivedPrRating(options: {
 function nextPrRatingLabels(
   labels: readonly string[],
   rating: Pick<PrRating, "overallTier">,
+  reviewFailed = false,
 ): string[] {
   const nextLabels = labels.filter((label) => !PR_RATING_LABEL_NAMES.has(label));
+  if (reviewFailed) return nextLabels;
   nextLabels.push(ratingLabelForTier(rating.overallTier).name);
   return nextLabels;
 }
@@ -10062,9 +10064,13 @@ export function realBehaviorProofMediaLabelsForTest(
   return nextRealBehaviorProofMediaLabels(labels, { evidenceKind: proofEvidenceKind });
 }
 
-export function prRatingLabelsForTest(labels: readonly string[], tier: string): string[] {
+export function prRatingLabelsForTest(
+  labels: readonly string[],
+  tier: string,
+  reviewFailed = false,
+): string[] {
   const overallTier = PR_RATING_TIERS.has(tier as PrRatingTier) ? (tier as PrRatingTier) : "NA";
-  return nextPrRatingLabels(labels, { overallTier });
+  return nextPrRatingLabels(labels, { overallTier }, reviewFailed);
 }
 
 export function prRatingLabelSchemeForTest(): {
@@ -10734,9 +10740,10 @@ function syncPrRatingLabel(options: {
   number: number;
   labels: readonly string[];
   rating: Pick<PrRating, "overallTier">;
+  reviewFailed?: boolean;
   dryRun: boolean;
 }): { labels: string[]; changed: boolean } {
-  const nextLabels = nextPrRatingLabels(options.labels, options.rating);
+  const nextLabels = nextPrRatingLabels(options.labels, options.rating, options.reviewFailed);
   const currentLabelKeys = new Set(options.labels.map((label) => label.toLowerCase()));
   const nextLabelKeys = new Set(nextLabels.map((label) => label.toLowerCase()));
   const labelsToRemove = options.labels.filter(
@@ -12847,9 +12854,7 @@ function desiredClawSweeperLabelsFromPublicReport(
     labels = nextMergeRiskLabels(labels, mergeRiskLabelsFromReport(markdown));
     labels = nextRealBehaviorProofSufficientLabels(labels, realBehaviorProof);
     labels = nextRealBehaviorProofMediaLabels(labels, realBehaviorProof);
-    labels = reviewFailed
-      ? labels.filter((label) => !PR_RATING_LABEL_NAMES.has(label))
-      : nextPrRatingLabels(labels, reportPrRating(markdown));
+    labels = nextPrRatingLabels(labels, reportPrRating(markdown), reviewFailed);
     labels = nextFeatureShowcaseLabels(labels, {
       isPullRequest,
       itemCategory: frontMatterValue(markdown, "item_category"),
@@ -16199,6 +16204,7 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
         number,
         labels: item.labels,
         rating: reportPrRating(markdown),
+        reviewFailed: frontMatterValue(markdown, "review_status") === "failed",
         dryRun,
       });
       item.labels = prRatingSyncResult.labels;

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -8236,6 +8236,20 @@ function publicMergeReadinessBlock(rating: PrRating, proof: RealBehaviorProof): 
   return lines.join("\n");
 }
 
+function publicFailedReviewReadinessBlock(markdown: string): string {
+  const reason =
+    reportEvidence(markdown)
+      .find((entry) => entry.label === "failure reason")
+      ?.detail.trim() || "Codex review failed before completion.";
+  return [
+    "Not assessed.",
+    `Failure reason: ${sentence(reason)}`,
+    "",
+    "This is a ClawSweeper/Codex infrastructure failure, not a PR readiness or patch-quality verdict.",
+    "Keep any merge decision on the normal maintainer review path until ClawSweeper can complete a fresh review.",
+  ].join("\n");
+}
+
 function prStatusLabelKindFromLabels(labels: readonly string[]): PrStatusLabelKind | null {
   for (const label of PR_STATUS_LABELS) {
     if (labels.includes(label.name)) return label.kind;
@@ -11001,6 +11015,7 @@ function isExternalPullRequestReport(markdown: string): boolean {
 }
 
 function realBehaviorProofBlocksMerge(markdown: string): boolean {
+  if (frontMatterValue(markdown, "review_status") === "failed") return false;
   if (!isExternalPullRequestReport(markdown)) return false;
   if (frontMatterStringArray(markdown, "labels").includes(PROOF_OVERRIDE_LABEL)) return false;
   if (isDocsOnlyPullRequestReport(markdown)) return false;
@@ -12824,6 +12839,7 @@ function desiredClawSweeperLabelsFromPublicReport(
   options: ReviewCommentRenderOptions = {},
 ): string[] {
   const isPullRequest = frontMatterValue(markdown, "type") === "pull_request";
+  const reviewFailed = frontMatterValue(markdown, "review_status") === "failed";
   let labels = nextPriorityLabels(currentLabels, triagePriorityFromReport(markdown));
   labels = nextImpactLabels(labels, isPullRequest ? [] : impactLabelsFromReport(markdown));
   if (isPullRequest) {
@@ -12831,7 +12847,9 @@ function desiredClawSweeperLabelsFromPublicReport(
     labels = nextMergeRiskLabels(labels, mergeRiskLabelsFromReport(markdown));
     labels = nextRealBehaviorProofSufficientLabels(labels, realBehaviorProof);
     labels = nextRealBehaviorProofMediaLabels(labels, realBehaviorProof);
-    labels = nextPrRatingLabels(labels, reportPrRating(markdown));
+    labels = reviewFailed
+      ? labels.filter((label) => !PR_RATING_LABEL_NAMES.has(label))
+      : nextPrRatingLabels(labels, reportPrRating(markdown));
     labels = nextFeatureShowcaseLabels(labels, {
       isPullRequest,
       itemCategory: frontMatterValue(markdown, "item_category"),
@@ -12896,6 +12914,11 @@ function labelTransitionReason(
         : "Current PR review selected no merge-risk labels.";
   }
   if (PR_RATING_LABEL_NAMES.has(label)) {
+    if (frontMatterValue(markdown, "review_status") === "failed") {
+      return action === "add"
+        ? "Failed reviews do not select PR readiness rating labels."
+        : "Current review failed before PR readiness was assessed, so no rating label should remain.";
+    }
     const rating = reportPrRating(markdown);
     const current = ratingLabelForTier(rating.overallTier).name;
     return action === "add"
@@ -12993,7 +13016,7 @@ function labelJustificationsFromPublicReport(
   };
   const isPullRequest = frontMatterValue(markdown, "type") === "pull_request";
   const realBehaviorProof = reportRealBehaviorProof(markdown);
-  if (isPullRequest) {
+  if (isPullRequest && frontMatterValue(markdown, "review_status") !== "failed") {
     const rating = reportPrRating(markdown);
     const ratingLabel = ratingLabelForTier(rating.overallTier).name;
     const previousRatingLabel = frontMatterStringArray(markdown, "labels").find(
@@ -13743,6 +13766,7 @@ function renderKeepOpenCommentFromReport(
   const workReason = reportWorkCandidateReason(markdown);
   const workCandidate = frontMatterValue(markdown, "work_candidate");
   const isPullRequest = frontMatterValue(markdown, "type") === "pull_request";
+  const reviewFailed = frontMatterValue(markdown, "review_status") === "failed";
   const validation = frontMatterStringArray(markdown, "work_validation")
     .slice(0, 5)
     .map((step) =>
@@ -13750,7 +13774,8 @@ function renderKeepOpenCommentFromReport(
     );
   const isRepairCandidate = workCandidate === "queue_fix_pr";
   const isRepairLoopPass = isPullRequest && Boolean(repairLoopPassModeFromReport(markdown));
-  const hasRealBehaviorProofBlocker = isPullRequest && realBehaviorProofBlocksMerge(markdown);
+  const hasRealBehaviorProofBlocker =
+    isPullRequest && !reviewFailed && realBehaviorProofBlocksMerge(markdown);
   const summaryLine = sentence(summary) || "_No summary provided._";
   const changeSummaryLine = sentence(changeSummary || summary) || "_No change summary provided._";
   const fallbackNextStep =
@@ -13769,17 +13794,19 @@ function renderKeepOpenCommentFromReport(
   const labelDetails: string[] = [];
   const evidenceDetails: string[] = [];
   const hasReviewFindings = isPullRequest && reviewFindings.length > 0;
-  const verdictLine = hasRealBehaviorProofBlocker
-    ? "Codex review: needs real behavior proof before merge."
-    : isRepairLoopPass
-      ? "Codex review: passed."
-      : isPullRequest && isRepairCandidate
-        ? "Codex review: needs changes before merge."
-        : hasReviewFindings
-          ? "Codex review: found issues before merge."
-          : isPullRequest
-            ? "Codex review: needs maintainer review before merge."
-            : "Codex review: keeping this open for maintainer follow-up; there is still a little grit to resolve.";
+  const verdictLine = reviewFailed
+    ? "ClawSweeper review: did not complete due to Codex infrastructure failure."
+    : hasRealBehaviorProofBlocker
+      ? "Codex review: needs real behavior proof before merge."
+      : isRepairLoopPass
+        ? "Codex review: passed."
+        : isPullRequest && isRepairCandidate
+          ? "Codex review: needs changes before merge."
+          : hasReviewFindings
+            ? "Codex review: found issues before merge."
+            : isPullRequest
+              ? "Codex review: needs maintainer review before merge."
+              : "Codex review: keeping this open for maintainer follow-up; there is still a little grit to resolve.";
   const lines = [`${verdictLine}${reviewFreshnessText(markdown)}`, ""];
   const prSurface = renderOpenClawPrSurfaceFromReport(markdown);
   const prSurfaceSummary = prSurface.split("\n\n", 1)[0]?.trim() ?? "";
@@ -13810,7 +13837,9 @@ function renderKeepOpenCommentFromReport(
     appendPublicSection(
       lines,
       "Merge readiness",
-      publicMergeReadinessBlock(prRating, realBehaviorProof),
+      reviewFailed
+        ? publicFailedReviewReadinessBlock(markdown)
+        : publicMergeReadinessBlock(prRating, realBehaviorProof),
     );
   }
   const mantisSuggestion = isPullRequest
@@ -13921,7 +13950,7 @@ function renderKeepOpenCommentFromReport(
   if (labelDetailsBlock) lines.push("", labelDetailsBlock);
   const evidenceDetailsBlock = collapsedDetailsBlock("Evidence reviewed", evidenceDetails);
   if (evidenceDetailsBlock) lines.push("", evidenceDetailsBlock);
-  if (isPullRequest) lines.push("", publicRankDetailsBlock());
+  if (isPullRequest && !reviewFailed) lines.push("", publicRankDetailsBlock());
   lines.push("", ...reviewWorkflowCallout());
   return sanitizePublicSelfReferences(
     lines.join("\n"),

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -17053,6 +17053,9 @@ test("ClawSweeper PR rating labels use one themed overall label", () => {
     "bug",
     "rating: 🌊 off-meta tidepool",
   ]);
+  assert.deepEqual(prRatingLabelsForTest(["bug", "rating: 🌊 off-meta tidepool"], "NA", true), [
+    "bug",
+  ]);
 });
 
 test("ClawSweeper PR rating label scheme exposes boring internal tiers", () => {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -4412,6 +4412,86 @@ Full review comments:
   assert.doesNotMatch(labelDetails, /PR readiness rating was derived from proof quality/);
 });
 
+test("failed Codex review comments suppress PR readiness ratings", () => {
+  const report = `${reportFrontMatter({
+    type: "pull_request",
+    number: "91210",
+    decision: "keep_open",
+    close_reason: "none",
+    review_status: "failed",
+    confidence: "low",
+    author: "contributor",
+    author_association: "CONTRIBUTOR",
+    labels: JSON.stringify(["proof: supplied", "rating: 🌊 off-meta tidepool"]),
+    work_candidate: "none",
+    pull_head_sha: "abc123def456",
+    triage_priority: "none",
+    impact_labels: JSON.stringify([]),
+    merge_risk_labels: JSON.stringify([]),
+    label_justifications: JSON.stringify([]),
+    pr_rating_overall: "NA",
+    pr_rating_proof: "NA",
+    pr_rating_patch: "NA",
+  })}
+
+## Summary
+
+Codex review failed: retryable codex transport failure (network).
+
+## What This Changes
+
+Review failed before ClawSweeper could summarize the requested change.
+
+## Best Possible Solution
+
+Retry the Codex review after fixing the execution failure.
+
+${realBehaviorProofReportSection({
+  status: "not_applicable",
+  evidenceKind: "not_applicable",
+  needsContributorAction: false,
+  summary: "Real behavior proof was not assessed because the Codex review failed.",
+})}
+
+${prRatingReportSection({
+  overallTier: "NA",
+  proofTier: "NA",
+  patchTier: "NA",
+  overallLabel: "🌊 off-meta tidepool",
+  proofLabel: "🌊 off-meta tidepool",
+  patchLabel: "🌊 off-meta tidepool",
+  summary: "PR readiness rating was not assessed because the Codex review failed.",
+  nextSteps: "- none",
+})}
+
+## Evidence
+
+- **failure reason:** retryable codex transport failure (network)
+- **codex failure detail:** Codex review failed for this PR with exit 1.
+`;
+
+  const comment = renderReviewCommentFromReport(report, "none");
+  const labelDetails = detailsBody(comment, "Label changes");
+
+  assert.match(
+    comment,
+    /^ClawSweeper review: did not complete due to Codex infrastructure failure\./,
+  );
+  assert.match(comment, /\*\*Merge readiness\*\*\nNot assessed\./);
+  assert.match(
+    comment,
+    /This is a ClawSweeper\/Codex infrastructure failure, not a PR readiness or patch-quality verdict\./,
+  );
+  assert.doesNotMatch(comment, /Codex review: needs real behavior proof before merge\./);
+  assert.doesNotMatch(comment, /Overall follows the weaker of proof and patch quality/);
+  assert.doesNotMatch(comment, /<summary>What the crustacean ranks mean<\/summary>/);
+  assert.match(
+    labelDetails,
+    /- remove `rating: 🌊 off-meta tidepool`: Current review failed before PR readiness was assessed, so no rating label should remain\./,
+  );
+  assert.doesNotMatch(labelDetails, /Label justifications:[\s\S]*rating: 🌊 off-meta tidepool/);
+});
+
 test("public PR review comments explain label changes without duplicate justifications", () => {
   const report = `${reportFrontMatter({
     type: "pull_request",


### PR DESCRIPTION
## Summary

- Render failed Codex/ClawSweeper review artifacts as infrastructure failures instead of PR readiness verdicts.
- Suppress stale PR readiness rating labels and rating justifications when `review_status: failed`.
- Keep the existing real-behavior-proof blocker behavior for complete and legacy reports, while bypassing it for failed-review artifacts.

## Verification

- `pnpm run build:all && node --test --test-name-pattern 'failed Codex review comments suppress PR readiness ratings|mock-only real behavior proof blocks repair markers|proof-blocked PR comments show proof cap while preserving patch quality|public PR review details justify derived rating label changes' test/clawsweeper.test.ts`
- `pnpm run test:repair && pnpm run test:coverage:changed && pnpm run format:check`
- `pnpm run check` was also attempted. It stopped in `test:unit` on the existing local filesystem-mode assertion `read-only checkout mode restores file modes and leaves git metadata writable`, where `stat(...).mode & 0777` returned `0777` instead of the expected `0555`. The changed failed-review tests passed before that failure, and the independent downstream repair/coverage/format gates above passed.

## Notes

This is the backend side of the #91210/#92499 re-review failure cleanup: exhausted Codex transport failures should remain infra-only and should not leave patch-quality or readiness labels behind.
