### PR TITLE
Enforce repair contract at every checkpoint

### DIFF
--- a/src/repair/execute-fix-artifact.ts
+++ b/src/repair/execute-fix-artifact.ts
@@ -2145,9 +2145,11 @@ function editValidatePrepareMerge({
     });
   }
 
-  const firstCheckpoint = commitCheckpointIfNeeded({
+  const firstCheckpoint = commitRepairCheckpointIfNeeded({
+    fixArtifact,
     targetDir,
     message: fixArtifact.pr_title,
+    phase: "initial",
     trailers: mode === "replacement" ? coAuthorTrailers(contributorCredits) : [],
   });
   if (firstCheckpoint) {
@@ -2176,9 +2178,11 @@ function editValidatePrepareMerge({
       baseBranch,
       sourceHead: repairDeltaBaseHead,
       onReviewFix: (reviewAttempt: JsonValue) => {
-        const checkpoint = commitCheckpointIfNeeded({
+        const checkpoint = commitRepairCheckpointIfNeeded({
+          fixArtifact,
           targetDir,
           message: `fix(clawsweeper): address review for ${result.cluster_id} (${reviewAttempt})`,
+          phase: `review-fix-${reviewAttempt}`,
           trailers: mode === "replacement" ? coAuthorTrailers(contributorCredits) : [],
         });
         if (checkpoint) {
@@ -2207,9 +2211,11 @@ function editValidatePrepareMerge({
       headSha: currentHead(targetDir),
     });
     if (sync.status === "already-current") break;
-    const checkpoint = commitCheckpointIfNeeded({
+    const checkpoint = commitRepairCheckpointIfNeeded({
+      fixArtifact,
       targetDir,
       message: `fix(clawsweeper): reconcile ${result.cluster_id} with main (${attempt})`,
+      phase: `base-sync-${attempt}`,
       trailers: mode === "replacement" ? coAuthorTrailers(contributorCredits) : [],
     });
     if (checkpoint) {
@@ -2227,9 +2233,11 @@ function editValidatePrepareMerge({
       break;
     }
   }
-  const finalCheckpoint = commitCheckpointIfNeeded({
+  const finalCheckpoint = commitRepairCheckpointIfNeeded({
+    fixArtifact,
     targetDir,
     message: `fix(clawsweeper): finalize ${result.cluster_id}`,
+    phase: "finalize",
     trailers: mode === "replacement" ? coAuthorTrailers(contributorCredits) : [],
   });
   if (finalCheckpoint) {
@@ -3300,13 +3308,85 @@ function checkoutRecoverableReplacementBranch({
   return { resumed: false, branch };
 }
 
-function commitCheckpointIfNeeded({ targetDir, message, trailers = [] }: LooseRecord) {
-  if (!run("git", ["status", "--porcelain"], { cwd: targetDir }).trim()) return "";
+function commitRepairCheckpointIfNeeded({
+  fixArtifact,
+  targetDir,
+  message,
+  phase,
+  trailers = [],
+}: LooseRecord) {
+  const status = run("git", ["status", "--porcelain"], { cwd: targetDir }).trim();
+  if (!status) return "";
+  enforceRepairCheckpointContract({ fixArtifact, phase, status });
   run("git", ["add", "--all"], { cwd: targetDir });
   const args = ["commit", "-m", message];
   for (const trailer of uniqueStrings(trailers)) args.push("-m", trailer);
   runGitNetwork(args, targetDir);
   return run("git", ["rev-parse", "HEAD"], { cwd: targetDir }).trim();
+}
+
+function enforceRepairCheckpointContract({ fixArtifact, phase, status }: LooseRecord) {
+  const mustTouch = repairCheckpointMustTouchFiles(fixArtifact);
+  if (mustTouch.length === 0) return;
+
+  const changedFiles = changedFilesFromPorcelainStatus(String(status));
+  if (
+    changedFiles.some((file) =>
+      mustTouch.some((expected) => changedFileMatchesContract(file, expected)),
+    )
+  ) {
+    return;
+  }
+
+  throw new Error(
+    [
+      `repair checkpoint contract rejected ${String(phase || "checkpoint")}: no must_touch file changed`,
+      `must_touch=${mustTouch.join(", ")}`,
+      `changed_files=${changedFiles.join(", ") || "none"}`,
+    ].join("; "),
+  );
+}
+
+function repairCheckpointMustTouchFiles(fixArtifact: LooseRecord): string[] {
+  const candidates = [
+    ...jsonStringArray(fixArtifact.must_touch),
+    ...jsonStringArray(fixArtifact.must_touch_files),
+  ];
+  return uniqueStrings(candidates.map(normalizeRepairContractPath).filter(Boolean));
+}
+
+function jsonStringArray(value: JsonValue): string[] {
+  return Array.isArray(value) ? value.map((entry) => String(entry)) : [];
+}
+
+function changedFilesFromPorcelainStatus(status: string): string[] {
+  return uniqueStrings(
+    status
+      .split(/\r?\n/)
+      .flatMap((line) => porcelainChangedPaths(line))
+      .map(normalizeRepairContractPath)
+      .filter(Boolean),
+  );
+}
+
+function porcelainChangedPaths(line: string): string[] {
+  if (line.length < 4) return [];
+  const body = line.slice(3).trim();
+  if (!body) return [];
+  const renamed = body.split(" -> ");
+  return renamed.length === 2 ? [renamed[1] ?? ""] : [body];
+}
+
+function changedFileMatchesContract(changedFile: string, expected: string) {
+  return changedFile === expected || changedFile.startsWith(`${expected.replace(/\/$/, "")}/`);
+}
+
+function normalizeRepairContractPath(value: JsonValue): string {
+  const pathValue = String(value ?? "").trim();
+  if (!pathValue || pathValue.startsWith("/") || pathValue.includes("\0")) return "";
+  if (/[`$;&|<>()[\]{}*?~]/.test(pathValue)) return "";
+  if (pathValue.split(/[\\/]/).includes("..")) return "";
+  return pathValue.replace(/^\.\//, "");
 }
 
 function pushRecoverableBranch({ targetDir, branch }: LooseRecord) {

--- a/test/repair/execute-fix-artifact-source.test.ts
+++ b/test/repair/execute-fix-artifact-source.test.ts
@@ -148,3 +148,61 @@ test("issue implementation rechecks opt-out labels immediately before branch pus
   assert.match(source.slice(helperStart, helperEnd), /repairPauseLabel\(issue\.labels\)/);
   assert.match(source.slice(helperStart, helperEnd), /refusing to push or open a PR/);
 });
+
+test("repair contract checkpoints use one helper for every checkpoint path", () => {
+  const source = fs.readFileSync(
+    path.join(process.cwd(), "src/repair/execute-fix-artifact.ts"),
+    "utf8",
+  );
+  assert.equal(
+    [...source.matchAll(/commitCheckpointIfNeeded\(/g)].length,
+    0,
+    "legacy unguarded checkpoint helper must not remain",
+  );
+  assert.equal(
+    [...source.matchAll(/commitRepairCheckpointIfNeeded\(/g)].length,
+    5,
+    "four checkpoint call sites plus the helper definition should use the guarded helper",
+  );
+  assert.match(source, /phase: "initial"/);
+  assert.match(source, /phase: `review-fix-\$\{reviewAttempt\}`/);
+  assert.match(source, /phase: `base-sync-\$\{attempt\}`/);
+  assert.match(source, /phase: "finalize"/);
+});
+
+test("repair checkpoint contract is explicit must_touch and bypasses incomplete likely_files", () => {
+  const source = fs.readFileSync(
+    path.join(process.cwd(), "src/repair/execute-fix-artifact.ts"),
+    "utf8",
+  );
+  const helperStart = source.indexOf("function repairCheckpointMustTouchFiles(");
+  const helperEnd = source.indexOf("function changedFilesFromPorcelainStatus(", helperStart);
+  assert.notEqual(helperStart, -1);
+  assert.notEqual(helperEnd, -1);
+  const helper = source.slice(helperStart, helperEnd);
+  assert.match(helper, /fixArtifact\.must_touch/);
+  assert.match(helper, /fixArtifact\.must_touch_files/);
+  assert.doesNotMatch(helper, /likely_files/);
+
+  const enforceStart = source.indexOf("function enforceRepairCheckpointContract(");
+  const enforceEnd = source.indexOf("function repairCheckpointMustTouchFiles(", enforceStart);
+  assert.notEqual(enforceStart, -1);
+  const enforce = source.slice(enforceStart, enforceEnd);
+  assert.match(enforce, /if \(mustTouch\.length === 0\) return;/);
+  assert.match(enforce, /repair checkpoint contract rejected/);
+});
+
+test("repair contract parser preserves git porcelain path offsets", () => {
+  const source = fs.readFileSync(
+    path.join(process.cwd(), "src/repair/execute-fix-artifact.ts"),
+    "utf8",
+  );
+  const parserStart = source.indexOf("function porcelainChangedPaths(");
+  const parserEnd = source.indexOf("function changedFileMatchesContract(", parserStart);
+  assert.notEqual(parserStart, -1);
+  assert.notEqual(parserEnd, -1);
+  const parser = source.slice(parserStart, parserEnd);
+  assert.match(parser, /line\.slice\(3\)/);
+  assert.doesNotMatch(parser, /status\.slice\(3\)|text\.slice\(3\)/);
+  assert.match(parser, /body\.split\(" -> "\)/);
+});


### PR DESCRIPTION
## Summary

Rebuild the closed repair-contract proposal from current `main` following the maintainer guidance on #336.

This version:

```text
- starts from current main;
- removes the duplicated conflict-prompt work already landed in #332;
- routes all four checkpoint paths through one contract-enforcing helper;
- enforces only explicit `must_touch` / `must_touch_files`, not incomplete `likely_files`;
- includes the porcelain path parser fix from fork PR #2;
- adds focused source regression coverage for checkpoint centralization, `likely_files` bypass, and porcelain parsing.
```

## Why this is narrower than #336

The previous branch failed because it guarded only the first checkpoint and mixed in conflict-prompt behavior. This PR only changes checkpoint acceptance.

The contract is intentionally explicit: if the artifact does not declare `must_touch` / `must_touch_files`, checkpointing behaves as before. This avoids fail-closing valid repairs when `likely_files` is stale or incomplete.

## Validation

```text
corepack pnpm run build:repair
node --test test/repair/execute-fix-artifact-source.test.ts
corepack pnpm run lint:repair
corepack pnpm run format:check
```

Result:

```text
build:repair: passed
execute-fix-artifact-source.test.ts: 9/9 passed
lint:repair: 0 warnings, 0 errors
format:check: passed
```

I also started `corepack pnpm run check`; it passed build/lint and entered the long unit/coverage portion, but the terminal wrapper timed out before the full command completed. I am not claiming a completed full `pnpm check` run from this local session.

## Local repair-worker proof

I ran `dist/repair/execute-fix-artifact.js --dry-run` against temporary local checkouts with `CODEX_BIN` pointed at a local fake Codex harness. This is local worker proof of the checkpoint gate, not a real model-quality run.

### Allowed case: worker touches `must_touch`

Fixture:

```json
{
  "must_touch": ["docs/repair-contract-proof.md"],
  "validation_commands": ["git diff --check"]
}
```

Fake worker touched:

```text
docs/repair-contract-proof.md
```

Observed output:

```text
target validation plan accepted
Codex write preflight passed: skipped
starting Codex edit pass
Codex edit pass finished: status 0
```

Observed git result:

```text
commit created: test: local repair contract proof
working tree: clean
```

The run then reached the later validation/review loop and was blocked by the target repo's default `pnpm check:changed` because the temporary clone had no installed dependencies. That is after the checkpoint gate had already allowed and committed the `must_touch` change.

### Blocked case: worker touches only an off-contract file

Fixture:

```json
{
  "must_touch": ["docs/repair-contract-proof.md"],
  "validation_commands": ["git diff --check"]
}
```

Fake worker touched:

```text
docs/off-contract-proof.md
```

Observed failure before checkpoint:

```text
Error: repair checkpoint contract rejected initial: no must_touch file changed; must_touch=docs/repair-contract-proof.md; changed_files=docs/off-contract-proof.md
```

Observed git result:

```text
no checkpoint commit created
working tree still has: ?? docs/off-contract-proof.md
```

## Notes

This PR intentionally does not update or reopen #336. If this lands, fork PR https://github.com/Jhacarreiro/clawsweeper/pull/2 can be closed as superseded because its porcelain parser fix is included here.
