### PR TITLE
perf: skip stale close proofs early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Skipped stale PR close reports before expensive close-coverage proof when a newer durable review already makes the mutation unsafe.
 - Prioritized confirmed close proposals ahead of speculative live promotion probes so expensive no-op promotion scans cannot starve ready OpenClaw closures.
 - Split apply workflow helpers out of the oversized inline expression so GitHub can validate and start sweep runs again.
 - Bounded apply-existing checkpoints to five fresh closes, renewed the GitHub

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -18485,6 +18485,24 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
     if (existingReviewCommentUpdatedAt) {
       allowedSelfMutationUpdatedAts.add(existingReviewCommentUpdatedAt);
     }
+    const staleReviewCommentReason = staleReviewCommentSyncReason(
+      markdown,
+      existingReviewComment,
+      number,
+    );
+    if (state === "open" && isCloseProposal && staleReviewCommentReason) {
+      markdown = replaceFrontMatterValue(markdown, "apply_checked_at", new Date().toISOString());
+      if (!dryRun) writeReportMarkdown(path, markdown);
+      results.push({
+        number,
+        action: "skipped_stale_review_comment_sync",
+        reason: staleReviewCommentReason,
+      });
+      processedCount += 1;
+      maybeLogProgress(`skipped stale review comment sync #${number}`);
+      if (processedCount >= processedLimit) break;
+      continue;
+    }
     const updatedSinceReview = Boolean(storedUpdatedAt && item.updatedAt !== storedUpdatedAt);
     const reviewCommentOnlyUpdate = item.updatedAt === commentUpdatedAt(existingReviewComment);
     const labelSyncFreshEnough = (): boolean => {
@@ -19118,9 +19136,7 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       ? `synced advisory issue labels #${number}`
       : `synced ClawSweeper labels #${number}`;
     if (needsReviewCommentSync) {
-      const staleSyncReason = needsReviewCommentBodySync
-        ? staleReviewCommentSyncReason(markdown, existingReviewComment, number)
-        : null;
+      const staleSyncReason = needsReviewCommentBodySync ? staleReviewCommentReason : null;
       if (staleSyncReason) {
         markdown = replaceFrontMatterValue(markdown, "apply_checked_at", new Date().toISOString());
         if (!dryRun) writeReportMarkdown(path, markdown);

--- a/test/apply-pr-coverage-proof-close.test.ts
+++ b/test/apply-pr-coverage-proof-close.test.ts
@@ -5,6 +5,7 @@ import test from "node:test";
 
 import {
   lowSignalCloseReport,
+  markedReviewCommentForTest,
   promotionGhMock,
   reportWithSyncedReviewComment,
   runApplyDecisionsForTest,
@@ -12,6 +13,97 @@ import {
   withMockCodexProof,
   withMockGh,
 } from "./helpers.ts";
+
+test("apply-decisions skips stale close reports before duplicate PR coverage proof", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const proofLogPath = join(root, "proof.log");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const synced = reportWithSyncedReviewComment(
+      lowSignalCloseReport({
+        number: 353,
+        title: "Stale duplicate close report",
+        reviewed_at: "2026-05-01T00:00:00Z",
+        close_reason: "duplicate_or_superseded",
+        work_cluster_refs: JSON.stringify([
+          "Superseded by https://github.com/openclaw/openclaw/pull/400",
+        ]),
+      }).replace(
+        "Closing this PR because the branch is not a useful landing base.",
+        "Closing this PR as superseded by https://github.com/openclaw/openclaw/pull/400.",
+      ),
+      353,
+      "duplicate_or_superseded",
+    );
+    writeFileSync(join(itemsDir, "353.md"), synced.report, "utf8");
+    const newerComment = markedReviewCommentForTest(
+      353,
+      [
+        "Codex review: ready for maintainer look.",
+        "",
+        "<!-- clawsweeper-verdict:needs-human item=353 sha=head-sha confidence=high updated_at=2026-05-01T00:05:00Z reviewed_at=2026-05-01T00:10:00Z source_revision=new-source -->",
+      ].join("\n"),
+    );
+
+    withMockGh(
+      root,
+      promotionGhMock({
+        number: 353,
+        title: "Stale duplicate close report",
+        comment: newerComment,
+        linkedPulls: {
+          400: {
+            number: 400,
+            title: "Canonical replacement",
+            html_url: "https://github.com/openclaw/openclaw/pull/400",
+            state: "closed",
+            merged_at: "2026-05-02T00:00:00Z",
+            body: "Carries the replacement behavior.",
+            comments: [],
+            labels: [],
+          },
+        },
+      }),
+      () => {
+        withMockCodexProof(
+          root,
+          {
+            type: "decision",
+            decision: "covered",
+            reason: "The replacement carries the source behavior.",
+            invocationLogPath: proofLogPath,
+          },
+          () => {
+            runApplyDecisionsForTest({
+              itemsDir,
+              closedDir,
+              plansDir,
+              reportPath,
+              extraArgs: ["--target-repo", "openclaw/openclaw", "--apply-kind", "all"],
+            });
+          },
+        );
+      },
+    );
+
+    assert.equal(existsSync(proofLogPath), false);
+    assert.deepEqual(JSON.parse(readFileSync(reportPath, "utf8")), [
+      {
+        number: 353,
+        action: "skipped_stale_review_comment_sync",
+        reason:
+          "live durable review comment is newer than the local report: comment reviewed_at=2026-05-01T00:10:00Z, report reviewed_at=2026-05-01T00:00:00Z",
+      },
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
 
 test("apply-decisions checks duplicate PR coverage proof before syncing corrected review comments", () => {
   const root = mkdtempSync(tmpPrefix);


### PR DESCRIPTION
## Summary

- reject open PR close reports as soon as a newer trusted durable review makes them stale
- skip expensive duplicate/superseded close-coverage proof for reports that must fail closed anyway
- preserve already-closed archival and the existing post-proof freshness checks

## Why

Production run https://github.com/openclaw/clawsweeper/actions/runs/28733844377 spent about 41 minutes processing a 300-item window. It closed seven items quickly, then recorded 39 `skipped_stale_review_comment_sync` results only after entering the expensive close-proof path. A newer durable review already made those mutations unsafe, so the proof work could not change the outcome.

## Proof

- `pnpm run check`
- focused close-coverage regression: stale report exits without invoking Codex proof
- 669 core tests, 618 repair tests, changed coverage and formatting green
- AutoReview: no actionable findings

## Safety

This only moves an existing fail-closed stale-review check earlier for open close proposals. Already-closed items still archive idempotently, valid current reports follow the same coverage and mutation gates, and live state is still fetched before the check.
