### PR TITLE
fix: preserve rebased state between publishes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Refreshed generated source paths after each state publish so later checkpoints cannot overwrite concurrent record, cursor, or report updates learned during a push rebase.
 - Retried infrastructure-failed issue reviews against their exact source revision through bounded one-shot asynchronous dispatch, requeued source drift once, and preserved retry attempts in separate durable state so ambiguous timeouts cannot overwrite completed reviews.
 - Stopped later CI reruns from resetting PR inactivity clocks by anchoring head activity to the latest source-triggered workflow run associated with that pull request.
 - Prioritized ready close decisions and bounded PR close-coverage proofs before slow policy-gated candidates, kept default 20-item continuations shareable, and retried malformed successful GitHub JSON responses.

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -156,13 +156,17 @@ export function publishMainCommit(options: GitPublishOptions): PublishResult {
   const maxAttempts = positiveInt(options.maxAttempts, 8);
   const pushAttempts = positiveInt(options.pushAttempts, 3);
   const rebaseStrategy = options.rebaseStrategy ?? "normal";
+  const stateBaseCommit = captureStatePublishBaseline();
 
   syncPublishPaths(options.paths);
   configureGitUser();
   stagePaths(options.paths);
   if (!hasStagedChanges()) {
     console.log("No publish changes");
-    return "unchanged";
+    if (stateBaseCommit && !pushCommit({ remote, branch, pushAttempts, rebaseStrategy })) {
+      throw new Error(`Failed to synchronize unchanged publish with ${remote}/${branch}`);
+    }
+    return completeStatePublish("unchanged", options.paths, stateBaseCommit);
   }
 
   const commitMessage = commitMessageForPublishedPaths(options.message, options.paths);
@@ -171,7 +175,9 @@ export function publishMainCommit(options: GitPublishOptions): PublishResult {
   restoreWorktree(options.restorePaths ?? []);
 
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-    if (pushCommit({ remote, branch, pushAttempts, rebaseStrategy })) return "committed";
+    if (pushCommit({ remote, branch, pushAttempts, rebaseStrategy })) {
+      return completeStatePublish("committed", options.paths, stateBaseCommit);
+    }
     const rebuildResult = rebuildPublishCommit({
       remote,
       branch,
@@ -179,7 +185,9 @@ export function publishMainCommit(options: GitPublishOptions): PublishResult {
       paths: options.paths,
       sourceCommit,
     });
-    if (rebuildResult === "unchanged") return "unchanged";
+    if (rebuildResult === "unchanged") {
+      return completeStatePublish("unchanged", options.paths, stateBaseCommit);
+    }
     if (attempt === maxAttempts) break;
     const delaySeconds = attempt * 3 + Math.floor(Math.random() * 11);
     console.log(
@@ -188,8 +196,146 @@ export function publishMainCommit(options: GitPublishOptions): PublishResult {
     sleep(delaySeconds * 1000);
   }
 
-  if (pushCommit({ remote, branch, pushAttempts, rebaseStrategy })) return "committed";
+  if (pushCommit({ remote, branch, pushAttempts, rebaseStrategy })) {
+    return completeStatePublish("committed", options.paths, stateBaseCommit);
+  }
   throw new Error(`Failed to publish commit after ${maxAttempts} attempts`);
+}
+
+function completeStatePublish(
+  result: PublishResult,
+  paths: readonly string[],
+  stateBaseCommit: string | null,
+): PublishResult {
+  refreshSourceAfterStatePublish(paths, stateBaseCommit);
+  return result;
+}
+
+export function captureStatePublishBaseline(): string | null {
+  return publishRoot() ? runGit(["rev-parse", "HEAD"]).trim() : null;
+}
+
+export function refreshSourceAfterStatePublish(
+  paths: readonly string[],
+  stateBaseCommit: string | null,
+): void {
+  const stateRoot = publishRoot();
+  if (!stateRoot) return;
+
+  for (const path of uniqueNonEmpty(paths)) {
+    refreshSourcePathFromState(path, stateRoot);
+  }
+
+  if (stateBaseCommit) {
+    const publishedPaths = uniqueNonEmpty(paths).map(normalizedPublishPath);
+    const changedPaths = runGit([
+      "diff",
+      "--no-renames",
+      "--name-only",
+      "-z",
+      stateBaseCommit,
+      "HEAD",
+    ])
+      .split("\0")
+      .filter(Boolean);
+    const authoritativeRecordPaths = learnedClosedRecordPaths(changedPaths, stateBaseCommit);
+    for (const path of authoritativeRecordPaths) {
+      if (!publishedPaths.some((root) => pathIsWithin(root, path))) {
+        refreshSourcePathFromState(path, stateRoot);
+      }
+    }
+    for (const path of changedPaths) {
+      if (
+        !isGeneratedPublishPath(path) ||
+        publishedPaths.some((root) => pathIsWithin(root, path)) ||
+        authoritativeRecordPaths.has(path)
+      ) {
+        continue;
+      }
+      // A narrow status publish can rebase over concurrent generated-state
+      // changes. Import only files that still match the pre-rebase snapshot so
+      // in-flight local work outside this publish remains authoritative.
+      if (!sourcePathMatchesStateCommit(path, stateBaseCommit)) continue;
+      refreshSourcePathFromState(path, stateRoot);
+    }
+  }
+}
+
+function learnedClosedRecordPaths(
+  changedPaths: readonly string[],
+  stateBaseCommit: string,
+): Set<string> {
+  const recordKeys = new Set<string>();
+  for (const path of changedPaths) {
+    const match = /^records\/([^/]+)\/(?:items|closed)\/([^/]+\.md)$/.exec(path);
+    if (match) recordKeys.add(`${match[1]}/${match[2]}`);
+  }
+
+  const authoritative = new Set<string>();
+  for (const key of recordKeys) {
+    const separator = key.indexOf("/");
+    const repository = key.slice(0, separator);
+    const file = key.slice(separator + 1);
+    const item = `records/${repository}/items/${file}`;
+    const closed = `records/${repository}/closed/${file}`;
+    if (
+      !commitHasPath("HEAD", item) &&
+      commitHasPath("HEAD", closed) &&
+      (commitHasPath(stateBaseCommit, item) || !commitHasPath(stateBaseCommit, closed))
+    ) {
+      // A concurrent close is an authoritative state transition, matching the
+      // delete-wins behavior of an apply-records rebase. Refresh the full
+      // record tuple so pending open-item or plan edits cannot resurrect it.
+      authoritative.add(item);
+      authoritative.add(closed);
+      authoritative.add(`records/${repository}/plans/${file}`);
+      authoritative.add(`records/${repository}/decision-packets/${file.replace(/\.md$/, ".json")}`);
+    }
+  }
+  return authoritative;
+}
+
+function refreshSourcePathFromState(path: string, stateRoot: string): void {
+  const sourceRoot = resolve(".");
+  const source = resolve(path);
+  const published = resolve(stateRoot, path);
+  if (!isPathInsideOrEqual(sourceRoot, source)) {
+    throw new Error(`Refusing to refresh outside source root: ${path}`);
+  }
+  if (!isPathInsideOrEqual(stateRoot, published)) {
+    throw new Error(`Refusing to refresh source from outside state root: ${path}`);
+  }
+  if (source === published) return;
+  if (isPathInsideOrEqual(source, stateRoot)) {
+    throw new Error(`Refusing to refresh a source path that contains the state root: ${path}`);
+  }
+  rmSync(source, { force: true, recursive: true });
+  if (!existsSync(published)) return;
+  mkdirSync(dirname(source), { recursive: true });
+  cpSync(published, source, { recursive: true });
+}
+
+function sourcePathMatchesStateCommit(path: string, commit: string): boolean {
+  const source = resolve(path);
+  const committed = spawnGit(["rev-parse", "--verify", `${commit}:${path}`], {
+    allowFailure: true,
+  });
+  if (committed.status !== 0) return !existsSync(source);
+  if (!existsSync(source) || !statSync(source).isFile()) return false;
+  const current = spawnGit(["hash-object", `--path=${path}`, source], { allowFailure: true });
+  return current.status === 0 && current.stdout.trim() === committed.stdout.trim();
+}
+
+function normalizedPublishPath(path: string): string {
+  return toPosixPath(path).replace(/^\.\//, "").replace(/\/+$/, "");
+}
+
+function pathIsWithin(root: string, path: string): boolean {
+  return root === path || path.startsWith(`${root}/`);
+}
+
+function isGeneratedPublishPath(path: string): boolean {
+  return GENERATED_PUBLISH_PATHS.some((root) => pathIsWithin(root, path));
 }
 
 export function publishRoot(): string | undefined {

--- a/src/repair/publish-event-result.ts
+++ b/src/repair/publish-event-result.ts
@@ -8,12 +8,14 @@ import {
   resetEventSnapshot,
 } from "./event-record-store.js";
 import {
+  captureStatePublishBaseline,
   commitMessageForPublishedPaths,
   configureGitUser,
   hardResetToRemoteMain,
   hasStagedChanges,
   publishRoot,
   pushCommit,
+  refreshSourceAfterStatePublish,
   runGit,
   setTokenOrigin,
   stagePaths,
@@ -110,16 +112,17 @@ async function publishEventResult(options: EventOptions): Promise<void> {
       closedCount,
       closeReasons: options.closeReasons,
     });
+  const stateBaseCommit = captureStatePublishBaseline();
 
   for (let attempt = 1; attempt <= 20; attempt += 1) {
-    if (publishSnapshot({ paths: recordPaths, options, summary })) return;
+    if (publishSnapshot({ paths: recordPaths, options, summary, stateBaseCommit })) return;
     const delaySeconds = attempt * 3 + Math.floor(Math.random() * 11);
     console.log(
       `Event publish attempt ${attempt} failed; retrying from origin/main in ${delaySeconds}s`,
     );
     await sleep(delaySeconds * 1000);
   }
-  if (!publishSnapshot({ paths: recordPaths, options, summary })) {
+  if (!publishSnapshot({ paths: recordPaths, options, summary, stateBaseCommit })) {
     throw new Error(
       `Failed to publish event result for ${options.targetRepo}#${options.itemNumber}`,
     );
@@ -130,12 +133,20 @@ function publishSnapshot({
   paths,
   options,
   summary,
+  stateBaseCommit,
 }: {
   paths: EventRecordPaths;
   options: EventOptions;
   summary: () => void;
+  stateBaseCommit: string | null;
 }): boolean {
+  const commitPaths = [paths.itemRecord, paths.closedRecord];
   try {
+    const complete = (): true => {
+      refreshSourceAfterStatePublish(commitPaths, stateBaseCommit);
+      summary();
+      return true;
+    };
     hardResetToRemoteMain();
     const stateRoot = publishRoot();
     if (
@@ -147,30 +158,25 @@ function publishSnapshot({
       console.log(
         `Remote already has closed record for ${paths.targetSlug}#${options.itemNumber}; skipping open-record publish`,
       );
-      summary();
-      return true;
+      return complete();
     }
     const snapshotResult = applyEventSnapshot(paths);
     if (snapshotResult === "remote-closed") {
       console.log(
         `Remote already has closed record for ${paths.targetSlug}#${options.itemNumber}; skipping open-record publish`,
       );
-      summary();
-      return true;
+      return complete();
     }
     if (snapshotResult === "missing") {
       console.log(`No event record snapshot for ${paths.targetSlug}#${options.itemNumber}`);
-      summary();
-      return true;
+      return complete();
     }
 
-    const commitPaths = [paths.itemRecord, paths.closedRecord];
     syncPublishPaths(commitPaths);
     stagePaths(commitPaths);
     if (!hasStagedChanges()) {
       console.log("No event result changes");
-      summary();
-      return true;
+      return complete();
     }
 
     runGit([
@@ -182,8 +188,7 @@ function publishSnapshot({
       ),
     ]);
     if (!pushCommit({ pushAttempts: 3 })) return false;
-    summary();
-    return true;
+    return complete();
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error));
     return false;

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -6,8 +6,11 @@ import { execFileSync } from "node:child_process";
 import test from "node:test";
 
 import {
+  captureStatePublishBaseline,
   commitMessageForPublishedPaths,
+  hardResetToRemoteMain,
   publishMainCommit,
+  refreshSourceAfterStatePublish,
   setTokenOrigin,
   uniqueNonEmpty,
 } from "../../dist/repair/git-publish.js";
@@ -230,6 +233,302 @@ test("publishMainCommit publishes generated paths to state branch when state roo
     "ledger\n",
   );
   assert.throws(() => run("git", ["--git-dir", origin, "show", "main:results/ledger.txt"], root));
+});
+
+test("state refresh reconciles retried direct publisher resets before broad publishes", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
+  const origin = path.join(root, "origin.git");
+  const work = path.join(root, "work");
+  const state = path.join(root, "state");
+  const other = path.join(root, "other");
+  const itemRecord = "records/openclaw-openclaw/items/1.md";
+  const closedRecord = "records/openclaw-openclaw/closed/1.md";
+  const concurrentJob = "jobs/openclaw/closed/123.md";
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, state], root);
+  configureUser(state);
+  write(path.join(state, itemRecord), "record base\n");
+  write(path.join(state, "jobs/openclaw/inbox/base.md"), "base job\n");
+  run("git", ["add", "."], state);
+  run("git", ["commit", "-m", "initial state"], state);
+  run("git", ["push", "origin", "HEAD:state"], state);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/state"], root);
+  run("git", ["checkout", "-B", "state", "origin/state"], state);
+
+  fs.mkdirSync(work);
+  fs.cpSync(path.join(state, "records"), path.join(work, "records"), { recursive: true });
+  fs.cpSync(path.join(state, "jobs"), path.join(work, "jobs"), { recursive: true });
+
+  run("git", ["clone", origin, other], root);
+  configureUser(other);
+  write(path.join(other, concurrentJob), "concurrent closed job\n");
+  run("git", ["add", "."], other);
+  run("git", ["commit", "-m", "concurrent job result"], other);
+  run("git", ["push", "origin", "HEAD:state"], other);
+
+  const result = withEnv({ CLAWSWEEPER_STATE_DIR: state }, () =>
+    withCwd(work, () => {
+      const baseline = captureStatePublishBaseline();
+      hardResetToRemoteMain();
+      assert.equal(fs.existsSync(path.join(work, concurrentJob)), false);
+      // A failed event attempt can reset the state checkout without completing
+      // its source refresh. Reuse the original baseline on the retry.
+      hardResetToRemoteMain();
+      refreshSourceAfterStatePublish([itemRecord, closedRecord], baseline);
+      assert.equal(
+        fs.readFileSync(path.join(work, concurrentJob), "utf8"),
+        "concurrent closed job\n",
+      );
+      return publishMainCommit({
+        message: "chore: publish event router ledger",
+        paths: ["jobs"],
+        maxAttempts: 1,
+        pushAttempts: 1,
+      });
+    }),
+  );
+
+  assert.equal(result, "unchanged");
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `state:${concurrentJob}`], root),
+    "concurrent closed job\n",
+  );
+});
+
+test("publishMainCommit refreshes published source paths after a state rebase", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
+  const origin = path.join(root, "origin.git");
+  const work = path.join(root, "work");
+  const state = path.join(root, "state");
+  const other = path.join(root, "other");
+  const recordOne = "records/openclaw-openclaw/items/1.md";
+  const recordTwo = "records/openclaw-openclaw/items/2.md";
+  const recordThree = "records/openclaw-openclaw/items/3.md";
+  const recordFour = "records/openclaw-openclaw/items/4.md";
+  const closedFour = "records/openclaw-openclaw/closed/4.md";
+  const planFour = "records/openclaw-openclaw/plans/4.md";
+  const packetFour = "records/openclaw-openclaw/decision-packets/4.json";
+  const recordFive = "records/openclaw-openclaw/items/5.md";
+  const closedFive = "records/openclaw-openclaw/closed/5.md";
+  const planFive = "records/openclaw-openclaw/plans/5.md";
+  const packetFive = "records/openclaw-openclaw/decision-packets/5.json";
+  const configPath = "config/new.json";
+  const craftedPath = "results/..\\config\\new.json";
+  const openclawCursor = "results/apply-cursors/openclaw-openclaw.json";
+  const clawhubCursor = "results/apply-cursors/openclaw-clawhub.json";
+  const sweepStatus = "results/sweep-status/openclaw-openclaw.json";
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, state], root);
+  configureUser(state);
+  write(path.join(state, recordOne), "record one base\n");
+  write(path.join(state, recordTwo), "record two base\n");
+  write(path.join(state, recordThree), "record three base\n");
+  write(path.join(state, recordFour), "record four base\n");
+  write(path.join(state, planFour), "plan four base\n");
+  write(path.join(state, packetFour), '{"decision":"base"}\n');
+  write(path.join(state, openclawCursor), '{"cursor":"openclaw-base"}\n');
+  write(path.join(state, clawhubCursor), '{"cursor":"clawhub-base"}\n');
+  write(path.join(state, sweepStatus), '{"status":"base"}\n');
+  write(path.join(state, "apply-report.json"), '[{"report":"base"}]\n');
+  write(path.join(state, configPath), "config base\n");
+  run("git", ["add", "."], state);
+  run("git", ["commit", "-m", "initial state"], state);
+  run("git", ["push", "origin", "HEAD:state"], state);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/state"], root);
+  run("git", ["checkout", "-B", "state", "origin/state"], state);
+  run("git", ["config", "core.autocrlf", "true"], state);
+
+  fs.mkdirSync(work);
+  fs.cpSync(path.join(state, "records"), path.join(work, "records"), { recursive: true });
+  fs.cpSync(path.join(state, "results"), path.join(work, "results"), { recursive: true });
+  fs.cpSync(path.join(state, "config"), path.join(work, "config"), { recursive: true });
+  fs.cpSync(path.join(state, "apply-report.json"), path.join(work, "apply-report.json"));
+
+  run("git", ["clone", origin, other], root);
+  configureUser(other);
+  write(path.join(other, recordTwo), "record two concurrent\n");
+  write(path.join(other, recordThree), "record three concurrent\n");
+  write(path.join(other, closedFour), fs.readFileSync(path.join(other, recordFour), "utf8"));
+  fs.rmSync(path.join(other, recordFour));
+  fs.rmSync(path.join(other, planFour));
+  fs.rmSync(path.join(other, packetFour));
+  write(path.join(other, closedFive), "record five closed concurrently\n");
+  write(path.join(other, configPath), "config concurrent\n");
+  write(path.join(other, craftedPath), "crafted generated path\n");
+  write(path.join(other, clawhubCursor), '{"cursor":"clawhub-concurrent"}\n');
+  write(path.join(other, "apply-report.json"), '[{"report":"concurrent"}]\n');
+  run("git", ["add", "-A"], other);
+  run("git", ["commit", "-m", "concurrent state update"], other);
+  run("git", ["push", "origin", "HEAD:state"], other);
+
+  write(path.join(work, recordTwo), "record two base\r\n");
+  write(path.join(work, recordThree), "record three pending local\n");
+  write(path.join(work, recordFour), "record four pending local\n");
+  write(path.join(work, planFour), "plan four pending local\n");
+  write(path.join(work, packetFour), '{"decision":"pending-local"}\n');
+  write(path.join(work, recordFive), "record five pending local\n");
+  write(path.join(work, planFive), "plan five pending local\n");
+  write(path.join(work, packetFive), '{"decision":"pending-local"}\n');
+  write(path.join(work, sweepStatus), '{"status":"checkpoint"}\n');
+  const results = withEnv({ CLAWSWEEPER_STATE_DIR: state }, () =>
+    withCwd(work, () => {
+      const first = publishMainCommit({
+        message: "chore: update checkpoint status",
+        paths: ["results/sweep-status"],
+        maxAttempts: 1,
+        pushAttempts: 1,
+        rebaseStrategy: "apply-records",
+      });
+
+      assert.equal(
+        fs.readFileSync(path.join(work, recordTwo), "utf8"),
+        "record two concurrent\r\n",
+      );
+      assert.equal(
+        fs.readFileSync(path.join(work, recordThree), "utf8"),
+        "record three pending local\n",
+      );
+      assert.equal(
+        fs.readFileSync(path.join(work, clawhubCursor), "utf8"),
+        '{"cursor":"clawhub-concurrent"}\r\n',
+      );
+      assert.equal(
+        fs.readFileSync(path.join(work, "apply-report.json"), "utf8"),
+        '[{"report":"concurrent"}]\r\n',
+      );
+      assert.equal(fs.existsSync(path.join(work, recordFour)), false);
+      assert.equal(fs.existsSync(path.join(work, planFour)), false);
+      assert.equal(fs.existsSync(path.join(work, packetFour)), false);
+      assert.equal(fs.readFileSync(path.join(work, closedFour), "utf8"), "record four base\r\n");
+      assert.equal(fs.existsSync(path.join(work, recordFive)), false);
+      assert.equal(fs.existsSync(path.join(work, planFive)), false);
+      assert.equal(fs.existsSync(path.join(work, packetFive)), false);
+      assert.equal(
+        fs.readFileSync(path.join(work, closedFive), "utf8"),
+        "record five closed concurrently\r\n",
+      );
+      assert.equal(fs.readFileSync(path.join(work, configPath), "utf8"), "config base\n");
+      assert.equal(
+        fs.readFileSync(path.join(work, craftedPath), "utf8"),
+        "crafted generated path\r\n",
+      );
+
+      write(path.join(work, recordOne), "record one checkpoint\n");
+      write(path.join(work, openclawCursor), '{"cursor":"openclaw-checkpoint"}\n');
+      const second = publishMainCommit({
+        message: "chore: apply checkpoint",
+        paths: ["records", "results/apply-cursors", "apply-report.json"],
+        maxAttempts: 1,
+        pushAttempts: 1,
+        rebaseStrategy: "apply-records",
+      });
+
+      run("git", ["fetch", "origin", "state"], other);
+      run("git", ["reset", "--hard", "origin/state"], other);
+      write(path.join(other, recordTwo), "record two concurrent again\n");
+      write(path.join(other, clawhubCursor), '{"cursor":"clawhub-concurrent-again"}\n');
+      write(path.join(other, "apply-report.json"), '[{"report":"concurrent-again"}]\n');
+      run("git", ["commit", "-am", "second concurrent state update"], other);
+      run("git", ["push", "origin", "HEAD:state"], other);
+
+      write(path.join(work, sweepStatus), '{"status":"checkpoint-again"}\n');
+      const third = publishMainCommit({
+        message: "chore: update checkpoint status again",
+        paths: ["results/sweep-status"],
+        maxAttempts: 1,
+        pushAttempts: 1,
+        rebaseStrategy: "apply-records",
+      });
+      assert.equal(
+        fs.readFileSync(path.join(work, recordTwo), "utf8"),
+        "record two concurrent again\r\n",
+      );
+      assert.equal(fs.existsSync(path.join(work, recordFour)), false);
+      assert.equal(fs.existsSync(path.join(work, packetFour)), false);
+
+      const fourth = publishMainCommit({
+        message: "chore: apply checkpoint again",
+        paths: ["records", "results/apply-cursors", "apply-report.json"],
+        maxAttempts: 1,
+        pushAttempts: 1,
+        rebaseStrategy: "apply-records",
+      });
+
+      run("git", ["fetch", "origin", "state"], other);
+      run("git", ["reset", "--hard", "origin/state"], other);
+      write(path.join(other, recordTwo), "record two concurrent before no-op\n");
+      run("git", ["commit", "-am", "concurrent state update before no-op"], other);
+      run("git", ["push", "origin", "HEAD:state"], other);
+
+      const fifth = publishMainCommit({
+        message: "chore: publish unchanged checkpoint status",
+        paths: ["results/sweep-status"],
+        maxAttempts: 1,
+        pushAttempts: 1,
+        rebaseStrategy: "apply-records",
+      });
+      assert.equal(
+        fs.readFileSync(path.join(work, recordTwo), "utf8"),
+        "record two concurrent before no-op\r\n",
+      );
+      const sixth = publishMainCommit({
+        message: "chore: apply unchanged checkpoint",
+        paths: ["records", "results/apply-cursors", "apply-report.json"],
+        maxAttempts: 1,
+        pushAttempts: 1,
+        rebaseStrategy: "apply-records",
+      });
+      return [first, second, third, fourth, fifth, sixth];
+    }),
+  );
+
+  assert.deepEqual(results, [
+    "committed",
+    "committed",
+    "committed",
+    "unchanged",
+    "unchanged",
+    "unchanged",
+  ]);
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `state:${recordOne}`], root),
+    "record one checkpoint\n",
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `state:${recordTwo}`], root),
+    "record two concurrent before no-op\n",
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `state:${recordThree}`], root),
+    "record three pending local\n",
+  );
+  assert.throws(() => run("git", ["--git-dir", origin, "show", `state:${recordFour}`], root));
+  assert.throws(() => run("git", ["--git-dir", origin, "show", `state:${planFour}`], root));
+  assert.throws(() => run("git", ["--git-dir", origin, "show", `state:${packetFour}`], root));
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `state:${closedFour}`], root),
+    "record four base\n",
+  );
+  assert.throws(() => run("git", ["--git-dir", origin, "show", `state:${recordFive}`], root));
+  assert.throws(() => run("git", ["--git-dir", origin, "show", `state:${planFive}`], root));
+  assert.throws(() => run("git", ["--git-dir", origin, "show", `state:${packetFive}`], root));
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `state:${closedFive}`], root),
+    "record five closed concurrently\n",
+  );
+  assert.equal(fs.readFileSync(path.join(work, configPath), "utf8"), "config base\n");
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `state:${openclawCursor}`], root),
+    '{"cursor":"openclaw-checkpoint"}\n',
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `state:${clawhubCursor}`], root),
+    '{"cursor":"clawhub-concurrent-again"}\n',
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", "state:apply-report.json"], root),
+    '[{"report":"concurrent-again"}]\n',
+  );
 });
 
 test("publishMainCommit preserves concurrent records from a newer state snapshot", () => {


### PR DESCRIPTION
## Summary

- refresh hydrated generated state after every successful state publish, including rebases and no-op publishes
- preserve concurrent record, cursor, report, job, and close-transition updates before later broad checkpoints
- route event-result reset/push retries through the same baseline-aware source refresh
- keep pending local edits unless a concurrent item-to-closed transition must win atomically across item, closed, plan, and decision-packet files

## Tests

- `pnpm run test:repair` (628 passed)
- `pnpm run build:repair && pnpm exec tsx --test test/repair/git-publish.test.ts` (13 passed)
- `pnpm run lint:repair`
- `pnpm run lint:scripts`
- `pnpm run format:check`
- `git diff --check`
- autoreview clean

The regression exercises repeated narrow-rebase-to-broad-publish cycles, a stale no-op state checkout, direct event publisher reset retries, CRLF clean filters, literal backslash paths, post-base closes, and authoritative record/plan/decision-packet deletion.
