### PR TITLE
Fix label sync after review placeholder drift

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -16844,9 +16844,19 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
     }
     const updatedSinceReview = Boolean(storedUpdatedAt && item.updatedAt !== storedUpdatedAt);
     const reviewCommentOnlyUpdate = item.updatedAt === commentUpdatedAt(existingReviewComment);
-    const unchangedSinceReview = storedUpdatedAt
-      ? !updatedSinceReview || reviewCommentOnlyUpdate
-      : false;
+    const labelSyncFreshEnough = (): boolean => {
+      if (!storedUpdatedAt) return false;
+      if (!updatedSinceReview || reviewCommentOnlyUpdate) return true;
+      const existingReviewCommentUpdatedAtMs = timestampMs(commentUpdatedAt(existingReviewComment));
+      const itemUpdatedAtMs = timestampMs(item.updatedAt);
+      if (existingReviewCommentUpdatedAtMs === null || itemUpdatedAtMs === null) return false;
+      if (Math.abs(itemUpdatedAtMs - existingReviewCommentUpdatedAtMs) > 5 * 60 * 1000) {
+        return false;
+      }
+      const storedUpdatedAtMs = timestampMs(storedUpdatedAt);
+      if (storedUpdatedAtMs === null) return false;
+      return !contextHasNonAutomationActivityAfter(currentItemContext(), storedUpdatedAtMs);
+    };
     const markChangedSinceReview = (options: {
       reason: string;
       currentUpdatedAt?: string | undefined;
@@ -17043,7 +17053,7 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       }
     }
     const isCurrentCompleteReport =
-      frontMatterValue(markdown, "review_status") === "complete" && unchangedSinceReview;
+      frontMatterValue(markdown, "review_status") === "complete" && labelSyncFreshEnough();
     if (state === "open" && isCurrentCompleteReport) {
       try {
         const syncResult = syncPriorityLabel({

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -14370,6 +14370,137 @@ if (args[0] === "api" && /\\/issues\\/comments\\/\\d+$/.test(path)) {
   }
 });
 
+test("apply-decisions syncs labels when first review placeholder advanced issue updated_at", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const logPath = join(root, "gh.log");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+
+    const report = workPlanCandidateReport({
+      number: 321,
+      reviewed_at: "2026-05-01T00:05:00Z",
+      item_snapshot_hash: "reviewed-snapshot-321",
+      item_updated_at: "2026-05-01T00:00:00Z",
+      triage_priority: "P1",
+      impact_labels: JSON.stringify(["impact:message-loss"]),
+      reproduction_status: "source_reproducible",
+      reproduction_confidence: "high",
+    });
+    writeFileSync(join(itemsDir, "321.md"), report, "utf8");
+    const placeholder = renderReviewStartStatusComment({
+      number: 321,
+      kind: "issue",
+      title: "Render work plans",
+    });
+
+    const ghMock = `
+const { appendFileSync, readFileSync } = require("fs");
+const logPath = ${JSON.stringify(logPath)};
+const placeholder = ${JSON.stringify(placeholder)};
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+appendFileSync(logPath, JSON.stringify(args) + "\\n");
+const path = args.includes("-i") ? args[args.indexOf("-i") + 1] : args[1] || "";
+const commentMatch = path.match(/\\/issues\\/(\\d+)\\/comments(?:\\?|$)/);
+const issueMatch = path.match(/\\/issues\\/(\\d+)$/);
+if (args[0] === "api" && /\\/issues\\/comments\\/\\d+$/.test(path)) {
+  const inputPath = args[args.indexOf("--input") + 1];
+  const body = JSON.parse(readFileSync(inputPath, "utf8")).body;
+  appendFileSync(logPath, JSON.stringify(["comment-patch", body]) + "\\n");
+  console.log(JSON.stringify({
+    id: 9321,
+    html_url: "https://github.com/openclaw/clawsweeper/issues/321#issuecomment-9321",
+    created_at: "2026-05-01T00:01:00Z",
+    updated_at: "2026-05-01T00:06:00Z",
+    user: { login: "clawsweeper[bot]" },
+    body
+  }));
+} else if (args[0] === "api" && commentMatch) {
+  console.log(JSON.stringify([[{
+    id: 9321,
+    html_url: "https://github.com/openclaw/clawsweeper/issues/321#issuecomment-9321",
+    created_at: "2026-05-01T00:01:00Z",
+    updated_at: "2026-05-01T00:01:00Z",
+    user: { login: "clawsweeper[bot]" },
+    body: placeholder
+  }]]));
+} else if (args[0] === "api" && /\\/issues\\/321\\/timeline/.test(path)) {
+  console.log(JSON.stringify([{
+    id: 1,
+    event: "commented",
+    created_at: "2026-05-01T00:01:00Z",
+    actor: { login: "clawsweeper[bot]" }
+  }]));
+} else if (args[0] === "api" && issueMatch) {
+  console.log(JSON.stringify({
+    number: 321,
+    title: "Render work plans",
+    html_url: "https://github.com/openclaw/clawsweeper/issues/321",
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:01:01Z",
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "reporter" },
+    labels: [],
+    comments: 1,
+    pull_request: null
+  }));
+} else if (args[0] === "issue" && args[1] === "view") {
+  console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
+} else if (args[0] === "label" && args[1] === "create") {
+  console.log("");
+} else if (args[0] === "issue" && args[1] === "edit") {
+  console.log("");
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({ itemsDir, closedDir, plansDir, reportPath });
+    });
+
+    const calls = readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as string[]);
+    const editCalls = calls.filter((args) => args[0] === "issue" && args[1] === "edit");
+    assert.ok(editCalls.some((args) => args.includes("--add-label") && args.includes("P1")));
+    assert.ok(
+      editCalls.some(
+        (args) => args.includes("--add-label") && args.includes("impact:message-loss"),
+      ),
+    );
+    assert.ok(
+      editCalls.some(
+        (args) => args.includes("--add-label") && args.includes("clawsweeper:source-repro"),
+      ),
+    );
+    assert.deepEqual(JSON.parse(readFileSync(reportPath, "utf8")), [
+      {
+        number: 321,
+        action: "review_comment_synced",
+        reason: "updated durable Codex review comment",
+      },
+    ]);
+    const updatedReport = readFileSync(join(itemsDir, "321.md"), "utf8");
+    assert.match(updatedReport, /^labels: .*"P1"/m);
+    assert.match(updatedReport, /^labels: .*"impact:message-loss"/m);
+    assert.match(updatedReport, /^labels_synced_at: /m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("apply-decisions dry-run computes advisory labels without mutating GitHub labels", () => {
   const root = mkdtempSync(tmpPrefix);
   try {


### PR DESCRIPTION
## Summary
- allow kept-open label sync when the only apparent drift is ClawSweeper's first-review placeholder comment timestamp
- keep close/apply drift gates conservative by requiring no non-automation timeline activity after the stored snapshot
- add a regression test for https://github.com/openclaw/openclaw/issues/94547

## Validation
- pnpm run build
- node --test --test-name-pattern="apply-decisions (syncs labels when first review placeholder advanced issue updated_at|skips advisory labels for failed or stale kept-open reports)" test/clawsweeper.test.ts
- node --test test/clawsweeper.test.ts
- pnpm run check

No live labels were changed on https://github.com/openclaw/openclaw/issues/94547 during investigation.