### PR TITLE
fix: prevent stale PR review labels from persisting

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -15168,6 +15168,76 @@ function pullHeadShaFromReport(markdown: string): string | null {
   return value && value !== "unknown" ? value : null;
 }
 
+type StalePullRequestReviewHead = {
+  reportHeadSha: string;
+  liveHeadSha: string;
+  reason: string;
+};
+
+function stalePullRequestReviewHead(
+  markdown: string,
+  context: ItemContext,
+): StalePullRequestReviewHead | null {
+  if (frontMatterValue(markdown, "type") !== "pull_request") return null;
+  const reportHeadSha = pullHeadShaFromReport(markdown);
+  const liveHeadSha = pullHeadShaFromContext(context);
+  if (!reportHeadSha || !liveHeadSha || reportHeadSha === liveHeadSha) return null;
+  return {
+    reportHeadSha,
+    liveHeadSha,
+    reason: `live PR head ${liveHeadSha} differs from reviewed head ${reportHeadSha}`,
+  };
+}
+
+function isStalePullRequestReviewLabel(label: string): boolean {
+  return (
+    isClawSweeperOwnedLabel(label) &&
+    !PRIORITY_LABEL_NAMES.has(label) &&
+    !IMPACT_LABEL_NAMES.has(label) &&
+    !MATURITY_LABEL_NAMES.has(label) &&
+    !isIssueAdvisoryLabel(label)
+  );
+}
+
+function syncStalePullRequestReviewLabels(options: {
+  number: number;
+  labels: readonly string[];
+  dryRun: boolean;
+}): { labels: string[]; changed: boolean } {
+  const labelsToRemove = options.labels.filter(isStalePullRequestReviewLabel);
+  if (labelsToRemove.length === 0) return { labels: [...options.labels], changed: false };
+  const nextLabels = options.labels.filter((label) => !labelsToRemove.includes(label));
+  if (!options.dryRun) {
+    for (const label of labelsToRemove) {
+      ghWithRetry(["issue", "edit", String(options.number), "--remove-label", label]);
+    }
+  }
+  return { labels: nextLabels, changed: true };
+}
+
+function stalePullRequestReviewComment(options: {
+  number: number;
+  stale: StalePullRequestReviewHead;
+}): string {
+  const attrs = [
+    `item=${markerAttributeValue(String(options.number))}`,
+    `reviewed_sha=${markerAttributeValue(options.stale.reportHeadSha)}`,
+    `current_sha=${markerAttributeValue(options.stale.liveHeadSha)}`,
+    "reason=stale_head",
+  ].join(" ");
+  return [
+    "Codex review: stale review; fresh review needed.",
+    "",
+    "**Summary**",
+    `The latest durable ClawSweeper review was for head \`${options.stale.reportHeadSha}\`, but the PR head is now \`${options.stale.liveHeadSha}\`. Its old verdict and PR readiness labels are no longer current.`,
+    "",
+    "**Next step**",
+    "Run or wait for a fresh ClawSweeper review on the current PR head.",
+    "",
+    `<!-- clawsweeper-review-status:stale ${attrs} -->`,
+  ].join("\n");
+}
+
 function markerAttributeValue(value: string): string {
   return value.trim().replace(/[^\w./:@-]/g, "_") || "unknown";
 }
@@ -17431,68 +17501,110 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
         continue;
       }
     }
+    const existingReviewComment = issueReviewComment(number, [
+      renderReviewCommentFromReport(markdown, closeReason ?? "none", { previousLabels }),
+      reviewSectionValue(markdown, "closeComment"),
+    ]);
+    const existingReviewCommentUpdatedAt = commentUpdatedAt(existingReviewComment);
+    if (existingReviewCommentUpdatedAt) {
+      allowedSelfMutationUpdatedAts.add(existingReviewCommentUpdatedAt);
+    }
+    const updatedSinceReview = Boolean(storedUpdatedAt && item.updatedAt !== storedUpdatedAt);
+    const reviewCommentOnlyUpdate = item.updatedAt === commentUpdatedAt(existingReviewComment);
+    const labelSyncFreshEnough = (): boolean => {
+      if (!storedUpdatedAt) return false;
+      if (!updatedSinceReview || reviewCommentOnlyUpdate) return true;
+      const existingReviewCommentUpdatedAtMs = timestampMs(commentUpdatedAt(existingReviewComment));
+      const itemUpdatedAtMs = timestampMs(item.updatedAt);
+      if (existingReviewCommentUpdatedAtMs === null || itemUpdatedAtMs === null) return false;
+      if (Math.abs(itemUpdatedAtMs - existingReviewCommentUpdatedAtMs) > 5 * 60 * 1000) {
+        return false;
+      }
+      const storedUpdatedAtMs = timestampMs(storedUpdatedAt);
+      if (storedUpdatedAtMs === null) return false;
+      return !contextHasNonAutomationActivityAfter(currentItemContext(), storedUpdatedAtMs);
+    };
+    const stalePrReviewHead =
+      state === "open" && item.kind === "pull_request"
+        ? stalePullRequestReviewHead(markdown, currentItemContext())
+        : null;
     let currentPrStatusKind: PrStatusLabelKind | null = null;
     if (state === "open" && item.kind === "pull_request") {
-      const realBehaviorProof = reportRealBehaviorProof(markdown);
-      const proofSufficientSyncResult = syncRealBehaviorProofSufficientLabel({
-        number,
-        labels: item.labels,
-        proof: realBehaviorProof,
-        dryRun,
-      });
-      item.labels = proofSufficientSyncResult.labels;
-      clawSweeperLabelsChanged ||= proofSufficientSyncResult.changed;
-      const proofMediaSyncResult = syncRealBehaviorProofMediaLabels({
-        number,
-        labels: item.labels,
-        proof: realBehaviorProof,
-        dryRun,
-      });
-      item.labels = proofMediaSyncResult.labels;
-      clawSweeperLabelsChanged ||= proofMediaSyncResult.changed;
-      const prRatingSyncResult = syncPrRatingLabel({
-        number,
-        labels: item.labels,
-        rating: reportPrRating(markdown),
-        reviewFailed: frontMatterValue(markdown, "review_status") === "failed",
-        dryRun,
-      });
-      item.labels = prRatingSyncResult.labels;
-      clawSweeperLabelsChanged ||= prRatingSyncResult.changed;
-      const featureShowcaseSyncResult = syncFeatureShowcaseLabel({
-        number,
-        labels: item.labels,
-        isPullRequest: true,
-        itemCategory: frontMatterValue(markdown, "item_category"),
-        requiresNewFeature: frontMatterValue(markdown, "requires_new_feature") === "true",
-        showcase: reportFeatureShowcase(markdown),
-        securityReview: reportSecurityReview(markdown),
-        overallCorrectness: reportOverallCorrectness(markdown),
-        dryRun,
-      });
-      item.labels = featureShowcaseSyncResult.labels;
-      clawSweeperLabelsChanged ||= featureShowcaseSyncResult.changed;
-      currentPrStatusKind = prStatusLabelKindFromReport(
-        markdown,
-        currentItemContext(),
-        item.labels,
-      );
-      const prStatusSyncResult = syncPrStatusLabel({
-        number,
-        labels: item.labels,
-        statusKind: currentPrStatusKind,
-        dryRun,
-      });
-      item.labels = prStatusSyncResult.labels;
-      clawSweeperLabelsChanged ||= prStatusSyncResult.changed;
-      const telegramVisibleProofSyncResult = syncTelegramVisibleProofLabel({
-        number,
-        labels: item.labels,
-        proof: reportTelegramVisibleProof(markdown),
-        dryRun,
-      });
-      item.labels = telegramVisibleProofSyncResult.labels;
-      clawSweeperLabelsChanged ||= telegramVisibleProofSyncResult.changed;
+      if (stalePrReviewHead) {
+        const staleLabelSyncResult = syncStalePullRequestReviewLabels({
+          number,
+          labels: item.labels,
+          dryRun,
+        });
+        item.labels = staleLabelSyncResult.labels;
+        clawSweeperLabelsChanged ||= staleLabelSyncResult.changed;
+        markdown = replaceFrontMatterValue(
+          markdown,
+          "current_pull_head_sha",
+          stalePrReviewHead.liveHeadSha,
+        );
+      } else if (labelSyncFreshEnough()) {
+        const realBehaviorProof = reportRealBehaviorProof(markdown);
+        const proofSufficientSyncResult = syncRealBehaviorProofSufficientLabel({
+          number,
+          labels: item.labels,
+          proof: realBehaviorProof,
+          dryRun,
+        });
+        item.labels = proofSufficientSyncResult.labels;
+        clawSweeperLabelsChanged ||= proofSufficientSyncResult.changed;
+        const proofMediaSyncResult = syncRealBehaviorProofMediaLabels({
+          number,
+          labels: item.labels,
+          proof: realBehaviorProof,
+          dryRun,
+        });
+        item.labels = proofMediaSyncResult.labels;
+        clawSweeperLabelsChanged ||= proofMediaSyncResult.changed;
+        const prRatingSyncResult = syncPrRatingLabel({
+          number,
+          labels: item.labels,
+          rating: reportPrRating(markdown),
+          reviewFailed: frontMatterValue(markdown, "review_status") === "failed",
+          dryRun,
+        });
+        item.labels = prRatingSyncResult.labels;
+        clawSweeperLabelsChanged ||= prRatingSyncResult.changed;
+        const featureShowcaseSyncResult = syncFeatureShowcaseLabel({
+          number,
+          labels: item.labels,
+          isPullRequest: true,
+          itemCategory: frontMatterValue(markdown, "item_category"),
+          requiresNewFeature: frontMatterValue(markdown, "requires_new_feature") === "true",
+          showcase: reportFeatureShowcase(markdown),
+          securityReview: reportSecurityReview(markdown),
+          overallCorrectness: reportOverallCorrectness(markdown),
+          dryRun,
+        });
+        item.labels = featureShowcaseSyncResult.labels;
+        clawSweeperLabelsChanged ||= featureShowcaseSyncResult.changed;
+        currentPrStatusKind = prStatusLabelKindFromReport(
+          markdown,
+          currentItemContext(),
+          item.labels,
+        );
+        const prStatusSyncResult = syncPrStatusLabel({
+          number,
+          labels: item.labels,
+          statusKind: currentPrStatusKind,
+          dryRun,
+        });
+        item.labels = prStatusSyncResult.labels;
+        clawSweeperLabelsChanged ||= prStatusSyncResult.changed;
+        const telegramVisibleProofSyncResult = syncTelegramVisibleProofLabel({
+          number,
+          labels: item.labels,
+          proof: reportTelegramVisibleProof(markdown),
+          dryRun,
+        });
+        item.labels = telegramVisibleProofSyncResult.labels;
+        clawSweeperLabelsChanged ||= telegramVisibleProofSyncResult.changed;
+      }
     }
     markdown = replaceFrontMatterValue(markdown, "labels", JSON.stringify(item.labels));
     if (clawSweeperLabelsChanged && !dryRun) {
@@ -17506,19 +17618,9 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       renderOptions.hasOpenLinkedPullRequest =
         openClosingPullRequestApplyReason(currentClosingPullRequests) !== null;
     }
-    let reviewComment = renderReviewCommentFromReport(
-      markdown,
-      closeReason ?? "none",
-      renderOptions,
-    );
-    const existingReviewComment = issueReviewComment(number, [
-      reviewComment,
-      reviewSectionValue(markdown, "closeComment"),
-    ]);
-    const existingReviewCommentUpdatedAt = commentUpdatedAt(existingReviewComment);
-    if (existingReviewCommentUpdatedAt) {
-      allowedSelfMutationUpdatedAts.add(existingReviewCommentUpdatedAt);
-    }
+    let reviewComment = stalePrReviewHead
+      ? stalePullRequestReviewComment({ number, stale: stalePrReviewHead })
+      : renderReviewCommentFromReport(markdown, closeReason ?? "none", renderOptions);
     let markedReviewComment = markedReviewCommentBody(number, reviewComment);
     let proofBlockedForCommentSync: PrCloseCoverageProofGateBlock | null = null;
     const protectedApplyReason = applyProtectedLabelReason(item.labels, closeReason);
@@ -17550,21 +17652,6 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
         break;
       continue;
     }
-    const updatedSinceReview = Boolean(storedUpdatedAt && item.updatedAt !== storedUpdatedAt);
-    const reviewCommentOnlyUpdate = item.updatedAt === commentUpdatedAt(existingReviewComment);
-    const labelSyncFreshEnough = (): boolean => {
-      if (!storedUpdatedAt) return false;
-      if (!updatedSinceReview || reviewCommentOnlyUpdate) return true;
-      const existingReviewCommentUpdatedAtMs = timestampMs(commentUpdatedAt(existingReviewComment));
-      const itemUpdatedAtMs = timestampMs(item.updatedAt);
-      if (existingReviewCommentUpdatedAtMs === null || itemUpdatedAtMs === null) return false;
-      if (Math.abs(itemUpdatedAtMs - existingReviewCommentUpdatedAtMs) > 5 * 60 * 1000) {
-        return false;
-      }
-      const storedUpdatedAtMs = timestampMs(storedUpdatedAt);
-      if (storedUpdatedAtMs === null) return false;
-      return !contextHasNonAutomationActivityAfter(currentItemContext(), storedUpdatedAtMs);
-    };
     const markChangedSinceReview = (options: {
       reason: string;
       currentUpdatedAt?: string | undefined;
@@ -17724,6 +17811,16 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       if (processedCount >= processedLimit) break;
       continue;
     }
+    if (isCloseProposal && stalePrReviewHead) {
+      if (
+        markChangedSinceReview({
+          reason: stalePrReviewHead.reason,
+          currentUpdatedAt: item.updatedAt,
+        })
+      )
+        break;
+      continue;
+    }
     if (isCloseProposal && updatedSinceReview && !reviewCommentOnlyUpdate) {
       markdown = replaceFrontMatterValue(markdown, "action_taken", "skipped_changed_since_review");
       markdown = replaceFrontMatterValue(markdown, "current_item_updated_at", item.updatedAt);
@@ -17762,7 +17859,9 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       }
     }
     const isCurrentCompleteReport =
-      frontMatterValue(markdown, "review_status") === "complete" && labelSyncFreshEnough();
+      frontMatterValue(markdown, "review_status") === "complete" &&
+      !stalePrReviewHead &&
+      labelSyncFreshEnough();
     if (state === "open" && isCurrentCompleteReport) {
       try {
         const syncResult = syncPriorityLabel({
@@ -17844,7 +17943,9 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
         continue;
       }
     }
-    reviewComment = renderReviewCommentFromReport(markdown, closeReason ?? "none", renderOptions);
+    reviewComment = stalePrReviewHead
+      ? stalePullRequestReviewComment({ number, stale: stalePrReviewHead })
+      : renderReviewCommentFromReport(markdown, closeReason ?? "none", renderOptions);
     markedReviewComment = markedReviewCommentBody(number, reviewComment);
     if (isCloseProposal && item.kind === "issue") {
       currentClosingPullRequests ??= closingPullRequestsForIssue(number);

--- a/test/apply-label-sync.test.ts
+++ b/test/apply-label-sync.test.ts
@@ -266,6 +266,184 @@ if (args[0] === "api" && /\\/issues\\/74478$/.test(path)) {
   }
 });
 
+test("apply-decisions clears stale PR review labels when live head changed", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const logPath = join(root, "gh.log");
+    const itemPath = join(itemsDir, "74481.md");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const staleLabels = [
+      "P2",
+      "rating: 🧂 unranked krab",
+      "merge-risk: 🚨 session-state",
+      "status: 🔁 re-review loop",
+      "proof: sufficient",
+    ];
+    const sourceReport = `${reportFrontMatter({
+      repository: "openclaw/openclaw",
+      type: "pull_request",
+      number: "74481",
+      title: "Stale review label cleanup",
+      url: "https://github.com/openclaw/openclaw/pull/74481",
+      decision: "keep_open",
+      close_reason: "none",
+      confidence: "high",
+      action_taken: "kept_open",
+      review_status: "complete",
+      local_checkout_access: "verified",
+      author: "contributor",
+      author_association: "CONTRIBUTOR",
+      labels: JSON.stringify(staleLabels),
+      item_snapshot_hash: "snapshot-a",
+      item_updated_at: "2026-05-19T20:00:00Z",
+      reviewed_at: "2026-05-19T20:00:00Z",
+      pull_head_sha: "old-head",
+      merge_risk_labels: JSON.stringify(["merge-risk: 🚨 session-state"]),
+    })}
+
+## Summary
+
+This old report should not keep driving PR labels after the branch moves.
+
+${realBehaviorProofReportSection()}
+
+${prRatingReportSection({ overallTier: "F", proofTier: "F", patchTier: "F" })}
+
+## Review Findings
+
+Overall correctness: patch is incorrect
+
+Overall confidence: 0.87
+
+Full review comments:
+
+- [P1] Old finding — src/runtime.ts:10
+`;
+    const synced = reportWithSyncedReviewComment(sourceReport, 74481);
+    writeFileSync(itemPath, synced.report, "utf8");
+
+    const ghMock = `
+const { appendFileSync, readFileSync } = require("fs");
+const logPath = ${JSON.stringify(logPath)};
+const comment = ${JSON.stringify(synced.comment)};
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+appendFileSync(logPath, JSON.stringify(args) + "\\n");
+const path = args[1] || "";
+const staleLabels = ${JSON.stringify(staleLabels)};
+if (args[0] === "api" && /\\/issues\\/74481$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 74481,
+    title: "Stale review label cleanup",
+    html_url: "https://github.com/openclaw/openclaw/pull/74481",
+    created_at: "2026-05-19T19:00:00Z",
+    updated_at: "2026-05-19T20:10:00Z",
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "contributor" },
+    labels: staleLabels,
+    pull_request: {}
+  }));
+} else if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/74481\\/timeline(?:\\?|$)/.test(args[2] || "")) {
+  console.log("HTTP/2 200\\n\\n[]");
+} else if (args[0] === "api" && /\\/issues\\/74481\\/timeline(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/pulls\\/74481$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 74481,
+    html_url: "https://github.com/openclaw/openclaw/pull/74481",
+    state: "open",
+    changed_files: 1,
+    commits: 2,
+    review_comments: 0,
+    head: { sha: "new-head", ref: "branch", repo: { full_name: "fork/openclaw" } },
+    base: { sha: "base-sha", ref: "main", repo: { full_name: "openclaw/openclaw" } },
+    user: { login: "contributor" }
+  }));
+} else if (args[0] === "api" && /\\/pulls\\/74481\\/(files|commits|comments)(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/issues\\/74481\\/comments(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[
+    {
+      id: 987481,
+      html_url: "https://github.com/openclaw/openclaw/pull/74481#issuecomment-987481",
+      body: comment,
+      user: { login: "clawsweeper[bot]" },
+      created_at: "2026-05-19T20:00:00Z",
+      updated_at: "2026-05-19T20:00:00Z"
+    }
+  ]]));
+} else if (args[0] === "api" && /\\/issues\\/comments\\/987481$/.test(path)) {
+  const input = args[args.indexOf("--input") + 1];
+  appendFileSync(logPath, JSON.stringify(["patched-review-body", JSON.parse(readFileSync(input, "utf8")).body]) + "\\n");
+  console.log(JSON.stringify({
+    id: 987481,
+    html_url: "https://github.com/openclaw/openclaw/pull/74481#issuecomment-987481",
+    updated_at: "2026-05-19T20:11:00Z"
+  }));
+} else if (args[0] === "issue" && args[1] === "edit") {
+  console.log("");
+} else if (args[0] === "label" && args[1] === "create") {
+  console.log(JSON.stringify({ name: args[2] }));
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        targetRepo: "openclaw/openclaw",
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: ["--sync-comments-only", "--item-numbers", "74481"],
+      });
+    });
+
+    const calls = readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as string[]);
+    const removedLabels = calls
+      .filter((args) => args[0] === "issue" && args[1] === "edit")
+      .map((args) => args[args.indexOf("--remove-label") + 1])
+      .filter(Boolean)
+      .sort();
+    assert.deepEqual(removedLabels, [
+      "merge-risk: 🚨 session-state",
+      "proof: sufficient",
+      "rating: 🧂 unranked krab",
+      "status: 🔁 re-review loop",
+    ]);
+    const patchedBody = calls.find((args) => args[0] === "patched-review-body")?.[1] ?? "";
+    assert.match(patchedBody, /Codex review: stale review; fresh review needed/);
+    assert.match(patchedBody, /reviewed_sha=old-head current_sha=new-head/);
+    assert.doesNotMatch(patchedBody, /clawsweeper-verdict:/);
+    const updatedReport = readFileSync(itemPath, "utf8");
+    assert.match(updatedReport, /^current_pull_head_sha: new-head$/m);
+    assert.match(updatedReport, /^labels: \["P2"\]$/m);
+    assert.deepEqual(JSON.parse(readFileSync(reportPath, "utf8")), [
+      {
+        number: 74481,
+        action: "review_comment_synced",
+        reason: "updated durable Codex review comment",
+      },
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("apply-decisions routes parsed security owner acceptance to maintainer review", () => {
   const root = mkdtempSync(tmpPrefix);
   try {


### PR DESCRIPTION
## Summary

- Detect open PR reports where the stored `pull_head_sha` no longer matches the live PR head.
- Stop syncing old PR review-derived labels in that state, and remove stale rating/status/merge-risk/proof/showcase labels while preserving generic triage labels.
- Replace the durable review comment with a stale-review notice that records the reviewed and current head SHAs instead of republishing the old verdict.

## Problem

Refs openclaw/openclaw#99335. That PR had a durable ClawSweeper review for an older head while the PR branch had moved, but the apply path could still leave review-derived labels from the old verdict on the live PR.

## Why this layer

`apply-decisions` is the path that mutates GitHub labels and durable comments from stored reports. Guarding stale heads there prevents old review state from being published or retained while the fresh review catches up.

## Validation

- `PATH=/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/mauriceniu/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:$PATH node --test test/apply-label-sync.test.ts`
- `PATH=/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/mauriceniu/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:$PATH pnpm run check`
- `git diff --check`

## Staged Apply Proof

This is a staged apply run using the real `apply-decisions` path with a mock `gh` shim, so no live GitHub labels or comments were mutated. The scenario models a durable report reviewed at `reviewed-old-head` while the live PR head has moved to `live-new-head`.

Command:

```bash
PATH=/Users/mauriceniu/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/mauriceniu/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:$PATH node --input-type=module <staged stale-head apply proof>
```

Output:

```text
[apply] starting apply: files=1 dry_run=false apply_kind=issue sync_comments_only=true item_numbers=99335
[apply] finished apply closed=0/10 processed=1/1 counts={"review_comment_synced":1}
staged apply proof: PASS
reviewed head: reviewed-old-head
live head: live-new-head
removed review-derived labels: merge-risk: 🚨 session-state, proof: sufficient, rating: 🧂 unranked krab, status: 🔁 re-review loop
preserved labels after apply: ["P2"]
updated report current_pull_head_sha: live-new-head
stale comment status: Codex review: stale review; fresh review needed.
stale comment marker: <!-- clawsweeper-review-status:stale item=99335 reviewed_sha=reviewed-old-head current_sha=live-new-head reason=stale_head -->
old verdict marker present after patch: false
```

The staged run confirms the stale-head path removes only review-derived PR labels, preserves the generic `P2` label, records the current live head, replaces the durable comment with the stale-review notice, and does not keep publishing the old `clawsweeper-verdict` marker.
