### PR TITLE
fix: clarify generated PR completion

### DIFF
--- a/.github/workflows/repair-cluster-worker.yml
+++ b/.github/workflows/repair-cluster-worker.yml
@@ -592,6 +592,8 @@ jobs:
               post_flight_report=""
             fi
             if [ -n "$pr_url" ]; then
+              state="PR Opened"
+              detail="The implementation PR is open. Normal pull request checks and maintainer review continue on $pr_url."
               post_flight_ready="false"
               if [ -n "$post_flight_report" ]; then
                 post_flight_ready="$(
@@ -607,8 +609,7 @@ jobs:
                 )"
               fi
               if [ "$post_flight_ready" = "true" ]; then
-                state="Complete"
-                detail="The implementation worker opened or updated $pr_url after edit, validation, internal review, publish, and post-flight checks."
+                detail="The implementation PR passed the worker's edit, validation, review, publish, and post-flight gates."
               else
                 reason="$(
                   jq -r '
@@ -633,7 +634,7 @@ jobs:
                   )"
                 fi
                 if [ -n "$reason" ]; then
-                  detail="The automatic implementation worker stopped before all post-flight gates passed: $reason"
+                  detail="The implementation PR is open. Post-flight status: $reason"
                 fi
               fi
             fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Keep generated implementation PR bodies and terminal issue comments concise, avoid stale blocked states while PR checks are pending, and stop adding ClawSweeper itself as a commit co-author.
 - Prevented trusted ClawSweeper command status comments from re-entering GitHub activity handling and churning review automation. Thanks @ooiuuii.
 - Routed proof-sufficient security reviews that recommend maintainer risk acceptance to maintainer review instead of waiting on the contributor. Thanks @brokemac79.
 - Prevented automatic issue backfill from spending Codex workers on reports explicitly blocked by product-decision, no-new-fix-PR, or maintainer-review signals.

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -1,9 +1,5 @@
 import type { JsonValue, LooseRecord } from "./json-types.js";
-import {
-  CLAWSWEEPER_CO_AUTHOR_TRAILER,
-  clawsweeperCoAuthorKey,
-  coAuthorKey,
-} from "./co-author-credit.js";
+import { clawsweeperCoAuthorKey, coAuthorKey } from "./co-author-credit.js";
 import {
   extractClawSweeperCommandLine,
   isClawSweeperReReviewCommandText,
@@ -894,10 +890,6 @@ function automergeCreditTrailers({ command, comments, commits }: LooseRecord): s
   for (const trailer of coAuthorTrailersFromCommits(commits, coAuthorKeys)) {
     trailers.push(trailer);
   }
-  if (!coAuthorKeys.has(clawsweeperCoAuthorKey())) {
-    coAuthorKeys.add(clawsweeperCoAuthorKey());
-    trailers.push(CLAWSWEEPER_CO_AUTHOR_TRAILER);
-  }
 
   const maintainer = maintainerCredit(
     command.maintainer_attribution ??
@@ -907,9 +899,6 @@ function automergeCreditTrailers({ command, comments, commits }: LooseRecord): s
   );
   if (!maintainer) return trailers;
   trailers.push(`Approved-by: ${maintainer.login}`);
-  if (!coAuthorKeys.has(maintainer.coAuthorKey)) {
-    trailers.push(`Co-authored-by: ${maintainer.name} <${maintainer.email}>`);
-  }
   return trailers;
 }
 
@@ -958,7 +947,7 @@ function coAuthorTrailersFromCommits(commits: JsonValue, seen: Set<string>): str
       const email = String(author?.email ?? "").trim();
       if (!name || !email) continue;
       const key = coAuthorKey(name, email);
-      if (seen.has(key)) continue;
+      if (key === clawsweeperCoAuthorKey() || seen.has(key)) continue;
       seen.add(key);
       trailers.push(`Co-authored-by: ${name} <${email}>`);
     }
@@ -969,16 +958,8 @@ function coAuthorTrailersFromCommits(commits: JsonValue, seen: Set<string>): str
 function maintainerCredit(value: LooseRecord): LooseRecord | null {
   const login = normalizedLogin(value.author ?? value.login);
   if (!login || login.includes("[bot]")) return null;
-  const id = String(value.author_id ?? value.id ?? "").trim();
-  const name = String(value.author_name ?? value.name ?? login).trim() || login;
-  const email = id
-    ? `${id}+${login}@users.noreply.github.com`
-    : `${login}@users.noreply.github.com`;
   return {
     login,
-    name,
-    email,
-    coAuthorKey: coAuthorKey(name, email),
   };
 }
 

--- a/src/repair/execute-fix-github.ts
+++ b/src/repair/execute-fix-github.ts
@@ -1,9 +1,5 @@
 import type { JsonValue, LooseRecord } from "./json-types.js";
-import {
-  CLAWSWEEPER_CO_AUTHOR,
-  CLAWSWEEPER_CO_AUTHOR_TRAILER,
-  coAuthorKey,
-} from "./co-author-credit.js";
+import { CLAWSWEEPER_CO_AUTHOR, coAuthorKey } from "./co-author-credit.js";
 import { runCommand as run } from "./command-runner.js";
 import { parsePullRequestUrl } from "./github-ref.js";
 import { repoRoot } from "./lib.js";
@@ -114,18 +110,15 @@ export function sourceContributorCredits({
 export function coAuthorTrailers(contributorCredits: LooseRecord[]): string[] {
   const seen = new Set<string>();
   const trailers: string[] = [];
+  const clawsweeperKey = coAuthorKey(CLAWSWEEPER_CO_AUTHOR.name, CLAWSWEEPER_CO_AUTHOR.email);
   for (const credit of contributorCredits) {
     const name = String(credit.name ?? "").trim();
     const email = String(credit.email ?? "").trim();
     if (!name || !email) continue;
     const key = coAuthorKey(name, email);
-    if (seen.has(key)) continue;
+    if (key === clawsweeperKey || seen.has(key)) continue;
     seen.add(key);
     trailers.push(`Co-authored-by: ${name} <${email}>`);
-  }
-  const clawsweeperKey = coAuthorKey(CLAWSWEEPER_CO_AUTHOR.name, CLAWSWEEPER_CO_AUTHOR.email);
-  if (!seen.has(clawsweeperKey)) {
-    trailers.push(CLAWSWEEPER_CO_AUTHOR_TRAILER);
   }
   return trailers;
 }

--- a/src/repair/external-messages.ts
+++ b/src/repair/external-messages.ts
@@ -420,33 +420,27 @@ export function replacementSourceCloseComment({
 
 export function replacementPrBody({
   fixArtifact,
-  fallbackReason,
-  clusterId,
-  provenance,
   contributorCredits,
   maintainerAttribution = null,
   sourceClosingReferences = [],
 }: LooseRecord) {
-  const lines = [
-    fixArtifact.pr_body.trim(),
-    "",
-    `${SIGNATURE} replacement reef notes:`,
-    `- Cluster: ${clusterId}`,
-    `- Source PRs: ${(fixArtifact.source_prs ?? []).join(", ") || "none"}`,
-    `- Credit: ${listOrNone(fixArtifact.credit_notes)}`,
-    `- Validation: ${listOrNone(fixArtifact.validation_commands)}`,
-    "- Replacement reason: ClawSweeper could not update the source PR branch directly, so it opened a writable replacement PR instead.",
-  ];
+  const lines = [fixArtifact.pr_body.trim()];
+  const sourcePrs = uniqueLines(fixArtifact.source_prs);
+  if (sourcePrs.length > 0) {
+    lines.push(
+      "",
+      "## Source",
+      `Replacement for ${sourcePrs.join(", ")} because the source branch could not be updated.`,
+    );
+  }
   const maintainer = automergeMaintainerAttribution(maintainerAttribution);
   if (maintainer) {
-    lines.push(`- Automerge requested by: @${maintainer.login}`);
     lines.push(
       `<!-- clawsweeper-automerge-requested-by login="${escapeHtmlAttribute(
         maintainer.login,
       )}" id="${escapeHtmlAttribute(maintainer.id)}" -->`,
     );
   }
-  if (fallbackReason) lines.push(`- Repair fallback: ${fallbackReason}`);
   const closingReferences = uniqueLines(sourceClosingReferences);
   if (closingReferences.length > 0) {
     lines.push(
@@ -455,9 +449,22 @@ export function replacementPrBody({
       ...closingReferences.map((reference) => `${reference}`),
     );
   }
-  const creditLines = contributorCreditLines(contributorCredits);
-  if (creditLines.length > 0) lines.push("", ...creditLines);
-  lines.push("", fishNotes(provenance));
+  const contributorLogins = uniqueLines(
+    (Array.isArray(contributorCredits) ? contributorCredits : [])
+      .map((credit: JsonValue) =>
+        String(credit?.login ?? "")
+          .replace(/^@/, "")
+          .trim(),
+      )
+      .filter(Boolean)
+      .map((login: string) => `@${login}`),
+  );
+  if (contributorLogins.length > 0) {
+    lines.push(
+      "",
+      `Original contributor${contributorLogins.length === 1 ? "" : "s"}: ${contributorLogins.join(", ")}.`,
+    );
+  }
   return `${lines.join("\n")}\n`;
 }
 

--- a/src/repair/issue-implementation-status.ts
+++ b/src/repair/issue-implementation-status.ts
@@ -134,6 +134,32 @@ export function renderIssueImplementationStatusComment(
   options: StatusOptions,
 ) {
   const marker = issueImplementationStatusMarker(options.itemNumber);
+  const normalizedState = options.state.trim().toLowerCase();
+  if (normalizedState.includes("complete") || normalizedState.includes("open")) {
+    return [
+      marker,
+      "🦞✅",
+      options.prUrl
+        ? `Implementation PR opened: ${options.prUrl}`
+        : "Automatic implementation completed.",
+      options.detail ? `Status: ${options.detail}` : null,
+      options.runUrl ? `Worker: ${options.runUrl}` : null,
+    ]
+      .filter(Boolean)
+      .join("\n");
+  }
+  if (normalizedState.includes("block") || normalizedState.includes("fail")) {
+    return [
+      marker,
+      "🦞⚠️",
+      "Automatic implementation stopped before completion.",
+      options.detail ? `Reason: ${options.detail}` : null,
+      options.prUrl ? `PR: ${options.prUrl}` : null,
+      options.runUrl ? `Worker: ${options.runUrl}` : null,
+    ]
+      .filter(Boolean)
+      .join("\n");
+  }
   const progress = [
     PROGRESS_START,
     "Automatic implementation progress:",

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -2504,7 +2504,7 @@ test("automerge merge args pin the reviewed head SHA", () => {
   );
 });
 
-test("automerge squash message credits the initiating maintainer with approval and co-author trailers", () => {
+test("automerge squash message credits contributors and records maintainer approval", () => {
   const message = buildAutomergeSquashMessage({
     command: {
       issue_number: 123,
@@ -2536,18 +2536,12 @@ test("automerge squash message credits the initiating maintainer with approval a
     message.body,
     /^Co-authored-by: Contributor <111\+contributor@users\.noreply\.github\.com>$/m,
   );
-  assert.match(
-    message.body,
-    /^Co-authored-by: clawsweeper\[bot\] <274271284\+clawsweeper\[bot\]@users\.noreply\.github\.com>$/m,
-  );
+  assert.doesNotMatch(message.body, /Co-authored-by: clawsweeper\[bot\]/);
   assert.match(message.body, /^Approved-by: maintainer-user$/m);
-  assert.match(
-    message.body,
-    /^Co-authored-by: maintainer-user <123456\+maintainer-user@users\.noreply\.github\.com>$/m,
-  );
+  assert.doesNotMatch(message.body, /Co-authored-by: maintainer-user/);
 });
 
-test("automerge squash message dedupes maintainer co-author trailer", () => {
+test("automerge squash message does not duplicate a contributor as approving maintainer", () => {
   const message = buildAutomergeSquashMessage({
     command: {
       issue_number: 123,
@@ -2584,7 +2578,7 @@ test("automerge squash message dedupes maintainer co-author trailer", () => {
   assert.match(message.body, /^Approved-by: maintainer-user$/m);
 });
 
-test("automerge squash message dedupes ClawSweeper co-author trailer", () => {
+test("automerge squash message omits ClawSweeper co-author trailer", () => {
   const message = buildAutomergeSquashMessage({
     command: {
       issue_number: 123,
@@ -2614,7 +2608,7 @@ test("automerge squash message dedupes ClawSweeper co-author trailer", () => {
 
   assert.equal(
     message.body.split("\n").filter((line) => line === CLAWSWEEPER_CO_AUTHOR_TRAILER).length,
-    1,
+    0,
   );
   assert.match(message.body, /^Approved-by: maintainer-user$/m);
 });
@@ -2645,14 +2639,8 @@ test("automerge squash message credits maintainer metadata carried by replacemen
   });
 
   assert.match(message.body, /^Approved-by: maintainer-user$/m);
-  assert.match(
-    message.body,
-    /^Co-authored-by: clawsweeper\[bot\] <274271284\+clawsweeper\[bot\]@users\.noreply\.github\.com>$/m,
-  );
-  assert.match(
-    message.body,
-    /^Co-authored-by: maintainer-user <123456\+maintainer-user@users\.noreply\.github\.com>$/m,
-  );
+  assert.doesNotMatch(message.body, /Co-authored-by: clawsweeper\[bot\]/);
+  assert.doesNotMatch(message.body, /Co-authored-by: maintainer-user/);
 });
 
 test("automerge squash message credits requester from earlier automerge status marker", () => {
@@ -2708,10 +2696,7 @@ test("automerge squash message credits requester from earlier automerge status m
   });
 
   assert.match(message.body, /^Approved-by: maintainer-user$/m);
-  assert.match(
-    message.body,
-    /^Co-authored-by: maintainer-user <123456\+maintainer-user@users\.noreply\.github\.com>$/m,
-  );
+  assert.doesNotMatch(message.body, /Co-authored-by: maintainer-user/);
 });
 
 test("automerge gate block only reports the global merge policy gate", () => {

--- a/test/repair/execute-fix-github.test.ts
+++ b/test/repair/execute-fix-github.test.ts
@@ -1,10 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { CLAWSWEEPER_CO_AUTHOR_TRAILER } from "../../dist/repair/co-author-credit.js";
 import { coAuthorTrailers } from "../../dist/repair/execute-fix-github.js";
 
-test("replacement co-author trailers include contributor and ClawSweeper credit", () => {
+test("replacement co-author trailers include contributors without bot self-credit", () => {
   assert.deepEqual(
     coAuthorTrailers([
       {
@@ -12,14 +11,11 @@ test("replacement co-author trailers include contributor and ClawSweeper credit"
         email: "1+octocat@users.noreply.github.com",
       },
     ]),
-    [
-      "Co-authored-by: Mona Octocat <1+octocat@users.noreply.github.com>",
-      CLAWSWEEPER_CO_AUTHOR_TRAILER,
-    ],
+    ["Co-authored-by: Mona Octocat <1+octocat@users.noreply.github.com>"],
   );
 });
 
-test("replacement co-author trailers dedupe ClawSweeper credit", () => {
+test("replacement co-author trailers omit ClawSweeper self-credit", () => {
   assert.deepEqual(
     coAuthorTrailers([
       {
@@ -27,6 +23,6 @@ test("replacement co-author trailers dedupe ClawSweeper credit", () => {
         email: "274271284+clawsweeper[bot]@users.noreply.github.com",
       },
     ]),
-    [CLAWSWEEPER_CO_AUTHOR_TRAILER],
+    [],
   );
 });

--- a/test/repair/external-messages.test.ts
+++ b/test/repair/external-messages.test.ts
@@ -94,7 +94,7 @@ test("replacement comments explain no push rights and keep co-author credit visi
   );
 });
 
-test("replacement PR body records replacement reason and co-author credit", () => {
+test("replacement PR body keeps public context without internal worker notes", () => {
   const body = replacementPrBody({
     clusterId: "ghcrawl-123",
     fixArtifact: {
@@ -118,13 +118,11 @@ test("replacement PR body records replacement reason and co-author credit", () =
     provenance: { model: "gpt-test", reasoning: "medium", reviewedSha: "abcdef1234567890" },
   });
 
-  assert.match(body, /Replacement reason: ClawSweeper could not update the source PR branch/);
-  assert.match(body, /Repair fallback: source PR #12345 has maintainer_can_modify=false/);
   assert.match(
     body,
-    /@octocat: Co-authored-by: Mona Octocat <1\+octocat@users\.noreply\.github\.com>/,
+    /Replacement for https:\/\/github\.com\/openclaw\/openclaw\/pull\/12345 because the source branch could not be updated\./,
   );
-  assert.match(body, /Automerge requested by: @maintainer-user/);
+  assert.match(body, /Original contributor: @octocat\./);
   assert.match(
     body,
     /Inherited issue-closing references from the source PR:\nCloses #74124\nFixes openclaw\/openclaw#81234/,
@@ -133,6 +131,25 @@ test("replacement PR body records replacement reason and co-author credit", () =
     body,
     /<!-- clawsweeper-automerge-requested-by login="maintainer-user" id="123456" -->/,
   );
+  assert.doesNotMatch(body, /replacement reef notes|fish notes|Cluster:|Repair fallback:/);
+  assert.equal(body.match(/pnpm check/g)?.length ?? 0, 0);
+});
+
+test("issue-generated PR body does not claim to replace a source PR", () => {
+  const body = replacementPrBody({
+    clusterId: "issue-openclaw-gogcli-814",
+    fixArtifact: {
+      pr_body: "## Summary\n\nDocument the existing alias.\n\nFixes #814",
+      source_prs: [],
+      credit_notes: ["Thanks @reporter."],
+      validation_commands: ["pnpm check"],
+    },
+    fallbackReason: "",
+    contributorCredits: [],
+    provenance: { reasoning: "high", reviewedSha: "abcdef1234567890" },
+  });
+
+  assert.equal(body, "## Summary\n\nDocument the existing alias.\n\nFixes #814\n");
 });
 
 test("closingReferencesFromMarkdown extracts GitHub closing syntax", () => {

--- a/test/repair/issue-implementation-status.test.ts
+++ b/test/repair/issue-implementation-status.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
 import test from "node:test";
 
 import {
@@ -45,7 +46,34 @@ test("issue implementation status updates progress without replacing worker resu
     detail: "Implementation workflow completed.",
   });
 
-  assert.equal(updated.match(/Automatic implementation progress:/g)?.length, 1);
-  assert.match(updated, /State: Complete/);
-  assert.match(updated, /## Implementation result\n\nPull request opened\./);
+  assert.doesNotMatch(updated, /Automatic implementation progress:/);
+  assert.match(updated, /Automatic implementation completed\./);
+  assert.doesNotMatch(updated, /## Implementation result/);
+});
+
+test("issue implementation status collapses an opened PR to a concise terminal comment", () => {
+  const body = renderIssueImplementationStatusComment("", {
+    ...options,
+    state: "PR Opened",
+    detail: "Checks continue on the pull request.",
+    prUrl: "https://github.com/steipete/example/pull/51",
+  });
+
+  assert.match(
+    body,
+    /Implementation PR opened: https:\/\/github\.com\/steipete\/example\/pull\/51/,
+  );
+  assert.match(body, /Status: Checks continue on the pull request\./);
+  assert.doesNotMatch(body, /Automatic implementation progress|Opt out|State:/);
+});
+
+test("issue build workflow reports an opened PR without calling pending CI blocked", () => {
+  const workflow = fs.readFileSync(".github/workflows/repair-cluster-worker.yml", "utf8");
+
+  assert.match(workflow, /state="PR Opened"/);
+  assert.match(workflow, /The implementation PR is open\. Post-flight status:/);
+  assert.doesNotMatch(
+    workflow,
+    /detail="The automatic implementation worker stopped before all post-flight gates passed:/,
+  );
 });


### PR DESCRIPTION
## Summary

- keep generated implementation PR bodies focused on the change, source, and validation
- stop crediting ClawSweeper itself as a commit co-author
- collapse terminal issue progress comments to a concise final result
- report an opened PR as opened while checks continue instead of leaving a stale blocked state

## Validation

- `pnpm run check`
- focused repair suite: 115 tests passed
- autoreview: clean
