### PR TITLE
Fix runtime-yield apply continuation without cursor progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ checkpoint, and status-only commits are intentionally omitted.
 - Scoped Mantis recommendations to supported proof capture and kept code changes, PR repair, and GitHub mutations in ClawSweeper's deterministic lanes. Thanks @brokemac79.
 - Bounded automatic close-apply checkpoints to ten minutes, persisted exact cursor progress before immediate continuation, and limited close-coverage proofs to the time remaining in the checkpoint.
 - Kept close-limit apply checkpoints from advancing their resumable cursor past an unexecuted close candidate. Thanks @brokemac79.
+- Stopped zero-progress automatic apply runtime yields from queueing immediate continuations, leaving the scheduled apply run as the retry backstop. Thanks @brokemac79.
 - Kept automatic apply windows responsive by running at most one PR close-coverage proof after fast candidates and advancing independent fast/proof cursors only through records actually examined.
 - Prevented malformed `maintainer_decision` records from repeatedly consuming apply queue slots by recording their deterministic apply bookkeeping. Thanks @brokemac79.
 - Preserved ready-for-maintainer labels when a newer durable review matches the current PR head, while still removing readiness from stale-head reviews. Thanks @brokemac79.

--- a/scripts/apply-workflow-helpers.sh
+++ b/scripts/apply-workflow-helpers.sh
@@ -71,10 +71,17 @@ select_automatic_apply_runtime() {
 
 automatic_apply_runtime_reached() {
   local report_path="$1"
+  local runtime_cursor_advance_count="${2:-${cursor_advance_count:-}}"
+  local runtime_auto_selected_apply_batch="${3:-${auto_selected_apply_batch:-false}}"
   local runtime_budget_count
   runtime_budget_count="$(pnpm run --silent workflow -- count-actions --report "$report_path" --action skipped_runtime_budget)"
   if [ "$runtime_budget_count" -eq 0 ]; then
     return 1
+  fi
+  if [ "$runtime_auto_selected_apply_batch" = "true" ] &&
+    { [ -z "$runtime_cursor_advance_count" ] || [ "$runtime_cursor_advance_count" -eq 0 ]; }; then
+    echo "Automatic close checkpoint reached its 600000ms runtime budget before cursor progress; cursor is unchanged and scheduled apply will retry without queueing an immediate continuation."
+    return 0
   fi
   echo "Automatic close checkpoint reached its 600000ms runtime budget; cursor is persisted and a fresh-token continuation will resume the lane."
   continue_apply=true

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -239,6 +239,7 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
   assert.match(applyStep, /if \[ "\$result_count" -ge "\$close_processed_limit" \]; then/);
   assert.match(applyHelper, /--action skipped_runtime_budget/);
   assert.match(applyStep, /if automatic_apply_runtime_reached/);
+  assert.match(applyHelper, /runtime budget before cursor progress/);
   assert.match(applyHelper, /fresh-token continuation will resume the lane/);
   assert.doesNotMatch(
     applyStep,
@@ -273,6 +274,52 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
   assert.match(continueStep, /already covered by \$/);
   assert.match(continueStep, /-f apply_item_numbers="\$APPLY_ITEM_NUMBERS"/);
   assert.doesNotMatch(continueStep, /APPLY_CLOSED_TOTAL:-0.*APPLY_LIMIT:-0/);
+});
+
+test("apply workflow does not queue runtime-yield continuation without cursor progress", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const reportPath = join(root, "apply-report.json");
+  writeFileSync(reportPath, JSON.stringify([{ number: 0, action: "skipped_runtime_budget" }]));
+
+  try {
+    const output = execFileSync(
+      "bash",
+      [
+        "-lc",
+        [
+          "pnpm() { printf '1\\n'; }",
+          "source scripts/apply-workflow-helpers.sh",
+          "continue_apply=false",
+          "auto_selected_apply_batch=true",
+          "cursor_advance_count=0",
+          'if automatic_apply_runtime_reached "$REPORT_PATH"; then status=yielded; else status=no_yield; fi',
+          'printf \'%s|%s\\n\' "$status" "$continue_apply"',
+          "continue_apply=false",
+          "cursor_advance_count=1",
+          'if automatic_apply_runtime_reached "$REPORT_PATH"; then status=yielded; else status=no_yield; fi',
+          'printf \'%s|%s\\n\' "$status" "$continue_apply"',
+        ].join("\n"),
+      ],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          REPORT_PATH: reportPath,
+        },
+      },
+    );
+
+    assert.deepEqual(
+      output
+        .trim()
+        .split("\n")
+        .filter((line) => line.includes("|")),
+      ["yielded|false", "yielded|true"],
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("apply workflow drops a coverage-proof tail only after exact trace examination", () => {


### PR DESCRIPTION
## Summary

- Prevent automatic apply runtime-yield checkpoints from queueing an immediate continuation when the apply cursor made zero progress.
- Add a regression test proving a no-progress runtime yield leaves `continue_apply=false`, while a progressed runtime yield still queues the fresh-token continuation.

## Problem

Merged PR #423 / commit `0667396551a4aad665aeac90202484d449448847` left one accepted follow-up finding: an expensive proof can consume the automatic apply runtime budget before any selected item remains in the cursor trace. `write-apply-cursor` then preserves the previous cursor and `cursor_advance_count` is `0`, but the helper still set `continue_apply=true`, allowing the next continuation to select the same item again.

## Implementation

`automatic_apply_runtime_reached` now reads the caller's `cursor_advance_count` and `auto_selected_apply_batch` shell variables. For automatic cursor batches, a runtime yield with empty or zero cursor advancement stops the current checkpoint but does not set `continue_apply=true`; scheduled apply remains the backstop. Runtime yields with positive cursor progress and non-automatic/manual apply lanes keep the previous continuation behavior.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run build:all`
- `$env:PATH="C:\\Program Files\\Git\\bin;C:\\Program Files\\Git\\usr\\bin;$env:PATH"; node --test test/repair/workflow-utils.test.ts test/sweep-workflow.test.ts test/apply-cursor-trace.test.ts`
  - Result: 79 passed, 1 skipped (`read-only checkout mode restores file modes and leaves git metadata writable`, skipped on Windows as expected).
- `git diff --check`
- `$env:PATH="C:\\Program Files\\Git\\bin;C:\\Program Files\\Git\\usr\\bin;$env:PATH"; bash -n scripts/apply-workflow-helpers.sh`
- `pnpm run lint:scripts`
- `pnpm exec oxfmt --check scripts/apply-workflow-helpers.sh test/sweep-workflow.test.ts`
- `actionlint -version`
  - Result: unavailable locally (`actionlint` is not recognized). This PR does not modify `.github/workflows/**`; workflow-focused proof is the existing `test/sweep-workflow.test.ts` parser/contract coverage plus `bash -n` on the changed helper.

## Proof

Codex review closeout:

- Initial helper invocation through Bash failed before review because this host's `~/.codex/config.toml` contains `service_tier = "default"`, which `codex-cli 0.129.0` rejects for `review`.
- `codex -c service_tier=fast review --base origin/main`
  - Result: `No actionable correctness issues were identified in the changed runtime-yield continuation handling or its added regression coverage.`

Dry-run runtime-yield behavior proof (local, redacted; uses the real `pnpm run workflow -- apply-cursor-advance-count` utility and `scripts/apply-workflow-helpers.sh`, with no mocked `pnpm`):

Command summary:

```text
# create one skipped_runtime_budget report, one empty cursor trace, and one trace containing item 42
# source scripts/apply-workflow-helpers.sh
# auto_selected_apply_batch=true
# derive cursor_advance_count with pnpm run --silent workflow -- apply-cursor-advance-count
# call automatic_apply_runtime_reached and print APPLY_CONTINUE
```

Output:

```text
Automatic close checkpoint reached its 600000ms runtime budget before cursor progress; cursor is unchanged and scheduled apply will retry without queueing an immediate continuation.
zero-progress cursor_advance_count=0 APPLY_CONTINUE=false
Automatic close checkpoint reached its 600000ms runtime budget; cursor is persisted and a fresh-token continuation will resume the lane.
progressed cursor_advance_count=1 APPLY_CONTINUE=true
```

## Risks / Rollout

Risk is limited to automatic apply runtime-yield continuation decisions. The change intentionally keeps explicit/manual continuation behavior unchanged and relies on the scheduled apply lane when cursor progress is zero.

## Links

- Follow-up from PR #423 / commit `0667396551a4aad665aeac90202484d449448847`.