### PR TITLE
fix(apply): tolerate deleted review targets

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -17554,7 +17554,27 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
     if (decision === "close" && !isCloseProposal && !shouldProbeClosedState) {
       continue;
     }
-    const { item, state } = fetchItem(number);
+    let liveItem: ReturnType<typeof fetchItem>;
+    try {
+      liveItem = fetchItem(number);
+    } catch (error) {
+      if (!isGitHubNotFoundError(error)) throw error;
+      // Items can be deleted after review but before apply. Treat that terminal
+      // state like an already-closed item instead of failing the whole apply run.
+      markdown = replaceFrontMatterValue(markdown, "action_taken", "skipped_already_closed");
+      markdown = replaceFrontMatterValue(markdown, "apply_checked_at", new Date().toISOString());
+      archiveClosed(markdown);
+      results.push({
+        number,
+        action: "skipped_already_closed",
+        reason: "item not found on GitHub",
+      });
+      processedCount += 1;
+      maybeLogProgress(`archived #${number}: item not found on GitHub`);
+      if (processedCount >= processedLimit) break;
+      continue;
+    }
+    const { item, state } = liveItem;
     const previousLabels = [...item.labels];
     let currentContext: ItemContext | undefined;
     let currentClosingPullRequests: unknown[] | undefined;

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -17559,6 +17559,21 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       liveItem = fetchItem(number);
     } catch (error) {
       if (!isGitHubNotFoundError(error)) throw error;
+      // A repository lookup can return the same 404 when the repo is missing or
+      // inaccessible. Confirm repo access before treating this as an item miss.
+      ghJson<unknown>(["api", `repos/${targetRepo()}`]);
+      if (syncCommentsOnly) {
+        markApplyChecked();
+        results.push({
+          number,
+          action: "skipped_already_closed",
+          reason: "item not found on GitHub",
+        });
+        processedCount += 1;
+        maybeLogProgress(`skipped comment sync #${number}: item not found on GitHub`);
+        if (processedCount >= processedLimit) break;
+        continue;
+      }
       // Items can be deleted after review but before apply. Treat that terminal
       // state like an already-closed item instead of failing the whole apply run.
       markdown = replaceFrontMatterValue(markdown, "action_taken", "skipped_already_closed");

--- a/test/apply-live-state.test.ts
+++ b/test/apply-live-state.test.ts
@@ -34,6 +34,10 @@ if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
   console.error("gh: Not Found (HTTP 404)");
   process.exit(1);
 }
+if (args[0] === "api" && path === "repos/openclaw/clawsweeper") {
+  console.log(JSON.stringify({ full_name: "openclaw/clawsweeper" }));
+  process.exit(0);
+}
 console.error("unexpected gh args", JSON.stringify(args));
 process.exit(1);
 `;
@@ -51,6 +55,94 @@ process.exit(1);
         reason: "item not found on GitHub",
       },
     ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions keeps missing records queued during comment-only sync", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    writeFileSync(join(itemsDir, "321.md"), implementedCloseReport(), "utf8");
+
+    const ghMock = `
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+const path = args[1] || "";
+if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
+  console.error("gh: Not Found (HTTP 404)");
+  process.exit(1);
+}
+if (args[0] === "api" && path === "repos/openclaw/clawsweeper") {
+  console.log(JSON.stringify({ full_name: "openclaw/clawsweeper" }));
+  process.exit(0);
+}
+console.error("unexpected gh args", JSON.stringify(args));
+process.exit(1);
+`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: ["--sync-comments-only"],
+      });
+    });
+
+    assert.ok(existsSync(join(itemsDir, "321.md")));
+    assert.equal(existsSync(join(closedDir, "321.md")), false);
+    assert.match(readText(join(itemsDir, "321.md")), /^action_taken: proposed_close$/m);
+    assert.deepEqual(JSON.parse(readText(reportPath)), [
+      {
+        number: 321,
+        action: "skipped_already_closed",
+        reason: "item not found on GitHub",
+      },
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions fails safely when a missing repository also returns 404", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    writeFileSync(join(itemsDir, "321.md"), implementedCloseReport(), "utf8");
+
+    const ghMock = `
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+const path = args[1] || "";
+if (args[0] === "api" && (/\\/issues\\/321$/.test(path) || path === "repos/openclaw/clawsweeper")) {
+  console.error("gh: Not Found (HTTP 404)");
+  process.exit(1);
+}
+console.error("unexpected gh args", JSON.stringify(args));
+process.exit(1);
+`;
+    assert.throws(
+      () =>
+        withMockGh(root, ghMock, () => {
+          runApplyDecisionsForTest({ itemsDir, closedDir, plansDir, reportPath });
+        }),
+      /Not Found/,
+    );
+
+    assert.ok(existsSync(join(itemsDir, "321.md")));
+    assert.equal(existsSync(join(closedDir, "321.md")), false);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/apply-live-state.test.ts
+++ b/test/apply-live-state.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  implementedCloseReport,
+  readText,
+  runApplyDecisionsForTest,
+  tmpPrefix,
+  withMockGh,
+} from "./helpers.ts";
+
+test("apply-decisions archives records deleted after review instead of failing the run", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    writeFileSync(
+      join(itemsDir, "321.md"),
+      implementedCloseReport({ action_taken: "proposed_close" }),
+      "utf8",
+    );
+
+    const ghMock = `
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+const path = args[1] || "";
+if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
+  console.error("gh: Not Found (HTTP 404)");
+  process.exit(1);
+}
+console.error("unexpected gh args", JSON.stringify(args));
+process.exit(1);
+`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({ itemsDir, closedDir, plansDir, reportPath });
+    });
+
+    assert.equal(existsSync(join(itemsDir, "321.md")), false);
+    assert.ok(existsSync(join(closedDir, "321.md")));
+    assert.match(readText(join(closedDir, "321.md")), /^action_taken: skipped_already_closed$/m);
+    assert.deepEqual(JSON.parse(readText(reportPath)), [
+      {
+        number: 321,
+        action: "skipped_already_closed",
+        reason: "item not found on GitHub",
+      },
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -119,54 +119,6 @@ if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
   }
 });
 
-test("apply-decisions archives records deleted after review instead of failing the run", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
-    writeFileSync(
-      join(itemsDir, "321.md"),
-      implementedCloseReport({ action_taken: "proposed_close" }),
-      "utf8",
-    );
-
-    const ghMock = `
-const rawArgs = process.argv.slice(2);
-const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
-const path = args[1] || "";
-if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
-  console.error("gh: Not Found (HTTP 404)");
-  process.exit(1);
-}
-console.error("unexpected gh args", JSON.stringify(args));
-process.exit(1);
-`;
-    withMockGh(root, ghMock, () => {
-      runApplyDecisionsForTest({ itemsDir, closedDir, plansDir, reportPath });
-    });
-
-    assert.equal(existsSync(join(itemsDir, "321.md")), false);
-    assert.ok(existsSync(join(closedDir, "321.md")));
-    assert.match(
-      readFileSync(join(closedDir, "321.md"), "utf8"),
-      /^action_taken: skipped_already_closed$/m,
-    );
-    assert.deepEqual(JSON.parse(readFileSync(reportPath, "utf8")), [
-      {
-        number: 321,
-        action: "skipped_already_closed",
-        reason: "item not found on GitHub",
-      },
-    ]);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
-});
-
 test("apply-decisions skips advisory labels for failed or stale kept-open reports", () => {
   const root = mkdtempSync(tmpPrefix);
   try {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -119,6 +119,54 @@ if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
   }
 });
 
+test("apply-decisions archives records deleted after review instead of failing the run", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    writeFileSync(
+      join(itemsDir, "321.md"),
+      implementedCloseReport({ action_taken: "proposed_close" }),
+      "utf8",
+    );
+
+    const ghMock = `
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+const path = args[1] || "";
+if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
+  console.error("gh: Not Found (HTTP 404)");
+  process.exit(1);
+}
+console.error("unexpected gh args", JSON.stringify(args));
+process.exit(1);
+`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({ itemsDir, closedDir, plansDir, reportPath });
+    });
+
+    assert.equal(existsSync(join(itemsDir, "321.md")), false);
+    assert.ok(existsSync(join(closedDir, "321.md")));
+    assert.match(
+      readFileSync(join(closedDir, "321.md"), "utf8"),
+      /^action_taken: skipped_already_closed$/m,
+    );
+    assert.deepEqual(JSON.parse(readFileSync(reportPath, "utf8")), [
+      {
+        number: 321,
+        action: "skipped_already_closed",
+        reason: "item not found on GitHub",
+      },
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("apply-decisions skips advisory labels for failed or stale kept-open reports", () => {
   const root = mkdtempSync(tmpPrefix);
   try {


### PR DESCRIPTION
## Why

Live monitoring found [run 28709649723](https://github.com/openclaw/clawsweeper/actions/runs/28709649723) failing after a successful review because target item `openclaw/openclaw#99991` was deleted before `apply-decisions` fetched its live state. GitHub correctly returned 404, but apply treated that terminal race as a workflow failure.

## What changed

- Treat a confirmed item-level 404 as the same terminal state as an already-closed item.
- Verify repository access before archiving, so a missing/inaccessible repo still fails safely.
- Preserve comment-only semantics: record the missing item without moving its report out of the active queue.
- Keep every non-404 fetch failure fatal.
- Add focused regressions for item deletion, comment-only mode, and repository-level 404.

## Proof

Exact head: `a297b52e8e619b2ba165e066b02450650ca93050`

- Focused `test/apply-live-state.test.ts`: 3/3 passed.
- Full `pnpm run check`: 617 unit and 617 repair tests passed.
- Overall coverage: 76.87% lines, 70.80% branches, 84.13% functions.
- Formatting clean.
- AutoReview first found two edge cases; both repaired. Final AutoReview: no actionable findings, confidence 0.82.
- Live smoke against deleted `openclaw/openclaw#99991`: exit 0, source report removed, durable record archived, apply report emitted `skipped_already_closed` with reason `item not found on GitHub`.
- The smoke made no GitHub write; the only follow-up call confirmed repository access.

No changelog entry: this is internal apply-run reliability with no user-facing contract change.