### PR TITLE
fix: raise scheduled apply throughput

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2634,7 +2634,7 @@ jobs:
           set -euo pipefail
           test -n "$GH_TOKEN"
           source scripts/apply-workflow-helpers.sh
-          limit="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_limit || '20' }}"
+          limit="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_limit || '80' }}"
           min_age_days="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_min_age_days || '0' }}"
           min_age_minutes="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_min_age_minutes || '' }}"
           apply_kind="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_kind || 'all' }}"
@@ -2676,6 +2676,7 @@ jobs:
           next_cursor=""
           apply_ready_count=""
           cursor_advance_count=""
+          cursor_advance_total=0
           coverage_proof_item_numbers=""
           if [ "$sync_open_pr_batch" = "true" ]; then
             sync_comments_only="true"
@@ -2751,7 +2752,7 @@ jobs:
               --min-age-days "$min_age_days" \
               --min-age-minutes "$min_age_minutes" \
               --batch-size "$close_processed_limit" \
-              --close-limit "$((limit < checkpoint_size ? limit : checkpoint_size))" \
+              --close-limit "$limit" \
               --coverage-proof-limit "$coverage_proof_limit" \
               --cursor-path "$apply_cursor_path")"
             if [ -n "$item_numbers" ]; then
@@ -2805,7 +2806,7 @@ jobs:
           pnpm run status -- \
             --target-repo "$TARGET_REPO" \
             --state "Apply in progress" \
-            --detail "Starting apply/comment-sync run for up to $limit fresh $apply_kind closes. Close reasons: $apply_close_reasons.$candidate_quality_detail Scan window: $close_processed_limit records ($adaptive_apply_scan_reason). Existing Codex automated review comments are updated in place when closing or when comment-only sync is stale by ${comment_sync_min_age_days} day(s); checkpoints commit every $checkpoint_size fresh closes; close delay is ${close_delay_ms}ms; sync-comments-only=$sync_comments_only; item numbers=${item_numbers:-all}." \
+            --detail "Applying up to $limit $apply_kind closes. Reasons: $apply_close_reasons.$candidate_quality_detail Scan window: $close_processed_limit records ($adaptive_apply_scan_reason); comment staleness=${comment_sync_min_age_days}d; checkpoint=$checkpoint_size; delay=${close_delay_ms}ms; comment-only=$sync_comments_only; items=${item_numbers:-all}." \
             --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           if ! publish_changes "chore: mark sweep apply in progress" records results/sweep-status; then
             echo "Best-effort apply start status update failed"
@@ -2861,7 +2862,7 @@ jobs:
             publish_status "chore: update sweep comment sync status"
             echo "::endgroup::"
           fi
-          while [ "$closed_total" -lt "$limit" ]; do
+          while [ "$closed_total" -lt "$limit" ] && [ "$checkpoint" -lt "$max_apply_checkpoints" ]; do
             if [ "$sync_comments_only" = "true" ]; then
               break
             fi
@@ -2914,6 +2915,7 @@ jobs:
                 --report ".artifacts/apply-reports/apply-report-$checkpoint.json" \
                 --item-numbers "$item_numbers" \
                 --cursor-trace "$cursor_trace_path")"
+              cursor_advance_total=$((cursor_advance_total + cursor_advance_count))
               apply_publish_paths+=(results/apply-cursors)
             fi
             examined_count="$(apply_checkpoint_examined_count)"
@@ -2931,7 +2933,6 @@ jobs:
               --apply-health-file ".artifacts/apply-health-$checkpoint.json"
             publish_status "chore: update sweep apply checkpoint $checkpoint status"
             echo "::endgroup::"
-            drop_bounded_coverage_proof_tail "$cursor_trace_path"
             if automatic_apply_runtime_reached ".artifacts/apply-reports/apply-report-$checkpoint.json"; then break; fi
             if [ "$result_count" -ge "$close_processed_limit" ]; then
               if [ "$closed_in_chunk" -gt 0 ]; then
@@ -2952,9 +2953,9 @@ jobs:
               echo "Checkpoint made no fresh closes; stopping to avoid a retry loop."
               break
             fi
-            continue_apply=true
-            break
+            if ! drop_examined_apply_items "$cursor_trace_path"; then break; fi
           done
+          select_apply_continuation
           final_health_mode="close"
           final_health_processed_limit="$close_processed_limit"
           final_health_cursor_path=""
@@ -2966,7 +2967,7 @@ jobs:
             final_health_cursor_path="$apply_cursor_path"
             final_health_candidate_count="$apply_ready_count"
             final_health_scheduled_interval_minutes="15"
-            final_health_cursor_advance_count="$cursor_advance_count"
+            final_health_cursor_advance_count="$cursor_advance_total"
           fi
           if [ "$sync_comments_only" = "true" ]; then
             final_health_mode="comment_sync"
@@ -3050,7 +3051,7 @@ jobs:
           can_share_apply_continuation=false
           if [ "${APPLY_AUTO_SELECTED_BATCH:-false}" = "true" ] &&
             [ -z "${APPLY_ITEM_NUMBERS:-}" ] &&
-            [ "${APPLY_LIMIT:-20}" = "20" ] &&
+            [[ "${APPLY_LIMIT:-20}" =~ ^(20|80)$ ]] &&
             [ "${APPLY_MIN_AGE_DAYS:-0}" = "0" ] &&
             [ -z "${APPLY_MIN_AGE_MINUTES:-}" ] &&
             [ "${APPLY_KIND:-all}" = "all" ] &&

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Raised scheduled close-apply throughput to four serial 20-close checkpoints per run while retaining the 20-close manual default, per-checkpoint state publication, and fresh-token continuation only for post-checkpoint eligible work.
 - Upgraded Codex review and repair workers to GPT-5.6 Sol with high reasoning, invalidating cached reviews from the prior model policy.
 - Raised durable exact-review admission from 20 to 28 global leases and from 16 to 24 leases per target while preserving four slots for other repositories.
 - Redesigned the live dashboard and triage pages: an editorial status headline, borderless stat ticker, pipeline stepper, single capacity bar, and dense worker rows replace the boxed card layout, with a warm theme that follows the system light/dark preference, one lobster-coral accent, quiet outline pills, GitHub label colors as neutral dot-pills, and emoji-free metric and section labels.

--- a/README.md
+++ b/README.md
@@ -403,9 +403,13 @@ Apply wakes every 15 minutes, no-ops when there are no unchanged
 high-confidence close proposals, and narrows scheduled runs to the currently
 eligible proposal list so idle runs do not scan unrelated keep-open records.
 It defaults to all item kinds, no age floor, a 2-second close delay, and 20
-fresh closes per checkpoint, with a hard cap of 20 to keep each GitHub App
-token within its lifetime. After a checkpoint closes at least one item, it
-queues another apply run with a fresh token; a saturated scan that closes
+fresh closes per checkpoint, with a hard cap of 20 per checkpoint. Scheduled
+apply runs process up to 80 closes as four serial checkpoints, publishing each
+checkpoint independently so setup and state hydration are amortized without
+introducing concurrent writers. Manual dispatch keeps its 20-close default.
+A run queues a fresh-token continuation only when the cursor, runtime budget,
+or checkpoint cap stops a run and a post-checkpoint probe finds eligible work;
+a saturated scan that closes
 nothing stops and waits for the next scheduled tick instead of self-dispatching
 indefinitely.
 

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -463,10 +463,14 @@ hold the planner concurrency group or delay the next 89-shard backfill
 wave. Exact issue/PR reviews and repository-dispatch item runs still sync their
 selected comments inline before finishing.
 
-Long apply runs commit checkpoints every 20 fresh closes and dispatch a
-continuation with a fresh GitHub App token after any checkpoint that closes at
-least one item. A saturated scan that closes nothing stops without chaining so
-the same records cannot create an unbounded runner loop.
+Long scheduled apply runs process up to four serial checkpoints of 20 fresh
+closes, publishing each checkpoint independently before continuing in the same
+job. This amortizes setup and hydration while retaining one mutation writer and
+the 20-close manual-dispatch default. A fresh-token continuation is dispatched
+only when the cursor, runtime budget, or checkpoint cap stops a run and a
+post-checkpoint probe still finds eligible work. A saturated scan that closes
+nothing stops without chaining so the same records cannot create an unbounded
+runner loop.
 
 Untargeted cursor-based close apply starts with a 300-record scan window. If
 the previous cursor window was a full close-mode scan, closed nothing, skipped

--- a/scripts/apply-workflow-helpers.sh
+++ b/scripts/apply-workflow-helpers.sh
@@ -7,6 +7,7 @@
 max_close_processed_limit=900
 coverage_proof_limit=2
 progress_every=10
+max_apply_checkpoints=4
 
 publish_changes_with_strategy() {
   local rebase_strategy="$1"
@@ -169,6 +170,57 @@ automatic_apply_runtime_reached() {
   return 0
 }
 
+has_remaining_apply_candidates() {
+  local candidate_args=(
+    --target-repo "$TARGET_REPO"
+    --apply-kind "$apply_kind"
+    --apply-close-reasons "$apply_close_reasons"
+    --stale-min-age-days "$stale_min_age_days"
+    --min-age-days "$min_age_days"
+    --min-age-minutes "$min_age_minutes"
+    --batch-size 1
+    --close-limit 1
+    --coverage-proof-limit 1
+    --cursor-path "$apply_cursor_path"
+  )
+  if [ -n "${explicit_item_numbers:-}" ]; then
+    candidate_args+=(--item-numbers "$explicit_item_numbers")
+  fi
+  local remaining
+  remaining="$(pnpm run --silent workflow -- proposed-item-numbers "${candidate_args[@]}")"
+  [ -n "$remaining" ]
+}
+
+select_apply_continuation() {
+  local last_closed="${closed_in_chunk:-0}"
+  local continuation_reason=""
+
+  if [ "$sync_comments_only" = "true" ]; then
+    continue_apply=false
+    return 0
+  fi
+  if [ "$continue_apply" = "true" ]; then
+    continuation_reason="the cursor or runtime budget stopped this run"
+  elif [ "$closed_total" -ge "$limit" ]; then
+    continuation_reason="this run reached its close limit"
+  elif [ "$sync_comments_only" != "true" ] &&
+    [ "$checkpoint" -ge "$max_apply_checkpoints" ] &&
+    [ "$closed_total" -lt "$limit" ] &&
+    [ "$last_closed" -gt 0 ]; then
+    continuation_reason="this run reached its checkpoint token budget"
+  else
+    return 0
+  fi
+
+  continue_apply=false
+  if has_remaining_apply_candidates; then
+    echo "Apply still has eligible work after checkpoints because $continuation_reason; queueing a fresh-token continuation."
+    continue_apply=true
+  else
+    echo "Post-checkpoint eligibility is empty; not queueing an apply continuation."
+  fi
+}
+
 select_adaptive_apply_batch() {
   if [ "$sync_comments_only" = "true" ] || [ -n "$item_numbers" ]; then
     return
@@ -198,24 +250,22 @@ select_bounded_coverage_proof_tail() {
   coverage_proof_count="$(pnpm run --silent workflow -- count-csv --items "$coverage_proof_item_numbers")"
 }
 
-drop_bounded_coverage_proof_tail() {
-  if [ "$auto_selected_apply_batch" != "true" ] || [ -z "$coverage_proof_item_numbers" ]; then
-    return
+drop_examined_apply_items() {
+  if [ "$auto_selected_apply_batch" != "true" ]; then
+    return 0
   fi
   local cursor_trace_path="$1"
   local examined_item_numbers
   examined_item_numbers="$(pnpm run --silent workflow -- apply-cursor-trace-item-numbers --cursor-trace "$cursor_trace_path")"
   if [ -z "$examined_item_numbers" ]; then
-    return
+    return 0
   fi
   local remaining=",${item_numbers},"
   local remaining_proof=",${coverage_proof_item_numbers},"
   local number
-  for number in ${coverage_proof_item_numbers//,/ }; do
-    if [[ ",${examined_item_numbers}," == *",${number},"* ]]; then
-      remaining="${remaining//,${number},/,}"
-      remaining_proof="${remaining_proof//,${number},/,}"
-    fi
+  for number in ${examined_item_numbers//,/ }; do
+    remaining="${remaining//,${number},/,}"
+    remaining_proof="${remaining_proof//,${number},/,}"
   done
   item_numbers="${remaining#,}"
   item_numbers="${item_numbers%,}"
@@ -225,6 +275,7 @@ drop_bounded_coverage_proof_tail() {
   fi
   coverage_proof_item_numbers="${remaining_proof#,}"
   coverage_proof_item_numbers="${coverage_proof_item_numbers%,}"
+  [ -n "$item_numbers" ]
 }
 
 summarize_apply_candidate_quality() {

--- a/test/apply-cursor-trace.test.ts
+++ b/test/apply-cursor-trace.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
 
@@ -156,6 +157,160 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/(10|20)\\/timeline(?:\
       [10],
     );
     assert.deepEqual(trace, { schema_version: 1, examined_item_numbers: [10] });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("serial checkpoints skip archived tuples and advance only their examined trace", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const cursorPath = join(root, "apply-cursor.json");
+    const itemNumbers = [10, 20, 30, 40];
+    const comments: Record<number, string> = {};
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    for (const number of itemNumbers) {
+      const synced = reportWithSyncedReviewComment(
+        implementedCloseReport({ number }),
+        number,
+        "implemented_on_main",
+      );
+      writeFileSync(join(itemsDir, `${number}.md`), synced.report, "utf8");
+      comments[number] = synced.comment;
+    }
+
+    const ghMock = `
+const { readFileSync } = require("fs");
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+const path = args[1] === "-i" ? args[2] || "" : args[1] || "";
+const comments = ${JSON.stringify(comments)};
+const issueMatch = path.match(/\\/issues\\/(10|20|30|40)(?:$|\\/)/);
+const commentIdMatch = path.match(/\\/issues\\/comments\\/(90(?:10|20|30|40))$/);
+const number = issueMatch
+  ? Number(issueMatch[1])
+  : commentIdMatch
+    ? Number(commentIdMatch[1]) - 9000
+    : Number(args[2]);
+if (args[0] === "api" && args[1] === "-i" && /\\/timeline(?:\\?|$)/.test(path)) {
+  console.log("HTTP/2 200\\n\\n[]");
+} else if (args[0] === "api" && /\\/comments(?:\\?|$)/.test(path)) {
+  if (args.includes("--method")) {
+    const input = args[args.indexOf("--input") + 1];
+    const body = JSON.parse(readFileSync(input, "utf8")).body;
+    console.log(JSON.stringify({
+      id: 9000 + number,
+      html_url: "https://github.com/openclaw/clawsweeper/issues/" + number + "#issuecomment-" + (9000 + number),
+      body,
+      user: { login: "github-actions[bot]" },
+      created_at: "2026-05-01T01:00:00Z",
+      updated_at: "2026-05-01T01:00:00Z"
+    }));
+  } else {
+    console.log(JSON.stringify([[
+      {
+        id: 9000 + number,
+        html_url: "https://github.com/openclaw/clawsweeper/issues/" + number + "#issuecomment-" + (9000 + number),
+        body: comments[number],
+        user: { login: "github-actions[bot]" },
+        created_at: "2026-05-01T01:00:00Z",
+        updated_at: "2026-05-01T01:00:00Z"
+      }
+    ]]));
+  }
+} else if (args[0] === "api" && /\\/timeline(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && path.startsWith("search/issues?")) {
+  console.log(JSON.stringify({ items: [] }));
+} else if (args[0] === "api" && issueMatch) {
+  console.log(JSON.stringify({
+    number,
+    title: "Serial checkpoint " + number,
+    html_url: "https://github.com/openclaw/clawsweeper/issues/" + number,
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "reporter" },
+    labels: [],
+    comments: 1,
+    pull_request: null
+  }));
+} else if (args[0] === "issue" && args[1] === "view") {
+  console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
+} else if (args[0] === "issue" && args[1] === "close") {
+  console.log("");
+} else if (args[0] === "issue" || args[0] === "label") {
+  console.log("");
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+
+    withMockGh(root, ghMock, () => {
+      for (const [checkpoint, expected] of [
+        [1, [10, 20]],
+        [2, [30, 40]],
+      ] as const) {
+        const tracePath = join(root, `apply-cursor-trace-${checkpoint}.json`);
+        runApplyDecisionsForTest({
+          itemsDir,
+          closedDir,
+          plansDir,
+          reportPath,
+          extraArgs: [
+            "--item-numbers",
+            itemNumbers.join(","),
+            "--limit",
+            "2",
+            "--processed-limit",
+            "10",
+            "--cursor-trace",
+            tracePath,
+          ],
+        });
+        execFileSync(process.execPath, [
+          "dist/repair/workflow-utils.js",
+          "write-apply-cursor",
+          "--cursor-path",
+          cursorPath,
+          "--report",
+          reportPath,
+          "--target-repo",
+          "openclaw/clawsweeper",
+          "--item-numbers",
+          itemNumbers.join(","),
+          "--cursor-trace",
+          tracePath,
+        ]);
+
+        const report = JSON.parse(readFileSync(reportPath, "utf8"));
+        const trace = JSON.parse(readFileSync(tracePath, "utf8"));
+        const cursor = JSON.parse(readFileSync(cursorPath, "utf8"));
+        assert.deepEqual(
+          report
+            .filter((entry: { action: string }) => entry.action === "closed")
+            .map((entry: { number: number }) => entry.number),
+          expected,
+        );
+        assert.deepEqual(trace.examined_item_numbers, expected);
+        assert.equal(cursor.next_after_number, expected.at(-1));
+      }
+    });
+
+    for (const number of itemNumbers) {
+      assert.equal(existsSync(join(itemsDir, `${number}.md`)), false);
+      assert.equal(existsSync(join(closedDir, `${number}.md`)), true);
+    }
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -453,6 +453,10 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
   assert.match(workflow, /github\.event\.inputs\.apply_limit != '20'/);
   assert.match(workflow, /github\.event\.inputs\.apply_checkpoint_size != '20'/);
   assert.match(applyStep, /Capping apply checkpoint size at 20/);
+  assert.match(
+    applyStep,
+    /limit="\$\{\{ github\.event_name == 'workflow_dispatch' && github\.event\.inputs\.apply_limit \|\| '80' \}\}"/,
+  );
   assert.match(applyStep, /base_close_processed_limit=300/);
   assert.match(applyHelper, /coverage_proof_limit=2/);
   assert.match(applyHelper, /max_runtime_arg=\(--max-runtime-ms 600000\)/);
@@ -477,6 +481,12 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
   assert.match(applyStep, /proposed-item-count/);
   assert.match(applyStep, /apply-cursor-advance-count/);
   assert.match(applyStep, /examined_count="\$\(apply_checkpoint_examined_count\)"/);
+  assert.match(applyStep, /cursor_advance_total=0/);
+  assert.match(
+    applyStep,
+    /cursor_advance_total=\$\(\(cursor_advance_total \+ cursor_advance_count\)\)/,
+  );
+  assert.match(applyStep, /final_health_cursor_advance_count="\$cursor_advance_total"/);
   assert.match(applyHelper, /apply_checkpoint_examined_count\(\)/);
   assert.match(applyHelper, /printf '%s\\n' "unavailable"/);
   assert.match(applyStep, /Candidates examined: \$examined_count\. Action records: \$result_count/);
@@ -510,16 +520,17 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
   assert.ok(qualitySummaryIndex > applyReconcileIndex);
   assert.ok(proposedNumbersIndex > qualitySummaryIndex);
   assert.match(applyStep, /--batch-size "\$close_processed_limit"/);
-  assert.match(
-    applyStep,
-    /--close-limit "\$\(\(limit < checkpoint_size \? limit : checkpoint_size\)\)"/,
-  );
+  assert.match(applyStep, /--close-limit "\$limit"/);
   assert.match(applyStep, /--coverage-proof-limit "\$coverage_proof_limit"/);
   assert.match(applyStep, /select_bounded_coverage_proof_tail/);
   assert.match(applyHelper, /select_bounded_coverage_proof_tail\(\)/);
   assert.match(applyHelper, /proposed-pr-close-coverage-item-numbers/);
-  assert.match(applyHelper, /drop_bounded_coverage_proof_tail\(\)/);
-  assert.match(applyStep, /drop_bounded_coverage_proof_tail "\$cursor_trace_path"/);
+  assert.match(applyHelper, /drop_examined_apply_items\(\)/);
+  const dropExaminedItemsIndex = applyStep.indexOf(
+    'if ! drop_examined_apply_items "$cursor_trace_path"; then break; fi',
+  );
+  assert.ok(dropExaminedItemsIndex > applyStep.indexOf('if [ "$result_count" -ge'));
+  assert.ok(dropExaminedItemsIndex > applyStep.indexOf('if [ "$closed_in_chunk" -eq 0 ]'));
   assert.match(
     applyStep,
     /Scan window: \$close_processed_limit records \(\$adaptive_apply_scan_reason\)/,
@@ -549,8 +560,23 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
     /if \[ "\$result_count" -ge "\$close_processed_limit" \] && \[ "\$closed_in_chunk" -gt 0 \]/,
   );
   assert.match(applyStep, /sync_comments_only" != "true" .*apply_close_reasons/);
-  assert.match(applyStep, /continue_apply=true/);
-  assert.match(applyStep, /break\n\s+done/);
+  assert.doesNotMatch(applyStep, /continue_apply=true\n\s+break\n\s+done/);
+  assert.match(applyHelper, /max_apply_checkpoints=4/);
+  assert.match(
+    applyStep,
+    /while \[ "\$closed_total" -lt "\$limit" \] && \[ "\$checkpoint" -lt "\$max_apply_checkpoints" \]; do/,
+  );
+  assert.match(applyStep, /chunk_limit="\$checkpoint_size"/);
+  assert.match(applyStep, /publish_changes "chore: apply sweep decisions checkpoint \$checkpoint"/);
+  assert.match(applyStep, /select_apply_continuation/);
+  assert.match(
+    applyHelper,
+    /has_remaining_apply_candidates\(\)[\s\S]*--batch-size 1[\s\S]*proposed-item-numbers/,
+  );
+  assert.match(
+    applyHelper,
+    /\[ "\$checkpoint" -ge "\$max_apply_checkpoints" \][\s\S]*\[ "\$last_closed" -gt 0 \][\s\S]*has_remaining_apply_candidates/,
+  );
   assert.match(applyStep, /next_apply_item_numbers="\$item_numbers"/);
   assert.match(applyStep, /next_apply_item_numbers=""/);
   assert.match(applyStep, /echo "APPLY_CONTINUE=\$continue_apply"/);
@@ -560,7 +586,7 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
   assert.match(continueStep, /can_share_apply_continuation=false/);
   assert.match(continueStep, /\[ "\$\{APPLY_AUTO_SELECTED_BATCH:-false\}" = "true" \]/);
   assert.match(continueStep, /\[ -z "\$\{APPLY_ITEM_NUMBERS:-\}" \]/);
-  assert.match(continueStep, /\[ "\$\{APPLY_LIMIT:-20\}" = "20" \]/);
+  assert.match(continueStep, /\[\[ "\$\{APPLY_LIMIT:-20\}" =~ \^\(20\|80\)\$ \]\]/);
   assert.match(continueStep, /\[ "\$\{APPLY_CHECKPOINT_SIZE:-20\}" = "20" \]/);
   assert.match(continueStep, /\[ "\$\{APPLY_COMMENT_SYNC_MIN_AGE_DAYS:-7\}" = "7" \]/);
   assert.match(continueStep, /preserving exact continuation dispatch/);
@@ -580,6 +606,63 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
   assert.match(continueStep, /-f apply_item_numbers="\$APPLY_ITEM_NUMBERS"/);
   assert.doesNotMatch(continueStep, /-f item_numbers=/);
   assert.doesNotMatch(continueStep, /APPLY_CLOSED_TOTAL:-0.*APPLY_LIMIT:-0/);
+});
+
+test("apply continuation requires measured or checkpoint-bounded remaining work", () => {
+  const script = `
+    set -euo pipefail
+    source scripts/apply-workflow-helpers.sh
+    continue_apply=false
+    sync_comments_only="$1"
+    closed_total="$2"
+    limit="$3"
+    checkpoint="$4"
+    closed_in_chunk="$5"
+    remaining="$6"
+    has_remaining_apply_candidates() { [ "$remaining" = "true" ]; }
+    select_apply_continuation >/dev/null
+    printf '%s' "$continue_apply"
+  `;
+  const scenarios = [
+    {
+      name: "post-checkpoint backlog after requested closes",
+      args: ["false", "80", "80", "4", "20", "true"],
+      expected: "true",
+    },
+    {
+      name: "stale pre-run count but post-checkpoint queue exhausted",
+      args: ["false", "80", "80", "4", "20", "false"],
+      expected: "false",
+    },
+    {
+      name: "zero-progress stop before checkpoint cap",
+      args: ["false", "60", "80", "3", "0", "true"],
+      expected: "false",
+    },
+    {
+      name: "productive checkpoint cap",
+      args: ["false", "60", "100", "4", "20", "true"],
+      expected: "true",
+    },
+    {
+      name: "productive checkpoint cap exhausted the queue",
+      args: ["false", "60", "100", "4", "20", "false"],
+      expected: "false",
+    },
+    {
+      name: "comment sync never continues",
+      args: ["true", "80", "80", "4", "20", "true"],
+      expected: "false",
+    },
+  ];
+
+  for (const scenario of scenarios) {
+    const actual = execFileSync("bash", ["-c", script, scenario.name, ...scenario.args], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+    });
+    assert.equal(actual, scenario.expected, scenario.name);
+  }
 });
 
 test("apply workflow finalization retries only target status after checkpointed state", () => {
@@ -676,7 +759,7 @@ test("apply workflow does not queue runtime-yield continuation without cursor pr
   }
 });
 
-test("apply workflow drops a coverage-proof tail only after exact trace examination", () => {
+test("apply workflow drops only exactly examined items between checkpoints", () => {
   const root = mkdtempSync(tmpPrefix);
   const fastOnlyTrace = join(root, "fast-only.json");
   const firstProofTrace = join(root, "proof-first.json");
@@ -705,11 +788,11 @@ test("apply workflow drops a coverage-proof tail only after exact trace examinat
           "item_numbers=10,20,30,40",
           "coverage_proof_item_numbers=30,40",
           'item_numbers_arg=(--item-numbers "$item_numbers")',
-          'drop_bounded_coverage_proof_tail "$FAST_ONLY_TRACE"',
+          'drop_examined_apply_items "$FAST_ONLY_TRACE"',
           'printf \'%s|%s|%s\\n\' "$item_numbers" "$coverage_proof_item_numbers" "${item_numbers_arg[*]}"',
-          'drop_bounded_coverage_proof_tail "$FIRST_PROOF_TRACE"',
+          'drop_examined_apply_items "$FIRST_PROOF_TRACE"',
           'printf \'%s|%s|%s\\n\' "$item_numbers" "$coverage_proof_item_numbers" "${item_numbers_arg[*]}"',
-          'drop_bounded_coverage_proof_tail "$SECOND_PROOF_TRACE"',
+          'drop_examined_apply_items "$SECOND_PROOF_TRACE" || true',
           'printf \'%s|%s|%s\\n\' "$item_numbers" "$coverage_proof_item_numbers" "${item_numbers_arg[*]}"',
         ].join("\n"),
       ],
@@ -725,9 +808,9 @@ test("apply workflow drops a coverage-proof tail only after exact trace examinat
       },
     );
     assert.deepEqual(output.trim().split("\n"), [
-      "10,20,30,40|30,40|--item-numbers 10,20,30,40",
-      "10,20,40|40|--item-numbers 10,20,40",
-      "10,20||--item-numbers 10,20",
+      "30,40|30,40|--item-numbers 30,40",
+      "40|40|--item-numbers 40",
+      "||",
     ]);
   } finally {
     rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- raise scheduled close-apply capacity from one 20-close checkpoint to four serial 20-close checkpoints per job
- preserve one mutation writer and atomic per-checkpoint record/cursor publication while removing only exactly examined candidates between checkpoints
- accumulate cursor health across checkpoints and dispatch fresh-token continuations only when a post-checkpoint eligibility probe finds remaining work

Manual dispatch keeps its 20-close default. Comment-only apply behavior is unchanged.

## Validation

- `node --test test/sweep-workflow.test.ts test/apply-cursor-trace.test.ts` (53 passed)
- `node --test --test-concurrency=1 test/codex-review-runner.test.ts test/failed-review-retry.test.ts`
- `pnpm run build:all`
- `pnpm run format:check`
- `pnpm run lint:scripts`
- `pnpm run check:limits`
- autoreview: GPT-5.6 Sol, high reasoning, clean
