### PR TITLE
fix: avoid review marker regex backtracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Removed exponential backtracking from durable review-marker parsing so adversarial comment bodies cannot stall apply or comment synchronization.
 - Scoped Mantis recommendations to supported proof capture and kept code changes, PR repair, and GitHub mutations in ClawSweeper's deterministic lanes. Thanks @brokemac79.
 - Bounded automatic close-apply checkpoints to ten minutes, persisted exact cursor progress before immediate continuation, and limited close-coverage proofs to the time remaining in the checkpoint.
 - Kept close-limit apply checkpoints from advancing their resumable cursor past an unexecuted close candidate. Thanks @brokemac79.

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -126,6 +126,7 @@ import {
   type ReviewHistoryCycle,
   type ReviewHistoryLedger,
 } from "./review-history.js";
+import { trailingHtmlComments } from "./review-comment-markers.js";
 
 export {
   codexEnv,
@@ -16240,14 +16241,12 @@ function newestReviewMarkerAttribute(
   const reviewMarkerIndex = body.lastIndexOf(reviewMarker);
   if (reviewMarkerIndex < 0) return undefined;
   if (body.slice(reviewMarkerIndex + reviewMarker.length).trim() !== "") return undefined;
-  const markerBlock = body
-    .slice(0, reviewMarkerIndex)
-    .trimEnd()
-    .match(/(?:<!--[\s\S]*?-->\s*)+$/)?.[0];
-  if (!markerBlock) return undefined;
-  const markerPattern = /<!--\s+clawsweeper-verdict:[^\s>]+\b([^>]*)-->/g;
+  const markerComments = trailingHtmlComments(body.slice(0, reviewMarkerIndex));
+  const markerPattern = /^<!--\s+clawsweeper-verdict:[^\s>]+\b([^>]*)-->$/;
   let lastValue: string | undefined;
-  for (const match of markerBlock.matchAll(markerPattern)) {
+  for (const markerComment of markerComments) {
+    const match = markerComment.match(markerPattern);
+    if (!match) continue;
     const attributes = match[1] ?? "";
     if (!new RegExp(`\\bitem=${number}\\b`).test(attributes)) continue;
     const value = attributes.match(new RegExp(`\\b${attribute}=([^\\s>]+)`))?.[1];

--- a/src/review-comment-markers.ts
+++ b/src/review-comment-markers.ts
@@ -1,0 +1,17 @@
+export function trailingHtmlComments(value: string): string[] {
+  let cursor = 0;
+  let trailing: string[] = [];
+
+  while (cursor < value.length) {
+    const commentStart = value.indexOf("<!--", cursor);
+    if (commentStart < 0) break;
+    const commentEnd = value.indexOf("-->", commentStart + 4);
+    if (commentEnd < 0) break;
+
+    if (value.slice(cursor, commentStart).trim()) trailing = [];
+    trailing.push(value.slice(commentStart, commentEnd + 3));
+    cursor = commentEnd + 3;
+  }
+
+  return value.slice(cursor).trim() ? [] : trailing;
+}

--- a/test/review-comment-markers.test.ts
+++ b/test/review-comment-markers.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { trailingHtmlComments } from "../dist/review-comment-markers.js";
+
+test("trailingHtmlComments returns only the final contiguous comment block", () => {
+  assert.deepEqual(
+    trailingHtmlComments(
+      [
+        "Codex review: ready for maintainer look.",
+        "<!-- stale-marker -->",
+        "Visible review details.",
+        "<!-- clawsweeper-verdict:needs-human item=321 sha=head -->",
+        "<!-- clawsweeper-action:fix-required item=321 sha=head -->",
+        "",
+      ].join("\n"),
+    ),
+    [
+      "<!-- clawsweeper-verdict:needs-human item=321 sha=head -->",
+      "<!-- clawsweeper-action:fix-required item=321 sha=head -->",
+    ],
+  );
+});
+
+test("trailingHtmlComments rejects an unterminated adversarial suffix", () => {
+  const value = `<!--${"--><!--".repeat(10_000)}unterminated`;
+  assert.deepEqual(trailingHtmlComments(value), []);
+});


### PR DESCRIPTION
## Summary

- replace the backtracking review-marker suffix regex with a linear HTML-comment scanner
- preserve selection from the final contiguous marker block and fail closed on malformed comments
- add focused regression coverage and an Unreleased changelog entry

## Security impact

Resolves [CodeQL alert 55](https://github.com/openclaw/clawsweeper/security/code-scanning/55), where adversarial durable review-comment text could cause exponential regex backtracking during apply or comment synchronization.

## Proof

- `CI=true pnpm run check` on Node 24 with the repository-pinned pnpm 10.33.2
- 692/692 unit tests and 622/622 repair tests, changed/full coverage, lint, formatting
- 1.4 MB adversarial unterminated marker input parsed in 13.28 ms
- AutoReview: clean, no actionable findings, 0.86 confidence
