### PR TITLE
Clarify offline default branch planning

### DIFF
--- a/src/repair/plan-cluster.ts
+++ b/src/repair/plan-cluster.ts
@@ -732,10 +732,10 @@ function fetchDefaultBranchName(repo: string) {
 
 function offlineMainBranch(repo: string) {
   return {
-    name: "main",
+    name: "unknown",
     sha: null,
-    url: `https://github.com/${repo}/tree/main`,
-    note: "offline mode did not fetch current main",
+    url: `https://github.com/${repo}`,
+    note: "offline mode did not fetch current default branch",
   };
 }
 

--- a/test/repair/plan-cluster.test.ts
+++ b/test/repair/plan-cluster.test.ts
@@ -97,6 +97,51 @@ test("plan-cluster hydrates the repository default branch instead of hard-coding
   });
 });
 
+test("plan-cluster offline mode does not pretend the default branch is main", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-plan-offline-default-"));
+  const jobPath = path.join(tmp, "job.md");
+  const runDir = path.join(tmp, "run");
+
+  fs.writeFileSync(
+    jobPath,
+    [
+      "---",
+      "repo: openclaw/openclaw",
+      "cluster_id: issue-implementation-openclaw-openclaw-74134",
+      "mode: autonomous",
+      "allowed_actions:",
+      "  - comment",
+      "canonical:",
+      "  - #74134",
+      "candidates:",
+      "  - #74134",
+      "allow_fix_pr: false",
+      "security_policy: central_security_only",
+      "security_sensitive: false",
+      "---",
+      "Plan this item.",
+      "",
+    ].join("\n"),
+  );
+
+  execFileSync(
+    process.execPath,
+    ["dist/repair/plan-cluster.js", jobPath, "--run-dir", runDir, "--offline"],
+    {
+      cwd: process.cwd(),
+      stdio: "pipe",
+    },
+  );
+
+  const clusterPlan = JSON.parse(fs.readFileSync(path.join(runDir, "cluster-plan.json"), "utf8"));
+  assert.deepEqual(clusterPlan.main, {
+    name: "unknown",
+    sha: null,
+    url: "https://github.com/openclaw/openclaw",
+    note: "offline mode did not fetch current default branch",
+  });
+});
+
 test("plan-cluster allows security repair for adopted PR autofix jobs", () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-plan-security-autofix-"));
   const jobPath = path.join(tmp, "job.md");


### PR DESCRIPTION
## Summary

Avoid reporting `main` as the repository branch when plan-cluster runs in offline mode and cannot hydrate the real default branch.

Online planning already asks GitHub for `default_branch`. Offline planning cannot know that value, so the artifact should mark it as unknown instead of fabricating a `main` branch URL.

## Changes

- Change the offline branch fallback from `main` to `unknown`.
- Point the offline URL at the repository rather than `/tree/main`.
- Add a regression test for offline planning output.

## Validation

- `corepack pnpm run build:repair`
- `node --test test/repair/plan-cluster.test.ts`
