### PR TITLE
fix: rotate proof nudge scans

### DIFF
--- a/.github/workflows/proof-nudges.yml
+++ b/.github/workflows/proof-nudges.yml
@@ -173,8 +173,9 @@ jobs:
             "${item_numbers_arg[@]}" \
             "${cursor_arg[@]}" \
             "${execute_arg[@]}"
-          if [ "$PROOF_NUDGES_EXECUTE" = "true" ] && [ -d results/proof-nudge-cursors ]; then
-            cursor_publish_args+=(--path results/proof-nudge-cursors)
+          proof_cursor_path="results/proof-nudge-cursors/${target_slug}.json"
+          if [ "$PROOF_NUDGES_EXECUTE" = "true" ] && [ -f "$proof_cursor_path" ]; then
+            cursor_publish_args+=(--path "$proof_cursor_path")
           fi
 
           if [ "$BOT_PROOF_ENABLED" = "true" ]; then
@@ -190,8 +191,9 @@ jobs:
               "${item_numbers_arg[@]}" \
               "${bot_cursor_arg[@]}" \
               "${bot_proof_execute_arg[@]}"
-            if [ "$BOT_PROOF_EXECUTE" = "true" ] && [ -d results/bot-proof-cursors ]; then
-              cursor_publish_args+=(--path results/bot-proof-cursors)
+            bot_cursor_path="results/bot-proof-cursors/${target_slug}.json"
+            if [ "$BOT_PROOF_EXECUTE" = "true" ] && [ -f "$bot_cursor_path" ]; then
+              cursor_publish_args+=(--path "$bot_cursor_path")
             fi
           fi
           if [ ${#cursor_publish_args[@]} -gt 0 ]; then

--- a/.github/workflows/proof-nudges.yml
+++ b/.github/workflows/proof-nudges.yml
@@ -162,7 +162,6 @@ jobs:
           else
             cursor_arg=(--cursor-path "results/proof-nudge-cursors/${target_slug}.json")
             bot_cursor_arg=(--cursor-path "results/bot-proof-cursors/${target_slug}.json")
-            cursor_publish_args=(--path results/proof-nudge-cursors)
           fi
           pnpm run proof-nudges -- \
             --target-repo "$TARGET_REPO" \
@@ -174,14 +173,14 @@ jobs:
             "${item_numbers_arg[@]}" \
             "${cursor_arg[@]}" \
             "${execute_arg[@]}"
+          if [ "$PROOF_NUDGES_EXECUTE" = "true" ] && [ -d results/proof-nudge-cursors ]; then
+            cursor_publish_args+=(--path results/proof-nudge-cursors)
+          fi
 
           if [ "$BOT_PROOF_ENABLED" = "true" ]; then
             bot_proof_execute_arg=()
             if [ "$BOT_PROOF_EXECUTE" = "true" ]; then
               bot_proof_execute_arg=(--execute)
-            fi
-            if [ ${#bot_cursor_arg[@]} -gt 0 ]; then
-              cursor_publish_args+=(--path results/bot-proof-cursors)
             fi
             pnpm run bot-proof -- \
               --target-repo "$TARGET_REPO" \
@@ -191,6 +190,9 @@ jobs:
               "${item_numbers_arg[@]}" \
               "${bot_cursor_arg[@]}" \
               "${bot_proof_execute_arg[@]}"
+            if [ "$BOT_PROOF_EXECUTE" = "true" ] && [ -d results/bot-proof-cursors ]; then
+              cursor_publish_args+=(--path results/bot-proof-cursors)
+            fi
           fi
           if [ ${#cursor_publish_args[@]} -gt 0 ]; then
             pnpm run repair:publish-main -- \

--- a/.github/workflows/proof-nudges.yml
+++ b/.github/workflows/proof-nudges.yml
@@ -17,6 +17,10 @@ on:
         description: "Maximum proof nudges to plan or post"
         required: false
         default: "10"
+      processed_limit:
+        description: "Maximum candidate records to inspect before advancing the cursor"
+        required: false
+        default: ""
       min_age_days:
         description: "Minimum age in days since review/author activity before first proof nudge"
         required: false
@@ -117,6 +121,7 @@ jobs:
           PROOF_NUDGES_EXECUTE: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.execute == 'true') || (github.event_name == 'schedule' && vars.CLAWSWEEPER_PROOF_NUDGES_EXECUTE == '1') }}
           PROOF_NUDGES_ITEM_NUMBERS: ${{ github.event.inputs.item_numbers || '' }}
           PROOF_NUDGES_LIMIT: ${{ github.event.inputs.limit || vars.CLAWSWEEPER_PROOF_NUDGES_LIMIT || '10' }}
+          PROOF_NUDGES_PROCESSED_LIMIT: ${{ github.event.inputs.processed_limit || vars.CLAWSWEEPER_PROOF_NUDGES_PROCESSED_LIMIT || '' }}
           PROOF_NUDGES_MIN_AGE_DAYS: ${{ github.event.inputs.min_age_days || vars.CLAWSWEEPER_PROOF_NUDGES_MIN_AGE_DAYS || '5' }}
           PROOF_NUDGES_COOLDOWN_DAYS: ${{ github.event.inputs.cooldown_days || vars.CLAWSWEEPER_PROOF_NUDGES_COOLDOWN_DAYS || '7' }}
           BOT_PROOF_ENABLED: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.bot_proof == 'true') || (github.event_name == 'schedule' && vars.CLAWSWEEPER_BOT_PROOF_SCHEDULED == '1') }}
@@ -129,18 +134,35 @@ jobs:
               exit 1
             fi
           done
+          if [ -n "$PROOF_NUDGES_PROCESSED_LIMIT" ] && [[ ! "$PROOF_NUDGES_PROCESSED_LIMIT" =~ ^[0-9]+$ ]]; then
+            echo "::error::PROOF_NUDGES_PROCESSED_LIMIT must be a non-negative integer"
+            exit 1
+          fi
 
           execute_arg=()
           if [ "$PROOF_NUDGES_EXECUTE" = "true" ]; then
             execute_arg=(--execute)
           fi
+          processed_limit_arg=()
+          if [ -n "$PROOF_NUDGES_PROCESSED_LIMIT" ]; then
+            processed_limit_arg=(--processed-limit "$PROOF_NUDGES_PROCESSED_LIMIT")
+          fi
           item_numbers_arg=()
+          cursor_arg=()
+          bot_cursor_arg=()
+          cursor_publish_args=()
+          target_slug="$TARGET_REPO"
+          target_slug="${target_slug//\//-}"
           if [ -n "$PROOF_NUDGES_ITEM_NUMBERS" ]; then
             if [[ ! "$PROOF_NUDGES_ITEM_NUMBERS" =~ ^[0-9]+([[:space:]]*,[[:space:]]*[0-9]+)*$ ]]; then
               echo "::error::item_numbers must be a comma-separated list of pull request numbers"
               exit 1
             fi
             item_numbers_arg=(--item-numbers "$PROOF_NUDGES_ITEM_NUMBERS")
+          else
+            cursor_arg=(--cursor-path "results/proof-nudge-cursors/${target_slug}.json")
+            bot_cursor_arg=(--cursor-path "results/bot-proof-cursors/${target_slug}.json")
+            cursor_publish_args=(--path results/proof-nudge-cursors)
           fi
           pnpm run proof-nudges -- \
             --target-repo "$TARGET_REPO" \
@@ -148,7 +170,9 @@ jobs:
             --min-age-days "$PROOF_NUDGES_MIN_AGE_DAYS" \
             --cooldown-days "$PROOF_NUDGES_COOLDOWN_DAYS" \
             --report-path proof-nudge-report.json \
+            "${processed_limit_arg[@]}" \
             "${item_numbers_arg[@]}" \
+            "${cursor_arg[@]}" \
             "${execute_arg[@]}"
 
           if [ "$BOT_PROOF_ENABLED" = "true" ]; then
@@ -156,12 +180,23 @@ jobs:
             if [ "$BOT_PROOF_EXECUTE" = "true" ]; then
               bot_proof_execute_arg=(--execute)
             fi
+            if [ ${#bot_cursor_arg[@]} -gt 0 ]; then
+              cursor_publish_args+=(--path results/bot-proof-cursors)
+            fi
             pnpm run bot-proof -- \
               --target-repo "$TARGET_REPO" \
               --limit "$PROOF_NUDGES_LIMIT" \
               --report-path bot-proof-report.json \
+              "${processed_limit_arg[@]}" \
               "${item_numbers_arg[@]}" \
+              "${bot_cursor_arg[@]}" \
               "${bot_proof_execute_arg[@]}"
+          fi
+          if [ ${#cursor_publish_args[@]} -gt 0 ]; then
+            pnpm run repair:publish-main -- \
+              --message "chore: update proof handling cursors" \
+              --rebase-strategy theirs \
+              "${cursor_publish_args[@]}"
           fi
 
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/proof-nudges.yml
+++ b/.github/workflows/proof-nudges.yml
@@ -18,7 +18,7 @@ on:
         required: false
         default: "10"
       processed_limit:
-        description: "Maximum candidate records to inspect before advancing the cursor"
+        description: "Maximum candidate records to inspect before advancing the cursor (minimum 1)"
         required: false
         default: ""
       min_age_days:
@@ -134,8 +134,8 @@ jobs:
               exit 1
             fi
           done
-          if [ -n "$PROOF_NUDGES_PROCESSED_LIMIT" ] && [[ ! "$PROOF_NUDGES_PROCESSED_LIMIT" =~ ^[0-9]+$ ]]; then
-            echo "::error::PROOF_NUDGES_PROCESSED_LIMIT must be a non-negative integer"
+          if [ -n "$PROOF_NUDGES_PROCESSED_LIMIT" ] && [[ ! "$PROOF_NUDGES_PROCESSED_LIMIT" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::PROOF_NUDGES_PROCESSED_LIMIT must be a positive integer"
             exit 1
           fi
 

--- a/docs/proof-nudges.md
+++ b/docs/proof-nudges.md
@@ -74,6 +74,7 @@ Useful options:
 
 - `--limit`: maximum nudges to plan or post, default `10`.
 - `--processed-limit`: maximum records to inspect in one run.
+- `--cursor-path`: optional JSON cursor path used to rotate untargeted candidate scans after execute runs.
 - `--min-age-days`: first-nudge age gate, default `5`.
 - `--cooldown-days`: same-head cooldown, default `7`.
 - `--item-numbers`: comma-separated pull request numbers for a targeted dry-run or execute run.
@@ -92,10 +93,18 @@ Scheduled operation uses repository variables:
 - `CLAWSWEEPER_PROOF_NUDGES_EXECUTE=1`: allow the scheduled lane to post comments. Without this, scheduled runs remain dry-run only.
 - `CLAWSWEEPER_PROOF_NUDGES_TARGET_REPO`: optional target repo, default `openclaw/openclaw`.
 - `CLAWSWEEPER_PROOF_NUDGES_LIMIT`: optional scheduled batch size, default `10`.
+- `CLAWSWEEPER_PROOF_NUDGES_PROCESSED_LIMIT`: optional scheduled scan size before the cursor advances; the CLI default is `max(limit * 20, 50)`.
 - `CLAWSWEEPER_PROOF_NUDGES_MIN_AGE_DAYS`: optional first-nudge age gate, default `5`.
 - `CLAWSWEEPER_PROOF_NUDGES_COOLDOWN_DAYS`: optional same-head cooldown, default `7`.
 - `CLAWSWEEPER_BOT_PROOF_SCHEDULED=1`: include the bot-owned proof lane in scheduled runs.
 - `CLAWSWEEPER_BOT_PROOF_EXECUTE=1`: allow scheduled bot-owned proof runs to post status comments and labels. Without this, scheduled bot-proof runs remain dry-run only.
+
+Untargeted scheduled runs rotate through durable cursor files under
+`results/proof-nudge-cursors/` and `results/bot-proof-cursors/`. A skip-heavy
+run that spends its processed-record budget advances the cursor to the last
+processed candidate, so later runs inspect the next bounded window instead of
+repeating the same prefix. Targeted `--item-numbers` runs do not use or update
+those cursors.
 
 Suggested rollout:
 

--- a/docs/proof-nudges.md
+++ b/docs/proof-nudges.md
@@ -106,6 +106,11 @@ processed candidate, so later runs inspect the next bounded window instead of
 repeating the same prefix. Targeted `--item-numbers` runs do not use or update
 those cursors.
 
+The workflow publishes only the exact target cursor files, for example
+`results/proof-nudge-cursors/openclaw-openclaw.json`, and only after the
+corresponding lane executed and wrote that file. Dry-runs do not publish cursor
+paths, and one target repo run does not replace another target's cursor file.
+
 Suggested rollout:
 
 1. Run the proof-nudge workflow manually with `execute=false`.

--- a/docs/proof-nudges.md
+++ b/docs/proof-nudges.md
@@ -73,7 +73,7 @@ pnpm run proof-nudges -- --target-repo openclaw/openclaw --execute --limit 10
 Useful options:
 
 - `--limit`: maximum nudges to plan or post, default `10`.
-- `--processed-limit`: maximum records to inspect in one run.
+- `--processed-limit`: maximum records to inspect in one run, minimum `1`.
 - `--cursor-path`: optional JSON cursor path used to rotate untargeted candidate scans after execute runs.
 - `--min-age-days`: first-nudge age gate, default `5`.
 - `--cooldown-days`: same-head cooldown, default `7`.
@@ -93,7 +93,7 @@ Scheduled operation uses repository variables:
 - `CLAWSWEEPER_PROOF_NUDGES_EXECUTE=1`: allow the scheduled lane to post comments. Without this, scheduled runs remain dry-run only.
 - `CLAWSWEEPER_PROOF_NUDGES_TARGET_REPO`: optional target repo, default `openclaw/openclaw`.
 - `CLAWSWEEPER_PROOF_NUDGES_LIMIT`: optional scheduled batch size, default `10`.
-- `CLAWSWEEPER_PROOF_NUDGES_PROCESSED_LIMIT`: optional scheduled scan size before the cursor advances; the CLI default is `max(limit * 20, 50)`.
+- `CLAWSWEEPER_PROOF_NUDGES_PROCESSED_LIMIT`: optional positive scheduled scan size before the cursor advances; the CLI default is `max(limit * 20, 50)`.
 - `CLAWSWEEPER_PROOF_NUDGES_MIN_AGE_DAYS`: optional first-nudge age gate, default `5`.
 - `CLAWSWEEPER_PROOF_NUDGES_COOLDOWN_DAYS`: optional same-head cooldown, default `7`.
 - `CLAWSWEEPER_BOT_PROOF_SCHEDULED=1`: include the bot-owned proof lane in scheduled runs.

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -895,6 +895,12 @@ interface ProofLaneCandidate {
   sortAt: number;
 }
 
+interface ProofLaneCursor {
+  likely: boolean;
+  number: number;
+  sortAt: number;
+}
+
 interface ProofNudgeComment {
   author?: string | undefined;
   body?: string | undefined;
@@ -18392,12 +18398,80 @@ function proofLaneCandidateRecords(
       if (frontMatterValue(markdown, "type") !== "pull_request") return false;
       return true;
     })
-    .sort(
-      (left, right) =>
-        Number(right.likely) - Number(left.likely) ||
-        left.sortAt - right.sortAt ||
-        left.number - right.number,
+    .sort((left, right) => compareProofLaneSortKey(left, right));
+}
+
+function proofLaneSortAt(value: number): number {
+  return Number.isFinite(value) ? value : Number.NEGATIVE_INFINITY;
+}
+
+function compareProofLaneSortKey(
+  left: Pick<ProofLaneCursor, "likely" | "number" | "sortAt">,
+  right: Pick<ProofLaneCursor, "likely" | "number" | "sortAt">,
+): number {
+  if (left.likely !== right.likely) return left.likely ? -1 : 1;
+  return proofLaneSortAt(left.sortAt) - proofLaneSortAt(right.sortAt) || left.number - right.number;
+}
+
+function rotateProofLaneCandidates<T extends ProofLaneCandidate>(
+  candidates: readonly T[],
+  cursor: ProofLaneCursor | null,
+): T[] {
+  if (!cursor) return [...candidates];
+  return [
+    ...candidates.filter((candidate) => compareProofLaneSortKey(candidate, cursor) > 0),
+    ...candidates.filter((candidate) => compareProofLaneSortKey(candidate, cursor) <= 0),
+  ];
+}
+
+function proofLaneCursorPath(args: Args, requestedItemNumbers: readonly number[]): string | null {
+  if (requestedItemNumbers.length > 0) return null;
+  const rawPath = stringArg(args.cursor_path, "").trim();
+  return rawPath ? resolve(rawPath) : null;
+}
+
+function readProofLaneCursor(path: string): ProofLaneCursor | null {
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = asRecord(JSON.parse(readFileSync(path, "utf8")));
+    const number = Number(parsed.next_cursor_number);
+    if (!Number.isInteger(number) || number <= 0) return null;
+    return {
+      likely: parsed.next_cursor_likely === true,
+      number,
+      sortAt:
+        typeof parsed.next_cursor_sort_at_ms === "number" &&
+        Number.isFinite(parsed.next_cursor_sort_at_ms)
+          ? parsed.next_cursor_sort_at_ms
+          : Number.NEGATIVE_INFINITY,
+    };
+  } catch (error) {
+    console.warn(
+      `Ignoring invalid proof lane cursor ${path}: ${error instanceof Error ? error.message : String(error)}`,
     );
+    return null;
+  }
+}
+
+function writeProofLaneCursor(path: string, lane: string, candidate: ProofLaneCandidate): void {
+  ensureDir(dirname(path));
+  writeFileSync(
+    path,
+    `${JSON.stringify(
+      {
+        repository: targetRepo(),
+        lane,
+        next_cursor_number: candidate.number,
+        next_cursor_likely: candidate.likely,
+        next_cursor_sort_at_ms: Number.isFinite(candidate.sortAt) ? candidate.sortAt : null,
+        reviewed_at: candidate.reviewedAt ?? null,
+        updated_at: new Date().toISOString(),
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
 }
 
 function proofNudgeCandidateRecords(
@@ -18443,6 +18517,13 @@ export function proofNudgeCandidateRecordsForTest(
   return proofNudgeCandidateRecords(itemsDir, requestedItemNumbers);
 }
 
+export function rotateProofLaneCandidatesForTest<T extends ProofLaneCandidate>(
+  candidates: readonly T[],
+  cursor: ProofLaneCursor | null,
+): T[] {
+  return rotateProofLaneCandidates(candidates, cursor);
+}
+
 export function botProofCandidateRecordsForTest(
   itemsDir: string,
   requestedItemNumbers: readonly number[] = [],
@@ -18465,6 +18546,7 @@ function proofNudgesCommand(args: Args): void {
   const maxRuntimeMs = numberArg(args.max_runtime_ms, 0);
   const reportPath = resolve(stringArg(args.report_path, join(ROOT, "proof-nudge-report.json")));
   const requestedItemNumbers = itemNumbersArg(args.item_numbers, args.item_number);
+  const cursorPath = proofLaneCursorPath(args, requestedItemNumbers);
 
   if (!existsSync(itemsDir)) {
     const results: ProofNudgeResult[] = [];
@@ -18474,11 +18556,18 @@ function proofNudgesCommand(args: Args): void {
     return;
   }
 
-  const candidates = proofNudgeCandidateRecords(itemsDir, requestedItemNumbers);
+  const allCandidates = proofNudgeCandidateRecords(itemsDir, requestedItemNumbers);
+  const cursor = cursorPath ? readProofLaneCursor(cursorPath) : null;
+  const candidates = rotateProofLaneCandidates(allCandidates, cursor);
   const startedAtMs = Date.now();
   const results: ProofNudgeResult[] = [];
   let processedCount = 0;
   let nudgeCount = 0;
+  let lastProcessedCandidate: ProofLaneCandidate | null = null;
+  const markProcessed = (candidate: ProofLaneCandidate): void => {
+    processedCount += 1;
+    lastProcessedCandidate = candidate;
+  };
   const logProgress = (message: string): void => {
     const counts = results.reduce<Record<string, number>>((accumulator, result) => {
       accumulator[result.action] = (accumulator[result.action] ?? 0) + 1;
@@ -18496,7 +18585,7 @@ function proofNudgesCommand(args: Args): void {
   };
 
   logProgress(
-    `starting proof nudges: candidates=${candidates.length} min_age_days=${minAgeDays} cooldown_days=${cooldownDays} item_numbers=${requestedItemNumbers.join(",") || "all"}`,
+    `starting proof nudges: candidates=${allCandidates.length} min_age_days=${minAgeDays} cooldown_days=${cooldownDays} item_numbers=${requestedItemNumbers.join(",") || "all"} cursor_path=${cursorPath ?? "none"}`,
   );
   for (const candidate of candidates) {
     if (nudgeCount >= limit) break;
@@ -18529,7 +18618,7 @@ function proofNudgesCommand(args: Args): void {
         action: "skipped_live_fetch_failed",
         reason: proofNudgeLiveFetchFailureReason(error),
       });
-      processedCount += 1;
+      markProcessed(candidate);
       continue;
     }
     if (state !== "open") {
@@ -18538,7 +18627,7 @@ function proofNudgesCommand(args: Args): void {
         action: "skipped_not_open",
         reason: `state is ${state}`,
       });
-      processedCount += 1;
+      markProcessed(candidate);
       continue;
     }
     let pullDetails: Partial<ProofNudgePullRequestDetails> = {};
@@ -18563,7 +18652,7 @@ function proofNudgesCommand(args: Args): void {
         action: "skipped_live_fetch_failed",
         reason: proofNudgeLiveFetchFailureReason(error),
       });
-      processedCount += 1;
+      markProcessed(candidate);
       continue;
     }
     const eligibility = proofNudgeEligibility({
@@ -18584,7 +18673,7 @@ function proofNudgesCommand(args: Args): void {
         reason: eligibility.reason,
         headSha: pullDetails.headSha,
       });
-      processedCount += 1;
+      markProcessed(candidate);
       continue;
     }
 
@@ -18596,7 +18685,7 @@ function proofNudgesCommand(args: Args): void {
         action: "skipped_no_live_head",
         reason: "live PR head SHA could not be inspected",
       });
-      processedCount += 1;
+      markProcessed(candidate);
       continue;
     }
     const body = renderProofNudgeComment({ item, headSha, timestamp });
@@ -18617,9 +18706,12 @@ function proofNudgesCommand(args: Args): void {
         headSha,
       });
     }
-    processedCount += 1;
+    markProcessed(candidate);
     nudgeCount += 1;
     logProgress(`${dryRun ? "planned" : "posted"} proof nudge #${candidate.number}`);
+  }
+  if (!dryRun && cursorPath && lastProcessedCandidate) {
+    writeProofLaneCursor(cursorPath, "proof_nudges", lastProcessedCandidate);
   }
   ensureDir(dirname(reportPath));
   writeFileSync(reportPath, JSON.stringify(results, null, 2), "utf8");
@@ -18637,6 +18729,7 @@ function botProofCommand(args: Args): void {
   const maxRuntimeMs = numberArg(args.max_runtime_ms, 0);
   const reportPath = resolve(stringArg(args.report_path, join(ROOT, "bot-proof-report.json")));
   const requestedItemNumbers = itemNumbersArg(args.item_numbers, args.item_number);
+  const cursorPath = proofLaneCursorPath(args, requestedItemNumbers);
 
   if (!existsSync(itemsDir)) {
     const results: BotProofResult[] = [];
@@ -18646,11 +18739,18 @@ function botProofCommand(args: Args): void {
     return;
   }
 
-  const candidates = botProofCandidateRecords(itemsDir, requestedItemNumbers);
+  const allCandidates = botProofCandidateRecords(itemsDir, requestedItemNumbers);
+  const cursor = cursorPath ? readProofLaneCursor(cursorPath) : null;
+  const candidates = rotateProofLaneCandidates(allCandidates, cursor);
   const startedAtMs = Date.now();
   const results: BotProofResult[] = [];
   let processedCount = 0;
   let actionCount = 0;
+  let lastProcessedCandidate: ProofLaneCandidate | null = null;
+  const markProcessed = (candidate: ProofLaneCandidate): void => {
+    processedCount += 1;
+    lastProcessedCandidate = candidate;
+  };
   const logProgress = (message: string): void => {
     const counts = results.reduce<Record<string, number>>((accumulator, result) => {
       accumulator[result.action] = (accumulator[result.action] ?? 0) + 1;
@@ -18668,7 +18768,7 @@ function botProofCommand(args: Args): void {
   };
 
   logProgress(
-    `starting bot proof handling: candidates=${candidates.length} item_numbers=${requestedItemNumbers.join(",") || "all"}`,
+    `starting bot proof handling: candidates=${allCandidates.length} item_numbers=${requestedItemNumbers.join(",") || "all"} cursor_path=${cursorPath ?? "none"}`,
   );
   for (const candidate of candidates) {
     if (actionCount >= limit) break;
@@ -18704,7 +18804,7 @@ function botProofCommand(args: Args): void {
         action: "skipped_live_fetch_failed",
         reason: proofNudgeLiveFetchFailureReason(error),
       });
-      processedCount += 1;
+      markProcessed(candidate);
       continue;
     }
     if (state !== "open") {
@@ -18713,7 +18813,7 @@ function botProofCommand(args: Args): void {
         action: "skipped_not_open",
         reason: `state is ${state}`,
       });
-      processedCount += 1;
+      markProcessed(candidate);
       continue;
     }
     const eligibility = botProofEligibility({
@@ -18729,7 +18829,7 @@ function botProofCommand(args: Args): void {
         reason: eligibility.reason,
         headSha: pullDetails.headSha,
       });
-      processedCount += 1;
+      markProcessed(candidate);
       continue;
     }
     const headSha = pullDetails.headSha;
@@ -18739,7 +18839,7 @@ function botProofCommand(args: Args): void {
         action: "skipped_no_live_head",
         reason: "live PR head SHA could not be inspected",
       });
-      processedCount += 1;
+      markProcessed(candidate);
       continue;
     }
     const commentBody = renderBotProofDecisionComment({
@@ -18774,9 +18874,12 @@ function botProofCommand(args: Args): void {
         headSha,
       });
     }
-    processedCount += 1;
+    markProcessed(candidate);
     actionCount += 1;
     logProgress(`${dryRun ? "planned" : "posted"} bot proof handling #${candidate.number}`);
+  }
+  if (!dryRun && cursorPath && lastProcessedCandidate) {
+    writeProofLaneCursor(cursorPath, "bot_proof", lastProcessedCandidate);
   }
   ensureDir(dirname(reportPath));
   writeFileSync(reportPath, JSON.stringify(results, null, 2), "utf8");

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -18430,6 +18430,14 @@ function proofLaneCursorPath(args: Args, requestedItemNumbers: readonly number[]
   return rawPath ? resolve(rawPath) : null;
 }
 
+function proofLaneProcessedLimit(args: Args, fallback: number): number {
+  const value = numberArg(args.processed_limit, fallback);
+  if (!Number.isInteger(value) || value < 1) {
+    throw new UserFacingCommandError("--processed-limit must be a positive integer");
+  }
+  return value;
+}
+
 function readProofLaneCursor(path: string): ProofLaneCursor | null {
   if (!existsSync(path)) return null;
   try {
@@ -18477,18 +18485,18 @@ function writeProofLaneCursor(path: string, lane: string, candidate: ProofLaneCa
 function proofNudgeCandidateRecords(
   itemsDir: string,
   requestedItemNumbers: readonly number[],
-): (ProofLaneCandidate & { likelyProofNudge: boolean })[] {
+): ProofLaneCandidate[] {
   return proofLaneCandidateRecords(
     itemsDir,
     requestedItemNumbers,
     realBehaviorProofNeedsContributorNudge,
-  ).map((candidate) => ({ ...candidate, likelyProofNudge: candidate.likely }));
+  );
 }
 
 function botProofCandidateRecords(
   itemsDir: string,
   requestedItemNumbers: readonly number[],
-): (ProofLaneCandidate & { likelyBotProof: boolean })[] {
+): ProofLaneCandidate[] {
   return proofLaneCandidateRecords(itemsDir, requestedItemNumbers, (markdown) => {
     return (
       frontMatterValue(markdown, "review_status") === "complete" &&
@@ -18496,7 +18504,7 @@ function botProofCandidateRecords(
       isClawSweeperAppAuthor(frontMatterValue(markdown, "author")) &&
       realBehaviorProofBlocksBotOwnedMerge(markdown)
     );
-  }).map((candidate) => ({ ...candidate, likelyBotProof: candidate.likely }));
+  });
 }
 
 function proofNudgeLiveFetchFailureReason(error: unknown): string {
@@ -18535,7 +18543,7 @@ function proofNudgesCommand(args: Args): void {
   repoFromArgs(args);
   const itemsDir = resolve(stringArg(args.items_dir, defaultItemsDir()));
   const limit = Math.max(0, numberArg(args.limit, DEFAULT_PROOF_NUDGE_LIMIT));
-  const processedLimit = Math.max(1, numberArg(args.processed_limit, Math.max(limit * 20, 50)));
+  const processedLimit = proofLaneProcessedLimit(args, Math.max(limit * 20, 50));
   const minAgeDays = Math.max(0, numberArg(args.min_age_days, DEFAULT_PROOF_NUDGE_MIN_AGE_DAYS));
   const cooldownDays = Math.max(
     0,
@@ -18723,7 +18731,7 @@ function botProofCommand(args: Args): void {
   repoFromArgs(args);
   const itemsDir = resolve(stringArg(args.items_dir, defaultItemsDir()));
   const limit = Math.max(0, numberArg(args.limit, DEFAULT_PROOF_NUDGE_LIMIT));
-  const processedLimit = Math.max(1, numberArg(args.processed_limit, Math.max(limit * 20, 50)));
+  const processedLimit = proofLaneProcessedLimit(args, Math.max(limit * 20, 50));
   const execute = boolArg(args.execute);
   const dryRun = !execute;
   const maxRuntimeMs = numberArg(args.max_runtime_ms, 0);

--- a/test/proof-nudge-policy.test.ts
+++ b/test/proof-nudge-policy.test.ts
@@ -11,6 +11,7 @@ import {
   proofNudgeEligibilityForTest,
   renderBotProofDecisionCommentForTest,
   renderProofNudgeCommentForTest,
+  rotateProofLaneCandidatesForTest,
 } from "../dist/clawsweeper.js";
 import { item, tmpPrefix, withMockGh } from "./helpers.ts";
 
@@ -280,6 +281,101 @@ Stored report label snapshots can be older than the live PR labels.
       allCandidates.map((candidate) => candidate.number),
       [41, 42],
     );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("proof nudge candidate rotation resumes after the cursor", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    writeFileSync(join(root, "41.md"), proofNudgeReport({ reviewedAt: "2026-01-01T00:00:00Z" }));
+    writeFileSync(join(root, "42.md"), proofNudgeReport({ reviewedAt: "2026-01-02T00:00:00Z" }));
+    writeFileSync(join(root, "43.md"), proofNudgeReport({ reviewedAt: "2026-01-03T00:00:00Z" }));
+
+    const candidates = proofNudgeCandidateRecordsForTest(root);
+    assert.deepEqual(
+      rotateProofLaneCandidatesForTest(candidates, {
+        likely: true,
+        number: 42,
+        sortAt: Date.parse("2026-01-02T00:00:00Z"),
+      }).map((candidate) => candidate.number),
+      [43, 41, 42],
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("proof nudge execute scans advance cursor to the last processed candidate", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const reportPath = join(root, "proof-nudge-report.json");
+    const cursorPath = join(root, "results", "proof-nudge-cursors", "openclaw-openclaw.json");
+    mkdirSync(itemsDir, { recursive: true });
+    writeFileSync(
+      join(itemsDir, "41.md"),
+      proofNudgeReport({ reviewedAt: "2026-01-01T00:00:00Z" }),
+    );
+    writeFileSync(
+      join(itemsDir, "42.md"),
+      proofNudgeReport({ reviewedAt: "2026-01-02T00:00:00Z" }),
+    );
+    withMockGh(
+      root,
+      `#!/usr/bin/env node
+const args = process.argv.slice(2);
+const path = args[1] || "";
+const match = path.match(/\\/issues\\/(41|42)$/);
+if (match) {
+  console.log(JSON.stringify({
+    number: Number(match[1]),
+    title: "Closed proof nudge sample",
+    html_url: "https://github.com/openclaw/openclaw/pull/" + match[1],
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-02T00:00:00Z",
+    closed_at: "2026-01-03T00:00:00Z",
+    state: "closed",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "contributor" },
+    labels: ["triage: needs-real-behavior-proof"],
+    pull_request: {}
+  }));
+  process.exit(0);
+}
+console.error("unexpected gh args: " + args.join(" "));
+process.exit(1);
+`,
+      () => {
+        execFileSync(process.execPath, [
+          "dist/clawsweeper.js",
+          "proof-nudges",
+          "--target-repo",
+          "openclaw/openclaw",
+          "--items-dir",
+          itemsDir,
+          "--limit",
+          "10",
+          "--processed-limit",
+          "2",
+          "--report-path",
+          reportPath,
+          "--cursor-path",
+          cursorPath,
+          "--execute",
+        ]);
+      },
+    );
+
+    const cursor = JSON.parse(readFileSync(cursorPath, "utf8"));
+    assert.equal(cursor.repository, "openclaw/openclaw");
+    assert.equal(cursor.lane, "proof_nudges");
+    assert.equal(cursor.next_cursor_number, 42);
+    assert.equal(cursor.next_cursor_likely, true);
+    assert.equal(cursor.reviewed_at, "2026-01-02T00:00:00Z");
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/proof-nudge-policy.test.ts
+++ b/test/proof-nudge-policy.test.ts
@@ -7,6 +7,7 @@ import test from "node:test";
 import {
   botProofCandidateRecordsForTest,
   botProofEligibilityForTest,
+  main,
   proofNudgeCandidateRecordsForTest,
   proofNudgeEligibilityForTest,
   renderBotProofDecisionCommentForTest,
@@ -343,101 +344,64 @@ test("proof nudge candidate rotation resumes after the cursor", () => {
   }
 });
 
-test("proof nudge execute scans advance cursor to the last processed candidate", () => {
+test("proof lane execute scans advance cursors to the last processed candidate", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const reportPath = join(root, "proof-nudge-report.json");
-    const cursorPath = join(root, "results", "proof-nudge-cursors", "openclaw-openclaw.json");
-    mkdirSync(itemsDir, { recursive: true });
-    writeFileSync(
-      join(itemsDir, "41.md"),
-      proofNudgeReport({ reviewedAt: "2026-01-01T00:00:00Z" }),
-    );
-    writeFileSync(
-      join(itemsDir, "42.md"),
-      proofNudgeReport({ reviewedAt: "2026-01-02T00:00:00Z" }),
-    );
-    withMockGh(root, closedProofLaneGhMockScript([41, 42]), () => {
-      execFileSync(process.execPath, [
-        "dist/clawsweeper.js",
-        "proof-nudges",
-        "--target-repo",
-        "openclaw/openclaw",
-        "--items-dir",
-        itemsDir,
-        "--limit",
-        "10",
-        "--processed-limit",
-        "2",
-        "--report-path",
-        reportPath,
-        "--cursor-path",
-        cursorPath,
-        "--execute",
-      ]);
+    const cases = [
+      { command: "proof-nudges", lane: "proof_nudges", numbers: [41, 42], bot: false },
+      { command: "bot-proof", lane: "bot_proof", numbers: [51, 52], bot: true },
+    ] as const;
+    withMockGh(root, closedProofLaneGhMockScript(cases.flatMap(({ numbers }) => numbers)), () => {
+      for (const { command, lane, numbers, bot } of cases) {
+        const itemsDir = join(root, command);
+        const cursorPath = join(root, "results", `${command}-cursors`, "openclaw-openclaw.json");
+        mkdirSync(itemsDir, { recursive: true });
+        numbers.forEach((number, index) =>
+          writeFileSync(
+            join(itemsDir, `${number}.md`),
+            proofNudgeReport({
+              author: bot ? "app/clawsweeper" : "contributor",
+              authorAssociation: bot ? "NONE" : "CONTRIBUTOR",
+              reviewedAt: `2026-01-0${index + 1}T00:00:00Z`,
+            }),
+          ),
+        );
+        execFileSync(process.execPath, [
+          "dist/clawsweeper.js",
+          command,
+          "--target-repo",
+          "openclaw/openclaw",
+          "--items-dir",
+          itemsDir,
+          "--processed-limit",
+          "2",
+          "--report-path",
+          join(root, `${command}.json`),
+          "--cursor-path",
+          cursorPath,
+          "--execute",
+        ]);
+        const cursor = JSON.parse(readFileSync(cursorPath, "utf8"));
+        assert.deepEqual(
+          {
+            repository: cursor.repository,
+            lane: cursor.lane,
+            number: cursor.next_cursor_number,
+            likely: cursor.next_cursor_likely,
+            sortAt: cursor.next_cursor_sort_at_ms,
+            reviewedAt: cursor.reviewed_at,
+          },
+          {
+            repository: "openclaw/openclaw",
+            lane,
+            number: numbers[1],
+            likely: true,
+            sortAt: Date.parse("2026-01-02T00:00:00Z"),
+            reviewedAt: "2026-01-02T00:00:00Z",
+          },
+        );
+      }
     });
-
-    const cursor = JSON.parse(readFileSync(cursorPath, "utf8"));
-    assert.equal(cursor.repository, "openclaw/openclaw");
-    assert.equal(cursor.lane, "proof_nudges");
-    assert.equal(cursor.next_cursor_number, 42);
-    assert.equal(cursor.next_cursor_likely, true);
-    assert.equal(cursor.reviewed_at, "2026-01-02T00:00:00Z");
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
-});
-
-test("bot proof execute scans advance cursor to the last processed candidate", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const reportPath = join(root, "bot-proof-report.json");
-    const cursorPath = join(root, "results", "bot-proof-cursors", "openclaw-openclaw.json");
-    mkdirSync(itemsDir, { recursive: true });
-    writeFileSync(
-      join(itemsDir, "51.md"),
-      proofNudgeReport({
-        author: "app/clawsweeper",
-        authorAssociation: "NONE",
-        reviewedAt: "2026-01-01T00:00:00Z",
-      }),
-    );
-    writeFileSync(
-      join(itemsDir, "52.md"),
-      proofNudgeReport({
-        author: "app/clawsweeper",
-        authorAssociation: "NONE",
-        reviewedAt: "2026-01-02T00:00:00Z",
-      }),
-    );
-    withMockGh(root, closedProofLaneGhMockScript([51, 52]), () => {
-      execFileSync(process.execPath, [
-        "dist/clawsweeper.js",
-        "bot-proof",
-        "--target-repo",
-        "openclaw/openclaw",
-        "--items-dir",
-        itemsDir,
-        "--limit",
-        "10",
-        "--processed-limit",
-        "2",
-        "--report-path",
-        reportPath,
-        "--cursor-path",
-        cursorPath,
-        "--execute",
-      ]);
-    });
-
-    const cursor = JSON.parse(readFileSync(cursorPath, "utf8"));
-    assert.equal(cursor.repository, "openclaw/openclaw");
-    assert.equal(cursor.lane, "bot_proof");
-    assert.equal(cursor.next_cursor_number, 52);
-    assert.equal(cursor.next_cursor_likely, true);
-    assert.equal(cursor.reviewed_at, "2026-01-02T00:00:00Z");
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -446,74 +410,46 @@ test("bot proof execute scans advance cursor to the last processed candidate", (
 test("targeted proof lane execute scans ignore cursor paths", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const proofItemsDir = join(root, "proof-items");
-    const botItemsDir = join(root, "bot-items");
-    const proofReportPath = join(root, "proof-nudge-report.json");
-    const botReportPath = join(root, "bot-proof-report.json");
-    const proofCursorPath = join(root, "results", "proof-nudge-cursors", "openclaw-openclaw.json");
-    const botCursorPath = join(root, "results", "bot-proof-cursors", "openclaw-openclaw.json");
-    mkdirSync(proofItemsDir, { recursive: true });
-    mkdirSync(botItemsDir, { recursive: true });
-    writeFileSync(join(proofItemsDir, "42.md"), proofNudgeReport());
-    writeFileSync(
-      join(botItemsDir, "52.md"),
-      proofNudgeReport({ author: "app/clawsweeper", authorAssociation: "NONE" }),
-    );
+    const cases = [
+      { command: "proof-nudges", number: 42, bot: false },
+      { command: "bot-proof", number: 52, bot: true },
+    ] as const;
     withMockGh(root, closedProofLaneGhMockScript([42, 52]), () => {
-      execFileSync(process.execPath, [
-        "dist/clawsweeper.js",
-        "proof-nudges",
-        "--target-repo",
-        "openclaw/openclaw",
-        "--items-dir",
-        proofItemsDir,
-        "--item-numbers",
-        "42",
-        "--limit",
-        "10",
-        "--processed-limit",
-        "10",
-        "--report-path",
-        proofReportPath,
-        "--cursor-path",
-        proofCursorPath,
-        "--execute",
-      ]);
-      execFileSync(process.execPath, [
-        "dist/clawsweeper.js",
-        "bot-proof",
-        "--target-repo",
-        "openclaw/openclaw",
-        "--items-dir",
-        botItemsDir,
-        "--item-numbers",
-        "52",
-        "--limit",
-        "10",
-        "--processed-limit",
-        "10",
-        "--report-path",
-        botReportPath,
-        "--cursor-path",
-        botCursorPath,
-        "--execute",
-      ]);
+      for (const { command, number, bot } of cases) {
+        const itemsDir = join(root, command);
+        const cursorPath = join(root, `${command}-cursor.json`);
+        mkdirSync(itemsDir, { recursive: true });
+        writeFileSync(
+          join(itemsDir, `${number}.md`),
+          proofNudgeReport({
+            author: bot ? "app/clawsweeper" : "contributor",
+            authorAssociation: bot ? "NONE" : "CONTRIBUTOR",
+          }),
+        );
+        execFileSync(process.execPath, [
+          "dist/clawsweeper.js",
+          command,
+          "--items-dir",
+          itemsDir,
+          "--item-numbers",
+          String(number),
+          "--report-path",
+          join(root, `${command}.json`),
+          "--cursor-path",
+          cursorPath,
+          "--execute",
+        ]);
+        assert.equal(existsSync(cursorPath), false);
+      }
     });
-
-    const proofReport = JSON.parse(readFileSync(proofReportPath, "utf8"));
-    const botReport = JSON.parse(readFileSync(botReportPath, "utf8"));
-    assert.deepEqual(
-      proofReport.map((entry: { number: number; action: string }) => [entry.number, entry.action]),
-      [[42, "skipped_not_open"]],
-    );
-    assert.deepEqual(
-      botReport.map((entry: { number: number; action: string }) => [entry.number, entry.action]),
-      [[52, "skipped_not_open"]],
-    );
-    assert.equal(existsSync(proofCursorPath), false);
-    assert.equal(existsSync(botCursorPath), false);
   } finally {
     rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("proof lanes reject non-positive processed limits", async () => {
+  for (const command of ["proof-nudges", "bot-proof"]) {
+    await assert.rejects(main([command, "--processed-limit", "0"]), /positive integer/);
   }
 });
 

--- a/test/proof-nudge-policy.test.ts
+++ b/test/proof-nudge-policy.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
 
@@ -93,6 +93,42 @@ function proofNudgeItem(overrides = {}) {
     activeLockReason: null,
     ...overrides,
   });
+}
+
+function closedProofLaneGhMockScript(numbers: readonly number[]): string {
+  return `#!/usr/bin/env node
+const handled = new Set(${JSON.stringify(numbers)});
+const args = process.argv.slice(2);
+const path = args[1] || "";
+const issueMatch = path.match(/\\/issues\\/(\\d+)$/);
+if (issueMatch && handled.has(Number(issueMatch[1]))) {
+  const number = Number(issueMatch[1]);
+  const bot = number >= 50;
+  console.log(JSON.stringify({
+    number,
+    title: bot ? "Closed bot proof sample" : "Closed proof nudge sample",
+    html_url: "https://github.com/openclaw/openclaw/pull/" + number,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-02T00:00:00Z",
+    closed_at: "2026-01-03T00:00:00Z",
+    state: "closed",
+    locked: false,
+    active_lock_reason: null,
+    author_association: bot ? "NONE" : "CONTRIBUTOR",
+    user: { login: bot ? "app/clawsweeper" : "contributor" },
+    labels: ["triage: needs-real-behavior-proof"],
+    pull_request: {}
+  }));
+  process.exit(0);
+}
+const pullMatch = path.match(/\\/pulls\\/(\\d+)$/);
+if (pullMatch && handled.has(Number(pullMatch[1]))) {
+  console.log(JSON.stringify({ draft: false, head: { sha: null, repo: { full_name: null } } }));
+  process.exit(0);
+}
+console.error("unexpected gh args: " + args.join(" "));
+process.exit(1);
+`;
 }
 
 test("bot proof candidate scan prioritizes ClawSweeper proof blockers", () => {
@@ -322,53 +358,25 @@ test("proof nudge execute scans advance cursor to the last processed candidate",
       join(itemsDir, "42.md"),
       proofNudgeReport({ reviewedAt: "2026-01-02T00:00:00Z" }),
     );
-    withMockGh(
-      root,
-      `#!/usr/bin/env node
-const args = process.argv.slice(2);
-const path = args[1] || "";
-const match = path.match(/\\/issues\\/(41|42)$/);
-if (match) {
-  console.log(JSON.stringify({
-    number: Number(match[1]),
-    title: "Closed proof nudge sample",
-    html_url: "https://github.com/openclaw/openclaw/pull/" + match[1],
-    created_at: "2026-01-01T00:00:00Z",
-    updated_at: "2026-01-02T00:00:00Z",
-    closed_at: "2026-01-03T00:00:00Z",
-    state: "closed",
-    locked: false,
-    active_lock_reason: null,
-    author_association: "CONTRIBUTOR",
-    user: { login: "contributor" },
-    labels: ["triage: needs-real-behavior-proof"],
-    pull_request: {}
-  }));
-  process.exit(0);
-}
-console.error("unexpected gh args: " + args.join(" "));
-process.exit(1);
-`,
-      () => {
-        execFileSync(process.execPath, [
-          "dist/clawsweeper.js",
-          "proof-nudges",
-          "--target-repo",
-          "openclaw/openclaw",
-          "--items-dir",
-          itemsDir,
-          "--limit",
-          "10",
-          "--processed-limit",
-          "2",
-          "--report-path",
-          reportPath,
-          "--cursor-path",
-          cursorPath,
-          "--execute",
-        ]);
-      },
-    );
+    withMockGh(root, closedProofLaneGhMockScript([41, 42]), () => {
+      execFileSync(process.execPath, [
+        "dist/clawsweeper.js",
+        "proof-nudges",
+        "--target-repo",
+        "openclaw/openclaw",
+        "--items-dir",
+        itemsDir,
+        "--limit",
+        "10",
+        "--processed-limit",
+        "2",
+        "--report-path",
+        reportPath,
+        "--cursor-path",
+        cursorPath,
+        "--execute",
+      ]);
+    });
 
     const cursor = JSON.parse(readFileSync(cursorPath, "utf8"));
     assert.equal(cursor.repository, "openclaw/openclaw");
@@ -376,6 +384,134 @@ process.exit(1);
     assert.equal(cursor.next_cursor_number, 42);
     assert.equal(cursor.next_cursor_likely, true);
     assert.equal(cursor.reviewed_at, "2026-01-02T00:00:00Z");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("bot proof execute scans advance cursor to the last processed candidate", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const reportPath = join(root, "bot-proof-report.json");
+    const cursorPath = join(root, "results", "bot-proof-cursors", "openclaw-openclaw.json");
+    mkdirSync(itemsDir, { recursive: true });
+    writeFileSync(
+      join(itemsDir, "51.md"),
+      proofNudgeReport({
+        author: "app/clawsweeper",
+        authorAssociation: "NONE",
+        reviewedAt: "2026-01-01T00:00:00Z",
+      }),
+    );
+    writeFileSync(
+      join(itemsDir, "52.md"),
+      proofNudgeReport({
+        author: "app/clawsweeper",
+        authorAssociation: "NONE",
+        reviewedAt: "2026-01-02T00:00:00Z",
+      }),
+    );
+    withMockGh(root, closedProofLaneGhMockScript([51, 52]), () => {
+      execFileSync(process.execPath, [
+        "dist/clawsweeper.js",
+        "bot-proof",
+        "--target-repo",
+        "openclaw/openclaw",
+        "--items-dir",
+        itemsDir,
+        "--limit",
+        "10",
+        "--processed-limit",
+        "2",
+        "--report-path",
+        reportPath,
+        "--cursor-path",
+        cursorPath,
+        "--execute",
+      ]);
+    });
+
+    const cursor = JSON.parse(readFileSync(cursorPath, "utf8"));
+    assert.equal(cursor.repository, "openclaw/openclaw");
+    assert.equal(cursor.lane, "bot_proof");
+    assert.equal(cursor.next_cursor_number, 52);
+    assert.equal(cursor.next_cursor_likely, true);
+    assert.equal(cursor.reviewed_at, "2026-01-02T00:00:00Z");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("targeted proof lane execute scans ignore cursor paths", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const proofItemsDir = join(root, "proof-items");
+    const botItemsDir = join(root, "bot-items");
+    const proofReportPath = join(root, "proof-nudge-report.json");
+    const botReportPath = join(root, "bot-proof-report.json");
+    const proofCursorPath = join(root, "results", "proof-nudge-cursors", "openclaw-openclaw.json");
+    const botCursorPath = join(root, "results", "bot-proof-cursors", "openclaw-openclaw.json");
+    mkdirSync(proofItemsDir, { recursive: true });
+    mkdirSync(botItemsDir, { recursive: true });
+    writeFileSync(join(proofItemsDir, "42.md"), proofNudgeReport());
+    writeFileSync(
+      join(botItemsDir, "52.md"),
+      proofNudgeReport({ author: "app/clawsweeper", authorAssociation: "NONE" }),
+    );
+    withMockGh(root, closedProofLaneGhMockScript([42, 52]), () => {
+      execFileSync(process.execPath, [
+        "dist/clawsweeper.js",
+        "proof-nudges",
+        "--target-repo",
+        "openclaw/openclaw",
+        "--items-dir",
+        proofItemsDir,
+        "--item-numbers",
+        "42",
+        "--limit",
+        "10",
+        "--processed-limit",
+        "10",
+        "--report-path",
+        proofReportPath,
+        "--cursor-path",
+        proofCursorPath,
+        "--execute",
+      ]);
+      execFileSync(process.execPath, [
+        "dist/clawsweeper.js",
+        "bot-proof",
+        "--target-repo",
+        "openclaw/openclaw",
+        "--items-dir",
+        botItemsDir,
+        "--item-numbers",
+        "52",
+        "--limit",
+        "10",
+        "--processed-limit",
+        "10",
+        "--report-path",
+        botReportPath,
+        "--cursor-path",
+        botCursorPath,
+        "--execute",
+      ]);
+    });
+
+    const proofReport = JSON.parse(readFileSync(proofReportPath, "utf8"));
+    const botReport = JSON.parse(readFileSync(botReportPath, "utf8"));
+    assert.deepEqual(
+      proofReport.map((entry: { number: number; action: string }) => [entry.number, entry.action]),
+      [[42, "skipped_not_open"]],
+    );
+    assert.deepEqual(
+      botReport.map((entry: { number: number; action: string }) => [entry.number, entry.action]),
+      [[52, "skipped_not_open"]],
+    );
+    assert.equal(existsSync(proofCursorPath), false);
+    assert.equal(existsSync(botCursorPath), false);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -260,6 +260,7 @@ test("proof nudge workflow is manual-first and scheduled behind repo vars", () =
   assert.match(job, /PROOF_NUDGES_ITEM_NUMBERS:/);
   assert.match(job, /item_numbers must be a comma-separated list/);
   assert.match(job, /PROOF_NUDGES_LIMIT:/);
+  assert.match(job, /PROOF_NUDGES_PROCESSED_LIMIT:/);
   assert.match(job, /PROOF_NUDGES_MIN_AGE_DAYS:/);
   assert.match(job, /PROOF_NUDGES_COOLDOWN_DAYS:/);
   assert.match(job, /permission-pull-requests: write/);
@@ -269,8 +270,16 @@ test("proof nudge workflow is manual-first and scheduled behind repo vars", () =
   );
   assert.match(job, /execute_arg=\(\)/);
   assert.match(job, /if \[ "\$PROOF_NUDGES_EXECUTE" = "true" \]/);
+  assert.match(job, /processed_limit_arg=\(\)/);
+  assert.match(job, /--processed-limit "\$PROOF_NUDGES_PROCESSED_LIMIT"/);
+  assert.match(job, /--cursor-path "results\/proof-nudge-cursors\/\$\{target_slug\}\.json"/);
+  assert.match(job, /--cursor-path "results\/bot-proof-cursors\/\$\{target_slug\}\.json"/);
   assert.match(job, /pnpm run proof-nudges/);
   assert.match(job, /vars\.CLAWSWEEPER_PROOF_NUDGES_LIMIT/);
+  assert.match(job, /vars\.CLAWSWEEPER_PROOF_NUDGES_PROCESSED_LIMIT/);
+  assert.match(job, /repair:publish-main/);
+  assert.match(job, /results\/proof-nudge-cursors/);
+  assert.match(job, /results\/bot-proof-cursors/);
 });
 
 test("read-only checkout mode restores file modes and leaves git metadata writable", () => {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -282,6 +282,38 @@ test("proof nudge workflow is manual-first and scheduled behind repo vars", () =
   assert.match(job, /results\/bot-proof-cursors/);
 });
 
+test("proof nudge workflow publishes cursors only for executed lanes", () => {
+  const workflow = readFileSync(".github/workflows/proof-nudges.yml", "utf8");
+  const job = workflow.slice(workflow.indexOf("  proof-nudges:"), workflow.length);
+  const untargetedCursorStart = job.indexOf(
+    'cursor_arg=(--cursor-path "results/proof-nudge-cursors/${target_slug}.json")',
+  );
+  const proofRunStart = job.indexOf("pnpm run proof-nudges", untargetedCursorStart);
+  const botEnabledStart = job.indexOf('if [ "$BOT_PROOF_ENABLED" = "true" ]; then', proofRunStart);
+  const publishStart = job.indexOf("pnpm run repair:publish-main", botEnabledStart);
+
+  assert.notEqual(untargetedCursorStart, -1);
+  assert.notEqual(proofRunStart, -1);
+  assert.notEqual(botEnabledStart, -1);
+  assert.notEqual(publishStart, -1);
+
+  const cursorSetup = job.slice(untargetedCursorStart, proofRunStart);
+  const proofAfterRun = job.slice(proofRunStart, botEnabledStart);
+  const botBlock = job.slice(botEnabledStart, publishStart);
+
+  assert.doesNotMatch(cursorSetup, /cursor_publish_args/);
+  assert.match(
+    proofAfterRun,
+    /if \[ "\$PROOF_NUDGES_EXECUTE" = "true" \] && \[ -d results\/proof-nudge-cursors \]/,
+  );
+  assert.match(proofAfterRun, /cursor_publish_args\+=\(--path results\/proof-nudge-cursors\)/);
+  assert.match(
+    botBlock,
+    /if \[ "\$BOT_PROOF_EXECUTE" = "true" \] && \[ -d results\/bot-proof-cursors \]/,
+  );
+  assert.match(botBlock, /cursor_publish_args\+=\(--path results\/bot-proof-cursors\)/);
+});
+
 test("read-only checkout mode restores file modes and leaves git metadata writable", () => {
   const root = mkdtempSync(tmpPrefix);
   try {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -282,7 +282,7 @@ test("proof nudge workflow is manual-first and scheduled behind repo vars", () =
   assert.match(job, /results\/bot-proof-cursors/);
 });
 
-test("proof nudge workflow publishes cursors only for executed lanes", () => {
+test("proof nudge workflow publishes exact cursor files only for executed lanes", () => {
   const workflow = readFileSync(".github/workflows/proof-nudges.yml", "utf8");
   const job = workflow.slice(workflow.indexOf("  proof-nudges:"), workflow.length);
   const untargetedCursorStart = job.indexOf(
@@ -304,14 +304,23 @@ test("proof nudge workflow publishes cursors only for executed lanes", () => {
   assert.doesNotMatch(cursorSetup, /cursor_publish_args/);
   assert.match(
     proofAfterRun,
-    /if \[ "\$PROOF_NUDGES_EXECUTE" = "true" \] && \[ -d results\/proof-nudge-cursors \]/,
+    /proof_cursor_path="results\/proof-nudge-cursors\/\$\{target_slug\}\.json"/,
   );
-  assert.match(proofAfterRun, /cursor_publish_args\+=\(--path results\/proof-nudge-cursors\)/);
   assert.match(
-    botBlock,
-    /if \[ "\$BOT_PROOF_EXECUTE" = "true" \] && \[ -d results\/bot-proof-cursors \]/,
+    proofAfterRun,
+    /if \[ "\$PROOF_NUDGES_EXECUTE" = "true" \] && \[ -f "\$proof_cursor_path" \]/,
   );
-  assert.match(botBlock, /cursor_publish_args\+=\(--path results\/bot-proof-cursors\)/);
+  assert.match(proofAfterRun, /cursor_publish_args\+=\(--path "\$proof_cursor_path"\)/);
+  assert.doesNotMatch(
+    proofAfterRun,
+    /cursor_publish_args\+=\(--path results\/proof-nudge-cursors\)/,
+  );
+  assert.doesNotMatch(proofAfterRun, /\[ -d results\/proof-nudge-cursors \]/);
+  assert.match(botBlock, /bot_cursor_path="results\/bot-proof-cursors\/\$\{target_slug\}\.json"/);
+  assert.match(botBlock, /if \[ "\$BOT_PROOF_EXECUTE" = "true" \] && \[ -f "\$bot_cursor_path" \]/);
+  assert.match(botBlock, /cursor_publish_args\+=\(--path "\$bot_cursor_path"\)/);
+  assert.doesNotMatch(botBlock, /cursor_publish_args\+=\(--path results\/bot-proof-cursors\)/);
+  assert.doesNotMatch(botBlock, /\[ -d results\/bot-proof-cursors \]/);
 });
 
 test("read-only checkout mode restores file modes and leaves git metadata writable", () => {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -261,6 +261,7 @@ test("proof nudge workflow is manual-first and scheduled behind repo vars", () =
   assert.match(job, /item_numbers must be a comma-separated list/);
   assert.match(job, /PROOF_NUDGES_LIMIT:/);
   assert.match(job, /PROOF_NUDGES_PROCESSED_LIMIT:/);
+  assert.match(job, /PROOF_NUDGES_PROCESSED_LIMIT must be a positive integer/);
   assert.match(job, /PROOF_NUDGES_MIN_AGE_DAYS:/);
   assert.match(job, /PROOF_NUDGES_COOLDOWN_DAYS:/);
   assert.match(job, /permission-pull-requests: write/);
@@ -285,42 +286,15 @@ test("proof nudge workflow is manual-first and scheduled behind repo vars", () =
 test("proof nudge workflow publishes exact cursor files only for executed lanes", () => {
   const workflow = readFileSync(".github/workflows/proof-nudges.yml", "utf8");
   const job = workflow.slice(workflow.indexOf("  proof-nudges:"), workflow.length);
-  const untargetedCursorStart = job.indexOf(
-    'cursor_arg=(--cursor-path "results/proof-nudge-cursors/${target_slug}.json")',
-  );
-  const proofRunStart = job.indexOf("pnpm run proof-nudges", untargetedCursorStart);
-  const botEnabledStart = job.indexOf('if [ "$BOT_PROOF_ENABLED" = "true" ]; then', proofRunStart);
-  const publishStart = job.indexOf("pnpm run repair:publish-main", botEnabledStart);
-
-  assert.notEqual(untargetedCursorStart, -1);
-  assert.notEqual(proofRunStart, -1);
-  assert.notEqual(botEnabledStart, -1);
-  assert.notEqual(publishStart, -1);
-
-  const cursorSetup = job.slice(untargetedCursorStart, proofRunStart);
-  const proofAfterRun = job.slice(proofRunStart, botEnabledStart);
-  const botBlock = job.slice(botEnabledStart, publishStart);
-
-  assert.doesNotMatch(cursorSetup, /cursor_publish_args/);
-  assert.match(
-    proofAfterRun,
-    /proof_cursor_path="results\/proof-nudge-cursors\/\$\{target_slug\}\.json"/,
-  );
-  assert.match(
-    proofAfterRun,
-    /if \[ "\$PROOF_NUDGES_EXECUTE" = "true" \] && \[ -f "\$proof_cursor_path" \]/,
-  );
-  assert.match(proofAfterRun, /cursor_publish_args\+=\(--path "\$proof_cursor_path"\)/);
+  assert.match(job, /proof_cursor_path="results\/proof-nudge-cursors\/\$\{target_slug\}\.json"/);
+  assert.match(job, /bot_cursor_path="results\/bot-proof-cursors\/\$\{target_slug\}\.json"/);
+  assert.match(job, /if \[ "\$PROOF_NUDGES_EXECUTE" = "true" \] && \[ -f "\$proof_cursor_path" \]/);
+  assert.match(job, /if \[ "\$BOT_PROOF_EXECUTE" = "true" \] && \[ -f "\$bot_cursor_path" \]/);
+  assert.match(job, /cursor_publish_args\+=\(--path "\$(?:proof|bot)_cursor_path"\)/);
   assert.doesNotMatch(
-    proofAfterRun,
-    /cursor_publish_args\+=\(--path results\/proof-nudge-cursors\)/,
+    job,
+    /cursor_publish_args\+=\(--path results\/(?:proof-nudge|bot-proof)-cursors\)/,
   );
-  assert.doesNotMatch(proofAfterRun, /\[ -d results\/proof-nudge-cursors \]/);
-  assert.match(botBlock, /bot_cursor_path="results\/bot-proof-cursors\/\$\{target_slug\}\.json"/);
-  assert.match(botBlock, /if \[ "\$BOT_PROOF_EXECUTE" = "true" \] && \[ -f "\$bot_cursor_path" \]/);
-  assert.match(botBlock, /cursor_publish_args\+=\(--path "\$bot_cursor_path"\)/);
-  assert.doesNotMatch(botBlock, /cursor_publish_args\+=\(--path results\/bot-proof-cursors\)/);
-  assert.doesNotMatch(botBlock, /\[ -d results\/bot-proof-cursors \]/);
 });
 
 test("read-only checkout mode restores file modes and leaves git metadata writable", () => {


### PR DESCRIPTION
## What Problem This Solves

The scheduled proof-nudge lane can spend its whole processed-record budget on the same skip-heavy prefix of report records. When the first candidate window is mostly protected, recently reviewed, already nudged, or otherwise skipped, later stale PRs that still need real behavior proof can wait even though the workflow is running successfully every day.

## Why This Change Was Made

This adds durable cursor rotation to the untargeted `proof-nudges` and `bot-proof` scans. Each executing untargeted run starts after the previous cursor, processes a bounded candidate window, and advances the cursor to the last processed candidate. Targeted `--item-numbers` runs stay deterministic and do not read or update cursor state.

The workflow now passes proof-specific cursor paths, publishes state back to `clawsweeper-state`, and exposes `processed_limit` / `CLAWSWEEPER_PROOF_NUDGES_PROCESSED_LIMIT` so scan depth can be tuned separately from the max comments/actions per run. Cursor publishing is gated on the corresponding lane running in execute mode and producing the exact target cursor file, so dry-runs do not publish missing cursor paths and one target repo run does not replace another target repo's cursor file.

## User Impact

Scheduled proof handling should move through the proof backlog more predictably instead of repeatedly inspecting the same skipped records. The change does not increase the default comment batch size, does not alter proof eligibility rules, and does not make targeted manual runs rotate unexpectedly.

## Evidence

Head proofed: `eb444762164a928c45d4635d5861e0a0a3e83ce1`.

- Open PR overlap scan on 2026-06-27 found only this PR for `proof nudge cursor` and `CLAWSWEEPER_PROOF_NUDGES_PROCESSED_LIMIT`, and no other open PR for `proof nudge rotation`.
- Runtime cursor proof on 2026-06-27 used the built CLI entrypoints with `GH_BIN` mocked only for safe GitHub read responses. Both lanes ran with `--execute` and wrote cursor files under the same `results/...` paths used by the workflow:

```text
command: node dist/clawsweeper.js proof-nudges --target-repo openclaw/openclaw --items-dir <temp>/proof-items --limit 10 --processed-limit 2 --report-path <temp>/proof-nudge-run-1-report.json --cursor-path <temp>/results/proof-nudge-cursors/openclaw-openclaw.json --execute
result: 41:skipped_not_open, 42:skipped_not_open
cursor: lane=proof_nudges next_cursor_number=42 next_cursor_likely=True reviewed_at=2026-01-02T00:00:00Z

command: node dist/clawsweeper.js proof-nudges --target-repo openclaw/openclaw --items-dir <temp>/proof-items --limit 10 --processed-limit 2 --report-path <temp>/proof-nudge-run-2-report.json --cursor-path <temp>/results/proof-nudge-cursors/openclaw-openclaw.json --execute
result: 43:skipped_not_open, 41:skipped_not_open
cursor: lane=proof_nudges next_cursor_number=41 next_cursor_likely=True reviewed_at=2026-01-01T00:00:00Z

command: node dist/clawsweeper.js bot-proof --target-repo openclaw/openclaw --items-dir <temp>/bot-items --limit 10 --processed-limit 2 --report-path <temp>/bot-proof-run-1-report.json --cursor-path <temp>/results/bot-proof-cursors/openclaw-openclaw.json --execute
result: 51:skipped_not_open, 52:skipped_not_open
cursor: lane=bot_proof next_cursor_number=52 next_cursor_likely=True reviewed_at=2026-01-02T00:00:00Z

command: node dist/clawsweeper.js bot-proof --target-repo openclaw/openclaw --items-dir <temp>/bot-items --limit 10 --processed-limit 2 --report-path <temp>/bot-proof-run-2-report.json --cursor-path <temp>/results/bot-proof-cursors/openclaw-openclaw.json --execute
result: 53:skipped_not_open, 51:skipped_not_open
cursor: lane=bot_proof next_cursor_number=51 next_cursor_likely=True reviewed_at=2026-01-01T00:00:00Z
```

- Workflow repair after ClawSweeper review publishes exact per-target cursor files: `results/proof-nudge-cursors/${target_slug}.json` and `results/bot-proof-cursors/${target_slug}.json`, each only when the corresponding lane executed and wrote that file.
- Current-head test coverage includes direct execute-path regression tests for `bot-proof` cursor writes and for targeted proof-lane runs ignoring `--cursor-path` and leaving cursor files absent.
- Current-head workflow coverage includes a focused assertion that untargeted cursor setup does not populate `cursor_publish_args`, and that proof-nudge and bot-proof cursor publish paths are exact target files added only behind execute-mode plus file-exists gates.
- Docs now state that the workflow publishes only exact target cursor files and does not replace another target repo's cursor file.
- Rollout monitoring item from the ClawSweeper review: after merge, inspect the first executed scheduled proof-lane state commit and verify it updates only the exact per-target cursor JSON file for the executed lane/target, with no directory-level replacement and no sibling target cursor deletion.
- `pnpm install --frozen-lockfile` completed and installed the pinned dev toolchain in the fresh worktree.
- `pnpm exec oxfmt --write .github/workflows/proof-nudges.yml test/sweep-workflow.test.ts docs/proof-nudges.md test/proof-nudge-policy.test.ts src/clawsweeper.ts` passed.
- `pnpm exec oxfmt --check .github/workflows/proof-nudges.yml test/sweep-workflow.test.ts docs/proof-nudges.md test/proof-nudge-policy.test.ts src/clawsweeper.ts` passed on current head.
- `pnpm run build:all` passed on current head.
- `pnpm run lint:src` passed on current head.
- `pnpm run lint:scripts` passed on current head.
- `node --test test/proof-nudge-policy.test.ts` passed on current head: 17 tests, 17 pass.
- `node --test --test-name-pattern "proof nudge workflow" test/sweep-workflow.test.ts` passed on current head: 2 tests, 2 pass.
- `pnpm run check` was run locally after the exact-file publish repair; it failed on unrelated Windows-checkout issues in existing tests, including CRLF-sensitive workflow assertions, Windows file-mode expectations, and existing command/Codex tests.
- GitHub `pnpm check` passed on current head: job `83852938494` completed at 2026-06-27T21:41:06Z.
- GitHub checks observed on current head: `pnpm check`, CodeQL, Windows launcher, Socket checks, and later `github activity to openclaw/notify` runs passed. One earlier `notify` run was skipped before later notify successes.