### PR TITLE
feat(repair): add safe author-wide PR intake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Added
 
+- Added author-wide PR repair intake across configured public repositories, with private and unsupported repositories excluded before job generation. Thanks @Jhacarreiro.
+
 ### Changed
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ exact-head review, and run a bounded Codex review/fix loop. Codex handles the
 code repair and local validation loop; deterministic executor steps own every
 GitHub mutation, branch push, label update, and final merge gate.
 
+Operators can create repair-only jobs for one author's blocked pull requests in
+one repository with `pnpm repair:pr-intake -- --repo owner/name --author login`,
+or across all configured public repositories with
+`pnpm repair:pr-intake -- --author login --all-open`. Author-wide discovery
+skips private, unsupported, and unverifiable repositories without persisting
+their names. Generated jobs cannot close or merge their source pull requests.
+
 Automerge waits for exact-head review, required checks, mergeability, and policy
 gates. If repair was needed, the mutable status comment records each review,
 repair, re-review, and merge step with timing and links. The final merge result

--- a/src/repair/pr-repair-intake.ts
+++ b/src/repair/pr-repair-intake.ts
@@ -6,6 +6,7 @@ import { ghJson } from "./github-cli.js";
 import { renderJobIntentFrontmatter } from "./job-intent.js";
 import { parseArgs, parseJob, repoRoot, validateJob } from "./lib.js";
 import { slug } from "./text-utils.js";
+import { repositoryProfileFor } from "../repository-profiles.js";
 
 type Signal = {
   kind: string;
@@ -27,9 +28,19 @@ type Candidate = {
   updatedAt?: string;
 };
 
+type AuthorSearchPullRequest = {
+  repository?: { nameWithOwner?: string };
+};
+
+type AuthorWideRepositoryDecision = {
+  repo?: string;
+  reason?: "private" | "metadata_unavailable" | "unsupported_profile";
+};
+
 const args = parseArgs(process.argv.slice(2));
-const repo = stringArg("repo", "");
+const requestedRepo = stringArg("repo", "");
 const author = stringArg("author", "");
+const allOpen = truthy(args["all-open"] ?? args.all_open);
 const limit = numberArg("limit", 50);
 const outDirArg = stringArg("out-dir", stringArg("out_dir", ""));
 const dryRun = truthy(args["dry-run"] ?? args.dry_run);
@@ -58,70 +69,164 @@ query($owner:String!, $name:String!, $number:Int!) {
 }
 `;
 
-if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) die("--repo owner/name is required");
 if (!author.trim()) die("--author is required");
 
-const owner = repo.split("/")[0] ?? "unknown";
-const outDir = path.resolve(repoRoot(), outDirArg || `jobs/${owner}/inbox`);
-const prs = fetchOpenPullRequests({ repo, author, limit });
-const results = prs
-  .map((pr) => candidateResult(pr))
-  .filter((result) => result.signals.length >= minSignals);
-
-if (!dryRun) fs.mkdirSync(outDir, { recursive: true });
-
-const written: LooseRecord[] = [];
-for (const result of results) {
-  const clusterId = slug(`repair-pr-${repo.replace("/", "-")}-${result.number}`);
-  const jobPath = path.join(outDir, `${clusterId}.md`);
-  const relativeJobPath = path.relative(repoRoot(), jobPath);
-  const branch = `clawsweeper/${clusterId}`;
-  const body = renderJob({ result, clusterId, branch });
-  if (dryRun) {
-    written.push({
-      status: "planned",
-      job: relativeJobPath,
-      number: result.number,
-      signals: result.signals,
-    });
-    continue;
-  }
-  if (fs.existsSync(jobPath) && !force) {
-    written.push({
-      status: "exists",
-      job: relativeJobPath,
-      number: result.number,
-      signals: result.signals,
-    });
-    continue;
-  }
-  fs.writeFileSync(jobPath, body, "utf8");
-  const parsed = parseJob(jobPath);
-  const errors = validateJob(parsed);
-  if (errors.length > 0) die(`generated invalid job ${relativeJobPath}:\n- ${errors.join("\n- ")}`);
-  written.push({
-    status: "written",
-    job: relativeJobPath,
-    number: result.number,
-    signals: result.signals,
-  });
+if (/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(requestedRepo)) {
+  console.log(JSON.stringify(runRepoIntake(requestedRepo, repoModeOutDir(requestedRepo)), null, 2));
+} else if (allOpen) {
+  console.log(JSON.stringify(runAuthorWideIntake(), null, 2));
+} else {
+  die("--repo owner/name is required unless --all-open is set");
 }
 
-console.log(
-  JSON.stringify(
-    {
-      status: "ok",
-      repo,
-      author,
-      scanned: prs.length,
-      candidates: results.length,
-      dry_run: dryRun,
-      jobs: written,
-    },
-    null,
-    2,
-  ),
-);
+function runAuthorWideIntake() {
+  const pullRequests = fetchAuthorOpenPullRequests({ author, limit });
+  const discoveredRepositories = Array.from(
+    new Set(pullRequests.map((pr) => repoNameWithOwner(pr)).filter(Boolean)),
+  ).sort();
+  const decisions = discoveredRepositories.map(authorWideRepositoryDecision);
+  const repositories = decisions.flatMap((decision) => (decision.repo ? [decision.repo] : []));
+  const summaries = repositories.map((targetRepo) =>
+    runRepoIntake(targetRepo, authorWideOutDir(targetRepo)),
+  );
+
+  return {
+    status: "ok",
+    mode: "author-wide",
+    author,
+    state: "open",
+    searched: pullRequests.length,
+    repos_discovered: discoveredRepositories.length,
+    repos_scanned: summaries.length,
+    skipped_repositories: skippedRepositoryCounts(decisions),
+    scanned: summaries.reduce((sum, summary) => sum + Number(summary.scanned ?? 0), 0),
+    candidates: summaries.reduce((sum, summary) => sum + Number(summary.candidates ?? 0), 0),
+    dry_run: dryRun,
+    jobs: summaries.flatMap((summary) => (Array.isArray(summary.jobs) ? summary.jobs : [])),
+    repositories: summaries,
+  };
+}
+
+function runRepoIntake(targetRepo: string, outDir: string): LooseRecord {
+  const prs = fetchOpenPullRequests({ repo: targetRepo, author, limit });
+  const results = prs
+    .map((pr) => candidateResult(targetRepo, pr))
+    .filter((result) => result.signals.length >= minSignals);
+
+  if (!dryRun) fs.mkdirSync(outDir, { recursive: true });
+
+  const written: LooseRecord[] = [];
+  for (const result of results) {
+    const clusterId = slug(`repair-pr-${targetRepo.replace("/", "-")}-${result.number}`);
+    const jobPath = path.join(outDir, `${clusterId}.md`);
+    const relativeJobPath = path.relative(repoRoot(), jobPath);
+    const branch = `clawsweeper/${clusterId}`;
+    const body = renderJob({ targetRepo, result, clusterId, branch });
+    if (dryRun) {
+      written.push({
+        status: "planned",
+        job: relativeJobPath,
+        number: result.number,
+        signals: result.signals,
+      });
+      continue;
+    }
+    if (fs.existsSync(jobPath) && !force) {
+      written.push({
+        status: "exists",
+        job: relativeJobPath,
+        number: result.number,
+        signals: result.signals,
+      });
+      continue;
+    }
+    fs.writeFileSync(jobPath, body, "utf8");
+    const parsed = parseJob(jobPath);
+    const errors = validateJob(parsed);
+    if (errors.length > 0)
+      die(`generated invalid job ${relativeJobPath}:\n- ${errors.join("\n- ")}`);
+    written.push({
+      status: "written",
+      job: relativeJobPath,
+      number: result.number,
+      signals: result.signals,
+    });
+  }
+
+  return {
+    status: "ok",
+    repo: targetRepo,
+    author,
+    scanned: prs.length,
+    candidates: results.length,
+    dry_run: dryRun,
+    jobs: written,
+  };
+}
+
+function repoModeOutDir(targetRepo: string): string {
+  const owner = targetRepo.split("/")[0] ?? "unknown";
+  return path.resolve(repoRoot(), outDirArg || `jobs/${owner}/inbox`);
+}
+
+function authorWideOutDir(targetRepo: string): string {
+  const root = outDirArg
+    ? path.resolve(repoRoot(), outDirArg)
+    : path.resolve(repoRoot(), "jobs", "author", slug(author));
+  return path.join(root, slug(targetRepo), "inbox");
+}
+
+function fetchAuthorOpenPullRequests({
+  author,
+  limit,
+}: {
+  author: string;
+  limit: number;
+}): AuthorSearchPullRequest[] {
+  return ghJson<AuthorSearchPullRequest[]>([
+    "search",
+    "prs",
+    "--author",
+    author,
+    "--state",
+    "open",
+    "--limit",
+    String(limit),
+    "--json",
+    "repository",
+  ]);
+}
+
+function repoNameWithOwner(pr: AuthorSearchPullRequest): string {
+  return String(pr.repository?.nameWithOwner ?? "");
+}
+
+function authorWideRepositoryDecision(targetRepo: string): AuthorWideRepositoryDecision {
+  try {
+    repositoryProfileFor(targetRepo);
+  } catch {
+    return { reason: "unsupported_profile" };
+  }
+  try {
+    const metadata = ghJson<LooseRecord>(["repo", "view", targetRepo, "--json", "isPrivate"]);
+    if (metadata.isPrivate === true) return { reason: "private" };
+    return metadata.isPrivate === false ? { repo: targetRepo } : { reason: "metadata_unavailable" };
+  } catch {
+    return { reason: "metadata_unavailable" };
+  }
+}
+
+function skippedRepositoryCounts(decisions: AuthorWideRepositoryDecision[]) {
+  const counts = {
+    private: 0,
+    metadata_unavailable: 0,
+    unsupported_profile: 0,
+  };
+  for (const decision of decisions) {
+    if (decision.reason) counts[decision.reason] += 1;
+  }
+  return counts;
+}
 
 function fetchOpenPullRequests({
   repo,
@@ -160,7 +265,7 @@ function fetchOpenPullRequests({
   ]);
 }
 
-function candidateResult(pr: Candidate) {
+function candidateResult(targetRepo: string, pr: Candidate) {
   const blockingSignals: Signal[] = [];
   const contextSignals: Signal[] = [];
   const mergeState = String(pr.mergeStateStatus ?? "").toUpperCase();
@@ -178,7 +283,7 @@ function candidateResult(pr: Candidate) {
     if (signal) blockingSignals.push(signal);
   }
 
-  const reviewThreadSignals = unresolvedReviewThreadSignals(pr.number);
+  const reviewThreadSignals = unresolvedReviewThreadSignals(targetRepo, pr.number);
   blockingSignals.push(...reviewThreadSignals);
 
   if (includeComments) {
@@ -217,15 +322,15 @@ function candidateResult(pr: Candidate) {
   };
 }
 
-function unresolvedReviewThreadSignals(number: number): Signal[] {
+function unresolvedReviewThreadSignals(targetRepo: string, number: number): Signal[] {
   try {
     const data = ghJson<LooseRecord>([
       "api",
       "graphql",
       "-f",
-      `owner=${repo.split("/")[0]}`,
+      `owner=${targetRepo.split("/")[0]}`,
       "-f",
-      `name=${repo.split("/")[1]}`,
+      `name=${targetRepo.split("/")[1]}`,
       "-F",
       `number=${number}`,
       "-f",
@@ -301,12 +406,12 @@ function actionableTextSignal(kind: string, entry: LooseRecord): Signal | null {
   };
 }
 
-function renderJob({ result, clusterId, branch }: LooseRecord) {
+function renderJob({ targetRepo, result, clusterId, branch }: LooseRecord) {
   const ref = `#${result.number}`;
   const sourcePr = String(result.url);
-  const prompt = renderPrompt(result);
+  const prompt = renderPrompt(targetRepo, result);
   return `---
-repo: ${repo}
+repo: ${targetRepo}
 cluster_id: ${clusterId}
 mode: autonomous
 ${renderJobIntentFrontmatter("pr_repair")}
@@ -338,7 +443,7 @@ target_branch: ${branch}
 source: pr-repair-intake
 ---
 
-# Repair-only PR intake for ${repo}${ref}
+# Repair-only PR intake for ${targetRepo}${ref}
 
 This job was created by deterministic repair-only intake. It does not represent a full ClawSweeper review verdict and must not close or merge the source PR.
 
@@ -369,9 +474,9 @@ ${prompt}
 `;
 }
 
-function renderPrompt(result: LooseRecord) {
+function renderPrompt(targetRepo: JsonValue, result: LooseRecord) {
   const lines = [
-    `Repair source PR ${result.url} (${repo}#${result.number}): ${result.title}`,
+    `Repair source PR ${result.url} (${targetRepo}#${result.number}): ${result.title}`,
     "",
     "The PR has objective repair signals and should be made merge-ready if possible.",
     "Use read-only GitHub inspection to review the PR diff, checks, comments, reviews, and latest head/base state before editing.",

--- a/test/repair/pr-repair-intake.test.ts
+++ b/test/repair/pr-repair-intake.test.ts
@@ -55,6 +55,7 @@ test("pr repair intake writes PR repair jobs for failed checks", () => {
   const parsed = JSON.parse(output);
   assert.equal(parsed.candidates, 1);
   assert.equal(parsed.jobs[0].status, "written");
+  assert.doesNotMatch(output, /private-tool|readonly\/example|openclaw\/unavailable/);
   assert.equal(
     parsed.jobs[0].job,
     path.relative(process.cwd(), path.join(outDir, "repair-pr-openclaw-clawsweeper-291.md")),
@@ -63,6 +64,61 @@ test("pr repair intake writes PR repair jobs for failed checks", () => {
   const job = fs.readFileSync(path.join(outDir, "repair-pr-openclaw-clawsweeper-291.md"), "utf8");
   assert.match(job, /^job_intent: pr_repair$/m);
   assert.match(job, /pnpm check: conclusion=FAILURE/);
+});
+
+test("pr repair intake supports author-wide open PR discovery", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-pr-intake-"));
+  const bin = path.join(root, "bin");
+  const outDir = path.join(root, "jobs", "runs", "author-wide");
+  fs.mkdirSync(bin);
+  writeFakeGhAuthorWide(bin);
+
+  const output = execFileSync(
+    process.execPath,
+    [
+      scriptPath,
+      "--author",
+      "Jhacarreiro",
+      "--all-open",
+      "--limit",
+      "10",
+      "--no-comments",
+      "--out-dir",
+      outDir,
+    ],
+    {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        PATH: `${path.join(root, "bin")}${path.delimiter}${process.env.PATH ?? ""}`,
+      },
+      encoding: "utf8",
+    },
+  );
+
+  const parsed = JSON.parse(output);
+  assert.equal(parsed.mode, "author-wide");
+  assert.equal(parsed.searched, 4);
+  assert.equal(parsed.repos_discovered, 4);
+  assert.equal(parsed.repos_scanned, 1);
+  assert.deepEqual(parsed.skipped_repositories, {
+    private: 1,
+    metadata_unavailable: 1,
+    unsupported_profile: 1,
+  });
+  assert.equal(parsed.candidates, 1);
+  assert.equal(parsed.jobs[0].status, "written");
+
+  const jobPath = path.join(
+    outDir,
+    "openclaw-clawsweeper",
+    "inbox",
+    "repair-pr-openclaw-clawsweeper-291.md",
+  );
+  assert.equal(fs.existsSync(jobPath), true);
+  assert.equal(fs.existsSync(path.join(outDir, "steipete-private-tool")), false);
+  assert.equal(fs.existsSync(path.join(outDir, "readonly-example")), false);
+  assert.equal(fs.existsSync(path.join(outDir, "openclaw-unavailable")), false);
 });
 
 function runIntake(root: string, extraArgs: string[]): string {
@@ -98,6 +154,66 @@ function writeFakeGh(bin: string, prs: unknown[]) {
 const args = process.argv.slice(2);
 if (args[0] === "pr" && args[1] === "list") {
   process.stdout.write(${JSON.stringify(JSON.stringify(prs))});
+  process.exit(0);
+}
+if (args[0] === "api" && args[1] === "graphql") {
+  process.stdout.write(JSON.stringify({
+    data: {
+      repository: {
+        pullRequest: {
+          reviewThreads: { nodes: [] }
+        }
+      }
+    }
+  }));
+  process.exit(0);
+}
+console.error("unexpected gh args", args.join(" "));
+process.exit(1);
+`,
+    { mode: 0o755 },
+  );
+}
+
+function writeFakeGhAuthorWide(bin: string) {
+  const gh = path.join(bin, "gh");
+  fs.writeFileSync(
+    gh,
+    `#!/usr/bin/env node
+const args = process.argv.slice(2);
+const byRepo = {
+  "openclaw/clawsweeper": [
+    {
+      number: 291,
+      title: "failed check",
+      url: "https://github.com/openclaw/clawsweeper/pull/291",
+      mergeStateStatus: "CLEAN",
+      reviewDecision: "",
+      statusCheckRollup: [{ name: "pnpm check", conclusion: "FAILURE", status: "COMPLETED" }],
+      comments: [],
+      reviews: [],
+      updatedAt: "2026-06-15T00:00:00Z",
+    },
+  ],
+};
+if (args[0] === "search" && args[1] === "prs") {
+  process.stdout.write(JSON.stringify([
+    { repository: { nameWithOwner: "openclaw/clawsweeper" } },
+    { repository: { nameWithOwner: "readonly/example" } },
+    { repository: { nameWithOwner: "steipete/private-tool" } },
+    { repository: { nameWithOwner: "openclaw/unavailable" } },
+  ]));
+  process.exit(0);
+}
+if (args[0] === "repo" && args[1] === "view") {
+  const repo = args[2];
+  if (repo === "openclaw/unavailable") process.exit(1);
+  process.stdout.write(JSON.stringify({ isPrivate: repo === "steipete/private-tool" }));
+  process.exit(0);
+}
+if (args[0] === "pr" && args[1] === "list") {
+  const repo = args[args.indexOf("--repo") + 1];
+  process.stdout.write(JSON.stringify(byRepo[repo] || []));
   process.exit(0);
 }
 if (args[0] === "api" && args[1] === "graphql") {


### PR DESCRIPTION
## Summary

- discover an author's open pull requests across GitHub
- scan only configured or supported public repositories
- fail closed for private, unsupported, or unverifiable repositories
- report aggregate skip counts without persisting excluded repository names
- thread repository context explicitly through review-thread lookup and job rendering
- preserve the existing repo-scoped command

Replaces https://github.com/openclaw/clawsweeper/pull/314 because the contributor fork is not writable by the maintainer token. Preserves contributor credit.

## Verification

- `pnpm run check`
- 526 unit tests passed
- 561 repair tests passed
- 1,087 full coverage tests passed
- Codex autoreview clean
