### PR TITLE
fix: include GitHub JSON in sparse repair builds

### DIFF
--- a/.github/workflows/repair-comment-router.yml
+++ b/.github/workflows/repair-comment-router.yml
@@ -102,6 +102,7 @@ jobs:
             src/codex-process-worker.ts
             src/codex-process.ts
             src/codex-transient.ts
+            src/github-json.ts
             src/github-retry.ts
             src/pr-close-coverage-proof.ts
             src/repair

--- a/.github/workflows/spam-comment-intake.yml
+++ b/.github/workflows/spam-comment-intake.yml
@@ -63,6 +63,7 @@ jobs:
             src/codex-process.ts
             src/codex-spawn.ts
             src/codex-transient.ts
+            src/github-json.ts
             src/github-retry.ts
             src/pr-close-coverage-proof.ts
             src/repair

--- a/.github/workflows/spam-scanner.yml
+++ b/.github/workflows/spam-scanner.yml
@@ -86,6 +86,7 @@ jobs:
             src/codex-process.ts
             src/codex-spawn.ts
             src/codex-transient.ts
+            src/github-json.ts
             src/github-retry.ts
             src/pr-close-coverage-proof.ts
             src/repair

--- a/test/repair/workflow-sparse-checkout.test.ts
+++ b/test/repair/workflow-sparse-checkout.test.ts
@@ -14,6 +14,7 @@ const REPAIR_RUNTIME_PATHS = [
   "src/codex-process.ts",
   "src/codex-spawn.ts",
   "src/codex-transient.ts",
+  "src/github-json.ts",
   "src/pr-close-coverage-proof.ts",
 ] as const;
 


### PR DESCRIPTION
## Summary

- include `src/github-json.ts` in every partial sparse checkout that builds the repair runtime
- extend the shared sparse-workflow contract so all three manifests must retain the dependency

## Root cause

`src/repair/github-cli.ts` imports `../github-json.js`, but the repair comment router, spam comment intake, and spam scanner sparse checkouts omitted the source file. TypeScript could still build the checked-out repair tree, but the emitted runtime lacked `dist/github-json.js` and failed on import with `ERR_MODULE_NOT_FOUND`.

## Verification

- `pnpm run build:repair`
- `node --test test/repair/workflow-sparse-checkout.test.ts` (5 pass)
- targeted oxlint on the contract test
- `pnpm run format:check`
- recreated each workflow's non-cone sparse checkout, built `tsconfig.repair.json`, verified `dist/github-json.js`, and imported `dist/repair/github-cli.js` successfully
- independent review: clean
