### PR TITLE
Fix dashboard apply-health hero status

### DIFF
--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -7084,11 +7084,15 @@ async function load() {
 
 function renderDashboard(data, note) {
   const unresolved = data.health?.unresolved_failures || 0;
+  const applyAttention = (data.recent?.apply_health?.items || []).filter(item =>
+    applyHealthNeedsAttention(item.status)
+  ).length;
+  const needsAttention = unresolved || applyAttention;
   const workerCount = (data.workers || []).length;
   const repoCount = (data.source.target_repositories || []).length;
-  document.getElementById("hero-dot").className = "hero-dot " + (unresolved ? "amber" : "ok");
+  document.getElementById("hero-dot").className = "hero-dot " + (needsAttention ? "amber" : "ok");
   document.getElementById("hero-headline").textContent =
-    (unresolved ? "Needs attention" : "All clear") + " — " +
+    (needsAttention ? "Needs attention" : "All clear") + " — " +
     fmt.format(workerCount) + " claw worker" + (workerCount === 1 ? "" : "s") + " sweeping " +
     fmt.format(repoCount) + " " + (repoCount === 1 ? "repository" : "repositories");
   document.getElementById("subtitle").textContent = data.source.target_repositories.join(", ");

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { createHmac, generateKeyPairSync } from "node:crypto";
 import test from "node:test";
+import { createContext, Script } from "node:vm";
 
 import worker, {
   automaticIssueWork,
@@ -778,6 +779,154 @@ test("dashboard HTML preserves UTF-8 emoji labels", async () => {
   assert.match(html, /Worker Health/);
   assert.match(html, /Recent Activity/);
   assert.doesNotMatch(html, /ðŸ|â|âš|âœ/);
+});
+
+test("dashboard hero treats apply health attention as needs attention", async () => {
+  const response = await worker.fetch(new Request("https://clawsweeper.openclaw.ai/"));
+  const html = await response.text();
+  const script = html.match(/<script>\n([\s\S]*)\n<\/script>/)?.[1];
+  assert.ok(script);
+
+  const elements = new Map();
+  const elementFor = (id) => {
+    if (!elements.has(id)) {
+      elements.set(id, {
+        addEventListener: () => undefined,
+        className: "",
+        close() {
+          this.open = false;
+        },
+        dataset: {},
+        id,
+        innerHTML: "",
+        open: false,
+        showModal() {
+          this.open = true;
+        },
+        style: {},
+        textContent: "",
+      });
+    }
+    return elements.get(id);
+  };
+  const status = {
+    generated_at: "2026-07-05T11:22:43.934Z",
+    source: { target_repositories: ["openclaw/openclaw"] },
+    health: {
+      attempts: 0,
+      error_rate_percent: 0,
+      failed_attempts: 0,
+      failures: [],
+      recovered_failures: 0,
+      recovery_rate_percent: 100,
+      unresolved_failures: 0,
+    },
+    fleet: {
+      active_codex_jobs: 0,
+      active_workflow_runs: 0,
+      budget_used_percent: 0,
+      queued_workflow_runs: 0,
+      support_queued_workflow_runs: 0,
+      support_workflow_runs: 0,
+      worker_budget: 128,
+      worker_detail_fallbacks: 0,
+    },
+    workers: [],
+    automatic_work: [],
+    pipeline: [],
+    diagnostics: { errors: [] },
+    recent: {
+      apply_health: {
+        attention_count: 1,
+        items: [
+          {
+            attention_reasons: ["cursor_required_but_missing_after_full_window"],
+            closed: 0,
+            comment_synced: 0,
+            cursor: null,
+            cursor_required: true,
+            cycle: null,
+            lanes: {
+              closure: {
+                closed: 0,
+                comment_synced: 0,
+                processed: 2,
+                skip_reasons: { skipped_changed_since_review: 2 },
+                skipped: 2,
+              },
+              comment_sync: {
+                closed: 0,
+                comment_synced: 0,
+                processed: 0,
+                skip_reasons: {},
+                skipped: 0,
+              },
+            },
+            mode: "close",
+            next_action_buckets: { review_refresh: 2 },
+            next_actions: [
+              {
+                bucket: "review_refresh",
+                count: 2,
+                label: "Refresh review",
+                next_step: "Queue a fresh ClawSweeper review before any close retry.",
+                owner: "clawsweeper",
+                reason: "skipped_changed_since_review",
+                retryable: true,
+                summary: "The item changed after review.",
+              },
+            ],
+            processed: 2,
+            run_url: "https://github.com/openclaw/clawsweeper/actions/runs/99",
+            skip_reasons: { skipped_changed_since_review: 2 },
+            skipped: 2,
+            status: "needs_attention",
+            target_repo: "openclaw/openclaw",
+            updated_at: "2026-07-05T11:22:03.748Z",
+          },
+        ],
+      },
+      automerge: [],
+      closed_items: [],
+      closed_stats: { issues: 0, prs: 0, total: 0, window_hours: 24 },
+      cluster_repair: null,
+      events: [],
+      operation_counts: {},
+    },
+  };
+
+  const context = createContext({
+    console,
+    document: {
+      addEventListener: () => undefined,
+      body: { classList: { add: () => undefined, remove: () => undefined } },
+      getElementById: elementFor,
+      querySelector: () => null,
+      querySelectorAll: () => [],
+    },
+    fetch: async () => ({
+      headers: { get: () => "fresh" },
+      json: async () => status,
+      ok: true,
+      status: 200,
+    }),
+    history: { replaceState: () => undefined },
+    localStorage: {
+      getItem: () => null,
+      setItem: () => undefined,
+    },
+    location: { hash: "", pathname: "/", search: "" },
+    navigator: { clipboard: { writeText: async () => undefined } },
+    setInterval: () => 1,
+    setTimeout: () => 1,
+    window: { addEventListener: () => undefined },
+  });
+  new Script(script).runInContext(context);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(elementFor("hero-dot").className, "hero-dot amber");
+  assert.match(elementFor("hero-headline").textContent, /^Needs attention/);
+  assert.match(elementFor("apply-health").innerHTML, /Pruning sweep blocked/);
 });
 
 test("dashboard groups automatic issue lifecycle events with active workers", () => {


### PR DESCRIPTION
## Summary
- Treat apply-health `needs_attention` items as dashboard hero attention.
- Add a focused dashboard-worker regression test that executes the shipped client script against a status payload with no unresolved failures but one apply-health attention row.

## Problem
PR #412 added apply-health reporting to the dashboard, but the hero status still only looked at `health.unresolved_failures`. That let the page render `All clear` even when the apply-health table was reporting a blocked pruning/apply condition.

## Implementation
- Count `recent.apply_health.items` whose status satisfies `applyHealthNeedsAttention()`.
- Drive the hero dot and headline from unresolved failures or apply-health attention.
- Cover the exact case ClawSweeper flagged: `unresolved_failures: 0` plus a `needs_attention` apply-health item.

## Validation
- `node --test test/dashboard-worker.test.ts` - 54/54 passing, including `dashboard hero treats apply health attention as needs attention`.
- `pnpm run build:dashboard` - passing.
- `git diff --check HEAD~1..HEAD` - passing.
- `C:\Users\marti\.codex\skills\autoreview\scripts\autoreview --mode commit --commit HEAD` - exited 0 with no findings printed.
- GitHub checks are passing for the current head, including `pnpm check`, CodeQL, Windows Codex launcher, and analyze jobs.

## Browser Proof
Used Playwright Chromium against a local HTTP server serving the generated `dashboard/worker.ts` HTML from this branch. The server returned a mocked `/api/status` response with `health.unresolved_failures = 0`, `health.recovery_rate_percent = 100`, and one `recent.apply_health.items[]` row with `status = "needs_attention"`.

DOM state captured from the browser run:

```json
{
  "url": "/",
  "heroDotClass": "hero-dot amber",
  "heroDotBackground": "rgb(179, 131, 29)",
  "heroHeadline": "Needs attention — 0 claw workers sweeping 1 repository",
  "applyHealthText": "Pruning sweep blocked - openclaw/openclaw close lane ClawSweeper processed 2 records without closing or syncing anything; 2 records skipped. Main signal: Rotation cursor missing. Next check: Open the workflow run and check the cursor-write step; until the cursor is written, the next run can repeat this window. Inspect the cursor-write and state-publish steps; rerun only after the cursor write failure is understood. open run 2 processed 0 closed 0 comments synced cursor missing Rotation cursor missing Refresh review 2 workflow run"
}
```

Screenshots from the same Playwright setup are embedded below. They are stored on a separate fork proof tag so the PR code diff stays clean.

![Apply-health hero needs attention proof](https://raw.githubusercontent.com/brokemac79/clawsweeper/proof-apply-health-418/proof/apply-health-418/apply-health-needs-attention.png)

![Apply-health full dashboard proof](https://raw.githubusercontent.com/brokemac79/clawsweeper/proof-apply-health-418/proof/apply-health-418/apply-health-main.png)

Raw image URL checks returned HTTP 200 with `content-type: image/png` for both screenshots.

## Static Proof
The new regression test renders the dashboard HTML, extracts and executes the bundled client script in a mocked browser context, feeds `/api/status` with `health.unresolved_failures = 0` and `recent.apply_health.items[0].status = "needs_attention"`, and asserts:
- `#hero-dot` becomes `hero-dot amber`.
- `#hero-headline` starts with `Needs attention`.
- `#apply-health` still renders the blocked pruning/apply text.

## Risks / Rollout
Low risk. The change only affects the dashboard hero summary state; apply-health table rendering and status generation are unchanged.

## Links
- Follow-up from ClawSweeper review on #412: https://github.com/openclaw/clawsweeper/pull/412#issuecomment-4884307529