### PR TITLE
perf(review): reuse prior verdict when reviewable content is unchanged

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1345,6 +1345,7 @@ jobs:
           GH_TOKEN: ${{ steps.target-read-token.outputs.token || github.token }}
           CLAWSWEEPER_PROOF_INSPECTION_TOKEN: ${{ steps.codex-inspection-token.outputs.token || github.token }}
           ADDITIONAL_PROMPT: ${{ github.event.inputs.additional_prompt || github.event.client_payload.additional_prompt || '' }}
+          EXACT_ITEM: ${{ github.event.client_payload.item_number || github.event.inputs.item_number || github.event.inputs.item_numbers || '' }}
         run: |
           hot_intake_arg=()
           if [ "${{ needs.plan.outputs.hot_intake }}" = "true" ]; then
@@ -1353,6 +1354,10 @@ jobs:
           additional_prompt_arg=()
           if [ -n "$ADDITIONAL_PROMPT" ]; then
             additional_prompt_arg=(--additional-prompt "$ADDITIONAL_PROMPT")
+          fi
+          planned_automatic_review_arg=()
+          if [ -z "$EXACT_ITEM" ]; then
+            planned_automatic_review_arg=(--planned-automatic-review)
           fi
           codex_timeout_seconds=$(((${{ needs.plan.outputs.codex_timeout_ms }} + 999) / 1000))
           review_timeout_seconds=$(((codex_timeout_seconds + 180) * ${{ needs.plan.outputs.batch_size }}))
@@ -1374,7 +1379,7 @@ jobs:
             --codex-sandbox danger-full-access \
             --codex-timeout-ms ${{ needs.plan.outputs.codex_timeout_ms }} \
             --item-numbers "${{ matrix.item_numbers }}" \
-            --planned-automatic-review \
+            "${planned_automatic_review_arg[@]}" \
             "${hot_intake_arg[@]}" \
             --readonly-openclaw \
             --shard-index ${{ matrix.shard }} \

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1374,6 +1374,7 @@ jobs:
             --codex-sandbox danger-full-access \
             --codex-timeout-ms ${{ needs.plan.outputs.codex_timeout_ms }} \
             --item-numbers "${{ matrix.item_numbers }}" \
+            --planned-automatic-review \
             "${hot_intake_arg[@]}" \
             --readonly-openclaw \
             --shard-index ${{ matrix.shard }} \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Reused unchanged scheduled keep-open reviews for up to 14 days while forcing fresh reviews after content, policy, target-head, or human-activity changes and before any close promotion. Thanks @yetval.
 - Expanded untargeted close-apply scans from 300 toward a capped 900 records after skip-heavy zero-close windows without changing close or worker limits. Thanks @brokemac79.
 - Made ClawHub diversion comments a practical self-serve handoff with package-shape, manifest, configuration, documentation, usage, and smoke-proof guidance. Thanks @brokemac79.
 - Reduced duplicate GitHub API reads in each live-dashboard status snapshot and batched recent automerge hydration into one GraphQL request with a REST fallback. Thanks @brokemac79.

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -339,7 +339,6 @@ interface ExistingReview {
   decision: string | undefined;
   reviewStatus: string | undefined;
   reviewPolicy: string | undefined;
-  mainSha: string | undefined;
   contentDigest: string | undefined;
   lastFullReviewAt: string | undefined;
 }
@@ -5362,7 +5361,6 @@ function existingReview(
     decision: frontMatterValue(markdown, "decision"),
     reviewStatus: effectiveReviewStatus(markdown),
     reviewPolicy: frontMatterValue(markdown, "review_policy"),
-    mainSha: frontMatterValue(markdown, "main_sha"),
     contentDigest: frontMatterValue(markdown, "review_content_digest"),
     lastFullReviewAt: frontMatterValue(markdown, "last_full_review_at"),
   };
@@ -5393,7 +5391,6 @@ function buildExistingReviewIndex(itemsDir: string): ExistingReviewIndex {
       decision: frontMatterValue(markdown, "decision"),
       reviewStatus: effectiveReviewStatus(markdown),
       reviewPolicy: frontMatterValue(markdown, "review_policy"),
-      mainSha: frontMatterValue(markdown, "main_sha"),
       contentDigest: frontMatterValue(markdown, "review_content_digest"),
       lastFullReviewAt: frontMatterValue(markdown, "last_full_review_at"),
     });
@@ -16790,7 +16787,6 @@ function reviewCommand(args: Args): void {
           review: priorReview,
           reviewPolicy,
           contentDigest,
-          currentMainSha: git.mainSha,
           now: Date.now(),
           explicitDispatch,
           maintainerRequest,

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -2372,6 +2372,7 @@ function itemContentDigest(item: Item, context: ItemContext, git?: GitInfo): str
       latestRelease: git?.latestRelease
         ? { tagName: git.latestRelease.tagName ?? null, sha: git.latestRelease.sha ?? null }
         : null,
+      targetMainSha: isPull ? null : (git?.mainSha ?? null),
       headSha: isPull ? pullHeadShaFromContext(context) : null,
       baseSha: isPull ? baseSha : null,
       pullState: isPull

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -339,6 +339,7 @@ interface ExistingReview {
   decision: string | undefined;
   reviewStatus: string | undefined;
   reviewPolicy: string | undefined;
+  mainSha: string | undefined;
   contentDigest: string | undefined;
   lastFullReviewAt: string | undefined;
 }
@@ -5361,6 +5362,7 @@ function existingReview(
     decision: frontMatterValue(markdown, "decision"),
     reviewStatus: effectiveReviewStatus(markdown),
     reviewPolicy: frontMatterValue(markdown, "review_policy"),
+    mainSha: frontMatterValue(markdown, "main_sha"),
     contentDigest: frontMatterValue(markdown, "review_content_digest"),
     lastFullReviewAt: frontMatterValue(markdown, "last_full_review_at"),
   };
@@ -5391,6 +5393,7 @@ function buildExistingReviewIndex(itemsDir: string): ExistingReviewIndex {
       decision: frontMatterValue(markdown, "decision"),
       reviewStatus: effectiveReviewStatus(markdown),
       reviewPolicy: frontMatterValue(markdown, "review_policy"),
+      mainSha: frontMatterValue(markdown, "main_sha"),
       contentDigest: frontMatterValue(markdown, "review_content_digest"),
       lastFullReviewAt: frontMatterValue(markdown, "last_full_review_at"),
     });
@@ -16787,6 +16790,7 @@ function reviewCommand(args: Args): void {
           review: priorReview,
           reviewPolicy,
           contentDigest,
+          currentMainSha: git.mainSha,
           now: Date.now(),
           explicitDispatch,
           maintainerRequest,

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -56,6 +56,7 @@ import {
   compareHotIntakeDueCandidates,
   hasReviewPolicyMismatch,
   nextReviewDueAtMs,
+  reviewContentCacheHit,
   reviewedAtMs,
   reviewPriority,
   schedulerBucket,
@@ -338,6 +339,8 @@ interface ExistingReview {
   decision: string | undefined;
   reviewStatus: string | undefined;
   reviewPolicy: string | undefined;
+  contentDigest: string | undefined;
+  lastFullReviewAt: string | undefined;
 }
 
 interface LatestRelease {
@@ -2297,6 +2300,42 @@ function isClawSweeperAdvisorySourceRevisionLabel(label: string): boolean {
 
 export function itemSourceRevisionSha256ForTest(issue: unknown, comments: unknown[] = []): string {
   return itemSourceRevisionSha256(issue, comments);
+}
+
+function reviewCommentDigestParts(entries: unknown): unknown {
+  if (!Array.isArray(entries)) return null;
+  return entries
+    .map(asRecord)
+    .filter(
+      (entry) =>
+        typeof entry.author !== "string" ||
+        !CLAWSWEEPER_BOT_AUTHORS.has(entry.author.toLowerCase()),
+    )
+    .map((entry) => ({
+      author: entry.author ?? null,
+      authorAssociation: entry.authorAssociation ?? null,
+      body: entry.body ?? null,
+    }));
+}
+
+function itemContentDigest(item: Item, context: ItemContext): string {
+  const isPull = item.kind === "pull_request";
+  const base = asRecord(asRecord(context.pullRequest).base);
+  const baseSha = typeof base.sha === "string" ? base.sha : null;
+  return sha256(
+    stableJson({
+      kind: item.kind,
+      source: context.sourceRevision ?? null,
+      headSha: isPull ? pullHeadShaFromContext(context) : null,
+      baseSha: isPull ? baseSha : null,
+      diff: isPull ? (context.pullFiles ?? null) : null,
+      reviewComments: isPull ? reviewCommentDigestParts(context.pullReviewComments) : null,
+    }),
+  );
+}
+
+export function itemContentDigestForTest(item: Item, context: ItemContext): string {
+  return itemContentDigest(item, context);
 }
 
 function reviewPolicyHash(options: {
@@ -5322,6 +5361,8 @@ function existingReview(
     decision: frontMatterValue(markdown, "decision"),
     reviewStatus: effectiveReviewStatus(markdown),
     reviewPolicy: frontMatterValue(markdown, "review_policy"),
+    contentDigest: frontMatterValue(markdown, "review_content_digest"),
+    lastFullReviewAt: frontMatterValue(markdown, "last_full_review_at"),
   };
 }
 
@@ -5350,6 +5391,8 @@ function buildExistingReviewIndex(itemsDir: string): ExistingReviewIndex {
       decision: frontMatterValue(markdown, "decision"),
       reviewStatus: effectiveReviewStatus(markdown),
       reviewPolicy: frontMatterValue(markdown, "review_policy"),
+      contentDigest: frontMatterValue(markdown, "review_content_digest"),
+      lastFullReviewAt: frontMatterValue(markdown, "last_full_review_at"),
     });
   }
   return { byKey };
@@ -16252,10 +16295,12 @@ function markdownFor(options: {
   action: Action;
   reviewMode: "propose" | "apply";
   snapshotHash: string;
+  contentDigest: string;
   reviewPolicy: string;
   runtime: ReviewRuntime;
 }): string {
   const labels = options.item.labels.length ? options.item.labels.join(", ") : "none";
+  const reviewedAt = new Date().toISOString();
   const fixedPullRequest = options.decision.fixedPullRequest;
   const evidence = options.decision.evidence.length
     ? options.decision.evidence
@@ -16322,7 +16367,7 @@ item_updated_at: ${options.item.updatedAt}
 author: ${options.item.author}
 author_association: ${options.item.authorAssociation}
 labels: ${JSON.stringify(options.item.labels)}
-reviewed_at: ${new Date().toISOString()}
+reviewed_at: ${reviewedAt}
 main_sha: ${options.git.mainSha}
 pull_head_sha: ${pullHeadShaFromContext(options.context) ?? "unknown"}
 latest_release: ${options.git.latestRelease?.tagName ?? "unknown"}
@@ -16354,6 +16399,8 @@ review_status: ${options.decision.summary.startsWith("Codex review failed") ? "f
 review_terminal_failure: ${options.decision.codexTerminalFailure === true}
 local_checkout_access: verified
 item_snapshot_hash: ${options.snapshotHash}
+review_content_digest: ${options.contentDigest}
+last_full_review_at: ${reviewedAt}
 item_source_revision: ${options.context.sourceRevision ?? "unknown"}
 close_comment_sha256: ${options.action.closeComment ? sha256(options.action.closeComment) : "none"}
 review_comment_sha256: none
@@ -16681,6 +16728,8 @@ function reviewCommand(args: Args): void {
     ? gitInfo(openclawDir, { targetBranch: checkout.gitTargetBranch })
     : gitInfo(openclawDir);
   const reviewPolicy = reviewPolicyHash({ model, reasoningEffort, sandboxMode, serviceTier });
+  const explicitDispatch = itemNumber !== undefined || itemNumbers !== undefined;
+  const maintainerRequest = additionalPrompt.trim().length > 0;
   const readonlyModeSnapshots = readonlyOpenclaw ? makeTreeReadOnly(openclawDir) : [];
   try {
     const selectionOptions: Parameters<typeof selectCandidates>[0] = {
@@ -16716,6 +16765,7 @@ function reviewCommand(args: Args): void {
     );
     let completed = 0;
     let codexFailures = 0;
+    let cacheHits = 0;
     const codexFailureReports: string[] = [];
     for (const item of candidates) {
       if (humanLocalReview) {
@@ -16729,6 +16779,42 @@ function reviewCommand(args: Args): void {
       const contextStartedAt = Date.now();
       const context = collectItemContext(item);
       const contextElapsedMs = Date.now() - contextStartedAt;
+      const contentDigest = itemContentDigest(item, context);
+      const priorReview =
+        explicitDispatch || maintainerRequest ? null : existingReview(item, itemsDir);
+      if (
+        reviewContentCacheHit({
+          review: priorReview,
+          reviewPolicy,
+          contentDigest,
+          now: Date.now(),
+          explicitDispatch,
+          maintainerRequest,
+        })
+      ) {
+        const reportPath = join(artifactDir, reportFileName(item.repo, item.number));
+        let carried = priorReview!.markdown;
+        carried = replaceFrontMatterValue(carried, "reviewed_at", new Date().toISOString());
+        carried = replaceFrontMatterValue(carried, "item_updated_at", item.updatedAt);
+        carried = replaceFrontMatterValue(
+          carried,
+          "item_snapshot_hash",
+          itemSnapshotHash(item, context),
+        );
+        writeFileSync(reportPath, carried, "utf8");
+        completed += 1;
+        cacheHits += 1;
+        if (humanLocalReview) {
+          console.error("");
+          console.error("Review cache hit; content unchanged since the last review");
+          console.error(`  report: ${displayPath(reportPath)}`);
+        } else {
+          console.error(
+            `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} cache-hit content-unchanged skip-model #${item.number} (${completed}/${candidates.length})`,
+          );
+        }
+        continue;
+      }
       const codexWorkDir = join(artifactDir, "codex");
       const proofScratchDir = join(codexWorkDir, "proof-scratch", String(item.number));
       const preparedMediaProof = prepareMediaProofArtifacts(context, proofScratchDir);
@@ -16841,6 +16927,7 @@ function reviewCommand(args: Args): void {
           action,
           reviewMode: "propose",
           snapshotHash,
+          contentDigest,
           reviewPolicy,
           runtime,
         }),
@@ -16864,7 +16951,7 @@ function reviewCommand(args: Args): void {
     }
     if (!humanLocalReview) {
       console.error(
-        `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} complete reviewed=${completed}`,
+        `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} complete reviewed=${completed} cache_hits=${cacheHits}`,
       );
     }
     if (codexFailures > 0) {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -560,6 +560,7 @@ interface ItemContext {
   comments: unknown[];
   timeline: unknown[];
   sourceRevision?: string;
+  timelineRevision?: string;
   previousClawSweeperReview?: unknown;
   closingPullRequests?: unknown[];
   referencingMergedPullRequests?: unknown[];
@@ -568,6 +569,7 @@ interface ItemContext {
   pullFiles?: unknown[];
   pullCommits?: unknown[];
   pullReviewComments?: unknown[];
+  pullReviewCommentsRevision?: string;
   counts?: {
     comments: number;
     commentsHydrated?: number;
@@ -2312,11 +2314,24 @@ function reviewCommentDigestParts(entries: unknown): unknown {
         typeof entry.author !== "string" ||
         !CLAWSWEEPER_BOT_AUTHORS.has(entry.author.toLowerCase()),
     )
-    .map((entry) => ({
-      author: entry.author ?? null,
-      authorAssociation: entry.authorAssociation ?? null,
-      body: entry.body ?? null,
-    }));
+    .map((entry) => {
+      const omitted = githubCount(entry.omitted);
+      if (omitted !== null) return { omitted };
+      return {
+        id: entry.id ?? null,
+        author: entry.author ?? null,
+        authorAssociation: entry.authorAssociation ?? null,
+        body: entry.body ?? null,
+      };
+    });
+}
+
+function reviewCommentContentRevision(entries: readonly unknown[]): string {
+  return sha256(stableJson(reviewCommentDigestParts(entries)));
+}
+
+export function reviewCommentContentRevisionForTest(entries: readonly unknown[]): string {
+  return reviewCommentContentRevision(entries);
 }
 
 function reviewTimelineDigestParts(entries: unknown): unknown {
@@ -2349,7 +2364,7 @@ function itemContentDigest(item: Item, context: ItemContext, git?: GitInfo): str
     stableJson({
       kind: item.kind,
       source: context.sourceRevision ?? null,
-      timeline: reviewTimelineDigestParts(context.timeline),
+      timeline: context.timelineRevision ?? reviewTimelineDigestParts(context.timeline),
       relations: {
         closingPullRequests: context.closingPullRequests ?? null,
         referencingMergedPullRequests: context.referencingMergedPullRequests ?? null,
@@ -2372,7 +2387,10 @@ function itemContentDigest(item: Item, context: ItemContext, git?: GitInfo): str
         : null,
       diff: isPull ? (context.pullFiles ?? null) : null,
       commits: isPull ? (context.pullCommits ?? null) : null,
-      reviewComments: isPull ? reviewCommentDigestParts(context.pullReviewComments) : null,
+      reviewComments: isPull
+        ? (context.pullReviewCommentsRevision ??
+          reviewCommentDigestParts(context.pullReviewComments))
+        : null,
     }),
   );
 }
@@ -6392,7 +6410,7 @@ function planCandidates(options: {
 
 function collectItemContext(
   item: Item,
-  options: { fullTimelineForRelations?: boolean } = {},
+  options: { fullTimelineForRelations?: boolean; reviewCacheDigest?: boolean } = {},
 ): ItemContext {
   const issue = ghJson<unknown>(["api", `repos/${targetRepo()}/issues/${item.number}`]);
   const issueRecord = asRecord(issue);
@@ -6412,6 +6430,10 @@ function collectItemContext(
     80,
   );
   const timeline = timelineWindow.items;
+  const fullTimeline =
+    timelineWindow.truncated && (options.fullTimelineForRelations || options.reviewCacheDigest)
+      ? ghPaged<unknown>(`repos/${targetRepo()}/issues/${item.number}/timeline`)
+      : null;
   const context: ItemContext = {
     issue: compactIssue(issue),
     sourceRevision: itemSourceRevisionSha256(issue, sourceRevisionComments),
@@ -6433,10 +6455,16 @@ function collectItemContext(
       timelineTruncated: timelineWindow.truncated,
     },
   };
+  if (options.reviewCacheDigest) {
+    context.timelineRevision = sha256(
+      stableJson(reviewTimelineDigestParts((fullTimeline ?? timeline).map(compactTimelineEvent))),
+    );
+  }
   if (previousClawSweeperReview) context.previousClawSweeperReview = previousClawSweeperReview;
   let pullRequest: unknown = null;
   let pullReviewComments: unknown[] | null = null;
   let filteredPullReviewComments: { included: unknown[]; filtered: number } | null = null;
+  let digestPullReviewComments: { included: unknown[]; filtered: number } | null = null;
   if (item.kind === "issue") {
     const closingPullRequests = closingPullRequestsForIssue(item.number);
     if (closingPullRequests.length > 0) {
@@ -6486,6 +6514,14 @@ function collectItemContext(
     );
     pullReviewComments = pullReviewCommentsWindow.items;
     filteredPullReviewComments = filterReviewContextComments(pullReviewComments, item.number);
+    const fullPullReviewComments =
+      options.reviewCacheDigest && pullReviewCommentsWindow.truncated
+        ? ghPaged<unknown>(`repos/${targetRepo()}/pulls/${item.number}/comments`)
+        : pullReviewComments;
+    digestPullReviewComments =
+      fullPullReviewComments === pullReviewComments
+        ? filteredPullReviewComments
+        : filterReviewContextComments(fullPullReviewComments, item.number);
     context.pullRequest = compactPullRequest(pullRequest);
     context.pullFiles = compactMappedWindow(pullFiles, pullFilesWindow.total, 80, compactPullFile);
     context.pullCommits = compactMappedWindow(
@@ -6500,6 +6536,11 @@ function collectItemContext(
       40,
       compactComment,
     );
+    if (options.reviewCacheDigest) {
+      context.pullReviewCommentsRevision = reviewCommentContentRevision(
+        digestPullReviewComments.included.map(compactComment),
+      );
+    }
     context.counts = {
       ...context.counts,
       comments: commentsWindow.total,
@@ -6523,10 +6564,7 @@ function collectItemContext(
       pullReviewCommentsFiltered: filteredPullReviewComments.filtered,
     };
   }
-  const relationTimeline =
-    options.fullTimelineForRelations && timelineWindow.truncated
-      ? ghPaged<unknown>(`repos/${targetRepo()}/issues/${item.number}/timeline`)
-      : timeline;
+  const relationTimeline = fullTimeline ?? timeline;
   const relatedOptions: Parameters<typeof relatedItemsContext>[0] = {
     item,
     issue,
@@ -6534,8 +6572,8 @@ function collectItemContext(
     timeline: relationTimeline,
   };
   if (pullRequest) relatedOptions.pullRequest = pullRequest;
-  if (filteredPullReviewComments)
-    relatedOptions.pullReviewComments = filteredPullReviewComments.included;
+  if (digestPullReviewComments)
+    relatedOptions.pullReviewComments = digestPullReviewComments.included;
   const relatedItems = relatedItemsContext(relatedOptions);
   if (relatedItems.length) {
     context.relatedItems = relatedItems;
@@ -16826,7 +16864,10 @@ function reviewCommand(args: Args): void {
         );
       }
       const contextStartedAt = Date.now();
-      const context = collectItemContext(item);
+      const context = collectItemContext(item, {
+        fullTimelineForRelations: true,
+        reviewCacheDigest: true,
+      });
       const contextElapsedMs = Date.now() - contextStartedAt;
       const contentDigest = itemContentDigest(item, context, git);
       const priorReview =

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -341,6 +341,7 @@ interface ExistingReview {
   reviewPolicy: string | undefined;
   contentDigest: string | undefined;
   lastFullReviewAt: string | undefined;
+  mainSha: string | undefined;
 }
 
 interface LatestRelease {
@@ -2318,24 +2319,44 @@ function reviewCommentDigestParts(entries: unknown): unknown {
     }));
 }
 
-function itemContentDigest(item: Item, context: ItemContext): string {
+function itemContentDigest(item: Item, context: ItemContext, git?: GitInfo): string {
   const isPull = item.kind === "pull_request";
-  const base = asRecord(asRecord(context.pullRequest).base);
+  const pull = asRecord(context.pullRequest);
+  const base = asRecord(pull.base);
   const baseSha = typeof base.sha === "string" ? base.sha : null;
   return sha256(
     stableJson({
       kind: item.kind,
       source: context.sourceRevision ?? null,
+      relations: {
+        closingPullRequests: context.closingPullRequests ?? null,
+        referencingMergedPullRequests: context.referencingMergedPullRequests ?? null,
+        relatedItems: context.relatedItems ?? null,
+      },
+      latestRelease: git?.latestRelease
+        ? { tagName: git.latestRelease.tagName ?? null, sha: git.latestRelease.sha ?? null }
+        : null,
       headSha: isPull ? pullHeadShaFromContext(context) : null,
       baseSha: isPull ? baseSha : null,
+      pullState: isPull
+        ? {
+            draft: pull.draft ?? null,
+            mergeable: pull.mergeable ?? null,
+            mergeableState: pull.mergeableState ?? null,
+            additions: pull.additions ?? null,
+            deletions: pull.deletions ?? null,
+            changedFiles: pull.changedFiles ?? null,
+          }
+        : null,
       diff: isPull ? (context.pullFiles ?? null) : null,
+      commits: isPull ? (context.pullCommits ?? null) : null,
       reviewComments: isPull ? reviewCommentDigestParts(context.pullReviewComments) : null,
     }),
   );
 }
 
-export function itemContentDigestForTest(item: Item, context: ItemContext): string {
-  return itemContentDigest(item, context);
+export function itemContentDigestForTest(item: Item, context: ItemContext, git?: GitInfo): string {
+  return itemContentDigest(item, context, git);
 }
 
 function reviewPolicyHash(options: {
@@ -5363,6 +5384,7 @@ function existingReview(
     reviewPolicy: frontMatterValue(markdown, "review_policy"),
     contentDigest: frontMatterValue(markdown, "review_content_digest"),
     lastFullReviewAt: frontMatterValue(markdown, "last_full_review_at"),
+    mainSha: frontMatterValue(markdown, "main_sha"),
   };
 }
 
@@ -5393,6 +5415,7 @@ function buildExistingReviewIndex(itemsDir: string): ExistingReviewIndex {
       reviewPolicy: frontMatterValue(markdown, "review_policy"),
       contentDigest: frontMatterValue(markdown, "review_content_digest"),
       lastFullReviewAt: frontMatterValue(markdown, "last_full_review_at"),
+      mainSha: frontMatterValue(markdown, "main_sha"),
     });
   }
   return { byKey };
@@ -16728,7 +16751,11 @@ function reviewCommand(args: Args): void {
     ? gitInfo(openclawDir, { targetBranch: checkout.gitTargetBranch })
     : gitInfo(openclawDir);
   const reviewPolicy = reviewPolicyHash({ model, reasoningEffort, sandboxMode, serviceTier });
-  const explicitDispatch = itemNumber !== undefined || itemNumbers !== undefined;
+  // Planned background shards receive exact item numbers from the planner, but they are not
+  // user-requested exact reviews. Only the workflow may opt those batches into cache reuse.
+  const plannedAutomaticReview = boolArg(args.planned_automatic_review);
+  const explicitDispatch =
+    !plannedAutomaticReview && (itemNumber !== undefined || itemNumbers !== undefined);
   const maintainerRequest = additionalPrompt.trim().length > 0;
   const readonlyModeSnapshots = readonlyOpenclaw ? makeTreeReadOnly(openclawDir) : [];
   try {
@@ -16779,7 +16806,7 @@ function reviewCommand(args: Args): void {
       const contextStartedAt = Date.now();
       const context = collectItemContext(item);
       const contextElapsedMs = Date.now() - contextStartedAt;
-      const contentDigest = itemContentDigest(item, context);
+      const contentDigest = itemContentDigest(item, context, git);
       const priorReview =
         explicitDispatch || maintainerRequest ? null : existingReview(item, itemsDir);
       if (
@@ -16787,6 +16814,7 @@ function reviewCommand(args: Args): void {
           review: priorReview,
           reviewPolicy,
           contentDigest,
+          currentMainSha: git.mainSha,
           now: Date.now(),
           explicitDispatch,
           maintainerRequest,

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -6569,8 +6569,9 @@ function collectItemContext(
     timeline: relationTimeline,
   };
   if (pullRequest) relatedOptions.pullRequest = pullRequest;
-  if (digestPullReviewComments)
-    relatedOptions.pullReviewComments = digestPullReviewComments.included;
+  const relatedPullReviewComments = digestPullReviewComments ?? filteredPullReviewComments;
+  if (relatedPullReviewComments)
+    relatedOptions.pullReviewComments = relatedPullReviewComments.included;
   const relatedItems = relatedItemsContext(relatedOptions);
   if (relatedItems.length) {
     context.relatedItems = relatedItems;

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -349,6 +349,7 @@ interface ExistingReview {
   reviewPolicy: string | undefined;
   contentDigest: string | undefined;
   lastFullReviewAt: string | undefined;
+  lastFullReviewDecision: string | undefined;
 }
 
 interface LatestRelease {
@@ -5408,6 +5409,14 @@ function frontMatterBoolean(markdown: string, key: string): boolean {
   return /^true$/i.test(frontMatterValue(markdown, key) ?? "");
 }
 
+function reviewReportCanPromoteToClose(markdown: string): boolean {
+  return !frontMatterBoolean(markdown, "review_cache_hit");
+}
+
+export function reviewReportCanPromoteToCloseForTest(markdown: string): boolean {
+  return reviewReportCanPromoteToClose(markdown);
+}
+
 function existingReview(
   item: Pick<Item, "number" | "repo">,
   itemsDir: string,
@@ -5432,6 +5441,7 @@ function existingReview(
     reviewPolicy: frontMatterValue(markdown, "review_policy"),
     contentDigest: frontMatterValue(markdown, "review_content_digest"),
     lastFullReviewAt: frontMatterValue(markdown, "last_full_review_at"),
+    lastFullReviewDecision: frontMatterValue(markdown, "last_full_review_decision"),
   };
 }
 
@@ -5462,6 +5472,7 @@ function buildExistingReviewIndex(itemsDir: string): ExistingReviewIndex {
       reviewPolicy: frontMatterValue(markdown, "review_policy"),
       contentDigest: frontMatterValue(markdown, "review_content_digest"),
       lastFullReviewAt: frontMatterValue(markdown, "last_full_review_at"),
+      lastFullReviewDecision: frontMatterValue(markdown, "last_full_review_decision"),
     });
   }
   return { byKey };
@@ -13826,6 +13837,7 @@ function pullRequestClosePromotion(
   options: { reportDirs?: readonly string[] } = {},
 ): PullRequestClosePromotion | null {
   if (item.kind !== "pull_request") return null;
+  if (!reviewReportCanPromoteToClose(markdown)) return null;
   if (frontMatterValue(markdown, "decision") !== "keep_open") return null;
   if (frontMatterValue(markdown, "action_taken") !== "kept_open") return null;
   if (frontMatterValue(markdown, "review_status") !== "complete") return null;
@@ -16515,6 +16527,8 @@ local_checkout_access: verified
 item_snapshot_hash: ${options.snapshotHash}
 review_content_digest: ${options.contentDigest}
 last_full_review_at: ${reviewedAt}
+last_full_review_decision: ${options.decision.decision}
+review_cache_hit: false
 item_source_revision: ${options.context.sourceRevision ?? "unknown"}
 close_comment_sha256: ${options.action.closeComment ? sha256(options.action.closeComment) : "none"}
 review_comment_sha256: none
@@ -17078,6 +17092,7 @@ function reviewCommand(args: Args): void {
           "item_snapshot_hash",
           itemSnapshotHash(item, context),
         );
+        carried = replaceFrontMatterValue(carried, "review_cache_hit", "true");
         writeFileSync(reportPath, carried, "utf8");
         completed += 1;
         cacheHits += 1;
@@ -18045,7 +18060,8 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       action === "kept_open" &&
       storedUpdatedAt &&
       item.updatedAt === storedUpdatedAt &&
-      livePullRequestHasNoDiff(currentItemContext())
+      livePullRequestHasNoDiff(currentItemContext()) &&
+      reviewReportCanPromoteToClose(markdown)
     ) {
       markdown = upgradeNoDiffPullRequestReport(markdown, item);
       closeReason = "duplicate_or_superseded";

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -2319,6 +2319,27 @@ function reviewCommentDigestParts(entries: unknown): unknown {
     }));
 }
 
+function reviewTimelineDigestParts(entries: unknown): unknown {
+  if (!Array.isArray(entries)) return null;
+  return entries
+    .map(asRecord)
+    .filter((entry) => {
+      const actor = typeof entry.actor === "string" ? entry.actor.toLowerCase() : "";
+      if (actor && CLAWSWEEPER_BOT_AUTHORS.has(actor)) return false;
+      const label = typeof entry.label === "string" ? normalizeLabelName(entry.label) : "";
+      return !label || !isIgnorableSourceRevisionLabel(label);
+    })
+    .map((entry) => ({
+      id: entry.id ?? null,
+      event: entry.event ?? null,
+      actor: entry.actor ?? null,
+      commitId: entry.commitId ?? null,
+      label: entry.label ?? null,
+      rename: entry.rename ?? null,
+      sourceIssue: entry.sourceIssue ?? null,
+    }));
+}
+
 function itemContentDigest(item: Item, context: ItemContext, git?: GitInfo): string {
   const isPull = item.kind === "pull_request";
   const pull = asRecord(context.pullRequest);
@@ -2328,6 +2349,7 @@ function itemContentDigest(item: Item, context: ItemContext, git?: GitInfo): str
     stableJson({
       kind: item.kind,
       source: context.sourceRevision ?? null,
+      timeline: reviewTimelineDigestParts(context.timeline),
       relations: {
         closingPullRequests: context.closingPullRequests ?? null,
         referencingMergedPullRequests: context.referencingMergedPullRequests ?? null,

--- a/src/scheduler-policy.ts
+++ b/src/scheduler-policy.ts
@@ -18,6 +18,7 @@ export interface SchedulerExistingReview {
   decision?: string | undefined;
   contentDigest?: string | undefined;
   lastFullReviewAt?: string | undefined;
+  lastFullReviewDecision?: string | undefined;
 }
 
 export type SchedulerBucket =
@@ -156,6 +157,7 @@ export function reviewContentCacheHit(options: {
   const review = options.review;
   if (!review || review.reviewStatus !== "complete") return false;
   if (review.decision !== "keep_open") return false;
+  if (review.lastFullReviewDecision !== "keep_open") return false;
   if (hasReviewPolicyMismatch(review, options.reviewPolicy)) return false;
   if (!review.contentDigest || review.contentDigest !== options.contentDigest) return false;
   const lastFullReviewAt = timestampMs(review.lastFullReviewAt);

--- a/src/scheduler-policy.ts
+++ b/src/scheduler-policy.ts
@@ -16,7 +16,6 @@ export interface SchedulerExistingReview {
   reviewStatus?: string | undefined;
   reviewPolicy?: string | undefined;
   decision?: string | undefined;
-  mainSha?: string | undefined;
   contentDigest?: string | undefined;
   lastFullReviewAt?: string | undefined;
 }
@@ -149,7 +148,6 @@ export function reviewContentCacheHit(options: {
   review: SchedulerExistingReview | null;
   reviewPolicy: string | undefined;
   contentDigest: string;
-  currentMainSha?: string | undefined;
   now?: number;
   explicitDispatch: boolean;
   maintainerRequest: boolean;
@@ -157,14 +155,9 @@ export function reviewContentCacheHit(options: {
   if (options.explicitDispatch || options.maintainerRequest) return false;
   const review = options.review;
   if (!review || review.reviewStatus !== "complete") return false;
+  if (review.decision !== "keep_open") return false;
   if (hasReviewPolicyMismatch(review, options.reviewPolicy)) return false;
   if (!review.contentDigest || review.contentDigest !== options.contentDigest) return false;
-  if (
-    review.decision === "close" &&
-    (!review.mainSha || review.mainSha !== options.currentMainSha)
-  ) {
-    return false;
-  }
   const lastFullReviewAt = timestampMs(review.lastFullReviewAt);
   if (lastFullReviewAt === null) return false;
   const now = options.now ?? Date.now();

--- a/src/scheduler-policy.ts
+++ b/src/scheduler-policy.ts
@@ -15,6 +15,8 @@ export interface SchedulerExistingReview {
   labelsSyncedAt?: string | undefined;
   reviewStatus?: string | undefined;
   reviewPolicy?: string | undefined;
+  contentDigest?: string | undefined;
+  lastFullReviewAt?: string | undefined;
 }
 
 export type SchedulerBucket =
@@ -137,6 +139,27 @@ export function shouldReviewItem(
   const reviewedAt = reviewedAtMs(review);
   if (reviewedAt === null) return true;
   return now - reviewedAt >= reviewCadenceMs(item, review, now);
+}
+
+export const REVIEW_CACHE_MAX_AGE_DAYS = 14;
+
+export function reviewContentCacheHit(options: {
+  review: SchedulerExistingReview | null;
+  reviewPolicy: string | undefined;
+  contentDigest: string;
+  now?: number;
+  explicitDispatch: boolean;
+  maintainerRequest: boolean;
+}): boolean {
+  if (options.explicitDispatch || options.maintainerRequest) return false;
+  const review = options.review;
+  if (!review || review.reviewStatus !== "complete") return false;
+  if (hasReviewPolicyMismatch(review, options.reviewPolicy)) return false;
+  if (!review.contentDigest || review.contentDigest !== options.contentDigest) return false;
+  const lastFullReviewAt = timestampMs(review.lastFullReviewAt);
+  if (lastFullReviewAt === null) return false;
+  const now = options.now ?? Date.now();
+  return now - lastFullReviewAt < REVIEW_CACHE_MAX_AGE_DAYS * DAY_MS;
 }
 
 export function reviewPriority(

--- a/src/scheduler-policy.ts
+++ b/src/scheduler-policy.ts
@@ -17,7 +17,6 @@ export interface SchedulerExistingReview {
   reviewPolicy?: string | undefined;
   contentDigest?: string | undefined;
   lastFullReviewAt?: string | undefined;
-  decision?: string | undefined;
   mainSha?: string | undefined;
 }
 
@@ -159,12 +158,7 @@ export function reviewContentCacheHit(options: {
   if (!review || review.reviewStatus !== "complete") return false;
   if (hasReviewPolicyMismatch(review, options.reviewPolicy)) return false;
   if (!review.contentDigest || review.contentDigest !== options.contentDigest) return false;
-  if (
-    review.decision === "close" &&
-    (!review.mainSha || review.mainSha !== options.currentMainSha)
-  ) {
-    return false;
-  }
+  if (!review.mainSha || review.mainSha !== options.currentMainSha) return false;
   const lastFullReviewAt = timestampMs(review.lastFullReviewAt);
   if (lastFullReviewAt === null) return false;
   const now = options.now ?? Date.now();

--- a/src/scheduler-policy.ts
+++ b/src/scheduler-policy.ts
@@ -17,6 +17,8 @@ export interface SchedulerExistingReview {
   reviewPolicy?: string | undefined;
   contentDigest?: string | undefined;
   lastFullReviewAt?: string | undefined;
+  decision?: string | undefined;
+  mainSha?: string | undefined;
 }
 
 export type SchedulerBucket =
@@ -147,6 +149,7 @@ export function reviewContentCacheHit(options: {
   review: SchedulerExistingReview | null;
   reviewPolicy: string | undefined;
   contentDigest: string;
+  currentMainSha: string;
   now?: number;
   explicitDispatch: boolean;
   maintainerRequest: boolean;
@@ -156,6 +159,12 @@ export function reviewContentCacheHit(options: {
   if (!review || review.reviewStatus !== "complete") return false;
   if (hasReviewPolicyMismatch(review, options.reviewPolicy)) return false;
   if (!review.contentDigest || review.contentDigest !== options.contentDigest) return false;
+  if (
+    review.decision === "close" &&
+    (!review.mainSha || review.mainSha !== options.currentMainSha)
+  ) {
+    return false;
+  }
   const lastFullReviewAt = timestampMs(review.lastFullReviewAt);
   if (lastFullReviewAt === null) return false;
   const now = options.now ?? Date.now();

--- a/src/scheduler-policy.ts
+++ b/src/scheduler-policy.ts
@@ -15,6 +15,8 @@ export interface SchedulerExistingReview {
   labelsSyncedAt?: string | undefined;
   reviewStatus?: string | undefined;
   reviewPolicy?: string | undefined;
+  decision?: string | undefined;
+  mainSha?: string | undefined;
   contentDigest?: string | undefined;
   lastFullReviewAt?: string | undefined;
 }
@@ -147,6 +149,7 @@ export function reviewContentCacheHit(options: {
   review: SchedulerExistingReview | null;
   reviewPolicy: string | undefined;
   contentDigest: string;
+  currentMainSha?: string | undefined;
   now?: number;
   explicitDispatch: boolean;
   maintainerRequest: boolean;
@@ -156,6 +159,12 @@ export function reviewContentCacheHit(options: {
   if (!review || review.reviewStatus !== "complete") return false;
   if (hasReviewPolicyMismatch(review, options.reviewPolicy)) return false;
   if (!review.contentDigest || review.contentDigest !== options.contentDigest) return false;
+  if (
+    review.decision === "close" &&
+    (!review.mainSha || review.mainSha !== options.currentMainSha)
+  ) {
+    return false;
+  }
   const lastFullReviewAt = timestampMs(review.lastFullReviewAt);
   if (lastFullReviewAt === null) return false;
   const now = options.now ?? Date.now();

--- a/test/review-content-cache.test.ts
+++ b/test/review-content-cache.test.ts
@@ -289,17 +289,17 @@ test("cache misses when the prior review predates the digest field", () => {
   assert.equal(cacheHit({ review: freshReview({ contentDigest: undefined }) }), false);
 });
 
-test("cache misses for a close decision after target main changes", () => {
+test("cache misses after target main changes", () => {
   assert.equal(
     cacheHit({
-      review: freshReview({ decision: "close", mainSha: "main-sha-1" }),
+      review: freshReview({ mainSha: "main-sha-1" }),
       currentMainSha: "main-sha-2",
     }),
     false,
   );
 });
 
-test("cache misses for a close decision without recorded target main", () => {
+test("cache misses without recorded target main", () => {
   assert.equal(cacheHit({ review: freshReview({ decision: "close", mainSha: undefined }) }), false);
 });
 
@@ -307,6 +307,6 @@ test("cache hits for a close decision on the same target main", () => {
   assert.equal(cacheHit({ review: freshReview({ decision: "close" }) }), true);
 });
 
-test("cache can carry a keep-open decision across target main changes", () => {
-  assert.equal(cacheHit({ currentMainSha: "main-sha-2" }), true);
+test("cache does not carry a keep-open decision across target main changes", () => {
+  assert.equal(cacheHit({ currentMainSha: "main-sha-2" }), false);
 });

--- a/test/review-content-cache.test.ts
+++ b/test/review-content-cache.test.ts
@@ -5,6 +5,7 @@ import { reviewContentCacheHit } from "../dist/scheduler-policy.js";
 import {
   itemContentDigestForTest,
   reviewCommentContentRevisionForTest,
+  reviewReportCanPromoteToCloseForTest,
 } from "../dist/clawsweeper.js";
 import { item } from "./helpers.ts";
 
@@ -270,6 +271,7 @@ function freshReview(overrides = {}) {
     decision: "keep_open",
     contentDigest: "digest-1",
     lastFullReviewAt: new Date(NOW - DAY_MS).toISOString(),
+    lastFullReviewDecision: "keep_open",
     ...overrides,
   };
 }
@@ -335,6 +337,28 @@ test("close verdict is never cached", () => {
   assert.equal(cacheHit({ review: freshReview({ decision: "close" }) }), false);
 });
 
+test("apply-rewritten close verdicts are never cached", () => {
+  assert.equal(
+    cacheHit({
+      review: freshReview({ decision: "keep_open", lastFullReviewDecision: "close" }),
+    }),
+    false,
+  );
+});
+
+test("reports without original-verdict provenance refresh once", () => {
+  assert.equal(cacheHit({ review: freshReview({ lastFullReviewDecision: undefined }) }), false);
+});
+
 test("verdict without a decision is never cached", () => {
   assert.equal(cacheHit({ review: freshReview({ decision: undefined }) }), false);
+});
+
+test("cache-carried reports cannot be promoted to close", () => {
+  assert.equal(reviewReportCanPromoteToCloseForTest("---\nreview_cache_hit: true\n---\n"), false);
+});
+
+test("fresh and legacy reports retain existing close promotion behavior", () => {
+  assert.equal(reviewReportCanPromoteToCloseForTest("---\nreview_cache_hit: false\n---\n"), true);
+  assert.equal(reviewReportCanPromoteToCloseForTest("---\ndecision: keep_open\n---\n"), true);
 });

--- a/test/review-content-cache.test.ts
+++ b/test/review-content-cache.test.ts
@@ -158,6 +158,7 @@ function freshReview(overrides = {}) {
   return {
     reviewStatus: "complete",
     reviewPolicy: "policy-1",
+    decision: "keep_open",
     contentDigest: "digest-1",
     lastFullReviewAt: new Date(NOW - DAY_MS).toISOString(),
     ...overrides,
@@ -217,39 +218,14 @@ test("cache misses when the prior review predates the digest field", () => {
   assert.equal(cacheHit({ review: freshReview({ contentDigest: undefined }) }), false);
 });
 
-test("close verdict cache hits when target-branch state is unchanged", () => {
-  assert.equal(
-    cacheHit({
-      review: freshReview({ decision: "close", mainSha: "main-1" }),
-      currentMainSha: "main-1",
-    }),
-    true,
-  );
+test("keep-open verdict is cache eligible", () => {
+  assert.equal(cacheHit({ review: freshReview({ decision: "keep_open" }) }), true);
 });
 
-test("close verdict cache misses when the target branch moved", () => {
-  assert.equal(
-    cacheHit({
-      review: freshReview({ decision: "close", mainSha: "main-1" }),
-      currentMainSha: "main-2",
-    }),
-    false,
-  );
+test("close verdict is never cached", () => {
+  assert.equal(cacheHit({ review: freshReview({ decision: "close" }) }), false);
 });
 
-test("close verdict cache misses when the prior review has no target-branch sha", () => {
-  assert.equal(
-    cacheHit({ review: freshReview({ decision: "close" }), currentMainSha: "main-1" }),
-    false,
-  );
-});
-
-test("keep-open verdict cache hits despite target-branch movement", () => {
-  assert.equal(
-    cacheHit({
-      review: freshReview({ decision: "keep_open", mainSha: "main-1" }),
-      currentMainSha: "main-2",
-    }),
-    true,
-  );
+test("verdict without a decision is never cached", () => {
+  assert.equal(cacheHit({ review: freshReview({ decision: undefined }) }), false);
 });

--- a/test/review-content-cache.test.ts
+++ b/test/review-content-cache.test.ts
@@ -98,6 +98,42 @@ test("issue digest ignores pull-request-only fields", () => {
   assert.equal(a, b);
 });
 
+test("issue digest busts when closing pull request context changes", () => {
+  const issue = item({ kind: "issue", number: 300 });
+  const a = itemContentDigestForTest(issue, issueContext({ closingPullRequests: [] }));
+  const b = itemContentDigestForTest(
+    issue,
+    issueContext({
+      closingPullRequests: [{ number: 301, state: "open", head: { sha: "head-1" } }],
+    }),
+  );
+  assert.notEqual(a, b);
+});
+
+test("content digest busts when related item context changes", () => {
+  const pull = item({ kind: "pull_request", number: 200 });
+  const a = itemContentDigestForTest(pull, pullContext({ relatedItems: [] }));
+  const b = itemContentDigestForTest(
+    pull,
+    pullContext({ relatedItems: [{ issue: { number: 199, state: "closed" } }] }),
+  );
+  assert.notEqual(a, b);
+});
+
+test("content digest busts when the latest release changes", () => {
+  const issue = item({ kind: "issue", number: 300 });
+  const context = issueContext();
+  const a = itemContentDigestForTest(issue, context, {
+    mainSha: "main-1",
+    latestRelease: { tagName: "v1.0.0", sha: "release-1" },
+  });
+  const b = itemContentDigestForTest(issue, context, {
+    mainSha: "main-2",
+    latestRelease: { tagName: "v1.1.0", sha: "release-2" },
+  });
+  assert.notEqual(a, b);
+});
+
 test("content digest busts when a human adds a PR review comment", () => {
   const pull = item({ kind: "pull_request", number: 200 });
   const a = itemContentDigestForTest(pull, pullContext({ pullReviewComments: [] }));
@@ -160,6 +196,8 @@ function freshReview(overrides = {}) {
     reviewPolicy: "policy-1",
     contentDigest: "digest-1",
     lastFullReviewAt: new Date(NOW - DAY_MS).toISOString(),
+    decision: "keep_open",
+    mainSha: "main-sha-1",
     ...overrides,
   };
 }
@@ -169,6 +207,7 @@ function cacheHit(overrides = {}) {
     review: freshReview(),
     reviewPolicy: "policy-1",
     contentDigest: "digest-1",
+    currentMainSha: "main-sha-1",
     now: NOW,
     explicitDispatch: false,
     maintainerRequest: false,
@@ -215,4 +254,26 @@ test("cache misses on a first-ever review", () => {
 
 test("cache misses when the prior review predates the digest field", () => {
   assert.equal(cacheHit({ review: freshReview({ contentDigest: undefined }) }), false);
+});
+
+test("cache misses for a close decision after target main changes", () => {
+  assert.equal(
+    cacheHit({
+      review: freshReview({ decision: "close", mainSha: "main-sha-1" }),
+      currentMainSha: "main-sha-2",
+    }),
+    false,
+  );
+});
+
+test("cache misses for a close decision without recorded target main", () => {
+  assert.equal(cacheHit({ review: freshReview({ decision: "close", mainSha: undefined }) }), false);
+});
+
+test("cache hits for a close decision on the same target main", () => {
+  assert.equal(cacheHit({ review: freshReview({ decision: "close" }) }), true);
+});
+
+test("cache can carry a keep-open decision across target main changes", () => {
+  assert.equal(cacheHit({ currentMainSha: "main-sha-2" }), true);
 });

--- a/test/review-content-cache.test.ts
+++ b/test/review-content-cache.test.ts
@@ -1,0 +1,218 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { reviewContentCacheHit } from "../dist/scheduler-policy.js";
+import { itemContentDigestForTest } from "../dist/clawsweeper.js";
+import { item } from "./helpers.ts";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function pullContext(overrides = {}) {
+  return {
+    sourceRevision: "source-rev-1",
+    timeline: [],
+    counts: { comments: 0, timeline: 0 },
+    pullRequest: { head: { sha: "head-sha-1" }, base: { sha: "base-sha-1" } },
+    pullFiles: [{ filename: "src/a.ts", status: "modified", patch: "@@ -1 +1 @@\n-old\n+new" }],
+    ...overrides,
+  };
+}
+
+function issueContext(overrides = {}) {
+  return {
+    sourceRevision: "source-rev-1",
+    timeline: [],
+    counts: { comments: 0, timeline: 0 },
+    ...overrides,
+  };
+}
+
+test("content digest is stable across bot-only context churn", () => {
+  const pull = item({ kind: "pull_request", number: 200 });
+  const a = itemContentDigestForTest(
+    pull,
+    pullContext({ timeline: [{ id: 1 }], counts: { comments: 3, timeline: 1 } }),
+  );
+  const b = itemContentDigestForTest(
+    pull,
+    pullContext({ timeline: [{ id: 2 }, { id: 3 }], counts: { comments: 9, timeline: 2 } }),
+  );
+  assert.equal(a, b);
+});
+
+test("content digest busts when the source revision changes", () => {
+  const pull = item({ kind: "pull_request", number: 200 });
+  const a = itemContentDigestForTest(pull, pullContext());
+  const b = itemContentDigestForTest(pull, pullContext({ sourceRevision: "source-rev-2" }));
+  assert.notEqual(a, b);
+});
+
+test("content digest busts when a diff patch byte changes", () => {
+  const pull = item({ kind: "pull_request", number: 200 });
+  const a = itemContentDigestForTest(pull, pullContext());
+  const b = itemContentDigestForTest(
+    pull,
+    pullContext({
+      pullFiles: [{ filename: "src/a.ts", status: "modified", patch: "@@ -1 +1 @@\n-old\n+newer" }],
+    }),
+  );
+  assert.notEqual(a, b);
+});
+
+test("content digest busts when the PR head sha changes", () => {
+  const pull = item({ kind: "pull_request", number: 200 });
+  const a = itemContentDigestForTest(pull, pullContext());
+  const b = itemContentDigestForTest(
+    pull,
+    pullContext({ pullRequest: { head: { sha: "head-sha-2" }, base: { sha: "base-sha-1" } } }),
+  );
+  assert.notEqual(a, b);
+});
+
+test("content digest busts when the PR base sha changes", () => {
+  const pull = item({ kind: "pull_request", number: 200 });
+  const a = itemContentDigestForTest(pull, pullContext());
+  const b = itemContentDigestForTest(
+    pull,
+    pullContext({ pullRequest: { head: { sha: "head-sha-1" }, base: { sha: "base-sha-2" } } }),
+  );
+  assert.notEqual(a, b);
+});
+
+test("issue digest ignores pull-request-only fields", () => {
+  const issue = item({ kind: "issue", number: 300 });
+  const a = itemContentDigestForTest(
+    issue,
+    issueContext({
+      pullFiles: [{ filename: "x", patch: "one" }],
+      pullRequest: { head: { sha: "h1" } },
+    }),
+  );
+  const b = itemContentDigestForTest(
+    issue,
+    issueContext({
+      pullFiles: [{ filename: "y", patch: "two" }],
+      pullRequest: { head: { sha: "h2" } },
+    }),
+  );
+  assert.equal(a, b);
+});
+
+test("content digest busts when a human adds a PR review comment", () => {
+  const pull = item({ kind: "pull_request", number: 200 });
+  const a = itemContentDigestForTest(pull, pullContext({ pullReviewComments: [] }));
+  const b = itemContentDigestForTest(
+    pull,
+    pullContext({
+      pullReviewComments: [
+        {
+          author: "maintainer",
+          authorAssociation: "MEMBER",
+          body: "Please do not close; this still needs a fix.",
+        },
+      ],
+    }),
+  );
+  assert.notEqual(a, b);
+});
+
+test("content digest ignores ClawSweeper's own PR review comments", () => {
+  const pull = item({ kind: "pull_request", number: 200 });
+  const a = itemContentDigestForTest(pull, pullContext({ pullReviewComments: [] }));
+  const b = itemContentDigestForTest(
+    pull,
+    pullContext({
+      pullReviewComments: [
+        { author: "ClawSweeper[bot]", authorAssociation: "NONE", body: "Automated review note." },
+      ],
+    }),
+  );
+  assert.equal(a, b);
+});
+
+test("content digest ignores PR review comment timestamp churn", () => {
+  const pull = item({ kind: "pull_request", number: 200 });
+  const comment = { author: "maintainer", authorAssociation: "MEMBER", body: "Looks good to me." };
+  const a = itemContentDigestForTest(
+    pull,
+    pullContext({
+      pullReviewComments: [
+        { ...comment, createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-01-01T00:00:00Z" },
+      ],
+    }),
+  );
+  const b = itemContentDigestForTest(
+    pull,
+    pullContext({
+      pullReviewComments: [
+        { ...comment, createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-05-05T00:00:00Z" },
+      ],
+    }),
+  );
+  assert.equal(a, b);
+});
+
+const NOW = Date.parse("2026-07-01T00:00:00Z");
+
+function freshReview(overrides = {}) {
+  return {
+    reviewStatus: "complete",
+    reviewPolicy: "policy-1",
+    contentDigest: "digest-1",
+    lastFullReviewAt: new Date(NOW - DAY_MS).toISOString(),
+    ...overrides,
+  };
+}
+
+function cacheHit(overrides = {}) {
+  return reviewContentCacheHit({
+    review: freshReview(),
+    reviewPolicy: "policy-1",
+    contentDigest: "digest-1",
+    now: NOW,
+    explicitDispatch: false,
+    maintainerRequest: false,
+    ...overrides,
+  });
+}
+
+test("cache hits when content is unchanged, fresh, complete, and policy matches", () => {
+  assert.equal(cacheHit(), true);
+});
+
+test("cache misses when the content digest differs", () => {
+  assert.equal(cacheHit({ contentDigest: "digest-2" }), false);
+});
+
+test("cache misses when the review policy changed", () => {
+  assert.equal(cacheHit({ reviewPolicy: "policy-2" }), false);
+});
+
+test("cache misses past the staleness ceiling", () => {
+  assert.equal(
+    cacheHit({
+      review: freshReview({ lastFullReviewAt: new Date(NOW - 15 * DAY_MS).toISOString() }),
+    }),
+    false,
+  );
+});
+
+test("cache misses on an explicit re-review dispatch", () => {
+  assert.equal(cacheHit({ explicitDispatch: true }), false);
+});
+
+test("cache misses on a maintainer request", () => {
+  assert.equal(cacheHit({ maintainerRequest: true }), false);
+});
+
+test("cache misses when the prior review did not complete", () => {
+  assert.equal(cacheHit({ review: freshReview({ reviewStatus: "failed" }) }), false);
+});
+
+test("cache misses on a first-ever review", () => {
+  assert.equal(cacheHit({ review: null }), false);
+});
+
+test("cache misses when the prior review predates the digest field", () => {
+  assert.equal(cacheHit({ review: freshReview({ contentDigest: undefined }) }), false);
+});

--- a/test/review-content-cache.test.ts
+++ b/test/review-content-cache.test.ts
@@ -170,6 +170,14 @@ test("content digest busts when the latest release changes", () => {
   assert.notEqual(a, b);
 });
 
+test("issue digest busts when target main changes", () => {
+  const issue = item({ kind: "issue", number: 300 });
+  const context = issueContext();
+  const a = itemContentDigestForTest(issue, context, { mainSha: "main-1" });
+  const b = itemContentDigestForTest(issue, context, { mainSha: "main-2" });
+  assert.notEqual(a, b);
+});
+
 test("content digest busts when a human adds a PR review comment", () => {
   const pull = item({ kind: "pull_request", number: 200 });
   const a = itemContentDigestForTest(pull, pullContext({ pullReviewComments: [] }));

--- a/test/review-content-cache.test.ts
+++ b/test/review-content-cache.test.ts
@@ -31,11 +31,44 @@ test("content digest is stable across bot-only context churn", () => {
   const pull = item({ kind: "pull_request", number: 200 });
   const a = itemContentDigestForTest(
     pull,
-    pullContext({ timeline: [{ id: 1 }], counts: { comments: 3, timeline: 1 } }),
+    pullContext({
+      timeline: [{ id: 1, event: "labeled", actor: "ClawSweeper[bot]" }],
+      counts: { comments: 3, timeline: 1 },
+    }),
   );
   const b = itemContentDigestForTest(
     pull,
-    pullContext({ timeline: [{ id: 2 }, { id: 3 }], counts: { comments: 9, timeline: 2 } }),
+    pullContext({
+      timeline: [
+        { id: 2, event: "labeled", actor: "clawsweeper" },
+        { id: 3, event: "commented", actor: "openclaw-clawsweeper[bot]" },
+      ],
+      counts: { comments: 9, timeline: 2 },
+    }),
+  );
+  assert.equal(a, b);
+});
+
+test("content digest busts when a human timeline event appears", () => {
+  const pull = item({ kind: "pull_request", number: 200 });
+  const a = itemContentDigestForTest(pull, pullContext({ timeline: [] }));
+  const b = itemContentDigestForTest(
+    pull,
+    pullContext({
+      timeline: [{ id: 9, event: "reviewed", actor: "maintainer" }],
+    }),
+  );
+  assert.notEqual(a, b);
+});
+
+test("content digest ignores advisory-label timeline churn", () => {
+  const issue = item({ kind: "issue", number: 300 });
+  const a = itemContentDigestForTest(issue, issueContext({ timeline: [] }));
+  const b = itemContentDigestForTest(
+    issue,
+    issueContext({
+      timeline: [{ id: 10, event: "labeled", actor: "github-actions[bot]", label: "P2" }],
+    }),
   );
   assert.equal(a, b);
 });

--- a/test/review-content-cache.test.ts
+++ b/test/review-content-cache.test.ts
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { reviewContentCacheHit } from "../dist/scheduler-policy.js";
-import { itemContentDigestForTest } from "../dist/clawsweeper.js";
+import {
+  itemContentDigestForTest,
+  reviewCommentContentRevisionForTest,
+} from "../dist/clawsweeper.js";
 import { item } from "./helpers.ts";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -219,6 +222,35 @@ test("content digest ignores PR review comment timestamp churn", () => {
     }),
   );
   assert.equal(a, b);
+});
+
+test("review comment revision covers comments outside the bounded prompt window", () => {
+  const comments = Array.from({ length: 81 }, (_, index) => ({
+    id: index + 1,
+    author: "maintainer",
+    authorAssociation: "MEMBER",
+    body: `comment ${index + 1}`,
+  }));
+  const changed = comments.map((comment, index) =>
+    index === 40 ? { ...comment, body: "middle comment edited" } : comment,
+  );
+  assert.notEqual(
+    reviewCommentContentRevisionForTest(comments),
+    reviewCommentContentRevisionForTest(changed),
+  );
+});
+
+test("content digest uses the full review-comment revision", () => {
+  const pull = item({ kind: "pull_request", number: 200 });
+  const a = itemContentDigestForTest(
+    pull,
+    pullContext({ pullReviewCommentsRevision: "review-comments-1" }),
+  );
+  const b = itemContentDigestForTest(
+    pull,
+    pullContext({ pullReviewCommentsRevision: "review-comments-2" }),
+  );
+  assert.notEqual(a, b);
 });
 
 const NOW = Date.parse("2026-07-01T00:00:00Z");

--- a/test/review-content-cache.test.ts
+++ b/test/review-content-cache.test.ts
@@ -216,3 +216,40 @@ test("cache misses on a first-ever review", () => {
 test("cache misses when the prior review predates the digest field", () => {
   assert.equal(cacheHit({ review: freshReview({ contentDigest: undefined }) }), false);
 });
+
+test("close verdict cache hits when target-branch state is unchanged", () => {
+  assert.equal(
+    cacheHit({
+      review: freshReview({ decision: "close", mainSha: "main-1" }),
+      currentMainSha: "main-1",
+    }),
+    true,
+  );
+});
+
+test("close verdict cache misses when the target branch moved", () => {
+  assert.equal(
+    cacheHit({
+      review: freshReview({ decision: "close", mainSha: "main-1" }),
+      currentMainSha: "main-2",
+    }),
+    false,
+  );
+});
+
+test("close verdict cache misses when the prior review has no target-branch sha", () => {
+  assert.equal(
+    cacheHit({ review: freshReview({ decision: "close" }), currentMainSha: "main-1" }),
+    false,
+  );
+});
+
+test("keep-open verdict cache hits despite target-branch movement", () => {
+  assert.equal(
+    cacheHit({
+      review: freshReview({ decision: "keep_open", mainSha: "main-1" }),
+      currentMainSha: "main-2",
+    }),
+    true,
+  );
+});

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -779,6 +779,22 @@ test("scheduled normal review keeps workers warm with multi-item shards", () => 
   );
 });
 
+test("planned background reviews allow safe content-cache reuse without weakening exact reviews", () => {
+  const workflow = readText(".github/workflows/sweep.yml");
+  const eventReviewJobStart = workflow.indexOf("\n  event-review-apply:");
+  const planJobStart = workflow.indexOf("\n  plan:", eventReviewJobStart);
+  const eventReviewJob = workflow.slice(eventReviewJobStart, planJobStart);
+  const reviewJobStart = workflow.indexOf("\n  review:");
+  const publishJobStart = workflow.indexOf("\n  publish:", reviewJobStart);
+  const reviewJob = workflow.slice(reviewJobStart, publishJobStart);
+
+  assert.match(
+    reviewJob,
+    /--item-numbers "\$\{\{ matrix\.item_numbers \}\}" \\\n+\s+--planned-automatic-review/,
+  );
+  assert.doesNotMatch(eventReviewJob, /--planned-automatic-review/);
+});
+
 test("sweep event reviews and target fanout avoid storm amplification", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const legacyIntakeBlock = workflow.slice(

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -790,7 +790,13 @@ test("planned background reviews allow safe content-cache reuse without weakenin
 
   assert.match(
     reviewJob,
-    /--item-numbers "\$\{\{ matrix\.item_numbers \}\}" \\\n+\s+--planned-automatic-review/,
+    /EXACT_ITEM: \$\{\{ github\.event\.client_payload\.item_number \|\| github\.event\.inputs\.item_number \|\| github\.event\.inputs\.item_numbers \|\| '' \}\}/,
+  );
+  assert.match(reviewJob, /if \[ -z "\$EXACT_ITEM" \]; then/);
+  assert.match(reviewJob, /planned_automatic_review_arg=\(--planned-automatic-review\)/);
+  assert.match(
+    reviewJob,
+    /--item-numbers "\$\{\{ matrix\.item_numbers \}\}" \\\n+\s+"\$\{planned_automatic_review_arg\[@\]\}"/,
   );
   assert.doesNotMatch(eventReviewJob, /--planned-automatic-review/);
 });


### PR DESCRIPTION
## What this changes

Scheduled reviews currently start a fresh high-reasoning Codex process even when the reviewable content is unchanged. This adds a conservative content cache for planned background reviews without reducing the 128-worker pool.

An automatic review can reuse a prior report only when all of these are true:

- the prior review completed successfully and decided `keep_open`;
- the review policy and reviewable-content digest still match;
- the last full model review is less than 14 days old; and
- the run is a planned background review, not an exact dispatch or maintainer-requested review.

Close verdicts are never cached. They always receive a fresh model review.

## Reviewable content

The digest covers the issue or PR source, human timeline activity, closing and related items, the latest release, PR head/base state, diff, commits, and inline review comments. ClawSweeper-owned churn and advisory-label churn are ignored.

Issue cache keys also include the target main SHA because a main-branch fix can change an issue verdict without changing its discussion. PR keys already include their live base SHA.

Prompts remain bounded, but cache freshness does not depend on those bounds: long human timelines and PRs with more than 40 inline comments get full-set revision hashes. A changed middle comment therefore invalidates the cache even when that comment is omitted from the model prompt window.

The cache is self-migrating. Existing reports without the new digest fields take one full review before they can become eligible.

## Safety boundaries

- First reviews, failed reviews, policy changes, content changes, exact dispatches, maintainer prompts, missing decisions, and reports older than 14 days always run Codex.
- Only non-destructive `keep_open` verdicts can be reused. A stale close can never be carried into apply.
- Cache eligibility uses the immutable verdict from the last full model run, so an apply-time close-to-keep-open rewrite cannot enter the cache.
- Cache-carried reports cannot be promoted to close by no-diff, supersession, pause/close, or stale-rating apply rules. A fresh full review must run first.
- Related-item discovery still receives the full available review-comment context, including outside the cache path.
- Workflow-generated planned item lists are cache eligible; manual exact-item workflow dispatches remain fresh.

## Proof

- Focused cache and close-promotion suite: 41/41 passed.
- Full repository `pnpm run check`: 651 unit, 617 repair, and 1,268 coverage tests passed, plus builds, lint, coverage thresholds, active-surface/limits checks, and formatting.
- Independent AutoReview: no accepted or actionable findings on exact head `63c5a7d1bd2672c12c198a3f5598d2e1e7db63f8`.
- No dependency, release, version, or worker-count changes.

The original subprocess smoke remains representative: among first review, unchanged keep-open, changed diff, new maintainer comment, and unchanged close, only the unchanged keep-open review skips the model process.
