### PR TITLE
fix(automerge): wait for replacement proof checks

### DIFF
--- a/src/repair/comment-router-utils.ts
+++ b/src/repair/comment-router-utils.ts
@@ -11,6 +11,7 @@ const DEFAULT_IGNORED_CHECKS = [
   "notify",
   "Stale",
 ];
+const TRANSIENT_CANCELLED_CHECKS = new Set(["real behavior proof"]);
 
 export function summarizeChecks(checks: LooseRecord[]) {
   const ignored = ignoredCheckNames();
@@ -43,6 +44,12 @@ export function summarizeChecks(checks: LooseRecord[]) {
       const blocker = `${name}:${status}`;
       blockers.push(blocker);
       pending.push(blocker);
+    }
+    if (conclusion === "CANCELLED" && TRANSIENT_CANCELLED_CHECKS.has(name.toLowerCase())) {
+      const blocker = `${name}:${conclusion}`;
+      blockers.push(blocker);
+      pending.push(blocker);
+      continue;
     }
     if (conclusion && !PASSING_CHECK_CONCLUSIONS.has(conclusion)) {
       const blocker = `${name}:${conclusion}`;

--- a/test/repair/comment-router-utils.test.ts
+++ b/test/repair/comment-router-utils.test.ts
@@ -338,6 +338,21 @@ test("summarizeChecks still blocks cancelled required checks", () => {
   assert.deepEqual(checks.terminalBlockers, ["required-build:CANCELLED"]);
 });
 
+test("summarizeChecks waits for a cancelled real behavior proof replacement", () => {
+  const checks = summarizeChecks([
+    {
+      name: "Real behavior proof",
+      workflowName: "Real behavior proof",
+      status: "COMPLETED",
+      conclusion: "CANCELLED",
+    },
+  ]);
+
+  assert.deepEqual(checks.blockers, ["Real behavior proof:CANCELLED"]);
+  assert.deepEqual(checks.pending, ["Real behavior proof:CANCELLED"]);
+  assert.deepEqual(checks.terminalBlockers, []);
+});
+
 test("summarizeChecks separates pending checks from terminal blockers", () => {
   const checks = summarizeChecks([
     {


### PR DESCRIPTION
A cancelled `Real behavior proof` check is often the short handoff before its replacement run starts. Treat it as a transient wait so automerge re-fetches the PR checks instead of dispatching a no-op repair worker.

Other cancelled required checks remain terminal blockers.

Validation: `pnpm run check`.