### PR TITLE
fix: include Codex spawn sources in sparse workflows

### DIFF
--- a/.github/workflows/repair-comment-router.yml
+++ b/.github/workflows/repair-comment-router.yml
@@ -96,9 +96,11 @@ jobs:
             scripts/hydrate-state.ts
             src/clawsweeper-text.ts
             src/codex-env.ts
+            src/codex-app-server-worker.ts
             src/codex-output-capture.ts
             src/codex-process-worker.ts
             src/codex-process.ts
+            src/codex-spawn.ts
             src/codex-transient.ts
             src/github-retry.ts
             src/pr-close-coverage-proof.ts

--- a/.github/workflows/spam-comment-intake.yml
+++ b/.github/workflows/spam-comment-intake.yml
@@ -57,9 +57,11 @@ jobs:
             schema/clawsweeper-pr-close-coverage-proof.schema.json
             src/clawsweeper-text.ts
             src/codex-env.ts
+            src/codex-app-server-worker.ts
             src/codex-output-capture.ts
             src/codex-process-worker.ts
             src/codex-process.ts
+            src/codex-spawn.ts
             src/codex-transient.ts
             src/github-retry.ts
             src/pr-close-coverage-proof.ts

--- a/.github/workflows/spam-scanner.yml
+++ b/.github/workflows/spam-scanner.yml
@@ -80,9 +80,11 @@ jobs:
             scripts/hydrate-state.ts
             src/clawsweeper-text.ts
             src/codex-env.ts
+            src/codex-app-server-worker.ts
             src/codex-output-capture.ts
             src/codex-process-worker.ts
             src/codex-process.ts
+            src/codex-spawn.ts
             src/codex-transient.ts
             src/github-retry.ts
             src/pr-close-coverage-proof.ts


### PR DESCRIPTION
## Summary

- add the new Codex spawn/app-server source files to sparse checkout lists used by repair/spam workflows
- fixes `build:repair` failures where sparse checkouts omitted `src/codex-spawn.ts` after the Codex spawn helper split

## Verification

- `pnpm run build:repair`
- sparse checkout simulation matching `repair-comment-router.yml` + `pnpm run build:repair`
- `git diff --check`
- `pnpm run format:check`
- `pnpm run check` started and passed active-surface, limits, build:all, lint, then timed out during long `test:unit` after 180s
