### PR TITLE
fix: raise apply proof capacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ checkpoint, and status-only commits are intentionally omitted.
 - Bounded automatic close-apply checkpoints to ten minutes, persisted exact cursor progress before immediate continuation, and limited close-coverage proofs to the time remaining in the checkpoint.
 - Kept close-limit apply checkpoints from advancing their resumable cursor past an unexecuted close candidate. Thanks @brokemac79.
 - Stopped zero-progress automatic apply runtime yields from queueing immediate continuations, leaving the scheduled apply run as the retry backstop. Thanks @brokemac79.
-- Kept automatic apply windows responsive by running at most one PR close-coverage proof after fast candidates and advancing independent fast/proof cursors only through records actually examined.
+- Kept automatic apply windows responsive by reserving up to two PR close-coverage proofs, capped by the effective close budget, and advancing independent fast/proof cursors only through records actually examined.
 - Prevented malformed `maintainer_decision` records from repeatedly consuming apply queue slots by recording their deterministic apply bookkeeping. Thanks @brokemac79.
 - Preserved ready-for-maintainer labels when a newer durable review matches the current PR head, while still removing readiness from stale-head reviews. Thanks @brokemac79.
 - Surfaced apply-health `needs_attention` state in the dashboard hero and added explicit System, Light, and Dark theme controls. Thanks @brokemac79.

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -468,13 +468,16 @@ records, capped at 900. This changes only the deterministic scan window:
 policy gates stay unchanged. The workflow logs and sweep status detail include
 the selected scan window and reason.
 
-Automatic windows reserve a one-candidate tail for PR close-coverage proof.
-Fast deterministic candidates run first; the proof candidate runs last and has
-an independent cursor. An executor trace advances each cursor only through
-records actually examined, so a partial window neither repeats completed proof
-work nor skips unexamined candidates. Coverage proof, live-state refresh,
-freshness checks, and close gates remain unchanged. Explicit targeted apply
-runs keep their requested item set and ordering policy.
+Automatic windows reserve up to two candidates for PR close-coverage proof,
+capped by the effective close budget. Confirmed proof-gated close proposals stay
+ahead of speculative promotion proofs; spare proof capacity rotates promotions
+on the same independent proof cursor. Reserved proofs run before deterministic
+closes could exhaust the checkpoint's mutation limit. An executor trace advances
+each cursor only through records actually examined, so a partial window preserves
+unexamined candidates and each pool resumes from its exact last-examined
+position. Coverage proof, live-state refresh, freshness checks, and close gates
+remain unchanged. Explicit targeted apply runs keep their requested item set and
+ordering policy.
 
 Before a close-mode apply run starts, the workflow summarizes the selected close
 candidate mix by quality bucket in the status detail. Buckets such as

--- a/scripts/apply-workflow-helpers.sh
+++ b/scripts/apply-workflow-helpers.sh
@@ -5,7 +5,7 @@
 # shellcheck disable=SC2034,SC2154
 
 max_close_processed_limit=900
-coverage_proof_limit=1
+coverage_proof_limit=2
 progress_every=10
 
 publish_changes() {

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -1307,18 +1307,20 @@ function selectedProposedItemCandidates(
     ].slice(0, batchSize);
   }
 
-  const proofLimit = Math.max(0, Math.min(options.coverageProofLimit, batchSize));
+  const closeLimit = Math.max(1, Math.min(options.closeLimit ?? batchSize, batchSize));
+  const proofLimit = Math.max(0, Math.min(options.coverageProofLimit, batchSize, closeLimit));
   const fastConfirmedCandidates = prioritizeFastCloseCandidates(
     rotate("confirmed_close", false, cursor),
   );
   const proofCursor = cursor?.coverageProof ?? cursor;
+  // Preserve confirmed proof work ahead of speculative promotions. Any reserve
+  // left after confirmed proofs lets the promotion-proof pool rotate independently.
   const proofCandidates = [
     ...rotate("confirmed_close", true, proofCursor),
     ...rotate("promotion_probe", true, proofCursor),
   ];
   const selectedProof = proofCandidates.slice(0, proofLimit);
   const selectedFast = fastConfirmedCandidates.slice(0, batchSize - selectedProof.length);
-  const closeLimit = Math.max(1, Math.min(options.closeLimit ?? batchSize, batchSize));
   // Let ready closes run first, but place every reserved proof before those
   // closes could hit the mutation limit and stop the checkpoint. A candidate
   // can close both a PR and its same-author issue counterpart.

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -2042,7 +2042,7 @@ test("workflow utilities cool down recently examined promotion probes", () => {
   );
 });
 
-test("workflow utilities bound coverage proofs with an independent cursor", () => {
+test("workflow utilities use spare proof capacity to rotate promotion probes", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
   const oldDate = "2024-01-01T00:00:00Z";
   const cursorPath = path.join(root, "results/apply-cursors/openclaw-openclaw.json");
@@ -2064,15 +2064,30 @@ test("workflow utilities bound coverage proofs with an independent cursor", () =
     oldDate,
     { applyCheckedAt: "2026-01-01T00:00:00Z" },
   );
-  writeProposedRecord(
-    root,
-    50,
-    "pull_request",
-    "proposed_close",
-    "duplicate_or_superseded",
-    oldDate,
-    { applyCheckedAt: "2026-01-02T00:00:00Z" },
-  );
+  for (const [number, applyCheckedAt] of [
+    [50, "2026-01-02T00:00:00Z"],
+    [60, "2026-01-03T00:00:00Z"],
+    [70, "2026-01-04T00:00:00Z"],
+  ]) {
+    write(
+      path.join(root, `records/openclaw-openclaw/items/openclaw-openclaw-${number}.md`),
+      [
+        "---",
+        "repository: openclaw/openclaw",
+        "type: pull_request",
+        "decision: keep_open",
+        "review_status: complete",
+        "local_checkout_access: verified",
+        "action_taken: kept_open",
+        "close_reason: none",
+        `item_created_at: ${oldDate}`,
+        `apply_checked_at: ${applyCheckedAt}`,
+        `work_cluster_refs: ${JSON.stringify(["Superseded by #400"])}`,
+        "---",
+        "",
+      ].join("\n"),
+    );
+  }
   const options = {
     targetRepo: "openclaw/openclaw",
     applyKind: "all",
@@ -2081,13 +2096,17 @@ test("workflow utilities bound coverage proofs with an independent cursor", () =
     minAgeDays: 0,
     minAgeMinutes: null,
     batchSize: 4,
-    coverageProofLimit: 1,
+    coverageProofLimit: 2,
     cursorPath,
   };
 
   assert.deepEqual(
     withCwd(root, () => proposedItemNumbers(options)),
-    [10, 40, 20, 30],
+    [40, 50, 10, 20],
+  );
+  assert.deepEqual(
+    withCwd(root, () => proposedItemNumbers({ ...options, closeLimit: 1 })),
+    [40, 10, 20, 30],
   );
   write(
     cursorPath,
@@ -2095,14 +2114,28 @@ test("workflow utilities bound coverage proofs with an independent cursor", () =
       next_after_number: 20,
       next_after_apply_checked_at: "2026-01-02T00:00:00Z",
       coverage_proof_cursor: {
-        next_after_number: 40,
-        next_after_apply_checked_at: "2026-01-01T00:00:00Z",
+        next_after_number: 50,
+        next_after_apply_checked_at: "2026-01-02T00:00:00Z",
       },
     }),
   );
   assert.deepEqual(
     withCwd(root, () => proposedItemNumbers(options)),
-    [30, 50, 10, 20],
+    [40, 60, 30, 10],
+  );
+
+  writeProposedRecord(
+    root,
+    45,
+    "pull_request",
+    "proposed_close",
+    "duplicate_or_superseded",
+    oldDate,
+    { applyCheckedAt: "2026-01-01T12:00:00Z" },
+  );
+  assert.deepEqual(
+    withCwd(root, () => proposedItemNumbers(options)),
+    [40, 45, 30, 10],
   );
 });
 
@@ -2171,7 +2204,14 @@ test("workflow utilities advance fast and coverage-proof cursors from the exact 
   write(tracePath, JSON.stringify({ schema_version: 1, examined_item_numbers: [10, 30] }));
 
   withCwd(root, () =>
-    writeApplyCursor(cursorPath, reportPath, "openclaw/openclaw", "10,20,30", "30", tracePath),
+    writeApplyCursor(
+      cursorPath,
+      reportPath,
+      "openclaw/openclaw",
+      "10,20,30,40",
+      "30,40",
+      tracePath,
+    ),
   );
   let cursor = JSON.parse(fs.readFileSync(cursorPath, "utf8"));
   assert.deepEqual(
@@ -2183,7 +2223,7 @@ test("workflow utilities advance fast and coverage-proof cursors from the exact 
     ],
     [10, "2026-01-01T00:00:00Z", 30, "2026-01-03T00:00:00Z"],
   );
-  assert.equal(applyCursorAdvanceCount(reportPath, "10,20,30", tracePath), 2);
+  assert.equal(applyCursorAdvanceCount(reportPath, "10,20,30,40", tracePath), 2);
 
   write(tracePath, JSON.stringify({ schema_version: 1, examined_item_numbers: [20] }));
   withCwd(root, () =>
@@ -2192,6 +2232,14 @@ test("workflow utilities advance fast and coverage-proof cursors from the exact 
   cursor = JSON.parse(fs.readFileSync(cursorPath, "utf8"));
   assert.equal(cursor.next_after_number, 20);
   assert.equal(cursor.coverage_proof_cursor.next_after_number, 30);
+
+  write(tracePath, JSON.stringify({ schema_version: 1, examined_item_numbers: [40] }));
+  withCwd(root, () =>
+    writeApplyCursor(cursorPath, reportPath, "openclaw/openclaw", "40", "40", tracePath),
+  );
+  cursor = JSON.parse(fs.readFileSync(cursorPath, "utf8"));
+  assert.equal(cursor.next_after_number, 20);
+  assert.equal(cursor.coverage_proof_cursor.next_after_number, 40);
 });
 
 test("workflow utilities count records advanced by the apply cursor", () => {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -181,7 +181,7 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
   assert.match(workflow, /github\.event\.inputs\.apply_checkpoint_size != '20'/);
   assert.match(applyStep, /Capping apply checkpoint size at 20/);
   assert.match(applyStep, /base_close_processed_limit=300/);
-  assert.match(applyHelper, /coverage_proof_limit=1/);
+  assert.match(applyHelper, /coverage_proof_limit=2/);
   assert.match(applyHelper, /max_runtime_arg=\(--max-runtime-ms 600000\)/);
   assert.match(applyHelper, /max_close_processed_limit=900/);
   assert.match(applyStep, /close_processed_limit="\$base_close_processed_limit"/);
@@ -357,12 +357,20 @@ test("apply workflow does not queue runtime-yield continuation without cursor pr
 test("apply workflow drops a coverage-proof tail only after exact trace examination", () => {
   const root = mkdtempSync(tmpPrefix);
   const fastOnlyTrace = join(root, "fast-only.json");
-  const proofTrace = join(root, "proof.json");
+  const firstProofTrace = join(root, "proof-first.json");
+  const secondProofTrace = join(root, "proof-second.json");
   writeFileSync(
     fastOnlyTrace,
     JSON.stringify({ schema_version: 1, examined_item_numbers: [10, 20] }),
   );
-  writeFileSync(proofTrace, JSON.stringify({ schema_version: 1, examined_item_numbers: [30] }));
+  writeFileSync(
+    firstProofTrace,
+    JSON.stringify({ schema_version: 1, examined_item_numbers: [30] }),
+  );
+  writeFileSync(
+    secondProofTrace,
+    JSON.stringify({ schema_version: 1, examined_item_numbers: [40] }),
+  );
 
   try {
     const output = execFileSync(
@@ -372,23 +380,31 @@ test("apply workflow drops a coverage-proof tail only after exact trace examinat
         [
           "source scripts/apply-workflow-helpers.sh",
           "auto_selected_apply_batch=true",
-          "item_numbers=10,20,30",
-          "coverage_proof_item_numbers=30",
+          "item_numbers=10,20,30,40",
+          "coverage_proof_item_numbers=30,40",
           'item_numbers_arg=(--item-numbers "$item_numbers")',
           'drop_bounded_coverage_proof_tail "$FAST_ONLY_TRACE"',
           'printf \'%s|%s|%s\\n\' "$item_numbers" "$coverage_proof_item_numbers" "${item_numbers_arg[*]}"',
-          'drop_bounded_coverage_proof_tail "$PROOF_TRACE"',
+          'drop_bounded_coverage_proof_tail "$FIRST_PROOF_TRACE"',
+          'printf \'%s|%s|%s\\n\' "$item_numbers" "$coverage_proof_item_numbers" "${item_numbers_arg[*]}"',
+          'drop_bounded_coverage_proof_tail "$SECOND_PROOF_TRACE"',
           'printf \'%s|%s|%s\\n\' "$item_numbers" "$coverage_proof_item_numbers" "${item_numbers_arg[*]}"',
         ].join("\n"),
       ],
       {
         cwd: process.cwd(),
         encoding: "utf8",
-        env: { ...process.env, FAST_ONLY_TRACE: fastOnlyTrace, PROOF_TRACE: proofTrace },
+        env: {
+          ...process.env,
+          FAST_ONLY_TRACE: fastOnlyTrace,
+          FIRST_PROOF_TRACE: firstProofTrace,
+          SECOND_PROOF_TRACE: secondProofTrace,
+        },
       },
     );
     assert.deepEqual(output.trim().split("\n"), [
-      "10,20,30|30|--item-numbers 10,20,30",
+      "10,20,30,40|30,40|--item-numbers 10,20,30,40",
+      "10,20,40|40|--item-numbers 10,20,40",
       "10,20||--item-numbers 10,20",
     ]);
   } finally {


### PR DESCRIPTION
## Summary

- raise automatic PR close-coverage proof capacity from one candidate to two
- cap the reserve by the effective close budget so one-close checkpoints never start a discarded second proof
- preserve confirmed-proof priority while using spare capacity to rotate promotion proofs on the independent proof cursor
- retain unexamined proofs across checkpoints and document the scheduler contract

## Why

Consecutive production apply runs `29047900311` and `29048645899` each used the sole proof slot for confirmed candidate `#91668`. Because confirmed proofs intentionally sort ahead of speculative promotion proofs, four promotion-proof candidates could not advance with a one-candidate reserve. A second bounded slot lets that pool rotate without weakening close gates or confirmed-proof priority.

## Validation

- `pnpm run build:all`
- `pnpm run lint`
- `node --test test/repair/workflow-utils.test.ts test/sweep-workflow.test.ts` (84 passed)
- focused selector, independent cursor, and incremental proof-retention coverage
- structured review and independent code review: no actionable findings

`pnpm run check` was also attempted twice. Its unit stage reached 725 passing tests, with only existing wall-clock runtime-budget and failed-review-retry timing tests failing under local parallel load; the changed focused suites pass.
