### PR TITLE
fix(review): require late-finding schema field

### DIFF
--- a/schema/clawsweeper-decision.schema.json
+++ b/schema/clawsweeper-decision.schema.json
@@ -509,7 +509,8 @@
           "confidenceScore",
           "file",
           "lineStart",
-          "lineEnd"
+          "lineEnd",
+          "lateFinding"
         ],
         "properties": {
           "title": {
@@ -544,7 +545,7 @@
           },
           "lateFinding": {
             "type": "boolean",
-            "description": "True when this finding targets code unchanged since an earlier reviewed head where the concern was equally visible but was not raised. Omit or use false for findings introduced by new commits or newly available evidence."
+            "description": "True when this finding targets code unchanged since an earlier reviewed head where the concern was equally visible but was not raised. Use false for findings introduced by new commits or newly available evidence."
           }
         }
       }

--- a/test/review-prompt-policy.test.ts
+++ b/test/review-prompt-policy.test.ts
@@ -303,6 +303,13 @@ test("decision schema keeps draft and protected workflow state out of PR rank", 
   );
 });
 
+test("review finding schema requires every structured-output property", () => {
+  const schema = JSON.parse(readFileSync("schema/clawsweeper-decision.schema.json", "utf8"));
+  const finding = schema.properties.reviewFindings.items;
+
+  assert.deepEqual([...finding.required].sort(), Object.keys(finding.properties).sort());
+});
+
 test("review prompt and schema describe positive-only feature showcase labels", () => {
   const prompt = readFileSync("prompts/review-item.md", "utf8");
   const schema = JSON.parse(readFileSync("schema/clawsweeper-decision.schema.json", "utf8"));


### PR DESCRIPTION
## What Problem This Solves

The live exact-item review for #341 failed twice immediately after #384 landed. The Responses API rejected `schema/clawsweeper-decision.schema.json` because `reviewFindings[].lateFinding` was present in `properties` but absent from that object's `required` array.

Observed production error:

```text
Invalid schema for response_format 'codex_output_schema':
Missing 'lateFinding'.
```

## Why This Change Was Made

OpenAI strict structured outputs require every object property to appear in `required`. This adds `lateFinding` to the required list and tells the model to emit `false` when the finding is not late.

The regression test compares the finding object's complete property set with its required set, so adding another optional-looking property cannot silently break every review again.

## User Impact

ClawSweeper reviews can reach the model again. Runtime parsing remains backward-tolerant, while model output now always supplies a boolean `lateFinding` value.

## Evidence

Exact head: `2d352da39c`

```text
pnpm run build
  passed

node --test test/review-prompt-policy.test.ts test/review-history.test.ts
  passed (43/43)

oxfmt --check schema/clawsweeper-decision.schema.json test/review-prompt-policy.test.ts
  passed

autoreview --mode local
  clean; patch is correct (0.88)
```

Live failure evidence: #341's durable review record shows `invalid_json_schema` with `Missing 'lateFinding'` at exact head `bae964f9611a3cf470158966e95a034f0ec7b30a`.
