### PR TITLE
Separate human-only PR intake signals

### DIFF
--- a/src/repair/pr-repair-intake.ts
+++ b/src/repair/pr-repair-intake.ts
@@ -22,6 +22,7 @@ type Candidate = {
   headRefName?: string;
   mergeStateStatus?: string;
   reviewDecision?: string;
+  labels?: LooseRecord[];
   statusCheckRollup?: JsonValue[];
   comments?: LooseRecord[];
   reviews?: LooseRecord[];
@@ -109,8 +110,10 @@ function runAuthorWideIntake() {
 
 function runRepoIntake(targetRepo: string, outDir: string): LooseRecord {
   const prs = fetchOpenPullRequests({ repo: targetRepo, author, limit });
-  const results = prs
-    .map((pr) => candidateResult(targetRepo, pr))
+  const evaluated = prs.map((pr) => candidateResult(targetRepo, pr));
+  const requiresHuman = evaluated.filter((result) => result.triage?.action === "requires_human");
+  const results = evaluated
+    .filter((result) => result.triage?.action !== "requires_human")
     .filter((result) => result.signals.length >= minSignals);
 
   if (!dryRun) fs.mkdirSync(outDir, { recursive: true });
@@ -159,6 +162,13 @@ function runRepoIntake(targetRepo: string, outDir: string): LooseRecord {
     author,
     scanned: prs.length,
     candidates: results.length,
+    requires_human: requiresHuman.map((result) => ({
+      number: result.number,
+      url: result.url,
+      reason: result.triage?.reason,
+      repairable_signals: result.triage?.repairable_signals ?? [],
+      metadata_signals: result.triage?.metadata_signals ?? [],
+    })),
     dry_run: dryRun,
     jobs: written,
   };
@@ -257,6 +267,7 @@ function fetchOpenPullRequests({
       "headRefName",
       "mergeStateStatus",
       "reviewDecision",
+      "labels",
       "statusCheckRollup",
       "comments",
       "reviews",
@@ -276,6 +287,11 @@ function candidateResult(targetRepo: string, pr: Candidate) {
   const reviewDecision = String(pr.reviewDecision ?? "").toUpperCase();
   if (reviewDecision === "CHANGES_REQUESTED") {
     blockingSignals.push({ kind: "review_decision", detail: "reviewDecision=CHANGES_REQUESTED" });
+  }
+
+  for (const label of pr.labels ?? []) {
+    const signal = labelSignal(label);
+    if (signal) blockingSignals.push(signal);
   }
 
   for (const check of pr.statusCheckRollup ?? []) {
@@ -308,6 +324,11 @@ function candidateResult(targetRepo: string, pr: Candidate) {
     }
   }
 
+  const signals = dedupeSignals([
+    ...blockingSignals,
+    ...(blockingSignals.length > 0 || includeReviewOnly ? contextSignals : []),
+  ]).slice(0, 12);
+
   return {
     number: pr.number,
     title: pr.title,
@@ -315,11 +336,78 @@ function candidateResult(targetRepo: string, pr: Candidate) {
     baseRefName: pr.baseRefName ?? "main",
     headRefName: pr.headRefName ?? "",
     updatedAt: pr.updatedAt ?? "",
-    signals: dedupeSignals([
-      ...blockingSignals,
-      ...(blockingSignals.length > 0 || includeReviewOnly ? contextSignals : []),
-    ]).slice(0, 12),
+    triage: triageDecision(pr, signals),
+    signals,
   };
+}
+
+function triageDecision(pr: Candidate, signals: Signal[]) {
+  if (signals.length === 0) return null;
+
+  const repairable = signals.filter((signal) => isRepairableSignal(pr, signal, signals));
+  if (repairable.length > 0) return null;
+
+  const metadata = signals.filter((signal) => isHumanOrMetadataSignal(pr, signal, signals));
+  if (metadata.length === 0) return null;
+
+  return {
+    action: "requires_human",
+    reason:
+      "No repairable blocker was detected. Remaining signals look like human/review workflow or stale metadata, so do not create an automatic repair job.",
+    repairable_signals: repairable,
+    metadata_signals: metadata,
+  };
+}
+
+function isRepairableSignal(pr: Candidate, signal: Signal, allSignals: Signal[]) {
+  switch (signal.kind) {
+    case "check_failed":
+    case "review_decision":
+    case "review_thread_unresolved":
+    case "review_changes_requested":
+    case "review_actionable":
+      return true;
+    case "merge_state":
+      return /mergeStateStatus=(DIRTY|BLOCKED)/i.test(signal.detail);
+    case "comment_actionable":
+      return !hasProofSufficientLabel(pr) || hasHardRepairableSignal(allSignals);
+    default:
+      return false;
+  }
+}
+
+function hasHardRepairableSignal(signals: Signal[]) {
+  return signals.some((signal) => {
+    if (
+      [
+        "check_failed",
+        "review_decision",
+        "review_thread_unresolved",
+        "review_changes_requested",
+        "review_actionable",
+      ].includes(signal.kind)
+    )
+      return true;
+    if (signal.kind === "merge_state")
+      return /mergeStateStatus=(DIRTY|BLOCKED)/i.test(signal.detail);
+    return false;
+  });
+}
+
+function isHumanOrMetadataSignal(pr: Candidate, signal: Signal, allSignals: Signal[]) {
+  if (["clawsweeper_status", "clawsweeper_rating", "clawsweeper_merge_risk"].includes(signal.kind))
+    return true;
+  if (signal.kind === "merge_state" && !isRepairableSignal(pr, signal, allSignals)) return true;
+  if (signal.kind === "comment_actionable" && !isRepairableSignal(pr, signal, allSignals))
+    return true;
+  return false;
+}
+
+function hasProofSufficientLabel(pr: Candidate) {
+  return (pr.labels ?? []).some(
+    (label) =>
+      String(objectRecord(label).name ?? label ?? "").toLowerCase() === "proof: sufficient",
+  );
 }
 
 function unresolvedReviewThreadSignals(targetRepo: string, number: number): Signal[] {
@@ -359,6 +447,22 @@ function reviewThreadSignal(thread: LooseRecord): Signal | null {
     detail: compact(`unresolved review thread by ${loginOf(latest.author)}: ${latest.body ?? ""}`),
     source: String(latest.url ?? ""),
   };
+}
+
+function labelSignal(label: JsonValue): Signal | null {
+  const record = objectRecord(label);
+  const name = String(record.name ?? label ?? "");
+  const normalized = name.toLowerCase();
+  if (!normalized.trim()) return null;
+  if (normalized.startsWith("status:") && normalized.includes("needs proof"))
+    return { kind: "clawsweeper_status", detail: "label=" + name };
+  if (normalized.startsWith("status:") && normalized.includes("waiting on author"))
+    return { kind: "clawsweeper_status", detail: "label=" + name };
+  if (normalized.startsWith("rating:") && normalized.includes("unranked krab"))
+    return { kind: "clawsweeper_rating", detail: "label=" + name };
+  if (normalized.startsWith("merge-risk:"))
+    return { kind: "clawsweeper_merge_risk", detail: "label=" + name };
+  return null;
 }
 
 function checkSignal(check: JsonValue): Signal | null {

--- a/test/repair/pr-repair-intake.test.ts
+++ b/test/repair/pr-repair-intake.test.ts
@@ -121,6 +121,66 @@ test("pr repair intake supports author-wide open PR discovery", () => {
   assert.equal(fs.existsSync(path.join(outDir, "openclaw-unavailable")), false);
 });
 
+test("pr repair intake routes metadata-only ClawSweeper labels to human review", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-pr-intake-"));
+  const bin = path.join(root, "bin");
+  fs.mkdirSync(bin);
+  writeFakeGh(bin, [
+    {
+      number: 292,
+      title: "metadata only",
+      url: "https://github.com/openclaw/clawsweeper/pull/292",
+      mergeStateStatus: "CLEAN",
+      reviewDecision: "",
+      labels: [{ name: "status: 📣 needs proof" }, { name: "rating: 🧂 unranked krab" }],
+      statusCheckRollup: [],
+      comments: [],
+      reviews: [],
+      updatedAt: "2026-06-15T00:00:00Z",
+    },
+  ]);
+
+  const output = runIntake(root, ["--dry-run"]);
+  const parsed = JSON.parse(output);
+  assert.equal(parsed.scanned, 1);
+  assert.equal(parsed.candidates, 0);
+  assert.deepEqual(parsed.jobs, []);
+  assert.equal(parsed.requires_human[0].number, 292);
+  assert.match(parsed.requires_human[0].reason, /No repairable blocker/);
+  assert.deepEqual(
+    parsed.requires_human[0].metadata_signals.map((signal: { kind: string }) => signal.kind),
+    ["clawsweeper_status", "clawsweeper_rating"],
+  );
+});
+
+test("pr repair intake still writes jobs when objective repair blockers exist", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-pr-intake-"));
+  const bin = path.join(root, "bin");
+  const outDir = path.join(root, "jobs", "openclaw", "inbox");
+  fs.mkdirSync(bin);
+  writeFakeGh(bin, [
+    {
+      number: 293,
+      title: "metadata plus failed check",
+      url: "https://github.com/openclaw/clawsweeper/pull/293",
+      mergeStateStatus: "CLEAN",
+      reviewDecision: "",
+      labels: [{ name: "status: 📣 needs proof" }],
+      statusCheckRollup: [{ name: "pnpm check", conclusion: "FAILURE", status: "COMPLETED" }],
+      comments: [],
+      reviews: [],
+      updatedAt: "2026-06-15T00:00:00Z",
+    },
+  ]);
+
+  const output = runIntake(root, ["--out-dir", outDir]);
+  const parsed = JSON.parse(output);
+  assert.equal(parsed.candidates, 1);
+  assert.deepEqual(parsed.requires_human, []);
+  assert.equal(parsed.jobs[0].status, "written");
+  assert.equal(parsed.jobs[0].number, 293);
+});
+
 function runIntake(root: string, extraArgs: string[]): string {
   return execFileSync(
     process.execPath,


### PR DESCRIPTION
## Summary

Reintroduce only the focused human-only PR intake classification from #333, rebuilt on current `main` after #335 landed.

This PR classifies metadata-only ClawSweeper signals as `requires_human` instead of enqueueing a repair job, while preserving repair jobs when objective repair blockers exist.

## Scope

```text
- human-only / metadata-only classification only
- no watch-silence state
- no fingerprinting
- no adapter/model code
- preserves author-wide intake from #335
```

## Validation

```text
corepack pnpm run build:repair
node --test test/repair/pr-repair-intake.test.ts
```

Result:

```text
build:repair: passed
pr-repair-intake.test.ts: 5/5 tests passed
```

Covered cases:

```text
- cancelled-only checks stay ignored
- failed checks still write repair jobs
- author-wide discovery still works
- metadata-only ClawSweeper labels route to requires_human
- metadata plus failed check still writes a repair job
```

## Real dry-run proof

After rebuilding this branch locally from `fix/human-only-pr-intake-v2`, I reran the dry-runs requested by review.

Validation:

```text
corepack pnpm run build:repair
node --test test/repair/pr-repair-intake.test.ts
```

Result:

```text
build:repair: passed
pr-repair-intake.test.ts: 5/5 tests passed
```

### 1. Metadata-only PR becomes `requires_human`, no repair job

Command:

```text
node dist/repair/pr-repair-intake.js --repo openclaw/clawsweeper --author Jhacarreiro --limit 100 --dry-run --no-comments
```

Redacted output summary:

```json
{
  "status": "ok",
  "repo": "openclaw/clawsweeper",
  "author": "Jhacarreiro",
  "scanned": 1,
  "candidates": 0,
  "requires_human": [
    {
      "number": 339,
      "url": "https://github.com/openclaw/clawsweeper/pull/339",
      "reason": "No repairable blocker was detected. Remaining signals look like human/review workflow or stale metadata, so do not create an automatic repair job.",
      "repairable_signals": [],
      "metadata_signals": [
        { "kind": "clawsweeper_rating", "detail": "label=rating: unranked krab" },
        { "kind": "clawsweeper_status", "detail": "label=status: needs proof" },
        { "kind": "clawsweeper_merge_risk", "detail": "label=merge-risk: automation" }
      ]
    }
  ],
  "jobs": []
}
```

### 2. Objectively repairable PR still creates a repair job

Command:

```text
node dist/repair/pr-repair-intake.js --repo Jhacarreiro/clawsweeper --author Jhacarreiro --limit 100 --dry-run --no-comments
```

Redacted output summary:

```json
{
  "status": "ok",
  "repo": "Jhacarreiro/clawsweeper",
  "author": "Jhacarreiro",
  "scanned": 1,
  "candidates": 1,
  "requires_human": [],
  "jobs": [
    {
      "status": "planned",
      "job": "jobs/Jhacarreiro/inbox/repair-pr-jhacarreiro-clawsweeper-2.md",
      "number": 2,
      "signals": [
        { "kind": "check_failed", "detail": "pnpm check: conclusion=FAILURE" }
      ]
    }
  ]
}
```

This covers both sides requested by review: metadata-only PRs are not enqueued as repair jobs, and objectively failed-check PRs remain repair candidates.
