### PR TITLE
Clarify Mantis proof suggestion scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Scoped Mantis recommendations to supported proof capture and kept code changes, PR repair, and GitHub mutations in ClawSweeper's deterministic lanes. Thanks @brokemac79.
 - Bounded automatic close-apply checkpoints to ten minutes, persisted exact cursor progress before immediate continuation, and limited close-coverage proofs to the time remaining in the checkpoint.
 - Kept automatic apply windows responsive by running at most one PR close-coverage proof after fast candidates and advancing independent fast/proof cursors only through records actually examined.
 - Prevented malformed `maintainer_decision` records from repeatedly consuming apply queue slots by recording their deterministic apply bookkeeping. Thanks @brokemac79.

--- a/VISION.md
+++ b/VISION.md
@@ -90,6 +90,11 @@ local checkout, but model subprocesses do not receive GitHub write credentials.
 Deterministic executor steps own comments, labels, branch pushes, closes, checks,
 and merges.
 
+Mantis is a proof worker, not a mutation worker. ClawSweeper may recommend it
+for supported Telegram, Discord, or web UI chat reproduction and redacted
+evidence capture, but never for code changes, CI fixes, branch updates, PR
+repair, or GitHub mutations. Those remain in ClawSweeper's deterministic lanes.
+
 ### 6. Public state must be durable and safe
 
 Durable records, dashboard output, labels, and comments are operational history.

--- a/docs/proof-nudges.md
+++ b/docs/proof-nudges.md
@@ -40,6 +40,12 @@ posts a durable Mantis proof request comment. Otherwise it updates one durable
 status comment asking maintainers to choose proof capture, proof override, or
 pause. It does not post contributor reminders.
 
+Mantis requests are proof-only. They may ask Mantis to reproduce or inspect
+supported Telegram, Discord, or web UI chat behavior and return redacted
+screenshots, transcripts, logs, or interaction results. Code changes, CI fixes,
+branch updates, commits, PR repair, labels, comments, closes, and merges stay in
+ClawSweeper's deterministic repair, apply, and automerge lanes.
+
 For dashboard accounting, status-only maintainer requests use
 `bot_proof_decision_planned` or `bot_proof_decision_posted`. Mantis proof
 requests use `bot_proof_mantis_request_planned` or

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -784,12 +784,16 @@ that is not usefully visible in that recording.
 
 Always fill `mantisRecommendation`. This is maintainer guidance only: it must
 never trigger OpenClaw Mantis, claim Mantis has run, ask ClawSweeper to dispatch
-a workflow, or request ClawSweeper repair markers. Recommend Mantis only when a
-PR changes behavior that is best verified in a real transport or visible UI.
+a workflow, or request ClawSweeper repair markers. Recommend Mantis only for
+Telegram, Discord, or web UI chat behavior that Mantis can currently prove.
 Use `status: "not_recommended"`, `scenario: "none"`, and an empty
 `maintainerComment` for issues, docs-only/test-only/internal refactors, CI-only
-work, pure schema/type changes, or behavior where unit tests are the better
-proof.
+work, pure schema/type changes, unsupported native app/page proof such as WinUI,
+or behavior where unit tests, maintainer screenshot/manual proof,
+browser/Playwright proof, Crabbox, or normal local artifact proof is the better
+path. Put that non-Mantis proof path in the real behavior proof summary,
+PR-rating next step, best solution, or public next step instead of creating a
+Mantis command.
 
 Known Mantis lanes:
 
@@ -803,10 +807,14 @@ Known Mantis lanes:
   reaction proof. Use only for status reaction behavior.
 - `discord_thread_attachment`: before/after Discord thread reply filePath
   attachment proof. Use only for thread attachment behavior.
-- `slack_desktop_smoke`: Slack desktop/VNC proof. Use for Slack desktop or
-  gateway-visible behavior.
-- `visual_task`: generic visible browser/desktop proof. Use only when no
-  dedicated transport scenario fits and the proof can be described concretely.
+- `web_ui_chat_proof`: before/after web UI chat transcript or chat interaction
+  proof. Use only for OpenClaw web UI chat behavior, not generic browser pages,
+  settings panes, dashboards, WinUI screens, or other non-chat visual proof.
+
+Do not recommend Mantis for Slack desktop, WinUI, generic browser screenshots,
+settings pages, dashboards, terminal-only behavior, local file artifacts, or
+other non-chat UI proof. For those surfaces, use `not_recommended` and suggest
+the more appropriate proof path outside `mantisRecommendation`.
 
 When `mantisRecommendation.status` is `recommended`, write a single-line
 `maintainerComment` that starts with `@openclaw-mantis` and describes the exact

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -786,6 +786,13 @@ Always fill `mantisRecommendation`. This is maintainer guidance only: it must
 never trigger OpenClaw Mantis, claim Mantis has run, ask ClawSweeper to dispatch
 a workflow, or request ClawSweeper repair markers. Recommend Mantis only for
 Telegram, Discord, or web UI chat behavior that Mantis can currently prove.
+Mantis is proof-only: it may reproduce or inspect those surfaces and return
+redacted screenshots, transcripts, logs, or interaction results. Never
+recommend Mantis to edit code, fix CI, update a branch, push commits, repair a
+pull request, change labels or comments, close an item, or perform another
+GitHub mutation. Those actions belong to ClawSweeper's repair, apply, and
+automerge lanes. When the next useful step is mutation rather than proof, use
+`not_recommended`.
 Use `status: "not_recommended"`, `scenario: "none"`, and an empty
 `maintainerComment` for issues, docs-only/test-only/internal refactors, CI-only
 work, pure schema/type changes, unsupported native app/page proof such as WinUI,
@@ -818,7 +825,10 @@ the more appropriate proof path outside `mantisRecommendation`.
 
 When `mantisRecommendation.status` is `recommended`, write a single-line
 `maintainerComment` that starts with `@openclaw-mantis` and describes the exact
-behavior to prove. Do not use any shorter or ambiguous Mantis account mention.
+behavior to prove. Include an explicit proof action such as `verify`,
+`reproduce`, `capture`, `inspect`, `record`, or `test`; ambiguous requests
+without proof intent fail closed. Do not use any shorter or ambiguous Mantis
+account mention.
 ClawSweeper validates the account mention and renders it in a fenced text block
 so maintainers can copy the exact PR comment without accidentally starting a
 Mantis workflow from the ClawSweeper review comment. Example:

--- a/schema/clawsweeper-decision.schema.json
+++ b/schema/clawsweeper-decision.schema.json
@@ -774,7 +774,7 @@
     "mantisRecommendation": {
       "type": "object",
       "additionalProperties": false,
-      "description": "For PRs, recommend a copy-paste maintainer comment for OpenClaw Mantis only when live transport or visual proof would materially help review. Do not claim Mantis has run and do not dispatch any workflow.",
+      "description": "For PRs, recommend a copy-paste maintainer comment for OpenClaw Mantis only when Telegram, Discord, or web UI chat proof would materially help review. Do not claim Mantis has run and do not dispatch any workflow.",
       "required": ["status", "scenario", "reason", "maintainerComment"],
       "properties": {
         "status": {
@@ -789,13 +789,12 @@
             "telegram_desktop_proof",
             "discord_status_reactions",
             "discord_thread_attachment",
-            "slack_desktop_smoke",
-            "visual_task"
+            "web_ui_chat_proof"
           ]
         },
         "reason": {
           "type": "string",
-          "description": "One concise sentence explaining why this Mantis lane would or would not add useful maintainer proof."
+          "description": "One concise sentence explaining why this supported Mantis lane would or would not add useful maintainer proof. For unsupported proof surfaces such as WinUI, generic browser pages, screenshots, local artifacts, or terminal-only behavior, explain the better non-Mantis proof path while using not_recommended."
         },
         "maintainerComment": {
           "type": "string",

--- a/schema/clawsweeper-decision.schema.json
+++ b/schema/clawsweeper-decision.schema.json
@@ -774,7 +774,7 @@
     "mantisRecommendation": {
       "type": "object",
       "additionalProperties": false,
-      "description": "For PRs, recommend a copy-paste maintainer comment for OpenClaw Mantis only when Telegram, Discord, or web UI chat proof would materially help review. Do not claim Mantis has run and do not dispatch any workflow.",
+      "description": "For PRs, recommend a copy-paste maintainer comment for OpenClaw Mantis only when Telegram, Discord, or web UI chat proof would materially help review. Mantis is proof-only: it may reproduce or inspect those surfaces and return redacted screenshots, transcripts, logs, or interaction results. Do not ask Mantis to edit code, fix CI, update branches, push commits, repair PRs, change labels or comments, close items, or perform other GitHub mutations; those belong to ClawSweeper's deterministic repair, apply, and automerge lanes. Do not claim Mantis has run and do not dispatch any workflow.",
       "required": ["status", "scenario", "reason", "maintainerComment"],
       "properties": {
         "status": {
@@ -798,7 +798,7 @@
         },
         "maintainerComment": {
           "type": "string",
-          "description": "When recommended, a single-line PR comment starting with @openclaw-mantis that a maintainer can paste. ClawSweeper validates and renders this mention inside a fenced text block so the public recommendation is directly copyable without starting Mantis workflows. Do not use shorter or ambiguous Mantis account mentions. For not_recommended, use an empty string."
+          "description": "When recommended, a single-line proof-only PR comment starting with @openclaw-mantis that asks Mantis to reproduce or inspect supported Telegram, Discord, or web UI chat behavior and return redacted evidence. Include an explicit proof action such as verify, reproduce, capture, inspect, record, or test; ambiguous requests without proof intent fail closed. Never ask for code edits, CI fixes, branch updates, commits, PR repair, labels, comments, closes, merges, or other GitHub mutations. ClawSweeper validates and renders this mention inside a fenced text block so the public recommendation is directly copyable without starting Mantis workflows. Do not use shorter or ambiguous Mantis account mentions. For not_recommended, use an empty string."
         }
       }
     },

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -9316,6 +9316,41 @@ function prStatusLabelKindFromReportLabels(markdown: string): PrStatusLabelKind 
   return PR_STATUS_LABELS.find((label) => rawLabels.includes(label.name))?.kind ?? null;
 }
 
+function mantisMaintainerCommentRequestsMutation(comment: string): boolean {
+  const commandBody = comment.replace(/^@openclaw-mantis\s+/i, "").trim();
+  const mutationVerb = String.raw`(?:add|apply|approve|assign|cancel|change|close|comment|commit|create|delete|disable|edit|enable|file|fix|implement|label|land|lock|make|mark|merge|modify|open|post|publish|push|rebase|remove|reopen|repair|request|resolve|restart|resume|re-?run|retry|re-?trigger|review|rewrite|run|set|submit|triage|trigger|unlock|update|write)`;
+  const mutationObject = String.raw`(?:automerge|branch(?:es)?|change(?:s)?|check(?:s)?|CI|code(?!\s+(?:block|snippet|sample|example)\b)|commit(?:s)?|GitHub(?:\s+state)?|issue(?:s)?|item(?:s)?|label(?:s)?|comment(?:s)?|patch(?:es)?|pull\s+request(?:s)?|PRs?|ready\s+for\s+review|repositor(?:y|ies)|repo(?:s)?|review(?:s|\s+request(?:s)?)?|workflow(?:s)?)`;
+  const scopedMutation = new RegExp(
+    `\\b${mutationVerb}\\b(?:\\s+\\S+){0,12}\\s+\\b${mutationObject}\\b`,
+    "i",
+  );
+  const explicitToolMutation = new RegExp(
+    `\\b(?:gh|git|GitHub)\\b(?:\\s+\\S+){0,12}\\s+\\b${mutationVerb}\\b`,
+    "i",
+  );
+  const maintenanceVerb = String.raw`(?:apply|approve|assign|close|comment|commit|create|file|fix|implement|label|land|lock|make|merge|modify|publish|push|rebase|reopen|repair|resolve|review|rewrite|submit|triage|unlock)`;
+  const bareMutationImperative = new RegExp(
+    `(?:^|[,.!?:;]\\s*|\\b(?:and|then|also)\\s+)(?:(?:please|kindly)\\s+|(?:can|could|would|will)\\s+you\\s+)*${maintenanceVerb}\\b`,
+    "i",
+  );
+  return (
+    scopedMutation.test(commandBody) ||
+    explicitToolMutation.test(commandBody) ||
+    bareMutationImperative.test(commandBody) ||
+    new RegExp(`\\b${mutationVerb}\\b\\s+(?:it|this|that|them|these|those)\\b`, "i").test(
+      commandBody,
+    ) ||
+    /\b(?:gh\s+workflow|workflow_dispatch|dispatch|trigger\s+the\s+workflow)\b/i.test(commandBody)
+  );
+}
+
+function mantisMaintainerCommentHasProofIntent(comment: string): boolean {
+  const commandBody = comment.replace(/^@openclaw-mantis\s+/i, "").trim();
+  return /\b(?:proof|verify|reproduce|capture|inspect|record|test|check|confirm|compare|exercise|demonstrate|show)\b/i.test(
+    commandBody,
+  );
+}
+
 function validMantisMaintainerComment(recommendation: MantisRecommendation): string {
   if (recommendation.status !== "recommended" || recommendation.scenario === "none") return "";
   const comment = recommendation.maintainerComment.trim();
@@ -9324,7 +9359,8 @@ function validMantisMaintainerComment(recommendation: MantisRecommendation): str
   if (
     !comment.startsWith(`${accountMention} `) ||
     ambiguousMantisMention.test(comment) ||
-    /\b(?:gh\s+workflow|workflow_dispatch|dispatch|trigger\s+the\s+workflow)\b/i.test(comment) ||
+    !mantisMaintainerCommentHasProofIntent(comment) ||
+    mantisMaintainerCommentRequestsMutation(comment) ||
     comment.length > 500 ||
     comment.includes("\n")
   ) {
@@ -9356,15 +9392,33 @@ function publicMantisRecommendationBlock(recommendation: MantisRecommendation): 
   return [intro, "", "```text", comment, "```"].join("\n");
 }
 
-function publicUnsupportedMantisRecommendationBlock(recommendation: MantisRecommendation): string {
+function publicNonDispatchableMantisRecommendationBlock(
+  recommendation: MantisRecommendation,
+): string {
+  if (recommendation.status !== "recommended" || recommendation.scenario === "none") return "";
+  const mutationRequest = mantisMaintainerCommentRequestsMutation(
+    recommendation.maintainerComment.trim(),
+  );
+  const missingProofIntent = !mantisMaintainerCommentHasProofIntent(
+    recommendation.maintainerComment.trim(),
+  );
   if (
-    recommendation.status !== "recommended" ||
-    recommendation.scenario === "none" ||
-    isSupportedMantisScenario(recommendation.scenario)
+    isSupportedMantisScenario(recommendation.scenario) &&
+    !mutationRequest &&
+    !missingProofIntent
   ) {
     return "";
   }
   const reason = sentence(recommendation.reason);
+  if (mutationRequest || missingProofIntent) {
+    const intro = reason
+      ? `${reason} Mantis is proof-only, so it must not be asked to change code or mutate GitHub state.`
+      : "Mantis is proof-only, so it must not be asked to change code or mutate GitHub state.";
+    return [
+      intro,
+      "Use ClawSweeper's repair, apply, or automerge lanes for code changes, branch updates, labels, comments, PR repair, closes, or merges.",
+    ].join("\n");
+  }
   const intro = reason
     ? `${reason} Mantis is currently scoped to Telegram, Discord, and web UI chat proof, so it is not the right proof path for this surface.`
     : "Mantis is currently scoped to Telegram, Discord, and web UI chat proof, so it is not the right proof path for this surface.";
@@ -12884,7 +12938,7 @@ function renderBotProofDecisionComment(options: {
       const comment = validMantisMaintainerComment(recommendation);
       if (comment) lines.push("", "Mantis proof suggestion:", "", "```text", comment, "```");
     } else {
-      const scopeText = publicUnsupportedMantisRecommendationBlock(recommendation);
+      const scopeText = publicNonDispatchableMantisRecommendationBlock(recommendation);
       if (scopeText) lines.push("", "Proof path suggestion:", "", scopeText);
     }
   }
@@ -15358,7 +15412,7 @@ function renderKeepOpenCommentFromReport(
     : "";
   if (mantisSuggestion) appendPublicSection(lines, "Mantis proof suggestion", mantisSuggestion);
   const unsupportedMantisSuggestion = isPullRequest
-    ? publicUnsupportedMantisRecommendationBlock(mantisRecommendation)
+    ? publicNonDispatchableMantisRecommendationBlock(mantisRecommendation)
     : "";
   if (unsupportedMantisSuggestion) {
     appendPublicSection(lines, "Proof path suggestion", unsupportedMantisSuggestion);

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -255,6 +255,7 @@ type MantisRecommendationScenario =
   | "telegram_desktop_proof"
   | "discord_status_reactions"
   | "discord_thread_attachment"
+  | "web_ui_chat_proof"
   | "slack_desktop_smoke"
   | "visual_task";
 type VisionFitStatus = "aligned" | "rejected" | "unclear" | "not_applicable";
@@ -1719,6 +1720,7 @@ const MANTIS_RECOMMENDATION_SCENARIOS = new Set<MantisRecommendationScenario>([
   "telegram_desktop_proof",
   "discord_status_reactions",
   "discord_thread_attachment",
+  "web_ui_chat_proof",
   "slack_desktop_smoke",
   "visual_task",
 ]);
@@ -9314,7 +9316,7 @@ function prStatusLabelKindFromReportLabels(markdown: string): PrStatusLabelKind 
   return PR_STATUS_LABELS.find((label) => rawLabels.includes(label.name))?.kind ?? null;
 }
 
-function publicMantisRecommendationBlock(recommendation: MantisRecommendation): string {
+function validMantisMaintainerComment(recommendation: MantisRecommendation): string {
   if (recommendation.status !== "recommended" || recommendation.scenario === "none") return "";
   const comment = recommendation.maintainerComment.trim();
   const accountMention = "@openclaw-mantis";
@@ -9330,11 +9332,46 @@ function publicMantisRecommendationBlock(recommendation: MantisRecommendation): 
   }
   const commandBody = comment.slice(accountMention.length).trim();
   if (!commandBody) return "";
+  return `${accountMention} ${commandBody}`;
+}
+
+function isSupportedMantisScenario(scenario: MantisRecommendationScenario): boolean {
+  return (
+    scenario === "telegram_live" ||
+    scenario === "telegram_desktop_proof" ||
+    scenario === "discord_status_reactions" ||
+    scenario === "discord_thread_attachment" ||
+    scenario === "web_ui_chat_proof"
+  );
+}
+
+function publicMantisRecommendationBlock(recommendation: MantisRecommendation): string {
+  if (!hasDispatchableMantisScenario(recommendation)) return "";
+  const comment = validMantisMaintainerComment(recommendation);
+  if (!comment) return "";
   const reason = sentence(recommendation.reason);
   const intro = reason
     ? `${reason} A maintainer can ask Mantis to capture proof by posting this exact PR comment:`
     : "A maintainer can ask Mantis to capture proof by posting this exact PR comment:";
-  return [intro, "", "```text", `${accountMention} ${commandBody}`, "```"].join("\n");
+  return [intro, "", "```text", comment, "```"].join("\n");
+}
+
+function publicUnsupportedMantisRecommendationBlock(recommendation: MantisRecommendation): string {
+  if (
+    recommendation.status !== "recommended" ||
+    recommendation.scenario === "none" ||
+    isSupportedMantisScenario(recommendation.scenario)
+  ) {
+    return "";
+  }
+  const reason = sentence(recommendation.reason);
+  const intro = reason
+    ? `${reason} Mantis is currently scoped to Telegram, Discord, and web UI chat proof, so it is not the right proof path for this surface.`
+    : "Mantis is currently scoped to Telegram, Discord, and web UI chat proof, so it is not the right proof path for this surface.";
+  return [
+    intro,
+    "Use maintainer screenshot/manual proof, browser or Playwright proof, Crabbox where appropriate, or normal local artifact proof instead.",
+  ].join("\n");
 }
 
 function closeIntro(reason: CloseReason): string {
@@ -12735,11 +12772,8 @@ function isClawSweeperAppAuthor(author: string | undefined): boolean {
 function hasDispatchableMantisScenario(recommendation: MantisRecommendation): boolean {
   return (
     recommendation.status === "recommended" &&
-    (recommendation.scenario === "telegram_live" ||
-      recommendation.scenario === "telegram_desktop_proof" ||
-      recommendation.scenario === "discord_status_reactions" ||
-      recommendation.scenario === "discord_thread_attachment" ||
-      recommendation.scenario === "slack_desktop_smoke")
+    isSupportedMantisScenario(recommendation.scenario) &&
+    Boolean(validMantisMaintainerComment(recommendation))
   );
 }
 
@@ -12846,10 +12880,13 @@ function renderBotProofDecisionComment(options: {
     recommendation.scenario !== "none" &&
     recommendation.maintainerComment.trim()
   ) {
-    const heading = hasDispatchableMantisScenario(recommendation)
-      ? "Mantis proof suggestion:"
-      : "Possible manual Mantis/desktop proof suggestion:";
-    lines.push("", heading, "", "```text", recommendation.maintainerComment.trim(), "```");
+    if (hasDispatchableMantisScenario(recommendation)) {
+      const comment = validMantisMaintainerComment(recommendation);
+      if (comment) lines.push("", "Mantis proof suggestion:", "", "```text", comment, "```");
+    } else {
+      const scopeText = publicUnsupportedMantisRecommendationBlock(recommendation);
+      if (scopeText) lines.push("", "Proof path suggestion:", "", scopeText);
+    }
   }
   lines.push("", marker);
   return lines.join("\n");
@@ -15320,6 +15357,12 @@ function renderKeepOpenCommentFromReport(
     ? publicMantisRecommendationBlock(mantisRecommendation)
     : "";
   if (mantisSuggestion) appendPublicSection(lines, "Mantis proof suggestion", mantisSuggestion);
+  const unsupportedMantisSuggestion = isPullRequest
+    ? publicUnsupportedMantisRecommendationBlock(mantisRecommendation)
+    : "";
+  if (unsupportedMantisSuggestion) {
+    appendPublicSection(lines, "Proof path suggestion", unsupportedMantisSuggestion);
+  }
   if (mergeRiskLine) appendPublicSection(lines, "Risk before merge", mergeRiskLine);
   appendPublicSection(
     lines,

--- a/test/proof-nudge-policy.test.ts
+++ b/test/proof-nudge-policy.test.ts
@@ -206,6 +206,20 @@ test("bot proof handling selects maintainer or Mantis proof path for ClawSweeper
   assert.equal(webUiChat.eligible, true);
   assert.equal(webUiChat.action, "bot_proof_mantis_request_planned");
 
+  const webUiChatCodeBlock = botProofEligibilityForTest({
+    ...baseOptions,
+    markdown: proofNudgeReport({
+      author: "app/clawsweeper",
+      mantisStatus: "recommended",
+      mantisScenario: "web_ui_chat_proof",
+      mantisReason: "A web UI chat proof would show the changed transcript behavior.",
+      mantisComment:
+        "@openclaw-mantis web UI chat proof: verify the assistant can post a code block in the chat transcript",
+    }),
+  });
+  assert.equal(webUiChatCodeBlock.eligible, true);
+  assert.equal(webUiChatCodeBlock.action, "bot_proof_mantis_request_planned");
+
   const manualVisual = botProofEligibilityForTest({
     ...baseOptions,
     markdown: proofNudgeReport({
@@ -231,6 +245,38 @@ test("bot proof handling selects maintainer or Mantis proof path for ClawSweeper
   });
   assert.equal(invalidMantisCommand.eligible, true);
   assert.equal(invalidMantisCommand.action, "bot_proof_decision_planned");
+
+  const mutationMantisCommand = botProofEligibilityForTest({
+    ...baseOptions,
+    markdown: proofNudgeReport({
+      author: "app/clawsweeper",
+      mantisStatus: "recommended",
+      mantisScenario: "telegram_desktop_proof",
+      mantisReason: "The Telegram behavior still needs live proof and a branch repair.",
+      mantisComment: "@openclaw-mantis fix this PR and push the repaired branch",
+    }),
+  });
+  assert.equal(mutationMantisCommand.eligible, true);
+  assert.equal(mutationMantisCommand.action, "bot_proof_decision_planned");
+
+  for (const maintainerComment of [
+    "@openclaw-mantis verify the Telegram behavior and mark this PR ready for review",
+    "@openclaw-mantis verify the Telegram behavior and enable automerge",
+    "@openclaw-mantis verify the Telegram behavior and request a review from maintainers",
+  ]) {
+    const prStateMutation = botProofEligibilityForTest({
+      ...baseOptions,
+      markdown: proofNudgeReport({
+        author: "app/clawsweeper",
+        mantisStatus: "recommended",
+        mantisScenario: "telegram_desktop_proof",
+        mantisReason: "The Telegram behavior needs live proof.",
+        mantisComment: maintainerComment,
+      }),
+    });
+    assert.equal(prStateMutation.eligible, true);
+    assert.equal(prStateMutation.action, "bot_proof_decision_planned");
+  }
 
   assert.equal(
     botProofEligibilityForTest({
@@ -314,6 +360,26 @@ test("bot proof status comment asks maintainers without contributor nudge copy",
   assert.match(comment, /<!-- clawsweeper-bot-proof-decision item="42" sha="abc123def456"/);
   assert.doesNotMatch(comment, /thanks for the PR/);
   assert.doesNotMatch(comment, /Once proof is added/);
+});
+
+test("bot proof status routes mutation-oriented Mantis commands to ClawSweeper", () => {
+  const markdown = proofNudgeReport({
+    author: "app/clawsweeper",
+    mantisStatus: "recommended",
+    mantisScenario: "telegram_desktop_proof",
+    mantisReason: "The Telegram behavior still needs live proof and a branch repair.",
+    mantisComment: "@openclaw-mantis fix this PR and push the repaired branch",
+  });
+  const comment = renderBotProofDecisionCommentForTest({
+    number: 42,
+    headSha: "abc123def456",
+    markdown,
+  });
+
+  assert.match(comment, /Proof path suggestion/);
+  assert.match(comment, /Mantis is proof-only/);
+  assert.match(comment, /ClawSweeper's repair, apply, or automerge lanes/);
+  assert.doesNotMatch(comment, /@openclaw-mantis fix this PR/);
 });
 
 test("proof nudge candidate scan defers proof-label checks to live PR state", () => {

--- a/test/proof-nudge-policy.test.ts
+++ b/test/proof-nudge-policy.test.ts
@@ -192,6 +192,20 @@ test("bot proof handling selects maintainer or Mantis proof path for ClawSweeper
   assert.equal(mantis.eligible, true);
   assert.equal(mantis.action, "bot_proof_mantis_request_planned");
 
+  const webUiChat = botProofEligibilityForTest({
+    ...baseOptions,
+    markdown: proofNudgeReport({
+      author: "app/clawsweeper",
+      mantisStatus: "recommended",
+      mantisScenario: "web_ui_chat_proof",
+      mantisReason: "A web UI chat proof would show the changed transcript behavior.",
+      mantisComment:
+        "@openclaw-mantis web UI chat proof: verify the active chat transcript behavior",
+    }),
+  });
+  assert.equal(webUiChat.eligible, true);
+  assert.equal(webUiChat.action, "bot_proof_mantis_request_planned");
+
   const manualVisual = botProofEligibilityForTest({
     ...baseOptions,
     markdown: proofNudgeReport({
@@ -204,6 +218,19 @@ test("bot proof handling selects maintainer or Mantis proof path for ClawSweeper
   });
   assert.equal(manualVisual.eligible, true);
   assert.equal(manualVisual.action, "bot_proof_decision_planned");
+
+  const invalidMantisCommand = botProofEligibilityForTest({
+    ...baseOptions,
+    markdown: proofNudgeReport({
+      author: "app/clawsweeper",
+      mantisStatus: "recommended",
+      mantisScenario: "telegram_desktop_proof",
+      mantisReason: "Native Telegram Desktop proof would show the visible topic behavior.",
+      mantisComment: "@mantis telegram desktop proof: verify the topic behavior",
+    }),
+  });
+  assert.equal(invalidMantisCommand.eligible, true);
+  assert.equal(invalidMantisCommand.action, "bot_proof_decision_planned");
 
   assert.equal(
     botProofEligibilityForTest({
@@ -279,8 +306,11 @@ test("bot proof status comment asks maintainers without contributor nudge copy",
 
   assert.match(comment, /ClawSweeper-authored replacement PR is blocked on real behavior proof/);
   assert.match(comment, /proof: override/);
-  assert.match(comment, /Possible manual Mantis\/desktop proof suggestion/);
-  assert.match(comment, /@openclaw-mantis capture Control UI proof/);
+  assert.match(comment, /Proof path suggestion/);
+  assert.match(comment, /Mantis is currently scoped to Telegram, Discord, and web UI chat proof/);
+  assert.match(comment, /browser or Playwright proof/);
+  assert.doesNotMatch(comment, /Possible manual Mantis\/desktop proof suggestion/);
+  assert.doesNotMatch(comment, /@openclaw-mantis capture Control UI proof/);
   assert.match(comment, /<!-- clawsweeper-bot-proof-decision item="42" sha="abc123def456"/);
   assert.doesNotMatch(comment, /thanks for the PR/);
   assert.doesNotMatch(comment, /Once proof is added/);

--- a/test/review-prompt-policy.test.ts
+++ b/test/review-prompt-policy.test.ts
@@ -368,6 +368,12 @@ test("review prompt classifies Telegram visible proof candidates", () => {
   assert.match(prompt, /mantisRecommendation/);
   assert.match(prompt, /@openclaw-mantis/);
   assert.match(prompt, /ambiguous Mantis account mention/);
+  assert.match(prompt, /Telegram,\s+Discord,\s+or web UI chat behavior/);
+  assert.match(prompt, /web_ui_chat_proof/);
+  assert.match(prompt, /WinUI/);
+  assert.match(prompt, /browser\/Playwright proof/);
+  assert.doesNotMatch(prompt, /`visual_task`: generic visible browser\/desktop proof/);
+  assert.doesNotMatch(prompt, /`slack_desktop_smoke`/);
 });
 
 test("pull request review comments suggest copy-paste Mantis proof comments", () => {
@@ -429,6 +435,137 @@ Reason: Maintainers should review the proof before merge.
   assert.match(comment, /```text\n@openclaw-mantis telegram desktop proof:/);
 });
 
+test("pull request review comments keep Discord and web UI chat Mantis suggestions", () => {
+  const discordComment = renderReviewCommentFromReport(
+    `${reportFrontMatter({
+      type: "pull_request",
+      number: "83140",
+      decision: "keep_open",
+      close_reason: "none",
+      work_candidate: "none",
+      pull_head_sha: "abc123def456",
+    })}
+
+## Summary
+
+Keep this Discord PR open for maintainer review.
+
+## Mantis Recommendation
+
+Status: recommended
+
+Scenario: discord_status_reactions
+
+Reason: This changes visible Discord status reactions.
+
+Maintainer comment: @openclaw-mantis discord status reactions proof: verify queued and done reactions update around the worker run.
+
+## Work Candidate
+
+Candidate: none
+
+Confidence: low
+
+Priority: low
+
+Status: none
+
+Reason: Maintainers should review the proof before merge.
+	`,
+    "none",
+  );
+  assert.match(discordComment, /\*\*Mantis proof suggestion\*\*/);
+  assert.match(discordComment, /@openclaw-mantis discord status reactions proof:/);
+
+  const webUiChatComment = renderReviewCommentFromReport(
+    `${reportFrontMatter({
+      type: "pull_request",
+      number: "83141",
+      decision: "keep_open",
+      close_reason: "none",
+      work_candidate: "none",
+      pull_head_sha: "def456abc123",
+    })}
+
+## Summary
+
+Keep this web UI chat PR open for maintainer review.
+
+## Mantis Recommendation
+
+Status: recommended
+
+Scenario: web_ui_chat_proof
+
+Reason: This changes a visible web UI chat transcript interaction.
+
+Maintainer comment: @openclaw-mantis web UI chat proof: verify the assistant reply streams into the active chat transcript.
+
+## Work Candidate
+
+Candidate: none
+
+Confidence: low
+
+Priority: low
+
+Status: none
+
+Reason: Maintainers should review the proof before merge.
+	`,
+    "none",
+  );
+  assert.match(webUiChatComment, /\*\*Mantis proof suggestion\*\*/);
+  assert.match(webUiChatComment, /@openclaw-mantis web UI chat proof:/);
+});
+
+test("pull request review comments scope unsupported Mantis visual suggestions", () => {
+  const comment = renderReviewCommentFromReport(
+    `${reportFrontMatter({
+      type: "pull_request",
+      number: "83142",
+      decision: "keep_open",
+      close_reason: "none",
+      work_candidate: "none",
+      pull_head_sha: "123abc456def",
+    })}
+
+## Summary
+
+Keep this WinUI PR open for maintainer review.
+
+## Mantis Recommendation
+
+Status: recommended
+
+Scenario: visual_task
+
+Reason: A short visible WinUI proof would materially help because this changes a Sessions page filter toggle.
+
+Maintainer comment: @openclaw-mantis visual task: verify the Sessions page hides clean completed sessions by default.
+
+## Work Candidate
+
+Candidate: none
+
+Confidence: low
+
+Priority: low
+
+Status: none
+
+Reason: Maintainers should review the proof before merge.
+	`,
+    "none",
+  );
+
+  assert.doesNotMatch(comment, /\*\*Mantis proof suggestion\*\*/);
+  assert.doesNotMatch(comment, /@openclaw-mantis visual task/);
+  assert.match(comment, /\*\*Proof path suggestion\*\*/);
+  assert.match(comment, /Mantis is currently scoped to Telegram, Discord, and web UI chat proof/);
+  assert.match(comment, /browser or Playwright proof/);
+});
+
 test("pull request review comments suppress unsafe Mantis recommendations", () => {
   const comment = renderReviewCommentFromReport(
     `${reportFrontMatter({
@@ -470,6 +607,7 @@ Reason: Maintainers should review the proof before merge.
   );
 
   assert.doesNotMatch(comment, /\*\*Mantis proof suggestion\*\*/);
+  assert.doesNotMatch(comment, /\*\*Proof path suggestion\*\*/);
   assert.doesNotMatch(comment, /@openclaw-mantis/);
 });
 

--- a/test/review-prompt-policy.test.ts
+++ b/test/review-prompt-policy.test.ts
@@ -367,11 +367,16 @@ test("review prompt classifies Telegram visible proof candidates", () => {
   assert.match(prompt, /mantis: telegram-visible-proof/);
   assert.match(prompt, /mantisRecommendation/);
   assert.match(prompt, /@openclaw-mantis/);
-  assert.match(prompt, /ambiguous Mantis account mention/);
+  assert.match(prompt, /ambiguous Mantis\s+account mention/);
   assert.match(prompt, /Telegram,\s+Discord,\s+or web UI chat behavior/);
   assert.match(prompt, /web_ui_chat_proof/);
   assert.match(prompt, /WinUI/);
   assert.match(prompt, /browser\/Playwright proof/);
+  assert.match(prompt, /Mantis is proof-only/);
+  assert.match(prompt, /Never\s+recommend Mantis to edit code, fix CI/);
+  assert.match(prompt, /ClawSweeper's repair, apply, and\s+automerge lanes/);
+  assert.match(prompt, /explicit proof action/);
+  assert.match(prompt, /ambiguous requests\s+without proof intent fail closed/);
   assert.doesNotMatch(prompt, /`visual_task`: generic visible browser\/desktop proof/);
   assert.doesNotMatch(prompt, /`slack_desktop_smoke`/);
 });
@@ -609,6 +614,204 @@ Reason: Maintainers should review the proof before merge.
   assert.doesNotMatch(comment, /\*\*Mantis proof suggestion\*\*/);
   assert.doesNotMatch(comment, /\*\*Proof path suggestion\*\*/);
   assert.doesNotMatch(comment, /@openclaw-mantis/);
+});
+
+test("pull request review comments keep Mantis proof-only and route mutations to ClawSweeper", () => {
+  const mutationComment = renderReviewCommentFromReport(
+    `${reportFrontMatter({
+      type: "pull_request",
+      number: "83143",
+      decision: "keep_open",
+      close_reason: "none",
+      work_candidate: "none",
+      pull_head_sha: "abc456def789",
+    })}
+
+## Summary
+
+Keep this Telegram PR open for maintainer review.
+
+## Mantis Recommendation
+
+Status: recommended
+
+Scenario: telegram_desktop_proof
+
+Reason: The Telegram behavior still needs live proof and a branch repair.
+
+Maintainer comment: @openclaw-mantis fix this PR and push the repaired branch.
+
+## Work Candidate
+
+Candidate: none
+
+Confidence: low
+
+Priority: low
+
+Status: none
+
+Reason: Maintainers should review the proof before merge.
+	`,
+    "none",
+  );
+
+  assert.doesNotMatch(mutationComment, /\*\*Mantis proof suggestion\*\*/);
+  assert.doesNotMatch(mutationComment, /@openclaw-mantis fix this PR/);
+  assert.match(mutationComment, /\*\*Proof path suggestion\*\*/);
+  assert.match(mutationComment, /Mantis is proof-only/);
+  assert.match(mutationComment, /ClawSweeper's repair, apply, or automerge lanes/);
+
+  const proofComment = renderReviewCommentFromReport(
+    `${reportFrontMatter({
+      type: "pull_request",
+      number: "83144",
+      decision: "keep_open",
+      close_reason: "none",
+      work_candidate: "none",
+      pull_head_sha: "def789abc456",
+    })}
+
+## Summary
+
+Keep this Telegram PR open for maintainer review.
+
+## Mantis Recommendation
+
+Status: recommended
+
+Scenario: telegram_desktop_proof
+
+Reason: Native Telegram proof would show the corrected visible behavior.
+
+Maintainer comment: @openclaw-mantis telegram desktop proof: verify the fix in Telegram Desktop and capture redacted logs.
+
+## Work Candidate
+
+Candidate: none
+
+Confidence: low
+
+Priority: low
+
+Status: none
+
+Reason: Maintainers should review the proof before merge.
+	`,
+    "none",
+  );
+
+  assert.match(proofComment, /\*\*Mantis proof suggestion\*\*/);
+  assert.match(proofComment, /verify the fix in Telegram Desktop/);
+  assert.doesNotMatch(proofComment, /\*\*Proof path suggestion\*\*/);
+});
+
+test("pull request review comments reject GitHub metadata mutations without blocking chat interaction proof", () => {
+  for (const maintainerComment of [
+    "@openclaw-mantis change labels on this PR",
+    "@openclaw-mantis add a comment to this PR",
+    "@openclaw-mantis reproduce the Telegram issue, push the repaired branch",
+    "@openclaw-mantis close this item",
+    "@openclaw-mantis comment on this PR",
+    "@openclaw-mantis make this code change",
+    "@openclaw-mantis please can you push the repaired branch",
+    "@openclaw-mantis please use gh to merge this PR",
+    "@openclaw-mantis can you use GitHub to close this item",
+    "@openclaw-mantis fix it",
+    "@openclaw-mantis repair this",
+    "@openclaw-mantis verify the Telegram fix and merge",
+    "@openclaw-mantis capture logs and approve",
+    "@openclaw-mantis discord proof: capture logs and approve if correct",
+    "@openclaw-mantis telegram proof: verify the fix and merge when done",
+    "@openclaw-mantis verify the Telegram fix and rerun CI",
+    "@openclaw-mantis capture logs and retry the failed workflow",
+  ]) {
+    const comment = renderReviewCommentFromReport(
+      `${reportFrontMatter({
+        type: "pull_request",
+        number: "83145",
+        decision: "keep_open",
+        close_reason: "none",
+        work_candidate: "none",
+        pull_head_sha: "456def789abc",
+      })}
+
+## Summary
+
+Keep this Discord PR open for maintainer review.
+
+## Mantis Recommendation
+
+Status: recommended
+
+Scenario: discord_thread_attachment
+
+Reason: This changes a visible Discord interaction.
+
+Maintainer comment: ${maintainerComment}
+
+## Work Candidate
+
+Candidate: none
+
+Confidence: low
+
+Priority: low
+
+Status: none
+
+Reason: Maintainers should review the proof before merge.
+	`,
+      "none",
+    );
+    assert.doesNotMatch(comment, /\*\*Mantis proof suggestion\*\*/);
+    assert.doesNotMatch(
+      comment,
+      new RegExp(maintainerComment.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+    );
+    assert.match(comment, /Mantis is proof-only/);
+  }
+
+  const interactionProof = renderReviewCommentFromReport(
+    `${reportFrontMatter({
+      type: "pull_request",
+      number: "83146",
+      decision: "keep_open",
+      close_reason: "none",
+      work_candidate: "none",
+      pull_head_sha: "789abc456def",
+    })}
+
+## Summary
+
+Keep this Discord PR open for maintainer review.
+
+## Mantis Recommendation
+
+Status: recommended
+
+Scenario: discord_thread_attachment
+
+Reason: This changes visible Discord message behavior.
+
+Maintainer comment: @openclaw-mantis discord proof: edit a Discord message and verify the attachment remains in the thread.
+
+## Work Candidate
+
+Candidate: none
+
+Confidence: low
+
+Priority: low
+
+Status: none
+
+Reason: Maintainers should review the proof before merge.
+	`,
+    "none",
+  );
+  assert.match(interactionProof, /\*\*Mantis proof suggestion\*\*/);
+  assert.match(interactionProof, /edit a Discord message/);
 });
 
 test("ClawSweeper proof judgement controls the sufficient proof label", () => {


### PR DESCRIPTION
## Summary

- Keep Mantis recommendations limited to Telegram, Discord, and web UI chat QA proof: reproduction, screenshots, redacted logs or transcripts, and behavior checks.
- Keep code changes and deterministic GitHub mutations in ClawSweeper: branch and PR repair, labels, comments, closes, merges, and CI repair.
- Fail closed when a proposed Mantis command lacks explicit proof intent or asks for repository or GitHub mutation, while preserving legitimate chat interactions such as editing a Discord message or posting a code block.
- Document the ownership boundary in VISION.md and the proof-nudge operator guide.

## Proof

- `pnpm run check`
- 47 focused prompt and proof-nudge tests
- Source-blind behavior contract: 9 pass, 0 fail, 0 blocked
- AutoReview completed; all accepted findings repaired, with no accepted actionable findings remaining

Preserves and extends @brokemac79's original contribution.
