### PR TITLE
Add docs site dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ checkpoint, and status-only commits are intentionally omitted.
 ### Added
 
 - Added author-wide PR repair intake across configured public repositories, with private and unsupported repositories excluded before job generation. Thanks @Jhacarreiro.
+- Added a system, light, and dark theme switcher to the generated documentation site. Thanks @joshka.
 
 ### Changed
 

--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -405,7 +405,7 @@ function layout({ page, html, toc, prev, next, sectionName }) {
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>${escapeHtml(page.title)}${isHome ? " - Conservative maintenance bot" : " - ClawSweeper Docs"}</title>
   <meta name="description" content="${escapeAttr(description)}">
-  <meta name="theme-color" content="#0b1f24">
+  <meta name="theme-color" content="#f4ead7">
   <meta property="og:title" content="${escapeAttr(page.title)}${isHome ? " - ClawSweeper" : " - ClawSweeper docs"}">
   <meta property="og:description" content="${escapeAttr(description)}">
   <meta property="og:type" content="website">
@@ -421,6 +421,7 @@ function layout({ page, html, toc, prev, next, sectionName }) {
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,500;0,600;0,700;1,500&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  ${themeInitScript()}
   <style>${css()}</style>
 </head>
 <body${isHome ? ' class="home"' : ""}>
@@ -436,9 +437,19 @@ function layout({ page, html, toc, prev, next, sectionName }) {
       <label class="search"><span>Search docs</span><input id="doc-search" type="search" placeholder="commits, repair, dispatch"></label>
       <nav>${navHtml(page.rel, rootPrefix)}</nav>
       <div class="sidebar-foot">
-        <a href="${repoUrl}" rel="noopener">GitHub</a>
-        <span>·</span>
-        <a href="${repoUrl}/issues" rel="noopener">Issues</a>
+        <div class="theme-control" aria-label="Theme">
+          <span>Theme</span>
+          <div class="theme-options" role="group" aria-label="Theme preference">
+            <button type="button" data-theme-choice="system" aria-pressed="true">System</button>
+            <button type="button" data-theme-choice="light" aria-pressed="false">Light</button>
+            <button type="button" data-theme-choice="dark" aria-pressed="false">Dark</button>
+          </div>
+        </div>
+        <div class="sidebar-links">
+          <a href="${repoUrl}" rel="noopener">GitHub</a>
+          <span>·</span>
+          <a href="${repoUrl}/issues" rel="noopener">Issues</a>
+        </div>
       </div>
     </aside>
     <main>
@@ -638,6 +649,25 @@ function sitemap(pages) {
   return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>\n`;
 }
 
+function themeInitScript() {
+  return `<script>
+(() => {
+  const key = "clawsweeper-theme";
+  const themes = new Set(["system", "light", "dark"]);
+  const darkQuery = window.matchMedia?.("(prefers-color-scheme: dark)");
+  const themeColor = { light: "#f4ead7", dark: "#081417" };
+  let choice = "system";
+  try {
+    const saved = window.localStorage?.getItem(key);
+    if (themes.has(saved)) choice = saved;
+  } catch {}
+  const active = choice === "system" && darkQuery?.matches ? "dark" : choice === "dark" ? "dark" : "light";
+  document.documentElement.dataset.theme = active;
+  document.querySelector('meta[name="theme-color"]')?.setAttribute("content", themeColor[active]);
+})();
+</script>`;
+}
+
 function css() {
   return `
 :root{
@@ -648,6 +678,7 @@ function css() {
   --tide:#0a6a72;
   --kelp:#13848e;
   --coral:#ec5b3c;
+  --accent-text:#b6422d;
   --crab:#d9472b;
   --sun:#f4a93a;
   --sand:#e9d7b1;
@@ -657,52 +688,143 @@ function css() {
   --code-bg:#0a1d20;
   --code-fg:#f1e3c8;
   --shadow:0 24px 60px -28px rgba(6,24,28,.35);
+  --home-bg:linear-gradient(180deg,#fbf1de 0%,#f4ead7 38%,#ecdec0 100%);
+  --page-glow:radial-gradient(800px 500px at 110% -10%,rgba(236,91,60,.08),transparent 60%),radial-gradient(700px 500px at -10% 110%,rgba(10,106,114,.10),transparent 60%);
+  --sidebar-bg:rgba(253,246,233,.78);
+  --sidebar-mobile-bg:var(--paper);
+  --body-text:#293836;
+  --body-text-soft:#3b4a48;
+  --focus-ring:rgba(236,91,60,.20);
+  --nav-hover-bg:rgba(236,91,60,.08);
+  --nav-active-bg:#f0e0bf;
+  --inline-code-bg:#f0e0bf;
+  --inline-code-line:#e2cf9f;
+  --feature-bg:rgba(253,246,233,.86);
+  --feature-icon-bg:linear-gradient(135deg,#fbe2cf,#f4a93a55);
+  --feature-hover-shadow:0 16px 30px -16px rgba(11,58,63,.25);
+  --lane-bg:linear-gradient(180deg,rgba(253,246,233,.96),rgba(244,234,215,.6));
+  --lane-hover-shadow:0 16px 30px -14px rgba(217,71,43,.22);
+  --rules-bg:linear-gradient(135deg,rgba(11,58,63,.06),rgba(236,91,60,.04));
+  --code-border:#06141660;
+  --code-scroll:#3a4a47;
+  --code-copy-bg:rgba(253,246,233,.06);
+  --code-copy-line:rgba(253,246,233,.18);
+  --code-copy-hover:rgba(253,246,233,.14);
+  --code-comment:#7e948f;
+  --blockquote-bg:#f3e3c5;
+  --pager-shadow:0 6px 18px rgba(11,58,63,.10);
+  --toggle-shadow:0 6px 18px rgba(6,24,28,.14);
+  --sidebar-shadow:0 18px 40px rgba(6,24,28,.18);
+  --art-shadow:drop-shadow(0 30px 50px rgba(217,71,43,.22));
+  --brand-shadow:drop-shadow(0 4px 10px rgba(217,71,43,.25));
+  --selected-shadow:0 1px 6px rgba(6,24,28,.10);
+  --snippet-shadow:0 24px 50px -22px rgba(6,24,28,.4);
+  --cta-shadow:0 8px 22px rgba(11,58,63,.3);
+}
+html[data-theme="dark"]{
+  --ink:#edf4ed;
+  --paper:#102023;
+  --shell:#081417;
+  --reef:#9ed4d1;
+  --tide:#72d0d8;
+  --kelp:#60c0aa;
+  --coral:#ff7a5c;
+  --accent-text:#ff8a70;
+  --crab:#f05f42;
+  --sun:#f5bf65;
+  --sand:#594d37;
+  --line:#314448;
+  --line-soft:#23363a;
+  --muted:#a6b8b4;
+  --code-bg:#061013;
+  --code-fg:#f6e5c8;
+  --shadow:0 28px 70px -34px rgba(0,0,0,.86);
+  --home-bg:linear-gradient(180deg,#09191c 0%,#0b171a 42%,#101b1d 100%);
+  --page-glow:radial-gradient(800px 500px at 110% -10%,rgba(255,122,92,.12),transparent 62%),radial-gradient(700px 500px at -10% 110%,rgba(114,208,216,.10),transparent 60%);
+  --sidebar-bg:rgba(11,25,28,.82);
+  --sidebar-mobile-bg:#0d1b1e;
+  --body-text:#d3dfdc;
+  --body-text-soft:#c0cfcb;
+  --focus-ring:rgba(255,122,92,.28);
+  --nav-hover-bg:rgba(255,122,92,.13);
+  --nav-active-bg:#213539;
+  --inline-code-bg:#1b3032;
+  --inline-code-line:#385054;
+  --feature-bg:rgba(16,32,35,.88);
+  --feature-icon-bg:linear-gradient(135deg,rgba(255,122,92,.24),rgba(245,191,101,.20));
+  --feature-hover-shadow:0 18px 34px -20px rgba(0,0,0,.75);
+  --lane-bg:linear-gradient(180deg,rgba(16,32,35,.96),rgba(10,22,25,.72));
+  --lane-hover-shadow:0 18px 34px -20px rgba(0,0,0,.82);
+  --rules-bg:linear-gradient(135deg,rgba(114,208,216,.10),rgba(255,122,92,.08));
+  --code-border:#22383d;
+  --code-scroll:#52686a;
+  --code-copy-bg:rgba(246,229,200,.08);
+  --code-copy-line:rgba(246,229,200,.22);
+  --code-copy-hover:rgba(246,229,200,.15);
+  --code-comment:#9eb3ad;
+  --blockquote-bg:#1c2d2f;
+  --pager-shadow:0 8px 22px rgba(0,0,0,.36);
+  --toggle-shadow:0 8px 22px rgba(0,0,0,.38);
+  --sidebar-shadow:0 18px 44px rgba(0,0,0,.54);
+  --art-shadow:drop-shadow(0 30px 56px rgba(0,0,0,.45));
+  --brand-shadow:drop-shadow(0 4px 10px rgba(255,122,92,.20));
+  --selected-shadow:0 1px 8px rgba(0,0,0,.34);
+  --snippet-shadow:0 24px 50px -22px rgba(0,0,0,.78);
+  --cta-shadow:0 8px 22px rgba(0,0,0,.34);
 }
 *{box-sizing:border-box}
 html{scroll-behavior:smooth;scroll-padding-top:24px}
 body{margin:0;background:var(--shell);color:var(--ink);font-family:Inter,"IBM Plex Sans",system-ui,sans-serif;line-height:1.65;overflow-x:hidden;-webkit-font-smoothing:antialiased;font-feature-settings:"ss01","cv11"}
-body.home{background:linear-gradient(180deg,#fbf1de 0%,#f4ead7 38%,#ecdec0 100%)}
-body:before{content:"";position:fixed;inset:0;pointer-events:none;background:radial-gradient(800px 500px at 110% -10%,rgba(236,91,60,.08),transparent 60%),radial-gradient(700px 500px at -10% 110%,rgba(10,106,114,.10),transparent 60%);z-index:-1}
+body.home{background:var(--home-bg)}
+body:before{content:"";position:fixed;inset:0;pointer-events:none;background:var(--page-glow);z-index:-1}
 ::selection{background:var(--coral);color:var(--paper)}
 a{color:var(--tide);text-decoration-thickness:.07em;text-underline-offset:.18em;transition:color .15s}
-a:hover{color:var(--coral)}
+a:hover{color:var(--accent-text)}
 .shell{display:grid;grid-template-columns:288px minmax(0,1fr);min-height:100vh}
 
 /* sidebar */
-.sidebar{position:sticky;top:0;height:100vh;overflow:auto;padding:24px 20px 14px;background:rgba(253,246,233,.78);border-right:1px solid var(--line);backdrop-filter:blur(20px);scrollbar-width:thin;scrollbar-color:var(--line) transparent;display:flex;flex-direction:column}
+.sidebar{position:sticky;top:0;height:100vh;overflow:auto;padding:24px 20px 14px;background:var(--sidebar-bg);border-right:1px solid var(--line);backdrop-filter:blur(20px);scrollbar-width:thin;scrollbar-color:var(--line) transparent;display:flex;flex-direction:column}
 .sidebar::-webkit-scrollbar{width:6px}
 .sidebar::-webkit-scrollbar-thumb{background:var(--line);border-radius:6px}
 .brand{display:flex;align-items:center;gap:11px;color:var(--ink);text-decoration:none;margin-bottom:22px}
-.brand img{width:46px;height:46px;filter:drop-shadow(0 4px 10px rgba(217,71,43,.25))}
+.brand img{width:46px;height:46px;filter:var(--brand-shadow)}
 .brand strong{display:block;font-family:Fraunces,Georgia,serif;font-size:1.36rem;line-height:1;letter-spacing:-.005em;font-weight:700}
 .brand small{display:block;color:var(--muted);font-size:.74rem;margin-top:5px;letter-spacing:.01em}
 .search{display:block;margin:0 0 22px}
 .search span{display:block;color:var(--muted);font-size:.7rem;font-weight:700;text-transform:uppercase;letter-spacing:.1em;margin-bottom:7px}
 .search input{width:100%;border:1px solid var(--line);background:var(--paper);border-radius:9px;padding:10px 12px;font:inherit;font-size:.92rem;color:var(--ink);outline:none;transition:border-color .15s,box-shadow .15s}
-.search input:focus{border-color:var(--coral);box-shadow:0 0 0 3px rgba(236,91,60,.20)}
+.search input:focus{border-color:var(--coral);box-shadow:0 0 0 3px var(--focus-ring)}
+.theme-control{display:grid;grid-template-columns:auto minmax(0,1fr);align-items:center;gap:8px;color:var(--muted)}
+.theme-control>span{font-size:.68rem;font-weight:700;text-transform:uppercase;letter-spacing:.1em}
+.theme-options{display:grid;grid-template-columns:repeat(3,1fr);gap:1px;border:1px solid var(--line-soft);background:transparent;border-radius:8px;padding:2px}
+.theme-options button{appearance:none;border:0;border-radius:6px;background:transparent;color:var(--muted);font:700 .66rem/1 Inter,sans-serif;padding:5px 4px;cursor:pointer;transition:background .15s,color .15s,box-shadow .15s}
+.theme-options button:hover{color:var(--ink);background:var(--nav-hover-bg)}
+.theme-options button:focus-visible{outline:0;box-shadow:0 0 0 3px var(--focus-ring)}
+.theme-options button[aria-pressed="true"]{background:var(--paper);color:var(--ink);box-shadow:var(--selected-shadow)}
 nav section{margin:0 0 18px}
 nav h2{font-size:.66rem;color:var(--muted);text-transform:uppercase;letter-spacing:.13em;margin:0 0 6px;font-weight:700}
 .nav-link{display:block;color:var(--ink);text-decoration:none;border-radius:7px;padding:6px 10px;margin:1px 0;font-size:.91rem;line-height:1.4;border-left:2px solid transparent;transition:background .12s,color .12s}
-.nav-link:hover{background:rgba(236,91,60,.08);color:var(--reef)}
-.nav-link.active{background:#f0e0bf;color:var(--reef);border-left-color:var(--coral);font-weight:600}
-.sidebar-foot{margin-top:auto;padding-top:12px;border-top:1px solid var(--line-soft);font-size:.78rem;color:var(--muted);display:flex;gap:8px;align-items:center}
+.nav-link:hover{background:var(--nav-hover-bg);color:var(--reef)}
+.nav-link.active{background:var(--nav-active-bg);color:var(--reef);border-left-color:var(--coral);font-weight:600}
+.sidebar-foot{margin-top:auto;padding-top:12px;border-top:1px solid var(--line-soft);font-size:.78rem;color:var(--muted);display:grid;gap:10px}
+.sidebar-links{display:flex;gap:8px;align-items:center}
 .sidebar-foot a{color:var(--muted);text-decoration:none}
-.sidebar-foot a:hover{color:var(--coral)}
+.sidebar-foot a:hover{color:var(--accent-text)}
 
 /* main */
 main{min-width:0;padding:28px clamp(20px,4.5vw,60px) 36px;max-width:1240px;margin:0 auto;width:100%;display:flex;flex-direction:column;min-height:100vh}
 .page-foot{margin-top:auto;padding:24px 0 0;display:flex;justify-content:space-between;color:var(--muted);font-size:.8rem;flex-wrap:wrap;gap:8px;border-top:1px dashed var(--line);margin-top:48px}
 .page-foot a{color:var(--muted)}
-.page-foot a:hover{color:var(--coral)}
+.page-foot a:hover{color:var(--accent-text)}
 
 .hero{display:flex;align-items:flex-end;justify-content:space-between;gap:22px;border-bottom:1px solid var(--line);padding:18px 0 22px;position:relative;flex-wrap:wrap}
 .hero:after{content:"";position:absolute;left:0;bottom:-1px;width:96px;height:3px;background:linear-gradient(90deg,var(--coral),var(--sun),var(--kelp));border-radius:3px}
 .hero-text{min-width:0;flex:1 1 320px}
-.eyebrow{margin:0 0 8px;color:var(--coral);font-weight:700;text-transform:uppercase;letter-spacing:.14em;font-size:.72rem}
+.eyebrow{margin:0 0 8px;color:var(--accent-text);font-weight:700;text-transform:uppercase;letter-spacing:.14em;font-size:.72rem}
 .hero h1{font-family:Fraunces,Georgia,serif;font-size:clamp(1.9rem,3.4vw,2.85rem);line-height:1.05;letter-spacing:-.005em;margin:0;font-weight:700;color:var(--ink)}
 .hero-meta{display:flex;gap:8px;flex:0 0 auto}
 .repo,.edit{border:1px solid var(--line);color:var(--ink);text-decoration:none;border-radius:9px;padding:7px 12px;font-weight:600;font-size:.84rem;background:var(--paper);transition:border-color .15s,color .15s}
-.repo:hover,.edit:hover{border-color:var(--coral);color:var(--coral)}
+.repo:hover,.edit:hover{border-color:var(--coral);color:var(--accent-text)}
 .edit{color:var(--muted)}
 
 /* landing hero */
@@ -710,20 +832,22 @@ main{min-width:0;padding:28px clamp(20px,4.5vw,60px) 36px;max-width:1240px;margi
 .hero-home:after{display:none}
 .hero-home .eyebrow{margin-bottom:14px}
 .hero-home h1{font-size:clamp(2.2rem,5vw,4rem);line-height:1.0;letter-spacing:-.018em;font-weight:700;margin:0 0 18px;max-width:18ch}
-.hero-home h1 em{font-style:italic;color:var(--coral);font-weight:600}
-.lede{margin:0 0 22px;color:#293836;font-size:clamp(1rem,1.25vw,1.13rem);line-height:1.55;max-width:48ch}
-.lede.small{font-size:.96rem;color:#3b4a48}
-.lede code{background:#f0e0bf;border:1px solid #e2cf9f;border-radius:5px;padding:.04em .3em;font-size:.86em}
+.hero-home h1 em{font-style:italic;color:var(--accent-text);font-weight:600}
+.lede{margin:0 0 22px;color:var(--body-text);font-size:clamp(1rem,1.25vw,1.13rem);line-height:1.55;max-width:48ch}
+.lede.small{font-size:.96rem;color:var(--body-text-soft)}
+.lede code{background:var(--inline-code-bg);border:1px solid var(--inline-code-line);border-radius:5px;padding:.04em .3em;font-size:.86em}
 .cta{display:flex;gap:10px;flex-wrap:wrap;margin-bottom:14px}
 .cta-primary,.cta-secondary{display:inline-flex;align-items:center;border-radius:10px;padding:11px 18px;font-weight:600;font-size:.95rem;text-decoration:none;transition:transform .15s,box-shadow .15s,background .15s,border-color .15s,color .15s}
 .cta-primary{background:var(--ink);color:var(--paper);border:1px solid var(--ink)}
-.cta-primary:hover{background:var(--reef);border-color:var(--reef);color:var(--paper);transform:translateY(-1px);box-shadow:0 8px 22px rgba(11,58,63,.3)}
+.cta-primary:hover{background:var(--reef);border-color:var(--reef);color:var(--paper);transform:translateY(-1px);box-shadow:var(--cta-shadow)}
 .cta-secondary{border:1px solid var(--ink);color:var(--ink);background:transparent}
-.cta-secondary:hover{border-color:var(--coral);color:var(--coral);transform:translateY(-1px)}
+.cta-secondary:hover{border-color:var(--coral);color:var(--accent-text);transform:translateY(-1px)}
 .cta-foot{margin:6px 0 0;color:var(--muted);font-size:.84rem;font-style:italic}
 
 .hero-art{position:relative;display:flex;align-items:center;justify-content:center;min-height:340px}
-.hero-art svg{width:min(440px,90%);height:auto;filter:drop-shadow(0 30px 50px rgba(217,71,43,.22))}
+.hero-art svg{width:min(440px,90%);height:auto;filter:var(--art-shadow)}
+html[data-theme="dark"] .hero-art svg [stroke="#0b3a3f"]{stroke:#123c43}
+html[data-theme="dark"] .hero-art svg [fill="#06181c"]{fill:#081417}
 .hero-art .crab-body{transform-origin:center;animation:sway 6s ease-in-out infinite}
 .hero-art .claw-l{transform-origin:88px 142px;animation:snip-l 4s ease-in-out infinite}
 .hero-art .claw-r{transform-origin:312px 142px;animation:snip-r 4s ease-in-out infinite}
@@ -738,51 +862,51 @@ main{min-width:0;padding:28px clamp(20px,4.5vw,60px) 36px;max-width:1240px;margi
 
 /* feature cards on landing */
 .features-row{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:14px;margin:42px 0 6px}
-.feature{background:rgba(253,246,233,.86);border:1px solid var(--line-soft);border-radius:14px;padding:22px 22px 20px;transition:border-color .15s,transform .15s,box-shadow .15s;position:relative;overflow:hidden}
-.feature:hover{border-color:var(--coral);transform:translateY(-2px);box-shadow:0 16px 30px -16px rgba(11,58,63,.25)}
-.feature-icon{display:inline-flex;width:38px;height:38px;border-radius:10px;background:linear-gradient(135deg,#fbe2cf,#f4a93a55);align-items:center;justify-content:center;margin-bottom:12px;color:var(--reef)}
+.feature{background:var(--feature-bg);border:1px solid var(--line-soft);border-radius:14px;padding:22px 22px 20px;transition:border-color .15s,transform .15s,box-shadow .15s;position:relative;overflow:hidden}
+.feature:hover{border-color:var(--coral);transform:translateY(-2px);box-shadow:var(--feature-hover-shadow)}
+.feature-icon{display:inline-flex;width:38px;height:38px;border-radius:10px;background:var(--feature-icon-bg);align-items:center;justify-content:center;margin-bottom:12px;color:var(--reef)}
 .feature-icon svg{width:22px;height:22px}
 .feature h3{font-family:Fraunces,Georgia,serif;font-size:1.12rem;margin:0 0 6px;font-weight:600;letter-spacing:-.005em;line-height:1.2}
-.feature p{margin:0;color:#293836;font-size:.94rem;line-height:1.55}
-.feature code{font-size:.82em;background:#f0e0bf;border:1px solid #e2cf9f;border-radius:5px;padding:.04em .3em;font-family:"JetBrains Mono",ui-monospace,monospace}
+.feature p{margin:0;color:var(--body-text);font-size:.94rem;line-height:1.55}
+.feature code{font-size:.82em;background:var(--inline-code-bg);border:1px solid var(--inline-code-line);border-radius:5px;padding:.04em .3em;font-family:"JetBrains Mono",ui-monospace,monospace}
 
 /* snippet row */
 .snippet-row{margin:42px 0 0;display:grid;grid-template-columns:minmax(0,1fr) minmax(0,1.05fr);gap:32px;align-items:center}
 .snippet-text h2{font-family:Fraunces,Georgia,serif;font-size:clamp(1.4rem,2.1vw,1.85rem);margin:0 0 12px;line-height:1.15;letter-spacing:-.005em;font-weight:600}
-.snippet-text p{margin:0 0 14px;color:#293836}
-.snippet-list{margin:0;padding-left:18px;color:#293836}
+.snippet-text p{margin:0 0 14px;color:var(--body-text)}
+.snippet-list{margin:0;padding-left:18px;color:var(--body-text)}
 .snippet-list li{margin:6px 0}
-.snippet{margin:0;background:var(--code-bg);color:var(--code-fg);border-radius:14px;padding:24px 24px;font:500 .9rem/1.65 "JetBrains Mono",ui-monospace,monospace;border:1px solid #06141660;box-shadow:0 24px 50px -22px rgba(6,24,28,.4);overflow:hidden}
+.snippet{margin:0;background:var(--code-bg);color:var(--code-fg);border-radius:14px;padding:24px 24px;font:500 .9rem/1.65 "JetBrains Mono",ui-monospace,monospace;border:1px solid var(--code-border);box-shadow:var(--snippet-shadow);overflow:hidden}
 .snippet code{background:transparent;border:0;padding:0;color:inherit;font:inherit;display:block;white-space:pre}
 .snippet .prompt{color:var(--sun)}
-.snippet .comment{color:#7e948f}
+.snippet .comment{color:var(--code-comment)}
 
 /* lanes row */
 .lanes-row{margin:48px 0 0}
 .lanes-row h2{font-family:Fraunces,Georgia,serif;font-size:clamp(1.4rem,2.1vw,1.85rem);margin:0 0 16px;line-height:1.15;letter-spacing:-.005em;font-weight:600}
 .lanes{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:14px}
-.lane{display:block;background:linear-gradient(180deg,rgba(253,246,233,.96),rgba(244,234,215,.6));border:1px solid var(--line);border-radius:14px;padding:22px 22px 22px;text-decoration:none;color:var(--ink);position:relative;overflow:hidden;transition:transform .15s,border-color .15s,box-shadow .15s}
-.lane:hover{transform:translateY(-2px);border-color:var(--coral);box-shadow:0 16px 30px -14px rgba(217,71,43,.22)}
+.lane{display:block;background:var(--lane-bg);border:1px solid var(--line);border-radius:14px;padding:22px 22px 22px;text-decoration:none;color:var(--ink);position:relative;overflow:hidden;transition:transform .15s,border-color .15s,box-shadow .15s}
+.lane:hover{transform:translateY(-2px);border-color:var(--coral);box-shadow:var(--lane-hover-shadow)}
 .lane-arrow{position:absolute;top:18px;right:20px;color:var(--coral);font-family:"JetBrains Mono",monospace;font-weight:700;font-size:1.05rem;transition:transform .2s}
 .lane:hover .lane-arrow{transform:translateX(4px)}
 .lane h3{font-family:Fraunces,Georgia,serif;font-size:1.18rem;margin:0 0 6px;font-weight:600;letter-spacing:-.005em}
-.lane p{margin:0;color:#3b4a48;font-size:.94rem;line-height:1.55}
-.lane code{background:#f0e0bf;border:1px solid #e2cf9f;border-radius:5px;padding:.04em .3em;font-size:.84em;font-family:"JetBrains Mono",monospace}
+.lane p{margin:0;color:var(--body-text-soft);font-size:.94rem;line-height:1.55}
+.lane code{background:var(--inline-code-bg);border:1px solid var(--inline-code-line);border-radius:5px;padding:.04em .3em;font-size:.84em;font-family:"JetBrains Mono",monospace}
 
 /* rules */
-.rules{margin:48px 0 8px;padding:28px 28px 26px;background:linear-gradient(135deg,rgba(11,58,63,.06),rgba(236,91,60,.04));border:1px solid var(--line);border-radius:18px}
+.rules{margin:48px 0 8px;padding:28px 28px 26px;background:var(--rules-bg);border:1px solid var(--line);border-radius:18px}
 .rules h2{font-family:Fraunces,Georgia,serif;font-size:clamp(1.4rem,2.1vw,1.85rem);margin:0 0 8px;line-height:1.15;letter-spacing:-.005em;font-weight:600}
-.rules-list{list-style:none;padding:0;margin:14px 0 0;display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:8px 18px;color:#293836}
+.rules-list{list-style:none;padding:0;margin:14px 0 0;display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:8px 18px;color:var(--body-text)}
 .rules-list li{position:relative;padding-left:22px;line-height:1.5}
 .rules-list li:before{content:"";position:absolute;left:0;top:.55em;width:10px;height:10px;background:var(--coral);clip-path:polygon(50% 0,100% 50%,50% 100%,0 50%);transform:rotate(0deg)}
-.rules-list code{background:#f0e0bf;border:1px solid #e2cf9f;border-radius:5px;padding:.04em .3em;font-size:.86em;font-family:"JetBrains Mono",monospace}
+.rules-list code{background:var(--inline-code-bg);border:1px solid var(--inline-code-line);border-radius:5px;padding:.04em .3em;font-size:.86em;font-family:"JetBrains Mono",monospace}
 
 /* layout: doc + toc */
 .doc-grid{display:grid;grid-template-columns:minmax(0,1fr);gap:36px;margin-top:30px}
 .doc-grid-home{margin-top:18px}
 .doc-home{background:transparent;box-shadow:none;border:0;padding:0;max-width:none;width:100%}
 @media(min-width:1180px){.doc-grid{grid-template-columns:minmax(0,74ch) 200px;justify-content:start}.doc-grid-home{grid-template-columns:minmax(0,1fr)}}
-.doc{min-width:0;max-width:74ch;background:rgba(253,246,233,.86);box-shadow:var(--shadow);border:1px solid var(--line-soft);border-radius:14px;padding:clamp(22px,3.6vw,44px);overflow-wrap:break-word}
+.doc{min-width:0;max-width:74ch;background:var(--feature-bg);box-shadow:var(--shadow);border:1px solid var(--line-soft);border-radius:14px;padding:clamp(22px,3.6vw,44px);overflow-wrap:break-word}
 .doc h1{display:none}
 .doc h2{font-family:Fraunces,Georgia,serif;font-size:1.7rem;line-height:1.15;margin:1.9em 0 .5em;font-weight:600;letter-spacing:-.005em;position:relative}
 .doc h3{font-size:1.14rem;margin:1.6em 0 .3em;position:relative;font-weight:600}
@@ -790,22 +914,22 @@ main{min-width:0;padding:28px clamp(20px,4.5vw,60px) 36px;max-width:1240px;margi
 .doc h2:first-child,.doc h3:first-child,.doc h4:first-child{margin-top:0}
 .doc :is(h2,h3,h4) .anchor{position:absolute;left:-1em;top:0;color:var(--muted);opacity:0;text-decoration:none;font-weight:400;padding-right:.3em;transition:opacity .12s,color .12s}
 .doc :is(h2,h3,h4):hover .anchor{opacity:.55}
-.doc :is(h2,h3,h4) .anchor:hover{opacity:1;color:var(--coral)}
+.doc :is(h2,h3,h4) .anchor:hover{opacity:1;color:var(--accent-text)}
 .doc p{margin:0 0 1.05em}
 .doc ul,.doc ol{padding-left:1.35rem;margin:0 0 1.2em}
 .doc li{margin:.25em 0}
 .doc li>p{margin:0 0 .4em}
 .doc strong{font-weight:600}
-.doc code{font-family:"JetBrains Mono",ui-monospace,monospace;font-size:.86em;background:#f0e0bf;border:1px solid #e2cf9f;border-radius:5px;padding:.08em .34em}
-.doc pre{position:relative;overflow:auto;background:var(--code-bg);color:var(--code-fg);border-radius:11px;padding:16px 20px;border:1px solid #06141660;box-shadow:inset 0 0 0 1px rgba(255,255,255,.03);margin:1.35em 0;font-size:.88em;scrollbar-width:thin;scrollbar-color:#3a4a47 transparent}
+.doc code{font-family:"JetBrains Mono",ui-monospace,monospace;font-size:.86em;background:var(--inline-code-bg);border:1px solid var(--inline-code-line);border-radius:5px;padding:.08em .34em}
+.doc pre{position:relative;overflow:auto;background:var(--code-bg);color:var(--code-fg);border-radius:11px;padding:16px 20px;border:1px solid var(--code-border);box-shadow:inset 0 0 0 1px rgba(255,255,255,.03);margin:1.35em 0;font-size:.88em;scrollbar-width:thin;scrollbar-color:var(--code-scroll) transparent}
 .doc pre::-webkit-scrollbar{height:8px}
-.doc pre::-webkit-scrollbar-thumb{background:#3a4a47;border-radius:8px}
+.doc pre::-webkit-scrollbar-thumb{background:var(--code-scroll);border-radius:8px}
 .doc pre code{background:transparent;border:0;color:inherit;padding:0;font-size:1em}
-.doc pre .copy{position:absolute;top:8px;right:8px;background:rgba(253,246,233,.06);color:var(--code-fg);border:1px solid rgba(253,246,233,.18);border-radius:6px;padding:3px 9px;font:600 .7rem/1 Inter,sans-serif;cursor:pointer;opacity:0;transition:opacity .15s,background .15s,border-color .15s}
+.doc pre .copy{position:absolute;top:8px;right:8px;background:var(--code-copy-bg);color:var(--code-fg);border:1px solid var(--code-copy-line);border-radius:6px;padding:3px 9px;font:600 .7rem/1 Inter,sans-serif;cursor:pointer;opacity:0;transition:opacity .15s,background .15s,border-color .15s}
 .doc pre:hover .copy,.doc pre .copy:focus{opacity:1}
-.doc pre .copy:hover{background:rgba(253,246,233,.14)}
+.doc pre .copy:hover{background:var(--code-copy-hover)}
 .doc pre .copy.copied{background:var(--coral);border-color:var(--coral);opacity:1}
-.doc blockquote{margin:1.4em 0;padding:12px 16px;border-left:3px solid var(--coral);background:#f3e3c5;border-radius:0 9px 9px 0;color:var(--ink)}
+.doc blockquote{margin:1.4em 0;padding:12px 16px;border-left:3px solid var(--coral);background:var(--blockquote-bg);border-radius:0 9px 9px 0;color:var(--ink)}
 .doc blockquote p:last-child{margin-bottom:0}
 .doc table{width:100%;border-collapse:collapse;margin:1.2em 0;font-size:.94em}
 .doc th,.doc td{border-bottom:1px solid var(--line);padding:9px 10px;text-align:left}
@@ -826,7 +950,7 @@ main{min-width:0;padding:28px clamp(20px,4.5vw,60px) 36px;max-width:1240px;margi
 /* prev/next pager */
 .page-nav{display:grid;grid-template-columns:1fr 1fr;gap:14px;margin-top:48px}
 .page-nav>a{display:block;border:1px solid var(--line);background:var(--paper);border-radius:11px;padding:14px 18px;text-decoration:none;color:var(--ink);transition:border-color .15s,transform .15s,box-shadow .15s}
-.page-nav>a:hover{border-color:var(--coral);transform:translateY(-1px);box-shadow:0 6px 18px rgba(11,58,63,.10)}
+.page-nav>a:hover{border-color:var(--coral);transform:translateY(-1px);box-shadow:var(--pager-shadow)}
 .page-nav small{display:block;color:var(--muted);font-size:.7rem;text-transform:uppercase;letter-spacing:.12em;margin-bottom:5px;font-weight:700}
 .page-nav span{display:block;font-weight:600;line-height:1.3}
 .page-nav-prev{text-align:left}
@@ -834,7 +958,7 @@ main{min-width:0;padding:28px clamp(20px,4.5vw,60px) 36px;max-width:1240px;margi
 .page-nav-prev:only-child{grid-column:1}
 
 /* mobile nav toggle */
-.nav-toggle{display:none;position:fixed;top:14px;right:14px;z-index:20;width:42px;height:42px;border-radius:10px;background:var(--paper);border:1px solid var(--line);cursor:pointer;padding:11px 10px;flex-direction:column;justify-content:space-between;box-shadow:0 6px 18px rgba(6,24,28,.14)}
+.nav-toggle{display:none;position:fixed;top:14px;right:14px;z-index:20;width:42px;height:42px;border-radius:10px;background:var(--paper);border:1px solid var(--line);cursor:pointer;padding:11px 10px;flex-direction:column;justify-content:space-between;box-shadow:var(--toggle-shadow)}
 .nav-toggle span{display:block;height:2px;background:var(--ink);border-radius:2px;transition:transform .2s,opacity .2s}
 .nav-toggle[aria-expanded="true"] span:nth-child(1){transform:translateY(8px) rotate(45deg)}
 .nav-toggle[aria-expanded="true"] span:nth-child(2){opacity:0}
@@ -843,7 +967,7 @@ main{min-width:0;padding:28px clamp(20px,4.5vw,60px) 36px;max-width:1240px;margi
 /* mobile */
 @media(max-width:980px){
   .shell{display:block}
-  .sidebar{position:fixed;inset:0 25% 0 0;max-width:340px;height:100vh;z-index:15;transform:translateX(-100%);transition:transform .25s ease;box-shadow:0 18px 40px rgba(6,24,28,.18);background:var(--paper)}
+  .sidebar{position:fixed;inset:0 25% 0 0;max-width:340px;height:100vh;z-index:15;transform:translateX(-100%);transition:transform .25s ease;box-shadow:var(--sidebar-shadow);background:var(--sidebar-mobile-bg)}
   .sidebar.open{transform:translateX(0)}
   .nav-toggle{display:flex}
   main{padding:64px 18px 32px}
@@ -874,6 +998,19 @@ main{min-width:0;padding:28px clamp(20px,4.5vw,60px) 36px;max-width:1240px;margi
 
 function js() {
   return `
+const themeKey='clawsweeper-theme';
+const themeChoices=new Set(['system','light','dark']);
+const themeColor={light:'#f4ead7',dark:'#081417'};
+const themeQuery=window.matchMedia?.('(prefers-color-scheme: dark)');
+const themeButtons=document.querySelectorAll('[data-theme-choice]');
+const readThemeChoice=()=>{try{const saved=window.localStorage?.getItem(themeKey);return themeChoices.has(saved)?saved:'system'}catch{return 'system'}};
+let themeChoice=readThemeChoice();
+const activeTheme=()=>themeChoice==='system'&&themeQuery?.matches?'dark':themeChoice==='dark'?'dark':'light';
+const applyTheme=()=>{const active=activeTheme();document.documentElement.dataset.theme=active;document.querySelector('meta[name="theme-color"]')?.setAttribute('content',themeColor[active]);themeButtons.forEach(btn=>{const selected=btn.dataset.themeChoice===themeChoice;btn.setAttribute('aria-pressed',selected?'true':'false')})};
+themeButtons.forEach(btn=>btn.addEventListener('click',()=>{const choice=btn.dataset.themeChoice;if(!themeChoices.has(choice))return;themeChoice=choice;try{window.localStorage?.setItem(themeKey,choice)}catch{}applyTheme()}));
+themeQuery?.addEventListener('change',()=>{if(themeChoice==='system')applyTheme()});
+applyTheme();
+
 const sidebar=document.querySelector('.sidebar');
 const toggle=document.querySelector('.nav-toggle');
 toggle?.addEventListener('click',()=>{const open=sidebar.classList.toggle('open');toggle.setAttribute('aria-expanded',open?'true':'false')});

--- a/test/docs-site-theme.test.ts
+++ b/test/docs-site-theme.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+test("docs site emits an early persistent theme switcher", () => {
+  execFileSync(process.execPath, ["scripts/build-docs-site.mjs"], {
+    cwd: process.cwd(),
+    stdio: "pipe",
+  });
+
+  const html = readFileSync("dist/docs-site/index.html", "utf8");
+  const themeInit = html.indexOf('const key = "clawsweeper-theme"');
+  const styles = html.indexOf("<style>");
+
+  assert.notEqual(themeInit, -1);
+  assert.notEqual(styles, -1);
+  assert.ok(themeInit < styles, "saved theme must be applied before site styles");
+  assert.match(html, /html\[data-theme="dark"\]/);
+  assert.match(html, /data-theme-choice="system"/);
+  assert.match(html, /data-theme-choice="light"/);
+  assert.match(html, /data-theme-choice="dark"/);
+  assert.match(html, /localStorage\?\.setItem\(themeKey,choice\)/);
+  assert.match(html, /themeQuery\?\.addEventListener\('change'/);
+  assert.match(html, /setAttribute\('aria-pressed',selected\?'true':'false'\)/);
+  assert.match(html, /setAttribute\("content", themeColor\[active\]\)/);
+});


### PR DESCRIPTION
## Summary

- add a system/light/dark theme switcher to the generated Pages docs site
- apply the theme before paint and keep `theme-color` in sync
- move the picker into the sidebar footer so it stays subtle and out of the primary docs nav

## Validation

- `node scripts/build-docs-site.mjs`
- `pnpm run format:check`
- `pnpm run lint:scripts`
- in-app browser check at `1280x720` and `390x844`
- representative WCAG contrast audit for light and dark theme text/background pairs
