### PR TITLE
fix: expose apply candidates examined

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2691,6 +2691,7 @@ jobs:
                 --cursor-trace "$cursor_trace_path")"
               apply_publish_paths+=(results/apply-cursors)
             fi
+            examined_count="$(apply_checkpoint_examined_count)"
             publish_changes "chore: apply sweep decisions checkpoint $checkpoint" "${apply_publish_paths[@]}"
             close_health_cursor_path=""
             if [ "$auto_selected_apply_batch" = "true" ]; then
@@ -2700,7 +2701,7 @@ jobs:
             pnpm run status -- \
               --target-repo "$TARGET_REPO" \
               --state "Apply in progress" \
-              --detail "Checkpoint $checkpoint finished. Fresh closes in checkpoint: $closed_in_chunk. Total fresh closes in this run: $closed_total/$limit. Result records in checkpoint: $result_count, including durable review comment syncs." \
+              --detail "Checkpoint $checkpoint finished. Fresh closes in checkpoint: $closed_in_chunk. Total fresh closes in this run: $closed_total/$limit. Candidates examined: $examined_count. Action records: $result_count, including durable review comment syncs." \
               --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
               --apply-health-file ".artifacts/apply-health-$checkpoint.json"
             publish_status "chore: update sweep apply checkpoint $checkpoint status"

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -3679,6 +3679,8 @@ async function readApplyHealthMarker(
       mode: nullableString(health.mode),
       status: nullableString(health.status) || "unavailable",
       summary: nullableString(health.summary),
+      examined: optionalNumber(health.examined),
+      action_records: numberOrNull(health.action_records),
       processed: numberOrNull(health.processed),
       processed_limit: numberOrNull(health.processed_limit),
       close_limit: numberOrNull(health.close_limit),
@@ -7282,11 +7284,21 @@ function renderApplyHealth(data) {
     const cursorPill = showCursor
       ? '<span class="pill" title="' + esc(cursorTitle) + '">' + esc(cursor) + '</span>'
       : "";
-    const processed = Number.isFinite(item.processed) ? fmt.format(item.processed) : "unknown";
+    const actionRecords = Number.isFinite(item.action_records)
+      ? fmt.format(item.action_records)
+      : Number.isFinite(item.processed)
+        ? fmt.format(item.processed)
+        : "unknown";
+    const hasExamined = Number.isFinite(item.examined);
+    const examined = hasExamined ? fmt.format(item.examined) : null;
+    const activityLabel = hasExamined ? examined + " examined" : actionRecords + " actions";
+    const activityTitle = hasExamined
+      ? examined + " candidates examined; " + actionRecords + " produced action records."
+      : actionRecords + " action records; candidate examined count unavailable for this lane.";
     const closed = Number.isFinite(item.closed) ? fmt.format(item.closed) : "unknown";
     const synced = Number.isFinite(item.comment_synced) ? fmt.format(item.comment_synced) : "unknown";
-    const closureProcessed = Number.isFinite(item.lanes?.closure?.processed) ? fmt.format(item.lanes.closure.processed) : processed;
-    const syncProcessed = Number.isFinite(item.lanes?.comment_sync?.processed) ? fmt.format(item.lanes.comment_sync.processed) : processed;
+    const closureProcessed = Number.isFinite(item.lanes?.closure?.processed) ? fmt.format(item.lanes.closure.processed) : actionRecords;
+    const syncProcessed = Number.isFinite(item.lanes?.comment_sync?.processed) ? fmt.format(item.lanes.comment_sync.processed) : actionRecords;
     const closureSynced = Number.isFinite(item.lanes?.closure?.comment_synced) ? fmt.format(item.lanes.closure.comment_synced) : "0";
     const syncLaneSynced = Number.isFinite(item.lanes?.comment_sync?.comment_synced) ? fmt.format(item.lanes.comment_sync.comment_synced) : "0";
     const cycle = applyHealthCyclePill(item.cycle);
@@ -7295,7 +7307,7 @@ function renderApplyHealth(data) {
       '<p>' + esc(applyHealthOperatorSummary(item, topInfo)) + '</p>' +
       '<p class="apply-health-next"><strong>Next check:</strong> ' + esc(topInfo.action) + '</p>' +
       applyHealthActionHtml(action) +
-      '<div class="apply-health-meta"><span class="pill" title="Records checked in this pruning window.">' + esc(processed) + ' processed</span><span class="pill" title="' + esc("Closure lane: " + closureProcessed + " records processed; " + closed + " closed.") + '">' + esc(closed) + ' closed</span><span class="pill" title="' + esc("Durable review comments refreshed across lanes: " + synced + ". Closure lane refreshed " + closureSynced + "; comment-sync lane refreshed " + syncLaneSynced + " from " + syncProcessed + " records.") + '">' + esc(synced) + ' comments synced</span>' + cycle + cursorPill + reasons + buckets + linkClass(item.run_url, "workflow run", "pill run-link") + '</div></div>';
+      '<div class="apply-health-meta"><span class="pill" title="' + esc(activityTitle) + '">' + esc(activityLabel) + '</span><span class="pill" title="' + esc("Closure lane: " + closureProcessed + " action records; " + closed + " closed.") + '">' + esc(closed) + ' closed</span><span class="pill" title="' + esc("Durable review comments refreshed across lanes: " + synced + ". Closure lane refreshed " + closureSynced + "; comment-sync lane refreshed " + syncLaneSynced + " from " + syncProcessed + " action records.") + '">' + esc(synced) + ' comments synced</span>' + cycle + cursorPill + reasons + buckets + linkClass(item.run_url, "workflow run", "pill run-link") + '</div></div>';
   }).join("");
 }
 function applyHealthCyclePill(cycle) {

--- a/scripts/apply-workflow-helpers.sh
+++ b/scripts/apply-workflow-helpers.sh
@@ -62,6 +62,14 @@ write_apply_health() {
   pnpm run --silent workflow -- summarize-apply-report "${health_args[@]}" > "$output_path"
 }
 
+apply_checkpoint_examined_count() {
+  if [ "$auto_selected_apply_batch" = "true" ] && [ -n "$cursor_advance_count" ]; then
+    printf '%s\n' "$cursor_advance_count"
+  else
+    printf '%s\n' "unavailable"
+  fi
+}
+
 select_automatic_apply_runtime() {
   max_runtime_arg=()
   if [ "$auto_selected_apply_batch" = "true" ]; then

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -44,6 +44,8 @@ type ApplyReportSummary = {
   mode: string;
   status: "ok" | "idle" | "needs_attention";
   summary: string;
+  examined: number | null;
+  action_records: number;
   processed: number;
   processed_limit: number | null;
   close_limit: number | null;
@@ -540,6 +542,12 @@ export function applyContinuationBlocker(
 
 export function summarizeApplyReport(options: ApplyReportSummaryOptions): ApplyReportSummary {
   const actions = readApplyActions(options.reportPath);
+  const examined =
+    options.cursorRequired &&
+    options.cursorAdvanceCount !== null &&
+    options.cursorAdvanceCount !== undefined
+      ? options.cursorAdvanceCount
+      : null;
   const lanes = summarizeApplyLanes(actions, options.mode);
   const skipReasons: Record<string, number> = {};
   let closed = 0;
@@ -567,7 +575,7 @@ export function summarizeApplyReport(options: ApplyReportSummaryOptions): ApplyR
   if (
     options.cursorRequired &&
     processedLimit !== null &&
-    actions.length >= processedLimit &&
+    (actions.length >= processedLimit || (examined !== null && examined >= processedLimit)) &&
     !cursor
   ) {
     attentionReasons.push("cursor_required_but_missing_after_full_window");
@@ -596,10 +604,15 @@ export function summarizeApplyReport(options: ApplyReportSummaryOptions): ApplyR
   const nextActions = applySkipNextActions(skipReasons);
 
   const status =
-    actions.length === 0 ? "idle" : attentionReasons.length > 0 ? "needs_attention" : "ok";
+    attentionReasons.length > 0
+      ? "needs_attention"
+      : actions.length === 0 && (examined === null || examined === 0)
+        ? "idle"
+        : "ok";
   const summary = applyReportHealthSummary({
     status,
-    processed: actions.length,
+    examined,
+    actionRecords: actions.length,
     processedLimit,
     closed,
     commentSynced,
@@ -615,6 +628,8 @@ export function summarizeApplyReport(options: ApplyReportSummaryOptions): ApplyR
     mode: options.mode,
     status,
     summary,
+    examined,
+    action_records: actions.length,
     processed: actions.length,
     processed_limit: processedLimit,
     close_limit: options.closeLimit,
@@ -972,7 +987,8 @@ function durationLabel(minutes: number): string {
 }
 function applyReportHealthSummary(options: {
   status: ApplyReportSummary["status"];
-  processed: number;
+  examined: number | null;
+  actionRecords: number;
   processedLimit: number | null;
   closed: number;
   commentSynced: number;
@@ -980,15 +996,19 @@ function applyReportHealthSummary(options: {
   cursor: ApplyReportSummary["cursor"];
   attentionReasons: string[];
 }): string {
-  if (options.status === "idle") return "Apply processed no records in this run.";
-  const budget =
+  const actionRecords =
     options.processedLimit === null
-      ? `${options.processed} processed`
-      : `${options.processed}/${options.processedLimit} processed`;
+      ? `${options.actionRecords} action records`
+      : `${options.actionRecords}/${options.processedLimit} action records`;
+  const examined =
+    options.examined === null ? "examined count unavailable" : `${options.examined} examined`;
+  if (options.status === "idle") {
+    return `Apply produced no action records in this run; ${examined}.`;
+  }
   const cursorText = options.cursor
     ? `cursor at #${options.cursor.next_after_number}`
     : "no cursor recorded";
-  const base = `${budget}; ${options.closed} closed, ${options.commentSynced} comments synced, ${options.skipped} skipped; ${cursorText}.`;
+  const base = `${examined}; ${actionRecords}; ${options.closed} closed, ${options.commentSynced} comments synced, ${options.skipped} skipped; ${cursorText}.`;
   if (options.attentionReasons.length === 0) return base;
   return `${base} Attention: ${options.attentionReasons.join(", ")}.`;
 }

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -758,6 +758,7 @@ test("dashboard HTML preserves UTF-8 emoji labels", async () => {
   assert.match(html, /System Overview/);
   assert.match(html, /id="apply-health"/);
   assert.match(html, /function renderApplyHealth/);
+  assert.match(html, /candidate examined count unavailable for this lane/);
   assert.match(html, /Pruning sweep/);
   assert.match(html, /Copy command/);
   assert.match(html, /applyHealthRecommendedAction/);
@@ -1695,7 +1696,10 @@ test("dashboard exposes apply health from sweep status without broad scans", asy
     apply_health: {
       mode: "close",
       status: "needs_attention",
-      summary: "2/2 processed; 0 closed, 0 comments synced, 2 skipped; no cursor recorded.",
+      summary:
+        "4 examined; 2/2 action records; 0 closed, 0 comments synced, 2 skipped; no cursor recorded.",
+      examined: 4,
+      action_records: 2,
       processed: 2,
       processed_limit: 2,
       close_limit: 5,
@@ -1789,6 +1793,8 @@ test("dashboard exposes apply health from sweep status without broad scans", asy
     const status = await response.json();
     assert.equal(status.recent.apply_health.attention_count, 1);
     assert.equal(status.recent.apply_health.items[0].status, "needs_attention");
+    assert.equal(status.recent.apply_health.items[0].examined, 4);
+    assert.equal(status.recent.apply_health.items[0].action_records, 2);
     assert.equal(status.recent.apply_health.items[0].processed, 2);
     assert.equal(status.recent.apply_health.items[0].cursor_required, true);
     assert.deepEqual(status.recent.apply_health.items[0].skip_reasons, {

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -334,7 +334,10 @@ test("workflow utilities summarize apply health with skip buckets and cursor", (
   });
 
   assert.equal(summary.status, "ok");
+  assert.equal(summary.examined, 4);
+  assert.equal(summary.action_records, 6);
   assert.equal(summary.processed, 6);
+  assert.match(summary.summary, /4 examined; 6\/300 action records/);
   assert.equal(summary.closed, 1);
   assert.equal(summary.comment_synced, 1);
   assert.deepEqual(summary.skip_reasons, {
@@ -381,6 +384,42 @@ test("workflow utilities summarize apply health with skip buckets and cursor", (
   assert.equal(summary.cursor?.next_after_number, 40);
 });
 
+test("workflow utilities distinguish examined promotion probes from action records", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const reportPath = path.join(root, "apply-report.json");
+  const cursorPath = path.join(root, "results/apply-cursors/openclaw-openclaw.json");
+  write(reportPath, JSON.stringify([]));
+  write(
+    cursorPath,
+    JSON.stringify({
+      next_after_number: 79148,
+      next_after_apply_checked_at: "2026-06-18T00:00:00Z",
+      updated_at: "2026-07-09T00:03:00Z",
+    }),
+  );
+
+  const summary = summarizeApplyReport({
+    reportPath,
+    targetRepo: "openclaw/openclaw",
+    mode: "close",
+    processedLimit: 300,
+    closeLimit: 20,
+    cursorPath,
+    cursorRequired: true,
+    candidateCount: 565,
+    cursorAdvanceCount: 40,
+    scheduledIntervalMinutes: 15,
+  });
+
+  assert.equal(summary.status, "ok");
+  assert.equal(summary.examined, 40);
+  assert.equal(summary.action_records, 0);
+  assert.equal(summary.processed, 0);
+  assert.match(summary.summary, /^40 examined; 0\/300 action records;/);
+  assert.equal(summary.cycle.window_size, 40);
+  assert.equal(summary.cursor?.next_after_number, 79148);
+});
+
 test("workflow utilities summarize comment-sync apply reports separately from closure", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
   const reportPath = path.join(root, "apply-report.json");
@@ -404,6 +443,9 @@ test("workflow utilities summarize comment-sync apply reports separately from cl
   });
 
   assert.equal(summary.mode, "comment_sync");
+  assert.equal(summary.examined, null);
+  assert.equal(summary.action_records, 3);
+  assert.match(summary.summary, /examined count unavailable; 3\/25 action records/);
   assert.equal(summary.closed, 0);
   assert.equal(summary.comment_synced, 1);
   assert.deepEqual(summary.lanes.closure, {
@@ -519,11 +561,34 @@ test("workflow utilities flag full-window close scans without the required curso
   });
 
   assert.equal(summary.status, "needs_attention");
+  assert.equal(summary.examined, null);
   assert.deepEqual(summary.attention_reasons, [
     "cursor_required_but_missing_after_full_window",
     "skipped_changed_since_review",
   ]);
   assert.match(summary.summary, /Attention:/);
+});
+
+test("workflow utilities flag a missing cursor after a no-action full window", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const reportPath = path.join(root, "apply-report.json");
+  write(reportPath, JSON.stringify([]));
+
+  const summary = summarizeApplyReport({
+    reportPath,
+    targetRepo: "openclaw/openclaw",
+    mode: "close",
+    processedLimit: 2,
+    closeLimit: 5,
+    cursorPath: path.join(root, "missing-cursor.json"),
+    cursorRequired: true,
+    cursorAdvanceCount: 2,
+  });
+
+  assert.equal(summary.status, "needs_attention");
+  assert.equal(summary.examined, 2);
+  assert.equal(summary.action_records, 0);
+  assert.deepEqual(summary.attention_reasons, ["cursor_required_but_missing_after_full_window"]);
 });
 
 test("workflow utilities keep a resumable runtime yield healthy", () => {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -191,6 +191,10 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
   assert.match(applyHelper, /write_apply_health\(\)/);
   assert.match(applyStep, /proposed-item-count/);
   assert.match(applyStep, /apply-cursor-advance-count/);
+  assert.match(applyStep, /examined_count="\$\(apply_checkpoint_examined_count\)"/);
+  assert.match(applyHelper, /apply_checkpoint_examined_count\(\)/);
+  assert.match(applyHelper, /printf '%s\\n' "unavailable"/);
+  assert.match(applyStep, /Candidates examined: \$examined_count\. Action records: \$result_count/);
   assert.match(applyHelper, /--candidate-count "\$health_candidate_count"/);
   assert.match(applyHelper, /--cursor-advance-count "\$health_cursor_advance_count"/);
   assert.match(applyHelper, /--scheduled-interval-minutes "\$health_scheduled_interval_minutes"/);


### PR DESCRIPTION
## Summary

- distinguish cursor-traced candidates examined from emitted apply action records
- keep legacy `processed` output compatible while exposing `examined` and `action_records`
- surface the distinction in workflow checkpoints and the live dashboard
- treat zero-action cursor windows as healthy scans and retain missing-cursor alarms

## Proof

- `pnpm run build:all`
- `pnpm run lint`
- `pnpm run test:unit` (727 passed)
- `pnpm run test:repair` (626 passed)
- `pnpm run format:check`
- source-blind behavior contract: 4 passed, 0 failed
- autoreview: clean

This makes runs such as 40 candidates examined / 12 action records explicit instead of reporting the scan as only 12 processed records.
