### PR TITLE
fix: preserve exact-review command context

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -253,6 +253,15 @@ jobs:
                 ...(Number.isFinite(Number(payload.media_proof_timeout_ms))
                   ? { mediaProofTimeoutMs: Number(payload.media_proof_timeout_ms) }
                   : {}),
+                ...(Object.hasOwn(payload, "command_status_marker")
+                  ? { commandStatusMarker: payload.command_status_marker }
+                  : {}),
+                ...(Object.hasOwn(payload, "status_comment_id")
+                  ? { statusCommentId: payload.status_comment_id }
+                  : {}),
+                ...(Object.hasOwn(payload, "additional_prompt")
+                  ? { additionalPrompt: payload.additional_prompt }
+                  : {}),
               },
             }),
           );
@@ -316,9 +325,9 @@ jobs:
       - name: Resolve event payload
         id: target
         env:
-          ADAPTIVE_CODEX_TIMEOUT_MS: ${{ github.event.client_payload.codex_timeout_ms || '' }}
+          ADAPTIVE_CODEX_TIMEOUT_MS: ${{ github.event.client_payload.review_options.codex_timeout_ms || github.event.client_payload.codex_timeout_ms || '' }}
           CONFIGURED_CODEX_TIMEOUT_MS: ${{ vars.CLAWSWEEPER_CODEX_TIMEOUT_MS || '1200000' }}
-          MEDIA_PROOF_TIMEOUT_MS: ${{ github.event.client_payload.media_proof_timeout_ms || '0' }}
+          MEDIA_PROOF_TIMEOUT_MS: ${{ github.event.client_payload.review_options.media_proof_timeout_ms || github.event.client_payload.media_proof_timeout_ms || '0' }}
         run: |
           set -euo pipefail
           target_repo="${{ github.event.client_payload.target_repo || 'openclaw/openclaw' }}"
@@ -499,8 +508,8 @@ jobs:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
           ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
-          COMMAND_STATUS_MARKER: ${{ github.event.client_payload.command_status_marker || '' }}
-          STATUS_COMMENT_ID: ${{ github.event.client_payload.status_comment_id || '' }}
+          COMMAND_STATUS_MARKER: ${{ github.event.client_payload.review_options.command_status_marker || github.event.client_payload.command_status_marker || '' }}
+          STATUS_COMMENT_ID: ${{ github.event.client_payload.review_options.status_comment_id || github.event.client_payload.status_comment_id || '' }}
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           pnpm run repair:update-command-status -- \
@@ -526,7 +535,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
           CLAWSWEEPER_PROOF_INSPECTION_TOKEN: ${{ steps.target-read-token.outputs.token || github.token }}
-          ADDITIONAL_PROMPT: ${{ github.event.client_payload.additional_prompt || '' }}
+          ADDITIONAL_PROMPT: ${{ github.event.client_payload.review_options.additional_prompt || github.event.client_payload.additional_prompt || '' }}
           CLAWSWEEPER_RELATED_GITHUB_SEARCH: ${{ vars.CLAWSWEEPER_RELATED_GITHUB_SEARCH || '1' }}
         run: |
           set -euo pipefail
@@ -651,8 +660,8 @@ jobs:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
           ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
-          COMMAND_STATUS_MARKER: ${{ github.event.client_payload.command_status_marker || '' }}
-          STATUS_COMMENT_ID: ${{ github.event.client_payload.status_comment_id || '' }}
+          COMMAND_STATUS_MARKER: ${{ github.event.client_payload.review_options.command_status_marker || github.event.client_payload.command_status_marker || '' }}
+          STATUS_COMMENT_ID: ${{ github.event.client_payload.review_options.status_comment_id || github.event.client_payload.status_comment_id || '' }}
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           REVIEW_OUTCOME: ${{ steps.review-exact-event-item.outcome }}
           PUBLISH_OUTCOME: ${{ steps.publish-event-result.outcome }}
@@ -1149,7 +1158,7 @@ jobs:
           fi
           {
             echo "batch_size=$batch_size"
-            echo "codex_timeout_ms=${{ github.event.client_payload.codex_timeout_ms || github.event.inputs.codex_timeout_ms || vars.CLAWSWEEPER_CODEX_TIMEOUT_MS || '1200000' }}"
+            echo "codex_timeout_ms=${{ github.event.client_payload.review_options.codex_timeout_ms || github.event.client_payload.codex_timeout_ms || github.event.inputs.codex_timeout_ms || vars.CLAWSWEEPER_CODEX_TIMEOUT_MS || '1200000' }}"
             echo "hot_intake=$hot_intake"
             echo "max_pages=$max_pages"
             echo "min_active_shards=$min_active_shards"
@@ -1344,7 +1353,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.target-read-token.outputs.token || github.token }}
           CLAWSWEEPER_PROOF_INSPECTION_TOKEN: ${{ steps.codex-inspection-token.outputs.token || github.token }}
-          ADDITIONAL_PROMPT: ${{ github.event.inputs.additional_prompt || github.event.client_payload.additional_prompt || '' }}
+          ADDITIONAL_PROMPT: ${{ github.event.inputs.additional_prompt || github.event.client_payload.review_options.additional_prompt || github.event.client_payload.additional_prompt || '' }}
           EXACT_ITEM: ${{ github.event.client_payload.item_number || github.event.inputs.item_number || github.event.inputs.item_numbers || '' }}
           EXPECTED_SOURCE_REVISION: ${{ github.event.client_payload.expected_source_revision || '' }}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ checkpoint, and status-only commits are intentionally omitted.
 ### Fixed
 
 - Refreshed generated source paths after each state publish so later checkpoints cannot overwrite concurrent record, cursor, or report updates learned during a push rebase.
+- Preserved bounded command status and prompt context through durable exact-review queue leases so successful re-reviews advance their original acknowledgement instead of remaining queued.
 - Retried infrastructure-failed issue reviews against their exact source revision through bounded one-shot asynchronous dispatch, requeued source drift once, and preserved retry attempts in separate durable state so ambiguous timeouts cannot overwrite completed reviews.
 - Stopped later CI reruns from resetting PR inactivity clocks by anchoring head activity to the latest source-triggered workflow run associated with that pull request.
 - Prioritized ready close decisions and bounded PR close-coverage proofs before slow policy-gated candidates, kept default 20-item continuations shareable, and retried malformed successful GitHub JSON responses.

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -31,6 +31,9 @@ type ExactReviewDecision = {
   supersedesInProgress: boolean;
   codexTimeoutMs?: number;
   mediaProofTimeoutMs?: number;
+  commandStatusMarker?: string;
+  statusCommentId?: number;
+  additionalPrompt?: string;
 };
 type ExactReviewQueueItem = {
   key: string;
@@ -80,6 +83,9 @@ const DEFAULT_EXACT_REVIEW_RETRY_MS = 30_000;
 const EXACT_REVIEW_QUEUE_DELIVERY_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const EXACT_REVIEW_QUEUE_STATE_KEY = "exact-review-queue";
 const EXACT_REVIEW_QUEUE_NAME = "global";
+const EXACT_REVIEW_COMMAND_STATUS_MARKER_PATTERN =
+  /^<!-- clawsweeper-command-status:[^<>\r\n]{1,200} -->$/;
+const EXACT_REVIEW_ADDITIONAL_PROMPT_MAX_CHARS = 5000;
 const CLAWSWEEPER_REVIEW_REPO = "openclaw/clawsweeper";
 const CLAWSWEEPER_STATE_REPO = "openclaw/clawsweeper-state";
 const CLAWSWEEPER_STATE_REF = "state";
@@ -355,7 +361,13 @@ export class ExactReviewQueue {
       const key = exactReviewItemKey(decision);
       const current = state.items[key];
       if (current) {
-        current.decision = decision;
+        // A pending command has no executor yet, so an ordinary item event must not erase its
+        // acknowledgement context. Once dispatched, that lease already owns the context and a
+        // newer revision should start clean unless it carries its own command fields.
+        current.decision =
+          current.state === "pending"
+            ? mergePendingExactReviewDecision(current.decision, decision)
+            : decision;
         current.revision += 1;
         current.updatedAt = now;
         current.nextAttemptAt = now;
@@ -1121,12 +1133,39 @@ function exactReviewDecisionFrom(value): ExactReviewDecision | null {
   const itemKind = String(decision.itemKind || "");
   const sourceEvent = String(decision.sourceEvent || "");
   const sourceAction = String(decision.sourceAction || "");
+  const hasCommandStatusMarker = Object.hasOwn(decision, "commandStatusMarker");
+  const commandStatusMarker = hasCommandStatusMarker ? decision.commandStatusMarker : undefined;
+  const hasStatusCommentId = Object.hasOwn(decision, "statusCommentId");
+  const statusCommentId = hasStatusCommentId ? Number(decision.statusCommentId) : undefined;
+  const hasAdditionalPrompt = Object.hasOwn(decision, "additionalPrompt");
+  const additionalPrompt = hasAdditionalPrompt ? decision.additionalPrompt : undefined;
   if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(targetRepo)) return null;
   if (!/^[A-Za-z0-9_./-]+$/.test(targetBranch)) return null;
   if (!Number.isInteger(itemNumber) || itemNumber <= 0) return null;
   if (itemKind !== "issue" && itemKind !== "pull_request") return null;
   if (sourceEvent !== "issues" && sourceEvent !== "pull_request") return null;
   if (!sourceAction) return null;
+  if (
+    hasCommandStatusMarker &&
+    (typeof commandStatusMarker !== "string" ||
+      !EXACT_REVIEW_COMMAND_STATUS_MARKER_PATTERN.test(commandStatusMarker))
+  ) {
+    return null;
+  }
+  if (
+    hasStatusCommentId &&
+    (!Number.isSafeInteger(statusCommentId) || Number(statusCommentId) <= 0)
+  ) {
+    return null;
+  }
+  if (
+    hasAdditionalPrompt &&
+    (typeof additionalPrompt !== "string" ||
+      additionalPrompt.length > EXACT_REVIEW_ADDITIONAL_PROMPT_MAX_CHARS ||
+      additionalPrompt.includes("\0"))
+  ) {
+    return null;
+  }
   return {
     targetRepo,
     targetBranch,
@@ -1141,7 +1180,25 @@ function exactReviewDecisionFrom(value): ExactReviewDecision | null {
     ...(Number.isFinite(Number(decision.mediaProofTimeoutMs))
       ? { mediaProofTimeoutMs: Number(decision.mediaProofTimeoutMs) }
       : {}),
+    ...(hasCommandStatusMarker ? { commandStatusMarker } : {}),
+    ...(hasStatusCommentId ? { statusCommentId } : {}),
+    ...(hasAdditionalPrompt ? { additionalPrompt } : {}),
   };
+}
+
+function mergePendingExactReviewDecision(
+  current: ExactReviewDecision,
+  next: ExactReviewDecision,
+): ExactReviewDecision {
+  const merged = { ...current, ...next };
+  if (
+    Object.hasOwn(next, "commandStatusMarker") &&
+    next.commandStatusMarker !== current.commandStatusMarker &&
+    !Object.hasOwn(next, "statusCommentId")
+  ) {
+    delete merged.statusCommentId;
+  }
+  return merged;
 }
 
 function exactReviewItemKey(decision: ExactReviewDecision) {
@@ -1590,6 +1647,17 @@ async function dispatchClawsweeperItem({
   decision: ExactReviewDecision;
   leaseId?: string;
 }) {
+  const reviewOptions = {
+    ...(decision.codexTimeoutMs ? { codex_timeout_ms: decision.codexTimeoutMs } : {}),
+    ...(decision.mediaProofTimeoutMs
+      ? { media_proof_timeout_ms: decision.mediaProofTimeoutMs }
+      : {}),
+    ...(decision.commandStatusMarker
+      ? { command_status_marker: decision.commandStatusMarker }
+      : {}),
+    ...(decision.statusCommentId ? { status_comment_id: decision.statusCommentId } : {}),
+    ...(decision.additionalPrompt ? { additional_prompt: decision.additionalPrompt } : {}),
+  };
   await githubTokenJson({
     token,
     path: `/repos/${CLAWSWEEPER_REVIEW_REPO}/dispatches`,
@@ -1605,10 +1673,7 @@ async function dispatchClawsweeperItem({
         source_action: decision.sourceAction,
         supersedes_in_progress: decision.supersedesInProgress,
         ...(leaseId ? { queue_lease_id: leaseId } : {}),
-        ...(decision.codexTimeoutMs ? { codex_timeout_ms: decision.codexTimeoutMs } : {}),
-        ...(decision.mediaProofTimeoutMs
-          ? { media_proof_timeout_ms: decision.mediaProofTimeoutMs }
-          : {}),
+        ...(Object.keys(reviewOptions).length > 0 ? { review_options: reviewOptions } : {}),
       },
     },
     errorLabel: "ClawSweeper item dispatch",

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -174,6 +174,8 @@ Do not move these into the dashboard:
 The dashboard Worker owns durable exact-review admission only: it deduplicates
 webhook deliveries, coalesces each repository/item pair, and leases at most
 28 Actions executors, with up to 24 active leases per target repository. It does
-not decide review outcomes or perform target repository mutations. GitHub Actions
-remains the executor and the existing review/apply safety model remains
-unchanged.
+not decide review outcomes or perform target repository mutations. For
+command-triggered reviews, the queue retains the bounded review prompt and
+command-status identifiers so the leased GitHub Actions executor can update the
+original acknowledgement through completion. GitHub Actions remains the
+executor and the existing review/apply safety model remains unchanged.

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2136,6 +2136,9 @@ test("sweep workflow executes only durable queue leases without runner-side admi
   assert.match(legacyIntakeBlock, /\/internal\/exact-review\/enqueue/);
   assert.match(legacyIntakeBlock, /x-clawsweeper-exact-review-signature/);
   assert.match(legacyIntakeBlock, /CLAWSWEEPER_WEBHOOK_SECRET/);
+  assert.match(legacyIntakeBlock, /commandStatusMarker: payload\.command_status_marker/);
+  assert.match(legacyIntakeBlock, /statusCommentId: payload\.status_comment_id/);
+  assert.match(legacyIntakeBlock, /additionalPrompt: payload\.additional_prompt/);
   assert.match(eventReviewBlock, /cancel-in-progress: false/);
   assert.ok(claimIndex >= 0);
   assert.ok(setupPnpmIndex > claimIndex);

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -251,13 +251,19 @@ test("exact-review queue coalesces deliveries, leases bounded work, and rejects 
         EXACT_REVIEW_QUEUE_MAX_CONCURRENT: "1",
       },
     );
-    const first = buildExactReviewQueueRequest("delivery-1", 597, "opened");
+    const commandStatusMarker =
+      "<!-- clawsweeper-command-status:597:re_review:0123456789abcdef0123456789abcdef01234567 -->";
+    const first = buildExactReviewQueueRequest("delivery-1", 597, "opened", "issue", undefined, {
+      commandStatusMarker,
+      statusCommentId: 9001,
+      additionalPrompt: "Check the maintainer-requested regression path.",
+      codexTimeoutMs: 1_200_000,
+      mediaProofTimeoutMs: 480_000,
+    });
+    const duplicate = first.clone();
     const latest = buildExactReviewQueueRequest("delivery-2", 597, "edited");
     const second = buildExactReviewQueueRequest("delivery-3", 598, "opened");
-    assert.equal(
-      (await queue.fetch(buildExactReviewQueueRequest("delivery-1", 597, "opened"))).status,
-      202,
-    );
+    assert.equal((await queue.fetch(duplicate)).status, 202);
     assert.equal((await queue.fetch(latest)).status, 202);
     assert.equal((await queue.fetch(second)).status, 202);
     assert.equal((await queue.fetch(first)).status, 202);
@@ -269,6 +275,14 @@ test("exact-review queue coalesces deliveries, leases bounded work, and rejects 
     const payload = dispatched[0].client_payload as Record<string, unknown>;
     assert.equal(payload.item_number, 597);
     assert.equal(payload.source_action, "edited");
+    assert.ok(Object.keys(payload).length <= 10);
+    assert.deepEqual(payload.review_options, {
+      codex_timeout_ms: 1_200_000,
+      media_proof_timeout_ms: 480_000,
+      command_status_marker: commandStatusMarker,
+      status_comment_id: 9001,
+      additional_prompt: "Check the maintainer-requested regression path.",
+    });
     const leaseId = String(payload.queue_lease_id || "");
     assert.match(leaseId, /^[0-9a-f-]{36}$/);
 
@@ -306,6 +320,12 @@ test("exact-review queue coalesces deliveries, leases bounded work, and rejects 
       }),
     );
     assert.deepEqual(await completed.json(), { ok: true, requeued: true });
+    const requeued = (await storage.get("exact-review-queue")) as {
+      items: Record<string, { decision: Record<string, unknown> }>;
+    };
+    assert.equal(requeued.items["openclaw/gogcli#597"].decision.commandStatusMarker, undefined);
+    assert.equal(requeued.items["openclaw/gogcli#597"].decision.statusCommentId, undefined);
+    assert.equal(requeued.items["openclaw/gogcli#597"].decision.additionalPrompt, undefined);
     const stats = await (
       await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
     ).json();
@@ -488,7 +508,10 @@ test("exact-review queue wakes while target capacity remains", async () => {
 });
 
 test("authenticated legacy exact-review intake enters the durable queue", async () => {
-  const queue = new ExactReviewQueue({ storage: new MemoryDurableStorage() }, {});
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  const commandStatusMarker =
+    "<!-- clawsweeper-command-status:597:re_review:0123456789abcdef0123456789abcdef01234567 -->";
   const payload = JSON.stringify({
     delivery_id: "legacy:100:1",
     decision: {
@@ -499,6 +522,9 @@ test("authenticated legacy exact-review intake enters the durable queue", async 
       sourceEvent: "issues",
       sourceAction: "legacy_dispatch",
       supersedesInProgress: false,
+      commandStatusMarker,
+      statusCommentId: "9001",
+      additionalPrompt: "Check the maintainer-requested regression path.",
     },
   });
   const signature = `sha256=${createHmac("sha256", "test-secret").update(payload).digest("hex")}`;
@@ -523,6 +549,21 @@ test("authenticated legacy exact-review intake enters the durable queue", async 
     queued: true,
     item_key: "openclaw/gogcli#597",
   });
+  const stored = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { decision: Record<string, unknown> }>;
+  };
+  assert.deepEqual(
+    {
+      commandStatusMarker: stored.items["openclaw/gogcli#597"].decision.commandStatusMarker,
+      statusCommentId: stored.items["openclaw/gogcli#597"].decision.statusCommentId,
+      additionalPrompt: stored.items["openclaw/gogcli#597"].decision.additionalPrompt,
+    },
+    {
+      commandStatusMarker,
+      statusCommentId: 9001,
+      additionalPrompt: "Check the maintainer-requested regression path.",
+    },
+  );
 
   const denied = await worker.fetch(
     new Request("https://clawsweeper.openclaw.ai/internal/exact-review/enqueue", {
@@ -536,6 +577,33 @@ test("authenticated legacy exact-review intake enters the durable queue", async 
     },
   );
   assert.equal(denied.status, 401);
+});
+
+test("exact-review queue rejects unbounded or unsafe command context", async () => {
+  const queue = new ExactReviewQueue({ storage: new MemoryDurableStorage() }, {});
+  const invalidDecisions = [
+    {
+      commandStatusMarker: "<!-- clawsweeper-command-status:597:re_review:na -->\nextra",
+    },
+    { statusCommentId: Number.MAX_SAFE_INTEGER + 1 },
+    { additionalPrompt: "x".repeat(5001) },
+    { additionalPrompt: "unsafe\0prompt" },
+  ];
+
+  for (const [index, decision] of invalidDecisions.entries()) {
+    const response = await queue.fetch(
+      buildExactReviewQueueRequest(
+        `invalid-command-context-${index}`,
+        597,
+        "legacy_dispatch",
+        "issue",
+        undefined,
+        decision,
+      ),
+    );
+    assert.equal(response.status, 400);
+    assert.deepEqual(await response.json(), { error: "invalid_exact_review_item" });
+  }
 });
 
 test("exact-review queue retries dispatch failures and reclaims an unclaimed lease", async () => {
@@ -4323,6 +4391,7 @@ function buildExactReviewQueueRequest(
   sourceAction: string,
   itemKind: "issue" | "pull_request" = "issue",
   targetRepo = "openclaw/gogcli",
+  decisionOverrides: Record<string, unknown> = {},
 ) {
   const sourceEvent = itemKind === "issue" ? "issues" : "pull_request";
   return new Request("https://clawsweeper-exact-review-queue/enqueue", {
@@ -4337,6 +4406,7 @@ function buildExactReviewQueueRequest(
         sourceEvent,
         sourceAction,
         supersedesInProgress: sourceAction === "edited" || sourceAction === "synchronize",
+        ...decisionOverrides,
       },
     }),
   });

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -980,6 +980,9 @@ test("sweep event reviews and target fanout avoid storm amplification", () => {
   assert.match(eventBlock, /cancel-in-progress: false/);
   assert.match(legacyIntakeBlock, /legacy-event-queue-intake:/);
   assert.match(legacyIntakeBlock, /\/internal\/exact-review\/enqueue/);
+  assert.match(legacyIntakeBlock, /commandStatusMarker: payload\.command_status_marker/);
+  assert.match(legacyIntakeBlock, /statusCommentId: payload\.status_comment_id/);
+  assert.match(legacyIntakeBlock, /additionalPrompt: payload\.additional_prompt/);
   assert.match(
     fanoutBlock,
     /FANOUT_LIMIT: \$\{\{ github\.event\.schedule == '41 \* \* \* \*' && '6' \|\| \(github\.event\.schedule == '37 \*\/6 \* \* \*' && '12' \|\| '6'\) \}\}/,
@@ -1017,7 +1020,7 @@ test("sweep exact event reviews consume adaptive Codex timeout payload", () => {
 
   assert.match(
     resolveBlock,
-    /ADAPTIVE_CODEX_TIMEOUT_MS: \$\{\{ github\.event\.client_payload\.codex_timeout_ms \|\| '' \}\}/,
+    /ADAPTIVE_CODEX_TIMEOUT_MS: \$\{\{ github\.event\.client_payload\.review_options\.codex_timeout_ms \|\| github\.event\.client_payload\.codex_timeout_ms \|\| '' \}\}/,
   );
   assert.match(
     resolveBlock,
@@ -1025,7 +1028,7 @@ test("sweep exact event reviews consume adaptive Codex timeout payload", () => {
   );
   assert.match(
     resolveBlock,
-    /MEDIA_PROOF_TIMEOUT_MS: \$\{\{ github\.event\.client_payload\.media_proof_timeout_ms \|\| '0' \}\}/,
+    /MEDIA_PROOF_TIMEOUT_MS: \$\{\{ github\.event\.client_payload\.review_options\.media_proof_timeout_ms \|\| github\.event\.client_payload\.media_proof_timeout_ms \|\| '0' \}\}/,
   );
   assert.match(resolveBlock, /Ignoring invalid adaptive codex_timeout_ms payload/);
   assert.match(


### PR DESCRIPTION
## Summary

- carry command status markers, status comment IDs, and additional review prompts through signed legacy intake and the durable exact-review queue
- validate and bound the stored command context while preserving pending commands across ordinary item-event coalescing
- nest optional review settings so leased repository dispatches remain below GitHub's ten-top-level-key limit
- consume the nested settings with backward-compatible flat-payload fallbacks

## Testing

- `pnpm run build:all`
- `node --test test/dashboard-worker.test.ts test/sweep-workflow.test.ts test/clawsweeper.test.ts` (173 passed)
- `pnpm run test:repair` (627 passed)
- `pnpm run check:active-surface`
- `pnpm run check:limits`
- `pnpm run lint`
- `pnpm run format:check`
- autoreview clean after addressing its repository-dispatch key-limit finding
