### PR TITLE
fix: isolate coverage proof from apply credentials

### DIFF
--- a/.github/actions/setup-state/action.yml
+++ b/.github/actions/setup-state/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: Optional newline-separated state paths to hydrate.
     required: false
     default: ""
+  persist-credentials:
+    description: Persist the checkout token in local git config for later state publication.
+    required: false
+    default: "true"
 runs:
   using: composite
   steps:
@@ -40,6 +44,7 @@ runs:
         filter: ${{ inputs.filter }}
         fetch-depth: ${{ inputs.fetch-depth }}
         sparse-checkout: ${{ inputs.sparse-checkout }}
+        persist-credentials: ${{ inputs.persist-credentials }}
 
     - name: Export state root
       shell: bash

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -211,7 +211,8 @@ env:
 
 concurrency:
   group: ${{ (github.event_name == 'schedule' && (github.event.schedule == '4/15 * * * *' || github.event.schedule == '41 * * * *' || github.event.schedule == '37 */6 * * *')) && format('clawsweeper-target-fanout-{0}', github.event.schedule || github.run_id) || github.event_name == 'repository_dispatch' && format('clawsweeper-event-{0}-{1}', github.event.client_payload.target_repo || 'openclaw/openclaw', github.event.client_payload.item_number || github.run_id) || format('{0}-{1}', (github.event_name == 'schedule' && github.event.schedule == '13 * * * *') && 'clawsweeper-failed-review-retry' || ((github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true' && github.event.inputs.apply_sync_comments_only == 'true') || (github.event_name == 'schedule' && github.event.schedule == '6,21,36,51 * * * *')) && 'clawsweeper-comment-sync' || ((github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '3 * * * *' || github.event.schedule == '18 * * * *' || github.event.schedule == '33 * * * *' || github.event.schedule == '48 * * * *' || github.event.schedule == '8,23,38,53 * * * *'))) && 'clawsweeper-apply' || (github.event_name == 'workflow_dispatch' && (github.event.inputs.item_number != '' || github.event.inputs.item_numbers != '')) && format('clawsweeper-intake-exact-{0}', github.event.inputs.item_number || github.event.inputs.item_numbers) || ((github.event_name == 'workflow_dispatch' && github.event.inputs.hot_intake == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '*/5 * * * *' || github.event.schedule == '2/5 * * * *'))) && format('clawsweeper-intake-v2-{0}', github.run_id) || ((github.event_name == 'workflow_dispatch' && github.event.inputs.audit_dashboard == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '7 */6 * * *' || github.event.schedule == '12 */6 * * *' || github.event.schedule == '17 */6 * * *'))) && 'clawsweeper-audit' || format('clawsweeper-review-{0}', github.run_id), github.event.inputs.target_repo || github.event.client_payload.target_repo || ((github.event.schedule == '17 */6 * * *') && 'openclaw/clawsweeper' || ((github.event.schedule == '2/5 * * * *' || github.event.schedule == '22 * * * *' || github.event.schedule == '8,23,38,53 * * * *' || github.event.schedule == '12 */6 * * *') && 'openclaw/clawhub' || 'openclaw/openclaw'))) }}
-  cancel-in-progress: ${{ github.event_name == 'repository_dispatch' && github.event.action == 'clawsweeper_target_sweep' }}
+  queue: max
+  cancel-in-progress: false
 
 jobs:
   event-disabled-target:
@@ -1741,11 +1742,16 @@ jobs:
     if: ${{ always() && needs.plan.result == 'success' && needs.review.result != 'cancelled' && needs.plan.outputs.target_repo != '' && (github.event_name != 'repository_dispatch' || github.event.action == 'clawsweeper_target_sweep') && !((github.event_name == 'workflow_dispatch' && (github.event.inputs.apply_existing == 'true' || github.event.inputs.audit_dashboard == 'true')) || (github.event_name == 'schedule' && ((github.event.schedule == '3 * * * *' || github.event.schedule == '18 * * * *' || github.event.schedule == '33 * * * *' || github.event.schedule == '48 * * * *' || github.event.schedule == '8,23,38,53 * * * *' || github.event.schedule == '6,21,36,51 * * * *') || (github.event.schedule == '7 */6 * * *' || github.event.schedule == '12 */6 * * *' || github.event.schedule == '17 */6 * * *')))) }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    concurrency:
+      group: clawsweeper-target-publish-${{ needs.plan.outputs.target_repo }}
+      cancel-in-progress: false
+      queue: max
     steps:
       - uses: actions/checkout@v7
         with:
           filter: blob:none
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Create target write token
         id: target-write-token
@@ -2083,68 +2089,41 @@ jobs:
             --path "results/sweep-status/${target_slug}.json" \
             --rebase-strategy theirs
 
-      - uses: ./.github/actions/setup-codex
+      - name: Dispatch selected safe close proposals to isolated apply
         if: ${{ success() && steps.target-write-token.outputs.token != '' && github.event.inputs.apply_after_review == 'true' }}
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          CLAWSWEEPER_INTERNAL_MODEL: ${{ secrets.CLAWSWEEPER_MODEL }}
-
-      - name: Apply selected safe close proposals
-        if: ${{ success() && steps.target-write-token.outputs.token != '' && github.event.inputs.apply_after_review == 'true' }}
-        timeout-minutes: 30
-        env:
-          GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
           TARGET_REPO: ${{ needs.plan.outputs.target_repo }}
-          CLAWSWEEPER_UNCONFIRMED_PRODUCT_DIRECTION_CLOSE_ENABLED: ${{ vars.CLAWSWEEPER_UNCONFIRMED_PRODUCT_DIRECTION_CLOSE_ENABLED || 'false' }}
         run: |
           set -euo pipefail
-          test -n "$GH_TOKEN"
-          target_slug="$TARGET_REPO"
-          target_slug="${target_slug//\//-}"
           item_numbers="$(pnpm run --silent workflow -- artifact-item-numbers --artifact-dir artifacts)"
           if [ -z "$item_numbers" ]; then
-            echo "No review artifacts to apply."
+            echo "No review artifacts to dispatch for isolated apply."
             exit 0
           fi
           item_count="$(pnpm run --silent workflow -- count-csv --items "$item_numbers")"
           close_reasons="${{ github.event.inputs.apply_after_review_close_reasons || 'implemented_on_main,duplicate_or_superseded,low_signal_unmergeable_pr' }}"
           min_age_minutes="${{ github.event.inputs.apply_after_review_min_age_minutes || '0' }}"
-          git pull --rebase --autostash
-          pnpm run apply-decisions -- \
-            --target-repo "$TARGET_REPO" \
-            --skip-dashboard \
-            --item-numbers "$item_numbers" \
-            --apply-kind all \
-            --apply-close-reasons "$close_reasons" \
-            --stale-min-age-days 30 \
-            --limit "$item_count" \
-            --processed-limit "$((item_count * 10))" \
-            --min-age-minutes "$min_age_minutes" \
-            --close-delay-ms 1000 \
-            --comment-sync-min-age-days 0 \
-            --progress-every 1
-          closed_count="$(pnpm run --silent workflow -- count-actions --report apply-report.json --action closed)"
-          pnpm run status -- \
-            --target-repo "$TARGET_REPO" \
-            --state "Immediate apply checked" \
-            --detail "Checked selected safe close proposals right after review publish. Closed: $closed_count/$item_count. Close reasons enabled: $close_reasons. Item numbers: $item_numbers." \
-            --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            --planned-count "${{ needs.plan.outputs.planned_count }}" \
-            --planned-capacity "${{ needs.plan.outputs.planned_capacity }}" \
-            --planned-shards "${{ needs.plan.outputs.planned_shards }}" \
-            --active-codex "0" \
-            --due-backlog "${{ needs.plan.outputs.due_backlog }}" \
-            --oldest-unreviewed-at "${{ needs.plan.outputs.oldest_unreviewed_at }}" \
-            --capacity-reason "${{ needs.plan.outputs.capacity_reason }}"
-          pnpm run repair:publish-main -- \
-            --message "chore: apply selected sweep decisions" \
-            --path "records/${target_slug}" \
-            --rebase-strategy reconcile-records
-          pnpm run repair:publish-main -- \
-            --message "chore: publish selected sweep decision status" \
-            --path apply-report.json \
-            --path "results/sweep-status/${target_slug}.json" \
-            --rebase-strategy theirs
+          for attempt in 1 2 3; do
+            if gh workflow run sweep.yml \
+              --ref main \
+              -f target_repo="$TARGET_REPO" \
+              -f apply_existing=true \
+              -f apply_item_numbers="$item_numbers" \
+              -f apply_limit="$item_count" \
+              -f apply_min_age_minutes="$min_age_minutes" \
+              -f apply_kind=all \
+              -f apply_close_reasons="$close_reasons" \
+              -f apply_stale_min_age_days=30 \
+              -f apply_close_delay_ms=1000 \
+              -f apply_comment_sync_min_age_days=0; then
+              echo "Dispatched isolated apply for item numbers: $item_numbers"
+              exit 0
+            fi
+            sleep "$((attempt * 10))"
+          done
+          echo "Unable to dispatch isolated apply after three attempts." >&2
+          exit 1
 
       - name: Continue sweep
         if: ${{ success() && needs.plan.outputs.planned_count == needs.plan.outputs.planned_capacity && github.event_name != 'repository_dispatch' && (github.event_name != 'workflow_dispatch' || (github.event.inputs.item_number == '' && github.event.inputs.item_numbers == '')) }}
@@ -2462,11 +2441,178 @@ jobs:
             --repo openclaw/clawsweeper-state \
             --ref main || echo "Best-effort dashboard refresh dispatch failed; scheduled state dashboard will retry."
 
+  apply-proof:
+    name: Prove close coverage without write credentials
+    if: ${{ ((github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '3 * * * *' || github.event.schedule == '18 * * * *' || github.event.schedule == '33 * * * *' || github.event.schedule == '48 * * * *' || github.event.schedule == '8,23,38,53 * * * *' || github.event.schedule == '6,21,36,51 * * * *'))) && !(github.event_name == 'repository_dispatch' && github.event.client_payload.target_repo == 'openclaw/clawhub' && vars.CLAWSWEEPER_ENABLE_CLAWHUB != '1') && !(github.event_name == 'schedule' && github.event.schedule == '8,23,38,53 * * * *' && vars.CLAWSWEEPER_ENABLE_CLAWHUB != '1') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+    env:
+      CLAWSWEEPER_UNCONFIRMED_PRODUCT_DIRECTION_CLOSE_ENABLED: ${{ vars.CLAWSWEEPER_UNCONFIRMED_PRODUCT_DIRECTION_CLOSE_ENABLED || 'false' }}
+    outputs:
+      target_repo: ${{ steps.target.outputs.target_repo }}
+      artifact_name: ${{ steps.proof-artifact.outputs.name }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          filter: blob:none
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Resolve proof target repository
+        id: target
+        run: |
+          target_repo="${{ github.event.inputs.target_repo || '' }}"
+          if [ -z "$target_repo" ]; then
+            case "${{ github.event.schedule || '' }}" in
+              "8,23,38,53 * * * *") target_repo="openclaw/clawhub" ;;
+              *) target_repo="openclaw/openclaw" ;;
+            esac
+          fi
+          echo "target_repo=$target_repo" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve proof artifact identity
+        id: proof-artifact
+        run: echo "name=apply-coverage-proofs-${{ github.run_id }}-${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
+
+      - uses: ./.github/actions/setup-state
+        with:
+          token: ${{ github.token }}
+          persist-credentials: "false"
+
+      - uses: ./.github/actions/setup-pnpm
+        with:
+          build-script: build:all
+
+      - name: Reconcile read-only proof inputs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_REPO: ${{ steps.target.outputs.target_repo }}
+        run: |
+          set -euo pipefail
+          item_numbers="${{ github.event.inputs.apply_item_numbers || '' }}"
+          if [ "$item_numbers" = "__cursor__" ]; then
+            item_numbers=""
+          fi
+          reconcile_args=(--target-repo "$TARGET_REPO" --skip-closed-at)
+          if [ -n "$item_numbers" ]; then
+            reconcile_args+=(--item-numbers "$item_numbers")
+          fi
+          pnpm run reconcile -- "${reconcile_args[@]}"
+
+      - name: Select bounded coverage proof work
+        id: proof-select
+        env:
+          TARGET_REPO: ${{ steps.target.outputs.target_repo }}
+        run: |
+          set -euo pipefail
+          min_age_days="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_min_age_days || '0' }}"
+          min_age_minutes="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_min_age_minutes || '' }}"
+          apply_kind="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_kind || 'all' }}"
+          apply_close_reasons="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_close_reasons || 'all' }}"
+          stale_min_age_days="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_stale_min_age_days || '60' }}"
+          item_numbers="${{ github.event.inputs.apply_item_numbers || '' }}"
+          sync_comments_only="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_sync_comments_only || 'false' }}"
+          if [ "$item_numbers" = "__cursor__" ]; then
+            item_numbers=""
+            sync_comments_only="true"
+          fi
+          product_direction_enabled=false
+          case "${CLAWSWEEPER_UNCONFIRMED_PRODUCT_DIRECTION_CLOSE_ENABLED,,}" in
+            true|1|yes|on) product_direction_enabled=true ;;
+          esac
+          if [ "$sync_comments_only" != "true" ] && [ "$product_direction_enabled" != "true" ] && [ "$apply_close_reasons" != "all" ]; then
+            apply_close_reasons="$(printf '%s\n' "$apply_close_reasons" | tr ',' '\n' | awk '$0 != "unconfirmed_product_direction" && NF' | paste -sd, -)"
+          fi
+          selected=""
+          if [ "$sync_comments_only" != "true" ] && [ -n "$apply_close_reasons" ]; then
+            proof_args=(
+              --target-repo "$TARGET_REPO"
+              --apply-kind "$apply_kind"
+              --apply-close-reasons "$apply_close_reasons"
+              --stale-min-age-days "$stale_min_age_days"
+              --min-age-days "$min_age_days"
+              --min-age-minutes "$min_age_minutes"
+              --batch-size 2
+              --close-limit 2
+              --coverage-proof-limit 2
+            )
+            if [ -n "$item_numbers" ]; then
+              proof_args+=(--item-numbers "$item_numbers")
+            else
+              target_slug="${TARGET_REPO//\//-}"
+              proof_args+=(--cursor-path "results/apply-cursors/${target_slug}.json")
+            fi
+            selected="$(pnpm run --silent workflow -- proposed-pr-close-coverage-item-numbers "${proof_args[@]}")"
+          fi
+          echo "item_numbers=$selected" >> "$GITHUB_OUTPUT"
+          echo "Selected read-only coverage proof items: ${selected:-none}"
+
+      - uses: ./.github/actions/setup-codex
+        if: ${{ steps.proof-select.outputs.item_numbers != '' }}
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          CLAWSWEEPER_INTERNAL_MODEL: ${{ secrets.CLAWSWEEPER_MODEL }}
+
+      - name: Generate bound close coverage proofs
+        if: ${{ steps.proof-select.outputs.item_numbers != '' }}
+        timeout-minutes: 50
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CLAWSWEEPER_PROOF_INSPECTION_TOKEN: ${{ github.token }}
+          TARGET_REPO: ${{ steps.target.outputs.target_repo }}
+        run: |
+          set -euo pipefail
+          item_numbers="${{ steps.proof-select.outputs.item_numbers }}"
+          item_count="$(pnpm run --silent workflow -- count-csv --items "$item_numbers")"
+          min_age_minutes="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_min_age_minutes || '' }}"
+          min_age_minutes_arg=()
+          if [ -n "$min_age_minutes" ]; then
+            min_age_minutes_arg=(--min-age-minutes "$min_age_minutes")
+          fi
+          mkdir -p .artifacts/apply-proof/pr-close-coverage-proof
+          pnpm run apply-decisions -- \
+            --target-repo "$TARGET_REPO" \
+            --skip-dashboard \
+            --dry-run \
+            --item-numbers "$item_numbers" \
+            --apply-kind "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_kind || 'all' }}" \
+            --apply-close-reasons "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_close_reasons || 'all' }}" \
+            --stale-min-age-days "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_stale_min_age_days || '60' }}" \
+            --min-age-days "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_min_age_days || '0' }}" \
+            "${min_age_minutes_arg[@]}" \
+            --limit "$item_count" \
+            --processed-limit "$((item_count * 10))" \
+            --close-delay-ms 0 \
+            --max-runtime-ms 2700000 \
+            --codex-model internal \
+            --codex-reasoning-effort high \
+            --artifact-dir .artifacts/apply-proof \
+            --report-path .artifacts/apply-proof/apply-report.json \
+            --progress-every 1
+
+      - name: Upload bound close coverage proofs
+        if: ${{ always() && steps.proof-select.outputs.item_numbers != '' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ steps.proof-artifact.outputs.name }}
+          path: .artifacts/apply-proof/pr-close-coverage-proof/*.proof.json
+          if-no-files-found: ignore
+          retention-days: 1
+
   apply-existing:
     name: Apply close proposals
+    needs: apply-proof
     if: ${{ ((github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '3 * * * *' || github.event.schedule == '18 * * * *' || github.event.schedule == '33 * * * *' || github.event.schedule == '48 * * * *' || github.event.schedule == '8,23,38,53 * * * *' || github.event.schedule == '6,21,36,51 * * * *'))) && !(github.event_name == 'repository_dispatch' && github.event.client_payload.target_repo == 'openclaw/clawhub' && vars.CLAWSWEEPER_ENABLE_CLAWHUB != '1') && !(github.event_name == 'schedule' && github.event.schedule == '8,23,38,53 * * * *' && vars.CLAWSWEEPER_ENABLE_CLAWHUB != '1') }}
     runs-on: ubuntu-latest
     timeout-minutes: 360
+    concurrency:
+      group: clawsweeper-target-publish-${{ needs.apply-proof.outputs.target_repo }}
+      cancel-in-progress: false
+      queue: max
     env:
       CLAWSWEEPER_UNCONFIRMED_PRODUCT_DIRECTION_CLOSE_ENABLED: ${{ vars.CLAWSWEEPER_UNCONFIRMED_PRODUCT_DIRECTION_CLOSE_ENABLED || 'false' }}
     steps:
@@ -2474,9 +2620,12 @@ jobs:
         with:
           filter: blob:none
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Resolve target repository
         id: target
+        env:
+          PROOF_TARGET_REPO: ${{ needs.apply-proof.outputs.target_repo }}
         run: |
           target_repo="${{ github.event_name == 'repository_dispatch' && github.event.client_payload.target_repo || github.event.inputs.target_repo || '' }}"
           if [ -z "$target_repo" ]; then
@@ -2489,6 +2638,10 @@ jobs:
                 ;;
             esac
           fi
+          if [ -z "$PROOF_TARGET_REPO" ] || [ "$target_repo" != "$PROOF_TARGET_REPO" ]; then
+            echo "Resolved mutation target '$target_repo' differs from proof target '${PROOF_TARGET_REPO:-missing}'." >&2
+            exit 1
+          fi
           target_owner="${target_repo%%/*}"
           target_name="${target_repo#*/}"
           {
@@ -2496,9 +2649,6 @@ jobs:
             echo "target_repo_owner=$target_owner"
             echo "target_repo_name=$target_name"
           } >> "$GITHUB_OUTPUT"
-
-      - name: Sync source checkout before state hydration
-        run: git pull --rebase --autostash
 
       - name: Create target write token
         id: target-write-token
@@ -2529,6 +2679,19 @@ jobs:
         with:
           build-script: build:all
 
+      - uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: ${{ needs.apply-proof.outputs.artifact_name }}
+          path: .artifacts/apply-proof/pr-close-coverage-proof
+
+      - name: Validate downloaded close coverage proof tree
+        run: |
+          set -euo pipefail
+          source scripts/apply-workflow-helpers.sh
+          # Two source items, with at most four canonical candidates per item.
+          validate_coverage_proof_tree ".artifacts/apply-proof/pr-close-coverage-proof" 8 262144 2097152
+
       - name: Reconcile before apply preselect
         env:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
@@ -2545,82 +2708,6 @@ jobs:
             reconcile_args+=(--item-numbers "$item_numbers")
           fi
           persist_reconciliation "${reconcile_args[@]}"
-
-      - name: Preselect apply work that can need Codex
-        id: apply-preselect
-        env:
-          TARGET_REPO: ${{ steps.target.outputs.target_repo }}
-        run: |
-          set -euo pipefail
-          min_age_days="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_min_age_days || '0' }}"
-          min_age_minutes="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_min_age_minutes || '' }}"
-          apply_kind="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_kind || 'all' }}"
-          apply_close_reasons="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_close_reasons || 'all' }}"
-          stale_min_age_days="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_stale_min_age_days || '60' }}"
-          item_numbers="${{ github.event_name == 'repository_dispatch' && github.event.client_payload.item_number || github.event.inputs.apply_item_numbers || '' }}"
-          sync_open_pr_batch="${{ github.event_name == 'schedule' && github.event.schedule == '6,21,36,51 * * * *' && 'true' || 'false' }}"
-          if [ "$item_numbers" = "__cursor__" ]; then
-            sync_open_pr_batch="true"
-            item_numbers=""
-          fi
-          sync_comments_only="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_sync_comments_only || 'false' }}"
-          product_direction_enabled=false
-          case "${CLAWSWEEPER_UNCONFIRMED_PRODUCT_DIRECTION_CLOSE_ENABLED,,}" in
-            true|1|yes|on) product_direction_enabled=true ;;
-          esac
-          if [ "$sync_comments_only" != "true" ] && [ "$product_direction_enabled" != "true" ] && [ "$apply_close_reasons" != "all" ]; then
-            apply_close_reasons="$(printf '%s\n' "$apply_close_reasons" | tr ',' '\n' | awk '$0 != "unconfirmed_product_direction" && NF' | paste -sd, -)"
-          fi
-          if [ "$sync_comments_only" != "true" ] && [ -z "$apply_close_reasons" ]; then
-            echo "No enabled close reasons remain after policy filtering; skipping apply."
-            echo "needs_codex=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if [ "$sync_open_pr_batch" = "true" ]; then
-            sync_comments_only="true"
-            apply_kind="pull_request"
-          fi
-
-          needs_codex=false
-          if [ "$sync_comments_only" = "true" ]; then
-            if [ "$sync_open_pr_batch" = "true" ]; then
-              target_slug="$TARGET_REPO"
-              target_slug="${target_slug//\//-}"
-              cursor_path="results/comment-sync-cursors/${target_slug}.json"
-              sync_batch_size="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_limit || '25' }}"
-              batch_env=".artifacts/apply-preselect-comment-sync-batch.env"
-              mkdir -p "$(dirname "$batch_env")"
-              pnpm run --silent workflow -- comment-sync-batch \
-                --target-repo "$TARGET_REPO" \
-                --apply-kind "$apply_kind" \
-                --batch-size "$sync_batch_size" \
-                --cursor-path "$cursor_path" > "$batch_env"
-              batch_count="$(awk -F= '$1 == "count" { print $2 }' "$batch_env")"
-            fi
-          else
-            proof_args=(
-              --target-repo "$TARGET_REPO"
-              --apply-kind "$apply_kind"
-              --apply-close-reasons "$apply_close_reasons"
-              --stale-min-age-days "$stale_min_age_days"
-              --min-age-days "$min_age_days"
-              --min-age-minutes "$min_age_minutes"
-            )
-            if [ -n "$item_numbers" ]; then
-              proof_args+=(--item-numbers "$item_numbers")
-            fi
-            selected="$(pnpm run --silent workflow -- proposed-pr-close-coverage-item-numbers "${proof_args[@]}")"
-            if [ -n "$selected" ]; then
-              needs_codex=true
-            fi
-          fi
-          echo "needs_codex=$needs_codex" >> "$GITHUB_OUTPUT"
-
-      - uses: ./.github/actions/setup-codex
-        if: ${{ steps.apply-preselect.outputs.needs_codex == 'true' }}
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          CLAWSWEEPER_INTERNAL_MODEL: ${{ secrets.CLAWSWEEPER_MODEL }}
 
       - name: Apply unchanged proposed decisions with checkpoints
         env:
@@ -2877,7 +2964,6 @@ jobs:
               cursor_trace_arg=(--cursor-trace "$cursor_trace_path")
             fi
             echo "::group::Apply checkpoint $checkpoint"
-            echo "Applying up to $chunk_limit fresh closes; $closed_total/$limit already closed in this run"
             CLAWSWEEPER_APPLY_CHECKPOINT="$checkpoint" pnpm run apply-decisions -- \
               --target-repo "$TARGET_REPO" \
               --skip-dashboard \
@@ -2894,7 +2980,9 @@ jobs:
               "${item_numbers_arg[@]}" \
               "${max_runtime_arg[@]}" \
               "${cursor_trace_arg[@]}" \
-              "${sync_comments_arg[@]}"
+              "${sync_comments_arg[@]}" \
+              --artifact-dir .artifacts/apply-proof \
+              --require-precomputed-pr-close-coverage-proof
             cp apply-report.json ".artifacts/apply-reports/apply-report-$checkpoint.json"
             pnpm run workflow -- merge-apply-reports --dir .artifacts/apply-reports --output apply-report.json
             closed_in_chunk="$(pnpm run --silent workflow -- count-actions --report ".artifacts/apply-reports/apply-report-$checkpoint.json" --action closed)"

--- a/scripts/apply-workflow-helpers.sh
+++ b/scripts/apply-workflow-helpers.sh
@@ -6,6 +6,48 @@
 
 max_close_processed_limit=900
 coverage_proof_limit=2
+
+validate_coverage_proof_tree() {
+  local proof_dir="$1"
+  local max_files="${2:-2}"
+  local max_file_bytes="${3:-262144}"
+  local max_total_bytes="${4:-524288}"
+  mkdir -p "$proof_dir"
+  local unexpected
+  unexpected="$(find "$proof_dir" -mindepth 1 -maxdepth 1 ! -type f -print -quit)"
+  if [ -n "$unexpected" ]; then
+    echo "Unexpected non-file coverage proof artifact: $unexpected" >&2
+    return 1
+  fi
+  local proof_files=()
+  local proof_file
+  while IFS= read -r -d '' proof_file; do
+    proof_files+=("$proof_file")
+  done < <(find "$proof_dir" -mindepth 1 -maxdepth 1 -type f -print0)
+  if [ "${#proof_files[@]}" -gt "$max_files" ]; then
+    echo "Coverage proof artifact contains ${#proof_files[@]} files; maximum is $max_files." >&2
+    return 1
+  fi
+  local total_bytes=0
+  local proof_name proof_bytes
+  for proof_file in "${proof_files[@]}"; do
+    proof_name="$(basename "$proof_file")"
+    if ! [[ "$proof_name" =~ ^[1-9][0-9]*-[1-9][0-9]*\.proof\.json$ ]]; then
+      echo "Unexpected coverage proof filename: $proof_name" >&2
+      return 1
+    fi
+    proof_bytes="$(wc -c < "$proof_file" | tr -d ' ')"
+    if [ "$proof_bytes" -gt "$max_file_bytes" ]; then
+      echo "Coverage proof artifact exceeds $max_file_bytes bytes: $proof_name" >&2
+      return 1
+    fi
+    total_bytes=$((total_bytes + proof_bytes))
+  done
+  if [ "$total_bytes" -gt "$max_total_bytes" ]; then
+    echo "Coverage proof artifacts exceed the $max_total_bytes-byte total limit." >&2
+    return 1
+  fi
+}
 progress_every=10
 
 publish_changes_with_strategy() {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -93,7 +93,12 @@ import {
   formatPrCloseCoverageProofDetailList,
   prCloseCoverageProofCandidateCanClose,
   prCloseCoverageProofCloseDecision,
+  prCloseCoverageProofEnvelopePath,
+  prCloseCoverageProofPromptSha256,
+  readPrCloseCoverageProofEnvelope,
   runPrCloseCoverageProofModel,
+  validatePrCloseCoverageProofEnvelopeBinding,
+  writePrCloseCoverageProofEnvelope,
   type PrCloseCoverageProofModelResult,
   type PrCloseCoverageProofPullRequestView,
   type PrCloseCoverageProofRuntime,
@@ -14196,13 +14201,17 @@ function linkedRefCanBePullRequest(ref: PullRequestRef): boolean {
   }
 }
 
+const PR_CLOSE_COVERAGE_PROOF_MAX_CANDIDATES_PER_ITEM = 4;
+
 function prCloseCoverageProofCandidateRefs(markdown: string, item: Item): PullRequestRef[] {
   if (item.kind !== "pull_request") return [];
   const linkedRefs = linkedPullRequestRefsFromReport(markdown, item.number);
   const canonicalRefs = linkedRefs
     .filter((ref) => linkedPullRequestHasSupersessionSignal(markdown, item.number, ref.number))
     .filter(linkedRefCanBePullRequest);
-  if (canonicalRefs.length > 0) return canonicalRefs;
+  if (canonicalRefs.length > 0) {
+    return canonicalRefs.slice(0, PR_CLOSE_COVERAGE_PROOF_MAX_CANDIDATES_PER_ITEM);
+  }
   if (frontMatterValue(markdown, "pr_close_coverage_proof_fallback_refs") === "false") return [];
   const possiblePullRequestRefs = linkedRefs.filter(linkedRefCanBePullRequest);
   return possiblePullRequestRefs.length === 1 ? possiblePullRequestRefs : [];
@@ -14277,6 +14286,7 @@ interface PrCloseCoverageProofGateBlock {
 
 interface PrCloseCoverageProofCoveringWitness {
   number: number;
+  provedAtMs: number;
   updatedAt: string | null;
   url: string;
   proof: PrCloseCoverageProofModelResult;
@@ -14341,6 +14351,7 @@ function sourcePrCloseCoveragePullRequestView(
       stringOrUndefined(pull.body) ?? stringOrUndefined(issue.body) ?? "",
     ),
     updatedAt: item.updatedAt,
+    headSha: pullHeadShaFromContext(context) ?? null,
     comments: (context.comments ?? []).map(compactPrCloseCoverageProofComment),
     commentsTruncated: Boolean(context.counts?.commentsTruncated),
   };
@@ -14371,6 +14382,7 @@ function coveringPrCloseCoveragePullRequestView(
       stringOrUndefined(pull.body) ?? stringOrUndefined(issue.body) ?? "",
     ),
     updatedAt: stringOrUndefined(pull.updated_at) ?? stringOrUndefined(issue.updated_at) ?? null,
+    headSha: stringOrUndefined(asRecord(pull.head).sha) ?? null,
     comments: filteredComments.included.map(compactPrCloseCoverageProofComment),
     commentsTruncated: commentsWindow.truncated,
   };
@@ -14408,8 +14420,12 @@ function prCloseCoverageProofGateResult(options: {
   item: Item;
   context: ItemContext;
   runtime: PrCloseCoverageProofRuntime;
+  requirePrecomputedProof?: boolean;
   runtimeBudget?: PrCloseCoverageRuntimeBudget;
 }): PrCloseCoverageProofGateResult {
+  // This trusted timestamp precedes mutation-side hydration and validation. The
+  // proof artifact's own timestamp is audit metadata, not a freshness authority.
+  const proofBindingStartedAtMs = Date.now();
   const beforeCandidateResolution = prCloseCoverageRuntimeBudgetBlock(
     options.runtimeBudget,
     "before resolving",
@@ -14476,28 +14492,64 @@ function prCloseCoverageProofGateResult(options: {
         },
       };
     }
-    const proofRuntime = prCloseCoverageRuntime(options.runtime, options.runtimeBudget);
-    if (!proofRuntime) {
-      return prCloseCoverageRuntimeBudgetBlock(options.runtimeBudget, "before running");
-    }
     try {
-      const proof = runPrCloseCoverageProofModel({
+      const relationshipSignalSnippets = prCloseCoverageProofSignalSnippets(
+        options.markdown,
+        options.item.number,
+        linkedNumber,
+      );
+      const promptSha256 = prCloseCoverageProofPromptSha256({
         source,
         covering,
-        markdown: options.markdown,
-        relationshipSignalSnippets: prCloseCoverageProofSignalSnippets(
-          options.markdown,
-          options.item.number,
-          linkedNumber,
-        ),
-        runtime: proofRuntime,
+        reportMarkdown: options.markdown,
+        relationshipSignalSnippets,
+        promptTemplate: options.runtime.promptTemplate,
       });
+      let proofStartedAtMs = proofBindingStartedAtMs;
+      const envelope = options.requirePrecomputedProof
+        ? readPrCloseCoverageProofEnvelope(
+            prCloseCoverageProofEnvelopePath(
+              options.runtime.workDir,
+              source.number,
+              covering.number,
+            ),
+          )
+        : (() => {
+            const proofRuntime = prCloseCoverageRuntime(options.runtime, options.runtimeBudget);
+            if (!proofRuntime) {
+              throw new Error("runtime budget reached before running PR close coverage proof");
+            }
+            proofStartedAtMs = Date.now();
+            const proof = runPrCloseCoverageProofModel({
+              source,
+              covering,
+              markdown: options.markdown,
+              relationshipSignalSnippets,
+              runtime: proofRuntime,
+            });
+            return writePrCloseCoverageProofEnvelope({
+              workDir: options.runtime.workDir,
+              targetRepo: targetRepo(),
+              promptSha256,
+              source,
+              covering,
+              proof,
+            });
+          })();
+      validatePrCloseCoverageProofEnvelopeBinding(envelope, {
+        targetRepo: targetRepo(),
+        promptSha256,
+        source,
+        covering,
+      });
+      const proof = envelope.proof;
       const closeDecision = prCloseCoverageProofCloseDecision(proof);
       if (closeDecision.close) {
         return {
           status: "allowed",
           covering: {
             number: covering.number,
+            provedAtMs: proofStartedAtMs,
             updatedAt: covering.updatedAt,
             url: covering.url,
             proof: closeDecision.proof,
@@ -14518,7 +14570,9 @@ function prCloseCoverageProofGateResult(options: {
         status: "blocked",
         block: {
           actionTaken: "retry_pr_close_coverage_proof",
-          reason: `PR close coverage proof failed for linked canonical PR #${linkedNumber}: ${
+          reason: `PR close coverage proof ${
+            options.requirePrecomputedProof ? "artifact validation" : "generation"
+          } failed for linked canonical PR #${linkedNumber}: ${
             error instanceof Error ? error.message : String(error)
           }`,
         },
@@ -19687,6 +19741,9 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
   const closeDelayMs = numberArg(args.close_delay_ms, 2_000);
   const progressEvery = Math.max(1, numberArg(args.progress_every, 10));
   const dryRun = boolArg(args.dry_run);
+  const requirePrecomputedPrCloseCoverageProof = boolArg(
+    args.require_precomputed_pr_close_coverage_proof,
+  );
   const syncCommentsOnly = boolArg(args.sync_comments_only);
   const emitEventApplyProof = boolArg(args.event_apply_proof);
   const commentSyncMinAgeDays = numberArg(args.comment_sync_min_age_days, 0);
@@ -20393,12 +20450,12 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
             if (proofTimeoutMs === null) {
               cachedPrCloseCoverageProofGateResult = runtimeBudgetProofBlock();
             } else {
-              prCloseCoverageProofStartedAtMs = Date.now();
               const proofGateResult = prCloseCoverageProofGateResult({
                 markdown,
                 item,
                 context,
                 runtime: { ...prCloseCoverageProofRuntime, timeoutMs: proofTimeoutMs },
+                requirePrecomputedProof: requirePrecomputedPrCloseCoverageProof,
                 runtimeBudget: { startedAtMs, maxRuntimeMs },
               });
               cachedPrCloseCoverageProofGateResult =
@@ -20411,6 +20468,10 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
                 )
                   ? runtimeBudgetProofBlock("during")
                   : proofGateResult;
+              if (cachedPrCloseCoverageProofGateResult?.status === "allowed") {
+                prCloseCoverageProofStartedAtMs =
+                  cachedPrCloseCoverageProofGateResult.covering.provedAtMs;
+              }
             }
           }
         } else {

--- a/src/pr-close-coverage-proof.ts
+++ b/src/pr-close-coverage-proof.ts
@@ -1,5 +1,6 @@
 import { codexLoginConfig, codexModelArgs } from "./codex-env.js";
-import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { existsSync, lstatSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { codexEnv } from "./codex-env.js";
 import { runCodexProcess } from "./codex-process.js";
@@ -30,6 +31,7 @@ export interface PrCloseCoverageProofPullRequestView {
   mergedAt: string | null;
   body: string;
   updatedAt: string | null;
+  headSha?: string | null;
   comments: unknown[];
   commentsTruncated: boolean;
 }
@@ -47,6 +49,22 @@ export interface PrCloseCoverageProofRuntime {
   ghToken?: string;
 }
 
+export interface PrCloseCoverageProofEnvelope {
+  schemaVersion: 1;
+  targetRepo: string;
+  generatedAt: string;
+  promptSha256: string;
+  source: {
+    number: number;
+    snapshotSha256: string;
+  };
+  covering: {
+    number: number;
+    snapshotSha256: string;
+  };
+  proof: PrCloseCoverageProofModelResult;
+}
+
 const PR_CLOSE_COVERAGE_PROOF_DECISIONS = new Set<PrCloseCoverageProofModelDecision>([
   "covered",
   "keep_open",
@@ -60,6 +78,16 @@ const PR_CLOSE_COVERAGE_PROOF_SCHEMA_KEYS = new Set([
   "decision",
   "reason",
 ]);
+const PR_CLOSE_COVERAGE_PROOF_ENVELOPE_KEYS = new Set([
+  "schemaVersion",
+  "targetRepo",
+  "generatedAt",
+  "promptSha256",
+  "source",
+  "covering",
+  "proof",
+]);
+const PR_CLOSE_COVERAGE_PROOF_SNAPSHOT_KEYS = new Set(["number", "snapshotSha256"]);
 const PR_CLOSE_COVERAGE_PROOF_GENERIC_WORDS = new Set([
   "a",
   "an",
@@ -232,6 +260,12 @@ export function buildPrCloseCoverageProofPrompt(options: {
   ].join("\n");
 }
 
+export function prCloseCoverageProofPromptSha256(
+  options: Parameters<typeof buildPrCloseCoverageProofPrompt>[0],
+): string {
+  return createHash("sha256").update(buildPrCloseCoverageProofPrompt(options)).digest("hex");
+}
+
 export function runPrCloseCoverageProofModel(options: {
   source: PrCloseCoverageProofPullRequestView;
   covering: PrCloseCoverageProofPullRequestView;
@@ -241,7 +275,7 @@ export function runPrCloseCoverageProofModel(options: {
 }): PrCloseCoverageProofModelResult {
   mkdirSync(options.runtime.workDir, { recursive: true });
   const prefix = `${options.source.number}-${options.covering.number}`;
-  const outputPath = join(options.runtime.workDir, `${prefix}.json`);
+  const outputPath = join(options.runtime.workDir, `${prefix}.model.json`);
   const prompt = buildPrCloseCoverageProofPrompt({
     source: options.source,
     covering: options.covering,
@@ -312,6 +346,170 @@ export function runPrCloseCoverageProofModel(options: {
   return readPrCloseCoverageProofModelOutput(outputPath);
 }
 
+export function prCloseCoverageProofEnvelopePath(
+  workDir: string,
+  sourceNumber: number,
+  coveringNumber: number,
+): string {
+  if (!Number.isInteger(sourceNumber) || sourceNumber <= 0) {
+    throw new Error("sourceNumber must be a positive integer");
+  }
+  if (!Number.isInteger(coveringNumber) || coveringNumber <= 0) {
+    throw new Error("coveringNumber must be a positive integer");
+  }
+  return join(workDir, `${sourceNumber}-${coveringNumber}.proof.json`);
+}
+
+export function prCloseCoverageProofSnapshotSha256(
+  pullRequest: PrCloseCoverageProofPullRequestView,
+): string {
+  return createHash("sha256").update(JSON.stringify(pullRequest)).digest("hex");
+}
+
+export function createPrCloseCoverageProofEnvelope(options: {
+  targetRepo: string;
+  generatedAt?: string;
+  promptSha256: string;
+  source: PrCloseCoverageProofPullRequestView;
+  covering: PrCloseCoverageProofPullRequestView;
+  proof: PrCloseCoverageProofModelResult;
+}): PrCloseCoverageProofEnvelope {
+  const targetRepo = normalizedProofTargetRepo(options.targetRepo);
+  const generatedAt = options.generatedAt ?? new Date().toISOString();
+  requireTimestamp(generatedAt, "prCloseCoverageProofEnvelope.generatedAt");
+  const promptSha256 = requireSha256(
+    options.promptSha256,
+    "prCloseCoverageProofEnvelope.promptSha256",
+  );
+  return {
+    schemaVersion: 1,
+    targetRepo,
+    generatedAt,
+    promptSha256,
+    source: {
+      number: options.source.number,
+      snapshotSha256: prCloseCoverageProofSnapshotSha256(options.source),
+    },
+    covering: {
+      number: options.covering.number,
+      snapshotSha256: prCloseCoverageProofSnapshotSha256(options.covering),
+    },
+    proof: normalizedPrCloseCoverageProofModelResult(options.proof),
+  };
+}
+
+export function writePrCloseCoverageProofEnvelope(options: {
+  workDir: string;
+  targetRepo: string;
+  generatedAt?: string;
+  promptSha256: string;
+  source: PrCloseCoverageProofPullRequestView;
+  covering: PrCloseCoverageProofPullRequestView;
+  proof: PrCloseCoverageProofModelResult;
+}): PrCloseCoverageProofEnvelope {
+  const envelope = createPrCloseCoverageProofEnvelope(options);
+  mkdirSync(options.workDir, { recursive: true });
+  writeFileSync(
+    prCloseCoverageProofEnvelopePath(
+      options.workDir,
+      envelope.source.number,
+      envelope.covering.number,
+    ),
+    `${JSON.stringify(envelope, null, 2)}\n`,
+    "utf8",
+  );
+  return envelope;
+}
+
+export function parsePrCloseCoverageProofEnvelope(value: unknown): PrCloseCoverageProofEnvelope {
+  const parsed = requireRecord(value, "prCloseCoverageProofEnvelope");
+  rejectUnexpectedKeys(
+    parsed,
+    PR_CLOSE_COVERAGE_PROOF_ENVELOPE_KEYS,
+    "prCloseCoverageProofEnvelope",
+  );
+  if (parsed.schemaVersion !== 1) {
+    throw new Error("prCloseCoverageProofEnvelope.schemaVersion must be 1");
+  }
+  const source = parseProofSnapshotBinding(parsed.source, "prCloseCoverageProofEnvelope.source");
+  const covering = parseProofSnapshotBinding(
+    parsed.covering,
+    "prCloseCoverageProofEnvelope.covering",
+  );
+  const generatedAt = requireString(parsed.generatedAt, "prCloseCoverageProofEnvelope.generatedAt");
+  requireTimestamp(generatedAt, "prCloseCoverageProofEnvelope.generatedAt");
+  return {
+    schemaVersion: 1,
+    targetRepo: normalizedProofTargetRepo(
+      requireString(parsed.targetRepo, "prCloseCoverageProofEnvelope.targetRepo"),
+    ),
+    generatedAt,
+    promptSha256: requireSha256(parsed.promptSha256, "prCloseCoverageProofEnvelope.promptSha256"),
+    source,
+    covering,
+    proof: normalizedPrCloseCoverageProofModelResult(
+      parsePrCloseCoverageProofModelResult(parsed.proof),
+    ),
+  };
+}
+
+export function readPrCloseCoverageProofEnvelope(path: string): PrCloseCoverageProofEnvelope {
+  const stat = lstatSync(path);
+  if (!stat.isFile()) throw new Error("coverage proof artifact must be a regular file");
+  if (stat.size > 256 * 1024) {
+    throw new Error("coverage proof artifact exceeds the 256 KiB size limit");
+  }
+  return parsePrCloseCoverageProofEnvelope(JSON.parse(readFileSync(path, "utf8").trim()));
+}
+
+export function validatePrCloseCoverageProofEnvelopeBinding(
+  envelope: PrCloseCoverageProofEnvelope,
+  options: {
+    targetRepo: string;
+    promptSha256: string;
+    source: PrCloseCoverageProofPullRequestView;
+    covering: PrCloseCoverageProofPullRequestView;
+  },
+): void {
+  const targetRepo = normalizedProofTargetRepo(options.targetRepo);
+  const generatedAtMs = Date.parse(envelope.generatedAt);
+  if (generatedAtMs > Date.now() + 5 * 60 * 1000) {
+    throw new Error("proof generation timestamp is in the future");
+  }
+  if (envelope.targetRepo !== targetRepo) {
+    throw new Error(
+      `proof target repo ${envelope.targetRepo} did not match expected ${targetRepo}`,
+    );
+  }
+  const promptSha256 = requireSha256(
+    options.promptSha256,
+    "expectedPrCloseCoverageProof.promptSha256",
+  );
+  if (envelope.promptSha256 !== promptSha256) {
+    throw new Error("proof prompt snapshot is stale or mismatched");
+  }
+  if (envelope.source.number !== options.source.number) {
+    throw new Error(
+      `proof source #${envelope.source.number} did not match expected #${options.source.number}`,
+    );
+  }
+  if (envelope.covering.number !== options.covering.number) {
+    throw new Error(
+      `proof covering PR #${envelope.covering.number} did not match expected #${options.covering.number}`,
+    );
+  }
+  const sourceSnapshotSha256 = prCloseCoverageProofSnapshotSha256(options.source);
+  if (envelope.source.snapshotSha256 !== sourceSnapshotSha256) {
+    throw new Error(`proof source snapshot for #${options.source.number} is stale or mismatched`);
+  }
+  const coveringSnapshotSha256 = prCloseCoverageProofSnapshotSha256(options.covering);
+  if (envelope.covering.snapshotSha256 !== coveringSnapshotSha256) {
+    throw new Error(
+      `proof covering snapshot for #${options.covering.number} is stale or mismatched`,
+    );
+  }
+}
+
 export function readPrCloseCoverageProofModelOutput(
   outputPath: string,
 ): PrCloseCoverageProofModelResult {
@@ -359,6 +557,44 @@ function requireRecord(value: unknown, path: string): Record<string, unknown> {
     throw new Error(`${path} must be an object`);
   }
   return value as Record<string, unknown>;
+}
+
+function parseProofSnapshotBinding(
+  value: unknown,
+  path: string,
+): PrCloseCoverageProofEnvelope["source"] {
+  const parsed = requireRecord(value, path);
+  rejectUnexpectedKeys(parsed, PR_CLOSE_COVERAGE_PROOF_SNAPSHOT_KEYS, path);
+  if (typeof parsed.number !== "number") throw new Error(`${path}.number must be a number`);
+  const number = parsed.number;
+  if (!Number.isInteger(number) || number <= 0) throw new Error(`${path}.number must be positive`);
+  const snapshotSha256 = requireString(parsed.snapshotSha256, `${path}.snapshotSha256`);
+  if (!/^[a-f0-9]{64}$/.test(snapshotSha256)) {
+    throw new Error(`${path}.snapshotSha256 must be a lowercase SHA-256 digest`);
+  }
+  return { number, snapshotSha256 };
+}
+
+function normalizedProofTargetRepo(value: string): string {
+  const normalized = value.trim().toLowerCase();
+  if (!/^[a-z0-9_.-]+\/[a-z0-9_.-]+$/.test(normalized)) {
+    throw new Error("prCloseCoverageProofEnvelope.targetRepo must be an owner/repo slug");
+  }
+  return normalized;
+}
+
+function requireTimestamp(value: string, path: string): void {
+  if (!value.trim() || !Number.isFinite(Date.parse(value))) {
+    throw new Error(`${path} must be an ISO timestamp`);
+  }
+}
+
+function requireSha256(value: unknown, path: string): string {
+  const digest = requireString(value, path);
+  if (!/^[a-f0-9]{64}$/.test(digest)) {
+    throw new Error(`${path} must be a lowercase SHA-256 digest`);
+  }
+  return digest;
 }
 
 function rejectUnexpectedKeys(

--- a/test/apply-pr-coverage-proof-close.test.ts
+++ b/test/apply-pr-coverage-proof-close.test.ts
@@ -1,5 +1,13 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
 
@@ -383,6 +391,358 @@ test("apply-decisions records successful duplicate PR coverage proof for closed 
       /Covering PR: https:\/\/github\.com\/openclaw\/openclaw\/pull\/400\./,
     );
   } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions consumes a bound precomputed proof without invoking Codex", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const originalCodexBin = process.env.CODEX_BIN;
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const artifactDir = join(root, "proof-artifacts");
+    const proofLogPath = join(root, "proof.log");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const synced = reportWithSyncedReviewComment(
+      lowSignalCloseReport({
+        number: 361,
+        title: "Provider route fallback",
+        close_reason: "duplicate_or_superseded",
+        work_cluster_refs: JSON.stringify([
+          "Superseded by https://github.com/openclaw/openclaw/pull/400",
+        ]),
+      }).replace(
+        "Closing this PR because the branch is not a useful landing base.",
+        "Closing this PR as superseded by https://github.com/openclaw/openclaw/pull/400.",
+      ),
+      361,
+      "duplicate_or_superseded",
+    );
+    writeFileSync(join(itemsDir, "361.md"), synced.report, "utf8");
+
+    withMockGh(
+      root,
+      promotionGhMock({
+        number: 361,
+        title: "Provider route fallback",
+        comment: synced.comment,
+        linkedPulls: {
+          400: {
+            number: 400,
+            title: "Provider cleanup",
+            html_url: "https://github.com/openclaw/openclaw/pull/400",
+            state: "closed",
+            merged_at: "2026-05-02T00:00:00Z",
+            updated_at: "2026-05-01T00:00:00Z",
+            body: "Includes the fallback route behavior from PR 361.",
+            comments: [],
+            labels: [],
+          },
+        },
+      }),
+      () => {
+        withMockCodexProof(
+          root,
+          {
+            type: "decision",
+            decision: "covered",
+            reason: "PR B carries forward PR A's fallback route behavior.",
+            invocationLogPath: proofLogPath,
+          },
+          () => {
+            runApplyDecisionsForTest({
+              itemsDir,
+              closedDir,
+              plansDir,
+              reportPath,
+              extraArgs: [
+                "--target-repo",
+                "openclaw/openclaw",
+                "--artifact-dir",
+                artifactDir,
+                "--dry-run",
+                "--apply-kind",
+                "all",
+                "--processed-limit",
+                "3",
+              ],
+            });
+          },
+        );
+
+        assert.equal(readFileSync(proofLogPath, "utf8"), "proof\n");
+        assert.equal(
+          existsSync(join(artifactDir, "pr-close-coverage-proof", "361-400.proof.json")),
+          true,
+        );
+        process.env.CODEX_BIN = join(root, "codex-must-not-run");
+        writeFileSync(
+          join(itemsDir, "361.md"),
+          synced.report.replace(
+            "Superseded by https://github.com/openclaw/openclaw/pull/400",
+            "Fixed by https://github.com/openclaw/openclaw/pull/400",
+          ),
+          "utf8",
+        );
+        runApplyDecisionsForTest({
+          itemsDir,
+          closedDir,
+          plansDir,
+          reportPath,
+          extraArgs: [
+            "--target-repo",
+            "openclaw/openclaw",
+            "--artifact-dir",
+            artifactDir,
+            "--require-precomputed-pr-close-coverage-proof",
+            "--apply-kind",
+            "all",
+            "--processed-limit",
+            "3",
+          ],
+        });
+        const staleInputReport = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+          action: string;
+          reason: string;
+        }>;
+        assert.equal(
+          staleInputReport.some((entry) => entry.action === "closed"),
+          false,
+        );
+        assert.match(staleInputReport[0]?.reason ?? "", /prompt snapshot is stale/);
+
+        writeFileSync(join(itemsDir, "361.md"), synced.report, "utf8");
+        runApplyDecisionsForTest({
+          itemsDir,
+          closedDir,
+          plansDir,
+          reportPath,
+          extraArgs: [
+            "--target-repo",
+            "openclaw/openclaw",
+            "--artifact-dir",
+            artifactDir,
+            "--require-precomputed-pr-close-coverage-proof",
+            "--apply-kind",
+            "all",
+            "--processed-limit",
+            "3",
+          ],
+        });
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{ action: string }>;
+    assert.equal(
+      report.some((entry) => entry.action === "closed"),
+      true,
+    );
+    assert.equal(existsSync(join(closedDir, "361.md")), true);
+    assert.equal(readFileSync(proofLogPath, "utf8"), "proof\n");
+  } finally {
+    if (originalCodexBin === undefined) delete process.env.CODEX_BIN;
+    else process.env.CODEX_BIN = originalCodexBin;
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions bounds proof envelopes for reports with many canonical PR refs", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const artifactDir = join(root, "proof-artifacts");
+    const proofLogPath = join(root, "proof.log");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const coveringNumbers = [400, 401, 402, 403, 404];
+    const synced = reportWithSyncedReviewComment(
+      lowSignalCloseReport({
+        number: 365,
+        title: "Provider route fallback",
+        close_reason: "duplicate_or_superseded",
+        work_cluster_refs: JSON.stringify(
+          coveringNumbers.map(
+            (number) => `Superseded by https://github.com/openclaw/openclaw/pull/${number}`,
+          ),
+        ),
+      }).replace(
+        "Closing this PR because the branch is not a useful landing base.",
+        "Closing this PR as superseded by the linked canonical pull requests.",
+      ),
+      365,
+      "duplicate_or_superseded",
+    );
+    writeFileSync(join(itemsDir, "365.md"), synced.report, "utf8");
+    const linkedPulls = Object.fromEntries(
+      coveringNumbers.map((number) => [
+        number,
+        {
+          number,
+          title: `Provider cleanup ${number}`,
+          html_url: `https://github.com/openclaw/openclaw/pull/${number}`,
+          state: "closed",
+          merged_at: "2026-05-02T00:00:00Z",
+          updated_at: "2026-05-01T00:00:00Z",
+          body: `Provider cleanup candidate ${number}.`,
+          comments: [],
+          labels: [],
+        },
+      ]),
+    );
+
+    withMockGh(
+      root,
+      promotionGhMock({
+        number: 365,
+        title: "Provider route fallback",
+        comment: synced.comment,
+        linkedPulls,
+      }),
+      () => {
+        withMockCodexProof(
+          root,
+          {
+            type: "decision",
+            decision: "keep_open",
+            reason: "The source still contains unique provider route behavior.",
+            invocationLogPath: proofLogPath,
+          },
+          () => {
+            runApplyDecisionsForTest({
+              itemsDir,
+              closedDir,
+              plansDir,
+              reportPath,
+              extraArgs: [
+                "--target-repo",
+                "openclaw/openclaw",
+                "--artifact-dir",
+                artifactDir,
+                "--dry-run",
+                "--apply-kind",
+                "all",
+                "--processed-limit",
+                "3",
+              ],
+            });
+          },
+        );
+      },
+    );
+
+    assert.equal(readFileSync(proofLogPath, "utf8").trim().split("\n").length, 4);
+    const proofFiles = readdirSync(join(artifactDir, "pr-close-coverage-proof")).filter((name) =>
+      name.endsWith(".proof.json"),
+    );
+    assert.equal(proofFiles.length, 4);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions fails closed when a required precomputed proof is missing", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const originalCodexBin = process.env.CODEX_BIN;
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const synced = reportWithSyncedReviewComment(
+      lowSignalCloseReport({
+        number: 362,
+        title: "Provider route fallback",
+        close_reason: "duplicate_or_superseded",
+        work_cluster_refs: JSON.stringify([
+          "Superseded by https://github.com/openclaw/openclaw/pull/400",
+        ]),
+      }).replace(
+        "Closing this PR because the branch is not a useful landing base.",
+        "Closing this PR as superseded by https://github.com/openclaw/openclaw/pull/400.",
+      ),
+      362,
+      "duplicate_or_superseded",
+    );
+    writeFileSync(join(itemsDir, "362.md"), synced.report, "utf8");
+    process.env.CODEX_BIN = join(root, "codex-must-not-run");
+    const ghMock = promotionGhMock({
+      number: 362,
+      title: "Provider route fallback",
+      comment: synced.comment,
+      linkedPulls: {
+        400: {
+          number: 400,
+          title: "Provider cleanup",
+          html_url: "https://github.com/openclaw/openclaw/pull/400",
+          state: "closed",
+          merged_at: "2026-05-02T00:00:00Z",
+          body: "Includes the fallback route behavior from PR 362.",
+          comments: [],
+          labels: [],
+        },
+      },
+    });
+    const runRequiredProofApply = (artifactDir: string) =>
+      withMockGh(root, ghMock, () => {
+        runApplyDecisionsForTest({
+          itemsDir,
+          closedDir,
+          plansDir,
+          reportPath,
+          extraArgs: [
+            "--target-repo",
+            "openclaw/openclaw",
+            "--artifact-dir",
+            artifactDir,
+            "--require-precomputed-pr-close-coverage-proof",
+            "--apply-kind",
+            "all",
+            "--processed-limit",
+            "3",
+          ],
+        });
+      });
+
+    const artifactDir = join(root, "missing-proof-artifacts");
+    runRequiredProofApply(artifactDir);
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+      action: string;
+      reason: string;
+    }>;
+    assert.equal(
+      report.some((entry) => entry.action === "closed"),
+      false,
+    );
+    assert.equal(report[0]?.action, "retry_pr_close_coverage_proof");
+    assert.match(report[0]?.reason ?? "", /artifact validation.*ENOENT/);
+
+    const proofDir = join(artifactDir, "pr-close-coverage-proof");
+    mkdirSync(proofDir, { recursive: true });
+    writeFileSync(join(proofDir, "362-400.proof.json"), '{"schemaVersion":1}\n');
+    runRequiredProofApply(artifactDir);
+    const invalidReport = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+      action: string;
+      reason: string;
+    }>;
+    assert.equal(
+      invalidReport.some((entry) => entry.action === "closed"),
+      false,
+    );
+    assert.equal(invalidReport[0]?.action, "retry_pr_close_coverage_proof");
+    assert.match(invalidReport[0]?.reason ?? "", /artifact validation.*source must be an object/);
+  } finally {
+    if (originalCodexBin === undefined) delete process.env.CODEX_BIN;
+    else process.env.CODEX_BIN = originalCodexBin;
     rmSync(root, { recursive: true, force: true });
   }
 });

--- a/test/pr-close-coverage-proof.test.ts
+++ b/test/pr-close-coverage-proof.test.ts
@@ -4,9 +4,35 @@ import test from "node:test";
 
 import {
   buildPrCloseCoverageProofPrompt,
+  createPrCloseCoverageProofEnvelope,
+  parsePrCloseCoverageProofEnvelope,
+  prCloseCoverageProofEnvelopePath,
   parsePrCloseCoverageProofModelResult,
   prCloseCoverageProofCloseDecision,
+  validatePrCloseCoverageProofEnvelopeBinding,
 } from "../dist/pr-close-coverage-proof.js";
+
+const concreteCoverageProof = {
+  sourceSummary: "PR A fixes the auth route.",
+  coveringSummary: "PR B fixes the same auth route.",
+  coveredWork: ["PR B includes the auth route fix that PR A proposed."],
+  uniqueSourceWork: [] as string[],
+  decision: "covered" as const,
+  reason: "PR B covers PR A's auth behavior and PR A has no unique remaining work.",
+};
+const proofPromptSha256 = "a".repeat(64);
+
+const proofPullRequest = (number: number) => ({
+  number,
+  title: `Auth route ${number}`,
+  url: `https://github.com/openclaw/openclaw/pull/${number}`,
+  state: "open",
+  mergedAt: null,
+  body: `Auth route body ${number}`,
+  updatedAt: "2026-07-10T00:00:00Z",
+  comments: [{ author: "octocat", body: `Auth route comment ${number}` }],
+  commentsTruncated: false,
+});
 
 test("PR close coverage proof rejects blank covered work before closing", () => {
   const decision = prCloseCoverageProofCloseDecision({
@@ -68,17 +94,132 @@ for (const scenario of [
 }
 
 test("PR close coverage proof can close when coverage is concrete", () => {
-  const decision = prCloseCoverageProofCloseDecision({
-    sourceSummary: "PR A fixes the auth route.",
-    coveringSummary: "PR B fixes the same auth route.",
-    coveredWork: ["PR B includes the auth route fix that PR A proposed."],
-    uniqueSourceWork: [],
-    decision: "covered",
-    reason: "PR B covers PR A's auth behavior and PR A has no unique remaining work.",
-  });
+  const decision = prCloseCoverageProofCloseDecision(concreteCoverageProof);
 
   assert.equal(decision.close, true);
   assert.equal(decision.proof.decision, "covered");
+});
+
+test("PR close coverage proof envelope binds repo and exact pull request snapshots", () => {
+  const source = proofPullRequest(10);
+  const covering = proofPullRequest(20);
+  const envelope = createPrCloseCoverageProofEnvelope({
+    targetRepo: "OpenClaw/OpenClaw",
+    generatedAt: "2026-07-10T01:02:03.000Z",
+    promptSha256: proofPromptSha256,
+    source,
+    covering,
+    proof: concreteCoverageProof,
+  });
+
+  assert.equal(envelope.targetRepo, "openclaw/openclaw");
+  assert.equal(envelope.source.number, 10);
+  assert.equal(envelope.covering.number, 20);
+  validatePrCloseCoverageProofEnvelopeBinding(envelope, {
+    targetRepo: "openclaw/openclaw",
+    promptSha256: proofPromptSha256,
+    source,
+    covering,
+  });
+  assert.match(prCloseCoverageProofEnvelopePath("proofs", 10, 20), /10-20\.proof\.json$/);
+});
+
+for (const scenario of [
+  {
+    name: "different repository",
+    mutate: (value: ReturnType<typeof createPrCloseCoverageProofEnvelope>) => ({
+      ...value,
+      targetRepo: "openclaw/clawhub",
+    }),
+    expected: /target repo/,
+  },
+  {
+    name: "stale prompt snapshot",
+    mutate: (value: ReturnType<typeof createPrCloseCoverageProofEnvelope>) => ({
+      ...value,
+      promptSha256: "0".repeat(64),
+    }),
+    expected: /prompt snapshot/,
+  },
+  {
+    name: "different source item",
+    mutate: (value: ReturnType<typeof createPrCloseCoverageProofEnvelope>) => ({
+      ...value,
+      source: { ...value.source, number: 11 },
+    }),
+    expected: /proof source #11/,
+  },
+  {
+    name: "stale source snapshot",
+    mutate: (value: ReturnType<typeof createPrCloseCoverageProofEnvelope>) => ({
+      ...value,
+      source: { ...value.source, snapshotSha256: "0".repeat(64) },
+    }),
+    expected: /source snapshot/,
+  },
+  {
+    name: "stale covering snapshot",
+    mutate: (value: ReturnType<typeof createPrCloseCoverageProofEnvelope>) => ({
+      ...value,
+      covering: { ...value.covering, snapshotSha256: "0".repeat(64) },
+    }),
+    expected: /covering snapshot/,
+  },
+  {
+    name: "future generation timestamp",
+    mutate: (value: ReturnType<typeof createPrCloseCoverageProofEnvelope>) => ({
+      ...value,
+      generatedAt: "2099-01-01T00:00:00.000Z",
+    }),
+    expected: /timestamp is in the future/,
+  },
+]) {
+  test(`PR close coverage proof envelope rejects ${scenario.name}`, () => {
+    const source = proofPullRequest(10);
+    const covering = proofPullRequest(20);
+    const envelope = createPrCloseCoverageProofEnvelope({
+      targetRepo: "openclaw/openclaw",
+      promptSha256: proofPromptSha256,
+      source,
+      covering,
+      proof: concreteCoverageProof,
+    });
+
+    assert.throws(
+      () =>
+        validatePrCloseCoverageProofEnvelopeBinding(scenario.mutate(envelope), {
+          targetRepo: "openclaw/openclaw",
+          promptSha256: proofPromptSha256,
+          source,
+          covering,
+        }),
+      scenario.expected,
+    );
+  });
+}
+
+test("PR close coverage proof envelope parser is strict", () => {
+  const envelope = createPrCloseCoverageProofEnvelope({
+    targetRepo: "openclaw/openclaw",
+    promptSha256: proofPromptSha256,
+    source: proofPullRequest(10),
+    covering: proofPullRequest(20),
+    proof: concreteCoverageProof,
+  });
+
+  assert.throws(
+    () => parsePrCloseCoverageProofEnvelope({ ...envelope, artifactPath: "../../forged.json" }),
+    /unexpected keys: artifactPath/,
+  );
+  assert.throws(
+    () =>
+      parsePrCloseCoverageProofEnvelope({
+        ...envelope,
+        source: { ...envelope.source, number: "10" },
+      }),
+    /source\.number must be a number/,
+  );
+  assert.throws(() => prCloseCoverageProofEnvelopePath("proofs", -1, 20), /positive integer/);
 });
 
 test("PR close coverage proof can close concrete loopback embeddings bypass work", () => {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -171,23 +171,29 @@ test("terminal exact-review runs reconcile through a signed isolated backstop", 
   assert.doesNotMatch(workflow, /(?:GH_TOKEN|GITHUB_TOKEN|github\.token)/);
 });
 
-test("publish workflow installs Codex from the root checkout path", () => {
+test("publish workflow dispatches immediate apply through the isolated lane", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const publishJobStart = workflow.indexOf("\n  publish:");
   const recoverJobStart = workflow.indexOf("\n  recover-review-failures:", publishJobStart);
   const publishJob = workflow.slice(publishJobStart, recoverJobStart);
-
-  assert.match(publishJob, /uses: \.\/\.github\/actions\/setup-codex/);
-  assert.doesNotMatch(publishJob, /uses: \.\/clawsweeper\/\.github\/actions\/setup-codex/);
-  const setupCodexStart = publishJob.indexOf("- uses: ./.github/actions/setup-codex");
-  const syncCommentsStart = publishJob.indexOf("- name: Sync selected review comments");
-  const applySelectedStart = publishJob.indexOf("- name: Apply selected safe close proposals");
-  assert.ok(setupCodexStart > syncCommentsStart);
-  assert.ok(applySelectedStart > setupCodexStart);
-  assert.match(
-    publishJob.slice(setupCodexStart, applySelectedStart),
-    /if: \$\{\{ success\(\) && steps\.target-write-token\.outputs\.token != '' && github\.event\.inputs\.apply_after_review == 'true' \}\}/,
+  const dispatchStart = publishJob.indexOf(
+    "- name: Dispatch selected safe close proposals to isolated apply",
   );
+  const dispatchEnd = publishJob.indexOf("\n      - ", dispatchStart + 1);
+  const dispatchStep = publishJob.slice(dispatchStart, dispatchEnd);
+
+  assert.doesNotMatch(publishJob, /setup-codex/);
+  assert.match(publishJob, /name: Dispatch selected safe close proposals to isolated apply/);
+  assert.doesNotMatch(dispatchStep, /pnpm run apply-decisions/);
+  assert.match(dispatchStep, /gh workflow run sweep\.yml/);
+  assert.match(dispatchStep, /-f apply_existing=true/);
+  assert.match(dispatchStep, /-f apply_item_numbers="\$item_numbers"/);
+  assert.match(
+    publishJob,
+    /group: clawsweeper-target-publish-\$\{\{ needs\.plan\.outputs\.target_repo \}\}/,
+  );
+  assert.match(publishJob, /cancel-in-progress: false/);
+  assert.match(publishJob, /queue: max/);
 });
 
 test("broad record publishers isolate tuple reconciliation from status and auxiliary state", () => {
@@ -195,7 +201,6 @@ test("broad record publishers isolate tuple reconciliation from status and auxil
   for (const stepName of [
     "Commit review records",
     "Sync selected review comments",
-    "Apply selected safe close proposals",
     "Commit Audit Health",
   ]) {
     const start = workflow.indexOf(`- name: ${stepName}`);
@@ -226,55 +231,63 @@ test("broad record publishers isolate tuple reconciliation from status and auxil
   }
 });
 
-test("apply workflow installs Codex only when proof-eligible apply work can run", () => {
+test("apply workflow isolates Codex proof from the credentialed mutation runner", () => {
   const workflow = readText(".github/workflows/sweep.yml");
+  const workflowConcurrency = workflow.slice(
+    workflow.indexOf("\nconcurrency:"),
+    workflow.indexOf("\njobs:"),
+  );
+  const proofJobStart = workflow.indexOf("\n  apply-proof:");
   const applyJobStart = workflow.indexOf("\n  apply-existing:");
+  assert.notEqual(proofJobStart, -1);
   assert.notEqual(applyJobStart, -1);
+  assert.match(workflowConcurrency, /queue: max/);
+  assert.match(workflowConcurrency, /cancel-in-progress: false/);
+  const proofJob = workflow.slice(proofJobStart, applyJobStart);
   const applyJob = workflow.slice(applyJobStart);
-  const reconcileStart = applyJob.indexOf("- name: Reconcile before apply preselect");
-  const preselectStart = applyJob.indexOf("- name: Preselect apply work that can need Codex");
-  const setupCodexStart = applyJob.indexOf("- uses: ./.github/actions/setup-codex", preselectStart);
-  const applyStart = applyJob.indexOf(
-    "- name: Apply unchanged proposed decisions with checkpoints",
-  );
 
-  assert.ok(reconcileStart !== -1);
-  assert.ok(preselectStart !== -1);
-  assert.ok(preselectStart > reconcileStart);
-  assert.ok(setupCodexStart > preselectStart);
-  assert.ok(applyStart > setupCodexStart);
-  const reconcileBlock = applyJob.slice(reconcileStart, preselectStart);
-  assert.match(reconcileBlock, /GH_TOKEN: \$\{\{ steps\.target-write-token\.outputs\.token \}\}/);
-  assert.match(reconcileBlock, /source scripts\/apply-workflow-helpers\.sh/);
-  assert.match(reconcileBlock, /persist_reconciliation "\$\{reconcile_args\[@\]\}"/);
+  assert.match(proofJob, /permissions:\s+contents: read\s+issues: read\s+pull-requests: read/);
+  assert.match(proofJob, /persist-credentials: false/);
+  assert.match(proofJob, /persist-credentials: "false"/);
+  assert.doesNotMatch(proofJob, /Create target write token|Create state token/);
+  assert.match(proofJob, /proposed-pr-close-coverage-item-numbers/);
+  assert.match(proofJob, /--batch-size 2/);
+  assert.match(proofJob, /--coverage-proof-limit 2/);
+  assert.match(proofJob, /uses: \.\/\.github\/actions\/setup-codex/);
+  assert.match(proofJob, /--dry-run/);
+  assert.match(proofJob, /--codex-model internal/);
+  assert.match(proofJob, /--codex-reasoning-effort high/);
+  assert.match(proofJob, /\*\.proof\.json/);
+  assert.match(proofJob, /artifact_name: \$\{\{ steps\.proof-artifact\.outputs\.name \}\}/);
   assert.match(
-    applyJob.slice(setupCodexStart, applyStart),
-    /if: \$\{\{ steps\.apply-preselect\.outputs\.needs_codex == 'true' \}\}/,
+    proofJob,
+    /name=apply-coverage-proofs-\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}/,
   );
-  const preselectBlock = applyJob.slice(preselectStart, setupCodexStart);
-  assert.match(preselectBlock, /\[ "\$sync_comments_only" = "true" \]/);
-  assert.match(preselectBlock, /comment-sync-batch/);
-  assert.match(preselectBlock, /batch_count="\$\(awk -F=/);
-  const syncOnlyStart = preselectBlock.indexOf('if [ "$sync_comments_only" = "true" ]; then');
-  assert.ok(syncOnlyStart !== -1);
-  const nonSyncMatch = /\n\s+else\n\s+proof_args=\(/.exec(preselectBlock.slice(syncOnlyStart));
-  assert.ok(nonSyncMatch);
-  const nonSyncStart = syncOnlyStart + nonSyncMatch.index;
-  assert.ok(nonSyncStart > syncOnlyStart);
-  assert.doesNotMatch(preselectBlock.slice(syncOnlyStart, nonSyncStart), /needs_codex=true/);
-  assert.match(preselectBlock, /\[ -n "\$item_numbers" \]/);
-  assert.match(preselectBlock, /proposed-pr-close-coverage-item-numbers/);
-  assert.match(preselectBlock, /proof_args\+=\(--item-numbers "\$item_numbers"\)/);
-  assert.match(preselectBlock, /if \[ -n "\$selected" \]; then\s+needs_codex=true/);
-  assert.doesNotMatch(preselectBlock, /if \[ -n "\$item_numbers" \]; then\s+needs_codex=true/);
-  assert.doesNotMatch(preselectBlock, /normalized_apply_close_reasons=/);
+  assert.match(proofJob, /name: \$\{\{ steps\.proof-artifact\.outputs\.name \}\}/);
+
+  assert.match(applyJob, /needs: apply-proof/);
+  assert.doesNotMatch(applyJob, /setup-codex|OPENAI_API_KEY|CLAWSWEEPER_INTERNAL_MODEL/);
+  assert.match(applyJob, /Create target write token/);
+  assert.match(applyJob, /Create state token/);
+  assert.match(applyJob, /actions\/download-artifact@v8/);
+  assert.match(applyJob, /name: \$\{\{ needs\.apply-proof\.outputs\.artifact_name \}\}/);
+  assert.match(applyJob, /validate_coverage_proof_tree .* 8 262144 2097152/);
+  assert.doesNotMatch(applyJob, /COVERAGE_PROOF_TRUSTED_STARTED_AT|proof-trust/);
+  assert.match(applyJob, /target_repo.*PROOF_TARGET_REPO/);
+  assert.match(applyJob, /--require-precomputed-pr-close-coverage-proof/);
+  assert.match(applyJob, /--artifact-dir \.artifacts\/apply-proof/);
+  assert.match(
+    applyJob,
+    /group: clawsweeper-target-publish-\$\{\{ needs\.apply-proof\.outputs\.target_repo \}\}/,
+  );
+  assert.match(applyJob, /cancel-in-progress: false/);
+  assert.match(applyJob, /queue: max/);
 });
 
 test("apply workflow durably publishes each reconciliation before no-op exits", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const applyJob = workflow.slice(workflow.indexOf("\n  apply-existing:"));
   const preselectReconcile = applyJob.indexOf('persist_reconciliation "${reconcile_args[@]}"');
-  const preselectStart = applyJob.indexOf("- name: Preselect apply work that can need Codex");
   const applyStart = applyJob.indexOf(
     "- name: Apply unchanged proposed decisions with checkpoints",
   );
@@ -287,7 +300,7 @@ test("apply workflow durably publishes each reconciliation before no-op exits", 
   const closeIdle = applyJob.indexOf('--state "Apply idle"', applyStart);
 
   assert.ok(preselectReconcile !== -1);
-  assert.ok(preselectReconcile < preselectStart);
+  assert.ok(preselectReconcile < applyStart);
   assert.ok(policyNoop > preselectReconcile);
   assert.ok(applyReconcile > policyNoop);
   assert.ok(commentIdle > applyReconcile);
@@ -380,6 +393,42 @@ test("apply checkpoints split record tuples from auxiliary state", () => {
     { encoding: "utf8" },
   );
   assert.equal(failedOutput.trim(), "reconcile-records");
+});
+
+test("apply workflow rejects malformed or oversized coverage proof artifact trees", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const validate = (maxFiles = 2, maxFileBytes = 64, maxTotalBytes = 128) =>
+    execFileSync(
+      "bash",
+      [
+        "-lc",
+        `source scripts/apply-workflow-helpers.sh\nvalidate_coverage_proof_tree "$PROOF_DIR" ${maxFiles} ${maxFileBytes} ${maxTotalBytes}`,
+      ],
+      { encoding: "utf8", env: { ...process.env, PROOF_DIR: root } },
+    );
+
+  try {
+    writeFileSync(join(root, "10-20.proof.json"), "{}\n");
+    writeFileSync(join(root, "30-40.proof.json"), "{}\n");
+    assert.equal(validate(), "");
+
+    writeFileSync(join(root, "50-60.proof.json"), "{}\n");
+    assert.throws(() => validate(), /maximum is 2/);
+    rmSync(join(root, "50-60.proof.json"));
+
+    writeFileSync(join(root, "unexpected.json"), "{}\n");
+    assert.throws(() => validate(3), /Unexpected coverage proof filename/);
+    rmSync(join(root, "unexpected.json"));
+
+    mkdirSync(join(root, "nested"));
+    assert.throws(() => validate(), /Unexpected non-file coverage proof artifact/);
+    rmSync(join(root, "nested"), { recursive: true });
+
+    writeFileSync(join(root, "10-20.proof.json"), "x".repeat(65));
+    assert.throws(() => validate(), /exceeds 64 bytes/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("apply workflow target token can inspect source workflow runs", () => {
@@ -734,23 +783,23 @@ test("apply workflow drops a coverage-proof tail only after exact trace examinat
   }
 });
 
-test("apply workflow syncs source checkout before state hydration", () => {
+test("apply proof and mutation start from fresh non-persisted source checkouts", () => {
   const workflow = readText(".github/workflows/sweep.yml");
+  const proofJobStart = workflow.indexOf("\n  apply-proof:");
   const applyJobStart = workflow.indexOf("\n  apply-existing:");
+  assert.notEqual(proofJobStart, -1);
   assert.notEqual(applyJobStart, -1);
+  const proofJob = workflow.slice(proofJobStart, applyJobStart);
   const applyJob = workflow.slice(applyJobStart);
-  const resolveTargetStart = applyJob.indexOf("- name: Resolve target repository");
-  const syncStart = applyJob.indexOf("- name: Sync source checkout before state hydration");
-  const setupStateStart = applyJob.indexOf("- uses: ./.github/actions/setup-state");
-  const reconcileStart = applyJob.indexOf("- name: Reconcile before apply preselect");
 
-  assert.ok(resolveTargetStart !== -1);
-  assert.ok(syncStart > resolveTargetStart);
-  assert.ok(setupStateStart > syncStart);
-  assert.ok(reconcileStart > setupStateStart);
-  assert.equal(applyJob.indexOf("- name: Sync before applying decisions"), -1);
-  assert.match(applyJob.slice(syncStart, setupStateStart), /run: git pull --rebase/);
-  assert.doesNotMatch(applyJob.slice(setupStateStart, reconcileStart), /git pull --rebase/);
+  assert.match(proofJob, /actions\/checkout@v7[\s\S]*?persist-credentials: false/);
+  assert.match(
+    proofJob,
+    /uses: \.\/\.github\/actions\/setup-state[\s\S]*?persist-credentials: "false"/,
+  );
+  assert.match(applyJob, /actions\/checkout@v7[\s\S]*?persist-credentials: false/);
+  assert.doesNotMatch(proofJob, /git pull --rebase/);
+  assert.doesNotMatch(applyJob, /git pull --rebase/);
 });
 
 test("sweep target tokens fall back when an org app installation is missing", () => {


### PR DESCRIPTION
## Summary

- split PR-close coverage proof into a read-only Codex job and a fresh credentialed mutation job that never starts Codex
- bind proof artifacts to the exact target repository, source and covering PR snapshots, and prompt digest, then revalidate live state before any write
- bound proof generation and artifact ingestion while preserving non-dropping per-target apply concurrency
- dispatch immediate apply work through the same isolated lane and disable persisted checkout credentials on untrusted/read-only checkouts

## Validation

- `pnpm run build:all && node --test --test-concurrency=4 test/*.test.ts test/repair/*.test.ts dist/repair/*.test.js` (1441/1441)
- `pnpm run build:all && node --test test/apply-pr-coverage-proof-close.test.ts test/pr-close-coverage-proof.test.ts test/sweep-workflow.test.ts test/apply-runtime-budget.test.ts` (94/94)
- `node --test test/codex-review-runner.test.ts` (16/16)
- `pnpm run check:active-surface`
- `pnpm run check:limits`
- `pnpm run lint`
- `pnpm run format:check`
- `git diff --check`
