### PR TITLE
fix: checkpoint malformed maintainer decisions during apply

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -18047,6 +18047,8 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
       const reason = `invalid maintainer_decision: ${detail}`;
+      markdown = replaceFrontMatterValue(markdown, "apply_checked_at", new Date().toISOString());
+      if (!dryRun) writeFileSync(path, markdown, "utf8");
       results.push({ number, action: "kept_open", reason });
       processedCount += 1;
       maybeLogProgress(`skipped #${number}: ${reason}`);

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -446,20 +446,53 @@ test("apply-decisions makes no GitHub mutation for malformed maintainer decision
       implementedCloseReport({ maintainer_decision: "{" }),
       "utf8",
     );
+    writeFileSync(
+      join(itemsDir, "322.md"),
+      implementedCloseReport({ number: 322, maintainer_decision: "{" }),
+      "utf8",
+    );
 
     const ghMock = `
 console.error("malformed maintainer decision reached GitHub");
 process.exit(1);
 `;
     withMockGh(root, ghMock, () => {
-      runApplyDecisionsForTest({ itemsDir, closedDir, plansDir, reportPath });
+      runApplyDecisionsForTest({
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: ["--processed-limit", "1"],
+      });
     });
 
     assert.equal(existsSync(join(itemsDir, "321.md")), true);
     assert.equal(existsSync(join(closedDir, "321.md")), false);
+    const firstUpdatedReport = readFileSync(join(itemsDir, "321.md"), "utf8");
+    assert.match(firstUpdatedReport, /^apply_checked_at: /m);
+    assert.doesNotMatch(readFileSync(join(itemsDir, "322.md"), "utf8"), /^apply_checked_at: /m);
     assert.deepEqual(JSON.parse(readFileSync(reportPath, "utf8")), [
       {
         number: 321,
+        action: "kept_open",
+        reason: "invalid maintainer_decision: maintainer_decision must contain valid JSON",
+      },
+    ]);
+
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: ["--processed-limit", "1"],
+      });
+    });
+
+    assert.match(readFileSync(join(itemsDir, "322.md"), "utf8"), /^apply_checked_at: /m);
+    assert.deepEqual(JSON.parse(readFileSync(reportPath, "utf8")), [
+      {
+        number: 322,
         action: "kept_open",
         reason: "invalid maintainer_decision: maintainer_decision must contain valid JSON",
       },


### PR DESCRIPTION
﻿## Summary

- Stamp malformed `maintainer_decision` apply records with `apply_checked_at` before recording the kept-open result.
- Preserve the no-GitHub-mutation behavior for malformed decision frontmatter.
- Strengthen the regression test so two malformed records with `--processed-limit 1` advance from the first record to the second on the next apply run.

## Problem

The decision-packet rewrite in #358 added a `maintainer_decision` parse step in the apply loop. When frontmatter contained malformed maintainer decision JSON, the catch path returned a kept-open result and advanced `processedCount`, but did not persist `apply_checked_at`. That let the same malformed report keep sorting as unchecked and repeatedly consume bounded apply queue slots.

## Implementation

- In the malformed `maintainer_decision` catch path, write `apply_checked_at` directly to the report markdown when not in dry-run mode.
- Avoid `writeReportMarkdown` in this specific path because decision-packet sync reparses the malformed frontmatter and would fail again.
- Leave the result action and reason as `kept_open` / `invalid maintainer_decision: ...` and do not call GitHub.

## Validation

- `pnpm run build:all` passed.
- `node --test test\clawsweeper.test.ts` passed: 69 tests.
- `pnpm run lint:src` passed.
- `pnpm run lint:scripts` passed.
- `pnpm exec oxfmt --check src\clawsweeper.ts test\clawsweeper.test.ts` passed.
- `git diff --check` passed.
- `$env:Path = 'C:\msys64\usr\bin;' + $env:Path; node --test --test-skip-pattern "dispatch receipt gate|--local-range" test\*.test.ts` passed: 663 tests, 662 pass, 1 skipped.
- Live CLI proof below passed with `node dist/clawsweeper.js apply-decisions` against two malformed reports and a fatal mock `gh`.

## Proof

The updated malformed-decision test creates `321.md` and `322.md`, both with invalid `maintainer_decision` JSON, and runs apply twice with `--processed-limit 1` while the mock `gh` exits if called. The first run stamps `321.md` with `apply_checked_at`; the second run processes `322.md`, proving the malformed first record no longer monopolizes the bounded apply slot and no GitHub mutation is attempted.

Live apply-run proof from a local built checkout, with temp paths redacted:

```text
Proof root: $PROOF_ROOT
Command: node dist/clawsweeper.js apply-decisions --target-repo openclaw/clawsweeper --items-dir $PROOF_ROOT/items --closed-dir $PROOF_ROOT/closed --plans-dir $PROOF_ROOT/plans --report-path $PROOF_ROOT/apply-report.json --processed-limit 1 --min-age-days 0 --close-delay-ms 0
GitHub mock: GH_BIN=node, GH_BIN_ARGS=[$PROOF_ROOT/bin/gh.js]; mock appends to $PROOF_ROOT/gh-called.log and exits 1 if called.

Run 1 output:
[apply] 2026-07-05T11:27:58.263Z starting apply: files=2 dry_run=false apply_kind=issue min_age=0 days apply_close_reasons=all stale_min_age_days=60 close_delay_ms=0 sync_comments_only=false comment_sync_min_age_days=0 max_runtime_ms=0 item_numbers=all closed=0/20 processed=0/1 counts={}
[apply] 2026-07-05T11:27:58.268Z finished apply closed=0/20 processed=1/1 counts={"kept_open":1}
[
  {
    "number": 321,
    "action": "kept_open",
    "reason": "invalid maintainer_decision: maintainer_decision must contain valid JSON"
  }
]

Run 1 apply-report.json:
[
  {
    "number": 321,
    "action": "kept_open",
    "reason": "invalid maintainer_decision: maintainer_decision must contain valid JSON"
  }
]
Run 1 checkpoints:
321: apply_checked_at: 2026-07-05T11:27:58.267Z
322: <none>
Run 1 GitHub mock called: False

Run 2 output:
[apply] 2026-07-05T11:27:58.385Z starting apply: files=2 dry_run=false apply_kind=issue min_age=0 days apply_close_reasons=all stale_min_age_days=60 close_delay_ms=0 sync_comments_only=false comment_sync_min_age_days=0 max_runtime_ms=0 item_numbers=all closed=0/20 processed=0/1 counts={}
[apply] 2026-07-05T11:27:58.388Z finished apply closed=0/20 processed=1/1 counts={"kept_open":1}
[
  {
    "number": 322,
    "action": "kept_open",
    "reason": "invalid maintainer_decision: maintainer_decision must contain valid JSON"
  }
]

Run 2 apply-report.json:
[
  {
    "number": 322,
    "action": "kept_open",
    "reason": "invalid maintainer_decision: maintainer_decision must contain valid JSON"
  }
]
Run 2 checkpoints:
321: apply_checked_at: 2026-07-05T11:27:58.267Z
322: apply_checked_at: 2026-07-05T11:27:58.387Z
Run 2 GitHub mock called: False
```

I also attempted unfiltered `pnpm run test:unit`. On this Windows host it fails in environment-sensitive tests unrelated to this change: `dispatch-receipt-owner` needs `jq` in the shell path, and two `local-range-review` tests do not produce their fake Codex marker files. The skip-pattern run above covers the rest of the top-level suite.

## Risks / Rollout

- Low risk: the change is limited to the malformed maintainer-decision validation catch path.
- No workflow files are touched.
- Dry-run still avoids writing report markdown.

## Links

- Related: #358
- Follow-up note: CSW-001 malformed maintainer-decision apply bookkeeping

## Codex Review Closeout

- Command: `C:\msys64\usr\bin\bash.exe C:/Users/marti/.codex/skills/codex-review/scripts/codex-review --mode branch --base origin/main --codex-bin C:/Users/marti/AppData/Local/Temp/codex-fast-wrapper.sh --output C:\Users\marti\AppData\Local\Temp\codex-review-pr416.txt`
- Nested review target: `codex -c 'service_tier="fast"' review --base origin/main` from `codex/fix-maintainer-decision-apply-checkpoint` against actual PR base `origin/main` (`44d3b656300f647a20e1c82a48e84f8ad24225f9`). The wrapper only corrected the local CLI config's rejected `service_tier=default`; model remained `gpt-5.5` with `xhigh` reasoning.
- Result: `codex-review clean: no accepted/actionable findings reported`. Codex review summary: malformed decision records now stamp `apply_checked_at`, processed-limit runs can advance to later items, and the focused test covers that rotation.
- Accepted findings: none.
- Rejected findings: none.
- Rerun validation after review: `pnpm run build:all` passed; `node --test test\clawsweeper.test.ts` passed (69 tests); direct `node dist/clawsweeper.js apply-decisions ... --processed-limit 1 --min-age-days 0 --close-delay-ms 0` proof passed twice. The proof showed run 1 processed/stamped only item 321, run 2 processed/stamped item 322, and the fatal `gh` mock was not called.
