### PR TITLE
Clarify rebase conflict repair prompts

### DIFF
--- a/src/repair/fix-prompt-builder.test.ts
+++ b/src/repair/fix-prompt-builder.test.ts
@@ -144,6 +144,7 @@ test("fix prompt includes rebase and previous no-diff recovery details", () => {
       base_ref: "origin/main",
       base_sha: "def456",
       detail: "CONFLICT (content): CHANGELOG.md",
+      unmerged_paths: ["CHANGELOG.md", "src/messages.ts"],
     },
     maxEditAttempts: 5,
   });
@@ -153,7 +154,11 @@ test("fix prompt includes rebase and previous no-diff recovery details", () => {
   assert.match(prompt, /Existing repair branch detected/);
   assert.match(prompt, /Source head before edit: abc123/);
   assert.match(prompt, /Deterministic pre-edit rebase: conflicts onto origin\/main \(def456\)/);
-  assert.match(prompt, /Resolve the active rebase conflicts/);
+  assert.match(prompt, /Conflict-first mode:/);
+  assert.match(prompt, /resolve only the active rebase conflicts before doing any feature repair/);
+  assert.match(prompt, /git status --short/);
+  assert.match(prompt, /git rebase --continue/);
+  assert.match(prompt, /Unmerged conflict paths: CHANGELOG\.md, src\/messages\.ts/);
   assert.match(prompt, /Rebase output: CONFLICT \(content\): CHANGELOG\.md/);
   assert.match(prompt, /Previous attempt produced no target repo diff/);
   assert.match(prompt, /Previous no-diff summary: Analyzed without editing files/);

--- a/src/repair/fix-prompt-builder.ts
+++ b/src/repair/fix-prompt-builder.ts
@@ -284,10 +284,23 @@ function renderRebaseResult(rebaseResult: LooseRecord) {
   const baseRef = String(rebaseResult.base_ref ?? "origin/main");
   const baseSha = String(rebaseResult.base_sha ?? "unknown");
   const detail = compactText(String(rebaseResult.detail ?? "").trim(), 800);
+  const unmergedPaths = Array.isArray(rebaseResult.unmerged_paths)
+    ? rebaseResult.unmerged_paths.map((entry: unknown) => String(entry)).filter(Boolean)
+    : [];
   return [
     `Deterministic pre-edit rebase: ${status} onto ${baseRef} (${baseSha}).`,
     status === "conflicts"
-      ? "Resolve the active rebase conflicts, continue or finish the rebase, and leave the checkout in a normal non-rebasing state before returning."
+      ? [
+          "Conflict-first mode:",
+          "- resolve only the active rebase conflicts before doing any feature repair;",
+          "- inspect `git status --short` and the conflicted files listed below;",
+          "- remove all conflict markers and stage the resolved files;",
+          "- run `git rebase --continue` until the checkout is no longer rebasing;",
+          "- do not broaden the patch while conflicts remain.",
+        ].join("\n")
+      : "",
+    status === "conflicts" && unmergedPaths.length > 0
+      ? `Unmerged conflict paths: ${unmergedPaths.join(", ")}`
       : "",
     detail ? `Rebase output: ${detail}` : "",
   ]


### PR DESCRIPTION
## Summary

Make repair prompts more explicit when a deterministic pre-edit rebase reports conflicts.

Instead of a single generic sentence, the prompt now enters a conflict-first mode that tells the editor to resolve the active rebase conflicts before broadening the repair patch.

## Changes

- Render conflict-first instructions for conflicted rebase results.
- Include known unmerged paths when the rebase result provides them.
- Extend the fix-prompt regression test to cover the new conflict-first guidance.

## Validation

- `corepack pnpm run build:repair`
- `node --test dist/repair/fix-prompt-builder.test.js`
