### PR TITLE
fix: isolate maintainer report publishing

### DIFF
--- a/.github/workflows/maintainer-activity-report.yml
+++ b/.github/workflows/maintainer-activity-report.yml
@@ -150,6 +150,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Check out ClawSweeper
+        uses: actions/checkout@v7
+        with:
+          path: clawsweeper
+          filter: blob:none
+          persist-credentials: false
+
       - name: Create maintainer repo write token
         id: maintainers_write_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -176,40 +183,23 @@ jobs:
           name: maintainer-reports-${{ github.run_id }}-${{ github.run_attempt }}
           path: generated-reports
 
-      - name: Validate generated report tree
-        run: |
-          set -euo pipefail
-          test -n "${{ needs.generate.outputs.maintainers_sha }}"
-          test "$(git -C maintainers rev-parse HEAD)" = "${{ needs.generate.outputs.maintainers_sha }}"
-          if find generated-reports \( -name .git -o -name .gitattributes -o -name .gitmodules \) -print -quit | grep -q .; then
-            echo "Generated reports must not contain Git control files." >&2
-            exit 1
-          fi
-          if find generated-reports ! -type f ! -type d -print -quit | grep -q .; then
-            echo "Generated reports must contain only regular files and directories." >&2
-            exit 1
-          fi
-          file_count="$(find generated-reports -type f | wc -l | tr -d ' ')"
-          size_kib="$(du -sk generated-reports | cut -f1)"
-          if [ "$file_count" -gt 2000 ] || [ "$size_kib" -gt 262144 ]; then
-            echo "Generated report artifact exceeds its bounded file-count or size limit." >&2
-            exit 1
-          fi
-          rsync --archive --delete generated-reports/ maintainers/reports/
+      - name: Prepare generated report publication
+        id: prepare
+        run: >-
+          bash clawsweeper/scripts/prepare-maintainer-report-publication.sh
+          generated-reports
+          maintainers
+          "${{ needs.generate.outputs.maintainers_sha }}"
 
       - name: Commit report history
+        if: ${{ steps.prepare.outputs.changed == 'true' }}
         working-directory: maintainers
         env:
           GH_TOKEN: ${{ steps.maintainers_write_token.outputs.token }}
         run: |
           set -euo pipefail
-          if git diff --quiet -- reports; then
-            echo "No report changes."
-            exit 0
-          fi
           git config user.name "openclaw-clawsweeper[bot]"
           git config user.email "openclaw-clawsweeper[bot]@users.noreply.github.com"
-          git add reports
           git commit -m "chore: publish maintainer activity report"
           gh auth setup-git
           git pull --rebase origin main
@@ -230,11 +220,22 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      - name: Create maintainer repo read token
+        id: maintainers_read_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+          owner: openclaw
+          repositories: maintainers
+          permission-contents: read
+
       - name: Check out maintainers
         uses: actions/checkout@v7
         with:
           repository: openclaw/maintainers
           path: maintainers
+          token: ${{ steps.maintainers_read_token.outputs.token }}
           fetch-depth: 1
           persist-credentials: false
 

--- a/.github/workflows/maintainer-activity-report.yml
+++ b/.github/workflows/maintainer-activity-report.yml
@@ -49,20 +49,23 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  report:
-    name: Generate and publish maintainer reports
+  generate:
+    name: Generate maintainer reports
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.generate }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    outputs:
+      maintainers_sha: ${{ steps.maintainers-base.outputs.sha }}
     steps:
-      - name: Create maintainer repo token
-        id: maintainers_token
+      - name: Create maintainer repo read token
+        id: maintainers_read_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
           private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
           owner: openclaw
           repositories: maintainers
-          permission-contents: write
+          permission-contents: read
 
       - name: Create OpenClaw read token
         id: openclaw_read_token
@@ -80,8 +83,14 @@ jobs:
         with:
           repository: openclaw/maintainers
           path: maintainers
-          token: ${{ steps.maintainers_token.outputs.token }}
+          token: ${{ steps.maintainers_read_token.outputs.token }}
           fetch-depth: 0
+          persist-credentials: false
+
+      - name: Record maintainer base
+        id: maintainers-base
+        working-directory: maintainers
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -100,25 +109,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAWSWEEPER_INTERNAL_MODEL: ${{ secrets.CLAWSWEEPER_MODEL }}
 
-      - name: Configure Cloudflare Access
-        working-directory: maintainers
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.OPENCLAW_CLOUDFLARE_CONFIG_API_TOKEN || secrets.OPENCLAW_CLOUDFLARE_ACCESS_API_TOKEN }}
-          CF_API_TOKEN: ${{ secrets.OPENCLAW_CLOUDFLARE_CONFIG_API_TOKEN || secrets.OPENCLAW_CLOUDFLARE_ACCESS_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
-        run: |
-          set -euo pipefail
-          if [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
-            echo "::notice title=Cloudflare Access not configured::Set OPENCLAW_CLOUDFLARE_CONFIG_API_TOKEN with Pages, DNS, and Zero Trust Access write scope to enforce GitHub org login for reports.openclaw.ai."
-            exit 0
-          fi
-          node scripts/ensure-cloudflare-maintainer-reports.mjs \
-            --domain "$REPORTS_DOMAIN" \
-            --project "$REPORTS_PROJECT" \
-            --github-org openclaw
-
       - name: Generate reports
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.generate }}
         working-directory: maintainers
         env:
           GH_TOKEN: ${{ steps.openclaw_read_token.outputs.token }}
@@ -143,9 +134,73 @@ jobs:
           fi
           node .agents/skills/openclaw-maintainer-activity/scripts/generate-maintainer-activity-history.mjs "${args[@]}"
 
+      - name: Upload generated reports
+        uses: actions/upload-artifact@v7
+        with:
+          name: maintainer-reports-${{ github.run_id }}-${{ github.run_attempt }}
+          path: maintainers/reports
+          if-no-files-found: error
+          include-hidden-files: true
+          retention-days: 1
+
+  publish:
+    name: Publish maintainer reports
+    needs: generate
+    if: ${{ always() && needs.generate.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Create maintainer repo write token
+        id: maintainers_write_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+          owner: openclaw
+          repositories: maintainers
+          permission-contents: write
+
+      - name: Check out maintainer base
+        uses: actions/checkout@v7
+        with:
+          repository: openclaw/maintainers
+          path: maintainers
+          ref: ${{ needs.generate.outputs.maintainers_sha }}
+          token: ${{ steps.maintainers_write_token.outputs.token }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Download generated reports
+        uses: actions/download-artifact@v8
+        with:
+          name: maintainer-reports-${{ github.run_id }}-${{ github.run_attempt }}
+          path: generated-reports
+
+      - name: Validate generated report tree
+        run: |
+          set -euo pipefail
+          test -n "${{ needs.generate.outputs.maintainers_sha }}"
+          test "$(git -C maintainers rev-parse HEAD)" = "${{ needs.generate.outputs.maintainers_sha }}"
+          if find generated-reports \( -name .git -o -name .gitattributes -o -name .gitmodules \) -print -quit | grep -q .; then
+            echo "Generated reports must not contain Git control files." >&2
+            exit 1
+          fi
+          if find generated-reports ! -type f ! -type d -print -quit | grep -q .; then
+            echo "Generated reports must contain only regular files and directories." >&2
+            exit 1
+          fi
+          file_count="$(find generated-reports -type f | wc -l | tr -d ' ')"
+          size_kib="$(du -sk generated-reports | cut -f1)"
+          if [ "$file_count" -gt 2000 ] || [ "$size_kib" -gt 262144 ]; then
+            echo "Generated report artifact exceeds its bounded file-count or size limit." >&2
+            exit 1
+          fi
+          rsync --archive --delete generated-reports/ maintainers/reports/
+
       - name: Commit report history
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.generate }}
         working-directory: maintainers
+        env:
+          GH_TOKEN: ${{ steps.maintainers_write_token.outputs.token }}
         run: |
           set -euo pipefail
           if git diff --quiet -- reports; then
@@ -156,11 +211,55 @@ jobs:
           git config user.email "openclaw-clawsweeper[bot]@users.noreply.github.com"
           git add reports
           git commit -m "chore: publish maintainer activity report"
+          gh auth setup-git
           git pull --rebase origin main
           git push origin HEAD:main
 
+  deploy:
+    name: Deploy maintainer reports
+    needs: [generate, publish]
+    if: >-
+      ${{
+        always() &&
+        (github.event_name != 'workflow_dispatch' || inputs.deploy) &&
+        (
+          (needs.generate.result == 'success' && needs.publish.result == 'success') ||
+          needs.generate.result == 'skipped'
+        )
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out maintainers
+        uses: actions/checkout@v7
+        with:
+          repository: openclaw/maintainers
+          path: maintainers
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Configure Cloudflare Access
+        working-directory: maintainers
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.OPENCLAW_CLOUDFLARE_CONFIG_API_TOKEN || secrets.OPENCLAW_CLOUDFLARE_ACCESS_API_TOKEN }}
+          CF_API_TOKEN: ${{ secrets.OPENCLAW_CLOUDFLARE_CONFIG_API_TOKEN || secrets.OPENCLAW_CLOUDFLARE_ACCESS_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
+            echo "::notice title=Cloudflare Access not configured::Set OPENCLAW_CLOUDFLARE_CONFIG_API_TOKEN with Pages, DNS, and Zero Trust Access write scope to enforce GitHub org login for reports.openclaw.ai."
+            exit 0
+          fi
+          node scripts/ensure-cloudflare-maintainer-reports.mjs \
+            --domain "$REPORTS_DOMAIN" \
+            --project "$REPORTS_PROJECT" \
+            --github-org openclaw
+
       - name: Deploy reports.openclaw.ai
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.deploy }}
         working-directory: maintainers
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.OPENCLAW_CLOUDFLARE_PAGES_API_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ checkpoint, and status-only commits are intentionally omitted.
 - Serialized explicit workflow-dispatch planners through a non-dropping target queue and accounted for recovery runs by their requested or live shards, preventing overlapping target planning and false 89-shard reservations without undercounting multi-shard retries.
 - Released workflow-owned review leases after unsuccessful exact reviews, deferred coordination-held retries until lease expiry, and skipped state checkout without fresh artifacts, preventing held-lease loops from wasting exact-review capacity.
 - Bound exact-review execution to immutable queue claims and preserved both Worker/workflow deployment orders through a versioned rolling-upgrade protocol, avoiding stalled leases without disabling ClawSweeper.
+- Isolated maintainer-report Codex generation from GitHub and deployment write credentials by publishing its bounded report artifact on fresh runners.
 - Reconciled terminal exact-review runs by requested run instead of sampling the first 32 claimed leases, while preserving attempt and claim-generation guards across larger worker waves.
 - Dequeued already-closed exact-review events before setup and treated items closed during review as terminal no-ops, preventing permanent retry churn from consuming live worker capacity.
 - Kept broad reconciliation draining independent record repairs when one valid tuple has ambiguous legacy contents, while timestamping closed-record sidecar cleanup as an orderable atomic mutation.

--- a/scripts/prepare-maintainer-report-publication.sh
+++ b/scripts/prepare-maintainer-report-publication.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+generated_dir="${1:?generated report directory is required}"
+maintainers_dir="${2:?maintainers checkout directory is required}"
+expected_sha="${3:?expected maintainer base SHA is required}"
+
+if [ ! -d "$generated_dir" ] || [ ! -d "$maintainers_dir/.git" ]; then
+  echo "Generated reports and a maintainer Git checkout are required." >&2
+  exit 1
+fi
+
+actual_sha="$(git -C "$maintainers_dir" rev-parse HEAD)"
+if [ "$actual_sha" != "$expected_sha" ]; then
+  echo "Maintainer checkout does not match the generation base." >&2
+  exit 1
+fi
+
+if find "$generated_dir" \( -name .git -o -name .gitattributes -o -name .gitmodules \) -print -quit | grep -q .; then
+  echo "Generated reports must not contain Git control files." >&2
+  exit 1
+fi
+if find "$generated_dir" ! -type f ! -type d -print -quit | grep -q .; then
+  echo "Generated reports must contain only regular files and directories." >&2
+  exit 1
+fi
+
+file_count="$(find "$generated_dir" -type f | wc -l | tr -d ' ')"
+size_kib="$(du -sk "$generated_dir" | cut -f1)"
+if [ "$file_count" -lt 1 ] || [ "$file_count" -gt 2000 ] || [ "$size_kib" -gt 262144 ]; then
+  echo "Generated report artifact is empty or exceeds its bounded file-count or size limit." >&2
+  exit 1
+fi
+
+mkdir -p "$maintainers_dir/reports"
+rsync --archive --delete "$generated_dir/" "$maintainers_dir/reports/"
+git -C "$maintainers_dir" add -A -- reports
+
+changed=true
+if git -C "$maintainers_dir" diff --cached --quiet -- reports; then
+  changed=false
+fi
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  printf 'changed=%s\n' "$changed" >> "$GITHUB_OUTPUT"
+fi
+printf 'changed=%s\n' "$changed"

--- a/scripts/prepare-maintainer-report-publication.sh
+++ b/scripts/prepare-maintainer-report-publication.sh
@@ -16,7 +16,7 @@ if [ "$actual_sha" != "$expected_sha" ]; then
   exit 1
 fi
 
-if find "$generated_dir" \( -name .git -o -name .gitattributes -o -name .gitmodules \) -print -quit | grep -q .; then
+if find "$generated_dir" \( -name .git -o -name .gitattributes -o -name .gitignore -o -name .gitmodules \) -print -quit | grep -q .; then
   echo "Generated reports must not contain Git control files." >&2
   exit 1
 fi

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2276,6 +2276,33 @@ test("Codex workflows install pinned CLI releases and keep the model secret", ()
   }
 });
 
+test("maintainer report generation cannot access publish or deploy credentials", () => {
+  const workflow = readText(".github/workflows/maintainer-activity-report.yml");
+  const generateStart = workflow.indexOf("\n  generate:");
+  const publishStart = workflow.indexOf("\n  publish:", generateStart);
+  const deployStart = workflow.indexOf("\n  deploy:", publishStart);
+
+  assert.ok(generateStart >= 0);
+  assert.ok(publishStart > generateStart);
+  assert.ok(deployStart > publishStart);
+
+  const generate = workflow.slice(generateStart, publishStart);
+  const publish = workflow.slice(publishStart, deployStart);
+  const deploy = workflow.slice(deployStart);
+
+  assert.match(generate, /permission-contents: read/);
+  assert.doesNotMatch(generate, /permission-contents: write/);
+  assert.doesNotMatch(generate, /maintainers_write_token|git push|CLOUDFLARE_API_TOKEN/);
+  assert.equal(generate.match(/persist-credentials: false/g)?.length, 2);
+
+  assert.match(publish, /permission-contents: write/);
+  assert.match(publish, /persist-credentials: false/);
+  assert.doesNotMatch(publish, /setup-codex|OPENAI_API_KEY|CLOUDFLARE_API_TOKEN/);
+
+  assert.match(deploy, /persist-credentials: false/);
+  assert.doesNotMatch(deploy, /create-github-app-token|setup-codex|OPENAI_API_KEY/);
+});
+
 test("background review fanout keeps per-review transient recovery", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const reviewStart = workflow.indexOf("\n  review:");

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2276,33 +2276,6 @@ test("Codex workflows install pinned CLI releases and keep the model secret", ()
   }
 });
 
-test("maintainer report generation cannot access publish or deploy credentials", () => {
-  const workflow = readText(".github/workflows/maintainer-activity-report.yml");
-  const generateStart = workflow.indexOf("\n  generate:");
-  const publishStart = workflow.indexOf("\n  publish:", generateStart);
-  const deployStart = workflow.indexOf("\n  deploy:", publishStart);
-
-  assert.ok(generateStart >= 0);
-  assert.ok(publishStart > generateStart);
-  assert.ok(deployStart > publishStart);
-
-  const generate = workflow.slice(generateStart, publishStart);
-  const publish = workflow.slice(publishStart, deployStart);
-  const deploy = workflow.slice(deployStart);
-
-  assert.match(generate, /permission-contents: read/);
-  assert.doesNotMatch(generate, /permission-contents: write/);
-  assert.doesNotMatch(generate, /maintainers_write_token|git push|CLOUDFLARE_API_TOKEN/);
-  assert.equal(generate.match(/persist-credentials: false/g)?.length, 2);
-
-  assert.match(publish, /permission-contents: write/);
-  assert.match(publish, /persist-credentials: false/);
-  assert.doesNotMatch(publish, /setup-codex|OPENAI_API_KEY|CLOUDFLARE_API_TOKEN/);
-
-  assert.match(deploy, /persist-credentials: false/);
-  assert.doesNotMatch(deploy, /create-github-app-token|setup-codex|OPENAI_API_KEY/);
-});
-
 test("background review fanout keeps per-review transient recovery", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const reviewStart = workflow.indexOf("\n  review:");

--- a/test/maintainer-activity-report.test.ts
+++ b/test/maintainer-activity-report.test.ts
@@ -105,7 +105,7 @@ test("maintainer report publication stages new paths and retries idempotently", 
   }
 });
 
-test("maintainer report publication rejects empty artifacts", () => {
+test("maintainer report publication rejects empty artifacts and Git control files", () => {
   const root = mkdtempSync(join(tmpdir(), "clawsweeper-maintainer-report-empty-"));
   const maintainers = join(root, "maintainers");
   const generated = join(root, "generated");
@@ -122,6 +122,12 @@ test("maintainer report publication rejects empty artifacts", () => {
     assert.throws(
       () => prepare(generated, maintainers, baseSha),
       /Command failed|empty or exceeds/,
+    );
+
+    writeFileSync(join(generated, ".gitignore"), "*\n");
+    assert.throws(
+      () => prepare(generated, maintainers, baseSha),
+      /Command failed|Git control files/,
     );
   } finally {
     rmSync(root, { recursive: true, force: true });

--- a/test/maintainer-activity-report.test.ts
+++ b/test/maintainer-activity-report.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+const workflowPath = ".github/workflows/maintainer-activity-report.yml";
+const prepareScript = join(process.cwd(), "scripts/prepare-maintainer-report-publication.sh");
+
+function git(cwd: string, ...args: string[]) {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+function configureCommitter(cwd: string) {
+  git(cwd, "config", "user.name", "ClawSweeper Test");
+  git(cwd, "config", "user.email", "clawsweeper@example.invalid");
+}
+
+function prepare(generated: string, maintainers: string, baseSha: string) {
+  return execFileSync("bash", [prepareScript, generated, maintainers, baseSha], {
+    encoding: "utf8",
+  }).trim();
+}
+
+test("maintainer report jobs isolate generation, publication, and deployment credentials", () => {
+  const workflow = readFileSync(workflowPath, "utf8");
+  const generateStart = workflow.indexOf("\n  generate:");
+  const publishStart = workflow.indexOf("\n  publish:", generateStart);
+  const deployStart = workflow.indexOf("\n  deploy:", publishStart);
+
+  assert.ok(generateStart >= 0);
+  assert.ok(publishStart > generateStart);
+  assert.ok(deployStart > publishStart);
+
+  const generate = workflow.slice(generateStart, publishStart);
+  const publish = workflow.slice(publishStart, deployStart);
+  const deploy = workflow.slice(deployStart);
+
+  assert.match(generate, /permission-contents: read/);
+  assert.doesNotMatch(generate, /permission-contents: write/);
+  assert.doesNotMatch(generate, /maintainers_write_token|git push|CLOUDFLARE_API_TOKEN/);
+  assert.equal(generate.match(/persist-credentials: false/g)?.length, 2);
+
+  assert.match(publish, /permission-contents: write/);
+  assert.match(publish, /prepare-maintainer-report-publication\.sh/);
+  assert.match(publish, /steps\.prepare\.outputs\.changed == 'true'/);
+  assert.doesNotMatch(publish, /setup-codex|OPENAI_API_KEY|CLOUDFLARE_API_TOKEN/);
+
+  assert.match(deploy, /permission-contents: read/);
+  assert.doesNotMatch(deploy, /permission-contents: write/);
+  assert.match(deploy, /token: \$\{\{ steps\.maintainers_read_token\.outputs\.token \}\}/);
+  assert.doesNotMatch(deploy, /setup-codex|OPENAI_API_KEY|maintainers_write_token/);
+});
+
+test("maintainer report publication stages new paths and retries idempotently", () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-maintainer-report-"));
+  const remote = join(root, "maintainers.git");
+  const seed = join(root, "seed");
+  const first = join(root, "first");
+  const retry = join(root, "retry");
+  const generated = join(root, "generated");
+
+  try {
+    git(root, "init", "--bare", remote);
+    mkdirSync(seed);
+    git(seed, "init", "-b", "main");
+    configureCommitter(seed);
+    mkdirSync(join(seed, "reports"));
+    writeFileSync(join(seed, "reports", "old.json"), "old\n");
+    git(seed, "add", "reports");
+    git(seed, "commit", "-m", "seed reports");
+    git(seed, "remote", "add", "origin", remote);
+    git(seed, "push", "-u", "origin", "main");
+    const baseSha = git(seed, "rev-parse", "HEAD");
+
+    mkdirSync(join(generated, "day"), { recursive: true });
+    writeFileSync(join(generated, "day", "report.json"), '{"status":"ready"}\n');
+
+    git(root, "clone", remote, first);
+    configureCommitter(first);
+    assert.equal(prepare(generated, first, baseSha), "changed=true");
+    assert.match(git(first, "status", "--porcelain"), /D  reports\/old\.json/);
+    assert.match(git(first, "status", "--porcelain"), /A  reports\/day\/report\.json/);
+    git(first, "commit", "-m", "publish reports");
+    git(first, "push", "origin", "HEAD:main");
+    assert.equal(git(remote, "rev-list", "--count", "refs/heads/main"), "2");
+
+    git(root, "clone", remote, retry);
+    configureCommitter(retry);
+    git(retry, "checkout", "--detach", baseSha);
+    assert.equal(prepare(generated, retry, baseSha), "changed=true");
+    git(retry, "commit", "-m", "publish reports");
+    git(retry, "pull", "--rebase", "origin", "main");
+    git(retry, "push", "origin", "HEAD:main");
+
+    assert.equal(git(remote, "rev-list", "--count", "refs/heads/main"), "2");
+    assert.equal(
+      readFileSync(join(retry, "reports", "day", "report.json"), "utf8"),
+      '{"status":"ready"}\n',
+    );
+    assert.equal(prepare(generated, retry, git(retry, "rev-parse", "HEAD")), "changed=false");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("maintainer report publication rejects empty artifacts", () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-maintainer-report-empty-"));
+  const maintainers = join(root, "maintainers");
+  const generated = join(root, "generated");
+  try {
+    mkdirSync(maintainers);
+    mkdirSync(generated);
+    git(maintainers, "init", "-b", "main");
+    configureCommitter(maintainers);
+    writeFileSync(join(maintainers, "README.md"), "maintainers\n");
+    git(maintainers, "add", "README.md");
+    git(maintainers, "commit", "-m", "seed");
+    const baseSha = git(maintainers, "rev-parse", "HEAD");
+
+    assert.throws(
+      () => prepare(generated, maintainers, baseSha),
+      /Command failed|empty or exceeds/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/maintainer-activity-report.test.ts
+++ b/test/maintainer-activity-report.test.ts
@@ -72,6 +72,7 @@ test("maintainer report publication stages new paths and retries idempotently", 
     git(seed, "commit", "-m", "seed reports");
     git(seed, "remote", "add", "origin", remote);
     git(seed, "push", "-u", "origin", "main");
+    git(remote, "symbolic-ref", "HEAD", "refs/heads/main");
     const baseSha = git(seed, "rev-parse", "HEAD");
 
     mkdirSync(join(generated, "day"), { recursive: true });


### PR DESCRIPTION
## Summary

- run Codex report generation with read-only repository tokens
- publish the bounded report artifact on a fresh runner with the write token
- deploy on a third runner so Cloudflare credentials never share a process tree with Codex

## Validation

- `pnpm run check`
- `actionlint .github/workflows/maintainer-activity-report.yml`
- Autoreview: no findings

## Exact-head live proof

Head: `27bd5fb9a7783be7b22db13761be9d42f32aef38`

- [CI](https://github.com/openclaw/clawsweeper/actions/runs/29156420597): Linux `pnpm check` and the Windows launcher passed.
- [CodeQL](https://github.com/openclaw/clawsweeper/actions/runs/29156420618): Actions and JavaScript/TypeScript analysis passed.
- [First generation/publication run](https://github.com/openclaw/clawsweeper/actions/runs/29156428766): generation used read-only repository tokens; a separate fresh runner minted the repository write token, published the generated artifact once, and revoked the token during cleanup; deployment was skipped.
- [Second generation/publication run](https://github.com/openclaw/clawsweeper/actions/runs/29157839325): the same credential boundaries passed again and deployment was skipped. The live source data had changed, so this run produced a distinct report artifact and one corresponding publication rather than duplicating the first artifact.
- Focused integration coverage runs an identical artifact through publication twice and proves exactly one remote commit: the first attempt publishes and the second is a no-op. Empty artifacts, staging control files, additions, modifications, and deletions are covered.
- [Exact-head ClawSweeper review](https://github.com/openclaw/clawsweeper/actions/runs/29156436804) accepted all prior code findings as resolved; its remaining request was completed live behavior proof.

Cloudflare deployment was explicitly disabled and was not exercised. Landing therefore still requires either an item-specific waiver for Cloudflare live proof or later authorization for that proof.
