### PR TITLE
fix: require head-fresh review evidence before close-safety trusts proof labels

### DIFF
--- a/.github/workflows/repair-cluster-worker.yml
+++ b/.github/workflows/repair-cluster-worker.yml
@@ -479,7 +479,9 @@ jobs:
         with:
           token: ${{ steps.state-token.outputs.token }}
           fetch-depth: 1
-          sparse-checkout: jobs
+          sparse-checkout: |
+            jobs
+            records
 
       - name: Check job file
         id: check_job

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -5343,6 +5343,14 @@ function frontMatterValue(markdown: string, key: string): string | undefined {
   return value?.startsWith('"') && value.endsWith('"') ? value.slice(1, -1) : value;
 }
 
+function frontMatterBlock(markdown: string): string {
+  return /^---\n([\s\S]*?)\n---(?:\n|$)/.exec(markdown)?.[1] ?? "";
+}
+
+function frontMatterOnlyValue(markdown: string, key: string): string | undefined {
+  return frontMatterValue(frontMatterBlock(markdown), key);
+}
+
 function reportCloseReason(markdown: string): CloseReason | undefined {
   const closeReason = frontMatterValue(markdown, "close_reason");
   return closeReason && ALLOWED_REASONS.has(closeReason as CloseReason)
@@ -13738,7 +13746,11 @@ function unsafeCanonicalPullRequestReason(
   const reportAtLiveHead = Boolean(
     report && linkedPull.headSha && pullHeadShaFromReport(report) === linkedPull.headSha,
   );
-  const reportProofPassed = reportAtLiveHead && proofPassedInReport(report);
+  const reportProofStatus = report
+    ? frontMatterOnlyValue(report, "real_behavior_proof_status")
+    : undefined;
+  const reportProofPassed =
+    reportAtLiveHead && (reportProofStatus === "sufficient" || reportProofStatus === "override");
   const labelProofPassed =
     overrideProofPassed || (proofPassedInLabels(linkedPull.labels) && reportProofPassed);
   const proofPassed = reportProofPassed || overrideProofPassed;
@@ -15904,7 +15916,7 @@ function pullHeadShaFromContext(context: ItemContext): string | null {
 }
 
 function pullHeadShaFromReport(markdown: string): string | null {
-  const value = frontMatterValue(markdown, "pull_head_sha");
+  const value = frontMatterOnlyValue(markdown, "pull_head_sha");
   return value && value !== "unknown" ? value : null;
 }
 

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -13230,6 +13230,7 @@ interface LinkedPullRequestSupersession {
   state: string;
   mergedAt: string | null;
   mergeableState: string | null;
+  headSha: string | null;
   draft: boolean;
   labels: string[];
   files: string[];
@@ -13628,6 +13629,7 @@ function linkedPullRequestSupersession(
         state,
         mergedAt,
         mergeableState: stringOrUndefined(pull.mergeable_state)?.toLowerCase() ?? null,
+        headSha: stringOrUndefined(asRecord(pull.head).sha) ?? null,
         draft: pull.draft === true,
         labels: linkedPullRequestLabels(number, pull),
         files: linkedFiles.files,
@@ -13727,14 +13729,19 @@ function unsafeCanonicalPullRequestReason(
 
   const report = linkedPullRequestReportMarkdown(linkedPull.number, options.reportDirs);
   const labels = linkedPull.labels.map(normalizeLabelName);
-  const labelProofPassed = proofPassedInLabels(linkedPull.labels);
+  const overrideProofPassed = labels.some((label) => /^proof:\s*override\b/i.test(label));
   const liveNeedsProof = labels.some(
     (label) =>
       label === "triage: needs-real-behavior-proof" ||
       (label.startsWith("status:") && label.includes("needs proof")),
   );
-  const reportProofPassed = proofPassedInReport(report);
-  const proofPassed = reportProofPassed || labelProofPassed;
+  const reportAtLiveHead = Boolean(
+    report && linkedPull.headSha && pullHeadShaFromReport(report) === linkedPull.headSha,
+  );
+  const reportProofPassed = reportAtLiveHead && proofPassedInReport(report);
+  const labelProofPassed =
+    overrideProofPassed || (proofPassedInLabels(linkedPull.labels) && reportProofPassed);
+  const proofPassed = reportProofPassed || overrideProofPassed;
 
   if (labels.some((label) => label.startsWith("rating:") && label.includes("unranked"))) {
     return `linked canonical PR #${linkedPull.number} is F-rated`;
@@ -13765,6 +13772,9 @@ function unsafeCanonicalPullRequestReason(
     }
   }
   if (!proofPassed) {
+    if (proofPassedInLabels(linkedPull.labels) || proofPassedInReport(report)) {
+      return `linked canonical PR #${linkedPull.number} real behavior proof is not verified at its current head`;
+    }
     return `linked canonical PR #${linkedPull.number} has no positive real behavior proof`;
   }
 
@@ -13789,6 +13799,7 @@ function duplicateCanonicalPullRequestBlockReason(
         state: stringOrUndefined(pull.state)?.toLowerCase() ?? "",
         mergedAt: stringOrUndefined(pull.merged_at) ?? null,
         mergeableState: stringOrUndefined(pull.mergeable_state)?.toLowerCase() ?? null,
+        headSha: stringOrUndefined(asRecord(pull.head).sha) ?? null,
         draft: pull.draft === true,
         labels: linkedPullRequestLabels(number, pull),
         files: linkedFiles.files,

--- a/src/repair/apply-result.ts
+++ b/src/repair/apply-result.ts
@@ -1101,7 +1101,11 @@ function validatePrCloseCoverageCoveringSafety({
   }
 
   const labels = labelNames(coveringIssue.labels).map(normalizeLabelName);
-  const proofPassed = labels.some((label) => /^proof:\s*(sufficient|override)\b/i.test(label));
+  const overrideProofPassed = labels.some((label) => /^proof:\s*override\b/i.test(label));
+  const sufficientProofLabel = labels.some((label) => /^proof:\s*sufficient\b/i.test(label));
+  const proofPassed =
+    overrideProofPassed ||
+    (sufficientProofLabel && coveringReviewReportAtHead(result.repo, coveringRef, pullRequest));
   const needsProof = labels.some(
     (label) =>
       label === "triage: needs-real-behavior-proof" ||
@@ -1114,9 +1118,35 @@ function validatePrCloseCoverageCoveringSafety({
     return `linked canonical PR #${coveringRef} is still waiting for real behavior proof`;
   }
   if (!proofPassed) {
-    return `linked canonical PR #${coveringRef} has no positive real behavior proof`;
+    return sufficientProofLabel
+      ? `linked canonical PR #${coveringRef} real behavior proof is not verified at its current head`
+      : `linked canonical PR #${coveringRef} has no positive real behavior proof`;
   }
   return "";
+}
+
+function coveringReviewReportAtHead(
+  repo: JsonValue,
+  coveringRef: JsonValue,
+  pullRequest: LooseRecord,
+): boolean {
+  const headSha = stringFromUnknown(pullRequest.head?.sha);
+  if (!headSha) return false;
+  const recordsRoot = process.env.CLAWSWEEPER_RECORDS_ROOT || path.join(repoRoot(), "records");
+  const slug = String(repo).replace(/[^A-Za-z0-9_.-]+/g, "-");
+  for (const dir of ["items", "closed"]) {
+    const file = path.join(recordsRoot, slug, dir, `${coveringRef}.md`);
+    if (!fs.existsSync(file)) continue;
+    const report = fs.readFileSync(file, "utf8");
+    const headMatch = /^pull_head_sha:\s*(\S+)\s*$/m.exec(report);
+    return Boolean(
+      headMatch &&
+      headMatch[1] !== "unknown" &&
+      headMatch[1] === headSha &&
+      /^real_behavior_proof_status:\s*(sufficient|override)\s*$/m.test(report),
+    );
+  }
+  return false;
 }
 
 function formatCoveringPullRequestBlock(coveringRef: JsonValue, reason: string): string {

--- a/src/repair/apply-result.ts
+++ b/src/repair/apply-result.ts
@@ -1138,12 +1138,13 @@ function coveringReviewReportAtHead(
     const file = path.join(recordsRoot, slug, dir, `${coveringRef}.md`);
     if (!fs.existsSync(file)) continue;
     const report = fs.readFileSync(file, "utf8");
-    const headMatch = /^pull_head_sha:\s*(\S+)\s*$/m.exec(report);
+    const frontMatter = /^---\n([\s\S]*?)\n---(?:\n|$)/.exec(report)?.[1] ?? "";
+    const headMatch = /^pull_head_sha:\s*(\S+)\s*$/m.exec(frontMatter);
     return Boolean(
       headMatch &&
       headMatch[1] !== "unknown" &&
       headMatch[1] === headSha &&
-      /^real_behavior_proof_status:\s*(sufficient|override)\s*$/m.test(report),
+      /^real_behavior_proof_status:\s*(sufficient|override)\s*$/m.test(frontMatter),
     );
   }
   return false;

--- a/test/apply-pr-promotion.test.ts
+++ b/test/apply-pr-promotion.test.ts
@@ -207,7 +207,10 @@ test("apply-decisions promotes old F-rated stale PRs to duplicate closes", () =>
       () => {
         withMockCodexProof(
           root,
-          { type: "failure", message: "proof should not run for stale promotion incidental ref" },
+          {
+            type: "failure",
+            message: "proof should not run for stale promotion incidental ref",
+          },
           () => {
             runApplyDecisionsForTest({
               itemsDir,
@@ -300,7 +303,9 @@ test("apply-decisions promotes stale PRs after automation-only drift", () => {
       },
     );
 
-    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{ action: string }>;
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+      action: string;
+    }>;
     assert.equal(
       report.some((entry) => entry.action === "closed"),
       true,
@@ -360,7 +365,9 @@ test("apply-decisions does not promote stale PRs from truncated activity", () =>
       },
     );
 
-    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{ action: string }>;
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+      action: string;
+    }>;
     assert.equal(
       report.some((entry) => entry.action === "closed"),
       false,
@@ -428,7 +435,9 @@ test("apply-decisions does not promote stale PRs after human follow-up", () => {
       },
     );
 
-    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{ action: string }>;
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+      action: string;
+    }>;
     assert.equal(
       report.some((entry) => entry.action === "closed"),
       false,
@@ -505,7 +514,9 @@ test("apply-decisions does not promote stale PRs after a command-only re-review 
       },
     );
 
-    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{ action: string }>;
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+      action: string;
+    }>;
     assert.equal(
       report.some((entry) => entry.action === "closed"),
       false,
@@ -549,7 +560,11 @@ test("apply-decisions promotes recommended pause-or-close PRs", () => {
 
     withMockGh(
       root,
-      promotionGhMock({ number: 331, title: "Superseded prompt PR", comment: synced.comment }),
+      promotionGhMock({
+        number: 331,
+        title: "Superseded prompt PR",
+        comment: synced.comment,
+      }),
       () => {
         runApplyDecisionsForTest({
           itemsDir,
@@ -569,7 +584,9 @@ test("apply-decisions promotes recommended pause-or-close PRs", () => {
       },
     );
 
-    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{ action: string }>;
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+      action: string;
+    }>;
     assert.equal(
       report.some((entry) => entry.action === "closed"),
       true,
@@ -604,6 +621,24 @@ test("apply-decisions promotes PRs superseded by linked pull requests", () => {
       .replace("Patch tier: F", "Patch tier: D");
     const synced = reportWithSyncedReviewComment(linkedMarkdownLabelReport, 332, "none");
     writeFileSync(join(itemsDir, "332.md"), synced.report, "utf8");
+    writeFileSync(
+      join(itemsDir, "400.md"),
+      stalePullRequestReport({
+        number: 400,
+        title: "Canonical activity PR",
+        labels: JSON.stringify(["proof: sufficient"]),
+        pull_head_sha: "canonical-head-400",
+        pr_rating_overall: "D",
+        pr_rating_proof: "D",
+        pr_rating_patch: "D",
+      })
+        .replace("Status: missing", "Status: sufficient")
+        .replace(
+          "Overall tier: F\nProof tier: F\nPatch tier: F",
+          "Overall tier: D\nProof tier: D\nPatch tier: D",
+        ),
+      "utf8",
+    );
 
     withMockGh(
       root,
@@ -619,6 +654,7 @@ test("apply-decisions promotes PRs superseded by linked pull requests", () => {
             state: "open",
             merged_at: null,
             mergeable_state: "clean",
+            head: { sha: "canonical-head-400" },
             labels: ["proof: sufficient"],
           },
         },
@@ -644,6 +680,8 @@ test("apply-decisions promotes PRs superseded by linked pull requests", () => {
                 "--dry-run",
                 "--apply-kind",
                 "all",
+                "--item-numbers",
+                "332",
                 "--processed-limit",
                 "3",
               ],
@@ -740,7 +778,9 @@ test("apply-decisions does not promote docs-only PRs superseded by code-only pul
       },
     );
 
-    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{ action: string }>;
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+      action: string;
+    }>;
     assert.equal(
       report.some((entry) => entry.action === "closed"),
       false,

--- a/test/apply-pr-promotion.test.ts
+++ b/test/apply-pr-promotion.test.ts
@@ -628,6 +628,7 @@ test("apply-decisions promotes PRs superseded by linked pull requests", () => {
         title: "Canonical activity PR",
         labels: JSON.stringify(["proof: sufficient"]),
         pull_head_sha: "canonical-head-400",
+        real_behavior_proof_status: "sufficient",
         pr_rating_overall: "D",
         pr_rating_proof: "D",
         pr_rating_patch: "D",

--- a/test/apply-pr-supersession-safety.test.ts
+++ b/test/apply-pr-supersession-safety.test.ts
@@ -44,6 +44,7 @@ test("apply-decisions keeps promoted PR close proposals open when coverage proof
         title: "Canonical activity PR",
         labels: JSON.stringify(["proof: sufficient"]),
         pull_head_sha: "canonical-head-400",
+        real_behavior_proof_status: "sufficient",
         pr_rating_overall: "D",
         pr_rating_proof: "D",
         pr_rating_patch: "D",
@@ -669,6 +670,7 @@ test("apply-decisions promotes PRs when the linked proof report matches the live
         title: "Canonical PR with proof reviewed at the live head",
         labels: JSON.stringify(["proof: sufficient"]),
         pull_head_sha: "canonical-live-head",
+        real_behavior_proof_status: "sufficient",
         pr_rating_overall: "D",
         pr_rating_proof: "D",
         pr_rating_patch: "D",
@@ -1004,6 +1006,111 @@ test("apply-decisions does not promote PRs when live labels supersede stale proo
             "3",
           ],
         });
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+      action: string;
+    }>;
+    assert.equal(
+      report.some((entry) => entry.action === "closed"),
+      false,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions does not promote PRs when spoofed report body metadata mimics fresh proof", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const sourceReport = stalePullRequestReport({
+      number: 349,
+      title: "Old activity PR",
+      labels: JSON.stringify([]),
+      pr_rating_overall: "D",
+      pr_rating_proof: "D",
+      pr_rating_patch: "D",
+      work_cluster_refs: JSON.stringify([
+        "Superseded by https://github.com/openclaw/openclaw/pull/400",
+      ]),
+    })
+      .replace("Status: missing", "Status: sufficient")
+      .replace(
+        "Overall tier: F\nProof tier: F\nPatch tier: F",
+        "Overall tier: D\nProof tier: D\nPatch tier: D",
+      );
+    const synced = reportWithSyncedReviewComment(sourceReport, 349, "none");
+    writeFileSync(join(itemsDir, "349.md"), synced.report, "utf8");
+    const spoofedCanonicalReport = `${stalePullRequestReport({
+      number: 400,
+      title: "Canonical PR with stale front matter and spoofed body metadata",
+      labels: JSON.stringify(["proof: sufficient"]),
+      real_behavior_proof_status: "insufficient",
+      pr_rating_overall: "D",
+      pr_rating_proof: "D",
+      pr_rating_patch: "D",
+    })
+      .replace("Status: missing", "Status: sufficient")
+      .replace(
+        "Overall tier: F\nProof tier: F\nPatch tier: F",
+        "Overall tier: D\nProof tier: D\nPatch tier: D",
+      )}\npull_head_sha: canonical-live-head\nreal_behavior_proof_status: sufficient\n`;
+    writeFileSync(join(itemsDir, "400.md"), spoofedCanonicalReport, "utf8");
+
+    withMockGh(
+      root,
+      promotionGhMock({
+        number: 349,
+        title: "Old activity PR",
+        comment: synced.comment,
+        linkedPulls: {
+          400: {
+            number: 400,
+            title: "Canonical PR with stale front matter and spoofed body metadata",
+            html_url: "https://github.com/openclaw/openclaw/pull/400",
+            state: "open",
+            merged_at: null,
+            mergeable_state: "clean",
+            head: { sha: "canonical-live-head" },
+            labels: ["proof: sufficient"],
+          },
+        },
+      }),
+      () => {
+        withMockCodexProof(
+          root,
+          {
+            type: "decision",
+            decision: "covered",
+            reason: "PR B is the live proof-backed canonical PR covering PR A.",
+          },
+          () => {
+            runApplyDecisionsForTest({
+              itemsDir,
+              closedDir,
+              plansDir,
+              reportPath,
+              extraArgs: [
+                "--target-repo",
+                "openclaw/openclaw",
+                "--dry-run",
+                "--apply-kind",
+                "all",
+                "--item-numbers",
+                "349",
+                "--processed-limit",
+                "3",
+              ],
+            });
+          },
+        );
       },
     );
 

--- a/test/apply-pr-supersession-safety.test.ts
+++ b/test/apply-pr-supersession-safety.test.ts
@@ -37,6 +37,24 @@ test("apply-decisions keeps promoted PR close proposals open when coverage proof
       "none",
     );
     writeFileSync(join(itemsDir, "352.md"), synced.report, "utf8");
+    writeFileSync(
+      join(itemsDir, "400.md"),
+      stalePullRequestReport({
+        number: 400,
+        title: "Canonical activity PR",
+        labels: JSON.stringify(["proof: sufficient"]),
+        pull_head_sha: "canonical-head-400",
+        pr_rating_overall: "D",
+        pr_rating_proof: "D",
+        pr_rating_patch: "D",
+      })
+        .replace("Status: missing", "Status: sufficient")
+        .replace(
+          "Overall tier: F\nProof tier: F\nPatch tier: F",
+          "Overall tier: D\nProof tier: D\nPatch tier: D",
+        ),
+      "utf8",
+    );
 
     withMockGh(
       root,
@@ -52,6 +70,7 @@ test("apply-decisions keeps promoted PR close proposals open when coverage proof
             state: "open",
             merged_at: null,
             mergeable_state: "clean",
+            head: { sha: "canonical-head-400" },
             labels: ["proof: sufficient"],
           },
         },
@@ -69,6 +88,8 @@ test("apply-decisions keeps promoted PR close proposals open when coverage proof
               "--dry-run",
               "--apply-kind",
               "all",
+              "--item-numbers",
+              "352",
               "--processed-limit",
               "3",
             ],
@@ -244,7 +265,9 @@ test("apply-decisions does not promote PRs superseded by no-proof linked pull re
       },
     );
 
-    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{ action: string }>;
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+      action: string;
+    }>;
     assert.equal(
       report.some((entry) => entry.action === "closed"),
       false,
@@ -318,7 +341,9 @@ test("apply-decisions does not promote PRs superseded by unsafe linked pull requ
       },
     );
 
-    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{ action: string }>;
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+      action: string;
+    }>;
     assert.equal(
       report.some((entry) => entry.action === "closed"),
       false,
@@ -396,7 +421,9 @@ test("apply-decisions does not promote PRs superseded by F-rated linked pull req
       },
     );
 
-    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{ action: string }>;
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+      action: string;
+    }>;
     assert.equal(
       report.some((entry) => entry.action === "closed"),
       false,
@@ -487,7 +514,9 @@ test("apply-decisions does not promote PRs superseded by section-only unsafe lin
       },
     );
 
-    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{ action: string }>;
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+      action: string;
+    }>;
     assert.equal(
       report.some((entry) => entry.action === "closed"),
       false,
@@ -498,7 +527,7 @@ test("apply-decisions does not promote PRs superseded by section-only unsafe lin
   }
 });
 
-test("apply-decisions promotes PRs when live proof labels supersede stale linked reports", () => {
+test("apply-decisions does not promote PRs when live proof labels lack a head-fresh linked report", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
     const itemsDir = join(root, "items");
@@ -529,15 +558,18 @@ test("apply-decisions promotes PRs when live proof labels supersede stale linked
       join(itemsDir, "400.md"),
       stalePullRequestReport({
         number: 400,
-        title: "Canonical PR with stale proof report",
-        labels: JSON.stringify(["status: needs proof"]),
+        title: "Canonical PR with proof reviewed at an old head",
+        labels: JSON.stringify(["proof: sufficient"]),
+        pull_head_sha: "canonical-old-head",
         pr_rating_overall: "D",
         pr_rating_proof: "D",
         pr_rating_patch: "D",
-      }).replace(
-        "Overall tier: F\nProof tier: F\nPatch tier: F",
-        "Overall tier: D\nProof tier: D\nPatch tier: D",
-      ),
+      })
+        .replace("Status: missing", "Status: sufficient")
+        .replace(
+          "Overall tier: F\nProof tier: F\nPatch tier: F",
+          "Overall tier: D\nProof tier: D\nPatch tier: D",
+        ),
       "utf8",
     );
 
@@ -555,6 +587,7 @@ test("apply-decisions promotes PRs when live proof labels supersede stale linked
             state: "open",
             merged_at: null,
             mergeable_state: "clean",
+            head: { sha: "canonical-new-head" },
             labels: ["proof: sufficient"],
           },
         },
@@ -590,10 +623,300 @@ test("apply-decisions promotes PRs when live proof labels supersede stale linked
       },
     );
 
-    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{ action: string }>;
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+      action: string;
+    }>;
+    assert.equal(
+      report.some((entry) => entry.action === "closed"),
+      false,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions promotes PRs when the linked proof report matches the live head", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const sourceReport = stalePullRequestReport({
+      number: 345,
+      title: "Old activity PR",
+      labels: JSON.stringify([]),
+      pr_rating_overall: "D",
+      pr_rating_proof: "D",
+      pr_rating_patch: "D",
+      work_cluster_refs: JSON.stringify([
+        "Superseded by https://github.com/openclaw/openclaw/pull/400",
+      ]),
+    })
+      .replace("Status: missing", "Status: sufficient")
+      .replace(
+        "Overall tier: F\nProof tier: F\nPatch tier: F",
+        "Overall tier: D\nProof tier: D\nPatch tier: D",
+      );
+    const synced = reportWithSyncedReviewComment(sourceReport, 345, "none");
+    writeFileSync(join(itemsDir, "345.md"), synced.report, "utf8");
+    writeFileSync(
+      join(itemsDir, "400.md"),
+      stalePullRequestReport({
+        number: 400,
+        title: "Canonical PR with proof reviewed at the live head",
+        labels: JSON.stringify(["proof: sufficient"]),
+        pull_head_sha: "canonical-live-head",
+        pr_rating_overall: "D",
+        pr_rating_proof: "D",
+        pr_rating_patch: "D",
+      })
+        .replace("Status: missing", "Status: sufficient")
+        .replace(
+          "Overall tier: F\nProof tier: F\nPatch tier: F",
+          "Overall tier: D\nProof tier: D\nPatch tier: D",
+        ),
+      "utf8",
+    );
+
+    withMockGh(
+      root,
+      promotionGhMock({
+        number: 345,
+        title: "Old activity PR",
+        comment: synced.comment,
+        linkedPulls: {
+          400: {
+            number: 400,
+            title: "Canonical PR with live proof label",
+            html_url: "https://github.com/openclaw/openclaw/pull/400",
+            state: "open",
+            merged_at: null,
+            mergeable_state: "clean",
+            head: { sha: "canonical-live-head" },
+            labels: ["proof: sufficient"],
+          },
+        },
+      }),
+      () => {
+        withMockCodexProof(
+          root,
+          {
+            type: "decision",
+            decision: "covered",
+            reason: "PR B is the live proof-backed canonical PR covering PR A.",
+          },
+          () => {
+            runApplyDecisionsForTest({
+              itemsDir,
+              closedDir,
+              plansDir,
+              reportPath,
+              extraArgs: [
+                "--target-repo",
+                "openclaw/openclaw",
+                "--dry-run",
+                "--apply-kind",
+                "all",
+                "--item-numbers",
+                "345",
+                "--processed-limit",
+                "3",
+              ],
+            });
+          },
+        );
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+      action: string;
+    }>;
     assert.equal(
       report.some((entry) => entry.action === "closed"),
       true,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions promotes PRs when the linked PR carries a human proof override", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const sourceReport = stalePullRequestReport({
+      number: 346,
+      title: "Old activity PR",
+      labels: JSON.stringify([]),
+      pr_rating_overall: "D",
+      pr_rating_proof: "D",
+      pr_rating_patch: "D",
+      work_cluster_refs: JSON.stringify([
+        "Superseded by https://github.com/openclaw/openclaw/pull/400",
+      ]),
+    })
+      .replace("Status: missing", "Status: sufficient")
+      .replace(
+        "Overall tier: F\nProof tier: F\nPatch tier: F",
+        "Overall tier: D\nProof tier: D\nPatch tier: D",
+      );
+    const synced = reportWithSyncedReviewComment(sourceReport, 346, "none");
+    writeFileSync(join(itemsDir, "346.md"), synced.report, "utf8");
+
+    withMockGh(
+      root,
+      promotionGhMock({
+        number: 346,
+        title: "Old activity PR",
+        comment: synced.comment,
+        linkedPulls: {
+          400: {
+            number: 400,
+            title: "Canonical PR with human proof override",
+            html_url: "https://github.com/openclaw/openclaw/pull/400",
+            state: "open",
+            merged_at: null,
+            mergeable_state: "clean",
+            head: { sha: "canonical-new-head" },
+            labels: ["proof: override"],
+          },
+        },
+      }),
+      () => {
+        withMockCodexProof(
+          root,
+          {
+            type: "decision",
+            decision: "covered",
+            reason: "PR B is the human-overridden canonical PR covering PR A.",
+          },
+          () => {
+            runApplyDecisionsForTest({
+              itemsDir,
+              closedDir,
+              plansDir,
+              reportPath,
+              extraArgs: [
+                "--target-repo",
+                "openclaw/openclaw",
+                "--dry-run",
+                "--apply-kind",
+                "all",
+                "--item-numbers",
+                "346",
+                "--processed-limit",
+                "3",
+              ],
+            });
+          },
+        );
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+      action: string;
+    }>;
+    assert.equal(
+      report.some((entry) => entry.action === "closed"),
+      true,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions does not promote PRs when live proof labels have no linked report", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const sourceReport = stalePullRequestReport({
+      number: 347,
+      title: "Old activity PR",
+      labels: JSON.stringify([]),
+      pr_rating_overall: "D",
+      pr_rating_proof: "D",
+      pr_rating_patch: "D",
+      work_cluster_refs: JSON.stringify([
+        "Superseded by https://github.com/openclaw/openclaw/pull/400",
+      ]),
+    })
+      .replace("Status: missing", "Status: sufficient")
+      .replace(
+        "Overall tier: F\nProof tier: F\nPatch tier: F",
+        "Overall tier: D\nProof tier: D\nPatch tier: D",
+      );
+    const synced = reportWithSyncedReviewComment(sourceReport, 347, "none");
+    writeFileSync(join(itemsDir, "347.md"), synced.report, "utf8");
+
+    withMockGh(
+      root,
+      promotionGhMock({
+        number: 347,
+        title: "Old activity PR",
+        comment: synced.comment,
+        linkedPulls: {
+          400: {
+            number: 400,
+            title: "Canonical PR with live proof label and no report",
+            html_url: "https://github.com/openclaw/openclaw/pull/400",
+            state: "open",
+            merged_at: null,
+            mergeable_state: "clean",
+            head: { sha: "canonical-new-head" },
+            labels: ["proof: sufficient"],
+          },
+        },
+      }),
+      () => {
+        withMockCodexProof(
+          root,
+          {
+            type: "decision",
+            decision: "covered",
+            reason: "PR B is the live proof-backed canonical PR covering PR A.",
+          },
+          () => {
+            runApplyDecisionsForTest({
+              itemsDir,
+              closedDir,
+              plansDir,
+              reportPath,
+              extraArgs: [
+                "--target-repo",
+                "openclaw/openclaw",
+                "--dry-run",
+                "--apply-kind",
+                "all",
+                "--item-numbers",
+                "347",
+                "--processed-limit",
+                "3",
+              ],
+            });
+          },
+        );
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+      action: string;
+    }>;
+    assert.equal(
+      report.some((entry) => entry.action === "closed"),
+      false,
     );
   } finally {
     rmSync(root, { recursive: true, force: true });
@@ -684,7 +1007,9 @@ test("apply-decisions does not promote PRs when live labels supersede stale proo
       },
     );
 
-    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{ action: string }>;
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+      action: string;
+    }>;
     assert.equal(
       report.some((entry) => entry.action === "closed"),
       false,
@@ -759,7 +1084,9 @@ test("apply-decisions does not promote PRs superseded by unknown-mergeability PR
       },
     );
 
-    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{ action: string }>;
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+      action: string;
+    }>;
     assert.equal(
       report.some((entry) => entry.action === "closed"),
       false,
@@ -834,7 +1161,9 @@ test("apply-decisions does not promote PRs superseded by non-clean linked pull r
       },
     );
 
-    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{ action: string }>;
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+      action: string;
+    }>;
     assert.equal(
       report.some((entry) => entry.action === "closed"),
       false,

--- a/test/apply-same-author-pair-close.test.ts
+++ b/test/apply-same-author-pair-close.test.ts
@@ -8,6 +8,7 @@ import {
   lowSignalCloseReport,
   reportWithSyncedReviewComment,
   runApplyDecisionsForTest,
+  stalePullRequestReport,
   tmpPrefix,
   withMockCodexProof,
   withMockGh,
@@ -354,6 +355,24 @@ test("apply-decisions records PR coverage proof retry before same-author pair sk
       "duplicate_or_superseded",
     );
     writeFileSync(join(itemsDir, "321.md"), pullSynced.report, "utf8");
+    writeFileSync(
+      join(itemsDir, "400.md"),
+      stalePullRequestReport({
+        number: 400,
+        title: "Canonical provider cleanup",
+        labels: JSON.stringify(["proof: sufficient"]),
+        pull_head_sha: "canonical-head-400",
+        pr_rating_overall: "D",
+        pr_rating_proof: "D",
+        pr_rating_patch: "D",
+      })
+        .replace("Status: missing", "Status: sufficient")
+        .replace(
+          "Overall tier: F\nProof tier: F\nPatch tier: F",
+          "Overall tier: D\nProof tier: D\nPatch tier: D",
+        ),
+      "utf8",
+    );
 
     const ghMock = `
 const comments = {
@@ -436,6 +455,7 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
     merged_at: null,
     mergeable_state: "clean",
     draft: false,
+    head: { sha: "canonical-head-400" },
     labels: [{ name: "proof: sufficient" }],
     body: "Carries the provider cleanup."
   }));
@@ -473,6 +493,8 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
             "openclaw/openclaw",
             "--apply-kind",
             "all",
+            "--item-numbers",
+            "321",
             "--processed-limit",
             "3",
           ],

--- a/test/apply-same-author-pair-close.test.ts
+++ b/test/apply-same-author-pair-close.test.ts
@@ -362,6 +362,7 @@ test("apply-decisions records PR coverage proof retry before same-author pair sk
         title: "Canonical provider cleanup",
         labels: JSON.stringify(["proof: sufficient"]),
         pull_head_sha: "canonical-head-400",
+        real_behavior_proof_status: "sufficient",
         pr_rating_overall: "D",
         pr_rating_proof: "D",
         pr_rating_patch: "D",

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2046,7 +2046,7 @@ test("issue implementation workflow lets job intent choose dispatch capacity", (
   );
 });
 
-test("repair workers hydrate only durable jobs from generated state", () => {
+test("repair workers hydrate durable jobs and execute-lane review records from generated state", () => {
   const workflow = readText(".github/workflows/repair-cluster-worker.yml");
   const requeue = readText("src/repair/requeue-job.ts");
 
@@ -2055,10 +2055,11 @@ test("repair workers hydrate only durable jobs from generated state", () => {
   assert.match(workflow, /requeue:\n\s+description:/);
   assert.match(requeue, /"requeue=true"/);
   assert.equal(
-    workflow.match(/uses: \.\/\.github\/actions\/setup-state[\s\S]*?sparse-checkout: jobs/g)
+    workflow.match(/uses: \.\/\.github\/actions\/setup-state[\s\S]*?sparse-checkout: jobs\n/g)
       ?.length,
-    2,
+    1,
   );
+  assert.match(workflow, /sparse-checkout: \|\n\s+jobs\n\s+records/);
   assert.match(workflow, /CLAWSWEEPER_STEERABLE_CODEX/);
   assert.match(workflow, /actions\/cache\/restore@v6/);
   assert.match(workflow, /actions\/cache\/save@v6/);

--- a/test/repair/apply-result.test.ts
+++ b/test/repair/apply-result.test.ts
@@ -799,6 +799,71 @@ test("repair apply blocks PR close when the head-fresh report does not confirm p
   }
 });
 
+test("repair apply blocks PR close when spoofed report body metadata mimics fresh proof", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-apply-result-"));
+  try {
+    const paths = writeApplyFixture(tmp, {
+      action: "close_duplicate",
+      classification: "duplicate",
+      canonical: "#202",
+    });
+    writeFakeGh(paths.binDir, {
+      issues: {
+        101: issue({ number: 101, title: "Add config validation", pullRequest: true }),
+        202: issue({
+          number: 202,
+          title: "Rewrite config validation",
+          pullRequest: true,
+          labels: ["proof: sufficient"],
+        }),
+      },
+      pulls: {
+        101: pull({ number: 101, title: "Add config validation" }),
+        202: pull({
+          number: 202,
+          title: "Rewrite config validation",
+          headSha: "covering-head-202",
+        }),
+      },
+      comments: {
+        101: [comment("alice", "PR A keeps legacy config behavior intact.")],
+        202: [comment("bob", "PR B carries forward the legacy config behavior.")],
+      },
+      logPath: paths.ghLogPath,
+    });
+    writeFakeCodex(paths.binDir);
+    const itemsDir = path.join(paths.recordsRoot, "openclaw-openclaw", "items");
+    fs.mkdirSync(itemsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(itemsDir, "202.md"),
+      [
+        "---",
+        "number: 202",
+        "real_behavior_proof_status: insufficient",
+        "---",
+        "",
+        "Report body.",
+        "",
+        "pull_head_sha: covering-head-202",
+        "real_behavior_proof_status: sufficient",
+        "",
+      ].join("\n"),
+    );
+
+    runApplyResult(paths, { proofDecision: "covered", failIfProofRuns: true });
+
+    const report = JSON.parse(fs.readFileSync(paths.reportPath, "utf8"));
+    assert.equal(report.actions[0].status, "blocked");
+    assert.equal(
+      report.actions[0].reason,
+      "linked canonical PR #202 real behavior proof is not verified at its current head",
+    );
+    assert.equal(hasPrCloseCall(paths.ghLogPath), false);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test("repair apply blocks PR close when covering proof label has no report at all", () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-apply-result-"));
   try {

--- a/test/repair/apply-result.test.ts
+++ b/test/repair/apply-result.test.ts
@@ -936,6 +936,71 @@ test("repair apply executes PR duplicate close when the covering PR has a human 
   }
 });
 
+test("repair apply reads covering reports from the default records root", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-apply-result-"));
+  const defaultRecordsRoot = path.join(repoRoot, "records");
+  const recordsRootExisted = fs.existsSync(defaultRecordsRoot);
+  const defaultReportPath = path.join(defaultRecordsRoot, "openclaw-openclaw", "items", "202.md");
+  const priorReport = fs.existsSync(defaultReportPath) ? fs.readFileSync(defaultReportPath) : null;
+  try {
+    const paths = writeApplyFixture(tmp, {
+      action: "close_duplicate",
+      classification: "duplicate",
+      canonical: "#202",
+    });
+    writeFakeGh(paths.binDir, {
+      issues: {
+        101: issue({ number: 101, title: "Add config validation", pullRequest: true }),
+        202: issue({
+          number: 202,
+          title: "Rewrite config validation",
+          pullRequest: true,
+          labels: ["proof: sufficient"],
+        }),
+      },
+      pulls: {
+        101: pull({ number: 101, title: "Add config validation" }),
+        202: pull({
+          number: 202,
+          title: "Rewrite config validation",
+          headSha: "covering-head-202",
+        }),
+      },
+      comments: {
+        101: [comment("alice", "PR A keeps legacy config behavior intact.")],
+        202: [comment("bob", "PR B carries forward the legacy config behavior.")],
+      },
+      logPath: paths.ghLogPath,
+    });
+    writeFakeCodex(paths.binDir);
+    fs.mkdirSync(path.dirname(defaultReportPath), { recursive: true });
+    fs.writeFileSync(
+      defaultReportPath,
+      [
+        "---",
+        "number: 202",
+        "pull_head_sha: covering-head-202",
+        "real_behavior_proof_status: sufficient",
+        "---",
+        "",
+        "Report body.",
+        "",
+      ].join("\n"),
+    );
+
+    runApplyResult(paths, { proofDecision: "covered", useDefaultRecordsRoot: true });
+
+    const report = JSON.parse(fs.readFileSync(paths.reportPath, "utf8"));
+    assert.equal(report.actions[0].status, "executed");
+    assert.equal(hasPrCloseCall(paths.ghLogPath), true);
+  } finally {
+    if (!recordsRootExisted) fs.rmSync(defaultRecordsRoot, { recursive: true, force: true });
+    else if (priorReport === null) fs.rmSync(defaultReportPath, { force: true });
+    else fs.writeFileSync(defaultReportPath, priorReport);
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test("repair apply executes PR duplicate close when coverage proof says covered", () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-apply-result-"));
   try {
@@ -1686,6 +1751,7 @@ function runApplyResult(
     proofFailureMessage?: string;
     afterProofPath?: string;
     allowMissingUpdatedAt?: boolean;
+    useDefaultRecordsRoot?: boolean;
   },
 ) {
   const args = ["dist/repair/apply-result.js", paths.jobPath, paths.resultPath];
@@ -1697,7 +1763,7 @@ function runApplyResult(
       CLAWSWEEPER_ALLOW_EXECUTE: "1",
       CLAWSWEEPER_ALLOWED_OWNER: "openclaw",
       CLAWSWEEPER_MODEL: "model-test",
-      CLAWSWEEPER_RECORDS_ROOT: paths.recordsRoot,
+      ...(options.useDefaultRecordsRoot ? {} : { CLAWSWEEPER_RECORDS_ROOT: paths.recordsRoot }),
       // Coverage instrumentation plus the parallel repair suite can delay this child process.
       // Keep the bound short for a fake binary without making CI depend on a 10-second scheduler window.
       CLAWSWEEPER_PR_CLOSE_COVERAGE_PROOF_TIMEOUT_MS: "30000",

--- a/test/repair/apply-result.test.ts
+++ b/test/repair/apply-result.test.ts
@@ -19,7 +19,11 @@ test("repair apply blocks PR duplicate close when coverage proof keeps the sourc
     });
     writeFakeGh(paths.binDir, {
       issues: {
-        101: issue({ number: 101, title: "Add config validation", pullRequest: true }),
+        101: issue({
+          number: 101,
+          title: "Add config validation",
+          pullRequest: true,
+        }),
         202: issue({
           number: 202,
           title: "Rewrite config validation",
@@ -29,7 +33,11 @@ test("repair apply blocks PR duplicate close when coverage proof keeps the sourc
       },
       pulls: {
         101: pull({ number: 101, title: "Add config validation" }),
-        202: pull({ number: 202, title: "Rewrite config validation" }),
+        202: pull({
+          number: 202,
+          title: "Rewrite config validation",
+          headSha: "covering-head-202",
+        }),
       },
       comments: {
         101: [comment("alice", "PR A keeps legacy config behavior intact.")],
@@ -38,6 +46,7 @@ test("repair apply blocks PR duplicate close when coverage proof keeps the sourc
       logPath: paths.ghLogPath,
     });
     writeFakeCodex(paths.binDir);
+    writeCoveringReport(paths, 202, "covering-head-202");
 
     runApplyResult(paths, { proofDecision: "keep_open" });
 
@@ -63,7 +72,11 @@ test("repair apply blocks stale covering PR refs instead of crashing", () => {
     });
     writeFakeGh(paths.binDir, {
       issues: {
-        101: issue({ number: 101, title: "Add config validation", pullRequest: true }),
+        101: issue({
+          number: 101,
+          title: "Add config validation",
+          pullRequest: true,
+        }),
       },
       pulls: {
         101: pull({ number: 101, title: "Add config validation" }),
@@ -74,6 +87,7 @@ test("repair apply blocks stale covering PR refs instead of crashing", () => {
       logPath: paths.ghLogPath,
     });
     writeFakeCodex(paths.binDir);
+    writeCoveringReport(paths, 202, "covering-head-202");
 
     runApplyResult(paths, { proofDecision: "covered", failIfProofRuns: true });
 
@@ -100,7 +114,11 @@ test("repair apply requeues transient coverage proof setup failures", () => {
     });
     writeFakeGh(paths.binDir, {
       issues: {
-        101: issue({ number: 101, title: "Add config validation", pullRequest: true }),
+        101: issue({
+          number: 101,
+          title: "Add config validation",
+          pullRequest: true,
+        }),
         202: issue({
           number: 202,
           title: "Rewrite config validation",
@@ -110,7 +128,11 @@ test("repair apply requeues transient coverage proof setup failures", () => {
       },
       pulls: {
         101: pull({ number: 101, title: "Add config validation" }),
-        202: pull({ number: 202, title: "Rewrite config validation" }),
+        202: pull({
+          number: 202,
+          title: "Rewrite config validation",
+          headSha: "covering-head-202",
+        }),
       },
       comments: {
         101: [comment("alice", "PR A keeps legacy config behavior intact.")],
@@ -120,6 +142,7 @@ test("repair apply requeues transient coverage proof setup failures", () => {
       logPath: paths.ghLogPath,
     });
     writeFakeCodex(paths.binDir);
+    writeCoveringReport(paths, 202, "covering-head-202");
 
     runApplyResult(paths, { proofDecision: "covered", failIfProofRuns: true });
 
@@ -143,7 +166,11 @@ test("repair apply blocks proof subprocess failures after hydrating valid coveri
     });
     writeFakeGh(paths.binDir, {
       issues: {
-        101: issue({ number: 101, title: "Add config validation", pullRequest: true }),
+        101: issue({
+          number: 101,
+          title: "Add config validation",
+          pullRequest: true,
+        }),
         202: issue({
           number: 202,
           title: "Rewrite config validation",
@@ -153,7 +180,11 @@ test("repair apply blocks proof subprocess failures after hydrating valid coveri
       },
       pulls: {
         101: pull({ number: 101, title: "Add config validation" }),
-        202: pull({ number: 202, title: "Rewrite config validation" }),
+        202: pull({
+          number: 202,
+          title: "Rewrite config validation",
+          headSha: "covering-head-202",
+        }),
       },
       comments: {
         101: [comment("alice", "PR A keeps legacy config behavior intact.")],
@@ -162,6 +193,7 @@ test("repair apply blocks proof subprocess failures after hydrating valid coveri
       logPath: paths.ghLogPath,
     });
     writeFakeCodex(paths.binDir);
+    writeCoveringReport(paths, 202, "covering-head-202");
 
     runApplyResult(paths, {
       proofDecision: "covered",
@@ -191,7 +223,11 @@ test("repair apply blocks F-rated covering PRs before coverage proof", () => {
     });
     writeFakeGh(paths.binDir, {
       issues: {
-        101: issue({ number: 101, title: "Add config validation", pullRequest: true }),
+        101: issue({
+          number: 101,
+          title: "Add config validation",
+          pullRequest: true,
+        }),
         202: issue({
           number: 202,
           title: "Rewrite config validation",
@@ -201,7 +237,11 @@ test("repair apply blocks F-rated covering PRs before coverage proof", () => {
       },
       pulls: {
         101: pull({ number: 101, title: "Add config validation" }),
-        202: pull({ number: 202, title: "Rewrite config validation" }),
+        202: pull({
+          number: 202,
+          title: "Rewrite config validation",
+          headSha: "covering-head-202",
+        }),
       },
       comments: {
         101: [comment("alice", "PR A keeps legacy config behavior intact.")],
@@ -210,6 +250,7 @@ test("repair apply blocks F-rated covering PRs before coverage proof", () => {
       logPath: paths.ghLogPath,
     });
     writeFakeCodex(paths.binDir);
+    writeCoveringReport(paths, 202, "covering-head-202");
 
     runApplyResult(paths, { proofDecision: "covered", failIfProofRuns: true });
 
@@ -235,7 +276,11 @@ test("repair apply compacts PR bodies in coverage proof prompts", () => {
     const longBody = `${"legacy config ".repeat(30)}${unboundedTail}`;
     writeFakeGh(paths.binDir, {
       issues: {
-        101: issue({ number: 101, title: "Add config validation", pullRequest: true }),
+        101: issue({
+          number: 101,
+          title: "Add config validation",
+          pullRequest: true,
+        }),
         202: issue({
           number: 202,
           title: "Rewrite config validation",
@@ -244,8 +289,18 @@ test("repair apply compacts PR bodies in coverage proof prompts", () => {
         }),
       },
       pulls: {
-        101: { ...pull({ number: 101, title: "Add config validation" }), body: longBody },
-        202: { ...pull({ number: 202, title: "Rewrite config validation" }), body: longBody },
+        101: {
+          ...pull({ number: 101, title: "Add config validation" }),
+          body: longBody,
+        },
+        202: {
+          ...pull({
+            number: 202,
+            title: "Rewrite config validation",
+            headSha: "covering-head-202",
+          }),
+          body: longBody,
+        },
       },
       comments: {
         101: [comment("alice", "PR A keeps legacy config behavior intact.")],
@@ -254,6 +309,7 @@ test("repair apply compacts PR bodies in coverage proof prompts", () => {
       logPath: paths.ghLogPath,
     });
     writeFakeCodex(paths.binDir);
+    writeCoveringReport(paths, 202, "covering-head-202");
 
     runApplyResult(paths, {
       proofDecision: "covered",
@@ -278,7 +334,11 @@ test("repair apply filters automation comments from coverage proof prompts", () 
     });
     writeFakeGh(paths.binDir, {
       issues: {
-        101: issue({ number: 101, title: "Add config validation", pullRequest: true }),
+        101: issue({
+          number: 101,
+          title: "Add config validation",
+          pullRequest: true,
+        }),
         202: issue({
           number: 202,
           title: "Rewrite config validation",
@@ -288,7 +348,11 @@ test("repair apply filters automation comments from coverage proof prompts", () 
       },
       pulls: {
         101: pull({ number: 101, title: "Add config validation" }),
-        202: pull({ number: 202, title: "Rewrite config validation" }),
+        202: pull({
+          number: 202,
+          title: "Rewrite config validation",
+          headSha: "covering-head-202",
+        }),
       },
       comments: {
         101: [
@@ -317,6 +381,7 @@ test("repair apply filters automation comments from coverage proof prompts", () 
       logPath: paths.ghLogPath,
     });
     writeFakeCodex(paths.binDir);
+    writeCoveringReport(paths, 202, "covering-head-202");
 
     runApplyResult(paths, {
       proofDecision: "covered",
@@ -398,7 +463,11 @@ for (const scenario of [
       const paths = writeApplyFixture(tmp, scenario.action);
       writeFakeGh(paths.binDir, {
         issues: {
-          101: issue({ number: 101, title: "Add config validation", pullRequest: true }),
+          101: issue({
+            number: 101,
+            title: "Add config validation",
+            pullRequest: true,
+          }),
           202: issue({
             number: 202,
             title: "Rewrite config validation",
@@ -412,6 +481,7 @@ for (const scenario of [
             number: 202,
             title: "Rewrite config validation",
             mergedAt: scenario.mergedCandidate ? "2026-05-26T00:00:00Z" : undefined,
+            headSha: "covering-head-202",
           }),
         },
         comments: {
@@ -421,6 +491,7 @@ for (const scenario of [
         logPath: paths.ghLogPath,
       });
       writeFakeCodex(paths.binDir);
+      writeCoveringReport(paths, 202, "covering-head-202");
 
       runApplyResult(paths, { proofDecision: "keep_open" });
 
@@ -448,18 +519,30 @@ test("repair apply checks superseded candidate PR coverage before canonical issu
     });
     writeFakeGh(paths.binDir, {
       issues: {
-        101: issue({ number: 101, title: "Add config validation", pullRequest: true }),
+        101: issue({
+          number: 101,
+          title: "Add config validation",
+          pullRequest: true,
+        }),
         202: issue({
           number: 202,
           title: "Rewrite config validation",
           pullRequest: true,
           labels: ["proof: sufficient"],
         }),
-        303: issue({ number: 303, title: "Tracking issue", pullRequest: false }),
+        303: issue({
+          number: 303,
+          title: "Tracking issue",
+          pullRequest: false,
+        }),
       },
       pulls: {
         101: pull({ number: 101, title: "Add config validation" }),
-        202: pull({ number: 202, title: "Rewrite config validation" }),
+        202: pull({
+          number: 202,
+          title: "Rewrite config validation",
+          headSha: "covering-head-202",
+        }),
       },
       comments: {
         101: [comment("alice", "PR A keeps legacy config behavior intact.")],
@@ -469,6 +552,7 @@ test("repair apply checks superseded candidate PR coverage before canonical issu
       logPath: paths.ghLogPath,
     });
     writeFakeCodex(paths.binDir);
+    writeCoveringReport(paths, 202, "covering-head-202");
 
     runApplyResult(paths, { proofDecision: "keep_open" });
 
@@ -494,7 +578,11 @@ test("repair apply bounds covering PR comments when issue comment count is absen
     });
     writeFakeGh(paths.binDir, {
       issues: {
-        101: issue({ number: 101, title: "Add config validation", pullRequest: true }),
+        101: issue({
+          number: 101,
+          title: "Add config validation",
+          pullRequest: true,
+        }),
         202: issue({
           number: 202,
           title: "Rewrite config validation",
@@ -504,7 +592,11 @@ test("repair apply bounds covering PR comments when issue comment count is absen
       },
       pulls: {
         101: pull({ number: 101, title: "Add config validation" }),
-        202: pull({ number: 202, title: "Rewrite config validation" }),
+        202: pull({
+          number: 202,
+          title: "Rewrite config validation",
+          headSha: "covering-head-202",
+        }),
       },
       comments: {
         101: [comment("alice", "PR A keeps legacy config behavior intact.")],
@@ -521,6 +613,7 @@ test("repair apply bounds covering PR comments when issue comment count is absen
       logPath: paths.ghLogPath,
     });
     writeFakeCodex(paths.binDir);
+    writeCoveringReport(paths, 202, "covering-head-202");
 
     runApplyResult(paths, {
       proofDecision: "covered",
@@ -562,7 +655,11 @@ test("repair apply blocks PR close when open covering PR lacks positive proof", 
     });
     writeFakeGh(paths.binDir, {
       issues: {
-        101: issue({ number: 101, title: "Add config validation", pullRequest: true }),
+        101: issue({
+          number: 101,
+          title: "Add config validation",
+          pullRequest: true,
+        }),
         202: issue({
           number: 202,
           title: "Rewrite config validation",
@@ -572,7 +669,11 @@ test("repair apply blocks PR close when open covering PR lacks positive proof", 
       },
       pulls: {
         101: pull({ number: 101, title: "Add config validation" }),
-        202: pull({ number: 202, title: "Rewrite config validation" }),
+        202: pull({
+          number: 202,
+          title: "Rewrite config validation",
+          headSha: "covering-head-202",
+        }),
       },
       comments: {
         101: [comment("alice", "PR A keeps legacy config behavior intact.")],
@@ -581,6 +682,7 @@ test("repair apply blocks PR close when open covering PR lacks positive proof", 
       logPath: paths.ghLogPath,
     });
     writeFakeCodex(paths.binDir);
+    writeCoveringReport(paths, 202, "covering-head-202");
 
     runApplyResult(paths, { proofDecision: "covered", failIfProofRuns: true });
 
@@ -599,7 +701,153 @@ test("repair apply blocks PR close when open covering PR lacks positive proof", 
   }
 });
 
-test("repair apply executes PR duplicate close when coverage proof says covered", () => {
+test("repair apply blocks PR close when covering proof label lacks a head-fresh report", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-apply-result-"));
+  try {
+    const paths = writeApplyFixture(tmp, {
+      action: "close_duplicate",
+      classification: "duplicate",
+      canonical: "#202",
+    });
+    writeFakeGh(paths.binDir, {
+      issues: {
+        101: issue({ number: 101, title: "Add config validation", pullRequest: true }),
+        202: issue({
+          number: 202,
+          title: "Rewrite config validation",
+          pullRequest: true,
+          labels: ["proof: sufficient"],
+        }),
+      },
+      pulls: {
+        101: pull({ number: 101, title: "Add config validation" }),
+        202: pull({
+          number: 202,
+          title: "Rewrite config validation",
+          headSha: "covering-head-202",
+        }),
+      },
+      comments: {
+        101: [comment("alice", "PR A keeps legacy config behavior intact.")],
+        202: [comment("bob", "PR B carries forward the legacy config behavior.")],
+      },
+      logPath: paths.ghLogPath,
+    });
+    writeFakeCodex(paths.binDir);
+    writeCoveringReport(paths, 202, "covering-old-head-202");
+
+    runApplyResult(paths, { proofDecision: "covered", failIfProofRuns: true });
+
+    const report = JSON.parse(fs.readFileSync(paths.reportPath, "utf8"));
+    assert.equal(report.actions[0].status, "blocked");
+    assert.equal(
+      report.actions[0].reason,
+      "linked canonical PR #202 real behavior proof is not verified at its current head",
+    );
+    assert.equal(hasPrCloseCall(paths.ghLogPath), false);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("repair apply blocks PR close when the head-fresh report does not confirm proof", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-apply-result-"));
+  try {
+    const paths = writeApplyFixture(tmp, {
+      action: "close_duplicate",
+      classification: "duplicate",
+      canonical: "#202",
+    });
+    writeFakeGh(paths.binDir, {
+      issues: {
+        101: issue({ number: 101, title: "Add config validation", pullRequest: true }),
+        202: issue({
+          number: 202,
+          title: "Rewrite config validation",
+          pullRequest: true,
+          labels: ["proof: sufficient"],
+        }),
+      },
+      pulls: {
+        101: pull({ number: 101, title: "Add config validation" }),
+        202: pull({
+          number: 202,
+          title: "Rewrite config validation",
+          headSha: "covering-head-202",
+        }),
+      },
+      comments: {
+        101: [comment("alice", "PR A keeps legacy config behavior intact.")],
+        202: [comment("bob", "PR B carries forward the legacy config behavior.")],
+      },
+      logPath: paths.ghLogPath,
+    });
+    writeFakeCodex(paths.binDir);
+    writeCoveringReport(paths, 202, "covering-head-202", "insufficient");
+
+    runApplyResult(paths, { proofDecision: "covered", failIfProofRuns: true });
+
+    const report = JSON.parse(fs.readFileSync(paths.reportPath, "utf8"));
+    assert.equal(report.actions[0].status, "blocked");
+    assert.equal(
+      report.actions[0].reason,
+      "linked canonical PR #202 real behavior proof is not verified at its current head",
+    );
+    assert.equal(hasPrCloseCall(paths.ghLogPath), false);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("repair apply blocks PR close when covering proof label has no report at all", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-apply-result-"));
+  try {
+    const paths = writeApplyFixture(tmp, {
+      action: "close_duplicate",
+      classification: "duplicate",
+      canonical: "#202",
+    });
+    writeFakeGh(paths.binDir, {
+      issues: {
+        101: issue({ number: 101, title: "Add config validation", pullRequest: true }),
+        202: issue({
+          number: 202,
+          title: "Rewrite config validation",
+          pullRequest: true,
+          labels: ["proof: sufficient"],
+        }),
+      },
+      pulls: {
+        101: pull({ number: 101, title: "Add config validation" }),
+        202: pull({
+          number: 202,
+          title: "Rewrite config validation",
+          headSha: "covering-head-202",
+        }),
+      },
+      comments: {
+        101: [comment("alice", "PR A keeps legacy config behavior intact.")],
+        202: [comment("bob", "PR B carries forward the legacy config behavior.")],
+      },
+      logPath: paths.ghLogPath,
+    });
+    writeFakeCodex(paths.binDir);
+
+    runApplyResult(paths, { proofDecision: "covered", failIfProofRuns: true });
+
+    const report = JSON.parse(fs.readFileSync(paths.reportPath, "utf8"));
+    assert.equal(report.actions[0].status, "blocked");
+    assert.equal(
+      report.actions[0].reason,
+      "linked canonical PR #202 real behavior proof is not verified at its current head",
+    );
+    assert.equal(hasPrCloseCall(paths.ghLogPath), false);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("repair apply blocks PR close when the covering PR head is unknown", () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-apply-result-"));
   try {
     const paths = writeApplyFixture(tmp, {
@@ -628,6 +876,104 @@ test("repair apply executes PR duplicate close when coverage proof says covered"
       logPath: paths.ghLogPath,
     });
     writeFakeCodex(paths.binDir);
+    writeCoveringReport(paths, 202, "covering-head-202");
+
+    runApplyResult(paths, { proofDecision: "covered", failIfProofRuns: true });
+
+    const report = JSON.parse(fs.readFileSync(paths.reportPath, "utf8"));
+    assert.equal(report.actions[0].status, "blocked");
+    assert.equal(
+      report.actions[0].reason,
+      "linked canonical PR #202 real behavior proof is not verified at its current head",
+    );
+    assert.equal(hasPrCloseCall(paths.ghLogPath), false);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("repair apply executes PR duplicate close when the covering PR has a human proof override", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-apply-result-"));
+  try {
+    const paths = writeApplyFixture(tmp, {
+      action: "close_duplicate",
+      classification: "duplicate",
+      canonical: "#202",
+    });
+    writeFakeGh(paths.binDir, {
+      issues: {
+        101: issue({ number: 101, title: "Add config validation", pullRequest: true }),
+        202: issue({
+          number: 202,
+          title: "Rewrite config validation",
+          pullRequest: true,
+          labels: ["proof: override"],
+        }),
+      },
+      pulls: {
+        101: pull({ number: 101, title: "Add config validation" }),
+        202: pull({
+          number: 202,
+          title: "Rewrite config validation",
+          headSha: "covering-head-202",
+        }),
+      },
+      comments: {
+        101: [comment("alice", "PR A keeps legacy config behavior intact.")],
+        202: [comment("bob", "PR B carries forward the legacy config behavior.")],
+      },
+      logPath: paths.ghLogPath,
+    });
+    writeFakeCodex(paths.binDir);
+
+    runApplyResult(paths, { proofDecision: "covered" });
+
+    const report = JSON.parse(fs.readFileSync(paths.reportPath, "utf8"));
+    assert.equal(report.actions[0].status, "executed");
+    assert.equal(hasPrCloseCall(paths.ghLogPath), true);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("repair apply executes PR duplicate close when coverage proof says covered", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-apply-result-"));
+  try {
+    const paths = writeApplyFixture(tmp, {
+      action: "close_duplicate",
+      classification: "duplicate",
+      canonical: "#202",
+    });
+    writeFakeGh(paths.binDir, {
+      issues: {
+        101: issue({
+          number: 101,
+          title: "Add config validation",
+          pullRequest: true,
+        }),
+        202: issue({
+          number: 202,
+          title: "Rewrite config validation",
+          pullRequest: true,
+          labels: ["proof: sufficient"],
+        }),
+      },
+      pulls: {
+        101: pull({ number: 101, title: "Add config validation" }),
+        202: pull({
+          number: 202,
+          title: "Rewrite config validation",
+          headSha: "covering-head-202",
+        }),
+      },
+      comments: {
+        101: [comment("alice", "PR A keeps legacy config behavior intact.")],
+        202: [comment("bob", "PR B carries forward the legacy config behavior.")],
+      },
+      logPath: paths.ghLogPath,
+    });
+    writeFakeCodex(paths.binDir);
+    writeCoveringReport(paths, 202, "covering-head-202");
 
     runApplyResult(paths, { proofDecision: "covered" });
 
@@ -705,7 +1051,11 @@ for (const scenario of [
       const paths = writeApplyFixture(tmp, scenario.action);
       writeFakeGh(paths.binDir, {
         issues: {
-          101: issue({ number: 101, title: "Add config validation", pullRequest: true }),
+          101: issue({
+            number: 101,
+            title: "Add config validation",
+            pullRequest: true,
+          }),
           202: issue({
             number: 202,
             title: "Rewrite config validation",
@@ -719,6 +1069,7 @@ for (const scenario of [
             number: 202,
             title: "Rewrite config validation",
             mergedAt: scenario.mergedCandidate ? "2026-05-26T00:00:00Z" : undefined,
+            headSha: "covering-head-202",
           }),
         },
         comments: {
@@ -728,6 +1079,7 @@ for (const scenario of [
         logPath: paths.ghLogPath,
       });
       writeFakeCodex(paths.binDir);
+      writeCoveringReport(paths, 202, "covering-head-202");
 
       runApplyResult(paths, { proofDecision: "covered" });
 
@@ -755,7 +1107,11 @@ test("repair apply rechecks target freshness after coverage proof passes", () =>
     const afterProofPath = path.join(tmp, "proof-ran");
     writeFakeGh(paths.binDir, {
       issues: {
-        101: issue({ number: 101, title: "Add config validation", pullRequest: true }),
+        101: issue({
+          number: 101,
+          title: "Add config validation",
+          pullRequest: true,
+        }),
         202: issue({
           number: 202,
           title: "Rewrite config validation",
@@ -765,7 +1121,11 @@ test("repair apply rechecks target freshness after coverage proof passes", () =>
       },
       pulls: {
         101: pull({ number: 101, title: "Add config validation" }),
-        202: pull({ number: 202, title: "Rewrite config validation" }),
+        202: pull({
+          number: 202,
+          title: "Rewrite config validation",
+          headSha: "covering-head-202",
+        }),
       },
       comments: {
         101: [comment("alice", "PR A keeps legacy config behavior intact.")],
@@ -778,6 +1138,7 @@ test("repair apply rechecks target freshness after coverage proof passes", () =>
       logPath: paths.ghLogPath,
     });
     writeFakeCodex(paths.binDir);
+    writeCoveringReport(paths, 202, "covering-head-202");
 
     runApplyResult(paths, { proofDecision: "covered", afterProofPath });
 
@@ -803,7 +1164,11 @@ test("repair apply rechecks covering PR safety after coverage proof passes", () 
     const afterProofPath = path.join(tmp, "proof-ran");
     writeFakeGh(paths.binDir, {
       issues: {
-        101: issue({ number: 101, title: "Add config validation", pullRequest: true }),
+        101: issue({
+          number: 101,
+          title: "Add config validation",
+          pullRequest: true,
+        }),
         202: issue({
           number: 202,
           title: "Rewrite config validation",
@@ -813,7 +1178,11 @@ test("repair apply rechecks covering PR safety after coverage proof passes", () 
       },
       pulls: {
         101: pull({ number: 101, title: "Add config validation" }),
-        202: pull({ number: 202, title: "Rewrite config validation" }),
+        202: pull({
+          number: 202,
+          title: "Rewrite config validation",
+          headSha: "covering-head-202",
+        }),
       },
       comments: {
         101: [comment("alice", "PR A keeps legacy config behavior intact.")],
@@ -831,6 +1200,7 @@ test("repair apply rechecks covering PR safety after coverage proof passes", () 
       logPath: paths.ghLogPath,
     });
     writeFakeCodex(paths.binDir);
+    writeCoveringReport(paths, 202, "covering-head-202");
 
     runApplyResult(paths, { proofDecision: "covered", afterProofPath });
 
@@ -857,7 +1227,11 @@ test("repair apply rechecks covering PR freshness after coverage proof passes", 
     const afterProofPath = path.join(tmp, "proof-ran");
     writeFakeGh(paths.binDir, {
       issues: {
-        101: issue({ number: 101, title: "Add config validation", pullRequest: true }),
+        101: issue({
+          number: 101,
+          title: "Add config validation",
+          pullRequest: true,
+        }),
         202: issue({
           number: 202,
           title: "Rewrite config validation",
@@ -867,7 +1241,11 @@ test("repair apply rechecks covering PR freshness after coverage proof passes", 
       },
       pulls: {
         101: pull({ number: 101, title: "Add config validation" }),
-        202: pull({ number: 202, title: "Rewrite config validation" }),
+        202: pull({
+          number: 202,
+          title: "Rewrite config validation",
+          headSha: "covering-head-202",
+        }),
       },
       comments: {
         101: [comment("alice", "PR A keeps legacy config behavior intact.")],
@@ -883,6 +1261,7 @@ test("repair apply rechecks covering PR freshness after coverage proof passes", 
       logPath: paths.ghLogPath,
     });
     writeFakeCodex(paths.binDir);
+    writeCoveringReport(paths, 202, "covering-head-202");
 
     runApplyResult(paths, { proofDecision: "covered", afterProofPath });
 
@@ -907,7 +1286,11 @@ test("repair apply requeues transient post-proof covering PR safety failures", (
     const afterProofPath = path.join(tmp, "proof-ran");
     writeFakeGh(paths.binDir, {
       issues: {
-        101: issue({ number: 101, title: "Add config validation", pullRequest: true }),
+        101: issue({
+          number: 101,
+          title: "Add config validation",
+          pullRequest: true,
+        }),
         202: issue({
           number: 202,
           title: "Rewrite config validation",
@@ -917,7 +1300,11 @@ test("repair apply requeues transient post-proof covering PR safety failures", (
       },
       pulls: {
         101: pull({ number: 101, title: "Add config validation" }),
-        202: pull({ number: 202, title: "Rewrite config validation" }),
+        202: pull({
+          number: 202,
+          title: "Rewrite config validation",
+          headSha: "covering-head-202",
+        }),
       },
       comments: {
         101: [comment("alice", "PR A keeps legacy config behavior intact.")],
@@ -928,6 +1315,7 @@ test("repair apply requeues transient post-proof covering PR safety failures", (
       logPath: paths.ghLogPath,
     });
     writeFakeCodex(paths.binDir);
+    writeCoveringReport(paths, 202, "covering-head-202");
 
     runApplyResult(paths, { proofDecision: "covered", afterProofPath });
 
@@ -953,7 +1341,11 @@ test("repair apply skips target closed after proof when updated_at is missing", 
     const afterProofPath = path.join(tmp, "proof-ran");
     writeFakeGh(paths.binDir, {
       issues: {
-        101: issue({ number: 101, title: "Add config validation", pullRequest: true }),
+        101: issue({
+          number: 101,
+          title: "Add config validation",
+          pullRequest: true,
+        }),
         202: issue({
           number: 202,
           title: "Rewrite config validation",
@@ -963,7 +1355,11 @@ test("repair apply skips target closed after proof when updated_at is missing", 
       },
       pulls: {
         101: pull({ number: 101, title: "Add config validation" }),
-        202: pull({ number: 202, title: "Rewrite config validation" }),
+        202: pull({
+          number: 202,
+          title: "Rewrite config validation",
+          headSha: "covering-head-202",
+        }),
       },
       comments: {
         101: [comment("alice", "PR A keeps legacy config behavior intact.")],
@@ -981,6 +1377,7 @@ test("repair apply skips target closed after proof when updated_at is missing", 
       logPath: paths.ghLogPath,
     });
     writeFakeCodex(paths.binDir);
+    writeCoveringReport(paths, 202, "covering-head-202");
 
     runApplyResult(paths, {
       proofDecision: "covered",
@@ -1013,11 +1410,19 @@ test("repair apply treats already-closed PR duplicate close as idempotent before
           pullRequest: true,
           state: "closed",
         }),
-        202: issue({ number: 202, title: "Rewrite config validation", pullRequest: true }),
+        202: issue({
+          number: 202,
+          title: "Rewrite config validation",
+          pullRequest: true,
+        }),
       },
       pulls: {
         101: pull({ number: 101, title: "Add config validation" }),
-        202: pull({ number: 202, title: "Rewrite config validation" }),
+        202: pull({
+          number: 202,
+          title: "Rewrite config validation",
+          headSha: "covering-head-202",
+        }),
       },
       comments: {
         101: [
@@ -1035,8 +1440,12 @@ test("repair apply treats already-closed PR duplicate close as idempotent before
       logPath: paths.ghLogPath,
     });
     writeFakeCodex(paths.binDir);
+    writeCoveringReport(paths, 202, "covering-head-202");
 
-    runApplyResult(paths, { proofDecision: "keep_open", failIfProofRuns: true });
+    runApplyResult(paths, {
+      proofDecision: "keep_open",
+      failIfProofRuns: true,
+    });
 
     const report = JSON.parse(fs.readFileSync(paths.reportPath, "utf8"));
     assert.equal(report.actions[0].status, "executed");
@@ -1060,11 +1469,23 @@ test("repair apply leaves issue duplicate close behavior unchanged", () => {
     });
     writeFakeGh(paths.binDir, {
       issues: {
-        101: issue({ number: 101, title: "Add config validation", pullRequest: false }),
-        202: issue({ number: 202, title: "Rewrite config validation", pullRequest: true }),
+        101: issue({
+          number: 101,
+          title: "Add config validation",
+          pullRequest: false,
+        }),
+        202: issue({
+          number: 202,
+          title: "Rewrite config validation",
+          pullRequest: true,
+        }),
       },
       pulls: {
-        202: pull({ number: 202, title: "Rewrite config validation" }),
+        202: pull({
+          number: 202,
+          title: "Rewrite config validation",
+          headSha: "covering-head-202",
+        }),
       },
       comments: {
         101: [comment("alice", "Issue A is duplicated by PR B.")],
@@ -1073,6 +1494,7 @@ test("repair apply leaves issue duplicate close behavior unchanged", () => {
       logPath: paths.ghLogPath,
     });
     writeFakeCodex(paths.binDir);
+    writeCoveringReport(paths, 202, "covering-head-202");
 
     runApplyResult(paths, { proofDecision: "keep_open" });
 
@@ -1097,7 +1519,11 @@ test("repair apply leaves current-main fixed closeout outside coverage proof", (
     });
     writeFakeGh(paths.binDir, {
       issues: {
-        101: issue({ number: 101, title: "Add config validation", pullRequest: true }),
+        101: issue({
+          number: 101,
+          title: "Add config validation",
+          pullRequest: true,
+        }),
       },
       pulls: {
         101: pull({ number: 101, title: "Add config validation" }),
@@ -1108,6 +1534,7 @@ test("repair apply leaves current-main fixed closeout outside coverage proof", (
       logPath: paths.ghLogPath,
     });
     writeFakeCodex(paths.binDir);
+    writeCoveringReport(paths, 202, "covering-head-202");
 
     runApplyResult(paths, { proofDecision: "covered", failIfProofRuns: true });
 
@@ -1126,6 +1553,7 @@ type ApplyFixturePaths = {
   resultPath: string;
   reportPath: string;
   ghLogPath: string;
+  recordsRoot: string;
 };
 
 type ApplyFixtureAction = {
@@ -1161,8 +1589,10 @@ function writeApplyFixture(tmp: string, action: ApplyFixtureAction): ApplyFixtur
   const resultPath = path.join(runDir, "result.json");
   const reportPath = path.join(runDir, "apply-report.json");
   const ghLogPath = path.join(tmp, "gh.log");
+  const recordsRoot = path.join(tmp, "records");
   fs.mkdirSync(binDir, { recursive: true });
   fs.mkdirSync(runDir, { recursive: true });
+  fs.mkdirSync(recordsRoot, { recursive: true });
   fs.writeFileSync(
     jobPath,
     [
@@ -1220,7 +1650,30 @@ function writeApplyFixture(tmp: string, action: ApplyFixtureAction): ApplyFixtur
       2,
     ),
   );
-  return { binDir, jobPath, resultPath, reportPath, ghLogPath };
+  return { binDir, jobPath, resultPath, reportPath, ghLogPath, recordsRoot };
+}
+
+function writeCoveringReport(
+  paths: ApplyFixturePaths,
+  number: number,
+  headSha: string,
+  proofStatus = "sufficient",
+) {
+  const itemsDir = path.join(paths.recordsRoot, "openclaw-openclaw", "items");
+  fs.mkdirSync(itemsDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(itemsDir, `${number}.md`),
+    [
+      "---",
+      `number: ${number}`,
+      `pull_head_sha: ${headSha}`,
+      `real_behavior_proof_status: ${proofStatus}`,
+      "---",
+      "",
+      "Report body.",
+      "",
+    ].join("\n"),
+  );
 }
 
 function runApplyResult(
@@ -1244,6 +1697,7 @@ function runApplyResult(
       CLAWSWEEPER_ALLOW_EXECUTE: "1",
       CLAWSWEEPER_ALLOWED_OWNER: "openclaw",
       CLAWSWEEPER_MODEL: "model-test",
+      CLAWSWEEPER_RECORDS_ROOT: paths.recordsRoot,
       // Coverage instrumentation plus the parallel repair suite can delay this child process.
       // Keep the bound short for a fake binary without making CI depend on a 10-second scheduler window.
       CLAWSWEEPER_PR_CLOSE_COVERAGE_PROOF_TIMEOUT_MS: "30000",
@@ -1493,7 +1947,7 @@ function issue(options: {
   };
 }
 
-function pull(options: { number: number; title: string; mergedAt?: string }) {
+function pull(options: { number: number; title: string; mergedAt?: string; headSha?: string }) {
   return {
     number: options.number,
     title: options.title,
@@ -1503,6 +1957,7 @@ function pull(options: { number: number; title: string; mergedAt?: string }) {
     merged_at: options.mergedAt ?? null,
     body: `${options.title} body.`,
     updated_at: "2026-05-25T00:00:00Z",
+    ...(options.headSha ? { head: { sha: options.headSha } } : {}),
   };
 }
 


### PR DESCRIPTION
## Summary

Rework of this PR per maintainer direction (https://github.com/openclaw/clawsweeper/pull/435#issuecomment): the previous `reproduce-proof` execution and attestation lane is gone entirely. ClawSweeper keeps its boundary of requesting, describing, reviewing, routing, and gating on proof, and never executes proof commands. This rework instead reduces trust in model-derived proof labels at the exact point where they gate a destructive action.

## The trust gap

The `proof: sufficient` label is model-derived: the review model emits `RealBehaviorProof.status`, and deterministic code writes the label. The label write side is already head-gated (the stale-review sweep strips ClawSweeper labels when a PR's head changes, and label restore requires a fresh-head review), and automerge is already pinned to exact-head trusted review markers. But the two close-safety readers were not:

- `validatePrCloseCoverageCoveringSafety` (`src/repair/apply-result.ts`) accepted `proof: sufficient` from the covering PR's live GitHub labels with no head check.
- `unsafeCanonicalPullRequestReason` (`src/clawsweeper.ts`) accepted the same label from the linked canonical PR, and also accepted a stored review report claiming sufficient proof without comparing the report's `pull_head_sha` to the linked PR's live head.

So a canonical PR could earn `proof: sufficient` at head A, push head B (GitHub keeps the label; ClawSweeper only strips it when it next reprocesses that PR), and the stale judgment still admitted closing sibling PRs as duplicate or superseded.

## Production incidence

This is not a theoretical race. Mining the durable records (clawsweeper-state, `state` branch) against live GitHub timelines: of the 396 applied `duplicate_or_superseded` PR closes on openclaw/openclaw to date, five closed a sibling while the canonical PR's proof evidence was pinned to a head that no longer existed. Each candidate was verified against the state repo's per-file commit history (the canonical's last `reviewed_at`/`pull_head_sha` before the close) and the canonical's timeline (`head_ref_force_pushed` events carry the new commit id).

| closed sibling | canonical | canonical's last review before close | head changed | close applied | staleness at close |
|---|---|---|---|---|---|
| openclaw/openclaw#96829 | #96503 | 2026-06-25 00:59 UTC at `8de6279d1b32` | force-push 2026-06-25 01:26 to `0e1566d8bdbe` | 2026-06-25 16:56 | ~15.5 h |
| openclaw/openclaw#97474 | #96503 | same | same | 2026-06-28 10:49 | ~3.4 days |
| openclaw/openclaw#97755 | #96503 | same | same | 2026-06-29 11:38 | ~4.4 days |
| openclaw/openclaw#100652 | #99419 | 2026-07-03 08:00 at `eeaf502cc582` | push 2026-07-05 02:22 | 2026-07-06 06:25 | ~28 h |
| openclaw/openclaw#100503 | #100482 | 2026-07-06 00:19 | push 2026-07-06 00:29 | 2026-07-06 00:49 | 20 min |

The #96503 case anchors three of the five: it earned `proof: sufficient` at 00:53, was force-pushed 33 minutes later, was never re-reviewed at the new head, and kept the label for 11 days; during that window three sibling PRs were closed with close records that explicitly cite it as "proof-positive" with "sufficient real behavior proof" (`records/openclaw-openclaw/closed/97474.md`, `root_cause_cluster.canonicalRef`). The #100503 case shows the other extreme: a 20 minute review-to-push gap was enough to be consumed.

The window is structural, not re-review latency:

- openclaw/openclaw#96480 carried a stale `proof: sufficient` for ~40 hours after a 2026-07-05 force-push, including a final 2h05m stretch after a completed fresh-head review had already recorded `real_behavior_proof_status: insufficient` (the label side outvoting a fresh insufficient report, the sibling gap this patch also closes). Six records in the archive show that label/report divergence: openclaw#96480, #77904, #95065, #90628, #86010, telecrawl#9.
- `sweep.yml` runs apply-existing on cron four times per hour, decoupled from review sweeps, and its changed-since-review skip covers the item being closed, not the canonical whose labels the gate reads. 181 apply actions ran inside #96480's single stale window.
- The stored-report side has failed the same way: openclaw#97756 was closed 2026-06-29 against canonical #96300 while the newest stored record for #96300 was pinned to a head replaced a day earlier (a fresher review existed but was overwritten by a stale record write two minutes later).

All five outcomes were plausibly benign, which is luck, not a gate: the judgment consumed at close time described code that was no longer in the PR.

## The change

A model-derived proof signal now clears close-safety only when a ClawSweeper review report exists at the linked or covering PR's current head SHA:

- `src/clawsweeper.ts`: `LinkedPullRequestSupersession` gains `headSha` (populated from the pulls API object both constructors already fetch). In `unsafeCanonicalPullRequestReason`, the report side passes only when `pullHeadShaFromReport(report)` equals the live head, and the label side passes only when backed by that same head-fresh report. A stale report still contributes blocking evidence (proposed-for-close, insufficient status, F-rating); it just no longer contributes passing evidence. This also closes the sibling gap where a fresh report saying insufficient was overridden by a lingering sufficient label.
- `src/repair/apply-result.ts`: the covering-safety gate accepts `proof: sufficient` only when `coveringReviewReportAtHead` finds `records/<slug>/{items,closed}/<n>.md` whose `pull_head_sha` front matter equals the covering PR's live `head.sha` (`unknown` rejected) and whose `real_behavior_proof_status` front matter is `sufficient` or `override`, so a head-fresh report that judged the proof insufficient cannot be outvoted by a lingering label. The slug uses the same normalization as the review-lane record writer. `CLAWSWEEPER_RECORDS_ROOT` overrides the records root so the test harness can point the applicator at fixture records; production behavior without the variable is unchanged (`repoRoot()/records`).

The human `proof: override` label keeps working exactly as before in both gates. Every failure mode is fail-closed to a blocked close with a distinct reason, `linked canonical PR #N real behavior proof is not verified at its current head`, so a blocked close is the worst outcome; nothing is ever closed on a stale or unverifiable signal.

- `.github/workflows/repair-cluster-worker.yml`: the execute job's state checkout now hydrates `records` alongside `jobs` (same `setup-state` mechanism the sweep and proof-nudge lanes already use with full state), so `repair:apply-result` finds the durable review records at `repoRoot()/records` in production instead of fail-closing every label-backed covering close for want of a local record.
- Both gates parse the durable review metadata from the record's YAML front matter only. Previously the key lookups ran a multiline regex over the whole record file, so a `pull_head_sha:` or `real_behavior_proof_status:` line appearing in the record body (model-emitted prose, quoted PR content) could satisfy the head-fresh check when the front matter carried no such key. `pullHeadShaFromReport` and the canonical gate's proof-status read now go through a front-matter-scoped lookup in `src/clawsweeper.ts`, and `coveringReviewReportAtHead` in `src/repair/apply-result.ts` matches both keys inside the leading `---` block only. The record writer has always emitted these keys in front matter, so no valid record changes outcome.

## Deliberately unchanged

- Proof-nudge and bot-proof label exemptions: a stale label there only suppresses reminder comments, never admits a close.
- Label write side and stale-review label sweep (already head-gated), automerge readiness (already head-pinned), covering freshness recheck (updated_at based, orthogonal), dashboards (display only).
- No new lane, no subcommand, no schema change, no prompt change, no command execution anywhere.

## Tests

- `test/apply-pr-supersession-safety.test.ts`: the old test "promotes PRs when live proof labels supersede stale linked reports" asserted exactly the trust gap this PR removes; it is flipped to the blocked case (live sufficient label, report at an old head, promotion refused). New tests cover fresh-head report promoted, human override promoted, and label-with-no-report blocked.
- `test/repair/apply-result.test.ts`: new covering-safety tests for stale-head report, head-fresh report with insufficient status, no report, unknown covering head (all blocked with the new reason) and human override (executed). Existing covering-PR fixtures gain `head.sha` plus a head-fresh sufficient report record, which is the new minimum for a label-cleared close. A dedicated test also exercises the production records-root path: with `CLAWSWEEPER_RECORDS_ROOT` unset, the applicator reads the covering report from the default `repoRoot()/records/<slug>/items/<n>.md` location (the layout the worker hydration produces) and executes the close.
- `test/apply-pr-promotion.test.ts` and `test/apply-same-author-pair-close.test.ts`: canonical-PR fixtures updated the same way.
- Spoof regression tests in both lanes: a record whose front matter says `real_behavior_proof_status: insufficient` with no `pull_head_sha`, but whose body contains spoofed `pull_head_sha: <live head>` and `real_behavior_proof_status: sufficient` lines, is refused by both gates. Both tests fail on the pre-hardening code (the body lines satisfied the whole-file regex and admitted the close) and pass with front-matter-only parsing.

## Verification

- `pnpm run check` (check:active-surface, check:limits, build:all, lint, test:unit, test:repair, coverage, format:check) passes end to end on Node 24.

## Real behavior proof

Behavior addressed: both close-safety gates trusted a model-derived `proof: sufficient` label from a linked or covering PR without verifying the judgment was made at that PR's current head, so a stale label admitted duplicate/superseded closes; after this patch the close is blocked unless a review report exists at the live head, while head-fresh proof and human overrides keep closing.
Real environment tested: the real `dist/clawsweeper.js apply-decisions` CLI and the real `dist/repair/apply-result.js` applicator on this Linux host, built with the repo toolchain, driven against a scripted `gh` backend (`GH_BIN`) and a scripted coverage-proof model (`CODEX_BIN`, `PATH`), with real report records on disk; compared against pristine main `9b7281103a` built the same way, on byte-identical fixture inputs. Nothing inside the changed code paths was mocked.
Exact steps or command run after this patch: a driver provisions items records for source PR 342 (superseded by PR 400) and canonical PR 400, serves PR 400 with live head `1111111d0c77` and label `proof: sufficient` (or `proof: override`), varies only the 400 report's `pull_head_sha` (`0000000a9e55` stale vs `1111111d0c77` fresh, absent for override) and its proof status (`sufficient` vs `insufficient`), then runs `node dist/clawsweeper.js apply-decisions --target-repo openclaw/openclaw --items-dir ... --item-numbers 342 --dry-run --apply-kind all`; a second driver does the same for `node dist/repair/apply-result.js job.md result.json` with a `close_duplicate` action whose covering PR 202 carries the same head/label/report matrix.
Evidence after fix:

```
# apply-decisions lane (unsafeCanonicalPullRequestReason)
# BEFORE (pristine main 9b7281103a): the label alone admits every close
stale        reportHead=0000000a9e55 reportStatus=sufficient    closed=true
insufficient reportHead=1111111d0c77 reportStatus=insufficient  closed=true
fresh        reportHead=1111111d0c77 reportStatus=sufficient    closed=true
override     reportHead=(no report)                             closed=true

# AFTER (this patch): only verified proof or a human override closes
stale        reportHead=0000000a9e55 reportStatus=sufficient    closed=false
insufficient reportHead=1111111d0c77 reportStatus=insufficient  closed=false
fresh        reportHead=1111111d0c77 reportStatus=sufficient    closed=true
override     reportHead=(no report)                             closed=true

# repair applicator lane (validatePrCloseCoverageCoveringSafety)
# BEFORE (pristine main 9b7281103a): all four execute the close and issue gh pr close
stale:        actionStatus=executed  ghPrCloseIssued=true
insufficient: actionStatus=executed  ghPrCloseIssued=true
fresh:        actionStatus=executed  ghPrCloseIssued=true
override:     actionStatus=executed  ghPrCloseIssued=true

# AFTER (this patch): stale or unconfirmed judgments blocked, no gh pr close issued
stale:        actionStatus=blocked   ghPrCloseIssued=false
insufficient: actionStatus=blocked   ghPrCloseIssued=false
              actionReason=linked canonical PR #202 real behavior proof is not verified at its current head
fresh:        actionStatus=executed  ghPrCloseIssued=true
override:     actionStatus=executed  ghPrCloseIssued=true
```

Observed result after fix: on identical inputs, a `proof: sufficient` label whose backing review was made at an old head, or whose head-fresh review judged the proof insufficient, went from admitting a duplicate/superseded close in both lanes to a blocked close with the reason above and zero `gh pr close` calls, while a head-fresh sufficient report and the human `proof: override` label continued to admit the close in both lanes.
What was not tested: no live GitHub PR was closed or labeled during verification; the GitHub API and the coverage-proof model were scripted stand-ins outside the changed code paths.

Implements the label-trust reduction requested in the maintainer review of this PR. The earlier reproduce-and-attest proposal (#421) is closed.
