### PR TITLE
fix: recover interrupted command dispatches

### DIFF
--- a/.github/workflows/assist.yml
+++ b/.github/workflows/assist.yml
@@ -81,9 +81,36 @@ jobs:
             exit 0
           fi
           expected_title="Assist ${TARGET_REPO}#${ITEM_NUMBER} [${DISPATCH_KEY}]"
-          if gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/workflows/assist.yml/runs?per_page=100" \
-            | jq -e --arg title "$expected_title" --arg current "$GITHUB_RUN_ID" \
-              'any(.workflow_runs[]; .display_title == $title and .id < ($current | tonumber) and (.status == "queued" or .status == "in_progress" or .status == "waiting" or .status == "pending" or .status == "requested" or .conclusion == "success"))' >/dev/null; then
+          duplicate_run_id="$(
+            gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/workflows/assist.yml/runs?per_page=100" \
+              | jq -r --arg title "$expected_title" --arg current "$GITHUB_RUN_ID" '
+                  .workflow_runs[]
+                  | select(.display_title == $title and .id < ($current | tonumber))
+                  | select(.status == "queued" or .status == "in_progress" or .status == "waiting" or .status == "pending" or .status == "requested")
+                  | .id
+                ' \
+              | head -n 1
+          )"
+          if [ -z "$duplicate_run_id" ]; then
+            while IFS= read -r run_id; do
+              if [ -z "$run_id" ]; then
+                continue
+              fi
+              if gh run view "$run_id" --repo "${GITHUB_REPOSITORY}" --json jobs \
+                | jq -e '.jobs[]? | select(.name == "assist" and .conclusion == "success")' >/dev/null; then
+                duplicate_run_id="$run_id"
+                break
+              fi
+            done < <(
+              gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/workflows/assist.yml/runs?per_page=100" \
+                | jq -r --arg title "$expected_title" --arg current "$GITHUB_RUN_ID" '
+                    .workflow_runs[]
+                    | select(.display_title == $title and .id < ($current | tonumber) and .conclusion == "success")
+                    | .id
+                  '
+            )
+          fi
+          if [ -n "$duplicate_run_id" ]; then
             echo "proceed=false" >> "$GITHUB_OUTPUT"
             echo "An older exact command dispatch receipt already exists; skipping duplicate assist."
             exit 0

--- a/.github/workflows/assist.yml
+++ b/.github/workflows/assist.yml
@@ -83,9 +83,9 @@ jobs:
           expected_title="Assist ${TARGET_REPO}#${ITEM_NUMBER} [${DISPATCH_KEY}]"
           if gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/workflows/assist.yml/runs?per_page=100" \
             | jq -e --arg title "$expected_title" --arg current "$GITHUB_RUN_ID" \
-              'any(.workflow_runs[]; .display_title == $title and (.id | tostring) != $current)' >/dev/null; then
+              'any(.workflow_runs[]; .display_title == $title and .id < ($current | tonumber))' >/dev/null; then
             echo "proceed=false" >> "$GITHUB_OUTPUT"
-            echo "Exact command dispatch receipt already exists; skipping duplicate assist."
+            echo "An older exact command dispatch receipt already exists; skipping duplicate assist."
             exit 0
           fi
           echo "proceed=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/assist.yml
+++ b/.github/workflows/assist.yml
@@ -68,6 +68,11 @@ jobs:
     outputs:
       proceed: ${{ steps.receipt.outputs.proceed }}
     steps:
+      - uses: actions/checkout@v5
+        with:
+          sparse-checkout: scripts/dispatch-receipt-owner.sh
+          sparse-checkout-cone-mode: false
+
       - id: receipt
         env:
           DISPATCH_KEY: ${{ github.event.client_payload.dispatch_key || '' }}
@@ -81,38 +86,11 @@ jobs:
             exit 0
           fi
           expected_title="Assist ${TARGET_REPO}#${ITEM_NUMBER} [${DISPATCH_KEY}]"
-          duplicate_run_id="$(
-            gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/workflows/assist.yml/runs?per_page=100" \
-              | jq -r --arg title "$expected_title" --arg current "$GITHUB_RUN_ID" '
-                  .workflow_runs[]
-                  | select(.display_title == $title and .id < ($current | tonumber))
-                  | select(.status == "queued" or .status == "in_progress" or .status == "waiting" or .status == "pending" or .status == "requested")
-                  | .id
-                ' \
-              | head -n 1
-          )"
-          if [ -z "$duplicate_run_id" ]; then
-            while IFS= read -r run_id; do
-              if [ -z "$run_id" ]; then
-                continue
-              fi
-              if gh run view "$run_id" --repo "${GITHUB_REPOSITORY}" --json jobs \
-                | jq -e '.jobs[]? | select(.name == "assist" and .conclusion == "success")' >/dev/null; then
-                duplicate_run_id="$run_id"
-                break
-              fi
-            done < <(
-              gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/workflows/assist.yml/runs?per_page=100" \
-                | jq -r --arg title "$expected_title" --arg current "$GITHUB_RUN_ID" '
-                    .workflow_runs[]
-                    | select(.display_title == $title and .id < ($current | tonumber) and .conclusion == "success")
-                    | .id
-                  '
-            )
-          fi
-          if [ -n "$duplicate_run_id" ]; then
+          owner="$(bash scripts/dispatch-receipt-owner.sh \
+            assist.yml "$expected_title" "$GITHUB_RUN_ID" assist)"
+          if [ "$owner" = "owner" ]; then
             echo "proceed=false" >> "$GITHUB_OUTPUT"
-            echo "An older exact command dispatch receipt already exists; skipping duplicate assist."
+            echo "An older active or successfully executed command dispatch already exists; skipping duplicate assist."
             exit 0
           fi
           echo "proceed=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/assist.yml
+++ b/.github/workflows/assist.yml
@@ -1,6 +1,6 @@
 name: ClawSweeper assist
 
-run-name: ${{ format('Assist {0}#{1}', github.event.client_payload.target_repo || 'openclaw/openclaw', github.event.client_payload.item_number || '?') }}
+run-name: ${{ github.event.client_payload.dispatch_key && format('Assist {0}#{1} [{2}]', github.event.client_payload.target_repo || 'openclaw/openclaw', github.event.client_payload.item_number || '?', github.event.client_payload.dispatch_key) || format('Assist {0}#{1}', github.event.client_payload.target_repo || 'openclaw/openclaw', github.event.client_payload.item_number || '?') }}
 
 on:
   repository_dispatch:
@@ -47,6 +47,7 @@ on:
         type: string
 
 permissions:
+  actions: read
   contents: read
   issues: write
   pull-requests: read
@@ -61,7 +62,37 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  receipt:
+    name: Deduplicate command dispatch receipt
+    runs-on: ubuntu-latest
+    outputs:
+      proceed: ${{ steps.receipt.outputs.proceed }}
+    steps:
+      - id: receipt
+        env:
+          DISPATCH_KEY: ${{ github.event.client_payload.dispatch_key || '' }}
+          ITEM_NUMBER: ${{ github.event.client_payload.item_number || '?' }}
+          TARGET_REPO: ${{ github.event.client_payload.target_repo || 'openclaw/openclaw' }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ -z "$DISPATCH_KEY" ]; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          expected_title="Assist ${TARGET_REPO}#${ITEM_NUMBER} [${DISPATCH_KEY}]"
+          if gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/workflows/assist.yml/runs?per_page=100" \
+            | jq -e --arg title "$expected_title" --arg current "$GITHUB_RUN_ID" \
+              'any(.workflow_runs[]; .display_title == $title and (.id | tostring) != $current)' >/dev/null; then
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            echo "Exact command dispatch receipt already exists; skipping duplicate assist."
+            exit 0
+          fi
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+
   capacity:
+    needs: receipt
+    if: ${{ needs.receipt.outputs.proceed == 'true' }}
     runs-on: ubuntu-latest
     outputs:
       proceed: ${{ steps.limit.outputs.proceed }}

--- a/.github/workflows/assist.yml
+++ b/.github/workflows/assist.yml
@@ -83,7 +83,7 @@ jobs:
           expected_title="Assist ${TARGET_REPO}#${ITEM_NUMBER} [${DISPATCH_KEY}]"
           if gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/workflows/assist.yml/runs?per_page=100" \
             | jq -e --arg title "$expected_title" --arg current "$GITHUB_RUN_ID" \
-              'any(.workflow_runs[]; .display_title == $title and .id < ($current | tonumber))' >/dev/null; then
+              'any(.workflow_runs[]; .display_title == $title and .id < ($current | tonumber) and (.status == "queued" or .status == "in_progress" or .status == "waiting" or .status == "pending" or .status == "requested" or .conclusion == "success"))' >/dev/null; then
             echo "proceed=false" >> "$GITHUB_OUTPUT"
             echo "An older exact command dispatch receipt already exists; skipping duplicate assist."
             exit 0

--- a/.github/workflows/repair-cluster-worker.yml
+++ b/.github/workflows/repair-cluster-worker.yml
@@ -99,9 +99,9 @@ jobs:
           expected_title="${title} [${DISPATCH_KEY}]"
           if gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/workflows/repair-cluster-worker.yml/runs?per_page=100" \
             | jq -e --arg title "$expected_title" --arg current "$GITHUB_RUN_ID" \
-              'any(.workflow_runs[]; .display_title == $title and (.id | tostring) != $current)' >/dev/null; then
+              'any(.workflow_runs[]; .display_title == $title and .id < ($current | tonumber))' >/dev/null; then
             echo "proceed=false" >> "$GITHUB_OUTPUT"
-            echo "Exact command dispatch receipt already exists; skipping duplicate repair."
+            echo "An older exact command dispatch receipt already exists; skipping duplicate repair."
             exit 0
           fi
           echo "proceed=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/repair-cluster-worker.yml
+++ b/.github/workflows/repair-cluster-worker.yml
@@ -99,7 +99,7 @@ jobs:
           expected_title="${title} [${DISPATCH_KEY}]"
           if gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/workflows/repair-cluster-worker.yml/runs?per_page=100" \
             | jq -e --arg title "$expected_title" --arg current "$GITHUB_RUN_ID" \
-              'any(.workflow_runs[]; .display_title == $title and .id < ($current | tonumber))' >/dev/null; then
+              'any(.workflow_runs[]; .display_title == $title and .id < ($current | tonumber) and (.status == "queued" or .status == "in_progress" or .status == "waiting" or .status == "pending" or .status == "requested" or .conclusion == "success"))' >/dev/null; then
             echo "proceed=false" >> "$GITHUB_OUTPUT"
             echo "An older exact command dispatch receipt already exists; skipping duplicate repair."
             exit 0

--- a/.github/workflows/repair-cluster-worker.yml
+++ b/.github/workflows/repair-cluster-worker.yml
@@ -77,9 +77,15 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read
+      contents: read
     outputs:
       proceed: ${{ steps.receipt.outputs.proceed }}
     steps:
+      - uses: actions/checkout@v5
+        with:
+          sparse-checkout: scripts/dispatch-receipt-owner.sh
+          sparse-checkout-cone-mode: false
+
       - id: receipt
         env:
           DISPATCH_KEY: ${{ inputs.dispatch_key }}
@@ -97,38 +103,11 @@ jobs:
             *) title="repair cluster $JOB_PATH" ;;
           esac
           expected_title="${title} [${DISPATCH_KEY}]"
-          duplicate_run_id="$(
-            gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/workflows/repair-cluster-worker.yml/runs?per_page=100" \
-              | jq -r --arg title "$expected_title" --arg current "$GITHUB_RUN_ID" '
-                  .workflow_runs[]
-                  | select(.display_title == $title and .id < ($current | tonumber))
-                  | select(.status == "queued" or .status == "in_progress" or .status == "waiting" or .status == "pending" or .status == "requested")
-                  | .id
-                ' \
-              | head -n 1
-          )"
-          if [ -z "$duplicate_run_id" ]; then
-            while IFS= read -r run_id; do
-              if [ -z "$run_id" ]; then
-                continue
-              fi
-              if gh run view "$run_id" --repo "${GITHUB_REPOSITORY}" --json jobs \
-                | jq -e '.jobs[]? | select(.name == "Plan and review cluster" and .conclusion == "success")' >/dev/null; then
-                duplicate_run_id="$run_id"
-                break
-              fi
-            done < <(
-              gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/workflows/repair-cluster-worker.yml/runs?per_page=100" \
-                | jq -r --arg title "$expected_title" --arg current "$GITHUB_RUN_ID" '
-                    .workflow_runs[]
-                    | select(.display_title == $title and .id < ($current | tonumber) and .conclusion == "success")
-                    | .id
-                  '
-            )
-          fi
-          if [ -n "$duplicate_run_id" ]; then
+          owner="$(bash scripts/dispatch-receipt-owner.sh \
+            repair-cluster-worker.yml "$expected_title" "$GITHUB_RUN_ID" "Plan and review cluster")"
+          if [ "$owner" = "owner" ]; then
             echo "proceed=false" >> "$GITHUB_OUTPUT"
-            echo "An older exact command dispatch receipt already exists; skipping duplicate repair."
+            echo "An older active or successfully executed command dispatch already exists; skipping duplicate repair."
             exit 0
           fi
           echo "proceed=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/repair-cluster-worker.yml
+++ b/.github/workflows/repair-cluster-worker.yml
@@ -97,9 +97,36 @@ jobs:
             *) title="repair cluster $JOB_PATH" ;;
           esac
           expected_title="${title} [${DISPATCH_KEY}]"
-          if gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/workflows/repair-cluster-worker.yml/runs?per_page=100" \
-            | jq -e --arg title "$expected_title" --arg current "$GITHUB_RUN_ID" \
-              'any(.workflow_runs[]; .display_title == $title and .id < ($current | tonumber) and (.status == "queued" or .status == "in_progress" or .status == "waiting" or .status == "pending" or .status == "requested" or .conclusion == "success"))' >/dev/null; then
+          duplicate_run_id="$(
+            gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/workflows/repair-cluster-worker.yml/runs?per_page=100" \
+              | jq -r --arg title "$expected_title" --arg current "$GITHUB_RUN_ID" '
+                  .workflow_runs[]
+                  | select(.display_title == $title and .id < ($current | tonumber))
+                  | select(.status == "queued" or .status == "in_progress" or .status == "waiting" or .status == "pending" or .status == "requested")
+                  | .id
+                ' \
+              | head -n 1
+          )"
+          if [ -z "$duplicate_run_id" ]; then
+            while IFS= read -r run_id; do
+              if [ -z "$run_id" ]; then
+                continue
+              fi
+              if gh run view "$run_id" --repo "${GITHUB_REPOSITORY}" --json jobs \
+                | jq -e '.jobs[]? | select(.name == "Plan and review cluster" and .conclusion == "success")' >/dev/null; then
+                duplicate_run_id="$run_id"
+                break
+              fi
+            done < <(
+              gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/workflows/repair-cluster-worker.yml/runs?per_page=100" \
+                | jq -r --arg title "$expected_title" --arg current "$GITHUB_RUN_ID" '
+                    .workflow_runs[]
+                    | select(.display_title == $title and .id < ($current | tonumber) and .conclusion == "success")
+                    | .id
+                  '
+            )
+          fi
+          if [ -n "$duplicate_run_id" ]; then
             echo "proceed=false" >> "$GITHUB_OUTPUT"
             echo "An older exact command dispatch receipt already exists; skipping duplicate repair."
             exit 0

--- a/.github/workflows/repair-cluster-worker.yml
+++ b/.github/workflows/repair-cluster-worker.yml
@@ -1,6 +1,6 @@
 name: repair cluster worker
 
-run-name: ${{ contains(inputs.job, '/inbox/issue-') && format('issue implementation {0}', inputs.job) || contains(inputs.job, '/inbox/automerge-') && format('automerge repair {0}', inputs.job) || format('repair cluster {0}', inputs.job) }}
+run-name: ${{ inputs.dispatch_key && format('{0} [{1}]', contains(inputs.job, '/inbox/issue-') && format('issue implementation {0}', inputs.job) || contains(inputs.job, '/inbox/automerge-') && format('automerge repair {0}', inputs.job) || format('repair cluster {0}', inputs.job), inputs.dispatch_key) || contains(inputs.job, '/inbox/issue-') && format('issue implementation {0}', inputs.job) || contains(inputs.job, '/inbox/automerge-') && format('automerge repair {0}', inputs.job) || format('repair cluster {0}', inputs.job) }}
 
 on:
   workflow_dispatch:
@@ -8,6 +8,11 @@ on:
       job:
         description: "Job markdown path, for example jobs/openclaw/inbox/cluster-001.md"
         required: true
+        type: string
+      dispatch_key:
+        description: "Optional command-router idempotency key"
+        required: false
+        default: ""
         type: string
       mode:
         description: "Worker mode"
@@ -67,8 +72,44 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  receipt:
+    name: Deduplicate command dispatch receipt
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    outputs:
+      proceed: ${{ steps.receipt.outputs.proceed }}
+    steps:
+      - id: receipt
+        env:
+          DISPATCH_KEY: ${{ inputs.dispatch_key }}
+          JOB_PATH: ${{ inputs.job }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ -z "$DISPATCH_KEY" ]; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          case "$JOB_PATH" in
+            */inbox/issue-*) title="issue implementation $JOB_PATH" ;;
+            */inbox/automerge-*) title="automerge repair $JOB_PATH" ;;
+            *) title="repair cluster $JOB_PATH" ;;
+          esac
+          expected_title="${title} [${DISPATCH_KEY}]"
+          if gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/workflows/repair-cluster-worker.yml/runs?per_page=100" \
+            | jq -e --arg title "$expected_title" --arg current "$GITHUB_RUN_ID" \
+              'any(.workflow_runs[]; .display_title == $title and (.id | tostring) != $current)' >/dev/null; then
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            echo "Exact command dispatch receipt already exists; skipping duplicate repair."
+            exit 0
+          fi
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+
   cluster:
     name: Plan and review cluster
+    needs: receipt
+    if: ${{ needs.receipt.outputs.proceed == 'true' }}
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 90
     outputs:

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -20,6 +20,8 @@ run-name: >-
       format('Review event item {0}#{1} [{2}]', github.event.client_payload.target_repo || 'openclaw/openclaw', github.event.client_payload.item_number || '?', github.event.client_payload.dispatch_key) ||
     github.event_name == 'repository_dispatch' &&
       format('Review event item {0}#{1}', github.event.client_payload.target_repo || 'openclaw/openclaw', github.event.client_payload.item_number || '?') ||
+    (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.item_numbers, 'router-')) &&
+      format('Review event item {0}#{1} [{2}]', github.event.inputs.target_repo || 'openclaw/openclaw', github.event.inputs.item_number || '?', github.event.inputs.item_numbers) ||
     ((github.event_name == 'workflow_dispatch' &&
       github.event.inputs.apply_existing == 'true' &&
       github.event.inputs.apply_sync_comments_only == 'true') ||
@@ -1162,7 +1164,9 @@ jobs:
           BATCH_SIZE: ${{ steps.mode.outputs.batch_size }}
           HOT_INTAKE: ${{ steps.mode.outputs.hot_intake }}
           ITEM_NUMBER: ${{ github.event.inputs.item_number || '' }}
-          ITEM_NUMBERS: ${{ github.event.inputs.item_numbers || github.event.client_payload.item_number || '' }}
+          # A router fallback carries its receipt key in item_numbers because GitHub caps this
+          # workflow at 25 inputs; item_number remains the exact review target in that case.
+          ITEM_NUMBERS: ${{ (github.event.inputs.item_number != '' && startsWith(github.event.inputs.item_numbers, 'router-') && github.event.inputs.item_number) || github.event.inputs.item_numbers || github.event.client_payload.item_number || '' }}
           MAX_PAGES: ${{ steps.mode.outputs.max_pages }}
           MIN_ACTIVE_SHARDS: ${{ steps.mode.outputs.min_active_shards }}
           MIN_BACKFILL_REVIEW_AGE_MINUTES: ${{ steps.mode.outputs.min_backfill_review_age_minutes }}

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -16,6 +16,8 @@ run-name: >-
     (github.event_name == 'repository_dispatch' &&
       github.event.action == 'clawsweeper_target_sweep') &&
       format('Review target repo {0}', github.event.client_payload.target_repo || 'openclaw/openclaw') ||
+    (github.event_name == 'repository_dispatch' && github.event.client_payload.dispatch_key != '') &&
+      format('Review event item {0}#{1} [{2}]', github.event.client_payload.target_repo || 'openclaw/openclaw', github.event.client_payload.item_number || '?', github.event.client_payload.dispatch_key) ||
     github.event_name == 'repository_dispatch' &&
       format('Review event item {0}#{1}', github.event.client_payload.target_repo || 'openclaw/openclaw', github.event.client_payload.item_number || '?') ||
     ((github.event_name == 'workflow_dispatch' &&
@@ -229,9 +231,12 @@ jobs:
           const payload = JSON.parse(process.env.CLIENT_PAYLOAD || "{}");
           const itemKind = payload.item_kind === "pull_request" ? "pull_request" : "issue";
           const sourceEvent = payload.source_event === "pull_request" ? "pull_request" : "issues";
+          const dispatchKey = String(payload.dispatch_key || "").trim();
           process.stdout.write(
             JSON.stringify({
-              delivery_id: `legacy:${process.env.GITHUB_RUN_ID}:${process.env.GITHUB_RUN_ATTEMPT}`,
+              delivery_id: dispatchKey
+                ? `router:${dispatchKey}`
+                : `legacy:${process.env.GITHUB_RUN_ID}:${process.env.GITHUB_RUN_ATTEMPT}`,
               decision: {
                 targetRepo: payload.target_repo || "openclaw/openclaw",
                 targetBranch: payload.target_branch || "main",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
-- Prevented comment-router retries from either duplicating or permanently losing dispatch-bearing commands by recovering exact Actions receipts and retrying only stale pre-dispatch claims. Thanks @ag-linden.
 - Split apply workflow helpers out of the oversized inline expression so GitHub can validate and start sweep runs again.
 - Bounded apply-existing checkpoints to five fresh closes, renewed the GitHub
   App token between continuation runs, and stopped zero-progress scans from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Prevented comment-router retries from either duplicating or permanently losing dispatch-bearing commands by recovering exact Actions receipts and retrying only stale pre-dispatch claims. Thanks @ag-linden.
 - Split apply workflow helpers out of the oversized inline expression so GitHub can validate and start sweep runs again.
 - Bounded apply-existing checkpoints to five fresh closes, renewed the GitHub
   App token between continuation runs, and stopped zero-progress scans from

--- a/scripts/dispatch-receipt-owner.sh
+++ b/scripts/dispatch-receipt-owner.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workflow="${1:?workflow file is required}"
+expected_title="${2:?expected run title is required}"
+current_run_id="${3:?current run id is required}"
+required_job_name="${4:?required worker job name is required}"
+
+runs_json="$(gh api --method GET \
+  "repos/${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}/actions/workflows/${workflow}/runs?per_page=100")"
+
+active_owner_id="$(
+  jq -r --arg title "$expected_title" --arg current "$current_run_id" '
+    first(
+      .workflow_runs[]
+      | select(.display_title == $title and .id < ($current | tonumber))
+      | select(.status == "queued" or .status == "in_progress" or .status == "waiting" or .status == "pending" or .status == "requested")
+      | .id
+    ) // empty
+  ' <<<"$runs_json"
+)"
+if [ -n "$active_owner_id" ]; then
+  printf 'owner\n'
+  exit 0
+fi
+
+successful_run_ids="$(
+  jq -r --arg title "$expected_title" --arg current "$current_run_id" '
+    .workflow_runs[]
+    | select(.display_title == $title and .id < ($current | tonumber) and .conclusion == "success")
+    | .id
+  ' <<<"$runs_json"
+)"
+while IFS= read -r run_id; do
+  if [ -z "$run_id" ]; then
+    continue
+  fi
+  jobs_json="$(gh api --method GET \
+    "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/jobs?per_page=100")"
+  if jq -e --arg required "$required_job_name" \
+    'any(.jobs[]; .name == $required and .conclusion == "success")' \
+    <<<"$jobs_json" >/dev/null; then
+    printf 'owner\n'
+    exit 0
+  fi
+done <<<"$successful_run_ids"
+
+printf 'none\n'

--- a/src/repair/comment-router-utils.ts
+++ b/src/repair/comment-router-utils.ts
@@ -13,6 +13,16 @@ const DEFAULT_IGNORED_CHECKS = [
 ];
 const TRANSIENT_CANCELLED_CHECKS = new Set(["real behavior proof"]);
 
+export function dispatchClaimLookupKeys(entry: LooseRecord) {
+  const keys: string[] = [];
+  const commentId = String(entry.comment_id ?? "").trim();
+  const commentUpdatedAt = String(entry.comment_updated_at ?? "").trim();
+  if (commentId && commentUpdatedAt) keys.push(`comment:${commentId}:${commentUpdatedAt}`);
+  const idempotencyKey = String(entry.idempotency_key ?? "").trim();
+  if (idempotencyKey) keys.push(`idempotency:${idempotencyKey}`);
+  return keys;
+}
+
 export function summarizeChecks(checks: LooseRecord[]) {
   const ignored = ignoredCheckNames();
   const latestChecks = latestCheckRuns(checks);
@@ -131,7 +141,7 @@ export function dispatchClaimDecision({
   if (!claim) return { action: "dispatch", run: null };
   const normalizedGraceMs = Number.isFinite(graceMs) ? Math.max(0, graceMs) : 300_000;
   const claimedAtMs = Date.parse(String(claim.processed_at ?? ""));
-  const matchingRun = runs.find((run) => {
+  const matchingRuns = runs.filter((run) => {
     if (String(run.display_title ?? run.displayTitle ?? "") !== expectedTitle) return false;
     const createdAtMs = Date.parse(String(run.created_at ?? run.createdAt ?? ""));
     return (
@@ -140,7 +150,16 @@ export function dispatchClaimDecision({
       createdAtMs >= claimedAtMs - 5_000
     );
   });
-  if (matchingRun) return { action: "recover", run: matchingRun };
+  const successfulRun = matchingRuns.find(
+    (run) => String(run.conclusion ?? "").toLowerCase() === "success",
+  );
+  if (successfulRun) return { action: "recover", run: successfulRun };
+  const activeRun = matchingRuns.find((run) =>
+    ["queued", "in_progress", "waiting", "pending", "requested"].includes(
+      String(run.status ?? "").toLowerCase(),
+    ),
+  );
+  if (activeRun) return { action: "wait", run: null };
   if (Number.isFinite(claimedAtMs) && nowMs - claimedAtMs >= normalizedGraceMs) {
     return { action: "dispatch", run: null };
   }

--- a/src/repair/comment-router-utils.ts
+++ b/src/repair/comment-router-utils.ts
@@ -32,6 +32,14 @@ export function dispatchReceiptKeyMaterial(entry: LooseRecord, claim: LooseRecor
   return `${idempotencyKey}:${attempt}`;
 }
 
+export function hasSuccessfulDispatchExecutionJob(jobs: LooseRecord[], requiredJobName: string) {
+  return jobs.some(
+    (job) =>
+      String(job.name ?? "") === requiredJobName &&
+      String(job.conclusion ?? "").toLowerCase() === "success",
+  );
+}
+
 export function summarizeChecks(checks: LooseRecord[]) {
   const ignored = ignoredCheckNames();
   const latestChecks = latestCheckRuns(checks);
@@ -160,7 +168,9 @@ export function dispatchClaimDecision({
     );
   });
   const successfulRun = matchingRuns.find(
-    (run) => String(run.conclusion ?? "").toLowerCase() === "success",
+    (run) =>
+      String(run.conclusion ?? "").toLowerCase() === "success" &&
+      run.dispatch_execution_verified !== false,
   );
   if (successfulRun) return { action: "recover", run: successfulRun };
   const activeRun = matchingRuns.find((run) =>
@@ -375,7 +385,10 @@ function isNoopSkip(entry: LooseRecord) {
 }
 
 function stableLedgerEntry(entry: LooseRecord) {
-  return JSON.stringify({ ...entry, processed_at: null });
+  return JSON.stringify({
+    ...entry,
+    processed_at: entry.status === "claimed" ? entry.processed_at : null,
+  });
 }
 
 function ledgerEntryKey(entry: LooseRecord) {

--- a/src/repair/comment-router-utils.ts
+++ b/src/repair/comment-router-utils.ts
@@ -115,6 +115,38 @@ export function shouldSuppressProcessedCommentVersion(entry: LooseRecord) {
   return true;
 }
 
+export function dispatchClaimDecision({
+  claim,
+  runs,
+  expectedTitle,
+  nowMs = Date.now(),
+  graceMs = 300_000,
+}: {
+  claim: LooseRecord | null;
+  runs: LooseRecord[];
+  expectedTitle: string;
+  nowMs?: number;
+  graceMs?: number;
+}) {
+  if (!claim) return { action: "dispatch", run: null };
+  const normalizedGraceMs = Number.isFinite(graceMs) ? Math.max(0, graceMs) : 300_000;
+  const claimedAtMs = Date.parse(String(claim.processed_at ?? ""));
+  const matchingRun = runs.find((run) => {
+    if (String(run.display_title ?? run.displayTitle ?? "") !== expectedTitle) return false;
+    const createdAtMs = Date.parse(String(run.created_at ?? run.createdAt ?? ""));
+    return (
+      Number.isFinite(claimedAtMs) &&
+      Number.isFinite(createdAtMs) &&
+      createdAtMs >= claimedAtMs - 5_000
+    );
+  });
+  if (matchingRun) return { action: "recover", run: matchingRun };
+  if (Number.isFinite(claimedAtMs) && nowMs - claimedAtMs >= normalizedGraceMs) {
+    return { action: "dispatch", run: null };
+  }
+  return { action: "wait", run: null };
+}
+
 export function sortCommentsForRouting(comments: LooseRecord[]) {
   return [...comments].sort((left: LooseRecord, right: LooseRecord) => {
     const leftTime = commentRoutingTime(left);
@@ -244,7 +276,9 @@ export function readLedger(file: JsonValue) {
 
 export function appendLedger(current: LooseRecord, entries: LooseRecord[]) {
   const compact = entries
-    .filter((entry: JsonValue) => ["executed", "skipped", "waiting"].includes(entry.status))
+    .filter((entry: JsonValue) =>
+      ["claimed", "executed", "skipped", "waiting"].includes(entry.status),
+    )
     .filter((entry: JsonValue) => !isNoopSkip(entry))
     .map((entry: JsonValue) => {
       const actions = compactLedgerActions(entry.actions);
@@ -271,7 +305,7 @@ export function appendLedger(current: LooseRecord, entries: LooseRecord[]) {
         expected_head_sha: entry.expected_head_sha ?? null,
         finding_id: entry.finding_id ?? null,
         status: entry.status,
-        processed_at: new Date().toISOString(),
+        processed_at: entry.processed_at ?? new Date().toISOString(),
         target: entry.target
           ? {
               kind: entry.target.kind,

--- a/src/repair/comment-router-utils.ts
+++ b/src/repair/comment-router-utils.ts
@@ -23,6 +23,15 @@ export function dispatchClaimLookupKeys(entry: LooseRecord) {
   return keys;
 }
 
+export function dispatchReceiptKeyMaterial(entry: LooseRecord, claim: LooseRecord | null) {
+  const idempotencyKey = String(entry.idempotency_key ?? entry.comment_version_key ?? "unknown");
+  if (entry.automation_source !== "repair_loop_label_sweep") return idempotencyKey;
+  const attempt = String(
+    claim?.processed_at ?? entry.processed_at ?? entry.comment_updated_at ?? "unknown-attempt",
+  );
+  return `${idempotencyKey}:${attempt}`;
+}
+
 export function summarizeChecks(checks: LooseRecord[]) {
   const ignored = ignoredCheckNames();
   const latestChecks = latestCheckRuns(checks);
@@ -370,6 +379,13 @@ function stableLedgerEntry(entry: LooseRecord) {
 }
 
 function ledgerEntryKey(entry: LooseRecord) {
+  if (
+    !entry.comment_version_key &&
+    entry.automation_source === "repair_loop_label_sweep" &&
+    entry.idempotency_key
+  ) {
+    return `idempotency:${entry.idempotency_key}`;
+  }
   return (
     entry.comment_version_key ??
     `${entry.comment_id ?? "unknown"}:${entry.comment_updated_at ?? "unknown"}`

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -182,6 +182,7 @@ const collaboratorPermissionCache = new Map();
 const activeRepairRunsByPrefix = new Map<string, LooseRecord[]>();
 const liveTargetCache = new Map<number, LooseRecord>();
 const issueCommentsCache = new Map<number, JsonValue[]>();
+const MAX_MEDIA_PREPROCESSING_TIMEOUT_MS = 480_000;
 const PROOF_OVERRIDE_DESCRIPTION_MARKER = "<!-- clawsweeper-proof-override-note -->";
 const cachedIssueComments = createCachedIssueCommentsLookup(
   (number) => ghPaged<JsonValue>(`repos/${targetRepo}/issues/${number}/comments?per_page=100`),
@@ -2378,6 +2379,11 @@ function dispatchClawSweeperReview(command: LooseRecord): LooseRecord {
     command.target?.kind === "pull_request"
       ? adaptiveReviewBudgetForPullRequest(command.target)
       : null;
+  // Comment-only media is hydrated after dispatch, so fallback must reserve the full bounded
+  // preprocessing budget even when the initial PR title/body did not expose media.
+  const fallbackCodexTimeoutMs = reviewBudget
+    ? reviewBudget.codexTimeoutMs + MAX_MEDIA_PREPROCESSING_TIMEOUT_MS
+    : null;
   const commandStatus = ["re_review", "autofix", "automerge"].includes(String(command.intent ?? ""))
     ? {
         command_status_marker: commandStatusMarker(command),
@@ -2412,11 +2418,45 @@ function dispatchClawSweeperReview(command: LooseRecord): LooseRecord {
     },
   );
   if (result.status !== 0) {
-    throw new Error(
-      `failed to dispatch ClawSweeper review for #${command.issue_number}: ${
-        result.stderr || result.stdout
-      }`,
+    const fallback = ghSpawn(
+      [
+        "workflow",
+        "run",
+        reviewWorkflow,
+        "--repo",
+        reviewRepo,
+        "-f",
+        `target_repo=${command.repo}`,
+        "-f",
+        ...(command.target_branch ? [`target_branch=${String(command.target_branch)}`, "-f"] : []),
+        `item_number=${command.issue_number}`,
+        "-f",
+        `item_numbers=${dispatchKey}`,
+        "-f",
+        `additional_prompt=${freeformReviewPrompt(command)}`,
+        "-f",
+        ...(fallbackCodexTimeoutMs ? [`codex_timeout_ms=${fallbackCodexTimeoutMs}`, "-f"] : []),
+        "batch_size=1",
+        "-f",
+        "shard_count=1",
+      ],
+      { env: dispatchTokenEnv() },
     );
+    if (fallback.status !== 0) {
+      throw new Error(
+        `failed to dispatch ClawSweeper review for #${command.issue_number}: repository_dispatch=${
+          result.stderr || result.stdout
+        }; workflow_dispatch=${fallback.stderr || fallback.stdout}`,
+      );
+    }
+    return {
+      workflow: reviewWorkflow,
+      event: "workflow_dispatch",
+      repo: reviewRepo,
+      item_number: command.issue_number,
+      dispatch_key: dispatchKey,
+      fallback_reason: stripAnsi(result.stderr || result.stdout).trim(),
+    };
   }
   return {
     workflow: reviewWorkflow,

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -88,6 +88,7 @@ import {
   appendLedger,
   dispatchClaimDecision,
   dispatchClaimLookupKeys,
+  dispatchReceiptKeyMaterial,
   issueNumberFromUrl,
   isAllowedMutationActor,
   isGitHubAppIntegrationAuthError,
@@ -349,11 +350,13 @@ async function measureAsync<T>(name: string, fn: () => Promise<T>): Promise<T> {
 }
 
 function claimDispatchCommands(commands: LooseRecord[]) {
+  const processedAt = new Date().toISOString();
   const claims = commands
     .filter(commandNeedsDurableDispatchClaim)
     .filter((command) => !priorDispatchClaim(command))
     .map((command) => ({
       ...command,
+      processed_at: command.processed_at ?? processedAt,
       status: "claimed",
       actions: Array.isArray(command.actions)
         ? command.actions.map((action: JsonValue) =>
@@ -361,7 +364,11 @@ function claimDispatchCommands(commands: LooseRecord[]) {
           )
         : command.actions,
     }));
-  return appendLedger(ledger, claims);
+  const changed = appendLedger(ledger, claims);
+  for (const claim of claims) {
+    for (const key of dispatchClaimLookupKeys(claim)) priorDispatchClaims.set(key, claim);
+  }
+  return changed;
 }
 
 function commandNeedsDurableDispatchClaim(command: LooseRecord) {
@@ -389,7 +396,7 @@ function priorDispatchClaim(command: LooseRecord) {
 
 function dispatchReceiptKey(command: LooseRecord) {
   return `router-${createHash("sha256")
-    .update(String(command.idempotency_key ?? command.comment_version_key ?? "unknown"))
+    .update(dispatchReceiptKeyMaterial(command, priorDispatchClaim(command)))
     .digest("hex")
     .slice(0, 16)}`;
 }

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -89,6 +89,7 @@ import {
   dispatchClaimDecision,
   dispatchClaimLookupKeys,
   dispatchReceiptKeyMaterial,
+  hasSuccessfulDispatchExecutionJob,
   issueNumberFromUrl,
   isAllowedMutationActor,
   isGitHubAppIntegrationAuthError,
@@ -354,21 +355,29 @@ function claimDispatchCommands(commands: LooseRecord[]) {
   const claims = commands
     .filter(commandNeedsDurableDispatchClaim)
     .filter((command) => !priorDispatchClaim(command))
-    .map((command) => ({
-      ...command,
-      processed_at: command.processed_at ?? processedAt,
-      status: "claimed",
-      actions: Array.isArray(command.actions)
-        ? command.actions.map((action: JsonValue) =>
-            actionNeedsDurableDispatchClaim(action) ? { ...action, status: "claimed" } : action,
-          )
-        : command.actions,
-    }));
-  const changed = appendLedger(ledger, claims);
-  for (const claim of claims) {
-    for (const key of dispatchClaimLookupKeys(claim)) priorDispatchClaims.set(key, claim);
-  }
-  return changed;
+    .map((command) => dispatchClaimEntry(command, processedAt));
+  return appendLedger(ledger, claims);
+}
+
+function dispatchClaimEntry(command: LooseRecord, processedAt: string) {
+  command.processed_at = processedAt;
+  return {
+    ...command,
+    processed_at: processedAt,
+    status: "claimed",
+    actions: Array.isArray(command.actions)
+      ? command.actions.map((action: JsonValue) =>
+          actionNeedsDurableDispatchClaim(action) ? { ...action, status: "claimed" } : action,
+        )
+      : command.actions,
+  };
+}
+
+function refreshDispatchClaim(command: LooseRecord) {
+  const claim = dispatchClaimEntry(command, new Date().toISOString());
+  appendLedger(ledger, [claim]);
+  writeLedger(ledgerPath(), ledger);
+  for (const key of dispatchClaimLookupKeys(claim)) priorDispatchClaims.set(key, claim);
 }
 
 function commandNeedsDurableDispatchClaim(command: LooseRecord) {
@@ -437,13 +446,32 @@ function claimedDispatchState({
       reason: `waiting to verify the previous dispatch claim: ${compactText(ghErrorText(error), 300)}`,
     };
   }
+  let verifiedRuns: LooseRecord[];
+  try {
+    verifiedRuns = verifyDispatchExecutionRuns({
+      claim,
+      runs,
+      repo,
+      workflowName,
+      expectedTitle,
+    });
+  } catch (error) {
+    return {
+      status: "claimed",
+      dispatch_key: dispatchReceiptKey(command),
+      reason: `waiting to verify the previous dispatch execution: ${compactText(ghErrorText(error), 300)}`,
+    };
+  }
   const decision = dispatchClaimDecision({
     claim,
-    runs,
+    runs: verifiedRuns,
     expectedTitle,
     graceMs: dispatchClaimGraceMs(),
   });
-  if (decision.action === "dispatch") return null;
+  if (decision.action === "dispatch") {
+    refreshDispatchClaim(command);
+    return null;
+  }
   if (decision.action === "wait") {
     return {
       status: "claimed",
@@ -460,6 +488,54 @@ function claimedDispatchState({
     run_url: run.html_url ?? run.url ?? null,
     event: run.event ?? null,
   };
+}
+
+function verifyDispatchExecutionRuns({
+  claim,
+  runs,
+  repo,
+  workflowName,
+  expectedTitle,
+}: {
+  claim: LooseRecord;
+  runs: LooseRecord[];
+  repo: string;
+  workflowName: string;
+  expectedTitle: string;
+}) {
+  const requiredJobName =
+    workflowName === "assist.yml"
+      ? "assist"
+      : workflowName === "repair-cluster-worker.yml"
+        ? "Plan and review cluster"
+        : null;
+  if (!requiredJobName) return runs;
+  const claimedAtMs = Date.parse(String(claim.processed_at ?? ""));
+  return runs.map((run) => {
+    const createdAtMs = Date.parse(String(run.created_at ?? run.createdAt ?? ""));
+    if (
+      String(run.display_title ?? run.displayTitle ?? "") !== expectedTitle ||
+      String(run.conclusion ?? "").toLowerCase() !== "success" ||
+      !Number.isFinite(claimedAtMs) ||
+      !Number.isFinite(createdAtMs) ||
+      createdAtMs < claimedAtMs - 5_000
+    ) {
+      return run;
+    }
+    const runId = Number(run.id ?? run.databaseId ?? 0);
+    if (!Number.isInteger(runId) || runId <= 0) {
+      return { ...run, dispatch_execution_verified: false };
+    }
+    const response = ghJson<LooseRecord>(
+      ["api", "--method", "GET", `repos/${repo}/actions/runs/${runId}/jobs?per_page=100`],
+      { env: dispatchTokenEnv() },
+    );
+    const jobs = Array.isArray(response.jobs) ? response.jobs : [];
+    return {
+      ...run,
+      dispatch_execution_verified: hasSuccessfulDispatchExecutionJob(jobs, requiredJobName),
+    };
+  });
 }
 
 function dispatchClaimGraceMs() {
@@ -2288,7 +2364,7 @@ function repairJobModeForCommand(command: LooseRecord) {
 }
 
 function dispatchClawSweeperReview(command: LooseRecord): LooseRecord {
-  const dispatchKey = dispatchReceiptKey(command);
+  let dispatchKey = dispatchReceiptKey(command);
   const expectedTitle = `Review event item ${command.repo}#${command.issue_number} [${dispatchKey}]`;
   const claimed = claimedDispatchState({
     command,
@@ -2297,6 +2373,7 @@ function dispatchClawSweeperReview(command: LooseRecord): LooseRecord {
     expectedTitle,
   });
   if (claimed) return { ...claimed, workflow: reviewWorkflow, repo: reviewRepo };
+  dispatchKey = dispatchReceiptKey(command);
   const reviewBudget =
     command.target?.kind === "pull_request"
       ? adaptiveReviewBudgetForPullRequest(command.target)
@@ -2351,7 +2428,7 @@ function dispatchClawSweeperReview(command: LooseRecord): LooseRecord {
 }
 
 function dispatchClawSweeperAssist(command: LooseRecord): LooseRecord {
-  const dispatchKey = dispatchReceiptKey(command);
+  let dispatchKey = dispatchReceiptKey(command);
   const workflowName = "assist.yml";
   const expectedTitle = `Assist ${command.repo}#${command.issue_number} [${dispatchKey}]`;
   const claimed = claimedDispatchState({
@@ -2361,6 +2438,7 @@ function dispatchClawSweeperAssist(command: LooseRecord): LooseRecord {
     expectedTitle,
   });
   if (claimed) return { ...claimed, workflow: workflowName, repo: reviewRepo };
+  dispatchKey = dispatchReceiptKey(command);
   const baseDispatchPayload = buildClawSweeperAssistDispatchPayload(command);
   const dispatchPayload = {
     ...baseDispatchPayload,
@@ -2422,7 +2500,7 @@ function freeformReviewPrompt(command: LooseRecord): string {
 }
 
 function dispatchRepair(command: LooseRecord) {
-  const dispatchKey = dispatchReceiptKey(command);
+  let dispatchKey = dispatchReceiptKey(command);
   const expectedTitle = repairRunNameForJob(
     command.target.job_path,
     automergeRunNamePrefix,
@@ -2446,6 +2524,7 @@ function dispatchRepair(command: LooseRecord) {
       model,
     };
   }
+  dispatchKey = dispatchReceiptKey(command);
   const activeRun = activeRepairRunForCommand(command);
   if (activeRun) {
     return {

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import type { JsonValue, LooseRecord } from "./json-types.js";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { adaptiveReviewBudgetForPullRequest } from "./adaptive-review-budget.js";
@@ -8,6 +9,7 @@ import {
   assertLiveWorkerCapacity,
   parseArgs,
   parseJob,
+  repairRunNameForJob,
   repoRoot,
   validateJob,
   waitForLiveWorkerCapacity,
@@ -84,6 +86,7 @@ import { mergeAutomergeTimelineSection } from "./automerge-status-timeline.js";
 import {
   SUPERSEDED_RE_REVIEW_REASON,
   appendLedger,
+  dispatchClaimDecision,
   issueNumberFromUrl,
   isAllowedMutationActor,
   isGitHubAppIntegrationAuthError,
@@ -148,6 +151,12 @@ const {
 const startedAtMs = Date.now();
 const timings: LooseRecord[] = [];
 const ledger = readLedger(ledgerPath());
+const priorDispatchClaims = new Map<string, LooseRecord>();
+for (const entry of ledger.commands ?? []) {
+  if (entry.status !== "claimed") continue;
+  const key = commentVersionKey(entry);
+  if (key) priorDispatchClaims.set(key, entry);
+}
 const TARGET_LOOKUP_RETRY_ATTEMPTS = 3;
 const processedCommentVersions = forceReprocess
   ? new Set()
@@ -159,7 +168,7 @@ const processedCommentVersions = forceReprocess
     );
 const retryPendingCommentVersions = new Set(
   (ledger.commands ?? [])
-    .filter((entry: JsonValue) => entry.status === "waiting")
+    .filter((entry: JsonValue) => entry.status === "waiting" || entry.status === "claimed")
     .map(commentVersionKey)
     .filter(Boolean),
 );
@@ -171,7 +180,6 @@ const collaboratorPermissionCache = new Map();
 const activeRepairRunsByPrefix = new Map<string, LooseRecord[]>();
 const liveTargetCache = new Map<number, LooseRecord>();
 const issueCommentsCache = new Map<number, JsonValue[]>();
-const MAX_MEDIA_PREPROCESSING_TIMEOUT_MS = 480_000;
 const PROOF_OVERRIDE_DESCRIPTION_MARKER = "<!-- clawsweeper-proof-override-note -->";
 const cachedIssueComments = createCachedIssueCommentsLookup(
   (number) => ghPaged<JsonValue>(`repos/${targetRepo}/issues/${number}/comments?per_page=100`),
@@ -295,8 +303,6 @@ const report: LooseRecord = {
 if (execute) {
   await measureAsync("execute_commands", async () => {
     assertMutationActorIsClawsweeperBot();
-    for (const command of commands) convergePrecreatedCommandAckComments(command);
-    for (const command of commands) acknowledgeSkippedMaintainerCommand(command);
     const capacityRequests = workerCapacityRequests(actionable);
     if (capacityRequests.length > 0) {
       const capacities = capacityRequests.map((request) =>
@@ -305,6 +311,12 @@ if (execute) {
       report.live_worker_capacity_before_dispatch =
         capacities.length === 1 ? capacities[0] : capacities;
     }
+    report.ledger_claimed = measure("claim_dispatch_commands", () =>
+      claimDispatchCommands(actionable),
+    );
+    if (report.ledger_claimed) writeLedger(ledgerPath(), ledger);
+    for (const command of commands) convergePrecreatedCommandAckComments(command);
+    for (const command of commands) acknowledgeSkippedMaintainerCommand(command);
     for (const command of actionable) executeCommand(command);
   });
   report.ledger_changed = measure("append_ledger", () => appendLedger(ledger, commands));
@@ -334,6 +346,132 @@ async function measureAsync<T>(name: string, fn: () => Promise<T>): Promise<T> {
   } finally {
     timings.push({ name, ms: Date.now() - start });
   }
+}
+
+function claimDispatchCommands(commands: LooseRecord[]) {
+  const claims = commands
+    .filter(commandNeedsDurableDispatchClaim)
+    .filter((command) => !priorDispatchClaim(command))
+    .map((command) => ({
+      ...command,
+      status: "claimed",
+      actions: Array.isArray(command.actions)
+        ? command.actions.map((action: JsonValue) =>
+            actionNeedsDurableDispatchClaim(action) ? { ...action, status: "claimed" } : action,
+          )
+        : command.actions,
+    }));
+  return appendLedger(ledger, claims);
+}
+
+function commandNeedsDurableDispatchClaim(command: LooseRecord) {
+  return (
+    String(command.status ?? "") === "ready" &&
+    (commandHasAction(command, "dispatch_clawsweeper") ||
+      commandHasAction(command, "dispatch_repair") ||
+      commandHasAction(command, "dispatch_assist"))
+  );
+}
+
+function actionNeedsDurableDispatchClaim(action: JsonValue) {
+  return ["dispatch_clawsweeper", "dispatch_repair", "dispatch_assist"].includes(
+    String(action?.action ?? ""),
+  );
+}
+
+function priorDispatchClaim(command: LooseRecord) {
+  return priorDispatchClaims.get(commentVersionKey(command) ?? "") ?? null;
+}
+
+function dispatchReceiptKey(command: LooseRecord) {
+  return `router-${createHash("sha256")
+    .update(String(command.idempotency_key ?? command.comment_version_key ?? "unknown"))
+    .digest("hex")
+    .slice(0, 16)}`;
+}
+
+function claimedDispatchState({
+  command,
+  repo,
+  workflowName,
+  expectedTitle,
+}: {
+  command: LooseRecord;
+  repo: string;
+  workflowName: string;
+  expectedTitle: string;
+}) {
+  const claim = priorDispatchClaim(command);
+  if (!claim) return null;
+  const runs: LooseRecord[] = [];
+  try {
+    for (let page = 1; page <= 3; page += 1) {
+      const response = ghJson<LooseRecord>(
+        [
+          "api",
+          "--method",
+          "GET",
+          `repos/${repo}/actions/workflows/${encodeURIComponent(workflowName)}/runs?per_page=100&page=${page}`,
+        ],
+        { env: dispatchTokenEnv() },
+      );
+      const pageRuns = Array.isArray(response.workflow_runs) ? response.workflow_runs : [];
+      runs.push(...pageRuns);
+      if (pageRuns.length < 100) break;
+    }
+  } catch (error) {
+    return {
+      status: "claimed",
+      dispatch_key: dispatchReceiptKey(command),
+      reason: `waiting to verify the previous dispatch claim: ${compactText(ghErrorText(error), 300)}`,
+    };
+  }
+  const decision = dispatchClaimDecision({
+    claim,
+    runs,
+    expectedTitle,
+    graceMs: dispatchClaimGraceMs(),
+  });
+  if (decision.action === "dispatch") return null;
+  if (decision.action === "wait") {
+    return {
+      status: "claimed",
+      dispatch_key: dispatchReceiptKey(command),
+      reason: "waiting for the previous dispatch to become visible before retrying",
+    };
+  }
+  const run = decision.run ?? {};
+  return {
+    status: "recovered",
+    dispatch_key: dispatchReceiptKey(command),
+    recovered: true,
+    run_id: run.id ?? run.databaseId ?? null,
+    run_url: run.html_url ?? run.url ?? null,
+    event: run.event ?? null,
+  };
+}
+
+function dispatchClaimGraceMs() {
+  const configured = Number(process.env.CLAWSWEEPER_DISPATCH_CLAIM_GRACE_MS ?? 300_000);
+  return Number.isFinite(configured) && configured >= 0 ? configured : 300_000;
+}
+
+function dispatchedActionStatus(dispatch: LooseRecord) {
+  const { status: dispatchStatus, ...receipt } = dispatch;
+  if (dispatchStatus === "claimed") return { ...receipt, status: "claimed" };
+  return {
+    ...receipt,
+    status: "executed",
+    ...(dispatchStatus === "recovered"
+      ? { recovered: true, receipt_verified_at: new Date().toISOString() }
+      : { dispatched_at: new Date().toISOString() }),
+  };
+}
+
+function keepCommandClaimed(command: LooseRecord) {
+  command.status = "claimed";
+  const claimedAt = priorDispatchClaim(command)?.processed_at;
+  if (claimedAt) command.processed_at = claimedAt;
 }
 
 function assertMutationActorIsClawsweeperBot() {
@@ -1466,6 +1604,20 @@ function executeCommand(command: LooseRecord) {
       }
       const repair = dispatchRepair(command);
       dispatched = REPAIR_INTENTS.has(command.intent) ? repair : { repair };
+      if (repair.status === "claimed") {
+        command.actions = command.actions.map((action: JsonValue) =>
+          action.action === "dispatch_repair"
+            ? {
+                ...action,
+                job_path: command.target.job_path,
+                mode: command.target.mode,
+                ...dispatchRepairActionStatus(repair),
+              }
+            : action,
+        );
+        keepCommandClaimed(command);
+        return;
+      }
       const labelsToRemove = command.actions
         .filter((action: JsonValue) => action.action === "remove_label")
         .map((action: JsonValue) => String(action.label ?? ""))
@@ -1554,13 +1706,15 @@ function executeCommand(command: LooseRecord) {
         if (action.action === "dispatch_clawsweeper") {
           return {
             ...action,
-            status: "executed",
-            dispatched_at: new Date().toISOString(),
-            ...clawsweeper,
+            ...dispatchedActionStatus(clawsweeper),
           };
         }
         return action;
       });
+      if (clawsweeper.status === "claimed") {
+        keepCommandClaimed(command);
+        return;
+      }
     }
     if (
       (command.intent === "freeform_assist" || command.intent === "visualize") &&
@@ -1573,13 +1727,15 @@ function executeCommand(command: LooseRecord) {
         if (action.action === "dispatch_assist") {
           return {
             ...action,
-            status: "executed",
-            dispatched_at: new Date().toISOString(),
-            ...clawsweeper,
+            ...dispatchedActionStatus(clawsweeper),
           };
         }
         return action;
       });
+      if (clawsweeper.status === "claimed") {
+        keepCommandClaimed(command);
+        return;
+      }
     }
     if (command.intent === "re_review" && command.issue_number && shouldDispatchClawSweeper) {
       const clawsweeper = dispatchClawSweeperReview(command);
@@ -1588,13 +1744,15 @@ function executeCommand(command: LooseRecord) {
         if (action.action === "dispatch_clawsweeper") {
           return {
             ...action,
-            status: "executed",
-            dispatched_at: new Date().toISOString(),
-            ...clawsweeper,
+            ...dispatchedActionStatus(clawsweeper),
           };
         }
         return action;
       });
+      if (clawsweeper.status === "claimed") {
+        keepCommandClaimed(command);
+        return;
+      }
     }
     if (
       AUTOCLOSE_INTENTS.has(command.intent) &&
@@ -1693,6 +1851,10 @@ function executeCommand(command: LooseRecord) {
             mode: command.target.mode,
             ...dispatchRepairActionStatus(repair),
           });
+          if (repair.status === "claimed") {
+            keepCommandClaimed(command);
+            return;
+          }
         }
       }
     }
@@ -1751,7 +1913,11 @@ function executeCommand(command: LooseRecord) {
           }
         : action,
     );
-    command.status = commandHasWaitingRepairDispatch(command) ? "waiting" : "executed";
+    command.status = commandHasClaimedDispatch(command)
+      ? "claimed"
+      : commandHasWaitingRepairDispatch(command)
+        ? "waiting"
+        : "executed";
   } finally {
     clearTerminalMaintainerCommandReaction(command);
   }
@@ -2110,16 +2276,20 @@ function repairJobModeForCommand(command: LooseRecord) {
   return "automerge";
 }
 
-function dispatchClawSweeperReview(command: LooseRecord) {
+function dispatchClawSweeperReview(command: LooseRecord): LooseRecord {
+  const dispatchKey = dispatchReceiptKey(command);
+  const expectedTitle = `Review event item ${command.repo}#${command.issue_number} [${dispatchKey}]`;
+  const claimed = claimedDispatchState({
+    command,
+    repo: reviewRepo,
+    workflowName: reviewWorkflow,
+    expectedTitle,
+  });
+  if (claimed) return { ...claimed, workflow: reviewWorkflow, repo: reviewRepo };
   const reviewBudget =
     command.target?.kind === "pull_request"
       ? adaptiveReviewBudgetForPullRequest(command.target)
       : null;
-  // Comment-only media is hydrated after dispatch, so fallback must reserve the full bounded
-  // preprocessing budget even when the initial PR title/body did not expose media.
-  const fallbackCodexTimeoutMs = reviewBudget
-    ? reviewBudget.codexTimeoutMs + MAX_MEDIA_PREPROCESSING_TIMEOUT_MS
-    : null;
   const commandStatus = ["re_review", "autofix", "automerge"].includes(String(command.intent ?? ""))
     ? {
         command_status_marker: commandStatusMarker(command),
@@ -2135,6 +2305,7 @@ function dispatchClawSweeperReview(command: LooseRecord) {
       ...(command.target_branch ? { target_branch: String(command.target_branch) } : {}),
       item_number: String(command.issue_number),
       item_kind: command.target?.kind ?? "",
+      dispatch_key: dispatchKey,
       additional_prompt: freeformReviewPrompt(command),
       ...(reviewBudget
         ? {
@@ -2153,55 +2324,38 @@ function dispatchClawSweeperReview(command: LooseRecord) {
     },
   );
   if (result.status !== 0) {
-    const fallback = ghSpawn(
-      [
-        "workflow",
-        "run",
-        reviewWorkflow,
-        "--repo",
-        reviewRepo,
-        "-f",
-        `target_repo=${command.repo}`,
-        "-f",
-        ...(command.target_branch ? [`target_branch=${String(command.target_branch)}`, "-f"] : []),
-        `item_number=${command.issue_number}`,
-        "-f",
-        `item_numbers=${command.issue_number}`,
-        "-f",
-        `additional_prompt=${freeformReviewPrompt(command)}`,
-        "-f",
-        ...(fallbackCodexTimeoutMs ? [`codex_timeout_ms=${fallbackCodexTimeoutMs}`, "-f"] : []),
-        "batch_size=1",
-        "-f",
-        "shard_count=1",
-      ],
-      { env: dispatchTokenEnv() },
+    throw new Error(
+      `failed to dispatch ClawSweeper review for #${command.issue_number}: ${
+        result.stderr || result.stdout
+      }`,
     );
-    if (fallback.status !== 0) {
-      throw new Error(
-        `failed to dispatch ClawSweeper review for #${command.issue_number}: repository_dispatch=${
-          result.stderr || result.stdout
-        }; workflow_dispatch=${fallback.stderr || fallback.stdout}`,
-      );
-    }
-    return {
-      workflow: reviewWorkflow,
-      event: "workflow_dispatch",
-      repo: reviewRepo,
-      item_number: command.issue_number,
-      fallback_reason: stripAnsi(result.stderr || result.stdout).trim(),
-    };
   }
   return {
     workflow: reviewWorkflow,
     event: "repository_dispatch",
     repo: reviewRepo,
     item_number: command.issue_number,
+    dispatch_key: dispatchKey,
   };
 }
 
-function dispatchClawSweeperAssist(command: LooseRecord) {
-  const payload = JSON.stringify(buildClawSweeperAssistDispatchPayload(command));
+function dispatchClawSweeperAssist(command: LooseRecord): LooseRecord {
+  const dispatchKey = dispatchReceiptKey(command);
+  const workflowName = "assist.yml";
+  const expectedTitle = `Assist ${command.repo}#${command.issue_number} [${dispatchKey}]`;
+  const claimed = claimedDispatchState({
+    command,
+    repo: reviewRepo,
+    workflowName,
+    expectedTitle,
+  });
+  if (claimed) return { ...claimed, workflow: workflowName, repo: reviewRepo };
+  const baseDispatchPayload = buildClawSweeperAssistDispatchPayload(command);
+  const dispatchPayload = {
+    ...baseDispatchPayload,
+    client_payload: { ...baseDispatchPayload.client_payload, dispatch_key: dispatchKey },
+  };
+  const payload = JSON.stringify(dispatchPayload);
   const result = ghSpawn(
     ["api", `repos/${reviewRepo}/dispatches`, "--method", "POST", "--input", "-"],
     {
@@ -2217,10 +2371,11 @@ function dispatchClawSweeperAssist(command: LooseRecord) {
     );
   }
   return {
-    workflow: "assist.yml",
+    workflow: workflowName,
     event: "repository_dispatch",
     repo: reviewRepo,
     item_number: command.issue_number,
+    dispatch_key: dispatchKey,
   };
 }
 
@@ -2256,6 +2411,30 @@ function freeformReviewPrompt(command: LooseRecord): string {
 }
 
 function dispatchRepair(command: LooseRecord) {
+  const dispatchKey = dispatchReceiptKey(command);
+  const expectedTitle = repairRunNameForJob(
+    command.target.job_path,
+    automergeRunNamePrefix,
+    dispatchKey,
+  );
+  const claimed = claimedDispatchState({
+    command,
+    repo: repairRepo,
+    workflowName: workflow,
+    expectedTitle,
+  });
+  if (claimed) {
+    return {
+      ...claimed,
+      workflow,
+      repair_repo: repairRepo,
+      job_path: command.target.job_path,
+      mode: command.target.mode,
+      runner,
+      execution_runner: executionRunner,
+      model,
+    };
+  }
   const activeRun = activeRepairRunForCommand(command);
   if (activeRun) {
     return {
@@ -2282,6 +2461,8 @@ function dispatchRepair(command: LooseRecord) {
       repairRepo,
       "-f",
       `job=${command.target.job_path}`,
+      "-f",
+      `dispatch_key=${dispatchKey}`,
       "-f",
       `mode=${command.target.mode}`,
       "-f",
@@ -2312,6 +2493,13 @@ function dispatchRepair(command: LooseRecord) {
 }
 
 function dispatchRepairActionStatus(repair: LooseRecord) {
+  if (repair.status === "claimed") {
+    return {
+      status: "claimed",
+      reason: repair.reason,
+      ...(repair.dispatch_key ? { dispatch_key: repair.dispatch_key } : {}),
+    };
+  }
   if (repair.status === "already_running") {
     return {
       status: "active",
@@ -2324,9 +2512,19 @@ function dispatchRepairActionStatus(repair: LooseRecord) {
   }
   return {
     status: "executed",
-    dispatched_at: new Date().toISOString(),
+    ...(repair.status === "recovered"
+      ? { recovered: true, receipt_verified_at: new Date().toISOString() }
+      : { dispatched_at: new Date().toISOString() }),
+    ...(repair.dispatch_key ? { dispatch_key: repair.dispatch_key } : {}),
     ...(repair.run_url ? { run_url: repair.run_url } : {}),
+    ...(repair.run_id ? { run_id: repair.run_id } : {}),
   };
+}
+
+function commandHasClaimedDispatch(command: LooseRecord) {
+  return command.actions?.some(
+    (action: JsonValue) => actionNeedsDurableDispatchClaim(action) && action.status === "claimed",
+  );
 }
 
 function commandHasWaitingRepairDispatch(command: LooseRecord) {

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -87,6 +87,7 @@ import {
   SUPERSEDED_RE_REVIEW_REASON,
   appendLedger,
   dispatchClaimDecision,
+  dispatchClaimLookupKeys,
   issueNumberFromUrl,
   isAllowedMutationActor,
   isGitHubAppIntegrationAuthError,
@@ -154,8 +155,7 @@ const ledger = readLedger(ledgerPath());
 const priorDispatchClaims = new Map<string, LooseRecord>();
 for (const entry of ledger.commands ?? []) {
   if (entry.status !== "claimed") continue;
-  const key = commentVersionKey(entry);
-  if (key) priorDispatchClaims.set(key, entry);
+  for (const key of dispatchClaimLookupKeys(entry)) priorDispatchClaims.set(key, entry);
 }
 const TARGET_LOOKUP_RETRY_ATTEMPTS = 3;
 const processedCommentVersions = forceReprocess
@@ -380,7 +380,11 @@ function actionNeedsDurableDispatchClaim(action: JsonValue) {
 }
 
 function priorDispatchClaim(command: LooseRecord) {
-  return priorDispatchClaims.get(commentVersionKey(command) ?? "") ?? null;
+  for (const key of dispatchClaimLookupKeys(command)) {
+    const claim = priorDispatchClaims.get(key);
+    if (claim) return claim;
+  }
+  return null;
 }
 
 function dispatchReceiptKey(command: LooseRecord) {

--- a/src/repair/live-worker-capacity.ts
+++ b/src/repair/live-worker-capacity.ts
@@ -8,6 +8,7 @@ import { sleepMs } from "./timing.js";
 const DEFAULT_MAX_LIVE_WORKERS = AUTOMATION_LIMITS.repair_live_runs.default;
 export const MAX_LIVE_WORKERS = AUTOMATION_LIMITS.repair_live_runs.hard_cap;
 export const DEFAULT_AUTOMERGE_REPAIR_RUN_NAME_PREFIX = "automerge repair ";
+export const DEFAULT_ISSUE_IMPLEMENTATION_RUN_NAME_PREFIX = "issue implementation ";
 export const DEFAULT_REPAIR_RUN_NAME_PREFIX = "repair cluster ";
 const DEFAULT_CAPACITY_POLL_MS = 30_000;
 const DEFAULT_CAPACITY_TIMEOUT_MS = 30 * 60 * 1000;
@@ -168,9 +169,12 @@ export function repairRunNamePrefixForJob(
   jobPath: JsonValue,
   automergeRunNamePrefix: JsonValue = DEFAULT_AUTOMERGE_REPAIR_RUN_NAME_PREFIX,
 ) {
-  return String(jobPath ?? "").includes("/inbox/automerge-")
-    ? String(automergeRunNamePrefix ?? DEFAULT_AUTOMERGE_REPAIR_RUN_NAME_PREFIX)
-    : DEFAULT_REPAIR_RUN_NAME_PREFIX;
+  const job = String(jobPath ?? "");
+  if (job.includes("/inbox/issue-")) return DEFAULT_ISSUE_IMPLEMENTATION_RUN_NAME_PREFIX;
+  if (job.includes("/inbox/automerge-")) {
+    return String(automergeRunNamePrefix ?? DEFAULT_AUTOMERGE_REPAIR_RUN_NAME_PREFIX);
+  }
+  return DEFAULT_REPAIR_RUN_NAME_PREFIX;
 }
 
 export function repairRunNameForJob(

--- a/src/repair/live-worker-capacity.ts
+++ b/src/repair/live-worker-capacity.ts
@@ -176,11 +176,14 @@ export function repairRunNamePrefixForJob(
 export function repairRunNameForJob(
   jobPath: JsonValue,
   automergeRunNamePrefix: JsonValue = DEFAULT_AUTOMERGE_REPAIR_RUN_NAME_PREFIX,
+  dispatchKey: JsonValue = null,
 ) {
-  return joinRepairRunNamePrefix(
+  const title = joinRepairRunNamePrefix(
     repairRunNamePrefixForJob(jobPath, automergeRunNamePrefix),
     String(jobPath ?? ""),
   );
+  const key = String(dispatchKey ?? "").trim();
+  return key ? `${title} [${key}]` : title;
 }
 
 export function activeRepairWorkflowRunForJob({
@@ -225,7 +228,10 @@ export function activeRepairWorkflowRunForJob({
           env,
         });
   return (
-    activeRuns?.find((run: JsonValue) => String(run.displayTitle ?? "") === expectedTitle) ?? null
+    activeRuns?.find((run: JsonValue) => {
+      const title = String(run.displayTitle ?? "");
+      return title === expectedTitle || title.startsWith(`${expectedTitle} [router-`);
+    }) ?? null
   );
 }
 

--- a/test/dispatch-receipt-owner.test.ts
+++ b/test/dispatch-receipt-owner.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import test from "node:test";
+
+const SCRIPT = join(process.cwd(), "scripts", "dispatch-receipt-owner.sh");
+const EXPECTED_TITLE = "Assist openclaw/openclaw#42 [router-proof]";
+
+function fixtureEnv(options: {
+  jobs101?: unknown[];
+  jobs102?: unknown[];
+  runs: unknown[];
+  failJobs?: boolean;
+}) {
+  const binDir = mkdtempSync(join(tmpdir(), "dispatch-receipt-owner-"));
+  const gh = join(binDir, "gh");
+  writeFileSync(
+    gh,
+    `#!/bin/sh
+case "$*" in
+  *actions/workflows/*) printf '%s\\n' "$FAKE_RUNS_JSON" ;;
+  *actions/runs/101/jobs*)
+    [ "\${FAKE_FAIL_JOBS:-0}" = 1 ] && exit 7
+    printf '%s\\n' "$FAKE_JOBS_101_JSON"
+    ;;
+  *actions/runs/102/jobs*)
+    [ "\${FAKE_FAIL_JOBS:-0}" = 1 ] && exit 7
+    printf '%s\\n' "$FAKE_JOBS_102_JSON"
+    ;;
+  *) echo "unexpected gh args: $*" >&2; exit 9 ;;
+esac
+`,
+  );
+  chmodSync(gh, 0o755);
+  return {
+    binDir,
+    env: {
+      ...process.env,
+      PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}`,
+      GITHUB_REPOSITORY: "openclaw/clawsweeper",
+      FAKE_RUNS_JSON: JSON.stringify({ workflow_runs: options.runs }),
+      FAKE_JOBS_101_JSON: JSON.stringify({ jobs: options.jobs101 ?? [] }),
+      FAKE_JOBS_102_JSON: JSON.stringify({ jobs: options.jobs102 ?? [] }),
+      FAKE_FAIL_JOBS: options.failJobs ? "1" : "0",
+    },
+  };
+}
+
+function runGate(options: Parameters<typeof fixtureEnv>[0], requiredJobName = "assist") {
+  const fixture = fixtureEnv(options);
+  try {
+    return execFileSync("bash", [SCRIPT, "assist.yml", EXPECTED_TITLE, "200", requiredJobName], {
+      encoding: "utf8",
+      env: fixture.env,
+    }).trim();
+  } finally {
+    rmSync(fixture.binDir, { recursive: true, force: true });
+  }
+}
+
+test("dispatch receipt gate keeps an older active run as owner", () => {
+  assert.equal(
+    runGate({
+      runs: [{ id: 101, display_title: EXPECTED_TITLE, status: "in_progress" }],
+    }),
+    "owner",
+  );
+});
+
+test("dispatch receipt gate allows retry after failed owner and receipt-only success", () => {
+  for (const requiredJobName of ["assist", "Plan and review cluster"]) {
+    assert.equal(
+      runGate(
+        {
+          runs: [
+            { id: 101, display_title: EXPECTED_TITLE, status: "completed", conclusion: "failure" },
+            { id: 102, display_title: EXPECTED_TITLE, status: "completed", conclusion: "success" },
+          ],
+          jobs102: [
+            { name: "Deduplicate command dispatch receipt", conclusion: "success" },
+            { name: requiredJobName, conclusion: "skipped" },
+          ],
+        },
+        requiredJobName,
+      ),
+      "none",
+    );
+  }
+});
+
+test("dispatch receipt gate keeps a successfully executed worker as owner", () => {
+  assert.equal(
+    runGate({
+      runs: [
+        { id: 102, display_title: EXPECTED_TITLE, status: "completed", conclusion: "success" },
+      ],
+      jobs102: [{ name: "assist", conclusion: "success" }],
+    }),
+    "owner",
+  );
+});
+
+test("dispatch receipt gate fails closed when worker job verification fails", () => {
+  const fixture = fixtureEnv({
+    runs: [{ id: 102, display_title: EXPECTED_TITLE, status: "completed", conclusion: "success" }],
+    failJobs: true,
+  });
+  try {
+    const result = spawnSync("bash", [SCRIPT, "assist.yml", EXPECTED_TITLE, "200", "assist"], {
+      encoding: "utf8",
+      env: fixture.env,
+    });
+    assert.equal(result.status, 7);
+    assert.equal(result.stdout, "");
+  } finally {
+    rmSync(fixture.binDir, { recursive: true, force: true });
+  }
+});

--- a/test/repair/apply-result.test.ts
+++ b/test/repair/apply-result.test.ts
@@ -1244,7 +1244,9 @@ function runApplyResult(
       CLAWSWEEPER_ALLOW_EXECUTE: "1",
       CLAWSWEEPER_ALLOWED_OWNER: "openclaw",
       CLAWSWEEPER_MODEL: "model-test",
-      CLAWSWEEPER_PR_CLOSE_COVERAGE_PROOF_TIMEOUT_MS: "10000",
+      // Coverage instrumentation plus the parallel repair suite can delay this child process.
+      // Keep the bound short for a fake binary without making CI depend on a 10-second scheduler window.
+      CLAWSWEEPER_PR_CLOSE_COVERAGE_PROOF_TIMEOUT_MS: "30000",
       GH_TOKEN: "write-token",
       ...mockGhBinEnv(path.join(paths.binDir, "gh.js")),
       PATH: `${paths.binDir}${path.delimiter}${process.env.PATH ?? ""}`,

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -1482,6 +1482,8 @@ test("comment router durably claims dispatch commands and recovers exact workflo
   assert.match(claimFunction, /commandHasAction\(command,\s*"dispatch_assist"\)/);
   assert.match(source, /function claimedDispatchState/);
   assert.match(source, /dispatchClaimDecision\(\{/);
+  assert.match(source, /dispatchClaimLookupKeys\(entry\)/);
+  assert.match(claimFunction, /dispatchClaimLookupKeys\(command\)/);
   assert.match(source, /\/runs\?per_page=100&page=\$\{page\}/);
   assert.match(source, /status:\s*"recovered"/);
   assert.doesNotMatch(source, /fallbackCodexTimeoutMs/);
@@ -1502,6 +1504,8 @@ test("command receipt gates let the oldest same-key run proceed when a newer dup
 
   for (const workflow of workflows) {
     assert.match(workflow, /\.display_title == \$title and \.id < \(\$current \| tonumber\)/);
+    assert.match(workflow, /\.status == "in_progress"/);
+    assert.match(workflow, /\.conclusion == "success"/);
     assert.doesNotMatch(workflow, /\(\.id \| tostring\) != \$current/);
   }
 });

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -1456,6 +1456,44 @@ test("router classifies fresh human-review pauses before label sweeps", () => {
   assert.match(source, /\.filter\(isReadyHumanReviewPause\)/);
 });
 
+test("comment router durably claims dispatch commands and recovers exact workflow receipts", () => {
+  const source = readFileSync("src/repair/comment-router.ts", "utf8");
+  const sweepWorkflow = readFileSync(".github/workflows/sweep.yml", "utf8");
+  const assistWorkflow = readFileSync(".github/workflows/assist.yml", "utf8");
+  const repairWorkflow = readFileSync(".github/workflows/repair-cluster-worker.yml", "utf8");
+  const executeBlock = source.slice(
+    source.indexOf('await measureAsync("execute_commands"'),
+    source.indexOf('report.ledger_changed = measure("append_ledger"'),
+  );
+  const claimIndex = executeBlock.indexOf("claimDispatchCommands(actionable)");
+  const ackIndex = executeBlock.indexOf("convergePrecreatedCommandAckComments(command)");
+  const executeIndex = executeBlock.indexOf("executeCommand(command)");
+  const claimFunction = source.slice(
+    source.indexOf("function claimDispatchCommands"),
+    source.indexOf("function assertMutationActorIsClawsweeperBot"),
+  );
+
+  assert.ok(claimIndex >= 0);
+  assert.ok(ackIndex > claimIndex);
+  assert.ok(executeIndex > claimIndex);
+  assert.match(claimFunction, /status:\s*"claimed"/);
+  assert.match(claimFunction, /commandHasAction\(command,\s*"dispatch_clawsweeper"\)/);
+  assert.match(claimFunction, /commandHasAction\(command,\s*"dispatch_repair"\)/);
+  assert.match(claimFunction, /commandHasAction\(command,\s*"dispatch_assist"\)/);
+  assert.match(source, /function claimedDispatchState/);
+  assert.match(source, /dispatchClaimDecision\(\{/);
+  assert.match(source, /\/runs\?per_page=100&page=\$\{page\}/);
+  assert.match(source, /status:\s*"recovered"/);
+  assert.doesNotMatch(source, /fallbackCodexTimeoutMs/);
+  assert.match(sweepWorkflow, /Review event item \{0\}#\{1\} \[\{2\}\]/);
+  assert.match(assistWorkflow, /Assist \{0\}#\{1\} \[\{2\}\]/);
+  assert.match(sweepWorkflow, /delivery_id: dispatchKey/);
+  assert.match(sweepWorkflow, /`router:\$\{dispatchKey\}`/);
+  assert.match(assistWorkflow, /Exact command dispatch receipt already exists/);
+  assert.match(repairWorkflow, /Exact command dispatch receipt already exists/);
+  assert.match(repairWorkflow, /dispatch_key:/);
+});
+
 test("trusted autoclose markers are live close gated before close execution", () => {
   const source = readFileSync("src/repair/comment-router.ts", "utf8");
   const autocloseClassifier = source.slice(

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -1481,6 +1481,12 @@ test("comment router durably claims dispatch commands and recovers exact workflo
   assert.match(claimFunction, /commandHasAction\(command,\s*"dispatch_repair"\)/);
   assert.match(claimFunction, /commandHasAction\(command,\s*"dispatch_assist"\)/);
   assert.match(source, /function claimedDispatchState/);
+  assert.match(source, /function refreshDispatchClaim/);
+  assert.match(source, /writeLedger\(ledgerPath\(\), ledger\)/);
+  assert.match(source, /function verifyDispatchExecutionRuns/);
+  assert.match(source, /actions\/runs\/\$\{runId\}\/jobs\?per_page=100/);
+  assert.match(source, /Plan and review cluster/);
+  assert.match(source, /dispatch_execution_verified/);
   assert.match(source, /dispatchClaimDecision\(\{/);
   assert.match(source, /dispatchClaimLookupKeys\(entry\)/);
   assert.match(claimFunction, /dispatchClaimLookupKeys\(command\)/);

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -1492,28 +1492,34 @@ test("comment router durably claims dispatch commands and recovers exact workflo
   assert.match(claimFunction, /dispatchClaimLookupKeys\(command\)/);
   assert.match(source, /\/runs\?per_page=100&page=\$\{page\}/);
   assert.match(source, /status:\s*"recovered"/);
-  assert.doesNotMatch(source, /fallbackCodexTimeoutMs/);
+  assert.match(source, /`item_numbers=\$\{dispatchKey\}`/);
+  assert.match(source, /event:\s*"workflow_dispatch"/);
+  assert.match(source, /workflow_dispatch=\$\{fallback\.stderr \|\| fallback\.stdout\}/);
   assert.match(sweepWorkflow, /Review event item \{0\}#\{1\} \[\{2\}\]/);
+  assert.match(sweepWorkflow, /startsWith\(github\.event\.inputs\.item_numbers, 'router-'\)/);
+  assert.match(
+    sweepWorkflow,
+    /ITEM_NUMBERS:.*startsWith\(github\.event\.inputs\.item_numbers, 'router-'\)/,
+  );
   assert.match(assistWorkflow, /Assist \{0\}#\{1\} \[\{2\}\]/);
   assert.match(sweepWorkflow, /delivery_id: dispatchKey/);
   assert.match(sweepWorkflow, /`router:\$\{dispatchKey\}`/);
-  assert.match(assistWorkflow, /older exact command dispatch receipt already exists/i);
-  assert.match(repairWorkflow, /older exact command dispatch receipt already exists/i);
+  assert.match(assistWorkflow, /dispatch-receipt-owner\.sh/);
+  assert.match(assistWorkflow, /assist\.yml.*assist/s);
+  assert.match(repairWorkflow, /dispatch-receipt-owner\.sh/);
+  assert.match(repairWorkflow, /repair-cluster-worker\.yml.*Plan and review cluster/s);
   assert.match(repairWorkflow, /dispatch_key:/);
 });
 
 test("command receipt gates let the oldest same-key run proceed when a newer duplicate is pending", () => {
-  const workflows = [
-    readFileSync(".github/workflows/assist.yml", "utf8"),
-    readFileSync(".github/workflows/repair-cluster-worker.yml", "utf8"),
-  ];
+  const receiptGate = readFileSync("scripts/dispatch-receipt-owner.sh", "utf8");
 
-  for (const workflow of workflows) {
-    assert.match(workflow, /\.display_title == \$title and \.id < \(\$current \| tonumber\)/);
-    assert.match(workflow, /\.status == "in_progress"/);
-    assert.match(workflow, /\.conclusion == "success"/);
-    assert.doesNotMatch(workflow, /\(\.id \| tostring\) != \$current/);
-  }
+  assert.match(receiptGate, /\.display_title == \$title and \.id < \(\$current \| tonumber\)/);
+  assert.match(receiptGate, /\.status == "in_progress"/);
+  assert.match(receiptGate, /\.conclusion == "success"/);
+  assert.match(receiptGate, /actions\/runs\/\$\{run_id\}\/jobs\?per_page=100/);
+  assert.match(receiptGate, /\.name == \$required and \.conclusion == "success"/);
+  assert.doesNotMatch(receiptGate, /\(\.id \| tostring\) != \$current/);
 });
 
 test("trusted autoclose markers are live close gated before close execution", () => {

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -1489,9 +1489,21 @@ test("comment router durably claims dispatch commands and recovers exact workflo
   assert.match(assistWorkflow, /Assist \{0\}#\{1\} \[\{2\}\]/);
   assert.match(sweepWorkflow, /delivery_id: dispatchKey/);
   assert.match(sweepWorkflow, /`router:\$\{dispatchKey\}`/);
-  assert.match(assistWorkflow, /Exact command dispatch receipt already exists/);
-  assert.match(repairWorkflow, /Exact command dispatch receipt already exists/);
+  assert.match(assistWorkflow, /older exact command dispatch receipt already exists/i);
+  assert.match(repairWorkflow, /older exact command dispatch receipt already exists/i);
   assert.match(repairWorkflow, /dispatch_key:/);
+});
+
+test("command receipt gates let the oldest same-key run proceed when a newer duplicate is pending", () => {
+  const workflows = [
+    readFileSync(".github/workflows/assist.yml", "utf8"),
+    readFileSync(".github/workflows/repair-cluster-worker.yml", "utf8"),
+  ];
+
+  for (const workflow of workflows) {
+    assert.match(workflow, /\.display_title == \$title and \.id < \(\$current \| tonumber\)/);
+    assert.doesNotMatch(workflow, /\(\.id \| tostring\) != \$current/);
+  }
 });
 
 test("trusted autoclose markers are live close gated before close execution", () => {

--- a/test/repair/comment-router-utils.test.ts
+++ b/test/repair/comment-router-utils.test.ts
@@ -6,6 +6,7 @@ import {
   appendLedger,
   dispatchClaimDecision,
   dispatchClaimLookupKeys,
+  dispatchReceiptKeyMaterial,
   isGitHubAppIntegrationAuthError,
   isAllowedMutationActor,
   normalizeGitHubActor,
@@ -33,6 +34,64 @@ test("synthetic dispatch claims retain a stable idempotency lookup across router
     first.filter((key) => replay.includes(key)),
     [`idempotency:${idempotencyKey}`],
   );
+});
+
+test("synthetic dispatch receipt material is stable within an attempt and changes next attempt", () => {
+  const command = {
+    idempotency_key: "repair-loop-label-sweep:openclaw/openclaw:automerge:74499",
+    automation_source: "repair_loop_label_sweep",
+    comment_updated_at: "2026-04-29T03:01:00Z",
+  };
+  const firstClaim = { processed_at: "2026-04-29T03:01:01Z" };
+  const replayedClaim = { processed_at: "2026-04-29T03:01:01Z" };
+  const nextClaim = { processed_at: "2026-04-29T04:15:00Z" };
+
+  assert.equal(
+    dispatchReceiptKeyMaterial(command, firstClaim),
+    dispatchReceiptKeyMaterial(command, replayedClaim),
+  );
+  assert.notEqual(
+    dispatchReceiptKeyMaterial(command, firstClaim),
+    dispatchReceiptKeyMaterial(command, nextClaim),
+  );
+});
+
+test("synthetic dispatch attempt replaces its durable claim in the ledger", () => {
+  const ledger = { updated_at: null, commands: [] };
+  const base = {
+    idempotency_key: "repair-loop-label-sweep:openclaw/openclaw:automerge:74499",
+    comment_id: "repair-loop-label-sweep:automerge:74499",
+    comment_version_key: null,
+    automation_source: "repair_loop_label_sweep",
+    repo: "openclaw/openclaw",
+    issue_number: 74499,
+    intent: "automerge",
+  };
+
+  assert.equal(
+    appendLedger(ledger, [
+      {
+        ...base,
+        comment_updated_at: "2026-04-29T03:01:00Z",
+        processed_at: "2026-04-29T03:01:01Z",
+        status: "claimed",
+      },
+    ]),
+    true,
+  );
+  assert.equal(
+    appendLedger(ledger, [
+      {
+        ...base,
+        comment_updated_at: "2026-04-29T03:06:00Z",
+        processed_at: "2026-04-29T03:01:01Z",
+        status: "executed",
+      },
+    ]),
+    true,
+  );
+  assert.equal(ledger.commands.length, 1);
+  assert.equal(ledger.commands[0]?.status, "executed");
 });
 
 test("newer re-review commands supersede older retries from the same requester", () => {

--- a/test/repair/comment-router-utils.test.ts
+++ b/test/repair/comment-router-utils.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   SUPERSEDED_RE_REVIEW_REASON,
   appendLedger,
+  dispatchClaimDecision,
   isGitHubAppIntegrationAuthError,
   isAllowedMutationActor,
   normalizeGitHubActor,
@@ -128,6 +129,181 @@ test("appendLedger records waiting commands without making them terminal", () =>
   assert.equal(ledger.commands.length, 1);
   assert.equal(ledger.commands[0].status, "waiting");
   assert.equal(shouldSuppressProcessedCommentVersion(ledger.commands[0]), false);
+});
+
+test("appendLedger records claimed dispatch commands as recoverable idempotency claims", () => {
+  const ledger = { updated_at: null, commands: [] };
+
+  assert.equal(
+    appendLedger(ledger, [
+      {
+        idempotency_key: "claim-before-dispatch",
+        comment_id: "125",
+        comment_version_key: "125:2026-04-29T03:01:00Z",
+        comment_updated_at: "2026-04-29T03:01:00Z",
+        status: "claimed",
+        intent: "clawsweeper_re_review",
+        issue_number: 74499,
+        repo: "openclaw/openclaw",
+        actions: [{ action: "dispatch_clawsweeper", status: "claimed" }],
+      },
+    ]),
+    true,
+  );
+
+  assert.equal(ledger.commands.length, 1);
+  assert.equal(ledger.commands[0].status, "claimed");
+  assert.equal(shouldSuppressProcessedCommentVersion(ledger.commands[0]), false);
+  assert.deepEqual(ledger.commands[0].actions, [
+    {
+      action: "dispatch_clawsweeper",
+      status: "claimed",
+      label: null,
+      job_path: null,
+    },
+  ]);
+});
+
+test("fresh dispatch claims wait for the Actions receipt visibility window", () => {
+  const claim = { processed_at: "2026-04-29T03:01:00Z" };
+
+  assert.deepEqual(
+    dispatchClaimDecision({
+      claim,
+      runs: [],
+      expectedTitle: "Review event item openclaw/openclaw#74499 [router-abc]",
+      nowMs: Date.parse("2026-04-29T03:04:00Z"),
+    }),
+    { action: "wait", run: null },
+  );
+});
+
+test("dispatch claims recover the exact Actions receipt created after the claim", () => {
+  const claim = { processed_at: "2026-04-29T03:01:00Z" };
+  const matchingRun = {
+    id: 991,
+    display_title: "Review event item openclaw/openclaw#74499 [router-abc]",
+    created_at: "2026-04-29T03:01:02Z",
+  };
+
+  assert.deepEqual(
+    dispatchClaimDecision({
+      claim,
+      runs: [
+        {
+          id: 990,
+          display_title: matchingRun.display_title,
+          created_at: "2026-04-29T02:59:00Z",
+        },
+        matchingRun,
+      ],
+      expectedTitle: matchingRun.display_title,
+      nowMs: Date.parse("2026-04-29T03:10:00Z"),
+    }),
+    { action: "recover", run: matchingRun },
+  );
+});
+
+test("stale dispatch claims without an exact receipt become retryable", () => {
+  assert.deepEqual(
+    dispatchClaimDecision({
+      claim: { processed_at: "2026-04-29T03:01:00Z" },
+      runs: [
+        {
+          id: 990,
+          display_title: "Review event item openclaw/openclaw#74499 [router-other]",
+          created_at: "2026-04-29T03:01:02Z",
+        },
+      ],
+      expectedTitle: "Review event item openclaw/openclaw#74499 [router-abc]",
+      nowMs: Date.parse("2026-04-29T03:10:00Z"),
+      graceMs: Number.NaN,
+    }),
+    { action: "dispatch", run: null },
+  );
+});
+
+test("dispatch claims with malformed timestamps fail closed", () => {
+  assert.deepEqual(
+    dispatchClaimDecision({
+      claim: { processed_at: "not-a-timestamp" },
+      runs: [
+        {
+          id: 991,
+          display_title: "Review event item openclaw/openclaw#74499 [router-abc]",
+          created_at: "2026-04-29T03:01:02Z",
+        },
+      ],
+      expectedTitle: "Review event item openclaw/openclaw#74499 [router-abc]",
+      nowMs: Date.parse("2026-04-29T03:10:00Z"),
+    }),
+    { action: "wait", run: null },
+  );
+});
+
+test("appendLedger preserves the original timestamp while a claim waits", () => {
+  const ledger = { updated_at: null, commands: [] };
+  const processedAt = "2026-04-29T03:01:00Z";
+
+  appendLedger(ledger, [
+    {
+      idempotency_key: "claim-before-dispatch",
+      comment_id: "125",
+      comment_version_key: "125:2026-04-29T03:01:00Z",
+      status: "claimed",
+      intent: "clawsweeper_re_review",
+      processed_at: processedAt,
+      actions: [{ action: "dispatch_clawsweeper", status: "claimed" }],
+    },
+  ]);
+
+  assert.equal(ledger.commands[0].processed_at, processedAt);
+});
+
+test("appendLedger upgrades claimed dispatch commands after execution", () => {
+  const ledger = { updated_at: null, commands: [] };
+
+  appendLedger(ledger, [
+    {
+      idempotency_key: "claim-before-dispatch",
+      comment_id: "125",
+      comment_version_key: "125:2026-04-29T03:01:00Z",
+      comment_updated_at: "2026-04-29T03:01:00Z",
+      status: "claimed",
+      intent: "clawsweeper_re_review",
+      issue_number: 74499,
+      repo: "openclaw/openclaw",
+      actions: [{ action: "dispatch_clawsweeper", status: "claimed" }],
+    },
+  ]);
+
+  assert.equal(
+    appendLedger(ledger, [
+      {
+        idempotency_key: "claim-before-dispatch",
+        comment_id: "125",
+        comment_version_key: "125:2026-04-29T03:01:00Z",
+        comment_updated_at: "2026-04-29T03:01:00Z",
+        status: "executed",
+        intent: "clawsweeper_re_review",
+        issue_number: 74499,
+        repo: "openclaw/openclaw",
+        actions: [{ action: "dispatch_clawsweeper", status: "executed" }],
+      },
+    ]),
+    true,
+  );
+
+  assert.equal(ledger.commands.length, 1);
+  assert.equal(ledger.commands[0].status, "executed");
+  assert.deepEqual(ledger.commands[0].actions, [
+    {
+      action: "dispatch_clawsweeper",
+      status: "executed",
+      label: null,
+      job_path: null,
+    },
+  ]);
 });
 
 test("appendLedger ignores no-op skipped command versions", () => {

--- a/test/repair/comment-router-utils.test.ts
+++ b/test/repair/comment-router-utils.test.ts
@@ -7,6 +7,7 @@ import {
   dispatchClaimDecision,
   dispatchClaimLookupKeys,
   dispatchReceiptKeyMaterial,
+  hasSuccessfulDispatchExecutionJob,
   isGitHubAppIntegrationAuthError,
   isAllowedMutationActor,
   normalizeGitHubActor,
@@ -344,6 +345,76 @@ test("dispatch claim recovery prefers an older success over a newer cancelled du
     }),
     { action: "recover", run: successfulRun },
   );
+});
+
+test("dispatch claims ignore receipt-only duplicate successes", () => {
+  const expectedTitle = "Assist openclaw/openclaw#74499 [router-abc]";
+  assert.deepEqual(
+    dispatchClaimDecision({
+      claim: { processed_at: "2026-04-29T03:01:00Z" },
+      runs: [
+        {
+          id: 991,
+          display_title: expectedTitle,
+          created_at: "2026-04-29T03:01:02Z",
+          status: "completed",
+          conclusion: "failure",
+        },
+        {
+          id: 992,
+          display_title: expectedTitle,
+          created_at: "2026-04-29T03:02:00Z",
+          status: "completed",
+          conclusion: "success",
+          dispatch_execution_verified: false,
+        },
+      ],
+      expectedTitle,
+      nowMs: Date.parse("2026-04-29T03:10:00Z"),
+      graceMs: 300_000,
+    }),
+    { action: "dispatch", run: null },
+  );
+});
+
+test("dispatch execution verification requires the real worker job to succeed", () => {
+  assert.equal(
+    hasSuccessfulDispatchExecutionJob(
+      [
+        { name: "Deduplicate command dispatch receipt", conclusion: "success" },
+        { name: "assist", conclusion: "skipped" },
+      ],
+      "assist",
+    ),
+    false,
+  );
+  assert.equal(
+    hasSuccessfulDispatchExecutionJob(
+      [
+        { name: "Deduplicate command dispatch receipt", conclusion: "success" },
+        { name: "assist", conclusion: "success" },
+      ],
+      "assist",
+    ),
+    true,
+  );
+});
+
+test("appendLedger refreshes a stale dispatch claim before retry", () => {
+  const ledger = { updated_at: null, commands: [] };
+  const base = {
+    idempotency_key: "claim-before-dispatch",
+    comment_id: "125",
+    comment_version_key: "125:2026-04-29T03:01:00Z",
+    status: "claimed",
+    intent: "clawsweeper_re_review",
+    actions: [{ action: "dispatch_clawsweeper", status: "claimed" }],
+  };
+  appendLedger(ledger, [{ ...base, processed_at: "2026-04-29T03:01:00Z" }]);
+  appendLedger(ledger, [{ ...base, processed_at: "2026-04-29T03:10:00Z" }]);
+
+  assert.equal(ledger.commands.length, 1);
+  assert.equal(ledger.commands[0]?.processed_at, "2026-04-29T03:10:00Z");
 });
 
 test("stale dispatch claims without an exact receipt become retryable", () => {

--- a/test/repair/comment-router-utils.test.ts
+++ b/test/repair/comment-router-utils.test.ts
@@ -5,6 +5,7 @@ import {
   SUPERSEDED_RE_REVIEW_REASON,
   appendLedger,
   dispatchClaimDecision,
+  dispatchClaimLookupKeys,
   isGitHubAppIntegrationAuthError,
   isAllowedMutationActor,
   normalizeGitHubActor,
@@ -14,6 +15,25 @@ import {
   supersededReReviewCommentVersions,
   summarizeChecks,
 } from "../../dist/repair/comment-router-utils.js";
+
+test("synthetic dispatch claims retain a stable idempotency lookup across router runs", () => {
+  const idempotencyKey = "repair-loop-label-sweep:openclaw/openclaw:automerge:74499";
+  const first = dispatchClaimLookupKeys({
+    idempotency_key: idempotencyKey,
+    comment_id: "repair-loop-label-sweep:automerge:74499",
+    comment_updated_at: "2026-04-29T03:01:00Z",
+  });
+  const replay = dispatchClaimLookupKeys({
+    idempotency_key: idempotencyKey,
+    comment_id: "repair-loop-label-sweep:automerge:74499",
+    comment_updated_at: "2026-04-29T03:06:00Z",
+  });
+
+  assert.deepEqual(
+    first.filter((key) => replay.includes(key)),
+    [`idempotency:${idempotencyKey}`],
+  );
+});
 
 test("newer re-review commands supersede older retries from the same requester", () => {
   const commands = [
@@ -184,6 +204,8 @@ test("dispatch claims recover the exact Actions receipt created after the claim"
     id: 991,
     display_title: "Review event item openclaw/openclaw#74499 [router-abc]",
     created_at: "2026-04-29T03:01:02Z",
+    status: "completed",
+    conclusion: "success",
   };
 
   assert.deepEqual(
@@ -201,6 +223,67 @@ test("dispatch claims recover the exact Actions receipt created after the claim"
       nowMs: Date.parse("2026-04-29T03:10:00Z"),
     }),
     { action: "recover", run: matchingRun },
+  );
+});
+
+test("dispatch claims wait for active receipts and retry terminal failures", () => {
+  const claim = { processed_at: "2026-04-29T03:01:00Z" };
+  const expectedTitle = "Review event item openclaw/openclaw#74499 [router-abc]";
+  const run = {
+    id: 991,
+    display_title: expectedTitle,
+    created_at: "2026-04-29T03:01:02Z",
+  };
+
+  assert.deepEqual(
+    dispatchClaimDecision({
+      claim,
+      runs: [{ ...run, status: "in_progress", conclusion: null }],
+      expectedTitle,
+      nowMs: Date.parse("2026-04-29T03:10:00Z"),
+    }),
+    { action: "wait", run: null },
+  );
+  for (const conclusion of ["cancelled", "failure", "skipped", "timed_out"]) {
+    assert.deepEqual(
+      dispatchClaimDecision({
+        claim,
+        runs: [{ ...run, status: "completed", conclusion }],
+        expectedTitle,
+        nowMs: Date.parse("2026-04-29T03:10:00Z"),
+      }),
+      { action: "dispatch", run: null },
+    );
+  }
+});
+
+test("dispatch claim recovery prefers an older success over a newer cancelled duplicate", () => {
+  const claim = { processed_at: "2026-04-29T03:01:00Z" };
+  const expectedTitle = "Review event item openclaw/openclaw#74499 [router-abc]";
+  const successfulRun = {
+    id: 991,
+    display_title: expectedTitle,
+    created_at: "2026-04-29T03:01:02Z",
+    status: "completed",
+    conclusion: "success",
+  };
+
+  assert.deepEqual(
+    dispatchClaimDecision({
+      claim,
+      runs: [
+        {
+          ...successfulRun,
+          id: 992,
+          created_at: "2026-04-29T03:02:00Z",
+          conclusion: "cancelled",
+        },
+        successfulRun,
+      ],
+      expectedTitle,
+      nowMs: Date.parse("2026-04-29T03:10:00Z"),
+    }),
+    { action: "recover", run: successfulRun },
   );
 });
 

--- a/test/repair/live-worker-capacity.test.ts
+++ b/test/repair/live-worker-capacity.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   MAX_LIVE_WORKERS,
+  activeRepairWorkflowRunForJob,
   activeRepairWorkflowRunForJobAfterDispatchRecheck,
   fetchRecentWorkflowRuns,
   listActiveWorkflowRuns,
@@ -50,6 +51,26 @@ test("repair run names match workflow dispatch titles", () => {
       "automerge repair",
     ),
     "automerge repair jobs/openclaw/inbox/automerge-openclaw-openclaw-75363.md",
+  );
+});
+
+test("repair run names include command receipt keys without hiding active jobs", () => {
+  const job = "jobs/openclaw/inbox/automerge-openclaw-openclaw-75363.md";
+  assert.equal(
+    repairRunNameForJob(job, "automerge repair ", "router-abc123"),
+    `automerge repair ${job} [router-abc123]`,
+  );
+  assert.equal(
+    activeRepairWorkflowRunForJob({
+      jobPath: job,
+      activeRunsByPrefix: new Map([
+        [
+          "automerge repair ",
+          [{ displayTitle: `automerge repair ${job} [router-abc123]`, status: "in_progress" }],
+        ],
+      ]),
+    })?.status,
+    "in_progress",
   );
 });
 

--- a/test/repair/live-worker-capacity.test.ts
+++ b/test/repair/live-worker-capacity.test.ts
@@ -36,6 +36,13 @@ test("live worker capacity accepts env default within the global Codex cap", () 
 });
 
 test("repair run names match workflow dispatch titles", () => {
+  const issueJob = "jobs/openclaw/inbox/issue-openclaw-openclaw-75364.md";
+  assert.equal(repairRunNamePrefixForJob(issueJob), "issue implementation ");
+  assert.equal(repairRunNameForJob(issueJob), `issue implementation ${issueJob}`);
+  assert.equal(
+    repairRunNameForJob(issueJob, "automerge repair ", "router-issue123"),
+    `issue implementation ${issueJob} [router-issue123]`,
+  );
   assert.equal(
     repairRunNameForJob("jobs/openclaw/inbox/automerge-openclaw-openclaw-75363.md"),
     "automerge repair jobs/openclaw/inbox/automerge-openclaw-openclaw-75363.md",

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -497,9 +497,11 @@ test("comment commands keep the router-to-sweep dispatch contract", () => {
   assert.match(routerSource, /adaptiveReviewBudgetForPullRequest\(command\.target\)/);
   assert.match(routerSource, /media_proof_timeout_ms: reviewBudget\.mediaProofTimeoutMs/);
   assert.match(routerSource, /dispatch_key:\s*dispatchKey/);
-  assert.doesNotMatch(routerSource, /fallbackCodexTimeoutMs/);
+  assert.match(routerSource, /`item_numbers=\$\{dispatchKey\}`/);
+  assert.match(routerSource, /event:\s*"workflow_dispatch"/);
   assert.match(sweepWorkflow, /types:\s*\[clawsweeper_item,\s*clawsweeper_target_sweep\]/);
   assert.match(sweepWorkflow, /Review event item \{0\}#\{1\} \[\{2\}\]/);
+  assert.match(sweepWorkflow, /startsWith\(github\.event\.inputs\.item_numbers, 'router-'\)/);
   assert.doesNotMatch(sweepWorkflow, /types:\s*\[[^\]]*clawsweeper_comment/);
 });
 

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -495,15 +495,11 @@ test("comment commands keep the router-to-sweep dispatch contract", () => {
   assert.match(routerWorkflow, /--status-comment-id "\$status_comment_id"/);
   assert.match(routerSource, /event_type:\s*"clawsweeper_item"/);
   assert.match(routerSource, /adaptiveReviewBudgetForPullRequest\(command\.target\)/);
-  assert.match(routerSource, /const MAX_MEDIA_PREPROCESSING_TIMEOUT_MS = 480_000/);
   assert.match(routerSource, /media_proof_timeout_ms: reviewBudget\.mediaProofTimeoutMs/);
-  assert.match(routerSource, /reviewBudget\.codexTimeoutMs \+ MAX_MEDIA_PREPROCESSING_TIMEOUT_MS/);
-  assert.doesNotMatch(
-    routerSource,
-    /reviewBudget\.codexTimeoutMs \+ reviewBudget\.mediaProofTimeoutMs/,
-  );
-  assert.match(routerSource, /`codex_timeout_ms=\$\{fallbackCodexTimeoutMs\}`/);
+  assert.match(routerSource, /dispatch_key:\s*dispatchKey/);
+  assert.doesNotMatch(routerSource, /fallbackCodexTimeoutMs/);
   assert.match(sweepWorkflow, /types:\s*\[clawsweeper_item,\s*clawsweeper_target_sweep\]/);
+  assert.match(sweepWorkflow, /Review event item \{0\}#\{1\} \[\{2\}\]/);
   assert.doesNotMatch(sweepWorkflow, /types:\s*\[[^\]]*clawsweeper_comment/);
 });
 


### PR DESCRIPTION
## What changed

This keeps the useful pre-dispatch claim from #380, but makes the claim recoverable instead of terminal.

- Review, assist, and repair dispatches carry deterministic receipt keys.
- Retries recover the exact Actions run created after the durable claim. Active runs wait; successful executions recover; failed, cancelled, skipped, timed-out, or missing runs retry after the visibility window.
- Exact-review dispatch keeps the existing `workflow_dispatch` fallback. The fallback carries the same receipt key and produces the same recoverable run title as `repository_dispatch`.
- Assist and repair recovery verifies that the real worker job succeeded. A successful receipt-only duplicate cannot be mistaken for completed work.
- Before a stale or terminal claim is retried, its durable timestamp is refreshed. A second crash therefore gets a fresh grace window instead of immediately dispatching another duplicate.
- Receiving workflows give the oldest active or successfully executed same-key run ownership. Later duplicates and failed older runs cannot suppress every retry.
- Active repair detection recognizes keyed run names, including issue-implementation titles.
- Synthetic label-sweep commands recover prior claims by stable idempotency key, while each legitimate new attempt gets a fresh receipt key.
- API-read failures fail closed: the router waits instead of risking duplicate execution.

The contributor branch could not be updated through the available workflow-scoped OAuth authorization, so this replacement preserves and extends @ag-linden's work with co-author credit.

## Proof

Exact head: `ca335bc305181cbfe61c60af91480f937e3e8eec`

- **Live GitHub Actions fallback smoke:** [run 28708493789](https://github.com/openclaw/clawsweeper/actions/runs/28708493789) completed successfully on the exact head. GitHub accepted the keyed `workflow_dispatch`, rendered `Review event item openclaw/clawsweeper#407 [router-live-ca335bc3]`, planned exactly PR #407, completed the review shard, published artifacts, and completed recovery handling.
- The live smoke proves the real fallback transport, keyed title, exact-item routing, worker execution, and artifact publication. Crash timing itself remains covered by the deterministic regression tests rather than an intentionally killed production worker.
- Crash/retry contract: crash before dispatch waits; crash after dispatch recovers; stale claim without a receipt retries.
- Receipt regression: failed owner → receipt-only duplicate success → later retry proceeds for both assist and repair; actual worker success remains authoritative; API failure fails closed.
- Full repository: 604 unit tests, 617 repair tests, and 1,221 aggregate coverage tests passed.
- Changed coverage: 100% lines, 89.17% branches, 100% functions.
- Overall coverage: 76.69% lines, 70.65% branches, 84.00% functions.
- Build, lint, formatting, active-surface, workflow-input, and automation-limit checks passed.
- AutoReview: clean; patch correct at 0.78 confidence on the exact final tree.

## Risk

Medium. This changes command-dispatch recovery and three receiving workflows. Recovery is deliberately conservative: claims wait five minutes before stale recovery, worker execution must be proven for assist/repair, failed receipts remain retryable, the fallback preserves the previous transport, and receiver-side ownership prevents duplicate execution without losing every copy.

Replaces #380.
