### PR TITLE
fix: merge concurrent sweep status updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 - Refreshed generated source paths after each state publish so later checkpoints cannot overwrite concurrent record, cursor, or report updates learned during a push rebase.
 - Preserved bounded command status and prompt context through durable exact-review queue leases so successful re-reviews advance their original acknowledgement instead of remaining queued.
+- Preserved independently updated sweep status and nested apply-health snapshots across concurrent state publication retries with timestamp-safe three-way merging.
 - Retried infrastructure-failed issue reviews against their exact source revision through bounded one-shot asynchronous dispatch, requeued source drift once, and preserved retry attempts in separate durable state so ambiguous timeouts cannot overwrite completed reviews.
 - Stopped later CI reruns from resetting PR inactivity clocks by anchoring head activity to the latest source-triggered workflow run associated with that pull request.
 - Prioritized ready close decisions and bounded PR close-coverage proofs before slow policy-gated candidates, kept default 20-item continuations shareable, and retried malformed successful GitHub JSON responses.

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -1,10 +1,19 @@
 import { spawnSync } from "node:child_process";
-import { cpSync, existsSync, mkdirSync, readdirSync, rmSync, statSync } from "node:fs";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 
 import { clawsweeperGitUserEmail, clawsweeperGitUserName } from "./process-env.js";
+import { mergeSweepStatusJson } from "./sweep-status-merge.js";
 
 export type GitRunResult = {
   status: number;
@@ -28,6 +37,7 @@ export type RebaseStrategy = "normal" | "theirs" | "apply-records";
 export type GitRunOptions = {
   allowFailure?: boolean;
   displayArgs?: readonly string[];
+  quiet?: boolean;
 };
 
 export type PublishResult = "committed" | "unchanged";
@@ -84,8 +94,8 @@ export function spawnGit(args: readonly string[], options: GitRunOptions = {}): 
     env: process.env,
     encoding: "utf8",
   });
-  if (child.stdout) process.stdout.write(child.stdout);
-  if (child.stderr) process.stderr.write(child.stderr);
+  if (!options.quiet && child.stdout) process.stdout.write(child.stdout);
+  if (!options.quiet && child.stderr) process.stderr.write(child.stderr);
   return {
     status: child.status ?? 1,
     stdout: child.stdout ?? "",
@@ -502,13 +512,23 @@ export function pushCommit(options: {
   for (let pushAttempt = 1; pushAttempt <= pushAttempts; pushAttempt += 1) {
     if (spawnGit(["push", remote, `HEAD:${branch}`]).status === 0) return true;
     console.log(`Push attempt ${pushAttempt} lost the ${branch} race; rebasing`);
+    const localCommit = runGit(["rev-parse", "HEAD"], { quiet: true }).trim();
+    const localCommitMessage = runGit(["log", "-1", "--format=%B"], { quiet: true });
     runGit(["fetch", remote, branch], { allowFailure: true });
+    const remoteCommit = runGit(["rev-parse", `${remote}/${branch}`], { quiet: true }).trim();
+    const statusMerges = planSweepStatusMerges({ localCommit, remoteCommit });
     const rebaseArgs =
       rebaseStrategy === "theirs" || rebaseStrategy === "apply-records"
         ? ["rebase", "-X", "theirs", `${remote}/${branch}`]
         : ["rebase", `${remote}/${branch}`];
-    if (spawnGit(rebaseArgs).status !== 0) {
-      if (rebaseStrategy === "apply-records" && resolveApplyRecordConflicts()) continue;
+    if (spawnGit(rebaseArgs).status === 0) {
+      applySweepStatusMerges({ statusMerges, remoteCommit, localCommitMessage });
+      continue;
+    }
+    if (rebaseStrategy === "apply-records" && resolveApplyRecordConflicts(statusMerges)) {
+      applySweepStatusMerges({ statusMerges, remoteCommit, localCommitMessage });
+      continue;
+    } else {
       runGit(["rebase", "--abort"], { allowFailure: true });
       return false;
     }
@@ -525,7 +545,17 @@ function rebuildPublishCommit(options: {
 }): PublishResult {
   console.log(`Rebuilding publish commit on ${options.remote}/${options.branch}`);
   runGit(["fetch", options.remote, options.branch]);
-  runGit(["reset", "--hard", `${options.remote}/${options.branch}`]);
+  const remoteCommit = runGit(["rev-parse", `${options.remote}/${options.branch}`], {
+    quiet: true,
+  }).trim();
+  const statusMerges = planSweepStatusMerges({
+    baseCommit: runGit(["rev-parse", `${options.sourceCommit}^`], { quiet: true }).trim(),
+    localCommit: options.sourceCommit,
+    remoteCommit,
+    includeIndependent: true,
+    pathspecs: options.paths,
+  });
+  runGit(["reset", "--hard", remoteCommit]);
 
   for (const path of uniqueNonEmpty(options.paths)) {
     const preserved = preserveStateOnlyCommitFiles({ path, sourceCommit: options.sourceCommit });
@@ -540,6 +570,7 @@ function rebuildPublishCommit(options: {
     }
   }
 
+  applySweepStatusMergeFiles(statusMerges);
   stagePaths(options.paths);
   if (!hasStagedChanges()) {
     console.log("No publish changes after syncing remote");
@@ -590,17 +621,117 @@ function positiveInt(value: number | undefined, fallback: number): number {
   return value !== undefined && Number.isInteger(value) && value > 0 ? value : fallback;
 }
 
-function resolveApplyRecordConflicts(): boolean {
+type SweepStatusMerge = {
+  path: string;
+  content: string;
+};
+
+function planSweepStatusMerges(options: {
+  baseCommit?: string;
+  localCommit: string;
+  remoteCommit: string;
+  includeIndependent?: boolean;
+  pathspecs?: readonly string[];
+}): SweepStatusMerge[] {
+  const baseCommit =
+    options.baseCommit ??
+    runGit(["merge-base", options.localCommit, options.remoteCommit], { quiet: true }).trim();
+  if (!baseCommit) {
+    throw new Error("Refusing sweep status merge without a common Git base");
+  }
+  const localPaths = changedSweepStatusPaths(baseCommit, options.localCommit);
+  const remotePaths = changedSweepStatusPaths(baseCommit, options.remoteCommit);
+  const changedPaths = options.includeIndependent
+    ? new Set([...localPaths, ...remotePaths])
+    : new Set([...localPaths].filter((path) => remotePaths.has(path)));
+  const mergePaths = [...changedPaths].filter(
+    (path) =>
+      !options.pathspecs ||
+      options.pathspecs.some(
+        (pathspec) => path === pathspec || path.startsWith(`${pathspec.replace(/\/+$/, "")}/`),
+      ),
+  );
+  return mergePaths.sort().map((path) => ({
+    path,
+    content: mergeSweepStatusJson({
+      path,
+      baseText: readGitPath(baseCommit, path),
+      localText: readGitPath(options.localCommit, path),
+      remoteText: readGitPath(options.remoteCommit, path),
+    }),
+  }));
+}
+
+function changedSweepStatusPaths(baseCommit: string, commit: string): Set<string> {
+  const output = runGit(
+    ["diff", "--no-renames", "--name-only", "-z", baseCommit, commit, "--", "results/sweep-status"],
+    { quiet: true },
+  );
+  return new Set(
+    output.split("\0").filter((path) => /^results\/sweep-status\/[^/]+\.json$/.test(path)),
+  );
+}
+
+function readGitPath(commit: string, path: string): string | null {
+  const result = spawnGit(["show", `${commit}:${path}`], {
+    allowFailure: true,
+    displayArgs: ["show", "<commit>:<sweep-status-path>"],
+    quiet: true,
+  });
+  return result.status === 0 ? result.stdout : null;
+}
+
+function applySweepStatusMergeFiles(statusMerges: readonly SweepStatusMerge[]): void {
+  const root = publishRoot() ?? resolve(".");
+  for (const statusMerge of statusMerges) {
+    const destination = resolve(root, statusMerge.path);
+    if (!isPathInsideOrEqual(root, destination)) {
+      throw new Error(`Refusing to merge sweep status outside publish root: ${statusMerge.path}`);
+    }
+    mkdirSync(dirname(destination), { recursive: true });
+    writeFileSync(destination, statusMerge.content, "utf8");
+    runGit(["add", "--", statusMerge.path]);
+  }
+}
+
+function applySweepStatusMerges(options: {
+  statusMerges: readonly SweepStatusMerge[];
+  remoteCommit: string;
+  localCommitMessage: string;
+}): void {
+  if (options.statusMerges.length === 0) return;
+  applySweepStatusMergeFiles(options.statusMerges);
+  if (!hasStagedChanges()) return;
+  if (spawnGit(["diff", "--cached", "--quiet", options.remoteCommit]).status === 0) {
+    runGit(["reset", "--hard", options.remoteCommit]);
+    return;
+  }
+  const commitsAhead = Number(
+    runGit(["rev-list", "--count", `${options.remoteCommit}..HEAD`], { quiet: true }).trim(),
+  );
+  if (Number.isInteger(commitsAhead) && commitsAhead > 0) {
+    runGit(["commit", "--amend", "--no-edit"]);
+  } else {
+    runGit(["commit", "-m", options.localCommitMessage]);
+  }
+}
+
+function resolveApplyRecordConflicts(statusMerges: readonly SweepStatusMerge[]): boolean {
   const conflicts = runGit(["diff", "--name-only", "--diff-filter=U"], { allowFailure: true })
     .split(/\r?\n/)
     .map((path) => path.trim())
     .filter(Boolean);
   if (conflicts.length === 0) return false;
 
+  const statusMergePaths = new Set(statusMerges.map((entry) => entry.path));
+  applySweepStatusMergeFiles(statusMerges);
+
   for (const path of conflicts) {
     if (/^records\/[^/]+\/items\/[^/]+\.md$/.test(path)) {
       runGit(["rm", "-f", "--", path], { allowFailure: true });
     } else if (/^records\/[^/]+\/closed\/[^/]+\.md$/.test(path) || path === "apply-report.json") {
+      runGit(["add", "--", path]);
+    } else if (statusMergePaths.has(path)) {
       runGit(["add", "--", path]);
     } else {
       console.log(`Unsupported apply rebase conflict path: ${path}`);

--- a/src/repair/sweep-status-merge.ts
+++ b/src/repair/sweep-status-merge.ts
@@ -1,0 +1,333 @@
+import { isDeepStrictEqual } from "node:util";
+
+type JsonPrimitive = boolean | null | number | string;
+type JsonValue = JsonObject | JsonPrimitive | JsonValue[];
+type JsonObject = { [key: string]: JsonValue };
+
+const MISSING = Symbol("missing sweep status value");
+type MergeValue = JsonValue | typeof MISSING;
+
+const HEALTH_KEYS = new Set(["apply_health", "last_close_apply_health"]);
+const IMMUTABLE_KEYS = ["schema_version", "slug", "target_repo"] as const;
+const METADATA_KEYS = new Set([...IMMUTABLE_KEYS, "display_name"]);
+const STATUS_SNAPSHOT_KEYS = new Set([
+  "state",
+  "detail",
+  "run_url",
+  "planned_count",
+  "planned_capacity",
+  "planned_shards",
+  "active_codex",
+  "due_backlog",
+  "oldest_unreviewed_at",
+  "capacity_reason",
+  "inherited_label_cleanups",
+  "self_heal_conflict_repairs",
+  "failed_review_retries",
+  "failed_review_retry_exhaustions",
+  "bot_owned_proof_decisions_requested",
+  "bot_owned_proof_dispatches",
+  "updated_at",
+]);
+const ISO_TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
+
+export function mergeSweepStatusJson(options: {
+  path: string;
+  baseText: string | null;
+  localText: string | null;
+  remoteText: string | null;
+}): string {
+  const parsedBase = parseStatus(options.baseText, options.path, "base");
+  const local = parseStatus(options.localText, options.path, "local");
+  const remote = parseStatus(options.remoteText, options.path, "remote");
+  if (parsedBase !== null && (local === null || remote === null)) {
+    throw new Error(`Refusing to merge deleted sweep status ${options.path}`);
+  }
+  if (local === null && remote === null) {
+    throw new Error(`Refusing to merge missing sweep status ${options.path}`);
+  }
+  if (local === null || remote === null) {
+    const added = local ?? remote;
+    if (added === null) throw new Error(`Refusing to merge missing sweep status ${options.path}`);
+    assertStatusIdentity(options.path, added);
+    requiredTimestamp(
+      optionalTimestamp(added.updated_at, options.path, "added.updated_at"),
+      options.path,
+      "added.updated_at",
+    );
+    return `${JSON.stringify(added, null, 2)}\n`;
+  }
+
+  const base = parsedBase ?? (Object.create(null) as JsonObject);
+  assertImmutableIdentity(options.path, base, local, remote);
+
+  const localRootTimestamp = requiredTimestamp(
+    optionalTimestamp(local.updated_at, options.path, "local.updated_at"),
+    options.path,
+    "local.updated_at",
+  );
+  const remoteRootTimestamp = requiredTimestamp(
+    optionalTimestamp(remote.updated_at, options.path, "remote.updated_at"),
+    options.path,
+    "remote.updated_at",
+  );
+  const keys = new Set([...Object.keys(local), ...Object.keys(remote), ...Object.keys(base)]);
+  const snapshotKeys = new Set(STATUS_SNAPSHOT_KEYS);
+  for (const key of keys) {
+    if (!HEALTH_KEYS.has(key) && !METADATA_KEYS.has(key)) snapshotKeys.add(key);
+  }
+  const statusSnapshot = mergeStatusSnapshot({
+    path: options.path,
+    base,
+    local,
+    remote,
+    snapshotKeys,
+    localRootTimestamp,
+    remoteRootTimestamp,
+  });
+  const merged: JsonObject = Object.create(null) as JsonObject;
+
+  for (const key of keys) {
+    let value: MergeValue;
+    if (snapshotKeys.has(key)) {
+      value = ownValue(statusSnapshot, key);
+    } else if (HEALTH_KEYS.has(key)) {
+      value = mergeHealthSnapshot({
+        path: `${options.path}:${key}`,
+        base: ownValue(base, key),
+        local: ownValue(local, key),
+        remote: ownValue(remote, key),
+        localRootTimestamp,
+        remoteRootTimestamp,
+      });
+    } else {
+      value = mergeMetadataValue({
+        path: `${options.path}:${key}`,
+        base: ownValue(base, key),
+        local: ownValue(local, key),
+        remote: ownValue(remote, key),
+        localRootTimestamp,
+        remoteRootTimestamp,
+      });
+    }
+    if (value !== MISSING) merged[key] = value;
+  }
+
+  return `${JSON.stringify(merged, null, 2)}\n`;
+}
+
+function parseStatus(
+  text: string | null,
+  path: string,
+  side: "base" | "local" | "remote",
+): JsonObject | null {
+  if (text === null) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error(`Refusing to merge malformed sweep status JSON ${path} (${side})`);
+  }
+  if (!isJsonObject(parsed)) {
+    throw new Error(`Refusing to merge non-object sweep status JSON ${path} (${side})`);
+  }
+  assertStatusIdentity(path, parsed, side);
+  return parsed;
+}
+
+function assertStatusIdentity(
+  path: string,
+  status: JsonObject,
+  side?: "base" | "local" | "remote",
+): void {
+  const suffix = side ? ` (${side})` : "";
+  if (!Number.isInteger(status.schema_version) || Number(status.schema_version) < 1) {
+    throw new Error(
+      `Refusing to merge malformed sweep status identity ${path}:schema_version${suffix}`,
+    );
+  }
+  if (typeof status.slug !== "string" || !status.slug.trim()) {
+    throw new Error(`Refusing to merge malformed sweep status identity ${path}:slug${suffix}`);
+  }
+  if (typeof status.target_repo !== "string" || !status.target_repo.includes("/")) {
+    throw new Error(
+      `Refusing to merge malformed sweep status identity ${path}:target_repo${suffix}`,
+    );
+  }
+}
+
+function assertImmutableIdentity(
+  path: string,
+  base: JsonObject,
+  local: JsonObject,
+  remote: JsonObject,
+): void {
+  for (const key of IMMUTABLE_KEYS) {
+    const localValue = ownValue(local, key);
+    const remoteValue = ownValue(remote, key);
+    const baseValue = ownValue(base, key);
+    if (
+      !sameValue(localValue, remoteValue) ||
+      (baseValue !== MISSING && !sameValue(baseValue, localValue))
+    ) {
+      throw new Error(`Refusing to merge sweep status identity conflict ${path}:${key}`);
+    }
+  }
+}
+
+function mergeStatusSnapshot(options: {
+  path: string;
+  base: JsonObject;
+  local: JsonObject;
+  remote: JsonObject;
+  snapshotKeys: ReadonlySet<string>;
+  localRootTimestamp: number;
+  remoteRootTimestamp: number;
+}): JsonObject {
+  const base = selectKeys(options.base, options.snapshotKeys);
+  const local = selectKeys(options.local, options.snapshotKeys);
+  const remote = selectKeys(options.remote, options.snapshotKeys);
+  if (isDeepStrictEqual(local, remote)) return local;
+  if (isDeepStrictEqual(local, base)) return remote;
+  if (isDeepStrictEqual(remote, base)) return local;
+  return chooseNewer({
+    path: `${options.path}:status snapshot`,
+    local,
+    remote,
+    localTimestamp: options.localRootTimestamp,
+    remoteTimestamp: options.remoteRootTimestamp,
+  });
+}
+
+function mergeHealthSnapshot(options: {
+  path: string;
+  base: MergeValue;
+  local: MergeValue;
+  remote: MergeValue;
+  localRootTimestamp: number;
+  remoteRootTimestamp: number;
+}): MergeValue {
+  const simple = simpleThreeWay(options.base, options.local, options.remote);
+  if (simple !== undefined) return simple;
+  const localTimestamp = snapshotTimestamp(
+    options.local,
+    options.localRootTimestamp,
+    options.path,
+    "local",
+  );
+  const remoteTimestamp = snapshotTimestamp(
+    options.remote,
+    options.remoteRootTimestamp,
+    options.path,
+    "remote",
+  );
+  return chooseNewer({
+    path: options.path,
+    local: options.local,
+    remote: options.remote,
+    localTimestamp,
+    remoteTimestamp,
+  });
+}
+
+function mergeMetadataValue(options: {
+  path: string;
+  base: MergeValue;
+  local: MergeValue;
+  remote: MergeValue;
+  localRootTimestamp: number;
+  remoteRootTimestamp: number;
+}): MergeValue {
+  const simple = simpleThreeWay(options.base, options.local, options.remote);
+  if (simple !== undefined) return simple;
+  return chooseNewer({
+    path: options.path,
+    local: options.local,
+    remote: options.remote,
+    localTimestamp: options.localRootTimestamp,
+    remoteTimestamp: options.remoteRootTimestamp,
+  });
+}
+
+function simpleThreeWay(
+  base: MergeValue,
+  local: MergeValue,
+  remote: MergeValue,
+): MergeValue | undefined {
+  if (sameValue(local, remote)) return local;
+  if (sameValue(local, base)) return remote;
+  if (sameValue(remote, base)) return local;
+  return undefined;
+}
+
+function snapshotTimestamp(
+  value: MergeValue,
+  rootTimestamp: number,
+  path: string,
+  side: "local" | "remote",
+): number {
+  if (value !== MISSING && isJsonObject(value) && Object.hasOwn(value, "generated_at")) {
+    return requiredTimestamp(
+      optionalTimestamp(value.generated_at, path, `${side}.generated_at`),
+      path,
+      `${side}.generated_at`,
+    );
+  }
+  return rootTimestamp;
+}
+
+function optionalTimestamp(
+  value: JsonValue | undefined,
+  path: string,
+  label: string,
+): number | null {
+  if (value === undefined || value === null) return null;
+  if (
+    typeof value !== "string" ||
+    !ISO_TIMESTAMP_PATTERN.test(value) ||
+    !Number.isFinite(Date.parse(value))
+  ) {
+    throw new Error(`Refusing to merge sweep status with invalid timestamp ${path}:${label}`);
+  }
+  return Date.parse(value);
+}
+
+function requiredTimestamp(value: number | null, path: string, label: string): number {
+  if (value === null) {
+    throw new Error(`Refusing ambiguous sweep status merge without ${path}:${label}`);
+  }
+  return value;
+}
+
+function chooseNewer<T extends MergeValue | JsonObject>(options: {
+  path: string;
+  local: T;
+  remote: T;
+  localTimestamp: number;
+  remoteTimestamp: number;
+}): T {
+  if (options.localTimestamp > options.remoteTimestamp) return options.local;
+  if (options.remoteTimestamp > options.localTimestamp) return options.remote;
+  throw new Error(`Refusing ambiguous sweep status merge at equal timestamp ${options.path}`);
+}
+
+function selectKeys(source: JsonObject, keys: ReadonlySet<string>): JsonObject {
+  const selected: JsonObject = Object.create(null) as JsonObject;
+  for (const key of keys) {
+    if (Object.hasOwn(source, key)) selected[key] = source[key] as JsonValue;
+  }
+  return selected;
+}
+
+function ownValue(source: JsonObject, key: string): MergeValue {
+  return Object.hasOwn(source, key) ? (source[key] as JsonValue) : MISSING;
+}
+
+function sameValue(left: MergeValue, right: MergeValue): boolean {
+  if (left === MISSING || right === MISSING) return left === right;
+  return isDeepStrictEqual(left, right);
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -139,15 +139,268 @@ test("publishMainCommit resolves apply record delete conflicts during rebase", (
   );
 });
 
+test("publishMainCommit preserves status and health across apply and theirs publish races", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
+  const origin = path.join(root, "origin.git");
+  const work = path.join(root, "work");
+  const other = path.join(root, "other");
+  const statusFile = "results/sweep-status/openclaw-openclaw.json";
+  const initialHealth = sweepHealth("2026-07-09T20:00:00Z", "comment_sync", 1);
+  const firstCloseHealth = sweepHealth("2026-07-09T20:02:00Z", "close", 2);
+  const secondCloseHealth = sweepHealth("2026-07-09T20:04:00Z", "close", 3);
+
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, work], root);
+  configureUser(work);
+  writeJson(
+    path.join(work, statusFile),
+    sweepStatus("2026-07-09T20:00:01Z", "Initial", initialHealth, initialHealth),
+  );
+  run("git", ["add", "."], work);
+  run("git", ["commit", "-m", "initial"], work);
+  run("git", ["push", "origin", "HEAD:main"], work);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/main"], root);
+  run("git", ["checkout", "-B", "main", "origin/main"], work);
+
+  run("git", ["clone", origin, other], root);
+  configureUser(other);
+  writeJson(
+    path.join(other, statusFile),
+    sweepStatus("2026-07-09T20:02:01Z", "Remote close one", firstCloseHealth, firstCloseHealth),
+  );
+  run("git", ["commit", "-am", "remote close health one"], other);
+  run("git", ["push", "origin", "HEAD:main"], other);
+
+  writeJson(
+    path.join(work, statusFile),
+    sweepStatus("2026-07-09T20:03:00Z", "Local event one", initialHealth, initialHealth),
+  );
+  assert.equal(
+    withCwd(work, () =>
+      publishMainCommit({
+        message: "chore: publish event status one",
+        paths: [statusFile],
+        maxAttempts: 1,
+        pushAttempts: 1,
+        rebaseStrategy: "theirs",
+      }),
+    ),
+    "committed",
+  );
+  const first = readOriginJson(origin, `main:${statusFile}`, root);
+  assert.equal(first.state, "Local event one");
+  assert.deepEqual(first.apply_health, firstCloseHealth);
+  assert.deepEqual(first.last_close_apply_health, firstCloseHealth);
+
+  run("git", ["pull", "--ff-only"], other);
+  writeJson(
+    path.join(other, statusFile),
+    sweepStatus("2026-07-09T20:04:01Z", "Remote close two", secondCloseHealth, secondCloseHealth),
+  );
+  run("git", ["commit", "-am", "remote close health two"], other);
+  run("git", ["push", "origin", "HEAD:main"], other);
+
+  writeJson(
+    path.join(work, statusFile),
+    sweepStatus("2026-07-09T20:05:00Z", "Local event two", firstCloseHealth, firstCloseHealth),
+  );
+  assert.equal(
+    withCwd(work, () =>
+      publishMainCommit({
+        message: "chore: publish event status two",
+        paths: [statusFile],
+        maxAttempts: 1,
+        pushAttempts: 1,
+        rebaseStrategy: "apply-records",
+      }),
+    ),
+    "committed",
+  );
+  const second = readOriginJson(origin, `main:${statusFile}`, root);
+  assert.equal(second.state, "Local event two");
+  assert.deepEqual(second.apply_health, secondCloseHealth);
+  assert.deepEqual(second.last_close_apply_health, secondCloseHealth);
+});
+
+test("publishMainCommit drops a status commit fully superseded by the remote", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
+  const origin = path.join(root, "origin.git");
+  const work = path.join(root, "work");
+  const other = path.join(root, "other");
+  const statusFile = "results/sweep-status/openclaw-openclaw.json";
+  const initialHealth = sweepHealth("2026-07-09T20:00:00Z", "close", 1);
+  const localHealth = sweepHealth("2026-07-09T20:02:00Z", "close", 2);
+  const remoteHealth = sweepHealth("2026-07-09T20:03:00Z", "close", 3);
+
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, work], root);
+  configureUser(work);
+  writeJson(
+    path.join(work, statusFile),
+    sweepStatus("2026-07-09T20:00:01Z", "Initial", initialHealth, initialHealth),
+  );
+  run("git", ["add", "."], work);
+  run("git", ["commit", "-m", "initial"], work);
+  run("git", ["push", "origin", "HEAD:main"], work);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/main"], root);
+  run("git", ["checkout", "-B", "main", "origin/main"], work);
+
+  run("git", ["clone", origin, other], root);
+  configureUser(other);
+  writeJson(
+    path.join(other, statusFile),
+    sweepStatus("2026-07-09T20:03:01Z", "Remote newest", remoteHealth, remoteHealth),
+  );
+  run("git", ["commit", "-am", "newer remote status"], other);
+  run("git", ["push", "origin", "HEAD:main"], other);
+  const remoteHead = run("git", ["--git-dir", origin, "rev-parse", "main"], root).trim();
+
+  writeJson(
+    path.join(work, statusFile),
+    sweepStatus("2026-07-09T20:02:01Z", "Local older", localHealth, localHealth),
+  );
+  assert.equal(
+    withCwd(work, () =>
+      publishMainCommit({
+        message: "chore: publish superseded status",
+        paths: [statusFile],
+        maxAttempts: 1,
+        pushAttempts: 1,
+        rebaseStrategy: "apply-records",
+      }),
+    ),
+    "committed",
+  );
+
+  assert.equal(run("git", ["--git-dir", origin, "rev-parse", "main"], root).trim(), remoteHead);
+  assert.equal(run("git", ["rev-parse", "HEAD"], work).trim(), remoteHead);
+  const merged = readOriginJson(origin, `main:${statusFile}`, root);
+  assert.equal(merged.state, "Remote newest");
+  assert.deepEqual(merged.apply_health, remoteHealth);
+});
+
+test("publishMainCommit preserves latest health when a second race forces commit rebuild", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
+  const origin = path.join(root, "origin.git");
+  const work = path.join(root, "work");
+  const other = path.join(root, "other");
+  const statusFile = "results/sweep-status/openclaw-openclaw.json";
+  const initialHealth = sweepHealth("2026-07-09T20:00:00Z", "comment_sync", 1);
+  const firstCloseHealth = sweepHealth("2026-07-09T20:02:00Z", "close", 2);
+  const secondCloseHealth = sweepHealth("2026-07-09T20:02:30Z", "close", 3);
+
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, work], root);
+  configureUser(work);
+  writeJson(
+    path.join(work, statusFile),
+    sweepStatus("2026-07-09T20:00:01Z", "Initial", initialHealth, initialHealth),
+  );
+  run("git", ["add", "."], work);
+  run("git", ["commit", "-m", "initial"], work);
+  run("git", ["push", "origin", "HEAD:main"], work);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/main"], root);
+  run("git", ["checkout", "-B", "main", "origin/main"], work);
+
+  run("git", ["clone", origin, other], root);
+  configureUser(other);
+  writeJson(
+    path.join(other, statusFile),
+    sweepStatus("2026-07-09T20:02:01Z", "Remote close one", firstCloseHealth, firstCloseHealth),
+  );
+  run("git", ["commit", "-am", "remote close health one"], other);
+  run("git", ["push", "origin", "HEAD:main"], other);
+  writeJson(
+    path.join(other, statusFile),
+    sweepStatus("2026-07-09T20:02:31Z", "Remote close two", secondCloseHealth, secondCloseHealth),
+  );
+  run("git", ["commit", "-am", "remote close health two"], other);
+  installSecondPushRaceHook(work, other);
+
+  writeJson(
+    path.join(work, statusFile),
+    sweepStatus("2026-07-09T20:03:00Z", "Local event", initialHealth, initialHealth),
+  );
+  assert.equal(
+    withCwd(work, () =>
+      publishMainCommit({
+        message: "chore: publish event status",
+        paths: [statusFile],
+        maxAttempts: 1,
+        pushAttempts: 1,
+        rebaseStrategy: "apply-records",
+      }),
+    ),
+    "committed",
+  );
+
+  const merged = readOriginJson(origin, `main:${statusFile}`, root);
+  assert.equal(merged.state, "Local event");
+  assert.deepEqual(merged.apply_health, secondCloseHealth);
+  assert.deepEqual(merged.last_close_apply_health, secondCloseHealth);
+});
+
+test("publishMainCommit fails closed when a racing sweep status is malformed", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
+  const origin = path.join(root, "origin.git");
+  const work = path.join(root, "work");
+  const other = path.join(root, "other");
+  const statusFile = "results/sweep-status/openclaw-openclaw.json";
+  const initialHealth = sweepHealth("2026-07-09T20:00:00Z", "close", 1);
+
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, work], root);
+  configureUser(work);
+  writeJson(
+    path.join(work, statusFile),
+    sweepStatus("2026-07-09T20:00:01Z", "Initial", initialHealth, initialHealth),
+  );
+  run("git", ["add", "."], work);
+  run("git", ["commit", "-m", "initial"], work);
+  run("git", ["push", "origin", "HEAD:main"], work);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/main"], root);
+  run("git", ["checkout", "-B", "main", "origin/main"], work);
+
+  run("git", ["clone", origin, other], root);
+  configureUser(other);
+  write(path.join(other, statusFile), "{broken\n");
+  run("git", ["commit", "-am", "malformed remote status"], other);
+  run("git", ["push", "origin", "HEAD:main"], other);
+
+  writeJson(
+    path.join(work, statusFile),
+    sweepStatus("2026-07-09T20:02:00Z", "Local event", initialHealth, initialHealth),
+  );
+  assert.throws(
+    () =>
+      withCwd(work, () =>
+        publishMainCommit({
+          message: "chore: publish valid status",
+          paths: [statusFile],
+          maxAttempts: 1,
+          pushAttempts: 1,
+          rebaseStrategy: "apply-records",
+        }),
+      ),
+    /malformed sweep status JSON/,
+  );
+  assert.equal(run("git", ["--git-dir", origin, "show", `main:${statusFile}`], root), "{broken\n");
+});
+
 test("publishMainCommit rebuilds generated state commits without deleting concurrent records", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
   const origin = path.join(root, "origin.git");
   const work = path.join(root, "work");
   const other = path.join(root, "other");
+  const statusFile = "results/sweep-status/openclaw-openclaw.json";
+  const initialHealth = sweepHealth("2026-07-09T20:00:00Z", "comment_sync", 1);
   run("git", ["init", "--bare", origin], root);
   run("git", ["clone", origin, work], root);
   configureUser(work);
-  write(path.join(work, "results/sweep-status/openclaw-openclaw.json"), "{}\n");
+  writeJson(
+    path.join(work, statusFile),
+    sweepStatus("2026-07-09T20:00:01Z", "Initial", initialHealth, initialHealth),
+  );
   write(path.join(work, "records/openclaw-openclaw/items/1.md"), "record old\n");
   write(path.join(work, "keep.txt"), "keep old\n");
   run("git", ["add", "."], work);
@@ -158,7 +411,10 @@ test("publishMainCommit rebuilds generated state commits without deleting concur
 
   run("git", ["clone", origin, other], root);
   configureUser(other);
-  write(path.join(other, "results/sweep-status/openclaw-openclaw.json"), '{"state":"remote"}\n');
+  writeJson(
+    path.join(other, statusFile),
+    sweepStatus("2026-07-09T20:01:00Z", "Remote", initialHealth, initialHealth),
+  );
   write(path.join(other, "records/openclaw-openclaw/items/1.md"), "record remote\n");
   write(path.join(other, "records/openclaw-openclaw/items/2.md"), "remote only\n");
   write(path.join(other, "keep.txt"), "keep remote\n");
@@ -166,7 +422,10 @@ test("publishMainCommit rebuilds generated state commits without deleting concur
   run("git", ["commit", "-m", "remote generated state update"], other);
   run("git", ["push", "origin", "HEAD:main"], other);
 
-  write(path.join(work, "results/sweep-status/openclaw-openclaw.json"), '{"state":"local"}\n');
+  writeJson(
+    path.join(work, statusFile),
+    sweepStatus("2026-07-09T20:02:00Z", "Local", initialHealth, initialHealth),
+  );
   write(path.join(work, "records/openclaw-openclaw/items/1.md"), "record local\n");
 
   const result = withCwd(work, () =>
@@ -179,14 +438,7 @@ test("publishMainCommit rebuilds generated state commits without deleting concur
   );
 
   assert.equal(result, "committed");
-  assert.equal(
-    run(
-      "git",
-      ["--git-dir", origin, "show", "main:results/sweep-status/openclaw-openclaw.json"],
-      root,
-    ),
-    '{"state":"local"}\n',
-  );
+  assert.equal(readOriginJson(origin, `main:${statusFile}`, root).state, "Local");
   assert.equal(
     run("git", ["--git-dir", origin, "show", "main:records/openclaw-openclaw/items/1.md"], root),
     "record local\n",
@@ -233,6 +485,82 @@ test("publishMainCommit publishes generated paths to state branch when state roo
     "ledger\n",
   );
   assert.throws(() => run("git", ["--git-dir", origin, "show", "main:results/ledger.txt"], root));
+});
+
+test("publishMainCommit refreshes merged health before the next state-root status publish", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
+  const origin = path.join(root, "origin.git");
+  const work = path.join(root, "work");
+  const state = path.join(root, "state");
+  const other = path.join(root, "other");
+  const statusFile = "results/sweep-status/openclaw-openclaw.json";
+  const initialHealth = sweepHealth("2026-07-09T20:00:00Z", "comment_sync", 1);
+  const closeHealth = sweepHealth("2026-07-09T20:02:00Z", "close", 2);
+
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, state], root);
+  configureUser(state);
+  writeJson(
+    path.join(state, statusFile),
+    sweepStatus("2026-07-09T20:00:01Z", "Initial", initialHealth, initialHealth),
+  );
+  run("git", ["add", "."], state);
+  run("git", ["commit", "-m", "initial state"], state);
+  run("git", ["push", "origin", "HEAD:state"], state);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/state"], root);
+  run("git", ["checkout", "-B", "state", "origin/state"], state);
+
+  fs.mkdirSync(work);
+  fs.cpSync(path.join(state, "results"), path.join(work, "results"), { recursive: true });
+  run("git", ["clone", origin, other], root);
+  configureUser(other);
+  writeJson(
+    path.join(other, statusFile),
+    sweepStatus("2026-07-09T20:02:01Z", "Remote close", closeHealth, closeHealth),
+  );
+  run("git", ["commit", "-am", "remote close health"], other);
+  run("git", ["push", "origin", "HEAD:state"], other);
+
+  writeJson(
+    path.join(work, statusFile),
+    sweepStatus("2026-07-09T20:03:00Z", "Local checkpoint", initialHealth, initialHealth),
+  );
+  const results = withEnv({ CLAWSWEEPER_STATE_DIR: state }, () =>
+    withCwd(work, () => {
+      const first = publishMainCommit({
+        message: "chore: publish checkpoint status",
+        paths: [statusFile],
+        maxAttempts: 1,
+        pushAttempts: 1,
+        rebaseStrategy: "theirs",
+      });
+      const learned = JSON.parse(fs.readFileSync(path.join(work, statusFile), "utf8"));
+      assert.equal(learned.state, "Local checkpoint");
+      assert.deepEqual(learned.apply_health, closeHealth);
+      assert.deepEqual(learned.last_close_apply_health, closeHealth);
+
+      writeJson(path.join(work, statusFile), {
+        ...learned,
+        state: "Local final",
+        detail: "Local final detail",
+        updated_at: "2026-07-09T20:04:00Z",
+      });
+      const second = publishMainCommit({
+        message: "chore: publish final status",
+        paths: [statusFile],
+        maxAttempts: 1,
+        pushAttempts: 1,
+        rebaseStrategy: "theirs",
+      });
+      return [first, second];
+    }),
+  );
+
+  assert.deepEqual(results, ["committed", "committed"]);
+  const published = readOriginJson(origin, `state:${statusFile}`, root);
+  assert.equal(published.state, "Local final");
+  assert.deepEqual(published.apply_health, closeHealth);
+  assert.deepEqual(published.last_close_apply_health, closeHealth);
 });
 
 test("state refresh reconciles retried direct publisher resets before broad publishes", () => {
@@ -819,6 +1147,55 @@ function configureUser(cwd) {
 function write(file, content) {
   fs.mkdirSync(path.dirname(file), { recursive: true });
   fs.writeFileSync(file, content);
+}
+
+function writeJson(file, value) {
+  write(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function readOriginJson(origin, revision, cwd) {
+  return JSON.parse(run("git", ["--git-dir", origin, "show", revision], cwd));
+}
+
+function sweepStatus(updatedAt, state, applyHealth, lastCloseApplyHealth) {
+  return {
+    schema_version: 1,
+    slug: "openclaw-openclaw",
+    display_name: "OpenClaw",
+    target_repo: "openclaw/openclaw",
+    state,
+    detail: `${state} detail`,
+    run_url: "https://github.com/openclaw/clawsweeper/actions/runs/1",
+    apply_health: applyHealth,
+    last_close_apply_health: lastCloseApplyHealth,
+    updated_at: updatedAt,
+  };
+}
+
+function sweepHealth(generatedAt, mode, processed) {
+  return {
+    schema_version: 1,
+    generated_at: generatedAt,
+    target_repo: "openclaw/openclaw",
+    mode,
+    processed,
+  };
+}
+
+function installSecondPushRaceHook(work, other) {
+  const hook = path.join(work, ".git/hooks/pre-push");
+  const counter = path.join(work, ".git/hooks/pre-push-count");
+  fs.writeFileSync(
+    hook,
+    `#!/bin/sh
+count=0
+if test -f "${counter}"; then count=$(cat "${counter}"); fi
+count=$((count + 1))
+printf '%s\\n' "$count" > "${counter}"
+if test "$count" -eq 2; then git -C "${other}" push origin HEAD:main; fi
+`,
+  );
+  fs.chmodSync(hook, 0o755);
 }
 
 function captureConsoleLog(callback) {

--- a/test/repair/sweep-status-merge.test.ts
+++ b/test/repair/sweep-status-merge.test.ts
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { mergeSweepStatusJson } from "../../dist/repair/sweep-status-merge.js";
+
+const statusPath = "results/sweep-status/openclaw-openclaw.json";
+
+test("mergeSweepStatusJson preserves newer top-level status and independent remote health", () => {
+  const initialHealth = health("2026-07-09T20:00:00Z", "comment_sync", 1);
+  const remoteHealth = health("2026-07-09T20:59:00Z", "close", 2);
+  const base = status("2026-07-09T20:00:01Z", "Applying", initialHealth, initialHealth);
+  const local = status("2026-07-09T21:02:00Z", "Complete", initialHealth, initialHealth);
+  const remote = status("2026-07-09T20:59:01Z", "Applying close", remoteHealth, remoteHealth);
+
+  const merged = merge({ base, local, remote });
+
+  assert.equal(merged.state, "Complete");
+  assert.equal(merged.detail, "Complete detail");
+  assert.equal(merged.updated_at, "2026-07-09T21:02:00Z");
+  assert.deepEqual(merged.apply_health, remoteHealth);
+  assert.deepEqual(merged.last_close_apply_health, remoteHealth);
+});
+
+test("mergeSweepStatusJson timestamps top-level and health conflicts independently", () => {
+  const baseHealth = health("2026-07-09T20:00:00Z", "close", 1);
+  const localHealth = health("2026-07-09T21:06:00Z", "close", 2);
+  const remoteHealth = health("2026-07-09T21:05:00Z", "close", 3);
+  const base = status("2026-07-09T20:00:01Z", "Base", baseHealth, baseHealth);
+  const local = status("2026-07-09T21:07:00Z", "Local", localHealth, localHealth);
+  const remote = status("2026-07-09T21:08:00Z", "Remote", remoteHealth, remoteHealth);
+
+  const merged = merge({ base, local, remote });
+
+  assert.equal(merged.state, "Remote");
+  assert.equal(merged.updated_at, "2026-07-09T21:08:00Z");
+  assert.deepEqual(merged.apply_health, localHealth);
+  assert.deepEqual(merged.last_close_apply_health, localHealth);
+});
+
+test("mergeSweepStatusJson keeps future top-level fields in the atomic status snapshot", () => {
+  const baseHealth = health("2026-07-09T20:00:00Z", "close", 1);
+  const base = {
+    ...status("2026-07-09T20:00:01Z", "Base", baseHealth, baseHealth),
+    future_phase: "base",
+    future_count: 0,
+  };
+  const local = {
+    ...status("2026-07-09T21:00:00Z", "Local", baseHealth, baseHealth),
+    future_phase: "local",
+    future_count: 0,
+  };
+  const remote = {
+    ...status("2026-07-09T21:01:00Z", "Remote", baseHealth, baseHealth),
+    future_phase: "base",
+    future_count: 2,
+  };
+
+  const merged = merge({ base, local, remote });
+
+  assert.equal(merged.state, "Remote");
+  assert.equal(merged.future_phase, "base");
+  assert.equal(merged.future_count, 2);
+});
+
+test("mergeSweepStatusJson rejects equal-timestamp same-key conflicts", () => {
+  const baseHealth = health("2026-07-09T20:00:00Z", "close", 1);
+  const base = status("2026-07-09T20:00:01Z", "Base", baseHealth, baseHealth);
+  const local = status("2026-07-09T21:00:00Z", "Local", baseHealth, baseHealth);
+  const remote = status("2026-07-09T21:00:00Z", "Remote", baseHealth, baseHealth);
+
+  assert.throws(
+    () => merge({ base, local, remote }),
+    /ambiguous sweep status merge at equal timestamp.*status snapshot/,
+  );
+
+  const localHealth = health("2026-07-09T21:30:00Z", "close", 2);
+  const remoteHealth = health("2026-07-09T21:30:00Z", "close", 3);
+  assert.throws(
+    () =>
+      merge({
+        base,
+        local: status("2026-07-09T21:31:00Z", "Local", localHealth, localHealth),
+        remote: status("2026-07-09T21:32:00Z", "Remote", remoteHealth, remoteHealth),
+      }),
+    /ambiguous sweep status merge at equal timestamp.*apply_health/,
+  );
+});
+
+test("mergeSweepStatusJson fails closed for malformed, invalid, and deleted status", () => {
+  const initialHealth = health("2026-07-09T20:00:00Z", "close", 1);
+  const base = status("2026-07-09T20:00:01Z", "Base", initialHealth, initialHealth);
+  const local = status("2026-07-09T21:00:00Z", "Local", initialHealth, initialHealth);
+  const remote = status("2026-07-09T21:01:00Z", "Remote", initialHealth, initialHealth);
+
+  assert.throws(
+    () =>
+      mergeSweepStatusJson({
+        path: statusPath,
+        baseText: JSON.stringify(base),
+        localText: JSON.stringify(local),
+        remoteText: "{broken",
+      }),
+    /malformed sweep status JSON/,
+  );
+  assert.throws(
+    () =>
+      merge({
+        base,
+        local: { ...local, updated_at: "today" },
+        remote,
+      }),
+    /invalid timestamp/,
+  );
+  assert.throws(
+    () =>
+      mergeSweepStatusJson({
+        path: statusPath,
+        baseText: JSON.stringify(base),
+        localText: JSON.stringify(local),
+        remoteText: null,
+      }),
+    /deleted sweep status/,
+  );
+});
+
+test("mergeSweepStatusJson accepts an independently added valid status", () => {
+  const added = status("2026-07-09T21:00:00Z", "Added", null, null);
+  const merged = JSON.parse(
+    mergeSweepStatusJson({
+      path: statusPath,
+      baseText: null,
+      localText: null,
+      remoteText: JSON.stringify(added),
+    }),
+  );
+
+  assert.deepEqual(merged, added);
+});
+
+function merge({ base, local, remote }) {
+  return JSON.parse(
+    mergeSweepStatusJson({
+      path: statusPath,
+      baseText: JSON.stringify(base),
+      localText: JSON.stringify(local),
+      remoteText: JSON.stringify(remote),
+    }),
+  );
+}
+
+function status(updatedAt, state, applyHealth, lastCloseApplyHealth) {
+  return {
+    schema_version: 1,
+    slug: "openclaw-openclaw",
+    display_name: "OpenClaw",
+    target_repo: "openclaw/openclaw",
+    state,
+    detail: `${state} detail`,
+    run_url: "https://github.com/openclaw/clawsweeper/actions/runs/1",
+    apply_health: applyHealth,
+    last_close_apply_health: lastCloseApplyHealth,
+    updated_at: updatedAt,
+  };
+}
+
+function health(generatedAt, mode, processed) {
+  return {
+    schema_version: 1,
+    generated_at: generatedAt,
+    target_repo: "openclaw/openclaw",
+    mode,
+    processed,
+  };
+}


### PR DESCRIPTION
## Summary

- merge concurrent `results/sweep-status/*.json` updates with an atomic top-level run snapshot and independently timestamped apply-health snapshots
- apply the semantic merge across normal, `theirs`, apply-record, and rebuilt publish commits; fail closed on malformed, deleted, identity-conflicting, or timestamp-ambiguous state
- preserve merged state in the source checkout so a following checkpoint cannot regress it

## Validation

- `pnpm run build:all`
- `pnpm run lint`
- `node --test test/repair/sweep-status-merge.test.ts test/repair/git-publish.test.ts` (24/24)
- `pnpm run format:check`
- final autoreview clean with no accepted/actionable findings

The broad local check reached 725/729 tests; four unrelated load-sensitive runtime/process tests missed their timing windows or hit a transient child-process `EPIPE`. The focused publish and merge suites pass in full.
