### PR TITLE
feat(radar): detect open PRs with overlapping diffs (report-only interference radar)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "audit": "node dist/clawsweeper.js audit",
     "reconcile": "node dist/clawsweeper.js reconcile",
     "status": "node dist/clawsweeper.js status",
+    "pr-radar": "node dist/pr-radar.js",
     "commit-review": "node dist/commit-sweeper.js",
     "commit-reports": "node dist/commit-sweeper.js reports",
     "local-review": "node dist/commit-sweeper.js local-review",

--- a/schema/clawsweeper-pr-interference.schema.json
+++ b/schema/clawsweeper-pr-interference.schema.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "target_repo",
+    "prs_scanned",
+    "limits",
+    "truncated",
+    "pairs",
+    "digest",
+    "updated_at"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "target_repo": {
+      "type": "string",
+      "description": "owner/repo whose open pull requests were scanned."
+    },
+    "prs_scanned": {
+      "type": "integer",
+      "description": "Number of open pull requests included in the scan."
+    },
+    "limits": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["max_prs", "max_file_pages_per_pr", "max_pairs"],
+      "properties": {
+        "max_prs": { "type": "integer" },
+        "max_file_pages_per_pr": { "type": "integer" },
+        "max_pairs": { "type": "integer" }
+      }
+    },
+    "truncated": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["prs", "pairs"],
+      "properties": {
+        "prs": { "type": "boolean" },
+        "pairs": { "type": "boolean" }
+      }
+    },
+    "pairs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["pr_a", "pr_b", "severity", "containment", "overlapping_line_total", "files"],
+        "properties": {
+          "pr_a": { "$ref": "#/$defs/pairSide" },
+          "pr_b": { "$ref": "#/$defs/pairSide" },
+          "severity": {
+            "type": "string",
+            "enum": ["lines", "file"]
+          },
+          "containment": {
+            "type": "string",
+            "enum": ["a_within_b", "b_within_a", "equal", "none"]
+          },
+          "overlapping_line_total": {
+            "type": "integer",
+            "description": "Total count of base-branch lines edited by both pull requests."
+          },
+          "files": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["base_path", "severity", "overlapping_lines"],
+              "properties": {
+                "base_path": {
+                  "type": "string",
+                  "description": "Path in base-branch coordinates as of each pull request's merge base."
+                },
+                "severity": {
+                  "type": "string",
+                  "enum": ["lines", "file"]
+                },
+                "overlapping_lines": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": { "type": "integer" },
+                    "minItems": 2,
+                    "maxItems": 2
+                  },
+                  "description": "Inclusive base-line ranges edited by both sides; empty for file-level overlap."
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "digest": {
+      "type": "string",
+      "description": "sha256 over the stable JSON of the report without digest and updated_at."
+    },
+    "updated_at": {
+      "type": "string",
+      "description": "ISO timestamp of the scan."
+    }
+  },
+  "$defs": {
+    "pairSide": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["number", "title", "url", "author", "draft", "head_sha"],
+      "properties": {
+        "number": { "type": "integer" },
+        "title": { "type": "string" },
+        "url": { "type": "string" },
+        "author": { "type": "string" },
+        "draft": { "type": "boolean" },
+        "head_sha": { "type": "string" }
+      }
+    }
+  }
+}

--- a/src/pr-interference.ts
+++ b/src/pr-interference.ts
@@ -1,0 +1,324 @@
+import { createHash } from "node:crypto";
+
+import { stableJson } from "./stable-json.js";
+
+export type InterferenceSeverity = "lines" | "file";
+export type InterferenceContainment = "a_within_b" | "b_within_a" | "equal" | "none";
+
+export interface PrRadarFile {
+  base_path: string;
+  status: string;
+  line_ranges: number[][] | null;
+}
+
+export interface PrRadarPr {
+  number: number;
+  title: string;
+  url: string;
+  author: string;
+  draft: boolean;
+  base_ref: string;
+  head_sha: string;
+  files: PrRadarFile[];
+  files_truncated: boolean;
+}
+
+export interface InterferencePairSide {
+  number: number;
+  title: string;
+  url: string;
+  author: string;
+  draft: boolean;
+  head_sha: string;
+}
+
+export interface InterferenceFileOverlap {
+  base_path: string;
+  severity: InterferenceSeverity;
+  overlapping_lines: number[][];
+}
+
+export interface InterferencePair {
+  pr_a: InterferencePairSide;
+  pr_b: InterferencePairSide;
+  severity: InterferenceSeverity;
+  containment: InterferenceContainment;
+  overlapping_line_total: number;
+  files: InterferenceFileOverlap[];
+}
+
+export interface PrInterferenceLimits {
+  max_prs: number;
+  max_file_pages_per_pr: number;
+  max_pairs: number;
+}
+
+export interface PrInterferenceReport {
+  schema_version: 1;
+  target_repo: string;
+  prs_scanned: number;
+  limits: PrInterferenceLimits;
+  truncated: { prs: boolean; pairs: boolean };
+  pairs: InterferencePair[];
+  digest: string;
+  updated_at: string;
+}
+
+const HUNK_HEADER_PATTERN = /^@@ -(\d+)(?:,(\d+))? \+\d+(?:,\d+)? @@/gm;
+
+export function parseBaseIntervals(patch: string): number[][] {
+  const intervals: number[][] = [];
+  for (const match of patch.matchAll(HUNK_HEADER_PATTERN)) {
+    const start = Number(match[1]);
+    const count = match[2] === undefined ? 1 : Number(match[2]);
+    if (count > 0) intervals.push([start, start + count - 1]);
+    else intervals.push([Math.max(1, start), start + 1]);
+  }
+  return mergeIntervals(intervals);
+}
+
+export function mergeIntervals(intervals: readonly (readonly number[])[]): number[][] {
+  const sorted = intervals
+    .map((interval): [number, number] => [interval[0] ?? 0, interval[1] ?? 0])
+    .sort((left, right) => left[0] - right[0] || left[1] - right[1]);
+  const merged: [number, number][] = [];
+  for (const interval of sorted) {
+    const last = merged[merged.length - 1];
+    if (last && interval[0] <= last[1] + 1) last[1] = Math.max(last[1], interval[1]);
+    else merged.push([interval[0], interval[1]]);
+  }
+  return merged;
+}
+
+export function prRadarFileFromApi(file: {
+  filename: string;
+  status: string;
+  previous_filename?: string | undefined;
+  patch?: string | undefined;
+}): PrRadarFile {
+  const basePath = file.previous_filename ?? file.filename;
+  const lineRanges =
+    file.status === "added" || typeof file.patch !== "string"
+      ? null
+      : parseBaseIntervals(file.patch);
+  return { base_path: basePath, status: file.status, line_ranges: lineRanges };
+}
+
+export function detectInterference(
+  prs: readonly PrRadarPr[],
+  maxPairs: number,
+): { pairs: InterferencePair[]; pairs_truncated: boolean } {
+  const byPath = new Map<string, { pr: PrRadarPr; file: PrRadarFile }[]>();
+  for (const pr of prs) {
+    for (const file of pr.files) {
+      const key = `${pr.base_ref}\u0000${file.base_path}`;
+      const entries = byPath.get(key) ?? [];
+      entries.push({ pr, file });
+      byPath.set(key, entries);
+    }
+  }
+
+  const overlapsByPair = new Map<
+    string,
+    { a: PrRadarPr; b: PrRadarPr; files: InterferenceFileOverlap[] }
+  >();
+  for (const entries of byPath.values()) {
+    for (let left = 0; left < entries.length; left += 1) {
+      for (let right = left + 1; right < entries.length; right += 1) {
+        const first = entries[left]!;
+        const second = entries[right]!;
+        if (first.pr.number === second.pr.number) continue;
+        const [a, b] = first.pr.number < second.pr.number ? [first, second] : [second, first];
+        const overlapping =
+          a.file.line_ranges && b.file.line_ranges
+            ? intersectIntervals(a.file.line_ranges, b.file.line_ranges)
+            : [];
+        const key = `${a.pr.number}\u0000${b.pr.number}`;
+        const pair = overlapsByPair.get(key) ?? { a: a.pr, b: b.pr, files: [] };
+        pair.files.push({
+          base_path: a.file.base_path,
+          severity: overlapping.length ? "lines" : "file",
+          overlapping_lines: overlapping,
+        });
+        overlapsByPair.set(key, pair);
+      }
+    }
+  }
+
+  const pairs = [...overlapsByPair.values()].map(({ a, b, files }) => {
+    files.sort(
+      (left, right) =>
+        intervalTotal(right.overlapping_lines) - intervalTotal(left.overlapping_lines) ||
+        left.base_path.localeCompare(right.base_path),
+    );
+    return {
+      pr_a: pairSide(a),
+      pr_b: pairSide(b),
+      severity: files.some((file) => file.severity === "lines")
+        ? ("lines" as const)
+        : ("file" as const),
+      containment: containmentRelation(a, b),
+      overlapping_line_total: files.reduce(
+        (total, file) => total + intervalTotal(file.overlapping_lines),
+        0,
+      ),
+      files,
+    };
+  });
+  pairs.sort(
+    (left, right) =>
+      Number(right.severity === "lines") - Number(left.severity === "lines") ||
+      right.overlapping_line_total - left.overlapping_line_total ||
+      left.pr_a.number - right.pr_a.number ||
+      left.pr_b.number - right.pr_b.number,
+  );
+  return { pairs: pairs.slice(0, maxPairs), pairs_truncated: pairs.length > maxPairs };
+}
+
+export function buildPrInterferenceReport(options: {
+  targetRepo: string;
+  prs: readonly PrRadarPr[];
+  limits: PrInterferenceLimits;
+  prsTruncated: boolean;
+  updatedAt: string;
+}): PrInterferenceReport {
+  const { pairs, pairs_truncated } = detectInterference(options.prs, options.limits.max_pairs);
+  const core = {
+    schema_version: 1 as const,
+    target_repo: options.targetRepo,
+    prs_scanned: options.prs.length,
+    limits: options.limits,
+    truncated: { prs: options.prsTruncated, pairs: pairs_truncated },
+    pairs,
+  };
+  return {
+    ...core,
+    digest: `sha256:${createHash("sha256").update(stableJson(core)).digest("hex")}`,
+    updated_at: options.updatedAt,
+  };
+}
+
+export function renderPrInterferenceMarkdown(report: PrInterferenceReport): string {
+  const lines = [
+    `# PR interference radar - ${report.target_repo}`,
+    "",
+    `${report.prs_scanned} open pull requests scanned, ${report.pairs.length} interfering ${pluralize("pair", report.pairs.length)}.`,
+    "",
+  ];
+  if (report.pairs.length === 0) {
+    lines.push("No interfering open pull request pairs found.", "");
+  } else {
+    lines.push(
+      "| Pair | Severity | Containment | Files | Overlapping base lines |",
+      "|---|---|---|---|---|",
+      ...report.pairs.map(
+        (pair) =>
+          `| ${pairSideMarkdown(pair.pr_a)} and ${pairSideMarkdown(pair.pr_b)} | ${pair.severity} | ${containmentText(pair)} | ${pairFilesMarkdown(pair)} | ${pairLinesMarkdown(pair)} |`,
+      ),
+      "",
+    );
+  }
+  lines.push(
+    "Line numbers are base-branch coordinates as of each pull request's merge base. Pairs are pinned to the head SHAs recorded in report.json and go stale once either head moves.",
+    "",
+    `Scan limits: ${report.limits.max_prs} pull requests, ${report.limits.max_file_pages_per_pr} file pages per pull request, ${report.limits.max_pairs} pairs. ${truncationText(report)}`,
+  );
+  return lines.join("\n");
+}
+
+function pairSide(pr: PrRadarPr): InterferencePairSide {
+  return {
+    number: pr.number,
+    title: pr.title,
+    url: pr.url,
+    author: pr.author,
+    draft: pr.draft,
+    head_sha: pr.head_sha,
+  };
+}
+
+function intersectIntervals(
+  left: readonly (readonly number[])[],
+  right: readonly (readonly number[])[],
+): number[][] {
+  const overlaps: number[][] = [];
+  let leftIndex = 0;
+  let rightIndex = 0;
+  while (leftIndex < left.length && rightIndex < right.length) {
+    const [leftStart = 0, leftEnd = 0] = left[leftIndex]!;
+    const [rightStart = 0, rightEnd = 0] = right[rightIndex]!;
+    const start = Math.max(leftStart, rightStart);
+    const end = Math.min(leftEnd, rightEnd);
+    if (start <= end) overlaps.push([start, end]);
+    if (leftEnd < rightEnd) leftIndex += 1;
+    else rightIndex += 1;
+  }
+  return overlaps;
+}
+
+function intervalTotal(intervals: readonly (readonly number[])[]): number {
+  return intervals.reduce((total, [start = 0, end = 0]) => total + (end - start + 1), 0);
+}
+
+function containmentRelation(a: PrRadarPr, b: PrRadarPr): InterferenceContainment {
+  const aWithinB = prWithin(a, b);
+  const bWithinA = prWithin(b, a);
+  if (aWithinB && bWithinA) return "equal";
+  if (aWithinB) return "a_within_b";
+  if (bWithinA) return "b_within_a";
+  return "none";
+}
+
+function prWithin(inner: PrRadarPr, outer: PrRadarPr): boolean {
+  if (inner.files.length === 0 || inner.files_truncated || outer.files_truncated) return false;
+  const outerByPath = new Map(outer.files.map((file) => [file.base_path, file]));
+  return inner.files.every((file) => {
+    const outerFile = outerByPath.get(file.base_path);
+    if (!outerFile) return false;
+    const innerRanges = file.line_ranges;
+    const outerRanges = outerFile.line_ranges;
+    if (!innerRanges?.length || !outerRanges?.length) return false;
+    return innerRanges.every((range) =>
+      outerRanges.some((outerRange) => outerRange[0]! <= range[0]! && range[1]! <= outerRange[1]!),
+    );
+  });
+}
+
+function pairSideMarkdown(side: InterferencePairSide): string {
+  return `[#${side.number}](${side.url})${side.draft ? " (draft)" : ""}`;
+}
+
+function containmentText(pair: InterferencePair): string {
+  if (pair.containment === "a_within_b") return `#${pair.pr_a.number} within #${pair.pr_b.number}`;
+  if (pair.containment === "b_within_a") return `#${pair.pr_b.number} within #${pair.pr_a.number}`;
+  if (pair.containment === "equal") return "equal surface";
+  return "none";
+}
+
+function pairFilesMarkdown(pair: InterferencePair): string {
+  const names = pair.files.slice(0, 3).map((file) => `\`${file.base_path}\``);
+  const extra = pair.files.length - names.length;
+  return extra > 0 ? `${names.join(", ")} and ${extra} more` : names.join(", ");
+}
+
+function pairLinesMarkdown(pair: InterferencePair): string {
+  const ranges = pair.files
+    .filter((file) => file.overlapping_lines.length)
+    .slice(0, 3)
+    .flatMap((file) => file.overlapping_lines.slice(0, 3))
+    .map(([start, end]) => (start === end ? String(start) : `${start}-${end}`));
+  return ranges.length ? ranges.join(", ") : "shared files only";
+}
+
+function truncationText(report: PrInterferenceReport): string {
+  const truncated = [
+    report.truncated.prs ? "the open pull request list" : "",
+    report.truncated.pairs ? "the pair list" : "",
+  ].filter(Boolean);
+  if (truncated.length === 0) return "No truncation occurred.";
+  return `Truncated: ${truncated.join(" and ")}; the scan is not complete.`;
+}
+
+function pluralize(word: string, count: number): string {
+  return count === 1 ? word : `${word}s`;
+}

--- a/src/pr-radar.ts
+++ b/src/pr-radar.ts
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { argNumber, argString, parseArgs, type Args } from "./clawsweeper-args.js";
+import { isUserFacingCommandError, runText } from "./command.js";
+import { parseGhJson } from "./github-json.js";
+import { ghRetryKind, ghRetryWaitMs, summarizeGhArgs } from "./github-retry.js";
+import {
+  buildPrInterferenceReport,
+  prRadarFileFromApi,
+  renderPrInterferenceMarkdown,
+  type PrRadarPr,
+} from "./pr-interference.js";
+import { DEFAULT_TARGET_REPO } from "./repository-profiles.js";
+
+const TARGET_REPO_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const PAGE_SIZE = 100;
+
+interface GitHubPullListItem {
+  number: number;
+  title: string;
+  html_url: string;
+  draft: boolean;
+  user: { login: string } | null;
+  base: { ref: string };
+  head: { sha: string };
+}
+
+interface GitHubPullFile {
+  filename: string;
+  status: string;
+  previous_filename?: string | undefined;
+  patch?: string | undefined;
+}
+
+function ghJson<T>(args: string[], attempts = 3): T {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      return parseGhJson<T>(runText("gh", args, { trim: "both" }), args);
+    } catch (error) {
+      lastError = error;
+      const retryKind = ghRetryKind(error);
+      if (retryKind === "none" || attempt === attempts - 1) throw error;
+      const waitMs = ghRetryWaitMs(retryKind, attempt);
+      console.error(
+        `Transient GitHub API failure; retrying ${summarizeGhArgs(args)} in ${Math.round(waitMs / 1000)}s`,
+      );
+      sleepMs(waitMs);
+    }
+  }
+  throw lastError;
+}
+
+function sleepMs(milliseconds: number): void {
+  if (milliseconds <= 0) return;
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function fetchOpenPrs(
+  targetRepo: string,
+  maxPrs: number,
+  maxFilePages: number,
+): { prs: PrRadarPr[]; truncated: boolean } {
+  const items: GitHubPullListItem[] = [];
+  let lastPageFull = false;
+  for (let page = 1; items.length < maxPrs; page += 1) {
+    const batch = ghJson<GitHubPullListItem[]>([
+      "api",
+      `repos/${targetRepo}/pulls?state=open&sort=created&direction=asc&per_page=${PAGE_SIZE}&page=${page}`,
+    ]);
+    items.push(...batch);
+    lastPageFull = batch.length === PAGE_SIZE;
+    if (!lastPageFull) break;
+  }
+  const truncated = items.length > maxPrs || (lastPageFull && items.length === maxPrs);
+  const prs = items.slice(0, maxPrs).map((item) => {
+    const files = fetchPrFiles(targetRepo, item.number, maxFilePages);
+    return {
+      number: item.number,
+      title: item.title,
+      url: item.html_url,
+      author: item.user?.login ?? "",
+      draft: item.draft === true,
+      base_ref: item.base.ref,
+      head_sha: item.head.sha,
+      files: files.files.map(prRadarFileFromApi),
+      files_truncated: files.truncated,
+    };
+  });
+  return { prs, truncated };
+}
+
+function fetchPrFiles(
+  targetRepo: string,
+  pullNumber: number,
+  maxFilePages: number,
+): { files: GitHubPullFile[]; truncated: boolean } {
+  const files: GitHubPullFile[] = [];
+  let lastPageFull = false;
+  for (let page = 1; page <= maxFilePages; page += 1) {
+    const batch = ghJson<GitHubPullFile[]>([
+      "api",
+      `repos/${targetRepo}/pulls/${pullNumber}/files?per_page=${PAGE_SIZE}&page=${page}`,
+    ]);
+    files.push(...batch);
+    lastPageFull = batch.length === PAGE_SIZE;
+    if (!lastPageFull) break;
+  }
+  return { files, truncated: lastPageFull };
+}
+
+function scanCommand(args: Args): void {
+  const targetRepo = argString(args, "target_repo", DEFAULT_TARGET_REPO);
+  if (!TARGET_REPO_PATTERN.test(targetRepo))
+    throw new Error("--target-repo must be owner/repo with GitHub-safe characters");
+  const maxPrs = positiveIntegerArg(args, "max_prs", 200);
+  const maxFilePages = positiveIntegerArg(args, "max_file_pages", 3);
+  const maxPairs = positiveIntegerArg(args, "max_pairs", 50);
+  const slug = targetRepo.replaceAll("/", "-");
+  const outDir = argString(args, "out_dir", join("artifacts", "pr-radar", slug));
+
+  const { prs, truncated } = fetchOpenPrs(targetRepo, maxPrs, maxFilePages);
+  const report = buildPrInterferenceReport({
+    targetRepo,
+    prs,
+    limits: { max_prs: maxPrs, max_file_pages_per_pr: maxFilePages, max_pairs: maxPairs },
+    prsTruncated: truncated,
+    updatedAt: new Date().toISOString(),
+  });
+  const markdown = renderPrInterferenceMarkdown(report);
+
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(join(outDir, "report.json"), `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  writeFileSync(join(outDir, "report.md"), `${markdown}\n`, "utf8");
+  console.log(markdown);
+  console.error(`Wrote report.json and report.md to ${outDir}`);
+}
+
+function positiveIntegerArg(args: Args, key: string, fallback: number): number {
+  const value = argNumber(args, key, fallback);
+  if (!Number.isInteger(value) || value <= 0)
+    throw new Error(`--${key.replaceAll("_", "-")} must be a positive integer`);
+  return value;
+}
+
+export async function main(argv = process.argv.slice(2)): Promise<void> {
+  const args = parseArgs(argv);
+  const command = args._[0] ?? "scan";
+  if (command === "scan") scanCommand(args);
+  else throw new Error(`Unknown command: ${command}`);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(formatFatalError(error));
+    process.exit(1);
+  });
+}
+
+function formatFatalError(error: unknown): string {
+  if (isUserFacingCommandError(error)) return `Error: ${error.message}`;
+  return error instanceof Error ? error.stack || error.message : String(error);
+}

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -808,22 +808,31 @@ export const git = {
   latestRelease: null,
 };
 
-export function withMockGh(root: string, script: string, run: () => void): void {
+export function withMockGh<T>(root: string, script: string, run: () => T): T {
   const originalGhBin = process.env.GH_BIN;
   const originalGhBinArgs = process.env.GH_BIN_ARGS;
   const binDir = join(root, "bin");
   mkdirSync(binDir, { recursive: true });
   const ghPath = join(binDir, "gh.js");
   writeFileSync(ghPath, script, { mode: 0o755 });
-  try {
-    process.env.GH_BIN = process.execPath;
-    process.env.GH_BIN_ARGS = JSON.stringify([ghPath]);
-    run();
-  } finally {
+  const restore = () => {
     if (originalGhBin === undefined) delete process.env.GH_BIN;
     else process.env.GH_BIN = originalGhBin;
     if (originalGhBinArgs === undefined) delete process.env.GH_BIN_ARGS;
     else process.env.GH_BIN_ARGS = originalGhBinArgs;
+  };
+  try {
+    process.env.GH_BIN = process.execPath;
+    process.env.GH_BIN_ARGS = JSON.stringify([ghPath]);
+    const result = run();
+    if (result && typeof (result as PromiseLike<unknown>).then === "function") {
+      return Promise.resolve(result).finally(restore) as T;
+    }
+    restore();
+    return result;
+  } catch (error) {
+    restore();
+    throw error;
   }
 }
 

--- a/test/pr-interference.test.ts
+++ b/test/pr-interference.test.ts
@@ -1,0 +1,355 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import {
+  buildPrInterferenceReport,
+  detectInterference,
+  mergeIntervals,
+  parseBaseIntervals,
+  prRadarFileFromApi,
+  renderPrInterferenceMarkdown,
+  type PrRadarFile,
+  type PrRadarPr,
+} from "../dist/pr-interference.js";
+
+function radarPr(
+  number: number,
+  files: PrRadarFile[],
+  overrides: Partial<PrRadarPr> = {},
+): PrRadarPr {
+  return {
+    number,
+    title: `title ${number}`,
+    url: `https://github.com/openclaw/openclaw/pull/${number}`,
+    author: "alice",
+    draft: false,
+    base_ref: "main",
+    head_sha: `sha-${number}`,
+    files,
+    files_truncated: false,
+    ...overrides,
+  };
+}
+
+function radarFile(basePath: string, lineRanges: number[][] | null): PrRadarFile {
+  return { base_path: basePath, status: "modified", line_ranges: lineRanges };
+}
+
+test("parseBaseIntervals merges hunks and defaults omitted counts", () => {
+  assert.deepEqual(parseBaseIntervals("@@ -10,5 +10,6 @@\n context\n@@ -14,3 +20,3 @@\n"), [
+    [10, 16],
+  ]);
+  assert.deepEqual(parseBaseIntervals("@@ -5 +5 @@\n-old\n+new\n"), [[5, 5]]);
+  assert.deepEqual(parseBaseIntervals("@@ -3,3 +3,3 @@\n@@ -8,2 +8,2 @@\n"), [
+    [3, 5],
+    [8, 9],
+  ]);
+});
+
+test("parseBaseIntervals anchors insertions to neighboring base lines", () => {
+  assert.deepEqual(parseBaseIntervals("@@ -0,0 +1,3 @@\n+a\n+b\n+c\n"), [[1, 1]]);
+  assert.deepEqual(parseBaseIntervals("@@ -40,0 +41,2 @@\n+a\n+b\n"), [[40, 41]]);
+});
+
+test("parseBaseIntervals keeps pure deletions on the pre-image range", () => {
+  assert.deepEqual(parseBaseIntervals("@@ -10,3 +9,0 @@\n-a\n-b\n-c\n"), [[10, 12]]);
+});
+
+test("mergeIntervals coalesces overlapping and adjacent ranges", () => {
+  assert.deepEqual(
+    mergeIntervals([
+      [6, 8],
+      [3, 5],
+    ]),
+    [[3, 8]],
+  );
+  assert.deepEqual(
+    mergeIntervals([
+      [3, 5],
+      [7, 8],
+    ]),
+    [
+      [3, 5],
+      [7, 8],
+    ],
+  );
+});
+
+test("prRadarFileFromApi resolves base paths and file granularity", () => {
+  assert.deepEqual(
+    prRadarFileFromApi({
+      filename: "src/new-name.ts",
+      status: "renamed",
+      previous_filename: "src/old-name.ts",
+      patch: "@@ -4,2 +4,2 @@\n",
+    }),
+    { base_path: "src/old-name.ts", status: "renamed", line_ranges: [[4, 5]] },
+  );
+  assert.deepEqual(
+    prRadarFileFromApi({ filename: "src/gone.ts", status: "removed", patch: "@@ -1,9 +0,0 @@\n" }),
+    { base_path: "src/gone.ts", status: "removed", line_ranges: [[1, 9]] },
+  );
+  assert.deepEqual(
+    prRadarFileFromApi({ filename: "src/new.ts", status: "added", patch: "@@ -0,0 +1,20 @@\n" }),
+    { base_path: "src/new.ts", status: "added", line_ranges: null },
+  );
+  assert.deepEqual(prRadarFileFromApi({ filename: "assets/logo.png", status: "modified" }), {
+    base_path: "assets/logo.png",
+    status: "modified",
+    line_ranges: null,
+  });
+});
+
+test("detectInterference reports line overlaps with clipped ranges", () => {
+  const { pairs, pairs_truncated } = detectInterference(
+    [
+      radarPr(101, [radarFile("src/a.ts", [[10, 20]])]),
+      radarPr(102, [radarFile("src/a.ts", [[15, 30]])], { draft: true }),
+    ],
+    50,
+  );
+  assert.equal(pairs_truncated, false);
+  assert.equal(pairs.length, 1);
+  assert.equal(pairs[0]?.severity, "lines");
+  assert.equal(pairs[0]?.overlapping_line_total, 6);
+  assert.equal(pairs[0]?.pr_a.number, 101);
+  assert.equal(pairs[0]?.pr_b.number, 102);
+  assert.equal(pairs[0]?.pr_b.draft, true);
+  assert.equal(pairs[0]?.pr_b.head_sha, "sha-102");
+  assert.deepEqual(pairs[0]?.files, [
+    { base_path: "src/a.ts", severity: "lines", overlapping_lines: [[15, 20]] },
+  ]);
+});
+
+test("detectInterference treats shared boundaries as overlap and adjacency as file-level", () => {
+  const boundary = detectInterference(
+    [
+      radarPr(1, [radarFile("src/a.ts", [[10, 20]])]),
+      radarPr(2, [radarFile("src/a.ts", [[20, 25]])]),
+    ],
+    50,
+  );
+  assert.deepEqual(boundary.pairs[0]?.files[0]?.overlapping_lines, [[20, 20]]);
+  const adjacent = detectInterference(
+    [
+      radarPr(1, [radarFile("src/a.ts", [[10, 20]])]),
+      radarPr(2, [radarFile("src/a.ts", [[21, 25]])]),
+    ],
+    50,
+  );
+  assert.equal(adjacent.pairs.length, 1);
+  assert.equal(adjacent.pairs[0]?.severity, "file");
+  assert.deepEqual(adjacent.pairs[0]?.files[0]?.overlapping_lines, []);
+});
+
+test("detectInterference only pairs pull requests with the same base ref", () => {
+  const { pairs } = detectInterference(
+    [
+      radarPr(1, [radarFile("src/a.ts", [[10, 20]])]),
+      radarPr(2, [radarFile("src/a.ts", [[10, 20]])], { base_ref: "release-1" }),
+    ],
+    50,
+  );
+  assert.deepEqual(pairs, []);
+});
+
+test("detectInterference degrades to file granularity without line ranges", () => {
+  const { pairs } = detectInterference(
+    [
+      radarPr(1, [radarFile("assets/logo.png", null)]),
+      radarPr(2, [radarFile("assets/logo.png", [[3, 9]])]),
+    ],
+    50,
+  );
+  assert.equal(pairs.length, 1);
+  assert.equal(pairs[0]?.severity, "file");
+  assert.equal(pairs[0]?.containment, "none");
+});
+
+test("detectInterference never claims containment for opaque line ranges", () => {
+  const rangedInner = detectInterference(
+    [radarPr(21, [radarFile("src/a.ts", [[10, 12]])]), radarPr(22, [radarFile("src/a.ts", null)])],
+    50,
+  );
+  assert.equal(rangedInner.pairs[0]?.containment, "none");
+  const bothOpaque = detectInterference(
+    [radarPr(21, [radarFile("src/a.ts", null)]), radarPr(22, [radarFile("src/a.ts", null)])],
+    50,
+  );
+  assert.equal(bothOpaque.pairs[0]?.containment, "none");
+  const emptyRanges = detectInterference(
+    [radarPr(21, [radarFile("src/a.ts", [])]), radarPr(22, [radarFile("src/a.ts", [[5, 40]])])],
+    50,
+  );
+  assert.equal(emptyRanges.pairs[0]?.containment, "none");
+});
+
+test("detectInterference pairs renamed files under the base-branch path", () => {
+  const renamed = prRadarFileFromApi({
+    filename: "src/renamed.ts",
+    status: "renamed",
+    previous_filename: "src/original.ts",
+    patch: "@@ -12,4 +12,4 @@\n",
+  });
+  const { pairs } = detectInterference(
+    [radarPr(1, [renamed]), radarPr(2, [radarFile("src/original.ts", [[14, 18]])])],
+    50,
+  );
+  assert.equal(pairs.length, 1);
+  assert.equal(pairs[0]?.severity, "lines");
+  assert.deepEqual(pairs[0]?.files[0]?.overlapping_lines, [[14, 15]]);
+});
+
+test("detectInterference records containment between overlapping pull requests", () => {
+  const within = detectInterference(
+    [
+      radarPr(11, [radarFile("src/a.ts", [[10, 12]])]),
+      radarPr(12, [radarFile("src/a.ts", [[5, 40]]), radarFile("src/b.ts", [[1, 4]])]),
+    ],
+    50,
+  );
+  assert.equal(within.pairs[0]?.containment, "a_within_b");
+  const equal = detectInterference(
+    [
+      radarPr(11, [radarFile("src/a.ts", [[10, 12]])]),
+      radarPr(12, [radarFile("src/a.ts", [[10, 12]])]),
+    ],
+    50,
+  );
+  assert.equal(equal.pairs[0]?.containment, "equal");
+  const crossed = detectInterference(
+    [
+      radarPr(11, [radarFile("src/a.ts", [[10, 12]]), radarFile("src/c.ts", [[1, 2]])]),
+      radarPr(12, [radarFile("src/a.ts", [[5, 40]]), radarFile("src/b.ts", [[1, 4]])]),
+    ],
+    50,
+  );
+  assert.equal(crossed.pairs[0]?.containment, "none");
+  const truncated = detectInterference(
+    [
+      radarPr(11, [radarFile("src/a.ts", [[10, 12]])]),
+      radarPr(12, [radarFile("src/a.ts", [[5, 40]])], { files_truncated: true }),
+    ],
+    50,
+  );
+  assert.equal(truncated.pairs[0]?.containment, "none");
+});
+
+test("detectInterference sorts line pairs first and enforces the pair cap", () => {
+  const { pairs, pairs_truncated } = detectInterference(
+    [
+      radarPr(1, [radarFile("src/a.ts", [[1, 2]])]),
+      radarPr(2, [radarFile("src/a.ts", [[1, 40]])]),
+      radarPr(3, [radarFile("src/a.ts", null)]),
+    ],
+    2,
+  );
+  assert.equal(pairs_truncated, true);
+  assert.deepEqual(
+    pairs.map((pair) => [pair.pr_a.number, pair.pr_b.number, pair.severity]),
+    [
+      [1, 2, "lines"],
+      [1, 3, "file"],
+    ],
+  );
+});
+
+test("buildPrInterferenceReport digests are stable across timestamps and input order", () => {
+  const prs = [
+    radarPr(1, [radarFile("src/a.ts", [[10, 20]])]),
+    radarPr(2, [radarFile("src/a.ts", [[15, 30]])]),
+  ];
+  const limits = { max_prs: 200, max_file_pages_per_pr: 3, max_pairs: 50 };
+  const first = buildPrInterferenceReport({
+    targetRepo: "openclaw/openclaw",
+    prs,
+    limits,
+    prsTruncated: false,
+    updatedAt: "2026-07-06T00:00:00.000Z",
+  });
+  const second = buildPrInterferenceReport({
+    targetRepo: "openclaw/openclaw",
+    prs: [...prs].reverse(),
+    limits,
+    prsTruncated: false,
+    updatedAt: "2026-07-07T12:00:00.000Z",
+  });
+  assert.equal(first.digest, second.digest);
+  assert.equal(first.schema_version, 1);
+  assert.equal(first.prs_scanned, 2);
+  const moved = buildPrInterferenceReport({
+    targetRepo: "openclaw/openclaw",
+    prs: [prs[0]!, radarPr(2, [radarFile("src/a.ts", [[16, 30]])])],
+    limits,
+    prsTruncated: false,
+    updatedAt: "2026-07-06T00:00:00.000Z",
+  });
+  assert.notEqual(first.digest, moved.digest);
+});
+
+test("report JSON shape matches the published schema", () => {
+  const schema = JSON.parse(readFileSync("schema/clawsweeper-pr-interference.schema.json", "utf8"));
+  const report = buildPrInterferenceReport({
+    targetRepo: "openclaw/openclaw",
+    prs: [
+      radarPr(1, [radarFile("src/a.ts", [[10, 20]])]),
+      radarPr(2, [radarFile("src/a.ts", [[15, 30]])]),
+    ],
+    limits: { max_prs: 200, max_file_pages_per_pr: 3, max_pairs: 50 },
+    prsTruncated: false,
+    updatedAt: "2026-07-06T00:00:00.000Z",
+  });
+  assert.deepEqual(Object.keys(schema.properties).sort(), [...schema.required].sort());
+  assert.deepEqual(Object.keys(report).sort(), [...schema.required].sort());
+  const pairSchema = schema.properties.pairs.items;
+  assert.deepEqual(Object.keys(pairSchema.properties).sort(), [...pairSchema.required].sort());
+  assert.deepEqual(Object.keys(report.pairs[0]!).sort(), [...pairSchema.required].sort());
+  assert.deepEqual(
+    Object.keys(report.pairs[0]!.pr_a).sort(),
+    [...schema.$defs.pairSide.required].sort(),
+  );
+});
+
+test("renderPrInterferenceMarkdown renders pairs, containment, and truncation", () => {
+  const report = buildPrInterferenceReport({
+    targetRepo: "openclaw/openclaw",
+    prs: [
+      radarPr(11, [radarFile("src/a.ts", [[10, 12]])], { draft: true }),
+      radarPr(12, [radarFile("src/a.ts", [[5, 40]])]),
+      radarPr(13, [radarFile("src/a.ts", [[6, 8]])]),
+    ],
+    limits: { max_prs: 200, max_file_pages_per_pr: 3, max_pairs: 2 },
+    prsTruncated: true,
+    updatedAt: "2026-07-06T00:00:00.000Z",
+  });
+  const markdown = renderPrInterferenceMarkdown(report);
+  assert.match(markdown, /# PR interference radar - openclaw\/openclaw/);
+  assert.match(markdown, /3 open pull requests scanned, 2 interfering pairs\./);
+  assert.match(
+    markdown,
+    /\[#11\]\(https:\/\/github\.com\/openclaw\/openclaw\/pull\/11\) \(draft\) and \[#12\]/,
+  );
+  assert.match(markdown, /#11 within #12/);
+  assert.match(markdown, /`src\/a\.ts`/);
+  assert.match(markdown, /10-12/);
+  assert.match(markdown, /base-branch coordinates/);
+  assert.match(
+    markdown,
+    /Truncated: the open pull request list and the pair list; the scan is not complete\./,
+  );
+});
+
+test("renderPrInterferenceMarkdown renders the empty state", () => {
+  const report = buildPrInterferenceReport({
+    targetRepo: "openclaw/openclaw",
+    prs: [],
+    limits: { max_prs: 200, max_file_pages_per_pr: 3, max_pairs: 50 },
+    prsTruncated: false,
+    updatedAt: "2026-07-06T00:00:00.000Z",
+  });
+  const markdown = renderPrInterferenceMarkdown(report);
+  assert.match(markdown, /0 open pull requests scanned, 0 interfering pairs\./);
+  assert.match(markdown, /No interfering open pull request pairs found\./);
+  assert.match(markdown, /No truncation occurred\./);
+});

--- a/test/pr-radar.test.ts
+++ b/test/pr-radar.test.ts
@@ -1,0 +1,231 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+import { main } from "../dist/pr-radar.js";
+import { tmpPrefix, withMockGh } from "./helpers.ts";
+
+const happyPathMock = `
+const args = process.argv.slice(2);
+const apiIndex = args.lastIndexOf("api");
+const path = args[apiIndex + 1] || "";
+const pulls = [
+  {
+    number: 101,
+    title: "fix: gateway reconnect",
+    html_url: "https://github.com/openclaw/openclaw/pull/101",
+    draft: false,
+    user: { login: "alice" },
+    base: { ref: "main" },
+    head: { sha: "headsha101" },
+  },
+  {
+    number: 102,
+    title: "refactor: gateway session",
+    html_url: "https://github.com/openclaw/openclaw/pull/102",
+    draft: true,
+    user: { login: "bob" },
+    base: { ref: "main" },
+    head: { sha: "headsha102" },
+  },
+  {
+    number: 103,
+    title: "docs: gateway guide",
+    html_url: "https://github.com/openclaw/openclaw/pull/103",
+    draft: false,
+    user: { login: "carol" },
+    base: { ref: "main" },
+    head: { sha: "headsha103" },
+  },
+];
+if (apiIndex === -1) {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+if (path.startsWith("repos/openclaw/openclaw/pulls?")) {
+  console.log(JSON.stringify(path.includes("page=1") ? pulls : []));
+} else if (path.startsWith("repos/openclaw/openclaw/pulls/101/files")) {
+  console.log(JSON.stringify([
+    { filename: "src/gateway/session.ts", status: "modified", patch: "@@ -140,20 +140,25 @@" },
+  ]));
+} else if (path.startsWith("repos/openclaw/openclaw/pulls/102/files")) {
+  console.log(JSON.stringify([
+    { filename: "src/gateway/session.ts", status: "modified", patch: "@@ -150,10 +150,12 @@" },
+  ]));
+} else if (path.startsWith("repos/openclaw/openclaw/pulls/103/files")) {
+  console.log(JSON.stringify([
+    { filename: "docs/gateway.md", status: "modified", patch: "@@ -1,5 +1,9 @@" },
+  ]));
+} else {
+  console.error("unexpected gh path", path);
+  process.exit(1);
+}
+`;
+
+test("pr-radar scan writes a schema-shaped report for interfering pull requests", async () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const outDir = join(root, "out");
+    await withMockGh(root, happyPathMock, () =>
+      main(["scan", "--target-repo", "openclaw/openclaw", "--out-dir", outDir]),
+    );
+    const report = JSON.parse(readFileSync(join(outDir, "report.json"), "utf8"));
+    assert.equal(report.schema_version, 1);
+    assert.equal(report.target_repo, "openclaw/openclaw");
+    assert.equal(report.prs_scanned, 3);
+    assert.deepEqual(report.truncated, { prs: false, pairs: false });
+    assert.equal(report.pairs.length, 1);
+    const pair = report.pairs[0];
+    assert.equal(pair.pr_a.number, 101);
+    assert.equal(pair.pr_a.head_sha, "headsha101");
+    assert.equal(pair.pr_b.number, 102);
+    assert.equal(pair.pr_b.draft, true);
+    assert.equal(pair.severity, "lines");
+    assert.deepEqual(pair.files, [
+      {
+        base_path: "src/gateway/session.ts",
+        severity: "lines",
+        overlapping_lines: [[150, 159]],
+      },
+    ]);
+    const markdown = readFileSync(join(outDir, "report.md"), "utf8");
+    assert.match(markdown, /\[#101\].* and \[#102\].*\(draft\)/);
+    assert.match(markdown, /150-159/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+const truncatedFilesMock = `
+const args = process.argv.slice(2);
+const apiIndex = args.lastIndexOf("api");
+const path = args[apiIndex + 1] || "";
+const pulls = [
+  {
+    number: 7,
+    title: "wide refactor",
+    html_url: "https://github.com/openclaw/openclaw/pull/7",
+    draft: false,
+    user: { login: "alice" },
+    base: { ref: "main" },
+    head: { sha: "headsha7" },
+  },
+  {
+    number: 8,
+    title: "small fix",
+    html_url: "https://github.com/openclaw/openclaw/pull/8",
+    draft: false,
+    user: { login: "bob" },
+    base: { ref: "main" },
+    head: { sha: "headsha8" },
+  },
+];
+if (path.startsWith("repos/openclaw/openclaw/pulls?")) {
+  console.log(JSON.stringify(path.includes("page=1") ? pulls : []));
+} else if (path.startsWith("repos/openclaw/openclaw/pulls/7/files")) {
+  const files = Array.from({ length: 100 }, (_, index) => ({
+    filename: "src/file-" + index + ".ts",
+    status: "modified",
+    patch: "@@ -1,2 +1,2 @@",
+  }));
+  files[0] = { filename: "src/shared.ts", status: "modified", patch: "@@ -5,36 +5,36 @@" };
+  console.log(JSON.stringify(files));
+} else if (path.startsWith("repos/openclaw/openclaw/pulls/8/files")) {
+  console.log(JSON.stringify([
+    { filename: "src/shared.ts", status: "modified", patch: "@@ -10,3 +10,3 @@" },
+  ]));
+} else {
+  console.error("unexpected gh path", path);
+  process.exit(1);
+}
+`;
+
+test("pr-radar scan withholds containment when a file page cap truncates a pull request", async () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const outDir = join(root, "out");
+    await withMockGh(root, truncatedFilesMock, () =>
+      main([
+        "scan",
+        "--target-repo",
+        "openclaw/openclaw",
+        "--out-dir",
+        outDir,
+        "--max-file-pages",
+        "1",
+      ]),
+    );
+    const report = JSON.parse(readFileSync(join(outDir, "report.json"), "utf8"));
+    assert.equal(report.pairs.length, 1);
+    assert.equal(report.pairs[0].severity, "lines");
+    assert.equal(report.pairs[0].containment, "none");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+const emptyRepoMock = `
+const args = process.argv.slice(2);
+const apiIndex = args.lastIndexOf("api");
+const path = args[apiIndex + 1] || "";
+if (path.startsWith("repos/openclaw/openclaw/pulls?")) {
+  console.log("[]");
+} else {
+  console.error("unexpected gh path", path);
+  process.exit(1);
+}
+`;
+
+test("pr-radar scan renders the empty state for a repository without open pull requests", async () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const outDir = join(root, "out");
+    await withMockGh(root, emptyRepoMock, () =>
+      main(["scan", "--target-repo", "openclaw/openclaw", "--out-dir", outDir]),
+    );
+    const report = JSON.parse(readFileSync(join(outDir, "report.json"), "utf8"));
+    assert.equal(report.prs_scanned, 0);
+    assert.deepEqual(report.pairs, []);
+    assert.match(
+      readFileSync(join(outDir, "report.md"), "utf8"),
+      /No interfering open pull request pairs found\./,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+const failingMock = `
+console.error("boom: repository unavailable");
+process.exit(1);
+`;
+
+test("pr-radar scan rejects on non-retryable gh failures", async () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const pending = withMockGh(root, failingMock, () =>
+      main(["scan", "--target-repo", "openclaw/openclaw", "--out-dir", join(root, "out")]),
+    );
+    await assert.rejects(pending, /boom: repository unavailable|Command failed/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("pr-radar rejects invalid target repositories and unknown commands", async () => {
+  await assert.rejects(main(["scan", "--target-repo", "not-a-repo"]), /owner\/repo/);
+  await assert.rejects(main(["frobnicate"]), /Unknown command/);
+});
+
+test("pr-radar rejects non-positive and fractional scan limits", async () => {
+  await assert.rejects(main(["scan", "--max-prs", "0"]), /--max-prs must be a positive integer/);
+  await assert.rejects(
+    main(["scan", "--max-file-pages", "0"]),
+    /--max-file-pages must be a positive integer/,
+  );
+  await assert.rejects(
+    main(["scan", "--max-pairs", "1.5"]),
+    /--max-pairs must be a positive integer/,
+  );
+});


### PR DESCRIPTION
## Summary

Adds a deterministic, report-only PR interference radar CLI. It scans a target repository's open pull requests, parses each changed file's unified diff hunk headers into pre-image base-branch line intervals, and reports open PR pairs whose diffs touch the same base files or overlapping base line ranges.

This is now intentionally narrowed after ClawSweeper review: no new workflow, no scheduled job, no dashboard panel, and no state-repository publishing path. The PR leaves only a local/read-only CLI, JSON schema, package script, and tests.

Zero model calls, zero new dependencies, no GitHub mutations.

## What changed

- `src/pr-interference.ts`: new pure module for hunk parsing, merged base intervals, pair detection, severity (`lines` over `file`), neutral containment facts (`a_within_b`, `b_within_a`, `equal`, `none`), stable report digests, and markdown rendering.
- `src/pr-radar.ts`: thin CLI entry (`dist/pr-radar.js`, `pnpm run pr-radar`) that uses read-only `gh api` GETs for open PRs and paged PR files, then writes `report.json` and `report.md` to a gitignored output directory.
- `schema/clawsweeper-pr-interference.schema.json`: draft 2020-12 schema for the report artifact.
- `package.json`: adds the `pr-radar` script.
- `test/pr-interference.test.ts` and `test/pr-radar.test.ts`: focused coverage for hunk edge cases, insertion/deletion anchors, renames, omitted patches, overlap semantics, base-ref grouping, containment guards, sorting/capping, digest determinism, schema shape, markdown rendering, CLI output, failure paths, and positive-integer scan-limit validation.
- `test/helpers.ts`: lets the existing mock `gh` helper keep command overrides alive until async callbacks settle.

## Design notes

- Coordinates are base-branch pre-image coordinates from each PR's merge base, and PRs are only compared within the same `base.ref`.
- Insertion hunks (`b == 0`) anchor to both neighboring base lines, matching git merge-conflict semantics for dual insertions at the same point.
- Added files and files whose patch GitHub omits degrade to whole-file granularity instead of being dropped.
- Containment is a fact, not advice. The CLI never proposes merge order, labels, closes, comments, repair dispatch, or automerge.
- Containment is withheld (`none`) whenever either side's file list was truncated or any shared path lacks comparable line ranges, so partial or opaque scans cannot claim full containment.

## Real behavior proof

Base: `c089d676c190a86f8002fb63fe0c017a6ac4a7f6`

Current head: `8f47e4eac47d2e73cf6bcb4c121cfc4d869bc804`

### Before

Current main has no PR radar CLI/source/schema surface:

```sh
grep -R "pr-radar\|pr_interference\|PR interference radar" src package.json schema test
# no PR radar implementation on main
```

### After

Exact-head read-only CLI run against live GitHub:

```sh
node dist/pr-radar.js scan --target-repo openclaw/clawsweeper --max-prs 20 --max-pairs 5 --out-dir artifacts/pr-radar-proof-current
```

Output:

```text
# PR interference radar - openclaw/clawsweeper

3 open pull requests scanned, 0 interfering pairs.

No interfering open pull request pairs found.

Line numbers are base-branch coordinates as of each pull request's merge base. Pairs are pinned to the head SHAs recorded in report.json and go stale once either head moves.

Scan limits: 20 pull requests, 3 file pages per pull request, 5 pairs. No truncation occurred.
Wrote report.json and report.md to artifacts/pr-radar-proof-current
```

Earlier large-sample proof for the same scanner logic, before the dashboard/workflow surface was removed, scanned 150 open `openclaw/openclaw` PRs and found 25 real interfering pairs. The preserved artifacts are still available for inspection: [report.md](https://github.com/yetval/clawsweeper/blob/radar-proof-assets/report.md), [report.json](https://github.com/yetval/clawsweeper/blob/radar-proof-assets/report.json).

## Gates

Run locally on this branch:

```sh
pnpm run build:all
pnpm run format:check
pnpm run lint:scripts
node --test test/pr-interference.test.ts test/pr-radar.test.ts
```

Results: all passed. Local shell is Node 22.19.0, so pnpm reports the repo's Node >=24 engine warning, but the build and checks completed successfully.

GitHub CI for head `8f47e4eac47d2e73cf6bcb4c121cfc4d869bc804` is running after the force-push.

## Limits and non-goals

- Advisory only: no labels, comments, closes, merges, repair dispatch, workflow scheduling, dashboard state, or state-repository publishing.
- Known accepted ceilings: an insertion at end of file flags a phantom next line, an add versus rename-onto-the-same-path pair is not detected, and GitHub-omitted patches degrade to file granularity.
- Deferred follow-ups if maintainers want them: uploaded artifacts, a dashboard panel, a durable per-PR advisory comment, a re-scan trigger when an interfering head moves, or review-freshness integration.
