### PR TITLE
fix: retry tuple-safe state publication races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ checkpoint, and status-only commits are intentionally omitted.
 ### Fixed
 
 - Bounded broad reconciliation with batched Git I/O and tuple checkpoints that report progress and resume safely under concurrent state writers.
+- Retried tuple-safe broad reconciliation after full push batches lose continuous exact-state races, including candidates that normalize to no changes.
 - Serialized explicit workflow-dispatch planners through a non-dropping target queue and accounted for recovery runs by their requested or live shards, preventing overlapping target planning and false 89-shard reservations without undercounting multi-shard retries.
 - Reconciled terminal exact-review runs by requested run instead of sampling the first 32 claimed leases, while preserving attempt and claim-generation guards across larger worker waves.
 - Dequeued already-closed exact-review events before setup and treated items closed during review as terminal no-ops, preventing permanent retry churn from consuming live worker capacity.

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -289,7 +289,7 @@ function publishMainCommitInternal(options: GitPublishOptions): PublishResult {
           branch,
           pushAttempts,
           maxAttempts,
-          reconciliationSourceCommit,
+          ...(reconciliationSourceCommit ? { reconciliationSourceCommit } : {}),
         })
       ) {
         throw new Error(`Failed to synchronize unchanged publish with ${remote}/${branch}`);
@@ -320,8 +320,8 @@ function publishMainCommitInternal(options: GitPublishOptions): PublishResult {
         branch,
         pushAttempts,
         maxAttempts,
-        reconciliationSourceCommit,
-        reconciliationTupleKeys,
+        ...(reconciliationSourceCommit ? { reconciliationSourceCommit } : {}),
+        ...(reconciliationTupleKeys ? { reconciliationTupleKeys } : {}),
       })
     ) {
       throw new Error(

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -260,7 +260,12 @@ function publishMainCommitInternal(options: GitPublishOptions): PublishResult {
   stagePaths(options.paths);
   if (!hasStagedChanges()) {
     console.log("No publish changes");
-    if (stateBaseCommit && !pushCommit({ remote, branch, pushAttempts, rebaseStrategy })) {
+    const synchronized =
+      !stateBaseCommit ||
+      (rebaseStrategy === "reconcile-records"
+        ? pushReconciliationCommit({ remote, branch, pushAttempts, maxAttempts })
+        : pushCommit({ remote, branch, pushAttempts, rebaseStrategy }));
+    if (!synchronized) {
       throw new Error(`Failed to synchronize unchanged publish with ${remote}/${branch}`);
     }
     return completeStatePublish("unchanged", options.paths, stateBaseCommit);
@@ -279,12 +284,12 @@ function publishMainCommitInternal(options: GitPublishOptions): PublishResult {
     if (!normalized.changed) {
       restoreWorktree(options.restorePaths ?? []);
       if (
-        !pushCommit({
+        !pushReconciliationCommit({
           remote,
           branch,
           pushAttempts,
-          rebaseStrategy,
-          ...(reconciliationSourceCommit ? { reconciliationSourceCommit } : {}),
+          maxAttempts,
+          reconciliationSourceCommit,
         })
       ) {
         throw new Error(`Failed to synchronize unchanged publish with ${remote}/${branch}`);
@@ -308,6 +313,24 @@ function publishMainCommitInternal(options: GitPublishOptions): PublishResult {
   restoreWorktree(options.restorePaths ?? []);
 
   gitPublishPhase("push");
+  if (rebaseStrategy === "reconcile-records") {
+    if (
+      !pushReconciliationCommit({
+        remote,
+        branch,
+        pushAttempts,
+        maxAttempts,
+        reconciliationSourceCommit,
+        reconciliationTupleKeys,
+      })
+    ) {
+      throw new Error(
+        "Failed to publish reconciliation without overwriting concurrent record tuples",
+      );
+    }
+    return completeStatePublish("committed", options.paths, stateBaseCommit);
+  }
+
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     if (
       pushCommit({
@@ -315,16 +338,9 @@ function publishMainCommitInternal(options: GitPublishOptions): PublishResult {
         branch,
         pushAttempts,
         rebaseStrategy,
-        ...(reconciliationSourceCommit ? { reconciliationSourceCommit } : {}),
-        ...(reconciliationTupleKeys ? { reconciliationTupleKeys } : {}),
       })
     ) {
       return completeStatePublish("committed", options.paths, stateBaseCommit);
-    }
-    if (rebaseStrategy === "reconcile-records") {
-      throw new Error(
-        "Failed to publish reconciliation without overwriting concurrent record tuples",
-      );
     }
     const rebuildResult = rebuildPublishCommit({
       remote,
@@ -350,13 +366,57 @@ function publishMainCommitInternal(options: GitPublishOptions): PublishResult {
       branch,
       pushAttempts,
       rebaseStrategy,
-      ...(reconciliationSourceCommit ? { reconciliationSourceCommit } : {}),
-      ...(reconciliationTupleKeys ? { reconciliationTupleKeys } : {}),
     })
   ) {
     return completeStatePublish("committed", options.paths, stateBaseCommit);
   }
   throw new Error(`Failed to publish commit after ${maxAttempts} attempts`);
+}
+
+function pushReconciliationCommit(options: {
+  remote: string;
+  branch: string;
+  pushAttempts: number;
+  maxAttempts: number;
+  reconciliationSourceCommit?: string;
+  reconciliationTupleKeys?: ReadonlySet<string>;
+}): boolean {
+  for (let attempt = 1; attempt <= options.maxAttempts; attempt += 1) {
+    if (
+      pushCommit({
+        remote: options.remote,
+        branch: options.branch,
+        pushAttempts: options.pushAttempts,
+        rebaseStrategy: "reconcile-records",
+        ...(options.reconciliationSourceCommit
+          ? { reconciliationSourceCommit: options.reconciliationSourceCommit }
+          : {}),
+        ...(options.reconciliationTupleKeys
+          ? { reconciliationTupleKeys: options.reconciliationTupleKeys }
+          : {}),
+      })
+    ) {
+      return true;
+    }
+    if (attempt === options.maxAttempts) break;
+    const delaySeconds = attempt * 3 + Math.floor(Math.random() * 11);
+    console.log(
+      `Reconciliation publish attempt ${attempt} lost continuous ${options.branch} races; retrying in ${delaySeconds}s`,
+    );
+    sleep(delaySeconds * 1000);
+  }
+  return pushCommit({
+    remote: options.remote,
+    branch: options.branch,
+    pushAttempts: options.pushAttempts,
+    rebaseStrategy: "reconcile-records",
+    ...(options.reconciliationSourceCommit
+      ? { reconciliationSourceCommit: options.reconciliationSourceCommit }
+      : {}),
+    ...(options.reconciliationTupleKeys
+      ? { reconciliationTupleKeys: options.reconciliationTupleKeys }
+      : {}),
+  });
 }
 
 function completeStatePublish(

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -304,6 +304,7 @@ function publishMainCommitInternal(options: GitPublishOptions): PublishResult {
         remote,
         branch,
         pushAttempts,
+        maxAttempts,
         sourceCommit: reconciliationSourceCommit ?? sourceCommit,
         tupleKeys,
       });
@@ -478,6 +479,7 @@ function publishReconciliationChunks(options: {
   remote: string;
   branch: string;
   pushAttempts: number;
+  maxAttempts: number;
   sourceCommit: string;
   tupleKeys: readonly string[];
 }): PublishResult {
@@ -502,11 +504,11 @@ function publishReconciliationChunks(options: {
     }
     committed = true;
     if (
-      !pushCommit({
+      !pushReconciliationCommit({
         remote: options.remote,
         branch: options.branch,
         pushAttempts: options.pushAttempts,
-        rebaseStrategy: "reconcile-records",
+        maxAttempts: options.maxAttempts,
         reconciliationSourceCommit: options.sourceCommit,
         reconciliationTupleKeys: allowedTupleKeys,
       })

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -1236,7 +1236,7 @@ test("reconcile-records bounds git subprocesses for a 516-tuple publish", () => 
   const failedLines = [];
   assert.throws(
     () => captureConsoleLog(() => captureProcessWrites(publish), failedLines),
-    /Failed to publish reconciliation checkpoint 2\/5/,
+    /Failed to publish reconciliation checkpoint 3\/5/,
   );
   assert.equal(
     failedLines.some((line) => line.includes("Git publish failure: phase=checkpoint")),
@@ -1249,10 +1249,18 @@ test("reconcile-records bounds git subprocesses for a 516-tuple publish", () => 
   assert.match(
     run(
       "git",
-      ["--git-dir", origin, "show", `state:${recordsRoot}/items/${numbers[128]}.md`],
+      ["--git-dir", origin, "show", `state:${recordsRoot}/closed/${numbers[128]}.md`],
       root,
     ),
-    new RegExp(`# base ${numbers[128]}`),
+    new RegExp(`# closed ${numbers[128]}`),
+  );
+  assert.match(
+    run(
+      "git",
+      ["--git-dir", origin, "show", `state:${recordsRoot}/items/${numbers[256]}.md`],
+      root,
+    ),
+    new RegExp(`# base ${numbers[256]}`),
   );
   run("git", ["fetch", "origin", "state"], other);
   run("git", ["rebase", "origin/state"], other);
@@ -2358,7 +2366,9 @@ if test -f "${counter}"; then count=$(cat "${counter}"); fi
 count=$((count + 1))
 printf '%s\\n' "$count" > "${counter}"
 if test "$count" -eq 1; then git -C "${other}" push origin HEAD:${branch}; fi
-if test "$count" -eq 3 || test "$count" -eq 4; then exit 1; fi
+case "$count" in
+  3|4|6|7|8|9) exit 1 ;;
+esac
 `,
   );
   fs.chmodSync(hook, 0o755);

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -832,6 +832,152 @@ test("reconcile-records quarantines an ambiguous valid tuple without blocking in
   );
 });
 
+test("reconcile-records retries after a full push batch loses continuous state races", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
+  const origin = path.join(root, "origin.git");
+  const work = path.join(root, "work");
+  const other = path.join(root, "other");
+  const recordsRoot = "records/openclaw-openclaw";
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, work], root);
+  configureUser(work);
+  writeRecordTuple(work, {
+    number: 41,
+    marker: "base local tuple",
+    reviewedAt: "2026-07-09T23:00:00.000Z",
+    itemUpdatedAt: "2026-07-09T22:59:00Z",
+  });
+  run("git", ["add", "."], work);
+  run("git", ["commit", "-m", "initial"], work);
+  run("git", ["push", "origin", "HEAD:main"], work);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/main"], root);
+  run("git", ["checkout", "-B", "main", "origin/main"], work);
+
+  run("git", ["clone", origin, other], root);
+  configureUser(other);
+  const firstRemoteTuple = writeRecordTuple(other, {
+    number: 42,
+    marker: "first exact event race",
+    reviewedAt: "2026-07-09T23:01:00.000Z",
+    itemUpdatedAt: "2026-07-09T23:00:00Z",
+  });
+  run("git", ["add", "."], other);
+  run("git", ["commit", "-m", "first exact event"], other);
+  const firstRemoteCommit = run("git", ["rev-parse", "HEAD"], other).trim();
+  const secondRemoteTuple = writeRecordTuple(other, {
+    number: 43,
+    marker: "second exact event race",
+    reviewedAt: "2026-07-09T23:02:00.000Z",
+    itemUpdatedAt: "2026-07-09T23:01:00Z",
+  });
+  run("git", ["add", "."], other);
+  run("git", ["commit", "-m", "second exact event"], other);
+  run("git", ["push", "origin", `${firstRemoteCommit}:main`], other);
+  installSecondPushRaceHook(work, other);
+
+  const localTuple = writeRecordTuple(work, {
+    number: 41,
+    marker: "broad reconciliation",
+    reviewedAt: "2026-07-09T23:03:00.000Z",
+    itemUpdatedAt: "2026-07-09T23:02:00Z",
+  });
+  const result = withCwd(work, () =>
+    publishMainCommit({
+      message: "chore: publish broad reconciliation",
+      paths: [recordsRoot],
+      maxAttempts: 1,
+      pushAttempts: 1,
+      rebaseStrategy: "reconcile-records",
+    }),
+  );
+
+  assert.equal(result, "committed");
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `main:${recordsRoot}/items/41.md`], root),
+    localTuple.primary,
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `main:${recordsRoot}/items/42.md`], root),
+    firstRemoteTuple.primary,
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `main:${recordsRoot}/items/43.md`], root),
+    secondRemoteTuple.primary,
+  );
+});
+
+test("reconcile-records retries unchanged normalization through continuous state races", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
+  const origin = path.join(root, "origin.git");
+  const work = path.join(root, "work");
+  const other = path.join(root, "other");
+  const recordsRoot = "records/openclaw-openclaw";
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, work], root);
+  configureUser(work);
+  const baseTuple = writeRecordTuple(work, {
+    number: 41,
+    marker: "newer base tuple",
+    reviewedAt: "2026-07-09T23:03:00.000Z",
+    itemUpdatedAt: "2026-07-09T23:02:00Z",
+  });
+  run("git", ["add", "."], work);
+  run("git", ["commit", "-m", "initial"], work);
+  run("git", ["push", "origin", "HEAD:main"], work);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/main"], root);
+  run("git", ["checkout", "-B", "main", "origin/main"], work);
+
+  run("git", ["clone", origin, other], root);
+  configureUser(other);
+  const firstRemoteTuple = writeRecordTuple(other, {
+    number: 42,
+    marker: "first exact event race",
+    reviewedAt: "2026-07-09T23:04:00.000Z",
+    itemUpdatedAt: "2026-07-09T23:03:00Z",
+  });
+  run("git", ["add", "."], other);
+  run("git", ["commit", "-m", "first exact event"], other);
+  const firstRemoteCommit = run("git", ["rev-parse", "HEAD"], other).trim();
+  const secondRemoteTuple = writeRecordTuple(other, {
+    number: 43,
+    marker: "second exact event race",
+    reviewedAt: "2026-07-09T23:05:00.000Z",
+    itemUpdatedAt: "2026-07-09T23:04:00Z",
+  });
+  run("git", ["add", "."], other);
+  run("git", ["commit", "-m", "second exact event"], other);
+  run("git", ["push", "origin", `${firstRemoteCommit}:main`], other);
+  installSecondPushRaceHook(work, other);
+
+  writeRecordTuple(work, {
+    number: 41,
+    marker: "stale broad reconciliation",
+    reviewedAt: "2026-07-09T23:00:00.000Z",
+    itemUpdatedAt: "2026-07-09T22:59:00Z",
+  });
+  const result = withCwd(work, () =>
+    publishMainCommit({
+      message: "chore: discard stale broad reconciliation",
+      paths: [recordsRoot],
+      maxAttempts: 1,
+      pushAttempts: 1,
+      rebaseStrategy: "reconcile-records",
+    }),
+  );
+
+  assert.equal(result, "unchanged");
+  for (const [number, tuple] of [
+    [41, baseTuple],
+    [42, firstRemoteTuple],
+    [43, secondRemoteTuple],
+  ]) {
+    assert.equal(
+      run("git", ["--git-dir", origin, "show", `main:${recordsRoot}/items/${number}.md`], root),
+      tuple.primary,
+    );
+  }
+});
+
 test("reconcile-records rejects a malformed tuple before an uncontended push", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
   const origin = path.join(root, "origin.git");


### PR DESCRIPTION
## Summary

- retry tuple-safe broad reconciliation after a full push batch loses continuous exact-state races
- preserve the original reconciliation source commit and optional tuple guards across every retry batch
- apply the retry path to changed, normalized-unchanged, initially unchanged, and chunked checkpoint publications while retaining the bounded publisher from #474

## Production evidence

[Broad reconciliation run 29083242751](https://github.com/openclaw/clawsweeper/actions/runs/29083242751) exhausted its first push batch while exact-state writers kept advancing the state branch, then failed even though the outer publisher still had retry budget.

## Verification

- `pnpm run build:repair`
- `node --test test/repair/git-publish.test.ts` (30 passed)
- 516-tuple bounded checkpoint regression (134 git processes; limit 192)
- `pnpm exec oxlint src/repair/git-publish.ts test/repair/git-publish.test.ts --deny-warnings --report-unused-disable-directives -D correctness`
- `pnpm run format:check`
- GPT-5.6 Sol High autoreview: clean, 0 findings (0.94 confidence)
