### PR TITLE
fix: include command helper in repair sparse checkouts

### DIFF
--- a/.github/workflows/assist.yml
+++ b/.github/workflows/assist.yml
@@ -73,6 +73,7 @@ jobs:
           sparse-checkout: |
             .github/actions/setup-pnpm
             config
+            src/command.ts
             src
             package.json
             pnpm-lock.yaml

--- a/.github/workflows/repair-comment-router.yml
+++ b/.github/workflows/repair-comment-router.yml
@@ -95,6 +95,7 @@ jobs:
             schema/clawsweeper-pr-close-coverage-proof.schema.json
             scripts/hydrate-state.ts
             src/clawsweeper-text.ts
+            src/command.ts
             src/codex-env.ts
             src/codex-output-capture.ts
             src/codex-spawn.ts

--- a/.github/workflows/spam-comment-intake.yml
+++ b/.github/workflows/spam-comment-intake.yml
@@ -56,6 +56,7 @@ jobs:
             prompts/pr-close-coverage-proof.md
             schema/clawsweeper-pr-close-coverage-proof.schema.json
             src/clawsweeper-text.ts
+            src/command.ts
             src/codex-env.ts
             src/codex-output-capture.ts
             src/codex-process-worker.ts

--- a/.github/workflows/spam-scanner.yml
+++ b/.github/workflows/spam-scanner.yml
@@ -79,6 +79,7 @@ jobs:
             schema/clawsweeper-pr-close-coverage-proof.schema.json
             scripts/hydrate-state.ts
             src/clawsweeper-text.ts
+            src/command.ts
             src/codex-env.ts
             src/codex-output-capture.ts
             src/codex-process-worker.ts

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1,5 +1,13 @@
 import assert from "node:assert/strict";
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
 


### PR DESCRIPTION
## Summary
- include `src/command.ts` in sparse checkouts that run `build:repair`
- unblocks repair/comment-router builds that compile `src/codex-spawn.ts` and `src/repair/*` imports from `command.js`
- fix a current-main unit test import exposed by CI (`readFileSync` in `test/sweep-workflow.test.ts`)

## Why
OpenClaw PR openclaw/openclaw#98396 is clean and all checks are green, but its latest `@clawsweeper automerge` command hit failing ClawSweeper comment-router runs:
- https://github.com/openclaw/clawsweeper/actions/runs/28506991149
- https://github.com/openclaw/clawsweeper/actions/runs/28507000626

Both failed in `build:repair` with missing `./command.js` / `../command.js` module resolution because the sparse checkout did not include `src/command.ts`.

## Verification
- `pnpm run build:repair`
- `pnpm exec oxfmt --check test/sweep-workflow.test.ts .github/workflows/assist.yml .github/workflows/repair-comment-router.yml .github/workflows/spam-comment-intake.yml .github/workflows/spam-scanner.yml`
- `pnpm run build && node --test test/sweep-workflow.test.ts` (35/35 pass)
- `git diff --check`

Note: local `pnpm run test:unit` on Node 22 still exposes unrelated pending-promise failures in `test/dashboard-worker.test.ts`; the pushed change fixes the CI failure observed on #381 (`readFileSync is not defined`).
