### PR TITLE
fix(spam): include Codex spawn in sparse checkout

### DIFF
--- a/.github/workflows/spam-comment-intake.yml
+++ b/.github/workflows/spam-comment-intake.yml
@@ -60,6 +60,7 @@ jobs:
             src/codex-output-capture.ts
             src/codex-process-worker.ts
             src/codex-process.ts
+            src/codex-spawn.ts
             src/codex-transient.ts
             src/github-retry.ts
             src/pr-close-coverage-proof.ts

--- a/.github/workflows/spam-scanner.yml
+++ b/.github/workflows/spam-scanner.yml
@@ -83,6 +83,7 @@ jobs:
             src/codex-output-capture.ts
             src/codex-process-worker.ts
             src/codex-process.ts
+            src/codex-spawn.ts
             src/codex-transient.ts
             src/github-retry.ts
             src/pr-close-coverage-proof.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Restored the Codex spawn helper to spam workflow sparse checkouts so repair builds can start.
 - Removed unconditional ffmpeg provisioning from review startup so optional media proof cannot block exact-review leases; unavailable media tools remain per-item evidence failures.
 - Prevented contributor-branch repairs and changelog-free repair artifacts from adding release-owned changelog entries, keeping contributor credit and release-note context in PR bodies or commit history instead.
 - Added an explicit trusted ephemeral-runner fallback for repair planning when the host cannot start Codex's Linux read-only sandbox.

--- a/test/repair/workflow-sparse-checkout.test.ts
+++ b/test/repair/workflow-sparse-checkout.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import test from "node:test";
 
-const REPAIR_PROOF_RUNTIME_PATHS = [
+const REPAIR_RUNTIME_PATHS = [
   "prompts/pr-close-coverage-proof.md",
   "schema/clawsweeper-pr-close-coverage-proof.schema.json",
   "src/clawsweeper-text.ts",
@@ -11,6 +11,7 @@ const REPAIR_PROOF_RUNTIME_PATHS = [
   "src/codex-output-capture.ts",
   "src/codex-process-worker.ts",
   "src/codex-process.ts",
+  "src/codex-spawn.ts",
   "src/codex-transient.ts",
   "src/pr-close-coverage-proof.ts",
 ] as const;
@@ -21,13 +22,13 @@ const SPARSE_REPAIR_BUILD_WORKFLOWS = [
   ".github/workflows/spam-scanner.yml",
 ] as const;
 
-test("sparse repair build workflows include PR close proof runtime files", () => {
+test("sparse repair build workflows include runtime dependencies", () => {
   for (const workflowPath of SPARSE_REPAIR_BUILD_WORKFLOWS) {
     const workflow = fs.readFileSync(path.join(process.cwd(), workflowPath), "utf8");
     assert.match(workflow, /build-script: build:repair/);
 
     const entries = sparseCheckoutEntries(workflow);
-    for (const requiredPath of REPAIR_PROOF_RUNTIME_PATHS) {
+    for (const requiredPath of REPAIR_RUNTIME_PATHS) {
       assert.ok(entries.has(requiredPath), `${workflowPath} missing ${requiredPath}`);
     }
   }


### PR DESCRIPTION
## Summary
- restore `src/codex-spawn.ts` to both spam workflow sparse checkouts
- make the shared sparse-checkout test cover direct repair runtime dependencies

## Root cause
Both workflows ran `build:repair` after a selective checkout that omitted the direct Codex spawn import.

## Validation
- `pnpm run check`
- emulated sparse checkout plus `pnpm run build:repair` for spam intake and scanner