### PR TITLE
fix: retry malformed GitHub JSON lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Retried successful GitHub CLI JSON-lines responses when their output is truncated, preventing transient list-page corruption from aborting close-apply runs.
 - Allowed conflict-free canonical PRs that only need a base update to back duplicate or superseded closures while retaining proof, review, check, draft, and conflict guards.
 - Bounded broad reconciliation with batched Git I/O and tuple checkpoints that report progress and resume safely under concurrent state writers.
 - Retried tuple-safe broad reconciliation after full push batches lose continuous exact-state races, including candidates that normalize to no changes.

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -48,7 +48,7 @@ import {
   isLockedConversationCommentError,
   summarizeGhArgs,
 } from "./github-retry.js";
-import { parseGhJson, parseGhJsonLines, parseGhJsonWithRetry } from "./github-json.js";
+import { parseGhJson, parseGhJsonLinesWithRetry, parseGhJsonWithRetry } from "./github-json.js";
 import { stableJson } from "./stable-json.js";
 import {
   appendFloorBackfillCandidates,
@@ -143,6 +143,7 @@ export {
 export {
   parseGhJson,
   parseGhJsonLines,
+  parseGhJsonLinesWithRetry,
   parseGhJsonWithRetry,
   parseGhJsonWithRetryAsync,
 } from "./github-json.js";
@@ -2473,7 +2474,15 @@ function ghJsonOnce<T>(args: string[], timeoutMs: number): T {
 }
 
 function ghJsonLines<T>(args: string[]): T[] {
-  return parseGhJsonLines<T>(ghWithRetry(args), args);
+  return parseGhJsonLinesWithRetry<T>(() => ghWithRetry(args), args, {
+    onRetry: (_error, attempt) => {
+      const waitMs = ghRetryWaitMs("transient", attempt - 1);
+      console.error(
+        `Malformed GitHub JSON-lines response; retrying ${summarizeGhArgs(args)} in ${Math.round(waitMs / 1000)}s`,
+      );
+      sleepBeforeGitHubRetry(waitMs);
+    },
+  });
 }
 
 function sha256(text: string): string {

--- a/src/github-json.ts
+++ b/src/github-json.ts
@@ -77,6 +77,28 @@ export function parseGhJsonLines<T>(text: string, args: readonly string[]): T[] 
     });
 }
 
+export function parseGhJsonLinesWithRetry<T>(
+  load: () => string,
+  args: readonly string[],
+  options: {
+    attempts?: number;
+    onRetry?: (error: GhJsonParseError, attempt: number, attempts: number) => void;
+  } = {},
+): T[] {
+  const attempts = Math.max(1, options.attempts ?? 3);
+  let lastError: GhJsonParseError | undefined;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return parseGhJsonLines<T>(load(), args);
+    } catch (error) {
+      if (!(error instanceof GhJsonParseError) || attempt === attempts) throw error;
+      lastError = error;
+      options.onRetry?.(error, attempt, attempts);
+    }
+  }
+  throw lastError;
+}
+
 function formatParseError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }

--- a/test/github-json.test.ts
+++ b/test/github-json.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseGhJsonLinesWithRetry } from "../dist/github-json.js";
+
+test("JSON-lines loader retries a successful command with truncated output", () => {
+  const responses = ['{"number":1}\n{"number":', '{"number":1}\n{"number":2}'];
+  const retries: number[] = [];
+
+  const parsed = parseGhJsonLinesWithRetry<{ number: number }>(
+    () => responses.shift() ?? "",
+    ["api", "repos/openclaw/openclaw/issues", "--jq", ".[]"],
+    {
+      onRetry: (_error, attempt) => retries.push(attempt),
+    },
+  );
+
+  assert.deepEqual(parsed, [{ number: 1 }, { number: 2 }]);
+  assert.deepEqual(retries, [1]);
+  assert.equal(responses.length, 0);
+});


### PR DESCRIPTION
## Summary

- retry malformed JSON-lines output from successful GitHub CLI list requests, matching the existing retry behavior for whole JSON responses
- keep retries bounded and inside the existing GitHub runtime budget
- cover a truncated response followed by a valid retry

## Production failure

- https://github.com/openclaw/clawsweeper/actions/runs/29090994808 failed after `gh api` exited successfully with a truncated `--jq` JSON line (`unexpected end of JSON input`)

## Tests

- `pnpm -s build`
- `node --test test/github-json.test.ts test/clawsweeper.test.ts` (76 passed)
- `pnpm run lint:src`
- `pnpm run lint:scripts`
- `pnpm run format:check`
- GPT-5.6 Sol/high autoreview: clean (0.96)
