### PR TITLE
fix: retry failed issue reviews safely

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1346,6 +1346,7 @@ jobs:
           CLAWSWEEPER_PROOF_INSPECTION_TOKEN: ${{ steps.codex-inspection-token.outputs.token || github.token }}
           ADDITIONAL_PROMPT: ${{ github.event.inputs.additional_prompt || github.event.client_payload.additional_prompt || '' }}
           EXACT_ITEM: ${{ github.event.client_payload.item_number || github.event.inputs.item_number || github.event.inputs.item_numbers || '' }}
+          EXPECTED_SOURCE_REVISION: ${{ github.event.client_payload.expected_source_revision || '' }}
         run: |
           hot_intake_arg=()
           if [ "${{ needs.plan.outputs.hot_intake }}" = "true" ]; then
@@ -1354,6 +1355,10 @@ jobs:
           additional_prompt_arg=()
           if [ -n "$ADDITIONAL_PROMPT" ]; then
             additional_prompt_arg=(--additional-prompt "$ADDITIONAL_PROMPT")
+          fi
+          expected_source_revision_arg=()
+          if [ -n "$EXPECTED_SOURCE_REVISION" ]; then
+            expected_source_revision_arg=(--expected-source-revision "$EXPECTED_SOURCE_REVISION")
           fi
           planned_automatic_review_arg=()
           if [ -z "$EXACT_ITEM" ]; then
@@ -1384,7 +1389,8 @@ jobs:
             --readonly-openclaw \
             --shard-index ${{ matrix.shard }} \
             --shard-count ${{ needs.plan.outputs.planned_shards }} \
-            "${additional_prompt_arg[@]}"
+            "${additional_prompt_arg[@]}" \
+            "${expected_source_revision_arg[@]}"
 
       - name: Record shard metrics
         if: always()
@@ -1444,6 +1450,78 @@ jobs:
           name: review-metrics-${{ matrix.shard }}
           path: review-artifacts/metrics/shard-${{ matrix.shard }}.json
           if-no-files-found: ignore
+
+      - uses: actions/upload-artifact@v7
+        if: ${{ always() && github.event_name == 'repository_dispatch' && github.event.client_payload.expected_source_revision != '' }}
+        with:
+          name: review-source-revision-mismatch-${{ matrix.shard }}
+          path: review-artifacts/shard-${{ matrix.shard }}/source-revision-mismatch.json
+          if-no-files-found: ignore
+
+  requeue-source-revision-drift:
+    name: Requeue source-revision drift
+    needs: [plan, review]
+    if: ${{ always() && needs.plan.result == 'success' && needs.review.result != 'cancelled' && github.event_name == 'repository_dispatch' && github.event.action == 'clawsweeper_target_sweep' && github.event.client_payload.expected_source_revision != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: review-source-revision-mismatch-*
+          path: source-revision-mismatches
+          merge-multiple: true
+
+      - name: Dispatch exact review at current revision
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_SOURCE_REVISION: ${{ github.event.client_payload.expected_source_revision || '' }}
+          REQUEUE_COUNT: ${{ github.event.client_payload.source_revision_requeue_count || '0' }}
+          TARGET_REPO: ${{ needs.plan.outputs.target_repo }}
+          TARGET_BRANCH: ${{ needs.plan.outputs.target_branch }}
+          CODEX_TIMEOUT_MS: ${{ needs.plan.outputs.codex_timeout_ms }}
+        run: |
+          set -euo pipefail
+          marker="source-revision-mismatches/source-revision-mismatch.json"
+          if [ ! -f "$marker" ]; then
+            exit 0
+          fi
+          if ! [[ "$REQUEUE_COUNT" =~ ^[0-9]+$ ]] || [ "$REQUEUE_COUNT" -ge 1 ]; then
+            echo "::warning::Source revision changed again; leaving the normal scheduler to pick up the latest revision."
+            exit 0
+          fi
+          marker_expected="$(jq -r '.expected_source_revision // empty' "$marker")"
+          actual_revision="$(jq -r '.actual_source_revision // empty' "$marker")"
+          item_number="$(jq -r '.item_number // empty' "$marker")"
+          if [ "$marker_expected" != "$EXPECTED_SOURCE_REVISION" ] || \
+             ! [[ "$actual_revision" =~ ^[0-9a-f]{64}$ ]] || \
+             ! [[ "$item_number" =~ ^[0-9]+$ ]]; then
+            echo "::warning::Ignoring invalid source-revision mismatch marker."
+            exit 0
+          fi
+          jq -n \
+            --arg target_repo "$TARGET_REPO" \
+            --arg target_branch "$TARGET_BRANCH" \
+            --arg item_number "$item_number" \
+            --arg codex_timeout_ms "$CODEX_TIMEOUT_MS" \
+            --arg expected_source_revision "$actual_revision" \
+            '{
+              event_type: "clawsweeper_target_sweep",
+              client_payload: {
+                target_repo: $target_repo,
+                target_branch: $target_branch,
+                item_number: $item_number,
+                batch_size: "1",
+                shard_count: "1",
+                hot_intake: "false",
+                codex_timeout_ms: $codex_timeout_ms,
+                expected_source_revision: $expected_source_revision,
+                source_revision_requeue_count: "1"
+              }
+            }' | gh api --method POST "repos/$GITHUB_REPOSITORY/dispatches" --input -
+          echo "::notice::Requeued $TARGET_REPO#$item_number at source revision $actual_revision."
 
   publish:
     name: Publish review artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Retried infrastructure-failed issue reviews against their exact source revision and preserved bounded retry metadata across repeated review failures.
 - Stopped later CI reruns from resetting PR inactivity clocks by anchoring head activity to the latest source-triggered workflow run associated with that pull request.
 - Prioritized ready close decisions and bounded PR close-coverage proofs before slow policy-gated candidates, kept default 20-item continuations shareable, and retried malformed successful GitHub JSON responses.
 - Removed exponential backtracking from durable review-marker parsing so adversarial comment bodies cannot stall apply or comment synchronization.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
-- Retried infrastructure-failed issue reviews against their exact source revision and preserved bounded retry metadata across repeated review failures.
+- Retried infrastructure-failed issue reviews against their exact source revision through asynchronous dispatch, requeued source drift once, and preserved bounded retry metadata across repeated review failures.
 - Stopped later CI reruns from resetting PR inactivity clocks by anchoring head activity to the latest source-triggered workflow run associated with that pull request.
 - Prioritized ready close decisions and bounded PR close-coverage proofs before slow policy-gated candidates, kept default 20-item continuations shareable, and retried malformed successful GitHub JSON responses.
 - Removed exponential backtracking from durable review-marker parsing so adversarial comment bodies cannot stall apply or comment synchronization.

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -158,6 +158,11 @@ type ItemKind = "issue" | "pull_request";
 type ApplyKind = ItemKind | "all";
 type DecisionKind = "close" | "keep_open";
 type WorkCandidateKind = "none" | "manual_review" | "queue_fix_pr";
+type FailedReviewRetryRevisionKind = "pull_head_sha" | "item_source_revision";
+interface FailedReviewRetryRevision {
+  kind: FailedReviewRetryRevisionKind;
+  value: string;
+}
 type FailedReviewRetryAction =
   | "dispatched_failed_review_retry"
   | "planned_failed_review_retry"
@@ -169,6 +174,9 @@ type FailedReviewRetryAction =
   | "skipped_missing_report_head"
   | "skipped_missing_live_head"
   | "skipped_stale_head"
+  | "skipped_missing_report_revision"
+  | "skipped_missing_live_revision"
+  | "skipped_stale_revision"
   | "skipped_non_infrastructure_failure"
   | "skipped_retry_cooldown"
   | "skipped_retry_exhausted"
@@ -887,6 +895,8 @@ interface FailedReviewRetryResult {
   action: FailedReviewRetryAction;
   reason: string;
   headSha?: string | undefined;
+  revisionKind?: FailedReviewRetryRevisionKind | undefined;
+  revision?: string | undefined;
   attempts?: number | undefined;
   reportPath?: string | undefined;
   dispatchUrl?: string | undefined;
@@ -5678,25 +5688,75 @@ function effectiveReviewStatus(markdown: string): string {
   return status;
 }
 
-function failedReviewRetryCount(markdown: string, headSha: string): number {
-  const storedHead = frontMatterValue(markdown, "failed_review_retry_head_sha");
-  if (storedHead && storedHead !== headSha) return 0;
+function failedReviewRetryRevisionForReport(markdown: string): FailedReviewRetryRevision | null {
+  const kind = frontMatterValue(markdown, "type");
+  if (kind === "pull_request") {
+    const value = pullHeadShaFromReport(markdown);
+    return value ? { kind: "pull_head_sha", value } : null;
+  }
+  if (kind === "issue") {
+    const value = frontMatterValue(markdown, "item_source_revision");
+    return value && value !== "unknown" ? { kind: "item_source_revision", value } : null;
+  }
+  return null;
+}
+
+function storedFailedReviewRetryRevision(markdown: string): FailedReviewRetryRevision | null {
+  const kind = frontMatterValue(markdown, "failed_review_retry_revision_kind");
+  const value = frontMatterValue(markdown, "failed_review_retry_revision");
+  if ((kind === "pull_head_sha" || kind === "item_source_revision") && value) {
+    return { kind, value };
+  }
+  const legacyHead = frontMatterValue(markdown, "failed_review_retry_head_sha");
+  return legacyHead ? { kind: "pull_head_sha", value: legacyHead } : null;
+}
+
+function sameFailedReviewRetryRevision(
+  left: FailedReviewRetryRevision,
+  right: FailedReviewRetryRevision,
+): boolean {
+  return left.kind === right.kind && left.value === right.value;
+}
+
+function failedReviewRetryResultRevision(revision: FailedReviewRetryRevision): {
+  headSha?: string;
+  revisionKind: FailedReviewRetryRevisionKind;
+  revision: string;
+} {
+  return {
+    ...(revision.kind === "pull_head_sha" ? { headSha: revision.value } : {}),
+    revisionKind: revision.kind,
+    revision: revision.value,
+  };
+}
+
+function failedReviewRetryCount(markdown: string, revision: FailedReviewRetryRevision): number {
+  const storedRevision = storedFailedReviewRetryRevision(markdown);
+  if (storedRevision && !sameFailedReviewRetryRevision(storedRevision, revision)) return 0;
   const value = frontMatterValue(markdown, "failed_review_retry_count");
   if (!value) return 0;
   const parsed = Number(value);
   return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 0;
 }
 
-function failedReviewRetryLastAtMs(markdown: string, headSha: string): number | null {
-  const storedHead = frontMatterValue(markdown, "failed_review_retry_head_sha");
-  if (storedHead && storedHead !== headSha) return null;
+function failedReviewRetryLastAtMs(
+  markdown: string,
+  revision: FailedReviewRetryRevision,
+): number | null {
+  const storedRevision = storedFailedReviewRetryRevision(markdown);
+  if (storedRevision && !sameFailedReviewRetryRevision(storedRevision, revision)) return null;
   return timestampMs(frontMatterValue(markdown, "failed_review_retry_last_at"));
 }
 
-function isFailedReviewRetryAlreadyExhausted(markdown: string, headSha: string): boolean {
+function isFailedReviewRetryAlreadyExhausted(
+  markdown: string,
+  revision: FailedReviewRetryRevision,
+): boolean {
+  const storedRevision = storedFailedReviewRetryRevision(markdown);
   return (
     frontMatterValue(markdown, "failed_review_retry_status") === "exhausted" &&
-    frontMatterValue(markdown, "failed_review_retry_head_sha") === headSha
+    storedRevision !== null &&
+    sameFailedReviewRetryRevision(storedRevision, revision)
   );
 }
 
@@ -5731,6 +5791,7 @@ export function failedReviewRetryEligibilityForTest(options: {
   markdown: string;
   liveState: string;
   liveHeadSha?: string | null;
+  liveSourceRevision?: string | null;
   now: number;
   maxAttempts: number;
   cooldownMs: number;
@@ -5742,6 +5803,7 @@ function failedReviewRetryEligibility(options: {
   markdown: string;
   liveState: string;
   liveHeadSha?: string | null;
+  liveSourceRevision?: string | null;
   now: number;
   maxAttempts: number;
   cooldownMs: number;
@@ -5754,40 +5816,61 @@ function failedReviewRetryEligibility(options: {
   if (options.liveState !== "open") {
     return { repo, number, action: "skipped_not_open", reason: `state is ${options.liveState}` };
   }
-  if (frontMatterValue(options.markdown, "type") !== "pull_request") {
+  const itemKind = frontMatterValue(options.markdown, "type");
+  if (itemKind !== "pull_request" && itemKind !== "issue") {
     return {
       repo,
       number,
       action: "skipped_not_pull_request",
-      reason: "failed-review retry requires a pull request head SHA",
+      reason: "failed-review retry requires an issue or pull request report",
     };
   }
-  const reportHeadSha = pullHeadShaFromReport(options.markdown);
-  if (!reportHeadSha) {
+  const reportRevision = failedReviewRetryRevisionForReport(options.markdown);
+  if (!reportRevision) {
     return {
       repo,
       number,
-      action: "skipped_missing_report_head",
-      reason: "report does not record a pull_head_sha",
+      action:
+        itemKind === "pull_request"
+          ? "skipped_missing_report_head"
+          : "skipped_missing_report_revision",
+      reason:
+        itemKind === "pull_request"
+          ? "report does not record a pull_head_sha"
+          : "report does not record an item_source_revision",
     };
   }
-  const liveHeadSha = options.liveHeadSha?.trim() || null;
-  if (!liveHeadSha) {
+  const liveRevisionValue =
+    (reportRevision.kind === "pull_head_sha"
+      ? options.liveHeadSha
+      : options.liveSourceRevision
+    )?.trim() || null;
+  if (!liveRevisionValue) {
     return {
       repo,
       number,
-      action: "skipped_missing_live_head",
-      reason: "live pull request head SHA is unavailable",
-      headSha: reportHeadSha,
+      action:
+        reportRevision.kind === "pull_head_sha"
+          ? "skipped_missing_live_head"
+          : "skipped_missing_live_revision",
+      reason:
+        reportRevision.kind === "pull_head_sha"
+          ? "live pull request head SHA is unavailable"
+          : "live issue source revision is unavailable",
+      ...failedReviewRetryResultRevision(reportRevision),
     };
   }
-  if (liveHeadSha !== reportHeadSha) {
+  if (liveRevisionValue !== reportRevision.value) {
     return {
       repo,
       number,
-      action: "skipped_stale_head",
-      reason: `live head ${liveHeadSha} does not match failed report head ${reportHeadSha}`,
-      headSha: reportHeadSha,
+      action:
+        reportRevision.kind === "pull_head_sha" ? "skipped_stale_head" : "skipped_stale_revision",
+      reason:
+        reportRevision.kind === "pull_head_sha"
+          ? `live head ${liveRevisionValue} does not match failed report head ${reportRevision.value}`
+          : `live source revision ${liveRevisionValue} does not match failed report source revision ${reportRevision.value}`,
+      ...failedReviewRetryResultRevision(reportRevision),
     };
   }
   if (!isInfrastructureFailedReview(options.markdown)) {
@@ -5796,21 +5879,25 @@ function failedReviewRetryEligibility(options: {
       number,
       action: "skipped_non_infrastructure_failure",
       reason: "failed review does not look like a Codex timeout or infrastructure failure",
-      headSha: reportHeadSha,
+      ...failedReviewRetryResultRevision(reportRevision),
     };
   }
-  const attempts = failedReviewRetryCount(options.markdown, reportHeadSha);
+  const attempts = failedReviewRetryCount(options.markdown, reportRevision);
+  const revisionDescription =
+    reportRevision.kind === "pull_head_sha"
+      ? `head ${reportRevision.value}`
+      : `source revision ${reportRevision.value}`;
   if (attempts >= options.maxAttempts) {
     return {
       repo,
       number,
       action: "skipped_retry_exhausted",
-      reason: `retry attempts exhausted for head ${reportHeadSha}: ${attempts}/${options.maxAttempts}`,
-      headSha: reportHeadSha,
+      reason: `retry attempts exhausted for ${revisionDescription}: ${attempts}/${options.maxAttempts}`,
+      ...failedReviewRetryResultRevision(reportRevision),
       attempts,
     };
   }
-  const lastAtMs = failedReviewRetryLastAtMs(options.markdown, reportHeadSha);
+  const lastAtMs = failedReviewRetryLastAtMs(options.markdown, reportRevision);
   if (lastAtMs !== null && options.now - lastAtMs < options.cooldownMs) {
     const remainingMs = Math.max(0, options.cooldownMs - (options.now - lastAtMs));
     return {
@@ -5818,7 +5905,7 @@ function failedReviewRetryEligibility(options: {
       number,
       action: "skipped_retry_cooldown",
       reason: `retry cooldown has ${Math.ceil(remainingMs / 60000)} minute(s) remaining`,
-      headSha: reportHeadSha,
+      ...failedReviewRetryResultRevision(reportRevision),
       attempts,
     };
   }
@@ -5826,8 +5913,8 @@ function failedReviewRetryEligibility(options: {
     repo,
     number,
     action: "planned_failed_review_retry",
-    reason: `eligible infrastructure failed review at head ${reportHeadSha}`,
-    headSha: reportHeadSha,
+    reason: `eligible infrastructure failed review at ${revisionDescription}`,
+    ...failedReviewRetryResultRevision(reportRevision),
     attempts,
   };
 }
@@ -17939,9 +18026,19 @@ function livePullHeadSha(number: number): string | null {
   return sha.trim() || null;
 }
 
+function liveIssueSourceRevision(number: number): string {
+  const issue = ghJson<unknown>(["api", `repos/${targetRepo()}/issues/${number}`]);
+  const comments = ghPaged<unknown>(`repos/${targetRepo()}/issues/${number}/comments`);
+  return itemSourceRevisionSha256(issue, comments);
+}
+
+function failedReviewRetryRevisionLabel(revision: FailedReviewRetryRevision): string {
+  return revision.kind === "pull_head_sha" ? "head SHA" : "issue source revision";
+}
+
 function failedReviewRetryPrompt(options: {
   number: number;
-  headSha: string;
+  revision: FailedReviewRetryRevision;
   reason: string;
   attempts: number;
   maxAttempts: number;
@@ -17951,7 +18048,7 @@ function failedReviewRetryPrompt(options: {
     "",
     "This is a bounded exact-item retry for a prior Codex timeout or infrastructure failure.",
     `Retry item: #${options.number}`,
-    `Failed report head SHA: ${options.headSha}`,
+    `Failed report ${failedReviewRetryRevisionLabel(options.revision)}: ${options.revision.value}`,
     `Prior failure: ${options.reason}`,
     `Retry attempt: ${options.attempts + 1}/${options.maxAttempts}`,
     "",
@@ -17963,7 +18060,7 @@ function failedReviewRetryPrompt(options: {
 function failedReviewRetrySection(options: {
   status: "dispatched" | "exhausted";
   at: string;
-  headSha: string;
+  revision: FailedReviewRetryRevision;
   attempts: number;
   maxAttempts: number;
   reason: string;
@@ -17972,14 +18069,14 @@ function failedReviewRetrySection(options: {
   const lines = [
     `- status: ${options.status}`,
     `- recorded at: ${options.at}`,
-    `- head SHA: ${options.headSha}`,
+    `- ${failedReviewRetryRevisionLabel(options.revision)}: ${options.revision.value}`,
     `- attempts: ${options.attempts}/${options.maxAttempts}`,
     `- reason: ${options.reason}`,
   ];
   if (options.dispatchUrl) lines.push(`- retry run: ${options.dispatchUrl}`);
   if (options.status === "exhausted") {
     lines.push(
-      "- next step: needs human review; retry attempts for this exact head are exhausted.",
+      "- next step: needs human review; retry attempts for this exact revision are exhausted.",
     );
   }
   return lines.join("\n");
@@ -17989,7 +18086,7 @@ function markFailedReviewRetry(options: {
   markdown: string;
   status: "dispatched" | "exhausted";
   at: string;
-  headSha: string;
+  revision: FailedReviewRetryRevision;
   attempts: number;
   maxAttempts: number;
   reason: string;
@@ -17999,7 +18096,11 @@ function markFailedReviewRetry(options: {
   next = replaceFrontMatterValue(next, "failed_review_retry_status", options.status);
   next = replaceFrontMatterValue(next, "failed_review_retry_count", String(options.attempts));
   next = replaceFrontMatterValue(next, "failed_review_retry_last_at", options.at);
-  next = replaceFrontMatterValue(next, "failed_review_retry_head_sha", options.headSha);
+  next = replaceFrontMatterValue(next, "failed_review_retry_revision_kind", options.revision.kind);
+  next = replaceFrontMatterValue(next, "failed_review_retry_revision", options.revision.value);
+  if (options.revision.kind === "pull_head_sha") {
+    next = replaceFrontMatterValue(next, "failed_review_retry_head_sha", options.revision.value);
+  }
   next = replaceFrontMatterValue(
     next,
     "failed_review_retry_reason",
@@ -18011,12 +18112,55 @@ function markFailedReviewRetry(options: {
   return appendSectionValue(next, "Failed Review Retry", failedReviewRetrySection(options));
 }
 
+const FAILED_REVIEW_RETRY_METADATA_KEYS = [
+  "failed_review_retry_status",
+  "failed_review_retry_count",
+  "failed_review_retry_last_at",
+  "failed_review_retry_revision_kind",
+  "failed_review_retry_revision",
+  "failed_review_retry_head_sha",
+  "failed_review_retry_reason",
+  "failed_review_retry_dispatch_url",
+] as const;
+
+export function preserveFailedReviewRetryMetadataForTest(
+  previousMarkdown: string,
+  incomingMarkdown: string,
+): string {
+  return preserveFailedReviewRetryMetadata(previousMarkdown, incomingMarkdown);
+}
+
+function preserveFailedReviewRetryMetadata(
+  previousMarkdown: string,
+  incomingMarkdown: string,
+): string {
+  if (effectiveReviewStatus(incomingMarkdown) !== "failed") return incomingMarkdown;
+  const previousRevision = storedFailedReviewRetryRevision(previousMarkdown);
+  const incomingRevision = failedReviewRetryRevisionForReport(incomingMarkdown);
+  if (
+    !previousRevision ||
+    !incomingRevision ||
+    !sameFailedReviewRetryRevision(previousRevision, incomingRevision)
+  ) {
+    return incomingMarkdown;
+  }
+
+  let next = incomingMarkdown;
+  for (const key of FAILED_REVIEW_RETRY_METADATA_KEYS) {
+    const value = frontMatterValue(previousMarkdown, key);
+    if (value) next = replaceFrontMatterValue(next, key, value);
+  }
+  const retrySection = sectionValue(previousMarkdown, "Failed Review Retry");
+  if (retrySection) next = replaceSectionValue(next, "Failed Review Retry", retrySection);
+  return next;
+}
+
 function dispatchFailedReviewRetry(options: {
   workflowRepo: string;
   workflowRef: string;
   targetRepo: string;
   number: number;
-  headSha: string;
+  revision: FailedReviewRetryRevision;
   reason: string;
   attempts: number;
   maxAttempts: number;
@@ -18024,7 +18168,7 @@ function dispatchFailedReviewRetry(options: {
 }): string {
   const prompt = failedReviewRetryPrompt({
     number: options.number,
-    headSha: options.headSha,
+    revision: options.revision,
     reason: options.reason,
     attempts: options.attempts,
     maxAttempts: options.maxAttempts,
@@ -18100,9 +18244,11 @@ function retryFailedReviewsCommand(args: Args): void {
     let item: Item;
     let state: string;
     let liveHeadSha: string | null = null;
+    let liveSourceRevision: string | null = null;
     try {
       ({ item, state } = fetchItem(number));
       if (item.kind === "pull_request") liveHeadSha = livePullHeadSha(number);
+      else liveSourceRevision = liveIssueSourceRevision(number);
     } catch (error) {
       results.push({
         repo: targetRepo(),
@@ -18117,12 +18263,17 @@ function retryFailedReviewsCommand(args: Args): void {
       markdown,
       liveState: state,
       liveHeadSha,
+      liveSourceRevision,
       now,
       maxAttempts,
       cooldownMs,
     });
-    if (eligibility.action === "skipped_retry_exhausted" && eligibility.headSha) {
-      if (isFailedReviewRetryAlreadyExhausted(markdown, eligibility.headSha)) {
+    const retryRevision =
+      eligibility.revisionKind && eligibility.revision
+        ? { kind: eligibility.revisionKind, value: eligibility.revision }
+        : null;
+    if (eligibility.action === "skipped_retry_exhausted" && retryRevision) {
+      if (isFailedReviewRetryAlreadyExhausted(markdown, retryRevision)) {
         results.push({
           ...eligibility,
           action: "skipped_retry_already_exhausted",
@@ -18135,7 +18286,7 @@ function retryFailedReviewsCommand(args: Args): void {
         markdown,
         status: "exhausted",
         at: nowIso,
-        headSha: eligibility.headSha,
+        revision: retryRevision,
         attempts,
         maxAttempts,
         reason: eligibility.reason,
@@ -18148,7 +18299,7 @@ function retryFailedReviewsCommand(args: Args): void {
       });
       continue;
     }
-    if (eligibility.action !== "planned_failed_review_retry" || !eligibility.headSha) {
+    if (eligibility.action !== "planned_failed_review_retry" || !retryRevision) {
       results.push({ ...eligibility, reportPath: path });
       continue;
     }
@@ -18166,7 +18317,7 @@ function retryFailedReviewsCommand(args: Args): void {
         workflowRef,
         targetRepo: targetRepo(),
         number,
-        headSha: eligibility.headSha,
+        revision: retryRevision,
         reason: retryReason,
         attempts: eligibility.attempts ?? 0,
         maxAttempts,
@@ -18176,7 +18327,7 @@ function retryFailedReviewsCommand(args: Args): void {
         markdown,
         status: "dispatched",
         at: nowIso,
-        headSha: eligibility.headSha,
+        revision: retryRevision,
         attempts,
         maxAttempts,
         reason: retryReason,
@@ -18188,7 +18339,7 @@ function retryFailedReviewsCommand(args: Args): void {
         number,
         action: "dispatched_failed_review_retry",
         reason: retryReason,
-        headSha: eligibility.headSha,
+        ...failedReviewRetryResultRevision(retryRevision),
         attempts,
         reportPath: path,
         dispatchUrl,
@@ -18200,7 +18351,7 @@ function retryFailedReviewsCommand(args: Args): void {
         number,
         action: "skipped_dispatch_failed",
         reason: error instanceof Error ? error.message : String(error),
-        headSha: eligibility.headSha,
+        ...failedReviewRetryResultRevision(retryRevision),
         attempts: eligibility.attempts,
         reportPath: path,
       });
@@ -20580,7 +20731,7 @@ function applyArtifactsCommand(args: Args): void {
       const source = join(artifactDir, name);
       if (!parseReportFileName(basename(source))) continue;
       const number = numberForMarkdownFile(basename(source));
-      const markdown = readFileSync(source, "utf8");
+      let markdown = readFileSync(source, "utf8");
       if (!isMarkdownForActiveRepo(markdown, basename(source))) continue;
       const destinationFile = reportFileName(
         markdownRepository(markdown, basename(source)),
@@ -20599,6 +20750,9 @@ function applyArtifactsCommand(args: Args): void {
       const stalePath = join(destinationDir === itemsDir ? closedDir : itemsDir, destinationFile);
       if (existsSync(stalePath)) unlinkSync(stalePath);
       const reportPath = join(destinationDir, destinationFile);
+      if (existsSync(reportPath)) {
+        markdown = preserveFailedReviewRetryMetadata(readFileSync(reportPath, "utf8"), markdown);
+      }
       const syncedMarkdown = syncDecisionPacketRecord({
         markdown,
         reportPath,

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -17698,6 +17698,12 @@ function reviewCommand(args: Args): void {
   const sandboxMode = stringArg(args.codex_sandbox, "read-only");
   const serviceTier = stringArg(args.codex_service_tier, localOnly ? "fast" : DEFAULT_SERVICE_TIER);
   const timeoutMs = numberArg(args.codex_timeout_ms, DEFAULT_REVIEW_CODEX_TIMEOUT_MS);
+  const expectedSourceRevision = stringArg(args.expected_source_revision, "").trim();
+  if (expectedSourceRevision && !/^[0-9a-f]{64}$/.test(expectedSourceRevision)) {
+    throw new UserFacingCommandError(
+      "--expected-source-revision must be a lowercase SHA-256 digest.",
+    );
+  }
   let additionalPrompt = stringArg(
     args.additional_prompt,
     process.env.CLAWSWEEPER_ADDITIONAL_PROMPT ?? "",
@@ -17779,6 +17785,11 @@ function reviewCommand(args: Args): void {
     const { candidates, scannedPages } = localRangeData
       ? { candidates: [localRangeData.item], scannedPages: 0 }
       : selectCandidates(selectionOptions);
+    if (expectedSourceRevision && candidates.length !== 1) {
+      throw new UserFacingCommandError(
+        `--expected-source-revision requires exactly one selected issue; selected ${candidates.length}.`,
+      );
+    }
     if (humanLocalReview) {
       if (candidates.length === 0) throw exactLocalReviewNoCandidateError(itemNumber, shardIndex);
       const item = candidates[0]!;
@@ -17815,6 +17826,16 @@ function reviewCommand(args: Args): void {
             reviewCacheDigest: true,
           });
       const contextElapsedMs = Date.now() - contextStartedAt;
+      if (expectedSourceRevision) {
+        enforceExpectedIssueSourceRevision({
+          expectedSourceRevision,
+          itemKind: item.kind,
+          repo: item.repo,
+          number: item.number,
+          sourceRevision: context.sourceRevision,
+          artifactDir,
+        });
+      }
       const contentDigest = itemContentDigest(item, context, git);
       const priorReview =
         explicitDispatch || maintainerRequest ? null : existingReview(item, itemsDir);
@@ -18016,6 +18037,58 @@ function reviewCommand(args: Args): void {
   }
 }
 
+const SOURCE_REVISION_MISMATCH_MARKER = "source-revision-mismatch.json";
+
+interface ExpectedIssueSourceRevisionOptions {
+  expectedSourceRevision: string;
+  itemKind: "issue" | "pull_request";
+  repo: string;
+  number: number;
+  sourceRevision: string | undefined;
+  artifactDir: string;
+}
+
+function enforceExpectedIssueSourceRevision(options: ExpectedIssueSourceRevisionOptions): void {
+  if (options.itemKind !== "issue") {
+    throw new UserFacingCommandError(
+      "--expected-source-revision can only bind an exact issue review.",
+    );
+  }
+  const actualSourceRevision = options.sourceRevision ?? "";
+  if (!/^[0-9a-f]{64}$/.test(actualSourceRevision)) {
+    throw new UserFacingCommandError(
+      `Could not compute the live source revision for ${options.repo}#${options.number}.`,
+    );
+  }
+  if (actualSourceRevision === options.expectedSourceRevision) return;
+
+  writeFileSync(
+    join(options.artifactDir, SOURCE_REVISION_MISMATCH_MARKER),
+    `${JSON.stringify(
+      {
+        schema_version: 1,
+        target_repo: options.repo,
+        item_number: options.number,
+        expected_source_revision: options.expectedSourceRevision,
+        actual_source_revision: actualSourceRevision,
+        detected_at: new Date().toISOString(),
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+  throw new UserFacingCommandError(
+    `${options.repo}#${options.number} changed before review: expected source revision ${options.expectedSourceRevision}, found ${actualSourceRevision}.`,
+  );
+}
+
+export function enforceExpectedIssueSourceRevisionForTest(
+  options: ExpectedIssueSourceRevisionOptions,
+): void {
+  enforceExpectedIssueSourceRevision(options);
+}
+
 function livePullHeadSha(number: number): string | null {
   const sha = ghWithRetry([
     "api",
@@ -18173,6 +18246,53 @@ function dispatchFailedReviewRetry(options: {
     attempts: options.attempts,
     maxAttempts: options.maxAttempts,
   });
+  if (options.revision.kind === "item_source_revision") {
+    const workflowDefaultBranch = ghWithRetry([
+      "api",
+      `repos/${options.workflowRepo}`,
+      "--jq",
+      ".default_branch // empty",
+    ]).trim();
+    if (!workflowDefaultBranch) {
+      throw new UserFacingCommandError(
+        `Could not resolve the default branch for ${options.workflowRepo}.`,
+      );
+    }
+    if (options.workflowRef !== workflowDefaultBranch) {
+      throw new UserFacingCommandError(
+        `Issue retry repository dispatch requires the workflow repository default branch (${workflowDefaultBranch}); got --workflow-ref ${options.workflowRef}.`,
+      );
+    }
+    ghRawWithRetry([
+      "api",
+      "--method",
+      "POST",
+      `repos/${options.workflowRepo}/dispatches`,
+      "-f",
+      "event_type=clawsweeper_target_sweep",
+      "-f",
+      `client_payload[target_repo]=${options.targetRepo}`,
+      "-f",
+      "client_payload[target_branch]=main",
+      "-f",
+      "client_payload[batch_size]=1",
+      "-f",
+      "client_payload[shard_count]=1",
+      "-f",
+      "client_payload[hot_intake]=false",
+      "-f",
+      `client_payload[codex_timeout_ms]=${options.codexTimeoutMs}`,
+      "-f",
+      `client_payload[item_number]=${options.number}`,
+      "-f",
+      `client_payload[additional_prompt]=${prompt}`,
+      "-f",
+      `client_payload[expected_source_revision]=${options.revision.value}`,
+      "-f",
+      "client_payload[source_revision_requeue_count]=0",
+    ]);
+    return `https://github.com/${options.workflowRepo}/actions/workflows/sweep.yml`;
+  }
   ghRawWithRetry([
     "workflow",
     "run",

--- a/test/failed-review-retry.test.ts
+++ b/test/failed-review-retry.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import test from "node:test";
 
 import {
+  enforceExpectedIssueSourceRevisionForTest,
   failedReviewRetryEligibilityForTest,
   itemSourceRevisionSha256ForTest,
   isInfrastructureFailedReviewForTest,
@@ -266,11 +267,12 @@ test("failed review retry eligibility enforces cooldown and max attempts per hea
   );
 });
 
-test("failed issue retry command plans an exact-item retry without a pull request head", () => {
+test("failed issue retry dispatch binds the expected source revision", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
     const itemsDir = join(root, "items");
     const reportPath = join(root, "failed-review-retry-report.json");
+    const dispatchPath = join(root, "dispatch.json");
     const issue = {
       number: 4343,
       title: "Failed issue review retry sample",
@@ -312,6 +314,14 @@ if (path.endsWith("/issues/4343")) {
   console.log(${JSON.stringify(JSON.stringify(issue))});
   process.exit(0);
 }
+if (path === "repos/openclaw/clawsweeper") {
+  console.log("main");
+  process.exit(0);
+}
+if (path.endsWith("/dispatches") && args.includes("POST")) {
+  require("node:fs").writeFileSync(${JSON.stringify(dispatchPath)}, JSON.stringify(args));
+  process.exit(0);
+}
 console.error("unexpected gh args: " + args.join(" "));
 process.exit(1);
 `;
@@ -326,7 +336,29 @@ process.exit(1);
         itemsDir,
         "--item-number",
         "4343",
-        "--dry-run",
+        "--workflow-ref",
+        "test-branch",
+        "--report-path",
+        reportPath,
+      ]);
+      const rejected = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+        action: string;
+        reason: string;
+      }>;
+      assert.equal(rejected[0]?.action, "skipped_dispatch_failed");
+      assert.match(rejected[0]?.reason ?? "", /default branch \(main\).*test-branch/);
+
+      execFileSync(process.execPath, [
+        "dist/clawsweeper.js",
+        "retry-failed-reviews",
+        "--target-repo",
+        "openclaw/openclaw",
+        "--items-dir",
+        itemsDir,
+        "--item-number",
+        "4343",
+        "--workflow-ref",
+        "main",
         "--report-path",
         reportPath,
       ]);
@@ -338,12 +370,70 @@ process.exit(1);
       revision?: string;
     }>;
     assert.equal(report.length, 1);
-    assert.equal(report[0]?.action, "planned_failed_review_retry");
+    assert.equal(report[0]?.action, "dispatched_failed_review_retry");
     assert.equal(report[0]?.revisionKind, "item_source_revision");
     assert.equal(report[0]?.revision, sourceRevision);
+    const dispatch = JSON.parse(readFileSync(dispatchPath, "utf8")) as string[];
+    assert.ok(dispatch.includes("repos/openclaw/clawsweeper/dispatches"));
+    assert.ok(dispatch.includes("event_type=clawsweeper_target_sweep"));
+    assert.ok(dispatch.includes(`client_payload[expected_source_revision]=${sourceRevision}`));
+    assert.ok(dispatch.includes("client_payload[source_revision_requeue_count]=0"));
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+test("expected issue source revision aborts drift and writes a requeue marker", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const expectedSourceRevision = "a".repeat(64);
+  const actualSourceRevision = "b".repeat(64);
+  try {
+    assert.doesNotThrow(() =>
+      enforceExpectedIssueSourceRevisionForTest({
+        expectedSourceRevision,
+        itemKind: "issue",
+        repo: "openclaw/openclaw",
+        number: 4343,
+        sourceRevision: expectedSourceRevision,
+        artifactDir: root,
+      }),
+    );
+    assert.throws(
+      () =>
+        enforceExpectedIssueSourceRevisionForTest({
+          expectedSourceRevision,
+          itemKind: "issue",
+          repo: "openclaw/openclaw",
+          number: 4343,
+          sourceRevision: actualSourceRevision,
+          artifactDir: root,
+        }),
+      /changed before review/,
+    );
+    const marker = JSON.parse(
+      readFileSync(join(root, "source-revision-mismatch.json"), "utf8"),
+    ) as Record<string, unknown>;
+    assert.equal(marker.target_repo, "openclaw/openclaw");
+    assert.equal(marker.item_number, 4343);
+    assert.equal(marker.expected_source_revision, expectedSourceRevision);
+    assert.equal(marker.actual_source_revision, actualSourceRevision);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("sweep workflow forwards source revision and bounds drift requeue", () => {
+  const workflow = readFileSync(".github/workflows/sweep.yml", "utf8");
+
+  assert.match(workflow, /EXPECTED_SOURCE_REVISION:.*client_payload\.expected_source_revision/);
+  assert.match(workflow, /--expected-source-revision "\$EXPECTED_SOURCE_REVISION"/);
+  assert.match(workflow, /requeue-source-revision-drift:\n\s+name: Requeue source-revision drift/);
+  assert.match(workflow, /name: review-source-revision-mismatch-\$\{\{ matrix\.shard \}\}/);
+  assert.match(workflow, /requeue-source-revision-drift:[\s\S]*?contents: write/);
+  assert.match(workflow, /review:[\s\S]*?permissions:\n\s+contents: read/);
+  assert.match(workflow, /\[ "\$REQUEUE_COUNT" -ge 1 \]/);
+  assert.match(workflow, /expected_source_revision: \$expected_source_revision/);
+  assert.match(workflow, /source_revision_requeue_count: "1"/);
 });
 
 test("failed retry metadata survives a repeated failure at the same revision", () => {

--- a/test/failed-review-retry.test.ts
+++ b/test/failed-review-retry.test.ts
@@ -6,7 +6,9 @@ import test from "node:test";
 
 import {
   failedReviewRetryEligibilityForTest,
+  itemSourceRevisionSha256ForTest,
   isInfrastructureFailedReviewForTest,
+  preserveFailedReviewRetryMetadataForTest,
 } from "../dist/clawsweeper.js";
 import { tmpPrefix, withMockGh, workPlanCandidateReport } from "./helpers.ts";
 
@@ -17,6 +19,7 @@ function failedReviewReport(overrides = {}) {
     type: "pull_request",
     review_status: "failed",
     pull_head_sha: "abc123def456",
+    item_source_revision: "issue-source-revision",
     decision: "keep_open",
     confidence: "low",
     action_taken: "kept_open",
@@ -55,6 +58,8 @@ test("failed review retry eligibility requires infrastructure failure and matchi
       action: "planned_failed_review_retry",
       reason: "eligible infrastructure failed review at head abc123def456",
       headSha: "abc123def456",
+      revisionKind: "pull_head_sha",
+      revision: "abc123def456",
       attempts: 0,
     },
   );
@@ -79,6 +84,80 @@ test("failed review retry eligibility requires infrastructure failure and matchi
       cooldownMs: 45 * 60 * 1000,
     }).action,
     "skipped_not_failed_review",
+  );
+});
+
+test("failed issue reviews retry at a matching live source revision", () => {
+  const markdown = failedReviewReport({
+    type: "issue",
+    pull_head_sha: "unknown",
+    item_source_revision: "issue-source-revision",
+  });
+  const options = {
+    markdown,
+    liveState: "open",
+    liveSourceRevision: "issue-source-revision",
+    now: Date.parse("2026-06-05T20:00:00Z"),
+    maxAttempts: 2,
+    cooldownMs: 45 * 60 * 1000,
+  };
+
+  assert.deepEqual(failedReviewRetryEligibilityForTest(options), {
+    repo: "openclaw/openclaw",
+    number: 4242,
+    action: "planned_failed_review_retry",
+    reason: "eligible infrastructure failed review at source revision issue-source-revision",
+    revisionKind: "item_source_revision",
+    revision: "issue-source-revision",
+    attempts: 0,
+  });
+  assert.equal(
+    failedReviewRetryEligibilityForTest({
+      ...options,
+      liveSourceRevision: "new-source-revision",
+    }).action,
+    "skipped_stale_revision",
+  );
+  assert.equal(
+    failedReviewRetryEligibilityForTest({
+      ...options,
+      markdown: failedReviewReport({
+        type: "issue",
+        pull_head_sha: "unknown",
+        item_source_revision: "unknown",
+      }),
+    }).action,
+    "skipped_missing_report_revision",
+  );
+  assert.equal(
+    failedReviewRetryEligibilityForTest({
+      ...options,
+      markdown: failedReviewReport({
+        type: "issue",
+        pull_head_sha: "unknown",
+        item_source_revision: "issue-source-revision",
+        failed_review_retry_revision_kind: "item_source_revision",
+        failed_review_retry_revision: "issue-source-revision",
+        failed_review_retry_count: 1,
+        failed_review_retry_last_at: "2026-06-05T19:30:00Z",
+      }),
+    }).action,
+    "skipped_retry_cooldown",
+  );
+  assert.equal(
+    failedReviewRetryEligibilityForTest({
+      ...options,
+      markdown: failedReviewReport({
+        type: "issue",
+        pull_head_sha: "unknown",
+        item_source_revision: "issue-source-revision",
+        failed_review_retry_revision_kind: "item_source_revision",
+        failed_review_retry_revision: "issue-source-revision",
+        failed_review_retry_count: 2,
+        failed_review_retry_last_at: "2026-06-05T18:00:00Z",
+      }),
+    }).action,
+    "skipped_retry_exhausted",
   );
 });
 
@@ -187,6 +266,141 @@ test("failed review retry eligibility enforces cooldown and max attempts per hea
   );
 });
 
+test("failed issue retry command plans an exact-item retry without a pull request head", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const reportPath = join(root, "failed-review-retry-report.json");
+    const issue = {
+      number: 4343,
+      title: "Failed issue review retry sample",
+      body: "Issue body",
+      html_url: "https://github.com/openclaw/openclaw/issues/4343",
+      created_at: "2026-06-01T00:00:00Z",
+      updated_at: "2026-06-01T01:00:00Z",
+      closed_at: null,
+      state: "open",
+      locked: false,
+      active_lock_reason: null,
+      author_association: "CONTRIBUTOR",
+      user: { login: "contributor" },
+      labels: [],
+      comments: 0,
+      pull_request: null,
+    };
+    const sourceRevision = itemSourceRevisionSha256ForTest(issue, []);
+    mkdirSync(itemsDir, { recursive: true });
+    writeFileSync(
+      join(itemsDir, "4343.md"),
+      failedReviewReport({
+        number: 4343,
+        type: "issue",
+        pull_head_sha: "unknown",
+        item_source_revision: sourceRevision,
+      }),
+      "utf8",
+    );
+
+    const ghMock = `#!/usr/bin/env node
+const args = process.argv.slice(2);
+const path = args.find((arg) => arg.startsWith("repos/")) || "";
+if (/\\/issues\\/4343\\/comments(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify(args.includes("--slurp") ? [[]] : []));
+  process.exit(0);
+}
+if (path.endsWith("/issues/4343")) {
+  console.log(${JSON.stringify(JSON.stringify(issue))});
+  process.exit(0);
+}
+console.error("unexpected gh args: " + args.join(" "));
+process.exit(1);
+`;
+
+    withMockGh(root, ghMock, () => {
+      execFileSync(process.execPath, [
+        "dist/clawsweeper.js",
+        "retry-failed-reviews",
+        "--target-repo",
+        "openclaw/openclaw",
+        "--items-dir",
+        itemsDir,
+        "--item-number",
+        "4343",
+        "--dry-run",
+        "--report-path",
+        reportPath,
+      ]);
+    });
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+      action: string;
+      revisionKind?: string;
+      revision?: string;
+    }>;
+    assert.equal(report.length, 1);
+    assert.equal(report[0]?.action, "planned_failed_review_retry");
+    assert.equal(report[0]?.revisionKind, "item_source_revision");
+    assert.equal(report[0]?.revision, sourceRevision);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("failed retry metadata survives a repeated failure at the same revision", () => {
+  const previous = `${failedReviewReport({
+    type: "issue",
+    pull_head_sha: "unknown",
+    item_source_revision: "issue-source-revision",
+    failed_review_retry_status: "dispatched",
+    failed_review_retry_count: 1,
+    failed_review_retry_last_at: "2026-06-05T19:30:00Z",
+    failed_review_retry_revision_kind: "item_source_revision",
+    failed_review_retry_revision: "issue-source-revision",
+    failed_review_retry_reason: JSON.stringify("timeout"),
+  })}
+
+## Failed Review Retry
+
+- status: dispatched
+- attempts: 1/2
+`;
+  const repeatedFailure = failedReviewReport({
+    type: "issue",
+    pull_head_sha: "unknown",
+    item_source_revision: "issue-source-revision",
+  });
+  const preserved = preserveFailedReviewRetryMetadataForTest(previous, repeatedFailure);
+
+  assert.match(preserved, /^failed_review_retry_status: dispatched$/m);
+  assert.match(preserved, /^failed_review_retry_count: 1$/m);
+  assert.match(preserved, /^failed_review_retry_revision_kind: item_source_revision$/m);
+  assert.match(preserved, /^failed_review_retry_revision: issue-source-revision$/m);
+  assert.match(preserved, /^## Failed Review Retry$/m);
+  assert.doesNotMatch(
+    preserveFailedReviewRetryMetadataForTest(
+      previous,
+      failedReviewReport({
+        type: "issue",
+        pull_head_sha: "unknown",
+        item_source_revision: "changed-source-revision",
+      }),
+    ),
+    /^failed_review_retry_status:/m,
+  );
+  assert.doesNotMatch(
+    preserveFailedReviewRetryMetadataForTest(
+      previous,
+      failedReviewReport({
+        type: "issue",
+        pull_head_sha: "unknown",
+        item_source_revision: "issue-source-revision",
+        review_status: "complete",
+      }),
+    ),
+    /^failed_review_retry_status:/m,
+  );
+});
+
 test("failed review retry exhaustion is idempotent for the same head", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
@@ -274,6 +488,8 @@ process.exit(1);
         action: "skipped_retry_already_exhausted",
         reason: "retry attempts exhausted for head abc123def456: 2/2",
         headSha: "abc123def456",
+        revisionKind: "pull_head_sha",
+        revision: "abc123def456",
         attempts: 2,
         reportPath: itemPath,
       },


### PR DESCRIPTION
## Summary

- retry infrastructure-failed issue reviews at a deterministic issue source revision, alongside the existing pull-request head-SHA path
- carry the expected issue revision through asynchronous dispatch and abort before Codex or artifact creation if the live issue changed
- requeue revision drift once through a validated marker, while preserving retry cooldown and attempt metadata only for repeated failures at the same revision

## Root cause

The failed-review backstop assumed every review had a pull-request head SHA. Failed issue reports therefore had no eligible retry identity and were skipped. Adding issue eligibility alone was insufficient because issue content could change after scheduler validation but before the asynchronous review worker hydrated its context.

Issue retries now use a SHA-256 revision over the live title, body, relevant labels, and non-ClawSweeper comments. The worker compares the dispatched revision with freshly hydrated context immediately before review. A mismatch writes no markdown review artifact and permits one exact-item requeue at the newly observed revision; later churn falls back to the normal scheduler.

## Security

The Codex-facing review job remains `contents: read`. Revision mismatch state crosses the job boundary as a narrow JSON artifact, and a separate post-review job alone receives `contents: write` to emit the repository dispatch. That job validates the expected revision, actual revision, item number, and bounded requeue count before dispatch, so no repository-write fallback token is exposed to danger-full-access Codex.

Repository dispatch always loads the workflow from its default branch. The retry command therefore resolves that branch live and rejects a conflicting `--workflow-ref` instead of silently running an incompatible workflow revision.

## Proof

Rebased directly onto #444 at `76360b98742b2863046668bb52b30224fd879d5b`; its source-activity and close-throughput regressions remain green.

- `pnpm run build:all`
- `node --test test/failed-review-retry.test.ts` — 12 passed
- `node --test test/sweep-workflow.test.ts` — 41 passed
- `node --test test/apply-stalled-pr-policies.test.ts test/review-close-policy.test.ts` — 42 passed
- `node --test test/repair/workflow-sparse-checkout.test.ts test/repair/workflow-utils.test.ts` — 45 passed
- `pnpm run lint`
- `pnpm run format:check`
- `git diff --check origin/main...HEAD`
- branch autoreview against `origin/main` — clean, no actionable findings

`actionlint .github/workflows/sweep.yml` reports only the same two pre-existing ShellCheck warnings reproduced against `origin/main`; this change adds no workflow-lint finding.
