### PR TITLE
fix: preserve review marker tails after unmatched openers

### DIFF
--- a/src/review-comment-markers.ts
+++ b/src/review-comment-markers.ts
@@ -1,17 +1,17 @@
 export function trailingHtmlComments(value: string): string[] {
-  let cursor = 0;
-  let trailing: string[] = [];
+  let end = value.length;
+  const trailing: string[] = [];
 
-  while (cursor < value.length) {
-    const commentStart = value.indexOf("<!--", cursor);
+  while (end > 0) {
+    while (end > 0 && /\s/.test(value[end - 1] ?? "")) end -= 1;
+    if (end === 0) break;
+    if (!value.endsWith("-->", end)) break;
+
+    const commentStart = value.lastIndexOf("<!--", end - 3);
     if (commentStart < 0) break;
-    const commentEnd = value.indexOf("-->", commentStart + 4);
-    if (commentEnd < 0) break;
-
-    if (value.slice(cursor, commentStart).trim()) trailing = [];
-    trailing.push(value.slice(commentStart, commentEnd + 3));
-    cursor = commentEnd + 3;
+    trailing.push(value.slice(commentStart, end));
+    end = commentStart;
   }
 
-  return value.slice(cursor).trim() ? [] : trailing;
+  return trailing.reverse();
 }

--- a/test/review-comment-markers.test.ts
+++ b/test/review-comment-markers.test.ts
@@ -26,3 +26,19 @@ test("trailingHtmlComments rejects an unterminated adversarial suffix", () => {
   const value = `<!--${"--><!--".repeat(10_000)}unterminated`;
   assert.deepEqual(trailingHtmlComments(value), []);
 });
+
+test("trailingHtmlComments recovers when prose contains an unmatched opener", () => {
+  assert.deepEqual(
+    trailingHtmlComments(
+      [
+        "Codex review: mention the literal `<!--` delimiter in visible prose.",
+        "<!-- clawsweeper-verdict:needs-human item=321 sha=head -->",
+        "<!-- clawsweeper-review item=321 -->",
+      ].join("\n"),
+    ),
+    [
+      "<!-- clawsweeper-verdict:needs-human item=321 sha=head -->",
+      "<!-- clawsweeper-review item=321 -->",
+    ],
+  );
+});


### PR DESCRIPTION
## Summary

- Fix `trailingHtmlComments` to scan generated review-marker footers from the end backward.
- Preserve valid verdict markers when visible review prose contains a literal unmatched `<!--` delimiter.
- Add regression coverage for the unmatched-opener case found while reviewing Peter's merged PR #429.

## Problem

Peter's #429 replaced a backtracking regex with a linear scanner for durable review-comment marker tails. The forward scanner could still mis-parse a valid generated footer when earlier visible review text mentioned an unmatched `<!--` delimiter, pairing that prose opener with the verdict marker's closing `-->`. In that case `newestReviewMarkerAttribute` could miss the live `sha` and `reviewed_at`, so apply/comment sync might fail to protect a newer durable review from an older local report.

## Implementation

The footer parser now walks backward from the trimmed end of the comment body, collecting only the final contiguous HTML-comment block. This keeps non-footer text and stale body markers out of the trusted tail while recovering from unmatched openers in visible prose before the generated footer.

## Validation

- `pnpm run build`
- `node --test test/review-comment-markers.test.ts`
- `node --test test/clawsweeper.test.ts`
- `pnpm run lint:src`
- `git diff --check`
- Adversarial 1.4 MB unterminated marker probe: `resultLength=0`, `elapsedMs=0.37`
- Codex review loop:
  - `codex review -c service_tier='"fast"' --commit 25d7e74e6dc5c33c9342089a12933d1c53b78e65` accepted one P2 finding for unmatched openers swallowing footer markers.
  - `codex review -c service_tier='"fast"' --uncommitted` after the fix: no actionable correctness issues found.

Broader note: `pnpm run test:unit` was also attempted on this Windows host. It reached 685 passing tests, 1 skipped, and 8 failures from this host's baseline missing `/bin/bash` WSL path plus local fake-Codex assertions, not from the touched parser surface.

## Proof

The new regression test covers prose containing a literal unmatched `<!--` before a valid generated verdict/review footer. The focused apply-sync suite in `test/clawsweeper.test.ts` still passes, including newer durable review protection and forged marker rejection. The adversarial unterminated suffix remains fail-closed and linear.

## Risks / Rollout

Low-risk parser-only fix. The parser intentionally trusts only the final contiguous HTML-comment footer block and returns no markers when trailing visible text follows the footer. No GitHub workflow, credential, or mutation-gate behavior changes.

## Links

- Source regression review target: #429