### PR TITLE
fix: isolate assist publication credentials

### DIFF
--- a/.github/workflows/assist.yml
+++ b/.github/workflows/assist.yml
@@ -330,7 +330,7 @@ jobs:
           owner: ${{ steps.target.outputs.target_repo_owner }}
           repositories: ${{ steps.target.outputs.target_repo_name }}
           permission-issues: write
-          permission-pull-requests: read
+          permission-pull-requests: write
 
       - name: Revalidate and publish assist comment
         env:

--- a/.github/workflows/assist.yml
+++ b/.github/workflows/assist.yml
@@ -49,7 +49,7 @@ on:
 permissions:
   actions: read
   contents: read
-  issues: write
+  issues: read
   pull-requests: read
 
 env:
@@ -58,7 +58,7 @@ env:
   CLAWSWEEPER_MODEL: internal
 
 concurrency:
-  group: ${{ format('clawsweeper-assist-{0}-{1}-{2}', github.event.client_payload.target_repo || inputs.target_repo || 'openclaw/openclaw', github.event.client_payload.item_number || inputs.item_number || github.run_id, github.event.client_payload.comment_id || inputs.comment_id || github.run_id) }}
+  group: ${{ format('clawsweeper-assist-{0}-{1}-{2}', github.event.client_payload.target_repo || inputs.target_repo || 'openclaw/openclaw', github.event.client_payload.item_number || inputs.item_number || 'unknown', github.event.client_payload.comment_id || inputs.comment_id || 'manual') }}
   cancel-in-progress: false
 
 jobs:
@@ -72,6 +72,7 @@ jobs:
         with:
           sparse-checkout: scripts/dispatch-receipt-owner.sh
           sparse-checkout-cone-mode: false
+          persist-credentials: false
 
       - id: receipt
         env:
@@ -117,6 +118,7 @@ jobs:
             tsconfig.json
             tsconfig.repair.json
           sparse-checkout-cone-mode: false
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-pnpm
         with:
@@ -147,7 +149,7 @@ jobs:
             printf '%s' "$total"
           }
 
-          for attempt in $(seq 1 80); do
+          for _ in $(seq 1 80); do
             active="$(active_assist_jobs)"
             if [ "$active" -lt "$cap" ]; then
               echo "proceed=true" >> "$GITHUB_OUTPUT"
@@ -165,34 +167,53 @@ jobs:
     if: ${{ needs.capacity.outputs.proceed == 'true' }}
     runs-on: ${{ vars.CLAWSWEEPER_WORKER_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 8
+    outputs:
+      generation_attempt: ${{ steps.generate.outputs.generation_attempt }}
     steps:
       - uses: actions/checkout@v7
         with:
+          ref: ${{ github.sha }}
           filter: blob:none
-
-      - name: Create GitHub App token
-        id: app_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
-          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
-          owner: ${{ vars.CLAWSWEEPER_ALLOWED_OWNER || github.repository_owner }}
-          permission-issues: write
-          permission-pull-requests: write
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-pnpm
         with:
           build-script: build
+
+      - name: Resolve validated target repository
+        id: target
+        env:
+          TARGET_REPO: ${{ github.event.client_payload.target_repo || inputs.target_repo }}
+        run: |
+          set -euo pipefail
+          resolved="$(node dist/clawsweeper.js assist-target --target-repo "$TARGET_REPO")"
+          {
+            echo "target_repo=$(jq -er '.repo' <<< "$resolved")"
+            echo "target_repo_owner=$(jq -er '.owner' <<< "$resolved")"
+            echo "target_repo_name=$(jq -er '.repository' <<< "$resolved")"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create read-only GitHub App token
+        id: read_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+          owner: ${{ steps.target.outputs.target_repo_owner }}
+          repositories: ${{ steps.target.outputs.target_repo_name }}
+          permission-issues: read
+          permission-pull-requests: read
 
       - uses: ./.github/actions/setup-codex
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAWSWEEPER_INTERNAL_MODEL: ${{ secrets.CLAWSWEEPER_MODEL }}
 
-      - name: Answer maintainer question
+      - name: Generate bounded assist artifact
+        id: generate
         env:
-          GH_TOKEN: ${{ steps.app_token.outputs.token }}
-          TARGET_REPO: ${{ github.event.client_payload.target_repo || inputs.target_repo }}
+          GH_TOKEN: ${{ steps.read_token.outputs.token }}
+          TARGET_REPO: ${{ steps.target.outputs.target_repo }}
           ITEM_NUMBER: ${{ github.event.client_payload.item_number || inputs.item_number }}
           QUESTION: ${{ github.event.client_payload.question || inputs.question }}
           MODE: ${{ github.event.client_payload.assist.mode || github.event.client_payload.mode || inputs.mode || 'assist' }}
@@ -205,7 +226,8 @@ jobs:
           TIMEOUT_MS: ${{ github.event.client_payload.assist.timeout_ms || github.event.client_payload.timeout_ms || '120000' }}
         run: |
           set -euo pipefail
-          node dist/clawsweeper.js assist \
+          test -n "$GH_TOKEN"
+          node dist/clawsweeper.js assist-generate \
             --target-repo "$TARGET_REPO" \
             --item-number "$ITEM_NUMBER" \
             --question "$QUESTION" \
@@ -217,4 +239,125 @@ jobs:
             --codex-model "$MODEL" \
             --codex-reasoning-effort "$REASONING_EFFORT" \
             --codex-sandbox read-only \
-            --codex-timeout-ms "$TIMEOUT_MS"
+            --codex-timeout-ms "$TIMEOUT_MS" \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --artifact .artifacts/assist-result.json
+          echo "generation_attempt=$GITHUB_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
+
+      - name: Upload assist artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: clawsweeper-assist-${{ github.run_id }}-${{ steps.generate.outputs.generation_attempt }}
+          path: .artifacts/assist-result.json
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Publish trusted assist comment
+    needs: assist
+    if: ${{ needs.assist.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          filter: blob:none
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-pnpm
+        with:
+          build-script: build
+
+      - name: Verify exact workflow source
+        run: test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+
+      - name: Resolve validated target repository
+        id: target
+        env:
+          TARGET_REPO: ${{ github.event.client_payload.target_repo || inputs.target_repo }}
+        run: |
+          set -euo pipefail
+          resolved="$(node dist/clawsweeper.js assist-target --target-repo "$TARGET_REPO")"
+          {
+            echo "target_repo=$(jq -er '.repo' <<< "$resolved")"
+            echo "target_repo_owner=$(jq -er '.owner' <<< "$resolved")"
+            echo "target_repo_name=$(jq -er '.repository' <<< "$resolved")"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Download assist artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: clawsweeper-assist-${{ github.run_id }}-${{ needs.assist.outputs.generation_attempt }}
+          path: .artifacts/publish
+
+      - name: Validate untrusted assist artifact
+        env:
+          TARGET_REPO: ${{ steps.target.outputs.target_repo }}
+          ITEM_NUMBER: ${{ github.event.client_payload.item_number || inputs.item_number }}
+          QUESTION: ${{ github.event.client_payload.question || inputs.question }}
+          MODE: ${{ github.event.client_payload.assist.mode || github.event.client_payload.mode || inputs.mode || 'assist' }}
+          LENS: ${{ github.event.client_payload.assist.lens || github.event.client_payload.lens || inputs.lens || 'auto' }}
+          COMMENT_ID: ${{ github.event.client_payload.comment_id || inputs.comment_id || '' }}
+          COMMENT_URL: ${{ github.event.client_payload.comment_url || inputs.comment_url || '' }}
+          AUTHOR: ${{ github.event.client_payload.author || inputs.author || '' }}
+          REASONING_EFFORT: high
+          GENERATION_ATTEMPT: ${{ needs.assist.outputs.generation_attempt }}
+        run: |
+          set -euo pipefail
+          node dist/clawsweeper.js assist-validate \
+            --artifact .artifacts/publish/assist-result.json \
+            --target-repo "$TARGET_REPO" \
+            --item-number "$ITEM_NUMBER" \
+            --question "$QUESTION" \
+            --mode "$MODE" \
+            --lens "$LENS" \
+            --comment-id "$COMMENT_ID" \
+            --comment-url "$COMMENT_URL" \
+            --author "$AUTHOR" \
+            --codex-reasoning-effort "$REASONING_EFFORT" \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GENERATION_ATTEMPT"
+
+      - name: Create narrow GitHub App write token
+        id: write_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+          owner: ${{ steps.target.outputs.target_repo_owner }}
+          repositories: ${{ steps.target.outputs.target_repo_name }}
+          permission-issues: write
+          permission-pull-requests: read
+
+      - name: Revalidate and publish assist comment
+        env:
+          GH_TOKEN: ${{ steps.write_token.outputs.token }}
+          TARGET_REPO: ${{ steps.target.outputs.target_repo }}
+          ITEM_NUMBER: ${{ github.event.client_payload.item_number || inputs.item_number }}
+          QUESTION: ${{ github.event.client_payload.question || inputs.question }}
+          MODE: ${{ github.event.client_payload.assist.mode || github.event.client_payload.mode || inputs.mode || 'assist' }}
+          LENS: ${{ github.event.client_payload.assist.lens || github.event.client_payload.lens || inputs.lens || 'auto' }}
+          COMMENT_ID: ${{ github.event.client_payload.comment_id || inputs.comment_id || '' }}
+          COMMENT_URL: ${{ github.event.client_payload.comment_url || inputs.comment_url || '' }}
+          AUTHOR: ${{ github.event.client_payload.author || inputs.author || '' }}
+          REASONING_EFFORT: high
+          GENERATION_ATTEMPT: ${{ needs.assist.outputs.generation_attempt }}
+        run: |
+          set -euo pipefail
+          test -n "$GH_TOKEN"
+          node dist/clawsweeper.js assist-publish \
+            --artifact .artifacts/publish/assist-result.json \
+            --target-repo "$TARGET_REPO" \
+            --item-number "$ITEM_NUMBER" \
+            --question "$QUESTION" \
+            --mode "$MODE" \
+            --lens "$LENS" \
+            --comment-id "$COMMENT_ID" \
+            --comment-url "$COMMENT_URL" \
+            --author "$AUTHOR" \
+            --codex-reasoning-effort "$REASONING_EFFORT" \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GENERATION_ATTEMPT"

--- a/README.md
+++ b/README.md
@@ -233,7 +233,9 @@ Common commands:
   a 120-second per-item timeout, and its own five-job cap. It posts a separate
   non-durable answer comment and never edits the durable ClawSweeper review
   comment, closes, merges, labels, pushes, repairs, or emits review/apply
-  markers.
+  markers. The model job has read-only GitHub access and emits a bounded artifact;
+  a fresh trusted publisher validates its workflow request, target revision, PR
+  head, and source comment before minting a narrow comment-write token.
 - `visualize [lens]` dispatches the read-only visual assist lane and posts or
   updates a marker-backed visual brief comment for the requested lens.
 - `fix ci`, `address review`, and `rebase` dispatch the repair worker only for

--- a/schema/assist-artifact.schema.json
+++ b/schema/assist-artifact.schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://clawsweeper.openclaw.ai/schema/assist-artifact.schema.json",
+  "title": "ClawSweeper assist generation artifact",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "generated_at",
+    "workflow",
+    "target",
+    "source",
+    "request",
+    "output",
+    "idempotency_key"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "generated_at": { "type": "string", "format": "date-time", "maxLength": 64 },
+    "workflow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["run_id", "run_attempt"],
+      "properties": {
+        "run_id": { "type": "string", "pattern": "^[0-9]{1,30}$" },
+        "run_attempt": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repo",
+        "item_number",
+        "item_kind",
+        "source_revision",
+        "context_digest",
+        "pull_head_sha"
+      ],
+      "properties": {
+        "repo": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_.-]{1,100}/[A-Za-z0-9_.-]{1,100}$"
+        },
+        "item_number": { "type": "integer", "minimum": 1 },
+        "item_kind": { "enum": ["issue", "pull_request"] },
+        "source_revision": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "context_digest": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "pull_head_sha": {
+          "oneOf": [{ "type": "null" }, { "type": "string", "pattern": "^[0-9a-f]{40}$" }]
+        }
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["comment_id", "comment_url", "author", "digest"],
+      "properties": {
+        "comment_id": { "type": "string", "pattern": "^(?:|[0-9]{1,30})$" },
+        "comment_url": { "type": "string", "maxLength": 1000 },
+        "author": { "type": "string", "maxLength": 100 },
+        "digest": {
+          "oneOf": [{ "type": "null" }, { "type": "string", "pattern": "^[0-9a-f]{64}$" }]
+        }
+      }
+    },
+    "request": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sha256", "mode", "lens", "reasoning_effort"],
+      "properties": {
+        "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "mode": { "enum": ["assist", "visual"] },
+        "lens": {
+          "enum": ["auto", "ux", "flow", "state", "data", "proof", "risk", "maintainer"]
+        },
+        "reasoning_effort": { "enum": ["low", "medium", "high", "xhigh"] }
+      }
+    },
+    "output": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["answer"],
+      "properties": {
+        "answer": { "type": "string", "minLength": 1, "maxLength": 60000 }
+      }
+    },
+    "idempotency_key": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+  }
+}

--- a/src/assist-artifact.ts
+++ b/src/assist-artifact.ts
@@ -1,0 +1,512 @@
+import { createHash } from "node:crypto";
+
+export const ASSIST_ARTIFACT_SCHEMA_VERSION = 1 as const;
+export const ASSIST_ARTIFACT_MAX_BYTES = 128 * 1024;
+export const ASSIST_ANSWER_MAX_BYTES = 60_000;
+
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+const REPO_PATTERN = /^[A-Za-z0-9_.-]{1,100}\/[A-Za-z0-9_.-]{1,100}$/;
+const COMMENT_ID_PATTERN = /^\d{1,30}$/;
+const CLAWSWEEPER_MARKER_PATTERN = /<!--\s*clawsweeper(?:-|:)/i;
+
+export type AssistMode = "assist" | "visual";
+
+export interface AssistRequestBinding {
+  targetRepo: string;
+  itemNumber: number;
+  question: string;
+  mode: AssistMode;
+  lens: string;
+  sourceCommentId: string;
+  sourceCommentUrl: string;
+  author: string;
+  reasoningEffort: string;
+}
+
+export interface AssistArtifact {
+  schema_version: typeof ASSIST_ARTIFACT_SCHEMA_VERSION;
+  generated_at: string;
+  workflow: {
+    run_id: string;
+    run_attempt: number;
+  };
+  target: {
+    repo: string;
+    item_number: number;
+    item_kind: "issue" | "pull_request";
+    source_revision: string;
+    context_digest: string;
+    pull_head_sha: string | null;
+  };
+  source: {
+    comment_id: string;
+    comment_url: string;
+    author: string;
+    digest: string | null;
+  };
+  request: {
+    sha256: string;
+    mode: AssistMode;
+    lens: string;
+    reasoning_effort: string;
+  };
+  output: {
+    answer: string;
+  };
+  idempotency_key: string;
+}
+
+export interface CreateAssistArtifactOptions {
+  generatedAt: string;
+  runId: string;
+  runAttempt: number;
+  itemKind: "issue" | "pull_request";
+  sourceRevision: string;
+  contextDigest: string;
+  pullHeadSha: string | null;
+  sourceDigest: string | null;
+  request: AssistRequestBinding;
+  answer: string;
+}
+
+export interface ExpectedAssistArtifact {
+  runId: string;
+  runAttempt: number;
+  request: AssistRequestBinding;
+}
+
+export interface AssistLiveRevision {
+  itemKind: "issue" | "pull_request";
+  sourceRevision: string;
+  contextDigest: string;
+  pullHeadSha: string | null;
+  sourceDigest: string | null;
+}
+
+export function assistRequestSha256(request: AssistRequestBinding): string {
+  return sha256(
+    JSON.stringify({
+      target_repo: request.targetRepo,
+      item_number: request.itemNumber,
+      question: request.question,
+      mode: request.mode,
+      lens: request.lens,
+      source_comment_id: request.sourceCommentId,
+      source_comment_url: request.sourceCommentUrl,
+      author: request.author,
+      reasoning_effort: request.reasoningEffort,
+    }),
+  );
+}
+
+export function assistSourceCommentSha256(comment: {
+  id: string;
+  issueUrl: string;
+  htmlUrl: string;
+  author: string;
+  body: string;
+  updatedAt: string;
+}): string {
+  return sha256(
+    JSON.stringify({
+      id: comment.id,
+      issue_url: comment.issueUrl,
+      html_url: comment.htmlUrl,
+      author: comment.author,
+      body: comment.body,
+      updated_at: comment.updatedAt,
+    }),
+  );
+}
+
+export function createAssistArtifact(options: CreateAssistArtifactOptions): AssistArtifact {
+  const requestSha = assistRequestSha256(options.request);
+  const idempotencyKey = assistIdempotencyKey({
+    targetRepo: options.request.targetRepo,
+    itemNumber: options.request.itemNumber,
+    itemKind: options.itemKind,
+    sourceCommentId: options.request.sourceCommentId,
+    sourceCommentUrl: options.request.sourceCommentUrl,
+    author: options.request.author,
+    mode: options.request.mode,
+    lens: options.request.lens,
+    reasoningEffort: options.request.reasoningEffort,
+    requestSha,
+    sourceRevision: options.sourceRevision,
+    contextDigest: options.contextDigest,
+    pullHeadSha: options.pullHeadSha,
+    sourceDigest: options.sourceDigest,
+  });
+  return validateAssistArtifact({
+    schema_version: ASSIST_ARTIFACT_SCHEMA_VERSION,
+    generated_at: options.generatedAt,
+    workflow: {
+      run_id: options.runId,
+      run_attempt: options.runAttempt,
+    },
+    target: {
+      repo: options.request.targetRepo,
+      item_number: options.request.itemNumber,
+      item_kind: options.itemKind,
+      source_revision: options.sourceRevision,
+      context_digest: options.contextDigest,
+      pull_head_sha: options.pullHeadSha,
+    },
+    source: {
+      comment_id: options.request.sourceCommentId,
+      comment_url: options.request.sourceCommentUrl,
+      author: options.request.author,
+      digest: options.sourceDigest,
+    },
+    request: {
+      sha256: requestSha,
+      mode: options.request.mode,
+      lens: options.request.lens,
+      reasoning_effort: options.request.reasoningEffort,
+    },
+    output: {
+      answer: options.answer,
+    },
+    idempotency_key: idempotencyKey,
+  });
+}
+
+export function parseAssistArtifact(
+  text: string,
+  expected?: ExpectedAssistArtifact,
+): AssistArtifact {
+  if (Buffer.byteLength(text, "utf8") > ASSIST_ARTIFACT_MAX_BYTES) {
+    throw new Error(`assist artifact exceeds ${ASSIST_ARTIFACT_MAX_BYTES} bytes`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error("assist artifact is not valid JSON");
+  }
+  const artifact = validateAssistArtifact(parsed);
+  if (expected) validateExpectedAssistArtifact(artifact, expected);
+  return artifact;
+}
+
+export function assertAssistArtifactLiveRevision(
+  artifact: AssistArtifact,
+  live: AssistLiveRevision,
+): void {
+  if (live.itemKind !== artifact.target.item_kind) {
+    throw new Error("assist target kind changed after generation");
+  }
+  if (live.sourceRevision !== artifact.target.source_revision) {
+    throw new Error("assist target source changed after generation; refusing stale publication");
+  }
+  if (live.contextDigest !== artifact.target.context_digest) {
+    throw new Error("assist prompt context changed after generation; refusing stale publication");
+  }
+  if (live.pullHeadSha !== artifact.target.pull_head_sha) {
+    throw new Error(
+      "assist pull request head changed after generation; refusing stale publication",
+    );
+  }
+  if (live.sourceDigest !== artifact.source.digest) {
+    throw new Error("assist source comment changed after generation; refusing stale publication");
+  }
+}
+
+export function validateAssistArtifact(value: unknown): AssistArtifact {
+  const artifact = record(value, "assist artifact");
+  exactKeys(artifact, [
+    "schema_version",
+    "generated_at",
+    "workflow",
+    "target",
+    "source",
+    "request",
+    "output",
+    "idempotency_key",
+  ]);
+  if (artifact.schema_version !== ASSIST_ARTIFACT_SCHEMA_VERSION) {
+    throw new Error(
+      `unsupported assist artifact schema version: ${String(artifact.schema_version)}`,
+    );
+  }
+  const generatedAt = scalar(artifact.generated_at, "generated_at", 64);
+  const generatedDate = new Date(generatedAt);
+  const canonicalGeneratedAt = Number.isFinite(generatedDate.valueOf())
+    ? generatedDate.toISOString()
+    : "";
+  if (
+    !canonicalGeneratedAt ||
+    (generatedAt !== canonicalGeneratedAt &&
+      generatedAt !== canonicalGeneratedAt.replace(".000Z", "Z"))
+  ) {
+    throw new Error("generated_at must be a canonical ISO timestamp");
+  }
+
+  const workflow = record(artifact.workflow, "workflow");
+  exactKeys(workflow, ["run_id", "run_attempt"]);
+  const runId = digits(workflow.run_id, "workflow.run_id", 30);
+  const runAttempt = positiveInteger(workflow.run_attempt, "workflow.run_attempt");
+
+  const target = record(artifact.target, "target");
+  exactKeys(target, [
+    "repo",
+    "item_number",
+    "item_kind",
+    "source_revision",
+    "context_digest",
+    "pull_head_sha",
+  ]);
+  const repo = scalar(target.repo, "target.repo", 201);
+  if (!REPO_PATTERN.test(repo)) throw new Error("target.repo is invalid");
+  const itemNumber = positiveInteger(target.item_number, "target.item_number");
+  if (target.item_kind !== "issue" && target.item_kind !== "pull_request") {
+    throw new Error("target.item_kind must be issue or pull_request");
+  }
+  const sourceRevision = digest(target.source_revision, "target.source_revision");
+  const contextDigest = digest(target.context_digest, "target.context_digest");
+  const pullHeadSha = nullableSha(target.pull_head_sha, "target.pull_head_sha");
+  if (target.item_kind === "pull_request" && !pullHeadSha) {
+    throw new Error("pull_request assist artifacts require target.pull_head_sha");
+  }
+  if (target.item_kind === "issue" && pullHeadSha !== null) {
+    throw new Error("issue assist artifacts must not include target.pull_head_sha");
+  }
+
+  const source = record(artifact.source, "source");
+  exactKeys(source, ["comment_id", "comment_url", "author", "digest"]);
+  const commentId = optionalCommentId(source.comment_id, "source.comment_id");
+  const commentUrl = scalar(source.comment_url, "source.comment_url", 1_000, true);
+  const author = scalar(source.author, "source.author", 100, true);
+  const sourceDigest = nullableDigest(source.digest, "source.digest");
+  if (commentId && !sourceDigest) {
+    throw new Error("source.digest is required when source.comment_id is present");
+  }
+  if (!commentId && sourceDigest) {
+    throw new Error("source.digest requires source.comment_id");
+  }
+
+  const request = record(artifact.request, "request");
+  exactKeys(request, ["sha256", "mode", "lens", "reasoning_effort"]);
+  const requestSha = digest(request.sha256, "request.sha256");
+  if (request.mode !== "assist" && request.mode !== "visual") {
+    throw new Error("request.mode must be assist or visual");
+  }
+  const lens = scalar(request.lens, "request.lens", 32);
+  if (!/^(?:auto|ux|flow|state|data|proof|risk|maintainer)$/.test(lens)) {
+    throw new Error("request.lens is invalid");
+  }
+  const reasoningEffort = scalar(request.reasoning_effort, "request.reasoning_effort", 16);
+  if (!/^(?:low|medium|high|xhigh)$/.test(reasoningEffort)) {
+    throw new Error("request.reasoning_effort is invalid");
+  }
+
+  const output = record(artifact.output, "output");
+  exactKeys(output, ["answer"]);
+  const answer = scalar(output.answer, "output.answer", ASSIST_ANSWER_MAX_BYTES, false, true);
+  if (!answer.trim()) throw new Error("output.answer must not be empty");
+  if (CLAWSWEEPER_MARKER_PATTERN.test(answer)) {
+    throw new Error("output.answer must not contain ClawSweeper control markers");
+  }
+
+  const idempotencyKey = digest(artifact.idempotency_key, "idempotency_key");
+  const expectedIdempotencyKey = assistIdempotencyKey({
+    targetRepo: repo,
+    itemNumber,
+    itemKind: target.item_kind,
+    sourceCommentId: commentId,
+    sourceCommentUrl: commentUrl,
+    author,
+    mode: request.mode,
+    lens,
+    reasoningEffort,
+    requestSha,
+    sourceRevision,
+    contextDigest,
+    pullHeadSha,
+    sourceDigest,
+  });
+  if (idempotencyKey !== expectedIdempotencyKey) {
+    throw new Error("assist artifact idempotency key does not match its bound inputs");
+  }
+
+  return {
+    schema_version: ASSIST_ARTIFACT_SCHEMA_VERSION,
+    generated_at: generatedAt,
+    workflow: { run_id: runId, run_attempt: runAttempt },
+    target: {
+      repo,
+      item_number: itemNumber,
+      item_kind: target.item_kind,
+      source_revision: sourceRevision,
+      context_digest: contextDigest,
+      pull_head_sha: pullHeadSha,
+    },
+    source: {
+      comment_id: commentId,
+      comment_url: commentUrl,
+      author,
+      digest: sourceDigest,
+    },
+    request: {
+      sha256: requestSha,
+      mode: request.mode,
+      lens,
+      reasoning_effort: reasoningEffort,
+    },
+    output: { answer },
+    idempotency_key: idempotencyKey,
+  };
+}
+
+function validateExpectedAssistArtifact(
+  artifact: AssistArtifact,
+  expected: ExpectedAssistArtifact,
+): void {
+  const expectedRunId = digits(expected.runId, "expected run id", 30);
+  const expectedRunAttempt = positiveInteger(expected.runAttempt, "expected run attempt");
+  if (
+    artifact.workflow.run_id !== expectedRunId ||
+    artifact.workflow.run_attempt !== expectedRunAttempt
+  ) {
+    throw new Error("assist artifact belongs to a different workflow run or attempt");
+  }
+  if (
+    artifact.target.repo !== expected.request.targetRepo ||
+    artifact.target.item_number !== expected.request.itemNumber
+  ) {
+    throw new Error("assist artifact target does not match the trusted workflow request");
+  }
+  if (artifact.request.sha256 !== assistRequestSha256(expected.request)) {
+    throw new Error("assist artifact request does not match the trusted workflow request");
+  }
+  if (
+    artifact.source.comment_id !== expected.request.sourceCommentId ||
+    artifact.source.comment_url !== expected.request.sourceCommentUrl ||
+    artifact.source.author !== expected.request.author ||
+    artifact.request.mode !== expected.request.mode ||
+    artifact.request.lens !== expected.request.lens ||
+    artifact.request.reasoning_effort !== expected.request.reasoningEffort
+  ) {
+    throw new Error("assist artifact metadata does not match the trusted workflow request");
+  }
+}
+
+function assistIdempotencyKey(options: {
+  targetRepo: string;
+  itemNumber: number;
+  itemKind: "issue" | "pull_request";
+  sourceCommentId: string;
+  sourceCommentUrl: string;
+  author: string;
+  mode: AssistMode;
+  lens: string;
+  reasoningEffort: string;
+  requestSha: string;
+  sourceRevision: string;
+  contextDigest: string;
+  pullHeadSha: string | null;
+  sourceDigest: string | null;
+}): string {
+  return sha256(
+    JSON.stringify({
+      target_repo: options.targetRepo,
+      item_number: options.itemNumber,
+      item_kind: options.itemKind,
+      source_comment_id: options.sourceCommentId,
+      source_comment_url: options.sourceCommentUrl,
+      author: options.author,
+      mode: options.mode,
+      lens: options.lens,
+      reasoning_effort: options.reasoningEffort,
+      request_sha256: options.requestSha,
+      source_revision: options.sourceRevision,
+      context_digest: options.contextDigest,
+      pull_head_sha: options.pullHeadSha,
+      source_digest: options.sourceDigest,
+    }),
+  );
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function record(value: unknown, name: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${name} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(value: Record<string, unknown>, expected: string[]): void {
+  const actual = Object.keys(value).sort();
+  const allowed = [...expected].sort();
+  if (actual.length !== allowed.length || actual.some((key, index) => key !== allowed[index])) {
+    throw new Error(`unexpected assist artifact fields: ${actual.join(", ")}`);
+  }
+}
+
+function scalar(
+  value: unknown,
+  name: string,
+  maxBytes: number,
+  allowEmpty = false,
+  allowNewlines = false,
+): string {
+  if (typeof value !== "string") throw new Error(`${name} must be a string`);
+  if (!allowEmpty && value.length === 0) throw new Error(`${name} must not be empty`);
+  if (Buffer.byteLength(value, "utf8") > maxBytes) {
+    throw new Error(`${name} exceeds ${maxBytes} bytes`);
+  }
+  if (containsUnsupportedControlCharacter(value, allowNewlines)) {
+    throw new Error(`${name} contains control characters`);
+  }
+  return value;
+}
+
+function containsUnsupportedControlCharacter(value: string, allowNewlines: boolean): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code === 0x7f) return true;
+    if (code >= 0x20) continue;
+    if (allowNewlines && (code === 0x09 || code === 0x0a || code === 0x0d)) continue;
+    return true;
+  }
+  return false;
+}
+
+function digits(value: unknown, name: string, maxBytes: number): string {
+  const text = scalar(value, name, maxBytes);
+  if (!COMMENT_ID_PATTERN.test(text)) throw new Error(`${name} must contain decimal digits`);
+  return text;
+}
+
+function optionalCommentId(value: unknown, name: string): string {
+  if (value === "") return "";
+  return digits(value, name, 30);
+}
+
+function positiveInteger(value: unknown, name: string): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive safe integer`);
+  }
+  return value;
+}
+
+function digest(value: unknown, name: string): string {
+  const text = scalar(value, name, 64);
+  if (!SHA256_PATTERN.test(text)) throw new Error(`${name} must be a lowercase SHA-256 digest`);
+  return text;
+}
+
+function nullableDigest(value: unknown, name: string): string | null {
+  return value === null ? null : digest(value, name);
+}
+
+function nullableSha(value: unknown, name: string): string | null {
+  if (value === null) return null;
+  const text = scalar(value, name, 40);
+  if (!SHA_PATTERN.test(text)) throw new Error(`${name} must be a lowercase 40-character SHA`);
+  return text;
+}

--- a/src/assist-artifact.ts
+++ b/src/assist-artifact.ts
@@ -133,10 +133,6 @@ export function createAssistArtifact(options: CreateAssistArtifactOptions): Assi
     lens: options.request.lens,
     reasoningEffort: options.request.reasoningEffort,
     requestSha,
-    sourceRevision: options.sourceRevision,
-    contextDigest: options.contextDigest,
-    pullHeadSha: options.pullHeadSha,
-    sourceDigest: options.sourceDigest,
   });
   return validateAssistArtifact({
     schema_version: ASSIST_ARTIFACT_SCHEMA_VERSION,
@@ -321,10 +317,6 @@ export function validateAssistArtifact(value: unknown): AssistArtifact {
     lens,
     reasoningEffort,
     requestSha,
-    sourceRevision,
-    contextDigest,
-    pullHeadSha,
-    sourceDigest,
   });
   if (idempotencyKey !== expectedIdempotencyKey) {
     throw new Error("assist artifact idempotency key does not match its bound inputs");
@@ -403,10 +395,6 @@ function assistIdempotencyKey(options: {
   lens: string;
   reasoningEffort: string;
   requestSha: string;
-  sourceRevision: string;
-  contextDigest: string;
-  pullHeadSha: string | null;
-  sourceDigest: string | null;
 }): string {
   return sha256(
     JSON.stringify({
@@ -420,10 +408,6 @@ function assistIdempotencyKey(options: {
       lens: options.lens,
       reasoning_effort: options.reasoningEffort,
       request_sha256: options.requestSha,
-      source_revision: options.sourceRevision,
-      context_digest: options.contextDigest,
-      pull_head_sha: options.pullHeadSha,
-      source_digest: options.sourceDigest,
     }),
   );
 }

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -3,8 +3,12 @@ import { spawnSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import {
   chmodSync,
+  closeSync,
   existsSync,
+  fstatSync,
   mkdirSync,
+  openSync,
+  readSync,
   readFileSync,
   readdirSync,
   renameSync,
@@ -50,6 +54,16 @@ import {
 } from "./github-retry.js";
 import { parseGhJson, parseGhJsonLinesWithRetry, parseGhJsonWithRetry } from "./github-json.js";
 import { stableJson } from "./stable-json.js";
+import {
+  ASSIST_ANSWER_MAX_BYTES,
+  ASSIST_ARTIFACT_MAX_BYTES,
+  assertAssistArtifactLiveRevision,
+  assistSourceCommentSha256,
+  createAssistArtifact,
+  parseAssistArtifact,
+  type AssistArtifact,
+  type AssistRequestBinding,
+} from "./assist-artifact.js";
 import {
   appendFloorBackfillCandidates,
   compareDueCandidates,
@@ -4493,6 +4507,7 @@ function isClawSweeperNoiseComment(value: unknown, number: number): boolean {
   if (!body.trim() || !isClawSweeperComment(value)) return false;
   if (isClawSweeperDurableReviewComment(value, number)) return true;
   if (/clawsweeper-pr-egg-hatch:/i.test(body)) return true;
+  if (/clawsweeper-assist:/i.test(body)) return true;
   if (/clawsweeper-visual\s+item=/i.test(body)) return true;
   if (/clawsweeper-command(?:-status|-ack)?:/i.test(body)) return true;
   if (/clawsweeper-review-status:/i.test(body)) return true;
@@ -8607,6 +8622,51 @@ function stripTextFence(markdown: string): string {
   return match ? (match[1]?.trim() ?? trimmed) : trimmed;
 }
 
+const ASSIST_ISSUE_VOLATILE_PROMPT_FIELDS = new Set(["comments", "updatedAt"]);
+const ASSIST_PULL_VOLATILE_PROMPT_FIELDS = new Set(["mergeable", "mergeableState", "updatedAt"]);
+
+function omitRecordFields(value: unknown, omitted: ReadonlySet<string>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(asRecord(value)).filter(([key]) => !omitted.has(key)));
+}
+
+function assistPromptContext(context: ItemContext): Record<string, unknown> {
+  const projected: Record<string, unknown> = {
+    issue: omitRecordFields(context.issue, ASSIST_ISSUE_VOLATILE_PROMPT_FIELDS),
+    comments: context.comments,
+    sourceRevision: context.sourceRevision ?? null,
+  };
+  if (context.goodFirstIssueHumanLabelState !== undefined) {
+    projected.goodFirstIssueHumanLabelState = context.goodFirstIssueHumanLabelState;
+  }
+  if (context.previousClawSweeperReview !== undefined) {
+    projected.previousClawSweeperReview = context.previousClawSweeperReview;
+  }
+  if (context.closingPullRequests !== undefined) {
+    projected.closingPullRequests = context.closingPullRequests.map((pull) =>
+      omitRecordFields(pull, ASSIST_PULL_VOLATILE_PROMPT_FIELDS),
+    );
+  }
+  if (context.referencingMergedPullRequests !== undefined) {
+    projected.referencingMergedPullRequests = context.referencingMergedPullRequests;
+  }
+  if (context.pullRequest !== undefined) {
+    projected.pullRequest = omitRecordFields(
+      context.pullRequest,
+      ASSIST_PULL_VOLATILE_PROMPT_FIELDS,
+    );
+  }
+  if (context.pullFiles !== undefined) projected.pullFiles = context.pullFiles;
+  if (context.pullCommits !== undefined) projected.pullCommits = context.pullCommits;
+  if (context.pullReviewComments !== undefined) {
+    projected.pullReviewComments = context.pullReviewComments;
+  }
+  return projected;
+}
+
+export function assistPromptContextForTest(context: unknown): Record<string, unknown> {
+  return assistPromptContext(context as ItemContext);
+}
+
 function buildAssistPrompt(options: {
   item: Item;
   context: ItemContext;
@@ -8655,7 +8715,7 @@ function buildAssistPrompt(options: {
     "",
     "GitHub context JSON:",
     "```json",
-    JSON.stringify(options.context, null, 2),
+    JSON.stringify(assistPromptContext(options.context), null, 2),
     "```",
   ].join("\n");
 }
@@ -8720,7 +8780,7 @@ function buildVisualPrompt(options: {
     "",
     "GitHub context JSON:",
     "```json",
-    JSON.stringify(options.context, null, 2),
+    JSON.stringify(assistPromptContext(options.context), null, 2),
     "```",
   ].join("\n");
 }
@@ -8757,6 +8817,8 @@ function runCodexAssist(options: {
     codexLoginConfig(),
     'approval_policy="never"',
   ];
+  const emptyGitHubConfigDir = join(options.workDir, ".gh-empty");
+  ensureDir(emptyGitHubConfigDir);
   const result = runCodexProcess({
     args: [
       "exec",
@@ -8769,7 +8831,7 @@ function runCodexAssist(options: {
       "-",
     ],
     cwd: ROOT,
-    env: codexEnv(),
+    env: { ...codexEnv(), GH_CONFIG_DIR: emptyGitHubConfigDir },
     input: prompt,
     timeoutMs: options.timeoutMs,
   });
@@ -8782,11 +8844,37 @@ function runCodexAssist(options: {
           }`;
     throw new Error(`Codex assist failed for #${options.item.number}: ${detail}`);
   }
-  return stripTextFence(readFileSync(outputPath, "utf8"));
+  return stripTextFence(
+    readBoundedUtf8File(outputPath, ASSIST_ANSWER_MAX_BYTES + 4_096, "Codex assist output"),
+  );
 }
 
-function assistCommentMarker(commentId: string): string {
-  return `<!-- clawsweeper-assist:${commentId || "unknown"} -->`;
+function readBoundedUtf8File(path: string, maxBytes: number, label: string): string {
+  const fd = openSync(path, "r");
+  try {
+    const size = fstatSync(fd).size;
+    if (!Number.isSafeInteger(size) || size < 0 || size > maxBytes) {
+      throw new Error(`${label} exceeds ${maxBytes} bytes`);
+    }
+    const buffer = Buffer.alloc(size);
+    let offset = 0;
+    while (offset < size) {
+      const bytesRead = readSync(fd, buffer, offset, size - offset, null);
+      if (bytesRead === 0) break;
+      offset += bytesRead;
+    }
+    const extra = Buffer.alloc(1);
+    if (readSync(fd, extra, 0, 1, null) > 0) {
+      throw new Error(`${label} changed while being read`);
+    }
+    return buffer.subarray(0, offset).toString("utf8");
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function assistCommentMarker(idempotencyKey: string): string {
+  return `<!-- clawsweeper-assist:${idempotencyKey} -->`;
 }
 
 const VISUAL_LENSES = new Set(["ux", "flow", "state", "data", "proof", "risk", "maintainer"]);
@@ -8841,6 +8929,7 @@ function renderAssistComment(options: {
   reasoningEffort: string;
   sourceCommentUrl: string;
   sourceCommentId: string;
+  idempotencyKey: string;
 }): string {
   const body = options.body.trim() || "ClawSweeper assist: I could not produce an answer.";
   const sourceLine = options.sourceCommentUrl
@@ -8852,7 +8941,7 @@ function renderAssistComment(options: {
     "---",
     `${sourceLine}`,
     `Assist reasoning: ${options.reasoningEffort}.`,
-    assistCommentMarker(options.sourceCommentId),
+    assistCommentMarker(options.idempotencyKey),
   ].join("\n");
 }
 
@@ -8882,18 +8971,6 @@ function renderVisualComment(options: {
   ].join("\n");
 }
 
-function postAssistComment(number: number, body: string): void {
-  const payload = writeCommentPayload(number, body);
-  ghWithRetry([
-    "api",
-    `repos/${targetRepo()}/issues/${number}/comments`,
-    "--method",
-    "POST",
-    "--input",
-    payload,
-  ]);
-}
-
 function itemHeadSha(item: Item, context: ItemContext): string {
   if (item.kind !== "pull_request") return "na";
   const pull = asRecord(context.pullRequest);
@@ -8901,16 +8978,24 @@ function itemHeadSha(item: Item, context: ItemContext): string {
   return typeof head.sha === "string" ? head.sha.trim() || "na" : "na";
 }
 
-function postOrUpdateVisualComment(
-  number: number,
-  lens: string,
-  headSha: string,
-  body: string,
-): void {
-  const marker = visualCommentMarker(number, lens, headSha);
-  const existing = ghPaged<unknown>(`repos/${targetRepo()}/issues/${number}/comments?per_page=100`)
+function findOwnedCommentByMarker(number: number, marker: string): Record<string, unknown> | null {
+  const owned = ghPaged<unknown>(`repos/${targetRepo()}/issues/${number}/comments?per_page=100`)
     .map(asRecord)
-    .find((comment) => typeof comment.body === "string" && comment.body.includes(marker));
+    .filter(
+      (comment) =>
+        typeof comment.body === "string" &&
+        comment.body.includes(marker) &&
+        canPatchReviewComment(comment),
+    );
+  return owned.at(-1) ?? null;
+}
+
+function publishIdempotentAssistComment(
+  number: number,
+  existing: Record<string, unknown> | null,
+  body: string,
+): "posted" | "updated" | "unchanged" {
+  if (existing && existing.body === body) return "unchanged";
   const payload = writeCommentPayload(number, body);
   const existingId =
     typeof existing?.id === "number" || typeof existing?.id === "string" ? existing.id : null;
@@ -8923,7 +9008,7 @@ function postOrUpdateVisualComment(
       "--input",
       payload,
     ]);
-    return;
+    return "updated";
   }
   ghWithRetry([
     "api",
@@ -8933,6 +9018,7 @@ function postOrUpdateVisualComment(
     "--input",
     payload,
   ]);
+  return "posted";
 }
 
 function closeReasonText(reason: CloseReason): string {
@@ -24924,80 +25010,328 @@ function applyHealthStatusArg(args: Args): Record<string, unknown> | undefined {
   return parsed as Record<string, unknown>;
 }
 
-function assistCommand(args: Args): void {
-  repoFromArgs(args);
+interface AssistSourceCommentSnapshot {
+  id: string;
+  issueUrl: string;
+  htmlUrl: string;
+  author: string;
+  body: string;
+  updatedAt: string;
+}
+
+interface LiveAssistBinding {
+  item: Item;
+  context: ItemContext;
+  sourceComment: AssistSourceCommentSnapshot | null;
+}
+
+function assistResolveTargetCommand(args: Args): void {
+  const profile = repoFromArgs(args);
+  const [owner, repository, ...extra] = profile.targetRepo.split("/");
+  if (!owner || !repository || extra.length > 0) {
+    throw new Error("assist target repository must be an owner/repository slug");
+  }
+  console.log(JSON.stringify({ repo: profile.targetRepo, owner, repository }));
+}
+
+function assistRequestFromArgs(args: Args): AssistRequestBinding {
   const itemNumber = numberArg(args.item_number, 0);
-  if (!itemNumber) throw new Error("--item-number is required for assist");
+  if (!Number.isSafeInteger(itemNumber) || itemNumber <= 0) {
+    throw new Error("--item-number is required for assist");
+  }
   const question = stringArg(args.question, "").trim();
   if (!question) throw new Error("--question is required for assist");
+  if (Buffer.byteLength(question, "utf8") > 10_000) {
+    throw new Error("--question exceeds the 10000-byte assist limit");
+  }
+  const mode = stringArg(args.mode, "assist").trim();
+  if (mode !== "assist" && mode !== "visual") {
+    throw new Error("--mode must be assist or visual");
+  }
+  const requestedLens = stringArg(args.lens, "auto").trim().toLowerCase();
+  if (requestedLens !== "auto" && !VISUAL_LENSES.has(requestedLens)) {
+    throw new Error("--lens is invalid for assist");
+  }
+  const request: AssistRequestBinding = {
+    targetRepo: targetRepo(),
+    itemNumber,
+    question,
+    mode,
+    lens: requestedLens,
+    sourceCommentId: stringArg(args.comment_id, "").trim(),
+    sourceCommentUrl: stringArg(args.comment_url, "").trim(),
+    author: stringArg(args.author, "").trim(),
+    reasoningEffort: stringArg(args.codex_reasoning_effort, "high").trim(),
+  };
+  if (Buffer.byteLength(request.sourceCommentUrl, "utf8") > 1_000) {
+    throw new Error("--comment-url exceeds the 1000-byte assist limit");
+  }
+  if (Buffer.byteLength(request.author, "utf8") > 100) {
+    throw new Error("--author exceeds the 100-byte assist limit");
+  }
+  if (!/^(?:low|medium|high|xhigh)$/.test(request.reasoningEffort)) {
+    throw new Error("--codex-reasoning-effort is invalid for assist");
+  }
+  return request;
+}
+
+function assistWorkflowIdentity(args: Args): { runId: string; runAttempt: number } {
+  const runId = stringArg(args.run_id, process.env.GITHUB_RUN_ID ?? "").trim();
+  const runAttempt = numberArg(
+    args.run_attempt,
+    Number.parseInt(process.env.GITHUB_RUN_ATTEMPT ?? "", 10),
+  );
+  if (!/^\d{1,30}$/.test(runId)) throw new Error("--run-id is required for assist artifacts");
+  if (!Number.isSafeInteger(runAttempt) || runAttempt <= 0) {
+    throw new Error("--run-attempt is required for assist artifacts");
+  }
+  return { runId, runAttempt };
+}
+
+function assistArtifactPath(args: Args): string {
+  const value = stringArg(args.artifact, "").trim();
+  if (!value) throw new Error("--artifact is required for assist generation and publishing");
+  return resolve(value);
+}
+
+function fetchAssistSourceComment(
+  request: AssistRequestBinding,
+): AssistSourceCommentSnapshot | null {
+  if (!request.sourceCommentId) return null;
+  if (!/^\d{1,30}$/.test(request.sourceCommentId)) {
+    throw new Error("assist source comment id is invalid");
+  }
+  const comment = ghJson<Record<string, unknown>>([
+    "api",
+    `repos/${targetRepo()}/issues/comments/${request.sourceCommentId}`,
+  ]);
+  const user = asRecord(comment.user);
+  const id = comment.id;
+  const snapshot: AssistSourceCommentSnapshot = {
+    id: typeof id === "string" || typeof id === "number" ? String(id) : "",
+    issueUrl: typeof comment.issue_url === "string" ? comment.issue_url : "",
+    htmlUrl: typeof comment.html_url === "string" ? comment.html_url : "",
+    author: typeof user.login === "string" ? user.login : "",
+    body: typeof comment.body === "string" ? comment.body : "",
+    updatedAt:
+      typeof comment.updated_at === "string"
+        ? comment.updated_at
+        : typeof comment.created_at === "string"
+          ? comment.created_at
+          : "",
+  };
+  if (
+    snapshot.id !== request.sourceCommentId ||
+    !assistIssueUrlMatches(snapshot.issueUrl, targetRepo(), request.itemNumber) ||
+    !snapshot.htmlUrl
+  ) {
+    throw new Error("assist source comment does not belong to the requested repository and item");
+  }
+  if (request.author && snapshot.author.toLowerCase() !== request.author.toLowerCase()) {
+    throw new Error("assist source comment author changed or does not match the request");
+  }
+  if (request.sourceCommentUrl && snapshot.htmlUrl !== request.sourceCommentUrl) {
+    throw new Error("assist source comment URL does not match the request");
+  }
+  return snapshot;
+}
+
+function assistIssueUrlMatches(issueUrl: string, repo: string, itemNumber: number): boolean {
+  const expectedIssuePath = `/repos/${repo}/issues/${itemNumber}`.toLowerCase();
+  return issueUrl.toLowerCase().endsWith(expectedIssuePath);
+}
+
+export function assistIssueUrlMatchesForTest(
+  issueUrl: string,
+  repo: string,
+  itemNumber: number,
+): boolean {
+  return assistIssueUrlMatches(issueUrl, repo, itemNumber);
+}
+
+function assistSourceDigest(source: AssistSourceCommentSnapshot | null): string | null {
+  return source ? assistSourceCommentSha256(source) : null;
+}
+
+function assistPromptContextDigest(item: Item, context: ItemContext): string {
+  return sha256(
+    stableJson({
+      item: {
+        repo: item.repo,
+        number: item.number,
+        kind: item.kind,
+        title: item.title,
+        url: item.url,
+      },
+      context: assistPromptContext(context),
+    }),
+  );
+}
+
+function captureLiveAssistBinding(request: AssistRequestBinding): LiveAssistBinding {
+  const { item, state } = fetchItem(request.itemNumber);
+  if (state.toLowerCase() !== "open") {
+    throw new Error(`assist requires an open issue or PR; #${request.itemNumber} is ${state}`);
+  }
+  const context = collectItemContext(item);
+  if (!/^[0-9a-f]{64}$/.test(String(context.sourceRevision ?? ""))) {
+    throw new Error("assist could not compute the live item source revision");
+  }
+  return {
+    item,
+    context,
+    sourceComment: fetchAssistSourceComment(request),
+  };
+}
+
+function validateLiveAssistArtifact(
+  artifact: AssistArtifact,
+  request: AssistRequestBinding,
+): LiveAssistBinding {
+  const live = captureLiveAssistBinding(request);
+  const liveHead = live.item.kind === "pull_request" ? itemHeadSha(live.item, live.context) : null;
+  assertAssistArtifactLiveRevision(artifact, {
+    itemKind: live.item.kind,
+    sourceRevision: live.context.sourceRevision!,
+    contextDigest: assistPromptContextDigest(live.item, live.context),
+    pullHeadSha: liveHead,
+    sourceDigest: assistSourceDigest(live.sourceComment),
+  });
+  return live;
+}
+
+function assistGenerateCommand(args: Args): void {
+  repoFromArgs(args);
+  const request = assistRequestFromArgs(args);
+  const workflow = assistWorkflowIdentity(args);
+  const artifactPath = assistArtifactPath(args);
   const model = stringArg(args.codex_model, PUBLIC_CODEX_MODEL);
-  const reasoningEffort = stringArg(args.codex_reasoning_effort, "high");
   const sandboxMode = stringArg(args.codex_sandbox, "read-only");
   const timeoutMs = numberArg(args.codex_timeout_ms, 120_000);
   const workDir = resolve(stringArg(args.work_dir, join(ROOT, ".artifacts", "assist-codex")));
-  const sourceCommentId = stringArg(args.comment_id, "");
-  const sourceCommentUrl = stringArg(args.comment_url, "");
-  const author = stringArg(args.author, "");
-  const mode = stringArg(args.mode, "assist") === "visual" ? "visual" : "assist";
-  const lens = normalizeVisualLens(stringArg(args.lens, "auto"));
-  const { item, state } = fetchItem(itemNumber);
-  if (state.toLowerCase() !== "open") {
-    throw new Error(`assist requires an open issue or PR; #${itemNumber} is ${state}`);
-  }
-  const context = collectItemContext(item);
+  const live = captureLiveAssistBinding(request);
   const answer = runCodexAssist({
-    item,
-    context,
-    question,
-    sourceCommentUrl,
-    author,
+    item: live.item,
+    context: live.context,
+    question: request.question,
+    sourceCommentUrl: live.sourceComment?.htmlUrl ?? request.sourceCommentUrl,
+    author: live.sourceComment?.author ?? request.author,
     model,
-    reasoningEffort,
+    reasoningEffort: request.reasoningEffort,
     sandboxMode,
     timeoutMs,
     workDir,
-    mode,
-    lens,
+    mode: request.mode,
+    lens: request.lens,
   });
-  if (mode === "visual") {
-    const comment = renderVisualComment({
-      body: answer,
-      item,
-      context,
-      lens,
-      model: PUBLIC_CODEX_MODEL,
-      reasoningEffort,
-      sourceCommentUrl,
-      sourceCommentId,
-    });
-    postOrUpdateVisualComment(item.number, lens, itemHeadSha(item, context), comment);
-    console.log(
-      JSON.stringify({
-        posted: true,
-        mode,
-        item: item.number,
-        lens,
-        model: PUBLIC_CODEX_MODEL,
-        reasoningEffort,
-      }),
-    );
-    return;
-  }
-  const comment = renderAssistComment({
-    body: answer,
-    model: PUBLIC_CODEX_MODEL,
-    reasoningEffort,
-    sourceCommentUrl,
-    sourceCommentId,
+  const pullHeadSha =
+    live.item.kind === "pull_request" ? itemHeadSha(live.item, live.context) : null;
+  const artifact = createAssistArtifact({
+    generatedAt: new Date().toISOString(),
+    runId: workflow.runId,
+    runAttempt: workflow.runAttempt,
+    itemKind: live.item.kind,
+    sourceRevision: live.context.sourceRevision!,
+    contextDigest: assistPromptContextDigest(live.item, live.context),
+    pullHeadSha,
+    sourceDigest: assistSourceDigest(live.sourceComment),
+    request,
+    answer,
   });
-  postAssistComment(item.number, comment);
+  ensureDir(dirname(artifactPath));
+  writeFileSync(artifactPath, `${JSON.stringify(artifact, null, 2)}\n`, "utf8");
   console.log(
     JSON.stringify({
-      posted: true,
-      mode,
-      item: item.number,
+      generated: true,
+      posted: false,
+      artifact: artifactPath,
+      idempotency_key: artifact.idempotency_key,
+      mode: request.mode,
+      item: request.itemNumber,
       model: PUBLIC_CODEX_MODEL,
-      reasoningEffort,
+      reasoningEffort: request.reasoningEffort,
+    }),
+  );
+}
+
+function assistPublishCommand(args: Args): void {
+  repoFromArgs(args);
+  const request = assistRequestFromArgs(args);
+  const workflow = assistWorkflowIdentity(args);
+  const artifact = parseAssistArtifact(
+    readBoundedUtf8File(assistArtifactPath(args), ASSIST_ARTIFACT_MAX_BYTES, "assist artifact"),
+    {
+      runId: workflow.runId,
+      runAttempt: workflow.runAttempt,
+      request,
+    },
+  );
+
+  const initialLive = validateLiveAssistArtifact(artifact, request);
+  const initialHead =
+    initialLive.item.kind === "pull_request"
+      ? itemHeadSha(initialLive.item, initialLive.context)
+      : "na";
+  const marker =
+    request.mode === "visual"
+      ? visualCommentMarker(request.itemNumber, request.lens, initialHead)
+      : assistCommentMarker(artifact.idempotency_key);
+  const existing = findOwnedCommentByMarker(request.itemNumber, marker);
+
+  // Re-fetch after idempotency discovery so target/source drift during artifact handling wins
+  // immediately before the only GitHub mutation in this process.
+  const live = validateLiveAssistArtifact(artifact, request);
+  const sourceCommentUrl = live.sourceComment?.htmlUrl ?? request.sourceCommentUrl;
+  const body =
+    request.mode === "visual"
+      ? renderVisualComment({
+          body: artifact.output.answer,
+          item: live.item,
+          context: live.context,
+          lens: request.lens,
+          model: PUBLIC_CODEX_MODEL,
+          reasoningEffort: request.reasoningEffort,
+          sourceCommentUrl,
+          sourceCommentId: request.sourceCommentId,
+        })
+      : renderAssistComment({
+          body: artifact.output.answer,
+          model: PUBLIC_CODEX_MODEL,
+          reasoningEffort: request.reasoningEffort,
+          sourceCommentUrl,
+          sourceCommentId: request.sourceCommentId,
+          idempotencyKey: artifact.idempotency_key,
+        });
+  const action = publishIdempotentAssistComment(request.itemNumber, existing, body);
+  console.log(
+    JSON.stringify({
+      posted: action === "posted",
+      action,
+      mode: request.mode,
+      item: request.itemNumber,
+      idempotency_key: artifact.idempotency_key,
+    }),
+  );
+}
+
+function assistValidateArtifactCommand(args: Args): void {
+  repoFromArgs(args);
+  const request = assistRequestFromArgs(args);
+  const workflow = assistWorkflowIdentity(args);
+  const artifact = parseAssistArtifact(
+    readBoundedUtf8File(assistArtifactPath(args), ASSIST_ARTIFACT_MAX_BYTES, "assist artifact"),
+    {
+      runId: workflow.runId,
+      runAttempt: workflow.runAttempt,
+      request,
+    },
+  );
+  console.log(
+    JSON.stringify({
+      valid: true,
+      item: artifact.target.item_number,
+      mode: artifact.request.mode,
+      idempotency_key: artifact.idempotency_key,
     }),
   );
 }
@@ -25028,7 +25362,10 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
       resolve(stringArg(args.closed_dir, defaultClosedDir())),
     );
   } else if (command === "status") statusCommand(args);
-  else if (command === "assist") assistCommand(args);
+  else if (command === "assist-target") assistResolveTargetCommand(args);
+  else if (command === "assist" || command === "assist-generate") assistGenerateCommand(args);
+  else if (command === "assist-validate") assistValidateArtifactCommand(args);
+  else if (command === "assist-publish") assistPublishCommand(args);
   else if (command === "check") checkCommand();
   else {
     console.error(`Unknown command: ${command}`);

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -1993,10 +1993,15 @@ export function parseRoutedCommentCommand(
   comment: LooseRecord,
   { trustedAuthors = new Set() }: LooseRecord = {},
 ) {
+  if (isAssistPublicationCommentBody(String(comment?.body ?? ""))) return null;
   if (isTrustedReviewStartStatusComment({ comment, trustedAuthors })) return null;
   const trusted = parseTrustedAutomation(comment, { trustedAuthors });
   if (trusted) return trusted;
   return parseCommand(String(comment?.body ?? ""));
+}
+
+export function isAssistPublicationCommentBody(body: string) {
+  return /<!--\s*clawsweeper-(?:assist:|visual(?:\s|-->))/i.test(String(body ?? ""));
 }
 
 export function isProofNudgeCommentBody(body: string) {

--- a/src/repair/comment-webhook.ts
+++ b/src/repair/comment-webhook.ts
@@ -5,6 +5,7 @@ import http from "node:http";
 import { repositoryProfileFor } from "../repository-profiles.js";
 import type { JsonValue, LooseRecord } from "./json-types.js";
 import {
+  isAssistPublicationCommentBody,
   isProofNudgeCommentBody,
   parseCommand,
   staleClosedItemCommandReason,
@@ -179,6 +180,9 @@ export function classifyIssueCommentWebhook({
   const issue = asRecord(payload.issue);
   const repo = asRecord(payload.repository);
   const association = String(comment.author_association ?? "").toUpperCase();
+  if (isAssistPublicationCommentBody(String(comment.body ?? ""))) {
+    return { accepted: false, reason: "assist publication comment" };
+  }
   if (isProofNudgeCommentBody(String(comment.body ?? ""))) {
     return { accepted: false, reason: "proof nudge comment" };
   }

--- a/test/assist-artifact.test.ts
+++ b/test/assist-artifact.test.ts
@@ -209,6 +209,8 @@ test("assist workflow isolates Codex generation from the fresh write-token publi
   );
   assert.equal(workflow.match(/uses: actions\/checkout@v7/g)?.length, 4);
   assert.equal(workflow.match(/persist-credentials: false/g)?.length, 4);
+  assert.equal(workflow.match(/REASONING_EFFORT: high/g)?.length, 3);
+  assert.doesNotMatch(workflow, /inputs\.reasoning_effort|client_payload\.reasoning_effort/);
 
   assert.match(generation, /Create read-only GitHub App token/);
   assert.ok(

--- a/test/assist-artifact.test.ts
+++ b/test/assist-artifact.test.ts
@@ -130,6 +130,36 @@ test("assist artifact validation rejects stale or redirected publication", () =>
   );
 });
 
+test("assist retry identity stays stable across live context revisions", () => {
+  const first = artifact();
+  const later = createAssistArtifact({
+    generatedAt: "2026-07-10T01:02:00Z",
+    runId: "987654322",
+    runAttempt: 1,
+    itemKind: "pull_request",
+    sourceRevision: "c".repeat(64),
+    contextDigest: "f".repeat(64),
+    pullHeadSha: "d".repeat(40),
+    sourceDigest: "9".repeat(64),
+    request,
+    answer: "ClawSweeper assist: refreshed answer.",
+  });
+
+  assert.equal(later.idempotency_key, first.idempotency_key);
+  assert.notEqual(later.target.context_digest, first.target.context_digest);
+  assert.throws(
+    () =>
+      assertAssistArtifactLiveRevision(first, {
+        itemKind: later.target.item_kind,
+        sourceRevision: later.target.source_revision,
+        contextDigest: later.target.context_digest,
+        pullHeadSha: later.target.pull_head_sha,
+        sourceDigest: later.source.digest,
+      }),
+    /target source changed/,
+  );
+});
+
 test("assist artifact validation rejects hostile shape, markers, and oversized output", () => {
   const extra = { ...artifact(), executable: "./payload.sh" };
   assert.throws(

--- a/test/assist-artifact.test.ts
+++ b/test/assist-artifact.test.ts
@@ -1,0 +1,268 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import {
+  ASSIST_ANSWER_MAX_BYTES,
+  assertAssistArtifactLiveRevision,
+  assistSourceCommentSha256,
+  createAssistArtifact,
+  parseAssistArtifact,
+  type AssistRequestBinding,
+} from "../dist/assist-artifact.js";
+
+const request: AssistRequestBinding = {
+  targetRepo: "openclaw/openclaw",
+  itemNumber: 42,
+  question: "What still blocks this pull request?",
+  mode: "assist",
+  lens: "auto",
+  sourceCommentId: "123456",
+  sourceCommentUrl: "https://github.com/openclaw/openclaw/issues/42#issuecomment-123456",
+  author: "maintainer",
+  reasoningEffort: "high",
+};
+
+const sourceDigest = assistSourceCommentSha256({
+  id: request.sourceCommentId,
+  issueUrl: "https://api.github.com/repos/openclaw/openclaw/issues/42",
+  htmlUrl: request.sourceCommentUrl,
+  author: request.author,
+  body: "@clawsweeper what still blocks this?",
+  updatedAt: "2026-07-10T01:00:00Z",
+});
+
+function artifact() {
+  return createAssistArtifact({
+    generatedAt: "2026-07-10T01:01:00Z",
+    runId: "987654321",
+    runAttempt: 2,
+    itemKind: "pull_request",
+    sourceRevision: "a".repeat(64),
+    contextDigest: "e".repeat(64),
+    pullHeadSha: "b".repeat(40),
+    sourceDigest,
+    request,
+    answer: "ClawSweeper assist: one required check is still pending.",
+  });
+}
+
+test("assist artifacts bind workflow, request, target revision, and source comment", () => {
+  const value = artifact();
+  const parsed = parseAssistArtifact(JSON.stringify(value), {
+    runId: "987654321",
+    runAttempt: 2,
+    request,
+  });
+
+  assert.deepEqual(parsed, value);
+  assertAssistArtifactLiveRevision(parsed, {
+    itemKind: "pull_request",
+    sourceRevision: "a".repeat(64),
+    contextDigest: "e".repeat(64),
+    pullHeadSha: "b".repeat(40),
+    sourceDigest,
+  });
+});
+
+test("assist artifact validation rejects stale or redirected publication", () => {
+  const value = artifact();
+  assert.throws(
+    () =>
+      parseAssistArtifact(JSON.stringify(value), {
+        runId: "987654322",
+        runAttempt: 2,
+        request,
+      }),
+    /different workflow run or attempt/,
+  );
+  assert.throws(
+    () =>
+      parseAssistArtifact(JSON.stringify(value), {
+        runId: "987654321",
+        runAttempt: 2,
+        request: { ...request, itemNumber: 43 },
+      }),
+    /target does not match/,
+  );
+  assert.throws(
+    () =>
+      assertAssistArtifactLiveRevision(value, {
+        itemKind: "pull_request",
+        sourceRevision: "c".repeat(64),
+        contextDigest: "e".repeat(64),
+        pullHeadSha: "b".repeat(40),
+        sourceDigest,
+      }),
+    /target source changed/,
+  );
+  assert.throws(
+    () =>
+      assertAssistArtifactLiveRevision(value, {
+        itemKind: "pull_request",
+        sourceRevision: "a".repeat(64),
+        contextDigest: "e".repeat(64),
+        pullHeadSha: "c".repeat(40),
+        sourceDigest,
+      }),
+    /pull request head changed/,
+  );
+  assert.throws(
+    () =>
+      assertAssistArtifactLiveRevision(value, {
+        itemKind: "pull_request",
+        sourceRevision: "a".repeat(64),
+        contextDigest: "e".repeat(64),
+        pullHeadSha: "b".repeat(40),
+        sourceDigest: "d".repeat(64),
+      }),
+    /source comment changed/,
+  );
+  assert.throws(
+    () =>
+      assertAssistArtifactLiveRevision(value, {
+        itemKind: "pull_request",
+        sourceRevision: "a".repeat(64),
+        contextDigest: "f".repeat(64),
+        pullHeadSha: "b".repeat(40),
+        sourceDigest,
+      }),
+    /prompt context changed/,
+  );
+});
+
+test("assist artifact validation rejects hostile shape, markers, and oversized output", () => {
+  const extra = { ...artifact(), executable: "./payload.sh" };
+  assert.throws(
+    () => parseAssistArtifact(JSON.stringify(extra)),
+    /unexpected assist artifact fields/,
+  );
+
+  const redirected = structuredClone(artifact());
+  redirected.target.repo = "attacker/example";
+  assert.throws(
+    () => parseAssistArtifact(JSON.stringify(redirected)),
+    /idempotency key does not match/,
+  );
+
+  const ambiguousTimestamp = structuredClone(artifact());
+  ambiguousTimestamp.generated_at = "2026-07-10";
+  assert.throws(
+    () => parseAssistArtifact(JSON.stringify(ambiguousTimestamp)),
+    /canonical ISO timestamp/,
+  );
+
+  assert.throws(
+    () =>
+      createAssistArtifact({
+        generatedAt: "2026-07-10T01:01:00Z",
+        runId: "987654321",
+        runAttempt: 2,
+        itemKind: "pull_request",
+        sourceRevision: "a".repeat(64),
+        contextDigest: "e".repeat(64),
+        pullHeadSha: "b".repeat(40),
+        sourceDigest,
+        request,
+        answer: "<!-- clawsweeper-verdict:pass -->",
+      }),
+    /must not contain ClawSweeper control markers/,
+  );
+  assert.throws(
+    () =>
+      createAssistArtifact({
+        generatedAt: "2026-07-10T01:01:00Z",
+        runId: "987654321",
+        runAttempt: 2,
+        itemKind: "pull_request",
+        sourceRevision: "a".repeat(64),
+        contextDigest: "e".repeat(64),
+        pullHeadSha: "b".repeat(40),
+        sourceDigest,
+        request,
+        answer: "x".repeat(ASSIST_ANSWER_MAX_BYTES + 1),
+      }),
+    /output\.answer exceeds/,
+  );
+});
+
+test("assist artifact schema is strict and versioned", () => {
+  const schema = JSON.parse(readFileSync("schema/assist-artifact.schema.json", "utf8"));
+  assert.equal(schema.additionalProperties, false);
+  assert.equal(schema.properties.schema_version.const, 1);
+  assert.match(schema.properties.target.properties.context_digest.pattern, /64/);
+  assert.equal(schema.properties.output.additionalProperties, false);
+  assert.equal(schema.properties.output.properties.answer.maxLength, ASSIST_ANSWER_MAX_BYTES);
+});
+
+test("assist workflow isolates Codex generation from the fresh write-token publisher", () => {
+  const workflow = readFileSync(".github/workflows/assist.yml", "utf8");
+  const source = readFileSync("src/clawsweeper.ts", "utf8");
+  const assistStart = workflow.indexOf("\n  assist:");
+  const publishStart = workflow.indexOf("\n  publish:", assistStart);
+  assert.ok(assistStart > 0 && publishStart > assistStart);
+  const generation = workflow.slice(assistStart, publishStart);
+  const publish = workflow.slice(publishStart);
+
+  assert.match(
+    workflow,
+    /permissions:\n  actions: read\n  contents: read\n  issues: read\n  pull-requests: read/,
+  );
+  assert.equal(workflow.match(/uses: actions\/checkout@v7/g)?.length, 4);
+  assert.equal(workflow.match(/persist-credentials: false/g)?.length, 4);
+
+  assert.match(generation, /Create read-only GitHub App token/);
+  assert.ok(
+    generation.indexOf("Resolve validated target repository") <
+      generation.indexOf("Create read-only GitHub App token"),
+  );
+  assert.match(generation, /repositories: \$\{\{ steps\.target\.outputs\.target_repo_name \}\}/);
+  assert.match(generation, /permission-issues: read/);
+  assert.match(generation, /permission-pull-requests: read/);
+  assert.match(generation, /GH_TOKEN: \$\{\{ steps\.read_token\.outputs\.token \}\}/);
+  assert.match(generation, /setup-codex/);
+  assert.match(generation, /assist-generate/);
+  assert.match(
+    generation,
+    /generation_attempt: \$\{\{ steps\.generate\.outputs\.generation_attempt \}\}/,
+  );
+  assert.match(generation, /generation_attempt=\$GITHUB_RUN_ATTEMPT/);
+  assert.match(generation, /actions\/upload-artifact@v7/);
+  assert.match(generation, /include-hidden-files: true/);
+  assert.doesNotMatch(generation, /permission-issues: write/);
+  assert.doesNotMatch(generation, /write_token|Create narrow GitHub App write token/);
+
+  const validateIndex = publish.indexOf("Validate untrusted assist artifact");
+  const tokenIndex = publish.indexOf("Create narrow GitHub App write token");
+  const mutateIndex = publish.indexOf("Revalidate and publish assist comment");
+  assert.ok(validateIndex >= 0 && validateIndex < tokenIndex && tokenIndex < mutateIndex);
+  assert.match(publish, /runs-on: ubuntu-latest/);
+  assert.match(publish, /ref: \$\{\{ github\.sha \}\}/);
+  assert.match(publish, /Verify exact workflow source/);
+  assert.ok(
+    publish.indexOf("Resolve validated target repository") <
+      publish.indexOf("Create narrow GitHub App write token"),
+  );
+  assert.match(publish, /actions\/download-artifact@v8/);
+  assert.match(
+    publish,
+    /clawsweeper-assist-\$\{\{ github\.run_id \}\}-\$\{\{ needs\.assist\.outputs\.generation_attempt \}\}/,
+  );
+  assert.equal(publish.match(/--run-attempt "\$GENERATION_ATTEMPT"/g)?.length, 2);
+  assert.match(publish, /permission-issues: write/);
+  assert.match(publish, /permission-pull-requests: read/);
+  assert.match(publish, /repositories: \$\{\{ steps\.target\.outputs\.target_repo_name \}\}/);
+  assert.match(publish, /GH_TOKEN: \$\{\{ steps\.write_token\.outputs\.token \}\}/);
+  assert.match(publish, /assist-validate/);
+  assert.match(publish, /assist-publish/);
+  assert.doesNotMatch(publish, /setup-codex|OPENAI_API_KEY|CLAWSWEEPER_INTERNAL_MODEL/);
+  assert.ok(publish.indexOf("GH_TOKEN:") > tokenIndex);
+  assert.match(
+    workflow,
+    /github\.event\.client_payload\.comment_id \|\| inputs\.comment_id \|\| 'manual'/,
+  );
+  assert.doesNotMatch(workflow.match(/group: .*\n/)?.[0] ?? "", /github\.run_id/);
+  assert.match(source, /readBoundedUtf8File\([\s\S]*ASSIST_ARTIFACT_MAX_BYTES/);
+  assert.match(source, /findOwnedCommentByMarker[\s\S]*canPatchReviewComment/);
+  assert.match(source, /live\.sourceComment\?\.htmlUrl \?\? request\.sourceCommentUrl/);
+  assert.doesNotMatch(source, /idempotency marker is owned by a non-ClawSweeper comment/);
+});

--- a/test/assist-artifact.test.ts
+++ b/test/assist-artifact.test.ts
@@ -251,7 +251,7 @@ test("assist workflow isolates Codex generation from the fresh write-token publi
   );
   assert.equal(publish.match(/--run-attempt "\$GENERATION_ATTEMPT"/g)?.length, 2);
   assert.match(publish, /permission-issues: write/);
-  assert.match(publish, /permission-pull-requests: read/);
+  assert.match(publish, /permission-pull-requests: write/);
   assert.match(publish, /repositories: \$\{\{ steps\.target\.outputs\.target_repo_name \}\}/);
   assert.match(publish, /GH_TOKEN: \$\{\{ steps\.write_token\.outputs\.token \}\}/);
   assert.match(publish, /assist-validate/);

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  assistIssueUrlMatchesForTest,
+  assistPromptContextForTest,
   compactMappedSlice,
   compactMappedWindow,
   extractLatestClawSweeperReviewForTest,
@@ -13,6 +15,25 @@ import {
   githubPaginatedPath,
   stripEmptyMaintainerRulingFieldsForTest,
 } from "../dist/clawsweeper.js";
+
+test("assist source comment URL matching preserves canonical repository casing", () => {
+  assert.equal(
+    assistIssueUrlMatchesForTest(
+      "https://api.github.com/repos/OpenClaw/ExampleRepo/issues/42",
+      "openclaw/examplerepo",
+      42,
+    ),
+    true,
+  );
+  assert.equal(
+    assistIssueUrlMatchesForTest(
+      "https://api.github.com/repos/OpenClaw/ExampleRepo/issues/420",
+      "openclaw/examplerepo",
+      42,
+    ),
+    false,
+  );
+});
 
 test("githubPaginatedPath requests maximum REST page size by default", () => {
   assert.equal(
@@ -126,6 +147,11 @@ test("review context comment filter removes ClawSweeper self-noise and command-o
       "<!-- clawsweeper-visual item=123 lens=state sha=abc -->\n# Visual brief",
       "clawsweeper",
     ),
+    issueComment(
+      8,
+      "ClawSweeper assist: prior answer.\n\n<!-- clawsweeper-assist:abc -->",
+      "clawsweeper[bot]",
+    ),
     issueComment(4, "@clawsweeper re-review", "author"),
     issueComment(5, "Here is real behavior proof from my terminal.", "author"),
     issueComment(6, "Actionable file/line review feedback.", "chatgpt-codex-connector[bot]"),
@@ -133,10 +159,66 @@ test("review context comment filter removes ClawSweeper self-noise and command-o
 
   const result = filterReviewContextCommentsForTest(comments, 123);
 
-  assert.equal(result.filtered, 5);
+  assert.equal(result.filtered, 6);
   assert.deepEqual(
     result.included.map((comment) => (comment as { id: number }).id),
     [5, 6],
+  );
+});
+
+test("assist prompt context excludes transient API state but preserves material review inputs", () => {
+  const base = {
+    issue: {
+      number: 42,
+      title: "Stable title",
+      state: "open",
+      comments: 3,
+      updatedAt: "2026-07-10T01:00:00Z",
+      body: "Stable body",
+    },
+    comments: [{ id: 1, author: "maintainer", body: "Please verify this." }],
+    timeline: [{ id: 9, event: "commented", actor: "clawsweeper[bot]" }],
+    sourceRevision: "a".repeat(64),
+    relatedItems: [{ issue: { number: 99, title: "Local search result" } }],
+    counts: { comments: 3, timeline: 9, pullFiles: 2 },
+    pullRequest: {
+      number: 42,
+      state: "open",
+      draft: false,
+      mergeable: null,
+      mergeableState: "unknown",
+      updatedAt: "2026-07-10T01:00:00Z",
+      head: { sha: "b".repeat(40) },
+      base: { sha: "c".repeat(40) },
+    },
+    pullFiles: [{ filename: "src/example.ts", patch: "+fixed" }],
+    pullCommits: [{ sha: "b".repeat(40), message: "fix: example" }],
+    pullReviewComments: [{ id: 2, author: "reviewer", body: "Needs a test." }],
+  };
+  const transientlyChanged = structuredClone(base);
+  transientlyChanged.issue.comments = 4;
+  transientlyChanged.issue.updatedAt = "2026-07-10T01:01:00Z";
+  transientlyChanged.counts.comments = 4;
+  transientlyChanged.pullRequest.mergeable = true;
+  transientlyChanged.pullRequest.mergeableState = "clean";
+  transientlyChanged.pullRequest.updatedAt = "2026-07-10T01:01:00Z";
+
+  assert.deepEqual(
+    assistPromptContextForTest(base),
+    assistPromptContextForTest(transientlyChanged),
+  );
+  const projected = assistPromptContextForTest(base);
+  assert.equal(projected.timeline, undefined);
+  assert.equal(projected.relatedItems, undefined);
+  assert.equal(projected.counts, undefined);
+  assert.equal((projected.issue as Record<string, unknown>).updatedAt, undefined);
+  assert.equal((projected.pullRequest as Record<string, unknown>).mergeableState, undefined);
+
+  const materiallyChanged = structuredClone(base);
+  materiallyChanged.pullRequest.draft = true;
+  assert.notDeepEqual(
+    assistPromptContextForTest(base),
+    assistPromptContextForTest(materiallyChanged),
   );
 });
 

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -1319,6 +1319,33 @@ test("parseRoutedCommentCommand ignores proof-nudge marker comments", () => {
   assert.equal(parseCommand(comment.body), null);
 });
 
+test("parseRoutedCommentCommand never routes commands embedded in assist publications", () => {
+  const trustedAuthors = new Set(["clawsweeper[bot]"]);
+  for (const body of [
+    [
+      "ClawSweeper assist: run the requested checks.",
+      "",
+      "/review",
+      "/autoclose injected reason",
+      "@clawsweeper automerge",
+      "",
+      "<!-- clawsweeper-assist:abc123 -->",
+    ].join("\n"),
+    [
+      "# Visual brief",
+      "",
+      "/clawsweeper review",
+      "",
+      "<!-- clawsweeper-visual item=42 lens=state sha=abc123 -->",
+    ].join("\n"),
+  ]) {
+    assert.equal(
+      parseRoutedCommentCommand({ user: { login: "clawsweeper[bot]" }, body }, { trustedAuthors }),
+      null,
+    );
+  }
+});
+
 test("parseRoutedCommentCommand prefers trusted verdict markers over copyable commands", () => {
   const trustedAuthors = new Set(["clawsweeper"]);
   const parsed = parseRoutedCommentCommand(

--- a/test/repair/comment-webhook.test.ts
+++ b/test/repair/comment-webhook.test.ts
@@ -66,6 +66,46 @@ test("comment webhook ignores ClawSweeper proof-nudge comments", () => {
   assert.deepEqual(result, { accepted: false, reason: "proof nudge comment" });
 });
 
+test("comment webhook ignores command-bearing assist and visual publications before ack or dispatch", async () => {
+  const originalFetch = globalThis.fetch;
+  let requests = 0;
+  globalThis.fetch = async () => {
+    requests += 1;
+    throw new Error("generated publications must not reach GitHub");
+  };
+
+  try {
+    for (const body of [
+      "@clawsweeper automerge\n<!-- clawsweeper-assist:stable-request -->",
+      "/autoclose\n<!-- clawsweeper-visual -->",
+    ]) {
+      const result = await handleGitHubWebhook({
+        event: "issue_comment",
+        payload: {
+          action: "created",
+          repository: { full_name: "openclaw/openclaw", default_branch: "main" },
+          issue: { number: 86422 },
+          installation: { id: 123 },
+          comment: {
+            id: 456,
+            body,
+            author_association: "MEMBER",
+            user: { login: "clawsweeper[bot]" },
+          },
+        },
+      });
+
+      assert.deepEqual(result, {
+        statusCode: 202,
+        body: { accepted: false, reason: "assist publication comment" },
+      });
+    }
+    assert.equal(requests, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("comment webhook rejects inline ClawSweeper mentions before visible ack", () => {
   const result = classifyIssueCommentWebhook({
     event: "issue_comment",


### PR DESCRIPTION
## Summary

- split untrusted Codex assist generation from a fresh, ephemeral publisher; scope both GitHub App tokens to the configured repository and pin publisher code to the triggering workflow SHA
- validate a bounded, strict artifact bound to the workflow run, request, target revision, source comment, PR head, and stable prompt context; recheck live state immediately before the single GitHub mutation
- make publication retry-safe and idempotent, and categorically prevent assist/visual output from being routed back into ClawSweeper commands

## Live findings fixed

- exact-head live publication initially failed because the publisher token had issue-write but only pull-request-read; the trusted publisher now requests pull-request-write while the model job remains read-only
- identical successful runs initially produced different markers when material prompt context drifted; retry identity now uses stable request identity while live revision/context bindings remain mandatory stale-publication guards
- fresh exact-head review found generated publication text could still enter the fast webhook acknowledgement/dispatch path; webhook ingestion now applies the shared publication guard before command matching, with no-request coverage proving no acknowledgement or dispatch

## Validation

- `pnpm -s build`
- `pnpm run build:repair`
- focused assist/context/router/webhook suite — 170 passed
- `pnpm run lint:src`
- `pnpm run lint:repair`
- `pnpm run lint:scripts`
- `pnpm run format:check`
- `actionlint .github/workflows/assist.yml`
- branch-wide autoreview — clean; no accepted/actionable findings
- dependency freshness — no outdated packages; audit reports 0 vulnerabilities

`pnpm run check` reaches the same three macOS harness failures reproduced from an archived clean current-main snapshot: two Bash 3.2 lowercase-expansion cases and one coverage-tail fixture. Exact-head hosted Linux CI is green.

## Exact-head live proof

Exact head: `7d3b4834b62f36803bb1a52ee4273128a853aed4`

- first final run: https://github.com/openclaw/clawsweeper/actions/runs/29155314306
- identical retry: https://github.com/openclaw/clawsweeper/actions/runs/29155375862
- resulting owned assist comment: https://github.com/openclaw/clawsweeper/pull/479#issuecomment-4946464599
- hosted CI: https://github.com/openclaw/clawsweeper/actions/runs/29155304737
- hosted CodeQL: https://github.com/openclaw/clawsweeper/actions/runs/29155304722

Both final runs used the same idempotency key. The first publisher reported `action: posted`; the retry reported `action: updated`; exactly one marker-backed assist comment remains at the same comment ID. Each run shows the read-only token in the generation job, bounded artifact upload/download and validation, and the fresh write token only in the separate trusted publisher job.

The earlier failed publication run is retained as root-cause proof: https://github.com/openclaw/clawsweeper/actions/runs/29154425050
