### PR TITLE
feat: summarize close candidate quality

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2369,6 +2369,7 @@ jobs:
             checkpoint_size=20
           fi
           candidate_quality_summary="not evaluated"
+          candidate_quality_detail=""
           mkdir -p .artifacts/apply-reports
           publish_changes() {
             message="$1"
@@ -2443,6 +2444,7 @@ jobs:
             pnpm run --silent workflow -- proposed-item-quality-summary "${quality_args[@]}" > "$candidate_quality_env"
             cat "$candidate_quality_env"
             candidate_quality_summary="$(awk -F= '$1 == "candidate_quality_summary" { print $2 }' "$candidate_quality_env")"
+            candidate_quality_detail=" Close candidate mix: $candidate_quality_summary."
           fi
           if [ "$sync_open_pr_batch" = "true" ] && [ -z "$item_numbers" ]; then
             batch_env=".artifacts/comment-sync-batch.env"
@@ -2519,7 +2521,7 @@ jobs:
             pnpm run status -- \
               --target-repo "$TARGET_REPO" \
               --state "Apply idle" \
-              --detail "No unchanged high-confidence close proposals are awaiting apply. Close candidate mix: $candidate_quality_summary. Scheduled apply wakes every 15 minutes and exits without scanning unrelated keep-open records when there is no close work." \
+              --detail "No unchanged high-confidence close proposals are awaiting apply.$candidate_quality_detail Scheduled apply wakes every 15 minutes and exits without scanning unrelated keep-open records when there is no close work." \
               --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             publish_status "chore: update idle sweep apply status"
             {
@@ -2543,7 +2545,7 @@ jobs:
           pnpm run status -- \
             --target-repo "$TARGET_REPO" \
             --state "Apply in progress" \
-            --detail "Starting apply/comment-sync run for up to $limit fresh $apply_kind closes. Close reasons: $apply_close_reasons. Close candidate mix: $candidate_quality_summary. Existing Codex automated review comments are updated in place when closing or when comment-only sync is stale by ${comment_sync_min_age_days} day(s); checkpoints commit every $checkpoint_size fresh closes; close delay is ${close_delay_ms}ms; sync-comments-only=$sync_comments_only; item numbers=${item_numbers:-all}." \
+            --detail "Starting apply/comment-sync run for up to $limit fresh $apply_kind closes. Close reasons: $apply_close_reasons.$candidate_quality_detail Existing Codex automated review comments are updated in place when closing or when comment-only sync is stale by ${comment_sync_min_age_days} day(s); checkpoints commit every $checkpoint_size fresh closes; close delay is ${close_delay_ms}ms; sync-comments-only=$sync_comments_only; item numbers=${item_numbers:-all}." \
             --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           if ! publish_changes "chore: mark sweep apply in progress" records results/sweep-status; then
             echo "Best-effort apply start status update failed"

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2311,6 +2311,7 @@ jobs:
             echo "Capping apply checkpoint size at 5 to keep each GitHub App token within its lifetime."
             checkpoint_size=5
           fi
+          candidate_quality_summary="not evaluated"
           mkdir -p .artifacts/apply-reports
           publish_changes() {
             message="$1"
@@ -2367,6 +2368,25 @@ jobs:
             reconcile_args+=(--item-numbers "$item_numbers")
           fi
           pnpm run reconcile -- "${reconcile_args[@]}"
+          if [ "$sync_comments_only" != "true" ]; then
+            quality_args=(
+              --target-repo "$TARGET_REPO"
+              --apply-kind "$apply_kind"
+              --apply-close-reasons "$apply_close_reasons"
+              --stale-min-age-days "$stale_min_age_days"
+              --min-age-days "$min_age_days"
+              --min-age-minutes "$min_age_minutes"
+            )
+            if [ -n "$item_numbers" ]; then
+              quality_args+=(--item-numbers "$item_numbers")
+            else
+              quality_args+=(--batch-size "$close_processed_limit" --cursor-path "$apply_cursor_path")
+            fi
+            candidate_quality_env=".artifacts/apply-candidate-quality.env"
+            pnpm run --silent workflow -- proposed-item-quality-summary "${quality_args[@]}" > "$candidate_quality_env"
+            cat "$candidate_quality_env"
+            candidate_quality_summary="$(awk -F= '$1 == "candidate_quality_summary" { print $2 }' "$candidate_quality_env")"
+          fi
           if [ "$sync_open_pr_batch" = "true" ] && [ -z "$item_numbers" ]; then
             batch_env=".artifacts/comment-sync-batch.env"
             pnpm run --silent workflow -- comment-sync-batch \
@@ -2442,7 +2462,7 @@ jobs:
             pnpm run status -- \
               --target-repo "$TARGET_REPO" \
               --state "Apply idle" \
-              --detail "No unchanged high-confidence close proposals are awaiting apply. Scheduled apply wakes every 15 minutes and exits without scanning unrelated keep-open records when there is no close work." \
+              --detail "No unchanged high-confidence close proposals are awaiting apply. Close candidate mix: $candidate_quality_summary. Scheduled apply wakes every 15 minutes and exits without scanning unrelated keep-open records when there is no close work." \
               --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             publish_status "chore: update idle sweep apply status"
             {
@@ -2466,7 +2486,7 @@ jobs:
           pnpm run status -- \
             --target-repo "$TARGET_REPO" \
             --state "Apply in progress" \
-            --detail "Starting apply/comment-sync run for up to $limit fresh $apply_kind closes. Close reasons: $apply_close_reasons. Existing Codex automated review comments are updated in place when closing or when comment-only sync is stale by ${comment_sync_min_age_days} day(s); checkpoints commit every $checkpoint_size fresh closes; close delay is ${close_delay_ms}ms; sync-comments-only=$sync_comments_only; item numbers=${item_numbers:-all}." \
+            --detail "Starting apply/comment-sync run for up to $limit fresh $apply_kind closes. Close reasons: $apply_close_reasons. Close candidate mix: $candidate_quality_summary. Existing Codex automated review comments are updated in place when closing or when comment-only sync is stale by ${comment_sync_min_age_days} day(s); checkpoints commit every $checkpoint_size fresh closes; close delay is ${close_delay_ms}ms; sync-comments-only=$sync_comments_only; item numbers=${item_numbers:-all}." \
             --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           if ! publish_changes "chore: mark sweep apply in progress" records results/sweep-status; then
             echo "Best-effort apply start status update failed"
@@ -2659,6 +2679,7 @@ jobs:
             echo "APPLY_SYNC_OPEN_PR_BATCH=$sync_open_pr_batch"
             echo "APPLY_AUTO_SELECTED_BATCH=$auto_selected_apply_batch"
             echo "APPLY_COMMENT_SYNC_MIN_AGE_DAYS=$comment_sync_min_age_days"
+            echo "APPLY_CANDIDATE_QUALITY_SUMMARY=$candidate_quality_summary"
           } >> "$GITHUB_ENV"
 
       - name: Commit apply results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Added
 
+- Added close-candidate quality telemetry to apply status while keeping reporting separate from close eligibility and comment-only sync. Thanks @brokemac79.
 - Added the PR-only `stalled_unproven_pr` close reason: external D/F-rated pull requests whose requested real-behavior proof stayed missing, mock-only, or insufficient can close after 14 idle days, guarded by live checks that the proof request itself was visible for 14 days plus proof-label, draft, head-commit, and human-engagement gates.
 - Added the PR-only `abandoned_pr` close reason: external pull requests idle for 30 days that are still drafts, waiting on their author, or failing checks on the live head can close, while high-quality proven work stays open for repair/adopt paths. See `docs/stalled-pr-close-policies.md`.
 - Added apply-health telemetry and a quiet-by-default dashboard alert for stalled, cursorless, or fully blocked pruning windows. Thanks @brokemac79.

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -459,6 +459,13 @@ continuation with a fresh GitHub App token after any checkpoint that closes at
 least one item. A saturated scan that closes nothing stops without chaining so
 the same records cannot create an unbounded runner loop.
 
+Before a close-mode apply run starts, the workflow summarizes the selected close
+candidate mix by quality bucket in the status detail. Buckets such as
+implemented-on-main, duplicate/superseded, needs PR close proof,
+aging/low-signal, policy-sensitive, and retry-after-guard-skip are
+operator-facing telemetry only; they do not change candidate eligibility, close
+limits, live-state checks, or policy gates.
+
 ## Continuation and Recovery
 
 When a normal or hot review run fills its planned capacity, the publish job

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -928,7 +928,7 @@ export function proposedPrCloseCoverageItemNumbers(options: ProposedItemOptions)
   );
 }
 
-type ProposedItemSelection = "all" | "pr-close-coverage-proof";
+type ProposedItemSelection = "all" | "pr-close-coverage-proof" | "quality-summary";
 
 type ProposedItemCandidate = {
   number: number;
@@ -971,7 +971,6 @@ function selectedProposedItemCandidates(
 
   const allowedReasons = new Set([
     "cannot_reproduce",
-    "abandoned_pr",
     "clawhub",
     "duplicate_or_superseded",
     "incoherent",
@@ -980,9 +979,9 @@ function selectedProposedItemCandidates(
     "mostly_implemented_on_main",
     "not_actionable_in_repo",
     "stale_insufficient_info",
-    "stalled_unproven_pr",
     "unconfirmed_product_direction",
   ]);
+  const qualitySummaryOnlyReasons = new Set(["abandoned_pr", "stalled_unproven_pr"]);
   const allowedCloseReasons =
     options.applyCloseReasons === "all"
       ? null
@@ -1015,7 +1014,10 @@ function selectedProposedItemCandidates(
         decision === "close" &&
         confidence === "high" &&
         isSelectableCloseAction(action, reason) &&
-        allowedForTarget(options.targetRepo, type, reason, allowedReasons) &&
+        (allowedForTarget(options.targetRepo, type, reason, allowedReasons) ||
+          (selection === "quality-summary" &&
+            type === "pull_request" &&
+            qualitySummaryOnlyReasons.has(reason))) &&
         (!allowedCloseReasons || allowedCloseReasons.has(reason));
       const selectablePromotion =
         decision === "keep_open" &&
@@ -1079,7 +1081,7 @@ function selectedProposedItemCandidates(
 export function proposedItemQualitySummary(
   options: ProposedItemOptions,
 ): ProposedItemQualitySummary {
-  const candidates = selectedProposedItemCandidates(options, "all");
+  const candidates = selectedProposedItemCandidates(options, "quality-summary");
   const counts = new Map<ProposedItemQualityBucket, number>();
   for (const candidate of candidates) {
     counts.set(candidate.qualityBucket, (counts.get(candidate.qualityBucket) || 0) + 1);

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -192,6 +192,9 @@ function runCli(): void {
     case "proposed-item-count":
       process.stdout.write(String(proposedItemCount(proposedItemOptions())));
       break;
+    case "proposed-item-quality-summary":
+      printProposedItemQualitySummary(proposedItemOptions());
+      break;
     case "proposed-pr-close-coverage-item-numbers":
       process.stdout.write(proposedPrCloseCoverageItemNumbers(proposedItemOptions()).join(","));
       break;
@@ -876,6 +879,33 @@ type ProposedItemSelection = "all" | "pr-close-coverage-proof";
 type ProposedItemCandidate = {
   number: number;
   applyCheckedAt: string;
+  kind: string;
+  closeReason: string;
+  action: string;
+  qualityBucket: ProposedItemQualityBucket;
+};
+
+type ProposedItemQualityBucket =
+  | "ready_implemented"
+  | "duplicate_or_superseded"
+  | "needs_pr_close_coverage"
+  | "aging_or_low_signal"
+  | "policy_sensitive"
+  | "retry_after_guard_skip"
+  | "other";
+
+type ProposedItemQualityBucketSummary = {
+  bucket: ProposedItemQualityBucket;
+  label: string;
+  count: number;
+  next_step: string;
+};
+
+type ProposedItemQualitySummary = {
+  schema_version: 1;
+  total: number;
+  summary: string;
+  buckets: ProposedItemQualityBucketSummary[];
 };
 
 function selectedProposedItemCandidates(
@@ -959,7 +989,21 @@ function selectedProposedItemCandidates(
         return [];
       }
       if (!olderThan(frontMatterValue(markdown, "item_created_at"), minAgeMs)) return [];
-      return [{ number, applyCheckedAt: frontMatterValue(markdown, "apply_checked_at") }];
+      const candidateCloseReason = selectablePromotion ? "duplicate_or_superseded" : reason;
+      return [
+        {
+          number,
+          applyCheckedAt: frontMatterValue(markdown, "apply_checked_at"),
+          kind: type,
+          closeReason: candidateCloseReason,
+          action,
+          qualityBucket: proposedItemQualityBucket({
+            action,
+            closeReason: candidateCloseReason,
+            prCloseCoverageProofCanRun,
+          }),
+        },
+      ];
     })
     .sort((left, right) => left.number - right.number);
   const batchSize = options.batchSize ?? null;
@@ -974,6 +1018,113 @@ function selectedProposedItemCandidates(
     ...afterCursor,
     ...sorted.filter((candidate) => compareCandidateToApplyCursor(candidate, cursor) <= 0),
   ].slice(0, batchSize);
+}
+
+export function proposedItemQualitySummary(
+  options: ProposedItemOptions,
+): ProposedItemQualitySummary {
+  const candidates = selectedProposedItemCandidates(options, "all");
+  const counts = new Map<ProposedItemQualityBucket, number>();
+  for (const candidate of candidates) {
+    counts.set(candidate.qualityBucket, (counts.get(candidate.qualityBucket) || 0) + 1);
+  }
+  const buckets = QUALITY_BUCKET_ORDER.flatMap((bucket) => {
+    const count = counts.get(bucket) || 0;
+    if (count === 0) return [];
+    const metadata = QUALITY_BUCKET_METADATA[bucket];
+    return [{ bucket, count, label: metadata.label, next_step: metadata.nextStep }];
+  });
+  return {
+    schema_version: 1,
+    total: candidates.length,
+    summary: qualitySummaryText(buckets),
+    buckets,
+  };
+}
+
+function printProposedItemQualitySummary(options: ProposedItemOptions): void {
+  const summary = proposedItemQualitySummary(options);
+  printOutput({
+    candidate_quality_total: String(summary.total),
+    candidate_quality_summary: summary.summary,
+    candidate_quality_buckets_json: JSON.stringify(summary.buckets),
+  });
+}
+
+const QUALITY_BUCKET_ORDER: ProposedItemQualityBucket[] = [
+  "ready_implemented",
+  "duplicate_or_superseded",
+  "needs_pr_close_coverage",
+  "aging_or_low_signal",
+  "policy_sensitive",
+  "retry_after_guard_skip",
+  "other",
+];
+
+const QUALITY_BUCKET_METADATA: Record<
+  ProposedItemQualityBucket,
+  { label: string; nextStep: string }
+> = {
+  ready_implemented: {
+    label: "implemented-on-main",
+    nextStep: "Live-state checks can close these if the item is still unchanged.",
+  },
+  duplicate_or_superseded: {
+    label: "duplicate/superseded",
+    nextStep: "Confirm the canonical or superseding item is still valid before close.",
+  },
+  needs_pr_close_coverage: {
+    label: "needs PR close proof",
+    nextStep: "Run or reuse close-coverage proof before closing the PR.",
+  },
+  aging_or_low_signal: {
+    label: "aging/low-signal",
+    nextStep: "Rely on stale-age and live-state checks; inspect if this bucket dominates.",
+  },
+  policy_sensitive: {
+    label: "policy-sensitive",
+    nextStep: "Close only when the explicit policy gate remains enabled.",
+  },
+  retry_after_guard_skip: {
+    label: "retry after guard skip",
+    nextStep: "Retry only after the previous guard condition has been rechecked.",
+  },
+  other: {
+    label: "other close candidates",
+    nextStep: "Inspect repeated entries and add a deterministic bucket if needed.",
+  },
+};
+
+function proposedItemQualityBucket(options: {
+  action: string;
+  closeReason: string;
+  prCloseCoverageProofCanRun: boolean;
+}): ProposedItemQualityBucket {
+  if (options.prCloseCoverageProofCanRun) return "needs_pr_close_coverage";
+  if (options.closeReason === "unconfirmed_product_direction") return "policy_sensitive";
+  if (
+    options.closeReason === "stale_insufficient_info" ||
+    options.closeReason === "mostly_implemented_on_main" ||
+    options.closeReason === "low_signal_unmergeable_pr"
+  ) {
+    return "aging_or_low_signal";
+  }
+  if (
+    options.action === "skipped_invalid_decision" ||
+    options.action === "skipped_maintainer_authored"
+  ) {
+    return "retry_after_guard_skip";
+  }
+  if (options.closeReason === "duplicate_or_superseded") return "duplicate_or_superseded";
+  if (options.closeReason === "implemented_on_main" || options.closeReason === "clawhub") {
+    return "ready_implemented";
+  }
+  return "other";
+}
+
+function qualitySummaryText(buckets: ProposedItemQualityBucketSummary[]): string {
+  if (buckets.length === 0) return "no close candidates";
+  return buckets.map((bucket) => `${bucket.count} ${bucket.label}`).join(", ");
 }
 
 function compareApplyCursorCandidate(

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -16,6 +16,7 @@ import {
   mergeApplyReports,
   planOutputFields,
   plannedItemNumberCsv,
+  proposedItemQualitySummary,
   proposedItemNumbers,
   proposedPrCloseCoverageItemNumbers,
   summarizeApplyReport,
@@ -1059,6 +1060,67 @@ test("workflow utilities allow ClawHub implemented-on-main issue proposals", () 
   );
 
   assert.deepEqual(selected, [7]);
+});
+
+test("workflow utilities summarize proposed close candidate quality buckets", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const oldDate = "2024-01-01T00:00:00Z";
+  writeProposedRecord(root, 5, "issue", "proposed_close", "implemented_on_main", oldDate);
+  writeProposedRecord(root, 6, "issue", "proposed_close", "duplicate_or_superseded", oldDate);
+  writeProposedRecord(
+    root,
+    7,
+    "pull_request",
+    "proposed_close",
+    "duplicate_or_superseded",
+    oldDate,
+  );
+  writeProposedRecord(root, 8, "issue", "proposed_close", "stale_insufficient_info", oldDate);
+  writeProposedRecord(
+    root,
+    9,
+    "pull_request",
+    "proposed_close",
+    "unconfirmed_product_direction",
+    oldDate,
+  );
+  writeProposedRecord(
+    root,
+    10,
+    "issue",
+    "skipped_invalid_decision",
+    "implemented_on_main",
+    oldDate,
+  );
+
+  const summary = withCwd(root, () =>
+    proposedItemQualitySummary({
+      targetRepo: "openclaw/openclaw",
+      applyKind: "all",
+      applyCloseReasons: "all",
+      staleMinAgeDays: 60,
+      minAgeDays: 0,
+      minAgeMinutes: null,
+    }),
+  );
+
+  assert.equal(summary.total, 6);
+  assert.equal(
+    summary.summary,
+    "1 implemented-on-main, 1 duplicate/superseded, 1 needs PR close proof, 1 aging/low-signal, 1 policy-sensitive, 1 retry after guard skip",
+  );
+  assert.deepEqual(
+    summary.buckets.map((bucket) => [bucket.bucket, bucket.count]),
+    [
+      ["ready_implemented", 1],
+      ["duplicate_or_superseded", 1],
+      ["needs_pr_close_coverage", 1],
+      ["aging_or_low_signal", 1],
+      ["policy_sensitive", 1],
+      ["retry_after_guard_skip", 1],
+    ],
+  );
+  assert.match(summary.buckets[2]?.next_step ?? "", /close-coverage proof/);
 });
 
 test("workflow utilities select proposed PR closes that can need coverage proof", () => {

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -1216,7 +1216,19 @@ test("workflow utilities summarize proposed close candidate quality buckets", ()
     }),
   );
 
+  const selected = withCwd(root, () =>
+    proposedItemNumbers({
+      targetRepo: "openclaw/openclaw",
+      applyKind: "all",
+      applyCloseReasons: "all",
+      staleMinAgeDays: 60,
+      minAgeDays: 0,
+      minAgeMinutes: null,
+    }),
+  );
+
   assert.equal(summary.total, 8);
+  assert.deepEqual(selected, [5, 6, 7, 8, 9, 10]);
   assert.equal(
     summary.summary,
     "1 implemented-on-main, 1 duplicate/superseded, 1 needs PR close proof, 3 aging/low-signal, 1 policy-sensitive, 1 retry after guard skip",

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -162,6 +162,15 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
   assert.match(applyStep, /--apply-health-file "\.artifacts\/apply-health-\$checkpoint\.json"/);
   assert.match(applyStep, /--apply-health-file "\.artifacts\/apply-health-final\.json"/);
   assert.match(applyStep, /--state "Apply idle"/);
+  assert.match(applyStep, /proposed-item-quality-summary/);
+  assert.match(applyStep, /candidate_quality_summary="\$\(awk -F=/);
+  assert.match(applyStep, /Close candidate mix: \$candidate_quality_summary/);
+  const applyReconcileIndex = applyStep.indexOf('pnpm run reconcile -- "${reconcile_args[@]}"');
+  const qualitySummaryIndex = applyStep.indexOf("proposed-item-quality-summary");
+  const proposedNumbersIndex = applyStep.indexOf("proposed-item-numbers");
+  assert.notEqual(applyReconcileIndex, -1);
+  assert.ok(qualitySummaryIndex > applyReconcileIndex);
+  assert.ok(proposedNumbersIndex > qualitySummaryIndex);
   assert.match(applyStep, /--batch-size "\$close_processed_limit"/);
   assert.match(applyStep, /--cursor-path "\$apply_cursor_path"/);
   assert.match(applyStep, /write-apply-cursor/);
@@ -184,6 +193,7 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
   assert.match(applyStep, /next_apply_item_numbers=""/);
   assert.match(applyStep, /echo "APPLY_CONTINUE=\$continue_apply"/);
   assert.match(applyStep, /echo "APPLY_AUTO_SELECTED_BATCH=\$auto_selected_apply_batch"/);
+  assert.match(applyStep, /echo "APPLY_CANDIDATE_QUALITY_SUMMARY=\$candidate_quality_summary"/);
   assert.match(continueStep, /APPLY_CONTINUE:-false/);
   assert.match(continueStep, /-f apply_item_numbers="\$APPLY_ITEM_NUMBERS"/);
   assert.doesNotMatch(continueStep, /APPLY_CLOSED_TOTAL:-0.*APPLY_LIMIT:-0/);

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -170,7 +170,12 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
   assert.match(applyStep, /--state "Apply idle"/);
   assert.match(applyStep, /proposed-item-quality-summary/);
   assert.match(applyStep, /candidate_quality_summary="\$\(awk -F=/);
-  assert.match(applyStep, /Close candidate mix: \$candidate_quality_summary/);
+  assert.match(
+    applyStep,
+    /candidate_quality_detail=" Close candidate mix: \$candidate_quality_summary\."/,
+  );
+  assert.match(applyStep, /awaiting apply\.\$candidate_quality_detail Scheduled apply/);
+  assert.match(applyStep, /\$apply_close_reasons\.\$candidate_quality_detail Existing Codex/);
   const applyReconcileIndex = applyStep.indexOf('pnpm run reconcile -- "${reconcile_args[@]}"');
   const qualitySummaryIndex = applyStep.indexOf("proposed-item-quality-summary");
   const proposedNumbersIndex = applyStep.indexOf("proposed-item-numbers");


### PR DESCRIPTION
## What changed

Apply status now summarizes the close-proposal mix as implemented-on-main, duplicate or superseded, needs PR close proof, aging or low-signal, policy-sensitive, retry-after-guard-skip, or other.

The current-main rewrite also accounts for the `stalled_unproven_pr` and `abandoned_pr` reasons added by #403. They are reported as aging/low-signal without being added to the automatic close selector. A regression asserts both the richer summary and the unchanged eligible item numbers.

Comment-only sync runs no longer show a misleading `Close candidate mix: not evaluated` sentence. The existing apply cursor, limits, live-state gates, and close policy are unchanged.

## Proof

- Focused build and workflow tests: 68 passed.
- Full `pnpm run check`: 599 unit tests and 596 repair tests passed.
- Changed-file coverage: 100% lines, 89.17% branches, 100% functions.
- Whole-repository coverage: 76.63% lines, 70.57% branches, 83.86% functions.
- Formatting and lint clean.
- Final-tree AutoReview: no actionable findings, confidence 0.86.

## Risk

Low. This is reporting-only. The main review finding was that adding #403 reasons to the selector would silently widen auto-close behavior; the rewrite separates the quality-summary view from apply eligibility and locks that boundary with a regression.
