### PR TITLE
fix(ci): reduce ClawSweeper GitHub API pressure

### DIFF
--- a/.github/workflows/commit-review.yml
+++ b/.github/workflows/commit-review.yml
@@ -202,8 +202,7 @@ jobs:
                 active_shards=0
               fi
               # Planning, publish, queued, and not-yet-expanded matrix runs have not
-              # created shard jobs yet. Reserve their quiet lane size so commit review
-              # does not over-allocate while a sweep matrix is still expanding.
+              # created shard jobs yet. Reserve their quiet lane size while they expand.
               if [ "$active_shards" -lt 1 ]; then
                 if [ "$title" = "Review hot ClawSweeper items" ]; then
                   active_shards="$(pnpm --dir clawsweeper run --silent workflow -- limit review_shards.hot_intake_default)"

--- a/.github/workflows/github-activity.yml
+++ b/.github/workflows/github-activity.yml
@@ -91,53 +91,6 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Dispatch spam comment intake candidates
-        if: steps.core-budget.outputs.skip != 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          payload_path="$RUNNER_TEMP/spam-comment-intake-dispatch.json"
-          node <<'NODE' > "$payload_path"
-          const fs = require("fs");
-          const eventName = process.env.GITHUB_EVENT_NAME || "";
-          const root = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"));
-          const clientPayload = root.client_payload || {};
-          const activity = clientPayload.activity || clientPayload || {};
-          const type = activity.type || clientPayload.event_name || (eventName === "repository_dispatch" ? "" : eventName);
-          const action = activity.action || clientPayload.action || root.action || "";
-          if (!["issue_comment", "pull_request_review_comment"].includes(type)) process.exit(0);
-          if (!["created", "edited"].includes(action)) process.exit(0);
-          const repo =
-            activity.target_repo ||
-            activity.repo ||
-            (activity.repository && activity.repository.full_name) ||
-            (typeof activity.repository === "string" && activity.repository) ||
-            clientPayload.target_repo ||
-            clientPayload.repo ||
-            (clientPayload.repository && clientPayload.repository.full_name) ||
-            (typeof clientPayload.repository === "string" && clientPayload.repository) ||
-            (root.repository && root.repository.full_name) ||
-            process.env.GITHUB_REPOSITORY;
-          process.stdout.write(JSON.stringify({
-            event_type: "clawsweeper_spam_comment_intake",
-            client_payload: {
-              target_repo: repo,
-              event_name: type,
-              action,
-              activity: { ...activity, type, action, repo },
-            },
-          }));
-          NODE
-          if [ ! -s "$payload_path" ]; then
-            echo "No spam comment intake candidate for this activity."
-            exit 0
-          fi
-          gh api "repos/${GITHUB_REPOSITORY}/dispatches" \
-            --method POST \
-            --input "$payload_path"
-
       - uses: actions/checkout@v6
         if: steps.core-budget.outputs.skip != 'true'
         with:
@@ -194,6 +147,14 @@ jobs:
             sleep "$((attempt * 10))"
           done
           pnpm run build:repair
+
+      - name: Dispatch spam scan candidate
+        if: steps.core-budget.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          pnpm run repair:spam-comment-intake -- --write-report
 
       - name: Feed activity to OpenClaw
         if: steps.core-budget.outputs.skip != 'true'

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -994,8 +994,7 @@ jobs:
                 active_shards=0
               fi
               # Planning, publish, queued, and not-yet-expanded matrix runs have not
-              # created shard jobs yet. Reserve their quiet lane size so a second
-              # planner cannot over-allocate before the first matrix expands.
+              # created shard jobs yet. Reserve their quiet lane size while they expand.
               if [ "$active_shards" -lt 1 ]; then
                 if [ "$title" = "Review hot ClawSweeper items" ] || [[ "$title" == Review\ hot\ target\ repo\ * ]]; then
                   active_shards="$(limit review_shards.hot_intake_default)"

--- a/docs/target-dispatcher.md
+++ b/docs/target-dispatcher.md
@@ -230,3 +230,45 @@ The event job creates only a target read token before Codex runs. The target
 write token and the repository push token are introduced after Codex exits, and
 the same `apply-decisions` guard path still re-fetches the item before any
 comment or close mutation.
+
+## Rate-limit-safe CI setup
+
+Install one dispatcher workflow per target repository. Keep the event fanout
+inside that workflow; do not add separate comment, spam, or generic-activity
+dispatch workflows in the target repository.
+
+The snippet below is only the trigger, permission, and concurrency fragment.
+It is not a complete workflow; use the full dispatcher example above as the
+copy-pasteable job definition.
+
+```yaml
+name: ClawSweeper Dispatch
+
+on:
+  issues:
+    types: [opened, reopened, edited, labeled, unlabeled]
+  issue_comment:
+    types: [created, edited]
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review, edited, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: clawsweeper-dispatch-${{ github.repository }}-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event.action == 'edited' || github.event.action == 'synchronize' || github.event.action == 'ready_for_review' }}
+```
+
+The job should mint one short-lived `clawsweeper` App token scoped to
+`openclaw/clawsweeper`, then send one `clawsweeper_item` or
+`clawsweeper_comment` `repository_dispatch`. For comments, check the command
+syntax before minting a target write token. Do not use a PAT or dispatch the
+same comment through both the exact router and a second spam/generic workflow.
+
+The ClawSweeper `github-activity` workflow performs spam-candidate
+classification in-process and only dispatches the scanner for an accepted
+candidate. This keeps ordinary comments to one activity run instead of an
+activity run plus a second intake workflow. Preserve the source delivery or
+comment id in every payload so receiver-side deduplication can collapse
+redeliveries.

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -91,6 +91,7 @@ export { itemNumbersArg } from "./clawsweeper-args.js";
 export { safeOutputTail } from "./clawsweeper-text.js";
 export {
   ghRetryKind,
+  ghRetryWaitMs,
   isGitHubNotFoundError,
   isGitHubRequiresAuthenticationError,
   isLockedConversationCommentError,

--- a/src/github-retry.ts
+++ b/src/github-retry.ts
@@ -4,10 +4,12 @@ const GH_THROTTLE_PATTERNS = [
   /was submitted too quickly/i,
   /secondary rate/i,
   /API rate limit exceeded/i,
+  /rate limit/i,
 ];
 
 const GH_TRANSIENT_PATTERNS = [
   /unexpected EOF/i,
+  /connection reset/i,
   /connection reset by peer/i,
   /error connecting to api\.github\.com/i,
   /bad gateway/i,
@@ -20,12 +22,18 @@ const GH_TRANSIENT_PATTERNS = [
   /TLS handshake timeout/i,
   /\bi\/o timeout\b/i,
   /Client\.Timeout exceeded/i,
+  /connection refused/i,
+  /could not resolve host/i,
+  /timed out/i,
+  /\btimeout\b/i,
   /temporary failure/i,
+  /try again later/i,
 ];
 
 export function ghRetryKind(error: unknown): GhRetryKind {
   const message = ghErrorText(error);
   if (GH_THROTTLE_PATTERNS.some((pattern) => pattern.test(message))) return "throttle";
+  if (hasGitHubStatus(message, [429])) return "throttle";
   if (hasGitHubStatus(message, [500, 502, 503, 504])) return "transient";
   if (GH_TRANSIENT_PATTERNS.some((pattern) => pattern.test(message))) return "transient";
   return "none";
@@ -56,7 +64,7 @@ export function isGitHubRequiresAuthenticationError(error: unknown): boolean {
 }
 
 export function ghRetryWaitMs(kind: GhRetryKind, attempt: number): number {
-  if (kind === "throttle") return Math.min(600_000, 30_000 * 2 ** attempt);
+  if (kind === "throttle") return Math.min(60_000, 30_000 * 2 ** attempt);
   if (kind === "transient") return Math.min(60_000, 2_000 * 2 ** attempt);
   return 0;
 }

--- a/src/repair/github-cli.ts
+++ b/src/repair/github-cli.ts
@@ -4,6 +4,7 @@ import { promisify } from "node:util";
 import { stripAnsi } from "./comment-router-utils.js";
 import { ghCliEnv } from "./process-env.js";
 import { repoRoot } from "./paths.js";
+import { ghRetryKind, ghRetryWaitMs } from "../github-retry.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -131,8 +132,9 @@ export function ghPagedLimitWithRetry<T = JsonValue>(
       return ghPagedLimit<T>(apiPath, limit, resolved);
     } catch (error) {
       lastError = error;
-      if (attempt >= attempts || !shouldRetryGh(error)) throw error;
-      sleepMs(Math.min(1000 * attempt, 5000));
+      const retryKind = ghRetryKind(error);
+      if (attempt >= attempts || retryKind === "none") throw error;
+      sleepMs(ghRetryWaitMs(retryKind, attempt - 1));
     }
   }
   throw lastError instanceof Error ? lastError : new Error(String(lastError));
@@ -159,8 +161,9 @@ export function ghTextWithRetry(ghArgs: string[], options: GhRetryOptions | numb
       return ghText(ghArgs, resolved);
     } catch (error) {
       lastError = error;
-      if (attempt >= attempts || !shouldRetryGh(error)) throw error;
-      sleepMs(Math.min(1000 * attempt, 5000));
+      const retryKind = ghRetryKind(error);
+      if (attempt >= attempts || retryKind === "none") throw error;
+      sleepMs(ghRetryWaitMs(retryKind, attempt - 1));
     }
   }
   throw lastError instanceof Error ? lastError : new Error(String(lastError));
@@ -178,8 +181,9 @@ export async function ghTextWithRetryAsync(
       return await ghTextAsync(ghArgs, resolved);
     } catch (error) {
       lastError = error;
-      if (attempt >= attempts || !shouldRetryGh(error)) throw error;
-      await sleepAsync(Math.min(1000 * attempt, 5000));
+      const retryKind = ghRetryKind(error);
+      if (attempt >= attempts || retryKind === "none") throw error;
+      await sleepAsync(ghRetryWaitMs(retryKind, attempt - 1));
     }
   }
   throw lastError instanceof Error ? lastError : new Error(String(lastError));
@@ -255,27 +259,6 @@ export function ghStdoutFromError(error: unknown): string {
   return stripAnsi(
     bufferLikeToString(commandError.stdout ?? commandError.output?.[1] ?? ""),
   ).trim();
-}
-
-export function shouldRetryGh(error: unknown): boolean {
-  const text = ghErrorText(error).toLowerCase();
-  return (
-    text.includes("http 502") ||
-    text.includes("http 503") ||
-    text.includes("http 504") ||
-    text.includes("bad gateway") ||
-    text.includes("gateway timeout") ||
-    text.includes("service unavailable") ||
-    text.includes("timed out") ||
-    text.includes("timeout") ||
-    text.includes("connection reset") ||
-    text.includes("connection refused") ||
-    text.includes("could not resolve host") ||
-    text.includes("temporary failure") ||
-    text.includes("try again later") ||
-    text.includes("secondary rate limit") ||
-    text.includes("rate limit")
-  );
 }
 
 function resolveRetryOptions(options: GhRetryOptions | number): GhRetryOptions {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -30,6 +30,7 @@ import {
   fixedPullRequestFromCommitPullsForTest,
   formatRecentClosedRows,
   ghRetryKind,
+  ghRetryWaitMs,
   hotIntakeRecencyMs,
   isCodexReviewCommentBody,
   isInfrastructureFailedReviewForTest,
@@ -13754,6 +13755,7 @@ test("review capacity probes use REST actions run listing", () => {
     assert.match(block, /updatedAt:\.updated_at/);
     assert.match(block, /STALE_QUEUED_CUTOFF/);
     assert.doesNotMatch(block, /gh run list/);
+    assert.match(block, /gh run view/);
   }
 });
 
@@ -13949,20 +13951,10 @@ test("github activity workflow scopes cancellation to matching item activity", (
   assert.match(workflow, /Check core API budget/);
   assert.match(workflow, /CLAWSWEEPER_MIN_CORE_REMAINING/);
   assert.match(workflow, /contents: write/);
-  assert.match(workflow, /Dispatch spam comment intake candidates/);
-  assert.match(workflow, /clawsweeper_spam_comment_intake/);
-  assert.match(workflow, /\["issue_comment", "pull_request_review_comment"\]/);
-  assert.match(workflow, /\["created", "edited"\]/);
-  const dispatchStep = workflow.slice(
-    workflow.indexOf("- name: Dispatch spam comment intake candidates"),
-    workflow.indexOf("\n      - uses: actions/checkout@v6"),
-  );
-  const dispatchScript = dispatchStep
-    .slice(dispatchStep.indexOf("        run: |\n") + "        run: |\n".length)
-    .split("\n")
-    .map((line) => line.replace(/^ {10}/, ""))
-    .join("\n");
-  execFileSync("bash", ["-n"], { input: dispatchScript });
+  assert.doesNotMatch(workflow, /Dispatch spam comment intake candidates/);
+  assert.match(workflow, /Dispatch spam scan candidate/);
+  assert.match(workflow, /repair:spam-comment-intake -- --write-report/);
+  assert.doesNotMatch(workflow, /gh api "repos\/\$\{GITHUB_REPOSITORY\}\/dispatches"/);
   assert.match(concurrencyBlock, /cancel-in-progress: true/);
   assert.doesNotMatch(
     concurrencyBlock,
@@ -14802,6 +14794,10 @@ test("GitHub retry classifier distinguishes throttle and transient failures", ()
   const throttled = new Error("API rate limit exceeded for user ID 1");
   assert.equal(ghRetryKind(throttled), "throttle");
   assert.equal(shouldRetryGh(throttled), true);
+  assert.equal(ghRetryKind(new Error("gh: HTTP 429: Too Many Requests")), "throttle");
+  assert.equal(ghRetryWaitMs("throttle", 0), 30_000);
+  assert.equal(ghRetryWaitMs("throttle", 3), 60_000);
+  assert.equal(ghRetryWaitMs("transient", 0), 2_000);
 
   const eof = Object.assign(new Error("Command failed: gh api repos/openclaw/openclaw/issues"), {
     stderr: 'Get "https://api.github.com/repos/openclaw/openclaw/issues?page=54": unexpected EOF\n',
@@ -14813,6 +14809,7 @@ test("GitHub retry classifier distinguishes throttle and transient failures", ()
     "Post https://api.github.com/graphql: read: connection reset by peer",
   );
   assert.equal(ghRetryKind(connectionReset), "transient");
+  assert.equal(ghRetryKind(new Error("read: connection reset")), "transient");
 
   const badGateway = Object.assign(new Error("gh: HTTP 502: Bad Gateway"), { stderr: "" });
   assert.equal(ghRetryKind(badGateway), "transient");
@@ -14830,6 +14827,9 @@ test("GitHub retry classifier distinguishes throttle and transient failures", ()
     { stderr: "invalid character '<' looking for beginning of value\n" },
   );
   assert.equal(ghRetryKind(htmlInsteadOfJson), "transient");
+  assert.equal(ghRetryKind(new Error("dial tcp: connection refused")), "transient");
+  assert.equal(ghRetryKind(new Error("Could not resolve host: api.github.com")), "transient");
+  assert.equal(ghRetryKind(new Error("request timed out")), "transient");
 
   const authFailure = Object.assign(new Error("gh: HTTP 401: Bad credentials"), {
     stderr: "Bad credentials",


### PR DESCRIPTION
## Summary

Reduce GitHub API pressure across ClawSweeper intake and review workers:
- classify spam-comment candidates in-process before dispatching scanner work
- centralize retry classification and bounded throttle waits across repair GitHub CLI calls
- retain paginated status discovery while avoiding speculative capacity loss
- document the one-dispatcher, one-token target setup

## Verification

- CI=true pnpm run check
- CI=true pnpm run build:all
- CI=true pnpm run check:limits
- CI=true pnpm run check:active-surface
- CI=true pnpm run test:unit
- CI=true pnpm run test:repair
- CI=true pnpm run test:coverage:changed
- CI=true pnpm run format:check
- local autoreview: clean

The OpenClaw ingress-side token pre-filter is in the companion PR: openclaw/openclaw.