### PR TITLE
Harden repair execution for rebase conflicts

### DIFF
--- a/src/repair/execute-fix-artifact.ts
+++ b/src/repair/execute-fix-artifact.ts
@@ -666,18 +666,26 @@ try {
       });
       throw error;
     }
+    const unresolvedRebaseConflicts = needsHumanRebaseConflictReason(error);
     outcome = {
-      action: "execute_fix",
+      action: unresolvedRebaseConflicts ? "needs_human" : "execute_fix",
       status: "blocked",
       repair_strategy: fixArtifact.repair_strategy,
       reason: error.message,
-      ...(isRetryableCodexFailure(error) ? { requeue_required: true } : {}),
+      ...(unresolvedRebaseConflicts
+        ? { needs_human: [unresolvedRebaseConflicts] }
+        : isRetryableCodexFailure(error)
+          ? { requeue_required: true }
+          : {}),
     };
   }
 }
 
-report.status = outcome.status;
+report.status = outcome.action === "needs_human" ? "needs_human" : outcome.status;
 if (outcome.reason && !report.reason) report.reason = outcome.reason;
+if (Array.isArray(outcome.needs_human) && outcome.needs_human.length > 0) {
+  report.needs_human = uniqueStrings([...(report.needs_human ?? []), ...outcome.needs_human]);
+}
 report.actions.push(outcome);
 writeReport(report, resultPath);
 if (outcome.requeue_required === true) process.exitCode = 1;
@@ -688,6 +696,25 @@ updateAutomergeProgressStatus({
   details: compactText(String(outcome.reason ?? outcome.action ?? "done"), 240),
   headSha: outcome.commit ?? null,
 });
+
+function needsHumanRebaseConflictReason(error: JsonValue) {
+  const message = String(error?.message ?? error ?? "");
+  return /rebase conflicts remain unresolved:/i.test(message) ? message : null;
+}
+
+function rebaseConflictFailureReason({
+  targetDir,
+  rebaseResult,
+  attempt,
+  maxEditAttempts,
+}: LooseRecord) {
+  if (rebaseResult?.status !== "conflicts") return null;
+  if (Number(attempt) < Number(maxEditAttempts)) return null;
+  const remainingConflicts = unmergedPaths(String(targetDir));
+  return remainingConflicts.length > 0
+    ? `rebase conflicts remain unresolved: ${remainingConflicts.join(", ")}`
+    : null;
+}
 
 function isRetryableCodexFailure(...values: JsonValue[]) {
   const messages = values.flat().map(String);
@@ -1982,7 +2009,10 @@ function editValidatePrepareMerge({
         repositoryContext,
         reconcileWithBase,
         sourceHead,
-        rebaseResult,
+        rebaseResult:
+          rebaseResult?.status === "conflicts"
+            ? { ...rebaseResult, unmerged_paths: unmergedPaths(targetDir) }
+            : rebaseResult,
         maxEditAttempts,
         validationCommands: validationPreflight.resolved_commands ?? [],
         isAutomergeRepair: isAutomergeRepairJob(),
@@ -2037,6 +2067,13 @@ function editValidatePrepareMerge({
           codexResult,
           codexResult.error.message || String(codexResult.error),
         );
+        const unresolvedConflictFailure = rebaseConflictFailureReason({
+          targetDir,
+          rebaseResult,
+          attempt,
+          maxEditAttempts,
+        });
+        if (unresolvedConflictFailure) throw new Error(unresolvedConflictFailure);
         if (attempt < maxEditAttempts && isRetryableCodexErrorMessage(errorDetail)) {
           previousSummary = compactText(errorDetail, 360);
           const retryDelayMs = codexRetryDelayMs(errorDetail, attempt);
@@ -2060,6 +2097,13 @@ function editValidatePrepareMerge({
       }
       if (codexResult.status !== 0) {
         const errorDetail = codexFailureDetail(codexResult, "Codex fix worker failed");
+        const unresolvedConflictFailure = rebaseConflictFailureReason({
+          targetDir,
+          rebaseResult,
+          attempt,
+          maxEditAttempts,
+        });
+        if (unresolvedConflictFailure) throw new Error(unresolvedConflictFailure);
         if (attempt < maxEditAttempts && isRetryableCodexErrorMessage(errorDetail)) {
           previousSummary = compactText(errorDetail, 360);
           const retryDelayMs = codexRetryDelayMs(errorDetail, attempt);
@@ -2089,6 +2133,30 @@ function editValidatePrepareMerge({
         details: `exit ${codexResult.status}`,
         headSha: currentHead(targetDir),
       });
+
+      if (rebaseResult?.status === "conflicts") {
+        const remainingConflicts = unmergedPaths(targetDir);
+        if (remainingConflicts.length > 0) {
+          previousSummary =
+            readTextIfExists(summaryPath).trim() ||
+            `Rebase conflicts remain unresolved after edit attempt ${attempt}: ${remainingConflicts.join(", ")}`;
+          logProgress("rebase conflicts remain after Codex edit pass", {
+            mode,
+            attempt,
+            max_attempts: maxEditAttempts,
+            unresolved: remainingConflicts,
+          });
+          updateAutomergeProgressStatus({
+            id: `codex-edit-${mode}-${attempt}`,
+            label: `Codex edit ${attempt}`,
+            status: attempt < maxEditAttempts ? "retrying" : "blocked",
+            details: `unresolved rebase conflicts: ${remainingConflicts.join(", ")}`,
+            headSha: currentHead(targetDir),
+          });
+          if (attempt < maxEditAttempts) continue;
+          throw new Error(`rebase conflicts remain unresolved: ${remainingConflicts.join(", ")}`);
+        }
+      }
 
       const hasWorkingTreeChanges = Boolean(
         run("git", ["status", "--porcelain"], { cwd: targetDir }).trim(),

--- a/src/repair/fix-prompt-builder.test.ts
+++ b/src/repair/fix-prompt-builder.test.ts
@@ -127,6 +127,7 @@ test("fix prompt includes rebase and previous no-diff recovery details", () => {
       base_ref: "origin/main",
       base_sha: "def456",
       detail: "CONFLICT (content): CHANGELOG.md",
+      unmerged_paths: ["src/index.ts", "CHANGELOG.md"],
     },
     maxEditAttempts: 5,
   });
@@ -136,7 +137,9 @@ test("fix prompt includes rebase and previous no-diff recovery details", () => {
   assert.match(prompt, /Existing repair branch detected/);
   assert.match(prompt, /Source head before edit: abc123/);
   assert.match(prompt, /Deterministic pre-edit rebase: conflicts onto origin\/main \(def456\)/);
-  assert.match(prompt, /Resolve the active rebase conflicts/);
+  assert.match(prompt, /Conflict-first mode/);
+  assert.match(prompt, /resolve only the active rebase conflicts/);
+  assert.match(prompt, /Unmerged conflict paths: src\/index\.ts, CHANGELOG\.md/);
   assert.match(prompt, /Rebase output: CONFLICT \(content\): CHANGELOG\.md/);
   assert.match(prompt, /Previous attempt produced no target repo diff/);
   assert.match(prompt, /Previous no-diff summary: Analyzed without editing files/);

--- a/src/repair/fix-prompt-builder.ts
+++ b/src/repair/fix-prompt-builder.ts
@@ -276,10 +276,23 @@ function renderRebaseResult(rebaseResult: LooseRecord) {
   const baseRef = String(rebaseResult.base_ref ?? "origin/main");
   const baseSha = String(rebaseResult.base_sha ?? "unknown");
   const detail = compactText(String(rebaseResult.detail ?? "").trim(), 800);
+  const unmergedPaths = Array.isArray(rebaseResult.unmerged_paths)
+    ? rebaseResult.unmerged_paths.map((entry: unknown) => String(entry)).filter(Boolean)
+    : [];
   return [
     `Deterministic pre-edit rebase: ${status} onto ${baseRef} (${baseSha}).`,
     status === "conflicts"
-      ? "Resolve the active rebase conflicts, continue or finish the rebase, and leave the checkout in a normal non-rebasing state before returning."
+      ? [
+          "Conflict-first mode:",
+          "- resolve only the active rebase conflicts before doing any feature repair;",
+          "- inspect `git status --short` and the conflicted files listed below;",
+          "- remove all conflict markers and stage the resolved files;",
+          "- run `git rebase --continue` until the checkout is no longer rebasing;",
+          "- do not broaden the patch while conflicts remain.",
+        ].join("\n")
+      : "",
+    status === "conflicts" && unmergedPaths.length > 0
+      ? `Unmerged conflict paths: ${unmergedPaths.join(", ")}`
       : "",
     detail ? `Rebase output: ${detail}` : "",
   ]

--- a/test/repair/execute-fix-artifact-source.test.ts
+++ b/test/repair/execute-fix-artifact-source.test.ts
@@ -148,3 +148,16 @@ test("issue implementation rechecks opt-out labels immediately before branch pus
   assert.match(source.slice(helperStart, helperEnd), /repairPauseLabel\(issue\.labels\)/);
   assert.match(source.slice(helperStart, helperEnd), /refusing to push or open a PR/);
 });
+
+
+test("unresolved rebase conflicts are terminal needs_human repair reports", () => {
+  const source = fs.readFileSync(
+    path.join(process.cwd(), "src/repair/execute-fix-artifact.ts"),
+    "utf8",
+  );
+  assert.match(source, /function needsHumanRebaseConflictReason/);
+  assert.match(source, /rebase conflicts remain unresolved:/i);
+  assert.match(source, /action: unresolvedRebaseConflicts \? "needs_human" : "execute_fix"/);
+  assert.match(source, /report.status = outcome.action === "needs_human" \? "needs_human" : outcome.status/);
+  assert.match(source, /report.needs_human = uniqueStrings/);
+});


### PR DESCRIPTION
## Summary
- pass current unmerged rebase paths into the Codex repair prompt
- make the prompt explicitly enter conflict-first mode before functional repair
- keep retrying edit attempts when a Codex pass exits successfully but leaves unmerged paths
- block with exact unresolved conflict paths after edit attempts are exhausted

## Rationale
Repair execution currently treats any working tree change as enough to leave the edit loop. In a conflicted rebase, unresolved unmerged paths are also working tree changes, so the executor can proceed to `completeRebaseIfResolved()` and fail only after the edit loop has ended. This makes the repair worker less likely to retry with focused conflict evidence.

This keeps conflict handling inside the bounded edit loop and makes unresolved conflict paths explicit in progress/reporting.

## Verification
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm run build:repair`
- `node --test dist/repair/fix-prompt-builder.test.js`
- `node --test dist/repair/fix-prompt-builder.test.js test/repair/execute-fix-validation.test.ts test/repair/fix-edit-policy.test.ts test/repair/mechanical-rebase-conflicts.test.ts`
