### PR TITLE
fix: prioritize confirmed apply candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Prioritized confirmed close proposals ahead of speculative live promotion probes so expensive no-op promotion scans cannot starve ready OpenClaw closures.
 - Split apply workflow helpers out of the oversized inline expression so GitHub can validate and start sweep runs again.
 - Bounded apply-existing checkpoints to five fresh closes, renewed the GitHub
   App token between continuation runs, and stopped zero-progress scans from

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -899,8 +899,7 @@ function applyCycleSummary(options: {
       estimated_full_cycle_windows: null,
       estimated_full_cycle_minutes: null,
       scheduled_interval_minutes: cadence,
-      label:
-        "Cycle estimate is unavailable because the apply-ready candidate count was not recorded.",
+      label: "Cycle estimate is unavailable because the close-candidate count was not recorded.",
     };
   }
   if (options.candidateCount === 0) {
@@ -911,7 +910,7 @@ function applyCycleSummary(options: {
       estimated_full_cycle_windows: 0,
       estimated_full_cycle_minutes: 0,
       scheduled_interval_minutes: cadence,
-      label: "No apply-ready close candidates are waiting in this lane.",
+      label: "No confirmed close proposals or live promotion probes are waiting in this lane.",
     };
   }
   if (!windowSize) {
@@ -945,7 +944,7 @@ function cycleLabel(
   minutes: number | null,
   cadence: number | null,
 ): string {
-  const base = `${candidateCount} apply-ready close candidates at ${windowSize} records per latest cursor advance: about ${windows} window${windows === 1 ? "" : "s"}`;
+  const base = `${candidateCount} close candidates (confirmed proposals plus live promotion probes) at ${windowSize} records per latest cursor advance: about ${windows} window${windows === 1 ? "" : "s"}`;
   if (!minutes || !cadence) return `${base}.`;
   return `${base}; scheduled cadence alone would take roughly ${durationLabel(minutes)} at ${cadence}-minute intervals, while successful windows can continue sooner.`;
 }
@@ -1057,6 +1056,7 @@ type ProposedItemCandidate = {
   kind: string;
   closeReason: string;
   action: string;
+  stage: "confirmed_close" | "promotion_probe";
   qualityBucket: ProposedItemQualityBucket;
 };
 
@@ -1064,6 +1064,7 @@ type ProposedItemQualityBucket =
   | "ready_implemented"
   | "duplicate_or_superseded"
   | "needs_pr_close_coverage"
+  | "promotion_probe"
   | "aging_or_low_signal"
   | "policy_sensitive"
   | "retry_after_guard_skip"
@@ -1118,7 +1119,7 @@ function selectedProposedItemCandidates(
       ? options.minAgeDays * 24 * 60 * 60 * 1000
       : options.minAgeMinutes * 60 * 1000;
 
-  const candidates = fs
+  const candidates: ProposedItemCandidate[] = fs
     .readdirSync(itemsDir)
     .filter((name) => /(?:^|[a-z0-9-]-)\d+\.md$/.test(name))
     .flatMap((name) => {
@@ -1174,10 +1175,12 @@ function selectedProposedItemCandidates(
           kind: type,
           closeReason: candidateCloseReason,
           action,
+          stage: selectablePromotion ? ("promotion_probe" as const) : ("confirmed_close" as const),
           qualityBucket: proposedItemQualityBucket({
             action,
             closeReason: candidateCloseReason,
             prCloseCoverageProofCanRun,
+            promotionProbe: selectablePromotion,
           }),
         },
       ];
@@ -1185,16 +1188,25 @@ function selectedProposedItemCandidates(
     .sort((left, right) => left.number - right.number);
   const batchSize = options.batchSize ?? null;
   if (!batchSize || batchSize <= 0) return candidates;
-  const sorted = [...candidates].sort(compareApplyCursorCandidate);
   const cursor = options.cursorPath ? readApplyCursor(options.cursorPath) : null;
-  if (!cursor) return sorted.slice(0, batchSize);
-  const afterCursor = sorted.filter(
-    (candidate) => compareCandidateToApplyCursor(candidate, cursor) > 0,
-  );
-  return [
-    ...afterCursor,
-    ...sorted.filter((candidate) => compareCandidateToApplyCursor(candidate, cursor) <= 0),
-  ].slice(0, batchSize);
+  const rotate = (stage: ProposedItemCandidate["stage"]): ProposedItemCandidate[] => {
+    const sorted = candidates
+      .filter((candidate) => candidate.stage === stage)
+      .sort(compareApplyCursorCandidate);
+    if (!cursor) return sorted;
+    const afterCursor = sorted.filter(
+      (candidate) => compareCandidateToApplyCursor(candidate, cursor) > 0,
+    );
+    return [
+      ...afterCursor,
+      ...sorted.filter((candidate) => compareCandidateToApplyCursor(candidate, cursor) <= 0),
+    ];
+  };
+
+  // Confirmed close proposals have already passed review eligibility. Keep
+  // speculative keep-open promotions as bounded backfill so their live graph
+  // hydration cannot consume an entire apply window ahead of real proposals.
+  return [...rotate("confirmed_close"), ...rotate("promotion_probe")].slice(0, batchSize);
 }
 
 export function proposedItemQualitySummary(
@@ -1232,6 +1244,7 @@ const QUALITY_BUCKET_ORDER: ProposedItemQualityBucket[] = [
   "ready_implemented",
   "duplicate_or_superseded",
   "needs_pr_close_coverage",
+  "promotion_probe",
   "aging_or_low_signal",
   "policy_sensitive",
   "retry_after_guard_skip",
@@ -1253,6 +1266,10 @@ const QUALITY_BUCKET_METADATA: Record<
   needs_pr_close_coverage: {
     label: "needs PR close proof",
     nextStep: "Run or reuse close-coverage proof before closing the PR.",
+  },
+  promotion_probe: {
+    label: "needs live promotion check",
+    nextStep: "Backfill after confirmed closes and promote only if live safety checks still pass.",
   },
   aging_or_low_signal: {
     label: "aging/low-signal",
@@ -1276,7 +1293,9 @@ function proposedItemQualityBucket(options: {
   action: string;
   closeReason: string;
   prCloseCoverageProofCanRun: boolean;
+  promotionProbe: boolean;
 }): ProposedItemQualityBucket {
+  if (options.promotionProbe) return "promotion_probe";
   if (options.prCloseCoverageProofCanRun) return "needs_pr_close_coverage";
   if (options.closeReason === "unconfirmed_product_direction") return "policy_sensitive";
   if (

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -1574,7 +1574,7 @@ test("dashboard exposes apply health from sweep status without broad scans", asy
         estimated_full_cycle_minutes: null,
         scheduled_interval_minutes: null,
         label:
-          "1200 apply-ready close candidates at 300 records per latest cursor advance: about 4 windows.",
+          "1200 close candidates (confirmed proposals plus live promotion probes) at 300 records per latest cursor advance: about 4 windows.",
       },
       attention_reasons: ["cursor_required_but_missing_after_full_window"],
       cursor: null,

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -376,7 +376,7 @@ test("workflow utilities summarize apply health with skip buckets and cursor", (
     estimated_full_cycle_minutes: 45,
     scheduled_interval_minutes: 15,
     label:
-      "12 apply-ready close candidates at 4 records per latest cursor advance: about 3 windows; scheduled cadence alone would take roughly 45 min at 15-minute intervals, while successful windows can continue sooner.",
+      "12 close candidates (confirmed proposals plus live promotion probes) at 4 records per latest cursor advance: about 3 windows; scheduled cadence alone would take roughly 45 min at 15-minute intervals, while successful windows can continue sooner.",
   });
   assert.equal(summary.cursor?.next_after_number, 40);
 });
@@ -1602,6 +1602,65 @@ test("workflow utilities rotate bounded apply candidate batches by apply cursor"
   assert.deepEqual(
     withCwd(root, () => proposedItemNumbers(options)),
     [20, 30],
+  );
+});
+
+test("workflow utilities backfill promotion probes after confirmed close proposals", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const oldDate = "2024-01-01T00:00:00Z";
+  const cursorPath = path.join(root, "results/apply-cursors/openclaw-openclaw.json");
+  writeProposedRecord(root, 30, "issue", "proposed_close", "implemented_on_main", oldDate, {
+    applyCheckedAt: "2026-01-01T00:00:00Z",
+  });
+  for (const [number, applyCheckedAt] of [
+    [10, "2026-01-02T00:00:00Z"],
+    [20, "2026-01-04T00:00:00Z"],
+  ]) {
+    write(
+      path.join(root, `records/openclaw-openclaw/items/openclaw-openclaw-${number}.md`),
+      [
+        "---",
+        "repository: openclaw/openclaw",
+        "type: pull_request",
+        "decision: keep_open",
+        "review_status: complete",
+        "local_checkout_access: verified",
+        "action_taken: kept_open",
+        "close_reason: none",
+        `item_created_at: ${oldDate}`,
+        `apply_checked_at: ${applyCheckedAt}`,
+        `work_cluster_refs: ${JSON.stringify(["Superseded by #400"])}`,
+        "---",
+        "",
+      ].join("\n"),
+    );
+  }
+  write(
+    cursorPath,
+    JSON.stringify({ next_after_number: 10, next_after_apply_checked_at: "2026-01-02T00:00:00Z" }),
+  );
+  const options = {
+    targetRepo: "openclaw/openclaw",
+    applyKind: "all",
+    applyCloseReasons: "all",
+    staleMinAgeDays: 60,
+    minAgeDays: 0,
+    minAgeMinutes: null,
+    batchSize: 2,
+    cursorPath,
+  };
+
+  assert.deepEqual(
+    withCwd(root, () => proposedItemNumbers(options)),
+    [30, 20],
+  );
+  const summary = withCwd(root, () => proposedItemQualitySummary(options));
+  assert.deepEqual(
+    summary.buckets.map((bucket) => [bucket.bucket, bucket.count]),
+    [
+      ["ready_implemented", 1],
+      ["promotion_probe", 1],
+    ],
   );
 });
 


### PR DESCRIPTION
## What changed

- Select confirmed close proposals before speculative keep-open promotion probes.
- Preserve cursor rotation inside both stages; use probes only to fill remaining batch capacity.
- Report promotion probes separately so dashboard apply-ready telemetry is honest.

## Why

Production apply run https://github.com/openclaw/clawsweeper/actions/runs/28733219874 spent about 43 minutes hydrating 300 speculative promotion probes and closed nothing while confirmed proposals remained later in the cursor cycle.

This changes scheduling only. Live freshness, coverage proof, protected-label, serialization, and fail-closed mutation gates remain unchanged. Worker capacity remains 128.

## Proof

- `pnpm run check`
  - 668 core tests
  - 618 repair tests
  - 1,286 full-coverage tests
  - build, lint, coverage thresholds, and formatting green
- AutoReview: no findings

