### PR TITLE
Allow opt-in external worker command for Codex-compatible repair execution

### DIFF
--- a/docs/repair/internal-features.md
+++ b/docs/repair/internal-features.md
@@ -625,6 +625,12 @@ Important defaults:
 - `CODEX_BIN`: optional Codex executable override. Native Windows runs resolve
   npm-installed `codex.cmd` launchers through an escaped `cmd.exe` invocation;
   native executables and Unix runs keep direct process spawning.
+- `CLAWSWEEPER_MODEL_COMMAND`: optional worker command override for
+  operator-supplied Codex-compatible processes. When set, it takes
+  precedence over `CODEX_BIN` and bypasses command-specific `*_BIN`
+  re-resolution. The external command receives the same argv and stdin
+  contract the corresponding Codex command receives today. Keep it
+  unset for normal ClawSweeper runs.
 - `CLAWSWEEPER_MAX_LIVE_WORKERS`: dispatch capacity guard. Existing repair
   lanes derive their checked-in default from `workers.max`; imported gitcrawl
   cluster jobs use `lanes.repair.cluster_max_live_runs`.

--- a/src/codex-spawn.ts
+++ b/src/codex-spawn.ts
@@ -16,6 +16,8 @@ import {
 export type CodexSpawnInvocation = CommandInvocation;
 
 export function codexProcessCommand(env: NodeJS.ProcessEnv = process.env): string {
+  const externalWorker = env.CLAWSWEEPER_MODEL_COMMAND?.trim();
+  if (externalWorker) return externalWorker;
   const configured = env.CODEX_BIN?.trim();
   if (configured) return configured;
   if (process.platform === "win32" && env.CLAWSWEEPER_PREFER_WINDOWS_CODEX_APP === "1") {
@@ -31,12 +33,14 @@ export function codexSpawnInvocation(
   platform: NodeJS.Platform = process.platform,
   cwd = process.cwd(),
 ): CodexSpawnInvocation {
-  const configuredCommand = codexProcessCommand(env);
+  const externalWorker = env.CLAWSWEEPER_MODEL_COMMAND?.trim();
+  const configuredCommand = externalWorker || codexProcessCommand(env);
   return resolveSpawnCommand(configuredCommand, args, {
     cwd,
     env,
     missingCommandMessage: `Unable to resolve Windows Codex command: ${configuredCommand}`,
     platform,
+    resolveBinOverride: !externalWorker,
   });
 }
 

--- a/src/command.ts
+++ b/src/command.ts
@@ -21,6 +21,7 @@ export type ResolveSpawnCommandOptions = {
   env?: NodeJS.ProcessEnv;
   missingCommandMessage?: string;
   platform?: NodeJS.Platform;
+  resolveBinOverride?: boolean;
 };
 
 const windowsExecutablePattern = /\.(?:com|exe)$/i;
@@ -106,9 +107,12 @@ export function resolveSpawnCommand(
     env = process.env,
     missingCommandMessage,
     platform = process.platform,
+    resolveBinOverride = true,
   }: ResolveSpawnCommandOptions = {},
 ): CommandInvocation {
-  const resolved = resolveCommand(command, args, env);
+  const resolved = resolveBinOverride
+    ? resolveCommand(command, args, env)
+    : { command, args: [...args] };
   if (platform !== "win32") return resolved;
 
   const windowsCommand = resolveWindowsCommand(resolved.command, env, cwd);

--- a/test/codex-process.test.ts
+++ b/test/codex-process.test.ts
@@ -24,10 +24,25 @@ const tmpPrefix = join(tmpdir(), "clawsweeper-codex-process-test-");
 test("Codex process resolves command overrides and escaped Windows launchers", () => {
   assert.equal(codexProcessCommand({}), "codex");
   assert.equal(codexProcessCommand({ CODEX_BIN: "  custom-codex  " }), "custom-codex");
+  assert.equal(
+    codexProcessCommand({
+      CODEX_BIN: "  custom-codex  ",
+      CLAWSWEEPER_MODEL_COMMAND: "  external-worker  ",
+    }),
+    "external-worker",
+  );
   assert.deepEqual(codexSpawnInvocation(["exec", "-"], { CODEX_BIN: "codex" }, "linux"), {
     command: "codex",
     args: ["exec", "-"],
   });
+  assert.deepEqual(
+    codexSpawnInvocation(
+      ["exec", "-"],
+      { CLAWSWEEPER_MODEL_COMMAND: "codex", CODEX_BIN: "should-not-be-used" },
+      "linux",
+    ),
+    { command: "codex", args: ["exec", "-"] },
+  );
   const escaped = codexSpawnInvocation(
     ["space value", "a&b"],
     {
@@ -96,6 +111,67 @@ test("Codex process resolves extensionless Windows node shebang shims", () => {
     assert.equal(invocation.command, process.execPath);
     assert.deepEqual(invocation.args, [codexPath, "exec", "-"]);
     assert.equal(invocation.windowsVerbatimArguments, undefined);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("Codex process uses CLAWSWEEPER_MODEL_COMMAND and preserves argv and stdin delivery", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const markerPath = join(root, "stdin.txt");
+  const argvPath = join(root, "argv.json");
+  const workerPath = join(root, "external-worker");
+  writeFileSync(
+    workerPath,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const input = fs.readFileSync(0, "utf8");
+fs.writeFileSync(process.env.CODEX_TEST_STDIN_PATH, input);
+fs.writeFileSync(process.env.CODEX_TEST_ARGV_PATH, JSON.stringify(process.argv.slice(2)));
+process.stdout.write("external-worker-ok");
+`,
+    { mode: 0o755 },
+  );
+  try {
+    const result = runCodexProcess({
+      args: [
+        "exec",
+        "--cd",
+        join(root, "directory with spaces"),
+        "--output-schema",
+        "schema.json",
+        "--output-last-message",
+        "result.json",
+        "--json",
+        "-",
+      ],
+      cwd: root,
+      env: {
+        ...process.env,
+        CODEX_BIN: "should-not-be-used",
+        CLAWSWEEPER_MODEL_COMMAND: workerPath,
+        CODEX_TEST_ARGV_PATH: argvPath,
+        CODEX_TEST_STDIN_PATH: markerPath,
+      },
+      input: "prompt over stdin",
+      timeoutMs: 10_000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.error, undefined);
+    assert.match(result.stdout, /external-worker-ok/);
+    assert.equal(readFileSync(markerPath, "utf8"), "prompt over stdin");
+    assert.deepEqual(JSON.parse(readFileSync(argvPath, "utf8")), [
+      "exec",
+      "--cd",
+      join(root, "directory with spaces"),
+      "--output-schema",
+      "schema.json",
+      "--output-last-message",
+      "result.json",
+      "--json",
+      "-",
+    ]);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Add an opt-in `CLAWSWEEPER_MODEL_COMMAND` override for the existing Codex worker command.

This gives ClawSweeper operators a small, generic extension point: they can provide their own Codex-compatible worker command without ClawSweeper needing to know or own how that command is implemented.

When unset, ClawSweeper keeps the current behavior:

1. use `CODEX_BIN` when configured;
2. on Windows, optionally use the Codex app binary when `CLAWSWEEPER_PREFER_WINDOWS_CODEX_APP=1`;
3. otherwise fall back to `codex`.

When set, `CLAWSWEEPER_MODEL_COMMAND` is used as the worker command while preserving the existing argv/stdin contract.

## Update after ClawSweeper review

Addressed the review feedback on the first head:

- fixed the precedence issue so an explicit `CLAWSWEEPER_MODEL_COMMAND` bypasses later command-specific `*_BIN` re-resolution;
- added regression coverage for `CLAWSWEEPER_MODEL_COMMAND=codex` with `CODEX_BIN=should-not-be-used`;
- documented `CLAWSWEEPER_MODEL_COMMAND` next to `CODEX_BIN`, including precedence and argv/stdin contract;
- added redacted live behavior proof from a real external-worker run outside the unit-test harness.

## Why

ClawSweeper already has a strong operator-oriented design: the core system owns repair orchestration, validation, checkpointing and publishing, while operators can configure how the tool runs in their environment.

This PR follows that spirit with a narrow command-level seam. It lets an operator plug in an external worker that speaks the same Codex-shaped process contract, without adding provider-specific code, credential handling, tool loops or alternate repair logic to ClawSweeper core.

## Scope

This PR only changes command selection.

It does not add:

- a provider backend abstraction;
- provider-specific clients;
- a model-specific runner;
- model tool loops;
- GitHub context helpers;
- credential handling changes;
- sandbox policy changes;
- repair result normalization;
- new repair phases;
- new publishing behavior.

## Contract preserved

The external command receives the same arguments and stdin that the Codex command receives today.

The focused regression test verifies that `CLAWSWEEPER_MODEL_COMMAND`:

- takes precedence over `CODEX_BIN`;
- bypasses later `*_BIN` re-resolution when explicitly set;
- receives the full argv unchanged;
- receives the prompt over stdin;
- returns through the same `runCodexProcess` path.

## Safety

This is opt-in. Existing installations that do not set `CLAWSWEEPER_MODEL_COMMAND` continue to use the existing Codex command resolution path.

The PR does not expose credentials to a model-controlled tool runtime, does not introduce raw shell tools, and does not add any new GitHub API capability. Any external command remains an operator-supplied process boundary outside ClawSweeper core.

## Proof / evidence

Patch size on the updated head:

```text
docs/repair/internal-features.md |  6 ++++
src/codex-spawn.ts               |  6 +++-
src/command.ts                   |  6 +++-
test/codex-process.test.ts       | 76 ++++++++++++++++++++++++++++++++++++++++
4 files changed, 92 insertions(+), 2 deletions(-)
```

Redacted live external-worker proof outside the unit-test harness:

```text
CLAWSWEEPER_MODEL_COMMAND=codex
CODEX_BIN_SENTINEL_CONFIGURED=yes
spawn_invocation={"command":"codex","args":["exec","-"]}
status=0
stdout=EXTERNAL_WORKER_OK
stderr=
stdin=live proof prompt
argv=exec|--cd|/tmp/clawsweeper-411-live-proof/cwd|--output-schema|schema.json|--output-last-message|result.json|--json|-
```

What this proves:

- `CLAWSWEEPER_MODEL_COMMAND=codex` remained the literal command selected for spawn.
- `CODEX_BIN` pointed at a failing sentinel, but the sentinel was not used.
- The external worker executed successfully.
- The prompt arrived over stdin.
- The full argv contract was preserved.

Focused test result:

```text
node --test test/codex-process.test.ts
tests 8
pass 8
fail 0
```

## Validation

Ran locally:

- `corepack pnpm run format:check`
- `corepack pnpm run build`
- `node --test test/codex-process.test.ts`
- `corepack pnpm run build:repair`
- `corepack pnpm run lint:src`
- `corepack pnpm run lint:scripts`
- `corepack pnpm run lint:repair`
- `corepack pnpm run check:active-surface`
- `corepack pnpm run check:limits`
- `git diff --check origin/main...HEAD`
