### PR TITLE
Refactor label sync freshness policy

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -12320,6 +12320,29 @@ function contextHasNonAutomationActivityAfter(
   );
 }
 
+function isCompleteReportFreshEnoughForLabelSync(options: {
+  storedUpdatedAt: string | undefined;
+  itemUpdatedAt: string | undefined;
+  reviewCommentUpdatedAt: string | undefined;
+  context: () => ItemContext;
+  reviewCommentDriftToleranceMs?: number;
+}): boolean {
+  const { storedUpdatedAt, itemUpdatedAt, reviewCommentUpdatedAt } = options;
+  if (!storedUpdatedAt || !itemUpdatedAt) return false;
+  if (itemUpdatedAt === storedUpdatedAt || itemUpdatedAt === reviewCommentUpdatedAt) return true;
+  const reviewCommentUpdatedAtMs = timestampMs(reviewCommentUpdatedAt);
+  const itemUpdatedAtMs = timestampMs(itemUpdatedAt);
+  if (reviewCommentUpdatedAtMs === null || itemUpdatedAtMs === null) return false;
+  const toleranceMs = options.reviewCommentDriftToleranceMs ?? 5 * 60 * 1000;
+  if (Math.abs(itemUpdatedAtMs - reviewCommentUpdatedAtMs) > toleranceMs) return false;
+  const storedUpdatedAtMs = timestampMs(storedUpdatedAt);
+  if (storedUpdatedAtMs === null) return false;
+  return !contextHasNonAutomationActivityAfter(options.context(), storedUpdatedAtMs);
+}
+
+export const isCompleteReportFreshEnoughForLabelSyncForTest =
+  isCompleteReportFreshEnoughForLabelSync;
+
 function pullRequestUrlForNumber(number: number): string {
   return repoUrlFor(targetRepo(), `/pull/${number}`);
 }
@@ -16844,19 +16867,6 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
     }
     const updatedSinceReview = Boolean(storedUpdatedAt && item.updatedAt !== storedUpdatedAt);
     const reviewCommentOnlyUpdate = item.updatedAt === commentUpdatedAt(existingReviewComment);
-    const labelSyncFreshEnough = (): boolean => {
-      if (!storedUpdatedAt) return false;
-      if (!updatedSinceReview || reviewCommentOnlyUpdate) return true;
-      const existingReviewCommentUpdatedAtMs = timestampMs(commentUpdatedAt(existingReviewComment));
-      const itemUpdatedAtMs = timestampMs(item.updatedAt);
-      if (existingReviewCommentUpdatedAtMs === null || itemUpdatedAtMs === null) return false;
-      if (Math.abs(itemUpdatedAtMs - existingReviewCommentUpdatedAtMs) > 5 * 60 * 1000) {
-        return false;
-      }
-      const storedUpdatedAtMs = timestampMs(storedUpdatedAt);
-      if (storedUpdatedAtMs === null) return false;
-      return !contextHasNonAutomationActivityAfter(currentItemContext(), storedUpdatedAtMs);
-    };
     const markChangedSinceReview = (options: {
       reason: string;
       currentUpdatedAt?: string | undefined;
@@ -17053,7 +17063,13 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       }
     }
     const isCurrentCompleteReport =
-      frontMatterValue(markdown, "review_status") === "complete" && labelSyncFreshEnough();
+      frontMatterValue(markdown, "review_status") === "complete" &&
+      isCompleteReportFreshEnoughForLabelSync({
+        storedUpdatedAt,
+        itemUpdatedAt: item.updatedAt,
+        reviewCommentUpdatedAt: commentUpdatedAt(existingReviewComment),
+        context: currentItemContext,
+      });
     if (state === "open" && isCurrentCompleteReport) {
       try {
         const syncResult = syncPriorityLabel({

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -53,6 +53,7 @@ import {
   hotIntakeRecencyMs,
   isCodexReviewCommentBody,
   isInfrastructureFailedReviewForTest,
+  isCompleteReportFreshEnoughForLabelSyncForTest,
   isGitHubLabelCapacityErrorForTest,
   isGitHubNotFoundError,
   isGitHubRequiresAuthenticationError,
@@ -514,6 +515,73 @@ test("review context comment filter keeps contributor text that only quotes mark
   assert.equal(result.filtered, 0);
   assert.equal(result.included.length, 1);
   assert.equal(extractLatestClawSweeperReviewForTest(comments, 123), null);
+});
+
+test("label sync freshness accepts unchanged reports without hydrating context", () => {
+  let contextCalls = 0;
+  const fresh = isCompleteReportFreshEnoughForLabelSyncForTest({
+    storedUpdatedAt: "2026-05-01T00:00:00Z",
+    itemUpdatedAt: "2026-05-01T00:00:00Z",
+    reviewCommentUpdatedAt: undefined,
+    context: () => {
+      contextCalls += 1;
+      return { issue: {}, comments: [], timeline: [] };
+    },
+  });
+
+  assert.equal(fresh, true);
+  assert.equal(contextCalls, 0);
+});
+
+test("label sync freshness accepts near review-comment drift with automation-only activity", () => {
+  const fresh = isCompleteReportFreshEnoughForLabelSyncForTest({
+    storedUpdatedAt: "2026-05-01T00:00:00Z",
+    itemUpdatedAt: "2026-05-01T00:01:01Z",
+    reviewCommentUpdatedAt: "2026-05-01T00:01:00Z",
+    context: () => ({
+      issue: {},
+      comments: [],
+      timeline: [
+        {
+          createdAt: "2026-05-01T00:01:00Z",
+          actor: "clawsweeper[bot]",
+        },
+      ],
+    }),
+  });
+
+  assert.equal(fresh, true);
+});
+
+test("label sync freshness blocks near review-comment drift with human activity", () => {
+  const fresh = isCompleteReportFreshEnoughForLabelSyncForTest({
+    storedUpdatedAt: "2026-05-01T00:00:00Z",
+    itemUpdatedAt: "2026-05-01T00:01:01Z",
+    reviewCommentUpdatedAt: "2026-05-01T00:01:00Z",
+    context: () => ({
+      issue: {},
+      comments: [{ createdAt: "2026-05-01T00:00:30Z", author: "reporter" }],
+      timeline: [],
+    }),
+  });
+
+  assert.equal(fresh, false);
+});
+
+test("label sync freshness blocks stale review-comment drift without hydrating context", () => {
+  let contextCalls = 0;
+  const fresh = isCompleteReportFreshEnoughForLabelSyncForTest({
+    storedUpdatedAt: "2026-05-01T00:00:00Z",
+    itemUpdatedAt: "2026-05-01T00:10:01Z",
+    reviewCommentUpdatedAt: "2026-05-01T00:01:00Z",
+    context: () => {
+      contextCalls += 1;
+      return { issue: {}, comments: [], timeline: [] };
+    },
+  });
+
+  assert.equal(fresh, false);
+  assert.equal(contextCalls, 0);
 });
 
 test("latest ClawSweeper durable review is extracted as compact previous review state", () => {


### PR DESCRIPTION
## Summary
- move complete-report label freshness into a named helper near the existing review activity helpers
- keep context hydration lazy for unchanged reports and clearly stale review-comment drift
- add direct coverage for unchanged, automation-only drift, human activity, and stale drift cases

## Validation
- pnpm run build
- node --test --test-name-pattern="label sync freshness|apply-decisions syncs labels when first review placeholder advanced issue updated_at" test/clawsweeper.test.ts
- pnpm run check

Follow-up to the label-sync investigation for https://github.com/openclaw/openclaw/issues/94547.