### PR TITLE
feat(local-review): add fixed-claude CLI engine via --engine

### DIFF
--- a/docs/commit-sweeper.md
+++ b/docs/commit-sweeper.md
@@ -273,6 +273,13 @@ disables Codex web search, and explicitly forbids network lookups. Repositories
 without a configured profile are rejected (no foreign-profile fallback). Unlike the
 hosted lane it never writes to GitHub — the local Markdown report is the only output.
 
+By default `local-review` uses the **codex** engine. Pass `--engine claude` to drive a
+**fixed `claude` CLI** through the same bounded runner instead — provider-neutral, with
+zero extra dependencies. The claude engine uses your existing Claude auth; for a
+subscription set `CLAUDE_CODE_OAUTH_TOKEN` (from `claude setup-token`) and leave
+`ANTHROPIC_API_KEY` unset. The binary is fixed (`codex`/`claude`), never
+operator-configurable.
+
 ## Enable / Disable
 
 Target repositories can disable hook-based dispatch with:

--- a/src/codex-process.ts
+++ b/src/codex-process.ts
@@ -79,6 +79,9 @@ export function runCodexProcess(options: {
   stdoutPath?: string;
   stderrPath?: string;
   appServer?: CodexAppServerProcessOptions;
+  /** Override the spawned binary (defaults to codex) so the same bounded runner
+   * can drive another fixed review CLI, e.g. `claude`. */
+  command?: string;
 }): CodexProcessResult {
   const workDir = mkdtempSync(join(tmpdir(), "clawsweeper-codex-process-"));
   const optionsPath = join(workDir, "options.json");
@@ -90,7 +93,7 @@ export function runCodexProcess(options: {
       optionsPath,
       JSON.stringify({
         args: [...options.args],
-        command: codexProcessCommand(options.env),
+        command: options.command ?? codexProcessCommand(options.env),
         timeoutMs: options.timeoutMs,
         resultPath,
         stdoutPath,

--- a/src/commit-sweeper.ts
+++ b/src/commit-sweeper.ts
@@ -480,6 +480,12 @@ export function localReviewAdditionalPrompt(
 function localReviewCommand(args: Args): void {
   const targetDir = resolve(argString(args, "target_dir", "."));
   const baseBranch = argString(args, "base", "main");
+  // Validate the engine up front, before creating any run state.
+  const engine = argString(args, "engine", "codex");
+  if (engine !== "codex" && engine !== "claude") {
+    console.error(`[local-review] --engine must be "codex" or "claude", got "${engine}"`);
+    process.exit(1);
+  }
   const reportDir = resolve(
     argString(args, "report_dir", join(homedir(), ".clawsweeper-local-reviews")),
   );
@@ -541,9 +547,8 @@ function localReviewCommand(args: Args): void {
     `[local-review] repo=${targetRepo} profile=${profileSlug} base=${baseBranch} range=${baseSha.slice(0, 8)}..${headSha.slice(0, 8)}`,
   );
 
-  // codex is the built-in default engine; --engine claude drives a fixed `claude`
-  // CLI through the same bounded runner (provider-neutral, zero new deps).
-  const engine = argString(args, "engine", "codex");
+  // engine validated up front; codex is the default, --engine claude drives a fixed
+  // `claude` CLI through the same bounded runner (provider-neutral, zero new deps).
   let reviewMarkdown: string;
   if (engine === "claude") {
     reviewMarkdown = runClaudeReview({
@@ -555,7 +560,7 @@ function localReviewCommand(args: Args): void {
       timeoutMs: argNumber(args, "claude_timeout_ms", 1_800_000),
       additionalPrompt,
     });
-  } else if (engine === "codex") {
+  } else {
     reviewMarkdown = runCodex({
       targetDir,
       targetRepo,
@@ -571,9 +576,6 @@ function localReviewCommand(args: Args): void {
       additionalPrompt,
       extraCodexConfig: [LOCAL_REVIEW_WEB_SEARCH_CONFIG],
     });
-  } else {
-    console.error(`[local-review] --engine must be "codex" or "claude", got "${engine}"`);
-    process.exit(1);
   }
   const markdown = ensureCommitReportTimestamps(reviewMarkdown, metadata);
 

--- a/src/commit-sweeper.ts
+++ b/src/commit-sweeper.ts
@@ -364,16 +364,39 @@ function runClaudeReview(options: {
   baseSha: string;
   metadata: CommitMetadata;
   timeoutMs: number;
+  workDir: string;
   additionalPrompt: string;
 }): string {
-  const prompt = promptForCommit({
+  // The claude reviewer is read-only (Read/Grep/Glob, no shell), so unlike the
+  // sandboxed codex lane it cannot run `git` to inspect the range. Embed the full
+  // committed-range diff in the prompt so it reviews the actual change, not just the
+  // current HEAD files plus a changed-file list.
+  const rawDiff = run("git", ["diff", `${options.baseSha}..${options.sha}`], {
+    cwd: options.targetDir,
+  });
+  const maxDiffBytes = 256 * 1024;
+  const diff =
+    rawDiff.length > maxDiffBytes
+      ? `${rawDiff.slice(0, maxDiffBytes)}\n…(diff truncated at ${maxDiffBytes} bytes)…`
+      : rawDiff;
+  const prompt = `${promptForCommit({
     targetDir: options.targetDir,
     targetRepo: options.targetRepo,
     sha: options.sha,
     baseSha: options.baseSha,
     metadata: options.metadata,
     additionalPrompt: options.additionalPrompt,
-  });
+  })}
+
+## Full Range Diff (\`${options.baseSha}..${options.sha}\`)
+
+\`\`\`diff
+${diff || "(empty diff)"}
+\`\`\`
+`;
+  // Capture the FULL stdout (not the runner's 64 KiB tail) so a large report's YAML
+  // front matter at the top is never truncated away.
+  const stdoutPath = join(options.workDir, "claude-stdout.log");
   const result = runCodexProcess({
     command: "claude",
     args: ["-p", "--output-format", "text", "--allowedTools", "Read Grep Glob"],
@@ -381,13 +404,17 @@ function runClaudeReview(options: {
     env: codexEnv(),
     input: prompt,
     timeoutMs: options.timeoutMs,
+    stdoutPath,
   });
+  const stdout = existsSync(stdoutPath) ? readFileSync(stdoutPath, "utf8") : result.stdout;
   if (result.error || result.status !== 0) {
     const timeout = codexProcessErrorCode(result.error) === "ETIMEDOUT";
     const detail =
       result.error instanceof Error
-        ? `${result.error.message}\n${safeOutputTail(result.stderr)}`
-        : `exit ${result.status ?? "unknown"}\n${safeOutputTail(result.stderr) || "No output."}`;
+        ? `${result.error.message}\n${safeOutputTail(result.stderr) || safeOutputTail(stdout)}`
+        : `exit ${result.status ?? "unknown"}\n${
+            safeOutputTail(result.stderr) || safeOutputTail(stdout) || "No output."
+          }`;
     return failureReport({
       targetRepo: options.targetRepo,
       sha: options.sha,
@@ -397,7 +424,7 @@ function runClaudeReview(options: {
       timeout,
     });
   }
-  const markdown = stripMarkdownFence(result.stdout);
+  const markdown = stripMarkdownFence(stdout);
   if (!markdown.trim()) {
     return failureReport({
       targetRepo: options.targetRepo,
@@ -558,6 +585,7 @@ function localReviewCommand(args: Args): void {
       baseSha,
       metadata,
       timeoutMs: argNumber(args, "claude_timeout_ms", 1_800_000),
+      workDir: runDir,
       additionalPrompt,
     });
   } else {

--- a/src/commit-sweeper.ts
+++ b/src/commit-sweeper.ts
@@ -399,7 +399,7 @@ ${diff || "(empty diff)"}
   const stdoutPath = join(options.workDir, "claude-stdout.log");
   const result = runCodexProcess({
     command: "claude",
-    args: ["-p", "--output-format", "text", "--allowedTools", "Read Grep Glob"],
+    args: ["-p", "--output-format", "text", "--allowedTools", "Read,Grep,Glob"],
     cwd: options.targetDir,
     env: codexEnv(),
     input: prompt,

--- a/src/commit-sweeper.ts
+++ b/src/commit-sweeper.ts
@@ -353,6 +353,64 @@ function runCodex(options: {
   return stripMarkdownFence(readFileSync(outputPath, "utf8"));
 }
 
+// Local-review Claude engine: drives a FIXED `claude` CLI through the same bounded
+// runner as codex (no operator-configurable binary), credentials scrubbed via
+// codexEnv, read-only tools. Auth is the caller's existing Claude auth — for a
+// subscription set CLAUDE_CODE_OAUTH_TOKEN (and leave ANTHROPIC_API_KEY unset).
+function runClaudeReview(options: {
+  targetDir: string;
+  targetRepo: string;
+  sha: string;
+  baseSha: string;
+  metadata: CommitMetadata;
+  timeoutMs: number;
+  additionalPrompt: string;
+}): string {
+  const prompt = promptForCommit({
+    targetDir: options.targetDir,
+    targetRepo: options.targetRepo,
+    sha: options.sha,
+    baseSha: options.baseSha,
+    metadata: options.metadata,
+    additionalPrompt: options.additionalPrompt,
+  });
+  const result = runCodexProcess({
+    command: "claude",
+    args: ["-p", "--output-format", "text", "--allowedTools", "Read Grep Glob"],
+    cwd: options.targetDir,
+    env: codexEnv(),
+    input: prompt,
+    timeoutMs: options.timeoutMs,
+  });
+  if (result.error || result.status !== 0) {
+    const timeout = codexProcessErrorCode(result.error) === "ETIMEDOUT";
+    const detail =
+      result.error instanceof Error
+        ? `${result.error.message}\n${safeOutputTail(result.stderr)}`
+        : `exit ${result.status ?? "unknown"}\n${safeOutputTail(result.stderr) || "No output."}`;
+    return failureReport({
+      targetRepo: options.targetRepo,
+      sha: options.sha,
+      baseSha: options.baseSha,
+      metadata: options.metadata,
+      detail: detail.trim(),
+      timeout,
+    });
+  }
+  const markdown = stripMarkdownFence(result.stdout);
+  if (!markdown.trim()) {
+    return failureReport({
+      targetRepo: options.targetRepo,
+      sha: options.sha,
+      baseSha: options.baseSha,
+      metadata: options.metadata,
+      detail: "claude produced no output",
+      timeout: false,
+    });
+  }
+  return markdown;
+}
+
 function reviewCommand(args: Args): void {
   const targetRepo = argString(args, "target_repo", DEFAULT_TARGET_REPO);
   const targetDir = resolve(
@@ -483,8 +541,22 @@ function localReviewCommand(args: Args): void {
     `[local-review] repo=${targetRepo} profile=${profileSlug} base=${baseBranch} range=${baseSha.slice(0, 8)}..${headSha.slice(0, 8)}`,
   );
 
-  const markdown = ensureCommitReportTimestamps(
-    runCodex({
+  // codex is the built-in default engine; --engine claude drives a fixed `claude`
+  // CLI through the same bounded runner (provider-neutral, zero new deps).
+  const engine = argString(args, "engine", "codex");
+  let reviewMarkdown: string;
+  if (engine === "claude") {
+    reviewMarkdown = runClaudeReview({
+      targetDir,
+      targetRepo,
+      sha: headSha,
+      baseSha,
+      metadata,
+      timeoutMs: argNumber(args, "claude_timeout_ms", 1_800_000),
+      additionalPrompt,
+    });
+  } else if (engine === "codex") {
+    reviewMarkdown = runCodex({
       targetDir,
       targetRepo,
       sha: headSha,
@@ -498,9 +570,12 @@ function localReviewCommand(args: Args): void {
       workDir: runDir,
       additionalPrompt,
       extraCodexConfig: [LOCAL_REVIEW_WEB_SEARCH_CONFIG],
-    }),
-    metadata,
-  );
+    });
+  } else {
+    console.error(`[local-review] --engine must be "codex" or "claude", got "${engine}"`);
+    process.exit(1);
+  }
+  const markdown = ensureCommitReportTimestamps(reviewMarkdown, metadata);
 
   const outputPath = join(runDir, "local-review.md");
   writeFileSync(outputPath, markdown.endsWith("\n") ? markdown : `${markdown}\n`, "utf8");

--- a/src/commit-sweeper.ts
+++ b/src/commit-sweeper.ts
@@ -371,9 +371,28 @@ function runClaudeReview(options: {
   // sandboxed codex lane it cannot run `git` to inspect the range. Embed the full
   // committed-range diff in the prompt so it reviews the actual change, not just the
   // current HEAD files plus a changed-file list.
-  const rawDiff = run("git", ["diff", `${options.baseSha}..${options.sha}`], {
-    cwd: options.targetDir,
-  });
+  // `run` buffers the whole diff host-side (execFileSync). A huge whole-branch diff
+  // (vendored/generated/binary-ish blobs) can exceed the maxBuffer ceiling and throw
+  // before the cap below ever applies — degrade to a failure report, like the rest of
+  // the lane, instead of aborting the process with a stack trace. (codex avoids this by
+  // diffing inside its own sandbox.)
+  let rawDiff: string;
+  try {
+    rawDiff = run("git", ["diff", `${options.baseSha}..${options.sha}`], {
+      cwd: options.targetDir,
+    });
+  } catch (error) {
+    return failureReport({
+      targetRepo: options.targetRepo,
+      sha: options.sha,
+      baseSha: options.baseSha,
+      metadata: options.metadata,
+      detail: `failed to read range diff: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      timeout: false,
+    });
+  }
   const maxDiffBytes = 256 * 1024;
   const diff =
     rawDiff.length > maxDiffBytes

--- a/test/local-review.test.ts
+++ b/test/local-review.test.ts
@@ -111,6 +111,28 @@ test("local-review rejects repositories covered only by a generic owner fallback
   }
 });
 
+test("local-review rejects an unknown --engine", () => {
+  const dir = initRepo();
+  try {
+    const base = git(dir, "rev-parse", "HEAD");
+    writeFileSync(join(dir, "b.txt"), "2\n");
+    git(dir, "add", "b.txt");
+    git(dir, "commit", "-q", "-m", "second");
+    const { status, out } = runLocalReview(dir, [
+      "--target-repo",
+      "openclaw/clawsweeper",
+      "--base",
+      base,
+      "--engine",
+      "bogus",
+    ]);
+    assert.equal(status, 1);
+    assert.match(out, /--engine must be "codex" or "claude"/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("local-review reports nothing to review when HEAD has no commits beyond base", () => {
   const dir = initRepo();
   try {


### PR DESCRIPTION
## What

`local-review --engine claude` — drive a **fixed `claude` CLI** through the *same* bounded runner as codex. `runCodexProcess` gains an optional `command` param (the worker already takes one internally), so a second fixed review CLI reuses the existing process/retry/capture path. **codex stays the default.** Provider-neutral, **zero new dependencies** (`package.json` unchanged).

```text
pnpm local-review -- --base main                 # codex (default)
pnpm local-review -- --base main --engine claude # fixed `claude` CLI
```

## Addresses the #274 close, point by point

- **fixed trusted executable boundary** → fixed `claude`/`codex`; **no `--claude-bin` / no operator-configurable binary**
- **minimal allowlisted environment** → `codexEnv()` (scrubs GitHub/OpenAI/app creds, keeps the OS env + the engine's own auth)
- **shared process capture/retry handling** → the existing `runCodexProcess` worker, now command-agnostic
- **identical final schema validation** → same `failureReport` / `stripMarkdownFence` / timestamp path as codex
- **provider-neutral committed-range review + unique temporary state** → inherited from the merged local-review foundation
- **no SDK dependency** → CLI subprocess, not the Agent SDK

## Auth

The claude engine uses the caller's existing Claude auth. For a **subscription**, set `CLAUDE_CODE_OAUTH_TOKEN` (from `claude setup-token`) and leave `ANTHROPIC_API_KEY` unset.

## Verification

- `pnpm run build`, lint (type-aware), `oxfmt`, and the local-review test suite (8 tests, incl. a new unknown-`--engine` guard) all pass.
- **codex path is fully covered** by the existing tests — the runner change is backward-compatible (default still resolves codex).
- **The claude execution path is now run-verified** via a meta self-review: I ran `local-review --engine claude` on this very branch (subscription auth, `ANTHROPIC_API_KEY` unset). It executed end-to-end through the shared runner, read the changed files in full, and produced a schema-valid report each iteration. The loop also caught — and I fixed — four real bugs in the engine itself before converging clean (see below), which doubles as evidence the lane actually reviews rather than rubber-stamps.

## Proof — claude engine reviewing its own PR

`local-review --engine claude --base origin/main` run repeatedly against this branch as it hardened. Each run produced a valid report (front matter + `result`/`confidence`/`highest_severity`); the findings drove the fix commits:

| run | result | severity | finding → fix |
|----|--------|----------|----------------|
| 1 | findings | (3) | claude lane couldn't see the diff / 64 KiB stdout tail truncated front matter / spawn-error gave no detail → `b4ea2701` (diff in prompt, full-stdout capture, error fallback) |
| 2 | findings | medium | `--allowedTools "Read Grep Glob"` was one space-joined token → no tools enabled in `-p` mode → `d0d62765` (comma-separate `Read,Grep,Glob`) |
| 3 | findings | low | whole-branch `git diff` buffered host-side could exceed `maxBuffer` and crash before any report → `36239522` (try/catch → `failureReport`) |
| 4 | **nothing_found** | **none** | clean, high confidence — reviewer read 9 files in full and traced every spawn path |

The final clean run (`36239522`, `result: nothing_found`, `confidence: high`) verifies the fixed binary, the env scrub, full-stdout capture, and engine-validation ordering by name. Run via ambient subscription credentials; no API key, no token minted.

## Not included

- The Agent-SDK approach (it pulls many deps — wrong fit for this zero-dep tool).
- Any configurable binary or second-provider scope beyond the engine switch.
