### PR TITLE
fix(review): tolerate invalid root-cause clusters

### DIFF
--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -445,15 +445,15 @@ Classify the current item and each evidence-backed related member as
 supports exactly one canonical item; otherwise use null. Do not include the
 current item in `members`, do not repeat refs, and do not infer shared root
 cause from title similarity, labels, product area, or gitcrawl membership
-alone. Use `fixed_by_candidate` only when the canonical item is a pull request:
-`canonicalRef` must be that PR URL and `members` must include exactly one
-`canonical` member with the same PR URL. If the canonical item is an issue,
-use `duplicate`, `same_root_cause`, `partial_overlap`, `superseded`, or
-`needs_human` instead. Use the independent default with low confidence and no
-members when no cluster is established. This assessment is proposal-only: it
-does not dispatch repair, suppress issue implementation, mutate siblings,
-close, or merge anything. Keep `workClusterRefs` separate; those remain
-work-lane context, not a typed root-cause contract.
+alone. Use `fixed_by_candidate` only when one side of that relationship is a
+pull request: an issue may be fixed by a canonical PR, or a PR may be the
+candidate fix for a canonical issue. Do not label issue-to-issue overlaps as
+`fixed_by_candidate`; use `duplicate`, `same_root_cause`, `partial_overlap`,
+`superseded`, or `needs_human` instead. Use the independent default with low
+confidence and no members when no cluster is established. This assessment is
+proposal-only: it does not dispatch repair, suppress issue implementation,
+mutate siblings, close, or merge anything. Keep `workClusterRefs` separate;
+those remain work-lane context, not a typed root-cause contract.
 
 Close as implemented when current `main` solves the observable user problem well enough, even if it did not use the exact workflow, file split, or field names proposed in the item. For broad umbrella requests, weigh the title and central user problem first. If current `main` solves the central problem and any leftovers are already tracked by a narrower related item, close as `duplicate_or_superseded` or `implemented_on_main` as appropriate and link the canonical follow-up. For older PRs where current `main` covers most of the branch but not every line, use `mostly_implemented_on_main` instead of stretching `implemented_on_main`. Keep open when a meaningful requested capability remains missing and no narrower canonical follow-up exists.
 

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -445,11 +445,15 @@ Classify the current item and each evidence-backed related member as
 supports exactly one canonical item; otherwise use null. Do not include the
 current item in `members`, do not repeat refs, and do not infer shared root
 cause from title similarity, labels, product area, or gitcrawl membership
-alone. Use the independent default with low confidence and no members when no
-cluster is established. This assessment is proposal-only: it does not dispatch
-repair, suppress issue implementation, mutate siblings, close, or merge
-anything. Keep `workClusterRefs` separate; those remain work-lane context, not a
-typed root-cause contract.
+alone. Use `fixed_by_candidate` only when the canonical item is a pull request:
+`canonicalRef` must be that PR URL and `members` must include exactly one
+`canonical` member with the same PR URL. If the canonical item is an issue,
+use `duplicate`, `same_root_cause`, `partial_overlap`, `superseded`, or
+`needs_human` instead. Use the independent default with low confidence and no
+members when no cluster is established. This assessment is proposal-only: it
+does not dispatch repair, suppress issue implementation, mutate siblings,
+close, or merge anything. Keep `workClusterRefs` separate; those remain
+work-lane context, not a typed root-cause contract.
 
 Close as implemented when current `main` solves the observable user problem well enough, even if it did not use the exact workflow, file split, or field names proposed in the item. For broad umbrella requests, weigh the title and central user problem first. If current `main` solves the central problem and any leftovers are already tracked by a narrower related item, close as `duplicate_or_superseded` or `implemented_on_main` as appropriate and link the canonical follow-up. For older PRs where current `main` covers most of the branch but not every line, use `mostly_implemented_on_main` instead of stretching `implemented_on_main`. Keep open when a meaningful requested capability remains missing and no narrower canonical follow-up exists.
 

--- a/schema/clawsweeper-decision.schema.json
+++ b/schema/clawsweeper-decision.schema.json
@@ -377,7 +377,7 @@
     "rootCauseCluster": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Read-only root-cause relationship assessment. This does not dispatch repair, suppress jobs, mutate sibling items, close, or merge anything.",
+      "description": "Read-only root-cause relationship assessment. This does not dispatch repair, suppress jobs, mutate sibling items, close, or merge anything. Use fixed_by_candidate only when one side of that relationship is a pull request: an issue may be fixed by a canonical PR, or a PR may be the candidate fix for a canonical issue.",
       "required": ["confidence", "canonicalRef", "currentItemRelationship", "summary", "members"],
       "properties": {
         "confidence": {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -2751,19 +2751,26 @@ function parseRootCauseCluster(
   ) {
     throw new Error(`${path}.currentItemRelationship cannot claim a canonical ref`);
   }
-  for (const member of members) {
+  for (const { member, parsed } of parsedMembers) {
     if (requiresCanonical.has(member.relationship) && !canonicalRef) {
       throw new Error(`${path} relationship ${member.relationship} requires a canonical ref`);
     }
-    if (member.relationship === "fixed_by_candidate" && parsedCanonical?.kind !== "pull_request") {
-      throw new Error(`${path} fixed_by_candidate requires a canonical pull request`);
+    if (
+      member.relationship === "fixed_by_candidate" &&
+      parsed.kind !== "pull_request" &&
+      parsedCanonical?.kind !== "pull_request"
+    ) {
+      throw new Error(`${path} fixed_by_candidate requires the member or canonical ref to be a PR`);
     }
   }
   if (
     currentItemRelationship === "fixed_by_candidate" &&
+    item?.kind !== "pull_request" &&
     parsedCanonical?.kind !== "pull_request"
   ) {
-    throw new Error(`${path}.currentItemRelationship fixed_by_candidate requires a canonical PR`);
+    throw new Error(
+      `${path}.currentItemRelationship fixed_by_candidate requires the current item or canonical ref to be a PR`,
+    );
   }
 
   return {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -2775,6 +2775,18 @@ function parseRootCauseCluster(
   };
 }
 
+function parseRootCauseClusterOrDefault(
+  value: unknown,
+  path: string,
+  item?: RootCauseNormalizationItem,
+): RootCauseClusterAssessment {
+  try {
+    return parseRootCauseCluster(value, path, item);
+  } catch {
+    return defaultRootCauseCluster();
+  }
+}
+
 function parseAgentsPolicyStatus(value: unknown, path: string): AgentsPolicyStatus {
   const record = requireRecord(value, path);
   rejectUnexpectedKeys(record, AGENTS_POLICY_STATUS_SCHEMA_KEYS, path);
@@ -2875,7 +2887,7 @@ export function parseDecision(value: unknown, item?: DecisionNormalizationItem):
       AUTO_IMPLEMENTATION_CANDIDATES,
       "decision.autoImplementationCandidate",
     ),
-    rootCauseCluster: parseRootCauseCluster(
+    rootCauseCluster: parseRootCauseClusterOrDefault(
       record.rootCauseCluster,
       "decision.rootCauseCluster",
       item,

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -16648,6 +16648,8 @@ test("decision parser enforces required schema-shaped evidence", () => {
 
 test("decision parser validates typed root-cause clusters", () => {
   const canonicalRef = "https://github.com/openclaw/openclaw/pull/456";
+  const canonicalIssueRef = "https://github.com/openclaw/openclaw/issues/456";
+  const candidatePullRef = "https://github.com/openclaw/openclaw/pull/789";
   const independentRootCauseCluster = {
     confidence: "low",
     canonicalRef: null,
@@ -16673,6 +16675,46 @@ test("decision parser validates typed root-cause clusters", () => {
     item({ repo: "openclaw/openclaw", number: 123, kind: "issue" }),
   );
   assert.deepEqual(parsed.rootCauseCluster, rootCauseCluster);
+
+  const prCandidateForCanonicalIssue = {
+    confidence: "high",
+    canonicalRef: canonicalIssueRef,
+    currentItemRelationship: "fixed_by_candidate",
+    summary: "This PR is the candidate fix for the canonical issue.",
+    members: [
+      {
+        ref: canonicalIssueRef,
+        relationship: "canonical",
+        reason: "The issue tracks the underlying user-visible bug.",
+      },
+    ],
+  };
+  assert.deepEqual(
+    parseDecision(
+      closeDecision({ rootCauseCluster: prCandidateForCanonicalIssue }),
+      item({ kind: "pull_request" }),
+    ).rootCauseCluster,
+    prCandidateForCanonicalIssue,
+  );
+
+  const canonicalIssueWithCandidateMember = {
+    confidence: "high",
+    canonicalRef: "https://github.com/openclaw/openclaw/issues/123",
+    currentItemRelationship: "canonical",
+    summary: "The issue is canonical and has an open candidate fix PR.",
+    members: [
+      {
+        ref: candidatePullRef,
+        relationship: "fixed_by_candidate",
+        reason: "The PR carries the candidate fix for this canonical issue.",
+      },
+    ],
+  };
+  assert.deepEqual(
+    parseDecision(closeDecision({ rootCauseCluster: canonicalIssueWithCandidateMember }), item())
+      .rootCauseCluster,
+    canonicalIssueWithCandidateMember,
+  );
 
   const invalidRootCauseClusters = [
     {
@@ -16711,11 +16753,21 @@ test("decision parser validates typed root-cause clusters", () => {
     },
     {
       ...rootCauseCluster,
-      canonicalRef: "https://github.com/openclaw/openclaw/issues/456",
+      canonicalRef: canonicalIssueRef,
       members: [
         {
           ...rootCauseCluster.members[0],
-          ref: "https://github.com/openclaw/openclaw/issues/456",
+          ref: canonicalIssueRef,
+        },
+      ],
+    },
+    {
+      ...canonicalIssueWithCandidateMember,
+      members: [
+        {
+          ref: "https://github.com/openclaw/openclaw/issues/789",
+          relationship: "fixed_by_candidate",
+          reason: "Issue-to-issue candidate-fix labels are not meaningful.",
         },
       ],
     },

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -16648,6 +16648,13 @@ test("decision parser enforces required schema-shaped evidence", () => {
 
 test("decision parser validates typed root-cause clusters", () => {
   const canonicalRef = "https://github.com/openclaw/openclaw/pull/456";
+  const independentRootCauseCluster = {
+    confidence: "low",
+    canonicalRef: null,
+    currentItemRelationship: "independent",
+    summary: "No evidence-backed root-cause cluster was established.",
+    members: [],
+  };
   const rootCauseCluster = {
     confidence: "high",
     canonicalRef,
@@ -16667,156 +16674,98 @@ test("decision parser validates typed root-cause clusters", () => {
   );
   assert.deepEqual(parsed.rootCauseCluster, rootCauseCluster);
 
-  assert.throws(
-    () =>
+  const invalidRootCauseClusters = [
+    {
+      ...rootCauseCluster,
+      members: [...rootCauseCluster.members, ...rootCauseCluster.members],
+    },
+    {
+      ...rootCauseCluster,
+      canonicalRef: "https://github.com/other/repo/pull/456",
+      members: [
+        {
+          ...rootCauseCluster.members[0],
+          ref: "https://github.com/other/repo/pull/456",
+        },
+      ],
+    },
+    {
+      ...rootCauseCluster,
+      members: [
+        ...rootCauseCluster.members,
+        {
+          ref: "https://github.com/openclaw/openclaw/issues/789",
+          relationship: "canonical",
+          reason: "A conflicting second canonical item.",
+        },
+      ],
+    },
+    {
+      ...rootCauseCluster,
+      members: [
+        {
+          ...rootCauseCluster.members[0],
+          ref: "https://github.com/openclaw/openclaw/pull/789",
+        },
+      ],
+    },
+    {
+      ...rootCauseCluster,
+      canonicalRef: "https://github.com/openclaw/openclaw/issues/456",
+      members: [
+        {
+          ...rootCauseCluster.members[0],
+          ref: "https://github.com/openclaw/openclaw/issues/456",
+        },
+      ],
+    },
+    {
+      ...rootCauseCluster,
+      members: [
+        {
+          ref: "https://github.com/openclaw/openclaw/issues/123",
+          relationship: "canonical",
+          reason: "Incorrectly repeats the current item.",
+        },
+      ],
+      canonicalRef: "https://github.com/openclaw/openclaw/issues/123",
+      currentItemRelationship: "duplicate",
+    },
+    {
+      ...rootCauseCluster,
+      members: [
+        {
+          ref: "https://github.com/OpenClaw/OpenClaw/issues/123",
+          relationship: "canonical",
+          reason: "Incorrectly repeats the current item with different casing.",
+        },
+      ],
+      canonicalRef: "https://github.com/OpenClaw/OpenClaw/issues/123",
+      currentItemRelationship: "duplicate",
+    },
+    {
+      ...rootCauseCluster,
+      members: [
+        rootCauseCluster.members[0],
+        {
+          ...rootCauseCluster.members[0],
+          ref: "https://github.com/OpenClaw/OpenClaw/pull/456",
+        },
+      ],
+    },
+  ];
+
+  for (const invalidRootCauseCluster of invalidRootCauseClusters) {
+    assert.deepEqual(
       parseDecision(
         closeDecision({
-          rootCauseCluster: {
-            ...rootCauseCluster,
-            members: [...rootCauseCluster.members, ...rootCauseCluster.members],
-          },
+          rootCauseCluster: invalidRootCauseCluster,
         }),
         item(),
-      ),
-    /duplicate refs/,
-  );
-  assert.throws(
-    () =>
-      parseDecision(
-        closeDecision({
-          rootCauseCluster: {
-            ...rootCauseCluster,
-            canonicalRef: "https://github.com/other/repo/pull/456",
-            members: [
-              {
-                ...rootCauseCluster.members[0],
-                ref: "https://github.com/other/repo/pull/456",
-              },
-            ],
-          },
-        }),
-        item(),
-      ),
-    /must stay within openclaw\/openclaw/,
-  );
-  assert.throws(
-    () =>
-      parseDecision(
-        closeDecision({
-          rootCauseCluster: {
-            ...rootCauseCluster,
-            members: [
-              ...rootCauseCluster.members,
-              {
-                ref: "https://github.com/openclaw/openclaw/issues/789",
-                relationship: "canonical",
-                reason: "A conflicting second canonical item.",
-              },
-            ],
-          },
-        }),
-        item(),
-      ),
-    /at most one canonical member/,
-  );
-  assert.throws(
-    () =>
-      parseDecision(
-        closeDecision({
-          rootCauseCluster: {
-            ...rootCauseCluster,
-            members: [
-              {
-                ...rootCauseCluster.members[0],
-                ref: "https://github.com/openclaw/openclaw/pull/789",
-              },
-            ],
-          },
-        }),
-        item(),
-      ),
-    /canonicalRef must identify exactly one canonical member/,
-  );
-  assert.throws(
-    () =>
-      parseDecision(
-        closeDecision({
-          rootCauseCluster: {
-            ...rootCauseCluster,
-            canonicalRef: "https://github.com/openclaw/openclaw/issues/456",
-            members: [
-              {
-                ...rootCauseCluster.members[0],
-                ref: "https://github.com/openclaw/openclaw/issues/456",
-              },
-            ],
-          },
-        }),
-        item(),
-      ),
-    /fixed_by_candidate requires a canonical PR/,
-  );
-  assert.throws(
-    () =>
-      parseDecision(
-        closeDecision({
-          rootCauseCluster: {
-            ...rootCauseCluster,
-            members: [
-              {
-                ref: "https://github.com/openclaw/openclaw/issues/123",
-                relationship: "canonical",
-                reason: "Incorrectly repeats the current item.",
-              },
-            ],
-            canonicalRef: "https://github.com/openclaw/openclaw/issues/123",
-            currentItemRelationship: "duplicate",
-          },
-        }),
-        item(),
-      ),
-    /must not repeat the current item/,
-  );
-  assert.throws(
-    () =>
-      parseDecision(
-        closeDecision({
-          rootCauseCluster: {
-            ...rootCauseCluster,
-            members: [
-              {
-                ref: "https://github.com/OpenClaw/OpenClaw/issues/123",
-                relationship: "canonical",
-                reason: "Incorrectly repeats the current item with different casing.",
-              },
-            ],
-            canonicalRef: "https://github.com/OpenClaw/OpenClaw/issues/123",
-            currentItemRelationship: "duplicate",
-          },
-        }),
-        item(),
-      ),
-    /must not repeat the current item/,
-  );
-  assert.throws(
-    () =>
-      parseDecision(
-        closeDecision({
-          rootCauseCluster: {
-            ...rootCauseCluster,
-            members: [
-              rootCauseCluster.members[0],
-              {
-                ...rootCauseCluster.members[0],
-                ref: "https://github.com/OpenClaw/OpenClaw/pull/456",
-              },
-            ],
-          },
-        }),
-        item(),
-      ),
-    /duplicate refs/,
-  );
+      ).rootCauseCluster,
+      independentRootCauseCluster,
+    );
+  }
 });
 
 test("root-cause report parsing defaults legacy and malformed reports safely", () => {


### PR DESCRIPTION
## Summary

- fall back to the independent root-cause cluster when optional `decision.rootCauseCluster` metadata is schema-invalid
- preserve valid `fixed_by_candidate` clusters when either side of the relationship is a PR, covering both issue fixed by canonical PR and PR candidate for canonical issue shapes
- tighten the review prompt and schema wording so issue-to-issue overlaps do not use `fixed_by_candidate`
- update parser regression coverage so malformed proposal-only root-cause cluster metadata no longer aborts an otherwise usable review

## Impact / Frequency

Refreshed `openclaw/clawsweeper-state` to `ab77ab8a`. In the current OpenClaw item reports:

- Since `2026-06-15T21:00:00Z`, 144 of 672 reviewed items failed with invalid structured output whose failure detail names `decision.rootCauseCluster` (21.4% of reviewed items, 87.3% of failed reviews).
- Since `2026-06-16T00:00:00Z`, 122 of 579 reviewed items failed this way (21.1% of reviewed items, 85.3% of failed reviews).
- Since `2026-06-16T04:00:00Z`, 114 of 229 reviewed items failed this way (49.8% of reviewed items, 84.4% of failed reviews).

Recent examples include `openclaw/openclaw#93304` at `2026-06-16T05:55:58Z`, `openclaw/openclaw#38730` at `2026-06-16T05:20:02Z`, and `openclaw/openclaw#25574` at `2026-06-16T05:17:11Z`.

## Verification

- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build`
- `node --test test/clawsweeper.test.ts`

Full `pnpm run check` was not completed locally; the earlier attempt hung in the broad `test:repair` lane under local Node `v25.9.0`.
