### PR TITLE
Add maturity shortlist helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,9 @@
     "crabbox:warmup": "crabbox warmup",
     "repair:pr-intake": "node dist/repair/pr-repair-intake.js"
   },
+  "dependencies": {
+    "yaml": "^2.9.0"
+  },
   "devDependencies": {
     "@types/node": "^25.9.2",
     "@typescript/native-preview": "7.0.0-dev.20260609.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
       '@types/node':
         specifier: ^25.9.2
@@ -387,6 +391,11 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
 snapshots:
 
   '@oxfmt/binding-android-arm-eabi@0.54.0':
@@ -615,3 +624,5 @@ snapshots:
   tinypool@2.1.0: {}
 
   undici-types@7.24.6: {}
+
+  yaml@2.9.0: {}

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -166,10 +166,12 @@ review findings.
 
 Set `maturityLabels` for issues only; use `[]` for PRs or unsupported matches.
 `maturity:stable`: Issue affects a taxonomy feature currently scored M4/M5.
-Match the issue to active features in `taxonomy.yaml` and
-the checked-out `qa/maturity-scores.yaml` (`docs/maturity/` may help). Select
-`maturity:stable` only for M4/M5 matches. Cite the feature id/name and score in
-`evidence` and `labelJustifications`.
+First run `node "$CLAWSWEEPER_PROOF_SCRATCH_DIR/maturity-stable-shortlist.mjs"`
+from the target checkout and compare the issue against the M4+ shortlist. Read
+`taxonomy.yaml`, the full checked-out `qa/maturity-scores.yaml`, or
+`docs/maturity/` only if the shortlist is ambiguous. Select `maturity:stable`
+only for M4/M5 matches. Cite the feature id/name and score in `evidence` and
+`labelJustifications`.
 Stable maturity supports priority, but does not automatically escalate it.
 
 Set `mergeRiskLabels` as PR-only ClawSweeper-owned GitHub labels for merge

--- a/scripts/maturity-stable-shortlist.mjs
+++ b/scripts/maturity-stable-shortlist.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync } from "node:fs";
+import { parse } from "yaml";
+
+const scorecardPath = process.argv[2] || "qa/maturity-scores.yaml";
+
+if (!existsSync(scorecardPath)) {
+  console.error(`Maturity scorecard not found: ${scorecardPath}`);
+  process.exit(1);
+}
+
+console.log(stableShortlist(readFileSync(scorecardPath, "utf8")));
+
+function stableShortlist(text) {
+  const scorecard = parse(text);
+  const surfaces = Array.isArray(scorecard?.surfaces) ? scorecard.surfaces : [];
+  const rows = surfaces
+    .map(surfaceSummary)
+    .filter((surface) => Number(surface.code.replace(/^M/, "")) >= 4);
+
+  if (rows.length === 0) return "No M4+ maturity scorecard surfaces found.";
+  return rows
+    .map((surface) => {
+      const categories = surface.categories.length
+        ? ` | categories: ${surface.categories.join("; ")}`
+        : "";
+      return `${surface.id} | ${surface.name} | ${surface.code} ${surface.label} | q${surface.quality} c${surface.completeness}${categories}`;
+    })
+    .join("\n");
+}
+
+function surfaceSummary(surface) {
+  return {
+    id: String(surface?.id ?? ""),
+    name: String(surface?.name ?? ""),
+    code: String(surface?.level?.code ?? ""),
+    label: String(surface?.level?.label ?? ""),
+    quality: Number(surface?.scores?.quality?.score ?? 0),
+    completeness: Number(surface?.scores?.completeness?.score ?? 0),
+    categories: Array.isArray(surface?.categories)
+      ? surface.categories.map((category) => String(category?.name ?? "")).filter(Boolean)
+      : [],
+  };
+}

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -1085,6 +1085,11 @@ const DEFAULT_CODEX_FALLBACK_MIN_BUDGET_MS = 120_000;
 const REVIEW_POLICY_VERSION = "2026-06-15-policy-v22";
 const REVIEW_ITEM_PROMPT_PATH = join(ROOT, "prompts", "review-item.md");
 const CLAWSWEEPER_DECISION_SCHEMA_PATH = join(ROOT, "schema", "clawsweeper-decision.schema.json");
+const MATURITY_STABLE_SHORTLIST_SCRIPT_PATH = join(
+  ROOT,
+  "scripts",
+  "maturity-stable-shortlist.mjs",
+);
 const PR_CLOSE_COVERAGE_PROOF_PROMPT_PATH = join(ROOT, "prompts", "pr-close-coverage-proof.md");
 const PR_CLOSE_COVERAGE_PROOF_SCHEMA_PATH = join(
   ROOT,
@@ -6941,6 +6946,9 @@ function buildReviewPrompt(
   const contextJson = contextJsonForPrompt(context);
   const schema = reviewDecisionSchemaText();
   const proofScratchDir = runtimeHints.proofScratchDir?.trim();
+  const maturityHelperPath = proofScratchDir
+    ? `\`${proofScratchDir}/maturity-stable-shortlist.mjs\``
+    : "the scratch directory as `maturity-stable-shortlist.mjs`";
   const mediaProofPrompt = mediaProofRuntimePrompt(
     runtimeHints.mediaProofSummary,
     runtimeHints.mediaProofManifestPath,
@@ -6975,6 +6983,7 @@ ${additionalPrompt.trim()}
 - You may use the available network and read-only GitHub token to inspect PR body links, comments, screenshots, videos, logs, terminal output, and target-repo artifacts.
 - Download proof artifacts into ${proofScratchDir ? `\`${proofScratchDir}\`` : "a temporary scratch directory"} before inspecting them.
 - The target checkout is read-only for review. Do not modify repository files; use the scratch directory or /tmp for downloaded evidence and generated video stills/contact sheets.
+- A token-light maturity helper is available at ${maturityHelperPath}. For issue maturity labels, first run \`node "$CLAWSWEEPER_PROOF_SCRATCH_DIR/maturity-stable-shortlist.mjs"\` from the target checkout and compare the issue against that shortlist; read the full scorecard or taxonomy only if the shortlist is ambiguous.
 ${mediaProofPrompt}
 
 ## GitHub Context
@@ -6994,6 +7003,31 @@ ${extra}
       additionalPromptChars: additionalPrompt.trim().length,
     },
   };
+}
+
+function prepareMaturityStableShortlistScript(proofScratchDir: string, openclawDir: string): void {
+  const scorecardPath = join(openclawDir, "qa", "maturity-scores.yaml");
+  const shortlist = maturityStableShortlist(scorecardPath);
+  writeFileSync(
+    join(proofScratchDir, "maturity-stable-shortlist.mjs"),
+    `#!/usr/bin/env node\nconsole.log(${JSON.stringify(shortlist)});\n`,
+    "utf8",
+  );
+}
+
+function maturityStableShortlist(scorecardPath: string): string {
+  const result = spawnSync(
+    process.execPath,
+    [MATURITY_STABLE_SHORTLIST_SCRIPT_PATH, scorecardPath],
+    {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+    },
+  );
+  if (result.status === 0) return result.stdout.trim();
+  const detail =
+    result.stderr?.trim() || result.error?.message || "maturity shortlist script failed";
+  return `Unable to read maturity shortlist: ${detail}`;
 }
 
 function reviewPromptTelemetry(
@@ -7378,6 +7412,7 @@ function runCodex(options: {
   const proofScratchDir =
     options.proofScratchDir ?? join(options.workDir, "proof-scratch", String(options.item.number));
   ensureDir(proofScratchDir);
+  prepareMaturityStableShortlistScript(proofScratchDir, options.openclawDir);
   const preparedMediaProof = options.prompt
     ? { manifestPath: null, summaryPath: null, artifacts: [] }
     : prepareMediaProofArtifacts(options.context, proofScratchDir);

--- a/test/maturity-shortlist-script.test.ts
+++ b/test/maturity-shortlist-script.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+test("maturity shortlist script emits only M4+ surfaces", () => {
+  const dir = mkdtempSync(join(tmpdir(), "clawsweeper-maturity-"));
+  try {
+    const scorecard = join(dir, "maturity-scores.yaml");
+    writeFileSync(
+      scorecard,
+      [
+        "surfaces:",
+        "  - id: gateway-runtime",
+        "    name: Gateway runtime",
+        "    level:",
+        "      code: M4",
+        "      label: Stable",
+        "    scores:",
+        "      quality:",
+        "        score: 81",
+        "      completeness:",
+        "        score: 89",
+        "    categories:",
+        "      - name: HTTP APIs",
+        "  - id: agent-runtime",
+        "    name: Agent runtime",
+        "    level:",
+        "      code: M3",
+        "      label: Beta",
+      ].join("\n"),
+    );
+
+    const output = execFileSync(process.execPath, [
+      "scripts/maturity-stable-shortlist.mjs",
+      scorecard,
+    ]).toString();
+
+    assert.match(output, /gateway-runtime \| Gateway runtime \| M4 Stable \| q81 c89/);
+    assert.match(output, /categories: HTTP APIs/);
+    assert.doesNotMatch(output, /agent-runtime/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/review-prompt-policy.test.ts
+++ b/test/review-prompt-policy.test.ts
@@ -317,6 +317,28 @@ test("review prompt and schema describe positive-only feature showcase labels", 
   assert.deepEqual(featureShowcase.properties.status.enum, ["showcase", "none"]);
 });
 
+test("review prompt uses token-light maturity shortlist helper", () => {
+  const prompt = readFileSync("prompts/review-item.md", "utf8");
+  const runtimePrompt = reviewPromptForTest(
+    item({ kind: "issue" }),
+    { issue: {}, comments: [], timeline: [] },
+    { mainSha: "abc123", latestRelease: null },
+    "",
+    { proofScratchDir: "/tmp/proof" },
+  );
+
+  assert.match(prompt, /maturity-stable-shortlist\.mjs/);
+  assert.match(prompt, /compare the issue against the M4\+ shortlist/);
+  assert.match(
+    runtimePrompt,
+    /node "\$CLAWSWEEPER_PROOF_SCRATCH_DIR\/maturity-stable-shortlist\.mjs"/,
+  );
+  assert.match(
+    runtimePrompt,
+    /read the full scorecard or taxonomy only if the shortlist is ambiguous/,
+  );
+});
+
 test("review prompt classifies Telegram visible proof candidates", () => {
   const prompt = readFileSync("prompts/review-item.md", "utf8");
 


### PR DESCRIPTION
## Summary
- add a deterministic YAML-backed maturity shortlist CLI
- stage a dependency-free scratch helper that prints the precomputed M4+ shortlist for Codex reviews
- update the review prompt to compare issues against the shortlist before reading full taxonomy files

## Verification
- pnpm run check