### PR TITLE
ci: make Pages reruns artifact-safe

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,6 +24,8 @@ jobs:
     name: Deploy docs
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      PAGES_ARTIFACT_NAME: github-pages-${{ github.run_attempt }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -45,8 +47,11 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:
+          name: ${{ env.PAGES_ARTIFACT_NAME }}
           path: dist/docs-site
 
       - name: Deploy
         id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          artifact_name: ${{ env.PAGES_ARTIFACT_NAME }}

--- a/test/pages-workflow.test.ts
+++ b/test/pages-workflow.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+test("Pages reruns upload and deploy a run-attempt-scoped artifact", () => {
+  const workflow = readFileSync(".github/workflows/pages.yml", "utf8");
+
+  assert.match(workflow, /PAGES_ARTIFACT_NAME: github-pages-\$\{\{ github\.run_attempt \}\}/);
+  assert.equal(workflow.match(/\$\{\{ env\.PAGES_ARTIFACT_NAME \}\}/g)?.length, 2);
+  assert.match(
+    workflow,
+    /uses: actions\/upload-pages-artifact@v4\n\s+with:\n\s+name: \$\{\{ env\.PAGES_ARTIFACT_NAME \}\}/,
+  );
+  assert.match(
+    workflow,
+    /uses: actions\/deploy-pages@v4\n\s+with:\n\s+artifact_name: \$\{\{ env\.PAGES_ARTIFACT_NAME \}\}/,
+  );
+});


### PR DESCRIPTION
## Summary

- scope each Pages artifact name to `github.run_attempt`
- pass the same exact artifact name to `actions/deploy-pages`
- add a workflow regression test for the upload/deploy contract

## Why

The first Pages deployment for #420 reached GitHub Pages and failed transiently. Rerunning the failed job then uploaded a second immutable artifact named `github-pages`, so `actions/deploy-pages` refused the retry because two artifacts shared that name.

This makes every retry use a unique artifact while preserving the required upload/deploy name match.

Failed run: https://github.com/openclaw/clawsweeper/actions/runs/28749371638

## Validation

- `node --test test/pages-workflow.test.ts`
- `pnpm run lint:scripts`
- `pnpm run format:check`
- `git diff --check`
- AutoReview clean

No changelog entry: CI-only retry hardening.
