### PR TITLE
feat: classify apply skip next actions

### DIFF
--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -6958,6 +6958,7 @@ function applyHealthBucketLabel(bucket) {
   const labels = {
     already_resolved: "already resolved",
     close_coverage_proof: "needs close proof",
+    conversation_unlock: "unlock conversation",
     defer_until_closing_pr: "defer for PR state",
     inspect: "inspect skips",
     live_state_recovery: "live check recovery",

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -3561,6 +3561,7 @@ async function readApplyHealthMarker(env, targetRepo) {
     const status = parseJsonObject(decodeGithubContent(content?.content)) || {};
     const health = objectValue(status.apply_health);
     const skipReasons = numericRecord(health.skip_reasons);
+    const nextActions = applyHealthNextActions(health.next_actions);
     const cursor = objectValue(health.cursor);
     return {
       target_repo: nullableString(status.target_repo) || targetRepo,
@@ -3581,6 +3582,8 @@ async function readApplyHealthMarker(env, targetRepo) {
       skip_reasons: skipReasons,
       cursor_required: health.cursor_required === true,
       lanes: applyHealthLanes(health.lanes),
+      next_actions: nextActions,
+      next_action_buckets: numericRecord(health.next_action_buckets),
       attention_reasons: Array.isArray(health.attention_reasons)
         ? health.attention_reasons
             .map((reason) => String(reason))
@@ -3615,6 +3618,8 @@ async function readApplyHealthMarker(env, targetRepo) {
       skip_reasons: {},
       cursor_required: false,
       lanes: emptyApplyHealthLanes(),
+      next_actions: [],
+      next_action_buckets: {},
       attention_reasons: [],
       cursor: null,
     };
@@ -3631,6 +3636,8 @@ function emptyApplyHealthStatus(targetRepos) {
       skip_reasons: {},
       cursor_required: false,
       lanes: emptyApplyHealthLanes(),
+      next_actions: [],
+      next_action_buckets: {},
       attention_reasons: [],
       cursor: null,
     })),
@@ -3671,6 +3678,27 @@ function applyHealthLane(value) {
   };
 }
 
+function applyHealthNextActions(value) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) => {
+      const source = objectValue(entry);
+      const reason = nullableString(source.reason);
+      if (!reason) return null;
+      return {
+        reason,
+        count: numberOrNull(source.count),
+        bucket: nullableString(source.bucket),
+        owner: nullableString(source.owner),
+        retryable: Boolean(source.retryable),
+        label: nullableString(source.label),
+        summary: nullableString(source.summary),
+        next_step: nullableString(source.next_step),
+      };
+    })
+    .filter(Boolean)
+    .slice(0, 12);
+}
 function latestIso(values) {
   const timestamps = values
     .map((value) => Date.parse(value || ""))
@@ -6840,13 +6868,14 @@ function renderApplyHealth(data) {
   }
   target.innerHTML = items.map(item => {
     const topReason = applyHealthPrimaryReason(item);
-    const topInfo = applyHealthReasonInfo(topReason);
+    const topInfo = applyHealthReasonInfo(topReason, item);
     const action = applyHealthRecommendedAction(item, topReason);
     const reasons = applyHealthReasonEntries(item)
       .slice(0, 4)
-      .map(([reason, count]) => applyHealthReasonPill(reason, count))
+      .map(([reason, count]) => applyHealthReasonPill(reason, count, item))
       .join("");
     const showCursor = item.cursor_required || Boolean(item.cursor?.next_after_number);
+    const buckets = applyHealthNextActionBucketPills(item);
     const cursor = item.cursor?.next_after_number ? "cursor #" + item.cursor.next_after_number : "cursor missing";
     const cursorTitle = item.cursor?.next_after_number
       ? "Rotation cursor was recorded; the next pruning run should continue after this item."
@@ -6866,7 +6895,7 @@ function renderApplyHealth(data) {
       '<p>' + esc(applyHealthOperatorSummary(item, topInfo)) + '</p>' +
       '<p class="apply-health-next"><strong>Next check:</strong> ' + esc(topInfo.action) + '</p>' +
       applyHealthActionHtml(action) +
-      '<div class="apply-health-meta"><span class="pill" title="Records checked in this pruning window.">' + esc(processed) + ' processed</span><span class="pill" title="' + esc("Closure lane: " + closureProcessed + " records processed; " + closed + " closed.") + '">' + esc(closed) + ' closed</span><span class="pill" title="' + esc("Durable review comments refreshed across lanes: " + synced + ". Closure lane refreshed " + closureSynced + "; comment-sync lane refreshed " + syncLaneSynced + " from " + syncProcessed + " records.") + '">' + esc(synced) + ' comments synced</span>' + cursorPill + reasons + linkClass(item.run_url, "workflow run", "pill run-link") + '</div></div>';
+      '<div class="apply-health-meta"><span class="pill" title="Records checked in this pruning window.">' + esc(processed) + ' processed</span><span class="pill" title="' + esc("Closure lane: " + closureProcessed + " records processed; " + closed + " closed.") + '">' + esc(closed) + ' closed</span><span class="pill" title="' + esc("Durable review comments refreshed across lanes: " + synced + ". Closure lane refreshed " + closureSynced + "; comment-sync lane refreshed " + syncLaneSynced + " from " + syncProcessed + " records.") + '">' + esc(synced) + ' comments synced</span>' + cursorPill + reasons + buckets + linkClass(item.run_url, "workflow run", "pill run-link") + '</div></div>';
   }).join("");
 }
 function applyHealthNeedsAttention(status) {
@@ -6904,10 +6933,41 @@ function applyHealthReasonEntries(item) {
 function applyHealthPrimaryReason(item) {
   return applyHealthReasonEntries(item)[0]?.[0] || item.status || "";
 }
-function applyHealthReasonPill(reason, count) {
-  const info = applyHealthReasonInfo(reason);
+function applyHealthReasonPill(reason, count, item) {
+  const info = applyHealthReasonInfo(reason, item);
   const countText = Number.isFinite(count) ? " " + fmt.format(count) : "";
   return '<span class="pill apply-health-reason" title="' + esc(info.summary + " Next: " + info.action) + '">' + esc(info.label + countText) + '</span>';
+}
+function applyHealthNextActionForReason(item, reason) {
+  return (item.next_actions || []).find(action => action.reason === reason) || null;
+}
+function applyHealthNextActionBucketPills(item) {
+  const buckets = item.next_action_buckets || {};
+  const entries = Object.entries(buckets)
+    .filter(([, count]) => Number.isFinite(count) && count > 0)
+    .sort((left, right) => Number(right[1]) - Number(left[1]));
+  if (entries.length < 2) return "";
+  const total = entries.reduce((sum, [, count]) => sum + Number(count), 0);
+  const summary = entries
+    .slice(0, 4)
+    .map(([bucket, count]) => applyHealthBucketLabel(bucket) + " " + fmt.format(Number(count)))
+    .join("; ");
+  return '<span class="pill apply-health-reason" title="' + esc("Follow-up buckets: " + summary) + '">' + esc("follow-ups " + fmt.format(total)) + '</span>';
+}
+function applyHealthBucketLabel(bucket) {
+  const labels = {
+    already_resolved: "already resolved",
+    close_coverage_proof: "needs close proof",
+    defer_until_closing_pr: "defer for PR state",
+    inspect: "inspect skips",
+    live_state_recovery: "live check recovery",
+    maintainer_review: "maintainer decision",
+    report_quality_repair: "repair review report",
+    review_refresh: "refresh reviews",
+    run_budget: "runtime budget",
+    stable_skip: "stable skips",
+  };
+  return labels[bucket] || applyHealthReasonLabel(bucket);
 }
 function applyHealthActionHtml(action) {
   if (!action) return "";
@@ -6921,6 +6981,7 @@ function applyHealthRecommendedAction(item, reason) {
   const targetRepo = String(item.target_repo || "openclaw/openclaw");
   const mode = String(item.mode || "").toLowerCase();
   const workflowUrl = "https://github.com/openclaw/clawsweeper/actions/workflows/sweep.yml";
+  const nextAction = applyHealthNextActionForReason(item, reason);
   if (reason === "cursor_required_but_missing_after_full_window") {
     return {
       title: "Maintainer action: inspect the current run before rerunning, because a missing cursor can make the next run repeat the same window.",
@@ -6931,7 +6992,7 @@ function applyHealthRecommendedAction(item, reason) {
   }
   if (reason === "skipped_changed_since_review") {
     return {
-      title: "Maintainer action: refresh review records before trying to close changed items.",
+      title: "Maintainer action: " + (nextAction?.next_step || "refresh review records before trying to close changed items."),
       command: "gh workflow run sweep.yml --repo openclaw/clawsweeper -f target_repo=" + targetRepo + " -f apply_existing=false",
       url: workflowUrl,
       linkLabel: "open workflow",
@@ -6939,8 +7000,32 @@ function applyHealthRecommendedAction(item, reason) {
   }
   if (reason === "skipped_pr_close_coverage_proof") {
     return {
-      title: "Maintainer action: add close-coverage proof before retrying PR pruning.",
-      detail: "Add or refresh close-coverage proof, then rerun the close lane.",
+      title: "Maintainer action: " + (nextAction?.next_step || "add close-coverage proof before retrying PR pruning."),
+      detail: nextAction?.next_step || "Add or refresh close-coverage proof, then rerun the close lane.",
+      url: item.run_url || workflowUrl,
+      linkLabel: item.run_url ? "open run" : "open workflow",
+    };
+  }
+  if (nextAction && !nextAction.retryable) {
+    return {
+      title: "Maintainer action: " + (nextAction.next_step || "inspect this stable or policy-gated skip before rerunning."),
+      detail: nextAction.next_step || "No automatic rerun is recommended for this skip bucket.",
+      url: item.run_url || workflowUrl,
+      linkLabel: item.run_url ? "open run" : "open workflow",
+    };
+  }
+  if (nextAction && nextAction.bucket === "report_quality_repair") {
+    return {
+      title: "Maintainer action: " + (nextAction.next_step || "repair or refresh the review report."),
+      detail: nextAction.next_step || "Queue report-quality repair or re-review before retrying apply.",
+      url: item.run_url || workflowUrl,
+      linkLabel: item.run_url ? "open run" : "open workflow",
+    };
+  }
+  if (nextAction) {
+    return {
+      title: "Maintainer action: " + (nextAction.next_step || "inspect this follow-up before rerunning."),
+      detail: nextAction.next_step || "Inspect this follow-up bucket before retrying apply.",
       url: item.run_url || workflowUrl,
       linkLabel: item.run_url ? "open run" : "open workflow",
     };
@@ -6961,7 +7046,15 @@ function applyHealthRecommendedAction(item, reason) {
     linkLabel: "open workflow",
   };
 }
-function applyHealthReasonInfo(reason) {
+function applyHealthReasonInfo(reason, item) {
+  const nextAction = item ? applyHealthNextActionForReason(item, reason) : null;
+  if (nextAction?.label || nextAction?.summary || nextAction?.next_step) {
+    return {
+      label: nextAction.label || applyHealthReasonLabel(reason),
+      summary: nextAction.summary || "ClawSweeper classified this skip bucket with a deterministic follow-up.",
+      action: nextAction.next_step || "Inspect this follow-up bucket before rerunning.",
+    };
+  }
   const value = String(reason || "");
   if (value === "cursor_required_but_missing_after_full_window") {
     return {

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -131,6 +131,9 @@ is absent or a cache event lands in another Cloudflare colo.
 - lane-level apply health in status JSON so closure processing and durable
   review-comment sync are reported separately even when they share the same
   applicator
+- skip next-action buckets in apply health JSON so stale reviews, missing close
+  proof, protected labels, stable skips, invalid reports, and open closing PRs
+  are discoverable without reading individual item records
 
 The Worker fetches job details only for the bounded active-run set, limits that
 GitHub fanout to 12 concurrent requests, and caches each run's jobs for 60

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -41,6 +41,8 @@ type ApplyReportSummary = {
     closure: ApplyLaneSummary;
     comment_sync: ApplyLaneSummary;
   };
+  next_actions: ApplySkipNextAction[];
+  next_action_buckets: Record<string, number>;
   attention_reasons: string[];
   cursor_required: boolean;
   cursor: {
@@ -59,6 +61,26 @@ type ApplyLaneSummary = {
   skip_reasons: Record<string, number>;
 };
 
+type ApplySkipNextAction = {
+  reason: string;
+  count: number;
+  bucket:
+    | "review_refresh"
+    | "close_coverage_proof"
+    | "maintainer_review"
+    | "stable_skip"
+    | "report_quality_repair"
+    | "defer_until_closing_pr"
+    | "run_budget"
+    | "live_state_recovery"
+    | "already_resolved"
+    | "inspect";
+  owner: "clawsweeper" | "maintainer" | "github" | "none";
+  retryable: boolean;
+  label: string;
+  summary: string;
+  next_step: string;
+};
 const args = parseArgs(process.argv.slice(2));
 
 function runCli(): void {
@@ -333,6 +355,7 @@ export function summarizeApplyReport(options: ApplyReportSummaryOptions): ApplyR
       }
     }
   }
+  const nextActions = applySkipNextActions(skipReasons);
 
   const status =
     actions.length === 0 ? "idle" : attentionReasons.length > 0 ? "needs_attention" : "ok";
@@ -364,6 +387,8 @@ export function summarizeApplyReport(options: ApplyReportSummaryOptions): ApplyR
       Object.entries(skipReasons).sort(([left], [right]) => left.localeCompare(right)),
     ),
     lanes,
+    next_actions: nextActions,
+    next_action_buckets: applyNextActionBuckets(nextActions),
     attention_reasons: attentionReasons,
     cursor_required: options.cursorRequired,
     cursor,
@@ -435,6 +460,183 @@ function isProductiveApplyAction(entry: ApplyAction): boolean {
   );
 }
 
+function applySkipNextActions(skipReasons: Record<string, number>): ApplySkipNextAction[] {
+  return Object.entries(skipReasons)
+    .filter(([, count]) => Number.isFinite(count) && count > 0)
+    .map(([reason, count]) => applySkipNextAction(reason, count))
+    .sort(
+      (left, right) =>
+        right.count - left.count ||
+        applyNextActionBucketRank(left.bucket) - applyNextActionBucketRank(right.bucket) ||
+        left.reason.localeCompare(right.reason),
+    );
+}
+
+function applyNextActionBuckets(actions: ApplySkipNextAction[]): Record<string, number> {
+  const buckets: Record<string, number> = {};
+  for (const action of actions) {
+    buckets[action.bucket] = (buckets[action.bucket] || 0) + action.count;
+  }
+  return Object.fromEntries(
+    Object.entries(buckets).sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+function applyNextActionBucketRank(bucket: ApplySkipNextAction["bucket"]): number {
+  return [
+    "live_state_recovery",
+    "run_budget",
+    "review_refresh",
+    "close_coverage_proof",
+    "report_quality_repair",
+    "defer_until_closing_pr",
+    "maintainer_review",
+    "stable_skip",
+    "already_resolved",
+    "inspect",
+  ].indexOf(bucket);
+}
+
+function applySkipNextAction(reason: string, count: number): ApplySkipNextAction {
+  if (reason === "skipped_changed_since_review") {
+    return {
+      reason,
+      count,
+      bucket: "review_refresh",
+      owner: "clawsweeper",
+      retryable: true,
+      label: "Refresh review",
+      summary: "The item changed after the review that proposed closing it.",
+      next_step: "Queue a fresh ClawSweeper review before any close retry.",
+    };
+  }
+  if (reason === "skipped_pr_close_coverage_proof") {
+    return {
+      reason,
+      count,
+      bucket: "close_coverage_proof",
+      owner: "clawsweeper",
+      retryable: true,
+      label: "Add close proof",
+      summary: "The PR close proposal needs coverage proof before it can be applied.",
+      next_step: "Run or refresh close-coverage proof for the canonical/covered PR pair.",
+    };
+  }
+  if (reason === "skipped_protected_label" || reason === "skipped_policy_exempt") {
+    return {
+      reason,
+      count,
+      bucket: "maintainer_review",
+      owner: "maintainer",
+      retryable: false,
+      label: "Maintainer decision",
+      summary: "A protected label or policy exemption blocks automated pruning.",
+      next_step: "Have a maintainer confirm the label/policy should remain or close manually.",
+    };
+  }
+  if (reason === "skipped_maintainer_authored") {
+    return {
+      reason,
+      count,
+      bucket: "maintainer_review",
+      owner: "maintainer",
+      retryable: false,
+      label: "Maintainer-authored",
+      summary: "Automation does not close maintainer-authored items without human judgement.",
+      next_step: "Route to maintainer review or close manually if the owner agrees.",
+    };
+  }
+  if (reason === "skipped_same_author_pair") {
+    return {
+      reason,
+      count,
+      bucket: "stable_skip",
+      owner: "none",
+      retryable: false,
+      label: "Stable skip",
+      summary:
+        "The source and canonical items have the same author, so automated duplicate close is intentionally conservative.",
+      next_step: "Leave as a stable skip unless maintainers change the same-author close policy.",
+    };
+  }
+  if (reason === "skipped_invalid_decision") {
+    return {
+      reason,
+      count,
+      bucket: "report_quality_repair",
+      owner: "clawsweeper",
+      retryable: true,
+      label: "Repair review report",
+      summary: "The durable review decision was incomplete or invalid for apply.",
+      next_step: "Queue report-quality repair or re-review so the close decision becomes valid.",
+    };
+  }
+  if (reason === "skipped_open_closing_pr") {
+    return {
+      reason,
+      count,
+      bucket: "defer_until_closing_pr",
+      owner: "github",
+      retryable: false,
+      label: "Wait for closing PR",
+      summary: "The item appears covered by a pull request that is still open.",
+      next_step: "Defer until the linked closing PR merges, closes, or changes state.",
+    };
+  }
+  if (reason === "skipped_runtime_budget") {
+    return {
+      reason,
+      count,
+      bucket: "run_budget",
+      owner: "clawsweeper",
+      retryable: true,
+      label: "Runtime budget",
+      summary: "The apply lane stopped because it reached its bounded runtime.",
+      next_step: "Let the next scheduled run continue; tune runtime or batch size if this repeats.",
+    };
+  }
+  if (reason === "skipped_live_fetch_failed") {
+    return {
+      reason,
+      count,
+      bucket: "live_state_recovery",
+      owner: "github",
+      retryable: true,
+      label: "Recover live check",
+      summary: "ClawSweeper could not confirm live GitHub state before mutating.",
+      next_step:
+        "Inspect auth, API, or rate-limit failures and retry only after live checks recover.",
+    };
+  }
+  if (
+    reason === "skipped_not_open" ||
+    reason === "skipped_already_closed" ||
+    reason === "skipped_closed"
+  ) {
+    return {
+      reason,
+      count,
+      bucket: "already_resolved",
+      owner: "none",
+      retryable: false,
+      label: "Already resolved",
+      summary: "The item was not open by the time apply checked it.",
+      next_step:
+        "No action is normally needed; investigate only if this bucket dominates repeated runs.",
+    };
+  }
+  return {
+    reason,
+    count,
+    bucket: "inspect",
+    owner: "maintainer",
+    retryable: false,
+    label: "Inspect skip",
+    summary: "Apply reported an unmapped skip bucket.",
+    next_step:
+      "Inspect the workflow run and add a deterministic next-action mapping if this repeats.",
+  };
+}
 function applyReportHealthSummary(options: {
   status: ApplyReportSummary["status"];
   processed: number;

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -67,6 +67,7 @@ type ApplySkipNextAction = {
   bucket:
     | "review_refresh"
     | "close_coverage_proof"
+    | "conversation_unlock"
     | "maintainer_review"
     | "stable_skip"
     | "report_quality_repair"
@@ -81,6 +82,8 @@ type ApplySkipNextAction = {
   summary: string;
   next_step: string;
 };
+
+type ApplySkipNextActionDetail = Omit<ApplySkipNextAction, "reason" | "count">;
 const args = parseArgs(process.argv.slice(2));
 
 function runCli(): void {
@@ -490,6 +493,7 @@ function applyNextActionBucketRank(bucket: ApplySkipNextAction["bucket"]): numbe
     "close_coverage_proof",
     "report_quality_repair",
     "defer_until_closing_pr",
+    "conversation_unlock",
     "maintainer_review",
     "stable_skip",
     "already_resolved",
@@ -497,144 +501,147 @@ function applyNextActionBucketRank(bucket: ApplySkipNextAction["bucket"]): numbe
   ].indexOf(bucket);
 }
 
+const APPLY_SKIP_NEXT_ACTION_DETAILS: Record<string, ApplySkipNextActionDetail> = {
+  skipped_changed_since_review: {
+    bucket: "review_refresh",
+    owner: "clawsweeper",
+    retryable: true,
+    label: "Refresh review",
+    summary: "The item changed after the review that proposed closing it.",
+    next_step: "Queue a fresh ClawSweeper review before any close retry.",
+  },
+  skipped_stale_review_comment_sync: {
+    bucket: "review_refresh",
+    owner: "clawsweeper",
+    retryable: true,
+    label: "Refresh review state",
+    summary: "The durable review comment is newer than the local review report.",
+    next_step: "Queue a fresh review instead of overwriting the newer durable comment.",
+  },
+  skipped_pr_close_coverage_proof: {
+    bucket: "close_coverage_proof",
+    owner: "clawsweeper",
+    retryable: true,
+    label: "Add close proof",
+    summary: "The PR close proposal needs positive coverage proof before apply can close it.",
+    next_step: "Run or refresh close-coverage proof for the canonical and covered PR pair.",
+  },
+  retry_pr_close_coverage_proof: {
+    bucket: "close_coverage_proof",
+    owner: "clawsweeper",
+    retryable: true,
+    label: "Retry close proof",
+    summary: "The close-coverage proof check failed transiently before reaching a decision.",
+    next_step: "Inspect the proof failure, then retry after model and GitHub access recover.",
+  },
+  skipped_protected_label: maintainerDecisionAction(),
+  skipped_policy_exempt: maintainerDecisionAction(),
+  skipped_maintainer_authored: {
+    bucket: "maintainer_review",
+    owner: "maintainer",
+    retryable: false,
+    label: "Maintainer-authored",
+    summary: "Automation does not close maintainer-authored items without human judgement.",
+    next_step: "Route to maintainer review or close manually if the owner agrees.",
+  },
+  skipped_locked_conversation: {
+    bucket: "conversation_unlock",
+    owner: "maintainer",
+    retryable: false,
+    label: "Conversation locked",
+    summary: "GitHub blocked the durable comment write because the conversation is locked.",
+    next_step: "Unlock the conversation before retrying comment sync, or leave it unchanged.",
+  },
+  skipped_same_author_pair: {
+    bucket: "stable_skip",
+    owner: "none",
+    retryable: false,
+    label: "Stable skip",
+    summary:
+      "The source and canonical items have the same author, so automated duplicate close is intentionally conservative.",
+    next_step: "Leave as a stable skip unless maintainers change the same-author close policy.",
+  },
+  skipped_invalid_decision: reportRepairAction(),
+  skipped_missing_record: reportRepairAction(),
+  skipped_open_closing_pr: {
+    bucket: "defer_until_closing_pr",
+    owner: "github",
+    retryable: false,
+    label: "Wait for closing PR",
+    summary: "The item appears covered by a pull request that is still open.",
+    next_step: "Defer until the linked closing PR merges, closes, or changes state.",
+  },
+  skipped_runtime_budget: {
+    bucket: "run_budget",
+    owner: "clawsweeper",
+    retryable: true,
+    label: "Runtime budget",
+    summary: "The apply lane stopped because it reached its bounded runtime.",
+    next_step: "Let the next scheduled run continue; tune runtime or batch size if this repeats.",
+  },
+  skipped_live_fetch_failed: {
+    bucket: "live_state_recovery",
+    owner: "github",
+    retryable: true,
+    label: "Recover live check",
+    summary: "ClawSweeper could not confirm live GitHub state before mutating.",
+    next_step: "Inspect auth, API, or rate-limit failures and retry after live checks recover.",
+  },
+  skipped_comment_auth: {
+    bucket: "live_state_recovery",
+    owner: "clawsweeper",
+    retryable: true,
+    label: "Repair comment auth",
+    summary: "GitHub rejected the durable review comment write as unauthenticated.",
+    next_step: "Repair the GitHub App write token before retrying comment sync.",
+  },
+  skipped_not_open: alreadyResolvedAction(),
+  skipped_already_closed: alreadyResolvedAction(),
+  skipped_closed: alreadyResolvedAction(),
+};
+
 function applySkipNextAction(reason: string, count: number): ApplySkipNextAction {
-  if (reason === "skipped_changed_since_review") {
-    return {
-      reason,
-      count,
-      bucket: "review_refresh",
-      owner: "clawsweeper",
-      retryable: true,
-      label: "Refresh review",
-      summary: "The item changed after the review that proposed closing it.",
-      next_step: "Queue a fresh ClawSweeper review before any close retry.",
-    };
-  }
-  if (reason === "skipped_pr_close_coverage_proof") {
-    return {
-      reason,
-      count,
-      bucket: "close_coverage_proof",
-      owner: "clawsweeper",
-      retryable: true,
-      label: "Add close proof",
-      summary: "The PR close proposal needs coverage proof before it can be applied.",
-      next_step: "Run or refresh close-coverage proof for the canonical/covered PR pair.",
-    };
-  }
-  if (reason === "skipped_protected_label" || reason === "skipped_policy_exempt") {
-    return {
-      reason,
-      count,
-      bucket: "maintainer_review",
-      owner: "maintainer",
-      retryable: false,
-      label: "Maintainer decision",
-      summary: "A protected label or policy exemption blocks automated pruning.",
-      next_step: "Have a maintainer confirm the label/policy should remain or close manually.",
-    };
-  }
-  if (reason === "skipped_maintainer_authored") {
-    return {
-      reason,
-      count,
-      bucket: "maintainer_review",
-      owner: "maintainer",
-      retryable: false,
-      label: "Maintainer-authored",
-      summary: "Automation does not close maintainer-authored items without human judgement.",
-      next_step: "Route to maintainer review or close manually if the owner agrees.",
-    };
-  }
-  if (reason === "skipped_same_author_pair") {
-    return {
-      reason,
-      count,
-      bucket: "stable_skip",
-      owner: "none",
-      retryable: false,
-      label: "Stable skip",
-      summary:
-        "The source and canonical items have the same author, so automated duplicate close is intentionally conservative.",
-      next_step: "Leave as a stable skip unless maintainers change the same-author close policy.",
-    };
-  }
-  if (reason === "skipped_invalid_decision") {
-    return {
-      reason,
-      count,
-      bucket: "report_quality_repair",
-      owner: "clawsweeper",
-      retryable: true,
-      label: "Repair review report",
-      summary: "The durable review decision was incomplete or invalid for apply.",
-      next_step: "Queue report-quality repair or re-review so the close decision becomes valid.",
-    };
-  }
-  if (reason === "skipped_open_closing_pr") {
-    return {
-      reason,
-      count,
-      bucket: "defer_until_closing_pr",
-      owner: "github",
-      retryable: false,
-      label: "Wait for closing PR",
-      summary: "The item appears covered by a pull request that is still open.",
-      next_step: "Defer until the linked closing PR merges, closes, or changes state.",
-    };
-  }
-  if (reason === "skipped_runtime_budget") {
-    return {
-      reason,
-      count,
-      bucket: "run_budget",
-      owner: "clawsweeper",
-      retryable: true,
-      label: "Runtime budget",
-      summary: "The apply lane stopped because it reached its bounded runtime.",
-      next_step: "Let the next scheduled run continue; tune runtime or batch size if this repeats.",
-    };
-  }
-  if (reason === "skipped_live_fetch_failed") {
-    return {
-      reason,
-      count,
-      bucket: "live_state_recovery",
-      owner: "github",
-      retryable: true,
-      label: "Recover live check",
-      summary: "ClawSweeper could not confirm live GitHub state before mutating.",
-      next_step:
-        "Inspect auth, API, or rate-limit failures and retry only after live checks recover.",
-    };
-  }
-  if (
-    reason === "skipped_not_open" ||
-    reason === "skipped_already_closed" ||
-    reason === "skipped_closed"
-  ) {
-    return {
-      reason,
-      count,
-      bucket: "already_resolved",
-      owner: "none",
-      retryable: false,
-      label: "Already resolved",
-      summary: "The item was not open by the time apply checked it.",
-      next_step:
-        "No action is normally needed; investigate only if this bucket dominates repeated runs.",
-    };
-  }
-  return {
-    reason,
-    count,
+  const detail = APPLY_SKIP_NEXT_ACTION_DETAILS[reason] ?? {
     bucket: "inspect",
     owner: "maintainer",
     retryable: false,
     label: "Inspect skip",
     summary: "Apply reported an unmapped skip bucket.",
-    next_step:
-      "Inspect the workflow run and add a deterministic next-action mapping if this repeats.",
+    next_step: "Inspect the workflow run and add a deterministic mapping if this repeats.",
+  };
+  return { reason, count, ...detail };
+}
+
+function maintainerDecisionAction(): ApplySkipNextActionDetail {
+  return {
+    bucket: "maintainer_review",
+    owner: "maintainer",
+    retryable: false,
+    label: "Maintainer decision",
+    summary: "A protected label or policy exemption blocks automated pruning.",
+    next_step: "Confirm the policy should remain, or close manually if it should not.",
+  };
+}
+
+function reportRepairAction(): ApplySkipNextActionDetail {
+  return {
+    bucket: "report_quality_repair",
+    owner: "clawsweeper",
+    retryable: true,
+    label: "Repair review report",
+    summary: "The durable review record is missing or invalid for apply.",
+    next_step: "Queue a fresh review so apply receives a complete, valid decision.",
+  };
+}
+
+function alreadyResolvedAction(): ApplySkipNextActionDetail {
+  return {
+    bucket: "already_resolved",
+    owner: "none",
+    retryable: false,
+    label: "Already resolved",
+    summary: "The item was not open by the time apply checked it.",
+    next_step: "No action is needed unless this bucket dominates repeated runs.",
   };
 }
 function applyReportHealthSummary(options: {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -1542,6 +1542,21 @@ test("dashboard exposes apply health from sweep status without broad scans", asy
           skip_reasons: {},
         },
       },
+      next_actions: [
+        {
+          reason: "skipped_changed_since_review",
+          count: 2,
+          bucket: "review_refresh",
+          owner: "clawsweeper",
+          retryable: true,
+          label: "Refresh review",
+          summary: "The item changed after the review that proposed closing it.",
+          next_step: "Queue a fresh ClawSweeper review before any close retry.",
+        },
+      ],
+      next_action_buckets: {
+        review_refresh: 2,
+      },
       attention_reasons: ["cursor_required_but_missing_after_full_window"],
       cursor: null,
     },
@@ -1597,6 +1612,13 @@ test("dashboard exposes apply health from sweep status without broad scans", asy
       },
     });
     assert.equal(status.recent.apply_health.items[0].lanes.comment_sync.processed, 0);
+    assert.deepEqual(status.recent.apply_health.items[0].next_action_buckets, {
+      review_refresh: 2,
+    });
+    assert.equal(
+      status.recent.apply_health.items[0].next_actions[0].next_step,
+      "Queue a fresh ClawSweeper review before any close retry.",
+    );
     assert.equal(status.recent.apply_health.items[0].cursor, null);
   } finally {
     globalThis.fetch = originalFetch;

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -290,6 +290,57 @@ test("workflow utilities summarize comment-sync apply reports separately from cl
   });
 });
 
+test("workflow utilities classify common apply skip reasons into next actions", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const reportPath = path.join(root, "apply-report.json");
+  write(
+    reportPath,
+    JSON.stringify([
+      { number: 10, action: "skipped_pr_close_coverage_proof" },
+      { number: 20, action: "skipped_protected_label" },
+      { number: 30, action: "skipped_same_author_pair" },
+      { number: 40, action: "skipped_invalid_decision" },
+      { number: 50, action: "skipped_open_closing_pr" },
+      { number: 60, action: "skipped_maintainer_authored" },
+    ]),
+  );
+
+  const summary = summarizeApplyReport({
+    reportPath,
+    targetRepo: "openclaw/openclaw",
+    mode: "close",
+    processedLimit: 300,
+    closeLimit: 5,
+    cursorPath: path.join(root, "missing-cursor.json"),
+    cursorRequired: false,
+  });
+
+  assert.deepEqual(summary.next_action_buckets, {
+    close_coverage_proof: 1,
+    defer_until_closing_pr: 1,
+    maintainer_review: 2,
+    report_quality_repair: 1,
+    stable_skip: 1,
+  });
+  assert.equal(
+    summary.next_actions.find((action) => action.reason === "skipped_pr_close_coverage_proof")
+      ?.next_step,
+    "Run or refresh close-coverage proof for the canonical/covered PR pair.",
+  );
+  assert.equal(
+    summary.next_actions.find((action) => action.reason === "skipped_open_closing_pr")?.bucket,
+    "defer_until_closing_pr",
+  );
+  assert.equal(
+    summary.next_actions.find((action) => action.reason === "skipped_same_author_pair")?.retryable,
+    false,
+  );
+  assert.equal(
+    summary.next_actions.find((action) => action.reason === "skipped_invalid_decision")?.owner,
+    "clawsweeper",
+  );
+});
+
 test("workflow utilities flag full-window close scans without the required cursor", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
   const reportPath = path.join(root, "apply-report.json");

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -243,6 +243,15 @@ test("workflow utilities summarize apply health with skip buckets and cursor", (
       skipped_locked_conversation: 1,
     },
   });
+  assert.deepEqual(summary.next_action_buckets, {
+    conversation_unlock: 1,
+    live_state_recovery: 1,
+    review_refresh: 2,
+  });
+  assert.equal(
+    summary.next_actions.find((action) => action.reason === "skipped_comment_auth")?.next_step,
+    "Repair the GitHub App write token before retrying comment sync.",
+  );
   assert.equal(summary.cursor?.next_after_number, 40);
 });
 
@@ -288,6 +297,15 @@ test("workflow utilities summarize comment-sync apply reports separately from cl
       skipped_stale_review_comment_sync: 1,
     },
   });
+  assert.deepEqual(summary.next_action_buckets, {
+    close_coverage_proof: 1,
+    review_refresh: 1,
+  });
+  assert.equal(
+    summary.next_actions.find((action) => action.reason === "skipped_stale_review_comment_sync")
+      ?.label,
+    "Refresh review state",
+  );
 });
 
 test("workflow utilities classify common apply skip reasons into next actions", () => {
@@ -302,6 +320,8 @@ test("workflow utilities classify common apply skip reasons into next actions", 
       { number: 40, action: "skipped_invalid_decision" },
       { number: 50, action: "skipped_open_closing_pr" },
       { number: 60, action: "skipped_maintainer_authored" },
+      { number: 70, action: "retry_pr_close_coverage_proof" },
+      { number: 80, action: "skipped_missing_record" },
     ]),
   );
 
@@ -316,16 +336,16 @@ test("workflow utilities classify common apply skip reasons into next actions", 
   });
 
   assert.deepEqual(summary.next_action_buckets, {
-    close_coverage_proof: 1,
+    close_coverage_proof: 2,
     defer_until_closing_pr: 1,
     maintainer_review: 2,
-    report_quality_repair: 1,
+    report_quality_repair: 2,
     stable_skip: 1,
   });
   assert.equal(
     summary.next_actions.find((action) => action.reason === "skipped_pr_close_coverage_proof")
       ?.next_step,
-    "Run or refresh close-coverage proof for the canonical/covered PR pair.",
+    "Run or refresh close-coverage proof for the canonical and covered PR pair.",
   );
   assert.equal(
     summary.next_actions.find((action) => action.reason === "skipped_open_closing_pr")?.bucket,
@@ -338,6 +358,14 @@ test("workflow utilities classify common apply skip reasons into next actions", 
   assert.equal(
     summary.next_actions.find((action) => action.reason === "skipped_invalid_decision")?.owner,
     "clawsweeper",
+  );
+  assert.equal(
+    summary.next_actions.find((action) => action.reason === "retry_pr_close_coverage_proof")?.label,
+    "Retry close proof",
+  );
+  assert.equal(
+    summary.next_actions.find((action) => action.reason === "skipped_missing_record")?.bucket,
+    "report_quality_repair",
   );
 });
 


### PR DESCRIPTION
## What Problem This Solves

Apply health previously exposed raw skip reason names without telling maintainers whether a blocked window needed a fresh review, close-proof work, an auth repair, an unlock, human judgement, or no action.

## Why This Change Was Made

- Adds durable `next_actions` and `next_action_buckets` to apply report summaries.
- Classifies closure and comment-sync outcomes into human-readable labels, owners, retryability, and concrete next steps.
- Covers changed reviews, stale durable comments, close-proof blocks and transient retries, protected/maintainer items, locked conversations, missing or invalid reports, runtime limits, live-state failures, auth failures, stable skips, and already-resolved items.
- Teaches the dashboard to prefer the durable guidance while preserving the lane-level health contract from #397.
- Keeps stable and non-retryable outcomes from suggesting misleading rerun commands.

## User Impact

Maintainers can distinguish “wait,” “repair,” “review,” and “retry” outcomes directly from the live dashboard instead of decoding internal action names or opening every item record. No close gate is weakened and the dashboard does not dispatch work by itself.

## Evidence

- Rebased onto current `main` after #397.
- `pnpm run build:all` passed.
- `node --test test/repair/workflow-utils.test.ts test/dashboard-worker.test.ts` passed: 77 passed, 0 failed.
- Focused autoreview of the maintainer taxonomy changes: no accepted/actionable findings.
- Whole-branch autoreview: no accepted/actionable findings, confidence 0.90.
- Exact-head GitHub CI is green: pnpm check, Windows launcher, CodeQL, and Socket checks passed.

## Risk Notes

- Durable status JSON gains additive fields; existing aggregate and lane fields remain intact.
- Operator copy is deterministic and escaped before dashboard rendering.
- Proof images remain in the PR discussion only; no screenshot assets are committed to the product repository.

