### PR TITLE
fix: preserve PR promotion close semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ checkpoint, and status-only commits are intentionally omitted.
 - Stopped later CI reruns from resetting PR inactivity clocks by anchoring head activity to the latest source-triggered workflow run associated with that pull request.
 - Prioritized ready close decisions and bounded PR close-coverage proofs before slow policy-gated candidates, kept default 20-item continuations shareable, and retried malformed successful GitHub JSON responses.
 - Kept automatic close-apply checkpoints within their runtime budget by bounding GitHub commands and retry waits while preserving resumable report and cursor output.
+- Kept stale F-rated PR promotions semantically consistent by recording them as low-signal unmergeable closes and replacing contradictory keep-open summaries.
 - Removed exponential backtracking from durable review-marker parsing so adversarial comment bodies cannot stall apply or comment synchronization.
 - Scoped Mantis recommendations to supported proof capture and kept code changes, PR repair, and GitHub mutations in ClawSweeper's deterministic lanes. Thanks @brokemac79.
 - Bounded automatic close-apply checkpoints to ten minutes, persisted exact cursor progress before immediate continuation, and limited close-coverage proofs to the time remaining in the checkpoint.

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -13624,6 +13624,11 @@ interface LinkedPullRequestSupersession {
   filesKnown: boolean;
 }
 
+interface LinkedPullRequestSupersessionResolution {
+  candidate: LinkedPullRequestSupersession | null;
+  unsafeReason: string | null;
+}
+
 function upgradePullRequestClosePromotionReport(
   markdown: string,
   item: Item,
@@ -13997,7 +14002,8 @@ function linkedPullRequestSupersession(
   markdown: string,
   item: Item,
   options: { reportDirs?: readonly string[] } = {},
-): LinkedPullRequestSupersession | null {
+): LinkedPullRequestSupersessionResolution {
+  let unsafeReason: string | null = null;
   for (const number of linkedPullRequestNumbersFromReport(markdown, item.number)) {
     try {
       const hasSupersessionSignal = linkedPullRequestHasSupersessionSignal(
@@ -14023,13 +14029,17 @@ function linkedPullRequestSupersession(
         filesKnown: linkedFiles.known,
       };
       if (linkedPullCannotSupersedeDocsOnlySource(markdown, linkedPull)) continue;
-      if (unsafeCanonicalPullRequestReason(linkedPull, options) !== null) continue;
-      return linkedPull;
+      const candidateUnsafeReason = unsafeCanonicalPullRequestReason(linkedPull, options);
+      if (candidateUnsafeReason !== null) {
+        unsafeReason ??= candidateUnsafeReason;
+        continue;
+      }
+      return { candidate: linkedPull, unsafeReason: null };
     } catch {
       // Missing or cross-repo stale references are not close evidence.
     }
   }
-  return null;
+  return { candidate: null, unsafeReason };
 }
 
 function linkedPullRequestLabels(number: number, pull: Record<string, unknown>): string[] {
@@ -14616,12 +14626,8 @@ function pauseOrClosePromotion(
 }
 
 function linkedPullRequestSupersessionPromotion(
-  markdown: string,
-  item: Item,
-  options: { reportDirs?: readonly string[] } = {},
-): PullRequestClosePromotion | null {
-  const linkedPull = linkedPullRequestSupersession(markdown, item, options);
-  if (!linkedPull) return null;
+  linkedPull: LinkedPullRequestSupersession,
+): PullRequestClosePromotion {
   const stateText = linkedPull.mergedAt
     ? `merged at ${linkedPull.mergedAt}`
     : "still open as the canonical replacement";
@@ -14652,11 +14658,16 @@ function pullRequestClosePromotion(
   if (frontMatterValue(markdown, "action_taken") !== "kept_open") return null;
   if (frontMatterValue(markdown, "review_status") !== "complete") return null;
   if (closePromotionHasNonAutomationActivityAfterReview(markdown, context)) return null;
-  return (
-    linkedPullRequestSupersessionPromotion(markdown, item, options) ??
-    pauseOrClosePromotion(markdown, item, staleMinAgeDays) ??
-    staleFRatedPullRequestPromotion(markdown, item, staleMinAgeDays)
-  );
+  const linkedSupersession = linkedPullRequestSupersession(markdown, item, options);
+  if (linkedSupersession.candidate) {
+    return linkedPullRequestSupersessionPromotion(linkedSupersession.candidate);
+  }
+  const pauseOrClose = pauseOrClosePromotion(markdown, item, staleMinAgeDays);
+  if (pauseOrClose) return pauseOrClose;
+  // A live canonical candidate that is itself unsafe cannot justify treating the
+  // source as generic low-signal work. Missing or non-covering references can.
+  if (linkedSupersession.unsafeReason) return null;
+  return staleFRatedPullRequestPromotion(markdown, item, staleMinAgeDays);
 }
 
 function workPlanPathForReport(file: string, plansDir = defaultPlansDir()): string {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -19541,6 +19541,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
       storedUpdatedAt &&
       item.updatedAt === storedUpdatedAt &&
       livePullRequestHasNoDiff(currentItemContext()) &&
+      closeReasonEnabled("duplicate_or_superseded", applyCloseReasons) &&
       reviewReportCanPromoteToClose(markdown)
     ) {
       markdown = upgradeNoDiffPullRequestReport(markdown, item);
@@ -19563,7 +19564,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
         staleMinAgeDays,
         { reportDirs: [itemsDir, closedDir] },
       );
-      if (promotion) {
+      if (promotion && closeReasonEnabled(promotion.closeReason, applyCloseReasons)) {
         markdown = upgradePullRequestClosePromotionReport(
           markdown,
           item,

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -19532,7 +19532,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
     if (isUpgradedCloseCandidate) {
       markdown = replaceFrontMatterValue(markdown, "action_taken", "proposed_close");
     }
-    if (
+    const hasLiveNoDiffPullRequestPromotion =
       state === "open" &&
       !isCloseProposal &&
       item.kind === "pull_request" &&
@@ -19541,8 +19541,10 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
       storedUpdatedAt &&
       item.updatedAt === storedUpdatedAt &&
       livePullRequestHasNoDiff(currentItemContext()) &&
-      closeReasonEnabled("duplicate_or_superseded", applyCloseReasons) &&
-      reviewReportCanPromoteToClose(markdown)
+      reviewReportCanPromoteToClose(markdown);
+    if (
+      hasLiveNoDiffPullRequestPromotion &&
+      closeReasonEnabled("duplicate_or_superseded", applyCloseReasons)
     ) {
       markdown = upgradeNoDiffPullRequestReport(markdown, item);
       closeReason = "duplicate_or_superseded";
@@ -19552,6 +19554,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
     if (
       state === "open" &&
       !isCloseProposal &&
+      !hasLiveNoDiffPullRequestPromotion &&
       item.kind === "pull_request" &&
       decision === "keep_open" &&
       action === "kept_open"

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -13581,6 +13581,11 @@ function upgradeNoDiffPullRequestReport(markdown: string, item: Item): string {
   upgraded = replaceFrontMatterValue(upgraded, "work_status", "none");
   upgraded = replaceSectionValue(
     upgraded,
+    REVIEW_SECTIONS.summary,
+    "Close this PR: GitHub reports no changed files against the current base branch.",
+  );
+  upgraded = replaceSectionValue(
+    upgraded,
     REVIEW_SECTIONS.bestSolution,
     "Close this PR: GitHub reports no changed files against the current base branch, so the branch is already empty or superseded by `main`.",
   );
@@ -13598,6 +13603,8 @@ function upgradeNoDiffPullRequestReport(markdown: string, item: Item): string {
 }
 
 interface PullRequestClosePromotion {
+  closeReason: CloseReason;
+  summary: string;
   bestSolution: string;
   evidence: string;
   closeComment: string;
@@ -13625,7 +13632,7 @@ function upgradePullRequestClosePromotionReport(
 ): string {
   let upgraded = markdown;
   upgraded = replaceFrontMatterValue(upgraded, "decision", "close");
-  upgraded = replaceFrontMatterValue(upgraded, "close_reason", "duplicate_or_superseded");
+  upgraded = replaceFrontMatterValue(upgraded, "close_reason", promotion.closeReason);
   upgraded = replaceFrontMatterValue(upgraded, "confidence", "high");
   upgraded = replaceFrontMatterValue(upgraded, "action_taken", "proposed_close");
   upgraded = replaceFrontMatterValue(
@@ -13646,6 +13653,7 @@ function upgradePullRequestClosePromotionReport(
     "item_source_revision",
     context.sourceRevision ?? "unknown",
   );
+  upgraded = replaceSectionValue(upgraded, REVIEW_SECTIONS.summary, promotion.summary);
   upgraded = replaceSectionValue(upgraded, REVIEW_SECTIONS.bestSolution, promotion.bestSolution);
   upgraded = replaceSectionValue(upgraded, REVIEW_SECTIONS.evidence, promotion.evidence);
   upgraded = replaceSectionValue(upgraded, REVIEW_SECTIONS.closeComment, promotion.closeComment);
@@ -14570,6 +14578,9 @@ function staleFRatedPullRequestPromotion(
     return null;
   }
   return {
+    closeReason: "low_signal_unmergeable_pr",
+    summary:
+      "Close this stale PR: the latest review rated it F, it still lacks merge-ready proof, and there has been no human follow-up after the durable review.",
     coverageProofFallbackRefs: false,
     bestSolution:
       "Close this stale PR. The latest review rated it F, the branch still lacks merge-ready proof, and there has been no human follow-up after the durable review.",
@@ -14591,6 +14602,8 @@ function pauseOrClosePromotion(
   const option = recommendedPauseOrCloseOption(markdown);
   if (!option || !isOlderThanDays(item.createdAt, staleMinAgeDays)) return null;
   return {
+    closeReason: "duplicate_or_superseded",
+    summary: `Close this stale PR as superseded: ${option.title}.`,
     coverageProofFallbackRefs: false,
     bestSolution: `Close this stale PR as superseded: ${option.title}. ${option.body}`,
     evidence: [
@@ -14613,6 +14626,8 @@ function linkedPullRequestSupersessionPromotion(
     ? `merged at ${linkedPull.mergedAt}`
     : "still open as the canonical replacement";
   return {
+    closeReason: "duplicate_or_superseded",
+    summary: `Close this PR as superseded by ${linkedPull.url}.`,
     coverageProofFallbackRefs: true,
     bestSolution: `Close this PR as superseded by ${linkedPull.url}.`,
     evidence: [
@@ -19557,7 +19572,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
         );
         storedUpdatedAt = item.updatedAt;
         storedHash = itemSnapshotHash(item, promotionContext);
-        closeReason = "duplicate_or_superseded";
+        closeReason = promotion.closeReason;
         isCloseProposal = true;
         cachedPrCloseCoverageProofGateResult = undefined;
       }

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -1482,7 +1482,8 @@ function hasPullRequestClosePromotionSignal(
 ): boolean {
   return (
     hasLinkedPullRequestSupersessionSignal(markdown, targetRepo) ||
-    ((hasRecommendedPauseOrCloseOption(markdown) || hasStaleFRatedPullRequestSignal(markdown)) &&
+    ((hasRecommendedPauseOrCloseOption(markdown) ||
+      hasLowSignalPullRequestPromotionSignal(markdown)) &&
       olderThan(frontMatterValue(markdown, "item_created_at"), options.staleMinAgeMs))
   );
 }
@@ -1501,7 +1502,7 @@ function pullRequestClosePromotionReasons(
   // to the low-signal promotion when that linked candidate does not cover it.
   if (
     !recommendedPauseOrClose &&
-    hasStaleFRatedPullRequestSignal(markdown) &&
+    hasLowSignalPullRequestPromotionSignal(markdown) &&
     olderThan(frontMatterValue(markdown, "item_created_at"), options.staleMinAgeMs)
   ) {
     reasons.push("low_signal_unmergeable_pr");
@@ -1560,12 +1561,20 @@ function hasRecommendedPauseOrCloseOption(markdown: string): boolean {
   });
 }
 
-function hasStaleFRatedPullRequestSignal(markdown: string): boolean {
+function hasLowSignalPullRequestPromotionSignal(markdown: string): boolean {
+  const ratingSection = sectionValue(markdown, "PR Rating");
+  const proofSection = sectionValue(markdown, "Real Behavior Proof");
+  const overallTier =
+    sectionLineValue(ratingSection, "Overall tier") ||
+    frontMatterValue(markdown, "pr_rating_overall");
+  const proofTier =
+    sectionLineValue(ratingSection, "Proof tier") || frontMatterValue(markdown, "pr_rating_proof");
+  const proofStatus =
+    sectionLineValue(proofSection, "Status") ||
+    frontMatterValue(markdown, "real_behavior_proof_status");
   return (
-    frontMatterValue(markdown, "pr_rating_overall") === "F" ||
-    frontMatterValue(markdown, "pr_rating_proof") === "F" ||
-    sectionLineValue(markdown, "Overall tier") === "F" ||
-    sectionLineValue(markdown, "Proof tier") === "F"
+    overallTier === "F" &&
+    (proofTier === "F" || ["missing", "mock_only", "insufficient"].includes(proofStatus))
   );
 }
 

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -1183,6 +1183,14 @@ function selectedProposedItemCandidates(
         isSelectableCloseAction(action, reason) &&
         allowedForTarget(options.targetRepo, type, reason, allowedReasons) &&
         (!allowedCloseReasons || allowedCloseReasons.has(reason));
+      const promotionCloseReasons = pullRequestClosePromotionReasons(markdown, options.targetRepo, {
+        staleMinAgeMs: options.staleMinAgeDays * 24 * 60 * 60 * 1000,
+      });
+      const selectedPromotionCloseReasons = promotionCloseReasons.filter(
+        (promotionReason) =>
+          allowedForTarget(options.targetRepo, type, promotionReason, allowedReasons) &&
+          (!allowedCloseReasons || allowedCloseReasons.has(promotionReason)),
+      );
       const selectablePromotion =
         decision === "keep_open" &&
         action === "kept_open" &&
@@ -1192,10 +1200,11 @@ function selectedProposedItemCandidates(
         hasPullRequestClosePromotionSignal(markdown, options.targetRepo, {
           staleMinAgeMs: options.staleMinAgeDays * 24 * 60 * 60 * 1000,
         }) &&
-        allowedForTarget(options.targetRepo, type, "duplicate_or_superseded", allowedReasons) &&
-        (!allowedCloseReasons || allowedCloseReasons.has("duplicate_or_superseded"));
+        selectedPromotionCloseReasons.length > 0;
       const selectableProofPromotion =
-        selectablePromotion && hasLinkedPullRequestSupersessionSignal(markdown, options.targetRepo);
+        selectablePromotion &&
+        selectedPromotionCloseReasons.includes("duplicate_or_superseded") &&
+        hasLinkedPullRequestSupersessionSignal(markdown, options.targetRepo);
       if (!selectableClose && !selectablePromotion) return [];
       const prCloseCoverageProofCanRun =
         type === "pull_request" &&
@@ -1211,7 +1220,7 @@ function selectedProposedItemCandidates(
         return [];
       }
       if (!olderThan(frontMatterValue(markdown, "item_created_at"), minAgeMs)) return [];
-      const candidateCloseReason = selectablePromotion ? "duplicate_or_superseded" : reason;
+      const candidateCloseReason = selectablePromotion ? selectedPromotionCloseReasons[0]! : reason;
       return [
         {
           number,
@@ -1476,6 +1485,28 @@ function hasPullRequestClosePromotionSignal(
     ((hasRecommendedPauseOrCloseOption(markdown) || hasStaleFRatedPullRequestSignal(markdown)) &&
       olderThan(frontMatterValue(markdown, "item_created_at"), options.staleMinAgeMs))
   );
+}
+
+function pullRequestClosePromotionReasons(
+  markdown: string,
+  targetRepo: string,
+  options: { staleMinAgeMs: number },
+): Array<"duplicate_or_superseded" | "low_signal_unmergeable_pr"> {
+  const linkedSupersession = hasLinkedPullRequestSupersessionSignal(markdown, targetRepo);
+  const recommendedPauseOrClose = hasRecommendedPauseOrCloseOption(markdown);
+  const reasons: Array<"duplicate_or_superseded" | "low_signal_unmergeable_pr"> = [];
+  if (linkedSupersession || recommendedPauseOrClose) reasons.push("duplicate_or_superseded");
+  // Pause-or-close is a deterministic duplicate promotion. A linked PR is only
+  // speculative until live hydration, so an F-rated report can still fall back
+  // to the low-signal promotion when that linked candidate does not cover it.
+  if (
+    !recommendedPauseOrClose &&
+    hasStaleFRatedPullRequestSignal(markdown) &&
+    olderThan(frontMatterValue(markdown, "item_created_at"), options.staleMinAgeMs)
+  ) {
+    reasons.push("low_signal_unmergeable_pr");
+  }
+  return reasons;
 }
 
 function hasLinkedPullRequestSupersessionSignal(markdown: string, targetRepo: string): boolean {

--- a/test/apply-pr-promotion.test.ts
+++ b/test/apply-pr-promotion.test.ts
@@ -168,22 +168,23 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/322\\/timeline(?:\\?|$
   }
 });
 
-test("apply-decisions promotes old F-rated stale PRs to duplicate closes", () => {
+test("apply-decisions promotes old F-rated stale PRs with low-signal close semantics", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
     const itemsDir = join(root, "items");
     const closedDir = join(root, "closed");
     const plansDir = join(root, "plans");
     const reportPath = join(root, "apply-report.json");
+    const closeAppliedBodyLogPath = join(root, "close-applied-body.log");
     mkdirSync(itemsDir, { recursive: true });
     mkdirSync(plansDir, { recursive: true });
-    const synced = reportWithSyncedReviewComment(
-      stalePullRequestReport({
-        work_cluster_refs: JSON.stringify(["Related discussion in #400"]),
-      }),
-      330,
-      "none",
+    const staleReport = stalePullRequestReport({
+      work_cluster_refs: JSON.stringify(["Related discussion in #400"]),
+    }).replace(
+      "## Summary\n\nThe dashboard has queue_fix_pr candidates but no generated coding plan.",
+      "## Summary\n\nKeep open: this branch needs contributor follow-up before any close decision.",
     );
+    const synced = reportWithSyncedReviewComment(staleReport, 330, "none");
     writeFileSync(join(itemsDir, "330.md"), synced.report, "utf8");
 
     withMockGh(
@@ -191,6 +192,7 @@ test("apply-decisions promotes old F-rated stale PRs to duplicate closes", () =>
       promotionGhMock({
         number: 330,
         comment: synced.comment,
+        closeAppliedBodyLogPath,
         linkedPulls: {
           400: {
             number: 400,
@@ -217,7 +219,6 @@ test("apply-decisions promotes old F-rated stale PRs to duplicate closes", () =>
               extraArgs: [
                 "--target-repo",
                 "openclaw/openclaw",
-                "--dry-run",
                 "--apply-kind",
                 "all",
                 "--processed-limit",
@@ -244,9 +245,19 @@ test("apply-decisions promotes old F-rated stale PRs to duplicate closes", () =>
     );
     assert.match(
       report.find((entry) => entry.action === "closed")?.reason ?? "",
-      /duplicate or superseded/,
+      /low-signal unmergeable PR/,
     );
     assert.doesNotMatch(JSON.stringify(report), /proof should not run/);
+    const promoted = readFileSync(join(closedDir, "330.md"), "utf8");
+    assert.match(promoted, /^close_reason: low_signal_unmergeable_pr$/m);
+    assert.match(
+      promoted,
+      /## Summary\n\nClose this stale PR: the latest review rated it F, it still lacks merge-ready proof, and there has been no human follow-up after the durable review\./,
+    );
+    assert.doesNotMatch(promoted, /## Summary\n\nKeep open:/);
+    const closeAppliedBody = readFileSync(closeAppliedBodyLogPath, "utf8");
+    assert.match(closeAppliedBody, /Close reason: low-signal unmergeable PR\./);
+    assert.doesNotMatch(closeAppliedBody, /Keep open:/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -681,22 +692,22 @@ test("apply-decisions does not promote docs-only PRs superseded by code-only pul
     const reportPath = join(root, "apply-report.json");
     mkdirSync(itemsDir, { recursive: true });
     mkdirSync(plansDir, { recursive: true });
-    const synced = reportWithSyncedReviewComment(
-      stalePullRequestReport({
-        number: 337,
-        title: "ENETDOWN docs companion",
-        pr_rating_overall: "D",
-        pr_rating_proof: "D",
-        pr_rating_patch: "D",
-        pull_files: JSON.stringify(["docs/gateway/troubleshooting.md", "docs/platforms/macos.md"]),
-        pull_files_truncated: false,
-        work_cluster_refs: JSON.stringify([
-          "Superseded by https://github.com/openclaw/openclaw/pull/400",
-        ]),
-      }),
-      337,
-      "none",
-    );
+    const docsOnlyReport = stalePullRequestReport({
+      number: 337,
+      title: "ENETDOWN docs companion",
+      pr_rating_overall: "D",
+      pr_rating_proof: "D",
+      pr_rating_patch: "D",
+      pull_files: JSON.stringify(["docs/gateway/troubleshooting.md", "docs/platforms/macos.md"]),
+      pull_files_truncated: false,
+      work_cluster_refs: JSON.stringify([
+        "Superseded by https://github.com/openclaw/openclaw/pull/400",
+      ]),
+    })
+      .replace("Overall tier: F", "Overall tier: D")
+      .replace("Proof tier: F", "Proof tier: D")
+      .replace("Patch tier: F", "Patch tier: D");
+    const synced = reportWithSyncedReviewComment(docsOnlyReport, 337, "none");
     writeFileSync(join(itemsDir, "337.md"), synced.report, "utf8");
 
     withMockGh(

--- a/test/apply-pr-promotion.test.ts
+++ b/test/apply-pr-promotion.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
 
@@ -13,6 +13,110 @@ import {
   withMockGh,
   workPlanCandidateReport,
 } from "./helpers.ts";
+
+function assertResolvedPromotionRespectsCloseReasonFilter(options: {
+  number: number;
+  applyCloseReason: "duplicate_or_superseded" | "low_signal_unmergeable_pr";
+  sourceFiles: string[];
+  linkedFiles: string[];
+}): void {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const proofLogPath = join(root, "proof.log");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const keepOpenSummary =
+      "Keep open: live promotion must first resolve to an enabled close reason.";
+    const sourceReport = stalePullRequestReport({
+      number: options.number,
+      title: "Ambiguous stale promotion",
+      pull_files: JSON.stringify(options.sourceFiles),
+      pull_files_truncated: false,
+      work_cluster_refs: JSON.stringify(["Superseded by #400"]),
+    }).replace(
+      "## Summary\n\nThe dashboard has queue_fix_pr candidates but no generated coding plan.",
+      `## Summary\n\n${keepOpenSummary}`,
+    );
+    const synced = reportWithSyncedReviewComment(sourceReport, options.number, "none");
+    const itemPath = join(itemsDir, `${options.number}.md`);
+    writeFileSync(itemPath, synced.report, "utf8");
+
+    withMockGh(
+      root,
+      promotionGhMock({
+        number: options.number,
+        title: "Ambiguous stale promotion",
+        comment: synced.comment,
+        linkedPulls: {
+          400: {
+            number: 400,
+            title: "Merged canonical replacement",
+            html_url: "https://github.com/openclaw/openclaw/pull/400",
+            state: "closed",
+            merged_at: "2026-05-02T00:00:00Z",
+            mergeable_state: "clean",
+            labels: ["proof: sufficient"],
+            files: options.linkedFiles,
+          },
+        },
+      }),
+      () => {
+        withMockCodexProof(
+          root,
+          {
+            type: "failure",
+            message: "proof must not run for a resolved disallowed promotion",
+            invocationLogPath: proofLogPath,
+          },
+          () => {
+            runApplyDecisionsForTest({
+              itemsDir,
+              closedDir,
+              plansDir,
+              reportPath,
+              extraArgs: [
+                "--target-repo",
+                "openclaw/openclaw",
+                "--apply-kind",
+                "all",
+                "--apply-close-reasons",
+                options.applyCloseReason,
+                "--processed-limit",
+                "3",
+              ],
+            });
+          },
+        );
+      },
+    );
+
+    const results = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{ action: string }>;
+    assert.equal(
+      results.some((entry) => entry.action === "closed"),
+      false,
+    );
+    assert.equal(existsSync(join(closedDir, `${options.number}.md`)), false);
+    const stored = readFileSync(itemPath, "utf8");
+    assert.match(stored, /^decision: keep_open$/m);
+    assert.match(stored, /^close_reason: none$/m);
+    assert.match(
+      stored,
+      new RegExp(`## Summary\\n\\n${keepOpenSummary.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`),
+    );
+    const commentStatePath = join(root, `comment-state-${options.number}.json`);
+    const liveComment = existsSync(commentStatePath)
+      ? (JSON.parse(readFileSync(commentStatePath, "utf8")) as { body: string }).body
+      : synced.comment;
+    assert.doesNotMatch(liveComment, /clawsweeper-(?:verdict:close|action:close-required)/);
+    assert.equal(existsSync(proofLogPath), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
 
 test("apply-decisions upgrades live no-diff kept-open PRs to duplicate closes", () => {
   const root = mkdtempSync(tmpPrefix);
@@ -261,6 +365,24 @@ test("apply-decisions promotes old F-rated stale PRs with low-signal close seman
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+test("apply-decisions does not persist duplicate promotion when only low-signal closes are enabled", () => {
+  assertResolvedPromotionRespectsCloseReasonFilter({
+    number: 338,
+    applyCloseReason: "low_signal_unmergeable_pr",
+    sourceFiles: ["src/runtime.ts"],
+    linkedFiles: ["src/runtime.ts"],
+  });
+});
+
+test("apply-decisions does not persist low-signal fallback when only duplicate closes are enabled", () => {
+  assertResolvedPromotionRespectsCloseReasonFilter({
+    number: 339,
+    applyCloseReason: "duplicate_or_superseded",
+    sourceFiles: ["docs/gateway/troubleshooting.md"],
+    linkedFiles: ["src/runtime.ts"],
+  });
 });
 
 test("apply-decisions promotes stale PRs after automation-only drift", () => {

--- a/test/apply-pr-promotion.test.ts
+++ b/test/apply-pr-promotion.test.ts
@@ -18,7 +18,8 @@ function assertResolvedPromotionRespectsCloseReasonFilter(options: {
   number: number;
   applyCloseReason: "duplicate_or_superseded" | "low_signal_unmergeable_pr";
   sourceFiles: string[];
-  linkedFiles: string[];
+  linkedFiles?: string[];
+  noDiff?: boolean;
 }): void {
   const root = mkdtempSync(tmpPrefix);
   try {
@@ -36,7 +37,7 @@ function assertResolvedPromotionRespectsCloseReasonFilter(options: {
       title: "Ambiguous stale promotion",
       pull_files: JSON.stringify(options.sourceFiles),
       pull_files_truncated: false,
-      work_cluster_refs: JSON.stringify(["Superseded by #400"]),
+      work_cluster_refs: JSON.stringify(options.linkedFiles ? ["Superseded by #400"] : []),
     }).replace(
       "## Summary\n\nThe dashboard has queue_fix_pr candidates but no generated coding plan.",
       `## Summary\n\n${keepOpenSummary}`,
@@ -51,18 +52,22 @@ function assertResolvedPromotionRespectsCloseReasonFilter(options: {
         number: options.number,
         title: "Ambiguous stale promotion",
         comment: synced.comment,
-        linkedPulls: {
-          400: {
-            number: 400,
-            title: "Merged canonical replacement",
-            html_url: "https://github.com/openclaw/openclaw/pull/400",
-            state: "closed",
-            merged_at: "2026-05-02T00:00:00Z",
-            mergeable_state: "clean",
-            labels: ["proof: sufficient"],
-            files: options.linkedFiles,
-          },
-        },
+        changedFiles: options.noDiff ? 0 : options.sourceFiles.length,
+        sourceFiles: options.sourceFiles,
+        linkedPulls: options.linkedFiles
+          ? {
+              400: {
+                number: 400,
+                title: "Merged canonical replacement",
+                html_url: "https://github.com/openclaw/openclaw/pull/400",
+                state: "closed",
+                merged_at: "2026-05-02T00:00:00Z",
+                mergeable_state: "clean",
+                labels: ["proof: sufficient"],
+                files: options.linkedFiles,
+              },
+            }
+          : {},
       }),
       () => {
         withMockCodexProof(
@@ -382,6 +387,15 @@ test("apply-decisions does not persist low-signal fallback when only duplicate c
     applyCloseReason: "duplicate_or_superseded",
     sourceFiles: ["docs/gateway/troubleshooting.md"],
     linkedFiles: ["src/runtime.ts"],
+  });
+});
+
+test("apply-decisions does not fall through from filtered no-diff to low-signal promotion", () => {
+  assertResolvedPromotionRespectsCloseReasonFilter({
+    number: 340,
+    applyCloseReason: "low_signal_unmergeable_pr",
+    sourceFiles: [],
+    noDiff: true,
   });
 });
 

--- a/test/apply-pr-supersession-safety.test.ts
+++ b/test/apply-pr-supersession-safety.test.ts
@@ -236,6 +236,8 @@ test("apply-decisions does not promote PRs superseded by no-proof linked pull re
               "--dry-run",
               "--apply-kind",
               "all",
+              "--apply-close-reasons",
+              "low_signal_unmergeable_pr",
               "--processed-limit",
               "3",
             ],
@@ -248,6 +250,10 @@ test("apply-decisions does not promote PRs superseded by no-proof linked pull re
     assert.equal(
       report.some((entry) => entry.action === "closed"),
       false,
+    );
+    assert.equal(
+      report.some((entry) => entry.action === "kept_open"),
+      true,
     );
     assert.doesNotMatch(JSON.stringify(report), /proof should not run/);
   } finally {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -433,6 +433,8 @@ export function promotionGhMock(options: {
   itemUpdatedAtAfterLabelSyncLogPath?: string;
   itemUpdatedAtAfterProof?: string;
   itemUpdatedAtAfterProofLogPath?: string;
+  changedFiles?: number;
+  sourceFiles?: string[];
   issueCommentCount?: number;
   comment: string;
   commentWriteLogPath?: string;
@@ -514,6 +516,12 @@ export function promotionGhMock(options: {
 		const labels = ${JSON.stringify(options.labels ?? ["status: 📣 needs proof"])};
 		const itemCreatedAt = ${JSON.stringify(itemCreatedAt)};
 		const itemUpdatedAt = ${JSON.stringify(itemUpdatedAt)};
+		const changedFiles = ${options.changedFiles ?? 2};
+		const sourceFiles = ${JSON.stringify(
+      (options.sourceFiles ?? ["src/runtime.ts", "test/runtime.test.ts"]).map((filename) => ({
+        filename,
+      })),
+    )};
 		const itemUpdatedAtAfterLabelSync = ${JSON.stringify(
       options.itemUpdatedAtAfterLabelSync ?? "",
     )};
@@ -584,7 +592,7 @@ export function promotionGhMock(options: {
     title,
     html_url: "https://github.com/openclaw/openclaw/pull/" + number,
     state: "open",
-    changed_files: 2,
+    changed_files: changedFiles,
     commits: 1,
     review_comments: 0,
     body: "Stale PR body.",
@@ -650,7 +658,6 @@ export function promotionGhMock(options: {
 	    console.error("unexpected linked pull files", linkedNumber);
 	    process.exit(1);
 	  }
-	  const sourceFiles = [{ filename: "src/runtime.ts" }, { filename: "test/runtime.test.ts" }];
 	  const files = linkedNumber === number ? sourceFiles : liveLinkedPulls[linkedNumber].files || sourceFiles;
   if (jq === "[.[].filename]") {
     console.log(JSON.stringify(files.map((file) =>

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -439,6 +439,7 @@ export function promotionGhMock(options: {
   closeAppliedBodyLogPath?: string;
   closeCommandDelayMs?: number;
   comments?: unknown[];
+  reviews?: unknown[];
   timeline?: unknown[];
   linkedPulls?: Record<number, unknown>;
   linkedPullsAfterProof?: Record<number, unknown>;
@@ -474,6 +475,7 @@ export function promotionGhMock(options: {
 	const jqIndex = args.indexOf("--jq");
 	const jq = jqIndex >= 0 ? args[jqIndex + 1] : "";
 	const comments = ${JSON.stringify(comments)};
+	const reviews = ${JSON.stringify(options.reviews ?? [])};
 	const timeline = ${JSON.stringify(timeline)};
 	const linkedPulls = ${JSON.stringify(linkedPulls)};
 	const linkedPullsAfterProof = ${JSON.stringify(options.linkedPullsAfterProof ?? {})};
@@ -554,8 +556,10 @@ export function promotionGhMock(options: {
 	} else if (args[0] === "api" && new RegExp("/issues/" + number + "/comments(?:\\\\?|$)").test(path)) {
 	  const currentComments = liveComments();
 	  console.log(JSON.stringify(slurp ? [currentComments] : currentComments));
-	} else if (args[0] === "api" && new RegExp("/issues/" + number + "/timeline(?:\\\\?|$)").test(path)) {
+} else if (args[0] === "api" && new RegExp("/issues/" + number + "/timeline(?:\\\\?|$)").test(path)) {
   console.log(JSON.stringify(slurp ? [timeline] : timeline));
+} else if (args[0] === "api" && new RegExp("/pulls/" + number + "/reviews(?:\\\\?|$)").test(path)) {
+  console.log(JSON.stringify(slurp ? [reviews] : reviews));
 } else if (args[0] === "api" && new RegExp("/issues/" + number + "$").test(path)) {
   console.log(JSON.stringify({
     number,

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -1134,6 +1134,7 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: kept_open",
       "close_reason: none",
       "pr_rating_overall: F",
+      "pr_rating_proof: F",
       `item_created_at: ${oldDate}`,
       "---",
       "",
@@ -1292,8 +1293,66 @@ test("workflow utilities select eligible proposed close records", () => {
       "action_taken: kept_open",
       "close_reason: none",
       "pr_rating_overall: F",
+      "pr_rating_proof: F",
       `item_created_at: ${oldDate}`,
       `work_cluster_refs: ${JSON.stringify(["Superseded by #400"])}`,
+      "---",
+      "",
+    ].join("\n"),
+  );
+  write(
+    path.join(root, "records/openclaw-openclaw/items/openclaw-openclaw-33.md"),
+    [
+      "---",
+      "repository: openclaw/openclaw",
+      "type: pull_request",
+      "decision: keep_open",
+      "review_status: complete",
+      "local_checkout_access: verified",
+      "action_taken: kept_open",
+      "close_reason: none",
+      "pr_rating_overall: B",
+      "pr_rating_proof: F",
+      "real_behavior_proof_status: missing",
+      `item_created_at: ${oldDate}`,
+      "---",
+      "",
+    ].join("\n"),
+  );
+  write(
+    path.join(root, "records/openclaw-openclaw/items/openclaw-openclaw-34.md"),
+    [
+      "---",
+      "repository: openclaw/openclaw",
+      "type: pull_request",
+      "decision: keep_open",
+      "review_status: complete",
+      "local_checkout_access: verified",
+      "action_taken: kept_open",
+      "close_reason: none",
+      "pr_rating_overall: F",
+      "pr_rating_proof: A",
+      "real_behavior_proof_status: sufficient",
+      `item_created_at: ${oldDate}`,
+      "---",
+      "",
+    ].join("\n"),
+  );
+  write(
+    path.join(root, "records/openclaw-openclaw/items/openclaw-openclaw-35.md"),
+    [
+      "---",
+      "repository: openclaw/openclaw",
+      "type: pull_request",
+      "decision: keep_open",
+      "review_status: complete",
+      "local_checkout_access: verified",
+      "action_taken: kept_open",
+      "close_reason: none",
+      "pr_rating_overall: F",
+      "pr_rating_proof: A",
+      "real_behavior_proof_status: insufficient",
+      `item_created_at: ${oldDate}`,
       "---",
       "",
     ].join("\n"),
@@ -1310,7 +1369,7 @@ test("workflow utilities select eligible proposed close records", () => {
     }),
   );
 
-  assert.deepEqual(selected, [5, 12, 15, 17, 18, 21, 22, 24, 25, 26, 27, 30, 31, 32]);
+  assert.deepEqual(selected, [5, 12, 15, 17, 18, 21, 22, 24, 25, 26, 27, 30, 31, 32, 35]);
   assert.deepEqual(
     withCwd(root, () =>
       proposedItemNumbers({
@@ -1322,7 +1381,7 @@ test("workflow utilities select eligible proposed close records", () => {
         minAgeMinutes: null,
       }),
     ),
-    [15, 22, 32],
+    [15, 22, 32, 35],
   );
   assert.deepEqual(
     withCwd(root, () =>
@@ -1592,6 +1651,7 @@ test("workflow utilities select proposed PR closes that can need coverage proof"
       "close_reason: none",
       `item_created_at: ${oldDate}`,
       "pr_rating_overall: F",
+      "pr_rating_proof: F",
       "---",
       "",
     ].join("\n"),
@@ -1754,6 +1814,7 @@ test("workflow utilities run a bounded confirmed prefix before proof and defer p
       "close_reason: none",
       `item_created_at: ${oldDate}`,
       "pr_rating_overall: F",
+      "pr_rating_proof: F",
       "---",
       "",
     ].join("\n"),

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -1280,6 +1280,24 @@ test("workflow utilities select eligible proposed close records", () => {
       "",
     ].join("\n"),
   );
+  write(
+    path.join(root, "records/openclaw-openclaw/items/openclaw-openclaw-32.md"),
+    [
+      "---",
+      "repository: openclaw/openclaw",
+      "type: pull_request",
+      "decision: keep_open",
+      "review_status: complete",
+      "local_checkout_access: verified",
+      "action_taken: kept_open",
+      "close_reason: none",
+      "pr_rating_overall: F",
+      `item_created_at: ${oldDate}`,
+      `work_cluster_refs: ${JSON.stringify(["Superseded by #400"])}`,
+      "---",
+      "",
+    ].join("\n"),
+  );
 
   const selected = withCwd(root, () =>
     proposedItemNumbers({
@@ -1292,7 +1310,46 @@ test("workflow utilities select eligible proposed close records", () => {
     }),
   );
 
-  assert.deepEqual(selected, [5, 12, 15, 17, 18, 21, 22, 24, 25, 26, 27, 30, 31]);
+  assert.deepEqual(selected, [5, 12, 15, 17, 18, 21, 22, 24, 25, 26, 27, 30, 31, 32]);
+  assert.deepEqual(
+    withCwd(root, () =>
+      proposedItemNumbers({
+        targetRepo: "openclaw/openclaw",
+        applyKind: "all",
+        applyCloseReasons: "low_signal_unmergeable_pr",
+        staleMinAgeDays: 60,
+        minAgeDays: 0,
+        minAgeMinutes: null,
+      }),
+    ),
+    [15, 22, 32],
+  );
+  assert.deepEqual(
+    withCwd(root, () =>
+      proposedItemNumbers({
+        targetRepo: "openclaw/openclaw",
+        applyKind: "all",
+        applyCloseReasons: "duplicate_or_superseded",
+        staleMinAgeDays: 60,
+        minAgeDays: 0,
+        minAgeMinutes: null,
+      }),
+    ),
+    [17, 18, 21, 24, 25, 26, 32],
+  );
+  assert.deepEqual(
+    withCwd(root, () =>
+      proposedPrCloseCoverageItemNumbers({
+        targetRepo: "openclaw/openclaw",
+        applyKind: "all",
+        applyCloseReasons: "low_signal_unmergeable_pr",
+        staleMinAgeDays: 60,
+        minAgeDays: 0,
+        minAgeMinutes: null,
+      }),
+    ),
+    [],
+  );
 });
 
 test("workflow utilities allow ClawHub implemented-on-main issue proposals", () => {


### PR DESCRIPTION
## Summary

- preserve the resolved close reason for promoted stale F-rated PRs: use `low_signal_unmergeable_pr` unless the higher-priority no-diff path resolves to `duplicate_or_superseded`
- rewrite the archived Summary when a keep-open review is promoted, so stored reports no longer contradict the close decision
- select ambiguous promotion candidates for every possible enabled outcome, then gate the live resolved reason before report persistence, comment sync, or close mutation
- keep no-diff precedence independent of apply filtering so a disabled duplicate reason cannot fall through to a lower-priority low-signal close

This is rebased onto `76360b9874` (`#444`), retaining its apply-throughput changes while making promotion reason selection and filtering consistent.

## Proof

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm run build:all`
- `node --test test/apply-pr-promotion.test.ts test/apply-pr-duplicate-proof.test.ts test/apply-pr-coverage-proof-close.test.ts test/apply-label-sync.test.ts test/close-reasons.test.ts test/review-close-policy.test.ts test/repair/workflow-utils.test.ts` — 140/140 passed
- `corepack pnpm run lint:src`
- `corepack pnpm run lint:repair`
- `corepack pnpm run lint:scripts`
- `corepack pnpm exec oxfmt --check src/clawsweeper.ts src/repair/workflow-utils.ts test/helpers.ts test/apply-pr-promotion.test.ts test/repair/workflow-utils.test.ts`
- `git diff --check origin/main...HEAD`
- `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests 'corepack pnpm run build:all && node --test test/apply-pr-promotion.test.ts test/repair/workflow-utils.test.ts' --stream-engine-output` — clean, findings `[]`, 52/52 parallel tests passed
