### PR TITLE
Use public inventory fallback for local fanout

### DIFF
--- a/src/repair/target-fanout.ts
+++ b/src/repair/target-fanout.ts
@@ -304,7 +304,7 @@ function inventoryEnv(owner: string): NodeJS.ProcessEnv | null {
   if (token === PUBLIC_INVENTORY_TOKEN) return publicInventoryEnv();
   if (token) return { GH_TOKEN: token, GITHUB_TOKEN: token };
   if (process.env.GITHUB_ACTIONS === "true") return null;
-  return { GH_TOKEN: "", GITHUB_TOKEN: "" };
+  return publicInventoryEnv();
 }
 
 function publicInventoryEnv(): NodeJS.ProcessEnv {

--- a/test/repair/target-fanout.test.ts
+++ b/test/repair/target-fanout.test.ts
@@ -167,6 +167,19 @@ process.exit(2);
   );
 });
 
+test("target fanout falls back to public inventory env outside Actions", () => {
+  const source = readFileSync("src/repair/target-fanout.ts", "utf8");
+  const helperStart = source.indexOf("function inventoryEnv(");
+  const helperEnd = source.indexOf("function publicInventoryEnv(", helperStart);
+
+  assert.notEqual(helperStart, -1);
+  assert.notEqual(helperEnd, -1);
+  const helper = source.slice(helperStart, helperEnd);
+  assert.match(helper, /if \(process\.env\.GITHUB_ACTIONS === "true"\) return null;/);
+  assert.match(helper, /return publicInventoryEnv\(\);/);
+  assert.doesNotMatch(helper, /GH_TOKEN: ""/);
+});
+
 test("target fanout selection advances cursor with wraparound", () => {
   const repositories = [
     { targetRepo: "openclaw/a", defaultBranch: "main", visibility: "PUBLIC" },


### PR DESCRIPTION
## Summary

Use the public inventory token fallback for local target fanout runs when an owner-specific inventory token is absent.

GitHub Actions still skips owners without minted inventory tokens. Outside Actions, local operators can safely use the public inventory env path instead of forcing empty `GH_TOKEN`/`GITHUB_TOKEN` values.

## Changes

- Return `publicInventoryEnv()` for non-Actions runs without owner-specific inventory tokens.
- Add a focused regression test that preserves the Actions skip behavior while asserting the local fallback path.

## Validation

- `corepack pnpm run build:repair`
- `node --test test/repair/target-fanout.test.ts`
