### PR TITLE
fix(repair): settle stale branch pushes before dispatch

### DIFF
--- a/.github/workflows/repair-cluster-worker.yml
+++ b/.github/workflows/repair-cluster-worker.yml
@@ -46,6 +46,11 @@ on:
         required: true
         default: false
         type: boolean
+      requeue:
+        description: "Run in a dedicated lane while replacing a stale-head worker"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -56,7 +61,9 @@ env:
   CLAWSWEEPER_MODEL: internal
 
 concurrency:
-  group: clawsweeper-repair-${{ inputs.job }}-${{ inputs.mode }}
+  group: ${{ inputs.requeue && format('clawsweeper-repair-requeue-{0}-{1}', inputs.job, github.run_id) || format('clawsweeper-repair-{0}', inputs.job) }}
+  # Keep an active execute run alive so its temporary gate cleanup can finish;
+  # GitHub still coalesces pending runs in this group to the newest dispatch.
   cancel-in-progress: false
 
 jobs:
@@ -664,7 +671,8 @@ jobs:
           echo "count=$count" >> "$GITHUB_OUTPUT"
 
       - name: Requeue source-head repair races
-        if: ${{ steps.repair_requeue.outputs.count != '' && steps.repair_requeue.outputs.count != '0' }}
+        id: requeue_dispatch
+        if: ${{ always() && steps.repair_requeue.outputs.count != '' && steps.repair_requeue.outputs.count != '0' }}
         env:
           GH_TOKEN: ${{ steps.requeue-token.outputs.token }}
           CLAWSWEEPER_MUTATION_TOKEN_SOURCE: clawsweeper-app
@@ -681,7 +689,7 @@ jobs:
             --model "${{ inputs.model }}"
 
       - name: Record requeued work
-        if: ${{ success() && steps.crabfleet_session.outcome == 'success' && steps.repair_requeue.outputs.count != '' && steps.repair_requeue.outputs.count != '0' }}
+        if: ${{ always() && steps.crabfleet_session.outcome == 'success' && steps.repair_requeue.outputs.count != '' && steps.repair_requeue.outputs.count != '0' && steps.requeue_dispatch.outcome == 'success' }}
         run: pnpm run repair:action-session -- update --state running --phase requeued --summary "Source head changed; replacement Action dispatched"
 
       - name: Record work completion
@@ -730,6 +738,6 @@ jobs:
           key: ${{ runner.os }}-clawsweeper-codex-thread-${{ steps.codex_session.outputs.key }}-${{ github.run_id }}-${{ github.run_attempt }}-execute
 
       - name: Record work failure
-        if: ${{ failure() && steps.crabfleet_session.outcome == 'success' }}
+        if: ${{ always() && failure() && steps.crabfleet_session.outcome == 'success' && (steps.repair_requeue.outputs.count == '' || steps.repair_requeue.outputs.count == '0' || steps.requeue_dispatch.outcome != 'success') }}
         continue-on-error: true
         run: pnpm run repair:action-session -- update --state blocked --phase action_failed --summary "Repair Action failed before all completion gates passed" --completion-reason action_failed

--- a/README.md
+++ b/README.md
@@ -432,6 +432,14 @@ appropriate repair job.
   review and merge.
 - `automerge` merges only after review verdict, checks, mergeability,
   security, maintainer stop/approve state, and repository policy gates pass.
+- Repair workers coalesce pending runs for the same durable job while allowing
+  an active execute run to finish its gate cleanup. Stale-head retries use a
+  dedicated run-scoped lane so they can start during that temporary gate
+  window. Before a contributor branch push, ClawSweeper waits 90 seconds by
+  default, fetches the live PR head again, and requeues instead of pushing when
+  that head changed. It also refuses to push when the PR closed during the
+  wait. Override the window with `CLAWSWEEPER_BRANCH_PUSH_SETTLE_SECONDS`
+  (bounded to 0-120 seconds) when a manual backfill is already settled.
 - An OpenClaw organization member can comment `@clawsweeper implement issue`;
   ClawSweeper refuses when an open PR already mentions the issue, a generated
   branch PR is already open, the issue is paused, or security blockers remain.

--- a/src/repair/execute-fix-artifact.ts
+++ b/src/repair/execute-fix-artifact.ts
@@ -140,6 +140,7 @@ import {
 const FIX_ACTIONS = new Set(["fix_needed", "build_fix_artifact", "open_fix_pr"]);
 const NON_EXECUTABLE_REPAIR_STRATEGIES = new Set(["already_fixed_on_main", "needs_human"]);
 const DEFAULT_BASE_BRANCH = "main";
+const DEFAULT_REPAIR_PUSH_SETTLE_SECONDS = 90;
 
 const args = parseArgs(process.argv.slice(2));
 const jobPath = args._[0];
@@ -982,6 +983,14 @@ function pushRepairBranchAndUpdateStatus({
   if (!sameRepoBranch) {
     assertRepairBranchWritable({ targetDir, pull, rewritten: branchUpdate.rewritten });
   }
+  const settleSeconds = repairPushSettleSeconds();
+  if (settleSeconds > 0) {
+    logProgress("settling repair before branch push", {
+      source_pr: sourcePr.url,
+      seconds: settleSeconds,
+    });
+    sleepMs(settleSeconds * 1000);
+  }
   const livePull = fetchPullRequest(result.repo, sourcePr.number);
   const livePauseBlock = liveRepairPauseBlock({
     pull: livePull,
@@ -991,6 +1000,15 @@ function pushRepairBranchAndUpdateStatus({
     branchUpdate,
   });
   if (livePauseBlock) return livePauseBlock;
+  const liveHeadBlock = repairPushSettleBlock({
+    initialPull: pull,
+    livePull,
+    number: sourcePr.number,
+    target: sourcePr.url,
+    commit: prep.commit,
+    branchUpdate,
+  });
+  if (liveHeadBlock) return liveHeadBlock;
   const pushArgs = repairBranchPushArgs({ pull, rewritten: branchUpdate.rewritten });
   try {
     runGitNetwork(pushArgs, targetDir);
@@ -1070,6 +1088,47 @@ function pushRepairBranchAndUpdateStatus({
     status_comment_updated: statusCommentUpdated,
     merge_preflight: prep.merge_preflight,
     review_threads: threadResolution,
+  };
+}
+
+function repairPushSettleSeconds() {
+  const configured = Number(
+    process.env.CLAWSWEEPER_BRANCH_PUSH_SETTLE_SECONDS ?? DEFAULT_REPAIR_PUSH_SETTLE_SECONDS,
+  );
+  if (!Number.isFinite(configured)) return DEFAULT_REPAIR_PUSH_SETTLE_SECONDS;
+  return Math.min(120, Math.max(0, Math.floor(configured)));
+}
+
+function repairPushSettleBlock({
+  initialPull,
+  livePull,
+  number,
+  target,
+  commit,
+  branchUpdate,
+}: LooseRecord) {
+  const liveState = String(livePull?.state ?? "").toLowerCase();
+  if (liveState !== "open") {
+    return {
+      action: "repair_contributor_branch",
+      status: "blocked",
+      target,
+      commit,
+      branch_rewritten: branchUpdate?.rewritten ?? null,
+      reason: `source PR #${number} is ${liveState || "no longer open"} after the repair settle window; refusing to push`,
+    };
+  }
+  const initialHead = String(initialPull?.head?.sha ?? "");
+  const liveHead = String(livePull?.head?.sha ?? "");
+  if (!initialHead || !liveHead || initialHead === liveHead) return null;
+  return {
+    action: "repair_contributor_branch",
+    status: "blocked",
+    target,
+    commit,
+    branch_rewritten: branchUpdate?.rewritten ?? null,
+    reason: `source PR #${number} changed during the repair settle window; requeue against the latest head`,
+    requeue_required: true,
   };
 }
 

--- a/src/repair/requeue-job.ts
+++ b/src/repair/requeue-job.ts
@@ -175,6 +175,8 @@ function dispatchJob(jobPath: string, mode: string) {
       `execution_runner=${executionRunner}`,
       "-f",
       `model=${model}`,
+      "-f",
+      "requeue=true",
     ],
     { cwd: repoRoot(), encoding: "utf8", stdio: "pipe" },
   );

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -14034,7 +14034,12 @@ test("issue implementation workflow lets job intent choose dispatch capacity", (
 
 test("repair workers hydrate only durable jobs from generated state", () => {
   const workflow = readFileSync(".github/workflows/repair-cluster-worker.yml", "utf8");
+  const requeue = readFileSync("src/repair/requeue-job.ts", "utf8");
 
+  assert.match(workflow, /clawsweeper-repair-requeue-\{0\}-\{1\}.*clawsweeper-repair-\{0\}/);
+  assert.match(workflow, /cancel-in-progress: false/);
+  assert.match(workflow, /requeue:\n\s+description:/);
+  assert.match(requeue, /"requeue=true"/);
   assert.equal(
     workflow.match(/uses: \.\/\.github\/actions\/setup-state[\s\S]*?sparse-checkout: jobs/g)
       ?.length,
@@ -14048,6 +14053,14 @@ test("repair workers hydrate only durable jobs from generated state", () => {
   assert.match(workflow, /post_flight_report=.*post-flight-report\.json/);
   assert.match(workflow, /\.action == "finalize_fix_pr"/);
   assert.match(workflow, /\.status == "ready"/);
+  assert.match(
+    workflow,
+    /id: requeue_dispatch[\s\S]*if: \$\{\{ always\(\) && steps\.repair_requeue\.outputs\.count != '' && steps\.repair_requeue\.outputs\.count != '0' \}\}/,
+  );
+  assert.match(
+    workflow,
+    /if: \$\{\{ always\(\) && failure\(\) && steps\.crabfleet_session\.outcome == 'success' && \(steps\.repair_requeue\.outputs\.count == '' \|\| steps\.repair_requeue\.outputs\.count == '0' \|\| steps\.requeue_dispatch\.outcome != 'success'\) \}\}/,
+  );
   assert.equal(workflow.match(/id: crabfleet_session/g)?.length, 2);
   assert.equal(workflow.match(/steps\.crabfleet_session\.outcome == 'success'/g)?.length, 6);
   assert.doesNotMatch(workflow, /if: \$\{\{[^\n]*env\.CLAWSWEEPER_CRABFLEET_AGENT_TOKEN/);

--- a/test/repair/execute-fix-artifact-source.test.ts
+++ b/test/repair/execute-fix-artifact-source.test.ts
@@ -51,6 +51,36 @@ test("repair source branch writability preflight runs before expensive repair pr
   );
 });
 
+test("repair branch pushes settle and re-check the exact source head", () => {
+  const sourcePath = path.join(process.cwd(), "src/repair/execute-fix-artifact.ts");
+  const source = fs.readFileSync(sourcePath, "utf8");
+  const pushStart = source.indexOf("function pushRepairBranchAndUpdateStatus(");
+  const pushEnd = source.indexOf("function repairPushSettleSeconds()", pushStart);
+  assert.notEqual(pushStart, -1);
+  assert.notEqual(pushEnd, -1);
+  const push = source.slice(pushStart, pushEnd);
+
+  assert.match(source, /DEFAULT_REPAIR_PUSH_SETTLE_SECONDS = 90/);
+  assert.match(source, /CLAWSWEEPER_BRANCH_PUSH_SETTLE_SECONDS/);
+  assert.match(push, /sleepMs\(settleSeconds \* 1000\)/);
+  assert.ok(
+    push.indexOf("sleepMs(settleSeconds * 1000)") <
+      push.indexOf("const livePull = fetchPullRequest"),
+    "the live head must be fetched after the settle window",
+  );
+  assert.ok(
+    push.indexOf("repairPushSettleBlock") < push.indexOf("runGitNetwork(pushArgs, targetDir)"),
+    "the exact-head guard must run before the branch push",
+  );
+
+  const settleStart = source.indexOf("function repairPushSettleBlock(");
+  const settle = source.slice(settleStart, source.indexOf("\n}\n", settleStart) + 2);
+  assert.match(settle, /initialPull\?\.head\?\.sha/);
+  assert.match(settle, /livePull\?\.head\?\.sha/);
+  assert.match(settle, /liveState !== "open"/);
+  assert.match(settle, /requeue_required: true/);
+});
+
 test("merged source replacement skip runs before publishing replacement PRs", () => {
   const sourcePath = path.join(process.cwd(), "src/repair/execute-fix-artifact.ts");
   const source = fs.readFileSync(sourcePath, "utf8");


### PR DESCRIPTION
## Summary
- coalesce pending repair workers per durable job while giving stale-head retries a run-scoped lane
- wait 90 seconds before contributor branch pushes, then re-fetch the PR and refuse stale or closed heads
- ensure requeue dispatch/status cleanup runs after intentional retry failures and records failed dispatches correctly

## Verification
- `pnpm run format:check`
- `pnpm run build:repair`
- `node --test test/repair/execute-fix-artifact-source.test.ts` (7 passed)
- `git diff --check`

The settle window is configurable with `CLAWSWEEPER_REPAIR_PUSH_SETTLE_SECONDS`, bounded to 0-120 seconds.