### PR TITLE
perf(review): add structural review cache

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1906,6 +1906,7 @@ jobs:
           name: review-shard-${{ matrix.shard }}
           path: |
             review-artifacts/shard-${{ matrix.shard }}/*.md
+            review-artifacts/shard-${{ matrix.shard }}/review-cache-metrics.json
           if-no-files-found: ignore
 
       - uses: actions/upload-artifact@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 - Expanded stale-insufficient-info issue handling to materially outdated reports with no current-version confirmation for 60 days, and counted live merge conflicts as an abandoned-PR stalled state.
 - Upgraded Codex review and repair workers to GPT-5.6 Sol with high reasoning, invalidating cached reviews from the prior model policy.
+- Added a fail-closed structural review cache that can reuse unchanged scheduled keep-open verdicts before comments, timelines, diffs, and commits are hydrated, with per-run savings metrics and the existing full-content cache retained as a second stage.
 - Raised durable exact-review admission from 20 to 28 global leases and from 16 to 24 leases per target while preserving four slots for other repositories.
 - Redesigned the live dashboard and triage pages: an editorial status headline, borderless stat ticker, pipeline stepper, single capacity bar, and dense worker rows replace the boxed card layout, with a warm theme that follows the system light/dark preference, one lobster-coral accent, quiet outline pills, GitHub label colors as neutral dot-pills, and emoji-free metric and section labels.
 - Reused unchanged scheduled keep-open reviews for up to 14 days while forcing fresh reviews after content, policy, target-head, or human-activity changes and before any close promotion. Thanks @yetval.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 - Expanded stale-insufficient-info issue handling to materially outdated reports with no current-version confirmation for 60 days, and counted live merge conflicts as an abandoned-PR stalled state.
 - Upgraded Codex review and repair workers to GPT-5.6 Sol with high reasoning, invalidating cached reviews from the prior model policy.
-- Added a fail-closed structural review cache that can reuse unchanged scheduled keep-open verdicts before comments, timelines, diffs, and commits are hydrated, with per-run savings metrics and the existing full-content cache retained as a second stage.
+- Added a fail-closed structural review cache that can reuse unchanged scheduled keep-open verdicts before comments, timelines, diffs, and commits are hydrated, with same-second human edit detection, complete hydrated PR-state binding, per-run savings metrics, and the existing full-content cache retained as a second stage.
 - Raised durable exact-review admission from 20 to 28 global leases and from 16 to 24 leases per target while preserving four slots for other repositories.
 - Redesigned the live dashboard and triage pages: an editorial status headline, borderless stat ticker, pipeline stepper, single capacity bar, and dense worker rows replace the boxed card layout, with a warm theme that follows the system light/dark preference, one lobster-coral accent, quiet outline pills, GitHub label colors as neutral dot-pills, and emoji-free metric and section labels.
 - Reused unchanged scheduled keep-open reviews for up to 14 days while forcing fresh reviews after content, policy, target-head, or human-activity changes and before any close promotion. Thanks @yetval.

--- a/docs/review-cache.md
+++ b/docs/review-cache.md
@@ -1,0 +1,43 @@
+# Review Cache
+
+Scheduled keep-open reviews use two independent cache stages.
+
+## Structural Stage
+
+Before ClawSweeper creates a review lease or hydrates full GitHub context, it
+loads bounded metadata for the selected item. The metadata record contains only
+digests, timestamps, item identifiers, and commit SHAs. Bodies and comment text
+are never persisted.
+
+A structural hit requires all of the following:
+
+- the prior review completed with an original keep-open verdict;
+- the review is less than 14 days old;
+- the review policy and public model are unchanged;
+- the item kind and bounded source revision are unchanged;
+- human issue comments, bounded timeline events, PR reviews, review threads,
+  and linked-item metadata are unchanged and complete;
+- the target branch head is unchanged;
+- a PR head is unchanged; and
+- any item activity timestamp change is covered by the recorded ClawSweeper
+  comment or label synchronization boundary.
+
+Explicit reviews, maintainer prompts, close verdicts, failed reviews, legacy
+records, truncated metadata, malformed API responses, and probe failures always
+continue to full hydration.
+
+## Content Stage
+
+When the structural stage misses, ClawSweeper hydrates the normal comments,
+timeline, relations, PR files, commits, and review comments. The existing
+content digest may still reuse an unchanged keep-open verdict after that full
+context is proven.
+
+Neither cache stage can promote a report to close.
+
+## Metrics
+
+Each review run writes `review-cache-metrics.json` in its artifact directory.
+It reports structural checks, hits, probe failures, probe time, miss reasons,
+content-cache hits, and full hydration count. The final review log emits the
+same high-level counters.

--- a/docs/review-cache.md
+++ b/docs/review-cache.md
@@ -15,8 +15,9 @@ A structural hit requires all of the following:
 - the prior review completed with an original keep-open verdict;
 - the review is less than 14 days old;
 - the review policy and public model are unchanged;
-- the item kind and bounded source revision are unchanged, and the post-hydration
-  probe matches the hydrated title, body, labels, and human comments exactly;
+- the item kind and bounded source revision are unchanged across probes taken
+  immediately before and after hydration, and the post-hydration probe matches
+  the hydrated title, body, labels, and human comments exactly;
 - human issue comments, bounded timeline events, PR reviews, review threads,
   and linked-item metadata are unchanged and complete;
 - no explicit relation, matching local report, Gitcrawl cluster member, or
@@ -30,6 +31,13 @@ A structural hit requires all of the following:
 Explicit reviews, maintainer prompts, close verdicts, failed reviews, legacy
 records, truncated metadata, malformed API responses, and probe failures always
 continue to full hydration.
+
+ClawSweeper evaluates those cheap eligibility conditions before issuing the
+bounded GraphQL query. Eligible legacy reports may still be probed so a
+structural record can be seeded after hydration. A record is seeded only when
+the pre-hydration and post-hydration snapshots describe the same complete
+timeline, review, and review-thread input; the final verdict probe must match
+that anchor again.
 
 Before carrying a structural hit, ClawSweeper acquires the normal durable review
 lease for the unchanged PR head or issue source revision. Missing coordination,

--- a/docs/review-cache.md
+++ b/docs/review-cache.md
@@ -5,8 +5,10 @@ Scheduled keep-open reviews use two independent cache stages.
 ## Structural Stage
 
 Before ClawSweeper hydrates full GitHub context, it loads bounded metadata for
-the selected item. The metadata record contains only digests, timestamps, item
-identifiers, and commit SHAs. Bodies and comment text are never persisted.
+the selected item. It inspects bounded item, comment, and review-comment bodies
+only for same-repository relation links; body text is never persisted. The
+metadata record contains only digests, booleans, timestamps, item identifiers,
+and commit SHAs.
 
 A structural hit requires all of the following:
 
@@ -16,6 +18,8 @@ A structural hit requires all of the following:
 - the item kind and bounded source revision are unchanged;
 - human issue comments, bounded timeline events, PR reviews, review threads,
   and linked-item metadata are unchanged and complete;
+- no explicit relation, matching local report, Gitcrawl cluster member, or
+  enabled GitHub related-item search result can contribute review context;
 - the target branch head is unchanged;
 - a PR head is unchanged; and
 - any item activity timestamp change is covered by the recorded ClawSweeper

--- a/docs/review-cache.md
+++ b/docs/review-cache.md
@@ -15,7 +15,8 @@ A structural hit requires all of the following:
 - the prior review completed with an original keep-open verdict;
 - the review is less than 14 days old;
 - the review policy and public model are unchanged;
-- the item kind and bounded source revision are unchanged;
+- the item kind and bounded source revision are unchanged, and the post-hydration
+  probe matches the hydrated title, body, labels, and human comments exactly;
 - human issue comments, bounded timeline events, PR reviews, review threads,
   and linked-item metadata are unchanged and complete;
 - no explicit relation, matching local report, Gitcrawl cluster member, or

--- a/docs/review-cache.md
+++ b/docs/review-cache.md
@@ -4,10 +4,9 @@ Scheduled keep-open reviews use two independent cache stages.
 
 ## Structural Stage
 
-Before ClawSweeper creates a review lease or hydrates full GitHub context, it
-loads bounded metadata for the selected item. The metadata record contains only
-digests, timestamps, item identifiers, and commit SHAs. Bodies and comment text
-are never persisted.
+Before ClawSweeper hydrates full GitHub context, it loads bounded metadata for
+the selected item. The metadata record contains only digests, timestamps, item
+identifiers, and commit SHAs. Bodies and comment text are never persisted.
 
 A structural hit requires all of the following:
 
@@ -25,6 +24,10 @@ A structural hit requires all of the following:
 Explicit reviews, maintainer prompts, close verdicts, failed reviews, legacy
 records, truncated metadata, malformed API responses, and probe failures always
 continue to full hydration.
+
+Before carrying a structural hit, ClawSweeper acquires the normal durable review
+lease for the unchanged PR head or issue source revision. Missing coordination,
+an incomplete lease tuple, or a concurrent review always disables reuse.
 
 ## Content Stage
 

--- a/docs/review-cache.md
+++ b/docs/review-cache.md
@@ -28,6 +28,8 @@ continue to full hydration.
 Before carrying a structural hit, ClawSweeper acquires the normal durable review
 lease for the unchanged PR head or issue source revision. Missing coordination,
 an incomplete lease tuple, or a concurrent review always disables reuse.
+ClawSweeper then repeats the bounded probe under that lease; any intervening
+non-ClawSweeper activity forces full hydration.
 
 ## Content Stage
 
@@ -42,5 +44,5 @@ Neither cache stage can promote a report to close.
 
 Each review run writes `review-cache-metrics.json` in its artifact directory.
 It reports structural checks, hits, probe failures, probe time, miss reasons,
-content-cache hits, and full hydration count. The final review log emits the
-same high-level counters.
+post-lease revalidation results, content-cache hits, and full hydration count.
+The final review log emits the same high-level counters.

--- a/docs/review-cache.md
+++ b/docs/review-cache.md
@@ -21,7 +21,8 @@ A structural hit requires all of the following:
 - no explicit relation, matching local report, Gitcrawl cluster member, or
   enabled GitHub related-item search result can contribute review context;
 - the target branch head is unchanged;
-- a PR head is unchanged; and
+- the complete hydrated PR state is unchanged, including head and base SHAs,
+  draft and mergeability state, diff counts, and commit count; and
 - any item activity timestamp change is covered by the recorded ClawSweeper
   comment or label synchronization boundary.
 

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -5362,18 +5362,22 @@ function sqliteScalarBestEffort(dbPath: string, sql: string): string | null {
 }
 
 function sqliteJsonBestEffort(dbPath: string, sql: string): unknown[] {
+  return sqliteJsonProbe(dbPath, sql) ?? [];
+}
+
+function sqliteJsonProbe(dbPath: string, sql: string): unknown[] | null {
   const result = spawnSync("sqlite3", ["-json", dbPath, sql], {
     cwd: ROOT,
     encoding: "utf8",
     maxBuffer: 16 * 1024 * 1024,
     timeout: 10_000,
   });
-  if (result.error || result.status !== 0) return [];
+  if (result.error || result.status !== 0) return null;
   try {
     const parsed = JSON.parse(result.stdout.trim() || "[]") as unknown;
-    return Array.isArray(parsed) ? parsed : [];
+    return Array.isArray(parsed) ? parsed : null;
   } catch {
-    return [];
+    return null;
   }
 }
 
@@ -5548,6 +5552,55 @@ function compactRelatedGitcrawlItems(item: Item, seen: ReadonlySet<number>): unk
         body: truncateText(typeof row.body === "string" ? row.body : "", 800),
       },
     }));
+}
+
+function structuralExternalRelationSensitivity(item: Item): boolean | null {
+  const seen = new Set<number>([item.number]);
+  if (compactLocalRelatedTitleItems(item, seen).length > 0) return true;
+  if (item.kind !== "issue") return false;
+
+  const repo = targetRepo();
+  const dbPath = gitcrawlDbPath(repo);
+  if (dbPath) {
+    const source = detectGitcrawlClusterSource(dbPath);
+    if (!source) return null;
+    const rows = sqliteJsonProbe(
+      dbPath,
+      gitcrawlRelatedIssueSql(source, item.number, RELATED_GITCRAWL_LIMIT, repo),
+    );
+    if (!rows) return null;
+    if (
+      rows.some((entry) => {
+        const number = asRecord(entry).number;
+        return typeof number === "number" && number !== item.number;
+      })
+    ) {
+      return true;
+    }
+  }
+
+  if (!envFlagEnabled(process.env.CLAWSWEEPER_RELATED_GITHUB_SEARCH)) return false;
+  const query = relatedGitHubIssueSearchQuery(repo, item.title);
+  if (!query) return false;
+  try {
+    const response = asRecord(
+      ghJsonOnce<unknown>(
+        [
+          "api",
+          `search/issues?q=${encodeURIComponent(query)}&per_page=${RELATED_GITHUB_SEARCH_LIMIT}`,
+        ],
+        RELATED_GITHUB_SEARCH_TIMEOUT_MS,
+      ),
+    );
+    if (!Array.isArray(response.items)) return null;
+    return response.items.map(asRecord).some((candidate) => {
+      const number = candidate.number;
+      return typeof number === "number" && number !== item.number && !candidate.pull_request;
+    });
+  } catch (error) {
+    if (error instanceof GitHubRuntimeBudgetError) throw error;
+    return null;
+  }
 }
 
 function relatedItemNumber(value: unknown): number | null {
@@ -6156,6 +6209,7 @@ function reviewStructuralRecordFromMarkdown(markdown: string): ReviewStructuralR
     kind,
     sourceRevision: frontMatterValue(markdown, "review_structural_source_revision") ?? "",
     activityUpdatedAt: frontMatterValue(markdown, "review_structural_activity_updated_at") ?? "",
+    relationSensitive: frontMatterBoolean(markdown, "review_structural_relation_sensitive"),
     targetHeadSha: frontMatterValue(markdown, "review_structural_target_head_sha") ?? "",
     pullHeadSha: pullHeadSha && pullHeadSha !== "none" ? pullHeadSha : null,
     reviewPolicy: frontMatterValue(markdown, "review_policy") ?? "",
@@ -7310,6 +7364,10 @@ function fetchReviewStructuralRecord(options: {
 }): ReviewStructuralRecord | null {
   const [owner, name] = options.item.repo.split("/");
   if (!owner || !name) return null;
+  const externalRelationSensitive = structuralExternalRelationSensitivity(options.item);
+  if (externalRelationSensitive === null) {
+    throw new Error(`structural relation probe failed for #${options.item.number}`);
+  }
   const response = ghJson<unknown>([
     "api",
     "graphql",
@@ -7334,6 +7392,7 @@ function fetchReviewStructuralRecord(options: {
     reviewModel: options.reviewModel,
     ignoreAuthor: (author) => CLAWSWEEPER_BOT_AUTHORS.has(author.toLowerCase()),
     ignoreLabel: (label) => isIgnorableSourceRevisionLabel(normalizeLabelName(label)),
+    externalRelationSensitive,
   });
 }
 
@@ -18798,6 +18857,11 @@ function updateReviewStructuralFrontMatter(
   );
   next = replaceFrontMatterValue(
     next,
+    "review_structural_relation_sensitive",
+    record ? String(record.relationSensitive) : "unknown",
+  );
+  next = replaceFrontMatterValue(
+    next,
     "review_structural_target_head_sha",
     record?.targetHeadSha ?? "unknown",
   );
@@ -18935,6 +18999,9 @@ review_structural_cache_version: ${options.structuralRecord?.version ?? "unknown
 review_structural_fingerprint: ${options.structuralRecord?.fingerprint ?? "unknown"}
 review_structural_source_revision: ${options.structuralRecord?.sourceRevision ?? "unknown"}
 review_structural_activity_updated_at: ${options.structuralRecord?.activityUpdatedAt ?? "unknown"}
+review_structural_relation_sensitive: ${
+    options.structuralRecord ? options.structuralRecord.relationSensitive : "unknown"
+  }
 review_structural_target_head_sha: ${options.structuralRecord?.targetHeadSha ?? "unknown"}
 review_structural_pull_head_sha: ${
     options.structuralRecord ? (options.structuralRecord.pullHeadSha ?? "none") : "unknown"

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -65,6 +65,7 @@ import {
   reviewStructuralQuery,
   reviewStructuralRecordFromGraphql,
   reviewStructuralCacheDecision,
+  reviewStructuralCacheProbeDecision,
   validReviewStructuralRecord,
   type ReviewStructuralPullState,
   type ReviewStructuralRecord,
@@ -19694,187 +19695,205 @@ function reviewCommand(args: Args): void {
       const priorReview = localRangeData ? null : existingReview(item, itemsDir);
       let acquiredReviewLease: AcquiredReviewStartLease | null = null;
       let structuralRecord: ReviewStructuralRecord | null = null;
+      let preHydrationStructuralRecord: ReviewStructuralRecord | null = null;
       let hydratedStructuralAnchor: ReviewStructuralRecord | null = null;
       if (!localRangeData) {
         structuralCacheChecks += 1;
-        const structuralProbeStartedAt = Date.now();
-        try {
-          structuralRecord = fetchReviewStructuralRecord({
-            item,
-            git,
-            reviewPolicy,
-            reviewModel: PUBLIC_CODEX_MODEL,
-          });
-          if (!reviewStructuralRecordAtLeastAsFresh(structuralRecord, item.updatedAt)) {
-            structuralRecord = null;
-          }
-        } catch (error) {
-          structuralCacheProbeFailures += 1;
-          console.error(
-            `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} structural-cache=probe-failed #${item.number}: ${
-              error instanceof Error ? error.message : String(error)
-            }`,
-          );
-        } finally {
-          structuralCacheProbeMs += Date.now() - structuralProbeStartedAt;
-        }
-        if (structuralRecord) item.updatedAt = structuralRecord.activityUpdatedAt;
-        const structuralDecision = reviewStructuralCacheDecision({
+        const structuralProbeDecision = reviewStructuralCacheProbeDecision({
           review: priorReview,
-          priorRecord: priorReview?.structuralRecord ?? null,
-          currentRecord: structuralRecord,
           reviewPolicy,
           reviewModel: PUBLIC_CODEX_MODEL,
           explicitDispatch,
           maintainerRequest,
           coordinationEnabled: !skipStartComment,
         });
-        structuralCacheReasons.set(
-          structuralDecision.reason,
-          (structuralCacheReasons.get(structuralDecision.reason) ?? 0) + 1,
-        );
-        if (structuralDecision.hit) {
-          const initialStructuralRecord = structuralRecord;
+        if (!structuralProbeDecision.hit) {
+          structuralCacheReasons.set(
+            structuralProbeDecision.reason,
+            (structuralCacheReasons.get(structuralProbeDecision.reason) ?? 0) + 1,
+          );
+        } else {
+          const structuralProbeStartedAt = Date.now();
           try {
-            const leaseRevision =
-              item.kind === "pull_request"
-                ? structuralRecord?.pullHeadSha
-                : priorReview?.itemSourceRevision;
-            const startComment = postReviewStartStatusComment({
-              item,
-              headSha: leaseRevision ?? "",
-              reviewTimeoutMs: timeoutMs,
-              position: completed + 1,
-              total: candidates.length,
-              shardIndex,
-              shardCount,
-            });
-            console.error(
-              `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} structural-cache-start-comment=${startComment.status} #${item.number}`,
-            );
-            if (startComment.status === "held") {
-              coordinationHeldRetryAt = startComment.retryAt;
-              continue;
-            }
-            acquiredReviewLease = startComment.lease;
-            if (!acquiredReviewLease) {
-              throw new Error(
-                `structural cache lease acquisition returned no identity for #${item.number}`,
-              );
-            }
-            acquiredReviewLeases.push({ itemNumber: item.number, lease: acquiredReviewLease });
-          } catch (error) {
-            leaseAcquisitionFailures += 1;
-            leaseAcquisitionFailureDetails.push(
-              `#${item.number}: ${error instanceof Error ? error.message : String(error)}`,
-            );
-            console.error(
-              `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} structural-cache-start-comment=failed #${item.number}: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            );
-            continue;
-          }
-          structuralCacheRevalidations += 1;
-          const structuralRevalidationStartedAt = Date.now();
-          let revalidatedStructuralRecord: ReviewStructuralRecord | null = null;
-          try {
-            revalidatedStructuralRecord = fetchReviewStructuralRecord({
+            structuralRecord = fetchReviewStructuralRecord({
               item,
               git,
               reviewPolicy,
               reviewModel: PUBLIC_CODEX_MODEL,
             });
-            if (
-              !reviewStructuralRecordAtLeastAsFresh(revalidatedStructuralRecord, item.updatedAt)
-            ) {
-              revalidatedStructuralRecord = null;
+            if (!reviewStructuralRecordAtLeastAsFresh(structuralRecord, item.updatedAt)) {
+              structuralRecord = null;
             }
           } catch (error) {
-            structuralCacheRevalidationFailures += 1;
+            structuralCacheProbeFailures += 1;
             console.error(
-              `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} structural-cache=revalidation-probe-failed #${item.number}: ${
+              `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} structural-cache=probe-failed #${item.number}: ${
                 error instanceof Error ? error.message : String(error)
               }`,
             );
           } finally {
-            structuralCacheRevalidationMs += Date.now() - structuralRevalidationStartedAt;
+            structuralCacheProbeMs += Date.now() - structuralProbeStartedAt;
           }
-          const revalidationDecision = reviewStructuralCacheDecision({
-            review: priorReview
-              ? {
-                  ...priorReview,
-                  reviewCommentSyncedAt: new Date().toISOString(),
-                }
-              : null,
-            priorRecord: initialStructuralRecord,
-            currentRecord: revalidatedStructuralRecord,
+          preHydrationStructuralRecord = structuralRecord;
+          if (structuralRecord) item.updatedAt = structuralRecord.activityUpdatedAt;
+          const structuralDecision = reviewStructuralCacheDecision({
+            review: priorReview,
+            priorRecord: priorReview?.structuralRecord ?? null,
+            currentRecord: structuralRecord,
             reviewPolicy,
             reviewModel: PUBLIC_CODEX_MODEL,
             explicitDispatch,
             maintainerRequest,
-            coordinationEnabled: true,
+            coordinationEnabled: !skipStartComment,
           });
-          structuralCacheRevalidationReasons.set(
-            revalidationDecision.reason,
-            (structuralCacheRevalidationReasons.get(revalidationDecision.reason) ?? 0) + 1,
+          structuralCacheReasons.set(
+            structuralDecision.reason,
+            (structuralCacheReasons.get(structuralDecision.reason) ?? 0) + 1,
           );
-          if (!revalidationDecision.hit) {
-            const leaseToRelease = acquiredReviewLease!;
-            if (!deleteOwnedDedicatedReviewStartLease(item.number, leaseToRelease)) {
+          if (structuralDecision.hit) {
+            const initialStructuralRecord = structuralRecord;
+            try {
+              const leaseRevision =
+                item.kind === "pull_request"
+                  ? structuralRecord?.pullHeadSha
+                  : priorReview?.itemSourceRevision;
+              const startComment = postReviewStartStatusComment({
+                item,
+                headSha: leaseRevision ?? "",
+                reviewTimeoutMs: timeoutMs,
+                position: completed + 1,
+                total: candidates.length,
+                shardIndex,
+                shardCount,
+              });
+              console.error(
+                `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} structural-cache-start-comment=${startComment.status} #${item.number}`,
+              );
+              if (startComment.status === "held") {
+                coordinationHeldRetryAt = startComment.retryAt;
+                continue;
+              }
+              acquiredReviewLease = startComment.lease;
+              if (!acquiredReviewLease) {
+                throw new Error(
+                  `structural cache lease acquisition returned no identity for #${item.number}`,
+                );
+              }
+              acquiredReviewLeases.push({ itemNumber: item.number, lease: acquiredReviewLease });
+            } catch (error) {
               leaseAcquisitionFailures += 1;
               leaseAcquisitionFailureDetails.push(
-                `#${item.number}: could not release structural cache lease after ${revalidationDecision.reason}`,
+                `#${item.number}: ${error instanceof Error ? error.message : String(error)}`,
+              );
+              console.error(
+                `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} structural-cache-start-comment=failed #${item.number}: ${
+                  error instanceof Error ? error.message : String(error)
+                }`,
               );
               continue;
             }
-            const acquiredIndex = acquiredReviewLeases.findIndex(
-              (entry) =>
-                entry.itemNumber === item.number &&
-                entry.lease.commentId === leaseToRelease.commentId &&
-                entry.lease.owner === leaseToRelease.owner,
-            );
-            if (acquiredIndex >= 0) acquiredReviewLeases.splice(acquiredIndex, 1);
-            acquiredReviewLease = null;
-            structuralRecord = revalidatedStructuralRecord;
-            if (structuralRecord) item.updatedAt = structuralRecord.activityUpdatedAt;
-            console.error(
-              `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} structural-cache=revalidation-miss reason=${revalidationDecision.reason} hydrate #${item.number}`,
-            );
-          } else {
-            const confirmedStructuralRecord = revalidatedStructuralRecord!;
-            structuralRecord = confirmedStructuralRecord;
-            item.updatedAt = confirmedStructuralRecord.activityUpdatedAt;
-            const reportPath = join(artifactDir, reportFileName(item.repo, item.number));
-            let carried = priorReview!.markdown;
-            carried = replaceFrontMatterValue(carried, "reviewed_at", new Date().toISOString());
-            carried = replaceFrontMatterValue(carried, "item_updated_at", item.updatedAt);
-            carried = replaceFrontMatterValue(
-              carried,
-              "review_lease_owner",
-              acquiredReviewLease.owner,
-            );
-            carried = replaceFrontMatterValue(
-              carried,
-              "review_lease_comment_id",
-              String(acquiredReviewLease.commentId),
-            );
-            carried = replaceFrontMatterValue(carried, "review_cache_hit", "true");
-            carried = updateReviewStructuralFrontMatter(carried, structuralRecord, true);
-            writeFileSync(reportPath, carried, "utf8");
-            completed += 1;
-            cacheHits += 1;
-            structuralCacheHits += 1;
-            if (humanLocalReview) {
-              console.error("");
-              console.error("Structural review cache hit; GitHub context unchanged");
-              console.error(`  report: ${displayPath(reportPath)}`);
-            } else {
+            structuralCacheRevalidations += 1;
+            const structuralRevalidationStartedAt = Date.now();
+            let revalidatedStructuralRecord: ReviewStructuralRecord | null = null;
+            try {
+              revalidatedStructuralRecord = fetchReviewStructuralRecord({
+                item,
+                git,
+                reviewPolicy,
+                reviewModel: PUBLIC_CODEX_MODEL,
+              });
+              if (
+                !reviewStructuralRecordAtLeastAsFresh(revalidatedStructuralRecord, item.updatedAt)
+              ) {
+                revalidatedStructuralRecord = null;
+              }
+            } catch (error) {
+              structuralCacheRevalidationFailures += 1;
               console.error(
-                `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} cache-hit structural-unchanged skip-hydration-model #${item.number} (${completed}/${candidates.length})`,
+                `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} structural-cache=revalidation-probe-failed #${item.number}: ${
+                  error instanceof Error ? error.message : String(error)
+                }`,
               );
+            } finally {
+              structuralCacheRevalidationMs += Date.now() - structuralRevalidationStartedAt;
             }
-            continue;
+            const revalidationDecision = reviewStructuralCacheDecision({
+              review: priorReview
+                ? {
+                    ...priorReview,
+                    reviewCommentSyncedAt: new Date().toISOString(),
+                  }
+                : null,
+              priorRecord: initialStructuralRecord,
+              currentRecord: revalidatedStructuralRecord,
+              reviewPolicy,
+              reviewModel: PUBLIC_CODEX_MODEL,
+              explicitDispatch,
+              maintainerRequest,
+              coordinationEnabled: true,
+            });
+            structuralCacheRevalidationReasons.set(
+              revalidationDecision.reason,
+              (structuralCacheRevalidationReasons.get(revalidationDecision.reason) ?? 0) + 1,
+            );
+            if (!revalidationDecision.hit) {
+              const leaseToRelease = acquiredReviewLease!;
+              if (!deleteOwnedDedicatedReviewStartLease(item.number, leaseToRelease)) {
+                leaseAcquisitionFailures += 1;
+                leaseAcquisitionFailureDetails.push(
+                  `#${item.number}: could not release structural cache lease after ${revalidationDecision.reason}`,
+                );
+                continue;
+              }
+              const acquiredIndex = acquiredReviewLeases.findIndex(
+                (entry) =>
+                  entry.itemNumber === item.number &&
+                  entry.lease.commentId === leaseToRelease.commentId &&
+                  entry.lease.owner === leaseToRelease.owner,
+              );
+              if (acquiredIndex >= 0) acquiredReviewLeases.splice(acquiredIndex, 1);
+              acquiredReviewLease = null;
+              structuralRecord = revalidatedStructuralRecord;
+              preHydrationStructuralRecord = revalidatedStructuralRecord;
+              if (structuralRecord) item.updatedAt = structuralRecord.activityUpdatedAt;
+              console.error(
+                `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} structural-cache=revalidation-miss reason=${revalidationDecision.reason} hydrate #${item.number}`,
+              );
+            } else {
+              const confirmedStructuralRecord = revalidatedStructuralRecord!;
+              structuralRecord = confirmedStructuralRecord;
+              item.updatedAt = confirmedStructuralRecord.activityUpdatedAt;
+              const reportPath = join(artifactDir, reportFileName(item.repo, item.number));
+              let carried = priorReview!.markdown;
+              carried = replaceFrontMatterValue(carried, "reviewed_at", new Date().toISOString());
+              carried = replaceFrontMatterValue(carried, "item_updated_at", item.updatedAt);
+              carried = replaceFrontMatterValue(
+                carried,
+                "review_lease_owner",
+                acquiredReviewLease.owner,
+              );
+              carried = replaceFrontMatterValue(
+                carried,
+                "review_lease_comment_id",
+                String(acquiredReviewLease.commentId),
+              );
+              carried = replaceFrontMatterValue(carried, "review_cache_hit", "true");
+              carried = updateReviewStructuralFrontMatter(carried, structuralRecord, true);
+              writeFileSync(reportPath, carried, "utf8");
+              completed += 1;
+              cacheHits += 1;
+              structuralCacheHits += 1;
+              if (humanLocalReview) {
+                console.error("");
+                console.error("Structural review cache hit; GitHub context unchanged");
+                console.error(`  report: ${displayPath(reportPath)}`);
+              } else {
+                console.error(
+                  `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} cache-hit structural-unchanged skip-hydration-model #${item.number} (${completed}/${candidates.length})`,
+                );
+              }
+              continue;
+            }
           }
         }
       }
@@ -19925,7 +19944,7 @@ function reviewCommand(args: Args): void {
       const contextElapsedMs = Date.now() - contextStartedAt;
       const contextItemUpdatedAt = stringOrUndefined(asRecord(context.issue).updatedAt);
       if (contextItemUpdatedAt) item.updatedAt = contextItemUpdatedAt;
-      if (!localRangeData && contextItemUpdatedAt) {
+      if (!localRangeData && contextItemUpdatedAt && preHydrationStructuralRecord) {
         structuralCacheRevalidations += 1;
         const structuralRevalidationStartedAt = Date.now();
         try {
@@ -19936,6 +19955,10 @@ function reviewCommand(args: Args): void {
             reviewModel: PUBLIC_CODEX_MODEL,
           });
           if (
+            reviewStructuralRecordsDescribeSameVerdictInput(
+              preHydrationStructuralRecord,
+              candidate,
+            ) &&
             reviewStructuralRecordMatchesObservedUpdate(candidate, contextItemUpdatedAt) &&
             reviewStructuralRecordMatchesHydratedItem(
               candidate,

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -55,6 +55,14 @@ import {
 import { parseGhJson, parseGhJsonLinesWithRetry, parseGhJsonWithRetry } from "./github-json.js";
 import { stableJson } from "./stable-json.js";
 import {
+  REVIEW_STRUCTURAL_CACHE_VERSION,
+  reviewStructuralQuery,
+  reviewStructuralRecordFromGraphql,
+  reviewStructuralCacheDecision,
+  validReviewStructuralRecord,
+  type ReviewStructuralRecord,
+} from "./review-structural-cache.js";
+import {
   ASSIST_ANSWER_MAX_BYTES,
   ASSIST_ARTIFACT_MAX_BYTES,
   assertAssistArtifactLiveRevision,
@@ -430,9 +438,11 @@ interface ExistingReview {
   decision: string | undefined;
   reviewStatus: string | undefined;
   reviewPolicy: string | undefined;
+  reviewModel: string | undefined;
   contentDigest: string | undefined;
   lastFullReviewAt: string | undefined;
   lastFullReviewDecision: string | undefined;
+  structuralRecord: ReviewStructuralRecord | null;
 }
 
 interface LatestRelease {
@@ -4455,7 +4465,9 @@ const CLAWSWEEPER_BOT_AUTHORS = new Set(
     "clawsweeper[bot]",
     "openclaw-clawsweeper[bot]",
     process.env.CLAWSWEEPER_COMMENT_AUTHOR_LOGIN,
-  ].filter((login): login is string => typeof login === "string" && login.length > 0),
+  ]
+    .filter((login): login is string => typeof login === "string" && login.length > 0)
+    .map((login) => login.toLowerCase()),
 );
 const CLAWSWEEPER_COMMAND_ONLY_PATTERN = /^@clawsweeper\s+(?:re-review|re-run|review)\s*$/i;
 
@@ -6132,6 +6144,25 @@ export function reviewReportCanPromoteToCloseForTest(markdown: string): boolean 
   return reviewReportCanPromoteToClose(markdown);
 }
 
+function reviewStructuralRecordFromMarkdown(markdown: string): ReviewStructuralRecord | null {
+  const version = Number(frontMatterValue(markdown, "review_structural_cache_version"));
+  const kind = reportItemKind(markdown);
+  const pullHeadSha = frontMatterValue(markdown, "review_structural_pull_head_sha");
+  if (version !== REVIEW_STRUCTURAL_CACHE_VERSION || !kind) return null;
+  const record: ReviewStructuralRecord = {
+    version: REVIEW_STRUCTURAL_CACHE_VERSION,
+    fingerprint: frontMatterValue(markdown, "review_structural_fingerprint") ?? "",
+    kind,
+    sourceRevision: frontMatterValue(markdown, "review_structural_source_revision") ?? "",
+    activityUpdatedAt: frontMatterValue(markdown, "review_structural_activity_updated_at") ?? "",
+    targetHeadSha: frontMatterValue(markdown, "review_structural_target_head_sha") ?? "",
+    pullHeadSha: pullHeadSha && pullHeadSha !== "none" ? pullHeadSha : null,
+    reviewPolicy: frontMatterValue(markdown, "review_policy") ?? "",
+    reviewModel: frontMatterValue(markdown, "review_model") ?? "",
+  };
+  return validReviewStructuralRecord(record) ? record : null;
+}
+
 function existingReview(
   item: Pick<Item, "number" | "repo">,
   itemsDir: string,
@@ -6154,9 +6185,11 @@ function existingReview(
     decision: frontMatterValue(markdown, "decision"),
     reviewStatus: effectiveReviewStatus(markdown),
     reviewPolicy: frontMatterValue(markdown, "review_policy"),
+    reviewModel: frontMatterValue(markdown, "review_model"),
     contentDigest: frontMatterValue(markdown, "review_content_digest"),
     lastFullReviewAt: frontMatterValue(markdown, "last_full_review_at"),
     lastFullReviewDecision: frontMatterValue(markdown, "last_full_review_decision"),
+    structuralRecord: reviewStructuralRecordFromMarkdown(markdown),
   };
 }
 
@@ -6185,9 +6218,11 @@ function buildExistingReviewIndex(itemsDir: string): ExistingReviewIndex {
       decision: frontMatterValue(markdown, "decision"),
       reviewStatus: effectiveReviewStatus(markdown),
       reviewPolicy: frontMatterValue(markdown, "review_policy"),
+      reviewModel: frontMatterValue(markdown, "review_model"),
       contentDigest: frontMatterValue(markdown, "review_content_digest"),
       lastFullReviewAt: frontMatterValue(markdown, "last_full_review_at"),
       lastFullReviewDecision: frontMatterValue(markdown, "last_full_review_decision"),
+      structuralRecord: reviewStructuralRecordFromMarkdown(markdown),
     });
   }
   return { byKey };
@@ -7262,6 +7297,41 @@ function planCandidates(options: {
       floorBackfill,
     }),
   };
+}
+
+function fetchReviewStructuralRecord(options: {
+  item: Item;
+  git: GitInfo;
+  reviewPolicy: string;
+  reviewModel: string;
+}): ReviewStructuralRecord | null {
+  const [owner, name] = options.item.repo.split("/");
+  if (!owner || !name) return null;
+  const response = ghJson<unknown>([
+    "api",
+    "graphql",
+    "-f",
+    `owner=${owner}`,
+    "-f",
+    `name=${name}`,
+    "-F",
+    `number=${options.item.number}`,
+    "-f",
+    `query=${reviewStructuralQuery(options.item.kind)}`,
+  ]);
+  return reviewStructuralRecordFromGraphql({
+    response,
+    repo: options.item.repo,
+    number: options.item.number,
+    kind: options.item.kind,
+    targetHeadSha: options.git.mainSha.trim().toLowerCase(),
+    latestReleaseTag: options.git.latestRelease?.tagName ?? null,
+    latestReleaseSha: options.git.latestRelease?.sha?.trim().toLowerCase() ?? null,
+    reviewPolicy: options.reviewPolicy,
+    reviewModel: options.reviewModel,
+    ignoreAuthor: (author) => CLAWSWEEPER_BOT_AUTHORS.has(author.toLowerCase()),
+    ignoreLabel: (label) => isIgnorableSourceRevisionLabel(normalizeLabelName(label)),
+  });
 }
 
 function collectItemContext(
@@ -18698,6 +18768,44 @@ function pullRequestFilePathsFromContext(context: ItemContext): string[] {
   return pullRequestFilePathsFromContextForTest(context);
 }
 
+function updateReviewStructuralFrontMatter(
+  markdown: string,
+  record: ReviewStructuralRecord | null,
+  cacheHit: boolean,
+): string {
+  let next = replaceFrontMatterValue(
+    markdown,
+    "review_structural_cache_version",
+    record ? String(record.version) : "unknown",
+  );
+  next = replaceFrontMatterValue(
+    next,
+    "review_structural_fingerprint",
+    record?.fingerprint ?? "unknown",
+  );
+  next = replaceFrontMatterValue(
+    next,
+    "review_structural_source_revision",
+    record?.sourceRevision ?? "unknown",
+  );
+  next = replaceFrontMatterValue(
+    next,
+    "review_structural_activity_updated_at",
+    record?.activityUpdatedAt ?? "unknown",
+  );
+  next = replaceFrontMatterValue(
+    next,
+    "review_structural_target_head_sha",
+    record?.targetHeadSha ?? "unknown",
+  );
+  next = replaceFrontMatterValue(
+    next,
+    "review_structural_pull_head_sha",
+    record ? (record.pullHeadSha ?? "none") : "unknown",
+  );
+  return replaceFrontMatterValue(next, "review_structural_cache_hit", cacheHit ? "true" : "false");
+}
+
 function markdownFor(options: {
   item: Item;
   context: ItemContext;
@@ -18709,6 +18817,7 @@ function markdownFor(options: {
   contentDigest: string;
   reviewPolicy: string;
   runtime: ReviewRuntime;
+  structuralRecord?: ReviewStructuralRecord | null;
   reviewLeaseOwner?: string;
   reviewLeaseCommentId?: number;
 }): string {
@@ -18819,6 +18928,15 @@ review_content_digest: ${options.contentDigest}
 last_full_review_at: ${reviewedAt}
 last_full_review_decision: ${options.decision.decision}
 review_cache_hit: false
+review_structural_cache_version: ${options.structuralRecord?.version ?? "unknown"}
+review_structural_fingerprint: ${options.structuralRecord?.fingerprint ?? "unknown"}
+review_structural_source_revision: ${options.structuralRecord?.sourceRevision ?? "unknown"}
+review_structural_activity_updated_at: ${options.structuralRecord?.activityUpdatedAt ?? "unknown"}
+review_structural_target_head_sha: ${options.structuralRecord?.targetHeadSha ?? "unknown"}
+review_structural_pull_head_sha: ${
+    options.structuralRecord ? (options.structuralRecord.pullHeadSha ?? "none") : "unknown"
+  }
+review_structural_cache_hit: false
 item_source_revision: ${options.context.sourceRevision ?? "unknown"}
 close_comment_sha256: ${options.action.closeComment ? sha256(options.action.closeComment) : "none"}
 review_comment_sha256: none
@@ -19364,6 +19482,13 @@ function reviewCommand(args: Args): void {
     let codexFailures = 0;
     let leaseAcquisitionFailures = 0;
     let cacheHits = 0;
+    let contentCacheHits = 0;
+    let structuralCacheChecks = 0;
+    let structuralCacheHits = 0;
+    let structuralCacheProbeFailures = 0;
+    let structuralCacheProbeMs = 0;
+    let hydrationRuns = 0;
+    const structuralCacheReasons = new Map<string, number>();
     const codexFailureReports: string[] = [];
     const leaseAcquisitionFailureDetails: string[] = [];
     for (const item of candidates) {
@@ -19375,12 +19500,73 @@ function reviewCommand(args: Args): void {
           `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} start #${item.number} (${completed + 1}/${candidates.length})`,
         );
       }
+      const priorReview = localRangeData ? null : existingReview(item, itemsDir);
+      let structuralRecord: ReviewStructuralRecord | null = null;
+      if (!localRangeData) {
+        structuralCacheChecks += 1;
+        const structuralProbeStartedAt = Date.now();
+        try {
+          structuralRecord = fetchReviewStructuralRecord({
+            item,
+            git,
+            reviewPolicy,
+            reviewModel: PUBLIC_CODEX_MODEL,
+          });
+        } catch (error) {
+          structuralCacheProbeFailures += 1;
+          console.error(
+            `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} structural-cache=probe-failed #${item.number}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        } finally {
+          structuralCacheProbeMs += Date.now() - structuralProbeStartedAt;
+        }
+        if (structuralRecord) item.updatedAt = structuralRecord.activityUpdatedAt;
+        const structuralDecision = reviewStructuralCacheDecision({
+          review: priorReview,
+          priorRecord: priorReview?.structuralRecord ?? null,
+          currentRecord: structuralRecord,
+          reviewPolicy,
+          reviewModel: PUBLIC_CODEX_MODEL,
+          explicitDispatch,
+          maintainerRequest,
+        });
+        structuralCacheReasons.set(
+          structuralDecision.reason,
+          (structuralCacheReasons.get(structuralDecision.reason) ?? 0) + 1,
+        );
+        if (structuralDecision.hit) {
+          const reportPath = join(artifactDir, reportFileName(item.repo, item.number));
+          let carried = priorReview!.markdown;
+          carried = replaceFrontMatterValue(carried, "reviewed_at", new Date().toISOString());
+          carried = replaceFrontMatterValue(carried, "item_updated_at", item.updatedAt);
+          carried = replaceFrontMatterValue(carried, "review_lease_owner", "unknown");
+          carried = replaceFrontMatterValue(carried, "review_lease_comment_id", "unknown");
+          carried = replaceFrontMatterValue(carried, "review_cache_hit", "true");
+          carried = updateReviewStructuralFrontMatter(carried, structuralRecord, true);
+          writeFileSync(reportPath, carried, "utf8");
+          completed += 1;
+          cacheHits += 1;
+          structuralCacheHits += 1;
+          if (humanLocalReview) {
+            console.error("");
+            console.error("Structural review cache hit; GitHub context unchanged");
+            console.error(`  report: ${displayPath(reportPath)}`);
+          } else {
+            console.error(
+              `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} cache-hit structural-unchanged skip-hydration-model #${item.number} (${completed}/${candidates.length})`,
+            );
+          }
+          continue;
+        }
+      }
       let acquiredReviewLease: AcquiredReviewStartLease | null = null;
       if (!skipStartComment && item.kind === "pull_request") {
         try {
           const startComment = postReviewStartStatusComment({
             item,
-            headSha: pullRequestHeadSha(item.number),
+            headSha: structuralRecord?.pullHeadSha ?? pullRequestHeadSha(item.number),
             reviewTimeoutMs: timeoutMs,
             position: completed + 1,
             total: candidates.length,
@@ -19413,6 +19599,7 @@ function reviewCommand(args: Args): void {
         }
       }
       const contextStartedAt = Date.now();
+      if (!localRangeData) hydrationRuns += 1;
       const context = localRangeData
         ? localRangeData.context
         : collectItemContext(item, {
@@ -19490,11 +19677,10 @@ function reviewCommand(args: Args): void {
         }
       }
       const contentDigest = itemContentDigest(item, context, git);
-      const priorReview =
-        explicitDispatch || maintainerRequest ? null : existingReview(item, itemsDir);
+      const contentCacheReview = explicitDispatch || maintainerRequest ? null : priorReview;
       if (
         reviewContentCacheHit({
-          review: priorReview,
+          review: contentCacheReview,
           reviewPolicy,
           contentDigest,
           now: Date.now(),
@@ -19522,9 +19708,13 @@ function reviewCommand(args: Args): void {
           itemSnapshotHash(item, context),
         );
         carried = replaceFrontMatterValue(carried, "review_cache_hit", "true");
+        carried = structuralRecord
+          ? updateReviewStructuralFrontMatter(carried, structuralRecord, false)
+          : replaceFrontMatterValue(carried, "review_structural_cache_hit", "false");
         writeFileSync(reportPath, carried, "utf8");
         completed += 1;
         cacheHits += 1;
+        contentCacheHits += 1;
         if (humanLocalReview) {
           console.error("");
           console.error("Review cache hit; content unchanged since the last review");
@@ -19632,6 +19822,7 @@ function reviewCommand(args: Args): void {
           contentDigest,
           reviewPolicy,
           runtime,
+          structuralRecord,
           ...(acquiredReviewLease
             ? {
                 reviewLeaseOwner: acquiredReviewLease.owner,
@@ -19666,9 +19857,33 @@ function reviewCommand(args: Args): void {
     }
     if (!humanLocalReview) {
       console.error(
-        `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} complete reviewed=${completed} cache_hits=${cacheHits}`,
+        `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} complete reviewed=${completed} cache_hits=${cacheHits} structural_cache_checks=${structuralCacheChecks} structural_cache_hits=${structuralCacheHits} content_cache_hits=${contentCacheHits} hydrations=${hydrationRuns}`,
       );
     }
+    writeFileSync(
+      join(artifactDir, "review-cache-metrics.json"),
+      JSON.stringify(
+        {
+          candidates: candidates.length,
+          completed,
+          cache_hits: cacheHits,
+          structural_cache_checks: structuralCacheChecks,
+          structural_cache_hits: structuralCacheHits,
+          structural_cache_probe_failures: structuralCacheProbeFailures,
+          structural_cache_probe_ms: structuralCacheProbeMs,
+          structural_cache_reasons: Object.fromEntries(
+            [...structuralCacheReasons.entries()].sort(([left], [right]) =>
+              left.localeCompare(right),
+            ),
+          ),
+          content_cache_hits: contentCacheHits,
+          hydrations: hydrationRuns,
+        },
+        null,
+        2,
+      ) + "\n",
+      "utf8",
+    );
     if (leaseAcquisitionFailures > 0) {
       throw new Error(
         `Could not acquire durable review coordination for ${leaseAcquisitionFailures} item${

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -57,6 +57,8 @@ import { stableJson } from "./stable-json.js";
 import {
   REVIEW_STRUCTURAL_CACHE_VERSION,
   reviewStructuralRecordAtLeastAsFresh,
+  reviewStructuralItemStateDigest,
+  reviewStructuralRecordMatchesHydratedItem,
   reviewStructuralRecordMatchesHydratedPull,
   reviewStructuralRecordMatchesObservedUpdate,
   reviewStructuralRecordsDescribeSameVerdictInput,
@@ -669,6 +671,7 @@ interface ItemContext {
   issue: unknown;
   comments: unknown[];
   timeline: unknown[];
+  structuralItemStateDigest?: string;
   goodFirstIssueHumanLabelState?: GoodFirstIssueHumanLabelState;
   sourceRevision?: string;
   timelineRevision?: string;
@@ -2619,6 +2622,48 @@ function itemSourceRevisionSha256(issue: unknown, comments: unknown[] = []): str
       ),
   };
   return sha256(JSON.stringify(snapshot));
+}
+
+function hydratedReviewStructuralItemStateDigest(
+  issue: unknown,
+  comments: readonly unknown[],
+): string | undefined {
+  const source = asRecord(issue);
+  const title = sourceRevisionScalar(source.title);
+  const body = sourceRevisionScalar(source.body);
+  const author = login(source.user);
+  const authorAssociation = normalizeAuthorAssociation(
+    stringOrUndefined(source.author_association),
+  );
+  const state = stringOrUndefined(source.state);
+  if (!author || !authorAssociation || !state || typeof source.locked !== "boolean") {
+    return undefined;
+  }
+  return (
+    reviewStructuralItemStateDigest({
+      titleDigest: sha256(title),
+      bodyDigest: sha256(body),
+      state,
+      locked: source.locked,
+      author,
+      authorAssociation,
+      labels: revisionLabels(source.labels),
+      comments: comments
+        .map(asRecord)
+        .filter((comment) => !isClawSweeperComment(comment))
+        .map((comment) => ({
+          updatedAt: sourceRevisionScalar(
+            comment.updated_at ?? comment.updatedAt ?? comment.created_at,
+          ),
+          author: login(comment.user) ?? stringOrUndefined(comment.author) ?? null,
+          authorAssociation:
+            normalizeAuthorAssociation(
+              stringOrUndefined(comment.author_association ?? comment.authorAssociation),
+            ) ?? null,
+          bodyDigest: sha256(sourceRevisionScalar(comment.body)),
+        })),
+    }) ?? undefined
+  );
 }
 
 function sourceRevisionScalar(value: unknown): string {
@@ -6214,6 +6259,7 @@ function reviewStructuralRecordFromMarkdown(markdown: string): ReviewStructuralR
     fingerprint: frontMatterValue(markdown, "review_structural_fingerprint") ?? "",
     kind,
     sourceRevision: frontMatterValue(markdown, "review_structural_source_revision") ?? "",
+    itemStateDigest: frontMatterValue(markdown, "review_structural_item_state_digest") ?? "",
     activityUpdatedAt: frontMatterValue(markdown, "review_structural_activity_updated_at") ?? "",
     relationSensitive: frontMatterBoolean(markdown, "review_structural_relation_sensitive"),
     targetHeadSha: frontMatterValue(markdown, "review_structural_target_head_sha") ?? "",
@@ -7451,6 +7497,13 @@ function collectItemContext(
       timelineTruncated: timelineWindow.truncated,
     },
   };
+  const structuralItemStateDigest = hydratedReviewStructuralItemStateDigest(
+    issue,
+    sourceRevisionComments,
+  );
+  if (structuralItemStateDigest) {
+    context.structuralItemStateDigest = structuralItemStateDigest;
+  }
   if (options.reviewCacheDigest) {
     context.timelineRevision = sha256(
       stableJson(reviewTimelineDigestParts((fullTimeline ?? timeline).map(compactTimelineEvent))),
@@ -18902,6 +18955,11 @@ function updateReviewStructuralFrontMatter(
   );
   next = replaceFrontMatterValue(
     next,
+    "review_structural_item_state_digest",
+    record?.itemStateDigest ?? "unknown",
+  );
+  next = replaceFrontMatterValue(
+    next,
     "review_structural_activity_updated_at",
     record?.activityUpdatedAt ?? "unknown",
   );
@@ -19053,6 +19111,7 @@ review_cache_hit: false
 review_structural_cache_version: ${options.structuralRecord?.version ?? "unknown"}
 review_structural_fingerprint: ${options.structuralRecord?.fingerprint ?? "unknown"}
 review_structural_source_revision: ${options.structuralRecord?.sourceRevision ?? "unknown"}
+review_structural_item_state_digest: ${options.structuralRecord?.itemStateDigest ?? "unknown"}
 review_structural_activity_updated_at: ${options.structuralRecord?.activityUpdatedAt ?? "unknown"}
 review_structural_relation_sensitive: ${
     options.structuralRecord ? options.structuralRecord.relationSensitive : "unknown"
@@ -19878,6 +19937,10 @@ function reviewCommand(args: Args): void {
           });
           if (
             reviewStructuralRecordMatchesObservedUpdate(candidate, contextItemUpdatedAt) &&
+            reviewStructuralRecordMatchesHydratedItem(
+              candidate,
+              context.structuralItemStateDigest,
+            ) &&
             (item.kind !== "pull_request" ||
               reviewStructuralRecordMatchesHydratedPull(
                 candidate,

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -19490,8 +19490,12 @@ function reviewCommand(args: Args): void {
     let structuralCacheHits = 0;
     let structuralCacheProbeFailures = 0;
     let structuralCacheProbeMs = 0;
+    let structuralCacheRevalidations = 0;
+    let structuralCacheRevalidationFailures = 0;
+    let structuralCacheRevalidationMs = 0;
     let hydrationRuns = 0;
     const structuralCacheReasons = new Map<string, number>();
+    const structuralCacheRevalidationReasons = new Map<string, number>();
     const codexFailureReports: string[] = [];
     const leaseAcquisitionFailureDetails: string[] = [];
     for (const item of candidates) {
@@ -19542,6 +19546,7 @@ function reviewCommand(args: Args): void {
           (structuralCacheReasons.get(structuralDecision.reason) ?? 0) + 1,
         );
         if (structuralDecision.hit) {
+          const initialStructuralRecord = structuralRecord;
           try {
             const leaseRevision =
               item.kind === "pull_request"
@@ -19582,36 +19587,102 @@ function reviewCommand(args: Args): void {
             );
             continue;
           }
-          const reportPath = join(artifactDir, reportFileName(item.repo, item.number));
-          let carried = priorReview!.markdown;
-          carried = replaceFrontMatterValue(carried, "reviewed_at", new Date().toISOString());
-          carried = replaceFrontMatterValue(carried, "item_updated_at", item.updatedAt);
-          carried = replaceFrontMatterValue(
-            carried,
-            "review_lease_owner",
-            acquiredReviewLease.owner,
-          );
-          carried = replaceFrontMatterValue(
-            carried,
-            "review_lease_comment_id",
-            String(acquiredReviewLease.commentId),
-          );
-          carried = replaceFrontMatterValue(carried, "review_cache_hit", "true");
-          carried = updateReviewStructuralFrontMatter(carried, structuralRecord, true);
-          writeFileSync(reportPath, carried, "utf8");
-          completed += 1;
-          cacheHits += 1;
-          structuralCacheHits += 1;
-          if (humanLocalReview) {
-            console.error("");
-            console.error("Structural review cache hit; GitHub context unchanged");
-            console.error(`  report: ${displayPath(reportPath)}`);
-          } else {
+          structuralCacheRevalidations += 1;
+          const structuralRevalidationStartedAt = Date.now();
+          let revalidatedStructuralRecord: ReviewStructuralRecord | null = null;
+          try {
+            revalidatedStructuralRecord = fetchReviewStructuralRecord({
+              item,
+              git,
+              reviewPolicy,
+              reviewModel: PUBLIC_CODEX_MODEL,
+            });
+          } catch (error) {
+            structuralCacheRevalidationFailures += 1;
             console.error(
-              `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} cache-hit structural-unchanged skip-hydration-model #${item.number} (${completed}/${candidates.length})`,
+              `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} structural-cache=revalidation-probe-failed #${item.number}: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
             );
+          } finally {
+            structuralCacheRevalidationMs += Date.now() - structuralRevalidationStartedAt;
           }
-          continue;
+          const revalidationDecision = reviewStructuralCacheDecision({
+            review: priorReview
+              ? {
+                  ...priorReview,
+                  reviewCommentSyncedAt: new Date().toISOString(),
+                }
+              : null,
+            priorRecord: initialStructuralRecord,
+            currentRecord: revalidatedStructuralRecord,
+            reviewPolicy,
+            reviewModel: PUBLIC_CODEX_MODEL,
+            explicitDispatch,
+            maintainerRequest,
+            coordinationEnabled: true,
+          });
+          structuralCacheRevalidationReasons.set(
+            revalidationDecision.reason,
+            (structuralCacheRevalidationReasons.get(revalidationDecision.reason) ?? 0) + 1,
+          );
+          if (!revalidationDecision.hit) {
+            const leaseToRelease = acquiredReviewLease!;
+            if (!deleteOwnedDedicatedReviewStartLease(item.number, leaseToRelease)) {
+              leaseAcquisitionFailures += 1;
+              leaseAcquisitionFailureDetails.push(
+                `#${item.number}: could not release structural cache lease after ${revalidationDecision.reason}`,
+              );
+              continue;
+            }
+            const acquiredIndex = acquiredReviewLeases.findIndex(
+              (entry) =>
+                entry.itemNumber === item.number &&
+                entry.lease.commentId === leaseToRelease.commentId &&
+                entry.lease.owner === leaseToRelease.owner,
+            );
+            if (acquiredIndex >= 0) acquiredReviewLeases.splice(acquiredIndex, 1);
+            acquiredReviewLease = null;
+            structuralRecord = revalidatedStructuralRecord;
+            if (structuralRecord) item.updatedAt = structuralRecord.activityUpdatedAt;
+            console.error(
+              `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} structural-cache=revalidation-miss reason=${revalidationDecision.reason} hydrate #${item.number}`,
+            );
+          } else {
+            const confirmedStructuralRecord = revalidatedStructuralRecord!;
+            structuralRecord = confirmedStructuralRecord;
+            item.updatedAt = confirmedStructuralRecord.activityUpdatedAt;
+            const reportPath = join(artifactDir, reportFileName(item.repo, item.number));
+            let carried = priorReview!.markdown;
+            carried = replaceFrontMatterValue(carried, "reviewed_at", new Date().toISOString());
+            carried = replaceFrontMatterValue(carried, "item_updated_at", item.updatedAt);
+            carried = replaceFrontMatterValue(
+              carried,
+              "review_lease_owner",
+              acquiredReviewLease.owner,
+            );
+            carried = replaceFrontMatterValue(
+              carried,
+              "review_lease_comment_id",
+              String(acquiredReviewLease.commentId),
+            );
+            carried = replaceFrontMatterValue(carried, "review_cache_hit", "true");
+            carried = updateReviewStructuralFrontMatter(carried, structuralRecord, true);
+            writeFileSync(reportPath, carried, "utf8");
+            completed += 1;
+            cacheHits += 1;
+            structuralCacheHits += 1;
+            if (humanLocalReview) {
+              console.error("");
+              console.error("Structural review cache hit; GitHub context unchanged");
+              console.error(`  report: ${displayPath(reportPath)}`);
+            } else {
+              console.error(
+                `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} cache-hit structural-unchanged skip-hydration-model #${item.number} (${completed}/${candidates.length})`,
+              );
+            }
+            continue;
+          }
         }
       }
       if (!skipStartComment && item.kind === "pull_request") {
@@ -19909,7 +19980,7 @@ function reviewCommand(args: Args): void {
     }
     if (!humanLocalReview) {
       console.error(
-        `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} complete reviewed=${completed} cache_hits=${cacheHits} structural_cache_checks=${structuralCacheChecks} structural_cache_hits=${structuralCacheHits} content_cache_hits=${contentCacheHits} hydrations=${hydrationRuns}`,
+        `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} complete reviewed=${completed} cache_hits=${cacheHits} structural_cache_checks=${structuralCacheChecks} structural_cache_hits=${structuralCacheHits} structural_cache_revalidations=${structuralCacheRevalidations} content_cache_hits=${contentCacheHits} hydrations=${hydrationRuns}`,
       );
     }
     writeFileSync(
@@ -19923,8 +19994,16 @@ function reviewCommand(args: Args): void {
           structural_cache_hits: structuralCacheHits,
           structural_cache_probe_failures: structuralCacheProbeFailures,
           structural_cache_probe_ms: structuralCacheProbeMs,
+          structural_cache_revalidations: structuralCacheRevalidations,
+          structural_cache_revalidation_failures: structuralCacheRevalidationFailures,
+          structural_cache_revalidation_ms: structuralCacheRevalidationMs,
           structural_cache_reasons: Object.fromEntries(
             [...structuralCacheReasons.entries()].sort(([left], [right]) =>
+              left.localeCompare(right),
+            ),
+          ),
+          structural_cache_revalidation_reasons: Object.fromEntries(
+            [...structuralCacheRevalidationReasons.entries()].sort(([left], [right]) =>
               left.localeCompare(right),
             ),
           ),

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -57,12 +57,14 @@ import { stableJson } from "./stable-json.js";
 import {
   REVIEW_STRUCTURAL_CACHE_VERSION,
   reviewStructuralRecordAtLeastAsFresh,
+  reviewStructuralRecordMatchesHydratedPull,
   reviewStructuralRecordMatchesObservedUpdate,
   reviewStructuralRecordsDescribeSameVerdictInput,
   reviewStructuralQuery,
   reviewStructuralRecordFromGraphql,
   reviewStructuralCacheDecision,
   validReviewStructuralRecord,
+  type ReviewStructuralPullState,
   type ReviewStructuralRecord,
 } from "./review-structural-cache.js";
 import {
@@ -6205,6 +6207,7 @@ function reviewStructuralRecordFromMarkdown(markdown: string): ReviewStructuralR
   const version = Number(frontMatterValue(markdown, "review_structural_cache_version"));
   const kind = reportItemKind(markdown);
   const pullHeadSha = frontMatterValue(markdown, "review_structural_pull_head_sha");
+  const pullStateDigest = frontMatterValue(markdown, "review_structural_pull_state_digest");
   if (version !== REVIEW_STRUCTURAL_CACHE_VERSION || !kind) return null;
   const record: ReviewStructuralRecord = {
     version: REVIEW_STRUCTURAL_CACHE_VERSION,
@@ -6215,6 +6218,7 @@ function reviewStructuralRecordFromMarkdown(markdown: string): ReviewStructuralR
     relationSensitive: frontMatterBoolean(markdown, "review_structural_relation_sensitive"),
     targetHeadSha: frontMatterValue(markdown, "review_structural_target_head_sha") ?? "",
     pullHeadSha: pullHeadSha && pullHeadSha !== "none" ? pullHeadSha : null,
+    pullStateDigest: pullStateDigest && pullStateDigest !== "none" ? pullStateDigest : null,
     reviewPolicy: frontMatterValue(markdown, "review_policy") ?? "",
     reviewModel: frontMatterValue(markdown, "review_model") ?? "",
   };
@@ -17215,6 +17219,49 @@ function pullHeadShaFromContext(context: ItemContext): string | null {
   return typeof sha === "string" && sha.trim() ? sha.trim() : null;
 }
 
+function reviewStructuralPullStateFromContext(
+  context: ItemContext,
+): ReviewStructuralPullState | null {
+  const pull = asRecord(context.pullRequest);
+  const head = asRecord(pull.head);
+  const base = asRecord(pull.base);
+  const headSha = stringOrUndefined(head.sha);
+  const baseSha = stringOrUndefined(base.sha);
+  const mergeStateStatus = stringOrUndefined(pull.mergeableState);
+  const additions = githubCount(pull.additions);
+  const deletions = githubCount(pull.deletions);
+  const changedFiles = githubCount(pull.changedFiles);
+  const commitCount = context.counts?.pullCommits;
+  if (
+    !headSha ||
+    !baseSha ||
+    typeof pull.draft !== "boolean" ||
+    (pull.mergeable !== null &&
+      typeof pull.mergeable !== "boolean" &&
+      typeof pull.mergeable !== "string") ||
+    !mergeStateStatus ||
+    additions === null ||
+    deletions === null ||
+    changedFiles === null ||
+    typeof commitCount !== "number" ||
+    !Number.isSafeInteger(commitCount) ||
+    commitCount < 0
+  ) {
+    return null;
+  }
+  return {
+    headSha,
+    baseSha,
+    draft: pull.draft,
+    mergeable: pull.mergeable,
+    mergeStateStatus,
+    additions,
+    deletions,
+    changedFiles,
+    commitCount,
+  };
+}
+
 function pullHeadShaFromReport(markdown: string): string | null {
   const value = frontMatterValue(markdown, "pull_head_sha");
   return value && value !== "unknown" ? value : null;
@@ -18873,6 +18920,11 @@ function updateReviewStructuralFrontMatter(
     "review_structural_pull_head_sha",
     record ? (record.pullHeadSha ?? "none") : "unknown",
   );
+  next = replaceFrontMatterValue(
+    next,
+    "review_structural_pull_state_digest",
+    record ? (record.pullStateDigest ?? "none") : "unknown",
+  );
   return replaceFrontMatterValue(next, "review_structural_cache_hit", cacheHit ? "true" : "false");
 }
 
@@ -19008,6 +19060,9 @@ review_structural_relation_sensitive: ${
 review_structural_target_head_sha: ${options.structuralRecord?.targetHeadSha ?? "unknown"}
 review_structural_pull_head_sha: ${
     options.structuralRecord ? (options.structuralRecord.pullHeadSha ?? "none") : "unknown"
+  }
+review_structural_pull_state_digest: ${
+    options.structuralRecord ? (options.structuralRecord.pullStateDigest ?? "none") : "unknown"
   }
 review_structural_cache_hit: false
 item_source_revision: ${options.context.sourceRevision ?? "unknown"}
@@ -19821,10 +19876,13 @@ function reviewCommand(args: Args): void {
             reviewPolicy,
             reviewModel: PUBLIC_CODEX_MODEL,
           });
-          const contextPullHeadSha = pullHeadShaFromContext(context)?.trim().toLowerCase() ?? null;
           if (
             reviewStructuralRecordMatchesObservedUpdate(candidate, contextItemUpdatedAt) &&
-            (item.kind !== "pull_request" || candidate.pullHeadSha === contextPullHeadSha)
+            (item.kind !== "pull_request" ||
+              reviewStructuralRecordMatchesHydratedPull(
+                candidate,
+                reviewStructuralPullStateFromContext(context),
+              ))
           ) {
             hydratedStructuralAnchor = candidate;
           }

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -56,6 +56,9 @@ import { parseGhJson, parseGhJsonLinesWithRetry, parseGhJsonWithRetry } from "./
 import { stableJson } from "./stable-json.js";
 import {
   REVIEW_STRUCTURAL_CACHE_VERSION,
+  reviewStructuralRecordAtLeastAsFresh,
+  reviewStructuralRecordMatchesObservedUpdate,
+  reviewStructuralRecordsDescribeSameVerdictInput,
   reviewStructuralQuery,
   reviewStructuralRecordFromGraphql,
   reviewStructuralCacheDecision,
@@ -19577,6 +19580,7 @@ function reviewCommand(args: Args): void {
       const priorReview = localRangeData ? null : existingReview(item, itemsDir);
       let acquiredReviewLease: AcquiredReviewStartLease | null = null;
       let structuralRecord: ReviewStructuralRecord | null = null;
+      let hydratedStructuralAnchor: ReviewStructuralRecord | null = null;
       if (!localRangeData) {
         structuralCacheChecks += 1;
         const structuralProbeStartedAt = Date.now();
@@ -19587,6 +19591,9 @@ function reviewCommand(args: Args): void {
             reviewPolicy,
             reviewModel: PUBLIC_CODEX_MODEL,
           });
+          if (!reviewStructuralRecordAtLeastAsFresh(structuralRecord, item.updatedAt)) {
+            structuralRecord = null;
+          }
         } catch (error) {
           structuralCacheProbeFailures += 1;
           console.error(
@@ -19664,6 +19671,11 @@ function reviewCommand(args: Args): void {
               reviewPolicy,
               reviewModel: PUBLIC_CODEX_MODEL,
             });
+            if (
+              !reviewStructuralRecordAtLeastAsFresh(revalidatedStructuralRecord, item.updatedAt)
+            ) {
+              revalidatedStructuralRecord = null;
+            }
           } catch (error) {
             structuralCacheRevalidationFailures += 1;
             console.error(
@@ -19799,6 +19811,74 @@ function reviewCommand(args: Args): void {
       const contextElapsedMs = Date.now() - contextStartedAt;
       const contextItemUpdatedAt = stringOrUndefined(asRecord(context.issue).updatedAt);
       if (contextItemUpdatedAt) item.updatedAt = contextItemUpdatedAt;
+      if (!localRangeData && contextItemUpdatedAt) {
+        structuralCacheRevalidations += 1;
+        const structuralRevalidationStartedAt = Date.now();
+        try {
+          const candidate = fetchReviewStructuralRecord({
+            item,
+            git,
+            reviewPolicy,
+            reviewModel: PUBLIC_CODEX_MODEL,
+          });
+          const contextPullHeadSha = pullHeadShaFromContext(context)?.trim().toLowerCase() ?? null;
+          if (
+            reviewStructuralRecordMatchesObservedUpdate(candidate, contextItemUpdatedAt) &&
+            (item.kind !== "pull_request" || candidate.pullHeadSha === contextPullHeadSha)
+          ) {
+            hydratedStructuralAnchor = candidate;
+          }
+        } catch (error) {
+          structuralCacheRevalidationFailures += 1;
+          console.error(
+            `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} structural-cache=hydrated-anchor-probe-failed #${item.number}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        } finally {
+          structuralCacheRevalidationMs += Date.now() - structuralRevalidationStartedAt;
+        }
+        const anchorReason = hydratedStructuralAnchor
+          ? "hydrated_anchor_match"
+          : "hydrated_anchor_miss";
+        structuralCacheRevalidationReasons.set(
+          anchorReason,
+          (structuralCacheRevalidationReasons.get(anchorReason) ?? 0) + 1,
+        );
+      }
+      const refreshStructuralRecordForVerdict = (): ReviewStructuralRecord | null => {
+        if (!hydratedStructuralAnchor) return null;
+        structuralCacheRevalidations += 1;
+        const structuralRevalidationStartedAt = Date.now();
+        let candidate: ReviewStructuralRecord | null = null;
+        try {
+          candidate = fetchReviewStructuralRecord({
+            item,
+            git,
+            reviewPolicy,
+            reviewModel: PUBLIC_CODEX_MODEL,
+          });
+        } catch (error) {
+          structuralCacheRevalidationFailures += 1;
+          console.error(
+            `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} structural-cache=verdict-probe-failed #${item.number}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        } finally {
+          structuralCacheRevalidationMs += Date.now() - structuralRevalidationStartedAt;
+        }
+        const matched = reviewStructuralRecordsDescribeSameVerdictInput(
+          hydratedStructuralAnchor,
+          candidate,
+        );
+        const reason = matched ? "verdict_input_match" : "verdict_input_changed";
+        structuralCacheRevalidationReasons.set(
+          reason,
+          (structuralCacheRevalidationReasons.get(reason) ?? 0) + 1,
+        );
+        return matched ? candidate : null;
+      };
       if (
         acquiredReviewLease &&
         pullHeadShaFromContext(context)?.trim().toLowerCase() !== acquiredReviewLease.headSha
@@ -19868,16 +19948,16 @@ function reviewCommand(args: Args): void {
       }
       const contentDigest = itemContentDigest(item, context, git);
       const contentCacheReview = explicitDispatch || maintainerRequest ? null : priorReview;
-      if (
-        reviewContentCacheHit({
-          review: contentCacheReview,
-          reviewPolicy,
-          contentDigest,
-          now: Date.now(),
-          explicitDispatch,
-          maintainerRequest,
-        })
-      ) {
+      const contentCacheHit = reviewContentCacheHit({
+        review: contentCacheReview,
+        reviewPolicy,
+        contentDigest,
+        now: Date.now(),
+        explicitDispatch,
+        maintainerRequest,
+      });
+      if (contentCacheHit) {
+        structuralRecord = refreshStructuralRecordForVerdict();
         const reportPath = join(artifactDir, reportFileName(item.repo, item.number));
         let carried = priorReview!.markdown;
         carried = replaceFrontMatterValue(carried, "reviewed_at", new Date().toISOString());
@@ -19998,6 +20078,7 @@ function reviewCommand(args: Args): void {
         codexElapsedMs,
       };
       const action = reviewActionForDecision({ item, decision, git, runtime });
+      structuralRecord = refreshStructuralRecordForVerdict();
       const reportPath = join(artifactDir, reportFileName(item.repo, item.number));
       writeFileSync(
         reportPath,

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -439,6 +439,7 @@ interface ExistingReview {
   reviewStatus: string | undefined;
   reviewPolicy: string | undefined;
   reviewModel: string | undefined;
+  itemSourceRevision: string | undefined;
   contentDigest: string | undefined;
   lastFullReviewAt: string | undefined;
   lastFullReviewDecision: string | undefined;
@@ -6186,6 +6187,7 @@ function existingReview(
     reviewStatus: effectiveReviewStatus(markdown),
     reviewPolicy: frontMatterValue(markdown, "review_policy"),
     reviewModel: frontMatterValue(markdown, "review_model"),
+    itemSourceRevision: frontMatterValue(markdown, "item_source_revision"),
     contentDigest: frontMatterValue(markdown, "review_content_digest"),
     lastFullReviewAt: frontMatterValue(markdown, "last_full_review_at"),
     lastFullReviewDecision: frontMatterValue(markdown, "last_full_review_decision"),
@@ -6219,6 +6221,7 @@ function buildExistingReviewIndex(itemsDir: string): ExistingReviewIndex {
       reviewStatus: effectiveReviewStatus(markdown),
       reviewPolicy: frontMatterValue(markdown, "review_policy"),
       reviewModel: frontMatterValue(markdown, "review_model"),
+      itemSourceRevision: frontMatterValue(markdown, "item_source_revision"),
       contentDigest: frontMatterValue(markdown, "review_content_digest"),
       lastFullReviewAt: frontMatterValue(markdown, "last_full_review_at"),
       lastFullReviewDecision: frontMatterValue(markdown, "last_full_review_decision"),
@@ -19501,6 +19504,7 @@ function reviewCommand(args: Args): void {
         );
       }
       const priorReview = localRangeData ? null : existingReview(item, itemsDir);
+      let acquiredReviewLease: AcquiredReviewStartLease | null = null;
       let structuralRecord: ReviewStructuralRecord | null = null;
       if (!localRangeData) {
         structuralCacheChecks += 1;
@@ -19531,18 +19535,67 @@ function reviewCommand(args: Args): void {
           reviewModel: PUBLIC_CODEX_MODEL,
           explicitDispatch,
           maintainerRequest,
+          coordinationEnabled: !skipStartComment,
         });
         structuralCacheReasons.set(
           structuralDecision.reason,
           (structuralCacheReasons.get(structuralDecision.reason) ?? 0) + 1,
         );
         if (structuralDecision.hit) {
+          try {
+            const leaseRevision =
+              item.kind === "pull_request"
+                ? structuralRecord?.pullHeadSha
+                : priorReview?.itemSourceRevision;
+            const startComment = postReviewStartStatusComment({
+              item,
+              headSha: leaseRevision ?? "",
+              reviewTimeoutMs: timeoutMs,
+              position: completed + 1,
+              total: candidates.length,
+              shardIndex,
+              shardCount,
+            });
+            console.error(
+              `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} structural-cache-start-comment=${startComment.status} #${item.number}`,
+            );
+            if (startComment.status === "held") {
+              coordinationHeldRetryAt = startComment.retryAt;
+              continue;
+            }
+            acquiredReviewLease = startComment.lease;
+            if (!acquiredReviewLease) {
+              throw new Error(
+                `structural cache lease acquisition returned no identity for #${item.number}`,
+              );
+            }
+            acquiredReviewLeases.push({ itemNumber: item.number, lease: acquiredReviewLease });
+          } catch (error) {
+            leaseAcquisitionFailures += 1;
+            leaseAcquisitionFailureDetails.push(
+              `#${item.number}: ${error instanceof Error ? error.message : String(error)}`,
+            );
+            console.error(
+              `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} structural-cache-start-comment=failed #${item.number}: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+            );
+            continue;
+          }
           const reportPath = join(artifactDir, reportFileName(item.repo, item.number));
           let carried = priorReview!.markdown;
           carried = replaceFrontMatterValue(carried, "reviewed_at", new Date().toISOString());
           carried = replaceFrontMatterValue(carried, "item_updated_at", item.updatedAt);
-          carried = replaceFrontMatterValue(carried, "review_lease_owner", "unknown");
-          carried = replaceFrontMatterValue(carried, "review_lease_comment_id", "unknown");
+          carried = replaceFrontMatterValue(
+            carried,
+            "review_lease_owner",
+            acquiredReviewLease.owner,
+          );
+          carried = replaceFrontMatterValue(
+            carried,
+            "review_lease_comment_id",
+            String(acquiredReviewLease.commentId),
+          );
           carried = replaceFrontMatterValue(carried, "review_cache_hit", "true");
           carried = updateReviewStructuralFrontMatter(carried, structuralRecord, true);
           writeFileSync(reportPath, carried, "utf8");
@@ -19561,7 +19614,6 @@ function reviewCommand(args: Args): void {
           continue;
         }
       }
-      let acquiredReviewLease: AcquiredReviewStartLease | null = null;
       if (!skipStartComment && item.kind === "pull_request") {
         try {
           const startComment = postReviewStartStatusComment({

--- a/src/review-structural-cache.ts
+++ b/src/review-structural-cache.ts
@@ -1,0 +1,852 @@
+import { createHash } from "node:crypto";
+
+import { REVIEW_CACHE_MAX_AGE_DAYS } from "./scheduler-policy.js";
+import { stableJson } from "./stable-json.js";
+
+export const REVIEW_STRUCTURAL_CACHE_VERSION = 1;
+export const REVIEW_STRUCTURAL_CACHE_MAX_AGE_DAYS = REVIEW_CACHE_MAX_AGE_DAYS;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const MAX_MACHINE_METADATA_CHARS = 64 * 1024;
+const SHA_PATTERN = /^[0-9a-f]{40,64}$/;
+const DIGEST_PATTERN = /^[0-9a-f]{64}$/;
+
+export type ReviewStructuralKind = "issue" | "pull_request";
+
+export interface ReviewStructuralActivity {
+  id: string;
+  updatedAt: string;
+  author: string | null;
+  authorAssociation: string | null;
+  state: string | null;
+  commitSha: string | null;
+}
+
+export interface ReviewStructuralThread {
+  id: string;
+  isResolved: boolean;
+  comments: readonly ReviewStructuralActivity[];
+  commentsTruncated: boolean;
+}
+
+export interface ReviewStructuralPullMetadata {
+  headSha: string;
+  baseSha: string;
+  draft: boolean;
+  mergeable: string;
+  additions: number;
+  deletions: number;
+  changedFiles: number;
+  commitCount: number;
+  reviews: readonly ReviewStructuralActivity[];
+  reviewsTruncated: boolean;
+  reviewThreads: readonly ReviewStructuralThread[];
+  reviewThreadsTruncated: boolean;
+}
+
+export interface ReviewStructuralSnapshot {
+  repo: string;
+  number: number;
+  kind: ReviewStructuralKind;
+  nodeId: string;
+  author: string;
+  authorAssociation: string;
+  titleDigest: string;
+  bodyDigest: string;
+  state: string;
+  locked: boolean;
+  labels: readonly string[];
+  labelsTruncated: boolean;
+  activityUpdatedAt: string;
+  comments: readonly ReviewStructuralActivity[];
+  commentsTruncated: boolean;
+  timeline: readonly unknown[];
+  timelineTruncated: boolean;
+  targetHeadSha: string;
+  latestReleaseTag: string | null;
+  latestReleaseSha: string | null;
+  pull: ReviewStructuralPullMetadata | null;
+}
+
+export interface ReviewStructuralRecord {
+  version: typeof REVIEW_STRUCTURAL_CACHE_VERSION;
+  fingerprint: string;
+  kind: ReviewStructuralKind;
+  sourceRevision: string;
+  activityUpdatedAt: string;
+  targetHeadSha: string;
+  pullHeadSha: string | null;
+  reviewPolicy: string;
+  reviewModel: string;
+}
+
+export interface ReviewStructuralPriorReview {
+  reviewStatus?: string | undefined;
+  decision?: string | undefined;
+  lastFullReviewAt?: string | undefined;
+  lastFullReviewDecision?: string | undefined;
+  reviewPolicy?: string | undefined;
+  reviewModel?: string | undefined;
+  reviewCommentSyncedAt?: string | undefined;
+  labelsSyncedAt?: string | undefined;
+}
+
+export type ReviewStructuralCacheReason =
+  | "hit"
+  | "explicit_dispatch"
+  | "maintainer_request"
+  | "missing_review"
+  | "incomplete_review"
+  | "non_keep_open_verdict"
+  | "policy_changed"
+  | "model_changed"
+  | "stale_review"
+  | "missing_or_invalid_record"
+  | "item_kind_changed"
+  | "source_changed"
+  | "activity_changed"
+  | "target_changed"
+  | "pull_head_changed";
+
+export interface ReviewStructuralCacheDecision {
+  hit: boolean;
+  reason: ReviewStructuralCacheReason;
+}
+
+export interface ReviewStructuralGraphqlOptions {
+  response: unknown;
+  repo: string;
+  number: number;
+  kind: ReviewStructuralKind;
+  targetHeadSha: string;
+  latestReleaseTag: string | null;
+  latestReleaseSha: string | null;
+  reviewPolicy: string;
+  reviewModel: string;
+  ignoreAuthor: (author: string) => boolean;
+  ignoreLabel: (label: string) => boolean;
+}
+
+const REVIEW_STRUCTURAL_TIMELINE_QUERY = `
+  timelineItems(last: 100) {
+    pageInfo { hasPreviousPage }
+    nodes {
+      __typename
+      ... on Node { id }
+      ... on IssueComment {
+        updatedAt
+        author { login }
+      }
+      ... on LabeledEvent {
+        createdAt
+        actor { login }
+        label { name }
+      }
+      ... on UnlabeledEvent {
+        createdAt
+        actor { login }
+        label { name }
+      }
+      ... on CrossReferencedEvent {
+        createdAt
+        willCloseTarget
+        source {
+          __typename
+          ... on Issue {
+            id
+            number
+            state
+            updatedAt
+            repository { nameWithOwner }
+          }
+          ... on PullRequest {
+            id
+            number
+            state
+            updatedAt
+            headRefOid
+            repository { nameWithOwner }
+          }
+        }
+      }
+      ... on ConnectedEvent {
+        createdAt
+        subject {
+          __typename
+          ... on Issue {
+            id
+            number
+            state
+            updatedAt
+            repository { nameWithOwner }
+          }
+          ... on PullRequest {
+            id
+            number
+            state
+            updatedAt
+            headRefOid
+            repository { nameWithOwner }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const REVIEW_STRUCTURAL_COMMON_QUERY = `
+  id
+  number
+  title
+  body
+  state
+  locked
+  updatedAt
+  author { login }
+  authorAssociation
+  labels(first: 100) {
+    pageInfo { hasNextPage }
+    nodes { name }
+  }
+  comments(last: 100) {
+    pageInfo { hasPreviousPage }
+    nodes {
+      id
+      updatedAt
+      author { login }
+      authorAssociation
+    }
+  }
+  ${REVIEW_STRUCTURAL_TIMELINE_QUERY}
+`;
+
+export function reviewStructuralQuery(kind: ReviewStructuralKind): string {
+  const field = kind === "pull_request" ? "pullRequest" : "issue";
+  const pullFields =
+    kind === "pull_request"
+      ? `
+        headRefOid
+        baseRefOid
+        isDraft
+        mergeable
+        additions
+        deletions
+        changedFiles
+        commits(first: 1) { totalCount }
+        reviews(last: 100) {
+          pageInfo { hasPreviousPage }
+          nodes {
+            id
+            updatedAt
+            author { login }
+            authorAssociation
+            state
+            commit { oid }
+          }
+        }
+        reviewThreads(last: 100) {
+          pageInfo { hasPreviousPage }
+          nodes {
+            id
+            isResolved
+            comments(last: 100) {
+              pageInfo { hasPreviousPage }
+              nodes {
+                id
+                updatedAt
+                author { login }
+                authorAssociation
+              }
+            }
+          }
+        }
+      `
+      : "";
+  return `
+    query ReviewStructuralMetadata($owner: String!, $name: String!, $number: Int!) {
+      repository(owner: $owner, name: $name) {
+        ${field}(number: $number) {
+          ${REVIEW_STRUCTURAL_COMMON_QUERY}
+          ${pullFields}
+        }
+      }
+    }
+  `;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function stringOrUndefined(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function nonNegativeInteger(value: unknown): number | null {
+  const number =
+    typeof value === "number" ? value : typeof value === "string" ? Number(value) : Number.NaN;
+  if (!Number.isFinite(number) || number < 0) return null;
+  return Math.floor(number);
+}
+
+function structuralConnection(value: unknown): {
+  nodes: unknown[];
+  truncated: boolean;
+} {
+  const connection = asRecord(value);
+  const nodes = connection.nodes;
+  const pageInfo = asRecord(connection.pageInfo);
+  if (!Array.isArray(nodes)) return { nodes: [], truncated: true };
+  return {
+    nodes,
+    truncated:
+      pageInfo.hasPreviousPage === true ||
+      pageInfo.hasNextPage === true ||
+      (pageInfo.hasPreviousPage !== false && pageInfo.hasNextPage !== false),
+  };
+}
+
+function structuralActivities(
+  value: unknown,
+  ignoreAuthor: (author: string) => boolean,
+): {
+  activities: ReviewStructuralActivity[];
+  truncated: boolean;
+} {
+  const connection = structuralConnection(value);
+  let malformed = false;
+  const activities = connection.nodes.flatMap((entry) => {
+    const record = asRecord(entry);
+    const id = stringOrUndefined(record.id);
+    const updatedAt = stringOrUndefined(record.updatedAt);
+    const author = stringOrUndefined(asRecord(record.author).login) ?? null;
+    const authorAssociation = stringOrUndefined(record.authorAssociation) ?? null;
+    const state = stringOrUndefined(record.state) ?? null;
+    const commitSha = stringOrUndefined(asRecord(record.commit).oid) ?? null;
+    if (!id || !updatedAt) {
+      malformed = true;
+      return [];
+    }
+    if (author && ignoreAuthor(author)) return [];
+    return [{ id, updatedAt, author, authorAssociation, state, commitSha }];
+  });
+  return { activities, truncated: connection.truncated || malformed };
+}
+
+export function reviewStructuralActivitiesForTest(
+  value: unknown,
+  ignoredAuthors: readonly string[] = [],
+): {
+  activities: ReviewStructuralActivity[];
+  truncated: boolean;
+} {
+  const ignored = new Set(ignoredAuthors.map((author) => author.toLowerCase()));
+  return structuralActivities(value, (author) => ignored.has(author.toLowerCase()));
+}
+
+function structuralLabels(
+  value: unknown,
+  ignoreLabel: (label: string) => boolean,
+): {
+  labels: string[];
+  truncated: boolean;
+} {
+  const connection = structuralConnection(value);
+  let malformed = false;
+  const labels = connection.nodes.flatMap((entry) => {
+    const name = stringOrUndefined(asRecord(entry).name);
+    if (!name) {
+      malformed = true;
+      return [];
+    }
+    return ignoreLabel(name) ? [] : [name];
+  });
+  return { labels, truncated: connection.truncated || malformed };
+}
+
+function structuralRelationTarget(value: unknown): unknown {
+  const target = asRecord(value);
+  const repository = stringOrUndefined(asRecord(target.repository).nameWithOwner);
+  const type = stringOrUndefined(target.__typename);
+  const id = stringOrUndefined(target.id);
+  const number = nonNegativeInteger(target.number);
+  if (!type || !id || !repository || number === null) return null;
+  return {
+    type,
+    id,
+    repository,
+    number,
+    state: stringOrUndefined(target.state) ?? null,
+    updatedAt: stringOrUndefined(target.updatedAt) ?? null,
+    headSha: stringOrUndefined(target.headRefOid) ?? null,
+  };
+}
+
+function structuralTimeline(
+  value: unknown,
+  ignoreAuthor: (author: string) => boolean,
+  ignoreLabel: (label: string) => boolean,
+): {
+  timeline: unknown[];
+  truncated: boolean;
+} {
+  const connection = structuralConnection(value);
+  let malformed = false;
+  const timeline = connection.nodes.flatMap((entry) => {
+    const record = asRecord(entry);
+    const type = stringOrUndefined(record.__typename);
+    const id = stringOrUndefined(record.id);
+    const author =
+      stringOrUndefined(asRecord(record.author).login) ??
+      stringOrUndefined(asRecord(record.actor).login) ??
+      null;
+    const label = stringOrUndefined(asRecord(record.label).name) ?? null;
+    if (!type || !id) {
+      malformed = true;
+      return [];
+    }
+    if (author && ignoreAuthor(author)) return [];
+    if (label && ignoreLabel(label)) return [];
+    return [
+      {
+        type,
+        id,
+        createdAt: stringOrUndefined(record.createdAt) ?? null,
+        updatedAt: stringOrUndefined(record.updatedAt) ?? null,
+        author,
+        label,
+        willCloseTarget:
+          typeof record.willCloseTarget === "boolean" ? record.willCloseTarget : null,
+        target: structuralRelationTarget(record.source ?? record.subject),
+      },
+    ];
+  });
+  return { timeline, truncated: connection.truncated || malformed };
+}
+
+function structuralReviewThreads(
+  value: unknown,
+  ignoreAuthor: (author: string) => boolean,
+): {
+  threads: ReviewStructuralThread[];
+  truncated: boolean;
+} {
+  const connection = structuralConnection(value);
+  let malformed = false;
+  const threads = connection.nodes.flatMap((entry) => {
+    const record = asRecord(entry);
+    const id = stringOrUndefined(record.id);
+    if (!id || typeof record.isResolved !== "boolean") {
+      malformed = true;
+      return [];
+    }
+    const comments = structuralActivities(record.comments, ignoreAuthor);
+    return [
+      {
+        id,
+        isResolved: record.isResolved,
+        comments: comments.activities,
+        commentsTruncated: comments.truncated,
+      },
+    ];
+  });
+  return { threads, truncated: connection.truncated || malformed };
+}
+
+export function reviewStructuralRecordFromGraphql(
+  options: ReviewStructuralGraphqlOptions,
+): ReviewStructuralRecord | null {
+  const response = asRecord(options.response);
+  const repository = asRecord(asRecord(response.data).repository);
+  const node = asRecord(
+    options.kind === "pull_request" ? repository.pullRequest : repository.issue,
+  );
+  const id = stringOrUndefined(node.id);
+  const number = nonNegativeInteger(node.number);
+  const title = stringOrUndefined(node.title);
+  const author = stringOrUndefined(asRecord(node.author).login);
+  const authorAssociation = stringOrUndefined(node.authorAssociation);
+  const body = node.body;
+  const state = stringOrUndefined(node.state);
+  const updatedAt = stringOrUndefined(node.updatedAt);
+  if (
+    !id ||
+    number !== options.number ||
+    title === undefined ||
+    !author ||
+    !authorAssociation ||
+    (typeof body !== "string" && body !== null) ||
+    !state ||
+    typeof node.locked !== "boolean" ||
+    !updatedAt
+  ) {
+    return null;
+  }
+  const labels = structuralLabels(node.labels, options.ignoreLabel);
+  const comments = structuralActivities(node.comments, options.ignoreAuthor);
+  const timeline = structuralTimeline(
+    node.timelineItems,
+    options.ignoreAuthor,
+    options.ignoreLabel,
+  );
+  const snapshot: ReviewStructuralSnapshot = {
+    repo: options.repo,
+    number: options.number,
+    kind: options.kind,
+    nodeId: id,
+    author,
+    authorAssociation,
+    titleDigest: sha256(title),
+    bodyDigest: sha256(typeof body === "string" ? body : ""),
+    state,
+    locked: node.locked,
+    labels: labels.labels,
+    labelsTruncated: labels.truncated,
+    activityUpdatedAt: updatedAt,
+    comments: comments.activities,
+    commentsTruncated: comments.truncated,
+    timeline: timeline.timeline,
+    timelineTruncated: timeline.truncated,
+    targetHeadSha: options.targetHeadSha.trim().toLowerCase(),
+    latestReleaseTag: options.latestReleaseTag,
+    latestReleaseSha: options.latestReleaseSha?.trim().toLowerCase() ?? null,
+    pull: null,
+  };
+  if (options.kind === "pull_request") {
+    const reviews = structuralActivities(node.reviews, options.ignoreAuthor);
+    const reviewThreads = structuralReviewThreads(node.reviewThreads, options.ignoreAuthor);
+    const headSha = stringOrUndefined(node.headRefOid)?.trim().toLowerCase();
+    const baseSha = stringOrUndefined(node.baseRefOid)?.trim().toLowerCase();
+    const additions = nonNegativeInteger(node.additions);
+    const deletions = nonNegativeInteger(node.deletions);
+    const changedFiles = nonNegativeInteger(node.changedFiles);
+    const commitCount = nonNegativeInteger(asRecord(node.commits).totalCount);
+    if (
+      !headSha ||
+      !baseSha ||
+      typeof node.isDraft !== "boolean" ||
+      !stringOrUndefined(node.mergeable) ||
+      additions === null ||
+      deletions === null ||
+      changedFiles === null ||
+      commitCount === null
+    ) {
+      return null;
+    }
+    snapshot.pull = {
+      headSha,
+      baseSha,
+      draft: node.isDraft,
+      mergeable: String(node.mergeable),
+      additions,
+      deletions,
+      changedFiles,
+      commitCount,
+      reviews: reviews.activities,
+      reviewsTruncated: reviews.truncated,
+      reviewThreads: reviewThreads.threads,
+      reviewThreadsTruncated: reviewThreads.truncated,
+    };
+  }
+  return createReviewStructuralRecord(snapshot, {
+    reviewPolicy: options.reviewPolicy,
+    reviewModel: options.reviewModel,
+  });
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function validTimestamp(value: string): boolean {
+  return value.length > 0 && Number.isFinite(Date.parse(value));
+}
+
+function validActivity(activity: ReviewStructuralActivity): boolean {
+  return (
+    activity.id.length > 0 &&
+    activity.id.length <= 128 &&
+    validTimestamp(activity.updatedAt) &&
+    (activity.author === null || activity.author.length <= 128) &&
+    (activity.authorAssociation === null || activity.authorAssociation.length <= 64) &&
+    (activity.state === null || activity.state.length <= 64) &&
+    (activity.commitSha === null || SHA_PATTERN.test(activity.commitSha))
+  );
+}
+
+function validMachineMetadata(value: unknown): boolean {
+  const serialized = stableJson(value);
+  return serialized.length > 0 && serialized.length <= MAX_MACHINE_METADATA_CHARS;
+}
+
+function normalizedActivities(
+  activities: readonly ReviewStructuralActivity[],
+): ReviewStructuralActivity[] {
+  return [...activities]
+    .map((activity) => ({
+      id: activity.id,
+      updatedAt: activity.updatedAt,
+      author: activity.author?.toLowerCase() ?? null,
+      authorAssociation: activity.authorAssociation?.toUpperCase() ?? null,
+      state: activity.state?.toUpperCase() ?? null,
+      commitSha: activity.commitSha,
+    }))
+    .sort(
+      (left, right) =>
+        left.id.localeCompare(right.id) ||
+        left.updatedAt.localeCompare(right.updatedAt) ||
+        String(left.author).localeCompare(String(right.author)),
+    );
+}
+
+function sourceRevision(snapshot: ReviewStructuralSnapshot): string {
+  return sha256(
+    stableJson({
+      repo: snapshot.repo,
+      number: snapshot.number,
+      kind: snapshot.kind,
+      nodeId: snapshot.nodeId,
+      author: snapshot.author.toLowerCase(),
+      authorAssociation: snapshot.authorAssociation.toUpperCase(),
+      titleDigest: snapshot.titleDigest,
+      bodyDigest: snapshot.bodyDigest,
+      state: snapshot.state,
+      locked: snapshot.locked,
+      labels: [...snapshot.labels].map((label) => label.toLowerCase()).sort(),
+      comments: normalizedActivities(snapshot.comments),
+      timeline: snapshot.timeline,
+      latestRelease: {
+        tag: snapshot.latestReleaseTag,
+        sha: snapshot.latestReleaseSha,
+      },
+      pull:
+        snapshot.pull === null
+          ? null
+          : {
+              baseSha: snapshot.pull.baseSha,
+              draft: snapshot.pull.draft,
+              mergeable: snapshot.pull.mergeable,
+              additions: snapshot.pull.additions,
+              deletions: snapshot.pull.deletions,
+              changedFiles: snapshot.pull.changedFiles,
+              commitCount: snapshot.pull.commitCount,
+              reviews: normalizedActivities(snapshot.pull.reviews),
+              reviewThreads: [...snapshot.pull.reviewThreads]
+                .map((thread) => ({
+                  id: thread.id,
+                  isResolved: thread.isResolved,
+                  comments: normalizedActivities(thread.comments),
+                }))
+                .sort((left, right) => left.id.localeCompare(right.id)),
+            },
+    }),
+  );
+}
+
+function recordFingerprint(record: Omit<ReviewStructuralRecord, "fingerprint">): string {
+  return sha256(stableJson(record));
+}
+
+function validPullMetadata(pull: ReviewStructuralPullMetadata): boolean {
+  return (
+    SHA_PATTERN.test(pull.headSha) &&
+    SHA_PATTERN.test(pull.baseSha) &&
+    Number.isSafeInteger(pull.additions) &&
+    pull.additions >= 0 &&
+    Number.isSafeInteger(pull.deletions) &&
+    pull.deletions >= 0 &&
+    Number.isSafeInteger(pull.changedFiles) &&
+    pull.changedFiles >= 0 &&
+    Number.isSafeInteger(pull.commitCount) &&
+    pull.commitCount >= 0 &&
+    !pull.reviewsTruncated &&
+    pull.reviews.every(validActivity) &&
+    !pull.reviewThreadsTruncated &&
+    pull.reviewThreads.every(
+      (thread) =>
+        thread.id.length > 0 &&
+        thread.id.length <= 128 &&
+        !thread.commentsTruncated &&
+        thread.comments.every(validActivity),
+    )
+  );
+}
+
+export function createReviewStructuralRecord(
+  snapshot: ReviewStructuralSnapshot,
+  options: { reviewPolicy: string; reviewModel: string },
+): ReviewStructuralRecord | null {
+  if (
+    !snapshot.repo ||
+    !Number.isSafeInteger(snapshot.number) ||
+    snapshot.number < 0 ||
+    !snapshot.nodeId ||
+    !snapshot.author ||
+    snapshot.author.length > 128 ||
+    !snapshot.authorAssociation ||
+    snapshot.authorAssociation.length > 64 ||
+    !DIGEST_PATTERN.test(snapshot.titleDigest) ||
+    !DIGEST_PATTERN.test(snapshot.bodyDigest) ||
+    !snapshot.state ||
+    snapshot.labelsTruncated ||
+    snapshot.labels.length > 100 ||
+    !validTimestamp(snapshot.activityUpdatedAt) ||
+    snapshot.commentsTruncated ||
+    snapshot.comments.length > 100 ||
+    !snapshot.comments.every(validActivity) ||
+    snapshot.timelineTruncated ||
+    snapshot.timeline.length > 100 ||
+    !validMachineMetadata(snapshot.timeline) ||
+    !validMachineMetadata({
+      comments: snapshot.comments,
+      reviews: snapshot.pull?.reviews ?? [],
+      reviewThreads: snapshot.pull?.reviewThreads ?? [],
+    }) ||
+    !SHA_PATTERN.test(snapshot.targetHeadSha) ||
+    (snapshot.latestReleaseTag !== null &&
+      (snapshot.latestReleaseTag.length === 0 || snapshot.latestReleaseTag.length > 128)) ||
+    (snapshot.latestReleaseSha !== null && !SHA_PATTERN.test(snapshot.latestReleaseSha)) ||
+    !options.reviewPolicy ||
+    !options.reviewModel
+  ) {
+    return null;
+  }
+  if (snapshot.kind === "pull_request") {
+    if (!snapshot.pull || !validPullMetadata(snapshot.pull)) return null;
+  } else if (snapshot.pull !== null) {
+    return null;
+  }
+  const recordWithoutFingerprint = {
+    version: REVIEW_STRUCTURAL_CACHE_VERSION,
+    kind: snapshot.kind,
+    sourceRevision: sourceRevision(snapshot),
+    activityUpdatedAt: snapshot.activityUpdatedAt,
+    targetHeadSha: snapshot.targetHeadSha,
+    pullHeadSha: snapshot.pull?.headSha ?? null,
+    reviewPolicy: options.reviewPolicy,
+    reviewModel: options.reviewModel,
+  } satisfies Omit<ReviewStructuralRecord, "fingerprint">;
+  return {
+    ...recordWithoutFingerprint,
+    fingerprint: recordFingerprint(recordWithoutFingerprint),
+  };
+}
+
+export function validReviewStructuralRecord(
+  record: ReviewStructuralRecord | null,
+): record is ReviewStructuralRecord {
+  if (!record) return false;
+  if (
+    record.version !== REVIEW_STRUCTURAL_CACHE_VERSION ||
+    !DIGEST_PATTERN.test(record.fingerprint) ||
+    !DIGEST_PATTERN.test(record.sourceRevision) ||
+    !validTimestamp(record.activityUpdatedAt) ||
+    !SHA_PATTERN.test(record.targetHeadSha) ||
+    !record.reviewPolicy ||
+    !record.reviewModel
+  ) {
+    return false;
+  }
+  if (record.kind === "pull_request") {
+    if (!record.pullHeadSha || !SHA_PATTERN.test(record.pullHeadSha)) return false;
+  } else if (record.pullHeadSha !== null) {
+    return false;
+  }
+  const { fingerprint: _, ...recordWithoutFingerprint } = record;
+  return fingerprintMatches(recordFingerprint(recordWithoutFingerprint), record.fingerprint);
+}
+
+function fingerprintMatches(expected: string, actual: string): boolean {
+  return expected === actual;
+}
+
+function timestampMs(value: string | undefined): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function activityCoveredByReview(
+  prior: ReviewStructuralRecord,
+  current: ReviewStructuralRecord,
+  review: ReviewStructuralPriorReview,
+): boolean {
+  if (current.activityUpdatedAt === prior.activityUpdatedAt) return true;
+  const priorActivity = timestampMs(prior.activityUpdatedAt);
+  const currentActivity = timestampMs(current.activityUpdatedAt);
+  const latestOwnedSync = Math.max(
+    timestampMs(review.reviewCommentSyncedAt) ?? -Infinity,
+    timestampMs(review.labelsSyncedAt) ?? -Infinity,
+  );
+  return (
+    priorActivity !== null &&
+    currentActivity !== null &&
+    Number.isFinite(latestOwnedSync) &&
+    currentActivity >= priorActivity &&
+    currentActivity <= latestOwnedSync
+  );
+}
+
+export function reviewStructuralCacheDecision(options: {
+  review: ReviewStructuralPriorReview | null;
+  priorRecord: ReviewStructuralRecord | null;
+  currentRecord: ReviewStructuralRecord | null;
+  reviewPolicy: string;
+  reviewModel: string;
+  explicitDispatch: boolean;
+  maintainerRequest: boolean;
+  now?: number;
+}): ReviewStructuralCacheDecision {
+  if (options.explicitDispatch) return { hit: false, reason: "explicit_dispatch" };
+  if (options.maintainerRequest) return { hit: false, reason: "maintainer_request" };
+  const review = options.review;
+  if (!review) return { hit: false, reason: "missing_review" };
+  if (review.reviewStatus !== "complete") return { hit: false, reason: "incomplete_review" };
+  if (review.decision !== "keep_open" || review.lastFullReviewDecision !== "keep_open") {
+    return { hit: false, reason: "non_keep_open_verdict" };
+  }
+  if (review.reviewPolicy !== options.reviewPolicy) {
+    return { hit: false, reason: "policy_changed" };
+  }
+  if (review.reviewModel !== options.reviewModel) {
+    return { hit: false, reason: "model_changed" };
+  }
+  const lastFullReviewAt = timestampMs(review.lastFullReviewAt);
+  const now = options.now ?? Date.now();
+  if (
+    lastFullReviewAt === null ||
+    now - lastFullReviewAt >= REVIEW_STRUCTURAL_CACHE_MAX_AGE_DAYS * DAY_MS
+  ) {
+    return { hit: false, reason: "stale_review" };
+  }
+  const prior = options.priorRecord;
+  const current = options.currentRecord;
+  if (!validReviewStructuralRecord(prior) || !validReviewStructuralRecord(current)) {
+    return { hit: false, reason: "missing_or_invalid_record" };
+  }
+  if (
+    prior.reviewPolicy !== options.reviewPolicy ||
+    current.reviewPolicy !== options.reviewPolicy
+  ) {
+    return { hit: false, reason: "policy_changed" };
+  }
+  if (prior.reviewModel !== options.reviewModel || current.reviewModel !== options.reviewModel) {
+    return { hit: false, reason: "model_changed" };
+  }
+  if (prior.kind !== current.kind) return { hit: false, reason: "item_kind_changed" };
+  if (prior.sourceRevision !== current.sourceRevision) {
+    return { hit: false, reason: "source_changed" };
+  }
+  if (!activityCoveredByReview(prior, current, review)) {
+    return { hit: false, reason: "activity_changed" };
+  }
+  if (prior.targetHeadSha !== current.targetHeadSha) {
+    return { hit: false, reason: "target_changed" };
+  }
+  if (prior.pullHeadSha !== current.pullHeadSha) {
+    return { hit: false, reason: "pull_head_changed" };
+  }
+  return { hit: true, reason: "hit" };
+}

--- a/src/review-structural-cache.ts
+++ b/src/review-structural-cache.ts
@@ -149,6 +149,16 @@ export interface ReviewStructuralCacheDecision {
   reason: ReviewStructuralCacheReason;
 }
 
+export interface ReviewStructuralCacheProbeOptions {
+  review: ReviewStructuralPriorReview | null;
+  reviewPolicy: string;
+  reviewModel: string;
+  explicitDispatch: boolean;
+  maintainerRequest: boolean;
+  coordinationEnabled: boolean;
+  now?: number;
+}
+
 export interface ReviewStructuralGraphqlOptions {
   response: unknown;
   repo: string;
@@ -1134,17 +1144,9 @@ function activityCoveredByReview(
   );
 }
 
-export function reviewStructuralCacheDecision(options: {
-  review: ReviewStructuralPriorReview | null;
-  priorRecord: ReviewStructuralRecord | null;
-  currentRecord: ReviewStructuralRecord | null;
-  reviewPolicy: string;
-  reviewModel: string;
-  explicitDispatch: boolean;
-  maintainerRequest: boolean;
-  coordinationEnabled: boolean;
-  now?: number;
-}): ReviewStructuralCacheDecision {
+export function reviewStructuralCacheProbeDecision(
+  options: ReviewStructuralCacheProbeOptions,
+): ReviewStructuralCacheDecision {
   if (options.explicitDispatch) return { hit: false, reason: "explicit_dispatch" };
   if (options.maintainerRequest) return { hit: false, reason: "maintainer_request" };
   if (!options.coordinationEnabled) return { hit: false, reason: "coordination_disabled" };
@@ -1172,6 +1174,18 @@ export function reviewStructuralCacheDecision(options: {
   ) {
     return { hit: false, reason: "stale_review" };
   }
+  return { hit: true, reason: "hit" };
+}
+
+export function reviewStructuralCacheDecision(
+  options: ReviewStructuralCacheProbeOptions & {
+    priorRecord: ReviewStructuralRecord | null;
+    currentRecord: ReviewStructuralRecord | null;
+  },
+): ReviewStructuralCacheDecision {
+  const probeDecision = reviewStructuralCacheProbeDecision(options);
+  if (!probeDecision.hit) return probeDecision;
+  const review = options.review!;
   const prior = options.priorRecord;
   const current = options.currentRecord;
   if (!validReviewStructuralRecord(prior) || !validReviewStructuralRecord(current)) {

--- a/src/review-structural-cache.ts
+++ b/src/review-structural-cache.ts
@@ -3,7 +3,7 @@ import { createHash } from "node:crypto";
 import { REVIEW_CACHE_MAX_AGE_DAYS } from "./scheduler-policy.js";
 import { stableJson } from "./stable-json.js";
 
-export const REVIEW_STRUCTURAL_CACHE_VERSION = 1;
+export const REVIEW_STRUCTURAL_CACHE_VERSION = 2;
 export const REVIEW_STRUCTURAL_CACHE_MAX_AGE_DAYS = REVIEW_CACHE_MAX_AGE_DAYS;
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -63,6 +63,7 @@ export interface ReviewStructuralSnapshot {
   commentsTruncated: boolean;
   timeline: readonly unknown[];
   timelineTruncated: boolean;
+  relationSensitive: boolean;
   targetHeadSha: string;
   latestReleaseTag: string | null;
   latestReleaseSha: string | null;
@@ -75,6 +76,7 @@ export interface ReviewStructuralRecord {
   kind: ReviewStructuralKind;
   sourceRevision: string;
   activityUpdatedAt: string;
+  relationSensitive: boolean;
   targetHeadSha: string;
   pullHeadSha: string | null;
   reviewPolicy: string;
@@ -109,6 +111,7 @@ export type ReviewStructuralCacheReason =
   | "item_kind_changed"
   | "source_changed"
   | "activity_changed"
+  | "relation_context_present"
   | "target_changed"
   | "pull_head_changed";
 
@@ -129,6 +132,7 @@ export interface ReviewStructuralGraphqlOptions {
   reviewModel: string;
   ignoreAuthor: (author: string) => boolean;
   ignoreLabel: (label: string) => boolean;
+  externalRelationSensitive?: boolean;
 }
 
 const REVIEW_STRUCTURAL_TIMELINE_QUERY = `
@@ -139,6 +143,7 @@ const REVIEW_STRUCTURAL_TIMELINE_QUERY = `
       ... on Node { id }
       ... on IssueComment {
         updatedAt
+        body
         author { login }
       }
       ... on LabeledEvent {
@@ -217,6 +222,7 @@ const REVIEW_STRUCTURAL_COMMON_QUERY = `
     nodes {
       id
       updatedAt
+      body
       author { login }
       authorAssociation
     }
@@ -259,6 +265,7 @@ export function reviewStructuralQuery(kind: ReviewStructuralKind): string {
               nodes {
                 id
                 updatedAt
+                body
                 author { login }
                 authorAssociation
               }
@@ -404,6 +411,77 @@ function structuralRelationTarget(value: unknown): unknown {
   };
 }
 
+function relatedItemReference(value: unknown, repo: string, currentNumber: number): boolean {
+  if (typeof value !== "string" || !value.trim()) return false;
+  const [owner, name] = repo.split("/");
+  if (!owner || !name) return false;
+  const escapedRepo = `${escapeRegExp(owner)}\\/${escapeRegExp(name)}`;
+  for (const match of value.matchAll(
+    new RegExp(
+      `github\\.com\\/${escapedRepo}\\/(?:issues|pull)\\/(\\d+)|(?<![\\w/])#(\\d+)\\b`,
+      "g",
+    ),
+  )) {
+    const number = Number(match[1] ?? match[2]);
+    if (Number.isInteger(number) && number > 0 && number !== currentNumber) return true;
+  }
+  return false;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function commentRelationSensitivity(
+  value: unknown,
+  options: ReviewStructuralGraphqlOptions,
+): boolean | null {
+  const connection = structuralConnection(value, "last");
+  if (connection.truncated) return null;
+  for (const entry of connection.nodes) {
+    const record = asRecord(entry);
+    const author = stringOrUndefined(asRecord(record.author).login);
+    if (author && options.ignoreAuthor(author)) continue;
+    if (typeof record.body !== "string") return null;
+    if (relatedItemReference(record.body, options.repo, options.number)) return true;
+  }
+  return false;
+}
+
+function timelineRelationSensitivity(
+  value: unknown,
+  options: ReviewStructuralGraphqlOptions,
+): boolean | null {
+  const connection = structuralConnection(value, "last");
+  if (connection.truncated) return null;
+  for (const entry of connection.nodes) {
+    const record = asRecord(entry);
+    const type = stringOrUndefined(record.__typename);
+    if (!type) return null;
+    if (type === "CrossReferencedEvent" || type === "ConnectedEvent") return true;
+    if (type !== "IssueComment") continue;
+    const author = stringOrUndefined(asRecord(record.author).login);
+    if (author && options.ignoreAuthor(author)) continue;
+    if (typeof record.body !== "string") return null;
+    if (relatedItemReference(record.body, options.repo, options.number)) return true;
+  }
+  return false;
+}
+
+function reviewThreadRelationSensitivity(
+  value: unknown,
+  options: ReviewStructuralGraphqlOptions,
+): boolean | null {
+  const connection = structuralConnection(value, "last");
+  if (connection.truncated) return null;
+  for (const entry of connection.nodes) {
+    const sensitive = commentRelationSensitivity(asRecord(entry).comments, options);
+    if (sensitive === null) return null;
+    if (sensitive) return true;
+  }
+  return false;
+}
+
 function structuralTimeline(
   value: unknown,
   ignoreAuthor: (author: string) => boolean,
@@ -519,6 +597,14 @@ export function reviewStructuralRecordFromGraphql(
     options.ignoreAuthor,
     options.ignoreLabel,
   );
+  const commentRelations = commentRelationSensitivity(node.comments, options);
+  const timelineRelations = timelineRelationSensitivity(node.timelineItems, options);
+  if (commentRelations === null || timelineRelations === null) return null;
+  let relationSensitive =
+    options.externalRelationSensitive === true ||
+    relatedItemReference(body, options.repo, options.number) ||
+    commentRelations ||
+    timelineRelations;
   const snapshot: ReviewStructuralSnapshot = {
     repo: options.repo,
     number: options.number,
@@ -537,6 +623,7 @@ export function reviewStructuralRecordFromGraphql(
     commentsTruncated: comments.truncated,
     timeline: timeline.timeline,
     timelineTruncated: timeline.truncated,
+    relationSensitive,
     targetHeadSha: options.targetHeadSha.trim().toLowerCase(),
     latestReleaseTag: options.latestReleaseTag,
     latestReleaseSha: options.latestReleaseSha?.trim().toLowerCase() ?? null,
@@ -545,6 +632,7 @@ export function reviewStructuralRecordFromGraphql(
   if (options.kind === "pull_request") {
     const reviews = structuralActivities(node.reviews, options.ignoreAuthor);
     const reviewThreads = structuralReviewThreads(node.reviewThreads, options.ignoreAuthor);
+    const reviewThreadRelations = reviewThreadRelationSensitivity(node.reviewThreads, options);
     const headSha = stringOrUndefined(node.headRefOid)?.trim().toLowerCase();
     const baseSha = stringOrUndefined(node.baseRefOid)?.trim().toLowerCase();
     const additions = nonNegativeInteger(node.additions);
@@ -564,6 +652,9 @@ export function reviewStructuralRecordFromGraphql(
     ) {
       return null;
     }
+    if (reviewThreadRelations === null) return null;
+    relationSensitive ||= reviewThreadRelations;
+    snapshot.relationSensitive = relationSensitive;
     snapshot.pull = {
       headSha,
       baseSha,
@@ -647,6 +738,7 @@ function sourceRevision(snapshot: ReviewStructuralSnapshot): string {
       labels: [...snapshot.labels].map((label) => label.toLowerCase()).sort(),
       comments: normalizedActivities(snapshot.comments),
       timeline: snapshot.timeline,
+      relationSensitive: snapshot.relationSensitive,
       latestRelease: {
         tag: snapshot.latestReleaseTag,
         sha: snapshot.latestReleaseSha,
@@ -733,6 +825,7 @@ export function createReviewStructuralRecord(
     !snapshot.comments.every(validActivity) ||
     snapshot.timelineTruncated ||
     snapshot.timeline.length > 100 ||
+    typeof snapshot.relationSensitive !== "boolean" ||
     !validMachineMetadata(snapshot.timeline) ||
     !validMachineMetadata({
       comments: snapshot.comments,
@@ -758,6 +851,7 @@ export function createReviewStructuralRecord(
     kind: snapshot.kind,
     sourceRevision: sourceRevision(snapshot),
     activityUpdatedAt: snapshot.activityUpdatedAt,
+    relationSensitive: snapshot.relationSensitive,
     targetHeadSha: snapshot.targetHeadSha,
     pullHeadSha: snapshot.pull?.headSha ?? null,
     reviewPolicy: options.reviewPolicy,
@@ -778,6 +872,7 @@ export function validReviewStructuralRecord(
     !DIGEST_PATTERN.test(record.fingerprint) ||
     !DIGEST_PATTERN.test(record.sourceRevision) ||
     !validTimestamp(record.activityUpdatedAt) ||
+    typeof record.relationSensitive !== "boolean" ||
     !SHA_PATTERN.test(record.targetHeadSha) ||
     !record.reviewPolicy ||
     !record.reviewModel
@@ -882,6 +977,9 @@ export function reviewStructuralCacheDecision(options: {
   }
   if (!activityCoveredByReview(prior, current, review)) {
     return { hit: false, reason: "activity_changed" };
+  }
+  if (current.relationSensitive) {
+    return { hit: false, reason: "relation_context_present" };
   }
   if (prior.targetHeadSha !== current.targetHeadSha) {
     return { hit: false, reason: "target_changed" };

--- a/src/review-structural-cache.ts
+++ b/src/review-structural-cache.ts
@@ -76,6 +76,7 @@ export interface ReviewStructuralRecord {
   fingerprint: string;
   kind: ReviewStructuralKind;
   sourceRevision: string;
+  itemStateDigest: string;
   activityUpdatedAt: string;
   relationSensitive: boolean;
   targetHeadSha: string;
@@ -95,6 +96,20 @@ export interface ReviewStructuralPullState {
   deletions: number;
   changedFiles: number;
   commitCount: number;
+}
+
+export interface ReviewStructuralItemState {
+  titleDigest: string;
+  bodyDigest: string;
+  state: string;
+  locked: boolean;
+  author: string;
+  authorAssociation: string;
+  labels: readonly string[];
+  comments: readonly Pick<
+    ReviewStructuralActivity,
+    "updatedAt" | "author" | "authorAssociation" | "bodyDigest"
+  >[];
 }
 
 export interface ReviewStructuralPriorReview {
@@ -796,6 +811,51 @@ function recordFingerprint(record: Omit<ReviewStructuralRecord, "fingerprint">):
   return sha256(stableJson(record));
 }
 
+export function reviewStructuralItemStateDigest(item: ReviewStructuralItemState): string | null {
+  if (
+    !DIGEST_PATTERN.test(item.titleDigest) ||
+    !DIGEST_PATTERN.test(item.bodyDigest) ||
+    !item.state ||
+    item.state.length > 64 ||
+    !item.author ||
+    item.author.length > 128 ||
+    !item.authorAssociation ||
+    item.authorAssociation.length > 64 ||
+    item.labels.length > 100 ||
+    item.comments.length > 100 ||
+    item.comments.some(
+      (comment) =>
+        !validTimestamp(comment.updatedAt) ||
+        (comment.author !== null && comment.author.length > 128) ||
+        (comment.authorAssociation !== null && comment.authorAssociation.length > 64) ||
+        comment.bodyDigest === null ||
+        !DIGEST_PATTERN.test(comment.bodyDigest),
+    )
+  ) {
+    return null;
+  }
+  const comments = item.comments
+    .map((comment) => ({
+      updatedAt: comment.updatedAt,
+      author: comment.author?.toLowerCase() ?? null,
+      authorAssociation: comment.authorAssociation?.toUpperCase() ?? null,
+      bodyDigest: comment.bodyDigest,
+    }))
+    .sort((left, right) => stableJson(left).localeCompare(stableJson(right)));
+  return sha256(
+    stableJson({
+      titleDigest: item.titleDigest,
+      bodyDigest: item.bodyDigest,
+      state: item.state.toUpperCase(),
+      locked: item.locked,
+      author: item.author.toLowerCase(),
+      authorAssociation: item.authorAssociation.toUpperCase(),
+      labels: [...item.labels].map((label) => label.toLowerCase()).sort(),
+      comments,
+    }),
+  );
+}
+
 function normalizedMergeable(value: ReviewStructuralPullState["mergeable"]): string | null {
   if (value === true) return "MERGEABLE";
   if (value === false) return "CONFLICTING";
@@ -911,10 +971,22 @@ export function createReviewStructuralRecord(
   } else if (snapshot.pull !== null) {
     return null;
   }
+  const itemStateDigest = reviewStructuralItemStateDigest({
+    titleDigest: snapshot.titleDigest,
+    bodyDigest: snapshot.bodyDigest,
+    state: snapshot.state,
+    locked: snapshot.locked,
+    author: snapshot.author,
+    authorAssociation: snapshot.authorAssociation,
+    labels: snapshot.labels,
+    comments: snapshot.comments,
+  });
+  if (!itemStateDigest) return null;
   const recordWithoutFingerprint = {
     version: REVIEW_STRUCTURAL_CACHE_VERSION,
     kind: snapshot.kind,
     sourceRevision: sourceRevision(snapshot),
+    itemStateDigest,
     activityUpdatedAt: snapshot.activityUpdatedAt,
     relationSensitive: snapshot.relationSensitive,
     targetHeadSha: snapshot.targetHeadSha,
@@ -938,6 +1010,7 @@ export function validReviewStructuralRecord(
     record.version !== REVIEW_STRUCTURAL_CACHE_VERSION ||
     !DIGEST_PATTERN.test(record.fingerprint) ||
     !DIGEST_PATTERN.test(record.sourceRevision) ||
+    !DIGEST_PATTERN.test(record.itemStateDigest) ||
     !validTimestamp(record.activityUpdatedAt) ||
     typeof record.relationSensitive !== "boolean" ||
     !SHA_PATTERN.test(record.targetHeadSha) ||
@@ -990,6 +1063,18 @@ export function reviewStructuralRecordMatchesObservedUpdate(
   );
 }
 
+export function reviewStructuralRecordMatchesHydratedItem(
+  record: ReviewStructuralRecord | null,
+  itemStateDigest: string | undefined,
+): record is ReviewStructuralRecord {
+  return (
+    validReviewStructuralRecord(record) &&
+    typeof itemStateDigest === "string" &&
+    DIGEST_PATTERN.test(itemStateDigest) &&
+    record.itemStateDigest === itemStateDigest
+  );
+}
+
 export function reviewStructuralRecordMatchesHydratedPull(
   record: ReviewStructuralRecord | null,
   pull: ReviewStructuralPullState | null,
@@ -1008,6 +1093,7 @@ export function reviewStructuralRecordsDescribeSameVerdictInput(
     reviewStructuralRecordAtLeastAsFresh(current, anchor.activityUpdatedAt) &&
     anchor.kind === current.kind &&
     anchor.sourceRevision === current.sourceRevision &&
+    anchor.itemStateDigest === current.itemStateDigest &&
     anchor.relationSensitive === current.relationSensitive &&
     anchor.targetHeadSha === current.targetHeadSha &&
     anchor.pullHeadSha === current.pullHeadSha &&

--- a/src/review-structural-cache.ts
+++ b/src/review-structural-cache.ts
@@ -88,6 +88,7 @@ export interface ReviewStructuralPriorReview {
   lastFullReviewDecision?: string | undefined;
   reviewPolicy?: string | undefined;
   reviewModel?: string | undefined;
+  itemSourceRevision?: string | undefined;
   reviewCommentSyncedAt?: string | undefined;
   labelsSyncedAt?: string | undefined;
 }
@@ -96,8 +97,10 @@ export type ReviewStructuralCacheReason =
   | "hit"
   | "explicit_dispatch"
   | "maintainer_request"
+  | "coordination_disabled"
   | "missing_review"
   | "incomplete_review"
+  | "missing_lease_revision"
   | "non_keep_open_verdict"
   | "policy_changed"
   | "model_changed"
@@ -829,13 +832,18 @@ export function reviewStructuralCacheDecision(options: {
   reviewModel: string;
   explicitDispatch: boolean;
   maintainerRequest: boolean;
+  coordinationEnabled: boolean;
   now?: number;
 }): ReviewStructuralCacheDecision {
   if (options.explicitDispatch) return { hit: false, reason: "explicit_dispatch" };
   if (options.maintainerRequest) return { hit: false, reason: "maintainer_request" };
+  if (!options.coordinationEnabled) return { hit: false, reason: "coordination_disabled" };
   const review = options.review;
   if (!review) return { hit: false, reason: "missing_review" };
   if (review.reviewStatus !== "complete") return { hit: false, reason: "incomplete_review" };
+  if (!review.itemSourceRevision || !DIGEST_PATTERN.test(review.itemSourceRevision)) {
+    return { hit: false, reason: "missing_lease_revision" };
+  }
   if (review.decision !== "keep_open" || review.lastFullReviewDecision !== "keep_open") {
     return { hit: false, reason: "non_keep_open_verdict" };
   }

--- a/src/review-structural-cache.ts
+++ b/src/review-structural-cache.ts
@@ -750,6 +750,10 @@ function validMachineMetadata(value: unknown): boolean {
   return serialized.length > 0 && serialized.length <= MAX_MACHINE_METADATA_CHARS;
 }
 
+function canonicalGitHubLogin(login: string): string {
+  return login.toLowerCase().replace(/\[bot\]$/, "");
+}
+
 function normalizedActivities(
   activities: readonly ReviewStructuralActivity[],
 ): ReviewStructuralActivity[] {
@@ -757,7 +761,7 @@ function normalizedActivities(
     .map((activity) => ({
       id: activity.id,
       updatedAt: activity.updatedAt,
-      author: activity.author?.toLowerCase() ?? null,
+      author: activity.author === null ? null : canonicalGitHubLogin(activity.author),
       authorAssociation: activity.authorAssociation?.toUpperCase() ?? null,
       state: activity.state?.toUpperCase() ?? null,
       commitSha: activity.commitSha,
@@ -778,7 +782,7 @@ function sourceRevision(snapshot: ReviewStructuralSnapshot): string {
       number: snapshot.number,
       kind: snapshot.kind,
       nodeId: snapshot.nodeId,
-      author: snapshot.author.toLowerCase(),
+      author: canonicalGitHubLogin(snapshot.author),
       authorAssociation: snapshot.authorAssociation.toUpperCase(),
       titleDigest: snapshot.titleDigest,
       bodyDigest: snapshot.bodyDigest,
@@ -847,7 +851,7 @@ export function reviewStructuralItemStateDigest(item: ReviewStructuralItemState)
   const comments = item.comments
     .map((comment) => ({
       updatedAt: comment.updatedAt,
-      author: comment.author?.toLowerCase() ?? null,
+      author: comment.author === null ? null : canonicalGitHubLogin(comment.author),
       authorAssociation: comment.authorAssociation?.toUpperCase() ?? null,
       bodyDigest: comment.bodyDigest,
     }))
@@ -858,7 +862,7 @@ export function reviewStructuralItemStateDigest(item: ReviewStructuralItemState)
       bodyDigest: item.bodyDigest,
       state: item.state.toUpperCase(),
       locked: item.locked,
-      author: item.author.toLowerCase(),
+      author: canonicalGitHubLogin(item.author),
       authorAssociation: item.authorAssociation.toUpperCase(),
       labels: [...item.labels].map((label) => label.toLowerCase()).sort(),
       comments,

--- a/src/review-structural-cache.ts
+++ b/src/review-structural-cache.ts
@@ -3,7 +3,7 @@ import { createHash } from "node:crypto";
 import { REVIEW_CACHE_MAX_AGE_DAYS } from "./scheduler-policy.js";
 import { stableJson } from "./stable-json.js";
 
-export const REVIEW_STRUCTURAL_CACHE_VERSION = 2;
+export const REVIEW_STRUCTURAL_CACHE_VERSION = 3;
 export const REVIEW_STRUCTURAL_CACHE_MAX_AGE_DAYS = REVIEW_CACHE_MAX_AGE_DAYS;
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -20,6 +20,7 @@ export interface ReviewStructuralActivity {
   authorAssociation: string | null;
   state: string | null;
   commitSha: string | null;
+  bodyDigest: string | null;
 }
 
 export interface ReviewStructuralThread {
@@ -79,8 +80,21 @@ export interface ReviewStructuralRecord {
   relationSensitive: boolean;
   targetHeadSha: string;
   pullHeadSha: string | null;
+  pullStateDigest: string | null;
   reviewPolicy: string;
   reviewModel: string;
+}
+
+export interface ReviewStructuralPullState {
+  headSha: string;
+  baseSha: string;
+  draft: boolean;
+  mergeable: string | boolean | null;
+  mergeStateStatus: string;
+  additions: number;
+  deletions: number;
+  changedFiles: number;
+  commitCount: number;
 }
 
 export interface ReviewStructuralPriorReview {
@@ -249,6 +263,7 @@ export function reviewStructuralQuery(kind: ReviewStructuralKind): string {
           nodes {
             id
             updatedAt
+            body
             author { login }
             authorAssociation
             state
@@ -338,12 +353,19 @@ function structuralActivities(
     const authorAssociation = stringOrUndefined(record.authorAssociation) ?? null;
     const state = stringOrUndefined(record.state) ?? null;
     const commitSha = stringOrUndefined(asRecord(record.commit).oid) ?? null;
-    if (!id || !updatedAt) {
+    const hasBody = typeof record.body === "string" || record.body === null;
+    const bodyDigest =
+      typeof record.body === "string"
+        ? sha256(record.body)
+        : record.body === null
+          ? sha256("")
+          : null;
+    if (!id || !updatedAt || !hasBody) {
       malformed = true;
       return [];
     }
     if (author && ignoreAuthor(author)) return [];
-    return [{ id, updatedAt, author, authorAssociation, state, commitSha }];
+    return [{ id, updatedAt, author, authorAssociation, state, commitSha, bodyDigest }];
   });
   return { activities, truncated: connection.truncated || malformed };
 }
@@ -693,7 +715,8 @@ function validActivity(activity: ReviewStructuralActivity): boolean {
     (activity.author === null || activity.author.length <= 128) &&
     (activity.authorAssociation === null || activity.authorAssociation.length <= 64) &&
     (activity.state === null || activity.state.length <= 64) &&
-    (activity.commitSha === null || SHA_PATTERN.test(activity.commitSha))
+    (activity.commitSha === null || SHA_PATTERN.test(activity.commitSha)) &&
+    (activity.bodyDigest === null || DIGEST_PATTERN.test(activity.bodyDigest))
   );
 }
 
@@ -713,6 +736,7 @@ function normalizedActivities(
       authorAssociation: activity.authorAssociation?.toUpperCase() ?? null,
       state: activity.state?.toUpperCase() ?? null,
       commitSha: activity.commitSha,
+      bodyDigest: activity.bodyDigest,
     }))
     .sort(
       (left, right) =>
@@ -770,6 +794,47 @@ function sourceRevision(snapshot: ReviewStructuralSnapshot): string {
 
 function recordFingerprint(record: Omit<ReviewStructuralRecord, "fingerprint">): string {
   return sha256(stableJson(record));
+}
+
+function normalizedMergeable(value: ReviewStructuralPullState["mergeable"]): string | null {
+  if (value === true) return "MERGEABLE";
+  if (value === false) return "CONFLICTING";
+  if (value === null) return "UNKNOWN";
+  const normalized = value.trim().toUpperCase();
+  return normalized ? normalized : null;
+}
+
+export function reviewStructuralPullStateDigest(pull: ReviewStructuralPullState): string | null {
+  const headSha = pull.headSha.trim().toLowerCase();
+  const baseSha = pull.baseSha.trim().toLowerCase();
+  const mergeable = normalizedMergeable(pull.mergeable);
+  const mergeStateStatus = pull.mergeStateStatus.trim().toUpperCase();
+  const counts = [pull.additions, pull.deletions, pull.changedFiles, pull.commitCount];
+  if (
+    !SHA_PATTERN.test(headSha) ||
+    !SHA_PATTERN.test(baseSha) ||
+    typeof pull.draft !== "boolean" ||
+    !mergeable ||
+    mergeable.length > 64 ||
+    !mergeStateStatus ||
+    mergeStateStatus.length > 64 ||
+    counts.some((value) => !Number.isSafeInteger(value) || value < 0)
+  ) {
+    return null;
+  }
+  return sha256(
+    stableJson({
+      headSha,
+      baseSha,
+      draft: pull.draft,
+      mergeable,
+      mergeStateStatus,
+      additions: pull.additions,
+      deletions: pull.deletions,
+      changedFiles: pull.changedFiles,
+      commitCount: pull.commitCount,
+    }),
+  );
 }
 
 function validPullMetadata(pull: ReviewStructuralPullMetadata): boolean {
@@ -854,9 +919,11 @@ export function createReviewStructuralRecord(
     relationSensitive: snapshot.relationSensitive,
     targetHeadSha: snapshot.targetHeadSha,
     pullHeadSha: snapshot.pull?.headSha ?? null,
+    pullStateDigest: snapshot.pull ? reviewStructuralPullStateDigest(snapshot.pull) : null,
     reviewPolicy: options.reviewPolicy,
     reviewModel: options.reviewModel,
   } satisfies Omit<ReviewStructuralRecord, "fingerprint">;
+  if (snapshot.pull && !recordWithoutFingerprint.pullStateDigest) return null;
   return {
     ...recordWithoutFingerprint,
     fingerprint: recordFingerprint(recordWithoutFingerprint),
@@ -880,8 +947,15 @@ export function validReviewStructuralRecord(
     return false;
   }
   if (record.kind === "pull_request") {
-    if (!record.pullHeadSha || !SHA_PATTERN.test(record.pullHeadSha)) return false;
-  } else if (record.pullHeadSha !== null) {
+    if (
+      !record.pullHeadSha ||
+      !SHA_PATTERN.test(record.pullHeadSha) ||
+      !record.pullStateDigest ||
+      !DIGEST_PATTERN.test(record.pullStateDigest)
+    ) {
+      return false;
+    }
+  } else if (record.pullHeadSha !== null || record.pullStateDigest !== null) {
     return false;
   }
   const { fingerprint: _, ...recordWithoutFingerprint } = record;
@@ -916,6 +990,15 @@ export function reviewStructuralRecordMatchesObservedUpdate(
   );
 }
 
+export function reviewStructuralRecordMatchesHydratedPull(
+  record: ReviewStructuralRecord | null,
+  pull: ReviewStructuralPullState | null,
+): record is ReviewStructuralRecord {
+  if (!validReviewStructuralRecord(record) || record.kind !== "pull_request" || !pull) return false;
+  const digest = reviewStructuralPullStateDigest(pull);
+  return digest !== null && record.pullStateDigest === digest;
+}
+
 export function reviewStructuralRecordsDescribeSameVerdictInput(
   anchor: ReviewStructuralRecord | null,
   current: ReviewStructuralRecord | null,
@@ -928,6 +1011,7 @@ export function reviewStructuralRecordsDescribeSameVerdictInput(
     anchor.relationSensitive === current.relationSensitive &&
     anchor.targetHeadSha === current.targetHeadSha &&
     anchor.pullHeadSha === current.pullHeadSha &&
+    anchor.pullStateDigest === current.pullStateDigest &&
     anchor.reviewPolicy === current.reviewPolicy &&
     anchor.reviewModel === current.reviewModel
   );

--- a/src/review-structural-cache.ts
+++ b/src/review-structural-cache.ts
@@ -34,6 +34,7 @@ export interface ReviewStructuralPullMetadata {
   baseSha: string;
   draft: boolean;
   mergeable: string;
+  mergeStateStatus: string;
   additions: number;
   deletions: number;
   changedFiles: number;
@@ -229,6 +230,7 @@ export function reviewStructuralQuery(kind: ReviewStructuralKind): string {
         baseRefOid
         isDraft
         mergeable
+        mergeStateStatus
         additions
         deletions
         changedFiles
@@ -551,6 +553,7 @@ export function reviewStructuralRecordFromGraphql(
       !baseSha ||
       typeof node.isDraft !== "boolean" ||
       !stringOrUndefined(node.mergeable) ||
+      !stringOrUndefined(node.mergeStateStatus) ||
       additions === null ||
       deletions === null ||
       changedFiles === null ||
@@ -563,6 +566,7 @@ export function reviewStructuralRecordFromGraphql(
       baseSha,
       draft: node.isDraft,
       mergeable: String(node.mergeable),
+      mergeStateStatus: String(node.mergeStateStatus),
       additions,
       deletions,
       changedFiles,
@@ -651,6 +655,7 @@ function sourceRevision(snapshot: ReviewStructuralSnapshot): string {
               baseSha: snapshot.pull.baseSha,
               draft: snapshot.pull.draft,
               mergeable: snapshot.pull.mergeable,
+              mergeStateStatus: snapshot.pull.mergeStateStatus,
               additions: snapshot.pull.additions,
               deletions: snapshot.pull.deletions,
               changedFiles: snapshot.pull.changedFiles,
@@ -676,6 +681,10 @@ function validPullMetadata(pull: ReviewStructuralPullMetadata): boolean {
   return (
     SHA_PATTERN.test(pull.headSha) &&
     SHA_PATTERN.test(pull.baseSha) &&
+    pull.mergeable.length > 0 &&
+    pull.mergeable.length <= 64 &&
+    pull.mergeStateStatus.length > 0 &&
+    pull.mergeStateStatus.length <= 64 &&
     Number.isSafeInteger(pull.additions) &&
     pull.additions >= 0 &&
     Number.isSafeInteger(pull.deletions) &&

--- a/src/review-structural-cache.ts
+++ b/src/review-structural-cache.ts
@@ -291,7 +291,10 @@ function nonNegativeInteger(value: unknown): number | null {
   return Math.floor(number);
 }
 
-function structuralConnection(value: unknown): {
+function structuralConnection(
+  value: unknown,
+  direction: "first" | "last",
+): {
   nodes: unknown[];
   truncated: boolean;
 } {
@@ -299,12 +302,10 @@ function structuralConnection(value: unknown): {
   const nodes = connection.nodes;
   const pageInfo = asRecord(connection.pageInfo);
   if (!Array.isArray(nodes)) return { nodes: [], truncated: true };
+  const boundary = direction === "first" ? pageInfo.hasNextPage : pageInfo.hasPreviousPage;
   return {
     nodes,
-    truncated:
-      pageInfo.hasPreviousPage === true ||
-      pageInfo.hasNextPage === true ||
-      (pageInfo.hasPreviousPage !== false && pageInfo.hasNextPage !== false),
+    truncated: boundary !== false,
   };
 }
 
@@ -315,7 +316,7 @@ function structuralActivities(
   activities: ReviewStructuralActivity[];
   truncated: boolean;
 } {
-  const connection = structuralConnection(value);
+  const connection = structuralConnection(value, "last");
   let malformed = false;
   const activities = connection.nodes.flatMap((entry) => {
     const record = asRecord(entry);
@@ -353,7 +354,7 @@ function structuralLabels(
   labels: string[];
   truncated: boolean;
 } {
-  const connection = structuralConnection(value);
+  const connection = structuralConnection(value, "first");
   let malformed = false;
   const labels = connection.nodes.flatMap((entry) => {
     const name = stringOrUndefined(asRecord(entry).name);
@@ -372,15 +373,29 @@ function structuralRelationTarget(value: unknown): unknown {
   const type = stringOrUndefined(target.__typename);
   const id = stringOrUndefined(target.id);
   const number = nonNegativeInteger(target.number);
-  if (!type || !id || !repository || number === null) return null;
+  const state = stringOrUndefined(target.state);
+  const updatedAt = stringOrUndefined(target.updatedAt);
+  const headSha = stringOrUndefined(target.headRefOid)?.trim().toLowerCase() ?? null;
+  if (
+    (type !== "Issue" && type !== "PullRequest") ||
+    !id ||
+    !repository ||
+    number === null ||
+    !state ||
+    !updatedAt ||
+    !validTimestamp(updatedAt) ||
+    (type === "PullRequest" && (!headSha || !SHA_PATTERN.test(headSha)))
+  ) {
+    return null;
+  }
   return {
     type,
     id,
     repository,
     number,
-    state: stringOrUndefined(target.state) ?? null,
-    updatedAt: stringOrUndefined(target.updatedAt) ?? null,
-    headSha: stringOrUndefined(target.headRefOid) ?? null,
+    state,
+    updatedAt,
+    headSha: type === "PullRequest" ? headSha : null,
   };
 }
 
@@ -392,7 +407,7 @@ function structuralTimeline(
   timeline: unknown[];
   truncated: boolean;
 } {
-  const connection = structuralConnection(value);
+  const connection = structuralConnection(value, "last");
   let malformed = false;
   const timeline = connection.nodes.flatMap((entry) => {
     const record = asRecord(entry);
@@ -409,6 +424,14 @@ function structuralTimeline(
     }
     if (author && ignoreAuthor(author)) return [];
     if (label && ignoreLabel(label)) return [];
+    const relationTarget =
+      type === "CrossReferencedEvent" || type === "ConnectedEvent"
+        ? structuralRelationTarget(record.source ?? record.subject)
+        : null;
+    if ((type === "CrossReferencedEvent" || type === "ConnectedEvent") && relationTarget === null) {
+      malformed = true;
+      return [];
+    }
     return [
       {
         type,
@@ -419,7 +442,7 @@ function structuralTimeline(
         label,
         willCloseTarget:
           typeof record.willCloseTarget === "boolean" ? record.willCloseTarget : null,
-        target: structuralRelationTarget(record.source ?? record.subject),
+        target: relationTarget,
       },
     ];
   });
@@ -433,7 +456,7 @@ function structuralReviewThreads(
   threads: ReviewStructuralThread[];
   truncated: boolean;
 } {
-  const connection = structuralConnection(value);
+  const connection = structuralConnection(value, "last");
   let malformed = false;
   const threads = connection.nodes.flatMap((entry) => {
     const record = asRecord(entry);
@@ -817,6 +840,7 @@ export function reviewStructuralCacheDecision(options: {
   const now = options.now ?? Date.now();
   if (
     lastFullReviewAt === null ||
+    lastFullReviewAt > now ||
     now - lastFullReviewAt >= REVIEW_STRUCTURAL_CACHE_MAX_AGE_DAYS * DAY_MS
   ) {
     return { hit: false, reason: "stale_review" };

--- a/src/review-structural-cache.ts
+++ b/src/review-structural-cache.ts
@@ -888,6 +888,51 @@ export function validReviewStructuralRecord(
   return fingerprintMatches(recordFingerprint(recordWithoutFingerprint), record.fingerprint);
 }
 
+export function reviewStructuralRecordAtLeastAsFresh(
+  record: ReviewStructuralRecord | null,
+  observedUpdatedAt: string | undefined,
+): record is ReviewStructuralRecord {
+  const recordUpdatedAtMs = timestampMs(record?.activityUpdatedAt);
+  const observedUpdatedAtMs = timestampMs(observedUpdatedAt);
+  return (
+    validReviewStructuralRecord(record) &&
+    recordUpdatedAtMs !== null &&
+    observedUpdatedAtMs !== null &&
+    recordUpdatedAtMs >= observedUpdatedAtMs
+  );
+}
+
+export function reviewStructuralRecordMatchesObservedUpdate(
+  record: ReviewStructuralRecord | null,
+  observedUpdatedAt: string | undefined,
+): record is ReviewStructuralRecord {
+  const recordUpdatedAtMs = timestampMs(record?.activityUpdatedAt);
+  const observedUpdatedAtMs = timestampMs(observedUpdatedAt);
+  return (
+    validReviewStructuralRecord(record) &&
+    recordUpdatedAtMs !== null &&
+    observedUpdatedAtMs !== null &&
+    recordUpdatedAtMs === observedUpdatedAtMs
+  );
+}
+
+export function reviewStructuralRecordsDescribeSameVerdictInput(
+  anchor: ReviewStructuralRecord | null,
+  current: ReviewStructuralRecord | null,
+): current is ReviewStructuralRecord {
+  return (
+    validReviewStructuralRecord(anchor) &&
+    reviewStructuralRecordAtLeastAsFresh(current, anchor.activityUpdatedAt) &&
+    anchor.kind === current.kind &&
+    anchor.sourceRevision === current.sourceRevision &&
+    anchor.relationSensitive === current.relationSensitive &&
+    anchor.targetHeadSha === current.targetHeadSha &&
+    anchor.pullHeadSha === current.pullHeadSha &&
+    anchor.reviewPolicy === current.reviewPolicy &&
+    anchor.reviewModel === current.reviewModel
+  );
+}
+
 function fingerprintMatches(expected: string, actual: string): boolean {
   return expected === actual;
 }

--- a/test/review-comment-rendering.test.ts
+++ b/test/review-comment-rendering.test.ts
@@ -104,21 +104,27 @@ test("comment matcher recognizes old and new Codex review comments", () => {
   assert.equal(isCodexReviewCommentBody("Thanks for the report, I can reproduce this."), false);
 });
 
-test("review start lease is acquired before cache reuse and slow media preprocessing", () => {
+test("structural cache runs before leases while content cache remains lease-coordinated", () => {
   const source = readFileSync("src/clawsweeper.ts", "utf8");
   const reviewLoop = source.slice(
     source.indexOf("for (const item of candidates)"),
     source.indexOf("let decision: Decision", source.indexOf("for (const item of candidates)")),
   );
-  const cacheHit = reviewLoop.indexOf("reviewContentCacheHit({");
+  const structuralCache = reviewLoop.indexOf("reviewStructuralCacheDecision({");
+  const contentCache = reviewLoop.indexOf("reviewContentCacheHit({");
   const startLease = reviewLoop.indexOf("postReviewStartStatusComment({");
-  const mediaPrep = reviewLoop.indexOf("prepareMediaProofArtifacts(context", cacheHit);
+  const hydration = reviewLoop.indexOf("collectItemContext(item");
+  const mediaPrep = reviewLoop.indexOf("prepareMediaProofArtifacts(context", contentCache);
 
+  assert.ok(structuralCache >= 0);
   assert.ok(startLease >= 0);
-  assert.ok(cacheHit > startLease);
-  assert.ok(mediaPrep > cacheHit);
+  assert.ok(structuralCache < startLease);
+  assert.ok(structuralCache < hydration);
+  assert.ok(contentCache > startLease);
+  assert.ok(mediaPrep > contentCache);
   assert.match(source, /coordination-held\.json/);
   assert.match(source, /coordinationHeldRetryAt = startComment\.retryAt/);
+  assert.match(source, /review-cache-metrics\.json/);
 });
 
 test("review comment patching only targets ClawSweeper-owned comments", () => {

--- a/test/review-comment-rendering.test.ts
+++ b/test/review-comment-rendering.test.ts
@@ -110,7 +110,12 @@ test("structural cache probes before hydration but acquires a lease before carry
     source.indexOf("for (const item of candidates)"),
     source.indexOf("let decision: Decision", source.indexOf("for (const item of candidates)")),
   );
-  const structuralCache = reviewLoop.indexOf("reviewStructuralCacheDecision({");
+  const structuralEligibility = reviewLoop.indexOf("reviewStructuralCacheProbeDecision({");
+  const structuralProbe = reviewLoop.indexOf(
+    "structuralRecord = fetchReviewStructuralRecord({",
+    structuralEligibility,
+  );
+  const structuralCache = reviewLoop.indexOf("reviewStructuralCacheDecision({", structuralProbe);
   const structuralHit = reviewLoop.indexOf("if (structuralDecision.hit)");
   const structuralLease = reviewLoop.indexOf("postReviewStartStatusComment({", structuralHit);
   const structuralRevalidation = reviewLoop.indexOf(
@@ -122,6 +127,8 @@ test("structural cache probes before hydration but acquires a lease before carry
   const hydration = reviewLoop.indexOf("collectItemContext(item");
   const mediaPrep = reviewLoop.indexOf("prepareMediaProofArtifacts(context", contentCache);
 
+  assert.ok(structuralEligibility >= 0);
+  assert.ok(structuralProbe > structuralEligibility);
   assert.ok(structuralCache >= 0);
   assert.ok(structuralCache < hydration);
   assert.ok(structuralHit > structuralCache);
@@ -139,6 +146,12 @@ test("structural cache probes before hydration but acquires a lease before carry
     reviewLoop.slice(structuralHit, structuralWrite),
     /review_lease_comment_id[\s\S]*acquiredReviewLease\.commentId/,
   );
+  const hydratedAnchor = reviewLoop.indexOf(
+    "reviewStructuralRecordsDescribeSameVerdictInput(",
+    hydration,
+  );
+  assert.ok(hydratedAnchor > hydration);
+  assert.match(reviewLoop.slice(hydration, hydratedAnchor + 160), /preHydrationStructuralRecord/);
   assert.match(source, /coordination-held\.json/);
   assert.match(source, /coordinationHeldRetryAt = startComment\.retryAt/);
   assert.match(source, /review-cache-metrics\.json/);

--- a/test/review-comment-rendering.test.ts
+++ b/test/review-comment-rendering.test.ts
@@ -104,24 +104,36 @@ test("comment matcher recognizes old and new Codex review comments", () => {
   assert.equal(isCodexReviewCommentBody("Thanks for the report, I can reproduce this."), false);
 });
 
-test("structural cache runs before leases while content cache remains lease-coordinated", () => {
+test("structural cache probes before hydration but acquires a lease before carrying a hit", () => {
   const source = readFileSync("src/clawsweeper.ts", "utf8");
   const reviewLoop = source.slice(
     source.indexOf("for (const item of candidates)"),
     source.indexOf("let decision: Decision", source.indexOf("for (const item of candidates)")),
   );
   const structuralCache = reviewLoop.indexOf("reviewStructuralCacheDecision({");
+  const structuralHit = reviewLoop.indexOf("if (structuralDecision.hit)");
+  const structuralLease = reviewLoop.indexOf("postReviewStartStatusComment({", structuralHit);
+  const structuralWrite = reviewLoop.indexOf("writeFileSync(reportPath, carried", structuralLease);
   const contentCache = reviewLoop.indexOf("reviewContentCacheHit({");
-  const startLease = reviewLoop.indexOf("postReviewStartStatusComment({");
   const hydration = reviewLoop.indexOf("collectItemContext(item");
   const mediaPrep = reviewLoop.indexOf("prepareMediaProofArtifacts(context", contentCache);
 
   assert.ok(structuralCache >= 0);
-  assert.ok(startLease >= 0);
-  assert.ok(structuralCache < startLease);
   assert.ok(structuralCache < hydration);
-  assert.ok(contentCache > startLease);
+  assert.ok(structuralHit > structuralCache);
+  assert.ok(structuralLease > structuralHit);
+  assert.ok(structuralWrite > structuralLease);
+  assert.ok(structuralWrite < hydration);
+  assert.ok(contentCache > structuralLease);
   assert.ok(mediaPrep > contentCache);
+  assert.match(
+    reviewLoop.slice(structuralHit, structuralWrite),
+    /review_lease_owner[\s\S]*acquiredReviewLease\.owner/,
+  );
+  assert.match(
+    reviewLoop.slice(structuralHit, structuralWrite),
+    /review_lease_comment_id[\s\S]*acquiredReviewLease\.commentId/,
+  );
   assert.match(source, /coordination-held\.json/);
   assert.match(source, /coordinationHeldRetryAt = startComment\.retryAt/);
   assert.match(source, /review-cache-metrics\.json/);

--- a/test/review-comment-rendering.test.ts
+++ b/test/review-comment-rendering.test.ts
@@ -113,6 +113,10 @@ test("structural cache probes before hydration but acquires a lease before carry
   const structuralCache = reviewLoop.indexOf("reviewStructuralCacheDecision({");
   const structuralHit = reviewLoop.indexOf("if (structuralDecision.hit)");
   const structuralLease = reviewLoop.indexOf("postReviewStartStatusComment({", structuralHit);
+  const structuralRevalidation = reviewLoop.indexOf(
+    "structuralCacheRevalidations += 1",
+    structuralLease,
+  );
   const structuralWrite = reviewLoop.indexOf("writeFileSync(reportPath, carried", structuralLease);
   const contentCache = reviewLoop.indexOf("reviewContentCacheHit({");
   const hydration = reviewLoop.indexOf("collectItemContext(item");
@@ -122,7 +126,8 @@ test("structural cache probes before hydration but acquires a lease before carry
   assert.ok(structuralCache < hydration);
   assert.ok(structuralHit > structuralCache);
   assert.ok(structuralLease > structuralHit);
-  assert.ok(structuralWrite > structuralLease);
+  assert.ok(structuralRevalidation > structuralLease);
+  assert.ok(structuralWrite > structuralRevalidation);
   assert.ok(structuralWrite < hydration);
   assert.ok(contentCache > structuralLease);
   assert.ok(mediaPrep > contentCache);
@@ -137,6 +142,11 @@ test("structural cache probes before hydration but acquires a lease before carry
   assert.match(source, /coordination-held\.json/);
   assert.match(source, /coordinationHeldRetryAt = startComment\.retryAt/);
   assert.match(source, /review-cache-metrics\.json/);
+  const workflow = readFileSync(".github/workflows/sweep.yml", "utf8");
+  assert.match(
+    workflow,
+    /review-artifacts\/shard-\$\{\{ matrix\.shard \}\}\/review-cache-metrics\.json/,
+  );
 });
 
 test("review comment patching only targets ClawSweeper-owned comments", () => {

--- a/test/review-structural-cache.test.ts
+++ b/test/review-structural-cache.test.ts
@@ -52,6 +52,7 @@ function issueSnapshot(
     commentsTruncated: false,
     timeline: [{ type: "CrossReferencedEvent", id: "CE_1", source: "PR_kwDO1" }],
     timelineTruncated: false,
+    relationSensitive: false,
     targetHeadSha: TARGET_SHA,
     latestReleaseTag: "v1.0.0",
     latestReleaseSha: TARGET_SHA,
@@ -172,12 +173,14 @@ function graphqlNode(kind: "issue" | "pull_request") {
       {
         id: "IC_human",
         updatedAt: "2026-07-10T09:00:00Z",
+        body: "No related item",
         author: { login: "contributor" },
         authorAssociation: "CONTRIBUTOR",
       },
       {
         id: "IC_bot",
         updatedAt: "2026-07-10T09:30:00Z",
+        body: "Automated status",
         author: { login: "clawsweeper[bot]" },
         authorAssociation: "NONE",
       },
@@ -188,6 +191,7 @@ function graphqlNode(kind: "issue" | "pull_request") {
         __typename: "IssueComment",
         id: "IC_bot_timeline",
         updatedAt: "2026-07-10T09:30:00Z",
+        body: "Automated status",
         author: { login: "clawsweeper[bot]" },
       },
       {
@@ -229,6 +233,7 @@ function graphqlNode(kind: "issue" | "pull_request") {
           {
             id: "PRRC_comment",
             updatedAt: "2026-07-10T08:30:00Z",
+            body: "No related item",
             author: { login: "maintainer" },
             authorAssociation: "MEMBER",
           },
@@ -382,6 +387,46 @@ test("changed target head forces issue hydration", () => {
   assert.equal(decision({ priorRecord, currentRecord }).reason, "target_changed");
 });
 
+test("relation-sensitive records always force full hydration", () => {
+  const relationRecord = record(issueSnapshot({ relationSensitive: true }));
+  assert.deepEqual(decision({ priorRecord: relationRecord, currentRecord: relationRecord }), {
+    hit: false,
+    reason: "relation_context_present",
+  });
+});
+
+test("GraphQL decoder detects explicit and external relation sources", () => {
+  const explicit = graphqlRecord("issue", {
+    ...graphqlNode("issue"),
+    body: "See #456 for the shared failure.",
+  });
+  assert.ok(explicit);
+  assert.equal(explicit.relationSensitive, true);
+
+  const external = reviewStructuralRecordFromGraphql({
+    response: {
+      data: {
+        repository: {
+          issue: graphqlNode("issue"),
+        },
+      },
+    },
+    repo: "openclaw/openclaw",
+    number: 123,
+    kind: "issue",
+    targetHeadSha: TARGET_SHA,
+    latestReleaseTag: "v1.0.0",
+    latestReleaseSha: TARGET_SHA,
+    reviewPolicy: "policy-1",
+    reviewModel: "gpt-5.6",
+    ignoreAuthor: (author) => author.toLowerCase() === "clawsweeper[bot]",
+    ignoreLabel: (label) => label.toLowerCase() === "p2",
+    externalRelationSensitive: true,
+  });
+  assert.ok(external);
+  assert.equal(external.relationSensitive, true);
+});
+
 test("changed author association or release identity forces hydration", () => {
   const priorRecord = record();
   assert.equal(
@@ -533,16 +578,16 @@ test("truncated comments, timeline, reviews, and threads cannot seed the cache",
   );
 });
 
-test("metadata probes request activity metadata without comment or review bodies", () => {
+test("metadata probes inspect relation links without persisting comment or review bodies", () => {
   const issueQuery = reviewStructuralQuery("issue");
   const pullQuery = reviewStructuralQuery("pull_request");
 
   assert.match(issueQuery, /comments\(last: 100\)/);
   assert.match(issueQuery, /CrossReferencedEvent/);
-  assert.doesNotMatch(issueQuery, /comments\(last: 100\)[\s\S]*?\bbody\b/);
+  assert.match(issueQuery, /comments\(last: 100\)[\s\S]*?\bbody\b/);
   assert.match(pullQuery, /headRefOid/);
   assert.match(pullQuery, /reviewThreads\(last: 100\)/);
-  assert.doesNotMatch(pullQuery, /reviewThreads\(last: 100\)[\s\S]*?\bbody\b/);
+  assert.match(pullQuery, /reviewThreads\(last: 100\)[\s\S]*?\bbody\b/);
 });
 
 test("metadata probes ignore ClawSweeper comments but fail closed on malformed entries", () => {
@@ -553,12 +598,14 @@ test("metadata probes ignore ClawSweeper comments but fail closed on malformed e
         {
           id: "bot-comment",
           updatedAt: "2026-07-10T10:00:00Z",
+          body: "Automated status",
           author: { login: "ClawSweeper[bot]" },
           authorAssociation: "NONE",
         },
         {
           id: "human-comment",
           updatedAt: "2026-07-10T10:01:00Z",
+          body: "No related item",
           author: { login: "maintainer" },
           authorAssociation: "MEMBER",
         },

--- a/test/review-structural-cache.test.ts
+++ b/test/review-structural-cache.test.ts
@@ -6,6 +6,7 @@ import {
   createReviewStructuralRecord,
   reviewStructuralActivitiesForTest,
   reviewStructuralCacheDecision,
+  reviewStructuralCacheProbeDecision,
   reviewStructuralQuery,
   reviewStructuralRecordAtLeastAsFresh,
   reviewStructuralRecordFromGraphql,
@@ -276,6 +277,37 @@ function graphqlRecord(kind: "issue" | "pull_request", node = graphqlNode(kind))
 
 test("unchanged completed keep-open issue hits the structural cache", () => {
   assert.deepEqual(decision(), { hit: true, reason: "hit" });
+});
+
+test("cheap eligibility rejects ineligible reviews before structural records are needed", () => {
+  const eligible = {
+    review: review(),
+    reviewPolicy: "policy-1",
+    reviewModel: "gpt-5.6",
+    explicitDispatch: false,
+    maintainerRequest: false,
+    coordinationEnabled: true,
+    now: NOW,
+  };
+  assert.deepEqual(reviewStructuralCacheProbeDecision(eligible), {
+    hit: true,
+    reason: "hit",
+  });
+  assert.equal(
+    reviewStructuralCacheProbeDecision({ ...eligible, review: null }).reason,
+    "missing_review",
+  );
+  assert.equal(
+    reviewStructuralCacheProbeDecision({ ...eligible, explicitDispatch: true }).reason,
+    "explicit_dispatch",
+  );
+  assert.equal(
+    reviewStructuralCacheProbeDecision({
+      ...eligible,
+      review: review({ lastFullReviewAt: new Date(NOW - 14 * DAY_MS).toISOString() }),
+    }).reason,
+    "stale_review",
+  );
 });
 
 test("structural probes cannot undercut a newer observed item generation", () => {
@@ -656,6 +688,44 @@ test("same-second review-thread edits change the structural source revision", ()
   assert.ok(original);
   assert.ok(edited);
   assert.notEqual(original.sourceRevision, edited.sourceRevision);
+});
+
+test("hydration anchors reject same-second PR review and timeline edits", () => {
+  const node = graphqlNode("pull_request");
+  const beforeHydration = graphqlRecord("pull_request", node);
+  const review = node.reviews.nodes[0];
+  assert.ok(beforeHydration);
+  assert.ok(review);
+  const reviewEdited = graphqlRecord("pull_request", {
+    ...node,
+    reviews: graphqlConnection([{ ...review, body: "Edited during hydration" }]),
+  });
+  assert.ok(reviewEdited);
+  assert.equal(reviewStructuralRecordMatchesObservedUpdate(reviewEdited, node.updatedAt), true);
+  assert.equal(
+    reviewStructuralRecordsDescribeSameVerdictInput(beforeHydration, reviewEdited),
+    false,
+  );
+
+  const timelineEdited = graphqlRecord("pull_request", {
+    ...node,
+    timelineItems: graphqlConnection([
+      ...node.timelineItems.nodes,
+      {
+        __typename: "LabeledEvent",
+        id: "LE_human",
+        createdAt: node.updatedAt,
+        actor: { login: "maintainer" },
+        label: { name: "needs-review" },
+      },
+    ]),
+  });
+  assert.ok(timelineEdited);
+  assert.equal(reviewStructuralRecordMatchesObservedUpdate(timelineEdited, node.updatedAt), true);
+  assert.equal(
+    reviewStructuralRecordsDescribeSameVerdictInput(beforeHydration, timelineEdited),
+    false,
+  );
 });
 
 test("hydrated pull state must match the complete structural PR state", () => {

--- a/test/review-structural-cache.test.ts
+++ b/test/review-structural-cache.test.ts
@@ -1,0 +1,511 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import test from "node:test";
+
+import {
+  createReviewStructuralRecord,
+  reviewStructuralActivitiesForTest,
+  reviewStructuralCacheDecision,
+  reviewStructuralQuery,
+  reviewStructuralRecordFromGraphql,
+  type ReviewStructuralRecord,
+  type ReviewStructuralSnapshot,
+} from "../dist/review-structural-cache.js";
+
+const NOW = Date.parse("2026-07-12T12:00:00Z");
+const DAY_MS = 24 * 60 * 60 * 1000;
+const TARGET_SHA = "a".repeat(40);
+const HEAD_SHA = "b".repeat(40);
+const BASE_SHA = "c".repeat(40);
+
+function digest(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function issueSnapshot(
+  overrides: Partial<ReviewStructuralSnapshot> = {},
+): ReviewStructuralSnapshot {
+  return {
+    repo: "openclaw/openclaw",
+    number: 123,
+    kind: "issue",
+    nodeId: "I_kwDOIssue",
+    author: "contributor",
+    authorAssociation: "CONTRIBUTOR",
+    titleDigest: digest("title"),
+    bodyDigest: digest("body"),
+    state: "OPEN",
+    locked: false,
+    labels: ["bug"],
+    labelsTruncated: false,
+    activityUpdatedAt: "2026-07-10T10:00:00Z",
+    comments: [
+      {
+        id: "IC_comment_1",
+        updatedAt: "2026-07-10T09:00:00Z",
+        author: "contributor",
+        authorAssociation: "CONTRIBUTOR",
+        state: null,
+        commitSha: null,
+      },
+    ],
+    commentsTruncated: false,
+    timeline: [{ type: "CrossReferencedEvent", id: "CE_1", source: "PR_kwDO1" }],
+    timelineTruncated: false,
+    targetHeadSha: TARGET_SHA,
+    latestReleaseTag: "v1.0.0",
+    latestReleaseSha: TARGET_SHA,
+    pull: null,
+    ...overrides,
+  };
+}
+
+function pullSnapshot(overrides: Partial<ReviewStructuralSnapshot> = {}): ReviewStructuralSnapshot {
+  return {
+    ...issueSnapshot(),
+    kind: "pull_request",
+    nodeId: "PR_kwDOPull",
+    pull: {
+      headSha: HEAD_SHA,
+      baseSha: BASE_SHA,
+      draft: false,
+      mergeable: "MERGEABLE",
+      additions: 10,
+      deletions: 2,
+      changedFiles: 3,
+      commitCount: 2,
+      reviews: [
+        {
+          id: "PRR_review_1",
+          updatedAt: "2026-07-10T08:00:00Z",
+          author: "maintainer",
+          authorAssociation: "MEMBER",
+          state: "APPROVED",
+          commitSha: HEAD_SHA,
+        },
+      ],
+      reviewsTruncated: false,
+      reviewThreads: [
+        {
+          id: "PRRT_thread_1",
+          isResolved: true,
+          comments: [
+            {
+              id: "PRRC_comment_1",
+              updatedAt: "2026-07-10T08:30:00Z",
+              author: "maintainer",
+              authorAssociation: "MEMBER",
+              state: null,
+              commitSha: null,
+            },
+          ],
+          commentsTruncated: false,
+        },
+      ],
+      reviewThreadsTruncated: false,
+    },
+    ...overrides,
+  };
+}
+
+function record(
+  snapshot: ReviewStructuralSnapshot = issueSnapshot(),
+  options: { policy?: string; model?: string } = {},
+): ReviewStructuralRecord {
+  const result = createReviewStructuralRecord(snapshot, {
+    reviewPolicy: options.policy ?? "policy-1",
+    reviewModel: options.model ?? "gpt-5.6",
+  });
+  assert.ok(result);
+  return result;
+}
+
+function review(overrides = {}) {
+  return {
+    reviewStatus: "complete",
+    decision: "keep_open",
+    lastFullReviewAt: new Date(NOW - DAY_MS).toISOString(),
+    lastFullReviewDecision: "keep_open",
+    reviewPolicy: "policy-1",
+    reviewModel: "gpt-5.6",
+    reviewCommentSyncedAt: "2026-07-10T10:01:00Z",
+    labelsSyncedAt: "2026-07-10T10:02:00Z",
+    ...overrides,
+  };
+}
+
+function decision(overrides = {}) {
+  const priorRecord = record();
+  return reviewStructuralCacheDecision({
+    review: review(),
+    priorRecord,
+    currentRecord: priorRecord,
+    reviewPolicy: "policy-1",
+    reviewModel: "gpt-5.6",
+    explicitDispatch: false,
+    maintainerRequest: false,
+    now: NOW,
+    ...overrides,
+  });
+}
+
+function graphqlConnection(nodes: unknown[] = []) {
+  return { pageInfo: { hasPreviousPage: false, hasNextPage: false }, nodes };
+}
+
+function graphqlNode(kind: "issue" | "pull_request") {
+  const common = {
+    id: kind === "issue" ? "I_kwDOIssue" : "PR_kwDOPull",
+    number: 123,
+    title: "Title",
+    body: "Body",
+    state: "OPEN",
+    locked: false,
+    updatedAt: "2026-07-10T10:00:00Z",
+    author: { login: "contributor" },
+    authorAssociation: "CONTRIBUTOR",
+    labels: graphqlConnection([{ name: "bug" }]),
+    comments: graphqlConnection([
+      {
+        id: "IC_human",
+        updatedAt: "2026-07-10T09:00:00Z",
+        author: { login: "contributor" },
+        authorAssociation: "CONTRIBUTOR",
+      },
+      {
+        id: "IC_bot",
+        updatedAt: "2026-07-10T09:30:00Z",
+        author: { login: "clawsweeper[bot]" },
+        authorAssociation: "NONE",
+      },
+    ]),
+    timelineItems: graphqlConnection([
+      { __typename: "AssignedEvent", id: "AE_human" },
+      {
+        __typename: "IssueComment",
+        id: "IC_bot_timeline",
+        updatedAt: "2026-07-10T09:30:00Z",
+        author: { login: "clawsweeper[bot]" },
+      },
+      {
+        __typename: "LabeledEvent",
+        id: "LE_advisory",
+        createdAt: "2026-07-10T09:40:00Z",
+        actor: { login: "github-actions[bot]" },
+        label: { name: "P2" },
+      },
+    ]),
+  };
+  if (kind === "issue") return common;
+  return {
+    ...common,
+    headRefOid: HEAD_SHA,
+    baseRefOid: BASE_SHA,
+    isDraft: false,
+    mergeable: "MERGEABLE",
+    additions: 10,
+    deletions: 2,
+    changedFiles: 3,
+    commits: { totalCount: 2 },
+    reviews: graphqlConnection([
+      {
+        id: "PRR_review",
+        updatedAt: "2026-07-10T08:00:00Z",
+        author: { login: "maintainer" },
+        authorAssociation: "MEMBER",
+        state: "APPROVED",
+        commit: { oid: HEAD_SHA },
+      },
+    ]),
+    reviewThreads: graphqlConnection([
+      {
+        id: "PRRT_thread",
+        isResolved: true,
+        comments: graphqlConnection([
+          {
+            id: "PRRC_comment",
+            updatedAt: "2026-07-10T08:30:00Z",
+            author: { login: "maintainer" },
+            authorAssociation: "MEMBER",
+          },
+        ]),
+      },
+    ]),
+  };
+}
+
+function graphqlRecord(kind: "issue" | "pull_request", node = graphqlNode(kind)) {
+  return reviewStructuralRecordFromGraphql({
+    response: {
+      data: {
+        repository: {
+          [kind === "issue" ? "issue" : "pullRequest"]: node,
+        },
+      },
+    },
+    repo: "openclaw/openclaw",
+    number: 123,
+    kind,
+    targetHeadSha: TARGET_SHA,
+    latestReleaseTag: "v1.0.0",
+    latestReleaseSha: TARGET_SHA,
+    reviewPolicy: "policy-1",
+    reviewModel: "gpt-5.6",
+    ignoreAuthor: (author) => author.toLowerCase() === "clawsweeper[bot]",
+    ignoreLabel: (label) => label.toLowerCase() === "p2",
+  });
+}
+
+test("unchanged completed keep-open issue hits the structural cache", () => {
+  assert.deepEqual(decision(), { hit: true, reason: "hit" });
+});
+
+test("GraphQL decoder builds bounded issue and PR records", () => {
+  const issueRecord = graphqlRecord("issue");
+  const pullRecord = graphqlRecord("pull_request");
+  assert.ok(issueRecord);
+  assert.equal(issueRecord.kind, "issue");
+  assert.equal(issueRecord.pullHeadSha, null);
+  assert.ok(pullRecord);
+  assert.equal(pullRecord.kind, "pull_request");
+  assert.equal(pullRecord.pullHeadSha, HEAD_SHA);
+});
+
+test("GraphQL decoder fails closed on truncated metadata", () => {
+  const issue = graphqlNode("issue");
+  const comments = {
+    ...issue.comments,
+    pageInfo: { hasPreviousPage: true, hasNextPage: false },
+  };
+  assert.equal(graphqlRecord("issue", { ...issue, comments }), null);
+});
+
+test("GraphQL decoder tracks human timeline events and ignores owned churn", () => {
+  const node = graphqlNode("issue");
+  const full = graphqlRecord("issue", node);
+  assert.ok(full);
+  const timeline = node.timelineItems.nodes;
+  const withoutIgnored = graphqlRecord("issue", {
+    ...node,
+    timelineItems: graphqlConnection([timeline[0]]),
+  });
+  assert.ok(withoutIgnored);
+  assert.equal(full.sourceRevision, withoutIgnored.sourceRevision);
+  const withoutHuman = graphqlRecord("issue", {
+    ...node,
+    timelineItems: graphqlConnection(timeline.slice(1)),
+  });
+  assert.ok(withoutHuman);
+  assert.notEqual(full.sourceRevision, withoutHuman.sourceRevision);
+});
+
+test("changed human comment metadata forces hydration", () => {
+  const priorRecord = record();
+  const currentRecord = record(
+    issueSnapshot({
+      comments: [
+        {
+          id: "IC_comment_1",
+          updatedAt: "2026-07-11T09:00:00Z",
+          author: "contributor",
+          authorAssociation: "CONTRIBUTOR",
+          state: null,
+          commitSha: null,
+        },
+      ],
+    }),
+  );
+  assert.equal(decision({ priorRecord, currentRecord }).reason, "source_changed");
+});
+
+test("unexplained activity after owned sync forces hydration", () => {
+  const priorRecord = record();
+  const currentRecord = record(issueSnapshot({ activityUpdatedAt: "2026-07-10T10:03:00Z" }));
+  assert.equal(decision({ priorRecord, currentRecord }).reason, "activity_changed");
+});
+
+test("owned comment or label synchronization may explain metadata-only activity", () => {
+  const priorRecord = record();
+  const currentRecord = record(issueSnapshot({ activityUpdatedAt: "2026-07-10T10:02:00Z" }));
+  assert.equal(decision({ priorRecord, currentRecord }).hit, true);
+});
+
+test("changed target head forces issue hydration", () => {
+  const priorRecord = record();
+  const currentRecord = record(issueSnapshot({ targetHeadSha: "d".repeat(40) }));
+  assert.equal(decision({ priorRecord, currentRecord }).reason, "target_changed");
+});
+
+test("changed author association or release identity forces hydration", () => {
+  const priorRecord = record();
+  assert.equal(
+    decision({
+      priorRecord,
+      currentRecord: record(issueSnapshot({ authorAssociation: "MEMBER" })),
+    }).reason,
+    "source_changed",
+  );
+  assert.equal(
+    decision({
+      priorRecord,
+      currentRecord: record(
+        issueSnapshot({
+          latestReleaseTag: "v1.1.0",
+          latestReleaseSha: "d".repeat(40),
+        }),
+      ),
+    }).reason,
+    "source_changed",
+  );
+});
+
+test("changed review policy or model forces hydration", () => {
+  assert.equal(decision({ reviewPolicy: "policy-2" }).reason, "policy_changed");
+  assert.equal(decision({ reviewModel: "gpt-next" }).reason, "model_changed");
+});
+
+test("explicit dispatch and maintainer requests always hydrate", () => {
+  assert.equal(decision({ explicitDispatch: true }).reason, "explicit_dispatch");
+  assert.equal(decision({ maintainerRequest: true }).reason, "maintainer_request");
+});
+
+test("stale completed reviews force hydration", () => {
+  assert.equal(
+    decision({
+      review: review({ lastFullReviewAt: new Date(NOW - 14 * DAY_MS).toISOString() }),
+    }).reason,
+    "stale_review",
+  );
+});
+
+test("old reports without structural fields force hydration", () => {
+  assert.equal(decision({ priorRecord: null }).reason, "missing_or_invalid_record");
+});
+
+test("failed and close reviews always hydrate", () => {
+  assert.equal(
+    decision({ review: review({ reviewStatus: "failed" }) }).reason,
+    "incomplete_review",
+  );
+  assert.equal(decision({ review: review({ decision: "close" }) }).reason, "non_keep_open_verdict");
+  assert.equal(
+    decision({ review: review({ lastFullReviewDecision: "close" }) }).reason,
+    "non_keep_open_verdict",
+  );
+});
+
+test("PR records require unchanged PR source and head", () => {
+  const priorRecord = record(pullSnapshot());
+  const changedHead = pullSnapshot({
+    pull: {
+      ...pullSnapshot().pull!,
+      headSha: "d".repeat(40),
+    },
+  });
+  const currentRecord = record(changedHead);
+  assert.equal(decision({ priorRecord, currentRecord }).reason, "pull_head_changed");
+});
+
+test("changed PR review state forces hydration", () => {
+  const priorRecord = record(pullSnapshot());
+  const currentRecord = record(
+    pullSnapshot({
+      pull: {
+        ...pullSnapshot().pull!,
+        reviews: [
+          {
+            ...pullSnapshot().pull!.reviews[0]!,
+            state: "CHANGES_REQUESTED",
+          },
+        ],
+      },
+    }),
+  );
+  assert.equal(decision({ priorRecord, currentRecord }).reason, "source_changed");
+});
+
+test("issue and PR records cannot be reused across kinds", () => {
+  assert.equal(
+    decision({ priorRecord: record(), currentRecord: record(pullSnapshot()) }).reason,
+    "item_kind_changed",
+  );
+});
+
+test("truncated comments, timeline, reviews, and threads cannot seed the cache", () => {
+  assert.equal(
+    createReviewStructuralRecord(issueSnapshot({ commentsTruncated: true }), {
+      reviewPolicy: "policy-1",
+      reviewModel: "gpt-5.6",
+    }),
+    null,
+  );
+  assert.equal(
+    createReviewStructuralRecord(issueSnapshot({ timelineTruncated: true }), {
+      reviewPolicy: "policy-1",
+      reviewModel: "gpt-5.6",
+    }),
+    null,
+  );
+  assert.equal(
+    createReviewStructuralRecord(
+      pullSnapshot({
+        pull: { ...pullSnapshot().pull!, reviewThreadsTruncated: true },
+      }),
+      { reviewPolicy: "policy-1", reviewModel: "gpt-5.6" },
+    ),
+    null,
+  );
+});
+
+test("metadata probes request activity metadata without comment or review bodies", () => {
+  const issueQuery = reviewStructuralQuery("issue");
+  const pullQuery = reviewStructuralQuery("pull_request");
+
+  assert.match(issueQuery, /comments\(last: 100\)/);
+  assert.match(issueQuery, /CrossReferencedEvent/);
+  assert.doesNotMatch(issueQuery, /comments\(last: 100\)[\s\S]*?\bbody\b/);
+  assert.match(pullQuery, /headRefOid/);
+  assert.match(pullQuery, /reviewThreads\(last: 100\)/);
+  assert.doesNotMatch(pullQuery, /reviewThreads\(last: 100\)[\s\S]*?\bbody\b/);
+});
+
+test("metadata probes ignore ClawSweeper comments but fail closed on malformed entries", () => {
+  const result = reviewStructuralActivitiesForTest(
+    {
+      pageInfo: { hasPreviousPage: false },
+      nodes: [
+        {
+          id: "bot-comment",
+          updatedAt: "2026-07-10T10:00:00Z",
+          author: { login: "ClawSweeper[bot]" },
+          authorAssociation: "NONE",
+        },
+        {
+          id: "human-comment",
+          updatedAt: "2026-07-10T10:01:00Z",
+          author: { login: "maintainer" },
+          authorAssociation: "MEMBER",
+        },
+      ],
+    },
+    ["clawsweeper[bot]"],
+  );
+  assert.equal(result.truncated, false);
+  assert.deepEqual(result.activities, [
+    {
+      id: "human-comment",
+      updatedAt: "2026-07-10T10:01:00Z",
+      author: "maintainer",
+      authorAssociation: "MEMBER",
+      state: null,
+      commitSha: null,
+    },
+  ]);
+  assert.equal(
+    reviewStructuralActivitiesForTest({
+      pageInfo: { hasPreviousPage: false },
+      nodes: [{ id: "missing-timestamp", author: { login: "maintainer" } }],
+    }).truncated,
+    true,
+  );
+});

--- a/test/review-structural-cache.test.ts
+++ b/test/review-structural-cache.test.ts
@@ -9,6 +9,7 @@ import {
   reviewStructuralQuery,
   reviewStructuralRecordAtLeastAsFresh,
   reviewStructuralRecordFromGraphql,
+  reviewStructuralRecordMatchesHydratedItem,
   reviewStructuralRecordMatchesHydratedPull,
   reviewStructuralRecordMatchesObservedUpdate,
   reviewStructuralRecordsDescribeSameVerdictInput,
@@ -308,6 +309,7 @@ test("GraphQL decoder builds bounded issue and PR records", () => {
   assert.ok(issueRecord);
   assert.equal(issueRecord.kind, "issue");
   assert.equal(issueRecord.pullHeadSha, null);
+  assert.ok(issueRecord.itemStateDigest);
   assert.ok(pullRecord);
   assert.equal(pullRecord.kind, "pull_request");
   assert.equal(pullRecord.pullHeadSha, HEAD_SHA);
@@ -596,6 +598,19 @@ test("same-second human comment edits change the structural source revision", ()
   assert.ok(original);
   assert.ok(edited);
   assert.notEqual(original.sourceRevision, edited.sourceRevision);
+});
+
+test("post-hydration anchors reject same-second semantic edits", () => {
+  const node = graphqlNode("issue");
+  const hydrated = graphqlRecord("issue", node);
+  const edited = graphqlRecord("issue", {
+    ...node,
+    body: "Edited without a timestamp advance",
+  });
+  assert.ok(hydrated);
+  assert.ok(edited);
+  assert.equal(reviewStructuralRecordMatchesObservedUpdate(edited, node.updatedAt), true);
+  assert.equal(reviewStructuralRecordMatchesHydratedItem(edited, hydrated.itemStateDigest), false);
 });
 
 test("same-second review edits change the structural source revision", () => {

--- a/test/review-structural-cache.test.ts
+++ b/test/review-structural-cache.test.ts
@@ -348,6 +348,33 @@ test("GraphQL decoder builds bounded issue and PR records", () => {
   assert.ok(pullRecord.pullStateDigest);
 });
 
+test("structural records canonicalize GitHub App login suffixes", () => {
+  const graphql = record(
+    issueSnapshot({
+      author: "dependabot",
+      comments: [
+        {
+          ...issueSnapshot().comments[0],
+          author: "third-party-app",
+        },
+      ],
+    }),
+  );
+  const rest = record(
+    issueSnapshot({
+      author: "dependabot[bot]",
+      comments: [
+        {
+          ...issueSnapshot().comments[0],
+          author: "third-party-app[bot]",
+        },
+      ],
+    }),
+  );
+  assert.equal(graphql.itemStateDigest, rest.itemStateDigest);
+  assert.equal(graphql.sourceRevision, rest.sourceRevision);
+});
+
 test("GraphQL decoder fails closed on truncated metadata", () => {
   const issue = graphqlNode("issue");
   const comments = {

--- a/test/review-structural-cache.test.ts
+++ b/test/review-structural-cache.test.ts
@@ -70,6 +70,7 @@ function pullSnapshot(overrides: Partial<ReviewStructuralSnapshot> = {}): Review
       baseSha: BASE_SHA,
       draft: false,
       mergeable: "MERGEABLE",
+      mergeStateStatus: "CLEAN",
       additions: 10,
       deletions: 2,
       changedFiles: 3,
@@ -203,6 +204,7 @@ function graphqlNode(kind: "issue" | "pull_request") {
     baseRefOid: BASE_SHA,
     isDraft: false,
     mergeable: "MERGEABLE",
+    mergeStateStatus: "CLEAN",
     additions: 10,
     deletions: 2,
     changedFiles: 3,
@@ -469,6 +471,19 @@ test("changed PR review state forces hydration", () => {
             state: "CHANGES_REQUESTED",
           },
         ],
+      },
+    }),
+  );
+  assert.equal(decision({ priorRecord, currentRecord }).reason, "source_changed");
+});
+
+test("changed PR merge-state status forces hydration", () => {
+  const priorRecord = record(pullSnapshot());
+  const currentRecord = record(
+    pullSnapshot({
+      pull: {
+        ...pullSnapshot().pull!,
+        mergeStateStatus: "BLOCKED",
       },
     }),
   );

--- a/test/review-structural-cache.test.ts
+++ b/test/review-structural-cache.test.ts
@@ -280,6 +280,48 @@ test("GraphQL decoder fails closed on truncated metadata", () => {
   assert.equal(graphqlRecord("issue", { ...issue, comments }), null);
 });
 
+test("GraphQL decoder requires the queried pagination boundary", () => {
+  const issue = graphqlNode("issue");
+  assert.equal(
+    graphqlRecord("issue", {
+      ...issue,
+      labels: {
+        pageInfo: { hasPreviousPage: false },
+        nodes: [{ name: "bug" }],
+      },
+    }),
+    null,
+  );
+  assert.equal(
+    graphqlRecord("issue", {
+      ...issue,
+      comments: {
+        pageInfo: { hasNextPage: false },
+        nodes: issue.comments.nodes,
+      },
+    }),
+    null,
+  );
+});
+
+test("GraphQL decoder rejects incomplete relation targets", () => {
+  const issue = graphqlNode("issue");
+  assert.equal(
+    graphqlRecord("issue", {
+      ...issue,
+      timelineItems: graphqlConnection([
+        {
+          __typename: "CrossReferencedEvent",
+          id: "CE_incomplete",
+          createdAt: "2026-07-10T09:45:00Z",
+          source: null,
+        },
+      ]),
+    }),
+    null,
+  );
+});
+
 test("GraphQL decoder tracks human timeline events and ignores owned churn", () => {
   const node = graphqlNode("issue");
   const full = graphqlRecord("issue", node);
@@ -373,6 +415,15 @@ test("stale completed reviews force hydration", () => {
   assert.equal(
     decision({
       review: review({ lastFullReviewAt: new Date(NOW - 14 * DAY_MS).toISOString() }),
+    }).reason,
+    "stale_review",
+  );
+});
+
+test("future completed review timestamps force hydration", () => {
+  assert.equal(
+    decision({
+      review: review({ lastFullReviewAt: new Date(NOW + DAY_MS).toISOString() }),
     }).reason,
     "stale_review",
   );

--- a/test/review-structural-cache.test.ts
+++ b/test/review-structural-cache.test.ts
@@ -129,6 +129,7 @@ function review(overrides = {}) {
     lastFullReviewDecision: "keep_open",
     reviewPolicy: "policy-1",
     reviewModel: "gpt-5.6",
+    itemSourceRevision: digest("full item source"),
     reviewCommentSyncedAt: "2026-07-10T10:01:00Z",
     labelsSyncedAt: "2026-07-10T10:02:00Z",
     ...overrides,
@@ -145,6 +146,7 @@ function decision(overrides = {}) {
     reviewModel: "gpt-5.6",
     explicitDispatch: false,
     maintainerRequest: false,
+    coordinationEnabled: true,
     now: NOW,
     ...overrides,
   });
@@ -411,6 +413,14 @@ test("changed review policy or model forces hydration", () => {
 test("explicit dispatch and maintainer requests always hydrate", () => {
   assert.equal(decision({ explicitDispatch: true }).reason, "explicit_dispatch");
   assert.equal(decision({ maintainerRequest: true }).reason, "maintainer_request");
+});
+
+test("disabled coordination and missing lease revisions force hydration", () => {
+  assert.equal(decision({ coordinationEnabled: false }).reason, "coordination_disabled");
+  assert.equal(
+    decision({ review: review({ itemSourceRevision: undefined }) }).reason,
+    "missing_lease_revision",
+  );
 });
 
 test("stale completed reviews force hydration", () => {

--- a/test/review-structural-cache.test.ts
+++ b/test/review-structural-cache.test.ts
@@ -9,6 +9,7 @@ import {
   reviewStructuralQuery,
   reviewStructuralRecordAtLeastAsFresh,
   reviewStructuralRecordFromGraphql,
+  reviewStructuralRecordMatchesHydratedPull,
   reviewStructuralRecordMatchesObservedUpdate,
   reviewStructuralRecordsDescribeSameVerdictInput,
   type ReviewStructuralRecord,
@@ -50,6 +51,7 @@ function issueSnapshot(
         authorAssociation: "CONTRIBUTOR",
         state: null,
         commitSha: null,
+        bodyDigest: digest("comment"),
       },
     ],
     commentsTruncated: false,
@@ -87,6 +89,7 @@ function pullSnapshot(overrides: Partial<ReviewStructuralSnapshot> = {}): Review
           authorAssociation: "MEMBER",
           state: "APPROVED",
           commitSha: HEAD_SHA,
+          bodyDigest: digest("review"),
         },
       ],
       reviewsTruncated: false,
@@ -102,6 +105,7 @@ function pullSnapshot(overrides: Partial<ReviewStructuralSnapshot> = {}): Review
               authorAssociation: "MEMBER",
               state: null,
               commitSha: null,
+              bodyDigest: digest("thread comment"),
             },
           ],
           commentsTruncated: false,
@@ -222,6 +226,7 @@ function graphqlNode(kind: "issue" | "pull_request") {
       {
         id: "PRR_review",
         updatedAt: "2026-07-10T08:00:00Z",
+        body: "Approved",
         author: { login: "maintainer" },
         authorAssociation: "MEMBER",
         state: "APPROVED",
@@ -306,6 +311,7 @@ test("GraphQL decoder builds bounded issue and PR records", () => {
   assert.ok(pullRecord);
   assert.equal(pullRecord.kind, "pull_request");
   assert.equal(pullRecord.pullHeadSha, HEAD_SHA);
+  assert.ok(pullRecord.pullStateDigest);
 });
 
 test("GraphQL decoder fails closed on truncated metadata", () => {
@@ -390,6 +396,7 @@ test("changed human comment metadata forces hydration", () => {
           authorAssociation: "CONTRIBUTOR",
           state: null,
           commitSha: null,
+          bodyDigest: digest("comment"),
         },
       ],
     }),
@@ -573,6 +580,106 @@ test("changed PR merge-state status forces hydration", () => {
   assert.equal(decision({ priorRecord, currentRecord }).reason, "source_changed");
 });
 
+test("same-second human comment edits change the structural source revision", () => {
+  const node = graphqlNode("issue");
+  const original = graphqlRecord("issue", node);
+  const edited = graphqlRecord("issue", {
+    ...node,
+    comments: graphqlConnection([
+      {
+        ...node.comments.nodes[0],
+        body: "Edited without a timestamp advance",
+      },
+      node.comments.nodes[1],
+    ]),
+  });
+  assert.ok(original);
+  assert.ok(edited);
+  assert.notEqual(original.sourceRevision, edited.sourceRevision);
+});
+
+test("same-second review edits change the structural source revision", () => {
+  const node = graphqlNode("pull_request");
+  const original = graphqlRecord("pull_request", node);
+  const review = node.reviews.nodes[0];
+  assert.ok(review);
+  const edited = graphqlRecord("pull_request", {
+    ...node,
+    reviews: graphqlConnection([
+      {
+        ...review,
+        body: "Approved after another pass",
+      },
+    ]),
+  });
+  assert.ok(original);
+  assert.ok(edited);
+  assert.notEqual(original.sourceRevision, edited.sourceRevision);
+});
+
+test("same-second review-thread edits change the structural source revision", () => {
+  const node = graphqlNode("pull_request");
+  const original = graphqlRecord("pull_request", node);
+  const thread = node.reviewThreads.nodes[0];
+  assert.ok(thread);
+  const comment = thread.comments.nodes[0];
+  assert.ok(comment);
+  const edited = graphqlRecord("pull_request", {
+    ...node,
+    reviewThreads: graphqlConnection([
+      {
+        ...thread,
+        comments: graphqlConnection([
+          {
+            ...comment,
+            body: "Edited without a timestamp advance",
+          },
+        ]),
+      },
+    ]),
+  });
+  assert.ok(original);
+  assert.ok(edited);
+  assert.notEqual(original.sourceRevision, edited.sourceRevision);
+});
+
+test("hydrated pull state must match the complete structural PR state", () => {
+  const current = record(pullSnapshot());
+  const hydrated = {
+    headSha: HEAD_SHA,
+    baseSha: BASE_SHA,
+    draft: false,
+    mergeable: true,
+    mergeStateStatus: "clean",
+    additions: 10,
+    deletions: 2,
+    changedFiles: 3,
+    commitCount: 2,
+  };
+  assert.equal(reviewStructuralRecordMatchesHydratedPull(current, hydrated), true);
+  assert.equal(
+    reviewStructuralRecordMatchesHydratedPull(current, {
+      ...hydrated,
+      baseSha: "d".repeat(40),
+    }),
+    false,
+  );
+  assert.equal(
+    reviewStructuralRecordMatchesHydratedPull(current, {
+      ...hydrated,
+      mergeStateStatus: "blocked",
+    }),
+    false,
+  );
+  assert.equal(
+    reviewStructuralRecordMatchesHydratedPull(current, {
+      ...hydrated,
+      mergeable: false,
+    }),
+    false,
+  );
+});
+
 test("issue and PR records cannot be reused across kinds", () => {
   assert.equal(
     decision({ priorRecord: record(), currentRecord: record(pullSnapshot()) }).reason,
@@ -650,6 +757,7 @@ test("metadata probes ignore ClawSweeper comments but fail closed on malformed e
       authorAssociation: "MEMBER",
       state: null,
       commitSha: null,
+      bodyDigest: digest("No related item"),
     },
   ]);
   assert.equal(

--- a/test/review-structural-cache.test.ts
+++ b/test/review-structural-cache.test.ts
@@ -7,7 +7,10 @@ import {
   reviewStructuralActivitiesForTest,
   reviewStructuralCacheDecision,
   reviewStructuralQuery,
+  reviewStructuralRecordAtLeastAsFresh,
   reviewStructuralRecordFromGraphql,
+  reviewStructuralRecordMatchesObservedUpdate,
+  reviewStructuralRecordsDescribeSameVerdictInput,
   type ReviewStructuralRecord,
   type ReviewStructuralSnapshot,
 } from "../dist/review-structural-cache.js";
@@ -267,6 +270,31 @@ function graphqlRecord(kind: "issue" | "pull_request", node = graphqlNode(kind))
 
 test("unchanged completed keep-open issue hits the structural cache", () => {
   assert.deepEqual(decision(), { hit: true, reason: "hit" });
+});
+
+test("structural probes cannot undercut a newer observed item generation", () => {
+  const current = record();
+  assert.equal(reviewStructuralRecordAtLeastAsFresh(current, "2026-07-10T10:00:00Z"), true);
+  assert.equal(reviewStructuralRecordAtLeastAsFresh(current, "2026-07-10T10:00:01Z"), false);
+  assert.equal(reviewStructuralRecordMatchesObservedUpdate(current, "2026-07-10T10:00:00Z"), true);
+  assert.equal(reviewStructuralRecordMatchesObservedUpdate(current, "2026-07-10T09:59:59Z"), false);
+});
+
+test("verdict fingerprints may advance owned activity but not semantic input", () => {
+  const anchor = record();
+  const ownedActivityAdvance = record(issueSnapshot({ activityUpdatedAt: "2026-07-10T10:01:00Z" }));
+  assert.equal(reviewStructuralRecordsDescribeSameVerdictInput(anchor, ownedActivityAdvance), true);
+  const changedInput = record(
+    issueSnapshot({
+      activityUpdatedAt: "2026-07-10T10:02:00Z",
+      titleDigest: digest("changed title"),
+    }),
+  );
+  assert.equal(reviewStructuralRecordsDescribeSameVerdictInput(anchor, changedInput), false);
+  assert.equal(
+    reviewStructuralRecordsDescribeSameVerdictInput(ownedActivityAdvance, anchor),
+    false,
+  );
 });
 
 test("GraphQL decoder builds bounded issue and PR records", () => {


### PR DESCRIPTION
## Summary

- add a fail-closed structural fingerprint for scheduled keep-open reviews
- reuse unchanged verdicts before hydrating comments, timelines, diffs, commits, and review threads
- acquire the normal durable review lease and revalidate before reuse
- canonicalize REST and GraphQL GitHub App identities before structural hashing
- retain the full-content cache as a second stage and expose per-run savings metrics

## Safety

- explicit reviews, close verdicts, policy/model changes, incomplete metadata, probe failures, source drift, and human activity fall through to full hydration
- pre-hydration, post-hydration, and final-verdict probes bind reuse to one unchanged semantic input
- structural hits cannot promote an item to close
- persisted fingerprints contain bounded metadata and digests, not bodies or comment text

## Validation

- 189 review tests
- TypeScript build, lint, format, and diff checks
- formal focused reviews clean after same-second drift and GitHub App identity fixes

## Release notes

- updated `CHANGELOG.md`
- added `docs/review-cache.md`
