### PR TITLE
fix(review): requeue capacity-blocked exact reviews

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -285,6 +285,17 @@ jobs:
           permission-issues: write
           permission-pull-requests: write
 
+      - name: Create ClawSweeper dispatch token
+        id: clawsweeper-dispatch-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+
       - name: React to target item review start
         continue-on-error: true
         env:
@@ -383,8 +394,95 @@ jobs:
           pnpm run repair:codex-capacity -- \
             --repo "${{ github.repository }}" \
             --run-id "${{ github.run_id }}" \
-            --poll-ms 30000 \
+            --poll-ms 120000 \
             --timeout-ms 1200000
+
+      - name: Requeue capacity-blocked exact review
+        id: capacity-requeue
+        if: ${{ failure() && steps.codex-capacity.outcome == 'failure' }}
+        env:
+          DISPATCH_TOKEN: ${{ steps.clawsweeper-dispatch-token.outputs.token || github.token }}
+          STATUS_GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          CLIENT_PAYLOAD: ${{ toJson(github.event.client_payload) }}
+          TARGET_REPO: ${{ steps.target.outputs.target_repo }}
+          ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
+          COMMAND_STATUS_MARKER: ${{ github.event.client_payload.command_status_marker || '' }}
+          STATUS_COMMENT_ID: ${{ github.event.client_payload.status_comment_id || '' }}
+          MAX_CAPACITY_RETRIES: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_CAPACITY_RETRIES || '1' }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p .artifacts
+          result_file=".artifacts/capacity-requeue.json"
+          dispatch_file=".artifacts/capacity-requeue-dispatch.json"
+          node <<'NODE' > "$result_file"
+          const payload = JSON.parse(process.env.CLIENT_PAYLOAD || "{}");
+          const existingRetry =
+            payload.capacity_retry && typeof payload.capacity_retry === "object"
+              ? payload.capacity_retry
+              : {};
+          const parsedMax = Number.parseInt(process.env.MAX_CAPACITY_RETRIES || "1", 10);
+          const max = Number.isFinite(parsedMax) && parsedMax >= 0 ? parsedMax : 1;
+          const parsedPrevious = Number.parseInt(
+            String(existingRetry.count ?? payload.capacity_retry_count ?? "0"),
+            10,
+          );
+          const previous = Number.isFinite(parsedPrevious) && parsedPrevious > 0 ? parsedPrevious : 0;
+          if (previous >= max) {
+            console.log(JSON.stringify({ status: "exhausted", attempt: previous, max }));
+          } else {
+            const attempt = previous + 1;
+            delete payload.capacity_retry_count;
+            delete payload.capacity_retry_source_run;
+            delete payload.capacity_retry_source_url;
+            delete payload.capacity_retry_reason;
+            payload.capacity_retry = {
+              ...existingRetry,
+              count: attempt,
+              source_run: process.env.GITHUB_RUN_ID,
+              source_url: process.env.RUN_URL,
+              reason: "exact-review-capacity-timeout",
+            };
+            console.log(
+              JSON.stringify({
+                status: "scheduled",
+                attempt,
+                max,
+                dispatch: { event_type: "clawsweeper_item", client_payload: payload },
+              }),
+            );
+          }
+          NODE
+          status="$(node -e 'const fs=require("fs"); const result=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); console.log(result.status);' "$result_file")"
+          attempt="$(node -e 'const fs=require("fs"); const result=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); console.log(result.attempt ?? 0);' "$result_file")"
+          max="$(node -e 'const fs=require("fs"); const result=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); console.log(result.max ?? 0);' "$result_file")"
+          if [ "$status" = "scheduled" ]; then
+            if [ -n "$STATUS_GH_TOKEN" ]; then
+              GH_TOKEN="$STATUS_GH_TOKEN" pnpm run repair:update-command-status -- \
+                --repo "$TARGET_REPO" \
+                --item-number "$ITEM_NUMBER" \
+                --marker "$COMMAND_STATUS_MARKER" \
+                --status-comment-id "$STATUS_COMMENT_ID" \
+                --state "Retry scheduled" \
+                --detail "The targeted re-review timed out or was rate-limited while waiting for exact-review Codex capacity. ClawSweeper scheduled bounded retry ${attempt}/${max}." \
+                --run-url "$RUN_URL" \
+                --wait-ms 120000 || true
+            fi
+            node -e 'const fs=require("fs"); const result=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); fs.writeFileSync(process.argv[2], JSON.stringify(result.dispatch));' "$result_file" "$dispatch_file"
+            if GH_TOKEN="$DISPATCH_TOKEN" gh api --method POST "repos/${GITHUB_REPOSITORY}/dispatches" --input "$dispatch_file"; then
+              echo "::notice::Scheduled exact-review capacity retry ${attempt}/${max}."
+            else
+              echo "::warning::Unable to schedule exact-review capacity retry ${attempt}/${max}."
+              status="dispatch_failed"
+            fi
+          else
+            echo "::warning::Exact-review capacity retry limit already exhausted (${attempt}/${max})."
+          fi
+          {
+            echo "status=$status"
+            echo "attempt=$attempt"
+            echo "max=$max"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Mark re-review command in progress
         continue-on-error: true
@@ -551,11 +649,22 @@ jobs:
           PUBLISH_OUTCOME: ${{ steps.publish-event-result.outcome }}
           ROUTE_OUTCOME: ${{ steps.route-synced-verdict.outcome }}
           CAPACITY_OUTCOME: ${{ steps.codex-capacity.outcome }}
+          CAPACITY_REQUEUE_STATUS: ${{ steps.capacity-requeue.outputs.status }}
+          CAPACITY_REQUEUE_ATTEMPT: ${{ steps.capacity-requeue.outputs.attempt }}
+          CAPACITY_REQUEUE_MAX: ${{ steps.capacity-requeue.outputs.max }}
         run: |
           state="Failed"
           detail="The targeted re-review did not finish cleanly. Check the workflow run for details."
           if [ "$CAPACITY_OUTCOME" = "failure" ]; then
             detail="The targeted re-review timed out or failed while waiting for exact-review Codex capacity. Retry after capacity recovers."
+            if [ "$CAPACITY_REQUEUE_STATUS" = "scheduled" ]; then
+              state="Retry scheduled"
+              detail="The targeted re-review timed out or was rate-limited while waiting for exact-review Codex capacity. ClawSweeper scheduled bounded retry ${CAPACITY_REQUEUE_ATTEMPT}/${CAPACITY_REQUEUE_MAX}."
+            elif [ "$CAPACITY_REQUEUE_STATUS" = "exhausted" ]; then
+              detail="The targeted re-review timed out or was rate-limited while waiting for exact-review Codex capacity, and the bounded capacity retry limit is exhausted."
+            elif [ "$CAPACITY_REQUEUE_STATUS" = "dispatch_failed" ]; then
+              detail="The targeted re-review timed out or was rate-limited while waiting for exact-review Codex capacity, and ClawSweeper could not schedule the bounded retry."
+            fi
           fi
           if [ "$REVIEW_OUTCOME" = "cancelled" ]; then
             state="Superseded"

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -110,11 +110,18 @@ their derived lane ceiling and at the remaining global budget after other active
 priority work.
 
 Exact-item review runs use a deterministic live Actions semaphore before Codex
-starts. Active exact runs are ordered by creation time and run ID; only the
-oldest `lanes.exact_review.max_concurrent` runs proceed. Cancelled and completed
-runs disappear from the next poll, so no lease or TTL recovery is required.
-This is an exact-review burst limit, not a hard distributed provider semaphore
-across every Codex workflow.
+starts. Running exact jobs are ordered by creation time and run ID; only the
+oldest `lanes.exact_review.max_concurrent` jobs proceed. Queued or pending
+Actions runs are not counted until their job starts, because they are not yet
+competing for Codex slots. Cancelled and completed runs disappear from the next
+poll.
+
+Capacity waiters poll the Actions API at a low cadence. If a waiter times out
+or cannot verify capacity before Codex starts, the event workflow records a
+retry-scheduled status and re-dispatches the exact item with bounded retry
+metadata through a separate ClawSweeper App dispatch token instead of treating
+the overflow as a permanent review failure. This is an exact-review burst limit,
+not a hard distributed provider semaphore across every Codex workflow.
 
 Examples with the current config:
 

--- a/src/repair/codex-capacity.ts
+++ b/src/repair/codex-capacity.ts
@@ -6,7 +6,10 @@ import { AUTOMATION_LIMITS } from "./limits.js";
 import { parseArgs } from "./lib.js";
 import { sleepMs } from "./timing.js";
 
-const ACTIVE_STATUSES = ["in_progress", "pending", "queued", "waiting", "requested"];
+// Only running workflow jobs can enter the Codex gate. Queued/pending Actions
+// runs do not consume Codex capacity yet, and polling every active status from
+// every waiter can exhaust the GitHub App installation rate limit during bursts.
+const RUNNING_STATUSES = ["in_progress"];
 const EXACT_REVIEW_TITLE_PREFIX = "Review event item ";
 const DEFAULT_POLL_MS = 15_000;
 const DEFAULT_TIMEOUT_MS = 20 * 60 * 1000;
@@ -111,7 +114,7 @@ export function fetchActiveExactReviewRuns(
   fetchPage: (args: string[]) => JsonValue[] = (args) =>
     ghJsonWithRetry<JsonValue[]>(args, { attempts: 3 }),
 ): CapacityRun[] {
-  const runs = ACTIVE_STATUSES.flatMap((status) => {
+  const runs = RUNNING_STATUSES.flatMap((status) => {
     const statusRuns: JsonValue[] = [];
     for (let page = 1; ; page += 1) {
       const pageRuns = fetchPage([

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -19736,6 +19736,7 @@ test("sweep workflow admits exact event reviews through an exact-review semaphor
   const setupPnpmIndex = eventReviewBlock.indexOf("- uses: ./.github/actions/setup-pnpm");
   const readTokenIndex = eventReviewBlock.indexOf("- name: Create target read token");
   const writeTokenIndex = eventReviewBlock.indexOf("- name: Create target write token");
+  const dispatchTokenIndex = eventReviewBlock.indexOf("- name: Create ClawSweeper dispatch token");
   const waitingStatusIndex = eventReviewBlock.indexOf(
     "- name: Mark re-review waiting for capacity",
   );
@@ -19745,6 +19746,9 @@ test("sweep workflow admits exact event reviews through an exact-review semaphor
   const setupCodexIndex = eventReviewBlock.indexOf("- uses: ./.github/actions/setup-codex");
   const checkoutIndex = eventReviewBlock.indexOf("- name: Check out target repository");
   const capacityIndex = eventReviewBlock.indexOf("- name: Wait for exact-review Codex capacity");
+  const capacityRequeueIndex = eventReviewBlock.indexOf(
+    "- name: Requeue capacity-blocked exact review",
+  );
   const exactReviewIndex = eventReviewBlock.indexOf("- name: Review exact event item");
   const exactReviewStep = eventReviewBlock.slice(
     exactReviewIndex,
@@ -19759,17 +19763,34 @@ test("sweep workflow admits exact event reviews through an exact-review semaphor
   assert.ok(setupPnpmIndex >= 0);
   assert.ok(readTokenIndex > setupPnpmIndex);
   assert.ok(writeTokenIndex > readTokenIndex);
-  assert.ok(checkoutIndex > writeTokenIndex);
+  assert.ok(dispatchTokenIndex > writeTokenIndex);
+  assert.ok(checkoutIndex > dispatchTokenIndex);
   assert.ok(waitingStatusIndex > checkoutIndex);
   assert.ok(capacityIndex > waitingStatusIndex);
-  assert.ok(inProgressStatusIndex > capacityIndex);
+  assert.ok(capacityRequeueIndex > capacityIndex);
+  assert.ok(inProgressStatusIndex > capacityRequeueIndex);
   assert.ok(setupCodexIndex > inProgressStatusIndex);
   assert.ok(exactReviewIndex > setupCodexIndex);
   assert.match(eventReviewBlock, /pnpm run repair:codex-capacity/);
   assert.match(eventReviewBlock, /--run-id "\$\{\{ github\.run_id \}\}"/);
+  assert.match(eventReviewBlock, /--poll-ms 120000/);
   assert.match(eventReviewBlock, /--state "Waiting for Codex capacity"/);
   assert.match(eventReviewBlock, /exact-review semaphore admitted this run/);
   assert.match(eventReviewBlock, /CAPACITY_OUTCOME: \$\{\{ steps\.codex-capacity\.outcome \}\}/);
+  assert.match(
+    eventReviewBlock,
+    /CAPACITY_REQUEUE_STATUS: \$\{\{ steps\.capacity-requeue\.outputs\.status \}\}/,
+  );
+  assert.match(eventReviewBlock, /CLAWSWEEPER_EXACT_REVIEW_CAPACITY_RETRIES/);
+  assert.match(eventReviewBlock, /permission-contents: write/);
+  assert.match(
+    eventReviewBlock,
+    /DISPATCH_TOKEN: \$\{\{ steps\.clawsweeper-dispatch-token\.outputs\.token \|\| github\.token \}\}/,
+  );
+  assert.match(eventReviewBlock, /payload\.capacity_retry = \{/);
+  assert.match(eventReviewBlock, /delete payload\.capacity_retry_count/);
+  assert.match(eventReviewBlock, /repos\/\$\{GITHUB_REPOSITORY\}\/dispatches/);
+  assert.match(eventReviewBlock, /state="Retry scheduled"/);
   assert.match(
     eventReviewBlock,
     /timed out or failed while waiting for exact-review Codex capacity/,

--- a/test/repair/codex-capacity.test.ts
+++ b/test/repair/codex-capacity.test.ts
@@ -69,8 +69,10 @@ test("cancelled or completed exact runs disappear without lease recovery", () =>
 });
 
 test("workflow-scoped fetch accepts dynamic Actions run names", () => {
+  const statuses = new Set<string>();
   const runs = fetchActiveExactReviewRuns("openclaw/clawsweeper", (args) => {
     const query = new URL(`https://github.test/${args[3]}`).searchParams;
+    statuses.add(query.get("status") ?? "");
     if (query.get("status") !== "in_progress") return [];
     return [
       exactApiRun(500, "2026-06-15T12:00:00Z"),
@@ -88,6 +90,7 @@ test("workflow-scoped fetch accepts dynamic Actions run names", () => {
     runs.map((run) => run.databaseId),
     [500],
   );
+  assert.deepEqual([...statuses], ["in_progress"]);
 });
 
 test("exact review run fetch paginates until the oldest active page", () => {


### PR DESCRIPTION
## Summary
- Reduce exact-review capacity polling to running workflow jobs only, with a lower polling cadence to avoid GitHub App rate-limit stampedes during bursts.
- Add a bounded capacity retry path before Codex starts: timed-out or rate-limited exact-review waiters mark the command as `Retry scheduled` and redispatch the same item once by default.
- Use a separate ClawSweeper App dispatch token for the retry path, so recovery does not depend on the same Actions token that may have been exhausted by capacity polling.
- Keep retry metadata nested under one `client_payload.capacity_retry` key so repository dispatches stay within GitHub's 10-property payload limit.
- Document the exact-review queue behavior and add focused unit/workflow assertions.

Fixes #310
Refs #304

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm run build:all`
- `node --test test\repair\codex-capacity.test.ts`
- `node --test --test-name-pattern "sweep workflow admits exact event reviews" test\clawsweeper.test.ts`
- `pnpm run format:check`
- `pnpm run check:limits`
- `pnpm run lint:repair`
- `git diff --check` (CRLF warning only)
- Custom Node workflow assertion for the capacity retry/re-dispatch token path
- `codex -c service_tier=fast review --base origin/main` found and I fixed the retry-token issue; the final rerun reported no actionable correctness issues.

## Notes
- `node --test test\clawsweeper.test.ts --test-name-pattern "exact-review|capacity|event review|workflow"` is currently blocked in this Windows checkout by unrelated baseline failures around `/usr/bin/git`, `/bin/bash`, local Codex config, and unrelated assertions, so the workflow behavior is covered by focused assertions instead.
