### PR TITLE
fix(repair): isolate issue intake runner

### DIFF
--- a/.github/workflows/repair-issue-implementation-intake.yml
+++ b/.github/workflows/repair-issue-implementation-intake.yml
@@ -76,7 +76,7 @@ concurrency:
 
 jobs:
   intake:
-    runs-on: ${{ github.event.inputs.runner || vars.CLAWSWEEPER_ISSUE_IMPLEMENTATION_INTAKE_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    runs-on: ${{ github.event.client_payload.intake_runner || vars.CLAWSWEEPER_ISSUE_IMPLEMENTATION_INTAKE_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -230,8 +230,8 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.dispatch-token.outputs.token }}
           MAX_LIVE_WORKERS: ${{ vars.CLAWSWEEPER_AUTO_IMPLEMENT_MAX_LIVE_WORKERS || '' }}
-          RUNNER: ${{ github.event.inputs.runner || vars.CLAWSWEEPER_WORKER_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
-          EXECUTION_RUNNER: ${{ github.event.inputs.execution_runner || vars.CLAWSWEEPER_EXECUTION_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
+          RUNNER: ${{ github.event.inputs.runner || github.event.client_payload.runner || vars.CLAWSWEEPER_WORKER_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+          EXECUTION_RUNNER: ${{ github.event.inputs.execution_runner || github.event.client_payload.execution_runner || vars.CLAWSWEEPER_EXECUTION_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
           MODEL: internal
         run: |
           set -euo pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Kept issue implementation intake and dispatch off the Codex worker runner by default so saturated repair capacity cannot stall eligible issue backfills before worker admission.
 - Kept unresolved rebase conflicts inside the bounded Codex repair loop and reported exhausted conflicts as human-required with exact paths. Thanks @Jhacarreiro.
 - Restored the Codex spawn helper to spam workflow sparse checkouts so repair builds can start.
 - Removed unconditional ffmpeg provisioning from review startup so optional media proof cannot block exact-review leases; unavailable media tools remain per-item evidence failures.

--- a/README.md
+++ b/README.md
@@ -440,6 +440,8 @@ appropriate repair job.
   implementation remains limited to public sibling repositories;
   `openclaw/openclaw` uses its separately gated strict-bug and vision-fit lanes,
   and `openclaw/clawhub` remains excluded.
+- Issue intake and dispatch use `ubuntu-latest` by default, independently of the
+  Blacksmith runner selected for Codex planning and repair execution.
 
 Repair internals are documented in
 [`docs/repair/README.md`](docs/repair/README.md), and the automerge state

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -16091,7 +16091,25 @@ test("spam scanner exact dispatches publish only per-comment audit records", () 
 
 test("issue implementation workflow lets job intent choose dispatch capacity", () => {
   const workflow = readFileSync(".github/workflows/repair-issue-implementation-intake.yml", "utf8");
+  const dispatchInputs = workflow.slice(
+    workflow.indexOf("  workflow_dispatch:"),
+    workflow.indexOf("\npermissions:"),
+  );
 
+  assert.equal(dispatchInputs.match(/^      [a-z_]+:/gm)?.length, 10);
+  assert.doesNotMatch(workflow, /^\s+intake_runner:/m);
+  assert.match(
+    workflow,
+    /runs-on: \$\{\{ github\.event\.client_payload\.intake_runner \|\| vars\.CLAWSWEEPER_ISSUE_IMPLEMENTATION_INTAKE_RUNNER \|\| 'ubuntu-latest' \}\}/,
+  );
+  assert.match(
+    workflow,
+    /RUNNER: \$\{\{ github\.event\.inputs\.runner \|\| github\.event\.client_payload\.runner \|\| vars\.CLAWSWEEPER_WORKER_RUNNER/,
+  );
+  assert.match(
+    workflow,
+    /EXECUTION_RUNNER: \$\{\{ github\.event\.inputs\.execution_runner \|\| github\.event\.client_payload\.execution_runner \|\| vars\.CLAWSWEEPER_EXECUTION_RUNNER/,
+  );
   assert.match(workflow, /cap_args=\(\)/);
   assert.match(workflow, /--max-live-workers "\$MAX_LIVE_WORKERS"/);
   assert.match(workflow, /"\$\{cap_args\[@\]\}"/);


### PR DESCRIPTION
## Summary

- run lightweight issue implementation intake on `ubuntu-latest` by default instead of the Codex worker pool
- preserve planning and execution runner overrides for both workflow and repository dispatches
- retain GitHub's 10-input workflow-dispatch limit with regression coverage

## Validation

- `actionlint .github/workflows/repair-issue-implementation-intake.yml`
- focused workflow contract test
- unit, repair, and coverage suites: 526 + 561 + 1,087 passing
- `pnpm run format:check`
- final Codex autoreview: clean
