### PR TITLE
fix: cool down apply promotion probes

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -19562,6 +19562,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
       isCloseProposal = true;
       cachedPrCloseCoverageProofGateResult = undefined;
     }
+    let attemptedPullRequestClosePromotion = hasLiveNoDiffPullRequestPromotion;
     if (
       state === "open" &&
       !isCloseProposal &&
@@ -19570,6 +19571,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
       decision === "keep_open" &&
       action === "kept_open"
     ) {
+      attemptedPullRequestClosePromotion = true;
       const promotionContext = currentItemContext();
       const promotion = pullRequestClosePromotion(
         markdown,
@@ -20421,6 +20423,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
     }
     if (syncCommentsOnly) continue;
     if (!isCloseProposal || !closeReason) {
+      if (!isCloseProposal && attemptedPullRequestClosePromotion) markApplyChecked();
       continue;
     }
     if (requiredMaintainerDecision?.required) {

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -1090,6 +1090,7 @@ type ProposedItemSelection = "all" | "pr-close-coverage-proof" | "quality-summar
 type ProposedItemCandidate = {
   number: number;
   applyCheckedAt: string;
+  reviewedAt: string;
   kind: string;
   closeReason: string;
   action: string;
@@ -1132,6 +1133,9 @@ const FAST_CLOSE_BUCKET_ORDER: ProposedItemQualityBucket[] = [
   "needs_pr_close_coverage",
   "promotion_probe",
 ];
+
+// Promotion probes hydrate related live graphs; a fresh review bypasses this daily backoff.
+const APPLY_PROMOTION_PROBE_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 
 function prioritizeFastCloseCandidates(
   candidates: ProposedItemCandidate[],
@@ -1245,6 +1249,7 @@ function selectedProposedItemCandidates(
         {
           number,
           applyCheckedAt: frontMatterValue(markdown, "apply_checked_at"),
+          reviewedAt: frontMatterValue(markdown, "reviewed_at"),
           kind: type,
           closeReason: candidateCloseReason,
           action,
@@ -1262,13 +1267,20 @@ function selectedProposedItemCandidates(
     .sort((left, right) => left.number - right.number);
   const batchSize = options.batchSize ?? null;
   if (!batchSize || batchSize <= 0) return candidates;
+  const coolDownPromotionProbes = !options.itemNumbers || options.itemNumbers.size === 0;
+  const readyCandidates = candidates.filter(
+    (candidate) =>
+      candidate.stage !== "promotion_probe" ||
+      !coolDownPromotionProbes ||
+      !promotionProbeCoolingDown(candidate),
+  );
   const cursor = options.cursorPath ? readApplyCursor(options.cursorPath) : null;
   const rotate = (
     stage: ProposedItemCandidate["stage"],
     coverageProof: boolean | null,
     position: ApplyCursorPosition | null,
   ): ProposedItemCandidate[] => {
-    const sorted = candidates
+    const sorted = readyCandidates
       .filter(
         (candidate) =>
           candidate.stage === stage &&
@@ -1328,6 +1340,12 @@ function selectedProposedItemCandidates(
     ...selectedFast.slice(preProofFastCount),
     ...selectedPromotions,
   ];
+}
+
+function promotionProbeCoolingDown(candidate: ProposedItemCandidate, nowMs = Date.now()): boolean {
+  const checkedAtMs = timestampValue(candidate.applyCheckedAt);
+  if (checkedAtMs === 0 || timestampValue(candidate.reviewedAt) > checkedAtMs) return false;
+  return nowMs - checkedAtMs < APPLY_PROMOTION_PROBE_COOLDOWN_MS;
 }
 
 export function proposedItemQualitySummary(

--- a/test/apply-pr-promotion.test.ts
+++ b/test/apply-pr-promotion.test.ts
@@ -108,6 +108,7 @@ function assertResolvedPromotionRespectsCloseReasonFilter(options: {
     const stored = readFileSync(itemPath, "utf8");
     assert.match(stored, /^decision: keep_open$/m);
     assert.match(stored, /^close_reason: none$/m);
+    assert.match(stored, /^apply_checked_at: /m);
     assert.match(
       stored,
       new RegExp(`## Summary\\n\\n${keepOpenSummary.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`),
@@ -122,6 +123,61 @@ function assertResolvedPromotionRespectsCloseReasonFilter(options: {
     rmSync(root, { recursive: true, force: true });
   }
 }
+
+test("apply-decisions checkpoints a valid promotion probe with no action record", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const itemPath = join(itemsDir, "333.md");
+    const now = new Date().toISOString();
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const sourceReport = stalePullRequestReport({
+      number: 333,
+      title: "Recent incomplete PR",
+      item_created_at: now,
+      item_updated_at: now,
+      reviewed_at: now,
+      labels: JSON.stringify([]),
+    });
+    const synced = reportWithSyncedReviewComment(sourceReport, 333, "none");
+    writeFileSync(itemPath, synced.report, "utf8");
+
+    const ghOptions = {
+      number: 333,
+      title: "Recent incomplete PR",
+      itemCreatedAt: now,
+      itemUpdatedAt: now,
+      comment: synced.comment,
+    };
+    let liveLabels = [];
+    let actions = [{ action: "not-run" }];
+    for (let attempt = 0; attempt < 5 && actions.length > 0; attempt += 1) {
+      withMockGh(root, promotionGhMock({ ...ghOptions, labels: liveLabels }), () => {
+        runApplyDecisionsForTest({
+          itemsDir,
+          closedDir,
+          plansDir,
+          reportPath,
+          extraArgs: ["--target-repo", "openclaw/openclaw", "--processed-limit", "3"],
+        });
+      });
+      actions = JSON.parse(readFileSync(reportPath, "utf8"));
+      if (actions.length === 0) break;
+      const stored = readFileSync(itemPath, "utf8");
+      liveLabels = JSON.parse(stored.match(/^labels: (.+)$/m)?.[1] ?? "[]");
+      writeFileSync(itemPath, stored.replace(/^apply_checked_at: .*\n/m, ""), "utf8");
+    }
+
+    assert.deepEqual(actions, []);
+    assert.match(readFileSync(itemPath, "utf8"), /^apply_checked_at: /m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
 
 test("apply-decisions upgrades live no-diff kept-open PRs to duplicate closes", () => {
   const root = mkdtempSync(tmpPrefix);

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -1942,7 +1942,8 @@ test("workflow utilities backfill promotion probes after confirmed close proposa
         "close_reason: none",
         `item_created_at: ${oldDate}`,
         `apply_checked_at: ${applyCheckedAt}`,
-        `work_cluster_refs: ${JSON.stringify(["Superseded by #400"])}`,
+        "pr_rating_overall: F",
+        "pr_rating_proof: F",
         "---",
         "",
       ].join("\n"),
@@ -1974,6 +1975,70 @@ test("workflow utilities backfill promotion probes after confirmed close proposa
       ["ready_implemented", 1],
       ["promotion_probe", 1],
     ],
+  );
+});
+
+test("workflow utilities cool down recently examined promotion probes", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const oldDate = "2024-01-01T00:00:00Z";
+  const promotionRecord = (number, applyCheckedAt, coverageProof = false, reviewedAt = "") =>
+    write(
+      path.join(root, `records/openclaw-openclaw/items/openclaw-openclaw-${number}.md`),
+      [
+        "---",
+        "repository: openclaw/openclaw",
+        "type: pull_request",
+        "decision: keep_open",
+        "review_status: complete",
+        "local_checkout_access: verified",
+        "action_taken: kept_open",
+        "close_reason: none",
+        `item_created_at: ${oldDate}`,
+        `apply_checked_at: ${applyCheckedAt}`,
+        ...(reviewedAt ? [`reviewed_at: ${reviewedAt}`] : []),
+        ...(coverageProof
+          ? [`work_cluster_refs: ${JSON.stringify(["Superseded by #400"])}`]
+          : ["pr_rating_overall: F", "pr_rating_proof: F"]),
+        "---",
+        "",
+      ].join("\n"),
+    );
+  promotionRecord(10, new Date(Date.now() - 60 * 60 * 1000).toISOString());
+  promotionRecord(20, new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString());
+  promotionRecord(30, new Date(Date.now() - 60 * 60 * 1000).toISOString(), true);
+  promotionRecord(40, new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString(), true);
+  promotionRecord(
+    50,
+    new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+    false,
+    new Date().toISOString(),
+  );
+
+  const options = {
+    targetRepo: "openclaw/openclaw",
+    applyKind: "all",
+    applyCloseReasons: "all",
+    staleMinAgeDays: 60,
+    minAgeDays: 0,
+    minAgeMinutes: null,
+    batchSize: 10,
+    coverageProofLimit: 1,
+  };
+
+  assert.deepEqual(
+    withCwd(root, () => proposedItemNumbers(options)),
+    [40, 20, 50],
+  );
+  assert.deepEqual(
+    withCwd(root, () => proposedItemNumbers({ ...options, itemNumbers: new Set([10]) })),
+    [10],
+  );
+  assert.deepEqual(
+    withCwd(root, () => proposedItemQualitySummary(options)).buckets.map((bucket) => [
+      bucket.bucket,
+      bucket.count,
+    ]),
+    [["promotion_probe", 3]],
   );
 });
 


### PR DESCRIPTION
## Summary

- persist `apply_checked_at` after a valid live promotion probe produces no close or action record
- cool automatic promotion probes for 24 hours after examination
- let explicit item retries and newer reviews bypass the cooldown immediately
- keep confirmed close and proof lanes independent from speculative backfill

## Production evidence

Consecutive scheduled runs repeatedly selected the same 39 non-proof promotion probes while only the single proof-tail candidate advanced:

- run 29043656336: 43 examined, 12 actions, 0 closes
- run 29044888201: the same 39 promotion probes, 12 actions, 0 closes

Each window spent roughly 8–9 minutes hydrating the same live graphs.

## Proof

- `pnpm run build:all`
- focused promotion tests: 3 passed
- focused selector/cursor tests: 3 passed
- zero-action regression persists the check timestamp with an empty action report
- recent probes are excluded; stale probes, explicit targets, and newer reviews remain eligible
- autoreview: clean after two accepted fixes and final review

The broader parallel unit gate exposed existing wall-clock/runtime-budget flakes under load; each affected runtime test passes in isolation.
