### PR TITLE
fix: stop held exact-review retry loops

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -445,6 +445,7 @@ jobs:
         id: target
         env:
           CLAIM_DECISION: ${{ steps.claim-exact-review-queue.outputs.decision }}
+          CLAWHUB_ENABLED: ${{ vars.CLAWSWEEPER_ENABLE_CLAWHUB }}
           CONFIGURED_CODEX_TIMEOUT_MS: ${{ vars.CLAWSWEEPER_CODEX_TIMEOUT_MS || '1200000' }}
         run: |
           set -euo pipefail
@@ -470,6 +471,8 @@ jobs:
           const [owner, name] = targetRepo.split("/");
           const checkoutDir = targetRepo === process.env.GITHUB_REPOSITORY ? `${name}-target` : name;
           const hasCommandContext = Boolean(decision.commandStatusMarker || decision.statusCommentId);
+          const targetEnabled =
+            targetRepo !== "openclaw/clawhub" || process.env.CLAWHUB_ENABLED === "1";
           const output = {
             target_repo: targetRepo,
             target_repo_owner: owner,
@@ -479,6 +482,7 @@ jobs:
             codex_timeout_ms: Math.max(configuredTimeout, adaptiveTimeout),
             media_proof_timeout_ms: mediaTimeout,
             has_command_context: hasCommandContext,
+            target_enabled: targetEnabled,
           };
           fs.appendFileSync(
             process.env.GITHUB_OUTPUT,
@@ -488,7 +492,12 @@ jobs:
           );
           NODE
 
+      - name: Skip disabled claimed target
+        if: ${{ steps.target.outputs.target_enabled == 'false' }}
+        run: echo "Completing the claimed exact-review lease without target access because this target is disabled."
+
       - name: Create target read token
+        if: ${{ steps.target.outputs.target_enabled == 'true' }}
         id: target-read-token
         continue-on-error: true
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -502,6 +511,7 @@ jobs:
           permission-pull-requests: read
 
       - name: Check live target item state
+        if: ${{ steps.target.outputs.target_enabled == 'true' }}
         id: live-item
         env:
           GH_TOKEN: ${{ steps.target-read-token.outputs.token }}
@@ -1116,7 +1126,7 @@ jobs:
           remove_own_eyes_reactions
 
       - name: Fail unsuccessful exact review
-        if: ${{ always() && steps.live-item.outputs.proceed != 'false' && steps.publish-event-result.outputs.terminal_noop != 'true' && steps.publish-event-result.outputs.policy_noop != 'true' && steps.publish-event-result.outputs.requeue_latest != 'true' && (steps.review-exact-event-item.outcome != 'success' || steps.publish-event-result.outcome != 'success' || (steps.publish-event-result.outputs.terminal_missing != 'true' && steps.publish-event-result.outputs.terminal_closed != 'true' && steps.publish-event-result.outputs.guarded_open != 'true' && steps.route-synced-verdict.outcome != 'success' && steps.queue-deferred-verdict-router.outcome != 'success')) }}
+        if: ${{ always() && steps.target.outputs.target_enabled != 'false' && steps.live-item.outputs.proceed != 'false' && steps.publish-event-result.outputs.terminal_noop != 'true' && steps.publish-event-result.outputs.policy_noop != 'true' && steps.publish-event-result.outputs.requeue_latest != 'true' && (steps.review-exact-event-item.outcome != 'success' || steps.publish-event-result.outcome != 'success' || (steps.publish-event-result.outputs.terminal_missing != 'true' && steps.publish-event-result.outputs.terminal_closed != 'true' && steps.publish-event-result.outputs.guarded_open != 'true' && steps.route-synced-verdict.outcome != 'success' && steps.queue-deferred-verdict-router.outcome != 'success')) }}
         run: exit 1
 
       - name: Complete exact-review queue lease

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -17,7 +17,7 @@ run-name: >-
       github.event.action == 'clawsweeper_target_sweep') &&
       format('Review target repo {0}', github.event.client_payload.target_repo || 'openclaw/openclaw') ||
     (github.event_name == 'repository_dispatch' && github.event.client_payload.queue_lease_id != '') &&
-      format('Review event item {0}', github.event.client_payload.item_key || '?') ||
+      format('Review event item {0}', github.event.client_payload.queue_claim.item_key || github.event.client_payload.item_key || '?') ||
     (github.event_name == 'repository_dispatch' && github.event.client_payload.dispatch_key != '') &&
       format('Review event item {0}#{1} [{2}]', github.event.client_payload.target_repo || 'openclaw/openclaw', github.event.client_payload.item_number || '?', github.event.client_payload.dispatch_key) ||
     github.event_name == 'repository_dispatch' &&
@@ -294,7 +294,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     concurrency:
-      group: clawsweeper-event-review-${{ github.event.client_payload.item_key || github.run_id }}
+      group: clawsweeper-event-review-${{ github.event.client_payload.queue_claim.item_key || github.event.client_payload.item_key || github.run_id }}
       cancel-in-progress: false
     permissions:
       actions: write
@@ -306,9 +306,9 @@ jobs:
         id: claim-exact-review-queue
         env:
           DISPATCH_PAYLOAD: ${{ toJSON(github.event.client_payload) }}
-          ITEM_KEY: ${{ github.event.client_payload.item_key }}
+          ITEM_KEY: ${{ github.event.client_payload.queue_claim.item_key || github.event.client_payload.item_key }}
           QUEUE_LEASE_ID: ${{ github.event.client_payload.queue_lease_id }}
-          QUEUE_LEASE_REVISION: ${{ github.event.client_payload.lease_revision }}
+          QUEUE_LEASE_REVISION: ${{ github.event.client_payload.queue_claim.lease_revision || github.event.client_payload.lease_revision }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -760,7 +760,7 @@ jobs:
           done <<< "$lease_ids"
       - name: Route synced ClawSweeper verdict
         id: route-synced-verdict
-        if: ${{ steps.review-exact-event-item.outcome == 'success' && steps.publish-event-result.outcome == 'success' && steps.publish-event-result.outputs.terminal_noop != 'true' && steps.publish-event-result.outputs.terminal_missing != 'true' && steps.publish-event-result.outputs.terminal_closed != 'true' && steps.publish-event-result.outputs.guarded_open != 'true' && steps.publish-event-result.outputs.remote_tuple_verified == 'true' && steps.publish-event-result.outputs.routing_deferred == 'false' }}
+        if: ${{ steps.review-exact-event-item.outcome == 'success' && steps.publish-event-result.outcome == 'success' && steps.publish-event-result.outputs.terminal_noop != 'true' && steps.publish-event-result.outputs.terminal_missing != 'true' && steps.publish-event-result.outputs.terminal_closed != 'true' && steps.publish-event-result.outputs.guarded_open != 'true' && steps.publish-event-result.outputs.policy_noop != 'true' && steps.publish-event-result.outputs.requeue_latest != 'true' && steps.publish-event-result.outputs.remote_tuple_verified == 'true' && steps.publish-event-result.outputs.routing_deferred == 'false' }}
         timeout-minutes: 4
         env:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
@@ -871,12 +871,22 @@ jobs:
           GUARDED_OPEN: ${{ steps.publish-event-result.outputs.guarded_open }}
           REMOTE_TUPLE_VERIFIED: ${{ steps.publish-event-result.outputs.remote_tuple_verified }}
           ROUTING_DEFERRED: ${{ steps.publish-event-result.outputs.routing_deferred }}
+          POLICY_NOOP: ${{ steps.publish-event-result.outputs.policy_noop }}
+          REQUEUE_LATEST: ${{ steps.publish-event-result.outputs.requeue_latest }}
         run: |
           state="Failed"
           detail="The targeted re-review did not finish cleanly. Check the workflow run for details."
           if [ "$REVIEW_OUTCOME" = "cancelled" ]; then
             state="Interrupted"
             detail="The targeted re-review was interrupted. The exact-review queue will reconcile a newer pending item if one arrived."
+          fi
+          if [ "$POLICY_NOOP" = "true" ]; then
+            state="Complete"
+            detail="The exact review reached a deterministic same-author pair policy veto; no action was taken and the queue item is terminal."
+          fi
+          if [ "$REQUEUE_LATEST" = "true" ]; then
+            state="Interrupted"
+            detail="The item changed after review. This run is returning it to the exact-review queue; the workflow will fail if that handoff is not acknowledged."
           fi
           if [ "${{ steps.confirm-terminal-item.outputs.confirmed }}" = "true" ]; then
             state="Complete"
@@ -970,12 +980,13 @@ jobs:
             --rebase-strategy theirs
 
       - name: React to target item completion
-        if: ${{ steps.live-item.outputs.guarded_open == 'true' || (steps.review-exact-event-item.outcome == 'success' && steps.publish-event-result.outcome == 'success' && (steps.publish-event-result.outputs.terminal_closed == 'true' || steps.publish-event-result.outputs.guarded_open == 'true' || steps.queue-deferred-verdict-router.outcome == 'success' || steps.route-synced-verdict.outcome == 'success')) }}
+        if: ${{ steps.live-item.outputs.guarded_open == 'true' || (steps.review-exact-event-item.outcome == 'success' && steps.publish-event-result.outcome == 'success' && (steps.publish-event-result.outputs.terminal_closed == 'true' || steps.publish-event-result.outputs.guarded_open == 'true' || steps.publish-event-result.outputs.policy_noop == 'true' || steps.queue-deferred-verdict-router.outcome == 'success' || steps.route-synced-verdict.outcome == 'success')) }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
           ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
+          POLICY_NOOP: ${{ steps.publish-event-result.outputs.policy_noop }}
         run: |
           set -euo pipefail
           test -n "$GH_TOKEN"
@@ -1025,14 +1036,17 @@ jobs:
               rm -f "$err"
             done <<< "$ids"
           }
-          add_completion_reaction
+          if [ "$POLICY_NOOP" != "true" ]; then
+            add_completion_reaction
+          fi
           remove_own_eyes_reactions
 
       - name: Fail unsuccessful exact review
-        if: ${{ always() && steps.live-item.outputs.proceed != 'false' && steps.publish-event-result.outputs.terminal_noop != 'true' && (steps.review-exact-event-item.outcome != 'success' || steps.publish-event-result.outcome != 'success' || (steps.publish-event-result.outputs.terminal_missing != 'true' && steps.publish-event-result.outputs.terminal_closed != 'true' && steps.publish-event-result.outputs.guarded_open != 'true' && steps.route-synced-verdict.outcome != 'success' && steps.queue-deferred-verdict-router.outcome != 'success')) }}
+        if: ${{ always() && steps.live-item.outputs.proceed != 'false' && steps.publish-event-result.outputs.terminal_noop != 'true' && steps.publish-event-result.outputs.policy_noop != 'true' && steps.publish-event-result.outputs.requeue_latest != 'true' && (steps.review-exact-event-item.outcome != 'success' || steps.publish-event-result.outcome != 'success' || (steps.publish-event-result.outputs.terminal_missing != 'true' && steps.publish-event-result.outputs.terminal_closed != 'true' && steps.publish-event-result.outputs.guarded_open != 'true' && steps.route-synced-verdict.outcome != 'success' && steps.queue-deferred-verdict-router.outcome != 'success')) }}
         run: exit 1
 
       - name: Complete exact-review queue lease
+        id: complete-exact-review-queue
         if: ${{ always() }}
         continue-on-error: true
         env:
@@ -1040,6 +1054,7 @@ jobs:
           QUEUE_LEASE_ID: ${{ github.event.client_payload.queue_lease_id }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           RETRY_AT: ${{ steps.review-exact-event-item.outputs.retry_at }}
+          REQUEUE_LATEST: ${{ steps.publish-event-result.outputs.requeue_latest }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
@@ -1054,12 +1069,14 @@ jobs:
                 ? "cancelled"
                 : "failure";
             const retryAt = String(process.env.RETRY_AT || "").trim();
+            const requeueLatest = process.env.REQUEUE_LATEST === "true";
             process.stdout.write(JSON.stringify({
               lease_id: process.env.QUEUE_LEASE_ID,
               run_id: process.env.GITHUB_RUN_ID,
               run_attempt: runAttempt,
               outcome,
               ...(retryAt ? { retry_at: retryAt } : {}),
+              ...(requeueLatest ? { requeue_latest: true } : {}),
             }));
           ')"
           for attempt in 1 2 3; do
@@ -1075,6 +1092,10 @@ jobs:
             fi
           done
           exit 1
+
+      - name: Fail unacknowledged source-drift requeue
+        if: ${{ always() && steps.publish-event-result.outputs.requeue_latest == 'true' && steps.complete-exact-review-queue.outcome != 'success' }}
+        run: exit 1
 
   target-fanout:
     name: Fan out target repository sweeps

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -656,16 +656,39 @@ jobs:
             --shard-count 1 \
             "${additional_prompt_arg[@]}"
 
+          coordination_held_path="artifacts/event/coordination-held.json"
+          if [ -f "$coordination_held_path" ]; then
+            retry_at="$(node -e '
+              const data = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"));
+              const value = String(data.retry_at || "").trim();
+              const timestamp = Date.parse(value);
+              if (!value || !Number.isFinite(timestamp)) process.exit(1);
+              process.stdout.write(new Date(timestamp).toISOString());
+            ' "$coordination_held_path")"
+            echo "retry_at=$retry_at" >> "$GITHUB_OUTPUT"
+            echo "::notice::Review coordination is held until $retry_at."
+          fi
+
+          report_path="artifacts/event/${{ steps.target.outputs.item_number }}.md"
+          if [ ! -f "$report_path" ]; then
+            live_state="$(gh api "repos/${{ steps.target.outputs.target_repo }}/issues/${{ steps.target.outputs.item_number }}" --jq .state)"
+            if [ "$live_state" != "closed" ]; then
+              echo "Exact review produced no artifact for open item ${{ steps.target.outputs.target_repo }}#${{ steps.target.outputs.item_number }}." >&2
+              exit 1
+            fi
+            echo "::notice::Exact review produced no artifact because the item closed during review."
+          fi
+
       - name: Create state token
         id: state-token
-        if: ${{ steps.live-item.outputs.proceed == 'true' }}
+        if: ${{ steps.live-item.outputs.proceed == 'true' && steps.review-exact-event-item.outcome == 'success' }}
         uses: ./.github/actions/create-state-token
         with:
           client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
           private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
 
       - uses: ./.github/actions/setup-state
-        if: ${{ steps.live-item.outputs.proceed == 'true' }}
+        if: ${{ steps.live-item.outputs.proceed == 'true' && steps.review-exact-event-item.outcome == 'success' }}
         with:
           token: ${{ steps.state-token.outputs.token }}
           fetch-depth: 1
@@ -715,6 +738,26 @@ jobs:
           echo "terminal_noop=false" >> "$GITHUB_OUTPUT"
           pnpm run repair:publish-event-result
 
+      - name: Release unsuccessful workflow-owned review lease
+        if: ${{ always() && steps.live-item.outputs.proceed == 'true' && (steps.review-exact-event-item.outcome != 'success' || steps.publish-event-result.outcome != 'success') }}
+        env:
+          GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          TARGET_REPO: ${{ steps.target.outputs.target_repo }}
+          ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
+          LEASE_OWNER: github-run-${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+          test -n "$GH_TOKEN"
+          lease_ids="$(
+            gh api "repos/$TARGET_REPO/issues/$ITEM_NUMBER/comments?per_page=100" \
+              --paginate \
+              --jq ".[] | select(.user.login == \"clawsweeper[bot]\" or .user.login == \"openclaw-clawsweeper[bot]\") | select(.body | contains(\"<!-- clawsweeper-review-lease item=$ITEM_NUMBER -->\")) | select(.body | contains(\"owner=$LEASE_OWNER \")) | .id"
+          )"
+          while IFS= read -r lease_id; do
+            [ -n "$lease_id" ] || continue
+            gh api "repos/$TARGET_REPO/issues/comments/$lease_id" --method DELETE
+            echo "Released unsuccessful review lease comment $lease_id owned by $LEASE_OWNER."
+          done <<< "$lease_ids"
       - name: Route synced ClawSweeper verdict
         id: route-synced-verdict
         if: ${{ steps.review-exact-event-item.outcome == 'success' && steps.publish-event-result.outcome == 'success' && steps.publish-event-result.outputs.terminal_noop != 'true' && steps.publish-event-result.outputs.terminal_missing != 'true' && steps.publish-event-result.outputs.terminal_closed != 'true' && steps.publish-event-result.outputs.guarded_open != 'true' && steps.publish-event-result.outputs.remote_tuple_verified == 'true' && steps.publish-event-result.outputs.routing_deferred == 'false' }}
@@ -996,6 +1039,7 @@ jobs:
           JOB_STATUS: ${{ job.status }}
           QUEUE_LEASE_ID: ${{ github.event.client_payload.queue_lease_id }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          RETRY_AT: ${{ steps.review-exact-event-item.outputs.retry_at }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
@@ -1009,11 +1053,13 @@ jobs:
               : process.env.JOB_STATUS === "cancelled"
                 ? "cancelled"
                 : "failure";
+            const retryAt = String(process.env.RETRY_AT || "").trim();
             process.stdout.write(JSON.stringify({
               lease_id: process.env.QUEUE_LEASE_ID,
               run_id: process.env.GITHUB_RUN_ID,
               run_attempt: runAttempt,
               outcome,
+              ...(retryAt ? { retry_at: retryAt } : {}),
             }));
           ')"
           for attempt in 1 2 3; do

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -851,7 +851,7 @@ jobs:
           echo "confirmed=true" >> "$GITHUB_OUTPUT"
 
       - name: Mark re-review complete
-        if: ${{ always() && steps.setup-pnpm.outcome == 'success' && (steps.live-item.outputs.proceed == 'true' || steps.live-item.outputs.terminal_missing == 'true' || steps.live-item.outputs.guarded_open == 'true' || steps.confirm-terminal-item.outputs.confirmed == 'true') }}
+        if: ${{ always() && steps.setup-pnpm.outcome == 'success' && steps.publish-event-result.outputs.requeue_latest != 'true' && (steps.live-item.outputs.proceed == 'true' || steps.live-item.outputs.terminal_missing == 'true' || steps.live-item.outputs.guarded_open == 'true' || steps.confirm-terminal-item.outputs.confirmed == 'true') }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
@@ -1092,6 +1092,26 @@ jobs:
             fi
           done
           exit 1
+
+      - name: Mark source-drift re-review queued
+        if: ${{ always() && steps.setup-pnpm.outcome == 'success' && steps.publish-event-result.outputs.requeue_latest == 'true' && steps.complete-exact-review-queue.outcome == 'success' }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          TARGET_REPO: ${{ steps.target.outputs.target_repo }}
+          ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
+          COMMAND_STATUS_MARKER: ${{ github.event.client_payload.review_options.command_status_marker || github.event.client_payload.command_status_marker || '' }}
+          STATUS_COMMENT_ID: ${{ github.event.client_payload.review_options.status_comment_id || github.event.client_payload.status_comment_id || '' }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          pnpm run repair:update-command-status -- \
+            --repo "$TARGET_REPO" \
+            --item-number "$ITEM_NUMBER" \
+            --marker "$COMMAND_STATUS_MARKER" \
+            --status-comment-id "$STATUS_COMMENT_ID" \
+            --state "Complete" \
+            --detail "The item changed after review; the queue acknowledged one fresh review of the latest state." \
+            --run-url "$RUN_URL"
 
       - name: Fail unacknowledged source-drift requeue
         if: ${{ always() && steps.publish-event-result.outputs.requeue_latest == 'true' && steps.complete-exact-review-queue.outcome != 'success' }}

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -16,6 +16,8 @@ run-name: >-
     (github.event_name == 'repository_dispatch' &&
       github.event.action == 'clawsweeper_target_sweep') &&
       format('Review target repo {0}', github.event.client_payload.target_repo || 'openclaw/openclaw') ||
+    (github.event_name == 'repository_dispatch' && github.event.client_payload.queue_lease_id != '') &&
+      format('Review event item {0}', github.event.client_payload.item_key || '?') ||
     (github.event_name == 'repository_dispatch' && github.event.client_payload.dispatch_key != '') &&
       format('Review event item {0}#{1} [{2}]', github.event.client_payload.target_repo || 'openclaw/openclaw', github.event.client_payload.item_number || '?', github.event.client_payload.dispatch_key) ||
     github.event_name == 'repository_dispatch' &&
@@ -288,11 +290,11 @@ jobs:
 
   event-review-apply:
     name: Review, comment, and apply event item
-    if: ${{ github.event_name == 'repository_dispatch' && github.event.action != 'clawsweeper_target_sweep' && github.event.client_payload.queue_lease_id != '' && !(github.event.client_payload.target_repo == 'openclaw/clawhub' && vars.CLAWSWEEPER_ENABLE_CLAWHUB != '1') }}
+    if: ${{ github.event_name == 'repository_dispatch' && github.event.action != 'clawsweeper_target_sweep' && github.event.client_payload.queue_lease_id != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
     concurrency:
-      group: clawsweeper-event-review-${{ github.event.client_payload.target_repo || 'openclaw/openclaw' }}-${{ github.event.client_payload.item_number || github.run_id }}
+      group: clawsweeper-event-review-${{ github.event.client_payload.item_key || github.run_id }}
       cancel-in-progress: false
     permissions:
       actions: write
@@ -301,19 +303,26 @@ jobs:
       pull-requests: write
     steps:
       - name: Claim exact-review queue lease
+        id: claim-exact-review-queue
         env:
+          ITEM_KEY: ${{ github.event.client_payload.item_key }}
           QUEUE_LEASE_ID: ${{ github.event.client_payload.queue_lease_id }}
+          QUEUE_LEASE_REVISION: ${{ github.event.client_payload.lease_revision }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
-          test -n "$QUEUE_LEASE_ID"
+          test -n "$QUEUE_LEASE_ID" && test -n "$ITEM_KEY"
           queue_url="${QUEUE_URL%/}"
           payload="$(node -e '
             const runAttempt = Number(process.env.RUN_ATTEMPT);
+            const leaseRevision = Number(process.env.QUEUE_LEASE_REVISION);
             if (!Number.isInteger(runAttempt) || runAttempt < 1) process.exit(1);
+            if (!Number.isInteger(leaseRevision) || leaseRevision < 1) process.exit(1);
             process.stdout.write(JSON.stringify({
               lease_id: process.env.QUEUE_LEASE_ID,
+              item_key: process.env.ITEM_KEY,
+              lease_revision: leaseRevision,
               run_id: process.env.GITHUB_RUN_ID,
               run_attempt: runAttempt,
             }));
@@ -324,10 +333,42 @@ jobs:
               --header "content-type: application/json" \
               --data "$payload" \
               "$queue_url/internal/exact-review/claim")" &&
-              RESPONSE="$response" node -e '
+              RESPONSE="$response" node <<'NODE'
+                const fs = require("node:fs");
                 const response = JSON.parse(process.env.RESPONSE || "{}");
-                if (response.claimed !== true) process.exit(1);
-              '; then
+                const decision = response.decision;
+                const leaseRevision = Number(process.env.QUEUE_LEASE_REVISION);
+                const claimGeneration = Number(response.claim_generation);
+                const itemKey = String(process.env.ITEM_KEY || "");
+                const targetRepo = String(decision?.targetRepo || "");
+                const itemNumber = Number(decision?.itemNumber);
+                if (
+                  response.claimed !== true ||
+                  response.item_key !== itemKey ||
+                  response.lease_revision !== leaseRevision ||
+                  !Number.isInteger(claimGeneration) ||
+                  claimGeneration < 1 ||
+                  !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(targetRepo) ||
+                  !Number.isInteger(itemNumber) ||
+                  itemNumber < 1 ||
+                  `${targetRepo}#${itemNumber}` !== itemKey ||
+                  (decision.itemKind !== "issue" && decision.itemKind !== "pull_request") ||
+                  (decision.sourceEvent !== "issues" && decision.sourceEvent !== "pull_request") ||
+                  typeof decision.sourceAction !== "string" ||
+                  !decision.sourceAction
+                ) {
+                  process.exit(1);
+                }
+                const output = [
+                  `lease_id=${process.env.QUEUE_LEASE_ID}`,
+                  `item_key=${itemKey}`,
+                  `lease_revision=${leaseRevision}`,
+                  `claim_generation=${claimGeneration}`,
+                  `decision=${JSON.stringify(decision)}`,
+                ];
+                fs.appendFileSync(process.env.GITHUB_OUTPUT, `${output.join("\n")}\n`);
+          NODE
+            then
               exit 0
             fi
             if [ "$attempt" -lt 3 ]; then
@@ -345,83 +386,49 @@ jobs:
       - name: Resolve event payload
         id: target
         env:
-          ADAPTIVE_CODEX_TIMEOUT_MS: ${{ github.event.client_payload.review_options.codex_timeout_ms || github.event.client_payload.codex_timeout_ms || '' }}
+          CLAIM_DECISION: ${{ steps.claim-exact-review-queue.outputs.decision }}
           CONFIGURED_CODEX_TIMEOUT_MS: ${{ vars.CLAWSWEEPER_CODEX_TIMEOUT_MS || '1200000' }}
-          MEDIA_PROOF_TIMEOUT_MS: ${{ github.event.client_payload.review_options.media_proof_timeout_ms || github.event.client_payload.media_proof_timeout_ms || '0' }}
         run: |
           set -euo pipefail
-          target_repo="${{ github.event.client_payload.target_repo || 'openclaw/openclaw' }}"
-          target_branch="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.target_branch || github.event.client_payload.target_branch || 'main' }}"
-          item_number="${{ github.event.client_payload.item_number || '' }}"
-          item_kind="${{ github.event.client_payload.item_kind || '' }}"
-          if ! printf '%s' "$target_repo" | grep -Eq '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'; then
-            echo "Invalid target_repo: $target_repo" >&2
-            exit 1
-          fi
-          if ! printf '%s' "$target_branch" | grep -Eq '^[A-Za-z0-9_.\/-]+$'; then
-            echo "Invalid target_branch: $target_branch" >&2
-            exit 1
-          fi
-          if ! printf '%s' "$item_number" | grep -Eq '^[0-9]+$'; then
-            echo "Invalid item_number: $item_number" >&2
-            exit 1
-          fi
-          case "$item_kind" in
-            ""|"issue"|"pull_request") ;;
-            *)
-              echo "Invalid item_kind: $item_kind" >&2
-              exit 1
-              ;;
-          esac
-          configured_codex_timeout_ms="$CONFIGURED_CODEX_TIMEOUT_MS"
-          if ! printf '%s' "$configured_codex_timeout_ms" | grep -Eq '^[0-9]{1,10}$' || [ "$configured_codex_timeout_ms" -lt 1 ]; then
-            echo "::warning::Invalid configured Codex timeout; using 1200000."
-            configured_codex_timeout_ms="1200000"
-          fi
-          configured_codex_timeout_ms="$((10#$configured_codex_timeout_ms))"
-          codex_timeout_ms="$configured_codex_timeout_ms"
-          if [ -n "$ADAPTIVE_CODEX_TIMEOUT_MS" ]; then
-            adaptive_codex_timeout_ms="$ADAPTIVE_CODEX_TIMEOUT_MS"
-            if ! printf '%s' "$adaptive_codex_timeout_ms" | grep -Eq '^[0-9]{1,10}$' || [ "$adaptive_codex_timeout_ms" -lt 1 ]; then
-              echo "::warning::Ignoring invalid adaptive codex_timeout_ms payload."
-            else
-              adaptive_codex_timeout_ms="$((10#$adaptive_codex_timeout_ms))"
-              if [ "$adaptive_codex_timeout_ms" -lt 600000 ]; then
-                adaptive_codex_timeout_ms="600000"
-              fi
-              if [ "$adaptive_codex_timeout_ms" -gt 1800000 ]; then
-                adaptive_codex_timeout_ms="1800000"
-              fi
-              if [ "$adaptive_codex_timeout_ms" -gt "$codex_timeout_ms" ]; then
-                codex_timeout_ms="$adaptive_codex_timeout_ms"
-              fi
-            fi
-          fi
-          media_proof_timeout_ms="$MEDIA_PROOF_TIMEOUT_MS"
-          if ! printf '%s' "$media_proof_timeout_ms" | grep -Eq '^[0-9]{1,6}$'; then
-            echo "::warning::Ignoring invalid media_proof_timeout_ms payload."
-            media_proof_timeout_ms="0"
-          fi
-          media_proof_timeout_ms="$((10#$media_proof_timeout_ms))"
-          if [ "$media_proof_timeout_ms" -gt 480000 ]; then
-            media_proof_timeout_ms="480000"
-          fi
-          target_owner="${target_repo%%/*}"
-          target_name="${target_repo#*/}"
-          target_checkout_dir="$target_name"
-          if [ "$target_repo" = "${{ github.repository }}" ]; then
-            target_checkout_dir="${target_name}-target"
-          fi
-          {
-            echo "target_repo=$target_repo"
-            echo "target_repo_owner=$target_owner"
-            echo "target_repo_name=$target_name"
-            echo "target_branch=$target_branch"
-            echo "target_checkout_dir=$target_checkout_dir"
-            echo "item_number=$item_number"
-            echo "codex_timeout_ms=$codex_timeout_ms"
-            echo "media_proof_timeout_ms=$media_proof_timeout_ms"
-          } >> "$GITHUB_OUTPUT"
+          node <<'NODE'
+          const fs = require("node:fs");
+          const decision = JSON.parse(process.env.CLAIM_DECISION || "{}");
+          const targetRepo = String(decision.targetRepo || "");
+          const itemNumber = Number(decision.itemNumber);
+          if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(targetRepo)) process.exit(1);
+          if (!Number.isInteger(itemNumber) || itemNumber < 1) process.exit(1);
+
+          const configuredValue = Number(process.env.CONFIGURED_CODEX_TIMEOUT_MS);
+          const configuredTimeout =
+            Number.isInteger(configuredValue) && configuredValue > 0 ? configuredValue : 1_200_000;
+          const adaptiveValue = Number(decision.codexTimeoutMs);
+          const adaptiveTimeout =
+            Number.isInteger(adaptiveValue) && adaptiveValue > 0
+              ? Math.min(1_800_000, Math.max(600_000, adaptiveValue))
+              : 0;
+          const mediaValue = Number(decision.mediaProofTimeoutMs);
+          const mediaTimeout =
+            Number.isInteger(mediaValue) && mediaValue > 0 ? Math.min(480_000, mediaValue) : 0;
+          const [owner, name] = targetRepo.split("/");
+          const checkoutDir = targetRepo === process.env.GITHUB_REPOSITORY ? `${name}-target` : name;
+          const hasCommandContext = Boolean(decision.commandStatusMarker || decision.statusCommentId);
+          const output = {
+            target_repo: targetRepo,
+            target_repo_owner: owner,
+            target_repo_name: name,
+            target_checkout_dir: checkoutDir,
+            item_number: itemNumber,
+            codex_timeout_ms: Math.max(configuredTimeout, adaptiveTimeout),
+            media_proof_timeout_ms: mediaTimeout,
+            has_command_context: hasCommandContext,
+          };
+          fs.appendFileSync(
+            process.env.GITHUB_OUTPUT,
+            `${Object.entries(output)
+              .map(([key, value]) => `${key}=${value}`)
+              .join("\n")}\n`,
+          );
+          NODE
 
       - name: Create target read token
         id: target-read-token
@@ -445,6 +452,12 @@ jobs:
         run: |
           set -euo pipefail
           test -n "$GH_TOKEN"
+          target_branch="$(gh api "repos/$TARGET_REPO" --jq .default_branch)"
+          if ! printf '%s' "$target_branch" | grep -Eq '^[A-Za-z0-9_.\/-]+$'; then
+            echo "Invalid live default branch for $TARGET_REPO: $target_branch" >&2
+            exit 1
+          fi
+          echo "target_branch=$target_branch" >> "$GITHUB_OUTPUT"
           live_item_error="$(mktemp)"
           if ! live_item="$(gh api "repos/$TARGET_REPO/issues/$ITEM_NUMBER" 2>"$live_item_error")"; then
             if grep -Eqi 'HTTP 404|Not Found' "$live_item_error" && gh api "repos/$TARGET_REPO" >/dev/null; then
@@ -464,6 +477,8 @@ jobs:
           rm -f "$live_item_error"
           live_state="$(jq -r '.state' <<< "$live_item")"
           live_locked="$(jq -r '.locked == true' <<< "$live_item")"
+          item_kind="$(jq -r 'if .pull_request then "pull_request" else "issue" end' <<< "$live_item")"
+          echo "item_kind=$item_kind" >> "$GITHUB_OUTPUT"
           case "$live_state" in
             open)
               echo "terminal_noop=false" >> "$GITHUB_OUTPUT"
@@ -509,7 +524,7 @@ jobs:
 
       - uses: ./.github/actions/setup-pnpm
         id: setup-pnpm
-        if: ${{ steps.live-item.outputs.proceed == 'true' || ((steps.live-item.outputs.terminal_noop == 'true' || steps.live-item.outputs.terminal_missing == 'true' || steps.live-item.outputs.guarded_open == 'true') && (github.event.client_payload.review_options.command_status_marker != '' || github.event.client_payload.review_options.status_comment_id != '' || github.event.client_payload.command_status_marker != '' || github.event.client_payload.status_comment_id != '')) }}
+        if: ${{ steps.live-item.outputs.proceed == 'true' || ((steps.live-item.outputs.terminal_noop == 'true' || steps.live-item.outputs.terminal_missing == 'true' || steps.live-item.outputs.guarded_open == 'true') && steps.target.outputs.has_command_context == 'true') }}
         with:
           build-script: ${{ steps.live-item.outputs.proceed == 'true' && 'build:all' || 'build:repair' }}
 
@@ -558,7 +573,7 @@ jobs:
           url="https://github.com/${{ steps.target.outputs.target_repo }}.git"
           cache_dir="${{ steps.target.outputs.target_checkout_dir }}-cache.git"
           checkout_dir="${{ steps.target.outputs.target_checkout_dir }}"
-          target_branch="${{ steps.target.outputs.target_branch }}"
+          target_branch="${{ steps.live-item.outputs.target_branch }}"
           if [ -d "$cache_dir" ]; then
             git -C "$cache_dir" remote set-url origin "$url"
             git -C "$cache_dir" config remote.origin.promisor true
@@ -591,8 +606,8 @@ jobs:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
           ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
-          COMMAND_STATUS_MARKER: ${{ github.event.client_payload.review_options.command_status_marker || github.event.client_payload.command_status_marker || '' }}
-          STATUS_COMMENT_ID: ${{ github.event.client_payload.review_options.status_comment_id || github.event.client_payload.status_comment_id || '' }}
+          COMMAND_STATUS_MARKER: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).commandStatusMarker || '' }}
+          STATUS_COMMENT_ID: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).statusCommentId || '' }}
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           pnpm run repair:update-command-status -- \
@@ -620,7 +635,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
           CLAWSWEEPER_PROOF_INSPECTION_TOKEN: ${{ steps.target-read-token.outputs.token || github.token }}
-          ADDITIONAL_PROMPT: ${{ github.event.client_payload.review_options.additional_prompt || github.event.client_payload.additional_prompt || '' }}
+          ADDITIONAL_PROMPT: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).additionalPrompt || '' }}
           CLAWSWEEPER_RELATED_GITHUB_SEARCH: ${{ vars.CLAWSWEEPER_RELATED_GITHUB_SEARCH || '1' }}
         run: |
           set -euo pipefail
@@ -701,8 +716,8 @@ jobs:
           REPO_TOKEN: ${{ github.token }}
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
           ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
-          CLOSE_REASONS: ${{ github.event.client_payload.apply_close_reasons || 'implemented_on_main,duplicate_or_superseded,low_signal_unmergeable_pr' }}
-          MIN_AGE_MINUTES: ${{ github.event.client_payload.apply_min_age_minutes || '0' }}
+          CLOSE_REASONS: implemented_on_main,duplicate_or_superseded,low_signal_unmergeable_pr
+          MIN_AGE_MINUTES: "0"
         run: |
           set -euo pipefail
           live_item_error="$(mktemp)"
@@ -758,6 +773,7 @@ jobs:
             gh api "repos/$TARGET_REPO/issues/comments/$lease_id" --method DELETE
             echo "Released unsuccessful review lease comment $lease_id owned by $LEASE_OWNER."
           done <<< "$lease_ids"
+
       - name: Route synced ClawSweeper verdict
         id: route-synced-verdict
         if: ${{ steps.review-exact-event-item.outcome == 'success' && steps.publish-event-result.outcome == 'success' && steps.publish-event-result.outputs.terminal_noop != 'true' && steps.publish-event-result.outputs.terminal_missing != 'true' && steps.publish-event-result.outputs.terminal_closed != 'true' && steps.publish-event-result.outputs.guarded_open != 'true' && steps.publish-event-result.outputs.policy_noop != 'true' && steps.publish-event-result.outputs.requeue_latest != 'true' && steps.publish-event-result.outputs.remote_tuple_verified == 'true' && steps.publish-event-result.outputs.routing_deferred == 'false' }}
@@ -787,7 +803,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
-          TARGET_BRANCH: ${{ steps.target.outputs.target_branch }}
+          TARGET_BRANCH: ${{ steps.live-item.outputs.target_branch }}
           CLAWSWEEPER_COMMENT_LOOKBACK_MINUTES: ${{ vars.CLAWSWEEPER_COMMENT_LOOKBACK_MINUTES || '180' }}
           CLAWSWEEPER_COMMENT_MAX_COMMENTS: ${{ vars.CLAWSWEEPER_COMMENT_MAX_COMMENTS || '1000' }}
         run: |
@@ -857,8 +873,8 @@ jobs:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
           ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
-          COMMAND_STATUS_MARKER: ${{ github.event.client_payload.review_options.command_status_marker || github.event.client_payload.command_status_marker || '' }}
-          STATUS_COMMENT_ID: ${{ github.event.client_payload.review_options.status_comment_id || github.event.client_payload.status_comment_id || '' }}
+          COMMAND_STATUS_MARKER: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).commandStatusMarker || '' }}
+          STATUS_COMMENT_ID: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).statusCommentId || '' }}
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           REVIEW_OUTCOME: ${{ steps.review-exact-event-item.outcome }}
           PUBLISH_OUTCOME: ${{ steps.publish-event-result.outcome }}
@@ -1051,18 +1067,25 @@ jobs:
         continue-on-error: true
         env:
           JOB_STATUS: ${{ job.status }}
-          QUEUE_LEASE_ID: ${{ github.event.client_payload.queue_lease_id }}
+          CLAIM_GENERATION: ${{ steps.claim-exact-review-queue.outputs.claim_generation }}
+          ITEM_KEY: ${{ steps.claim-exact-review-queue.outputs.item_key }}
+          QUEUE_LEASE_ID: ${{ steps.claim-exact-review-queue.outputs.lease_id }}
+          QUEUE_LEASE_REVISION: ${{ steps.claim-exact-review-queue.outputs.lease_revision }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           RETRY_AT: ${{ steps.review-exact-event-item.outputs.retry_at }}
           REQUEUE_LATEST: ${{ steps.publish-event-result.outputs.requeue_latest }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
-          test -n "$QUEUE_LEASE_ID"
+          test -n "$QUEUE_LEASE_ID" && test -n "$ITEM_KEY"
           queue_url="${QUEUE_URL%/}"
           payload="$(node -e '
             const runAttempt = Number(process.env.RUN_ATTEMPT);
+            const leaseRevision = Number(process.env.QUEUE_LEASE_REVISION);
+            const claimGeneration = Number(process.env.CLAIM_GENERATION);
             if (!Number.isInteger(runAttempt) || runAttempt < 1) process.exit(1);
+            if (!Number.isInteger(leaseRevision) || leaseRevision < 1) process.exit(1);
+            if (!Number.isInteger(claimGeneration) || claimGeneration < 1) process.exit(1);
             const outcome = process.env.JOB_STATUS === "success"
               ? "success"
               : process.env.JOB_STATUS === "cancelled"
@@ -1072,6 +1095,9 @@ jobs:
             const requeueLatest = process.env.REQUEUE_LATEST === "true";
             process.stdout.write(JSON.stringify({
               lease_id: process.env.QUEUE_LEASE_ID,
+              item_key: process.env.ITEM_KEY,
+              lease_revision: leaseRevision,
+              claim_generation: claimGeneration,
               run_id: process.env.GITHUB_RUN_ID,
               run_attempt: runAttempt,
               outcome,
@@ -1100,8 +1126,8 @@ jobs:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
           ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
-          COMMAND_STATUS_MARKER: ${{ github.event.client_payload.review_options.command_status_marker || github.event.client_payload.command_status_marker || '' }}
-          STATUS_COMMENT_ID: ${{ github.event.client_payload.review_options.status_comment_id || github.event.client_payload.status_comment_id || '' }}
+          COMMAND_STATUS_MARKER: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).commandStatusMarker || '' }}
+          STATUS_COMMENT_ID: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).statusCommentId || '' }}
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           pnpm run repair:update-command-status -- \

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -305,6 +305,7 @@ jobs:
       - name: Claim exact-review queue lease
         id: claim-exact-review-queue
         env:
+          DISPATCH_PAYLOAD: ${{ toJSON(github.event.client_payload) }}
           ITEM_KEY: ${{ github.event.client_payload.item_key }}
           QUEUE_LEASE_ID: ${{ github.event.client_payload.queue_lease_id }}
           QUEUE_LEASE_REVISION: ${{ github.event.client_payload.lease_revision }}
@@ -312,17 +313,21 @@ jobs:
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
-          test -n "$QUEUE_LEASE_ID" && test -n "$ITEM_KEY"
+          test -n "$QUEUE_LEASE_ID"
           queue_url="${QUEUE_URL%/}"
           payload="$(node -e '
             const runAttempt = Number(process.env.RUN_ATTEMPT);
-            const leaseRevision = Number(process.env.QUEUE_LEASE_REVISION);
             if (!Number.isInteger(runAttempt) || runAttempt < 1) process.exit(1);
-            if (!Number.isInteger(leaseRevision) || leaseRevision < 1) process.exit(1);
+            const itemKey = String(process.env.ITEM_KEY || "").trim();
+            const rawLeaseRevision = String(process.env.QUEUE_LEASE_REVISION || "").trim();
+            const hasTuple = Boolean(itemKey || rawLeaseRevision);
+            const leaseRevision = Number(rawLeaseRevision);
+            if (hasTuple && (!itemKey || !Number.isInteger(leaseRevision) || leaseRevision < 1)) {
+              process.exit(1);
+            }
             process.stdout.write(JSON.stringify({
               lease_id: process.env.QUEUE_LEASE_ID,
-              item_key: process.env.ITEM_KEY,
-              lease_revision: leaseRevision,
+              ...(hasTuple ? { item_key: itemKey, lease_revision: leaseRevision } : {}),
               run_id: process.env.GITHUB_RUN_ID,
               run_attempt: runAttempt,
             }));
@@ -336,22 +341,61 @@ jobs:
               RESPONSE="$response" node <<'NODE'
                 const fs = require("node:fs");
                 const response = JSON.parse(process.env.RESPONSE || "{}");
-                const decision = response.decision;
-                const leaseRevision = Number(process.env.QUEUE_LEASE_REVISION);
-                const claimGeneration = Number(response.claim_generation);
-                const itemKey = String(process.env.ITEM_KEY || "");
+                const dispatch = JSON.parse(process.env.DISPATCH_PAYLOAD || "{}");
+                const requestedItemKey = String(process.env.ITEM_KEY || "").trim();
+                const requestedLeaseRevision = Number(process.env.QUEUE_LEASE_REVISION);
+                const responseProtocol = Number(response.protocol_version || 1);
+                if (responseProtocol !== 1 && responseProtocol !== 2) process.exit(1);
+                if (response.claimed !== true) process.exit(1);
+
+                const reviewOptions =
+                  dispatch.review_options && typeof dispatch.review_options === "object"
+                    ? dispatch.review_options
+                    : {};
+                const legacyDecision = {
+                  targetRepo: String(dispatch.target_repo || ""),
+                  targetBranch: String(dispatch.target_branch || "main"),
+                  itemNumber: Number(dispatch.item_number),
+                  itemKind: String(dispatch.item_kind || ""),
+                  sourceEvent: String(dispatch.source_event || ""),
+                  sourceAction: String(dispatch.source_action || "legacy_dispatch"),
+                  supersedesInProgress: dispatch.supersedes_in_progress === true,
+                  ...(Number.isFinite(Number(reviewOptions.codex_timeout_ms))
+                    ? { codexTimeoutMs: Number(reviewOptions.codex_timeout_ms) }
+                    : {}),
+                  ...(Number.isFinite(Number(reviewOptions.media_proof_timeout_ms))
+                    ? { mediaProofTimeoutMs: Number(reviewOptions.media_proof_timeout_ms) }
+                    : {}),
+                  ...(Object.hasOwn(reviewOptions, "command_status_marker")
+                    ? { commandStatusMarker: reviewOptions.command_status_marker }
+                    : {}),
+                  ...(Object.hasOwn(reviewOptions, "status_comment_id")
+                    ? { statusCommentId: reviewOptions.status_comment_id }
+                    : {}),
+                  ...(Object.hasOwn(reviewOptions, "additional_prompt")
+                    ? { additionalPrompt: reviewOptions.additional_prompt }
+                    : {}),
+                };
+                const decision =
+                  response.decision && typeof response.decision === "object"
+                    ? response.decision
+                    : legacyDecision;
                 const targetRepo = String(decision?.targetRepo || "");
                 const itemNumber = Number(decision?.itemNumber);
+                const itemKey = `${targetRepo}#${itemNumber}`;
+                const leaseRevision =
+                  responseProtocol === 2
+                    ? Number(response.lease_revision)
+                    : Number(
+                        response.revision ||
+                          response.lease_revision ||
+                          process.env.QUEUE_LEASE_REVISION,
+                      );
+                const claimGeneration = Number(response.claim_generation);
                 if (
-                  response.claimed !== true ||
-                  response.item_key !== itemKey ||
-                  response.lease_revision !== leaseRevision ||
-                  !Number.isInteger(claimGeneration) ||
-                  claimGeneration < 1 ||
                   !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(targetRepo) ||
                   !Number.isInteger(itemNumber) ||
                   itemNumber < 1 ||
-                  `${targetRepo}#${itemNumber}` !== itemKey ||
                   (decision.itemKind !== "issue" && decision.itemKind !== "pull_request") ||
                   (decision.sourceEvent !== "issues" && decision.sourceEvent !== "pull_request") ||
                   typeof decision.sourceAction !== "string" ||
@@ -359,11 +403,25 @@ jobs:
                 ) {
                   process.exit(1);
                 }
+                if (response.item_key && response.item_key !== itemKey) process.exit(1);
+                if (requestedItemKey && requestedItemKey !== itemKey) process.exit(1);
+                if (
+                  responseProtocol === 2 &&
+                  (!response.decision ||
+                    typeof response.decision !== "object" ||
+                    response.item_key !== requestedItemKey ||
+                    response.lease_revision !== requestedLeaseRevision ||
+                    !Number.isInteger(claimGeneration) ||
+                    claimGeneration < 1)
+                ) {
+                  process.exit(1);
+                }
                 const output = [
                   `lease_id=${process.env.QUEUE_LEASE_ID}`,
                   `item_key=${itemKey}`,
-                  `lease_revision=${leaseRevision}`,
-                  `claim_generation=${claimGeneration}`,
+                  `lease_revision=${Number.isInteger(leaseRevision) ? leaseRevision : ""}`,
+                  `claim_generation=${responseProtocol === 2 ? claimGeneration : ""}`,
+                  `protocol_version=${responseProtocol}`,
                   `decision=${JSON.stringify(decision)}`,
                 ];
                 fs.appendFileSync(process.env.GITHUB_OUTPUT, `${output.join("\n")}\n`);
@@ -1069,6 +1127,7 @@ jobs:
           JOB_STATUS: ${{ job.status }}
           CLAIM_GENERATION: ${{ steps.claim-exact-review-queue.outputs.claim_generation }}
           ITEM_KEY: ${{ steps.claim-exact-review-queue.outputs.item_key }}
+          PROTOCOL_VERSION: ${{ steps.claim-exact-review-queue.outputs.protocol_version }}
           QUEUE_LEASE_ID: ${{ steps.claim-exact-review-queue.outputs.lease_id }}
           QUEUE_LEASE_REVISION: ${{ steps.claim-exact-review-queue.outputs.lease_revision }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
@@ -1077,15 +1136,23 @@ jobs:
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
-          test -n "$QUEUE_LEASE_ID" && test -n "$ITEM_KEY"
+          test -n "$QUEUE_LEASE_ID"
           queue_url="${QUEUE_URL%/}"
           payload="$(node -e '
             const runAttempt = Number(process.env.RUN_ATTEMPT);
+            const protocolVersion = Number(process.env.PROTOCOL_VERSION);
             const leaseRevision = Number(process.env.QUEUE_LEASE_REVISION);
             const claimGeneration = Number(process.env.CLAIM_GENERATION);
             if (!Number.isInteger(runAttempt) || runAttempt < 1) process.exit(1);
-            if (!Number.isInteger(leaseRevision) || leaseRevision < 1) process.exit(1);
-            if (!Number.isInteger(claimGeneration) || claimGeneration < 1) process.exit(1);
+            if (protocolVersion !== 1 && protocolVersion !== 2) process.exit(1);
+            if (
+              protocolVersion === 2 &&
+              (!process.env.ITEM_KEY ||
+                !Number.isInteger(leaseRevision) ||
+                leaseRevision < 1 ||
+                !Number.isInteger(claimGeneration) ||
+                claimGeneration < 1)
+            ) process.exit(1);
             const outcome = process.env.JOB_STATUS === "success"
               ? "success"
               : process.env.JOB_STATUS === "cancelled"
@@ -1095,9 +1162,13 @@ jobs:
             const requeueLatest = process.env.REQUEUE_LATEST === "true";
             process.stdout.write(JSON.stringify({
               lease_id: process.env.QUEUE_LEASE_ID,
-              item_key: process.env.ITEM_KEY,
-              lease_revision: leaseRevision,
-              claim_generation: claimGeneration,
+              ...(protocolVersion === 2
+                ? {
+                    item_key: process.env.ITEM_KEY,
+                    lease_revision: leaseRevision,
+                    claim_generation: claimGeneration,
+                  }
+                : {}),
               run_id: process.env.GITHUB_RUN_ID,
               run_attempt: runAttempt,
               outcome,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ checkpoint, and status-only commits are intentionally omitted.
 - Bounded broad reconciliation with batched Git I/O and tuple checkpoints that report progress and resume safely under concurrent state writers.
 - Retried tuple-safe broad reconciliation after full push batches lose continuous exact-state races, including candidates that normalize to no changes.
 - Serialized explicit workflow-dispatch planners through a non-dropping target queue and accounted for recovery runs by their requested or live shards, preventing overlapping target planning and false 89-shard reservations without undercounting multi-shard retries.
+- Released workflow-owned review leases after unsuccessful exact reviews, deferred coordination-held retries until lease expiry, and skipped state checkout without fresh artifacts, preventing held-lease loops from wasting exact-review capacity.
 - Reconciled terminal exact-review runs by requested run instead of sampling the first 32 claimed leases, while preserving attempt and claim-generation guards across larger worker waves.
 - Dequeued already-closed exact-review events before setup and treated items closed during review as terminal no-ops, preventing permanent retry churn from consuming live worker capacity.
 - Kept broad reconciliation draining independent record repairs when one valid tuple has ambiguous legacy contents, while timestamping closed-record sidecar cleanup as an orderable atomic mutation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ checkpoint, and status-only commits are intentionally omitted.
 - Retried tuple-safe broad reconciliation after full push batches lose continuous exact-state races, including candidates that normalize to no changes.
 - Serialized explicit workflow-dispatch planners through a non-dropping target queue and accounted for recovery runs by their requested or live shards, preventing overlapping target planning and false 89-shard reservations without undercounting multi-shard retries.
 - Released workflow-owned review leases after unsuccessful exact reviews, deferred coordination-held retries until lease expiry, and skipped state checkout without fresh artifacts, preventing held-lease loops from wasting exact-review capacity.
+- Bound exact-review execution to immutable queue claims and preserved both Worker/workflow deployment orders through a versioned rolling-upgrade protocol, avoiding stalled leases without disabling ClawSweeper.
 - Reconciled terminal exact-review runs by requested run instead of sampling the first 32 claimed leases, while preserving attempt and claim-generation guards across larger worker waves.
 - Dequeued already-closed exact-review events before setup and treated items closed during review as terminal no-ops, preventing permanent retry churn from consuming live worker capacity.
 - Kept broad reconciliation draining independent record repairs when one valid tuple has ambiguous legacy contents, while timestamping closed-record sidecar cleanup as an orderable atomic mutation.

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -465,6 +465,13 @@ export class ExactReviewQueue {
       }
       const outcome = exactReviewCompletionOutcome(body.outcome, "success");
       if (!outcome) return json({ error: "invalid_outcome" }, 400);
+      const requeueLatest = body.requeue_latest === true;
+      if (body.requeue_latest !== undefined && typeof body.requeue_latest !== "boolean") {
+        return json({ error: "invalid_requeue_latest" }, 400);
+      }
+      if (requeueLatest && outcome !== "success") {
+        return json({ error: "invalid_requeue_latest_outcome" }, 400);
+      }
 
       const now = Date.now();
       const requestedRetryAt = exactReviewCompletionRetryAt(body.retry_at, now);
@@ -485,7 +492,11 @@ export class ExactReviewQueue {
       // Keep the claim until the signed workflow_run backstop verifies that exact attempt as
       // terminal, otherwise cancellation or a failing post-action could be acknowledged as
       // success. A newer revision is already known to need another review and can requeue now.
-      if (outcome === "success" && item.revision <= Number(item.leaseRevision || 0)) {
+      if (
+        outcome === "success" &&
+        !requeueLatest &&
+        item.revision <= Number(item.leaseRevision || 0)
+      ) {
         await this.scheduleNext(state, now);
         return json({ ok: true, requeued: false, deferred: true });
       }
@@ -496,6 +507,7 @@ export class ExactReviewQueue {
         now,
         outcome,
         requestedRetryAt ?? undefined,
+        requeueLatest,
       );
       await this.writeState(state);
       await this.scheduleNext(state, now);
@@ -1648,10 +1660,11 @@ function finishExactReviewQueueItem(
   now: number,
   outcome: ExactReviewCompletionOutcome,
   requestedRetryAt = 0,
+  requeueLatest = false,
 ) {
   const retryingFailure = outcome !== "success";
   const hasNewerRevision = item.revision > Number(item.leaseRevision || 0);
-  const requeued = retryingFailure || hasNewerRevision;
+  const requeued = retryingFailure || hasNewerRevision || requeueLatest;
   if (requeued) {
     clearExactReviewLease(item);
     item.state = "pending";

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -52,6 +52,7 @@ type ExactReviewQueueItem = {
   claimedRunId?: string;
   claimedRunAttempt?: number;
   claimGeneration?: number;
+  claimProtocolVersion?: 1 | 2;
 };
 type ExactReviewCompletionOutcome = "success" | "failure" | "cancelled";
 type ExactReviewClaimedRun = {
@@ -426,13 +427,13 @@ export class ExactReviewQueue {
       const itemKey = String(body.item_key || "").trim();
       const leaseRevision = Number(body.lease_revision);
       const runId = String(body.run_id || "").trim();
-      if (!leaseId || !itemKey || !runId) {
-        return json({ error: "missing_lease_item_or_run" }, 400);
-      }
+      if (!leaseId || !runId) return json({ error: "missing_lease_or_run" }, 400);
       if (!/^\d+$/.test(runId)) return json({ error: "invalid_run_id" }, 400);
-      if (!Number.isInteger(leaseRevision) || leaseRevision < 1) {
+      const tupleClaim = Boolean(itemKey) || body.lease_revision !== undefined;
+      if (tupleClaim && (!itemKey || !Number.isInteger(leaseRevision) || leaseRevision < 1)) {
         return json({ error: "invalid_lease_revision" }, 400);
       }
+      const claimProtocolVersion: 1 | 2 = tupleClaim ? 2 : 1;
       const runAttempt = exactReviewRunAttempt(body.run_attempt);
       if (body.run_attempt !== undefined && runAttempt === null) {
         return json({ error: "invalid_run_attempt" }, 400);
@@ -440,11 +441,11 @@ export class ExactReviewQueue {
 
       const now = Date.now();
       const state = await this.readState();
-      const item = state.items[itemKey];
+      const item = tupleClaim ? state.items[itemKey] : exactReviewItemForLease(state, leaseId);
       if (
         !item ||
         item.leaseId !== leaseId ||
-        item.leaseRevision !== leaseRevision ||
+        (tupleClaim && item.leaseRevision !== leaseRevision) ||
         !isLiveExactReviewLease(item, now)
       ) {
         return json({ error: "lease_not_active" }, 409);
@@ -469,51 +470,51 @@ export class ExactReviewQueue {
           return json({ error: "stale_run_attempt" }, 409);
         }
         if (runAttempt === claimedRunAttempt) {
+          if (
+            item.claimProtocolVersion !== undefined &&
+            item.claimProtocolVersion !== claimProtocolVersion
+          ) {
+            return json({ error: "claim_protocol_mismatch" }, 409);
+          }
           const claimGeneration = Math.max(1, exactReviewClaimGeneration(item.claimGeneration));
-          if (item.claimGeneration !== claimGeneration) {
+          if (
+            item.claimGeneration !== claimGeneration ||
+            item.claimProtocolVersion !== claimProtocolVersion
+          ) {
             item.claimGeneration = claimGeneration;
+            item.claimProtocolVersion = claimProtocolVersion;
             await this.writeState(state);
           }
-          return json({
-            ok: true,
-            claimed: true,
-            item_key: item.key,
-            lease_revision: item.leaseRevision,
-            claim_generation: claimGeneration,
-            decision: item.leaseDecision,
-          });
+          return json(exactReviewClaimResponse(item, claimProtocolVersion, claimGeneration));
         }
       } else if (item.claimedRunId && runAttempt === null) {
+        if (
+          item.claimProtocolVersion !== undefined &&
+          item.claimProtocolVersion !== claimProtocolVersion
+        ) {
+          return json({ error: "claim_protocol_mismatch" }, 409);
+        }
         const claimGeneration = Math.max(1, exactReviewClaimGeneration(item.claimGeneration));
-        if (item.claimGeneration !== claimGeneration) {
+        if (
+          item.claimGeneration !== claimGeneration ||
+          item.claimProtocolVersion !== claimProtocolVersion
+        ) {
           item.claimGeneration = claimGeneration;
+          item.claimProtocolVersion = claimProtocolVersion;
           await this.writeState(state);
         }
-        return json({
-          ok: true,
-          claimed: true,
-          item_key: item.key,
-          lease_revision: item.leaseRevision,
-          claim_generation: claimGeneration,
-          decision: item.leaseDecision,
-        });
+        return json(exactReviewClaimResponse(item, claimProtocolVersion, claimGeneration));
       }
 
       item.state = "leased";
       item.claimedRunId = runId;
       item.claimedRunAttempt = runAttempt ?? undefined;
       item.claimGeneration = exactReviewClaimGeneration(item.claimGeneration) + 1;
+      item.claimProtocolVersion = claimProtocolVersion;
       item.leaseExpiresAt = now + exactReviewExecutionLeaseMs(this.env);
       await this.writeState(state);
       await this.scheduleNext(state, now);
-      return json({
-        ok: true,
-        claimed: true,
-        item_key: item.key,
-        lease_revision: item.leaseRevision,
-        claim_generation: item.claimGeneration,
-        decision: item.leaseDecision,
-      });
+      return json(exactReviewClaimResponse(item, claimProtocolVersion, item.claimGeneration));
     }
 
     if (request.method === "POST" && url.pathname === "/complete") {
@@ -523,16 +524,21 @@ export class ExactReviewQueue {
       const leaseRevision = Number(body.lease_revision);
       const claimGeneration = Number(body.claim_generation);
       const runId = String(body.run_id || "").trim();
-      if (!leaseId || !itemKey || !runId) {
-        return json({ error: "missing_lease_item_or_run" }, 400);
-      }
+      if (!leaseId || !runId) return json({ error: "missing_lease_or_run" }, 400);
       if (!/^\d+$/.test(runId)) return json({ error: "invalid_run_id" }, 400);
-      if (!Number.isInteger(leaseRevision) || leaseRevision < 1) {
-        return json({ error: "invalid_lease_revision" }, 400);
+      const tupleCompletion =
+        Boolean(itemKey) ||
+        body.lease_revision !== undefined ||
+        body.claim_generation !== undefined;
+      if (tupleCompletion) {
+        if (!itemKey || !Number.isInteger(leaseRevision) || leaseRevision < 1) {
+          return json({ error: "invalid_lease_revision" }, 400);
+        }
+        if (!Number.isInteger(claimGeneration) || claimGeneration < 1) {
+          return json({ error: "invalid_claim_generation" }, 400);
+        }
       }
-      if (!Number.isInteger(claimGeneration) || claimGeneration < 1) {
-        return json({ error: "invalid_claim_generation" }, 400);
-      }
+      const completionProtocolVersion: 1 | 2 = tupleCompletion ? 2 : 1;
       const runAttempt = exactReviewRunAttempt(body.run_attempt);
       if (body.run_attempt !== undefined && runAttempt === null) {
         return json({ error: "invalid_run_attempt" }, 400);
@@ -553,15 +559,18 @@ export class ExactReviewQueue {
         return json({ error: "invalid_retry_at" }, 400);
       }
       const state = await this.readState();
-      const item = state.items[itemKey];
+      const item = tupleCompletion ? state.items[itemKey] : exactReviewItemForLease(state, leaseId);
       if (
         !item ||
         item.leaseId !== leaseId ||
-        item.leaseRevision !== leaseRevision ||
-        exactReviewClaimGeneration(item.claimGeneration) !== claimGeneration ||
+        (tupleCompletion && item.leaseRevision !== leaseRevision) ||
+        (tupleCompletion && exactReviewClaimGeneration(item.claimGeneration) !== claimGeneration) ||
         item.claimedRunId !== runId
       ) {
         return json({ error: "lease_not_claimed" }, 409);
+      }
+      if ((item.claimProtocolVersion ?? 1) !== completionProtocolVersion) {
+        return json({ error: "lease_protocol_not_claimed" }, 409);
       }
       if (
         item.claimedRunAttempt !== undefined &&
@@ -772,6 +781,7 @@ export class ExactReviewQueue {
       try {
         await dispatchClawsweeperItem({
           token: preflight.token,
+          decision: item.leaseDecision || item.decision,
           itemKey: item.key,
           leaseId: item.leaseId,
           leaseRevision: item.leaseRevision,
@@ -1626,6 +1636,27 @@ function isExactReviewQueueTargetEnabled(decision: ExactReviewDecision, env) {
   );
 }
 
+function exactReviewItemForLease(state: ExactReviewQueueState, leaseId: string) {
+  return Object.values(state.items).find((item) => item.leaseId === leaseId) || null;
+}
+
+function exactReviewClaimResponse(
+  item: ExactReviewQueueItem,
+  protocolVersion: 1 | 2,
+  claimGeneration: number,
+) {
+  return {
+    ok: true,
+    claimed: true,
+    protocol_version: protocolVersion,
+    item_key: item.key,
+    ...(protocolVersion === 1 ? { revision: item.leaseRevision } : {}),
+    lease_revision: item.leaseRevision,
+    claim_generation: claimGeneration,
+    decision: item.leaseDecision,
+  };
+}
+
 function exactReviewCompletionOutcome(
   value,
   fallback?: ExactReviewCompletionOutcome,
@@ -1784,6 +1815,7 @@ function clearExactReviewLease(item: ExactReviewQueueItem) {
   item.claimedRunId = undefined;
   item.claimedRunAttempt = undefined;
   item.claimGeneration = undefined;
+  item.claimProtocolVersion = undefined;
 }
 
 function isLiveExactReviewLease(item: ExactReviewQueueItem, now: number) {
@@ -2344,15 +2376,31 @@ async function addIssueCommentReaction({ token, repo, commentId, content }) {
 
 async function dispatchClawsweeperItem({
   token,
+  decision,
   itemKey,
   leaseId,
   leaseRevision,
 }: {
   token: string;
+  decision: ExactReviewDecision;
   itemKey: string;
   leaseId: string;
   leaseRevision: number;
 }) {
+  // Keep the v1 fields during the rolling-upgrade window. Old workflows consume
+  // this immutable dispatch snapshot, while v2 workflows ignore it after claim
+  // and consume the Worker's leaseDecision response instead.
+  const reviewOptions = {
+    ...(decision.codexTimeoutMs ? { codex_timeout_ms: decision.codexTimeoutMs } : {}),
+    ...(decision.mediaProofTimeoutMs
+      ? { media_proof_timeout_ms: decision.mediaProofTimeoutMs }
+      : {}),
+    ...(decision.commandStatusMarker
+      ? { command_status_marker: decision.commandStatusMarker }
+      : {}),
+    ...(decision.statusCommentId ? { status_comment_id: decision.statusCommentId } : {}),
+    ...(decision.additionalPrompt ? { additional_prompt: decision.additionalPrompt } : {}),
+  };
   await githubTokenJson({
     token,
     path: `/repos/${CLAWSWEEPER_REVIEW_REPO}/dispatches`,
@@ -2360,9 +2408,18 @@ async function dispatchClawsweeperItem({
     body: {
       event_type: "clawsweeper_item",
       client_payload: {
+        queue_protocol_version: 2,
         queue_lease_id: leaseId,
         item_key: itemKey,
         lease_revision: leaseRevision,
+        target_repo: decision.targetRepo,
+        target_branch: decision.targetBranch,
+        item_number: decision.itemNumber,
+        item_kind: decision.itemKind,
+        source_event: decision.sourceEvent,
+        source_action: decision.sourceAction,
+        supersedes_in_progress: decision.supersedesInProgress,
+        ...(Object.keys(reviewOptions).length > 0 ? { review_options: reviewOptions } : {}),
       },
     },
     errorLabel: "ClawSweeper item dispatch",

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -2408,10 +2408,12 @@ async function dispatchClawsweeperItem({
     body: {
       event_type: "clawsweeper_item",
       client_payload: {
-        queue_protocol_version: 2,
         queue_lease_id: leaseId,
-        item_key: itemKey,
-        lease_revision: leaseRevision,
+        queue_claim: {
+          protocol_version: 2,
+          item_key: itemKey,
+          lease_revision: leaseRevision,
+        },
         target_repo: decision.targetRepo,
         target_branch: decision.targetBranch,
         item_number: decision.itemNumber,

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -97,6 +97,7 @@ const DEFAULT_EXACT_REVIEW_DISPATCH_LEASE_MS = 10 * 60 * 1000;
 const DEFAULT_EXACT_REVIEW_EXECUTION_LEASE_MS = 130 * 60 * 1000;
 const DEFAULT_EXACT_REVIEW_RETRY_MS = 30_000;
 const DEFAULT_EXACT_REVIEW_WORKFLOW_PAUSED_RETRY_MS = 60_000;
+const EXACT_REVIEW_COMPLETION_RETRY_MAX_MS = 2 * 60 * 60 * 1000;
 const EXACT_REVIEW_RECONCILE_RUN_LIMIT = 32;
 const EXACT_REVIEW_RECONCILE_CLAIM_MATCH_LIMIT = EXACT_REVIEW_RECONCILE_RUN_LIMIT * 2;
 const EXACT_REVIEW_RECONCILE_CONCURRENCY = 4;
@@ -466,6 +467,10 @@ export class ExactReviewQueue {
       if (!outcome) return json({ error: "invalid_outcome" }, 400);
 
       const now = Date.now();
+      const requestedRetryAt = exactReviewCompletionRetryAt(body.retry_at, now);
+      if (body.retry_at !== undefined && requestedRetryAt === null) {
+        return json({ error: "invalid_retry_at" }, 400);
+      }
       const state = await this.readState();
       const item = exactReviewItemForLease(state, leaseId);
       if (!item || item.claimedRunId !== runId) return json({ error: "lease_not_claimed" }, 409);
@@ -485,7 +490,13 @@ export class ExactReviewQueue {
         return json({ ok: true, requeued: false, deferred: true });
       }
 
-      const requeued = finishExactReviewQueueItem(state, item, now, outcome);
+      const requeued = finishExactReviewQueueItem(
+        state,
+        item,
+        now,
+        outcome,
+        requestedRetryAt ?? undefined,
+      );
       await this.writeState(state);
       await this.scheduleNext(state, now);
       return json({ ok: true, requeued });
@@ -1636,9 +1647,11 @@ function finishExactReviewQueueItem(
   item: ExactReviewQueueItem,
   now: number,
   outcome: ExactReviewCompletionOutcome,
+  requestedRetryAt = 0,
 ) {
   const retryingFailure = outcome !== "success";
-  const requeued = retryingFailure || item.revision > Number(item.leaseRevision || 0);
+  const hasNewerRevision = item.revision > Number(item.leaseRevision || 0);
+  const requeued = retryingFailure || hasNewerRevision;
   if (requeued) {
     clearExactReviewLease(item);
     item.state = "pending";
@@ -1647,6 +1660,7 @@ function finishExactReviewQueueItem(
       item.nextAttemptAt = Math.max(
         exactReviewQueueEnqueueAttemptAt(state, now),
         now + exactReviewRetryDelayMs(item.attempts),
+        hasNewerRevision ? 0 : requestedRetryAt,
       );
     } else {
       item.nextAttemptAt = exactReviewQueueEnqueueAttemptAt(state, now);
@@ -1657,6 +1671,14 @@ function finishExactReviewQueueItem(
     delete state.items[item.key];
   }
   return requeued;
+}
+
+function exactReviewCompletionRetryAt(value, now: number): number | null {
+  if (value === undefined || value === null || value === "") return null;
+  const retryAt = Date.parse(String(value));
+  if (!Number.isFinite(retryAt)) return null;
+  if (retryAt > now + EXACT_REVIEW_COMPLETION_RETRY_MAX_MS) return null;
+  return Math.max(now, retryAt);
 }
 
 function clearExactReviewLease(item: ExactReviewQueueItem) {

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -39,6 +39,7 @@ type ExactReviewDecision = {
 type ExactReviewQueueItem = {
   key: string;
   decision: ExactReviewDecision;
+  leaseDecision?: ExactReviewDecision;
   state: "pending" | "dispatching" | "leased";
   revision: number;
   createdAt: number;
@@ -422,8 +423,16 @@ export class ExactReviewQueue {
     if (request.method === "POST" && url.pathname === "/claim") {
       const body = objectValue(await request.json().catch(() => null));
       const leaseId = String(body.lease_id || "").trim();
+      const itemKey = String(body.item_key || "").trim();
+      const leaseRevision = Number(body.lease_revision);
       const runId = String(body.run_id || "").trim();
-      if (!leaseId || !runId) return json({ error: "missing_lease_or_run" }, 400);
+      if (!leaseId || !itemKey || !runId) {
+        return json({ error: "missing_lease_item_or_run" }, 400);
+      }
+      if (!/^\d+$/.test(runId)) return json({ error: "invalid_run_id" }, 400);
+      if (!Number.isInteger(leaseRevision) || leaseRevision < 1) {
+        return json({ error: "invalid_lease_revision" }, 400);
+      }
       const runAttempt = exactReviewRunAttempt(body.run_attempt);
       if (body.run_attempt !== undefined && runAttempt === null) {
         return json({ error: "invalid_run_attempt" }, 400);
@@ -431,12 +440,63 @@ export class ExactReviewQueue {
 
       const now = Date.now();
       const state = await this.readState();
-      const item = exactReviewItemForLease(state, leaseId);
-      if (!item || !isLiveExactReviewLease(item, now)) {
+      const item = state.items[itemKey];
+      if (
+        !item ||
+        item.leaseId !== leaseId ||
+        item.leaseRevision !== leaseRevision ||
+        !isLiveExactReviewLease(item, now)
+      ) {
         return json({ error: "lease_not_active" }, 409);
       }
       if (item.claimedRunId && item.claimedRunId !== runId) {
         return json({ error: "lease_already_claimed" }, 409);
+      }
+
+      // Deploys can observe a pre-snapshot lease. Recover it only when no newer
+      // enqueue has replaced the decision that was dispatched for this revision.
+      if (!item.leaseDecision) {
+        if (item.revision !== item.leaseRevision) {
+          return json({ error: "lease_decision_unavailable" }, 409);
+        }
+        item.leaseDecision = { ...item.decision };
+      }
+
+      const claimedRunAttempt = item.claimedRunAttempt;
+      if (item.claimedRunId && claimedRunAttempt !== undefined) {
+        if (runAttempt === null) return json({ error: "missing_run_attempt" }, 409);
+        if (runAttempt < claimedRunAttempt) {
+          return json({ error: "stale_run_attempt" }, 409);
+        }
+        if (runAttempt === claimedRunAttempt) {
+          const claimGeneration = Math.max(1, exactReviewClaimGeneration(item.claimGeneration));
+          if (item.claimGeneration !== claimGeneration) {
+            item.claimGeneration = claimGeneration;
+            await this.writeState(state);
+          }
+          return json({
+            ok: true,
+            claimed: true,
+            item_key: item.key,
+            lease_revision: item.leaseRevision,
+            claim_generation: claimGeneration,
+            decision: item.leaseDecision,
+          });
+        }
+      } else if (item.claimedRunId && runAttempt === null) {
+        const claimGeneration = Math.max(1, exactReviewClaimGeneration(item.claimGeneration));
+        if (item.claimGeneration !== claimGeneration) {
+          item.claimGeneration = claimGeneration;
+          await this.writeState(state);
+        }
+        return json({
+          ok: true,
+          claimed: true,
+          item_key: item.key,
+          lease_revision: item.leaseRevision,
+          claim_generation: claimGeneration,
+          decision: item.leaseDecision,
+        });
       }
 
       item.state = "leased";
@@ -450,15 +510,29 @@ export class ExactReviewQueue {
         ok: true,
         claimed: true,
         item_key: item.key,
-        revision: item.leaseRevision,
+        lease_revision: item.leaseRevision,
+        claim_generation: item.claimGeneration,
+        decision: item.leaseDecision,
       });
     }
 
     if (request.method === "POST" && url.pathname === "/complete") {
       const body = objectValue(await request.json().catch(() => null));
       const leaseId = String(body.lease_id || "").trim();
+      const itemKey = String(body.item_key || "").trim();
+      const leaseRevision = Number(body.lease_revision);
+      const claimGeneration = Number(body.claim_generation);
       const runId = String(body.run_id || "").trim();
-      if (!leaseId || !runId) return json({ error: "missing_lease_or_run" }, 400);
+      if (!leaseId || !itemKey || !runId) {
+        return json({ error: "missing_lease_item_or_run" }, 400);
+      }
+      if (!/^\d+$/.test(runId)) return json({ error: "invalid_run_id" }, 400);
+      if (!Number.isInteger(leaseRevision) || leaseRevision < 1) {
+        return json({ error: "invalid_lease_revision" }, 400);
+      }
+      if (!Number.isInteger(claimGeneration) || claimGeneration < 1) {
+        return json({ error: "invalid_claim_generation" }, 400);
+      }
       const runAttempt = exactReviewRunAttempt(body.run_attempt);
       if (body.run_attempt !== undefined && runAttempt === null) {
         return json({ error: "invalid_run_attempt" }, 400);
@@ -479,8 +553,16 @@ export class ExactReviewQueue {
         return json({ error: "invalid_retry_at" }, 400);
       }
       const state = await this.readState();
-      const item = exactReviewItemForLease(state, leaseId);
-      if (!item || item.claimedRunId !== runId) return json({ error: "lease_not_claimed" }, 409);
+      const item = state.items[itemKey];
+      if (
+        !item ||
+        item.leaseId !== leaseId ||
+        item.leaseRevision !== leaseRevision ||
+        exactReviewClaimGeneration(item.claimGeneration) !== claimGeneration ||
+        item.claimedRunId !== runId
+      ) {
+        return json({ error: "lease_not_claimed" }, 409);
+      }
       if (
         item.claimedRunAttempt !== undefined &&
         (runAttempt === null || runAttempt !== item.claimedRunAttempt)
@@ -673,8 +755,11 @@ export class ExactReviewQueue {
       item.state = "dispatching";
       item.leaseId = crypto.randomUUID();
       item.leaseRevision = item.revision;
+      item.leaseDecision = { ...item.decision };
       item.leaseExpiresAt = now + exactReviewDispatchLeaseMs(this.env);
       item.claimedRunId = undefined;
+      item.claimedRunAttempt = undefined;
+      item.claimGeneration = undefined;
     }
     await this.writeState(state);
     if (!admitted.length) {
@@ -687,8 +772,9 @@ export class ExactReviewQueue {
       try {
         await dispatchClawsweeperItem({
           token: preflight.token,
-          decision: item.decision,
+          itemKey: item.key,
           leaseId: item.leaseId,
+          leaseRevision: item.leaseRevision,
         });
       } catch {
         failures.push({ key: item.key, leaseId: String(item.leaseId || "") });
@@ -1540,10 +1626,6 @@ function isExactReviewQueueTargetEnabled(decision: ExactReviewDecision, env) {
   );
 }
 
-function exactReviewItemForLease(state: ExactReviewQueueState, leaseId: string) {
-  return Object.values(state.items).find((item) => item.leaseId === leaseId) || null;
-}
-
 function exactReviewCompletionOutcome(
   value,
   fallback?: ExactReviewCompletionOutcome,
@@ -1697,6 +1779,7 @@ function exactReviewCompletionRetryAt(value, now: number): number | null {
 function clearExactReviewLease(item: ExactReviewQueueItem) {
   item.leaseId = undefined;
   item.leaseRevision = undefined;
+  item.leaseDecision = undefined;
   item.leaseExpiresAt = undefined;
   item.claimedRunId = undefined;
   item.claimedRunAttempt = undefined;
@@ -2261,24 +2344,15 @@ async function addIssueCommentReaction({ token, repo, commentId, content }) {
 
 async function dispatchClawsweeperItem({
   token,
-  decision,
+  itemKey,
   leaseId,
+  leaseRevision,
 }: {
   token: string;
-  decision: ExactReviewDecision;
-  leaseId?: string;
+  itemKey: string;
+  leaseId: string;
+  leaseRevision: number;
 }) {
-  const reviewOptions = {
-    ...(decision.codexTimeoutMs ? { codex_timeout_ms: decision.codexTimeoutMs } : {}),
-    ...(decision.mediaProofTimeoutMs
-      ? { media_proof_timeout_ms: decision.mediaProofTimeoutMs }
-      : {}),
-    ...(decision.commandStatusMarker
-      ? { command_status_marker: decision.commandStatusMarker }
-      : {}),
-    ...(decision.statusCommentId ? { status_comment_id: decision.statusCommentId } : {}),
-    ...(decision.additionalPrompt ? { additional_prompt: decision.additionalPrompt } : {}),
-  };
   await githubTokenJson({
     token,
     path: `/repos/${CLAWSWEEPER_REVIEW_REPO}/dispatches`,
@@ -2286,15 +2360,9 @@ async function dispatchClawsweeperItem({
     body: {
       event_type: "clawsweeper_item",
       client_payload: {
-        target_repo: decision.targetRepo,
-        target_branch: decision.targetBranch,
-        item_number: decision.itemNumber,
-        item_kind: decision.itemKind,
-        source_event: decision.sourceEvent,
-        source_action: decision.sourceAction,
-        supersedes_in_progress: decision.supersedesInProgress,
-        ...(leaseId ? { queue_lease_id: leaseId } : {}),
-        ...(Object.keys(reviewOptions).length > 0 ? { review_options: reviewOptions } : {}),
+        queue_lease_id: leaseId,
+        item_key: itemKey,
+        lease_revision: leaseRevision,
       },
     },
     errorLabel: "ClawSweeper item dispatch",

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -122,7 +122,11 @@ how many of those slots one target repository may consume; production sets it
 to 24 so other target repositories retain four global slots during an OpenClaw
 backlog drain.
 
-Each dispatched workflow claims its opaque lease before checkout. Duplicate
+Each dispatched workflow claims its opaque lease before checkout. Protocol v2
+binds claim and completion to the item key, lease revision, run attempt, claim
+generation, and an immutable decision snapshot. During the rolling-upgrade
+window, dispatches also carry the immutable v1 snapshot and the Worker accepts
+lease-id-only finalization only for claims recorded as protocol v1. Duplicate
 dispatches and stale workflows cannot claim the same lease, and a completion
 immediately schedules a known newer revision. Failed and cancelled executors
 requeue their item with bounded retry backoff. Successful finalizer reports stay

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -125,7 +125,7 @@ backlog drain.
 Each dispatched workflow claims its opaque lease before checkout. Protocol v2
 binds claim and completion to the item key, lease revision, run attempt, claim
 generation, and an immutable decision snapshot. During the rolling-upgrade
-window, dispatches also carry the immutable v1 snapshot and the Worker accepts
+window, dispatches nest the strict tuple under `queue_claim`, also carry the immutable v1 snapshot, and the Worker accepts
 lease-id-only finalization only for claims recorded as protocol v1. Duplicate
 dispatches and stale workflows cannot claim the same lease, and a completion
 immediately schedules a known newer revision. Failed and cancelled executors

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -48,7 +48,7 @@ the dashboard response.
 
 When a change updates both the Worker and a GitHub Actions workflow, keep the
 cross-component protocol compatible in both deployment orders. The exact-review
-v2 rollout dispatches the immutable lease tuple plus a bounded v1 snapshot; the
+v2 rollout dispatches the immutable lease tuple under `queue_claim` plus a bounded v1 snapshot; the
 Worker accepts v1 claims/finalizers while the workflow can consume either v1 or
 v2 claim responses. Deploying the reviewed Worker first remains the preferred
 order, but this rollout does not require disabling or draining ClawSweeper:
@@ -206,7 +206,7 @@ exact bytes with `CLAWSWEEPER_WEBHOOK_SECRET` in
 `x-clawsweeper-exact-review-signature: sha256=<hmac>`.
 
 Do not disable or drain the sweep workflow for this protocol rollout. A v2
-Worker sends both the strict tuple and the immutable v1 event snapshot, accepts
+Worker sends the strict tuple under `queue_claim` plus the immutable v1 event snapshot, accepts
 legacy lease-id claims/finalizers only for claims recorded as protocol v1, and
 keeps tuple/generation CAS mandatory for protocol v2. A v2 workflow falls back
 to the v1 event snapshot only when the claim response identifies or implies a

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -46,10 +46,12 @@ GitHub secret into a temporary Wrangler config as the Worker `INGEST_TOKEN`.
 Its smoke test also verifies the durable exact-review queue binding, not only
 the dashboard response.
 
-When a change updates both the Worker and a GitHub Actions workflow that calls
-a new Worker route, deploy the reviewed Worker branch first and wait for the
-dashboard workflow to pass. Then merge the workflow change. This avoids a
-window where Actions sends events to a route that production has not deployed:
+When a change updates both the Worker and a GitHub Actions workflow, keep the
+cross-component protocol compatible in both deployment orders. The exact-review
+v2 rollout dispatches the immutable lease tuple plus a bounded v1 snapshot; the
+Worker accepts v1 claims/finalizers while the workflow can consume either v1 or
+v2 claim responses. Deploying the reviewed Worker first remains the preferred
+order, but this rollout does not require disabling or draining ClawSweeper:
 
 ```bash
 gh workflow run dashboard.yml --repo openclaw/clawsweeper --ref <reviewed-branch>
@@ -203,10 +205,12 @@ is `{ "runs": [{ "run_id": "<run-id>", "run_attempt": 1 }] }`, signed over the
 exact bytes with `CLAWSWEEPER_WEBHOOK_SECRET` in
 `x-clawsweeper-exact-review-signature: sha256=<hmac>`.
 
-Keep the sweep workflow disabled and wait for `/api/exact-review-queue` to show
-both `dispatching: 0` and `leased: 0` before deploying this Worker revision.
-Deploy the Worker route from the reviewed revision before merging or enabling
-any workflow that calls the reconciliation endpoint. The dashboard deployment
-smoke test must observe HTTP 401 from an unsigned reconciliation request; HTTP
-404 means the old Worker is still serving. This order keeps legacy finalizers
-from creating provisional successes before the terminal-run backstop exists.
+Do not disable or drain the sweep workflow for this protocol rollout. A v2
+Worker sends both the strict tuple and the immutable v1 event snapshot, accepts
+legacy lease-id claims/finalizers only for claims recorded as protocol v1, and
+keeps tuple/generation CAS mandatory for protocol v2. A v2 workflow falls back
+to the v1 event snapshot only when the claim response identifies or implies a
+v1 Worker. Keep this mixed-version coverage until every in-flight v1 dispatch
+has drained naturally. The dashboard deployment smoke test must still observe
+HTTP 401 from an unsigned reconciliation request; HTTP 404 means the old Worker
+is serving that route.

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -926,6 +926,8 @@ interface ApplyResult {
   terminalMissingVerified?: boolean;
   terminalStateVerified?: boolean;
   guardedOpenStateVerified?: boolean;
+  terminalPolicyNoopVerified?: boolean;
+  sourceDriftVerified?: boolean;
 }
 
 interface FailedReviewRetryResult {
@@ -2554,6 +2556,28 @@ function itemSnapshotHash(item: Item, context: ItemContext): string {
     labels: item.labels,
   };
   return sha256(stableJson({ item: snapshotItem, context }));
+}
+
+function isApplyAutomationOnlyUpdate(options: {
+  itemUpdatedAt: string;
+  reviewCommentUpdatedAt?: string | null | undefined;
+  ownedReviewLeaseUpdatedAts?: readonly string[];
+  labelSyncOnlyUpdate?: boolean;
+}): boolean {
+  return (
+    options.itemUpdatedAt === options.reviewCommentUpdatedAt ||
+    (options.ownedReviewLeaseUpdatedAts ?? []).includes(options.itemUpdatedAt) ||
+    options.labelSyncOnlyUpdate === true
+  );
+}
+
+export function isApplyAutomationOnlyUpdateForTest(options: {
+  itemUpdatedAt: string;
+  reviewCommentUpdatedAt?: string | null | undefined;
+  ownedReviewLeaseUpdatedAts?: readonly string[];
+  labelSyncOnlyUpdate?: boolean;
+}): boolean {
+  return isApplyAutomationOnlyUpdate(options);
 }
 
 function itemSourceRevisionSha256(issue: unknown, comments: unknown[] = []): string {
@@ -20304,6 +20328,16 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
       markdown = replaceFrontMatterValue(markdown, "apply_checked_at", new Date().toISOString());
       if (!dryRun) writeReportMarkdown(path, markdown, subjectState);
     };
+    const eventApplyDispositionProof = (actionTaken: ActionTaken): Partial<ApplyResult> => {
+      if (!emitEventApplyProof) return {};
+      if (actionTaken === "skipped_same_author_pair") {
+        return { terminalPolicyNoopVerified: true };
+      }
+      if (actionTaken === "skipped_changed_since_review") {
+        return { sourceDriftVerified: true };
+      }
+      return {};
+    };
     const recordApplySkipped = (
       actionTaken: ActionTaken,
       reason: string,
@@ -20318,6 +20352,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
           emitEventApplyProof,
           liveGuardVerified,
         }),
+        ...eventApplyDispositionProof(actionTaken),
       });
       processedCount += 1;
       maybeLogProgress(`skipped #${number}: ${reason}`);
@@ -21269,6 +21304,12 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
             reviewStartLeaseOwner(leaseComment) === reportReviewLeaseOwner,
         )
       : [];
+    const reportOwnedLeaseUpdatedAts = reportOwnedLeaseComments
+      .map(commentUpdatedAt)
+      .filter((updatedAt): updatedAt is string => timestampMs(updatedAt) !== null);
+    for (const updatedAt of reportOwnedLeaseUpdatedAts) {
+      allowedSelfMutationUpdatedAts.add(updatedAt);
+    }
     const latestLabelFreshnessAutomationUpdatedAt = [
       existingReviewComment,
       ...reportOwnedLeaseComments,
@@ -21556,6 +21597,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
         number,
         action: "skipped_changed_since_review",
         reason: options.reason,
+        ...eventApplyDispositionProof("skipped_changed_since_review"),
       });
       processedCount += 1;
       maybeLogProgress(`skipped #${number}: ${options.reason}`);
@@ -21717,6 +21759,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
         number,
         action: "skipped_changed_since_review",
         reason: "updated_at changed",
+        ...eventApplyDispositionProof("skipped_changed_since_review"),
       });
       processedCount += 1;
       maybeLogProgress(`skipped #${number}: changed since review`);
@@ -21738,6 +21781,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
           number,
           action: "skipped_changed_since_review",
           reason: "snapshot changed",
+          ...eventApplyDispositionProof("skipped_changed_since_review"),
         });
         processedCount += 1;
         maybeLogProgress(`skipped #${number}: snapshot changed`);

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -186,6 +186,7 @@ type FailedReviewRetryAction =
   | "skipped_retry_already_exhausted"
   | "skipped_not_failed_review"
   | "skipped_not_open"
+  | "skipped_locked_conversation"
   | "skipped_not_pull_request"
   | "skipped_missing_report_head"
   | "skipped_missing_live_head"
@@ -6217,6 +6218,8 @@ function isInfrastructureFailedReview(markdown: string): boolean {
 export function failedReviewRetryEligibilityForTest(options: {
   markdown: string;
   liveState: string;
+  liveLocked?: boolean;
+  liveActiveLockReason?: string | null;
   liveHeadSha?: string | null;
   liveSourceRevision?: string | null;
   now: number;
@@ -6229,6 +6232,8 @@ export function failedReviewRetryEligibilityForTest(options: {
 function failedReviewRetryEligibility(options: {
   markdown: string;
   liveState: string;
+  liveLocked?: boolean;
+  liveActiveLockReason?: string | null;
   liveHeadSha?: string | null;
   liveSourceRevision?: string | null;
   now: number;
@@ -6242,6 +6247,13 @@ function failedReviewRetryEligibility(options: {
   }
   if (options.liveState !== "open") {
     return { repo, number, action: "skipped_not_open", reason: `state is ${options.liveState}` };
+  }
+  const lockedReason = lockedConversationApplyReason({
+    locked: options.liveLocked === true,
+    activeLockReason: options.liveActiveLockReason ?? null,
+  });
+  if (lockedReason) {
+    return { repo, number, action: "skipped_locked_conversation", reason: lockedReason };
   }
   const itemKind = frontMatterValue(options.markdown, "type");
   if (itemKind !== "pull_request" && itemKind !== "issue") {
@@ -19872,8 +19884,10 @@ function retryFailedReviewsCommandInner(args: Args): void {
       let liveSourceRevision: string | null = null;
       try {
         ({ item, state } = fetchItem(number));
-        if (item.kind === "pull_request") liveHeadSha = livePullHeadSha(number);
-        else liveSourceRevision = liveIssueSourceRevision(number);
+        if (state === "open" && !lockedConversationApplyReason(item)) {
+          if (item.kind === "pull_request") liveHeadSha = livePullHeadSha(number);
+          else liveSourceRevision = liveIssueSourceRevision(number);
+        }
       } catch (error) {
         if (error instanceof GitHubRuntimeBudgetError) throw error;
         results.push({
@@ -19888,6 +19902,8 @@ function retryFailedReviewsCommandInner(args: Args): void {
       const eligibility = failedReviewRetryEligibility({
         markdown,
         liveState: state,
+        liveLocked: item.locked === true,
+        liveActiveLockReason: item.activeLockReason ?? null,
         liveHeadSha,
         liveSourceRevision,
         now,

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -399,7 +399,7 @@ type AcquiredReviewStartLease = {
 
 type ReviewStartStatusCommentResult =
   | { status: "posted"; lease: AcquiredReviewStartLease }
-  | { status: "held"; lease: null };
+  | { status: "held"; lease: null; retryAt: string };
 
 interface ExistingReview {
   path: string;
@@ -17860,6 +17860,25 @@ function reviewStartLeaseOwner(comment: Record<string, unknown> | undefined): st
   return match?.[1]?.match(/\bowner=([^\s>]+)/i)?.[1] ?? null;
 }
 
+function newReviewStartLeaseOwner(
+  env: NodeJS.ProcessEnv = process.env,
+  fallback: () => string = randomUUID,
+): string {
+  const runId = String(env.GITHUB_RUN_ID ?? "").trim();
+  const runAttempt = String(env.GITHUB_RUN_ATTEMPT ?? "").trim();
+  if (/^[1-9]\d*$/.test(runId) && /^[1-9]\d*$/.test(runAttempt)) {
+    return `github-run-${runId}-${runAttempt}`;
+  }
+  return fallback();
+}
+
+export function newReviewStartLeaseOwnerForTest(
+  env: NodeJS.ProcessEnv,
+  fallback: () => string,
+): string {
+  return newReviewStartLeaseOwner(env, fallback);
+}
+
 function freshDedicatedReviewStartLeases(options: {
   comments: Record<string, unknown>[];
   itemNumber: number;
@@ -17919,7 +17938,7 @@ function postReviewStartStatusComment(options: {
   purpose?: "review" | "apply";
 }): ReviewStartStatusCommentResult {
   const startedAtMs = Date.now();
-  const leaseOwner = randomUUID();
+  const leaseOwner = newReviewStartLeaseOwner();
   const leaseOptions: ReviewStartStatusCommentOptions = {
     number: options.item.number,
     kind: options.item.kind,
@@ -17943,15 +17962,14 @@ function postReviewStartStatusComment(options: {
       `cannot acquire a review lease without the current item revision for #${options.item.number}`,
     );
   }
-  if (
-    freshDedicatedReviewStartLeases({
-      comments: initialState.leaseComments,
-      itemNumber: options.item.number,
-      headSha: normalizedHead,
-      nowMs: startedAtMs,
-    }).length > 0
-  ) {
-    return { status: "held", lease: null };
+  const initialLease = freshDedicatedReviewStartLeases({
+    comments: initialState.leaseComments,
+    itemNumber: options.item.number,
+    headSha: normalizedHead,
+    nowMs: startedAtMs,
+  })[0];
+  if (initialLease) {
+    return { status: "held", lease: null, retryAt: initialLease.expiresAt };
   }
   const body = renderReviewStartStatusComment(leaseOptions);
   const payload = writeCommentPayload(options.item.number, body);
@@ -17989,7 +18007,12 @@ function postReviewStartStatusComment(options: {
     reviewStartLeaseOwner(winner?.comment) !== leaseOwner
   ) {
     deleteOwnedDedicatedReviewStartLease(options.item.number, acquired);
-    return { status: "held", lease: null };
+    if (!winner) {
+      throw new Error(
+        `could not identify the winning review lease for #${options.item.number}; retry required`,
+      );
+    }
+    return { status: "held", lease: null, retryAt: winner.expiresAt };
   }
   return { status: "posted", lease: acquired };
 }
@@ -18934,6 +18957,8 @@ function reviewCommand(args: Args): void {
     ? buildLocalRangeReview(openclawDir, targetRepo(), stringArg(args.base, ""))
     : undefined;
   ensureDir(artifactDir);
+  const coordinationHeldPath = join(artifactDir, "coordination-held.json");
+  if (existsSync(coordinationHeldPath)) unlinkSync(coordinationHeldPath);
   if (localRangeData) {
     // Reuse #298's FULL offline envelope (not just token-scrub): withhold every GitHub
     // credential AND point gh at an empty config dir — token deletion alone can't stop
@@ -19013,6 +19038,7 @@ function reviewCommand(args: Args): void {
       JSON.stringify({ shardIndex, shardCount, scannedPages, candidates, reviewPolicy }, null, 2),
     );
     let completed = 0;
+    let coordinationHeldRetryAt: string | null = null;
     let codexFailures = 0;
     let leaseAcquisitionFailures = 0;
     let cacheHits = 0;
@@ -19042,7 +19068,10 @@ function reviewCommand(args: Args): void {
           console.error(
             `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} start-comment=${startComment.status} #${item.number}`,
           );
-          if (startComment.status === "held") continue;
+          if (startComment.status === "held") {
+            coordinationHeldRetryAt = startComment.retryAt;
+            continue;
+          }
           acquiredReviewLease = startComment.lease;
           if (!acquiredReviewLease) {
             throw new Error(`review lease acquisition returned no identity for PR #${item.number}`);
@@ -19114,7 +19143,10 @@ function reviewCommand(args: Args): void {
           console.error(
             `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} start-comment=${startComment.status} #${item.number}`,
           );
-          if (startComment.status === "held") continue;
+          if (startComment.status === "held") {
+            coordinationHeldRetryAt = startComment.retryAt;
+            continue;
+          }
           acquiredReviewLease = startComment.lease;
           if (!acquiredReviewLease) {
             throw new Error(
@@ -19302,6 +19334,13 @@ function reviewCommand(args: Args): void {
           `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} done #${item.number} (${completed}/${candidates.length}) decision=${decision.decision} confidence=${decision.confidence} action=${action.actionTaken}`,
         );
       }
+    }
+    if (coordinationHeldRetryAt) {
+      writeFileSync(
+        coordinationHeldPath,
+        JSON.stringify({ retry_at: coordinationHeldRetryAt }, null, 2) + "\n",
+        "utf8",
+      );
     }
     if (!humanLocalReview) {
       console.error(

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -2559,28 +2559,6 @@ function itemSnapshotHash(item: Item, context: ItemContext): string {
   return sha256(stableJson({ item: snapshotItem, context }));
 }
 
-function isApplyAutomationOnlyUpdate(options: {
-  itemUpdatedAt: string;
-  reviewCommentUpdatedAt?: string | null | undefined;
-  ownedReviewLeaseUpdatedAts?: readonly string[];
-  labelSyncOnlyUpdate?: boolean;
-}): boolean {
-  return (
-    options.itemUpdatedAt === options.reviewCommentUpdatedAt ||
-    (options.ownedReviewLeaseUpdatedAts ?? []).includes(options.itemUpdatedAt) ||
-    options.labelSyncOnlyUpdate === true
-  );
-}
-
-export function isApplyAutomationOnlyUpdateForTest(options: {
-  itemUpdatedAt: string;
-  reviewCommentUpdatedAt?: string | null | undefined;
-  ownedReviewLeaseUpdatedAts?: readonly string[];
-  labelSyncOnlyUpdate?: boolean;
-}): boolean {
-  return isApplyAutomationOnlyUpdate(options);
-}
-
 function itemSourceRevisionSha256(issue: unknown, comments: unknown[] = []): string {
   const source = asRecord(issue);
   const snapshot = {

--- a/src/repair/event-apply-proof.ts
+++ b/src/repair/event-apply-proof.ts
@@ -7,6 +7,8 @@ export type EventApplyAction = {
   terminalMissingVerified: boolean;
   terminalStateVerified: boolean;
   guardedOpenStateVerified: boolean;
+  terminalPolicyNoopVerified: boolean;
+  sourceDriftVerified: boolean;
 };
 
 export type ExactEventPublishDisposition = {
@@ -58,6 +60,12 @@ export function exactEventPublishDisposition({
   };
 }
 
+export type ExactEventApplyDisposition =
+  | "applied"
+  | "terminal_policy_noop"
+  | "source_drift"
+  | "unproven";
+
 export function exactEventApplyProof(
   actions: readonly EventApplyAction[],
   itemNumber: number,
@@ -69,16 +77,37 @@ export function exactEventApplyProof(
   terminalCount: number;
   guardedOpenAction: string | null;
   latestRevisionRequeueRequired: boolean;
+  disposition: ExactEventApplyDisposition;
 } {
   const exactActions = actions.filter((entry) => entry.number === itemNumber);
   const soleExactResult =
     actions.length === 1 && exactActions.length === 1 ? (exactActions[0] ?? null) : null;
   const soleExactAction = soleExactResult?.action ?? "";
+  const syncedCount = exactActions.filter((entry) => entry.durableReviewSynced).length;
+  const terminalCount = exactActions.filter((entry) => entry.terminalStateVerified).length;
+  const terminalPolicyNoop =
+    exactActions.length > 0 &&
+    exactActions.every(
+      (entry) => entry.action === "skipped_same_author_pair" && entry.terminalPolicyNoopVerified,
+    );
+  const sourceDriftActions = exactActions.filter(
+    (entry) => entry.action === "skipped_changed_since_review",
+  );
+  const sourceDrift =
+    sourceDriftActions.length > 0 &&
+    sourceDriftActions.every((entry) => entry.sourceDriftVerified) &&
+    exactActions.every(
+      (entry) =>
+        entry.action === "skipped_changed_since_review" ||
+        entry.durableReviewSynced ||
+        entry.terminalStateVerified,
+    );
+  const hasSourceDrift = sourceDriftActions.length > 0;
   return {
     exactActions,
-    syncedCount: exactActions.filter((entry) => entry.durableReviewSynced).length,
+    syncedCount,
     terminalMissingCount: exactActions.filter((entry) => entry.terminalMissingVerified).length,
-    terminalCount: exactActions.filter((entry) => entry.terminalStateVerified).length,
+    terminalCount,
     guardedOpenAction:
       snapshotActionTaken === soleExactAction &&
       soleExactResult?.guardedOpenStateVerified === true &&
@@ -88,6 +117,15 @@ export function exactEventApplyProof(
     latestRevisionRequeueRequired:
       snapshotActionTaken === "skipped_changed_since_review" &&
       soleExactAction === "skipped_changed_since_review",
+    disposition: hasSourceDrift
+      ? sourceDrift
+        ? "source_drift"
+        : "unproven"
+      : terminalPolicyNoop
+        ? "terminal_policy_noop"
+        : syncedCount + terminalCount > 0
+          ? "applied"
+          : "unproven",
   };
 }
 
@@ -112,5 +150,7 @@ export function eventApplyAction(value: LooseRecord): EventApplyAction {
     terminalMissingVerified: value.terminalMissingVerified === true,
     terminalStateVerified: value.terminalStateVerified === true,
     guardedOpenStateVerified: value.guardedOpenStateVerified === true,
+    terminalPolicyNoopVerified: value.terminalPolicyNoopVerified === true,
+    sourceDriftVerified: value.sourceDriftVerified === true,
   };
 }

--- a/src/repair/event-apply-proof.ts
+++ b/src/repair/event-apply-proof.ts
@@ -69,7 +69,7 @@ export type ExactEventApplyDisposition =
 export function exactEventApplyProof(
   actions: readonly EventApplyAction[],
   itemNumber: number,
-  snapshotActionTaken: string | null,
+  snapshotActionTaken: string | null = null,
 ): {
   exactActions: EventApplyAction[];
   syncedCount: number;
@@ -93,8 +93,9 @@ export function exactEventApplyProof(
   const sourceDriftActions = exactActions.filter(
     (entry) => entry.action === "skipped_changed_since_review",
   );
+  const hasSourceDrift = sourceDriftActions.length > 0;
   const sourceDrift =
-    sourceDriftActions.length > 0 &&
+    hasSourceDrift &&
     sourceDriftActions.every((entry) => entry.sourceDriftVerified) &&
     exactActions.every(
       (entry) =>
@@ -102,7 +103,6 @@ export function exactEventApplyProof(
         entry.durableReviewSynced ||
         entry.terminalStateVerified,
     );
-  const hasSourceDrift = sourceDriftActions.length > 0;
   return {
     exactActions,
     syncedCount,

--- a/src/repair/publish-event-result.ts
+++ b/src/repair/publish-event-result.ts
@@ -315,9 +315,7 @@ function publishSnapshot({
         ...disposition,
         policyNoop: disposition.guardedOpenAction === "skipped_same_author_pair",
         requeueLatest:
-          requeueLatestExpected &&
-          candidateMatchesCurrentTuple &&
-          candidateTupleState === "open",
+          requeueLatestExpected && candidateMatchesCurrentTuple && candidateTupleState === "open",
         remoteTupleVerified: candidateMatchesCurrentTuple,
         routingDeferred: disposition.routableSyncVerified,
       };

--- a/src/repair/publish-event-result.ts
+++ b/src/repair/publish-event-result.ts
@@ -155,11 +155,9 @@ async function publishEventResult(options: EventOptions): Promise<void> {
     terminalMissingCount: missingCount,
     terminalCount: closedCount,
     guardedOpenAction,
-    latestRevisionRequeueRequired,
     disposition: applyDisposition,
   } = exactEventApplyProof(actions, Number(options.itemNumber), snapshotActionTaken);
-  const requeueLatestExpected =
-    latestRevisionRequeueRequired && applyDisposition === "source_drift";
+  const requeueLatestExpected = applyDisposition === "source_drift";
   if (
     syncedCount + closedCount + missingCount === 0 &&
     guardedOpenAction === null &&
@@ -171,9 +169,7 @@ async function publishEventResult(options: EventOptions): Promise<void> {
         .filter(Boolean)
         .join(", ") || "none";
     throw new Error(
-      latestRevisionRequeueRequired
-        ? `Event review for ${options.targetRepo}#${options.itemNumber} changed since review; requeue against the latest item revision`
-        : `Event review for ${options.targetRepo}#${options.itemNumber} was not applied; actions: ${observed}`,
+      `Event review for ${options.targetRepo}#${options.itemNumber} was not applied; actions: ${observed}`,
     );
   }
   const summary = () =>

--- a/src/repair/publish-event-result.ts
+++ b/src/repair/publish-event-result.ts
@@ -45,6 +45,8 @@ type EventOptions = {
 
 type PublishedEventSnapshot = {
   guardedOpenAction: string | null;
+  policyNoop: boolean;
+  requeueLatest: boolean;
   remoteTupleVerified: boolean;
   routableSyncVerified: boolean;
   routingDeferred: boolean;
@@ -54,6 +56,7 @@ type PublishedEventSnapshot = {
 
 class GuardedOpenPublishRaceError extends Error {}
 class RoutableSyncPublishRaceError extends Error {}
+class SourceDriftPublishRaceError extends Error {}
 class TerminalClosedPublishRaceError extends Error {}
 class TerminalMissingPublishRaceError extends Error {}
 
@@ -153,8 +156,15 @@ async function publishEventResult(options: EventOptions): Promise<void> {
     terminalCount: closedCount,
     guardedOpenAction,
     latestRevisionRequeueRequired,
+    disposition: applyDisposition,
   } = exactEventApplyProof(actions, Number(options.itemNumber), snapshotActionTaken);
-  if (syncedCount + closedCount + missingCount === 0 && guardedOpenAction === null) {
+  const requeueLatestExpected =
+    latestRevisionRequeueRequired && applyDisposition === "source_drift";
+  if (
+    syncedCount + closedCount + missingCount === 0 &&
+    guardedOpenAction === null &&
+    !requeueLatestExpected
+  ) {
     const observed =
       exactActions
         .map((entry) => entry.action)
@@ -176,7 +186,11 @@ async function publishEventResult(options: EventOptions): Promise<void> {
       closeReasons: options.closeReasons,
     });
   const routableSyncExpected =
-    syncedCount > 0 && closedCount === 0 && missingCount === 0 && guardedOpenAction === null;
+    syncedCount > 0 &&
+    closedCount === 0 &&
+    missingCount === 0 &&
+    guardedOpenAction === null &&
+    !requeueLatestExpected;
   for (let attempt = 1; attempt <= 20; attempt += 1) {
     const published = publishSnapshot({
       paths: recordPaths,
@@ -184,6 +198,7 @@ async function publishEventResult(options: EventOptions): Promise<void> {
       summary,
       stateBaseCommit,
       guardedOpenAction,
+      requeueLatestExpected,
       routableSyncExpected,
       terminalClosedExpected: closedCount > 0,
       terminalMissingExpected: missingCount > 0,
@@ -204,6 +219,7 @@ async function publishEventResult(options: EventOptions): Promise<void> {
     summary,
     stateBaseCommit,
     guardedOpenAction,
+    requeueLatestExpected,
     routableSyncExpected,
     terminalClosedExpected: closedCount > 0,
     terminalMissingExpected: missingCount > 0,
@@ -256,6 +272,7 @@ function publishSnapshot({
   summary,
   stateBaseCommit,
   guardedOpenAction,
+  requeueLatestExpected,
   routableSyncExpected,
   terminalClosedExpected,
   terminalMissingExpected,
@@ -265,6 +282,7 @@ function publishSnapshot({
   summary: () => void;
   stateBaseCommit: string | null;
   guardedOpenAction: string | null;
+  requeueLatestExpected: boolean;
   routableSyncExpected: boolean;
   terminalClosedExpected: boolean;
   terminalMissingExpected: boolean;
@@ -284,9 +302,10 @@ function publishSnapshot({
       hardResetToRemoteMain();
       refreshSourceAfterStatePublish(commitPaths, stateBaseCommit);
       const candidateMatchesCurrentTuple = candidateApplied && eventSnapshotMatchesCurrent(paths);
+      const candidateTupleState = candidateEventTupleState(paths);
       const disposition = exactEventPublishDisposition({
         candidateMatchesCurrentTuple,
-        candidateTupleState: candidateEventTupleState(paths),
+        candidateTupleState,
         terminalClosedExpected,
         terminalMissingExpected,
         guardedOpenAction,
@@ -294,6 +313,11 @@ function publishSnapshot({
       });
       const published = {
         ...disposition,
+        policyNoop: disposition.guardedOpenAction === "skipped_same_author_pair",
+        requeueLatest:
+          requeueLatestExpected &&
+          candidateMatchesCurrentTuple &&
+          candidateTupleState === "open",
         remoteTupleVerified: candidateMatchesCurrentTuple,
         routingDeferred: disposition.routableSyncVerified,
       };
@@ -310,6 +334,11 @@ function publishSnapshot({
       if (terminalClosedExpected && !published.terminalClosed) {
         throw new TerminalClosedPublishRaceError(
           `Verified terminal close for ${paths.targetSlug}#${options.itemNumber} lost the publish race; requeue against the latest item revision`,
+        );
+      }
+      if (requeueLatestExpected && !published.requeueLatest) {
+        throw new SourceDriftPublishRaceError(
+          `Verified source drift for ${paths.targetSlug}#${options.itemNumber} lost the publish race; requeue against the latest item revision`,
         );
       }
       if (
@@ -367,6 +396,7 @@ function publishSnapshot({
       error instanceof RecordTupleError ||
       error instanceof GuardedOpenPublishRaceError ||
       error instanceof RoutableSyncPublishRaceError ||
+      error instanceof SourceDriftPublishRaceError ||
       error instanceof TerminalClosedPublishRaceError ||
       error instanceof TerminalMissingPublishRaceError
     )
@@ -448,6 +478,8 @@ function writeEventDispositionOutputs(published: PublishedEventSnapshot): void {
       `terminal_closed=${published.terminalClosed ? "true" : "false"}`,
       `guarded_open=${published.guardedOpenAction === null ? "false" : "true"}`,
       `guarded_open_action=${published.guardedOpenAction ?? ""}`,
+      `policy_noop=${published.policyNoop ? "true" : "false"}`,
+      `requeue_latest=${published.requeueLatest ? "true" : "false"}`,
       `routing_deferred=${published.routingDeferred ? "true" : "false"}`,
       "",
     ].join("\n"),

--- a/test/apply-label-sync.test.ts
+++ b/test/apply-label-sync.test.ts
@@ -640,7 +640,13 @@ if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
 }
 `;
     withMockGh(root, ghMock, () => {
-      runApplyDecisionsForTest({ itemsDir, closedDir, plansDir, reportPath });
+      runApplyDecisionsForTest({
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: ["--event-apply-proof"],
+      });
     });
 
     const calls = readFileSync(logPath, "utf8")
@@ -661,6 +667,7 @@ if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
         number: 321,
         action: "skipped_changed_since_review",
         reason: "updated_at changed",
+        sourceDriftVerified: true,
       },
     ]);
   } finally {

--- a/test/apply-same-author-pair-close.test.ts
+++ b/test/apply-same-author-pair-close.test.ts
@@ -646,6 +646,7 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/(320|321)\\/timeline(?
         number: 321,
         action: "skipped_same_author_pair",
         reason: "open issue #320 (Paired issue) by the same author is paired with this PR",
+        guardedOpenStateVerified: true,
         terminalPolicyNoopVerified: true,
       },
     ]);

--- a/test/apply-same-author-pair-close.test.ts
+++ b/test/apply-same-author-pair-close.test.ts
@@ -636,6 +636,7 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/(320|321)\\/timeline(?
           "all",
           "--processed-limit",
           "1",
+          "--event-apply-proof",
         ],
       });
     });
@@ -645,6 +646,7 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/(320|321)\\/timeline(?
         number: 321,
         action: "skipped_same_author_pair",
         reason: "open issue #320 (Paired issue) by the same author is paired with this PR",
+        terminalPolicyNoopVerified: true,
       },
     ]);
   } finally {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -20,7 +20,6 @@ import {
   ghRetryWaitMs,
   isGitHubNotFoundError,
   isGitHubRequiresAuthenticationError,
-  isApplyAutomationOnlyUpdateForTest,
   isLockedConversationCommentError,
   itemSourceRevisionSha256ForTest,
   itemNumbersArg,
@@ -847,27 +846,6 @@ if (args[0] === "api" && /\\/issues\\/comments\\/\\d+$/.test(path)) {
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
-});
-
-test("apply treats its exact review lease timestamp as automation-only churn", () => {
-  assert.equal(
-    isApplyAutomationOnlyUpdateForTest({
-      itemUpdatedAt: "2026-05-01T00:01:00Z",
-      reviewCommentUpdatedAt: null,
-      ownedReviewLeaseUpdatedAts: ["2026-05-01T00:01:00Z"],
-      labelSyncOnlyUpdate: false,
-    }),
-    true,
-  );
-  assert.equal(
-    isApplyAutomationOnlyUpdateForTest({
-      itemUpdatedAt: "2026-05-01T00:02:00Z",
-      reviewCommentUpdatedAt: null,
-      ownedReviewLeaseUpdatedAts: ["2026-05-01T00:01:00Z"],
-      labelSyncOnlyUpdate: false,
-    }),
-    false,
-  );
 });
 
 test("apply-decisions syncs labels when first review placeholder advanced issue updated_at", () => {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2182,7 +2182,7 @@ test("sweep workflow executes only durable queue leases without runner-side admi
 
   assert.match(
     eventReviewBlock,
-    /group: clawsweeper-event-review-\$\{\{ github\.event\.client_payload\.item_key \|\| github\.run_id \}\}/,
+    /group: clawsweeper-event-review-\$\{\{ github\.event\.client_payload\.queue_claim\.item_key \|\| github\.event\.client_payload\.item_key \|\| github\.run_id \}\}/,
   );
   assert.match(eventReviewBlock, /github\.event\.client_payload\.queue_lease_id != ''/);
   assert.match(legacyIntakeBlock, /Queue legacy exact-review event/);

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2204,8 +2204,12 @@ test("sweep workflow executes only durable queue leases without runner-side admi
   assert.match(eventReviewBlock, /\/internal\/exact-review\/claim/);
   assert.match(eventReviewBlock, /\/internal\/exact-review\/complete/);
   assert.match(claimStep, /RUN_ATTEMPT: \$\{\{ github\.run_attempt \}\}/);
-  assert.match(claimStep, /item_key: process\.env\.ITEM_KEY/);
-  assert.match(claimStep, /lease_revision: leaseRevision/);
+  assert.match(
+    claimStep,
+    /hasTuple \? \{ item_key: itemKey, lease_revision: leaseRevision \} : \{\}/,
+  );
+  assert.match(claimStep, /response\.protocol_version \|\| 1/);
+  assert.match(claimStep, /const legacyDecision = \{/);
   assert.match(claimStep, /run_attempt: runAttempt/);
   assert.match(
     eventReviewBlock.slice(failReviewIndex, completeLeaseIndex),
@@ -2223,6 +2227,10 @@ test("sweep workflow executes only durable queue leases without runner-side admi
   assert.match(completeLeaseStep, /if: \$\{\{ always\(\) \}\}/);
   assert.match(completeLeaseStep, /continue-on-error: true/);
   assert.match(completeLeaseStep, /RUN_ATTEMPT: \$\{\{ github\.run_attempt \}\}/);
+  assert.match(
+    completeLeaseStep,
+    /PROTOCOL_VERSION: \$\{\{ steps\.claim-exact-review-queue\.outputs\.protocol_version \}\}/,
+  );
   assert.match(completeLeaseStep, /process\.env\.JOB_STATUS === "cancelled"/);
   assert.match(completeLeaseStep, /claim_generation: claimGeneration/);
   assert.match(completeLeaseStep, /item_key: process\.env\.ITEM_KEY/);

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -20,6 +20,7 @@ import {
   ghRetryWaitMs,
   isGitHubNotFoundError,
   isGitHubRequiresAuthenticationError,
+  isApplyAutomationOnlyUpdateForTest,
   isLockedConversationCommentError,
   itemSourceRevisionSha256ForTest,
   itemNumbersArg,
@@ -846,6 +847,27 @@ if (args[0] === "api" && /\\/issues\\/comments\\/\\d+$/.test(path)) {
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+test("apply treats its exact review lease timestamp as automation-only churn", () => {
+  assert.equal(
+    isApplyAutomationOnlyUpdateForTest({
+      itemUpdatedAt: "2026-05-01T00:01:00Z",
+      reviewCommentUpdatedAt: null,
+      ownedReviewLeaseUpdatedAts: ["2026-05-01T00:01:00Z"],
+      labelSyncOnlyUpdate: false,
+    }),
+    true,
+  );
+  assert.equal(
+    isApplyAutomationOnlyUpdateForTest({
+      itemUpdatedAt: "2026-05-01T00:02:00Z",
+      reviewCommentUpdatedAt: null,
+      ownedReviewLeaseUpdatedAts: ["2026-05-01T00:01:00Z"],
+      labelSyncOnlyUpdate: false,
+    }),
+    false,
+  );
 });
 
 test("apply-decisions syncs labels when first review placeholder advanced issue updated_at", () => {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2182,7 +2182,7 @@ test("sweep workflow executes only durable queue leases without runner-side admi
 
   assert.match(
     eventReviewBlock,
-    /group: clawsweeper-event-review-\$\{\{ github\.event\.client_payload\.target_repo/,
+    /group: clawsweeper-event-review-\$\{\{ github\.event\.client_payload\.item_key \|\| github\.run_id \}\}/,
   );
   assert.match(eventReviewBlock, /github\.event\.client_payload\.queue_lease_id != ''/);
   assert.match(legacyIntakeBlock, /Queue legacy exact-review event/);
@@ -2204,6 +2204,8 @@ test("sweep workflow executes only durable queue leases without runner-side admi
   assert.match(eventReviewBlock, /\/internal\/exact-review\/claim/);
   assert.match(eventReviewBlock, /\/internal\/exact-review\/complete/);
   assert.match(claimStep, /RUN_ATTEMPT: \$\{\{ github\.run_attempt \}\}/);
+  assert.match(claimStep, /item_key: process\.env\.ITEM_KEY/);
+  assert.match(claimStep, /lease_revision: leaseRevision/);
   assert.match(claimStep, /run_attempt: runAttempt/);
   assert.match(
     eventReviewBlock.slice(failReviewIndex, completeLeaseIndex),
@@ -2222,6 +2224,9 @@ test("sweep workflow executes only durable queue leases without runner-side admi
   assert.match(completeLeaseStep, /continue-on-error: true/);
   assert.match(completeLeaseStep, /RUN_ATTEMPT: \$\{\{ github\.run_attempt \}\}/);
   assert.match(completeLeaseStep, /process\.env\.JOB_STATUS === "cancelled"/);
+  assert.match(completeLeaseStep, /claim_generation: claimGeneration/);
+  assert.match(completeLeaseStep, /item_key: process\.env\.ITEM_KEY/);
+  assert.match(completeLeaseStep, /lease_revision: leaseRevision/);
   assert.match(completeLeaseStep, /run_attempt: runAttempt/);
   assert.match(completeLeaseStep, /outcome,/);
   assert.match(eventReviewBlock, /exact-review queue leased this run/);

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -217,7 +217,7 @@ test("dashboard durable status store persists, expires, and prepends events", as
   assert.equal(storage.has("cold-expired"), false);
 });
 
-test("exact-review queue coalesces deliveries, dispatches only bindings, and rejects duplicate claims", async () => {
+test("exact-review queue coalesces deliveries, dispatches a bound rollout snapshot, and rejects duplicate claims", async () => {
   const originalFetch = globalThis.fetch;
   const storage = new MemoryDurableStorage();
   const dispatched: Record<string, unknown>[] = [];
@@ -329,9 +329,24 @@ test("exact-review queue coalesces deliveries, dispatches only bindings, and rej
     const leaseId = String(payload.queue_lease_id || "");
     assert.match(leaseId, /^[0-9a-f-]{36}$/);
     assert.deepEqual(payload, {
+      queue_protocol_version: 2,
       queue_lease_id: leaseId,
       item_key: "openclaw/gogcli#597",
       lease_revision: 2,
+      target_repo: "openclaw/gogcli",
+      target_branch: "main",
+      item_number: 597,
+      item_kind: "issue",
+      source_event: "issues",
+      source_action: "edited",
+      supersedes_in_progress: true,
+      review_options: {
+        codex_timeout_ms: 1_200_000,
+        media_proof_timeout_ms: 480_000,
+        command_status_marker: commandStatusMarker,
+        status_comment_id: 9001,
+        additional_prompt: "Check the maintainer-requested regression path.",
+      },
     });
 
     const newer = buildExactReviewQueueRequest("delivery-4", 597, "synchronize", "pull_request");
@@ -353,6 +368,7 @@ test("exact-review queue coalesces deliveries, dispatches only bindings, and rej
     assert.deepEqual(await claimed.json(), {
       ok: true,
       claimed: true,
+      protocol_version: 2,
       item_key: "openclaw/gogcli#597",
       lease_revision: 2,
       claim_generation: 1,
@@ -460,6 +476,7 @@ test("exact-review claim preserves its immutable decision across a newer enqueue
   assert.deepEqual(await claim.json(), {
     ok: true,
     claimed: true,
+    protocol_version: 2,
     item_key: "openclaw/openclaw#620",
     lease_revision: 1,
     claim_generation: 1,
@@ -515,6 +532,93 @@ test("exact-review claim preserves its immutable decision across a newer enqueue
     "edited",
   );
   assert.equal(requeued.items["openclaw/openclaw#620"].leaseDecision, undefined);
+});
+
+test("new exact-review queue serves legacy workflow claims during rolling deploys", async () => {
+  const storage = new MemoryDurableStorage();
+  const item = unclaimedExactReviewQueueItem(624);
+  await storage.put("exact-review-queue", {
+    deliveries: {},
+    items: { "openclaw/openclaw#624": item },
+  });
+  const queue = new ExactReviewQueue({ storage }, {});
+
+  assert.equal(
+    (
+      await queue.fetch(
+        buildExactReviewQueueRequest(
+          "newer-624",
+          624,
+          "edited",
+          "pull_request",
+          "openclaw/openclaw",
+        ),
+      )
+    ).status,
+    202,
+  );
+
+  const legacyClaim = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/claim", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: "lease-624",
+        run_id: "6240",
+        run_attempt: 1,
+      }),
+    }),
+  );
+  assert.equal(legacyClaim.status, 200);
+  assert.deepEqual(await legacyClaim.json(), {
+    ok: true,
+    claimed: true,
+    protocol_version: 1,
+    item_key: "openclaw/openclaw#624",
+    revision: 1,
+    lease_revision: 1,
+    claim_generation: 1,
+    decision: item.leaseDecision,
+  });
+
+  const strictCompletion = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: "lease-624",
+        item_key: "openclaw/openclaw#624",
+        lease_revision: 1,
+        claim_generation: 1,
+        run_id: "6240",
+        run_attempt: 1,
+        outcome: "success",
+      }),
+    }),
+  );
+  assert.equal(strictCompletion.status, 409);
+  assert.deepEqual(await strictCompletion.json(), { error: "lease_protocol_not_claimed" });
+
+  const legacyCompletion = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: "lease-624",
+        run_id: "6240",
+        run_attempt: 1,
+        outcome: "success",
+      }),
+    }),
+  );
+  assert.equal(legacyCompletion.status, 200);
+  assert.deepEqual(await legacyCompletion.json(), { ok: true, requeued: true });
+  const requeued = (await storage.get("exact-review-queue")) as {
+    items: Record<string, Record<string, unknown>>;
+  };
+  assert.equal(requeued.items["openclaw/openclaw#624"].state, "pending");
+  assert.equal(requeued.items["openclaw/openclaw#624"].claimProtocolVersion, undefined);
+  assert.equal(
+    (requeued.items["openclaw/openclaw#624"].decision as { sourceAction: string }).sourceAction,
+    "edited",
+  );
 });
 
 test("exact-review claims advance generations only for newer run attempts", async () => {
@@ -5798,6 +5902,7 @@ function leasedExactReviewQueueItem(itemNumber: number, runId: string, runAttemp
     claimedRunId: runId,
     claimedRunAttempt: runAttempt,
     claimGeneration: 1,
+    claimProtocolVersion: 2,
   };
 }
 
@@ -5808,5 +5913,6 @@ function unclaimedExactReviewQueueItem(itemNumber: number) {
     claimedRunId: undefined,
     claimedRunAttempt: undefined,
     claimGeneration: undefined,
+    claimProtocolVersion: undefined,
   };
 }

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -913,6 +913,90 @@ test("exact-review queue requeues a cancelled claimed lease", async () => {
   assert.equal(state.items["openclaw/openclaw#710"].claimGeneration, undefined);
 });
 
+test("exact-review queue defers a coordination-held failure until the lease expires", async () => {
+  const storage = new MemoryDurableStorage();
+  const retryAt = Date.now() + 45 * 60_000;
+  await storage.put("exact-review-queue", {
+    deliveries: {},
+    items: {
+      "openclaw/openclaw#711": leasedExactReviewQueueItem(711, "held-run"),
+    },
+  });
+  const queue = new ExactReviewQueue({ storage }, {});
+
+  const response = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: "lease-711",
+        run_id: "held-run",
+        run_attempt: 1,
+        outcome: "failure",
+        retry_at: new Date(retryAt).toISOString(),
+      }),
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { ok: true, requeued: true });
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<string, Record<string, unknown>>;
+  };
+  assert.ok(Number(state.items["openclaw/openclaw#711"].nextAttemptAt) >= retryAt);
+  assert.equal(state.items["openclaw/openclaw#711"].attempts, 1);
+});
+
+test("exact-review queue does not carry an old coordination deadline to a newer revision", async () => {
+  const storage = new MemoryDurableStorage();
+  const retryAt = Date.now() + 45 * 60_000;
+  const item = leasedExactReviewQueueItem(712, "held-run");
+  item.revision = Number(item.leaseRevision) + 1;
+  await storage.put("exact-review-queue", {
+    deliveries: {},
+    items: { "openclaw/openclaw#712": item },
+  });
+  const queue = new ExactReviewQueue({ storage }, {});
+
+  const response = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: "lease-712",
+        run_id: "held-run",
+        run_attempt: 1,
+        outcome: "failure",
+        retry_at: new Date(retryAt).toISOString(),
+      }),
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<string, Record<string, unknown>>;
+  };
+  assert.ok(Number(state.items["openclaw/openclaw#712"].nextAttemptAt) < retryAt);
+});
+
+test("exact-review queue rejects invalid coordination retry deadlines", async () => {
+  const queue = new ExactReviewQueue({ storage: new MemoryDurableStorage() }, {});
+  for (const retryAt of ["not-a-timestamp", new Date(Date.now() + 3 * 60 * 60_000).toISOString()]) {
+    const response = await queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/complete", {
+        method: "POST",
+        body: JSON.stringify({
+          lease_id: "lease-712",
+          run_id: "held-run",
+          run_attempt: 1,
+          outcome: "failure",
+          retry_at: retryAt,
+        }),
+      }),
+    );
+    assert.equal(response.status, 400);
+    assert.deepEqual(await response.json(), { error: "invalid_retry_at" });
+  }
+});
+
 test("exact-review completion rejects stale owners and is race-idempotent", async () => {
   const storage = new MemoryDurableStorage();
   await storage.put("exact-review-queue", {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -997,6 +997,102 @@ test("exact-review queue rejects invalid coordination retry deadlines", async ()
   }
 });
 
+test("exact-review queue requeues a verified source drift exactly once without failure backoff", async () => {
+  const storage = new MemoryDurableStorage();
+  await storage.put("exact-review-queue", {
+    deliveries: {},
+    items: {
+      "openclaw/openclaw#713": leasedExactReviewQueueItem(713, "drift-run"),
+    },
+  });
+  const queue = new ExactReviewQueue({ storage }, {});
+  const complete = () =>
+    queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/complete", {
+        method: "POST",
+        body: JSON.stringify({
+          lease_id: "lease-713",
+          run_id: "drift-run",
+          run_attempt: 1,
+          outcome: "success",
+          requeue_latest: true,
+        }),
+      }),
+    );
+
+  const response = await complete();
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { ok: true, requeued: true });
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<string, Record<string, unknown>>;
+  };
+  assert.equal(state.items["openclaw/openclaw#713"].state, "pending");
+  assert.equal(state.items["openclaw/openclaw#713"].attempts, 0);
+  assert.equal(state.items["openclaw/openclaw#713"].revision, 1);
+  assert.equal(state.items["openclaw/openclaw#713"].leaseId, undefined);
+  assert.equal((await complete()).status, 409);
+  const replayedState = (await storage.get("exact-review-queue")) as {
+    items: Record<string, Record<string, unknown>>;
+  };
+  assert.equal(Object.keys(replayedState.items).length, 1);
+  assert.equal(replayedState.items["openclaw/openclaw#713"].state, "pending");
+});
+
+test("exact-review source-drift requeue preserves an already-enqueued latest decision", async () => {
+  const storage = new MemoryDurableStorage();
+  const item = leasedExactReviewQueueItem(714, "drift-run");
+  item.revision = 2;
+  item.decision.sourceAction = "edited";
+  await storage.put("exact-review-queue", {
+    deliveries: {},
+    items: { "openclaw/openclaw#714": item },
+  });
+  const queue = new ExactReviewQueue({ storage }, {});
+
+  const response = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: "lease-714",
+        run_id: "drift-run",
+        run_attempt: 1,
+        outcome: "success",
+        requeue_latest: true,
+      }),
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { state: string; revision: number; decision: { sourceAction: string } }>;
+  };
+  assert.equal(Object.keys(state.items).length, 1);
+  assert.equal(state.items["openclaw/openclaw#714"].state, "pending");
+  assert.equal(state.items["openclaw/openclaw#714"].revision, 2);
+  assert.equal(state.items["openclaw/openclaw#714"].decision.sourceAction, "edited");
+});
+
+test("exact-review queue rejects invalid source-drift requeue requests", async () => {
+  const queue = new ExactReviewQueue({ storage: new MemoryDurableStorage() }, {});
+  for (const body of [
+    { outcome: "success", requeue_latest: "true" },
+    { outcome: "failure", requeue_latest: true },
+  ]) {
+    const response = await queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/complete", {
+        method: "POST",
+        body: JSON.stringify({
+          lease_id: "lease-715",
+          run_id: "drift-run",
+          run_attempt: 1,
+          ...body,
+        }),
+      }),
+    );
+    assert.equal(response.status, 400);
+  }
+});
+
 test("exact-review completion rejects stale owners and is race-idempotent", async () => {
   const storage = new MemoryDurableStorage();
   await storage.put("exact-review-queue", {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -329,10 +329,12 @@ test("exact-review queue coalesces deliveries, dispatches a bound rollout snapsh
     const leaseId = String(payload.queue_lease_id || "");
     assert.match(leaseId, /^[0-9a-f-]{36}$/);
     assert.deepEqual(payload, {
-      queue_protocol_version: 2,
       queue_lease_id: leaseId,
-      item_key: "openclaw/gogcli#597",
-      lease_revision: 2,
+      queue_claim: {
+        protocol_version: 2,
+        item_key: "openclaw/gogcli#597",
+        lease_revision: 2,
+      },
       target_repo: "openclaw/gogcli",
       target_branch: "main",
       item_number: 597,
@@ -348,6 +350,7 @@ test("exact-review queue coalesces deliveries, dispatches a bound rollout snapsh
         additional_prompt: "Check the maintainer-requested regression path.",
       },
     });
+    assert.equal(Object.keys(payload).length, 10);
 
     const newer = buildExactReviewQueueRequest("delivery-4", 597, "synchronize", "pull_request");
     assert.equal((await queue.fetch(newer)).status, 202);
@@ -859,9 +862,8 @@ test("exact-review queue admits at most one active item per target repository", 
     assert.equal(dispatched.length, 2);
     const nextAlarm = await storage.getAlarm();
     assert.ok(nextAlarm && nextAlarm > Date.now() + 60_000);
-    const targets = dispatched.map(
-      (payload) =>
-        String((payload.client_payload as Record<string, unknown>).item_key).split("#", 1)[0],
+    const targets = dispatched.map((payload) =>
+      String((payload.client_payload as Record<string, unknown>).target_repo),
     );
     assert.equal(new Set(targets).size, 2);
     assert.equal(targets.filter((target) => target === "openclaw/gogcli").length, 1);

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -1002,7 +1002,7 @@ test("exact-review queue requeues a verified source drift exactly once without f
   await storage.put("exact-review-queue", {
     deliveries: {},
     items: {
-      "openclaw/openclaw#713": leasedExactReviewQueueItem(713, "drift-run"),
+      "openclaw/openclaw#713": leasedExactReviewQueueItem(713, "9113"),
     },
   });
   const queue = new ExactReviewQueue({ storage }, {});
@@ -1012,7 +1012,7 @@ test("exact-review queue requeues a verified source drift exactly once without f
         method: "POST",
         body: JSON.stringify({
           lease_id: "lease-713",
-          run_id: "drift-run",
+          run_id: "9113",
           run_attempt: 1,
           outcome: "success",
           requeue_latest: true,
@@ -1036,6 +1036,32 @@ test("exact-review queue requeues a verified source drift exactly once without f
   };
   assert.equal(Object.keys(replayedState.items).length, 1);
   assert.equal(replayedState.items["openclaw/openclaw#713"].state, "pending");
+  const reconciled = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/reconcile", {
+      method: "POST",
+      body: JSON.stringify({
+        runs: [
+          {
+            run_id: "9113",
+            run_attempt: 1,
+            claimed_run_attempt: 1,
+            claim_generation: 1,
+            outcome: "success",
+          },
+        ],
+      }),
+    }),
+  );
+  assert.deepEqual(await reconciled.json(), {
+    ok: true,
+    reconciled: 0,
+    requeued: 0,
+    completed: 0,
+  });
+  const reconciledState = (await storage.get("exact-review-queue")) as {
+    items: Record<string, Record<string, unknown>>;
+  };
+  assert.equal(reconciledState.items["openclaw/openclaw#713"].state, "pending");
 });
 
 test("exact-review source-drift requeue preserves an already-enqueued latest decision", async () => {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -217,7 +217,7 @@ test("dashboard durable status store persists, expires, and prepends events", as
   assert.equal(storage.has("cold-expired"), false);
 });
 
-test("exact-review queue coalesces deliveries, leases bounded work, and rejects duplicate claims", async () => {
+test("exact-review queue coalesces deliveries, dispatches only bindings, and rejects duplicate claims", async () => {
   const originalFetch = globalThis.fetch;
   const storage = new MemoryDurableStorage();
   const dispatched: Record<string, unknown>[] = [];
@@ -326,23 +326,27 @@ test("exact-review queue coalesces deliveries, leases bounded work, and rejects 
     const nextAlarm = await storage.getAlarm();
     assert.ok(nextAlarm && nextAlarm > Date.now() + 60_000);
     const payload = dispatched[0].client_payload as Record<string, unknown>;
-    assert.equal(payload.item_number, 597);
-    assert.equal(payload.source_action, "edited");
-    assert.ok(Object.keys(payload).length <= 10);
-    assert.deepEqual(payload.review_options, {
-      codex_timeout_ms: 1_200_000,
-      media_proof_timeout_ms: 480_000,
-      command_status_marker: commandStatusMarker,
-      status_comment_id: 9001,
-      additional_prompt: "Check the maintainer-requested regression path.",
-    });
     const leaseId = String(payload.queue_lease_id || "");
     assert.match(leaseId, /^[0-9a-f-]{36}$/);
+    assert.deepEqual(payload, {
+      queue_lease_id: leaseId,
+      item_key: "openclaw/gogcli#597",
+      lease_revision: 2,
+    });
+
+    const newer = buildExactReviewQueueRequest("delivery-4", 597, "synchronize", "pull_request");
+    assert.equal((await queue.fetch(newer)).status, 202);
 
     const claimed = await queue.fetch(
       new Request("https://clawsweeper-exact-review-queue/claim", {
         method: "POST",
-        body: JSON.stringify({ lease_id: leaseId, run_id: "100" }),
+        body: JSON.stringify({
+          lease_id: leaseId,
+          item_key: "openclaw/gogcli#597",
+          lease_revision: 2,
+          run_id: "100",
+          run_attempt: 1,
+        }),
       }),
     );
     assert.equal(claimed.status, 200);
@@ -350,26 +354,52 @@ test("exact-review queue coalesces deliveries, leases bounded work, and rejects 
       ok: true,
       claimed: true,
       item_key: "openclaw/gogcli#597",
-      revision: 2,
+      lease_revision: 2,
+      claim_generation: 1,
+      decision: {
+        targetRepo: "openclaw/gogcli",
+        targetBranch: "main",
+        itemNumber: 597,
+        itemKind: "issue",
+        sourceEvent: "issues",
+        sourceAction: "edited",
+        supersedesInProgress: true,
+        commandStatusMarker,
+        statusCommentId: 9001,
+        additionalPrompt: "Check the maintainer-requested regression path.",
+        codexTimeoutMs: 1_200_000,
+        mediaProofTimeoutMs: 480_000,
+      },
     });
     assert.equal(
       (
         await queue.fetch(
           new Request("https://clawsweeper-exact-review-queue/claim", {
             method: "POST",
-            body: JSON.stringify({ lease_id: leaseId, run_id: "101" }),
+            body: JSON.stringify({
+              lease_id: leaseId,
+              item_key: "openclaw/gogcli#597",
+              lease_revision: 2,
+              run_id: "101",
+              run_attempt: 1,
+            }),
           }),
         )
       ).status,
       409,
     );
 
-    const newer = buildExactReviewQueueRequest("delivery-4", 597, "synchronize", "pull_request");
-    assert.equal((await queue.fetch(newer)).status, 202);
     const completed = await queue.fetch(
       new Request("https://clawsweeper-exact-review-queue/complete", {
         method: "POST",
-        body: JSON.stringify({ lease_id: leaseId, run_id: "100" }),
+        body: JSON.stringify({
+          lease_id: leaseId,
+          item_key: "openclaw/gogcli#597",
+          lease_revision: 2,
+          claim_generation: 1,
+          run_id: "100",
+          run_attempt: 1,
+        }),
       }),
     );
     assert.deepEqual(await completed.json(), { ok: true, requeued: true });
@@ -393,6 +423,273 @@ test("exact-review queue coalesces deliveries, leases bounded work, and rejects 
     assert.match(String(stats.oldest_pending_at), /^\d{4}-\d{2}-\d{2}T/);
   } finally {
     globalThis.fetch = originalFetch;
+  }
+});
+
+test("exact-review claim preserves its immutable decision across a newer enqueue", async () => {
+  const storage = new MemoryDurableStorage();
+  const item = unclaimedExactReviewQueueItem(620);
+  await storage.put("exact-review-queue", {
+    deliveries: {},
+    items: { "openclaw/openclaw#620": item },
+  });
+  const queue = new ExactReviewQueue({ storage }, {});
+
+  const newer = buildExactReviewQueueRequest(
+    "newer-620",
+    620,
+    "edited",
+    "pull_request",
+    "openclaw/openclaw",
+  );
+  assert.equal((await queue.fetch(newer)).status, 202);
+
+  const claim = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/claim", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: "lease-620",
+        item_key: "openclaw/openclaw#620",
+        lease_revision: 1,
+        run_id: "6200",
+        run_attempt: 1,
+      }),
+    }),
+  );
+  assert.equal(claim.status, 200);
+  assert.deepEqual(await claim.json(), {
+    ok: true,
+    claimed: true,
+    item_key: "openclaw/openclaw#620",
+    lease_revision: 1,
+    claim_generation: 1,
+    decision: item.leaseDecision,
+  });
+
+  const claimedState = (await storage.get("exact-review-queue")) as {
+    items: Record<
+      string,
+      {
+        revision: number;
+        decision: { sourceAction: string; itemKind: string };
+        leaseDecision: { sourceAction: string; itemKind: string };
+      }
+    >;
+  };
+  assert.equal(claimedState.items["openclaw/openclaw#620"].revision, 2);
+  assert.deepEqual(claimedState.items["openclaw/openclaw#620"].decision, {
+    targetRepo: "openclaw/openclaw",
+    targetBranch: "main",
+    itemNumber: 620,
+    itemKind: "pull_request",
+    sourceEvent: "pull_request",
+    sourceAction: "edited",
+    supersedesInProgress: true,
+  });
+  assert.deepEqual(claimedState.items["openclaw/openclaw#620"].leaseDecision, item.leaseDecision);
+
+  const complete = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: "lease-620",
+        item_key: "openclaw/openclaw#620",
+        lease_revision: 1,
+        claim_generation: 1,
+        run_id: "6200",
+        run_attempt: 1,
+        outcome: "success",
+      }),
+    }),
+  );
+  assert.equal(complete.status, 200);
+  assert.deepEqual(await complete.json(), { ok: true, requeued: true });
+
+  const requeued = (await storage.get("exact-review-queue")) as {
+    items: Record<string, Record<string, unknown>>;
+  };
+  assert.equal(requeued.items["openclaw/openclaw#620"].state, "pending");
+  assert.equal(requeued.items["openclaw/openclaw#620"].revision, 2);
+  assert.equal(
+    (requeued.items["openclaw/openclaw#620"].decision as { sourceAction: string }).sourceAction,
+    "edited",
+  );
+  assert.equal(requeued.items["openclaw/openclaw#620"].leaseDecision, undefined);
+});
+
+test("exact-review claims advance generations only for newer run attempts", async () => {
+  const storage = new MemoryDurableStorage();
+  await storage.put("exact-review-queue", {
+    deliveries: {},
+    items: { "openclaw/openclaw#621": unclaimedExactReviewQueueItem(621) },
+  });
+  const queue = new ExactReviewQueue({ storage }, {});
+  const claim = (runAttempt?: number) =>
+    queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/claim", {
+        method: "POST",
+        body: JSON.stringify({
+          lease_id: "lease-621",
+          item_key: "openclaw/openclaw#621",
+          lease_revision: 1,
+          run_id: "6210",
+          ...(runAttempt === undefined ? {} : { run_attempt: runAttempt }),
+        }),
+      }),
+    );
+
+  const first = await claim(1);
+  assert.equal(first.status, 200);
+  const firstPayload = await first.json();
+  assert.equal(firstPayload.claim_generation, 1);
+  assert.equal(firstPayload.lease_revision, 1);
+
+  const replay = await claim(1);
+  assert.equal(replay.status, 200);
+  assert.deepEqual(await replay.json(), firstPayload);
+
+  const nextAttempt = await claim(2);
+  assert.equal(nextAttempt.status, 200);
+  assert.equal((await nextAttempt.json()).claim_generation, 2);
+  const latestState = structuredClone(await storage.get("exact-review-queue"));
+
+  const staleAttempt = await claim(1);
+  assert.equal(staleAttempt.status, 409);
+  assert.deepEqual(await staleAttempt.json(), { error: "stale_run_attempt" });
+  assert.deepEqual(await storage.get("exact-review-queue"), latestState);
+
+  const missingAttempt = await claim();
+  assert.equal(missingAttempt.status, 409);
+  assert.deepEqual(await missingAttempt.json(), { error: "missing_run_attempt" });
+  assert.deepEqual(await storage.get("exact-review-queue"), latestState);
+
+  const staleCompletion = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: "lease-621",
+        item_key: "openclaw/openclaw#621",
+        lease_revision: 1,
+        claim_generation: 1,
+        run_id: "6210",
+        run_attempt: 1,
+        outcome: "failure",
+      }),
+    }),
+  );
+  assert.equal(staleCompletion.status, 409);
+  assert.deepEqual(await staleCompletion.json(), { error: "lease_not_claimed" });
+  assert.deepEqual(await storage.get("exact-review-queue"), latestState);
+});
+
+test("exact-review claim upgrades a legacy same-attempt generation", async () => {
+  const storage = new MemoryDurableStorage();
+  const item = unclaimedExactReviewQueueItem(622);
+  item.state = "leased";
+  item.claimedRunId = "6220";
+  item.claimedRunAttempt = 1;
+  item.leaseDecision = structuredClone(item.decision);
+  await storage.put("exact-review-queue", {
+    deliveries: {},
+    items: { "openclaw/openclaw#622": item },
+  });
+  const queue = new ExactReviewQueue({ storage }, {});
+  const response = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/claim", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: "lease-622",
+        item_key: "openclaw/openclaw#622",
+        lease_revision: 1,
+        run_id: "6220",
+        run_attempt: 1,
+      }),
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal((await response.json()).claim_generation, 1);
+  const stored = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { claimGeneration?: number }>;
+  };
+  assert.equal(stored.items["openclaw/openclaw#622"].claimGeneration, 1);
+});
+
+test("exact-review claim and completion reject forged or incomplete lease tuples", async () => {
+  const storage = new MemoryDurableStorage();
+  await storage.put("exact-review-queue", {
+    deliveries: {},
+    items: {
+      "openclaw/openclaw#622": unclaimedExactReviewQueueItem(622),
+      "openclaw/openclaw#623": unclaimedExactReviewQueueItem(623),
+    },
+  });
+  const queue = new ExactReviewQueue({ storage }, {});
+  const claimBase = {
+    lease_id: "lease-622",
+    item_key: "openclaw/openclaw#622",
+    lease_revision: 1,
+    run_id: "6220",
+    run_attempt: 1,
+  };
+  const initialState = structuredClone(await storage.get("exact-review-queue"));
+  const invalidClaims = [
+    { body: { ...claimBase, item_key: undefined }, status: 400 },
+    { body: { ...claimBase, lease_revision: undefined }, status: 400 },
+    { body: { ...claimBase, item_key: "openclaw/openclaw#623" }, status: 409 },
+    { body: { ...claimBase, lease_revision: 2 }, status: 409 },
+    {
+      body: {
+        ...claimBase,
+        lease_id: "lease-623",
+        item_key: "openclaw/openclaw#622",
+      },
+      status: 409,
+    },
+  ];
+  for (const candidate of invalidClaims) {
+    const response = await queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/claim", {
+        method: "POST",
+        body: JSON.stringify(candidate.body),
+      }),
+    );
+    assert.equal(response.status, candidate.status);
+    assert.deepEqual(await storage.get("exact-review-queue"), initialState);
+  }
+
+  const validClaim = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/claim", {
+      method: "POST",
+      body: JSON.stringify(claimBase),
+    }),
+  );
+  assert.equal(validClaim.status, 200);
+  assert.equal((await validClaim.json()).claim_generation, 1);
+
+  const completeBase = {
+    ...claimBase,
+    claim_generation: 1,
+    outcome: "failure",
+  };
+  const claimedState = structuredClone(await storage.get("exact-review-queue"));
+  const invalidCompletions = [
+    { body: { ...completeBase, item_key: undefined }, status: 400 },
+    { body: { ...completeBase, item_key: "openclaw/openclaw#623" }, status: 409 },
+    { body: { ...completeBase, lease_revision: undefined }, status: 400 },
+    { body: { ...completeBase, lease_revision: 2 }, status: 409 },
+    { body: { ...completeBase, claim_generation: undefined }, status: 400 },
+    { body: { ...completeBase, claim_generation: 2 }, status: 409 },
+  ];
+  for (const candidate of invalidCompletions) {
+    const response = await queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/complete", {
+        method: "POST",
+        body: JSON.stringify(candidate.body),
+      }),
+    );
+    assert.equal(response.status, candidate.status);
+    assert.deepEqual(await storage.get("exact-review-queue"), claimedState);
   }
 });
 
@@ -459,7 +756,8 @@ test("exact-review queue admits at most one active item per target repository", 
     const nextAlarm = await storage.getAlarm();
     assert.ok(nextAlarm && nextAlarm > Date.now() + 60_000);
     const targets = dispatched.map(
-      (payload) => (payload.client_payload as Record<string, unknown>).target_repo,
+      (payload) =>
+        String((payload.client_payload as Record<string, unknown>).item_key).split("#", 1)[0],
     );
     assert.equal(new Set(targets).size, 2);
     assert.equal(targets.filter((target) => target === "openclaw/gogcli").length, 1);
@@ -831,13 +1129,20 @@ test("exact-review queue preserves a claimed lease after an ambiguous dispatch f
     const alarm = queue.alarm();
     await dispatchStarted;
     const dispatching = (await storage.get("exact-review-queue")) as {
-      items: Record<string, { leaseId: string }>;
+      items: Record<string, { leaseId: string; leaseRevision: number }>;
     };
-    const leaseId = dispatching.items["openclaw/gogcli#601"].leaseId;
+    const dispatchingItem = dispatching.items["openclaw/gogcli#601"];
+    const leaseId = dispatchingItem.leaseId;
     const claim = await queue.fetch(
       new Request("https://clawsweeper-exact-review-queue/claim", {
         method: "POST",
-        body: JSON.stringify({ lease_id: leaseId, run_id: "ambiguous-run" }),
+        body: JSON.stringify({
+          lease_id: leaseId,
+          item_key: "openclaw/gogcli#601",
+          lease_revision: dispatchingItem.leaseRevision,
+          run_id: "6010",
+          run_attempt: 1,
+        }),
       }),
     );
     assert.equal(claim.status, 200);
@@ -854,7 +1159,14 @@ test("exact-review queue preserves a claimed lease after an ambiguous dispatch f
     const completed = await queue.fetch(
       new Request("https://clawsweeper-exact-review-queue/complete", {
         method: "POST",
-        body: JSON.stringify({ lease_id: leaseId, run_id: "ambiguous-run" }),
+        body: JSON.stringify({
+          lease_id: leaseId,
+          item_key: "openclaw/gogcli#601",
+          lease_revision: dispatchingItem.leaseRevision,
+          claim_generation: 1,
+          run_id: "6010",
+          run_attempt: 1,
+        }),
       }),
     );
     assert.deepEqual(await completed.json(), { ok: true, requeued: false, deferred: true });
@@ -881,7 +1193,7 @@ test("exact-review queue requeues a cancelled claimed lease", async () => {
       retryAt,
     },
     items: {
-      "openclaw/openclaw#710": leasedExactReviewQueueItem(710, "cancelled-run"),
+      "openclaw/openclaw#710": leasedExactReviewQueueItem(710, "7100"),
     },
   });
   const queue = new ExactReviewQueue({ storage }, {});
@@ -891,7 +1203,10 @@ test("exact-review queue requeues a cancelled claimed lease", async () => {
       method: "POST",
       body: JSON.stringify({
         lease_id: "lease-710",
-        run_id: "cancelled-run",
+        item_key: "openclaw/openclaw#710",
+        lease_revision: 1,
+        claim_generation: 1,
+        run_id: "7100",
         run_attempt: 1,
         outcome: "cancelled",
       }),
@@ -919,7 +1234,7 @@ test("exact-review queue defers a coordination-held failure until the lease expi
   await storage.put("exact-review-queue", {
     deliveries: {},
     items: {
-      "openclaw/openclaw#711": leasedExactReviewQueueItem(711, "held-run"),
+      "openclaw/openclaw#711": leasedExactReviewQueueItem(711, "7110"),
     },
   });
   const queue = new ExactReviewQueue({ storage }, {});
@@ -929,7 +1244,10 @@ test("exact-review queue defers a coordination-held failure until the lease expi
       method: "POST",
       body: JSON.stringify({
         lease_id: "lease-711",
-        run_id: "held-run",
+        item_key: "openclaw/openclaw#711",
+        lease_revision: 1,
+        claim_generation: 1,
+        run_id: "7110",
         run_attempt: 1,
         outcome: "failure",
         retry_at: new Date(retryAt).toISOString(),
@@ -949,7 +1267,7 @@ test("exact-review queue defers a coordination-held failure until the lease expi
 test("exact-review queue does not carry an old coordination deadline to a newer revision", async () => {
   const storage = new MemoryDurableStorage();
   const retryAt = Date.now() + 45 * 60_000;
-  const item = leasedExactReviewQueueItem(712, "held-run");
+  const item = leasedExactReviewQueueItem(712, "7120");
   item.revision = Number(item.leaseRevision) + 1;
   await storage.put("exact-review-queue", {
     deliveries: {},
@@ -962,7 +1280,10 @@ test("exact-review queue does not carry an old coordination deadline to a newer 
       method: "POST",
       body: JSON.stringify({
         lease_id: "lease-712",
-        run_id: "held-run",
+        item_key: "openclaw/openclaw#712",
+        lease_revision: 1,
+        claim_generation: 1,
+        run_id: "7120",
         run_attempt: 1,
         outcome: "failure",
         retry_at: new Date(retryAt).toISOString(),
@@ -985,7 +1306,10 @@ test("exact-review queue rejects invalid coordination retry deadlines", async ()
         method: "POST",
         body: JSON.stringify({
           lease_id: "lease-712",
-          run_id: "held-run",
+          item_key: "openclaw/openclaw#712",
+          lease_revision: 1,
+          claim_generation: 1,
+          run_id: "7120",
           run_attempt: 1,
           outcome: "failure",
           retry_at: retryAt,
@@ -1012,6 +1336,9 @@ test("exact-review queue requeues a verified source drift exactly once without f
         method: "POST",
         body: JSON.stringify({
           lease_id: "lease-713",
+          item_key: "openclaw/openclaw#713",
+          lease_revision: 1,
+          claim_generation: 1,
           run_id: "9113",
           run_attempt: 1,
           outcome: "success",
@@ -1066,7 +1393,7 @@ test("exact-review queue requeues a verified source drift exactly once without f
 
 test("exact-review source-drift requeue preserves an already-enqueued latest decision", async () => {
   const storage = new MemoryDurableStorage();
-  const item = leasedExactReviewQueueItem(714, "drift-run");
+  const item = leasedExactReviewQueueItem(714, "7140");
   item.revision = 2;
   item.decision.sourceAction = "edited";
   await storage.put("exact-review-queue", {
@@ -1080,7 +1407,10 @@ test("exact-review source-drift requeue preserves an already-enqueued latest dec
       method: "POST",
       body: JSON.stringify({
         lease_id: "lease-714",
-        run_id: "drift-run",
+        item_key: "openclaw/openclaw#714",
+        lease_revision: 1,
+        claim_generation: 1,
+        run_id: "7140",
         run_attempt: 1,
         outcome: "success",
         requeue_latest: true,
@@ -1109,7 +1439,10 @@ test("exact-review queue rejects invalid source-drift requeue requests", async (
         method: "POST",
         body: JSON.stringify({
           lease_id: "lease-715",
-          run_id: "drift-run",
+          item_key: "openclaw/openclaw#715",
+          lease_revision: 1,
+          claim_generation: 1,
+          run_id: "7150",
           run_attempt: 1,
           ...body,
         }),
@@ -1129,12 +1462,21 @@ test("exact-review completion rejects stale owners and is race-idempotent", asyn
     },
   });
   const queue = new ExactReviewQueue({ storage }, {});
-  const complete = (leaseId: string, runId: string, runAttempt: number, outcome: string) =>
+  const complete = (
+    itemNumber: number,
+    leaseId: string,
+    runId: string,
+    runAttempt: number,
+    outcome: string,
+  ) =>
     queue.fetch(
       new Request("https://clawsweeper-exact-review-queue/complete", {
         method: "POST",
         body: JSON.stringify({
           lease_id: leaseId,
+          item_key: `openclaw/openclaw#${itemNumber}`,
+          lease_revision: 1,
+          claim_generation: 1,
           run_id: runId,
           run_attempt: runAttempt,
           outcome,
@@ -1142,17 +1484,17 @@ test("exact-review completion rejects stale owners and is race-idempotent", asyn
       }),
     );
 
-  assert.equal((await complete("lease-716", "9100", 1, "failure")).status, 409);
-  assert.equal((await complete("lease-716", "wrong-run", 2, "failure")).status, 409);
-  const failed = await complete("lease-716", "9100", 2, "failure");
+  assert.equal((await complete(716, "lease-716", "9100", 1, "failure")).status, 409);
+  assert.equal((await complete(716, "lease-716", "9999", 2, "failure")).status, 409);
+  const failed = await complete(716, "lease-716", "9100", 2, "failure");
   assert.equal(failed.status, 200);
   assert.deepEqual(await failed.json(), { ok: true, requeued: true });
-  assert.equal((await complete("lease-716", "9100", 2, "success")).status, 409);
+  assert.equal((await complete(716, "lease-716", "9100", 2, "success")).status, 409);
 
-  const completed = await complete("lease-717", "9101", 1, "success");
+  const completed = await complete(717, "lease-717", "9101", 1, "success");
   assert.equal(completed.status, 200);
   assert.deepEqual(await completed.json(), { ok: true, requeued: false, deferred: true });
-  const failedAfterProvisionalSuccess = await complete("lease-717", "9101", 1, "failure");
+  const failedAfterProvisionalSuccess = await complete(717, "lease-717", "9101", 1, "failure");
   assert.equal(failedAfterProvisionalSuccess.status, 200);
   assert.deepEqual(await failedAfterProvisionalSuccess.json(), { ok: true, requeued: true });
 
@@ -1292,6 +1634,9 @@ test("signed exact-review reconciliation releases only immutable terminal runs",
         method: "POST",
         body: JSON.stringify({
           lease_id: "lease-719",
+          item_key: "openclaw/openclaw#719",
+          lease_revision: 1,
+          claim_generation: 1,
           run_id: "9003",
           run_attempt: 1,
           outcome: "failure",
@@ -1371,7 +1716,13 @@ test("exact-review reconciliation targets leases beyond 64 entries without accep
       const claim = await queue.fetch(
         new Request("https://clawsweeper-exact-review-queue/claim", {
           method: "POST",
-          body: JSON.stringify({ lease_id: "lease-8066", run_id: "9902", run_attempt: 2 }),
+          body: JSON.stringify({
+            lease_id: "lease-8066",
+            item_key: "openclaw/openclaw#8066",
+            lease_revision: 1,
+            run_id: "9902",
+            run_attempt: 2,
+          }),
         }),
       );
       assert.equal(claim.status, 200);
@@ -1486,7 +1837,13 @@ test("exact-review reconciliation cannot release a later attempt with the same r
       const claim = await queue.fetch(
         new Request("https://clawsweeper-exact-review-queue/claim", {
           method: "POST",
-          body: JSON.stringify({ lease_id: "lease-713", run_id: "9010", run_attempt: 2 }),
+          body: JSON.stringify({
+            lease_id: "lease-713",
+            item_key: "openclaw/openclaw#713",
+            lease_revision: 1,
+            run_id: "9010",
+            run_attempt: 2,
+          }),
         }),
       );
       assert.equal(claim.status, 200);
@@ -5416,17 +5773,19 @@ function buildExactReviewQueueRequest(
 
 function leasedExactReviewQueueItem(itemNumber: number, runId: string, runAttempt = 1) {
   const now = Date.now();
+  const decision = {
+    targetRepo: "openclaw/openclaw",
+    targetBranch: "main",
+    itemNumber,
+    itemKind: "issue" as const,
+    sourceEvent: "issues",
+    sourceAction: "opened",
+    supersedesInProgress: false,
+  };
   return {
     key: `openclaw/openclaw#${itemNumber}`,
-    decision: {
-      targetRepo: "openclaw/openclaw",
-      targetBranch: "main",
-      itemNumber,
-      itemKind: "issue",
-      sourceEvent: "issues",
-      sourceAction: "opened",
-      supersedesInProgress: false,
-    },
+    decision,
+    leaseDecision: { ...decision },
     state: "leased",
     revision: 1,
     createdAt: now - 60_000,
@@ -5439,5 +5798,15 @@ function leasedExactReviewQueueItem(itemNumber: number, runId: string, runAttemp
     claimedRunId: runId,
     claimedRunAttempt: runAttempt,
     claimGeneration: 1,
+  };
+}
+
+function unclaimedExactReviewQueueItem(itemNumber: number) {
+  return {
+    ...leasedExactReviewQueueItem(itemNumber, "unclaimed"),
+    state: "dispatching" as const,
+    claimedRunId: undefined,
+    claimedRunAttempt: undefined,
+    claimGeneration: undefined,
   };
 }

--- a/test/failed-review-retry.test.ts
+++ b/test/failed-review-retry.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
 
@@ -174,6 +174,44 @@ test("failed review retry eligibility requires infrastructure failure and matchi
   );
 });
 
+test("failed review retry does not redispatch locked or closed no-action items", () => {
+  const now = Date.parse("2026-07-10T16:00:00Z");
+  const locked = failedReviewRetryEligibilityForTest({
+    markdown: failedReviewReport({
+      number: 64319,
+      type: "issue",
+      pull_head_sha: "unknown",
+      item_source_revision: "unknown",
+    }),
+    liveState: "open",
+    liveLocked: true,
+    liveActiveLockReason: "resolved",
+    now,
+    maxAttempts: 2,
+    cooldownMs: 45 * 60 * 1000,
+  });
+  assert.deepEqual(
+    { number: locked.number, action: locked.action, reason: locked.reason },
+    {
+      number: 64319,
+      action: "skipped_locked_conversation",
+      reason: "conversation is locked (resolved)",
+    },
+  );
+
+  const closed = failedReviewRetryEligibilityForTest({
+    markdown: failedReviewReport({ number: 3050 }),
+    liveState: "closed",
+    now,
+    maxAttempts: 2,
+    cooldownMs: 45 * 60 * 1000,
+  });
+  assert.deepEqual(
+    { number: closed.number, action: closed.action, reason: closed.reason },
+    { number: 3050, action: "skipped_not_open", reason: "state is closed" },
+  );
+});
+
 test("failed issue reviews retry at a matching live source revision", () => {
   const markdown = failedReviewReport({
     type: "issue",
@@ -246,6 +284,44 @@ test("failed issue reviews retry at a matching live source revision", () => {
     }).action,
     "skipped_retry_exhausted",
   );
+});
+
+test("failed issue retry never dispatches a locked live item", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const fixture = failedIssueRetryFixture(root, 64319);
+  const dispatchPath = join(root, "dispatch.json");
+  fixture.issue.locked = true;
+  fixture.issue.active_lock_reason = "resolved";
+  try {
+    withMockGh(
+      root,
+      issueRetryGhMock(
+        fixture.issue,
+        `require("node:fs").writeFileSync(${JSON.stringify(dispatchPath)}, "dispatched"); process.exit(0);`,
+      ),
+      () => runFailedIssueRetry(fixture),
+    );
+
+    const report = JSON.parse(readFileSync(fixture.reportPath, "utf8")) as Array<{
+      number: number;
+      action: string;
+      reason: string;
+    }>;
+    assert.deepEqual(
+      report.map(({ number, action, reason }) => ({ number, action, reason })),
+      [
+        {
+          number: 64319,
+          action: "skipped_locked_conversation",
+          reason: "conversation is locked (resolved)",
+        },
+      ],
+    );
+    assert.equal(existsSync(dispatchPath), false);
+    assert.equal(existsSync(fixture.statePath), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("failed review retry eligibility treats Codex rate limits as infrastructure failures", () => {

--- a/test/repair/event-apply-proof.test.ts
+++ b/test/repair/event-apply-proof.test.ts
@@ -151,6 +151,7 @@ test("exact event proof accepts durable sync independently of the apply action n
   assert.equal(proof.syncedCount, 1);
   assert.equal(proof.terminalMissingCount, 0);
   assert.equal(proof.terminalCount, 0);
+  assert.equal(proof.disposition, "applied");
 });
 
 test("ordinary kept-open sync cannot route after its live tuple changes", () => {
@@ -224,6 +225,38 @@ test("exact event proof accepts verified terminal state and rejects action names
   assert.equal(proof.syncedCount, 0);
   assert.equal(proof.terminalCount, 1);
   assert.equal(proof.exactActions.length, 2);
+  assert.equal(proof.disposition, "applied");
+});
+
+test("exact event proof accepts only explicit trusted no-action dispositions", () => {
+  const terminalPolicy = exactEventApplyProof(
+    [
+      eventApplyAction({
+        number: 42,
+        action: "skipped_same_author_pair",
+        terminalPolicyNoopVerified: true,
+      }),
+    ],
+    42,
+  );
+  const sourceDrift = exactEventApplyProof(
+    [
+      eventApplyAction({
+        number: 42,
+        action: "skipped_changed_since_review",
+        sourceDriftVerified: true,
+      }),
+    ],
+    42,
+  );
+  const unproven = exactEventApplyProof(
+    [eventApplyAction({ number: 42, action: "skipped_same_author_pair" })],
+    42,
+  );
+
+  assert.equal(terminalPolicy.disposition, "terminal_policy_noop");
+  assert.equal(sourceDrift.disposition, "source_drift");
+  assert.equal(unproven.disposition, "unproven");
 });
 
 test("exact event proof completes live-shaped deterministic guarded-open results", () => {

--- a/test/repair/event-apply-proof.test.ts
+++ b/test/repair/event-apply-proof.test.ts
@@ -258,7 +258,6 @@ test("exact event proof accepts only explicit trusted no-action dispositions", (
   assert.equal(sourceDrift.disposition, "source_drift");
   assert.equal(unproven.disposition, "unproven");
 });
-
 test("exact event proof completes live-shaped deterministic guarded-open results", () => {
   for (const action of [
     "skipped_same_author_pair",
@@ -357,4 +356,36 @@ test("event record action parsing ignores body lookalikes", () => {
     ),
     null,
   );
+});
+
+test("verified source drift overrides an earlier durable sync", () => {
+  const verified = exactEventApplyProof(
+    [
+      eventApplyAction({
+        number: 42,
+        action: "review_comment_synced",
+        durableReviewSynced: true,
+      }),
+      eventApplyAction({
+        number: 42,
+        action: "skipped_changed_since_review",
+        sourceDriftVerified: true,
+      }),
+    ],
+    42,
+  );
+  const unverified = exactEventApplyProof(
+    [
+      eventApplyAction({
+        number: 42,
+        action: "review_comment_synced",
+        durableReviewSynced: true,
+      }),
+      eventApplyAction({ number: 42, action: "skipped_changed_since_review" }),
+    ],
+    42,
+  );
+
+  assert.equal(verified.disposition, "source_drift");
+  assert.equal(unverified.disposition, "unproven");
 });

--- a/test/repair/workflow-sparse-checkout.test.ts
+++ b/test/repair/workflow-sparse-checkout.test.ts
@@ -69,7 +69,7 @@ test("repair comment router workflow preserves repository dispatch target branch
   );
 });
 
-test("sweep workflow preserves workflow dispatch target branch", () => {
+test("sweep workflow preserves manual target branches and hydrates exact branches live", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const dispatchTargetBranchResolver =
     /target_branch="\$\{\{ github\.event_name == 'workflow_dispatch' && github\.event\.inputs\.target_branch \|\| github\.event\.client_payload\.target_branch \|\| 'main' \}\}"/g;
@@ -77,8 +77,13 @@ test("sweep workflow preserves workflow dispatch target branch", () => {
     /-f target_branch="\$\{\{ needs\.plan\.outputs\.target_branch \}\}"/g;
 
   assert.match(workflow, /target_branch:\n\s+description: "Target repository branch to review"/);
-  assert.equal([...workflow.matchAll(dispatchTargetBranchResolver)].length, 2);
+  assert.equal([...workflow.matchAll(dispatchTargetBranchResolver)].length, 1);
   assert.equal([...workflow.matchAll(continuationTargetBranch)].length, 2);
+  assert.match(
+    workflow,
+    /target_branch="\$\(gh api "repos\/\$TARGET_REPO" --jq \.default_branch\)"/,
+  );
+  assert.match(workflow, /target_branch="\$\{\{ steps\.live-item\.outputs\.target_branch \}\}"/);
 });
 
 function sparseCheckoutEntries(workflow: string): Set<string> {

--- a/test/review-comment-rendering.test.ts
+++ b/test/review-comment-rendering.test.ts
@@ -6,6 +6,7 @@ import {
   canPatchReviewComment,
   itemSourceRevisionSha256ForTest,
   isCodexReviewCommentBody,
+  newReviewStartLeaseOwnerForTest,
   renderReviewCommentFromReport,
   renderReviewStartStatusComment,
   reviewAutomationMarkersFromReport,
@@ -58,6 +59,23 @@ function implementedCloseReport(overrides = {}) {
   ].join("\n");
 }
 
+test("GitHub workflow review leases use a recoverable run identity", () => {
+  assert.equal(
+    newReviewStartLeaseOwnerForTest(
+      { GITHUB_RUN_ID: "29083888985", GITHUB_RUN_ATTEMPT: "2" },
+      () => "random-owner",
+    ),
+    "github-run-29083888985-2",
+  );
+  assert.equal(
+    newReviewStartLeaseOwnerForTest(
+      { GITHUB_RUN_ID: "29083888985", GITHUB_RUN_ATTEMPT: "invalid" },
+      () => "random-owner",
+    ),
+    "random-owner",
+  );
+});
+
 test("comment matcher recognizes old and new Codex review comments", () => {
   assert.equal(
     isCodexReviewCommentBody(
@@ -99,6 +117,8 @@ test("review start lease is acquired before cache reuse and slow media preproces
   assert.ok(startLease >= 0);
   assert.ok(cacheHit > startLease);
   assert.ok(mediaPrep > cacheHit);
+  assert.match(source, /coordination-held\.json/);
+  assert.match(source, /coordinationHeldRetryAt = startComment\.retryAt/);
 });
 
 test("review comment patching only targets ClawSweeper-owned comments", () => {
@@ -124,7 +144,7 @@ test("spoofed durable markers cannot suppress a bot-owned start lease", () => {
   );
   assert.match(postStart, /issueReviewCommentState\(options\.item\.number\)/);
   assert.match(postStart, /freshDedicatedReviewStartLeases\(\{/);
-  assert.match(postStart, /return \{ status: "held", lease: null \}/);
+  assert.match(postStart, /return \{ status: "held", lease: null, retryAt: [^}]+\.expiresAt \}/);
   assert.match(postStart, /issues\/\$\{options\.item\.number\}\/comments/);
 });
 

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -325,10 +325,13 @@ test("exact event workflow binds all work to the canonical queue claim", () => {
   const claimStep = eventJob.slice(claimStart, checkoutStart);
   const claimedWork = eventJob.slice(checkoutStart);
 
-  assert.match(claimStep, /ITEM_KEY: \$\{\{ github\.event\.client_payload\.item_key \}\}/);
   assert.match(
     claimStep,
-    /QUEUE_LEASE_REVISION: \$\{\{ github\.event\.client_payload\.lease_revision \}\}/,
+    /ITEM_KEY: \$\{\{ github\.event\.client_payload\.queue_claim\.item_key \|\| github\.event\.client_payload\.item_key \}\}/,
+  );
+  assert.match(
+    claimStep,
+    /QUEUE_LEASE_REVISION: \$\{\{ github\.event\.client_payload\.queue_claim\.lease_revision \|\| github\.event\.client_payload\.lease_revision \}\}/,
   );
   assert.match(
     claimStep,
@@ -1701,7 +1704,7 @@ test("sweep event reviews and target fanout avoid storm amplification", () => {
   assert.match(eventBlock, /concurrency:/);
   assert.match(
     eventBlock,
-    /group: clawsweeper-event-review-\$\{\{ github\.event\.client_payload\.item_key \|\| github\.run_id \}\}/,
+    /group: clawsweeper-event-review-\$\{\{ github\.event\.client_payload\.queue_claim\.item_key \|\| github\.event\.client_payload\.item_key \|\| github\.run_id \}\}/,
   );
   assert.match(eventBlock, /queue_lease_id != ''/);
   assert.match(eventBlock, /item_key: process\.env\.ITEM_KEY/);

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -160,6 +160,7 @@ test("exact event publish and routing require a successful fresh review artifact
   assert.match(publisher, /routing_deferred=/);
   assert.match(publisher, /class GuardedOpenPublishRaceError extends Error/);
   assert.match(publisher, /class RoutableSyncPublishRaceError extends Error/);
+  assert.match(publisher, /class SourceDriftPublishRaceError extends Error/);
   assert.match(publisher, /class TerminalClosedPublishRaceError extends Error/);
   assert.match(publisher, /class TerminalMissingPublishRaceError extends Error/);
   assert.match(publisher, /terminalClosedExpected: closedCount > 0/);
@@ -174,9 +175,12 @@ test("exact event publish and routing require a successful fresh review artifact
   assert.match(publisher, /guardedOpenAction !== null/);
   assert.match(publisher, /error instanceof GuardedOpenPublishRaceError/);
   assert.match(publisher, /error instanceof RoutableSyncPublishRaceError/);
+  assert.match(publisher, /error instanceof SourceDriftPublishRaceError/);
   assert.match(publisher, /error instanceof TerminalClosedPublishRaceError/);
   assert.match(publisher, /error instanceof TerminalMissingPublishRaceError/);
   assert.match(publisher, /Event state .* was not applied because .*requeue/);
+  assert.match(publisher, /policy_noop=/);
+  assert.match(publisher, /requeue_latest=/);
   assert.doesNotMatch(publisher, /entry\.action === "review_comment_synced"/);
   assert.ok(authoritativeReset > publisherCompleteStart);
   assert.ok(authoritativeRefresh > authoritativeReset);
@@ -188,6 +192,8 @@ test("exact event publish and routing require a successful fresh review artifact
   assert.match(routeStep, /steps\.publish-event-result\.outputs\.guarded_open != 'true'/);
   assert.match(routeStep, /steps\.publish-event-result\.outputs\.remote_tuple_verified == 'true'/);
   assert.match(routeStep, /steps\.publish-event-result\.outputs\.routing_deferred == 'false'/);
+  assert.match(routeStep, /steps\.publish-event-result\.outputs\.policy_noop != 'true'/);
+  assert.match(routeStep, /steps\.publish-event-result\.outputs\.requeue_latest != 'true'/);
   assert.doesNotMatch(routeStep, /outputs\.routing_deferred != 'true'/);
   assert.match(
     deferredRouteStep,
@@ -278,11 +284,32 @@ test("exact event publish and routing require a successful fresh review artifact
   assert.match(failStep, /steps\.publish-event-result\.outputs\.guarded_open != 'true'/);
   assert.match(failStep, /steps\.route-synced-verdict\.outcome != 'success'/);
   assert.match(failStep, /steps\.queue-deferred-verdict-router\.outcome != 'success'/);
+  assert.match(failStep, /steps\.publish-event-result\.outputs\.policy_noop != 'true'/);
+  assert.match(failStep, /steps\.publish-event-result\.outputs\.requeue_latest != 'true'/);
   assert.match(
     eventReviewJob,
     /RETRY_AT: \$\{\{ steps\.review-exact-event-item\.outputs\.retry_at \}\}/,
   );
   assert.match(eventReviewJob, /\.\.\.\(retryAt \? \{ retry_at: retryAt \} : \{\}\)/);
+  assert.match(
+    eventReviewJob,
+    /REQUEUE_LATEST: \$\{\{ steps\.publish-event-result\.outputs\.requeue_latest \}\}/,
+  );
+  assert.match(eventReviewJob, /\.\.\.\(requeueLatest \? \{ requeue_latest: true \} : \{\}\)/);
+  assert.match(eventReviewJob, /id: complete-exact-review-queue/);
+  assert.match(
+    eventReviewJob,
+    /Fail unacknowledged source-drift requeue[\s\S]*steps\.complete-exact-review-queue\.outcome != 'success'/,
+  );
+  const reReviewStatus = eventReviewJob.indexOf("- name: Mark re-review complete");
+  const completeQueue = eventReviewJob.indexOf("- name: Complete exact-review queue lease");
+  assert.ok(reReviewStatus > 0 && completeQueue > reReviewStatus);
+  assert.match(eventReviewJob, /This run is returning it to the exact-review queue/);
+  assert.match(
+    eventReviewJob,
+    /React to target item completion[\s\S]*steps\.publish-event-result\.outputs\.policy_noop == 'true'/,
+  );
+  assert.match(eventReviewJob, /if \[ "\$POLICY_NOOP" != "true" \]; then/);
 });
 
 test("dashboard syncs Worker secrets with durable lifecycle storage", () => {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -351,7 +351,10 @@ test("exact event workflow binds all work to the canonical queue claim", () => {
     claimedWork,
     /CLAIM_DECISION: \$\{\{ steps\.claim-exact-review-queue\.outputs\.decision \}\}/,
   );
-  assert.match(claimedWork, /const decision = JSON\.parse\(process\.env\.CLAIM_DECISION \|\| "\{\}"\)/);
+  assert.match(
+    claimedWork,
+    /const decision = JSON\.parse\(process\.env\.CLAIM_DECISION \|\| "\{\}"\)/,
+  );
   assert.match(
     claimedWork,
     /CLAIM_GENERATION: \$\{\{ steps\.claim-exact-review-queue\.outputs\.claim_generation \}\}/,

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -40,6 +40,13 @@ test("review workflow gives Codex a read-only inspection token", () => {
     exactReviewStep,
     /CLAWSWEEPER_PROOF_INSPECTION_TOKEN: \$\{\{ steps\.target-read-token\.outputs\.token \|\| github\.token \}\}/,
   );
+  assert.match(
+    exactReviewStep,
+    /report_path="artifacts\/event\/\$\{\{ steps\.target\.outputs\.item_number \}\}\.md"/,
+  );
+  assert.match(exactReviewStep, /coordination-held\.json/);
+  assert.match(exactReviewStep, /echo "retry_at=\$retry_at" >> "\$GITHUB_OUTPUT"/);
+  assert.match(exactReviewStep, /Exact review produced no artifact for open item/);
   assert.match(reviewJob, /uses: \.\/clawsweeper\/\.github\/actions\/setup-codex/);
   assert.doesNotMatch(reviewJob, /uses: \.\/\.github\/actions\/setup-codex/);
 });
@@ -56,6 +63,10 @@ test("exact event publish and routing require a successful fresh review artifact
   const setupCodexStart = eventReviewJob.indexOf("- uses: ./.github/actions/setup-codex");
   const exactReviewStart = eventReviewJob.indexOf("- name: Review exact event item");
   const publishStart = eventReviewJob.indexOf("- name: Publish event result and apply safe close");
+  const releaseUnsuccessfulStart = eventReviewJob.indexOf(
+    "- name: Release unsuccessful workflow-owned review lease",
+    publishStart,
+  );
   const routeStart = eventReviewJob.indexOf("- name: Route synced ClawSweeper verdict");
   const deferredRouteStart = eventReviewJob.indexOf(
     "- name: Queue deferred exact verdict router",
@@ -75,7 +86,8 @@ test("exact event publish and routing require a successful fresh review artifact
   const liveItemStep = eventReviewJob.slice(liveItemStart, setupPnpmStart);
   const setupCodexStep = eventReviewJob.slice(setupCodexStart, exactReviewStart);
   const exactReviewStep = eventReviewJob.slice(exactReviewStart, publishStart);
-  const publishStep = eventReviewJob.slice(publishStart, routeStart);
+  const publishStep = eventReviewJob.slice(publishStart, releaseUnsuccessfulStart);
+  const releaseUnsuccessfulStep = eventReviewJob.slice(releaseUnsuccessfulStart, routeStart);
   const routeStep = eventReviewJob.slice(routeStart, deferredRouteStart);
   const deferredRouteStep = eventReviewJob.slice(deferredRouteStart, releaseLeaseStart);
   const reactStep = eventReviewJob.slice(reactStart, failStart);
@@ -129,6 +141,16 @@ test("exact event publish and routing require a successful fresh review artifact
   assert.match(publishStep, /gh api "repos\/\$TARGET_REPO" >\/dev\/null/);
   assert.match(publishStep, /cat "\$live_item_error" >&2/);
   assert.match(publishStep, /Exact review produced no artifact for open item/);
+  assert.ok(releaseUnsuccessfulStart > publishStart);
+  assert.match(releaseUnsuccessfulStep, /always\(\)/);
+  assert.match(
+    releaseUnsuccessfulStep,
+    /github-run-\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}/,
+  );
+  assert.match(releaseUnsuccessfulStep, /clawsweeper-review-lease item=\$ITEM_NUMBER/);
+  assert.match(releaseUnsuccessfulStep, /owner=\$LEASE_OWNER/);
+  assert.match(releaseUnsuccessfulStep, /issues\/comments\/\$lease_id/);
+  assert.match(releaseUnsuccessfulStep, /--method DELETE/);
   assert.match(publisher, /"--event-apply-proof"/);
   assert.match(publisher, /exactEventApplyProof\(/);
   assert.match(publisher, /terminal_missing=/);
@@ -256,6 +278,11 @@ test("exact event publish and routing require a successful fresh review artifact
   assert.match(failStep, /steps\.publish-event-result\.outputs\.guarded_open != 'true'/);
   assert.match(failStep, /steps\.route-synced-verdict\.outcome != 'success'/);
   assert.match(failStep, /steps\.queue-deferred-verdict-router\.outcome != 'success'/);
+  assert.match(
+    eventReviewJob,
+    /RETRY_AT: \$\{\{ steps\.review-exact-event-item\.outputs\.retry_at \}\}/,
+  );
+  assert.match(eventReviewJob, /\.\.\.\(retryAt \? \{ retry_at: retryAt \} : \{\}\)/);
 });
 
 test("dashboard syncs Worker secrets with durable lifecycle storage", () => {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -153,6 +153,7 @@ test("exact event publish and routing require a successful fresh review artifact
   assert.match(releaseUnsuccessfulStep, /--method DELETE/);
   assert.match(publisher, /"--event-apply-proof"/);
   assert.match(publisher, /exactEventApplyProof\(/);
+  assert.match(publisher, /const requeueLatestExpected = applyDisposition === "source_drift"/);
   assert.match(publisher, /terminal_missing=/);
   assert.match(publisher, /terminal_closed=/);
   assert.match(publisher, /guarded_open=/);
@@ -354,6 +355,22 @@ test("exact event workflow binds all work to the canonical queue claim", () => {
   assert.match(
     claimedWork,
     /const decision = JSON\.parse\(process\.env\.CLAIM_DECISION \|\| "\{\}"\)/,
+  );
+  assert.match(
+    claimedWork,
+    /targetRepo !== "openclaw\/clawhub" \|\| process\.env\.CLAWHUB_ENABLED === "1"/,
+  );
+  assert.match(
+    claimedWork,
+    /Create target read token[\s\S]*steps\.target\.outputs\.target_enabled == 'true'/,
+  );
+  assert.match(
+    claimedWork,
+    /Check live target item state[\s\S]*steps\.target\.outputs\.target_enabled == 'true'/,
+  );
+  assert.match(
+    claimedWork,
+    /Fail unsuccessful exact review[\s\S]*steps\.target\.outputs\.target_enabled != 'false'/,
   );
   assert.match(
     claimedWork,

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -301,10 +301,13 @@ test("exact event publish and routing require a successful fresh review artifact
     eventReviewJob,
     /Fail unacknowledged source-drift requeue[\s\S]*steps\.complete-exact-review-queue\.outcome != 'success'/,
   );
-  const reReviewStatus = eventReviewJob.indexOf("- name: Mark re-review complete");
+  const reReviewStatus = eventReviewJob.indexOf("- name: Mark source-drift re-review queued");
   const completeQueue = eventReviewJob.indexOf("- name: Complete exact-review queue lease");
-  assert.ok(reReviewStatus > 0 && completeQueue > reReviewStatus);
-  assert.match(eventReviewJob, /This run is returning it to the exact-review queue/);
+  assert.ok(completeQueue > 0 && reReviewStatus > completeQueue);
+  assert.match(
+    eventReviewJob,
+    /Mark source-drift re-review queued[\s\S]*steps\.complete-exact-review-queue\.outcome == 'success'/,
+  );
   assert.match(
     eventReviewJob,
     /React to target item completion[\s\S]*steps\.publish-event-result\.outputs\.policy_noop == 'true'/,

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -315,6 +315,45 @@ test("exact event publish and routing require a successful fresh review artifact
   assert.match(eventReviewJob, /if \[ "\$POLICY_NOOP" != "true" \]; then/);
 });
 
+test("exact event workflow binds all work to the canonical queue claim", () => {
+  const workflow = readText(".github/workflows/sweep.yml");
+  const eventStart = workflow.indexOf("\n  event-review-apply:");
+  const eventEnd = workflow.indexOf("\n  target-fanout:", eventStart);
+  const eventJob = workflow.slice(eventStart, eventEnd);
+  const claimStart = eventJob.indexOf("- name: Claim exact-review queue lease");
+  const checkoutStart = eventJob.indexOf("- uses: actions/checkout@v7", claimStart);
+  const claimStep = eventJob.slice(claimStart, checkoutStart);
+  const claimedWork = eventJob.slice(checkoutStart);
+
+  assert.match(claimStep, /ITEM_KEY: \$\{\{ github\.event\.client_payload\.item_key \}\}/);
+  assert.match(
+    claimStep,
+    /QUEUE_LEASE_REVISION: \$\{\{ github\.event\.client_payload\.lease_revision \}\}/,
+  );
+  assert.match(claimStep, /item_key: process\.env\.ITEM_KEY/);
+  assert.match(claimStep, /lease_revision: leaseRevision/);
+  assert.match(claimStep, /response\.item_key !== itemKey/);
+  assert.match(claimStep, /response\.lease_revision !== leaseRevision/);
+  assert.match(claimStep, /`\$\{targetRepo\}#\$\{itemNumber\}` !== itemKey/);
+  assert.match(claimStep, /claim_generation=\$\{claimGeneration\}/);
+  assert.match(claimStep, /decision=\$\{JSON\.stringify\(decision\)\}/);
+  assert.doesNotMatch(claimedWork, /github\.event\.client_payload/);
+  assert.match(claimedWork, /gh api "repos\/\$TARGET_REPO" --jq \.default_branch/);
+  assert.match(claimedWork, /if \.pull_request then "pull_request" else "issue" end/);
+  assert.match(claimedWork, /steps\.live-item\.outputs\.target_branch/);
+  assert.match(
+    claimedWork,
+    /fromJSON\(steps\.claim-exact-review-queue\.outputs\.decision\)\.sourceAction/,
+  );
+  assert.match(
+    claimedWork,
+    /CLAIM_GENERATION: \$\{\{ steps\.claim-exact-review-queue\.outputs\.claim_generation \}\}/,
+  );
+  assert.match(claimedWork, /item_key: process\.env\.ITEM_KEY/);
+  assert.match(claimedWork, /lease_revision: leaseRevision/);
+  assert.match(claimedWork, /claim_generation: claimGeneration/);
+});
+
 test("dashboard syncs Worker secrets with durable lifecycle storage", () => {
   const workflow = readText(".github/workflows/dashboard.yml");
   const smoke = readText("scripts/dashboard-smoke.mjs");
@@ -1632,13 +1671,13 @@ test("sweep event reviews and target fanout avoid storm amplification", () => {
   assert.match(eventBlock, /concurrency:/);
   assert.match(
     eventBlock,
-    /clawsweeper-event-review-\$\{\{ github\.event\.client_payload\.target_repo/,
-  );
-  assert.match(
-    eventBlock,
-    /group: clawsweeper-event-review-\$\{\{ github\.event\.client_payload\.target_repo \|\| 'openclaw\/openclaw' \}\}-\$\{\{ github\.event\.client_payload\.item_number/,
+    /group: clawsweeper-event-review-\$\{\{ github\.event\.client_payload\.item_key \|\| github\.run_id \}\}/,
   );
   assert.match(eventBlock, /queue_lease_id != ''/);
+  assert.match(eventBlock, /item_key: process\.env\.ITEM_KEY/);
+  assert.match(eventBlock, /lease_revision: leaseRevision/);
+  assert.match(eventBlock, /claim_generation: claimGeneration/);
+  assert.match(eventBlock, /decision=\$\{JSON\.stringify\(decision\)\}/);
   assert.match(eventBlock, /cancel-in-progress: false/);
   assert.match(legacyIntakeBlock, /legacy-event-queue-intake:/);
   assert.match(legacyIntakeBlock, /\/internal\/exact-review\/enqueue/);
@@ -1669,7 +1708,7 @@ test("setup-state defaults to an auth-safe shallow checkout", () => {
   assert.match(action, /ref: state/);
 });
 
-test("sweep exact event reviews consume adaptive Codex timeout payload", () => {
+test("sweep exact event reviews consume only the immutable claimed decision", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const resolveBlock = workflow.slice(
     workflow.indexOf("- name: Resolve event payload"),
@@ -1682,32 +1721,18 @@ test("sweep exact event reviews consume adaptive Codex timeout payload", () => {
 
   assert.match(
     resolveBlock,
-    /ADAPTIVE_CODEX_TIMEOUT_MS: \$\{\{ github\.event\.client_payload\.review_options\.codex_timeout_ms \|\| github\.event\.client_payload\.codex_timeout_ms \|\| '' \}\}/,
+    /CLAIM_DECISION: \$\{\{ steps\.claim-exact-review-queue\.outputs\.decision \}\}/,
   );
   assert.match(
     resolveBlock,
     /CONFIGURED_CODEX_TIMEOUT_MS: \$\{\{ vars\.CLAWSWEEPER_CODEX_TIMEOUT_MS \|\| '1200000' \}\}/,
   );
-  assert.match(
-    resolveBlock,
-    /MEDIA_PROOF_TIMEOUT_MS: \$\{\{ github\.event\.client_payload\.review_options\.media_proof_timeout_ms \|\| github\.event\.client_payload\.media_proof_timeout_ms \|\| '0' \}\}/,
-  );
-  assert.match(resolveBlock, /Ignoring invalid adaptive codex_timeout_ms payload/);
-  assert.match(
-    resolveBlock,
-    /configured_codex_timeout_ms="\$\(\(10#\$configured_codex_timeout_ms\)\)"/,
-  );
-  assert.match(
-    resolveBlock,
-    /adaptive_codex_timeout_ms="\$\(\(10#\$adaptive_codex_timeout_ms\)\)"/,
-  );
-  assert.match(resolveBlock, /media_proof_timeout_ms="\$\(\(10#\$media_proof_timeout_ms\)\)"/);
-  assert.match(resolveBlock, /\[ "\$media_proof_timeout_ms" -gt 480000 \]/);
-  assert.match(resolveBlock, /\[ "\$adaptive_codex_timeout_ms" -lt 600000 \]/);
-  assert.match(resolveBlock, /\[ "\$adaptive_codex_timeout_ms" -gt 1800000 \]/);
-  assert.match(resolveBlock, /\[ "\$adaptive_codex_timeout_ms" -gt "\$codex_timeout_ms" \]/);
-  assert.match(resolveBlock, /echo "codex_timeout_ms=\$codex_timeout_ms"/);
-  assert.match(resolveBlock, /echo "media_proof_timeout_ms=\$media_proof_timeout_ms"/);
+  assert.match(resolveBlock, /const decision = JSON\.parse\(process\.env\.CLAIM_DECISION/);
+  assert.match(resolveBlock, /Math\.min\(1_800_000, Math\.max\(600_000, adaptiveValue\)\)/);
+  assert.match(resolveBlock, /Math\.min\(480_000, mediaValue\)/);
+  assert.match(resolveBlock, /codex_timeout_ms: Math\.max\(configuredTimeout, adaptiveTimeout\)/);
+  assert.match(resolveBlock, /media_proof_timeout_ms: mediaTimeout/);
+  assert.doesNotMatch(resolveBlock, /github\.event\.client_payload/);
   assert.match(
     reviewBlock,
     /codex_timeout_ms="\$\{\{ steps\.target\.outputs\.codex_timeout_ms \}\}"/,
@@ -1736,8 +1761,8 @@ test("sweep exact event reviews preserve the configured fallback without an adap
     resolveBlock,
     /CONFIGURED_CODEX_TIMEOUT_MS: \$\{\{ vars\.CLAWSWEEPER_CODEX_TIMEOUT_MS \|\| '1200000' \}\}/,
   );
-  assert.match(resolveBlock, /codex_timeout_ms="\$configured_codex_timeout_ms"/);
-  assert.match(resolveBlock, /\[ "\$adaptive_codex_timeout_ms" -gt "\$codex_timeout_ms" \]/);
+  assert.match(resolveBlock, /configuredValue > 0 \? configuredValue : 1_200_000/);
+  assert.match(resolveBlock, /codex_timeout_ms: Math\.max\(configuredTimeout, adaptiveTimeout\)/);
 });
 
 test("github activity workflow scopes cancellation to matching item activity", () => {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -349,8 +349,9 @@ test("exact event workflow binds all work to the canonical queue claim", () => {
   assert.match(claimedWork, /steps\.live-item\.outputs\.target_branch/);
   assert.match(
     claimedWork,
-    /fromJSON\(steps\.claim-exact-review-queue\.outputs\.decision\)\.sourceAction/,
+    /CLAIM_DECISION: \$\{\{ steps\.claim-exact-review-queue\.outputs\.decision \}\}/,
   );
+  assert.match(claimedWork, /const decision = JSON\.parse\(process\.env\.CLAIM_DECISION \|\| "\{\}"\)/);
   assert.match(
     claimedWork,
     /CLAIM_GENERATION: \$\{\{ steps\.claim-exact-review-queue\.outputs\.claim_generation \}\}/,

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -330,12 +330,15 @@ test("exact event workflow binds all work to the canonical queue claim", () => {
     claimStep,
     /QUEUE_LEASE_REVISION: \$\{\{ github\.event\.client_payload\.lease_revision \}\}/,
   );
-  assert.match(claimStep, /item_key: process\.env\.ITEM_KEY/);
-  assert.match(claimStep, /lease_revision: leaseRevision/);
-  assert.match(claimStep, /response\.item_key !== itemKey/);
-  assert.match(claimStep, /response\.lease_revision !== leaseRevision/);
-  assert.match(claimStep, /`\$\{targetRepo\}#\$\{itemNumber\}` !== itemKey/);
-  assert.match(claimStep, /claim_generation=\$\{claimGeneration\}/);
+  assert.match(
+    claimStep,
+    /hasTuple \? \{ item_key: itemKey, lease_revision: leaseRevision \} : \{\}/,
+  );
+  assert.match(claimStep, /response\.item_key !== requestedItemKey/);
+  assert.match(claimStep, /response\.lease_revision !== requestedLeaseRevision/);
+  assert.match(claimStep, /const itemKey = `\$\{targetRepo\}#\$\{itemNumber\}`/);
+  assert.match(claimStep, /claim_generation=\$\{responseProtocol === 2 \? claimGeneration : ""\}/);
+  assert.match(claimStep, /protocol_version=\$\{responseProtocol\}/);
   assert.match(claimStep, /decision=\$\{JSON\.stringify\(decision\)\}/);
   assert.doesNotMatch(claimedWork, /github\.event\.client_payload/);
   assert.match(claimedWork, /gh api "repos\/\$TARGET_REPO" --jq \.default_branch/);
@@ -349,9 +352,36 @@ test("exact event workflow binds all work to the canonical queue claim", () => {
     claimedWork,
     /CLAIM_GENERATION: \$\{\{ steps\.claim-exact-review-queue\.outputs\.claim_generation \}\}/,
   );
+  assert.match(
+    claimedWork,
+    /PROTOCOL_VERSION: \$\{\{ steps\.claim-exact-review-queue\.outputs\.protocol_version \}\}/,
+  );
   assert.match(claimedWork, /item_key: process\.env\.ITEM_KEY/);
   assert.match(claimedWork, /lease_revision: leaseRevision/);
   assert.match(claimedWork, /claim_generation: claimGeneration/);
+});
+
+test("exact event workflow keeps both queue protocol versions live during rolling deploys", () => {
+  const workflow = readText(".github/workflows/sweep.yml");
+  const eventStart = workflow.indexOf("\n  event-review-apply:");
+  const eventEnd = workflow.indexOf("\n  target-fanout:", eventStart);
+  const eventJob = workflow.slice(eventStart, eventEnd);
+  const claimStart = eventJob.indexOf("- name: Claim exact-review queue lease");
+  const checkoutStart = eventJob.indexOf("- uses: actions/checkout@v7", claimStart);
+  const claimStep = eventJob.slice(claimStart, checkoutStart);
+  const completeStart = eventJob.indexOf("- name: Complete exact-review queue lease");
+  const completeEnd = eventJob.indexOf("\n      - ", completeStart + 1);
+  const completeStep = eventJob.slice(completeStart, completeEnd);
+
+  assert.match(claimStep, /DISPATCH_PAYLOAD: \$\{\{ toJSON\(github\.event\.client_payload\) \}\}/);
+  assert.match(claimStep, /const responseProtocol = Number\(response\.protocol_version \|\| 1\)/);
+  assert.match(claimStep, /const legacyDecision = \{/);
+  assert.match(claimStep, /response\.decision && typeof response\.decision === "object"/);
+  assert.match(claimStep, /reviewOptions\.command_status_marker/);
+  assert.match(claimStep, /responseProtocol === 2/);
+  assert.match(completeStep, /protocolVersion !== 1 && protocolVersion !== 2/);
+  assert.match(completeStep, /protocolVersion === 2/);
+  assert.match(completeStep, /: \{\}\),/);
 });
 
 test("dashboard syncs Worker secrets with durable lifecycle storage", () => {


### PR DESCRIPTION
## Summary

- make exact-review comment leases recoverable by their GitHub workflow run and delete only the current unsuccessful run's trusted owned lease
- carry a coordination-held lease deadline into the durable queue so retries wait for expiry without delaying newer item revisions
- fail open-item/no-artifact reviews before state hydration, avoiding repeated state checkout and publish failures
- bind queue decisions to immutable lease tuples across rolling v1/v2 deploys and acknowledge verified source drift exactly once
- stop failed-review redispatch for locked/closed no-action items and complete disabled ClawHub claims without target access

## Production evidence

Run 29083585749 was cancelled after posting the review lease for openclaw/openclaw#98021. Six later runs observed the held lease, reported zero reviewed items, hydrated state, then failed publication because no artifact existed. Work resumed immediately after the stale lease expired, confirming the loop.

## Validation

- `pnpm run build:all`
- `node --test test/clawsweeper.test.ts test/dashboard-worker.test.ts test/review-comment-rendering.test.ts test/sweep-workflow.test.ts`
- `pnpm run test:repair`
- `pnpm run test:coverage:changed`
- `pnpm run format:check`
- 252 focused integration tests, including locked #64319 and closed #3050 retry-loop regressions
- GPT-5.6 Sol High autoreview: clean (0.86)

Worker limits and workflow enablement are unchanged.
