### PR TITLE
fix: let maintainer automerge resume paused PRs

### DIFF
--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -773,9 +773,17 @@ export function existingModeStatusBlocksReplay({
 export function pausedModeStatusBlocksReplay({
   hasPauseLabels,
   hasExistingModeStatusResponse,
+  allowNewMaintainerModeCommand,
   forceReprocess,
 }: LooseRecord = {}) {
-  return Boolean(hasPauseLabels) && Boolean(hasExistingModeStatusResponse) && !forceReprocess;
+  // A fresh maintainer mode command is the explicit resume path after `stop`;
+  // historical/replayed mode status must stay blocked by the pause label.
+  return (
+    Boolean(hasPauseLabels) &&
+    Boolean(hasExistingModeStatusResponse) &&
+    !allowNewMaintainerModeCommand &&
+    !forceReprocess
+  );
 }
 
 export function isMaintainerCommandAllowed({

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -786,6 +786,18 @@ export function pausedModeStatusBlocksReplay({
   );
 }
 
+export function maintainerModeCommandCanResumePausedMode({
+  command,
+  entries = [],
+}: LooseRecord = {}) {
+  if (command?.trusted_bot) return false;
+  if (!["autofix", "automerge"].includes(String(command?.intent ?? ""))) return false;
+  const commandAt = repairLoopControlTime(command);
+  if (!commandAt) return false;
+  const pauseAt = latestRepairLoopPauseTime(entries, command);
+  return pauseAt > 0 && commandAt > pauseAt;
+}
+
 export function isMaintainerCommandAllowed({
   authorAssociation,
   repositoryPermission = null,
@@ -2391,6 +2403,28 @@ export function repairLoopStopPauseReason({ command, entries = [] }: LooseRecord
 
   if (stopAt <= resumeAt) return null;
   return "ClawSweeper automation was paused by a later /clawsweeper stop command";
+}
+
+function latestRepairLoopPauseTime(entries: JsonValue, command: LooseRecord) {
+  if (!Array.isArray(entries)) return 0;
+  let latest = 0;
+  for (const entry of entries) {
+    if (!entry || typeof entry !== "object") continue;
+    if (entry.repo !== command?.repo) continue;
+    if (Number(entry.issue_number) !== Number(command?.issue_number)) continue;
+    if (!isRepairLoopPauseEntry(entry)) continue;
+    latest = Math.max(latest, repairLoopControlTime(entry));
+  }
+  return latest;
+}
+
+function isRepairLoopPauseEntry(entry: LooseRecord) {
+  if (String(entry.intent ?? "") === "stop") return true;
+  if (String(entry.intent ?? "") !== "clawsweeper_needs_human") return false;
+  return (entry.actions ?? []).some(
+    (action: JsonValue) =>
+      action.action === "label" && String(action.label ?? "") === HUMAN_REVIEW_LABEL,
+  );
 }
 
 function latestRepairLoopControlTime(entries: JsonValue, command: LooseRecord, intents: string[]) {

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -54,6 +54,7 @@ import {
   issueImplementationClusterId,
   issueImplementationJobPath,
   isReadyHumanReviewPause,
+  maintainerModeCommandCanResumePausedMode,
   maintainerAutomergeOptInApprovesNeedsHuman as maintainerAutomergeOptInApprovesNeedsHumanReason,
   latestRepairLoopResumeTime,
   parseRoutedCommentCommand,
@@ -655,7 +656,10 @@ function classifyCommand(command: LooseRecord): JsonValue {
           command.issue_number,
           command.intent,
         ),
-        allowNewMaintainerModeCommand: !command.trusted_bot,
+        allowNewMaintainerModeCommand: maintainerModeCommandCanResumePausedMode({
+          command: next,
+          entries: repairLoopControlEntries(),
+        }),
         forceReprocess,
       })
     ) {
@@ -1407,7 +1411,9 @@ function repairLoopControlEntries() {
 }
 
 function isRepairLoopControlIntent(command: LooseRecord) {
-  return ["stop", "autofix", "automerge"].includes(String(command?.intent ?? ""));
+  return ["stop", "autofix", "automerge", "clawsweeper_needs_human"].includes(
+    String(command?.intent ?? ""),
+  );
 }
 
 function executeCommand(command: LooseRecord) {

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -655,6 +655,7 @@ function classifyCommand(command: LooseRecord): JsonValue {
           command.issue_number,
           command.intent,
         ),
+        allowNewMaintainerModeCommand: !command.trusted_bot,
         forceReprocess,
       })
     ) {

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -535,6 +535,26 @@ test("force reprocess bypasses existing command status guards", () => {
     pausedModeStatusBlocksReplay({
       hasPauseLabels: true,
       hasExistingModeStatusResponse: true,
+      allowNewMaintainerModeCommand: true,
+      forceReprocess: false,
+    }),
+    false,
+    "old shared automerge status plus human-review must not block a fresh maintainer automerge command",
+  );
+  assert.equal(
+    pausedModeStatusBlocksReplay({
+      hasPauseLabels: true,
+      hasExistingModeStatusResponse: true,
+      allowNewMaintainerModeCommand: false,
+      forceReprocess: false,
+    }),
+    true,
+    "bot replay and label-sweep mode status should stay paused until a maintainer asks again",
+  );
+  assert.equal(
+    pausedModeStatusBlocksReplay({
+      hasPauseLabels: true,
+      hasExistingModeStatusResponse: true,
       forceReprocess: true,
     }),
     false,

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -45,6 +45,7 @@ import {
   isMaintainerCommandAllowed,
   isIssueImplementationCommandAllowed,
   maintainerAutomergeOptInApprovesNeedsHuman,
+  maintainerModeCommandCanResumePausedMode,
   parseCommand,
   parseRoutedCommentCommand,
   planCommandAckConvergence,
@@ -712,6 +713,63 @@ test("later stop command pauses older automerge automation", () => {
       entries,
     }),
     null,
+  );
+});
+
+test("paused mode resume requires a maintainer command after the pause", () => {
+  const entries = [
+    {
+      repo: "openclaw/openclaw",
+      issue_number: 93209,
+      intent: "automerge",
+      status: "executed",
+      comment_updated_at: "2026-06-15T09:45:21Z",
+    },
+    {
+      repo: "openclaw/openclaw",
+      issue_number: 93209,
+      intent: "stop",
+      status: "executed",
+      comment_updated_at: "2026-06-15T09:45:57Z",
+    },
+  ];
+
+  assert.equal(
+    maintainerModeCommandCanResumePausedMode({
+      command: {
+        repo: "openclaw/openclaw",
+        issue_number: 93209,
+        intent: "automerge",
+        comment_updated_at: "2026-06-15T09:45:21Z",
+      },
+      entries,
+    }),
+    false,
+  );
+  assert.equal(
+    maintainerModeCommandCanResumePausedMode({
+      command: {
+        repo: "openclaw/openclaw",
+        issue_number: 93209,
+        intent: "automerge",
+        comment_updated_at: "2026-07-02T02:31:23Z",
+      },
+      entries,
+    }),
+    true,
+  );
+  assert.equal(
+    maintainerModeCommandCanResumePausedMode({
+      command: {
+        repo: "openclaw/openclaw",
+        issue_number: 93209,
+        intent: "automerge",
+        trusted_bot: true,
+        comment_updated_at: "2026-07-02T02:31:23Z",
+      },
+      entries,
+    }),
+    false,
   );
 });
 


### PR DESCRIPTION
## Summary

Fix the comment router pause guard so a fresh maintainer `@clawsweeper automerge` command can resume a PR after `@clawsweeper stop` left it paused for human review.

## Root Cause

https://github.com/openclaw/openclaw/pull/93209 exposed a replay-guard bug in the automerge command router. The PR had an older shared automerge status comment, then a later `@clawsweeper stop` removed `clawsweeper:automerge` and added `clawsweeper:human-review`. When a maintainer later posted a new `@clawsweeper automerge`, `pausedModeStatusBlocksReplay()` saw the pause label plus the old status comment and classified the fresh maintainer command as skipped. That meant both `approve` and `automerge` could fail to recover the paused lane without manual label removal.

## Changes

- Allow only a fresh non-bot maintainer mode command to bypass the paused-mode replay guard.
- Keep bot/replay/label-sweep status handling blocked while a pause label remains.
- Add regression assertions for the old shared automerge status plus human-review pause case.

## Validation

- `pnpm run build:repair && node --test test/repair/comment-router-core.test.ts`
- `pnpm run check`
