### PR TITLE
fix: unblock close apply throughput

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
             README.md
             package.json
             pnpm-lock.yaml
+            pnpm-workspace.yaml
             tsconfig.dashboard.json
             tsconfig.json
             tsconfig.repair.json

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2204,6 +2204,7 @@ jobs:
           owner: ${{ steps.target.outputs.target_repo_owner }}
           repositories: ${{ steps.target.outputs.target_repo_name }}
           permission-contents: write
+          permission-actions: read
           permission-issues: write
           permission-pull-requests: write
 
@@ -2383,7 +2384,7 @@ jobs:
             min_age_minutes_arg=(--min-age-minutes "$min_age_minutes")
           fi
           if [ "$checkpoint_size" -gt 20 ]; then
-            echo "Capping apply checkpoint size at 20 to keep each GitHub App token within its lifetime."
+            echo "Capping apply checkpoint size at 20"
             checkpoint_size=20
           fi
           select_adaptive_apply_batch
@@ -2443,6 +2444,7 @@ jobs:
               --min-age-days "$min_age_days" \
               --min-age-minutes "$min_age_minutes" \
               --batch-size "$close_processed_limit" \
+              --close-limit "$((limit < checkpoint_size ? limit : checkpoint_size))" \
               --coverage-proof-limit "$coverage_proof_limit" \
               --cursor-path "$apply_cursor_path")"
             if [ -n "$item_numbers" ]; then
@@ -2459,7 +2461,7 @@ jobs:
               if [ "$proposed_count" -lt "$limit" ]; then
                 limit="$proposed_count"
               fi
-              echo "Auto-selected $proposed_count proposed close candidate(s) from $close_processed_limit-record apply cursor window ($adaptive_apply_scan_reason), including $coverage_proof_count/$coverage_proof_limit bounded PR coverage proof candidate(s): $item_numbers; apply-ready count: ${apply_ready_count:-unknown}"
+              echo "Selected $proposed_count from $close_processed_limit ($adaptive_apply_scan_reason); proof $coverage_proof_count/$coverage_proof_limit: $item_numbers; ready: ${apply_ready_count:-unknown}"
             fi
           fi
           item_numbers_arg=()

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -31,14 +31,14 @@ run-name: >-
       github.event.inputs.apply_existing == 'true' &&
       github.event.inputs.apply_sync_comments_only != 'true' &&
       (github.event.inputs.apply_item_numbers != '' ||
-        github.event.inputs.apply_limit != '5' ||
+        github.event.inputs.apply_limit != '20' ||
         github.event.inputs.apply_min_age_days != '0' ||
         github.event.inputs.apply_min_age_minutes != '' ||
         github.event.inputs.apply_kind != 'all' ||
         github.event.inputs.apply_close_reasons != 'all' ||
         github.event.inputs.apply_stale_min_age_days != '60' ||
         github.event.inputs.apply_close_delay_ms != '2000' ||
-        github.event.inputs.apply_checkpoint_size != '5' ||
+        github.event.inputs.apply_checkpoint_size != '20' ||
         github.event.inputs.apply_comment_sync_min_age_days != '7')) &&
       format('Apply custom ClawSweeper closures for {0}', github.event.inputs.target_repo || 'openclaw/openclaw') ||
     ((github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true') ||
@@ -2750,14 +2750,14 @@ jobs:
           can_share_apply_continuation=false
           if [ "${APPLY_AUTO_SELECTED_BATCH:-false}" = "true" ] &&
             [ -z "${APPLY_ITEM_NUMBERS:-}" ] &&
-            [ "${APPLY_LIMIT:-5}" = "5" ] &&
+            [ "${APPLY_LIMIT:-20}" = "20" ] &&
             [ "${APPLY_MIN_AGE_DAYS:-0}" = "0" ] &&
             [ -z "${APPLY_MIN_AGE_MINUTES:-}" ] &&
             [ "${APPLY_KIND:-all}" = "all" ] &&
             [ "${APPLY_CLOSE_REASONS:-all}" = "all" ] &&
             [ "${APPLY_STALE_MIN_AGE_DAYS:-60}" = "60" ] &&
             [ "${APPLY_CLOSE_DELAY_MS:-2000}" = "2000" ] &&
-            [ "${APPLY_CHECKPOINT_SIZE:-5}" = "5" ] &&
+            [ "${APPLY_CHECKPOINT_SIZE:-20}" = "20" ] &&
             [ "${APPLY_COMMENT_SYNC_MIN_AGE_DAYS:-7}" = "7" ]; then
             can_share_apply_continuation=true
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Prioritized ready close decisions and bounded PR close-coverage proofs before slow policy-gated candidates, kept default 20-item continuations shareable, and retried malformed successful GitHub JSON responses.
 - Removed exponential backtracking from durable review-marker parsing so adversarial comment bodies cannot stall apply or comment synchronization.
 - Scoped Mantis recommendations to supported proof capture and kept code changes, PR repair, and GitHub mutations in ClawSweeper's deterministic lanes. Thanks @brokemac79.
 - Bounded automatic close-apply checkpoints to ten minutes, persisted exact cursor progress before immediate continuation, and limited close-coverage proofs to the time remaining in the checkpoint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Stopped later CI reruns from resetting PR inactivity clocks by anchoring head activity to the latest source-triggered workflow run associated with that pull request.
 - Prioritized ready close decisions and bounded PR close-coverage proofs before slow policy-gated candidates, kept default 20-item continuations shareable, and retried malformed successful GitHub JSON responses.
 - Removed exponential backtracking from durable review-marker parsing so adversarial comment bodies cannot stall apply or comment synchronization.
 - Scoped Mantis recommendations to supported proof capture and kept code changes, PR repair, and GitHub mutations in ClawSweeper's deterministic lanes. Thanks @brokemac79.

--- a/docs/stalled-pr-close-policies.md
+++ b/docs/stalled-pr-close-policies.md
@@ -24,10 +24,12 @@ Review may propose it only when all of these hold:
 
 Apply additionally verifies live state:
 
-- the PR is older than 14 days and its head shows no new commit or check
-  activity for 14 days (the inactivity clock takes the newest of the head
-  committer date and status/check-run timestamps, so pushing an old commit
-  still counts as fresh activity);
+- the PR is older than 14 days and its current head has no source-triggered
+  workflow run associated with that pull request created in the last 14 days.
+  This immutable run creation time counts a push of an old commit as fresh
+  activity without letting later CI reruns reset the clock. A force-push event
+  targeting the current head also resets the clock; missing source-activity
+  data keeps the PR open;
 - a dated proof request is visible on the PR — a needs-proof label timeline
   event or a proof-nudge comment — and that request is at least 14 days old,
   so the contributor had a real window to respond. The durable review comment
@@ -52,8 +54,9 @@ blocks the reason because that work belongs in repair/adopt paths.
 
 Apply additionally verifies live state:
 
-- the PR is older than 30 days and its head shows no new commit or check
-  activity for 30 days, using the same push-safe inactivity clock as
+- the PR is older than 30 days and its current head has no source-triggered
+  workflow run associated with that pull request created in the last 30 days,
+  using the same push-safe, rerun-stable inactivity clock as
   `stalled_unproven_pr`;
 - the live PR is still stalled: a draft, labeled
   `status: ⏳ waiting on author`, or failing checks

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -8782,8 +8782,17 @@ function fixedPullRequestFromContext(
 function fixedPullRequestFromCommitPulls(
   pulls: readonly unknown[],
   source: string,
+  issueNumber: number,
+  commitMessage = "",
+  defaultBranch = "main",
 ): FixedPullRequest | null {
+  const commitClosesIssue = textExplicitlyClosesIssue(commitMessage, issueNumber);
   const candidates = pulls
+    .filter(
+      (pull) =>
+        pullTargetsBranch(pull, defaultBranch) &&
+        (commitClosesIssue || pullExplicitlyClosesIssue(pull, issueNumber)),
+    )
     .map((pull) => fixedPullRequestFromUnknown(pull, source))
     .filter((pull): pull is FixedPullRequest => pull !== null)
     .sort((left, right) => {
@@ -8796,11 +8805,44 @@ function fixedPullRequestFromCommitPulls(
 
 export function fixedPullRequestFromCommitPullsForTest(
   pulls: readonly unknown[],
+  issueNumber: number,
+  commitMessage = "",
+  defaultBranch = "main",
 ): FixedPullRequest | null {
-  return fixedPullRequestFromCommitPulls(pulls, "GitHub commit PR lookup");
+  return fixedPullRequestFromCommitPulls(
+    pulls,
+    "GitHub commit PR lookup",
+    issueNumber,
+    commitMessage,
+    defaultBranch,
+  );
 }
 
-function fixedPullRequestFromCommitSha(decision: Decision): FixedPullRequest | null {
+function pullTargetsBranch(value: unknown, branch: string): boolean {
+  return asRecord(asRecord(value).base).ref === branch;
+}
+
+function pullExplicitlyClosesIssue(value: unknown, issueNumber: number): boolean {
+  const body = asRecord(value).body;
+  if (typeof body !== "string" || !body.trim()) return false;
+  return textExplicitlyClosesIssue(body, issueNumber);
+}
+
+function textExplicitlyClosesIssue(text: string, issueNumber: number): boolean {
+  const issue = escapeRegExp(String(issueNumber));
+  const repo = escapeRegExp(targetRepo());
+  const closingReference = new RegExp(
+    `\\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\b[\\t ]*(?::[\\t ]*)?` +
+      `(?:#${issue}\\b|${repo}#${issue}\\b|https?:\\/\\/github\\.com\\/${repo}\\/issues\\/${issue}\\b)`,
+    "i",
+  );
+  return text.split(/\r?\n/).some((line) => closingReference.test(line));
+}
+
+function fixedPullRequestFromCommitSha(
+  decision: Decision,
+  issueNumber: number,
+): FixedPullRequest | null {
   if (decision.decision !== "close" || decision.confidence !== "high") return null;
   const fixedSha = decision.fixedSha?.trim();
   if (!fixedSha || fixedSha === "unknown") return null;
@@ -8811,7 +8853,26 @@ function fixedPullRequestFromCommitSha(decision: Decision): FixedPullRequest | n
       "-H",
       "Accept: application/vnd.github+json",
     ]);
-    return fixedPullRequestFromCommitPulls(pulls, "GitHub commit PR lookup");
+    const repository = asRecord(ghJson<unknown>(["api", `repos/${targetRepo()}`]));
+    const defaultBranch = repository.default_branch;
+    if (typeof defaultBranch !== "string" || !defaultBranch.trim()) return null;
+    const bodyMatch = fixedPullRequestFromCommitPulls(
+      pulls,
+      "GitHub commit PR lookup",
+      issueNumber,
+      "",
+      defaultBranch,
+    );
+    if (bodyMatch) return bodyMatch;
+    const commit = asRecord(ghJson<unknown>(["api", `repos/${targetRepo()}/commits/${fixedSha}`]));
+    const commitMessage = asRecord(commit.commit).message;
+    return fixedPullRequestFromCommitPulls(
+      pulls,
+      "GitHub commit PR lookup",
+      issueNumber,
+      typeof commitMessage === "string" ? commitMessage : "",
+      defaultBranch,
+    );
   } catch (error) {
     if (isGitHubNotFoundError(error)) return null;
     throw error;
@@ -8822,7 +8883,7 @@ function attachFixedPullRequest(decision: Decision, item: Item, context: ItemCon
   if (decision.fixedPullRequest) return decision;
   const fixedPullRequest =
     fixedPullRequestFromContext(item, context, decision) ??
-    (item.kind === "issue" ? fixedPullRequestFromCommitSha(decision) : null);
+    (item.kind === "issue" ? fixedPullRequestFromCommitSha(decision, item.number) : null);
   return fixedPullRequest ? { ...decision, fixedPullRequest } : decision;
 }
 

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -3617,14 +3617,16 @@ interface PullRequestLiveActivity {
 
 const FAILING_CHECK_RUN_CONCLUSIONS = new Set(["failure", "timed_out"]);
 
-// Committer dates alone under-report activity: a contributor can push an old
-// commit, so the inactivity clock also observes status/check-run timestamps,
-// which CI refreshes on every push. Missing data keeps the PR open.
+// Commit dates are author-controlled and a force-push can reuse an old SHA.
+// A pull_request workflow run associated with this PR is tied to source
+// activity, while rerunning its checks leaves created_at unchanged. Missing
+// source-run data keeps the PR open.
 function pullRequestLiveActivity(number: number): PullRequestLiveActivity {
-  const pull = ghJson<{ draft?: boolean; head?: { sha?: string } }>([
-    "api",
-    `repos/${targetRepo()}/pulls/${number}`,
-  ]);
+  const pull = ghJson<{
+    created_at?: string;
+    draft?: boolean;
+    head?: { ref?: string; repo?: { full_name?: string; id?: unknown }; sha?: string };
+  }>(["api", `repos/${targetRepo()}/pulls/${number}`]);
   const headSha = typeof pull.head?.sha === "string" ? pull.head.sha : "";
   let headActivityAtMs: number | null = null;
   let headChecksFailing = false;
@@ -3635,21 +3637,45 @@ function pullRequestLiveActivity(number: number): PullRequestLiveActivity {
     }
   };
   if (headSha) {
-    const commit = ghJson<{ commit?: { committer?: { date?: string } } }>([
+    const sourceRuns = ghJson<{ workflow_runs?: unknown[] }>([
       "api",
-      `repos/${targetRepo()}/commits/${headSha}`,
+      `repos/${targetRepo()}/actions/runs?head_sha=${encodeURIComponent(headSha)}&event=pull_request&per_page=100`,
     ]);
-    observe(commit.commit?.committer?.date);
-    const combined = ghJson<{ state?: string; statuses?: unknown[] }>([
+    for (const run of sourceRuns.workflow_runs ?? []) {
+      const record = asRecord(run);
+      const directlyAssociated = Array.isArray(record.pull_requests)
+        ? record.pull_requests.some((pull) => Number(asRecord(pull).number) === number)
+        : false;
+      const runRepo = asRecord(record.head_repository);
+      const pullCreatedAtMs = Date.parse(pull.created_at ?? "");
+      const runCreatedAtMs = Date.parse(
+        typeof record.created_at === "string" ? record.created_at : "",
+      );
+      const sameSourceBranch =
+        typeof pull.head?.ref === "string" &&
+        record.head_branch === pull.head.ref &&
+        ((Number.isFinite(Number(pull.head.repo?.id)) &&
+          Number(pull.head.repo?.id) === Number(runRepo.id)) ||
+          (typeof pull.head.repo?.full_name === "string" &&
+            runRepo.full_name === pull.head.repo.full_name)) &&
+        Number.isFinite(pullCreatedAtMs) &&
+        Number.isFinite(runCreatedAtMs) &&
+        runCreatedAtMs >= pullCreatedAtMs;
+      if (record.event === "pull_request" && (directlyAssociated || sameSourceBranch)) {
+        observe(record.created_at);
+      }
+    }
+    for (const event of ghPaged<unknown>(`repos/${targetRepo()}/issues/${number}/timeline`)) {
+      const record = asRecord(event);
+      if (record.event === "head_ref_force_pushed" && record.commit_id === headSha) {
+        observe(record.created_at);
+      }
+    }
+    const combined = ghJson<{ state?: string }>([
       "api",
       `repos/${targetRepo()}/commits/${headSha}/status`,
     ]);
     if (combined.state === "failure" || combined.state === "error") headChecksFailing = true;
-    for (const status of combined.statuses ?? []) {
-      const record = asRecord(status);
-      observe(record.updated_at);
-      observe(record.created_at);
-    }
     const checks = ghJson<{ check_runs?: unknown[] }>([
       "api",
       `repos/${targetRepo()}/commits/${headSha}/check-runs?per_page=100`,
@@ -3662,8 +3688,6 @@ function pullRequestLiveActivity(number: number): PullRequestLiveActivity {
       ) {
         headChecksFailing = true;
       }
-      observe(record.started_at);
-      observe(record.completed_at);
     }
   }
   return { draft: pull.draft === true, headSha, headActivityAtMs, headChecksFailing };
@@ -3759,7 +3783,7 @@ function stalledUnprovenPrApplyBlockReason(
     activity.headActivityAtMs === null ||
     Date.now() - activity.headActivityAtMs <= STALLED_UNPROVEN_PR_MIN_INACTIVE_DAYS * DAY_MS
   ) {
-    return `stalled_unproven_pr requires ${STALLED_UNPROVEN_PR_MIN_INACTIVE_DAYS} days without new head commit or check activity`;
+    return `stalled_unproven_pr requires ${STALLED_UNPROVEN_PR_MIN_INACTIVE_DAYS} days without source activity on the current head`;
   }
   return pullRequestHumanEngagementBlockReason(number);
 }
@@ -3790,7 +3814,7 @@ function abandonedPrApplyBlockReason(
     activity.headActivityAtMs === null ||
     Date.now() - activity.headActivityAtMs <= ABANDONED_PR_MIN_INACTIVE_DAYS * DAY_MS
   ) {
-    return `abandoned_pr requires ${ABANDONED_PR_MIN_INACTIVE_DAYS} days without new head commit or check activity`;
+    return `abandoned_pr requires ${ABANDONED_PR_MIN_INACTIVE_DAYS} days without source activity on the current head`;
   }
   const waitingOnAuthor = item.labels
     .map(normalizeLabelName)

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -48,7 +48,7 @@ import {
   isLockedConversationCommentError,
   summarizeGhArgs,
 } from "./github-retry.js";
-import { parseGhJson, parseGhJsonLines } from "./github-json.js";
+import { parseGhJson, parseGhJsonLines, parseGhJsonWithRetry } from "./github-json.js";
 import { stableJson } from "./stable-json.js";
 import {
   appendFloorBackfillCandidates,
@@ -134,7 +134,12 @@ export {
   codexLoginMethod,
   redactInternalCodexModel,
 } from "./codex-env.js";
-export { parseGhJson, parseGhJsonLines } from "./github-json.js";
+export {
+  parseGhJson,
+  parseGhJsonLines,
+  parseGhJsonWithRetry,
+  parseGhJsonWithRetryAsync,
+} from "./github-json.js";
 export { itemNumbersArg } from "./clawsweeper-args.js";
 export {
   buildDecisionPacketFromReport,
@@ -2287,7 +2292,15 @@ function ghRawWithRetry(args: string[], attempts = 12): string {
 }
 
 function ghJson<T>(args: string[]): T {
-  return parseGhJson<T>(ghWithRetry(args), args);
+  return parseGhJsonWithRetry<T>(() => ghWithRetry(args), args, {
+    onRetry: (_error, attempt) => {
+      const waitMs = ghRetryWaitMs("transient", attempt - 1);
+      console.error(
+        `Malformed GitHub JSON response; retrying ${summarizeGhArgs(args)} in ${Math.round(waitMs / 1000)}s`,
+      );
+      sleepMs(waitMs);
+    },
+  });
 }
 
 function ghJsonOnce<T>(args: string[], timeoutMs: number): T {

--- a/src/github-json.ts
+++ b/src/github-json.ts
@@ -1,13 +1,64 @@
 import { summarizeGhArgs } from "./github-retry.js";
 
+export class GhJsonParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "GhJsonParseError";
+  }
+}
+
 export function parseGhJson<T>(text: string, args: readonly string[]): T {
   try {
     return JSON.parse(text) as T;
   } catch (error) {
-    throw new Error(
+    throw new GhJsonParseError(
       `Failed to parse JSON from ${summarizeGhArgs(args)}: ${formatParseError(error)}`,
     );
   }
+}
+
+export function parseGhJsonWithRetry<T>(
+  load: () => string,
+  args: readonly string[],
+  options: {
+    attempts?: number;
+    onRetry?: (error: GhJsonParseError, attempt: number, attempts: number) => void;
+  } = {},
+): T {
+  const attempts = Math.max(1, options.attempts ?? 3);
+  let lastError: GhJsonParseError | undefined;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return parseGhJson<T>(load(), args);
+    } catch (error) {
+      if (!(error instanceof GhJsonParseError) || attempt === attempts) throw error;
+      lastError = error;
+      options.onRetry?.(error, attempt, attempts);
+    }
+  }
+  throw lastError;
+}
+
+export async function parseGhJsonWithRetryAsync<T>(
+  load: () => Promise<string>,
+  args: readonly string[],
+  options: {
+    attempts?: number;
+    onRetry?: (error: GhJsonParseError, attempt: number, attempts: number) => void | Promise<void>;
+  } = {},
+): Promise<T> {
+  const attempts = Math.max(1, options.attempts ?? 3);
+  let lastError: GhJsonParseError | undefined;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return parseGhJson<T>(await load(), args);
+    } catch (error) {
+      if (!(error instanceof GhJsonParseError) || attempt === attempts) throw error;
+      lastError = error;
+      await options.onRetry?.(error, attempt, attempts);
+    }
+  }
+  throw lastError;
 }
 
 export function parseGhJsonLines<T>(text: string, args: readonly string[]): T[] {
@@ -19,7 +70,7 @@ export function parseGhJsonLines<T>(text: string, args: readonly string[]): T[] 
       try {
         return JSON.parse(line) as T;
       } catch (error) {
-        throw new Error(
+        throw new GhJsonParseError(
           `Failed to parse JSON line ${index + 1} from ${summarizeGhArgs(args)}: ${formatParseError(error)}`,
         );
       }

--- a/src/repair/github-cli.ts
+++ b/src/repair/github-cli.ts
@@ -5,6 +5,7 @@ import { stripAnsi } from "./comment-router-utils.js";
 import { ghCliEnv } from "./process-env.js";
 import { repoRoot } from "./paths.js";
 import { ghRetryKind, ghRetryWaitMs } from "../github-retry.js";
+import { parseGhJsonWithRetry, parseGhJsonWithRetryAsync } from "../github-json.js";
 import { resolveCommand } from "../command.js";
 
 const execFileAsync = promisify(execFile);
@@ -27,14 +28,22 @@ export function ghJsonWithRetry<T = JsonValue>(
   ghArgs: string[],
   options: GhRetryOptions | number = {},
 ): T {
-  return JSON.parse(ghTextWithRetry(ghArgs, options) || "null") as T;
+  return parseGhJsonWithRetry<T>(() => ghTextWithRetry(ghArgs, options) || "null", ghArgs, {
+    onRetry: (_error, attempt) => sleepMs(ghRetryWaitMs("transient", attempt - 1)),
+  });
 }
 
 export async function ghJsonWithRetryAsync<T = JsonValue>(
   ghArgs: string[],
   options: GhRetryOptions | number = {},
 ): Promise<T> {
-  return JSON.parse((await ghTextWithRetryAsync(ghArgs, options)) || "null") as T;
+  return parseGhJsonWithRetryAsync<T>(
+    async () => (await ghTextWithRetryAsync(ghArgs, options)) || "null",
+    ghArgs,
+    {
+      onRetry: (_error, attempt) => sleepAsync(ghRetryWaitMs("transient", attempt - 1)),
+    },
+  );
 }
 
 export function ghJsonBestEffort<T = JsonValue>(

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -1103,11 +1103,11 @@ type ProposedItemQualitySummary = {
 
 const FAST_CLOSE_BUCKET_ORDER: ProposedItemQualityBucket[] = [
   "ready_implemented",
+  "duplicate_or_superseded",
   "other",
   "aging_or_low_signal",
   "policy_sensitive",
   "retry_after_guard_skip",
-  "duplicate_or_superseded",
   "needs_pr_close_coverage",
   "promotion_probe",
 ];

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -1039,6 +1039,7 @@ type ProposedItemOptions = {
   batchSize?: number | null;
   cursorPath?: string | null;
   coverageProofLimit?: number | null;
+  closeLimit?: number | null;
   itemNumbers?: ReadonlySet<number> | null;
 };
 
@@ -1266,18 +1267,38 @@ function selectedProposedItemCandidates(
   }
 
   const proofLimit = Math.max(0, Math.min(options.coverageProofLimit, batchSize));
-  const fastCandidates = [
-    ...prioritizeFastCloseCandidates(rotate("confirmed_close", false, cursor)),
-    ...rotate("promotion_probe", false, cursor),
-  ];
+  const fastConfirmedCandidates = prioritizeFastCloseCandidates(
+    rotate("confirmed_close", false, cursor),
+  );
   const proofCursor = cursor?.coverageProof ?? cursor;
   const proofCandidates = [
     ...rotate("confirmed_close", true, proofCursor),
     ...rotate("promotion_probe", true, proofCursor),
   ];
   const selectedProof = proofCandidates.slice(0, proofLimit);
-  const selectedFast = fastCandidates.slice(0, batchSize - selectedProof.length);
-  return [...selectedProof, ...selectedFast];
+  const selectedFast = fastConfirmedCandidates.slice(0, batchSize - selectedProof.length);
+  const closeLimit = Math.max(1, Math.min(options.closeLimit ?? batchSize, batchSize));
+  // Let ready closes run first, but place every reserved proof before those
+  // closes could hit the mutation limit and stop the checkpoint. A candidate
+  // can close both a PR and its same-author issue counterpart.
+  const maxClosesPerCandidate = 2;
+  const closesReservedBeforeLastProof = Math.max(0, selectedProof.length - 1) * 2;
+  const candidatesBeforeProof = Math.floor(
+    Math.max(0, closeLimit - 1 - closesReservedBeforeLastProof) / maxClosesPerCandidate,
+  );
+  const preProofFastCount = selectedProof.length
+    ? Math.min(selectedFast.length, candidatesBeforeProof)
+    : selectedFast.length;
+  const selectedPromotions = rotate("promotion_probe", false, cursor).slice(
+    0,
+    batchSize - selectedFast.length - selectedProof.length,
+  );
+  return [
+    ...selectedFast.slice(0, preProofFastCount),
+    ...selectedProof,
+    ...selectedFast.slice(preProofFastCount),
+    ...selectedPromotions,
+  ];
 }
 
 export function proposedItemQualitySummary(
@@ -1740,6 +1761,7 @@ function applyCheckedAtForItem(targetRepo: string, itemNumber: number): string {
 function proposedItemOptions(): ProposedItemOptions {
   const batchSizeText = optionalString("batch-size");
   const coverageProofLimitText = optionalString("coverage-proof-limit");
+  const closeLimitText = optionalString("close-limit");
   return {
     targetRepo: requiredString("target-repo"),
     applyKind: optionalString("apply-kind") || "all",
@@ -1750,6 +1772,7 @@ function proposedItemOptions(): ProposedItemOptions {
     batchSize: batchSizeText ? numberArg("batch-size", 0) : null,
     cursorPath: optionalString("cursor-path") || null,
     coverageProofLimit: coverageProofLimitText ? numberArg("coverage-proof-limit", 0) : null,
+    closeLimit: closeLimitText ? numberArg("close-limit", 1) : null,
     itemNumbers: itemNumberSet(optionalString("item-numbers")),
   };
 }

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -1101,6 +1101,32 @@ type ProposedItemQualitySummary = {
   buckets: ProposedItemQualityBucketSummary[];
 };
 
+const FAST_CLOSE_BUCKET_ORDER: ProposedItemQualityBucket[] = [
+  "ready_implemented",
+  "other",
+  "aging_or_low_signal",
+  "policy_sensitive",
+  "retry_after_guard_skip",
+  "duplicate_or_superseded",
+  "needs_pr_close_coverage",
+  "promotion_probe",
+];
+
+function prioritizeFastCloseCandidates(
+  candidates: ProposedItemCandidate[],
+): ProposedItemCandidate[] {
+  const rank = new Map(FAST_CLOSE_BUCKET_ORDER.map((bucket, index) => [bucket, index]));
+  return candidates
+    .map((candidate, index) => ({ candidate, index }))
+    .sort(
+      (left, right) =>
+        (rank.get(left.candidate.qualityBucket) ?? Number.MAX_SAFE_INTEGER) -
+          (rank.get(right.candidate.qualityBucket) ?? Number.MAX_SAFE_INTEGER) ||
+        left.index - right.index,
+    )
+    .map(({ candidate }) => candidate);
+}
+
 function selectedProposedItemCandidates(
   options: ProposedItemOptions,
   selection: ProposedItemSelection,
@@ -1234,14 +1260,14 @@ function selectedProposedItemCandidates(
   // hydration cannot consume an entire apply window ahead of real proposals.
   if (options.coverageProofLimit === null || options.coverageProofLimit === undefined) {
     return [
-      ...rotate("confirmed_close", null, cursor),
+      ...prioritizeFastCloseCandidates(rotate("confirmed_close", null, cursor)),
       ...rotate("promotion_probe", null, cursor),
     ].slice(0, batchSize);
   }
 
   const proofLimit = Math.max(0, Math.min(options.coverageProofLimit, batchSize));
   const fastCandidates = [
-    ...rotate("confirmed_close", false, cursor),
+    ...prioritizeFastCloseCandidates(rotate("confirmed_close", false, cursor)),
     ...rotate("promotion_probe", false, cursor),
   ];
   const proofCursor = cursor?.coverageProof ?? cursor;
@@ -1251,7 +1277,7 @@ function selectedProposedItemCandidates(
   ];
   const selectedProof = proofCandidates.slice(0, proofLimit);
   const selectedFast = fastCandidates.slice(0, batchSize - selectedProof.length);
-  return [...selectedFast, ...selectedProof];
+  return [...selectedProof, ...selectedFast];
 }
 
 export function proposedItemQualitySummary(

--- a/test/apply-stalled-pr-policies.test.ts
+++ b/test/apply-stalled-pr-policies.test.ts
@@ -104,18 +104,42 @@ function stalledPrApplyGhMock(
   options: {
     draft?: boolean;
     headCommittedAt?: string;
+    sourceRunCreatedAts?: string[];
+    sourceRunHeadBranch?: string;
+    sourceRunPullNumber?: number;
     combinedStatusState?: string;
     checkRunConclusion?: string | null;
+    checkRunStartedAt?: string;
+    checkRunCompletedAt?: string;
+    forcePushAt?: string;
+    forcePushCommitId?: string;
     maintainerComment?: boolean;
     proofRequestedAt?: string;
   } = {},
 ): string {
   const draft = options.draft === true;
   const headCommittedAt = options.headCommittedAt ?? "2026-05-01T00:00:00Z";
+  const sourceRuns = (options.sourceRunCreatedAts ?? [headCommittedAt]).map((created_at) => ({
+    event: "pull_request",
+    created_at,
+    head_branch: options.sourceRunHeadBranch ?? "branch",
+    head_repository: { full_name: "fork/openclaw", id: 99 },
+    pull_requests:
+      options.sourceRunPullNumber === undefined ? [] : [{ number: options.sourceRunPullNumber }],
+  }));
   const proofRequestedAt = options.proofRequestedAt ?? "2026-05-10T00:00:00Z";
   const combinedStatusState = options.combinedStatusState ?? "failure";
   const checkRunConclusion =
     options.checkRunConclusion === undefined ? "failure" : options.checkRunConclusion;
+  const checkRunStartedAt = options.checkRunStartedAt ?? headCommittedAt;
+  const checkRunCompletedAt = options.checkRunCompletedAt ?? checkRunStartedAt;
+  const forcePushEvent = options.forcePushAt
+    ? `,{
+      event: "head_ref_force_pushed",
+      commit_id: ${JSON.stringify(options.forcePushCommitId ?? "head-sha")},
+      created_at: ${JSON.stringify(options.forcePushAt)}
+    }`
+    : "";
   const maintainerComment = options.maintainerComment
     ? `,{
       id: 9901,
@@ -148,7 +172,7 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
     event: "labeled",
     label: { name: "triage: needs-real-behavior-proof" },
     created_at: ${JSON.stringify(proofRequestedAt)}
-  }]]));
+  }${forcePushEvent}]]));
 } else if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
   console.log(JSON.stringify({
     number: 321,
@@ -177,24 +201,31 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
     html_url: "https://github.com/openclaw/openclaw/pull/321",
     state: "open",
     draft: ${draft},
+    created_at: "2026-05-01T00:00:00Z",
     changed_files: 1,
     commits: 1,
     review_comments: 0,
     requested_reviewers: [],
     requested_teams: [],
     body: "Fixes a small bug.",
-    head: { sha: "head-sha", ref: "branch", repo: { full_name: "fork/openclaw" } },
+    head: { sha: "head-sha", ref: "branch", repo: { full_name: "fork/openclaw", id: 99 } },
     base: { sha: "base-sha", ref: "main", repo: { full_name: "openclaw/openclaw" } },
     user: { login: "reporter" }
   }));
 } else if (args[0] === "api" && /\\/pulls\\/321\\/(files|commits|comments|reviews)(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/actions\\/runs\\?/.test(path)) {
+  console.log(JSON.stringify({ workflow_runs: ${JSON.stringify(sourceRuns)} }));
 } else if (args[0] === "api" && /\\/commits\\/head-sha\\/status(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify({ state: ${JSON.stringify(combinedStatusState)}, statuses: [] }));
 } else if (args[0] === "api" && /\\/commits\\/head-sha\\/check-runs(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify({
     total_count: ${checkRunConclusion === null ? 0 : 1},
-    check_runs: ${checkRunConclusion === null ? "[]" : `[{ conclusion: ${JSON.stringify(checkRunConclusion)} }]`}
+    check_runs: ${
+      checkRunConclusion === null
+        ? "[]"
+        : `[{ conclusion: ${JSON.stringify(checkRunConclusion)}, started_at: ${JSON.stringify(checkRunStartedAt)}, completed_at: ${JSON.stringify(checkRunCompletedAt)} }]`
+    }
   }));
 } else if (args[0] === "api" && /\\/commits\\/head-sha(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify({
@@ -298,20 +329,112 @@ test("stalled-unproven apply keeps a draft PR open for the abandoned policy", ()
   assert.equal(result.closedExists, false);
 });
 
-test("stalled-unproven apply keeps a PR open when head commits are recent", () => {
+test("stalled-unproven apply keeps a reused old head SHA open after fresh source activity", () => {
+  const recentSourceRunAt = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString();
   const result = runStalledPrApply({
     report: stalledUnprovenCloseReport(),
     closeReason: "stalled_unproven_pr",
-    ghOptions: { headCommittedAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString() },
+    ghOptions: {
+      headCommittedAt: "2025-01-01T00:00:00Z",
+      sourceRunCreatedAts: ["2026-05-01T00:00:00Z", recentSourceRunAt],
+    },
   });
   assert.deepEqual(result.entries, [
     {
       number: 321,
       action: "kept_open",
-      reason: "stalled_unproven_pr requires 14 days without new head commit or check activity",
+      reason: "stalled_unproven_pr requires 14 days without source activity on the current head",
     },
   ]);
   assert.equal(result.closedExists, false);
+});
+
+test("stalled-unproven apply keeps a reused old head SHA open after a force push", () => {
+  const recentForcePushAt = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString();
+  const result = runStalledPrApply({
+    report: stalledUnprovenCloseReport(),
+    closeReason: "stalled_unproven_pr",
+    ghOptions: {
+      headCommittedAt: "2025-01-01T00:00:00Z",
+      sourceRunCreatedAts: ["2026-05-01T00:00:00Z"],
+      forcePushAt: recentForcePushAt,
+    },
+  });
+  assert.deepEqual(result.entries, [
+    {
+      number: 321,
+      action: "kept_open",
+      reason: "stalled_unproven_pr requires 14 days without source activity on the current head",
+    },
+  ]);
+});
+
+test("stalled-unproven apply ignores later check reruns after old source activity", () => {
+  const recentCheckAt = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+  const result = runStalledPrApply({
+    report: stalledUnprovenCloseReport(),
+    closeReason: "stalled_unproven_pr",
+    ghOptions: {
+      sourceRunCreatedAts: ["2026-05-01T00:00:00Z"],
+      checkRunStartedAt: recentCheckAt,
+      checkRunCompletedAt: recentCheckAt,
+    },
+  });
+  assert.equal(result.entries.length, 1);
+  assert.equal(result.entries[0]?.action, "closed");
+});
+
+test("stalled-unproven apply keeps a PR open without a source workflow run", () => {
+  const result = runStalledPrApply({
+    report: stalledUnprovenCloseReport(),
+    closeReason: "stalled_unproven_pr",
+    ghOptions: {
+      sourceRunCreatedAts: [],
+    },
+  });
+  assert.deepEqual(result.entries, [
+    {
+      number: 321,
+      action: "kept_open",
+      reason: "stalled_unproven_pr requires 14 days without source activity on the current head",
+    },
+  ]);
+});
+
+test("stalled-unproven apply ignores a source run for another PR sharing the head SHA", () => {
+  const result = runStalledPrApply({
+    report: stalledUnprovenCloseReport(),
+    closeReason: "stalled_unproven_pr",
+    ghOptions: {
+      sourceRunCreatedAts: ["2026-05-01T00:00:00Z"],
+      sourceRunHeadBranch: "other-branch",
+      sourceRunPullNumber: 999,
+    },
+  });
+  assert.deepEqual(result.entries, [
+    {
+      number: 321,
+      action: "kept_open",
+      reason: "stalled_unproven_pr requires 14 days without source activity on the current head",
+    },
+  ]);
+});
+
+test("stalled-unproven apply ignores a same-branch source run from before this PR opened", () => {
+  const result = runStalledPrApply({
+    report: stalledUnprovenCloseReport(),
+    closeReason: "stalled_unproven_pr",
+    ghOptions: {
+      sourceRunCreatedAts: ["2026-04-01T00:00:00Z"],
+    },
+  });
+  assert.deepEqual(result.entries, [
+    {
+      number: 321,
+      action: "kept_open",
+      reason: "stalled_unproven_pr requires 14 days without source activity on the current head",
+    },
+  ]);
 });
 
 test("stalled-unproven apply keeps a PR open when the proof request is too fresh", () => {
@@ -358,17 +481,18 @@ test("apply dry-run closes an abandoned PR with failing checks", () => {
   assert.match(result.entries[0]?.reason ?? "", /would close as abandoned inactive PR/);
 });
 
-test("abandoned apply keeps a PR open when head commits are recent", () => {
+test("abandoned apply keeps a PR open when source activity is recent", () => {
+  const recentSourceRunAt = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString();
   const result = runStalledPrApply({
     report: abandonedCloseReport(),
     closeReason: "abandoned_pr",
-    ghOptions: { headCommittedAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString() },
+    ghOptions: { sourceRunCreatedAts: [recentSourceRunAt] },
   });
   assert.deepEqual(result.entries, [
     {
       number: 321,
       action: "kept_open",
-      reason: "abandoned_pr requires 30 days without new head commit or check activity",
+      reason: "abandoned_pr requires 30 days without source activity on the current head",
     },
   ]);
   assert.equal(result.closedExists, false);

--- a/test/repair/workflow-sparse-checkout.test.ts
+++ b/test/repair/workflow-sparse-checkout.test.ts
@@ -35,6 +35,13 @@ test("sparse repair build workflows include runtime dependencies", () => {
   }
 });
 
+test("sparse CI checkout includes pnpm workspace policy", () => {
+  const workflow = readText(".github/workflows/ci.yml");
+  const entries = sparseCheckoutEntries(workflow);
+
+  assert.ok(entries.has("pnpm-workspace.yaml"));
+});
+
 test("repair build emits the bounded Codex process worker", () => {
   const config = JSON.parse(fs.readFileSync("tsconfig.repair.json", "utf8")) as {
     include?: string[];

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -1660,7 +1660,7 @@ test("workflow utilities rotate bounded apply candidate batches by apply cursor"
   );
 });
 
-test("workflow utilities prioritize ready closes ahead of policy-gated candidates", () => {
+test("workflow utilities prioritize ready and duplicate closes ahead of policy candidates", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
   const oldDate = "2024-01-01T00:00:00Z";
   writeProposedRecord(
@@ -1674,6 +1674,8 @@ test("workflow utilities prioritize ready closes ahead of policy-gated candidate
   writeProposedRecord(root, 20, "issue", "proposed_close", "implemented_on_main", oldDate, {
     applyCheckedAt: "2026-01-01T00:00:00Z",
   });
+  writeProposedRecord(root, 30, "issue", "proposed_close", "duplicate_or_superseded", oldDate);
+  writeProposedRecord(root, 40, "pull_request", "proposed_close", "stalled_unproven_pr", oldDate);
 
   assert.deepEqual(
     withCwd(root, () =>
@@ -1684,11 +1686,11 @@ test("workflow utilities prioritize ready closes ahead of policy-gated candidate
         staleMinAgeDays: 60,
         minAgeDays: 0,
         minAgeMinutes: null,
-        batchSize: 2,
+        batchSize: 4,
         coverageProofLimit: 1,
       }),
     ),
-    [20, 10],
+    [20, 30, 40, 10],
   );
 });
 

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -1660,6 +1660,38 @@ test("workflow utilities rotate bounded apply candidate batches by apply cursor"
   );
 });
 
+test("workflow utilities prioritize ready closes ahead of policy-gated candidates", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const oldDate = "2024-01-01T00:00:00Z";
+  writeProposedRecord(
+    root,
+    10,
+    "pull_request",
+    "proposed_close",
+    "unconfirmed_product_direction",
+    oldDate,
+  );
+  writeProposedRecord(root, 20, "issue", "proposed_close", "implemented_on_main", oldDate, {
+    applyCheckedAt: "2026-01-01T00:00:00Z",
+  });
+
+  assert.deepEqual(
+    withCwd(root, () =>
+      proposedItemNumbers({
+        targetRepo: "openclaw/openclaw",
+        applyKind: "all",
+        applyCloseReasons: "all",
+        staleMinAgeDays: 60,
+        minAgeDays: 0,
+        minAgeMinutes: null,
+        batchSize: 2,
+        coverageProofLimit: 1,
+      }),
+    ),
+    [20, 10],
+  );
+});
+
 test("workflow utilities backfill promotion probes after confirmed close proposals", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
   const oldDate = "2024-01-01T00:00:00Z";
@@ -1764,7 +1796,7 @@ test("workflow utilities bound coverage proofs with an independent cursor", () =
 
   assert.deepEqual(
     withCwd(root, () => proposedItemNumbers(options)),
-    [10, 20, 30, 40],
+    [40, 10, 20, 30],
   );
   write(
     cursorPath,
@@ -1779,7 +1811,7 @@ test("workflow utilities bound coverage proofs with an independent cursor", () =
   );
   assert.deepEqual(
     withCwd(root, () => proposedItemNumbers(options)),
-    [30, 10, 20, 50],
+    [50, 30, 10, 20],
   );
 });
 

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -1660,7 +1660,7 @@ test("workflow utilities rotate bounded apply candidate batches by apply cursor"
   );
 });
 
-test("workflow utilities prioritize ready and duplicate closes ahead of policy candidates", () => {
+test("workflow utilities run a bounded confirmed prefix before proof and defer promotion probes", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
   const oldDate = "2024-01-01T00:00:00Z";
   writeProposedRecord(
@@ -1675,7 +1675,32 @@ test("workflow utilities prioritize ready and duplicate closes ahead of policy c
     applyCheckedAt: "2026-01-01T00:00:00Z",
   });
   writeProposedRecord(root, 30, "issue", "proposed_close", "duplicate_or_superseded", oldDate);
+  writeProposedRecord(
+    root,
+    35,
+    "pull_request",
+    "proposed_close",
+    "duplicate_or_superseded",
+    oldDate,
+  );
   writeProposedRecord(root, 40, "pull_request", "proposed_close", "stalled_unproven_pr", oldDate);
+  write(
+    path.join(root, "records/openclaw-openclaw/items/openclaw-openclaw-50.md"),
+    [
+      "---",
+      "repository: openclaw/openclaw",
+      "type: pull_request",
+      "decision: keep_open",
+      "review_status: complete",
+      "local_checkout_access: verified",
+      "action_taken: kept_open",
+      "close_reason: none",
+      `item_created_at: ${oldDate}`,
+      "pr_rating_overall: F",
+      "---",
+      "",
+    ].join("\n"),
+  );
 
   assert.deepEqual(
     withCwd(root, () =>
@@ -1686,11 +1711,27 @@ test("workflow utilities prioritize ready and duplicate closes ahead of policy c
         staleMinAgeDays: 60,
         minAgeDays: 0,
         minAgeMinutes: null,
-        batchSize: 4,
+        batchSize: 5,
         coverageProofLimit: 1,
       }),
     ),
-    [20, 30, 40, 10],
+    [20, 30, 35, 40, 10],
+  );
+  assert.deepEqual(
+    withCwd(root, () =>
+      proposedItemNumbers({
+        targetRepo: "openclaw/openclaw",
+        applyKind: "all",
+        applyCloseReasons: "all",
+        staleMinAgeDays: 60,
+        minAgeDays: 0,
+        minAgeMinutes: null,
+        batchSize: 6,
+        closeLimit: 4,
+        coverageProofLimit: 1,
+      }),
+    ),
+    [20, 35, 30, 40, 10, 50],
   );
 });
 
@@ -1798,7 +1839,7 @@ test("workflow utilities bound coverage proofs with an independent cursor", () =
 
   assert.deepEqual(
     withCwd(root, () => proposedItemNumbers(options)),
-    [40, 10, 20, 30],
+    [10, 40, 20, 30],
   );
   write(
     cursorPath,
@@ -1813,7 +1854,7 @@ test("workflow utilities bound coverage proofs with an independent cursor", () =
   );
   assert.deepEqual(
     withCwd(root, () => proposedItemNumbers(options)),
-    [50, 30, 10, 20],
+    [30, 50, 10, 20],
   );
 });
 

--- a/test/review-close-policy.test.ts
+++ b/test/review-close-policy.test.ts
@@ -276,29 +276,38 @@ test("close comments reference high-confidence merged fixing PRs", () => {
 });
 
 test("commit PR lookup selects the newest merged pull request", () => {
-  const fixedPullRequest = fixedPullRequestFromCommitPullsForTest([
-    {
-      number: 455,
-      html_url: "https://github.com/openclaw/openclaw/pull/455",
-      title: "fix: older candidate",
-      merged: true,
-      merged_at: "2026-04-27T12:00:00Z",
-      merge_commit_sha: "1111111111111111",
-    },
-    {
-      number: 456,
-      html_url: "https://github.com/openclaw/openclaw/pull/456",
-      title: "fix: wire the shell check",
-      merged_at: "2026-04-28T12:00:00Z",
-      merge_commit_sha: "fedcba9876543210",
-    },
-    {
-      number: 457,
-      html_url: "https://github.com/openclaw/openclaw/pull/457",
-      title: "open follow-up",
-      merged: false,
-    },
-  ]);
+  const fixedPullRequest = fixedPullRequestFromCommitPullsForTest(
+    [
+      {
+        number: 455,
+        html_url: "https://github.com/openclaw/openclaw/pull/455",
+        title: "fix: older candidate",
+        merged: true,
+        merged_at: "2026-04-27T12:00:00Z",
+        merge_commit_sha: "1111111111111111",
+        body: "Fixes openclaw/openclaw#123",
+        base: { ref: "main" },
+      },
+      {
+        number: 456,
+        html_url: "https://github.com/openclaw/openclaw/pull/456",
+        title: "fix: wire the shell check",
+        merged_at: "2026-04-28T12:00:00Z",
+        merge_commit_sha: "fedcba9876543210",
+        body: "Resolves https://github.com/openclaw/openclaw/issues/123",
+        base: { ref: "main" },
+      },
+      {
+        number: 457,
+        html_url: "https://github.com/openclaw/openclaw/pull/457",
+        title: "open follow-up",
+        merged: false,
+        body: "Closes #123",
+        base: { ref: "main" },
+      },
+    ],
+    123,
+  );
 
   assert.deepEqual(fixedPullRequest, {
     repo: "openclaw/openclaw",
@@ -310,6 +319,77 @@ test("commit PR lookup selects the newest merged pull request", () => {
     confidence: "high",
     source: "GitHub commit PR lookup",
   });
+});
+
+test("commit PR lookup rejects unrelated closing references at the claimed fixed SHA", () => {
+  const fixedPullRequest = fixedPullRequestFromCommitPullsForTest(
+    [
+      {
+        number: 456,
+        html_url: "https://github.com/openclaw/openclaw/pull/456",
+        title: "fix: unrelated main-head change",
+        merged_at: "2026-04-28T12:00:00Z",
+        merge_commit_sha: "fedcba9876543210",
+        body: "Fixes #999",
+      },
+      {
+        number: 457,
+        html_url: "https://github.com/openclaw/openclaw/pull/457",
+        title: "fix: mentions the issue without closing it",
+        merged_at: "2026-04-29T12:00:00Z",
+        merge_commit_sha: "abcdef9876543210",
+        body: "Fixes #999; related to #123",
+      },
+      {
+        number: 458,
+        html_url: "https://github.com/openclaw/openclaw/pull/458",
+        title: "fix: closes the same number in another repository",
+        merged_at: "2026-04-30T12:00:00Z",
+        merge_commit_sha: "1234567890abcdef",
+        body: "Fixes other/repository#123",
+      },
+    ],
+    123,
+  );
+
+  assert.equal(fixedPullRequest, null);
+});
+
+test("commit PR lookup accepts an exact closing reference in the fixed commit message", () => {
+  const pull = {
+    number: 456,
+    html_url: "https://github.com/openclaw/openclaw/pull/456",
+    title: "fix: wire the shell check",
+    merged_at: "2026-04-28T12:00:00Z",
+    merge_commit_sha: "fedcba9876543210",
+    body: "Related to #123",
+    base: { ref: "main" },
+  };
+
+  assert.equal(
+    fixedPullRequestFromCommitPullsForTest([pull], 123, "Fixes other/repository#123"),
+    null,
+  );
+  assert.equal(fixedPullRequestFromCommitPullsForTest([pull], 123, "Fixes #999; see #123"), null);
+  assert.equal(
+    fixedPullRequestFromCommitPullsForTest([pull], 123, "Fixes openclaw/openclaw#123")?.number,
+    456,
+  );
+});
+
+test("commit PR lookup rejects closing references on a non-default branch", () => {
+  const pull = {
+    number: 456,
+    html_url: "https://github.com/openclaw/openclaw/pull/456",
+    title: "fix: backport the shell check",
+    merged_at: "2026-04-28T12:00:00Z",
+    merge_commit_sha: "fedcba9876543210",
+    body: "Fixes #123",
+    base: { ref: "release" },
+  };
+
+  assert.equal(fixedPullRequestFromCommitPullsForTest([pull], 123), null);
+  assert.equal(fixedPullRequestFromCommitPullsForTest([pull], 123, "Fixes #123"), null);
 });
 
 test("report-rendered close comments keep merged fixing PR provenance", () => {

--- a/test/review-close-policy.test.ts
+++ b/test/review-close-policy.test.ts
@@ -6,6 +6,7 @@ import {
   isProtectedItem,
   parseGhJson,
   parseGhJsonLines,
+  parseGhJsonWithRetry,
   protectedLabels,
   renderReviewCommentFromReport,
   reviewActionForDecision,
@@ -47,6 +48,19 @@ test("parseGhJsonLines adds line number and command context to malformed JSONL e
     () => parseGhJsonLines('{"ok":true}\nnot-json\n', ["issue", "list", "--json", "number"]),
     /Failed to parse JSON line 2 from gh issue list --json:/,
   );
+});
+
+test("parseGhJsonWithRetry reloads malformed successful responses", () => {
+  const responses = ['{"items":', '{"items":[1]}'];
+  const retries: number[] = [];
+  const parsed = parseGhJsonWithRetry<{ items: number[] }>(
+    () => responses.shift() ?? "",
+    ["api", "repos/openclaw/openclaw/pulls/42/files"],
+    { onRetry: (_error, attempt) => retries.push(attempt) },
+  );
+
+  assert.deepEqual(parsed, { items: [1] });
+  assert.deepEqual(retries, [1]);
 });
 
 test("commit review reports use one canonical path per commit", () => {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -121,6 +121,17 @@ test("apply workflow installs Codex only when proof-eligible apply work can run"
   assert.doesNotMatch(preselectBlock, /normalized_apply_close_reasons=/);
 });
 
+test("apply workflow target token can inspect source workflow runs", () => {
+  const workflow = readText(".github/workflows/sweep.yml");
+  const applyJob = workflow.slice(workflow.indexOf("\n  apply-existing:"));
+  const tokenStart = applyJob.indexOf("- name: Create target write token");
+  const stateTokenStart = applyJob.indexOf("- name: Create state token", tokenStart);
+
+  assert.ok(tokenStart !== -1);
+  assert.ok(stateTokenStart > tokenStart);
+  assert.match(applyJob.slice(tokenStart, stateTokenStart), /permission-actions: read/);
+});
+
 test("apply workflow bounds checkpoints and requeues with a fresh token", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const applyHelper = readText("scripts/apply-workflow-helpers.sh");
@@ -210,6 +221,10 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
   assert.ok(qualitySummaryIndex > applyReconcileIndex);
   assert.ok(proposedNumbersIndex > qualitySummaryIndex);
   assert.match(applyStep, /--batch-size "\$close_processed_limit"/);
+  assert.match(
+    applyStep,
+    /--close-limit "\$\(\(limit < checkpoint_size \? limit : checkpoint_size\)\)"/,
+  );
   assert.match(applyStep, /--coverage-proof-limit "\$coverage_proof_limit"/);
   assert.match(applyStep, /select_bounded_coverage_proof_tail/);
   assert.match(applyHelper, /select_bounded_coverage_proof_tail\(\)/);
@@ -220,10 +235,7 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
     applyStep,
     /Scan window: \$close_processed_limit records \(\$adaptive_apply_scan_reason\)/,
   );
-  assert.match(
-    applyStep,
-    /Auto-selected \$proposed_count proposed close candidate\(s\) from \$close_processed_limit-record apply cursor window/,
-  );
+  assert.match(applyStep, /Selected \$proposed_count from \$close_processed_limit/);
   assert.match(applyStep, /--cursor-path "\$apply_cursor_path"/);
   assert.match(applyStep, /write-apply-cursor/);
   assert.match(applyStep, /--item-numbers "\$item_numbers"/);

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -154,6 +154,8 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
   );
   assert.match(inputBlock, /apply_limit:[\s\S]*default: "20"/);
   assert.match(inputBlock, /apply_checkpoint_size:[\s\S]*default: "20"/);
+  assert.match(workflow, /github\.event\.inputs\.apply_limit != '20'/);
+  assert.match(workflow, /github\.event\.inputs\.apply_checkpoint_size != '20'/);
   assert.match(applyStep, /Capping apply checkpoint size at 20/);
   assert.match(applyStep, /base_close_processed_limit=300/);
   assert.match(applyHelper, /coverage_proof_limit=1/);
@@ -257,6 +259,8 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
   assert.match(continueStep, /can_share_apply_continuation=false/);
   assert.match(continueStep, /\[ "\$\{APPLY_AUTO_SELECTED_BATCH:-false\}" = "true" \]/);
   assert.match(continueStep, /\[ -z "\$\{APPLY_ITEM_NUMBERS:-\}" \]/);
+  assert.match(continueStep, /\[ "\$\{APPLY_LIMIT:-20\}" = "20" \]/);
+  assert.match(continueStep, /\[ "\$\{APPLY_CHECKPOINT_SIZE:-20\}" = "20" \]/);
   assert.match(continueStep, /\[ "\$\{APPLY_COMMENT_SYNC_MIN_AGE_DAYS:-7\}" = "7" \]/);
   assert.match(continueStep, /preserving exact continuation dispatch/);
   assert.match(


### PR DESCRIPTION
## Summary

- raise default close-apply limits and checkpoints from 5 to 20
- run a bounded prefix of confirmed closes before the reserved close-coverage proof, then defer speculative promotion scans
- anchor stalled-PR inactivity to source-triggered workflow runs and matching force-push events without letting later CI reruns reset the clock
- retry malformed successful GitHub JSON responses in core and repair paths
- load the root pnpm workspace policy in sparse CI checkouts so release-age exemptions are actually enforced

## Why

Close runs were spending their small windows on slow or speculative candidates before reaching already-reviewed decisions, while putting proof first could consume the whole checkpoint before any known-safe close. Bot-triggered check reruns also made old PR heads appear active forever. Successful `gh` calls that returned malformed JSON failed the whole lane instead of retrying.

## Impact

Default apply runs can drain up to 20 fresh closes per checkpoint and preserve shareable continuations. Confirmed closes get useful work done before the one reserved proof, but that proof remains guaranteed to run before pair-closes can exhaust the mutation cap. Inactivity is tied to the exact PR or source branch after the PR opened, with current-head force pushes counted and missing source data kept open. Protected-label, author, human-engagement, proof, and snapshot-freshness gates remain unchanged.

## Validation

- `corepack pnpm run check`
- focused stalled-PR, candidate-ordering, cursor, and workflow-permission regressions
- repeated local autoreview until no actionable findings remained
- live GitHub verification of source-run timestamps, branch identity, and force-push timeline events
- manual cleanup validated backlog candidates against current main and canonical issues
