### PR TITLE
fix: skip stale label sync for newer review comments

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -16058,9 +16058,10 @@ function commentBody(comment: Record<string, unknown> | undefined): string | und
   return typeof body === "string" ? body : undefined;
 }
 
-function newestReviewMarkerReviewedAt(
+function newestReviewMarkerAttribute(
   comment: Record<string, unknown> | undefined,
   number: number,
+  attribute: "reviewed_at" | "sha",
 ): string | undefined {
   if (!canPatchReviewComment(comment)) return undefined;
   const body = commentBody(comment);
@@ -16075,25 +16076,33 @@ function newestReviewMarkerReviewedAt(
     .match(/(?:<!--[\s\S]*?-->\s*)+$/)?.[0];
   if (!markerBlock) return undefined;
   const markerPattern = /<!--\s+clawsweeper-verdict:[^\s>]+\b([^>]*)-->/g;
-  let lastReviewedAt: string | undefined;
+  let lastValue: string | undefined;
   for (const match of markerBlock.matchAll(markerPattern)) {
     const attributes = match[1] ?? "";
     if (!new RegExp(`\\bitem=${number}\\b`).test(attributes)) continue;
-    const reviewedAt = attributes.match(/\breviewed_at=([^\s>]+)/)?.[1];
-    if (!reviewedAt || reviewedAt === "unknown") continue;
-    lastReviewedAt = reviewedAt;
+    const value = attributes.match(new RegExp(`\\b${attribute}=([^\\s>]+)`))?.[1];
+    if (!value || value === "unknown") continue;
+    lastValue = value;
   }
-  return lastReviewedAt;
+  return lastValue;
 }
 
 function staleReviewCommentSyncReason(
   markdown: string,
   existingReviewComment: Record<string, unknown> | undefined,
   number: number,
+  context: ItemContext,
 ): string | null {
   if (frontMatterValue(markdown, "type") !== "pull_request") return null;
   // Comment updated_at can move for command/status edits; only review markers prove verdict freshness.
-  const liveReviewedAt = newestReviewMarkerReviewedAt(existingReviewComment, number);
+  const liveReviewedAt = newestReviewMarkerAttribute(existingReviewComment, number, "reviewed_at");
+  const liveReviewedSha = newestReviewMarkerAttribute(existingReviewComment, number, "sha");
+  const currentHeadSha = pullHeadShaFromContext(context);
+  const reportHeadSha = pullHeadShaFromReport(markdown);
+  if (!liveReviewedSha || !currentHeadSha) return null;
+  // Trust a newer comment when it matches the live head, or when the live API still reports the
+  // report's head and may be lagging the comment. Otherwise the newer comment is stale too.
+  if (liveReviewedSha !== currentHeadSha && currentHeadSha !== reportHeadSha) return null;
   const reportReviewedAt = frontMatterValue(markdown, "reviewed_at");
   const liveReviewedAtMs = timestampMs(liveReviewedAt);
   const reportReviewedAtMs = timestampMs(reportReviewedAt);
@@ -18491,6 +18500,7 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       markdown,
       existingReviewComment,
       number,
+      currentItemContext(),
     );
     if (state === "open" && staleReviewCommentReason) {
       markdown = replaceFrontMatterValue(markdown, "apply_checked_at", new Date().toISOString());

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -18492,7 +18492,7 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       existingReviewComment,
       number,
     );
-    if (state === "open" && isCloseProposal && staleReviewCommentReason) {
+    if (state === "open" && staleReviewCommentReason) {
       markdown = replaceFrontMatterValue(markdown, "apply_checked_at", new Date().toISOString());
       if (!dryRun) writeReportMarkdown(path, markdown);
       results.push({

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -18496,12 +18496,15 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
     if (existingReviewCommentUpdatedAt) {
       allowedSelfMutationUpdatedAts.add(existingReviewCommentUpdatedAt);
     }
-    const staleReviewCommentReason = staleReviewCommentSyncReason(
-      markdown,
-      existingReviewComment,
-      number,
-      currentItemContext(),
-    );
+    const staleReviewCommentReason =
+      item.kind === "pull_request"
+        ? staleReviewCommentSyncReason(
+            markdown,
+            existingReviewComment,
+            number,
+            currentItemContext(),
+          )
+        : null;
     if (state === "open" && staleReviewCommentReason) {
       markdown = replaceFrontMatterValue(markdown, "apply_checked_at", new Date().toISOString());
       if (!dryRun) writeReportMarkdown(path, markdown);

--- a/test/apply-label-sync.test.ts
+++ b/test/apply-label-sync.test.ts
@@ -356,11 +356,15 @@ Full review comments:
 `;
     const synced = reportWithSyncedReviewComment(sourceReport, 74481);
     writeFileSync(itemPath, synced.report, "utf8");
+    const newerStaleHeadComment = synced.comment.replace(
+      /\breviewed_at=[^\s>]+/,
+      "reviewed_at=2026-05-20T00:00:00.000Z",
+    );
 
     const ghMock = `
 const { appendFileSync, readFileSync } = require("fs");
 const logPath = ${JSON.stringify(logPath)};
-const comment = ${JSON.stringify(synced.comment)};
+const comment = ${JSON.stringify(newerStaleHeadComment)};
 const rawArgs = process.argv.slice(2);
 const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
 appendFileSync(logPath, JSON.stringify(args) + "\\n");
@@ -461,7 +465,7 @@ if (args[0] === "api" && /\\/issues\\/74481$/.test(path)) {
     assert.match(patchedBody, /clawsweeper-review-history v=1 total=1/);
     assert.match(
       patchedBody,
-      /- reviewed 2026-05-19T20:00:00Z sha old-head :: needs maintainer review before merge\./,
+      /- reviewed 2026-05-20T00:00:00\.000Z sha old-head :: needs maintainer review before merge\./,
     );
     assert.doesNotMatch(patchedBody, /clawsweeper-verdict:/);
     const updatedReport = readFileSync(itemPath, "utf8");

--- a/test/apply-label-sync.test.ts
+++ b/test/apply-label-sync.test.ts
@@ -479,6 +479,188 @@ if (args[0] === "api" && /\\/issues\\/74481$/.test(path)) {
   }
 });
 
+test("apply-decisions skips stale label cleanup when the durable review comment is newer", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const logPath = join(root, "gh.log");
+    const itemPath = join(itemsDir, "74483.md");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const readyLabel = "status: \u{1F440} ready for maintainer look";
+    const mergeRiskLabel = "merge-risk: \u{1F6A8} message-delivery";
+    const staleLabels = [
+      "P1",
+      "rating: \u{1F99E} diamond lobster",
+      mergeRiskLabel,
+      readyLabel,
+      "proof: sufficient",
+    ];
+    writeFileSync(
+      itemPath,
+      `${reportFrontMatter({
+        repository: "openclaw/openclaw",
+        type: "pull_request",
+        number: "74483",
+        title: "Stale report with newer durable comment",
+        url: "https://github.com/openclaw/openclaw/pull/74483",
+        decision: "keep_open",
+        close_reason: "none",
+        confidence: "high",
+        action_taken: "kept_open",
+        review_status: "complete",
+        local_checkout_access: "verified",
+        author: "contributor",
+        author_association: "CONTRIBUTOR",
+        labels: JSON.stringify(staleLabels),
+        item_snapshot_hash: "snapshot-a",
+        item_updated_at: "2026-05-19T20:00:00Z",
+        reviewed_at: "2026-05-19T20:00:00.000Z",
+        pull_head_sha: "old-head",
+        merge_risk_labels: JSON.stringify([mergeRiskLabel]),
+      })}
+
+## Summary
+
+This stored report is stale because a later review already updated the durable comment.
+
+${realBehaviorProofReportSection()}
+
+${prRatingReportSection({ overallTier: "A", proofTier: "A", patchTier: "A" })}
+
+## Review Findings
+
+Overall correctness: patch is correct
+
+Overall confidence: 0.9
+
+Full review comments:
+
+- none
+`,
+      "utf8",
+    );
+
+    const newerComment = [
+      "Codex review: needs maintainer review before merge.",
+      "",
+      "<!-- clawsweeper-verdict:needs-human item=74483 sha=new-head confidence=high updated_at=2026-05-19T20:10:00Z reviewed_at=2026-05-20T00:00:00.000Z source_revision=new-source -->",
+      "<!-- clawsweeper-review item=74483 -->",
+    ].join("\n");
+    const ghMock = `
+const { appendFileSync, readFileSync } = require("fs");
+const logPath = ${JSON.stringify(logPath)};
+const newerComment = ${JSON.stringify(newerComment)};
+const staleLabels = ${JSON.stringify(staleLabels)};
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+appendFileSync(logPath, JSON.stringify(args) + "\\n");
+const path = args[1] || "";
+if (args[0] === "api" && /\\/issues\\/74483$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 74483,
+    title: "Stale report with newer durable comment",
+    html_url: "https://github.com/openclaw/openclaw/pull/74483",
+    created_at: "2026-05-19T19:00:00Z",
+    updated_at: "2026-05-19T20:10:00Z",
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "contributor" },
+    labels: staleLabels,
+    pull_request: {}
+  }));
+} else if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/74483\\/timeline(?:\\?|$)/.test(args[2] || "")) {
+  console.log("HTTP/2 200\\n\\n[]");
+} else if (args[0] === "api" && /\\/issues\\/74483\\/timeline(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/pulls\\/74483$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 74483,
+    html_url: "https://github.com/openclaw/openclaw/pull/74483",
+    state: "open",
+    changed_files: 1,
+    commits: 2,
+    review_comments: 0,
+    head: { sha: "new-head", ref: "branch", repo: { full_name: "fork/openclaw" } },
+    base: { sha: "base-sha", ref: "main", repo: { full_name: "openclaw/openclaw" } },
+    user: { login: "contributor" }
+  }));
+} else if (args[0] === "api" && /\\/pulls\\/74483\\/(files|commits|comments)(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/issues\\/74483\\/comments(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[
+    {
+      id: 987483,
+      html_url: "https://github.com/openclaw/openclaw/pull/74483#issuecomment-987483",
+      body: newerComment,
+      user: { login: "clawsweeper[bot]" },
+      created_at: "2026-05-20T00:00:00Z",
+      updated_at: "2026-05-20T00:00:00Z"
+    }
+  ]]));
+} else if (args[0] === "api" && /\\/issues\\/comments\\/987483$/.test(path)) {
+  const input = args[args.indexOf("--input") + 1];
+  appendFileSync(logPath, JSON.stringify(["patched-review-body", JSON.parse(readFileSync(input, "utf8")).body]) + "\\n");
+  console.log(JSON.stringify({
+    id: 987483,
+    html_url: "https://github.com/openclaw/openclaw/pull/74483#issuecomment-987483",
+    updated_at: "2026-05-20T00:01:00Z"
+  }));
+} else if (args[0] === "issue" && args[1] === "edit") {
+  console.log("");
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        targetRepo: "openclaw/openclaw",
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: ["--sync-comments-only", "--item-numbers", "74483"],
+      });
+    });
+
+    const calls = readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as string[]);
+    assert.deepEqual(
+      calls.filter((args) => args[0] === "issue" && args[1] === "edit"),
+      [],
+    );
+    assert.equal(
+      calls.some((args) => args[0] === "patched-review-body"),
+      false,
+    );
+    const updatedReport = readFileSync(itemPath, "utf8");
+    assert.ok(updatedReport.includes(`labels: ${JSON.stringify(staleLabels)}`));
+    const result = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+      number: number;
+      action: string;
+      reason: string;
+    }>;
+    assert.equal(result[0]?.number, 74483);
+    assert.equal(result[0]?.action, "skipped_stale_review_comment_sync");
+    assert.match(
+      result[0]?.reason ?? "",
+      /live durable review comment is newer than the local report/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("apply-decisions syncs fresh-head PR labels after a command-only re-review comment", () => {
   const root = mkdtempSync(tmpPrefix);
   try {


### PR DESCRIPTION
## Summary

- Prevent stale stored PR reports from removing ClawSweeper-owned PR readiness labels when the live durable review comment contains a newer review marker.
- Keep the existing stale-head cleanup behavior when the durable comment is not newer than the report.
- Add regression coverage for a stale report plus newer durable comment carrying `status: 👀 ready for maintainer look`.

## Problem

Live intake for openclaw/openclaw#97259 showed a persistent mismatch: the latest durable ClawSweeper comment still says the PR is ready for maintainer review, but the `status: 👀 ready for maintainer look` label is absent.

Evidence from GitHub on 2026-07-05:

- Latest ClawSweeper review comment: https://github.com/openclaw/openclaw/pull/97259#issuecomment-4818477795, updated 2026-07-04T21:34:33Z.
- That comment includes `Result: ready for maintainer review.` and a label justification for `status: 👀 ready for maintainer look`.
- Label timeline: ClawSweeper added `status: 👀 ready for maintainer look` at 2026-07-04T21:28:04Z, then removed it at 2026-07-05T01:43:37Z.
- Current live labels no longer include the ready label.
- Current relevant checks on the PR head are green, including latest `Real behavior proof` and `auto-response` checks.

State evidence:

- `origin/state:records/openclaw-openclaw/items/97259.md` is stale relative to the live durable comment: report `reviewed_at` is 2026-06-27T20:56:58.627Z and `pull_head_sha` is `da1a789...`, while the live comment marker is reviewed on 2026-07-04 for head `0a88f037...`.
- The state report records `labels_synced_at: 2026-07-05T01:43:37.636Z` and `labels: ["gateway","agents","size: L","extensions: qa-lab","P1"]`, matching the later label removal.
- The apply path already detects the newer durable comment through `staleReviewCommentSyncReason`, but only skipped early for close proposals. For keep-open PRs it could remove stale labels first and only later skip comment sync, creating the observed contradiction.

Related PR check:

- No open openclaw/clawsweeper PR already covers this branch/bug. The only open PR seen during intake was #416 on `codex/fix-maintainer-decision-apply-checkpoint`, which is unrelated apply checkpoint work.

## Implementation

- Broaden the existing `staleReviewCommentSyncReason` guard so open PR apply processing skips before any label mutation whenever the live durable review marker is newer than the local report.
- Add a regression test that models a stale report, a newer durable comment on the live head, and live ready/merge-risk/proof labels. The test asserts no `gh issue edit` label removal and no comment downgrade occur.

## Validation

Passed:

- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `node --test test/apply-label-sync.test.ts` (13/13 pass)
- `pnpm run lint:src`
- `pnpm run lint:scripts`
- `pnpm exec oxfmt --check src\clawsweeper.ts test\apply-label-sync.test.ts`
- `git diff --check`
- `pnpm run build:all`

Broader lane attempted:

- `pnpm run test:unit` ran 670 tests: 663 passed, 1 skipped, 6 failed due this Windows host environment.
- Four failures are `test/dispatch-receipt-owner.test.ts` invoking `bash`, which resolves through WSL and fails because this host's default WSL distro lacks `/bin/bash`.
- Two failures are `test/local-range-review.test.ts` expecting fake Codex shim output files that were not produced in this Windows run.
- The focused apply-label sync coverage passed both separately and inside this broader run.

## Proof

The regression test exercises the exact failure ordering:

1. Stored report has an old `pull_head_sha` and stale ClawSweeper-owned labels.
2. Live PR head is newer.
3. Existing durable ClawSweeper comment has a newer `clawsweeper-verdict` marker.
4. Apply returns `skipped_stale_review_comment_sync` before label mutation.
5. No `issue edit --remove-label` call is made and no stale review comment is patched over the newer durable comment.

This preserves the existing stale-head behavior when the durable comment is not newer; the adjacent existing test still removes stale labels and patches the comment to `Codex review: stale review; fresh review needed.`

## Docker-Backed Local Container Proof

I reran the focused regression and the apply replay inside Docker-backed Crabbox local-container, using the Playwright Linux image from the project proof instructions.

```text
COMMAND=C:\Users\marti\.local\bin\crabbox.exe run --provider local-container --local-container-image mcr.microsoft.com/playwright:v1.60.0-noble --local-container-memory 8g --no-hydrate --timing-json --script-stdin
PROVIDER=local-container
LEASE=cbx_53731180c485
SLUG=jade-shrimp
IMAGE=mcr.microsoft.com/playwright:v1.60.0-noble
EXIT_CODE=0
PROOF_TARGET=openclaw/openclaw#97259
PROOF_SHA=385a0791873321f6840afbb424a8962fec0f7f4d
NODE_VERSION=v24.15.0
PNPM_VERSION=10.33.2

CRABBOX_PHASE:install
pnpm install --frozen-lockfile

CRABBOX_PHASE:build
pnpm run build

CRABBOX_PHASE:focused_regression_test
node --test test/apply-label-sync.test.ts
RESULT=13 tests, 13 pass, 0 fail

CRABBOX_PHASE:apply_replay_97259
[apply] 2026-07-05T12:35:58.008Z starting apply: files=1 dry_run=false apply_kind=issue sync_comments_only=true item_numbers=97259
[apply] 2026-07-05T12:35:58.256Z finished apply closed=0/10 processed=1/1 counts={"skipped_stale_review_comment_sync":1}

APPLY_REPORT:
[
  {
    "number": 97259,
    "action": "skipped_stale_review_comment_sync",
    "reason": "live durable review comment is newer than the local report: comment reviewed_at=2026-07-04T21:34:33.000Z, report reviewed_at=2026-06-27T20:56:58.627Z"
  }
]

GH_CALLS:
["api","repos/openclaw/openclaw/issues/97259","--jq","{number,title,html_url,created_at,updated_at,closed_at,state,locked,active_lock_reason,author_association,user:{login:.user.login},labels:[.labels[].name],pull_request:(.pull_request // null)}"]
["api","repos/openclaw/openclaw/issues/97259"]
["api","repos/openclaw/openclaw/issues/97259/comments?per_page=100","--paginate","--slurp"]
["api","-i","repos/openclaw/openclaw/issues/97259/timeline?per_page=100&page=1"]
["api","repos/openclaw/openclaw/pulls/97259"]
["api","repos/openclaw/openclaw/pulls/97259/files?per_page=100&page=1"]
["api","repos/openclaw/openclaw/pulls/97259/commits?per_page=100&page=1"]
["api","repos/openclaw/openclaw/issues/97259/comments?per_page=100","--paginate","--slurp"]

ASSERT_ACTION=skipped_stale_review_comment_sync
ASSERT_MUTATION_CALLS=[]
ASSERT_LABELS_PRESERVED=labels: ["gateway","agents","size: L","extensions: qa-lab","P1","rating: 🦞 diamond lobster","merge-risk: 🚨 message-delivery","status: 👀 ready for maintainer look","proof: sufficient"]

TIMING_JSON={"provider":"local-container","leaseId":"cbx_53731180c485","slug":"jade-shrimp","syncSkipped":false,"commandPhases":[{"name":"toolchain","ms":2170},{"name":"install","ms":2578},{"name":"build","ms":776},{"name":"focused_regression_test","ms":5543},{"name":"apply_replay_97259","ms":396}],"exitCode":0,"leaseStopped":true}
```

This is stronger than a screenshot for this change because the changed behavior is a CLI mutation boundary, not a visual UI. The proof exercises the compiled public apply entrypoint on Linux, against a `#97259`-shaped stale report and a newer durable review marker. The fake `gh` shim records every GitHub boundary call; the assertion proves there was no `gh issue edit` label mutation and no durable comment patch while the ready/proof/merge-risk labels stayed preserved in the report.

## Risks / Rollout

- Low behavioral risk: this only suppresses label/comment mutation when ClawSweeper already has a newer durable review marker than the state report.
- The tradeoff is intentionally conservative: labels may remain temporarily stale until state catches up, but apply will no longer make labels contradict a newer public review comment.
- No workflow files changed, so there is no GitHub OAuth/workflow-scope risk.

## Links

- Live intake target: https://github.com/openclaw/openclaw/pull/97259
## Codex Review Closeout

Target reviewed:

- PR head: `385a0791873321f6840afbb424a8962fec0f7f4d`
- PR base: `origin/main` at `44d3b656300f647a20e1c82a48e84f8ad24225f9`
- Changed files: `src/clawsweeper.ts`, `test/apply-label-sync.test.ts`

Review commands:

```text
C:\msys64\usr\bin\bash.exe C:\Users\marti\.codex\skills\codex-review\scripts\codex-review --mode branch --base origin/main --parallel-tests "node --test test/apply-label-sync.test.ts" --dry-run
# selected: codex review --base origin/main

codex review -c service_tier='"fast"' --base origin/main
# exit: 0, elapsed: 153s
```

The full helper parallel run was not used as the final run on this Windows host because its test child invokes `bash -lc`, which resolved through the broken WSL shim, and the local Codex config contains an unsupported `service_tier = "default"` value for this CLI. The final review kept the same branch/base target and used the supported `service_tier="fast"` override; no model override was used.

Codex review result:

```text
The change safely broadens stale durable review-comment protection to open PR keep-open reports, preventing stale label/comment mutations. Focused build and apply-label-sync tests passed.
```

Accepted findings: none.

Rejected findings: none. One `[P1]` string appears in the raw review log only because the diff includes a test fixture line (`Old finding - src/runtime.ts:10`); it is not a Codex review finding.

Focused validation rerun after review:

```text
node --test test/apply-label-sync.test.ts
# 13 tests, 13 pass, 0 fail
```