### PR TITLE
fix: allow behind canonical close coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Allowed conflict-free canonical PRs that only need a base update to back duplicate or superseded closures while retaining proof, review, check, draft, and conflict guards.
 - Bounded broad reconciliation with batched Git I/O and tuple checkpoints that report progress and resume safely under concurrent state writers.
 - Retried tuple-safe broad reconciliation after full push batches lose continuous exact-state races, including candidates that normalize to no changes.
 - Serialized explicit workflow-dispatch planners through a non-dropping target queue and accounted for recovery runs by their requested or live shards, preventing overlapping target planning and false 89-shard reservations without undercounting multi-shard retries.

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -14096,7 +14096,8 @@ function unsafeCanonicalPullRequestReason(
   if (linkedPull.mergeableState === "dirty") {
     return `linked canonical PR #${linkedPull.number} has merge conflicts`;
   }
-  if (linkedPull.mergeableState !== "clean") {
+  // GitHub reports "behind" for a conflict-free PR that only needs a base update.
+  if (linkedPull.mergeableState !== "clean" && linkedPull.mergeableState !== "behind") {
     return `linked canonical PR #${linkedPull.number} is not cleanly mergeable (${linkedPull.mergeableState})`;
   }
 

--- a/src/repair/apply-result.ts
+++ b/src/repair/apply-result.ts
@@ -60,6 +60,8 @@ const CLOSE_CLASSIFICATIONS = new Set([
 ]);
 const PASSING_CHECK_CONCLUSIONS = new Set(["SUCCESS", "SKIPPED", "NEUTRAL"]);
 const CLEAN_MERGE_STATES = new Set(["CLEAN"]);
+// A covering PR may need a base update, but actual merge actions remain CLEAN-only.
+const VIABLE_COVERING_PR_MERGE_STATES = new Set(["CLEAN", "BEHIND"]);
 const PR_CLOSE_COVERAGE_PROOF_COMMENT_LIMIT = 50;
 const GITHUB_MAX_PAGE_SIZE = 100;
 const CLAWSWEEPER_COMMAND_ONLY_PATTERN = /^@clawsweeper\s+(?:re-review|re-run|review)\s*$/i;
@@ -1094,7 +1096,11 @@ function validatePrCloseCoverageCoveringSafety({
   if (covering.mergedAt) return "";
   const pullRequest = fetchPullRequest(result.repo, coveringRef);
   const view = fetchPullRequestView(result.repo, coveringRef);
-  const mergeBlock = validateMergeablePullRequest({ pullRequest, view });
+  const mergeBlock = validateMergeablePullRequest({
+    pullRequest,
+    view,
+    allowedMergeStates: VIABLE_COVERING_PR_MERGE_STATES,
+  });
   if (mergeBlock) return formatCoveringPullRequestBlock(coveringRef, mergeBlock);
   if (resultHasPlannedCloseForTarget(result, coveringRef)) {
     return `linked canonical PR #${coveringRef} is itself proposed for close`;
@@ -1480,13 +1486,17 @@ function prCloseCoverageProofRuntime() {
   return ghToken ? { ...runtime, ghToken } : runtime;
 }
 
-function validateMergeablePullRequest({ pullRequest, view }: LooseRecord) {
+function validateMergeablePullRequest({
+  pullRequest,
+  view,
+  allowedMergeStates = CLEAN_MERGE_STATES,
+}: LooseRecord) {
   if (pullRequest.state !== "open") return `pull request is ${pullRequest.state}`;
   if (pullRequest.draft || view.isDraft) return "pull request is draft";
   if (String(view.baseRefName ?? pullRequest.base?.ref ?? "") !== "main")
     return "pull request base is not main";
   if (view.mergeable !== "MERGEABLE") return `mergeable state is ${view.mergeable || "unknown"}`;
-  if (!CLEAN_MERGE_STATES.has(String(view.mergeStateStatus ?? ""))) {
+  if (!allowedMergeStates.has(String(view.mergeStateStatus ?? ""))) {
     return `merge state status is ${view.mergeStateStatus || "unknown"}`;
   }
   if (["CHANGES_REQUESTED", "REVIEW_REQUIRED"].includes(String(view.reviewDecision ?? ""))) {

--- a/test/apply-pr-supersession-safety.test.ts
+++ b/test/apply-pr-supersession-safety.test.ts
@@ -504,7 +504,7 @@ test("apply-decisions does not promote PRs superseded by section-only unsafe lin
   }
 });
 
-test("apply-decisions promotes PRs when live proof labels supersede stale linked reports", () => {
+test("apply-decisions promotes PRs when a proof-backed canonical PR is behind", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
     const itemsDir = join(root, "items");
@@ -560,7 +560,7 @@ test("apply-decisions promotes PRs when live proof labels supersede stale linked
             html_url: "https://github.com/openclaw/openclaw/pull/400",
             state: "open",
             merged_at: null,
-            mergeable_state: "clean",
+            mergeable_state: "behind",
             labels: ["proof: sufficient"],
           },
         },


### PR DESCRIPTION
## Summary

- treat GitHub's `BEHIND` merge state as viable only when an open, proof-backed canonical PR covers a weaker duplicate or superseded PR
- keep ClawSweeper's actual merge actions `CLEAN`-only
- retain draft, conflict, review, check, proof, freshness, and source-coverage guards

## Live evidence

[Apply run 29088452497](https://github.com/openclaw/clawsweeper/actions/runs/29088452497) reached the repaired apply path, but kept open openclaw/openclaw#91668 solely because its stronger canonical PR #90817 was conflict-free but behind the base branch.

## Verification

- `pnpm run build`
- `pnpm run build:repair`
- `node --test test/apply-pr-supersession-safety.test.ts test/repair/apply-result.test.ts test/apply-pr-coverage-proof-close.test.ts test/apply-pr-coverage-proof-recheck.test.ts`
- focused lint, format, and diff checks
- GPT-5.6 Sol High autoreview: clean after preserving `CLEAN`-only merge execution
