### PR TITLE
fix: report truthful apply-ready metrics

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2826,6 +2826,7 @@ jobs:
           apply_cursor_path="results/apply-cursors/${target_slug}.json"
           next_cursor=""
           apply_ready_count=""
+          candidate_counts_json=""
           cursor_advance_count=""
           coverage_proof_item_numbers=""
           if [ "$sync_open_pr_batch" = "true" ]; then
@@ -2894,32 +2895,15 @@ jobs:
             echo "Selected cursor-based comment sync batch: $item_numbers"
           fi
           if [ "$sync_comments_only" != "true" ] && [ -z "$item_numbers" ]; then
-            item_numbers="$(pnpm run --silent workflow -- proposed-item-numbers \
-              --target-repo "$TARGET_REPO" \
-              --apply-kind "$apply_kind" \
-              --apply-close-reasons "$apply_close_reasons" \
-              --stale-min-age-days "$stale_min_age_days" \
-              --min-age-days "$min_age_days" \
-              --min-age-minutes "$min_age_minutes" \
-              --batch-size "$close_processed_limit" \
-              --close-limit "$((limit < checkpoint_size ? limit : checkpoint_size))" \
-              --coverage-proof-limit "$coverage_proof_limit" \
-              --cursor-path "$apply_cursor_path")"
+            auto_selected_apply_batch=true
+            select_apply_candidate_inventory
             if [ -n "$item_numbers" ]; then
-              auto_selected_apply_batch=true
               select_bounded_coverage_proof_tail
               proposed_count="$(pnpm run --silent workflow -- count-csv --items "$item_numbers")"
-              apply_ready_count="$(pnpm run --silent workflow -- proposed-item-count \
-                --target-repo "$TARGET_REPO" \
-                --apply-kind "$apply_kind" \
-                --apply-close-reasons "$apply_close_reasons" \
-                --stale-min-age-days "$stale_min_age_days" \
-                --min-age-days "$min_age_days" \
-                --min-age-minutes "$min_age_minutes")"
               if [ "$proposed_count" -lt "$limit" ]; then
                 limit="$proposed_count"
               fi
-              echo "Selected $proposed_count from $close_processed_limit ($adaptive_apply_scan_reason); proof $coverage_proof_count/$coverage_proof_limit: $item_numbers; ready: ${apply_ready_count:-unknown}"
+              echo "Selected $proposed_count from $close_processed_limit ($adaptive_apply_scan_reason); proof $coverage_proof_count/$coverage_proof_limit: $item_numbers; currently eligible: ${apply_ready_count:-unknown}; inventory: ${candidate_counts_json:-unknown}"
             fi
           fi
           item_numbers_arg=()
@@ -2928,29 +2912,7 @@ jobs:
           fi
           select_automatic_apply_runtime
           if [ "$sync_comments_only" != "true" ] && [ -z "$item_numbers" ]; then
-            echo "No unchanged high-confidence close proposals are awaiting apply. Scheduled apply wakes every 15 minutes and exits without scanning unrelated keep-open records when there is no close work."
-            pnpm run status -- \
-              --target-repo "$TARGET_REPO" \
-              --state "Apply idle" \
-              --detail "No unchanged high-confidence close proposals are awaiting apply.$candidate_quality_detail Scheduled apply wakes every 15 minutes and exits without scanning unrelated keep-open records when there is no close work." \
-              --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            publish_status "chore: update idle sweep apply status"
-            {
-              echo "APPLY_CLOSED_TOTAL=0"
-              echo "APPLY_LIMIT=1"
-              echo "APPLY_MIN_AGE_DAYS=$min_age_days"
-              echo "APPLY_MIN_AGE_MINUTES=$min_age_minutes"
-              echo "APPLY_KIND=$apply_kind"
-              echo "APPLY_CLOSE_REASONS=$apply_close_reasons"
-              echo "APPLY_STALE_MIN_AGE_DAYS=$stale_min_age_days"
-              echo "APPLY_CLOSE_DELAY_MS=$close_delay_ms"
-              echo "APPLY_PROGRESS_EVERY=$progress_every"
-              echo "APPLY_CHECKPOINT_SIZE=$checkpoint_size"
-              echo "APPLY_ITEM_NUMBERS="
-              echo "APPLY_SYNC_COMMENTS_ONLY=false"
-              echo "APPLY_COMMENT_SYNC_MIN_AGE_DAYS=$comment_sync_min_age_days"
-              echo "APPLY_NOOP=true"
-            } >> "$GITHUB_ENV"
+            publish_automatic_apply_idle
             exit 0
           fi
           pnpm run status -- \
@@ -3070,11 +3032,14 @@ jobs:
             fi
             examined_count="$(apply_checkpoint_examined_count)"
             publish_changes "chore: apply sweep decisions checkpoint $checkpoint" "${apply_publish_paths[@]}"
+            if [ "$auto_selected_apply_batch" = "true" ]; then
+              select_apply_candidate_inventory false
+            fi
             close_health_cursor_path=""
             if [ "$auto_selected_apply_batch" = "true" ]; then
               close_health_cursor_path="$apply_cursor_path"
             fi
-            write_apply_health ".artifacts/apply-reports/apply-report-$checkpoint.json" ".artifacts/apply-health-$checkpoint.json" "close" "$close_processed_limit" "$close_health_cursor_path" "$auto_selected_apply_batch" "$apply_ready_count" "15" "$cursor_advance_count"
+            write_apply_health ".artifacts/apply-reports/apply-report-$checkpoint.json" ".artifacts/apply-health-$checkpoint.json" "close" "$close_processed_limit" "$close_health_cursor_path" "$auto_selected_apply_batch" "$apply_ready_count" "15" "$cursor_advance_count" "$candidate_counts_json"
             pnpm run status -- \
               --target-repo "$TARGET_REPO" \
               --state "Apply in progress" \
@@ -3114,11 +3079,13 @@ jobs:
           final_health_candidate_count=""
           final_health_scheduled_interval_minutes=""
           final_health_cursor_advance_count=""
+          final_health_candidate_counts_json=""
           if [ "$auto_selected_apply_batch" = "true" ]; then
             final_health_cursor_path="$apply_cursor_path"
             final_health_candidate_count="$apply_ready_count"
             final_health_scheduled_interval_minutes="15"
             final_health_cursor_advance_count="$cursor_advance_count"
+            final_health_candidate_counts_json="$candidate_counts_json"
           fi
           if [ "$sync_comments_only" = "true" ]; then
             final_health_mode="comment_sync"
@@ -3127,13 +3094,14 @@ jobs:
             final_health_candidate_count=""
             final_health_scheduled_interval_minutes=""
             final_health_cursor_advance_count=""
+            final_health_candidate_counts_json=""
             if [ "$sync_open_pr_batch" = "true" ]; then
               final_health_cursor_path="$cursor_path"
               final_health_cursor_required="true"
               final_health_processed_limit="$sync_batch_size"
             fi
           fi
-          write_apply_health "apply-report.json" ".artifacts/apply-health-final.json" "$final_health_mode" "$final_health_processed_limit" "$final_health_cursor_path" "$final_health_cursor_required" "$final_health_candidate_count" "$final_health_scheduled_interval_minutes" "$final_health_cursor_advance_count"
+          write_apply_health "apply-report.json" ".artifacts/apply-health-final.json" "$final_health_mode" "$final_health_processed_limit" "$final_health_cursor_path" "$final_health_cursor_required" "$final_health_candidate_count" "$final_health_scheduled_interval_minutes" "$final_health_cursor_advance_count" "$final_health_candidate_counts_json"
           pnpm run status -- \
             --target-repo "$TARGET_REPO" \
             --state "Apply finished" \

--- a/README.md
+++ b/README.md
@@ -393,7 +393,9 @@ still valid.
 
 - Updates the single marker-backed Codex automated review comment in place.
 - Closes only unchanged high-confidence proposals.
-- Reuses the review comment when closing; no duplicate close comment.
+- Keeps the durable review comment. Applied PR closes also post one idempotent,
+  marker-backed close receipt; issue closes currently leave the durable review
+  as ClawSweeper's sole comment.
 - Moves closed or already-closed reports to
   `records/<repo-slug>/closed/<number>.md`.
 - Moves reopened archived reports back to the repo’s `items/` folder as stale.
@@ -408,6 +410,12 @@ token within its lifetime. After a checkpoint closes at least one item, it
 queues another apply run with a fresh token; a saturated scan that closes
 nothing stops and waits for the next scheduled tick instead of self-dispatching
 indefinitely.
+
+Apply health keeps the scheduler-admitted `apply_ready_count` separate from the
+full promotion backlog, cooldown-eligible probes, proof-required work, guarded
+retries, and inconsistent records. Its cycle estimate covers work actionable in
+the current scheduler window rather than presenting every probe as immediately
+closable.
 
 Exact event runs skip the bulk planner, shard matrix, artifact upload, and
 separate publish job. They still use the same review and apply code paths, but

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -4467,6 +4467,7 @@ function applyHealthCycle(value) {
   return {
     basis: nullableString(source.basis),
     apply_ready_count: optionalNumber(source.apply_ready_count),
+    candidate_counts: applyHealthCandidateCounts(source.candidate_counts),
     window_size: optionalNumber(source.window_size),
     estimated_full_cycle_windows: optionalNumber(source.estimated_full_cycle_windows),
     estimated_full_cycle_minutes: optionalNumber(source.estimated_full_cycle_minutes),
@@ -4479,12 +4480,28 @@ function emptyApplyHealthCycle() {
   return {
     basis: null,
     apply_ready_count: null,
+    candidate_counts: null,
     window_size: null,
     estimated_full_cycle_windows: null,
     estimated_full_cycle_minutes: null,
     scheduled_interval_minutes: null,
     label: null,
   };
+}
+function applyHealthCandidateCounts(value) {
+  const source = objectValue(value);
+  const keys = [
+    "confirmed_proposal",
+    "guarded_retry",
+    "proof_required",
+    "promotion_total",
+    "promotion_eligible",
+    "promotion_cooldown_eligible",
+    "cooldown_eligible_total",
+    "inconsistent_or_stale",
+  ];
+  if (!keys.some((key) => Number.isFinite(Number(source[key])))) return null;
+  return Object.fromEntries(keys.map((key) => [key, numberOrNull(source[key]) || 0]));
 }
 function latestIso(values) {
   const timestamps = values
@@ -7953,12 +7970,13 @@ function renderApplyHealth(data) {
     const closureSynced = Number.isFinite(item.lanes?.closure?.comment_synced) ? fmt.format(item.lanes.closure.comment_synced) : "0";
     const syncLaneSynced = Number.isFinite(item.lanes?.comment_sync?.comment_synced) ? fmt.format(item.lanes.comment_sync.comment_synced) : "0";
     const cycle = applyHealthCyclePill(item.cycle);
+    const candidateMix = applyHealthCandidateMixPill(item.cycle);
     return '<div class="apply-health-alert" role="status" title="' + esc(topInfo.summary + " Next: " + topInfo.action) + '">' +
       '<div class="apply-health-heading"><strong>Pruning sweep ' + esc(applyHealthStatusLabel(item.status)) + " - " + esc(item.target_repo || "target repo") + '</strong><span class="pill" title="' + esc("Latest " + applyHealthModeLabel(item.mode) + " status from the sweep-status marker.") + '">' + esc(applyHealthModeLabel(item.mode)) + '</span></div>' +
       '<p>' + esc(applyHealthOperatorSummary(item, topInfo)) + '</p>' +
       '<p class="apply-health-next"><strong>Next check:</strong> ' + esc(topInfo.action) + '</p>' +
       applyHealthActionHtml(action) +
-      '<div class="apply-health-meta"><span class="pill" title="' + esc(activityTitle) + '">' + esc(activityLabel) + '</span><span class="pill" title="' + esc("Closure lane: " + closureProcessed + " action records; " + closed + " closed.") + '">' + esc(closed) + ' closed</span><span class="pill" title="' + esc("Durable review comments refreshed across lanes: " + synced + ". Closure lane refreshed " + closureSynced + "; comment-sync lane refreshed " + syncLaneSynced + " from " + syncProcessed + " action records.") + '">' + esc(synced) + ' comments synced</span>' + cycle + cursorPill + reasons + buckets + linkClass(item.run_url, "workflow run", "pill run-link") + '</div></div>';
+      '<div class="apply-health-meta"><span class="pill" title="' + esc(activityTitle) + '">' + esc(activityLabel) + '</span><span class="pill" title="' + esc("Closure lane: " + closureProcessed + " action records; " + closed + " closed.") + '">' + esc(closed) + ' closed</span><span class="pill" title="' + esc("Durable review comments refreshed across lanes: " + synced + ". Closure lane refreshed " + closureSynced + "; comment-sync lane refreshed " + syncLaneSynced + " from " + syncProcessed + " action records.") + '">' + esc(synced) + ' comments synced</span>' + cycle + candidateMix + cursorPill + reasons + buckets + linkClass(item.run_url, "workflow run", "pill run-link") + '</div></div>';
   }).join("");
 }
 function applyHealthCyclePill(cycle) {
@@ -7968,6 +7986,21 @@ function applyHealthCyclePill(cycle) {
     ? "revisit ~" + fmt.format(windows) + " window" + (windows === 1 ? "" : "s")
     : "revisit estimate";
   return '<span class="pill" title="' + esc(cycle.label || "Estimated time to revisit the current apply-ready close queue.") + '">' + esc(label) + '</span>';
+}
+function applyHealthCandidateMixPill(cycle) {
+  const counts = cycle?.candidate_counts;
+  if (!counts) return "";
+  const confirmed = Number(counts.confirmed_proposal) || 0;
+  const guarded = Number(counts.guarded_retry) || 0;
+  const proof = Number(counts.proof_required) || 0;
+  const promotions = Number(counts.promotion_total) || 0;
+  const eligiblePromotions = Number(counts.promotion_eligible) || 0;
+  const cooldownEligiblePromotions = Number(counts.promotion_cooldown_eligible) || 0;
+  const cooldownEligibleTotal = Number(counts.cooldown_eligible_total) || 0;
+  const inconsistent = Number(counts.inconsistent_or_stale) || 0;
+  const label = fmt.format(confirmed) + " proposals · " + fmt.format(guarded) + " retries · " + fmt.format(eligiblePromotions) + "/" + fmt.format(promotions) + " promotions admitted";
+  const title = fmt.format(confirmed) + " confirmed proposals; " + fmt.format(guarded) + " guarded retries; " + fmt.format(eligiblePromotions) + " of " + fmt.format(promotions) + " promotion probes scheduler-admitted; " + fmt.format(cooldownEligiblePromotions) + " promotion probes and " + fmt.format(cooldownEligibleTotal) + " total candidates meet cooldown rules; " + fmt.format(proof) + " admitted candidates require close proof; " + fmt.format(inconsistent) + " inconsistent or stale records excluded.";
+  return '<span class="pill" title="' + esc(title) + '">' + esc(label) + '</span>';
 }
 function applyHealthNeedsAttention(status) {
   return ["attention", "blocked", "degraded", "failed", "needs_attention", "warning"].includes(String(status || "").toLowerCase());

--- a/scripts/apply-workflow-helpers.sh
+++ b/scripts/apply-workflow-helpers.sh
@@ -152,6 +152,7 @@ write_apply_health() {
   local health_candidate_count="${7:-}"
   local health_scheduled_interval_minutes="${8:-}"
   local health_cursor_advance_count="${9:-}"
+  local health_candidate_counts_json="${10:-}"
   local health_args=(
     --target-repo "$TARGET_REPO"
     --report "$report_path"
@@ -167,6 +168,9 @@ write_apply_health() {
   fi
   if [ -n "$health_candidate_count" ]; then
     health_args+=(--candidate-count "$health_candidate_count")
+  fi
+  if [ -n "$health_candidate_counts_json" ]; then
+    health_args+=(--candidate-counts-json "$health_candidate_counts_json")
   fi
   if [ -n "$health_scheduled_interval_minutes" ]; then
     health_args+=(--scheduled-interval-minutes "$health_scheduled_interval_minutes")
@@ -224,6 +228,57 @@ select_adaptive_apply_batch() {
   cat "$adaptive_batch_env"
   close_processed_limit="$(awk -F= '$1 == "close_processed_limit" { print $2 }' "$adaptive_batch_env")"
   adaptive_apply_scan_reason="$(awk -F= '$1 == "adaptive_apply_scan_reason" { print $2 }' "$adaptive_batch_env")"
+}
+
+select_apply_candidate_inventory() {
+  local update_item_numbers="${1:-true}"
+  local candidate_inventory_env=".artifacts/apply-candidate-inventory.env"
+  pnpm run --silent workflow -- proposed-item-inventory \
+    --target-repo "$TARGET_REPO" \
+    --apply-kind "$apply_kind" \
+    --apply-close-reasons "$apply_close_reasons" \
+    --stale-min-age-days "$stale_min_age_days" \
+    --min-age-days "$min_age_days" \
+    --min-age-minutes "$min_age_minutes" \
+    --batch-size "$close_processed_limit" \
+    --close-limit "$((limit < checkpoint_size ? limit : checkpoint_size))" \
+    --coverage-proof-limit "$coverage_proof_limit" \
+    --cursor-path "$apply_cursor_path" > "$candidate_inventory_env"
+  cat "$candidate_inventory_env"
+  if [ "$update_item_numbers" = "true" ]; then
+    item_numbers="$(awk -F= '$1 == "item_numbers" { print $2 }' "$candidate_inventory_env")"
+  fi
+  apply_ready_count="$(awk -F= '$1 == "apply_ready_count" { print $2 }' "$candidate_inventory_env")"
+  candidate_counts_json="$(awk -F= '$1 == "candidate_counts_json" { sub(/^[^=]*=/, ""); print }' "$candidate_inventory_env")"
+}
+
+publish_automatic_apply_idle() {
+  echo "No unchanged high-confidence close proposals are awaiting apply. Scheduled apply wakes every 15 minutes and exits without scanning unrelated keep-open records when there is no close work."
+  printf '[]\n' > .artifacts/apply-reports/apply-report-idle.json
+  write_apply_health ".artifacts/apply-reports/apply-report-idle.json" ".artifacts/apply-health-idle.json" "close" "$close_processed_limit" "$apply_cursor_path" "true" "$apply_ready_count" "15" "0" "$candidate_counts_json"
+  pnpm run status -- \
+    --target-repo "$TARGET_REPO" \
+    --state "Apply idle" \
+    --detail "No unchanged high-confidence close proposals are awaiting apply.$candidate_quality_detail Scheduled apply wakes every 15 minutes and exits without scanning unrelated keep-open records when there is no close work." \
+    --run-url "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+    --apply-health-file ".artifacts/apply-health-idle.json"
+  publish_status "chore: update idle sweep apply status"
+  {
+    echo "APPLY_CLOSED_TOTAL=0"
+    echo "APPLY_LIMIT=1"
+    echo "APPLY_MIN_AGE_DAYS=$min_age_days"
+    echo "APPLY_MIN_AGE_MINUTES=$min_age_minutes"
+    echo "APPLY_KIND=$apply_kind"
+    echo "APPLY_CLOSE_REASONS=$apply_close_reasons"
+    echo "APPLY_STALE_MIN_AGE_DAYS=$stale_min_age_days"
+    echo "APPLY_CLOSE_DELAY_MS=$close_delay_ms"
+    echo "APPLY_PROGRESS_EVERY=$progress_every"
+    echo "APPLY_CHECKPOINT_SIZE=$checkpoint_size"
+    echo "APPLY_ITEM_NUMBERS="
+    echo "APPLY_SYNC_COMMENTS_ONLY=false"
+    echo "APPLY_COMMENT_SYNC_MIN_AGE_DAYS=$comment_sync_min_age_days"
+    echo "APPLY_NOOP=true"
+  } >> "$GITHUB_ENV"
 }
 
 select_bounded_coverage_proof_tail() {

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -33,8 +33,24 @@ type ApplyReportSummaryOptions = {
   cursorPath: string;
   cursorRequired: boolean;
   candidateCount?: number | null;
+  candidateCounts?: ApplyCandidateCounts | null;
   cursorAdvanceCount?: number | null;
   scheduledIntervalMinutes?: number | null;
+};
+
+export type ApplyCandidateCounts = {
+  confirmed_proposal: number;
+  guarded_retry: number;
+  proof_required: number;
+  promotion_total: number;
+  promotion_eligible: number;
+  promotion_cooldown_eligible: number;
+  cooldown_eligible_total: number;
+  inconsistent_or_stale: number;
+};
+
+export type ProposedItemInventory = ApplyCandidateCounts & {
+  eligible_total: number;
 };
 
 type ApplyReportSummary = {
@@ -109,6 +125,7 @@ type ApplyCycleSummary = {
     | "missing_window_size"
     | "no_apply_ready_candidates";
   apply_ready_count: number | null;
+  candidate_counts: ApplyCandidateCounts | null;
   window_size: number | null;
   estimated_full_cycle_windows: number | null;
   estimated_full_cycle_minutes: number | null;
@@ -197,6 +214,7 @@ function runCli(): void {
             candidateCount: optionalString("candidate-count")
               ? nonNegativeIntegerArg("candidate-count")
               : null,
+            candidateCounts: applyCandidateCounts(optionalString("candidate-counts-json")),
             cursorAdvanceCount: optionalString("cursor-advance-count")
               ? nonNegativeIntegerArg("cursor-advance-count")
               : null,
@@ -261,6 +279,9 @@ function runCli(): void {
       break;
     case "proposed-item-count":
       process.stdout.write(String(proposedItemCount(proposedItemOptions())));
+      break;
+    case "proposed-item-inventory":
+      printProposedItemInventory(proposedItemOptions());
       break;
     case "proposed-item-quality-summary":
       printProposedItemQualitySummary(proposedItemOptions());
@@ -568,6 +589,7 @@ export function summarizeApplyReport(options: ApplyReportSummaryOptions): ApplyR
     mode: options.mode,
     cursorRequired: options.cursorRequired,
     candidateCount: options.candidateCount ?? null,
+    candidateCounts: options.candidateCounts ?? null,
     cursorAdvanceCount: options.cursorAdvanceCount ?? null,
     scheduledIntervalMinutes: options.scheduledIntervalMinutes ?? null,
   });
@@ -909,6 +931,7 @@ function applyCycleSummary(options: {
   mode: string;
   cursorRequired: boolean;
   candidateCount: number | null;
+  candidateCounts: ApplyCandidateCounts | null;
   cursorAdvanceCount: number | null;
   scheduledIntervalMinutes: number | null;
 }): ApplyCycleSummary {
@@ -923,6 +946,7 @@ function applyCycleSummary(options: {
     return {
       basis: "not_close_cursor",
       apply_ready_count: options.candidateCount,
+      candidate_counts: options.candidateCounts,
       window_size: windowSize,
       estimated_full_cycle_windows: null,
       estimated_full_cycle_minutes: null,
@@ -934,6 +958,7 @@ function applyCycleSummary(options: {
     return {
       basis: "missing_candidate_count",
       apply_ready_count: null,
+      candidate_counts: options.candidateCounts,
       window_size: windowSize,
       estimated_full_cycle_windows: null,
       estimated_full_cycle_minutes: null,
@@ -945,17 +970,19 @@ function applyCycleSummary(options: {
     return {
       basis: "no_apply_ready_candidates",
       apply_ready_count: 0,
+      candidate_counts: options.candidateCounts,
       window_size: windowSize,
       estimated_full_cycle_windows: 0,
       estimated_full_cycle_minutes: 0,
       scheduled_interval_minutes: cadence,
-      label: "No confirmed close proposals or live promotion probes are waiting in this lane.",
+      label: zeroCandidateCycleLabel(options.candidateCounts),
     };
   }
   if (!windowSize) {
     return {
       basis: "missing_window_size",
       apply_ready_count: options.candidateCount,
+      candidate_counts: options.candidateCounts,
       window_size: null,
       estimated_full_cycle_windows: null,
       estimated_full_cycle_minutes: null,
@@ -968,11 +995,19 @@ function applyCycleSummary(options: {
   return {
     basis: "scheduled_close_cursor",
     apply_ready_count: options.candidateCount,
+    candidate_counts: options.candidateCounts,
     window_size: windowSize,
     estimated_full_cycle_windows: windows,
     estimated_full_cycle_minutes: minutes,
     scheduled_interval_minutes: cadence,
-    label: cycleLabel(options.candidateCount, windowSize, windows, minutes, cadence),
+    label: cycleLabel(
+      options.candidateCount,
+      windowSize,
+      windows,
+      minutes,
+      cadence,
+      options.candidateCounts,
+    ),
   };
 }
 
@@ -982,10 +1017,37 @@ function cycleLabel(
   windows: number,
   minutes: number | null,
   cadence: number | null,
+  counts: ApplyCandidateCounts | null,
 ): string {
-  const base = `${candidateCount} close candidates (confirmed proposals plus live promotion probes) at ${windowSize} records per latest cursor advance: about ${windows} window${windows === 1 ? "" : "s"}`;
+  const base = `${candidateCount} currently actionable close candidates${candidateCountBreakdown(counts)} at ${windowSize} records per latest cursor advance: about ${windows} window${windows === 1 ? "" : "s"}`;
   if (!minutes || !cadence) return `${base}.`;
   return `${base}; scheduled cadence alone would take roughly ${durationLabel(minutes)} at ${cadence}-minute intervals, while successful windows can continue sooner.`;
+}
+
+function zeroCandidateCycleLabel(counts: ApplyCandidateCounts | null): string {
+  if (!counts) return "No currently actionable close candidates are waiting in this lane.";
+  const coolingPromotions = Math.max(
+    0,
+    counts.promotion_total - counts.promotion_cooldown_eligible,
+  );
+  const eligibleBacklog = counts.cooldown_eligible_total
+    ? ` ${counts.cooldown_eligible_total} candidate${counts.cooldown_eligible_total === 1 ? " meets" : "s meet"} cooldown rules but none were admitted by this scheduler window.`
+    : "";
+  const suffix = coolingPromotions
+    ? ` ${coolingPromotions} promotion probe${coolingPromotions === 1 ? " is" : "s are"} cooling down.`
+    : "";
+  return `No currently actionable close candidates are waiting in this lane.${eligibleBacklog}${suffix}`;
+}
+
+function candidateCountBreakdown(counts: ApplyCandidateCounts | null): string {
+  if (!counts) return "";
+  const confirmed = `${counts.confirmed_proposal} confirmed proposal${counts.confirmed_proposal === 1 ? "" : "s"}`;
+  const guarded = `${counts.guarded_retry} guarded ${counts.guarded_retry === 1 ? "retry" : "retries"}`;
+  const promotions = `${counts.promotion_eligible}/${counts.promotion_total} promotion probe${counts.promotion_total === 1 ? "" : "s"} admitted`;
+  const proof = `${counts.proof_required} ${counts.proof_required === 1 ? "requires" : "require"} proof`;
+  const inconsistent = `${counts.inconsistent_or_stale} inconsistent or stale record${counts.inconsistent_or_stale === 1 ? "" : "s"} excluded`;
+  const cooldownBacklog = `${counts.cooldown_eligible_total} cooldown-eligible backlog (${counts.promotion_cooldown_eligible} promotions)`;
+  return ` (${confirmed}, ${guarded}, ${promotions}; ${proof}; ${cooldownBacklog}; ${inconsistent})`;
 }
 
 function durationLabel(minutes: number): string {
@@ -1084,8 +1146,84 @@ export function proposedItemNumbers(options: ProposedItemOptions): number[] {
 }
 
 export function proposedItemCount(options: ProposedItemOptions): number {
-  return selectedProposedItemCandidates({ ...options, batchSize: null, cursorPath: null }, "all")
-    .length;
+  return proposedItemInventory(options).eligible_total;
+}
+
+export function proposedItemInventory(options: ProposedItemOptions): ProposedItemInventory {
+  return proposedItemInventorySelection(options).inventory;
+}
+
+function proposedItemInventorySelection(options: ProposedItemOptions): {
+  inventory: ProposedItemInventory;
+  itemNumbers: number[];
+} {
+  const nowMs = Date.now();
+  const allCandidates = selectedProposedItemCandidates(
+    { ...options, batchSize: null, cursorPath: null },
+    "all",
+  );
+  const cooldownEligibleCandidates = allCandidates.filter(
+    (candidate) =>
+      candidate.stage !== "promotion_probe" || !promotionProbeCoolingDown(candidate, nowMs),
+  );
+  const eligibleCandidates =
+    options.batchSize && options.batchSize > 0
+      ? selectedProposedItemCandidates(options, "all", allCandidates, nowMs)
+      : cooldownEligibleCandidates;
+  const candidateNumbers = new Set(allCandidates.map((candidate) => candidate.number));
+  const confirmedCandidates = eligibleCandidates.filter(
+    (candidate) => candidate.stage === "confirmed_close",
+  );
+  return {
+    itemNumbers: eligibleCandidates.map((candidate) => candidate.number),
+    inventory: {
+      eligible_total: eligibleCandidates.length,
+      confirmed_proposal: confirmedCandidates.filter(
+        (candidate) => candidate.action === "proposed_close",
+      ).length,
+      guarded_retry: confirmedCandidates.filter(
+        (candidate) => candidate.action !== "proposed_close",
+      ).length,
+      proof_required: eligibleCandidates.filter((candidate) => candidate.coverageProof).length,
+      promotion_total: allCandidates.filter((candidate) => candidate.stage === "promotion_probe")
+        .length,
+      promotion_eligible: eligibleCandidates.filter(
+        (candidate) => candidate.stage === "promotion_probe",
+      ).length,
+      promotion_cooldown_eligible: cooldownEligibleCandidates.filter(
+        (candidate) => candidate.stage === "promotion_probe",
+      ).length,
+      cooldown_eligible_total: cooldownEligibleCandidates.length,
+      inconsistent_or_stale: inconsistentOrStaleProposedItemCount(options, candidateNumbers),
+    },
+  };
+}
+
+function printProposedItemInventory(options: ProposedItemOptions): void {
+  const { inventory, itemNumbers } = proposedItemInventorySelection(options);
+  const candidateCounts: ApplyCandidateCounts = {
+    confirmed_proposal: inventory.confirmed_proposal,
+    guarded_retry: inventory.guarded_retry,
+    proof_required: inventory.proof_required,
+    promotion_total: inventory.promotion_total,
+    promotion_eligible: inventory.promotion_eligible,
+    promotion_cooldown_eligible: inventory.promotion_cooldown_eligible,
+    cooldown_eligible_total: inventory.cooldown_eligible_total,
+    inconsistent_or_stale: inventory.inconsistent_or_stale,
+  };
+  printOutput({
+    item_numbers: itemNumbers.join(","),
+    apply_ready_count: String(inventory.eligible_total),
+    confirmed_proposal: String(inventory.confirmed_proposal),
+    guarded_retry: String(inventory.guarded_retry),
+    proof_required: String(inventory.proof_required),
+    promotion_total: String(inventory.promotion_total),
+    promotion_eligible: String(inventory.promotion_eligible),
+    promotion_cooldown_eligible: String(inventory.promotion_cooldown_eligible),
+    cooldown_eligible_total: String(inventory.cooldown_eligible_total),
+    inconsistent_or_stale: String(inventory.inconsistent_or_stale),
+    candidate_counts_json: JSON.stringify(candidateCounts),
+  });
 }
 
 export function proposedPrCloseCoverageItemNumbers(options: ProposedItemOptions): number[] {
@@ -1146,6 +1284,21 @@ const FAST_CLOSE_BUCKET_ORDER: ProposedItemQualityBucket[] = [
 // Promotion probes hydrate related live graphs; a fresh review bypasses this daily backoff.
 const APPLY_PROMOTION_PROBE_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 
+const ALLOWED_CLOSE_REASONS = new Set([
+  "abandoned_pr",
+  "cannot_reproduce",
+  "clawhub",
+  "duplicate_or_superseded",
+  "incoherent",
+  "implemented_on_main",
+  "low_signal_unmergeable_pr",
+  "mostly_implemented_on_main",
+  "not_actionable_in_repo",
+  "stalled_unproven_pr",
+  "stale_insufficient_info",
+  "unconfirmed_product_direction",
+]);
+
 function prioritizeFastCloseCandidates(
   candidates: ProposedItemCandidate[],
 ): ProposedItemCandidate[] {
@@ -1164,24 +1317,12 @@ function prioritizeFastCloseCandidates(
 function selectedProposedItemCandidates(
   options: ProposedItemOptions,
   selection: ProposedItemSelection,
+  candidateSnapshot?: readonly ProposedItemCandidate[],
+  nowMs = Date.now(),
 ): ProposedItemCandidate[] {
   const itemsDir = path.join("records", targetSlug(options.targetRepo), "items");
-  if (!fs.existsSync(itemsDir)) return [];
+  if (!candidateSnapshot && !fs.existsSync(itemsDir)) return [];
 
-  const allowedReasons = new Set([
-    "abandoned_pr",
-    "cannot_reproduce",
-    "clawhub",
-    "duplicate_or_superseded",
-    "incoherent",
-    "implemented_on_main",
-    "low_signal_unmergeable_pr",
-    "mostly_implemented_on_main",
-    "not_actionable_in_repo",
-    "stalled_unproven_pr",
-    "stale_insufficient_info",
-    "unconfirmed_product_direction",
-  ]);
   const allowedCloseReasons =
     options.applyCloseReasons === "all"
       ? null
@@ -1196,84 +1337,94 @@ function selectedProposedItemCandidates(
       ? options.minAgeDays * 24 * 60 * 60 * 1000
       : options.minAgeMinutes * 60 * 1000;
 
-  const candidates: ProposedItemCandidate[] = fs
-    .readdirSync(itemsDir)
-    .filter((name) => /(?:^|[a-z0-9-]-)\d+\.md$/.test(name))
-    .flatMap((name) => {
-      const number = numberFor(name);
-      if (options.itemNumbers && !options.itemNumbers.has(number)) return [];
-      const markdown = fs.readFileSync(path.join(itemsDir, name), "utf8");
-      if (repoFor(markdown, name) !== options.targetRepo) return [];
-      const type = frontMatterValue(markdown, "type");
-      if (options.applyKind !== "all" && type && type !== options.applyKind) return [];
-      const decision = frontMatterValue(markdown, "decision");
-      const action = frontMatterValue(markdown, "action_taken");
-      const confidence = frontMatterValue(markdown, "confidence");
-      const reason = frontMatterValue(markdown, "close_reason");
-      const selectableClose =
-        decision === "close" &&
-        confidence === "high" &&
-        isSelectableCloseAction(action, reason) &&
-        allowedForTarget(options.targetRepo, type, reason, allowedReasons) &&
-        (!allowedCloseReasons || allowedCloseReasons.has(reason));
-      const promotionCloseReasons = pullRequestClosePromotionReasons(markdown, options.targetRepo, {
-        staleMinAgeMs: options.staleMinAgeDays * 24 * 60 * 60 * 1000,
-      });
-      const selectedPromotionCloseReasons = promotionCloseReasons.filter(
-        (promotionReason) =>
-          allowedForTarget(options.targetRepo, type, promotionReason, allowedReasons) &&
-          (!allowedCloseReasons || allowedCloseReasons.has(promotionReason)),
-      );
-      const selectablePromotion =
-        decision === "keep_open" &&
-        action === "kept_open" &&
-        type === "pull_request" &&
-        frontMatterValue(markdown, "review_status") === "complete" &&
-        frontMatterValue(markdown, "local_checkout_access") === "verified" &&
-        hasPullRequestClosePromotionSignal(markdown, options.targetRepo, {
-          staleMinAgeMs: options.staleMinAgeDays * 24 * 60 * 60 * 1000,
-        }) &&
-        selectedPromotionCloseReasons.length > 0;
-      const selectableProofPromotion =
-        selectablePromotion &&
-        selectedPromotionCloseReasons.includes("duplicate_or_superseded") &&
-        hasLinkedPullRequestSupersessionSignal(markdown, options.targetRepo);
-      if (!selectableClose && !selectablePromotion) return [];
-      const prCloseCoverageProofCanRun =
-        type === "pull_request" &&
-        ((selectableClose && reason === "duplicate_or_superseded") || selectableProofPromotion);
-      if (selection === "pr-close-coverage-proof" && !prCloseCoverageProofCanRun) return [];
-      if (
-        (reason === "stale_insufficient_info" || reason === "mostly_implemented_on_main") &&
-        !olderThan(
-          frontMatterValue(markdown, "item_created_at"),
-          options.staleMinAgeDays * 24 * 60 * 60 * 1000,
-        )
-      ) {
-        return [];
-      }
-      if (!olderThan(frontMatterValue(markdown, "item_created_at"), minAgeMs)) return [];
-      const candidateCloseReason = selectablePromotion ? selectedPromotionCloseReasons[0]! : reason;
-      return [
-        {
-          number,
-          applyCheckedAt: frontMatterValue(markdown, "apply_checked_at"),
-          reviewedAt: frontMatterValue(markdown, "reviewed_at"),
-          kind: type,
-          closeReason: candidateCloseReason,
-          action,
-          stage: selectablePromotion ? ("promotion_probe" as const) : ("confirmed_close" as const),
-          coverageProof: prCloseCoverageProofCanRun,
-          qualityBucket: proposedItemQualityBucket({
-            action,
-            closeReason: candidateCloseReason,
-            prCloseCoverageProofCanRun,
-            promotionProbe: selectablePromotion,
-          }),
-        },
-      ];
-    })
-    .sort((left, right) => left.number - right.number);
+  const candidates: ProposedItemCandidate[] = candidateSnapshot
+    ? [...candidateSnapshot]
+    : fs
+        .readdirSync(itemsDir)
+        .filter((name) => /(?:^|[a-z0-9-]-)\d+\.md$/.test(name))
+        .flatMap((name) => {
+          const number = numberFor(name);
+          if (options.itemNumbers && !options.itemNumbers.has(number)) return [];
+          const markdown = fs.readFileSync(path.join(itemsDir, name), "utf8");
+          if (repoFor(markdown, name) !== options.targetRepo) return [];
+          const type = frontMatterValue(markdown, "type");
+          if (options.applyKind !== "all" && type && type !== options.applyKind) return [];
+          const decision = frontMatterValue(markdown, "decision");
+          const action = frontMatterValue(markdown, "action_taken");
+          const confidence = frontMatterValue(markdown, "confidence");
+          const reason = frontMatterValue(markdown, "close_reason");
+          const selectableClose =
+            decision === "close" &&
+            confidence === "high" &&
+            isSelectableCloseAction(action, reason) &&
+            allowedForTarget(options.targetRepo, type, reason, ALLOWED_CLOSE_REASONS) &&
+            (!allowedCloseReasons || allowedCloseReasons.has(reason));
+          const promotionCloseReasons = pullRequestClosePromotionReasons(
+            markdown,
+            options.targetRepo,
+            {
+              staleMinAgeMs: options.staleMinAgeDays * 24 * 60 * 60 * 1000,
+            },
+          );
+          const selectedPromotionCloseReasons = promotionCloseReasons.filter(
+            (promotionReason) =>
+              allowedForTarget(options.targetRepo, type, promotionReason, ALLOWED_CLOSE_REASONS) &&
+              (!allowedCloseReasons || allowedCloseReasons.has(promotionReason)),
+          );
+          const selectablePromotion =
+            decision === "keep_open" &&
+            action === "kept_open" &&
+            type === "pull_request" &&
+            frontMatterValue(markdown, "review_status") === "complete" &&
+            frontMatterValue(markdown, "local_checkout_access") === "verified" &&
+            hasPullRequestClosePromotionSignal(markdown, options.targetRepo, {
+              staleMinAgeMs: options.staleMinAgeDays * 24 * 60 * 60 * 1000,
+            }) &&
+            selectedPromotionCloseReasons.length > 0;
+          const selectableProofPromotion =
+            selectablePromotion &&
+            selectedPromotionCloseReasons.includes("duplicate_or_superseded") &&
+            hasLinkedPullRequestSupersessionSignal(markdown, options.targetRepo);
+          if (!selectableClose && !selectablePromotion) return [];
+          const prCloseCoverageProofCanRun =
+            type === "pull_request" &&
+            ((selectableClose && reason === "duplicate_or_superseded") || selectableProofPromotion);
+          if (selection === "pr-close-coverage-proof" && !prCloseCoverageProofCanRun) return [];
+          if (
+            (reason === "stale_insufficient_info" || reason === "mostly_implemented_on_main") &&
+            !olderThan(
+              frontMatterValue(markdown, "item_created_at"),
+              options.staleMinAgeDays * 24 * 60 * 60 * 1000,
+            )
+          ) {
+            return [];
+          }
+          if (!olderThan(frontMatterValue(markdown, "item_created_at"), minAgeMs)) return [];
+          const candidateCloseReason = selectablePromotion
+            ? selectedPromotionCloseReasons[0]!
+            : reason;
+          return [
+            {
+              number,
+              applyCheckedAt: frontMatterValue(markdown, "apply_checked_at"),
+              reviewedAt: frontMatterValue(markdown, "reviewed_at"),
+              kind: type,
+              closeReason: candidateCloseReason,
+              action,
+              stage: selectablePromotion
+                ? ("promotion_probe" as const)
+                : ("confirmed_close" as const),
+              coverageProof: prCloseCoverageProofCanRun,
+              qualityBucket: proposedItemQualityBucket({
+                action,
+                closeReason: candidateCloseReason,
+                prCloseCoverageProofCanRun,
+                promotionProbe: selectablePromotion,
+              }),
+            },
+          ];
+        })
+        .sort((left, right) => left.number - right.number);
   const batchSize = options.batchSize ?? null;
   if (!batchSize || batchSize <= 0) return candidates;
   const coolDownPromotionProbes = !options.itemNumbers || options.itemNumbers.size === 0;
@@ -1281,7 +1432,7 @@ function selectedProposedItemCandidates(
     (candidate) =>
       candidate.stage !== "promotion_probe" ||
       !coolDownPromotionProbes ||
-      !promotionProbeCoolingDown(candidate),
+      !promotionProbeCoolingDown(candidate, nowMs),
   );
   const cursor = options.cursorPath ? readApplyCursor(options.cursorPath) : null;
   const rotate = (
@@ -1351,6 +1502,57 @@ function selectedProposedItemCandidates(
     ...selectedFast.slice(preProofFastCount),
     ...selectedPromotions,
   ];
+}
+
+function inconsistentOrStaleProposedItemCount(
+  options: ProposedItemOptions,
+  candidateNumbers: ReadonlySet<number>,
+): number {
+  const itemsDir = path.join("records", targetSlug(options.targetRepo), "items");
+  if (!fs.existsSync(itemsDir)) return 0;
+  const allowedCloseReasons =
+    options.applyCloseReasons === "all"
+      ? null
+      : new Set(
+          options.applyCloseReasons
+            .split(",")
+            .map((reason) => reason.trim())
+            .filter(Boolean),
+        );
+  const minAgeMs =
+    options.minAgeMinutes === null
+      ? options.minAgeDays * 24 * 60 * 60 * 1000
+      : options.minAgeMinutes * 60 * 1000;
+  return fs
+    .readdirSync(itemsDir)
+    .filter((name) => /(?:^|[a-z0-9-]-)\d+\.md$/.test(name))
+    .filter((name) => {
+      const number = numberFor(name);
+      if (candidateNumbers.has(number)) return false;
+      if (options.itemNumbers && !options.itemNumbers.has(number)) return false;
+      const markdown = fs.readFileSync(path.join(itemsDir, name), "utf8");
+      if (repoFor(markdown, name) !== options.targetRepo) return false;
+      const type = frontMatterValue(markdown, "type");
+      if (options.applyKind !== "all" && type && type !== options.applyKind) return false;
+      const action = frontMatterValue(markdown, "action_taken");
+      if (action !== "proposed_close" && action !== "retry_pr_close_coverage_proof") return false;
+      const reason = frontMatterValue(markdown, "close_reason");
+      if (allowedCloseReasons && !allowedCloseReasons.has(reason)) return false;
+      if (
+        ALLOWED_CLOSE_REASONS.has(reason) &&
+        !allowedForTarget(options.targetRepo, type, reason, ALLOWED_CLOSE_REASONS)
+      ) {
+        return false;
+      }
+      const createdAt = frontMatterValue(markdown, "item_created_at");
+      if (
+        (reason === "stale_insufficient_info" || reason === "mostly_implemented_on_main") &&
+        !olderThan(createdAt, options.staleMinAgeDays * 24 * 60 * 60 * 1000)
+      ) {
+        return false;
+      }
+      return olderThan(createdAt, minAgeMs);
+    }).length;
 }
 
 function promotionProbeCoolingDown(candidate: ProposedItemCandidate, nowMs = Date.now()): boolean {
@@ -1845,6 +2047,49 @@ function applyCheckedAtForItem(targetRepo: string, itemNumber: number): string {
     return frontMatterValue(fs.readFileSync(path.join(dir, name), "utf8"), "apply_checked_at");
   }
   return "";
+}
+
+function applyCandidateCounts(value: string): ApplyCandidateCounts | null {
+  if (!value) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error("candidate-counts-json must be valid JSON");
+  }
+  if (!isJsonObject(parsed)) throw new Error("candidate-counts-json must be an object");
+  const keys: Array<keyof ApplyCandidateCounts> = [
+    "confirmed_proposal",
+    "guarded_retry",
+    "proof_required",
+    "promotion_total",
+    "promotion_eligible",
+    "promotion_cooldown_eligible",
+    "cooldown_eligible_total",
+    "inconsistent_or_stale",
+  ];
+  const counts = {} as ApplyCandidateCounts;
+  for (const key of keys) {
+    const count = Number(parsed[key]);
+    if (!Number.isInteger(count) || count < 0) {
+      throw new Error(`candidate-counts-json.${key} must be a non-negative integer`);
+    }
+    counts[key] = count;
+  }
+  if (counts.promotion_eligible > counts.promotion_total) {
+    throw new Error("candidate-counts-json.promotion_eligible cannot exceed promotion_total");
+  }
+  if (counts.promotion_cooldown_eligible > counts.promotion_total) {
+    throw new Error(
+      "candidate-counts-json.promotion_cooldown_eligible cannot exceed promotion_total",
+    );
+  }
+  if (counts.promotion_eligible > counts.promotion_cooldown_eligible) {
+    throw new Error(
+      "candidate-counts-json.promotion_eligible cannot exceed promotion_cooldown_eligible",
+    );
+  }
+  return counts;
 }
 
 function proposedItemOptions(): ProposedItemOptions {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -2492,6 +2492,16 @@ test("dashboard exposes apply health from sweep status without broad scans", asy
       cycle: {
         basis: "scheduled_close_cursor",
         apply_ready_count: 1200,
+        candidate_counts: {
+          confirmed_proposal: 4,
+          guarded_retry: 2,
+          proof_required: 3,
+          promotion_total: 1194,
+          promotion_eligible: 1,
+          promotion_cooldown_eligible: 420,
+          cooldown_eligible_total: 427,
+          inconsistent_or_stale: 1,
+        },
         window_size: 300,
         estimated_full_cycle_windows: 4,
         estimated_full_cycle_minutes: null,
@@ -2565,6 +2575,16 @@ test("dashboard exposes apply health from sweep status without broad scans", asy
     );
     assert.equal(status.recent.apply_health.items[0].cycle.estimated_full_cycle_minutes, null);
     assert.equal(status.recent.apply_health.items[0].cycle.apply_ready_count, 1200);
+    assert.deepEqual(status.recent.apply_health.items[0].cycle.candidate_counts, {
+      confirmed_proposal: 4,
+      guarded_retry: 2,
+      proof_required: 3,
+      promotion_total: 1194,
+      promotion_eligible: 1,
+      promotion_cooldown_eligible: 420,
+      cooldown_eligible_total: 427,
+      inconsistent_or_stale: 1,
+    });
     assert.equal(status.recent.apply_health.items[0].cursor, null);
   } finally {
     globalThis.fetch = originalFetch;

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -18,6 +18,8 @@ import {
   mergeApplyReports,
   planOutputFields,
   plannedItemNumberCsv,
+  proposedItemCount,
+  proposedItemInventory,
   proposedItemQualitySummary,
   proposedItemNumbers,
   proposedPrCloseCoverageItemNumbers,
@@ -328,7 +330,17 @@ test("workflow utilities summarize apply health with skip buckets and cursor", (
     closeLimit: 5,
     cursorPath,
     cursorRequired: true,
-    candidateCount: 12,
+    candidateCount: 7,
+    candidateCounts: {
+      confirmed_proposal: 4,
+      guarded_retry: 2,
+      proof_required: 3,
+      promotion_total: 538,
+      promotion_eligible: 1,
+      promotion_cooldown_eligible: 420,
+      cooldown_eligible_total: 427,
+      inconsistent_or_stale: 1,
+    },
     cursorAdvanceCount: 4,
     scheduledIntervalMinutes: 15,
   });
@@ -373,13 +385,23 @@ test("workflow utilities summarize apply health with skip buckets and cursor", (
   );
   assert.deepEqual(summary.cycle, {
     basis: "scheduled_close_cursor",
-    apply_ready_count: 12,
+    apply_ready_count: 7,
+    candidate_counts: {
+      confirmed_proposal: 4,
+      guarded_retry: 2,
+      proof_required: 3,
+      promotion_total: 538,
+      promotion_eligible: 1,
+      promotion_cooldown_eligible: 420,
+      cooldown_eligible_total: 427,
+      inconsistent_or_stale: 1,
+    },
     window_size: 4,
-    estimated_full_cycle_windows: 3,
-    estimated_full_cycle_minutes: 45,
+    estimated_full_cycle_windows: 2,
+    estimated_full_cycle_minutes: 30,
     scheduled_interval_minutes: 15,
     label:
-      "12 close candidates (confirmed proposals plus live promotion probes) at 4 records per latest cursor advance: about 3 windows; scheduled cadence alone would take roughly 45 min at 15-minute intervals, while successful windows can continue sooner.",
+      "7 currently actionable close candidates (4 confirmed proposals, 2 guarded retries, 1/538 promotion probes admitted; 3 require proof; 427 cooldown-eligible backlog (420 promotions); 1 inconsistent or stale record excluded) at 4 records per latest cursor advance: about 2 windows; scheduled cadence alone would take roughly 30 min at 15-minute intervals, while successful windows can continue sooner.",
   });
   assert.equal(summary.cursor?.next_after_number, 40);
 });
@@ -418,6 +440,39 @@ test("workflow utilities distinguish examined promotion probes from action recor
   assert.match(summary.summary, /^40 examined; 0\/300 action records;/);
   assert.equal(summary.cycle.window_size, 40);
   assert.equal(summary.cursor?.next_after_number, 79148);
+});
+
+test("workflow utilities preserve a zero-action inventory for cooling promotion backlogs", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const reportPath = path.join(root, "apply-report.json");
+  write(reportPath, "[]\n");
+  const summary = summarizeApplyReport({
+    reportPath,
+    targetRepo: "openclaw/openclaw",
+    mode: "close",
+    processedLimit: 300,
+    closeLimit: 20,
+    cursorPath: path.join(root, "results/apply-cursors/openclaw-openclaw.json"),
+    cursorRequired: true,
+    candidateCount: 0,
+    candidateCounts: {
+      confirmed_proposal: 0,
+      guarded_retry: 0,
+      proof_required: 0,
+      promotion_total: 5,
+      promotion_eligible: 0,
+      promotion_cooldown_eligible: 0,
+      cooldown_eligible_total: 0,
+      inconsistent_or_stale: 1,
+    },
+    cursorAdvanceCount: 0,
+    scheduledIntervalMinutes: 15,
+  });
+
+  assert.equal(summary.status, "idle");
+  assert.equal(summary.cycle.basis, "no_apply_ready_candidates");
+  assert.equal(summary.cycle.apply_ready_count, 0);
+  assert.match(summary.cycle.label, /5 promotion probes are cooling down/);
 });
 
 test("workflow utilities summarize comment-sync apply reports separately from closure", () => {
@@ -2041,6 +2096,162 @@ test("workflow utilities cool down recently examined promotion probes", () => {
     ]),
     [["promotion_probe", 3]],
   );
+});
+
+test("workflow utilities report truthful eligible inventory across cursor and promotion cooldown", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const oldDate = "2024-01-01T00:00:00Z";
+  const cursorPath = path.join(root, "results/apply-cursors/openclaw-openclaw.json");
+  writeProposedRecord(root, 10, "issue", "proposed_close", "implemented_on_main", oldDate);
+  writeProposedRecord(root, 20, "issue", "skipped_open_closing_pr", "implemented_on_main", oldDate);
+  writeProposedRecord(
+    root,
+    30,
+    "pull_request",
+    "proposed_close",
+    "duplicate_or_superseded",
+    oldDate,
+  );
+  const writePromotion = (number, applyCheckedAt) =>
+    write(
+      path.join(root, `records/openclaw-openclaw/items/openclaw-openclaw-${number}.md`),
+      [
+        "---",
+        "repository: openclaw/openclaw",
+        "type: pull_request",
+        "decision: keep_open",
+        "review_status: complete",
+        "local_checkout_access: verified",
+        "action_taken: kept_open",
+        "close_reason: none",
+        `item_created_at: ${oldDate}`,
+        `apply_checked_at: ${applyCheckedAt}`,
+        "pr_rating_overall: F",
+        "pr_rating_proof: F",
+        "---",
+        "",
+      ].join("\n"),
+    );
+  writePromotion(40, new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString());
+  writePromotion(50, new Date(Date.now() - 60 * 60 * 1000).toISOString());
+  write(
+    path.join(root, "records/openclaw-openclaw/items/openclaw-openclaw-60.md"),
+    [
+      "---",
+      "repository: openclaw/openclaw",
+      "type: issue",
+      "decision: keep_open",
+      "confidence: high",
+      "action_taken: proposed_close",
+      "close_reason: none",
+      `item_created_at: ${oldDate}`,
+      "---",
+      "",
+    ].join("\n"),
+  );
+  write(
+    cursorPath,
+    JSON.stringify({
+      next_after_number: 30,
+      next_after_apply_checked_at: "2026-01-01T00:00:00Z",
+    }),
+  );
+  const options = {
+    targetRepo: "openclaw/openclaw",
+    applyKind: "all",
+    applyCloseReasons: "all",
+    staleMinAgeDays: 60,
+    minAgeDays: 0,
+    minAgeMinutes: null,
+    batchSize: 10,
+    closeLimit: 4,
+    coverageProofLimit: 1,
+    cursorPath,
+  };
+
+  const inventory = withCwd(root, () => proposedItemInventory(options));
+  assert.deepEqual(inventory, {
+    eligible_total: 4,
+    confirmed_proposal: 2,
+    guarded_retry: 1,
+    proof_required: 1,
+    promotion_total: 2,
+    promotion_eligible: 1,
+    promotion_cooldown_eligible: 1,
+    cooldown_eligible_total: 4,
+    inconsistent_or_stale: 1,
+  });
+  assert.equal(
+    withCwd(root, () => proposedItemCount(options)),
+    4,
+  );
+  assert.deepEqual(
+    withCwd(root, () => proposedItemNumbers(options)),
+    [10, 30, 20, 40],
+  );
+  write(
+    cursorPath,
+    JSON.stringify({
+      next_after_number: 50,
+      next_after_apply_checked_at: new Date().toISOString(),
+    }),
+  );
+  assert.deepEqual(
+    withCwd(root, () => proposedItemInventory(options)),
+    inventory,
+    "cursor rotation changes ordering, not truthful eligible counts",
+  );
+});
+
+test("workflow utilities do not call policy- or age-excluded proposals inconsistent", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const oldDate = "2024-01-01T00:00:00Z";
+  const youngDate = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+  const staleGateDate = new Date(Date.now() - 45 * 24 * 60 * 60 * 1000).toISOString();
+  writeProposedRecord(root, 10, "issue", "proposed_close", "implemented_on_main", oldDate);
+  writeProposedRecord(root, 20, "issue", "proposed_close", "duplicate_or_superseded", oldDate);
+  writeProposedRecord(root, 30, "issue", "proposed_close", "implemented_on_main", youngDate);
+  writeProposedRecord(
+    root,
+    40,
+    "issue",
+    "proposed_close",
+    "stale_insufficient_info",
+    staleGateDate,
+  );
+  write(
+    path.join(root, "records/openclaw-openclaw/items/openclaw-openclaw-50.md"),
+    [
+      "---",
+      "repository: openclaw/openclaw",
+      "type: issue",
+      "decision: keep_open",
+      "confidence: high",
+      "action_taken: proposed_close",
+      "close_reason: implemented_on_main",
+      `item_created_at: ${oldDate}`,
+      "---",
+      "",
+    ].join("\n"),
+  );
+
+  const inventory = withCwd(root, () =>
+    proposedItemInventory({
+      targetRepo: "openclaw/openclaw",
+      applyKind: "all",
+      applyCloseReasons: "implemented_on_main,stale_insufficient_info",
+      staleMinAgeDays: 60,
+      minAgeDays: 30,
+      minAgeMinutes: null,
+      batchSize: 20,
+      closeLimit: 20,
+      coverageProofLimit: 2,
+    }),
+  );
+
+  assert.equal(inventory.eligible_total, 1);
+  assert.equal(inventory.confirmed_proposal, 1);
+  assert.equal(inventory.inconsistent_or_stale, 1);
 });
 
 test("workflow utilities use spare proof capacity to rotate promotion probes", () => {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -446,7 +446,7 @@ test("apply workflow durably publishes each reconciliation before no-op exits", 
     applyStart,
   );
   const commentIdle = applyJob.indexOf('--state "Apply comments idle"', applyStart);
-  const closeIdle = applyJob.indexOf('--state "Apply idle"', applyStart);
+  const closeIdle = applyJob.indexOf("publish_automatic_apply_idle", applyStart);
 
   assert.ok(preselectReconcile !== -1);
   assert.ok(preselectReconcile < applyStart);
@@ -672,13 +672,26 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
   assert.ok(applyFlagInit < applyStep.indexOf("auto_selected_apply_batch=true"));
   assert.match(applyStep, /apply_cursor_path="results\/apply-cursors\/\$\{target_slug\}\.json"/);
   assert.match(applyHelper, /write_apply_health\(\)/);
-  assert.match(applyStep, /proposed-item-count/);
+  assert.match(applyStep, /select_apply_candidate_inventory/);
+  assert.match(applyHelper, /proposed-item-inventory/);
+  assert.match(
+    applyHelper,
+    /candidate_inventory_env="\.artifacts\/apply-candidate-inventory\.env"/,
+  );
+  assert.match(applyHelper, /update_item_numbers="\$\{1:-true\}"/);
+  assert.match(applyHelper, /item_numbers="\$\(awk -F=/);
+  assert.match(applyHelper, /apply_ready_count="\$\(awk -F=/);
+  assert.match(applyHelper, /candidate_counts_json="\$\(awk -F=/);
+  assert.match(applyHelper, /--batch-size "\$close_processed_limit"/);
+  assert.match(applyHelper, /--coverage-proof-limit "\$coverage_proof_limit"/);
+  assert.match(applyHelper, /--cursor-path "\$apply_cursor_path"/);
   assert.match(applyStep, /apply-cursor-advance-count/);
   assert.match(applyStep, /examined_count="\$\(apply_checkpoint_examined_count\)"/);
   assert.match(applyHelper, /apply_checkpoint_examined_count\(\)/);
   assert.match(applyHelper, /printf '%s\\n' "unavailable"/);
   assert.match(applyStep, /Candidates examined: \$examined_count\. Action records: \$result_count/);
   assert.match(applyHelper, /--candidate-count "\$health_candidate_count"/);
+  assert.match(applyHelper, /--candidate-counts-json "\$health_candidate_counts_json"/);
   assert.match(applyHelper, /--cursor-advance-count "\$health_cursor_advance_count"/);
   assert.match(applyHelper, /--scheduled-interval-minutes "\$health_scheduled_interval_minutes"/);
   assert.match(applyHelper, /pnpm run --silent workflow -- summarize-apply-report/);
@@ -689,30 +702,48 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
   assert.match(applyStep, /close_health_cursor_path="\$apply_cursor_path"/);
   assert.match(applyStep, /--apply-health-file "\.artifacts\/apply-health-\$checkpoint\.json"/);
   assert.match(applyStep, /--apply-health-file "\.artifacts\/apply-health-final\.json"/);
-  assert.match(applyStep, /--state "Apply idle"/);
+  assert.match(applyStep, /publish_automatic_apply_idle/);
+  assert.match(applyHelper, /--apply-health-file "\.artifacts\/apply-health-idle\.json"/);
+  assert.match(applyHelper, /apply-report-idle\.json/);
+  assert.match(applyHelper, /--state "Apply idle"/);
   assert.match(applyHelper, /proposed-item-quality-summary/);
   assert.match(applyHelper, /candidate_quality_summary="\$\(awk -F=/);
   assert.match(
     applyHelper,
     /candidate_quality_detail=" Close candidate mix: \$candidate_quality_summary\."/,
   );
-  assert.match(applyStep, /awaiting apply\.\$candidate_quality_detail Scheduled apply/);
+  assert.match(applyHelper, /awaiting apply\.\$candidate_quality_detail Scheduled apply/);
   assert.match(
     applyStep,
     /\$apply_close_reasons\.\$candidate_quality_detail Scan window: \$close_processed_limit/,
   );
   const applyReconcileIndex = applyStep.indexOf('persist_reconciliation "${reconcile_args[@]}"');
   const qualitySummaryIndex = applyStep.indexOf("summarize_apply_candidate_quality");
-  const proposedNumbersIndex = applyStep.indexOf("proposed-item-numbers");
+  const candidateInventoryIndex = applyStep.indexOf("select_apply_candidate_inventory");
+  const selectedItemsBranchIndex = applyStep.indexOf(
+    'if [ -n "$item_numbers" ]',
+    candidateInventoryIndex,
+  );
+  const checkpointPublishIndex = applyStep.indexOf(
+    'publish_changes "chore: apply sweep decisions checkpoint $checkpoint"',
+  );
+  const refreshedInventoryIndex = applyStep.indexOf(
+    "select_apply_candidate_inventory",
+    candidateInventoryIndex + 1,
+  );
   assert.notEqual(applyReconcileIndex, -1);
   assert.ok(qualitySummaryIndex > applyReconcileIndex);
-  assert.ok(proposedNumbersIndex > qualitySummaryIndex);
-  assert.match(applyStep, /--batch-size "\$close_processed_limit"/);
+  assert.ok(candidateInventoryIndex > qualitySummaryIndex);
+  assert.ok(selectedItemsBranchIndex > candidateInventoryIndex);
+  assert.ok(refreshedInventoryIndex > checkpointPublishIndex);
+  assert.match(applyStep, /select_apply_candidate_inventory false/);
+  assert.doesNotMatch(applyStep, /proposed-item-numbers/);
+  assert.match(applyHelper, /--batch-size "\$close_processed_limit"/);
   assert.match(
-    applyStep,
+    applyHelper,
     /--close-limit "\$\(\(limit < checkpoint_size \? limit : checkpoint_size\)\)"/,
   );
-  assert.match(applyStep, /--coverage-proof-limit "\$coverage_proof_limit"/);
+  assert.match(applyHelper, /--coverage-proof-limit "\$coverage_proof_limit"/);
   assert.match(applyStep, /select_bounded_coverage_proof_tail/);
   assert.match(applyHelper, /select_bounded_coverage_proof_tail\(\)/);
   assert.match(applyHelper, /proposed-pr-close-coverage-item-numbers/);


### PR DESCRIPTION
## Summary

- derive one scheduler-admitted apply candidate inventory and use it for selection, health, checkpoint refresh, and dashboard reporting
- separate immediately apply-ready work from guarded retries, proof-required candidates, promotion probes, cooldown-eligible backlog, and inconsistent or stale records
- validate structured candidate counts and document the dashboard semantics so backlog size is no longer presented as ready-to-close work

## Proof

- `pnpm run build:all`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run check:active-surface && pnpm run check:limits`
- `node --test test/dashboard-worker.test.ts test/repair/workflow-utils.test.ts test/sweep-workflow.test.ts` (161 passed)
- fresh structured review: Codex `gpt-5.6-sol`, high reasoning, no web; clean, patch correct 0.87

## Live hydrated-state sanity check

- apply-ready CSV count matched `apply_ready_count` at 7
- promotion ordering held: admitted 1 <= cooldown-eligible 424 <= total 541
- inventory also surfaced 5 confirmed proposals, 1 guarded retry, 2 proof-required candidates, and 1 inconsistent or stale record
