### PR TITLE
fix: guard low-signal close comments at write boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
-- Required a live `DIRTY` merge conflict and at least 30 days without contributor comments or head activity before closing low-signal pull requests, honoring longer configured stale thresholds and applying the same fail-closed policy to stale-review promotion and trusted close routing.
+- Required a live `DIRTY` merge conflict and at least 30 days without contributor comments or head activity before publishing or applying low-signal pull-request close verdicts, honoring longer configured stale thresholds and applying the same fail-closed policy to stale-review promotion and trusted close routing.
 - Retried successful GitHub CLI JSON-lines responses when their output is truncated, preventing transient list-page corruption from aborting close-apply runs.
 - Allowed conflict-free canonical PRs that only need a base update to back duplicate or superseded closures while retaining proof, review, check, draft, and conflict guards.
 - Bounded broad reconciliation with batched Git I/O and tuple checkpoints that report progress and resume safely under concurrent state writers.

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -21075,6 +21075,18 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
         continue;
       }
     }
+    if (state === "open" && isCloseProposal && closeReason === "low_signal_unmergeable_pr") {
+      // Reject stale low-signal verdicts before they can become durable public comments. The
+      // final close gate repeats this live check to catch activity arriving after comment sync.
+      const lowSignalBlockReason = lowSignalUnmergeablePrApplyBlockReasonSafe(
+        number,
+        staleMinAgeDays,
+      );
+      if (lowSignalBlockReason) {
+        if (markApplySkipped("kept_open", lowSignalBlockReason)) break;
+        continue;
+      }
+    }
     existingReviewComment ??= issueReviewComment(number, [
       renderReviewCommentFromReport(markdown, closeReason ?? "none", { previousLabels }),
       reviewSectionValue(markdown, "closeComment"),
@@ -21936,6 +21948,14 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
             processedCount += 1;
             maybeLogProgress(`skipped stale review comment sync #${number}`);
             if (processedCount >= processedLimit) break;
+            continue;
+          }
+          const lowSignalCommentSyncBlockReason =
+            closeReason === "low_signal_unmergeable_pr"
+              ? lowSignalUnmergeablePrApplyBlockReasonSafe(number, staleMinAgeDays)
+              : null;
+          if (lowSignalCommentSyncBlockReason) {
+            if (markApplySkipped("kept_open", lowSignalCommentSyncBlockReason)) break;
             continue;
           }
           try {

--- a/test/apply-pr-promotion.test.ts
+++ b/test/apply-pr-promotion.test.ts
@@ -612,6 +612,101 @@ test("apply-decisions keeps MERGEABLE UNSTABLE low-signal proposals open", () =>
   );
 });
 
+test("apply-decisions rechecks low-signal liveness before writing an unsynced close comment", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const number = 371;
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const commentWriteLogPath = join(root, "comment-writes.log");
+    const authorActivityAt = new Date().toISOString();
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const sourceReport = lowSignalCloseReport({
+      number,
+      title: "Unsynced low-signal close guard fixture",
+      item_created_at: "2026-02-01T00:00:00Z",
+      item_updated_at: "2026-05-01T00:00:00Z",
+      reviewed_at: "2026-05-01T00:00:00Z",
+      pull_head_sha: "head-sha",
+    });
+    const rendered = reportWithSyncedReviewComment(
+      sourceReport,
+      number,
+      "low_signal_unmergeable_pr",
+    );
+    writeFileSync(join(itemsDir, `${number}.md`), sourceReport, "utf8");
+
+    withMockGh(
+      root,
+      promotionGhMock({
+        number,
+        title: "Unsynced low-signal close guard fixture",
+        comment: rendered.comment,
+        commentWriteLogPath,
+        comments: [],
+        commentsAfterFirstRead: [
+          {
+            id: 9371,
+            created_at: authorActivityAt,
+            updated_at: authorActivityAt,
+            user: { login: "reporter" },
+            body: "I am still working on this PR.",
+          },
+        ],
+        itemCreatedAt: "2026-02-01T00:00:00Z",
+        itemUpdatedAt: "2026-05-01T00:00:00Z",
+        mergeable: false,
+        mergeableState: "dirty",
+        headActivityAt: "2026-02-01T01:00:00Z",
+      }),
+      () => {
+        runApplyDecisionsForTest({
+          targetRepo: "openclaw/openclaw",
+          itemsDir,
+          closedDir,
+          plansDir,
+          reportPath,
+          extraArgs: [
+            "--apply-close-reasons",
+            "duplicate_or_superseded",
+            "--stale-min-age-days",
+            "30",
+            "--processed-limit",
+            "1",
+            "--item-numbers",
+            String(number),
+          ],
+        });
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+      number: number;
+      action: string;
+      reason: string;
+    }>;
+    assert.deepEqual(report, [
+      {
+        number,
+        action: "kept_open",
+        reason:
+          "low_signal_unmergeable_pr requires 30 days without author comments or head activity",
+      },
+    ]);
+    assert.equal(existsSync(commentWriteLogPath), false);
+    assert.equal(existsSync(join(root, `comment-state-${number}.json`)), false);
+    assert.match(
+      readFileSync(join(itemsDir, `${number}.md`), "utf8"),
+      /^action_taken: kept_open$/m,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("apply-decisions keeps recently updated DIRTY low-signal proposals open", () => {
   const number = 342;
   const headSha = "3423423423423423423423423423423423423423";


### PR DESCRIPTION
## Summary

- validate low-signal PR liveness before any durable close-verdict comment can be synchronized
- repeat the live check at the comment mutation boundary and retain the final close-time recheck
- make pre-publication safety independent of apply-kind and close-reason filters
- cover contributor activity arriving between the initial read and the comment write

## Validation

- `pnpm run build:all`
- `node --test test/apply-pr-promotion.test.ts` (20 passed)
- `pnpm run lint:src`
- `pnpm run lint:scripts`
- `pnpm run format:check`
- GPT-5.6 Sol high autoreview: clean, patch correct (0.93)

Follow-up to #482 and its review finding about comment-sync ordering.
