### PR TITLE
fix(repair): harden rebase conflict retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Kept unresolved rebase conflicts inside the bounded Codex repair loop and reported exhausted conflicts as human-required with exact paths. Thanks @Jhacarreiro.
 - Restored the Codex spawn helper to spam workflow sparse checkouts so repair builds can start.
 - Removed unconditional ffmpeg provisioning from review startup so optional media proof cannot block exact-review leases; unavailable media tools remain per-item evidence failures.
 - Prevented contributor-branch repairs and changelog-free repair artifacts from adding release-owned changelog entries, keeping contributor credit and release-note context in PR bodies or commit history instead.

--- a/src/repair/execute-fix-artifact.ts
+++ b/src/repair/execute-fix-artifact.ts
@@ -114,7 +114,12 @@ import {
   type TargetValidationOptions,
 } from "./target-validation.js";
 import { uniqueStrings } from "./validation-command-utils.js";
+import {
+  rebaseConflictEditDecision,
+  unresolvedRebaseConflictReason,
+} from "./rebase-conflict-policy.js";
 import { validateActivePrAreaCapacity } from "./execute-fix-area-capacity.js";
+import { issueImplementationTerminalOutcome } from "./issue-implementation-outcome.js";
 import {
   repairPauseLabel,
   validateAutonomousFixScope,
@@ -666,18 +671,26 @@ try {
       });
       throw error;
     }
+    const unresolvedRebaseConflicts = unresolvedRebaseConflictReason(error);
     outcome = {
-      action: "execute_fix",
+      action: unresolvedRebaseConflicts ? "needs_human" : "execute_fix",
       status: "blocked",
       repair_strategy: fixArtifact.repair_strategy,
       reason: error.message,
-      ...(isRetryableCodexFailure(error) ? { requeue_required: true } : {}),
+      ...(unresolvedRebaseConflicts
+        ? { needs_human: [unresolvedRebaseConflicts] }
+        : isRetryableCodexFailure(error)
+          ? { requeue_required: true }
+          : {}),
     };
   }
 }
 
-report.status = outcome.status;
+report.status = outcome.action === "needs_human" ? "needs_human" : outcome.status;
 if (outcome.reason && !report.reason) report.reason = outcome.reason;
+if (Array.isArray(outcome.needs_human) && outcome.needs_human.length > 0) {
+  report.needs_human = uniqueStrings([...(report.needs_human ?? []), ...outcome.needs_human]);
+}
 report.actions.push(outcome);
 writeReport(report, resultPath);
 if (outcome.requeue_required === true) process.exitCode = 1;
@@ -1982,7 +1995,10 @@ function editValidatePrepareMerge({
         repositoryContext,
         reconcileWithBase,
         sourceHead,
-        rebaseResult,
+        rebaseResult:
+          rebaseResult?.status === "conflicts"
+            ? { ...rebaseResult, unmerged_paths: unmergedPaths(targetDir) }
+            : rebaseResult,
         maxEditAttempts,
         validationCommands: validationPreflight.resolved_commands ?? [],
         isAutomergeRepair: isAutomergeRepairJob(),
@@ -2029,37 +2045,49 @@ function editValidatePrepareMerge({
           stderrPath: path.join(workRoot, `${mode}-codex-${attempt}.stderr.log`),
         },
       );
-      if ((codexResult.error as JsonValue)?.code === "ETIMEDOUT") {
-        throw new Error(`Codex fix worker timed out after ${workerTimeoutMs}ms`);
-      }
-      if (codexResult.error) {
-        const errorDetail = codexFailureDetail(
-          codexResult,
-          codexResult.error.message || String(codexResult.error),
-        );
-        if (attempt < maxEditAttempts && isRetryableCodexErrorMessage(errorDetail)) {
-          previousSummary = compactText(errorDetail, 360);
-          const retryDelayMs = codexRetryDelayMs(errorDetail, attempt);
-          logProgress("retrying Codex edit pass after transient transport error", {
-            mode,
+      const timedOut = (codexResult.error as JsonValue)?.code === "ETIMEDOUT";
+      const errorDetail = timedOut
+        ? `Codex fix worker timed out after ${workerTimeoutMs}ms`
+        : codexResult.error
+          ? codexFailureDetail(codexResult, codexResult.error.message || String(codexResult.error))
+          : codexResult.status !== 0
+            ? codexFailureDetail(codexResult, "Codex fix worker failed")
+            : "";
+      const remainingConflicts =
+        rebaseResult?.status === "conflicts" ? unmergedPaths(targetDir) : [];
+      // Worker failures keep their transport/terminal classification. Only a completed
+      // edit pass that leaves conflicts consumes the bounded conflict-repair budget.
+      const conflictDecision = errorDetail
+        ? { action: "proceed" as const }
+        : rebaseConflictEditDecision({
+            rebaseStatus: rebaseResult?.status,
+            unmergedPaths: remainingConflicts,
             attempt,
-            max_attempts: maxEditAttempts,
-            retry_delay_ms: retryDelayMs,
+            maxEditAttempts,
           });
-          updateAutomergeProgressStatus({
-            id: `codex-edit-${mode}-${attempt}`,
-            label: `Codex edit ${attempt}`,
-            status: "retrying",
-            details: "transient Codex transport error",
-            headSha: currentHead(targetDir),
-          });
-          sleepMs(retryDelayMs);
-          continue;
-        }
-        throw new Error(codexFailureMessage("Codex fix worker failed", errorDetail));
+      if (conflictDecision.action !== "proceed") {
+        previousSummary =
+          readTextIfExists(summaryPath).trim() ||
+          compactText(errorDetail, 360) ||
+          `Rebase conflicts remain unresolved after edit attempt ${attempt}: ${remainingConflicts.join(", ")}`;
+        logProgress("rebase conflicts remain after Codex edit pass", {
+          mode,
+          attempt,
+          max_attempts: maxEditAttempts,
+          unresolved: remainingConflicts,
+        });
+        updateAutomergeProgressStatus({
+          id: `codex-edit-${mode}-${attempt}`,
+          label: `Codex edit ${attempt}`,
+          status: conflictDecision.action === "retry" ? "retrying" : "blocked",
+          details: `unresolved rebase conflicts: ${remainingConflicts.join(", ")}`,
+          headSha: currentHead(targetDir),
+        });
+        if (conflictDecision.action === "retry") continue;
+        throw new Error(conflictDecision.reason);
       }
-      if (codexResult.status !== 0) {
-        const errorDetail = codexFailureDetail(codexResult, "Codex fix worker failed");
+      if (timedOut) throw new Error(errorDetail);
+      if (codexResult.error || codexResult.status !== 0) {
         if (attempt < maxEditAttempts && isRetryableCodexErrorMessage(errorDetail)) {
           previousSummary = compactText(errorDetail, 360);
           const retryDelayMs = codexRetryDelayMs(errorDetail, attempt);
@@ -3456,25 +3484,6 @@ function issueImplementationPrAction(report: LooseRecord) {
     if (action?.action !== "open_fix_pr") return false;
     return typeof action?.pr_url === "string" && action.pr_url.trim();
   });
-}
-
-function issueImplementationTerminalOutcome(report: LooseRecord) {
-  const actionOutcome = [...(report.actions ?? [])].reverse().find((action: JsonValue) => {
-    const status = String(action?.status ?? "").toLowerCase();
-    if (!["blocked", "skipped", "failed"].includes(status)) return false;
-    return ["execute_fix", "open_fix_pr", "repair_contributor_branch"].includes(
-      String(action?.action ?? ""),
-    );
-  });
-  if (actionOutcome) return actionOutcome;
-
-  const status = String(report.status ?? "").toLowerCase();
-  if (!["blocked", "skipped", "failed"].includes(status)) return null;
-  return {
-    action: "issue_implementation",
-    status,
-    reason: report.reason,
-  };
 }
 
 function issueImplementationTargetIssueNumber() {

--- a/src/repair/fix-prompt-builder.test.ts
+++ b/src/repair/fix-prompt-builder.test.ts
@@ -144,6 +144,7 @@ test("fix prompt includes rebase and previous no-diff recovery details", () => {
       base_ref: "origin/main",
       base_sha: "def456",
       detail: "CONFLICT (content): CHANGELOG.md",
+      unmerged_paths: ["src/index.ts", "CHANGELOG.md"],
     },
     maxEditAttempts: 5,
   });
@@ -153,7 +154,9 @@ test("fix prompt includes rebase and previous no-diff recovery details", () => {
   assert.match(prompt, /Existing repair branch detected/);
   assert.match(prompt, /Source head before edit: abc123/);
   assert.match(prompt, /Deterministic pre-edit rebase: conflicts onto origin\/main \(def456\)/);
-  assert.match(prompt, /Resolve the active rebase conflicts/);
+  assert.match(prompt, /Conflict-first mode/);
+  assert.match(prompt, /resolve only the active rebase conflicts/);
+  assert.match(prompt, /Unmerged conflict paths: src\/index\.ts, CHANGELOG\.md/);
   assert.match(prompt, /Rebase output: CONFLICT \(content\): CHANGELOG\.md/);
   assert.match(prompt, /Previous attempt produced no target repo diff/);
   assert.match(prompt, /Previous no-diff summary: Analyzed without editing files/);

--- a/src/repair/fix-prompt-builder.ts
+++ b/src/repair/fix-prompt-builder.ts
@@ -284,10 +284,23 @@ function renderRebaseResult(rebaseResult: LooseRecord) {
   const baseRef = String(rebaseResult.base_ref ?? "origin/main");
   const baseSha = String(rebaseResult.base_sha ?? "unknown");
   const detail = compactText(String(rebaseResult.detail ?? "").trim(), 800);
+  const unmergedPaths = Array.isArray(rebaseResult.unmerged_paths)
+    ? rebaseResult.unmerged_paths.map((entry: unknown) => String(entry)).filter(Boolean)
+    : [];
   return [
     `Deterministic pre-edit rebase: ${status} onto ${baseRef} (${baseSha}).`,
     status === "conflicts"
-      ? "Resolve the active rebase conflicts, continue or finish the rebase, and leave the checkout in a normal non-rebasing state before returning."
+      ? [
+          "Conflict-first mode:",
+          "- resolve only the active rebase conflicts before doing any feature repair;",
+          "- inspect `git status --short` and the conflicted files listed below;",
+          "- remove all conflict markers and stage the resolved files;",
+          "- run `git rebase --continue` until the checkout is no longer rebasing;",
+          "- do not broaden the patch while conflicts remain.",
+        ].join("\n")
+      : "",
+    status === "conflicts" && unmergedPaths.length > 0
+      ? `Unmerged conflict paths: ${unmergedPaths.join(", ")}`
       : "",
     detail ? `Rebase output: ${detail}` : "",
   ]

--- a/src/repair/issue-implementation-outcome.test.ts
+++ b/src/repair/issue-implementation-outcome.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { issueImplementationTerminalOutcome } from "./issue-implementation-outcome.js";
+
+test("issue implementation treats needs-human repair actions as terminal", () => {
+  const outcome = issueImplementationTerminalOutcome({
+    status: "needs_human",
+    actions: [
+      {
+        action: "needs_human",
+        status: "blocked",
+        reason: "rebase conflicts remain unresolved: src/index.ts",
+      },
+    ],
+  });
+
+  assert.deepEqual(outcome, {
+    action: "needs_human",
+    status: "blocked",
+    reason: "rebase conflicts remain unresolved: src/index.ts",
+  });
+});
+
+test("issue implementation normalizes needs-human report fallback to blocked", () => {
+  assert.deepEqual(
+    issueImplementationTerminalOutcome({
+      status: "needs_human",
+      reason: "rebase produced additional conflicts: src/later.ts",
+    }),
+    {
+      action: "issue_implementation",
+      status: "blocked",
+      reason: "rebase produced additional conflicts: src/later.ts",
+    },
+  );
+});
+
+test("issue implementation ignores non-terminal reports", () => {
+  assert.equal(issueImplementationTerminalOutcome({ status: "complete", actions: [] }), null);
+});

--- a/src/repair/issue-implementation-outcome.ts
+++ b/src/repair/issue-implementation-outcome.ts
@@ -1,0 +1,20 @@
+import type { JsonValue, LooseRecord } from "./json-types.js";
+
+export function issueImplementationTerminalOutcome(report: LooseRecord) {
+  const actionOutcome = [...(report.actions ?? [])].reverse().find((action: JsonValue) => {
+    const status = String(action?.status ?? "").toLowerCase();
+    if (!["blocked", "skipped", "failed"].includes(status)) return false;
+    return ["execute_fix", "open_fix_pr", "repair_contributor_branch", "needs_human"].includes(
+      String(action?.action ?? ""),
+    );
+  });
+  if (actionOutcome) return actionOutcome;
+
+  const status = String(report.status ?? "").toLowerCase();
+  if (!["blocked", "skipped", "failed", "needs_human"].includes(status)) return null;
+  return {
+    action: "issue_implementation",
+    status: status === "needs_human" ? "blocked" : status,
+    reason: report.reason,
+  };
+}

--- a/src/repair/rebase-conflict-policy.test.ts
+++ b/src/repair/rebase-conflict-policy.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  rebaseConflictEditDecision,
+  unresolvedRebaseConflictReason,
+} from "./rebase-conflict-policy.js";
+
+test("unresolved rebase conflicts retry within the edit budget", () => {
+  assert.deepEqual(
+    rebaseConflictEditDecision({
+      rebaseStatus: "conflicts",
+      unmergedPaths: ["src/index.ts", "CHANGELOG.md"],
+      attempt: 1,
+      maxEditAttempts: 2,
+    }),
+    {
+      action: "retry",
+      reason: "rebase conflicts remain unresolved: src/index.ts, CHANGELOG.md",
+    },
+  );
+});
+
+test("unresolved rebase conflicts require human help after the edit budget", () => {
+  const decision = rebaseConflictEditDecision({
+    rebaseStatus: "conflicts",
+    unmergedPaths: ["src/index.ts"],
+    attempt: 2,
+    maxEditAttempts: 2,
+  });
+
+  assert.deepEqual(decision, {
+    action: "needs_human",
+    reason: "rebase conflicts remain unresolved: src/index.ts",
+  });
+  assert.equal(unresolvedRebaseConflictReason(new Error(decision.reason)), decision.reason);
+});
+
+test("resolved or non-conflicting rebases proceed", () => {
+  assert.deepEqual(
+    rebaseConflictEditDecision({
+      rebaseStatus: "conflicts",
+      unmergedPaths: [],
+      attempt: 1,
+      maxEditAttempts: 2,
+    }),
+    { action: "proceed" },
+  );
+  assert.deepEqual(
+    rebaseConflictEditDecision({
+      rebaseStatus: "rebased",
+      unmergedPaths: ["src/index.ts"],
+      attempt: 2,
+      maxEditAttempts: 2,
+    }),
+    { action: "proceed" },
+  );
+});
+
+test("later conflicts from rebase continuation require human help", () => {
+  const reason = "rebase produced additional conflicts: src/later.ts";
+  assert.equal(unresolvedRebaseConflictReason(new Error(reason)), reason);
+});

--- a/src/repair/rebase-conflict-policy.ts
+++ b/src/repair/rebase-conflict-policy.ts
@@ -1,0 +1,33 @@
+import type { JsonValue } from "./json-types.js";
+
+export type RebaseConflictEditDecision =
+  | { action: "proceed" }
+  | { action: "retry"; reason: string }
+  | { action: "needs_human"; reason: string };
+
+export function rebaseConflictEditDecision({
+  rebaseStatus,
+  unmergedPaths,
+  attempt,
+  maxEditAttempts,
+}: {
+  rebaseStatus: JsonValue;
+  unmergedPaths: string[];
+  attempt: number;
+  maxEditAttempts: number;
+}): RebaseConflictEditDecision {
+  if (rebaseStatus !== "conflicts" || unmergedPaths.length === 0) {
+    return { action: "proceed" };
+  }
+
+  const reason = `rebase conflicts remain unresolved: ${unmergedPaths.join(", ")}`;
+  if (attempt >= maxEditAttempts) return { action: "needs_human", reason };
+  return { action: "retry", reason };
+}
+
+export function unresolvedRebaseConflictReason(error: JsonValue): string | null {
+  const message = String(error?.message ?? error ?? "");
+  return /rebase (?:conflicts remain unresolved|produced additional conflicts):/i.test(message)
+    ? message
+    : null;
+}

--- a/test/repair/git-repo-utils.test.ts
+++ b/test/repair/git-repo-utils.test.ts
@@ -5,7 +5,11 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
 
-import { completeRebaseIfResolved, rebaseOntoBase } from "../../dist/repair/git-repo-utils.js";
+import {
+  completeRebaseIfResolved,
+  rebaseOntoBase,
+  unmergedPaths,
+} from "../../dist/repair/git-repo-utils.js";
 
 test("rebaseOntoBase rebases a repair branch onto latest origin main", () => {
   const { work } = fixtureRepo();
@@ -46,6 +50,7 @@ test("rebaseOntoBase leaves conflicts for Codex repair instead of aborting", () 
   const result = rebaseOntoBase({ targetDir: work, baseBranch: "main" });
 
   assert.equal(result.status, "conflicts");
+  assert.deepEqual(unmergedPaths(work), ["shared.txt"]);
   assert.match(fs.readFileSync(path.join(work, "shared.txt"), "utf8"), /<<<<<<< HEAD/);
 });
 


### PR DESCRIPTION
## Summary

- keep unresolved rebase conflicts inside the bounded Codex edit loop after successful edit passes
- preserve transport, terminal, and ordinary worker failure classification
- report exhausted and sequential rebase conflicts as human-required with exact paths
- update automatic issue implementation status comments for the new terminal outcome
- include conflicted paths and conflict-first guidance in repair prompts

Replaces https://github.com/openclaw/clawsweeper/pull/308 because the contributor fork rejected maintainer pushes. Preserves contributor credit.

## Verification

- `pnpm run check`
- 526 unit tests passed
- 560 repair tests passed
- 1,086 full coverage tests passed
- Codex autoreview clean after seven review/fix rounds
