### PR TITLE
fix: target exact review reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Reconciled terminal exact-review runs by requested run instead of sampling the first 32 claimed leases, while preserving attempt and claim-generation guards across larger worker waves.
 - Published exact-review records, plans, and decision packets as one validated tuple, and made broad sweep publishers preserve the semantically newer tuple and independently merged status health instead of replaying stale review state.
 - Requeued cancelled and failed exact-review leases, kept pre-terminal success provisional, and added signed exact-attempt reconciliation with claim-generation guards that releases only GitHub-confirmed terminal runs while preserving live workers.
 - Kept exact-review work pending with an explicit bounded retry when GitHub Actions cannot confirm that the executor workflow is active, instead of reporting silent repository dispatches to a disabled workflow as occupied capacity.

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -97,6 +97,7 @@ const DEFAULT_EXACT_REVIEW_EXECUTION_LEASE_MS = 130 * 60 * 1000;
 const DEFAULT_EXACT_REVIEW_RETRY_MS = 30_000;
 const DEFAULT_EXACT_REVIEW_WORKFLOW_PAUSED_RETRY_MS = 60_000;
 const EXACT_REVIEW_RECONCILE_RUN_LIMIT = 32;
+const EXACT_REVIEW_RECONCILE_CLAIM_MATCH_LIMIT = EXACT_REVIEW_RECONCILE_RUN_LIMIT * 2;
 const EXACT_REVIEW_RECONCILE_CONCURRENCY = 4;
 const EXACT_REVIEW_QUEUE_DELIVERY_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const EXACT_REVIEW_QUEUE_STATE_KEY = "exact-review-queue";
@@ -481,16 +482,37 @@ export class ExactReviewQueue {
       return json({ ok: true, requeued });
     }
 
-    if (request.method === "GET" && url.pathname === "/claimed-runs") {
+    if (request.method === "POST" && url.pathname === "/claimed-runs") {
+      const body = objectValue(await request.json().catch(() => null));
+      const requestedRuns = exactReviewRequestedRuns(body.runs);
+      if (!requestedRuns) return json({ error: "invalid_requested_runs" }, 400);
+
+      // The workflow_run hook names the exact terminal run. Return at most two matches for
+      // each requested id so a corrupt duplicate remains ambiguous without sampling the first
+      // N unrelated leases. This keeps the response bounded while allowing any live claim in
+      // the durable queue to be reconciled.
+      const requestedRunIds = new Set(requestedRuns.map((run) => run.runId));
+      const matchesByRunId = new Map<string, ExactReviewQueueItem[]>();
       const state = await this.readState();
-      const runs = Object.values(state.items)
-        .filter((item) => item.state === "leased" && item.claimedRunId)
-        .slice(0, EXACT_REVIEW_RECONCILE_RUN_LIMIT)
-        .map((item) => ({
+      for (const item of Object.values(state.items)) {
+        if (
+          item.state !== "leased" ||
+          !item.claimedRunId ||
+          !requestedRunIds.has(item.claimedRunId)
+        ) {
+          continue;
+        }
+        const matches = matchesByRunId.get(item.claimedRunId) || [];
+        if (matches.length < 2) matches.push(item);
+        matchesByRunId.set(item.claimedRunId, matches);
+      }
+      const runs = [...matchesByRunId.values()].flatMap((matches) =>
+        matches.map((item) => ({
           run_id: String(item.claimedRunId),
           run_attempt: item.claimedRunAttempt ?? null,
           claim_generation: exactReviewClaimGeneration(item.claimGeneration),
-        }));
+        })),
+      );
       return json({ runs });
     }
 
@@ -1259,7 +1281,20 @@ async function authenticatedExactReviewReconcile(request, env) {
   const requestedRuns = exactReviewRequestedRuns(body.runs ?? body.run_ids);
   if (!requestedRuns) return json({ error: "invalid_runs" }, 400);
 
-  const claimedResponse = await exactReviewQueueRequest(env, "/claimed-runs");
+  const claimedResponse = await exactReviewQueueRequest(
+    env,
+    "/claimed-runs",
+    new Request("https://clawsweeper-exact-review-queue/claimed-runs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        runs: requestedRuns.map((run) => ({
+          run_id: run.runId,
+          ...(run.runAttempt ? { run_attempt: run.runAttempt } : {}),
+        })),
+      }),
+    }),
+  );
   if (!claimedResponse.ok) return json({ error: "exact_review_queue_unavailable" }, 503);
   const claimedBody = objectValue(await claimedResponse.json().catch(() => null));
   const claimedRuns = exactReviewClaimedRuns(claimedBody.runs);
@@ -1543,7 +1578,9 @@ function exactReviewRequestedRuns(value) {
 }
 
 function exactReviewClaimedRuns(value): ExactReviewClaimedRun[] | null {
-  if (!Array.isArray(value) || value.length > EXACT_REVIEW_RECONCILE_RUN_LIMIT) return null;
+  if (!Array.isArray(value) || value.length > EXACT_REVIEW_RECONCILE_CLAIM_MATCH_LIMIT) {
+    return null;
+  }
   const runs: ExactReviewClaimedRun[] = [];
   for (const entry of value) {
     const record = objectValue(entry);

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -1120,6 +1120,129 @@ test("signed exact-review reconciliation releases only immutable terminal runs",
   }
 });
 
+test("exact-review reconciliation targets leases beyond 64 entries without accepting stale claims", async () => {
+  const originalFetch = globalThis.fetch;
+  const storage = new MemoryDurableStorage();
+  const fillerItems = Object.fromEntries(
+    Array.from({ length: 65 }, (_, index) => {
+      const itemNumber = 8000 + index;
+      return [
+        `openclaw/openclaw#${itemNumber}`,
+        leasedExactReviewQueueItem(itemNumber, String(10_000 + index)),
+      ];
+    }),
+  );
+  await storage.put("exact-review-queue", {
+    deliveries: {},
+    items: {
+      ...fillerItems,
+      "openclaw/openclaw#8065": leasedExactReviewQueueItem(8065, "9901", 2),
+      "openclaw/openclaw#8066": leasedExactReviewQueueItem(8066, "9902"),
+      "openclaw/openclaw#8067": leasedExactReviewQueueItem(8067, "9903"),
+    },
+  });
+  const queue = new ExactReviewQueue({ storage }, {});
+  const { privateKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  });
+  globalThis.fetch = async (input) => {
+    const url = new URL(String(input));
+    if (url.pathname === "/repos/openclaw/clawsweeper/installation") {
+      return jsonResponse({ id: 999 });
+    }
+    if (url.pathname === "/app/installations/999/access_tokens") {
+      return jsonResponse({ token: "t" });
+    }
+    if (url.pathname === "/repos/openclaw/clawsweeper/actions/runs/9901") {
+      return jsonResponse({ id: 9901, run_attempt: 2, status: "completed" });
+    }
+    if (url.pathname === "/repos/openclaw/clawsweeper/actions/runs/9902") {
+      return jsonResponse({ id: 9902, run_attempt: 1, status: "completed" });
+    }
+    if (url.pathname === "/repos/openclaw/clawsweeper/actions/runs/9902/attempts/1") {
+      const claim = await queue.fetch(
+        new Request("https://clawsweeper-exact-review-queue/claim", {
+          method: "POST",
+          body: JSON.stringify({ lease_id: "lease-8066", run_id: "9902", run_attempt: 2 }),
+        }),
+      );
+      assert.equal(claim.status, 200);
+      return jsonResponse({
+        id: 9902,
+        run_attempt: 1,
+        status: "completed",
+        conclusion: "cancelled",
+      });
+    }
+    if (url.pathname === "/repos/openclaw/clawsweeper/actions/runs/9903") {
+      return jsonResponse({ id: 9903, run_attempt: 1, status: "completed" });
+    }
+    if (url.pathname === "/repos/openclaw/clawsweeper/actions/runs/9903/attempts/1") {
+      return jsonResponse({
+        id: 9903,
+        run_attempt: 1,
+        status: "completed",
+        conclusion: "failure",
+      });
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  };
+
+  try {
+    const env = {
+      CLAWSWEEPER_APP_CLIENT_ID: "Iv23test",
+      CLAWSWEEPER_APP_PRIVATE_KEY: privateKey,
+      CLAWSWEEPER_WEBHOOK_SECRET: "test-secret",
+      EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+    };
+    const body = JSON.stringify({
+      runs: [
+        { run_id: "9901", run_attempt: 1 },
+        { run_id: "9902", run_attempt: 1 },
+        { run_id: "9903", run_attempt: 1 },
+      ],
+    });
+    const signature = `sha256=${createHmac("sha256", "test-secret").update(body).digest("hex")}`;
+    const response = await worker.fetch(
+      new Request("https://clawsweeper.openclaw.ai/internal/exact-review/reconcile", {
+        method: "POST",
+        headers: { "x-clawsweeper-exact-review-signature": signature },
+        body,
+      }),
+      env,
+    );
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      ok: true,
+      requested: 3,
+      claimed: 3,
+      terminal: 2,
+      unavailable: 0,
+      reconciled: 1,
+      requeued: 1,
+      completed: 0,
+    });
+    const state = (await storage.get("exact-review-queue")) as {
+      items: Record<string, Record<string, unknown>>;
+    };
+    assert.equal(state.items["openclaw/openclaw#8000"].state, "leased");
+    assert.equal(state.items["openclaw/openclaw#8065"].state, "leased");
+    assert.equal(state.items["openclaw/openclaw#8065"].claimedRunAttempt, 2);
+    assert.equal(state.items["openclaw/openclaw#8065"].claimGeneration, 1);
+    assert.equal(state.items["openclaw/openclaw#8066"].state, "leased");
+    assert.equal(state.items["openclaw/openclaw#8066"].claimedRunAttempt, 2);
+    assert.equal(state.items["openclaw/openclaw#8066"].claimGeneration, 2);
+    assert.equal(state.items["openclaw/openclaw#8067"].state, "pending");
+    assert.equal(state.items["openclaw/openclaw#8067"].attempts, 1);
+    assert.equal(state.items["openclaw/openclaw#8067"].claimedRunId, undefined);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("exact-review reconciliation cannot release a later attempt with the same run id", async () => {
   const originalFetch = globalThis.fetch;
   const storage = new MemoryDurableStorage();


### PR DESCRIPTION
## Summary

- look up exact-review claims by the terminal workflow run instead of sampling the first 32 leases
- bound duplicate detection to two matches per requested run and keep ambiguous claims fail-closed
- preserve exact attempt and claim-generation guards during terminal reconciliation

## Why

The workflow-run backstop could miss a claimed lease when that run was outside the queue's first 32 claimed entries. The lease then remained occupied until expiry even though GitHub had already recorded the run as terminal.

## Proof

- `node --test --test-name-pattern='exact-review reconciliation' test/dashboard-worker.test.ts`
- `node --test test/dashboard-worker.test.ts`
- `pnpm run build:dashboard`
- `pnpm run lint:dashboard`
- `pnpm run format:check`
- autoreview: clean, no accepted/actionable findings
