### PR TITLE
perf(router): short-circuit terminal comment versions

### DIFF
--- a/.github/workflows/repair-comment-router.yml
+++ b/.github/workflows/repair-comment-router.yml
@@ -198,9 +198,21 @@ jobs:
             item_numbers="${{ github.event.client_payload.item_number || '' }}"
             comment_ids="${{ github.event.client_payload.comment_id || '' }}"
             status_comment_id="${{ github.event.client_payload.status_comment_id || '' }}"
+            source_event="${{ github.event.client_payload.source_event || '' }}"
+            source_action="${{ github.event.client_payload.source_action || '' }}"
+            dispatch_actor="${{ github.actor }}"
+            comment_event_auth="${{ github.event.client_payload.comment_event_auth || '' }}"
+            comment_updated_at="${{ github.event.client_payload.comment_updated_at || '' }}"
+            comment_body_sha256="${{ github.event.client_payload.comment_body_sha256 || '' }}"
             force_reprocess="${{ github.event.client_payload.force_reprocess || 'false' }}"
           else
             status_comment_id=""
+            source_event=""
+            source_action=""
+            dispatch_actor=""
+            comment_event_auth=""
+            comment_updated_at=""
+            comment_body_sha256=""
           fi
 
           args=(
@@ -227,6 +239,24 @@ jobs:
           if [ -n "$status_comment_id" ]; then
             args+=(--status-comment-id "$status_comment_id")
           fi
+          if [ -n "$source_event" ]; then
+            args+=(--source-event "$source_event")
+          fi
+          if [ -n "$source_action" ]; then
+            args+=(--source-action "$source_action")
+          fi
+          if [ -n "$dispatch_actor" ]; then
+            args+=(--dispatch-actor "$dispatch_actor")
+          fi
+          if [ -n "$comment_event_auth" ]; then
+            args+=(--comment-event-auth "$comment_event_auth")
+          fi
+          if [ -n "$comment_updated_at" ]; then
+            args+=(--comment-updated-at "$comment_updated_at")
+          fi
+          if [ -n "$comment_body_sha256" ]; then
+            args+=(--comment-body-sha256 "$comment_body_sha256")
+          fi
           if [ "$force_reprocess" = "true" ]; then
             args+=(--force-reprocess)
           fi
@@ -240,6 +270,10 @@ jobs:
       - name: Commit comment router ledger
         if: always()
         run: |
+          if jq -e '.short_circuited == true' results/comment-router-latest.json >/dev/null 2>&1; then
+            echo "Exact terminal comment version already recorded; skipping state publication."
+            exit 0
+          fi
           pnpm run repair:publish-main -- \
             --message "chore: record ClawSweeper comment routing" \
             --path results/comment-router.json \
@@ -286,9 +320,21 @@ jobs:
             item_numbers="${{ github.event.client_payload.item_number || '' }}"
             comment_ids="${{ github.event.client_payload.comment_id || '' }}"
             status_comment_id="${{ github.event.client_payload.status_comment_id || '' }}"
+            source_event="${{ github.event.client_payload.source_event || '' }}"
+            source_action="${{ github.event.client_payload.source_action || '' }}"
+            dispatch_actor="${{ github.actor }}"
+            comment_event_auth="${{ github.event.client_payload.comment_event_auth || '' }}"
+            comment_updated_at="${{ github.event.client_payload.comment_updated_at || '' }}"
+            comment_body_sha256="${{ github.event.client_payload.comment_body_sha256 || '' }}"
             force_reprocess="${{ github.event.client_payload.force_reprocess || 'false' }}"
           else
             status_comment_id=""
+            source_event=""
+            source_action=""
+            dispatch_actor=""
+            comment_event_auth=""
+            comment_updated_at=""
+            comment_body_sha256=""
           fi
 
           args=(
@@ -314,6 +360,24 @@ jobs:
           fi
           if [ -n "$status_comment_id" ]; then
             args+=(--status-comment-id "$status_comment_id")
+          fi
+          if [ -n "$source_event" ]; then
+            args+=(--source-event "$source_event")
+          fi
+          if [ -n "$source_action" ]; then
+            args+=(--source-action "$source_action")
+          fi
+          if [ -n "$dispatch_actor" ]; then
+            args+=(--dispatch-actor "$dispatch_actor")
+          fi
+          if [ -n "$comment_event_auth" ]; then
+            args+=(--comment-event-auth "$comment_event_auth")
+          fi
+          if [ -n "$comment_updated_at" ]; then
+            args+=(--comment-updated-at "$comment_updated_at")
+          fi
+          if [ -n "$comment_body_sha256" ]; then
+            args+=(--comment-body-sha256 "$comment_body_sha256")
           fi
           if [ "$force_reprocess" = "true" ]; then
             args+=(--force-reprocess)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Short-circuited authenticated duplicate comment deliveries when their exact
+  body version is already terminal in the durable router ledger, while edited,
+  retryable, and state-drifted commands retain the full routing path.
 - Expanded stale-insufficient-info issue handling to materially outdated reports with no current-version confirmation for 60 days, and counted live merge conflicts as an abandoned-PR stalled state.
 - Upgraded Codex review and repair workers to GPT-5.6 Sol with high reasoning, invalidating cached reviews from the prior model policy.
 - Raised durable exact-review admission from 20 to 28 global leases and from 16 to 24 leases per target while preserving four slots for other repositories.

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -1183,12 +1183,6 @@ async function githubWebhook(request, env, ctx) {
     itemNumber: commentDecision.itemNumber,
     sourceCommentId: commentDecision.commentId,
   });
-  await addIssueCommentReaction({
-    token: targetToken,
-    repo: commentDecision.targetRepo,
-    commentId: commentDecision.commentId,
-    content: "eyes",
-  });
   await dispatchClawsweeperComment({
     token: dispatchToken,
     decision: commentDecision,
@@ -2373,19 +2367,6 @@ function fastAckMarker(sourceCommentId) {
   return `<!-- clawsweeper-command-ack:${sourceCommentId} -->`;
 }
 
-async function addIssueCommentReaction({ token, repo, commentId, content }) {
-  await githubTokenJson({
-    token,
-    path: `/repos/${repo}/issues/comments/${commentId}/reactions`,
-    method: "POST",
-    body: { content },
-    errorLabel: "ClawSweeper comment reaction",
-  }).catch((error) => {
-    if (!String(error.message || "").includes("422")) throw error;
-    return null;
-  });
-}
-
 async function dispatchClawsweeperItem({
   token,
   decision,
@@ -2464,7 +2445,6 @@ async function dispatchClawsweeperComment({ token, decision, statusCommentId }) 
         source_event: "issue_comment",
         source_action: decision.sourceAction,
         ...exactVersion,
-        max_comments: "1",
       },
     },
     errorLabel: "ClawSweeper comment dispatch",

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -1183,6 +1183,12 @@ async function githubWebhook(request, env, ctx) {
     itemNumber: commentDecision.itemNumber,
     sourceCommentId: commentDecision.commentId,
   });
+  await addIssueCommentReaction({
+    token: targetToken,
+    repo: commentDecision.targetRepo,
+    commentId: commentDecision.commentId,
+    content: "eyes",
+  });
   await dispatchClawsweeperComment({
     token: dispatchToken,
     decision: commentDecision,
@@ -2365,6 +2371,21 @@ function renderFastAckComment(sourceCommentId) {
 
 function fastAckMarker(sourceCommentId) {
   return `<!-- clawsweeper-command-ack:${sourceCommentId} -->`;
+}
+
+async function addIssueCommentReaction({ token, repo, commentId, content }) {
+  await githubTokenJson({
+    token,
+    path: `/repos/${repo}/issues/comments/${commentId}/reactions`,
+    method: "POST",
+    body: { content },
+    errorLabel: "ClawSweeper comment reaction",
+  }).catch((error) => {
+    if (!String(error.message || "").includes("422")) {
+      console.error(`ClawSweeper comment reaction failed: ${error?.message || error}`);
+    }
+    return null;
+  });
 }
 
 async function dispatchClawsweeperItem({

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -1144,7 +1144,7 @@ async function githubWebhook(request, env, ctx) {
     return json({ ok: true, accepted: false, reason: decision.reason }, 202);
   }
 
-  if (decision.type === "item") {
+  if ("type" in decision && decision.type === "item") {
     const deliveryId = request.headers.get("x-github-delivery") || "";
     const queued = await enqueueExactReview({
       env,
@@ -1248,6 +1248,7 @@ function classifyGithubIssueCommentWebhook({ event, payload }) {
   if (!Number.isInteger(installationId) || installationId <= 0) {
     return { accepted: false, reason: "missing installation id" };
   }
+  const commentUpdatedAt = exactWebhookTimestamp(comment.updated_at);
   return {
     accepted: true,
     type: "issue_comment",
@@ -1257,7 +1258,18 @@ function classifyGithubIssueCommentWebhook({ event, payload }) {
     commentId,
     installationId,
     sourceAction: action,
+    ...(commentUpdatedAt
+      ? {
+          commentUpdatedAt,
+          commentBody: String(comment.body || ""),
+        }
+      : {}),
   };
+}
+
+function exactWebhookTimestamp(value) {
+  const text = String(value || "").trim();
+  return text && Number.isFinite(Date.parse(text)) ? text : null;
 }
 
 function classifyGithubItemWebhook({ event, payload }) {
@@ -2429,6 +2441,14 @@ async function dispatchClawsweeperItem({
 }
 
 async function dispatchClawsweeperComment({ token, decision, statusCommentId }) {
+  const exactVersion =
+    decision.commentUpdatedAt && typeof decision.commentBody === "string"
+      ? {
+          comment_event_auth: "github_webhook_v1",
+          comment_updated_at: decision.commentUpdatedAt,
+          comment_body_sha256: await sha256Text(decision.commentBody),
+        }
+      : {};
   await githubTokenJson({
     token,
     path: `/repos/${CLAWSWEEPER_REVIEW_REPO}/dispatches`,
@@ -2443,11 +2463,17 @@ async function dispatchClawsweeperComment({ token, decision, statusCommentId }) 
         status_comment_id: statusCommentId,
         source_event: "issue_comment",
         source_action: decision.sourceAction,
+        ...exactVersion,
         max_comments: "1",
       },
     },
     errorLabel: "ClawSweeper comment dispatch",
   });
+}
+
+async function sha256Text(value) {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+  return hexEncode(new Uint8Array(digest));
 }
 
 async function githubTokenJson({ token, path, method = "GET", body, errorLabel }) {

--- a/src/repair/comment-router-utils.ts
+++ b/src/repair/comment-router-utils.ts
@@ -1,6 +1,8 @@
-import type { JsonValue, LooseRecord } from "./json-types.js";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+
+import type { JsonValue, LooseRecord } from "./json-types.js";
 
 const PASSING_CHECK_CONCLUSIONS = new Set(["SUCCESS", "SKIPPED", "NEUTRAL"]);
 const DEFAULT_IGNORED_CHECKS = [
@@ -140,6 +142,122 @@ export function shouldSuppressProcessedCommentVersion(entry: LooseRecord) {
     return false;
   }
   return true;
+}
+
+export function commentBodySha256(body: JsonValue) {
+  return createHash("sha256")
+    .update(String(body ?? ""), "utf8")
+    .digest("hex");
+}
+
+export function exactCommentVersionFastPathDecision({
+  authenticated,
+  sourceAction,
+  targetRepo,
+  commentId,
+  commentUpdatedAt,
+  commentBodyDigest,
+  forceReprocess,
+  ledger,
+  verificationLedgers,
+}: {
+  authenticated: boolean;
+  sourceAction: JsonValue;
+  targetRepo: JsonValue;
+  commentId: JsonValue;
+  commentUpdatedAt: JsonValue;
+  commentBodyDigest: JsonValue;
+  forceReprocess: boolean;
+  ledger: LooseRecord;
+  verificationLedgers: LooseRecord[];
+}) {
+  if (forceReprocess) return { suppress: false, reason: "force_reprocess" };
+  if (!authenticated) return { suppress: false, reason: "auth_uncertain" };
+  if (String(sourceAction ?? "") !== "created") {
+    return { suppress: false, reason: "edited_or_unknown_action" };
+  }
+
+  const normalizedRepo = String(targetRepo ?? "")
+    .trim()
+    .toLowerCase();
+  const normalizedCommentId = String(commentId ?? "").trim();
+  const normalizedUpdatedAt = normalizeExactTimestamp(commentUpdatedAt);
+  const normalizedBodyDigest = String(commentBodyDigest ?? "")
+    .trim()
+    .toLowerCase();
+  if (
+    !normalizedRepo ||
+    !/^[1-9]\d*$/.test(normalizedCommentId) ||
+    !normalizedUpdatedAt ||
+    !/^[0-9a-f]{64}$/.test(normalizedBodyDigest)
+  ) {
+    return { suppress: false, reason: "incomplete_exact_version" };
+  }
+
+  if (
+    verificationLedgers.length < 2 ||
+    verificationLedgers.some(
+      (verificationLedger) =>
+        stableLedgerSnapshot(verificationLedger) !== stableLedgerSnapshot(ledger),
+    )
+  ) {
+    return { suppress: false, reason: "state_drift" };
+  }
+
+  const matches = (Array.isArray(ledger.commands) ? ledger.commands : []).filter(
+    (entry: JsonValue) =>
+      String(entry?.repo ?? "")
+        .trim()
+        .toLowerCase() === normalizedRepo &&
+      String(entry?.comment_id ?? "").trim() === normalizedCommentId &&
+      normalizeExactTimestamp(entry?.comment_updated_at) === normalizedUpdatedAt,
+  );
+  if (matches.length !== 1) {
+    return {
+      suppress: false,
+      reason: matches.length === 0 ? "version_not_terminal" : "ambiguous_ledger_version",
+    };
+  }
+
+  const entry = matches[0] as LooseRecord;
+  if (
+    String(entry.comment_body_sha256 ?? "")
+      .trim()
+      .toLowerCase() !== normalizedBodyDigest
+  ) {
+    return { suppress: false, reason: "body_digest_mismatch" };
+  }
+  if (!shouldSuppressProcessedCommentVersion(entry)) {
+    return { suppress: false, reason: "version_retryable" };
+  }
+  if (
+    (Array.isArray(entry.actions) ? entry.actions : []).some((action: JsonValue) =>
+      ["claimed", "failed", "pending", "waiting"].includes(
+        String(action?.status ?? "").toLowerCase(),
+      ),
+    )
+  ) {
+    return { suppress: false, reason: "lease_uncertain" };
+  }
+  return {
+    suppress: true,
+    reason: "exact_terminal_comment_version",
+    commentVersionKey: `${normalizedCommentId}:${String(entry.comment_updated_at)}`,
+    status: String(entry.status ?? "").toLowerCase(),
+  };
+}
+
+function normalizeExactTimestamp(value: JsonValue) {
+  const text = String(value ?? "").trim();
+  const parsed = Date.parse(text);
+  return text && Number.isFinite(parsed) ? new Date(parsed).toISOString() : null;
+}
+
+function stableLedgerSnapshot(ledger: LooseRecord) {
+  return JSON.stringify({
+    updated_at: ledger.updated_at ?? null,
+    commands: Array.isArray(ledger.commands) ? ledger.commands : [],
+  });
 }
 
 export function dispatchClaimDecision({
@@ -327,6 +445,7 @@ export function appendLedger(current: LooseRecord, entries: LooseRecord[]) {
         comment_url: entry.comment_url,
         comment_created_at: entry.comment_created_at ?? null,
         comment_updated_at: entry.comment_updated_at ?? null,
+        ...(entry.comment_body_sha256 ? { comment_body_sha256: entry.comment_body_sha256 } : {}),
         repo: entry.repo,
         issue_number: entry.issue_number,
         author: entry.author,

--- a/src/repair/comment-router-utils.ts
+++ b/src/repair/comment-router-utils.ts
@@ -150,6 +150,16 @@ export function commentBodySha256(body: JsonValue) {
     .digest("hex");
 }
 
+export function exactCommentVersionMatchesLive(command: LooseRecord, live: JsonValue) {
+  if (!live || typeof live !== "object" || Array.isArray(live)) return false;
+  const comment = live as LooseRecord;
+  return (
+    String(comment.id ?? "") === String(command.comment_id ?? "") &&
+    String(comment.updated_at ?? "") === String(command.comment_updated_at ?? "") &&
+    commentBodySha256(comment.body) === String(command.comment_body_sha256 ?? "")
+  );
+}
+
 export function exactCommentVersionFastPathDecision({
   authenticated,
   sourceAction,

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -295,6 +295,7 @@ if (execute && exactCommentVersionFastPath.suppress && exactCommentVersionFastPa
   const versionStillCurrent = measure("verify_exact_comment_version_cleanup", () =>
     exactCommentVersionStillCurrent(exactCommentVersionFastPathCommand),
   );
+  if (versionStillCurrent) assertMutationActorIsClawsweeperBot();
   const ackConvergence = versionStillCurrent
     ? measure("converge_exact_comment_version_ack", () =>
         convergeExactCommentVersionFastPathAck(exactCommentVersionFastPathCommand, statusCommentId),
@@ -4300,6 +4301,7 @@ function convergeExactCommentVersionFastPathAck(command: LooseRecord, commentId:
     issueCommentsCache.delete(Number(command.issue_number));
     return "updated";
   } catch (error) {
+    if (/\b404\b|not found/i.test(ghErrorText(error))) return "already_converged";
     console.warn(
       `[comment-router] warning: exact comment acknowledgement convergence failed for ${command.repo}#${command.issue_number}: ${compactText(ghErrorText(error), 160)}`,
     );

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -90,9 +90,11 @@ import { mergeAutomergeTimelineSection } from "./automerge-status-timeline.js";
 import {
   SUPERSEDED_RE_REVIEW_REASON,
   appendLedger,
+  commentBodySha256,
   dispatchClaimDecision,
   dispatchClaimLookupKeys,
   dispatchReceiptKeyMaterial,
+  exactCommentVersionFastPathDecision,
   hasSuccessfulDispatchExecutionJob,
   issueNumberFromUrl,
   isAllowedMutationActor,
@@ -158,6 +160,20 @@ const {
 const startedAtMs = Date.now();
 const timings: LooseRecord[] = [];
 const ledger = readLedger(ledgerPath());
+const exactCommentVersionFastPath = exactCommentVersionFastPathDecision({
+  authenticated:
+    args["comment-event-auth"] === "github_webhook_v1" &&
+    args["source-event"] === "issue_comment" &&
+    isAllowedMutationActor(args["dispatch-actor"], trustedBots),
+  sourceAction: args["source-action"],
+  targetRepo,
+  commentId: commentIds.size === 1 ? [...commentIds][0] : null,
+  commentUpdatedAt: args["comment-updated-at"],
+  commentBodyDigest: args["comment-body-sha256"],
+  forceReprocess,
+  ledger,
+  verificationLedgers: exactCommentVersionVerificationLedgers(),
+});
 const priorDispatchClaims = new Map<string, LooseRecord>();
 for (const entry of ledger.commands ?? []) {
   if (entry.status !== "claimed") continue;
@@ -201,7 +217,9 @@ const openIssueNumbersByLabel = createCachedLabelNumberLookup((label) =>
     `repos/${targetRepo}/issues?state=open&labels=${encodeURIComponent(label)}&per_page=100`,
   ).map((issue: JsonValue) => issue.number),
 );
-const comments = measure("list_candidate_comments", () => listCandidateComments());
+const comments = measure("list_candidate_comments", () =>
+  exactCommentVersionFastPath.suppress ? [] : listCandidateComments(),
+);
 const rawCommands: LooseRecord[] = [];
 
 for (const comment of comments) {
@@ -224,6 +242,7 @@ for (const comment of comments) {
     author_association: String(comment.author_association ?? "").toUpperCase(),
     comment_created_at: comment.created_at,
     comment_updated_at: comment.updated_at,
+    comment_body_sha256: commentBodySha256(comment.body),
     status_comment_id:
       statusCommentId &&
       commentIds.size <= 1 &&
@@ -311,9 +330,11 @@ const report: LooseRecord = {
   max_auto_repairs_per_pr: maxAutoRepairsPerPr,
   lookup_concurrency: lookupConcurrency,
   commands,
+  exact_comment_version_fast_path: exactCommentVersionFastPath,
+  short_circuited: exactCommentVersionFastPath.suppress,
 };
 
-if (execute) {
+if (execute && !exactCommentVersionFastPath.suppress) {
   await measureAsync("execute_commands", async () => {
     assertMutationActorIsClawsweeperBot();
     const capacityRequests = workerCapacityRequests(actionable);
@@ -4486,6 +4507,14 @@ async function mapLimit<T, R>(
 
 function ledgerPath() {
   return path.join(repoRoot(), "results", "comment-router.json");
+}
+
+function exactCommentVersionVerificationLedgers() {
+  const stateDir = String(process.env.CLAWSWEEPER_STATE_DIR ?? "").trim();
+  if (!stateDir) return [];
+  const stateLedgerPath = path.join(path.resolve(stateDir), "results", "comment-router.json");
+  if (!fs.existsSync(stateLedgerPath)) return [];
+  return [readLedger(stateLedgerPath), readLedger(ledgerPath())];
 }
 
 function idempotencyKey(

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -236,10 +236,158 @@ const comments = measure("list_candidate_comments", () =>
 const rawCommands: LooseRecord[] = [];
 
 for (const comment of comments) {
+  const command = routedCommandForComment(comment);
+  if (command) rawCommands.push(command);
+}
+let supersededReReviewVersions = supersededReReviewCommentVersions(rawCommands);
+
+await measureAsync("prehydrate_comment_commands", () =>
+  prehydrateCommandLookups(rawCommands, { refreshIssueComments: true }),
+);
+const classifiedCommentCommands = measure("classify_comment_commands", () =>
+  rawCommands.map((command) => classifyCommand(command)),
+);
+for (const command of listRepairLoopSweepCommands(classifiedCommentCommands)) {
+  rawCommands.push(command);
+}
+
+const sweepCommands = rawCommands.slice(classifiedCommentCommands.length);
+await measureAsync("prehydrate_repair_loop_sweeps", () =>
+  prehydrateCommandLookups(sweepCommands, { refreshIssueComments: true }),
+);
+const commands = [
+  ...classifiedCommentCommands,
+  ...measure("classify_repair_loop_sweeps", () =>
+    sweepCommands.map((command) => classifyCommand(command)),
+  ),
+];
+
+let actionable = commands.filter((command: JsonValue) => command.status === "ready");
+const report: LooseRecord = {
+  status: execute ? "executed" : "dry_run",
+  generated_at: new Date().toISOString(),
+  repo: targetRepo,
+  repair_repo: repairRepo,
+  review_repo: reviewRepo,
+  since,
+  execute,
+  force_reprocess: forceReprocess,
+  max_comments: maxComments,
+  item_numbers: [...itemNumbers],
+  comment_ids: [...commentIds],
+  status_comment_id: statusCommentId,
+  max_autoclose_targets: maxAutocloseTargets,
+  scanned_comments: comments.length,
+  commands_seen: commands.length,
+  actionable: actionable.length,
+  trusted_bots: [...trustedBots],
+  allowed_repository_permissions: [...allowedRepositoryPermissions],
+  max_auto_repairs_per_head: maxAutoRepairsPerHead,
+  max_auto_repairs_per_pr: maxAutoRepairsPerPr,
+  lookup_concurrency: lookupConcurrency,
+  commands,
+  exact_comment_version_fast_path: exactCommentVersionFastPath,
+  short_circuited: exactCommentVersionFastPath.suppress,
+};
+
+if (execute && exactCommentVersionFastPath.suppress && exactCommentVersionFastPathCommand) {
+  const versionStillCurrent = measure("verify_exact_comment_version_cleanup", () =>
+    exactCommentVersionStillCurrent(exactCommentVersionFastPathCommand),
+  );
+  report.exact_comment_version_cleanup = versionStillCurrent ? "completed" : "skipped_source_drift";
+  if (versionStillCurrent) {
+    measure("cleanup_exact_comment_version", () => {
+      assertMutationActorIsClawsweeperBot();
+      cleanupTerminalCommentAck(exactCommentVersionFastPathCommand);
+      clearTerminalMaintainerCommandReaction(exactCommentVersionFastPathCommand);
+    });
+  } else {
+    exactCommentVersionFastPath = { suppress: false, reason: "cleanup_source_drift" };
+    const resumedComments = measure("list_candidate_comments_after_cleanup_drift", () =>
+      listCandidateComments(),
+    );
+    const resumedRawCommands = resumedComments
+      .map((comment) => routedCommandForComment(comment))
+      .filter((command): command is LooseRecord => Boolean(command));
+    rawCommands.push(...resumedRawCommands);
+    supersededReReviewVersions = supersededReReviewCommentVersions(rawCommands);
+    await measureAsync("prehydrate_cleanup_drift_commands", () =>
+      prehydrateCommandLookups(resumedRawCommands, { refreshIssueComments: true }),
+    );
+    const resumedClassified = measure("classify_cleanup_drift_commands", () =>
+      resumedRawCommands.map((command) => classifyCommand(command)),
+    );
+    const resumedSweepCommands = listRepairLoopSweepCommands(resumedClassified);
+    rawCommands.push(...resumedSweepCommands);
+    await measureAsync("prehydrate_cleanup_drift_sweeps", () =>
+      prehydrateCommandLookups(resumedSweepCommands, { refreshIssueComments: true }),
+    );
+    commands.push(
+      ...resumedClassified,
+      ...resumedSweepCommands.map((command) => classifyCommand(command)),
+    );
+    actionable = commands.filter((command: JsonValue) => command.status === "ready");
+    report.scanned_comments = Number(report.scanned_comments ?? 0) + resumedComments.length;
+    report.commands_seen = commands.length;
+    report.actionable = actionable.length;
+    report.exact_comment_version_fast_path = exactCommentVersionFastPath;
+    report.short_circuited = false;
+  }
+}
+
+if (execute && !exactCommentVersionFastPath.suppress) {
+  await measureAsync("execute_commands", async () => {
+    assertMutationActorIsClawsweeperBot();
+    const capacityRequests = workerCapacityRequests(actionable);
+    if (capacityRequests.length > 0) {
+      const capacities = capacityRequests.map((request) =>
+        waitForCapacity ? waitForLiveWorkerCapacity(request) : assertLiveWorkerCapacity(request),
+      );
+      report.live_worker_capacity_before_dispatch =
+        capacities.length === 1 ? capacities[0] : capacities;
+    }
+    report.ledger_claimed = measure("claim_dispatch_commands", () =>
+      claimDispatchCommands(actionable),
+    );
+    if (report.ledger_claimed) writeLedger(ledgerPath(), ledger);
+    for (const command of commands) convergePrecreatedCommandAckComments(command);
+    for (const command of commands) acknowledgeSkippedMaintainerCommand(command);
+    for (const command of actionable) executeCommand(command);
+  });
+  report.ledger_changed = measure("append_ledger", () => appendLedger(ledger, commands));
+  if (report.ledger_changed) writeLedger(ledgerPath(), ledger);
+}
+
+report.timings = {
+  total_ms: Date.now() - startedAtMs,
+  phases: timings,
+};
+if (writeReport) writeReportFile(repoRoot(), report);
+console.log(JSON.stringify(report, null, 2));
+
+function measure<T>(name: string, fn: () => T): T {
+  const start = Date.now();
+  try {
+    return fn();
+  } finally {
+    timings.push({ name, ms: Date.now() - start });
+  }
+}
+
+async function measureAsync<T>(name: string, fn: () => Promise<T>): Promise<T> {
+  const start = Date.now();
+  try {
+    return await fn();
+  } finally {
+    timings.push({ name, ms: Date.now() - start });
+  }
+}
+
+function routedCommandForComment(comment: JsonValue): LooseRecord | null {
   const parsed: LooseRecord = parseRoutedCommentCommand(comment, { trustedAuthors: trustedBots });
-  if (!parsed) continue;
+  if (!parsed) return null;
   const issueNumber = issueNumberFromUrl(comment.issue_url);
-  const command: LooseRecord = {
+  return {
     idempotency_key: idempotencyKey(parsed, issueNumber, comment.id, comment.updated_at),
     comment_id: String(comment.id),
     comment_version_key: commentVersionKey({
@@ -294,119 +442,6 @@ for (const comment of comments) {
     status: "pending",
     actions: [],
   };
-  rawCommands.push(command);
-}
-const supersededReReviewVersions = supersededReReviewCommentVersions(rawCommands);
-
-await measureAsync("prehydrate_comment_commands", () =>
-  prehydrateCommandLookups(rawCommands, { refreshIssueComments: true }),
-);
-const classifiedCommentCommands = measure("classify_comment_commands", () =>
-  rawCommands.map((command) => classifyCommand(command)),
-);
-for (const command of listRepairLoopSweepCommands(classifiedCommentCommands)) {
-  rawCommands.push(command);
-}
-
-const sweepCommands = rawCommands.slice(classifiedCommentCommands.length);
-await measureAsync("prehydrate_repair_loop_sweeps", () =>
-  prehydrateCommandLookups(sweepCommands, { refreshIssueComments: true }),
-);
-const commands = [
-  ...classifiedCommentCommands,
-  ...measure("classify_repair_loop_sweeps", () =>
-    sweepCommands.map((command) => classifyCommand(command)),
-  ),
-];
-
-const actionable = commands.filter((command: JsonValue) => command.status === "ready");
-const report: LooseRecord = {
-  status: execute ? "executed" : "dry_run",
-  generated_at: new Date().toISOString(),
-  repo: targetRepo,
-  repair_repo: repairRepo,
-  review_repo: reviewRepo,
-  since,
-  execute,
-  force_reprocess: forceReprocess,
-  max_comments: maxComments,
-  item_numbers: [...itemNumbers],
-  comment_ids: [...commentIds],
-  status_comment_id: statusCommentId,
-  max_autoclose_targets: maxAutocloseTargets,
-  scanned_comments: comments.length,
-  commands_seen: commands.length,
-  actionable: actionable.length,
-  trusted_bots: [...trustedBots],
-  allowed_repository_permissions: [...allowedRepositoryPermissions],
-  max_auto_repairs_per_head: maxAutoRepairsPerHead,
-  max_auto_repairs_per_pr: maxAutoRepairsPerPr,
-  lookup_concurrency: lookupConcurrency,
-  commands,
-  exact_comment_version_fast_path: exactCommentVersionFastPath,
-  short_circuited: exactCommentVersionFastPath.suppress,
-};
-
-if (execute && exactCommentVersionFastPath.suppress && exactCommentVersionFastPathCommand) {
-  const versionStillCurrent = measure("verify_exact_comment_version_cleanup", () =>
-    exactCommentVersionStillCurrent(exactCommentVersionFastPathCommand),
-  );
-  report.exact_comment_version_cleanup = versionStillCurrent ? "completed" : "skipped_source_drift";
-  if (versionStillCurrent) {
-    measure("cleanup_exact_comment_version", () => {
-      assertMutationActorIsClawsweeperBot();
-      cleanupTerminalCommentAck(exactCommentVersionFastPathCommand);
-      clearTerminalMaintainerCommandReaction(exactCommentVersionFastPathCommand);
-    });
-  }
-}
-
-if (execute && !exactCommentVersionFastPath.suppress) {
-  await measureAsync("execute_commands", async () => {
-    assertMutationActorIsClawsweeperBot();
-    const capacityRequests = workerCapacityRequests(actionable);
-    if (capacityRequests.length > 0) {
-      const capacities = capacityRequests.map((request) =>
-        waitForCapacity ? waitForLiveWorkerCapacity(request) : assertLiveWorkerCapacity(request),
-      );
-      report.live_worker_capacity_before_dispatch =
-        capacities.length === 1 ? capacities[0] : capacities;
-    }
-    report.ledger_claimed = measure("claim_dispatch_commands", () =>
-      claimDispatchCommands(actionable),
-    );
-    if (report.ledger_claimed) writeLedger(ledgerPath(), ledger);
-    for (const command of commands) convergePrecreatedCommandAckComments(command);
-    for (const command of commands) acknowledgeSkippedMaintainerCommand(command);
-    for (const command of actionable) executeCommand(command);
-  });
-  report.ledger_changed = measure("append_ledger", () => appendLedger(ledger, commands));
-  if (report.ledger_changed) writeLedger(ledgerPath(), ledger);
-}
-
-report.timings = {
-  total_ms: Date.now() - startedAtMs,
-  phases: timings,
-};
-if (writeReport) writeReportFile(repoRoot(), report);
-console.log(JSON.stringify(report, null, 2));
-
-function measure<T>(name: string, fn: () => T): T {
-  const start = Date.now();
-  try {
-    return fn();
-  } finally {
-    timings.push({ name, ms: Date.now() - start });
-  }
-}
-
-async function measureAsync<T>(name: string, fn: () => Promise<T>): Promise<T> {
-  const start = Date.now();
-  try {
-    return await fn();
-  } finally {
-    timings.push({ name, ms: Date.now() - start });
-  }
 }
 
 function claimDispatchCommands(commands: LooseRecord[]) {

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -160,7 +160,7 @@ const {
 const startedAtMs = Date.now();
 const timings: LooseRecord[] = [];
 const ledger = readLedger(ledgerPath());
-const exactCommentVersionFastPath = exactCommentVersionFastPathDecision({
+let exactCommentVersionFastPath = exactCommentVersionFastPathDecision({
   authenticated:
     args["comment-event-auth"] === "github_webhook_v1" &&
     args["source-event"] === "issue_comment" &&
@@ -174,6 +174,12 @@ const exactCommentVersionFastPath = exactCommentVersionFastPathDecision({
   ledger,
   verificationLedgers: exactCommentVersionVerificationLedgers(),
 });
+const exactCommentVersionFastPathCommand = exactCommentVersionFastPath.suppress
+  ? exactCommentVersionLedgerCommand(exactCommentVersionFastPath.commentVersionKey)
+  : null;
+if (exactCommentVersionFastPath.suppress && !exactCommentVersionFastPathCommand) {
+  exactCommentVersionFastPath = { suppress: false, reason: "state_drift" };
+}
 const priorDispatchClaims = new Map<string, LooseRecord>();
 for (const entry of ledger.commands ?? []) {
   if (entry.status !== "claimed") continue;
@@ -333,6 +339,14 @@ const report: LooseRecord = {
   exact_comment_version_fast_path: exactCommentVersionFastPath,
   short_circuited: exactCommentVersionFastPath.suppress,
 };
+
+if (execute && exactCommentVersionFastPath.suppress && exactCommentVersionFastPathCommand) {
+  measure("cleanup_exact_comment_version", () => {
+    assertMutationActorIsClawsweeperBot();
+    cleanupTerminalCommentAck(exactCommentVersionFastPathCommand);
+    clearTerminalMaintainerCommandReaction(exactCommentVersionFastPathCommand);
+  });
+}
 
 if (execute && !exactCommentVersionFastPath.suppress) {
   await measureAsync("execute_commands", async () => {
@@ -4193,6 +4207,15 @@ function convergePrecreatedCommandAckComments(command: LooseRecord) {
   }
 }
 
+function cleanupTerminalCommentAck(command: LooseRecord) {
+  const keep = convergePrecreatedCommandAckComments(command);
+  if (!keep || commandStatusMarkerFromBody(keep.body)) return;
+  const id = Number(keep.id ?? 0) || 0;
+  if (id <= 0) return;
+  ghBestEffort(["api", `repos/${command.repo}/issues/comments/${id}`, "--method", "DELETE"]);
+  issueCommentsCache.delete(Number(command.issue_number));
+}
+
 function convergePrecreatedCommandAckCommentsInner(command: LooseRecord) {
   const marker = commandAckMarkerForCommentId(command.comment_id);
   const comments = cachedIssueComments(command.issue_number).filter(
@@ -4515,6 +4538,13 @@ function exactCommentVersionVerificationLedgers() {
   const stateLedgerPath = path.join(path.resolve(stateDir), "results", "comment-router.json");
   if (!fs.existsSync(stateLedgerPath)) return [];
   return [readLedger(stateLedgerPath), readLedger(ledgerPath())];
+}
+
+function exactCommentVersionLedgerCommand(commentVersionKey: JsonValue) {
+  const matches = (Array.isArray(ledger.commands) ? ledger.commands : []).filter(
+    (entry: JsonValue) => entry?.comment_version_key === commentVersionKey,
+  );
+  return matches.length === 1 ? matches[0] : null;
 }
 
 function idempotencyKey(

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -95,6 +95,7 @@ import {
   dispatchClaimLookupKeys,
   dispatchReceiptKeyMaterial,
   exactCommentVersionFastPathDecision,
+  exactCommentVersionMatchesLive,
   hasSuccessfulDispatchExecutionJob,
   issueNumberFromUrl,
   isAllowedMutationActor,
@@ -341,11 +342,17 @@ const report: LooseRecord = {
 };
 
 if (execute && exactCommentVersionFastPath.suppress && exactCommentVersionFastPathCommand) {
-  measure("cleanup_exact_comment_version", () => {
-    assertMutationActorIsClawsweeperBot();
-    cleanupTerminalCommentAck(exactCommentVersionFastPathCommand);
-    clearTerminalMaintainerCommandReaction(exactCommentVersionFastPathCommand);
-  });
+  const versionStillCurrent = measure("verify_exact_comment_version_cleanup", () =>
+    exactCommentVersionStillCurrent(exactCommentVersionFastPathCommand),
+  );
+  report.exact_comment_version_cleanup = versionStillCurrent ? "completed" : "skipped_source_drift";
+  if (versionStillCurrent) {
+    measure("cleanup_exact_comment_version", () => {
+      assertMutationActorIsClawsweeperBot();
+      cleanupTerminalCommentAck(exactCommentVersionFastPathCommand);
+      clearTerminalMaintainerCommandReaction(exactCommentVersionFastPathCommand);
+    });
+  }
 }
 
 if (execute && !exactCommentVersionFastPath.suppress) {
@@ -4214,6 +4221,17 @@ function cleanupTerminalCommentAck(command: LooseRecord) {
   if (id <= 0) return;
   ghBestEffort(["api", `repos/${command.repo}/issues/comments/${id}`, "--method", "DELETE"]);
   issueCommentsCache.delete(Number(command.issue_number));
+}
+
+function exactCommentVersionStillCurrent(command: LooseRecord) {
+  try {
+    return exactCommentVersionMatchesLive(command, fetchIssueComment(command.comment_id));
+  } catch (error) {
+    console.warn(
+      `[comment-router] warning: exact comment cleanup verification failed for ${command.repo}#${command.issue_number}: ${compactText(ghErrorText(error), 160)}`,
+    );
+    return false;
+  }
 }
 
 function convergePrecreatedCommandAckCommentsInner(command: LooseRecord) {

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -42,6 +42,7 @@ import {
   buildAutomergeMergeArgs,
   buildAutomergeSquashMessage,
   commandHasAction,
+  commandResponseMarker,
   commandStatusMarkerFromBody,
   createCachedIssueCommentsLookup,
   createCachedIssueCommentsLookupAsync,
@@ -294,14 +295,18 @@ if (execute && exactCommentVersionFastPath.suppress && exactCommentVersionFastPa
   const versionStillCurrent = measure("verify_exact_comment_version_cleanup", () =>
     exactCommentVersionStillCurrent(exactCommentVersionFastPathCommand),
   );
-  report.exact_comment_version_ack = versionStillCurrent
+  const ackConvergence = versionStillCurrent
     ? measure("converge_exact_comment_version_ack", () =>
         convergeExactCommentVersionFastPathAck(exactCommentVersionFastPathCommand, statusCommentId),
       )
     : "skipped_source_drift";
+  report.exact_comment_version_ack = ackConvergence;
   report.exact_comment_version_cleanup = versionStillCurrent
     ? "skipped_shared_ownership"
     : "skipped_source_drift";
+  if (versionStillCurrent && exactCommentVersionAckFailed(ackConvergence)) {
+    throw new Error(`exact comment acknowledgement convergence failed: ${ackConvergence}`);
+  }
   if (!versionStillCurrent) {
     exactCommentVersionFastPath = { suppress: false, reason: "cleanup_source_drift" };
     const resumedComments = measure("list_candidate_comments_after_cleanup_drift", () =>
@@ -4272,13 +4277,17 @@ function convergeExactCommentVersionFastPathAck(command: LooseRecord, commentId:
   if (!Number.isInteger(id) || id <= 0) return "not_requested";
   try {
     const comment = fetchIssueComment(id);
-    if (!comment || !isTrustedStatusComment(comment)) return "skipped_untrusted";
+    if (!comment) return "already_converged";
+    if (!isTrustedStatusComment(comment)) return "skipped_untrusted";
     if (issueNumberFromUrl(comment.issue_url) !== Number(command.issue_number))
       return "skipped_item_mismatch";
     const ackMarker = commandAckMarkerForCommentId(command.comment_id);
     if (commandAckMarkerFromBody(comment.body) !== ackMarker) return "skipped_marker_mismatch";
     if (commandStatusMarkerFromBody(comment.body)) return "already_terminal";
-    const body = `${ackMarker}\n${renderResponse(command, replayedDispatchResult(command))}`;
+    const terminal = exactCommentVersionTerminalResponse(command, id);
+    const terminalBody =
+      String(terminal?.body ?? "").trim() || exactCommentVersionMissingTerminalBody(command);
+    const body = terminalBody.includes(ackMarker) ? terminalBody : `${ackMarker}\n${terminalBody}`;
     const payloadPath = writePayload(repoRoot(), `comment-router-fast-path-${id}`, { body });
     ghText([
       "api",
@@ -4298,24 +4307,37 @@ function convergeExactCommentVersionFastPathAck(command: LooseRecord, commentId:
   }
 }
 
-function replayedDispatchResult(command: LooseRecord) {
-  if (String(command.status ?? "") !== "executed") return null;
-  const action = (name: string) =>
-    (command.actions ?? []).find(
-      (candidate: JsonValue) =>
-        candidate?.action === name && ["executed", "active"].includes(String(candidate.status)),
-    );
-  const repair = action("dispatch_repair");
-  if (repair && REPAIR_INTENTS.has(String(command.intent ?? ""))) return repair;
-  const replayed: LooseRecord = {};
-  if (repair) replayed.repair = repair;
-  const clawsweeper = action("dispatch_clawsweeper") ?? action("dispatch_assist");
-  if (clawsweeper) replayed.clawsweeper = clawsweeper;
-  const autoclose = action("autoclose");
-  if (autoclose) replayed.autoclose = autoclose;
-  const merge = action("merge");
-  if (merge) replayed.merge = merge;
-  return Object.keys(replayed).length > 0 ? replayed : null;
+function exactCommentVersionTerminalResponse(command: LooseRecord, excludeId: number) {
+  const markerId = command.comment_version_key ?? command.comment_id;
+  return cachedIssueComments(command.issue_number)
+    .slice()
+    .reverse()
+    .find((comment: JsonValue) => {
+      if (Number(comment.id ?? 0) === excludeId || !isTrustedStatusComment(comment)) return false;
+      return hasCommandResponseMarker(comment.body, {
+        commentId: markerId,
+        intent: command.intent,
+        matchAnyHead: true,
+      });
+    });
+}
+
+function exactCommentVersionMissingTerminalBody(command: LooseRecord) {
+  return [
+    commandStatusMarker(command),
+    commandResponseMarker({
+      commentId: command.comment_version_key ?? command.comment_id,
+      intent: command.intent,
+      headSha: command.target?.head_sha ?? "na",
+    }),
+    "ClawSweeper already handled this exact command version.",
+    "",
+    "The original detailed response is no longer available. Run the command again for a fresh result.",
+  ].join("\n");
+}
+
+function exactCommentVersionAckFailed(result: string) {
+  return !["not_requested", "updated", "already_terminal", "already_converged"].includes(result);
 }
 
 function convergePrecreatedCommandAckCommentsInner(command: LooseRecord) {

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -180,6 +180,12 @@ const exactCommentVersionFastPathCommand = exactCommentVersionFastPath.suppress
   : null;
 if (exactCommentVersionFastPath.suppress && !exactCommentVersionFastPathCommand) {
   exactCommentVersionFastPath = { suppress: false, reason: "state_drift" };
+} else if (
+  exactCommentVersionFastPath.suppress &&
+  exactCommentVersionFastPathCommand &&
+  !exactCommentVersionStillCurrent(exactCommentVersionFastPathCommand)
+) {
+  exactCommentVersionFastPath = { suppress: false, reason: "source_drift" };
 }
 const priorDispatchClaims = new Map<string, LooseRecord>();
 for (const entry of ledger.commands ?? []) {

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -111,7 +111,7 @@ import {
   writePayload,
   writeReportFile,
 } from "./comment-router-utils.js";
-import { readCommentRouterConfig } from "./config.js";
+import { DEFAULT_TRUSTED_BOTS, readCommentRouterConfig } from "./config.js";
 import {
   ghBestEffort,
   ghErrorText,
@@ -302,12 +302,14 @@ if (execute && exactCommentVersionFastPath.suppress && exactCommentVersionFastPa
       )
     : "skipped_source_drift";
   report.exact_comment_version_ack = ackConvergence;
-  report.exact_comment_version_cleanup = versionStillCurrent
-    ? "skipped_shared_ownership"
-    : "skipped_source_drift";
   if (versionStillCurrent && exactCommentVersionAckFailed(ackConvergence)) {
     throw new Error(`exact comment acknowledgement convergence failed: ${ackConvergence}`);
   }
+  report.exact_comment_version_cleanup = versionStillCurrent
+    ? measure("clear_exact_comment_version_reaction", () =>
+        removeOwnCommentReaction(exactCommentVersionFastPathCommand, "eyes"),
+      )
+    : "skipped_source_drift";
   if (!versionStillCurrent) {
     exactCommentVersionFastPath = { suppress: false, reason: "cleanup_source_drift" };
     const resumedComments = measure("list_candidate_comments_after_cleanup_drift", () =>
@@ -4511,7 +4513,7 @@ function clearTerminalMaintainerCommandReaction(command: LooseRecord) {
 }
 
 function removeOwnCommentReaction(command: LooseRecord, content: string) {
-  if (!command.comment_id) return;
+  if (!command.comment_id) return "not_applicable";
   let reactions: LooseRecord[] = [];
   try {
     const fetched = ghJson<LooseRecord[]>(
@@ -4527,11 +4529,15 @@ function removeOwnCommentReaction(command: LooseRecord, content: string) {
     console.warn(
       `warning: failed to list ${content} reactions for comment ${command.comment_id}: ${message}`,
     );
-    return;
+    return "list_failed";
   }
 
+  let matched = false;
+  let removed = false;
+  let deleteFailed = false;
   for (const reaction of reactions) {
     if (!isOwnCommentReaction(reaction, content)) continue;
+    matched = true;
     try {
       ghText(
         [
@@ -4542,20 +4548,25 @@ function removeOwnCommentReaction(command: LooseRecord, content: string) {
         ],
         { attempts: 1 },
       );
+      removed = true;
     } catch (error) {
       const message = compactText(ghErrorText(error), 220);
       if (/\b404\b|not found/i.test(message)) continue;
+      deleteFailed = true;
       console.warn(
         `warning: failed to delete ${content} reaction ${reaction.id} from comment ${command.comment_id}: ${message}`,
       );
     }
   }
+  if (deleteFailed) return "delete_failed";
+  if (removed) return "removed";
+  return matched ? "already_absent" : "not_found";
 }
 
 function isOwnCommentReaction(reaction: LooseRecord, content: string) {
   if (String(reaction?.content ?? "").toLowerCase() !== content.toLowerCase()) return false;
   const login = String(reaction?.user?.login ?? "").toLowerCase();
-  return isAllowedMutationActor(login, trustedBots);
+  return isAllowedMutationActor(login, DEFAULT_TRUSTED_BOTS);
 }
 
 function ensureAutomergeLabel(repo: string) {

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -161,6 +161,7 @@ const {
 const startedAtMs = Date.now();
 const timings: LooseRecord[] = [];
 const ledger = readLedger(ledgerPath());
+const TARGET_LOOKUP_RETRY_ATTEMPTS = 3;
 let exactCommentVersionFastPath = exactCommentVersionFastPathDecision({
   authenticated:
     args["comment-event-auth"] === "github_webhook_v1" &&
@@ -192,7 +193,6 @@ for (const entry of ledger.commands ?? []) {
   if (entry.status !== "claimed") continue;
   for (const key of dispatchClaimLookupKeys(entry)) priorDispatchClaims.set(key, entry);
 }
-const TARGET_LOOKUP_RETRY_ATTEMPTS = 3;
 const processedCommentVersions = forceReprocess
   ? new Set()
   : new Set(
@@ -294,14 +294,10 @@ if (execute && exactCommentVersionFastPath.suppress && exactCommentVersionFastPa
   const versionStillCurrent = measure("verify_exact_comment_version_cleanup", () =>
     exactCommentVersionStillCurrent(exactCommentVersionFastPathCommand),
   );
-  report.exact_comment_version_cleanup = versionStillCurrent ? "completed" : "skipped_source_drift";
-  if (versionStillCurrent) {
-    measure("cleanup_exact_comment_version", () => {
-      assertMutationActorIsClawsweeperBot();
-      cleanupTerminalCommentAck(exactCommentVersionFastPathCommand);
-      clearTerminalMaintainerCommandReaction(exactCommentVersionFastPathCommand);
-    });
-  } else {
+  report.exact_comment_version_cleanup = versionStillCurrent
+    ? "skipped_shared_ownership"
+    : "skipped_source_drift";
+  if (!versionStillCurrent) {
     exactCommentVersionFastPath = { suppress: false, reason: "cleanup_source_drift" };
     const resumedComments = measure("list_candidate_comments_after_cleanup_drift", () =>
       listCandidateComments(),
@@ -4253,15 +4249,6 @@ function convergePrecreatedCommandAckComments(command: LooseRecord) {
     );
     return null;
   }
-}
-
-function cleanupTerminalCommentAck(command: LooseRecord) {
-  const keep = convergePrecreatedCommandAckComments(command);
-  if (!keep || commandStatusMarkerFromBody(keep.body)) return;
-  const id = Number(keep.id ?? 0) || 0;
-  if (id <= 0) return;
-  ghBestEffort(["api", `repos/${command.repo}/issues/comments/${id}`, "--method", "DELETE"]);
-  issueCommentsCache.delete(Number(command.issue_number));
 }
 
 function exactCommentVersionStillCurrent(command: LooseRecord) {

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -294,6 +294,11 @@ if (execute && exactCommentVersionFastPath.suppress && exactCommentVersionFastPa
   const versionStillCurrent = measure("verify_exact_comment_version_cleanup", () =>
     exactCommentVersionStillCurrent(exactCommentVersionFastPathCommand),
   );
+  report.exact_comment_version_ack = versionStillCurrent
+    ? measure("converge_exact_comment_version_ack", () =>
+        convergeExactCommentVersionFastPathAck(exactCommentVersionFastPathCommand, statusCommentId),
+      )
+    : "skipped_source_drift";
   report.exact_comment_version_cleanup = versionStillCurrent
     ? "skipped_shared_ownership"
     : "skipped_source_drift";
@@ -4260,6 +4265,57 @@ function exactCommentVersionStillCurrent(command: LooseRecord) {
     );
     return false;
   }
+}
+
+function convergeExactCommentVersionFastPathAck(command: LooseRecord, commentId: JsonValue) {
+  const id = Number(commentId ?? 0);
+  if (!Number.isInteger(id) || id <= 0) return "not_requested";
+  try {
+    const comment = fetchIssueComment(id);
+    if (!comment || !isTrustedStatusComment(comment)) return "skipped_untrusted";
+    if (issueNumberFromUrl(comment.issue_url) !== Number(command.issue_number))
+      return "skipped_item_mismatch";
+    const ackMarker = commandAckMarkerForCommentId(command.comment_id);
+    if (commandAckMarkerFromBody(comment.body) !== ackMarker) return "skipped_marker_mismatch";
+    if (commandStatusMarkerFromBody(comment.body)) return "already_terminal";
+    const body = `${ackMarker}\n${renderResponse(command, replayedDispatchResult(command))}`;
+    const payloadPath = writePayload(repoRoot(), `comment-router-fast-path-${id}`, { body });
+    ghText([
+      "api",
+      `repos/${command.repo}/issues/comments/${id}`,
+      "--method",
+      "PATCH",
+      "--input",
+      payloadPath,
+    ]);
+    issueCommentsCache.delete(Number(command.issue_number));
+    return "updated";
+  } catch (error) {
+    console.warn(
+      `[comment-router] warning: exact comment acknowledgement convergence failed for ${command.repo}#${command.issue_number}: ${compactText(ghErrorText(error), 160)}`,
+    );
+    return "failed";
+  }
+}
+
+function replayedDispatchResult(command: LooseRecord) {
+  if (String(command.status ?? "") !== "executed") return null;
+  const action = (name: string) =>
+    (command.actions ?? []).find(
+      (candidate: JsonValue) =>
+        candidate?.action === name && ["executed", "active"].includes(String(candidate.status)),
+    );
+  const repair = action("dispatch_repair");
+  if (repair && REPAIR_INTENTS.has(String(command.intent ?? ""))) return repair;
+  const replayed: LooseRecord = {};
+  if (repair) replayed.repair = repair;
+  const clawsweeper = action("dispatch_clawsweeper") ?? action("dispatch_assist");
+  if (clawsweeper) replayed.clawsweeper = clawsweeper;
+  const autoclose = action("autoclose");
+  if (autoclose) replayed.autoclose = autoclose;
+  const merge = action("merge");
+  if (merge) replayed.merge = merge;
+  return Object.keys(replayed).length > 0 ? replayed : null;
 }
 
 function convergePrecreatedCommandAckCommentsInner(command: LooseRecord) {

--- a/src/repair/comment-webhook.ts
+++ b/src/repair/comment-webhook.ts
@@ -137,12 +137,6 @@ export async function handleGitHubWebhook({
     itemNumber: accepted.itemNumber,
     sourceCommentId: accepted.commentId,
   });
-  await addReaction({
-    token: targetToken,
-    repo: accepted.targetRepo,
-    commentId: accepted.commentId,
-    content: "eyes",
-  });
   await dispatchCommentRouter({
     token: dispatchToken,
     targetRepo: accepted.targetRepo,
@@ -679,29 +673,6 @@ async function listFastAckComments({
   return comments;
 }
 
-async function addReaction({
-  token,
-  repo,
-  commentId,
-  content,
-}: {
-  token: string;
-  repo: string;
-  commentId: number;
-  content: string;
-}) {
-  try {
-    await githubFetch({
-      token,
-      path: `/repos/${repo}/issues/comments/${commentId}/reactions`,
-      method: "POST",
-      body: { content },
-    });
-  } catch (error) {
-    if (!/\b422\b|already exists/i.test(String(error))) throw error;
-  }
-}
-
 async function dispatchItemReview({
   token,
   accepted,
@@ -770,7 +741,6 @@ async function dispatchCommentRouter({
         comment_event_auth: "github_webhook_v1",
         ...(commentUpdatedAt ? { comment_updated_at: commentUpdatedAt } : {}),
         ...(commentBodyDigest ? { comment_body_sha256: commentBodyDigest } : {}),
-        max_comments: "1",
       },
     },
   });

--- a/src/repair/comment-webhook.ts
+++ b/src/repair/comment-webhook.ts
@@ -12,6 +12,7 @@ import {
 } from "./comment-router-core.js";
 import { adaptiveReviewBudgetForPullRequest } from "./adaptive-review-budget.js";
 import { isExactReviewCloseGuardLabel } from "./exact-review-guard-labels.js";
+import { commentBodySha256 } from "./comment-router-utils.js";
 
 const DEFAULT_PORT = 8787;
 const REVIEW_REPO = "openclaw/clawsweeper";
@@ -41,6 +42,8 @@ type AcceptedIssueCommentWebhook = {
   commentId: number;
   installationId: number;
   sourceAction: string;
+  commentUpdatedAt?: string;
+  commentBodySha256?: string;
 };
 
 type AcceptedItemWebhook = {
@@ -148,6 +151,8 @@ export async function handleGitHubWebhook({
     commentId: accepted.commentId,
     statusCommentId,
     sourceAction: accepted.sourceAction,
+    ...(accepted.commentUpdatedAt ? { commentUpdatedAt: accepted.commentUpdatedAt } : {}),
+    ...(accepted.commentBodySha256 ? { commentBodyDigest: accepted.commentBodySha256 } : {}),
   });
   settleFastAckComments({
     token: targetToken,
@@ -227,6 +232,7 @@ export function classifyIssueCommentWebhook({
   if (!Number.isInteger(installationId) || installationId <= 0) {
     return { accepted: false, reason: "missing installation id" };
   }
+  const commentUpdatedAt = exactWebhookTimestamp(comment.updated_at);
   return {
     accepted: true,
     type: "issue_comment",
@@ -236,7 +242,18 @@ export function classifyIssueCommentWebhook({
     commentId,
     installationId,
     sourceAction: String(payload.action ?? "created"),
+    ...(commentUpdatedAt
+      ? {
+          commentUpdatedAt,
+          commentBodySha256: commentBodySha256(comment.body),
+        }
+      : {}),
   };
+}
+
+function exactWebhookTimestamp(value: JsonValue) {
+  const text = String(value ?? "").trim();
+  return text && Number.isFinite(Date.parse(text)) ? text : null;
 }
 
 export function classifyItemWebhook({ event, payload }: { event: string; payload: LooseRecord }) {
@@ -723,6 +740,8 @@ async function dispatchCommentRouter({
   commentId,
   statusCommentId,
   sourceAction,
+  commentUpdatedAt,
+  commentBodyDigest,
 }: {
   token: string;
   targetRepo: string;
@@ -731,6 +750,8 @@ async function dispatchCommentRouter({
   commentId: number;
   statusCommentId: number;
   sourceAction: string;
+  commentUpdatedAt?: string;
+  commentBodyDigest?: string;
 }) {
   await githubFetch({
     token,
@@ -746,6 +767,9 @@ async function dispatchCommentRouter({
         status_comment_id: statusCommentId,
         source_event: "issue_comment",
         source_action: sourceAction,
+        comment_event_auth: "github_webhook_v1",
+        ...(commentUpdatedAt ? { comment_updated_at: commentUpdatedAt } : {}),
+        ...(commentBodyDigest ? { comment_body_sha256: commentBodyDigest } : {}),
         max_comments: "1",
       },
     },

--- a/src/repair/comment-webhook.ts
+++ b/src/repair/comment-webhook.ts
@@ -137,6 +137,12 @@ export async function handleGitHubWebhook({
     itemNumber: accepted.itemNumber,
     sourceCommentId: accepted.commentId,
   });
+  await addReaction({
+    token: targetToken,
+    repo: accepted.targetRepo,
+    commentId: accepted.commentId,
+    content: "eyes",
+  });
   await dispatchCommentRouter({
     token: dispatchToken,
     targetRepo: accepted.targetRepo,
@@ -671,6 +677,31 @@ async function listFastAckComments({
     if (response.length < 100) return comments;
   }
   return comments;
+}
+
+async function addReaction({
+  token,
+  repo,
+  commentId,
+  content,
+}: {
+  token: string;
+  repo: string;
+  commentId: number;
+  content: string;
+}) {
+  try {
+    await githubFetch({
+      token,
+      path: `/repos/${repo}/issues/comments/${commentId}/reactions`,
+      method: "POST",
+      body: { content },
+    });
+  } catch (error) {
+    if (!/\b422\b|already exists/i.test(String(error))) {
+      console.warn(`[clawsweeper webhook] comment reaction failed: ${String(error)}`);
+    }
+  }
 }
 
 async function dispatchItemReview({

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -5313,9 +5313,13 @@ test("hosted webhook reuses existing fast ack comments on redelivery", async () 
         comment_event_auth: "github_webhook_v1",
         comment_updated_at: "2026-07-12T20:00:00Z",
         comment_body_sha256: createHash("sha256").update("@clawsweeper status").digest("hex"),
-        max_comments: "1",
       },
     });
+    assert.equal(
+      Object.keys((dispatchBody as { client_payload: Record<string, unknown> }).client_payload)
+        .length,
+      10,
+    );
     await new Promise((resolve) => setTimeout(resolve, 0));
   } finally {
     globalThis.fetch = originalFetch;
@@ -5431,7 +5435,7 @@ test("hosted webhook coalesces concurrent duplicate fast ack comments", async ()
     assert.deepEqual(await leftResponse.json(), { ok: true, status_comment_id: 777 });
     assert.deepEqual(await rightResponse.json(), { ok: true, status_comment_id: 777 });
     assert.equal(fastAckPosts, 1);
-    assert.equal(reactions, 2);
+    assert.equal(reactions, 0);
     assert.equal(comments.length, 1);
     assert.match(comments[0]?.body || "", /clawsweeper-command-ack:456/);
     assert.equal(dispatchBodies.length, 2);
@@ -5555,9 +5559,12 @@ test("hosted webhook removes duplicate fast ack comments after concurrent redeli
         status_comment_id: 777,
         source_event: "issue_comment",
         source_action: "created",
-        max_comments: "1",
       },
     });
+    assert.ok(
+      Object.keys((dispatchBody as { client_payload: Record<string, unknown> }).client_payload)
+        .length <= 10,
+    );
     await new Promise((resolve) => setTimeout(resolve, 0));
   } finally {
     globalThis.fetch = originalFetch;

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { createHmac, generateKeyPairSync } from "node:crypto";
+import { createHash, createHmac, generateKeyPairSync } from "node:crypto";
 import test from "node:test";
 import { createContext, Script } from "node:vm";
 
@@ -5283,6 +5283,7 @@ test("hosted webhook reuses existing fast ack comments on redelivery", async () 
           comment: {
             id: 456,
             body: "@clawsweeper status",
+            updated_at: "2026-07-12T20:00:00Z",
             author_association: "OWNER",
             user: { login: "steipete" },
           },
@@ -5309,6 +5310,9 @@ test("hosted webhook reuses existing fast ack comments on redelivery", async () 
         status_comment_id: 777,
         source_event: "issue_comment",
         source_action: "created",
+        comment_event_auth: "github_webhook_v1",
+        comment_updated_at: "2026-07-12T20:00:00Z",
+        comment_body_sha256: createHash("sha256").update("@clawsweeper status").digest("hex"),
         max_comments: "1",
       },
     });

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -5435,7 +5435,7 @@ test("hosted webhook coalesces concurrent duplicate fast ack comments", async ()
     assert.deepEqual(await leftResponse.json(), { ok: true, status_comment_id: 777 });
     assert.deepEqual(await rightResponse.json(), { ok: true, status_comment_id: 777 });
     assert.equal(fastAckPosts, 1);
-    assert.equal(reactions, 0);
+    assert.equal(reactions, 2);
     assert.equal(comments.length, 1);
     assert.match(comments[0]?.body || "", /clawsweeper-command-ack:456/);
     assert.equal(dispatchBodies.length, 2);

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -2020,6 +2020,7 @@ test("exact comment fast path avoids shared terminal acknowledgement cleanup rac
   assert.match(cleanupBlock, /skipped_source_drift/);
   assert.match(cleanupBlock, /reason: "cleanup_source_drift"/);
   assert.match(cleanupBlock, /exactCommentVersionAckFailed\(ackConvergence\)/);
+  assert.match(cleanupBlock, /if \(versionStillCurrent\) assertMutationActorIsClawsweeperBot\(\)/);
   assert.match(cleanupBlock, /throw new Error/);
   assert.match(cleanupBlock, /list_candidate_comments_after_cleanup_drift/);
   assert.match(cleanupBlock, /prehydrate_cleanup_drift_commands/);
@@ -2048,6 +2049,7 @@ test("exact comment fast path avoids shared terminal acknowledgement cleanup rac
   assert.match(ackConvergence, /exactCommentVersionMissingTerminalBody\(command\)/);
   assert.match(ackConvergence, /commandResponseMarker\(\{/);
   assert.match(ackConvergence, /"--method",\s*"PATCH"/);
+  assert.match(ackConvergence, /\\b404\\b\|not found/);
   assert.doesNotMatch(ackConvergence, /renderResponse\(/);
   assert.doesNotMatch(ackConvergence, /"DELETE"/);
   assert.doesNotMatch(ackConvergence, /clearTerminalMaintainerCommandReaction/);

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -1991,11 +1991,16 @@ test("comment router durably claims dispatch commands and recovers exact workflo
 test("exact comment fast path preserves terminal acknowledgement cleanup", () => {
   const source = readFileSync("src/repair/comment-router.ts", "utf8");
   const cleanupBlock = source.slice(
-    source.indexOf('measure("cleanup_exact_comment_version"'),
+    source.indexOf('measure("verify_exact_comment_version_cleanup"'),
     source.indexOf("if (execute && !exactCommentVersionFastPath.suppress)"),
   );
 
   assert.match(cleanupBlock, /assertMutationActorIsClawsweeperBot\(\)/);
+  assert.match(
+    cleanupBlock,
+    /exactCommentVersionStillCurrent\(exactCommentVersionFastPathCommand\)/,
+  );
+  assert.match(cleanupBlock, /skipped_source_drift/);
   assert.match(cleanupBlock, /cleanupTerminalCommentAck\(exactCommentVersionFastPathCommand\)/);
   assert.match(
     cleanupBlock,

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -2014,6 +2014,12 @@ test("exact comment fast path preserves terminal acknowledgement cleanup", () =>
     /exactCommentVersionStillCurrent\(exactCommentVersionFastPathCommand\)/,
   );
   assert.match(cleanupBlock, /skipped_source_drift/);
+  assert.match(cleanupBlock, /reason: "cleanup_source_drift"/);
+  assert.match(cleanupBlock, /list_candidate_comments_after_cleanup_drift/);
+  assert.match(cleanupBlock, /prehydrate_cleanup_drift_commands/);
+  assert.match(cleanupBlock, /classify_cleanup_drift_commands/);
+  assert.match(cleanupBlock, /commands\.push/);
+  assert.match(cleanupBlock, /report\.short_circuited = false/);
   assert.match(cleanupBlock, /cleanupTerminalCommentAck\(exactCommentVersionFastPathCommand\)/);
   assert.match(
     cleanupBlock,

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -2019,6 +2019,8 @@ test("exact comment fast path avoids shared terminal acknowledgement cleanup rac
   assert.match(cleanupBlock, /skipped_shared_ownership/);
   assert.match(cleanupBlock, /skipped_source_drift/);
   assert.match(cleanupBlock, /reason: "cleanup_source_drift"/);
+  assert.match(cleanupBlock, /exactCommentVersionAckFailed\(ackConvergence\)/);
+  assert.match(cleanupBlock, /throw new Error/);
   assert.match(cleanupBlock, /list_candidate_comments_after_cleanup_drift/);
   assert.match(cleanupBlock, /prehydrate_cleanup_drift_commands/);
   assert.match(cleanupBlock, /classify_cleanup_drift_commands/);
@@ -2041,8 +2043,12 @@ test("exact comment fast path avoids shared terminal acknowledgement cleanup rac
   assert.match(ackConvergence, /issueNumberFromUrl\(comment\.issue_url\)/);
   assert.match(ackConvergence, /commandAckMarkerFromBody\(comment\.body\)/);
   assert.match(ackConvergence, /commandStatusMarkerFromBody\(comment\.body\)/);
-  assert.match(ackConvergence, /renderResponse\(command, replayedDispatchResult\(command\)\)/);
+  assert.match(ackConvergence, /exactCommentVersionTerminalResponse\(command, id\)/);
+  assert.match(ackConvergence, /hasCommandResponseMarker\(comment\.body/);
+  assert.match(ackConvergence, /exactCommentVersionMissingTerminalBody\(command\)/);
+  assert.match(ackConvergence, /commandResponseMarker\(\{/);
   assert.match(ackConvergence, /"--method",\s*"PATCH"/);
+  assert.doesNotMatch(ackConvergence, /renderResponse\(/);
   assert.doesNotMatch(ackConvergence, /"DELETE"/);
   assert.doesNotMatch(ackConvergence, /clearTerminalMaintainerCommandReaction/);
 });

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -1988,6 +1988,28 @@ test("comment router durably claims dispatch commands and recovers exact workflo
   assert.match(repairWorkflow, /dispatch_key:/);
 });
 
+test("exact comment fast path preserves terminal acknowledgement cleanup", () => {
+  const source = readFileSync("src/repair/comment-router.ts", "utf8");
+  const cleanupBlock = source.slice(
+    source.indexOf('measure("cleanup_exact_comment_version"'),
+    source.indexOf("if (execute && !exactCommentVersionFastPath.suppress)"),
+  );
+
+  assert.match(cleanupBlock, /assertMutationActorIsClawsweeperBot\(\)/);
+  assert.match(cleanupBlock, /cleanupTerminalCommentAck\(exactCommentVersionFastPathCommand\)/);
+  assert.match(
+    cleanupBlock,
+    /clearTerminalMaintainerCommandReaction\(exactCommentVersionFastPathCommand\)/,
+  );
+  const ackCleanup = source.slice(
+    source.indexOf("function cleanupTerminalCommentAck"),
+    source.indexOf("function convergePrecreatedCommandAckCommentsInner"),
+  );
+  assert.match(ackCleanup, /convergePrecreatedCommandAckComments\(command\)/);
+  assert.match(ackCleanup, /commandStatusMarkerFromBody\(keep\.body\)/);
+  assert.match(ackCleanup, /--method", "DELETE"/);
+});
+
 test("command receipt gates let the oldest same-key run proceed when a newer duplicate is pending", () => {
   const receiptGate = readFileSync("scripts/dispatch-receipt-owner.sh", "utf8");
 

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -1990,11 +1990,24 @@ test("comment router durably claims dispatch commands and recovers exact workflo
 
 test("exact comment fast path preserves terminal acknowledgement cleanup", () => {
   const source = readFileSync("src/repair/comment-router.ts", "utf8");
+  const preflightBlock = source.slice(
+    source.indexOf("const exactCommentVersionFastPathCommand"),
+    source.indexOf("const priorDispatchClaims"),
+  );
   const cleanupBlock = source.slice(
     source.indexOf('measure("verify_exact_comment_version_cleanup"'),
     source.indexOf("if (execute && !exactCommentVersionFastPath.suppress)"),
   );
 
+  assert.match(
+    preflightBlock,
+    /!exactCommentVersionStillCurrent\(exactCommentVersionFastPathCommand\)/,
+  );
+  assert.match(preflightBlock, /reason: "source_drift"/);
+  assert.ok(
+    source.indexOf("!exactCommentVersionStillCurrent(exactCommentVersionFastPathCommand)") <
+      source.indexOf('measure("list_candidate_comments"'),
+  );
   assert.match(cleanupBlock, /assertMutationActorIsClawsweeperBot\(\)/);
   assert.match(
     cleanupBlock,

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -1988,8 +1988,9 @@ test("comment router durably claims dispatch commands and recovers exact workflo
   assert.match(repairWorkflow, /dispatch_key:/);
 });
 
-test("exact comment fast path preserves terminal acknowledgement cleanup", () => {
+test("exact comment fast path avoids shared terminal acknowledgement cleanup races", () => {
   const source = readFileSync("src/repair/comment-router.ts", "utf8");
+  const retryConstant = source.indexOf("const TARGET_LOOKUP_RETRY_ATTEMPTS = 3");
   const preflightBlock = source.slice(
     source.indexOf("const exactCommentVersionFastPathCommand"),
     source.indexOf("const priorDispatchClaims"),
@@ -2003,16 +2004,17 @@ test("exact comment fast path preserves terminal acknowledgement cleanup", () =>
     preflightBlock,
     /!exactCommentVersionStillCurrent\(exactCommentVersionFastPathCommand\)/,
   );
+  assert.ok(retryConstant < source.indexOf("const exactCommentVersionFastPathCommand"));
   assert.match(preflightBlock, /reason: "source_drift"/);
   assert.ok(
     source.indexOf("!exactCommentVersionStillCurrent(exactCommentVersionFastPathCommand)") <
       source.indexOf('measure("list_candidate_comments"'),
   );
-  assert.match(cleanupBlock, /assertMutationActorIsClawsweeperBot\(\)/);
   assert.match(
     cleanupBlock,
     /exactCommentVersionStillCurrent\(exactCommentVersionFastPathCommand\)/,
   );
+  assert.match(cleanupBlock, /skipped_shared_ownership/);
   assert.match(cleanupBlock, /skipped_source_drift/);
   assert.match(cleanupBlock, /reason: "cleanup_source_drift"/);
   assert.match(cleanupBlock, /list_candidate_comments_after_cleanup_drift/);
@@ -2020,18 +2022,15 @@ test("exact comment fast path preserves terminal acknowledgement cleanup", () =>
   assert.match(cleanupBlock, /classify_cleanup_drift_commands/);
   assert.match(cleanupBlock, /commands\.push/);
   assert.match(cleanupBlock, /report\.short_circuited = false/);
-  assert.match(cleanupBlock, /cleanupTerminalCommentAck\(exactCommentVersionFastPathCommand\)/);
-  assert.match(
+  assert.doesNotMatch(
+    cleanupBlock,
+    /cleanupTerminalCommentAck\(exactCommentVersionFastPathCommand\)/,
+  );
+  assert.doesNotMatch(
     cleanupBlock,
     /clearTerminalMaintainerCommandReaction\(exactCommentVersionFastPathCommand\)/,
   );
-  const ackCleanup = source.slice(
-    source.indexOf("function cleanupTerminalCommentAck"),
-    source.indexOf("function convergePrecreatedCommandAckCommentsInner"),
-  );
-  assert.match(ackCleanup, /convergePrecreatedCommandAckComments\(command\)/);
-  assert.match(ackCleanup, /commandStatusMarkerFromBody\(keep\.body\)/);
-  assert.match(ackCleanup, /--method", "DELETE"/);
+  assert.doesNotMatch(source, /function cleanupTerminalCommentAck/);
 });
 
 test("command receipt gates let the oldest same-key run proceed when a newer duplicate is pending", () => {

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -2014,6 +2014,8 @@ test("exact comment fast path avoids shared terminal acknowledgement cleanup rac
     cleanupBlock,
     /exactCommentVersionStillCurrent\(exactCommentVersionFastPathCommand\)/,
   );
+  assert.match(cleanupBlock, /convergeExactCommentVersionFastPathAck\(/);
+  assert.match(cleanupBlock, /statusCommentId/);
   assert.match(cleanupBlock, /skipped_shared_ownership/);
   assert.match(cleanupBlock, /skipped_source_drift/);
   assert.match(cleanupBlock, /reason: "cleanup_source_drift"/);
@@ -2031,6 +2033,18 @@ test("exact comment fast path avoids shared terminal acknowledgement cleanup rac
     /clearTerminalMaintainerCommandReaction\(exactCommentVersionFastPathCommand\)/,
   );
   assert.doesNotMatch(source, /function cleanupTerminalCommentAck/);
+  const ackConvergence = source.slice(
+    source.indexOf("function convergeExactCommentVersionFastPathAck"),
+    source.indexOf("function convergePrecreatedCommandAckCommentsInner"),
+  );
+  assert.match(ackConvergence, /isTrustedStatusComment\(comment\)/);
+  assert.match(ackConvergence, /issueNumberFromUrl\(comment\.issue_url\)/);
+  assert.match(ackConvergence, /commandAckMarkerFromBody\(comment\.body\)/);
+  assert.match(ackConvergence, /commandStatusMarkerFromBody\(comment\.body\)/);
+  assert.match(ackConvergence, /renderResponse\(command, replayedDispatchResult\(command\)\)/);
+  assert.match(ackConvergence, /"--method",\s*"PATCH"/);
+  assert.doesNotMatch(ackConvergence, /"DELETE"/);
+  assert.doesNotMatch(ackConvergence, /clearTerminalMaintainerCommandReaction/);
 });
 
 test("command receipt gates let the oldest same-key run proceed when a newer duplicate is pending", () => {

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -1988,7 +1988,7 @@ test("comment router durably claims dispatch commands and recovers exact workflo
   assert.match(repairWorkflow, /dispatch_key:/);
 });
 
-test("exact comment fast path avoids shared terminal acknowledgement cleanup races", () => {
+test("exact comment fast path converges terminal acknowledgement before own reaction cleanup", () => {
   const source = readFileSync("src/repair/comment-router.ts", "utf8");
   const retryConstant = source.indexOf("const TARGET_LOOKUP_RETRY_ATTEMPTS = 3");
   const preflightBlock = source.slice(
@@ -2016,12 +2016,20 @@ test("exact comment fast path avoids shared terminal acknowledgement cleanup rac
   );
   assert.match(cleanupBlock, /convergeExactCommentVersionFastPathAck\(/);
   assert.match(cleanupBlock, /statusCommentId/);
-  assert.match(cleanupBlock, /skipped_shared_ownership/);
+  assert.match(cleanupBlock, /clear_exact_comment_version_reaction/);
+  assert.match(
+    cleanupBlock,
+    /removeOwnCommentReaction\(exactCommentVersionFastPathCommand,\s*"eyes"\)/,
+  );
   assert.match(cleanupBlock, /skipped_source_drift/);
   assert.match(cleanupBlock, /reason: "cleanup_source_drift"/);
   assert.match(cleanupBlock, /exactCommentVersionAckFailed\(ackConvergence\)/);
   assert.match(cleanupBlock, /if \(versionStillCurrent\) assertMutationActorIsClawsweeperBot\(\)/);
   assert.match(cleanupBlock, /throw new Error/);
+  assert.ok(
+    cleanupBlock.indexOf("exactCommentVersionAckFailed(ackConvergence)") <
+      cleanupBlock.indexOf('measure("clear_exact_comment_version_reaction"'),
+  );
   assert.match(cleanupBlock, /list_candidate_comments_after_cleanup_drift/);
   assert.match(cleanupBlock, /prehydrate_cleanup_drift_commands/);
   assert.match(cleanupBlock, /classify_cleanup_drift_commands/);
@@ -2053,6 +2061,15 @@ test("exact comment fast path avoids shared terminal acknowledgement cleanup rac
   assert.doesNotMatch(ackConvergence, /renderResponse\(/);
   assert.doesNotMatch(ackConvergence, /"DELETE"/);
   assert.doesNotMatch(ackConvergence, /clearTerminalMaintainerCommandReaction/);
+  const reactionCleanup = source.slice(
+    source.indexOf("function removeOwnCommentReaction"),
+    source.indexOf("function ensureAutomergeLabel"),
+  );
+  assert.match(reactionCleanup, /isOwnCommentReaction\(reaction, content\)/);
+  assert.match(reactionCleanup, /reactions\/\$\{reaction\.id\}/);
+  assert.match(reactionCleanup, /"--method",\s*"DELETE"/);
+  assert.match(reactionCleanup, /isAllowedMutationActor\(login, DEFAULT_TRUSTED_BOTS\)/);
+  assert.doesNotMatch(reactionCleanup, /isAllowedMutationActor\(login, trustedBots\)/);
 });
 
 test("command receipt gates let the oldest same-key run proceed when a newer duplicate is pending", () => {

--- a/test/repair/comment-router-utils.test.ts
+++ b/test/repair/comment-router-utils.test.ts
@@ -4,9 +4,11 @@ import test from "node:test";
 import {
   SUPERSEDED_RE_REVIEW_REASON,
   appendLedger,
+  commentBodySha256,
   dispatchClaimDecision,
   dispatchClaimLookupKeys,
   dispatchReceiptKeyMaterial,
+  exactCommentVersionFastPathDecision,
   hasSuccessfulDispatchExecutionJob,
   isGitHubAppIntegrationAuthError,
   isAllowedMutationActor,
@@ -17,6 +19,171 @@ import {
   supersededReReviewCommentVersions,
   summarizeChecks,
 } from "../../dist/repair/comment-router-utils.js";
+
+test("exact terminal comment versions short-circuit duplicate created deliveries", () => {
+  const body = "@clawsweeper re-review";
+  const ledger = exactVersionLedger({
+    status: "executed",
+    body,
+  });
+
+  assert.deepEqual(
+    exactCommentVersionFastPathDecision({
+      authenticated: true,
+      sourceAction: "created",
+      targetRepo: "openclaw/openclaw",
+      commentId: 456,
+      commentUpdatedAt: "2026-07-12T20:00:00Z",
+      commentBodyDigest: commentBodySha256(body),
+      forceReprocess: false,
+      ledger,
+      verificationLedgers: [structuredClone(ledger), structuredClone(ledger)],
+    }),
+    {
+      suppress: true,
+      reason: "exact_terminal_comment_version",
+      commentVersionKey: "456:2026-07-12T20:00:00Z",
+      status: "executed",
+    },
+  );
+});
+
+test("edited comments and changed body bytes always use the full router path", () => {
+  const ledger = exactVersionLedger({
+    status: "executed",
+    body: "@clawsweeper re-review",
+  });
+
+  assert.deepEqual(
+    exactCommentVersionFastPathDecision({
+      authenticated: true,
+      sourceAction: "edited",
+      targetRepo: "openclaw/openclaw",
+      commentId: 456,
+      commentUpdatedAt: "2026-07-12T20:01:00Z",
+      commentBodyDigest: commentBodySha256("@clawsweeper re-review with new context"),
+      forceReprocess: false,
+      ledger,
+      verificationLedgers: [structuredClone(ledger), structuredClone(ledger)],
+    }),
+    { suppress: false, reason: "edited_or_unknown_action" },
+  );
+  assert.deepEqual(
+    exactCommentVersionFastPathDecision({
+      authenticated: true,
+      sourceAction: "created",
+      targetRepo: "openclaw/openclaw",
+      commentId: 456,
+      commentUpdatedAt: "2026-07-12T20:00:00Z",
+      commentBodyDigest: commentBodySha256("@clawsweeper re-review with changed bytes"),
+      forceReprocess: false,
+      ledger,
+      verificationLedgers: [structuredClone(ledger), structuredClone(ledger)],
+    }),
+    { suppress: false, reason: "body_digest_mismatch" },
+  );
+});
+
+test("missing timestamps or authenticated provenance use the full router path", () => {
+  const ledger = exactVersionLedger({
+    status: "executed",
+    body: "@clawsweeper re-review",
+  });
+  const base = {
+    sourceAction: "created",
+    targetRepo: "openclaw/openclaw",
+    commentId: 456,
+    commentUpdatedAt: "2026-07-12T20:00:00Z",
+    commentBodyDigest: commentBodySha256("@clawsweeper re-review"),
+    forceReprocess: false,
+    ledger,
+    verificationLedgers: [structuredClone(ledger), structuredClone(ledger)],
+  };
+
+  assert.deepEqual(
+    exactCommentVersionFastPathDecision({
+      ...base,
+      authenticated: true,
+      commentUpdatedAt: null,
+    }),
+    { suppress: false, reason: "incomplete_exact_version" },
+  );
+  assert.deepEqual(
+    exactCommentVersionFastPathDecision({
+      ...base,
+      authenticated: false,
+    }),
+    { suppress: false, reason: "auth_uncertain" },
+  );
+});
+
+test("retryable claims and failed action leases are never short-circuited", () => {
+  for (const status of ["waiting", "claimed"]) {
+    const ledger = exactVersionLedger({
+      status,
+      body: "@clawsweeper re-review",
+      actions: [{ action: "dispatch_clawsweeper", status }],
+    });
+    assert.deepEqual(
+      exactCommentVersionFastPathDecision({
+        authenticated: true,
+        sourceAction: "created",
+        targetRepo: "openclaw/openclaw",
+        commentId: 456,
+        commentUpdatedAt: "2026-07-12T20:00:00Z",
+        commentBodyDigest: commentBodySha256("@clawsweeper re-review"),
+        forceReprocess: false,
+        ledger,
+        verificationLedgers: [structuredClone(ledger), structuredClone(ledger)],
+      }),
+      { suppress: false, reason: "version_retryable" },
+    );
+  }
+
+  const failedLedger = exactVersionLedger({
+    status: "executed",
+    body: "@clawsweeper re-review",
+    actions: [{ action: "dispatch_clawsweeper", status: "failed" }],
+  });
+  assert.deepEqual(
+    exactCommentVersionFastPathDecision({
+      authenticated: true,
+      sourceAction: "created",
+      targetRepo: "openclaw/openclaw",
+      commentId: 456,
+      commentUpdatedAt: "2026-07-12T20:00:00Z",
+      commentBodyDigest: commentBodySha256("@clawsweeper re-review"),
+      forceReprocess: false,
+      ledger: failedLedger,
+      verificationLedgers: [structuredClone(failedLedger), structuredClone(failedLedger)],
+    }),
+    { suppress: false, reason: "lease_uncertain" },
+  );
+});
+
+test("concurrent ledger changes fail closed to the full router path", () => {
+  const ledger = exactVersionLedger({
+    status: "executed",
+    body: "@clawsweeper re-review",
+  });
+  const changedLedger = structuredClone(ledger);
+  changedLedger.updated_at = "2026-07-12T20:01:00Z";
+
+  assert.deepEqual(
+    exactCommentVersionFastPathDecision({
+      authenticated: true,
+      sourceAction: "created",
+      targetRepo: "openclaw/openclaw",
+      commentId: 456,
+      commentUpdatedAt: "2026-07-12T20:00:00Z",
+      commentBodyDigest: commentBodySha256("@clawsweeper re-review"),
+      forceReprocess: false,
+      ledger,
+      verificationLedgers: [structuredClone(ledger), changedLedger],
+    }),
+    { suppress: false, reason: "state_drift" },
+  );
+});
 
 test("synthetic dispatch claims retain a stable idempotency lookup across router runs", () => {
   const idempotencyKey = "repair-loop-label-sweep:openclaw/openclaw:automerge:74499";
@@ -552,6 +719,7 @@ test("appendLedger reports compact executed writes", () => {
         comment_id: "125",
         comment_version_key: "125:2026-04-29T03:01:00Z",
         comment_updated_at: "2026-04-29T03:01:00Z",
+        comment_body_sha256: commentBodySha256("@clawsweeper re-review"),
         status: "executed",
         intent: "clawsweeper_re_review",
         issue_number: 74499,
@@ -562,6 +730,7 @@ test("appendLedger reports compact executed writes", () => {
   );
 
   assert.equal(ledger.commands.length, 1);
+  assert.equal(ledger.commands[0].comment_body_sha256, commentBodySha256("@clawsweeper re-review"));
 });
 
 test("appendLedger preserves maintainer identity fields for automerge attribution", () => {
@@ -622,6 +791,32 @@ test("appendLedger preserves compact executed actions for repair caps", () => {
     },
   ]);
 });
+
+function exactVersionLedger({
+  status,
+  body,
+  actions = [],
+}: {
+  status: string;
+  body: string;
+  actions?: Array<Record<string, string>>;
+}) {
+  return {
+    updated_at: "2026-07-12T20:00:01Z",
+    commands: [
+      {
+        repo: "openclaw/openclaw",
+        comment_id: "456",
+        comment_version_key: "456:2026-07-12T20:00:00Z",
+        comment_updated_at: "2026-07-12T20:00:00Z",
+        comment_body_sha256: commentBodySha256(body),
+        status,
+        intent: "re_review",
+        actions,
+      },
+    ],
+  };
+}
 
 test("sortCommentsForRouting prioritizes edited durable review comments", () => {
   const sorted = sortCommentsForRouting([

--- a/test/repair/comment-router-utils.test.ts
+++ b/test/repair/comment-router-utils.test.ts
@@ -9,6 +9,7 @@ import {
   dispatchClaimLookupKeys,
   dispatchReceiptKeyMaterial,
   exactCommentVersionFastPathDecision,
+  exactCommentVersionMatchesLive,
   hasSuccessfulDispatchExecutionJob,
   isGitHubAppIntegrationAuthError,
   isAllowedMutationActor,
@@ -81,6 +82,32 @@ test("edited comments and changed body bytes always use the full router path", (
       verificationLedgers: [structuredClone(ledger), structuredClone(ledger)],
     }),
     { suppress: false, reason: "body_digest_mismatch" },
+  );
+});
+
+test("terminal cleanup requires the same live comment version", () => {
+  const body = "@clawsweeper re-review";
+  const command = {
+    comment_id: "456",
+    comment_updated_at: "2026-07-12T20:00:00Z",
+    comment_body_sha256: commentBodySha256(body),
+  };
+
+  assert.equal(
+    exactCommentVersionMatchesLive(command, {
+      id: 456,
+      updated_at: "2026-07-12T20:00:00Z",
+      body,
+    }),
+    true,
+  );
+  assert.equal(
+    exactCommentVersionMatchesLive(command, {
+      id: 456,
+      updated_at: "2026-07-12T20:01:00Z",
+      body: `${body} now`,
+    }),
+    false,
   );
 });
 

--- a/test/repair/comment-webhook.test.ts
+++ b/test/repair/comment-webhook.test.ts
@@ -256,6 +256,8 @@ test("comment webhook still accepts post-close re-review commands for router res
     commentId: 456,
     installationId: 123,
     sourceAction: "created",
+    commentUpdatedAt: "2026-05-19T05:03:00Z",
+    commentBodySha256: crypto.createHash("sha256").update("@clawsweeper re-review").digest("hex"),
   });
 });
 
@@ -678,6 +680,7 @@ test("concurrent duplicate command webhooks converge on one fast ack comment", a
   let nextCommentId = 9001;
   let fastAckPosts = 0;
   let dispatches = 0;
+  const dispatchBodies: Array<Record<string, unknown>> = [];
   process.env.CLAWSWEEPER_APP_ID = "12345";
   delete process.env.CLAWSWEEPER_APP_CLIENT_ID;
   process.env.CLAWSWEEPER_FAST_ACK_SETTLE_DELAYS_MS = "0,0,0";
@@ -718,6 +721,7 @@ test("concurrent duplicate command webhooks converge on one fast ack comment", a
     }
     if (path === "/repos/openclaw/clawsweeper/dispatches" && method === "POST") {
       dispatches += 1;
+      dispatchBodies.push(JSON.parse(String(init?.body ?? "{}")));
       return jsonResponse({});
     }
     if (path.startsWith("/repos/openclaw/openclaw/issues/comments/") && method === "DELETE") {
@@ -738,6 +742,7 @@ test("concurrent duplicate command webhooks converge on one fast ack comment", a
       comment: {
         id: 456,
         body: "@clawsweeper re-review",
+        updated_at: "2026-07-12T20:00:00Z",
         author_association: "MEMBER",
         user: { login: "user" },
       },
@@ -751,6 +756,25 @@ test("concurrent duplicate command webhooks converge on one fast ack comment", a
     assert.deepEqual(right, { statusCode: 202, body: { ok: true, status_comment_id: 9001 } });
     assert.equal(fastAckPosts, 1);
     assert.equal(dispatches, 2);
+    assert.deepEqual(
+      dispatchBodies.map((body) => body.client_payload),
+      Array.from({ length: 2 }, () => ({
+        target_repo: "openclaw/openclaw",
+        target_branch: "main",
+        item_number: 71898,
+        comment_id: 456,
+        status_comment_id: 9001,
+        source_event: "issue_comment",
+        source_action: "created",
+        comment_event_auth: "github_webhook_v1",
+        comment_updated_at: "2026-07-12T20:00:00Z",
+        comment_body_sha256: crypto
+          .createHash("sha256")
+          .update("@clawsweeper re-review")
+          .digest("hex"),
+        max_comments: "1",
+      })),
+    );
     assert.equal(comments.length, 1);
     assert.match(comments[0]?.body ?? "", /clawsweeper-command-ack:456/);
     await new Promise((resolve) => setTimeout(resolve, 0));

--- a/test/repair/comment-webhook.test.ts
+++ b/test/repair/comment-webhook.test.ts
@@ -679,6 +679,7 @@ test("concurrent duplicate command webhooks converge on one fast ack comment", a
     [];
   let nextCommentId = 9001;
   let fastAckPosts = 0;
+  let reactions = 0;
   let dispatches = 0;
   const dispatchBodies: Array<Record<string, unknown>> = [];
   process.env.CLAWSWEEPER_APP_ID = "12345";
@@ -717,6 +718,7 @@ test("concurrent duplicate command webhooks converge on one fast ack comment", a
       return jsonResponse(comment);
     }
     if (path === "/repos/openclaw/openclaw/issues/comments/456/reactions" && method === "POST") {
+      reactions += 1;
       return jsonResponse({ id: 1 });
     }
     if (path === "/repos/openclaw/clawsweeper/dispatches" && method === "POST") {
@@ -755,6 +757,7 @@ test("concurrent duplicate command webhooks converge on one fast ack comment", a
     assert.deepEqual(left, { statusCode: 202, body: { ok: true, status_comment_id: 9001 } });
     assert.deepEqual(right, { statusCode: 202, body: { ok: true, status_comment_id: 9001 } });
     assert.equal(fastAckPosts, 1);
+    assert.equal(reactions, 0);
     assert.equal(dispatches, 2);
     assert.deepEqual(
       dispatchBodies.map((body) => body.client_payload),
@@ -772,8 +775,12 @@ test("concurrent duplicate command webhooks converge on one fast ack comment", a
           .createHash("sha256")
           .update("@clawsweeper re-review")
           .digest("hex"),
-        max_comments: "1",
       })),
+    );
+    assert.ok(
+      dispatchBodies.every(
+        (body) => Object.keys(body.client_payload as Record<string, unknown>).length <= 10,
+      ),
     );
     assert.equal(comments.length, 1);
     assert.match(comments[0]?.body ?? "", /clawsweeper-command-ack:456/);

--- a/test/repair/comment-webhook.test.ts
+++ b/test/repair/comment-webhook.test.ts
@@ -757,7 +757,7 @@ test("concurrent duplicate command webhooks converge on one fast ack comment", a
     assert.deepEqual(left, { statusCode: 202, body: { ok: true, status_comment_id: 9001 } });
     assert.deepEqual(right, { statusCode: 202, body: { ok: true, status_comment_id: 9001 } });
     assert.equal(fastAckPosts, 1);
-    assert.equal(reactions, 0);
+    assert.equal(reactions, 2);
     assert.equal(dispatches, 2);
     assert.deepEqual(
       dispatchBodies.map((body) => body.client_payload),

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1351,6 +1351,12 @@ test("comment commands keep the router-to-sweep dispatch contract", () => {
     /status_comment_id="\$\{\{ github\.event\.client_payload\.status_comment_id \|\| '' \}\}"/,
   );
   assert.match(routerWorkflow, /--status-comment-id "\$status_comment_id"/);
+  assert.match(routerWorkflow, /dispatch_actor="\$\{\{ github\.actor \}\}"/);
+  assert.match(routerWorkflow, /--dispatch-actor "\$dispatch_actor"/);
+  assert.match(routerWorkflow, /--comment-event-auth "\$comment_event_auth"/);
+  assert.match(routerWorkflow, /--comment-updated-at "\$comment_updated_at"/);
+  assert.match(routerWorkflow, /--comment-body-sha256 "\$comment_body_sha256"/);
+  assert.match(routerWorkflow, /\.short_circuited == true/);
   assert.match(routerSource, /event_type:\s*"clawsweeper_item"/);
   assert.match(routerSource, /adaptiveReviewBudgetForPullRequest\(command\.target\)/);
   assert.match(routerSource, /media_proof_timeout_ms: reviewBudget\.mediaProofTimeoutMs/);


### PR DESCRIPTION
## Summary

- forward authenticated comment version metadata through both webhook paths
- skip duplicate terminal comment deliveries only after durable and live-source verification
- preserve normal routing when the source version drifts or any proof is incomplete

## Validation

- 158 focused comment-router, webhook, dashboard, and workflow tests
- TypeScript, lint, format, and diff checks
- local ClawSweeper committed-range review: no actionable findings

## Risk

Automation behavior changes are fail-open: uncertain or edited comments continue through the existing full router path.