### PR TITLE
Add OpenAI-compatible repair backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ jobs/
 records/
 results/
 triage-dashboard-dev*.log
+config/model-backend.json
+
+.clawsweeper-home/

--- a/config/model-backend.example.json
+++ b/config/model-backend.example.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "backend": "openai-compatible-tools",
+  "base_url": "https://api.example.com/v1",
+  "model": "provider/model-name",
+  "api_key_env": "EXAMPLE_API_KEY",
+  "max_turns": 0,
+  "max_tokens": 0
+}

--- a/docs/repair/model-backends.md
+++ b/docs/repair/model-backends.md
@@ -1,0 +1,59 @@
+# Repair model backend configuration
+
+ClawSweeper repair workers can use different model backends without putting provider, model, URL, or key settings in ad-hoc shell commands.
+
+A user-level config can be placed at:
+
+```text
+~/.config/clawsweeper/model-backend.json
+```
+
+Set CLAWSWEEPER_MODEL_BACKEND_CONFIG to use another path.
+A repository-local config can also be used for development at:
+
+```text
+config/model-backend.json
+```
+
+That local file is ignored by git. Commit only the safe example file:
+
+```text
+config/model-backend.example.json
+```
+
+## Shape
+
+```json
+{
+  "schema_version": 1,
+  "backend": "openai-compatible-tools",
+  "openai_compatible": {
+    "base_url": "https://api.example.com/v1",
+    "model": "provider/model-name",
+    "api_key_env": "PROVIDER_API_KEY",
+    "max_turns": 0,
+    "max_tokens": 0
+  }
+}
+```
+
+`api_key_env` is the name of an environment variable already present in the runtime. Do not put API key values in this file. `max_turns` omitted, blank, or `0` means no turn limit; `max_tokens` omitted, blank, or `0` means do not send an explicit provider token cap.
+
+## Backends
+
+- `codex-cli`: run the Codex CLI and let Codex read its own `CODEX_HOME` configuration.
+- `openai-compatible-tools`: run ClawSweeper's OpenAI-compatible tool loop and fill its generic `base_url`, `model`, and `api_key_env` from this config.
+
+Environment variables such as `CLAWSWEEPER_MODEL_BACKEND` and `CLAWSWEEPER_OPENAI_COMPATIBLE_MODEL` remain supported as emergency/backcompat overrides, but normal operator commands should not include them.
+
+## Operator command
+
+```bash
+corepack pnpm run repair:worker -- jobs/<owner>/inbox/<job>.md --mode autonomous
+```
+
+If the execute gate is closed, open only the gate for that invocation:
+
+```bash
+CLAWSWEEPER_ALLOW_EXECUTE=1 corepack pnpm run repair:worker -- jobs/<owner>/inbox/<job>.md --mode autonomous
+```

--- a/docs/repair/openai-compatible-adapter-notes.md
+++ b/docs/repair/openai-compatible-adapter-notes.md
@@ -1,0 +1,194 @@
+# Repair-only OpenAI-compatible adapter — notes
+
+Date: 2026-06-13
+Branch: `feature/repair-only-intake`
+Status: working engineering note
+
+## Why this exists
+
+Repair-only PR intake now detects objective repair candidates instead of doing broad PR review. In a live target repository, the corrected intake selected only PRs with current objective blockers such as merge/check failures or unresolved review threads.
+
+Execution exposed a backend mismatch. The existing repair worker expected Codex-native output-schema support, but some deployments use OpenAI-compatible Chat Completions backends where that native Codex behaviour is not available.
+
+## Core idea
+
+Do not treat tool use and final structured output as the same phase.
+
+```text
+job.md
+  -> prepare target checkout
+  -> fetch source PR refs
+  -> bounded tool loop
+  -> finalization without tools
+  -> deterministic normalize/validate
+  -> result.json / fix_artifact
+```
+
+For OpenAI-compatible providers, final JSON should be a separate finalization phase plus local validation, not another LLM schema-repair loop.
+
+## Key learnings
+
+### Deterministic intake first
+
+Only current blockers create repair jobs: bad merge state, failed/cancelled/timed-out checks, current `CHANGES_REQUESTED`, unresolved current review threads. Historic CodeRabbit comments are context, not triggers. This fixed the initial 8/8 overmatching and got us to 2/8.
+
+### Source PR refs are mandatory for third-party repos
+
+For repos not owned by us, checkout starts on base `main`. The worker fetches PR heads into local refs:
+
+```bash
+git fetch origin refs/pull/<number>/head:clawsweeper/source-pr-<number>
+```
+
+The model must inspect with `git diff main...clawsweeper/source-pr-<number>` and `git show clawsweeper/source-pr-<number>:path`.
+
+### Pseudo-tool-call parsing is required
+
+Pioneer/DeepSeek may emit tool calls as text instead of native `tool_calls`, including JSON objects and DSML blocks. The adapter has to parse and normalize these into internal tool calls.
+
+### Local normalization, not LLM schema repair
+
+The earlier schema-repair LLM call caused timeouts and more malformed output. For `codex-result.schema.json`, use local parse/normalize/validate.
+
+### Finalization must be isolated and compact
+
+If max tool turns are exhausted after tool results, make a final call with tools disabled. Passing the full tool transcript can keep Pioneer/DeepSeek in tool-call mode. Use a compact isolated prompt: schema path, repo/cluster/canonical PR, source PR refs/job essentials, compact evidence, explicit “JSON only, no tools, no DSML”.
+
+### Normalize multiple fix_artifact shapes
+
+The model may return `{"fix_needed": true, "build_fix_artifact": {...}}` or `{"actions": [{"action": "build_fix_artifact", "fix_artifact": {...}}]}`. Preserve both into canonical `status=planned`, `action=build_fix_artifact`, `needs_human=[]`, `fix_artifact={...}`.
+
+### Block premature needs_human
+
+If output is `needs_human`, `toolsExecuted == 0`, and prompt has `## Source PR refs`, reject it and force source-ref inspection. We saw false claims that `clawsweeper/source-pr-460` was unavailable even though it was prepared.
+
+## Current green milestone
+
+A forced run against `#460` produced:
+
+```text
+status: planned
+action: build_fix_artifact
+needs_human: []
+fix_artifact: true
+repair_strategy: repair_contributor_branch
+source_prs: [https://github.com/example/project/pull/123]
+likely_files: [scripts/lib/workflows.sh]
+validation_commands: [bash -n scripts/lib/workflows.sh]
+```
+
+This is the key behavioural milestone: the adapter can produce a planned repair artifact instead of false `needs_human`.
+
+## Weak points still present
+
+1. `openai-compatible-tools-runner.ts` is too monolithic: provider transport, tool loop, textual tools, finalization, normalization, and quirks are mixed.
+2. Provider quirks are scattered conditionals instead of an explicit profile.
+3. No durable `Step[]` model yet; finalization is built from message slicing.
+4. No-diff `build_fix_artifact` can still use misleading language like “Applied fixes”. It should say “plan/propose repair artifact”.
+5. Schema-valid does not mean evidence-supported. Need a later evidence-support check.
+6. The pipeline reaches `result.json` / `fix_artifact`; it does not yet deliver the GitHub fix.
+7. Tests are mostly live integration tests. Need fixtures for pseudo-tools, DSML, init JSON, premature `needs_human`, action-scoped `fix_artifact`, boolean fields, finalization, and no-diff language.
+
+## External learning sources
+
+### Vercel AI SDK
+
+Most useful practical reference: multi-step tool loop, `stopWhen`, explicit steps, structured output after tool use, and OpenAI-compatible caveats.
+
+- https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling
+- https://ai-sdk.dev/docs/ai-sdk-core/generating-structured-data
+- https://vercel.com/academy/ai-sdk/multi-step-and-generative-ui
+- https://github.com/vercel/ai/discussions/3323
+- https://github.com/vercel/ai/issues/5197
+
+### OpenAI Agents / API docs
+
+Canonical loop: call model, inspect output, execute tool calls, continue, final output.
+
+- https://developers.openai.com/api/docs/guides/agents/running-agents
+- https://openai.github.io/openai-agents-python/tools/
+- https://openai.github.io/openai-agents-python/human_in_the_loop/
+
+### Pydantic AI
+
+Useful taxonomy: Tool Output, Native Output, Prompted Output.
+
+- https://pydantic.dev/docs/ai/core-concepts/output/
+- https://pydantic.dev/docs/ai/tools-toolsets/tools/
+- https://github.com/pydantic/pydantic-ai/issues/1192
+
+### Instructor
+
+Worth studying before expanding the normalizer: extraction-first structured output, retries, and provider-specific quirks.
+
+## Refactor direction inspired by Vercel
+
+Keep our integration, but split responsibilities:
+
+```text
+src/repair/openai-compatible/
+  profile.ts
+  provider.ts
+  tools.ts
+  textual-tools.ts
+  loop.ts
+  finalization.ts
+  normalize-result.ts
+  evidence.ts
+```
+
+Core types:
+
+```ts
+type ProviderProfile = {
+  name: string;
+  parseTextualToolCalls: boolean;
+  parseDsmlToolCalls: boolean;
+  finalizationMode: "same_history" | "isolated_summary";
+  structuredOutputMode: "native" | "prompt_json_then_validate";
+  ignoreNonFinalSystemJson: boolean;
+  normalizeActionScopedFixArtifact: boolean;
+  blockPrematureNeedsHumanBeforeTools: boolean;
+  maxToolSteps: number;
+};
+
+type Step = {
+  index: number;
+  assistantText?: string;
+  toolCalls: ToolCall[];
+  toolResults: ToolResult[];
+};
+```
+
+Pioneer/DeepSeek profile should set textual/DSML parsing on, isolated summary finalization, prompt+validate structured output, ignore non-final system JSON, normalize action-scoped fix artifacts, and block premature `needs_human`.
+
+## Humanizer next
+
+Study humanizer for maintainer-facing language, not tool-loop mechanics. Extract:
+
+- machine summary -> maintainer-safe language;
+- contributor credit preservation;
+- avoiding “applied/fixed” claims when only a plan exists;
+- exact blockers vs generic `needs_human`;
+- precise, non-accusatory PR bodies/comments.
+
+Humanizer should run after structural normalization and validation:
+
+```text
+raw model result
+  -> structural normalizer
+  -> schema validation
+  -> evidence support check
+  -> humanizer/language pass
+  -> final result.json / PR body
+```
+
+## Recommended next steps
+
+1. Preserve current green behaviour with unit fixtures.
+2. Add deterministic tests around all provider-quirk cases observed.
+3. Refactor monolithic runner into Vercel-style steps/profile modules.
+4. Add provider profile for Pioneer/DeepSeek.
+5. Add language sanitization for no-diff `build_fix_artifact`.
+6. Study humanizer and integrate it as a post-normalization pass.
+7. Only then wire downstream GitHub delivery for `repair_contributor_branch` / replacement PR.

--- a/src/repair/evidence-pack.ts
+++ b/src/repair/evidence-pack.ts
@@ -1,0 +1,211 @@
+import { spawnSync } from "node:child_process";
+import type { LooseRecord } from "./json-types.js";
+import { parsePullRequestUrl } from "./github-ref.js";
+import { sourcePullRequestRemoteRef } from "./source-pr-checkout.js";
+
+export type RepairEvidencePack = {
+  repo: string;
+  cluster_id: string;
+  source_prs: EvidenceSourcePullRequest[];
+  repair_signals: EvidenceRepairSignal[];
+  evidence_gates: {
+    source_pr_ref_fetched: boolean;
+    source_pr_diff_read: boolean;
+    actionable_signal_read: boolean;
+    relevant_hunk_read: boolean;
+  };
+  likely_files: string[];
+  validation_hints: string[];
+  operator_notes: string[];
+};
+
+type EvidenceSourcePullRequest = {
+  number: number;
+  url: string;
+  local_ref: string;
+  base_ref: string;
+  diff_ref: string;
+  changed_files: string[];
+  diff_stat: string;
+  relevant_hunks: EvidenceHunk[];
+};
+
+type EvidenceRepairSignal = {
+  kind: string;
+  text: string;
+  mentioned_files: string[];
+};
+
+type EvidenceHunk = {
+  file: string;
+  reason: string;
+  excerpt: string;
+};
+
+export function buildRepairEvidencePack(job: LooseRecord, targetDir: string): RepairEvidencePack {
+  const repo = stringValue(job.frontmatter?.repo);
+  const clusterId = stringValue(job.frontmatter?.cluster_id);
+  const signals = extractRepairSignals(String(job.body ?? job.raw ?? ""));
+  const signalFiles = unique(signals.flatMap((signal) => signal.mentioned_files));
+  const baseRef = targetBaseRef(targetDir);
+  const sourcePrs = sourcePullRequests(job).map(({ number, url }) => {
+    const localRef = sourcePullRequestRemoteRef(number);
+    const diffRef = hasMergeBase(targetDir, baseRef, localRef)
+      ? `${baseRef}...${localRef}`
+      : `${baseRef}..${localRef}`;
+    const changedFiles = gitLines(targetDir, ["diff", "--name-only", diffRef]);
+    const relevantFiles = selectRelevantFiles(changedFiles, signalFiles);
+    return {
+      number,
+      url,
+      local_ref: localRef,
+      base_ref: baseRef,
+      diff_ref: diffRef,
+      changed_files: changedFiles,
+      diff_stat: gitText(targetDir, ["diff", "--stat", diffRef]),
+      relevant_hunks: relevantFiles.slice(0, 6).map((file) => ({
+        file,
+        reason: signalFiles.includes(file) ? "mentioned_by_repair_signal_and_changed" : "changed_in_source_pr",
+        excerpt: truncate(gitText(targetDir, ["diff", "--unified=60", diffRef, "--", file]), 12000),
+      })),
+    };
+  });
+  const changedFiles = unique(sourcePrs.flatMap((pr) => pr.changed_files));
+  const likelyFiles = selectRelevantFiles(changedFiles, signalFiles);
+  return {
+    repo,
+    cluster_id: clusterId,
+    source_prs: sourcePrs,
+    repair_signals: signals,
+    evidence_gates: {
+      source_pr_ref_fetched: sourcePrs.some((pr) => gitRefExists(targetDir, pr.local_ref)),
+      source_pr_diff_read: sourcePrs.some((pr) => pr.changed_files.length > 0),
+      actionable_signal_read: signals.length > 0,
+      relevant_hunk_read: sourcePrs.some((pr) => pr.relevant_hunks.length > 0),
+    },
+    likely_files: likelyFiles,
+    validation_hints: validationHints(likelyFiles),
+    operator_notes: [
+      "Evidence pack is deterministic and generic; it is not a model conclusion.",
+      "The model must base repair-only intake on the source PR diff, objective repair signals, and relevant hunks above before finalizing.",
+    ],
+  };
+}
+
+export function renderRepairEvidencePack(pack: RepairEvidencePack): string {
+  return JSON.stringify(pack, null, 2);
+}
+
+export function extractRepairSignals(body: string): EvidenceRepairSignal[] {
+  const lines = body.split(/\r?\n/);
+  const out: EvidenceRepairSignal[] = [];
+  let inSignals = false;
+  for (const line of lines) {
+    if (/^(?:##\s+)?Repair signals:?$/i.test(line.trim())) {
+      inSignals = true;
+      continue;
+    }
+    if (inSignals && (/^##\s+/.test(line.trim()) || /^[A-Z][A-Za-z ]+:$/.test(line.trim()))) break;
+    if (!inSignals) continue;
+    const match = line.match(/^\s*-\s+([^:]+):\s*(.+)$/);
+    if (!match) continue;
+    const text = (match[2] ?? "").trim();
+    out.push({
+      kind: (match[1] ?? "repair_signal").trim(),
+      text,
+      mentioned_files: mentionedFiles(text),
+    });
+  }
+  return out;
+}
+
+function sourcePullRequests(job: LooseRecord): { number: number; url: string }[] {
+  const repo = stringValue(job.frontmatter?.repo);
+  const refs = new Map<number, string>();
+  for (const value of [
+    ...(Array.isArray(job.frontmatter?.canonical) ? job.frontmatter.canonical : []),
+    ...(Array.isArray(job.frontmatter?.candidates) ? job.frontmatter.candidates : []),
+  ]) {
+    const parsed = parsePullRequestUrl(value);
+    if (parsed) {
+      if (!repo || parsed.repo.toLowerCase() === repo.toLowerCase()) refs.set(parsed.number, parsed.url);
+      continue;
+    }
+    const shorthand = String(value ?? "").trim().match(/^#?(\d+)$/);
+    if (shorthand?.[1] && repo) refs.set(Number(shorthand[1]), `https://github.com/${repo}/pull/${shorthand[1]}`);
+  }
+  return [...refs].map(([number, url]) => ({ number, url }));
+}
+
+function mentionedFiles(text: string): string[] {
+  const out: string[] = [];
+  for (const match of text.matchAll(/`@?([^`]+)`/g)) addFileMentions(out, match[1] ?? "");
+  for (const match of text.matchAll(/@?([A-Za-z0-9_.-]+(?:\/[A-Za-z0-9_.@-]+)+)/g)) addFileMentions(out, match[1] ?? "");
+  return unique(out);
+}
+
+function addFileMentions(out: string[], value: string): void {
+  for (const part of value.split(/[\s,]+/)) {
+    const cleaned = part.trim().replace(/^@/, "").replace(/^\/+/, "").replace(/[).:,;]+$/, "");
+    if (!cleaned || cleaned.includes("http") || cleaned.startsWith("github.com/") || cleaned.startsWith("www.")) continue;
+    if (!cleaned.includes("/")) continue;
+    if (/^[A-Za-z0-9_.@-]+\/[A-Za-z0-9_.@-]+$/.test(cleaned) && !cleaned.includes(".")) continue;
+    out.push(cleaned);
+  }
+}
+
+function selectRelevantFiles(changedFiles: string[], signalFiles: string[]): string[] {
+  const exact = changedFiles.filter((file) => signalFiles.includes(file));
+  const parentMatches = changedFiles.filter((file) =>
+    signalFiles.some((signalFile) => file.startsWith(`${signalFile.replace(/\/$/, "")}/`) || signalFile.startsWith(`${file.replace(/\/$/, "")}/`)),
+  );
+  return unique([...exact, ...parentMatches, ...changedFiles]).slice(0, 12);
+}
+
+function validationHints(files: string[]): string[] {
+  const hints = new Set<string>();
+  if (files.some((file) => file.endsWith(".sh"))) hints.add("bash -n <changed shell scripts>");
+  if (files.some((file) => file.endsWith(".ts") || file.endsWith(".tsx") || file.endsWith(".js") || file.endsWith(".jsx"))) hints.add("run the narrowest package test/lint command for changed JS/TS files");
+  if (files.some((file) => file.startsWith("test/") || file.includes("/test") || file.includes("tests/"))) hints.add("run the touched or nearest tests when available");
+  if (hints.size === 0 && files.length > 0) hints.add("run the narrowest repo-native validation for the touched files");
+  return [...hints];
+}
+
+function targetBaseRef(targetDir: string): string {
+  const ref = gitText(targetDir, ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"]).trim();
+  return ref || "origin/HEAD";
+}
+
+function hasMergeBase(targetDir: string, baseRef: string, localRef: string): boolean {
+  return gitStatus(targetDir, ["merge-base", baseRef, localRef]) === 0;
+}
+
+function gitRefExists(targetDir: string, ref: string): boolean {
+  return gitStatus(targetDir, ["rev-parse", "--verify", ref]) === 0;
+}
+
+function gitLines(targetDir: string, args: string[]): string[] {
+  return gitText(targetDir, args).split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+}
+
+function gitText(targetDir: string, args: string[]): string {
+  const result = spawnSync("git", ["-C", targetDir, ...args], { encoding: "utf8", maxBuffer: 1024 * 1024 * 4 });
+  return result.status === 0 ? result.stdout : "";
+}
+
+function gitStatus(targetDir: string, args: string[]): number | null {
+  const result = spawnSync("git", ["-C", targetDir, ...args], { encoding: "utf8", maxBuffer: 1024 * 1024 });
+  return result.status ?? null;
+}
+
+function truncate(value: string, limit: number): string {
+  return value.length > limit ? `${value.slice(0, limit)}\n...[truncated ${value.length - limit} chars]` : value;
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value : value == null ? "" : String(value);
+}

--- a/src/repair/evidence-pack.ts
+++ b/src/repair/evidence-pack.ts
@@ -65,7 +65,9 @@ export function buildRepairEvidencePack(job: LooseRecord, targetDir: string): Re
       diff_stat: gitText(targetDir, ["diff", "--stat", diffRef]),
       relevant_hunks: relevantFiles.slice(0, 6).map((file) => ({
         file,
-        reason: signalFiles.includes(file) ? "mentioned_by_repair_signal_and_changed" : "changed_in_source_pr",
+        reason: signalFiles.includes(file)
+          ? "mentioned_by_repair_signal_and_changed"
+          : "changed_in_source_pr",
         excerpt: truncate(gitText(targetDir, ["diff", "--unified=60", diffRef, "--", file]), 12000),
       })),
     };
@@ -128,11 +130,15 @@ function sourcePullRequests(job: LooseRecord): { number: number; url: string }[]
   ]) {
     const parsed = parsePullRequestUrl(value);
     if (parsed) {
-      if (!repo || parsed.repo.toLowerCase() === repo.toLowerCase()) refs.set(parsed.number, parsed.url);
+      if (!repo || parsed.repo.toLowerCase() === repo.toLowerCase())
+        refs.set(parsed.number, parsed.url);
       continue;
     }
-    const shorthand = String(value ?? "").trim().match(/^#?(\d+)$/);
-    if (shorthand?.[1] && repo) refs.set(Number(shorthand[1]), `https://github.com/${repo}/pull/${shorthand[1]}`);
+    const shorthand = String(value ?? "")
+      .trim()
+      .match(/^#?(\d+)$/);
+    if (shorthand?.[1] && repo)
+      refs.set(Number(shorthand[1]), `https://github.com/${repo}/pull/${shorthand[1]}`);
   }
   return [...refs].map(([number, url]) => ({ number, url }));
 }
@@ -140,14 +146,25 @@ function sourcePullRequests(job: LooseRecord): { number: number; url: string }[]
 function mentionedFiles(text: string): string[] {
   const out: string[] = [];
   for (const match of text.matchAll(/`@?([^`]+)`/g)) addFileMentions(out, match[1] ?? "");
-  for (const match of text.matchAll(/@?([A-Za-z0-9_.-]+(?:\/[A-Za-z0-9_.@-]+)+)/g)) addFileMentions(out, match[1] ?? "");
+  for (const match of text.matchAll(/@?([A-Za-z0-9_.-]+(?:\/[A-Za-z0-9_.@-]+)+)/g))
+    addFileMentions(out, match[1] ?? "");
   return unique(out);
 }
 
 function addFileMentions(out: string[], value: string): void {
   for (const part of value.split(/[\s,]+/)) {
-    const cleaned = part.trim().replace(/^@/, "").replace(/^\/+/, "").replace(/[).:,;]+$/, "");
-    if (!cleaned || cleaned.includes("http") || cleaned.startsWith("github.com/") || cleaned.startsWith("www.")) continue;
+    const cleaned = part
+      .trim()
+      .replace(/^@/, "")
+      .replace(/^\/+/, "")
+      .replace(/[).:,;]+$/, "");
+    if (
+      !cleaned ||
+      cleaned.includes("http") ||
+      cleaned.startsWith("github.com/") ||
+      cleaned.startsWith("www.")
+    )
+      continue;
     if (!cleaned.includes("/")) continue;
     if (/^[A-Za-z0-9_.@-]+\/[A-Za-z0-9_.@-]+$/.test(cleaned) && !cleaned.includes(".")) continue;
     out.push(cleaned);
@@ -157,7 +174,11 @@ function addFileMentions(out: string[], value: string): void {
 function selectRelevantFiles(changedFiles: string[], signalFiles: string[]): string[] {
   const exact = changedFiles.filter((file) => signalFiles.includes(file));
   const parentMatches = changedFiles.filter((file) =>
-    signalFiles.some((signalFile) => file.startsWith(`${signalFile.replace(/\/$/, "")}/`) || signalFile.startsWith(`${file.replace(/\/$/, "")}/`)),
+    signalFiles.some(
+      (signalFile) =>
+        file.startsWith(`${signalFile.replace(/\/$/, "")}/`) ||
+        signalFile.startsWith(`${file.replace(/\/$/, "")}/`),
+    ),
   );
   return unique([...exact, ...parentMatches, ...changedFiles]).slice(0, 12);
 }
@@ -165,9 +186,24 @@ function selectRelevantFiles(changedFiles: string[], signalFiles: string[]): str
 function validationHints(files: string[]): string[] {
   const hints = new Set<string>();
   if (files.some((file) => file.endsWith(".sh"))) hints.add("bash -n <changed shell scripts>");
-  if (files.some((file) => file.endsWith(".ts") || file.endsWith(".tsx") || file.endsWith(".js") || file.endsWith(".jsx"))) hints.add("run the narrowest package test/lint command for changed JS/TS files");
-  if (files.some((file) => file.startsWith("test/") || file.includes("/test") || file.includes("tests/"))) hints.add("run the touched or nearest tests when available");
-  if (hints.size === 0 && files.length > 0) hints.add("run the narrowest repo-native validation for the touched files");
+  if (
+    files.some(
+      (file) =>
+        file.endsWith(".ts") ||
+        file.endsWith(".tsx") ||
+        file.endsWith(".js") ||
+        file.endsWith(".jsx"),
+    )
+  )
+    hints.add("run the narrowest package test/lint command for changed JS/TS files");
+  if (
+    files.some(
+      (file) => file.startsWith("test/") || file.includes("/test") || file.includes("tests/"),
+    )
+  )
+    hints.add("run the touched or nearest tests when available");
+  if (hints.size === 0 && files.length > 0)
+    hints.add("run the narrowest repo-native validation for the touched files");
   return [...hints];
 }
 
@@ -185,21 +221,32 @@ function gitRefExists(targetDir: string, ref: string): boolean {
 }
 
 function gitLines(targetDir: string, args: string[]): string[] {
-  return gitText(targetDir, args).split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  return gitText(targetDir, args)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
 }
 
 function gitText(targetDir: string, args: string[]): string {
-  const result = spawnSync("git", ["-C", targetDir, ...args], { encoding: "utf8", maxBuffer: 1024 * 1024 * 4 });
+  const result = spawnSync("git", ["-C", targetDir, ...args], {
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024 * 4,
+  });
   return result.status === 0 ? result.stdout : "";
 }
 
 function gitStatus(targetDir: string, args: string[]): number | null {
-  const result = spawnSync("git", ["-C", targetDir, ...args], { encoding: "utf8", maxBuffer: 1024 * 1024 });
+  const result = spawnSync("git", ["-C", targetDir, ...args], {
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024,
+  });
   return result.status ?? null;
 }
 
 function truncate(value: string, limit: number): string {
-  return value.length > limit ? `${value.slice(0, limit)}\n...[truncated ${value.length - limit} chars]` : value;
+  return value.length > limit
+    ? `${value.slice(0, limit)}\n...[truncated ${value.length - limit} chars]`
+    : value;
 }
 
 function unique(values: string[]): string[] {

--- a/src/repair/lib.ts
+++ b/src/repair/lib.ts
@@ -261,6 +261,16 @@ export function renderPrompt(
     "```",
   ];
 
+  if (context.repairEvidencePack) {
+    parts.push(
+      "## Repair evidence pack",
+      "Deterministic evidence extracted before model reasoning. Treat this as the primary source for repair-only intake; do not finalize without using the source PR diff, objective repair signals, and relevant hunks below.",
+      "```json",
+      String(context.repairEvidencePack),
+      "```",
+    );
+  }
+
   for (const [title, filePath] of [
     ["Cluster preflight artifact", context.clusterPlanPath],
     ["Fix artifact", context.fixArtifactPath],
@@ -285,6 +295,13 @@ export function renderPrompt(
       "## Target checkout",
       `The target repository checkout is \`${context.targetCheckout}\`. Run target-repo inspection commands from that checkout. The ClawSweeper repository is only the automation harness.`,
     );
+    if (context.sourcePrRefs) {
+      parts.push(
+        "## Source PR refs",
+        String(context.sourcePrRefs),
+        "For third-party repositories, the checkout starts on the base branch. That is expected. Read and diff the fetched source PR refs before deciding whether a contributor-branch repair or replacement branch is needed.",
+      );
+    }
   }
 
   parts.push(

--- a/src/repair/model-backend-config.ts
+++ b/src/repair/model-backend-config.ts
@@ -1,0 +1,146 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { JsonValue, LooseRecord } from "./json-types.js";
+import { repoRoot } from "./paths.js";
+
+export type ModelBackend = "codex-cli" | "openai-compatible-tools";
+
+export type OpenAiCompatibleConfig = {
+  baseUrl?: string;
+  model?: string;
+  apiKeyEnv?: string;
+  maxTurns?: number;
+  maxTokens?: number;
+  maxRetries?: number;
+};
+
+export type ModelBackendConfig = {
+  backend?: ModelBackend;
+  openaiCompatible?: OpenAiCompatibleConfig;
+  sourcePath?: string;
+};
+
+const DEFAULT_LOCAL_CONFIG_PATH = path.join(os.homedir(), ".config", "clawsweeper", "model-backend.json");
+
+export function readModelBackendConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): ModelBackendConfig {
+  const configPath = findModelBackendConfigPath(env);
+  if (!configPath) return {};
+  const parsed = JSON.parse(fs.readFileSync(configPath, "utf8")) as unknown;
+  return { ...normalizeModelBackendConfig(parsed, configPath), sourcePath: configPath };
+}
+
+export function findModelBackendConfigPath(env: NodeJS.ProcessEnv = process.env): string {
+  const explicit = String(env.CLAWSWEEPER_MODEL_BACKEND_CONFIG ?? "").trim();
+  if (explicit) return path.resolve(expandHome(explicit));
+
+  const candidates = [
+    DEFAULT_LOCAL_CONFIG_PATH,
+    path.join(repoRoot(), "config", "model-backend.json"),
+  ];
+  return candidates.find((candidate) => fs.existsSync(candidate)) ?? "";
+}
+
+export function normalizeBackend(value: JsonValue, fallback: ModelBackend = "codex-cli"): ModelBackend {
+  const raw = String(value ?? fallback)
+    .trim()
+    .toLowerCase()
+    .replace(/_/g, "-");
+  if (raw === "codex" || raw === "codex-cli") return "codex-cli";
+  if (raw === "openai-compatible" || raw === "openai-compatible-tools") {
+    return "openai-compatible-tools";
+  }
+  throw new Error(`unsupported model backend: ${raw}`);
+}
+
+function normalizeModelBackendConfig(value: unknown, label: string): ModelBackendConfig {
+  const config = record(value, label);
+  const backend = normalizeBackend(config.backend ?? config.default_backend, "codex-cli");
+  const nestedOpenaiCompatible = optionalRecord(
+    config.openai_compatible ?? config.openaiCompatible,
+    `${label}.openai_compatible`,
+  );
+  const openaiSource = nestedOpenaiCompatible ?? config;
+  const openaiConfig: OpenAiCompatibleConfig = {};
+  setOptional(openaiConfig, "baseUrl", optionalString(openaiSource.base_url ?? openaiSource.baseUrl));
+  setOptional(openaiConfig, "model", optionalString(openaiSource.model));
+  setOptional(
+    openaiConfig,
+    "apiKeyEnv",
+    optionalString(openaiSource.api_key_env ?? openaiSource.apiKeyEnv ?? openaiSource.key_env),
+  );
+  setOptional(
+    openaiConfig,
+    "maxTurns",
+    optionalInteger(openaiSource.max_turns ?? openaiSource.maxTurns, {
+      label: `${label}.max_turns`,
+      minimum: 0,
+    }),
+  );
+  setOptional(
+    openaiConfig,
+    "maxTokens",
+    optionalInteger(openaiSource.max_tokens ?? openaiSource.maxTokens, {
+      label: `${label}.max_tokens`,
+      minimum: 0,
+    }),
+  );
+  setOptional(
+    openaiConfig,
+    "maxRetries",
+    optionalInteger(openaiSource.max_retries ?? openaiSource.maxRetries, {
+      label: `${label}.max_retries`,
+      minimum: 1,
+    }),
+  );
+
+  const result: ModelBackendConfig = { backend };
+  if (Object.keys(openaiConfig).length > 0) result.openaiCompatible = openaiConfig;
+  return result;
+}
+
+function record(value: unknown, label: string): LooseRecord {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`invalid model backend config ${label}: expected object`);
+  }
+  return value as LooseRecord;
+}
+
+function optionalRecord(value: JsonValue, label: string): LooseRecord | undefined {
+  if (value === undefined || value === null) return undefined;
+  return record(value, label);
+}
+
+function optionalString(value: JsonValue): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  const text = String(value).trim();
+  return text || undefined;
+}
+
+function optionalInteger(
+  value: JsonValue,
+  { label, minimum }: { label: string; minimum: number },
+): number | undefined {
+  if (value === undefined || value === null || String(value).trim() === "") return undefined;
+  const number = Number(value);
+  if (!Number.isInteger(number) || number < minimum) {
+    throw new Error(`${label} must be an integer >= ${minimum}`);
+  }
+  return number;
+}
+
+function setOptional<K extends keyof OpenAiCompatibleConfig>(
+  config: OpenAiCompatibleConfig,
+  key: K,
+  value: OpenAiCompatibleConfig[K] | undefined,
+) {
+  if (value !== undefined) config[key] = value;
+}
+
+function expandHome(value: string): string {
+  if (value === "~") return os.homedir();
+  if (value.startsWith("~/")) return path.join(os.homedir(), value.slice(2));
+  return value;
+}

--- a/src/repair/model-backend-config.ts
+++ b/src/repair/model-backend-config.ts
@@ -21,11 +21,14 @@ export type ModelBackendConfig = {
   sourcePath?: string;
 };
 
-const DEFAULT_LOCAL_CONFIG_PATH = path.join(os.homedir(), ".config", "clawsweeper", "model-backend.json");
+const DEFAULT_LOCAL_CONFIG_PATH = path.join(
+  os.homedir(),
+  ".config",
+  "clawsweeper",
+  "model-backend.json",
+);
 
-export function readModelBackendConfig(
-  env: NodeJS.ProcessEnv = process.env,
-): ModelBackendConfig {
+export function readModelBackendConfig(env: NodeJS.ProcessEnv = process.env): ModelBackendConfig {
   const configPath = findModelBackendConfigPath(env);
   if (!configPath) return {};
   const parsed = JSON.parse(fs.readFileSync(configPath, "utf8")) as unknown;
@@ -43,7 +46,10 @@ export function findModelBackendConfigPath(env: NodeJS.ProcessEnv = process.env)
   return candidates.find((candidate) => fs.existsSync(candidate)) ?? "";
 }
 
-export function normalizeBackend(value: JsonValue, fallback: ModelBackend = "codex-cli"): ModelBackend {
+export function normalizeBackend(
+  value: JsonValue,
+  fallback: ModelBackend = "codex-cli",
+): ModelBackend {
   const raw = String(value ?? fallback)
     .trim()
     .toLowerCase()
@@ -64,7 +70,11 @@ function normalizeModelBackendConfig(value: unknown, label: string): ModelBacken
   );
   const openaiSource = nestedOpenaiCompatible ?? config;
   const openaiConfig: OpenAiCompatibleConfig = {};
-  setOptional(openaiConfig, "baseUrl", optionalString(openaiSource.base_url ?? openaiSource.baseUrl));
+  setOptional(
+    openaiConfig,
+    "baseUrl",
+    optionalString(openaiSource.base_url ?? openaiSource.baseUrl),
+  );
   setOptional(openaiConfig, "model", optionalString(openaiSource.model));
   setOptional(
     openaiConfig,

--- a/src/repair/model-backend.ts
+++ b/src/repair/model-backend.ts
@@ -35,7 +35,8 @@ export function modelBackendEnv(
 ): NodeJS.ProcessEnv {
   if (modelBackend(env) !== "openai-compatible-tools") return env;
   const out = { ...env };
-  const githubToken = env.GH_TOKEN || env.GITHUB_TOKEN || parentEnv.GH_TOKEN || parentEnv.GITHUB_TOKEN;
+  const githubToken =
+    env.GH_TOKEN || env.GITHUB_TOKEN || parentEnv.GH_TOKEN || parentEnv.GITHUB_TOKEN;
   if (githubToken && !out.CLAWSWEEPER_OPENAI_COMPATIBLE_GITHUB_TOKEN) {
     out.CLAWSWEEPER_OPENAI_COMPATIBLE_GITHUB_TOKEN = githubToken;
   }
@@ -70,4 +71,3 @@ function setIfMissing(env: NodeJS.ProcessEnv, key: string, value: string | undef
 function numberSetting(value: number | undefined): string | undefined {
   return value === undefined ? undefined : String(value);
 }
-

--- a/src/repair/model-backend.ts
+++ b/src/repair/model-backend.ts
@@ -29,13 +29,9 @@ export function modelBackendArgs(args: string[], env: NodeJS.ProcessEnv = proces
   return [path.join(repoRoot(), "dist/repair/openai-compatible-tools-runner.js"), ...args];
 }
 
-export function modelBackendEnv(
-  env: NodeJS.ProcessEnv = process.env,
-  parentEnv: NodeJS.ProcessEnv = process.env,
-): NodeJS.ProcessEnv {
+export function modelBackendEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
   if (modelBackend(env) !== "openai-compatible-tools") return env;
   const out = { ...env };
-  restoreGitHubToken(out, parentEnv);
   const config = readModelBackendConfig(env).openaiCompatible ?? {};
 
   setIfMissing(out, "CLAWSWEEPER_OPENAI_COMPATIBLE_BASE_URL", config.baseUrl);
@@ -68,9 +64,3 @@ function numberSetting(value: number | undefined): string | undefined {
   return value === undefined ? undefined : String(value);
 }
 
-function restoreGitHubToken(env: NodeJS.ProcessEnv, parentEnv: NodeJS.ProcessEnv) {
-  const token = env.GH_TOKEN || env.GITHUB_TOKEN || parentEnv.GH_TOKEN || parentEnv.GITHUB_TOKEN;
-  if (!token) return;
-  if (!env.GH_TOKEN) env.GH_TOKEN = token;
-  if (!env.GITHUB_TOKEN) env.GITHUB_TOKEN = token;
-}

--- a/src/repair/model-backend.ts
+++ b/src/repair/model-backend.ts
@@ -29,9 +29,16 @@ export function modelBackendArgs(args: string[], env: NodeJS.ProcessEnv = proces
   return [path.join(repoRoot(), "dist/repair/openai-compatible-tools-runner.js"), ...args];
 }
 
-export function modelBackendEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+export function modelBackendEnv(
+  env: NodeJS.ProcessEnv = process.env,
+  parentEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
   if (modelBackend(env) !== "openai-compatible-tools") return env;
   const out = { ...env };
+  const githubToken = env.GH_TOKEN || env.GITHUB_TOKEN || parentEnv.GH_TOKEN || parentEnv.GITHUB_TOKEN;
+  if (githubToken && !out.CLAWSWEEPER_OPENAI_COMPATIBLE_GITHUB_TOKEN) {
+    out.CLAWSWEEPER_OPENAI_COMPATIBLE_GITHUB_TOKEN = githubToken;
+  }
   const config = readModelBackendConfig(env).openaiCompatible ?? {};
 
   setIfMissing(out, "CLAWSWEEPER_OPENAI_COMPATIBLE_BASE_URL", config.baseUrl);

--- a/src/repair/model-backend.ts
+++ b/src/repair/model-backend.ts
@@ -1,0 +1,76 @@
+import path from "node:path";
+import type { JsonValue } from "./json-types.js";
+import {
+  normalizeBackend,
+  readModelBackendConfig,
+  type ModelBackend,
+} from "./model-backend-config.js";
+import { repoRoot } from "./paths.js";
+
+export type { ModelBackend } from "./model-backend-config.js";
+
+export function modelBackend(env: NodeJS.ProcessEnv = process.env): ModelBackend {
+  if (env.CLAWSWEEPER_MODEL_BACKEND?.trim()) {
+    return normalizeBackend(env.CLAWSWEEPER_MODEL_BACKEND, "codex-cli");
+  }
+  const config = readModelBackendConfig(env);
+  return normalizeBackend(config.backend, "codex-cli");
+}
+
+export function modelBackendCommand(env: NodeJS.ProcessEnv = process.env): string {
+  if (env.CLAWSWEEPER_MODEL_COMMAND?.trim()) {
+    return env.CLAWSWEEPER_MODEL_COMMAND.trim();
+  }
+  return modelBackend(env) === "openai-compatible-tools" ? process.execPath : "codex";
+}
+
+export function modelBackendArgs(args: string[], env: NodeJS.ProcessEnv = process.env): string[] {
+  if (modelBackend(env) !== "openai-compatible-tools") return args;
+  return [path.join(repoRoot(), "dist/repair/openai-compatible-tools-runner.js"), ...args];
+}
+
+export function modelBackendEnv(
+  env: NodeJS.ProcessEnv = process.env,
+  parentEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  if (modelBackend(env) !== "openai-compatible-tools") return env;
+  const out = { ...env };
+  restoreGitHubToken(out, parentEnv);
+  const config = readModelBackendConfig(env).openaiCompatible ?? {};
+
+  setIfMissing(out, "CLAWSWEEPER_OPENAI_COMPATIBLE_BASE_URL", config.baseUrl);
+  setIfMissing(out, "CLAWSWEEPER_OPENAI_COMPATIBLE_MODEL", config.model);
+  setIfMissing(out, "CLAWSWEEPER_OPENAI_COMPATIBLE_MAX_TURNS", numberSetting(config.maxTurns));
+  setIfMissing(out, "CLAWSWEEPER_OPENAI_COMPATIBLE_MAX_TOKENS", numberSetting(config.maxTokens));
+  setIfMissing(out, "CLAWSWEEPER_OPENAI_COMPATIBLE_MAX_RETRIES", numberSetting(config.maxRetries));
+
+  const apiKeyEnv =
+    out.CLAWSWEEPER_OPENAI_COMPATIBLE_API_KEY_ENV ||
+    out.OPENAI_COMPATIBLE_API_KEY_ENV ||
+    config.apiKeyEnv ||
+    "OPENAI_API_KEY";
+  out.CLAWSWEEPER_OPENAI_COMPATIBLE_API_KEY_ENV = apiKeyEnv;
+  return out;
+}
+
+export function modelBackendLabel(defaultLabel: JsonValue = "model worker"): string {
+  return modelBackend() === "openai-compatible-tools"
+    ? "OpenAI-compatible tool worker"
+    : String(defaultLabel);
+}
+
+function setIfMissing(env: NodeJS.ProcessEnv, key: string, value: string | undefined) {
+  if (env[key] || value === undefined) return;
+  env[key] = value;
+}
+
+function numberSetting(value: number | undefined): string | undefined {
+  return value === undefined ? undefined : String(value);
+}
+
+function restoreGitHubToken(env: NodeJS.ProcessEnv, parentEnv: NodeJS.ProcessEnv) {
+  const token = env.GH_TOKEN || env.GITHUB_TOKEN || parentEnv.GH_TOKEN || parentEnv.GITHUB_TOKEN;
+  if (!token) return;
+  if (!env.GH_TOKEN) env.GH_TOKEN = token;
+  if (!env.GITHUB_TOKEN) env.GITHUB_TOKEN = token;
+}

--- a/src/repair/openai-compatible-tools-runner.ts
+++ b/src/repair/openai-compatible-tools-runner.ts
@@ -34,6 +34,14 @@ const baseUrl = requiredEnv("CLAWSWEEPER_OPENAI_COMPATIBLE_BASE_URL").replace(/\
 const model = requiredEnv("CLAWSWEEPER_OPENAI_COMPATIBLE_MODEL");
 const apiKeyEnv = process.env.CLAWSWEEPER_OPENAI_COMPATIBLE_API_KEY_ENV || "OPENAI_API_KEY";
 const apiKey = process.env[apiKeyEnv] || "";
+const githubToken =
+  process.env.CLAWSWEEPER_OPENAI_COMPATIBLE_GITHUB_TOKEN ||
+  process.env.GH_TOKEN ||
+  process.env.GITHUB_TOKEN ||
+  "";
+delete process.env.CLAWSWEEPER_OPENAI_COMPATIBLE_GITHUB_TOKEN;
+delete process.env.GH_TOKEN;
+delete process.env.GITHUB_TOKEN;
 const maxTurns = numberEnvZeroMeansUnlimited("CLAWSWEEPER_OPENAI_COMPATIBLE_MAX_TURNS");
 const maxRetries = numberEnv("CLAWSWEEPER_OPENAI_COMPATIBLE_MAX_RETRIES", 3);
 const readLimit = numberEnv("CLAWSWEEPER_OPENAI_COMPATIBLE_READ_LIMIT", 200000);
@@ -109,12 +117,26 @@ const allTools = [
       maxResults: { type: "number" },
     },
   ),
+  tool(
+    "github_pr_context",
+    "Read pull request metadata, comments, reviews, review comments, and check runs through a deterministic GitHub helper.",
+    {
+      repo: { type: "string" },
+      number: { type: "number" },
+    },
+  ),
   tool("apply_patch", "Apply a unified diff patch to the target repository.", {
     patch: { type: "string" },
   }),
   tool("git_diff", "Return git status and git diff for the target repository.", {}),
 ];
-const readOnlyToolNames = new Set(["read_file", "read_file_range", "search_files", "git_diff"]);
+const readOnlyToolNames = new Set([
+  "read_file",
+  "read_file_range",
+  "search_files",
+  "github_pr_context",
+  "git_diff",
+]);
 const tools = readOnlySandbox
   ? allTools.filter((toolEntry) => readOnlyToolNames.has(toolEntry.function.name))
   : allTools;
@@ -134,10 +156,10 @@ async function main() {
         "Follow the stdin prompt exactly; do not invent a different workflow or role.",
         `The target checkout, branch, and sandbox have already been prepared by ClawSweeper. Sandbox: ${sandbox}.`,
         readOnlySandbox
-          ? "Read-only sandbox is active: write_file, replace_in_file, apply_patch, and run_command are unavailable. Use read_file, read_file_range, search_files, and git_diff only."
+          ? "Read-only sandbox is active: write_file, replace_in_file, apply_patch, and run_command are unavailable. Use read_file, read_file_range, search_files, github_pr_context, and git_diff only."
           : "Write-capable sandbox is active: use write_file, replace_in_file, apply_patch, and run_command only when necessary.",
         "When the repair prompt asks for repository inspection with rg/sed/git, use the available tools exposed in this request.",
-        "If the repair prompt names a pull request or source_pr URL and read-only gh is available, inspect PR comments, reviews, review threads, and check status with gh before deciding what to edit.",
+        "If the repair prompt names a pull request or source_pr URL, use github_pr_context to inspect PR metadata, comments, reviews, review comments, and checks before deciding what to edit.",
         readOnlySandbox
           ? "Do not attempt edits in this planning pass; return a schema-valid repair result based on read-only evidence."
           : "Make the narrowest concrete edit that satisfies the fix artifact.",
@@ -593,6 +615,17 @@ function executeTool(call: ToolCall): Message {
         stderr: truncate(result.stderr, commandOutputLimit),
       });
     }
+    if (call.function.name === "github_pr_context") {
+      const repo = String(parsed.repo ?? "").trim();
+      const number = Math.floor(Number(parsed.number ?? 0));
+      if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) {
+        return toolResult(call.id, { ok: false, error: "repo must be owner/name" });
+      }
+      if (!Number.isFinite(number) || number <= 0) {
+        return toolResult(call.id, { ok: false, error: "number must be a positive PR number" });
+      }
+      return toolResult(call.id, githubPrContext(repo, number));
+    }
     if (call.function.name === "search_files") {
       const relPath = parsed.path ? assertPath(String(parsed.path), false).rel : ".";
       const maxResults = Math.max(1, Math.min(Number(parsed.maxResults || 50), 200));
@@ -655,6 +688,97 @@ function executeTool(call: ToolCall): Message {
       error: error instanceof Error ? error.message : String(error),
     });
   }
+}
+
+
+function githubPrContext(repo: string, number: number): Record<string, unknown> {
+  if (!githubToken) {
+    return { ok: false, error: "GitHub token unavailable to deterministic helper" };
+  }
+  const base = `repos/${repo}`;
+  const pull = ghApiJson(`${base}/pulls/${number}`);
+  const issueComments = ghApiJson(`${base}/issues/${number}/comments`);
+  const reviews = ghApiJson(`${base}/pulls/${number}/reviews`);
+  const reviewComments = ghApiJson(`${base}/pulls/${number}/comments`);
+  const headSha = typeof pull.value === "object" && pull.value !== null
+    ? String((pull.value as any).head?.sha ?? "")
+    : "";
+  const checkRuns = /^[0-9a-f]{40}$/i.test(headSha)
+    ? ghApiJson(`${base}/commits/${headSha}/check-runs`)
+    : { ok: true, value: null };
+  return {
+    ok: pull.ok && issueComments.ok && reviews.ok && reviewComments.ok && checkRuns.ok,
+    repo,
+    number,
+    pull: simplifyPull(pull.value),
+    issue_comments: simplifyIssueComments(issueComments.value),
+    reviews: simplifyReviews(reviews.value),
+    review_comments: simplifyReviewComments(reviewComments.value),
+    check_runs: simplifyCheckRuns(checkRuns.value),
+    errors: [pull, issueComments, reviews, reviewComments, checkRuns]
+      .filter((entry) => !entry.ok)
+      .map((entry) => entry.error),
+  };
+}
+
+function ghApiJson(apiPath: string): { ok: boolean; value?: unknown; error?: string } {
+  const result = spawnSync("gh", ["api", apiPath], {
+    cwd,
+    env: { ...process.env, GH_TOKEN: githubToken, GITHUB_TOKEN: githubToken },
+    encoding: "utf8",
+    timeout: Math.min(commandTimeoutMs, 30000),
+    maxBuffer: 2 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    return { ok: false, error: truncate(result.stderr || result.stdout, 2000) };
+  }
+  try {
+    return { ok: true, value: JSON.parse(result.stdout || "null") };
+  } catch (error) {
+    return { ok: false, error: `GitHub API returned invalid JSON: ${String(error)}` };
+  }
+}
+
+function simplifyPull(value: unknown) {
+  const pull = (value ?? {}) as any;
+  return {
+    number: pull.number,
+    title: pull.title,
+    state: pull.state,
+    draft: pull.draft,
+    html_url: pull.html_url,
+    mergeable: pull.mergeable,
+    mergeable_state: pull.mergeable_state,
+    head: { ref: pull.head?.ref, sha: pull.head?.sha, repo: pull.head?.repo?.full_name },
+    base: { ref: pull.base?.ref, sha: pull.base?.sha, repo: pull.base?.repo?.full_name },
+    user: pull.user?.login,
+    updated_at: pull.updated_at,
+  };
+}
+
+function simplifyIssueComments(value: unknown) {
+  return Array.isArray(value)
+    ? value.map((comment: any) => ({ user: comment.user?.login, body: comment.body, html_url: comment.html_url, created_at: comment.created_at }))
+    : [];
+}
+
+function simplifyReviews(value: unknown) {
+  return Array.isArray(value)
+    ? value.map((review: any) => ({ state: review.state, user: review.user?.login, body: review.body, html_url: review.html_url, submitted_at: review.submitted_at }))
+    : [];
+}
+
+function simplifyReviewComments(value: unknown) {
+  return Array.isArray(value)
+    ? value.map((comment: any) => ({ path: comment.path, line: comment.line, side: comment.side, user: comment.user?.login, body: comment.body, html_url: comment.html_url, created_at: comment.created_at }))
+    : [];
+}
+
+function simplifyCheckRuns(value: unknown) {
+  const runs = (value as any)?.check_runs;
+  return Array.isArray(runs)
+    ? runs.map((run: any) => ({ name: run.name, status: run.status, conclusion: run.conclusion, html_url: run.html_url, completed_at: run.completed_at }))
+    : [];
 }
 
 function lineRange(parsed: Record<string, unknown>): { start: number; end: number } | null {

--- a/src/repair/openai-compatible-tools-runner.ts
+++ b/src/repair/openai-compatible-tools-runner.ts
@@ -22,6 +22,8 @@ const args = process.argv.slice(2);
 const cd = stringArg("--cd", process.cwd());
 const outputLastMessage = stringArg("--output-last-message", "");
 const outputSchema = stringArg("--output-schema", "");
+const sandbox = stringArg("--sandbox", "workspace-write").toLowerCase();
+const readOnlySandbox = sandbox === "read-only" || sandbox === "readonly";
 const outputSchemaAbs = outputSchema ? path.resolve(outputSchema) : "";
 const outputSchemaJson =
   outputSchemaAbs && fs.existsSync(outputSchemaAbs)
@@ -59,7 +61,7 @@ const optionalToolArgs = new Set([
   "replaceAll",
 ]);
 
-const tools = [
+const allTools = [
   tool(
     "read_file",
     "Read a UTF-8 text file under the target repository. Optional offset/limit are 1-based line controls.",
@@ -112,6 +114,10 @@ const tools = [
   }),
   tool("git_diff", "Return git status and git diff for the target repository.", {}),
 ];
+const readOnlyToolNames = new Set(["read_file", "read_file_range", "search_files", "git_diff"]);
+const tools = readOnlySandbox
+  ? allTools.filter((toolEntry) => readOnlyToolNames.has(toolEntry.function.name))
+  : allTools;
 const allowedToolNames = tools.map((toolEntry) => toolEntry.function.name);
 
 async function main() {
@@ -126,11 +132,18 @@ async function main() {
       content: [
         "You are emulating `codex exec` for ClawSweeper.",
         "Follow the stdin prompt exactly; do not invent a different workflow or role.",
-        "The target checkout, branch, and sandbox have already been prepared by ClawSweeper.",
-        "When the repair prompt asks for repository inspection with rg/sed/git, use the available tools: search_files, read_file_range, run_command, and git_diff.",
+        `The target checkout, branch, and sandbox have already been prepared by ClawSweeper. Sandbox: ${sandbox}.`,
+        readOnlySandbox
+          ? "Read-only sandbox is active: write_file, replace_in_file, apply_patch, and run_command are unavailable. Use read_file, read_file_range, search_files, and git_diff only."
+          : "Write-capable sandbox is active: use write_file, replace_in_file, apply_patch, and run_command only when necessary.",
+        "When the repair prompt asks for repository inspection with rg/sed/git, use the available tools exposed in this request.",
         "If the repair prompt names a pull request or source_pr URL and read-only gh is available, inspect PR comments, reviews, review threads, and check status with gh before deciding what to edit.",
-        "Make the narrowest concrete edit that satisfies the fix artifact.",
-        "Prefer replace_in_file for localized edits. Use write_file only for intended whole-file replacement.",
+        readOnlySandbox
+          ? "Do not attempt edits in this planning pass; return a schema-valid repair result based on read-only evidence."
+          : "Make the narrowest concrete edit that satisfies the fix artifact.",
+        readOnlySandbox
+          ? "Write tools are intentionally unavailable in read-only mode."
+          : "Prefer replace_in_file for localized edits. Use write_file only for intended whole-file replacement.",
         "Do not push, open PRs, comment, label, merge, or inspect secrets.",
         "Before returning, ensure git_diff reflects the intended change and summarize the validation you ran.",
         "Use tools to inspect and edit files. Do not pretend to use tools.",
@@ -141,7 +154,9 @@ async function main() {
         "For pr-repair-intake jobs, do not emit keep_canonical/merge/close verdicts. The deterministic intake already found a current repair signal.",
         "For pr-repair-intake jobs, emit fix_needed plus build_fix_artifact when repair is possible; otherwise emit needs_human with exact blocker evidence.",
         `Target repository cwd: ${cwd}.`,
-        `Allowed write files: ${allowed.join(", ") || "all files under cwd"}.`,
+        readOnlySandbox
+          ? "Allowed write files: none in read-only sandbox."
+          : `Allowed write files: ${allowed.join(", ") || "all files under cwd"}.`,
         schemaInstruction,
       ].join("\n"),
     },
@@ -495,6 +510,12 @@ function shellQuote(value: string): string {
 }
 
 function executeTool(call: ToolCall): Message {
+  if (!allowedToolNames.includes(call.function.name)) {
+    return toolResult(call.id, {
+      ok: false,
+      error: `tool not allowed by sandbox ${sandbox}: ${call.function.name}`,
+    });
+  }
   let parsed: any = {};
   try {
     parsed = JSON.parse(call.function.arguments || "{}");

--- a/src/repair/openai-compatible-tools-runner.ts
+++ b/src/repair/openai-compatible-tools-runner.ts
@@ -39,9 +39,12 @@ const githubToken =
   process.env.GH_TOKEN ||
   process.env.GITHUB_TOKEN ||
   "";
+delete process.env[apiKeyEnv];
 delete process.env.CLAWSWEEPER_OPENAI_COMPATIBLE_GITHUB_TOKEN;
 delete process.env.GH_TOKEN;
 delete process.env.GITHUB_TOKEN;
+delete process.env.OPENAI_API_KEY;
+delete process.env.CODEX_API_KEY;
 const maxTurns = numberEnvZeroMeansUnlimited("CLAWSWEEPER_OPENAI_COMPATIBLE_MAX_TURNS");
 const maxRetries = numberEnv("CLAWSWEEPER_OPENAI_COMPATIBLE_MAX_RETRIES", 3);
 const readLimit = numberEnv("CLAWSWEEPER_OPENAI_COMPATIBLE_READ_LIMIT", 200000);
@@ -603,6 +606,7 @@ function executeTool(call: ToolCall): Message {
       const timeout = Math.min(Number(parsed.timeoutMs || commandTimeoutMs), commandTimeoutMs);
       const result = spawnSync("bash", ["-lc", command], {
         cwd,
+        env: scrubbedToolEnv(),
         encoding: "utf8",
         timeout,
         maxBuffer: 1024 * 1024,
@@ -690,6 +694,17 @@ function executeTool(call: ToolCall): Message {
   }
 }
 
+
+function scrubbedToolEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  delete env[apiKeyEnv];
+  delete env.CLAWSWEEPER_OPENAI_COMPATIBLE_GITHUB_TOKEN;
+  delete env.GH_TOKEN;
+  delete env.GITHUB_TOKEN;
+  delete env.OPENAI_API_KEY;
+  delete env.CODEX_API_KEY;
+  return env;
+}
 
 function githubPrContext(repo: string, number: number): Record<string, unknown> {
   if (!githubToken) {

--- a/src/repair/openai-compatible-tools-runner.ts
+++ b/src/repair/openai-compatible-tools-runner.ts
@@ -1,0 +1,873 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import {
+  buildFinalizationPrompt,
+  isPrematureNeedsHuman,
+  looksLikeCodexResultCandidate,
+  normalizeCodexResult,
+} from "./openai-compatible/normalize-result.js";
+import { normalizeToolCalls, pseudoToolCalls } from "./openai-compatible/textual-tools.js";
+
+type Message = {
+  role: string;
+  content?: string | null;
+  tool_call_id?: string;
+  tool_calls?: ToolCall[];
+};
+type ToolCall = { id: string; function: { name: string; arguments?: string } };
+
+const args = process.argv.slice(2);
+const cd = stringArg("--cd", process.cwd());
+const outputLastMessage = stringArg("--output-last-message", "");
+const outputSchema = stringArg("--output-schema", "");
+const outputSchemaAbs = outputSchema ? path.resolve(outputSchema) : "";
+const outputSchemaJson =
+  outputSchemaAbs && fs.existsSync(outputSchemaAbs)
+    ? JSON.parse(fs.readFileSync(outputSchemaAbs, "utf8"))
+    : null;
+const cwd = path.resolve(cd);
+const baseUrl = requiredEnv("CLAWSWEEPER_OPENAI_COMPATIBLE_BASE_URL").replace(/\/$/, "");
+const model = requiredEnv("CLAWSWEEPER_OPENAI_COMPATIBLE_MODEL");
+const apiKeyEnv = process.env.CLAWSWEEPER_OPENAI_COMPATIBLE_API_KEY_ENV || "OPENAI_API_KEY";
+const apiKey = process.env[apiKeyEnv] || "";
+const maxTurns = numberEnvZeroMeansUnlimited("CLAWSWEEPER_OPENAI_COMPATIBLE_MAX_TURNS");
+const maxRetries = numberEnv("CLAWSWEEPER_OPENAI_COMPATIBLE_MAX_RETRIES", 3);
+const readLimit = numberEnv("CLAWSWEEPER_OPENAI_COMPATIBLE_READ_LIMIT", 200000);
+const commandTimeoutMs = numberEnv("CLAWSWEEPER_OPENAI_COMPATIBLE_COMMAND_TIMEOUT_MS", 120000);
+const requestTimeoutMs = numberEnv("CLAWSWEEPER_OPENAI_COMPATIBLE_REQUEST_TIMEOUT_MS", 600000);
+const maxTokens = numberEnvAllowZero("CLAWSWEEPER_OPENAI_COMPATIBLE_MAX_TOKENS", 0);
+const commandOutputLimit = numberEnv("CLAWSWEEPER_OPENAI_COMPATIBLE_COMMAND_OUTPUT_LIMIT", 200000);
+const diffOutputLimit = numberEnv("CLAWSWEEPER_OPENAI_COMPATIBLE_DIFF_OUTPUT_LIMIT", 200000);
+const allowed = String(process.env.CLAWSWEEPER_OPENAI_COMPATIBLE_ALLOWED_FILES || "")
+  .split(/[,:]/)
+  .map((entry) => entry.trim())
+  .filter(Boolean)
+  .map((entry) => path.normalize(entry));
+
+if (!apiKey) throw new Error(`missing API key in ${apiKeyEnv}`);
+
+const optionalToolArgs = new Set([
+  "start",
+  "end",
+  "offset",
+  "limit",
+  "timeoutMs",
+  "path",
+  "maxResults",
+  "replaceAll",
+]);
+
+const tools = [
+  tool(
+    "read_file",
+    "Read a UTF-8 text file under the target repository. Optional offset/limit are 1-based line controls.",
+    {
+      path: { type: "string" },
+      offset: { type: "number" },
+      limit: { type: "number" },
+      start: { type: "number" },
+      end: { type: "number" },
+    },
+  ),
+  tool("read_file_range", "Read a UTF-8 text file line range under the target repository.", {
+    path: { type: "string" },
+    start: { type: "number" },
+    end: { type: "number" },
+  }),
+  tool(
+    "write_file",
+    "Write a complete UTF-8 text file under the target repository. Use only when whole-file replacement is intended.",
+    {
+      path: { type: "string" },
+      content: { type: "string" },
+    },
+  ),
+  tool(
+    "replace_in_file",
+    "Replace an exact string in a file. Safer than write_file for small localized edits.",
+    {
+      path: { type: "string" },
+      search: { type: "string" },
+      replacement: { type: "string" },
+      replaceAll: { type: "boolean" },
+    },
+  ),
+  tool("run_command", "Run a short validation command in the target repository.", {
+    command: { type: "string" },
+    timeoutMs: { type: "number" },
+  }),
+  tool(
+    "search_files",
+    "Search repository text with grep. Use this instead of broad shell exploration.",
+    {
+      pattern: { type: "string" },
+      path: { type: "string" },
+      maxResults: { type: "number" },
+    },
+  ),
+  tool("apply_patch", "Apply a unified diff patch to the target repository.", {
+    patch: { type: "string" },
+  }),
+  tool("git_diff", "Return git status and git diff for the target repository.", {}),
+];
+const allowedToolNames = tools.map((toolEntry) => toolEntry.function.name);
+
+async function main() {
+  const rawPrompt = fs.readFileSync(0, "utf8");
+  const prompt = compactRepairOnlyPrompt(rawPrompt);
+  const schemaInstruction = outputSchema
+    ? `The final answer must be valid JSON matching the requested output schema path: ${outputSchema}. Do not wrap JSON in markdown.`
+    : "For implementation tasks, summarize the changes made and validation run.";
+  const messages: Message[] = [
+    {
+      role: "system",
+      content: [
+        "You are emulating `codex exec` for ClawSweeper.",
+        "Follow the stdin prompt exactly; do not invent a different workflow or role.",
+        "The target checkout, branch, and sandbox have already been prepared by ClawSweeper.",
+        "When the repair prompt asks for repository inspection with rg/sed/git, use the available tools: search_files, read_file_range, run_command, and git_diff.",
+        "If the repair prompt names a pull request or source_pr URL and read-only gh is available, inspect PR comments, reviews, review threads, and check status with gh before deciding what to edit.",
+        "Make the narrowest concrete edit that satisfies the fix artifact.",
+        "Prefer replace_in_file for localized edits. Use write_file only for intended whole-file replacement.",
+        "Do not push, open PRs, comment, label, merge, or inspect secrets.",
+        "Before returning, ensure git_diff reflects the intended change and summarize the validation you ran.",
+        "Use tools to inspect and edit files. Do not pretend to use tools.",
+        "Repair-only mode: the prompt already identifies the PR and concrete repair signals. Do not perform a broad repository audit.",
+        "Inspect only the source PR/comment/check evidence and the smallest relevant file ranges needed to fix that signal.",
+        "After a concrete issue is verified, edit immediately, run narrow validation, then stop and return the required JSON.",
+        "If you cannot verify and edit within a small number of tool calls, return a schema-valid blocked/needs_human result instead of continuing exploration.",
+        "For pr-repair-intake jobs, do not emit keep_canonical/merge/close verdicts. The deterministic intake already found a current repair signal.",
+        "For pr-repair-intake jobs, emit fix_needed plus build_fix_artifact when repair is possible; otherwise emit needs_human with exact blocker evidence.",
+        `Target repository cwd: ${cwd}.`,
+        `Allowed write files: ${allowed.join(", ") || "all files under cwd"}.`,
+        schemaInstruction,
+      ].join("\n"),
+    },
+    { role: "user", content: prompt },
+  ];
+  let finalContent = "";
+  let exhausted = true;
+  let toolsExecuted = 0;
+  for (let turn = 0; turn < maxTurns; turn += 1) {
+    const data = await chat(messages, turn + 1, true);
+    const msg = data.choices?.[0]?.message;
+    if (!msg) throw new Error("missing assistant message");
+    messages.push(msg);
+    if (msg.content) {
+      finalContent = String(msg.content);
+      process.stdout.write(`assistant:\n${finalContent}\n`);
+    }
+    const calls = normalizeToolCalls(
+      ((msg.tool_calls ?? []) as ToolCall[]).concat(pseudoToolCalls(msg.content, allowedToolNames)),
+      allowedToolNames,
+    );
+    process.stderr.write(`[openai-compatible-tools] turn=${turn + 1} tool_calls=${calls.length}\n`);
+    if (calls.length === 0) {
+      const validationErrors = validateFinalContent(finalContent);
+      if (outputSchema && validationErrors.length > 0) {
+        if (outputSchema.endsWith("codex-result.schema.json")) {
+          if (looksLikeCodexResultCandidate(finalContent)) {
+            const normalized = normalizeCodexResult(finalContent, rawPrompt, worktreeHasDiff());
+            const normalizedErrors = validateFinalContent(normalized);
+            if (normalizedErrors.length === 0) {
+              if (isPrematureNeedsHuman(normalized, rawPrompt, toolsExecuted)) {
+                messages.push({
+                  role: "user",
+                  content: [
+                    "Do not return needs_human before inspecting the prepared source PR ref.",
+                    "The prompt includes Source PR refs. Use run_command/read_file_range/git diff/git show to inspect them now.",
+                    "Only return needs_human after tool evidence proves an exact blocker.",
+                  ].join("\n"),
+                });
+                finalContent = "";
+                continue;
+              }
+              finalContent = normalized;
+              exhausted = false;
+              break;
+            }
+          }
+          if (toolsExecuted > 0) {
+            messages.push({
+              role: "user",
+              content: [
+                "Your previous assistant message was neither a supported tool call nor valid final JSON.",
+                "Continue the repair run: either use a supported tool call, or return final JSON matching the requested schema.",
+                "Do not return prose-only analysis.",
+              ].join("\n"),
+            });
+            finalContent = "";
+            continue;
+          }
+        }
+        messages.push({
+          role: "user",
+          content: [
+            "Your previous final answer did not satisfy the requested structured output contract.",
+            `Return only valid JSON matching this schema path: ${outputSchema}.`,
+            "Do not use markdown. Do not include explanatory prose outside the JSON object.",
+            "Validation failures:",
+            ...validationErrors.slice(0, 20).map((error: string) => `- ${error}`),
+          ].join("\n"),
+        });
+        continue;
+      }
+      exhausted = false;
+      break;
+    }
+    for (const call of calls) {
+      process.stdout.write(`tool_call: ${call.function.name} ${call.function.arguments || "{}"}\n`);
+      const result = executeTool(call);
+      toolsExecuted += 1;
+      process.stdout.write(`tool_result: ${truncate(result.content, 2000)}\n`);
+      messages.push(result);
+    }
+  }
+  const diffExistsAtEnd = worktreeHasDiff();
+  if (exhausted && outputSchema && outputSchema.endsWith("codex-result.schema.json")) {
+    if (toolsExecuted > 0) {
+      process.stderr.write(
+        "[openai-compatible-tools] finalization_start reason=max_turns_after_tools\n",
+      );
+      const finalMessages: Message[] = [
+        {
+          role: "system",
+          content: [
+            "You are producing the final ClawSweeper repair result.",
+            "Tools are unavailable. Do not call tools. Do not emit DSML/tool_calls.",
+            "Return JSON only. No markdown. No prose outside JSON.",
+          ].join("\n"),
+        },
+        {
+          role: "user",
+          content: buildFinalizationPrompt(rawPrompt, messages, diffExistsAtEnd, outputSchema),
+        },
+      ];
+      const data = await chat(finalMessages, maxTurns + 1, false);
+      const msg = data.choices?.[0]?.message;
+      if (!msg) throw new Error("missing final assistant message");
+      finalContent = String(msg.content ?? "");
+      if (finalContent) process.stdout.write(`assistant_finalization:\n${finalContent}\n`);
+    }
+    finalContent = normalizeCodexResult(finalContent, rawPrompt, diffExistsAtEnd);
+    exhausted = false;
+  } else if (exhausted && outputSchema) {
+    messages.push({
+      role: "user",
+      content: [
+        "Tool budget is exhausted. Do not call tools again.",
+        `Return only valid JSON matching this schema path: ${outputSchema}.`,
+        "Base the decision on the evidence already collected and the current git diff.",
+        "If evidence or changes are insufficient, return a conservative blocked or needs_human result that still satisfies the schema.",
+        "Do not use markdown. Do not include prose outside the JSON object.",
+      ].join("\n"),
+    });
+    const data = await chat(messages, maxTurns + 1, false);
+    const msg = data.choices?.[0]?.message;
+    if (!msg) throw new Error("missing final assistant message");
+    finalContent = String(msg.content ?? "");
+    if (finalContent) process.stdout.write(`assistant:\n${finalContent}\n`);
+  } else if (exhausted) {
+    finalContent = JSON.stringify({
+      status: diffExistsAtEnd ? "completed_with_diff" : "blocked",
+      reason: `openai-compatible-tools max_turns_exhausted after ${maxTurns} turns`,
+      partial_summary: finalContent || null,
+    });
+  }
+  if (outputSchema && outputSchema.endsWith("codex-result.schema.json"))
+    finalContent = normalizeCodexResult(finalContent, rawPrompt, diffExistsAtEnd);
+  let finalValidationErrors = validateFinalContent(finalContent);
+  if (
+    outputSchema &&
+    finalValidationErrors.length > 0 &&
+    finalContent.trim() &&
+    !outputSchema.endsWith("codex-result.schema.json")
+  ) {
+    process.stderr.write(
+      "[openai-compatible-tools] schema_repair_start errors=" +
+        JSON.stringify(finalValidationErrors.slice(0, 20)) +
+        "\n",
+    );
+    const repairMessages: Message[] = [
+      {
+        role: "system",
+        content: [
+          "You are emulating `codex exec --output-schema` for ClawSweeper.",
+          "Repair the provided JSON so it satisfies the requested JSON schema.",
+          "Return only the corrected JSON object. Do not use markdown or explanatory prose.",
+          "Do not add properties that are not allowed by the schema.",
+        ].join("\n"),
+      },
+      {
+        role: "user",
+        content: [
+          `Schema path: ${outputSchema}`,
+          "Validation failures:",
+          ...finalValidationErrors.slice(0, 40).map((error: string) => `- ${error}`),
+          "Current JSON candidate:",
+          normalizeFinalContent(finalContent).trim(),
+        ].join("\n"),
+      },
+    ];
+    const repair = await chat(repairMessages, maxTurns + 2, false);
+    const repairMsg = repair.choices?.[0]?.message;
+    if (repairMsg?.content) {
+      finalContent = String(repairMsg.content);
+      process.stdout.write(`assistant_schema_repair:\n${finalContent}\n`);
+      finalValidationErrors = validateFinalContent(finalContent);
+    }
+  }
+  if (outputSchema && finalValidationErrors.length > 0) {
+    process.stderr.write(
+      "[openai-compatible-tools] schema_invalid errors=" +
+        JSON.stringify(finalValidationErrors.slice(0, 20)) +
+        "\n",
+    );
+    finalDiffSummary();
+    if (!outputSchema.endsWith("codex-result.schema.json")) process.exit(2);
+    finalContent = normalizeCodexResult(finalContent, rawPrompt, diffExistsAtEnd);
+    finalValidationErrors = validateFinalContent(finalContent);
+    if (finalValidationErrors.length > 0) process.exit(2);
+  }
+  if (outputLastMessage) {
+    fs.mkdirSync(path.dirname(path.resolve(outputLastMessage)), { recursive: true });
+    fs.writeFileSync(outputLastMessage, normalizeFinalContent(finalContent));
+  }
+  finalDiffSummary();
+  if (exhausted && !diffExistsAtEnd && !outputSchema.endsWith("codex-result.schema.json"))
+    process.exit(2);
+}
+
+async function chat(messages: Message[], turn: number, allowTools: boolean): Promise<any> {
+  for (let attempt = 1; attempt <= maxRetries; attempt += 1) {
+    const payload: Record<string, unknown> = {
+      model,
+      messages,
+      temperature: 0,
+    };
+    if (maxTokens > 0) payload.max_tokens = maxTokens;
+    if (allowTools) {
+      payload.tools = tools;
+      payload.tool_choice = "auto";
+    }
+    if (outputSchema && !allowTools) payload.response_format = { type: "json_object" };
+    const body = JSON.stringify(payload);
+    const startedAt = Date.now();
+    process.stderr.write(
+      `[openai-compatible-tools] chat_start turn=${turn} attempt=${attempt}/${maxRetries} messages=${messages.length} bytes=${Buffer.byteLength(body)} timeout_ms=${requestTimeoutMs} max_tokens=${maxTokens > 0 ? maxTokens : "provider_default"}\n`,
+    );
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), requestTimeoutMs);
+    let res: Response;
+    let text = "";
+    try {
+      res = await fetch(`${baseUrl}/chat/completions`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
+        body,
+        signal: controller.signal,
+      });
+      text = await res.text();
+    } catch (error) {
+      const elapsed = Date.now() - startedAt;
+      process.stderr.write(
+        `[openai-compatible-tools] chat_error turn=${turn} attempt=${attempt}/${maxRetries} elapsed_ms=${elapsed} error=${truncate(error instanceof Error ? error.message : String(error), 300)}\n`,
+      );
+      if (attempt < maxRetries) {
+        await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
+        continue;
+      }
+      throw new Error(
+        `OpenAI-compatible backend request failed after ${elapsed}ms: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    } finally {
+      clearTimeout(timer);
+    }
+    const elapsed = Date.now() - startedAt;
+    process.stderr.write(
+      `[openai-compatible-tools] chat_done turn=${turn} attempt=${attempt}/${maxRetries} status=${res.status} elapsed_ms=${elapsed} response_bytes=${Buffer.byteLength(text)}\n`,
+    );
+    if (!res.ok) {
+      if ([429, 502, 503, 504].includes(res.status) && attempt < maxRetries) {
+        await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
+        continue;
+      }
+      throw new Error(`OpenAI-compatible backend HTTP ${res.status}: ${truncate(text, 1000)}`);
+    }
+    return JSON.parse(text);
+  }
+  throw new Error("OpenAI-compatible backend retry exhausted");
+}
+
+function compactRepairOnlyPrompt(prompt: string): string {
+  if (!prompt.includes("source: pr-repair-intake") && !prompt.includes("# Repair-only PR intake")) {
+    return prompt;
+  }
+  const jobStart = prompt.indexOf("## Job file");
+  const evidenceStart = prompt.indexOf("## Repair evidence pack");
+  const preflightStart = prompt.indexOf("## Cluster preflight artifact");
+  const jobSectionEnd = [evidenceStart, preflightStart].filter((index) => index >= 0).sort((a, b) => a - b)[0];
+  const jobSection =
+    jobStart >= 0
+      ? prompt.slice(jobStart, jobSectionEnd ?? undefined)
+      : prompt;
+  const evidencePack =
+    evidenceStart >= 0
+      ? prompt.slice(evidenceStart, preflightStart >= 0 ? preflightStart : evidenceStart + 36000)
+      : "";
+  const preflight = preflightStart >= 0 ? prompt.slice(preflightStart, preflightStart + 6000) : "";
+  const sourceRefsStart = prompt.indexOf("## Source PR refs");
+  const requiredOutputStart = prompt.indexOf("## Required final output");
+  const sourceRefs =
+    sourceRefsStart >= 0
+      ? prompt.slice(
+          sourceRefsStart,
+          requiredOutputStart >= 0 ? requiredOutputStart : sourceRefsStart + 4000,
+        )
+      : "";
+  return [
+    "# Compact repair-only ClawSweeper prompt",
+    "",
+    "This is a deterministic pr-repair-intake job. A current repair signal already exists.",
+    "Do not perform a normal review verdict. Do not return keep_canonical just because the PR is approved or clean.",
+    "Required outcome: produce a schema-valid repair result with fix_needed/build_fix_artifact, or needs_human/blocked with exact blocker evidence.",
+    "Focus on the repair evidence pack first: repair_signals, evidence_gates, likely_files, changed_files, and relevant_hunks.",
+    "If evidence_gates.source_pr_diff_read/actionable_signal_read/relevant_hunk_read are true, you may return final JSON immediately without exploratory tools.",
+    "Do not waste tool turns on git branch, git log, or generic status checks; those are not repair evidence.",
+    "If you use tools, inspect only the source diff or relevant file hunks named by the evidence pack, for example git diff <diff_ref> -- <likely_files>.",
+    "If a source PR branch needs repair, use repair_strategy=repair_contributor_branch and source_prs with the full PR URL.",
+    "Do not push, merge, close, comment, or label.",
+    "",
+    evidencePack.trim(),
+    "",
+    jobSection.trim(),
+    "",
+    sourceRefs.trim(),
+    "",
+    preflight.trim(),
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+function commandFromArgs(parsed: Record<string, unknown>): string {
+  const direct = typeof parsed.command === "string" ? parsed.command.trim() : "";
+  if (direct && direct !== "undefined") return direct;
+  for (const [key, value] of Object.entries(parsed)) {
+    if (typeof value === "string" && value.trim() && value.trim() !== "command") continue;
+    const candidate = key.trim();
+    if (/^(git|sed|awk|grep|cat|head|tail|bash|sh|npm|pnpm|python3?|node)\b/.test(candidate))
+      return candidate;
+  }
+  return "";
+}
+
+
+function rewriteUnsupportedGhPrView(command: string): string | null {
+  if (!/\bgh\s+pr\s+view\b/.test(command)) return null;
+  if (!/--json\s+[^\n]*(reviews|reviewRequests|comments)/.test(command)) return null;
+  const number = command.match(/\bgh\s+pr\s+view\s+(\d+)\b/)?.[1];
+  const repo = command.match(/--repo\s+([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)/)?.[1];
+  if (!number) return null;
+  const repoSetup = repo
+    ? ""
+    : "REPO=$(git remote get-url origin 2>/dev/null | sed -E 's#^git@github.com:##; s#^https://github.com/##; s#\\.git$##'); if [ -z \"$REPO\" ]; then echo '{\"source\":\"gh_api_rest_rewrite\",\"error\":\"repo_inference_failed\"}'; exit 2; fi; BASE=\"repos/$REPO\"";
+  const base = repo ? shellQuote(`repos/${repo}`) : '"$BASE"';
+  const pr = shellQuote(number);
+  return [
+    repoSetup,
+    "echo '{\"source\":\"gh_api_rest_rewrite\",\"reason\":\"gh pr view review/comment fields use GraphQL fields that can require extra org scopes; using REST with the same GH_TOKEN\",\"review_comments\":'",
+    `gh api ${base}/pulls/${pr}/comments --jq '[.[] | {path,line,side,user:.user.login,body,html_url,created_at}]'`,
+    "echo ',\"reviews\":'",
+    `gh api ${base}/pulls/${pr}/reviews --jq '[.[] | {state,user:.user.login,body,html_url,submitted_at}]'`,
+    "echo ',\"issue_comments\":'",
+    `gh api ${base}/issues/${pr}/comments --jq '[.[] | {user:.user.login,body,html_url,created_at}]'`,
+    "echo '}'",
+  ].filter(Boolean).join(" && ");
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+function executeTool(call: ToolCall): Message {
+  let parsed: any = {};
+  try {
+    parsed = JSON.parse(call.function.arguments || "{}");
+  } catch (error) {
+    return toolResult(call.id, { ok: false, error: `bad JSON args: ${String(error)}` });
+  }
+  try {
+    if (call.function.name === "read_file") {
+      const { rel, abs } = assertPath(parsed.path, false);
+      const range = lineRange(parsed);
+      if (range) return readFileRange(call.id, rel, abs, range.start, range.end);
+      return readFileRange(call.id, rel, abs, 1, defaultReadLineEnd(abs));
+    }
+    if (call.function.name === "read_file_range") {
+      const { rel, abs } = assertPath(parsed.path, false);
+      const start = Math.max(1, Number(parsed.start || 1));
+      const end = Math.max(start, Number(parsed.end || start));
+      return readFileRange(call.id, rel, abs, start, end);
+    }
+    if (call.function.name === "write_file") {
+      const { rel, abs } = assertPath(parsed.path, true);
+      fs.mkdirSync(path.dirname(abs), { recursive: true });
+      fs.writeFileSync(abs, String(parsed.content ?? ""));
+      return toolResult(call.id, {
+        ok: true,
+        path: rel,
+        bytes: Buffer.byteLength(String(parsed.content ?? "")),
+      });
+    }
+    if (call.function.name === "replace_in_file") {
+      const { rel, abs } = assertPath(parsed.path, true);
+      const search = String(parsed.search ?? "");
+      const replacement = String(parsed.replacement ?? "");
+      const replaceAll = parsed.replaceAll === true;
+      if (!search) return toolResult(call.id, { ok: false, error: "missing search" });
+      const before = fs.readFileSync(abs, "utf8");
+      const occurrences = before.split(search).length - 1;
+      if (occurrences === 0)
+        return toolResult(call.id, { ok: false, path: rel, error: "search string not found" });
+      if (occurrences > 1 && !replaceAll) {
+        return toolResult(call.id, {
+          ok: false,
+          path: rel,
+          error: `search string matched ${occurrences} times; set replaceAll=true or use a more specific search`,
+        });
+      }
+      const after = replaceAll
+        ? before.split(search).join(replacement)
+        : before.replace(search, replacement);
+      fs.writeFileSync(abs, after);
+      return toolResult(call.id, {
+        ok: true,
+        path: rel,
+        occurrences,
+        replaceAll,
+        bytes: Buffer.byteLength(after),
+      });
+    }
+    if (call.function.name === "run_command") {
+      let command = commandFromArgs(parsed);
+      if (!command) return toolResult(call.id, { ok: false, error: "missing command" });
+      command = rewriteUnsupportedGhPrView(command) ?? command;
+      const timeout = Math.min(Number(parsed.timeoutMs || commandTimeoutMs), commandTimeoutMs);
+      const result = spawnSync("bash", ["-lc", command], {
+        cwd,
+        encoding: "utf8",
+        timeout,
+        maxBuffer: 1024 * 1024,
+      });
+      return toolResult(call.id, {
+        ok: result.status === 0,
+        status: result.status,
+        signal: result.signal,
+        stdout: truncate(result.stdout, commandOutputLimit),
+        stderr: truncate(result.stderr, commandOutputLimit),
+      });
+    }
+    if (call.function.name === "search_files") {
+      const relPath = parsed.path ? assertPath(String(parsed.path), false).rel : ".";
+      const maxResults = Math.max(1, Math.min(Number(parsed.maxResults || 50), 200));
+      const pattern = String(parsed.pattern || "");
+      if (!pattern.trim()) return toolResult(call.id, { ok: false, error: "missing pattern" });
+      const result = spawnSync("grep", ["-RIn", "--exclude-dir=.git", "--", pattern, relPath], {
+        cwd,
+        encoding: "utf8",
+        timeout: Math.min(commandTimeoutMs, 30000),
+        maxBuffer: 1024 * 1024,
+      });
+      const lines = String(result.stdout || "")
+        .split(/\n/)
+        .filter(Boolean)
+        .slice(0, maxResults);
+      return toolResult(call.id, {
+        ok: result.status === 0 || result.status === 1,
+        status: result.status,
+        pattern,
+        path: relPath,
+        matches: lines,
+        truncated: lines.length >= maxResults,
+        stderr: truncate(result.stderr, Math.min(commandOutputLimit, 2000)),
+      });
+    }
+    if (call.function.name === "apply_patch") {
+      const patch = String(parsed.patch || "");
+      if (!patch.trim()) return toolResult(call.id, { ok: false, error: "missing patch" });
+      const result = spawnSync("git", ["apply", "--whitespace=nowarn", "-"], {
+        cwd,
+        input: patch,
+        encoding: "utf8",
+        timeout: Math.min(commandTimeoutMs, 30000),
+        maxBuffer: 1024 * 1024,
+      });
+      return toolResult(call.id, {
+        ok: result.status === 0,
+        status: result.status,
+        stdout: truncate(result.stdout, commandOutputLimit),
+        stderr: truncate(result.stderr, commandOutputLimit),
+      });
+    }
+    if (call.function.name === "git_diff") {
+      const status = spawnSync("git", ["status", "--short"], { cwd, encoding: "utf8" });
+      const diff = spawnSync("git", ["diff", "--", "."], {
+        cwd,
+        encoding: "utf8",
+        maxBuffer: 2 * 1024 * 1024,
+      });
+      return toolResult(call.id, {
+        ok: true,
+        status: status.stdout,
+        diff: truncate(diff.stdout, diffOutputLimit),
+      });
+    }
+    return toolResult(call.id, { ok: false, error: `unknown tool ${call.function.name}` });
+  } catch (error) {
+    return toolResult(call.id, {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+function lineRange(parsed: Record<string, unknown>): { start: number; end: number } | null {
+  const rawStart = parsed.start ?? parsed.offset;
+  const rawEnd = parsed.end;
+  const rawLimit = parsed.limit;
+  if (rawStart === undefined && rawEnd === undefined && rawLimit === undefined) return null;
+  const start = Math.max(1, Number(rawStart ?? 1));
+  if (rawEnd !== undefined) return { start, end: Math.max(start, Number(rawEnd)) };
+  const limit = Math.max(1, Number(rawLimit ?? 120));
+  return { start, end: start + limit - 1 };
+}
+
+function defaultReadLineEnd(abs: string): number {
+  const maxLines = numberEnv("CLAWSWEEPER_OPENAI_COMPATIBLE_READ_LINES", 1000);
+  const lineCount = fs.readFileSync(abs, "utf8").split(/\n/).length;
+  return Math.min(lineCount, maxLines);
+}
+
+function readFileRange(id: string, rel: string, abs: string, start: number, end: number): Message {
+  const lines = fs.readFileSync(abs, "utf8").split(/\n/);
+  const boundedEnd = Math.min(Math.max(start, end), lines.length);
+  const content = lines
+    .slice(start - 1, boundedEnd)
+    .map((line, i) => `${start + i}: ${line}`)
+    .join("\n");
+  return toolResult(id, {
+    ok: true,
+    path: rel,
+    start,
+    end: boundedEnd,
+    total_lines: lines.length,
+    truncated_before: start > 1,
+    truncated_after: boundedEnd < lines.length,
+    content: truncate(content, readLimit),
+  });
+}
+
+function tool(name: string, description: string, properties: Record<string, any>) {
+  return {
+    type: "function",
+    function: {
+      name,
+      description,
+      parameters: {
+        type: "object",
+        properties,
+        required: Object.keys(properties).filter((key) => !optionalToolArgs.has(key)),
+      },
+    },
+  };
+}
+
+function toolResult(id: string, obj: unknown): Message {
+  return { role: "tool", tool_call_id: id, content: JSON.stringify(obj) };
+}
+
+function assertPath(input: string, write: boolean) {
+  const raw = String(input || "");
+  const rawAbs = path.isAbsolute(raw) ? path.resolve(raw) : null;
+  const abs = rawAbs ?? path.resolve(cwd, path.normalize(raw.replace(/^\/+/, "")));
+  if (!abs.startsWith(cwd + path.sep) && abs !== cwd) throw new Error(`path outside cwd: ${input}`);
+  const rel = path.relative(cwd, abs) || ".";
+  if (!rel || rel.startsWith("..") || path.isAbsolute(rel))
+    throw new Error(`invalid repository path: ${input}`);
+  if (write && allowed.length > 0 && !allowed.includes(rel)) {
+    throw new Error(`write denied for ${rel}; allowed: ${allowed.join(", ")}`);
+  }
+  return { rel, abs };
+}
+
+function normalizeFinalContent(content: string): string {
+  const trimmed = content.trim();
+  if (!trimmed) return "\n";
+  const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
+  const candidate = (fenced?.[1] ?? extractJsonObject(trimmed) ?? trimmed).trim();
+  return `${candidate}\n`;
+}
+
+function extractJsonObject(value: string): string | null {
+  const start = value.indexOf("{");
+  if (start < 0) return null;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let index = start; index < value.length; index += 1) {
+    const char = value[index];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === '"') inString = false;
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+    if (char === "{") depth += 1;
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) return value.slice(start, index + 1);
+    }
+  }
+  return null;
+}
+
+function validateFinalContent(content: string): string[] {
+  if (!outputSchema) return [];
+  const normalized = normalizeFinalContent(content).trim();
+  if (!normalized) return ["final output is empty"];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(normalized);
+  } catch (error) {
+    return [
+      `final output is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    ];
+  }
+  if (!outputSchemaJson) return [];
+  return validateSchemaValue(outputSchemaJson, parsed, "$", []).slice(0, 40);
+}
+
+function validateSchemaValue(schema: any, value: unknown, at: string, errors: string[]): string[] {
+  if (!schema || typeof schema !== "object" || errors.length >= 40) return errors;
+  if (Array.isArray(schema.anyOf)) {
+    const alternatives = schema.anyOf.map((candidate: any) =>
+      validateSchemaValue(candidate, value, at, []),
+    );
+    if (alternatives.some((candidateErrors: string[]) => candidateErrors.length === 0))
+      return errors;
+    errors.push(`${at} does not match any allowed schema variant`);
+    return errors;
+  }
+  const types = Array.isArray(schema.type) ? schema.type : schema.type ? [schema.type] : [];
+  if (types.length > 0 && !types.some((type: string) => schemaTypeMatches(type, value))) {
+    errors.push(`${at} expected type ${types.join("|")}`);
+    return errors;
+  }
+  if (Array.isArray(schema.enum) && !schema.enum.includes(value)) {
+    errors.push(
+      `${at} expected one of ${schema.enum.map((entry: unknown) => JSON.stringify(entry)).join(", ")}`,
+    );
+    return errors;
+  }
+  if (schema.type === "object" || (value && typeof value === "object" && !Array.isArray(value))) {
+    const obj = value as Record<string, unknown>;
+    for (const key of schema.required ?? []) {
+      if (!(key in obj)) errors.push(`${at}.${key} is required`);
+      if (errors.length >= 40) return errors;
+    }
+    const properties = schema.properties ?? {};
+    if (schema.additionalProperties === false) {
+      for (const key of Object.keys(obj)) {
+        if (!(key in properties)) errors.push(`${at}.${key} is not allowed`);
+        if (errors.length >= 40) return errors;
+      }
+    }
+    for (const [key, childSchema] of Object.entries(properties)) {
+      if (key in obj) validateSchemaValue(childSchema, obj[key], `${at}.${key}`, errors);
+      if (errors.length >= 40) return errors;
+    }
+  }
+  if (Array.isArray(value) && schema.items) {
+    value.slice(0, 20).forEach((entry, index) => {
+      validateSchemaValue(schema.items, entry, `${at}[${index}]`, errors);
+    });
+  }
+  return errors;
+}
+
+function schemaTypeMatches(type: string, value: unknown): boolean {
+  if (type === "null") return value === null;
+  if (type === "array") return Array.isArray(value);
+  if (type === "object")
+    return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+  if (type === "integer") return Number.isInteger(value);
+  return typeof value === type;
+}
+
+function worktreeHasDiff(): boolean {
+  const diff = spawnSync("git", ["diff", "--quiet", "--", "."], { cwd, encoding: "utf8" });
+  return diff.status === 1;
+}
+
+function finalDiffSummary() {
+  const status = spawnSync("git", ["status", "--short"], { cwd, encoding: "utf8" });
+  const stat = spawnSync("git", ["diff", "--stat"], { cwd, encoding: "utf8" });
+  process.stdout.write(`RUNNER_FINAL_DIFF_EXISTS=${worktreeHasDiff() ? "1" : "0"}\n`);
+  if (status.stdout) process.stdout.write(`RUNNER_FINAL_STATUS:\n${status.stdout}`);
+  if (stat.stdout) process.stdout.write(`RUNNER_FINAL_DIFF_STAT:\n${stat.stdout}`);
+}
+
+function stringArg(name: string, fallback: string): string {
+  const index = args.indexOf(name);
+  return index >= 0 && args[index + 1] ? String(args[index + 1]) : fallback;
+}
+
+function requiredEnv(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`missing ${name}`);
+  return value;
+}
+
+function numberEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw !== undefined && raw.trim() === "") return fallback;
+  const value = Number(raw ?? fallback);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function numberEnvZeroMeansUnlimited(name: string): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") return Number.POSITIVE_INFINITY;
+  const value = Number(raw);
+  if (value === 0) return Number.POSITIVE_INFINITY;
+  return Number.isFinite(value) && value > 0 ? value : Number.POSITIVE_INFINITY;
+}
+
+function numberEnvAllowZero(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw !== undefined && raw.trim() === "") return 0;
+  const value = Number(raw ?? fallback);
+  return Number.isFinite(value) && value >= 0 ? value : fallback;
+}
+
+function truncate(value: unknown, limit = 12000): string {
+  const text = String(value ?? "");
+  return text.length > limit
+    ? `${text.slice(0, limit)}\n...[truncated ${text.length - limit} chars]`
+    : text;
+}
+
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exit(1);
+});

--- a/src/repair/openai-compatible-tools-runner.ts
+++ b/src/repair/openai-compatible-tools-runner.ts
@@ -450,11 +450,10 @@ function compactRepairOnlyPrompt(prompt: string): string {
   const jobStart = prompt.indexOf("## Job file");
   const evidenceStart = prompt.indexOf("## Repair evidence pack");
   const preflightStart = prompt.indexOf("## Cluster preflight artifact");
-  const jobSectionEnd = [evidenceStart, preflightStart].filter((index) => index >= 0).sort((a, b) => a - b)[0];
-  const jobSection =
-    jobStart >= 0
-      ? prompt.slice(jobStart, jobSectionEnd ?? undefined)
-      : prompt;
+  const jobSectionEnd = [evidenceStart, preflightStart]
+    .filter((index) => index >= 0)
+    .sort((a, b) => a - b)[0];
+  const jobSection = jobStart >= 0 ? prompt.slice(jobStart, jobSectionEnd ?? undefined) : prompt;
   const evidencePack =
     evidenceStart >= 0
       ? prompt.slice(evidenceStart, preflightStart >= 0 ? preflightStart : evidenceStart + 36000)
@@ -506,7 +505,6 @@ function commandFromArgs(parsed: Record<string, unknown>): string {
   return "";
 }
 
-
 function rewriteUnsupportedGhPrView(command: string): string | null {
   if (!/\bgh\s+pr\s+view\b/.test(command)) return null;
   if (!/--json\s+[^\n]*(reviews|reviewRequests|comments)/.test(command)) return null;
@@ -515,19 +513,21 @@ function rewriteUnsupportedGhPrView(command: string): string | null {
   if (!number) return null;
   const repoSetup = repo
     ? ""
-    : "REPO=$(git remote get-url origin 2>/dev/null | sed -E 's#^git@github.com:##; s#^https://github.com/##; s#\\.git$##'); if [ -z \"$REPO\" ]; then echo '{\"source\":\"gh_api_rest_rewrite\",\"error\":\"repo_inference_failed\"}'; exit 2; fi; BASE=\"repos/$REPO\"";
+    : 'REPO=$(git remote get-url origin 2>/dev/null | sed -E \'s#^git@github.com:##; s#^https://github.com/##; s#\\.git$##\'); if [ -z "$REPO" ]; then echo \'{"source":"gh_api_rest_rewrite","error":"repo_inference_failed"}\'; exit 2; fi; BASE="repos/$REPO"';
   const base = repo ? shellQuote(`repos/${repo}`) : '"$BASE"';
   const pr = shellQuote(number);
   return [
     repoSetup,
-    "echo '{\"source\":\"gh_api_rest_rewrite\",\"reason\":\"gh pr view review/comment fields use GraphQL fields that can require extra org scopes; using REST with the same GH_TOKEN\",\"review_comments\":'",
+    'echo \'{"source":"gh_api_rest_rewrite","reason":"gh pr view review/comment fields use GraphQL fields that can require extra org scopes; using REST with the same GH_TOKEN","review_comments":\'',
     `gh api ${base}/pulls/${pr}/comments --jq '[.[] | {path,line,side,user:.user.login,body,html_url,created_at}]'`,
     "echo ',\"reviews\":'",
     `gh api ${base}/pulls/${pr}/reviews --jq '[.[] | {state,user:.user.login,body,html_url,submitted_at}]'`,
     "echo ',\"issue_comments\":'",
     `gh api ${base}/issues/${pr}/comments --jq '[.[] | {user:.user.login,body,html_url,created_at}]'`,
     "echo '}'",
-  ].filter(Boolean).join(" && ");
+  ]
+    .filter(Boolean)
+    .join(" && ");
 }
 
 function shellQuote(value: string): string {
@@ -694,7 +694,6 @@ function executeTool(call: ToolCall): Message {
   }
 }
 
-
 function scrubbedToolEnv(): NodeJS.ProcessEnv {
   const env = { ...process.env };
   delete env[apiKeyEnv];
@@ -715,9 +714,10 @@ function githubPrContext(repo: string, number: number): Record<string, unknown> 
   const issueComments = ghApiJson(`${base}/issues/${number}/comments`);
   const reviews = ghApiJson(`${base}/pulls/${number}/reviews`);
   const reviewComments = ghApiJson(`${base}/pulls/${number}/comments`);
-  const headSha = typeof pull.value === "object" && pull.value !== null
-    ? String((pull.value as any).head?.sha ?? "")
-    : "";
+  const headSha =
+    typeof pull.value === "object" && pull.value !== null
+      ? String((pull.value as any).head?.sha ?? "")
+      : "";
   const checkRuns = /^[0-9a-f]{40}$/i.test(headSha)
     ? ghApiJson(`${base}/commits/${headSha}/check-runs`)
     : { ok: true, value: null };
@@ -773,26 +773,51 @@ function simplifyPull(value: unknown) {
 
 function simplifyIssueComments(value: unknown) {
   return Array.isArray(value)
-    ? value.map((comment: any) => ({ user: comment.user?.login, body: comment.body, html_url: comment.html_url, created_at: comment.created_at }))
+    ? value.map((comment: any) => ({
+        user: comment.user?.login,
+        body: comment.body,
+        html_url: comment.html_url,
+        created_at: comment.created_at,
+      }))
     : [];
 }
 
 function simplifyReviews(value: unknown) {
   return Array.isArray(value)
-    ? value.map((review: any) => ({ state: review.state, user: review.user?.login, body: review.body, html_url: review.html_url, submitted_at: review.submitted_at }))
+    ? value.map((review: any) => ({
+        state: review.state,
+        user: review.user?.login,
+        body: review.body,
+        html_url: review.html_url,
+        submitted_at: review.submitted_at,
+      }))
     : [];
 }
 
 function simplifyReviewComments(value: unknown) {
   return Array.isArray(value)
-    ? value.map((comment: any) => ({ path: comment.path, line: comment.line, side: comment.side, user: comment.user?.login, body: comment.body, html_url: comment.html_url, created_at: comment.created_at }))
+    ? value.map((comment: any) => ({
+        path: comment.path,
+        line: comment.line,
+        side: comment.side,
+        user: comment.user?.login,
+        body: comment.body,
+        html_url: comment.html_url,
+        created_at: comment.created_at,
+      }))
     : [];
 }
 
 function simplifyCheckRuns(value: unknown) {
   const runs = (value as any)?.check_runs;
   return Array.isArray(runs)
-    ? runs.map((run: any) => ({ name: run.name, status: run.status, conclusion: run.conclusion, html_url: run.html_url, completed_at: run.completed_at }))
+    ? runs.map((run: any) => ({
+        name: run.name,
+        status: run.status,
+        conclusion: run.conclusion,
+        html_url: run.html_url,
+        completed_at: run.completed_at,
+      }))
     : [];
 }
 
@@ -1025,7 +1050,6 @@ function truncate(value: unknown, limit = 12000): string {
     ? `${text.slice(0, limit)}\n...[truncated ${text.length - limit} chars]`
     : text;
 }
-
 
 main().catch((error) => {
   console.error(error instanceof Error ? error.stack || error.message : String(error));

--- a/src/repair/openai-compatible/normalize-result.ts
+++ b/src/repair/openai-compatible/normalize-result.ts
@@ -1,0 +1,625 @@
+type Message = { role: string; content?: string | null; tool_call_id?: string };
+
+function normalizeFinalContent(content: string): string {
+  const trimmed = content.trim();
+  if (!trimmed) return "\n";
+  const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
+  const candidate = (fenced?.[1] ?? extractJsonObject(trimmed) ?? trimmed).trim();
+  return `${candidate}\n`;
+}
+
+function extractJsonObject(value: string): string | null {
+  const start = value.indexOf("{");
+  if (start < 0) return null;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let index = start; index < value.length; index += 1) {
+    const char = value[index];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === '"') inString = false;
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+    if (char === "{") depth += 1;
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) return value.slice(start, index + 1);
+    }
+  }
+  return null;
+}
+
+function truncate(value: unknown, limit = 12000): string {
+  const text = String(value ?? "");
+  return text.length > limit
+    ? `${text.slice(0, limit)}\n...[truncated ${text.length - limit} chars]`
+    : text;
+}
+
+export function isPrematureNeedsHuman(
+  normalizedContent: string,
+  prompt: string,
+  toolsExecuted: number,
+): boolean {
+  if (toolsExecuted > 0) return false;
+  if (!prompt.includes("## Source PR refs")) return false;
+  try {
+    const obj = JSON.parse(normalizedContent);
+    return obj?.status === "needs_human" && !obj?.fix_artifact;
+  } catch {
+    return false;
+  }
+}
+
+export function looksLikeCodexResultCandidate(content: string): boolean {
+  const obj = parseLooseObject(content);
+  if (!obj || typeof obj !== "object" || Array.isArray(obj)) return false;
+  const keys = new Set(Object.keys(obj));
+  if (keys.has("status") || keys.has("actions") || keys.has("fix_artifact")) return true;
+  if (keys.has("needs_human") || keys.has("build_fix_artifact") || keys.has("repair_strategy"))
+    return true;
+  return false;
+}
+
+function codexResultContext(prompt: string) {
+  const repo = promptVal(prompt, "repo") || "unknown/unknown";
+  const number = prNum(prompt) || "0";
+  const ref = number === "0" ? null : `#${number}`;
+  const prUrl =
+    repo !== "unknown/unknown" && number !== "0"
+      ? `https://github.com/${repo}/pull/${number}`
+      : null;
+  return {
+    repo,
+    number,
+    ref,
+    prUrl,
+    clusterId: promptVal(prompt, "cluster_id") || `repair-pr-${repo.replace("/", "-")}-${number}`,
+  };
+}
+
+export function buildFinalizationPrompt(
+  rawPrompt: string,
+  messages: Message[],
+  diffExists: boolean,
+  outputSchema: string,
+): string {
+  const ctx = codexResultContext(rawPrompt);
+  const primarySignal = primaryRepairSignal(rawPrompt);
+  return [
+    `Schema path: ${outputSchema}`,
+    "Return final JSON only. Do not call tools. Do not emit DSML/tool_calls.",
+    "This is repair-only PR intake. The source PR is the suspect artifact, not canonical source material.",
+    "Never say to cherry-pick, apply, copy, or accept the source PR as-is. Build a repair artifact for unresolved review signals/check failures only.",
+    "Prefer status=planned with action=build_fix_artifact when repair is possible.",
+    "Use needs_human only for an exact unresolved blocker.",
+    `repo: ${ctx.repo}`,
+    `cluster_id: ${ctx.clusterId}`,
+    `canonical_pr: ${ctx.prUrl ?? ""}`,
+    `canonical: ${ctx.ref ?? ""}`,
+    `current_git_diff_exists: ${diffExists ? "yes" : "no"}`,
+    "Required fix_artifact minimum fields when planned: repair_strategy, source_prs, likely_files, validation_commands, summary, affected_surfaces, credit_notes, pr_title, pr_body.",
+    "A planned fix_artifact must directly repair the primary repair signal. Do not substitute a secondary cleanup, duplicate check, refactor, log cleanup, or incidental improvement unless it is explicitly the primary signal.",
+    "",
+    "## Primary repair signal (authoritative; must be fixed)",
+    primarySignal ? truncate(primarySignal, 2000) : "<none extracted>",
+    primarySignal ? primarySignalChecklist(primarySignal) : "",
+    "",
+    "## Source PR refs / job essentials",
+    truncate(extractFinalizationEssentials(rawPrompt), 4500),
+    "",
+    "## Evidence collected from tool loop",
+    truncate(finalizationTranscript(messages), 6500),
+  ].join("\n");
+}
+
+
+function primarySignalChecklist(signal: string): string {
+  const terms = importantSignalTerms(signal).slice(0, 8);
+  return [
+    "Checklist for this primary signal:",
+    "- The fix_artifact must directly address the primary signal above.",
+    "- Make summary, pr_title, pr_body, likely_files, and validation_commands point at that signal.",
+    "- Secondary findings may be mentioned only as supporting context; they must not replace the primary signal.",
+    terms.length ? `- Strong signal terms to preserve/address: ${terms.join(", ")}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+function finalizationTranscript(messages: Message[]): string {
+  const lines: string[] = [];
+  for (const msg of messages.slice(-12)) {
+    if (msg.role === "assistant" && msg.content) {
+      const text = String(msg.content);
+      if (
+        text.includes("tool_call") ||
+        text.includes("fix_artifact") ||
+        text.includes("build_fix_artifact")
+      ) {
+        lines.push(`assistant: ${truncate(text, 1200)}`);
+      }
+    }
+    if (msg.role === "tool" && msg.content) lines.push(`tool: ${truncate(msg.content, 1800)}`);
+  }
+  return lines.join("\n\n") || "No tool evidence captured.";
+}
+
+function extractFinalizationEssentials(prompt: string): string {
+  const sections = [
+    sectionFrom(prompt, "## Repair evidence pack", "## Cluster preflight artifact"),
+    sectionFrom(prompt, "## Job file", "## Target checkout"),
+    sectionFrom(prompt, "## Source PR refs", "## Required final output"),
+  ].filter(Boolean);
+  if (sections.length > 0) return sections.join("\n\n");
+  return prompt
+    .split(/\r?\n/)
+    .filter((line) => /repo:|cluster_id:|source:|source_prs|repair_strategy|pull\//.test(line))
+    .join("\n");
+}
+
+function sectionFrom(text: string, start: string, end: string): string {
+  const startIndex = text.indexOf(start);
+  if (startIndex < 0) return "";
+  const endIndex = text.indexOf(end, startIndex + start.length);
+  return text.slice(startIndex, endIndex >= 0 ? endIndex : startIndex + 3000);
+}
+
+export function normalizeCodexResult(content: string, prompt: string, diffExists: boolean): string {
+  const repo = promptVal(prompt, "repo") || "unknown/unknown";
+  const cluster = promptVal(prompt, "cluster_id") || "openai-compatible-fallback";
+  const rawMode = promptVal(prompt, "mode");
+  const mode = ["plan", "execute", "autonomous"].includes(rawMode) ? rawMode : "autonomous";
+  const num = prNum(prompt) || "0";
+  const ref = `#${num}`;
+  const prUrl =
+    repo !== "unknown/unknown" && num !== "0" ? `https://github.com/${repo}/pull/${num}` : null;
+  const obj = parseLooseObject(content);
+  const textualToolCall = content.includes("<｜DSML｜tool_calls") || content.includes("tool_calls");
+  const summary =
+    str(obj.summary) ||
+    str(obj.notes) ||
+    str(obj.reason) ||
+    str(obj.result) ||
+    str(obj.blocked_reason) ||
+    firstChangeRationale(obj) ||
+    (textualToolCall
+      ? "Adapter finalization returned tool calls instead of final JSON."
+      : diffExists
+        ? "OpenAI-compatible worker produced a diff but returned non-conforming structured output."
+        : "OpenAI-compatible worker returned non-conforming structured output.");
+  const needs = arr(obj.needs_human ?? obj.blockers ?? obj.exact_blocker_evidence);
+  if (textualToolCall && needs.length === 0) needs.push("adapter_finalization_returned_tool_calls");
+  let synthesizedFixArtifact = synthesizeFixArtifact(obj, repo, ref, prUrl, summary);
+  if (synthesizedFixArtifact && sourcePrTreatedAsCanonical(synthesizedFixArtifact, prUrl, ref)) {
+    needs.push("source_pr_treated_as_canonical");
+    synthesizedFixArtifact = null;
+  }
+  if (synthesizedFixArtifact && !fixArtifactSatisfiesPrimaryRepairSignal(prompt, synthesizedFixArtifact)) {
+    needs.push("fix_artifact_missing_primary_repair_signal");
+    synthesizedFixArtifact = null;
+  }
+  if (!synthesizedFixArtifact && (obj.fix_needed === true || str(obj.repair_strategy) || arr(obj.source_prs).length > 0 || obj.build_fix_artifact || obj.fix_artifact || firstBuildFixAction(obj))) {
+    if (needs.length === 0) needs.push("missing_fix_artifact_evidence");
+    if (!arr(obj.likely_files).length && !arr(obj.fix_artifact?.likely_files).length && !arr(obj.build_fix_artifact?.likely_files).length) needs.push("missing_likely_files_evidence");
+    if (!arr(obj.validation_commands).length && !arr(obj.fix_artifact?.validation_commands).length && !arr(obj.build_fix_artifact?.validation_commands).length) needs.push("missing_validation_commands_evidence");
+  }
+  const action = synthesizedFixArtifact ? "build_fix_artifact" : "needs_human";
+  const humanNeeds = action === "needs_human" && needs.length === 0 ? [summary] : needs;
+  return `${JSON.stringify(
+    {
+      status: action === "needs_human" ? "needs_human" : "planned",
+      repo,
+      cluster_id: cluster,
+      mode,
+      summary,
+      actions: [
+        {
+          target: action === "build_fix_artifact" ? `cluster:${cluster}` : ref,
+          action,
+          status: "planned",
+          idempotency_key: `${cluster}-${action}`,
+          classification: action === "needs_human" ? "needs_human" : "canonical",
+          target_kind: action === "build_fix_artifact" ? null : "pull_request",
+          target_updated_at:
+            action === "build_fix_artifact"
+              ? null
+              : promptUpdatedAt(prompt) || new Date().toISOString(),
+          canonical: ref,
+          duplicate_of: null,
+          candidate_fix: null,
+          comment: null,
+          evidence: humanNeeds.length ? humanNeeds : [summary],
+          reason: humanNeeds[0] || summary,
+        },
+      ],
+      needs_human: humanNeeds,
+      canonical: ref,
+      canonical_issue: null,
+      canonical_pr: prUrl,
+      merge_preflight: [],
+      fix_artifact: synthesizedFixArtifact,
+    },
+    null,
+    2,
+  )}\n`;
+}
+
+function firstBuildFixAction(obj: any): any {
+  const actions = Array.isArray(obj.actions) ? obj.actions : [];
+  return actions.find(
+    (entry: any) =>
+      entry &&
+      typeof entry === "object" &&
+      !Array.isArray(entry) &&
+      (entry.action === "build_fix_artifact" || entry.fix_artifact),
+  );
+}
+
+function synthesizeFixArtifact(
+  obj: any,
+  repo: string,
+  ref: string,
+  prUrl: string | null,
+  summary: string,
+) {
+  const topAction = firstBuildFixAction(obj);
+  const wantsFix =
+    obj.fix_needed === true ||
+    str(obj.repair_strategy) ||
+    arr(obj.source_prs).length > 0 ||
+    obj.build_fix_artifact ||
+    obj.fix_artifact ||
+    topAction;
+  if (!wantsFix) return null;
+  const action = topAction;
+  const actionFix = action?.fix_artifact;
+  const nested =
+    obj.fix_artifact && typeof obj.fix_artifact === "object" && !Array.isArray(obj.fix_artifact)
+      ? obj.fix_artifact
+      : obj.build_fix_artifact &&
+          typeof obj.build_fix_artifact === "object" &&
+          !Array.isArray(obj.build_fix_artifact)
+        ? obj.build_fix_artifact
+        : actionFix && typeof actionFix === "object" && !Array.isArray(actionFix)
+          ? actionFix
+          : {};
+  const artifactSummary =
+    str(nested.summary) ||
+    str(nested.fix_summary) ||
+    str(obj.fix_summary) ||
+    firstChangeRationale(nested) ||
+    str(obj.notes) ||
+    str(action?.reason) ||
+    summary;
+  const likelyFiles = arr(nested.likely_files).length
+    ? arr(nested.likely_files)
+    : arr(nested.files_changed).length
+      ? arr(nested.files_changed)
+      : arr(nested.changed_files).length
+        ? arr(nested.changed_files)
+        : changePaths(nested).length
+        ? changePaths(nested)
+        : arr(obj.likely_files).length
+          ? arr(obj.likely_files)
+          : [];
+  const validationCommands = arr(nested.validation_commands).length
+    ? arr(nested.validation_commands)
+    : arr(nested.validation?.ran).length
+      ? arr(nested.validation.ran)
+      : validationList(nested.validation).length
+        ? validationList(nested.validation)
+        : arr(obj.validation_commands).length
+        ? arr(obj.validation_commands)
+        : arr(obj.validation?.ran).length
+          ? arr(obj.validation.ran)
+          : validationList(obj.validation).length
+            ? validationList(obj.validation)
+            : [];
+  if (likelyFiles.length === 0 || validationCommands.length === 0) return null;
+  const validationSummary =
+    str(nested.validation_summary) ||
+    str(obj.validation_summary) ||
+    arr(nested.validation?.results).join("; ") ||
+    validationSummaryFromList(nested.validation) ||
+    arr(obj.validation?.results).join("; ") ||
+    validationSummaryFromList(obj.validation);
+  return {
+    summary: artifactSummary,
+    affected_surfaces: arr(nested.affected_surfaces).length
+      ? arr(nested.affected_surfaces)
+      : arr(obj.affected_surfaces).length
+        ? arr(obj.affected_surfaces)
+        : ["repair-only PR intake"],
+    likely_files: likelyFiles,
+    linked_refs: [ref],
+    validation_commands: validationSummary
+      ? [...validationCommands, `# ${validationSummary}`]
+      : validationCommands,
+    changelog_required: nested.changelog_required === true || obj.changelog_required === true,
+    credit_notes: [prUrl ? `Source PR: ${prUrl}` : "Preserve contributor credit."],
+    pr_title: str(nested.pr_title) || str(obj.pr_title) || `Repair ${repo} ${ref}`,
+    pr_body: str(nested.pr_body) || str(obj.pr_body) || str(obj.notes) || artifactSummary,
+    source_prs: normalizeSourcePrs(
+      arr(obj.source_prs).length ? arr(obj.source_prs) : arr(nested.source_prs),
+      prUrl,
+    ),
+    repair_strategy: normalizeRepairStrategy(
+      str(obj.repair_strategy) || str(nested.repair_strategy),
+    ),
+    allow_no_pr: nested.allow_no_pr === true || obj.allow_no_pr === true,
+    branch_update_blockers: arr(nested.branch_update_blockers).length
+      ? arr(nested.branch_update_blockers)
+      : arr(obj.branch_update_blockers),
+  };
+}
+
+
+const REPAIR_STRATEGIES = new Set([
+  "repair_contributor_branch",
+  "replace_uneditable_branch",
+  "new_fix_pr",
+  "already_fixed_on_main",
+  "needs_human",
+]);
+
+function normalizeRepairStrategy(value: string): string {
+  const raw = value.trim().toLowerCase().replace(/[ -]+/g, "_");
+  if (REPAIR_STRATEGIES.has(raw)) return raw;
+  const text = value.toLowerCase();
+  if (/already[_ -]?fixed|fixed on main|already on main/.test(text)) return "already_fixed_on_main";
+  if (/needs? human|manual|blocked/.test(text)) return "needs_human";
+  if (/uneditable|replace[_ -]?uneditable|replace[^.]{0,80}branch|replacement[^.]{0,80}branch/.test(text)) return "replace_uneditable_branch";
+  if (/new .*fix|new .*pr|follow.?up/.test(text)) return "new_fix_pr";
+  return "repair_contributor_branch";
+}
+
+function normalizeSourcePrs(values: string[], prUrl: string | null): string[] {
+  const urls: string[] = [];
+  const fallbackNumber = prUrl?.match(/\/pull\/(\d+)$/)?.[1] ?? "";
+  const fallbackPrefix = fallbackNumber ? prUrl!.slice(0, -fallbackNumber.length) : "";
+  const candidates = values.length > 0 ? values : prUrl ? [prUrl] : [];
+  for (const value of candidates) {
+    const text = value.trim();
+    if (!text) continue;
+    if (/^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+$/i.test(text)) {
+      urls.push(text);
+      continue;
+    }
+    const number = text.match(/^#?(\d+)$/)?.[1];
+    if (number && fallbackPrefix) urls.push(`${fallbackPrefix}${number}`);
+  }
+  if (urls.length === 0 && prUrl) urls.push(prUrl);
+  return [...new Set(urls)];
+}
+
+
+function sourcePrTreatedAsCanonical(artifact: any, prUrl: string | null, ref: string): boolean {
+  const text = artifactText(artifact);
+  const escapedRef = ref.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const prNumber = prUrl?.match(/\/pull\/(\d+)$/)?.[1] ?? ref.replace(/^#/, "");
+  const sourceRefPattern = prNumber
+    ? new RegExp(`(?:source\\s+pr|pr|#)\\s*#?${prNumber}`, "i")
+    : new RegExp(escapedRef, "i");
+  return (
+    /\bcherry[- ]pick\b/i.test(text) ||
+    /\bapply\s+(?:the\s+)?(?:fix|changes|patch)\s+from\s+(?:the\s+)?(?:source\s+)?pr\b/i.test(text) ||
+    /\bapply\s+(?:the\s+)?(?:source\s+)?pr\s+as[- ]is\b/i.test(text) ||
+    /\bcopy\s+(?:the\s+)?(?:source\s+)?pr\b/i.test(text) ||
+    /\baccept\s+(?:the\s+)?(?:source\s+)?pr\b/i.test(text) ||
+    /\bcanonical\s+(?:source\s+)?pr\b/i.test(text) ||
+    (/\bapply\b/i.test(text) && sourceRefPattern.test(text) && /\bas[- ]is\b/i.test(text))
+  );
+}
+
+function fixArtifactSatisfiesPrimaryRepairSignal(prompt: string, artifact: any): boolean {
+  const signal = primaryRepairSignal(prompt);
+  if (!signal) return true;
+  const text = artifactText(artifact);
+  const terms = importantSignalTerms(signal);
+  if (terms.length === 0) return true;
+  const hits = terms.filter((term) => text.includes(term)).length;
+  const requiredHits = Math.max(3, Math.ceil(terms.length * 0.4));
+  return hits >= Math.min(requiredHits, terms.length);
+}
+
+function primaryRepairSignal(prompt: string): string {
+  const signals = extractRepairSignals(prompt);
+  return (
+    signals.find((signal) => signal.kind === "review_thread_unresolved")?.text ||
+    signals.find((signal) => signal.kind === "review_changes_requested")?.text ||
+    signals.find((signal) => meaningfulRepairSignalText(signal.text))?.text ||
+    ""
+  );
+}
+
+function extractRepairSignals(prompt: string): Array<{ kind: string; text: string }> {
+  const signals: Array<{ kind: string; text: string }> = [];
+  const pattern = /"kind":\s*"([^"\\]+)"[\s\S]{0,1800}?"text":\s*"((?:\\.|[^"\\])*)"/g;
+  for (const match of prompt.matchAll(pattern)) {
+    const kind = match[1] || "";
+    const text = decodeJsonString(match[2] || "");
+    if (!kind || !text) continue;
+    signals.push({ kind, text });
+  }
+  return signals;
+}
+
+function decodeJsonString(value: string): string {
+  try {
+    return JSON.parse(`"${value}"`);
+  } catch {
+    return value;
+  }
+}
+
+function meaningfulRepairSignalText(text: string): boolean {
+  return !/^(mergeStateStatus|mergeable|state)=/i.test(text.trim());
+}
+
+function artifactText(artifact: any): string {
+  return [
+    artifact.repair_strategy,
+    artifact.summary,
+    artifact.pr_title,
+    artifact.pr_body,
+    ...(Array.isArray(artifact.affected_surfaces) ? artifact.affected_surfaces : []),
+    ...(Array.isArray(artifact.likely_files) ? artifact.likely_files : []),
+    ...(Array.isArray(artifact.validation_commands) ? artifact.validation_commands : []),
+    ...(Array.isArray(artifact.credit_notes) ? artifact.credit_notes : []),
+  ]
+    .map((value) => String(value ?? "").toLowerCase())
+    .join("\n");
+}
+
+function importantSignalTerms(signal: string): string[] {
+  const lower = signal.toLowerCase().replace(/https?:\/\/\S+/g, " ");
+  const codeTerms = [...lower.matchAll(/`([^`]+)`/g)].flatMap((match) => tokenizeSignalTerms(match[1] ?? "", 3));
+  const generalTerms = tokenizeSignalTerms(lower, 5);
+  return [...new Set([...codeTerms, ...generalTerms])]
+    .filter((term) => !REVIEW_SIGNAL_STOPWORDS.has(term))
+    .slice(0, 16);
+}
+
+function tokenizeSignalTerms(value: string, minLength: number): string[] {
+  const pattern = new RegExp(`[a-z_][a-z0-9_-]{${Math.max(0, minLength - 1)},}`, "g");
+  return value.match(pattern) ?? [];
+}
+
+const REVIEW_SIGNAL_STOPWORDS = new Set([
+  "review",
+  "thread",
+  "coderabbitai",
+  "potential",
+  "issue",
+  "major",
+  "quick",
+  "status",
+  "github",
+  "comments",
+  "comment",
+  "current",
+  "branch",
+  "around",
+  "line",
+  "lines",
+  "requested",
+  "changes",
+  "actionable",
+  "posted",
+  "details",
+  "summary",
+  "prompt",
+  "agents",
+  "agent",
+  "verify",
+  "finding",
+  "findings",
+  "against",
+  "still-valid",
+  "still",
+  "valid",
+  "skip",
+  "rest",
+  "brief",
+  "reason",
+  "minimal",
+  "validate",
+  "inline",
+  "file",
+  "files",
+  "view",
+  "html_url",
+  "created_at",
+  "body",
+  "user",
+]);
+
+
+function validationList(value: any): string[] {
+  const values = arr(value);
+  if (values.length === 0) return [];
+  return values.map(validationCommandFromText).filter(Boolean);
+}
+
+function validationCommandFromText(value: string): string {
+  const text = value.trim();
+  if (!text) return "";
+  const beforePassed = text.match(/^(.+?)\s+(?:passed|passes|succeeded|ok)\b/i)?.[1]?.trim();
+  if (beforePassed && looksLikeValidationCommand(beforePassed)) return beforePassed;
+  if (looksLikeValidationCommand(text)) return text;
+  return `# ${text}`;
+}
+
+function looksLikeValidationCommand(value: string): boolean {
+  return /^(bash|sh|shellcheck|bats|npm|pnpm|yarn|node|python3?|pytest|go test|cargo test|make|cmake|ruby|bundle)\b/.test(value.trim());
+}
+
+function validationSummaryFromList(value: any): string {
+  const values = arr(value).filter((entry) => !looksLikeValidationCommand(entry));
+  return values.join("; ");
+}
+
+function firstChangeRationale(obj: any): string {
+  const changes = Array.isArray(obj?.changes) ? obj.changes : [];
+  for (const change of changes) {
+    const rationale = str(change?.rationale);
+    if (rationale) return rationale;
+  }
+  return "";
+}
+
+function changePaths(obj: any): string[] {
+  const changes = Array.isArray(obj?.changes) ? obj.changes : [];
+  return changes.map((change: any) => str(change?.path)).filter(Boolean);
+}
+
+function promptVal(prompt: string, key: string): string {
+  const p = `${key}:`;
+  for (const line of prompt.split(/\r?\n/)) {
+    const t = line.trim();
+    if (t.startsWith(p)) return t.slice(p.length).trim();
+  }
+  return "";
+}
+function promptUpdatedAt(prompt: string): string {
+  return prompt.match(/"updated_at": "([^"]+)"/)?.[1] || "";
+}
+function prNum(prompt: string): string {
+  const a = prompt.match(/\/pull\/(\d+)/);
+  if (a?.[1]) return a[1];
+  const b = prompt.match(/#(\d+)/);
+  return b?.[1] || "";
+}
+function parseLooseObject(content: string): any {
+  const t = normalizeFinalContent(content).trim();
+  try {
+    return JSON.parse(t);
+  } catch {}
+  const a = t.indexOf("{");
+  const b = t.lastIndexOf("}");
+  if (a >= 0 && b > a) {
+    try {
+      return JSON.parse(t.slice(a, b + 1));
+    } catch {}
+  }
+  return {};
+}
+function str(v: unknown): string {
+  return typeof v === "string" ? v.trim() : v == null ? "" : String(v).trim();
+}
+function arr(v: unknown): string[] {
+  if (typeof v === "boolean" || v == null) return [];
+  const xs = Array.isArray(v) ? v : [v];
+  return xs
+    .filter((x) => typeof x !== "boolean" && x != null)
+    .map((x) => (typeof x === "string" ? x.trim() : JSON.stringify(x)))
+    .filter(Boolean);
+}
+

--- a/src/repair/openai-compatible/normalize-result.ts
+++ b/src/repair/openai-compatible/normalize-result.ts
@@ -119,7 +119,6 @@ export function buildFinalizationPrompt(
   ].join("\n");
 }
 
-
 function primarySignalChecklist(signal: string): string {
   const terms = importantSignalTerms(signal).slice(0, 8);
   return [
@@ -201,14 +200,35 @@ export function normalizeCodexResult(content: string, prompt: string, diffExists
     needs.push("source_pr_treated_as_canonical");
     synthesizedFixArtifact = null;
   }
-  if (synthesizedFixArtifact && !fixArtifactSatisfiesPrimaryRepairSignal(prompt, synthesizedFixArtifact)) {
+  if (
+    synthesizedFixArtifact &&
+    !fixArtifactSatisfiesPrimaryRepairSignal(prompt, synthesizedFixArtifact)
+  ) {
     needs.push("fix_artifact_missing_primary_repair_signal");
     synthesizedFixArtifact = null;
   }
-  if (!synthesizedFixArtifact && (obj.fix_needed === true || str(obj.repair_strategy) || arr(obj.source_prs).length > 0 || obj.build_fix_artifact || obj.fix_artifact || firstBuildFixAction(obj))) {
+  if (
+    !synthesizedFixArtifact &&
+    (obj.fix_needed === true ||
+      str(obj.repair_strategy) ||
+      arr(obj.source_prs).length > 0 ||
+      obj.build_fix_artifact ||
+      obj.fix_artifact ||
+      firstBuildFixAction(obj))
+  ) {
     if (needs.length === 0) needs.push("missing_fix_artifact_evidence");
-    if (!arr(obj.likely_files).length && !arr(obj.fix_artifact?.likely_files).length && !arr(obj.build_fix_artifact?.likely_files).length) needs.push("missing_likely_files_evidence");
-    if (!arr(obj.validation_commands).length && !arr(obj.fix_artifact?.validation_commands).length && !arr(obj.build_fix_artifact?.validation_commands).length) needs.push("missing_validation_commands_evidence");
+    if (
+      !arr(obj.likely_files).length &&
+      !arr(obj.fix_artifact?.likely_files).length &&
+      !arr(obj.build_fix_artifact?.likely_files).length
+    )
+      needs.push("missing_likely_files_evidence");
+    if (
+      !arr(obj.validation_commands).length &&
+      !arr(obj.fix_artifact?.validation_commands).length &&
+      !arr(obj.build_fix_artifact?.validation_commands).length
+    )
+      needs.push("missing_validation_commands_evidence");
   }
   const action = synthesizedFixArtifact ? "build_fix_artifact" : "needs_human";
   const humanNeeds = action === "needs_human" && needs.length === 0 ? [summary] : needs;
@@ -305,10 +325,10 @@ function synthesizeFixArtifact(
       : arr(nested.changed_files).length
         ? arr(nested.changed_files)
         : changePaths(nested).length
-        ? changePaths(nested)
-        : arr(obj.likely_files).length
-          ? arr(obj.likely_files)
-          : [];
+          ? changePaths(nested)
+          : arr(obj.likely_files).length
+            ? arr(obj.likely_files)
+            : [];
   const validationCommands = arr(nested.validation_commands).length
     ? arr(nested.validation_commands)
     : arr(nested.validation?.ran).length
@@ -316,12 +336,12 @@ function synthesizeFixArtifact(
       : validationList(nested.validation).length
         ? validationList(nested.validation)
         : arr(obj.validation_commands).length
-        ? arr(obj.validation_commands)
-        : arr(obj.validation?.ran).length
-          ? arr(obj.validation.ran)
-          : validationList(obj.validation).length
-            ? validationList(obj.validation)
-            : [];
+          ? arr(obj.validation_commands)
+          : arr(obj.validation?.ran).length
+            ? arr(obj.validation.ran)
+            : validationList(obj.validation).length
+              ? validationList(obj.validation)
+              : [];
   if (likelyFiles.length === 0 || validationCommands.length === 0) return null;
   const validationSummary =
     str(nested.validation_summary) ||
@@ -360,7 +380,6 @@ function synthesizeFixArtifact(
   };
 }
 
-
 const REPAIR_STRATEGIES = new Set([
   "repair_contributor_branch",
   "replace_uneditable_branch",
@@ -375,7 +394,12 @@ function normalizeRepairStrategy(value: string): string {
   const text = value.toLowerCase();
   if (/already[_ -]?fixed|fixed on main|already on main/.test(text)) return "already_fixed_on_main";
   if (/needs? human|manual|blocked/.test(text)) return "needs_human";
-  if (/uneditable|replace[_ -]?uneditable|replace[^.]{0,80}branch|replacement[^.]{0,80}branch/.test(text)) return "replace_uneditable_branch";
+  if (
+    /uneditable|replace[_ -]?uneditable|replace[^.]{0,80}branch|replacement[^.]{0,80}branch/.test(
+      text,
+    )
+  )
+    return "replace_uneditable_branch";
   if (/new .*fix|new .*pr|follow.?up/.test(text)) return "new_fix_pr";
   return "repair_contributor_branch";
 }
@@ -399,7 +423,6 @@ function normalizeSourcePrs(values: string[], prUrl: string | null): string[] {
   return [...new Set(urls)];
 }
 
-
 function sourcePrTreatedAsCanonical(artifact: any, prUrl: string | null, ref: string): boolean {
   const text = artifactText(artifact);
   const escapedRef = ref.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -409,7 +432,9 @@ function sourcePrTreatedAsCanonical(artifact: any, prUrl: string | null, ref: st
     : new RegExp(escapedRef, "i");
   return (
     /\bcherry[- ]pick\b/i.test(text) ||
-    /\bapply\s+(?:the\s+)?(?:fix|changes|patch)\s+from\s+(?:the\s+)?(?:source\s+)?pr\b/i.test(text) ||
+    /\bapply\s+(?:the\s+)?(?:fix|changes|patch)\s+from\s+(?:the\s+)?(?:source\s+)?pr\b/i.test(
+      text,
+    ) ||
     /\bapply\s+(?:the\s+)?(?:source\s+)?pr\s+as[- ]is\b/i.test(text) ||
     /\bcopy\s+(?:the\s+)?(?:source\s+)?pr\b/i.test(text) ||
     /\baccept\s+(?:the\s+)?(?:source\s+)?pr\b/i.test(text) ||
@@ -480,7 +505,9 @@ function artifactText(artifact: any): string {
 
 function importantSignalTerms(signal: string): string[] {
   const lower = signal.toLowerCase().replace(/https?:\/\/\S+/g, " ");
-  const codeTerms = [...lower.matchAll(/`([^`]+)`/g)].flatMap((match) => tokenizeSignalTerms(match[1] ?? "", 3));
+  const codeTerms = [...lower.matchAll(/`([^`]+)`/g)].flatMap((match) =>
+    tokenizeSignalTerms(match[1] ?? "", 3),
+  );
   const generalTerms = tokenizeSignalTerms(lower, 5);
   return [...new Set([...codeTerms, ...generalTerms])]
     .filter((term) => !REVIEW_SIGNAL_STOPWORDS.has(term))
@@ -541,7 +568,6 @@ const REVIEW_SIGNAL_STOPWORDS = new Set([
   "user",
 ]);
 
-
 function validationList(value: any): string[] {
   const values = arr(value);
   if (values.length === 0) return [];
@@ -558,7 +584,9 @@ function validationCommandFromText(value: string): string {
 }
 
 function looksLikeValidationCommand(value: string): boolean {
-  return /^(bash|sh|shellcheck|bats|npm|pnpm|yarn|node|python3?|pytest|go test|cargo test|make|cmake|ruby|bundle)\b/.test(value.trim());
+  return /^(bash|sh|shellcheck|bats|npm|pnpm|yarn|node|python3?|pytest|go test|cargo test|make|cmake|ruby|bundle)\b/.test(
+    value.trim(),
+  );
 }
 
 function validationSummaryFromList(value: any): string {
@@ -622,4 +650,3 @@ function arr(v: unknown): string[] {
     .map((x) => (typeof x === "string" ? x.trim() : JSON.stringify(x)))
     .filter(Boolean);
 }
-

--- a/src/repair/openai-compatible/textual-tools.ts
+++ b/src/repair/openai-compatible/textual-tools.ts
@@ -1,0 +1,208 @@
+export type ToolCall = { id: string; function: { name: string; arguments?: string } };
+
+function normalizeFinalContent(content: string): string {
+  const trimmed = content.trim();
+  if (!trimmed) return "\n";
+  const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
+  const candidate = (fenced?.[1] ?? extractJsonObject(trimmed) ?? trimmed).trim();
+  return `${candidate}\n`;
+}
+
+function extractJsonObject(value: string): string | null {
+  const start = value.indexOf("{");
+  if (start < 0) return null;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let index = start; index < value.length; index += 1) {
+    const char = value[index];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === '"') inString = false;
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+    if (char === "{") depth += 1;
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) return value.slice(start, index + 1);
+    }
+  }
+  return null;
+}
+
+export function normalizeToolCalls(calls: ToolCall[], allowedTools: readonly string[]): ToolCall[] {
+  return calls.map((call, index) => normalizeToolCall(call, index, allowedTools)).filter(Boolean) as ToolCall[];
+}
+
+function normalizeToolCall(call: ToolCall, index: number, allowedTools: readonly string[]): ToolCall | null {
+  const name = call.function?.name || "";
+  if (!allowedTools.includes(name)) return null;
+  let rawArgs: Record<string, unknown> = {};
+  try {
+    const parsed = JSON.parse(call.function.arguments || "{}");
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) rawArgs = parsed;
+  } catch {
+    return null;
+  }
+  const args = sanitizePseudoArgs(name, rawArgs);
+  if (!args) return null;
+  return {
+    id: call.id || `tool-${Date.now()}-${index}`,
+    function: { name, arguments: JSON.stringify(args) },
+  };
+}
+
+function parseLooseObject(content: string): any {
+  const t = normalizeFinalContent(content).trim();
+  try { return JSON.parse(t); } catch {}
+  const a = t.indexOf("{");
+  const b = t.lastIndexOf("}");
+  if (a >= 0 && b > a) { try { return JSON.parse(t.slice(a, b + 1)); } catch {} }
+  return {};
+}
+
+export function pseudoToolCalls(content: unknown, allowedTools: readonly string[]): ToolCall[] {
+  if (typeof content !== "string" || !content.trim()) return [];
+  const parsed = parseLooseObject(content);
+  const calls = Array.isArray(parsed.tool_calls) ? parsed.tool_calls : [parsed];
+  return calls
+    .map((entry: unknown, index: number) => normalizePseudoToolCall(entry, index, allowedTools))
+    .concat(dsmlToolCalls(content, allowedTools))
+    .filter(Boolean) as ToolCall[];
+}
+
+export function dsmlToolCalls(content: string, allowedTools: readonly string[]): ToolCall[] {
+  if (!content.includes("DSML") || !content.includes("invoke")) return [];
+  const out: ToolCall[] = [];
+  const invokeRe = /<[^>]*invoke name="([^"]+)"[^>]*>([\s\S]*?)<\/[^>]*invoke>/g;
+  let invoke: RegExpExecArray | null;
+  while ((invoke = invokeRe.exec(content))) {
+    const name = invoke[1] || "";
+    const body = invoke[2] || "";
+    const args: Record<string, unknown> = {};
+    const paramRe = /<[^>]*parameter name="([^"]+)"[^>]*>([\s\S]*?)<\/[^>]*parameter>/g;
+    let param: RegExpExecArray | null;
+    while ((param = paramRe.exec(body))) {
+      const key = param[1] || "";
+      const raw = (param[2] || "").trim();
+      if (key) args[key] = /^-?\d+$/.test(raw) ? Number(raw) : raw;
+    }
+    const normalized = normalizePseudoToolCall({ type: name, ...args }, out.length, allowedTools);
+    if (normalized) out.push(normalized);
+  }
+  return out;
+}
+
+function normalizePseudoToolCall(entry: unknown, index: number, allowedTools: readonly string[]): ToolCall | null {
+  const item =
+    entry && typeof entry === "object" && !Array.isArray(entry)
+      ? (entry as Record<string, unknown>)
+      : {};
+  const fn =
+    item.function && typeof item.function === "object" && !Array.isArray(item.function)
+      ? (item.function as Record<string, unknown>)
+      : null;
+  const name =
+    typeof item.name === "string"
+      ? item.name
+      : typeof item.type === "string"
+        ? item.type
+        : typeof item.tool === "string"
+          ? item.tool
+          : typeof fn?.name === "string"
+            ? fn.name
+            : "";
+  if (!allowedTools.includes(name)) return null;
+
+  const rawArgs = pseudoArgs(item, fn);
+  const args = sanitizePseudoArgs(name, rawArgs);
+  if (!args) return null;
+  return {
+    id: `pseudo-${Date.now()}-${index}`,
+    function: { name, arguments: JSON.stringify(args) },
+  };
+}
+
+function pseudoArgs(
+  item: Record<string, unknown>,
+  fn: Record<string, unknown> | null,
+): Record<string, unknown> {
+  const candidate = item.arguments ?? fn?.arguments ?? item.input ?? item.parameters ?? item.params;
+  if (typeof candidate === "string") {
+    try {
+      const parsed = JSON.parse(candidate);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed))
+        return parsed as Record<string, unknown>;
+    } catch {}
+  }
+  if (candidate && typeof candidate === "object" && !Array.isArray(candidate))
+    return candidate as Record<string, unknown>;
+  return { ...item };
+}
+
+function sanitizePseudoArgs(
+  name: string,
+  rawArgs: Record<string, unknown>,
+): Record<string, unknown> | null {
+  const args: Record<string, unknown> = { ...rawArgs };
+  for (const key of [
+    "name",
+    "type",
+    "tool",
+    "function",
+    "arguments",
+    "tool_calls",
+    "reply",
+    "input",
+    "parameters",
+    "params",
+  ])
+    delete args[key];
+  if (Object.keys(args).some((key) => key.includes("｜") || key.includes("parameter name")))
+    return null;
+  if (name === "run_command") {
+    const command = typeof args.command === "string" ? args.command.trim() : "";
+    if (!command || command === "undefined") return null;
+    return pickArgs(args, ["command", "timeoutMs"]);
+  }
+  if (name === "read_file" || name === "read_file_range") {
+    if (typeof args.path !== "string" || !args.path.trim()) return null;
+    return pickArgs(args, ["path", "offset", "limit", "start", "end"]);
+  }
+  if (name === "write_file") {
+    if (typeof args.path !== "string" || typeof args.content !== "string") return null;
+    return pickArgs(args, ["path", "content"]);
+  }
+  if (name === "replace_in_file") {
+    if (
+      typeof args.path !== "string" ||
+      typeof args.search !== "string" ||
+      typeof args.replacement !== "string"
+    )
+      return null;
+    return pickArgs(args, ["path", "search", "replacement", "replaceAll"]);
+  }
+  if (name === "search_files") {
+    if (typeof args.pattern !== "string" || !args.pattern.trim()) return null;
+    return pickArgs(args, ["pattern", "path", "maxResults"]);
+  }
+  if (name === "apply_patch") {
+    if (typeof args.patch !== "string" || !args.patch.trim()) return null;
+    return pickArgs(args, ["patch"]);
+  }
+  if (name === "git_diff") return {};
+  return args;
+}
+
+function pickArgs(args: Record<string, unknown>, keys: string[]): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const key of keys) if (args[key] !== undefined) out[key] = args[key];
+  return out;
+}
+
+

--- a/src/repair/openai-compatible/textual-tools.ts
+++ b/src/repair/openai-compatible/textual-tools.ts
@@ -36,10 +36,16 @@ function extractJsonObject(value: string): string | null {
 }
 
 export function normalizeToolCalls(calls: ToolCall[], allowedTools: readonly string[]): ToolCall[] {
-  return calls.map((call, index) => normalizeToolCall(call, index, allowedTools)).filter(Boolean) as ToolCall[];
+  return calls
+    .map((call, index) => normalizeToolCall(call, index, allowedTools))
+    .filter(Boolean) as ToolCall[];
 }
 
-function normalizeToolCall(call: ToolCall, index: number, allowedTools: readonly string[]): ToolCall | null {
+function normalizeToolCall(
+  call: ToolCall,
+  index: number,
+  allowedTools: readonly string[],
+): ToolCall | null {
   const name = call.function?.name || "";
   if (!allowedTools.includes(name)) return null;
   let rawArgs: Record<string, unknown> = {};
@@ -59,10 +65,16 @@ function normalizeToolCall(call: ToolCall, index: number, allowedTools: readonly
 
 function parseLooseObject(content: string): any {
   const t = normalizeFinalContent(content).trim();
-  try { return JSON.parse(t); } catch {}
+  try {
+    return JSON.parse(t);
+  } catch {}
   const a = t.indexOf("{");
   const b = t.lastIndexOf("}");
-  if (a >= 0 && b > a) { try { return JSON.parse(t.slice(a, b + 1)); } catch {} }
+  if (a >= 0 && b > a) {
+    try {
+      return JSON.parse(t.slice(a, b + 1));
+    } catch {}
+  }
   return {};
 }
 
@@ -98,7 +110,11 @@ export function dsmlToolCalls(content: string, allowedTools: readonly string[]):
   return out;
 }
 
-function normalizePseudoToolCall(entry: unknown, index: number, allowedTools: readonly string[]): ToolCall | null {
+function normalizePseudoToolCall(
+  entry: unknown,
+  index: number,
+  allowedTools: readonly string[],
+): ToolCall | null {
   const item =
     entry && typeof entry === "object" && !Array.isArray(entry)
       ? (entry as Record<string, unknown>)
@@ -204,5 +220,3 @@ function pickArgs(args: Record<string, unknown>, keys: string[]): Record<string,
   for (const key of keys) if (args[key] !== undefined) out[key] = args[key];
   return out;
 }
-
-

--- a/src/repair/run-worker.ts
+++ b/src/repair/run-worker.ts
@@ -471,10 +471,13 @@ function prepareSourcePrRefs(job: LooseRecord, targetDir: string): string {
   ]) {
     const parsed = parsePullRequestUrl(value);
     if (parsed) {
-      if (!repo || parsed.repo.toLowerCase() === repo.toLowerCase()) refs.set(parsed.number, parsed.url);
+      if (!repo || parsed.repo.toLowerCase() === repo.toLowerCase())
+        refs.set(parsed.number, parsed.url);
       continue;
     }
-    const shorthand = String(value ?? "").trim().match(/^#?(\d+)$/);
+    const shorthand = String(value ?? "")
+      .trim()
+      .match(/^#?(\d+)$/);
     if (shorthand?.[1] && repo) {
       refs.set(Number(shorthand[1]), `https://github.com/${repo}/pull/${shorthand[1]}`);
     }
@@ -484,7 +487,13 @@ function prepareSourcePrRefs(job: LooseRecord, targetDir: string): string {
   for (const [number, url] of refs) {
     const localRef = sourcePullRequestRemoteRef(number);
     try {
-      runCommand("git", ["-C", targetDir, "fetch", "origin", sourcePullRequestFetchSpec(number, localRef)]);
+      runCommand("git", [
+        "-C",
+        targetDir,
+        "fetch",
+        "origin",
+        sourcePullRequestFetchSpec(number, localRef),
+      ]);
       deepenSourcePrHistory(targetDir, number, localRef, baseRef);
       const diffRef = hasMergeBase(targetDir, baseRef, localRef)
         ? `${baseRef}...${localRef}`
@@ -513,7 +522,14 @@ function deepenSourcePrHistory(
   const baseBranch = baseRef.startsWith("origin/") ? baseRef.slice("origin/".length) : "";
   for (const args of [
     baseBranch ? ["-C", targetDir, "fetch", "--deepen=200", "origin", baseBranch] : null,
-    ["-C", targetDir, "fetch", "--deepen=200", "origin", sourcePullRequestFetchSpec(number, localRef)],
+    [
+      "-C",
+      targetDir,
+      "fetch",
+      "--deepen=200",
+      "origin",
+      sourcePullRequestFetchSpec(number, localRef),
+    ],
   ]) {
     if (!args) continue;
     try {
@@ -535,7 +551,15 @@ function hasMergeBase(targetDir: string, baseRef: string, localRef: string): boo
 
 function targetBaseRef(targetDir: string): string {
   try {
-    return runCommand("git", ["-C", targetDir, "symbolic-ref", "--short", "refs/remotes/origin/HEAD"]).trim() || "origin/HEAD";
+    return (
+      runCommand("git", [
+        "-C",
+        targetDir,
+        "symbolic-ref",
+        "--short",
+        "refs/remotes/origin/HEAD",
+      ]).trim() || "origin/HEAD"
+    );
   } catch {
     return "origin/HEAD";
   }

--- a/src/repair/run-worker.ts
+++ b/src/repair/run-worker.ts
@@ -3,7 +3,7 @@ import type { JsonValue, LooseRecord } from "./json-types.js";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import {
   appendCodexOutputCapture,
   closeCodexOutputCapture,
@@ -30,6 +30,16 @@ import {
   repairCodexServiceTier,
 } from "./process-env.js";
 import { sanitizeResultEvidence } from "./url-safety.js";
+import { parsePullRequestUrl } from "./github-ref.js";
+import { buildRepairEvidencePack, renderRepairEvidencePack } from "./evidence-pack.js";
+import { sourcePullRequestFetchSpec, sourcePullRequestRemoteRef } from "./source-pr-checkout.js";
+import {
+  modelBackend,
+  modelBackendArgs,
+  modelBackendCommand,
+  modelBackendEnv,
+  modelBackendLabel,
+} from "./model-backend.js";
 
 const args = parseArgs(process.argv.slice(2));
 const jobPath = args._[0];
@@ -89,6 +99,13 @@ const targetCheckout = dryRun ? "" : prepareTargetCheckout(job);
 if (targetCheckout) {
   process.env.CLAWSWEEPER_TARGET_CHECKOUT = targetCheckout;
   promptContext.targetCheckout = targetCheckout;
+  const sourcePrRefs = prepareSourcePrRefs(job, targetCheckout);
+  if (sourcePrRefs) promptContext.sourcePrRefs = sourcePrRefs;
+  if (job.frontmatter.source === "pr-repair-intake") {
+    promptContext.repairEvidencePack = renderRepairEvidencePack(
+      buildRepairEvidencePack(job, targetCheckout),
+    );
+  }
 }
 
 if (!dryRun) {
@@ -251,7 +268,11 @@ function spawnCodexWithHeartbeat({
   stderrPath,
   timeoutMs,
 }: LooseRecord): Promise<LooseRecord> {
-  const appServer = codexAppServerProcessOptionsFromEnv("Codex planning worker");
+  const backend = modelBackend();
+  const appServer =
+    backend === "codex-cli"
+      ? codexAppServerProcessOptionsFromEnv("Codex planning worker")
+      : undefined;
   if (appServer) {
     return Promise.resolve(
       runCodexProcess({
@@ -274,16 +295,25 @@ function spawnCodexWithHeartbeat({
     const stderr = openCodexOutputCapture(stderrPath);
 
     const childEnv = codexEnv();
-    const child = spawnCodex(commandArgs, { cwd, env: childEnv });
+    const child =
+      backend === "codex-cli"
+        ? spawnCodex(commandArgs, { cwd, env: childEnv })
+        : spawn(modelBackendCommand(), modelBackendArgs(commandArgs), {
+            cwd,
+            env: modelBackendEnv(childEnv),
+            stdio: ["pipe", "pipe", "pipe"],
+          });
 
     const heartbeat = setInterval(() => {
       const elapsedSeconds = Math.round((Date.now() - startedAt) / 1000);
       console.log(
-        `[clawsweeper repair] ${new Date().toISOString()} Codex worker still running (${elapsedSeconds}s elapsed)`,
+        `[clawsweeper repair] ${new Date().toISOString()} ${modelBackendLabel("Codex worker")} still running (${elapsedSeconds}s elapsed)`,
       );
     }, codexHeartbeatMs);
     const timeout = setTimeout(() => {
-      timeoutError = new Error(`Codex worker timed out after ${timeoutMs}ms`);
+      timeoutError = new Error(
+        `${modelBackendLabel("Codex worker")} timed out after ${timeoutMs}ms`,
+      );
       (timeoutError as LooseRecord).code = "ETIMEDOUT";
       terminateCodexProcessTree(child, "SIGTERM", 5_000);
     }, timeoutMs);
@@ -431,11 +461,91 @@ function prepareTargetCheckout(job: LooseRecord): string {
   return targetDir;
 }
 
+function prepareSourcePrRefs(job: LooseRecord, targetDir: string): string {
+  if (job.frontmatter.source !== "pr-repair-intake") return "";
+  const repo = stringValue(job.frontmatter.repo);
+  const refs = new Map<number, string>();
+  for (const value of [
+    ...(Array.isArray(job.frontmatter.canonical) ? job.frontmatter.canonical : []),
+    ...(Array.isArray(job.frontmatter.candidates) ? job.frontmatter.candidates : []),
+  ]) {
+    const parsed = parsePullRequestUrl(value);
+    if (parsed) {
+      if (!repo || parsed.repo.toLowerCase() === repo.toLowerCase()) refs.set(parsed.number, parsed.url);
+      continue;
+    }
+    const shorthand = String(value ?? "").trim().match(/^#?(\d+)$/);
+    if (shorthand?.[1] && repo) {
+      refs.set(Number(shorthand[1]), `https://github.com/${repo}/pull/${shorthand[1]}`);
+    }
+  }
+  const baseRef = targetBaseRef(targetDir);
+  const lines: string[] = [];
+  for (const [number, url] of refs) {
+    const localRef = sourcePullRequestRemoteRef(number);
+    try {
+      runCommand("git", ["-C", targetDir, "fetch", "origin", sourcePullRequestFetchSpec(number, localRef)]);
+      deepenSourcePrHistory(targetDir, number, localRef, baseRef);
+      const diffRef = hasMergeBase(targetDir, baseRef, localRef)
+        ? `${baseRef}...${localRef}`
+        : `${baseRef}..${localRef}`;
+      const fallbackNote = diffRef.includes("...")
+        ? ""
+        : "; merge-base unavailable after deepen, use two-dot diff fallback";
+      lines.push(
+        `PR #${number}: source ${url}; local ref ${localRef}; inspect with git diff ${diffRef} and git show ${localRef}:path${fallbackNote}`,
+      );
+    } catch (error) {
+      lines.push(
+        `PR #${number}: failed to fetch refs/pull/${number}/head from origin: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+  return lines.join("\n");
+}
+
+function deepenSourcePrHistory(
+  targetDir: string,
+  number: number,
+  localRef: string,
+  baseRef: string,
+): void {
+  const baseBranch = baseRef.startsWith("origin/") ? baseRef.slice("origin/".length) : "";
+  for (const args of [
+    baseBranch ? ["-C", targetDir, "fetch", "--deepen=200", "origin", baseBranch] : null,
+    ["-C", targetDir, "fetch", "--deepen=200", "origin", sourcePullRequestFetchSpec(number, localRef)],
+  ]) {
+    if (!args) continue;
+    try {
+      runCommand("git", args);
+    } catch {
+      // Best-effort only; prepareSourcePrRefs will advertise a two-dot fallback if merge-base is still unavailable.
+    }
+  }
+}
+
+function hasMergeBase(targetDir: string, baseRef: string, localRef: string): boolean {
+  try {
+    runCommand("git", ["-C", targetDir, "merge-base", baseRef, localRef]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function targetBaseRef(targetDir: string): string {
+  try {
+    return runCommand("git", ["-C", targetDir, "symbolic-ref", "--short", "refs/remotes/origin/HEAD"]).trim() || "origin/HEAD";
+  } catch {
+    return "origin/HEAD";
+  }
+}
+
 function stringValue(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
-function runCommand(command: string, commandArgs: string[]) {
+function runCommand(command: string, commandArgs: string[]): string {
   const result = spawnSync(command, commandArgs, {
     cwd: repoRoot(),
     encoding: "utf8",
@@ -446,6 +556,7 @@ function runCommand(command: string, commandArgs: string[]) {
       `${command} ${commandArgs.join(" ")} failed: ${result.stderr || result.stdout}`,
     );
   }
+  return result.stdout ?? "";
 }
 
 function writeBlockedResult(summary: LooseRecord) {

--- a/test/repair/evidence-pack.test.ts
+++ b/test/repair/evidence-pack.test.ts
@@ -8,15 +8,17 @@ import test from "node:test";
 import { buildRepairEvidencePack, extractRepairSignals } from "../../dist/repair/evidence-pack.js";
 
 test("extracts objective repair signals and mentioned files generically", () => {
-  const signals = extractRepairSignals([
-    "Repair signals:",
-    "- review_thread_unresolved: In `src/main.sh`: restore fallback behavior.",
-    "- check_failed: Unit Tests failed around packages/api/index.ts",
-    "- review_actionable: Prompt block @scripts/lib/workflows.sh",
-    "",
-    "## Other section",
-    "- ignored: later content",
-  ].join("\n"));
+  const signals = extractRepairSignals(
+    [
+      "Repair signals:",
+      "- review_thread_unresolved: In `src/main.sh`: restore fallback behavior.",
+      "- check_failed: Unit Tests failed around packages/api/index.ts",
+      "- review_actionable: Prompt block @scripts/lib/workflows.sh",
+      "",
+      "## Other section",
+      "- ignored: later content",
+    ].join("\n"),
+  );
   assert.equal(signals.length, 3);
   assert.equal(signals[0]?.kind, "review_thread_unresolved");
   assert.deepEqual(signals[0]?.mentioned_files, ["src/main.sh"]);
@@ -35,14 +37,21 @@ test("builds a source PR evidence pack from local refs and repair signals", () =
   execFileSync("git", ["commit", "-qm", "base"], { cwd: tmp });
   const baseSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: tmp, encoding: "utf8" }).trim();
   execFileSync("git", ["checkout", "-qb", "source-pr"], { cwd: tmp });
-  fs.writeFileSync(path.join(tmp, "src", "main.sh"), "#!/usr/bin/env bash\necho broken\nreturn 1\n");
+  fs.writeFileSync(
+    path.join(tmp, "src", "main.sh"),
+    "#!/usr/bin/env bash\necho broken\nreturn 1\n",
+  );
   execFileSync("git", ["add", "."], { cwd: tmp });
   execFileSync("git", ["commit", "-qm", "source pr"], { cwd: tmp });
   const prSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: tmp, encoding: "utf8" }).trim();
   execFileSync("git", ["checkout", "-q", "main"], { cwd: tmp });
   execFileSync("git", ["update-ref", "refs/remotes/origin/main", baseSha], { cwd: tmp });
-  execFileSync("git", ["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"], { cwd: tmp });
-  execFileSync("git", ["update-ref", "refs/remotes/clawsweeper/source-pr-123", prSha], { cwd: tmp });
+  execFileSync("git", ["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"], {
+    cwd: tmp,
+  });
+  execFileSync("git", ["update-ref", "refs/remotes/clawsweeper/source-pr-123", prSha], {
+    cwd: tmp,
+  });
 
   const job = {
     frontmatter: {
@@ -67,7 +76,10 @@ test("builds a source PR evidence pack from local refs and repair signals", () =
     relevant_hunk_read: true,
   });
   assert.deepEqual(pack.likely_files, ["src/main.sh"]);
-  assert.equal(pack.source_prs[0]?.diff_ref, "origin/main...refs/remotes/clawsweeper/source-pr-123");
+  assert.equal(
+    pack.source_prs[0]?.diff_ref,
+    "origin/main...refs/remotes/clawsweeper/source-pr-123",
+  );
   assert.match(pack.source_prs[0]?.relevant_hunks[0]?.excerpt ?? "", /return 1/);
   assert.ok(pack.validation_hints.includes("bash -n <changed shell scripts>"));
 });

--- a/test/repair/evidence-pack.test.ts
+++ b/test/repair/evidence-pack.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { buildRepairEvidencePack, extractRepairSignals } from "../../dist/repair/evidence-pack.js";
+
+test("extracts objective repair signals and mentioned files generically", () => {
+  const signals = extractRepairSignals([
+    "Repair signals:",
+    "- review_thread_unresolved: In `src/main.sh`: restore fallback behavior.",
+    "- check_failed: Unit Tests failed around packages/api/index.ts",
+    "- review_actionable: Prompt block @scripts/lib/workflows.sh",
+    "",
+    "## Other section",
+    "- ignored: later content",
+  ].join("\n"));
+  assert.equal(signals.length, 3);
+  assert.equal(signals[0]?.kind, "review_thread_unresolved");
+  assert.deepEqual(signals[0]?.mentioned_files, ["src/main.sh"]);
+  assert.deepEqual(signals[1]?.mentioned_files, ["packages/api/index.ts"]);
+  assert.deepEqual(signals[2]?.mentioned_files, ["scripts/lib/workflows.sh"]);
+});
+
+test("builds a source PR evidence pack from local refs and repair signals", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-evidence-pack-"));
+  execFileSync("git", ["init", "-q", "-b", "main"], { cwd: tmp });
+  execFileSync("git", ["config", "user.email", "smoke@example.invalid"], { cwd: tmp });
+  execFileSync("git", ["config", "user.name", "smoke"], { cwd: tmp });
+  fs.mkdirSync(path.join(tmp, "src"), { recursive: true });
+  fs.writeFileSync(path.join(tmp, "src", "main.sh"), "#!/usr/bin/env bash\necho ok\n");
+  execFileSync("git", ["add", "."], { cwd: tmp });
+  execFileSync("git", ["commit", "-qm", "base"], { cwd: tmp });
+  const baseSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: tmp, encoding: "utf8" }).trim();
+  execFileSync("git", ["checkout", "-qb", "source-pr"], { cwd: tmp });
+  fs.writeFileSync(path.join(tmp, "src", "main.sh"), "#!/usr/bin/env bash\necho broken\nreturn 1\n");
+  execFileSync("git", ["add", "."], { cwd: tmp });
+  execFileSync("git", ["commit", "-qm", "source pr"], { cwd: tmp });
+  const prSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: tmp, encoding: "utf8" }).trim();
+  execFileSync("git", ["checkout", "-q", "main"], { cwd: tmp });
+  execFileSync("git", ["update-ref", "refs/remotes/origin/main", baseSha], { cwd: tmp });
+  execFileSync("git", ["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"], { cwd: tmp });
+  execFileSync("git", ["update-ref", "refs/remotes/clawsweeper/source-pr-123", prSha], { cwd: tmp });
+
+  const job = {
+    frontmatter: {
+      repo: "example/project",
+      cluster_id: "repair-pr-example-project-123",
+      canonical: ["#123"],
+      candidates: ["#123"],
+    },
+    body: [
+      "# Repair-only PR intake",
+      "",
+      "## Repair signals",
+      "- review_thread_unresolved: In `src/main.sh`: restore fallback instead of hard failing.",
+    ].join("\n"),
+  };
+  const pack = buildRepairEvidencePack(job, tmp);
+  assert.equal(pack.repo, "example/project");
+  assert.deepEqual(pack.evidence_gates, {
+    source_pr_ref_fetched: true,
+    source_pr_diff_read: true,
+    actionable_signal_read: true,
+    relevant_hunk_read: true,
+  });
+  assert.deepEqual(pack.likely_files, ["src/main.sh"]);
+  assert.equal(pack.source_prs[0]?.diff_ref, "origin/main...refs/remotes/clawsweeper/source-pr-123");
+  assert.match(pack.source_prs[0]?.relevant_hunks[0]?.excerpt ?? "", /return 1/);
+  assert.ok(pack.validation_hints.includes("bash -n <changed shell scripts>"));
+});

--- a/test/repair/model-backend-config.test.ts
+++ b/test/repair/model-backend-config.test.ts
@@ -79,7 +79,7 @@ test("environment values remain emergency overrides", () => {
 });
 
 
-test("OpenAI-compatible backend restores GitHub token stripped from Codex env", () => {
+test("OpenAI-compatible backend keeps GitHub tokens out of model-controlled env", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-model-backend-"));
   const configPath = path.join(dir, "model-backend.json");
   fs.writeFileSync(
@@ -94,9 +94,9 @@ test("OpenAI-compatible backend restores GitHub token stripped from Codex env", 
   );
 
   const strippedEnv = { CLAWSWEEPER_MODEL_BACKEND_CONFIG: configPath };
-  const out = modelBackendEnv(strippedEnv, { GH_TOKEN: "ghp_test_token" });
-  assert.equal(out.GH_TOKEN, "ghp_test_token");
-  assert.equal(out.GITHUB_TOKEN, "ghp_test_token");
+  const out = modelBackendEnv(strippedEnv);
+  assert.equal(out.GH_TOKEN, undefined);
+  assert.equal(out.GITHUB_TOKEN, undefined);
 });
 
 

--- a/test/repair/model-backend-config.test.ts
+++ b/test/repair/model-backend-config.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  findModelBackendConfigPath,
+  readModelBackendConfig,
+} from "../../dist/repair/model-backend-config.js";
+import {
+  modelBackend,
+  modelBackendArgs,
+  modelBackendCommand,
+  modelBackendEnv,
+} from "../../dist/repair/model-backend.js";
+
+test("loads generic OpenAI-compatible backend config from a ClawSweeper file", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-model-backend-"));
+  const configPath = path.join(dir, "model-backend.json");
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify({
+      schema_version: 1,
+      backend: "openai-compatible-tools",
+      base_url: "https://api.example.com/v1",
+      model: "example/model",
+      api_key_env: "EXAMPLE_API_KEY",
+      max_turns: 10,
+      max_tokens: 0,
+      max_retries: 3,
+    }),
+  );
+
+  const env = { CLAWSWEEPER_MODEL_BACKEND_CONFIG: configPath };
+  assert.equal(findModelBackendConfigPath(env), configPath);
+  assert.equal(readModelBackendConfig(env).backend, "openai-compatible-tools");
+  assert.equal(modelBackend(env), "openai-compatible-tools");
+  assert.equal(modelBackendCommand(env), process.execPath);
+  assert.match(modelBackendArgs(["exec"], env)[0], /openai-compatible-tools-runner\.js$/);
+
+  const out = modelBackendEnv(env);
+  assert.equal(out.CLAWSWEEPER_OPENAI_COMPATIBLE_BASE_URL, "https://api.example.com/v1");
+  assert.equal(out.CLAWSWEEPER_OPENAI_COMPATIBLE_MODEL, "example/model");
+  assert.equal(out.CLAWSWEEPER_OPENAI_COMPATIBLE_API_KEY_ENV, "EXAMPLE_API_KEY");
+  assert.equal(out.CLAWSWEEPER_OPENAI_COMPATIBLE_MAX_TURNS, "10");
+  assert.equal(out.CLAWSWEEPER_OPENAI_COMPATIBLE_MAX_TOKENS, "0");
+  assert.equal(out.CLAWSWEEPER_OPENAI_COMPATIBLE_MAX_RETRIES, "3");
+});
+
+test("environment values remain emergency overrides", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-model-backend-"));
+  const configPath = path.join(dir, "model-backend.json");
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify({
+      schema_version: 1,
+      backend: "openai-compatible-tools",
+      base_url: "https://api.example.com/v1",
+      model: "example/model",
+      api_key_env: "EXAMPLE_API_KEY",
+    }),
+  );
+
+  const env = {
+    CLAWSWEEPER_MODEL_BACKEND_CONFIG: configPath,
+    CLAWSWEEPER_MODEL_BACKEND: "codex-cli",
+  };
+  assert.equal(modelBackend(env), "codex-cli");
+  assert.equal(modelBackendCommand(env), "codex");
+  assert.deepEqual(modelBackendArgs(["exec"], env), ["exec"]);
+  assert.equal(modelBackendEnv(env), env);
+
+  const openAiEnv = {
+    CLAWSWEEPER_MODEL_BACKEND_CONFIG: configPath,
+    CLAWSWEEPER_OPENAI_COMPATIBLE_MODEL: "override/model",
+  };
+  assert.equal(modelBackendEnv(openAiEnv).CLAWSWEEPER_OPENAI_COMPATIBLE_MODEL, "override/model");
+});
+
+
+test("OpenAI-compatible backend restores GitHub token stripped from Codex env", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-model-backend-"));
+  const configPath = path.join(dir, "model-backend.json");
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify({
+      schema_version: 1,
+      backend: "openai-compatible-tools",
+      base_url: "https://api.example.com/v1",
+      model: "example/model",
+      api_key_env: "EXAMPLE_API_KEY",
+    }),
+  );
+
+  const strippedEnv = { CLAWSWEEPER_MODEL_BACKEND_CONFIG: configPath };
+  const out = modelBackendEnv(strippedEnv, { GH_TOKEN: "ghp_test_token" });
+  assert.equal(out.GH_TOKEN, "ghp_test_token");
+  assert.equal(out.GITHUB_TOKEN, "ghp_test_token");
+});
+
+
+test("OpenAI-compatible retry config requires positive integer", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-model-backend-"));
+  const configPath = path.join(dir, "model-backend.json");
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify({
+      schema_version: 1,
+      backend: "openai-compatible-tools",
+      base_url: "https://api.example.com/v1",
+      model: "example/model",
+      api_key_env: "EXAMPLE_API_KEY",
+      max_retries: 0,
+    }),
+  );
+  assert.throws(() => readModelBackendConfig({ CLAWSWEEPER_MODEL_BACKEND_CONFIG: configPath }), /max_retries/);
+});

--- a/test/repair/model-backend-config.test.ts
+++ b/test/repair/model-backend-config.test.ts
@@ -79,7 +79,7 @@ test("environment values remain emergency overrides", () => {
 });
 
 
-test("OpenAI-compatible backend keeps GitHub tokens out of model-controlled env", () => {
+test("OpenAI-compatible backend passes GitHub token only to the deterministic helper channel", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-model-backend-"));
   const configPath = path.join(dir, "model-backend.json");
   fs.writeFileSync(
@@ -94,9 +94,10 @@ test("OpenAI-compatible backend keeps GitHub tokens out of model-controlled env"
   );
 
   const strippedEnv = { CLAWSWEEPER_MODEL_BACKEND_CONFIG: configPath };
-  const out = modelBackendEnv(strippedEnv);
+  const out = modelBackendEnv(strippedEnv, { GH_TOKEN: "ghp_test_token" });
   assert.equal(out.GH_TOKEN, undefined);
   assert.equal(out.GITHUB_TOKEN, undefined);
+  assert.equal(out.CLAWSWEEPER_OPENAI_COMPATIBLE_GITHUB_TOKEN, "ghp_test_token");
 });
 
 

--- a/test/repair/model-backend-config.test.ts
+++ b/test/repair/model-backend-config.test.ts
@@ -78,7 +78,6 @@ test("environment values remain emergency overrides", () => {
   assert.equal(modelBackendEnv(openAiEnv).CLAWSWEEPER_OPENAI_COMPATIBLE_MODEL, "override/model");
 });
 
-
 test("OpenAI-compatible backend passes GitHub token only to the deterministic helper channel", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-model-backend-"));
   const configPath = path.join(dir, "model-backend.json");
@@ -100,7 +99,6 @@ test("OpenAI-compatible backend passes GitHub token only to the deterministic he
   assert.equal(out.CLAWSWEEPER_OPENAI_COMPATIBLE_GITHUB_TOKEN, "ghp_test_token");
 });
 
-
 test("OpenAI-compatible retry config requires positive integer", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-model-backend-"));
   const configPath = path.join(dir, "model-backend.json");
@@ -115,5 +113,8 @@ test("OpenAI-compatible retry config requires positive integer", () => {
       max_retries: 0,
     }),
   );
-  assert.throws(() => readModelBackendConfig({ CLAWSWEEPER_MODEL_BACKEND_CONFIG: configPath }), /max_retries/);
+  assert.throws(
+    () => readModelBackendConfig({ CLAWSWEEPER_MODEL_BACKEND_CONFIG: configPath }),
+    /max_retries/,
+  );
 });

--- a/test/repair/openai-compatible-normalize-result.test.ts
+++ b/test/repair/openai-compatible-normalize-result.test.ts
@@ -16,15 +16,22 @@ const prompt = [
 ].join("\n");
 
 test("normalizes action-scoped fix_artifact", () => {
-  const raw = JSON.stringify({ actions: [{ action: "build_fix_artifact", fix_artifact: {
-    summary: "Repair workflow",
-    likely_files: ["scripts/workflows.sh"],
-    validation_commands: ["bash -n scripts/workflows.sh"],
-    source_prs: ["https://github.com/example/project/pull/123"],
-    repair_strategy: "repair_contributor_branch",
-    pr_title: "Repair workflow",
-    pr_body: "Repair workflow for the contributor branch."
-  }}] });
+  const raw = JSON.stringify({
+    actions: [
+      {
+        action: "build_fix_artifact",
+        fix_artifact: {
+          summary: "Repair workflow",
+          likely_files: ["scripts/workflows.sh"],
+          validation_commands: ["bash -n scripts/workflows.sh"],
+          source_prs: ["https://github.com/example/project/pull/123"],
+          repair_strategy: "repair_contributor_branch",
+          pr_title: "Repair workflow",
+          pr_body: "Repair workflow for the contributor branch.",
+        },
+      },
+    ],
+  });
   const result = JSON.parse(normalizeCodexResult(raw, prompt, false));
   assert.equal(result.status, "planned");
   assert.equal(result.actions[0].action, "build_fix_artifact");
@@ -33,7 +40,13 @@ test("normalizes action-scoped fix_artifact", () => {
 });
 
 test("does not invent repo-specific defaults when fix evidence is missing", () => {
-  const result = JSON.parse(normalizeCodexResult(JSON.stringify({ fix_needed: true, repair_strategy: "repair_contributor_branch" }), prompt, false));
+  const result = JSON.parse(
+    normalizeCodexResult(
+      JSON.stringify({ fix_needed: true, repair_strategy: "repair_contributor_branch" }),
+      prompt,
+      false,
+    ),
+  );
   assert.equal(result.status, "needs_human");
   assert.equal(result.fix_artifact, null);
   assert.match(result.needs_human.join("\n"), /missing_likely_files_evidence/);
@@ -48,7 +61,12 @@ test("detects premature needs_human only before source-ref tool inspection", () 
 });
 
 test("finalization prompt is tool-free and evidence-based", () => {
-  const finalPrompt = buildFinalizationPrompt(prompt, [{ role: "tool", content: "git diff evidence" }], false, "schema/repair/codex-result.schema.json");
+  const finalPrompt = buildFinalizationPrompt(
+    prompt,
+    [{ role: "tool", content: "git diff evidence" }],
+    false,
+    "schema/repair/codex-result.schema.json",
+  );
   assert.match(finalPrompt, /Return final JSON only/);
   assert.match(finalPrompt, /Do not call tools/);
   assert.match(finalPrompt, /git diff evidence/);
@@ -66,9 +84,10 @@ test("needs_human fallback is not empty for non-fix nonconforming output", () =>
   assert.deepEqual(result.actions[0].evidence, result.needs_human);
 });
 
-
 test("normalizes repair artifact enum and PR shorthand when aligned with primary repair signal", () => {
-  const alignedPrompt = prompt + "\n## Repair evidence pack\n```json\n{\"repair_signals\":[{\"kind\":\"review_thread_unresolved\",\"text\":\"Preserve the retry reason when the fallback path handles overlapping worker scopes; do not replace the fallback with a hard failure.\"}]}\n```\n";
+  const alignedPrompt =
+    prompt +
+    '\n## Repair evidence pack\n```json\n{"repair_signals":[{"kind":"review_thread_unresolved","text":"Preserve the retry reason when the fallback path handles overlapping worker scopes; do not replace the fallback with a hard failure."}]}\n```\n';
   const raw = JSON.stringify({
     status: "planned",
     action: "build_fix_artifact",
@@ -80,8 +99,9 @@ test("normalizes repair artifact enum and PR shorthand when aligned with primary
       summary: "Preserve the retry reason in the fallback path for overlapping worker scopes.",
       affected_surfaces: ["retry fallback", "worker scope handling"],
       pr_title: "Preserve fallback retry reason",
-      pr_body: "Keeps the fallback path and passes the overlap/retry reason through instead of turning it into a hard failure."
-    }
+      pr_body:
+        "Keeps the fallback path and passes the overlap/retry reason through instead of turning it into a hard failure.",
+    },
   });
   const result = JSON.parse(normalizeCodexResult(raw, alignedPrompt, false));
   assert.equal(result.status, "planned");
@@ -90,7 +110,9 @@ test("normalizes repair artifact enum and PR shorthand when aligned with primary
 });
 
 test("rejects schema-shaped repair artifacts that miss the primary repair signal", () => {
-  const signalPrompt = prompt + "\n## Repair evidence pack\n```json\n{\"repair_signals\":[{\"kind\":\"review_thread_unresolved\",\"text\":\"Preserve the retry reason when the fallback path handles overlapping worker scopes; do not replace the fallback with a hard failure.\"}]}\n```\n";
+  const signalPrompt =
+    prompt +
+    '\n## Repair evidence pack\n```json\n{"repair_signals":[{"kind":"review_thread_unresolved","text":"Preserve the retry reason when the fallback path handles overlapping worker scopes; do not replace the fallback with a hard failure."}]}\n```\n';
   const raw = JSON.stringify({
     status: "planned",
     action: "build_fix_artifact",
@@ -102,8 +124,8 @@ test("rejects schema-shaped repair artifacts that miss the primary repair signal
       summary: "Correct coding subtask counting and numbered-line parsing.",
       affected_surfaces: ["subtask counting"],
       pr_title: "Fix coding subtask counting",
-      pr_body: "Updates numbered subtask parsing."
-    }
+      pr_body: "Updates numbered subtask parsing.",
+    },
   });
   const result = JSON.parse(normalizeCodexResult(raw, signalPrompt, false));
   assert.equal(result.status, "needs_human");
@@ -111,9 +133,10 @@ test("rejects schema-shaped repair artifacts that miss the primary repair signal
   assert.match(result.needs_human.join("\n"), /fix_artifact_missing_primary_repair_signal/);
 });
 
-
 test("rejects artifacts that treat the source PR as canonical", () => {
-  const signalPrompt = prompt + "\n## Repair evidence pack\n```json\n{\"repair_signals\":[{\"kind\":\"review_changes_requested\",\"text\":\"Replace unsafe feature detection that can mis-detect support under strict shell mode, and cache the support detection result.\"}]}\n```\n";
+  const signalPrompt =
+    prompt +
+    '\n## Repair evidence pack\n```json\n{"repair_signals":[{"kind":"review_changes_requested","text":"Replace unsafe feature detection that can mis-detect support under strict shell mode, and cache the support detection result."}]}\n```\n';
   const raw = JSON.stringify({
     status: "planned",
     action: "build_fix_artifact",
@@ -124,7 +147,7 @@ test("rejects artifacts that treat the source PR as canonical", () => {
     summary: "Apply fix from PR #123.",
     affected_surfaces: ["Gemini CLI compatibility"],
     pr_title: "Apply source PR",
-    pr_body: "Cherry-pick from #123."
+    pr_body: "Cherry-pick from #123.",
   });
   const result = JSON.parse(normalizeCodexResult(raw, signalPrompt, false));
   assert.equal(result.status, "needs_human");
@@ -133,21 +156,23 @@ test("rejects artifacts that treat the source PR as canonical", () => {
   assert.doesNotMatch(result.needs_human.join("\n"), /fix_artifact_missing_primary_repair_signal/);
 });
 
-
-
 test("accepts artifacts that cover primary repair signal terms despite generic preflight gates", () => {
-  const signalPrompt = prompt + "\n## Repair evidence pack\n```json\n{\"evidence_gates\":[{\"kind\":\"merge_preflight\",\"text\":\"mergeStateStatus=BLOCKED\"}],\"repair_signals\":[{\"kind\":\"review_changes_requested\",\"text\":\"Replace unsafe feature detection that can mis-detect support under strict shell mode, and cache the support detection result.\"}]}\n```\n";
+  const signalPrompt =
+    prompt +
+    '\n## Repair evidence pack\n```json\n{"evidence_gates":[{"kind":"merge_preflight","text":"mergeStateStatus=BLOCKED"}],"repair_signals":[{"kind":"review_changes_requested","text":"Replace unsafe feature detection that can mis-detect support under strict shell mode, and cache the support detection result."}]}\n```\n';
   const raw = JSON.stringify({
     status: "planned",
     action: "build_fix_artifact",
-    repair_strategy: "Replace the unsafe feature detection with a robust strict-mode-safe check and cache the support detection result.",
+    repair_strategy:
+      "Replace the unsafe feature detection with a robust strict-mode-safe check and cache the support detection result.",
     source_prs: [123],
     likely_files: ["scripts/lib/runner.sh"],
     validation_commands: ["bash -n scripts/lib/runner.sh"],
     summary: "Fix unsafe feature detection and cache the support result.",
     affected_surfaces: ["feature detection", "strict shell mode"],
     pr_title: "Harden feature detection",
-    pr_body: "Replace unsafe detection with strict-mode-safe logic and cache the support detection result."
+    pr_body:
+      "Replace unsafe detection with strict-mode-safe logic and cache the support detection result.",
   });
   const result = JSON.parse(normalizeCodexResult(raw, signalPrompt, false));
   assert.equal(result.status, "planned");
@@ -157,46 +182,63 @@ test("accepts artifacts that cover primary repair signal terms despite generic p
 });
 
 test("finalization prompt elevates primary signal over secondary cleanup", () => {
-  const signalPrompt = prompt + "\n## Repair evidence pack\n```json\n{\"repair_signals\":[{\"kind\":\"review_thread_unresolved\",\"text\":\"Preserve the retry reason when the fallback path handles overlapping worker scopes; do not replace the fallback with a hard failure.\"}]}\n```\n";
-  const finalPrompt = buildFinalizationPrompt(signalPrompt, [{ role: "tool", content: "remove duplicate conditional check" }], false, "schema/repair/codex-result.schema.json");
+  const signalPrompt =
+    prompt +
+    '\n## Repair evidence pack\n```json\n{"repair_signals":[{"kind":"review_thread_unresolved","text":"Preserve the retry reason when the fallback path handles overlapping worker scopes; do not replace the fallback with a hard failure."}]}\n```\n';
+  const finalPrompt = buildFinalizationPrompt(
+    signalPrompt,
+    [{ role: "tool", content: "remove duplicate conditional check" }],
+    false,
+    "schema/repair/codex-result.schema.json",
+  );
   assert.match(finalPrompt, /Preserve the retry reason/);
   assert.match(finalPrompt, /overlapping worker scopes/);
   assert.match(finalPrompt, /Secondary findings may be mentioned only as supporting context/);
 });
 
-
 test("normalizes build_fix_artifact alias fields", () => {
-  const signalPrompt = prompt + "\n## Repair evidence pack\n```json\n{\"repair_signals\":[{\"kind\":\"review_changes_requested\",\"text\":\"Replace unsafe feature detection that can mis-detect support under strict shell mode, and cache the support detection result.\"}]}\n```\n";
+  const signalPrompt =
+    prompt +
+    '\n## Repair evidence pack\n```json\n{"repair_signals":[{"kind":"review_changes_requested","text":"Replace unsafe feature detection that can mis-detect support under strict shell mode, and cache the support detection result."}]}\n```\n';
   const raw = JSON.stringify({
     outcome: "fix_needed",
     repair_strategy: "repair_contributor_branch",
     source_prs: ["https://github.com/example/project/pull/123"],
     build_fix_artifact: {
-      fix_summary: "Replace unsafe feature detection with strict-mode-safe support detection and cache the support result.",
+      fix_summary:
+        "Replace unsafe feature detection with strict-mode-safe support detection and cache the support result.",
       changed_files: ["scripts/lib/runner.sh"],
       validation: ["bash -n scripts/lib/runner.sh passed", "Changed section matches source branch"],
-      notes: "Repair artifact uses alias fields from a non-schema final answer."
-    }
+      notes: "Repair artifact uses alias fields from a non-schema final answer.",
+    },
   });
   const result = JSON.parse(normalizeCodexResult(raw, signalPrompt, true));
   assert.equal(result.status, "planned");
   assert.deepEqual(result.fix_artifact.likely_files, ["scripts/lib/runner.sh"]);
-  assert.match(result.fix_artifact.validation_commands.join("\n"), /bash -n scripts\/lib\/runner\.sh/);
-  assert.match(result.fix_artifact.validation_commands.join("\n"), /Changed section matches source branch/);
+  assert.match(
+    result.fix_artifact.validation_commands.join("\n"),
+    /bash -n scripts\/lib\/runner\.sh/,
+  );
+  assert.match(
+    result.fix_artifact.validation_commands.join("\n"),
+    /Changed section matches source branch/,
+  );
 });
 
-
 test("normalizes alias artifact when review signal contains boilerplate before code terms", () => {
-  const signalPrompt = prompt + "\n## Repair evidence pack\n```json\n{\"repair_signals\":[{\"kind\":\"review_changes_requested\",\"text\":\"review by bot requested changes: Actionable comments posted. Verify each finding against current code. Inline comments: In `scripts/lib/runner.sh`: Replace `feature --help | grep -q -- --flag` because it is unsafe under strict_mode and can mis-detect support; cache support detection.\"}]}\n```\n";
+  const signalPrompt =
+    prompt +
+    '\n## Repair evidence pack\n```json\n{"repair_signals":[{"kind":"review_changes_requested","text":"review by bot requested changes: Actionable comments posted. Verify each finding against current code. Inline comments: In `scripts/lib/runner.sh`: Replace `feature --help | grep -q -- --flag` because it is unsafe under strict_mode and can mis-detect support; cache support detection."}]}\n```\n';
   const raw = JSON.stringify({
     outcome: "fix_needed",
     repair_strategy: "repair_contributor_branch",
     source_prs: ["https://github.com/example/project/pull/123"],
     build_fix_artifact: {
-      fix_summary: "Replace feature --help grep -q flag support detection with strict_mode-safe logic and cache support detection.",
+      fix_summary:
+        "Replace feature --help grep -q flag support detection with strict_mode-safe logic and cache support detection.",
       changed_files: ["scripts/lib/runner.sh"],
-      validation: ["bash -n scripts/lib/runner.sh passed"]
-    }
+      validation: ["bash -n scripts/lib/runner.sh passed"],
+    },
   });
   const result = JSON.parse(normalizeCodexResult(raw, signalPrompt, true));
   assert.equal(result.status, "planned");

--- a/test/repair/openai-compatible-normalize-result.test.ts
+++ b/test/repair/openai-compatible-normalize-result.test.ts
@@ -1,0 +1,204 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildFinalizationPrompt,
+  isPrematureNeedsHuman,
+  normalizeCodexResult,
+} from "../../dist/repair/openai-compatible/normalize-result.js";
+
+const prompt = [
+  "repo: example/project",
+  "cluster_id: repair-example-project-123",
+  "mode: plan",
+  "## Source PR refs",
+  "PR #123: source https://github.com/example/project/pull/123; local ref refs/remotes/clawsweeper/source-pr-123",
+].join("\n");
+
+test("normalizes action-scoped fix_artifact", () => {
+  const raw = JSON.stringify({ actions: [{ action: "build_fix_artifact", fix_artifact: {
+    summary: "Repair workflow",
+    likely_files: ["scripts/workflows.sh"],
+    validation_commands: ["bash -n scripts/workflows.sh"],
+    source_prs: ["https://github.com/example/project/pull/123"],
+    repair_strategy: "repair_contributor_branch",
+    pr_title: "Repair workflow",
+    pr_body: "Repair workflow for the contributor branch."
+  }}] });
+  const result = JSON.parse(normalizeCodexResult(raw, prompt, false));
+  assert.equal(result.status, "planned");
+  assert.equal(result.actions[0].action, "build_fix_artifact");
+  assert.deepEqual(result.needs_human, []);
+  assert.deepEqual(result.fix_artifact.likely_files, ["scripts/workflows.sh"]);
+});
+
+test("does not invent repo-specific defaults when fix evidence is missing", () => {
+  const result = JSON.parse(normalizeCodexResult(JSON.stringify({ fix_needed: true, repair_strategy: "repair_contributor_branch" }), prompt, false));
+  assert.equal(result.status, "needs_human");
+  assert.equal(result.fix_artifact, null);
+  assert.match(result.needs_human.join("\n"), /missing_likely_files_evidence/);
+  assert.match(result.needs_human.join("\n"), /missing_validation_commands_evidence/);
+  assert.doesNotMatch(JSON.stringify(result), /scripts\/lib\/workflows\.sh/);
+});
+
+test("detects premature needs_human only before source-ref tool inspection", () => {
+  const candidate = JSON.stringify({ status: "needs_human", fix_artifact: null });
+  assert.equal(isPrematureNeedsHuman(candidate, prompt, 0), true);
+  assert.equal(isPrematureNeedsHuman(candidate, prompt, 1), false);
+});
+
+test("finalization prompt is tool-free and evidence-based", () => {
+  const finalPrompt = buildFinalizationPrompt(prompt, [{ role: "tool", content: "git diff evidence" }], false, "schema/repair/codex-result.schema.json");
+  assert.match(finalPrompt, /Return final JSON only/);
+  assert.match(finalPrompt, /Do not call tools/);
+  assert.match(finalPrompt, /git diff evidence/);
+  assert.match(finalPrompt, /source PR is the suspect artifact/);
+  assert.match(finalPrompt, /Never say to cherry-pick/);
+  assert.match(finalPrompt, /Primary repair signal/);
+  assert.match(finalPrompt, /secondary cleanup/);
+});
+
+test("needs_human fallback is not empty for non-fix nonconforming output", () => {
+  const result = JSON.parse(normalizeCodexResult("not json", prompt, false));
+  assert.equal(result.status, "needs_human");
+  assert.equal(result.fix_artifact, null);
+  assert.ok(result.needs_human.length > 0);
+  assert.deepEqual(result.actions[0].evidence, result.needs_human);
+});
+
+
+test("normalizes repair artifact enum and PR shorthand when aligned with primary repair signal", () => {
+  const alignedPrompt = prompt + "\n## Repair evidence pack\n```json\n{\"repair_signals\":[{\"kind\":\"review_thread_unresolved\",\"text\":\"Preserve the retry reason when the fallback path handles overlapping worker scopes; do not replace the fallback with a hard failure.\"}]}\n```\n";
+  const raw = JSON.stringify({
+    status: "planned",
+    action: "build_fix_artifact",
+    fix_artifact: {
+      repair_strategy: "Preserve retry fallback reason",
+      source_prs: [123],
+      likely_files: ["scripts/workflows.sh"],
+      validation_commands: ["bash -n scripts/workflows.sh"],
+      summary: "Preserve the retry reason in the fallback path for overlapping worker scopes.",
+      affected_surfaces: ["retry fallback", "worker scope handling"],
+      pr_title: "Preserve fallback retry reason",
+      pr_body: "Keeps the fallback path and passes the overlap/retry reason through instead of turning it into a hard failure."
+    }
+  });
+  const result = JSON.parse(normalizeCodexResult(raw, alignedPrompt, false));
+  assert.equal(result.status, "planned");
+  assert.equal(result.fix_artifact.repair_strategy, "repair_contributor_branch");
+  assert.deepEqual(result.fix_artifact.source_prs, ["https://github.com/example/project/pull/123"]);
+});
+
+test("rejects schema-shaped repair artifacts that miss the primary repair signal", () => {
+  const signalPrompt = prompt + "\n## Repair evidence pack\n```json\n{\"repair_signals\":[{\"kind\":\"review_thread_unresolved\",\"text\":\"Preserve the retry reason when the fallback path handles overlapping worker scopes; do not replace the fallback with a hard failure.\"}]}\n```\n";
+  const raw = JSON.stringify({
+    status: "planned",
+    action: "build_fix_artifact",
+    fix_artifact: {
+      repair_strategy: "Fix coding subtask counting",
+      source_prs: [123],
+      likely_files: ["scripts/workflows.sh"],
+      validation_commands: ["bash -n scripts/workflows.sh"],
+      summary: "Correct coding subtask counting and numbered-line parsing.",
+      affected_surfaces: ["subtask counting"],
+      pr_title: "Fix coding subtask counting",
+      pr_body: "Updates numbered subtask parsing."
+    }
+  });
+  const result = JSON.parse(normalizeCodexResult(raw, signalPrompt, false));
+  assert.equal(result.status, "needs_human");
+  assert.equal(result.fix_artifact, null);
+  assert.match(result.needs_human.join("\n"), /fix_artifact_missing_primary_repair_signal/);
+});
+
+
+test("rejects artifacts that treat the source PR as canonical", () => {
+  const signalPrompt = prompt + "\n## Repair evidence pack\n```json\n{\"repair_signals\":[{\"kind\":\"review_changes_requested\",\"text\":\"Replace unsafe feature detection that can mis-detect support under strict shell mode, and cache the support detection result.\"}]}\n```\n";
+  const raw = JSON.stringify({
+    status: "planned",
+    action: "build_fix_artifact",
+    repair_strategy: "Cherry-pick the changes from PR #123 to add the original fix as-is.",
+    source_prs: ["https://github.com/example/project/pull/123"],
+    likely_files: ["scripts/lib/spawn.sh"],
+    validation_commands: ["bash -n scripts/lib/spawn.sh"],
+    summary: "Apply fix from PR #123.",
+    affected_surfaces: ["Gemini CLI compatibility"],
+    pr_title: "Apply source PR",
+    pr_body: "Cherry-pick from #123."
+  });
+  const result = JSON.parse(normalizeCodexResult(raw, signalPrompt, false));
+  assert.equal(result.status, "needs_human");
+  assert.equal(result.fix_artifact, null);
+  assert.match(result.needs_human.join("\n"), /source_pr_treated_as_canonical/);
+  assert.doesNotMatch(result.needs_human.join("\n"), /fix_artifact_missing_primary_repair_signal/);
+});
+
+
+
+test("accepts artifacts that cover primary repair signal terms despite generic preflight gates", () => {
+  const signalPrompt = prompt + "\n## Repair evidence pack\n```json\n{\"evidence_gates\":[{\"kind\":\"merge_preflight\",\"text\":\"mergeStateStatus=BLOCKED\"}],\"repair_signals\":[{\"kind\":\"review_changes_requested\",\"text\":\"Replace unsafe feature detection that can mis-detect support under strict shell mode, and cache the support detection result.\"}]}\n```\n";
+  const raw = JSON.stringify({
+    status: "planned",
+    action: "build_fix_artifact",
+    repair_strategy: "Replace the unsafe feature detection with a robust strict-mode-safe check and cache the support detection result.",
+    source_prs: [123],
+    likely_files: ["scripts/lib/runner.sh"],
+    validation_commands: ["bash -n scripts/lib/runner.sh"],
+    summary: "Fix unsafe feature detection and cache the support result.",
+    affected_surfaces: ["feature detection", "strict shell mode"],
+    pr_title: "Harden feature detection",
+    pr_body: "Replace unsafe detection with strict-mode-safe logic and cache the support detection result."
+  });
+  const result = JSON.parse(normalizeCodexResult(raw, signalPrompt, false));
+  assert.equal(result.status, "planned");
+  assert.equal(result.actions[0].action, "build_fix_artifact");
+  assert.deepEqual(result.needs_human, []);
+  assert.equal(result.fix_artifact.repair_strategy, "repair_contributor_branch");
+});
+
+test("finalization prompt elevates primary signal over secondary cleanup", () => {
+  const signalPrompt = prompt + "\n## Repair evidence pack\n```json\n{\"repair_signals\":[{\"kind\":\"review_thread_unresolved\",\"text\":\"Preserve the retry reason when the fallback path handles overlapping worker scopes; do not replace the fallback with a hard failure.\"}]}\n```\n";
+  const finalPrompt = buildFinalizationPrompt(signalPrompt, [{ role: "tool", content: "remove duplicate conditional check" }], false, "schema/repair/codex-result.schema.json");
+  assert.match(finalPrompt, /Preserve the retry reason/);
+  assert.match(finalPrompt, /overlapping worker scopes/);
+  assert.match(finalPrompt, /Secondary findings may be mentioned only as supporting context/);
+});
+
+
+test("normalizes build_fix_artifact alias fields", () => {
+  const signalPrompt = prompt + "\n## Repair evidence pack\n```json\n{\"repair_signals\":[{\"kind\":\"review_changes_requested\",\"text\":\"Replace unsafe feature detection that can mis-detect support under strict shell mode, and cache the support detection result.\"}]}\n```\n";
+  const raw = JSON.stringify({
+    outcome: "fix_needed",
+    repair_strategy: "repair_contributor_branch",
+    source_prs: ["https://github.com/example/project/pull/123"],
+    build_fix_artifact: {
+      fix_summary: "Replace unsafe feature detection with strict-mode-safe support detection and cache the support result.",
+      changed_files: ["scripts/lib/runner.sh"],
+      validation: ["bash -n scripts/lib/runner.sh passed", "Changed section matches source branch"],
+      notes: "Repair artifact uses alias fields from a non-schema final answer."
+    }
+  });
+  const result = JSON.parse(normalizeCodexResult(raw, signalPrompt, true));
+  assert.equal(result.status, "planned");
+  assert.deepEqual(result.fix_artifact.likely_files, ["scripts/lib/runner.sh"]);
+  assert.match(result.fix_artifact.validation_commands.join("\n"), /bash -n scripts\/lib\/runner\.sh/);
+  assert.match(result.fix_artifact.validation_commands.join("\n"), /Changed section matches source branch/);
+});
+
+
+test("normalizes alias artifact when review signal contains boilerplate before code terms", () => {
+  const signalPrompt = prompt + "\n## Repair evidence pack\n```json\n{\"repair_signals\":[{\"kind\":\"review_changes_requested\",\"text\":\"review by bot requested changes: Actionable comments posted. Verify each finding against current code. Inline comments: In `scripts/lib/runner.sh`: Replace `feature --help | grep -q -- --flag` because it is unsafe under strict_mode and can mis-detect support; cache support detection.\"}]}\n```\n";
+  const raw = JSON.stringify({
+    outcome: "fix_needed",
+    repair_strategy: "repair_contributor_branch",
+    source_prs: ["https://github.com/example/project/pull/123"],
+    build_fix_artifact: {
+      fix_summary: "Replace feature --help grep -q flag support detection with strict_mode-safe logic and cache support detection.",
+      changed_files: ["scripts/lib/runner.sh"],
+      validation: ["bash -n scripts/lib/runner.sh passed"]
+    }
+  });
+  const result = JSON.parse(normalizeCodexResult(raw, signalPrompt, true));
+  assert.equal(result.status, "planned");
+  assert.deepEqual(result.needs_human, []);
+});

--- a/test/repair/openai-compatible-runner-source.test.ts
+++ b/test/repair/openai-compatible-runner-source.test.ts
@@ -20,7 +20,16 @@ test("OpenAI-compatible runner rewrites gh pr view review context to REST endpoi
 
 test("OpenAI-compatible runner enforces read-only sandbox tool boundaries", () => {
   assert.match(source, /const readOnlySandbox = sandbox === "read-only"/);
-  assert.match(source, /const readOnlyToolNames = new Set\(\["read_file", "read_file_range", "search_files", "git_diff"\]\)/);
+  assert.match(source, /github_pr_context/);
+  assert.match(source, /const readOnlyToolNames = new Set/);
   assert.match(source, /allTools\.filter\(\(toolEntry\) => readOnlyToolNames\.has\(toolEntry\.function\.name\)\)/);
   assert.match(source, /tool not allowed by sandbox/);
+});
+
+test("OpenAI-compatible runner keeps GitHub token out of model shell while allowing deterministic GitHub helper", () => {
+  assert.match(source, /const githubToken =/);
+  assert.match(source, /delete process\.env\.GH_TOKEN/);
+  assert.match(source, /function githubPrContext/);
+  assert.match(source, /spawnSync\("gh", \["api", apiPath\]/);
+  assert.match(source, /env: \{ \.\.\.process\.env, GH_TOKEN: githubToken, GITHUB_TOKEN: githubToken \}/);
 });

--- a/test/repair/openai-compatible-runner-source.test.ts
+++ b/test/repair/openai-compatible-runner-source.test.ts
@@ -22,7 +22,10 @@ test("OpenAI-compatible runner enforces read-only sandbox tool boundaries", () =
   assert.match(source, /const readOnlySandbox = sandbox === "read-only"/);
   assert.match(source, /github_pr_context/);
   assert.match(source, /const readOnlyToolNames = new Set/);
-  assert.match(source, /allTools\.filter\(\(toolEntry\) => readOnlyToolNames\.has\(toolEntry\.function\.name\)\)/);
+  assert.match(
+    source,
+    /allTools\.filter\(\(toolEntry\) => readOnlyToolNames\.has\(toolEntry\.function\.name\)\)/,
+  );
   assert.match(source, /tool not allowed by sandbox/);
 });
 
@@ -31,7 +34,10 @@ test("OpenAI-compatible runner keeps GitHub token out of model shell while allow
   assert.match(source, /delete process\.env\.GH_TOKEN/);
   assert.match(source, /function githubPrContext/);
   assert.match(source, /spawnSync\("gh", \["api", apiPath\]/);
-  assert.match(source, /env: \{ \.\.\.process\.env, GH_TOKEN: githubToken, GITHUB_TOKEN: githubToken \}/);
+  assert.match(
+    source,
+    /env: \{ \.\.\.process\.env, GH_TOKEN: githubToken, GITHUB_TOKEN: githubToken \}/,
+  );
 });
 
 test("OpenAI-compatible runner scrubs provider API key from model shell env", () => {

--- a/test/repair/openai-compatible-runner-source.test.ts
+++ b/test/repair/openai-compatible-runner-source.test.ts
@@ -33,3 +33,11 @@ test("OpenAI-compatible runner keeps GitHub token out of model shell while allow
   assert.match(source, /spawnSync\("gh", \["api", apiPath\]/);
   assert.match(source, /env: \{ \.\.\.process\.env, GH_TOKEN: githubToken, GITHUB_TOKEN: githubToken \}/);
 });
+
+test("OpenAI-compatible runner scrubs provider API key from model shell env", () => {
+  assert.match(source, /delete process\.env\[apiKeyEnv\]/);
+  assert.match(source, /function scrubbedToolEnv/);
+  assert.match(source, /env: scrubbedToolEnv\(\)/);
+  assert.match(source, /delete env\[apiKeyEnv\]/);
+  assert.match(source, /delete env\.OPENAI_API_KEY/);
+});

--- a/test/repair/openai-compatible-runner-source.test.ts
+++ b/test/repair/openai-compatible-runner-source.test.ts
@@ -17,3 +17,10 @@ test("OpenAI-compatible runner rewrites gh pr view review context to REST endpoi
   assert.match(source, /git remote get-url origin/);
   assert.match(source, /repo_inference_failed/);
 });
+
+test("OpenAI-compatible runner enforces read-only sandbox tool boundaries", () => {
+  assert.match(source, /const readOnlySandbox = sandbox === "read-only"/);
+  assert.match(source, /const readOnlyToolNames = new Set\(\["read_file", "read_file_range", "search_files", "git_diff"\]\)/);
+  assert.match(source, /allTools\.filter\(\(toolEntry\) => readOnlyToolNames\.has\(toolEntry\.function\.name\)\)/);
+  assert.match(source, /tool not allowed by sandbox/);
+});

--- a/test/repair/openai-compatible-runner-source.test.ts
+++ b/test/repair/openai-compatible-runner-source.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const source = fs.readFileSync(
+  path.join(process.cwd(), "src/repair/openai-compatible-tools-runner.ts"),
+  "utf8",
+);
+
+test("OpenAI-compatible runner rewrites gh pr view review context to REST endpoints", () => {
+  assert.match(source, /function rewriteUnsupportedGhPrView/);
+  assert.match(source, /gh_api_rest_rewrite/);
+  assert.match(source, /pulls\/\$\{pr\}\/comments/);
+  assert.match(source, /pulls\/\$\{pr\}\/reviews/);
+  assert.match(source, /issues\/\$\{pr\}\/comments/);
+  assert.match(source, /git remote get-url origin/);
+  assert.match(source, /repo_inference_failed/);
+});

--- a/test/repair/openai-compatible-textual-tools.test.ts
+++ b/test/repair/openai-compatible-textual-tools.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  dsmlToolCalls,
+  normalizeToolCalls,
+  pseudoToolCalls,
+} from "../../dist/repair/openai-compatible/textual-tools.js";
+
+const allowed = [
+  "read_file",
+  "read_file_range",
+  "write_file",
+  "replace_in_file",
+  "run_command",
+  "search_files",
+  "apply_patch",
+  "git_diff",
+];
+
+function argsOf(call: { function: { arguments?: string } }) {
+  return JSON.parse(call.function.arguments || "{}");
+}
+
+test("normalizes native tool calls and strips unsupported args", () => {
+  const calls = normalizeToolCalls(
+    [
+      {
+        id: "native-1",
+        function: {
+          name: "run_command",
+          arguments: JSON.stringify({ command: "git status", unexpected: true }),
+        },
+      },
+    ],
+    allowed,
+  );
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]?.id, "native-1");
+  assert.deepEqual(argsOf(calls[0]!), { command: "git status" });
+});
+
+test("parses loose JSON pseudo tool calls", () => {
+  const calls = pseudoToolCalls(
+    JSON.stringify({ type: "read_file_range", path: "src/index.ts", start: 1, end: 8 }),
+    allowed,
+  );
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]?.function.name, "read_file_range");
+  assert.deepEqual(argsOf(calls[0]!), { path: "src/index.ts", start: 1, end: 8 });
+});
+
+test("parses OpenAI-like textual tool_calls array", () => {
+  const calls = pseudoToolCalls(
+    JSON.stringify({
+      tool_calls: [
+        { function: { name: "search_files", arguments: JSON.stringify({ pattern: "TODO", path: "src" }) } },
+      ],
+    }),
+    allowed,
+  );
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]?.function.name, "search_files");
+  assert.deepEqual(argsOf(calls[0]!), { pattern: "TODO", path: "src" });
+});
+
+test("parses DSML invoke blocks", () => {
+  const calls = dsmlToolCalls(
+    '<｜DSML｜tool_calls><invoke name="read_file_range"><parameter name="path">src/a.ts</parameter><parameter name="start">2</parameter><parameter name="end">5</parameter></invoke></｜DSML｜tool_calls>',
+    allowed,
+  );
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]?.function.name, "read_file_range");
+  assert.deepEqual(argsOf(calls[0]!), { path: "src/a.ts", start: 2, end: 5 });
+});
+
+test("rejects unknown tools and corrupted parameter keys", () => {
+  assert.deepEqual(pseudoToolCalls(JSON.stringify({ type: "delete_everything", path: "." }), allowed), []);
+  assert.deepEqual(
+    pseudoToolCalls(JSON.stringify({ type: "read_file", "parameter name=path": "src/a.ts" }), allowed),
+    [],
+  );
+});

--- a/test/repair/openai-compatible-textual-tools.test.ts
+++ b/test/repair/openai-compatible-textual-tools.test.ts
@@ -54,7 +54,12 @@ test("parses OpenAI-like textual tool_calls array", () => {
   const calls = pseudoToolCalls(
     JSON.stringify({
       tool_calls: [
-        { function: { name: "search_files", arguments: JSON.stringify({ pattern: "TODO", path: "src" }) } },
+        {
+          function: {
+            name: "search_files",
+            arguments: JSON.stringify({ pattern: "TODO", path: "src" }),
+          },
+        },
       ],
     }),
     allowed,
@@ -75,9 +80,15 @@ test("parses DSML invoke blocks", () => {
 });
 
 test("rejects unknown tools and corrupted parameter keys", () => {
-  assert.deepEqual(pseudoToolCalls(JSON.stringify({ type: "delete_everything", path: "." }), allowed), []);
   assert.deepEqual(
-    pseudoToolCalls(JSON.stringify({ type: "read_file", "parameter name=path": "src/a.ts" }), allowed),
+    pseudoToolCalls(JSON.stringify({ type: "delete_everything", path: "." }), allowed),
+    [],
+  );
+  assert.deepEqual(
+    pseudoToolCalls(
+      JSON.stringify({ type: "read_file", "parameter name=path": "src/a.ts" }),
+      allowed,
+    ),
     [],
   );
 });

--- a/test/repair/run-worker.test.ts
+++ b/test/repair/run-worker.test.ts
@@ -125,3 +125,9 @@ test("run-worker starts Codex in the target checkout when one is available", () 
     fs.rmSync(tmp, { recursive: true, force: true });
   }
 });
+
+test("run-worker routes steerable Codex app-server only for the Codex backend", () => {
+  const source = fs.readFileSync(path.join(repoRoot, "src/repair/run-worker.ts"), "utf8");
+  assert.match(source, /modelBackend\(\) === "codex-cli"[\s\S]*codexAppServerProcessOptionsFromEnv/);
+  assert.match(source, /: undefined/);
+});

--- a/test/repair/run-worker.test.ts
+++ b/test/repair/run-worker.test.ts
@@ -128,6 +128,6 @@ test("run-worker starts Codex in the target checkout when one is available", () 
 
 test("run-worker routes steerable Codex app-server only for the Codex backend", () => {
   const source = fs.readFileSync(path.join(repoRoot, "src/repair/run-worker.ts"), "utf8");
-  assert.match(source, /modelBackend\(\) === "codex-cli"[\s\S]*codexAppServerProcessOptionsFromEnv/);
+  assert.match(source, /backend === "codex-cli"[\s\S]*codexAppServerProcessOptionsFromEnv/);
   assert.match(source, /: undefined/);
 });

--- a/test/repair/run-worker.test.ts
+++ b/test/repair/run-worker.test.ts
@@ -93,6 +93,7 @@ test("run-worker starts Codex in the target checkout when one is available", () 
       cwd: repoRoot,
       env: {
         ...process.env,
+        CLAWSWEEPER_MODEL_BACKEND: "codex-cli",
         CLAWSWEEPER_TARGET_CHECKOUT: targetCheckout,
         FAKE_CODEX_CWD_FILE: cwdFile,
         FAKE_CODEX_ARGS_FILE: argsFile,


### PR DESCRIPTION
## Summary
- add a configurable repair model backend abstraction
- add an OpenAI-compatible repair backend with textual tool-call parsing and local result normalization
- add evidence-pack construction for source PR refs and repair signals
- document safe model backend config and include a gitignored example config path

## Security boundary updates
- read-only sandbox is enforced by the OpenAI-compatible runner: write tools and run_command are unavailable in read-only mode.
- GitHub access remains available to the model through a deterministic github_pr_context helper that returns PR metadata, comments, reviews, review comments, and check runs.
- GH_TOKEN and GITHUB_TOKEN are not exposed to model-controlled shell commands: the runner captures the token, deletes token env vars, and uses the token only inside the deterministic GitHub helper.
- steerable Codex app-server routing is now Codex-backend-only; selected non-Codex backends use the backend command path instead of being silently ignored.

## Replacement for #292
#292 was closed before the latest fix could be re-reviewed and could not be reopened through the API. This PR carries the same backend feature plus the follow-up fixes and proof.

## Verification
- pnpm run build:repair
- node --test test/repair/model-backend-config.test.ts test/repair/openai-compatible-runner-source.test.ts test/repair/openai-compatible-normalize-result.test.ts test/repair/openai-compatible-textual-tools.test.ts test/repair/run-worker.test.ts

Result: 26 tests passed.

## Real OpenAI-compatible backend proof
Provider proof was run against OpenRouter's OpenAI-compatible Chat Completions API with a redacted environment. No API key or GitHub token value was printed.

Read-only GitHub-context proof command shape:

    env CLAWSWEEPER_OPENAI_COMPATIBLE_BASE_URL=https://openrouter.ai/api/v1         CLAWSWEEPER_OPENAI_COMPATIBLE_MODEL=google/gemini-3.1-flash-lite         CLAWSWEEPER_OPENAI_COMPATIBLE_API_KEY_ENV=OPENROUTER_API_KEY         CLAWSWEEPER_OPENAI_COMPATIBLE_GITHUB_TOKEN=<redacted>         CLAWSWEEPER_OPENAI_COMPATIBLE_MAX_TURNS=2         node dist/repair/openai-compatible-tools-runner.js           --cd <tmp-checkout> --sandbox read-only --output-last-message <tmp>/out.txt

Output excerpt:

    [openai-compatible-tools] chat_start turn=1 attempt=1/1 messages=2 bytes=3837 timeout_ms=30000 max_tokens=provider_default
    [openai-compatible-tools] chat_done turn=1 attempt=1/1 status=200 elapsed_ms=1106 response_bytes=1257
    [openai-compatible-tools] turn=1 tool_calls=1
    tool_call: github_pr_context {"repo":"openclaw/clawsweeper","number":292}
    tool_result: {"ok":true,"repo":"openclaw/clawsweeper","number":292,"pull":{"number":292,"title":"Add OpenAI-compatible repair backend","state":"closed", ...}}
    [openai-compatible-tools] chat_start turn=2 attempt=1/1 messages=4 bytes=25203 timeout_ms=30000 max_tokens=provider_default
    [openai-compatible-tools] chat_done turn=2 attempt=1/1 status=200 elapsed_ms=832 response_bytes=1085
    assistant:
    The PR title is "Add OpenAI-compatible repair backend" and the state is "closed".
    [openai-compatible-tools] turn=2 tool_calls=0
    RUNNER_FINAL_DIFF_EXISTS=0
