### PR TITLE
fix: keep reconciliation batches draining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 - Reconciled terminal exact-review runs by requested run instead of sampling the first 32 claimed leases, while preserving attempt and claim-generation guards across larger worker waves.
 - Dequeued already-closed exact-review events before setup and treated items closed during review as terminal no-ops, preventing permanent retry churn from consuming live worker capacity.
+- Kept broad reconciliation draining independent record repairs when one valid tuple has ambiguous legacy contents, while timestamping closed-record sidecar cleanup as an orderable atomic mutation.
 - Published exact-review records, plans, and decision packets as one validated tuple, and made broad sweep publishers preserve the semantically newer tuple and independently merged status health instead of replaying stale review state.
 - Requeued cancelled and failed exact-review leases, kept pre-terminal success provisional, and added signed exact-attempt reconciliation with claim-generation guards that releases only GitHub-confirmed terminal runs while preserving live workers.
 - Kept exact-review work pending with an explicit bounded retry when GitHub Actions cannot confirm that the executor workflow is active, instead of reporting silent repository dispatches to a disabled workflow as occupied capacity.

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -23213,6 +23213,7 @@ function reconcileFolders(options: {
   ): void => {
     const planPath = workPlanPathForReport(reportPath, plansDir);
     let changed = existsSync(planPath);
+    let nextMarkdown = markdown;
     if (!dryRun && existsSync(planPath)) unlinkSync(planPath);
 
     const packetPath = options.decisionPacketsDir
@@ -23233,14 +23234,21 @@ function reconcileFolders(options: {
         changed = true;
       } else {
         const packetBefore = existsSync(packetPath) ? readFileSync(packetPath, "utf8") : null;
-        const syncedMarkdown = syncReconciledDecisionPacket(markdown, reportPath, "closed");
+        nextMarkdown = syncReconciledDecisionPacket(markdown, reportPath, "closed");
         const packetAfter = existsSync(packetPath) ? readFileSync(packetPath, "utf8") : null;
-        if (syncedMarkdown !== markdown) writeFileSync(reportPath, syncedMarkdown, "utf8");
-        changed ||= syncedMarkdown !== markdown || packetAfter !== packetBefore;
+        changed ||= nextMarkdown !== markdown || packetAfter !== packetBefore;
       }
     }
 
-    if (changed) markRecordChanged(number, file);
+    if (changed) {
+      if (!dryRun) {
+        // Sidecar cleanup is an atomic tuple mutation. Stamp the primary so
+        // tuple publication can order this deterministic repair against the
+        // hydrated state instead of rejecting equal version vectors.
+        writeFileSync(reportPath, markReconciledState(nextMarkdown, "closed"), "utf8");
+      }
+      markRecordChanged(number, file);
+    }
   };
 
   for (const file of markdownFiles(options.itemsDir)) {

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -16,13 +16,16 @@ import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { clawsweeperGitUserEmail, clawsweeperGitUserName } from "./process-env.js";
 import {
   chooseRecordTupleWinner,
+  RecordTupleError,
   recordTupleIdentityForPath,
   recordTupleMarkdownFileForPath,
   recordTuplePathList,
   recordTuplePaths,
+  validateRecordTuple,
   type RecordTupleContents,
   type RecordTupleIdentity,
   type RecordTuplePaths,
+  type RecordTupleWinner,
 } from "./record-tuple.js";
 import { mergeSweepStatusJson } from "./sweep-status-merge.js";
 
@@ -728,7 +731,7 @@ function rebuildReconciliationCommit(
       identity,
       changedPaths: [...changedPaths, ...(knownTuplePaths.get(key) ?? [])],
     });
-    const winner = chooseRecordTupleWinner({
+    const winner = chooseReconciliationTupleWinner({
       base: readRecordTupleAtCommit(baseCommit, tuplePaths),
       local: readRecordTupleAtCommit(sourceCommit, tuplePaths),
       remote: readRecordTupleAtCommit(remoteRef, tuplePaths),
@@ -789,7 +792,7 @@ function normalizeReconciliationCommit(sourceCommit: string): {
     });
     const base = readRecordTupleAtCommit(baseCommit, paths);
     const local = readRecordTupleAtCommit(sourceCommit, paths);
-    const winner = chooseRecordTupleWinner({ base, local, remote: base });
+    const winner = chooseReconciliationTupleWinner({ base, local, remote: base });
     if (winner === "local") selectedTuples.push(paths);
   }
 
@@ -811,6 +814,27 @@ function normalizeReconciliationCommit(sourceCommit: string): {
   if (!hasStagedChanges()) return { commit: baseCommit, changed: false };
   runGit(["commit", "-C", sourceCommit]);
   return { commit: runGit(["rev-parse", "HEAD"]).trim(), changed: true };
+}
+
+function chooseReconciliationTupleWinner(options: {
+  base: RecordTupleContents;
+  local: RecordTupleContents;
+  remote: RecordTupleContents;
+}): RecordTupleWinner | undefined {
+  // A malformed local tuple must still fail the publish. Once the candidate is
+  // structurally valid, however, an unorderable legacy/base conflict can be
+  // quarantined to this tuple instead of blocking every independent repair in
+  // a broad reconciliation batch.
+  validateRecordTuple(options.local, "local reconciliation");
+  try {
+    return chooseRecordTupleWinner(options);
+  } catch (error) {
+    if (!(error instanceof RecordTupleError)) throw error;
+    console.log(
+      `Deferring ambiguous reconciliation for ${options.local.paths.key}: ${error.message}`,
+    );
+    return undefined;
+  }
 }
 
 function changedPathsBetween(from: string, to: string): string[] {

--- a/test/reconcile.test.ts
+++ b/test/reconcile.test.ts
@@ -31,11 +31,13 @@ test("reconcile reports every changed record tuple and cleans already-closed sid
   writeFileSync(join(closedDir, "2.md"), report(2, "closed"));
   writeFileSync(join(itemsDir, "3.md"), report(3, "open"));
   writeFileSync(join(closedDir, "3.md"), report(3, "closed"));
-  writeFileSync(join(closedDir, "4.md"), report(4, "closed"));
+  const staleReconciledAt = "2026-07-01T00:00:00.000Z";
+  writeFileSync(join(closedDir, "4.md"), report(4, "closed", { reconciled_at: staleReconciledAt }));
   writeFileSync(join(plansDir, "4.md"), "stale plan for closed item\n");
   writeFileSync(
     join(closedDir, "5.md"),
     report(5, "closed", {
+      reconciled_at: staleReconciledAt,
       decision_packet_path: "records/openclaw-openclaw/decision-packets/5.json",
       decision_packet_sha256: "stale",
     }),
@@ -108,6 +110,14 @@ if (args[0] === "api" && args[1]?.includes("/issues?state=open")) {
     assert.equal(existsSync(join(plansDir, "1.md")), false);
     assert.equal(existsSync(join(plansDir, "4.md")), false);
     assert.equal(existsSync(join(packetsDir, "5.json")), false);
+    for (const number of [4, 5]) {
+      const reconciledMarkdown = readFileSync(join(closedDir, `${number}.md`), "utf8");
+      assert.doesNotMatch(
+        reconciledMarkdown,
+        new RegExp(`^reconciled_at: ${staleReconciledAt}$`, "m"),
+      );
+      assert.match(reconciledMarkdown, /^current_state: closed$/m);
+    }
     assert.match(readFileSync(join(closedDir, "5.md"), "utf8"), /^decision_packet_path: none$/m);
     assert.equal(existsSync(join(closedDir, "6.md")), true);
     assert.equal(existsSync(join(closedDir, "openclaw-openclaw-7.md")), true);

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -748,6 +748,74 @@ test("broad reconciliation rejects stale hydrated state before its first push", 
   );
 });
 
+test("reconcile-records quarantines an ambiguous valid tuple without blocking independent repairs", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
+  const origin = path.join(root, "origin.git");
+  const work = path.join(root, "work");
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, work], root);
+  configureUser(work);
+  const baseAmbiguous = writeRecordTuple(work, {
+    number: 41,
+    marker: "base tuple",
+    reviewedAt: "2026-07-09T23:00:00.000Z",
+    itemUpdatedAt: "2026-07-09T22:59:00Z",
+  });
+  writeRecordTuple(work, {
+    number: 42,
+    marker: "older independent tuple",
+    reviewedAt: "2026-07-09T23:00:00.000Z",
+    itemUpdatedAt: "2026-07-09T22:59:00Z",
+  });
+  run("git", ["add", "."], work);
+  run("git", ["commit", "-m", "initial"], work);
+  run("git", ["push", "origin", "HEAD:main"], work);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/main"], root);
+  run("git", ["checkout", "-B", "main", "origin/main"], work);
+
+  writeRecordTuple(work, {
+    number: 41,
+    marker: "same-vector ambiguous tuple",
+    reviewedAt: "2026-07-09T23:00:00.000Z",
+    itemUpdatedAt: "2026-07-09T22:59:00Z",
+  });
+  const independentRepair = writeRecordTuple(work, {
+    number: 42,
+    marker: "newer independent tuple",
+    reviewedAt: "2026-07-09T23:02:00.000Z",
+    itemUpdatedAt: "2026-07-09T23:01:00Z",
+  });
+
+  let result;
+  const lines = captureConsoleLog(() => {
+    result = withCwd(work, () =>
+      publishMainCommit({
+        message: "chore: reconcile independent tuples",
+        paths: ["records/openclaw-openclaw"],
+        maxAttempts: 1,
+        pushAttempts: 1,
+        rebaseStrategy: "reconcile-records",
+      }),
+    );
+  });
+
+  assert.equal(result, "committed");
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", "main:records/openclaw-openclaw/items/41.md"], root),
+    baseAmbiguous.primary,
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", "main:records/openclaw-openclaw/items/42.md"], root),
+    independentRepair.primary,
+  );
+  assert.equal(
+    lines.some((line) =>
+      line.includes("Deferring ambiguous reconciliation for openclaw-openclaw/41"),
+    ),
+    true,
+  );
+});
+
 test("reconcile-records rejects a malformed tuple before an uncontended push", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
   const origin = path.join(root, "origin.git");


### PR DESCRIPTION
## Summary

- stamp deterministic closed-record sidecar cleanup as a fresh atomic reconciliation mutation
- defer only a structurally valid but unorderable tuple during broad reconciliation so independent repairs still publish
- keep malformed local tuples fail-closed

## Root cause

Apply run 29077421961 rebuilt the decision packet for `openclaw/openclaw#100261` into canonical label order without changing a recognized mutation timestamp. The tuple publisher therefore saw an equal mutation vector with different contents and rejected the entire broad reconciliation batch.

## Validation

- `pnpm run build:all`
- `pnpm run lint`
- `node --test test/reconcile.test.ts test/repair/git-publish.test.ts` (24/24)
- `pnpm run format:check`
- GPT-5.6 Sol High autoreview: clean, no actionable findings
