### PR TITLE
fix: keep apply checkpoints within runtime budget

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2103,20 +2103,21 @@ jobs:
             --report-path artifacts/failed-review-retry-report.json \
             "${dry_run_arg[@]}"
 
-      - uses: actions/upload-artifact@v7
-        with:
-          name: failed-review-retry-report
-          path: artifacts/failed-review-retry-report.json
-          if-no-files-found: error
-          retention-days: 14
-
       - name: Publish failed-review retry state
-        if: ${{ vars.CLAWSWEEPER_FAILED_REVIEW_RETRY_ENABLED == '1' }}
+        if: ${{ always() && vars.CLAWSWEEPER_FAILED_REVIEW_RETRY_ENABLED == '1' && hashFiles('results/failed-review-retries/openclaw-openclaw/*.json') != '' }}
         run: |
           pnpm run repair:publish-main -- \
             --message "chore: update failed review retry state" \
             --path results/failed-review-retries/openclaw-openclaw \
             --rebase-strategy theirs
+
+      - uses: actions/upload-artifact@v7
+        if: ${{ always() }}
+        with:
+          name: failed-review-retry-report
+          path: artifacts/failed-review-retry-report.json
+          if-no-files-found: error
+          retention-days: 14
 
   audit-dashboard:
     name: Audit state

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2080,6 +2080,7 @@ jobs:
           RETRY_LIMIT: ${{ vars.CLAWSWEEPER_FAILED_REVIEW_RETRY_LIMIT || '3' }}
           RETRY_MAX_ATTEMPTS: ${{ vars.CLAWSWEEPER_FAILED_REVIEW_RETRY_MAX_ATTEMPTS || '2' }}
           RETRY_COOLDOWN_MINUTES: ${{ vars.CLAWSWEEPER_FAILED_REVIEW_RETRY_COOLDOWN_MINUTES || '45' }}
+          RETRY_MAX_RUNTIME_MS: ${{ vars.CLAWSWEEPER_FAILED_REVIEW_RETRY_MAX_RUNTIME_MS || '600000' }}
           CODEX_TIMEOUT_MS: ${{ vars.CLAWSWEEPER_FAILED_REVIEW_RETRY_CODEX_TIMEOUT_MS || vars.CLAWSWEEPER_CODEX_TIMEOUT_MS || '1200000' }}
         run: |
           set -euo pipefail
@@ -2094,9 +2095,11 @@ jobs:
             --limit "$RETRY_LIMIT" \
             --max-attempts "$RETRY_MAX_ATTEMPTS" \
             --cooldown-minutes "$RETRY_COOLDOWN_MINUTES" \
+            --max-runtime-ms "$RETRY_MAX_RUNTIME_MS" \
             --codex-timeout-ms "$CODEX_TIMEOUT_MS" \
             --workflow-repo "$GITHUB_REPOSITORY" \
             --workflow-ref main \
+            --state-dir results/failed-review-retries/openclaw-openclaw \
             --report-path artifacts/failed-review-retry-report.json \
             "${dry_run_arg[@]}"
 
@@ -2112,7 +2115,7 @@ jobs:
         run: |
           pnpm run repair:publish-main -- \
             --message "chore: update failed review retry state" \
-            --path records/openclaw-openclaw \
+            --path results/failed-review-retries/openclaw-openclaw \
             --rebase-strategy theirs
 
   audit-dashboard:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
-- Retried infrastructure-failed issue reviews against their exact source revision through asynchronous dispatch, requeued source drift once, and preserved bounded retry metadata across repeated review failures.
+- Retried infrastructure-failed issue reviews against their exact source revision through bounded one-shot asynchronous dispatch, requeued source drift once, and preserved retry attempts in separate durable state so ambiguous timeouts cannot overwrite completed reviews.
 - Stopped later CI reruns from resetting PR inactivity clocks by anchoring head activity to the latest source-triggered workflow run associated with that pull request.
 - Prioritized ready close decisions and bounded PR close-coverage proofs before slow policy-gated candidates, kept default 20-item continuations shareable, and retried malformed successful GitHub JSON responses.
 - Kept automatic close-apply checkpoints within their runtime budget by bounding GitHub commands and retry waits while preserving resumable report and cursor output.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ checkpoint, and status-only commits are intentionally omitted.
 - Retried infrastructure-failed issue reviews against their exact source revision through asynchronous dispatch, requeued source drift once, and preserved bounded retry metadata across repeated review failures.
 - Stopped later CI reruns from resetting PR inactivity clocks by anchoring head activity to the latest source-triggered workflow run associated with that pull request.
 - Prioritized ready close decisions and bounded PR close-coverage proofs before slow policy-gated candidates, kept default 20-item continuations shareable, and retried malformed successful GitHub JSON responses.
+- Kept automatic close-apply checkpoints within their runtime budget by bounding GitHub commands and retry waits while preserving resumable report and cursor output.
 - Removed exponential backtracking from durable review-marker parsing so adversarial comment bodies cannot stall apply or comment synchronization.
 - Scoped Mantis recommendations to supported proof capture and kept code changes, PR repair, and GitHub mutations in ClawSweeper's deterministic lanes. Thanks @brokemac79.
 - Bounded automatic close-apply checkpoints to ten minutes, persisted exact cursor progress before immediate continuation, and limited close-coverage proofs to the time remaining in the checkpoint.

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -163,6 +163,7 @@ interface FailedReviewRetryRevision {
   kind: FailedReviewRetryRevisionKind;
   value: string;
 }
+type FailedReviewRetryStatus = "dispatching" | "dispatched" | "dispatch_failed" | "exhausted";
 type FailedReviewRetryAction =
   | "dispatched_failed_review_retry"
   | "planned_failed_review_retry"
@@ -181,7 +182,8 @@ type FailedReviewRetryAction =
   | "skipped_retry_cooldown"
   | "skipped_retry_exhausted"
   | "skipped_live_fetch_failed"
-  | "skipped_dispatch_failed";
+  | "skipped_dispatch_failed"
+  | "skipped_runtime_budget";
 type TriagePriority = "P0" | "P1" | "P2" | "P3" | "none";
 type ImpactLabelName =
   | "impact:data-loss"
@@ -900,6 +902,20 @@ interface FailedReviewRetryResult {
   attempts?: number | undefined;
   reportPath?: string | undefined;
   dispatchUrl?: string | undefined;
+}
+
+interface FailedReviewRetryState {
+  schema_version: 1;
+  repo: string;
+  number: number;
+  status: FailedReviewRetryStatus;
+  revision_kind: FailedReviewRetryRevisionKind;
+  revision: string;
+  attempts: number;
+  max_attempts: number;
+  last_at: string;
+  reason: string;
+  dispatch_url?: string | undefined;
 }
 
 type ProofNudgeAction =
@@ -2168,82 +2184,94 @@ function run(
   });
 }
 
-const APPLY_RUNTIME_REPORT_FLUSH_RESERVE_MS = 1_000;
+const GITHUB_RUNTIME_REPORT_FLUSH_RESERVE_MS = 1_000;
 
-interface ApplyGitHubRuntimeBudget {
+interface GitHubRuntimeBudget {
   startedAtMs: number;
   maxRuntimeMs: number;
   onYield?: (reason: string, resumeCurrent?: boolean) => void;
   yieldReason?: string;
 }
 
-class ApplyRuntimeBudgetError extends Error {
+class GitHubRuntimeBudgetError extends Error {
   constructor(readonly reason: string) {
     super(reason);
-    this.name = "ApplyRuntimeBudgetError";
+    this.name = "GitHubRuntimeBudgetError";
   }
 }
 
-let activeApplyGitHubRuntimeBudget: ApplyGitHubRuntimeBudget | null = null;
+let activeGitHubRuntimeBudget: GitHubRuntimeBudget | null = null;
 
-function applyGitHubRuntimeRemainingMs(nowMs = Date.now()): number | null {
-  const budget = activeApplyGitHubRuntimeBudget;
-  if (!budget || budget.maxRuntimeMs <= 0) return null;
-  return budget.maxRuntimeMs - (nowMs - budget.startedAtMs) - APPLY_RUNTIME_REPORT_FLUSH_RESERVE_MS;
+function withGitHubRuntimeBudget<T>(runtimeBudget: GitHubRuntimeBudget, operation: () => T): T {
+  const previousRuntimeBudget = activeGitHubRuntimeBudget;
+  activeGitHubRuntimeBudget = runtimeBudget;
+  try {
+    return operation();
+  } finally {
+    activeGitHubRuntimeBudget = previousRuntimeBudget;
+  }
 }
 
-function applyRuntimeBudgetError(phase: string): ApplyRuntimeBudgetError {
-  const budget = activeApplyGitHubRuntimeBudget;
+function githubRuntimeRemainingMs(nowMs = Date.now()): number | null {
+  const budget = activeGitHubRuntimeBudget;
+  if (!budget || budget.maxRuntimeMs <= 0) return null;
+  return (
+    budget.maxRuntimeMs - (nowMs - budget.startedAtMs) - GITHUB_RUNTIME_REPORT_FLUSH_RESERVE_MS
+  );
+}
+
+function githubRuntimeBudgetError(phase: string): GitHubRuntimeBudgetError {
+  const budget = activeGitHubRuntimeBudget;
   const reason =
     budget?.yieldReason ?? `max runtime ${budget?.maxRuntimeMs ?? 0}ms reached ${phase}`;
   if (budget) budget.yieldReason = reason;
-  return new ApplyRuntimeBudgetError(reason);
+  return new GitHubRuntimeBudgetError(reason);
 }
 
-function pendingApplyRuntimeBudgetError(): ApplyRuntimeBudgetError | null {
-  const reason = activeApplyGitHubRuntimeBudget?.yieldReason;
-  return reason ? new ApplyRuntimeBudgetError(reason) : null;
+function pendingGitHubRuntimeBudgetError(): GitHubRuntimeBudgetError | null {
+  const reason = activeGitHubRuntimeBudget?.yieldReason;
+  return reason ? new GitHubRuntimeBudgetError(reason) : null;
 }
 
-function applyGitHubCommandTimeoutMs(requestedTimeoutMs?: number): number | undefined {
-  const pendingError = pendingApplyRuntimeBudgetError();
+function githubCommandTimeoutMs(requestedTimeoutMs?: number): number | undefined {
+  const pendingError = pendingGitHubRuntimeBudgetError();
   if (pendingError) throw pendingError;
-  const remainingMs = applyGitHubRuntimeRemainingMs();
+  const remainingMs = githubRuntimeRemainingMs();
   if (remainingMs === null) return requestedTimeoutMs;
-  if (remainingMs <= 0) throw applyRuntimeBudgetError("before GitHub operation");
+  if (remainingMs <= 0) throw githubRuntimeBudgetError("before GitHub operation");
   return Math.max(
     1,
     requestedTimeoutMs === undefined ? remainingMs : Math.min(requestedTimeoutMs, remainingMs),
   );
 }
 
-function ensureApplyGitHubRuntimeAvailable(phase: string): void {
-  const pendingError = pendingApplyRuntimeBudgetError();
+function ensureGitHubRuntimeAvailable(phase: string): void {
+  const pendingError = pendingGitHubRuntimeBudgetError();
   if (pendingError) throw pendingError;
-  const remainingMs = applyGitHubRuntimeRemainingMs();
-  if (remainingMs !== null && remainingMs <= 0) throw applyRuntimeBudgetError(phase);
+  const remainingMs = githubRuntimeRemainingMs();
+  if (remainingMs !== null && remainingMs <= 0) throw githubRuntimeBudgetError(phase);
 }
 
-function ensureApplyRuntimeDelayFits(waitMs: number, phase: string): void {
-  const pendingError = pendingApplyRuntimeBudgetError();
+function ensureRuntimeDelayFits(waitMs: number, phase: string): void {
+  const pendingError = pendingGitHubRuntimeBudgetError();
   if (pendingError) throw pendingError;
-  const remainingMs = applyGitHubRuntimeRemainingMs();
+  const remainingMs = githubRuntimeRemainingMs();
   if (remainingMs !== null && remainingMs <= waitMs) {
-    throw applyRuntimeBudgetError(phase);
+    throw githubRuntimeBudgetError(phase);
   }
 }
 
-function ensureApplyGitHubRetryFits(waitMs: number): void {
-  ensureApplyRuntimeDelayFits(waitMs, "before GitHub retry");
+function ensureGitHubRetryFits(waitMs: number): void {
+  ensureRuntimeDelayFits(waitMs, "before GitHub retry");
 }
 
 function sleepBeforeGitHubRetry(waitMs: number): void {
-  ensureApplyGitHubRetryFits(waitMs);
+  ensureGitHubRetryFits(waitMs);
   sleepMs(waitMs);
 }
 
 function gh(args: string[]): string {
-  const timeoutMs = applyGitHubCommandTimeoutMs();
+  const timeoutMs = githubCommandTimeoutMs();
   if (args[0] === "api") return run("gh", args, { timeoutMs });
   return run("gh", ["--repo", targetRepo(), ...args], { timeoutMs });
 }
@@ -2252,7 +2280,7 @@ function ghOnce(args: string[], timeoutMs: number): string {
   const resolvedArgs = args[0] === "api" ? args : ["--repo", targetRepo(), ...args];
   const env = { ...process.env, GIT_OPTIONAL_LOCKS: "0" };
   const command = resolveCommand("gh", resolvedArgs, env);
-  const commandTimeoutMs = applyGitHubCommandTimeoutMs(timeoutMs) ?? timeoutMs;
+  const commandTimeoutMs = githubCommandTimeoutMs(timeoutMs) ?? timeoutMs;
   const runtimeLimitedTimeout = commandTimeoutMs < timeoutMs;
   const result = spawnSync(command.command, command.args, {
     cwd: ROOT,
@@ -2264,7 +2292,7 @@ function ghOnce(args: string[], timeoutMs: number): string {
   });
   if (result.error) {
     if (runtimeLimitedTimeout && (result.error as NodeJS.ErrnoException).code === "ETIMEDOUT") {
-      throw applyRuntimeBudgetError("during GitHub operation");
+      throw githubRuntimeBudgetError("during GitHub operation");
     }
     throw result.error;
   }
@@ -2328,15 +2356,15 @@ function maybePublishThrottleHeartbeat(options: {
     if (diff.status === 0) return;
     run("git", ["commit", "-m", "chore: update sweep apply throttle status"]);
     try {
-      run("git", ["push"], { timeoutMs: applyGitHubCommandTimeoutMs() });
+      run("git", ["push"], { timeoutMs: githubCommandTimeoutMs() });
     } catch (error) {
-      if (error instanceof ApplyRuntimeBudgetError) throw error;
+      if (error instanceof GitHubRuntimeBudgetError) throw error;
       console.error(
         `Best-effort throttle status push failed: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
   } catch (error) {
-    if (error instanceof ApplyRuntimeBudgetError) throw error;
+    if (error instanceof GitHubRuntimeBudgetError) throw error;
     console.error(
       `Best-effort throttle status update failed: ${error instanceof Error ? error.message : String(error)}`,
     );
@@ -2349,13 +2377,13 @@ function ghWithRetry(args: string[], attempts = 12): string {
     try {
       return gh(args);
     } catch (error) {
-      if (error instanceof ApplyRuntimeBudgetError) throw error;
+      if (error instanceof GitHubRuntimeBudgetError) throw error;
       lastError = error;
-      ensureApplyGitHubRuntimeAvailable("after GitHub operation");
+      ensureGitHubRuntimeAvailable("after GitHub operation");
       const retryKind = ghRetryKind(error);
       if (retryKind === "none" || attempt === attempts - 1) throw error;
       const waitMs = ghRetryWaitMs(retryKind, attempt);
-      ensureApplyGitHubRetryFits(waitMs);
+      ensureGitHubRetryFits(waitMs);
       const retryLabel =
         retryKind === "throttle" ? "GitHub throttled" : "Transient GitHub API failure";
       console.error(
@@ -2370,26 +2398,30 @@ function ghWithRetry(args: string[], attempts = 12): string {
   throw lastError;
 }
 
-function ghRawWithRetry(args: string[], attempts = 12): string {
-  let lastError: unknown;
-  for (let attempt = 0; attempt < attempts; attempt += 1) {
-    try {
-      return run("gh", args, { timeoutMs: applyGitHubCommandTimeoutMs() });
-    } catch (error) {
-      if (error instanceof ApplyRuntimeBudgetError) throw error;
-      lastError = error;
-      ensureApplyGitHubRuntimeAvailable("after GitHub operation");
-      const retryKind = ghRetryKind(error);
-      if (retryKind === "none" || attempt === attempts - 1) throw error;
-      const waitMs = ghRetryWaitMs(retryKind, attempt);
-      ensureApplyGitHubRetryFits(waitMs);
-      console.error(
-        `Transient GitHub workflow dispatch failure; retrying ${summarizeGhArgs(args)} in ${Math.round(waitMs / 1000)}s`,
-      );
-      sleepBeforeGitHubRetry(waitMs);
+function ghRawOnceWithCheckpoint(args: string[], onBeforeRun: () => void): string {
+  const env = { ...process.env };
+  const command = resolveCommand("gh", args, env);
+  const timeoutMs = githubCommandTimeoutMs();
+  onBeforeRun();
+  const result = spawnSync(command.command, command.args, {
+    cwd: ROOT,
+    encoding: "utf8",
+    env,
+    maxBuffer: 128 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: timeoutMs,
+  });
+  if (result.error) {
+    if (timeoutMs !== undefined && (result.error as NodeJS.ErrnoException).code === "ETIMEDOUT") {
+      throw githubRuntimeBudgetError("during GitHub dispatch");
     }
+    throw result.error;
   }
-  throw lastError;
+  if (result.status !== 0) {
+    const stderr = typeof result.stderr === "string" ? result.stderr.trim() : "";
+    throw new Error([`Command failed: gh ${args.join(" ")}`, stderr].filter(Boolean).join("\n"));
+  }
+  return (result.stdout ?? "").trim();
 }
 
 function ghJson<T>(args: string[]): T {
@@ -4657,7 +4689,7 @@ function referencingMergedPullRequestsForIssue(number: number): unknown[] {
     const items = Array.isArray(response.items) ? response.items : [];
     return referencingMergedPullRequestCandidates(items);
   } catch (error) {
-    if (error instanceof ApplyRuntimeBudgetError) throw error;
+    if (error instanceof GitHubRuntimeBudgetError) throw error;
     console.error(
       `[referencingMergedPullRequestsForIssue] number=${number} status=failed reason=${
         error instanceof Error ? error.message : String(error)
@@ -4861,7 +4893,7 @@ function compactRelatedGitHubIssueSearchItems(item: Item, seen: ReadonlySet<numb
         commentCount: candidate.comments,
       }));
   } catch (error) {
-    if (error instanceof ApplyRuntimeBudgetError) throw error;
+    if (error instanceof GitHubRuntimeBudgetError) throw error;
     console.error(
       `Best-effort related issue GitHub search failed for #${item.number}: ${
         error instanceof Error ? error.message : String(error)
@@ -18224,7 +18256,7 @@ function failedReviewRetryPrompt(options: {
 }
 
 function failedReviewRetrySection(options: {
-  status: "dispatched" | "exhausted";
+  status: FailedReviewRetryStatus;
   at: string;
   revision: FailedReviewRetryRevision;
   attempts: number;
@@ -18244,13 +18276,17 @@ function failedReviewRetrySection(options: {
     lines.push(
       "- next step: needs human review; retry attempts for this exact revision are exhausted.",
     );
+  } else if (options.status === "dispatching") {
+    lines.push("- next step: dispatch attempt checkpointed; wait for the retry cooldown.");
+  } else if (options.status === "dispatch_failed") {
+    lines.push("- next step: dispatch command failed; retry after the cooldown if still eligible.");
   }
   return lines.join("\n");
 }
 
-function markFailedReviewRetry(options: {
+function checkpointFailedReviewRetry(options: {
   markdown: string;
-  status: "dispatched" | "exhausted";
+  status: FailedReviewRetryStatus;
   at: string;
   revision: FailedReviewRetryRevision;
   attempts: number;
@@ -18275,7 +18311,106 @@ function markFailedReviewRetry(options: {
   if (options.dispatchUrl) {
     next = replaceFrontMatterValue(next, "failed_review_retry_dispatch_url", options.dispatchUrl);
   }
+  return next;
+}
+
+function markFailedReviewRetry(options: {
+  markdown: string;
+  status: FailedReviewRetryStatus;
+  at: string;
+  revision: FailedReviewRetryRevision;
+  attempts: number;
+  maxAttempts: number;
+  reason: string;
+  dispatchUrl?: string;
+}): string {
+  const next = checkpointFailedReviewRetry(options);
   return appendSectionValue(next, "Failed Review Retry", failedReviewRetrySection(options));
+}
+
+function failedReviewRetryStatePath(stateDir: string, number: number): string {
+  return join(stateDir, `${number}.json`);
+}
+
+function readFailedReviewRetryState(path: string): FailedReviewRetryState | null {
+  if (!existsSync(path)) return null;
+  const parsed = JSON.parse(readFileSync(path, "utf8")) as Partial<FailedReviewRetryState>;
+  const validStatus =
+    parsed.status === "dispatching" ||
+    parsed.status === "dispatched" ||
+    parsed.status === "dispatch_failed" ||
+    parsed.status === "exhausted";
+  if (
+    parsed.schema_version !== 1 ||
+    typeof parsed.repo !== "string" ||
+    !Number.isInteger(parsed.number) ||
+    !validStatus ||
+    (parsed.revision_kind !== "pull_head_sha" && parsed.revision_kind !== "item_source_revision") ||
+    typeof parsed.revision !== "string" ||
+    !Number.isInteger(parsed.attempts) ||
+    !Number.isInteger(parsed.max_attempts) ||
+    typeof parsed.last_at !== "string" ||
+    typeof parsed.reason !== "string"
+  ) {
+    throw new Error(`Invalid failed-review retry state: ${path}`);
+  }
+  return parsed as FailedReviewRetryState;
+}
+
+function failedReviewRetryMarkdownWithState(
+  markdown: string,
+  state: FailedReviewRetryState | null,
+): string {
+  const reportNumber = Number(frontMatterValue(markdown, "number") ?? 0);
+  if (!state || state.repo !== targetRepo() || state.number !== reportNumber) return markdown;
+  const reportRevision = failedReviewRetryRevisionForReport(markdown);
+  const stateRevision: FailedReviewRetryRevision = {
+    kind: state.revision_kind,
+    value: state.revision,
+  };
+  if (!reportRevision || !sameFailedReviewRetryRevision(reportRevision, stateRevision)) {
+    return markdown;
+  }
+  return checkpointFailedReviewRetry({
+    markdown,
+    status: state.status,
+    at: state.last_at,
+    revision: stateRevision,
+    attempts: state.attempts,
+    maxAttempts: state.max_attempts,
+    reason: state.reason,
+    ...(state.dispatch_url ? { dispatchUrl: state.dispatch_url } : {}),
+  });
+}
+
+function writeFailedReviewRetryState(
+  path: string,
+  options: {
+    number: number;
+    status: FailedReviewRetryStatus;
+    at: string;
+    revision: FailedReviewRetryRevision;
+    attempts: number;
+    maxAttempts: number;
+    reason: string;
+    dispatchUrl?: string;
+  },
+): void {
+  const state: FailedReviewRetryState = {
+    schema_version: 1,
+    repo: targetRepo(),
+    number: options.number,
+    status: options.status,
+    revision_kind: options.revision.kind,
+    revision: options.revision.value,
+    attempts: options.attempts,
+    max_attempts: options.maxAttempts,
+    last_at: options.at,
+    reason: options.reason,
+    ...(options.dispatchUrl ? { dispatch_url: options.dispatchUrl } : {}),
+  };
+  ensureDir(dirname(path));
+  writeFileSync(path, `${JSON.stringify(state, null, 2)}\n`, "utf8");
 }
 
 const FAILED_REVIEW_RETRY_METADATA_KEYS = [
@@ -18331,6 +18466,7 @@ function dispatchFailedReviewRetry(options: {
   attempts: number;
   maxAttempts: number;
   codexTimeoutMs: number;
+  onBeforeDispatch?: (dispatchUrl: string) => void;
 }): string {
   const prompt = failedReviewRetryPrompt({
     number: options.number,
@@ -18356,69 +18492,88 @@ function dispatchFailedReviewRetry(options: {
         `Issue retry repository dispatch requires the workflow repository default branch (${workflowDefaultBranch}); got --workflow-ref ${options.workflowRef}.`,
       );
     }
-    ghRawWithRetry([
-      "api",
-      "--method",
-      "POST",
-      `repos/${options.workflowRepo}/dispatches`,
-      "-f",
-      "event_type=clawsweeper_target_sweep",
-      "-f",
-      `client_payload[target_repo]=${options.targetRepo}`,
-      "-f",
-      "client_payload[target_branch]=main",
-      "-f",
-      "client_payload[batch_size]=1",
-      "-f",
-      "client_payload[shard_count]=1",
-      "-f",
-      "client_payload[hot_intake]=false",
-      "-f",
-      `client_payload[codex_timeout_ms]=${options.codexTimeoutMs}`,
-      "-f",
-      `client_payload[item_number]=${options.number}`,
-      "-f",
-      `client_payload[additional_prompt]=${prompt}`,
-      "-f",
-      `client_payload[expected_source_revision]=${options.revision.value}`,
-      "-f",
-      "client_payload[source_revision_requeue_count]=0",
-    ]);
-    return `https://github.com/${options.workflowRepo}/actions/workflows/sweep.yml`;
+    const dispatchUrl = `https://github.com/${options.workflowRepo}/actions/workflows/sweep.yml`;
+    ghRawOnceWithCheckpoint(
+      [
+        "api",
+        "--method",
+        "POST",
+        `repos/${options.workflowRepo}/dispatches`,
+        "-f",
+        "event_type=clawsweeper_target_sweep",
+        "-f",
+        `client_payload[target_repo]=${options.targetRepo}`,
+        "-f",
+        "client_payload[target_branch]=main",
+        "-f",
+        "client_payload[batch_size]=1",
+        "-f",
+        "client_payload[shard_count]=1",
+        "-f",
+        "client_payload[hot_intake]=false",
+        "-f",
+        `client_payload[codex_timeout_ms]=${options.codexTimeoutMs}`,
+        "-f",
+        `client_payload[item_number]=${options.number}`,
+        "-f",
+        `client_payload[additional_prompt]=${prompt}`,
+        "-f",
+        `client_payload[expected_source_revision]=${options.revision.value}`,
+        "-f",
+        "client_payload[source_revision_requeue_count]=0",
+      ],
+      () => options.onBeforeDispatch?.(dispatchUrl),
+    );
+    return dispatchUrl;
   }
-  ghRawWithRetry([
-    "workflow",
-    "run",
-    "sweep.yml",
-    "--repo",
-    options.workflowRepo,
-    "--ref",
-    options.workflowRef,
-    "-f",
-    "apply_existing=false",
-    "-f",
-    "hot_intake=false",
-    "-f",
-    `target_repo=${options.targetRepo}`,
-    "-f",
-    "batch_size=1",
-    "-f",
-    "shard_count=1",
-    "-f",
-    `codex_timeout_ms=${options.codexTimeoutMs}`,
-    "-f",
-    `item_number=${options.number}`,
-    "-f",
-    `additional_prompt=${prompt}`,
-  ]);
-  return `https://github.com/${options.workflowRepo}/actions/workflows/sweep.yml`;
+  const dispatchUrl = `https://github.com/${options.workflowRepo}/actions/workflows/sweep.yml`;
+  ghRawOnceWithCheckpoint(
+    [
+      "workflow",
+      "run",
+      "sweep.yml",
+      "--repo",
+      options.workflowRepo,
+      "--ref",
+      options.workflowRef,
+      "-f",
+      "apply_existing=false",
+      "-f",
+      "hot_intake=false",
+      "-f",
+      `target_repo=${options.targetRepo}`,
+      "-f",
+      "batch_size=1",
+      "-f",
+      "shard_count=1",
+      "-f",
+      `codex_timeout_ms=${options.codexTimeoutMs}`,
+      "-f",
+      `item_number=${options.number}`,
+      "-f",
+      `additional_prompt=${prompt}`,
+    ],
+    () => options.onBeforeDispatch?.(dispatchUrl),
+  );
+  return dispatchUrl;
 }
 
 function retryFailedReviewsCommand(args: Args): void {
+  const runtimeBudget: GitHubRuntimeBudget = {
+    startedAtMs: Date.now(),
+    maxRuntimeMs: numberArg(args.max_runtime_ms, 0),
+  };
+  withGitHubRuntimeBudget(runtimeBudget, () => retryFailedReviewsCommandInner(args));
+}
+
+function retryFailedReviewsCommandInner(args: Args): void {
   repoFromArgs(args);
   const itemsDir = resolve(stringArg(args.items_dir, defaultItemsDir()));
   const reportPath = resolve(
     stringArg(args.report_path, join(ROOT, "artifacts", "failed-review-retry-report.json")),
+  );
+  const stateDir = resolve(
+    stringArg(args.state_dir, join(dirname(reportPath), "failed-review-retry-state")),
   );
   const limit = numberArg(args.limit, 5);
   const maxAttempts = Math.max(1, numberArg(args.max_attempts, 2));
@@ -18435,166 +18590,252 @@ function retryFailedReviewsCommand(args: Args): void {
   const now = Date.now();
   const nowIso = new Date(now).toISOString();
   const results: FailedReviewRetryResult[] = [];
+  let attempted = 0;
   let dispatched = 0;
   ensureDir(dirname(reportPath));
-  for (const file of markdownFiles(itemsDir)) {
-    const path = join(itemsDir, file);
-    let markdown = readFileSync(path, "utf8");
-    if (!isMarkdownForActiveRepo(markdown, path)) continue;
-    const number = numberForMarkdownFile(file);
-    if (requested.size > 0 && !requested.has(number)) continue;
-    if (results.some((result) => result.number === number)) continue;
-    if (effectiveReviewStatus(markdown) !== "failed") {
-      results.push({
-        repo: targetRepo(),
-        number,
-        action: "skipped_not_failed_review",
-        reason: "review is not failed",
-        reportPath: path,
-      });
-      continue;
-    }
-    let item: Item;
-    let state: string;
-    let liveHeadSha: string | null = null;
-    let liveSourceRevision: string | null = null;
-    try {
-      ({ item, state } = fetchItem(number));
-      if (item.kind === "pull_request") liveHeadSha = livePullHeadSha(number);
-      else liveSourceRevision = liveIssueSourceRevision(number);
-    } catch (error) {
-      results.push({
-        repo: targetRepo(),
-        number,
-        action: "skipped_live_fetch_failed",
-        reason: error instanceof Error ? error.message : String(error),
-        reportPath: path,
-      });
-      continue;
-    }
-    const eligibility = failedReviewRetryEligibility({
-      markdown,
-      liveState: state,
-      liveHeadSha,
-      liveSourceRevision,
-      now,
-      maxAttempts,
-      cooldownMs,
-    });
-    const retryRevision =
-      eligibility.revisionKind && eligibility.revision
-        ? { kind: eligibility.revisionKind, value: eligibility.revision }
-        : null;
-    if (eligibility.action === "skipped_retry_exhausted" && retryRevision) {
-      if (isFailedReviewRetryAlreadyExhausted(markdown, retryRevision)) {
+  try {
+    for (const file of markdownFiles(itemsDir)) {
+      ensureGitHubRuntimeAvailable("before failed-review retry item");
+      const path = join(itemsDir, file);
+      let markdown = readFileSync(path, "utf8");
+      if (!isMarkdownForActiveRepo(markdown, path)) continue;
+      const number = numberForMarkdownFile(file);
+      const statePath = failedReviewRetryStatePath(stateDir, number);
+      markdown = failedReviewRetryMarkdownWithState(
+        markdown,
+        readFailedReviewRetryState(statePath),
+      );
+      if (requested.size > 0 && !requested.has(number)) continue;
+      if (results.some((result) => result.number === number)) continue;
+      if (effectiveReviewStatus(markdown) !== "failed") {
         results.push({
-          ...eligibility,
-          action: "skipped_retry_already_exhausted",
+          repo: targetRepo(),
+          number,
+          action: "skipped_not_failed_review",
+          reason: "review is not failed",
           reportPath: path,
         });
         continue;
       }
-      const attempts = eligibility.attempts ?? maxAttempts;
-      markdown = markFailedReviewRetry({
+      let item: Item;
+      let state: string;
+      let liveHeadSha: string | null = null;
+      let liveSourceRevision: string | null = null;
+      try {
+        ({ item, state } = fetchItem(number));
+        if (item.kind === "pull_request") liveHeadSha = livePullHeadSha(number);
+        else liveSourceRevision = liveIssueSourceRevision(number);
+      } catch (error) {
+        if (error instanceof GitHubRuntimeBudgetError) throw error;
+        results.push({
+          repo: targetRepo(),
+          number,
+          action: "skipped_live_fetch_failed",
+          reason: error instanceof Error ? error.message : String(error),
+          reportPath: path,
+        });
+        continue;
+      }
+      const eligibility = failedReviewRetryEligibility({
         markdown,
-        status: "exhausted",
-        at: nowIso,
-        revision: retryRevision,
-        attempts,
+        liveState: state,
+        liveHeadSha,
+        liveSourceRevision,
+        now,
         maxAttempts,
-        reason: eligibility.reason,
+        cooldownMs,
       });
-      if (!dryRun) writeFileSync(path, markdown, "utf8");
-      results.push({
-        ...eligibility,
-        action: "marked_failed_review_retry_exhausted",
-        reportPath: path,
-      });
-      continue;
-    }
-    if (eligibility.action !== "planned_failed_review_retry" || !retryRevision) {
-      results.push({ ...eligibility, reportPath: path });
-      continue;
-    }
-    if (dispatched >= limit) break;
-    const retryReason = codexFailureReason(failedReviewFailureDetail(markdown));
-    if (dryRun) {
-      results.push({ ...eligibility, reason: retryReason, reportPath: path });
-      dispatched += 1;
-      continue;
-    }
-    try {
+      const retryRevision =
+        eligibility.revisionKind && eligibility.revision
+          ? { kind: eligibility.revisionKind, value: eligibility.revision }
+          : null;
+      if (eligibility.action === "skipped_retry_exhausted" && retryRevision) {
+        if (isFailedReviewRetryAlreadyExhausted(markdown, retryRevision)) {
+          results.push({
+            ...eligibility,
+            action: "skipped_retry_already_exhausted",
+            reportPath: path,
+          });
+          continue;
+        }
+        const attempts = eligibility.attempts ?? maxAttempts;
+        markdown = markFailedReviewRetry({
+          markdown,
+          status: "exhausted",
+          at: nowIso,
+          revision: retryRevision,
+          attempts,
+          maxAttempts,
+          reason: eligibility.reason,
+        });
+        if (!dryRun) {
+          writeFileSync(path, markdown, "utf8");
+          writeFailedReviewRetryState(statePath, {
+            number,
+            status: "exhausted",
+            at: nowIso,
+            revision: retryRevision,
+            attempts,
+            maxAttempts,
+            reason: eligibility.reason,
+          });
+        }
+        results.push({
+          ...eligibility,
+          action: "marked_failed_review_retry_exhausted",
+          reportPath: path,
+        });
+        continue;
+      }
+      if (eligibility.action !== "planned_failed_review_retry" || !retryRevision) {
+        results.push({ ...eligibility, reportPath: path });
+        continue;
+      }
+      if (attempted >= limit) break;
+      const retryReason = codexFailureReason(failedReviewFailureDetail(markdown));
+      if (dryRun) {
+        results.push({ ...eligibility, reason: retryReason, reportPath: path });
+        attempted += 1;
+        dispatched += 1;
+        continue;
+      }
       const attempts = (eligibility.attempts ?? 0) + 1;
-      const dispatchUrl = dispatchFailedReviewRetry({
-        workflowRepo,
-        workflowRef,
-        targetRepo: targetRepo(),
-        number,
-        revision: retryRevision,
-        reason: retryReason,
-        attempts: eligibility.attempts ?? 0,
-        maxAttempts,
-        codexTimeoutMs,
-      });
-      markdown = markFailedReviewRetry({
-        markdown,
-        status: "dispatched",
-        at: nowIso,
-        revision: retryRevision,
-        attempts,
-        maxAttempts,
-        reason: retryReason,
-        dispatchUrl,
-      });
-      writeFileSync(path, markdown, "utf8");
-      results.push({
-        repo: targetRepo(),
-        number,
-        action: "dispatched_failed_review_retry",
-        reason: retryReason,
-        ...failedReviewRetryResultRevision(retryRevision),
-        attempts,
-        reportPath: path,
-        dispatchUrl,
-      });
-      dispatched += 1;
-    } catch (error) {
-      results.push({
-        repo: targetRepo(),
-        number,
-        action: "skipped_dispatch_failed",
-        reason: error instanceof Error ? error.message : String(error),
-        ...failedReviewRetryResultRevision(retryRevision),
-        attempts: eligibility.attempts,
-        reportPath: path,
-      });
+      let dispatchCheckpointed = false;
+      let checkpointDispatchUrl: string | undefined;
+      try {
+        const dispatchUrl = dispatchFailedReviewRetry({
+          workflowRepo,
+          workflowRef,
+          targetRepo: targetRepo(),
+          number,
+          revision: retryRevision,
+          reason: retryReason,
+          attempts: eligibility.attempts ?? 0,
+          maxAttempts,
+          codexTimeoutMs,
+          onBeforeDispatch: (nextDispatchUrl) => {
+            dispatchCheckpointed = true;
+            checkpointDispatchUrl = nextDispatchUrl;
+            markdown = checkpointFailedReviewRetry({
+              markdown,
+              status: "dispatching",
+              at: nowIso,
+              revision: retryRevision,
+              attempts,
+              maxAttempts,
+              reason: retryReason,
+              dispatchUrl: nextDispatchUrl,
+            });
+            writeFileSync(path, markdown, "utf8");
+            writeFailedReviewRetryState(statePath, {
+              number,
+              status: "dispatching",
+              at: nowIso,
+              revision: retryRevision,
+              attempts,
+              maxAttempts,
+              reason: retryReason,
+              dispatchUrl: nextDispatchUrl,
+            });
+            attempted += 1;
+          },
+        });
+        markdown = markFailedReviewRetry({
+          markdown,
+          status: "dispatched",
+          at: nowIso,
+          revision: retryRevision,
+          attempts,
+          maxAttempts,
+          reason: retryReason,
+          dispatchUrl,
+        });
+        writeFileSync(path, markdown, "utf8");
+        writeFailedReviewRetryState(statePath, {
+          number,
+          status: "dispatched",
+          at: nowIso,
+          revision: retryRevision,
+          attempts,
+          maxAttempts,
+          reason: retryReason,
+          dispatchUrl,
+        });
+        results.push({
+          repo: targetRepo(),
+          number,
+          action: "dispatched_failed_review_retry",
+          reason: retryReason,
+          ...failedReviewRetryResultRevision(retryRevision),
+          attempts,
+          reportPath: path,
+          dispatchUrl,
+        });
+        dispatched += 1;
+      } catch (error) {
+        if (dispatchCheckpointed) {
+          markdown = markFailedReviewRetry({
+            markdown,
+            status: "dispatch_failed",
+            at: nowIso,
+            revision: retryRevision,
+            attempts,
+            maxAttempts,
+            reason: error instanceof Error ? error.message : String(error),
+            ...(checkpointDispatchUrl ? { dispatchUrl: checkpointDispatchUrl } : {}),
+          });
+          writeFileSync(path, markdown, "utf8");
+          writeFailedReviewRetryState(statePath, {
+            number,
+            status: "dispatch_failed",
+            at: nowIso,
+            revision: retryRevision,
+            attempts,
+            maxAttempts,
+            reason: error instanceof Error ? error.message : String(error),
+            ...(checkpointDispatchUrl ? { dispatchUrl: checkpointDispatchUrl } : {}),
+          });
+        }
+        if (error instanceof GitHubRuntimeBudgetError) throw error;
+        results.push({
+          repo: targetRepo(),
+          number,
+          action: "skipped_dispatch_failed",
+          reason: error instanceof Error ? error.message : String(error),
+          ...failedReviewRetryResultRevision(retryRevision),
+          attempts: dispatchCheckpointed ? attempts : eligibility.attempts,
+          reportPath: path,
+        });
+      }
     }
+  } catch (error) {
+    if (!(error instanceof GitHubRuntimeBudgetError)) throw error;
+    results.push({
+      number: 0,
+      action: "skipped_runtime_budget",
+      reason: error.reason,
+    });
   }
   writeFileSync(reportPath, `${JSON.stringify(results, null, 2)}\n`, "utf8");
-  console.log(JSON.stringify({ results, dryRun, dispatched }, null, 2));
+  console.log(JSON.stringify({ results, dryRun, attempted, dispatched }, null, 2));
 }
 
-async function applyDecisionsCommand(args: Args): Promise<void> {
-  const runtimeBudget: ApplyGitHubRuntimeBudget = {
+function applyDecisionsCommand(args: Args): void {
+  const runtimeBudget: GitHubRuntimeBudget = {
     startedAtMs: Date.now(),
     maxRuntimeMs: numberArg(args.max_runtime_ms, 0),
   };
-  const previousRuntimeBudget = activeApplyGitHubRuntimeBudget;
-  activeApplyGitHubRuntimeBudget = runtimeBudget;
-  try {
-    await applyDecisionsCommandInner(args, runtimeBudget);
-  } catch (error) {
-    if (!(error instanceof ApplyRuntimeBudgetError) || !runtimeBudget.onYield) throw error;
-    runtimeBudget.onYield(error.reason);
-  } finally {
-    activeApplyGitHubRuntimeBudget = previousRuntimeBudget;
-  }
+  withGitHubRuntimeBudget(runtimeBudget, () => {
+    try {
+      applyDecisionsCommandInner(args, runtimeBudget);
+    } catch (error) {
+      if (!(error instanceof GitHubRuntimeBudgetError) || !runtimeBudget.onYield) throw error;
+      runtimeBudget.onYield(error.reason);
+    }
+  });
 }
 
-async function applyDecisionsCommandInner(
-  args: Args,
-  runtimeBudget: ApplyGitHubRuntimeBudget,
-): Promise<void> {
+function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudget): void {
   repoFromArgs(args);
   const itemsDir = resolve(stringArg(args.items_dir, defaultItemsDir()));
   const closedDir = resolve(stringArg(args.closed_dir, defaultClosedDir()));
@@ -19650,7 +19891,7 @@ async function applyDecisionsCommandInner(
           reason: `linked canonical PR #${covering.number} changed after coverage proof`,
         };
       } catch (error) {
-        if (error instanceof ApplyRuntimeBudgetError) throw error;
+        if (error instanceof GitHubRuntimeBudgetError) throw error;
         return {
           actionTaken: "retry_pr_close_coverage_proof",
           reason: `PR close coverage proof could not recheck linked canonical PR #${covering.number}: ${
@@ -20263,14 +20504,14 @@ async function applyDecisionsCommandInner(
             dryRun,
           })
         : null;
-    ensureApplyRuntimeDelayFits(closeDelayMs, "before close");
+    ensureRuntimeDelayFits(closeDelayMs, "before close");
     closeItem({ number, kind: item.kind, reason: closeReason });
     let postCloseRuntimeYieldReason: string | null = null;
     try {
-      ensureApplyRuntimeDelayFits(closeDelayMs, "before close delay");
+      ensureRuntimeDelayFits(closeDelayMs, "before close delay");
       sleepMs(closeDelayMs);
     } catch (error) {
-      if (!(error instanceof ApplyRuntimeBudgetError)) throw error;
+      if (!(error instanceof GitHubRuntimeBudgetError)) throw error;
       postCloseRuntimeYieldReason = error.reason;
     }
     markdown = replaceSectionValue(markdown, REVIEW_SECTIONS.closeComment, reviewComment);
@@ -22490,7 +22731,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
   else if (command === "review") reviewCommand(args);
   else if (command === "retry-failed-reviews") retryFailedReviewsCommand(args);
   else if (command === "apply-artifacts") applyArtifactsCommand(args);
-  else if (command === "apply-decisions") await applyDecisionsCommand(args);
+  else if (command === "apply-decisions") applyDecisionsCommand(args);
   else if (command === "proof-nudges") proofNudgesCommand(args);
   else if (command === "bot-proof") botProofCommand(args);
   else if (command === "audit") auditCommand(args);

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -2156,20 +2156,77 @@ function evidenceEntry(options: Partial<Evidence> & Pick<Evidence, "label" | "de
 function run(
   command: string,
   args: string[],
-  options: { cwd?: string; env?: NodeJS.ProcessEnv } = {},
+  options: { cwd?: string; env?: NodeJS.ProcessEnv; timeoutMs?: number | undefined } = {},
 ): string {
   return runText(command, args, {
     cwd: options.cwd ?? ROOT,
     env: options.env,
     maxBuffer: 128 * 1024 * 1024,
     stdio: ["ignore", "pipe", "pipe"],
+    timeoutMs: options.timeoutMs,
     trim: "both",
   });
 }
 
+const APPLY_RUNTIME_REPORT_FLUSH_RESERVE_MS = 1_000;
+
+interface ApplyGitHubRuntimeBudget {
+  startedAtMs: number;
+  maxRuntimeMs: number;
+  onYield?: (reason: string) => void;
+}
+
+class ApplyRuntimeBudgetError extends Error {
+  constructor(readonly reason: string) {
+    super(reason);
+    this.name = "ApplyRuntimeBudgetError";
+  }
+}
+
+let activeApplyGitHubRuntimeBudget: ApplyGitHubRuntimeBudget | null = null;
+
+function applyGitHubRuntimeRemainingMs(nowMs = Date.now()): number | null {
+  const budget = activeApplyGitHubRuntimeBudget;
+  if (!budget || budget.maxRuntimeMs <= 0) return null;
+  return budget.maxRuntimeMs - (nowMs - budget.startedAtMs) - APPLY_RUNTIME_REPORT_FLUSH_RESERVE_MS;
+}
+
+function applyRuntimeBudgetError(phase: string): ApplyRuntimeBudgetError {
+  const maxRuntimeMs = activeApplyGitHubRuntimeBudget?.maxRuntimeMs ?? 0;
+  return new ApplyRuntimeBudgetError(`max runtime ${maxRuntimeMs}ms reached ${phase}`);
+}
+
+function applyGitHubCommandTimeoutMs(requestedTimeoutMs?: number): number | undefined {
+  const remainingMs = applyGitHubRuntimeRemainingMs();
+  if (remainingMs === null) return requestedTimeoutMs;
+  if (remainingMs <= 0) throw applyRuntimeBudgetError("before GitHub operation");
+  return Math.max(
+    1,
+    requestedTimeoutMs === undefined ? remainingMs : Math.min(requestedTimeoutMs, remainingMs),
+  );
+}
+
+function ensureApplyGitHubRuntimeAvailable(phase: string): void {
+  const remainingMs = applyGitHubRuntimeRemainingMs();
+  if (remainingMs !== null && remainingMs <= 0) throw applyRuntimeBudgetError(phase);
+}
+
+function ensureApplyGitHubRetryFits(waitMs: number): void {
+  const remainingMs = applyGitHubRuntimeRemainingMs();
+  if (remainingMs !== null && remainingMs <= waitMs) {
+    throw applyRuntimeBudgetError("before GitHub retry");
+  }
+}
+
+function sleepBeforeGitHubRetry(waitMs: number): void {
+  ensureApplyGitHubRetryFits(waitMs);
+  sleepMs(waitMs);
+}
+
 function gh(args: string[]): string {
-  if (args[0] === "api") return run("gh", args);
-  return run("gh", ["--repo", targetRepo(), ...args]);
+  const timeoutMs = applyGitHubCommandTimeoutMs();
+  if (args[0] === "api") return run("gh", args, { timeoutMs });
+  return run("gh", ["--repo", targetRepo(), ...args], { timeoutMs });
 }
 
 function ghOnce(args: string[], timeoutMs: number): string {
@@ -2182,7 +2239,7 @@ function ghOnce(args: string[], timeoutMs: number): string {
     env,
     maxBuffer: 8 * 1024 * 1024,
     stdio: ["ignore", "pipe", "pipe"],
-    timeout: timeoutMs,
+    timeout: applyGitHubCommandTimeoutMs(timeoutMs),
   });
   if (result.error) throw result.error;
   if (result.status !== 0) {
@@ -2245,7 +2302,7 @@ function maybePublishThrottleHeartbeat(options: {
     if (diff.status === 0) return;
     run("git", ["commit", "-m", "chore: update sweep apply throttle status"]);
     try {
-      run("git", ["push"]);
+      run("git", ["push"], { timeoutMs: applyGitHubCommandTimeoutMs() });
     } catch (error) {
       console.error(
         `Best-effort throttle status push failed: ${error instanceof Error ? error.message : String(error)}`,
@@ -2264,10 +2321,13 @@ function ghWithRetry(args: string[], attempts = 12): string {
     try {
       return gh(args);
     } catch (error) {
+      if (error instanceof ApplyRuntimeBudgetError) throw error;
       lastError = error;
+      ensureApplyGitHubRuntimeAvailable("after GitHub operation");
       const retryKind = ghRetryKind(error);
       if (retryKind === "none" || attempt === attempts - 1) throw error;
       const waitMs = ghRetryWaitMs(retryKind, attempt);
+      ensureApplyGitHubRetryFits(waitMs);
       const retryLabel =
         retryKind === "throttle" ? "GitHub throttled" : "Transient GitHub API failure";
       console.error(
@@ -2276,7 +2336,7 @@ function ghWithRetry(args: string[], attempts = 12): string {
       if (retryKind === "throttle") {
         maybePublishThrottleHeartbeat({ args, attempt, attempts, waitMs });
       }
-      sleepMs(waitMs);
+      sleepBeforeGitHubRetry(waitMs);
     }
   }
   throw lastError;
@@ -2286,16 +2346,19 @@ function ghRawWithRetry(args: string[], attempts = 12): string {
   let lastError: unknown;
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     try {
-      return run("gh", args);
+      return run("gh", args, { timeoutMs: applyGitHubCommandTimeoutMs() });
     } catch (error) {
+      if (error instanceof ApplyRuntimeBudgetError) throw error;
       lastError = error;
+      ensureApplyGitHubRuntimeAvailable("after GitHub operation");
       const retryKind = ghRetryKind(error);
       if (retryKind === "none" || attempt === attempts - 1) throw error;
       const waitMs = ghRetryWaitMs(retryKind, attempt);
+      ensureApplyGitHubRetryFits(waitMs);
       console.error(
         `Transient GitHub workflow dispatch failure; retrying ${summarizeGhArgs(args)} in ${Math.round(waitMs / 1000)}s`,
       );
-      sleepMs(waitMs);
+      sleepBeforeGitHubRetry(waitMs);
     }
   }
   throw lastError;
@@ -18482,6 +18545,26 @@ function retryFailedReviewsCommand(args: Args): void {
 }
 
 async function applyDecisionsCommand(args: Args): Promise<void> {
+  const runtimeBudget: ApplyGitHubRuntimeBudget = {
+    startedAtMs: Date.now(),
+    maxRuntimeMs: numberArg(args.max_runtime_ms, 0),
+  };
+  const previousRuntimeBudget = activeApplyGitHubRuntimeBudget;
+  activeApplyGitHubRuntimeBudget = runtimeBudget;
+  try {
+    await applyDecisionsCommandInner(args, runtimeBudget);
+  } catch (error) {
+    if (!(error instanceof ApplyRuntimeBudgetError) || !runtimeBudget.onYield) throw error;
+    runtimeBudget.onYield(error.reason);
+  } finally {
+    activeApplyGitHubRuntimeBudget = previousRuntimeBudget;
+  }
+}
+
+async function applyDecisionsCommandInner(
+  args: Args,
+  runtimeBudget: ApplyGitHubRuntimeBudget,
+): Promise<void> {
   repoFromArgs(args);
   const itemsDir = resolve(stringArg(args.items_dir, defaultItemsDir()));
   const closedDir = resolve(stringArg(args.closed_dir, defaultClosedDir()));
@@ -18502,7 +18585,7 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
   const dryRun = boolArg(args.dry_run);
   const syncCommentsOnly = boolArg(args.sync_comments_only);
   const commentSyncMinAgeDays = numberArg(args.comment_sync_min_age_days, 0);
-  const maxRuntimeMs = numberArg(args.max_runtime_ms, 0);
+  const maxRuntimeMs = runtimeBudget.maxRuntimeMs;
   const reportPath = resolve(stringArg(args.report_path, join(ROOT, "apply-report.json")));
   const artifactDir = resolve(stringArg(args.artifact_dir, join(ROOT, "artifacts", "apply")));
   const cursorTraceArg = stringArg(args.cursor_trace, "").trim();
@@ -18521,7 +18604,7 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       ? { ghToken: process.env.CLAWSWEEPER_PROOF_INSPECTION_TOKEN }
       : {}),
   };
-  const startedAtMs = Date.now();
+  const startedAtMs = runtimeBudget.startedAtMs;
   const requestedItemNumbers = itemNumbersArg(args.item_numbers, args.item_number);
   const requestedItemNumberSet = new Set(requestedItemNumbers);
   const requestedItemOrder = orderedApplyItemNumbers(args.item_numbers, args.item_number);
@@ -18625,6 +18708,22 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
       )}\n`,
       "utf8",
     );
+  };
+  const finishApply = (): void => {
+    ensureDir(dirname(reportPath));
+    writeFileSync(reportPath, JSON.stringify(results, null, 2), "utf8");
+    writeCursorTrace();
+    logProgress("finished apply");
+    console.log(JSON.stringify(results, null, 2));
+  };
+  runtimeBudget.onYield = (reason: string): void => {
+    const currentNumber = examinedItemNumbers.at(-1);
+    if (currentNumber !== undefined) {
+      removeCurrentCursorTraceItem(examinedItemNumbers, currentNumber);
+    }
+    results.push({ number: 0, action: "skipped_runtime_budget", reason });
+    logProgress(`stopping apply: ${reason}`);
+    finishApply();
   };
   if (fileEntries.length === 0 && !existsSync(itemsDir)) {
     console.log("No items directory.");
@@ -20152,11 +20251,7 @@ async function applyDecisionsCommand(args: Args): Promise<void> {
     closedThisRun.add(pairCloseKey(repo, number));
     if (processedCount >= processedLimit) break;
   }
-  ensureDir(dirname(reportPath));
-  writeFileSync(reportPath, JSON.stringify(results, null, 2), "utf8");
-  writeCursorTrace();
-  logProgress("finished apply");
-  console.log(JSON.stringify(results, null, 2));
+  finishApply();
 }
 
 function orderedApplyItemNumbers(

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import {
   chmodSync,
   existsSync,
@@ -2082,6 +2082,10 @@ function defaultClosedDir(profile = targetProfile()): string {
 
 function defaultPlansDir(profile = targetProfile()): string {
   return join(repoRecordsDir(profile), "plans");
+}
+
+function defaultFailedReviewRetryStateDir(profile = targetProfile()): string {
+  return join(ROOT, "results", "failed-review-retries", profile.slug);
 }
 
 function defaultDecisionPacketsDir(profile = targetProfile()): string {
@@ -6390,6 +6394,39 @@ function recordDashboardActivity(
       recordFailedReviewRetryStatus(failedReviewRetryStatus, bucket);
     }
   }
+}
+
+function dashboardMarkdownWithFailedReviewRetryState(
+  markdown: string,
+  number: number,
+  stateDir: string,
+): string {
+  const statePath = failedReviewRetryStatePath(stateDir, number);
+  let state: FailedReviewRetryState | null;
+  try {
+    state = readFailedReviewRetryState(statePath);
+  } catch (error) {
+    console.error(
+      `[dashboard] ignoring invalid failed-review retry state ${repoRelativePath(statePath)}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    state = null;
+  }
+  return failedReviewRetryMarkdownWithState(markdown, state);
+}
+
+export function dashboardFailedReviewRetryActivityForTest(options: {
+  markdown: string;
+  number: number;
+  stateDir: string;
+  now: number;
+}): DashboardActivityStats {
+  const activity = emptyDashboardActivityStats();
+  recordDashboardActivity(
+    dashboardMarkdownWithFailedReviewRetryState(options.markdown, options.number, options.stateDir),
+    activity,
+    options.now,
+  );
+  return activity;
 }
 
 function formatActivityRow(label: string, bucket: DashboardActivityBucket): string {
@@ -18410,7 +18447,16 @@ function writeFailedReviewRetryState(
     ...(options.dispatchUrl ? { dispatch_url: options.dispatchUrl } : {}),
   };
   ensureDir(dirname(path));
-  writeFileSync(path, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  const temporaryPath = join(
+    dirname(path),
+    `.${basename(path)}.${process.pid}.${randomUUID()}.tmp`,
+  );
+  try {
+    writeFileSync(temporaryPath, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+    renameSync(temporaryPath, path);
+  } finally {
+    if (existsSync(temporaryPath)) unlinkSync(temporaryPath);
+  }
 }
 
 const FAILED_REVIEW_RETRY_METADATA_KEYS = [
@@ -21924,8 +21970,13 @@ function dashboardStats(
   const recent: DashboardItem[] = [];
   const workQueue: DashboardItem[] = [];
   const recentClosed: DashboardClosedItem[] = [];
+  const failedReviewRetryStateDir = defaultFailedReviewRetryStateDir(profile);
   for (const entry of entries) {
-    const markdown = entry.markdown;
+    const markdown = dashboardMarkdownWithFailedReviewRetryState(
+      entry.markdown,
+      entry.number,
+      failedReviewRetryStateDir,
+    );
     const repo = entry.repo;
     const number = entry.number;
     const reviewedAt = frontMatterValue(markdown, "reviewed_at");
@@ -21987,7 +22038,11 @@ function dashboardStats(
     }
   }
   for (const entry of closedEntries) {
-    const markdown = entry.markdown;
+    const markdown = dashboardMarkdownWithFailedReviewRetryState(
+      entry.markdown,
+      entry.number,
+      failedReviewRetryStateDir,
+    );
     const repo = entry.repo;
     const action = frontMatterValue(markdown, "action_taken") ?? "unknown";
     const closedAt = dashboardClosedAt(markdown);

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -2173,7 +2173,7 @@ const APPLY_RUNTIME_REPORT_FLUSH_RESERVE_MS = 1_000;
 interface ApplyGitHubRuntimeBudget {
   startedAtMs: number;
   maxRuntimeMs: number;
-  onYield?: (reason: string) => void;
+  onYield?: (reason: string, resumeCurrent?: boolean) => void;
   yieldReason?: string;
 }
 
@@ -18746,9 +18746,9 @@ async function applyDecisionsCommandInner(
     logProgress("finished apply");
     console.log(JSON.stringify(results, null, 2));
   };
-  runtimeBudget.onYield = (reason: string): void => {
+  runtimeBudget.onYield = (reason: string, resumeCurrent = true): void => {
     const currentNumber = examinedItemNumbers.at(-1);
-    if (currentNumber !== undefined) {
+    if (resumeCurrent && currentNumber !== undefined) {
       removeCurrentCursorTraceItem(examinedItemNumbers, currentNumber);
     }
     results.push({ number: 0, action: "skipped_runtime_budget", reason });
@@ -20263,9 +20263,16 @@ async function applyDecisionsCommandInner(
             dryRun,
           })
         : null;
+    ensureApplyRuntimeDelayFits(closeDelayMs, "before close");
     closeItem({ number, kind: item.kind, reason: closeReason });
-    ensureApplyRuntimeDelayFits(closeDelayMs, "before close delay");
-    sleepMs(closeDelayMs);
+    let postCloseRuntimeYieldReason: string | null = null;
+    try {
+      ensureApplyRuntimeDelayFits(closeDelayMs, "before close delay");
+      sleepMs(closeDelayMs);
+    } catch (error) {
+      if (!(error instanceof ApplyRuntimeBudgetError)) throw error;
+      postCloseRuntimeYieldReason = error.reason;
+    }
     markdown = replaceSectionValue(markdown, REVIEW_SECTIONS.closeComment, reviewComment);
     markdown = replaceFrontMatterValue(markdown, "close_comment_sha256", sha256(reviewComment));
     markdown = replaceFrontMatterValue(markdown, "action_taken", "closed");
@@ -20281,6 +20288,10 @@ async function applyDecisionsCommandInner(
     });
     logProgress(`closed #${number}`);
     closedThisRun.add(pairCloseKey(repo, number));
+    if (postCloseRuntimeYieldReason) {
+      runtimeBudget.onYield?.(postCloseRuntimeYieldReason, false);
+      return;
+    }
     if (processedCount >= processedLimit) break;
   }
   if (runtimeBudget.yieldReason) {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -2399,7 +2399,7 @@ function ghJson<T>(args: string[]): T {
       console.error(
         `Malformed GitHub JSON response; retrying ${summarizeGhArgs(args)} in ${Math.round(waitMs / 1000)}s`,
       );
-      sleepMs(waitMs);
+      sleepBeforeGitHubRetry(waitMs);
     },
   });
 }

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -2174,6 +2174,7 @@ interface ApplyGitHubRuntimeBudget {
   startedAtMs: number;
   maxRuntimeMs: number;
   onYield?: (reason: string) => void;
+  yieldReason?: string;
 }
 
 class ApplyRuntimeBudgetError extends Error {
@@ -2192,11 +2193,21 @@ function applyGitHubRuntimeRemainingMs(nowMs = Date.now()): number | null {
 }
 
 function applyRuntimeBudgetError(phase: string): ApplyRuntimeBudgetError {
-  const maxRuntimeMs = activeApplyGitHubRuntimeBudget?.maxRuntimeMs ?? 0;
-  return new ApplyRuntimeBudgetError(`max runtime ${maxRuntimeMs}ms reached ${phase}`);
+  const budget = activeApplyGitHubRuntimeBudget;
+  const reason =
+    budget?.yieldReason ?? `max runtime ${budget?.maxRuntimeMs ?? 0}ms reached ${phase}`;
+  if (budget) budget.yieldReason = reason;
+  return new ApplyRuntimeBudgetError(reason);
+}
+
+function pendingApplyRuntimeBudgetError(): ApplyRuntimeBudgetError | null {
+  const reason = activeApplyGitHubRuntimeBudget?.yieldReason;
+  return reason ? new ApplyRuntimeBudgetError(reason) : null;
 }
 
 function applyGitHubCommandTimeoutMs(requestedTimeoutMs?: number): number | undefined {
+  const pendingError = pendingApplyRuntimeBudgetError();
+  if (pendingError) throw pendingError;
   const remainingMs = applyGitHubRuntimeRemainingMs();
   if (remainingMs === null) return requestedTimeoutMs;
   if (remainingMs <= 0) throw applyRuntimeBudgetError("before GitHub operation");
@@ -2207,11 +2218,15 @@ function applyGitHubCommandTimeoutMs(requestedTimeoutMs?: number): number | unde
 }
 
 function ensureApplyGitHubRuntimeAvailable(phase: string): void {
+  const pendingError = pendingApplyRuntimeBudgetError();
+  if (pendingError) throw pendingError;
   const remainingMs = applyGitHubRuntimeRemainingMs();
   if (remainingMs !== null && remainingMs <= 0) throw applyRuntimeBudgetError(phase);
 }
 
 function ensureApplyGitHubRetryFits(waitMs: number): void {
+  const pendingError = pendingApplyRuntimeBudgetError();
+  if (pendingError) throw pendingError;
   const remainingMs = applyGitHubRuntimeRemainingMs();
   if (remainingMs !== null && remainingMs <= waitMs) {
     throw applyRuntimeBudgetError("before GitHub retry");
@@ -19620,6 +19635,7 @@ async function applyDecisionsCommandInner(
           reason: `linked canonical PR #${covering.number} changed after coverage proof`,
         };
       } catch (error) {
+        if (error instanceof ApplyRuntimeBudgetError) throw error;
         return {
           actionTaken: "retry_pr_close_coverage_proof",
           reason: `PR close coverage proof could not recheck linked canonical PR #${covering.number}: ${
@@ -20250,6 +20266,10 @@ async function applyDecisionsCommandInner(
     logProgress(`closed #${number}`);
     closedThisRun.add(pairCloseKey(repo, number));
     if (processedCount >= processedLimit) break;
+  }
+  if (runtimeBudget.yieldReason) {
+    runtimeBudget.onYield?.(runtimeBudget.yieldReason);
+    return;
   }
   finishApply();
 }

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -2224,13 +2224,17 @@ function ensureApplyGitHubRuntimeAvailable(phase: string): void {
   if (remainingMs !== null && remainingMs <= 0) throw applyRuntimeBudgetError(phase);
 }
 
-function ensureApplyGitHubRetryFits(waitMs: number): void {
+function ensureApplyRuntimeDelayFits(waitMs: number, phase: string): void {
   const pendingError = pendingApplyRuntimeBudgetError();
   if (pendingError) throw pendingError;
   const remainingMs = applyGitHubRuntimeRemainingMs();
   if (remainingMs !== null && remainingMs <= waitMs) {
-    throw applyRuntimeBudgetError("before GitHub retry");
+    throw applyRuntimeBudgetError(phase);
   }
+}
+
+function ensureApplyGitHubRetryFits(waitMs: number): void {
+  ensureApplyRuntimeDelayFits(waitMs, "before GitHub retry");
 }
 
 function sleepBeforeGitHubRetry(waitMs: number): void {
@@ -20260,6 +20264,7 @@ async function applyDecisionsCommandInner(
           })
         : null;
     closeItem({ number, kind: item.kind, reason: closeReason });
+    ensureApplyRuntimeDelayFits(closeDelayMs, "before close delay");
     sleepMs(closeDelayMs);
     markdown = replaceSectionValue(markdown, REVIEW_SECTIONS.closeComment, reviewComment);
     markdown = replaceFrontMatterValue(markdown, "close_comment_sha256", sha256(reviewComment));

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -2248,15 +2248,22 @@ function ghOnce(args: string[], timeoutMs: number): string {
   const resolvedArgs = args[0] === "api" ? args : ["--repo", targetRepo(), ...args];
   const env = { ...process.env, GIT_OPTIONAL_LOCKS: "0" };
   const command = resolveCommand("gh", resolvedArgs, env);
+  const commandTimeoutMs = applyGitHubCommandTimeoutMs(timeoutMs) ?? timeoutMs;
+  const runtimeLimitedTimeout = commandTimeoutMs < timeoutMs;
   const result = spawnSync(command.command, command.args, {
     cwd: ROOT,
     encoding: "utf8",
     env,
     maxBuffer: 8 * 1024 * 1024,
     stdio: ["ignore", "pipe", "pipe"],
-    timeout: applyGitHubCommandTimeoutMs(timeoutMs),
+    timeout: commandTimeoutMs,
   });
-  if (result.error) throw result.error;
+  if (result.error) {
+    if (runtimeLimitedTimeout && (result.error as NodeJS.ErrnoException).code === "ETIMEDOUT") {
+      throw applyRuntimeBudgetError("during GitHub operation");
+    }
+    throw result.error;
+  }
   if (result.status !== 0) {
     const stderr = typeof result.stderr === "string" ? result.stderr.trim() : "";
     throw new Error(
@@ -2319,11 +2326,13 @@ function maybePublishThrottleHeartbeat(options: {
     try {
       run("git", ["push"], { timeoutMs: applyGitHubCommandTimeoutMs() });
     } catch (error) {
+      if (error instanceof ApplyRuntimeBudgetError) throw error;
       console.error(
         `Best-effort throttle status push failed: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
   } catch (error) {
+    if (error instanceof ApplyRuntimeBudgetError) throw error;
     console.error(
       `Best-effort throttle status update failed: ${error instanceof Error ? error.message : String(error)}`,
     );
@@ -4644,6 +4653,7 @@ function referencingMergedPullRequestsForIssue(number: number): unknown[] {
     const items = Array.isArray(response.items) ? response.items : [];
     return referencingMergedPullRequestCandidates(items);
   } catch (error) {
+    if (error instanceof ApplyRuntimeBudgetError) throw error;
     console.error(
       `[referencingMergedPullRequestsForIssue] number=${number} status=failed reason=${
         error instanceof Error ? error.message : String(error)
@@ -4847,6 +4857,7 @@ function compactRelatedGitHubIssueSearchItems(item: Item, seen: ReadonlySet<numb
         commentCount: candidate.comments,
       }));
   } catch (error) {
+    if (error instanceof ApplyRuntimeBudgetError) throw error;
     console.error(
       `Best-effort related issue GitHub search failed for #${item.number}: ${
         error instanceof Error ? error.message : String(error)

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -18585,7 +18585,7 @@ async function applyDecisionsCommandInner(
   const dryRun = boolArg(args.dry_run);
   const syncCommentsOnly = boolArg(args.sync_comments_only);
   const commentSyncMinAgeDays = numberArg(args.comment_sync_min_age_days, 0);
-  const maxRuntimeMs = runtimeBudget.maxRuntimeMs;
+  const maxRuntimeMs = numberArg(args.max_runtime_ms, 0);
   const reportPath = resolve(stringArg(args.report_path, join(ROOT, "apply-report.json")));
   const artifactDir = resolve(stringArg(args.artifact_dir, join(ROOT, "artifacts", "apply")));
   const cursorTraceArg = stringArg(args.cursor_trace, "").trim();
@@ -18604,7 +18604,7 @@ async function applyDecisionsCommandInner(
       ? { ghToken: process.env.CLAWSWEEPER_PROOF_INSPECTION_TOKEN }
       : {}),
   };
-  const startedAtMs = runtimeBudget.startedAtMs;
+  const startedAtMs = Date.now();
   const requestedItemNumbers = itemNumbersArg(args.item_numbers, args.item_number);
   const requestedItemNumberSet = new Set(requestedItemNumbers);
   const requestedItemOrder = orderedApplyItemNumbers(args.item_numbers, args.item_number);

--- a/src/command.ts
+++ b/src/command.ts
@@ -7,6 +7,7 @@ export type RunTextOptions = {
   env?: NodeJS.ProcessEnv | undefined;
   maxBuffer?: number;
   stdio?: ["ignore", "pipe", "pipe"] | ["ignore", "pipe", "ignore"];
+  timeoutMs?: number | undefined;
   trim?: "both" | "end" | "none";
 };
 
@@ -46,6 +47,7 @@ export function runText(
     env,
     maxBuffer = 64 * 1024 * 1024,
     stdio = ["ignore", "pipe", "pipe"],
+    timeoutMs,
     trim = "end",
   }: RunTextOptions = {},
 ): string {
@@ -59,6 +61,7 @@ export function runText(
       env: childEnv,
       maxBuffer,
       stdio,
+      timeout: timeoutMs,
     });
   } catch (error) {
     throw explainSpawnFailure(error, resolved.command, cwd);

--- a/test/apply-runtime-budget.test.ts
+++ b/test/apply-runtime-budget.test.ts
@@ -223,3 +223,82 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/724\\/timeline(?:\\?|$
     rmSync(fixture.root, { recursive: true, force: true });
   }
 });
+
+test("apply-decisions yields instead of starting a post-close delay that cannot fit", () => {
+  const fixture = runtimeBudgetFixture(725);
+  const maxRuntimeMs = 5_000;
+  const proofLogPath = join(fixture.root, "proof.log");
+  const synced = reportWithSyncedReviewComment(
+    lowSignalCloseReport({
+      number: 725,
+      title: "Provider route fallback",
+      close_reason: "duplicate_or_superseded",
+      work_cluster_refs: JSON.stringify([
+        "Superseded by https://github.com/openclaw/openclaw/pull/400",
+      ]),
+    }).replace(
+      "Closing this PR because the branch is not a useful landing base.",
+      "Closing this PR as superseded by https://github.com/openclaw/openclaw/pull/400.",
+    ),
+    725,
+    "duplicate_or_superseded",
+  );
+  writeFileSync(join(fixture.itemsDir, "725.md"), synced.report, "utf8");
+  try {
+    const startedAt = Date.now();
+    withMockGh(
+      fixture.root,
+      promotionGhMock({
+        number: 725,
+        title: "Provider route fallback",
+        comment: synced.comment,
+        itemUpdatedAtAfterProofLogPath: proofLogPath,
+        linkedPulls: {
+          400: {
+            number: 400,
+            title: "Provider cleanup",
+            html_url: "https://github.com/openclaw/openclaw/pull/400",
+            state: "closed",
+            merged_at: "2026-05-02T00:00:00Z",
+            updated_at: "2026-05-01T00:00:00Z",
+            body: "Includes the fallback route behavior from PR 725.",
+            comments: [],
+            labels: [],
+          },
+        },
+      }),
+      () => {
+        withMockCodexProof(
+          fixture.root,
+          {
+            type: "decision",
+            decision: "covered",
+            reason: "PR B carries forward PR A's fallback route behavior.",
+            invocationLogPath: proofLogPath,
+          },
+          () => {
+            runApplyDecisionsForTest({
+              ...fixture,
+              targetRepo: "openclaw/openclaw",
+              extraArgs: [
+                "--apply-kind",
+                "all",
+                "--max-runtime-ms",
+                String(maxRuntimeMs),
+                "--close-delay-ms",
+                "10000",
+                "--cursor-trace",
+                fixture.cursorTracePath,
+              ],
+            });
+          },
+        );
+      },
+    );
+
+    assert.ok(Date.now() - startedAt < 3_000, "post-close delay ignored the remaining runtime");
+    assertRuntimeYield(fixture, maxRuntimeMs);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});

--- a/test/apply-runtime-budget.test.ts
+++ b/test/apply-runtime-budget.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  implementedCloseReport,
+  runApplyDecisionsForTest,
+  tmpPrefix,
+  withMockGh,
+} from "./helpers.ts";
+
+function runtimeBudgetFixture(number: number) {
+  const root = mkdtempSync(tmpPrefix);
+  const itemsDir = join(root, "items");
+  const closedDir = join(root, "closed");
+  const plansDir = join(root, "plans");
+  const reportPath = join(root, "apply-report.json");
+  const cursorTracePath = join(root, "apply-cursor-trace.json");
+  mkdirSync(itemsDir, { recursive: true });
+  mkdirSync(plansDir, { recursive: true });
+  writeFileSync(join(itemsDir, `${number}.md`), implementedCloseReport({ number }), "utf8");
+  return { root, itemsDir, closedDir, plansDir, reportPath, cursorTracePath };
+}
+
+function assertRuntimeYield(
+  fixture: ReturnType<typeof runtimeBudgetFixture>,
+  maxRuntimeMs: number,
+) {
+  const report = JSON.parse(readFileSync(fixture.reportPath, "utf8"));
+  const cursorTrace = JSON.parse(readFileSync(fixture.cursorTracePath, "utf8"));
+  assert.deepEqual(report, [
+    {
+      number: 0,
+      action: "skipped_runtime_budget",
+      reason: report[0]?.reason,
+    },
+  ]);
+  assert.match(report[0]?.reason ?? "", new RegExp(`max runtime ${maxRuntimeMs}ms reached`));
+  assert.deepEqual(cursorTrace, { schema_version: 1, examined_item_numbers: [] });
+}
+
+test("apply-decisions bounds a hung GitHub command and writes a resumable runtime yield", () => {
+  const fixture = runtimeBudgetFixture(721);
+  const maxRuntimeMs = 2_200;
+  try {
+    const startedAt = Date.now();
+    withMockGh(fixture.root, "setTimeout(() => {}, 10_000);", () => {
+      runApplyDecisionsForTest({
+        ...fixture,
+        extraArgs: [
+          "--max-runtime-ms",
+          String(maxRuntimeMs),
+          "--cursor-trace",
+          fixture.cursorTracePath,
+        ],
+      });
+    });
+
+    assert.ok(Date.now() - startedAt < 4_000, "hung gh command exceeded the apply runtime bound");
+    assertRuntimeYield(fixture, maxRuntimeMs);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions yields instead of starting a GitHub retry that cannot fit", () => {
+  const fixture = runtimeBudgetFixture(722);
+  const maxRuntimeMs = 2_500;
+  try {
+    const startedAt = Date.now();
+    withMockGh(fixture.root, 'console.error("service unavailable"); process.exit(1);', () => {
+      runApplyDecisionsForTest({
+        ...fixture,
+        extraArgs: [
+          "--max-runtime-ms",
+          String(maxRuntimeMs),
+          "--cursor-trace",
+          fixture.cursorTracePath,
+        ],
+      });
+    });
+
+    assert.ok(Date.now() - startedAt < 2_000, "GitHub retry sleep ignored the remaining runtime");
+    assertRuntimeYield(fixture, maxRuntimeMs);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});

--- a/test/apply-runtime-budget.test.ts
+++ b/test/apply-runtime-budget.test.ts
@@ -92,6 +92,30 @@ test("apply-decisions yields instead of starting a GitHub retry that cannot fit"
   }
 });
 
+test("apply-decisions yields instead of retrying malformed GitHub JSON past the deadline", () => {
+  const fixture = runtimeBudgetFixture(726);
+  const maxRuntimeMs = 2_500;
+  try {
+    const startedAt = Date.now();
+    withMockGh(fixture.root, 'process.stdout.write("{");', () => {
+      runApplyDecisionsForTest({
+        ...fixture,
+        extraArgs: [
+          "--max-runtime-ms",
+          String(maxRuntimeMs),
+          "--cursor-trace",
+          fixture.cursorTracePath,
+        ],
+      });
+    });
+
+    assert.ok(Date.now() - startedAt < 2_000, "malformed JSON retry ignored the runtime bound");
+    assertRuntimeYield(fixture, maxRuntimeMs);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
 test("apply-decisions preserves a runtime yield through post-proof freshness handling", () => {
   const fixture = runtimeBudgetFixture(723);
   const maxRuntimeMs = 3_000;

--- a/test/apply-runtime-budget.test.ts
+++ b/test/apply-runtime-budget.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
 
@@ -322,6 +322,94 @@ test("apply-decisions yields instead of starting a post-close delay that cannot 
 
     assert.ok(Date.now() - startedAt < 3_000, "post-close delay ignored the remaining runtime");
     assertRuntimeYield(fixture, maxRuntimeMs);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions records a successful close before yielding after it", () => {
+  const fixture = runtimeBudgetFixture(727);
+  const maxRuntimeMs = 12_000;
+  const proofLogPath = join(fixture.root, "proof.log");
+  const synced = reportWithSyncedReviewComment(
+    lowSignalCloseReport({
+      number: 727,
+      title: "Provider route fallback",
+      close_reason: "duplicate_or_superseded",
+      work_cluster_refs: JSON.stringify([
+        "Superseded by https://github.com/openclaw/openclaw/pull/400",
+      ]),
+    }).replace(
+      "Closing this PR because the branch is not a useful landing base.",
+      "Closing this PR as superseded by https://github.com/openclaw/openclaw/pull/400.",
+    ),
+    727,
+    "duplicate_or_superseded",
+  );
+  writeFileSync(join(fixture.itemsDir, "727.md"), synced.report, "utf8");
+  try {
+    withMockGh(
+      fixture.root,
+      promotionGhMock({
+        number: 727,
+        title: "Provider route fallback",
+        comment: synced.comment,
+        closeCommandDelayMs: 3_000,
+        itemUpdatedAtAfterProofLogPath: proofLogPath,
+        linkedPulls: {
+          400: {
+            number: 400,
+            title: "Provider cleanup",
+            html_url: "https://github.com/openclaw/openclaw/pull/400",
+            state: "closed",
+            merged_at: "2026-05-02T00:00:00Z",
+            updated_at: "2026-05-01T00:00:00Z",
+            body: "Includes the fallback route behavior from PR 727.",
+            comments: [],
+            labels: [],
+          },
+        },
+      }),
+      () => {
+        withMockCodexProof(
+          fixture.root,
+          {
+            type: "decision",
+            decision: "covered",
+            reason: "PR B carries forward PR A's fallback route behavior.",
+            invocationLogPath: proofLogPath,
+          },
+          () => {
+            runApplyDecisionsForTest({
+              ...fixture,
+              targetRepo: "openclaw/openclaw",
+              extraArgs: [
+                "--apply-kind",
+                "all",
+                "--max-runtime-ms",
+                String(maxRuntimeMs),
+                "--close-delay-ms",
+                "8000",
+                "--cursor-trace",
+                fixture.cursorTracePath,
+              ],
+            });
+          },
+        );
+      },
+    );
+
+    const report = JSON.parse(readFileSync(fixture.reportPath, "utf8"));
+    const cursorTrace = JSON.parse(readFileSync(fixture.cursorTracePath, "utf8"));
+    assert.deepEqual(
+      report.map((entry: { number: number; action: string }) => [entry.number, entry.action]),
+      [
+        [727, "closed"],
+        [0, "skipped_runtime_budget"],
+      ],
+    );
+    assert.deepEqual(cursorTrace, { schema_version: 1, examined_item_numbers: [727] });
+    assert.equal(existsSync(join(fixture.closedDir, "727.md")), true);
   } finally {
     rmSync(fixture.root, { recursive: true, force: true });
   }

--- a/test/apply-runtime-budget.test.ts
+++ b/test/apply-runtime-budget.test.ts
@@ -167,3 +167,59 @@ test("apply-decisions preserves a runtime yield through post-proof freshness han
     rmSync(fixture.root, { recursive: true, force: true });
   }
 });
+
+test("apply-decisions preserves a runtime yield from a bounded one-shot GitHub search", () => {
+  const fixture = runtimeBudgetFixture(724);
+  const maxRuntimeMs = 3_000;
+  const ghMock = `
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+const path = args[1] === "-i" ? args[2] || "" : args[1] || "";
+if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/724\\/timeline(?:\\?|$)/.test(path)) {
+  console.log("HTTP/2 200\\n\\n[]");
+} else if (args[0] === "api" && /\\/issues\\/724\\/comments(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/issues\\/724$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 724,
+    title: "Bound one-shot search",
+    html_url: "https://github.com/openclaw/clawsweeper/issues/724",
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "reporter" },
+    labels: [],
+    comments: 0,
+    pull_request: null
+  }));
+} else if (args[0] === "api" && path.startsWith("search/issues?")) {
+  setTimeout(() => {}, 60_000);
+} else if (args[0] === "issue" && args[1] === "view") {
+  console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+  try {
+    withMockGh(fixture.root, ghMock, () => {
+      runApplyDecisionsForTest({
+        ...fixture,
+        extraArgs: [
+          "--max-runtime-ms",
+          String(maxRuntimeMs),
+          "--cursor-trace",
+          fixture.cursorTracePath,
+        ],
+      });
+    });
+
+    assertRuntimeYield(fixture, maxRuntimeMs);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});

--- a/test/apply-runtime-budget.test.ts
+++ b/test/apply-runtime-budget.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { join } from "node:path";
 import test from "node:test";
 
+import { main, referencingMergedPullRequestsForIssueForTest } from "../dist/clawsweeper.js";
 import {
   implementedCloseReport,
   lowSignalCloseReport,
@@ -65,6 +66,56 @@ test("apply-decisions bounds a hung GitHub command and writes a resumable runtim
     assertRuntimeYield(fixture, maxRuntimeMs);
   } finally {
     rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("concurrent apply invocations do not leak a runtime budget", async () => {
+  const root = mkdtempSync(tmpPrefix);
+  const binDir = join(root, "bin");
+  const ghMock = join(binDir, "gh.js");
+  mkdirSync(binDir, { recursive: true });
+  writeFileSync(ghMock, "process.stdout.write(JSON.stringify({ items: [] }));\n", "utf8");
+  const originalGhBin = process.env.GH_BIN;
+  const originalGhBinArgs = process.env.GH_BIN_ARGS;
+  const originalSearch = process.env.CLAWSWEEPER_REFERENCING_PR_SEARCH;
+  process.env.GH_BIN = process.execPath;
+  process.env.GH_BIN_ARGS = JSON.stringify([ghMock]);
+  process.env.CLAWSWEEPER_REFERENCING_PR_SEARCH = "true";
+  try {
+    const base = [
+      "apply-decisions",
+      "--target-repo",
+      "openclaw/openclaw",
+      "--max-runtime-ms",
+      "1",
+      "--limit",
+      "1",
+    ];
+    await Promise.all([
+      main([
+        ...base,
+        "--items-dir",
+        join(root, "missing-a"),
+        "--report-path",
+        join(root, "a.json"),
+      ]),
+      main([
+        ...base,
+        "--items-dir",
+        join(root, "missing-b"),
+        "--report-path",
+        join(root, "b.json"),
+      ]),
+    ]);
+    assert.deepEqual(referencingMergedPullRequestsForIssueForTest(1), []);
+  } finally {
+    if (originalGhBin === undefined) delete process.env.GH_BIN;
+    else process.env.GH_BIN = originalGhBin;
+    if (originalGhBinArgs === undefined) delete process.env.GH_BIN_ARGS;
+    else process.env.GH_BIN_ARGS = originalGhBinArgs;
+    if (originalSearch === undefined) delete process.env.CLAWSWEEPER_REFERENCING_PR_SEARCH;
+    else process.env.CLAWSWEEPER_REFERENCING_PR_SEARCH = originalSearch;
+    rmSync(root, { recursive: true, force: true });
   }
 });
 

--- a/test/apply-runtime-budget.test.ts
+++ b/test/apply-runtime-budget.test.ts
@@ -5,8 +5,12 @@ import test from "node:test";
 
 import {
   implementedCloseReport,
+  lowSignalCloseReport,
+  promotionGhMock,
+  reportWithSyncedReviewComment,
   runApplyDecisionsForTest,
   tmpPrefix,
+  withMockCodexProof,
   withMockGh,
 } from "./helpers.ts";
 
@@ -82,6 +86,82 @@ test("apply-decisions yields instead of starting a GitHub retry that cannot fit"
     });
 
     assert.ok(Date.now() - startedAt < 2_000, "GitHub retry sleep ignored the remaining runtime");
+    assertRuntimeYield(fixture, maxRuntimeMs);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions preserves a runtime yield through post-proof freshness handling", () => {
+  const fixture = runtimeBudgetFixture(723);
+  const maxRuntimeMs = 3_000;
+  const proofLogPath = join(fixture.root, "proof.log");
+  const synced = reportWithSyncedReviewComment(
+    lowSignalCloseReport({
+      number: 723,
+      title: "Provider route fallback",
+      close_reason: "duplicate_or_superseded",
+      work_cluster_refs: JSON.stringify([
+        "Superseded by https://github.com/openclaw/openclaw/pull/400",
+      ]),
+    }).replace(
+      "Closing this PR because the branch is not a useful landing base.",
+      "Closing this PR as superseded by https://github.com/openclaw/openclaw/pull/400.",
+    ),
+    723,
+    "duplicate_or_superseded",
+  );
+  writeFileSync(join(fixture.itemsDir, "723.md"), synced.report, "utf8");
+  try {
+    withMockGh(
+      fixture.root,
+      promotionGhMock({
+        number: 723,
+        title: "Provider route fallback",
+        comment: synced.comment,
+        itemUpdatedAtAfterProofLogPath: proofLogPath,
+        linkedPullHangAfterProof: true,
+        linkedPulls: {
+          400: {
+            number: 400,
+            title: "Provider cleanup",
+            html_url: "https://github.com/openclaw/openclaw/pull/400",
+            state: "closed",
+            merged_at: "2026-05-02T00:00:00Z",
+            updated_at: "2026-05-01T00:00:00Z",
+            body: "Includes the fallback route behavior from PR 723.",
+            comments: [],
+            labels: [],
+          },
+        },
+      }),
+      () => {
+        withMockCodexProof(
+          fixture.root,
+          {
+            type: "decision",
+            decision: "covered",
+            reason: "PR B carries forward PR A's fallback route behavior.",
+            invocationLogPath: proofLogPath,
+          },
+          () => {
+            runApplyDecisionsForTest({
+              ...fixture,
+              targetRepo: "openclaw/openclaw",
+              extraArgs: [
+                "--apply-kind",
+                "all",
+                "--max-runtime-ms",
+                String(maxRuntimeMs),
+                "--cursor-trace",
+                fixture.cursorTracePath,
+              ],
+            });
+          },
+        );
+      },
+    );
+
     assertRuntimeYield(fixture, maxRuntimeMs);
   } finally {
     rmSync(fixture.root, { recursive: true, force: true });

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2460,7 +2460,11 @@ test("sweep failed-review retry lane defaults to dry-run exact-item dispatch", (
   assert.match(retryBlock, /--dry-run/);
   assert.match(retryBlock, /--workflow-repo "\$GITHUB_REPOSITORY"/);
   assert.match(retryBlock, /--target-repo "\$TARGET_REPO"/);
-  assert.match(retryBlock, /--path records\/openclaw-openclaw/);
+  assert.match(retryBlock, /RETRY_MAX_RUNTIME_MS:.*'600000'/);
+  assert.match(retryBlock, /--max-runtime-ms "\$RETRY_MAX_RUNTIME_MS"/);
+  assert.match(retryBlock, /--state-dir results\/failed-review-retries\/openclaw-openclaw/);
+  assert.match(retryBlock, /--path results\/failed-review-retries\/openclaw-openclaw/);
+  assert.doesNotMatch(retryBlock, /--path records\/openclaw-openclaw/);
 });
 
 test("sweep dashboard status writes are scoped to the target repository", () => {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -13,6 +13,7 @@ import {
   codexLoginConfig,
   codexLoginMethod,
   coverageProofRetryExhaustedRuntimeBudget,
+  dashboardFailedReviewRetryActivityForTest,
   dashboardClosedAt,
   formatRecentClosedRows,
   ghRetryKind,
@@ -2465,6 +2466,112 @@ test("sweep failed-review retry lane defaults to dry-run exact-item dispatch", (
   assert.match(retryBlock, /--state-dir results\/failed-review-retries\/openclaw-openclaw/);
   assert.match(retryBlock, /--path results\/failed-review-retries\/openclaw-openclaw/);
   assert.doesNotMatch(retryBlock, /--path records\/openclaw-openclaw/);
+  const publishIndex = retryBlock.indexOf("- name: Publish failed-review retry state");
+  const uploadIndex = retryBlock.indexOf("- uses: actions/upload-artifact@v7");
+  assert.ok(publishIndex > 0);
+  assert.ok(uploadIndex > publishIndex);
+  assert.match(
+    retryBlock.slice(publishIndex, uploadIndex),
+    /if: \$\{\{ always\(\) && vars\.CLAWSWEEPER_FAILED_REVIEW_RETRY_ENABLED == '1' && hashFiles\('results\/failed-review-retries\/openclaw-openclaw\/\*\.json'\) != '' \}\}/,
+  );
+  assert.match(
+    retryBlock.slice(uploadIndex, retryBlock.indexOf("\n\n", uploadIndex)),
+    /if: \$\{\{ always\(\) \}\}/,
+  );
+});
+
+test("dashboard operation counters include persisted failed-review retry sidecars", () => {
+  const dir = mkdtempSync(tmpPrefix);
+  try {
+    const number = 42;
+    const revision = "a".repeat(64);
+    const at = "2026-07-09T12:00:00.000Z";
+    writeFileSync(
+      join(dir, `${number}.json`),
+      `${JSON.stringify({
+        schema_version: 1,
+        repo: "openclaw/openclaw",
+        number,
+        status: "exhausted",
+        revision_kind: "item_source_revision",
+        revision,
+        attempts: 2,
+        max_attempts: 2,
+        last_at: at,
+        reason: "retry budget exhausted",
+      })}\n`,
+      "utf8",
+    );
+    const activity = dashboardFailedReviewRetryActivityForTest({
+      markdown: reportFrontMatter({
+        number: String(number),
+        repository: "openclaw/openclaw",
+        type: "issue",
+        item_source_revision: revision,
+        review_status: "failed",
+        action_taken: "kept_open",
+      }),
+      number,
+      stateDir: dir,
+      now: Date.parse("2026-07-09T12:01:00.000Z"),
+    });
+
+    assert.equal(activity.last15Minutes.failedReviewRetries, 0);
+    assert.equal(activity.last15Minutes.failedReviewRetryExhaustions, 1);
+    assert.equal(activity.lastHour.failedReviewRetryExhaustions, 1);
+    assert.equal(activity.last24Hours.failedReviewRetryExhaustions, 1);
+
+    writeFileSync(
+      join(dir, `${number}.json`),
+      `${JSON.stringify({
+        schema_version: 1,
+        repo: "openclaw/openclaw",
+        number,
+        status: "dispatched",
+        revision_kind: "item_source_revision",
+        revision,
+        attempts: 1,
+        max_attempts: 2,
+        last_at: at,
+        reason: "retry dispatched",
+      })}\n`,
+      "utf8",
+    );
+    const dispatchedActivity = dashboardFailedReviewRetryActivityForTest({
+      markdown: reportFrontMatter({
+        number: String(number),
+        repository: "openclaw/openclaw",
+        type: "issue",
+        item_source_revision: revision,
+        review_status: "failed",
+        action_taken: "kept_open",
+      }),
+      number,
+      stateDir: dir,
+      now: Date.parse("2026-07-09T12:01:00.000Z"),
+    });
+    assert.equal(dispatchedActivity.last15Minutes.failedReviewRetries, 1);
+    assert.equal(dispatchedActivity.last15Minutes.failedReviewRetryExhaustions, 0);
+
+    writeFileSync(join(dir, `${number}.json`), "{\n", "utf8");
+    const malformedActivity = dashboardFailedReviewRetryActivityForTest({
+      markdown: reportFrontMatter({
+        number: String(number),
+        repository: "openclaw/openclaw",
+        type: "issue",
+        item_source_revision: revision,
+        review_status: "failed",
+        action_taken: "kept_open",
+      }),
+      number,
+      stateDir: dir,
+      now: Date.parse("2026-07-09T12:01:00.000Z"),
+    });
+    assert.equal(malformedActivity.last15Minutes.failedReviewRetries, 0);
+    assert.equal(malformedActivity.last15Minutes.failedReviewRetryExhaustions, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("sweep dashboard status writes are scoped to the target repository", () => {

--- a/test/failed-review-retry.test.ts
+++ b/test/failed-review-retry.test.ts
@@ -39,6 +39,92 @@ Codex review failed: timeout.
 `;
 }
 
+function failedIssueRetryFixture(root: string, number: number) {
+  const itemsDir = join(root, "items");
+  const reportPath = join(root, "failed-review-retry-report.json");
+  const itemPath = join(itemsDir, `${number}.md`);
+  const statePath = join(root, "failed-review-retry-state", `${number}.json`);
+  const issue = {
+    number,
+    title: "Failed issue review retry sample",
+    body: "Issue body",
+    html_url: `https://github.com/openclaw/openclaw/issues/${number}`,
+    created_at: "2026-06-01T00:00:00Z",
+    updated_at: "2026-06-01T01:00:00Z",
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "contributor" },
+    labels: [],
+    comments: 0,
+    pull_request: null,
+  };
+  const sourceRevision = itemSourceRevisionSha256ForTest(issue, []);
+  mkdirSync(itemsDir, { recursive: true });
+  writeFileSync(
+    itemPath,
+    failedReviewReport({
+      number,
+      type: "issue",
+      pull_head_sha: "unknown",
+      item_source_revision: sourceRevision,
+    }),
+    "utf8",
+  );
+  return { itemsDir, reportPath, itemPath, statePath, issue, sourceRevision, number };
+}
+
+function issueRetryGhMock(
+  issue: ReturnType<typeof failedIssueRetryFixture>["issue"],
+  dispatchBody: string,
+): string {
+  return `#!/usr/bin/env node
+const args = process.argv.slice(2);
+const path = args.find((arg) => arg.startsWith("repos/")) || "";
+if (/\\/issues\\/${issue.number}\\/comments(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify(args.includes("--slurp") ? [[]] : []));
+  process.exit(0);
+}
+if (path.endsWith("/issues/${issue.number}")) {
+  console.log(${JSON.stringify(JSON.stringify(issue))});
+  process.exit(0);
+}
+if (path === "repos/openclaw/clawsweeper") {
+  console.log("main");
+  process.exit(0);
+}
+if (path.endsWith("/dispatches") && args.includes("POST")) {
+  ${dispatchBody}
+} else {
+  console.error("unexpected gh args: " + args.join(" "));
+  process.exit(1);
+}
+`;
+}
+
+function runFailedIssueRetry(
+  fixture: ReturnType<typeof failedIssueRetryFixture>,
+  extraArgs: string[] = [],
+): void {
+  execFileSync(process.execPath, [
+    "dist/clawsweeper.js",
+    "retry-failed-reviews",
+    "--target-repo",
+    "openclaw/openclaw",
+    "--items-dir",
+    fixture.itemsDir,
+    "--item-number",
+    String(fixture.number),
+    "--workflow-ref",
+    "main",
+    "--report-path",
+    fixture.reportPath,
+    ...extraArgs,
+  ]);
+}
+
 test("failed review retry eligibility requires infrastructure failure and matching live head", () => {
   const markdown = failedReviewReport();
   const now = Date.parse("2026-06-05T20:00:00Z");
@@ -347,6 +433,10 @@ process.exit(1);
       }>;
       assert.equal(rejected[0]?.action, "skipped_dispatch_failed");
       assert.match(rejected[0]?.reason ?? "", /default branch \(main\).*test-branch/);
+      assert.doesNotMatch(
+        readFileSync(join(itemsDir, "4343.md"), "utf8"),
+        /^failed_review_retry_count:/m,
+      );
 
       execFileSync(process.execPath, [
         "dist/clawsweeper.js",
@@ -378,6 +468,229 @@ process.exit(1);
     assert.ok(dispatch.includes("event_type=clawsweeper_target_sweep"));
     assert.ok(dispatch.includes(`client_payload[expected_source_revision]=${sourceRevision}`));
     assert.ok(dispatch.includes("client_payload[source_revision_requeue_count]=0"));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("failed issue retry bounds a hung GitHub fetch and flushes its report", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const fixture = failedIssueRetryFixture(root, 4344);
+  const maxRuntimeMs = 2_200;
+  try {
+    const startedAt = Date.now();
+    withMockGh(root, "setTimeout(() => {}, 10_000);", () => {
+      runFailedIssueRetry(fixture, ["--max-runtime-ms", String(maxRuntimeMs)]);
+    });
+    assert.ok(Date.now() - startedAt < 4_000, "hung gh exceeded the retry runtime bound");
+    const report = JSON.parse(readFileSync(fixture.reportPath, "utf8")) as Array<{
+      number: number;
+      action: string;
+      reason: string;
+    }>;
+    assert.deepEqual(report, [
+      {
+        number: 0,
+        action: "skipped_runtime_budget",
+        reason: report[0]?.reason,
+      },
+    ]);
+    assert.match(report[0]?.reason ?? "", new RegExp(`max runtime ${maxRuntimeMs}ms reached`));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("failed issue retry checkpoints an ambiguous dispatch and prevents an immediate duplicate", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const fixture = failedIssueRetryFixture(root, 4345);
+  const originalMarkdown = readFileSync(fixture.itemPath, "utf8");
+  const dispatchCountPath = join(root, "dispatch-count.txt");
+  const incrementDispatchCount = `
+const fs = require("node:fs");
+const counter = ${JSON.stringify(dispatchCountPath)};
+const count = fs.existsSync(counter) ? Number(fs.readFileSync(counter, "utf8")) : 0;
+fs.writeFileSync(counter, String(count + 1));
+`;
+  try {
+    withMockGh(
+      root,
+      issueRetryGhMock(fixture.issue, `${incrementDispatchCount}\nsetTimeout(() => {}, 10_000);`),
+      () => runFailedIssueRetry(fixture, ["--max-runtime-ms", "2200"]),
+    );
+
+    const firstReport = JSON.parse(readFileSync(fixture.reportPath, "utf8")) as Array<{
+      action: string;
+      reason?: string;
+    }>;
+    assert.equal(firstReport.at(-1)?.action, "skipped_runtime_budget", JSON.stringify(firstReport));
+    const checkpointed = readFileSync(fixture.itemPath, "utf8");
+    assert.match(checkpointed, /^failed_review_retry_status: dispatch_failed$/m);
+    assert.match(checkpointed, /^failed_review_retry_count: 1$/m);
+    assert.match(checkpointed, /^failed_review_retry_revision_kind: item_source_revision$/m);
+    assert.match(
+      checkpointed,
+      new RegExp(`^failed_review_retry_revision: ${fixture.sourceRevision}$`, "m"),
+    );
+    assert.equal((checkpointed.match(/^## Failed Review Retry$/gm) ?? []).length, 1);
+    assert.equal(readFileSync(dispatchCountPath, "utf8"), "1");
+    const retryState = JSON.parse(readFileSync(fixture.statePath, "utf8")) as {
+      status: string;
+      attempts: number;
+      revision: string;
+    };
+    assert.deepEqual(
+      {
+        status: retryState.status,
+        attempts: retryState.attempts,
+        revision: retryState.revision,
+      },
+      { status: "dispatch_failed", attempts: 1, revision: fixture.sourceRevision },
+    );
+
+    // The generated sidecar is authoritative; review records are not published by this lane.
+    writeFileSync(fixture.itemPath, originalMarkdown, "utf8");
+
+    withMockGh(
+      root,
+      issueRetryGhMock(fixture.issue, `${incrementDispatchCount}\nprocess.exit(0);`),
+      () => runFailedIssueRetry(fixture),
+    );
+    const secondReport = JSON.parse(readFileSync(fixture.reportPath, "utf8")) as Array<{
+      action: string;
+      attempts?: number;
+    }>;
+    assert.equal(secondReport[0]?.action, "skipped_retry_cooldown");
+    assert.equal(secondReport[0]?.attempts, 1);
+    assert.equal(readFileSync(dispatchCountPath, "utf8"), "1");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("failed issue retry records a near-deadline success before later eligibility checks", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const fixture = failedIssueRetryFixture(root, 4346);
+  const originalMarkdown = readFileSync(fixture.itemPath, "utf8");
+  const dispatchCountPath = join(root, "dispatch-count.txt");
+  const incrementDispatchCount = `
+const fs = require("node:fs");
+const counter = ${JSON.stringify(dispatchCountPath)};
+const count = fs.existsSync(counter) ? Number(fs.readFileSync(counter, "utf8")) : 0;
+fs.writeFileSync(counter, String(count + 1));
+`;
+  try {
+    withMockGh(
+      root,
+      issueRetryGhMock(
+        fixture.issue,
+        `${incrementDispatchCount}\nsetTimeout(() => process.exit(0), 1300);`,
+      ),
+      () => runFailedIssueRetry(fixture, ["--max-runtime-ms", "2800"]),
+    );
+    const firstReport = JSON.parse(readFileSync(fixture.reportPath, "utf8")) as Array<{
+      action: string;
+      reason?: string;
+    }>;
+    assert.equal(
+      firstReport[0]?.action,
+      "dispatched_failed_review_retry",
+      JSON.stringify(firstReport),
+    );
+    const dispatched = readFileSync(fixture.itemPath, "utf8");
+    assert.match(dispatched, /^failed_review_retry_status: dispatched$/m);
+    assert.match(dispatched, /^failed_review_retry_count: 1$/m);
+    assert.equal((dispatched.match(/^## Failed Review Retry$/gm) ?? []).length, 1);
+    const retryState = JSON.parse(readFileSync(fixture.statePath, "utf8")) as {
+      status: string;
+      attempts: number;
+    };
+    assert.equal(retryState.status, "dispatched");
+    assert.equal(retryState.attempts, 1);
+
+    writeFileSync(fixture.itemPath, originalMarkdown, "utf8");
+
+    withMockGh(
+      root,
+      issueRetryGhMock(fixture.issue, `${incrementDispatchCount}\nprocess.exit(0);`),
+      () => runFailedIssueRetry(fixture),
+    );
+    const secondReport = JSON.parse(readFileSync(fixture.reportPath, "utf8")) as Array<{
+      action: string;
+      attempts?: number;
+    }>;
+    assert.equal(secondReport[0]?.action, "skipped_retry_cooldown");
+    assert.equal(secondReport[0]?.attempts, 1);
+    assert.equal(readFileSync(dispatchCountPath, "utf8"), "1");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("failed issue retry limit counts checkpointed ambiguous dispatches", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const first = failedIssueRetryFixture(root, 4347);
+  const second = failedIssueRetryFixture(root, 4348);
+  const dispatchCountPath = join(root, "dispatch-count.txt");
+  const issues = JSON.stringify({ [first.number]: first.issue, [second.number]: second.issue });
+  const ghMock = `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+const path = args.find((arg) => arg.startsWith("repos/")) || "";
+const issues = ${issues};
+const issueMatch = path.match(/\\/issues\\/(\\d+)$/);
+if (/\\/issues\\/\\d+\\/comments(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify(args.includes("--slurp") ? [[]] : []));
+  process.exit(0);
+}
+if (issueMatch && issues[issueMatch[1]]) {
+  console.log(JSON.stringify(issues[issueMatch[1]]));
+  process.exit(0);
+}
+if (path === "repos/openclaw/clawsweeper") {
+  console.log("main");
+  process.exit(0);
+}
+if (path.endsWith("/dispatches") && args.includes("POST")) {
+  const counter = ${JSON.stringify(dispatchCountPath)};
+  const count = fs.existsSync(counter) ? Number(fs.readFileSync(counter, "utf8")) : 0;
+  fs.writeFileSync(counter, String(count + 1));
+  console.error("dispatch response lost after acceptance");
+  process.exit(1);
+}
+console.error("unexpected gh args: " + args.join(" "));
+process.exit(1);
+`;
+  try {
+    withMockGh(root, ghMock, () => {
+      execFileSync(process.execPath, [
+        "dist/clawsweeper.js",
+        "retry-failed-reviews",
+        "--target-repo",
+        "openclaw/openclaw",
+        "--items-dir",
+        first.itemsDir,
+        "--limit",
+        "1",
+        "--workflow-ref",
+        "main",
+        "--report-path",
+        first.reportPath,
+      ]);
+    });
+
+    const report = JSON.parse(readFileSync(first.reportPath, "utf8")) as Array<{
+      number: number;
+      action: string;
+      attempts?: number;
+    }>;
+    assert.deepEqual(
+      report.map(({ number, action, attempts }) => ({ number, action, attempts })),
+      [{ number: 4347, action: "skipped_dispatch_failed", attempts: 1 }],
+    );
+    assert.equal(readFileSync(dispatchCountPath, "utf8"), "1");
+    assert.match(readFileSync(first.itemPath, "utf8"), /^failed_review_retry_count: 1$/m);
+    assert.doesNotMatch(readFileSync(second.itemPath, "utf8"), /^failed_review_retry_count:/m);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -441,6 +441,7 @@ export function promotionGhMock(options: {
   timeline?: unknown[];
   linkedPulls?: Record<number, unknown>;
   linkedPullsAfterProof?: Record<number, unknown>;
+  linkedPullHangAfterProof?: boolean;
   linkedIssues?: Record<number, unknown>;
 }) {
   const title = options.title ?? "Stale F PR";
@@ -475,6 +476,7 @@ export function promotionGhMock(options: {
 	const timeline = ${JSON.stringify(timeline)};
 	const linkedPulls = ${JSON.stringify(linkedPulls)};
 	const linkedPullsAfterProof = ${JSON.stringify(options.linkedPullsAfterProof ?? {})};
+	const linkedPullHangAfterProof = ${JSON.stringify(options.linkedPullHangAfterProof ?? false)};
 	const linkedIssues = ${JSON.stringify(linkedIssues)};
 	const commentWriteLogPath = ${JSON.stringify(options.commentWriteLogPath ?? "")};
 	const closeAppliedBodyLogPath = ${JSON.stringify(options.closeAppliedBodyLogPath ?? "")};
@@ -586,11 +588,15 @@ export function promotionGhMock(options: {
   }));
 	} else if (args[0] === "api" && /\\/pulls\\/(\\d+)$/.test(path)) {
 	  const linkedNumber = Number((path.match(/\\/pulls\\/(\\d+)$/) || [])[1]);
-	  if (!liveLinkedPulls[linkedNumber]) {
-	    console.error("unexpected linked pull", linkedNumber);
-	    process.exit(1);
+	  if (proofHasRun() && linkedPullHangAfterProof) {
+	    setTimeout(() => {}, 60_000);
+	  } else {
+	    if (!liveLinkedPulls[linkedNumber]) {
+	      console.error("unexpected linked pull", linkedNumber);
+	      process.exit(1);
+	    }
+	    console.log(JSON.stringify(liveLinkedPulls[linkedNumber]));
 	  }
-	  console.log(JSON.stringify(liveLinkedPulls[linkedNumber]));
 	} else if (args[0] === "api" && /\\/issues\\/(\\d+)\\/comments(?:\\?|$)/.test(path)) {
 	  const linkedNumber = Number((path.match(/\\/issues\\/(\\d+)\\/comments/) || [])[1]);
 	  const linkedIssue = liveLinkedPulls[linkedNumber] || linkedIssues[linkedNumber];

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -437,6 +437,7 @@ export function promotionGhMock(options: {
   comment: string;
   commentWriteLogPath?: string;
   closeAppliedBodyLogPath?: string;
+  closeCommandDelayMs?: number;
   comments?: unknown[];
   timeline?: unknown[];
   linkedPulls?: Record<number, unknown>;
@@ -480,6 +481,7 @@ export function promotionGhMock(options: {
 	const linkedIssues = ${JSON.stringify(linkedIssues)};
 	const commentWriteLogPath = ${JSON.stringify(options.commentWriteLogPath ?? "")};
 	const closeAppliedBodyLogPath = ${JSON.stringify(options.closeAppliedBodyLogPath ?? "")};
+	const closeCommandDelayMs = ${JSON.stringify(options.closeCommandDelayMs ?? 0)};
 	const number = ${options.number};
 	const commentStatePath = join(__dirname, "..", "comment-state-" + number + ".json");
 	const mutationComment = (id, body) => ({
@@ -656,7 +658,8 @@ export function promotionGhMock(options: {
 } else if (args[0] === "api" && new RegExp("/pulls/" + number + "/(files|commits|comments)(?:\\\\?|$)").test(path)) {
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "pr" && args[1] === "close" && args[2] === String(number)) {
-  console.log("");
+  if (closeCommandDelayMs > 0) setTimeout(() => console.log(""), closeCommandDelayMs);
+  else console.log("");
 	} else if (args[0] === "issue" && args[1] === "edit") {
 	  if (itemUpdatedAtAfterLabelSyncLogPath) appendFileSync(itemUpdatedAtAfterLabelSyncLogPath, args.join(" ") + "\\n");
 	  console.log("");


### PR DESCRIPTION
## Summary

- Bound apply-time GitHub commands, one-shot searches, retry backoffs, malformed-success JSON retries, and close pacing against the active checkpoint deadline.
- Reserve time to flush the apply report and cursor, emit a typed runtime-yield result, and leave unfinished items resumable.
- Preserve durable close bookkeeping when a remote close succeeds near the deadline, while retaining the completed item in the cursor trace.
- Keep the higher-throughput queue ordering and batching from #444 intact.

## Root cause

The apply loop checked its runtime budget only between items. A hung GitHub subprocess, retry sleep, one-shot search, coverage-proof freshness check, or close delay could therefore consume the rest of the workflow window before ClawSweeper wrote its report and cursor. Broad best-effort handlers could also turn deadline expiry into an ordinary skip, and a post-close yield could occur after the irreversible GitHub mutation but before local archival.

## Proof

- `pnpm run build:all`
- `node --test test/apply-runtime-budget.test.ts test/apply-cursor-trace.test.ts` (9 passing)
- `node --test test/apply-stalled-pr-policies.test.ts test/review-close-policy.test.ts` (42 passing)
- `node --test test/sweep-workflow.test.ts` (41 passing)
- `node --test test/repair/workflow-sparse-checkout.test.ts test/repair/workflow-utils.test.ts dist/repair/workflow-utils.test.js` (45 passing)
- `pnpm run lint:src`
- `pnpm run lint:scripts`
- `pnpm run format:check`
- Branch autoreview against `origin/main`: clean, no accepted/actionable findings; patch correct (0.91).
