### PR TITLE
test: normalize Pages workflow line endings

### DIFF
--- a/test/pages-workflow.test.ts
+++ b/test/pages-workflow.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 
 test("Pages reruns upload and deploy a run-attempt-scoped artifact", () => {
-  const workflow = readFileSync(".github/workflows/pages.yml", "utf8");
+  const workflow = readFileSync(".github/workflows/pages.yml", "utf8").replace(/\r\n/g, "\n");
 
   assert.match(workflow, /PAGES_ARTIFACT_NAME: github-pages-\$\{\{ github\.run_attempt \}\}/);
   assert.equal(workflow.match(/\$\{\{ env\.PAGES_ARTIFACT_NAME \}\}/g)?.length, 2);


### PR DESCRIPTION
## Summary

- Normalize the Pages workflow fixture text before matching it in `test/pages-workflow.test.ts`.
- Keep `.github/workflows/pages.yml` semantics unchanged.

## Problem

Merged PR #422 / commit `7763f08f3a1b8eb16ff3c2c543c1b92547922bc4` added a Pages workflow regression test that reads `.github/workflows/pages.yml` raw. On this Windows checkout, `git ls-files --eol .github/workflows/pages.yml` reports `w/crlf`, so the LF-only assertions fail even though the workflow content is correct.

## Implementation

The test now normalizes CRLF to LF on the loaded workflow text before running the existing assertions. This keeps the assertions focused on workflow structure and leaves the workflow file untouched.

## Validation

- `node --test test/pages-workflow.test.ts` - passed
- `pnpm run build:all` - passed after `pnpm install` restored this worktree's locked dependencies
- `git diff --check` - passed

## Proof

Before the fix, `node --test test/pages-workflow.test.ts` failed on Windows with the upload artifact assertion because the input contained `\r\n` while the regex expected `\n`.

After the fix:

```text
✔ Pages reruns upload and deploy a run-attempt-scoped artifact
ℹ pass 1
ℹ fail 0
```

## Codex Review Closeout

- Helper attempted: `C:\Program Files\Git\bin\bash.exe C:/Users/marti/.codex/skills/codex-review/scripts/codex-review --mode branch --base origin/main --parallel-tests "node --test test/pages-workflow.test.ts" --output C:/Users/marti/AppData/Local/Temp/csw-011-codex-review.txt`
- Helper selected the correct branch target and the parallel focused test passed, but the nested `codex review --base origin/main` process exited before review because the local Codex config uses `service_tier = "default"`, which this CLI rejects.
- Final review command: `codex -c 'service_tier="fast"' review --base origin/main`
- Final review result: clean. Codex reported: "The only change normalizes CRLF line endings before regex assertions in the Pages workflow test, which preserves the test intent while making it portable across checkout line endings. I found no actionable correctness issues."
- Findings accepted/rejected: none; no actionable findings were reported.

## Risks / Rollout

Risk is low: this is a test-only change and does not alter the Pages workflow. The remaining risk is limited to the test continuing to assert the same workflow structure after line-ending normalization. This PR does not touch `.github/workflows/**`, so it does not add GitHub OAuth/workflow-scope replacement-branch risk.

## Links

- Fixes accepted finding from #422 / `7763f08f3a1b8eb16ff3c2c543c1b92547922bc4`.