### PR TITLE
fix: serialize exact review planning

### DIFF
--- a/.github/workflows/commit-review.yml
+++ b/.github/workflows/commit-review.yml
@@ -184,28 +184,60 @@ jobs:
               || printf '0'
           }
           active_sweep_background_workers() {
-            local runs total id title status active_shards
+            local runs total id title status jobs_json active_shards total_shards
+            local reserved_shards hard_cap requested_shards item_numbers commas item_count
             total=0
+            hard_cap="$(pnpm --dir clawsweeper run --silent workflow -- limit review_shards.hard_cap)"
             runs="$(printf '%s' "$ACTIVE_RUNS_JSON" \
-              | STALE_QUEUED_CUTOFF="$STALE_QUEUED_CUTOFF" jq -r '.[] | select(.workflowPath == ".github/workflows/sweep.yml") | select(.status == "in_progress" or ((.status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") and ((.updatedAt // .createdAt // "") >= env.STALE_QUEUED_CUTOFF))) | select(.displayTitle == "Review ClawSweeper items" or .displayTitle == "Review hot ClawSweeper items") | [.databaseId, .displayTitle, .status] | @tsv' 2>/dev/null || true)"
+              | STALE_QUEUED_CUTOFF="$STALE_QUEUED_CUTOFF" jq -r '.[] | select(.workflowPath == ".github/workflows/sweep.yml") | select(.status == "in_progress" or ((.status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") and ((.updatedAt // .createdAt // "") >= env.STALE_QUEUED_CUTOFF))) | select(.displayTitle == "Review ClawSweeper items" or .displayTitle == "Review hot ClawSweeper items" or (.displayTitle | startswith("Review event items "))) | [.databaseId, .displayTitle, .status] | @tsv' 2>/dev/null || true)"
             while IFS=$'\t' read -r id title status; do
               if [ -z "$id" ]; then
                 continue
               fi
               active_shards=0
+              total_shards=0
               if [ "$status" = "in_progress" ]; then
-                active_shards="$(gh run view "$id" --repo "${{ github.repository }}" --json jobs 2>/dev/null \
+                jobs_json="$(gh run view "$id" --repo "${{ github.repository }}" --json jobs 2>/dev/null || printf '{"jobs":[]}')"
+                active_shards="$(printf '%s' "$jobs_json" \
                   | jq '[.jobs[]? | select(.name | startswith("Review shard ")) | select(.status == "in_progress" or .status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested")] | length' 2>/dev/null \
+                  || printf '0')"
+                total_shards="$(printf '%s' "$jobs_json" \
+                  | jq '[.jobs[]? | select(.name | startswith("Review shard "))] | length' 2>/dev/null \
                   || printf '0')"
               fi
               if ! [[ "$active_shards" =~ ^[0-9]+$ ]]; then
                 active_shards=0
               fi
-              # Planning, publish, queued, and not-yet-expanded matrix runs have not
-              # created shard jobs yet. Reserve their quiet lane size while they expand.
-              if [ "$active_shards" -lt 1 ]; then
+              if ! [[ "$total_shards" =~ ^[0-9]+$ ]]; then
+                total_shards=0
+              fi
+              # Planning, queued, and not-yet-expanded matrix runs reserve their lane
+              # size. Completed matrices are publishing and consume no Codex slots.
+              if [ "$active_shards" -lt 1 ] && [ "$total_shards" -lt 1 ]; then
                 if [ "$title" = "Review hot ClawSweeper items" ]; then
                   active_shards="$(pnpm --dir clawsweeper run --silent workflow -- limit review_shards.hot_intake_default)"
+                elif [[ "$title" == Review\ event\ items\ * ]]; then
+                  reserved_shards="$hard_cap"
+                  if [[ "$title" =~ \[shards=([0-9]+)\]$ ]]; then
+                    requested_shards="${BASH_REMATCH[1]}"
+                    item_numbers="${title#*#}"
+                    item_numbers="${item_numbers%% *}"
+                    if [[ "$item_numbers" =~ ^[0-9]+(,[0-9]+)*$ ]]; then
+                      if [ "$requested_shards" -lt 1 ]; then
+                        requested_shards=1
+                      fi
+                      commas="${item_numbers//[^,]/}"
+                      item_count=$((${#commas} + 1))
+                      reserved_shards="$requested_shards"
+                      if [ "$reserved_shards" -gt "$item_count" ]; then
+                        reserved_shards="$item_count"
+                      fi
+                      if [ "$reserved_shards" -gt "$hard_cap" ]; then
+                        reserved_shards="$hard_cap"
+                      fi
+                    fi
+                  fi
+                  active_shards="$reserved_shards"
                 else
                   active_shards="$(pnpm --dir clawsweeper run --silent workflow -- limit review_shards.normal_default)"
                 fi

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -23,8 +23,11 @@ run-name: >-
     (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.item_numbers, 'router-')) &&
       format('Review event item {0}#{1} [{2}]', github.event.inputs.target_repo || 'openclaw/openclaw', github.event.inputs.item_number || '?', github.event.inputs.item_numbers) ||
     (github.event_name == 'workflow_dispatch' &&
-      (github.event.inputs.item_number != '' || github.event.inputs.item_numbers != '')) &&
-      format('Review event item {0}#{1}', github.event.inputs.target_repo || 'openclaw/openclaw', github.event.inputs.item_number || github.event.inputs.item_numbers) ||
+      github.event.inputs.item_number != '' &&
+      github.event.inputs.item_numbers == '') &&
+      format('Review event item {0}#{1}', github.event.inputs.target_repo || 'openclaw/openclaw', github.event.inputs.item_number) ||
+    (github.event_name == 'workflow_dispatch' && github.event.inputs.item_numbers != '') &&
+      format('Review event items {0}#{1} [shards={2}]', github.event.inputs.target_repo || 'openclaw/openclaw', github.event.inputs.item_numbers, github.event.inputs.shard_count || '89') ||
     ((github.event_name == 'workflow_dispatch' &&
       github.event.inputs.apply_existing == 'true' &&
       github.event.inputs.apply_sync_comments_only == 'true') ||
@@ -1035,6 +1038,7 @@ jobs:
     timeout-minutes: 30
     concurrency:
       group: ${{ format('clawsweeper-planner-{0}', (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && (github.event.inputs.target_repo || ((github.event.schedule == '2/5 * * * *' || github.event.schedule == '22 * * * *') && 'openclaw/clawhub' || 'openclaw/openclaw')) || github.run_id) }}
+      queue: max
       cancel-in-progress: false
     outputs:
       batch_size: ${{ steps.mode.outputs.batch_size }}
@@ -1180,10 +1184,63 @@ jobs:
               | WORKFLOW_PATH="$1" STALE_QUEUED_CUTOFF="$STALE_QUEUED_CUTOFF" jq '[.[] | select(.workflowPath == env.WORKFLOW_PATH) | select(.status == "in_progress" or ((.status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") and ((.updatedAt // .createdAt // "") >= env.STALE_QUEUED_CUTOFF)))] | length' 2>/dev/null \
               || printf '0'
           }
-          active_sweep_exact_count() {
-            printf '%s' "$ACTIVE_RUNS_JSON" \
-              | STALE_QUEUED_CUTOFF="$STALE_QUEUED_CUTOFF" jq '[.[] | select(.workflowPath == ".github/workflows/sweep.yml") | select((.status == "in_progress" or ((.status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") and ((.updatedAt // .createdAt // "") >= env.STALE_QUEUED_CUTOFF))) and (.displayTitle | startswith("Review event item ")))] | length' 2>/dev/null \
-              || printf '0'
+          active_sweep_exact_workers() {
+            local runs total id title status jobs_json active_shards total_shards
+            local reserved_shards hard_cap requested_shards item_numbers commas item_count
+            total=0
+            hard_cap="$(limit review_shards.hard_cap)"
+            runs="$(printf '%s' "$ACTIVE_RUNS_JSON" \
+              | STALE_QUEUED_CUTOFF="$STALE_QUEUED_CUTOFF" jq -r '.[] | select(.workflowPath == ".github/workflows/sweep.yml") | select(.status == "in_progress" or ((.status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") and ((.updatedAt // .createdAt // "") >= env.STALE_QUEUED_CUTOFF))) | select((.displayTitle | startswith("Review event item ")) or (.displayTitle | startswith("Review event items "))) | [.databaseId, .displayTitle, .status] | @tsv' 2>/dev/null || true)"
+            while IFS=$'\t' read -r id title status; do
+              if [ -z "$id" ]; then
+                continue
+              fi
+              active_shards=0
+              total_shards=0
+              if [ "$status" = "in_progress" ]; then
+                jobs_json="$(gh run view "$id" --repo "${{ github.repository }}" --json jobs 2>/dev/null || printf '{"jobs":[]}')"
+                active_shards="$(printf '%s' "$jobs_json" \
+                  | jq '[.jobs[]? | select(.name | startswith("Review shard ")) | select(.status == "in_progress" or .status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested")] | length' 2>/dev/null \
+                  || printf '0')"
+                total_shards="$(printf '%s' "$jobs_json" \
+                  | jq '[.jobs[]? | select(.name | startswith("Review shard "))] | length' 2>/dev/null \
+                  || printf '0')"
+              fi
+              if ! [[ "$active_shards" =~ ^[0-9]+$ ]]; then
+                active_shards=0
+              fi
+              if ! [[ "$total_shards" =~ ^[0-9]+$ ]]; then
+                total_shards=0
+              fi
+              # Single-item event reviews reserve one worker. Explicit batches carry
+              # enough run-name metadata to reserve their maximum possible matrix until
+              # live shard jobs exist; after expansion, only live shard jobs consume slots.
+              if [ "$active_shards" -lt 1 ] && [ "$total_shards" -lt 1 ]; then
+                reserved_shards="$(limit review_shards.exact_item_default)"
+                if [[ "$title" == Review\ event\ items\ * ]]; then
+                  reserved_shards="$hard_cap"
+                  if [[ "$title" =~ \[shards=([0-9]+)\]$ ]]; then
+                    requested_shards="${BASH_REMATCH[1]}"
+                    item_numbers="${title#*#}"
+                    item_numbers="${item_numbers%% *}"
+                    if [[ "$item_numbers" =~ ^[0-9]+(,[0-9]+)*$ ]] && [ "$requested_shards" -gt 0 ]; then
+                      commas="${item_numbers//[^,]/}"
+                      item_count=$((${#commas} + 1))
+                      reserved_shards="$requested_shards"
+                      if [ "$reserved_shards" -gt "$item_count" ]; then
+                        reserved_shards="$item_count"
+                      fi
+                      if [ "$reserved_shards" -gt "$hard_cap" ]; then
+                        reserved_shards="$hard_cap"
+                      fi
+                    fi
+                  fi
+                fi
+                active_shards="$reserved_shards"
+              fi
+              total=$((total + active_shards))
+            done <<< "$runs"
+            printf '%s' "$total"
           }
           active_sweep_background_workers() {
             local runs total id title status jobs_json active_shards total_shards
@@ -1229,7 +1286,7 @@ jobs:
           normal_active_floor="$(limit review_shards.normal_active_floor)"
           hard_shard_cap="$(limit review_shards.hard_cap)"
           commit_page_size="$(limit commit_review.page_size_default)"
-          active_critical_workers="$(( $(active_run_count ".github/workflows/repair-cluster-worker.yml") + $(active_sweep_exact_count) ))"
+          active_critical_workers="$(( $(active_run_count ".github/workflows/repair-cluster-worker.yml") + $(active_sweep_exact_workers) ))"
           active_background_workers="$(( $(active_run_count ".github/workflows/commit-review.yml") * commit_page_size + $(active_sweep_background_workers) ))"
           hot_intake_shards="$(worker_limit hot_intake --active-critical "$active_critical_workers" --active-background "$active_background_workers")"
           normal_shards="$(worker_limit normal_review --active-critical "$active_critical_workers" --active-background "$active_background_workers")"

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -20,18 +20,6 @@ run-name: >-
       format('Review event item {0}#{1} [{2}]', github.event.client_payload.target_repo || 'openclaw/openclaw', github.event.client_payload.item_number || '?', github.event.client_payload.dispatch_key) ||
     github.event_name == 'repository_dispatch' &&
       format('Review event item {0}#{1}', github.event.client_payload.target_repo || 'openclaw/openclaw', github.event.client_payload.item_number || '?') ||
-    (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.item_numbers, 'router-')) &&
-      format('Review event item {0}#{1} [{2}]', github.event.inputs.target_repo || 'openclaw/openclaw', github.event.inputs.item_number || '?', github.event.inputs.item_numbers) ||
-    (github.event_name == 'workflow_dispatch' &&
-      github.event.inputs.item_number != '' &&
-      github.event.inputs.item_numbers != '') &&
-      format('Review event items {0}#{1},{2} [shards={3}]', github.event.inputs.target_repo || 'openclaw/openclaw', github.event.inputs.item_number, github.event.inputs.item_numbers, (github.event.inputs.hot_intake == 'true' && '1' || github.event.inputs.shard_count || '89')) ||
-    (github.event_name == 'workflow_dispatch' &&
-      github.event.inputs.item_number != '' &&
-      github.event.inputs.item_numbers == '') &&
-      format('Review event item {0}#{1}', github.event.inputs.target_repo || 'openclaw/openclaw', github.event.inputs.item_number) ||
-    (github.event_name == 'workflow_dispatch' && github.event.inputs.item_numbers != '') &&
-      format('Review event items {0}#{1} [shards={2}]', github.event.inputs.target_repo || 'openclaw/openclaw', github.event.inputs.item_numbers, (github.event.inputs.hot_intake == 'true' && '1' || github.event.inputs.shard_count || '89')) ||
     ((github.event_name == 'workflow_dispatch' &&
       github.event.inputs.apply_existing == 'true' &&
       github.event.inputs.apply_sync_comments_only == 'true') ||
@@ -59,6 +47,18 @@ run-name: >-
           github.event.schedule == '48 * * * *' ||
           github.event.schedule == '8,23,38,53 * * * *'))) &&
       format('Apply default ClawSweeper closures for {0}', github.event.inputs.target_repo || ((github.event.schedule == '8,23,38,53 * * * *') && 'openclaw/clawhub' || 'openclaw/openclaw')) ||
+    (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.item_numbers, 'router-')) &&
+      format('Review event item {0}#{1} [{2}]', github.event.inputs.target_repo || 'openclaw/openclaw', github.event.inputs.item_number || '?', github.event.inputs.item_numbers) ||
+    (github.event_name == 'workflow_dispatch' &&
+      github.event.inputs.item_number != '' &&
+      github.event.inputs.item_numbers != '') &&
+      format('Review event items {0}#{1},{2} [shards={3}]', github.event.inputs.target_repo || 'openclaw/openclaw', github.event.inputs.item_number, github.event.inputs.item_numbers, (github.event.inputs.hot_intake == 'true' && '1' || github.event.inputs.shard_count || '89')) ||
+    (github.event_name == 'workflow_dispatch' &&
+      github.event.inputs.item_number != '' &&
+      github.event.inputs.item_numbers == '') &&
+      format('Review event item {0}#{1}', github.event.inputs.target_repo || 'openclaw/openclaw', github.event.inputs.item_number) ||
+    (github.event_name == 'workflow_dispatch' && github.event.inputs.item_numbers != '') &&
+      format('Review event items {0}#{1} [shards={2}]', github.event.inputs.target_repo || 'openclaw/openclaw', github.event.inputs.item_numbers, (github.event.inputs.hot_intake == 'true' && '1' || github.event.inputs.shard_count || '89')) ||
     ((github.event_name == 'workflow_dispatch' && github.event.inputs.audit_dashboard == 'true') ||
       (github.event_name == 'schedule' &&
         (github.event.schedule == '7 */6 * * *' ||

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1201,6 +1201,11 @@ jobs:
               fi
               active_shards=0
               total_shards=0
+              if [[ "$title" == Review\ event\ item\ * ]]; then
+                active_shards=1
+                total=$((total + active_shards))
+                continue
+              fi
               if [ "$status" = "in_progress" ]; then
                 jobs_json="$(gh run view "$id" --repo "${{ github.repository }}" --json jobs 2>/dev/null || printf '{"jobs":[]}')"
                 active_shards="$(printf '%s' "$jobs_json" \

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -27,7 +27,7 @@ run-name: >-
       github.event.inputs.item_numbers == '') &&
       format('Review event item {0}#{1}', github.event.inputs.target_repo || 'openclaw/openclaw', github.event.inputs.item_number) ||
     (github.event_name == 'workflow_dispatch' && github.event.inputs.item_numbers != '') &&
-      format('Review event items {0}#{1} [shards={2}]', github.event.inputs.target_repo || 'openclaw/openclaw', github.event.inputs.item_numbers, github.event.inputs.shard_count || '89') ||
+      format('Review event items {0}#{1} [shards={2}]', github.event.inputs.target_repo || 'openclaw/openclaw', github.event.inputs.item_numbers, (github.event.inputs.hot_intake == 'true' && '1' || github.event.inputs.shard_count || '89')) ||
     ((github.event_name == 'workflow_dispatch' &&
       github.event.inputs.apply_existing == 'true' &&
       github.event.inputs.apply_sync_comments_only == 'true') ||
@@ -1223,7 +1223,10 @@ jobs:
                     requested_shards="${BASH_REMATCH[1]}"
                     item_numbers="${title#*#}"
                     item_numbers="${item_numbers%% *}"
-                    if [[ "$item_numbers" =~ ^[0-9]+(,[0-9]+)*$ ]] && [ "$requested_shards" -gt 0 ]; then
+                    if [[ "$item_numbers" =~ ^[0-9]+(,[0-9]+)*$ ]]; then
+                      if [ "$requested_shards" -lt 1 ]; then
+                        requested_shards=1
+                      fi
                       commas="${item_numbers//[^,]/}"
                       item_count=$((${#commas} + 1))
                       reserved_shards="$requested_shards"

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -24,6 +24,10 @@ run-name: >-
       format('Review event item {0}#{1} [{2}]', github.event.inputs.target_repo || 'openclaw/openclaw', github.event.inputs.item_number || '?', github.event.inputs.item_numbers) ||
     (github.event_name == 'workflow_dispatch' &&
       github.event.inputs.item_number != '' &&
+      github.event.inputs.item_numbers != '') &&
+      format('Review event items {0}#{1},{2} [shards={3}]', github.event.inputs.target_repo || 'openclaw/openclaw', github.event.inputs.item_number, github.event.inputs.item_numbers, (github.event.inputs.hot_intake == 'true' && '1' || github.event.inputs.shard_count || '89')) ||
+    (github.event_name == 'workflow_dispatch' &&
+      github.event.inputs.item_number != '' &&
       github.event.inputs.item_numbers == '') &&
       format('Review event item {0}#{1}', github.event.inputs.target_repo || 'openclaw/openclaw', github.event.inputs.item_number) ||
     (github.event_name == 'workflow_dispatch' && github.event.inputs.item_numbers != '') &&

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -22,6 +22,9 @@ run-name: >-
       format('Review event item {0}#{1}', github.event.client_payload.target_repo || 'openclaw/openclaw', github.event.client_payload.item_number || '?') ||
     (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.item_numbers, 'router-')) &&
       format('Review event item {0}#{1} [{2}]', github.event.inputs.target_repo || 'openclaw/openclaw', github.event.inputs.item_number || '?', github.event.inputs.item_numbers) ||
+    (github.event_name == 'workflow_dispatch' &&
+      (github.event.inputs.item_number != '' || github.event.inputs.item_numbers != '')) &&
+      format('Review event item {0}#{1}', github.event.inputs.target_repo || 'openclaw/openclaw', github.event.inputs.item_number || github.event.inputs.item_numbers) ||
     ((github.event_name == 'workflow_dispatch' &&
       github.event.inputs.apply_existing == 'true' &&
       github.event.inputs.apply_sync_comments_only == 'true') ||
@@ -1031,7 +1034,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     concurrency:
-      group: ${{ format('clawsweeper-planner-{0}', (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.item_number == '' && github.event.inputs.item_numbers == '')) && (github.event.inputs.target_repo || ((github.event.schedule == '2/5 * * * *' || github.event.schedule == '22 * * * *') && 'openclaw/clawhub' || 'openclaw/openclaw')) || github.run_id) }}
+      group: ${{ format('clawsweeper-planner-{0}', (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && (github.event.inputs.target_repo || ((github.event.schedule == '2/5 * * * *' || github.event.schedule == '22 * * * *') && 'openclaw/clawhub' || 'openclaw/openclaw')) || github.run_id) }}
       cancel-in-progress: false
     outputs:
       batch_size: ${{ steps.mode.outputs.batch_size }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Serialized explicit workflow-dispatch planners with their target's background planner and classified recovery runs as exact-item work, preventing overlapping target planning and 89-shard pre-plan capacity overcounting.
 - Reconciled terminal exact-review runs by requested run instead of sampling the first 32 claimed leases, while preserving attempt and claim-generation guards across larger worker waves.
 - Dequeued already-closed exact-review events before setup and treated items closed during review as terminal no-ops, preventing permanent retry churn from consuming live worker capacity.
 - Kept broad reconciliation draining independent record repairs when one valid tuple has ambiguous legacy contents, while timestamping closed-record sidecar cleanup as an orderable atomic mutation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
-- Serialized explicit workflow-dispatch planners with their target's background planner and classified recovery runs as exact-item work, preventing overlapping target planning and 89-shard pre-plan capacity overcounting.
+- Serialized explicit workflow-dispatch planners through a non-dropping target queue and accounted for recovery runs by their requested or live shards, preventing overlapping target planning and false 89-shard reservations without undercounting multi-shard retries.
 - Reconciled terminal exact-review runs by requested run instead of sampling the first 32 claimed leases, while preserving attempt and claim-generation guards across larger worker waves.
 - Dequeued already-closed exact-review events before setup and treated items closed during review as terminal no-ops, preventing permanent retry churn from consuming live worker capacity.
 - Kept broad reconciliation draining independent record repairs when one valid tuple has ambiguous legacy contents, while timestamping closed-record sidecar cleanup as an orderable atomic mutation.

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -975,11 +975,11 @@ test("comment router prunes bare ack comments after updating shared automerge st
   assert.match(postComment, /pruned_ack_comment_id: String\(precreatedId\)/);
 });
 
-test("manual exact-item review dispatches avoid broad review concurrency", () => {
+test("manual exact-item review dispatches reserve their live shard capacity", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const runName = workflow.slice(workflow.indexOf("run-name:"), workflow.indexOf("\non:"));
   const exactCapacityBlock = workflow.slice(
-    workflow.indexOf("active_sweep_exact_count()"),
+    workflow.indexOf("active_sweep_exact_workers()"),
     workflow.indexOf("active_sweep_background_workers()"),
   );
   const modeBlock = workflow.slice(
@@ -997,14 +997,23 @@ test("manual exact-item review dispatches avoid broad review concurrency", () =>
   );
   assert.match(
     runName,
-    /github\.event_name == 'workflow_dispatch' &&\s+\(github\.event\.inputs\.item_number != '' \|\| github\.event\.inputs\.item_numbers != ''\)\) &&\s+format\('Review event item \{0\}#\{1\}', github\.event\.inputs\.target_repo \|\| 'openclaw\/openclaw', github\.event\.inputs\.item_number \|\| github\.event\.inputs\.item_numbers\)/,
+    /github\.event_name == 'workflow_dispatch' &&\s+github\.event\.inputs\.item_number != '' &&\s+github\.event\.inputs\.item_numbers == ''\) &&\s+format\('Review event item \{0\}#\{1\}', github\.event\.inputs\.target_repo \|\| 'openclaw\/openclaw', github\.event\.inputs\.item_number\)/,
+  );
+  assert.match(
+    runName,
+    /format\('Review event items \{0\}#\{1\} \[shards=\{2\}\]', github\.event\.inputs\.target_repo \|\| 'openclaw\/openclaw', github\.event\.inputs\.item_numbers, github\.event\.inputs\.shard_count \|\| '89'\)/,
   );
   assert.ok(
     runName.indexOf("format('Review event item {0}#{1}'") <
       runName.lastIndexOf("'Review ClawSweeper items'"),
   );
   assert.match(exactCapacityBlock, /\.displayTitle \| startswith\("Review event item "\)/);
-  assert.match(modeBlock, /active_run_count .* \+ \$\(active_sweep_exact_count\)/);
+  assert.match(exactCapacityBlock, /\.displayTitle \| startswith\("Review event items "\)/);
+  assert.match(exactCapacityBlock, /gh run view "\$id".*--json jobs/);
+  assert.match(exactCapacityBlock, /limit review_shards\.hard_cap/);
+  assert.match(exactCapacityBlock, /reserved_shards="\$requested_shards"/);
+  assert.match(exactCapacityBlock, /reserved_shards="\$item_count"/);
+  assert.match(modeBlock, /active_run_count .* \+ \$\(active_sweep_exact_workers\)/);
 });
 
 test("sweep workflow publishes target-scoped state paths", () => {
@@ -1239,6 +1248,7 @@ test("target review planners serialize exact and broad workflow dispatches", () 
   assert.doesNotMatch(planHeader, /github\.event\.inputs\.item_number == ''/);
   assert.doesNotMatch(planHeader, /github\.event\.inputs\.item_numbers == ''/);
   assert.match(planHeader, /\|\| github\.run_id/);
+  assert.match(planHeader, /queue: max/);
   assert.match(planHeader, /cancel-in-progress: false/);
 });
 

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -393,6 +393,30 @@ test("apply workflow target token can inspect source workflow runs", () => {
   assert.match(applyJob.slice(tokenStart, stateTokenStart), /permission-actions: read/);
 });
 
+test("targeted apply dispatches keep apply names ahead of exact-review names", () => {
+  const workflow = readText(".github/workflows/sweep.yml");
+  const runName = workflow.slice(workflow.indexOf("run-name:"), workflow.indexOf("\non:"));
+  const firstExactDispatchName = runName.indexOf(
+    "(github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.item_numbers, 'router-'))",
+  );
+
+  assert.ok(firstExactDispatchName > -1);
+  for (const applyName of [
+    "format('Sync Codex review comments for {0}'",
+    "format('Apply custom ClawSweeper closures for {0}'",
+    "format('Apply default ClawSweeper closures for {0}'",
+  ]) {
+    assert.ok(
+      runName.indexOf(applyName) < firstExactDispatchName,
+      `${applyName} must win when apply_existing also carries item_number or item_numbers`,
+    );
+  }
+  assert.match(
+    workflow,
+    /item_numbers="\$\{\{ github\.event_name == 'repository_dispatch' && github\.event\.client_payload\.item_number \|\| github\.event\.inputs\.apply_item_numbers \|\| '' \}\}"/,
+  );
+});
+
 test("apply workflow bounds checkpoints and requeues with a fresh token", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const applyHelper = readText("scripts/apply-workflow-helpers.sh");
@@ -554,6 +578,7 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
   assert.match(continueStep, /existing default cursor run will continue the lane/);
   assert.match(continueStep, /already covered by \$/);
   assert.match(continueStep, /-f apply_item_numbers="\$APPLY_ITEM_NUMBERS"/);
+  assert.doesNotMatch(continueStep, /-f item_numbers=/);
   assert.doesNotMatch(continueStep, /APPLY_CLOSED_TOTAL:-0.*APPLY_LIMIT:-0/);
 });
 

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -977,6 +977,15 @@ test("comment router prunes bare ack comments after updating shared automerge st
 
 test("manual exact-item review dispatches avoid broad review concurrency", () => {
   const workflow = readText(".github/workflows/sweep.yml");
+  const runName = workflow.slice(workflow.indexOf("run-name:"), workflow.indexOf("\non:"));
+  const exactCapacityBlock = workflow.slice(
+    workflow.indexOf("active_sweep_exact_count()"),
+    workflow.indexOf("active_sweep_background_workers()"),
+  );
+  const modeBlock = workflow.slice(
+    workflow.indexOf("- id: mode"),
+    workflow.indexOf("- id: select"),
+  );
 
   assert.match(
     workflow,
@@ -986,6 +995,16 @@ test("manual exact-item review dispatches avoid broad review concurrency", () =>
     workflow,
     /github\.event_name == 'workflow_dispatch' && github\.event\.inputs\.hot_intake == 'true' && \(github\.event\.inputs\.item_number != '' \|\| github\.event\.inputs\.item_numbers != ''\)\) && format\('clawsweeper-intake-exact-\{0\}'/,
   );
+  assert.match(
+    runName,
+    /github\.event_name == 'workflow_dispatch' &&\s+\(github\.event\.inputs\.item_number != '' \|\| github\.event\.inputs\.item_numbers != ''\)\) &&\s+format\('Review event item \{0\}#\{1\}', github\.event\.inputs\.target_repo \|\| 'openclaw\/openclaw', github\.event\.inputs\.item_number \|\| github\.event\.inputs\.item_numbers\)/,
+  );
+  assert.ok(
+    runName.indexOf("format('Review event item {0}#{1}'") <
+      runName.lastIndexOf("'Review ClawSweeper items'"),
+  );
+  assert.match(exactCapacityBlock, /\.displayTitle \| startswith\("Review event item "\)/);
+  assert.match(modeBlock, /active_run_count .* \+ \$\(active_sweep_exact_count\)/);
 });
 
 test("sweep workflow publishes target-scoped state paths", () => {
@@ -1199,7 +1218,7 @@ test("review backstops identify sweep runs by stable workflow path", () => {
   assert.doesNotMatch(block, /run\.workflowName/);
 });
 
-test("scheduled background reviews serialize planners and refill released capacity", () => {
+test("target review planners serialize exact and broad workflow dispatches", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const concurrencyBlock = workflow.slice(
     workflow.indexOf("concurrency:"),
@@ -1213,6 +1232,12 @@ test("scheduled background reviews serialize planners and refill released capaci
   assert.match(concurrencyBlock, /format\('clawsweeper-intake-v2-\{0\}', github\.run_id\)/);
   assert.match(concurrencyBlock, /format\('clawsweeper-review-\{0\}', github\.run_id\)/);
   assert.match(planHeader, /group: \$\{\{ format\('clawsweeper-planner-\{0\}'/);
+  assert.match(
+    planHeader,
+    /github\.event_name == 'schedule' \|\| github\.event_name == 'workflow_dispatch'/,
+  );
+  assert.doesNotMatch(planHeader, /github\.event\.inputs\.item_number == ''/);
+  assert.doesNotMatch(planHeader, /github\.event\.inputs\.item_numbers == ''/);
   assert.match(planHeader, /\|\| github\.run_id/);
   assert.match(planHeader, /cancel-in-progress: false/);
 });

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -997,6 +997,10 @@ test("manual exact-item review dispatches reserve their live shard capacity", ()
   );
   assert.match(
     runName,
+    /format\('Review event items \{0\}#\{1\},\{2\} \[shards=\{3\}\]', github\.event\.inputs\.target_repo \|\| 'openclaw\/openclaw', github\.event\.inputs\.item_number, github\.event\.inputs\.item_numbers, \(github\.event\.inputs\.hot_intake == 'true' && '1' \|\| github\.event\.inputs\.shard_count \|\| '89'\)\)/,
+  );
+  assert.match(
+    runName,
     /github\.event_name == 'workflow_dispatch' &&\s+github\.event\.inputs\.item_number != '' &&\s+github\.event\.inputs\.item_numbers == ''\) &&\s+format\('Review event item \{0\}#\{1\}', github\.event\.inputs\.target_repo \|\| 'openclaw\/openclaw', github\.event\.inputs\.item_number\)/,
   );
   assert.match(

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1038,6 +1038,13 @@ test("manual exact-item review dispatches reserve their live shard capacity", ()
   );
   assert.match(exactCapacityBlock, /\.displayTitle \| startswith\("Review event item "\)/);
   assert.match(exactCapacityBlock, /\.displayTitle \| startswith\("Review event items "\)/);
+  const singularFastPath = exactCapacityBlock.slice(
+    exactCapacityBlock.indexOf('if [[ "$title" == Review\\ event\\ item\\ * ]]'),
+    exactCapacityBlock.indexOf('if [ "$status" = "in_progress" ]'),
+  );
+  assert.match(singularFastPath, /active_shards=1/);
+  assert.match(singularFastPath, /continue/);
+  assert.doesNotMatch(singularFastPath, /gh run view/);
   assert.match(exactCapacityBlock, /gh run view "\$id".*--json jobs/);
   assert.match(exactCapacityBlock, /limit review_shards\.hard_cap/);
   assert.match(exactCapacityBlock, /reserved_shards="\$requested_shards"/);

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1001,7 +1001,7 @@ test("manual exact-item review dispatches reserve their live shard capacity", ()
   );
   assert.match(
     runName,
-    /format\('Review event items \{0\}#\{1\} \[shards=\{2\}\]', github\.event\.inputs\.target_repo \|\| 'openclaw\/openclaw', github\.event\.inputs\.item_numbers, github\.event\.inputs\.shard_count \|\| '89'\)/,
+    /format\('Review event items \{0\}#\{1\} \[shards=\{2\}\]', github\.event\.inputs\.target_repo \|\| 'openclaw\/openclaw', github\.event\.inputs\.item_numbers, \(github\.event\.inputs\.hot_intake == 'true' && '1' \|\| github\.event\.inputs\.shard_count \|\| '89'\)\)/,
   );
   assert.ok(
     runName.indexOf("format('Review event item {0}#{1}'") <
@@ -1211,9 +1211,14 @@ test("background review capacity reserves expanding matrices and caps broad manu
   assert.match(commitBlock, /STALE_QUEUED_CUTOFF/);
   assert.match(commitBlock, /updatedAt:\.updated_at/);
   assert.match(commitBlock, /workflowPath == "\.github\/workflows\/sweep\.yml"/);
+  assert.match(commitBlock, /\.displayTitle \| startswith\("Review event items "\)/);
   assert.match(commitBlock, /WORKFLOW_PATH="\$1"/);
   assert.doesNotMatch(commitBlock, /workflowName == "ClawSweeper"/);
   assert.doesNotMatch(commitBlock, /WORKFLOW_NAME="\$1"/);
+  assert.match(commitBlock, /total_shards/);
+  assert.match(commitBlock, /limit review_shards\.hard_cap/);
+  assert.match(commitBlock, /reserved_shards="\$requested_shards"/);
+  assert.match(commitBlock, /reserved_shards="\$item_count"/);
 });
 
 test("review backstops identify sweep runs by stable workflow path", () => {


### PR DESCRIPTION
## Summary

- serialize broad and explicit workflow-dispatch planners per target with GitHub's non-dropping concurrency queue
- give recovery batches exact run names with their effective pre-plan shard reservation
- replace reservations with live matrix-job counts in both sweep and commit-review capacity accounting
- preserve single-shard hot exact reviews and account for combined exact-item inputs

## Why

Broad run 29080679491 and explicit recovery run 29080687903 planned `openclaw/clawhub#3050` concurrently. The recovery run also used the generic broad title, so pre-plan accounting reserved the 89-shard normal lane even though the dispatch requested one shard.

## Proof

- focused sweep workflow regressions pass
- workflow YAML parsing, formatting, and test lint pass
- GPT-5.6 Sol High review findings addressed; `queue: max` is supported by the current [GitHub Actions concurrency contract](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency)
- live evidence: [broad planner](https://github.com/openclaw/clawsweeper/actions/runs/29080679491), [exact recovery](https://github.com/openclaw/clawsweeper/actions/runs/29080687903)
