### PR TITLE
fix: rotate apply queue batches

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2171,6 +2171,8 @@ jobs:
             sync_open_pr_batch="true"
             item_numbers=""
           fi
+          explicit_item_numbers="$item_numbers"
+          auto_selected_apply_batch=false
           sync_comments_only="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_sync_comments_only || 'false' }}"
           product_direction_enabled=false
           case "${CLAWSWEEPER_UNCONFIRMED_PRODUCT_DIRECTION_CLOSE_ENABLED,,}" in
@@ -2276,6 +2278,7 @@ jobs:
           target_slug="$TARGET_REPO"
           target_slug="${target_slug//\//-}"
           cursor_path="results/comment-sync-cursors/${target_slug}.json"
+          apply_cursor_path="results/apply-cursors/${target_slug}.json"
           next_cursor=""
           if [ "$sync_open_pr_batch" = "true" ]; then
             sync_comments_only="true"
@@ -2363,13 +2366,16 @@ jobs:
               --apply-close-reasons "$apply_close_reasons" \
               --stale-min-age-days "$stale_min_age_days" \
               --min-age-days "$min_age_days" \
-              --min-age-minutes "$min_age_minutes")"
+              --min-age-minutes "$min_age_minutes" \
+              --batch-size "$close_processed_limit" \
+              --cursor-path "$apply_cursor_path")"
             if [ -n "$item_numbers" ]; then
+              auto_selected_apply_batch=true
               proposed_count="$(pnpm run --silent workflow -- count-csv --items "$item_numbers")"
               if [ "$proposed_count" -lt "$limit" ]; then
                 limit="$proposed_count"
               fi
-              echo "Auto-selected $proposed_count proposed close(s): $item_numbers"
+              echo "Auto-selected $proposed_count proposed close candidate(s) from apply cursor window: $item_numbers"
             fi
           fi
           item_numbers_arg=()
@@ -2478,7 +2484,15 @@ jobs:
             result_count="$(pnpm run --silent workflow -- count-report --report ".artifacts/apply-reports/apply-report-$checkpoint.json")"
             closed_total=$((closed_total + closed_in_chunk))
             echo "Checkpoint $checkpoint result_count=$result_count closed_in_chunk=$closed_in_chunk closed_total=$closed_total/$limit"
-            publish_changes "chore: apply sweep decisions checkpoint $checkpoint" records apply-report.json
+            apply_publish_paths=(records apply-report.json)
+            if [ "$auto_selected_apply_batch" = "true" ] && [ "$result_count" -gt 0 ]; then
+              pnpm run workflow -- write-apply-cursor \
+                --cursor-path "$apply_cursor_path" \
+                --report ".artifacts/apply-reports/apply-report-$checkpoint.json" \
+                --target-repo "$TARGET_REPO"
+              apply_publish_paths+=(results/apply-cursors)
+            fi
+            publish_changes "chore: apply sweep decisions checkpoint $checkpoint" "${apply_publish_paths[@]}"
             pnpm run status -- \
               --target-repo "$TARGET_REPO" \
               --state "Apply in progress" \
@@ -2486,9 +2500,13 @@ jobs:
               --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             publish_status "chore: update sweep apply checkpoint $checkpoint status"
             echo "::endgroup::"
-            if [ "$result_count" -ge "$close_processed_limit" ] && [ "$closed_in_chunk" -gt 0 ]; then
-              echo "Close scan reached its $close_processed_limit-record budget; queueing a fresh-token continuation."
-              continue_apply=true
+            if [ "$result_count" -ge "$close_processed_limit" ]; then
+              if [ "$auto_selected_apply_batch" = "true" ] || [ "$closed_in_chunk" -gt 0 ]; then
+                echo "Close scan reached its $close_processed_limit-record budget; queueing a fresh-token continuation."
+                continue_apply=true
+              else
+                echo "Explicit close scan reached its $close_processed_limit-record budget without fresh closes; stopping to avoid a retry loop."
+              fi
               break
             fi
             if [ "$result_count" -eq 0 ]; then
@@ -2508,6 +2526,10 @@ jobs:
             --detail "Apply/comment-sync run finished with $closed_total fresh closes out of requested limit $limit. See apply-report.json for per-item results." \
             --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           publish_status "chore: mark sweep apply finished"
+          next_apply_item_numbers="$item_numbers"
+          if [ "$auto_selected_apply_batch" = "true" ] && [ -z "$explicit_item_numbers" ]; then
+            next_apply_item_numbers=""
+          fi
           {
             echo "APPLY_CLOSED_TOTAL=$closed_total"
             echo "APPLY_LIMIT=$limit"
@@ -2520,10 +2542,11 @@ jobs:
             echo "APPLY_CLOSE_DELAY_MS=$close_delay_ms"
             echo "APPLY_PROGRESS_EVERY=$progress_every"
             echo "APPLY_CHECKPOINT_SIZE=$checkpoint_size"
-            echo "APPLY_ITEM_NUMBERS=$item_numbers"
+            echo "APPLY_ITEM_NUMBERS=$next_apply_item_numbers"
             echo "APPLY_TARGET_REPO=$TARGET_REPO"
             echo "APPLY_SYNC_COMMENTS_ONLY=$sync_comments_only"
             echo "APPLY_SYNC_OPEN_PR_BATCH=$sync_open_pr_batch"
+            echo "APPLY_AUTO_SELECTED_BATCH=$auto_selected_apply_batch"
             echo "APPLY_COMMENT_SYNC_MIN_AGE_DAYS=$comment_sync_min_age_days"
           } >> "$GITHUB_ENV"
 
@@ -2544,6 +2567,9 @@ jobs:
           )
           if [ "${APPLY_SYNC_OPEN_PR_BATCH:-false}" = "true" ]; then
             publish_args+=(--path results/comment-sync-cursors)
+          fi
+          if [ "${APPLY_AUTO_SELECTED_BATCH:-false}" = "true" ]; then
+            publish_args+=(--path results/apply-cursors)
           fi
           pnpm run repair:publish-main -- "${publish_args[@]}"
 

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2171,8 +2171,6 @@ jobs:
             sync_open_pr_batch="true"
             item_numbers=""
           fi
-          explicit_item_numbers="$item_numbers"
-          auto_selected_apply_batch=false
           sync_comments_only="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_sync_comments_only || 'false' }}"
           product_direction_enabled=false
           case "${CLAWSWEEPER_UNCONFIRMED_PRODUCT_DIRECTION_CLOSE_ENABLED,,}" in
@@ -2261,6 +2259,8 @@ jobs:
             sync_open_pr_batch="true"
             item_numbers=""
           fi
+          explicit_item_numbers="$item_numbers"
+          auto_selected_apply_batch=false
           sync_comments_only="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_sync_comments_only || 'false' }}"
           product_direction_enabled=false
           case "${CLAWSWEEPER_UNCONFIRMED_PRODUCT_DIRECTION_CLOSE_ENABLED,,}" in
@@ -2485,11 +2485,12 @@ jobs:
             closed_total=$((closed_total + closed_in_chunk))
             echo "Checkpoint $checkpoint result_count=$result_count closed_in_chunk=$closed_in_chunk closed_total=$closed_total/$limit"
             apply_publish_paths=(records apply-report.json)
-            if [ "$auto_selected_apply_batch" = "true" ] && [ "$result_count" -gt 0 ]; then
+            if [ "$auto_selected_apply_batch" = "true" ]; then
               pnpm run workflow -- write-apply-cursor \
                 --cursor-path "$apply_cursor_path" \
                 --report ".artifacts/apply-reports/apply-report-$checkpoint.json" \
-                --target-repo "$TARGET_REPO"
+                --target-repo "$TARGET_REPO" \
+                --item-numbers "$item_numbers"
               apply_publish_paths+=(results/apply-cursors)
             fi
             publish_changes "chore: apply sweep decisions checkpoint $checkpoint" "${apply_publish_paths[@]}"
@@ -2501,9 +2502,11 @@ jobs:
             publish_status "chore: update sweep apply checkpoint $checkpoint status"
             echo "::endgroup::"
             if [ "$result_count" -ge "$close_processed_limit" ]; then
-              if [ "$auto_selected_apply_batch" = "true" ] || [ "$closed_in_chunk" -gt 0 ]; then
+              if [ "$closed_in_chunk" -gt 0 ]; then
                 echo "Close scan reached its $close_processed_limit-record budget; queueing a fresh-token continuation."
                 continue_apply=true
+              elif [ "$auto_selected_apply_batch" = "true" ]; then
+                echo "Close scan reached its $close_processed_limit-record budget with no fresh closes; cursor is persisted and the next scheduled apply run will advance the next window."
               else
                 echo "Explicit close scan reached its $close_processed_limit-record budget without fresh closes; stopping to avoid a retry loop."
               fi

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -17056,7 +17056,12 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       });
       renameSync(path, join(closedDir, file));
     };
+    const markApplyChecked = (): void => {
+      markdown = replaceFrontMatterValue(markdown, "apply_checked_at", new Date().toISOString());
+      if (!dryRun) writeFileSync(path, markdown, "utf8");
+    };
     const recordApplySkipped = (actionTaken: ActionTaken, reason: string): boolean => {
+      markApplyChecked();
       results.push({ number, action: actionTaken, reason });
       processedCount += 1;
       maybeLogProgress(`skipped #${number}: ${reason}`);
@@ -17064,8 +17069,6 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
     };
     const markApplySkipped = (actionTaken: ActionTaken, reason: string): boolean => {
       markdown = replaceFrontMatterValue(markdown, "action_taken", actionTaken);
-      markdown = replaceFrontMatterValue(markdown, "apply_checked_at", new Date().toISOString());
-      if (!dryRun) writeFileSync(path, markdown, "utf8");
       return recordApplySkipped(actionTaken, reason);
     };
     const markLabelSyncAuthSkipped = (labelKind: string): boolean =>
@@ -17330,6 +17333,7 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       return result;
     };
     if (syncCommentsOnly && state !== "open") {
+      markApplyChecked();
       results.push({ number, action: "skipped_already_closed", reason: `state is ${state}` });
       processedCount += 1;
       maybeLogProgress(`skipped comment sync #${number}: already ${state}`);
@@ -17529,16 +17533,13 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
         : reviewedAuthorAssociation;
       markdown = replaceFrontMatterValue(markdown, "author_association", authorAssociation);
       markdown = replaceFrontMatterValue(markdown, "action_taken", "skipped_maintainer_authored");
-      markdown = replaceFrontMatterValue(markdown, "apply_checked_at", new Date().toISOString());
-      if (!dryRun) writeFileSync(path, markdown, "utf8");
-      results.push({
-        number,
-        action: "skipped_maintainer_authored",
-        reason: `author association is ${authorAssociation}`,
-      });
-      processedCount += 1;
-      maybeLogProgress(`skipped #${number}: maintainer authored`);
-      if (processedCount >= processedLimit) break;
+      if (
+        recordApplySkipped(
+          "skipped_maintainer_authored",
+          `author association is ${authorAssociation}`,
+        )
+      )
+        break;
       continue;
     }
     const updatedSinceReview = Boolean(storedUpdatedAt && item.updatedAt !== storedUpdatedAt);
@@ -17693,6 +17694,7 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
           "applied_at",
           commentUpdatedAt(existingReviewComment) ?? new Date().toISOString(),
         );
+        markdown = replaceFrontMatterValue(markdown, "apply_checked_at", new Date().toISOString());
         archiveClosed(markdown);
         closedCount += 1;
         processedCount += 1;
@@ -18031,6 +18033,7 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
         syncReasons.push("recorded existing durable comment metadata");
       }
       markdown = updateReviewCommentMetadata(markdown, syncedComment, markedReviewComment);
+      markdown = replaceFrontMatterValue(markdown, "apply_checked_at", new Date().toISOString());
       if (!dryRun) writeFileSync(path, markdown, "utf8");
       results.push({
         number,
@@ -18045,6 +18048,7 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
     }
     if (proofBlockedForCommentSync) {
       if (!needsReviewCommentSync) {
+        markdown = replaceFrontMatterValue(markdown, "apply_checked_at", new Date().toISOString());
         if (!dryRun) writeFileSync(path, markdown, "utf8");
         results.push({
           number,
@@ -18062,6 +18066,7 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       !needsReviewCommentSync &&
       (!isCloseProposal || syncCommentsOnly)
     ) {
+      markdown = replaceFrontMatterValue(markdown, "apply_checked_at", new Date().toISOString());
       if (!dryRun) writeFileSync(path, markdown, "utf8");
       results.push({
         number,
@@ -18078,25 +18083,18 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
     }
     if (closedCount >= limit) break;
     if (applyKind !== "all" && item.kind !== applyKind) {
-      results.push({
-        number,
-        action: "kept_open",
-        reason: `type is ${item.kind}; apply kind is ${applyKind}`,
-      });
-      processedCount += 1;
-      maybeLogProgress(`skipped #${number}: type is ${item.kind}`);
-      if (processedCount >= processedLimit) break;
+      if (recordApplySkipped("kept_open", `type is ${item.kind}; apply kind is ${applyKind}`))
+        break;
       continue;
     }
     if (!closeReasonEnabled(closeReason, applyCloseReasons)) {
-      results.push({
-        number,
-        action: "kept_open",
-        reason: `close reason ${closeReason} is not enabled for this apply run`,
-      });
-      processedCount += 1;
-      maybeLogProgress(`skipped #${number}: close reason ${closeReason} not enabled`);
-      if (processedCount >= processedLimit) break;
+      if (
+        recordApplySkipped(
+          "kept_open",
+          `close reason ${closeReason} is not enabled for this apply run`,
+        )
+      )
+        break;
       continue;
     }
     const currentReportValidation = validateCloseDecision(
@@ -18130,14 +18128,7 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       staleMinAgeDays,
     });
     if (ageSkipReason) {
-      results.push({
-        number,
-        action: "kept_open",
-        reason: ageSkipReason,
-      });
-      processedCount += 1;
-      maybeLogProgress(`skipped #${number}: ${ageSkipReason}`);
-      if (processedCount >= processedLimit) break;
+      if (recordApplySkipped("kept_open", ageSkipReason)) break;
       continue;
     }
     const prCloseCoverageBlock =
@@ -18226,6 +18217,7 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
     markdown = replaceFrontMatterValue(markdown, "close_comment_sha256", sha256(reviewComment));
     markdown = replaceFrontMatterValue(markdown, "action_taken", "closed");
     markdown = replaceFrontMatterValue(markdown, "applied_at", new Date().toISOString());
+    markdown = replaceFrontMatterValue(markdown, "apply_checked_at", new Date().toISOString());
     archiveClosed(markdown);
     closedCount += 1;
     processedCount += 1;

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -16973,6 +16973,7 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
   const applyReportEntriesForDir = (
     dir: string,
     location: "items" | "closed",
+    filterRequested = true,
   ): Array<
     ReportEntry & {
       location: "items" | "closed";
@@ -16984,7 +16985,9 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       .filter(
         (entry) =>
           entry.repo === targetRepo() &&
-          (requestedItemNumberSet.size === 0 || requestedItemNumberSet.has(entry.number)),
+          (!filterRequested ||
+            requestedItemNumberSet.size === 0 ||
+            requestedItemNumberSet.has(entry.number)),
       )
       .map((entry) => ({
         ...entry,
@@ -16998,9 +17001,8 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       left.number - right.number,
   );
   const files = fileEntries.map((entry) => entry.name);
-  const openFileEntryByNumber = new Map(
-    fileEntries.filter((entry) => entry.location === "items").map((entry) => [entry.number, entry]),
-  );
+  const allOpenFileEntries = applyReportEntriesForDir(itemsDir, "items", false);
+  const openFileEntryByNumber = new Map(allOpenFileEntries.map((entry) => [entry.number, entry]));
   const closedThisRun = new Set<string>();
   if (fileEntries.length === 0 && !existsSync(itemsDir)) {
     console.log("No items directory.");
@@ -17088,6 +17090,13 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
         action !== "retry_pr_close_coverage_proof" &&
         !shouldProbeClosedState)
     ) {
+      if (
+        !storedHash &&
+        requestedItemNumberSet.has(number) &&
+        recordApplySkipped("kept_open", "review lacks an item snapshot hash")
+      ) {
+        break;
+      }
       continue;
     }
     let isCloseProposal = isApplyCloseCandidateReport(markdown);
@@ -17325,6 +17334,9 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
               }) === null &&
               counterpartOpenClosingPullRequestReason === null &&
               counterpartSameAuthorReason === null;
+            if (result && !fileEntries.some((entry) => entry.number === counterpartNumber)) {
+              fileEntries.push(counterpartEntry);
+            }
           }
         }
       }

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -82,13 +82,11 @@ function runCli(): void {
       );
       break;
     case "write-apply-cursor":
-      printOutput(
-        writeApplyCursor(
-          requiredString("cursor-path"),
-          requiredString("report"),
-          requiredString("target-repo"),
-          optionalString("item-numbers"),
-        ),
+      writeApplyCursor(
+        requiredString("cursor-path"),
+        requiredString("report"),
+        requiredString("target-repo"),
+        optionalString("item-numbers"),
       );
       break;
     case "merge-apply-reports":
@@ -344,7 +342,6 @@ function selectedProposedItemCandidates(
       if (repoFor(markdown, name) !== options.targetRepo) return [];
       const type = frontMatterValue(markdown, "type");
       if (options.applyKind !== "all" && type && type !== options.applyKind) return [];
-      if (!frontMatterValue(markdown, "item_snapshot_hash")) return [];
       const decision = frontMatterValue(markdown, "decision");
       const action = frontMatterValue(markdown, "action_taken");
       const confidence = frontMatterValue(markdown, "confidence");
@@ -597,7 +594,7 @@ export function writeApplyCursor(
   reportPath: string,
   targetRepo: string,
   itemNumbers = "",
-): Record<string, string> {
+): void {
   const actions = readApplyActions(reportPath);
   const processed = actions.flatMap((action) =>
     typeof action.number === "number" ? [action.number] : [],
@@ -605,7 +602,12 @@ export function writeApplyCursor(
   const selected = csvItems(itemNumbers)
     .map((item) => Number(item))
     .filter((number) => Number.isInteger(number) && number > 0);
-  const number = processed.at(-1) ?? selected.at(-1) ?? 0;
+  const processedSet = new Set(processed);
+  const number =
+    selected.filter((itemNumber) => processedSet.has(itemNumber)).at(-1) ??
+    selected.at(-1) ??
+    processed.at(-1) ??
+    0;
   const applyCheckedAt = number > 0 ? applyCheckedAtForItem(targetRepo, number) : "";
   fs.mkdirSync(path.dirname(cursorPath), { recursive: true });
   fs.writeFileSync(
@@ -615,20 +617,12 @@ export function writeApplyCursor(
         target_repo: targetRepo,
         next_after_number: number,
         next_after_apply_checked_at: applyCheckedAt,
-        processed_count: processed.length,
-        selected_count: selected.length,
         updated_at: new Date().toISOString(),
       },
       null,
       2,
     )}\n`,
   );
-  return {
-    processed_count: String(processed.length),
-    selected_count: String(selected.length),
-    next_cursor_number: String(number),
-    next_cursor_apply_checked_at: applyCheckedAt,
-  };
 }
 
 function applyCheckedAtForItem(targetRepo: string, itemNumber: number): string {

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -87,6 +87,7 @@ function runCli(): void {
           requiredString("cursor-path"),
           requiredString("report"),
           requiredString("target-repo"),
+          optionalString("item-numbers"),
         ),
       );
       break;
@@ -343,6 +344,7 @@ function selectedProposedItemCandidates(
       if (repoFor(markdown, name) !== options.targetRepo) return [];
       const type = frontMatterValue(markdown, "type");
       if (options.applyKind !== "all" && type && type !== options.applyKind) return [];
+      if (!frontMatterValue(markdown, "item_snapshot_hash")) return [];
       const decision = frontMatterValue(markdown, "decision");
       const action = frontMatterValue(markdown, "action_taken");
       const confidence = frontMatterValue(markdown, "confidence");
@@ -594,12 +596,16 @@ export function writeApplyCursor(
   cursorPath: string,
   reportPath: string,
   targetRepo: string,
+  itemNumbers = "",
 ): Record<string, string> {
   const actions = readApplyActions(reportPath);
   const processed = actions.flatMap((action) =>
     typeof action.number === "number" ? [action.number] : [],
   );
-  const number = processed.at(-1) ?? 0;
+  const selected = csvItems(itemNumbers)
+    .map((item) => Number(item))
+    .filter((number) => Number.isInteger(number) && number > 0);
+  const number = processed.at(-1) ?? selected.at(-1) ?? 0;
   const applyCheckedAt = number > 0 ? applyCheckedAtForItem(targetRepo, number) : "";
   fs.mkdirSync(path.dirname(cursorPath), { recursive: true });
   fs.writeFileSync(
@@ -610,6 +616,7 @@ export function writeApplyCursor(
         next_after_number: number,
         next_after_apply_checked_at: applyCheckedAt,
         processed_count: processed.length,
+        selected_count: selected.length,
         updated_at: new Date().toISOString(),
       },
       null,
@@ -618,6 +625,7 @@ export function writeApplyCursor(
   );
   return {
     processed_count: String(processed.length),
+    selected_count: String(selected.length),
     next_cursor_number: String(number),
     next_cursor_apply_checked_at: applyCheckedAt,
   };

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -9,6 +9,7 @@ import { AUTOMATION_LIMITS, WORKER_CONFIG, workerLimit, type WorkerLane } from "
 
 type ApplyAction = {
   action: string;
+  number?: number;
 };
 
 const args = parseArgs(process.argv.slice(2));
@@ -78,6 +79,15 @@ function runCli(): void {
         requiredString("cursor-path"),
         numberArg("next-cursor", 0),
         requiredString("target-repo"),
+      );
+      break;
+    case "write-apply-cursor":
+      printOutput(
+        writeApplyCursor(
+          requiredString("cursor-path"),
+          requiredString("report"),
+          requiredString("target-repo"),
+        ),
       );
       break;
     case "merge-apply-reports":
@@ -261,6 +271,8 @@ type ProposedItemOptions = {
   staleMinAgeDays: number;
   minAgeDays: number;
   minAgeMinutes: number | null;
+  batchSize?: number | null;
+  cursorPath?: string | null;
   itemNumbers?: ReadonlySet<number> | null;
 };
 
@@ -272,24 +284,27 @@ type CommentSyncBatchOptions = {
 };
 
 export function proposedItemNumbers(options: ProposedItemOptions): number[] {
-  return selectedProposedItemNumbers(options, "all");
+  return selectedProposedItemCandidates(options, "all").map((candidate) => candidate.number);
 }
 
 export function proposedPrCloseCoverageItemNumbers(options: ProposedItemOptions): number[] {
-  return selectedProposedItemNumbers(options, "pr-close-coverage-proof");
+  return selectedProposedItemCandidates(options, "pr-close-coverage-proof").map(
+    (candidate) => candidate.number,
+  );
 }
 
 type ProposedItemSelection = "all" | "pr-close-coverage-proof";
 
-function selectedProposedItemNumbers(
+type ProposedItemCandidate = {
+  number: number;
+  applyCheckedAt: string;
+};
+
+function selectedProposedItemCandidates(
   options: ProposedItemOptions,
   selection: ProposedItemSelection,
-): number[] {
-  const targetSlug = options.targetRepo
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-|-$/g, "");
-  const itemsDir = path.join("records", targetSlug, "items");
+): ProposedItemCandidate[] {
+  const itemsDir = path.join("records", targetSlug(options.targetRepo), "items");
   if (!fs.existsSync(itemsDir)) return [];
 
   const allowedReasons = new Set([
@@ -318,7 +333,7 @@ function selectedProposedItemNumbers(
       ? options.minAgeDays * 24 * 60 * 60 * 1000
       : options.minAgeMinutes * 60 * 1000;
 
-  return fs
+  const candidates = fs
     .readdirSync(itemsDir)
     .filter((name) => /(?:^|[a-z0-9-]-)\d+\.md$/.test(name))
     .flatMap((name) => {
@@ -366,9 +381,52 @@ function selectedProposedItemNumbers(
         return [];
       }
       if (!olderThan(frontMatterValue(markdown, "item_created_at"), minAgeMs)) return [];
-      return [number];
+      return [{ number, applyCheckedAt: frontMatterValue(markdown, "apply_checked_at") }];
     })
-    .sort((left, right) => left - right);
+    .sort((left, right) => left.number - right.number);
+  const batchSize = options.batchSize ?? null;
+  if (!batchSize || batchSize <= 0) return candidates;
+  const sorted = [...candidates].sort(compareApplyCursorCandidate);
+  const cursor = options.cursorPath ? readApplyCursor(options.cursorPath) : null;
+  if (!cursor) return sorted.slice(0, batchSize);
+  const afterCursor = sorted.filter(
+    (candidate) => compareCandidateToApplyCursor(candidate, cursor) > 0,
+  );
+  return [
+    ...afterCursor,
+    ...sorted.filter((candidate) => compareCandidateToApplyCursor(candidate, cursor) <= 0),
+  ].slice(0, batchSize);
+}
+
+function compareApplyCursorCandidate(
+  left: ProposedItemCandidate,
+  right: ProposedItemCandidate,
+): number {
+  return (
+    compareApplyCheckedAt(left.applyCheckedAt, right.applyCheckedAt) || left.number - right.number
+  );
+}
+
+function compareCandidateToApplyCursor(
+  candidate: ProposedItemCandidate,
+  cursor: ApplyCursor,
+): number {
+  return (
+    compareApplyCheckedAt(candidate.applyCheckedAt, cursor.applyCheckedAt) ||
+    candidate.number - cursor.number
+  );
+}
+
+function compareApplyCheckedAt(left: string, right: string): number {
+  const leftMs = timestampValue(left);
+  const rightMs = timestampValue(right);
+  return leftMs - rightMs;
+}
+
+function timestampValue(value: string): number {
+  if (!value) return 0;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : 0;
 }
 
 const SELECTABLE_CLOSE_ACTIONS = new Set([
@@ -514,7 +572,73 @@ export function writeCommentSyncCursor(
   );
 }
 
+type ApplyCursor = {
+  applyCheckedAt: string;
+  number: number;
+};
+
+function readApplyCursor(cursorPath: string): ApplyCursor | null {
+  if (!fs.existsSync(cursorPath)) return null;
+  const parsed: unknown = JSON.parse(fs.readFileSync(cursorPath, "utf8"));
+  if (!isJsonObject(parsed)) return null;
+  const number = Number(parsed.next_after_number);
+  if (!Number.isInteger(number) || number < 0) return null;
+  const applyCheckedAt =
+    typeof parsed.next_after_apply_checked_at === "string"
+      ? parsed.next_after_apply_checked_at
+      : "";
+  return { number, applyCheckedAt };
+}
+
+export function writeApplyCursor(
+  cursorPath: string,
+  reportPath: string,
+  targetRepo: string,
+): Record<string, string> {
+  const actions = readApplyActions(reportPath);
+  const processed = actions.flatMap((action) =>
+    typeof action.number === "number" ? [action.number] : [],
+  );
+  const number = processed.at(-1) ?? 0;
+  const applyCheckedAt = number > 0 ? applyCheckedAtForItem(targetRepo, number) : "";
+  fs.mkdirSync(path.dirname(cursorPath), { recursive: true });
+  fs.writeFileSync(
+    cursorPath,
+    `${JSON.stringify(
+      {
+        target_repo: targetRepo,
+        next_after_number: number,
+        next_after_apply_checked_at: applyCheckedAt,
+        processed_count: processed.length,
+        updated_at: new Date().toISOString(),
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  return {
+    processed_count: String(processed.length),
+    next_cursor_number: String(number),
+    next_cursor_apply_checked_at: applyCheckedAt,
+  };
+}
+
+function applyCheckedAtForItem(targetRepo: string, itemNumber: number): string {
+  const baseDir = path.join("records", targetSlug(targetRepo));
+  for (const stateDir of ["items", "closed"]) {
+    const dir = path.join(baseDir, stateDir);
+    if (!fs.existsSync(dir)) continue;
+    const name = fs
+      .readdirSync(dir)
+      .find((entry) => /(?:^|[a-z0-9-]-)\d+\.md$/.test(entry) && numberFor(entry) === itemNumber);
+    if (!name) continue;
+    return frontMatterValue(fs.readFileSync(path.join(dir, name), "utf8"), "apply_checked_at");
+  }
+  return "";
+}
+
 function proposedItemOptions(): ProposedItemOptions {
+  const batchSizeText = optionalString("batch-size");
   return {
     targetRepo: requiredString("target-repo"),
     applyKind: optionalString("apply-kind") || "all",
@@ -522,6 +646,8 @@ function proposedItemOptions(): ProposedItemOptions {
     staleMinAgeDays: numberArg("stale-min-age-days", 60),
     minAgeDays: numberArg("min-age-days", 0),
     minAgeMinutes: optionalString("min-age-minutes") ? numberArg("min-age-minutes", 0) : null,
+    batchSize: batchSizeText ? numberArg("batch-size", 0) : null,
+    cursorPath: optionalString("cursor-path") || null,
     itemNumbers: itemNumberSet(optionalString("item-numbers")),
   };
 }
@@ -579,7 +705,9 @@ function readApplyActions(reportPath: string): ApplyAction[] {
   if (!Array.isArray(parsed)) throw new Error(`${reportPath} must contain an array`);
   return parsed.map((entry) => {
     if (!isJsonObject(entry) || typeof entry.action !== "string") return { action: "" };
-    return { action: entry.action };
+    const number = Number(entry.number);
+    if (!Number.isInteger(number) || number <= 0) return { action: entry.action };
+    return { action: entry.action, number };
   });
 }
 
@@ -713,6 +841,13 @@ function repoFor(markdown: string, name: string): string {
   return (
     frontMatterValue(markdown, "repository") || (/^\d+\.md$/.test(name) ? "openclaw/openclaw" : "")
   );
+}
+
+function targetSlug(targetRepo: string): string {
+  return targetRepo
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
 }
 
 function numberFor(name: string): number {

--- a/test/apply-same-author-pair-close.test.ts
+++ b/test/apply-same-author-pair-close.test.ts
@@ -145,6 +145,8 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/(320|321)\\/timeline(?
           "--dry-run",
           "--apply-kind",
           "all",
+          "--item-numbers",
+          "321",
           "--processed-limit",
           "4",
         ],

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -446,6 +446,8 @@ if (args[0] === "api" && /\\/issues\\/comments\\/\\d+$/.test(path)) {
     assert.doesNotMatch(patchedComment, /remove `clawsweeper:linked-pr-open`/);
     assert.doesNotMatch(patchedComment, /remove `clawsweeper:no-new-fix-pr`/);
     assert.match(readFileSync(join(itemsDir, "321.md"), "utf8"), /^labels_synced_at: /m);
+    assert.match(readFileSync(join(itemsDir, "321.md"), "utf8"), /^apply_checked_at: /m);
+    assert.doesNotMatch(readFileSync(join(itemsDir, "322.md"), "utf8"), /^apply_checked_at: /m);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -577,6 +579,7 @@ if (args[0] === "api" && /\\/issues\\/comments\\/\\d+$/.test(path)) {
     assert.match(updatedReport, /^labels: .*"P1"/m);
     assert.match(updatedReport, /^labels: .*"impact:message-loss"/m);
     assert.match(updatedReport, /^labels_synced_at: /m);
+    assert.match(updatedReport, /^apply_checked_at: /m);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -65,7 +65,6 @@ test("workflow utility CLI initializes close-selection constants before preselec
       "action_taken: skipped_invalid_decision",
       "close_reason: implemented_on_main",
       "item_created_at: 2024-01-01T00:00:00Z",
-      "item_snapshot_hash: reviewed-snapshot",
       "---",
       "",
     ].join("\n"),
@@ -278,7 +277,6 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: proposed_close",
       "close_reason: implemented_on_main",
       `item_created_at: ${oldDate}`,
-      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -294,7 +292,6 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: proposed_close",
       "close_reason: stale_insufficient_info",
       `item_created_at: ${oldDate}`,
-      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -310,7 +307,6 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: proposed_close",
       "close_reason: mostly_implemented_on_main",
       `item_created_at: ${oldDate}`,
-      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -326,7 +322,6 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: proposed_close",
       "close_reason: mostly_implemented_on_main",
       `item_created_at: ${oldDate}`,
-      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -342,7 +337,6 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: proposed_close",
       "close_reason: mostly_implemented_on_main",
       `item_created_at: ${new Date().toISOString()}`,
-      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -358,7 +352,6 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: proposed_close",
       "close_reason: low_signal_unmergeable_pr",
       `item_created_at: ${oldDate}`,
-      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -374,7 +367,6 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: proposed_close",
       "close_reason: low_signal_unmergeable_pr",
       `item_created_at: ${oldDate}`,
-      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -390,7 +382,6 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: retry_pr_close_coverage_proof",
       "close_reason: duplicate_or_superseded",
       `item_created_at: ${oldDate}`,
-      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -406,7 +397,6 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: kept_open",
       "close_reason: duplicate_or_superseded",
       `item_created_at: ${oldDate}`,
-      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -422,7 +412,6 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: skipped_pr_close_coverage_proof",
       "close_reason: duplicate_or_superseded",
       `item_created_at: ${oldDate}`,
-      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -439,7 +428,6 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: kept_open",
       "close_reason: none",
       `item_created_at: ${oldDate}`,
-      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -456,7 +444,6 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: kept_open",
       "close_reason: none",
       `item_created_at: ${oldDate}`,
-      `item_snapshot_hash: reviewed-snapshot`,
       `work_cluster_refs: ${JSON.stringify(["Superseded by https://github.com/openclaw/openclaw/pull/400"])}`,
       "---",
       "",
@@ -475,7 +462,6 @@ test("workflow utilities select eligible proposed close records", () => {
       "close_reason: none",
       "pr_rating_overall: F",
       `item_created_at: ${oldDate}`,
-      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -492,7 +478,6 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: kept_open",
       "close_reason: none",
       `item_created_at: ${oldDate}`,
-      `item_snapshot_hash: reviewed-snapshot`,
       `work_cluster_refs: ${JSON.stringify(["Superseded by openclaw/openclaw#400"])}`,
       "---",
       "",
@@ -510,7 +495,6 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: kept_open",
       "close_reason: none",
       `item_created_at: ${oldDate}`,
-      `item_snapshot_hash: reviewed-snapshot`,
       `work_cluster_refs: ${JSON.stringify(["Superseded by #400"])}`,
       "---",
       "",
@@ -529,7 +513,6 @@ test("workflow utilities select eligible proposed close records", () => {
       "close_reason: none",
       "pr_rating_overall: F",
       `item_created_at: ${new Date().toISOString()}`,
-      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -545,7 +528,6 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: skipped_same_author_pair",
       "close_reason: duplicate_or_superseded",
       `item_created_at: ${oldDate}`,
-      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -561,7 +543,6 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: skipped_open_closing_pr",
       "close_reason: implemented_on_main",
       `item_created_at: ${oldDate}`,
-      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -577,7 +558,6 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: skipped_invalid_decision",
       "close_reason: duplicate_or_superseded",
       `item_created_at: ${oldDate}`,
-      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -593,7 +573,6 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: skipped_maintainer_authored",
       "close_reason: duplicate_or_superseded",
       `item_created_at: ${oldDate}`,
-      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -609,7 +588,6 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: skipped_invalid_decision",
       "close_reason: implemented_on_main",
       `item_created_at: ${oldDate}`,
-      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -625,7 +603,6 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: skipped_maintainer_authored",
       "close_reason: implemented_on_main",
       `item_created_at: ${oldDate}`,
-      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -645,55 +622,6 @@ test("workflow utilities select eligible proposed close records", () => {
   assert.deepEqual(selected, [5, 12, 15, 17, 18, 21, 22, 24, 25, 26, 27, 30, 31]);
 });
 
-test("workflow utilities skip proposed apply records without snapshots", () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
-  const oldDate = "2024-01-01T00:00:00Z";
-  write(
-    path.join(root, "records/openclaw-openclaw/items/openclaw-openclaw-41.md"),
-    [
-      "---",
-      "repository: openclaw/openclaw",
-      "type: issue",
-      "decision: close",
-      "confidence: high",
-      "action_taken: proposed_close",
-      "close_reason: implemented_on_main",
-      `item_created_at: ${oldDate}`,
-      "---",
-      "",
-    ].join("\n"),
-  );
-  write(
-    path.join(root, "records/openclaw-openclaw/items/openclaw-openclaw-42.md"),
-    [
-      "---",
-      "repository: openclaw/openclaw",
-      "type: issue",
-      "decision: close",
-      "confidence: high",
-      "action_taken: proposed_close",
-      "close_reason: implemented_on_main",
-      `item_created_at: ${oldDate}`,
-      "item_snapshot_hash: reviewed-snapshot",
-      "---",
-      "",
-    ].join("\n"),
-  );
-
-  const selected = withCwd(root, () =>
-    proposedItemNumbers({
-      targetRepo: "openclaw/openclaw",
-      applyKind: "all",
-      applyCloseReasons: "all",
-      staleMinAgeDays: 60,
-      minAgeDays: 0,
-      minAgeMinutes: null,
-    }),
-  );
-
-  assert.deepEqual(selected, [42]);
-});
-
 test("workflow utilities allow ClawHub implemented-on-main issue proposals", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
   write(
@@ -707,7 +635,6 @@ test("workflow utilities allow ClawHub implemented-on-main issue proposals", () 
       "action_taken: proposed_close",
       "close_reason: implemented_on_main",
       "item_created_at: 2024-01-01T00:00:00Z",
-      "item_snapshot_hash: reviewed-snapshot",
       "---",
       "",
     ].join("\n"),
@@ -723,7 +650,6 @@ test("workflow utilities allow ClawHub implemented-on-main issue proposals", () 
       "action_taken: proposed_close",
       "close_reason: duplicate_or_superseded",
       "item_created_at: 2024-01-01T00:00:00Z",
-      "item_snapshot_hash: reviewed-snapshot",
       "---",
       "",
     ].join("\n"),
@@ -740,7 +666,6 @@ test("workflow utilities allow ClawHub implemented-on-main issue proposals", () 
       "action_taken: kept_open",
       "close_reason: none",
       "item_created_at: 2024-01-01T00:00:00Z",
-      "item_snapshot_hash: reviewed-snapshot",
       "---",
       "",
     ].join("\n"),
@@ -801,7 +726,6 @@ test("workflow utilities select proposed PR closes that can need coverage proof"
       "action_taken: kept_open",
       "close_reason: none",
       `item_created_at: ${oldDate}`,
-      `item_snapshot_hash: reviewed-snapshot`,
       `work_cluster_refs: ${JSON.stringify(["Superseded by #400"])}`,
       "---",
       "",
@@ -819,7 +743,6 @@ test("workflow utilities select proposed PR closes that can need coverage proof"
       "action_taken: kept_open",
       "close_reason: none",
       `item_created_at: ${oldDate}`,
-      `item_snapshot_hash: reviewed-snapshot`,
       `work_cluster_refs: ${JSON.stringify(["Superseded by [PR #400](https://github.com/other/repo/pull/400)"])}`,
       "---",
       "",
@@ -837,7 +760,6 @@ test("workflow utilities select proposed PR closes that can need coverage proof"
       "action_taken: kept_open",
       "close_reason: none",
       `item_created_at: ${oldDate}`,
-      `item_snapshot_hash: reviewed-snapshot`,
       `merge_risk_options: ${JSON.stringify([
         {
           category: "pause_or_close",
@@ -862,7 +784,6 @@ test("workflow utilities select proposed PR closes that can need coverage proof"
       "action_taken: kept_open",
       "close_reason: none",
       `item_created_at: ${oldDate}`,
-      `item_snapshot_hash: reviewed-snapshot`,
       "pr_rating_overall: F",
       "---",
       "",
@@ -956,7 +877,6 @@ test("workflow utilities rotate bounded apply candidate batches by apply cursor"
   writeProposedRecord(root, 40, "issue", "proposed_close", "implemented_on_main", oldDate, {
     applyCheckedAt: "2026-01-03T00:00:00Z",
   });
-
   const options = {
     targetRepo: "openclaw/openclaw",
     applyKind: "all",
@@ -972,35 +892,17 @@ test("workflow utilities rotate bounded apply candidate batches by apply cursor"
     withCwd(root, () => proposedItemNumbers(options)),
     [20, 30],
   );
-
   write(
     cursorPath,
-    `${JSON.stringify(
-      {
-        target_repo: "openclaw/openclaw",
-        next_after_number: 30,
-        next_after_apply_checked_at: "2026-01-01T00:00:00Z",
-      },
-      null,
-      2,
-    )}\n`,
+    JSON.stringify({ next_after_number: 30, next_after_apply_checked_at: "2026-01-01T00:00:00Z" }),
   );
   assert.deepEqual(
     withCwd(root, () => proposedItemNumbers(options)),
     [10, 40],
   );
-
   write(
     cursorPath,
-    `${JSON.stringify(
-      {
-        target_repo: "openclaw/openclaw",
-        next_after_number: 40,
-        next_after_apply_checked_at: "2026-01-03T00:00:00Z",
-      },
-      null,
-      2,
-    )}\n`,
+    JSON.stringify({ next_after_number: 40, next_after_apply_checked_at: "2026-01-03T00:00:00Z" }),
   );
   assert.deepEqual(
     withCwd(root, () => proposedItemNumbers(options)),
@@ -1008,76 +910,35 @@ test("workflow utilities rotate bounded apply candidate batches by apply cursor"
   );
 });
 
-test("workflow utilities write apply cursor from the last processed report item", () => {
+test("workflow utilities persist apply cursor from processed or selected items", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
   const cursorPath = path.join(root, "results/apply-cursors/openclaw-openclaw.json");
-  const reportPath = path.join(root, ".artifacts/apply-reports/apply-report-1.json");
-  const oldDate = "2024-01-01T00:00:00Z";
-  writeProposedRecord(root, 10, "issue", "proposed_close", "implemented_on_main", oldDate, {
-    applyCheckedAt: "2026-01-01T00:00:00Z",
-  });
-  writeProposedRecord(root, 20, "issue", "proposed_close", "implemented_on_main", oldDate, {
-    applyCheckedAt: "2026-01-02T00:00:00Z",
-  });
-  write(
-    reportPath,
-    `${JSON.stringify(
-      [
-        { number: 10, action: "kept_open", reason: "first" },
-        { number: 20, action: "kept_open", reason: "second" },
-      ],
-      null,
-      2,
-    )}\n`,
-  );
-
-  assert.deepEqual(
-    withCwd(root, () => writeApplyCursor(cursorPath, reportPath, "openclaw/openclaw")),
-    {
-      processed_count: "2",
-      selected_count: "0",
-      next_cursor_number: "20",
-      next_cursor_apply_checked_at: "2026-01-02T00:00:00Z",
-    },
-  );
-  assert.deepEqual(JSON.parse(fs.readFileSync(cursorPath, "utf8")), {
-    target_repo: "openclaw/openclaw",
-    next_after_number: 20,
-    next_after_apply_checked_at: "2026-01-02T00:00:00Z",
-    processed_count: 2,
-    selected_count: 0,
-    updated_at: JSON.parse(fs.readFileSync(cursorPath, "utf8")).updated_at,
-  });
-});
-
-test("workflow utilities write apply cursor from selected items when report is empty", () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
-  const cursorPath = path.join(root, "results/apply-cursors/openclaw-openclaw.json");
-  const reportPath = path.join(root, ".artifacts/apply-reports/apply-report-1.json");
+  const reportPath = path.join(root, "apply-report.json");
   const oldDate = "2024-01-01T00:00:00Z";
   writeProposedRecord(root, 10, "issue", "proposed_close", "implemented_on_main", oldDate);
   writeProposedRecord(root, 20, "issue", "proposed_close", "implemented_on_main", oldDate, {
     applyCheckedAt: "2026-01-02T00:00:00Z",
   });
-  write(reportPath, "[]\n");
 
-  assert.deepEqual(
-    withCwd(root, () => writeApplyCursor(cursorPath, reportPath, "openclaw/openclaw", "10,20")),
-    {
-      processed_count: "0",
-      selected_count: "2",
-      next_cursor_number: "20",
-      next_cursor_apply_checked_at: "2026-01-02T00:00:00Z",
-    },
-  );
-  assert.deepEqual(JSON.parse(fs.readFileSync(cursorPath, "utf8")), {
-    target_repo: "openclaw/openclaw",
-    next_after_number: 20,
-    next_after_apply_checked_at: "2026-01-02T00:00:00Z",
-    processed_count: 0,
-    selected_count: 2,
-    updated_at: JSON.parse(fs.readFileSync(cursorPath, "utf8")).updated_at,
-  });
+  for (const [report, selected] of [
+    [[{ number: 20, action: "kept_open" }], ""],
+    [
+      [
+        { number: 20, action: "kept_open" },
+        { number: 10, action: "closed" },
+      ],
+      "10,20",
+    ],
+    [[], "10,20"],
+  ]) {
+    write(reportPath, JSON.stringify(report));
+    withCwd(root, () => writeApplyCursor(cursorPath, reportPath, "openclaw/openclaw", selected));
+    const cursor = JSON.parse(fs.readFileSync(cursorPath, "utf8"));
+    assert.deepEqual(
+      [cursor.target_repo, cursor.next_after_number, cursor.next_after_apply_checked_at],
+      ["openclaw/openclaw", 20, "2026-01-02T00:00:00Z"],
+    );
+  }
 });
 
 test("workflow utilities select cursor-based PR comment sync batches", () => {
@@ -1181,7 +1042,6 @@ function writeProposedRecord(
     `action_taken: ${actionTaken}`,
     `close_reason: ${closeReason}`,
     `item_created_at: ${itemCreatedAt}`,
-    `item_snapshot_hash: reviewed-snapshot`,
   ];
   if (options.applyCheckedAt) lines.push(`apply_checked_at: ${options.applyCheckedAt}`);
   lines.push("---", "");

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -65,6 +65,7 @@ test("workflow utility CLI initializes close-selection constants before preselec
       "action_taken: skipped_invalid_decision",
       "close_reason: implemented_on_main",
       "item_created_at: 2024-01-01T00:00:00Z",
+      "item_snapshot_hash: reviewed-snapshot",
       "---",
       "",
     ].join("\n"),
@@ -277,6 +278,7 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: proposed_close",
       "close_reason: implemented_on_main",
       `item_created_at: ${oldDate}`,
+      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -292,6 +294,7 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: proposed_close",
       "close_reason: stale_insufficient_info",
       `item_created_at: ${oldDate}`,
+      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -307,6 +310,7 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: proposed_close",
       "close_reason: mostly_implemented_on_main",
       `item_created_at: ${oldDate}`,
+      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -322,6 +326,7 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: proposed_close",
       "close_reason: mostly_implemented_on_main",
       `item_created_at: ${oldDate}`,
+      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -337,6 +342,7 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: proposed_close",
       "close_reason: mostly_implemented_on_main",
       `item_created_at: ${new Date().toISOString()}`,
+      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -352,6 +358,7 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: proposed_close",
       "close_reason: low_signal_unmergeable_pr",
       `item_created_at: ${oldDate}`,
+      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -367,6 +374,7 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: proposed_close",
       "close_reason: low_signal_unmergeable_pr",
       `item_created_at: ${oldDate}`,
+      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -382,6 +390,7 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: retry_pr_close_coverage_proof",
       "close_reason: duplicate_or_superseded",
       `item_created_at: ${oldDate}`,
+      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -397,6 +406,7 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: kept_open",
       "close_reason: duplicate_or_superseded",
       `item_created_at: ${oldDate}`,
+      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -412,6 +422,7 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: skipped_pr_close_coverage_proof",
       "close_reason: duplicate_or_superseded",
       `item_created_at: ${oldDate}`,
+      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -428,6 +439,7 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: kept_open",
       "close_reason: none",
       `item_created_at: ${oldDate}`,
+      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -444,6 +456,7 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: kept_open",
       "close_reason: none",
       `item_created_at: ${oldDate}`,
+      `item_snapshot_hash: reviewed-snapshot`,
       `work_cluster_refs: ${JSON.stringify(["Superseded by https://github.com/openclaw/openclaw/pull/400"])}`,
       "---",
       "",
@@ -462,6 +475,7 @@ test("workflow utilities select eligible proposed close records", () => {
       "close_reason: none",
       "pr_rating_overall: F",
       `item_created_at: ${oldDate}`,
+      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -478,6 +492,7 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: kept_open",
       "close_reason: none",
       `item_created_at: ${oldDate}`,
+      `item_snapshot_hash: reviewed-snapshot`,
       `work_cluster_refs: ${JSON.stringify(["Superseded by openclaw/openclaw#400"])}`,
       "---",
       "",
@@ -495,6 +510,7 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: kept_open",
       "close_reason: none",
       `item_created_at: ${oldDate}`,
+      `item_snapshot_hash: reviewed-snapshot`,
       `work_cluster_refs: ${JSON.stringify(["Superseded by #400"])}`,
       "---",
       "",
@@ -513,6 +529,7 @@ test("workflow utilities select eligible proposed close records", () => {
       "close_reason: none",
       "pr_rating_overall: F",
       `item_created_at: ${new Date().toISOString()}`,
+      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -528,6 +545,7 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: skipped_same_author_pair",
       "close_reason: duplicate_or_superseded",
       `item_created_at: ${oldDate}`,
+      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -543,6 +561,7 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: skipped_open_closing_pr",
       "close_reason: implemented_on_main",
       `item_created_at: ${oldDate}`,
+      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -558,6 +577,7 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: skipped_invalid_decision",
       "close_reason: duplicate_or_superseded",
       `item_created_at: ${oldDate}`,
+      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -573,6 +593,7 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: skipped_maintainer_authored",
       "close_reason: duplicate_or_superseded",
       `item_created_at: ${oldDate}`,
+      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -588,6 +609,7 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: skipped_invalid_decision",
       "close_reason: implemented_on_main",
       `item_created_at: ${oldDate}`,
+      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -603,6 +625,7 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: skipped_maintainer_authored",
       "close_reason: implemented_on_main",
       `item_created_at: ${oldDate}`,
+      `item_snapshot_hash: reviewed-snapshot`,
       "---",
       "",
     ].join("\n"),
@@ -622,6 +645,55 @@ test("workflow utilities select eligible proposed close records", () => {
   assert.deepEqual(selected, [5, 12, 15, 17, 18, 21, 22, 24, 25, 26, 27, 30, 31]);
 });
 
+test("workflow utilities skip proposed apply records without snapshots", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const oldDate = "2024-01-01T00:00:00Z";
+  write(
+    path.join(root, "records/openclaw-openclaw/items/openclaw-openclaw-41.md"),
+    [
+      "---",
+      "repository: openclaw/openclaw",
+      "type: issue",
+      "decision: close",
+      "confidence: high",
+      "action_taken: proposed_close",
+      "close_reason: implemented_on_main",
+      `item_created_at: ${oldDate}`,
+      "---",
+      "",
+    ].join("\n"),
+  );
+  write(
+    path.join(root, "records/openclaw-openclaw/items/openclaw-openclaw-42.md"),
+    [
+      "---",
+      "repository: openclaw/openclaw",
+      "type: issue",
+      "decision: close",
+      "confidence: high",
+      "action_taken: proposed_close",
+      "close_reason: implemented_on_main",
+      `item_created_at: ${oldDate}`,
+      "item_snapshot_hash: reviewed-snapshot",
+      "---",
+      "",
+    ].join("\n"),
+  );
+
+  const selected = withCwd(root, () =>
+    proposedItemNumbers({
+      targetRepo: "openclaw/openclaw",
+      applyKind: "all",
+      applyCloseReasons: "all",
+      staleMinAgeDays: 60,
+      minAgeDays: 0,
+      minAgeMinutes: null,
+    }),
+  );
+
+  assert.deepEqual(selected, [42]);
+});
+
 test("workflow utilities allow ClawHub implemented-on-main issue proposals", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
   write(
@@ -635,6 +707,7 @@ test("workflow utilities allow ClawHub implemented-on-main issue proposals", () 
       "action_taken: proposed_close",
       "close_reason: implemented_on_main",
       "item_created_at: 2024-01-01T00:00:00Z",
+      "item_snapshot_hash: reviewed-snapshot",
       "---",
       "",
     ].join("\n"),
@@ -650,6 +723,7 @@ test("workflow utilities allow ClawHub implemented-on-main issue proposals", () 
       "action_taken: proposed_close",
       "close_reason: duplicate_or_superseded",
       "item_created_at: 2024-01-01T00:00:00Z",
+      "item_snapshot_hash: reviewed-snapshot",
       "---",
       "",
     ].join("\n"),
@@ -666,6 +740,7 @@ test("workflow utilities allow ClawHub implemented-on-main issue proposals", () 
       "action_taken: kept_open",
       "close_reason: none",
       "item_created_at: 2024-01-01T00:00:00Z",
+      "item_snapshot_hash: reviewed-snapshot",
       "---",
       "",
     ].join("\n"),
@@ -726,6 +801,7 @@ test("workflow utilities select proposed PR closes that can need coverage proof"
       "action_taken: kept_open",
       "close_reason: none",
       `item_created_at: ${oldDate}`,
+      `item_snapshot_hash: reviewed-snapshot`,
       `work_cluster_refs: ${JSON.stringify(["Superseded by #400"])}`,
       "---",
       "",
@@ -743,6 +819,7 @@ test("workflow utilities select proposed PR closes that can need coverage proof"
       "action_taken: kept_open",
       "close_reason: none",
       `item_created_at: ${oldDate}`,
+      `item_snapshot_hash: reviewed-snapshot`,
       `work_cluster_refs: ${JSON.stringify(["Superseded by [PR #400](https://github.com/other/repo/pull/400)"])}`,
       "---",
       "",
@@ -760,6 +837,7 @@ test("workflow utilities select proposed PR closes that can need coverage proof"
       "action_taken: kept_open",
       "close_reason: none",
       `item_created_at: ${oldDate}`,
+      `item_snapshot_hash: reviewed-snapshot`,
       `merge_risk_options: ${JSON.stringify([
         {
           category: "pause_or_close",
@@ -784,6 +862,7 @@ test("workflow utilities select proposed PR closes that can need coverage proof"
       "action_taken: kept_open",
       "close_reason: none",
       `item_created_at: ${oldDate}`,
+      `item_snapshot_hash: reviewed-snapshot`,
       "pr_rating_overall: F",
       "---",
       "",
@@ -956,6 +1035,7 @@ test("workflow utilities write apply cursor from the last processed report item"
     withCwd(root, () => writeApplyCursor(cursorPath, reportPath, "openclaw/openclaw")),
     {
       processed_count: "2",
+      selected_count: "0",
       next_cursor_number: "20",
       next_cursor_apply_checked_at: "2026-01-02T00:00:00Z",
     },
@@ -965,6 +1045,37 @@ test("workflow utilities write apply cursor from the last processed report item"
     next_after_number: 20,
     next_after_apply_checked_at: "2026-01-02T00:00:00Z",
     processed_count: 2,
+    selected_count: 0,
+    updated_at: JSON.parse(fs.readFileSync(cursorPath, "utf8")).updated_at,
+  });
+});
+
+test("workflow utilities write apply cursor from selected items when report is empty", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const cursorPath = path.join(root, "results/apply-cursors/openclaw-openclaw.json");
+  const reportPath = path.join(root, ".artifacts/apply-reports/apply-report-1.json");
+  const oldDate = "2024-01-01T00:00:00Z";
+  writeProposedRecord(root, 10, "issue", "proposed_close", "implemented_on_main", oldDate);
+  writeProposedRecord(root, 20, "issue", "proposed_close", "implemented_on_main", oldDate, {
+    applyCheckedAt: "2026-01-02T00:00:00Z",
+  });
+  write(reportPath, "[]\n");
+
+  assert.deepEqual(
+    withCwd(root, () => writeApplyCursor(cursorPath, reportPath, "openclaw/openclaw", "10,20")),
+    {
+      processed_count: "0",
+      selected_count: "2",
+      next_cursor_number: "20",
+      next_cursor_apply_checked_at: "2026-01-02T00:00:00Z",
+    },
+  );
+  assert.deepEqual(JSON.parse(fs.readFileSync(cursorPath, "utf8")), {
+    target_repo: "openclaw/openclaw",
+    next_after_number: 20,
+    next_after_apply_checked_at: "2026-01-02T00:00:00Z",
+    processed_count: 0,
+    selected_count: 2,
     updated_at: JSON.parse(fs.readFileSync(cursorPath, "utf8")).updated_at,
   });
 });
@@ -1070,6 +1181,7 @@ function writeProposedRecord(
     `action_taken: ${actionTaken}`,
     `close_reason: ${closeReason}`,
     `item_created_at: ${itemCreatedAt}`,
+    `item_snapshot_hash: reviewed-snapshot`,
   ];
   if (options.applyCheckedAt) lines.push(`apply_checked_at: ${options.applyCheckedAt}`);
   lines.push("---", "");

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -17,6 +17,7 @@ import {
   plannedItemNumberCsv,
   proposedItemNumbers,
   proposedPrCloseCoverageItemNumbers,
+  writeApplyCursor,
   writeCommentSyncCursor,
 } from "../../dist/repair/workflow-utils.js";
 import {
@@ -862,6 +863,112 @@ test("workflow utilities select gated product-direction PR close proposals", () 
   );
 });
 
+test("workflow utilities rotate bounded apply candidate batches by apply cursor", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const oldDate = "2024-01-01T00:00:00Z";
+  const cursorPath = path.join(root, "results/apply-cursors/openclaw-openclaw.json");
+  writeProposedRecord(root, 10, "issue", "proposed_close", "implemented_on_main", oldDate, {
+    applyCheckedAt: "2026-01-02T00:00:00Z",
+  });
+  writeProposedRecord(root, 20, "issue", "proposed_close", "implemented_on_main", oldDate);
+  writeProposedRecord(root, 30, "issue", "proposed_close", "implemented_on_main", oldDate, {
+    applyCheckedAt: "2026-01-01T00:00:00Z",
+  });
+  writeProposedRecord(root, 40, "issue", "proposed_close", "implemented_on_main", oldDate, {
+    applyCheckedAt: "2026-01-03T00:00:00Z",
+  });
+
+  const options = {
+    targetRepo: "openclaw/openclaw",
+    applyKind: "all",
+    applyCloseReasons: "all",
+    staleMinAgeDays: 60,
+    minAgeDays: 0,
+    minAgeMinutes: null,
+    batchSize: 2,
+    cursorPath,
+  };
+
+  assert.deepEqual(
+    withCwd(root, () => proposedItemNumbers(options)),
+    [20, 30],
+  );
+
+  write(
+    cursorPath,
+    `${JSON.stringify(
+      {
+        target_repo: "openclaw/openclaw",
+        next_after_number: 30,
+        next_after_apply_checked_at: "2026-01-01T00:00:00Z",
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  assert.deepEqual(
+    withCwd(root, () => proposedItemNumbers(options)),
+    [10, 40],
+  );
+
+  write(
+    cursorPath,
+    `${JSON.stringify(
+      {
+        target_repo: "openclaw/openclaw",
+        next_after_number: 40,
+        next_after_apply_checked_at: "2026-01-03T00:00:00Z",
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  assert.deepEqual(
+    withCwd(root, () => proposedItemNumbers(options)),
+    [20, 30],
+  );
+});
+
+test("workflow utilities write apply cursor from the last processed report item", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const cursorPath = path.join(root, "results/apply-cursors/openclaw-openclaw.json");
+  const reportPath = path.join(root, ".artifacts/apply-reports/apply-report-1.json");
+  const oldDate = "2024-01-01T00:00:00Z";
+  writeProposedRecord(root, 10, "issue", "proposed_close", "implemented_on_main", oldDate, {
+    applyCheckedAt: "2026-01-01T00:00:00Z",
+  });
+  writeProposedRecord(root, 20, "issue", "proposed_close", "implemented_on_main", oldDate, {
+    applyCheckedAt: "2026-01-02T00:00:00Z",
+  });
+  write(
+    reportPath,
+    `${JSON.stringify(
+      [
+        { number: 10, action: "kept_open", reason: "first" },
+        { number: 20, action: "kept_open", reason: "second" },
+      ],
+      null,
+      2,
+    )}\n`,
+  );
+
+  assert.deepEqual(
+    withCwd(root, () => writeApplyCursor(cursorPath, reportPath, "openclaw/openclaw")),
+    {
+      processed_count: "2",
+      next_cursor_number: "20",
+      next_cursor_apply_checked_at: "2026-01-02T00:00:00Z",
+    },
+  );
+  assert.deepEqual(JSON.parse(fs.readFileSync(cursorPath, "utf8")), {
+    target_repo: "openclaw/openclaw",
+    next_after_number: 20,
+    next_after_apply_checked_at: "2026-01-02T00:00:00Z",
+    processed_count: 2,
+    updated_at: JSON.parse(fs.readFileSync(cursorPath, "utf8")).updated_at,
+  });
+});
+
 test("workflow utilities select cursor-based PR comment sync batches", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
   const cursorPath = path.join(root, "results/comment-sync-cursors/openclaw-openclaw.json");
@@ -945,21 +1052,30 @@ function write(file, content) {
   fs.writeFileSync(file, content);
 }
 
-function writeProposedRecord(root, number, type, actionTaken, closeReason, itemCreatedAt) {
+function writeProposedRecord(
+  root,
+  number,
+  type,
+  actionTaken,
+  closeReason,
+  itemCreatedAt,
+  options = {},
+) {
+  const lines = [
+    "---",
+    "repository: openclaw/openclaw",
+    `type: ${type}`,
+    "decision: close",
+    "confidence: high",
+    `action_taken: ${actionTaken}`,
+    `close_reason: ${closeReason}`,
+    `item_created_at: ${itemCreatedAt}`,
+  ];
+  if (options.applyCheckedAt) lines.push(`apply_checked_at: ${options.applyCheckedAt}`);
+  lines.push("---", "");
   write(
     path.join(root, `records/openclaw-openclaw/items/openclaw-openclaw-${number}.md`),
-    [
-      "---",
-      "repository: openclaw/openclaw",
-      `type: ${type}`,
-      "decision: close",
-      "confidence: high",
-      `action_taken: ${actionTaken}`,
-      `close_reason: ${closeReason}`,
-      `item_created_at: ${itemCreatedAt}`,
-      "---",
-      "",
-    ].join("\n"),
+    lines.join("\n"),
   );
 }
 

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -143,12 +143,17 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
   assert.match(applyStep, /processed-limit "\$close_processed_limit"/);
   assert.match(applyStep, /comment_sync_processed_limit=1000/);
   assert.match(applyStep, /--processed-limit "\$comment_sync_processed_limit"/);
+  const applyFlagInit = applyStep.indexOf('explicit_item_numbers="$item_numbers"');
+  assert.ok(applyFlagInit > applyStep.indexOf('item_numbers="${{'));
+  assert.ok(applyFlagInit < applyStep.indexOf("auto_selected_apply_batch=true"));
   assert.match(applyStep, /apply_cursor_path="results\/apply-cursors\/\$\{target_slug\}\.json"/);
   assert.match(applyStep, /--batch-size "\$close_processed_limit"/);
   assert.match(applyStep, /--cursor-path "\$apply_cursor_path"/);
   assert.match(applyStep, /write-apply-cursor/);
+  assert.match(applyStep, /--item-numbers "\$item_numbers"/);
   assert.match(applyStep, /results\/apply-cursors/);
   assert.match(applyStep, /reached its \$close_processed_limit-record budget/);
+  assert.match(applyStep, /next scheduled apply run will advance the next window/);
   assert.match(applyStep, /apply_close_reasons="\$\(printf '%s\\n' "\$apply_close_reasons"/);
   assert.match(applyStep, /No enabled close reasons remain after policy filtering/);
   assert.match(applyStep, /true\|1\|yes\|on\) product_direction_enabled=true/);

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -143,19 +143,29 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
   assert.match(applyStep, /processed-limit "\$close_processed_limit"/);
   assert.match(applyStep, /comment_sync_processed_limit=1000/);
   assert.match(applyStep, /--processed-limit "\$comment_sync_processed_limit"/);
+  assert.match(applyStep, /apply_cursor_path="results\/apply-cursors\/\$\{target_slug\}\.json"/);
+  assert.match(applyStep, /--batch-size "\$close_processed_limit"/);
+  assert.match(applyStep, /--cursor-path "\$apply_cursor_path"/);
+  assert.match(applyStep, /write-apply-cursor/);
+  assert.match(applyStep, /results\/apply-cursors/);
   assert.match(applyStep, /reached its \$close_processed_limit-record budget/);
   assert.match(applyStep, /apply_close_reasons="\$\(printf '%s\\n' "\$apply_close_reasons"/);
   assert.match(applyStep, /No enabled close reasons remain after policy filtering/);
   assert.match(applyStep, /true\|1\|yes\|on\) product_direction_enabled=true/);
-  assert.match(
+  assert.match(applyStep, /if \[ "\$result_count" -ge "\$close_processed_limit" \]; then/);
+  assert.doesNotMatch(
     applyStep,
     /if \[ "\$result_count" -ge "\$close_processed_limit" \] && \[ "\$closed_in_chunk" -gt 0 \]/,
   );
   assert.match(applyStep, /sync_comments_only" != "true" .*apply_close_reasons/);
   assert.match(applyStep, /continue_apply=true/);
   assert.match(applyStep, /break\n\s+done/);
+  assert.match(applyStep, /next_apply_item_numbers="\$item_numbers"/);
+  assert.match(applyStep, /next_apply_item_numbers=""/);
   assert.match(applyStep, /echo "APPLY_CONTINUE=\$continue_apply"/);
+  assert.match(applyStep, /echo "APPLY_AUTO_SELECTED_BATCH=\$auto_selected_apply_batch"/);
   assert.match(continueStep, /APPLY_CONTINUE:-false/);
+  assert.match(continueStep, /-f apply_item_numbers="\$APPLY_ITEM_NUMBERS"/);
   assert.doesNotMatch(continueStep, /APPLY_CLOSED_TOTAL:-0.*APPLY_LIMIT:-0/);
 });
 


### PR DESCRIPTION
## What Problem This Solves

Scheduled `apply-existing` can spend its processed-record budget on the same front of the proposed-close queue when many candidates are skipped, policy-blocked, or otherwise unchanged. That can make later stale OpenClaw issues/PRs wait indefinitely even though the workflow is running.

This PR makes automatic apply runs rotate through a bounded cursor window instead of always scanning the same candidates first.

## Why This Change Was Made

- Auto-select proposed apply candidates with a 300-record window keyed by `apply_checked_at` and item number.
- Persist `results/apply-cursors/<target>.json` after automatic apply checkpoints.
- Stamp `apply_checked_at` on processed apply outcomes, including comment sync, label sync, policy skips, and closed records.
- Clear auto-selected item numbers before continuation dispatches so the next run reselects from the persisted cursor.
- Initialize apply-selection flags inside the apply shell step that uses them, avoiding `set -u` unbound variables.
- Persist cursor progress even if an auto-selected window produces an empty report, using the selected item list as the cursor fallback.
- Avoid immediate zero-close auto-continuation churn; the next scheduled apply run advances the next cursor window.
- Exclude proposed records without `item_snapshot_hash` from apply preselection, because `apply-decisions` ignores them before producing report entries.

## User Impact

ClawSweeper should move through stale apply candidates more predictably instead of repeatedly spending the same apply budget on a skip-heavy prefix. This does not run the #371 manual back-sweep; that remains an explicit maintainer-triggered apply run.

## Evidence

### Open PR overlap check

Checked the current open `openclaw/clawsweeper` PRs on 2026-06-27: #374, #370, #369, #358, #350, #342, and #341. The nearest overlaps are #350 (worker budget/caps), #341 (repair checkpoint contract), and #358 (decision packets), but none implement apply queue rotation, `apply_checked_at` coverage, or apply cursor persistence.

### ClawSweeper feedback addressed

- P1 unbound workflow variables: moved `explicit_item_numbers` and `auto_selected_apply_batch` initialization into the apply step that uses them.
- P2 zero-close continuation churn: automatic full windows with zero fresh closes now persist the cursor and wait for the next scheduled apply run instead of self-dispatching immediately.
- P2 empty-report cursor stall: `write-apply-cursor` now accepts `--item-numbers` and falls back to the selected window when the apply report is empty.
- P2 zero-result preselection: proposed records without `item_snapshot_hash` are not selected for apply windows.

### Tests and checks

- `pnpm run build:all`
- `node --test test/repair/workflow-utils.test.ts`
- `node --test --test-name-pattern "(apply workflow bounds checkpoints and requeues with a fresh token|apply-decisions counts advisory label-only syncs against the processed limit|apply-decisions syncs labels when first review placeholder advanced issue updated_at)" test/sweep-workflow.test.ts test/clawsweeper.test.ts`
- `pnpm exec oxfmt --check .github/workflows/sweep.yml src/clawsweeper.ts src/repair/workflow-utils.ts test/clawsweeper.test.ts test/repair/workflow-utils.test.ts test/sweep-workflow.test.ts`
- `pnpm run lint:repair`
- `pnpm run lint:src`
- `pnpm run lint:scripts`
- `pnpm run codex:local:check`
- `codex review -c 'service_tier="fast"' --base origin/main` -> no actionable correctness issues identified.
- `pnpm run review -- --local-only --target-repo openclaw/clawsweeper --item-number 375 --target-dir C:\oc-work\clawsweeper-apply-queue-rotation --artifact-dir artifacts/local-review-375 --codex-model gpt-5.5 --codex-reasoning-effort high --codex-timeout-ms 600000` -> patch correct, no review findings; remaining local review rank-up was PR-body proof, provided below.

Known local limitation: full `node --test test/sweep-workflow.test.ts` still has an existing Windows checkout file-mode assertion failure in `read-only checkout mode restores file modes and leaves git metadata writable` (`292 !== 365`). The apply workflow assertions in that file pass.

### Temp-state apply proof

This proof used a temp record tree and the built CLI, not live GitHub mutation. It exercised cursor-based preselection, real `apply-decisions` processing with `--processed-limit 300`, cursor persistence, next-window selection, and the empty-report cursor fallback.

```text
proof_root=C:\Users\marti\AppData\Local\Temp\clawsweeper-apply-cursor-proof-HxgqH9
initial_batch_count=300
initial_batch_first=1
initial_batch_last=300
apply_report_count=300
apply_report_first=1:kept_open
apply_report_last=300:kept_open
apply_checked_at_count=300
cursor_write=processed_count=300; selected_count=300; next_cursor_number=300; next_cursor_apply_checked_at=2026-06-27T14:03:06.038Z
cursor_next_after_number=300
cursor_processed_count=300
cursor_selected_count=300
next_batch_count=300
next_batch_first=301
next_batch_last=600
apply_exit_code=0
apply_stderr_tail=[apply] 2026-06-27T14:03:06.039Z finished apply closed=0/5 processed=300/300 counts={"kept_open":300}
empty_proof_root=C:\Users\marti\AppData\Local\Temp\clawsweeper-empty-cursor-proof-azvvio
empty_cursor_write=processed_count=0; selected_count=3; next_cursor_number=3; next_cursor_apply_checked_at=
empty_cursor_next_after_number=3
empty_cursor_processed_count=0
empty_cursor_selected_count=3
empty_next_batch=4,5,1
```