### PR TITLE
fix(review): recognize dynamic exact-review run names

### DIFF
--- a/src/repair/codex-capacity.ts
+++ b/src/repair/codex-capacity.ts
@@ -13,7 +13,6 @@ const DEFAULT_TIMEOUT_MS = 20 * 60 * 1000;
 
 export type CapacityRun = {
   databaseId: number;
-  workflowName: string;
   displayTitle: string;
   status: string;
   createdAt: string;
@@ -40,11 +39,7 @@ export function exactReviewAdmission({
   exactLimit?: number;
 }): ExactReviewAdmission {
   const exactRuns = snapshot.runs
-    .filter(
-      (run) =>
-        run.workflowName === "ClawSweeper" &&
-        run.displayTitle.startsWith(EXACT_REVIEW_TITLE_PREFIX),
-    )
+    .filter((run) => run.displayTitle.startsWith(EXACT_REVIEW_TITLE_PREFIX))
     .sort(compareRuns);
   if (!exactRuns.some((run) => run.databaseId === currentRunId)) {
     throw new Error(
@@ -139,16 +134,12 @@ export function fetchActiveExactReviewRuns(
         return [normalized.databaseId, normalized] as const;
       }),
     ).values(),
-  ].filter(
-    (run) =>
-      run.workflowName === "ClawSweeper" && run.displayTitle.startsWith(EXACT_REVIEW_TITLE_PREFIX),
-  );
+  ].filter((run) => run.displayTitle.startsWith(EXACT_REVIEW_TITLE_PREFIX));
 }
 
 function normalizeRun(run: LooseRecord): CapacityRun {
   return {
     databaseId: Number(run?.id ?? run?.databaseId ?? run?.database_id),
-    workflowName: String(run?.name ?? run?.workflowName ?? run?.workflow_name ?? ""),
     displayTitle: String(run?.display_title ?? run?.displayTitle ?? ""),
     status: String(run?.status ?? ""),
     createdAt: String(run?.created_at ?? run?.createdAt ?? ""),

--- a/test/repair/codex-capacity.test.ts
+++ b/test/repair/codex-capacity.test.ts
@@ -68,6 +68,28 @@ test("cancelled or completed exact runs disappear without lease recovery", () =>
   );
 });
 
+test("workflow-scoped fetch accepts dynamic Actions run names", () => {
+  const runs = fetchActiveExactReviewRuns("openclaw/clawsweeper", (args) => {
+    const query = new URL(`https://github.test/${args[3]}`).searchParams;
+    if (query.get("status") !== "in_progress") return [];
+    return [
+      exactApiRun(500, "2026-06-15T12:00:00Z"),
+      {
+        id: 501,
+        name: "Review target repo openclaw/openclaw",
+        display_title: "Review target repo openclaw/openclaw",
+        status: "in_progress",
+        created_at: "2026-06-15T12:00:01Z",
+      },
+    ];
+  });
+
+  assert.deepEqual(
+    runs.map((run) => run.databaseId),
+    [500],
+  );
+});
+
 test("exact review run fetch paginates until the oldest active page", () => {
   const calls: { status: string; page: number }[] = [];
   const runs = fetchActiveExactReviewRuns("openclaw/clawsweeper", (args) => {
@@ -107,7 +129,7 @@ function capacitySnapshot(runs: CapacityRun[]): CodexCapacitySnapshot {
 function exactApiRun(databaseId: number, createdAt: string) {
   return {
     id: databaseId,
-    name: "ClawSweeper",
+    name: `Review event item openclaw/openclaw#${databaseId}`,
     display_title: `Review event item openclaw/openclaw#${databaseId}`,
     status: "in_progress",
     created_at: createdAt,
@@ -117,7 +139,6 @@ function exactApiRun(databaseId: number, createdAt: string) {
 function exactRun(databaseId: number, createdAt: string): CapacityRun {
   return {
     databaseId,
-    workflowName: "ClawSweeper",
     displayTitle: `Review event item openclaw/openclaw#${databaseId}`,
     status: "in_progress",
     createdAt,


### PR DESCRIPTION
## Summary

- trust the workflow-scoped Actions endpoint instead of requiring its dynamic run name to equal the workflow name
- classify exact reviews by the existing `Review event item ` title contract
- add regression coverage using the live GitHub Actions REST response shape

## Root Cause

`sweep.yml` defines a dynamic `run-name`, so GitHub's workflow-runs REST response returns values such as `name: "Review event item openclaw/openclaw#93446"`. The exact-review capacity helper queried the workflow-specific `sweep.yml` endpoint but then filtered every result with `name === "ClawSweeper"`.

That removed the current run from every capacity snapshot. The fail-closed semaphore therefore waited until timeout without ever starting Codex.

## Verification

- `PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH" pnpm run build:repair && PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH" node --test test/repair/codex-capacity.test.ts`
- `PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH" pnpm run check`

## Real Behavior Proof

Ran the patched helper against live ClawSweeper Actions state.

An actual oldest active exact-review run was recognized and admitted:

```text
oldest_title=Review event item openclaw/openclaw#93181
{"proceed":true,"current_rank":1,"exact_waiters":31,"exact_limit":4}
```

The live exact-review run for this PR was also recognized as a waiter, and its rank advanced as older runs completed:

```text
Waiting for Codex capacity: exact rank 25/30, 4 exact-review slots configured.
Waiting for Codex capacity: exact rank 24/29, 4 exact-review slots configured.
Error: timed out waiting for Codex capacity: exact rank 24/29, 4 exact-review slots configured
```

This specifically proves the fixed path no longer fails with `current exact-review run ... was not found`.

The full `repository_dispatch -> capacity gate -> Codex review` path can only execute default-branch workflow code. Final end-to-end proof is one normal exact re-review after this fix reaches `main`.

Live runs:

- admitted-run target: https://github.com/openclaw/clawsweeper/actions/runs/27589883129
- recognized waiting run: https://github.com/openclaw/clawsweeper/actions/runs/27590522273
- old default-branch timeout: https://github.com/openclaw/clawsweeper/actions/runs/27589702909