### PR TITLE
fix: publish review records atomically

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1638,6 +1638,9 @@ jobs:
           pnpm run repair:publish-main -- \
             --message "chore: update sweep records" \
             --path "records/${target_slug}" \
+            --rebase-strategy reconcile-records
+          pnpm run repair:publish-main -- \
+            --message "chore: update sweep status" \
             --path "results/sweep-status/${target_slug}.json" \
             --rebase-strategy theirs
 
@@ -1870,6 +1873,9 @@ jobs:
           pnpm run repair:publish-main -- \
             --message "chore: sync selected review comments" \
             --path "records/${target_slug}" \
+            --rebase-strategy reconcile-records
+          pnpm run repair:publish-main -- \
+            --message "chore: publish selected review comment status" \
             --path apply-report.json \
             --path "results/sweep-status/${target_slug}.json" \
             --rebase-strategy theirs
@@ -1930,6 +1936,9 @@ jobs:
           pnpm run repair:publish-main -- \
             --message "chore: apply selected sweep decisions" \
             --path "records/${target_slug}" \
+            --rebase-strategy reconcile-records
+          pnpm run repair:publish-main -- \
+            --message "chore: publish selected sweep decision status" \
             --path apply-report.json \
             --path "results/sweep-status/${target_slug}.json" \
             --rebase-strategy theirs
@@ -2233,8 +2242,11 @@ jobs:
           target_slug="${target_slug//\//-}"
           pnpm run repair:publish-main -- \
             --message "chore: update sweep audit state" \
-            --path README.md \
             --path "records/${target_slug}" \
+            --rebase-strategy reconcile-records
+          pnpm run repair:publish-main -- \
+            --message "chore: publish sweep audit status" \
+            --path README.md \
             --path "results/audit/${target_slug}.json" \
             --path "results/sweep-status/${target_slug}.json" \
             --rebase-strategy theirs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Published exact-review records, plans, and decision packets as one validated tuple, and made broad sweep publishers preserve the semantically newer tuple and independently merged status health instead of replaying stale review state.
 - Kept exact-review work pending with an explicit bounded retry when GitHub Actions cannot confirm that the executor workflow is active, instead of reporting silent repository dispatches to a disabled workflow as occupied capacity.
 - Refreshed generated source paths after each state publish so later checkpoints cannot overwrite concurrent record, cursor, or report updates learned during a push rebase.
 - Preserved bounded command status and prompt context through durable exact-review queue leases so successful re-reviews advance their original acknowledgement instead of remaining queued.

--- a/scripts/apply-workflow-helpers.sh
+++ b/scripts/apply-workflow-helpers.sh
@@ -23,7 +23,26 @@ publish_changes_with_strategy() {
 publish_changes() {
   local message="$1"
   shift
-  publish_changes_with_strategy apply-records "$message" "$@"
+  local target_slug="${TARGET_REPO,,}"
+  target_slug="${target_slug//\//-}"
+  local record_paths=()
+  local other_paths=()
+  local path
+  for path in "$@"; do
+    if [ "$path" = "records" ]; then
+      record_paths+=("records/${target_slug}")
+    elif [[ "$path" = records/* ]]; then
+      record_paths+=("$path")
+    else
+      other_paths+=("$path")
+    fi
+  done
+  if [ "${#record_paths[@]}" -gt 0 ]; then
+    publish_changes_with_strategy reconcile-records "$message" "${record_paths[@]}" || return 1
+  fi
+  if [ "${#other_paths[@]}" -gt 0 ]; then
+    publish_changes_with_strategy apply-records "$message" "${other_paths[@]}" || return 1
+  fi
 }
 
 publish_status() {

--- a/src/repair/event-record-store.ts
+++ b/src/repair/event-record-store.ts
@@ -1,6 +1,13 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import {
+  chooseRecordTupleWinner,
+  recordTuplePaths,
+  type RecordTupleContents,
+  type RecordTuplePaths,
+} from "./record-tuple.js";
+
 export type EventRecordStore = {
   targetRepo: string;
   itemNumber: string;
@@ -11,51 +18,170 @@ export type EventRecordPaths = {
   targetSlug: string;
   itemRecord: string;
   closedRecord: string;
+  planRecord: string;
+  decisionPacket: string;
+  snapshotBaseItem: string;
+  snapshotBaseClosed: string;
+  snapshotBasePlan: string;
+  snapshotBaseDecisionPacket: string;
   snapshotItem: string;
   snapshotClosed: string;
+  snapshotPlan: string;
+  snapshotDecisionPacket: string;
 };
 
-export type EventSnapshotApplyResult = "closed" | "open" | "remote-closed" | "missing";
+export type EventSnapshotApplyResult =
+  | "closed"
+  | "open"
+  | "remote-closed"
+  | "remote-newer"
+  | "missing";
 
 export function eventRecordPaths(store: EventRecordStore): EventRecordPaths {
   const targetSlug = store.targetRepo.replace("/", "-");
+  const tuple = recordTuplePaths({ repository: targetSlug, number: store.itemNumber });
   return {
     targetSlug,
-    itemRecord: `records/${targetSlug}/items/${store.itemNumber}.md`,
-    closedRecord: `records/${targetSlug}/closed/${store.itemNumber}.md`,
-    snapshotItem: path.join(store.snapshotDir, "items", `${store.itemNumber}.md`),
-    snapshotClosed: path.join(store.snapshotDir, "closed", `${store.itemNumber}.md`),
+    itemRecord: tuple.item,
+    closedRecord: tuple.closed,
+    planRecord: tuple.plan,
+    decisionPacket: tuple.packet,
+    snapshotBaseItem: path.join(store.snapshotDir, "base", "items", `${store.itemNumber}.md`),
+    snapshotBaseClosed: path.join(store.snapshotDir, "base", "closed", `${store.itemNumber}.md`),
+    snapshotBasePlan: path.join(store.snapshotDir, "base", "plans", `${store.itemNumber}.md`),
+    snapshotBaseDecisionPacket: path.join(
+      store.snapshotDir,
+      "base",
+      "decision-packets",
+      `${store.itemNumber}.json`,
+    ),
+    snapshotItem: path.join(store.snapshotDir, "candidate", "items", `${store.itemNumber}.md`),
+    snapshotClosed: path.join(store.snapshotDir, "candidate", "closed", `${store.itemNumber}.md`),
+    snapshotPlan: path.join(store.snapshotDir, "candidate", "plans", `${store.itemNumber}.md`),
+    snapshotDecisionPacket: path.join(
+      store.snapshotDir,
+      "candidate",
+      "decision-packets",
+      `${store.itemNumber}.json`,
+    ),
   };
 }
 
 export function resetEventSnapshot(store: EventRecordStore): void {
   fs.rmSync(store.snapshotDir, { recursive: true, force: true });
-  fs.mkdirSync(path.join(store.snapshotDir, "items"), { recursive: true });
-  fs.mkdirSync(path.join(store.snapshotDir, "closed"), { recursive: true });
+  fs.mkdirSync(store.snapshotDir, { recursive: true });
+}
+
+export function captureEventBaseSnapshot(store: EventRecordStore): EventRecordPaths {
+  const paths = eventRecordPaths(store);
+  copyIfExists(paths.itemRecord, paths.snapshotBaseItem);
+  copyIfExists(paths.closedRecord, paths.snapshotBaseClosed);
+  copyIfExists(paths.planRecord, paths.snapshotBasePlan);
+  copyIfExists(paths.decisionPacket, paths.snapshotBaseDecisionPacket);
+  return paths;
 }
 
 export function captureEventSnapshot(store: EventRecordStore): EventRecordPaths {
   const paths = eventRecordPaths(store);
+  for (const snapshotPath of [
+    paths.snapshotItem,
+    paths.snapshotClosed,
+    paths.snapshotPlan,
+    paths.snapshotDecisionPacket,
+  ]) {
+    fs.rmSync(snapshotPath, { force: true });
+  }
   copyIfExists(paths.itemRecord, paths.snapshotItem);
   copyIfExists(paths.closedRecord, paths.snapshotClosed);
+  copyIfExists(paths.planRecord, paths.snapshotPlan);
+  copyIfExists(paths.decisionPacket, paths.snapshotDecisionPacket);
+  const candidate = snapshotTuple(paths, "candidate");
+  if (candidate.item !== null || candidate.closed !== null) {
+    const base = snapshotTuple(paths, "base");
+    chooseRecordTupleWinner({ base, local: candidate, remote: base });
+  }
   return paths;
 }
 
-export function applyEventSnapshot(paths: EventRecordPaths): EventSnapshotApplyResult {
-  if (fs.existsSync(paths.snapshotClosed)) {
-    fs.mkdirSync(path.dirname(paths.closedRecord), { recursive: true });
-    fs.rmSync(paths.itemRecord, { force: true });
-    fs.copyFileSync(paths.snapshotClosed, paths.closedRecord);
-    return "closed";
+export function applyEventSnapshot(
+  paths: EventRecordPaths,
+  options: { remoteRoot?: string } = {},
+): EventSnapshotApplyResult {
+  const base = snapshotTuple(paths, "base");
+  const candidate = snapshotTuple(paths, "candidate");
+  if (candidate.item === null && candidate.closed === null) return "missing";
+  const remote = recordTupleFromRoot(paths, options.remoteRoot ?? ".");
+  const winner = chooseRecordTupleWinner({ base, local: candidate, remote });
+  if (winner === "remote" || winner === "base") {
+    const selected = winner === "remote" ? remote : base;
+    return selected.closed !== null && candidate.item !== null ? "remote-closed" : "remote-newer";
   }
 
-  if (!fs.existsSync(paths.snapshotItem)) return "missing";
+  applyTupleToRecords(paths, candidate);
+  return candidate.closed !== null ? "closed" : "open";
+}
 
-  if (fs.existsSync(paths.closedRecord)) return "remote-closed";
+export function applyEventSnapshotIfCurrent(
+  paths: EventRecordPaths,
+  options: { remoteRoot?: string },
+  applyCurrent: () => void,
+): EventSnapshotApplyResult {
+  const result = applyEventSnapshot(paths, options);
+  if (result === "open" || result === "closed") applyCurrent();
+  return result;
+}
 
-  fs.mkdirSync(path.dirname(paths.itemRecord), { recursive: true });
-  fs.copyFileSync(paths.snapshotItem, paths.itemRecord);
-  return "open";
+function snapshotTuple(
+  paths: EventRecordPaths,
+  snapshot: "base" | "candidate",
+): RecordTupleContents {
+  const tuplePaths = tuplePathsForEvent(paths);
+  return {
+    paths: tuplePaths,
+    item: readIfExists(snapshot === "base" ? paths.snapshotBaseItem : paths.snapshotItem),
+    closed: readIfExists(snapshot === "base" ? paths.snapshotBaseClosed : paths.snapshotClosed),
+    plan: readIfExists(snapshot === "base" ? paths.snapshotBasePlan : paths.snapshotPlan),
+    packet: readIfExists(
+      snapshot === "base" ? paths.snapshotBaseDecisionPacket : paths.snapshotDecisionPacket,
+    ),
+  };
+}
+
+function recordTupleFromRoot(paths: EventRecordPaths, root: string): RecordTupleContents {
+  return {
+    paths: tuplePathsForEvent(paths),
+    item: readIfExists(path.join(root, paths.itemRecord)),
+    closed: readIfExists(path.join(root, paths.closedRecord)),
+    plan: readIfExists(path.join(root, paths.planRecord)),
+    packet: readIfExists(path.join(root, paths.decisionPacket)),
+  };
+}
+
+function tuplePathsForEvent(paths: EventRecordPaths): RecordTuplePaths {
+  return recordTuplePaths({
+    repository: paths.targetSlug,
+    number: path.basename(paths.itemRecord, ".md"),
+  });
+}
+
+function applyTupleToRecords(paths: EventRecordPaths, tuple: RecordTupleContents): void {
+  syncSnapshotPath(tuple.item, paths.itemRecord);
+  syncSnapshotPath(tuple.closed, paths.closedRecord);
+  syncSnapshotPath(tuple.plan, paths.planRecord);
+  syncSnapshotPath(tuple.packet, paths.decisionPacket);
+}
+
+function syncSnapshotPath(content: string | null, destination: string): void {
+  if (content === null) {
+    fs.rmSync(destination, { force: true });
+    return;
+  }
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.writeFileSync(destination, content, "utf8");
+}
+
+function readIfExists(file: string): string | null {
+  return fs.existsSync(file) ? fs.readFileSync(file, "utf8") : null;
 }
 
 function copyIfExists(source: string, destination: string): void {

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -3,6 +3,7 @@ import {
   cpSync,
   existsSync,
   mkdirSync,
+  readFileSync,
   readdirSync,
   rmSync,
   statSync,
@@ -13,6 +14,16 @@ import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 
 import { clawsweeperGitUserEmail, clawsweeperGitUserName } from "./process-env.js";
+import {
+  chooseRecordTupleWinner,
+  recordTupleIdentityForPath,
+  recordTupleMarkdownFileForPath,
+  recordTuplePathList,
+  recordTuplePaths,
+  type RecordTupleContents,
+  type RecordTupleIdentity,
+  type RecordTuplePaths,
+} from "./record-tuple.js";
 import { mergeSweepStatusJson } from "./sweep-status-merge.js";
 
 export type GitRunResult = {
@@ -93,6 +104,7 @@ export function spawnGit(args: readonly string[], options: GitRunOptions = {}): 
     cwd: publishRoot(),
     env: process.env,
     encoding: "utf8",
+    maxBuffer: 16 * 1024 * 1024,
   });
   if (!options.quiet && child.stdout) process.stdout.write(child.stdout);
   if (!options.quiet && child.stderr) process.stderr.write(child.stderr);
@@ -174,7 +186,7 @@ export function publishMainCommit(options: GitPublishOptions): PublishResult {
   const rebaseStrategy = options.rebaseStrategy ?? "normal";
   const stateBaseCommit = captureStatePublishBaseline();
 
-  syncPublishPaths(options.paths);
+  syncPublishPaths(options.paths, { rebaseStrategy });
   configureGitUser();
   stagePaths(options.paths);
   if (!hasStagedChanges()) {
@@ -187,11 +199,40 @@ export function publishMainCommit(options: GitPublishOptions): PublishResult {
 
   const commitMessage = commitMessageForPublishedPaths(options.message, options.paths);
   runGit(["commit", "-m", commitMessage]);
-  const sourceCommit = runGit(["rev-parse", "HEAD"]).trim();
+  let sourceCommit = runGit(["rev-parse", "HEAD"]).trim();
+  const reconciliationSourceCommit =
+    rebaseStrategy === "reconcile-records" ? sourceCommit : undefined;
+  if (rebaseStrategy === "reconcile-records") {
+    const normalized = normalizeReconciliationCommit(sourceCommit);
+    sourceCommit = normalized.commit;
+    if (!normalized.changed) {
+      restoreWorktree(options.restorePaths ?? []);
+      if (
+        !pushCommit({
+          remote,
+          branch,
+          pushAttempts,
+          rebaseStrategy,
+          ...(reconciliationSourceCommit ? { reconciliationSourceCommit } : {}),
+        })
+      ) {
+        throw new Error(`Failed to synchronize unchanged publish with ${remote}/${branch}`);
+      }
+      return completeStatePublish("unchanged", options.paths, stateBaseCommit);
+    }
+  }
   restoreWorktree(options.restorePaths ?? []);
 
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-    if (pushCommit({ remote, branch, pushAttempts, rebaseStrategy })) {
+    if (
+      pushCommit({
+        remote,
+        branch,
+        pushAttempts,
+        rebaseStrategy,
+        ...(reconciliationSourceCommit ? { reconciliationSourceCommit } : {}),
+      })
+    ) {
       return completeStatePublish("committed", options.paths, stateBaseCommit);
     }
     if (rebaseStrategy === "reconcile-records") {
@@ -217,7 +258,15 @@ export function publishMainCommit(options: GitPublishOptions): PublishResult {
     sleep(delaySeconds * 1000);
   }
 
-  if (pushCommit({ remote, branch, pushAttempts, rebaseStrategy })) {
+  if (
+    pushCommit({
+      remote,
+      branch,
+      pushAttempts,
+      rebaseStrategy,
+      ...(reconciliationSourceCommit ? { reconciliationSourceCommit } : {}),
+    })
+  ) {
     return completeStatePublish("committed", options.paths, stateBaseCommit);
   }
   throw new Error(`Failed to publish commit after ${maxAttempts} attempts`);
@@ -368,19 +417,27 @@ function publishDefaultBranch(): string {
   return process.env.CLAWSWEEPER_PUBLISH_BRANCH || (publishRoot() ? "state" : "main");
 }
 
-export function syncPublishPaths(paths: readonly string[]): void {
+export function syncPublishPaths(
+  paths: readonly string[],
+  options: { rebaseStrategy?: RebaseStrategy } = {},
+): void {
   const stateRoot = publishRoot();
-  if (stateRoot) syncStatePublishPaths(paths, stateRoot);
+  if (stateRoot) syncStatePublishPaths(paths, stateRoot, options.rebaseStrategy ?? "normal");
 }
 
-function syncStatePublishPaths(paths: readonly string[], stateRoot: string): void {
+function syncStatePublishPaths(
+  paths: readonly string[],
+  stateRoot: string,
+  rebaseStrategy: RebaseStrategy,
+): void {
   for (const path of uniqueNonEmpty(paths)) {
     const source = resolve(path);
     const destination = resolve(stateRoot, path);
     if (!isPathInsideOrEqual(stateRoot, destination)) {
       throw new Error(`Refusing to publish outside state root: ${path}`);
     }
-    const preserved = preserveStateOnlyFiles({ path, source, destination });
+    const statusMerges = planStateSweepStatusSyncs({ path, source, destination });
+    const preserved = preserveStateOnlyFiles({ path, source, destination, rebaseStrategy });
     try {
       rmSync(destination, { force: true, recursive: true });
       if (existsSync(source)) {
@@ -388,13 +445,14 @@ function syncStatePublishPaths(paths: readonly string[], stateRoot: string): voi
         cpSync(source, destination, { recursive: true });
       }
       restorePreservedFiles(preserved, destination);
+      applyStateSweepStatusSyncs(statusMerges, destination);
     } finally {
       rmSync(preserved.root, { force: true, recursive: true });
     }
   }
 }
 
-function preserveStateOnlyFiles({
+function planStateSweepStatusSyncs({
   path,
   source,
   destination,
@@ -402,6 +460,52 @@ function preserveStateOnlyFiles({
   path: string;
   source: string;
   destination: string;
+}): { rel: string; content: string }[] {
+  if (!existsSync(source) || !existsSync(destination)) return [];
+  const destinationFiles = listFiles(destination);
+  const syncs: { rel: string; content: string }[] = [];
+  for (const destinationFile of destinationFiles) {
+    const rel = statSync(destination).isFile()
+      ? ""
+      : toPosixPath(relative(destination, destinationFile));
+    const publishedPath = joinedPublishPath(path, rel);
+    if (!/^results\/sweep-status\/[^/]+\.json$/.test(publishedPath)) continue;
+    const sourceFile = rel ? resolve(source, rel) : source;
+    if (!existsSync(sourceFile) || !statSync(sourceFile).isFile()) continue;
+    syncs.push({
+      rel,
+      content: mergeSweepStatusJson({
+        path: publishedPath,
+        baseText: null,
+        localText: readFileSync(sourceFile, "utf8"),
+        remoteText: readFileSync(destinationFile, "utf8"),
+      }),
+    });
+  }
+  return syncs;
+}
+
+function applyStateSweepStatusSyncs(
+  syncs: readonly { rel: string; content: string }[],
+  destination: string,
+): void {
+  for (const sync of syncs) {
+    const target = sync.rel ? resolve(destination, sync.rel) : destination;
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, sync.content, "utf8");
+  }
+}
+
+function preserveStateOnlyFiles({
+  path,
+  source,
+  destination,
+  rebaseStrategy,
+}: {
+  path: string;
+  source: string;
+  destination: string;
+  rebaseStrategy: RebaseStrategy;
 }): { root: string; files: string[] } {
   const root = mkdtempSync(join(tmpdir(), "clawsweeper-state-preserve-"));
   if (!existsSync(destination)) return { root, files: [] };
@@ -414,7 +518,14 @@ function preserveStateOnlyFiles({
   for (const file of listFiles(destination)) {
     const rel = toPosixPath(relative(destination, file));
     if (existsSync(resolve(source, rel))) continue;
-    if (!shouldPreserveStateOnlyFile(path, rel, (candidate) => existsSync(resolve(candidate)))) {
+    if (
+      !shouldPreserveStateOnlyFile(
+        path,
+        rel,
+        (candidate) => existsSync(resolve(candidate)),
+        rebaseStrategy,
+      )
+    ) {
       continue;
     }
     const target = resolve(root, rel);
@@ -429,13 +540,37 @@ function shouldPreserveStateOnlyFile(
   path: string,
   rel: string,
   sourceHasPath: (path: string) => boolean,
+  rebaseStrategy: RebaseStrategy = "normal",
 ): boolean {
   if (path === "jobs")
     return /^[^/]+\/inbox\/(?:automerge|issue|self-heal|repair-pr)-.+\.md$/.test(rel);
   const publishedPath = joinedPublishPath(path, rel);
   if (!publishedPath.startsWith("records/")) return false;
+  if (rebaseStrategy === "reconcile-records") {
+    // Copy the candidate snapshot exactly. The base-aware tuple normalizer runs
+    // before the first push and restores any semantically newer base tuple.
+    // Preserving individual destination files here would hide intentional
+    // whole-tuple and sidecar deletions from that atomic comparison.
+    return false;
+  }
+  if (recordPrimaryCandidatesForSidecar(publishedPath).some(sourceHasPath)) {
+    return false;
+  }
   const counterpart = recordCounterpartPath(publishedPath);
   return !counterpart || !sourceHasPath(counterpart);
+}
+
+function recordPrimaryCandidatesForSidecar(path: string): string[] {
+  const planMatch = /^records\/([^/]+)\/plans\/([^/]+\.md)$/.exec(path);
+  if (planMatch?.[1] && planMatch[2]) {
+    const root = `records/${planMatch[1]}`;
+    return [`${root}/items/${planMatch[2]}`, `${root}/closed/${planMatch[2]}`];
+  }
+  const packetMatch = /^records\/([^/]+)\/decision-packets\/(\d+)\.json$/.exec(path);
+  if (!packetMatch?.[1] || !packetMatch[2]) return [];
+  const root = `records/${packetMatch[1]}`;
+  const files = [`${packetMatch[2]}.md`, `${packetMatch[1]}-${packetMatch[2]}.md`];
+  return files.flatMap((file) => [`${root}/items/${file}`, `${root}/closed/${file}`]);
 }
 
 function joinedPublishPath(path: string, rel: string): string {
@@ -518,6 +653,7 @@ export function pushCommit(options: {
   branch?: string;
   pushAttempts?: number;
   rebaseStrategy?: RebaseStrategy;
+  reconciliationSourceCommit?: string;
 }): boolean {
   const remote = options.remote ?? "origin";
   const branch = options.branch ?? publishDefaultBranch();
@@ -531,7 +667,9 @@ export function pushCommit(options: {
     const localCommitMessage = runGit(["log", "-1", "--format=%B"], { quiet: true });
     runGit(["fetch", remote, branch], { allowFailure: true });
     if (rebaseStrategy === "reconcile-records") {
-      if (!rebuildReconciliationCommit(`${remote}/${branch}`)) return false;
+      if (!rebuildReconciliationCommit(`${remote}/${branch}`, options.reconciliationSourceCommit)) {
+        return false;
+      }
       continue;
     }
     const remoteCommit = runGit(["rev-parse", `${remote}/${branch}`], { quiet: true }).trim();
@@ -555,34 +693,50 @@ export function pushCommit(options: {
   return spawnGit(["push", remote, `HEAD:${branch}`]).status === 0;
 }
 
-function rebuildReconciliationCommit(remoteRef: string): boolean {
-  const sourceCommit = runGit(["rev-parse", "HEAD"]).trim();
+function rebuildReconciliationCommit(
+  remoteRef: string,
+  reconciliationSourceCommit?: string,
+): boolean {
+  const sourceCommit = reconciliationSourceCommit ?? runGit(["rev-parse", "HEAD"]).trim();
   const baseCommit = runGit(["merge-base", sourceCommit, remoteRef]).trim();
   const localPaths = changedPathsBetween(baseCommit, sourceCommit);
-  const localTupleKeys = new Map<string, string>();
+  const remotePaths = changedPathsBetween(baseCommit, remoteRef);
+  const localTupleKeys = new Map<string, RecordTupleIdentity>();
 
   for (const path of localPaths) {
-    const tupleKey = reconciliationTupleKey(path);
-    if (!tupleKey) {
+    const identity = recordTupleIdentityForPath(path);
+    if (!identity) {
       console.log(`Unsupported reconciliation publish path: ${path}`);
       return false;
     }
-    localTupleKeys.set(path, tupleKey);
+    localTupleKeys.set(path, identity);
   }
 
-  const remoteTupleKeys = new Set(
-    changedPathsBetween(baseCommit, remoteRef)
-      .map(reconciliationTupleKey)
-      .filter((key): key is string => Boolean(key)),
+  const changedPaths = [...localPaths, ...remotePaths];
+  const localIdentities = new Map<string, RecordTupleIdentity>();
+  for (const identity of localTupleKeys.values()) {
+    localIdentities.set(recordTupleIdentityKey(identity), identity);
+  }
+  const knownTuplePaths = indexRecordTupleMarkdownPaths(
+    [baseCommit, sourceCommit, remoteRef],
+    new Set([...localIdentities.values()].map((identity) => identity.repository)),
   );
-  const selectedPaths = localPaths.filter(
-    (path) => !remoteTupleKeys.has(localTupleKeys.get(path) ?? ""),
-  );
-  const deferredTupleKeys = new Set(
-    localPaths
-      .map((path) => localTupleKeys.get(path))
-      .filter((key): key is string => key !== undefined && remoteTupleKeys.has(key)),
-  );
+  const selectedTuples: { paths: RecordTuplePaths; commit: string }[] = [];
+  const deferredTupleKeys = new Set<string>();
+  for (const [key, identity] of localIdentities) {
+    const tuplePaths = resolveRecordTuplePaths({
+      identity,
+      changedPaths: [...changedPaths, ...(knownTuplePaths.get(key) ?? [])],
+    });
+    const winner = chooseRecordTupleWinner({
+      base: readRecordTupleAtCommit(baseCommit, tuplePaths),
+      local: readRecordTupleAtCommit(sourceCommit, tuplePaths),
+      remote: readRecordTupleAtCommit(remoteRef, tuplePaths),
+    });
+    if (winner === "local") selectedTuples.push({ paths: tuplePaths, commit: sourceCommit });
+    else if (winner === "base") selectedTuples.push({ paths: tuplePaths, commit: baseCommit });
+    else deferredTupleKeys.add(key);
+  }
 
   if (deferredTupleKeys.size > 0) {
     console.log(
@@ -591,9 +745,14 @@ function rebuildReconciliationCommit(remoteRef: string): boolean {
   }
 
   runGit(["reset", "--hard", remoteRef]);
-  for (const path of selectedPaths) {
-    runGit(["rm", "-r", "--ignore-unmatch", "--", path], { allowFailure: true });
-    if (commitHasPath(sourceCommit, path)) runGit(["checkout", sourceCommit, "--", path]);
+  const selectedPaths = selectedTuples.flatMap((selection) => recordTuplePathList(selection.paths));
+  for (const selection of selectedTuples) {
+    for (const path of recordTuplePathList(selection.paths)) {
+      runGit(["rm", "-r", "--ignore-unmatch", "--", path], { allowFailure: true });
+      if (commitHasPath(selection.commit, path)) {
+        runGit(["checkout", selection.commit, "--", path]);
+      }
+    }
   }
 
   if (selectedPaths.length > 0) stagePaths(selectedPaths);
@@ -606,24 +765,154 @@ function rebuildReconciliationCommit(remoteRef: string): boolean {
   return true;
 }
 
+function normalizeReconciliationCommit(sourceCommit: string): {
+  commit: string;
+  changed: boolean;
+} {
+  const baseCommit = runGit(["rev-parse", `${sourceCommit}^`], { quiet: true }).trim();
+  const localPaths = changedPathsBetween(baseCommit, sourceCommit);
+  const identities = new Map<string, RecordTupleIdentity>();
+  for (const path of localPaths) {
+    const identity = recordTupleIdentityForPath(path);
+    if (!identity) throw new Error(`Unsupported reconciliation publish path: ${path}`);
+    identities.set(recordTupleIdentityKey(identity), identity);
+  }
+  const knownTuplePaths = indexRecordTupleMarkdownPaths(
+    [baseCommit, sourceCommit],
+    new Set([...identities.values()].map((identity) => identity.repository)),
+  );
+  const selectedTuples: RecordTuplePaths[] = [];
+  for (const [key, identity] of identities) {
+    const paths = resolveRecordTuplePaths({
+      identity,
+      changedPaths: [...localPaths, ...(knownTuplePaths.get(key) ?? [])],
+    });
+    const base = readRecordTupleAtCommit(baseCommit, paths);
+    const local = readRecordTupleAtCommit(sourceCommit, paths);
+    const winner = chooseRecordTupleWinner({ base, local, remote: base });
+    if (winner === "local") selectedTuples.push(paths);
+  }
+
+  if (selectedTuples.length === identities.size) {
+    return { commit: sourceCommit, changed: true };
+  }
+
+  const discarded = identities.size - selectedTuples.length;
+  console.log(`Discarding ${discarded} stale or ambiguous local record tuple(s) before push`);
+  runGit(["reset", "--hard", baseCommit]);
+  const selectedPaths = selectedTuples.flatMap(recordTuplePathList);
+  for (const paths of selectedTuples) {
+    for (const path of recordTuplePathList(paths)) {
+      runGit(["rm", "-r", "--ignore-unmatch", "--", path], { allowFailure: true });
+      if (commitHasPath(sourceCommit, path)) runGit(["checkout", sourceCommit, "--", path]);
+    }
+  }
+  if (selectedPaths.length > 0) stagePaths(selectedPaths);
+  if (!hasStagedChanges()) return { commit: baseCommit, changed: false };
+  runGit(["commit", "-C", sourceCommit]);
+  return { commit: runGit(["rev-parse", "HEAD"]).trim(), changed: true };
+}
+
 function changedPathsBetween(from: string, to: string): string[] {
   return runGit(["diff", "--no-renames", "--name-only", "-z", from, to])
     .split("\0")
     .filter(Boolean);
 }
 
-function reconciliationTupleKey(path: string): string | undefined {
-  const markdownMatch = /^records\/([^/]+)\/(?:items|closed|plans)\/([^/]+\.md)$/.exec(path);
-  if (markdownMatch) {
-    const repository = markdownMatch[1];
-    const filename = markdownMatch[2];
-    const number = filename ? /(?:^|-)(\d+)\.md$/.exec(filename)?.[1] : undefined;
-    return repository && number ? `${repository}/${number}` : undefined;
+function resolveRecordTuplePaths(options: {
+  identity: RecordTupleIdentity;
+  changedPaths: readonly string[];
+}): RecordTuplePaths {
+  const markdownFiles = {
+    items: new Set<string>(),
+    closed: new Set<string>(),
+    plans: new Set<string>(),
+  };
+  const collect = (path: string): void => {
+    const identity = recordTupleIdentityForPath(path);
+    if (
+      !identity ||
+      recordTupleIdentityKey(identity) !== recordTupleIdentityKey(options.identity)
+    ) {
+      return;
+    }
+    const section = /^records\/[^/]+\/(items|closed|plans)\//.exec(path)?.[1] as
+      | keyof typeof markdownFiles
+      | undefined;
+    const markdownFile = recordTupleMarkdownFileForPath(path);
+    if (section && markdownFile) markdownFiles[section].add(markdownFile);
+  };
+  for (const path of options.changedPaths) {
+    collect(path);
   }
-  const packetMatch = /^records\/([^/]+)\/decision-packets\/(\d+)\.json$/.exec(path);
-  const repository = packetMatch?.[1];
-  const number = packetMatch?.[2];
-  return repository && number ? `${repository}/${number}` : undefined;
+  for (const [section, files] of Object.entries(markdownFiles)) {
+    if (files.size > 1) {
+      throw new Error(
+        `Invalid record tuple ${recordTupleIdentityKey(options.identity)}: ambiguous ${section} filenames ${[
+          ...files,
+        ].join(", ")}`,
+      );
+    }
+  }
+  const resolved: { item?: string; closed?: string; plan?: string } = {};
+  const item = [...markdownFiles.items][0];
+  const closed = [...markdownFiles.closed][0];
+  const plan = [...markdownFiles.plans][0];
+  if (item) resolved.item = item;
+  if (closed) resolved.closed = closed;
+  if (plan) resolved.plan = plan;
+  return recordTuplePaths(options.identity, resolved);
+}
+
+function indexRecordTupleMarkdownPaths(
+  commits: readonly string[],
+  repositories: ReadonlySet<string>,
+): Map<string, string[]> {
+  const indexed = new Map<string, Set<string>>();
+  for (const commit of commits) {
+    for (const repository of repositories) {
+      const root = `records/${repository}`;
+      const paths = runGit(
+        [
+          "ls-tree",
+          "-r",
+          "--name-only",
+          "-z",
+          commit,
+          "--",
+          `${root}/items`,
+          `${root}/closed`,
+          `${root}/plans`,
+        ],
+        { quiet: true },
+      )
+        .split("\0")
+        .filter(Boolean);
+      for (const path of paths) {
+        const identity = recordTupleIdentityForPath(path);
+        if (!identity) continue;
+        const key = recordTupleIdentityKey(identity);
+        const existing = indexed.get(key) ?? new Set<string>();
+        existing.add(path);
+        indexed.set(key, existing);
+      }
+    }
+  }
+  return new Map([...indexed].map(([key, paths]) => [key, [...paths]]));
+}
+
+function readRecordTupleAtCommit(commit: string, paths: RecordTuplePaths): RecordTupleContents {
+  return {
+    paths,
+    item: readGitPath(commit, paths.item),
+    closed: readGitPath(commit, paths.closed),
+    plan: readGitPath(commit, paths.plan),
+    packet: readGitPath(commit, paths.packet),
+  };
+}
+
+function recordTupleIdentityKey(identity: RecordTupleIdentity): string {
+  return `${identity.repository}/${identity.number}`;
 }
 
 function rebuildPublishCommit(options: {

--- a/src/repair/publish-event-result.ts
+++ b/src/repair/publish-event-result.ts
@@ -3,6 +3,8 @@ import fs from "node:fs";
 import { spawnSync } from "node:child_process";
 import {
   applyEventSnapshot,
+  applyEventSnapshotIfCurrent,
+  captureEventBaseSnapshot,
   captureEventSnapshot,
   type EventRecordPaths,
   resetEventSnapshot,
@@ -22,6 +24,7 @@ import {
   syncPublishPaths,
 } from "./git-publish.js";
 import { isJsonObject } from "./json-types.js";
+import { RecordTupleError } from "./record-tuple.js";
 
 type ApplyAction = {
   action: string;
@@ -54,6 +57,7 @@ async function publishEventResult(options: EventOptions): Promise<void> {
   };
 
   resetEventSnapshot(recordStore);
+  captureEventBaseSnapshot(recordStore);
   fs.rmSync(options.reportPath, { force: true });
 
   runStreaming("pnpm", [
@@ -68,6 +72,81 @@ async function publishEventResult(options: EventOptions): Promise<void> {
     "--skip-dashboard",
     "--replay-closed-artifacts",
   ]);
+
+  // Preserve the exact artifact candidate before refreshing the state checkout.
+  // A stale event must be rejected before apply-decisions can comment, label,
+  // or close anything on GitHub.
+  const recordPaths = captureEventSnapshot(recordStore);
+  hardResetToRemoteMain();
+  const stateBaseCommit = captureStatePublishBaseline();
+  const stateRoot = publishRoot();
+  const preflightResult = applyEventSnapshotIfCurrent(
+    recordPaths,
+    stateRoot ? { remoteRoot: stateRoot } : {},
+    () => runApplyDecisions(options),
+  );
+  if (
+    preflightResult === "remote-closed" ||
+    preflightResult === "remote-newer" ||
+    preflightResult === "missing"
+  ) {
+    const detail =
+      preflightResult === "remote-closed"
+        ? "current state is already closed"
+        : preflightResult === "remote-newer"
+          ? "current state has a newer tuple"
+          : "the event produced no record tuple";
+    console.log(
+      `Skipping stale event apply for ${options.targetRepo}#${options.itemNumber}: ${detail}`,
+    );
+    refreshSourceAfterStatePublish(
+      [
+        recordPaths.itemRecord,
+        recordPaths.closedRecord,
+        recordPaths.planRecord,
+        recordPaths.decisionPacket,
+      ],
+      stateBaseCommit,
+    );
+    writeSummary({
+      targetRepo: options.targetRepo,
+      itemNumber: options.itemNumber,
+      syncedCount: 0,
+      closedCount: 0,
+      closeReasons: options.closeReasons,
+    });
+    return;
+  }
+
+  const actions = readApplyActions(options.reportPath);
+  const syncedCount = actions.filter((entry) => entry.action === "review_comment_synced").length;
+  const closedCount = actions.filter((entry) => entry.action === "closed").length;
+  captureEventSnapshot(recordStore);
+
+  const summary = () =>
+    writeSummary({
+      targetRepo: options.targetRepo,
+      itemNumber: options.itemNumber,
+      syncedCount,
+      closedCount,
+      closeReasons: options.closeReasons,
+    });
+  for (let attempt = 1; attempt <= 20; attempt += 1) {
+    if (publishSnapshot({ paths: recordPaths, options, summary, stateBaseCommit })) return;
+    const delaySeconds = attempt * 3 + Math.floor(Math.random() * 11);
+    console.log(
+      `Event publish attempt ${attempt} failed; retrying from origin/main in ${delaySeconds}s`,
+    );
+    await sleep(delaySeconds * 1000);
+  }
+  if (!publishSnapshot({ paths: recordPaths, options, summary, stateBaseCommit })) {
+    throw new Error(
+      `Failed to publish event result for ${options.targetRepo}#${options.itemNumber}`,
+    );
+  }
+}
+
+function runApplyDecisions(options: EventOptions): void {
   runStreaming("pnpm", [
     "run",
     "apply-decisions",
@@ -98,35 +177,6 @@ async function publishEventResult(options: EventOptions): Promise<void> {
     "--report-path",
     options.reportPath,
   ]);
-
-  const actions = readApplyActions(options.reportPath);
-  const syncedCount = actions.filter((entry) => entry.action === "review_comment_synced").length;
-  const closedCount = actions.filter((entry) => entry.action === "closed").length;
-  const recordPaths = captureEventSnapshot(recordStore);
-
-  const summary = () =>
-    writeSummary({
-      targetRepo: options.targetRepo,
-      itemNumber: options.itemNumber,
-      syncedCount,
-      closedCount,
-      closeReasons: options.closeReasons,
-    });
-  const stateBaseCommit = captureStatePublishBaseline();
-
-  for (let attempt = 1; attempt <= 20; attempt += 1) {
-    if (publishSnapshot({ paths: recordPaths, options, summary, stateBaseCommit })) return;
-    const delaySeconds = attempt * 3 + Math.floor(Math.random() * 11);
-    console.log(
-      `Event publish attempt ${attempt} failed; retrying from origin/main in ${delaySeconds}s`,
-    );
-    await sleep(delaySeconds * 1000);
-  }
-  if (!publishSnapshot({ paths: recordPaths, options, summary, stateBaseCommit })) {
-    throw new Error(
-      `Failed to publish event result for ${options.targetRepo}#${options.itemNumber}`,
-    );
-  }
 }
 
 function publishSnapshot({
@@ -140,7 +190,12 @@ function publishSnapshot({
   summary: () => void;
   stateBaseCommit: string | null;
 }): boolean {
-  const commitPaths = [paths.itemRecord, paths.closedRecord];
+  const commitPaths = [
+    paths.itemRecord,
+    paths.closedRecord,
+    paths.planRecord,
+    paths.decisionPacket,
+  ];
   try {
     const complete = (): true => {
       refreshSourceAfterStatePublish(commitPaths, stateBaseCommit);
@@ -149,21 +204,16 @@ function publishSnapshot({
     };
     hardResetToRemoteMain();
     const stateRoot = publishRoot();
-    if (
-      stateRoot &&
-      fs.existsSync(paths.snapshotItem) &&
-      !fs.existsSync(paths.snapshotClosed) &&
-      fs.existsSync(`${stateRoot}/${paths.closedRecord}`)
-    ) {
+    const snapshotResult = applyEventSnapshot(paths, stateRoot ? { remoteRoot: stateRoot } : {});
+    if (snapshotResult === "remote-closed") {
       console.log(
         `Remote already has closed record for ${paths.targetSlug}#${options.itemNumber}; skipping open-record publish`,
       );
       return complete();
     }
-    const snapshotResult = applyEventSnapshot(paths);
-    if (snapshotResult === "remote-closed") {
+    if (snapshotResult === "remote-newer") {
       console.log(
-        `Remote already has closed record for ${paths.targetSlug}#${options.itemNumber}; skipping open-record publish`,
+        `Remote has newer record tuple for ${paths.targetSlug}#${options.itemNumber}; skipping stale event publish`,
       );
       return complete();
     }
@@ -187,9 +237,10 @@ function publishSnapshot({
         commitPaths,
       ),
     ]);
-    if (!pushCommit({ pushAttempts: 3 })) return false;
+    if (!pushCommit({ pushAttempts: 3, rebaseStrategy: "reconcile-records" })) return false;
     return complete();
   } catch (error) {
+    if (error instanceof RecordTupleError) throw error;
     console.error(error instanceof Error ? error.message : String(error));
     return false;
   }

--- a/src/repair/record-tuple.ts
+++ b/src/repair/record-tuple.ts
@@ -1,0 +1,654 @@
+import { createHash } from "node:crypto";
+
+export type RecordTupleIdentity = {
+  repository: string;
+  number: string;
+};
+
+export type RecordTuplePaths = RecordTupleIdentity & {
+  key: string;
+  item: string;
+  closed: string;
+  plan: string;
+  packet: string;
+};
+
+export type RecordTupleContents = {
+  paths: RecordTuplePaths;
+  item: string | null;
+  closed: string | null;
+  plan: string | null;
+  packet: string | null;
+};
+
+export type RecordTupleWinner = "local" | "remote" | "base" | "equal";
+
+export class RecordTupleError extends Error {}
+
+type RecordTupleState = {
+  location: "items" | "closed" | null;
+  version: readonly (number | null)[] | null;
+  transitionAt: number | null;
+};
+
+const VERSION_GROUPS = [
+  ["item_updated_at", "current_item_updated_at", "current_item_closed_at"],
+  ["reviewed_at", "last_full_review_at"],
+  ["reconciled_at"],
+  ["applied_at", "apply_checked_at"],
+  ["review_comment_synced_at", "review_comment_checked_at"],
+  ["labels_synced_at"],
+  ["failed_review_retry_last_at"],
+] as const;
+const RECOGNIZED_TIMESTAMPS = new Set(VERSION_GROUPS.flat());
+
+/**
+ * Durable item state is one atomic tuple: exactly one open/closed record plus
+ * its optional work plan and decision packet. Tuple conflicts use only the
+ * recognized state-mutation timestamps above. Live subject freshness wins
+ * first, then full-review freshness; operational reconcile/apply/comment/label
+ * stamps can break ties but cannot revive older review content. Commit time is
+ * never a fallback. Equal vectors with different contents are ambiguous.
+ */
+export function chooseRecordTupleWinner(options: {
+  base: RecordTupleContents;
+  local: RecordTupleContents;
+  remote: RecordTupleContents;
+}): RecordTupleWinner {
+  const localChanged = !recordTupleContentsEqual(options.base, options.local);
+  const remoteChanged = !recordTupleContentsEqual(options.base, options.remote);
+
+  // Untouched legacy tuples are outside this reconciliation. In particular,
+  // do not make an unrelated publish fail because old state contains a tuple
+  // that predates the atomic invariant.
+  if (!localChanged && !remoteChanged) return "equal";
+
+  let baseState: RecordTupleState;
+  try {
+    baseState = inspectRecordTuple(options.base, "base");
+  } catch (error) {
+    if (!(error instanceof RecordTupleError)) throw error;
+    return chooseWinnerFromInvalidBase({ ...options, localChanged, remoteChanged });
+  }
+
+  const localState = localChanged ? inspectRecordTuple(options.local, "local") : baseState;
+  const remoteState = remoteChanged ? inspectRecordTuple(options.remote, "remote") : baseState;
+  if (recordTupleContentsEqual(options.local, options.remote)) return "equal";
+
+  // A deletion relative to an existing base is authoritative. This prevents a
+  // stale broad snapshot from resurrecting a tuple removed by another writer.
+  if (baseState.location) {
+    if (!localState.location && remoteState.location) return "local";
+    if (localState.location && !remoteState.location) return "remote";
+    if (!localState.location && !remoteState.location) return "equal";
+  } else {
+    // With no base tuple, an uncontested creation is publishable.
+    if (localState.location && !remoteState.location) return "local";
+    if (!localState.location && remoteState.location) return "remote";
+    if (!localState.location && !remoteState.location) return "equal";
+  }
+
+  const localRelation = compareTupleToBase(options.base, options.local, baseState, localState);
+  const remoteRelation = compareTupleToBase(options.base, options.remote, baseState, remoteState);
+  const localFresh = localRelation > 0;
+  const remoteFresh = remoteRelation > 0;
+  if (localFresh && !remoteFresh) return "local";
+  if (remoteFresh && !localFresh) return "remote";
+  if (!localFresh && !remoteFresh) return "base";
+  return chooseBetweenChangedTuples(options.local, options.remote, localState, remoteState);
+}
+
+function chooseWinnerFromInvalidBase(options: {
+  base: RecordTupleContents;
+  local: RecordTupleContents;
+  remote: RecordTupleContents;
+  localChanged: boolean;
+  remoteChanged: boolean;
+}): RecordTupleWinner {
+  const projection = uniqueValidBaseProjection(options.base);
+  if (projection) {
+    const projectedLocal = options.localChanged ? options.local : projection;
+    const projectedRemote = options.remoteChanged ? options.remote : projection;
+    const winner = chooseRecordTupleWinner({
+      base: projection,
+      local: projectedLocal,
+      remote: projectedRemote,
+    });
+    const localHeals = options.localChanged && recordTupleContentsEqual(options.local, projection);
+    const remoteHeals =
+      options.remoteChanged && recordTupleContentsEqual(options.remote, projection);
+    if ((winner === "base" || winner === "equal") && localHeals !== remoteHeals) {
+      return localHeals ? "local" : "remote";
+    }
+    return winner;
+  }
+
+  const legacyBaseState = inspectLenientSinglePrimary(options.base, "legacy base");
+  if (legacyBaseState) {
+    return chooseWinnerFromLegacyInvalidBase(options, legacyBaseState);
+  }
+
+  throw tupleError(options.base.paths, "base is structurally invalid and cannot be ordered");
+}
+
+function chooseWinnerFromLegacyInvalidBase(
+  options: {
+    base: RecordTupleContents;
+    local: RecordTupleContents;
+    remote: RecordTupleContents;
+    localChanged: boolean;
+    remoteChanged: boolean;
+  },
+  baseState: RecordTupleState,
+): RecordTupleWinner {
+  const local = options.localChanged
+    ? inspectLegacyCandidate(options.base, options.local, "local")
+    : { state: baseState, structurallyValid: false };
+  const remote = options.remoteChanged
+    ? inspectLegacyCandidate(options.base, options.remote, "remote")
+    : { state: baseState, structurallyValid: false };
+  if (recordTupleContentsEqual(options.local, options.remote)) return "equal";
+
+  if (baseState.location) {
+    if (!local.state.location && remote.state.location) return "local";
+    if (local.state.location && !remote.state.location) return "remote";
+    if (!local.state.location && !remote.state.location) return "equal";
+  }
+  if (!local.state.location || !remote.state.location) {
+    throw tupleError(options.base.paths, "ambiguous repair of legacy invalid tuple");
+  }
+
+  const localRelation = compareLegacyCandidateToBase(options.base, options.local, baseState, local);
+  const remoteRelation = compareLegacyCandidateToBase(
+    options.base,
+    options.remote,
+    baseState,
+    remote,
+  );
+  const localFresh = localRelation > 0;
+  const remoteFresh = remoteRelation > 0;
+  if (localFresh && !remoteFresh) return "local";
+  if (remoteFresh && !localFresh) return "remote";
+  if (!localFresh && !remoteFresh) return "base";
+  return chooseBetweenChangedTuples(options.local, options.remote, local.state, remote.state);
+}
+
+function inspectLegacyCandidate(
+  base: RecordTupleContents,
+  candidate: RecordTupleContents,
+  label: string,
+): { state: RecordTupleState; structurallyValid: boolean } {
+  let structurallyValid = false;
+  let strictState: RecordTupleState | null = null;
+  try {
+    strictState = inspectRecordTuple(candidate, label);
+    structurallyValid = true;
+  } catch (error) {
+    if (!(error instanceof RecordTupleError)) throw error;
+    if (!preservesLegacyInvalidSidecars(base, candidate)) throw error;
+  }
+  const primaryState = inspectLenientSinglePrimary(candidate, `${label} legacy candidate`);
+  if (primaryState) return { state: primaryState, structurallyValid };
+  if (strictState && strictState.location === null)
+    return { state: strictState, structurallyValid };
+  throw tupleError(candidate.paths, `${label} legacy candidate cannot be ordered`);
+}
+
+function compareLegacyCandidateToBase(
+  base: RecordTupleContents,
+  candidateContents: RecordTupleContents,
+  baseState: RecordTupleState,
+  candidate: { state: RecordTupleState; structurallyValid: boolean },
+): number {
+  if (recordTupleContentsEqual(base, candidateContents)) return 0;
+  if (!baseState.version || !candidate.state.version) {
+    throw tupleError(base.paths, "missing comparable state-mutation timestamp");
+  }
+  const comparison = compareRecordStates(candidate.state, baseState);
+  if (comparison !== 0) return comparison;
+  if (candidate.structurallyValid && isStrictLegacyStructuralRepair(base, candidateContents)) {
+    return 1;
+  }
+  throw tupleError(base.paths, "equal mutation vector with different tuple contents");
+}
+
+function uniqueValidBaseProjection(base: RecordTupleContents): RecordTupleContents | null {
+  if (base.item === null || base.closed === null) return null;
+  const projections = [
+    { ...base, closed: null },
+    { ...base, item: null },
+  ].filter((candidate) => {
+    try {
+      inspectRecordTuple(candidate, "base projection");
+      return true;
+    } catch (error) {
+      if (error instanceof RecordTupleError) return false;
+      throw error;
+    }
+  });
+  return projections.length === 1 ? (projections[0] ?? null) : null;
+}
+
+function inspectLenientSinglePrimary(
+  tuple: RecordTupleContents,
+  label: string,
+): RecordTupleState | null {
+  if ((tuple.item === null) === (tuple.closed === null)) return null;
+  const primary = tuple.item ?? tuple.closed;
+  if (primary === null) return null;
+  const frontMatter = parseFrontMatter(primary);
+  const timestampGroups: number[][] = VERSION_GROUPS.map(() => []);
+  collectFrontMatterTimestamps(frontMatter, timestampGroups, tuple.paths, label);
+  const grouped = timestampGroups.map(maxTimestamp);
+  return {
+    location: tuple.item !== null ? "items" : "closed",
+    version: grouped.every((timestamp) => timestamp === null) ? null : grouped,
+    transitionAt: stateTransitionTimestamp(frontMatter, tuple.item !== null ? "items" : "closed"),
+  };
+}
+
+function preservesLegacyInvalidSidecars(
+  base: RecordTupleContents,
+  candidate: RecordTupleContents,
+): boolean {
+  const basePrimary = base.item ?? base.closed;
+  const candidatePrimary = candidate.item ?? candidate.closed;
+  if (
+    basePrimary === null ||
+    candidatePrimary === null ||
+    (base.item !== null) !== (candidate.item !== null)
+  ) {
+    return false;
+  }
+  const baseFrontMatter = parseFrontMatter(basePrimary);
+  const candidateFrontMatter = parseFrontMatter(candidatePrimary);
+  return (
+    base.plan === candidate.plan &&
+    base.packet === candidate.packet &&
+    baseFrontMatter.get("decision_packet_sha256") ===
+      candidateFrontMatter.get("decision_packet_sha256") &&
+    baseFrontMatter.get("decision_packet_path") === candidateFrontMatter.get("decision_packet_path")
+  );
+}
+
+function isStrictLegacyStructuralRepair(
+  base: RecordTupleContents,
+  candidate: RecordTupleContents,
+): boolean {
+  const basePrimary = base.item ?? base.closed;
+  const candidatePrimary = candidate.item ?? candidate.closed;
+  const planIsUnchangedOrClosedCleanup =
+    base.plan === candidate.plan ||
+    (base.closed !== null &&
+      candidate.closed !== null &&
+      base.plan !== null &&
+      candidate.plan === null);
+  return (
+    basePrimary !== null &&
+    candidatePrimary !== null &&
+    (base.item !== null) === (candidate.item !== null) &&
+    withoutPacketReferenceFields(basePrimary) === withoutPacketReferenceFields(candidatePrimary) &&
+    planIsUnchangedOrClosedCleanup &&
+    !recordTupleContentsEqual(base, candidate)
+  );
+}
+
+function withoutPacketReferenceFields(markdown: string): string {
+  return markdown.replace(/^decision_packet_(?:sha256|path):.*(?:\n|$)/gm, "");
+}
+
+function compareTupleToBase(
+  base: RecordTupleContents,
+  candidate: RecordTupleContents,
+  baseState: RecordTupleState,
+  candidateState: RecordTupleState,
+): number {
+  if (recordTupleContentsEqual(base, candidate)) return 0;
+  if (!baseState.version || !candidateState.version) {
+    throw tupleError(candidate.paths, "missing comparable state-mutation timestamp");
+  }
+  const comparison = compareRecordStates(candidateState, baseState);
+  if (comparison !== 0) return comparison;
+  if (isStrictPlanRemoval(base, candidate)) return 1;
+  throw tupleError(candidate.paths, "equal mutation vector with different tuple contents");
+}
+
+function chooseBetweenChangedTuples(
+  local: RecordTupleContents,
+  remote: RecordTupleContents,
+  localState: RecordTupleState,
+  remoteState: RecordTupleState,
+): RecordTupleWinner {
+  if (!localState.version || !remoteState.version) {
+    throw tupleError(local.paths, "missing comparable state-mutation timestamp");
+  }
+  const comparison = compareRecordStates(localState, remoteState);
+  if (comparison > 0) return "local";
+  if (comparison < 0) return "remote";
+  if (isStrictPlanRemoval(remote, local)) return "local";
+  if (isStrictPlanRemoval(local, remote)) return "remote";
+  throw tupleError(local.paths, "equal mutation vector with different tuple contents");
+}
+
+function isStrictPlanRemoval(base: RecordTupleContents, candidate: RecordTupleContents): boolean {
+  return (
+    base.plan !== null &&
+    candidate.plan === null &&
+    base.item === candidate.item &&
+    base.closed === candidate.closed &&
+    base.packet === candidate.packet
+  );
+}
+
+export function validateRecordTuple(tuple: RecordTupleContents, label = "tuple"): void {
+  inspectRecordTuple(tuple, label);
+}
+
+export function recordTupleContentsEqual(
+  left: RecordTupleContents,
+  right: RecordTupleContents,
+): boolean {
+  return (
+    left.item === right.item &&
+    left.closed === right.closed &&
+    left.plan === right.plan &&
+    left.packet === right.packet
+  );
+}
+
+export function recordTupleIdentityForPath(path: string): RecordTupleIdentity | undefined {
+  const markdownMatch = /^records\/([^/]+)\/(?:items|closed|plans)\/([^/]+\.md)$/.exec(path);
+  if (markdownMatch) {
+    const repository = markdownMatch[1];
+    const filename = markdownMatch[2];
+    const number = filename ? /(?:^|-)(\d+)\.md$/.exec(filename)?.[1] : undefined;
+    return repository && number ? { repository, number } : undefined;
+  }
+  const packetMatch = /^records\/([^/]+)\/decision-packets\/(\d+)\.json$/.exec(path);
+  const repository = packetMatch?.[1];
+  const number = packetMatch?.[2];
+  return repository && number ? { repository, number } : undefined;
+}
+
+export function recordTupleMarkdownFileForPath(path: string): string | undefined {
+  return /^records\/[^/]+\/(?:items|closed|plans)\/([^/]+\.md)$/.exec(path)?.[1];
+}
+
+export function recordTuplePaths(
+  identity: RecordTupleIdentity,
+  markdownFiles: { item?: string; closed?: string; plan?: string } = {},
+): RecordTuplePaths {
+  const root = `records/${identity.repository}`;
+  const fallback =
+    markdownFiles.item ?? markdownFiles.closed ?? markdownFiles.plan ?? `${identity.number}.md`;
+  return {
+    ...identity,
+    key: `${identity.repository}/${identity.number}`,
+    item: `${root}/items/${markdownFiles.item ?? fallback}`,
+    closed: `${root}/closed/${markdownFiles.closed ?? fallback}`,
+    plan: `${root}/plans/${markdownFiles.plan ?? fallback}`,
+    packet: `${root}/decision-packets/${identity.number}.json`,
+  };
+}
+
+export function recordTuplePathList(paths: RecordTuplePaths): string[] {
+  return [paths.item, paths.closed, paths.plan, paths.packet];
+}
+
+function inspectRecordTuple(tuple: RecordTupleContents, label: string): RecordTupleState {
+  if (tuple.item !== null && tuple.closed !== null) {
+    throw tupleError(tuple.paths, `${label} has both open and closed primary records`);
+  }
+  const primary = tuple.item ?? tuple.closed;
+  if (primary === null) {
+    if (tuple.plan !== null || tuple.packet !== null) {
+      throw tupleError(tuple.paths, `${label} has orphaned sidecars without a primary record`);
+    }
+    return { location: null, version: null, transitionAt: null };
+  }
+  const location: "items" | "closed" = tuple.item !== null ? "items" : "closed";
+
+  const frontMatter = parseFrontMatter(primary);
+  validatePacketReference(tuple, frontMatter, label);
+  const timestampGroups: number[][] = VERSION_GROUPS.map(() => []);
+  collectFrontMatterTimestamps(frontMatter, timestampGroups, tuple.paths, label);
+  if (tuple.plan !== null) {
+    collectFrontMatterTimestamps(
+      parseFrontMatter(tuple.plan),
+      timestampGroups,
+      tuple.paths,
+      `${label} plan`,
+    );
+  }
+  if (tuple.packet !== null) {
+    collectPacketTimestamps(tuple.packet, timestampGroups, tuple.paths, label);
+  }
+  const grouped = timestampGroups.map(maxTimestamp);
+  return {
+    location,
+    version: grouped.every((timestamp) => timestamp === null) ? null : grouped,
+    transitionAt: stateTransitionTimestamp(frontMatter, location),
+  };
+}
+
+function validatePacketReference(
+  tuple: RecordTupleContents,
+  frontMatter: ReadonlyMap<string, string>,
+  label: string,
+): void {
+  const digest = frontMatter.get("decision_packet_sha256");
+  const pointer = frontMatter.get("decision_packet_path");
+  if (digest === undefined && pointer === undefined) {
+    if (tuple.packet !== null) {
+      throw tupleError(tuple.paths, `${label} has a packet without a primary pointer`);
+    }
+    return;
+  }
+  if (digest === undefined || pointer === undefined) {
+    throw tupleError(tuple.paths, `${label} has an incomplete decision packet reference`);
+  }
+  if (digest === "none" && pointer === "none") {
+    if (tuple.packet !== null) {
+      throw tupleError(tuple.paths, `${label} keeps a packet after clearing its pointer`);
+    }
+    return;
+  }
+  if (pointer !== tuple.paths.packet) {
+    throw tupleError(tuple.paths, `${label} points to unexpected packet path ${pointer}`);
+  }
+  if (!/^[a-f0-9]{64}$/.test(digest)) {
+    throw tupleError(tuple.paths, `${label} has malformed decision packet digest`);
+  }
+  if (tuple.packet === null) {
+    throw tupleError(tuple.paths, `${label} references a missing decision packet`);
+  }
+  const actual = createHash("sha256").update(tuple.packet).digest("hex");
+  if (actual !== digest) {
+    throw tupleError(tuple.paths, `${label} decision packet digest mismatch`);
+  }
+  validatePacketSemantics(tuple, frontMatter, label);
+}
+
+function validatePacketSemantics(
+  tuple: RecordTupleContents,
+  frontMatter: ReadonlyMap<string, string>,
+  label: string,
+): void {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(tuple.packet ?? "");
+  } catch {
+    throw tupleError(tuple.paths, `${label} decision packet is malformed JSON`);
+  }
+  if (!isObject(parsed) || parsed.version !== 1) {
+    throw tupleError(tuple.paths, `${label} decision packet has unsupported schema`);
+  }
+  const subject = isObject(parsed.subject) ? parsed.subject : null;
+  const source = isObject(parsed.source) ? parsed.source : null;
+  const primaryPath = tuple.item !== null ? tuple.paths.item : tuple.paths.closed;
+  if (
+    !subject ||
+    typeof subject.repo !== "string" ||
+    typeof subject.number !== "number" ||
+    !Number.isInteger(subject.number)
+  ) {
+    throw tupleError(tuple.paths, `${label} decision packet has malformed subject identity`);
+  }
+  if (
+    subject.repo.replace("/", "-") !== tuple.paths.repository ||
+    String(subject.number) !== tuple.paths.number
+  ) {
+    throw tupleError(tuple.paths, `${label} decision packet belongs to another subject`);
+  }
+  if (!source || source.reportPath !== primaryPath) {
+    throw tupleError(tuple.paths, `${label} decision packet points to another primary record`);
+  }
+  const primaryNumber = frontMatter.get("number");
+  const primaryRepository = frontMatter.get("repository");
+  if (primaryNumber !== undefined && primaryNumber !== tuple.paths.number) {
+    throw tupleError(tuple.paths, `${label} primary record has mismatched number`);
+  }
+  if (primaryRepository !== undefined && primaryRepository !== subject.repo) {
+    throw tupleError(tuple.paths, `${label} primary record has mismatched repository`);
+  }
+}
+
+function parseFrontMatter(markdown: string): Map<string, string> {
+  const normalized = markdown.replace(/\r\n/g, "\n");
+  if (!normalized.startsWith("---\n")) return new Map();
+  const end = normalized.indexOf("\n---", 4);
+  if (end === -1) return new Map();
+  const values = new Map<string, string>();
+  for (const line of normalized.slice(4, end).split("\n")) {
+    const match = /^([a-z][a-z0-9_]*):\s*(.*?)\s*$/.exec(line);
+    if (!match?.[1]) continue;
+    values.set(match[1], unquoteYamlScalar(match[2] ?? ""));
+  }
+  return values;
+}
+
+function unquoteYamlScalar(value: string): string {
+  if (
+    value.length >= 2 &&
+    ((value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'")))
+  ) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+function collectFrontMatterTimestamps(
+  frontMatter: ReadonlyMap<string, string>,
+  groups: number[][],
+  paths: RecordTuplePaths,
+  label: string,
+): void {
+  for (const [key, value] of frontMatter) {
+    if (!RECOGNIZED_TIMESTAMPS.has(key as (typeof VERSION_GROUPS)[number][number])) continue;
+    addTimestamp(groups, key, value, paths, label);
+  }
+}
+
+function collectPacketTimestamps(
+  packet: string,
+  groups: number[][],
+  paths: RecordTuplePaths,
+  label: string,
+): void {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(packet);
+  } catch {
+    throw tupleError(paths, `${label} decision packet is malformed JSON`);
+  }
+  if (!isObject(parsed)) return;
+  addOptionalTimestamp(groups, "reviewed_at", parsed.generatedAt, paths, `${label} packet`);
+  addOptionalTimestamp(groups, "item_updated_at", parsed.updatedAt, paths, `${label} packet`);
+  const source = isObject(parsed.source) ? parsed.source : undefined;
+  addOptionalTimestamp(groups, "reviewed_at", source?.reviewedAt, paths, `${label} packet`);
+}
+
+function addOptionalTimestamp(
+  groups: number[][],
+  key: (typeof VERSION_GROUPS)[number][number],
+  value: unknown,
+  paths: RecordTuplePaths,
+  label: string,
+): void {
+  if (value === undefined || value === null || value === "") return;
+  if (typeof value !== "string") {
+    throw tupleError(paths, `${label} has non-string ${key}`);
+  }
+  addTimestamp(groups, key, value, paths, label);
+}
+
+function addTimestamp(
+  groups: number[][],
+  key: string,
+  value: string,
+  paths: RecordTuplePaths,
+  label: string,
+): void {
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) {
+    throw tupleError(paths, `${label} has malformed ${key}`);
+  }
+  const group = VERSION_GROUPS.findIndex((keys) => (keys as readonly string[]).includes(key));
+  if (group !== -1) groups[group]?.push(timestamp);
+}
+
+function maxTimestamp(values: readonly number[]): number | null {
+  return values.length === 0 ? null : Math.max(...values);
+}
+
+function stateTransitionTimestamp(
+  frontMatter: ReadonlyMap<string, string>,
+  location: "items" | "closed",
+): number | null {
+  const keys =
+    location === "closed"
+      ? (["applied_at", "current_item_closed_at", "reconciled_at", "apply_checked_at"] as const)
+      : (["reconciled_at"] as const);
+  const timestamps = keys.flatMap((key) => {
+    const value = frontMatter.get(key);
+    if (value === undefined || value === "") return [];
+    const timestamp = Date.parse(value);
+    return Number.isFinite(timestamp) ? [timestamp] : [];
+  });
+  return maxTimestamp(timestamps);
+}
+
+function compareRecordStates(local: RecordTupleState, remote: RecordTupleState): number {
+  if (!local.version || !remote.version) return 0;
+  const subjectComparison = compareVersionVectors(local.version, remote.version, 0, 1);
+  if (subjectComparison !== 0) return subjectComparison;
+  if (local.location !== remote.location) {
+    const localTransition = local.transitionAt ?? Number.NEGATIVE_INFINITY;
+    const remoteTransition = remote.transitionAt ?? Number.NEGATIVE_INFINITY;
+    if (localTransition !== remoteTransition) return localTransition > remoteTransition ? 1 : -1;
+  }
+  return compareVersionVectors(local.version, remote.version, 1);
+}
+
+function compareVersionVectors(
+  local: readonly (number | null)[],
+  remote: readonly (number | null)[],
+  start = 0,
+  end = Math.max(local.length, remote.length),
+): number {
+  for (let index = start; index < end; index += 1) {
+    const left = local[index] ?? Number.NEGATIVE_INFINITY;
+    const right = remote[index] ?? Number.NEGATIVE_INFINITY;
+    if (left !== right) return left > right ? 1 : -1;
+  }
+  return 0;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function tupleError(paths: RecordTuplePaths, detail: string): Error {
+  return new RecordTupleError(`Invalid record tuple ${paths.key}: ${detail}`);
+}

--- a/test/repair/event-record-store.test.ts
+++ b/test/repair/event-record-store.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -6,6 +7,8 @@ import test from "node:test";
 
 import {
   applyEventSnapshot,
+  applyEventSnapshotIfCurrent,
+  captureEventBaseSnapshot,
   captureEventSnapshot,
   eventRecordPaths,
   resetEventSnapshot,
@@ -22,16 +25,35 @@ test("event record snapshots prefer closed records and remove open records", () 
   withCwd(root, () => {
     const paths = eventRecordPaths(store);
     resetEventSnapshot(store);
-    write(paths.itemRecord, "open\n");
-    write(paths.closedRecord, "closed\n");
+    writeEventTuple(paths, {
+      marker: "base open",
+      reviewedAt: "2026-07-09T23:00:00.000Z",
+      itemUpdatedAt: "2026-07-09T22:59:00Z",
+    });
+    captureEventBaseSnapshot(store);
+    const remoteRoot = path.join(root, "remote");
+    copyTupleToRoot(paths, remoteRoot);
+    writeEventTuple(paths, {
+      marker: "candidate closed",
+      reviewedAt: "2026-07-09T23:19:10.353Z",
+      itemUpdatedAt: "2026-07-09T23:10:43Z",
+      location: "closed",
+      packet: false,
+      plan: false,
+      extraFrontMatter: ["reconciled_at: 2026-07-09T23:20:21.470Z"],
+    });
 
     const captured = captureEventSnapshot(store);
-    fs.rmSync(paths.itemRecord);
-    fs.rmSync(paths.closedRecord);
+    fs.rmSync(paths.itemRecord, { force: true });
+    fs.rmSync(paths.closedRecord, { force: true });
+    fs.rmSync(paths.planRecord, { force: true });
+    fs.rmSync(paths.decisionPacket, { force: true });
 
-    assert.equal(applyEventSnapshot(captured), "closed");
+    assert.equal(applyEventSnapshot(captured, { remoteRoot }), "closed");
     assert.equal(fs.existsSync(paths.itemRecord), false);
-    assert.equal(fs.readFileSync(paths.closedRecord, "utf8"), "closed\n");
+    assert.match(fs.readFileSync(paths.closedRecord, "utf8"), /candidate closed/);
+    assert.equal(fs.existsSync(paths.planRecord), false);
+    assert.equal(fs.existsSync(paths.decisionPacket), false);
   });
 });
 
@@ -46,14 +68,702 @@ test("event record snapshots skip stale open snapshots when remote is already cl
   withCwd(root, () => {
     const paths = eventRecordPaths(store);
     resetEventSnapshot(store);
-    write(paths.itemRecord, "open snapshot\n");
+    writeEventTuple(paths, {
+      marker: "base open",
+      reviewedAt: "2026-07-09T23:00:00.000Z",
+      itemUpdatedAt: "2026-07-09T22:59:00Z",
+    });
+    captureEventBaseSnapshot(store);
+    writeEventTuple(paths, {
+      marker: "stale candidate open",
+      reviewedAt: "2026-07-09T23:13:13.035Z",
+      itemUpdatedAt: "2026-07-09T23:06:04Z",
+    });
     captureEventSnapshot(store);
-    fs.rmSync(paths.itemRecord);
-    write(paths.closedRecord, "remote closed\n");
+    const remoteRoot = path.join(root, "remote");
+    copyTupleToRoot(paths, remoteRoot);
+    writeEventTuple(
+      {
+        ...paths,
+        itemRecord: path.join(remoteRoot, paths.itemRecord),
+        closedRecord: path.join(remoteRoot, paths.closedRecord),
+        planRecord: path.join(remoteRoot, paths.planRecord),
+        decisionPacket: path.join(remoteRoot, paths.decisionPacket),
+      },
+      {
+        marker: "remote closed",
+        reviewedAt: "2026-07-09T23:18:00.000Z",
+        itemUpdatedAt: "2026-07-09T23:12:00Z",
+        location: "closed",
+        packet: false,
+        plan: false,
+        extraFrontMatter: ["reconciled_at: 2026-07-09T23:20:20.000Z"],
+      },
+    );
 
-    assert.equal(applyEventSnapshot(paths), "remote-closed");
-    assert.equal(fs.readFileSync(paths.closedRecord, "utf8"), "remote closed\n");
+    assert.equal(applyEventSnapshot(paths, { remoteRoot }), "remote-closed");
+    assert.match(
+      fs.readFileSync(path.join(remoteRoot, paths.closedRecord), "utf8"),
+      /remote closed/,
+    );
+  });
+});
+
+test("closed-state transition time outranks stale open review time", () => {
+  for (const transitionField of ["reconciled_at", "applied_at"]) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-event-records-"));
+    const store = {
+      targetRepo: "openclaw/openclaw",
+      itemNumber: transitionField === "reconciled_at" ? "71" : "72",
+      snapshotDir: path.join(root, "snapshot"),
+    };
+    withCwd(root, () => {
+      const paths = eventRecordPaths(store);
+      resetEventSnapshot(store);
+      writeEventTuple(paths, {
+        marker: "base open review T10",
+        reviewedAt: "2026-07-09T23:10:00.000Z",
+        itemUpdatedAt: "2026-07-09T23:00:00Z",
+      });
+      captureEventBaseSnapshot(store);
+      writeEventTuple(paths, {
+        marker: "stale open review T20",
+        reviewedAt: "2026-07-09T23:20:00.000Z",
+        itemUpdatedAt: "2026-07-09T23:00:00Z",
+      });
+      captureEventSnapshot(store);
+      const remoteRoot = path.join(root, "remote");
+      const remotePaths = {
+        ...paths,
+        itemRecord: path.join(remoteRoot, paths.itemRecord),
+        closedRecord: path.join(remoteRoot, paths.closedRecord),
+        planRecord: path.join(remoteRoot, paths.planRecord),
+        decisionPacket: path.join(remoteRoot, paths.decisionPacket),
+      };
+      writeEventTuple(remotePaths, {
+        marker: `closed by ${transitionField} T30`,
+        reviewedAt: "2026-07-09T23:10:00.000Z",
+        itemUpdatedAt: "2026-07-09T23:00:00Z",
+        location: "closed",
+        packet: false,
+        plan: false,
+        extraFrontMatter: [`${transitionField}: 2026-07-09T23:30:00.000Z`],
+      });
+      assert.equal(applyEventSnapshot(paths, { remoteRoot }), "remote-closed");
+
+      if (transitionField === "reconciled_at") {
+        resetEventSnapshot(store);
+        copyTupleFromRoot(paths, remoteRoot);
+        captureEventBaseSnapshot(store);
+        writeEventTuple(paths, {
+          marker: "hydrated stale open review T20",
+          reviewedAt: "2026-07-09T23:20:00.000Z",
+          itemUpdatedAt: "2026-07-09T23:00:00Z",
+        });
+        captureEventSnapshot(store);
+        assert.equal(applyEventSnapshot(paths, { remoteRoot }), "remote-closed");
+      }
+    });
+  }
+});
+
+test("latest closed-state transition wins when applied and reconciled timestamps coexist", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-event-records-"));
+  const store = {
+    targetRepo: "openclaw/openclaw",
+    itemNumber: "73",
+    snapshotDir: path.join(root, "snapshot"),
+  };
+
+  withCwd(root, () => {
+    const paths = eventRecordPaths(store);
+    resetEventSnapshot(store);
+    writeEventTuple(paths, {
+      marker: "base open transition T5",
+      reviewedAt: "2026-07-09T23:10:00.000Z",
+      itemUpdatedAt: "2026-07-09T23:00:00Z",
+      extraFrontMatter: ["reconciled_at: 2026-07-09T23:05:00.000Z"],
+    });
+    captureEventBaseSnapshot(store);
+    writeEventTuple(paths, {
+      marker: "stale open transition T40",
+      reviewedAt: "2026-07-09T23:10:00.000Z",
+      itemUpdatedAt: "2026-07-09T23:00:00Z",
+      extraFrontMatter: ["reconciled_at: 2026-07-09T23:40:00.000Z"],
+    });
+    captureEventSnapshot(store);
+
+    const remoteRoot = path.join(root, "remote");
+    const remotePaths = {
+      ...paths,
+      itemRecord: path.join(remoteRoot, paths.itemRecord),
+      closedRecord: path.join(remoteRoot, paths.closedRecord),
+      planRecord: path.join(remoteRoot, paths.planRecord),
+      decisionPacket: path.join(remoteRoot, paths.decisionPacket),
+    };
+    writeEventTuple(remotePaths, {
+      marker: "closed applied T30 reconciled T50",
+      reviewedAt: "2026-07-09T23:10:00.000Z",
+      itemUpdatedAt: "2026-07-09T23:00:00Z",
+      location: "closed",
+      packet: false,
+      plan: false,
+      extraFrontMatter: [
+        "applied_at: 2026-07-09T23:30:00.000Z",
+        "reconciled_at: 2026-07-09T23:50:00.000Z",
+      ],
+    });
+
+    assert.equal(applyEventSnapshot(paths, { remoteRoot }), "remote-closed");
+    assert.match(
+      fs.readFileSync(path.join(remoteRoot, paths.closedRecord), "utf8"),
+      /closed applied T30 reconciled T50/,
+    );
+  });
+});
+
+test("event snapshots publish an atomic record, plan, and matching decision packet", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-event-records-"));
+  const store = {
+    targetRepo: "openclaw/openclaw",
+    itemNumber: "100960",
+    snapshotDir: path.join(root, "snapshot"),
+  };
+
+  withCwd(root, () => {
+    const paths = eventRecordPaths(store);
+    resetEventSnapshot(store);
+    writeEventTuple(paths, {
+      marker: "base",
+      reviewedAt: "2026-07-09T23:13:13.035Z",
+      itemUpdatedAt: "2026-07-09T23:06:04Z",
+    });
+    captureEventBaseSnapshot(store);
+    const remoteRoot = path.join(root, "remote");
+    copyTupleToRoot(paths, remoteRoot);
+    const exact = writeEventTuple(paths, {
+      marker: "exact event 5731116d2efa",
+      reviewedAt: "2026-07-09T23:19:10.353Z",
+      itemUpdatedAt: "2026-07-09T23:10:43Z",
+      extraFrontMatter: [
+        "apply_checked_at: 2026-07-09T23:20:21.470Z",
+        "review_comment_synced_at: 2026-07-09T23:20:21.464Z",
+        "last_full_review_at: 2026-07-09T23:19:10.353Z",
+      ],
+    });
+    captureEventSnapshot(store);
+
+    assert.equal(applyEventSnapshot(paths, { remoteRoot }), "open");
+    assert.equal(fs.readFileSync(paths.itemRecord, "utf8"), exact.primary);
+    assert.equal(fs.readFileSync(paths.planRecord, "utf8"), exact.plan);
+    assert.equal(fs.readFileSync(paths.decisionPacket, "utf8"), exact.packet);
+    assert.match(
+      exact.primary,
+      new RegExp(
+        `^decision_packet_sha256: ${createHash("sha256").update(exact.packet).digest("hex")}$`,
+        "m",
+      ),
+    );
+  });
+});
+
+test("newer subject and review state outranks later operational stamps", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-event-records-"));
+  const store = {
+    targetRepo: "openclaw/openclaw",
+    itemNumber: "100960",
+    snapshotDir: path.join(root, "snapshot"),
+  };
+
+  withCwd(root, () => {
+    const paths = eventRecordPaths(store);
+    resetEventSnapshot(store);
+    writeEventTuple(paths, {
+      marker: "base",
+      reviewedAt: "2026-07-09T23:00:00.000Z",
+      itemUpdatedAt: "2026-07-09T22:59:00Z",
+    });
+    captureEventBaseSnapshot(store);
+    const candidate = writeEventTuple(paths, {
+      marker: "newer exact review",
+      reviewedAt: "2026-07-09T23:19:10.353Z",
+      itemUpdatedAt: "2026-07-09T23:10:43Z",
+    });
+    captureEventSnapshot(store);
+    const remoteRoot = path.join(root, "remote");
+    const remotePaths = {
+      ...paths,
+      itemRecord: path.join(remoteRoot, paths.itemRecord),
+      closedRecord: path.join(remoteRoot, paths.closedRecord),
+      planRecord: path.join(remoteRoot, paths.planRecord),
+      decisionPacket: path.join(remoteRoot, paths.decisionPacket),
+    };
+    writeEventTuple(remotePaths, {
+      marker: "older broad review with later apply stamp",
+      reviewedAt: "2026-07-09T23:13:13.035Z",
+      itemUpdatedAt: "2026-07-09T23:06:04Z",
+      extraFrontMatter: ["apply_checked_at: 2026-07-09T23:21:00.000Z"],
+    });
+
+    assert.equal(applyEventSnapshot(paths, { remoteRoot }), "open");
+    assert.equal(fs.readFileSync(paths.itemRecord, "utf8"), candidate.primary);
+  });
+});
+
+test("newer reopened exact tuple outranks an older broad close and restores its sidecars", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-event-records-"));
+  const store = {
+    targetRepo: "openclaw/openclaw",
+    itemNumber: "100960",
+    snapshotDir: path.join(root, "snapshot"),
+  };
+
+  withCwd(root, () => {
+    const paths = eventRecordPaths(store);
+    resetEventSnapshot(store);
+    writeEventTuple(paths, {
+      marker: "base open",
+      reviewedAt: "2026-07-09T23:00:00.000Z",
+      itemUpdatedAt: "2026-07-09T22:59:00Z",
+    });
+    captureEventBaseSnapshot(store);
+    const reopened = writeEventTuple(paths, {
+      marker: "newer exact reopen",
+      reviewedAt: "2026-07-09T23:19:10.353Z",
+      itemUpdatedAt: "2026-07-09T23:10:43Z",
+    });
+    captureEventSnapshot(store);
+    const remoteRoot = path.join(root, "remote");
+    const remotePaths = {
+      ...paths,
+      itemRecord: path.join(remoteRoot, paths.itemRecord),
+      closedRecord: path.join(remoteRoot, paths.closedRecord),
+      planRecord: path.join(remoteRoot, paths.planRecord),
+      decisionPacket: path.join(remoteRoot, paths.decisionPacket),
+    };
+    writeEventTuple(remotePaths, {
+      marker: "older broad close",
+      reviewedAt: "2026-07-09T23:13:13.035Z",
+      itemUpdatedAt: "2026-07-09T23:06:04Z",
+      location: "closed",
+      packet: false,
+      plan: false,
+      extraFrontMatter: ["reconciled_at: 2026-07-09T23:14:00.000Z"],
+    });
+
+    assert.equal(applyEventSnapshot(paths, { remoteRoot }), "open");
+    assert.equal(fs.readFileSync(paths.itemRecord, "utf8"), reopened.primary);
+    assert.equal(fs.existsSync(paths.closedRecord), false);
+    assert.equal(fs.readFileSync(paths.planRecord, "utf8"), reopened.plan);
+    assert.equal(fs.readFileSync(paths.decisionPacket, "utf8"), reopened.packet);
+  });
+});
+
+test("stale event preflight invokes no external apply callback", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-event-records-"));
+  const store = {
+    targetRepo: "openclaw/openclaw",
+    itemNumber: "100960",
+    snapshotDir: path.join(root, "snapshot"),
+  };
+
+  withCwd(root, () => {
+    const paths = eventRecordPaths(store);
+    resetEventSnapshot(store);
+    writeEventTuple(paths, {
+      marker: "newer captured base",
+      reviewedAt: "2026-07-09T23:19:10.353Z",
+      itemUpdatedAt: "2026-07-09T23:10:43Z",
+    });
+    captureEventBaseSnapshot(store);
+    const remoteRoot = path.join(root, "remote");
+    copyTupleToRoot(paths, remoteRoot);
+    writeEventTuple(paths, {
+      marker: "stale exact artifact",
+      reviewedAt: "2026-07-09T23:13:13.035Z",
+      itemUpdatedAt: "2026-07-09T23:06:04Z",
+    });
+    captureEventSnapshot(store);
+
+    let applyInvocations = 0;
+    assert.equal(
+      applyEventSnapshotIfCurrent(paths, { remoteRoot }, () => {
+        applyInvocations += 1;
+      }),
+      "remote-newer",
+    );
+    assert.equal(applyInvocations, 0);
+  });
+});
+
+test("event tuple cleanup accepts only-plan deletion and recaptures post-apply sidecar removal", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-event-records-"));
+  const store = {
+    targetRepo: "openclaw/openclaw",
+    itemNumber: "77",
+    snapshotDir: path.join(root, "snapshot"),
+  };
+
+  withCwd(root, () => {
+    const paths = eventRecordPaths(store);
+    resetEventSnapshot(store);
+    writeEventTuple(paths, {
+      marker: "base with obsolete plan",
+      reviewedAt: "2026-07-09T23:19:10.353Z",
+      itemUpdatedAt: "2026-07-09T23:10:43Z",
+    });
+    captureEventBaseSnapshot(store);
+    const remoteRoot = path.join(root, "remote");
+    copyTupleToRoot(paths, remoteRoot);
+    fs.rmSync(paths.planRecord);
+    captureEventSnapshot(store);
+    assert.equal(applyEventSnapshot(paths, { remoteRoot }), "open");
+    assert.equal(fs.existsSync(paths.planRecord), false);
+
+    writeEventTuple(paths, {
+      marker: "fresh apply candidate",
+      reviewedAt: "2026-07-09T23:20:10.353Z",
+      itemUpdatedAt: "2026-07-09T23:11:43Z",
+    });
+    captureEventSnapshot(store);
+    assert.equal(
+      applyEventSnapshotIfCurrent(paths, { remoteRoot }, () => {
+        writeEventTuple(paths, {
+          marker: "post-apply close",
+          reviewedAt: "2026-07-09T23:20:10.353Z",
+          itemUpdatedAt: "2026-07-09T23:11:43Z",
+          location: "closed",
+          packet: false,
+          plan: false,
+          extraFrontMatter: ["reconciled_at: 2026-07-09T23:21:00.000Z"],
+        });
+      }),
+      "open",
+    );
+    captureEventSnapshot(store);
+    fs.rmSync(paths.itemRecord, { force: true });
+    fs.rmSync(paths.closedRecord, { force: true });
+    fs.rmSync(paths.planRecord, { force: true });
+    fs.rmSync(paths.decisionPacket, { force: true });
+    assert.equal(applyEventSnapshot(paths, { remoteRoot }), "closed");
+    assert.equal(fs.existsSync(paths.planRecord), false);
+    assert.equal(fs.existsSync(paths.decisionPacket), false);
+  });
+});
+
+test("duplicate-primary base accepts only its packet-bound closed repair", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-event-records-"));
+  const store = {
+    targetRepo: "openclaw/openclaw",
+    itemNumber: "74",
+    snapshotDir: path.join(root, "snapshot"),
+  };
+
+  withCwd(root, () => {
+    const paths = eventRecordPaths(store);
+    resetEventSnapshot(store);
+    const closed = writeEventTuple(paths, {
+      marker: "authoritative closed projection",
+      reviewedAt: "2026-07-09T23:19:10.353Z",
+      itemUpdatedAt: "2026-07-09T23:10:43Z",
+      location: "closed",
+    });
+    write(
+      paths.itemRecord,
+      closed.primary.replace("# authoritative closed projection", "# duplicate stale open copy"),
+    );
+    captureEventBaseSnapshot(store);
+    const remoteRoot = path.join(root, "remote");
+    copyTupleToRoot(paths, remoteRoot);
+
+    writeEventTuple(paths, {
+      marker: "stale open repair",
+      reviewedAt: "2026-07-09T23:13:13.035Z",
+      itemUpdatedAt: "2026-07-09T23:06:04Z",
+    });
+    captureEventSnapshot(store);
+    assert.equal(applyEventSnapshot(paths, { remoteRoot }), "remote-closed");
+
+    resetEventSnapshot(store);
+    copyTupleFromRoot(paths, remoteRoot);
+    captureEventBaseSnapshot(store);
+    fs.rmSync(paths.itemRecord);
+    captureEventSnapshot(store);
+    assert.equal(applyEventSnapshot(paths, { remoteRoot }), "closed");
     assert.equal(fs.existsSync(paths.itemRecord), false);
+    assert.equal(fs.readFileSync(paths.closedRecord, "utf8"), closed.primary);
+  });
+});
+
+test("legacy-invalid packet sidecars cannot make an older valid primary win", () => {
+  const corruptions = [
+    {
+      name: "missing packet",
+      corrupt(paths) {
+        fs.rmSync(paths.decisionPacket);
+      },
+    },
+    {
+      name: "retained packet after none",
+      corrupt(paths) {
+        write(
+          paths.itemRecord,
+          fs
+            .readFileSync(paths.itemRecord, "utf8")
+            .replace(/^decision_packet_sha256: .*$/m, "decision_packet_sha256: none")
+            .replace(/^decision_packet_path: .*$/m, "decision_packet_path: none"),
+        );
+      },
+    },
+    {
+      name: "digest mismatch",
+      corrupt(paths) {
+        fs.appendFileSync(paths.decisionPacket, " ");
+      },
+    },
+    {
+      name: "packet without pointer",
+      corrupt(paths) {
+        write(
+          paths.itemRecord,
+          fs
+            .readFileSync(paths.itemRecord, "utf8")
+            .replace(/^decision_packet_(?:sha256|path): .*\n/gm, ""),
+        );
+      },
+    },
+  ];
+
+  for (const [index, corruption] of corruptions.entries()) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-event-records-"));
+    const store = {
+      targetRepo: "openclaw/openclaw",
+      itemNumber: String(800 + index),
+      snapshotDir: path.join(root, "snapshot"),
+    };
+    withCwd(root, () => {
+      const paths = eventRecordPaths(store);
+      resetEventSnapshot(store);
+      writeEventTuple(paths, {
+        marker: `${corruption.name} base T20`,
+        reviewedAt: "2026-07-09T23:20:00.000Z",
+        itemUpdatedAt: "2026-07-09T23:10:00Z",
+      });
+      corruption.corrupt(paths);
+      captureEventBaseSnapshot(store);
+      const remoteRoot = path.join(root, "remote");
+      copyTupleToRoot(paths, remoteRoot);
+      writeEventTuple(paths, {
+        marker: "older valid candidate T10",
+        reviewedAt: "2026-07-09T23:10:00.000Z",
+        itemUpdatedAt: "2026-07-09T23:00:00Z",
+      });
+      if (index === 0) {
+        const packet = JSON.parse(fs.readFileSync(paths.decisionPacket, "utf8"));
+        packet.generatedAt = "2026-07-09T23:30:00.000Z";
+        packet.updatedAt = "2026-07-09T23:30:00.000Z";
+        packet.source.reviewedAt = "2026-07-09T23:30:00.000Z";
+        const packetText = `${JSON.stringify(packet, null, 2)}\n`;
+        write(paths.decisionPacket, packetText);
+        write(
+          paths.itemRecord,
+          fs
+            .readFileSync(paths.itemRecord, "utf8")
+            .replace(
+              /^decision_packet_sha256: .*$/m,
+              `decision_packet_sha256: ${createHash("sha256").update(packetText).digest("hex")}`,
+            ),
+        );
+      }
+      captureEventSnapshot(store);
+      assert.equal(applyEventSnapshot(paths, { remoteRoot }), "remote-newer", corruption.name);
+    });
+  }
+});
+
+test("equal-vector legacy packet repair requires an unchanged primary and plan", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-event-records-"));
+  const store = {
+    targetRepo: "openclaw/openclaw",
+    itemNumber: "439",
+    snapshotDir: path.join(root, "snapshot"),
+  };
+  withCwd(root, () => {
+    const paths = eventRecordPaths(store);
+    resetEventSnapshot(store);
+    const valid = writeEventTuple(paths, {
+      marker: "legacy missing packet base",
+      reviewedAt: "2026-07-09T23:20:00.000Z",
+      itemUpdatedAt: "2026-07-09T23:10:00Z",
+    });
+    fs.rmSync(paths.decisionPacket);
+    captureEventBaseSnapshot(store);
+    const remoteRoot = path.join(root, "remote");
+    copyTupleToRoot(paths, remoteRoot);
+    write(paths.decisionPacket, valid.packet);
+    captureEventSnapshot(store);
+    assert.equal(applyEventSnapshot(paths, { remoteRoot }), "open");
+    assert.equal(fs.readFileSync(paths.decisionPacket, "utf8"), valid.packet);
+
+    resetEventSnapshot(store);
+    const corrected = writeEventTuple(paths, {
+      marker: "legacy digest mismatch base",
+      reviewedAt: "2026-07-09T23:20:00.000Z",
+      itemUpdatedAt: "2026-07-09T23:10:00Z",
+    });
+    write(
+      paths.itemRecord,
+      corrected.primary.replace(
+        /^decision_packet_sha256: .*$/m,
+        `decision_packet_sha256: ${"0".repeat(64)}`,
+      ),
+    );
+    captureEventBaseSnapshot(store);
+    const mismatchRemoteRoot = path.join(root, "mismatch-remote");
+    copyTupleToRoot(paths, mismatchRemoteRoot);
+    write(paths.itemRecord, corrected.primary);
+    captureEventSnapshot(store);
+    assert.equal(applyEventSnapshot(paths, { remoteRoot: mismatchRemoteRoot }), "open");
+    assert.equal(fs.readFileSync(paths.itemRecord, "utf8"), corrected.primary);
+
+    resetEventSnapshot(store);
+    writeEventTuple(paths, {
+      marker: "closed legacy packet and obsolete plan",
+      reviewedAt: "2026-07-09T23:20:00.000Z",
+      itemUpdatedAt: "2026-07-09T23:10:00Z",
+      location: "closed",
+    });
+    write(
+      paths.closedRecord,
+      fs
+        .readFileSync(paths.closedRecord, "utf8")
+        .replace(/^decision_packet_(?:sha256|path): .*\n/gm, ""),
+    );
+    captureEventBaseSnapshot(store);
+    const closedCleanupRemoteRoot = path.join(root, "closed-cleanup-remote");
+    copyTupleToRoot(paths, closedCleanupRemoteRoot);
+    fs.rmSync(paths.planRecord);
+    fs.rmSync(paths.decisionPacket);
+    captureEventSnapshot(store);
+    assert.equal(applyEventSnapshot(paths, { remoteRoot: closedCleanupRemoteRoot }), "closed");
+    assert.equal(fs.existsSync(paths.planRecord), false);
+    assert.equal(fs.existsSync(paths.decisionPacket), false);
+
+    resetEventSnapshot(store);
+    writeEventTuple(paths, {
+      marker: "legacy missing packet T20",
+      reviewedAt: "2026-07-09T23:20:00.000Z",
+      itemUpdatedAt: "2026-07-09T23:10:00Z",
+    });
+    fs.rmSync(paths.decisionPacket);
+    captureEventBaseSnapshot(store);
+    const preservedRemoteRoot = path.join(root, "preserved-invalid-remote");
+    copyTupleToRoot(paths, preservedRemoteRoot);
+    write(
+      paths.itemRecord,
+      fs
+        .readFileSync(paths.itemRecord, "utf8")
+        .replace("2026-07-09T23:20:00.000Z", "2026-07-09T23:30:00.000Z")
+        .replace("2026-07-09T23:10:00Z", "2026-07-09T23:20:00Z")
+        .replace("# legacy missing packet T20", "# monotonic legacy packet carry T30"),
+    );
+    captureEventSnapshot(store);
+    assert.equal(applyEventSnapshot(paths, { remoteRoot: preservedRemoteRoot }), "open");
+    assert.match(fs.readFileSync(paths.itemRecord, "utf8"), /monotonic legacy packet carry T30/);
+  });
+});
+
+test("event snapshots fail closed on packet mismatch and equal-time divergence", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-event-records-"));
+  const store = {
+    targetRepo: "openclaw/openclaw",
+    itemNumber: "42",
+    snapshotDir: path.join(root, "snapshot"),
+  };
+
+  withCwd(root, () => {
+    const paths = eventRecordPaths(store);
+    resetEventSnapshot(store);
+    writeEventTuple(paths, {
+      marker: "base",
+      reviewedAt: "2026-07-09T23:00:00.000Z",
+      itemUpdatedAt: "2026-07-09T22:59:00Z",
+    });
+    captureEventBaseSnapshot(store);
+    const remoteRoot = path.join(root, "remote");
+    copyTupleToRoot(paths, remoteRoot);
+    writeEventTuple(paths, {
+      marker: "candidate",
+      reviewedAt: "2026-07-09T23:10:00.000Z",
+      itemUpdatedAt: "2026-07-09T23:05:00Z",
+    });
+    fs.appendFileSync(paths.decisionPacket, " ");
+    assert.throws(() => captureEventSnapshot(store), /decision packet digest mismatch/);
+
+    resetEventSnapshot(store);
+    writeEventTuple(paths, {
+      marker: "wrong-primary packet",
+      reviewedAt: "2026-07-09T23:10:00.000Z",
+      itemUpdatedAt: "2026-07-09T23:05:00Z",
+    });
+    const wrongPrimaryPacket = JSON.parse(fs.readFileSync(paths.decisionPacket, "utf8"));
+    wrongPrimaryPacket.source.reportPath = paths.closedRecord;
+    const wrongPrimaryPacketText = `${JSON.stringify(wrongPrimaryPacket, null, 2)}\n`;
+    write(paths.decisionPacket, wrongPrimaryPacketText);
+    write(
+      paths.itemRecord,
+      fs
+        .readFileSync(paths.itemRecord, "utf8")
+        .replace(
+          /^decision_packet_sha256: .*$/m,
+          `decision_packet_sha256: ${createHash("sha256").update(wrongPrimaryPacketText).digest("hex")}`,
+        ),
+    );
+    assert.throws(() => captureEventSnapshot(store), /points to another primary record/);
+
+    resetEventSnapshot(store);
+    copyTupleFromRoot(paths, remoteRoot);
+    captureEventBaseSnapshot(store);
+    writeEventTuple(paths, {
+      marker: "malformed candidate",
+      reviewedAt: "not-a-timestamp",
+      itemUpdatedAt: "2026-07-09T23:05:00Z",
+    });
+    assert.throws(() => captureEventSnapshot(store), /malformed reviewed_at/);
+
+    resetEventSnapshot(store);
+    copyTupleFromRoot(paths, remoteRoot);
+    captureEventBaseSnapshot(store);
+    writeEventTuple(paths, {
+      marker: "same-time candidate",
+      reviewedAt: "2026-07-09T23:10:00.000Z",
+      itemUpdatedAt: "2026-07-09T23:05:00Z",
+    });
+    captureEventSnapshot(store);
+    const remotePaths = {
+      ...paths,
+      itemRecord: path.join(remoteRoot, paths.itemRecord),
+      closedRecord: path.join(remoteRoot, paths.closedRecord),
+      planRecord: path.join(remoteRoot, paths.planRecord),
+      decisionPacket: path.join(remoteRoot, paths.decisionPacket),
+    };
+    writeEventTuple(remotePaths, {
+      marker: "same-time remote",
+      reviewedAt: "2026-07-09T23:10:00.000Z",
+      itemUpdatedAt: "2026-07-09T23:05:00Z",
+    });
+    assert.throws(
+      () => applyEventSnapshot(paths, { remoteRoot }),
+      /equal mutation vector with different tuple contents/,
+    );
+
+    resetEventSnapshot(store);
+    writeTimelessTuple(paths, "timeless base");
+    captureEventBaseSnapshot(store);
+    const timelessRemoteRoot = path.join(root, "timeless-remote");
+    copyTupleToRoot(paths, timelessRemoteRoot);
+    writeTimelessTuple(paths, "timeless candidate");
+    assert.throws(() => captureEventSnapshot(store), /missing comparable state-mutation timestamp/);
   });
 });
 
@@ -70,4 +780,97 @@ function withCwd(cwd, callback) {
 function write(file, content) {
   fs.mkdirSync(path.dirname(file), { recursive: true });
   fs.writeFileSync(file, content);
+}
+
+function writeEventTuple(
+  paths,
+  {
+    marker,
+    reviewedAt,
+    itemUpdatedAt,
+    location = "items",
+    packet = true,
+    plan = true,
+    extraFrontMatter = [],
+  },
+) {
+  const packetContent = packet
+    ? `${JSON.stringify(
+        {
+          version: 1,
+          generatedAt: reviewedAt,
+          updatedAt: itemUpdatedAt,
+          subject: {
+            repo: "openclaw/openclaw",
+            number: Number(path.basename(paths.itemRecord, ".md")),
+          },
+          source: {
+            reportPath: (location === "items" ? paths.itemRecord : paths.closedRecord).replace(
+              /^.*?(records\/)/,
+              "$1",
+            ),
+            reviewedAt,
+          },
+          marker,
+        },
+        null,
+        2,
+      )}\n`
+    : null;
+  const digest = packetContent ? createHash("sha256").update(packetContent).digest("hex") : "none";
+  const primary = [
+    "---",
+    `decision_packet_sha256: ${digest}`,
+    `decision_packet_path: ${packetContent ? paths.decisionPacket.replace(/^.*?(records\/)/, "$1") : "none"}`,
+    `item_updated_at: ${itemUpdatedAt}`,
+    `reviewed_at: ${reviewedAt}`,
+    ...extraFrontMatter,
+    "---",
+    "",
+    `# ${marker}`,
+    "",
+  ].join("\n");
+  const planContent = plan ? `---\nreviewed_at: ${reviewedAt}\n---\n\n# Plan ${marker}\n` : null;
+
+  fs.rmSync(location === "items" ? paths.closedRecord : paths.itemRecord, { force: true });
+  write(location === "items" ? paths.itemRecord : paths.closedRecord, primary);
+  if (planContent) write(paths.planRecord, planContent);
+  else fs.rmSync(paths.planRecord, { force: true });
+  if (packetContent) write(paths.decisionPacket, packetContent);
+  else fs.rmSync(paths.decisionPacket, { force: true });
+  return { primary, plan: planContent, packet: packetContent };
+}
+
+function writeTimelessTuple(paths, marker) {
+  fs.rmSync(paths.closedRecord, { force: true });
+  fs.rmSync(paths.planRecord, { force: true });
+  fs.rmSync(paths.decisionPacket, { force: true });
+  write(
+    paths.itemRecord,
+    `---\ndecision_packet_sha256: none\ndecision_packet_path: none\n---\n\n# ${marker}\n`,
+  );
+}
+
+function copyTupleToRoot(paths, root) {
+  for (const recordPath of [
+    paths.itemRecord,
+    paths.closedRecord,
+    paths.planRecord,
+    paths.decisionPacket,
+  ]) {
+    if (fs.existsSync(recordPath)) write(path.join(root, recordPath), fs.readFileSync(recordPath));
+  }
+}
+
+function copyTupleFromRoot(paths, root) {
+  for (const recordPath of [
+    paths.itemRecord,
+    paths.closedRecord,
+    paths.planRecord,
+    paths.decisionPacket,
+  ]) {
+    fs.rmSync(recordPath, { force: true });
+    const source = path.join(root, recordPath);
+    if (fs.existsSync(source)) write(recordPath, fs.readFileSync(source));
+  }
 }

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -387,27 +388,51 @@ test("publishMainCommit fails closed when a racing sweep status is malformed", (
   assert.equal(run("git", ["--git-dir", origin, "show", `main:${statusFile}`], root), "{broken\n");
 });
 
-test("reconciliation preserves newer remote tuples and publishes independent tuples", () => {
+test("broad reconciliation preserves the newer exact tuple and replays independent tuples", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
   const origin = path.join(root, "origin.git");
   const work = path.join(root, "work");
   const state = path.join(root, "state");
   const other = path.join(root, "other");
-  const itemOne = "records/openclaw-openclaw/items/1.md";
-  const closedOne = "records/openclaw-openclaw/closed/1.md";
-  const planOne = "records/openclaw-openclaw/plans/1.md";
-  const packetOne = "records/openclaw-openclaw/decision-packets/1.json";
-  const itemTwo = "records/openclaw-openclaw/items/2.md";
-  const closedTwo = "records/openclaw-openclaw/closed/2.md";
-  const planTwo = "records/openclaw-openclaw/plans/2.md";
-  const packetTwo = "records/openclaw-openclaw/decision-packets/2.json";
+  const recordsRoot = "records/openclaw-openclaw";
+  const statusFile = "results/sweep-status/openclaw-openclaw.json";
+  const baseHealth = sweepHealth("2026-07-09T23:00:00Z", "comment_sync", 1);
+  const remoteHealth = sweepHealth("2026-07-09T23:20:22Z", "close", 2);
   run("git", ["init", "--bare", origin], root);
   run("git", ["clone", origin, state], root);
   configureUser(state);
-  write(path.join(state, closedOne), "closed one base\n");
-  write(path.join(state, planOne), "stale plan one\n");
-  write(path.join(state, packetOne), '{"decision":"base"}\n');
-  write(path.join(state, closedTwo), "closed two base\n");
+  for (const number of [100960, 100961, 100962, 100963]) {
+    writeRecordTuple(state, {
+      number,
+      marker: `base ${number}`,
+      reviewedAt: "2026-07-09T23:00:00.000Z",
+      itemUpdatedAt: "2026-07-09T22:59:00Z",
+    });
+  }
+  writeRecordTuple(state, {
+    number: 100965,
+    marker: "legacy per-kind paths base",
+    reviewedAt: "2026-07-09T23:00:00.000Z",
+    itemUpdatedAt: "2026-07-09T22:59:00Z",
+    recordFile: "openclaw-openclaw-100965.md",
+    planFile: "repair-openclaw-openclaw-100965.md",
+  });
+  writeRecordTuple(state, {
+    number: 100966,
+    marker: "plan deletion base",
+    reviewedAt: "2026-07-09T23:00:00.000Z",
+    itemUpdatedAt: "2026-07-09T22:59:00Z",
+  });
+  const strictPlanCleanupTuple = writeRecordTuple(state, {
+    number: 100967,
+    marker: "byte-identical primary plan cleanup",
+    reviewedAt: "2026-07-09T23:00:00.000Z",
+    itemUpdatedAt: "2026-07-09T22:59:00Z",
+  });
+  writeJson(
+    path.join(state, statusFile),
+    sweepStatus("2026-07-09T23:00:01Z", "Initial", baseHealth, baseHealth),
+  );
   run("git", ["add", "."], state);
   run("git", ["commit", "-m", "initial state"], state);
   run("git", ["push", "origin", "HEAD:state"], state);
@@ -416,55 +441,354 @@ test("reconciliation preserves newer remote tuples and publishes independent tup
 
   fs.mkdirSync(work);
   fs.cpSync(path.join(state, "records"), path.join(work, "records"), { recursive: true });
+  fs.cpSync(path.join(state, "results"), path.join(work, "results"), { recursive: true });
 
   run("git", ["clone", origin, other], root);
   configureUser(other);
-  write(path.join(other, closedOne), "closed one concurrent\n");
-  write(path.join(other, packetOne), '{"decision":"concurrent"}\n');
-  run("git", ["commit", "-am", "concurrent tuple update"], other);
+  const exactTuple = writeRecordTuple(other, {
+    number: 100960,
+    marker: "exact event 5731116d2efa",
+    reviewedAt: "2026-07-09T23:19:10.353Z",
+    itemUpdatedAt: "2026-07-09T23:10:43Z",
+    extraFrontMatter: [
+      "apply_checked_at: 2026-07-09T23:20:21.470Z",
+      "review_comment_synced_at: 2026-07-09T23:20:21.464Z",
+      "last_full_review_at: 2026-07-09T23:19:10.353Z",
+    ],
+  });
+  writeRecordTuple(other, {
+    number: 100962,
+    marker: "remote close",
+    reviewedAt: "2026-07-09T23:18:00.000Z",
+    itemUpdatedAt: "2026-07-09T23:12:00Z",
+    location: "closed",
+    packet: false,
+    plan: false,
+    extraFrontMatter: ["reconciled_at: 2026-07-09T23:20:20.000Z"],
+  });
+  writeJson(
+    path.join(other, statusFile),
+    sweepStatus("2026-07-09T23:20:23Z", "Exact event", remoteHealth, remoteHealth),
+  );
+  run("git", ["add", "-A"], other);
+  run("git", ["commit", "-m", "exact event tuple and close"], other);
   run("git", ["push", "origin", "HEAD:state"], other);
 
-  fs.rmSync(path.join(work, closedOne));
-  fs.rmSync(path.join(work, planOne));
-  fs.rmSync(path.join(work, packetOne));
-  write(path.join(work, itemOne), "stale reopen one\n");
-  fs.rmSync(path.join(work, closedTwo));
-  write(path.join(work, itemTwo), "reopened two\n");
+  writeRecordTuple(work, {
+    number: 100960,
+    marker: "stale broad 150adb4adaaf",
+    reviewedAt: "2026-07-09T23:13:13.035Z",
+    itemUpdatedAt: "2026-07-09T23:06:04Z",
+  });
+  const independentTuple = writeRecordTuple(work, {
+    number: 100961,
+    marker: "independent broad tuple",
+    reviewedAt: "2026-07-09T23:14:00.000Z",
+    itemUpdatedAt: "2026-07-09T23:07:00Z",
+  });
+  writeRecordTuple(work, {
+    number: 100962,
+    marker: "stale broad reopen",
+    reviewedAt: "2026-07-09T23:13:00.000Z",
+    itemUpdatedAt: "2026-07-09T23:06:00Z",
+  });
+  const localClose = writeRecordTuple(work, {
+    number: 100963,
+    marker: "independent broad close",
+    reviewedAt: "2026-07-09T23:15:00.000Z",
+    itemUpdatedAt: "2026-07-09T23:08:00Z",
+    location: "closed",
+    packet: false,
+    plan: false,
+    extraFrontMatter: ["reconciled_at: 2026-07-09T23:15:30.000Z"],
+  });
+  const legacyTuple = writeRecordTuple(work, {
+    number: 100965,
+    marker: "legacy per-kind paths updated",
+    reviewedAt: "2026-07-09T23:16:00.000Z",
+    itemUpdatedAt: "2026-07-09T23:09:00Z",
+    recordFile: "openclaw-openclaw-100965.md",
+    planFile: "repair-openclaw-openclaw-100965.md",
+  });
+  const planDeletionTuple = writeRecordTuple(work, {
+    number: 100966,
+    marker: "open tuple without obsolete repair plan",
+    reviewedAt: "2026-07-09T23:17:00.000Z",
+    itemUpdatedAt: "2026-07-09T23:09:30Z",
+    plan: false,
+  });
+  fs.rmSync(path.join(work, `${recordsRoot}/plans/100967.md`));
+  writeJson(
+    path.join(work, statusFile),
+    sweepStatus("2026-07-09T23:21:00Z", "Broad publish", baseHealth, baseHealth),
+  );
 
-  const result = withEnv({ CLAWSWEEPER_STATE_DIR: state }, () =>
-    withCwd(work, () =>
-      publishMainCommit({
+  const results = withEnv({ CLAWSWEEPER_STATE_DIR: state }, () =>
+    withCwd(work, () => {
+      const recordsResult = publishMainCommit({
         message: "chore: persist sweep reconciliation",
-        paths: [itemOne, closedOne, planOne, packetOne, itemTwo, closedTwo, planTwo, packetTwo],
+        paths: [recordsRoot],
         maxAttempts: 1,
         pushAttempts: 1,
         rebaseStrategy: "reconcile-records",
-      }),
-    ),
+      });
+      const statusResult = publishMainCommit({
+        message: "chore: update sweep status",
+        paths: [statusFile],
+        maxAttempts: 1,
+        pushAttempts: 1,
+        rebaseStrategy: "theirs",
+      });
+      return [recordsResult, statusResult];
+    }),
   );
 
-  assert.equal(result, "committed");
-  assert.throws(() => run("git", ["--git-dir", origin, "show", `state:${itemOne}`], root));
+  assert.deepEqual(results, ["committed", "committed"]);
   assert.equal(
-    run("git", ["--git-dir", origin, "show", `state:${closedOne}`], root),
-    "closed one concurrent\n",
+    run("git", ["--git-dir", origin, "show", `state:${recordsRoot}/items/100960.md`], root),
+    exactTuple.primary,
   );
   assert.equal(
-    run("git", ["--git-dir", origin, "show", `state:${planOne}`], root),
-    "stale plan one\n",
+    run(
+      "git",
+      ["--git-dir", origin, "show", `state:${recordsRoot}/decision-packets/100960.json`],
+      root,
+    ),
+    exactTuple.packet,
   );
   assert.equal(
-    run("git", ["--git-dir", origin, "show", `state:${packetOne}`], root),
-    '{"decision":"concurrent"}\n',
+    run("git", ["--git-dir", origin, "show", `state:${recordsRoot}/plans/100960.md`], root),
+    exactTuple.plan,
   );
   assert.equal(
-    run("git", ["--git-dir", origin, "show", `state:${itemTwo}`], root),
-    "reopened two\n",
+    run("git", ["--git-dir", origin, "show", `state:${recordsRoot}/items/100961.md`], root),
+    independentTuple.primary,
   );
-  assert.throws(() => run("git", ["--git-dir", origin, "show", `state:${closedTwo}`], root));
-  assert.equal(fs.readFileSync(path.join(work, closedOne), "utf8"), "closed one concurrent\n");
-  assert.equal(fs.readFileSync(path.join(work, packetOne), "utf8"), '{"decision":"concurrent"}\n');
-  assert.equal(fs.readFileSync(path.join(work, itemTwo), "utf8"), "reopened two\n");
+  assert.throws(() =>
+    run("git", ["--git-dir", origin, "show", `state:${recordsRoot}/items/100962.md`], root),
+  );
+  assert.match(
+    run("git", ["--git-dir", origin, "show", `state:${recordsRoot}/closed/100962.md`], root),
+    /remote close/,
+  );
+  for (const sidecar of ["plans/100962.md", "decision-packets/100962.json"]) {
+    assert.throws(() =>
+      run("git", ["--git-dir", origin, "show", `state:${recordsRoot}/${sidecar}`], root),
+    );
+  }
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `state:${recordsRoot}/closed/100963.md`], root),
+    localClose.primary,
+  );
+  for (const sidecar of ["items/100963.md", "plans/100963.md", "decision-packets/100963.json"]) {
+    assert.throws(() =>
+      run("git", ["--git-dir", origin, "show", `state:${recordsRoot}/${sidecar}`], root),
+    );
+  }
+  assert.equal(
+    fs.readFileSync(path.join(work, `${recordsRoot}/items/100960.md`), "utf8"),
+    exactTuple.primary,
+  );
+  assert.equal(
+    fs.readFileSync(path.join(work, `${recordsRoot}/decision-packets/100960.json`), "utf8"),
+    exactTuple.packet,
+  );
+  assert.equal(
+    run(
+      "git",
+      ["--git-dir", origin, "show", `state:${recordsRoot}/items/openclaw-openclaw-100965.md`],
+      root,
+    ),
+    legacyTuple.primary,
+  );
+  assert.equal(
+    run(
+      "git",
+      [
+        "--git-dir",
+        origin,
+        "show",
+        `state:${recordsRoot}/plans/repair-openclaw-openclaw-100965.md`,
+      ],
+      root,
+    ),
+    legacyTuple.plan,
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `state:${recordsRoot}/items/100966.md`], root),
+    planDeletionTuple.primary,
+  );
+  assert.throws(() =>
+    run("git", ["--git-dir", origin, "show", `state:${recordsRoot}/plans/100966.md`], root),
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `state:${recordsRoot}/items/100967.md`], root),
+    strictPlanCleanupTuple.primary,
+  );
+  assert.throws(() =>
+    run("git", ["--git-dir", origin, "show", `state:${recordsRoot}/plans/100967.md`], root),
+  );
+  const mergedStatus = readOriginJson(origin, `state:${statusFile}`, root);
+  assert.equal(mergedStatus.state, "Broad publish");
+  assert.deepEqual(mergedStatus.last_close_apply_health, remoteHealth);
+});
+
+test("broad reconciliation rejects stale hydrated state before its first push", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
+  const origin = path.join(root, "origin.git");
+  const state = path.join(root, "state");
+  const work = path.join(root, "work");
+  const recordsRoot = "records/openclaw-openclaw";
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, state], root);
+  configureUser(state);
+  const exactTuple = writeRecordTuple(state, {
+    number: 100960,
+    marker: "newer hydrated exact state",
+    reviewedAt: "2026-07-09T23:19:10.353Z",
+    itemUpdatedAt: "2026-07-09T23:10:43Z",
+  });
+  writeRecordTuple(state, {
+    number: 100961,
+    marker: "tuple intentionally deleted by broad reconcile",
+    reviewedAt: "2026-07-09T23:18:10.353Z",
+    itemUpdatedAt: "2026-07-09T23:09:43Z",
+  });
+  run("git", ["add", "."], state);
+  run("git", ["commit", "-m", "newer state base"], state);
+  run("git", ["push", "origin", "HEAD:state"], state);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/state"], root);
+  run("git", ["checkout", "-B", "state", "origin/state"], state);
+
+  fs.mkdirSync(work);
+  fs.cpSync(path.join(state, "records"), path.join(work, "records"), { recursive: true });
+  writeRecordTuple(work, {
+    number: 100960,
+    marker: "stale broad state",
+    reviewedAt: "2026-07-09T23:13:13.035Z",
+    itemUpdatedAt: "2026-07-09T23:06:04Z",
+  });
+  for (const relative of [
+    "items/100961.md",
+    "closed/100961.md",
+    "plans/100961.md",
+    "decision-packets/100961.json",
+  ]) {
+    fs.rmSync(path.join(work, recordsRoot, relative), { force: true });
+  }
+
+  assert.equal(
+    withEnv({ CLAWSWEEPER_STATE_DIR: state }, () =>
+      withCwd(work, () =>
+        publishMainCommit({
+          message: "chore: reconcile stale broad state",
+          paths: [recordsRoot],
+          maxAttempts: 1,
+          pushAttempts: 1,
+          rebaseStrategy: "reconcile-records",
+        }),
+      ),
+    ),
+    "committed",
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `state:${recordsRoot}/items/100960.md`], root),
+    exactTuple.primary,
+  );
+  assert.equal(
+    fs.readFileSync(path.join(work, `${recordsRoot}/items/100960.md`), "utf8"),
+    exactTuple.primary,
+  );
+  for (const relative of [
+    "items/100961.md",
+    "closed/100961.md",
+    "plans/100961.md",
+    "decision-packets/100961.json",
+  ]) {
+    assert.throws(() =>
+      run("git", ["--git-dir", origin, "show", `state:${recordsRoot}/${relative}`], root),
+    );
+  }
+
+  const other = path.join(root, "other");
+  run("git", ["clone", origin, other], root);
+  configureUser(other);
+  writeRecordTuple(other, {
+    number: 100960,
+    marker: "remote stale relative to merge base",
+    reviewedAt: "2026-07-09T23:14:13.035Z",
+    itemUpdatedAt: "2026-07-09T23:07:04Z",
+  });
+  run("git", ["add", "-A"], other);
+  run("git", ["commit", "-m", "remote stale tuple"], other);
+  run("git", ["push", "origin", "HEAD:state"], other);
+  writeRecordTuple(work, {
+    number: 100960,
+    marker: "local even staler than merge base",
+    reviewedAt: "2026-07-09T23:13:13.035Z",
+    itemUpdatedAt: "2026-07-09T23:06:04Z",
+  });
+  assert.equal(
+    withEnv({ CLAWSWEEPER_STATE_DIR: state }, () =>
+      withCwd(work, () =>
+        publishMainCommit({
+          message: "chore: reject two stale branches",
+          paths: [recordsRoot],
+          maxAttempts: 1,
+          pushAttempts: 1,
+          rebaseStrategy: "reconcile-records",
+        }),
+      ),
+    ),
+    "unchanged",
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `state:${recordsRoot}/items/100960.md`], root),
+    exactTuple.primary,
+  );
+});
+
+test("reconcile-records rejects a malformed tuple before an uncontended push", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
+  const origin = path.join(root, "origin.git");
+  const work = path.join(root, "work");
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, work], root);
+  configureUser(work);
+  const tuple = writeRecordTuple(work, {
+    number: 42,
+    marker: "valid base",
+    reviewedAt: "2026-07-09T23:00:00.000Z",
+    itemUpdatedAt: "2026-07-09T22:59:00Z",
+  });
+  run("git", ["add", "."], work);
+  run("git", ["commit", "-m", "initial"], work);
+  run("git", ["push", "origin", "HEAD:main"], work);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/main"], root);
+  run("git", ["checkout", "-B", "main", "origin/main"], work);
+
+  fs.appendFileSync(path.join(work, "records/openclaw-openclaw/decision-packets/42.json"), " ");
+  assert.throws(
+    () =>
+      withCwd(work, () =>
+        publishMainCommit({
+          message: "chore: publish malformed tuple",
+          paths: ["records/openclaw-openclaw"],
+          maxAttempts: 1,
+          pushAttempts: 1,
+          rebaseStrategy: "reconcile-records",
+        }),
+      ),
+    /decision packet digest mismatch/,
+  );
+  assert.equal(
+    run(
+      "git",
+      ["--git-dir", origin, "show", "main:records/openclaw-openclaw/decision-packets/42.json"],
+      root,
+    ),
+    tuple.packet,
+  );
 });
 
 test("publishMainCommit rebuilds generated state commits without deleting concurrent records", () => {
@@ -724,7 +1048,8 @@ test("publishMainCommit refreshes published source paths after a state rebase", 
   const craftedPath = "results/..\\config\\new.json";
   const openclawCursor = "results/apply-cursors/openclaw-openclaw.json";
   const clawhubCursor = "results/apply-cursors/openclaw-clawhub.json";
-  const sweepStatus = "results/sweep-status/openclaw-openclaw.json";
+  const sweepStatusPath = "results/sweep-status/openclaw-openclaw.json";
+  const refreshHealth = sweepHealth("2026-07-09T20:00:00Z", "comment_sync", 1);
   run("git", ["init", "--bare", origin], root);
   run("git", ["clone", origin, state], root);
   configureUser(state);
@@ -736,7 +1061,10 @@ test("publishMainCommit refreshes published source paths after a state rebase", 
   write(path.join(state, packetFour), '{"decision":"base"}\n');
   write(path.join(state, openclawCursor), '{"cursor":"openclaw-base"}\n');
   write(path.join(state, clawhubCursor), '{"cursor":"clawhub-base"}\n');
-  write(path.join(state, sweepStatus), '{"status":"base"}\n');
+  writeJson(
+    path.join(state, sweepStatusPath),
+    sweepStatus("2026-07-09T20:00:01Z", "Base", refreshHealth, refreshHealth),
+  );
   write(path.join(state, "apply-report.json"), '[{"report":"base"}]\n');
   write(path.join(state, configPath), "config base\n");
   run("git", ["add", "."], state);
@@ -777,7 +1105,10 @@ test("publishMainCommit refreshes published source paths after a state rebase", 
   write(path.join(work, recordFive), "record five pending local\n");
   write(path.join(work, planFive), "plan five pending local\n");
   write(path.join(work, packetFive), '{"decision":"pending-local"}\n');
-  write(path.join(work, sweepStatus), '{"status":"checkpoint"}\n');
+  writeJson(
+    path.join(work, sweepStatusPath),
+    sweepStatus("2026-07-09T20:01:00Z", "Checkpoint", refreshHealth, refreshHealth),
+  );
   const results = withEnv({ CLAWSWEEPER_STATE_DIR: state }, () =>
     withCwd(work, () => {
       const first = publishMainCommit({
@@ -839,7 +1170,10 @@ test("publishMainCommit refreshes published source paths after a state rebase", 
       run("git", ["commit", "-am", "second concurrent state update"], other);
       run("git", ["push", "origin", "HEAD:state"], other);
 
-      write(path.join(work, sweepStatus), '{"status":"checkpoint-again"}\n');
+      writeJson(
+        path.join(work, sweepStatusPath),
+        sweepStatus("2026-07-09T20:02:00Z", "Checkpoint again", refreshHealth, refreshHealth),
+      );
       const third = publishMainCommit({
         message: "chore: update checkpoint status again",
         paths: ["results/sweep-status"],
@@ -1184,7 +1518,7 @@ test("publish-main CLI accepts package-manager double dash separators", () => {
       "--path",
       "results",
       "--rebase-strategy",
-      "reconcile-records",
+      "theirs",
       "--max-attempts",
       "1",
       "--push-attempts",
@@ -1265,6 +1599,83 @@ function write(file, content) {
 
 function writeJson(file, value) {
   write(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function writeRecordTuple(
+  root,
+  {
+    number,
+    marker,
+    reviewedAt,
+    itemUpdatedAt,
+    location = "items",
+    packet = true,
+    plan = true,
+    recordFile = `${number}.md`,
+    planFile = recordFile,
+    extraFrontMatter = [],
+  },
+) {
+  const recordRoot = path.join(root, "records/openclaw-openclaw");
+  const itemPath = path.join(recordRoot, "items", recordFile);
+  const closedPath = path.join(recordRoot, "closed", recordFile);
+  const planPath = path.join(recordRoot, "plans", planFile);
+  const packetPath = path.join(recordRoot, "decision-packets", `${number}.json`);
+  const packetContent = packet
+    ? `${JSON.stringify(
+        {
+          version: 1,
+          generatedAt: reviewedAt,
+          updatedAt: itemUpdatedAt,
+          subject: { repo: "openclaw/openclaw", number },
+          source: {
+            reportPath: `records/openclaw-openclaw/${location}/${recordFile}`,
+            reviewedAt,
+          },
+          marker,
+        },
+        null,
+        2,
+      )}\n`
+    : null;
+  const digest = packetContent ? createHash("sha256").update(packetContent).digest("hex") : "none";
+  const pointer = packetContent
+    ? `records/openclaw-openclaw/decision-packets/${number}.json`
+    : "none";
+  const primary = [
+    "---",
+    `decision_packet_sha256: ${digest}`,
+    `decision_packet_path: ${pointer}`,
+    `number: ${number}`,
+    "repository: openclaw/openclaw",
+    `item_updated_at: ${itemUpdatedAt}`,
+    `reviewed_at: ${reviewedAt}`,
+    ...extraFrontMatter,
+    "---",
+    "",
+    `# ${marker}`,
+    "",
+  ].join("\n");
+  const planContent = plan
+    ? [
+        "---",
+        `number: ${number}`,
+        "repository: openclaw/openclaw",
+        `reviewed_at: ${reviewedAt}`,
+        "---",
+        "",
+        `# Plan ${marker}`,
+        "",
+      ].join("\n")
+    : null;
+
+  fs.rmSync(location === "items" ? closedPath : itemPath, { force: true });
+  write(location === "items" ? itemPath : closedPath, primary);
+  if (planContent) write(planPath, planContent);
+  else fs.rmSync(planPath, { force: true });
+  if (packetContent) write(packetPath, packetContent);
+  else fs.rmSync(packetPath, { force: true });
+  return { primary, plan: planContent, packet: packetContent };
 }
 
 function readOriginJson(origin, revision, cwd) {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -90,6 +90,42 @@ test("publish workflow installs Codex from the root checkout path", () => {
   );
 });
 
+test("broad record publishers isolate tuple reconciliation from status and auxiliary state", () => {
+  const workflow = readText(".github/workflows/sweep.yml");
+  for (const stepName of [
+    "Commit review records",
+    "Sync selected review comments",
+    "Apply selected safe close proposals",
+    "Commit Audit Health",
+  ]) {
+    const start = workflow.indexOf(`- name: ${stepName}`);
+    assert.notEqual(start, -1, stepName);
+    const nextStep = workflow.indexOf("\n      - ", start + 1);
+    const block = workflow.slice(start, nextStep === -1 ? undefined : nextStep);
+    const recordsPath = block.indexOf('--path "records/${target_slug}"');
+    const tupleStrategy = block.indexOf("--rebase-strategy reconcile-records", recordsPath);
+    const secondPublish = block.indexOf("pnpm run repair:publish-main", tupleStrategy);
+    const statusPath = block.indexOf("results/sweep-status/${target_slug}.json", secondPublish);
+    const statusStrategy = block.indexOf("--rebase-strategy theirs", statusPath);
+
+    assert.ok(recordsPath !== -1, `${stepName} records path`);
+    assert.ok(tupleStrategy > recordsPath, `${stepName} tuple strategy`);
+    assert.ok(secondPublish > tupleStrategy, `${stepName} split publish`);
+    assert.equal(
+      block.slice(recordsPath, tupleStrategy).includes("results/sweep-status"),
+      false,
+      `${stepName} must not mix status into tuple reconciliation`,
+    );
+    assert.ok(statusPath > secondPublish, `${stepName} status path`);
+    assert.ok(statusStrategy > statusPath, `${stepName} status strategy`);
+    assert.equal(
+      block.slice(secondPublish).includes('--path "records/${target_slug}"'),
+      false,
+      `${stepName} auxiliary publish must not replay records`,
+    );
+  }
+});
+
 test("apply workflow installs Codex only when proof-eligible apply work can run", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const applyJobStart = workflow.indexOf("\n  apply-existing:");
@@ -203,6 +239,47 @@ test("reconcile publication expands only exact changed record tuples", () => {
     { encoding: "utf8" },
   );
   assert.equal(emptyOutput.trim(), "Reconcile changed no durable record tuples.");
+});
+
+test("apply checkpoints split record tuples from auxiliary state", () => {
+  const output = execFileSync(
+    "bash",
+    [
+      "-lc",
+      [
+        "source scripts/apply-workflow-helpers.sh",
+        'publish_changes_with_strategy() { printf "%s\\n" "$@"; }',
+        'TARGET_REPO="OpenClaw/OpenClaw"',
+        'publish_changes "apply checkpoint" records apply-report.json results/sweep-status results/apply-cursors',
+      ].join("\n"),
+    ],
+    { encoding: "utf8" },
+  );
+  assert.deepEqual(output.trim().split("\n"), [
+    "reconcile-records",
+    "apply checkpoint",
+    "records/openclaw-openclaw",
+    "apply-records",
+    "apply checkpoint",
+    "apply-report.json",
+    "results/sweep-status",
+    "results/apply-cursors",
+  ]);
+
+  const failedOutput = execFileSync(
+    "bash",
+    [
+      "-lc",
+      [
+        "source scripts/apply-workflow-helpers.sh",
+        'publish_changes_with_strategy() { printf "%s\\n" "$1"; [ "$1" != reconcile-records ]; }',
+        'TARGET_REPO="openclaw/openclaw"',
+        'publish_changes "apply checkpoint" records apply-report.json || true',
+      ].join("\n"),
+    ],
+    { encoding: "utf8" },
+  );
+  assert.equal(failedOutput.trim(), "reconcile-records");
 });
 
 test("apply workflow target token can inspect source workflow runs", () => {


### PR DESCRIPTION
## Summary

- publish each review record, plan, and decision packet as one validated atomic tuple
- preserve the semantically newest tuple across exact-event, broad-sweep, hydrated-base, and push races
- split record reconciliation from independently merged status and report state
- validate current legacy tuple shapes while allowing only monotonic updates or strict structural repair

## Safety

- reject stale exact events before invoking apply decisions
- compare open and closed lifecycle transitions before review and operational timestamps
- keep the sweep workflow disabled until the separate shared mutation-boundary CAS lands

## Proof

- `pnpm -s test:repair` — 655 passed
- event record store — 13 passed
- git publisher — 22 passed
- sweep workflow — 47 passed
- `pnpm -s build:repair`
- `pnpm -s format:check`
- `git diff --check`
- independent tuple-gate review: no P0/P1/P2 findings

