### PR TITLE
fix(scheduler): count active runs by workflow path

### DIFF
--- a/.github/workflows/commit-review.yml
+++ b/.github/workflows/commit-review.yml
@@ -171,7 +171,7 @@ jobs:
               for run_status in in_progress pending queued waiting requested; do
                 gh api "repos/${{ github.repository }}/actions/runs?per_page=100&status=${run_status}" \
                   --paginate \
-                  --jq '.workflow_runs[] | {databaseId:.id, workflowName:.name, displayTitle:.display_title, status:.status, createdAt:.created_at, updatedAt:.updated_at}' 2>/dev/null \
+                  --jq '.workflow_runs[] | {databaseId:.id, workflowPath:.path, displayTitle:.display_title, status:.status, createdAt:.created_at, updatedAt:.updated_at}' 2>/dev/null \
                   || true
               done
             } | jq -s 'unique_by(.databaseId)'
@@ -180,14 +180,14 @@ jobs:
           STALE_QUEUED_CUTOFF="$(date -u -d '6 hours ago' '+%Y-%m-%dT%H:%M:%SZ')"
           active_run_count() {
             printf '%s' "$ACTIVE_RUNS_JSON" \
-              | WORKFLOW_NAME="$1" STALE_QUEUED_CUTOFF="$STALE_QUEUED_CUTOFF" jq '[.[] | select(.workflowName == env.WORKFLOW_NAME) | select(.status == "in_progress" or ((.status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") and ((.updatedAt // .createdAt // "") >= env.STALE_QUEUED_CUTOFF)))] | length' 2>/dev/null \
+              | WORKFLOW_PATH="$1" STALE_QUEUED_CUTOFF="$STALE_QUEUED_CUTOFF" jq '[.[] | select(.workflowPath == env.WORKFLOW_PATH) | select(.status == "in_progress" or ((.status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") and ((.updatedAt // .createdAt // "") >= env.STALE_QUEUED_CUTOFF)))] | length' 2>/dev/null \
               || printf '0'
           }
           active_sweep_background_workers() {
             local runs total id title status active_shards
             total=0
             runs="$(printf '%s' "$ACTIVE_RUNS_JSON" \
-              | STALE_QUEUED_CUTOFF="$STALE_QUEUED_CUTOFF" jq -r '.[] | select(.workflowName == "ClawSweeper") | select(.status == "in_progress" or ((.status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") and ((.updatedAt // .createdAt // "") >= env.STALE_QUEUED_CUTOFF))) | select(.displayTitle == "Review ClawSweeper items" or .displayTitle == "Review hot ClawSweeper items") | [.databaseId, .displayTitle, .status] | @tsv' 2>/dev/null || true)"
+              | STALE_QUEUED_CUTOFF="$STALE_QUEUED_CUTOFF" jq -r '.[] | select(.workflowPath == ".github/workflows/sweep.yml") | select(.status == "in_progress" or ((.status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") and ((.updatedAt // .createdAt // "") >= env.STALE_QUEUED_CUTOFF))) | select(.displayTitle == "Review ClawSweeper items" or .displayTitle == "Review hot ClawSweeper items") | [.databaseId, .displayTitle, .status] | @tsv' 2>/dev/null || true)"
             while IFS=$'\t' read -r id title status; do
               if [ -z "$id" ]; then
                 continue
@@ -216,11 +216,11 @@ jobs:
           }
           active_sweep_exact_count() {
             printf '%s' "$ACTIVE_RUNS_JSON" \
-              | STALE_QUEUED_CUTOFF="$STALE_QUEUED_CUTOFF" jq '[.[] | select(.workflowName == "ClawSweeper") | select((.status == "in_progress" or ((.status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") and ((.updatedAt // .createdAt // "") >= env.STALE_QUEUED_CUTOFF))) and (.displayTitle | startswith("Review event item ")))] | length' 2>/dev/null \
+              | STALE_QUEUED_CUTOFF="$STALE_QUEUED_CUTOFF" jq '[.[] | select(.workflowPath == ".github/workflows/sweep.yml") | select((.status == "in_progress" or ((.status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") and ((.updatedAt // .createdAt // "") >= env.STALE_QUEUED_CUTOFF))) and (.displayTitle | startswith("Review event item ")))] | length' 2>/dev/null \
               || printf '0'
           }
           if [ -z "$PAGE_SIZE" ]; then
-            active_critical_workers="$(( $(active_run_count "repair cluster worker") + $(active_sweep_exact_count) ))"
+            active_critical_workers="$(( $(active_run_count ".github/workflows/repair-cluster-worker.yml") + $(active_sweep_exact_count) ))"
             active_background_workers="$(active_sweep_background_workers)"
             PAGE_SIZE="$(pnpm --dir clawsweeper run --silent workflow -- worker-limit commit_review --active-critical "$active_critical_workers" --active-background "$active_background_workers")"
           fi

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -961,7 +961,7 @@ jobs:
               for run_status in in_progress pending queued waiting requested; do
                 gh api "repos/${{ github.repository }}/actions/runs?per_page=100&status=${run_status}" \
                   --paginate \
-                  --jq '.workflow_runs[] | {databaseId:.id, workflowName:.name, displayTitle:.display_title, status:.status, createdAt:.created_at, updatedAt:.updated_at}' 2>/dev/null \
+                  --jq '.workflow_runs[] | {databaseId:.id, workflowPath:.path, displayTitle:.display_title, status:.status, createdAt:.created_at, updatedAt:.updated_at}' 2>/dev/null \
                   || true
               done
             } | jq -s 'unique_by(.databaseId)'
@@ -970,19 +970,19 @@ jobs:
           STALE_QUEUED_CUTOFF="$(date -u -d '6 hours ago' '+%Y-%m-%dT%H:%M:%SZ')"
           active_run_count() {
             printf '%s' "$ACTIVE_RUNS_JSON" \
-              | WORKFLOW_NAME="$1" STALE_QUEUED_CUTOFF="$STALE_QUEUED_CUTOFF" jq '[.[] | select(.workflowName == env.WORKFLOW_NAME) | select(.status == "in_progress" or ((.status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") and ((.updatedAt // .createdAt // "") >= env.STALE_QUEUED_CUTOFF)))] | length' 2>/dev/null \
+              | WORKFLOW_PATH="$1" STALE_QUEUED_CUTOFF="$STALE_QUEUED_CUTOFF" jq '[.[] | select(.workflowPath == env.WORKFLOW_PATH) | select(.status == "in_progress" or ((.status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") and ((.updatedAt // .createdAt // "") >= env.STALE_QUEUED_CUTOFF)))] | length' 2>/dev/null \
               || printf '0'
           }
           active_sweep_exact_count() {
             printf '%s' "$ACTIVE_RUNS_JSON" \
-              | STALE_QUEUED_CUTOFF="$STALE_QUEUED_CUTOFF" jq '[.[] | select(.workflowName == "ClawSweeper") | select((.status == "in_progress" or ((.status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") and ((.updatedAt // .createdAt // "") >= env.STALE_QUEUED_CUTOFF))) and (.displayTitle | startswith("Review event item ")))] | length' 2>/dev/null \
+              | STALE_QUEUED_CUTOFF="$STALE_QUEUED_CUTOFF" jq '[.[] | select(.workflowPath == ".github/workflows/sweep.yml") | select((.status == "in_progress" or ((.status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") and ((.updatedAt // .createdAt // "") >= env.STALE_QUEUED_CUTOFF))) and (.displayTitle | startswith("Review event item ")))] | length' 2>/dev/null \
               || printf '0'
           }
           active_sweep_background_workers() {
             local runs total id title status jobs_json active_shards total_shards
             total=0
             runs="$(printf '%s' "$ACTIVE_RUNS_JSON" \
-              | CURRENT_RUN_ID="${GITHUB_RUN_ID:-0}" STALE_QUEUED_CUTOFF="$STALE_QUEUED_CUTOFF" jq -r '.[] | select((.databaseId | tostring) != env.CURRENT_RUN_ID) | select(.workflowName == "ClawSweeper") | select(.status == "in_progress" or ((.status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") and ((.updatedAt // .createdAt // "") >= env.STALE_QUEUED_CUTOFF))) | select(.displayTitle == "Review ClawSweeper items" or .displayTitle == "Review hot ClawSweeper items" or (.displayTitle | startswith("Review target repo ")) or (.displayTitle | startswith("Review hot target repo "))) | [.databaseId, .displayTitle, .status] | @tsv' 2>/dev/null || true)"
+              | CURRENT_RUN_ID="${GITHUB_RUN_ID:-0}" STALE_QUEUED_CUTOFF="$STALE_QUEUED_CUTOFF" jq -r '.[] | select((.databaseId | tostring) != env.CURRENT_RUN_ID) | select(.workflowPath == ".github/workflows/sweep.yml") | select(.status == "in_progress" or ((.status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") and ((.updatedAt // .createdAt // "") >= env.STALE_QUEUED_CUTOFF))) | select(.displayTitle == "Review ClawSweeper items" or .displayTitle == "Review hot ClawSweeper items" or (.displayTitle | startswith("Review target repo ")) or (.displayTitle | startswith("Review hot target repo "))) | [.databaseId, .displayTitle, .status] | @tsv' 2>/dev/null || true)"
             while IFS=$'\t' read -r id title status; do
               if [ -z "$id" ]; then
                 continue
@@ -1022,8 +1022,8 @@ jobs:
           normal_active_floor="$(limit review_shards.normal_active_floor)"
           hard_shard_cap="$(limit review_shards.hard_cap)"
           commit_page_size="$(limit commit_review.page_size_default)"
-          active_critical_workers="$(( $(active_run_count "repair cluster worker") + $(active_sweep_exact_count) ))"
-          active_background_workers="$(( $(active_run_count "ClawSweeper Commit Review") * commit_page_size + $(active_sweep_background_workers) ))"
+          active_critical_workers="$(( $(active_run_count ".github/workflows/repair-cluster-worker.yml") + $(active_sweep_exact_count) ))"
+          active_background_workers="$(( $(active_run_count ".github/workflows/commit-review.yml") * commit_page_size + $(active_sweep_background_workers) ))"
           hot_intake_shards="$(worker_limit hot_intake --active-critical "$active_critical_workers" --active-background "$active_background_workers")"
           normal_shards="$(worker_limit normal_review --active-critical "$active_critical_workers" --active-background "$active_background_workers")"
           hot_intake="${{ ((github.event_name == 'repository_dispatch' && github.event.client_payload.hot_intake == 'true') || (github.event_name == 'workflow_dispatch' && github.event.inputs.hot_intake == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '*/5 * * * *' || github.event.schedule == '2/5 * * * *'))) && 'true' || 'false' }}"
@@ -2645,7 +2645,11 @@ jobs:
           set -euo pipefail
           hot_intake_shards="$(pnpm run --silent workflow -- limit review_shards.hot_intake_default)"
           normal_shards="$(pnpm run --silent workflow -- limit review_shards.normal_default)"
-          runs_json="$(gh run list --repo "${{ github.repository }}" --limit 100 --json workflowName,displayTitle,status,createdAt,updatedAt)"
+          runs_json="$({
+            gh api "repos/${{ github.repository }}/actions/runs?per_page=100" \
+              --jq '.workflow_runs[] | {databaseId:.id, workflowPath:.path, displayTitle:.display_title, status:.status, createdAt:.created_at, updatedAt:.updated_at}' 2>/dev/null \
+              || true
+          } | jq -s 'unique_by(.databaseId)')"
           eval "$(
             RUNS_JSON="$runs_json" node <<'NODE'
           const runs = JSON.parse(process.env.RUNS_JSON || "[]");
@@ -2661,7 +2665,7 @@ jobs:
           }
           function recent(title, windowMs) {
             return runs.some((run) => {
-              if (run.workflowName !== "ClawSweeper") return false;
+              if (run.workflowPath !== ".github/workflows/sweep.yml") return false;
               if (run.displayTitle !== title) return false;
               if (activeRun(run)) return true;
               const createdAt = Date.parse(String(run.createdAt || ""));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Counted active sweep, commit-review, and repair runs by stable workflow path so overlapping planners cannot exceed the global Codex worker budget when GitHub exposes dynamic run names.
 - Bounded apply-existing checkpoints to five fresh closes, renewed the GitHub
   App token between continuation runs, and stopped zero-progress scans from
   chaining indefinitely.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
-- Counted active sweep, commit-review, and repair runs by stable workflow path so overlapping planners cannot exceed the global Codex worker budget when GitHub exposes dynamic run names.
 - Bounded apply-existing checkpoints to five fresh closes, renewed the GitHub
   App token between continuation runs, and stopped zero-progress scans from
   chaining indefinitely.

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -608,7 +608,8 @@ test("review capacity probes use REST actions run listing", () => {
     assert.match(block, /actions\/runs\?per_page=100/);
     assert.match(block, /--paginate/);
     assert.match(block, /status=\$\{run_status\}/);
-    assert.match(block, /workflowName:\.name/);
+    assert.match(block, /workflowPath:\.path/);
+    assert.doesNotMatch(block, /workflowName:\.name/);
     assert.match(block, /displayTitle:\.display_title/);
     assert.match(block, /createdAt:\.created_at/);
     assert.match(block, /updatedAt:\.updated_at/);
@@ -634,6 +635,10 @@ test("background review capacity reserves expanding matrices and caps broad manu
   assert.match(modeBlock, /limit review_shards\.normal_default/);
   assert.match(modeBlock, /STALE_QUEUED_CUTOFF/);
   assert.match(modeBlock, /updatedAt:\.updated_at/);
+  assert.match(modeBlock, /workflowPath == "\.github\/workflows\/sweep\.yml"/);
+  assert.match(modeBlock, /WORKFLOW_PATH="\$1"/);
+  assert.doesNotMatch(modeBlock, /workflowName == "ClawSweeper"/);
+  assert.doesNotMatch(modeBlock, /WORKFLOW_NAME="\$1"/);
   assert.match(modeBlock, /total_shards/);
   assert.match(modeBlock, /completed shard jobs are publishing and consume no/);
   assert.match(modeBlock, /\[ "\$active_shards" -lt 1 \] && \[ "\$total_shards" -lt 1 \]/);
@@ -644,6 +649,21 @@ test("background review capacity reserves expanding matrices and caps broad manu
   assert.match(commitBlock, /limit review_shards\.normal_default/);
   assert.match(commitBlock, /STALE_QUEUED_CUTOFF/);
   assert.match(commitBlock, /updatedAt:\.updated_at/);
+  assert.match(commitBlock, /workflowPath == "\.github\/workflows\/sweep\.yml"/);
+  assert.match(commitBlock, /WORKFLOW_PATH="\$1"/);
+  assert.doesNotMatch(commitBlock, /workflowName == "ClawSweeper"/);
+  assert.doesNotMatch(commitBlock, /WORKFLOW_NAME="\$1"/);
+});
+
+test("review backstops identify sweep runs by stable workflow path", () => {
+  const workflow = readText(".github/workflows/sweep.yml");
+  const block = workflow.slice(workflow.indexOf("- name: Queue review backstops"));
+
+  assert.match(block, /actions\/runs\?per_page=100/);
+  assert.match(block, /workflowPath:\.path/);
+  assert.match(block, /run\.workflowPath !== "\.github\/workflows\/sweep\.yml"/);
+  assert.doesNotMatch(block, /gh run list/);
+  assert.doesNotMatch(block, /run\.workflowName/);
 });
 
 test("scheduled background reviews serialize planners and refill released capacity", () => {


### PR DESCRIPTION
## Summary

- identify active sweep, commit-review, and repair runs by stable workflow file path
- keep dynamic run names only as display titles
- use the REST run payload for backstop detection, with regression coverage for every affected planner

## Why

Live verification after #392 exposed that GitHub's REST `name` field now follows the dynamic `run-name`. The scheduler still compared it with the workflow's static name, so a normal 89-shard wave was not counted before a hot planner allocated its lane. The excess hot run was cancelled immediately.

## Validation

- `pnpm run format`
- `pnpm run check:limits`
- `pnpm run build:all`
- `node --test test/sweep-workflow.test.ts` (37/37)
- isolated Codex process tests (24/24)
- autoreview: clean, no actionable findings

The complete local check passed 551/559 tests; its eight failures were Codex-process 10-second timeouts under the live 89-worker load. All eight passed when rerun in their two isolated test files.

Live failure evidence: https://github.com/openclaw/clawsweeper/actions/runs/28682959017

## Live verification plan

The scheduled workflow executes from `main`, so the after-fix overlap proof is necessarily post-merge. On the exact green head, observe the next natural broad overlap and verify the planner counts active workflow-path runs and admits no more than the remaining 128-worker budget. Cancel the new wave immediately if that invariant fails.

## After-merge proof

Verified on merged `main` commit `1343d8ec0cef4a5088be01084937fe4396cf9571`.

- Before the controlled normal overlap, 9 exact workers and 52 background shards were active.
- The normal run requested 89 shards and logged `Capping broad background review shards from 89 to scheduler allowance 1` after counting all overlapping fixed-head planners by workflow path.
- The run created exactly 1 shard; three adjacent fixed-head normal planners also created 1 shard each.
- A follow-up live count found 10 exact workers and 50 active background shards. Including the unchanged 24 fixed reserves, observed active use plus reserves was 84 of the unchanged 128-worker maximum; pending planners remained separately reserved and were therefore capped to one shard.

Proof run: https://github.com/openclaw/clawsweeper/actions/runs/28684426284
