### PR TITLE
test: support CRLF workflow assertions

### DIFF
--- a/test/failed-review-retry.test.ts
+++ b/test/failed-review-retry.test.ts
@@ -740,7 +740,10 @@ test("sweep workflow forwards source revision and bounds drift requeue", () => {
 
   assert.match(workflow, /EXPECTED_SOURCE_REVISION:.*client_payload\.expected_source_revision/);
   assert.match(workflow, /--expected-source-revision "\$EXPECTED_SOURCE_REVISION"/);
-  assert.match(workflow, /requeue-source-revision-drift:\r?\n\s+name: Requeue source-revision drift/);
+  assert.match(
+    workflow,
+    /requeue-source-revision-drift:\r?\n\s+name: Requeue source-revision drift/,
+  );
   assert.match(workflow, /name: review-source-revision-mismatch-\$\{\{ matrix\.shard \}\}/);
   assert.match(workflow, /requeue-source-revision-drift:[\s\S]*?contents: write/);
   assert.match(workflow, /review:[\s\S]*?permissions:\r?\n\s+contents: read/);

--- a/test/failed-review-retry.test.ts
+++ b/test/failed-review-retry.test.ts
@@ -740,10 +740,10 @@ test("sweep workflow forwards source revision and bounds drift requeue", () => {
 
   assert.match(workflow, /EXPECTED_SOURCE_REVISION:.*client_payload\.expected_source_revision/);
   assert.match(workflow, /--expected-source-revision "\$EXPECTED_SOURCE_REVISION"/);
-  assert.match(workflow, /requeue-source-revision-drift:\n\s+name: Requeue source-revision drift/);
+  assert.match(workflow, /requeue-source-revision-drift:\r?\n\s+name: Requeue source-revision drift/);
   assert.match(workflow, /name: review-source-revision-mismatch-\$\{\{ matrix\.shard \}\}/);
   assert.match(workflow, /requeue-source-revision-drift:[\s\S]*?contents: write/);
-  assert.match(workflow, /review:[\s\S]*?permissions:\n\s+contents: read/);
+  assert.match(workflow, /review:[\s\S]*?permissions:\r?\n\s+contents: read/);
   assert.match(workflow, /\[ "\$REQUEUE_COUNT" -ge 1 \]/);
   assert.match(workflow, /expected_source_revision: \$expected_source_revision/);
   assert.match(workflow, /source_revision_requeue_count: "1"/);


### PR DESCRIPTION
## Summary

Make the failed-review retry workflow-content test portable across LF and CRLF checkouts.

## Problem

PR #445 added assertions that read `.github/workflows/sweep.yml` and required LF-only newlines. With `core.autocrlf=true` on Windows, Git checks out that unchanged workflow with CRLF line endings, so `sweep workflow forwards source revision and bounds drift requeue` failed even though the job exists and is correctly configured.

## Implementation

- Allow either `LF` or `CRLF` in the two newline-sensitive workflow assertions.
- Preserve the asserted job names and permission structure.
- Format the long updated assertion with the repository formatter.
- Do not modify `.github/workflows/sweep.yml` or runtime code.

## Validation

- `node --test test/failed-review-retry.test.ts` — passed: 16/16 on a checkout with `core.autocrlf=true`; `sweep.yml` contained 3,287 CRLF lines.
- `pnpm exec oxfmt --check test/failed-review-retry.test.ts` — passed.
- `pnpm run build` — passed.
- `pnpm run lint:scripts` — passed.
- `git diff --check` — passed.
- `pnpm run test:unit` — 765 passed, 11 failed, 1 skipped. The 11 failures are pre-existing Windows-host noise from the unavailable WSL `/bin/bash` (plus dependent local-range fixtures). The same failures reproduce from the clean `origin/main` checkout; on that checkout the original LF-only failed-review assertion also fails.

## Proof

Before this change, the focused test reproduced as 15 passed and 1 failed, with the failure at the LF-only `requeue-source-revision-drift` assertion. After this change, the same CRLF checkout passes all 16 tests. The production requeue workflow was already present and correct; this PR changes test portability only.

The CI follow-up was formatting-only: CI ran 1,449 tests with 0 failures, then reported this test file as needing formatting. Commit `b487cccd6df23b42fc58d6bd78a86e37ae823e04` applies the formatter's line wrap without changing the regex or behavior.

## Codex review closeout

- Initial command: `codex review --base origin/main` — clean; no accepted or rejected findings.
- Follow-up dirty command: `codex review --uncommitted` — clean; no accepted or rejected findings.
- Follow-up branch command: `codex review --base origin/main` — clean; no accepted or rejected findings.
- Proof rerun: focused test passed 16/16 after the formatting commit.
- Final result: clean.

## Risks and rollout

Low risk: test-only regex widening from `\n` to `\r?\n`, followed by formatting-only wrapping. It still requires the same adjacent workflow structure and does not change production behavior. No release note is needed.

## Links

- Regression introduced by #445.
