### PR TITLE
fix: normalize event record slugs and reap expired review leases

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -80,7 +80,10 @@ import {
   LOCAL_REVIEW_WEB_SEARCH_CONFIG,
 } from "./commit-sweeper.js";
 import { AUTOMATION_LIMITS } from "./limits.js";
-import { freshExactHeadReviewStartLease } from "./repair/comment-router-core.js";
+import {
+  expiredReviewStartStatusLeases,
+  freshExactHeadReviewStartLease,
+} from "./repair/comment-router-core.js";
 import {
   AUTOMERGE_LABEL,
   AUTOFIX_LABEL,
@@ -17985,6 +17988,11 @@ function postReviewStartStatusComment(options: {
   if (initialLease) {
     return { status: "held", lease: null, retryAt: initialLease.expiresAt };
   }
+  reapExpiredDedicatedReviewStartLeases(
+    options.item.number,
+    initialState.dedicatedLeaseComments,
+    startedAtMs,
+  );
   const body = renderReviewStartStatusComment(leaseOptions);
   const payload = writeCommentPayload(options.item.number, body);
   const createArgs = [
@@ -18057,6 +18065,41 @@ function deleteOwnedDedicatedReviewStartLease(
       }`,
     );
     return false;
+  }
+}
+
+function reapExpiredDedicatedReviewStartLeases(
+  itemNumber: number,
+  dedicatedLeaseComments: Record<string, unknown>[],
+  nowMs: number,
+): void {
+  const expired = expiredReviewStartStatusLeases({
+    comments: dedicatedLeaseComments,
+    itemNumber,
+    trustedAuthors: new Set(
+      [...PATCHABLE_REVIEW_COMMENT_AUTHORS].map((author) => author.toLowerCase()),
+    ),
+    nowMs,
+  });
+  for (const lease of expired) {
+    try {
+      ghWithRetry([
+        "api",
+        `repos/${targetRepo()}/issues/comments/${lease.commentId}`,
+        "--method",
+        "DELETE",
+      ]);
+      console.error(
+        `[review] reaped expired review lease comment ${lease.commentId} for #${itemNumber} (lease expired ${lease.expiresAt})`,
+      );
+    } catch (error) {
+      // A failed reap must never block acquiring the new lease.
+      console.error(
+        `[review] could not reap expired review lease comment ${lease.commentId} for #${itemNumber}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
   }
 }
 

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -1802,6 +1802,44 @@ export function freshExactHeadReviewStartLease({
     : null;
 }
 
+export function expiredReviewStartStatusLeases({
+  comments,
+  itemNumber,
+  trustedAuthors = new Set<string>(),
+  nowMs = Date.now(),
+}: {
+  comments: LooseRecord[];
+  itemNumber: number;
+  trustedAuthors?: ReadonlySet<string>;
+  nowMs?: number;
+}): Array<{ commentId: number; expiresAt: string }> {
+  if (!Number.isInteger(itemNumber) || itemNumber <= 0) return [];
+  const expired: Array<{ commentId: number; expiresAt: string }> = [];
+  for (const comment of comments) {
+    const author = String(comment?.user?.login ?? "")
+      .trim()
+      .toLowerCase();
+    if (!author || !trustedAuthors.has(author)) continue;
+    const body = String(comment?.body ?? "");
+    // Only dedicated lease comments are reapable. The durable review comment can
+    // carry the same started marker via the legacy combined-lease path, and it
+    // must never be deleted here.
+    if (!body.includes(`<!-- clawsweeper-review-lease item=${itemNumber} -->`)) continue;
+    const canonical = canonicalReviewStartStatusMarker(body);
+    if (!canonical || canonical.itemNumber !== itemNumber) continue;
+    if (String(canonical.marker.attrs.v ?? "") !== "1") continue;
+    const expiresAt = String(canonical.marker.attrs.lease_expires_at ?? "");
+    const expiresAtMs = Date.parse(expiresAt);
+    // Unparseable expiry never qualifies: deleting is unrecoverable, so only a
+    // lease that provably lapsed may be reaped.
+    if (!Number.isFinite(expiresAtMs) || expiresAtMs >= nowMs) continue;
+    const rawCommentId = Number(comment?.id);
+    if (!Number.isInteger(rawCommentId) || rawCommentId <= 0) continue;
+    expired.push({ commentId: rawCommentId, expiresAt });
+  }
+  return expired;
+}
+
 export function trustedAutomationPredatesReviewStartLease({
   command,
   currentHeadSha,

--- a/src/repair/event-record-store.ts
+++ b/src/repair/event-record-store.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import { normalizeRepo, slugForRepo } from "../repository-profiles.js";
 import {
   chooseRecordTupleWinner,
   recordTupleContentsEqual,
@@ -39,7 +40,10 @@ export type EventSnapshotApplyResult =
   | "missing";
 
 export function eventRecordPaths(store: EventRecordStore): EventRecordPaths {
-  const targetSlug = store.targetRepo.replace("/", "-");
+  // Record tuples are written under the lowercased repository-profile slug
+  // (normalizeRepo + slugForRepo); read with the same normalization so
+  // display-cased target repos (steipete/Nameplate) resolve the same paths.
+  const targetSlug = slugForRepo(normalizeRepo(store.targetRepo));
   const tuple = recordTuplePaths({ repository: targetSlug, number: store.itemNumber });
   return {
     targetSlug,

--- a/src/repository-profiles.ts
+++ b/src/repository-profiles.ts
@@ -183,7 +183,7 @@ function fallbackDescription(): string {
     .join(", ");
 }
 
-function slugForRepo(targetRepo: string): string {
+export function slugForRepo(targetRepo: string): string {
   return targetRepo.replace(/[^A-Za-z0-9_.-]+/g, "-");
 }
 

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -33,6 +33,7 @@ import {
   createCachedLabelNumberLookup,
   existingCommandStatusBlocksReplay,
   existingModeStatusBlocksReplay,
+  expiredReviewStartStatusLeases,
   freshExactHeadReviewStartLease,
   hasCommandResponseMarker,
   issueImplementationClusterId,
@@ -1510,6 +1511,92 @@ test("label sweeps honor fresh trusted exact-head review start leases", () => {
       trustedAuthors: new Set(["other-bot[bot]"]),
     }),
     null,
+  );
+});
+
+test("expired review start leases select only provably lapsed dedicated lease comments", () => {
+  const itemNumber = 24;
+  const headSha = "0123456789abcdef0123456789abcdef01234567";
+  const leaseComment = (id, owner, startedAt, expiresAt, overrides = {}) => ({
+    id,
+    user: { login: overrides.login ?? "clawsweeper[bot]" },
+    body: [
+      "ClawSweeper status: review started.",
+      `<!-- clawsweeper-review-status:started item=${itemNumber} sha=${headSha} started_at=${startedAt} lease_expires_at=${expiresAt}${owner ? ` owner=${owner}` : ""} v=${overrides.version ?? "1"} -->`,
+      overrides.identityMarker ?? `<!-- clawsweeper-review-lease item=${itemNumber} -->`,
+    ].join("\n"),
+  });
+  const nowMs = Date.parse("2026-07-11T01:38:00.000Z");
+  const options = {
+    itemNumber,
+    trustedAuthors: new Set(["clawsweeper[bot]"]),
+    nowMs,
+  };
+
+  const expiredUuidOwner = leaseComment(
+    101,
+    "5749cf7a-f0ff-4a0f-ad39-e4e0534b38e0",
+    "2026-07-10T20:14:01.432Z",
+    "2026-07-10T20:44:01.432Z",
+  );
+  const expiredRunOwner = leaseComment(
+    102,
+    "github-run-29134971283-1",
+    "2026-07-10T20:49:54.000Z",
+    "2026-07-10T21:19:54.000Z",
+  );
+  const freshLease = leaseComment(
+    103,
+    "github-run-29135098886-1",
+    "2026-07-11T01:37:58.000Z",
+    "2026-07-11T02:07:58.000Z",
+  );
+  const malformedExpiry = leaseComment(104, "owner-a", "2026-07-10T20:14:01.432Z", "not-a-date");
+  const untrustedAuthor = leaseComment(
+    105,
+    "owner-b",
+    "2026-07-10T20:14:01.432Z",
+    "2026-07-10T20:44:01.432Z",
+    { login: "impostor" },
+  );
+  const legacyReviewComment = leaseComment(
+    106,
+    "owner-c",
+    "2026-07-10T20:14:01.432Z",
+    "2026-07-10T20:44:01.432Z",
+    { identityMarker: `<!-- clawsweeper-review item=${itemNumber} -->` },
+  );
+  const idlessExpired = {
+    ...leaseComment(0, "owner-d", "2026-07-10T20:14:01.432Z", "2026-07-10T20:44:01.432Z"),
+    id: undefined,
+  };
+
+  assert.deepEqual(
+    expiredReviewStartStatusLeases({
+      ...options,
+      comments: [
+        expiredUuidOwner,
+        expiredRunOwner,
+        freshLease,
+        malformedExpiry,
+        untrustedAuthor,
+        legacyReviewComment,
+        idlessExpired,
+      ],
+    }),
+    [
+      { commentId: 101, expiresAt: "2026-07-10T20:44:01.432Z" },
+      { commentId: 102, expiresAt: "2026-07-10T21:19:54.000Z" },
+    ],
+  );
+  assert.deepEqual(expiredReviewStartStatusLeases({ ...options, comments: [freshLease] }), []);
+  assert.deepEqual(
+    expiredReviewStartStatusLeases({
+      ...options,
+      itemNumber: 25,
+      comments: [expiredUuidOwner],
+    }),
+    [],
   );
 });
 

--- a/test/repair/event-record-store.test.ts
+++ b/test/repair/event-record-store.test.ts
@@ -892,6 +892,53 @@ test("event snapshots fail closed on packet mismatch and equal-time divergence",
   });
 });
 
+test("event record paths normalize display-cased target repos to the profile slug", () => {
+  const paths = eventRecordPaths({
+    targetRepo: "steipete/Nameplate",
+    itemNumber: "24",
+    snapshotDir: "snapshot",
+  });
+  assert.equal(paths.targetSlug, "steipete-nameplate");
+  assert.equal(paths.itemRecord, "records/steipete-nameplate/items/24.md");
+  assert.equal(paths.closedRecord, "records/steipete-nameplate/closed/24.md");
+  assert.equal(paths.planRecord, "records/steipete-nameplate/plans/24.md");
+  assert.equal(paths.decisionPacket, "records/steipete-nameplate/decision-packets/24.json");
+
+  const lowercase = eventRecordPaths({
+    targetRepo: "openclaw/openclaw",
+    itemNumber: "91668",
+    snapshotDir: "snapshot",
+  });
+  assert.equal(lowercase.targetSlug, "openclaw-openclaw");
+});
+
+test("display-cased target repo captures the tuple written under the lowercase profile slug", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-event-records-case-"));
+  const store = {
+    targetRepo: "steipete/Nameplate",
+    itemNumber: "24",
+    snapshotDir: path.join(root, "snapshot"),
+  };
+
+  withCwd(root, () => {
+    const paths = eventRecordPaths(store);
+    resetEventSnapshot(store);
+    captureEventBaseSnapshot(store);
+    // apply-artifacts writes through the repository profile, which lowercases
+    // the repo before deriving the slug.
+    writeEventTuple(paths, {
+      marker: "case-normalized candidate",
+      reviewedAt: "2026-07-10T20:20:00.000Z",
+      itemUpdatedAt: "2026-07-10T20:00:00Z",
+      packet: false,
+      plan: false,
+    });
+    const captured = captureEventSnapshot(store);
+    assert.equal(fs.existsSync(captured.snapshotItem), true);
+    assert.equal(applyEventSnapshot(captured), "open");
+  });
+});
+
 function withCwd(cwd, callback) {
   const previous = process.cwd();
   process.chdir(cwd);


### PR DESCRIPTION
Fixes #490

## What

Two narrow fixes for the event-review loop described in #490, observed live on steipete/Nameplate#24 (10 orphaned "review started" placeholders, no review ever published, one full Codex review burned per ~33 minutes):

1. `src/repair/event-record-store.ts`: derive the record slug with `slugForRepo(normalizeRepo(...))` (newly exported from `src/repository-profiles.ts`) instead of a case-preserving `replace("/", "-")`. The read path now matches what `apply-artifacts` / `apply-decisions` write for any input casing, so `publish-event-result` stops concluding "the event produced no record tuple" for display-cased target repos like `steipete/Nameplate` and `steipete/CodexBar`.
2. `postReviewStartStatusComment`: when no fresh lease exists, reap expired dedicated review-lease comments before posting the new placeholder, via a new `expiredReviewStartStatusLeases` helper in `comment-router-core.ts`. Deletion is restricted to trusted bot authors, the item's `clawsweeper-review-lease` identity marker, and a parseable `lease_expires_at` in the past; a failed delete logs and never blocks lease acquisition. This stops placeholder accumulation in every lane and retroactively removes the pre-#473 UUID-owner orphans (which the workflow's `owner=github-run-...` release step can never match) the next time a review runs on the item.

## Why the loop happened

Run [29134971283](https://github.com/openclaw/clawsweeper/actions/runs/29134971283): review completed (`decision=keep_open confidence=high`), `apply-artifacts` applied the report under `records/steipete-nameplate/...` (profile slug, lowercased), but the event snapshot read `records/steipete-Nameplate/...` (case-preserving slug) on a case-sensitive runner, found nothing, and threw. The queue completed the lease with outcome failure and requeued; each ~30-minute lease cycle posted a new placeholder. `records/steipete-nameplate/items/` in clawsweeper-state has entries for issues 9/10/12/17 (sweep lane) and nothing for the looping PRs 22/23/24.

## Safety notes

- The reaper never touches fresh leases (that path still returns `held` before the reap runs), never touches the durable review comment (the legacy combined-lease body carries the started marker but not the dedicated `clawsweeper-review-lease` identity marker), and treats malformed expiry timestamps as not expired since deletion is unrecoverable.
- The expiry helper lives next to `freshExactHeadReviewStartLease` in `comment-router-core.ts` and reuses the same canonical marker parsing, so freshness and expiry cannot drift apart.

## Tests

- `test/repair/event-record-store.test.ts`: display-cased `targetRepo` resolves the lowercase profile-slug paths; end-to-end capture/apply of a tuple written under the lowercase slug returns `open` instead of `missing` (mirrors the live failure).
- `test/repair/comment-router-core.test.ts`: expiry selection picks only provably lapsed dedicated lease comments; fresh leases, malformed expiry, untrusted authors, non-lease identity markers, id-less comments, and other item numbers are all excluded.
- `pnpm run test:unit` and `pnpm run test:repair` pass (696/696 repair; the only 2 unit failures are the pre-existing `${TARGET_REPO,,}` bash-3.2 environment failures in `test/sweep-workflow.test.ts`, identical on main).

Follow-ups deliberately left out to keep this narrow (detailed in #490): per-item attempt cap/backoff on the exact-review queue, placeholder copy that promises an edit that never happens, 0-indexed "Shard 0/1" display, and the sibling case-preserving `replace("/", "-")` call sites outside the event lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWeekBqQYx3iYZKvU5G6Cw
