### PR TITLE
fix(review): render copyable Mantis proof comments

### DIFF
--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -737,8 +737,9 @@ Known Mantis lanes:
 When `mantisRecommendation.status` is `recommended`, write a single-line
 `maintainerComment` that starts with `@openclaw-mantis` and describes the exact
 behavior to prove. Do not use any shorter or ambiguous Mantis account mention.
-ClawSweeper validates the account mention but does not render it publicly, so
-its own review comment does not accidentally start a Mantis workflow. Example:
+ClawSweeper validates the account mention and renders it in a fenced text block
+so maintainers can copy the exact PR comment without accidentally starting a
+Mantis workflow from the ClawSweeper review comment. Example:
 `@openclaw-mantis telegram desktop proof: verify that /stop targets the active
 topic and does not affect other topics.` Keep it short enough to paste into a
 PR comment.

--- a/schema/clawsweeper-decision.schema.json
+++ b/schema/clawsweeper-decision.schema.json
@@ -701,7 +701,7 @@
         },
         "maintainerComment": {
           "type": "string",
-          "description": "When recommended, a single-line PR comment starting with @openclaw-mantis that a maintainer can paste. ClawSweeper validates this mention but does not render it publicly, so review comments do not accidentally start Mantis workflows. Do not use shorter or ambiguous Mantis account mentions. For not_recommended, use an empty string."
+          "description": "When recommended, a single-line PR comment starting with @openclaw-mantis that a maintainer can paste. ClawSweeper validates and renders this mention inside a fenced text block so the public recommendation is directly copyable without starting Mantis workflows. Do not use shorter or ambiguous Mantis account mentions. For not_recommended, use an empty string."
         }
       }
     },

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -8615,9 +8615,9 @@ function publicMantisRecommendationBlock(recommendation: MantisRecommendation): 
   if (!commandBody) return "";
   const reason = sentence(recommendation.reason);
   const intro = reason
-    ? `${reason} A maintainer can ask Mantis to capture proof by posting a new PR comment that starts with the OpenClaw Mantis account mention, followed by:`
-    : "A maintainer can ask Mantis to capture proof by posting a new PR comment that starts with the OpenClaw Mantis account mention, followed by:";
-  return [intro, "", "```text", commandBody, "```"].join("\n");
+    ? `${reason} A maintainer can ask Mantis to capture proof by posting this exact PR comment:`
+    : "A maintainer can ask Mantis to capture proof by posting this exact PR comment:";
+  return [intro, "", "```text", `${accountMention} ${commandBody}`, "```"].join("\n");
 }
 
 function closeIntro(reason: CloseReason): string {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -17234,9 +17234,8 @@ Reason: Maintainers should review the proof before merge.
   );
 
   assert.match(comment, /\*\*Mantis proof suggestion\*\*/);
-  assert.match(comment, /starts with the OpenClaw Mantis account mention/);
-  assert.match(comment, /```text\ntelegram desktop proof:/);
-  assert.doesNotMatch(comment, /@openclaw-mantis/);
+  assert.match(comment, /posting this exact PR comment/);
+  assert.match(comment, /```text\n@openclaw-mantis telegram desktop proof:/);
 });
 
 test("pull request review comments suppress unsafe Mantis recommendations", () => {


### PR DESCRIPTION
## Summary
- render Mantis proof suggestions as exact copy-paste PR comments with @openclaw-mantis included inside the fenced block
- update the review prompt and decision schema to match the new public rendering behavior
- adjust the review-comment test to assert the copyable mention is present

## Validation
- PASS: env PATH=/root/.nvm/versions/node/v24.15.0/bin:$PATH node --test --test-name-pattern Mantis test/clawsweeper.test.ts
- PARTIAL: env PATH=/root/.nvm/versions/node/v24.15.0/bin:$PATH pnpm run check passed active-surface, limits, build, and lint, then failed in existing Codex process / PR close coverage proof tests unrelated to this Mantis rendering change. Representative failures included Codex CLI output producing empty structured JSON in runCodex tests and PR close coverage proof JSON parsing/retry assertions.