### PR TITLE
fix(apply): reconcile labels after re-review commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ checkpoint, and status-only commits are intentionally omitted.
 ### Fixed
 
 - Split apply workflow helpers out of the oversized inline expression so GitHub can validate and start sweep runs again.
+- Reconciled fresh-review PR labels after command-only re-review comments instead of treating their duplicate timeline events as new human activity. Thanks @joeVenner.
 - Bounded apply-existing checkpoints to five fresh closes, renewed the GitHub
   App token between continuation runs, and stopped zero-progress scans from
   chaining indefinitely.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@ checkpoint, and status-only commits are intentionally omitted.
 ### Fixed
 
 - Split apply workflow helpers out of the oversized inline expression so GitHub can validate and start sweep runs again.
-- Reconciled fresh-review PR labels after command-only re-review comments instead of treating their duplicate timeline events as new human activity. Thanks @joeVenner.
 - Bounded apply-existing checkpoints to five fresh closes, renewed the GitHub
   App token between continuation runs, and stopped zero-progress scans from
   chaining indefinitely.

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -12976,7 +12976,7 @@ function contextHasNonAutomationActivityAfter(
   reviewedAtMs: number,
   options: {
     truncationCountsAsActivity?: boolean;
-    ignoreTimelineCommentDuplicates?: boolean;
+    ignoreTimelineCommentsThroughMs?: number;
   } = {},
 ): boolean {
   const truncationCountsAsActivity = options.truncationCountsAsActivity ?? true;
@@ -12997,13 +12997,15 @@ function contextHasNonAutomationActivityAfter(
   };
   const hasNonAutomationEvent = (event: unknown): boolean => {
     const record = asRecord(event);
-    // Issue comments are checked above with their bodies. Ignore the timeline
-    // duplicate so filtered command-only comments do not become human activity.
+    // Issue comments are checked above with their bodies. Ignore timeline
+    // duplicates only through the completed review; later commands are fresh
+    // activity and must keep stale labels from being restored.
     if (
-      options.ignoreTimelineCommentDuplicates &&
-      stringOrUndefined(record.event) === "commented"
+      stringOrUndefined(record.event) === "commented" &&
+      options.ignoreTimelineCommentsThroughMs !== undefined
     ) {
-      return false;
+      const eventMs = eventTimestampMs(event);
+      if (eventMs !== null && eventMs <= options.ignoreTimelineCommentsThroughMs) return false;
     }
     return (
       isAfterReview(event, reviewedAtMs) &&
@@ -13014,6 +13016,25 @@ function contextHasNonAutomationActivityAfter(
     context.comments.some(hasNonAutomationComment) ||
     (context.pullReviewComments ?? []).some(hasNonAutomationComment) ||
     context.timeline.some(hasNonAutomationEvent)
+  );
+}
+
+export function contextHasNonAutomationActivityAfterForTest(options: {
+  comments?: unknown[];
+  timeline?: unknown[];
+  activityAfterMs: number;
+  ignoreTimelineCommentsThroughMs?: number;
+}): boolean {
+  return contextHasNonAutomationActivityAfter(
+    {
+      issue: {},
+      comments: options.comments ?? [],
+      timeline: options.timeline ?? [],
+    },
+    options.activityAfterMs,
+    options.ignoreTimelineCommentsThroughMs === undefined
+      ? {}
+      : { ignoreTimelineCommentsThroughMs: options.ignoreTimelineCommentsThroughMs },
   );
 }
 
@@ -18182,9 +18203,12 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       }
       const storedUpdatedAtMs = timestampMs(storedUpdatedAt);
       if (storedUpdatedAtMs === null) return false;
-      return !contextHasNonAutomationActivityAfter(currentItemContext(), storedUpdatedAtMs, {
-        ignoreTimelineCommentDuplicates: true,
-      });
+      const reviewedAtMs = timestampMs(frontMatterValue(markdown, "reviewed_at"));
+      return !contextHasNonAutomationActivityAfter(
+        currentItemContext(),
+        storedUpdatedAtMs,
+        reviewedAtMs === null ? {} : { ignoreTimelineCommentsThroughMs: reviewedAtMs },
+      );
     };
     const stalePrReviewHead =
       state === "open" && item.kind === "pull_request"

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -12974,7 +12974,10 @@ function closePromotionHasNonAutomationActivityAfterReview(
 function contextHasNonAutomationActivityAfter(
   context: ItemContext,
   reviewedAtMs: number,
-  options: { truncationCountsAsActivity?: boolean } = {},
+  options: {
+    truncationCountsAsActivity?: boolean;
+    ignoreTimelineCommentDuplicates?: boolean;
+  } = {},
 ): boolean {
   const truncationCountsAsActivity = options.truncationCountsAsActivity ?? true;
   if (
@@ -12994,6 +12997,14 @@ function contextHasNonAutomationActivityAfter(
   };
   const hasNonAutomationEvent = (event: unknown): boolean => {
     const record = asRecord(event);
+    // Issue comments are checked above with their bodies. Ignore the timeline
+    // duplicate so filtered command-only comments do not become human activity.
+    if (
+      options.ignoreTimelineCommentDuplicates &&
+      stringOrUndefined(record.event) === "commented"
+    ) {
+      return false;
+    }
     return (
       isAfterReview(event, reviewedAtMs) &&
       !isAutomationReportAuthor(stringOrUndefined(record.actor))
@@ -18171,7 +18182,9 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       }
       const storedUpdatedAtMs = timestampMs(storedUpdatedAt);
       if (storedUpdatedAtMs === null) return false;
-      return !contextHasNonAutomationActivityAfter(currentItemContext(), storedUpdatedAtMs);
+      return !contextHasNonAutomationActivityAfter(currentItemContext(), storedUpdatedAtMs, {
+        ignoreTimelineCommentDuplicates: true,
+      });
     };
     const stalePrReviewHead =
       state === "open" && item.kind === "pull_request"

--- a/test/apply-label-sync.test.ts
+++ b/test/apply-label-sync.test.ts
@@ -449,7 +449,7 @@ if (args[0] === "api" && /\\/issues\\/74481$/.test(path)) {
   }
 });
 
-test("apply-decisions syncs fresh-head PR review labels when bot activity bumps updated_at", () => {
+test("apply-decisions syncs fresh-head PR labels after a command-only re-review comment", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
     const itemsDir = join(root, "items");
@@ -464,7 +464,7 @@ test("apply-decisions syncs fresh-head PR review labels when bot activity bumps 
       repository: "openclaw/openclaw",
       type: "pull_request",
       number: "74482",
-      title: "Fresh head label restore",
+      title: "Fresh head label restore after re-review",
       url: "https://github.com/openclaw/openclaw/pull/74482",
       decision: "keep_open",
       close_reason: "none",
@@ -477,14 +477,14 @@ test("apply-decisions syncs fresh-head PR review labels when bot activity bumps 
       labels: JSON.stringify([]),
       item_snapshot_hash: "snapshot-a",
       item_updated_at: "2026-07-03T21:42:48Z",
-      reviewed_at: "2026-07-03T21:42:48Z",
+      reviewed_at: "2026-07-03T21:44:48Z",
       pull_head_sha: "bc60b889",
       merge_risk_labels: JSON.stringify(["merge-risk: 🚨 session-state"]),
     })}
 
 ## Summary
 
-This fresh review must keep driving PR labels even after a bot ack edit bumps updated_at.
+This fresh review must keep driving PR labels after its command-only re-review comment.
 
 ${realBehaviorProofReportSection()}
 
@@ -511,26 +511,32 @@ const rawArgs = process.argv.slice(2);
 const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
 appendFileSync(logPath, JSON.stringify(args) + "\\n");
 const path = args[1] || "";
+const reReviewTimeline = [{
+  id: 987483,
+  event: "commented",
+  actor: { login: "contributor" },
+  created_at: "2026-07-03T21:43:00Z"
+}];
 if (args[0] === "api" && /\\/issues\\/74482$/.test(path)) {
   console.log(JSON.stringify({
     number: 74482,
-    title: "Fresh head label restore",
+    title: "Fresh head label restore after re-review",
     html_url: "https://github.com/openclaw/openclaw/pull/74482",
     created_at: "2026-07-03T19:00:00Z",
-    updated_at: "2026-07-03T21:43:45Z",
+    updated_at: "2026-07-03T21:45:00Z",
     closed_at: null,
     state: "open",
     locked: false,
     active_lock_reason: null,
     author_association: "CONTRIBUTOR",
     user: { login: "contributor" },
-    labels: [],
+    labels: ["status: 📣 needs proof", "rating: 🦪 silver shellfish"],
     pull_request: {}
   }));
 } else if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/74482\\/timeline(?:\\?|$)/.test(args[2] || "")) {
-  console.log("HTTP/2 200\\n\\n[]");
+  console.log("HTTP/2 200\\n\\n" + JSON.stringify(reReviewTimeline));
 } else if (args[0] === "api" && /\\/issues\\/74482\\/timeline(?:\\?|$)/.test(path)) {
-  console.log(JSON.stringify([[]]));
+  console.log(JSON.stringify([reReviewTimeline]));
 } else if (args[0] === "api" && /\\/pulls\\/74482$/.test(path)) {
   console.log(JSON.stringify({
     number: 74482,
@@ -563,6 +569,15 @@ if (args[0] === "api" && /\\/issues\\/74482$/.test(path)) {
       author_association: "CONTRIBUTOR",
       created_at: "2026-07-03T21:42:28Z",
       updated_at: "2026-07-03T21:42:28Z"
+    },
+    {
+      id: 987484,
+      html_url: "https://github.com/openclaw/openclaw/pull/74482#issuecomment-987484",
+      body: "@clawsweeper re-review",
+      user: { login: "contributor" },
+      author_association: "CONTRIBUTOR",
+      created_at: "2026-07-03T21:43:00Z",
+      updated_at: "2026-07-03T21:43:00Z"
     }
   ]]));
 } else if (args[0] === "api" && /\\/issues\\/comments\\/987482$/.test(path)) {
@@ -609,6 +624,24 @@ if (args[0] === "api" && /\\/issues\\/74482$/.test(path)) {
           args[1] === "edit" &&
           args.includes("--add-label") &&
           args.includes("rating: 🦞 diamond lobster"),
+      ),
+    );
+    assert(
+      calls.some(
+        (args) =>
+          args[0] === "issue" &&
+          args[1] === "edit" &&
+          args.includes("--remove-label") &&
+          args.includes("status: 📣 needs proof"),
+      ),
+    );
+    assert(
+      calls.some(
+        (args) =>
+          args[0] === "issue" &&
+          args[1] === "edit" &&
+          args.includes("--remove-label") &&
+          args.includes("rating: 🦪 silver shellfish"),
       ),
     );
     assert(

--- a/test/apply-label-sync.test.ts
+++ b/test/apply-label-sync.test.ts
@@ -3,6 +3,8 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { join } from "node:path";
 import test from "node:test";
 
+import { contextHasNonAutomationActivityAfterForTest } from "../dist/clawsweeper.js";
+
 import {
   lowSignalCloseReport,
   prRatingReportSection,
@@ -15,6 +17,33 @@ import {
   withMockGh,
   workPlanCandidateReport,
 } from "./helpers.ts";
+
+test("command-only timeline activity is ignored only through the completed review", () => {
+  const storedAtMs = Date.parse("2026-07-03T21:42:48Z");
+  const reviewedAtMs = Date.parse("2026-07-03T21:44:48Z");
+  const timelineEvent = (createdAt: string) => ({
+    event: "commented",
+    actor: "contributor",
+    createdAt,
+  });
+
+  assert.equal(
+    contextHasNonAutomationActivityAfterForTest({
+      timeline: [timelineEvent("2026-07-03T21:43:00Z")],
+      activityAfterMs: storedAtMs,
+      ignoreTimelineCommentsThroughMs: reviewedAtMs,
+    }),
+    false,
+  );
+  assert.equal(
+    contextHasNonAutomationActivityAfterForTest({
+      timeline: [timelineEvent("2026-07-03T21:45:00Z")],
+      activityAfterMs: storedAtMs,
+      ignoreTimelineCommentsThroughMs: reviewedAtMs,
+    }),
+    true,
+  );
+});
 
 test("apply-decisions skips advisory label sync when a close report changed since review", () => {
   const root = mkdtempSync(tmpPrefix);

--- a/test/apply-pr-promotion.test.ts
+++ b/test/apply-pr-promotion.test.ts
@@ -371,6 +371,75 @@ test("apply-decisions does not promote stale PRs from truncated activity", () =>
   }
 });
 
+test("apply-decisions does not promote stale PRs after human follow-up", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const synced = reportWithSyncedReviewComment(stalePullRequestReport(), 330, "none");
+    writeFileSync(join(itemsDir, "330.md"), synced.report, "utf8");
+
+    withMockGh(
+      root,
+      promotionGhMock({
+        number: 330,
+        comment: synced.comment,
+        comments: [
+          {
+            id: 9330,
+            html_url: "https://github.com/openclaw/openclaw/pull/330#issuecomment-9330",
+            created_at: "2026-05-01T01:00:00Z",
+            updated_at: "2026-05-01T01:00:00Z",
+            user: { login: "clawsweeper[bot]" },
+            body: synced.comment,
+          },
+          {
+            id: 9331,
+            html_url: "https://github.com/openclaw/openclaw/pull/330#issuecomment-9331",
+            created_at: "2026-05-01T02:00:00Z",
+            updated_at: "2026-05-01T02:00:00Z",
+            user: { login: "reporter" },
+            body: "I can still work on this.",
+          },
+        ],
+      }),
+      () => {
+        withMockCodexProof(root, { type: "failure", message: "proof should not run" }, () => {
+          runApplyDecisionsForTest({
+            itemsDir,
+            closedDir,
+            plansDir,
+            reportPath,
+            extraArgs: [
+              "--target-repo",
+              "openclaw/openclaw",
+              "--dry-run",
+              "--apply-kind",
+              "all",
+              "--processed-limit",
+              "3",
+            ],
+          });
+        });
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{ action: string }>;
+    assert.equal(
+      report.some((entry) => entry.action === "closed"),
+      false,
+    );
+    assert.doesNotMatch(JSON.stringify(report), /proof should not run/);
+    assert.match(readFileSync(join(itemsDir, "330.md"), "utf8"), /^action_taken: kept_open$/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("apply-decisions does not promote stale PRs after a command-only re-review request", () => {
   const root = mkdtempSync(tmpPrefix);
   try {

--- a/test/apply-pr-promotion.test.ts
+++ b/test/apply-pr-promotion.test.ts
@@ -371,7 +371,7 @@ test("apply-decisions does not promote stale PRs from truncated activity", () =>
   }
 });
 
-test("apply-decisions does not promote stale PRs after human follow-up", () => {
+test("apply-decisions does not promote stale PRs after a command-only re-review request", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
     const itemsDir = join(root, "items");
@@ -403,7 +403,15 @@ test("apply-decisions does not promote stale PRs after human follow-up", () => {
             created_at: "2026-05-01T02:00:00Z",
             updated_at: "2026-05-01T02:00:00Z",
             user: { login: "reporter" },
-            body: "I can still work on this.",
+            body: "@clawsweeper re-review",
+          },
+        ],
+        timeline: [
+          {
+            id: 9331,
+            event: "commented",
+            created_at: "2026-05-01T02:00:00Z",
+            actor: { login: "reporter" },
           },
         ],
       }),


### PR DESCRIPTION
## What Problem This Solves

ClawSweeper could publish a complete fresh-head PR review with `proof: sufficient` and a diamond rating while leaving older `needs proof` and silver labels on the PR. A command-only `@clawsweeper re-review` comment was filtered from review context as intended, but GitHub's duplicate body-less `commented` timeline event still made the label freshness gate treat it as new substantive human activity.

Observed on https://github.com/steipete/CodexBar/pull/1869#issuecomment-4880229473.

## What Changed

Fresh-review label reconciliation now ignores duplicate timeline comment events only through the completed review timestamp. The command that requested the completed review no longer blocks its labels, while a later re-review command remains fresh human activity and prevents stale labels from being restored.

The exception remains limited to label reconciliation. Substantive human comments still block label changes, and both substantive comments and command-only re-review requests still block stale-PR close promotion.

The branch was rewritten onto current `main`. It preserves the original substantive-human-follow-up close regression, adds the separate command-only close case, and removes the release-owned changelog edit.

## Proof

- Focused apply and promotion replay: 21/21 passed.
- Credential-free apply behavior contract: 4/4 passed for command-only label sync, substantive-comment blocking, and both close-promotion blockers.
- Inspectable staged apply transcript: https://github.com/openclaw/clawsweeper/pull/405#issuecomment-4883361173 records the exact stale-label removals, fresh-label additions, durable-comment patch, apply report, and exit 0.
- Timestamp-boundary regression: a command event before review completion is ignored; a later event blocks label reconciliation.
- Main and repair suites: 653/653 and 617/617 passed.
- Full coverage and 299-file format checks passed; one timeout-capture timing test flaked once under the first instrumented run, then passed on exact retry and in the complete coverage rerun.
- AutoReview on exact head `74a9dcbb6e8c6aaa21a69874ee2382b25ab38058`: clean, no accepted or actionable findings (0.86 confidence).

## Diff

3 files, +187/-11. Production code scopes the exception by the completed review timestamp; the rest is regression coverage.
