### PR TITLE
fix: prevent final apply state replay

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2800,28 +2800,18 @@ jobs:
             echo "APPLY_CANDIDATE_QUALITY_SUMMARY=$candidate_quality_summary"
           } >> "$GITHUB_ENV"
 
-      - name: Commit apply results
+      - name: Retry final apply status publication
         run: |
           if [ "${APPLY_NOOP:-false}" = "true" ]; then
-            echo "No proposed closes were ready; no apply results to commit."
+            echo "No proposed closes were ready; no final apply status to retry."
             exit 0
           fi
           target_slug="$APPLY_TARGET_REPO"
           target_slug="${target_slug//\//-}"
-          publish_args=(
-            --message "chore: apply sweep decisions"
-            --path "records/${target_slug}"
-            --path apply-report.json
-            --path "results/sweep-status/${target_slug}.json"
+          pnpm run repair:publish-main -- \
+            --message "chore: mark sweep apply finished" \
+            --path "results/sweep-status/${target_slug}.json" \
             --rebase-strategy apply-records
-          )
-          if [ "${APPLY_SYNC_OPEN_PR_BATCH:-false}" = "true" ]; then
-            publish_args+=(--path results/comment-sync-cursors)
-          fi
-          if [ "${APPLY_AUTO_SELECTED_BATCH:-false}" = "true" ]; then
-            publish_args+=(--path results/apply-cursors)
-          fi
-          pnpm run repair:publish-main -- "${publish_args[@]}"
 
       - name: Continue apply sweep
         if: ${{ success() }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ checkpoint, and status-only commits are intentionally omitted.
 - Refreshed generated source paths after each state publish so later checkpoints cannot overwrite concurrent record, cursor, or report updates learned during a push rebase.
 - Preserved bounded command status and prompt context through durable exact-review queue leases so successful re-reviews advance their original acknowledgement instead of remaining queued.
 - Preserved independently updated sweep status and nested apply-health snapshots across concurrent state publication retries with timestamp-safe three-way merging.
+- Prevented completed apply and comment-sync runs from republishing stale hydrated records after their checkpoint commits, preserving concurrent apply bookkeeping while retaining a narrow final-status retry.
 - Retried infrastructure-failed issue reviews against their exact source revision through bounded one-shot asynchronous dispatch, requeued source drift once, and preserved retry attempts in separate durable state so ambiguous timeouts cannot overwrite completed reviews.
 - Stopped later CI reruns from resetting PR inactivity clocks by anchoring head activity to the latest source-triggered workflow run associated with that pull request.
 - Prioritized ready close decisions and bounded PR close-coverage proofs before slow policy-gated candidates, kept default 20-item continuations shareable, and retried malformed successful GitHub JSON responses.

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -154,7 +154,7 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
   const applyJob = workflow.slice(workflow.indexOf("\n  apply-existing:"));
   const applyStep = applyJob.slice(
     applyJob.indexOf("- name: Apply unchanged proposed decisions with checkpoints"),
-    applyJob.indexOf("- name: Commit apply results"),
+    applyJob.indexOf("- name: Retry final apply status publication"),
   );
   const continueStep = applyJob.slice(
     applyJob.indexOf("- name: Continue apply sweep"),
@@ -306,6 +306,54 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
   assert.match(continueStep, /already covered by \$/);
   assert.match(continueStep, /-f apply_item_numbers="\$APPLY_ITEM_NUMBERS"/);
   assert.doesNotMatch(continueStep, /APPLY_CLOSED_TOTAL:-0.*APPLY_LIMIT:-0/);
+});
+
+test("apply workflow finalization retries only target status after checkpointed state", () => {
+  const workflow = readText(".github/workflows/sweep.yml");
+  const applyJob = workflow.slice(workflow.indexOf("\n  apply-existing:"));
+  const applyStart = applyJob.indexOf(
+    "- name: Apply unchanged proposed decisions with checkpoints",
+  );
+  const finalStatusStart = applyJob.indexOf("- name: Retry final apply status publication");
+  const continueStart = applyJob.indexOf("- name: Continue apply sweep");
+  assert.ok(applyStart !== -1);
+  assert.ok(finalStatusStart > applyStart);
+  assert.ok(continueStart > finalStatusStart);
+  const applyStep = applyJob.slice(applyStart, finalStatusStart);
+  const finalStatusStep = applyJob.slice(finalStatusStart, continueStart);
+
+  const commentCheckpoint = applyStep.indexOf(
+    'publish_changes "chore: sync sweep review comments checkpoint $checkpoint" records apply-report.json results/comment-sync-cursors',
+  );
+  const closePaths = applyStep.indexOf("apply_publish_paths=(records apply-report.json)");
+  const cursorPath = applyStep.indexOf("apply_publish_paths+=(results/apply-cursors)");
+  const closeCheckpoint = applyStep.indexOf(
+    'publish_changes "chore: apply sweep decisions checkpoint $checkpoint" "${apply_publish_paths[@]}"',
+  );
+  assert.ok(commentCheckpoint !== -1);
+  assert.ok(closePaths !== -1);
+  assert.ok(cursorPath > closePaths);
+  assert.ok(closeCheckpoint > cursorPath);
+  for (const laterBranch of [
+    'if automatic_apply_runtime_reached ".artifacts/apply-reports/apply-report-$checkpoint.json"',
+    'if [ "$result_count" -ge "$close_processed_limit" ]; then',
+    'if [ "$result_count" -eq 0 ]; then',
+    'if [ "$closed_in_chunk" -eq 0 ]; then',
+  ]) {
+    assert.ok(applyStep.indexOf(laterBranch) > closeCheckpoint);
+  }
+  assert.match(applyStep, /publish_status "chore: mark sweep apply finished"/);
+
+  assert.match(finalStatusStep, /APPLY_NOOP:-false/);
+  assert.match(finalStatusStep, /--message "chore: mark sweep apply finished"/);
+  assert.deepEqual(
+    [...finalStatusStep.matchAll(/--path\s+("?[^\\\s]+"?)/g)].map((match) => match[1]),
+    ['"results/sweep-status/${target_slug}.json"'],
+  );
+  assert.match(finalStatusStep, /--rebase-strategy apply-records/);
+  assert.doesNotMatch(finalStatusStep, /--path\s+"?records(?:\/|\s)/);
+  assert.doesNotMatch(finalStatusStep, /apply-report\.json/);
+  assert.doesNotMatch(finalStatusStep, /results\/(?:apply|comment-sync)-cursors/);
 });
 
 test("apply workflow does not queue runtime-yield continuation without cursor progress", () => {


### PR DESCRIPTION
## Summary

- stop the final apply step from republishing checkpointed records, reports, and cursors
- retain a target-scoped final-status retry, including the post-commit push-failure case
- lock publication ordering and the narrow retry contract with workflow and Git regressions

## Root cause

The legacy final publisher predated checkpoint commits. A concurrent comment-sync run could hydrate older records, then replay them after another apply checkpoint had already advanced bookkeeping. This regressed `apply_checked_at` for an examined proof candidate while leaving its cursor advanced.

## Validation

- `pnpm run build:all`
- `node --test test/repair/git-publish.test.ts test/sweep-workflow.test.ts` (55 passed)
- `pnpm run lint:repair`
- `pnpm run lint:scripts`
- `pnpm run format:check`
- structured autoreview: clean

The scheduled workflow remains unchanged and disabled pending the separate state-source synchronization hardening.
