### PR TITLE
Add author-wide repair PR intake

### DIFF
--- a/src/repair/pr-repair-intake.ts
+++ b/src/repair/pr-repair-intake.ts
@@ -27,9 +27,14 @@ type Candidate = {
   updatedAt?: string;
 };
 
+type AuthorSearchPullRequest = {
+  repository?: { nameWithOwner?: string };
+};
+
 const args = parseArgs(process.argv.slice(2));
-const repo = stringArg("repo", "");
+let repo = stringArg("repo", "");
 const author = stringArg("author", "");
+const allOpen = truthy(args["all-open"] ?? args.all_open);
 const limit = numberArg("limit", 50);
 const outDirArg = stringArg("out-dir", stringArg("out_dir", ""));
 const dryRun = truthy(args["dry-run"] ?? args.dry_run);
@@ -58,71 +63,134 @@ query($owner:String!, $name:String!, $number:Int!) {
 }
 `;
 
-if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) die("--repo owner/name is required");
 if (!author.trim()) die("--author is required");
 
-const owner = repo.split("/")[0] ?? "unknown";
-const outDir = path.resolve(repoRoot(), outDirArg || `jobs/${owner}/inbox`);
-const prs = fetchOpenPullRequests({ repo, author, limit });
-const results = prs
-  .map((pr) => candidateResult(pr))
-  .filter((result) => result.signals.length >= minSignals);
-
-if (!dryRun) fs.mkdirSync(outDir, { recursive: true });
-
-const written: LooseRecord[] = [];
-for (const result of results) {
-  const clusterId = slug(`repair-pr-${repo.replace("/", "-")}-${result.number}`);
-  const jobPath = path.join(outDir, `${clusterId}.md`);
-  const relativeJobPath = path.relative(repoRoot(), jobPath);
-  const branch = `clawsweeper/${clusterId}`;
-  const body = renderJob({ result, clusterId, branch });
-  if (dryRun) {
-    written.push({
-      status: "planned",
-      job: relativeJobPath,
-      number: result.number,
-      signals: result.signals,
-    });
-    continue;
-  }
-  if (fs.existsSync(jobPath) && !force) {
-    written.push({
-      status: "exists",
-      job: relativeJobPath,
-      number: result.number,
-      signals: result.signals,
-    });
-    continue;
-  }
-  fs.writeFileSync(jobPath, body, "utf8");
-  const parsed = parseJob(jobPath);
-  const errors = validateJob(parsed);
-  if (errors.length > 0) die(`generated invalid job ${relativeJobPath}:\n- ${errors.join("\n- ")}`);
-  written.push({
-    status: "written",
-    job: relativeJobPath,
-    number: result.number,
-    signals: result.signals,
-  });
+if (/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) {
+  console.log(JSON.stringify(runRepoIntake(repo, repoModeOutDir(repo)), null, 2));
+} else if (allOpen) {
+  console.log(JSON.stringify(runAuthorWideIntake(), null, 2));
+} else {
+  die("--repo owner/name is required unless --all-open is set");
 }
 
-console.log(
-  JSON.stringify(
-    {
-      status: "ok",
-      repo,
-      author,
-      scanned: prs.length,
-      candidates: results.length,
-      dry_run: dryRun,
-      jobs: written,
-    },
-    null,
-    2,
-  ),
-);
+function runAuthorWideIntake() {
+  const pullRequests = fetchAuthorOpenPullRequests({ author, limit });
+  const repositories = Array.from(
+    new Set(pullRequests.map((pr) => repoNameWithOwner(pr)).filter(Boolean)),
+  ).sort();
+  const summaries = repositories.map((targetRepo) =>
+    runRepoIntake(targetRepo, authorWideOutDir(targetRepo)),
+  );
 
+  return {
+    status: "ok",
+    mode: "author-wide",
+    author,
+    state: "open",
+    searched: pullRequests.length,
+    repos_scanned: summaries.length,
+    scanned: summaries.reduce((sum, summary) => sum + Number(summary.scanned ?? 0), 0),
+    candidates: summaries.reduce((sum, summary) => sum + Number(summary.candidates ?? 0), 0),
+    dry_run: dryRun,
+    jobs: summaries.flatMap((summary) => (Array.isArray(summary.jobs) ? summary.jobs : [])),
+    repositories: summaries,
+  };
+}
+
+function runRepoIntake(targetRepo: string, outDir: string): LooseRecord {
+  repo = targetRepo;
+  const prs = fetchOpenPullRequests({ repo: targetRepo, author, limit });
+  const results = prs
+    .map((pr) => candidateResult(pr))
+    .filter((result) => result.signals.length >= minSignals);
+
+  if (!dryRun) fs.mkdirSync(outDir, { recursive: true });
+
+  const written: LooseRecord[] = [];
+  for (const result of results) {
+    const clusterId = slug(`repair-pr-${targetRepo.replace("/", "-")}-${result.number}`);
+    const jobPath = path.join(outDir, `${clusterId}.md`);
+    const relativeJobPath = path.relative(repoRoot(), jobPath);
+    const branch = `clawsweeper/${clusterId}`;
+    const body = renderJob({ result, clusterId, branch });
+    if (dryRun) {
+      written.push({
+        status: "planned",
+        job: relativeJobPath,
+        number: result.number,
+        signals: result.signals,
+      });
+      continue;
+    }
+    if (fs.existsSync(jobPath) && !force) {
+      written.push({
+        status: "exists",
+        job: relativeJobPath,
+        number: result.number,
+        signals: result.signals,
+      });
+      continue;
+    }
+    fs.writeFileSync(jobPath, body, "utf8");
+    const parsed = parseJob(jobPath);
+    const errors = validateJob(parsed);
+    if (errors.length > 0)
+      die(`generated invalid job ${relativeJobPath}:\n- ${errors.join("\n- ")}`);
+    written.push({
+      status: "written",
+      job: relativeJobPath,
+      number: result.number,
+      signals: result.signals,
+    });
+  }
+
+  return {
+    status: "ok",
+    repo: targetRepo,
+    author,
+    scanned: prs.length,
+    candidates: results.length,
+    dry_run: dryRun,
+    jobs: written,
+  };
+}
+
+function repoModeOutDir(targetRepo: string): string {
+  const owner = targetRepo.split("/")[0] ?? "unknown";
+  return path.resolve(repoRoot(), outDirArg || `jobs/${owner}/inbox`);
+}
+
+function authorWideOutDir(targetRepo: string): string {
+  const root = outDirArg
+    ? path.resolve(repoRoot(), outDirArg)
+    : path.resolve(repoRoot(), "jobs", "author", slug(author));
+  return path.join(root, slug(targetRepo), "inbox");
+}
+
+function fetchAuthorOpenPullRequests({
+  author,
+  limit,
+}: {
+  author: string;
+  limit: number;
+}): AuthorSearchPullRequest[] {
+  return ghJson<AuthorSearchPullRequest[]>([
+    "search",
+    "prs",
+    "--author",
+    author,
+    "--state",
+    "open",
+    "--limit",
+    String(limit),
+    "--json",
+    "repository",
+  ]);
+}
+
+function repoNameWithOwner(pr: AuthorSearchPullRequest): string {
+  return String(pr.repository?.nameWithOwner ?? "");
+}
 function fetchOpenPullRequests({
   repo,
   author,

--- a/test/repair/pr-repair-intake.test.ts
+++ b/test/repair/pr-repair-intake.test.ts
@@ -65,6 +65,52 @@ test("pr repair intake writes PR repair jobs for failed checks", () => {
   assert.match(job, /pnpm check: conclusion=FAILURE/);
 });
 
+test("pr repair intake supports author-wide open PR discovery", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-pr-intake-"));
+  const bin = path.join(root, "bin");
+  const outDir = path.join(root, "jobs", "runs", "author-wide");
+  fs.mkdirSync(bin);
+  writeFakeGhAuthorWide(bin);
+
+  const output = execFileSync(
+    process.execPath,
+    [
+      scriptPath,
+      "--author",
+      "Jhacarreiro",
+      "--all-open",
+      "--limit",
+      "10",
+      "--no-comments",
+      "--out-dir",
+      outDir,
+    ],
+    {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        PATH: `${path.join(root, "bin")}${path.delimiter}${process.env.PATH ?? ""}`,
+      },
+      encoding: "utf8",
+    },
+  );
+
+  const parsed = JSON.parse(output);
+  assert.equal(parsed.mode, "author-wide");
+  assert.equal(parsed.searched, 2);
+  assert.equal(parsed.repos_scanned, 2);
+  assert.equal(parsed.candidates, 1);
+  assert.equal(parsed.jobs[0].status, "written");
+
+  const jobPath = path.join(
+    outDir,
+    "openclaw-clawsweeper",
+    "inbox",
+    "repair-pr-openclaw-clawsweeper-291.md",
+  );
+  assert.equal(fs.existsSync(jobPath), true);
+});
+
 function runIntake(root: string, extraArgs: string[]): string {
   return execFileSync(
     process.execPath,
@@ -98,6 +144,58 @@ function writeFakeGh(bin: string, prs: unknown[]) {
 const args = process.argv.slice(2);
 if (args[0] === "pr" && args[1] === "list") {
   process.stdout.write(${JSON.stringify(JSON.stringify(prs))});
+  process.exit(0);
+}
+if (args[0] === "api" && args[1] === "graphql") {
+  process.stdout.write(JSON.stringify({
+    data: {
+      repository: {
+        pullRequest: {
+          reviewThreads: { nodes: [] }
+        }
+      }
+    }
+  }));
+  process.exit(0);
+}
+console.error("unexpected gh args", args.join(" "));
+process.exit(1);
+`,
+    { mode: 0o755 },
+  );
+}
+
+function writeFakeGhAuthorWide(bin: string) {
+  const gh = path.join(bin, "gh");
+  fs.writeFileSync(
+    gh,
+    `#!/usr/bin/env node
+const args = process.argv.slice(2);
+const byRepo = {
+  "openclaw/clawsweeper": [
+    {
+      number: 291,
+      title: "failed check",
+      url: "https://github.com/openclaw/clawsweeper/pull/291",
+      mergeStateStatus: "CLEAN",
+      reviewDecision: "",
+      statusCheckRollup: [{ name: "pnpm check", conclusion: "FAILURE", status: "COMPLETED" }],
+      comments: [],
+      reviews: [],
+      updatedAt: "2026-06-15T00:00:00Z",
+    },
+  ],
+};
+if (args[0] === "search" && args[1] === "prs") {
+  process.stdout.write(JSON.stringify([
+    { repository: { nameWithOwner: "openclaw/clawsweeper" } },
+    { repository: { nameWithOwner: "readonly/example" } },
+  ]));
+  process.exit(0);
+}
+if (args[0] === "pr" && args[1] === "list") {
+  const repo = args[args.indexOf("--repo") + 1];
+  process.stdout.write(JSON.stringify(byRepo[repo] || []));
   process.exit(0);
 }
 if (args[0] === "api" && args[1] === "graphql") {


### PR DESCRIPTION
## Summary

Adds an author-wide mode to repair PR intake:

```bash
corepack pnpm run repair:pr-intake -- --author <login> --all-open
```

The existing repo-scoped mode remains unchanged:

```bash
corepack pnpm run repair:pr-intake -- --repo owner/name --author <login>
```

## Why

The current repair intake can only scan one repository at a time. That is the wrong primitive for a maintainer workflow where the useful question is:

> Which open PRs authored by this user currently need repair, across GitHub?

This PR makes `author` usable as the discovery axis. It asks GitHub for open PRs by author, groups the result by repository, and then reuses the existing repo-scoped intake logic for each discovered repository.

## Behaviour

In `--all-open` mode the command:

1. runs `gh search prs --author <login> --state open`;
2. extracts each result's `repository.nameWithOwner`;
3. deduplicates repositories;
4. runs the existing PR intake for each repository with the same author and limit;
5. writes jobs under `<out-dir>/<repo-slug>/inbox/`;
6. returns a single aggregate JSON summary with `searched`, `repos_scanned`, `scanned`, `candidates`, `jobs`, and per-repository summaries.

It does not use `target_inventory`, repository owners, repository dispatch, or GitHub Actions.

## Safety model

This mode only discovers and evaluates **open PRs authored by the requested login**. It does not broaden intake to issues, closed PRs, merged PRs, branches, or repository-owner sweeps.

The generated jobs keep the existing repair-intake guardrails: no merge, no close, human required for merge, and repair-only intent.

## Validation

```bash
corepack pnpm run build:repair
node --test test/repair/pr-repair-intake.test.ts
```

Real dry-run against the current token/user:

```bash
node dist/repair/pr-repair-intake.js \
  --author Jhacarreiro \
  --all-open \
  --limit 100 \
  --no-comments \
  --dry-run \
  --out-dir jobs/runs/author-wide-dry-run-20260617B
```

Observed summary:

```text
searched=12
repos_scanned=6
scanned=12
candidates=6
jobs=6
```
