### PR TITLE
fix: suppress automerge status while paused

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -1166,6 +1166,7 @@ const REVIEW_START_STATUS_MARKER_PREFIX = "<!-- clawsweeper-review-status";
 const AUTOMERGE_LABEL = "clawsweeper:automerge";
 const AUTOFIX_LABEL = "clawsweeper:autofix";
 const HUMAN_REVIEW_LABEL = "clawsweeper:human-review";
+const MERGE_READY_LABEL = "clawsweeper:merge-ready";
 const MANUAL_ONLY_LABEL = "clawsweeper:manual-only";
 const PR_AUTO_CLOSE_EXEMPT_LABELS = new Set([
   HUMAN_REVIEW_LABEL,
@@ -9309,10 +9310,17 @@ function prStatusLabelKindFromLabels(labels: readonly string[]): PrStatusLabelKi
 
 function prStatusLabelKindFromReportLabels(markdown: string): PrStatusLabelKind | null {
   const parsedLabels = frontMatterStringArray(markdown, "labels");
+  if (hasRepairLoopPauseLabel(parsedLabels)) return null;
   const fromParsedLabels = prStatusLabelKindFromLabels(parsedLabels);
   if (fromParsedLabels) return fromParsedLabels;
   if (parsedLabels.includes(AUTOMERGE_LABEL)) return "automerge_armed";
   const rawLabels = frontMatterValue(markdown, "labels") ?? "";
+  if (
+    rawLabels.includes(HUMAN_REVIEW_LABEL) ||
+    rawLabels.includes(MANUAL_ONLY_LABEL) ||
+    rawLabels.includes(MERGE_READY_LABEL)
+  )
+    return null;
   if (rawLabels.includes(AUTOMERGE_LABEL)) return "automerge_armed";
   return PR_STATUS_LABELS.find((label) => rawLabels.includes(label.name))?.kind ?? null;
 }
@@ -10422,10 +10430,12 @@ function prStatusLabelKind(options: {
   mergeRiskOptions: readonly Pick<MergeRiskOption, "category" | "recommended">[];
   overallCorrectness: OverallCorrectness;
   hasAutomergeLabel: boolean;
+  hasRepairLoopPauseLabel: boolean;
   hasRecentReReviewRequest: boolean;
   hasRecentAuthorActivity: boolean;
 }): PrStatusLabelKind | null {
   const unresolvedWork = hasUnresolvedContributorWork(options);
+  if (options.hasRepairLoopPauseLabel) return null;
   if (options.hasAutomergeLabel) return "automerge_armed";
   if (options.hasRecentReReviewRequest) return "re_review_loop";
   if (options.hasRecentAuthorActivity && unresolvedWork) return "actively_grinding";
@@ -10448,6 +10458,15 @@ function nextPrStatusLabels(
   const nextLabels = labels.filter((label) => !PR_STATUS_LABEL_NAMES.has(label));
   if (statusKind) nextLabels.push(prStatusLabelForKind(statusKind).name);
   return nextLabels;
+}
+
+function hasRepairLoopPauseLabel(labels: readonly string[]): boolean {
+  const normalized = new Set(labels.map((label) => label.toLowerCase()));
+  return (
+    normalized.has(HUMAN_REVIEW_LABEL) ||
+    normalized.has(MANUAL_ONLY_LABEL) ||
+    normalized.has(MERGE_READY_LABEL)
+  );
 }
 
 function eventTimestampMs(value: unknown): number | null {
@@ -10527,6 +10546,7 @@ function prStatusLabelKindFromReport(
     mergeRiskOptions: mergeRiskOptionsFromReport(markdown),
     overallCorrectness: reportOverallCorrectness(markdown),
     hasAutomergeLabel: currentLabels.includes(AUTOMERGE_LABEL),
+    hasRepairLoopPauseLabel: hasRepairLoopPauseLabel(currentLabels),
     hasRecentReReviewRequest: hasRecentReReviewRequest(
       context,
       frontMatterValue(markdown, "reviewed_at"),
@@ -10588,6 +10608,7 @@ export function prStatusLabelsForTest(
       ? (options.overallCorrectness as OverallCorrectness)
       : "patch is correct",
     hasAutomergeLabel: options.hasAutomergeLabel ?? labels.includes(AUTOMERGE_LABEL),
+    hasRepairLoopPauseLabel: hasRepairLoopPauseLabel(labels),
     hasRecentReReviewRequest: hasRecentReReviewRequestValue,
     hasRecentAuthorActivity: options.hasRecentAuthorActivity === true,
   });

--- a/test/pr-label-policy.test.ts
+++ b/test/pr-label-policy.test.ts
@@ -197,12 +197,46 @@ test("ClawSweeper PR status labels preserve other label families", () => {
 });
 
 test("ClawSweeper PR status labels respect priority ordering", () => {
+  const automergeArmedLabel = prStatusLabelSchemeForTest().find(
+    (label) => label.kind === "automerge_armed",
+  )?.name;
+  assert.ok(automergeArmedLabel);
   assert.deepEqual(
     prStatusLabelsForTest(["clawsweeper:automerge"], {
       proofStatus: "missing",
       hasRecentReReviewRequest: true,
     }),
-    ["clawsweeper:automerge", "status: 🚀 automerge armed"],
+    ["clawsweeper:automerge", automergeArmedLabel],
+  );
+  assert.deepEqual(
+    prStatusLabelsForTest(
+      ["clawsweeper:automerge", "clawsweeper:human-review", automergeArmedLabel],
+      {
+        proofStatus: "missing",
+        hasRecentReReviewRequest: true,
+      },
+    ),
+    ["clawsweeper:automerge", "clawsweeper:human-review"],
+  );
+  assert.deepEqual(
+    prStatusLabelsForTest(
+      ["clawsweeper:automerge", "clawsweeper:merge-ready", automergeArmedLabel],
+      {
+        proofStatus: "missing",
+        hasRecentReReviewRequest: true,
+      },
+    ),
+    ["clawsweeper:automerge", "clawsweeper:merge-ready"],
+  );
+  assert.deepEqual(
+    prStatusLabelsForTest(
+      ["clawsweeper:automerge", "clawsweeper:manual-only", automergeArmedLabel],
+      {
+        proofStatus: "missing",
+        hasRecentReReviewRequest: true,
+      },
+    ),
+    ["clawsweeper:automerge", "clawsweeper:manual-only"],
   );
   assert.deepEqual(
     prStatusLabelsForTest([], {


### PR DESCRIPTION
## Summary

- Stop deriving a PR status label when ClawSweeper repair-loop pause labels are present.
- Keep durable control labels such as `clawsweeper:automerge`, but remove stale derived statuses like `status: 🚀 automerge armed` once `clawsweeper:human-review`, `clawsweeper:manual-only`, or `clawsweeper:merge-ready` is present.
- Add focused label-policy regression coverage for automerge plus pause-label combinations.

## Problem

Fixes openclaw/clawsweeper#436.

The reported repair run itself is no longer stuck: openclaw/clawsweeper run 28956830114 completed successfully at 2026-07-08T16:20:19Z. The live target PR openclaw/openclaw#101748 still showed the confusing state that motivated the report, though: it kept `clawsweeper:automerge` and `status: 🚀 automerge armed` while also carrying `clawsweeper:human-review` after a later exact-head review timeout.

That is misleading. `clawsweeper:automerge` is the durable opt-in/resume signal, but the derived status label should not advertise the PR as actively automerge-armed while a pause label is the operative state.

## Implementation

- Added `clawsweeper:merge-ready` to the main review label constants so the status-label logic can recognize the repair-loop pause labels already used by the repair router.
- Suppressed all derived PR status labels when current/report labels include `clawsweeper:human-review`, `clawsweeper:manual-only`, or `clawsweeper:merge-ready`.
- Covered stale `status: 🚀 automerge armed` removal for automerge PRs carrying each pause label.

## Validation

- `pnpm run build:all; if ($LASTEXITCODE -eq 0) { node --test test/pr-label-policy.test.ts test/repair/automerge-shepherd.test.ts }` - passed, 51 tests.
- Dry-run label derivation against built `dist/clawsweeper.js` - passed; output shown below under Real behavior proof.
- Redacted ClawSweeper `apply-decisions` label-sync proof in Docker-backed Crabbox local-container - passed; provider=`local-container`, leaseId=`cbx_227994b9fe68`, exitCode=`0`. Output shown below under Real behavior proof.
- `git diff --check` - passed.
- GitHub PR checks on #437 - green: `pnpm check`, CodeQL actions, CodeQL javascript-typescript, Windows Codex launcher, Socket Security checks, and github activity notify.
- Codex review closeout:
  - `codex --config service_tier=fast review --uncommitted` - clean before commit.
  - `codex --config service_tier=fast review --base origin/main` - first run found one accepted P2 finding: include `clawsweeper:manual-only` as a pause label too.
  - Fixed that finding, reran validation above, amended the commit.
  - Final `codex --config service_tier=fast review --base origin/main` - clean: no actionable correctness issues.
- ClawSweeper review closeout:
  - Initial review requested real behavior proof beyond unit tests and noted `pnpm check` was still pending.
  - Added dry-run label-sync proof below; GitHub `pnpm check` has since completed successfully.

## Real behavior proof

Behavior or issue addressed: A paused automerge PR should not keep the derived `status: 🚀 automerge armed` label while `clawsweeper:human-review`, `clawsweeper:manual-only`, or `clawsweeper:merge-ready` is present.

Real environment tested: Local ClawSweeper checkout on Windows, branch `codex/fix-issue-436-automerge-stuck`, against `origin/main`, using the built `dist/clawsweeper.js` from this patch.

Exact steps or command run after this patch: ran a local Node module import against `./dist/clawsweeper.js` to feed stale automerge-armed labels plus each pause label through `prStatusLabelsForTest`.

Evidence after fix:

```json
{"pause":"clawsweeper:human-review","input":["clawsweeper:automerge","clawsweeper:human-review","status: 🚀 automerge armed"],"output":["clawsweeper:automerge","clawsweeper:human-review"]}
{"pause":"clawsweeper:manual-only","input":["clawsweeper:automerge","clawsweeper:manual-only","status: 🚀 automerge armed"],"output":["clawsweeper:automerge","clawsweeper:manual-only"]}
{"pause":"clawsweeper:merge-ready","input":["clawsweeper:automerge","clawsweeper:merge-ready","status: 🚀 automerge armed"],"output":["clawsweeper:automerge","clawsweeper:merge-ready"]}
```

Additional redacted ClawSweeper label-sync proof: I ran the built `dist/clawsweeper.js apply-decisions` path against a temp report fixture for openclaw/openclaw#101748 with `GH_BIN/GH_BIN_ARGS` pointed at a mock `gh`. This is non-production proof: no GitHub token was used and no live labels were mutated. The mock live labels included `clawsweeper:automerge`, `clawsweeper:human-review`, and stale `status: 🚀 automerge armed`.

Environment: Docker-backed Crabbox local-container, provider `local-container`, leaseId `cbx_227994b9fe68`, image `node:24-bookworm`, exitCode `0`.

Command shape: sync this branch into the container, run `corepack pnpm install --frozen-lockfile`, run `corepack pnpm run build`, `corepack pnpm run build:repair`, `corepack pnpm run build:dashboard`, then run the redacted mock-gh `apply-decisions` harness.

Output:

```text
CRABBOX_PHASE:label-sync-proof
[
  {
    "number": 101748,
    "action": "kept_open",
    "reason": "synced ClawSweeper labels"
  }
]
APPLY_REPORT=[{"number":101748,"action":"kept_open","reason":"synced ClawSweeper labels"}]
ISSUE_EDIT_CALLS=[["issue","edit","101748","--remove-label","status: 🚀 automerge armed"]]
FINAL_LABELS=["docs","size: XS","clawsweeper","clawsweeper:automerge","clawsweeper:human-review","P3","rating: 🦞 diamond lobster"]
PRESERVED_CONTROL=true
PRESERVED_PAUSE=true
REMOVED_STALE_STATUS=true
```
Observed result after fix: The stale derived `status: 🚀 automerge armed` status is removed for each pause-label state, while the durable `clawsweeper:automerge` opt-in and the pause label remain.

Proof limitations or environment constraints: I did not mutate labels on openclaw/openclaw#101748. That target PR is live maintainer automation state; this PR proves the label reconciliation behavior through the same built label-policy function and leaves live cleanup to normal ClawSweeper label sync/review after this fix ships.

What was not tested: Live ClawSweeper label mutation against GitHub and workflow `actionlint` because no workflow files changed.

## Risks / rollout

Risk is low and limited to ClawSweeper-owned PR status labels. Durable control labels remain untouched, so maintainer resume commands and automerge opt-in state continue to work. The main behavior change is that pause labels become visually authoritative over derived status labels.

## Related

- Fixes openclaw/clawsweeper#436
- Evidence target: openclaw/openclaw#101748
- Reported repair run: https://github.com/openclaw/clawsweeper/actions/runs/28956830114
