### PR TITLE
fix: include UTC date in cross-date review timestamps

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -8432,7 +8432,7 @@ function formatReviewFreshnessTimestamp(iso: string | undefined): string {
   if (!iso) return "";
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return iso;
-  const utc = date.toISOString().slice(11, 16);
+  const utcTime = date.toISOString().slice(11, 16);
   const eastern = new Intl.DateTimeFormat("en-US", {
     year: "numeric",
     month: "long",
@@ -8444,6 +8444,19 @@ function formatReviewFreshnessTimestamp(iso: string | undefined): string {
   })
     .format(date)
     .replace(" at ", ", ");
+  const easternDate = new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "America/New_York",
+  }).format(date);
+  const utcDate = new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  }).format(date);
+  const utc = easternDate === utcDate ? utcTime : `${utcDate}, ${utcTime}`;
   return `${eastern} ET / ${utc} UTC`;
 }
 

--- a/test/review-comment-rendering.test.ts
+++ b/test/review-comment-rendering.test.ts
@@ -303,6 +303,39 @@ Reason: Maintainers should review the tests after the targeted lane is green.
   assert.match(comment, /<!-- clawsweeper-verdict:needs-human item=74265 sha=abc123def456/);
 });
 
+test("review comments include the UTC date when ET and UTC calendar dates differ", () => {
+  const comment = renderReviewCommentFromReport(
+    `${reportFrontMatter({
+      type: "pull_request",
+      number: "74266",
+      decision: "keep_open",
+      close_reason: "none",
+      work_candidate: "none",
+      pull_head_sha: "abc123def456",
+      reviewed_at: "2026-07-09T03:00:00.000Z",
+    })}
+
+## Summary
+
+Keep this PR open for maintainer review.
+
+## What This Changes
+
+Updates review timestamp formatting.
+
+## Best Possible Solution
+
+Land the timestamp fix after targeted validation is green.
+`,
+    "none",
+  );
+
+  assert.match(
+    comment,
+    /Codex review: needs maintainer review before merge\. _Reviewed July 8, 2026, 11:00 PM ET \/ July 9, 2026, 03:00 UTC\._/,
+  );
+});
+
 test("issue keep-open review comments surface reproducibility in the summary", () => {
   const comment = renderReviewCommentFromReport(
     `${reportFrontMatter({


### PR DESCRIPTION
## Summary

- Include the UTC calendar date in ClawSweeper review freshness text when the ET and UTC dates differ.
- Preserve the existing concise UTC time-only format when both zones share the same calendar date.
- Add regression coverage for the July 8 ET / July 9 UTC boundary case.

## Problem

A live ClawSweeper review on https://github.com/openclaw/openclaw/pull/101937 rendered:

`Reviewed July 8, 2026, 11:00 PM ET / 03:00 UTC.`

That is misleading because 11:00 PM ET on July 8, 2026 is 03:00 UTC on July 9, 2026. The UTC side needs its date when the calendar day differs.

Related live-state checks found no duplicate ClawSweeper PR:

- `gh pr list --repo openclaw/clawsweeper --state open --limit 30 --json number,title,author,headRefName,baseRefName,url,updatedAt,labels,isDraft`: only open PR was #432, unrelated.
- `gh pr list --repo openclaw/clawsweeper --state merged --limit 20 --json number,title,author,headRefName,mergedAt,url`: recent merged PRs were unrelated.
- `gh search prs "timestamp reviewed UTC timezone" --repo openclaw/clawsweeper --state open --json number,title,state,author,url,updatedAt --limit 20`: no matches.
- `gh search prs "timestamp reviewed UTC timezone" --repo openclaw/clawsweeper --state closed --json number,title,state,author,url,updatedAt --limit 20`: no matches.

## Implementation

`formatReviewFreshnessTimestamp` now formats the ET and UTC calendar dates separately. If they match, the UTC side remains `HH:MM UTC`; if they differ, the UTC side becomes `Month D, YYYY, HH:MM UTC`.

## Validation

Passed:

- `pnpm run build`
- `node --test test\review-comment-rendering.test.ts` (19 tests passed)
- `git diff --check`
- `pnpm run build:all`
- `pnpm run lint`
- `pnpm exec oxfmt --check src/clawsweeper.ts test/review-comment-rendering.test.ts`
- `codex -c service_tier=fast review --base origin/main`

Broad-check notes:

- `pnpm run check` reached `test:unit` and failed on Windows host prerequisites unrelated to this diff: default `bash` resolves to WSL `C:\Windows\System32\bash.exe`, whose distro lacks `/bin/bash`; after using Git Bash, the remaining unrelated failures were missing `jq` and two `--local-range` tests whose fake `.sh` Codex stubs did not execute on this Windows host.
- `pnpm run test:repair` passed 620 tests and failed 2 target-validation tests because temp target repos tried to spawn `C:\Users\marti\AppData\Local\Corepack\shims\pnpm` and hit `ENOENT`.
- Repo-wide `pnpm run format:check` reports existing formatting differences across many files; the touched-file format check above passed.

## Proof

Rendered-output proof from PR head (`f53b4b8cd80679f773dffc1401e7990735845e4e`):

Redacted terminal transcript showing generated review-comment output from the built renderer:

```text
PS> pnpm run build
$ tsgo -p tsconfig.json

PS> node --input-type=module <inline script importing renderReviewCommentFromReport from ./dist/clawsweeper.js and rendering a minimal PR report for same-date/cross-date reviewed_at values>
same-date: Codex review: needs maintainer review before merge. _Reviewed May 22, 2026, 12:43 AM ET / 04:43 UTC._
cross-date: Codex review: needs maintainer review before merge. _Reviewed July 8, 2026, 11:00 PM ET / July 9, 2026, 03:00 UTC._
```

The focused rendering test now covers both cases:

- Same-date ET/UTC rendering keeps the existing concise form, for example `May 22, 2026, 12:43 AM ET / 04:43 UTC`.
- Cross-date rendering now emits `July 8, 2026, 11:00 PM ET / July 9, 2026, 03:00 UTC`.

Codex review closeout:

- Command: `codex -c service_tier=fast review --base origin/main`
- Accepted findings: none.
- Rejected findings: none.
- Final result: clean; no actionable issues were found in the timestamp formatting change.

## Risks / Rollout

Risk is limited to the first-line ClawSweeper review freshness text. This does not touch review decisions, labels, gates, workflow files, repair behavior, auth, or merge automation.

User-facing release-note context: ClawSweeper review comments now avoid misleading UTC-only times around ET/UTC date boundaries.

## Links

- Example affected PR: https://github.com/openclaw/openclaw/pull/101937
