### PR TITLE
fix: guard low-signal PR closes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Required a live `DIRTY` merge conflict and at least 30 days without contributor comments or head activity before closing low-signal pull requests, honoring longer configured stale thresholds and applying the same fail-closed policy to stale-review promotion and trusted close routing.
 - Retried successful GitHub CLI JSON-lines responses when their output is truncated, preventing transient list-page corruption from aborting close-apply runs.
 - Allowed conflict-free canonical PRs that only need a base update to back duplicate or superseded closures while retaining proof, review, check, draft, and conflict guards.
 - Bounded broad reconciliation with batched Git I/O and tuple checkpoints that report progress and resume safely under concurrent state writers.

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -1199,6 +1199,7 @@ const STALLED_UNPROVEN_PR_MIN_AGE_DAYS = 14;
 const STALLED_UNPROVEN_PR_MIN_INACTIVE_DAYS = 14;
 const ABANDONED_PR_MIN_AGE_DAYS = 30;
 const ABANDONED_PR_MIN_INACTIVE_DAYS = 30;
+const LOW_SIGNAL_UNMERGEABLE_PR_MIN_INACTIVE_DAYS = 30;
 const DAY_MS = 24 * 60 * 60 * 1000;
 const RECENT_MISSING_OPEN_MS = DAY_MS;
 const DEFAULT_CODEX_MODEL = PUBLIC_CODEX_MODEL;
@@ -3644,7 +3645,127 @@ function maintainerAssociatedEntries(entries: readonly unknown[]): unknown[] {
   );
 }
 
-function lowSignalUnmergeablePrApplyBlockReason(number: number): string | null {
+function lowSignalUnmergeablePrConflictBlockReason(pullValue: unknown): string | null {
+  const pull = asRecord(pullValue);
+  const mergeableState = (
+    stringOrUndefined(pull.mergeableState) ??
+    stringOrUndefined(pull.mergeable_state) ??
+    "unknown"
+  ).toLowerCase();
+  if (pull.mergeable === false && mergeableState === "dirty") return null;
+  const mergeable = typeof pull.mergeable === "boolean" ? String(pull.mergeable) : "unknown";
+  return `low_signal_unmergeable_pr requires a live merge conflict; GitHub reports mergeable=${mergeable}, mergeable_state=${mergeableState}`;
+}
+
+function githubActivityTimestampMs(value: unknown): number | null {
+  const record = asRecord(value);
+  for (const candidate of [
+    record.updatedAt,
+    record.updated_at,
+    record.submitted_at,
+    record.createdAt,
+    record.created_at,
+  ]) {
+    const timestamp = Date.parse(typeof candidate === "string" ? candidate : "");
+    if (Number.isFinite(timestamp)) return timestamp;
+  }
+  return null;
+}
+
+function githubActivityLogin(value: unknown): string {
+  const record = asRecord(value);
+  return (
+    stringOrUndefined(record.author) ??
+    login(record.user) ??
+    stringOrUndefined(record.actor) ??
+    login(record.actor) ??
+    ""
+  )
+    .trim()
+    .toLowerCase();
+}
+
+function latestPullRequestAuthorActivityAtMs(options: {
+  author: string;
+  createdAt: string;
+  comments?: readonly unknown[];
+  reviews?: readonly unknown[];
+  inlineComments?: readonly unknown[];
+  timeline?: readonly unknown[];
+  headActivityAtMs?: number | null;
+}): number | null {
+  const author = options.author.trim().toLowerCase();
+  if (!author) return null;
+  let latest = Date.parse(options.createdAt);
+  if (!Number.isFinite(latest)) latest = Number.NEGATIVE_INFINITY;
+  const observe = (value: unknown): void => {
+    if (githubActivityLogin(value) !== author) return;
+    const timestamp = githubActivityTimestampMs(value);
+    if (timestamp !== null && timestamp > latest) latest = timestamp;
+  };
+  options.comments?.forEach(observe);
+  options.reviews?.forEach(observe);
+  options.inlineComments?.forEach(observe);
+  for (const event of options.timeline ?? []) {
+    const record = asRecord(event);
+    const eventName = stringOrUndefined(record.event) ?? "";
+    const commitId = stringOrUndefined(record.commitId) ?? stringOrUndefined(record.commit_id);
+    if (
+      eventName === "commented" ||
+      eventName === "committed" ||
+      eventName === "head_ref_force_pushed" ||
+      eventName === "head_ref_restored" ||
+      Boolean(commitId)
+    ) {
+      observe(event);
+    }
+  }
+  if (options.headActivityAtMs !== null && options.headActivityAtMs !== undefined) {
+    latest = Math.max(latest, options.headActivityAtMs);
+  }
+  return Number.isFinite(latest) ? latest : null;
+}
+
+function lowSignalUnmergeablePrAuthorActivityBlockReason(options: {
+  author: string;
+  createdAt: string;
+  comments?: readonly unknown[];
+  reviews?: readonly unknown[];
+  inlineComments?: readonly unknown[];
+  timeline?: readonly unknown[];
+  headActivityAtMs?: number | null;
+  staleMinAgeDays: number;
+  requireHeadActivityEvidence?: boolean;
+  now?: number;
+}): string | null {
+  if (
+    options.requireHeadActivityEvidence &&
+    (options.headActivityAtMs === null || options.headActivityAtMs === undefined)
+  ) {
+    return "low_signal_unmergeable_pr requires dated activity evidence for the current head";
+  }
+  const latestActivityAtMs = latestPullRequestAuthorActivityAtMs(options);
+  if (latestActivityAtMs === null) {
+    return "low_signal_unmergeable_pr requires dated author and current-head activity evidence";
+  }
+  const now = options.now ?? Date.now();
+  const configuredInactiveDays = Number.isFinite(options.staleMinAgeDays)
+    ? Math.max(0, options.staleMinAgeDays)
+    : LOW_SIGNAL_UNMERGEABLE_PR_MIN_INACTIVE_DAYS;
+  const minimumInactiveDays = Math.max(
+    LOW_SIGNAL_UNMERGEABLE_PR_MIN_INACTIVE_DAYS,
+    configuredInactiveDays,
+  );
+  if (now - latestActivityAtMs <= minimumInactiveDays * DAY_MS) {
+    return `low_signal_unmergeable_pr requires ${minimumInactiveDays} days without author comments or head activity`;
+  }
+  return null;
+}
+
+function lowSignalUnmergeablePrApplyBlockReason(
+  number: number,
+  staleMinAgeDays: number,
+): string | null {
   const issue = ghJson<{ assignees?: unknown[] }>([
     "api",
     `repos/${targetRepo()}/issues/${number}`,
@@ -3653,27 +3774,62 @@ function lowSignalUnmergeablePrApplyBlockReason(number: number): string | null {
   ]);
   if ((issue.assignees ?? []).length > 0) return "assigned PR has maintainer/human signal";
 
-  const pull = ghJson<{ requested_reviewers?: unknown[]; requested_teams?: unknown[] }>([
-    "api",
-    `repos/${targetRepo()}/pulls/${number}`,
-    "--jq",
-    "{requested_reviewers:[.requested_reviewers[]? | {login:.login}],requested_teams:[.requested_teams[]? | {slug:.slug}]}",
-  ]);
+  const pull = ghJson<{
+    created_at?: string;
+    mergeable?: boolean | null;
+    mergeable_state?: string | null;
+    requested_reviewers?: unknown[];
+    requested_teams?: unknown[];
+    user?: GitHubUser;
+    head?: { ref?: string; repo?: { full_name?: string; id?: unknown }; sha?: string };
+  }>(["api", `repos/${targetRepo()}/pulls/${number}`]);
   if ((pull.requested_reviewers ?? []).length > 0 || (pull.requested_teams ?? []).length > 0) {
     return "requested reviewers or teams indicate active review signal";
   }
 
-  const maintainerComments = maintainerAssociatedEntries(
-    ghPaged<unknown>(`repos/${targetRepo()}/issues/${number}/comments`),
-  );
+  const comments = ghPaged<unknown>(`repos/${targetRepo()}/issues/${number}/comments`);
+  const maintainerComments = maintainerAssociatedEntries(comments);
   if (maintainerComments.length > 0) return "maintainer issue comment blocks low-signal auto-close";
 
-  const maintainerReviews = maintainerAssociatedEntries(
-    ghPaged<unknown>(`repos/${targetRepo()}/pulls/${number}/reviews`),
-  );
+  const reviews = ghPaged<unknown>(`repos/${targetRepo()}/pulls/${number}/reviews`);
+  const maintainerReviews = maintainerAssociatedEntries(reviews);
   if (maintainerReviews.length > 0) return "maintainer PR review blocks low-signal auto-close";
 
-  return null;
+  const inlineComments = ghPaged<unknown>(`repos/${targetRepo()}/pulls/${number}/comments`);
+  const maintainerInlineComments = maintainerAssociatedEntries(inlineComments);
+  if (maintainerInlineComments.length > 0) {
+    return "maintainer inline review comment blocks low-signal auto-close";
+  }
+
+  const conflictBlock = lowSignalUnmergeablePrConflictBlockReason(pull);
+  if (conflictBlock) return conflictBlock;
+
+  const timeline = ghPaged<unknown>(`repos/${targetRepo()}/issues/${number}/timeline`);
+  const headActivity = pullRequestHeadActivity(number, pull, timeline);
+  return lowSignalUnmergeablePrAuthorActivityBlockReason({
+    author: pull.user?.login ?? "",
+    createdAt: pull.created_at ?? "",
+    comments,
+    reviews,
+    inlineComments,
+    timeline,
+    headActivityAtMs: headActivity.headActivityAtMs,
+    staleMinAgeDays,
+    requireHeadActivityEvidence: true,
+  });
+}
+
+function lowSignalUnmergeablePrApplyBlockReasonSafe(
+  number: number,
+  staleMinAgeDays: number,
+): string | null {
+  try {
+    return lowSignalUnmergeablePrApplyBlockReason(number, staleMinAgeDays);
+  } catch (error) {
+    return `low-signal conflict/activity check failed: ${
+      error instanceof Error ? error.message : String(error)
+    }`;
+  }
 }
 
 function unconfirmedProductDirectionApplyBlockReason(
@@ -3795,15 +3951,16 @@ const FAILING_CHECK_RUN_CONCLUSIONS = new Set(["failure", "timed_out"]);
 // A pull_request workflow run associated with this PR is tied to source
 // activity, while rerunning its checks leaves created_at unchanged. Missing
 // source-run data keeps the PR open.
-function pullRequestLiveActivity(number: number): PullRequestLiveActivity {
-  const pull = ghJson<{
+function pullRequestHeadActivity(
+  number: number,
+  pull: {
     created_at?: string;
-    draft?: boolean;
     head?: { ref?: string; repo?: { full_name?: string; id?: unknown }; sha?: string };
-  }>(["api", `repos/${targetRepo()}/pulls/${number}`]);
+  },
+  timeline = ghPaged<unknown>(`repos/${targetRepo()}/issues/${number}/timeline`),
+): Pick<PullRequestLiveActivity, "headSha" | "headActivityAtMs"> {
   const headSha = typeof pull.head?.sha === "string" ? pull.head.sha : "";
   let headActivityAtMs: number | null = null;
-  let headChecksFailing = false;
   const observe = (value: unknown): void => {
     const ms = Date.parse(typeof value === "string" ? value : "");
     if (Number.isFinite(ms) && (headActivityAtMs === null || ms > headActivityAtMs)) {
@@ -3839,12 +3996,26 @@ function pullRequestLiveActivity(number: number): PullRequestLiveActivity {
         observe(record.created_at);
       }
     }
-    for (const event of ghPaged<unknown>(`repos/${targetRepo()}/issues/${number}/timeline`)) {
+    for (const event of timeline) {
       const record = asRecord(event);
-      if (record.event === "head_ref_force_pushed" && record.commit_id === headSha) {
-        observe(record.created_at);
+      const commitId = stringOrUndefined(record.commitId) ?? stringOrUndefined(record.commit_id);
+      if (record.event === "head_ref_force_pushed" && commitId === headSha) {
+        observe(stringOrUndefined(record.createdAt) ?? record.created_at);
       }
     }
+  }
+  return { headSha, headActivityAtMs };
+}
+
+function pullRequestLiveActivity(number: number): PullRequestLiveActivity {
+  const pull = ghJson<{
+    created_at?: string;
+    draft?: boolean;
+    head?: { ref?: string; repo?: { full_name?: string; id?: unknown }; sha?: string };
+  }>(["api", `repos/${targetRepo()}/pulls/${number}`]);
+  const { headSha, headActivityAtMs } = pullRequestHeadActivity(number, pull);
+  let headChecksFailing = false;
+  if (headSha) {
     const combined = ghJson<{ state?: string }>([
       "api",
       `repos/${targetRepo()}/commits/${headSha}/status`,
@@ -14799,6 +14970,7 @@ function recommendedPauseOrCloseOption(markdown: string): MergeRiskOption | null
 function staleFRatedPullRequestPromotion(
   markdown: string,
   item: Item,
+  context: ItemContext,
   staleMinAgeDays: number,
 ): PullRequestClosePromotion | null {
   const proof = reportRealBehaviorProof(markdown);
@@ -14810,6 +14982,49 @@ function staleFRatedPullRequestPromotion(
     proof.status !== "mock_only" &&
     proof.status !== "insufficient" &&
     rating.proofTier !== "F"
+  ) {
+    return null;
+  }
+  if (
+    context.counts?.commentsTruncated ||
+    context.counts?.timelineTruncated ||
+    context.counts?.pullReviewCommentsTruncated
+  ) {
+    return null;
+  }
+  let livePull: {
+    created_at?: string;
+    mergeable?: boolean | null;
+    mergeable_state?: string | null;
+    user?: GitHubUser;
+    head?: { ref?: string; repo?: { full_name?: string; id?: unknown }; sha?: string };
+  };
+  let reviews: unknown[];
+  let headActivityAtMs: number | null;
+  try {
+    livePull = ghJson(["api", `repos/${targetRepo()}/pulls/${item.number}`]);
+    if (lowSignalUnmergeablePrConflictBlockReason(livePull)) return null;
+    reviews = ghPaged<unknown>(`repos/${targetRepo()}/pulls/${item.number}/reviews`);
+    headActivityAtMs = pullRequestHeadActivity(
+      item.number,
+      livePull,
+      context.timeline,
+    ).headActivityAtMs;
+  } catch {
+    return null;
+  }
+  if (
+    lowSignalUnmergeablePrAuthorActivityBlockReason({
+      author: livePull.user?.login ?? item.author,
+      createdAt: livePull.created_at ?? item.createdAt,
+      comments: context.comments,
+      reviews,
+      inlineComments: context.pullReviewComments ?? [],
+      timeline: context.timeline,
+      headActivityAtMs,
+      staleMinAgeDays,
+      requireHeadActivityEvidence: true,
+    })
   ) {
     return null;
   }
@@ -14893,7 +15108,7 @@ function pullRequestClosePromotion(
   // A live canonical candidate that is itself unsafe cannot justify treating the
   // source as generic low-signal work. Missing or non-covering references can.
   if (linkedSupersession.unsafeReason) return null;
-  return staleFRatedPullRequestPromotion(markdown, item, staleMinAgeDays);
+  return staleFRatedPullRequestPromotion(markdown, item, context, staleMinAgeDays);
 }
 
 function workPlanPathForReport(file: string, plansDir = defaultPlansDir()): string {
@@ -21911,7 +22126,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
     }
     const lowSignalBlockReason =
       closeReason === "low_signal_unmergeable_pr"
-        ? lowSignalUnmergeablePrApplyBlockReason(number)
+        ? lowSignalUnmergeablePrApplyBlockReasonSafe(number, staleMinAgeDays)
         : null;
     if (lowSignalBlockReason) {
       if (markApplySkipped("kept_open", lowSignalBlockReason)) break;

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -1235,6 +1235,7 @@ function trustedCloseReasonSpecificBlockReason({
       productDirection: false,
     });
     if (humanSignal) return humanSignal;
+    return "low_signal_unmergeable_pr closes require apply-decisions live conflict and author-activity proof";
   }
   return null;
 }

--- a/test/apply-pr-promotion.test.ts
+++ b/test/apply-pr-promotion.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import test from "node:test";
 
 import {
+  lowSignalCloseReport,
   promotionGhMock,
   reportWithSyncedReviewComment,
   runApplyDecisionsForTest,
@@ -13,6 +14,81 @@ import {
   withMockGh,
   workPlanCandidateReport,
 } from "./helpers.ts";
+
+function runLowSignalApplyFixture(options: {
+  number: number;
+  reportOverrides?: Record<string, unknown>;
+  itemCreatedAt?: string;
+  itemUpdatedAt?: string;
+  headSha?: string;
+  headActivityAt?: string | null;
+  mergeable?: boolean | null;
+  mergeableState?: string | null;
+  comments?: (reviewComment: string) => unknown[];
+  timeline?: unknown[];
+}): Array<{ number: number; action: string; reason: string }> {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const sourceReport = lowSignalCloseReport({
+      number: options.number,
+      title: "Low-signal close guard fixture",
+      ...options.reportOverrides,
+    });
+    const synced = reportWithSyncedReviewComment(
+      sourceReport,
+      options.number,
+      "low_signal_unmergeable_pr",
+    );
+    writeFileSync(join(itemsDir, `${options.number}.md`), synced.report, "utf8");
+
+    withMockGh(
+      root,
+      promotionGhMock({
+        number: options.number,
+        title: "Low-signal close guard fixture",
+        comment: synced.comment,
+        ...(options.itemCreatedAt ? { itemCreatedAt: options.itemCreatedAt } : {}),
+        ...(options.itemUpdatedAt ? { itemUpdatedAt: options.itemUpdatedAt } : {}),
+        ...(options.headSha ? { headSha: options.headSha } : {}),
+        ...(options.headActivityAt !== undefined ? { headActivityAt: options.headActivityAt } : {}),
+        ...(options.mergeable !== undefined ? { mergeable: options.mergeable } : {}),
+        ...(options.mergeableState !== undefined ? { mergeableState: options.mergeableState } : {}),
+        ...(options.comments ? { comments: options.comments(synced.comment) } : {}),
+        ...(options.timeline ? { timeline: options.timeline } : {}),
+      }),
+      () => {
+        runApplyDecisionsForTest({
+          targetRepo: "openclaw/openclaw",
+          itemsDir,
+          closedDir,
+          plansDir,
+          reportPath,
+          extraArgs: [
+            "--dry-run",
+            "--apply-kind",
+            "all",
+            "--apply-close-reasons",
+            "low_signal_unmergeable_pr",
+            "--stale-min-age-days",
+            "30",
+            "--item-numbers",
+            String(options.number),
+          ],
+        });
+      },
+    );
+
+    return JSON.parse(readFileSync(reportPath, "utf8"));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
 
 function assertResolvedPromotionRespectsCloseReasonFilter(options: {
   number: number;
@@ -438,6 +514,7 @@ test("apply-decisions promotes old F-rated stale PRs with low-signal close seman
       promotionGhMock({
         number: 330,
         comment: synced.comment,
+        headRunPullRequests: [],
         closeAppliedBodyLogPath,
         linkedPulls: {
           400: {
@@ -504,6 +581,228 @@ test("apply-decisions promotes old F-rated stale PRs with low-signal close seman
     const closeAppliedBody = readFileSync(closeAppliedBodyLogPath, "utf8");
     assert.match(closeAppliedBody, /Close reason: low-signal unmergeable PR\./);
     assert.doesNotMatch(closeAppliedBody, /Keep open:/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions keeps MERGEABLE UNSTABLE low-signal proposals open", () => {
+  const report = runLowSignalApplyFixture({
+    number: 341,
+    reportOverrides: {
+      item_created_at: "2026-02-01T00:00:00Z",
+      item_updated_at: "2026-05-01T00:00:00Z",
+      reviewed_at: "2026-05-01T00:00:00Z",
+      pull_head_sha: "head-sha",
+    },
+    itemCreatedAt: "2026-02-01T00:00:00Z",
+    itemUpdatedAt: "2026-05-01T00:00:00Z",
+    mergeable: true,
+    mergeableState: "unstable",
+    headActivityAt: "2026-02-01T01:00:00Z",
+  });
+
+  assert.match(
+    report.find((entry) => entry.action === "kept_open")?.reason ?? "",
+    /requires a live merge conflict; GitHub reports mergeable=true, mergeable_state=unstable/,
+  );
+  assert.equal(
+    report.some((entry) => entry.action === "closed"),
+    false,
+  );
+});
+
+test("apply-decisions keeps recently updated DIRTY low-signal proposals open", () => {
+  const number = 342;
+  const headSha = "3423423423423423423423423423423423423423";
+  const now = Date.now();
+  const createdAt = new Date(now - 45 * 24 * 60 * 60 * 1000).toISOString();
+  const authorActivityAt = new Date(now - 4.5 * 60 * 60 * 1000).toISOString();
+  const reviewedAt = new Date(now - 4 * 60 * 60 * 1000).toISOString();
+  const report = runLowSignalApplyFixture({
+    number,
+    reportOverrides: {
+      author: "reporter",
+      item_created_at: createdAt,
+      item_updated_at: reviewedAt,
+      reviewed_at: reviewedAt,
+      pull_head_sha: headSha,
+    },
+    itemCreatedAt: createdAt,
+    itemUpdatedAt: reviewedAt,
+    headSha,
+    mergeable: false,
+    mergeableState: "dirty",
+    headActivityAt: authorActivityAt,
+    comments: (reviewComment) => [
+      {
+        id: 9342,
+        created_at: reviewedAt,
+        updated_at: reviewedAt,
+        user: { login: "clawsweeper[bot]" },
+        body: reviewComment,
+      },
+      {
+        id: 9343,
+        created_at: authorActivityAt,
+        updated_at: authorActivityAt,
+        user: { login: "reporter" },
+        body: "Rebased and force-pushed the requested changes.",
+      },
+    ],
+    timeline: [
+      {
+        event: "head_ref_force_pushed",
+        created_at: authorActivityAt,
+        actor: { login: "reporter" },
+        commit_id: headSha,
+      },
+    ],
+  });
+
+  assert.match(
+    report.find((entry) => entry.action === "kept_open")?.reason ?? "",
+    /requires 30 days without author comments or head activity/,
+  );
+  assert.equal(
+    report.some((entry) => entry.action === "closed"),
+    false,
+  );
+});
+
+test("apply-decisions still closes old DIRTY low-signal proposals", () => {
+  const report = runLowSignalApplyFixture({
+    number: 343,
+    reportOverrides: {
+      item_created_at: "2026-02-01T00:00:00Z",
+      item_updated_at: "2026-05-01T00:00:00Z",
+      reviewed_at: "2026-05-01T00:00:00Z",
+      pull_head_sha: "head-sha",
+    },
+    itemCreatedAt: "2026-02-01T00:00:00Z",
+    itemUpdatedAt: "2026-05-01T00:00:00Z",
+    mergeable: false,
+    mergeableState: "dirty",
+    headActivityAt: "2026-02-01T01:00:00Z",
+  });
+
+  assert.match(
+    report.find((entry) => entry.action === "closed")?.reason ?? "",
+    /dry-run: would close as low-signal unmergeable PR/,
+  );
+});
+
+test("apply-decisions fails closed without current-head activity evidence", () => {
+  const report = runLowSignalApplyFixture({
+    number: 345,
+    reportOverrides: {
+      item_created_at: "2026-02-01T00:00:00Z",
+      item_updated_at: "2026-05-01T00:00:00Z",
+      reviewed_at: "2026-05-01T00:00:00Z",
+      pull_head_sha: "head-sha",
+    },
+    itemCreatedAt: "2026-02-01T00:00:00Z",
+    itemUpdatedAt: "2026-05-01T00:00:00Z",
+    mergeable: false,
+    mergeableState: "dirty",
+    headActivityAt: null,
+  });
+
+  assert.match(
+    report.find((entry) => entry.action === "kept_open")?.reason ?? "",
+    /requires dated activity evidence for the current head/,
+  );
+});
+
+test("stale F promotion ignores recent pre-review author reviews", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const number = 344;
+    const headSha = "3443443443443443443443443443443443443443";
+    const now = Date.now();
+    const createdAt = new Date(now - 45 * 24 * 60 * 60 * 1000).toISOString();
+    const authorActivityAt = new Date(now - 4.5 * 60 * 60 * 1000).toISOString();
+    const oldHeadActivityAt = new Date(now - 44 * 24 * 60 * 60 * 1000).toISOString();
+    const reviewedAt = new Date(now - 4 * 60 * 60 * 1000).toISOString();
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const sourceReport = stalePullRequestReport({
+      number,
+      title: "Recent contributor activity before review",
+      author: "reporter",
+      item_created_at: createdAt,
+      item_updated_at: reviewedAt,
+      reviewed_at: reviewedAt,
+      pull_head_sha: headSha,
+    });
+    const synced = reportWithSyncedReviewComment(sourceReport, number, "none");
+    writeFileSync(join(itemsDir, `${number}.md`), synced.report, "utf8");
+
+    withMockGh(
+      root,
+      promotionGhMock({
+        number,
+        title: "Recent contributor activity before review",
+        comment: synced.comment,
+        itemCreatedAt: createdAt,
+        itemUpdatedAt: reviewedAt,
+        headSha,
+        headActivityAt: oldHeadActivityAt,
+        mergeable: false,
+        mergeableState: "dirty",
+        comments: [
+          {
+            id: 9344,
+            created_at: reviewedAt,
+            updated_at: reviewedAt,
+            user: { login: "clawsweeper[bot]" },
+            body: synced.comment,
+          },
+        ],
+        reviews: [
+          {
+            id: 9345,
+            submitted_at: authorActivityAt,
+            user: { login: "reporter" },
+            state: "COMMENTED",
+          },
+        ],
+      }),
+      () => {
+        runApplyDecisionsForTest({
+          targetRepo: "openclaw/openclaw",
+          itemsDir,
+          closedDir,
+          plansDir,
+          reportPath,
+          extraArgs: [
+            "--dry-run",
+            "--apply-kind",
+            "all",
+            "--apply-close-reasons",
+            "low_signal_unmergeable_pr",
+            "--stale-min-age-days",
+            "30",
+            "--item-numbers",
+            String(number),
+          ],
+        });
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+      action: string;
+      reason: string;
+    }>;
+    assert.equal(
+      report.some((entry) => entry.action === "closed"),
+      false,
+    );
+    assert.match(readFileSync(join(itemsDir, `${number}.md`), "utf8"), /^close_reason: none$/m);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -446,7 +446,13 @@ export function promotionGhMock(options: {
   commentsAfterFirstRead?: unknown[];
   commentsAfterCommentWrite?: unknown[];
   reviews?: unknown[];
+  pullReviewComments?: unknown[];
   timeline?: unknown[];
+  mergeable?: boolean | null;
+  mergeableState?: string | null;
+  headActivityAt?: string | null;
+  headRunPullRequests?: unknown[];
+  authorLogin?: string;
   linkedPulls?: Record<number, unknown>;
   linkedPullsAfterProof?: Record<number, unknown>;
   linkedPullsAfterCommentRead?: Record<number, unknown>;
@@ -485,6 +491,7 @@ export function promotionGhMock(options: {
 	const commentsAfterFirstRead = ${JSON.stringify(options.commentsAfterFirstRead ?? null)};
 	const commentsAfterCommentWrite = ${JSON.stringify(options.commentsAfterCommentWrite ?? null)};
 	const reviews = ${JSON.stringify(options.reviews ?? [])};
+	const pullReviewComments = ${JSON.stringify(options.pullReviewComments ?? [])};
 	const timeline = ${JSON.stringify(timeline)};
 	const linkedPulls = ${JSON.stringify(linkedPulls)};
 	const linkedPullsAfterProof = ${JSON.stringify(options.linkedPullsAfterProof ?? {})};
@@ -532,6 +539,12 @@ export function promotionGhMock(options: {
 		const itemCreatedAt = ${JSON.stringify(itemCreatedAt)};
 		const itemUpdatedAt = ${JSON.stringify(itemUpdatedAt)};
 		const changedFiles = ${options.changedFiles ?? 2};
+		const mergeable = ${JSON.stringify(options.mergeable ?? false)};
+		const mergeableState = ${JSON.stringify(options.mergeableState ?? "dirty")};
+		const headActivityAt = ${JSON.stringify(
+      options.headActivityAt === undefined ? "2026-02-01T01:00:00Z" : options.headActivityAt,
+    )};
+		const authorLogin = ${JSON.stringify(options.authorLogin ?? "reporter")};
 		const sourceFiles = ${JSON.stringify(
       (options.sourceFiles ?? ["src/runtime.ts", "test/runtime.test.ts"]).map((filename) => ({
         filename,
@@ -610,7 +623,7 @@ export function promotionGhMock(options: {
     locked: false,
     active_lock_reason: null,
     author_association: "CONTRIBUTOR",
-    user: { login: "reporter" },
+    user: { login: authorLogin },
     labels,
     comments: issueCommentCount,
     pull_request: { url: "https://api.github.com/repos/openclaw/openclaw/pulls/" + number }
@@ -621,14 +634,29 @@ export function promotionGhMock(options: {
     title,
     html_url: "https://github.com/openclaw/openclaw/pull/" + number,
     state: "open",
+    created_at: itemCreatedAt,
+    mergeable,
+    mergeable_state: mergeableState,
     changed_files: changedFiles,
     commits: 1,
     review_comments: 0,
     body: "Stale PR body.",
-    head: { sha: ${JSON.stringify(options.headSha ?? "head-sha")}, ref: "branch", repo: { full_name: "fork/openclaw" } },
+    requested_reviewers: [],
+    requested_teams: [],
+    head: { sha: ${JSON.stringify(options.headSha ?? "head-sha")}, ref: "branch", repo: { id: 123, full_name: "fork/openclaw" } },
     base: { sha: "base-sha", ref: "main", repo: { full_name: "openclaw/openclaw" } },
-    user: { login: "reporter" }
+    user: { login: authorLogin }
   }));
+	} else if (args[0] === "api" && /\\/actions\\/runs\\?/.test(path)) {
+	  console.log(JSON.stringify({
+	    workflow_runs: headActivityAt ? [{
+	      event: "pull_request",
+	      created_at: headActivityAt,
+	      head_branch: "branch",
+	      head_repository: { id: 123, full_name: "fork/openclaw" },
+	      pull_requests: ${JSON.stringify(options.headRunPullRequests ?? [{ number: options.number }])}
+	    }] : []
+	  }));
 	} else if (args[0] === "api" && /\\/pulls\\/(\\d+)$/.test(path)) {
 	  const linkedNumber = Number((path.match(/\\/pulls\\/(\\d+)$/) || [])[1]);
 	  if (proofHasRun() && linkedPullHangAfterProof) {
@@ -695,7 +723,9 @@ export function promotionGhMock(options: {
   } else {
     console.log(JSON.stringify([files]));
   }
-} else if (args[0] === "api" && new RegExp("/pulls/" + number + "/(files|commits|comments)(?:\\\\?|$)").test(path)) {
+} else if (args[0] === "api" && new RegExp("/pulls/" + number + "/comments(?:\\\\?|$)").test(path)) {
+  console.log(JSON.stringify(slurp ? [pullReviewComments] : pullReviewComments));
+} else if (args[0] === "api" && new RegExp("/pulls/" + number + "/(files|commits)(?:\\\\?|$)").test(path)) {
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "pr" && args[1] === "close" && args[2] === String(number)) {
   if (closeCommandDelayMs > 0) setTimeout(() => console.log(""), closeCommandDelayMs);

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -2083,9 +2083,9 @@ test("trusted close gates block protected labels, source drift, and unsupported 
         originalProductDirectionPolicy;
     }
   }
-  assert.equal(
+  assert.match(
     trustedCloseBlockReason({ ...base, closeReason: "low_signal_unmergeable_pr" }),
-    null,
+    /require apply-decisions live conflict and author-activity proof/,
   );
   assert.match(
     trustedCloseBlockReason({


### PR DESCRIPTION
## Summary

- require a live `mergeable=false` / `mergeable_state=dirty` conflict before applying `low_signal_unmergeable_pr`
- require dated current-head evidence and at least the configured stale interval without contributor comments, reviews, inline comments, or head activity
- fail closed during stale F-rated promotion and route trusted low-signal close markers through the authoritative apply path
- leave duplicate, superseded, and implemented-on-main close reasons unchanged

## Why

OpenClaw PRs #91271 and #91280 were closed as low-signal even though both were `MERGEABLE` / `UNSTABLE` and their contributor had commented and force-pushed roughly 4.5 hours earlier. The old final guard checked maintainer signals but did not verify the claimed conflict or contributor activity.

## Validation

- `pnpm test` — 1454 passed
- `pnpm run build:all`
- `pnpm run lint`
- `pnpm run format:check`
- focused promotion/router suite — 134 passed
- GPT-5.6 Sol High structured review — clean
