### PR TITLE
fix(repair): configure CrabFleet action session owner

### DIFF
--- a/.github/workflows/repair-cluster-worker.yml
+++ b/.github/workflows/repair-cluster-worker.yml
@@ -209,6 +209,7 @@ jobs:
         if: ${{ steps.check_job.outputs.job_exists == '1' && env.CLAWSWEEPER_STEERABLE_CODEX == '1' && !inputs.dry_run }}
         env:
           CLAWSWEEPER_CRABFLEET_SERVICE_TOKEN: ${{ secrets.CLAWSWEEPER_CRABFLEET_SERVICE_TOKEN }}
+          CLAWSWEEPER_CRABFLEET_OWNER: ${{ vars.CLAWSWEEPER_CRABFLEET_OWNER }}
         run: pnpm run repair:action-session -- register "${{ inputs.job }}"
 
       - name: Verify GitHub read token
@@ -488,6 +489,7 @@ jobs:
         if: ${{ steps.check_job.outputs.job_exists == '1' && env.CLAWSWEEPER_STEERABLE_CODEX == '1' }}
         env:
           CLAWSWEEPER_CRABFLEET_SERVICE_TOKEN: ${{ secrets.CLAWSWEEPER_CRABFLEET_SERVICE_TOKEN }}
+          CLAWSWEEPER_CRABFLEET_OWNER: ${{ vars.CLAWSWEEPER_CRABFLEET_OWNER }}
         run: pnpm run repair:action-session -- register "${{ inputs.job }}"
 
       - name: Download worker artifacts

--- a/docs/steerable-repair-automation.md
+++ b/docs/steerable-repair-automation.md
@@ -503,6 +503,10 @@ commit, push, PR creation, label, comment, close, and merge operations.
 `CLAWSWEEPER_CRABFLEET_SERVICE_TOKEN` is used only to register or resume a
 logical action session.
 
+`CLAWSWEEPER_CRABFLEET_OWNER` identifies the active CrabFleet user principal
+that owns new action sessions. It must be configured as a repository variable;
+it is not the GitHub organization name.
+
 CrabFleet returns:
 
 - a rotated session-scoped agent token;
@@ -750,6 +754,7 @@ Core steerable-session configuration:
 | `CLAWSWEEPER_STEERABLE_CODEX` | Enables app-server threads, cache persistence, and CrabFleet steering. |
 | `CLAWSWEEPER_CRABFLEET_SERVICE_TOKEN` | Registers or resumes the logical action session. |
 | `CLAWSWEEPER_CRABFLEET_URL` | CrabFleet API and dashboard base URL. |
+| `CLAWSWEEPER_CRABFLEET_OWNER` | Active CrabFleet user principal for new action sessions. |
 | `CLAWSWEEPER_CODEX_TIMEOUT_MS` | Planning Codex call timeout. |
 | `CLAWSWEEPER_FIX_CODEX_TIMEOUT_MS` | Per-call execution Codex timeout. |
 | `CLAWSWEEPER_FIX_STEP_TIMEOUT_MS` | Overall fix executor step budget. |

--- a/src/repair/action-session.ts
+++ b/src/repair/action-session.ts
@@ -41,6 +41,12 @@ export function actionWorkKey(frontmatter: LooseRecord): string {
   return `${String(frontmatter.repo ?? "")}:${String(frontmatter.cluster_id ?? "")}`;
 }
 
+export function actionSessionOwner(env: NodeJS.ProcessEnv = process.env): string {
+  const owner = String(env.CLAWSWEEPER_CRABFLEET_OWNER ?? "").trim();
+  if (!owner) throw new Error("action session requires a configured CrabFleet owner");
+  return owner;
+}
+
 export function actionRunUrl(env: NodeJS.ProcessEnv = process.env): string {
   const server = String(env.GITHUB_SERVER_URL ?? "https://github.com").replace(/\/+$/, "");
   const repository = String(env.GITHUB_REPOSITORY ?? "");
@@ -86,6 +92,7 @@ async function registerActionSession(jobPath: string): Promise<void> {
     body: JSON.stringify({
       workKey: actionWorkKey(job.frontmatter),
       workKind: actionWorkKind(job.frontmatter),
+      owner: actionSessionOwner(),
       repo: String(job.frontmatter.repo ?? ""),
       branch: String(job.frontmatter.target_branch ?? process.env.GITHUB_REF_NAME ?? ""),
       sourceUrl,

--- a/test/repair/action-session.test.ts
+++ b/test/repair/action-session.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   actionRunUrl,
+  actionSessionOwner,
   actionSourceUrl,
   actionWorkKey,
   actionWorkKind,
@@ -32,6 +33,14 @@ test("action session builds stable work and run identifiers", () => {
       GITHUB_RUN_ID: "456",
     }),
     "https://github.example/openclaw/clawsweeper/actions/runs/456",
+  );
+});
+
+test("action session reads the configured CrabFleet owner principal", () => {
+  assert.equal(actionSessionOwner({ CLAWSWEEPER_CRABFLEET_OWNER: "@steipete" }), "@steipete");
+  assert.throws(
+    () => actionSessionOwner({}),
+    /action session requires a configured CrabFleet owner/,
   );
 });
 


### PR DESCRIPTION
Summary:
- pass the configured CrabFleet user principal when registering or resuming steerable repair sessions
- wire the repository variable through both repair worker paths and document the contract

Verification:
- pnpm run check
- autoreview: clean
- CLAWSWEEPER_CRABFLEET_OWNER configured as @steipete on openclaw/clawsweeper

Fixes the 400 `owner is required for new GitHub Actions work` failure from run 28007232117.