### PR TITLE
refactor: extract scheduler policy

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -116,15 +116,6 @@ export {
   isLockedConversationCommentError,
   shouldRetryGh,
 } from "./github-retry.js";
-export {
-  appendFloorBackfillCandidateNumbersForTest,
-  hotIntakeRecencyMs,
-  reviewPriority,
-  selectDueCandidateNumbersForTest,
-  shouldReviewItem,
-  shouldStopSaturatedPlanScan,
-} from "./scheduler-policy.js";
-
 type ItemKind = "issue" | "pull_request";
 type ApplyKind = ItemKind | "all";
 type DecisionKind = "close" | "keep_open";

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -51,6 +51,20 @@ import {
 import { parseGhJson, parseGhJsonLines } from "./github-json.js";
 import { stableJson } from "./stable-json.js";
 import {
+  appendFloorBackfillCandidates,
+  compareDueCandidates,
+  compareHotIntakeDueCandidates,
+  hasReviewPolicyMismatch,
+  nextReviewDueAtMs,
+  reviewedAtMs,
+  reviewPriority,
+  schedulerBucket,
+  selectDueCandidates,
+  shouldReviewItem,
+  shouldStopSaturatedPlanScan,
+  type SchedulerDueCandidate,
+} from "./scheduler-policy.js";
+import {
   isUserFacingCommandError,
   resolveCommand,
   runText,
@@ -102,6 +116,14 @@ export {
   isLockedConversationCommentError,
   shouldRetryGh,
 } from "./github-retry.js";
+export {
+  appendFloorBackfillCandidateNumbersForTest,
+  hotIntakeRecencyMs,
+  reviewPriority,
+  selectDueCandidateNumbersForTest,
+  shouldReviewItem,
+  shouldStopSaturatedPlanScan,
+} from "./scheduler-policy.js";
 
 type ItemKind = "issue" | "pull_request";
 type ApplyKind = ItemKind | "all";
@@ -806,22 +828,7 @@ const DEFAULT_PLAN_BATCH_SIZE = 3;
 const DEFAULT_PLAN_SHARD_COUNT = AUTOMATION_LIMITS.review_shards.normal_default;
 const MAX_PLAN_SHARD_COUNT = AUTOMATION_LIMITS.review_shards.hard_cap;
 
-type SchedulerBucket =
-  | "hot_issue"
-  | "hot_pull_request"
-  | "activity"
-  | "daily_pull_request"
-  | "recent_issue"
-  | "weekly_issue";
-
-interface DueCandidate {
-  item: Item;
-  review: ExistingReview | null;
-  priority: number;
-  reviewedAt: number;
-  nextDueAt: number;
-  bucket: SchedulerBucket;
-}
+type DueCandidate = SchedulerDueCandidate<Item, ExistingReview>;
 
 interface ApplyResult {
   repo?: string;
@@ -1084,7 +1091,6 @@ let activeRepositoryProfile = repositoryProfileFor(
 const FRESH_DAYS = 7;
 const HOT_REVIEW_DAYS = 7;
 const RECENT_ISSUE_DAYS = 30;
-const HOURLY_REVIEW_MS = 60 * 60 * 1000;
 const DEFAULT_BACKFILL_REVIEW_AGE_MINUTES = 360;
 const DAILY_REVIEW_DAYS = 1;
 const WEEKLY_REVIEW_DAYS = 7;
@@ -5289,126 +5295,6 @@ function isCurrentForCadence(options: {
   return options.now - reviewedAt < options.cadenceMs;
 }
 
-function reviewedAtMs(review: ExistingReview | null): number | null {
-  if (review?.reviewStatus !== "complete") return null;
-  if (!review.reviewedAt) return null;
-  const reviewedAt = Date.parse(review.reviewedAt);
-  return Number.isFinite(reviewedAt) ? reviewedAt : null;
-}
-
-function hasActivitySinceReview(item: Item, review: ExistingReview | null): boolean {
-  if (!review) return false;
-  const updatedAt = Date.parse(item.updatedAt);
-  const reviewedAt = reviewedAtMs(review);
-  const reviewCommentSyncedAt = timestampMs(review.reviewCommentSyncedAt);
-  const labelsSyncedAt = timestampMs(review.labelsSyncedAt);
-  const botOwnedSyncedAt = Math.max(
-    reviewCommentSyncedAt ?? -Infinity,
-    labelsSyncedAt ?? -Infinity,
-  );
-  if (review.itemUpdatedAt) {
-    if (item.updatedAt === review.itemUpdatedAt) return false;
-    if (Number.isFinite(updatedAt) && reviewedAt !== null && updatedAt <= reviewedAt) return false;
-    if (
-      Number.isFinite(updatedAt) &&
-      Number.isFinite(botOwnedSyncedAt) &&
-      updatedAt <= botOwnedSyncedAt
-    ) {
-      return false;
-    }
-    return true;
-  }
-  if (
-    Number.isFinite(updatedAt) &&
-    Number.isFinite(botOwnedSyncedAt) &&
-    updatedAt <= botOwnedSyncedAt
-  ) {
-    return false;
-  }
-  return reviewedAt !== null && Number.isFinite(updatedAt) && updatedAt > reviewedAt;
-}
-
-function isCreatedWithinDays(
-  item: Pick<Item, "createdAt">,
-  days: number,
-  now = Date.now(),
-): boolean {
-  const createdAt = Date.parse(item.createdAt);
-  return Number.isFinite(createdAt) && now - createdAt < days * DAY_MS;
-}
-
-function reviewCadenceMs(item: Item, review: ExistingReview | null, now = Date.now()): number {
-  if (hasActivitySinceReview(item, review)) return HOURLY_REVIEW_MS;
-  if (isCreatedWithinDays(item, HOT_REVIEW_DAYS, now)) return DAILY_REVIEW_DAYS * DAY_MS;
-  if (item.kind === "pull_request") return DAILY_REVIEW_DAYS * DAY_MS;
-  const createdAt = Date.parse(item.createdAt);
-  if (Number.isFinite(createdAt) && now - createdAt < RECENT_ISSUE_DAYS * DAY_MS) {
-    return DAILY_REVIEW_DAYS * DAY_MS;
-  }
-  return WEEKLY_REVIEW_DAYS * DAY_MS;
-}
-
-function hasReviewPolicyMismatch(review: ExistingReview | null, reviewPolicy?: string): boolean {
-  return Boolean(review && reviewPolicy && review.reviewPolicy !== reviewPolicy);
-}
-
-export function shouldReviewItem(
-  item: Item,
-  review: ExistingReview | null,
-  now = Date.now(),
-  reviewPolicy?: string,
-): boolean {
-  if (hasReviewPolicyMismatch(review, reviewPolicy)) return true;
-  const reviewedAt = reviewedAtMs(review);
-  if (reviewedAt === null) return true;
-  return now - reviewedAt >= reviewCadenceMs(item, review, now);
-}
-
-export function reviewPriority(
-  item: Item,
-  review: ExistingReview | null,
-  now = Date.now(),
-  reviewPolicy?: string,
-): number {
-  if (isCreatedWithinDays(item, HOT_REVIEW_DAYS, now) && item.kind === "issue") return 0;
-  if (isCreatedWithinDays(item, HOT_REVIEW_DAYS, now)) return 1;
-  if (hasActivitySinceReview(item, review)) return 2;
-  if (item.kind === "pull_request") return 3;
-  const createdAt = Date.parse(item.createdAt);
-  if (Number.isFinite(createdAt) && now - createdAt < RECENT_ISSUE_DAYS * DAY_MS) return 4;
-  if (hasReviewPolicyMismatch(review, reviewPolicy)) return 5;
-  return 6;
-}
-
-function schedulerBucket(
-  item: Item,
-  review: ExistingReview | null,
-  now = Date.now(),
-): SchedulerBucket {
-  if (isCreatedWithinDays(item, HOT_REVIEW_DAYS, now)) {
-    return item.kind === "issue" ? "hot_issue" : "hot_pull_request";
-  }
-  if (hasActivitySinceReview(item, review)) return "activity";
-  if (item.kind === "pull_request") return "daily_pull_request";
-  const createdAt = Date.parse(item.createdAt);
-  if (Number.isFinite(createdAt) && now - createdAt < RECENT_ISSUE_DAYS * DAY_MS) {
-    return "recent_issue";
-  }
-  return "weekly_issue";
-}
-
-function nextReviewDueAtMs(
-  item: Item,
-  review: ExistingReview | null,
-  now = Date.now(),
-  reviewPolicy?: string,
-): number {
-  if (hasReviewPolicyMismatch(review, reviewPolicy)) return 0;
-  const reviewedAt = reviewedAtMs(review);
-  if (reviewedAt === null) return 0;
-  return reviewedAt + reviewCadenceMs(item, review, now);
-}
-
 function dueCandidate(
   item: Item,
   itemsDir: string,
@@ -5450,196 +5336,6 @@ function reviewBackfillCandidate(
     nextDueAt: nextReviewDueAtMs(item, review, now, reviewPolicy),
     bucket: schedulerBucket(item, review, now),
   };
-}
-
-function compareDueCandidates(left: DueCandidate, right: DueCandidate): number {
-  return (
-    left.priority - right.priority ||
-    left.nextDueAt - right.nextDueAt ||
-    left.reviewedAt - right.reviewedAt ||
-    left.item.number - right.item.number
-  );
-}
-
-function compareBackfillCandidates(left: DueCandidate, right: DueCandidate): number {
-  return (
-    left.nextDueAt - right.nextDueAt ||
-    left.reviewedAt - right.reviewedAt ||
-    left.priority - right.priority ||
-    left.item.number - right.item.number
-  );
-}
-
-function weeklyReviewDeadlineMs(candidate: DueCandidate): number {
-  if (candidate.reviewedAt > 0) {
-    return candidate.reviewedAt + WEEKLY_REVIEW_DAYS * DAY_MS;
-  }
-  const createdAt = Date.parse(candidate.item.createdAt);
-  return Number.isFinite(createdAt) ? createdAt + WEEKLY_REVIEW_DAYS * DAY_MS : 0;
-}
-
-const SCHEDULER_BUCKET_WEIGHTS: ReadonlyArray<readonly [SchedulerBucket, number]> = [
-  ["hot_issue", 4],
-  ["hot_pull_request", 2],
-  ["activity", 2],
-  ["daily_pull_request", 3],
-  ["recent_issue", 2],
-  ["weekly_issue", 1],
-];
-
-function selectDueCandidates(
-  due: DueCandidate[],
-  limit: number,
-  compare: (left: DueCandidate, right: DueCandidate) => number = compareDueCandidates,
-  now = Date.now(),
-): DueCandidate[] {
-  const capacity = Math.max(0, limit);
-  if (capacity === 0) return [];
-  const buckets = new Map<SchedulerBucket, DueCandidate[]>();
-  for (const [bucket] of SCHEDULER_BUCKET_WEIGHTS) buckets.set(bucket, []);
-  for (const candidate of due) buckets.get(candidate.bucket)?.push(candidate);
-  for (const candidates of buckets.values()) candidates.sort(compare);
-
-  const selected: DueCandidate[] = [];
-  const selectedKeys = new Set<string>();
-  const take = (candidate: DueCandidate | undefined): void => {
-    if (!candidate || selected.length >= capacity) return;
-    const key = existingReviewKey(candidate.item.repo, candidate.item.number);
-    if (selectedKeys.has(key)) return;
-    selectedKeys.add(key);
-    selected.push(candidate);
-  };
-
-  // Weekly freshness is the outer SLO. Catch up breached items before applying
-  // the normal weighted mix for hourly and daily work.
-  const weeklyOverdue = due
-    .filter((candidate) => weeklyReviewDeadlineMs(candidate) <= now)
-    .sort(
-      (left, right) =>
-        weeklyReviewDeadlineMs(left) - weeklyReviewDeadlineMs(right) || compare(left, right),
-    );
-  for (const candidate of weeklyOverdue) take(candidate);
-  for (const [bucket, candidates] of buckets) {
-    buckets.set(
-      bucket,
-      candidates.filter(
-        (candidate) =>
-          !selectedKeys.has(existingReviewKey(candidate.item.repo, candidate.item.number)),
-      ),
-    );
-  }
-
-  while (selected.length < capacity) {
-    const before = selected.length;
-    for (const [bucket, weight] of SCHEDULER_BUCKET_WEIGHTS) {
-      const candidates = buckets.get(bucket);
-      if (!candidates?.length) continue;
-      for (let i = 0; i < weight && candidates.length && selected.length < capacity; i += 1) {
-        take(candidates.shift());
-      }
-    }
-    if (selected.length === before) break;
-  }
-
-  return selected;
-}
-
-function appendFloorBackfillCandidates(
-  selected: DueCandidate[],
-  backfill: DueCandidate[],
-  options: { activeFloor: number; capacity: number },
-): DueCandidate[] {
-  const activeFloor = Math.max(0, Math.floor(options.activeFloor));
-  const capacity = Math.max(0, Math.floor(options.capacity));
-  const target = Math.min(activeFloor, capacity);
-  if (selected.length >= target) return selected;
-  const selectedKeys = new Set(
-    selected.map((candidate) => existingReviewKey(candidate.item.repo, candidate.item.number)),
-  );
-  const filled = [...selected];
-  for (const candidate of [...backfill].sort(compareBackfillCandidates)) {
-    if (filled.length >= target) break;
-    const key = existingReviewKey(candidate.item.repo, candidate.item.number);
-    if (selectedKeys.has(key)) continue;
-    selectedKeys.add(key);
-    filled.push(candidate);
-  }
-  return filled;
-}
-
-export function selectDueCandidateNumbersForTest(
-  due: Array<{
-    item: Item;
-    bucket: SchedulerBucket;
-    priority?: number;
-    reviewedAt?: number;
-    nextDueAt?: number;
-  }>,
-  limit: number,
-  now = Date.now(),
-): number[] {
-  return selectDueCandidates(
-    due.map((candidate) => ({
-      item: candidate.item,
-      review: null,
-      priority: candidate.priority ?? reviewPriority(candidate.item, null),
-      reviewedAt: candidate.reviewedAt ?? 0,
-      nextDueAt: candidate.nextDueAt ?? 0,
-      bucket: candidate.bucket,
-    })),
-    limit,
-    compareDueCandidates,
-    now,
-  ).map((candidate) => candidate.item.number);
-}
-
-export function appendFloorBackfillCandidateNumbersForTest(
-  selected: Array<{
-    item: Item;
-    bucket: SchedulerBucket;
-    priority?: number;
-    reviewedAt?: number;
-    nextDueAt?: number;
-  }>,
-  backfill: Array<{
-    item: Item;
-    bucket: SchedulerBucket;
-    priority?: number;
-    reviewedAt?: number;
-    nextDueAt?: number;
-  }>,
-  activeFloor: number,
-  capacity: number,
-): number[] {
-  const normalize = (candidate: (typeof selected)[number]): DueCandidate => ({
-    item: candidate.item,
-    review: null,
-    priority: candidate.priority ?? reviewPriority(candidate.item, null),
-    reviewedAt: candidate.reviewedAt ?? 0,
-    nextDueAt: candidate.nextDueAt ?? 0,
-    bucket: candidate.bucket,
-  });
-  return appendFloorBackfillCandidates(selected.map(normalize), backfill.map(normalize), {
-    activeFloor,
-    capacity,
-  }).map((candidate) => candidate.item.number);
-}
-
-function compareHotIntakeDueCandidates(left: DueCandidate, right: DueCandidate): number {
-  return (
-    left.priority - right.priority ||
-    hotIntakeRecencyMs(right.item) - hotIntakeRecencyMs(left.item) ||
-    right.item.number - left.item.number
-  );
-}
-
-export function hotIntakeRecencyMs(item: Pick<Item, "createdAt" | "updatedAt">): number {
-  const updatedAt = Date.parse(item.updatedAt);
-  const createdAt = Date.parse(item.createdAt);
-  return Math.max(
-    Number.isFinite(updatedAt) ? updatedAt : 0,
-    Number.isFinite(createdAt) ? createdAt : 0,
-  );
 }
 
 function fetchOpenItemPage(
@@ -6134,13 +5830,6 @@ function oldestUnreviewedAt(candidates: readonly DueCandidate[]): string | undef
     oldest = candidate.item.createdAt;
   }
   return oldest;
-}
-
-export function shouldStopSaturatedPlanScan(options: {
-  dueCount: number;
-  capacity: number;
-}): boolean {
-  return options.capacity > 0 && options.dueCount >= options.capacity;
 }
 
 function planCapacityReason(options: {

--- a/src/scheduler-policy.ts
+++ b/src/scheduler-policy.ts
@@ -1,0 +1,409 @@
+export type SchedulerItemKind = "issue" | "pull_request";
+
+export interface SchedulerItem {
+  repo: string;
+  number: number;
+  kind: SchedulerItemKind;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SchedulerExistingReview {
+  reviewedAt?: string | undefined;
+  itemUpdatedAt?: string | undefined;
+  reviewCommentSyncedAt?: string | undefined;
+  labelsSyncedAt?: string | undefined;
+  reviewStatus?: string | undefined;
+  reviewPolicy?: string | undefined;
+}
+
+export type SchedulerBucket =
+  | "hot_issue"
+  | "hot_pull_request"
+  | "activity"
+  | "daily_pull_request"
+  | "recent_issue"
+  | "weekly_issue";
+
+export interface SchedulerDueCandidate<
+  ItemT extends SchedulerItem = SchedulerItem,
+  ReviewT extends SchedulerExistingReview = SchedulerExistingReview,
+> {
+  item: ItemT;
+  review: ReviewT | null;
+  priority: number;
+  reviewedAt: number;
+  nextDueAt: number;
+  bucket: SchedulerBucket;
+}
+
+const HOT_REVIEW_DAYS = 7;
+const RECENT_ISSUE_DAYS = 30;
+const HOURLY_REVIEW_MS = 60 * 60 * 1000;
+const DAILY_REVIEW_DAYS = 1;
+const WEEKLY_REVIEW_DAYS = 7;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function timestampMs(value: string | undefined): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function schedulerItemKey(repo: string, number: number): string {
+  return `${repo}#${number}`;
+}
+
+export function reviewedAtMs(review: SchedulerExistingReview | null): number | null {
+  if (review?.reviewStatus !== "complete") return null;
+  if (!review.reviewedAt) return null;
+  const reviewedAt = Date.parse(review.reviewedAt);
+  return Number.isFinite(reviewedAt) ? reviewedAt : null;
+}
+
+function hasActivitySinceReview(
+  item: SchedulerItem,
+  review: SchedulerExistingReview | null,
+): boolean {
+  if (!review) return false;
+  const updatedAt = Date.parse(item.updatedAt);
+  const reviewedAt = reviewedAtMs(review);
+  const reviewCommentSyncedAt = timestampMs(review.reviewCommentSyncedAt);
+  const labelsSyncedAt = timestampMs(review.labelsSyncedAt);
+  const botOwnedSyncedAt = Math.max(
+    reviewCommentSyncedAt ?? -Infinity,
+    labelsSyncedAt ?? -Infinity,
+  );
+  if (review.itemUpdatedAt) {
+    if (item.updatedAt === review.itemUpdatedAt) return false;
+    if (Number.isFinite(updatedAt) && reviewedAt !== null && updatedAt <= reviewedAt) return false;
+    if (
+      Number.isFinite(updatedAt) &&
+      Number.isFinite(botOwnedSyncedAt) &&
+      updatedAt <= botOwnedSyncedAt
+    ) {
+      return false;
+    }
+    return true;
+  }
+  if (
+    Number.isFinite(updatedAt) &&
+    Number.isFinite(botOwnedSyncedAt) &&
+    updatedAt <= botOwnedSyncedAt
+  ) {
+    return false;
+  }
+  return reviewedAt !== null && Number.isFinite(updatedAt) && updatedAt > reviewedAt;
+}
+
+function isCreatedWithinDays(
+  item: Pick<SchedulerItem, "createdAt">,
+  days: number,
+  now = Date.now(),
+): boolean {
+  const createdAt = Date.parse(item.createdAt);
+  return Number.isFinite(createdAt) && now - createdAt < days * DAY_MS;
+}
+
+function reviewCadenceMs(
+  item: SchedulerItem,
+  review: SchedulerExistingReview | null,
+  now = Date.now(),
+): number {
+  if (hasActivitySinceReview(item, review)) return HOURLY_REVIEW_MS;
+  if (isCreatedWithinDays(item, HOT_REVIEW_DAYS, now)) return DAILY_REVIEW_DAYS * DAY_MS;
+  if (item.kind === "pull_request") return DAILY_REVIEW_DAYS * DAY_MS;
+  const createdAt = Date.parse(item.createdAt);
+  if (Number.isFinite(createdAt) && now - createdAt < RECENT_ISSUE_DAYS * DAY_MS) {
+    return DAILY_REVIEW_DAYS * DAY_MS;
+  }
+  return WEEKLY_REVIEW_DAYS * DAY_MS;
+}
+
+export function hasReviewPolicyMismatch(
+  review: SchedulerExistingReview | null,
+  reviewPolicy?: string,
+): boolean {
+  return Boolean(review && reviewPolicy && review.reviewPolicy !== reviewPolicy);
+}
+
+export function shouldReviewItem(
+  item: SchedulerItem,
+  review: SchedulerExistingReview | null,
+  now = Date.now(),
+  reviewPolicy?: string,
+): boolean {
+  if (hasReviewPolicyMismatch(review, reviewPolicy)) return true;
+  const reviewedAt = reviewedAtMs(review);
+  if (reviewedAt === null) return true;
+  return now - reviewedAt >= reviewCadenceMs(item, review, now);
+}
+
+export function reviewPriority(
+  item: SchedulerItem,
+  review: SchedulerExistingReview | null,
+  now = Date.now(),
+  reviewPolicy?: string,
+): number {
+  if (isCreatedWithinDays(item, HOT_REVIEW_DAYS, now) && item.kind === "issue") return 0;
+  if (isCreatedWithinDays(item, HOT_REVIEW_DAYS, now)) return 1;
+  if (hasActivitySinceReview(item, review)) return 2;
+  if (item.kind === "pull_request") return 3;
+  const createdAt = Date.parse(item.createdAt);
+  if (Number.isFinite(createdAt) && now - createdAt < RECENT_ISSUE_DAYS * DAY_MS) return 4;
+  if (hasReviewPolicyMismatch(review, reviewPolicy)) return 5;
+  return 6;
+}
+
+export function schedulerBucket(
+  item: SchedulerItem,
+  review: SchedulerExistingReview | null,
+  now = Date.now(),
+): SchedulerBucket {
+  if (isCreatedWithinDays(item, HOT_REVIEW_DAYS, now)) {
+    return item.kind === "issue" ? "hot_issue" : "hot_pull_request";
+  }
+  if (hasActivitySinceReview(item, review)) return "activity";
+  if (item.kind === "pull_request") return "daily_pull_request";
+  const createdAt = Date.parse(item.createdAt);
+  if (Number.isFinite(createdAt) && now - createdAt < RECENT_ISSUE_DAYS * DAY_MS) {
+    return "recent_issue";
+  }
+  return "weekly_issue";
+}
+
+export function nextReviewDueAtMs(
+  item: SchedulerItem,
+  review: SchedulerExistingReview | null,
+  now = Date.now(),
+  reviewPolicy?: string,
+): number {
+  if (hasReviewPolicyMismatch(review, reviewPolicy)) return 0;
+  const reviewedAt = reviewedAtMs(review);
+  if (reviewedAt === null) return 0;
+  return reviewedAt + reviewCadenceMs(item, review, now);
+}
+
+export function compareDueCandidates<
+  ItemT extends SchedulerItem,
+  ReviewT extends SchedulerExistingReview,
+>(
+  left: SchedulerDueCandidate<ItemT, ReviewT>,
+  right: SchedulerDueCandidate<ItemT, ReviewT>,
+): number {
+  return (
+    left.priority - right.priority ||
+    left.nextDueAt - right.nextDueAt ||
+    left.reviewedAt - right.reviewedAt ||
+    left.item.number - right.item.number
+  );
+}
+
+function compareBackfillCandidates<
+  ItemT extends SchedulerItem,
+  ReviewT extends SchedulerExistingReview,
+>(
+  left: SchedulerDueCandidate<ItemT, ReviewT>,
+  right: SchedulerDueCandidate<ItemT, ReviewT>,
+): number {
+  return (
+    left.nextDueAt - right.nextDueAt ||
+    left.reviewedAt - right.reviewedAt ||
+    left.priority - right.priority ||
+    left.item.number - right.item.number
+  );
+}
+
+function weeklyReviewDeadlineMs(candidate: SchedulerDueCandidate): number {
+  if (candidate.reviewedAt > 0) {
+    return candidate.reviewedAt + WEEKLY_REVIEW_DAYS * DAY_MS;
+  }
+  const createdAt = Date.parse(candidate.item.createdAt);
+  return Number.isFinite(createdAt) ? createdAt + WEEKLY_REVIEW_DAYS * DAY_MS : 0;
+}
+
+const SCHEDULER_BUCKET_WEIGHTS: ReadonlyArray<readonly [SchedulerBucket, number]> = [
+  ["hot_issue", 4],
+  ["hot_pull_request", 2],
+  ["activity", 2],
+  ["daily_pull_request", 3],
+  ["recent_issue", 2],
+  ["weekly_issue", 1],
+];
+
+export function selectDueCandidates<
+  ItemT extends SchedulerItem,
+  ReviewT extends SchedulerExistingReview,
+>(
+  due: Array<SchedulerDueCandidate<ItemT, ReviewT>>,
+  limit: number,
+  compare: (
+    left: SchedulerDueCandidate<ItemT, ReviewT>,
+    right: SchedulerDueCandidate<ItemT, ReviewT>,
+  ) => number = compareDueCandidates,
+  now = Date.now(),
+): Array<SchedulerDueCandidate<ItemT, ReviewT>> {
+  const capacity = Math.max(0, limit);
+  if (capacity === 0) return [];
+  const buckets = new Map<SchedulerBucket, Array<SchedulerDueCandidate<ItemT, ReviewT>>>();
+  for (const [bucket] of SCHEDULER_BUCKET_WEIGHTS) buckets.set(bucket, []);
+  for (const candidate of due) buckets.get(candidate.bucket)?.push(candidate);
+  for (const candidates of buckets.values()) candidates.sort(compare);
+
+  const selected: Array<SchedulerDueCandidate<ItemT, ReviewT>> = [];
+  const selectedKeys = new Set<string>();
+  const take = (candidate: SchedulerDueCandidate<ItemT, ReviewT> | undefined): void => {
+    if (!candidate || selected.length >= capacity) return;
+    const key = schedulerItemKey(candidate.item.repo, candidate.item.number);
+    if (selectedKeys.has(key)) return;
+    selectedKeys.add(key);
+    selected.push(candidate);
+  };
+
+  // Weekly freshness is the outer SLO. Catch up breached items before applying
+  // the normal weighted mix for hourly and daily work.
+  const weeklyOverdue = due
+    .filter((candidate) => weeklyReviewDeadlineMs(candidate) <= now)
+    .sort(
+      (left, right) =>
+        weeklyReviewDeadlineMs(left) - weeklyReviewDeadlineMs(right) || compare(left, right),
+    );
+  for (const candidate of weeklyOverdue) take(candidate);
+  for (const [bucket, candidates] of buckets) {
+    buckets.set(
+      bucket,
+      candidates.filter(
+        (candidate) =>
+          !selectedKeys.has(schedulerItemKey(candidate.item.repo, candidate.item.number)),
+      ),
+    );
+  }
+
+  while (selected.length < capacity) {
+    const before = selected.length;
+    for (const [bucket, weight] of SCHEDULER_BUCKET_WEIGHTS) {
+      const candidates = buckets.get(bucket);
+      if (!candidates?.length) continue;
+      for (let i = 0; i < weight && candidates.length && selected.length < capacity; i += 1) {
+        take(candidates.shift());
+      }
+    }
+    if (selected.length === before) break;
+  }
+
+  return selected;
+}
+
+export function appendFloorBackfillCandidates<
+  ItemT extends SchedulerItem,
+  ReviewT extends SchedulerExistingReview,
+>(
+  selected: Array<SchedulerDueCandidate<ItemT, ReviewT>>,
+  backfill: Array<SchedulerDueCandidate<ItemT, ReviewT>>,
+  options: { activeFloor: number; capacity: number },
+): Array<SchedulerDueCandidate<ItemT, ReviewT>> {
+  const activeFloor = Math.max(0, Math.floor(options.activeFloor));
+  const capacity = Math.max(0, Math.floor(options.capacity));
+  const target = Math.min(activeFloor, capacity);
+  if (selected.length >= target) return selected;
+  const selectedKeys = new Set(
+    selected.map((candidate) => schedulerItemKey(candidate.item.repo, candidate.item.number)),
+  );
+  const filled = [...selected];
+  for (const candidate of [...backfill].sort(compareBackfillCandidates)) {
+    if (filled.length >= target) break;
+    const key = schedulerItemKey(candidate.item.repo, candidate.item.number);
+    if (selectedKeys.has(key)) continue;
+    selectedKeys.add(key);
+    filled.push(candidate);
+  }
+  return filled;
+}
+
+export function selectDueCandidateNumbersForTest(
+  due: Array<{
+    item: SchedulerItem;
+    bucket: SchedulerBucket;
+    priority?: number;
+    reviewedAt?: number;
+    nextDueAt?: number;
+  }>,
+  limit: number,
+  now = Date.now(),
+): number[] {
+  return selectDueCandidates(
+    due.map((candidate) => ({
+      item: candidate.item,
+      review: null,
+      priority: candidate.priority ?? reviewPriority(candidate.item, null),
+      reviewedAt: candidate.reviewedAt ?? 0,
+      nextDueAt: candidate.nextDueAt ?? 0,
+      bucket: candidate.bucket,
+    })),
+    limit,
+    compareDueCandidates,
+    now,
+  ).map((candidate) => candidate.item.number);
+}
+
+export function appendFloorBackfillCandidateNumbersForTest(
+  selected: Array<{
+    item: SchedulerItem;
+    bucket: SchedulerBucket;
+    priority?: number;
+    reviewedAt?: number;
+    nextDueAt?: number;
+  }>,
+  backfill: Array<{
+    item: SchedulerItem;
+    bucket: SchedulerBucket;
+    priority?: number;
+    reviewedAt?: number;
+    nextDueAt?: number;
+  }>,
+  activeFloor: number,
+  capacity: number,
+): number[] {
+  const normalize = (candidate: (typeof selected)[number]): SchedulerDueCandidate => ({
+    item: candidate.item,
+    review: null,
+    priority: candidate.priority ?? reviewPriority(candidate.item, null),
+    reviewedAt: candidate.reviewedAt ?? 0,
+    nextDueAt: candidate.nextDueAt ?? 0,
+    bucket: candidate.bucket,
+  });
+  return appendFloorBackfillCandidates(selected.map(normalize), backfill.map(normalize), {
+    activeFloor,
+    capacity,
+  }).map((candidate) => candidate.item.number);
+}
+
+export function compareHotIntakeDueCandidates<
+  ItemT extends SchedulerItem,
+  ReviewT extends SchedulerExistingReview,
+>(
+  left: SchedulerDueCandidate<ItemT, ReviewT>,
+  right: SchedulerDueCandidate<ItemT, ReviewT>,
+): number {
+  return (
+    left.priority - right.priority ||
+    hotIntakeRecencyMs(right.item) - hotIntakeRecencyMs(left.item) ||
+    right.item.number - left.item.number
+  );
+}
+
+export function hotIntakeRecencyMs(item: Pick<SchedulerItem, "createdAt" | "updatedAt">): number {
+  const updatedAt = Date.parse(item.updatedAt);
+  const createdAt = Date.parse(item.createdAt);
+  return Math.max(
+    Number.isFinite(updatedAt) ? updatedAt : 0,
+    Number.isFinite(createdAt) ? createdAt : 0,
+  );
+}
+
+export function shouldStopSaturatedPlanScan(options: {
+  dueCount: number;
+  capacity: number;
+}): boolean {
+  return options.capacity > 0 && options.dueCount >= options.capacity;
+}

--- a/src/scheduler-policy.ts
+++ b/src/scheduler-policy.ts
@@ -320,64 +320,6 @@ export function appendFloorBackfillCandidates<
   return filled;
 }
 
-export function selectDueCandidateNumbersForTest(
-  due: Array<{
-    item: SchedulerItem;
-    bucket: SchedulerBucket;
-    priority?: number;
-    reviewedAt?: number;
-    nextDueAt?: number;
-  }>,
-  limit: number,
-  now = Date.now(),
-): number[] {
-  return selectDueCandidates(
-    due.map((candidate) => ({
-      item: candidate.item,
-      review: null,
-      priority: candidate.priority ?? reviewPriority(candidate.item, null),
-      reviewedAt: candidate.reviewedAt ?? 0,
-      nextDueAt: candidate.nextDueAt ?? 0,
-      bucket: candidate.bucket,
-    })),
-    limit,
-    compareDueCandidates,
-    now,
-  ).map((candidate) => candidate.item.number);
-}
-
-export function appendFloorBackfillCandidateNumbersForTest(
-  selected: Array<{
-    item: SchedulerItem;
-    bucket: SchedulerBucket;
-    priority?: number;
-    reviewedAt?: number;
-    nextDueAt?: number;
-  }>,
-  backfill: Array<{
-    item: SchedulerItem;
-    bucket: SchedulerBucket;
-    priority?: number;
-    reviewedAt?: number;
-    nextDueAt?: number;
-  }>,
-  activeFloor: number,
-  capacity: number,
-): number[] {
-  const normalize = (candidate: (typeof selected)[number]): SchedulerDueCandidate => ({
-    item: candidate.item,
-    review: null,
-    priority: candidate.priority ?? reviewPriority(candidate.item, null),
-    reviewedAt: candidate.reviewedAt ?? 0,
-    nextDueAt: candidate.nextDueAt ?? 0,
-    bucket: candidate.bucket,
-  });
-  return appendFloorBackfillCandidates(selected.map(normalize), backfill.map(normalize), {
-    activeFloor,
-    capacity,
-  }).map((candidate) => candidate.item.number);
-}
-
 export function compareHotIntakeDueCandidates<
   ItemT extends SchedulerItem,
   ReviewT extends SchedulerExistingReview,

--- a/test/scheduler-policy.test.ts
+++ b/test/scheduler-policy.test.ts
@@ -2,28 +2,38 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
-  appendFloorBackfillCandidateNumbersForTest,
+  appendFloorBackfillCandidates,
   hotIntakeRecencyMs,
   reviewPriority,
-  selectDueCandidateNumbersForTest,
+  selectDueCandidates,
   shouldReviewItem,
   shouldStopSaturatedPlanScan,
 } from "../dist/scheduler-policy.js";
+import { item } from "./helpers.ts";
 
-function item(overrides = {}) {
+function schedulerCandidate(candidate) {
   return {
-    repo: "openclaw/openclaw",
-    number: 123,
-    kind: "issue",
-    title: "Sample item",
-    url: "https://github.com/openclaw/openclaw/issues/123",
-    createdAt: "2026-01-01T00:00:00Z",
-    updatedAt: "2026-01-01T00:00:00Z",
-    author: "contributor",
-    authorAssociation: "NONE",
-    labels: [],
-    ...overrides,
+    item: candidate.item,
+    review: null,
+    priority: candidate.priority ?? reviewPriority(candidate.item, null),
+    reviewedAt: candidate.reviewedAt ?? 0,
+    nextDueAt: candidate.nextDueAt ?? 0,
+    bucket: candidate.bucket,
   };
+}
+
+function selectedNumbers(due, limit, now) {
+  return selectDueCandidates(due.map(schedulerCandidate), limit, undefined, now).map(
+    (candidate) => candidate.item.number,
+  );
+}
+
+function backfilledNumbers(selected, backfill, activeFloor, capacity) {
+  return appendFloorBackfillCandidates(
+    selected.map(schedulerCandidate),
+    backfill.map(schedulerCandidate),
+    { activeFloor, capacity },
+  ).map((candidate) => candidate.item.number);
 }
 
 test("review policy changes force fresh complete reports back into planning", () => {
@@ -345,7 +355,7 @@ test("normal scheduler reserves throughput for PR and older buckets", () => {
     },
   );
 
-  assert.deepEqual(selectDueCandidateNumbersForTest(due, 8, now), [1, 2, 3, 4, 101, 201, 301, 5]);
+  assert.deepEqual(selectedNumbers(due, 8, now), [1, 2, 3, 4, 101, 201, 301, 5]);
 });
 
 test("normal scheduler prioritizes items already breaching weekly freshness", () => {
@@ -383,7 +393,7 @@ test("normal scheduler prioritizes items already breaching weekly freshness", ()
     },
   ];
 
-  assert.deepEqual(selectDueCandidateNumbersForTest(due, 3, now), [3, 2, 1]);
+  assert.deepEqual(selectedNumbers(due, 3, now), [3, 2, 1]);
 });
 
 test("weekly freshness preselection still fills remaining scheduler capacity", () => {
@@ -421,7 +431,7 @@ test("weekly freshness preselection still fills remaining scheduler capacity", (
     },
   );
 
-  assert.deepEqual(selectDueCandidateNumbersForTest(due, 7, now), [1, 2, 3, 4, 5, 7, 6]);
+  assert.deepEqual(selectedNumbers(due, 7, now), [1, 2, 3, 4, 5, 7, 6]);
 });
 
 test("normal scheduler can fill active floor from stale current reviews", () => {
@@ -457,11 +467,8 @@ test("normal scheduler can fill active floor from stale current reviews", () => 
     },
   ];
 
-  assert.deepEqual(
-    appendFloorBackfillCandidateNumbersForTest(selected, backfill, 3, 10),
-    [1, 10, 11],
-  );
-  assert.deepEqual(appendFloorBackfillCandidateNumbersForTest(selected, backfill, 3, 2), [1, 10]);
+  assert.deepEqual(backfilledNumbers(selected, backfill, 3, 10), [1, 10, 11]);
+  assert.deepEqual(backfilledNumbers(selected, backfill, 3, 2), [1, 10]);
 });
 
 test("normal scheduler can stop scanning once planned capacity is saturated", () => {

--- a/test/scheduler-policy.test.ts
+++ b/test/scheduler-policy.test.ts
@@ -8,8 +8,23 @@ import {
   selectDueCandidateNumbersForTest,
   shouldReviewItem,
   shouldStopSaturatedPlanScan,
-} from "../dist/clawsweeper.js";
-import { item } from "./helpers.ts";
+} from "../dist/scheduler-policy.js";
+
+function item(overrides = {}) {
+  return {
+    repo: "openclaw/openclaw",
+    number: 123,
+    kind: "issue",
+    title: "Sample item",
+    url: "https://github.com/openclaw/openclaw/issues/123",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    author: "contributor",
+    authorAssociation: "NONE",
+    labels: [],
+    ...overrides,
+  };
+}
 
 test("review policy changes force fresh complete reports back into planning", () => {
   const reviewedAt = new Date().toISOString();


### PR DESCRIPTION
## What Problem This Solves

Scheduler policy lived inside the large CLI module, coupling pure candidate-selection decisions to orchestration and making behavior-preserving scheduler changes harder to review and test.

## Why This Change Was Made

Extract the stable scheduler policy into `src/scheduler-policy.ts`. The CLI still owns GitHub I/O and orchestration; the new module owns pure capacity, ordering, floor-backfill, and partition decisions. Runtime exports are limited to production callers, while tests exercise the pure helpers directly.

## User Impact

No intended scheduling behavior change. The scheduler keeps the same selection order, capacity rules, floor backfill, and shard partitioning with a smaller owner boundary.

## Evidence

- Rebased on current `main` at `d20cf36edb6bbcd499e2e1980e88e8ecc77e7f1b`.
- Deterministic equivalence harness: 5,000 randomized inputs / 30,000 assertions against the pre-extraction implementation.
- Focused scheduler suite: 12/12 passing.
- `pnpm run build`, full `pnpm run lint`, `pnpm run format:check`, and `git diff --check`: passing.
- Whole-branch autoreview: clean at 0.88 confidence.
- Live read-only plan against `openclaw/openclaw`: 22 shards, 66 selected items, 93 due backlog, 22 active Codex targets; saturated-capacity decision preserved.
- Production diff: 351-line policy module replaces 335 lines in the CLI; net +31 production lines, with no second runtime path or compatibility facade.
