### PR TITLE
perf: bound apply coverage proofs

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2337,6 +2337,7 @@ jobs:
           checkpoint_size="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_checkpoint_size || '20' }}"
           comment_sync_processed_limit=1000
           base_close_processed_limit=300
+          coverage_proof_limit=1
           # Consumed by the sourced workflow helpers.
           # shellcheck disable=SC2034
           max_close_processed_limit=900
@@ -2372,6 +2373,7 @@ jobs:
           next_cursor=""
           apply_ready_count=""
           cursor_advance_count=""
+          coverage_proof_item_numbers=""
           if [ "$sync_open_pr_batch" = "true" ]; then
             sync_comments_only="true"
             apply_kind="pull_request"
@@ -2446,9 +2448,11 @@ jobs:
               --min-age-days "$min_age_days" \
               --min-age-minutes "$min_age_minutes" \
               --batch-size "$close_processed_limit" \
+              --coverage-proof-limit "$coverage_proof_limit" \
               --cursor-path "$apply_cursor_path")"
             if [ -n "$item_numbers" ]; then
               auto_selected_apply_batch=true
+              select_bounded_coverage_proof_tail
               proposed_count="$(pnpm run --silent workflow -- count-csv --items "$item_numbers")"
               apply_ready_count="$(pnpm run --silent workflow -- proposed-item-count \
                 --target-repo "$TARGET_REPO" \
@@ -2460,7 +2464,7 @@ jobs:
               if [ "$proposed_count" -lt "$limit" ]; then
                 limit="$proposed_count"
               fi
-              echo "Auto-selected $proposed_count proposed close candidate(s) from $close_processed_limit-record apply cursor window ($adaptive_apply_scan_reason): $item_numbers; apply-ready count: ${apply_ready_count:-unknown}"
+              echo "Auto-selected $proposed_count proposed close candidate(s) from $close_processed_limit-record apply cursor window ($adaptive_apply_scan_reason), including $coverage_proof_count/$coverage_proof_limit bounded PR coverage proof candidate(s): $item_numbers; apply-ready count: ${apply_ready_count:-unknown}"
             fi
           fi
           item_numbers_arg=()
@@ -2562,6 +2566,11 @@ jobs:
               chunk_limit="$remaining"
             fi
             checkpoint=$((checkpoint + 1))
+            cursor_trace_path=".artifacts/apply-cursor-trace-$checkpoint.json"
+            cursor_trace_arg=()
+            if [ "$auto_selected_apply_batch" = "true" ]; then
+              cursor_trace_arg=(--cursor-trace "$cursor_trace_path")
+            fi
             echo "::group::Apply checkpoint $checkpoint"
             echo "Applying up to $chunk_limit fresh closes; $closed_total/$limit already closed in this run"
             CLAWSWEEPER_APPLY_CHECKPOINT="$checkpoint" pnpm run apply-decisions -- \
@@ -2578,6 +2587,7 @@ jobs:
               --processed-limit "$close_processed_limit" \
               --comment-sync-min-age-days "$comment_sync_min_age_days" \
               "${item_numbers_arg[@]}" \
+              "${cursor_trace_arg[@]}" \
               "${sync_comments_arg[@]}"
             cp apply-report.json ".artifacts/apply-reports/apply-report-$checkpoint.json"
             pnpm run workflow -- merge-apply-reports --dir .artifacts/apply-reports --output apply-report.json
@@ -2591,10 +2601,13 @@ jobs:
                 --cursor-path "$apply_cursor_path" \
                 --report ".artifacts/apply-reports/apply-report-$checkpoint.json" \
                 --target-repo "$TARGET_REPO" \
-                --item-numbers "$item_numbers"
+                --item-numbers "$item_numbers" \
+                --coverage-proof-item-numbers "$coverage_proof_item_numbers" \
+                --cursor-trace "$cursor_trace_path"
               cursor_advance_count="$(pnpm run --silent workflow -- apply-cursor-advance-count \
                 --report ".artifacts/apply-reports/apply-report-$checkpoint.json" \
-                --item-numbers "$item_numbers")"
+                --item-numbers "$item_numbers" \
+                --cursor-trace "$cursor_trace_path")"
               apply_publish_paths+=(results/apply-cursors)
             fi
             publish_changes "chore: apply sweep decisions checkpoint $checkpoint" "${apply_publish_paths[@]}"
@@ -2611,6 +2624,7 @@ jobs:
               --apply-health-file ".artifacts/apply-health-$checkpoint.json"
             publish_status "chore: update sweep apply checkpoint $checkpoint status"
             echo "::endgroup::"
+            drop_bounded_coverage_proof_tail "$cursor_trace_path"
             if [ "$result_count" -ge "$close_processed_limit" ]; then
               if [ "$closed_in_chunk" -gt 0 ]; then
                 echo "Close scan reached its $close_processed_limit-record budget; queueing a fresh-token continuation."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Kept automatic apply windows responsive by running at most one PR close-coverage proof after fast candidates and advancing independent fast/proof cursors only through records actually examined.
 - Skipped stale PR close reports before expensive close-coverage proof when a newer durable review already makes the mutation unsafe.
 - Prioritized confirmed close proposals ahead of speculative live promotion probes so expensive no-op promotion scans cannot starve ready OpenClaw closures.
 - Split apply workflow helpers out of the oversized inline expression so GitHub can validate and start sweep runs again.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ checkpoint, and status-only commits are intentionally omitted.
 ### Fixed
 
 - Kept automatic apply windows responsive by running at most one PR close-coverage proof after fast candidates and advancing independent fast/proof cursors only through records actually examined.
+- Prevented malformed `maintainer_decision` records from repeatedly consuming apply queue slots by recording their deterministic apply bookkeeping. Thanks @brokemac79.
+- Preserved ready-for-maintainer labels when a newer durable review matches the current PR head, while still removing readiness from stale-head reviews. Thanks @brokemac79.
+- Surfaced apply-health `needs_attention` state in the dashboard hero and added explicit System, Light, and Dark theme controls. Thanks @brokemac79.
 - Skipped stale PR close reports before expensive close-coverage proof when a newer durable review already makes the mutation unsafe.
 - Prioritized confirmed close proposals ahead of speculative live promotion probes so expensive no-op promotion scans cannot starve ready OpenClaw closures.
 - Split apply workflow helpers out of the oversized inline expression so GitHub can validate and start sweep runs again.

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -468,6 +468,14 @@ records, capped at 900. This changes only the deterministic scan window:
 policy gates stay unchanged. The workflow logs and sweep status detail include
 the selected scan window and reason.
 
+Automatic windows reserve a one-candidate tail for PR close-coverage proof.
+Fast deterministic candidates run first; the proof candidate runs last and has
+an independent cursor. An executor trace advances each cursor only through
+records actually examined, so a partial window neither repeats completed proof
+work nor skips unexamined candidates. Coverage proof, live-state refresh,
+freshness checks, and close gates remain unchanged. Explicit targeted apply
+runs keep their requested item set and ordering policy.
+
 Before a close-mode apply run starts, the workflow summarizes the selected close
 candidate mix by quality bucket in the status detail. Buckets such as
 implemented-on-main, duplicate/superseded, needs PR close proof,

--- a/scripts/apply-workflow-helpers.sh
+++ b/scripts/apply-workflow-helpers.sh
@@ -73,6 +73,49 @@ select_adaptive_apply_batch() {
   adaptive_apply_scan_reason="$(awk -F= '$1 == "adaptive_apply_scan_reason" { print $2 }' "$adaptive_batch_env")"
 }
 
+select_bounded_coverage_proof_tail() {
+  local proof_args=(
+    --target-repo "$TARGET_REPO"
+    --apply-kind "$apply_kind"
+    --apply-close-reasons "$apply_close_reasons"
+    --stale-min-age-days "$stale_min_age_days"
+    --min-age-days "$min_age_days"
+    --min-age-minutes "$min_age_minutes"
+    --item-numbers "$item_numbers"
+  )
+  coverage_proof_item_numbers="$(pnpm run --silent workflow -- proposed-pr-close-coverage-item-numbers "${proof_args[@]}")"
+  coverage_proof_count="$(pnpm run --silent workflow -- count-csv --items "$coverage_proof_item_numbers")"
+}
+
+drop_bounded_coverage_proof_tail() {
+  if [ "$auto_selected_apply_batch" != "true" ] || [ -z "$coverage_proof_item_numbers" ]; then
+    return
+  fi
+  local cursor_trace_path="$1"
+  local examined_item_numbers
+  examined_item_numbers="$(pnpm run --silent workflow -- apply-cursor-trace-item-numbers --cursor-trace "$cursor_trace_path")"
+  if [ -z "$examined_item_numbers" ]; then
+    return
+  fi
+  local remaining=",${item_numbers},"
+  local remaining_proof=",${coverage_proof_item_numbers},"
+  local number
+  for number in ${coverage_proof_item_numbers//,/ }; do
+    if [[ ",${examined_item_numbers}," == *",${number},"* ]]; then
+      remaining="${remaining//,${number},/,}"
+      remaining_proof="${remaining_proof//,${number},/,}"
+    fi
+  done
+  item_numbers="${remaining#,}"
+  item_numbers="${item_numbers%,}"
+  item_numbers_arg=()
+  if [ -n "$item_numbers" ]; then
+    item_numbers_arg=(--item-numbers "$item_numbers")
+  fi
+  coverage_proof_item_numbers="${remaining_proof#,}"
+  coverage_proof_item_numbers="${coverage_proof_item_numbers%,}"
+}
+
 summarize_apply_candidate_quality() {
   candidate_quality_summary="not evaluated"
   candidate_quality_detail=""

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -17878,6 +17878,8 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
   const maxRuntimeMs = numberArg(args.max_runtime_ms, 0);
   const reportPath = resolve(stringArg(args.report_path, join(ROOT, "apply-report.json")));
   const artifactDir = resolve(stringArg(args.artifact_dir, join(ROOT, "artifacts", "apply")));
+  const cursorTraceArg = stringArg(args.cursor_trace, "").trim();
+  const cursorTracePath = cursorTraceArg ? resolve(cursorTraceArg) : null;
   const prCloseCoverageProofRuntime: PrCloseCoverageProofRuntime = {
     model: stringArg(args.codex_model, DEFAULT_CODEX_MODEL),
     reasoningEffort: stringArg(args.codex_reasoning_effort, DEFAULT_REASONING_EFFORT),
@@ -17895,7 +17897,12 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
   const startedAtMs = Date.now();
   const requestedItemNumbers = itemNumbersArg(args.item_numbers, args.item_number);
   const requestedItemNumberSet = new Set(requestedItemNumbers);
+  const requestedItemOrder = orderedApplyItemNumbers(args.item_numbers, args.item_number);
+  const requestedItemOrderIndex = new Map(
+    requestedItemOrder.map((number, index) => [number, index]),
+  );
   const results: ApplyResult[] = [];
+  const examinedItemNumbers: number[] = [];
   let closedCount = 0;
   let processedCount = 0;
   throttleHeartbeatContext = () =>
@@ -17965,19 +17972,38 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
     );
   };
   const fileEntries = applyReportEntriesForDir(itemsDir, "items").sort(
-    (left, right) =>
-      left.priority - right.priority ||
-      left.applyCheckedAt - right.applyCheckedAt ||
-      left.number - right.number,
+    cursorTracePath
+      ? (left, right) =>
+          (requestedItemOrderIndex.get(left.number) ?? Number.MAX_SAFE_INTEGER) -
+            (requestedItemOrderIndex.get(right.number) ?? Number.MAX_SAFE_INTEGER) ||
+          left.number - right.number
+      : (left, right) =>
+          left.priority - right.priority ||
+          left.applyCheckedAt - right.applyCheckedAt ||
+          left.number - right.number,
   );
   const files = fileEntries.map((entry) => entry.name);
   const allOpenFileEntries = applyReportEntriesForDir(itemsDir, "items", false);
   const openFileEntryByNumber = new Map(allOpenFileEntries.map((entry) => [entry.number, entry]));
   const closedThisRun = new Set<string>();
+  const writeCursorTrace = (): void => {
+    if (!cursorTracePath) return;
+    ensureDir(dirname(cursorTracePath));
+    writeFileSync(
+      cursorTracePath,
+      `${JSON.stringify(
+        { schema_version: 1, examined_item_numbers: examinedItemNumbers },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+  };
   if (fileEntries.length === 0 && !existsSync(itemsDir)) {
     console.log("No items directory.");
     ensureDir(dirname(reportPath));
     writeFileSync(reportPath, JSON.stringify(results, null, 2), "utf8");
+    writeCursorTrace();
     return;
   }
   logProgress(
@@ -17998,6 +18024,7 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
     let markdown = entry.markdown;
     const repo = entry.repo;
     const number = entry.number;
+    examinedItemNumbers.push(number);
     const decision = frontMatterValue(markdown, "decision");
     let closeReason = frontMatterValue(markdown, "close_reason") as CloseReason | undefined;
     const action = frontMatterValue(markdown, "action_taken");
@@ -19423,8 +19450,28 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
   }
   ensureDir(dirname(reportPath));
   writeFileSync(reportPath, JSON.stringify(results, null, 2), "utf8");
+  writeCursorTrace();
   logProgress("finished apply");
   console.log(JSON.stringify(results, null, 2));
+}
+
+function orderedApplyItemNumbers(
+  itemNumbers: string | boolean | string[] | undefined,
+  itemNumber: string | boolean | string[] | undefined,
+): number[] {
+  const ordered: number[] = [];
+  const seen = new Set<number>();
+  const add = (value: string): void => {
+    for (const part of value.split(",")) {
+      const parsed = Number(part.trim());
+      if (!Number.isInteger(parsed) || parsed <= 0 || seen.has(parsed)) continue;
+      seen.add(parsed);
+      ordered.push(parsed);
+    }
+  };
+  if (typeof itemNumbers === "string") add(itemNumbers);
+  if (typeof itemNumber === "string") add(itemNumber);
+  return ordered;
 }
 
 function proofNudgeComments(number: number): ProofNudgeComment[] {

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -159,8 +159,15 @@ function runCli(): void {
       break;
     case "apply-cursor-advance-count":
       console.log(
-        applyCursorAdvanceCount(requiredString("report"), optionalString("item-numbers")),
+        applyCursorAdvanceCount(
+          requiredString("report"),
+          optionalString("item-numbers"),
+          optionalString("cursor-trace"),
+        ),
       );
+      break;
+    case "apply-cursor-trace-item-numbers":
+      process.stdout.write(readApplyCursorTrace(requiredString("cursor-trace")).join(","));
       break;
     case "apply-continuation-blocker": {
       const blocker = applyContinuationBlocker(readJsonArray(requiredString("runs")), {
@@ -275,6 +282,8 @@ function runCli(): void {
         requiredString("report"),
         requiredString("target-repo"),
         optionalString("item-numbers"),
+        optionalString("coverage-proof-item-numbers"),
+        optionalString("cursor-trace"),
       );
       break;
     case "merge-apply-reports":
@@ -1023,6 +1032,7 @@ type ProposedItemOptions = {
   minAgeMinutes: number | null;
   batchSize?: number | null;
   cursorPath?: string | null;
+  coverageProofLimit?: number | null;
   itemNumbers?: ReadonlySet<number> | null;
 };
 
@@ -1057,6 +1067,7 @@ type ProposedItemCandidate = {
   closeReason: string;
   action: string;
   stage: "confirmed_close" | "promotion_probe";
+  coverageProof: boolean;
   qualityBucket: ProposedItemQualityBucket;
 };
 
@@ -1176,6 +1187,7 @@ function selectedProposedItemCandidates(
           closeReason: candidateCloseReason,
           action,
           stage: selectablePromotion ? ("promotion_probe" as const) : ("confirmed_close" as const),
+          coverageProof: prCloseCoverageProofCanRun,
           qualityBucket: proposedItemQualityBucket({
             action,
             closeReason: candidateCloseReason,
@@ -1189,24 +1201,51 @@ function selectedProposedItemCandidates(
   const batchSize = options.batchSize ?? null;
   if (!batchSize || batchSize <= 0) return candidates;
   const cursor = options.cursorPath ? readApplyCursor(options.cursorPath) : null;
-  const rotate = (stage: ProposedItemCandidate["stage"]): ProposedItemCandidate[] => {
+  const rotate = (
+    stage: ProposedItemCandidate["stage"],
+    coverageProof: boolean | null,
+    position: ApplyCursorPosition | null,
+  ): ProposedItemCandidate[] => {
     const sorted = candidates
-      .filter((candidate) => candidate.stage === stage)
+      .filter(
+        (candidate) =>
+          candidate.stage === stage &&
+          (coverageProof === null || candidate.coverageProof === coverageProof),
+      )
       .sort(compareApplyCursorCandidate);
-    if (!cursor) return sorted;
+    if (!position) return sorted;
     const afterCursor = sorted.filter(
-      (candidate) => compareCandidateToApplyCursor(candidate, cursor) > 0,
+      (candidate) => compareCandidateToApplyCursor(candidate, position) > 0,
     );
     return [
       ...afterCursor,
-      ...sorted.filter((candidate) => compareCandidateToApplyCursor(candidate, cursor) <= 0),
+      ...sorted.filter((candidate) => compareCandidateToApplyCursor(candidate, position) <= 0),
     ];
   };
 
   // Confirmed close proposals have already passed review eligibility. Keep
   // speculative keep-open promotions as bounded backfill so their live graph
   // hydration cannot consume an entire apply window ahead of real proposals.
-  return [...rotate("confirmed_close"), ...rotate("promotion_probe")].slice(0, batchSize);
+  if (options.coverageProofLimit === null || options.coverageProofLimit === undefined) {
+    return [
+      ...rotate("confirmed_close", null, cursor),
+      ...rotate("promotion_probe", null, cursor),
+    ].slice(0, batchSize);
+  }
+
+  const proofLimit = Math.max(0, Math.min(options.coverageProofLimit, batchSize));
+  const fastCandidates = [
+    ...rotate("confirmed_close", false, cursor),
+    ...rotate("promotion_probe", false, cursor),
+  ];
+  const proofCursor = cursor?.coverageProof ?? cursor;
+  const proofCandidates = [
+    ...rotate("confirmed_close", true, proofCursor),
+    ...rotate("promotion_probe", true, proofCursor),
+  ];
+  const selectedProof = proofCandidates.slice(0, proofLimit);
+  const selectedFast = fastCandidates.slice(0, batchSize - selectedProof.length);
+  return [...selectedFast, ...selectedProof];
 }
 
 export function proposedItemQualitySummary(
@@ -1336,7 +1375,7 @@ function compareApplyCursorCandidate(
 
 function compareCandidateToApplyCursor(
   candidate: ProposedItemCandidate,
-  cursor: ApplyCursor,
+  cursor: ApplyCursorPosition,
 ): number {
   return (
     compareApplyCheckedAt(candidate.applyCheckedAt, cursor.applyCheckedAt) ||
@@ -1499,10 +1538,14 @@ export function writeCommentSyncCursor(
   );
 }
 
-type ApplyCursor = {
+type ApplyCursorPosition = {
   applyCheckedAt: string;
   number: number;
+};
+
+type ApplyCursor = ApplyCursorPosition & {
   updatedAt: string | null;
+  coverageProof: ApplyCursorPosition | null;
 };
 
 function readApplyCursor(cursorPath: string): ApplyCursor | null {
@@ -1516,7 +1559,17 @@ function readApplyCursor(cursorPath: string): ApplyCursor | null {
       ? parsed.next_after_apply_checked_at
       : "";
   const updatedAt = typeof parsed.updated_at === "string" ? parsed.updated_at : null;
-  return { number, applyCheckedAt, updatedAt };
+  const coverageProof = applyCursorPosition(parsed.coverage_proof_cursor);
+  return { number, applyCheckedAt, updatedAt, coverageProof };
+}
+
+function applyCursorPosition(value: unknown): ApplyCursorPosition | null {
+  if (!isJsonObject(value)) return null;
+  const number = Number(value.next_after_number);
+  if (!Number.isInteger(number) || number < 0) return null;
+  const applyCheckedAt =
+    typeof value.next_after_apply_checked_at === "string" ? value.next_after_apply_checked_at : "";
+  return { number, applyCheckedAt };
 }
 
 function readApplyCursorForSummary(cursorPath: string): ApplyReportSummary["cursor"] {
@@ -1536,17 +1589,45 @@ export function writeApplyCursor(
   reportPath: string,
   targetRepo: string,
   itemNumbers = "",
+  coverageProofItemNumbers = "",
+  cursorTracePath = "",
 ): void {
-  const { number } = applyCursorAdvance(reportPath, itemNumbers);
-  const applyCheckedAt = number > 0 ? applyCheckedAtForItem(targetRepo, number) : "";
+  const previous = readApplyCursor(cursorPath);
+  const selected = positiveCsvNumbers(itemNumbers);
+  const proofNumbers = new Set(positiveCsvNumbers(coverageProofItemNumbers));
+  const examined = cursorTracePath
+    ? readApplyCursorTrace(cursorTracePath)
+    : readApplyActions(reportPath).flatMap((action) =>
+        typeof action.number === "number" && action.number > 0 ? [action.number] : [],
+      );
+  const examinedSet = new Set(examined);
+  const fastSelected = selected.filter((number) => !proofNumbers.has(number));
+  const proofSelected = selected.filter((number) => proofNumbers.has(number));
+  const legacyAdvance = !coverageProofItemNumbers && !cursorTracePath;
+  const fastNumber = legacyAdvance
+    ? applyCursorAdvance(reportPath, itemNumbers).number
+    : (lastExaminedSelectedNumber(fastSelected, examinedSet) ?? previous?.number ?? 0);
+  const previousProof = previous?.coverageProof ?? previous;
+  const proofNumber =
+    lastExaminedSelectedNumber(proofSelected, examinedSet) ?? previousProof?.number ?? 0;
+  const applyCheckedAt = fastNumber > 0 ? applyCheckedAtForItem(targetRepo, fastNumber) : "";
+  const proofApplyCheckedAt = proofNumber > 0 ? applyCheckedAtForItem(targetRepo, proofNumber) : "";
   fs.mkdirSync(path.dirname(cursorPath), { recursive: true });
   fs.writeFileSync(
     cursorPath,
     `${JSON.stringify(
       {
         target_repo: targetRepo,
-        next_after_number: number,
+        next_after_number: fastNumber,
         next_after_apply_checked_at: applyCheckedAt,
+        ...(coverageProofItemNumbers || cursorTracePath
+          ? {
+              coverage_proof_cursor: {
+                next_after_number: proofNumber,
+                next_after_apply_checked_at: proofApplyCheckedAt,
+              },
+            }
+          : {}),
         updated_at: new Date().toISOString(),
       },
       null,
@@ -1555,7 +1636,12 @@ export function writeApplyCursor(
   );
 }
 
-export function applyCursorAdvanceCount(reportPath: string, itemNumbers = ""): number {
+export function applyCursorAdvanceCount(
+  reportPath: string,
+  itemNumbers = "",
+  cursorTracePath = "",
+): number {
+  if (cursorTracePath) return new Set(readApplyCursorTrace(cursorTracePath)).size;
   return applyCursorAdvance(reportPath, itemNumbers).count;
 }
 
@@ -1566,9 +1652,7 @@ function applyCursorAdvance(
   const processed = readApplyActions(reportPath).flatMap((action) =>
     typeof action.number === "number" ? [action.number] : [],
   );
-  const selected = csvItems(itemNumbers)
-    .map((item) => Number(item))
-    .filter((number) => Number.isInteger(number) && number > 0);
+  const selected = positiveCsvNumbers(itemNumbers);
   if (selected.length === 0) {
     return {
       number: processed.at(-1) ?? 0,
@@ -1582,6 +1666,29 @@ function applyCursorAdvance(
     number: selected[cursorIndex] ?? 0,
     count: cursorIndex + 1,
   };
+}
+
+function positiveCsvNumbers(value: string): number[] {
+  return csvItems(value)
+    .map((item) => Number(item))
+    .filter((number) => Number.isInteger(number) && number > 0);
+}
+
+function lastExaminedSelectedNumber(
+  selected: readonly number[],
+  examined: ReadonlySet<number>,
+): number | null {
+  const index = selected.findLastIndex((number) => examined.has(number));
+  return index >= 0 ? (selected[index] ?? null) : null;
+}
+
+function readApplyCursorTrace(tracePath: string): number[] {
+  if (!fs.existsSync(tracePath)) return [];
+  const parsed: unknown = JSON.parse(fs.readFileSync(tracePath, "utf8"));
+  if (!isJsonObject(parsed) || !Array.isArray(parsed.examined_item_numbers)) return [];
+  return parsed.examined_item_numbers
+    .map((number) => Number(number))
+    .filter((number) => Number.isInteger(number) && number > 0);
 }
 
 function applyCheckedAtForItem(targetRepo: string, itemNumber: number): string {
@@ -1600,6 +1707,7 @@ function applyCheckedAtForItem(targetRepo: string, itemNumber: number): string {
 
 function proposedItemOptions(): ProposedItemOptions {
   const batchSizeText = optionalString("batch-size");
+  const coverageProofLimitText = optionalString("coverage-proof-limit");
   return {
     targetRepo: requiredString("target-repo"),
     applyKind: optionalString("apply-kind") || "all",
@@ -1609,6 +1717,7 @@ function proposedItemOptions(): ProposedItemOptions {
     minAgeMinutes: optionalString("min-age-minutes") ? numberArg("min-age-minutes", 0) : null,
     batchSize: batchSizeText ? numberArg("batch-size", 0) : null,
     cursorPath: optionalString("cursor-path") || null,
+    coverageProofLimit: coverageProofLimitText ? numberArg("coverage-proof-limit", 0) : null,
     itemNumbers: itemNumberSet(optionalString("item-numbers")),
   };
 }

--- a/test/apply-cursor-trace.test.ts
+++ b/test/apply-cursor-trace.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+import { runApplyDecisionsForTest, tmpPrefix, workPlanCandidateReport } from "./helpers.ts";
+
+test("apply-decisions preserves auto-selected order and traces only examined records", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const tracePath = join(root, "apply-cursor-trace.json");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    for (const number of [10, 20]) {
+      writeFileSync(
+        join(itemsDir, `${number}.md`),
+        workPlanCandidateReport({
+          repository: "openclaw/openclaw",
+          number,
+          local_checkout_access: "unverified",
+          decision: "keep_open",
+          action_taken: "kept_open",
+        }),
+        "utf8",
+      );
+    }
+
+    runApplyDecisionsForTest({
+      itemsDir,
+      closedDir,
+      plansDir,
+      reportPath,
+      extraArgs: [
+        "--target-repo",
+        "openclaw/openclaw",
+        "--item-numbers",
+        "20,10",
+        "--processed-limit",
+        "1",
+        "--cursor-trace",
+        tracePath,
+      ],
+    });
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    const trace = JSON.parse(readFileSync(tracePath, "utf8"));
+    assert.equal(report[0]?.number, 20);
+    assert.deepEqual(trace, { schema_version: 1, examined_item_numbers: [20] });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -1664,6 +1664,70 @@ test("workflow utilities backfill promotion probes after confirmed close proposa
   );
 });
 
+test("workflow utilities bound coverage proofs with an independent cursor", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const oldDate = "2024-01-01T00:00:00Z";
+  const cursorPath = path.join(root, "results/apply-cursors/openclaw-openclaw.json");
+  writeProposedRecord(root, 10, "issue", "proposed_close", "implemented_on_main", oldDate, {
+    applyCheckedAt: "2026-01-01T00:00:00Z",
+  });
+  writeProposedRecord(root, 20, "issue", "proposed_close", "implemented_on_main", oldDate, {
+    applyCheckedAt: "2026-01-02T00:00:00Z",
+  });
+  writeProposedRecord(root, 30, "issue", "proposed_close", "implemented_on_main", oldDate, {
+    applyCheckedAt: "2026-01-03T00:00:00Z",
+  });
+  writeProposedRecord(
+    root,
+    40,
+    "pull_request",
+    "proposed_close",
+    "duplicate_or_superseded",
+    oldDate,
+    { applyCheckedAt: "2026-01-01T00:00:00Z" },
+  );
+  writeProposedRecord(
+    root,
+    50,
+    "pull_request",
+    "proposed_close",
+    "duplicate_or_superseded",
+    oldDate,
+    { applyCheckedAt: "2026-01-02T00:00:00Z" },
+  );
+  const options = {
+    targetRepo: "openclaw/openclaw",
+    applyKind: "all",
+    applyCloseReasons: "all",
+    staleMinAgeDays: 60,
+    minAgeDays: 0,
+    minAgeMinutes: null,
+    batchSize: 4,
+    coverageProofLimit: 1,
+    cursorPath,
+  };
+
+  assert.deepEqual(
+    withCwd(root, () => proposedItemNumbers(options)),
+    [10, 20, 30, 40],
+  );
+  write(
+    cursorPath,
+    JSON.stringify({
+      next_after_number: 20,
+      next_after_apply_checked_at: "2026-01-02T00:00:00Z",
+      coverage_proof_cursor: {
+        next_after_number: 40,
+        next_after_apply_checked_at: "2026-01-01T00:00:00Z",
+      },
+    }),
+  );
+  assert.deepEqual(
+    withCwd(root, () => proposedItemNumbers(options)),
+    [30, 10, 20, 50],
+  );
+});
+
 test("workflow utilities persist apply cursor from processed or selected items", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
   const cursorPath = path.join(root, "results/apply-cursors/openclaw-openclaw.json");
@@ -1693,6 +1757,63 @@ test("workflow utilities persist apply cursor from processed or selected items",
       ["openclaw/openclaw", 20, "2026-01-02T00:00:00Z"],
     );
   }
+});
+
+test("workflow utilities advance fast and coverage-proof cursors from the exact scan trace", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const cursorPath = path.join(root, "results/apply-cursors/openclaw-openclaw.json");
+  const reportPath = path.join(root, "apply-report.json");
+  const tracePath = path.join(root, "apply-cursor-trace.json");
+  const oldDate = "2024-01-01T00:00:00Z";
+  writeProposedRecord(root, 10, "issue", "proposed_close", "implemented_on_main", oldDate, {
+    applyCheckedAt: "2026-01-01T00:00:00Z",
+  });
+  writeProposedRecord(root, 20, "issue", "proposed_close", "implemented_on_main", oldDate, {
+    applyCheckedAt: "2026-01-02T00:00:00Z",
+  });
+  writeProposedRecord(
+    root,
+    30,
+    "pull_request",
+    "proposed_close",
+    "duplicate_or_superseded",
+    oldDate,
+    { applyCheckedAt: "2026-01-03T00:00:00Z" },
+  );
+  writeProposedRecord(
+    root,
+    40,
+    "pull_request",
+    "proposed_close",
+    "duplicate_or_superseded",
+    oldDate,
+    { applyCheckedAt: "2026-01-04T00:00:00Z" },
+  );
+  write(reportPath, JSON.stringify([{ number: 10, action: "kept_open" }]));
+  write(tracePath, JSON.stringify({ schema_version: 1, examined_item_numbers: [10, 30] }));
+
+  withCwd(root, () =>
+    writeApplyCursor(cursorPath, reportPath, "openclaw/openclaw", "10,20,30", "30", tracePath),
+  );
+  let cursor = JSON.parse(fs.readFileSync(cursorPath, "utf8"));
+  assert.deepEqual(
+    [
+      cursor.next_after_number,
+      cursor.next_after_apply_checked_at,
+      cursor.coverage_proof_cursor.next_after_number,
+      cursor.coverage_proof_cursor.next_after_apply_checked_at,
+    ],
+    [10, "2026-01-01T00:00:00Z", 30, "2026-01-03T00:00:00Z"],
+  );
+  assert.equal(applyCursorAdvanceCount(reportPath, "10,20,30", tracePath), 2);
+
+  write(tracePath, JSON.stringify({ schema_version: 1, examined_item_numbers: [20] }));
+  withCwd(root, () =>
+    writeApplyCursor(cursorPath, reportPath, "openclaw/openclaw", "20,40", "40", tracePath),
+  );
+  cursor = JSON.parse(fs.readFileSync(cursorPath, "utf8"));
+  assert.equal(cursor.next_after_number, 20);
+  assert.equal(cursor.coverage_proof_cursor.next_after_number, 30);
 });
 
 test("workflow utilities count records advanced by the apply cursor", () => {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import {
   chmodSync,
   mkdirSync,
@@ -155,6 +156,7 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
   assert.match(inputBlock, /apply_checkpoint_size:[\s\S]*default: "20"/);
   assert.match(applyStep, /Capping apply checkpoint size at 20/);
   assert.match(applyStep, /base_close_processed_limit=300/);
+  assert.match(applyStep, /coverage_proof_limit=1/);
   assert.match(applyStep, /max_close_processed_limit=900/);
   assert.match(applyStep, /close_processed_limit="\$base_close_processed_limit"/);
   assert.match(applyStep, /source scripts\/apply-workflow-helpers\.sh/);
@@ -205,6 +207,12 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
   assert.ok(qualitySummaryIndex > applyReconcileIndex);
   assert.ok(proposedNumbersIndex > qualitySummaryIndex);
   assert.match(applyStep, /--batch-size "\$close_processed_limit"/);
+  assert.match(applyStep, /--coverage-proof-limit "\$coverage_proof_limit"/);
+  assert.match(applyStep, /select_bounded_coverage_proof_tail/);
+  assert.match(applyHelper, /select_bounded_coverage_proof_tail\(\)/);
+  assert.match(applyHelper, /proposed-pr-close-coverage-item-numbers/);
+  assert.match(applyHelper, /drop_bounded_coverage_proof_tail\(\)/);
+  assert.match(applyStep, /drop_bounded_coverage_proof_tail "\$cursor_trace_path"/);
   assert.match(
     applyStep,
     /Scan window: \$close_processed_limit records \(\$adaptive_apply_scan_reason\)/,
@@ -216,6 +224,9 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
   assert.match(applyStep, /--cursor-path "\$apply_cursor_path"/);
   assert.match(applyStep, /write-apply-cursor/);
   assert.match(applyStep, /--item-numbers "\$item_numbers"/);
+  assert.match(applyStep, /--coverage-proof-item-numbers "\$coverage_proof_item_numbers"/);
+  assert.match(applyStep, /--cursor-trace "\$cursor_trace_path"/);
+  assert.match(applyStep, /cursor_trace_arg=\(--cursor-trace "\$cursor_trace_path"\)/);
   assert.match(applyStep, /results\/apply-cursors/);
   assert.match(applyStep, /reached its \$close_processed_limit-record budget/);
   assert.match(applyStep, /next scheduled apply run will advance the next window/);
@@ -256,6 +267,48 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
   assert.match(continueStep, /already covered by \$/);
   assert.match(continueStep, /-f apply_item_numbers="\$APPLY_ITEM_NUMBERS"/);
   assert.doesNotMatch(continueStep, /APPLY_CLOSED_TOTAL:-0.*APPLY_LIMIT:-0/);
+});
+
+test("apply workflow drops a coverage-proof tail only after exact trace examination", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const fastOnlyTrace = join(root, "fast-only.json");
+  const proofTrace = join(root, "proof.json");
+  writeFileSync(
+    fastOnlyTrace,
+    JSON.stringify({ schema_version: 1, examined_item_numbers: [10, 20] }),
+  );
+  writeFileSync(proofTrace, JSON.stringify({ schema_version: 1, examined_item_numbers: [30] }));
+
+  try {
+    const output = execFileSync(
+      "bash",
+      [
+        "-lc",
+        [
+          "source scripts/apply-workflow-helpers.sh",
+          "auto_selected_apply_batch=true",
+          "item_numbers=10,20,30",
+          "coverage_proof_item_numbers=30",
+          'item_numbers_arg=(--item-numbers "$item_numbers")',
+          'drop_bounded_coverage_proof_tail "$FAST_ONLY_TRACE"',
+          'printf \'%s|%s|%s\\n\' "$item_numbers" "$coverage_proof_item_numbers" "${item_numbers_arg[*]}"',
+          'drop_bounded_coverage_proof_tail "$PROOF_TRACE"',
+          'printf \'%s|%s|%s\\n\' "$item_numbers" "$coverage_proof_item_numbers" "${item_numbers_arg[*]}"',
+        ].join("\n"),
+      ],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: { ...process.env, FAST_ONLY_TRACE: fastOnlyTrace, PROOF_TRACE: proofTrace },
+      },
+    );
+    assert.deepEqual(output.trim().split("\n"), [
+      "10,20,30|30|--item-numbers 10,20,30",
+      "10,20||--item-numbers 10,20",
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("apply workflow syncs source checkout before state hydration", () => {


### PR DESCRIPTION
## Summary

- cap automatic apply windows at one expensive PR coverage proof
- keep fast candidates ahead of the proof tail without changing explicit targeted applies
- persist independent fast and proof cursors from the exact executor trace
- retain unexamined proof work across checkpoints and scheduled continuations

## Why

Production proof on #415 showed that one legitimate PR coverage proof can dominate a 300-record apply window. This keeps the model-backed close-safety proof intact while preventing it from consuming the whole fast-close lane.

## Safety

Coverage semantics, live hydration, freshness checks, protected-label gates, and post-proof rechecks are unchanged. Legacy cursor files fall back to the existing top-level cursor. The executor advances only records it actually examined.

## Validation

- focused scheduler/apply suite: 77/77
- full repository check: 671 core tests and 620 repair tests
- changed coverage: 100% lines, 89.17% branches, 100% functions
- full coverage: 77.20% lines, 71.27% branches, 84.43% functions
- formatting and diff checks clean
- AutoReview clean after fixing its checkpoint-trace finding
