### PR TITLE
fix(apply): select stalled PR closures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
-- Included stalled-unproven and abandoned PR proposals in scheduled apply selection so their existing live safety gates can close eligible PRs.
 - Split apply workflow helpers out of the oversized inline expression so GitHub can validate and start sweep runs again.
 - Bounded apply-existing checkpoints to five fresh closes, renewed the GitHub
   App token between continuation runs, and stopped zero-progress scans from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Included stalled-unproven and abandoned PR proposals in scheduled apply selection so their existing live safety gates can close eligible PRs.
 - Split apply workflow helpers out of the oversized inline expression so GitHub can validate and start sweep runs again.
 - Bounded apply-existing checkpoints to five fresh closes, renewed the GitHub
   App token between continuation runs, and stopped zero-progress scans from

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -473,8 +473,10 @@ candidate mix by quality bucket in the status detail. Buckets such as
 implemented-on-main, duplicate/superseded, needs PR close proof,
 aging/low-signal (including stalled-unproven and abandoned PRs),
 policy-sensitive, and retry-after-guard-skip are
-operator-facing telemetry only; they do not change candidate eligibility, close
-limits, live-state checks, or policy gates.
+operator-facing telemetry only; the bucket classification does not change close
+limits, live-state checks, or policy gates. Stalled-unproven and abandoned PR
+proposals are eligible for apply selection, where the executor re-checks their
+PR-only age, activity, proof, status, and human-engagement gates before closing.
 
 Apply and comment-sync Actions run titles include the target repository. Before
 dispatching a default cursor-based apply continuation, the workflow checks

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -1091,6 +1091,7 @@ function selectedProposedItemCandidates(
   if (!fs.existsSync(itemsDir)) return [];
 
   const allowedReasons = new Set([
+    "abandoned_pr",
     "cannot_reproduce",
     "clawhub",
     "duplicate_or_superseded",
@@ -1099,10 +1100,10 @@ function selectedProposedItemCandidates(
     "low_signal_unmergeable_pr",
     "mostly_implemented_on_main",
     "not_actionable_in_repo",
+    "stalled_unproven_pr",
     "stale_insufficient_info",
     "unconfirmed_product_direction",
   ]);
-  const qualitySummaryOnlyReasons = new Set(["abandoned_pr", "stalled_unproven_pr"]);
   const allowedCloseReasons =
     options.applyCloseReasons === "all"
       ? null
@@ -1135,10 +1136,7 @@ function selectedProposedItemCandidates(
         decision === "close" &&
         confidence === "high" &&
         isSelectableCloseAction(action, reason) &&
-        (allowedForTarget(options.targetRepo, type, reason, allowedReasons) ||
-          (selection === "quality-summary" &&
-            type === "pull_request" &&
-            qualitySummaryOnlyReasons.has(reason))) &&
+        allowedForTarget(options.targetRepo, type, reason, allowedReasons) &&
         (!allowedCloseReasons || allowedCloseReasons.has(reason));
       const selectablePromotion =
         decision === "keep_open" &&
@@ -1871,6 +1869,8 @@ function allowedForTarget(
   if (type === "pull_request" && reason === "stale_insufficient_info") return false;
   if (type !== "pull_request" && reason === "mostly_implemented_on_main") return false;
   if (type !== "pull_request" && reason === "low_signal_unmergeable_pr") return false;
+  if (type !== "pull_request" && (reason === "abandoned_pr" || reason === "stalled_unproven_pr"))
+    return false;
   return allowedReasons.has(reason);
 }
 

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -1335,6 +1335,8 @@ test("workflow utilities summarize proposed close candidate quality buckets", ()
   );
   writeProposedRecord(root, 11, "pull_request", "proposed_close", "stalled_unproven_pr", oldDate);
   writeProposedRecord(root, 12, "pull_request", "proposed_close", "abandoned_pr", oldDate);
+  writeProposedRecord(root, 13, "issue", "proposed_close", "stalled_unproven_pr", oldDate);
+  writeProposedRecord(root, 14, "issue", "proposed_close", "abandoned_pr", oldDate);
 
   const summary = withCwd(root, () =>
     proposedItemQualitySummary({
@@ -1359,7 +1361,7 @@ test("workflow utilities summarize proposed close candidate quality buckets", ()
   );
 
   assert.equal(summary.total, 8);
-  assert.deepEqual(selected, [5, 6, 7, 8, 9, 10]);
+  assert.deepEqual(selected, [5, 6, 7, 8, 9, 10, 11, 12]);
   assert.equal(
     summary.summary,
     "1 implemented-on-main, 1 duplicate/superseded, 1 needs PR close proof, 3 aging/low-signal, 1 policy-sensitive, 1 retry after guard skip",


### PR DESCRIPTION
## What

Make scheduled apply select the two PR-only close reasons added by https://github.com/openclaw/clawsweeper/pull/403:

- `stalled_unproven_pr`
- `abandoned_pr`

The selector still rejects these reasons for issues. Apply still re-fetches live GitHub state and enforces all existing age, activity, proof, status, label, authorship, snapshot, and human-engagement gates before a close.

## Why

The executor and telemetry understood both reasons, but normal `proposed-item-numbers` selection excluded them. https://github.com/openclaw/clawsweeper/pull/402 added them only to the quality-summary view, so scheduled apply could report these candidates without ever processing them.

## Proof

- Focused workflow utility tests: 34 passed.
- Stalled-PR live-gate dry-run tests: 8 passed.
- `pnpm run check`: green; 655 unit tests, 617 repair tests, 1,272 full-coverage tests; changed coverage 100% lines / 89.17% branches / 100% functions; repository coverage 77.00% lines / 71.00% branches / 84.27% functions.
- GPT-5.5 AutoReview after the review fix: no actionable findings; patch correct, confidence 0.86.

### Real selector transcript

I built the branch and ran the production workflow utility against a temporary records directory containing exactly four high-confidence `proposed_close` records:

- PR 101: `stalled_unproven_pr`
- PR 102: `abandoned_pr`
- issue 201: `stalled_unproven_pr`
- issue 202: `abandoned_pr`

No GitHub mutation or mock `gh` process was involved.

```text
$ node dist/repair/workflow-utils.js proposed-item-numbers --target-repo openclaw/openclaw --apply-kind all --apply-close-reasons all --min-age-days 0
101,102

$ node dist/repair/workflow-utils.js proposed-item-numbers --target-repo openclaw/openclaw --apply-kind pull_request --apply-close-reasons stalled_unproven_pr,abandoned_pr --min-age-days 0
101,102

$ node dist/repair/workflow-utils.js proposed-item-numbers --target-repo openclaw/openclaw --apply-kind issue --apply-close-reasons stalled_unproven_pr,abandoned_pr --min-age-days 0
<empty>

$ node dist/repair/workflow-utils.js proposed-item-quality-summary --target-repo openclaw/openclaw --apply-kind all --apply-close-reasons all --min-age-days 0
candidate_quality_total=2
candidate_quality_summary=2 aging/low-signal
```

## Risk

Medium operational impact, narrow code change. This intentionally admits previously unreachable PR close proposals to scheduled apply. The mutation boundary is unchanged and remains fail-closed on missing or stale live evidence.
