### PR TITLE
fix(apply): restore PR review labels when the reviewed head matches the live head

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -17567,6 +17567,7 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       if (!storedUpdatedAt) return false;
       if (!updatedSinceReview || reviewCommentOnlyUpdate) return true;
       const completeFreshHeadReview =
+        !isCloseProposal &&
         item.kind === "pull_request" &&
         frontMatterValue(markdown, "review_status") === "complete" &&
         freshPullRequestReviewHead(markdown, currentItemContext());

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -15190,6 +15190,13 @@ function stalePullRequestReviewHead(
   };
 }
 
+function freshPullRequestReviewHead(markdown: string, context: ItemContext): boolean {
+  if (frontMatterValue(markdown, "type") !== "pull_request") return false;
+  const reportHeadSha = pullHeadShaFromReport(markdown);
+  const liveHeadSha = pullHeadShaFromContext(context);
+  return Boolean(reportHeadSha && liveHeadSha && reportHeadSha === liveHeadSha);
+}
+
 function isStalePullRequestReviewLabel(label: string): boolean {
   return (
     isClawSweeperOwnedLabel(label) &&
@@ -17559,11 +17566,19 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
     const labelSyncFreshEnough = (): boolean => {
       if (!storedUpdatedAt) return false;
       if (!updatedSinceReview || reviewCommentOnlyUpdate) return true;
-      const existingReviewCommentUpdatedAtMs = timestampMs(commentUpdatedAt(existingReviewComment));
-      const itemUpdatedAtMs = timestampMs(item.updatedAt);
-      if (existingReviewCommentUpdatedAtMs === null || itemUpdatedAtMs === null) return false;
-      if (Math.abs(itemUpdatedAtMs - existingReviewCommentUpdatedAtMs) > 5 * 60 * 1000) {
-        return false;
+      const completeFreshHeadReview =
+        item.kind === "pull_request" &&
+        frontMatterValue(markdown, "review_status") === "complete" &&
+        freshPullRequestReviewHead(markdown, currentItemContext());
+      if (!completeFreshHeadReview) {
+        const existingReviewCommentUpdatedAtMs = timestampMs(
+          commentUpdatedAt(existingReviewComment),
+        );
+        const itemUpdatedAtMs = timestampMs(item.updatedAt);
+        if (existingReviewCommentUpdatedAtMs === null || itemUpdatedAtMs === null) return false;
+        if (Math.abs(itemUpdatedAtMs - existingReviewCommentUpdatedAtMs) > 5 * 60 * 1000) {
+          return false;
+        }
       }
       const storedUpdatedAtMs = timestampMs(storedUpdatedAt);
       if (storedUpdatedAtMs === null) return false;

--- a/test/apply-label-sync.test.ts
+++ b/test/apply-label-sync.test.ts
@@ -474,6 +474,7 @@ test("apply-decisions syncs fresh-head PR review labels when bot activity bumps 
       item_updated_at: "2026-07-03T21:42:48Z",
       reviewed_at: "2026-07-03T21:42:48Z",
       pull_head_sha: "bc60b889",
+      merge_risk_labels: JSON.stringify(["merge-risk: 🚨 session-state"]),
     })}
 
 ## Summary
@@ -614,6 +615,24 @@ if (args[0] === "api" && /\\/issues\\/74482$/.test(path)) {
           args.includes("proof: sufficient"),
       ),
     );
+    assert(
+      calls.some(
+        (args) =>
+          args[0] === "issue" &&
+          args[1] === "edit" &&
+          args.includes("--add-label") &&
+          args.includes("merge-risk: 🚨 session-state"),
+      ),
+    );
+    const patchedBody = calls.find((args) => args[0] === "patched-review-body")?.[1] ?? "";
+    assert.match(patchedBody, /Label justifications:/);
+    assert.deepEqual(JSON.parse(readFileSync(reportPath, "utf8")), [
+      {
+        number: 74482,
+        action: "review_comment_synced",
+        reason: "updated durable Codex review comment",
+      },
+    ]);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -771,6 +790,183 @@ if (args[0] === "api" && /\\/issues\\/74483$/.test(path)) {
       .map((line) => JSON.parse(line) as string[]);
     assert.equal(
       calls.some((args) => args[0] === "issue" && args[1] === "edit"),
+      false,
+    );
+    assert.equal(
+      calls.some((args) => args[0] === "label" && args[1] === "create"),
+      false,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions withholds fresh-head PR label sync from close proposals", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const logPath = join(root, "gh.log");
+    const itemPath = join(itemsDir, "74484.md");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const sourceReport = `${reportFrontMatter({
+      repository: "openclaw/openclaw",
+      type: "pull_request",
+      number: "74484",
+      title: "Fresh head close proposal",
+      url: "https://github.com/openclaw/openclaw/pull/74484",
+      decision: "close",
+      close_reason: "low_signal_unmergeable_pr",
+      confidence: "high",
+      action_taken: "proposed_close",
+      review_status: "complete",
+      local_checkout_access: "verified",
+      author: "contributor",
+      author_association: "CONTRIBUTOR",
+      labels: JSON.stringify([]),
+      item_snapshot_hash: "snapshot-a",
+      item_updated_at: "2026-07-03T21:42:48Z",
+      reviewed_at: "2026-07-03T21:42:48Z",
+      pull_head_sha: "bc60b889",
+    })}
+
+## Summary
+
+A close proposal must not regain PR labels through the fresh-head allowance.
+
+${realBehaviorProofReportSection()}
+
+${prRatingReportSection({ overallTier: "F", proofTier: "F", patchTier: "F" })}
+
+## Review Findings
+
+Overall correctness: patch is incorrect
+
+Overall confidence: 0.9
+
+Full review comments:
+
+- none
+
+## Evidence
+
+- **branch shape:** PR diff is mostly unrelated provider churn around a tiny possible useful tweak
+
+## Close Comment
+
+Closing this PR because the branch is not a useful landing base.
+`;
+    const synced = reportWithSyncedReviewComment(sourceReport, 74484, "low_signal_unmergeable_pr");
+    writeFileSync(itemPath, synced.report, "utf8");
+
+    const ghMock = `
+const { appendFileSync, readFileSync } = require("fs");
+const logPath = ${JSON.stringify(logPath)};
+const comment = ${JSON.stringify(synced.comment)};
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+appendFileSync(logPath, JSON.stringify(args) + "\\n");
+const path = args[1] || "";
+if (args[0] === "api" && /\\/issues\\/74484$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 74484,
+    title: "Fresh head close proposal",
+    html_url: "https://github.com/openclaw/openclaw/pull/74484",
+    created_at: "2026-07-03T19:00:00Z",
+    updated_at: "2026-07-03T21:43:45Z",
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "contributor" },
+    labels: [],
+    pull_request: {}
+  }));
+} else if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/74484\\/timeline(?:\\?|$)/.test(args[2] || "")) {
+  console.log("HTTP/2 200\\n\\n[]");
+} else if (args[0] === "api" && /\\/issues\\/74484\\/timeline(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/pulls\\/74484$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 74484,
+    html_url: "https://github.com/openclaw/openclaw/pull/74484",
+    state: "open",
+    changed_files: 1,
+    commits: 2,
+    review_comments: 0,
+    requested_reviewers: [],
+    requested_teams: [],
+    head: { sha: "bc60b889", ref: "branch", repo: { full_name: "fork/openclaw" } },
+    base: { sha: "base-sha", ref: "main", repo: { full_name: "openclaw/openclaw" } },
+    user: { login: "contributor" }
+  }));
+} else if (args[0] === "api" && /\\/pulls\\/74484\\/reviews(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/pulls\\/74484\\/(files|commits|comments)(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/issues\\/74484\\/comments(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[
+    {
+      id: 987486,
+      html_url: "https://github.com/openclaw/openclaw/pull/74484#issuecomment-987486",
+      body: comment,
+      user: { login: "clawsweeper[bot]" },
+      created_at: "2026-07-03T21:33:21Z",
+      updated_at: "2026-07-03T21:33:21Z"
+    },
+    {
+      id: 987487,
+      html_url: "https://github.com/openclaw/openclaw/pull/74484#issuecomment-987487",
+      body: "Pushed a new head, please take another look.",
+      user: { login: "contributor" },
+      author_association: "CONTRIBUTOR",
+      created_at: "2026-07-03T21:42:28Z",
+      updated_at: "2026-07-03T21:42:28Z"
+    }
+  ]]));
+} else if (args[0] === "api" && /\\/issues\\/comments\\/987486$/.test(path)) {
+  const input = args[args.indexOf("--input") + 1];
+  appendFileSync(logPath, JSON.stringify(["patched-review-body", JSON.parse(readFileSync(input, "utf8")).body]) + "\\n");
+  console.log(JSON.stringify({
+    id: 987486,
+    html_url: "https://github.com/openclaw/openclaw/pull/74484#issuecomment-987486",
+    updated_at: "2026-07-03T21:48:00Z"
+  }));
+} else if (args[0] === "issue" && args[1] === "edit") {
+  console.log("");
+} else if (args[0] === "label" && args[1] === "create") {
+  console.log(JSON.stringify({ name: args[2] }));
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        targetRepo: "openclaw/openclaw",
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: ["--sync-comments-only", "--item-numbers", "74484"],
+      });
+    });
+
+    const updatedReport = readFileSync(itemPath, "utf8");
+    assert.doesNotMatch(updatedReport, /^labels_synced_at: /m);
+    const calls = readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as string[]);
+    assert.equal(
+      calls.some(
+        (args) => args[0] === "issue" && args[1] === "edit" && args.includes("--add-label"),
+      ),
       false,
     );
     assert.equal(

--- a/test/apply-label-sync.test.ts
+++ b/test/apply-label-sync.test.ts
@@ -444,6 +444,344 @@ if (args[0] === "api" && /\\/issues\\/74481$/.test(path)) {
   }
 });
 
+test("apply-decisions syncs fresh-head PR review labels when bot activity bumps updated_at", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const logPath = join(root, "gh.log");
+    const itemPath = join(itemsDir, "74482.md");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const sourceReport = `${reportFrontMatter({
+      repository: "openclaw/openclaw",
+      type: "pull_request",
+      number: "74482",
+      title: "Fresh head label restore",
+      url: "https://github.com/openclaw/openclaw/pull/74482",
+      decision: "keep_open",
+      close_reason: "none",
+      confidence: "high",
+      action_taken: "kept_open",
+      review_status: "complete",
+      local_checkout_access: "verified",
+      author: "contributor",
+      author_association: "CONTRIBUTOR",
+      labels: JSON.stringify([]),
+      item_snapshot_hash: "snapshot-a",
+      item_updated_at: "2026-07-03T21:42:48Z",
+      reviewed_at: "2026-07-03T21:42:48Z",
+      pull_head_sha: "bc60b889",
+    })}
+
+## Summary
+
+This fresh review must keep driving PR labels even after a bot ack edit bumps updated_at.
+
+${realBehaviorProofReportSection()}
+
+${prRatingReportSection({ overallTier: "A" })}
+
+## Review Findings
+
+Overall correctness: patch is correct
+
+Overall confidence: 0.9
+
+Full review comments:
+
+- none
+`;
+    const synced = reportWithSyncedReviewComment(sourceReport, 74482);
+    writeFileSync(itemPath, synced.report, "utf8");
+
+    const ghMock = `
+const { appendFileSync, readFileSync } = require("fs");
+const logPath = ${JSON.stringify(logPath)};
+const comment = ${JSON.stringify(synced.comment)};
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+appendFileSync(logPath, JSON.stringify(args) + "\\n");
+const path = args[1] || "";
+if (args[0] === "api" && /\\/issues\\/74482$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 74482,
+    title: "Fresh head label restore",
+    html_url: "https://github.com/openclaw/openclaw/pull/74482",
+    created_at: "2026-07-03T19:00:00Z",
+    updated_at: "2026-07-03T21:43:45Z",
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "contributor" },
+    labels: [],
+    pull_request: {}
+  }));
+} else if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/74482\\/timeline(?:\\?|$)/.test(args[2] || "")) {
+  console.log("HTTP/2 200\\n\\n[]");
+} else if (args[0] === "api" && /\\/issues\\/74482\\/timeline(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/pulls\\/74482$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 74482,
+    html_url: "https://github.com/openclaw/openclaw/pull/74482",
+    state: "open",
+    changed_files: 1,
+    commits: 2,
+    review_comments: 0,
+    head: { sha: "bc60b889", ref: "branch", repo: { full_name: "fork/openclaw" } },
+    base: { sha: "base-sha", ref: "main", repo: { full_name: "openclaw/openclaw" } },
+    user: { login: "contributor" }
+  }));
+} else if (args[0] === "api" && /\\/pulls\\/74482\\/(files|commits|comments)(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/issues\\/74482\\/comments(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[
+    {
+      id: 987482,
+      html_url: "https://github.com/openclaw/openclaw/pull/74482#issuecomment-987482",
+      body: comment,
+      user: { login: "clawsweeper[bot]" },
+      created_at: "2026-07-03T21:33:21Z",
+      updated_at: "2026-07-03T21:33:21Z"
+    },
+    {
+      id: 987483,
+      html_url: "https://github.com/openclaw/openclaw/pull/74482#issuecomment-987483",
+      body: "Pushed a new head, please take another look.",
+      user: { login: "contributor" },
+      author_association: "CONTRIBUTOR",
+      created_at: "2026-07-03T21:42:28Z",
+      updated_at: "2026-07-03T21:42:28Z"
+    }
+  ]]));
+} else if (args[0] === "api" && /\\/issues\\/comments\\/987482$/.test(path)) {
+  const input = args[args.indexOf("--input") + 1];
+  appendFileSync(logPath, JSON.stringify(["patched-review-body", JSON.parse(readFileSync(input, "utf8")).body]) + "\\n");
+  console.log(JSON.stringify({
+    id: 987482,
+    html_url: "https://github.com/openclaw/openclaw/pull/74482#issuecomment-987482",
+    updated_at: "2026-07-03T21:48:00Z"
+  }));
+} else if (args[0] === "issue" && args[1] === "edit") {
+  console.log("");
+} else if (args[0] === "label" && args[1] === "create") {
+  console.log(JSON.stringify({ name: args[2] }));
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        targetRepo: "openclaw/openclaw",
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: ["--sync-comments-only", "--item-numbers", "74482"],
+      });
+    });
+
+    const updatedReport = readFileSync(itemPath, "utf8");
+    assert.match(updatedReport, /^labels_synced_at: /m);
+    assert.match(updatedReport, /proof: sufficient/);
+    assert.match(updatedReport, /rating: 🦞 diamond lobster/);
+    const calls = readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as string[]);
+    assert(
+      calls.some(
+        (args) =>
+          args[0] === "issue" &&
+          args[1] === "edit" &&
+          args.includes("--add-label") &&
+          args.includes("rating: 🦞 diamond lobster"),
+      ),
+    );
+    assert(
+      calls.some(
+        (args) =>
+          args[0] === "issue" &&
+          args[1] === "edit" &&
+          args.includes("--add-label") &&
+          args.includes("proof: sufficient"),
+      ),
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions skips fresh-head PR label sync when humans act after the review snapshot", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const logPath = join(root, "gh.log");
+    const itemPath = join(itemsDir, "74483.md");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const sourceReport = `${reportFrontMatter({
+      repository: "openclaw/openclaw",
+      type: "pull_request",
+      number: "74483",
+      title: "Fresh head with human activity",
+      url: "https://github.com/openclaw/openclaw/pull/74483",
+      decision: "keep_open",
+      close_reason: "none",
+      confidence: "high",
+      action_taken: "kept_open",
+      review_status: "complete",
+      local_checkout_access: "verified",
+      author: "contributor",
+      author_association: "CONTRIBUTOR",
+      labels: JSON.stringify([]),
+      item_snapshot_hash: "snapshot-a",
+      item_updated_at: "2026-07-03T21:42:48Z",
+      reviewed_at: "2026-07-03T21:42:48Z",
+      pull_head_sha: "bc60b889",
+    })}
+
+## Summary
+
+Human activity after the review snapshot must still block label sync.
+
+${realBehaviorProofReportSection()}
+
+${prRatingReportSection({ overallTier: "A" })}
+
+## Review Findings
+
+Overall correctness: patch is correct
+
+Overall confidence: 0.9
+
+Full review comments:
+
+- none
+`;
+    const synced = reportWithSyncedReviewComment(sourceReport, 74483);
+    writeFileSync(itemPath, synced.report, "utf8");
+
+    const ghMock = `
+const { appendFileSync, readFileSync } = require("fs");
+const logPath = ${JSON.stringify(logPath)};
+const comment = ${JSON.stringify(synced.comment)};
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+appendFileSync(logPath, JSON.stringify(args) + "\\n");
+const path = args[1] || "";
+if (args[0] === "api" && /\\/issues\\/74483$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 74483,
+    title: "Fresh head with human activity",
+    html_url: "https://github.com/openclaw/openclaw/pull/74483",
+    created_at: "2026-07-03T19:00:00Z",
+    updated_at: "2026-07-03T21:43:45Z",
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "contributor" },
+    labels: [],
+    pull_request: {}
+  }));
+} else if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/74483\\/timeline(?:\\?|$)/.test(args[2] || "")) {
+  console.log("HTTP/2 200\\n\\n[]");
+} else if (args[0] === "api" && /\\/issues\\/74483\\/timeline(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/pulls\\/74483$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 74483,
+    html_url: "https://github.com/openclaw/openclaw/pull/74483",
+    state: "open",
+    changed_files: 1,
+    commits: 2,
+    review_comments: 0,
+    head: { sha: "bc60b889", ref: "branch", repo: { full_name: "fork/openclaw" } },
+    base: { sha: "base-sha", ref: "main", repo: { full_name: "openclaw/openclaw" } },
+    user: { login: "contributor" }
+  }));
+} else if (args[0] === "api" && /\\/pulls\\/74483\\/(files|commits|comments)(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/issues\\/74483\\/comments(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[
+    {
+      id: 987484,
+      html_url: "https://github.com/openclaw/openclaw/pull/74483#issuecomment-987484",
+      body: comment,
+      user: { login: "clawsweeper[bot]" },
+      created_at: "2026-07-03T21:33:21Z",
+      updated_at: "2026-07-03T21:33:21Z"
+    },
+    {
+      id: 987485,
+      html_url: "https://github.com/openclaw/openclaw/pull/74483#issuecomment-987485",
+      body: "I already relabeled this myself, leave the labels alone.",
+      user: { login: "maintainer" },
+      author_association: "MEMBER",
+      created_at: "2026-07-03T21:44:00Z",
+      updated_at: "2026-07-03T21:44:00Z"
+    }
+  ]]));
+} else if (args[0] === "api" && /\\/issues\\/comments\\/987484$/.test(path)) {
+  const input = args[args.indexOf("--input") + 1];
+  appendFileSync(logPath, JSON.stringify(["patched-review-body", JSON.parse(readFileSync(input, "utf8")).body]) + "\\n");
+  console.log(JSON.stringify({
+    id: 987484,
+    html_url: "https://github.com/openclaw/openclaw/pull/74483#issuecomment-987484",
+    updated_at: "2026-07-03T21:48:00Z"
+  }));
+} else if (args[0] === "issue" && args[1] === "edit") {
+  console.log("");
+} else if (args[0] === "label" && args[1] === "create") {
+  console.log(JSON.stringify({ name: args[2] }));
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        targetRepo: "openclaw/openclaw",
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: ["--sync-comments-only", "--item-numbers", "74483"],
+      });
+    });
+
+    const updatedReport = readFileSync(itemPath, "utf8");
+    assert.doesNotMatch(updatedReport, /^labels_synced_at: /m);
+    const calls = readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as string[]);
+    assert.equal(
+      calls.some((args) => args[0] === "issue" && args[1] === "edit"),
+      false,
+    );
+    assert.equal(
+      calls.some((args) => args[0] === "label" && args[1] === "create"),
+      false,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("apply-decisions routes parsed security owner acceptance to maintainer review", () => {
   const root = mkdtempSync(tmpPrefix);
   try {


### PR DESCRIPTION
## What problem this solves

Fixes #394.

PR #388 (commit b1e238d) correctly strips ClawSweeper review labels when a PR head moves past the reviewed head, but it also demoted the open-PR label sync block from unconditional to gated behind `labelSyncFreshEnough()`. That gate measures freshness by comment recency: when the item was updated after the review snapshot, it requires the item `updatedAt` to be within 5 minutes of the durable review comment's `updatedAt`.

After the exact stale-strip and re-review cycle that #388 creates, that proxy fails by construction: the stale-strip leaves the durable comment timestamp in the past, and ClawSweeper's own command-ack comment edit bumps the item `updatedAt` past the review snapshot. The apply pass that follows a fresh, head-matching review therefore skips every label write. The review comment updates (comment sync is a separate path) while the rating, status, proof, and merge-risk labels stay missing.

Live occurrence, openclaw/openclaw#97157 on 2026-07-03 (UTC): stale-strip at 21:33 (durable comment `updatedAt` becomes 21:33:21), re-review requested at 21:42:28 for new head bc60b889, review snapshot `item_updated_at` 21:42:48, ack edit bumps item `updatedAt` to 21:43:45, review completes at 21:47 for head bc60b889 with planned label adds in the report. On the 21:48 apply pass, |21:43:45 - 21:33:21| = 10m24s exceeds the 5 minute window, `labelSyncFreshEnough()` returns false, and the whole label sync block is skipped. The PR is left reviewed and rated with zero readiness labels.

## The fix

For PR review labels the correct freshness signal is head-SHA equality between the report and the live PR, which #388 already computes for the stale branch. This change adds a `freshPullRequestReviewHead()` helper (report head SHA present, live head SHA present, equal) and skips the 5 minute comment-recency window inside `labelSyncFreshEnough()` when the item is a pull request with a `review_status: complete` report for a provably fresh head.

The maintainer-override protection is preserved: the `contextHasNonAutomationActivityAfter` check still runs, so genuine human activity after the review snapshot continues to block label re-sync. Bot self-activity such as the command-ack edit is already classified as automation by that check, so no change to self-mutation handling was needed. The `item.kind === "pull_request"` short-circuit ahead of the helper avoids collecting item context for issue-kind items, whose gate is unchanged.

The priority label sync gate (`isCurrentCompleteReport`) routes through `labelSyncFreshEnough()` and picks up the same allowance with no separate edit. The stale-strip path from #388 is untouched.

The allowance is also excluded for close proposals: a report whose decision proposes closing the PR falls back to the pre-existing changed-since-review handling exactly as on main, so this path never relabels a PR that is being proposed for closure.

## Tests

`test/apply-label-sync.test.ts`:

- New: "apply-decisions syncs fresh-head PR review labels when bot activity bumps updated_at". Replays the openclaw/openclaw#97157 timestamps (snapshot 21:42:48, bot ack edit 21:43:45, durable comment 21:33:21, reviewed head equal to live head) and asserts the rating, proof, and merge-risk label adds, the patched durable comment containing the label justifications, and the exact apply-report record. Verified RED against unpatched origin/main and GREEN with the fix.
- New: "apply-decisions skips fresh-head PR label sync when humans act after the review snapshot". Same setup plus a MEMBER comment after the snapshot; asserts no label writes occur.
- New: "apply-decisions withholds fresh-head PR label sync from close proposals". Identical fresh-head timestamps with a close-proposal report; asserts zero label adds and no labels_synced_at. Verified RED against the first commit (guard absent) and GREEN with it.
- All pre-existing tests in the file, including the #388 stale-head strip tests, still pass (11/11).

## Validation

- `node --test test/apply-label-sync.test.ts`: 11 pass, 0 fail.
- `pnpm check:changed` subgates: check:active-surface, check:limits, build:all (tsgo), lint, and format:check all pass; test:unit 559 pass 0 fail; test:repair 573 pass 0 fail; coverage suites 1132 pass 0 fail with no threshold violations. The only anomalies are 5 dashboard-worker test cancellations that reproduce identically on pristine origin/main under this machine's Node 22.19.0 (repo declares engines node >= 24); they are an environment artifact, not caused by this change.

## Real behavior proof
Behavior addressed: After a stale-strip followed by a fresh re-review of the current head, the apply pass skipped every review-label write, leaving a reviewed and rated PR with no rating, status, or proof labels (live occurrence: openclaw/openclaw#97157 on 2026-07-03).
Real environment tested: the real dist CLI apply-decisions entry point, invoked exactly as the sweep.yml comment-sync apply pass runs it, built from pristine main@1343d8ec0cef4a5088be01084937fe4396cf9571 (before) and from PR head 4c41d0923fc86ab05a62bdd112af4937e222c743 (after, plus a close-proposal leg), against an identical records fixture replaying the openclaw/openclaw#97157 timestamps (report item_updated_at 21:42:48Z, live item updatedAt 21:43:45Z from the bot ack edit, durable review comment updatedAt 21:33:21Z, reviewed head equal to live head); the only faked boundary was a PATH-provided gh executable serving item, comment, timeline, and pull JSON and logging every invocation.
Exact steps or command run after this patch: node dist/clawsweeper.js apply-decisions --target-repo openclaw/openclaw --skip-dashboard --items-dir records/items --closed-dir records/closed --plans-dir records/plans --report-path apply-report.json --limit 0 --min-age-days 0 --apply-kind all --stale-min-age-days 60 --close-delay-ms 0 --progress-every 25 --processed-limit 1000 --comment-sync-min-age-days 7 --item-numbers 97157 --sync-comments-only
Evidence after fix:
```
# BEFORE (pristine main 1343d8ec0cef, identical fixture and command, exit 0)
[apply] 2026-07-03T22:47:49.770Z finished apply closed=0/0 processed=0/1000 counts={}
gh-calls-before.log: 8 invocations, all reads (issues/97157, comments, timeline, pulls/97157); no "issue edit", no "label create"
records/items/97157.md unchanged: labels: []  (no labels_synced_at)

# AFTER (this patch, head 4c41d0923fc86ab05a62bdd112af4937e222c743, identical inputs, exit 0)
[apply] 2026-07-03T23:55:26.329Z finished apply closed=0/0 processed=1/1000 counts={"review_comment_synced":1}
["issue","edit","97157","--add-label","proof: sufficient"]
["issue","edit","97157","--add-label","rating: 🦞 diamond lobster"]
["issue","edit","97157","--add-label","status: 👀 ready for maintainer look"]
records/items/97157.md: labels_synced_at: 2026-07-03T23:55:26.279Z
records/items/97157.md: labels: ["proof: sufficient","rating: 🦞 diamond lobster","status: 👀 ready for maintainer look"]

# CLOSE-PROPOSAL leg (this patch, same head, same fresh-head timestamps, close-proposal report, exit 0)
[apply] 2026-07-03T23:55:26.813Z finished apply closed=0/0 processed=1/1000 counts={"skipped_changed_since_review":1}
"action": "skipped_changed_since_review"
gh-calls-close.log: zero "--add-label", zero "label create"; labels: [] unchanged, no labels_synced_at
```
Observed result after fix: on identical inputs the pristine build issued only read calls and left the item unlabeled, while the patched build added the proof, rating, and status labels and recorded labels_synced_at for the keep-open report and correctly withheld the allowance for the close-proposal report, restoring label sync for a completed review whose reviewed head matches the live head.
What was not tested: no live GitHub API traffic (the gh boundary was a local logging stub with canned JSON); the human-activity guard path was exercised in the committed regression tests rather than this CLI run; Node 24 engine-matched validation is left to CI on this PR.
