### PR TITLE
fix: prevent dashboard refresh storms

### DIFF
--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -2,13 +2,6 @@ name: ClawSweeper Live Dashboard CI Status
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows:
-      - ClawSweeper
-      - ClawSweeper Commit Review
-      - repair cluster worker
-      - repair comment router
-    types: [completed]
   schedule:
     - cron: "*/5 * * * *"
 

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -59,6 +59,18 @@ test("dashboard syncs Worker secrets with durable lifecycle storage", () => {
   assert.doesNotMatch(workflow, /wrangler@[^\s]+ secret bulk/);
 });
 
+test("dashboard CI refreshes on cadence without completion-trigger storms", () => {
+  const workflow = readText(".github/workflows/dashboard-ci.yml");
+  const triggers = workflow.slice(workflow.indexOf("on:"), workflow.indexOf("\npermissions:"));
+  const concurrency = workflow.slice(workflow.indexOf("concurrency:"), workflow.indexOf("\njobs:"));
+
+  assert.match(triggers, /workflow_dispatch:/);
+  assert.match(triggers, /schedule:\s+- cron: "\*\/5 \* \* \* \*"/);
+  assert.doesNotMatch(triggers, /workflow_run:/);
+  assert.match(concurrency, /group: clawsweeper-live-dashboard-ci/);
+  assert.match(concurrency, /cancel-in-progress: true/);
+});
+
 test("publish workflow installs Codex from the root checkout path", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const publishJobStart = workflow.indexOf("\n  publish:");


### PR DESCRIPTION
## Summary

- stop launching the dashboard CI refresher after every ClawSweeper and repair workflow completion
- retain manual dispatch and the five-minute scheduled refresh cadence
- lock the trigger and global concurrency contract with a workflow regression test

## Why

The completion fan-out creates redundant dashboard runs during busy workflow periods. The existing scheduled refresh bounds telemetry staleness to five minutes, while the shared `cancel-in-progress` concurrency group continues to prevent overlap.

## Validation

- `node --test --test-name-pattern='dashboard CI refreshes on cadence|trusted-event workflows explicitly checkout' test/sweep-workflow.test.ts test/actions-checkout-v7.test.ts`
- `pnpm run build:all`
- `pnpm run lint`
- `pnpm run format:check`
- structured autoreview: clean
- `pnpm run check`: new test passed; full unit batch reached 724/728 and hit the existing load-sensitive runtime-budget and failed-review-retry timing tests
