### PR TITLE
fix(review): bound exact-review concurrency

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -315,33 +315,6 @@ jobs:
 
       - uses: ./.github/actions/setup-media-proof-tools
 
-      - name: Mark re-review command in progress
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
-          TARGET_REPO: ${{ steps.target.outputs.target_repo }}
-          ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
-          COMMAND_STATUS_MARKER: ${{ github.event.client_payload.command_status_marker || '' }}
-          STATUS_COMMENT_ID: ${{ github.event.client_payload.status_comment_id || '' }}
-          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          pnpm run repair:update-command-status -- \
-            --repo "$TARGET_REPO" \
-            --item-number "$ITEM_NUMBER" \
-            --marker "$COMMAND_STATUS_MARKER" \
-            --status-comment-id "$STATUS_COMMENT_ID" \
-            --state "Review in progress" \
-            --detail "Targeted re-review run started; Codex is reviewing the item." \
-            --run-url "$RUN_URL" \
-            --wait-ms 120000
-
-      - uses: ./.github/actions/setup-codex
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          CLAWSWEEPER_INTERNAL_MODEL: ${{ secrets.CLAWSWEEPER_MODEL }}
-        with:
-          login-status: "true"
-
       - uses: actions/cache@v5
         with:
           path: ${{ steps.target.outputs.target_checkout_dir }}-cache.git
@@ -381,6 +354,64 @@ jobs:
             git clone --filter=blob:none --branch "$target_branch" --single-branch "$url" "$checkout_dir"
           fi
           git -C "$checkout_dir" rev-parse --short HEAD
+
+      - name: Mark re-review waiting for capacity
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          TARGET_REPO: ${{ steps.target.outputs.target_repo }}
+          ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
+          COMMAND_STATUS_MARKER: ${{ github.event.client_payload.command_status_marker || '' }}
+          STATUS_COMMENT_ID: ${{ github.event.client_payload.status_comment_id || '' }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          pnpm run repair:update-command-status -- \
+            --repo "$TARGET_REPO" \
+            --item-number "$ITEM_NUMBER" \
+            --marker "$COMMAND_STATUS_MARKER" \
+            --status-comment-id "$STATUS_COMMENT_ID" \
+            --state "Waiting for Codex capacity" \
+            --detail "Targeted re-review checkout is ready and waiting for an exact-review Codex slot." \
+            --run-url "$RUN_URL" \
+            --wait-ms 120000
+
+      - name: Wait for exact-review Codex capacity
+        id: codex-capacity
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          pnpm run repair:codex-capacity -- \
+            --repo "${{ github.repository }}" \
+            --run-id "${{ github.run_id }}" \
+            --poll-ms 30000 \
+            --timeout-ms 1200000
+
+      - name: Mark re-review command in progress
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          TARGET_REPO: ${{ steps.target.outputs.target_repo }}
+          ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
+          COMMAND_STATUS_MARKER: ${{ github.event.client_payload.command_status_marker || '' }}
+          STATUS_COMMENT_ID: ${{ github.event.client_payload.status_comment_id || '' }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          pnpm run repair:update-command-status -- \
+            --repo "$TARGET_REPO" \
+            --item-number "$ITEM_NUMBER" \
+            --marker "$COMMAND_STATUS_MARKER" \
+            --status-comment-id "$STATUS_COMMENT_ID" \
+            --state "Review in progress" \
+            --detail "The exact-review semaphore admitted this run; Codex is reviewing the item." \
+            --run-url "$RUN_URL" \
+            --wait-ms 120000
+
+      - uses: ./.github/actions/setup-codex
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          CLAWSWEEPER_INTERNAL_MODEL: ${{ secrets.CLAWSWEEPER_MODEL }}
+        with:
+          login-status: "true"
 
       - name: Review exact event item
         id: review-exact-event-item
@@ -519,9 +550,13 @@ jobs:
           REVIEW_OUTCOME: ${{ steps.review-exact-event-item.outcome }}
           PUBLISH_OUTCOME: ${{ steps.publish-event-result.outcome }}
           ROUTE_OUTCOME: ${{ steps.route-synced-verdict.outcome }}
+          CAPACITY_OUTCOME: ${{ steps.codex-capacity.outcome }}
         run: |
           state="Failed"
           detail="The targeted re-review did not finish cleanly. Check the workflow run for details."
+          if [ "$CAPACITY_OUTCOME" = "failure" ]; then
+            detail="The targeted re-review timed out or failed while waiting for exact-review Codex capacity. Retry after capacity recovers."
+          fi
           if [ "$REVIEW_OUTCOME" = "cancelled" ]; then
             state="Superseded"
             detail="A newer re-review for this item started before this run finished, so GitHub cancelled this older run. Check the latest ClawSweeper run for the current result."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Added a cancellation-safe four-slot exact-review semaphore, replacing the proposed state-repository lease with deterministic live Actions ranking. Thanks @hxy91819.
 - Made every Codex subprocess honor `CODEX_BIN`, safely launch npm-installed `codex.cmd` wrappers on native Windows, and terminate their process trees on timeout. Thanks @anagnorisis2peripeteia.
 - Reserved the full bounded media preprocessing allowance for exact-event review deadlines and command-dispatch fallbacks, including media discovered only after comment hydration.
 - Keep generated implementation PR bodies and terminal issue comments concise, avoid stale blocked states while PR checks are pending, and stop adding ClawSweeper itself as a commit co-author.

--- a/README.md
+++ b/README.md
@@ -603,7 +603,10 @@ repair/issue implementation lanes use 40% of `workers.max`, currently 51 live
 workers. Imported gitcrawl cluster repair allows 2 live workers by default.
 Exact-item review, repair, and issue implementation are priority work; normal
 review, hot intake, and commit review are background work and automatically
-yield when priority work is active.
+yield when priority work is active. Exact-item runs also wait for deterministic
+live Actions admission before Codex starts, with at most four concurrent exact
+reviews and no state-repository lease. Other lanes retain the existing global
+128-worker scheduling model.
 Use `workers.max` first when turning total Codex usage up or down; use
 `lanes.repair.cluster_max_live_runs` to tune the imported legacy cluster-repair
 lane separately, and individual environment overrides only for temporary

--- a/config/automation-limits.json
+++ b/config/automation-limits.json
@@ -6,6 +6,9 @@
     "minimum_background": 16
   },
   "lanes": {
+    "exact_review": {
+      "max_concurrent": 4
+    },
     "assist": {
       "max": 10
     },

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -37,6 +37,7 @@ The mental model:
 | `workers.reserve_for_interactive` | 32 | Worker slots background lanes leave open for exact/manual/urgent work. |
 | `workers.expansion_reserve` | 32 | Extra slots background lanes leave open for independently planned matrix expansion. |
 | `workers.minimum_background` | 16 | Target floor for background progress when enough global capacity is available. |
+| `lanes.exact_review.max_concurrent` | 4 | Maximum concurrent exact-item review workflow runs admitted to Codex. |
 | `lanes.assist.max` | 10 | Maximum concurrent lightweight assist jobs. |
 | `lanes.repair.cluster_max_live_runs` | 2 | Default live repair workflow cap for imported gitcrawl cluster dispatches. |
 
@@ -51,6 +52,7 @@ by default.
 
 | Name | Current | Meaning |
 | --- | ---: | --- |
+| `exact_review.concurrent_max` | 4 | Exact-item review admission cap, clamped to `workers.max`. |
 | `assist.default` | 10 | Maintainer assist job cap. |
 | `review_shards.normal_default` | 89 | Quiet-system normal review shard ceiling. |
 | `review_shards.normal_active_floor` | 38 | Minimum active normal review shards to keep queued for `openclaw/openclaw`. |
@@ -106,6 +108,13 @@ lane allowance; exact-item runs still use the exact-item lane.
 Priority lanes do not subtract the interactive reserve. They cap themselves at
 their derived lane ceiling and at the remaining global budget after other active
 priority work.
+
+Exact-item review runs use a deterministic live Actions semaphore before Codex
+starts. Active exact runs are ordered by creation time and run ID; only the
+oldest `lanes.exact_review.max_concurrent` runs proceed. Cancelled and completed
+runs disappear from the next poll, so no lease or TTL recovery is required.
+This is an exact-review burst limit, not a hard distributed provider semaphore
+across every Codex workflow.
 
 Examples with the current config:
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "repair:spam-scan": "node dist/repair/spam-scanner.js",
     "repair:publish-event-result": "node dist/repair/publish-event-result.js",
     "repair:update-command-status": "node dist/repair/update-command-status.js",
+    "repair:codex-capacity": "node dist/repair/codex-capacity.js",
     "workflow": "node dist/repair/workflow-utils.js",
     "repair:promote-stuck-jobs": "node dist/repair/promote-stuck-jobs.js",
     "repair:sweep-openclaw-jobs": "node dist/repair/sweep-openclaw-jobs.js",

--- a/scripts/check-limits.ts
+++ b/scripts/check-limits.ts
@@ -10,6 +10,12 @@ type WorkerConfig = {
     minimum_background: number;
   };
   lanes: {
+    exact_review: {
+      max_concurrent: number;
+    };
+    assist: {
+      max: number;
+    };
     repair: {
       cluster_max_live_runs: number;
     };
@@ -17,6 +23,12 @@ type WorkerConfig = {
 };
 
 type AutomationLimits = {
+  exact_review: {
+    concurrent_max: number;
+  };
+  assist: {
+    default: number;
+  };
   review_shards: {
     normal_default: number;
     normal_active_floor: number;
@@ -164,6 +176,12 @@ function deriveAutomationLimits(workerConfig: WorkerConfig): AutomationLimits {
   const max = workerConfig.workers.max;
   const clusterRepairMax = Math.min(workerConfig.lanes.repair.cluster_max_live_runs, max);
   return {
+    exact_review: {
+      concurrent_max: Math.min(workerConfig.lanes.exact_review.max_concurrent, max),
+    },
+    assist: {
+      default: Math.min(workerConfig.lanes.assist.max, max),
+    },
     review_shards: {
       normal_default: percent(max, 70),
       normal_active_floor: percent(max, 30),

--- a/src/limits.ts
+++ b/src/limits.ts
@@ -10,6 +10,9 @@ export type WorkerConfig = {
     minimum_background: number;
   };
   lanes: {
+    exact_review: {
+      max_concurrent: number;
+    };
     repair: {
       cluster_max_live_runs: number;
     };
@@ -17,6 +20,9 @@ export type WorkerConfig = {
 };
 
 export type AutomationLimits = {
+  exact_review: {
+    concurrent_max: number;
+  };
   review_shards: {
     normal_default: number;
     normal_active_floor: number;
@@ -64,6 +70,9 @@ export function deriveAutomationLimits(config: WorkerConfig): AutomationLimits {
   const max = config.workers.max;
   const clusterRepairMax = Math.min(config.lanes.repair.cluster_max_live_runs, max);
   return {
+    exact_review: {
+      concurrent_max: Math.min(config.lanes.exact_review.max_concurrent, max),
+    },
     review_shards: {
       normal_default: percent(max, 70),
       normal_active_floor: percent(max, 30),
@@ -153,6 +162,9 @@ function validateWorkerConfig(value: unknown): WorkerConfig {
       minimum_background: positiveInteger(value, "workers.minimum_background"),
     },
     lanes: {
+      exact_review: {
+        max_concurrent: positiveInteger(value, "lanes.exact_review.max_concurrent"),
+      },
       repair: {
         cluster_max_live_runs: optionalPositiveInteger(
           value,

--- a/src/repair/codex-capacity.ts
+++ b/src/repair/codex-capacity.ts
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+import { pathToFileURL } from "node:url";
+import { ghJsonWithRetry } from "./github-cli.js";
+import type { JsonValue, LooseRecord } from "./json-types.js";
+import { AUTOMATION_LIMITS } from "./limits.js";
+import { parseArgs } from "./lib.js";
+import { sleepMs } from "./timing.js";
+
+const ACTIVE_STATUSES = ["in_progress", "pending", "queued", "waiting", "requested"];
+const EXACT_REVIEW_TITLE_PREFIX = "Review event item ";
+const DEFAULT_POLL_MS = 15_000;
+const DEFAULT_TIMEOUT_MS = 20 * 60 * 1000;
+
+export type CapacityRun = {
+  databaseId: number;
+  workflowName: string;
+  displayTitle: string;
+  status: string;
+  createdAt: string;
+};
+
+export type CodexCapacitySnapshot = {
+  runs: CapacityRun[];
+};
+
+export type ExactReviewAdmission = {
+  proceed: boolean;
+  current_rank: number;
+  exact_waiters: number;
+  exact_limit: number;
+};
+
+export function exactReviewAdmission({
+  currentRunId,
+  snapshot,
+  exactLimit = AUTOMATION_LIMITS.exact_review.concurrent_max,
+}: {
+  currentRunId: number;
+  snapshot: CodexCapacitySnapshot;
+  exactLimit?: number;
+}): ExactReviewAdmission {
+  const exactRuns = snapshot.runs
+    .filter(
+      (run) =>
+        run.workflowName === "ClawSweeper" &&
+        run.displayTitle.startsWith(EXACT_REVIEW_TITLE_PREFIX),
+    )
+    .sort(compareRuns);
+  if (!exactRuns.some((run) => run.databaseId === currentRunId)) {
+    throw new Error(
+      `current exact-review run ${currentRunId} was not found in active Actions runs`,
+    );
+  }
+
+  const currentIndex = exactRuns.findIndex((run) => run.databaseId === currentRunId);
+
+  return {
+    proceed: currentIndex >= 0 && currentIndex < exactLimit,
+    current_rank: currentIndex + 1,
+    exact_waiters: exactRuns.length,
+    exact_limit: exactLimit,
+  };
+}
+
+export function waitForExactReviewAdmission({
+  repo,
+  currentRunId,
+  pollMs = DEFAULT_POLL_MS,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  fetchSnapshot = fetchCodexCapacitySnapshot,
+}: {
+  repo: string;
+  currentRunId: number;
+  pollMs?: number;
+  timeoutMs?: number;
+  fetchSnapshot?: (repo: string) => CodexCapacitySnapshot;
+}): ExactReviewAdmission {
+  const deadline = Date.now() + timeoutMs;
+  let latest: ExactReviewAdmission | undefined;
+  let lastError: Error | undefined;
+
+  while (Date.now() <= deadline) {
+    try {
+      latest = exactReviewAdmission({
+        currentRunId,
+        snapshot: fetchSnapshot(repo),
+      });
+      lastError = undefined;
+      if (latest.proceed) return latest;
+      console.error(
+        `Waiting for Codex capacity: exact rank ${latest.current_rank}/${latest.exact_waiters}, ` +
+          `${latest.exact_limit} exact-review slots configured.`,
+      );
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      console.error(`Could not verify Codex capacity: ${lastError.message}`);
+    }
+    sleepMs(Math.min(pollMs, Math.max(1, deadline - Date.now())));
+  }
+
+  if (lastError) {
+    throw new Error(`timed out verifying Codex capacity: ${lastError.message}`);
+  }
+  throw new Error(
+    `timed out waiting for Codex capacity: exact rank ${latest?.current_rank ?? "unknown"}/` +
+      `${latest?.exact_waiters ?? "unknown"}, ${latest?.exact_limit ?? 0} exact-review slots configured`,
+  );
+}
+
+export function fetchCodexCapacitySnapshot(repo: string): CodexCapacitySnapshot {
+  return { runs: fetchActiveExactReviewRuns(repo) };
+}
+
+export function fetchActiveExactReviewRuns(
+  repo: string,
+  fetchPage: (args: string[]) => JsonValue[] = (args) =>
+    ghJsonWithRetry<JsonValue[]>(args, { attempts: 3 }),
+): CapacityRun[] {
+  const runs = ACTIVE_STATUSES.flatMap((status) => {
+    const statusRuns: JsonValue[] = [];
+    for (let page = 1; ; page += 1) {
+      const pageRuns = fetchPage([
+        "api",
+        "--method",
+        "GET",
+        `repos/${repo}/actions/workflows/sweep.yml/runs?per_page=100&event=repository_dispatch&status=${status}&page=${page}`,
+        "--jq",
+        ".workflow_runs",
+      ]);
+      statusRuns.push(...pageRuns);
+      if (pageRuns.length < 100) break;
+    }
+    return statusRuns;
+  });
+  return [
+    ...new Map(
+      runs.map((run: LooseRecord) => {
+        const normalized = normalizeRun(run);
+        return [normalized.databaseId, normalized] as const;
+      }),
+    ).values(),
+  ].filter(
+    (run) =>
+      run.workflowName === "ClawSweeper" && run.displayTitle.startsWith(EXACT_REVIEW_TITLE_PREFIX),
+  );
+}
+
+function normalizeRun(run: LooseRecord): CapacityRun {
+  return {
+    databaseId: Number(run?.id ?? run?.databaseId ?? run?.database_id),
+    workflowName: String(run?.name ?? run?.workflowName ?? run?.workflow_name ?? ""),
+    displayTitle: String(run?.display_title ?? run?.displayTitle ?? ""),
+    status: String(run?.status ?? ""),
+    createdAt: String(run?.created_at ?? run?.createdAt ?? ""),
+  };
+}
+
+function compareRuns(left: CapacityRun, right: CapacityRun): number {
+  const timeDifference = Date.parse(left.createdAt) - Date.parse(right.createdAt);
+  if (Number.isFinite(timeDifference) && timeDifference !== 0) return timeDifference;
+  return left.databaseId - right.databaseId;
+}
+
+function positiveInteger(value: JsonValue, name: string): number {
+  const number = Number(value);
+  if (!Number.isInteger(number) || number < 1)
+    throw new Error(`${name} must be a positive integer`);
+  return number;
+}
+
+function runCli(): void {
+  const args = parseArgs(process.argv.slice(2));
+  const repo = String(args.repo ?? process.env.GITHUB_REPOSITORY ?? "").trim();
+  if (!repo) throw new Error("--repo or GITHUB_REPOSITORY is required");
+  const currentRunId = positiveInteger(args["run-id"] ?? process.env.GITHUB_RUN_ID, "run id");
+  const admission = waitForExactReviewAdmission({
+    repo,
+    currentRunId,
+    pollMs: positiveInteger(args["poll-ms"] ?? DEFAULT_POLL_MS, "poll ms"),
+    timeoutMs: positiveInteger(args["timeout-ms"] ?? DEFAULT_TIMEOUT_MS, "timeout ms"),
+  });
+  process.stdout.write(`${JSON.stringify(admission)}\n`);
+}
+
+function isCliEntrypoint(): boolean {
+  const entrypoint = process.argv[1];
+  return Boolean(entrypoint && import.meta.url === pathToFileURL(entrypoint).href);
+}
+
+if (isCliEntrypoint()) runCli();

--- a/src/repair/limits.ts
+++ b/src/repair/limits.ts
@@ -10,6 +10,9 @@ export type WorkerConfig = {
     minimum_background: number;
   };
   lanes: {
+    exact_review: {
+      max_concurrent: number;
+    };
     assist: {
       max: number;
     };
@@ -20,6 +23,9 @@ export type WorkerConfig = {
 };
 
 export type AutomationLimits = {
+  exact_review: {
+    concurrent_max: number;
+  };
   assist: {
     default: number;
   };
@@ -71,6 +77,9 @@ export function deriveAutomationLimits(config: WorkerConfig): AutomationLimits {
   const max = config.workers.max;
   const clusterRepairMax = Math.min(config.lanes.repair.cluster_max_live_runs, max);
   return {
+    exact_review: {
+      concurrent_max: Math.min(config.lanes.exact_review.max_concurrent, max),
+    },
     assist: {
       default: Math.min(config.lanes.assist.max, max),
     },
@@ -164,6 +173,9 @@ function validateWorkerConfig(value: unknown): WorkerConfig {
       minimum_background: positiveInteger(value, "workers.minimum_background"),
     },
     lanes: {
+      exact_review: {
+        max_concurrent: positiveInteger(value, "lanes.exact_review.max_concurrent"),
+      },
       assist: {
         max: positiveInteger(value, "lanes.assist.max"),
       },

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -18274,8 +18274,11 @@ test("event re-review status explains superseded cancellations", () => {
   assert.match(block, /\[ "\$REVIEW_OUTCOME" = "cancelled" \]/);
   assert.match(block, /state="Superseded"/);
   assert.match(block, /A newer re-review for this item started before this run finished/);
-  assert.doesNotMatch(block, /CAPACITY_OUTCOME/);
-  assert.doesNotMatch(block, /Capacity wait timed out/);
+  assert.match(block, /CAPACITY_OUTCOME/);
+  assert.ok(
+    block.indexOf('[ "$REVIEW_OUTCOME" = "cancelled" ]') >
+      block.indexOf('[ "$CAPACITY_OUTCOME" = "failure" ]'),
+  );
 });
 
 test("event repair retries wait for active worker capacity", () => {
@@ -18796,7 +18799,7 @@ test("reviewed viable issues dispatch generated PRs and backfill durable open re
   assert.equal(workflow.match(/vars\.CLAWSWEEPER_AUTO_IMPLEMENT_ISSUES == '1'/g)?.length, 4);
 });
 
-test("sweep workflow runs exact event reviews without a global worker gate", () => {
+test("sweep workflow admits exact event reviews through an exact-review semaphore", () => {
   const workflow = readFileSync(".github/workflows/sweep.yml", "utf8").replace(/\r\n/g, "\n");
   const eventReviewBlock = workflow.slice(
     workflow.indexOf("\n  event-review-apply:"),
@@ -18805,10 +18808,15 @@ test("sweep workflow runs exact event reviews without a global worker gate", () 
   const setupPnpmIndex = eventReviewBlock.indexOf("- uses: ./.github/actions/setup-pnpm");
   const readTokenIndex = eventReviewBlock.indexOf("- name: Create target read token");
   const writeTokenIndex = eventReviewBlock.indexOf("- name: Create target write token");
+  const waitingStatusIndex = eventReviewBlock.indexOf(
+    "- name: Mark re-review waiting for capacity",
+  );
   const inProgressStatusIndex = eventReviewBlock.indexOf(
     "- name: Mark re-review command in progress",
   );
   const setupCodexIndex = eventReviewBlock.indexOf("- uses: ./.github/actions/setup-codex");
+  const checkoutIndex = eventReviewBlock.indexOf("- name: Check out target repository");
+  const capacityIndex = eventReviewBlock.indexOf("- name: Wait for exact-review Codex capacity");
   const exactReviewIndex = eventReviewBlock.indexOf("- name: Review exact event item");
   const exactReviewStep = eventReviewBlock.slice(
     exactReviewIndex,
@@ -18823,9 +18831,21 @@ test("sweep workflow runs exact event reviews without a global worker gate", () 
   assert.ok(setupPnpmIndex >= 0);
   assert.ok(readTokenIndex > setupPnpmIndex);
   assert.ok(writeTokenIndex > readTokenIndex);
-  assert.ok(inProgressStatusIndex > writeTokenIndex);
+  assert.ok(checkoutIndex > writeTokenIndex);
+  assert.ok(waitingStatusIndex > checkoutIndex);
+  assert.ok(capacityIndex > waitingStatusIndex);
+  assert.ok(inProgressStatusIndex > capacityIndex);
   assert.ok(setupCodexIndex > inProgressStatusIndex);
   assert.ok(exactReviewIndex > setupCodexIndex);
+  assert.match(eventReviewBlock, /pnpm run repair:codex-capacity/);
+  assert.match(eventReviewBlock, /--run-id "\$\{\{ github\.run_id \}\}"/);
+  assert.match(eventReviewBlock, /--state "Waiting for Codex capacity"/);
+  assert.match(eventReviewBlock, /exact-review semaphore admitted this run/);
+  assert.match(eventReviewBlock, /CAPACITY_OUTCOME: \$\{\{ steps\.codex-capacity\.outcome \}\}/);
+  assert.match(
+    eventReviewBlock,
+    /timed out or failed while waiting for exact-review Codex capacity/,
+  );
   assert.match(exactReviewStep, /--batch-size 1/);
   assert.match(exactReviewStep, /--shard-count 1/);
   assert.match(exactReviewStep, /media_preprocessing_reserve_seconds=480/);

--- a/test/repair/codex-capacity.test.ts
+++ b/test/repair/codex-capacity.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  exactReviewAdmission,
+  fetchActiveExactReviewRuns,
+  type CapacityRun,
+  type CodexCapacitySnapshot,
+} from "../../dist/repair/codex-capacity.js";
+
+test("exact review admission lets the oldest configured waiters proceed", () => {
+  const snapshot = capacitySnapshot([
+    exactRun(102, "2026-06-15T12:00:02Z"),
+    exactRun(100, "2026-06-15T12:00:00Z"),
+    exactRun(101, "2026-06-15T12:00:01Z"),
+  ]);
+
+  assert.equal(
+    exactReviewAdmission({
+      currentRunId: 101,
+      snapshot,
+      exactLimit: 2,
+    }).proceed,
+    true,
+  );
+  const blocked = exactReviewAdmission({
+    currentRunId: 102,
+    snapshot,
+    exactLimit: 2,
+  });
+  assert.equal(blocked.proceed, false);
+  assert.equal(blocked.current_rank, 3);
+});
+
+test("exact review admission fails closed when the current run is absent", () => {
+  assert.throws(
+    () =>
+      exactReviewAdmission({
+        currentRunId: 200,
+        snapshot: capacitySnapshot([exactRun(201, "2026-06-15T12:00:00Z")]),
+        exactLimit: 4,
+      }),
+    /current exact-review run 200 was not found/,
+  );
+});
+
+test("cancelled or completed exact runs disappear without lease recovery", () => {
+  const snapshot = capacitySnapshot([
+    exactRun(401, "2026-06-15T12:00:01Z"),
+    exactRun(402, "2026-06-15T12:00:02Z"),
+  ]);
+  const admission = exactReviewAdmission({
+    currentRunId: 402,
+    snapshot,
+    exactLimit: 1,
+  });
+  assert.equal(admission.current_rank, 2);
+  assert.equal(admission.proceed, false);
+
+  const afterCancellation = capacitySnapshot([exactRun(402, "2026-06-15T12:00:02Z")]);
+  assert.equal(
+    exactReviewAdmission({
+      currentRunId: 402,
+      snapshot: afterCancellation,
+      exactLimit: 1,
+    }).proceed,
+    true,
+  );
+});
+
+test("exact review run fetch paginates until the oldest active page", () => {
+  const calls: { status: string; page: number }[] = [];
+  const runs = fetchActiveExactReviewRuns("openclaw/clawsweeper", (args) => {
+    const query = new URL(`https://github.test/${args[3]}`).searchParams;
+    const status = query.get("status") ?? "";
+    const page = Number(query.get("page"));
+    calls.push({ status, page });
+    if (status !== "in_progress") return [];
+    if (page <= 2) {
+      return Array.from({ length: 100 }, (_, index) =>
+        exactApiRun(page * 100 + index, `2026-06-15T12:00:${page}Z`),
+      );
+    }
+    if (page === 3) return [exactApiRun(1, "2026-06-15T11:00:00Z")];
+    return [];
+  });
+
+  assert.equal(runs.length, 201);
+  assert.deepEqual(
+    calls.filter((call) => call.status === "in_progress"),
+    [
+      { status: "in_progress", page: 1 },
+      { status: "in_progress", page: 2 },
+      { status: "in_progress", page: 3 },
+    ],
+  );
+  assert.equal(
+    runs.some((run) => run.databaseId === 1),
+    true,
+  );
+});
+
+function capacitySnapshot(runs: CapacityRun[]): CodexCapacitySnapshot {
+  return { runs };
+}
+
+function exactApiRun(databaseId: number, createdAt: string) {
+  return {
+    id: databaseId,
+    name: "ClawSweeper",
+    display_title: `Review event item openclaw/openclaw#${databaseId}`,
+    status: "in_progress",
+    created_at: createdAt,
+  };
+}
+
+function exactRun(databaseId: number, createdAt: string): CapacityRun {
+  return {
+    databaseId,
+    workflowName: "ClawSweeper",
+    displayTitle: `Review event item openclaw/openclaw#${databaseId}`,
+    status: "in_progress",
+    createdAt,
+  };
+}

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -28,6 +28,10 @@ import {
 
 test("workflow utilities expose automation limits", () => {
   assert.equal(
+    automationLimit("exact_review.concurrent_max"),
+    AUTOMATION_LIMITS.exact_review.concurrent_max,
+  );
+  assert.equal(
     automationLimit("review_shards.normal_default"),
     AUTOMATION_LIMITS.review_shards.normal_default,
   );
@@ -126,6 +130,9 @@ test("worker config defaults imported cluster repair capacity for older configs"
         minimum_background: 1,
       },
       lanes: {
+        exact_review: {
+          max_concurrent: 16,
+        },
         assist: {
           max: 5,
         },


### PR DESCRIPTION
## Summary

Replaces the state-repository provider lease proposed in https://github.com/openclaw/clawsweeper/pull/281 with a smaller exact-review semaphore on current `main`.

- admits the oldest four active exact-review runs before Codex starts
- derives FIFO order from live GitHub Actions state; cancelled and completed runs release capacity automatically
- fails closed when the current run or Actions state cannot be verified
- reports waiting, admitted, timeout, and failure states through the existing command status comment
- preserves current adaptive review timeouts, issue implementation guards, publication, and routing behavior
- keeps the existing 128-worker model for other Codex lanes; this is intentionally an exact-review burst limit, not a second global control plane

This preserves the useful admission-control direction and contributor credit from @hxy91819 while removing lease renewal, state pushes, TTL recovery, release ordering, and embedded live-proof jobs.

## Safety

- no state-repository lease or cleanup step
- no release failure can suppress a completed review publication
- cancellation recovery is immediate on the next Actions poll
- full pagination preserves oldest-first ordering beyond 100 active runs
- exact capacity is independently tunable through `config/automation-limits.json`

## Validation

- `pnpm run check`
- focused exact-capacity and workflow tests
- Codex autoreview clean after fixing pagination beyond page two

## Decision

The main maintainer choice is the initial exact-review cap (`4`). It is intentionally conservative and can be tuned independently without changing the global 128-worker scheduler.
