### PR TITLE
Fix close-limit apply cursor trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 - Scoped Mantis recommendations to supported proof capture and kept code changes, PR repair, and GitHub mutations in ClawSweeper's deterministic lanes. Thanks @brokemac79.
 - Bounded automatic close-apply checkpoints to ten minutes, persisted exact cursor progress before immediate continuation, and limited close-coverage proofs to the time remaining in the checkpoint.
+- Kept close-limit apply checkpoints from advancing their resumable cursor past an unexecuted close candidate. Thanks @brokemac79.
 - Kept automatic apply windows responsive by running at most one PR close-coverage proof after fast candidates and advancing independent fast/proof cursors only through records actually examined.
 - Prevented malformed `maintainer_decision` records from repeatedly consuming apply queue slots by recording their deterministic apply bookkeeping. Thanks @brokemac79.
 - Preserved ready-for-maintainer labels when a newer durable review matches the current PR head, while still removing readiness from stale-head reviews. Thanks @brokemac79.

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -19584,7 +19584,10 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
         break;
       continue;
     }
-    if (closedCount >= limit) break;
+    if (closedCount >= limit) {
+      removeCurrentCursorTraceItem(examinedItemNumbers, number);
+      break;
+    }
     if (applyKind !== "all" && item.kind !== applyKind) {
       if (recordApplySkipped("kept_open", `type is ${item.kind}; apply kind is ${applyKind}`))
         break;

--- a/test/apply-cursor-trace.test.ts
+++ b/test/apply-cursor-trace.test.ts
@@ -3,7 +3,14 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { join } from "node:path";
 import test from "node:test";
 
-import { runApplyDecisionsForTest, tmpPrefix, workPlanCandidateReport } from "./helpers.ts";
+import {
+  implementedCloseReport,
+  reportWithSyncedReviewComment,
+  runApplyDecisionsForTest,
+  tmpPrefix,
+  withMockGh,
+  workPlanCandidateReport,
+} from "./helpers.ts";
 
 test("apply-decisions preserves auto-selected order and traces only examined records", () => {
   const root = mkdtempSync(tmpPrefix);
@@ -50,6 +57,105 @@ test("apply-decisions preserves auto-selected order and traces only examined rec
     const trace = JSON.parse(readFileSync(tracePath, "utf8"));
     assert.equal(report[0]?.number, 20);
     assert.deepEqual(trace, { schema_version: 1, examined_item_numbers: [20] });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions keeps close-limit candidates out of the cursor trace", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const tracePath = join(root, "apply-cursor-trace.json");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const comments: Record<number, string> = {};
+    for (const number of [10, 20]) {
+      const synced = reportWithSyncedReviewComment(
+        implementedCloseReport({ number }),
+        number,
+        "implemented_on_main",
+      );
+      writeFileSync(join(itemsDir, `${number}.md`), synced.report, "utf8");
+      comments[number] = synced.comment;
+    }
+
+    const ghMock = `
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+const path = args[1] === "-i" ? args[2] || "" : args[1] || "";
+const comments = ${JSON.stringify(comments)};
+if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/(10|20)\\/timeline(?:\\?|$)/.test(path)) {
+  console.log("HTTP/2 200\\n\\n[]");
+} else if (args[0] === "api" && /\\/issues\\/(10|20)\\/comments(?:\\?|$)/.test(path)) {
+  const number = Number(path.match(/\\/issues\\/(\\d+)\\/comments/)[1]);
+  console.log(JSON.stringify([[
+    {
+      id: 9000 + number,
+      html_url: "https://github.com/openclaw/clawsweeper/issues/" + number + "#issuecomment-" + (9000 + number),
+      body: comments[number],
+      user: { login: "github-actions[bot]" },
+      created_at: "2026-05-01T01:00:00Z",
+      updated_at: "2026-05-01T01:00:00Z"
+    }
+  ]]));
+} else if (args[0] === "api" && /\\/issues\\/(10|20)$/.test(path)) {
+  const number = Number(path.match(/\\/issues\\/(\\d+)$/)[1]);
+  console.log(JSON.stringify({
+    number,
+    title: "Close limit trace " + number,
+    html_url: "https://github.com/openclaw/clawsweeper/issues/" + number,
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "reporter" },
+    labels: [],
+    comments: 0,
+    pull_request: null
+  }));
+} else if (args[0] === "api" && path.startsWith("search/issues?")) {
+  console.log(JSON.stringify({ items: [] }));
+} else if (args[0] === "issue" && args[1] === "view") {
+  console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: [
+          "--dry-run",
+          "--limit",
+          "1",
+          "--processed-limit",
+          "10",
+          "--cursor-trace",
+          tracePath,
+        ],
+      });
+    });
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    const trace = JSON.parse(readFileSync(tracePath, "utf8"));
+    assert.deepEqual(
+      report
+        .filter((entry: { action: string }) => entry.action === "closed")
+        .map((entry: { number: number }) => entry.number),
+      [10],
+    );
+    assert.deepEqual(trace, { schema_version: 1, examined_item_numbers: [10] });
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- Keep the automatic apply cursor trace from advancing past a close candidate stopped by a filled close limit.
- Add a focused apply CLI regression covering a full close checkpoint with a next close candidate still in the scan window.

## Problem

Merged PR #420 added exact apply cursor tracing for bounded apply windows. The apply loop appended the current item to `examinedItemNumbers` near loop entry, but the later close-limit guard could break before executing the current close candidate. That let the cursor writer advance past a candidate that had not been closed, delaying it until cursor wrap.

## Implementation

- Remove the current item from the cursor trace immediately before the `closedCount >= limit` break.
- Add `apply-decisions keeps close-limit candidates out of the cursor trace`, which runs a dry close window with two candidates and `--limit 1`, then verifies only the first item is closed and only that item remains in the cursor trace.

## Validation

- `pnpm run build:all` - passed.
- `node --test test/apply-cursor-trace.test.ts test/repair/workflow-utils.test.ts test/clawsweeper.test.ts test/apply-label-sync.test.ts` - passed, 128 tests.
- `git diff --check` - passed.

## Proof

The regression exercises the cursor-producing apply path, not just the cursor writer. It builds two synthetic close candidates, fills the close limit on the first candidate, reaches the second candidate in the same dry-run scan, and asserts the trace stays at `[10]` instead of including the next close-limited candidate.

Redacted live dry-run proof against copied generated-state records for `openclaw/openclaw` candidates #94677 and #94998. This used live `gh` reads and `--dry-run`, so it did not mutate GitHub or the generated state checkout.

```text
PROOF_ROOT=<proof-root>
COMMAND node dist/clawsweeper.js apply-decisions --target-repo openclaw/openclaw --items-dir <proof-root>\items --closed-dir <proof-root>\closed --plans-dir <proof-root>\plans --report-path <proof-root>\apply-report.json --limit 1 --processed-limit 10 --close-delay-ms 0 --dry-run --apply-close-reasons implemented_on_main --cursor-trace <proof-root>\apply-cursor-trace.json
APPLY_OUTPUT
[apply] 2026-07-05T21:40:29.922Z starting apply: files=2 dry_run=true apply_kind=issue min_age=0 days apply_close_reasons=implemented_on_main stale_min_age_days=60 close_delay_ms=0 sync_comments_only=false comment_sync_min_age_days=0 max_runtime_ms=0 item_numbers=all closed=0/1 processed=0/10 counts={}
[apply] 2026-07-05T21:40:30.597Z finished apply closed=1/1 processed=1/10 counts={"closed":1}
[
  {
    "number": 94677,
    "action": "closed",
    "reason": "matching ClawSweeper review comment already exists"
  }
]
TRACE_JSON
{
  "schema_version": 1,
  "examined_item_numbers": [
    94677
  ]
}
TRACE_ITEMS 94677
```

## Codex Review Closeout

- Review command: `codex -c service_tier="fast" review --base origin/main`.
- Findings accepted/rejected: none; the final review reported no discrete correctness issues.
- Clean result: "The change keeps over-limit close candidates out of the cursor trace without breaking the apply flow, and the added focused coverage exercises the intended behavior. I did not identify any discrete correctness issues in the diff."
- Note: `codex review --base origin/main` failed before reviewing because the local config still had obsolete `service_tier = default`; `service_tier="flex"` parsed locally but was rejected provider-side. The successful review used the same branch/base target with `service_tier="fast"`.

## Risks / Rollout

Risk is limited to apply cursor trace bookkeeping when the close limit stops a scan. The close gates and cursor writer selection logic are unchanged.

## Links

- Follow-up to merged PR #420 / commit `bbc8c8f8e4de75735dc7831dffd75a162ea4ff63`.