### PR TITLE
feat: add typed root-cause cluster assessments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Added
 
+- Added typed, durable, proposal-only root-cause cluster assessments to reviews, with strict same-repository canonical-item validation and no repair dispatch, job suppression, sibling mutation, close, or merge behavior.
 - Added a fail-closed `CLAWSWEEPER_CODEX_LOGIN_METHOD=chatgpt` override for local Codex OAuth runs while retaining API authentication by default. Thanks @anagnorisis2peripeteia.
 - Added repair-only PR intake that scans an author's open pull requests for actionable failures and creates durable PR-repair jobs. Thanks @Jhacarreiro.
 - Added automatic issue-build lifecycle comments and dashboard cards with issue titles, queued/planning/building/completed/blocked history, live worker links, Actions runs, and generated PR drill-down.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ Review prompts include compact related issue and PR context from explicit links,
 linked closing PRs, existing local ClawSweeper reports, optional gitcrawl
 clusters, and opt-in live GitHub issue search for exact event reviews. This is
 advisory context for duplicate/superseded reasoning, not a standalone close
-decision. See
+decision. Reviews also persist a typed, proposal-only root-cause assessment with
+same-repository URLs and at most one evidence-backed canonical item; it does not
+dispatch repair, suppress jobs, mutate siblings, close, or merge. See
 [`docs/related-issue-discovery.md`](docs/related-issue-discovery.md).
 
 For open issues with complete, current kept-open reviews, ClawSweeper also

--- a/docs/related-issue-discovery.md
+++ b/docs/related-issue-discovery.md
@@ -22,6 +22,19 @@ The review prompt still requires a conservative canonical-search pass before
 using `duplicate_or_superseded`. The related context is a starting point, not a
 standalone duplicate verdict.
 
+## Root-Cause Assessment
+
+Each new review records a typed `rootCauseCluster` assessment separately from
+the existing work-lane `workClusterRefs`. It classifies the current item and up
+to 12 evidence-backed same-repository issue or PR URLs, records at most one
+canonical item, and preserves a short reason for every member.
+
+The independent low-confidence assessment is the default when no cluster is
+established. High-confidence assessments with a canonical item may be shown in
+the public review comment to make maintainer decisions easier. The assessment
+is proposal-only: it does not dispatch repair, suppress jobs, mutate sibling
+items, close, or merge anything.
+
 ## Live GitHub Search
 
 Live GitHub Search is intentionally opt-in because the Search API has tighter
@@ -70,6 +83,7 @@ older legacy cluster tables are supported on a best-effort basis.
 - Related discovery does not create new labels.
 - Related discovery does not auto-close an item by itself.
 - Related discovery does not make repair or automerge decisions.
+- Root-cause assessments do not dispatch or deduplicate repair jobs.
 - Duplicate or superseded close proposals still require concrete evidence in
   the review and must pass the existing apply-time live-state checks.
 - GitHub Search is enabled only for exact one-item event reviews by default, not

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -435,6 +435,21 @@ superseded, risky churn, or separately tracked. Do not use stale age to close a
 clearly described remaining feature, config surface, security hardening task, or
 product decision; keep those open or route them to the canonical item.
 
+Always fill `rootCauseCluster` as a conservative, read-only relationship
+assessment. Use only full same-repository GitHub issue or pull request URLs.
+Classify the current item and each evidence-backed related member as
+`canonical`, `duplicate`, `same_root_cause`, `partial_overlap`,
+`adjacent_distinct`, `superseded`, `fixed_by_candidate`, `independent`,
+`security_route`, or `needs_human`. Set one `canonicalRef` only when evidence
+supports exactly one canonical item; otherwise use null. Do not include the
+current item in `members`, do not repeat refs, and do not infer shared root
+cause from title similarity, labels, product area, or gitcrawl membership
+alone. Use the independent default with low confidence and no members when no
+cluster is established. This assessment is proposal-only: it does not dispatch
+repair, suppress issue implementation, mutate siblings, close, or merge
+anything. Keep `workClusterRefs` separate; those remain work-lane context, not a
+typed root-cause contract.
+
 Close as implemented when current `main` solves the observable user problem well enough, even if it did not use the exact workflow, file split, or field names proposed in the item. For broad umbrella requests, weigh the title and central user problem first. If current `main` solves the central problem and any leftovers are already tracked by a narrower related item, close as `duplicate_or_superseded` or `implemented_on_main` as appropriate and link the canonical follow-up. For older PRs where current `main` covers most of the branch but not every line, use `mostly_implemented_on_main` instead of stretching `implemented_on_main`. Keep open when a meaningful requested capability remains missing and no narrower canonical follow-up exists.
 
 Keep open for everything else, including real bugs, unclear-but-salvageable reports, stale PRs that still contain useful unique work, optional features that require a new core/plugin API first, or anything where the evidence is not high-confidence.

--- a/schema/clawsweeper-decision.schema.json
+++ b/schema/clawsweeper-decision.schema.json
@@ -31,6 +31,7 @@
     "visionFitEvidence",
     "implementationComplexity",
     "autoImplementationCandidate",
+    "rootCauseCluster",
     "agentsPolicyStatus",
     "reviewFindings",
     "securityReview",
@@ -371,6 +372,77 @@
       "type": "string",
       "enum": ["none", "strict_bug", "vision_fit"],
       "description": "Whether this issue should be eligible for automatic PR intake after review. Use strict_bug only for the existing reproduced-bug lane. Use vision_fit only for high-confidence, VISION.md-aligned, small, queue_fix_pr issue work with clear validation and no security/product-decision blocker. Otherwise use none."
+    },
+    "rootCauseCluster": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Read-only root-cause relationship assessment. This does not dispatch repair, suppress jobs, mutate sibling items, close, or merge anything.",
+      "required": ["confidence", "canonicalRef", "currentItemRelationship", "summary", "members"],
+      "properties": {
+        "confidence": {
+          "type": "string",
+          "enum": ["high", "medium", "low"]
+        },
+        "canonicalRef": {
+          "type": ["string", "null"],
+          "pattern": "^https://github\\.com/[^/\\s]+/[^/\\s]+/(?:issues|pull)/[1-9][0-9]*$"
+        },
+        "currentItemRelationship": {
+          "type": "string",
+          "enum": [
+            "canonical",
+            "duplicate",
+            "same_root_cause",
+            "partial_overlap",
+            "adjacent_distinct",
+            "superseded",
+            "fixed_by_candidate",
+            "independent",
+            "security_route",
+            "needs_human"
+          ]
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 500
+        },
+        "members": {
+          "type": "array",
+          "maxItems": 12,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["ref", "relationship", "reason"],
+            "properties": {
+              "ref": {
+                "type": "string",
+                "pattern": "^https://github\\.com/[^/\\s]+/[^/\\s]+/(?:issues|pull)/[1-9][0-9]*$"
+              },
+              "relationship": {
+                "type": "string",
+                "enum": [
+                  "canonical",
+                  "duplicate",
+                  "same_root_cause",
+                  "partial_overlap",
+                  "adjacent_distinct",
+                  "superseded",
+                  "fixed_by_candidate",
+                  "independent",
+                  "security_route",
+                  "needs_human"
+                ]
+              },
+              "reason": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 300
+              }
+            }
+          }
+        }
+      }
     },
     "agentsPolicyStatus": {
       "type": "object",

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -202,6 +202,17 @@ type MantisRecommendationScenario =
 type VisionFitStatus = "aligned" | "rejected" | "unclear" | "not_applicable";
 type ImplementationComplexity = "small" | "medium" | "large" | "unclear" | "not_applicable";
 type AutoImplementationCandidate = "none" | "strict_bug" | "vision_fit";
+type RootCauseRelationship =
+  | "canonical"
+  | "duplicate"
+  | "same_root_cause"
+  | "partial_overlap"
+  | "adjacent_distinct"
+  | "superseded"
+  | "fixed_by_candidate"
+  | "independent"
+  | "security_route"
+  | "needs_human";
 type CloseReason =
   | "implemented_on_main"
   | "mostly_implemented_on_main"
@@ -378,6 +389,20 @@ interface FeatureShowcase {
   reason: string;
 }
 
+interface RootCauseClusterMember {
+  ref: string;
+  relationship: RootCauseRelationship;
+  reason: string;
+}
+
+interface RootCauseClusterAssessment {
+  confidence: Confidence;
+  canonicalRef: string | null;
+  currentItemRelationship: RootCauseRelationship;
+  summary: string;
+  members: RootCauseClusterMember[];
+}
+
 interface FixedPullRequest {
   repo: string;
   number: number;
@@ -449,6 +474,7 @@ interface Decision {
   visionFitEvidence: string[];
   implementationComplexity: ImplementationComplexity;
   autoImplementationCandidate: AutoImplementationCandidate;
+  rootCauseCluster: RootCauseClusterAssessment;
   agentsPolicyStatus: AgentsPolicyStatus;
   reviewFindings: ReviewFinding[];
   securityReview: SecurityReview;
@@ -1047,7 +1073,7 @@ const DEFAULT_REASONING_EFFORT = "high";
 const DEFAULT_SERVICE_TIER = "";
 const DEFAULT_REVIEW_CODEX_TIMEOUT_MS = 1_200_000;
 const DEFAULT_CODEX_FALLBACK_MIN_BUDGET_MS = 120_000;
-const REVIEW_POLICY_VERSION = "2026-05-30-policy-v19";
+const REVIEW_POLICY_VERSION = "2026-06-15-policy-v21";
 const REVIEW_ITEM_PROMPT_PATH = join(ROOT, "prompts", "review-item.md");
 const CLAWSWEEPER_DECISION_SCHEMA_PATH = join(ROOT, "schema", "clawsweeper-decision.schema.json");
 const PR_CLOSE_COVERAGE_PROOF_PROMPT_PATH = join(ROOT, "prompts", "pr-close-coverage-proof.md");
@@ -1595,6 +1621,18 @@ const MERGE_RISK_OPTION_CATEGORIES = new Set<MergeRiskOptionCategory>([
   "accept_risk",
   "pause_or_close",
 ]);
+const ROOT_CAUSE_RELATIONSHIPS = new Set<RootCauseRelationship>([
+  "canonical",
+  "duplicate",
+  "same_root_cause",
+  "partial_overlap",
+  "adjacent_distinct",
+  "superseded",
+  "fixed_by_candidate",
+  "independent",
+  "security_route",
+  "needs_human",
+]);
 const DECISION_SCHEMA_KEYS = new Set([
   "decision",
   "closeReason",
@@ -1624,6 +1662,7 @@ const DECISION_SCHEMA_KEYS = new Set([
   "visionFitEvidence",
   "implementationComplexity",
   "autoImplementationCandidate",
+  "rootCauseCluster",
   "agentsPolicyStatus",
   "reviewFindings",
   "securityReview",
@@ -1670,6 +1709,14 @@ const MANTIS_RECOMMENDATION_SCHEMA_KEYS = new Set([
   "maintainerComment",
 ]);
 const FEATURE_SHOWCASE_SCHEMA_KEYS = new Set(["status", "reason"]);
+const ROOT_CAUSE_CLUSTER_SCHEMA_KEYS = new Set([
+  "confidence",
+  "canonicalRef",
+  "currentItemRelationship",
+  "summary",
+  "members",
+]);
+const ROOT_CAUSE_CLUSTER_MEMBER_SCHEMA_KEYS = new Set(["ref", "relationship", "reason"]);
 const AGENTS_POLICY_STATUS_SCHEMA_KEYS = new Set([
   "found",
   "readFully",
@@ -1718,6 +1765,7 @@ const REVIEW_SECTIONS = {
   reproductionAssessment: "Reproduction Assessment",
   solutionAssessment: "Solution Assessment",
   visionFit: "Vision Fit",
+  rootCauseCluster: "Root-Cause Cluster",
   reviewFindings: "Review Findings",
   securityReview: "Security Review",
   realBehaviorProof: "Real Behavior Proof",
@@ -2389,7 +2437,18 @@ function parseReviewFinding(value: unknown, path: string): ReviewFinding {
   };
 }
 
-type DecisionNormalizationItem = Pick<Item, "repo" | "kind" | "authorAssociation">;
+type DecisionNormalizationItem = Pick<Item, "repo" | "number" | "kind" | "authorAssociation">;
+type RootCauseNormalizationItem = Pick<Item, "repo" | "number" | "kind">;
+
+function defaultRootCauseCluster(): RootCauseClusterAssessment {
+  return {
+    confidence: "low",
+    canonicalRef: null,
+    currentItemRelationship: "independent",
+    summary: "No evidence-backed root-cause cluster was established.",
+    members: [],
+  };
+}
 
 const CHANGELOG_ENTRY_REVIEW_PATTERN = /\b(?:changelog\.md|changelog\s+entry|release[- ]?note)\b/i;
 const MISSING_CHANGELOG_ACTION_PATTERN =
@@ -2554,6 +2613,156 @@ function parseFeatureShowcase(value: unknown, path: string): FeatureShowcase {
   };
 }
 
+interface ParsedGitHubItemRef {
+  repo: string;
+  kind: ItemKind;
+  number: number;
+  url: string;
+}
+
+function parseGitHubItemRef(value: string, path: string): ParsedGitHubItemRef {
+  const match = value.match(
+    /^https:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/(issues|pull)\/([1-9][0-9]*)$/,
+  );
+  if (!match) throw new Error(`${path} must be a full GitHub issue or pull request URL`);
+  const repo = normalizeRepo(`${match[1]}/${match[2]}`);
+  const kind = match[3] === "pull" ? "pull_request" : "issue";
+  const number = Number(match[4]);
+  return {
+    repo,
+    kind,
+    number,
+    url: `https://github.com/${repo}/${kind === "pull_request" ? "pull" : "issues"}/${number}`,
+  };
+}
+
+function decisionItemUrl(item: RootCauseNormalizationItem): string {
+  const segment = item.kind === "pull_request" ? "pull" : "issues";
+  return `https://github.com/${normalizeRepo(item.repo)}/${segment}/${item.number}`;
+}
+
+function parseRootCauseClusterMember(value: unknown, path: string): RootCauseClusterMember {
+  const record = requireRecord(value, path);
+  rejectUnexpectedKeys(record, ROOT_CAUSE_CLUSTER_MEMBER_SCHEMA_KEYS, path);
+  const reason = requireString(record.reason, `${path}.reason`).trim();
+  if (!reason) throw new Error(`${path}.reason must not be empty`);
+  if (reason.length > 300) throw new Error(`${path}.reason must be at most 300 characters`);
+  const ref = parseGitHubItemRef(requireString(record.ref, `${path}.ref`), `${path}.ref`).url;
+  return {
+    ref,
+    relationship: requireEnum(
+      record.relationship,
+      ROOT_CAUSE_RELATIONSHIPS,
+      `${path}.relationship`,
+    ),
+    reason,
+  };
+}
+
+function parseRootCauseCluster(
+  value: unknown,
+  path: string,
+  item?: RootCauseNormalizationItem,
+): RootCauseClusterAssessment {
+  const record = requireRecord(value, path);
+  rejectUnexpectedKeys(record, ROOT_CAUSE_CLUSTER_SCHEMA_KEYS, path);
+  const summary = requireString(record.summary, `${path}.summary`).trim();
+  if (!summary) throw new Error(`${path}.summary must not be empty`);
+  if (summary.length > 500) throw new Error(`${path}.summary must be at most 500 characters`);
+  if (!Array.isArray(record.members)) throw new Error(`${path}.members must be an array`);
+  if (record.members.length > 12) throw new Error(`${path}.members must contain at most 12 items`);
+
+  const members = record.members.map((entry, index) =>
+    parseRootCauseClusterMember(entry, `${path}.members[${index}]`),
+  );
+  const parsedMembers = members.map((member, index) => ({
+    member,
+    parsed: parseGitHubItemRef(member.ref, `${path}.members[${index}].ref`),
+  }));
+  const seenRefs = new Set<string>();
+  for (const { member, parsed } of parsedMembers) {
+    if (seenRefs.has(member.ref)) throw new Error(`${path}.members contains duplicate refs`);
+    seenRefs.add(member.ref);
+    if (item && normalizeRepo(parsed.repo) !== normalizeRepo(item.repo)) {
+      throw new Error(`${path}.members must stay within ${item.repo}`);
+    }
+    if (item && member.ref === decisionItemUrl(item)) {
+      throw new Error(`${path}.members must not repeat the current item`);
+    }
+  }
+
+  const rawCanonicalRef = requireNullableString(record.canonicalRef, `${path}.canonicalRef`);
+  const parsedCanonical = rawCanonicalRef
+    ? parseGitHubItemRef(rawCanonicalRef, `${path}.canonicalRef`)
+    : null;
+  const canonicalRef = parsedCanonical?.url ?? null;
+  if (item && parsedCanonical && normalizeRepo(parsedCanonical.repo) !== normalizeRepo(item.repo)) {
+    throw new Error(`${path}.canonicalRef must stay within ${item.repo}`);
+  }
+  const currentItemRelationship = requireEnum(
+    record.currentItemRelationship,
+    ROOT_CAUSE_RELATIONSHIPS,
+    `${path}.currentItemRelationship`,
+  );
+  const canonicalMembers = members.filter((member) => member.relationship === "canonical");
+  if (canonicalMembers.length > 1)
+    throw new Error(`${path} must have at most one canonical member`);
+
+  const currentUrl = item ? decisionItemUrl(item) : null;
+  if (!canonicalRef) {
+    if (currentItemRelationship === "canonical" || canonicalMembers.length > 0) {
+      throw new Error(`${path}.canonicalRef is required for canonical relationships`);
+    }
+  } else if (currentItemRelationship === "canonical") {
+    if (currentUrl && canonicalRef !== currentUrl) {
+      throw new Error(`${path}.canonicalRef must identify the canonical current item`);
+    }
+    if (canonicalMembers.length > 0) {
+      throw new Error(`${path} cannot mark both the current item and a member canonical`);
+    }
+  } else if (canonicalMembers.length !== 1 || canonicalMembers[0]?.ref !== canonicalRef) {
+    throw new Error(`${path}.canonicalRef must identify exactly one canonical member`);
+  }
+
+  const requiresCanonical = new Set<RootCauseRelationship>([
+    "duplicate",
+    "same_root_cause",
+    "superseded",
+    "fixed_by_candidate",
+  ]);
+  if (requiresCanonical.has(currentItemRelationship) && !canonicalRef) {
+    throw new Error(`${path}.currentItemRelationship requires a canonical ref`);
+  }
+  if (
+    ["independent", "security_route", "needs_human"].includes(currentItemRelationship) &&
+    canonicalRef
+  ) {
+    throw new Error(`${path}.currentItemRelationship cannot claim a canonical ref`);
+  }
+  for (const member of members) {
+    if (requiresCanonical.has(member.relationship) && !canonicalRef) {
+      throw new Error(`${path} relationship ${member.relationship} requires a canonical ref`);
+    }
+    if (member.relationship === "fixed_by_candidate" && parsedCanonical?.kind !== "pull_request") {
+      throw new Error(`${path} fixed_by_candidate requires a canonical pull request`);
+    }
+  }
+  if (
+    currentItemRelationship === "fixed_by_candidate" &&
+    parsedCanonical?.kind !== "pull_request"
+  ) {
+    throw new Error(`${path}.currentItemRelationship fixed_by_candidate requires a canonical PR`);
+  }
+
+  return {
+    confidence: requireEnum(record.confidence, CONFIDENCES, `${path}.confidence`),
+    canonicalRef,
+    currentItemRelationship,
+    summary,
+    members,
+  };
+}
+
 function parseAgentsPolicyStatus(value: unknown, path: string): AgentsPolicyStatus {
   const record = requireRecord(value, path);
   rejectUnexpectedKeys(record, AGENTS_POLICY_STATUS_SCHEMA_KEYS, path);
@@ -2653,6 +2862,11 @@ export function parseDecision(value: unknown, item?: DecisionNormalizationItem):
       record.autoImplementationCandidate,
       AUTO_IMPLEMENTATION_CANDIDATES,
       "decision.autoImplementationCandidate",
+    ),
+    rootCauseCluster: parseRootCauseCluster(
+      record.rootCauseCluster,
+      "decision.rootCauseCluster",
+      item,
     ),
     agentsPolicyStatus: parseAgentsPolicyStatus(
       record.agentsPolicyStatus,
@@ -6563,6 +6777,7 @@ function codexFailureDecision(
     visionFitEvidence: [],
     implementationComplexity: "not_applicable",
     autoImplementationCandidate: "none",
+    rootCauseCluster: defaultRootCauseCluster(),
     agentsPolicyStatus: {
       found: false,
       readFully: false,
@@ -8831,6 +9046,24 @@ function reportFeatureShowcase(markdown: string): FeatureShowcase {
         ? "This report predates the structured feature showcase reason."
         : "No feature showcase assessment was recorded in this report."),
   };
+}
+
+function reportRootCauseCluster(markdown: string): RootCauseClusterAssessment {
+  const raw = frontMatterValue(markdown, "root_cause_cluster");
+  if (!raw) return defaultRootCauseCluster();
+  try {
+    return parseRootCauseCluster(JSON.parse(raw), "root_cause_cluster", {
+      repo: markdownRepository(markdown),
+      number: Number(frontMatterValue(markdown, "number")),
+      kind: (frontMatterValue(markdown, "type") as ItemKind | undefined) ?? "issue",
+    });
+  } catch {
+    return defaultRootCauseCluster();
+  }
+}
+
+export function rootCauseClusterFromReportForTest(markdown: string): RootCauseClusterAssessment {
+  return reportRootCauseCluster(markdown);
 }
 
 function reportAgentsPolicyStatus(markdown: string): AgentsPolicyStatus | undefined {
@@ -11793,6 +12026,7 @@ function reportDecision(markdown: string, closeReason: CloseReason): Decision {
     reproductionAssessment: reviewSectionValue(markdown, "reproductionAssessment"),
     solutionAssessment: reviewSectionValue(markdown, "solutionAssessment"),
     ...visionFit,
+    rootCauseCluster: reportRootCauseCluster(markdown),
     agentsPolicyStatus: reportAgentsPolicyStatus(markdown) ?? defaultAgentsPolicyStatus(),
     reviewFindings: reportReviewFindings(markdown),
     securityReview: reportSecurityReview(markdown),
@@ -13394,6 +13628,7 @@ function renderCloseComment(options: {
   likelyOwners?: LikelyOwner[];
   fixedPullRequest?: FixedPullRequest | null;
   securityReview?: SecurityReview;
+  rootCauseCluster?: RootCauseClusterAssessment;
   reviewLine: string;
   currentItem?: { repo?: string; kind?: ItemKind; number?: number } | undefined;
 }): string {
@@ -13410,6 +13645,8 @@ function renderCloseComment(options: {
       )}.`,
     );
   }
+  const rootCauseCluster = publicRootCauseClusterBlock(options.rootCauseCluster);
+  if (rootCauseCluster) lines.push("", "**Root-cause cluster**", rootCauseCluster);
   const bestSolutionLine = sentence(options.bestSolution ?? "");
   const canonicalLinks = duplicateCanonicalLinks({
     reason: options.reason,
@@ -13462,6 +13699,7 @@ function renderCloseCommentFromReport(markdown: string, reason: CloseReason): st
       likelyOwners: reportLikelyOwners(markdown),
       fixedPullRequest: fixedPullRequestFromReport(markdown),
       securityReview: reportSecurityReview(markdown),
+      rootCauseCluster: reportRootCauseCluster(markdown),
       reviewLine: closeReviewLineFromReport(markdown),
       currentItem: {
         repo: markdownRepository(markdown),
@@ -13516,6 +13754,7 @@ function normalizeComment(
     likelyOwners: decision.likelyOwners,
     fixedPullRequest: decision.fixedPullRequest ?? null,
     securityReview: decision.securityReview,
+    rootCauseCluster: decision.rootCauseCluster,
     reviewLine: closeReviewLineFromDecision(decision, git, runtime),
     currentItem: item,
   });
@@ -13553,6 +13792,35 @@ function agentsPolicyStatusLine(status: AgentsPolicyStatus | undefined): string 
 
 function appendPublicSection(lines: string[], heading: string, body: string): void {
   lines.push(`**${heading}**`, body, "");
+}
+
+function publicRootCauseClusterBlock(cluster: RootCauseClusterAssessment | undefined): string {
+  if (
+    !cluster ||
+    cluster.confidence !== "high" ||
+    !cluster.canonicalRef ||
+    cluster.members.length === 0 ||
+    ["independent", "security_route", "needs_human"].includes(cluster.currentItemRelationship)
+  ) {
+    return "";
+  }
+  const visibleMembers = cluster.members.slice(0, 5);
+  const memberLines = visibleMembers.map(
+    (member) => `- \`${member.relationship}\`: ${member.ref} - ${sentence(member.reason)}`,
+  );
+  if (cluster.members.length > visibleMembers.length) {
+    memberLines.push(`- ${cluster.members.length - visibleMembers.length} more in the report.`);
+  }
+  return [
+    `Relationship: \`${cluster.currentItemRelationship}\``,
+    `Canonical: ${cluster.canonicalRef}`,
+    `Summary: ${sentence(cluster.summary)}`,
+    "",
+    "Members:",
+    ...memberLines,
+    "",
+    "Proposal only: this assessment does not dispatch repair, suppress jobs, mutate sibling items, close, or merge anything.",
+  ].join("\n");
 }
 
 function publicReproducibilityLine(reproductionAssessment: string): string {
@@ -13766,6 +14034,7 @@ function renderKeepOpenCommentFromReport(
   const prRating = reportPrRating(markdown);
   const mantisRecommendation = reportMantisRecommendation(markdown);
   const agentsPolicyStatus = reportAgentsPolicyStatus(markdown);
+  const rootCauseCluster = reportRootCauseCluster(markdown);
   const summary = reviewSectionValue(markdown, "summary");
   const changeSummary = reviewSectionValue(markdown, "changeSummary");
   const bestSolution = reviewSectionValue(markdown, "bestSolution");
@@ -13833,6 +14102,10 @@ function renderKeepOpenCommentFromReport(
     if (dataModelWarning) appendPublicSection(lines, "Stored data model", dataModelWarning);
   } else {
     appendPublicSection(lines, "Summary", publicSummaryBody(summaryLine, reproductionAssessment));
+  }
+  const rootCauseClusterBlock = publicRootCauseClusterBlock(rootCauseCluster);
+  if (rootCauseClusterBlock) {
+    appendPublicSection(lines, "Root-cause cluster", rootCauseClusterBlock);
   }
   if (!isPullRequest) {
     const reproductionHelp = issueReproductionHelpSuggestions(markdown);
@@ -14869,6 +15142,28 @@ function renderFeatureShowcaseReportSection(decision: Decision): string {
   ].join("\n");
 }
 
+function renderRootCauseClusterReportSection(decision: Decision): string {
+  const members = decision.rootCauseCluster.members.length
+    ? decision.rootCauseCluster.members
+        .map(
+          (member) => `- **${member.relationship}:** ${member.ref}\n  - reason: ${member.reason}`,
+        )
+        .join("\n")
+    : "- none";
+  return [
+    `Current item relationship: ${decision.rootCauseCluster.currentItemRelationship}`,
+    "",
+    `Confidence: ${decision.rootCauseCluster.confidence}`,
+    "",
+    `Canonical ref: ${decision.rootCauseCluster.canonicalRef ?? "none"}`,
+    "",
+    `Summary: ${sentence(decision.rootCauseCluster.summary)}`,
+    "",
+    "Members:",
+    members,
+  ].join("\n");
+}
+
 function renderAgentsPolicyStatusReportSection(decision: Decision): string {
   return [
     `Status: ${decision.agentsPolicyStatus.status}`,
@@ -14943,6 +15238,7 @@ function markdownFor(options: {
     options.decision.reproductionAssessment.trim() || "_Not provided._";
   const solutionAssessment = options.decision.solutionAssessment.trim() || "_Not provided._";
   const visionFit = renderVisionFitReportSection(options.decision);
+  const rootCauseCluster = renderRootCauseClusterReportSection(options.decision);
   const reviewFindings = renderReviewFindingsReportSection(options.decision);
   const securityReview = renderSecurityReviewReportSection(options.decision);
   const realBehaviorProof = renderRealBehaviorProofReportSection(options.decision);
@@ -15017,6 +15313,7 @@ work_status: ${workStatusForDecision(options.decision)}
 work_reason_sha256: ${options.decision.workReason ? sha256(options.decision.workReason) : "none"}
 work_prompt_sha256: ${options.decision.workPrompt ? sha256(options.decision.workPrompt) : "none"}
 work_cluster_refs: ${jsonFrontMatterValue(options.decision.workClusterRefs)}
+root_cause_cluster: ${JSON.stringify(options.decision.rootCauseCluster)}
 work_validation: ${jsonFrontMatterValue(options.decision.workValidation)}
 work_likely_files: ${jsonFrontMatterValue(options.decision.workLikelyFiles)}
 triage_priority: ${options.decision.triagePriority}
@@ -15119,6 +15416,10 @@ ${solutionAssessment}
 ## ${REVIEW_SECTIONS.visionFit}
 
 ${visionFit}
+
+## ${REVIEW_SECTIONS.rootCauseCluster}
+
+${rootCauseCluster}
 
 ## ${REVIEW_SECTIONS.reviewFindings}
 

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -97,6 +97,7 @@ import {
   reviewPromptForTest,
   renderReviewCommentFromReport,
   renderReviewContextBudgetForTest,
+  rootCauseClusterFromReportForTest,
   renderWorkPlanFromReport,
   restoreTreeModesForTest,
   reviewContextLedgerForTest,
@@ -232,6 +233,13 @@ function closeDecision(overrides = {}) {
     visionFitEvidence: [],
     implementationComplexity: "not_applicable",
     autoImplementationCandidate: "none",
+    rootCauseCluster: {
+      confidence: "low",
+      canonicalRef: null,
+      currentItemRelationship: "independent",
+      summary: "No evidence-backed root-cause cluster was established.",
+      members: [],
+    },
     agentsPolicyStatus: {
       found: true,
       readFully: true,
@@ -3173,6 +3181,95 @@ Reason: The bug is narrow and source-reproducible.
     comment,
     /Do we have a high-confidence way to reproduce the issue\?\n\nYes\. A source-level reproduction is clear/,
   );
+});
+
+test("high-confidence root-cause clusters appear in keep-open review comments", () => {
+  const rootCauseCluster = {
+    confidence: "high",
+    canonicalRef: "https://github.com/openclaw/openclaw/pull/75880",
+    currentItemRelationship: "same_root_cause",
+    summary: "The issue and candidate PR cover the same reproduced callback failure.",
+    members: [
+      {
+        ref: "https://github.com/openclaw/openclaw/pull/75880",
+        relationship: "canonical",
+        reason: "This PR contains the focused fix and regression coverage.",
+      },
+    ],
+  };
+  const comment = renderReviewCommentFromReport(
+    `${reportFrontMatter({
+      type: "issue",
+      number: "75877",
+      root_cause_cluster: JSON.stringify(rootCauseCluster),
+    })}
+
+## Summary
+
+Keep open while maintainers evaluate the candidate fix.
+
+## Best Possible Solution
+
+Review the linked candidate PR.
+`,
+    "none",
+  );
+
+  assert.match(comment, /\*\*Root-cause cluster\*\*/);
+  assert.match(comment, /Relationship: `same_root_cause`/);
+  assert.match(comment, /Canonical: https:\/\/github\.com\/openclaw\/openclaw\/pull\/75880/);
+  assert.match(comment, /- `canonical`: https:\/\/github\.com\/openclaw\/openclaw\/pull\/75880/);
+  assert.match(comment, /Proposal only: this assessment does not dispatch repair/);
+});
+
+test("low-confidence root-cause clusters stay out of public comments", () => {
+  const comment = renderReviewCommentFromReport(
+    `${reportFrontMatter({
+      type: "issue",
+      number: "75877",
+      root_cause_cluster: JSON.stringify({
+        confidence: "low",
+        canonicalRef: null,
+        currentItemRelationship: "independent",
+        summary: "No evidence-backed root-cause cluster was established.",
+        members: [],
+      }),
+    })}
+
+## Summary
+
+Keep open for more evidence.
+`,
+    "none",
+  );
+
+  assert.doesNotMatch(comment, /\*\*Root-cause cluster\*\*/);
+  assert.doesNotMatch(comment, /Proposal only: this assessment/);
+});
+
+test("high-confidence root-cause clusters appear in close comments", () => {
+  const comment = renderReviewCommentFromReport(
+    implementedCloseReport({
+      root_cause_cluster: JSON.stringify({
+        confidence: "high",
+        canonicalRef: "https://github.com/openclaw/clawsweeper/issues/400",
+        currentItemRelationship: "duplicate",
+        summary: "The canonical issue tracks the remaining work.",
+        members: [
+          {
+            ref: "https://github.com/openclaw/clawsweeper/issues/400",
+            relationship: "canonical",
+            reason: "This issue has the broader accepted scope.",
+          },
+        ],
+      }),
+    }),
+    "implemented_on_main",
+  );
+
+  assert.match(comment, /\*\*Root-cause cluster\*\*/);
+  assert.match(comment, /Relationship: `duplicate`/);
+  assert.match(comment, /Canonical: https:\/\/github\.com\/openclaw\/clawsweeper\/issues\/400/);
 });
 
 test("issue keep-open review comments suggest concrete reproduction help", () => {
@@ -15935,6 +16032,226 @@ test("decision parser enforces required schema-shaped evidence", () => {
   assert.equal(workCandidate.reproductionStatus, "reproduced");
   assert.equal(workCandidate.realBehaviorProof.status, "not_applicable");
   assert.deepEqual(workCandidate.workClusterRefs, ["#123", "#456"]);
+});
+
+test("decision parser validates typed root-cause clusters", () => {
+  const canonicalRef = "https://github.com/openclaw/openclaw/pull/456";
+  const rootCauseCluster = {
+    confidence: "high",
+    canonicalRef,
+    currentItemRelationship: "fixed_by_candidate",
+    summary: "The candidate PR fixes the reproduced issue.",
+    members: [
+      {
+        ref: canonicalRef,
+        relationship: "canonical",
+        reason: "The PR contains the focused fix and regression test.",
+      },
+    ],
+  };
+  const parsed = parseDecision(
+    closeDecision({ rootCauseCluster }),
+    item({ repo: "openclaw/openclaw", number: 123, kind: "issue" }),
+  );
+  assert.deepEqual(parsed.rootCauseCluster, rootCauseCluster);
+
+  assert.throws(
+    () =>
+      parseDecision(
+        closeDecision({
+          rootCauseCluster: {
+            ...rootCauseCluster,
+            members: [...rootCauseCluster.members, ...rootCauseCluster.members],
+          },
+        }),
+        item(),
+      ),
+    /duplicate refs/,
+  );
+  assert.throws(
+    () =>
+      parseDecision(
+        closeDecision({
+          rootCauseCluster: {
+            ...rootCauseCluster,
+            canonicalRef: "https://github.com/other/repo/pull/456",
+            members: [
+              {
+                ...rootCauseCluster.members[0],
+                ref: "https://github.com/other/repo/pull/456",
+              },
+            ],
+          },
+        }),
+        item(),
+      ),
+    /must stay within openclaw\/openclaw/,
+  );
+  assert.throws(
+    () =>
+      parseDecision(
+        closeDecision({
+          rootCauseCluster: {
+            ...rootCauseCluster,
+            members: [
+              ...rootCauseCluster.members,
+              {
+                ref: "https://github.com/openclaw/openclaw/issues/789",
+                relationship: "canonical",
+                reason: "A conflicting second canonical item.",
+              },
+            ],
+          },
+        }),
+        item(),
+      ),
+    /at most one canonical member/,
+  );
+  assert.throws(
+    () =>
+      parseDecision(
+        closeDecision({
+          rootCauseCluster: {
+            ...rootCauseCluster,
+            members: [
+              {
+                ...rootCauseCluster.members[0],
+                ref: "https://github.com/openclaw/openclaw/pull/789",
+              },
+            ],
+          },
+        }),
+        item(),
+      ),
+    /canonicalRef must identify exactly one canonical member/,
+  );
+  assert.throws(
+    () =>
+      parseDecision(
+        closeDecision({
+          rootCauseCluster: {
+            ...rootCauseCluster,
+            canonicalRef: "https://github.com/openclaw/openclaw/issues/456",
+            members: [
+              {
+                ...rootCauseCluster.members[0],
+                ref: "https://github.com/openclaw/openclaw/issues/456",
+              },
+            ],
+          },
+        }),
+        item(),
+      ),
+    /fixed_by_candidate requires a canonical PR/,
+  );
+  assert.throws(
+    () =>
+      parseDecision(
+        closeDecision({
+          rootCauseCluster: {
+            ...rootCauseCluster,
+            members: [
+              {
+                ref: "https://github.com/openclaw/openclaw/issues/123",
+                relationship: "canonical",
+                reason: "Incorrectly repeats the current item.",
+              },
+            ],
+            canonicalRef: "https://github.com/openclaw/openclaw/issues/123",
+            currentItemRelationship: "duplicate",
+          },
+        }),
+        item(),
+      ),
+    /must not repeat the current item/,
+  );
+  assert.throws(
+    () =>
+      parseDecision(
+        closeDecision({
+          rootCauseCluster: {
+            ...rootCauseCluster,
+            members: [
+              {
+                ref: "https://github.com/OpenClaw/OpenClaw/issues/123",
+                relationship: "canonical",
+                reason: "Incorrectly repeats the current item with different casing.",
+              },
+            ],
+            canonicalRef: "https://github.com/OpenClaw/OpenClaw/issues/123",
+            currentItemRelationship: "duplicate",
+          },
+        }),
+        item(),
+      ),
+    /must not repeat the current item/,
+  );
+  assert.throws(
+    () =>
+      parseDecision(
+        closeDecision({
+          rootCauseCluster: {
+            ...rootCauseCluster,
+            members: [
+              rootCauseCluster.members[0],
+              {
+                ...rootCauseCluster.members[0],
+                ref: "https://github.com/OpenClaw/OpenClaw/pull/456",
+              },
+            ],
+          },
+        }),
+        item(),
+      ),
+    /duplicate refs/,
+  );
+});
+
+test("root-cause report parsing defaults legacy and malformed reports safely", () => {
+  assert.deepEqual(rootCauseClusterFromReportForTest(reportFrontMatter({ number: "123" })), {
+    confidence: "low",
+    canonicalRef: null,
+    currentItemRelationship: "independent",
+    summary: "No evidence-backed root-cause cluster was established.",
+    members: [],
+  });
+  assert.deepEqual(
+    rootCauseClusterFromReportForTest(
+      reportFrontMatter({
+        number: "123",
+        root_cause_cluster: "{not-json",
+      }),
+    ),
+    {
+      confidence: "low",
+      canonicalRef: null,
+      currentItemRelationship: "independent",
+      summary: "No evidence-backed root-cause cluster was established.",
+      members: [],
+    },
+  );
+  const valid = {
+    confidence: "high",
+    canonicalRef: "https://github.com/openclaw/openclaw/issues/456",
+    currentItemRelationship: "duplicate",
+    summary: "The other issue is the canonical report.",
+    members: [
+      {
+        ref: "https://github.com/openclaw/openclaw/issues/456",
+        relationship: "canonical",
+        reason: "It has the complete reproduction and accepted scope.",
+      },
+    ],
+  };
+  assert.deepEqual(
+    rootCauseClusterFromReportForTest(
+      reportFrontMatter({
+        number: "123",
+        root_cause_cluster: JSON.stringify(valid),
+      }),
+    ),
+    valid,
+  );
 });
 
 test("review prompt routes PR likely owners through feature history", () => {


### PR DESCRIPTION
## Summary

- add a typed `rootCauseCluster` contract to every new Codex review
- validate full same-repository issue/PR URLs, one canonical item, relationship consistency, current-item exclusion, and case-normalized duplicate identity
- persist the assessment in report frontmatter plus a readable durable report section
- show compact cluster context publicly only for high-confidence assessments with a canonical item
- default legacy or malformed reports to an independent, low-confidence assessment

## Safety boundary

This is deliberately phase one and proposal-only. It does not dispatch repair, suppress jobs, mutate sibling items, create or broaden PRs, close items, or merge anything. Existing apply and repair behavior is unchanged.

Landing this establishes the reviewed-item schema and durable evidence surface needed by a later coordinator. It does not claim the full write-side acceptance criteria from https://github.com/openclaw/clawsweeper/issues/265; race-safe canonical job promotion, one-PR enforcement, sibling refresh, and post-merge coordination remain a separate maintainer decision and implementation.

## Verification

- `pnpm run check`
- Codex autoreview: clean after fixing case-variant GitHub ref identity

Progresses https://github.com/openclaw/clawsweeper/issues/265
