### PR TITLE
fix(review): lengthen exact capacity wait

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -395,7 +395,7 @@ jobs:
             --repo "${{ github.repository }}" \
             --run-id "${{ github.run_id }}" \
             --poll-ms 120000 \
-            --timeout-ms 1200000
+            --timeout-ms 2400000
 
       - name: Requeue capacity-blocked exact review
         id: capacity-requeue

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -19832,6 +19832,7 @@ test("sweep workflow admits exact event reviews through an exact-review semaphor
   assert.match(eventReviewBlock, /pnpm run repair:codex-capacity/);
   assert.match(eventReviewBlock, /--run-id "\$\{\{ github\.run_id \}\}"/);
   assert.match(eventReviewBlock, /--poll-ms 120000/);
+  assert.match(eventReviewBlock, /--timeout-ms 2400000/);
   assert.match(eventReviewBlock, /--state "Waiting for Codex capacity"/);
   assert.match(eventReviewBlock, /exact-review semaphore admitted this run/);
   assert.match(eventReviewBlock, /CAPACITY_OUTCOME: \$\{\{ steps\.codex-capacity\.outcome \}\}/);


### PR DESCRIPTION
## Summary
- Increase exact-review capacity admission wait from 20 minutes to 40 minutes.
- Keep the wait before Codex setup so capacity pressure still does not start full review work early.
- Pin the sweep workflow assertion for the 40-minute admission timeout.

## Rationale
https://github.com/openclaw/clawsweeper/pull/294 introduced the exact-review semaphore with a 20-minute wait, but a healthy admitted exact-review slot can run for roughly the per-item 20-minute Codex budget plus the 8-minute media reserve and 3-minute margin before cleanup. A fifth run behind four healthy long reviews could therefore time out and fall into the https://github.com/openclaw/clawsweeper/pull/312 requeue path even under normal saturation.

40 minutes lets one full occupied slot clear in the original run, leaving bounded requeue as a fallback for real saturation or transient Actions visibility issues.

## Validation
- `node --test --test-name-pattern "sweep workflow admits exact event reviews through an exact-review semaphore" test/clawsweeper.test.ts`
- `pnpm run check`
