### PR TITLE
feat: adapt apply scan window

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2263,7 +2263,10 @@ jobs:
           progress_every="10"
           checkpoint_size="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_checkpoint_size || '5' }}"
           comment_sync_processed_limit=1000
-          close_processed_limit=300
+          base_close_processed_limit=300
+          max_close_processed_limit=900
+          close_processed_limit="$base_close_processed_limit"
+          adaptive_apply_scan_reason="base_window"
           sync_batch_size="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_limit || '25' }}"
           item_numbers="${{ github.event_name == 'repository_dispatch' && github.event.client_payload.item_number || github.event.inputs.apply_item_numbers || '' }}"
           sync_open_pr_batch="${{ github.event_name == 'schedule' && github.event.schedule == '6,21,36,51 * * * *' && 'true' || 'false' }}"
@@ -2310,6 +2313,17 @@ jobs:
           if [ "$checkpoint_size" -gt 5 ]; then
             echo "Capping apply checkpoint size at 5 to keep each GitHub App token within its lifetime."
             checkpoint_size=5
+          fi
+          if [ "$sync_comments_only" != "true" ] && [ -z "$item_numbers" ]; then
+            mkdir -p .artifacts
+            adaptive_batch_env=".artifacts/apply-adaptive-batch.env"
+            pnpm run --silent workflow -- adaptive-apply-batch-size \
+              --status-path "results/sweep-status/${target_slug}.json" \
+              --base-size "$base_close_processed_limit" \
+              --max-size "$max_close_processed_limit" > "$adaptive_batch_env"
+            cat "$adaptive_batch_env"
+            close_processed_limit="$(awk -F= '$1 == "close_processed_limit" { print $2 }' "$adaptive_batch_env")"
+            adaptive_apply_scan_reason="$(awk -F= '$1 == "adaptive_apply_scan_reason" { print $2 }' "$adaptive_batch_env")"
           fi
           mkdir -p .artifacts/apply-reports
           publish_changes() {
@@ -2430,7 +2444,7 @@ jobs:
               if [ "$proposed_count" -lt "$limit" ]; then
                 limit="$proposed_count"
               fi
-              echo "Auto-selected $proposed_count proposed close candidate(s) from apply cursor window: $item_numbers; apply-ready count: ${apply_ready_count:-unknown}"
+              echo "Auto-selected $proposed_count proposed close candidate(s) from $close_processed_limit-record apply cursor window ($adaptive_apply_scan_reason): $item_numbers; apply-ready count: ${apply_ready_count:-unknown}"
             fi
           fi
           item_numbers_arg=()
@@ -2466,7 +2480,7 @@ jobs:
           pnpm run status -- \
             --target-repo "$TARGET_REPO" \
             --state "Apply in progress" \
-            --detail "Starting apply/comment-sync run for up to $limit fresh $apply_kind closes. Close reasons: $apply_close_reasons. Existing Codex automated review comments are updated in place when closing or when comment-only sync is stale by ${comment_sync_min_age_days} day(s); checkpoints commit every $checkpoint_size fresh closes; close delay is ${close_delay_ms}ms; sync-comments-only=$sync_comments_only; item numbers=${item_numbers:-all}." \
+            --detail "Starting apply/comment-sync run for up to $limit fresh $apply_kind closes. Close reasons: $apply_close_reasons. Scan window: $close_processed_limit records ($adaptive_apply_scan_reason). Existing Codex automated review comments are updated in place when closing or when comment-only sync is stale by ${comment_sync_min_age_days} day(s); checkpoints commit every $checkpoint_size fresh closes; close delay is ${close_delay_ms}ms; sync-comments-only=$sync_comments_only; item numbers=${item_numbers:-all}." \
             --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           if ! publish_changes "chore: mark sweep apply in progress" records results/sweep-status; then
             echo "Best-effort apply start status update failed"
@@ -2659,6 +2673,8 @@ jobs:
             echo "APPLY_SYNC_OPEN_PR_BATCH=$sync_open_pr_batch"
             echo "APPLY_AUTO_SELECTED_BATCH=$auto_selected_apply_batch"
             echo "APPLY_COMMENT_SYNC_MIN_AGE_DAYS=$comment_sync_min_age_days"
+            echo "APPLY_CLOSE_PROCESSED_LIMIT=$close_processed_limit"
+            echo "APPLY_ADAPTIVE_SCAN_REASON=$adaptive_apply_scan_reason"
           } >> "$GITHUB_ENV"
 
       - name: Commit apply results

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -459,6 +459,15 @@ continuation with a fresh GitHub App token after any checkpoint that closes at
 least one item. A saturated scan that closes nothing stops without chaining so
 the same records cannot create an unbounded runner loop.
 
+Untargeted cursor-based close apply starts with a 300-record scan window. If
+the previous cursor window was a full close-mode scan, closed nothing, skipped
+at least 80% of processed records, and did not hit a live-fetch, runtime-budget,
+or missing-cursor failure, the next automatic window expands to inspect more
+records, capped at 900. This changes only the deterministic scan window:
+`apply_limit`, checkpoint size, close gates, live-state checks, and maintainer
+policy gates stay unchanged. The workflow logs and sweep status detail include
+the selected scan window and reason.
+
 ## Continuation and Recovery
 
 When a normal or hot review run fills its planned capacity, the publish job

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -760,6 +760,7 @@ interface WorkflowStatusSummary {
   detail: string;
   runUrl: string | undefined;
   applyHealth: Record<string, unknown> | undefined;
+  lastCloseApplyHealth: Record<string, unknown> | undefined;
   plannedCount: number | undefined;
   plannedCapacity: number | undefined;
   plannedShards: number | undefined;
@@ -1923,10 +1924,14 @@ function writeSweepStatus(options: {
 }): void {
   const profile = options.profile ?? targetProfile();
   const updatedAt = new Date().toISOString();
+  const previousStatus = readSweepStatusSummary(profile);
   const applyHealth =
-    options.applyHealth === undefined
-      ? readSweepStatusSummary(profile)?.applyHealth
-      : options.applyHealth;
+    options.applyHealth === undefined ? previousStatus?.applyHealth : options.applyHealth;
+  const previousCloseApplyHealth =
+    previousStatus?.lastCloseApplyHealth ??
+    (previousStatus?.applyHealth?.mode === "close" ? previousStatus.applyHealth : undefined);
+  const lastCloseApplyHealth =
+    applyHealth && applyHealth.mode === "close" ? applyHealth : previousCloseApplyHealth;
   const payload = {
     schema_version: 1,
     slug: profile.slug,
@@ -1949,6 +1954,7 @@ function writeSweepStatus(options: {
     bot_owned_proof_decisions_requested: options.botOwnedProofDecisionsRequested ?? null,
     bot_owned_proof_dispatches: options.botOwnedProofDispatches ?? null,
     apply_health: applyHealth ?? null,
+    last_close_apply_health: lastCloseApplyHealth ?? null,
     updated_at: updatedAt,
   };
   const outputPath = sweepStatusPath(profile);
@@ -8294,6 +8300,7 @@ function readSweepStatusSummary(profile = targetProfile()): WorkflowStatusSummar
       detail: stringOrUndefined(parsed.detail) ?? "No workflow status has been published yet.",
       runUrl: stringOrUndefined(parsed.run_url),
       applyHealth: recordOrUndefined(parsed.apply_health),
+      lastCloseApplyHealth: recordOrUndefined(parsed.last_close_apply_health),
       plannedCount: numberOrUndefined(parsed.planned_count),
       plannedCapacity: numberOrUndefined(parsed.planned_capacity),
       plannedShards: numberOrUndefined(parsed.planned_shards),
@@ -8388,6 +8395,7 @@ function workflowStatusSummary(block: string): WorkflowStatusSummary {
     detail,
     runUrl,
     applyHealth: undefined,
+    lastCloseApplyHealth: undefined,
     plannedCount: numberOrUndefined(planMatch?.[1]),
     plannedShards: numberOrUndefined(planMatch?.[2]),
     plannedCapacity: numberOrUndefined(planMatch?.[3]),

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -102,6 +102,25 @@ type ApplyCycleSummary = {
   scheduled_interval_minutes: number | null;
   label: string;
 };
+
+type AdaptiveApplyBatchSizeOptions = {
+  statusPath: string;
+  baseSize: number;
+  maxSize: number;
+};
+
+type AdaptiveApplyBatchSize = {
+  closeProcessedLimit: number;
+  baseCloseProcessedLimit: number;
+  maxCloseProcessedLimit: number;
+  adaptive: boolean;
+  reason: string;
+  previousProcessed: number | null;
+  previousProcessedLimit: number | null;
+  previousClosed: number | null;
+  previousSkipped: number | null;
+};
+
 const args = parseArgs(process.argv.slice(2));
 
 function runCli(): void {
@@ -158,6 +177,25 @@ function runCli(): void {
         )}\n`,
       );
       break;
+    case "adaptive-apply-batch-size": {
+      const result = adaptiveApplyBatchSize({
+        statusPath: requiredString("status-path"),
+        baseSize: numberArg("base-size", 300),
+        maxSize: numberArg("max-size", 900),
+      });
+      printOutput({
+        close_processed_limit: String(result.closeProcessedLimit),
+        base_close_processed_limit: String(result.baseCloseProcessedLimit),
+        max_close_processed_limit: String(result.maxCloseProcessedLimit),
+        adaptive_apply_scan: result.adaptive ? "true" : "false",
+        adaptive_apply_scan_reason: result.reason,
+        previous_apply_processed: optionalNumberOutput(result.previousProcessed),
+        previous_apply_processed_limit: optionalNumberOutput(result.previousProcessedLimit),
+        previous_apply_closed: optionalNumberOutput(result.previousClosed),
+        previous_apply_skipped: optionalNumberOutput(result.previousSkipped),
+      });
+      break;
+    }
     case "count-command-actions":
       console.log(
         countCommandActions(
@@ -306,6 +344,89 @@ function defaultCapacityReason(
   if (selectedCount === 0) return "idle: no due candidates found";
   if (dueBacklog >= capacity) return "saturated: due backlog filled planned capacity";
   return "under capacity: due backlog below planned capacity";
+}
+
+export function adaptiveApplyBatchSize(
+  options: AdaptiveApplyBatchSizeOptions,
+): AdaptiveApplyBatchSize {
+  const baseSize = positiveInteger(options.baseSize, "baseSize");
+  const maxSize = Math.max(baseSize, positiveInteger(options.maxSize, "maxSize"));
+  const base: AdaptiveApplyBatchSize = {
+    closeProcessedLimit: baseSize,
+    baseCloseProcessedLimit: baseSize,
+    maxCloseProcessedLimit: maxSize,
+    adaptive: false,
+    reason: "base_window",
+    previousProcessed: null,
+    previousProcessedLimit: null,
+    previousClosed: null,
+    previousSkipped: null,
+  };
+  const status = readJsonObjectIfPresent(options.statusPath);
+  if (!status) return base;
+  const health = closeApplyHealthFromStatus(status);
+  if (!health) return base;
+  const previousProcessed = nonNegativeIntegerOrNull(health.processed);
+  const previousProcessedLimit = nonNegativeIntegerOrNull(health.processed_limit);
+  const previousClosed = nonNegativeIntegerOrNull(health.closed);
+  const previousSkipped = nonNegativeIntegerOrNull(health.skipped);
+  const withPrevious = {
+    ...base,
+    previousProcessed,
+    previousProcessedLimit,
+    previousClosed,
+    previousSkipped,
+  };
+  if (health.cursor_required !== true) return withPrevious;
+  if (
+    previousProcessed === null ||
+    previousProcessedLimit === null ||
+    previousClosed === null ||
+    previousSkipped === null
+  ) {
+    return withPrevious;
+  }
+
+  const fullWindow = previousProcessedLimit > 0 && previousProcessed >= previousProcessedLimit;
+  const zeroClose = previousClosed === 0;
+  const skipHeavy = previousProcessed > 0 && previousSkipped / previousProcessed >= 0.8;
+  const attentionReasons = new Set(stringArray(health.attention_reasons));
+  const unsafeAttention = [
+    "cursor_required_but_missing_after_full_window",
+    "skipped_live_fetch_failed",
+    "skipped_runtime_budget",
+  ].some((reason) => attentionReasons.has(reason));
+  if (!fullWindow || !zeroClose || !skipHeavy || unsafeAttention) return withPrevious;
+
+  const grown = Math.min(maxSize, Math.max(baseSize, previousProcessedLimit * 2));
+  if (grown <= baseSize) return withPrevious;
+  return {
+    ...withPrevious,
+    closeProcessedLimit: grown,
+    adaptive: true,
+    reason: "previous_full_zero_close_skip_window",
+  };
+}
+
+function closeApplyHealthFromStatus(status: LooseRecord): LooseRecord | null {
+  const current = recordOrNull(status.apply_health);
+  if (current?.mode === "close") return current;
+  const preserved = recordOrNull(status.last_close_apply_health);
+  return preserved?.mode === "close" ? preserved : null;
+}
+
+function optionalNumberOutput(value: number | null): string {
+  return value === null ? "" : String(value);
+}
+
+function positiveInteger(value: number, name: string): number {
+  if (!Number.isInteger(value) || value < 1) throw new Error(`${name} must be a positive integer`);
+  return value;
+}
+
+function nonNegativeIntegerOrNull(value: JsonValue | undefined): number | null {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : null;
 }
 
 export function plannedItemNumberCsv(plan: LooseRecord): string {
@@ -1359,6 +1480,19 @@ function readJsonObject(filePath: string): LooseRecord {
   return parsed;
 }
 
+function readJsonObjectIfPresent(filePath: string): LooseRecord | null {
+  if (!filePath || !fs.existsSync(filePath)) return null;
+  try {
+    return readJsonObject(filePath);
+  } catch {
+    return null;
+  }
+}
+
+function recordOrNull(value: JsonValue | undefined): LooseRecord | null {
+  return isJsonObject(value) ? value : null;
+}
+
 function printOutput(values: Record<string, string>): void {
   for (const [key, value] of Object.entries(values)) console.log(`${key}=${value}`);
 }
@@ -1416,7 +1550,7 @@ function positiveNumber(value: string, fallback: number): number {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
-function stringArray(value: JsonValue): string[] {
+function stringArray(value: JsonValue | undefined): string[] {
   return Array.isArray(value)
     ? value.filter((entry): entry is string => typeof entry === "string")
     : [];

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -1996,6 +1996,9 @@ test("sweep status writer preserves non-apply health and clears stale apply upda
     /state\.startsWith\("Apply "\)\s+\?\s+null\s+:\s+readSweepStatusSummary\(profile\)\?\.applyHealth/,
   );
   assert.match(source, /apply_health: applyHealth \?\? null/);
+  assert.match(source, /last_close_apply_health: lastCloseApplyHealth \?\? null/);
+  assert.match(source, /previousStatus\?\.lastCloseApplyHealth/);
+  assert.match(source, /previousStatus\?\.applyHealth\?\.mode === "close"/);
 });
 
 test("review parser strips environment access caveats from risks", () => {

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -7,6 +7,7 @@ import test from "node:test";
 
 import {
   applyCursorAdvanceCount,
+  adaptiveApplyBatchSize,
   artifactItemNumbers,
   automationLimit,
   commentSyncBatchOutput,
@@ -636,6 +637,136 @@ test("workflow utilities expose review capacity telemetry from plans", () => {
       oldest_unreviewed_at: "2026-01-01T00:00:00Z",
       capacity_reason: "under capacity: due backlog below planned capacity",
     },
+  );
+});
+
+test("workflow utilities expand automatic apply scan after a skip-heavy zero-close window", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const statusPath = path.join(root, "results/sweep-status/openclaw-openclaw.json");
+  write(
+    statusPath,
+    JSON.stringify({
+      apply_health: {
+        mode: "close",
+        cursor_required: true,
+        processed: 300,
+        processed_limit: 300,
+        closed: 0,
+        skipped: 285,
+        attention_reasons: ["skipped_changed_since_review"],
+      },
+    }),
+  );
+
+  const result = adaptiveApplyBatchSize({ statusPath, baseSize: 300, maxSize: 900 });
+
+  assert.equal(result.closeProcessedLimit, 600);
+  assert.equal(result.adaptive, true);
+  assert.equal(result.reason, "previous_full_zero_close_skip_window");
+  assert.equal(result.previousProcessed, 300);
+  assert.equal(result.previousSkipped, 285);
+});
+
+test("workflow utilities use preserved close health after comment-sync status updates", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const statusPath = path.join(root, "results/sweep-status/openclaw-openclaw.json");
+  write(
+    statusPath,
+    JSON.stringify({
+      apply_health: {
+        mode: "comment_sync",
+        cursor_required: true,
+        processed: 25,
+        processed_limit: 25,
+        closed: 0,
+        skipped: 0,
+        attention_reasons: [],
+      },
+      last_close_apply_health: {
+        mode: "close",
+        cursor_required: true,
+        processed: 300,
+        processed_limit: 300,
+        closed: 0,
+        skipped: 300,
+        attention_reasons: ["skipped_changed_since_review"],
+      },
+    }),
+  );
+
+  const result = adaptiveApplyBatchSize({ statusPath, baseSize: 300, maxSize: 900 });
+
+  assert.equal(result.closeProcessedLimit, 600);
+  assert.equal(result.adaptive, true);
+  assert.equal(result.previousProcessed, 300);
+});
+
+test("workflow utilities cap adaptive apply scan and reset on productive or unsafe windows", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const statusPath = path.join(root, "results/sweep-status/openclaw-openclaw.json");
+  const size = () => adaptiveApplyBatchSize({ statusPath, baseSize: 300, maxSize: 900 });
+
+  write(
+    statusPath,
+    JSON.stringify({
+      apply_health: {
+        mode: "close",
+        cursor_required: true,
+        processed: 600,
+        processed_limit: 600,
+        closed: 0,
+        skipped: 600,
+        attention_reasons: ["skipped_protected_label"],
+      },
+    }),
+  );
+  assert.equal(size().closeProcessedLimit, 900);
+
+  write(
+    statusPath,
+    JSON.stringify({
+      apply_health: {
+        mode: "close",
+        cursor_required: true,
+        processed: 300,
+        processed_limit: 300,
+        closed: 1,
+        skipped: 299,
+        attention_reasons: [],
+      },
+    }),
+  );
+  assert.deepEqual(
+    { limit: size().closeProcessedLimit, reason: size().reason, adaptive: size().adaptive },
+    { limit: 300, reason: "base_window", adaptive: false },
+  );
+
+  write(
+    statusPath,
+    JSON.stringify({
+      apply_health: {
+        mode: "close",
+        cursor_required: true,
+        processed: 300,
+        processed_limit: 300,
+        closed: 0,
+        skipped: 300,
+        attention_reasons: ["skipped_live_fetch_failed"],
+      },
+    }),
+  );
+  assert.deepEqual(
+    { limit: size().closeProcessedLimit, reason: size().reason, adaptive: size().adaptive },
+    { limit: 300, reason: "base_window", adaptive: false },
+  );
+
+  assert.equal(
+    adaptiveApplyBatchSize({
+      statusPath: path.join(root, "missing.json"),
+      baseSize: 300,
+      maxSize: 900,
+    }).closeProcessedLimit,
+    300,
   );
 });
 

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -139,7 +139,11 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
   assert.match(inputBlock, /apply_limit:[\s\S]*default: "5"/);
   assert.match(inputBlock, /apply_checkpoint_size:[\s\S]*default: "5"/);
   assert.match(applyStep, /Capping apply checkpoint size at 5/);
-  assert.match(applyStep, /close_processed_limit=300/);
+  assert.match(applyStep, /base_close_processed_limit=300/);
+  assert.match(applyStep, /max_close_processed_limit=900/);
+  assert.match(applyStep, /close_processed_limit="\$base_close_processed_limit"/);
+  assert.match(applyStep, /adaptive-apply-batch-size/);
+  assert.match(applyStep, /--status-path "results\/sweep-status\/\$\{target_slug\}\.json"/);
   assert.match(applyStep, /processed-limit "\$close_processed_limit"/);
   assert.match(applyStep, /comment_sync_processed_limit=1000/);
   assert.match(applyStep, /--processed-limit "\$comment_sync_processed_limit"/);
@@ -163,6 +167,14 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
   assert.match(applyStep, /--apply-health-file "\.artifacts\/apply-health-final\.json"/);
   assert.match(applyStep, /--state "Apply idle"/);
   assert.match(applyStep, /--batch-size "\$close_processed_limit"/);
+  assert.match(
+    applyStep,
+    /Scan window: \$close_processed_limit records \(\$adaptive_apply_scan_reason\)/,
+  );
+  assert.match(
+    applyStep,
+    /Auto-selected \$proposed_count proposed close candidate\(s\) from \$close_processed_limit-record apply cursor window/,
+  );
   assert.match(applyStep, /--cursor-path "\$apply_cursor_path"/);
   assert.match(applyStep, /write-apply-cursor/);
   assert.match(applyStep, /--item-numbers "\$item_numbers"/);


### PR DESCRIPTION
﻿## What Problem This Solves

The apply lane can spend an entire automatic cursor window on old, skip-heavy records and close nothing. After #375, the cursor advances, but a fixed 300-record scan window can still make rotation through the open issue/PR universe slower than necessary when the previous window was entirely skipped.

## Why This Change Was Made

This adds a bounded adaptive scan-window selector for automatic close-mode apply runs:

- keeps the normal scan window at 300 records;
- expands the next automatic scan to 600, then up to a hard cap of 900, only after the previous close-mode cursor window was full, zero-close, and at least 80% skipped;
- does not change explicit item-number applies, comment-sync-only runs, close limits, checkpoint size, live-state checks, policy gates, or mutation gates;
- preserves `last_close_apply_health` so comment-sync/status updates do not hide the previous close-mode signal that drives the next scan-window choice;
- preserves legacy close health from existing status files whose previous close signal is still only in `apply_health`.

## User Impact

Maintainers get faster rotation through skip-heavy apply windows without increasing how many closes can happen in one run. The workflow status now reports the selected scan window and reason, for example:

```text
Scan window: 600 records (previous_full_zero_close_skip_window)
```

## Evidence

Focused local proof after rebasing onto current `origin/main` including #398:

```powershell
pnpm run build:all
node --test test\repair\workflow-utils.test.ts test\sweep-workflow.test.ts test\clawsweeper.test.ts
pnpm run format:check
```

Result: passed. The focused node test run reported 130 tests, 129 passing, 1 skipped.

Adaptive utility runtime proof on the final build, with current status in a non-close state but `last_close_apply_health` preserving the previous close signal:

```text
close_processed_limit=600
base_close_processed_limit=300
max_close_processed_limit=900
adaptive_apply_scan=true
adaptive_apply_scan_reason=previous_full_zero_close_skip_window
previous_apply_processed=300
previous_apply_processed_limit=300
previous_apply_closed=0
previous_apply_skipped=280
```

Full local check:

```powershell
$env:PNPM_BIN='C:\Users\marti\AppData\Local\Corepack\shims\pnpm.cmd'
pnpm run check
```

Result: passed. The full check reported 1150 tests, 1149 passing, 1 skipped, coverage gates at 100%, and format clean.

Codex review loop:

```powershell
codex review -c service_tier='fast' --base origin/main
```

Result: no actionable correctness issues found. The review noted the adaptive scan window logic, status preservation, workflow wiring, and tests are consistent with the intended behavior.

## Screenshots / Visual Proof

No UI surface changes. The operator-visible surface is workflow/status text, shown above as `Scan window: 600 records (previous_full_zero_close_skip_window)`.

## Dependency / Stack Note

This is based on current main after #391, #397, #395, and #398. It is independent from #400 and #402.

## Risk

The risk is limited to automatic apply scan-window selection. The PR only changes how many candidate records are scanned before selecting close candidates. It does not relax close gates, policy checks, live GitHub-state checks, checkpoint limits, or write permissions.
