### PR TITLE
fix: bound automatic apply runtime

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2333,14 +2333,9 @@ jobs:
           apply_close_reasons="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_close_reasons || 'all' }}"
           stale_min_age_days="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_stale_min_age_days || '60' }}"
           close_delay_ms="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_close_delay_ms || '2000' }}"
-          progress_every="10"
           checkpoint_size="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_checkpoint_size || '20' }}"
           comment_sync_processed_limit=1000
           base_close_processed_limit=300
-          coverage_proof_limit=1
-          # Consumed by the sourced workflow helpers.
-          # shellcheck disable=SC2034
-          max_close_processed_limit=900
           close_processed_limit="$base_close_processed_limit"
           adaptive_apply_scan_reason="base_window"
           sync_batch_size="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_limit || '25' }}"
@@ -2471,6 +2466,7 @@ jobs:
           if [ -n "$item_numbers" ]; then
             item_numbers_arg=(--item-numbers "$item_numbers")
           fi
+          select_automatic_apply_runtime
           if [ "$sync_comments_only" != "true" ] && [ -z "$item_numbers" ]; then
             echo "No unchanged high-confidence close proposals are awaiting apply. Scheduled apply wakes every 15 minutes and exits without scanning unrelated keep-open records when there is no close work."
             pnpm run status -- \
@@ -2587,6 +2583,7 @@ jobs:
               --processed-limit "$close_processed_limit" \
               --comment-sync-min-age-days "$comment_sync_min_age_days" \
               "${item_numbers_arg[@]}" \
+              "${max_runtime_arg[@]}" \
               "${cursor_trace_arg[@]}" \
               "${sync_comments_arg[@]}"
             cp apply-report.json ".artifacts/apply-reports/apply-report-$checkpoint.json"
@@ -2625,6 +2622,7 @@ jobs:
             publish_status "chore: update sweep apply checkpoint $checkpoint status"
             echo "::endgroup::"
             drop_bounded_coverage_proof_tail "$cursor_trace_path"
+            if automatic_apply_runtime_reached ".artifacts/apply-reports/apply-report-$checkpoint.json"; then break; fi
             if [ "$result_count" -ge "$close_processed_limit" ]; then
               if [ "$closed_in_chunk" -gt 0 ]; then
                 echo "Close scan reached its $close_processed_limit-record budget; queueing a fresh-token continuation."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Bounded automatic close-apply checkpoints to ten minutes, persisted exact cursor progress before immediate continuation, and limited close-coverage proofs to the time remaining in the checkpoint.
 - Kept automatic apply windows responsive by running at most one PR close-coverage proof after fast candidates and advancing independent fast/proof cursors only through records actually examined.
 - Prevented malformed `maintainer_decision` records from repeatedly consuming apply queue slots by recording their deterministic apply bookkeeping. Thanks @brokemac79.
 - Preserved ready-for-maintainer labels when a newer durable review matches the current PR head, while still removing readiness from stale-head reviews. Thanks @brokemac79.

--- a/scripts/apply-workflow-helpers.sh
+++ b/scripts/apply-workflow-helpers.sh
@@ -4,6 +4,10 @@
 # settings as shell variables before sourcing this file.
 # shellcheck disable=SC2034,SC2154
 
+max_close_processed_limit=900
+coverage_proof_limit=1
+progress_every=10
+
 publish_changes() {
   local message="$1"
   shift
@@ -56,6 +60,25 @@ write_apply_health() {
     health_args+=(--cursor-advance-count "$health_cursor_advance_count")
   fi
   pnpm run --silent workflow -- summarize-apply-report "${health_args[@]}" > "$output_path"
+}
+
+select_automatic_apply_runtime() {
+  max_runtime_arg=()
+  if [ "$auto_selected_apply_batch" = "true" ]; then
+    max_runtime_arg=(--max-runtime-ms 600000)
+  fi
+}
+
+automatic_apply_runtime_reached() {
+  local report_path="$1"
+  local runtime_budget_count
+  runtime_budget_count="$(pnpm run --silent workflow -- count-actions --report "$report_path" --action skipped_runtime_budget)"
+  if [ "$runtime_budget_count" -eq 0 ]; then
+    return 1
+  fi
+  echo "Automatic close checkpoint reached its 600000ms runtime budget; cursor is persisted and a fresh-token continuation will resume the lane."
+  continue_apply=true
+  return 0
 }
 
 select_adaptive_apply_batch() {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -13763,6 +13763,44 @@ type PrCloseCoverageProofGateResult =
   | { status: "blocked"; block: PrCloseCoverageProofGateBlock }
   | null;
 
+interface PrCloseCoverageRuntimeBudget {
+  startedAtMs: number;
+  maxRuntimeMs: number;
+}
+
+function prCloseCoverageRuntimeBudgetBlock(
+  runtimeBudget: PrCloseCoverageRuntimeBudget | undefined,
+  phase: string,
+): PrCloseCoverageProofGateResult {
+  if (
+    !runtimeBudget ||
+    !runtimeBudgetExceeded(runtimeBudget.startedAtMs, runtimeBudget.maxRuntimeMs, Date.now())
+  ) {
+    return null;
+  }
+  return {
+    status: "blocked",
+    block: {
+      actionTaken: "skipped_runtime_budget",
+      reason: `max runtime ${runtimeBudget.maxRuntimeMs}ms reached ${phase} PR close coverage proof`,
+    },
+  };
+}
+
+function prCloseCoverageRuntime(
+  runtime: PrCloseCoverageProofRuntime,
+  runtimeBudget: PrCloseCoverageRuntimeBudget | undefined,
+): PrCloseCoverageProofRuntime | null {
+  if (!runtimeBudget) return runtime;
+  const timeoutMs = timeoutWithinRuntimeBudget(
+    runtimeBudget.startedAtMs,
+    runtimeBudget.maxRuntimeMs,
+    runtime.timeoutMs,
+    Date.now(),
+  );
+  return timeoutMs === null ? null : { ...runtime, timeoutMs };
+}
+
 function sourcePrCloseCoveragePullRequestView(
   item: Item,
   context: ItemContext,
@@ -13846,8 +13884,19 @@ function prCloseCoverageProofGateResult(options: {
   item: Item;
   context: ItemContext;
   runtime: PrCloseCoverageProofRuntime;
+  runtimeBudget?: PrCloseCoverageRuntimeBudget;
 }): PrCloseCoverageProofGateResult {
+  const beforeCandidateResolution = prCloseCoverageRuntimeBudgetBlock(
+    options.runtimeBudget,
+    "before resolving",
+  );
+  if (beforeCandidateResolution) return beforeCandidateResolution;
   const candidateRefs = prCloseCoverageProofCandidateRefs(options.markdown, options.item);
+  const afterCandidateResolution = prCloseCoverageRuntimeBudgetBlock(
+    options.runtimeBudget,
+    "while resolving",
+  );
+  if (afterCandidateResolution) return afterCandidateResolution;
   if (candidateRefs.length === 0) return null;
 
   const source = sourcePrCloseCoveragePullRequestView(options.item, options.context);
@@ -13863,10 +13912,20 @@ function prCloseCoverageProofGateResult(options: {
   let checkedPullRequestCandidate = false;
   for (const candidateRef of candidateRefs) {
     const linkedNumber = candidateRef.number;
+    const beforeHydration = prCloseCoverageRuntimeBudgetBlock(
+      options.runtimeBudget,
+      "before hydrating",
+    );
+    if (beforeHydration) return beforeHydration;
     let covering: PrCloseCoverageProofPullRequestView;
     try {
       covering = coveringView(linkedNumber);
     } catch (error) {
+      const hydrationBudgetBlock = prCloseCoverageRuntimeBudgetBlock(
+        options.runtimeBudget,
+        "while hydrating",
+      );
+      if (hydrationBudgetBlock) return hydrationBudgetBlock;
       if (candidateRef.kind !== "pull_url" && shorthandRefIsIssue(linkedNumber)) continue;
       return {
         status: "blocked",
@@ -13878,6 +13937,11 @@ function prCloseCoverageProofGateResult(options: {
         },
       };
     }
+    const afterHydration = prCloseCoverageRuntimeBudgetBlock(
+      options.runtimeBudget,
+      "while hydrating",
+    );
+    if (afterHydration) return afterHydration;
     checkedPullRequestCandidate = true;
     if (!prCloseCoverageProofCandidateCanClose(covering)) {
       return {
@@ -13887,6 +13951,10 @@ function prCloseCoverageProofGateResult(options: {
           reason: `linked canonical PR #${linkedNumber} is ${covering.state || "not open"} and unmerged; refusing duplicate/superseded auto-close`,
         },
       };
+    }
+    const proofRuntime = prCloseCoverageRuntime(options.runtime, options.runtimeBudget);
+    if (!proofRuntime) {
+      return prCloseCoverageRuntimeBudgetBlock(options.runtimeBudget, "before running");
     }
     try {
       const proof = runPrCloseCoverageProofModel({
@@ -13898,7 +13966,7 @@ function prCloseCoverageProofGateResult(options: {
           options.item.number,
           linkedNumber,
         ),
-        runtime: options.runtime,
+        runtime: proofRuntime,
       });
       const closeDecision = prCloseCoverageProofCloseDecision(proof);
       if (closeDecision.close) {
@@ -13917,6 +13985,11 @@ function prCloseCoverageProofGateResult(options: {
         reason: `PR close coverage proof kept this PR open against ${covering.url}: ${closeDecision.reason}`,
       };
     } catch (error) {
+      const proofBudgetBlock = prCloseCoverageRuntimeBudgetBlock(
+        options.runtimeBudget,
+        "while running",
+      );
+      if (proofBudgetBlock) return proofBudgetBlock;
       return {
         status: "blocked",
         block: {
@@ -16207,6 +16280,61 @@ export function runtimeBudgetExceeded(
   return maxRuntimeMs > 0 && nowMs - startedAtMs >= maxRuntimeMs;
 }
 
+export function removeCurrentCursorTraceItem(
+  examinedItemNumbers: number[],
+  currentNumber: number,
+): void {
+  if (examinedItemNumbers.at(-1) === currentNumber) examinedItemNumbers.pop();
+}
+
+export function timeoutWithinRuntimeBudget(
+  startedAtMs: number,
+  maxRuntimeMs: number,
+  requestedTimeoutMs: number,
+  nowMs: number,
+): number | null {
+  if (maxRuntimeMs <= 0) return requestedTimeoutMs;
+  const remainingMs = maxRuntimeMs - (nowMs - startedAtMs);
+  return remainingMs > 0 ? Math.min(requestedTimeoutMs, remainingMs) : null;
+}
+
+export function coverageProofRetryExhaustedRuntimeBudget(
+  startedAtMs: number,
+  maxRuntimeMs: number,
+  actionTaken: string,
+  nowMs: number,
+): boolean {
+  return (
+    actionTaken === "retry_pr_close_coverage_proof" &&
+    runtimeBudgetExceeded(startedAtMs, maxRuntimeMs, nowMs)
+  );
+}
+
+export function recordedLabelSyncCoversUpdate(options: {
+  itemUpdatedAt: string;
+  labelsSyncedAt: string | undefined;
+  liveLabels: readonly string[];
+  recordedLabels: readonly string[];
+  hasNonAutomationActivity: boolean;
+}): boolean {
+  const itemUpdatedAtMs = timestampMs(options.itemUpdatedAt);
+  const labelsSyncedAtMs = timestampMs(options.labelsSyncedAt);
+  if (
+    itemUpdatedAtMs === null ||
+    labelsSyncedAtMs === null ||
+    itemUpdatedAtMs > labelsSyncedAtMs ||
+    options.hasNonAutomationActivity
+  ) {
+    return false;
+  }
+  const liveLabelSet = normalizedLabelSet(options.liveLabels);
+  const recordedLabelSet = normalizedLabelSet(options.recordedLabels);
+  return (
+    liveLabelSet.size === recordedLabelSet.size &&
+    [...liveLabelSet].every((label) => recordedLabelSet.has(label))
+  );
+}
+
 function updateReviewCommentMetadata(
   markdown: string,
   comment: Record<string, unknown> | undefined,
@@ -18169,6 +18297,13 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
     let cachedPrCloseCoverageProofGateResult: PrCloseCoverageProofGateResult | undefined;
     let prCloseCoverageProofGateChecked = false;
     let prCloseCoverageProofStartedAtMs: number | null = null;
+    const runtimeBudgetProofBlock = (phase = "before"): PrCloseCoverageProofGateResult => ({
+      status: "blocked",
+      block: {
+        actionTaken: "skipped_runtime_budget",
+        reason: `max runtime ${maxRuntimeMs}ms reached ${phase} PR close coverage proof`,
+      },
+    });
     const currentPrCloseCoverageProofGateBlock = (): PrCloseCoverageProofGateBlock | null => {
       if (cachedPrCloseCoverageProofGateResult === undefined) {
         prCloseCoverageProofGateChecked = true;
@@ -18176,13 +18311,45 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
           frontMatterValue(markdown, "decision") === "close" &&
           closeReason === "duplicate_or_superseded"
         ) {
-          prCloseCoverageProofStartedAtMs = Date.now();
-          cachedPrCloseCoverageProofGateResult = prCloseCoverageProofGateResult({
-            markdown,
-            item,
-            context: currentItemContext(),
-            runtime: prCloseCoverageProofRuntime,
-          });
+          let proofTimeoutMs = timeoutWithinRuntimeBudget(
+            startedAtMs,
+            maxRuntimeMs,
+            prCloseCoverageProofRuntime.timeoutMs,
+            Date.now(),
+          );
+          if (proofTimeoutMs === null) {
+            cachedPrCloseCoverageProofGateResult = runtimeBudgetProofBlock();
+          } else {
+            const context = currentItemContext();
+            proofTimeoutMs = timeoutWithinRuntimeBudget(
+              startedAtMs,
+              maxRuntimeMs,
+              prCloseCoverageProofRuntime.timeoutMs,
+              Date.now(),
+            );
+            if (proofTimeoutMs === null) {
+              cachedPrCloseCoverageProofGateResult = runtimeBudgetProofBlock();
+            } else {
+              prCloseCoverageProofStartedAtMs = Date.now();
+              const proofGateResult = prCloseCoverageProofGateResult({
+                markdown,
+                item,
+                context,
+                runtime: { ...prCloseCoverageProofRuntime, timeoutMs: proofTimeoutMs },
+                runtimeBudget: { startedAtMs, maxRuntimeMs },
+              });
+              cachedPrCloseCoverageProofGateResult =
+                proofGateResult?.status === "blocked" &&
+                coverageProofRetryExhaustedRuntimeBudget(
+                  startedAtMs,
+                  maxRuntimeMs,
+                  proofGateResult.block.actionTaken,
+                  Date.now(),
+                )
+                  ? runtimeBudgetProofBlock("during")
+                  : proofGateResult;
+            }
+          }
         } else {
           cachedPrCloseCoverageProofGateResult = null;
         }
@@ -18190,6 +18357,15 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       return cachedPrCloseCoverageProofGateResult?.status === "blocked"
         ? cachedPrCloseCoverageProofGateResult.block
         : null;
+    };
+    const recordRuntimeBudgetYield = (reason: string): void => {
+      if (clawSweeperLabelsChanged && !dryRun) {
+        markdown = replaceFrontMatterValue(markdown, "labels_synced_at", new Date().toISOString());
+        writeReportMarkdown(path, markdown);
+      }
+      removeCurrentCursorTraceItem(examinedItemNumbers, number);
+      results.push({ number: 0, action: "skipped_runtime_budget", reason });
+      logProgress(`stopping apply: ${reason}`);
     };
     const sameAuthorPairStartCloseable = new Map<string, boolean>();
     const currentCloseGatesPassed = (): boolean => {
@@ -18547,9 +18723,27 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
     }
     const updatedSinceReview = Boolean(storedUpdatedAt && item.updatedAt !== storedUpdatedAt);
     const reviewCommentOnlyUpdate = item.updatedAt === commentUpdatedAt(existingReviewComment);
+    const storedUpdatedAtMs = timestampMs(storedUpdatedAt);
+    const recordedLabelSyncMatches =
+      updatedSinceReview &&
+      recordedLabelSyncCoversUpdate({
+        itemUpdatedAt: item.updatedAt,
+        labelsSyncedAt: frontMatterValue(markdown, "labels_synced_at"),
+        liveLabels: item.labels,
+        recordedLabels: reportLabelsBeforeApply,
+        hasNonAutomationActivity: false,
+      });
+    const labelSyncOnlyUpdate = Boolean(
+      recordedLabelSyncMatches &&
+      storedUpdatedAtMs !== null &&
+      !contextHasNonAutomationActivityAfter(currentItemContext(), storedUpdatedAtMs, {
+        truncationCountsAsActivity: true,
+      }),
+    );
+    const automationOnlyUpdate = reviewCommentOnlyUpdate || labelSyncOnlyUpdate;
     const labelSyncFreshEnough = (): boolean => {
       if (!storedUpdatedAt) return false;
-      if (!updatedSinceReview || reviewCommentOnlyUpdate) return true;
+      if (!updatedSinceReview || automationOnlyUpdate) return true;
       const completeFreshHeadReview =
         !isCloseProposal &&
         item.kind === "pull_request" &&
@@ -18884,7 +19078,7 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
         break;
       continue;
     }
-    if (isCloseProposal && updatedSinceReview && !reviewCommentOnlyUpdate) {
+    if (isCloseProposal && updatedSinceReview && !automationOnlyUpdate) {
       markdown = replaceFrontMatterValue(markdown, "action_taken", "skipped_changed_since_review");
       markdown = replaceFrontMatterValue(markdown, "current_item_updated_at", item.updatedAt);
       markdown = replaceFrontMatterValue(markdown, "apply_checked_at", new Date().toISOString());
@@ -19094,6 +19288,10 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       ) {
         const prCloseCoverageBlock = currentPrCloseCoverageProofGateBlock();
         if (prCloseCoverageBlock) {
+          if (prCloseCoverageBlock.actionTaken === "skipped_runtime_budget") {
+            recordRuntimeBudgetYield(prCloseCoverageBlock.reason);
+            break;
+          }
           if (prCloseCoverageBlock.actionTaken !== "skipped_pr_close_coverage_proof") {
             if (markApplySkipped(prCloseCoverageBlock.actionTaken, prCloseCoverageBlock.reason))
               break;
@@ -19342,6 +19540,10 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
     const prCloseCoverageBlock =
       closeReason === "duplicate_or_superseded" ? currentPrCloseCoverageProofGateBlock() : null;
     if (prCloseCoverageBlock) {
+      if (prCloseCoverageBlock.actionTaken === "skipped_runtime_budget") {
+        recordRuntimeBudgetYield(prCloseCoverageBlock.reason);
+        break;
+      }
       if (markApplySkipped(prCloseCoverageBlock.actionTaken, prCloseCoverageBlock.reason)) break;
       continue;
     }

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -572,8 +572,13 @@ export function summarizeApplyReport(options: ApplyReportSummaryOptions): ApplyR
   ) {
     attentionReasons.push("cursor_required_but_missing_after_full_window");
   }
-  for (const reason of ["skipped_runtime_budget", "skipped_live_fetch_failed"]) {
-    if ((skipReasons[reason] || 0) > 0) attentionReasons.push(reason);
+  const resumableRuntimeBudget =
+    options.cursorRequired && Boolean(cursor) && (options.cursorAdvanceCount ?? 0) > 0;
+  if ((skipReasons.skipped_runtime_budget || 0) > 0 && !resumableRuntimeBudget) {
+    attentionReasons.push("skipped_runtime_budget");
+  }
+  if ((skipReasons.skipped_live_fetch_failed || 0) > 0) {
+    attentionReasons.push("skipped_live_fetch_failed");
   }
   if (actions.length > 0 && skipped === actions.length) {
     const benignSkipReasons = new Set([
@@ -581,6 +586,7 @@ export function summarizeApplyReport(options: ApplyReportSummaryOptions): ApplyR
       "skipped_closed",
       "skipped_not_open",
     ]);
+    if (resumableRuntimeBudget) benignSkipReasons.add("skipped_runtime_budget");
     for (const reason of Object.keys(skipReasons).sort()) {
       if (!benignSkipReasons.has(reason) && !attentionReasons.includes(reason)) {
         attentionReasons.push(reason);

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -12,6 +12,7 @@ import {
   codexEnv,
   codexLoginConfig,
   codexLoginMethod,
+  coverageProofRetryExhaustedRuntimeBudget,
   dashboardClosedAt,
   formatRecentClosedRows,
   ghRetryKind,
@@ -24,8 +25,10 @@ import {
   parseDecision,
   relatedGitHubIssueSearchQueryForTest,
   relatedTitleSearchTerms,
+  recordedLabelSyncCoversUpdate,
   renderReviewCommentFromReport,
   renderReviewStartStatusComment,
+  removeCurrentCursorTraceItem,
   reviewArtifactDestination,
   reviewCodexForcedLoginMethodForTest,
   runtimeBudgetExceeded,
@@ -33,6 +36,7 @@ import {
   shardItemNumbers,
   shouldSyncReviewComment,
   shouldRetryGh,
+  timeoutWithinRuntimeBudget,
 } from "../dist/clawsweeper.js";
 import { parseArgs as parseClawsweeperArgs } from "../dist/clawsweeper-args.js";
 import { AUTOMATION_LIMITS } from "../dist/limits.js";
@@ -1894,6 +1898,83 @@ test("runtime budget only trips after a positive elapsed limit", () => {
   assert.equal(runtimeBudgetExceeded(1000, 0, 100000), false);
   assert.equal(runtimeBudgetExceeded(1000, 5000, 5999), false);
   assert.equal(runtimeBudgetExceeded(1000, 5000, 6000), true);
+});
+
+test("coverage proof timeout cannot exceed the remaining apply runtime", () => {
+  assert.equal(timeoutWithinRuntimeBudget(1000, 0, 600_000, 900_000), 600_000);
+  assert.equal(timeoutWithinRuntimeBudget(1000, 600_000, 600_000, 301_000), 300_000);
+  assert.equal(timeoutWithinRuntimeBudget(1000, 600_000, 600_000, 601_000), null);
+});
+
+test("coverage proof refreshes its timeout after linked PR hydration", () => {
+  const source = readText("src/clawsweeper.ts");
+  const gateStart = source.indexOf("function prCloseCoverageProofGateResult");
+  const gateEnd = source.indexOf("function renderPrCloseCoverageProofReportSection", gateStart);
+  const gate = source.slice(gateStart, gateEnd);
+  const hydration = gate.indexOf("covering = coveringView(linkedNumber)");
+  const runtimeRefresh = gate.indexOf(
+    "const proofRuntime = prCloseCoverageRuntime(options.runtime, options.runtimeBudget)",
+  );
+  const modelRun = gate.indexOf("runPrCloseCoverageProofModel");
+
+  assert.ok(hydration >= 0);
+  assert.ok(runtimeRefresh > hydration);
+  assert.ok(modelRun > runtimeRefresh);
+  assert.match(gate, /runtime: proofRuntime/);
+});
+
+test("coverage proof retry becomes an exact cursor yield after exhausting runtime", () => {
+  assert.equal(
+    coverageProofRetryExhaustedRuntimeBudget(
+      1000,
+      600_000,
+      "retry_pr_close_coverage_proof",
+      601_000,
+    ),
+    true,
+  );
+  assert.equal(
+    coverageProofRetryExhaustedRuntimeBudget(
+      1000,
+      600_000,
+      "retry_pr_close_coverage_proof",
+      600_999,
+    ),
+    false,
+  );
+  assert.equal(
+    coverageProofRetryExhaustedRuntimeBudget(1000, 600_000, "kept_open", 601_000),
+    false,
+  );
+});
+
+test("recorded label sync covers only matching automation-owned updates", () => {
+  const base = {
+    itemUpdatedAt: "2026-07-05T18:00:00Z",
+    labelsSyncedAt: "2026-07-05T18:00:01Z",
+    liveLabels: ["status: ready", "proof: sufficient"],
+    recordedLabels: ["proof: sufficient", "status: ready"],
+    hasNonAutomationActivity: false,
+  };
+  assert.equal(recordedLabelSyncCoversUpdate(base), true);
+  assert.equal(recordedLabelSyncCoversUpdate({ ...base, liveLabels: ["status: ready"] }), false);
+  assert.equal(recordedLabelSyncCoversUpdate({ ...base, hasNonAutomationActivity: true }), false);
+  assert.equal(
+    recordedLabelSyncCoversUpdate({ ...base, itemUpdatedAt: "2026-07-05T18:00:02Z" }),
+    false,
+  );
+  assert.match(
+    readText("src/clawsweeper.ts"),
+    /recordedLabelSyncMatches[\s\S]*truncationCountsAsActivity: true/,
+  );
+});
+
+test("runtime yield keeps the unfinished item out of the apply cursor trace", () => {
+  const examined = [10, 20];
+  removeCurrentCursorTraceItem(examined, 20);
+  assert.deepEqual(examined, [10]);
+  removeCurrentCursorTraceItem(examined, 30);
+  assert.deepEqual(examined, [10]);
 });
 
 test("spam comment intake coalesces duplicate comment deliveries", () => {

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -526,6 +526,61 @@ test("workflow utilities flag full-window close scans without the required curso
   assert.match(summary.summary, /Attention:/);
 });
 
+test("workflow utilities keep a resumable runtime yield healthy", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const reportPath = path.join(root, "apply-report.json");
+  const cursorPath = path.join(root, "apply-cursor.json");
+  write(
+    reportPath,
+    JSON.stringify([
+      { number: 10, action: "skipped_already_closed" },
+      { number: 0, action: "skipped_runtime_budget" },
+    ]),
+  );
+  write(
+    cursorPath,
+    JSON.stringify({
+      next_after_number: 10,
+      next_after_apply_checked_at: "2026-07-05T18:00:00Z",
+      updated_at: "2026-07-05T18:10:00Z",
+    }),
+  );
+
+  const summary = summarizeApplyReport({
+    reportPath,
+    targetRepo: "openclaw/openclaw",
+    mode: "close",
+    processedLimit: 300,
+    closeLimit: 20,
+    cursorPath,
+    cursorRequired: true,
+    cursorAdvanceCount: 1,
+  });
+
+  assert.equal(summary.status, "ok");
+  assert.deepEqual(summary.attention_reasons, []);
+  assert.equal(summary.next_action_buckets.run_budget, 1);
+});
+
+test("workflow utilities flag a runtime yield that made no cursor progress", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const reportPath = path.join(root, "apply-report.json");
+  write(reportPath, JSON.stringify([{ number: 0, action: "skipped_runtime_budget" }]));
+
+  const summary = summarizeApplyReport({
+    reportPath,
+    targetRepo: "openclaw/openclaw",
+    mode: "close",
+    processedLimit: 300,
+    closeLimit: 20,
+    cursorRequired: true,
+    cursorAdvanceCount: 0,
+  });
+
+  assert.equal(summary.status, "needs_attention");
+  assert.deepEqual(summary.attention_reasons, ["skipped_runtime_budget"]);
+});
+
 test("workflow utilities require the cursor after a full window that closed an item", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
   const reportPath = path.join(root, "apply-report.json");

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -156,8 +156,9 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
   assert.match(inputBlock, /apply_checkpoint_size:[\s\S]*default: "20"/);
   assert.match(applyStep, /Capping apply checkpoint size at 20/);
   assert.match(applyStep, /base_close_processed_limit=300/);
-  assert.match(applyStep, /coverage_proof_limit=1/);
-  assert.match(applyStep, /max_close_processed_limit=900/);
+  assert.match(applyHelper, /coverage_proof_limit=1/);
+  assert.match(applyHelper, /max_runtime_arg=\(--max-runtime-ms 600000\)/);
+  assert.match(applyHelper, /max_close_processed_limit=900/);
   assert.match(applyStep, /close_processed_limit="\$base_close_processed_limit"/);
   assert.match(applyStep, /source scripts\/apply-workflow-helpers\.sh/);
   assert.match(applyStep, /select_adaptive_apply_batch/);
@@ -227,6 +228,8 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
   assert.match(applyStep, /--coverage-proof-item-numbers "\$coverage_proof_item_numbers"/);
   assert.match(applyStep, /--cursor-trace "\$cursor_trace_path"/);
   assert.match(applyStep, /cursor_trace_arg=\(--cursor-trace "\$cursor_trace_path"\)/);
+  assert.match(applyStep, /select_automatic_apply_runtime/);
+  assert.match(applyStep, /"\$\{max_runtime_arg\[@\]\}"/);
   assert.match(applyStep, /results\/apply-cursors/);
   assert.match(applyStep, /reached its \$close_processed_limit-record budget/);
   assert.match(applyStep, /next scheduled apply run will advance the next window/);
@@ -234,6 +237,9 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
   assert.match(applyStep, /No enabled close reasons remain after policy filtering/);
   assert.match(applyStep, /true\|1\|yes\|on\) product_direction_enabled=true/);
   assert.match(applyStep, /if \[ "\$result_count" -ge "\$close_processed_limit" \]; then/);
+  assert.match(applyHelper, /--action skipped_runtime_budget/);
+  assert.match(applyStep, /if automatic_apply_runtime_reached/);
+  assert.match(applyHelper, /fresh-token continuation will resume the lane/);
   assert.doesNotMatch(
     applyStep,
     /if \[ "\$result_count" -ge "\$close_processed_limit" \] && \[ "\$closed_in_chunk" -gt 0 \]/,


### PR DESCRIPTION
## Summary

- bound automatic close-apply checkpoints to a soft ten-minute runtime budget
- persist exact cursor progress and queue an immediate fresh-token continuation when the budget is reached
- cap PR close-coverage proof work to the time remaining in the checkpoint
- preserve label-sync state across a resumable yield without masking human activity or truncated history
- keep healthy resumable yields out of dashboard attention state when cursor progress is proven

## Why

The first production run after #420 processed the intended bounded proof candidate, but slow serialized GitHub reads plus one legitimate coverage proof stretched a 300-record checkpoint to 23 minutes. The lane remained safe, but it held the single apply workflow much longer than intended.

This keeps the existing fast/proof cursor semantics and close-safety gates. The limit is deliberately soft around an in-flight GitHub request; ClawSweeper stops before the next record or unfinished proof, removes that item from the cursor trace, persists completed progress, and resumes it in a fresh continuation.

## Proof

- `pnpm check`
- focused runtime, cursor, coverage-proof, label-sync, apply-health, and workflow wiring tests
- GPT-5.5 AutoReview: no findings

No release, version, or deployment changes.
