### PR TITLE
fix: restore hot target fanout coverage

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -911,7 +911,7 @@ jobs:
           CLAWSWEEPER_INVENTORY_TOKEN_OPENCLAW: ${{ steps.openclaw-token.outputs.token }}
           CLAWSWEEPER_INVENTORY_TOKEN_STEIPETE: ${{ steps.steipete-token.outputs.token || '__public__' }}
           FANOUT_MODE: ${{ github.event.schedule == '41 * * * *' && 'normal-review' || (github.event.schedule == '37 */6 * * *' && 'audit' || 'hot-intake') }}
-          FANOUT_LIMIT: ${{ github.event.schedule == '41 * * * *' && '6' || (github.event.schedule == '37 */6 * * *' && '12' || '6') }}
+          FANOUT_LIMIT: ${{ github.event.schedule == '41 * * * *' && '6' || (github.event.schedule == '37 */6 * * *' && '12' || '10') }}
         run: |
           set -euo pipefail
           pnpm run target-fanout -- \

--- a/src/repair/target-fanout.ts
+++ b/src/repair/target-fanout.ts
@@ -328,8 +328,8 @@ function fanoutMode(value: string): FanoutMode {
   throw new Error(`unsupported fanout mode: ${value}`);
 }
 
-function defaultLimit(mode: FanoutMode): string {
-  if (mode === "hot-intake") return "6";
+export function defaultLimit(mode: FanoutMode): string {
+  if (mode === "hot-intake") return "10";
   if (mode === "normal-review") return "6";
   return "12";
 }

--- a/test/repair/target-fanout.test.ts
+++ b/test/repair/target-fanout.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import test from "node:test";
 
 import {
+  defaultLimit,
   filterEligibleRepositories,
   selectRepositories,
   type InventoryConfig,
@@ -21,6 +22,12 @@ const config: InventoryConfig = {
   includeForks: false,
   requireIssues: true,
 };
+
+test("target fanout defaults match the scheduled cursor batch sizes", () => {
+  assert.equal(defaultLimit("hot-intake"), "10");
+  assert.equal(defaultLimit("normal-review"), "6");
+  assert.equal(defaultLimit("audit"), "12");
+});
 
 test("target fanout filters eligible repositories conservatively", () => {
   const repositories: ListedRepository[] = [

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1244,7 +1244,7 @@ test("sweep event reviews and target fanout avoid storm amplification", () => {
   assert.match(legacyIntakeBlock, /additionalPrompt: payload\.additional_prompt/);
   assert.match(
     fanoutBlock,
-    /FANOUT_LIMIT: \$\{\{ github\.event\.schedule == '41 \* \* \* \*' && '6' \|\| \(github\.event\.schedule == '37 \*\/6 \* \* \*' && '12' \|\| '6'\) \}\}/,
+    /FANOUT_LIMIT: \$\{\{ github\.event\.schedule == '41 \* \* \* \*' && '6' \|\| \(github\.event\.schedule == '37 \*\/6 \* \* \*' && '12' \|\| '10'\) \}\}/,
   );
 });
 


### PR DESCRIPTION
## Summary

- raise scheduled hot-intake target fanout from 6 to the documented 10 repositories
- align the target-fanout CLI default with the scheduled workflow
- cover the hot, normal, and audit defaults in focused tests

## Verification

- `pnpm run build:all`
- `node --test test/repair/target-fanout.test.ts` (8 passed)
- `node --test test/sweep-workflow.test.ts` (49 passed)
- `pnpm exec oxfmt --check .github/workflows/sweep.yml src/repair/target-fanout.ts test/repair/target-fanout.test.ts test/sweep-workflow.test.ts`
- autoreview: clean, no actionable findings
