### PR TITLE
fix(router): include codex spawn in sparse checkout

### DIFF
--- a/.github/workflows/repair-comment-router.yml
+++ b/.github/workflows/repair-comment-router.yml
@@ -97,6 +97,7 @@ jobs:
             src/clawsweeper-text.ts
             src/codex-env.ts
             src/codex-output-capture.ts
+            src/codex-spawn.ts
             src/codex-process-worker.ts
             src/codex-process.ts
             src/codex-transient.ts


### PR DESCRIPTION
## Summary

- include `src/codex-spawn.ts` in the repair comment router sparse checkout
- unblock `pnpm run build:repair` for comment-router runs that import `codex-process.ts`, `codex-process-worker.ts`, or `repair/run-worker.ts`

## Verification

- `pnpm run build:repair`
- `git diff --check`

## Context

Recent `repair comment router` runs failed before routing comments because the sparse checkout omitted `src/codex-spawn.ts`, while the repair build compiles files that import `./codex-spawn.js` / `../codex-spawn.js`.
