### PR TITLE
ci: run github activity on hosted runners

### DIFF
--- a/.github/workflows/github-activity.yml
+++ b/.github/workflows/github-activity.yml
@@ -69,7 +69,7 @@ jobs:
         !(github.event_name == 'repository_dispatch' && github.event.client_payload.activity.type == 'pull_request_target' && github.event.client_payload.activity.action == 'synchronize') &&
         !(github.event_name == 'workflow_run' && contains(fromJSON('["success","neutral","skipped"]'), github.event.workflow_run.conclusion))
       }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - name: Check core API budget

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -14080,6 +14080,8 @@ test("github activity workflow scopes cancellation to matching item activity", (
   assert.match(workflow, /repair:spam-comment-intake -- --write-report/);
   assert.doesNotMatch(workflow, /gh api "repos\/\$\{GITHUB_REPOSITORY\}\/dispatches"/);
   assert.match(concurrencyBlock, /cancel-in-progress: true/);
+  assert.match(workflow, /runs-on: ubuntu-24\.04/);
+  assert.doesNotMatch(workflow, /runs-on: blacksmith-/);
   assert.doesNotMatch(
     concurrencyBlock,
     /group: github-activity-\$\{\{ github\.event_name \}\}-\$\{\{ github\.run_id \}\}/,


### PR DESCRIPTION
## What Problem This Solves

GitHub confirmed OpenClaw's runner outage was caused by the org-wide self-hosted runner registration bucket, not core API quota. The `github-activity` notify lane is high-frequency and lightweight, so every Blacksmith execution here spends scarce registration budget unnecessarily.

## Why This Change Was Made

Move the `github-activity` notify job from `blacksmith-4vcpu-ubuntu-2404` to `ubuntu-24.04`. The workflow still performs the same API-budget check, checkout, setup, and notification dispatch; it just no longer registers a Blacksmith runner for this ingress lane.

## User Impact

ClawSweeper event intake spends fewer Blacksmith registrations during issue/PR bursts, preserving the registration bucket for exact reviews and repair work.

## Evidence

- `pnpm run build`
- `node --test --test-name-pattern "github activity workflow scopes cancellation" test/clawsweeper.test.ts`
- `./node_modules/.bin/oxfmt --check .github/workflows/github-activity.yml test/clawsweeper.test.ts && git diff --check`
- autoreview clean: no accepted/actionable findings reported
