### PR TITLE
feat: opt-in cadence to skip re-reviewing unchanged pull requests

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1092,6 +1092,7 @@ jobs:
           MAX_PAGES: ${{ steps.mode.outputs.max_pages }}
           MIN_ACTIVE_SHARDS: ${{ steps.mode.outputs.min_active_shards }}
           MIN_BACKFILL_REVIEW_AGE_MINUTES: ${{ steps.mode.outputs.min_backfill_review_age_minutes }}
+          CLAWSWEEPER_STALE_PULL_REQUEST_REVIEW_DAYS: ${{ vars.CLAWSWEEPER_STALE_PULL_REQUEST_REVIEW_DAYS || '' }}
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
           GH_TOKEN: ${{ steps.target-read-token.outputs.token || github.token }}
         run: |
@@ -2035,6 +2036,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.target-token.outputs.token }}
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
+          CLAWSWEEPER_STALE_PULL_REQUEST_REVIEW_DAYS: ${{ vars.CLAWSWEEPER_STALE_PULL_REQUEST_REVIEW_DAYS || '' }}
         run: |
           set -euo pipefail
           git pull --rebase --autostash

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -328,6 +328,12 @@ non-numeric, or at or below the daily cadence keep the default daily behavior,
 and the hourly activity and daily hot-window buckets are never affected, so
 changed and brand-new pull requests are still reviewed promptly.
 
+Set it as a repository variable (`vars.CLAWSWEEPER_STALE_PULL_REQUEST_REVIEW_DAYS`);
+`.github/workflows/sweep.yml` passes it into both the scheduled planner step and
+the dashboard `audit --update-dashboard` step, so scheduled GitHub runs honor it
+and the dashboard's "current within cadence" counts stay consistent with what the
+planner schedules. Self-hosted/CLI runs read it from the process environment.
+
 The activity check ignores ClawSweeper-owned GitHub mutations that are already
 recorded in durable report frontmatter. `review_comment_synced_at` covers public
 review comment writes, and `labels_synced_at` covers ClawSweeper label-only

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -313,10 +313,20 @@ Review cadence:
 
 - items with target-side activity since the last real review: hourly
 - items created in the last 7 days without new target-side activity: daily
-- pull requests outside the hot window: daily
+- pull requests outside the hot window: daily (configurable, see below)
 - issues created in the last 30 days: daily
 - older inactive issues: weekly
 - review policy hash changes: due immediately
+
+`CLAWSWEEPER_STALE_PULL_REQUEST_REVIEW_DAYS` (optional) extends only the third
+bucket — a pull request past its hot window with no activity since its last
+review. It defaults to the daily cadence above; set it to a larger number of
+days (for example `7` for weekly) to stop re-reviewing, and re-paying for,
+pull requests that have not changed since their last review. This is useful when
+the review brain runs on a metered or subscription budget. Values that are unset,
+non-numeric, or at or below the daily cadence keep the default daily behavior,
+and the hourly activity and daily hot-window buckets are never affected, so
+changed and brand-new pull requests are still reviewed promptly.
 
 The activity check ignores ClawSweeper-owned GitHub mutations that are already
 recorded in durable report frontmatter. `review_comment_synced_at` covers public

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -5209,10 +5209,28 @@ function isCreatedWithinDays(
   return Number.isFinite(createdAt) && now - createdAt < days * DAY_MS;
 }
 
+// Re-review cadence for a pull request that is past its hot window (created more
+// than HOT_REVIEW_DAYS ago) and has had no activity since its last review. This
+// defaults to the daily cadence. Operators who run the review brain on a metered
+// or subscription budget can extend it (never shorten it) via
+// CLAWSWEEPER_STALE_PULL_REQUEST_REVIEW_DAYS so that an open pull request which
+// has not changed since its last review is not re-reviewed -- and re-paid for --
+// every day only to reproduce an identical verdict. Unset or invalid keeps the
+// current daily cadence; the hourly "activity since review" and daily hot-window
+// branches in reviewCadenceMs are unaffected, so changed and brand-new pull
+// requests are still reviewed promptly.
+function stalePullRequestReviewCadenceMs(): number {
+  const configuredDays = Number(process.env.CLAWSWEEPER_STALE_PULL_REQUEST_REVIEW_DAYS);
+  if (!Number.isFinite(configuredDays) || configuredDays <= DAILY_REVIEW_DAYS) {
+    return DAILY_REVIEW_DAYS * DAY_MS;
+  }
+  return configuredDays * DAY_MS;
+}
+
 function reviewCadenceMs(item: Item, review: ExistingReview | null, now = Date.now()): number {
   if (hasActivitySinceReview(item, review)) return HOURLY_REVIEW_MS;
   if (isCreatedWithinDays(item, HOT_REVIEW_DAYS, now)) return DAILY_REVIEW_DAYS * DAY_MS;
-  if (item.kind === "pull_request") return DAILY_REVIEW_DAYS * DAY_MS;
+  if (item.kind === "pull_request") return stalePullRequestReviewCadenceMs();
   const createdAt = Date.parse(item.createdAt);
   if (Number.isFinite(createdAt) && now - createdAt < RECENT_ISSUE_DAYS * DAY_MS) {
     return DAILY_REVIEW_DAYS * DAY_MS;

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -19025,7 +19025,10 @@ function cadenceBucketForReview(
     return { bucket: "hourlyHotItems", cadenceMs: DAILY_REVIEW_DAYS * DAY_MS };
   }
   if (kind === "pull_request") {
-    return { bucket: "dailyPullRequests", cadenceMs: DAILY_REVIEW_DAYS * DAY_MS };
+    // Mirror reviewCadenceMs: a stale (non-hot) pull request honors the optional
+    // CLAWSWEEPER_STALE_PULL_REQUEST_REVIEW_DAYS extension, so the dashboard's
+    // "current within cadence" math matches what the planner actually schedules.
+    return { bucket: "dailyPullRequests", cadenceMs: stalePullRequestReviewCadenceMs() };
   }
 
   if (Number.isFinite(createdAt) && now - createdAt < RECENT_ISSUE_DAYS * DAY_MS) {

--- a/test/scheduler-policy.test.ts
+++ b/test/scheduler-policy.test.ts
@@ -103,6 +103,47 @@ test("hot new items review daily unless target-side activity requires hourly cad
   );
 });
 
+test("CLAWSWEEPER_STALE_PULL_REQUEST_REVIEW_DAYS extends the daily cadence for inactive stale PRs", () => {
+  const now = Date.parse("2026-04-30T12:00:00Z");
+  const review = (reviewedAt) => ({
+    path: "items/123.md",
+    markdown: "",
+    reviewedAt,
+    itemUpdatedAt: "2026-03-01T00:00:00Z",
+    decision: "keep_open",
+    reviewStatus: "complete",
+    reviewPolicy: "current",
+  });
+  // A pull request well past its 7-day hot window with no activity since review.
+  const stalePr = item({
+    kind: "pull_request",
+    createdAt: "2026-03-01T00:00:00Z",
+    updatedAt: "2026-03-01T00:00:00Z",
+  });
+
+  const original = process.env.CLAWSWEEPER_STALE_PULL_REQUEST_REVIEW_DAYS;
+  try {
+    // Default (unset): the stale PR comes due again one day after its last review.
+    delete process.env.CLAWSWEEPER_STALE_PULL_REQUEST_REVIEW_DAYS;
+    assert.equal(shouldReviewItem(stalePr, review("2026-04-29T10:00:00Z"), now, "current"), true);
+
+    // Extended to weekly: a review from ~1 day ago is no longer due...
+    process.env.CLAWSWEEPER_STALE_PULL_REQUEST_REVIEW_DAYS = "7";
+    assert.equal(shouldReviewItem(stalePr, review("2026-04-29T10:00:00Z"), now, "current"), false);
+    // ...but one older than the configured window still comes due.
+    assert.equal(shouldReviewItem(stalePr, review("2026-04-22T10:00:00Z"), now, "current"), true);
+
+    // Invalid or sub-daily values fall back to the default daily cadence.
+    process.env.CLAWSWEEPER_STALE_PULL_REQUEST_REVIEW_DAYS = "not-a-number";
+    assert.equal(shouldReviewItem(stalePr, review("2026-04-29T10:00:00Z"), now, "current"), true);
+    process.env.CLAWSWEEPER_STALE_PULL_REQUEST_REVIEW_DAYS = "0";
+    assert.equal(shouldReviewItem(stalePr, review("2026-04-29T10:00:00Z"), now, "current"), true);
+  } finally {
+    if (original === undefined) delete process.env.CLAWSWEEPER_STALE_PULL_REQUEST_REVIEW_DAYS;
+    else process.env.CLAWSWEEPER_STALE_PULL_REQUEST_REVIEW_DAYS = original;
+  }
+});
+
 test("scheduler ignores ClawSweeper-owned updated_at churn after review", () => {
   const reviewedAt = "2026-04-30T12:52:57Z";
   const review = {


### PR DESCRIPTION
We run ClawSweeper's review brain on a metered subscription and noticed open pull requests get re-reviewed about once a day even when nothing changed since the last review, reproducing an identical verdict and re-spending review budget each time.

reviewCadenceMs already drops to hourly when there is activity since the last review and uses the daily hot-window cadence for new pull requests, but a pull request past its hot window with no activity still falls to the daily branch. This adds an optional CLAWSWEEPER_STALE_PULL_REQUEST_REVIEW_DAYS that extends only that branch (for example 7 for weekly). Unset, non-numeric, or sub-daily values keep the current daily behavior, and the hourly-activity and daily hot-window branches are untouched, so changed and brand-new pull requests are still reviewed promptly. Behavior is unchanged unless an operator opts in.

- src: stalePullRequestReviewCadenceMs() helper, read in reviewCadenceMs
- test: scheduler-policy cadence cases (default daily, extended weekly, invalid/sub-daily fallback) through the exported shouldReviewItem
- docs: scheduler.md cadence section

Release note (CHANGELOG.md left untouched -- it is release-owned per AGENTS.md): adds optional CLAWSWEEPER_STALE_PULL_REQUEST_REVIEW_DAYS to extend the re-review cadence for open PRs past their hot window with no activity since last review.