### PR TITLE
[codex] Prevent stale review comment sync overwrites

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -245,6 +245,7 @@ type ActionTaken =
   | "skipped_comment_auth"
   | "skipped_locked_conversation"
   | "skipped_changed_since_review"
+  | "skipped_stale_review_comment_sync"
   | "skipped_open_closing_pr"
   | "skipped_same_author_pair"
   | "skipped_already_closed"
@@ -15415,6 +15416,50 @@ function commentBody(comment: Record<string, unknown> | undefined): string | und
   return typeof body === "string" ? body : undefined;
 }
 
+function newestReviewMarkerReviewedAt(
+  comment: Record<string, unknown> | undefined,
+  number: number,
+): string | undefined {
+  if (!canPatchReviewComment(comment)) return undefined;
+  const body = commentBody(comment);
+  if (!body) return undefined;
+  const reviewMarker = reviewCommentMarker(number);
+  const reviewMarkerIndex = body.lastIndexOf(reviewMarker);
+  if (reviewMarkerIndex < 0) return undefined;
+  if (body.slice(reviewMarkerIndex + reviewMarker.length).trim() !== "") return undefined;
+  const markerBlock = body
+    .slice(0, reviewMarkerIndex)
+    .trimEnd()
+    .match(/(?:<!--[\s\S]*?-->\s*)+$/)?.[0];
+  if (!markerBlock) return undefined;
+  const markerPattern = /<!--\s+clawsweeper-verdict:[^\s>]+\b([^>]*)-->/g;
+  let lastReviewedAt: string | undefined;
+  for (const match of markerBlock.matchAll(markerPattern)) {
+    const attributes = match[1] ?? "";
+    if (!new RegExp(`\\bitem=${number}\\b`).test(attributes)) continue;
+    const reviewedAt = attributes.match(/\breviewed_at=([^\s>]+)/)?.[1];
+    if (!reviewedAt || reviewedAt === "unknown") continue;
+    lastReviewedAt = reviewedAt;
+  }
+  return lastReviewedAt;
+}
+
+function staleReviewCommentSyncReason(
+  markdown: string,
+  existingReviewComment: Record<string, unknown> | undefined,
+  number: number,
+): string | null {
+  if (frontMatterValue(markdown, "type") !== "pull_request") return null;
+  // Comment updated_at can move for command/status edits; only review markers prove verdict freshness.
+  const liveReviewedAt = newestReviewMarkerReviewedAt(existingReviewComment, number);
+  const reportReviewedAt = frontMatterValue(markdown, "reviewed_at");
+  const liveReviewedAtMs = timestampMs(liveReviewedAt);
+  const reportReviewedAtMs = timestampMs(reportReviewedAt);
+  if (liveReviewedAtMs === null || reportReviewedAtMs === null) return null;
+  if (liveReviewedAtMs <= reportReviewedAtMs) return null;
+  return `live durable review comment is newer than the local report: comment reviewed_at=${liveReviewedAt}, report reviewed_at=${reportReviewedAt}`;
+}
+
 const APPLY_SYNC_EQUIVALENT_CLOSE_MARKER_ACTIONS = new Set([
   "proposed_close",
   "kept_open",
@@ -18002,6 +18047,22 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       ? `synced advisory issue labels #${number}`
       : `synced ClawSweeper labels #${number}`;
     if (needsReviewCommentSync) {
+      const staleSyncReason = needsReviewCommentBodySync
+        ? staleReviewCommentSyncReason(markdown, existingReviewComment, number)
+        : null;
+      if (staleSyncReason) {
+        markdown = replaceFrontMatterValue(markdown, "apply_checked_at", new Date().toISOString());
+        if (!dryRun) writeFileSync(path, markdown, "utf8");
+        results.push({
+          number,
+          action: "skipped_stale_review_comment_sync",
+          reason: staleSyncReason,
+        });
+        processedCount += 1;
+        maybeLogProgress(`skipped stale review comment sync #${number}`);
+        if (processedCount >= processedLimit) break;
+        continue;
+      }
       const lockedReason = needsReviewCommentBodySync ? lockedConversationApplyReason(item) : null;
       if (lockedReason) {
         if (markApplySkipped("skipped_locked_conversation", lockedReason)) break;

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -40,6 +40,7 @@ import {
   closeDecision,
   implementedCloseReport,
   item,
+  markedReviewCommentForTest,
   reportFrontMatter,
   reportWithSyncedReviewComment,
   readText,
@@ -914,6 +915,566 @@ test("comment-only sync creates or refreshes stale durable review comments", () 
     }),
     true,
   );
+});
+
+test("apply-decisions does not overwrite a newer durable review comment", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const logPath = join(root, "gh.log");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+
+    const oldReview = reportWithSyncedReviewComment(
+      workPlanCandidateReport({
+        number: 321,
+        repository: "openclaw/openclaw",
+        type: "pull_request",
+        reviewed_at: "2026-05-01T00:00:00Z",
+        item_snapshot_hash: "old-snapshot-321",
+        item_updated_at: "2026-05-01T00:00:00Z",
+        pull_head_sha: "old-head",
+      }),
+      321,
+    );
+    writeFileSync(join(itemsDir, "321.md"), oldReview.report, "utf8");
+    const newerComment = markedReviewCommentForTest(
+      321,
+      [
+        "Codex review: ready for maintainer look.",
+        "",
+        "<!-- clawsweeper-verdict:needs-human item=321 sha=new-head confidence=high updated_at=2026-05-01T00:05:00Z reviewed_at=2026-05-01T00:10:00Z source_revision=new-source -->",
+      ].join("\n"),
+    );
+
+    const ghMock = `
+const { appendFileSync, readFileSync } = require("fs");
+const logPath = ${JSON.stringify(logPath)};
+const comment = ${JSON.stringify(newerComment)};
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+appendFileSync(logPath, JSON.stringify(args) + "\\n");
+const path = args.includes("-i") ? args[args.indexOf("-i") + 1] : args[1] || "";
+if (args[0] === "api" && /\\/issues\\/comments\\/\\d+$/.test(path)) {
+  const inputPath = args[args.indexOf("--input") + 1];
+  const body = JSON.parse(readFileSync(inputPath, "utf8")).body;
+  appendFileSync(logPath, JSON.stringify(["comment-patch", body]) + "\\n");
+  console.log(JSON.stringify({ id: 9321, html_url: "https://github.com/openclaw/openclaw/pull/321#issuecomment-9321", updated_at: "2026-05-01T00:11:00Z", body }));
+} else if (args[0] === "api" && /\\/issues\\/321\\/timeline/.test(path) && args.includes("-i")) {
+  console.log("HTTP/2 200\\n\\n" + JSON.stringify([]));
+} else if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[{
+    id: 9321,
+    html_url: "https://github.com/openclaw/openclaw/pull/321#issuecomment-9321",
+    created_at: "2026-05-01T00:01:00Z",
+    updated_at: "2026-05-01T00:10:30Z",
+    user: { login: "clawsweeper[bot]" },
+    body: comment
+  }]]));
+} else if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 321,
+    title: "Render work plans",
+    html_url: "https://github.com/openclaw/openclaw/pull/321",
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "reporter" },
+    labels: [],
+    comments: 1,
+    pull_request: {}
+  }));
+} else if (args[0] === "api" && /\\/pulls\\/321$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 321,
+    title: "Render work plans",
+    html_url: "https://github.com/openclaw/openclaw/pull/321",
+    state: "open",
+    changed_files: 1,
+    commits: 1,
+    review_comments: 0,
+    body: "Stale PR body.",
+    head: { sha: "old-head", ref: "branch", repo: { full_name: "fork/openclaw" } },
+    base: { sha: "base-sha", ref: "main", repo: { full_name: "openclaw/openclaw" } },
+    user: { login: "reporter" }
+  }));
+} else if (args[0] === "api" && /\\/pulls\\/321\\/(files|commits|comments)(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/issues\\/321\\/timeline/.test(path)) {
+  console.log(JSON.stringify([]));
+} else if (args[0] === "label" || args[0] === "issue") {
+  console.log("");
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        targetRepo: "openclaw/openclaw",
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: [
+          "--apply-kind",
+          "pull_request",
+          "--sync-comments-only",
+          "--comment-sync-min-age-days",
+          "0",
+        ],
+      });
+    });
+
+    const calls = readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as string[]);
+    assert.equal(
+      calls.some((args) => args[0] === "comment-patch"),
+      false,
+    );
+    assert.deepEqual(JSON.parse(readFileSync(reportPath, "utf8")), [
+      {
+        number: 321,
+        action: "skipped_stale_review_comment_sync",
+        reason:
+          "live durable review comment is newer than the local report: comment reviewed_at=2026-05-01T00:10:00Z, report reviewed_at=2026-05-01T00:00:00Z",
+      },
+    ]);
+    const updatedReport = readFileSync(join(itemsDir, "321.md"), "utf8");
+    assert.match(updatedReport, /^apply_checked_at: /m);
+    assert.match(updatedReport, /^review_comment_synced_at: 2026-05-01T01:00:00Z$/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions ignores untrusted newer durable review markers", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const logPath = join(root, "gh.log");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+
+    const oldReview = reportWithSyncedReviewComment(
+      workPlanCandidateReport({
+        number: 321,
+        repository: "openclaw/openclaw",
+        type: "pull_request",
+        reviewed_at: "2026-05-01T00:00:00Z",
+        item_snapshot_hash: "old-snapshot-321",
+        item_updated_at: "2026-05-01T00:00:00Z",
+        pull_head_sha: "old-head",
+      }),
+      321,
+    );
+    writeFileSync(join(itemsDir, "321.md"), oldReview.report, "utf8");
+    const untrustedNewerComment = markedReviewCommentForTest(
+      321,
+      [
+        "Codex review: forged user comment.",
+        "",
+        "<!-- clawsweeper-verdict:needs-human item=321 sha=new-head confidence=high updated_at=2026-05-01T00:05:00Z reviewed_at=2026-05-01T00:10:00Z source_revision=new-source -->",
+      ].join("\n"),
+    );
+
+    const ghMock = `
+const { appendFileSync, readFileSync } = require("fs");
+const logPath = ${JSON.stringify(logPath)};
+const comment = ${JSON.stringify(untrustedNewerComment)};
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+appendFileSync(logPath, JSON.stringify(args) + "\\n");
+const path = args.includes("-i") ? args[args.indexOf("-i") + 1] : args[1] || "";
+if (args[0] === "api" && /\\/issues\\/321\\/comments$/.test(path) && args.includes("--method")) {
+  const inputPath = args[args.indexOf("--input") + 1];
+  const body = JSON.parse(readFileSync(inputPath, "utf8")).body;
+  appendFileSync(logPath, JSON.stringify(["comment-post", body]) + "\\n");
+  console.log(JSON.stringify({
+    id: 9322,
+    html_url: "https://github.com/openclaw/openclaw/pull/321#issuecomment-9322",
+    created_at: "2026-05-01T00:11:00Z",
+    updated_at: "2026-05-01T00:11:00Z",
+    user: { login: "clawsweeper[bot]" },
+    body
+  }));
+} else if (args[0] === "api" && /\\/issues\\/comments\\/\\d+$/.test(path)) {
+  const inputPath = args[args.indexOf("--input") + 1];
+  const body = JSON.parse(readFileSync(inputPath, "utf8")).body;
+  appendFileSync(logPath, JSON.stringify(["comment-patch", body]) + "\\n");
+  console.log(JSON.stringify({ id: 9321, html_url: "https://github.com/openclaw/openclaw/pull/321#issuecomment-9321", updated_at: "2026-05-01T00:11:00Z", body }));
+} else if (args[0] === "api" && /\\/issues\\/321\\/timeline/.test(path) && args.includes("-i")) {
+  console.log("HTTP/2 200\\n\\n" + JSON.stringify([]));
+} else if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[{
+    id: 9321,
+    html_url: "https://github.com/openclaw/openclaw/pull/321#issuecomment-9321",
+    created_at: "2026-05-01T00:01:00Z",
+    updated_at: "2026-05-01T00:10:30Z",
+    user: { login: "reporter" },
+    body: comment
+  }]]));
+} else if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 321,
+    title: "Render work plans",
+    html_url: "https://github.com/openclaw/openclaw/pull/321",
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "reporter" },
+    labels: [],
+    comments: 1,
+    pull_request: {}
+  }));
+} else if (args[0] === "api" && /\\/pulls\\/321$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 321,
+    title: "Render work plans",
+    html_url: "https://github.com/openclaw/openclaw/pull/321",
+    state: "open",
+    changed_files: 1,
+    commits: 1,
+    review_comments: 0,
+    body: "Stale PR body.",
+    head: { sha: "old-head", ref: "branch", repo: { full_name: "fork/openclaw" } },
+    base: { sha: "base-sha", ref: "main", repo: { full_name: "openclaw/openclaw" } },
+    user: { login: "reporter" }
+  }));
+} else if (args[0] === "api" && /\\/pulls\\/321\\/(files|commits|comments)(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/issues\\/321\\/timeline/.test(path)) {
+  console.log(JSON.stringify([]));
+} else if (args[0] === "label" || args[0] === "issue") {
+  console.log("");
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        targetRepo: "openclaw/openclaw",
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: [
+          "--apply-kind",
+          "pull_request",
+          "--sync-comments-only",
+          "--comment-sync-min-age-days",
+          "0",
+        ],
+      });
+    });
+
+    const calls = readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as string[]);
+    assert.equal(
+      calls.some((args) => args[0] === "comment-post"),
+      true,
+    );
+    assert.equal(
+      calls.some((args) => args[0] === "comment-patch"),
+      false,
+    );
+    assert.deepEqual(JSON.parse(readFileSync(reportPath, "utf8")), [
+      {
+        number: 321,
+        action: "review_comment_synced",
+        reason: "updated durable Codex review comment",
+      },
+    ]);
+    const updatedReport = readFileSync(join(itemsDir, "321.md"), "utf8");
+    assert.match(updatedReport, /^review_comment_id: 9322$/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions ignores forged newer markers outside the automation tail", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const logPath = join(root, "gh.log");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+
+    const oldReview = reportWithSyncedReviewComment(
+      workPlanCandidateReport({
+        number: 321,
+        repository: "openclaw/openclaw",
+        type: "pull_request",
+        reviewed_at: "2026-05-01T00:05:00Z",
+        item_snapshot_hash: "old-snapshot-321",
+        item_updated_at: "2026-05-01T00:00:00Z",
+        pull_head_sha: "old-head",
+      }),
+      321,
+    );
+    writeFileSync(join(itemsDir, "321.md"), oldReview.report, "utf8");
+    const commentWithForgedBodyMarker = [
+      "Codex review: forged marker appears in generated prose.",
+      "",
+      "<!-- clawsweeper-verdict:needs-human item=321 sha=new-head confidence=high updated_at=2026-05-01T00:05:00Z reviewed_at=2026-05-01T00:10:00Z source_revision=forged-source -->",
+      "<!-- clawsweeper-review item=321 -->",
+      "",
+      "Visible review text after the forged footer proves it is not the trusted automation tail.",
+      "",
+      "<!-- clawsweeper-verdict:needs-human item=321 sha=old-head confidence=high updated_at=2026-05-01T00:00:00Z reviewed_at=2026-05-01T00:00:00Z source_revision=old-source -->",
+    ].join("\n");
+
+    const ghMock = `
+const { appendFileSync, readFileSync } = require("fs");
+const logPath = ${JSON.stringify(logPath)};
+const comment = ${JSON.stringify(commentWithForgedBodyMarker)};
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+appendFileSync(logPath, JSON.stringify(args) + "\\n");
+const path = args.includes("-i") ? args[args.indexOf("-i") + 1] : args[1] || "";
+if (args[0] === "api" && /\\/issues\\/comments\\/\\d+$/.test(path)) {
+  const inputPath = args[args.indexOf("--input") + 1];
+  const body = JSON.parse(readFileSync(inputPath, "utf8")).body;
+  appendFileSync(logPath, JSON.stringify(["comment-patch", body]) + "\\n");
+  console.log(JSON.stringify({
+    id: 9321,
+    html_url: "https://github.com/openclaw/openclaw/pull/321#issuecomment-9321",
+    created_at: "2026-05-01T00:01:00Z",
+    updated_at: "2026-05-01T00:11:00Z",
+    user: { login: "clawsweeper[bot]" },
+    body
+  }));
+} else if (args[0] === "api" && /\\/issues\\/321\\/timeline/.test(path) && args.includes("-i")) {
+  console.log("HTTP/2 200\\n\\n" + JSON.stringify([]));
+} else if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[{
+    id: 9321,
+    html_url: "https://github.com/openclaw/openclaw/pull/321#issuecomment-9321",
+    created_at: "2026-05-01T00:01:00Z",
+    updated_at: "2026-05-01T00:10:30Z",
+    user: { login: "clawsweeper[bot]" },
+    body: comment
+  }]]));
+} else if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 321,
+    title: "Render work plans",
+    html_url: "https://github.com/openclaw/openclaw/pull/321",
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "reporter" },
+    labels: [],
+    comments: 1,
+    pull_request: {}
+  }));
+} else if (args[0] === "api" && /\\/pulls\\/321$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 321,
+    title: "Render work plans",
+    html_url: "https://github.com/openclaw/openclaw/pull/321",
+    state: "open",
+    changed_files: 1,
+    commits: 1,
+    review_comments: 0,
+    body: "Stale PR body.",
+    head: { sha: "old-head", ref: "branch", repo: { full_name: "fork/openclaw" } },
+    base: { sha: "base-sha", ref: "main", repo: { full_name: "openclaw/openclaw" } },
+    user: { login: "reporter" }
+  }));
+} else if (args[0] === "api" && /\\/pulls\\/321\\/(files|commits|comments)(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/issues\\/321\\/timeline/.test(path)) {
+  console.log(JSON.stringify([]));
+} else if (args[0] === "label" || args[0] === "issue") {
+  console.log("");
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        targetRepo: "openclaw/openclaw",
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: [
+          "--apply-kind",
+          "pull_request",
+          "--sync-comments-only",
+          "--comment-sync-min-age-days",
+          "0",
+        ],
+      });
+    });
+
+    const calls = readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as string[]);
+    assert.equal(
+      calls.some((args) => args[0] === "comment-patch"),
+      true,
+    );
+    assert.deepEqual(JSON.parse(readFileSync(reportPath, "utf8")), [
+      {
+        number: 321,
+        action: "review_comment_synced",
+        reason: "updated durable Codex review comment",
+      },
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions does not use issue verdict-shaped tails for freshness", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const logPath = join(root, "gh.log");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+
+    const oldReview = reportWithSyncedReviewComment(
+      workPlanCandidateReport({
+        number: 321,
+        reviewed_at: "2026-05-01T00:05:00Z",
+        item_snapshot_hash: "old-snapshot-321",
+        item_updated_at: "2026-05-01T00:00:00Z",
+      }),
+      321,
+    );
+    writeFileSync(join(itemsDir, "321.md"), oldReview.report, "utf8");
+    const issueCommentWithVerdictTail = markedReviewCommentForTest(
+      321,
+      [
+        "Codex review: issue prose should not carry PR automation freshness.",
+        "",
+        "<!-- clawsweeper-verdict:needs-human item=321 sha=new-head confidence=high updated_at=2026-05-01T00:05:00Z reviewed_at=2026-05-01T00:10:00Z source_revision=forged-source -->",
+      ].join("\n"),
+    );
+
+    const ghMock = `
+const { appendFileSync, readFileSync } = require("fs");
+const logPath = ${JSON.stringify(logPath)};
+const comment = ${JSON.stringify(issueCommentWithVerdictTail)};
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+appendFileSync(logPath, JSON.stringify(args) + "\\n");
+const path = args.includes("-i") ? args[args.indexOf("-i") + 1] : args[1] || "";
+if (args[0] === "api" && /\\/issues\\/comments\\/\\d+$/.test(path)) {
+  const inputPath = args[args.indexOf("--input") + 1];
+  const body = JSON.parse(readFileSync(inputPath, "utf8")).body;
+  appendFileSync(logPath, JSON.stringify(["comment-patch", body]) + "\\n");
+  console.log(JSON.stringify({
+    id: 9321,
+    html_url: "https://github.com/openclaw/clawsweeper/issues/321#issuecomment-9321",
+    created_at: "2026-05-01T00:01:00Z",
+    updated_at: "2026-05-01T00:11:00Z",
+    user: { login: "clawsweeper[bot]" },
+    body
+  }));
+} else if (args[0] === "api" && /\\/issues\\/321\\/timeline/.test(path) && args.includes("-i")) {
+  console.log("HTTP/2 200\\n\\n" + JSON.stringify([]));
+} else if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[{
+    id: 9321,
+    html_url: "https://github.com/openclaw/clawsweeper/issues/321#issuecomment-9321",
+    created_at: "2026-05-01T00:01:00Z",
+    updated_at: "2026-05-01T00:10:30Z",
+    user: { login: "clawsweeper[bot]" },
+    body: comment
+  }]]));
+} else if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 321,
+    title: "Render work plans",
+    html_url: "https://github.com/openclaw/clawsweeper/issues/321",
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "reporter" },
+    labels: [],
+    comments: 1,
+    pull_request: null
+  }));
+} else if (args[0] === "issue" && args[1] === "view") {
+  console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
+} else if (args[0] === "label" || args[0] === "issue") {
+  console.log("");
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: ["--sync-comments-only", "--comment-sync-min-age-days", "0"],
+      });
+    });
+
+    const calls = readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as string[]);
+    assert.equal(
+      calls.some((args) => args[0] === "comment-patch"),
+      true,
+    );
+    assert.deepEqual(JSON.parse(readFileSync(reportPath, "utf8")), [
+      {
+        number: 321,
+        action: "review_comment_synced",
+        reason: "updated durable Codex review comment",
+      },
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("review artifacts are ignored once the live item is closed", () => {


### PR DESCRIPTION
## Summary

- Prevent stale apply/comment-sync runs from overwriting a newer durable ClawSweeper review comment.
- Trust only pull-request review comments that are bot-owned, have the durable review marker as the final footer, and expose a trailing automation verdict marker with a newer `reviewed_at`.
- Add regression coverage for the real overwrite race plus untrusted/user-authored markers, forged marker prose, forged review footers, and issue comments.

## Root cause

A long-running apply/comment-sync job could load older state and later PATCH the durable review comment after a newer exact-review run had already updated it. Because the sync path compared desired body/hash metadata but did not check live review freshness, it could roll the public comment from a newer review back to an older one.

## Validation

- `pnpm run build`
- `pnpm exec node --test test/clawsweeper.test.ts`
- `pnpm run format:check`
- `autoreview --mode local --codex-bin /root/.nvm/versions/node/v22.21.1/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/bin/codex ...`

## Autoreview

Codex autoreview initially found trust-boundary issues in the freshness parser. Accepted and fixed:

- Do not trust user-authored marker comments.
- Do not trust marker-shaped text in generated review prose.
- Do not apply PR verdict-tail freshness logic to issue comments.
- Require the durable `clawsweeper-review` marker to be the final footer before trusting the preceding verdict marker.

Final autoreview result: `autoreview clean: no accepted/actionable findings reported`.
