### PR TITLE
fix: harden adaptive review timeout budgets

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -175,13 +175,16 @@ jobs:
 
       - name: Resolve event payload
         id: target
+        env:
+          ADAPTIVE_CODEX_TIMEOUT_MS: ${{ github.event.client_payload.codex_timeout_ms || '' }}
+          CONFIGURED_CODEX_TIMEOUT_MS: ${{ vars.CLAWSWEEPER_CODEX_TIMEOUT_MS || '1200000' }}
+          MEDIA_PROOF_TIMEOUT_MS: ${{ github.event.client_payload.media_proof_timeout_ms || '0' }}
         run: |
           set -euo pipefail
           target_repo="${{ github.event.client_payload.target_repo || 'openclaw/openclaw' }}"
           target_branch="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.target_branch || github.event.client_payload.target_branch || 'main' }}"
           item_number="${{ github.event.client_payload.item_number || '' }}"
           item_kind="${{ github.event.client_payload.item_kind || '' }}"
-          codex_timeout_ms="${{ github.event.client_payload.codex_timeout_ms || vars.CLAWSWEEPER_CODEX_TIMEOUT_MS || '1200000' }}"
           if ! printf '%s' "$target_repo" | grep -Eq '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'; then
             echo "Invalid target_repo: $target_repo" >&2
             exit 1
@@ -201,15 +204,38 @@ jobs:
               exit 1
               ;;
           esac
-          if ! printf '%s' "$codex_timeout_ms" | grep -Eq '^[0-9]+$'; then
-            echo "::warning::Invalid codex_timeout_ms payload '$codex_timeout_ms'; using 1200000."
-            codex_timeout_ms="1200000"
+          configured_codex_timeout_ms="$CONFIGURED_CODEX_TIMEOUT_MS"
+          if ! printf '%s' "$configured_codex_timeout_ms" | grep -Eq '^[0-9]{1,10}$' || [ "$configured_codex_timeout_ms" -lt 1 ]; then
+            echo "::warning::Invalid configured Codex timeout; using 1200000."
+            configured_codex_timeout_ms="1200000"
           fi
-          if [ "$codex_timeout_ms" -lt 600000 ]; then
-            codex_timeout_ms="600000"
+          configured_codex_timeout_ms="$((10#$configured_codex_timeout_ms))"
+          codex_timeout_ms="$configured_codex_timeout_ms"
+          if [ -n "$ADAPTIVE_CODEX_TIMEOUT_MS" ]; then
+            adaptive_codex_timeout_ms="$ADAPTIVE_CODEX_TIMEOUT_MS"
+            if ! printf '%s' "$adaptive_codex_timeout_ms" | grep -Eq '^[0-9]{1,10}$' || [ "$adaptive_codex_timeout_ms" -lt 1 ]; then
+              echo "::warning::Ignoring invalid adaptive codex_timeout_ms payload."
+            else
+              adaptive_codex_timeout_ms="$((10#$adaptive_codex_timeout_ms))"
+              if [ "$adaptive_codex_timeout_ms" -lt 600000 ]; then
+                adaptive_codex_timeout_ms="600000"
+              fi
+              if [ "$adaptive_codex_timeout_ms" -gt 1800000 ]; then
+                adaptive_codex_timeout_ms="1800000"
+              fi
+              if [ "$adaptive_codex_timeout_ms" -gt "$codex_timeout_ms" ]; then
+                codex_timeout_ms="$adaptive_codex_timeout_ms"
+              fi
+            fi
           fi
-          if [ "$codex_timeout_ms" -gt 1800000 ]; then
-            codex_timeout_ms="1800000"
+          media_proof_timeout_ms="$MEDIA_PROOF_TIMEOUT_MS"
+          if ! printf '%s' "$media_proof_timeout_ms" | grep -Eq '^[0-9]{1,6}$'; then
+            echo "::warning::Ignoring invalid media_proof_timeout_ms payload."
+            media_proof_timeout_ms="0"
+          fi
+          media_proof_timeout_ms="$((10#$media_proof_timeout_ms))"
+          if [ "$media_proof_timeout_ms" -gt 480000 ]; then
+            media_proof_timeout_ms="480000"
           fi
           target_owner="${target_repo%%/*}"
           target_name="${target_repo#*/}"
@@ -225,6 +251,7 @@ jobs:
             echo "target_checkout_dir=$target_checkout_dir"
             echo "item_number=$item_number"
             echo "codex_timeout_ms=$codex_timeout_ms"
+            echo "media_proof_timeout_ms=$media_proof_timeout_ms"
           } >> "$GITHUB_OUTPUT"
 
       - uses: ./.github/actions/setup-pnpm
@@ -363,7 +390,6 @@ jobs:
           CLAWSWEEPER_PROOF_INSPECTION_TOKEN: ${{ steps.target-read-token.outputs.token || github.token }}
           ADDITIONAL_PROMPT: ${{ github.event.client_payload.additional_prompt || '' }}
           CLAWSWEEPER_RELATED_GITHUB_SEARCH: ${{ vars.CLAWSWEEPER_RELATED_GITHUB_SEARCH || '1' }}
-          CODEX_TIMEOUT_MS: ${{ github.event.client_payload.codex_timeout_ms || vars.CLAWSWEEPER_CODEX_TIMEOUT_MS || '1200000' }}
         run: |
           set -euo pipefail
           test -n "$GH_TOKEN"
@@ -377,14 +403,10 @@ jobs:
             additional_prompt_arg=(--additional-prompt "$ADDITIONAL_PROMPT")
           fi
           codex_timeout_seconds=$(((codex_timeout_ms + 999) / 1000))
-          review_timeout_seconds=$((codex_timeout_seconds + 180))
-          if [ "$review_timeout_seconds" -lt 300 ]; then
-            review_timeout_seconds=300
-          fi
-          if [ "$review_timeout_seconds" -gt 4200 ]; then
-            review_timeout_seconds=4200
-          fi
-          echo "::notice::Exact event review timeout is ${review_timeout_seconds}s for per-item Codex timeout ${codex_timeout_seconds}s."
+          media_proof_timeout_ms="${{ steps.target.outputs.media_proof_timeout_ms }}"
+          media_proof_timeout_seconds=$(((media_proof_timeout_ms + 999) / 1000))
+          review_timeout_seconds=$((codex_timeout_seconds + media_proof_timeout_seconds + 180))
+          echo "::notice::Exact event review timeout is ${review_timeout_seconds}s for per-item Codex timeout ${codex_timeout_seconds}s and media proof allowance ${media_proof_timeout_seconds}s."
           timeout --kill-after=30s "${review_timeout_seconds}s" pnpm run review -- \
             --target-repo "${{ steps.target.outputs.target_repo }}" \
             --target-dir "${{ steps.target.outputs.target_checkout_dir }}" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@ checkpoint, and status-only commits are intentionally omitted.
 - Recover transport-exhausted reviews with one bounded lower-effort fallback while preserving the original failure classification when recovery also fails. Thanks @yetval. (#283)
 - Preserved records written by concurrent workers during generated-state publish races while retaining deliberate item-to-closed moves and plan cleanup.
 - Raised and unified Codex review timeouts at 20 minutes, including exact event reviews, so high-context reviews do not fall back at the previous 10-minute ceiling.
-- Scale pull request review timeouts for large diffs and video proofs while preserving the configured exact-event fallback for dispatches without adaptive payloads. Thanks @TurboTheTurtle.
+- Scale pull request review timeouts across webhook, command, and post-repair dispatches for large diffs and video proofs while preserving the configured Codex timeout as a floor and budgeting media preprocessing separately. Thanks @TurboTheTurtle.
 - Treat failed Codex reviews as infrastructure failures, suppress readiness verdicts, and remove stale PR rating labels until a fresh review completes. Thanks @SYU8384.
 - Deferred workflow utility CLI execution until module initialization completes, preventing apply preselection from crashing on close-action constants.
 - Prevented verbose Codex review and repair subprocess output from overflowing memory, retained capped durable logs and bounded redacted diagnostic tails, stopped retrying terminal model-access failures, and pinned the CLI/proxy pair to compatible version 0.139.0. Thanks @fuller-stack-dev.

--- a/src/repair/adaptive-review-budget.ts
+++ b/src/repair/adaptive-review-budget.ts
@@ -1,0 +1,98 @@
+import type { JsonValue, LooseRecord } from "./json-types.js";
+
+const DEFAULT_ADAPTIVE_CODEX_TIMEOUT_MS = 600_000;
+const MAX_ADAPTIVE_CODEX_TIMEOUT_MS = 1_500_000;
+const PR_SIZE_BASELINE_FILES = 20;
+const PR_SIZE_FILE_STEP_MS = 10_000;
+const PR_SIZE_BASELINE_LINES = 1_000;
+const PR_SIZE_LINE_STEP_MS = 50;
+const MAX_PR_FILE_TIMEOUT_BONUS_MS = 600_000;
+const MAX_PR_LINE_TIMEOUT_BONUS_MS = 300_000;
+const MEDIA_PROOF_TIMEOUT_BONUS_MS = 120_000;
+const MAX_MEDIA_PROOF_URLS = 4;
+const VIDEO_PROOF_EXTENSIONS = new Set([".mov", ".mp4", ".m4v", ".webm", ".avi", ".mkv"]);
+
+export type AdaptiveReviewBudget = {
+  codexTimeoutMs: number;
+  mediaProofTimeoutMs: number;
+};
+
+export function adaptiveReviewBudgetForPullRequest(pull: LooseRecord): AdaptiveReviewBudget {
+  const files = (Array.isArray(pull.files) ? pull.files : []) as LooseRecord[];
+  const changedFiles =
+    pull.changed_files == null && pull.changedFiles == null
+      ? files.length
+      : nonNegativeInteger(pull.changed_files ?? pull.changedFiles);
+  const changedLines =
+    pull.additions == null && pull.deletions == null
+      ? files.reduce<number>(
+          (total, file) =>
+            total + nonNegativeInteger(file?.additions) + nonNegativeInteger(file?.deletions),
+          0,
+        )
+      : nonNegativeInteger(pull.additions) + nonNegativeInteger(pull.deletions);
+  const mediaProofCount = videoProofUrlsFromText(
+    [String(pull.title ?? ""), String(pull.body ?? "")].join("\n"),
+  ).length;
+  const fileBonusMs = clamp(
+    (changedFiles - PR_SIZE_BASELINE_FILES) * PR_SIZE_FILE_STEP_MS,
+    0,
+    MAX_PR_FILE_TIMEOUT_BONUS_MS,
+  );
+  const lineBonusMs = clamp(
+    (changedLines - PR_SIZE_BASELINE_LINES) * PR_SIZE_LINE_STEP_MS,
+    0,
+    MAX_PR_LINE_TIMEOUT_BONUS_MS,
+  );
+  const mediaProofTimeoutMs = mediaProofCount * MEDIA_PROOF_TIMEOUT_BONUS_MS;
+  return {
+    codexTimeoutMs: clamp(
+      DEFAULT_ADAPTIVE_CODEX_TIMEOUT_MS + fileBonusMs + lineBonusMs,
+      DEFAULT_ADAPTIVE_CODEX_TIMEOUT_MS,
+      MAX_ADAPTIVE_CODEX_TIMEOUT_MS,
+    ),
+    mediaProofTimeoutMs,
+  };
+}
+
+function videoProofUrlsFromText(text: string) {
+  const matches = text.match(/https?:\/\/[^\s<>"'\\)]+/g) ?? [];
+  const urls: string[] = [];
+  const seen = new Set<string>();
+  for (const raw of matches) {
+    const cleaned = trimTrailingUrlPunctuation(raw);
+    let parsed: URL;
+    try {
+      parsed = new URL(cleaned);
+    } catch {
+      continue;
+    }
+    const pathname = parsed.pathname.toLowerCase();
+    const isVideo = [...VIDEO_PROOF_EXTENSIONS].some((extension) => pathname.endsWith(extension));
+    if (!isVideo || seen.has(parsed.href)) continue;
+    seen.add(parsed.href);
+    urls.push(parsed.href);
+    if (urls.length >= MAX_MEDIA_PROOF_URLS) break;
+  }
+  return urls;
+}
+
+function trimTrailingUrlPunctuation(raw: string): string {
+  let end = raw.length;
+  while (end > 0) {
+    const char = raw.charCodeAt(end - 1);
+    if (char !== 44 && char !== 46 && char !== 58 && char !== 59) break;
+    end -= 1;
+  }
+  return raw.slice(0, end);
+}
+
+function nonNegativeInteger(value: JsonValue) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 0;
+  return Math.floor(parsed);
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -2,6 +2,7 @@
 import type { JsonValue, LooseRecord } from "./json-types.js";
 import fs from "node:fs";
 import path from "node:path";
+import { adaptiveReviewBudgetForPullRequest } from "./adaptive-review-budget.js";
 import {
   activeRepairWorkflowRunForJobAfterDispatchRecheck,
   assertLiveWorkerCapacity,
@@ -2035,6 +2036,14 @@ function repairJobModeForCommand(command: LooseRecord) {
 }
 
 function dispatchClawSweeperReview(command: LooseRecord) {
+  const reviewBudget =
+    command.target?.kind === "pull_request"
+      ? adaptiveReviewBudgetForPullRequest(command.target)
+      : null;
+  // workflow_dispatch is at GitHub's input limit, so its one timeout carries both budgets.
+  const fallbackCodexTimeoutMs = reviewBudget
+    ? reviewBudget.codexTimeoutMs + reviewBudget.mediaProofTimeoutMs
+    : null;
   const commandStatus = ["re_review", "autofix", "automerge"].includes(String(command.intent ?? ""))
     ? {
         command_status_marker: commandStatusMarker(command),
@@ -2051,6 +2060,12 @@ function dispatchClawSweeperReview(command: LooseRecord) {
       item_number: String(command.issue_number),
       item_kind: command.target?.kind ?? "",
       additional_prompt: freeformReviewPrompt(command),
+      ...(reviewBudget
+        ? {
+            codex_timeout_ms: reviewBudget.codexTimeoutMs,
+            media_proof_timeout_ms: reviewBudget.mediaProofTimeoutMs,
+          }
+        : {}),
       ...commandStatus,
     },
   });
@@ -2079,6 +2094,7 @@ function dispatchClawSweeperReview(command: LooseRecord) {
         "-f",
         `additional_prompt=${freeformReviewPrompt(command)}`,
         "-f",
+        ...(fallbackCodexTimeoutMs ? [`codex_timeout_ms=${fallbackCodexTimeoutMs}`, "-f"] : []),
         "batch_size=1",
         "-f",
         "shard_count=1",
@@ -2788,6 +2804,9 @@ function classifyPullTarget(pull: LooseRecord, issueNumber: JsonValue): JsonValu
     author,
     labels,
     files: pull.files ?? [],
+    changedFiles: pull.changedFiles ?? null,
+    additions: pull.additions ?? null,
+    deletions: pull.deletions ?? null,
     is_clawsweeper_pr: branch.startsWith(headPrefix),
     cluster_id: adoptedJobPath ? automergeCluster : clusterId,
     job_path: repairJob.jobPath,
@@ -3010,13 +3029,16 @@ function fetchPullRequestView(number: JsonValue) {
       targetRepo,
       "--json",
       [
+        "additions",
         "headRefName",
         "headRefOid",
         "author",
         "baseRefName",
         "body",
+        "changedFiles",
         "closingIssuesReferences",
         "commits",
+        "deletions",
         "files",
         "isDraft",
         "labels",
@@ -3045,13 +3067,16 @@ function fetchPullRequestViewAsync(number: JsonValue) {
       targetRepo,
       "--json",
       [
+        "additions",
         "headRefName",
         "headRefOid",
         "author",
         "baseRefName",
         "body",
+        "changedFiles",
         "closingIssuesReferences",
         "commits",
+        "deletions",
         "files",
         "isDraft",
         "labels",

--- a/src/repair/comment-webhook.ts
+++ b/src/repair/comment-webhook.ts
@@ -9,6 +9,7 @@ import {
   parseCommand,
   staleClosedItemCommandReason,
 } from "./comment-router-core.js";
+import { adaptiveReviewBudgetForPullRequest } from "./adaptive-review-budget.js";
 
 const DEFAULT_PORT = 8787;
 const REVIEW_REPO = "openclaw/clawsweeper";
@@ -27,17 +28,6 @@ const PULL_ITEM_ACTIONS = new Set([
   "unlabeled",
 ]);
 const DEFAULT_FAST_ACK_SETTLE_DELAYS_MS = [250, 1500, 10_000];
-const DEFAULT_CODEX_TIMEOUT_MS = 600_000;
-const MAX_ADAPTIVE_CODEX_TIMEOUT_MS = 1_800_000;
-const PR_SIZE_BASELINE_FILES = 20;
-const PR_SIZE_FILE_STEP_MS = 10_000;
-const PR_SIZE_BASELINE_LINES = 1_000;
-const PR_SIZE_LINE_STEP_MS = 50;
-const MAX_PR_FILE_TIMEOUT_BONUS_MS = 600_000;
-const MAX_PR_LINE_TIMEOUT_BONUS_MS = 300_000;
-const MEDIA_PROOF_TIMEOUT_BONUS_MS = 120_000;
-const MAX_MEDIA_PROOF_URLS = 4;
-const VIDEO_PROOF_EXTENSIONS = new Set([".mov", ".mp4", ".m4v", ".webm", ".avi", ".mkv"]);
 const inFlightFastAcks = new Map<string, Promise<number>>();
 
 type AcceptedIssueCommentWebhook = {
@@ -63,6 +53,7 @@ type AcceptedItemWebhook = {
   sourceAction: string;
   supersedesInProgress: boolean;
   codexTimeoutMs?: number;
+  mediaProofTimeoutMs?: number;
 };
 
 type AcceptedWebhook = AcceptedIssueCommentWebhook | AcceptedItemWebhook;
@@ -286,6 +277,7 @@ export function classifyItemWebhook({ event, payload }: { event: string; payload
     if (!Number.isInteger(itemNumber) || itemNumber <= 0) {
       return { accepted: false, reason: "missing pull request number" };
     }
+    const reviewBudget = adaptiveReviewBudgetForPullRequest(pull);
     return {
       accepted: true,
       type: "item",
@@ -297,7 +289,8 @@ export function classifyItemWebhook({ event, payload }: { event: string; payload
       sourceEvent: "pull_request",
       sourceAction: action,
       supersedesInProgress: ["edited", "synchronize", "ready_for_review"].includes(action),
-      codexTimeoutMs: adaptiveCodexTimeoutMsForPullRequest(pull),
+      codexTimeoutMs: reviewBudget.codexTimeoutMs,
+      mediaProofTimeoutMs: reviewBudget.mediaProofTimeoutMs,
     };
   }
 
@@ -305,73 +298,7 @@ export function classifyItemWebhook({ event, payload }: { event: string; payload
 }
 
 export function adaptiveCodexTimeoutMsForTest(pull: LooseRecord) {
-  return adaptiveCodexTimeoutMsForPullRequest(pull);
-}
-
-function adaptiveCodexTimeoutMsForPullRequest(pull: LooseRecord) {
-  const changedFiles = nonNegativeInteger(pull.changed_files);
-  const changedLines = nonNegativeInteger(pull.additions) + nonNegativeInteger(pull.deletions);
-  const mediaProofUrls = videoProofUrlsFromText(
-    [String(pull.title ?? ""), String(pull.body ?? "")].join("\n"),
-  );
-  const fileBonusMs = clamp(
-    (changedFiles - PR_SIZE_BASELINE_FILES) * PR_SIZE_FILE_STEP_MS,
-    0,
-    MAX_PR_FILE_TIMEOUT_BONUS_MS,
-  );
-  const lineBonusMs = clamp(
-    (changedLines - PR_SIZE_BASELINE_LINES) * PR_SIZE_LINE_STEP_MS,
-    0,
-    MAX_PR_LINE_TIMEOUT_BONUS_MS,
-  );
-  const mediaBonusMs = mediaProofUrls.length * MEDIA_PROOF_TIMEOUT_BONUS_MS;
-  return clamp(
-    DEFAULT_CODEX_TIMEOUT_MS + fileBonusMs + lineBonusMs + mediaBonusMs,
-    DEFAULT_CODEX_TIMEOUT_MS,
-    MAX_ADAPTIVE_CODEX_TIMEOUT_MS,
-  );
-}
-
-function videoProofUrlsFromText(text: string) {
-  const matches = text.match(/https?:\/\/[^\s<>"'\\)]+/g) ?? [];
-  const urls: string[] = [];
-  const seen = new Set<string>();
-  for (const raw of matches) {
-    const cleaned = trimTrailingUrlPunctuation(raw);
-    let parsed: URL;
-    try {
-      parsed = new URL(cleaned);
-    } catch {
-      continue;
-    }
-    const pathname = parsed.pathname.toLowerCase();
-    const isVideo = [...VIDEO_PROOF_EXTENSIONS].some((extension) => pathname.endsWith(extension));
-    if (!isVideo || seen.has(parsed.href)) continue;
-    seen.add(parsed.href);
-    urls.push(parsed.href);
-    if (urls.length >= MAX_MEDIA_PROOF_URLS) break;
-  }
-  return urls;
-}
-
-function trimTrailingUrlPunctuation(raw: string): string {
-  let end = raw.length;
-  while (end > 0) {
-    const char = raw.charCodeAt(end - 1);
-    if (char !== 44 && char !== 46 && char !== 58 && char !== 59) break;
-    end -= 1;
-  }
-  return raw.slice(0, end);
-}
-
-function nonNegativeInteger(value: JsonValue) {
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed) || parsed <= 0) return 0;
-  return Math.floor(parsed);
-}
-
-function clamp(value: number, min: number, max: number) {
-  return Math.min(max, Math.max(min, value));
+  return adaptiveReviewBudgetForPullRequest(pull).codexTimeoutMs;
 }
 
 function isEligibleRepositoryPayload(repo: LooseRecord) {
@@ -764,6 +691,9 @@ async function dispatchItemReview({
         source_action: accepted.sourceAction,
         supersedes_in_progress: accepted.supersedesInProgress,
         ...(accepted.codexTimeoutMs ? { codex_timeout_ms: accepted.codexTimeoutMs } : {}),
+        ...(accepted.mediaProofTimeoutMs
+          ? { media_proof_timeout_ms: accepted.mediaProofTimeoutMs }
+          : {}),
       },
     },
   });

--- a/src/repair/execute-fix-artifact.ts
+++ b/src/repair/execute-fix-artifact.ts
@@ -3,6 +3,7 @@ import type { JsonValue, LooseRecord } from "./json-types.js";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { adaptiveReviewBudgetForPullRequest } from "./adaptive-review-budget.js";
 import {
   spawn,
   spawnSync,
@@ -3871,6 +3872,17 @@ function dispatchAutomergeCommentRouter({
 function dispatchAutomergeReviewAfterBranchRepair({ target, commit }: LooseRecord) {
   const reviewRepo = String(process.env.CLAWSWEEPER_REVIEW_REPO ?? "openclaw/clawsweeper").trim();
   const dispatchedAt = new Date().toISOString();
+  let reviewBudget = null;
+  try {
+    reviewBudget = adaptiveReviewBudgetForPullRequest(
+      fetchPullRequestViewForRepo({ repo: result.repo, number: target }),
+    );
+  } catch (error) {
+    logProgress("adaptive review budget lookup failed; using configured review timeout", {
+      target,
+      reason: compactText(error instanceof Error ? error.message : String(error), 180),
+    });
+  }
   const payloadPath = writePayload(`automerge-review-dispatch-${target}-${commit}`, {
     event_type: "clawsweeper_item",
     client_payload: {
@@ -3880,6 +3892,12 @@ function dispatchAutomergeReviewAfterBranchRepair({ target, commit }: LooseRecor
       source_event: "repair_completed",
       source_action: "branch_repaired",
       supersedes_in_progress: true,
+      ...(reviewBudget
+        ? {
+            codex_timeout_ms: reviewBudget.codexTimeoutMs,
+            media_proof_timeout_ms: reviewBudget.mediaProofTimeoutMs,
+          }
+        : {}),
     },
   });
   try {
@@ -4012,12 +4030,18 @@ function fetchPullRequestViewForRepo({ repo, number }: LooseRecord) {
         String(repo),
         "--json",
         [
+          "additions",
           "headRefOid",
+          "body",
+          "changedFiles",
+          "deletions",
+          "files",
           "mergeable",
           "mergeStateStatus",
           "mergedAt",
           "state",
           "statusCheckRollup",
+          "title",
         ].join(","),
       ],
       { cwd: repoRoot(), env: ghEnv(), timeoutMs: currentNetworkCommandTimeoutMs() },

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -18300,6 +18300,10 @@ test("comment commands keep the router-to-sweep dispatch contract", () => {
   );
   assert.match(routerWorkflow, /--status-comment-id "\$status_comment_id"/);
   assert.match(routerSource, /event_type:\s*"clawsweeper_item"/);
+  assert.match(routerSource, /adaptiveReviewBudgetForPullRequest\(command\.target\)/);
+  assert.match(routerSource, /media_proof_timeout_ms: reviewBudget\.mediaProofTimeoutMs/);
+  assert.match(routerSource, /reviewBudget\.codexTimeoutMs \+ reviewBudget\.mediaProofTimeoutMs/);
+  assert.match(routerSource, /`codex_timeout_ms=\$\{fallbackCodexTimeoutMs\}`/);
   assert.match(sweepWorkflow, /types:\s*\[clawsweeper_item,\s*clawsweeper_target_sweep\]/);
   assert.doesNotMatch(sweepWorkflow, /types:\s*\[[^\]]*clawsweeper_comment/);
 });
@@ -18588,17 +18592,39 @@ test("sweep exact event reviews consume adaptive Codex timeout payload", () => {
 
   assert.match(
     resolveBlock,
-    /codex_timeout_ms="\$\{\{ github\.event\.client_payload\.codex_timeout_ms \|\| vars\.CLAWSWEEPER_CODEX_TIMEOUT_MS \|\| '1200000' \}\}"/,
+    /ADAPTIVE_CODEX_TIMEOUT_MS: \$\{\{ github\.event\.client_payload\.codex_timeout_ms \|\| '' \}\}/,
   );
-  assert.match(resolveBlock, /Invalid codex_timeout_ms payload/);
-  assert.match(resolveBlock, /\[ "\$codex_timeout_ms" -lt 600000 \]/);
-  assert.match(resolveBlock, /\[ "\$codex_timeout_ms" -gt 1800000 \]/);
+  assert.match(
+    resolveBlock,
+    /CONFIGURED_CODEX_TIMEOUT_MS: \$\{\{ vars\.CLAWSWEEPER_CODEX_TIMEOUT_MS \|\| '1200000' \}\}/,
+  );
+  assert.match(
+    resolveBlock,
+    /MEDIA_PROOF_TIMEOUT_MS: \$\{\{ github\.event\.client_payload\.media_proof_timeout_ms \|\| '0' \}\}/,
+  );
+  assert.match(resolveBlock, /Ignoring invalid adaptive codex_timeout_ms payload/);
+  assert.match(
+    resolveBlock,
+    /configured_codex_timeout_ms="\$\(\(10#\$configured_codex_timeout_ms\)\)"/,
+  );
+  assert.match(
+    resolveBlock,
+    /adaptive_codex_timeout_ms="\$\(\(10#\$adaptive_codex_timeout_ms\)\)"/,
+  );
+  assert.match(resolveBlock, /media_proof_timeout_ms="\$\(\(10#\$media_proof_timeout_ms\)\)"/);
+  assert.match(resolveBlock, /\[ "\$adaptive_codex_timeout_ms" -lt 600000 \]/);
+  assert.match(resolveBlock, /\[ "\$adaptive_codex_timeout_ms" -gt 1800000 \]/);
+  assert.match(resolveBlock, /\[ "\$adaptive_codex_timeout_ms" -gt "\$codex_timeout_ms" \]/);
   assert.match(resolveBlock, /echo "codex_timeout_ms=\$codex_timeout_ms"/);
+  assert.match(resolveBlock, /echo "media_proof_timeout_ms=\$media_proof_timeout_ms"/);
   assert.match(
     reviewBlock,
     /codex_timeout_ms="\$\{\{ steps\.target\.outputs\.codex_timeout_ms \}\}"/,
   );
-  assert.match(reviewBlock, /review_timeout_seconds=\$\(\(codex_timeout_seconds \+ 180\)\)/);
+  assert.match(
+    reviewBlock,
+    /review_timeout_seconds=\$\(\(codex_timeout_seconds \+ media_proof_timeout_seconds \+ 180\)\)/,
+  );
   assert.match(reviewBlock, /timeout --kill-after=30s "\$\{review_timeout_seconds\}s"/);
   assert.match(reviewBlock, /--codex-timeout-ms "\$codex_timeout_ms"/);
   assert.doesNotMatch(reviewBlock, /timeout --kill-after=30s 12m/);
@@ -18614,13 +18640,10 @@ test("sweep exact event reviews preserve the configured fallback without an adap
 
   assert.match(
     resolveBlock,
-    /github\.event\.client_payload\.codex_timeout_ms \|\| vars\.CLAWSWEEPER_CODEX_TIMEOUT_MS \|\| '1200000'/,
+    /CONFIGURED_CODEX_TIMEOUT_MS: \$\{\{ vars\.CLAWSWEEPER_CODEX_TIMEOUT_MS \|\| '1200000' \}\}/,
   );
-  assert.match(resolveBlock, /using 1200000/);
-  assert.doesNotMatch(
-    resolveBlock,
-    /codex_timeout_ms="\$\{\{ github\.event\.client_payload\.codex_timeout_ms \|\| '600000' \}\}"/,
-  );
+  assert.match(resolveBlock, /codex_timeout_ms="\$configured_codex_timeout_ms"/);
+  assert.match(resolveBlock, /\[ "\$adaptive_codex_timeout_ms" -gt "\$codex_timeout_ms" \]/);
 });
 
 test("github activity workflow coalesces noisy observer runs", () => {
@@ -18796,9 +18819,8 @@ test("sweep workflow runs exact event reviews without a global worker gate", () 
   assert.match(exactReviewStep, /--shard-count 1/);
   assert.match(
     exactReviewStep,
-    /CODEX_TIMEOUT_MS: \$\{\{ github\.event\.client_payload\.codex_timeout_ms \|\| vars\.CLAWSWEEPER_CODEX_TIMEOUT_MS \|\| '1200000' \}\}/,
+    /review_timeout_seconds=\$\(\(codex_timeout_seconds \+ media_proof_timeout_seconds \+ 180\)\)/,
   );
-  assert.match(exactReviewStep, /review_timeout_seconds=\$\(\(codex_timeout_seconds \+ 180\)\)/);
   assert.match(exactReviewStep, /--codex-timeout-ms "\$codex_timeout_ms"/);
   assert.doesNotMatch(exactReviewStep, /--codex-timeout-ms 600000/);
   assert.doesNotMatch(eventReviewBlock, /Wait for exact event review capacity/);

--- a/test/repair/adaptive-review-budget.test.ts
+++ b/test/repair/adaptive-review-budget.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { adaptiveReviewBudgetForPullRequest } from "../../dist/repair/adaptive-review-budget.js";
+
+test("adaptive review budget normalizes REST aggregate and gh file shapes", () => {
+  const aggregate = adaptiveReviewBudgetForPullRequest({
+    changed_files: 71,
+    additions: 4176,
+    deletions: 0,
+    body: [
+      "https://uploads.example.invalid/proof-a.mov",
+      "https://uploads.example.invalid/proof-b.mp4",
+    ].join("\n"),
+  });
+  const files = adaptiveReviewBudgetForPullRequest({
+    changedFiles: 71,
+    additions: 4176,
+    deletions: 0,
+    files: Array.from({ length: 71 }, (_, index) => ({
+      additions: index === 0 ? 4176 : 0,
+      deletions: 0,
+    })),
+    body: [
+      "https://uploads.example.invalid/proof-a.mov",
+      "https://uploads.example.invalid/proof-b.mp4",
+    ].join("\n"),
+  });
+
+  assert.deepEqual(aggregate, {
+    codexTimeoutMs: 1_268_800,
+    mediaProofTimeoutMs: 240_000,
+  });
+  assert.deepEqual(files, aggregate);
+});
+
+test("adaptive review budget caps video preprocessing allowance", () => {
+  const budget = adaptiveReviewBudgetForPullRequest({
+    body: [
+      "https://uploads.example.invalid/one.mov",
+      "https://uploads.example.invalid/two.mp4",
+      "https://uploads.example.invalid/three.webm",
+      "https://uploads.example.invalid/four.mkv",
+      "https://uploads.example.invalid/five.avi",
+    ].join("\n"),
+  });
+
+  assert.equal(budget.mediaProofTimeoutMs, 480_000);
+  assert.equal(budget.codexTimeoutMs, 600_000);
+});

--- a/test/repair/comment-webhook.test.ts
+++ b/test/repair/comment-webhook.test.ts
@@ -321,6 +321,7 @@ test("webhook accepts eligible pull request events for generic steipete reposito
     sourceAction: "synchronize",
     supersedesInProgress: true,
     codexTimeoutMs: 600_000,
+    mediaProofTimeoutMs: 0,
   });
 });
 
@@ -336,7 +337,7 @@ test("adaptive Codex timeout preserves the default for small non-media PRs", () 
   );
 });
 
-test("adaptive Codex timeout scales for large PRs with video proofs", () => {
+test("adaptive Codex timeout scales for large PRs", () => {
   assert.equal(
     adaptiveCodexTimeoutMsForTest({
       changed_files: 71,
@@ -348,11 +349,11 @@ test("adaptive Codex timeout scales for large PRs with video proofs", () => {
         "https://uploads.example.invalid/proof-b.mp4.",
       ].join("\n"),
     }),
-    1_508_800,
+    1_268_800,
   );
 });
 
-test("adaptive Codex timeout stays capped within review shard limits", () => {
+test("adaptive Codex timeout stays capped separately from media preprocessing", () => {
   assert.equal(
     adaptiveCodexTimeoutMsForTest({
       changed_files: 1000,
@@ -366,7 +367,7 @@ test("adaptive Codex timeout stays capped within review shard limits", () => {
         "https://uploads.example.invalid/five.avi",
       ].join("\n"),
     }),
-    1_800_000,
+    1_500_000,
   );
 });
 
@@ -435,7 +436,11 @@ test("pull request webhooks dispatch adaptive Codex timeout payload", async () =
     assert.equal(dispatchedBody?.event_type, "clawsweeper_item");
     assert.equal(
       (dispatchedBody?.client_payload as Record<string, unknown>)?.codex_timeout_ms,
-      1_508_800,
+      1_268_800,
+    );
+    assert.equal(
+      (dispatchedBody?.client_payload as Record<string, unknown>)?.media_proof_timeout_ms,
+      240_000,
     );
   } finally {
     globalThis.fetch = previousFetch;


### PR DESCRIPTION
## Summary
- centralize adaptive review budgeting across webhook, maintainer-command, and post-repair dispatch paths
- preserve the configured Codex timeout as a floor instead of lowering operator-selected budgets
- budget media preprocessing separately, with bounded and validated workflow inputs
- keep the 25-input workflow-dispatch fallback within GitHub's limit by folding media allowance into its existing timeout input

Follow-up hardening for #275 after reviewing the landed generated implementation.

## Validation
- `pnpm run check` (495 unit tests, 541 repair tests, coverage, lint, builds, formatting)
- `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- autoreview clean: no accepted/actionable findings
