### PR TITLE
fix(queue): self-heal exact review alarms

### DIFF
--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -432,8 +432,14 @@ export class ExactReviewQueue {
     }
 
     if (request.method === "GET" && url.pathname === "/stats") {
+      const now = Date.now();
       const state = await this.readState();
-      return json(exactReviewQueueStats(state));
+      // Dashboard reads are also the operational heartbeat. Reclaim leases and
+      // restore the alarm here so a deploy or lost alarm cannot strand backlog.
+      const changed = reclaimExpiredExactReviewLeases(state, now);
+      if (changed) await this.writeState(state);
+      await this.scheduleNext(state, now);
+      return json(exactReviewQueueStats(state, now, exactReviewQueueCapacity(this.env)));
     }
 
     return new Response("not found", { status: 404 });
@@ -441,6 +447,7 @@ export class ExactReviewQueue {
 
   async alarm() {
     const now = Date.now();
+    await this.storage.deleteAlarm();
     const state = await this.readState();
     let changed = reclaimExpiredExactReviewLeases(state, now);
     const capacity = exactReviewQueueCapacity(this.env);
@@ -521,7 +528,8 @@ export class ExactReviewQueue {
       await this.storage.deleteAlarm();
       return;
     }
-    await this.storage.setAlarm(next);
+    const scheduled = await this.storage.getAlarm();
+    if (scheduled === null || next < scheduled) await this.storage.setAlarm(next);
   }
 }
 
@@ -1171,9 +1179,61 @@ function exactReviewQueueActiveCount(state: ExactReviewQueueState) {
   ).length;
 }
 
-function exactReviewQueueStats(state: ExactReviewQueueState) {
+function exactReviewQueueStats(
+  state: ExactReviewQueueState,
+  now = Date.now(),
+  capacity = Number.POSITIVE_INFINITY,
+) {
   const items = Object.values(state.items);
   const pending = items.filter((item) => item.state === "pending");
+  const targets = new Map<
+    string,
+    {
+      target_repo: string;
+      pending: number;
+      dispatching: number;
+      leased: number;
+      oldest_pending_at: number | null;
+    }
+  >();
+  for (const item of items) {
+    const targetRepo = item.decision.targetRepo;
+    const current = targets.get(targetRepo) ?? {
+      target_repo: targetRepo,
+      pending: 0,
+      dispatching: 0,
+      leased: 0,
+      oldest_pending_at: null,
+    };
+    if (item.state === "pending") {
+      current.pending += 1;
+      current.oldest_pending_at =
+        current.oldest_pending_at === null
+          ? item.createdAt
+          : Math.min(current.oldest_pending_at, item.createdAt);
+    } else if (item.state === "dispatching") {
+      current.dispatching += 1;
+    } else {
+      current.leased += 1;
+    }
+    targets.set(targetRepo, current);
+  }
+  const targetStats = [...targets.values()]
+    .map((target) => ({
+      target_repo: target.target_repo,
+      pending: target.pending,
+      dispatching: target.dispatching,
+      leased: target.leased,
+      oldest_pending_at:
+        target.oldest_pending_at === null ? null : new Date(target.oldest_pending_at).toISOString(),
+    }))
+    .sort(
+      (left, right) =>
+        right.pending - left.pending ||
+        right.dispatching + right.leased - (left.dispatching + left.leased) ||
+        left.target_repo.localeCompare(right.target_repo),
+    );
+  const nextWakeAt = exactReviewQueueNextWakeAt(state, now, capacity);
   return {
     pending: pending.length,
     dispatching: items.filter((item) => item.state === "dispatching").length,
@@ -1181,6 +1241,11 @@ function exactReviewQueueStats(state: ExactReviewQueueState) {
     oldest_pending_at: pending.length
       ? new Date(Math.min(...pending.map((item) => item.createdAt))).toISOString()
       : null,
+    oldest_pending_age_seconds: pending.length
+      ? Math.max(0, Math.floor((now - Math.min(...pending.map((item) => item.createdAt))) / 1000))
+      : null,
+    next_wake_at: nextWakeAt === null ? null : new Date(nextWakeAt).toISOString(),
+    target_stats: targetStats,
   };
 }
 

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -509,6 +509,90 @@ test("exact-review queue retries dispatch failures and reclaims an unclaimed lea
   }
 });
 
+test("exact-review stats heals a missing alarm and expired lease", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  await storage.put("exact-review-queue", {
+    deliveries: {},
+    items: {
+      "openclaw/openclaw#700": {
+        key: "openclaw/openclaw#700",
+        decision: {
+          targetRepo: "openclaw/openclaw",
+          targetBranch: "main",
+          itemNumber: 700,
+          itemKind: "pull_request",
+          sourceEvent: "pull_request",
+          sourceAction: "synchronize",
+          supersedesInProgress: true,
+        },
+        state: "leased",
+        revision: 1,
+        createdAt: Date.now() - 120_000,
+        updatedAt: Date.now() - 120_000,
+        nextAttemptAt: Date.now() - 120_000,
+        attempts: 0,
+        leaseId: "expired-lease",
+        leaseRevision: 1,
+        leaseExpiresAt: Date.now() - 1,
+        claimedRunId: "run-700",
+      },
+    },
+  });
+
+  const response = await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"));
+  assert.equal(response.status, 200);
+  const stats = await response.json();
+  assert.equal(stats.pending, 1);
+  assert.equal(stats.dispatching, 0);
+  assert.equal(stats.leased, 0);
+  assert.equal(stats.target_stats[0].target_repo, "openclaw/openclaw");
+  assert.equal(stats.target_stats[0].pending, 1);
+  assert.ok(stats.oldest_pending_age_seconds >= 120);
+  assert.ok(stats.next_wake_at);
+  assert.ok((await storage.getAlarm()) !== null);
+
+  const state = (await storage.get("exact-review-queue")) as {
+    deliveries: Record<string, number>;
+    items: Record<string, Record<string, unknown>>;
+  };
+  const activeLeaseExpiry = Date.now() + 60_000;
+  state.items["openclaw/openclaw#701"] = {
+    key: "openclaw/openclaw#701",
+    decision: state.items["openclaw/openclaw#700"].decision,
+    state: "leased",
+    revision: 1,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    nextAttemptAt: Date.now(),
+    attempts: 0,
+    leaseId: "active-lease",
+    leaseRevision: 1,
+    leaseExpiresAt: activeLeaseExpiry,
+    claimedRunId: "run-701",
+  };
+  state.items["openclaw/openclaw#702"] = {
+    key: "openclaw/openclaw#702",
+    decision: {
+      ...state.items["openclaw/openclaw#700"].decision,
+      itemNumber: 702,
+    },
+    state: "pending",
+    revision: 1,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    nextAttemptAt: Date.now(),
+    attempts: 0,
+  };
+  await storage.put("exact-review-queue", state);
+  await storage.setAlarm(Date.now() + 1_000);
+  const scheduledBeforePoll = await storage.getAlarm();
+  await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"));
+  const scheduledAfterPoll = await storage.getAlarm();
+  assert.ok(scheduledBeforePoll !== null && scheduledAfterPoll !== null);
+  assert.ok(scheduledAfterPoll <= scheduledBeforePoll);
+});
+
 function isoAgo(ms: number) {
   return new Date(Date.now() - ms).toISOString();
 }


### PR DESCRIPTION
## Summary
- make the exact-review queue self-heal when its Durable Object alarm is missing or a lease expires
- expose per-target queue depth/age and the next scheduled wake time for operations
- preserve an earlier alarm so dashboard polling cannot postpone due work

## Verification
- `pnpm run check`
- `node --test test/dashboard-worker.test.ts`
- autoreview: clean, no accepted/actionable findings

Operational context: this targets the live exact-review backlog without increasing global worker or per-target concurrency.
