### PR TITLE
fix: reconcile terminal exact-review leases

### DIFF
--- a/.github/workflows/exact-review-reconcile.yml
+++ b/.github/workflows/exact-review-reconcile.yml
@@ -1,0 +1,55 @@
+name: Reconcile exact-review leases
+
+on:
+  workflow_run:
+    workflows: [ClawSweeper]
+    types: [completed]
+
+permissions: {}
+
+concurrency:
+  group: exact-review-reconcile-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    name: Reconcile terminal exact-review run
+    if: ${{ github.event.workflow_run.event == 'repository_dispatch' && startsWith(github.event.workflow_run.display_title, 'Review event item ') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Reconcile terminal run
+        env:
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          SOURCE_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+          test -n "$CLAWSWEEPER_WEBHOOK_SECRET"
+          queue_url="${QUEUE_URL%/}"
+          payload="$(node -e '
+            const runAttempt = Number(process.env.SOURCE_RUN_ATTEMPT);
+            if (!Number.isInteger(runAttempt) || runAttempt < 1) process.exit(1);
+            process.stdout.write(JSON.stringify({
+              runs: [{
+                run_id: process.env.SOURCE_RUN_ID,
+                run_attempt: runAttempt,
+              }],
+            }));
+          ')"
+          signature="$(PAYLOAD="$payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
+          for attempt in 1 2 3; do
+            if curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+              --request POST \
+              --header "content-type: application/json" \
+              --header "x-clawsweeper-exact-review-signature: $signature" \
+              --data-binary "$payload" \
+              "$queue_url/internal/exact-review/reconcile" >/dev/null; then
+              exit 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              sleep "$((attempt * 5))"
+            fi
+          done
+          exit 1

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -293,11 +293,20 @@ jobs:
         env:
           QUEUE_LEASE_ID: ${{ github.event.client_payload.queue_lease_id }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
           test -n "$QUEUE_LEASE_ID"
           queue_url="${QUEUE_URL%/}"
-          payload="$(node -e 'process.stdout.write(JSON.stringify({ lease_id: process.env.QUEUE_LEASE_ID, run_id: process.env.GITHUB_RUN_ID }))')"
+          payload="$(node -e '
+            const runAttempt = Number(process.env.RUN_ATTEMPT);
+            if (!Number.isInteger(runAttempt) || runAttempt < 1) process.exit(1);
+            process.stdout.write(JSON.stringify({
+              lease_id: process.env.QUEUE_LEASE_ID,
+              run_id: process.env.GITHUB_RUN_ID,
+              run_attempt: runAttempt,
+            }));
+          ')"
           for attempt in 1 2 3; do
             if response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
               --request POST \
@@ -804,16 +813,36 @@ jobs:
           add_completion_reaction
           remove_own_eyes_reactions
 
+      - name: Fail unsuccessful exact review
+        if: ${{ always() && (steps.review-exact-event-item.outcome != 'success' || steps.publish-event-result.outcome != 'success' || steps.route-synced-verdict.outcome != 'success') }}
+        run: exit 1
+
       - name: Complete exact-review queue lease
         if: ${{ success() && steps.review-exact-event-item.outcome == 'success' && steps.publish-event-result.outcome == 'success' && steps.route-synced-verdict.outcome == 'success' }}
         env:
+          JOB_STATUS: ${{ job.status }}
           QUEUE_LEASE_ID: ${{ github.event.client_payload.queue_lease_id }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
           test -n "$QUEUE_LEASE_ID"
           queue_url="${QUEUE_URL%/}"
-          payload="$(node -e 'process.stdout.write(JSON.stringify({ lease_id: process.env.QUEUE_LEASE_ID, run_id: process.env.GITHUB_RUN_ID }))')"
+          payload="$(node -e '
+            const runAttempt = Number(process.env.RUN_ATTEMPT);
+            if (!Number.isInteger(runAttempt) || runAttempt < 1) process.exit(1);
+            const outcome = process.env.JOB_STATUS === "success"
+              ? "success"
+              : process.env.JOB_STATUS === "cancelled"
+                ? "cancelled"
+                : "failure";
+            process.stdout.write(JSON.stringify({
+              lease_id: process.env.QUEUE_LEASE_ID,
+              run_id: process.env.GITHUB_RUN_ID,
+              run_attempt: runAttempt,
+              outcome,
+            }));
+          ')"
           for attempt in 1 2 3; do
             if curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
               --request POST \

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -818,7 +818,8 @@ jobs:
         run: exit 1
 
       - name: Complete exact-review queue lease
-        if: ${{ success() && steps.review-exact-event-item.outcome == 'success' && steps.publish-event-result.outcome == 'success' && steps.route-synced-verdict.outcome == 'success' }}
+        if: ${{ always() }}
+        continue-on-error: true
         env:
           JOB_STATUS: ${{ job.status }}
           QUEUE_LEASE_ID: ${{ github.event.client_payload.queue_lease_id }}
@@ -856,10 +857,6 @@ jobs:
             fi
           done
           exit 1
-
-      - name: Fail unsuccessful exact review
-        if: ${{ always() && (steps.review-exact-event-item.outcome != 'success' || steps.publish-event-result.outcome != 'success' || steps.route-synced-verdict.outcome != 'success') }}
-        run: exit 1
 
   target-fanout:
     name: Fan out target repository sweeps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ checkpoint, and status-only commits are intentionally omitted.
 ### Fixed
 
 - Published exact-review records, plans, and decision packets as one validated tuple, and made broad sweep publishers preserve the semantically newer tuple and independently merged status health instead of replaying stale review state.
+- Requeued cancelled and failed exact-review leases, kept pre-terminal success provisional, and added signed exact-attempt reconciliation with claim-generation guards that releases only GitHub-confirmed terminal runs while preserving live workers.
 - Kept exact-review work pending with an explicit bounded retry when GitHub Actions cannot confirm that the executor workflow is active, instead of reporting silent repository dispatches to a disabled workflow as occupied capacity.
 - Refreshed generated source paths after each state publish so later checkpoints cannot overwrite concurrent record, cursor, or report updates learned during a push rebase.
 - Preserved bounded command status and prompt context through durable exact-review queue leases so successful re-reviews advance their original acknowledgement instead of remaining queued.

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -48,6 +48,14 @@ type ExactReviewQueueItem = {
   leaseRevision?: number;
   leaseExpiresAt?: number;
   claimedRunId?: string;
+  claimedRunAttempt?: number;
+  claimGeneration?: number;
+};
+type ExactReviewCompletionOutcome = "success" | "failure" | "cancelled";
+type ExactReviewClaimedRun = {
+  runId: string;
+  runAttempt?: number;
+  claimGeneration: number;
 };
 type ExactReviewQueueState = {
   deliveries: Record<string, number>;
@@ -88,6 +96,8 @@ const DEFAULT_EXACT_REVIEW_DISPATCH_LEASE_MS = 10 * 60 * 1000;
 const DEFAULT_EXACT_REVIEW_EXECUTION_LEASE_MS = 130 * 60 * 1000;
 const DEFAULT_EXACT_REVIEW_RETRY_MS = 30_000;
 const DEFAULT_EXACT_REVIEW_WORKFLOW_PAUSED_RETRY_MS = 60_000;
+const EXACT_REVIEW_RECONCILE_RUN_LIMIT = 32;
+const EXACT_REVIEW_RECONCILE_CONCURRENCY = 4;
 const EXACT_REVIEW_QUEUE_DELIVERY_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const EXACT_REVIEW_QUEUE_STATE_KEY = "exact-review-queue";
 const EXACT_REVIEW_QUEUE_NAME = "global";
@@ -403,6 +413,10 @@ export class ExactReviewQueue {
       const leaseId = String(body.lease_id || "").trim();
       const runId = String(body.run_id || "").trim();
       if (!leaseId || !runId) return json({ error: "missing_lease_or_run" }, 400);
+      const runAttempt = exactReviewRunAttempt(body.run_attempt);
+      if (body.run_attempt !== undefined && runAttempt === null) {
+        return json({ error: "invalid_run_attempt" }, 400);
+      }
 
       const now = Date.now();
       const state = await this.readState();
@@ -416,6 +430,8 @@ export class ExactReviewQueue {
 
       item.state = "leased";
       item.claimedRunId = runId;
+      item.claimedRunAttempt = runAttempt ?? undefined;
+      item.claimGeneration = exactReviewClaimGeneration(item.claimGeneration) + 1;
       item.leaseExpiresAt = now + exactReviewExecutionLeaseMs(this.env);
       await this.writeState(state);
       await this.scheduleNext(state, now);
@@ -432,25 +448,82 @@ export class ExactReviewQueue {
       const leaseId = String(body.lease_id || "").trim();
       const runId = String(body.run_id || "").trim();
       if (!leaseId || !runId) return json({ error: "missing_lease_or_run" }, 400);
+      const runAttempt = exactReviewRunAttempt(body.run_attempt);
+      if (body.run_attempt !== undefined && runAttempt === null) {
+        return json({ error: "invalid_run_attempt" }, 400);
+      }
+      const outcome = exactReviewCompletionOutcome(body.outcome, "success");
+      if (!outcome) return json({ error: "invalid_outcome" }, 400);
 
       const now = Date.now();
       const state = await this.readState();
       const item = exactReviewItemForLease(state, leaseId);
       if (!item || item.claimedRunId !== runId) return json({ error: "lease_not_claimed" }, 409);
-
-      const requeued = item.revision > Number(item.leaseRevision || 0);
-      if (requeued) {
-        clearExactReviewLease(item);
-        item.state = "pending";
-        item.nextAttemptAt = now;
-        item.attempts = 0;
-        item.updatedAt = now;
-      } else {
-        delete state.items[item.key];
+      if (
+        item.claimedRunAttempt !== undefined &&
+        (runAttempt === null || runAttempt !== item.claimedRunAttempt)
+      ) {
+        return json({ error: "lease_attempt_not_claimed" }, 409);
       }
+
+      // A successful finalizer still runs before GitHub records the workflow-run conclusion.
+      // Keep the claim until the signed workflow_run backstop verifies that exact attempt as
+      // terminal, otherwise cancellation or a failing post-action could be acknowledged as
+      // success. A newer revision is already known to need another review and can requeue now.
+      if (outcome === "success" && item.revision <= Number(item.leaseRevision || 0)) {
+        await this.scheduleNext(state, now);
+        return json({ ok: true, requeued: false, deferred: true });
+      }
+
+      const requeued = finishExactReviewQueueItem(state, item, now, outcome);
       await this.writeState(state);
       await this.scheduleNext(state, now);
       return json({ ok: true, requeued });
+    }
+
+    if (request.method === "GET" && url.pathname === "/claimed-runs") {
+      const state = await this.readState();
+      const runs = Object.values(state.items)
+        .filter((item) => item.state === "leased" && item.claimedRunId)
+        .slice(0, EXACT_REVIEW_RECONCILE_RUN_LIMIT)
+        .map((item) => ({
+          run_id: String(item.claimedRunId),
+          run_attempt: item.claimedRunAttempt ?? null,
+          claim_generation: exactReviewClaimGeneration(item.claimGeneration),
+        }));
+      return json({ runs });
+    }
+
+    if (request.method === "POST" && url.pathname === "/reconcile") {
+      const body = objectValue(await request.json().catch(() => null));
+      const runs = exactReviewTerminalRuns(body.runs);
+      if (!runs) return json({ error: "invalid_terminal_runs" }, 400);
+
+      const now = Date.now();
+      const state = await this.readState();
+      let reconciled = 0;
+      let requeued = 0;
+      let completed = 0;
+      for (const run of runs) {
+        const matches = Object.values(state.items).filter(
+          (item) =>
+            item.state === "leased" &&
+            item.claimedRunId === run.runId &&
+            exactReviewClaimGeneration(item.claimGeneration) === run.claimGeneration &&
+            (item.claimedRunAttempt ?? null) === (run.claimedRunAttempt ?? null),
+        );
+        if (matches.length !== 1) continue;
+        const item = matches[0];
+        const didRequeue = finishExactReviewQueueItem(state, item, now, run.outcome);
+        reconciled += 1;
+        if (didRequeue) requeued += 1;
+        else completed += 1;
+      }
+      if (reconciled) {
+        await this.writeState(state);
+        await this.scheduleNext(state, now);
+      }
+      return json({ ok: true, reconciled, requeued, completed });
     }
 
     if (request.method === "GET" && url.pathname === "/stats") {
@@ -652,6 +725,8 @@ export default {
       return exactReviewQueueRequest(env, "/claim", request);
     if (url.pathname === "/internal/exact-review/complete" && request.method === "POST")
       return exactReviewQueueRequest(env, "/complete", request);
+    if (url.pathname === "/internal/exact-review/reconcile" && request.method === "POST")
+      return authenticatedExactReviewReconcile(request, env);
     if (url.pathname === "/api/exact-review-queue" && request.method === "GET")
       return exactReviewQueueRequest(env, "/stats");
     if (url.pathname === "/api/status") return statusJson(request, env, ctx);
@@ -1171,6 +1246,104 @@ async function authenticatedExactReviewEnqueue(request, env) {
   );
 }
 
+async function authenticatedExactReviewReconcile(request, env) {
+  const secret = stringEnv(env.CLAWSWEEPER_WEBHOOK_SECRET);
+  if (!secret) return json({ error: "webhook_not_configured" }, 503);
+  const bodyText = await request.text();
+  const signature = request.headers.get("x-clawsweeper-exact-review-signature") || "";
+  if (!(await verifyGithubWebhookSignature({ secret, signature, bodyText }))) {
+    return json({ error: "invalid_signature" }, 401);
+  }
+  const body = parseJsonObject(bodyText);
+  if (!body) return json({ error: "invalid_json" }, 400);
+  const requestedRuns = exactReviewRequestedRuns(body.runs ?? body.run_ids);
+  if (!requestedRuns) return json({ error: "invalid_runs" }, 400);
+
+  const claimedResponse = await exactReviewQueueRequest(env, "/claimed-runs");
+  if (!claimedResponse.ok) return json({ error: "exact_review_queue_unavailable" }, 503);
+  const claimedBody = objectValue(await claimedResponse.json().catch(() => null));
+  const claimedRuns = exactReviewClaimedRuns(claimedBody.runs);
+  if (!claimedRuns) return json({ error: "exact_review_queue_unavailable" }, 503);
+  const candidates: Array<ExactReviewClaimedRun & { requestedRunAttempt?: number }> = [];
+  for (const requested of requestedRuns) {
+    const matches = claimedRuns.filter((claimed) => claimed.runId === requested.runId);
+    if (matches.length !== 1) continue;
+    candidates.push({ ...matches[0], requestedRunAttempt: requested.runAttempt });
+  }
+  if (!candidates.length) {
+    return json({
+      ok: true,
+      requested: requestedRuns.length,
+      claimed: 0,
+      terminal: 0,
+      unavailable: 0,
+      reconciled: 0,
+      requeued: 0,
+      completed: 0,
+    });
+  }
+
+  let token: string;
+  try {
+    token = await exactReviewActionsReadToken(env);
+  } catch {
+    return json({ error: "github_run_status_unavailable" }, 502);
+  }
+  const checked = await mapWithConcurrency(
+    candidates,
+    EXACT_REVIEW_RECONCILE_CONCURRENCY,
+    async (candidate) => {
+      try {
+        return await exactReviewTerminalRun(token, candidate);
+      } catch {
+        return undefined;
+      }
+    },
+  );
+  const unavailable = checked.filter((result) => result === undefined).length;
+  const terminalRuns = checked.filter(
+    (
+      result,
+    ): result is {
+      run_id: string;
+      run_attempt: number;
+      claimed_run_attempt: number | null;
+      claim_generation: number;
+      outcome: ExactReviewCompletionOutcome;
+    } => Boolean(result),
+  );
+  let reconciliation = { reconciled: 0, requeued: 0, completed: 0 };
+  if (terminalRuns.length) {
+    const response = await exactReviewQueueRequest(
+      env,
+      "/reconcile",
+      new Request("https://clawsweeper-exact-review-queue/reconcile", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ runs: terminalRuns }),
+      }),
+    );
+    if (!response.ok) return json({ error: "exact_review_reconcile_failed" }, 502);
+    const result = objectValue(await response.json().catch(() => null));
+    reconciliation = {
+      reconciled: Number(result.reconciled) || 0,
+      requeued: Number(result.requeued) || 0,
+      completed: Number(result.completed) || 0,
+    };
+  }
+  return json(
+    {
+      ok: unavailable === 0,
+      requested: requestedRuns.length,
+      claimed: candidates.length,
+      terminal: terminalRuns.length,
+      unavailable,
+      ...reconciliation,
+    },
+    unavailable ? 502 : 200,
+  );
+}
+
 async function enqueueExactReview({
   deliveryId,
   decision,
@@ -1285,11 +1458,149 @@ function exactReviewItemForLease(state: ExactReviewQueueState, leaseId: string) 
   return Object.values(state.items).find((item) => item.leaseId === leaseId) || null;
 }
 
+function exactReviewCompletionOutcome(
+  value,
+  fallback?: ExactReviewCompletionOutcome,
+): ExactReviewCompletionOutcome | null {
+  const normalized =
+    value === undefined || value === null || value === "" ? fallback : String(value);
+  return normalized === "success" || normalized === "failure" || normalized === "cancelled"
+    ? normalized
+    : null;
+}
+
+function exactReviewRunAttempt(value): number | null {
+  const runAttempt = Number(value);
+  return Number.isInteger(runAttempt) && runAttempt > 0 ? runAttempt : null;
+}
+
+function exactReviewClaimGeneration(value) {
+  const generation = Number(value);
+  return Number.isInteger(generation) && generation >= 0 ? generation : 0;
+}
+
+function exactReviewTerminalRuns(value) {
+  if (!Array.isArray(value) || value.length > EXACT_REVIEW_RECONCILE_RUN_LIMIT) return null;
+  const runs: Array<
+    ExactReviewClaimedRun & {
+      runAttempt: number;
+      claimedRunAttempt?: number;
+      outcome: ExactReviewCompletionOutcome;
+    }
+  > = [];
+  const seen = new Set<string>();
+  for (const entry of value) {
+    const record = objectValue(entry);
+    const runId = String(record.run_id || "").trim();
+    const runAttempt = exactReviewRunAttempt(record.run_attempt);
+    const claimedRunAttempt =
+      record.claimed_run_attempt === null || record.claimed_run_attempt === undefined
+        ? undefined
+        : exactReviewRunAttempt(record.claimed_run_attempt);
+    const claimGeneration = Number(record.claim_generation);
+    const outcome = exactReviewCompletionOutcome(record.outcome);
+    if (
+      !/^\d+$/.test(runId) ||
+      !runAttempt ||
+      claimedRunAttempt === null ||
+      !Number.isInteger(claimGeneration) ||
+      claimGeneration < 0 ||
+      !outcome
+    ) {
+      return null;
+    }
+    const key = `${runId}:${runAttempt}:${claimGeneration}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    runs.push({ runId, runAttempt, claimedRunAttempt, claimGeneration, outcome });
+  }
+  return runs;
+}
+
+function exactReviewRequestedRuns(value) {
+  if (
+    !Array.isArray(value) ||
+    value.length < 1 ||
+    value.length > EXACT_REVIEW_RECONCILE_RUN_LIMIT
+  ) {
+    return null;
+  }
+  const runs: Array<{ runId: string; runAttempt?: number }> = [];
+  const seen = new Set<string>();
+  for (const entry of value) {
+    const record = objectValue(entry);
+    const runId = String(record.run_id || (typeof entry !== "object" ? entry : "")).trim();
+    if (!/^\d+$/.test(runId)) return null;
+    const hasRunAttempt = Object.hasOwn(record, "run_attempt");
+    const runAttempt = hasRunAttempt ? exactReviewRunAttempt(record.run_attempt) : null;
+    if (hasRunAttempt && !runAttempt) return null;
+    const key = `${runId}:${runAttempt || "latest"}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    runs.push({ runId, ...(runAttempt ? { runAttempt } : {}) });
+  }
+  return runs;
+}
+
+function exactReviewClaimedRuns(value): ExactReviewClaimedRun[] | null {
+  if (!Array.isArray(value) || value.length > EXACT_REVIEW_RECONCILE_RUN_LIMIT) return null;
+  const runs: ExactReviewClaimedRun[] = [];
+  for (const entry of value) {
+    const record = objectValue(entry);
+    const runId = String(record.run_id || "").trim();
+    const runAttempt =
+      record.run_attempt === null || record.run_attempt === undefined
+        ? undefined
+        : exactReviewRunAttempt(record.run_attempt);
+    const claimGeneration = Number(record.claim_generation);
+    if (
+      !/^\d+$/.test(runId) ||
+      runAttempt === null ||
+      !Number.isInteger(claimGeneration) ||
+      claimGeneration < 0
+    ) {
+      return null;
+    }
+    runs.push({ runId, runAttempt, claimGeneration });
+  }
+  return runs;
+}
+
+function finishExactReviewQueueItem(
+  state: ExactReviewQueueState,
+  item: ExactReviewQueueItem,
+  now: number,
+  outcome: ExactReviewCompletionOutcome,
+) {
+  const retryingFailure = outcome !== "success";
+  const requeued = retryingFailure || item.revision > Number(item.leaseRevision || 0);
+  if (requeued) {
+    clearExactReviewLease(item);
+    item.state = "pending";
+    if (retryingFailure) {
+      item.attempts += 1;
+      item.nextAttemptAt = Math.max(
+        exactReviewQueueEnqueueAttemptAt(state, now),
+        now + exactReviewRetryDelayMs(item.attempts),
+      );
+    } else {
+      item.nextAttemptAt = exactReviewQueueEnqueueAttemptAt(state, now);
+      item.attempts = 0;
+    }
+    item.updatedAt = now;
+  } else {
+    delete state.items[item.key];
+  }
+  return requeued;
+}
+
 function clearExactReviewLease(item: ExactReviewQueueItem) {
   item.leaseId = undefined;
   item.leaseRevision = undefined;
   item.leaseExpiresAt = undefined;
   item.claimedRunId = undefined;
+  item.claimedRunAttempt = undefined;
+  item.claimGeneration = undefined;
 }
 
 function isLiveExactReviewLease(item: ExactReviewQueueItem, now: number) {
@@ -1558,6 +1869,14 @@ function exactReviewWorkflowPausedRetryMs(env) {
 }
 
 async function exactReviewDispatchToken(env) {
+  return exactReviewRepositoryToken(env, { actions: "read", contents: "write" });
+}
+
+async function exactReviewActionsReadToken(env) {
+  return exactReviewRepositoryToken(env, { actions: "read" });
+}
+
+async function exactReviewRepositoryToken(env, permissions) {
   const credentials = githubAppCredentials(env);
   if (!credentials) throw new Error("github app is not configured");
   const appJwt = await signGithubAppJwt(credentials.issuer, credentials.privateKey);
@@ -1567,7 +1886,7 @@ async function exactReviewDispatchToken(env) {
     installationId,
     label: CLAWSWEEPER_REVIEW_REPO,
     repositories: [repoName(CLAWSWEEPER_REVIEW_REPO)],
-    permissions: { actions: "read", contents: "write" },
+    permissions,
   });
 }
 
@@ -1582,6 +1901,60 @@ async function exactReviewWorkflowState(token: string) {
   const state = String(payload.state || "").trim();
   if (!state) throw new Error("ClawSweeper workflow status response missing state");
   return state;
+}
+
+async function exactReviewTerminalRun(
+  token: string,
+  candidate: ExactReviewClaimedRun & { requestedRunAttempt?: number },
+) {
+  const expectedRunAttempt = candidate.requestedRunAttempt ?? candidate.runAttempt;
+  const latest = await githubTokenJson({
+    token,
+    path: `/repos/${CLAWSWEEPER_REVIEW_REPO}/actions/runs/${candidate.runId}`,
+    method: "GET",
+    body: undefined,
+    errorLabel: "ClawSweeper run status",
+  });
+  if (String(latest.id || "") !== candidate.runId) {
+    throw new Error("ClawSweeper run status response id mismatch");
+  }
+  const latestRunAttempt = exactReviewRunAttempt(latest.run_attempt);
+  if (!latestRunAttempt) {
+    throw new Error("ClawSweeper run status response attempt mismatch");
+  }
+  if (expectedRunAttempt && latestRunAttempt !== expectedRunAttempt) return null;
+  if (String(latest.status || "") !== "completed") return null;
+
+  const payload = await githubTokenJson({
+    token,
+    path: `/repos/${CLAWSWEEPER_REVIEW_REPO}/actions/runs/${candidate.runId}/attempts/${latestRunAttempt}`,
+    method: "GET",
+    body: undefined,
+    errorLabel: "ClawSweeper run attempt status",
+  });
+  if (
+    String(payload.id || "") !== candidate.runId ||
+    exactReviewRunAttempt(payload.run_attempt) !== latestRunAttempt ||
+    String(payload.status || "") !== "completed"
+  ) {
+    throw new Error("ClawSweeper run attempt status response mismatch");
+  }
+  const conclusion = String(payload.conclusion || "").trim();
+  if (!conclusion) throw new Error("ClawSweeper completed run missing conclusion");
+  return {
+    run_id: candidate.runId,
+    run_attempt: latestRunAttempt,
+    claimed_run_attempt: candidate.runAttempt ?? null,
+    claim_generation: candidate.claimGeneration,
+    outcome:
+      conclusion === "success" ? "success" : conclusion === "cancelled" ? "cancelled" : "failure",
+  } satisfies {
+    run_id: string;
+    run_attempt: number;
+    claimed_run_attempt: number | null;
+    claim_generation: number;
+    outcome: ExactReviewCompletionOutcome;
+  };
 }
 
 async function createGithubAppTokenFor({

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -124,9 +124,16 @@ backlog drain.
 
 Each dispatched workflow claims its opaque lease before checkout. Duplicate
 dispatches and stale workflows cannot claim the same lease, and a completion
-releases the lease or immediately schedules the newest revision. If a workflow
-never claims or completes, the Durable Object reclaims the expired lease. This
-keeps capacity waiting and retry state out of GitHub Actions runners.
+immediately schedules a known newer revision. Failed and cancelled executors
+requeue their item with bounded retry backoff. Successful finalizer reports stay
+leased until a signed terminal-run reconciliation backstop confirms that exact
+GitHub attempt completed successfully; this backstop can also recover terminal
+failed or cancelled runs before lease expiry.
+Run-attempt binding and a per-claim generation check keep delayed terminal
+decisions from releasing a later rerun; queued and in-progress runs are never
+released. If a workflow never claims or completes, the Durable Object reclaims
+the expired lease. This keeps capacity waiting and retry state out of GitHub
+Actions runners.
 
 Examples with the current config:
 

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -203,6 +203,10 @@ is `{ "runs": [{ "run_id": "<run-id>", "run_attempt": 1 }] }`, signed over the
 exact bytes with `CLAWSWEEPER_WEBHOOK_SECRET` in
 `x-clawsweeper-exact-review-signature: sha256=<hmac>`.
 
+Keep the sweep workflow disabled and wait for `/api/exact-review-queue` to show
+both `dispatching: 0` and `leased: 0` before deploying this Worker revision.
 Deploy the Worker route from the reviewed revision before merging or enabling
-any workflow that calls the reconciliation endpoint. This keeps workflow
-finalizers compatible throughout a staged rollout.
+any workflow that calls the reconciliation endpoint. The dashboard deployment
+smoke test must observe HTTP 401 from an unsigned reconciliation request; HTTP
+404 means the old Worker is still serving. This order keeps legacy finalizers
+from creating provisional successes before the terminal-run backstop exists.

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -187,3 +187,22 @@ default). `/api/exact-review-queue` exposes the bounded dispatcher state, reason
 workflow state, check time, and retry time so an intentional pause cannot look
 like occupied executor capacity. Re-enabling the workflow does not require a
 queue mutation; the next status check resumes normal admission.
+
+Executors report the GitHub job outcome from their finalizer. Failure or
+cancellation clears the lease and requeues the item. Finalizer success remains
+provisional because GitHub can still cancel the run or fail a post-action; only
+the signed terminal-run backstop removes the item after GitHub confirms the
+exact attempt succeeded. A newer revision can requeue immediately. A signed
+`POST /internal/exact-review/reconcile` backstop accepts at most 32 exact run IDs
+and intersects them with currently claimed leases. The Worker checks those IDs
+and attempts with an Actions-read GitHub App token and reconciles only runs
+whose immutable GitHub attempt status is `completed`; queued and in-progress
+runs remain leased. A per-claim generation check prevents a terminal decision
+sampled before a rerun claim from releasing that newer attempt. The request body
+is `{ "runs": [{ "run_id": "<run-id>", "run_attempt": 1 }] }`, signed over the
+exact bytes with `CLAWSWEEPER_WEBHOOK_SECRET` in
+`x-clawsweeper-exact-review-signature: sha256=<hmac>`.
+
+Deploy the Worker route from the reviewed revision before merging or enabling
+any workflow that calls the reconciliation endpoint. This keeps workflow
+finalizers compatible throughout a staged rollout.

--- a/scripts/dashboard-smoke.mjs
+++ b/scripts/dashboard-smoke.mjs
@@ -29,6 +29,17 @@ async function main() {
     }
   }
 
+  const reconcileResponse = await fetch(`${baseUrl}/internal/exact-review/reconcile`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: "{}",
+  });
+  if (reconcileResponse.status !== 401) {
+    throw new Error(
+      `${baseUrl}/internal/exact-review/reconcile returned ${reconcileResponse.status}, expected 401`,
+    );
+  }
+
   const html = await fetchText(`${baseUrl}/`);
   if (!html.includes("ClawSweeper Live")) throw new Error("dashboard HTML title missing");
   if (!html.includes("System Overview")) throw new Error("dashboard system overview missing");
@@ -44,6 +55,7 @@ async function main() {
         worker_details: status.workers.length,
         pipeline_rows: status.pipeline.length,
         exact_review_queue: exactReviewQueue,
+        exact_review_reconcile_status: reconcileResponse.status,
         cache_state: cacheState,
         status_fetch_ms: statusFetchMs,
         diagnostic_errors: status.diagnostics?.errors || [],

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2184,6 +2184,7 @@ test("sweep workflow executes only durable queue leases without runner-side admi
   assert.ok(inProgressStatusIndex > setupPnpmIndex);
   assert.ok(setupCodexIndex > inProgressStatusIndex);
   assert.ok(exactReviewIndex > setupCodexIndex);
+  assert.equal(eventReviewBlock.match(/- name: Fail unsuccessful exact review/g)?.length, 1);
   assert.ok(failReviewIndex > exactReviewIndex);
   assert.ok(completeLeaseIndex > failReviewIndex);
   assert.match(eventReviewBlock, /\/internal\/exact-review\/claim/);
@@ -2203,6 +2204,8 @@ test("sweep workflow executes only durable queue leases without runner-side admi
     /steps\.route-synced-verdict\.outcome != 'success'/,
   );
   assert.match(completeLeaseStep, /JOB_STATUS: \$\{\{ job\.status \}\}/);
+  assert.match(completeLeaseStep, /if: \$\{\{ always\(\) \}\}/);
+  assert.match(completeLeaseStep, /continue-on-error: true/);
   assert.match(completeLeaseStep, /RUN_ATTEMPT: \$\{\{ github\.run_attempt \}\}/);
   assert.match(completeLeaseStep, /process\.env\.JOB_STATUS === "cancelled"/);
   assert.match(completeLeaseStep, /run_attempt: runAttempt/);

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2151,6 +2151,16 @@ test("sweep workflow executes only durable queue leases without runner-side admi
   );
   const setupCodexIndex = eventReviewBlock.indexOf("- uses: ./.github/actions/setup-codex");
   const exactReviewIndex = eventReviewBlock.indexOf("- name: Review exact event item");
+  const failReviewIndex = eventReviewBlock.indexOf("- name: Fail unsuccessful exact review");
+  const completeLeaseIndex = eventReviewBlock.indexOf("- name: Complete exact-review queue lease");
+  const claimStep = eventReviewBlock.slice(
+    claimIndex,
+    eventReviewBlock.indexOf("\n      - ", claimIndex + 1),
+  );
+  const completeLeaseStep = eventReviewBlock.slice(
+    completeLeaseIndex,
+    eventReviewBlock.indexOf("\n      - ", completeLeaseIndex + 1),
+  );
   const exactReviewStep = eventReviewBlock.slice(
     exactReviewIndex,
     eventReviewBlock.indexOf("- name: Create state token", exactReviewIndex),
@@ -2174,8 +2184,29 @@ test("sweep workflow executes only durable queue leases without runner-side admi
   assert.ok(inProgressStatusIndex > setupPnpmIndex);
   assert.ok(setupCodexIndex > inProgressStatusIndex);
   assert.ok(exactReviewIndex > setupCodexIndex);
+  assert.ok(failReviewIndex > exactReviewIndex);
+  assert.ok(completeLeaseIndex > failReviewIndex);
   assert.match(eventReviewBlock, /\/internal\/exact-review\/claim/);
   assert.match(eventReviewBlock, /\/internal\/exact-review\/complete/);
+  assert.match(claimStep, /RUN_ATTEMPT: \$\{\{ github\.run_attempt \}\}/);
+  assert.match(claimStep, /run_attempt: runAttempt/);
+  assert.match(
+    eventReviewBlock.slice(failReviewIndex, completeLeaseIndex),
+    /steps\.review-exact-event-item\.outcome != 'success'/,
+  );
+  assert.match(
+    eventReviewBlock.slice(failReviewIndex, completeLeaseIndex),
+    /steps\.publish-event-result\.outcome != 'success'/,
+  );
+  assert.match(
+    eventReviewBlock.slice(failReviewIndex, completeLeaseIndex),
+    /steps\.route-synced-verdict\.outcome != 'success'/,
+  );
+  assert.match(completeLeaseStep, /JOB_STATUS: \$\{\{ job\.status \}\}/);
+  assert.match(completeLeaseStep, /RUN_ATTEMPT: \$\{\{ github\.run_attempt \}\}/);
+  assert.match(completeLeaseStep, /process\.env\.JOB_STATUS === "cancelled"/);
+  assert.match(completeLeaseStep, /run_attempt: runAttempt/);
+  assert.match(completeLeaseStep, /outcome,/);
   assert.match(eventReviewBlock, /exact-review queue leased this run/);
   assert.doesNotMatch(eventReviewBlock, /repair:codex-capacity/);
   assert.doesNotMatch(eventReviewBlock, /capacity-requeue/);

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -374,11 +374,16 @@ test("exact-review queue coalesces deliveries, leases bounded work, and rejects 
     );
     assert.deepEqual(await completed.json(), { ok: true, requeued: true });
     const requeued = (await storage.get("exact-review-queue")) as {
-      items: Record<string, { decision: Record<string, unknown> }>;
+      items: Record<
+        string,
+        { attempts: number; nextAttemptAt: number; decision: Record<string, unknown> }
+      >;
     };
     assert.equal(requeued.items["openclaw/gogcli#597"].decision.commandStatusMarker, undefined);
     assert.equal(requeued.items["openclaw/gogcli#597"].decision.statusCommentId, undefined);
     assert.equal(requeued.items["openclaw/gogcli#597"].decision.additionalPrompt, undefined);
+    assert.equal(requeued.items["openclaw/gogcli#597"].attempts, 0);
+    assert.ok(requeued.items["openclaw/gogcli#597"].nextAttemptAt <= Date.now());
     stats = await (
       await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
     ).json();
@@ -852,7 +857,386 @@ test("exact-review queue preserves a claimed lease after an ambiguous dispatch f
         body: JSON.stringify({ lease_id: leaseId, run_id: "ambiguous-run" }),
       }),
     );
-    assert.deepEqual(await completed.json(), { ok: true, requeued: false });
+    assert.deepEqual(await completed.json(), { ok: true, requeued: false, deferred: true });
+    const retained = await (
+      await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+    ).json();
+    assert.equal(retained.leased, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("exact-review queue requeues a cancelled claimed lease", async () => {
+  const storage = new MemoryDurableStorage();
+  const completedAfter = Date.now();
+  const retryAt = completedAfter + 10_000;
+  await storage.put("exact-review-queue", {
+    deliveries: {},
+    dispatcher: {
+      state: "paused",
+      reason: "workflow_not_active",
+      workflowState: "disabled_manually",
+      checkedAt: Date.now(),
+      retryAt,
+    },
+    items: {
+      "openclaw/openclaw#710": leasedExactReviewQueueItem(710, "cancelled-run"),
+    },
+  });
+  const queue = new ExactReviewQueue({ storage }, {});
+
+  const response = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: "lease-710",
+        run_id: "cancelled-run",
+        run_attempt: 1,
+        outcome: "cancelled",
+      }),
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { ok: true, requeued: true });
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<string, Record<string, unknown>>;
+  };
+  assert.equal(state.items["openclaw/openclaw#710"].state, "pending");
+  assert.ok(Number(state.items["openclaw/openclaw#710"].nextAttemptAt) >= completedAfter + 30_000);
+  assert.ok(Number(state.items["openclaw/openclaw#710"].nextAttemptAt) > retryAt);
+  assert.equal(state.items["openclaw/openclaw#710"].attempts, 1);
+  assert.equal(state.items["openclaw/openclaw#710"].leaseId, undefined);
+  assert.equal(state.items["openclaw/openclaw#710"].claimedRunId, undefined);
+  assert.equal(state.items["openclaw/openclaw#710"].claimedRunAttempt, undefined);
+  assert.equal(state.items["openclaw/openclaw#710"].claimGeneration, undefined);
+});
+
+test("exact-review completion rejects stale owners and is race-idempotent", async () => {
+  const storage = new MemoryDurableStorage();
+  await storage.put("exact-review-queue", {
+    deliveries: {},
+    items: {
+      "openclaw/openclaw#716": leasedExactReviewQueueItem(716, "9100", 2),
+      "openclaw/openclaw#717": leasedExactReviewQueueItem(717, "9101", 1),
+    },
+  });
+  const queue = new ExactReviewQueue({ storage }, {});
+  const complete = (leaseId: string, runId: string, runAttempt: number, outcome: string) =>
+    queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/complete", {
+        method: "POST",
+        body: JSON.stringify({
+          lease_id: leaseId,
+          run_id: runId,
+          run_attempt: runAttempt,
+          outcome,
+        }),
+      }),
+    );
+
+  assert.equal((await complete("lease-716", "9100", 1, "failure")).status, 409);
+  assert.equal((await complete("lease-716", "wrong-run", 2, "failure")).status, 409);
+  const failed = await complete("lease-716", "9100", 2, "failure");
+  assert.equal(failed.status, 200);
+  assert.deepEqual(await failed.json(), { ok: true, requeued: true });
+  assert.equal((await complete("lease-716", "9100", 2, "success")).status, 409);
+
+  const completed = await complete("lease-717", "9101", 1, "success");
+  assert.equal(completed.status, 200);
+  assert.deepEqual(await completed.json(), { ok: true, requeued: false, deferred: true });
+  const failedAfterProvisionalSuccess = await complete("lease-717", "9101", 1, "failure");
+  assert.equal(failedAfterProvisionalSuccess.status, 200);
+  assert.deepEqual(await failedAfterProvisionalSuccess.json(), { ok: true, requeued: true });
+
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<string, Record<string, unknown>>;
+  };
+  assert.equal(state.items["openclaw/openclaw#716"].state, "pending");
+  assert.equal(state.items["openclaw/openclaw#716"].attempts, 1);
+  assert.equal(state.items["openclaw/openclaw#716"].leaseId, undefined);
+  assert.equal(state.items["openclaw/openclaw#717"].state, "pending");
+  assert.equal(state.items["openclaw/openclaw#717"].attempts, 1);
+  assert.equal(state.items["openclaw/openclaw#717"].leaseId, undefined);
+});
+
+test("signed exact-review reconciliation releases only immutable terminal runs", async () => {
+  const originalFetch = globalThis.fetch;
+  const storage = new MemoryDurableStorage();
+  await storage.put("exact-review-queue", {
+    deliveries: {},
+    items: {
+      "openclaw/openclaw#711": leasedExactReviewQueueItem(711, "9001"),
+      "openclaw/openclaw#712": leasedExactReviewQueueItem(712, "9002"),
+      "openclaw/openclaw#719": leasedExactReviewQueueItem(719, "9003"),
+    },
+  });
+  const queue = new ExactReviewQueue({ storage }, {});
+  const { privateKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  });
+  globalThis.fetch = async (input, init) => {
+    const url = new URL(String(input));
+    if (url.pathname === "/repos/openclaw/clawsweeper/installation") {
+      return jsonResponse({ id: 999 });
+    }
+    if (url.pathname === "/app/installations/999/access_tokens") {
+      assert.deepEqual(JSON.parse(String(init?.body)).permissions, { actions: "read" });
+      return jsonResponse({ token: "t" });
+    }
+    if (url.pathname === "/repos/openclaw/clawsweeper/actions/runs/9001") {
+      return jsonResponse({ id: 9001, run_attempt: 1, status: "completed" });
+    }
+    if (url.pathname === "/repos/openclaw/clawsweeper/actions/runs/9001/attempts/1") {
+      return jsonResponse({
+        id: 9001,
+        run_attempt: 1,
+        status: "completed",
+        conclusion: "cancelled",
+      });
+    }
+    if (url.pathname === "/repos/openclaw/clawsweeper/actions/runs/9002") {
+      return jsonResponse({ id: 9002, run_attempt: 1, status: "in_progress", conclusion: null });
+    }
+    if (url.pathname === "/repos/openclaw/clawsweeper/actions/runs/9003") {
+      return jsonResponse({ id: 9003, run_attempt: 1, status: "completed" });
+    }
+    if (url.pathname === "/repos/openclaw/clawsweeper/actions/runs/9003/attempts/1") {
+      return jsonResponse({
+        id: 9003,
+        run_attempt: 1,
+        status: "completed",
+        conclusion: "success",
+      });
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  };
+
+  try {
+    const env = {
+      CLAWSWEEPER_APP_CLIENT_ID: "Iv23test",
+      CLAWSWEEPER_APP_PRIVATE_KEY: privateKey,
+      CLAWSWEEPER_WEBHOOK_SECRET: "test-secret",
+      EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+    };
+    const body = JSON.stringify({
+      runs: [
+        { run_id: "9001", run_attempt: 1 },
+        { run_id: "9002", run_attempt: 1 },
+        { run_id: "9003", run_attempt: 1 },
+      ],
+    });
+    const unsigned = await worker.fetch(
+      new Request("https://clawsweeper.openclaw.ai/internal/exact-review/reconcile", {
+        method: "POST",
+        body,
+      }),
+      env,
+    );
+    assert.equal(unsigned.status, 401);
+
+    const oversizedBody = JSON.stringify({
+      run_ids: Array.from({ length: 33 }, (_, index) => String(index + 1)),
+    });
+    const oversizedSignature = `sha256=${createHmac("sha256", "test-secret").update(oversizedBody).digest("hex")}`;
+    const oversized = await worker.fetch(
+      new Request("https://clawsweeper.openclaw.ai/internal/exact-review/reconcile", {
+        method: "POST",
+        headers: { "x-clawsweeper-exact-review-signature": oversizedSignature },
+        body: oversizedBody,
+      }),
+      env,
+    );
+    assert.equal(oversized.status, 400);
+    assert.deepEqual(await oversized.json(), { error: "invalid_runs" });
+
+    const signature = `sha256=${createHmac("sha256", "test-secret").update(body).digest("hex")}`;
+    const response = await worker.fetch(
+      new Request("https://clawsweeper.openclaw.ai/internal/exact-review/reconcile", {
+        method: "POST",
+        headers: { "x-clawsweeper-exact-review-signature": signature },
+        body,
+      }),
+      env,
+    );
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      ok: true,
+      requested: 3,
+      claimed: 3,
+      terminal: 2,
+      unavailable: 0,
+      reconciled: 2,
+      requeued: 1,
+      completed: 1,
+    });
+    const state = (await storage.get("exact-review-queue")) as {
+      items: Record<string, Record<string, unknown>>;
+    };
+    assert.equal(state.items["openclaw/openclaw#711"].state, "pending");
+    assert.equal(state.items["openclaw/openclaw#711"].claimedRunId, undefined);
+    assert.equal(state.items["openclaw/openclaw#712"].state, "leased");
+    assert.equal(state.items["openclaw/openclaw#712"].claimedRunId, "9002");
+    assert.equal(state.items["openclaw/openclaw#719"], undefined);
+    const staleFailure = await queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/complete", {
+        method: "POST",
+        body: JSON.stringify({
+          lease_id: "lease-719",
+          run_id: "9003",
+          run_attempt: 1,
+          outcome: "failure",
+        }),
+      }),
+    );
+    assert.equal(staleFailure.status, 409);
+
+    const replayBody = JSON.stringify({ runs: [{ run_id: "9001", run_attempt: 1 }] });
+    const replaySignature = `sha256=${createHmac("sha256", "test-secret").update(replayBody).digest("hex")}`;
+    const replay = await worker.fetch(
+      new Request("https://clawsweeper.openclaw.ai/internal/exact-review/reconcile", {
+        method: "POST",
+        headers: { "x-clawsweeper-exact-review-signature": replaySignature },
+        body: replayBody,
+      }),
+      env,
+    );
+    assert.equal(replay.status, 200);
+    assert.deepEqual(await replay.json(), {
+      ok: true,
+      requested: 1,
+      claimed: 0,
+      terminal: 0,
+      unavailable: 0,
+      reconciled: 0,
+      requeued: 0,
+      completed: 0,
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("exact-review reconciliation cannot release a later attempt with the same run id", async () => {
+  const originalFetch = globalThis.fetch;
+  const storage = new MemoryDurableStorage();
+  await storage.put("exact-review-queue", {
+    deliveries: {},
+    items: {
+      "openclaw/openclaw#713": leasedExactReviewQueueItem(713, "9010"),
+      "openclaw/openclaw#714": {
+        ...leasedExactReviewQueueItem(714, "9011"),
+        claimedRunAttempt: undefined,
+        claimGeneration: 2,
+      },
+      "openclaw/openclaw#715": leasedExactReviewQueueItem(715, "9012"),
+      "openclaw/openclaw#718": leasedExactReviewQueueItem(718, "9013"),
+    },
+  });
+  const queue = new ExactReviewQueue({ storage }, {});
+  const { privateKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  });
+  globalThis.fetch = async (input) => {
+    const url = new URL(String(input));
+    if (url.pathname === "/repos/openclaw/clawsweeper/installation") {
+      return jsonResponse({ id: 999 });
+    }
+    if (url.pathname === "/app/installations/999/access_tokens") {
+      return jsonResponse({ token: "t" });
+    }
+    if (url.pathname === "/repos/openclaw/clawsweeper/actions/runs/9010") {
+      return jsonResponse({ id: 9010, run_attempt: 1, status: "completed" });
+    }
+    if (url.pathname === "/repos/openclaw/clawsweeper/actions/runs/9010/attempts/1") {
+      const claim = await queue.fetch(
+        new Request("https://clawsweeper-exact-review-queue/claim", {
+          method: "POST",
+          body: JSON.stringify({ lease_id: "lease-713", run_id: "9010", run_attempt: 2 }),
+        }),
+      );
+      assert.equal(claim.status, 200);
+      return jsonResponse({
+        id: 9010,
+        run_attempt: 1,
+        status: "completed",
+        conclusion: "cancelled",
+      });
+    }
+    if (url.pathname === "/repos/openclaw/clawsweeper/actions/runs/9011") {
+      return jsonResponse({ id: 9011, run_attempt: 2, status: "in_progress", conclusion: null });
+    }
+    if (url.pathname === "/repos/openclaw/clawsweeper/actions/runs/9012") {
+      return jsonResponse({ id: 9012, run_attempt: 2, status: "queued", conclusion: null });
+    }
+    if (url.pathname === "/repos/openclaw/clawsweeper/actions/runs/9013") {
+      return jsonResponse({ id: 9013, run_attempt: 2, status: "completed" });
+    }
+    if (url.pathname === "/repos/openclaw/clawsweeper/actions/runs/9013/attempts/2") {
+      return jsonResponse({ id: 9013, run_attempt: 2, status: "completed", conclusion: "failure" });
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  };
+
+  try {
+    const env = {
+      CLAWSWEEPER_APP_CLIENT_ID: "Iv23test",
+      CLAWSWEEPER_APP_PRIVATE_KEY: privateKey,
+      CLAWSWEEPER_WEBHOOK_SECRET: "test-secret",
+      EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+    };
+    const body = JSON.stringify({
+      runs: [
+        { run_id: "9010", run_attempt: 1 },
+        { run_id: "9011", run_attempt: 1 },
+        { run_id: "9012", run_attempt: 1 },
+        { run_id: "9013", run_attempt: 2 },
+      ],
+    });
+    const signature = `sha256=${createHmac("sha256", "test-secret").update(body).digest("hex")}`;
+    const response = await worker.fetch(
+      new Request("https://clawsweeper.openclaw.ai/internal/exact-review/reconcile", {
+        method: "POST",
+        headers: { "x-clawsweeper-exact-review-signature": signature },
+        body,
+      }),
+      env,
+    );
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      ok: true,
+      requested: 4,
+      claimed: 4,
+      terminal: 2,
+      unavailable: 0,
+      reconciled: 1,
+      requeued: 1,
+      completed: 0,
+    });
+    const state = (await storage.get("exact-review-queue")) as {
+      items: Record<string, Record<string, unknown>>;
+    };
+    assert.equal(state.items["openclaw/openclaw#713"].state, "leased");
+    assert.equal(state.items["openclaw/openclaw#713"].claimedRunId, "9010");
+    assert.equal(state.items["openclaw/openclaw#713"].claimedRunAttempt, 2);
+    assert.equal(state.items["openclaw/openclaw#713"].claimGeneration, 2);
+    assert.equal(state.items["openclaw/openclaw#714"].state, "leased");
+    assert.equal(state.items["openclaw/openclaw#714"].claimedRunId, "9011");
+    assert.equal(state.items["openclaw/openclaw#714"].claimedRunAttempt, undefined);
+    assert.equal(state.items["openclaw/openclaw#714"].claimGeneration, 2);
+    assert.equal(state.items["openclaw/openclaw#715"].state, "leased");
+    assert.equal(state.items["openclaw/openclaw#715"].claimedRunId, "9012");
+    assert.equal(state.items["openclaw/openclaw#715"].claimedRunAttempt, 1);
+    assert.equal(state.items["openclaw/openclaw#715"].claimGeneration, 1);
+    assert.equal(state.items["openclaw/openclaw#718"].state, "pending");
+    assert.equal(state.items["openclaw/openclaw#718"].attempts, 1);
+    assert.equal(state.items["openclaw/openclaw#718"].claimedRunId, undefined);
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -4581,4 +4965,32 @@ function buildExactReviewQueueRequest(
       },
     }),
   });
+}
+
+function leasedExactReviewQueueItem(itemNumber: number, runId: string, runAttempt = 1) {
+  const now = Date.now();
+  return {
+    key: `openclaw/openclaw#${itemNumber}`,
+    decision: {
+      targetRepo: "openclaw/openclaw",
+      targetBranch: "main",
+      itemNumber,
+      itemKind: "issue",
+      sourceEvent: "issues",
+      sourceAction: "opened",
+      supersedesInProgress: false,
+    },
+    state: "leased",
+    revision: 1,
+    createdAt: now - 60_000,
+    updatedAt: now - 60_000,
+    nextAttemptAt: now - 60_000,
+    attempts: 0,
+    leaseId: `lease-${itemNumber}`,
+    leaseRevision: 1,
+    leaseExpiresAt: now + 60 * 60_000,
+    claimedRunId: runId,
+    claimedRunAttempt: runAttempt,
+    claimGeneration: 1,
+  };
 }

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -73,6 +73,7 @@ test("exact event publish and routing require a successful fresh review artifact
 
 test("dashboard syncs Worker secrets with durable lifecycle storage", () => {
   const workflow = readText(".github/workflows/dashboard.yml");
+  const smoke = readText("scripts/dashboard-smoke.mjs");
   const config = readText("dashboard/wrangler.toml");
 
   assert.doesNotMatch(workflow, /storage\/kv\/namespaces/);
@@ -84,6 +85,9 @@ test("dashboard syncs Worker secrets with durable lifecycle storage", () => {
   assert.match(workflow, /Content-Type: application\/merge-patch\+json/);
   assert.match(workflow, /jq -e '\.success == true'/);
   assert.doesNotMatch(workflow, /wrangler@[^\s]+ secret bulk/);
+  assert.match(smoke, /\/internal\/exact-review\/reconcile/);
+  assert.match(smoke, /method: "POST"/);
+  assert.match(smoke, /reconcileResponse\.status !== 401/);
 });
 
 test("dashboard CI refreshes on cadence without completion-trigger storms", () => {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -98,6 +98,37 @@ test("dashboard CI refreshes on cadence without completion-trigger storms", () =
   assert.match(concurrency, /cancel-in-progress: true/);
 });
 
+test("terminal exact-review runs reconcile through a signed isolated backstop", () => {
+  const workflow = readText(".github/workflows/exact-review-reconcile.yml");
+
+  assert.match(workflow, /name: Reconcile exact-review leases/);
+  assert.match(workflow, /workflow_run:\s+workflows: \[ClawSweeper\]\s+types: \[completed\]/);
+  assert.match(workflow, /permissions: \{\}/);
+  assert.match(
+    workflow,
+    /group: exact-review-reconcile-\$\{\{ github\.event\.workflow_run\.id \}\}/,
+  );
+  assert.match(workflow, /cancel-in-progress: false/);
+  assert.match(workflow, /github\.event\.workflow_run\.event == 'repository_dispatch'/);
+  assert.match(
+    workflow,
+    /startsWith\(github\.event\.workflow_run\.display_title, 'Review event item '\)/,
+  );
+  assert.match(
+    workflow,
+    /SOURCE_RUN_ATTEMPT: \$\{\{ github\.event\.workflow_run\.run_attempt \}\}/,
+  );
+  assert.match(workflow, /SOURCE_RUN_ID: \$\{\{ github\.event\.workflow_run\.id \}\}/);
+  assert.match(workflow, /run_id: process\.env\.SOURCE_RUN_ID/);
+  assert.match(workflow, /run_attempt: runAttempt/);
+  assert.match(workflow, /CLAWSWEEPER_WEBHOOK_SECRET/);
+  assert.match(workflow, /x-clawsweeper-exact-review-signature: \$signature/);
+  assert.match(workflow, /--data-binary "\$payload"/);
+  assert.match(workflow, /\/internal\/exact-review\/reconcile/);
+  assert.doesNotMatch(workflow, /actions\/checkout/);
+  assert.doesNotMatch(workflow, /(?:GH_TOKEN|GITHUB_TOKEN|github\.token)/);
+});
+
 test("publish workflow installs Codex from the root checkout path", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const publishJobStart = workflow.indexOf("\n  publish:");


### PR DESCRIPTION
## Summary

- bind exact-review queue claims and finalizers to the GitHub run attempt and requeue failed or cancelled work with bounded backoff
- keep successful finalizer reports provisional until a signed `workflow_run` backstop verifies the immutable terminal attempt
- guard reconciliation with the claimed attempt and per-claim generation so delayed cleanup cannot release a live rerun
- add a zero-permission standalone backstop plus workflow, documentation, and race regression coverage

## Validation

- `pnpm run build:all`
- `pnpm run lint:dashboard`
- `pnpm run lint:scripts`
- `node --test test/dashboard-worker.test.ts test/clawsweeper.test.ts test/sweep-workflow.test.ts` (184 passed)
- `node --test test/apply-runtime-budget.test.ts` (8 passed)
- `node --test test/failed-review-retry.test.ts` (16 passed)
- `node --test test/codex-review-runner.test.ts` (17 passed)
- `pnpm run test:repair` (655 passed)
- `pnpm run test:coverage:changed` (100% lines/functions, 89.17% branches)
- `pnpm run format:check`
- autoreview clean

The all-at-once local unit and coverage invocations also hit unrelated load-sensitive deadline/EPIPE tests; every affected file passed when rerun alone. CI remains authoritative.

## Rollout order

Deploy the dashboard Worker from this reviewed branch before merging the workflow callers. Keep the sweep workflow disabled until the separate mutation-boundary CAS gate is landed and this branch is rebased with fresh exact-head CI.
