### PR TITLE
perf: bound reconciliation publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Bounded broad reconciliation with batched Git I/O and tuple checkpoints that report progress and resume safely under concurrent state writers.
 - Serialized explicit workflow-dispatch planners through a non-dropping target queue and accounted for recovery runs by their requested or live shards, preventing overlapping target planning and false 89-shard reservations without undercounting multi-shard retries.
 - Reconciled terminal exact-review runs by requested run instead of sampling the first 32 claimed leases, while preserving attempt and claim-generation guards across larger worker waves.
 - Dequeued already-closed exact-review events before setup and treated items closed during review as terminal no-ops, preventing permanent retry churn from consuming live worker capacity.

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -64,8 +64,21 @@ const GENERATED_PUBLISH_PATHS = [
   "results",
   "assets",
 ] as const;
+const GIT_PATHSPEC_BATCH_SIZE = 256;
+const GIT_OBJECT_BATCH_SIZE = 512;
+const GIT_OBJECT_BATCH_MAX_BUFFER = 64 * 1024 * 1024;
+const RECONCILIATION_TUPLE_CHUNK_SIZE = 128;
 const SKIP_CI_DIRECTIVE_PATTERN =
   /\[(?:skip ci|ci skip|no ci|skip actions|actions skip)\]|^skip-checks:\s*true$/im;
+
+type GitPublishMetrics = {
+  startedAtMs: number;
+  processes: number;
+  actions: Map<string, number>;
+  phase: string;
+};
+
+let activeGitPublishMetrics: GitPublishMetrics | null = null;
 
 export function configureGitUser(): void {
   runGit(["config", "user.name", clawsweeperGitUserName()]);
@@ -102,6 +115,7 @@ export function runGit(args: readonly string[], options: GitRunOptions = {}): st
 }
 
 export function spawnGit(args: readonly string[], options: GitRunOptions = {}): GitRunResult {
+  recordGitProcess(args[0]);
   console.log(`$ ${formatGitDisplayCommand(options.displayArgs ?? args)}`);
   const child = spawnSync("git", [...args], {
     cwd: publishRoot(),
@@ -116,6 +130,13 @@ export function spawnGit(args: readonly string[], options: GitRunOptions = {}): 
     stdout: child.stdout ?? "",
     stderr: child.stderr ?? "",
   };
+}
+
+function recordGitProcess(action: string | undefined): void {
+  if (!activeGitPublishMetrics) return;
+  const key = action || "command";
+  activeGitPublishMetrics.processes += 1;
+  activeGitPublishMetrics.actions.set(key, (activeGitPublishMetrics.actions.get(key) ?? 0) + 1);
 }
 
 function formatGitDisplayCommand(args: readonly string[]): string {
@@ -147,20 +168,31 @@ function safeGitDisplayAction(action: string | undefined): string {
 }
 
 export function stagePaths(paths: readonly string[]): void {
-  const uniquePaths = uniqueNonEmpty(paths);
-  if (uniquePaths.length === 0) throw new Error("No paths were provided for publishing");
-  for (const path of uniquePaths) {
-    const status = spawnGit(["status", "--porcelain", "--", path]).stdout.trim();
-    const worktreePath = resolve(publishRoot() ?? process.cwd(), path);
-    if (hasWorktreePath(path) || existsSync(worktreePath)) {
-      runGit(["add", "-A", "--", path]);
-    } else if (status) {
-      // Rebuilds remove exact missing paths with git rm, so their deletion is
-      // already staged and there is no pathspec left for git add to match.
-      console.log(`Publish path deletion already staged: ${path}`);
-    } else {
-      console.log(`Skipping untracked missing publish path: ${path}`);
+  const pathSpecs = uniqueNonEmpty(paths).map((path) => ({
+    path,
+    gitPath: normalizedPublishPath(path) || path,
+  }));
+  if (pathSpecs.length === 0) throw new Error("No paths were provided for publishing");
+  let skippedMissing = 0;
+  for (const batch of chunked(pathSpecs, GIT_PATHSPEC_BATCH_SIZE)) {
+    const trackedFiles = runGit(["ls-files", "-z", "--", ...batch.map(({ gitPath }) => gitPath)], {
+      quiet: true,
+    })
+      .split("\0")
+      .filter(Boolean);
+    const stageable = batch.filter(({ path, gitPath }) => {
+      const worktreePath = resolve(publishRoot() ?? process.cwd(), path);
+      return existsSync(worktreePath) || trackedFiles.some((file) => pathIsWithin(gitPath, file));
+    });
+    skippedMissing += batch.length - stageable.length;
+    if (stageable.length > 0) {
+      runGit(["add", "-A", "--", ...stageable.map(({ gitPath }) => gitPath)]);
     }
+  }
+  if (skippedMissing > 0) {
+    console.log(
+      `Skipped ${skippedMissing} untracked missing publish path(s); staged deletions remain intact`,
+    );
   }
 }
 
@@ -182,15 +214,49 @@ export function hasWorktreePath(path: string): boolean {
 }
 
 export function publishMainCommit(options: GitPublishOptions): PublishResult {
+  const previousMetrics = activeGitPublishMetrics;
+  const metrics: GitPublishMetrics = {
+    startedAtMs: Date.now(),
+    processes: 0,
+    actions: new Map(),
+    phase: "start",
+  };
+  activeGitPublishMetrics = metrics;
+  try {
+    return publishMainCommitInternal(options);
+  } catch (error) {
+    console.log(
+      `Git publish failure: phase=${metrics.phase} processes=${metrics.processes} duration_ms=${Date.now() - metrics.startedAtMs} error=${errorMessage(error)}`,
+    );
+    throw error;
+  } finally {
+    const actions = [...metrics.actions]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([action, count]) => `${action}:${count}`)
+      .join(",");
+    console.log(
+      `Git publish metrics: phase=${metrics.phase} processes=${metrics.processes} duration_ms=${Date.now() - metrics.startedAtMs} actions=${actions}`,
+    );
+    activeGitPublishMetrics = previousMetrics;
+  }
+}
+
+function publishMainCommitInternal(options: GitPublishOptions): PublishResult {
   const remote = options.remote ?? "origin";
   const branch = options.branch ?? publishDefaultBranch();
   const maxAttempts = positiveInt(options.maxAttempts, 8);
   const pushAttempts = positiveInt(options.pushAttempts, 3);
   const rebaseStrategy = options.rebaseStrategy ?? "normal";
+  gitPublishPhase(
+    "sync",
+    `paths=${uniqueNonEmpty(options.paths).length} strategy=${rebaseStrategy}`,
+  );
+  prepareReconciliationStateRoot(remote, branch, rebaseStrategy);
   const stateBaseCommit = captureStatePublishBaseline();
 
   syncPublishPaths(options.paths, { rebaseStrategy });
   configureGitUser();
+  gitPublishPhase("stage", `paths=${uniqueNonEmpty(options.paths).length}`);
   stagePaths(options.paths);
   if (!hasStagedChanges()) {
     console.log("No publish changes");
@@ -205,7 +271,9 @@ export function publishMainCommit(options: GitPublishOptions): PublishResult {
   let sourceCommit = runGit(["rev-parse", "HEAD"]).trim();
   const reconciliationSourceCommit =
     rebaseStrategy === "reconcile-records" ? sourceCommit : undefined;
+  let reconciliationTupleKeys: ReadonlySet<string> | undefined;
   if (rebaseStrategy === "reconcile-records") {
+    gitPublishPhase("normalize");
     const normalized = normalizeReconciliationCommit(sourceCommit);
     sourceCommit = normalized.commit;
     if (!normalized.changed) {
@@ -223,9 +291,23 @@ export function publishMainCommit(options: GitPublishOptions): PublishResult {
       }
       return completeStatePublish("unchanged", options.paths, stateBaseCommit);
     }
+    const tupleKeys = reconciliationTupleKeysForCommit(sourceCommit);
+    reconciliationTupleKeys = new Set(tupleKeys);
+    if (tupleKeys.length > RECONCILIATION_TUPLE_CHUNK_SIZE) {
+      restoreWorktree(options.restorePaths ?? []);
+      const result = publishReconciliationChunks({
+        remote,
+        branch,
+        pushAttempts,
+        sourceCommit: reconciliationSourceCommit ?? sourceCommit,
+        tupleKeys,
+      });
+      return completeStatePublish(result, options.paths, stateBaseCommit);
+    }
   }
   restoreWorktree(options.restorePaths ?? []);
 
+  gitPublishPhase("push");
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     if (
       pushCommit({
@@ -234,6 +316,7 @@ export function publishMainCommit(options: GitPublishOptions): PublishResult {
         pushAttempts,
         rebaseStrategy,
         ...(reconciliationSourceCommit ? { reconciliationSourceCommit } : {}),
+        ...(reconciliationTupleKeys ? { reconciliationTupleKeys } : {}),
       })
     ) {
       return completeStatePublish("committed", options.paths, stateBaseCommit);
@@ -268,6 +351,7 @@ export function publishMainCommit(options: GitPublishOptions): PublishResult {
       pushAttempts,
       rebaseStrategy,
       ...(reconciliationSourceCommit ? { reconciliationSourceCommit } : {}),
+      ...(reconciliationTupleKeys ? { reconciliationTupleKeys } : {}),
     })
   ) {
     return completeStatePublish("committed", options.paths, stateBaseCommit);
@@ -280,8 +364,98 @@ function completeStatePublish(
   paths: readonly string[],
   stateBaseCommit: string | null,
 ): PublishResult {
+  gitPublishPhase("refresh", `paths=${uniqueNonEmpty(paths).length}`);
   refreshSourceAfterStatePublish(paths, stateBaseCommit);
+  gitPublishPhase("complete", `result=${result}`);
   return result;
+}
+
+function gitPublishPhase(phase: string, detail = ""): void {
+  if (activeGitPublishMetrics) activeGitPublishMetrics.phase = phase;
+  console.log(`Git publish phase=${phase}${detail ? ` ${detail}` : ""}`);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message.replace(/[\r\n]+/g, " ") : String(error);
+}
+
+function prepareReconciliationStateRoot(
+  remote: string,
+  branch: string,
+  rebaseStrategy: RebaseStrategy,
+): void {
+  const stateRoot = publishRoot();
+  if (
+    rebaseStrategy !== "reconcile-records" ||
+    !stateRoot ||
+    resolve(stateRoot) === resolve(process.cwd())
+  ) {
+    return;
+  }
+  gitPublishPhase("prepare");
+  runGit(["fetch", remote, branch]);
+  const remoteRef = `${remote}/${branch}`;
+  if (spawnGit(["merge-base", "--is-ancestor", "HEAD", remoteRef], { quiet: true }).status === 0) {
+    return;
+  }
+  const semanticBase = runGit(["merge-base", "HEAD", remoteRef], { quiet: true }).trim();
+  console.log("Discarding an unpublished reconciliation checkpoint before retry");
+  runGit(["reset", "--hard", semanticBase]);
+}
+
+function reconciliationTupleKeysForCommit(sourceCommit: string): string[] {
+  const baseCommit = runGit(["rev-parse", `${sourceCommit}^`], { quiet: true }).trim();
+  const keys = new Set<string>();
+  for (const path of changedPathsBetween(baseCommit, sourceCommit)) {
+    const identity = recordTupleIdentityForPath(path);
+    if (!identity) throw new Error(`Unsupported reconciliation publish path: ${path}`);
+    keys.add(recordTupleIdentityKey(identity));
+  }
+  return [...keys];
+}
+
+function publishReconciliationChunks(options: {
+  remote: string;
+  branch: string;
+  pushAttempts: number;
+  sourceCommit: string;
+  tupleKeys: readonly string[];
+}): PublishResult {
+  const chunks = chunked(options.tupleKeys, RECONCILIATION_TUPLE_CHUNK_SIZE);
+  console.log(
+    `Reconciliation checkpoint plan: tuples=${options.tupleKeys.length} chunks=${chunks.length} chunk_size=${RECONCILIATION_TUPLE_CHUNK_SIZE}`,
+  );
+  let committed = false;
+  for (const [index, tupleKeys] of chunks.entries()) {
+    gitPublishPhase("checkpoint", `chunk=${index + 1}/${chunks.length} tuples=${tupleKeys.length}`);
+    runGit(["fetch", options.remote, options.branch]);
+    const remoteRef = `${options.remote}/${options.branch}`;
+    const remoteCommit = runGit(["rev-parse", remoteRef], { quiet: true }).trim();
+    const allowedTupleKeys = new Set(tupleKeys);
+    if (!rebuildReconciliationCommit(remoteRef, options.sourceCommit, allowedTupleKeys)) {
+      throw new Error(`Failed to build reconciliation checkpoint ${index + 1}/${chunks.length}`);
+    }
+    const checkpointCommit = runGit(["rev-parse", "HEAD"], { quiet: true }).trim();
+    if (checkpointCommit === remoteCommit) {
+      console.log(`Reconciliation checkpoint ${index + 1}/${chunks.length}: no changes remain`);
+      continue;
+    }
+    committed = true;
+    if (
+      !pushCommit({
+        remote: options.remote,
+        branch: options.branch,
+        pushAttempts: options.pushAttempts,
+        rebaseStrategy: "reconcile-records",
+        reconciliationSourceCommit: options.sourceCommit,
+        reconciliationTupleKeys: allowedTupleKeys,
+      })
+    ) {
+      throw new Error(`Failed to publish reconciliation checkpoint ${index + 1}/${chunks.length}`);
+    }
+    console.log(`Reconciliation checkpoint ${index + 1}/${chunks.length}: published`);
+  }
+  return committed ? "committed" : "unchanged";
 }
 
 export function captureStatePublishBaseline(): string | null {
@@ -344,17 +518,31 @@ function learnedClosedRecordPaths(
     if (match) recordKeys.add(`${match[1]}/${match[2]}`);
   }
 
-  const authoritative = new Set<string>();
-  for (const key of recordKeys) {
+  const tuples = [...recordKeys].map((key) => {
     const separator = key.indexOf("/");
     const repository = key.slice(0, separator);
     const file = key.slice(separator + 1);
     const item = `records/${repository}/items/${file}`;
     const closed = `records/${repository}/closed/${file}`;
+    return { repository, file, item, closed };
+  });
+  const existing = gitObjectExistence(
+    tuples.flatMap(({ item, closed }) => [
+      { commit: "HEAD", path: item },
+      { commit: "HEAD", path: closed },
+      { commit: stateBaseCommit, path: item },
+      { commit: stateBaseCommit, path: closed },
+    ]),
+  );
+  const hasPath = (commit: string, path: string): boolean =>
+    existing.has(gitObjectSpec(commit, path));
+
+  const authoritative = new Set<string>();
+  for (const { repository, file, item, closed } of tuples) {
     if (
-      !commitHasPath("HEAD", item) &&
-      commitHasPath("HEAD", closed) &&
-      (commitHasPath(stateBaseCommit, item) || !commitHasPath(stateBaseCommit, closed))
+      !hasPath("HEAD", item) &&
+      hasPath("HEAD", closed) &&
+      (hasPath(stateBaseCommit, item) || !hasPath(stateBaseCommit, closed))
     ) {
       // A concurrent close is an authoritative state transition, matching the
       // delete-wins behavior of an apply-records rebase. Refresh the full
@@ -433,6 +621,10 @@ function syncStatePublishPaths(
   stateRoot: string,
   rebaseStrategy: RebaseStrategy,
 ): void {
+  if (rebaseStrategy === "reconcile-records") {
+    syncReconciliationStatePublishPaths(paths, stateRoot);
+    return;
+  }
   for (const path of uniqueNonEmpty(paths)) {
     const source = resolve(path);
     const destination = resolve(stateRoot, path);
@@ -452,6 +644,34 @@ function syncStatePublishPaths(
     } finally {
       rmSync(preserved.root, { force: true, recursive: true });
     }
+  }
+}
+
+function syncReconciliationStatePublishPaths(paths: readonly string[], stateRoot: string): void {
+  const copies = uniqueNonEmpty(paths).map((path) => {
+    const normalized = normalizedPublishPath(path);
+    if (
+      !recordTupleIdentityForPath(normalized) &&
+      !/^records\/[A-Za-z0-9][A-Za-z0-9_.-]*$/.test(normalized)
+    ) {
+      throw new Error(`Unsupported reconciliation publish path: ${path}`);
+    }
+    const source = resolve(path);
+    const destination = resolve(stateRoot, path);
+    if (!isPathInsideOrEqual(stateRoot, destination)) {
+      throw new Error(`Refusing to publish outside state root: ${path}`);
+    }
+    return { source, destination };
+  });
+
+  // Reconciliation intentionally copies the candidate snapshot exactly. Its
+  // base-aware tuple normalizer restores newer base tuples before the first
+  // push, so per-path preservation temp directories are both wrong and costly.
+  for (const { source, destination } of copies) {
+    rmSync(destination, { force: true, recursive: true });
+    if (!existsSync(source)) continue;
+    mkdirSync(dirname(destination), { recursive: true });
+    cpSync(source, destination, { recursive: true });
   }
 }
 
@@ -657,6 +877,7 @@ export function pushCommit(options: {
   pushAttempts?: number;
   rebaseStrategy?: RebaseStrategy;
   reconciliationSourceCommit?: string;
+  reconciliationTupleKeys?: ReadonlySet<string>;
 }): boolean {
   const remote = options.remote ?? "origin";
   const branch = options.branch ?? publishDefaultBranch();
@@ -670,7 +891,26 @@ export function pushCommit(options: {
     const localCommitMessage = runGit(["log", "-1", "--format=%B"], { quiet: true });
     runGit(["fetch", remote, branch], { allowFailure: true });
     if (rebaseStrategy === "reconcile-records") {
-      if (!rebuildReconciliationCommit(`${remote}/${branch}`, options.reconciliationSourceCommit)) {
+      const remoteRef = `${remote}/${branch}`;
+      const overlaps = reconciliationChangesOverlap(
+        remoteRef,
+        options.reconciliationSourceCommit,
+        options.reconciliationTupleKeys,
+      );
+      if (!overlaps) {
+        if (spawnGit(["rebase", remoteRef]).status === 0) {
+          console.log("Rebased reconciliation over disjoint remote tuple changes");
+          continue;
+        }
+        runGit(["rebase", "--abort"], { allowFailure: true });
+      }
+      if (
+        !rebuildReconciliationCommit(
+          remoteRef,
+          options.reconciliationSourceCommit,
+          options.reconciliationTupleKeys,
+        )
+      ) {
         return false;
       }
       continue;
@@ -696,48 +936,82 @@ export function pushCommit(options: {
   return spawnGit(["push", remote, `HEAD:${branch}`]).status === 0;
 }
 
+function reconciliationChangesOverlap(
+  remoteRef: string,
+  reconciliationSourceCommit?: string,
+  allowedTupleKeys?: ReadonlySet<string>,
+): boolean {
+  const sourceCommit = reconciliationSourceCommit ?? "HEAD";
+  const baseCommit = runGit(["merge-base", sourceCommit, remoteRef], { quiet: true }).trim();
+  const localKeys = recordTupleKeysForPaths(changedPathsBetween(baseCommit, sourceCommit));
+  const remoteKeys = recordTupleKeysForPaths(changedPathsBetween(baseCommit, remoteRef), true);
+  for (const key of localKeys) {
+    if ((!allowedTupleKeys || allowedTupleKeys.has(key)) && remoteKeys.has(key)) return true;
+  }
+  return false;
+}
+
+function recordTupleKeysForPaths(paths: readonly string[], ignoreUnsupported = false): Set<string> {
+  const keys = new Set<string>();
+  for (const path of paths) {
+    const identity = recordTupleIdentityForPath(path);
+    if (!identity) {
+      if (ignoreUnsupported) continue;
+      throw new Error(`Unsupported reconciliation publish path: ${path}`);
+    }
+    keys.add(recordTupleIdentityKey(identity));
+  }
+  return keys;
+}
+
 function rebuildReconciliationCommit(
   remoteRef: string,
   reconciliationSourceCommit?: string,
+  allowedTupleKeys?: ReadonlySet<string>,
 ): boolean {
   const sourceCommit = reconciliationSourceCommit ?? runGit(["rev-parse", "HEAD"]).trim();
   const baseCommit = runGit(["merge-base", sourceCommit, remoteRef]).trim();
   const localPaths = changedPathsBetween(baseCommit, sourceCommit);
-  const remotePaths = changedPathsBetween(baseCommit, remoteRef);
-  const localTupleKeys = new Map<string, RecordTupleIdentity>();
-
+  const localIdentities = new Map<string, RecordTupleIdentity>();
   for (const path of localPaths) {
     const identity = recordTupleIdentityForPath(path);
     if (!identity) {
       console.log(`Unsupported reconciliation publish path: ${path}`);
       return false;
     }
-    localTupleKeys.set(path, identity);
-  }
-
-  const changedPaths = [...localPaths, ...remotePaths];
-  const localIdentities = new Map<string, RecordTupleIdentity>();
-  for (const identity of localTupleKeys.values()) {
-    localIdentities.set(recordTupleIdentityKey(identity), identity);
+    const key = recordTupleIdentityKey(identity);
+    if (!allowedTupleKeys || allowedTupleKeys.has(key)) localIdentities.set(key, identity);
   }
   const knownTuplePaths = indexRecordTupleMarkdownPaths(
     [baseCommit, sourceCommit, remoteRef],
     new Set([...localIdentities.values()].map((identity) => identity.repository)),
+    new Set(localIdentities.keys()),
+  );
+  const resolvedTuples = [...localIdentities].map(([key, identity]) => ({
+    key,
+    paths: resolveRecordTuplePaths({
+      identity,
+      changedPaths: [...localPaths, ...(knownTuplePaths.get(key) ?? [])],
+    }),
+  }));
+  const snapshots = readRecordTupleSnapshots(
+    resolvedTuples.flatMap(({ paths }) => [
+      { commit: baseCommit, paths },
+      { commit: sourceCommit, paths },
+      { commit: remoteRef, paths },
+    ]),
   );
   const selectedTuples: { paths: RecordTuplePaths; commit: string }[] = [];
   const deferredTupleKeys = new Set<string>();
-  for (const [key, identity] of localIdentities) {
-    const tuplePaths = resolveRecordTuplePaths({
-      identity,
-      changedPaths: [...changedPaths, ...(knownTuplePaths.get(key) ?? [])],
-    });
+  for (const [index, { key, paths }] of resolvedTuples.entries()) {
+    const offset = index * 3;
     const winner = chooseReconciliationTupleWinner({
-      base: readRecordTupleAtCommit(baseCommit, tuplePaths),
-      local: readRecordTupleAtCommit(sourceCommit, tuplePaths),
-      remote: readRecordTupleAtCommit(remoteRef, tuplePaths),
+      base: snapshots[offset]!,
+      local: snapshots[offset + 1]!,
+      remote: snapshots[offset + 2]!,
     });
-    if (winner === "local") selectedTuples.push({ paths: tuplePaths, commit: sourceCommit });
-    else if (winner === "base") selectedTuples.push({ paths: tuplePaths, commit: baseCommit });
+    if (winner === "local") selectedTuples.push({ paths, commit: sourceCommit });
+    else if (winner === "base") selectedTuples.push({ paths, commit: baseCommit });
     else deferredTupleKeys.add(key);
   }
 
@@ -748,15 +1022,7 @@ function rebuildReconciliationCommit(
   }
 
   runGit(["reset", "--hard", remoteRef]);
-  const selectedPaths = selectedTuples.flatMap((selection) => recordTuplePathList(selection.paths));
-  for (const selection of selectedTuples) {
-    for (const path of recordTuplePathList(selection.paths)) {
-      runGit(["rm", "-r", "--ignore-unmatch", "--", path], { allowFailure: true });
-      if (commitHasPath(selection.commit, path)) {
-        runGit(["checkout", selection.commit, "--", path]);
-      }
-    }
-  }
+  const selectedPaths = applyRecordTupleSelections(selectedTuples);
 
   if (selectedPaths.length > 0) stagePaths(selectedPaths);
   if (!hasStagedChanges()) {
@@ -780,18 +1046,29 @@ function normalizeReconciliationCommit(sourceCommit: string): {
     if (!identity) throw new Error(`Unsupported reconciliation publish path: ${path}`);
     identities.set(recordTupleIdentityKey(identity), identity);
   }
+  gitPublishPhase("normalize", `tuples=${identities.size} paths=${localPaths.length}`);
   const knownTuplePaths = indexRecordTupleMarkdownPaths(
     [baseCommit, sourceCommit],
     new Set([...identities.values()].map((identity) => identity.repository)),
+    new Set(identities.keys()),
   );
-  const selectedTuples: RecordTuplePaths[] = [];
-  for (const [key, identity] of identities) {
-    const paths = resolveRecordTuplePaths({
+  const resolvedTuples = [...identities].map(([key, identity]) => ({
+    key,
+    paths: resolveRecordTuplePaths({
       identity,
       changedPaths: [...localPaths, ...(knownTuplePaths.get(key) ?? [])],
-    });
-    const base = readRecordTupleAtCommit(baseCommit, paths);
-    const local = readRecordTupleAtCommit(sourceCommit, paths);
+    }),
+  }));
+  const snapshots = readRecordTupleSnapshots(
+    resolvedTuples.flatMap(({ paths }) => [
+      { commit: baseCommit, paths },
+      { commit: sourceCommit, paths },
+    ]),
+  );
+  const selectedTuples: RecordTuplePaths[] = [];
+  for (const [index, { paths }] of resolvedTuples.entries()) {
+    const base = snapshots[index * 2]!;
+    const local = snapshots[index * 2 + 1]!;
     const winner = chooseReconciliationTupleWinner({ base, local, remote: base });
     if (winner === "local") selectedTuples.push(paths);
   }
@@ -803,13 +1080,9 @@ function normalizeReconciliationCommit(sourceCommit: string): {
   const discarded = identities.size - selectedTuples.length;
   console.log(`Discarding ${discarded} stale or ambiguous local record tuple(s) before push`);
   runGit(["reset", "--hard", baseCommit]);
-  const selectedPaths = selectedTuples.flatMap(recordTuplePathList);
-  for (const paths of selectedTuples) {
-    for (const path of recordTuplePathList(paths)) {
-      runGit(["rm", "-r", "--ignore-unmatch", "--", path], { allowFailure: true });
-      if (commitHasPath(sourceCommit, path)) runGit(["checkout", sourceCommit, "--", path]);
-    }
-  }
+  const selectedPaths = applyRecordTupleSelections(
+    selectedTuples.map((paths) => ({ paths, commit: sourceCommit })),
+  );
   if (selectedPaths.length > 0) stagePaths(selectedPaths);
   if (!hasStagedChanges()) return { commit: baseCommit, changed: false };
   runGit(["commit", "-C", sourceCommit]);
@@ -838,7 +1111,7 @@ function chooseReconciliationTupleWinner(options: {
 }
 
 function changedPathsBetween(from: string, to: string): string[] {
-  return runGit(["diff", "--no-renames", "--name-only", "-z", from, to])
+  return runGit(["diff", "--no-renames", "--name-only", "-z", from, to], { quiet: true })
     .split("\0")
     .filter(Boolean);
 }
@@ -891,6 +1164,7 @@ function resolveRecordTuplePaths(options: {
 function indexRecordTupleMarkdownPaths(
   commits: readonly string[],
   repositories: ReadonlySet<string>,
+  targetKeys?: ReadonlySet<string>,
 ): Map<string, string[]> {
   const indexed = new Map<string, Set<string>>();
   for (const commit of commits) {
@@ -916,6 +1190,7 @@ function indexRecordTupleMarkdownPaths(
         const identity = recordTupleIdentityForPath(path);
         if (!identity) continue;
         const key = recordTupleIdentityKey(identity);
+        if (targetKeys && !targetKeys.has(key)) continue;
         const existing = indexed.get(key) ?? new Set<string>();
         existing.add(path);
         indexed.set(key, existing);
@@ -925,14 +1200,149 @@ function indexRecordTupleMarkdownPaths(
   return new Map([...indexed].map(([key, paths]) => [key, [...paths]]));
 }
 
-function readRecordTupleAtCommit(commit: string, paths: RecordTuplePaths): RecordTupleContents {
-  return {
+type RecordTupleSnapshotRequest = { commit: string; paths: RecordTuplePaths };
+type GitObjectRequest = { commit: string; path: string };
+
+function readRecordTupleSnapshots(
+  requests: readonly RecordTupleSnapshotRequest[],
+): RecordTupleContents[] {
+  const objects = readGitObjects(
+    requests.flatMap(({ commit, paths }) =>
+      recordTuplePathList(paths).map((path) => ({ commit, path })),
+    ),
+  );
+  return requests.map(({ commit, paths }) => ({
     paths,
-    item: readGitPath(commit, paths.item),
-    closed: readGitPath(commit, paths.closed),
-    plan: readGitPath(commit, paths.plan),
-    packet: readGitPath(commit, paths.packet),
-  };
+    item: objects.get(gitObjectSpec(commit, paths.item)) ?? null,
+    closed: objects.get(gitObjectSpec(commit, paths.closed)) ?? null,
+    plan: objects.get(gitObjectSpec(commit, paths.plan)) ?? null,
+    packet: objects.get(gitObjectSpec(commit, paths.packet)) ?? null,
+  }));
+}
+
+function readGitObjects(requests: readonly GitObjectRequest[]): Map<string, string | null> {
+  const specs = uniqueNonEmpty(requests.map(({ commit, path }) => gitObjectSpec(commit, path)));
+  const objects = new Map<string, string | null>();
+  for (const batch of chunked(specs, GIT_OBJECT_BATCH_SIZE)) {
+    const output = runGitObjectBatch("--batch", batch);
+    let offset = 0;
+    for (const spec of batch) {
+      const newline = output.indexOf(0x0a, offset);
+      if (newline < 0) throw new Error(`Malformed git cat-file batch header for ${spec}`);
+      const header = output.subarray(offset, newline).toString("utf8");
+      offset = newline + 1;
+      if (header.endsWith(" missing")) {
+        objects.set(spec, null);
+        continue;
+      }
+      const match = /^([0-9a-f]+) ([^ ]+) (\d+)$/.exec(header);
+      if (!match || match[2] !== "blob") {
+        throw new Error(`Unexpected git cat-file batch response for ${spec}: ${header}`);
+      }
+      const size = Number(match[3]);
+      if (!Number.isSafeInteger(size) || size < 0 || offset + size >= output.length) {
+        throw new Error(`Invalid git cat-file batch size for ${spec}: ${match[3]}`);
+      }
+      const content = output.subarray(offset, offset + size).toString("utf8");
+      offset += size;
+      if (output[offset] !== 0x0a) {
+        throw new Error(`Malformed git cat-file batch terminator for ${spec}`);
+      }
+      offset += 1;
+      objects.set(spec, content);
+    }
+    if (offset !== output.length) {
+      throw new Error("Unexpected trailing output from git cat-file batch");
+    }
+  }
+  return objects;
+}
+
+function gitObjectExistence(requests: readonly GitObjectRequest[]): Set<string> {
+  const specs = uniqueNonEmpty(requests.map(({ commit, path }) => gitObjectSpec(commit, path)));
+  const existing = new Set<string>();
+  for (const batch of chunked(specs, GIT_OBJECT_BATCH_SIZE)) {
+    const lines = runGitObjectBatch("--batch-check", batch).toString("utf8").split("\n");
+    if (lines.at(-1) === "") lines.pop();
+    if (lines.length !== batch.length) {
+      throw new Error(
+        `Unexpected git cat-file batch-check response count: ${lines.length}/${batch.length}`,
+      );
+    }
+    for (const [index, line] of lines.entries()) {
+      if (line!.endsWith(" missing")) continue;
+      if (!/^[0-9a-f]+ [^ ]+ \d+$/.test(line!)) {
+        throw new Error(`Unexpected git cat-file batch-check response: ${line}`);
+      }
+      existing.add(batch[index]!);
+    }
+  }
+  return existing;
+}
+
+function runGitObjectBatch(mode: "--batch" | "--batch-check", specs: readonly string[]): Buffer {
+  recordGitProcess("cat-file");
+  console.log("$ git cat-file <redacted-args>");
+  const child = spawnSync("git", ["cat-file", mode], {
+    cwd: publishRoot(),
+    env: process.env,
+    input: Buffer.from(`${specs.join("\n")}\n`, "utf8"),
+    maxBuffer: GIT_OBJECT_BATCH_MAX_BUFFER,
+  });
+  if (child.error) throw child.error;
+  const stdout = Buffer.isBuffer(child.stdout) ? child.stdout : Buffer.from(child.stdout ?? "");
+  const stderr = Buffer.isBuffer(child.stderr)
+    ? child.stderr.toString("utf8")
+    : String(child.stderr ?? "");
+  if ((child.status ?? 1) !== 0) {
+    throw new Error(stderr.trim() || `git cat-file ${mode} exited ${child.status ?? 1}`);
+  }
+  return stdout;
+}
+
+function gitObjectSpec(commit: string, path: string): string {
+  const spec = `${commit}:${path}`;
+  if (spec.includes("\n") || spec.includes("\0")) {
+    throw new Error("Invalid newline or NUL in git object specification");
+  }
+  return spec;
+}
+
+function applyRecordTupleSelections(
+  selections: readonly { paths: RecordTuplePaths; commit: string }[],
+): string[] {
+  const commitByPath = new Map<string, string>();
+  for (const selection of selections) {
+    for (const path of recordTuplePathList(selection.paths)) {
+      const existing = commitByPath.get(path);
+      if (existing && existing !== selection.commit) {
+        throw new Error(`Conflicting tuple selections for ${path}`);
+      }
+      commitByPath.set(path, selection.commit);
+    }
+  }
+  const selectedPaths = [...commitByPath.keys()];
+  for (const batch of chunked(selectedPaths, GIT_PATHSPEC_BATCH_SIZE)) {
+    runGit(["rm", "-r", "--ignore-unmatch", "--", ...batch], {
+      allowFailure: true,
+      quiet: true,
+    });
+  }
+
+  const pathsByCommit = new Map<string, string[]>();
+  for (const [path, commit] of commitByPath) {
+    const paths = pathsByCommit.get(commit) ?? [];
+    paths.push(path);
+    pathsByCommit.set(commit, paths);
+  }
+  for (const [commit, paths] of pathsByCommit) {
+    const existing = gitObjectExistence(paths.map((path) => ({ commit, path })));
+    const checkoutPaths = paths.filter((path) => existing.has(gitObjectSpec(commit, path)));
+    for (const batch of chunked(checkoutPaths, GIT_PATHSPEC_BATCH_SIZE)) {
+      runGit(["checkout", commit, "--", ...batch]);
+    }
+  }
+  return selectedPaths;
 }
 
 function recordTupleIdentityKey(identity: RecordTupleIdentity): string {
@@ -999,6 +1409,14 @@ export function hardResetToRemoteMain(remote = "origin", branch = publishDefault
 
 export function uniqueNonEmpty(values: readonly string[]): string[] {
   return [...new Set(values.map((value) => value.trim()).filter(Boolean))];
+}
+
+function chunked<T>(values: readonly T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let index = 0; index < values.length; index += size) {
+    chunks.push(values.slice(index, index + size));
+  }
+  return chunks;
 }
 
 export function commitMessageForPublishedPaths(message: string, paths: readonly string[]): string {

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -13,6 +13,7 @@ import {
   publishMainCommit,
   refreshSourceAfterStatePublish,
   setTokenOrigin,
+  stagePaths,
   uniqueNonEmpty,
 } from "../../dist/repair/git-publish.js";
 
@@ -47,6 +48,21 @@ test("commitMessageForPublishedPaths skips CI for generated-only publishes", () 
     commitMessageForPublishedPaths("fix: update scheduler", ["src/repair/git-publish.ts"]),
     "fix: update scheduler",
   );
+});
+
+test("stagePaths normalizes tracked deletion pathspecs", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-stage-paths-"));
+  const file = "records/openclaw-openclaw/items/42.md";
+  run("git", ["init"], root);
+  configureUser(root);
+  write(path.join(root, file), "tracked\n");
+  run("git", ["add", "."], root);
+  run("git", ["commit", "-m", "initial"], root);
+  fs.rmSync(path.join(root, file));
+
+  withCwd(root, () => stagePaths(["./records/openclaw-openclaw/items/"]));
+
+  assert.equal(run("git", ["diff", "--cached", "--name-only"], root), `${file}\n`);
 });
 
 test("publishMainCommit commits selected paths and restores volatile tracked files", () => {
@@ -856,6 +872,384 @@ test("reconcile-records rejects a malformed tuple before an uncontended push", (
       root,
     ),
     tuple.packet,
+  );
+});
+
+test("reconcile-records fails closed on a concurrent tuple filename alias", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-alias-"));
+  const origin = path.join(root, "origin.git");
+  const work = path.join(root, "work");
+  const other = path.join(root, "other");
+  const recordsRoot = "records/openclaw-openclaw";
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, work], root);
+  configureUser(work);
+  writeRecordTuple(work, {
+    number: 42,
+    marker: "base exact filename",
+    reviewedAt: "2026-07-09T23:00:00.000Z",
+    itemUpdatedAt: "2026-07-09T22:59:00Z",
+  });
+  run("git", ["add", "."], work);
+  run("git", ["commit", "-m", "initial state"], work);
+  run("git", ["push", "origin", "HEAD:main"], work);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/main"], root);
+  run("git", ["checkout", "-B", "main", "origin/main"], work);
+  run("git", ["clone", origin, other], root);
+  configureUser(other);
+
+  fs.rmSync(path.join(other, recordsRoot, "items/42.md"));
+  fs.rmSync(path.join(other, recordsRoot, "plans/42.md"));
+  const remoteAlias = writeRecordTuple(other, {
+    number: 42,
+    marker: "newer remote alias",
+    reviewedAt: "2026-07-09T23:04:00.000Z",
+    itemUpdatedAt: "2026-07-09T23:03:00Z",
+    recordFile: "openclaw-openclaw-42.md",
+    planFile: "repair-openclaw-openclaw-42.md",
+  });
+  run("git", ["add", "-A"], other);
+  run("git", ["commit", "-m", "rename tuple to legacy alias"], other);
+  installFirstPushRaceHook(work, other);
+  writeRecordTuple(work, {
+    number: 42,
+    marker: "local exact update",
+    reviewedAt: "2026-07-09T23:02:00.000Z",
+    itemUpdatedAt: "2026-07-09T23:01:00Z",
+  });
+
+  const lines = [];
+  assert.throws(
+    () =>
+      captureConsoleLog(
+        () =>
+          withCwd(work, () =>
+            publishMainCommit({
+              message: "chore: reconcile filename alias",
+              paths: [recordsRoot],
+              maxAttempts: 1,
+              pushAttempts: 1,
+              rebaseStrategy: "reconcile-records",
+            }),
+          ),
+        lines,
+      ),
+    /ambiguous items filenames/,
+  );
+  assert.equal(
+    lines.some((line) => line.includes("Git publish failure: phase=push")),
+    true,
+  );
+  assert.equal(
+    run(
+      "git",
+      ["--git-dir", origin, "show", `main:${recordsRoot}/items/openclaw-openclaw-42.md`],
+      root,
+    ),
+    remoteAlias.primary,
+  );
+  assert.throws(() =>
+    run("git", ["--git-dir", origin, "show", `main:${recordsRoot}/items/42.md`], root),
+  );
+});
+
+test("reconcile-records fails closed when state and remote have no common base", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-unrelated-"));
+  const origin = path.join(root, "origin.git");
+  const state = path.join(root, "state");
+  const work = path.join(root, "work");
+  const recordsRoot = "records/openclaw-openclaw";
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, state], root);
+  configureUser(state);
+  const baseTuple = writeRecordTuple(state, {
+    number: 42,
+    marker: "remote base",
+    reviewedAt: "2026-07-09T23:00:00.000Z",
+    itemUpdatedAt: "2026-07-09T22:59:00Z",
+  });
+  run("git", ["add", "."], state);
+  run("git", ["commit", "-m", "remote base"], state);
+  run("git", ["push", "origin", "HEAD:state"], state);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/state"], root);
+  fs.mkdirSync(work);
+  fs.cpSync(path.join(state, "records"), path.join(work, "records"), { recursive: true });
+  writeRecordTuple(work, {
+    number: 42,
+    marker: "candidate update",
+    reviewedAt: "2026-07-09T23:02:00.000Z",
+    itemUpdatedAt: "2026-07-09T23:01:00Z",
+  });
+
+  run("git", ["checkout", "--orphan", "unrelated"], state);
+  run("git", ["read-tree", "--empty"], state);
+  fs.rmSync(path.join(state, "records"), { force: true, recursive: true });
+  fs.writeFileSync(path.join(state, "unrelated.txt"), "unrelated history\n");
+  run("git", ["add", "-A"], state);
+  run("git", ["commit", "-m", "unrelated local history"], state);
+
+  const lines = [];
+  assert.throws(
+    () =>
+      captureConsoleLog(
+        () =>
+          withEnv({ CLAWSWEEPER_STATE_DIR: state }, () =>
+            withCwd(work, () =>
+              publishMainCommit({
+                message: "chore: reject unrelated state",
+                paths: [recordsRoot],
+                maxAttempts: 1,
+                pushAttempts: 1,
+                rebaseStrategy: "reconcile-records",
+              }),
+            ),
+          ),
+        lines,
+      ),
+    /git command <redacted-args> exited 1/,
+  );
+  assert.equal(
+    lines.some((line) => line.includes("Git publish failure: phase=prepare")),
+    true,
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `state:${recordsRoot}/items/42.md`], root),
+    baseTuple.primary,
+  );
+});
+
+test("reconcile-records bounds git subprocesses for a 516-tuple publish", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-scale-"));
+  const origin = path.join(root, "origin.git");
+  const state = path.join(root, "state");
+  const work = path.join(root, "work");
+  const other = path.join(root, "other");
+  const recordsRoot = "records/openclaw-openclaw";
+  const numbers = Array.from({ length: 516 }, (_, index) => 110_000 + index);
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, state], root);
+  configureUser(state);
+  for (const number of numbers) {
+    writeRecordTuple(state, {
+      number,
+      marker: `base ${number}`,
+      reviewedAt: "2026-07-09T23:00:00.000Z",
+      itemUpdatedAt: "2026-07-09T22:59:00Z",
+    });
+  }
+  run("git", ["add", "."], state);
+  run("git", ["commit", "-m", "initial state"], state);
+  run("git", ["push", "origin", "HEAD:state"], state);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/state"], root);
+  run("git", ["checkout", "-B", "state", "origin/state"], state);
+
+  fs.mkdirSync(work);
+  fs.cpSync(path.join(state, "records"), path.join(work, "records"), { recursive: true });
+  for (const number of numbers) {
+    writeRecordTuple(work, {
+      number,
+      marker: `closed ${number}`,
+      reviewedAt: "2026-07-09T23:01:00.000Z",
+      itemUpdatedAt: "2026-07-09T23:00:00Z",
+      location: "closed",
+      packet: false,
+      plan: false,
+      extraFrontMatter: ["reconciled_at: 2026-07-09T23:02:00.000Z"],
+    });
+  }
+  run("git", ["clone", origin, other], root);
+  configureUser(other);
+  const remoteWinner = writeRecordTuple(other, {
+    number: numbers.at(-1),
+    marker: "newer remote tuple during checkpoint publish",
+    reviewedAt: "2026-07-09T23:10:00.000Z",
+    itemUpdatedAt: "2026-07-09T23:09:00Z",
+  });
+  run("git", ["add", "-A"], other);
+  run("git", ["commit", "-m", "newer remote checkpoint tuple"], other);
+  installCheckpointFailureHook(state, other, "state");
+  const paths = numbers.flatMap((number) => [
+    `${recordsRoot}/items/${number}.md`,
+    `${recordsRoot}/closed/${number}.md`,
+    `${recordsRoot}/plans/${number}.md`,
+    `${recordsRoot}/decision-packets/${number}.json`,
+  ]);
+
+  const publish = () =>
+    withEnv({ CLAWSWEEPER_STATE_DIR: state }, () =>
+      withCwd(work, () =>
+        publishMainCommit({
+          message: "chore: publish 516 reconciled tuples",
+          paths,
+          maxAttempts: 1,
+          pushAttempts: 1,
+          rebaseStrategy: "reconcile-records",
+        }),
+      ),
+    );
+  const failedLines = [];
+  assert.throws(
+    () => captureConsoleLog(() => captureProcessWrites(publish), failedLines),
+    /Failed to publish reconciliation checkpoint 2\/5/,
+  );
+  assert.equal(
+    failedLines.some((line) => line.includes("Git publish failure: phase=checkpoint")),
+    true,
+  );
+  assert.match(
+    run("git", ["--git-dir", origin, "show", `state:${recordsRoot}/closed/${numbers[0]}.md`], root),
+    new RegExp(`# closed ${numbers[0]}`),
+  );
+  assert.match(
+    run(
+      "git",
+      ["--git-dir", origin, "show", `state:${recordsRoot}/items/${numbers[128]}.md`],
+      root,
+    ),
+    new RegExp(`# base ${numbers[128]}`),
+  );
+  run("git", ["fetch", "origin", "state"], other);
+  run("git", ["rebase", "origin/state"], other);
+  const divergentRemote = writeRecordTuple(other, {
+    number: 130_000,
+    marker: "divergent remote tuple before retry",
+    reviewedAt: "2026-07-09T23:11:00.000Z",
+    itemUpdatedAt: "2026-07-09T23:10:00Z",
+  });
+  run("git", ["add", "-A"], other);
+  run("git", ["commit", "-m", "divergent remote tuple"], other);
+  run("git", ["push", "origin", "HEAD:state"], other);
+
+  let result;
+  const lines = captureConsoleLog(() =>
+    captureProcessWrites(() => {
+      result = publish();
+    }),
+  );
+
+  assert.equal(result, "committed");
+  const metrics = lines.find((line) => line.startsWith("Git publish metrics:"));
+  assert.ok(metrics, "publish emits bounded git subprocess metrics");
+  console.log(`516-tuple ${metrics}`);
+  const processCount = Number(/processes=(\d+)/.exec(metrics)?.[1]);
+  assert.ok(
+    Number.isInteger(processCount) && processCount <= 192,
+    `516-tuple checkpoint publish used ${processCount} git subprocesses; expected at most 192`,
+  );
+  assert.match(
+    run("git", ["--git-dir", origin, "show", `state:${recordsRoot}/closed/${numbers[0]}.md`], root),
+    new RegExp(`# closed ${numbers[0]}`),
+  );
+  assert.throws(() =>
+    run("git", ["--git-dir", origin, "show", `state:${recordsRoot}/items/${numbers[0]}.md`], root),
+  );
+  assert.equal(
+    run(
+      "git",
+      ["--git-dir", origin, "show", `state:${recordsRoot}/items/${numbers.at(-1)}.md`],
+      root,
+    ),
+    remoteWinner.primary,
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `state:${recordsRoot}/items/130000.md`], root),
+    divergentRemote.primary,
+  );
+});
+
+test("reconcile-records lands one local tuple through a disjoint remote update storm", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-storm-"));
+  const origin = path.join(root, "origin.git");
+  const work = path.join(root, "work");
+  const other = path.join(root, "other");
+  const recordsRoot = "records/openclaw-openclaw";
+  const remoteNumbers = Array.from({ length: 300 }, (_, index) => 120_000 + index);
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, work], root);
+  configureUser(work);
+  writeRecordTuple(work, {
+    number: 42,
+    marker: "local base",
+    reviewedAt: "2026-07-09T23:00:00.000Z",
+    itemUpdatedAt: "2026-07-09T22:59:00Z",
+  });
+  for (const number of remoteNumbers) {
+    writeRecordTuple(work, {
+      number,
+      marker: `remote base ${number}`,
+      reviewedAt: "2026-07-09T23:00:00.000Z",
+      itemUpdatedAt: "2026-07-09T22:59:00Z",
+    });
+  }
+  run("git", ["add", "."], work);
+  run("git", ["commit", "-m", "initial state"], work);
+  run("git", ["push", "origin", "HEAD:main"], work);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/main"], root);
+  run("git", ["checkout", "-B", "main", "origin/main"], work);
+  run("git", ["clone", origin, other], root);
+  configureUser(other);
+
+  const remoteTuples = new Map();
+  for (const number of remoteNumbers) {
+    remoteTuples.set(
+      number,
+      writeRecordTuple(other, {
+        number,
+        marker: `remote update ${number}`,
+        reviewedAt: "2026-07-09T23:02:00.000Z",
+        itemUpdatedAt: "2026-07-09T23:01:00Z",
+      }),
+    );
+  }
+  run("git", ["add", "-A"], other);
+  run("git", ["commit", "-m", "remote tuple update storm"], other);
+  installFirstPushRaceHook(work, other);
+
+  const localTuple = writeRecordTuple(work, {
+    number: 42,
+    marker: "local close through storm",
+    reviewedAt: "2026-07-09T23:03:00.000Z",
+    itemUpdatedAt: "2026-07-09T23:02:00Z",
+    location: "closed",
+    packet: false,
+    plan: false,
+    extraFrontMatter: ["reconciled_at: 2026-07-09T23:04:00.000Z"],
+  });
+
+  let result;
+  const lines = captureConsoleLog(() => {
+    result = withCwd(work, () =>
+      publishMainCommit({
+        message: "chore: reconcile through remote storm",
+        paths: [recordsRoot],
+        maxAttempts: 1,
+        pushAttempts: 2,
+        rebaseStrategy: "reconcile-records",
+      }),
+    );
+  });
+
+  assert.equal(result, "committed");
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `main:${recordsRoot}/closed/42.md`], root),
+    localTuple.primary,
+  );
+  for (const number of [remoteNumbers[0], remoteNumbers.at(-1)]) {
+    assert.equal(
+      run("git", ["--git-dir", origin, "show", `main:${recordsRoot}/items/${number}.md`], root),
+      remoteTuples.get(number).primary,
+    );
+  }
+  assert.equal(
+    lines.some((line) => line === "Rebased reconciliation over disjoint remote tuple changes"),
+    true,
+  );
+  const metrics = lines.find((line) => line.startsWith("Git publish metrics:"));
+  assert.ok(metrics, "storm publish emits metrics");
+  const processCount = Number(/processes=(\d+)/.exec(metrics)?.[1]);
+  assert.ok(
+    Number.isInteger(processCount) && processCount <= 48,
+    `storm publish used ${processCount} git subprocesses; expected at most 48`,
   );
 });
 
@@ -1791,9 +2185,41 @@ if test "$count" -eq 2; then git -C "${other}" push origin HEAD:main; fi
   fs.chmodSync(hook, 0o755);
 }
 
-function captureConsoleLog(callback) {
+function installFirstPushRaceHook(work, other, branch = "main") {
+  const hook = path.join(work, ".git/hooks/pre-push");
+  const counter = path.join(work, ".git/hooks/pre-push-count");
+  fs.writeFileSync(
+    hook,
+    `#!/bin/sh
+count=0
+if test -f "${counter}"; then count=$(cat "${counter}"); fi
+count=$((count + 1))
+printf '%s\\n' "$count" > "${counter}"
+if test "$count" -eq 1; then git -C "${other}" push origin HEAD:${branch}; fi
+`,
+  );
+  fs.chmodSync(hook, 0o755);
+}
+
+function installCheckpointFailureHook(work, other, branch) {
+  const hook = path.join(work, ".git/hooks/pre-push");
+  const counter = path.join(work, ".git/hooks/pre-push-count");
+  fs.writeFileSync(
+    hook,
+    `#!/bin/sh
+count=0
+if test -f "${counter}"; then count=$(cat "${counter}"); fi
+count=$((count + 1))
+printf '%s\\n' "$count" > "${counter}"
+if test "$count" -eq 1; then git -C "${other}" push origin HEAD:${branch}; fi
+if test "$count" -eq 3 || test "$count" -eq 4; then exit 1; fi
+`,
+  );
+  fs.chmodSync(hook, 0o755);
+}
+
+function captureConsoleLog(callback, lines = []) {
   const original = console.log;
-  const lines = [];
   console.log = (message) => {
     lines.push(String(message));
   };
@@ -1802,5 +2228,18 @@ function captureConsoleLog(callback) {
     return lines;
   } finally {
     console.log = original;
+  }
+}
+
+function captureProcessWrites(callback) {
+  const stdoutWrite = process.stdout.write;
+  const stderrWrite = process.stderr.write;
+  process.stdout.write = () => true;
+  process.stderr.write = () => true;
+  try {
+    return callback();
+  } finally {
+    process.stdout.write = stdoutWrite;
+    process.stderr.write = stderrWrite;
   }
 }


### PR DESCRIPTION
## Summary

- batch reconciliation staging, blob reads, existence checks, and tuple restoration instead of spawning Git once per path or blob
- publish large reconciliations as bounded 128-tuple checkpoints, preserving tuple-level winner validation and fail-closed malformed/alias behavior
- recover partial checkpoint failures from the shared semantic base, fast-rebase provably disjoint remote tuple updates, and emit phase/failure/process metrics

## Why

Two broad reconcile canaries (runs `29082934063` and `29084433462`) deterministically spent about 13 minutes in publishing and exited before apply. A 516-tuple local profile reproduced 10,846 Git subprocesses and about 223 seconds of publisher time.

The 516-tuple regression now completes a forced first-push race, a later-checkpoint failure, divergent remote progress, and an idempotent retry with 167 Git subprocesses in about 11 seconds of retry publisher time. It verifies that landed checkpoints, a newer remote tuple winner, and an unrelated divergent remote tuple all survive.

## Validation

- `pnpm run build:repair`
- `node --test test/repair/git-publish.test.ts` (28/28)
- `pnpm exec oxfmt --check src/repair/git-publish.ts test/repair/git-publish.test.ts`
- `git diff --check origin/main...HEAD`
- GPT-5.6 Sol High autoreview

## Live acceptance

- [ ] rerun the broad reconcile canary
- [ ] confirm publisher checkpoint/metrics output and bounded completion
- [ ] confirm the workflow advances into the close/apply phase
