### PR TITLE
Add dashboard theme preference control

### DIFF
--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -5191,9 +5191,14 @@ function dashboardThemeControlScript() {
     } catch {}
     applyTheme();
   }));
-  themeQuery?.addEventListener("change", () => {
+  const updateSystemTheme = () => {
     if (themeChoice === "system") applyTheme();
-  });
+  };
+  if (typeof themeQuery?.addEventListener === "function") {
+    themeQuery.addEventListener("change", updateSystemTheme);
+  } else {
+    themeQuery?.addListener?.(updateSystemTheme);
+  }
   applyTheme();
 })();`;
 }

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -5076,6 +5076,128 @@ function externalHttpUrl(value, fallback) {
   }
 }
 
+function dashboardThemeInitScript() {
+  return `<script>
+(() => {
+  const themeKey = "clawsweeper-theme";
+  const themeChoices = new Set(["system", "light", "dark"]);
+  const themeQuery = window.matchMedia?.("(prefers-color-scheme: dark)");
+  const themeColor = { light: "#f6f3ec", dark: "#141110" };
+  let themeChoice = "system";
+  try {
+    const saved = window.localStorage?.getItem(themeKey);
+    if (themeChoices.has(saved)) themeChoice = saved;
+  } catch {}
+  const active = themeChoice === "system" && themeQuery?.matches ? "dark" : themeChoice === "dark" ? "dark" : "light";
+  document.documentElement.dataset.theme = active;
+  document.querySelector('meta[name="theme-color"]')?.setAttribute("content", themeColor[active]);
+})();
+</script>`;
+}
+
+function dashboardThemeCss() {
+  return `
+:root[data-theme="light"] { color-scheme: light; }
+:root[data-theme="dark"] { color-scheme: dark; }
+.theme-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--muted);
+}
+.theme-control > span {
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.theme-options {
+  display: inline-grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  padding: 2px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+}
+.theme-options button {
+  appearance: none;
+  min-width: 48px;
+  min-height: 24px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 11px;
+  font-weight: 650;
+  line-height: 1;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+.theme-options button:hover {
+  color: var(--text);
+}
+.theme-options button[aria-pressed="true"] {
+  color: var(--claw);
+  background: color-mix(in srgb, var(--claw) 10%, transparent);
+}
+`;
+}
+
+function dashboardThemeControlHtml() {
+  return `<div class="theme-control" aria-label="Theme">
+        <span>Theme</span>
+        <div class="theme-options" role="group" aria-label="Theme preference">
+          <button type="button" data-theme-choice="system" aria-pressed="true">System</button>
+          <button type="button" data-theme-choice="light" aria-pressed="false">Light</button>
+          <button type="button" data-theme-choice="dark" aria-pressed="false">Dark</button>
+        </div>
+      </div>`;
+}
+
+function dashboardThemeControlScript() {
+  return `(() => {
+  const themeKey = "clawsweeper-theme";
+  const themeChoices = new Set(["system", "light", "dark"]);
+  const themeColor = { light: "#f6f3ec", dark: "#141110" };
+  const themeQuery = window.matchMedia?.("(prefers-color-scheme: dark)");
+  const themeButtons = document.querySelectorAll("[data-theme-choice]");
+  const readThemeChoice = () => {
+    try {
+      const saved = window.localStorage?.getItem(themeKey);
+      return themeChoices.has(saved) ? saved : "system";
+    } catch {
+      return "system";
+    }
+  };
+  let themeChoice = readThemeChoice();
+  const activeTheme = () => themeChoice === "system" && themeQuery?.matches ? "dark" : themeChoice === "dark" ? "dark" : "light";
+  const applyTheme = () => {
+    const active = activeTheme();
+    document.documentElement.dataset.theme = active;
+    document.querySelector('meta[name="theme-color"]')?.setAttribute("content", themeColor[active]);
+    themeButtons.forEach(button => {
+      const selected = button.dataset.themeChoice === themeChoice;
+      button.setAttribute("aria-pressed", selected ? "true" : "false");
+    });
+  };
+  themeButtons.forEach(button => button.addEventListener("click", () => {
+    const choice = button.dataset.themeChoice;
+    if (!themeChoices.has(choice)) return;
+    themeChoice = choice;
+    try {
+      window.localStorage?.setItem(themeKey, choice);
+    } catch {}
+    applyTheme();
+  }));
+  themeQuery?.addEventListener("change", () => {
+    if (themeChoice === "system") applyTheme();
+  });
+  applyTheme();
+})();`;
+}
+
 function serializedPageConfig(config) {
   return JSON.stringify(config).replace(/</g, "\\u003c");
 }
@@ -5095,7 +5217,9 @@ function triageHtml(config) {
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="theme-color" content="#f6f3ec">
 <title>${escapeHtml(config.title)}</title>
+${dashboardThemeInitScript()}
 <style>
 :root {
   color-scheme: light dark;
@@ -5113,6 +5237,7 @@ function triageHtml(config) {
 }
 * { box-sizing: border-box; }
 html { scrollbar-color: light-dark(#cfc6b6, #3a332b) transparent; }
+${dashboardThemeCss()}
 body {
   margin: 0;
   background: var(--bg);
@@ -5460,6 +5585,7 @@ body.resizing-col {
     </div>
     <div class="top-links">
       ${config.links.map((link) => `<a class="top-link" href="${escapeHtml(link.href)}">${escapeHtml(link.label)}</a>`).join("")}
+      ${dashboardThemeControlHtml()}
       <span class="muted mono" id="updated"></span>
     </div>
   </header>
@@ -5501,6 +5627,7 @@ body.resizing-col {
   <section id="diagnostics" class="muted"></section>
 </main>
 <script>
+${dashboardThemeControlScript()}
 const PAGE = ${pageConfig};
 const fmt = new Intl.NumberFormat();
 const rel = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
@@ -5917,6 +6044,8 @@ function dashboardHtml(env: DashboardEnv = {}) {
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="theme-color" content="#f6f3ec">
+${dashboardThemeInitScript()}
 <title>🦞 ClawSweeper Live</title>
 <style>
 :root {
@@ -5936,6 +6065,7 @@ function dashboardHtml(env: DashboardEnv = {}) {
 }
 * { box-sizing: border-box; }
 html { scrollbar-color: light-dark(#cfc6b6, #3a332b) transparent; }
+${dashboardThemeCss()}
 body {
   margin: 0;
   background: var(--bg);
@@ -6689,6 +6819,7 @@ a.pill:hover { color: var(--claw); text-decoration: none; }
       <a class="top-link" href="/triage">Issue triage</a>
       <a class="top-link" href="/pr-proof-triage">PR proof triage</a>
       <a class="top-link" href="${escapeHtml(crabfleetUrl)}">Live terminals</a>
+      ${dashboardThemeControlHtml()}
       <span class="muted mono" id="updated"></span>
     </div>
   </header>
@@ -6760,6 +6891,7 @@ a.pill:hover { color: var(--claw); text-decoration: none; }
   </div>
 </dialog>
 <script>
+${dashboardThemeControlScript()}
 const fmt = new Intl.NumberFormat();
 const rel = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
 function elapsed(ms) {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -784,7 +784,7 @@ test("dashboard HTML preserves UTF-8 emoji labels", async () => {
 test("dashboard hero treats apply health attention as needs attention", async () => {
   const response = await worker.fetch(new Request("https://clawsweeper.openclaw.ai/"));
   const html = await response.text();
-  const script = html.match(/<script>\n([\s\S]*)\n<\/script>/)?.[1];
+  const script = [...html.matchAll(/<script>\n([\s\S]*?)\n<\/script>/g)].at(-1)?.[1];
   assert.ok(script);
 
   const elements = new Map();
@@ -900,6 +900,7 @@ test("dashboard hero treats apply health attention as needs attention", async ()
     document: {
       addEventListener: () => undefined,
       body: { classList: { add: () => undefined, remove: () => undefined } },
+      documentElement: { dataset: {} },
       getElementById: elementFor,
       querySelector: () => null,
       querySelectorAll: () => [],
@@ -927,6 +928,27 @@ test("dashboard hero treats apply health attention as needs attention", async ()
   assert.equal(elementFor("hero-dot").className, "hero-dot amber");
   assert.match(elementFor("hero-headline").textContent, /^Needs attention/);
   assert.match(elementFor("apply-health").innerHTML, /Pruning sweep blocked/);
+});
+
+test("dashboard HTML emits early persistent theme controls", async () => {
+  for (const path of ["/", "/triage", "/pr-proof-triage"]) {
+    const response = await worker.fetch(new Request("https://clawsweeper.openclaw.ai" + path));
+    const html = await response.text();
+    const themeInit = html.indexOf('const themeKey = "clawsweeper-theme";');
+    const styles = html.indexOf("<style>");
+
+    assert.notEqual(themeInit, -1, path + " should initialize theme preference");
+    assert.notEqual(styles, -1, path + " should include CSS");
+    assert.ok(themeInit < styles, path + " should apply saved theme before styles");
+    assert.match(html, /:root\[data-theme="light"\] \{ color-scheme: light; \}/);
+    assert.match(html, /:root\[data-theme="dark"\] \{ color-scheme: dark; \}/);
+    assert.match(html, /data-theme-choice="system"/);
+    assert.match(html, /data-theme-choice="light"/);
+    assert.match(html, /data-theme-choice="dark"/);
+    assert.match(html, /window\.localStorage\?\.setItem\(themeKey, choice\)/);
+    assert.match(html, /themeQuery\?\.addEventListener\("change"/);
+    assert.match(html, /setAttribute\("aria-pressed", selected \? "true" : "false"\)/);
+  }
 });
 
 test("dashboard groups automatic issue lifecycle events with active workers", () => {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -946,7 +946,9 @@ test("dashboard HTML emits early persistent theme controls", async () => {
     assert.match(html, /data-theme-choice="light"/);
     assert.match(html, /data-theme-choice="dark"/);
     assert.match(html, /window\.localStorage\?\.setItem\(themeKey, choice\)/);
-    assert.match(html, /themeQuery\?\.addEventListener\("change"/);
+    assert.match(html, /typeof themeQuery\?\.addEventListener === "function"/);
+    assert.match(html, /themeQuery\.addEventListener\("change", updateSystemTheme\)/);
+    assert.match(html, /themeQuery\?\.addListener\?\.\(updateSystemTheme\)/);
     assert.match(html, /setAttribute\("aria-pressed", selected \? "true" : "false"\)/);
   }
 });


### PR DESCRIPTION
## Summary
- Add a persistent `System / Light / Dark` theme selector to the ClawSweeper live dashboard and triage pages.
- Apply the saved theme before dashboard CSS loads to avoid a light-mode flash when dark is selected.
- Reuse the existing `clawsweeper-theme` localStorage preference key used by the docs site.

## Problem
The dashboard CSS follows browser/system preference with `color-scheme: light dark` and `light-dark(...)`, but the dashboard itself had no visible override. After #412, users who landed in light mode had no page-level way to return to dark mode.

## Implementation
- Added shared dashboard theme helpers for early initialization, selector markup, selector CSS, and click/change handling.
- Injected the selector into `/`, `/triage`, and `/pr-proof-triage` top bars.
- Added a regression test proving each rendered page initializes `clawsweeper-theme` before CSS, exposes `System`, `Light`, and `Dark`, persists selections, and updates `aria-pressed`.
- Guarded the system theme-change listener so older `MediaQueryList` implementations without `addEventListener` fall back to `addListener` instead of aborting dashboard JavaScript.

## Preference Key
The shared `clawsweeper-theme` key is intentional. The docs site already uses this key for the same `System / Light / Dark` preference, and the dashboard now follows the same ClawSweeper-origin preference so a user does not have to set theme separately per ClawSweeper surface.

## Validation
- `node --test test/dashboard-worker.test.ts` - 54/54 passing, including `dashboard HTML emits early persistent theme controls`; rerun after the MediaQueryList compatibility fix.
- `pnpm run build:dashboard` - passing.
- `git diff --check HEAD~1..HEAD` - passing.
- `C:\Users\marti\.codex\skills\autoreview\scripts\autoreview --mode commit --commit HEAD` - exited 0 with no findings printed.
- GitHub checks are passing for the current head, including `pnpm check`, CodeQL, Windows Codex launcher, and analyze jobs.

## Codex Review Closeout
Command used:

```text
C:\Program Files\Git\bin\bash.exe C:/Users/marti/.codex/skills/codex-review/scripts/codex-review --mode branch --base origin/main --codex-bin /c/clawsweeper-work/artifacts/codex-review/codex-fast-wrapper.sh --parallel-tests "node --test test/dashboard-worker.test.ts" --output /c/clawsweeper-work/artifacts/codex-review/pr-419-review-final.txt
```

Accepted finding from the initial run:
- `[P2] Guard missing MediaQueryList.addEventListener`: verified and fixed in `0167ce67a6` by adding a guarded `addEventListener` path plus a legacy `addListener` fallback.

Final result:
- `codex-review exit: 0`
- `tests exit: 0`
- `codex-review clean: no accepted/actionable findings reported`

## Browser Proof
Used Playwright Chromium against a local HTTP server serving generated `dashboard/worker.ts` HTML from this branch, with mocked `/api/status`, `/api/triage`, and `/api/pr-proof-triage` responses. The run clicked the actual selector buttons and inspected browser DOM, computed CSS, and localStorage.

```json
[
  {
    "label": "live after Dark click",
    "url": "/",
    "storedTheme": "dark",
    "dataTheme": "dark",
    "colorScheme": "dark",
    "bodyBackground": "rgb(20, 17, 16)",
    "bodyColor": "rgb(236, 229, 218)",
    "pressed": ["dark"]
  },
  {
    "label": "triage after persisted Dark",
    "url": "/triage",
    "storedTheme": "dark",
    "dataTheme": "dark",
    "colorScheme": "dark",
    "bodyBackground": "rgb(20, 17, 16)",
    "bodyColor": "rgb(236, 229, 218)",
    "pressed": ["dark"]
  },
  {
    "label": "pr-proof-triage after persisted Dark",
    "url": "/pr-proof-triage",
    "storedTheme": "dark",
    "dataTheme": "dark",
    "colorScheme": "dark",
    "bodyBackground": "rgb(20, 17, 16)",
    "bodyColor": "rgb(236, 229, 218)",
    "pressed": ["dark"]
  },
  {
    "label": "live after Light click",
    "url": "/",
    "storedTheme": "light",
    "dataTheme": "light",
    "colorScheme": "light",
    "bodyBackground": "rgb(246, 243, 236)",
    "bodyColor": "rgb(33, 28, 21)",
    "pressed": ["light"]
  },
  {
    "label": "live after System click",
    "url": "/",
    "storedTheme": "system",
    "dataTheme": "light",
    "colorScheme": "light",
    "bodyBackground": "rgb(246, 243, 236)",
    "bodyColor": "rgb(33, 28, 21)",
    "pressed": ["system"]
  }
]
```

Screenshots from the same Playwright run are embedded below. They are stored on a separate fork proof tag so the PR code diff stays clean.

![Live dashboard dark theme proof](https://raw.githubusercontent.com/brokemac79/clawsweeper/proof-theme-419/proof/theme-419/live-dark.png)

![Issue triage dark theme proof](https://raw.githubusercontent.com/brokemac79/clawsweeper/proof-theme-419/proof/theme-419/triage-dark.png)

![PR proof triage dark theme proof](https://raw.githubusercontent.com/brokemac79/clawsweeper/proof-theme-419/proof/theme-419/pr-proof-triage-dark.png)

## Static Proof
The new test covers all dashboard-rendered pages:
- `/`
- `/triage`
- `/pr-proof-triage`

For each page, it asserts the early theme initializer appears before `<style>`, the forced light/dark `color-scheme` selectors are present, all three `data-theme-choice` buttons render, localStorage persistence is wired, system preference changes are handled, and `aria-pressed` reflects the active selection.

## Risks / Rollout
Low risk and intentionally separate from the apply-health correctness fix. If maintainers prefer no explicit dark-mode control, this PR can be declined without affecting the apply-health fix.

## Links
- Split from the apply-health correctness follow-up so maintainers can decide on dashboard theme UX independently.