### PR TITLE
perf: cache report entries during scans

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -16918,37 +16918,28 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
   const maybeLogProgress = (message: string): void => {
     if (processedCount % progressEvery === 0) logProgress(message);
   };
-  const reportEntriesForDir = (
+  const applyReportEntriesForDir = (
     dir: string,
     location: "items" | "closed",
-  ): Array<{
-    name: string;
-    number: number;
-    path: string;
-    location: "items" | "closed";
-    priority: number;
-    applyCheckedAt: number;
-  }> => {
-    if (!existsSync(dir)) return [];
-    return readdirSync(dir)
-      .filter((name) => parseReportFileName(name) !== null)
-      .filter((name) => {
-        const markdown = readFileSync(join(dir, name), "utf8");
-        if (!isMarkdownForActiveRepo(markdown, name)) return false;
-        return (
-          requestedItemNumberSet.size === 0 ||
-          requestedItemNumberSet.has(numberForMarkdownFile(name))
-        );
-      })
-      .map((name) => ({
-        name,
-        number: numberForMarkdownFile(name),
-        path: join(dir, name),
+  ): Array<
+    ReportEntry & {
+      location: "items" | "closed";
+      priority: number;
+      applyCheckedAt: number;
+    }
+  > =>
+    reportEntriesForDir(dir)
+      .filter(
+        (entry) =>
+          entry.repo === targetRepo() &&
+          (requestedItemNumberSet.size === 0 || requestedItemNumberSet.has(entry.number)),
+      )
+      .map((entry) => ({
+        ...entry,
         location,
-        ...applyQueueSortFields(readFileSync(join(dir, name), "utf8"), syncCommentsOnly, applyKind),
+        ...applyQueueSortFields(entry.markdown, syncCommentsOnly, applyKind),
       }));
-  };
-  const fileEntries = reportEntriesForDir(itemsDir, "items").sort(
+  const fileEntries = applyReportEntriesForDir(itemsDir, "items").sort(
     (left, right) =>
       left.priority - right.priority ||
       left.applyCheckedAt - right.applyCheckedAt ||
@@ -16980,9 +16971,9 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       logProgress(`stopping apply: max runtime ${maxRuntimeMs}ms reached`);
       break;
     }
-    let markdown = readFileSync(path, "utf8");
-    const repo = markdownRepository(markdown, path);
-    const number = numberForMarkdownFile(file);
+    let markdown = entry.markdown;
+    const repo = entry.repo;
+    const number = entry.number;
     const decision = frontMatterValue(markdown, "decision");
     let closeReason = frontMatterValue(markdown, "close_reason") as CloseReason | undefined;
     const action = frontMatterValue(markdown, "action_taken");
@@ -18824,6 +18815,28 @@ function markdownFiles(dir: string): string[] {
     : [];
 }
 
+interface ReportEntry {
+  name: string;
+  number: number;
+  path: string;
+  repo: string;
+  markdown: string;
+}
+
+function reportEntriesForDir(dir: string): ReportEntry[] {
+  return markdownFiles(dir).map((name) => {
+    const path = join(dir, name);
+    const markdown = readFileSync(path, "utf8");
+    return {
+      name,
+      number: numberForMarkdownFile(name),
+      path,
+      repo: markdownRepository(markdown, path),
+      markdown,
+    };
+  });
+}
+
 function numberForMarkdownFile(file: string): number {
   const parsed = parseReportFileName(file);
   if (!parsed) throw new Error(`Invalid report filename: ${file}`);
@@ -19364,8 +19377,12 @@ function dashboardStats(
   closedDir = defaultClosedDir(),
   profile = targetProfile(),
 ): DashboardStats {
-  const files = markdownFiles(itemsDir);
-  const closedFiles = markdownFiles(closedDir);
+  const entries = reportEntriesForDir(itemsDir).filter(
+    (entry) => entry.repo === profile.targetRepo,
+  );
+  const closedEntries = reportEntriesForDir(closedDir).filter(
+    (entry) => entry.repo === profile.targetRepo,
+  );
   const plansDir = defaultPlansDir(profile);
   const now = Date.now();
   let fresh = 0;
@@ -19386,11 +19403,10 @@ function dashboardStats(
   const recent: DashboardItem[] = [];
   const workQueue: DashboardItem[] = [];
   const recentClosed: DashboardClosedItem[] = [];
-  for (const file of files) {
-    const markdown = readFileSync(join(itemsDir, file), "utf8");
-    if (markdownRepository(markdown, join(itemsDir, file)) !== profile.targetRepo) continue;
-    const repo = markdownRepository(markdown, join(closedDir, file));
-    const number = numberForMarkdownFile(file);
+  for (const entry of entries) {
+    const markdown = entry.markdown;
+    const repo = entry.repo;
+    const number = entry.number;
     const reviewedAt = frontMatterValue(markdown, "reviewed_at");
     const reviewStatus = effectiveReviewStatus(markdown);
     const action = frontMatterValue(markdown, "action_taken") ?? "unknown";
@@ -19436,9 +19452,9 @@ function dashboardStats(
       decision,
       action,
       reviewStatus,
-      reportPath: repoRelativePath(join(itemsDir, file)),
-      planPath: existsSync(join(plansDir, file))
-        ? repoRelativePath(join(plansDir, file))
+      reportPath: repoRelativePath(entry.path),
+      planPath: existsSync(join(plansDir, entry.name))
+        ? repoRelativePath(join(plansDir, entry.name))
         : undefined,
       workCandidate,
       workPriority,
@@ -19449,10 +19465,9 @@ function dashboardStats(
       workQueue.push(dashboardItem);
     }
   }
-  for (const file of closedFiles) {
-    const markdown = readFileSync(join(closedDir, file), "utf8");
-    if (markdownRepository(markdown, join(closedDir, file)) !== profile.targetRepo) continue;
-    const repo = markdownRepository(markdown, join(closedDir, file));
+  for (const entry of closedEntries) {
+    const markdown = entry.markdown;
+    const repo = entry.repo;
     const action = frontMatterValue(markdown, "action_taken") ?? "unknown";
     const closedAt = dashboardClosedAt(markdown);
     if (action === "closed") {
@@ -19461,13 +19476,13 @@ function dashboardStats(
     if (closedAt) {
       recentClosed.push({
         repo,
-        number: numberForMarkdownFile(file),
+        number: entry.number,
         kind: (frontMatterValue(markdown, "type") as ItemKind | undefined) ?? "issue",
         title: frontMatterValue(markdown, "title") ?? "",
         closedAt,
         appliedAt: frontMatterValue(markdown, "applied_at"),
         closeReason: dashboardCloseReason(markdown),
-        reportPath: repoRelativePath(join(closedDir, file)),
+        reportPath: repoRelativePath(entry.path),
       });
     }
     recordDashboardActivity(markdown, activity, now);
@@ -19509,18 +19524,10 @@ function dashboardStats(
     open,
     fresh,
     todo: cadenceDue,
-    files: files.filter(
-      (file) =>
-        markdownRepository(readFileSync(join(itemsDir, file), "utf8"), join(itemsDir, file)) ===
-        profile.targetRepo,
-    ).length,
+    files: entries.length,
     proposedClose,
     closed,
-    archivedFiles: closedFiles.filter(
-      (file) =>
-        markdownRepository(readFileSync(join(closedDir, file), "utf8"), join(closedDir, file)) ===
-        profile.targetRepo,
-    ).length,
+    archivedFiles: closedEntries.length,
     failed,
     stale,
     workCandidates,


### PR DESCRIPTION
## What Problem This Solves

ClawSweeper's apply/report scans reread the same report markdown while filtering, sorting, and rendering dashboard state. On larger queues that repeats local disk I/O and repeats frontmatter extraction for data that belongs to the same report snapshot.

## Why This Change Was Made

This adds a small private `ReportEntry` reader that loads each markdown report once with its filename, number, path, repository, and markdown body. The apply queue now reuses that entry for active-repo filtering, item-number filtering, sort fields, and the initial apply-loop markdown. Dashboard stats now iterate the same parsed entries for open and archived reports, so final file counts no longer reread every markdown file.

The apply loop still rereads pair-counterpart reports from disk when checking same-author pair closeability, because those checks can depend on report mutations earlier in the same apply run.

## User Impact

Apply and dashboard runs do less repeated filesystem work as report queues grow, without changing close gates, review decisions, dashboard rows, or public output.

## Evidence

Head proofed: `9dc7fed32df0413c46d0467f9b04ad279238d1fe`.

- Duplicate scan before opening found no open PR for `report entry cache`, `reportEntriesForDir`, or dashboard cache work.
- `pnpm install --frozen-lockfile` completed and installed the pinned dev toolchain. `corepack enable` printed a Windows Program Files permission warning first, but `pnpm` itself completed successfully.
- `pnpm exec oxfmt --write src/clawsweeper.ts` passed.
- `pnpm run build` passed.
- `pnpm run build:all` passed.
- `pnpm run lint` passed.
- `pnpm run check:active-surface` passed.
- `pnpm run check:limits` passed.
- `pnpm run format:check` passed.
- `node --test test/clawsweeper.test.ts` passed: 58 tests, 58 pass.
- `codex review -c service_tier='fast' --uncommitted` reported no actionable correctness issues.
- Runtime apply proof after the cache change used a rebuilt `dist/clawsweeper.js` and a realistic temp report tree with two open reports. The run exercises the cached report-entry apply scan, applies active-repo filtering and queue processing, exits 0, and the failing mock `gh` shim was never invoked:

```text
$ node dist/clawsweeper.js apply-decisions --target-repo openclaw/clawsweeper --items-dir %TEMP%\clawsweeper-report-entry-proof-...\items --closed-dir %TEMP%\clawsweeper-report-entry-proof-...\closed --plans-dir %TEMP%\clawsweeper-report-entry-proof-...\plans --report-path %TEMP%\clawsweeper-report-entry-proof-...\apply-report.json --dry-run --limit 10 --processed-limit 2 --close-delay-ms 0 --progress-every 1
[apply] 2026-06-27T20:43:56.285Z starting apply: files=2 dry_run=true apply_kind=issue min_age=0 days apply_close_reasons=all stale_min_age_days=60 close_delay_ms=0 sync_comments_only=false comment_sync_min_age_days=0 max_runtime_ms=0 item_numbers=all closed=0/10 processed=0/2 counts={}
[apply] 2026-06-27T20:43:56.287Z skipped #321: review lacks verified local checkout access closed=0/10 processed=1/2 counts={"kept_open":1}
[apply] 2026-06-27T20:43:56.288Z skipped #322: review lacks verified local checkout access closed=0/10 processed=2/2 counts={"kept_open":2}
[apply] 2026-06-27T20:43:56.289Z finished apply closed=0/10 processed=2/2 counts={"kept_open":2}
[
  {
    "number": 321,
    "action": "kept_open",
    "reason": "review lacks verified local checkout access"
  },
  {
    "number": 322,
    "action": "kept_open",
    "reason": "review lacks verified local checkout access"
  }
]
APPLY_EXIT=0
GH_LOG_EXISTS=False
APPLY_REPORT_JSON:
[
  {
    "number": 321,
    "action": "kept_open",
    "reason": "review lacks verified local checkout access"
  },
  {
    "number": 322,
    "action": "kept_open",
    "reason": "review lacks verified local checkout access"
  }
]
```

- Runtime dashboard proof after the cache change ran the rebuilt dashboard command in a throwaway copy of `dist/`, `config/`, and `README.md` so the working tree README was not touched. It used two verified open reports and one archived closed report; the mock `gh` fallback proves the generated dashboard came from local cached report entries:

```text
$ node %TEMP%\clawsweeper-dashboard-cache-proof-...\runtime\dist\clawsweeper.js dashboard --target-repo openclaw/clawsweeper --items-dir %TEMP%\clawsweeper-dashboard-cache-proof-...\items --closed-dir %TEMP%\clawsweeper-dashboard-cache-proof-...\closed
[dashboard] failed to fetch open item counts for openclaw/clawsweeper; using local record counts: Command failed: C:\Program Files\nodejs\node.exe %TEMP%\clawsweeper-dashboard-cache-proof-...\bin\gh-mock.js api graphql -f query=query { repository(owner: "openclaw", name: "clawsweeper") { issues(states: OPEN) { totalCount } pullRequests(states: OPEN) { totalCount } } }
intentional dashboard proof gh failure; using local record fallback

DASHBOARD_EXIT=0
GH_FALLBACK_CALLS=1
GENERATED_DASHBOARD_LINES:
| Reviewed files | 2 |
| Work candidates awaiting promotion | 2 |
| Closed by Codex apply | 1 |
| Archived closed files | 1 |
| [openclaw/clawsweeper](https://github.com/openclaw/clawsweeper) | [#400](https://github.com/openclaw/clawsweeper/issues/400) | Cache dashboard closed proof 400 | fixed | Jun 27, 2026, 20:45 UTC | [../closed/400.md](https://github.com/openclaw/clawsweeper/blob/main/../closed/400.md) |
| [openclaw/clawsweeper](https://github.com/openclaw/clawsweeper) | [#322](https://github.com/openclaw/clawsweeper/pull/322) | Cache dashboard proof 322 | medium | candidate | Jun 27, 2026, 20:41 UTC | _pending_ | [../items/322.md](https://github.com/openclaw/clawsweeper/blob/main/../items/322.md) |
| [openclaw/clawsweeper](https://github.com/openclaw/clawsweeper) | [#321](https://github.com/openclaw/clawsweeper/issues/321) | Cache dashboard proof 321 | medium | candidate | Jun 27, 2026, 20:40 UTC | [records/openclaw-clawsweeper/plans/321.md](https://github.com/openclaw/clawsweeper/blob/main/records/openclaw-clawsweeper/plans/321.md) | [../items/321.md](https://github.com/openclaw/clawsweeper/blob/main/../items/321.md) |
```

Local full `pnpm run test:unit` on this main-based Windows checkout is still blocked by the pre-existing Windows portability failures being handled in https://github.com/openclaw/clawsweeper/pull/376: Codex proof tests hit local config/service-tier handling, one command test observes CRLF output, and the POSIX mode test is not portable on Windows main. This branch does not depend on PR #376 and has no source-file overlap with it; GitHub CI should provide the full Linux `pnpm check` proof for this PR.