### PR TITLE
feat(review): opt-in external CLI engine for offline local review

### DIFF
--- a/docs/commit-sweeper.md
+++ b/docs/commit-sweeper.md
@@ -273,6 +273,45 @@ disables Codex web search, and explicitly forbids network lookups. Repositories
 without a configured profile are rejected (no foreign-profile fallback). Unlike the
 hosted lane it never writes to GitHub — the local Markdown report is the only output.
 
+### Non-codex engines (`--engine`)
+
+Both offline local-review paths — `commit-sweeper local-review` and
+`clawsweeper review --local-range` — default to `--engine codex` but accept an opt-in,
+provider-neutral **`external`** engine that drives any read-only CLI through the same
+bounded, offline runner (scrubbed credentials, empty `GH_CONFIG_DIR`, clean committed
+range). No providers are built in — you point it at your own CLI with inline flags:
+
+- `--external-cmd <bin>` — the read-only review CLI to run
+- `--external-args '<JSON array>'` — its argument template; the tokens `{prompt}`,
+  `{promptFile}`, and `{model}` are substituted
+- `--external-prompt stdin|argv|file` — how the review prompt reaches the CLI (default `stdin`)
+- `--external-model <model>` — substituted into a `{model}` token (optional)
+- `--external-timeout-ms <n>` — per-run timeout (default 30 min)
+
+The external engine reports a **Markdown** review. On `local-review` that markdown is the
+report; on `review --local-range` it is deterministically bridged into a benign advisory
+Decision (verdict `keep_open` — a pre-PR advisory closes nothing) whose summary carries the
+review. On the `review` command, `external` is restricted to `--local-range`; it never runs
+in the hosted/apply path. Codex remains the default and the only engine any automation uses.
+
+Example recipes (adjust for your CLI version):
+
+```bash
+# claude — prompt on stdin, its own read tools for exploration
+clawsweeper review --local-range --engine external --external-cmd claude \
+  --external-args '["-p","--output-format","text","--allowedTools","Read,Grep,Glob"]' \
+  --external-prompt stdin
+
+# agy — prompt as the trailing argv after --print
+clawsweeper review --local-range --engine external --external-cmd agy \
+  --external-args '["--model","{model}","--sandbox","--print"]' \
+  --external-model "Gemini 3.1 Pro (High)" --external-prompt argv
+
+# opencode — read-only plan agent
+clawsweeper review --local-range --engine external --external-cmd opencode \
+  --external-args '["run","--agent","plan"]' --external-prompt argv
+```
+
 ## Enable / Disable
 
 Target repositories can disable hook-based dispatch with:

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -33,6 +33,13 @@ import {
 } from "./codex-env.js";
 import { codexProcessErrorCode, runCodexProcess } from "./codex-process.js";
 import {
+  EXTERNAL_ARGV_MAX_DIFF_BYTES,
+  EXTERNAL_ENGINE_ID,
+  externalEngineSpecFromFlags,
+  planExternalRun,
+  type ExternalEngineSpec,
+} from "./external-engine.js";
+import {
   codexJsonlFailureDetail,
   codexRetryDelayMs,
   codexTerminalErrorDetail,
@@ -7722,6 +7729,195 @@ export function makeTreeReadOnlyForTest(path: string): FileModeSnapshot[] {
 
 export function restoreTreeModesForTest(snapshots: readonly FileModeSnapshot[]): void {
   restoreTreeModes(snapshots);
+}
+
+// Offline `external` engine for the structured Decision path (review --local-range only).
+// Drives the operator-named schema-capable CLI through the SAME bounded worker + offline
+// envelope as codex, then reads the schema-constrained Decision it emits — from {outputFile}
+// if the CLI wrote one (codex `--output-last-message`), else from stdout (e.g. claude
+// `--output-format json` envelope). Any missing/malformed output becomes a clean, visible
+// failure Decision; it never guesses a decision. Provider-neutral, no engine defaults.
+// Deterministic bridge: wrap an external engine's markdown review into a valid, benign
+// advisory Decision for `review --local-range`. External engines report prose, not the
+// mantis schema — so the verdict is always `keep_open` (a pre-PR advisory closes nothing),
+// the engine's markdown is carried in `summary` + `evidence` so it renders in the report,
+// and the structured sub-assessments are left neutral / "not extracted" rather than invented.
+function externalAdvisoryDecision(reviewMarkdown: string, engineName: string): Decision {
+  const review = reviewMarkdown.trim() || `${engineName} produced no review output.`;
+  const note = `Not separately extracted — the external \`${engineName}\` engine reported a markdown advisory (see summary), not the structured mantis schema.`;
+  return {
+    decision: "keep_open",
+    closeReason: "none",
+    confidence: "low",
+    summary: trimMiddle(review, 50_000),
+    changeSummary: `Advisory markdown review from the external \`${engineName}\` engine (offline --local-range).`,
+    evidence: [
+      evidenceEntry({ label: `${engineName} advisory review`, detail: trimMiddle(review, 8000) }),
+    ],
+    likelyOwners: [],
+    risks: [],
+    bestSolution: "See the advisory review in the summary.",
+    maintainerDecision: emptyMaintainerDecision(),
+    triagePriority: "none",
+    impactLabels: [],
+    mergeRiskLabels: [],
+    maturityLabels: [],
+    mergeRiskOptions: [],
+    reviewMetrics: [],
+    labelJustifications: [],
+    itemCategory: "unclear",
+    reproductionStatus: "unclear",
+    reproductionConfidence: "low",
+    requiresNewFeature: false,
+    requiresNewConfigOption: false,
+    requiresProductDecision: false,
+    reproductionAssessment: note,
+    solutionAssessment: note,
+    visionFit: "not_applicable",
+    visionFitReason: note,
+    visionFitEvidence: [],
+    implementationComplexity: "not_applicable",
+    autoImplementationCandidate: "none",
+    rootCauseCluster: defaultRootCauseCluster(),
+    agentsPolicyStatus: {
+      found: false,
+      readFully: false,
+      applied: false,
+      status: "unreadable_or_unclear",
+      summary: note,
+    },
+    reviewFindings: [],
+    securityReview: { status: "not_applicable", summary: note, concerns: [] },
+    realBehaviorProof: {
+      status: "not_applicable",
+      summary: note,
+      evidenceKind: "not_applicable",
+      needsContributorAction: false,
+    },
+    prRating: { proofTier: "NA", patchTier: "NA", overallTier: "NA", summary: note, nextSteps: [] },
+    telegramVisibleProof: { status: "not_needed", summary: note },
+    mantisRecommendation: {
+      status: "not_recommended",
+      scenario: "none",
+      reason: note,
+      maintainerComment: "",
+    },
+    featureShowcase: { status: "none", reason: note },
+    overallCorrectness: "not a patch",
+    overallConfidenceScore: 0,
+    codexTerminalFailure: false,
+    fixedRelease: null,
+    fixedSha: null,
+    fixedAt: null,
+    fixedPullRequest: null,
+    closeComment: "",
+    workCandidate: "none",
+    workConfidence: "low",
+    workPriority: "low",
+    workReason: "External advisory review — no work-lane recommendation extracted.",
+    workPrompt: "",
+    workClusterRefs: [],
+    workValidation: [],
+    workLikelyFiles: [],
+  };
+}
+
+// Markdown-review prompt for the `external` engine. External engines report MARKDOWN, so we
+// ASK for markdown (findings/risks/fixes) with the committed range embedded — NOT the codex
+// mantis-decision prompt, which makes single-shot engines emit JSON and agentic ones emit
+// schema-ignoring prose. Codex keeps its own structured prompt untouched.
+function externalMarkdownReviewPrompt(
+  item: Item,
+  context: ItemContext,
+  additionalPrompt: string,
+): string {
+  const files = Array.isArray(context.pullFiles) ? context.pullFiles : [];
+  let diff = files
+    .map((entry) => {
+      const f = entry as { filename?: string; status?: string; patch?: string };
+      return `### ${f.status ?? "?"} ${f.filename ?? "(unknown file)"}\n\n\`\`\`diff\n${f.patch ?? ""}\n\`\`\``;
+    })
+    .join("\n\n");
+  if (diff.length > EXTERNAL_ARGV_MAX_DIFF_BYTES) {
+    diff = `${diff.slice(0, EXTERNAL_ARGV_MAX_DIFF_BYTES)}\n...(diff truncated at ${EXTERNAL_ARGV_MAX_DIFF_BYTES} bytes)...`;
+  }
+  const title = item.title ? ` ("${item.title}")` : "";
+  return `${additionalPrompt}
+
+You are giving a pre-PR ADVISORY review of a committed local change range in ${item.repo}${title}. Review the change below for correctness bugs, risks, security issues, and concrete things to fix. Be specific and concise; skip praise.
+
+## Changed files (committed range)
+${diff || "(no file changes detected)"}
+
+Return ONLY a human-readable Markdown review — findings, risks, and suggested fixes. Do NOT output JSON, and do NOT wrap the whole report in a code fence.`;
+}
+
+// Offline `external` engine for `review --local-range` (only). Runs the operator-named CLI
+// through the same bounded worker + offline envelope as codex, captures its MARKDOWN review,
+// and deterministically bridges it into a benign advisory Decision — no schema for the engine
+// to satisfy, no second call. Provider-neutral; ships with no engine defaults.
+function runExternalDecision(options: {
+  item: Item;
+  prompt: string;
+  spec: ExternalEngineSpec;
+  workDir: string;
+  cwd: string;
+}): Decision {
+  const { spec, item } = options;
+  // codex creates this dir as a side-effect of its proof-scratch setup; the external path
+  // has none, so ensure it exists before writing logs into it.
+  ensureDir(options.workDir);
+  let promptFilePath = "";
+  if (spec.promptDelivery === "file") {
+    promptFilePath = join(options.workDir, `${item.number}.external.prompt.md`);
+    writeFileSync(promptFilePath, options.prompt, "utf8");
+  }
+  const plan = planExternalRun(spec, options.prompt, { promptFile: promptFilePath });
+  const stdoutPath = join(options.workDir, `${item.number}.external.stdout.log`);
+  const stderrPath = join(options.workDir, `${item.number}.external.stderr.log`);
+  const result = runCodexProcess({
+    command: plan.command,
+    args: plan.args,
+    cwd: options.cwd,
+    env: codexEnv(),
+    input: plan.input,
+    timeoutMs: spec.timeoutMs,
+    stdoutPath,
+    stderrPath,
+  });
+  const stdout = existsSync(stdoutPath) ? readFileSync(stdoutPath, "utf8") : result.stdout;
+  const stderr = existsSync(stderrPath) ? readFileSync(stderrPath, "utf8") : result.stderr;
+  // Failures THROW CodexReviewError (exactly like the codex path) so the review command's
+  // failure counter (`codexFailures`) and nonzero exit propagate — a *returned* failure
+  // Decision would produce failed-review content but silently pass the command's accounting.
+  if (result.error || result.status !== 0) {
+    const detail =
+      result.error instanceof Error
+        ? `${spec.command} review failed: ${result.error.message}`
+        : `${spec.command} review exited ${result.status ?? "unknown"}`;
+    throw new CodexReviewError({
+      message: detail,
+      status: result.status ?? null,
+      stdout,
+      stderr,
+      errorCode: codexProcessErrorCode(result.error),
+      signal: result.signal,
+      retryable: false,
+    });
+  }
+  // An engine that exits 0 but produces NO review output did not actually review — also a
+  // FAILED review (thrown, so it trips the same accounting), not a benign advisory.
+  if (!stdout.trim()) {
+    throw new CodexReviewError({
+      message: `${spec.command} exited 0 but produced no review output`,
+      status: result.status ?? null,
+      stdout,
+      stderr,
+      retryable: false,
+    });
+  }
+  // Deterministic bridge: the engine's markdown review => a benign advisory Decision.
+  return externalAdvisoryDecision(stdout, spec.command);
 }
 
 export function runCodexForTest(options: Parameters<typeof runCodex>[0]): Decision {
@@ -17479,6 +17675,37 @@ function reviewCommand(args: Args): void {
   const sandboxMode = stringArg(args.codex_sandbox, "read-only");
   const serviceTier = stringArg(args.codex_service_tier, localOnly ? "fast" : DEFAULT_SERVICE_TIER);
   const timeoutMs = numberArg(args.codex_timeout_ms, DEFAULT_REVIEW_CODEX_TIMEOUT_MS);
+
+  // Engine selection: codex (default, unchanged) or the provider-neutral `external` CLI
+  // engine. `external` is restricted to --local-range (offline, operator-local pre-PR
+  // review) — it never runs in the live-PR / automation path.
+  const engine = stringArg(args.engine, "codex");
+  if (engine !== "codex" && engine !== EXTERNAL_ENGINE_ID) {
+    console.error(`[review] --engine must be "codex" or "${EXTERNAL_ENGINE_ID}", got "${engine}"`);
+    process.exit(1);
+  }
+  if (engine === EXTERNAL_ENGINE_ID && !localRange) {
+    console.error(
+      `[review] --engine ${EXTERNAL_ENGINE_ID} is only supported with --local-range (offline pre-PR review).`,
+    );
+    process.exit(1);
+  }
+  let externalSpec: ExternalEngineSpec | null = null;
+  if (engine === EXTERNAL_ENGINE_ID) {
+    try {
+      externalSpec = externalEngineSpecFromFlags({
+        command: stringArg(args.external_cmd, ""),
+        argsJson: stringArg(args.external_args, ""),
+        promptDelivery: stringArg(args.external_prompt, "stdin"),
+        model: stringArg(args.external_model, ""),
+        timeoutMs: numberArg(args.external_timeout_ms, 1_800_000),
+      });
+    } catch (error) {
+      console.error(`[review] ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  }
+
   let additionalPrompt = stringArg(
     args.additional_prompt,
     process.env.CLAWSWEEPER_ADDITIONAL_PROMPT ?? "",
@@ -17692,26 +17919,35 @@ function reviewCommand(args: Args): void {
             `  stderr: ${displayPath(join(codexWorkDir, `${item.number}.1.codex.stderr.log`))}`,
           );
         }
-        decision = runCodex({
-          item,
-          context,
-          git,
-          model,
-          openclawDir,
-          reasoningEffort,
-          sandboxMode,
-          serviceTier,
-          forcedLoginMethod,
-          preserveCodexAuth: localOnly,
-          preferWindowsAppBinary: localOnly,
-          timeoutMs,
-          workDir: codexWorkDir,
-          additionalPrompt,
-          proofScratchDir,
-          prompt: prompt.text,
-          quietLogs: humanLocalReview,
-          ...(localRange ? { extraCodexConfig: [LOCAL_REVIEW_WEB_SEARCH_CONFIG] } : {}),
-        });
+        decision =
+          engine === EXTERNAL_ENGINE_ID
+            ? runExternalDecision({
+                item,
+                prompt: externalMarkdownReviewPrompt(item, context, additionalPrompt),
+                spec: externalSpec as ExternalEngineSpec,
+                workDir: codexWorkDir,
+                cwd: openclawDir,
+              })
+            : runCodex({
+                item,
+                context,
+                git,
+                model,
+                openclawDir,
+                reasoningEffort,
+                sandboxMode,
+                serviceTier,
+                forcedLoginMethod,
+                preserveCodexAuth: localOnly,
+                preferWindowsAppBinary: localOnly,
+                timeoutMs,
+                workDir: codexWorkDir,
+                additionalPrompt,
+                proofScratchDir,
+                prompt: prompt.text,
+                quietLogs: humanLocalReview,
+                ...(localRange ? { extraCodexConfig: [LOCAL_REVIEW_WEB_SEARCH_CONFIG] } : {}),
+              });
       } catch (error) {
         codexFailures += 1;
         codexFailed = true;

--- a/src/codex-process.ts
+++ b/src/codex-process.ts
@@ -74,6 +74,11 @@ export function runCodexProcess(options: {
   env: NodeJS.ProcessEnv;
   input: string;
   timeoutMs: number;
+  // Optional binary override; defaults to the resolved codex command. The offline
+  // `external` review engine sets this to an operator-named read-only CLI so it runs
+  // through the SAME bounded worker (timeout, output capture, scrubbed env). The worker
+  // applies cross-platform resolution via spawnCodex (CODEX_BIN), so any binary works.
+  command?: string;
   tailBytes?: number;
   outputFileBytes?: number;
   stdoutPath?: string;
@@ -90,7 +95,7 @@ export function runCodexProcess(options: {
       optionsPath,
       JSON.stringify({
         args: [...options.args],
-        command: codexProcessCommand(options.env),
+        command: options.command ?? codexProcessCommand(options.env),
         timeoutMs: options.timeoutMs,
         resultPath,
         stdoutPath,

--- a/src/commit-sweeper.ts
+++ b/src/commit-sweeper.ts
@@ -21,6 +21,13 @@ import { argBool, argNumber, argString, parseArgs, type Args } from "./clawsweep
 import { safeOutputTail } from "./clawsweeper-text.js";
 import { codexEnv, codexLoginConfig, codexModelArgs, PUBLIC_CODEX_MODEL } from "./codex-env.js";
 import { codexProcessErrorCode, runCodexProcess } from "./codex-process.js";
+import {
+  EXTERNAL_ENGINE_ID,
+  externalDiffCap,
+  externalEngineSpecFromFlags,
+  planExternalRun,
+  type ExternalEngineSpec,
+} from "./external-engine.js";
 import { runText } from "./command.js";
 import { ghRetryKind, ghRetryWaitMs } from "./github-retry.js";
 import {
@@ -453,6 +460,125 @@ export function localReviewAdditionalPrompt(
   return `This is a LOCAL pre-PR review of the COMMITTED range ${baseSha.slice(0, 8)}..${headSha.slice(0, 8)} (your branch vs ${baseBranch}) on a clean checkout — no staged or untracked changes. Review code correctness, bugs, and security; ignore PR metadata. This review is offline: do not run gh, use web search, access URLs, or make any network request. Use only the local checkout and git history.`;
 }
 
+// Build the read-only range-review prompt for the `external` engine: the base commit
+// prompt plus the embedded committed-range diff (capped), since a read-only CLI can't
+// shell out to inspect the range itself. Provider-neutral — no engine specifics here.
+function promptForReadOnlyRangeReview(options: {
+  targetDir: string;
+  targetRepo: string;
+  sha: string;
+  baseSha: string;
+  metadata: CommitMetadata;
+  additionalPrompt: string;
+  maxDiffBytes: number;
+}): { prompt: string } | { detail: string } {
+  let rawDiff: string;
+  try {
+    rawDiff = run("git", ["diff", `${options.baseSha}..${options.sha}`], {
+      cwd: options.targetDir,
+    });
+  } catch (error) {
+    return {
+      detail: `failed to read range diff: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+  const diff =
+    rawDiff.length > options.maxDiffBytes
+      ? `${rawDiff.slice(0, options.maxDiffBytes)}\n...(diff truncated at ${options.maxDiffBytes} bytes)...`
+      : rawDiff;
+  return {
+    prompt: `${promptForCommit({
+      targetDir: options.targetDir,
+      targetRepo: options.targetRepo,
+      sha: options.sha,
+      baseSha: options.baseSha,
+      metadata: options.metadata,
+      additionalPrompt: options.additionalPrompt,
+    })}
+
+## Full Range Diff (\`${options.baseSha}..${options.sha}\`)
+
+\`\`\`diff
+${diff || "(empty diff)"}
+\`\`\`
+
+Return only the Markdown report. Start the response with \`---\`; do not add a preamble or wrap the report in a code fence.
+`,
+  };
+}
+
+// Local-review `external` engine: drive the operator-named read-only CLI through the
+// SAME bounded runner and offline envelope as codex (credentials scrubbed via codexEnv,
+// empty GH_CONFIG_DIR, clean committed range). Opt-in only, ships with no provider
+// defaults. The prompt is delivered by stdin / argv / temp file per the spec; the
+// engine's markdown report is returned (or a failure report on error / timeout / empty).
+function runExternalEngineReview(options: {
+  spec: ExternalEngineSpec;
+  targetDir: string;
+  targetRepo: string;
+  sha: string;
+  baseSha: string;
+  metadata: CommitMetadata;
+  workDir: string;
+  additionalPrompt: string;
+}): string {
+  const { spec } = options;
+  const fail = (detail: string, timeout: boolean): string =>
+    failureReport({
+      targetRepo: options.targetRepo,
+      sha: options.sha,
+      baseSha: options.baseSha,
+      metadata: options.metadata,
+      detail,
+      timeout,
+    });
+
+  const prompt = promptForReadOnlyRangeReview({
+    targetDir: options.targetDir,
+    targetRepo: options.targetRepo,
+    sha: options.sha,
+    baseSha: options.baseSha,
+    metadata: options.metadata,
+    additionalPrompt: options.additionalPrompt,
+    maxDiffBytes: externalDiffCap(spec.promptDelivery),
+  });
+  if ("detail" in prompt) return fail(prompt.detail, false);
+
+  let promptFilePath = "";
+  if (spec.promptDelivery === "file") {
+    promptFilePath = join(options.workDir, "external-prompt.txt");
+    writeFileSync(promptFilePath, prompt.prompt, "utf8");
+  }
+  const plan = planExternalRun(spec, prompt.prompt, { promptFile: promptFilePath });
+
+  // Capture the FULL stdout (not the runner's truncated tail) so a large report's
+  // leading YAML front matter is never cut off.
+  const stdoutPath = join(options.workDir, "external-stdout.log");
+  const result = runCodexProcess({
+    command: plan.command,
+    args: plan.args,
+    cwd: options.targetDir,
+    env: codexEnv(),
+    input: plan.input,
+    timeoutMs: spec.timeoutMs,
+    stdoutPath,
+  });
+  const stdout = existsSync(stdoutPath) ? readFileSync(stdoutPath, "utf8") : result.stdout;
+  if (result.error || result.status !== 0) {
+    const timeout = codexProcessErrorCode(result.error) === "ETIMEDOUT";
+    const detail =
+      result.error instanceof Error
+        ? `${result.error.message}\n${safeOutputTail(result.stderr) || safeOutputTail(stdout)}`
+        : `exit ${result.status ?? "unknown"}\n${
+            safeOutputTail(result.stderr) || safeOutputTail(stdout) || "No output."
+          }`;
+    return fail(detail.trim(), timeout);
+  }
+  const markdown = stripMarkdownFence(stdout);
+  if (!markdown.trim()) return fail(`${spec.command} produced no output`, false);
+  return markdown;
+}
+
 // Local, offline pre-PR review of a whole branch: reviews the committed range
 // merge-base(base, HEAD)..HEAD as a single unit, reusing the Commit Sweeper engine.
 // Conforms to the #253 replacement spec: clean checkout, unique run dir, no GitHub
@@ -460,6 +586,33 @@ export function localReviewAdditionalPrompt(
 function localReviewCommand(args: Args): void {
   const targetDir = resolve(argString(args, "target_dir", "."));
   const baseBranch = argString(args, "base", "main");
+
+  // Engine selection: `codex` (default, unchanged) or the provider-neutral `external`
+  // CLI engine. Validated up front — before any run state or git work — so a usage
+  // error fails fast and cleanly.
+  const engine = argString(args, "engine", "codex");
+  if (engine !== "codex" && engine !== EXTERNAL_ENGINE_ID) {
+    console.error(
+      `[local-review] --engine must be "codex" or "${EXTERNAL_ENGINE_ID}", got "${engine}"`,
+    );
+    process.exit(1);
+  }
+  let externalSpec: ExternalEngineSpec | null = null;
+  if (engine === EXTERNAL_ENGINE_ID) {
+    try {
+      externalSpec = externalEngineSpecFromFlags({
+        command: argString(args, "external_cmd", ""),
+        argsJson: argString(args, "external_args", ""),
+        promptDelivery: argString(args, "external_prompt", "stdin"),
+        model: argString(args, "external_model", ""),
+        timeoutMs: argNumber(args, "external_timeout_ms", 1_800_000),
+      });
+    } catch (error) {
+      console.error(`[local-review] ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  }
+
   const reportDir = resolve(
     argString(args, "report_dir", join(homedir(), ".clawsweeper-local-reviews")),
   );
@@ -517,24 +670,36 @@ function localReviewCommand(args: Args): void {
     `[local-review] repo=${targetRepo} profile=${profileSlug} base=${baseBranch} range=${baseSha.slice(0, 8)}..${headSha.slice(0, 8)}`,
   );
 
-  const markdown = ensureCommitReportTimestamps(
-    runCodex({
-      targetDir,
-      targetRepo,
-      sha: headSha,
-      baseSha,
-      metadata,
-      model: argString(args, "codex_model", DEFAULT_CODEX_MODEL),
-      reasoningEffort: argString(args, "codex_reasoning_effort", DEFAULT_REASONING_EFFORT),
-      sandboxMode: argString(args, "codex_sandbox", "read-only"),
-      serviceTier: argString(args, "codex_service_tier", DEFAULT_SERVICE_TIER),
-      timeoutMs: argNumber(args, "codex_timeout_ms", 1_800_000),
-      workDir: runDir,
-      additionalPrompt,
-      extraCodexConfig: [LOCAL_REVIEW_WEB_SEARCH_CONFIG],
-    }),
-    metadata,
-  );
+  const markdown =
+    engine === EXTERNAL_ENGINE_ID
+      ? runExternalEngineReview({
+          spec: externalSpec as ExternalEngineSpec,
+          targetDir,
+          targetRepo,
+          sha: headSha,
+          baseSha,
+          metadata,
+          workDir: runDir,
+          additionalPrompt,
+        })
+      : ensureCommitReportTimestamps(
+          runCodex({
+            targetDir,
+            targetRepo,
+            sha: headSha,
+            baseSha,
+            metadata,
+            model: argString(args, "codex_model", DEFAULT_CODEX_MODEL),
+            reasoningEffort: argString(args, "codex_reasoning_effort", DEFAULT_REASONING_EFFORT),
+            sandboxMode: argString(args, "codex_sandbox", "read-only"),
+            serviceTier: argString(args, "codex_service_tier", DEFAULT_SERVICE_TIER),
+            timeoutMs: argNumber(args, "codex_timeout_ms", 1_800_000),
+            workDir: runDir,
+            additionalPrompt,
+            extraCodexConfig: [LOCAL_REVIEW_WEB_SEARCH_CONFIG],
+          }),
+          metadata,
+        );
 
   const outputPath = join(runDir, "local-review.md");
   writeFileSync(outputPath, markdown.endsWith("\n") ? markdown : `${markdown}\n`, "utf8");

--- a/src/external-engine.ts
+++ b/src/external-engine.ts
@@ -1,0 +1,195 @@
+// Provider-neutral "bring-your-own-CLI" review engine for the offline local review
+// paths (`commit-sweeper local-review` and `clawsweeper review --local-range`).
+//
+// This ships with ZERO providers: the operator points `--engine external` at any
+// read-only CLI via inline flags. Concrete engines (claude / agy / opencode / …)
+// are intended as small follow-up PRs, not baked in here — so this file has no
+// provider names, models, or quotas, and no network/quota policy.
+//
+// Every external engine reports a MARKDOWN review. The markdown local-review command
+// writes it as the report; `review --local-range` deterministically bridges it into a
+// benign advisory Decision (no schema for the engine to satisfy). This module is
+// deliberately pure: no fs, git, env, or process spawning. It only (1) parses the inline
+// flags into a spec and (2) plans an invocation (command, argv, optional stdin) from a
+// prompt. The calling command owns the offline envelope (scrubbed GitHub creds, empty
+// GH_CONFIG_DIR, clean committed range), the `git diff`, the temp-file write for `file`
+// delivery, and the bounded run — so `external` inherits the same guarantees as codex.
+
+export const EXTERNAL_ENGINE_ID = "external";
+
+// Where the review prompt reaches the CLI:
+//   stdin — piped to the process (no OS arg-length limit; default)
+//   argv  — substituted at `{prompt}`, or appended as the trailing arg if absent
+//   file  — written to a temp file; its path substituted at `{promptFile}`
+export type PromptDelivery = "stdin" | "argv" | "file";
+export const PROMPT_DELIVERIES: readonly PromptDelivery[] = ["stdin", "argv", "file"];
+
+export interface ExternalEngineSpec {
+  command: string; // binary to spawn (e.g. "claude", "opencode", "agy")
+  args: string[]; // arg template; {prompt}/{promptFile}/{model} tokens substituted
+  promptDelivery: PromptDelivery;
+  model: string; // substituted into {model}; "" => the {model} token/arg is dropped
+  timeoutMs: number;
+}
+
+// An argv-delivered prompt is bounded by the OS command-line limit, so the embedded
+// diff is capped tighter than for stdin/file (which are bounded only by prompt size).
+// Mirrors the caps the built-in read-only engines already use.
+export const EXTERNAL_ARGV_MAX_DIFF_BYTES = process.platform === "win32" ? 24 * 1024 : 96 * 1024;
+export const EXTERNAL_STREAM_MAX_DIFF_BYTES = 256 * 1024;
+
+export function externalDiffCap(delivery: PromptDelivery): number {
+  return delivery === "argv" ? EXTERNAL_ARGV_MAX_DIFF_BYTES : EXTERNAL_STREAM_MAX_DIFF_BYTES;
+}
+
+const DEFAULT_EXTERNAL_TIMEOUT_MS = 1_800_000; // 30 min, matching the codex/local-review default
+
+export const PROMPT_TOKEN = "{prompt}";
+export const PROMPT_FILE_TOKEN = "{promptFile}";
+export const MODEL_TOKEN = "{model}";
+
+function isPromptDelivery(value: string): value is PromptDelivery {
+  return (PROMPT_DELIVERIES as readonly string[]).includes(value);
+}
+
+function someArgIncludes(args: readonly string[], token: string): boolean {
+  return args.some((arg) => arg.includes(token));
+}
+
+// Parse the inline `--external-*` flags into a validated spec. Kept free of the
+// harness Args type: the caller extracts the raw flag strings and hands them in,
+// so this stays unit-testable in isolation. Throws on any malformed input with a
+// message aimed at the operator wiring up a new CLI slot.
+export function externalEngineSpecFromFlags(raw: {
+  command: string;
+  argsJson: string; // JSON array of strings, e.g. '["-p","--output-format","text"]'
+  promptDelivery: string;
+  model: string;
+  timeoutMs: number;
+}): ExternalEngineSpec {
+  const command = raw.command.trim();
+  if (!command) {
+    throw new Error(
+      "--engine external requires --external-cmd <binary> (the read-only review CLI to run).",
+    );
+  }
+
+  let args: string[];
+  const argsText = raw.argsJson.trim() || "[]";
+  try {
+    const parsed = JSON.parse(argsText) as unknown;
+    if (!Array.isArray(parsed) || !parsed.every((a) => typeof a === "string")) {
+      throw new Error("not a JSON array of strings");
+    }
+    args = parsed;
+  } catch (error) {
+    throw new Error(
+      `--external-args must be a JSON array of strings (e.g. '["-p","--output-format","text"]'), got ${JSON.stringify(
+        argsText,
+      )}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  const promptDelivery = (raw.promptDelivery.trim() || "stdin").toLowerCase();
+  if (!isPromptDelivery(promptDelivery)) {
+    throw new Error(
+      `--external-prompt must be one of ${PROMPT_DELIVERIES.join(", ")}, got "${raw.promptDelivery}".`,
+    );
+  }
+
+  // Fail loud on tokens that can't be honored for the chosen delivery, rather than
+  // silently shipping the literal "{prompt}" string to the CLI.
+  if (promptDelivery !== "argv" && someArgIncludes(args, PROMPT_TOKEN)) {
+    throw new Error(
+      `${PROMPT_TOKEN} in --external-args is only meaningful with --external-prompt argv (got ${promptDelivery}).`,
+    );
+  }
+  if (promptDelivery !== "file" && someArgIncludes(args, PROMPT_FILE_TOKEN)) {
+    throw new Error(
+      `${PROMPT_FILE_TOKEN} in --external-args is only meaningful with --external-prompt file (got ${promptDelivery}).`,
+    );
+  }
+  if (promptDelivery === "file" && !someArgIncludes(args, PROMPT_FILE_TOKEN)) {
+    throw new Error(
+      `--external-prompt file requires ${PROMPT_FILE_TOKEN} somewhere in --external-args so the CLI receives the prompt path.`,
+    );
+  }
+
+  const model = raw.model.trim();
+  if (!model && someArgIncludes(args, MODEL_TOKEN)) {
+    throw new Error(
+      `--external-args uses ${MODEL_TOKEN} but no --external-model was given. Pass --external-model, or drop ${MODEL_TOKEN}.`,
+    );
+  }
+
+  const timeoutMs =
+    Number.isFinite(raw.timeoutMs) && raw.timeoutMs > 0
+      ? raw.timeoutMs
+      : DEFAULT_EXTERNAL_TIMEOUT_MS;
+
+  return { command, args, promptDelivery, model, timeoutMs };
+}
+
+// A planned invocation for the bounded runner. `input` is the stdin payload: the
+// prompt for stdin delivery, and an empty string (harmless empty stdin) for argv/file
+// delivery. `args` is the fully-substituted argv.
+export interface ExternalRunPlan {
+  command: string;
+  args: string[];
+  input: string;
+}
+
+interface SubstitutionValues {
+  prompt: string;
+  promptFile: string;
+  model: string;
+}
+
+// Substitute the templated tokens in one arg. A standalone bare {model} whose value is
+// empty drops that arg (defensive — externalEngineSpecFromFlags already rejects {model}
+// without --external-model). Author templates with the token as its own arg (`--model {model}`).
+function substituteArg(arg: string, values: SubstitutionValues): string | null {
+  if (arg === MODEL_TOKEN && !values.model) return null;
+  return arg
+    .split(PROMPT_TOKEN)
+    .join(values.prompt)
+    .split(PROMPT_FILE_TOKEN)
+    .join(values.promptFile)
+    .split(MODEL_TOKEN)
+    .join(values.model);
+}
+
+// Values substituted into the arg template at run time. Optional: the stdin/argv paths
+// pass nothing; `file` delivery passes the promptFile the caller has already written.
+export interface ExternalRunSubstitutions {
+  promptFile?: string;
+}
+
+// Plan the invocation from the spec + the built review prompt. Pure: for `file` delivery
+// the caller must have already written subs.promptFile and pass it here.
+export function planExternalRun(
+  spec: ExternalEngineSpec,
+  prompt: string,
+  subs: ExternalRunSubstitutions = {},
+): ExternalRunPlan {
+  const values: SubstitutionValues = {
+    prompt: spec.promptDelivery === "argv" ? prompt : "",
+    promptFile: subs.promptFile ?? "",
+    model: spec.model,
+  };
+  const substituted = spec.args
+    .map((arg) => substituteArg(arg, values))
+    .filter((arg): arg is string => arg !== null);
+
+  // argv delivery with no explicit {prompt} token => append the prompt as the
+  // trailing arg (matches the common `<cli> run "<prompt>"` shape).
+  if (spec.promptDelivery === "argv" && !someArgIncludes(spec.args, PROMPT_TOKEN)) {
+    substituted.push(prompt);
+  }
+
+  return {
+    command: spec.command,
+    args: substituted,
+    input: spec.promptDelivery === "stdin" ? prompt : "",
+  };
+}

--- a/test/external-engine-review.test.ts
+++ b/test/external-engine-review.test.ts
@@ -1,0 +1,275 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { execFileSync, spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const COMMIT_SWEEPER = fileURLToPath(new URL("../dist/commit-sweeper.js", import.meta.url));
+const CLAWSWEEPER = fileURLToPath(new URL("../dist/clawsweeper.js", import.meta.url));
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+// A temp repo with a base-ref branch one commit behind HEAD, so the committed range
+// merge-base(base-ref, HEAD)..HEAD is non-empty (something to review). Stub scripts and
+// markers live in a SEPARATE tool dir — the review requires a clean working tree.
+function initRepoWithRange(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  git(dir, "init", "-q");
+  git(dir, "config", "user.email", "test@example.com");
+  git(dir, "config", "user.name", "External Tester");
+  git(dir, "config", "commit.gpgsign", "false");
+  writeFileSync(join(dir, "a.txt"), "base\n");
+  git(dir, "add", "a.txt");
+  git(dir, "commit", "-q", "-m", "init");
+  git(dir, "branch", "base-ref");
+  writeFileSync(join(dir, "a.txt"), "base\nfeature\n");
+  git(dir, "add", "a.txt");
+  git(dir, "commit", "-q", "-m", "feat: add a feature");
+  return dir;
+}
+
+function writeStub(toolDir: string, name: string, body: string): string {
+  const stub = join(toolDir, name);
+  writeFileSync(stub, body);
+  chmodSync(stub, 0o755);
+  return stub;
+}
+
+// --- Surface A: markdown commit-sweeper local-review ------------------------------
+
+test("local-review --engine external runs the named CLI and returns its markdown report", () => {
+  const dir = initRepoWithRange("ext-a-");
+  const toolDir = mkdtempSync(join(tmpdir(), "ext-a-tool-"));
+  try {
+    // stub read-only CLI: consume stdin, print a fixed markdown report (no real provider)
+    const stub = writeStub(
+      toolDir,
+      "stub-markdown.sh",
+      "#!/bin/sh\ncat >/dev/null\nprintf '%s\\n' '---' 'engine: external-stub' '---' '# External stub review' 'looks fine'\n",
+    );
+    const result = spawnSync(
+      process.execPath,
+      [
+        COMMIT_SWEEPER,
+        "local-review",
+        "--target-dir",
+        dir,
+        "--target-repo",
+        "openclaw/clawsweeper",
+        "--base",
+        "base-ref",
+        "--engine",
+        "external",
+        "--external-cmd",
+        stub,
+        "--external-args",
+        "[]",
+        "--external-prompt",
+        "stdin",
+      ],
+      { cwd: dir, encoding: "utf8", env: { ...process.env }, timeout: 60000 },
+    );
+    assert.equal(result.status, 0, `expected success, got:\n${result.stderr}\n${result.stdout}`);
+    // localReviewCommand prints the report path on stdout; the report holds the stub output.
+    const reportPath = (result.stdout ?? "").trim().split("\n").pop() ?? "";
+    assert.match(readFileSync(reportPath, "utf8"), /External stub review/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(toolDir, { recursive: true, force: true });
+  }
+});
+
+test("local-review --engine external rejects a missing --external-cmd", () => {
+  const dir = initRepoWithRange("ext-a-nocmd-");
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        COMMIT_SWEEPER,
+        "local-review",
+        "--target-dir",
+        dir,
+        "--target-repo",
+        "openclaw/clawsweeper",
+        "--base",
+        "base-ref",
+        "--engine",
+        "external",
+      ],
+      { cwd: dir, encoding: "utf8", env: { ...process.env }, timeout: 60000 },
+    );
+    assert.equal(result.status, 1);
+    assert.match(`${result.stderr}${result.stdout}`, /requires --external-cmd/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// --- Surface B: structured review --local-range ----------------------------------
+
+test("review --engine external is refused without --local-range (offline-only boundary)", () => {
+  const dir = mkdtempSync(join(tmpdir(), "ext-b-gate-"));
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        CLAWSWEEPER,
+        "review",
+        "--local-only",
+        "--target-repo",
+        "openclaw/clawsweeper",
+        "--target-dir",
+        dir,
+        "--engine",
+        "external",
+        "--external-cmd",
+        "true",
+      ],
+      { encoding: "utf8", env: { ...process.env }, timeout: 60000 },
+    );
+    assert.notEqual(result.status, 0);
+    assert.match(`${result.stderr}${result.stdout}`, /only supported with --local-range/i);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("review --local-range --engine external runs the CLI inside the offline envelope", () => {
+  const dir = initRepoWithRange("ext-b-env-");
+  const toolDir = mkdtempSync(join(tmpdir(), "ext-b-tool-"));
+  const marker = join(toolDir, "stub-ran.txt");
+  // Record CWD + the isolated gh config dir the external engine is handed — assert it ran
+  // through the SAME offline envelope (checkout cwd + empty GH_CONFIG_DIR) as codex.
+  const stub = writeStub(
+    toolDir,
+    "stub-env.sh",
+    `#!/bin/sh\ncat >/dev/null\nprintf '%s\\n%s\\n' "$PWD" "$GH_CONFIG_DIR" > "${marker}"\nprintf '# review\\nlgtm\\n'\n`,
+  );
+  try {
+    spawnSync(
+      process.execPath,
+      [
+        CLAWSWEEPER,
+        "review",
+        "--local-range",
+        "--base",
+        "base-ref",
+        "--target-repo",
+        "openclaw/clawsweeper",
+        "--engine",
+        "external",
+        "--external-cmd",
+        stub,
+        "--external-args",
+        "[]",
+        "--external-prompt",
+        "stdin",
+      ],
+      { cwd: dir, encoding: "utf8", env: { ...process.env }, timeout: 60000 },
+    );
+    const [cwd, ghConfigDir] = readFileSync(marker, "utf8").trim().split("\n");
+    assert.equal(realpathSync(cwd ?? ""), realpathSync(dir), "engine runs in the checkout");
+    assert.equal(basename(ghConfigDir ?? ""), ".gh-empty", "engine gets the isolated gh config");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(toolDir, { recursive: true, force: true });
+  }
+});
+
+test("review --local-range --engine external bridges the engine's markdown into an advisory Decision", () => {
+  const dir = initRepoWithRange("ext-b-adv-");
+  const toolDir = mkdtempSync(join(tmpdir(), "ext-b-adv-tool-"));
+  const artifactDir = mkdtempSync(join(tmpdir(), "ext-b-adv-art-"));
+  const stub = writeStub(
+    toolDir,
+    "stub-md.sh",
+    "#!/bin/sh\ncat >/dev/null\nprintf '%s\\n' '# External advisory' 'MARKER-ADVISORY-OK'\n",
+  );
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        CLAWSWEEPER,
+        "review",
+        "--local-range",
+        "--base",
+        "base-ref",
+        "--target-repo",
+        "openclaw/clawsweeper",
+        "--artifact-dir",
+        artifactDir,
+        "--engine",
+        "external",
+        "--external-cmd",
+        stub,
+        "--external-args",
+        "[]",
+        "--external-prompt",
+        "stdin",
+      ],
+      { cwd: dir, encoding: "utf8", env: { ...process.env }, timeout: 60000 },
+    );
+    // advisory keep_open, and the engine's markdown surfaces in the rendered report
+    assert.match(`${result.stderr}${result.stdout}`, /decision=keep_open/);
+    const found = spawnSync("grep", ["-rl", "MARKER-ADVISORY-OK", artifactDir], {
+      encoding: "utf8",
+    });
+    assert.equal(found.status, 0, "engine markdown should appear in the rendered report");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(toolDir, { recursive: true, force: true });
+    rmSync(artifactDir, { recursive: true, force: true });
+  }
+});
+
+test("review --local-range --engine external treats empty engine output as a FAILED review, not an advisory", () => {
+  const dir = initRepoWithRange("ext-b-empty-");
+  const toolDir = mkdtempSync(join(tmpdir(), "ext-b-empty-tool-"));
+  const artifactDir = mkdtempSync(join(tmpdir(), "ext-b-empty-art-"));
+  // stub exits 0 but prints NOTHING — a ran-but-said-nothing engine must not read as a pass.
+  const stub = writeStub(toolDir, "stub-empty.sh", "#!/bin/sh\ncat >/dev/null\nexit 0\n");
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        CLAWSWEEPER,
+        "review",
+        "--local-range",
+        "--base",
+        "base-ref",
+        "--target-repo",
+        "openclaw/clawsweeper",
+        "--artifact-dir",
+        artifactDir,
+        "--engine",
+        "external",
+        "--external-cmd",
+        stub,
+        "--external-args",
+        "[]",
+        "--external-prompt",
+        "stdin",
+      ],
+      { cwd: dir, encoding: "utf8", env: { ...process.env }, timeout: 60000 },
+    );
+    // The failure must PROPAGATE like a codex failure: the review command exits nonzero
+    // (via the codexFailures counter), not just write failed-review content.
+    assert.notEqual(
+      result.status,
+      0,
+      "empty engine output must fail the review command (nonzero exit)",
+    );
+    const found = spawnSync("grep", ["-rl", "produced no review output", artifactDir], {
+      encoding: "utf8",
+    });
+    assert.equal(found.status, 0, "empty engine output must produce a visible failed review");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(toolDir, { recursive: true, force: true });
+    rmSync(artifactDir, { recursive: true, force: true });
+  }
+});

--- a/test/external-engine.test.ts
+++ b/test/external-engine.test.ts
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  EXTERNAL_ENGINE_ID,
+  externalDiffCap,
+  externalEngineSpecFromFlags,
+  planExternalRun,
+  type ExternalEngineSpec,
+} from "../src/external-engine.ts";
+
+const baseFlags = {
+  command: "mycli",
+  argsJson: "[]",
+  promptDelivery: "stdin",
+  model: "",
+  timeoutMs: 1_800_000,
+};
+
+function specOf(overrides: Partial<ExternalEngineSpec> = {}): ExternalEngineSpec {
+  return {
+    command: "c",
+    args: [],
+    promptDelivery: "stdin",
+    model: "",
+    timeoutMs: 1000,
+    ...overrides,
+  };
+}
+
+// --- externalEngineSpecFromFlags -------------------------------------------------
+
+test("externalEngineSpecFromFlags parses a valid stdin spec", () => {
+  const spec = externalEngineSpecFromFlags({ ...baseFlags, argsJson: '["-p"]' });
+  assert.equal(spec.command, "mycli");
+  assert.deepEqual(spec.args, ["-p"]);
+  assert.equal(spec.promptDelivery, "stdin");
+  assert.equal(spec.model, "");
+});
+
+test("externalEngineSpecFromFlags accepts argv delivery", () => {
+  const spec = externalEngineSpecFromFlags({ ...baseFlags, promptDelivery: "argv" });
+  assert.equal(spec.promptDelivery, "argv");
+});
+
+test("externalEngineSpecFromFlags throws on an empty command", () => {
+  assert.throws(() => externalEngineSpecFromFlags({ ...baseFlags, command: "   " }));
+});
+
+test("externalEngineSpecFromFlags throws when args is not a JSON string array", () => {
+  assert.throws(() => externalEngineSpecFromFlags({ ...baseFlags, argsJson: "{}" }));
+  assert.throws(() => externalEngineSpecFromFlags({ ...baseFlags, argsJson: '["a",1]' }));
+});
+
+test("externalEngineSpecFromFlags defaults empty argsJson to []", () => {
+  const spec = externalEngineSpecFromFlags({ ...baseFlags, argsJson: "" });
+  assert.deepEqual(spec.args, []);
+});
+
+test("externalEngineSpecFromFlags throws on an unknown prompt delivery", () => {
+  assert.throws(() => externalEngineSpecFromFlags({ ...baseFlags, promptDelivery: "pipe" }));
+});
+
+test("externalEngineSpecFromFlags rejects {prompt} unless delivery is argv", () => {
+  assert.throws(() =>
+    externalEngineSpecFromFlags({
+      ...baseFlags,
+      promptDelivery: "stdin",
+      argsJson: '["{prompt}"]',
+    }),
+  );
+});
+
+test("externalEngineSpecFromFlags rejects {promptFile} unless delivery is file", () => {
+  assert.throws(() =>
+    externalEngineSpecFromFlags({
+      ...baseFlags,
+      promptDelivery: "argv",
+      argsJson: '["{promptFile}"]',
+    }),
+  );
+});
+
+test("externalEngineSpecFromFlags requires {promptFile} for file delivery", () => {
+  assert.throws(() =>
+    externalEngineSpecFromFlags({ ...baseFlags, promptDelivery: "file", argsJson: '["-p"]' }),
+  );
+  const spec = externalEngineSpecFromFlags({
+    ...baseFlags,
+    promptDelivery: "file",
+    argsJson: '["--in","{promptFile}"]',
+  });
+  assert.equal(spec.promptDelivery, "file");
+});
+
+test("externalEngineSpecFromFlags rejects {model} without a model", () => {
+  assert.throws(() =>
+    externalEngineSpecFromFlags({ ...baseFlags, argsJson: '["--model","{model}"]', model: "" }),
+  );
+  const spec = externalEngineSpecFromFlags({
+    ...baseFlags,
+    argsJson: '["--model","{model}"]',
+    model: "gpt",
+  });
+  assert.equal(spec.model, "gpt");
+});
+
+test("externalEngineSpecFromFlags falls back to a positive default timeout", () => {
+  assert.ok(externalEngineSpecFromFlags({ ...baseFlags, timeoutMs: 0 }).timeoutMs > 0);
+  assert.ok(externalEngineSpecFromFlags({ ...baseFlags, timeoutMs: Number.NaN }).timeoutMs > 0);
+});
+
+// --- planExternalRun -------------------------------------------------------------
+
+test("planExternalRun (stdin) sends the prompt on stdin, not argv", () => {
+  const plan = planExternalRun(specOf({ args: ["-p"] }), "REVIEW");
+  assert.equal(plan.input, "REVIEW");
+  assert.deepEqual(plan.args, ["-p"]);
+});
+
+test("planExternalRun (argv) substitutes an explicit {prompt} token", () => {
+  const plan = planExternalRun(
+    specOf({ promptDelivery: "argv", args: ["run", "{prompt}"] }),
+    "REVIEW",
+  );
+  assert.deepEqual(plan.args, ["run", "REVIEW"]);
+  assert.equal(plan.input, "");
+});
+
+test("planExternalRun (argv) appends the prompt when there is no {prompt} token", () => {
+  const plan = planExternalRun(specOf({ promptDelivery: "argv", args: ["run"] }), "REVIEW");
+  assert.deepEqual(plan.args, ["run", "REVIEW"]);
+});
+
+test("planExternalRun (file) substitutes {promptFile} and empties stdin", () => {
+  const plan = planExternalRun(
+    specOf({ promptDelivery: "file", args: ["--in", "{promptFile}"] }),
+    "REVIEW",
+    { promptFile: "/tmp/p.md" },
+  );
+  assert.deepEqual(plan.args, ["--in", "/tmp/p.md"]);
+  assert.equal(plan.input, "");
+});
+
+test("planExternalRun substitutes {model} when set", () => {
+  const plan = planExternalRun(specOf({ args: ["--model", "{model}"], model: "gpt" }), "R");
+  assert.deepEqual(plan.args, ["--model", "gpt"]);
+});
+
+test("planExternalRun drops a standalone empty {model} token", () => {
+  const plan = planExternalRun(specOf({ args: ["{model}", "-p"], model: "" }), "R");
+  assert.deepEqual(plan.args, ["-p"]);
+});
+
+// --- misc ------------------------------------------------------------------------
+
+test("externalDiffCap is tighter for argv than for stdin", () => {
+  assert.ok(externalDiffCap("argv") < externalDiffCap("stdin"));
+});
+
+test("EXTERNAL_ENGINE_ID is 'external'", () => {
+  assert.equal(EXTERNAL_ENGINE_ID, "external");
+});


### PR DESCRIPTION
## Summary

Adds an opt-in, provider-neutral **`--engine external`** to the two **offline, operator-local** pre-PR review paths — `commit-sweeper local-review` (markdown) and `clawsweeper review --local-range` (structured) — so they're no longer codex-only. You point it at any read-only CLI via inline flags; **no providers ship in-tree**. `codex` stays the default and is unchanged for every existing invocation. Follow-on to #408.

## What to review

| file | change |
|---|---|
| `src/external-engine.ts` (new) | The whole mechanism, pure/testable: engine spec, inline-flag parse, arg-template substitution (`{prompt}`/`{promptFile}`/`{model}`), stdin/argv/file delivery planner. No provider names, models, or quotas. |
| `src/codex-process.ts` | `runCodexProcess` gains an optional `command` (defaults to the resolved codex binary) so the existing bounded worker can run an operator-named CLI — the worker already resolves/spawns its `command` cross-platform via `CODEX_BIN`. |
| `src/commit-sweeper.ts` | `local-review` gains `--engine codex\|external`; `external` produces a markdown report through the bounded runner + existing offline envelope. |
| `src/clawsweeper.ts` | `review --local-range` gains `--engine codex\|external` (external **gated to `--local-range`** only). External engines get a markdown-review prompt and their markdown is deterministically bridged into a benign advisory Decision (`externalAdvisoryDecision`). |
| `test/external-engine*.test.ts` (new) | Unit tests for the pure module + stub-CLI integration for both surfaces. |
| `docs/commit-sweeper.md` | Documents `--engine external` + example recipes. |

## How it works

- **Offline envelope, unchanged.** `external` reuses #408's exact contract: scrubbed GitHub credentials, empty `GH_CONFIG_DIR`, clean committed range, read-only, same timeout/diff-cap bounds. "Offline" = no GitHub creds + read-only + committed range (a cloud CLI still reaches its own provider API, exactly as codex does).
- **Markdown, not schema.** External engines report a **markdown** review (so any CLI works, with its own tools/exploration). On `local-review` the markdown is the report; on `review --local-range` it's deterministically bridged into a `keep_open` advisory Decision (a pre-PR advisory closes nothing) whose summary carries the review. No schema for the engine to satisfy, no second LLM call. Codex keeps its native `--output-schema` structured path.
- **Gated.** `external` on the `review` command runs only with `--local-range` (offline, pre-PR); it never touches the live-PR / apply / automerge path. Codex stays the default and the only engine any automation uses.

## Testing

- `pnpm run check` green (build:all, lint, test:unit, test:repair, coverage, format:check); codex path untouched (no behavior change for existing invocations).
- Unit tests cover the pure module (flag validation, all three deliveries, token substitution). Stub-CLI integration tests prove: `local-review --engine external` produces a report; `review --local-range --engine external` bridges the engine's markdown into the advisory (markdown surfaces in the rendered report); the `--local-range` gate; offline-envelope inheritance (checkout cwd + isolated `GH_CONFIG_DIR`); and the missing-`--external-cmd` rejection.
- Exercised end-to-end locally with real CLIs (**claude** on stdin, **agy** on argv) — both produce clean markdown reviews that bridge into the advisory.

## Real behavior proof

`--engine external` run end-to-end against a committed change containing a real bug. The external engine (agy / Gemini, off-Claude) produced a substantive markdown review that **caught the bug**, and it deterministically bridged into the advisory `Decision`:

```console
$ clawsweeper review --local-range --engine external --external-cmd agy \
    --external-args '["--model","{model}","--sandbox","--print"]' \
    --external-model "Gemini 3.1 Pro (High)" --external-prompt argv

[review] shard=0/1 start #0 (1/1)
[review] shard=0/1 done #0 (1/1) decision=keep_open confidence=low action=kept_open

# agy (external engine) markdown review — captured stdout — caught a real bug:
### Bugs / Correctness
*   **Negative Indexing Bug:** If `n` > the array length, `arr.length - n` becomes negative and
    `slice` treats it as an offset from the end.
    *   **Example:** `lastN([1,2,3], 5)` → `[1,2,3].slice(-2)` → `[2,3]` instead of `[1,2,3]`.
    *   **Suggested Fix:** `return arr.slice(Math.max(0, arr.length - n));`

# rendered advisory report (<artifact>/0.md):
decision: keep_open
```

The engine's markdown surfaces in the rendered report's summary. Stub-CLI integration tests (`test/external-engine-review.test.ts`) additionally prove both surfaces, the offline-envelope inheritance (checkout cwd + isolated `GH_CONFIG_DIR`), and the `--local-range` gate; **claude** was verified end-to-end on the stdin recipe the same way.

## Not included / scope boundary

- No providers in-tree (the registry is empty; you point `--external-cmd` at your own CLI). Concrete engines can follow as small individual PRs — I've run **opencode, claude, and agy** locally and can send whichever you want.
- No cascade, metering, or fallback across engines.
- `external` never runs in the apply/automerge/repair/hosted-sweep path; codex remains the default + the only engine automation uses.
- No JSON-repair or structured extraction — external output is treated as markdown.

## Risk / mitigation

- **Operator-configurable subprocess exec** → only ever a binary the operator names in their own local CLI call; never remote-triggered, never in the automation path; gated to `--local-range`; offline envelope prevents credential leak. Same local trust model as running codex.

## Fixes addressed (since the @clawsweeper review)

- **External failures propagate like codex failures** — a nonzero exit, timeout, or empty-output external run now `throw`s `CodexReviewError`, so it trips the review command's failure counter and nonzero exit (previously it wrote failed-review content but silently passed the command's accounting). Regression test asserts the nonzero exit.
- **Empty external stdout is a visible failed review** (was a benign `keep_open` advisory) — an engine that exits `0` without producing review markdown now fails visibly, so a ran-but-said-nothing run can't read as a pass.
- **Removed a stray `.pr-gates/*.json` gate-ledger file** that had been committed to the branch.
- The opt-in external-subprocess boundary is left as a **maintainer decision** — it's opt-in, gated to `--local-range` (offline, pre-PR), enveloped (scrubbed creds, empty `GH_CONFIG_DIR`, read-only), and never runs in the automation/apply path; same local trust model as running codex.

## Review history

Pre-submission review log: https://gist.github.com/f7cb0b2aaecb2a55c622e9425cd48271
