### PR TITLE
ci: migrate checkout workflows to v7

### DIFF
--- a/.github/actions/setup-state/action.yml
+++ b/.github/actions/setup-state/action.yml
@@ -31,7 +31,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         repository: openclaw/clawsweeper-state
         ref: state

--- a/.github/workflows/assist.yml
+++ b/.github/workflows/assist.yml
@@ -68,7 +68,7 @@ jobs:
     outputs:
       proceed: ${{ steps.receipt.outputs.proceed }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           sparse-checkout: scripts/dispatch-receipt-owner.sh
           sparse-checkout-cone-mode: false
@@ -103,7 +103,7 @@ jobs:
       proceed: ${{ steps.limit.outputs.proceed }}
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           filter: blob:none
           sparse-checkout: |
@@ -165,7 +165,7 @@ jobs:
     runs-on: ${{ vars.CLAWSWEEPER_WORKER_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 8
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           filter: blob:none
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           sparse-checkout: |
             .github
@@ -59,7 +59,7 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/setup-pnpm
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,7 +36,7 @@ jobs:
           - actions
           - javascript-typescript
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           sparse-checkout: |
             .github

--- a/.github/workflows/commit-review.yml
+++ b/.github/workflows/commit-review.yml
@@ -76,7 +76,7 @@ jobs:
       target_repo_name: ${{ steps.target.outputs.target_repo_name }}
       target_repo_owner: ${{ steps.target.outputs.target_repo_owner }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           path: clawsweeper
           filter: blob:none
@@ -334,7 +334,7 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.plan.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           path: clawsweeper
           filter: blob:none
@@ -467,7 +467,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           filter: blob:none
           fetch-depth: 0

--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: [self-hosted, crabbox, openclaw, clawsweeper, "${{ inputs.crabbox_runner_label }}"]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref || github.ref }}
 

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -31,8 +31,9 @@ jobs:
       CLAWSWEEPER_STATUS_CI_LIMIT: "30"
       GITHUB_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
+          ref: ${{ github.event.repository.default_branch }}
           filter: blob:none
           fetch-depth: 1
 

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -34,7 +34,7 @@ jobs:
       CLAWSWEEPER_APP_PRIVATE_KEY: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
       CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/setup-pnpm
 

--- a/.github/workflows/github-activity.yml
+++ b/.github/workflows/github-activity.yml
@@ -91,7 +91,7 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         if: steps.core-budget.outputs.skip != 'true'
         with:
           ref: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/maintainer-activity-report.yml
+++ b/.github/workflows/maintainer-activity-report.yml
@@ -76,7 +76,7 @@ jobs:
           permission-pull-requests: read
 
       - name: Check out maintainers
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: openclaw/maintainers
           path: maintainers
@@ -89,7 +89,7 @@ jobs:
           node-version: 24
 
       - name: Check out ClawSweeper
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: clawsweeper
           filter: blob:none

--- a/.github/workflows/maintainer-report-discord.yml
+++ b/.github/workflows/maintainer-report-discord.yml
@@ -44,12 +44,12 @@ jobs:
           repositories: maintainers
           permission-contents: read
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           filter: blob:none
           persist-credentials: false
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           repository: openclaw/maintainers
           path: maintainers

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,7 +31,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Check out
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Node
         uses: actions/setup-node@v6

--- a/.github/workflows/proof-nudges.yml
+++ b/.github/workflows/proof-nudges.yml
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           filter: blob:none
           fetch-depth: 0

--- a/.github/workflows/repair-cluster-intake.yml
+++ b/.github/workflows/repair-cluster-intake.yml
@@ -87,7 +87,7 @@ jobs:
           repositories: gitcrawl-store
           permission-contents: read
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           token: ${{ steps.central-token.outputs.token }}
           filter: blob:none
@@ -109,7 +109,7 @@ jobs:
           token: ${{ steps.state-token.outputs.token }}
           fetch-depth: 1
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           repository: openclaw/gitcrawl-store
           token: ${{ steps.store-token.outputs.token }}

--- a/.github/workflows/repair-cluster-worker.yml
+++ b/.github/workflows/repair-cluster-worker.yml
@@ -81,7 +81,7 @@ jobs:
     outputs:
       proceed: ${{ steps.receipt.outputs.proceed }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           sparse-checkout: scripts/dispatch-receipt-owner.sh
           sparse-checkout-cone-mode: false
@@ -140,7 +140,7 @@ jobs:
       CLAWSWEEPER_CRABFLEET_URL: ${{ vars.CLAWSWEEPER_CRABFLEET_URL || 'https://crabfleet.openclaw.ai' }}
       OPENCLAW_LOCAL_CHECK: "0"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           filter: blob:none
 
@@ -419,7 +419,7 @@ jobs:
       CLAWSWEEPER_CRABFLEET_URL: ${{ vars.CLAWSWEEPER_CRABFLEET_URL || 'https://crabfleet.openclaw.ai' }}
       OPENCLAW_LOCAL_CHECK: "0"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           filter: blob:none
 

--- a/.github/workflows/repair-comment-router.yml
+++ b/.github/workflows/repair-comment-router.yml
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           filter: blob:none
           fetch-depth: 0

--- a/.github/workflows/repair-commit-finding-intake.yml
+++ b/.github/workflows/repair-commit-finding-intake.yml
@@ -85,7 +85,7 @@ jobs:
     runs-on: ${{ github.event.inputs.runner || vars.CLAWSWEEPER_COMMIT_FINDING_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     timeout-minutes: 75
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           filter: blob:none
           fetch-depth: 0

--- a/.github/workflows/repair-conflict-self-heal.yml
+++ b/.github/workflows/repair-conflict-self-heal.yml
@@ -62,7 +62,7 @@ jobs:
           permission-issues: write
           permission-pull-requests: write
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           filter: blob:none
           fetch-depth: 0

--- a/.github/workflows/repair-finalize-open-prs.yml
+++ b/.github/workflows/repair-finalize-open-prs.yml
@@ -54,7 +54,7 @@ jobs:
           permission-issues: read
           permission-pull-requests: read
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           filter: blob:none
           fetch-depth: 0

--- a/.github/workflows/repair-issue-implementation-intake.yml
+++ b/.github/workflows/repair-issue-implementation-intake.yml
@@ -79,7 +79,7 @@ jobs:
     runs-on: ${{ github.event.client_payload.intake_runner || vars.CLAWSWEEPER_ISSUE_IMPLEMENTATION_INTAKE_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           filter: blob:none
           fetch-depth: 0

--- a/.github/workflows/repair-publish-results.yml
+++ b/.github/workflows/repair-publish-results.yml
@@ -36,7 +36,7 @@ jobs:
           permission-contents: write
           permission-pull-requests: read
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.repository.default_branch }}
           filter: blob:none

--- a/.github/workflows/repair-self-heal.yml
+++ b/.github/workflows/repair-self-heal.yml
@@ -58,7 +58,7 @@ jobs:
           permission-actions: write
           permission-contents: write
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           filter: blob:none
           fetch-depth: 0

--- a/.github/workflows/spam-comment-intake.yml
+++ b/.github/workflows/spam-comment-intake.yml
@@ -45,7 +45,7 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         if: steps.core-budget.outputs.skip != 'true'
         with:
           filter: blob:none

--- a/.github/workflows/spam-scanner.yml
+++ b/.github/workflows/spam-scanner.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           filter: blob:none
           fetch-depth: 0

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -307,7 +307,7 @@ jobs:
           done
           exit 1
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           filter: blob:none
           fetch-depth: 0
@@ -824,7 +824,7 @@ jobs:
       actions: write
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           filter: blob:none
           fetch-depth: 0
@@ -916,7 +916,7 @@ jobs:
       target_repo_name: ${{ steps.target.outputs.target_repo_name }}
       target_repo_owner: ${{ steps.target.outputs.target_repo_owner }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           path: clawsweeper
           filter: blob:none
@@ -1245,7 +1245,7 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.plan.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           path: clawsweeper
           filter: blob:none
@@ -1452,7 +1452,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           filter: blob:none
           fetch-depth: 0
@@ -1974,7 +1974,7 @@ jobs:
       issues: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           filter: blob:none
           fetch-depth: 0
@@ -2043,7 +2043,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           filter: blob:none
           fetch-depth: 0
@@ -2164,7 +2164,7 @@ jobs:
     env:
       CLAWSWEEPER_UNCONFIRMED_PRODUCT_DIRECTION_CLOSE_ENABLED: ${{ vars.CLAWSWEEPER_UNCONFIRMED_PRODUCT_DIRECTION_CLOSE_ENABLED || 'false' }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           filter: blob:none
           fetch-depth: 0

--- a/test/actions-checkout-v7.test.ts
+++ b/test/actions-checkout-v7.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+import { parse } from "yaml";
+
+interface CheckoutStep {
+  uses?: string;
+  with?: Record<string, unknown>;
+}
+
+interface WorkflowDocument {
+  jobs?: Record<string, { steps?: CheckoutStep[] }>;
+}
+
+function yamlFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) return yamlFiles(path);
+    return /\.ya?ml$/.test(entry.name) ? [path] : [];
+  });
+}
+
+const actionFiles = yamlFiles(".github");
+const checkoutReferences = actionFiles.flatMap((path) =>
+  readFileSync(path, "utf8")
+    .split("\n")
+    .filter((line) => line.includes("actions/checkout@"))
+    .map((line) => ({ path, reference: line.trim().replace(/^-?\s*uses:\s*/, "") })),
+);
+
+test("every checkout uses v7 without disabling its fork-PR guard", () => {
+  assert.ok(checkoutReferences.length > 0, "expected checkout action references");
+  assert.deepEqual(
+    [...new Set(checkoutReferences.map(({ reference }) => reference))],
+    ["actions/checkout@v7"],
+    checkoutReferences.map(({ path, reference }) => `${path}: ${reference}`).join("\n"),
+  );
+
+  const sources = actionFiles.map((path) => readFileSync(path, "utf8")).join("\n");
+  assert.doesNotMatch(sources, /allow-unsafe-pr-checkout:\s*true/);
+});
+
+test("trusted-event workflows explicitly checkout the default branch", () => {
+  for (const path of [
+    ".github/workflows/dashboard-ci.yml",
+    ".github/workflows/github-activity.yml",
+    ".github/workflows/repair-publish-results.yml",
+  ]) {
+    const workflow = parse(readFileSync(path, "utf8")) as WorkflowDocument;
+    const checkoutSteps = Object.values(workflow.jobs ?? {})
+      .flatMap((job) => job.steps ?? [])
+      .filter((step) => step.uses === "actions/checkout@v7");
+    assert.equal(checkoutSteps.length, 1, path);
+    assert.equal(
+      checkoutSteps[0]?.with?.ref,
+      "${{ github.event.repository.default_branch }}",
+      path,
+    );
+  }
+});
+
+test("trusted-event state checkout remains pinned to the state repository branch", () => {
+  const action = parse(readFileSync(".github/actions/setup-state/action.yml", "utf8")) as {
+    runs?: { steps?: CheckoutStep[] };
+  };
+  const checkout = action.runs?.steps?.find((step) => step.uses === "actions/checkout@v7");
+  assert.equal(checkout?.with?.repository, "openclaw/clawsweeper-state");
+  assert.equal(checkout?.with?.ref, "state");
+});


### PR DESCRIPTION
## Summary

- migrate all 42 `actions/checkout` references from v5/v6 to v7
- keep v7 fork-PR protection enabled and make trusted `workflow_run` checkout explicit
- add structural regression coverage for checkout version and trust boundaries

## Why

Checkout v7 is the latest stable release and adds fail-closed protection against checking out fork pull-request code from privileged `pull_request_target` and `workflow_run` contexts. ClawSweeper does not intentionally do that; its sensitive workflows checkout the default branch or the separate state repository.

## Validation

- `node --test test/actions-checkout-v7.test.ts`
- `actionlint -shellcheck= <changed workflows>`
- `CI=true pnpm run check`
- AutoReview: clean, no findings (GPT-5.5 high)
