### PR TITLE
Add GitNexus adoption and benchmark guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,12 @@ Read the report at `artifacts/local-review-<number>/<number>.md`. Key fields are
 intentionally want to move reports into durable state or sync GitHub comments.
 Add `--verbose` when you need the underlying `[review]` diagnostic logs.
 
+For the optional GitNexus code-map adoption case, see
+[`docs/gitnexus-adoption.md`](docs/gitnexus-adoption.md). That page explains
+the maintainer-facing value story, Voyage AI setup notes, benchmark proof
+boundary, and post-merge index-refresh design. Benchmark measurement is covered
+in [`docs/gitnexus-benchmarks.md`](docs/gitnexus-benchmarks.md).
+
 If you prefer API-key auth, keep the key out of the repository and shell
 history. For POSIX shells:
 

--- a/docs/gitnexus-adoption.md
+++ b/docs/gitnexus-adoption.md
@@ -1,0 +1,177 @@
+# GitNexus Adoption Case
+
+Read when: deciding whether ClawSweeper should enable GitNexus-backed review
+context for OpenClaw PRs, or preparing the operational setup for that rollout.
+
+## Plain-English Summary
+
+GitNexus is a code map for large repositories. It indexes files, symbols,
+callers, imports, and related execution paths so a reviewer can ask, "What code
+is connected to this change?" without rediscovering the same repo structure on
+every PR.
+
+For ClawSweeper, the value is not "more AI." The value is better review context
+with less repeated discovery work. A fresh GitNexus packet can help ClawSweeper
+spend fewer model tokens searching for related code and more effort judging
+whether the PR is actually safe.
+
+PR #440 adds the default-off hook for using GitNexus as advisory context. This
+document explains why maintainers might enable it, how to operate it, and what
+must be measured before making cost-saving claims.
+
+## The Hypothesis
+
+NeonDiff experience suggests GitNexus-backed context may produce significant
+savings, potentially up to 50% in some review loops. ClawSweeper should treat
+that as a hypothesis until it has its own benchmark data.
+
+Acceptable public claim before benchmarks:
+
+> GitNexus is expected to reduce repeated code-discovery work and may produce
+> large token and runtime savings. ClawSweeper will benchmark the savings before
+> treating any percentage as proven.
+
+Do not claim that GitNexus guarantees a 50% reduction, catches every deep
+regression, or proves release readiness.
+
+## What GitNexus Gives ClawSweeper
+
+Without GitNexus, ClawSweeper often has to gather context by asking broad
+questions, searching files, and reading code around the changed files. That can
+work, but it can also repeat the same discovery work across review runs.
+
+With GitNexus enabled, ClawSweeper can request a compact context packet:
+
+- changed files and symbol hints;
+- nearby files, functions, methods, and classes;
+- caller/import relationships;
+- execution-flow or process hints when available;
+- index freshness;
+- omitted context, such as stale, empty, generated, or unsafe output;
+- packet hashes for evidence and cache state.
+
+This packet is advisory. GitHub's PR diff and the checked-out repository remain
+authoritative.
+
+## Where It Helps Most
+
+GitNexus is most useful when a PR touches code where the important question is
+not "does this line compile?" but "what else depends on this behavior?"
+
+Good candidates:
+
+- core runtime and session flow changes;
+- auth, security, provider-routing, and release automation changes;
+- refactors that move shared code paths;
+- repeated review loops on the same high-risk PR;
+- large PRs where search and context gathering dominate the review.
+
+Poor candidates:
+
+- docs-only changes;
+- small typo or formatting fixes;
+- repos without a fresh index;
+- PRs where the graph output is missing, stale, or secret-like.
+
+## Voyage AI Integration
+
+Voyage AI is one possible embedding backend for GitNexus. It is not required by
+ClawSweeper itself, but it is a practical option for code-search embeddings.
+
+Current official Voyage docs say `voyage-code-3` includes 200M free text
+embedding tokens per account, then paid usage after that:
+
+- https://docs.voyageai.com/docs/pricing
+
+The same docs family says rate-limit tiers can increase with billed usage or
+purchased credits:
+
+- https://docs.voyageai.com/docs/rate-limits
+
+Verify both links before enablement. Provider pricing, rate limits, and free
+tier terms can change.
+
+Recommended GitNexus environment shape for a Voyage-backed setup:
+
+```sh
+GITNEXUS_EMBEDDING_URL=https://api.voyageai.com/v1
+GITNEXUS_EMBEDDING_MODEL=voyage-code-3
+GITNEXUS_EMBEDDING_DIMS=2048
+GITNEXUS_EMBEDDING_API_KEY=<secret value from GitHub Actions secrets or operator storage>
+```
+
+Do not commit the API key. Do not print it in logs, evidence packets, PR
+comments, or docs.
+
+## Refresh Operations
+
+GitNexus only helps when its index is fresh enough for the PR being reviewed.
+The safe operating pattern is a deliberate refresh after merge batches, not a
+per-commit hook.
+
+Recommended flow:
+
+1. A PR merges to the protected default branch.
+2. A credential-gated workflow or operator job refreshes a clean checkout.
+3. The job runs an incremental GitNexus analyze for the configured alias.
+4. The job records the indexed commit, current commit, model, and evidence path.
+5. ClawSweeper treats stale or missing index state as lower-confidence context.
+
+Example operator command:
+
+```sh
+gitnexus analyze /path/to/openclaw-checkout \
+  --name openclaw \
+  --embeddings \
+  --index-only
+```
+
+Workflow skeleton:
+
+```yaml
+name: GitNexus refresh
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 */6 * * *"
+
+jobs:
+  refresh:
+    if: ${{ vars.CLAWSWEEPER_GITNEXUS_REFRESH_ENABLED == '1' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Refresh GitNexus index
+        env:
+          GITNEXUS_EMBEDDING_URL: ${{ vars.GITNEXUS_EMBEDDING_URL }}
+          GITNEXUS_EMBEDDING_MODEL: ${{ vars.GITNEXUS_EMBEDDING_MODEL }}
+          GITNEXUS_EMBEDDING_DIMS: ${{ vars.GITNEXUS_EMBEDDING_DIMS }}
+          GITNEXUS_EMBEDDING_API_KEY: ${{ secrets.GITNEXUS_EMBEDDING_API_KEY }}
+        run: |
+          gitnexus analyze "$GITHUB_WORKSPACE" \
+            --name openclaw \
+            --embeddings \
+            --index-only
+```
+
+Keep this disabled until maintainers approve credentials, runner cost, and
+where the index should live.
+
+## Rollout Decision
+
+Before enabling GitNexus broadly, maintainers should have:
+
+- benchmark evidence from `docs/gitnexus-benchmarks.md`;
+- a fresh-index operating path;
+- a credential owner for embeddings;
+- a stale-index fallback policy;
+- proof that secret-like graph output is omitted;
+- and a clear public proof boundary.
+
+The merge decision should be:
+
+> We accept GitNexus as an optional code-map layer that may reduce repeated
+> review discovery cost, with benchmarked savings reported separately and stale
+> graph context treated as lower confidence.
+

--- a/docs/gitnexus-adoption.md
+++ b/docs/gitnexus-adoption.md
@@ -15,11 +15,11 @@ with less repeated discovery work. A fresh GitNexus packet can help ClawSweeper
 spend fewer model tokens searching for related code and more effort judging
 whether the PR is actually safe.
 
-PR #440 proposes the default-off hook for using GitNexus as advisory context.
-This document explains why maintainers might enable that hook, how to operate
-it, and what must be measured before making cost-saving claims. If PR #440 has
-not merged yet, treat this page as the adoption proposal for the hook rather
-than current `main` behavior.
+https://github.com/openclaw/clawsweeper/pull/440 proposes the default-off hook
+for using GitNexus as advisory context. This document explains why maintainers
+might enable that hook, how to operate it, and what must be measured before
+making cost-saving claims. If that PR has not merged yet, treat this page as the
+adoption proposal for the hook rather than current `main` behavior.
 
 ## The Hypothesis
 

--- a/docs/gitnexus-adoption.md
+++ b/docs/gitnexus-adoption.md
@@ -15,9 +15,11 @@ with less repeated discovery work. A fresh GitNexus packet can help ClawSweeper
 spend fewer model tokens searching for related code and more effort judging
 whether the PR is actually safe.
 
-PR #440 adds the default-off hook for using GitNexus as advisory context. This
-document explains why maintainers might enable it, how to operate it, and what
-must be measured before making cost-saving claims.
+PR #440 proposes the default-off hook for using GitNexus as advisory context.
+This document explains why maintainers might enable that hook, how to operate
+it, and what must be measured before making cost-saving claims. If PR #440 has
+not merged yet, treat this page as the adoption proposal for the hook rather
+than current `main` behavior.
 
 ## The Hypothesis
 
@@ -174,4 +176,3 @@ The merge decision should be:
 > We accept GitNexus as an optional code-map layer that may reduce repeated
 > review discovery cost, with benchmarked savings reported separately and stale
 > graph context treated as lower confidence.
-

--- a/docs/gitnexus-benchmarks.md
+++ b/docs/gitnexus-benchmarks.md
@@ -96,11 +96,18 @@ after a baseline and GitNexus-enabled review have already been collected.
 
 ## Evidence Packet
 
-Store benchmark artifacts under:
+Store benchmark artifacts in a portable location chosen by the runner or
+operator. Good options:
 
 ```text
-/Volumes/LEXAR/Codex/evidence/clawsweeper-gitnexus-adoption/2026-07-09/<issue-or-pr>/
+artifacts/gitnexus-adoption/<run-id>/
+$CLAWSWEEPER_EVIDENCE_DIR/gitnexus-adoption/<run-id>/
+GitHub Actions artifact: gitnexus-adoption-<run-id>
 ```
+
+Do not hard-code contributor-local disk paths in published benchmark docs or PR
+evidence. Local operators can still keep their own scratch packets wherever
+their environment policy requires.
 
 Recommended files:
 
@@ -126,4 +133,3 @@ Not acceptable:
 - "GitNexus proves the PR is safe."
 - "GitNexus replaces maintainer review."
 - "GitNexus saw the whole repo" unless the evidence proves that exact claim.
-

--- a/docs/gitnexus-benchmarks.md
+++ b/docs/gitnexus-benchmarks.md
@@ -1,0 +1,129 @@
+# GitNexus Benchmark Plan
+
+Read when: measuring whether GitNexus-backed context actually improves
+ClawSweeper cost, speed, or review accuracy.
+
+## Goal
+
+Measure the advisory value of GitNexus before maintainers make public cost or
+accuracy claims.
+
+The benchmark compares two review modes:
+
+- baseline: ClawSweeper review without a GitNexus packet;
+- GitNexus-enabled: ClawSweeper review with advisory graph context.
+
+The benchmark does not prove release readiness. It only measures whether
+GitNexus reduces repeated discovery work and improves review signal on the
+selected scenarios.
+
+## Required Metrics
+
+Every benchmark run should emit JSON with these fields:
+
+```json
+{
+  "evalName": "clawsweeper-gitnexus-adoption-v0.1",
+  "scenario": "example",
+  "baselineTokens": 100000,
+  "gitnexusTokens": 60000,
+  "tokenDeltaPercent": 40,
+  "baselineRuntimeMs": 120000,
+  "gitnexusRuntimeMs": 90000,
+  "runtimeDeltaPercent": 25,
+  "baselineToolCalls": 30,
+  "gitnexusToolCalls": 18,
+  "toolCallDelta": 12,
+  "seededFindingsCaught": 3,
+  "seededFindingsTotal": 3,
+  "falsePositiveCount": 0,
+  "graphFreshness": "fresh",
+  "secretLeakageDetected": false
+}
+```
+
+Positive `tokenDeltaPercent` and `runtimeDeltaPercent` mean the GitNexus-enabled
+run used less of that resource than the baseline.
+
+## Scenarios
+
+Use a small, named scenario set before expanding:
+
+- high-risk auth/session PR with seeded regression;
+- core runtime/provider-routing PR with seeded regression;
+- release automation/config-default PR;
+- docs-only control PR;
+- stale-index fixture;
+- missing-index fixture;
+- secret-like graph-output fixture.
+
+Historical replay should include selected OpenClaw PRs from the 6.8 to 6.11
+regression window, but only after maintainers agree which PRs are representative.
+
+## Thresholds
+
+For a successful adoption recommendation:
+
+- zero secret leakage;
+- stale graph context is never treated as fresh;
+- docs-only controls do not block;
+- seeded critical regressions produce `needs_attention` or `blocked`;
+- benchmark output includes token, runtime, tool-call, accuracy, freshness, and
+  secret-safety fields;
+- any savings percentage is reported as measured for the dataset, not universal.
+
+## Dry-Run Helper
+
+Use the dry-run helper to normalize collected metrics into one JSON shape:
+
+```sh
+pnpm run gitnexus:benchmark -- \
+  --scenario auth-session-seeded \
+  --baseline-tokens 100000 \
+  --gitnexus-tokens 60000 \
+  --baseline-runtime-ms 120000 \
+  --gitnexus-runtime-ms 90000 \
+  --baseline-tool-calls 30 \
+  --gitnexus-tool-calls 18 \
+  --seeded-findings-caught 3 \
+  --seeded-findings-total 3 \
+  --false-positive-count 0 \
+  --graph-freshness fresh
+```
+
+The helper does not run ClawSweeper by itself. It records comparable metrics
+after a baseline and GitNexus-enabled review have already been collected.
+
+## Evidence Packet
+
+Store benchmark artifacts under:
+
+```text
+/Volumes/LEXAR/Codex/evidence/clawsweeper-gitnexus-adoption/2026-07-09/<issue-or-pr>/
+```
+
+Recommended files:
+
+- `baseline-review.json`
+- `gitnexus-review.json`
+- `benchmark-summary.json`
+- `redacted-gitnexus-packet.md`
+- `ci-links.md`
+- `notes.md`
+
+## Reporting Rules
+
+Acceptable:
+
+- "On this benchmark set, GitNexus reduced tokens by 38%."
+- "NeonDiff experience suggests larger savings may be possible, but this PR only
+  claims the measured ClawSweeper result."
+- "The graph was stale, so ClawSweeper correctly lowered confidence."
+
+Not acceptable:
+
+- "GitNexus saves 50%" without benchmark data.
+- "GitNexus proves the PR is safe."
+- "GitNexus replaces maintainer review."
+- "GitNexus saw the whole repo" unless the evidence proves that exact claim.
+

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "dashboard:dev": "npx wrangler@4.107.0 dev --config dashboard/wrangler.toml",
     "dashboard:refresh-ci": "node scripts/dashboard-refresh-ci.mjs",
     "dashboard:smoke": "node scripts/dashboard-smoke.mjs",
+    "gitnexus:benchmark": "node scripts/gitnexus-adoption-benchmark.mjs",
     "smoke:pr-close-coverage": "pnpm run build && node scripts/pr-close-coverage-smoke.mjs",
     "test": "pnpm run build:all && node --test test/*.test.ts test/repair/*.test.ts dist/repair/*.test.js",
     "test:unit": "node --test test/*.test.ts",

--- a/scripts/gitnexus-adoption-benchmark.mjs
+++ b/scripts/gitnexus-adoption-benchmark.mjs
@@ -3,15 +3,22 @@
 const evalName = "clawsweeper-gitnexus-adoption-v0.1";
 const allowedFreshness = new Set(["fresh", "stale", "missing", "unknown", "not_applicable"]);
 
-const args = parseArgs(process.argv.slice(2));
+try {
+  const args = parseArgs(process.argv.slice(2));
 
-if (args.help) {
-  printHelp();
-  process.exit(0);
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  const result = buildResult(args);
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`Error: ${message}\n`);
+  process.stderr.write("Run with --help for usage.\n");
+  process.exit(1);
 }
-
-const result = buildResult(args);
-process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
 
 function parseArgs(argv) {
   const parsed = {
@@ -45,31 +52,31 @@ function parseArgs(argv) {
         parsed.scenario = value;
         break;
       case "--baseline-tokens":
-        parsed.baselineTokens = numberValue(name, value);
+        parsed.baselineTokens = integerValue(name, value);
         break;
       case "--gitnexus-tokens":
-        parsed.gitnexusTokens = numberValue(name, value);
+        parsed.gitnexusTokens = integerValue(name, value);
         break;
       case "--baseline-runtime-ms":
-        parsed.baselineRuntimeMs = numberValue(name, value);
+        parsed.baselineRuntimeMs = integerValue(name, value);
         break;
       case "--gitnexus-runtime-ms":
-        parsed.gitnexusRuntimeMs = numberValue(name, value);
+        parsed.gitnexusRuntimeMs = integerValue(name, value);
         break;
       case "--baseline-tool-calls":
-        parsed.baselineToolCalls = numberValue(name, value);
+        parsed.baselineToolCalls = integerValue(name, value);
         break;
       case "--gitnexus-tool-calls":
-        parsed.gitnexusToolCalls = numberValue(name, value);
+        parsed.gitnexusToolCalls = integerValue(name, value);
         break;
       case "--seeded-findings-caught":
-        parsed.seededFindingsCaught = numberValue(name, value);
+        parsed.seededFindingsCaught = integerValue(name, value);
         break;
       case "--seeded-findings-total":
-        parsed.seededFindingsTotal = numberValue(name, value);
+        parsed.seededFindingsTotal = integerValue(name, value);
         break;
       case "--false-positive-count":
-        parsed.falsePositiveCount = numberValue(name, value);
+        parsed.falsePositiveCount = integerValue(name, value);
         break;
       case "--graph-freshness":
         if (!allowedFreshness.has(value)) {
@@ -91,6 +98,8 @@ function parseArgs(argv) {
 }
 
 function buildResult(values) {
+  validateMetrics(values);
+
   return {
     evalName,
     scenario: values.scenario,
@@ -111,15 +120,21 @@ function buildResult(values) {
   };
 }
 
+function validateMetrics(values) {
+  if (values.seededFindingsCaught > values.seededFindingsTotal) {
+    throw new Error("--seeded-findings-caught cannot exceed --seeded-findings-total");
+  }
+}
+
 function reductionPercent(baseline, candidate) {
   if (baseline <= 0) return 0;
   return Number((((baseline - candidate) / baseline) * 100).toFixed(2));
 }
 
-function numberValue(name, value) {
+function integerValue(name, value) {
   const parsed = Number(value);
-  if (!Number.isFinite(parsed) || parsed < 0) {
-    throw new Error(`${name} must be a non-negative number`);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
   }
   return parsed;
 }
@@ -135,15 +150,15 @@ function printHelp() {
 
 Options:
   --scenario <name>
-  --baseline-tokens <number>
-  --gitnexus-tokens <number>
-  --baseline-runtime-ms <number>
-  --gitnexus-runtime-ms <number>
-  --baseline-tool-calls <number>
-  --gitnexus-tool-calls <number>
-  --seeded-findings-caught <number>
-  --seeded-findings-total <number>
-  --false-positive-count <number>
+  --baseline-tokens <integer>
+  --gitnexus-tokens <integer>
+  --baseline-runtime-ms <integer>
+  --gitnexus-runtime-ms <integer>
+  --baseline-tool-calls <integer>
+  --gitnexus-tool-calls <integer>
+  --seeded-findings-caught <integer>
+  --seeded-findings-total <integer>
+  --false-positive-count <integer>
   --graph-freshness <fresh|stale|missing|unknown|not_applicable>
   --secret-leakage-detected <true|false>
 `);

--- a/scripts/gitnexus-adoption-benchmark.mjs
+++ b/scripts/gitnexus-adoption-benchmark.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+
+const evalName = "clawsweeper-gitnexus-adoption-v0.1";
+const allowedFreshness = new Set(["fresh", "stale", "missing", "unknown", "not_applicable"]);
+
+const args = parseArgs(process.argv.slice(2));
+
+if (args.help) {
+  printHelp();
+  process.exit(0);
+}
+
+const result = buildResult(args);
+process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+
+function parseArgs(argv) {
+  const parsed = {
+    scenario: "dry-run",
+    baselineTokens: 0,
+    gitnexusTokens: 0,
+    baselineRuntimeMs: 0,
+    gitnexusRuntimeMs: 0,
+    baselineToolCalls: 0,
+    gitnexusToolCalls: 0,
+    seededFindingsCaught: 0,
+    seededFindingsTotal: 0,
+    falsePositiveCount: 0,
+    graphFreshness: "unknown",
+    secretLeakageDetected: false,
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const name = argv[index];
+    if (name === "--") continue;
+    if (name === "--help" || name === "-h") {
+      parsed.help = true;
+      continue;
+    }
+    const value = argv[index + 1];
+    if (value === undefined) throw new Error(`Missing value for ${name}`);
+    index += 1;
+    switch (name) {
+      case "--scenario":
+        parsed.scenario = value;
+        break;
+      case "--baseline-tokens":
+        parsed.baselineTokens = numberValue(name, value);
+        break;
+      case "--gitnexus-tokens":
+        parsed.gitnexusTokens = numberValue(name, value);
+        break;
+      case "--baseline-runtime-ms":
+        parsed.baselineRuntimeMs = numberValue(name, value);
+        break;
+      case "--gitnexus-runtime-ms":
+        parsed.gitnexusRuntimeMs = numberValue(name, value);
+        break;
+      case "--baseline-tool-calls":
+        parsed.baselineToolCalls = numberValue(name, value);
+        break;
+      case "--gitnexus-tool-calls":
+        parsed.gitnexusToolCalls = numberValue(name, value);
+        break;
+      case "--seeded-findings-caught":
+        parsed.seededFindingsCaught = numberValue(name, value);
+        break;
+      case "--seeded-findings-total":
+        parsed.seededFindingsTotal = numberValue(name, value);
+        break;
+      case "--false-positive-count":
+        parsed.falsePositiveCount = numberValue(name, value);
+        break;
+      case "--graph-freshness":
+        if (!allowedFreshness.has(value)) {
+          throw new Error(
+            `Invalid --graph-freshness ${value}; expected one of ${[...allowedFreshness].join(", ")}`,
+          );
+        }
+        parsed.graphFreshness = value;
+        break;
+      case "--secret-leakage-detected":
+        parsed.secretLeakageDetected = booleanValue(name, value);
+        break;
+      default:
+        throw new Error(`Unknown option ${name}`);
+    }
+  }
+
+  return parsed;
+}
+
+function buildResult(values) {
+  return {
+    evalName,
+    scenario: values.scenario,
+    baselineTokens: values.baselineTokens,
+    gitnexusTokens: values.gitnexusTokens,
+    tokenDeltaPercent: reductionPercent(values.baselineTokens, values.gitnexusTokens),
+    baselineRuntimeMs: values.baselineRuntimeMs,
+    gitnexusRuntimeMs: values.gitnexusRuntimeMs,
+    runtimeDeltaPercent: reductionPercent(values.baselineRuntimeMs, values.gitnexusRuntimeMs),
+    baselineToolCalls: values.baselineToolCalls,
+    gitnexusToolCalls: values.gitnexusToolCalls,
+    toolCallDelta: values.baselineToolCalls - values.gitnexusToolCalls,
+    seededFindingsCaught: values.seededFindingsCaught,
+    seededFindingsTotal: values.seededFindingsTotal,
+    falsePositiveCount: values.falsePositiveCount,
+    graphFreshness: values.graphFreshness,
+    secretLeakageDetected: values.secretLeakageDetected,
+  };
+}
+
+function reductionPercent(baseline, candidate) {
+  if (baseline <= 0) return 0;
+  return Number((((baseline - candidate) / baseline) * 100).toFixed(2));
+}
+
+function numberValue(name, value) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`${name} must be a non-negative number`);
+  }
+  return parsed;
+}
+
+function booleanValue(name, value) {
+  if (value === "true") return true;
+  if (value === "false") return false;
+  throw new Error(`${name} must be true or false`);
+}
+
+function printHelp() {
+  process.stdout.write(`Usage: pnpm run gitnexus:benchmark -- [options]
+
+Options:
+  --scenario <name>
+  --baseline-tokens <number>
+  --gitnexus-tokens <number>
+  --baseline-runtime-ms <number>
+  --gitnexus-runtime-ms <number>
+  --baseline-tool-calls <number>
+  --gitnexus-tool-calls <number>
+  --seeded-findings-caught <number>
+  --seeded-findings-total <number>
+  --false-positive-count <number>
+  --graph-freshness <fresh|stale|missing|unknown|not_applicable>
+  --secret-leakage-detected <true|false>
+`);
+}

--- a/test/gitnexus-adoption-benchmark.test.ts
+++ b/test/gitnexus-adoption-benchmark.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import test from "node:test";
+
+test("GitNexus adoption benchmark emits normalized savings metrics", () => {
+  const output = execFileSync(process.execPath, [
+    "scripts/gitnexus-adoption-benchmark.mjs",
+    "--",
+    "--scenario",
+    "auth-session-seeded",
+    "--baseline-tokens",
+    "100000",
+    "--gitnexus-tokens",
+    "60000",
+    "--baseline-runtime-ms",
+    "120000",
+    "--gitnexus-runtime-ms",
+    "90000",
+    "--baseline-tool-calls",
+    "30",
+    "--gitnexus-tool-calls",
+    "18",
+    "--seeded-findings-caught",
+    "3",
+    "--seeded-findings-total",
+    "3",
+    "--false-positive-count",
+    "0",
+    "--graph-freshness",
+    "fresh",
+  ]).toString();
+
+  const result = JSON.parse(output);
+  assert.equal(result.evalName, "clawsweeper-gitnexus-adoption-v0.1");
+  assert.equal(result.scenario, "auth-session-seeded");
+  assert.equal(result.tokenDeltaPercent, 40);
+  assert.equal(result.runtimeDeltaPercent, 25);
+  assert.equal(result.toolCallDelta, 12);
+  assert.equal(result.seededFindingsCaught, 3);
+  assert.equal(result.seededFindingsTotal, 3);
+  assert.equal(result.falsePositiveCount, 0);
+  assert.equal(result.graphFreshness, "fresh");
+  assert.equal(result.secretLeakageDetected, false);
+});

--- a/test/gitnexus-adoption-benchmark.test.ts
+++ b/test/gitnexus-adoption-benchmark.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import test from "node:test";
 
 test("GitNexus adoption benchmark emits normalized savings metrics", () => {
@@ -41,4 +41,38 @@ test("GitNexus adoption benchmark emits normalized savings metrics", () => {
   assert.equal(result.falsePositiveCount, 0);
   assert.equal(result.graphFreshness, "fresh");
   assert.equal(result.secretLeakageDetected, false);
+});
+
+test("GitNexus adoption benchmark rejects impossible seeded finding counts", () => {
+  const result = spawnSync(
+    process.execPath,
+    [
+      "scripts/gitnexus-adoption-benchmark.mjs",
+      "--seeded-findings-caught",
+      "4",
+      "--seeded-findings-total",
+      "3",
+    ],
+    { encoding: "utf8" },
+  );
+
+  assert.notEqual(result.status, 0);
+  assert.match(
+    `${result.stderr}${result.stdout}`,
+    /--seeded-findings-caught cannot exceed --seeded-findings-total/,
+  );
+});
+
+test("GitNexus adoption benchmark rejects fractional count metrics", () => {
+  const result = spawnSync(
+    process.execPath,
+    ["scripts/gitnexus-adoption-benchmark.mjs", "--baseline-tool-calls", "1.5"],
+    { encoding: "utf8" },
+  );
+
+  assert.notEqual(result.status, 0);
+  assert.match(
+    `${result.stderr}${result.stdout}`,
+    /--baseline-tool-calls must be a non-negative integer/,
+  );
 });


### PR DESCRIPTION
Closes https://github.com/openclaw/clawsweeper/issues/442.
Related: https://github.com/openclaw/clawsweeper/issues/439 and https://github.com/openclaw/clawsweeper/pull/440.

## TLDR For Maintainers

This PR is the GitNexus adoption package for ClawSweeper. It explains why maintainers might want an optional code-map layer, how to evaluate the cost and review-quality claim, how to operate it safely, and where the proof boundary stops.

The short version:

- GitNexus is a code map, not another reviewer.
- It can give ClawSweeper related files, symbols, callers, and flows before the model starts broad repo discovery.
- The expected win is less repeated context lookup, faster review setup, and better high-risk PR evidence.
- NeonDiff experience suggests savings may be significant, potentially up to 50%, but this PR does not claim ClawSweeper has proven that yet.
- GitNexus stays default-off and advisory.
- GitHub diff and the checked-out repository remain authoritative.
- Stale or missing graph context must lower confidence.
- Secret-like graph output must fail closed.

## Why This PR Exists

ClawSweeper is being trusted on large OpenClaw PRs, including changes that can affect core runtime, auth, sessions, provider routing, config defaults, and release automation. Those reviews fail in subtle ways when the bot only checks the local diff but misses the connected architecture.

Large-repo review has a repeated-discovery tax:

- the same files and architecture are searched again on every review;
- token budget is spent finding context instead of judging risk;
- linked code paths can be missed when the PR looks locally reasonable;
- maintainers get a verdict without a clear statement of what was actually proven;
- follow-up reviews repeat tool calls after every push.

GitNexus addresses the map problem. It prepares related-code context so ClawSweeper can spend more of the review budget asking: does this change make sense in the architecture we already have?

## What GitNexus Means Here

For this PR, GitNexus means an optional code-map packet that may include:

- changed-file symbol hints;
- related files and modules;
- callers, imports, and dependency relationships;
- execution-flow hints when available;
- index freshness;
- omitted-context accounting;
- packet hashes for auditability.

It does not mean:

- ClawSweeper saw the whole repo in one prompt;
- the PR is safe because a graph exists;
- stale graph output can be trusted;
- maintainers can skip review;
- Voyage AI is mandatory;
- 50% savings are guaranteed.

```mermaid
flowchart TD
  A[OpenClaw PR] --> B[GitHub diff and checkout]
  A --> C[Optional GitNexus code map]
  C --> D[Related files, symbols, callers, flows]
  B --> E[ClawSweeper review]
  D --> E
  E --> F[Report with freshness and proof boundary]
  F --> G[Maintainer decision]
```

## What This PR Adds

This PR adds the maintainer-facing adoption material and a small benchmark helper:

- `docs/gitnexus-adoption.md` explains the value, rollout shape, Voyage setup, refresh operations, and proof boundary.
- `docs/gitnexus-benchmarks.md` defines how to measure token use, runtime, tool calls, seeded findings, false positives, graph freshness, and secret leakage.
- `scripts/gitnexus-adoption-benchmark.mjs` normalizes collected benchmark numbers into JSON.
- `pnpm run gitnexus:benchmark` exposes that helper.
- `test/gitnexus-adoption-benchmark.test.ts` covers normal output, impossible seeded-finding counts, and fractional count metrics.
- `README.md` links the adoption and benchmark docs.

## What Maintainers Are Being Asked To Decide

The remaining decision is product/security sequencing:

Should this adoption guide land before the default-off hook in https://github.com/openclaw/clawsweeper/pull/440 is accepted, or should it wait until that hook is merged or narrowed?

Recommended path:

1. Keep GitNexus default-off.
2. Treat this PR as proposal and evaluation guidance until the hook is accepted.
3. Run the benchmark on seeded and historical OpenClaw scenarios.
4. Publish only measured ClawSweeper results.
5. Enable broadly only if benchmarks show useful cost/speed/review-signal gains without stale-index or secret-safety regressions.

## Cost And Voyage AI Notes

Voyage AI is documented as one possible embedding backend, not as a hard dependency.

As of July 9, 2026, the official Voyage pricing page lists 200M free text-embedding tokens for voyage-code-3, with paid usage after that. The official rate-limit page describes organization and project limits, plus tier increases tied to billed usage or purchased credits.

Maintainers should verify these links before enablement because provider terms can change:

- Voyage pricing: https://docs.voyageai.com/docs/pricing
- Voyage rate limits: https://docs.voyageai.com/docs/rate-limits

Credential rule: API keys belong in GitHub Actions secrets or operator secret storage. They must not be committed, printed in logs, pasted into PR comments, or stored in benchmark artifacts.

## Benchmark Proof Boundary

The benchmark should compare two review modes:

- baseline: ClawSweeper review without GitNexus context;
- GitNexus-enabled: ClawSweeper review with an advisory graph-context packet.

The benchmark output shape includes:

```json
{
  "evalName": "clawsweeper-gitnexus-adoption-v0.1",
  "scenario": "auth-session-seeded",
  "baselineTokens": 100000,
  "gitnexusTokens": 60000,
  "tokenDeltaPercent": 40,
  "baselineRuntimeMs": 120000,
  "gitnexusRuntimeMs": 90000,
  "runtimeDeltaPercent": 25,
  "baselineToolCalls": 30,
  "gitnexusToolCalls": 18,
  "toolCallDelta": 12,
  "seededFindingsCaught": 3,
  "seededFindingsTotal": 3,
  "falsePositiveCount": 0,
  "graphFreshness": "fresh",
  "secretLeakageDetected": false
}
```

This sample proves the helper output shape only. It does not prove actual ClawSweeper savings. Actual savings can only be claimed after measured baseline-vs-GitNexus replay.

## Real Behavior Proof

Representative dry-run command:

```sh
pnpm run gitnexus:benchmark -- \
  --scenario auth-session-seeded \
  --baseline-tokens 100000 \
  --gitnexus-tokens 60000 \
  --baseline-runtime-ms 120000 \
  --gitnexus-runtime-ms 90000 \
  --baseline-tool-calls 30 \
  --gitnexus-tool-calls 18 \
  --seeded-findings-caught 3 \
  --seeded-findings-total 3 \
  --false-positive-count 0 \
  --graph-freshness fresh
```

The helper emits the JSON shown above.

Invalid metric command:

```sh
node scripts/gitnexus-adoption-benchmark.mjs --seeded-findings-caught 4 --seeded-findings-total 3
```

Expected output:

```text
Error: --seeded-findings-caught cannot exceed --seeded-findings-total
Run with --help for usage.
```

## ClawSweeper Feedback Already Addressed

Earlier ClawSweeper review found useful issues. This PR addressed them:

- impossible benchmark counts now fail closed;
- count-like metrics are non-negative integers;
- benchmark docs no longer hard-code contributor-local artifact paths;
- related PR references use full GitHub URLs;
- the PR body includes real behavior output rather than only listing commands.

Current ClawSweeper state: ready for maintainer review, with no concrete contributor-facing blocker left. The remaining risk is the intentional maintainer decision about publishing GitNexus/Voyage guidance before or after https://github.com/openclaw/clawsweeper/pull/440.

## Validation

Local focused checks run from `/Volumes/LEXAR/repos/clawsweeper`:

- `pnpm run gitnexus:benchmark -- --scenario auth-session-seeded --baseline-tokens 100000 --gitnexus-tokens 60000 --baseline-runtime-ms 120000 --gitnexus-runtime-ms 90000 --baseline-tool-calls 30 --gitnexus-tool-calls 18 --seeded-findings-caught 3 --seeded-findings-total 3 --false-positive-count 0 --graph-freshness fresh`
- `node scripts/gitnexus-adoption-benchmark.mjs --seeded-findings-caught 4 --seeded-findings-total 3` exits 1 with the expected error.
- `node --test test/gitnexus-adoption-benchmark.test.ts`
- `pnpm run check:active-surface`
- `pnpm run lint:scripts`
- `pnpm run format:check`
- `git diff --check`
- `pnpm run build`
- `node --test test/review-content-cache.test.ts test/decision-parser.test.ts test/gitnexus-adoption-benchmark.test.ts`

Remote validation:

- GitHub Actions `pnpm check` passed.
- CodeQL passed.
- Windows launcher check passed.
- Socket checks passed.
- No unresolved review threads.

## Merge Guidance

Merge when maintainers are comfortable with one of these positions:

1. Preferred: this lands after the default-off hook in https://github.com/openclaw/clawsweeper/pull/440 is accepted or narrowed.
2. Acceptable: this lands now as proposal-only guidance, with the current wording that the hook is not current-main behavior yet.
3. Not recommended: this lands as if GitNexus/Voyage is already approved operational infrastructure.
