### PR TITLE
fix(review): bind cache reuse to live verdicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,9 @@ checkpoint, and status-only commits are intentionally omitted.
 - Bound structural, semantic, and content review reuse to the complete live
   durable verdict under the acquired lease, excluding only validated review
   history and comment transport metadata; versioned security scanner directive
-  hashing, rejected malformed eligibility records, and skipped unreachable
-  compiler work for local-range reviews.
+  hashing, isolated durable-comment refresh failures to the affected item,
+  rejected malformed eligibility records, and skipped unreachable compiler
+  work for local-range reviews.
 - Packaged only planned prior review reports into scheduled shard runtimes and
   rebound structural cache probes to the explicit latest release state,
   restoring safe cache reuse without broad generated-state artifacts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,9 +40,10 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
-- Bound semantic review reuse to the live durable prior-review identity, preserved
-  security scanner suppression directives, rejected malformed eligibility
-  records, and skipped unreachable compiler work for local-range reviews.
+- Bound structural, semantic, and content review reuse to the live durable
+  prior-review identity under the acquired lease; versioned security scanner
+  directive hashing, rejected malformed eligibility records, and skipped
+  unreachable compiler work for local-range reviews.
 - Packaged only planned prior review reports into scheduled shard runtimes and
   rebound structural cache probes to the explicit latest release state,
   restoring safe cache reuse without broad generated-state artifacts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,10 +40,11 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
-- Bound structural, semantic, and content review reuse to the live durable
-  prior-review identity under the acquired lease; versioned security scanner
-  directive hashing, rejected malformed eligibility records, and skipped
-  unreachable compiler work for local-range reviews.
+- Bound structural, semantic, and content review reuse to the complete live
+  durable verdict under the acquired lease, excluding only validated review
+  history and comment transport metadata; versioned security scanner directive
+  hashing, rejected malformed eligibility records, and skipped unreachable
+  compiler work for local-range reviews.
 - Packaged only planned prior review reports into scheduled shard runtimes and
   rebound structural cache probes to the explicit latest release state,
   restoring safe cache reuse without broad generated-state artifacts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Bound semantic review reuse to the live durable prior-review identity, preserved
+  security scanner suppression directives, rejected malformed eligibility
+  records, and skipped unreachable compiler work for local-range reviews.
 - Packaged only planned prior review reports into scheduled shard runtimes and
   rebound structural cache probes to the explicit latest release state,
   restoring safe cache reuse without broad generated-state artifacts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,9 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
-- Bound structural, semantic, and content review reuse to the exact persisted
-  durable-comment body hash under the acquired lease, preserving label
+- Bound structural, semantic, and content review reuse to the canonical
+  persisted durable-comment body hash under the acquired lease, normalizing
+  surrounding whitespace while preserving label
   transitions and linked-item render context; versioned security scanner
   directive hashing, isolated durable-comment refresh failures to the affected
   item, rejected malformed eligibility records, and skipped unreachable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,12 +40,12 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
-- Bound structural, semantic, and content review reuse to the complete live
-  durable verdict under the acquired lease, excluding only validated review
-  history and comment transport metadata; versioned security scanner directive
-  hashing, isolated durable-comment refresh failures to the affected item,
-  rejected malformed eligibility records, and skipped unreachable compiler
-  work for local-range reviews.
+- Bound structural, semantic, and content review reuse to the exact persisted
+  durable-comment body hash under the acquired lease, preserving label
+  transitions and linked-item render context; versioned security scanner
+  directive hashing, isolated durable-comment refresh failures to the affected
+  item, rejected malformed eligibility records, and skipped unreachable
+  compiler work for local-range reviews.
 - Packaged only planned prior review reports into scheduled shard runtimes and
   rebound structural cache probes to the explicit latest release state,
   restoring safe cache reuse without broad generated-state artifacts.

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -22882,7 +22882,9 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
             );
             const counterpartAllowApplyCloseActionUpgrade =
               isApplyCloseCandidateReport(counterpartMarkdown);
-            const counterpartMarkedReviewCommentHash = sha256(counterpartMarkedReviewComment);
+            const counterpartMarkedReviewCommentHash = reviewCommentBodyDigest(
+              counterpartMarkedReviewComment,
+            );
             const counterpartNeedsReviewCommentSync = shouldSyncReviewComment({
               syncCommentsOnly: false,
               isCloseProposal: true,

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -4882,6 +4882,12 @@ function previousClawSweeperReviewFromReport(
   );
 }
 
+function liveClawSweeperReviewDigest(number: number): string | null {
+  return reviewSemanticPriorReviewDigest(
+    extractLatestClawSweeperReview(fetchIssueReviewComments(number), number),
+  );
+}
+
 export function previousClawSweeperReviewDigestFromReportForTest(
   markdown: string,
   number: number,
@@ -20309,6 +20315,11 @@ function reviewCommand(args: Args): void {
         );
       }
       const priorReview = localRangeData ? null : existingReview(item, itemsDir);
+      const expectedPreviousReviewDigest = priorReview
+        ? reviewSemanticPriorReviewDigest(
+            previousClawSweeperReviewFromReport(priorReview.markdown, item.number),
+          )
+        : null;
       let acquiredReviewLease: AcquiredReviewStartLease | null = null;
       let structuralRecord: ReviewStructuralRecord | null = null;
       let preHydrationStructuralRecord: ReviewStructuralRecord | null = null;
@@ -20413,6 +20424,7 @@ function reviewCommand(args: Args): void {
             structuralCacheRevalidations += 1;
             const structuralRevalidationStartedAt = Date.now();
             let revalidatedStructuralRecord: ReviewStructuralRecord | null = null;
+            let revalidatedPreviousReviewDigest: string | null = null;
             try {
               git = loadReviewGitInfo();
               revalidatedStructuralRecord = fetchReviewStructuralRecord({
@@ -20426,6 +20438,7 @@ function reviewCommand(args: Args): void {
               ) {
                 revalidatedStructuralRecord = null;
               }
+              revalidatedPreviousReviewDigest = liveClawSweeperReviewDigest(item.number);
             } catch (error) {
               structuralCacheRevalidationFailures += 1;
               console.error(
@@ -20451,16 +20464,23 @@ function reviewCommand(args: Args): void {
               maintainerRequest,
               coordinationEnabled: true,
             });
+            const previousReviewIdentityMatches =
+              expectedPreviousReviewDigest !== null &&
+              revalidatedPreviousReviewDigest !== null &&
+              expectedPreviousReviewDigest === revalidatedPreviousReviewDigest;
+            const revalidationReason = previousReviewIdentityMatches
+              ? revalidationDecision.reason
+              : "previous_review_changed";
             structuralCacheRevalidationReasons.set(
-              revalidationDecision.reason,
-              (structuralCacheRevalidationReasons.get(revalidationDecision.reason) ?? 0) + 1,
+              revalidationReason,
+              (structuralCacheRevalidationReasons.get(revalidationReason) ?? 0) + 1,
             );
-            if (!revalidationDecision.hit) {
+            if (!revalidationDecision.hit || !previousReviewIdentityMatches) {
               const leaseToRelease = acquiredReviewLease!;
               if (!deleteOwnedDedicatedReviewStartLease(item.number, leaseToRelease)) {
                 leaseAcquisitionFailures += 1;
                 leaseAcquisitionFailureDetails.push(
-                  `#${item.number}: could not release structural cache lease after ${revalidationDecision.reason}`,
+                  `#${item.number}: could not release structural cache lease after ${revalidationReason}`,
                 );
                 continue;
               }
@@ -20476,7 +20496,7 @@ function reviewCommand(args: Args): void {
               preHydrationStructuralRecord = revalidatedStructuralRecord;
               if (structuralRecord) item.updatedAt = structuralRecord.activityUpdatedAt;
               console.error(
-                `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} structural-cache=revalidation-miss reason=${revalidationDecision.reason} hydrate #${item.number}`,
+                `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} structural-cache=revalidation-miss reason=${revalidationReason} hydrate #${item.number}`,
               );
             } else {
               const confirmedStructuralRecord = revalidatedStructuralRecord!;
@@ -20712,6 +20732,47 @@ function reviewCommand(args: Args): void {
           continue;
         }
       }
+      if (!localRangeData && item.kind === "issue" && acquiredReviewLease) {
+        try {
+          const revalidatedPreviousReview = extractLatestClawSweeperReview(
+            fetchIssueReviewComments(item.number),
+            item.number,
+          );
+          if (revalidatedPreviousReview) {
+            context.previousClawSweeperReview = revalidatedPreviousReview;
+          } else {
+            delete context.previousClawSweeperReview;
+          }
+        } catch (error) {
+          const leaseToRelease = acquiredReviewLease;
+          leaseAcquisitionFailures += 1;
+          leaseAcquisitionFailureDetails.push(
+            `#${item.number}: could not refresh durable review after acquiring issue lease: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+          if (!deleteOwnedDedicatedReviewStartLease(item.number, leaseToRelease)) {
+            leaseAcquisitionFailureDetails.push(
+              `#${item.number}: could not release issue review lease after durable review refresh failed`,
+            );
+            continue;
+          }
+          const acquiredIndex = acquiredReviewLeases.findIndex(
+            (entry) =>
+              entry.itemNumber === item.number &&
+              entry.lease.commentId === leaseToRelease.commentId &&
+              entry.lease.owner === leaseToRelease.owner,
+          );
+          if (acquiredIndex >= 0) acquiredReviewLeases.splice(acquiredIndex, 1);
+          acquiredReviewLease = null;
+          console.error(
+            `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} durable-review=revalidation-failed defer #${item.number}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+          continue;
+        }
+      }
       const contentDigest = itemContentDigest(item, context, git);
       let currentPreviousReviewDigest: string | null = null;
       let previousReviewIdentityChanged = false;
@@ -20733,11 +20794,6 @@ function reviewCommand(args: Args): void {
           (semanticCacheEligibilityReasons.get(semanticRecord.eligibilityReason) ?? 0) + 1,
         );
         if (!semanticRecord.eligible) semanticCacheIneligible += 1;
-        const expectedPreviousReviewDigest = priorReview
-          ? reviewSemanticPriorReviewDigest(
-              previousClawSweeperReviewFromReport(priorReview.markdown, item.number),
-            )
-          : null;
         currentPreviousReviewDigest = reviewSemanticPriorReviewDigest(
           context.previousClawSweeperReview,
         );

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -20844,10 +20844,43 @@ function reviewCommand(args: Args): void {
           ...context,
           pullChecks: revalidatedChecks,
         };
-        const revalidatedPreviousReview = extractLatestClawSweeperReview(
-          fetchIssueReviewComments(item.number),
-          item.number,
-        );
+        let revalidatedPreviousReview: PreviousClawSweeperReview | null;
+        try {
+          revalidatedPreviousReview = extractLatestClawSweeperReview(
+            fetchIssueReviewComments(item.number),
+            item.number,
+          );
+        } catch (error) {
+          const revalidationReason = "durable_review_refresh_failed";
+          semanticCacheRevalidationFailures += 1;
+          semanticCacheRevalidationMs += Date.now() - semanticRevalidationStartedAt;
+          semanticCacheRevalidationReasons.set(
+            revalidationReason,
+            (semanticCacheRevalidationReasons.get(revalidationReason) ?? 0) + 1,
+          );
+          const leaseToRelease = acquiredReviewLease!;
+          if (!deleteOwnedDedicatedReviewStartLease(item.number, leaseToRelease)) {
+            leaseAcquisitionFailures += 1;
+            leaseAcquisitionFailureDetails.push(
+              `#${item.number}: could not release semantic cache lease after ${revalidationReason}`,
+            );
+            continue;
+          }
+          const acquiredIndex = acquiredReviewLeases.findIndex(
+            (entry) =>
+              entry.itemNumber === item.number &&
+              entry.lease.commentId === leaseToRelease.commentId &&
+              entry.lease.owner === leaseToRelease.owner,
+          );
+          if (acquiredIndex >= 0) acquiredReviewLeases.splice(acquiredIndex, 1);
+          acquiredReviewLease = null;
+          console.error(
+            `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} semantic-cache=revalidation-failed reason=${revalidationReason} defer #${item.number}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+          continue;
+        }
         if (revalidatedPreviousReview) {
           revalidatedContext.previousClawSweeperReview = revalidatedPreviousReview;
         } else {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -74,6 +74,7 @@ import {
   REVIEW_SEMANTIC_CACHE_VERSION,
   createReviewSemanticRecord,
   reviewSemanticCacheDecision,
+  reviewSemanticPriorReviewDigest,
   reviewSemanticRevalidationDecision,
   validReviewSemanticRecord,
   type ReviewSemanticRecord,
@@ -4838,6 +4839,56 @@ export function extractLatestClawSweeperReviewForTest(
   return extractLatestClawSweeperReview(comments, number);
 }
 
+function extractLatestClawSweeperReviewFromHydration(
+  commentsWindow: ContextHydration<unknown>,
+  completeComments: readonly unknown[],
+  number: number,
+): PreviousClawSweeperReview | null {
+  return extractLatestClawSweeperReview(
+    commentsWindow.truncated ? completeComments : commentsWindow.items,
+    number,
+  );
+}
+
+export function extractLatestClawSweeperReviewFromHydrationForTest(
+  commentsWindow: ContextHydration<unknown>,
+  completeComments: readonly unknown[],
+  number: number,
+): PreviousClawSweeperReview | null {
+  return extractLatestClawSweeperReviewFromHydration(commentsWindow, completeComments, number);
+}
+
+function previousClawSweeperReviewFromReport(
+  markdown: string,
+  number: number,
+): PreviousClawSweeperReview | null {
+  const closeReason =
+    (frontMatterValue(markdown, "close_reason") as CloseReason | undefined) ?? "none";
+  const body = markedReviewCommentBody(
+    number,
+    renderReviewCommentFromReport(markdown, closeReason),
+  );
+  return extractLatestClawSweeperReview(
+    [
+      {
+        id: `state-report-${number}`,
+        body,
+        html_url: "",
+        updated_at: frontMatterValue(markdown, "reviewed_at") ?? "",
+        user: { login: "clawsweeper[bot]" },
+      },
+    ],
+    number,
+  );
+}
+
+export function previousClawSweeperReviewDigestFromReportForTest(
+  markdown: string,
+  number: number,
+): string | null {
+  return reviewSemanticPriorReviewDigest(previousClawSweeperReviewFromReport(markdown, number));
+}
+
 function compactTimelineEvent(value: unknown): unknown {
   const event = asRecord(value);
   const sourceIssue = asRecord(asRecord(event.source).issue);
@@ -7819,7 +7870,11 @@ function collectItemContext(
     ? ghPaged<unknown>(`repos/${targetRepo()}/issues/${item.number}/comments`)
     : comments;
   const filteredComments = filterReviewContextComments(comments, item.number);
-  const previousClawSweeperReview = extractLatestClawSweeperReview(comments, item.number);
+  const previousClawSweeperReview = extractLatestClawSweeperReviewFromHydration(
+    commentsWindow,
+    sourceRevisionComments,
+    item.number,
+  );
   const timelineWindow = ghPagedLinkHeaderContextWindow<unknown>(
     `repos/${targetRepo()}/issues/${item.number}/timeline`,
     80,
@@ -20658,37 +20713,56 @@ function reviewCommand(args: Args): void {
         }
       }
       const contentDigest = itemContentDigest(item, context, git);
-      const semanticCacheStartedAt = Date.now();
-      semanticCacheChecks += 1;
-      semanticRecord = createReviewSemanticRecord({
-        item,
-        context,
-        git,
-        structuralContextRevision: hydratedStructuralAnchor?.contextRevision ?? null,
-        reviewPolicy,
-        reviewModel: PUBLIC_CODEX_MODEL,
-      });
-      semanticCacheMs += Date.now() - semanticCacheStartedAt;
-      semanticCacheEligibilityReasons.set(
-        semanticRecord.eligibilityReason,
-        (semanticCacheEligibilityReasons.get(semanticRecord.eligibilityReason) ?? 0) + 1,
-      );
-      if (!semanticRecord.eligible) semanticCacheIneligible += 1;
-      const semanticDecision = reviewSemanticCacheDecision({
-        review: priorReview,
-        priorRecord: priorReview?.semanticRecord ?? null,
-        currentRecord: semanticRecord,
-        reviewPolicy,
-        reviewModel: PUBLIC_CODEX_MODEL,
-        explicitDispatch,
-        maintainerRequest,
-        coordinationEnabled: Boolean(acquiredReviewLease),
-      });
-      semanticCacheReasons.set(
-        semanticDecision.reason,
-        (semanticCacheReasons.get(semanticDecision.reason) ?? 0) + 1,
-      );
-      if (semanticDecision.hit) {
+      let currentPreviousReviewDigest: string | null = null;
+      let previousReviewIdentityChanged = false;
+      let semanticDecision: ReturnType<typeof reviewSemanticCacheDecision> | null = null;
+      if (!localRangeData) {
+        const semanticCacheStartedAt = Date.now();
+        semanticCacheChecks += 1;
+        semanticRecord = createReviewSemanticRecord({
+          item,
+          context,
+          git,
+          structuralContextRevision: hydratedStructuralAnchor?.contextRevision ?? null,
+          reviewPolicy,
+          reviewModel: PUBLIC_CODEX_MODEL,
+        });
+        semanticCacheMs += Date.now() - semanticCacheStartedAt;
+        semanticCacheEligibilityReasons.set(
+          semanticRecord.eligibilityReason,
+          (semanticCacheEligibilityReasons.get(semanticRecord.eligibilityReason) ?? 0) + 1,
+        );
+        if (!semanticRecord.eligible) semanticCacheIneligible += 1;
+        const expectedPreviousReviewDigest = priorReview
+          ? reviewSemanticPriorReviewDigest(
+              previousClawSweeperReviewFromReport(priorReview.markdown, item.number),
+            )
+          : null;
+        currentPreviousReviewDigest = reviewSemanticPriorReviewDigest(
+          context.previousClawSweeperReview,
+        );
+        previousReviewIdentityChanged =
+          !expectedPreviousReviewDigest ||
+          !currentPreviousReviewDigest ||
+          expectedPreviousReviewDigest !== currentPreviousReviewDigest;
+        semanticDecision = reviewSemanticCacheDecision({
+          review: priorReview,
+          priorRecord: priorReview?.semanticRecord ?? null,
+          currentRecord: semanticRecord,
+          expectedPreviousReviewDigest,
+          currentPreviousReviewDigest,
+          reviewPolicy,
+          reviewModel: PUBLIC_CODEX_MODEL,
+          explicitDispatch,
+          maintainerRequest,
+          coordinationEnabled: Boolean(acquiredReviewLease),
+        });
+        semanticCacheReasons.set(
+          semanticDecision.reason,
+          (semanticCacheReasons.get(semanticDecision.reason) ?? 0) + 1,
+        );
+      }
+      if (semanticDecision?.hit) {
         semanticCacheRevalidations += 1;
         const initialSemanticRecord = semanticRecord;
         const semanticRevalidationStartedAt = Date.now();
@@ -20711,6 +20785,15 @@ function reviewCommand(args: Args): void {
           ...context,
           pullChecks: revalidatedChecks,
         };
+        const revalidatedPreviousReview = extractLatestClawSweeperReview(
+          fetchIssueReviewComments(item.number),
+          item.number,
+        );
+        if (revalidatedPreviousReview) {
+          revalidatedContext.previousClawSweeperReview = revalidatedPreviousReview;
+        } else {
+          delete revalidatedContext.previousClawSweeperReview;
+        }
         const revalidatedRelatedItems = refreshRelatedItemsContext(item, context);
         if (revalidatedRelatedItems.length > 0) {
           revalidatedContext.relatedItems = revalidatedRelatedItems;
@@ -20737,6 +20820,10 @@ function reviewCommand(args: Args): void {
         const semanticRevalidationDecision = reviewSemanticRevalidationDecision({
           initialRecord: initialSemanticRecord,
           currentRecord: revalidatedSemanticRecord,
+          initialPreviousReviewDigest: currentPreviousReviewDigest,
+          currentPreviousReviewDigest: reviewSemanticPriorReviewDigest(
+            revalidatedContext.previousClawSweeperReview,
+          ),
           reviewPolicy,
           reviewModel: PUBLIC_CODEX_MODEL,
         });
@@ -20825,6 +20912,7 @@ function reviewCommand(args: Args): void {
       const contentCacheReview =
         explicitDispatch ||
         maintainerRequest ||
+        previousReviewIdentityChanged ||
         !git.releaseStateComplete ||
         (item.kind === "pull_request" && !completePullChecksContext(context.pullChecks))
           ? null

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -176,6 +176,7 @@ import {
 import {
   appendReviewHistoryCycle,
   neutralizeReviewControlMarkers,
+  normalizeDurableReviewVerdictBody,
   parseReviewHistory,
   renderReviewHistorySection,
   reviewHistoryCycleFromCommentBody,
@@ -4569,6 +4570,7 @@ const CLAWSWEEPER_COMMAND_ONLY_PATTERN = /^@clawsweeper\s+(?:re-review|re-run|re
 
 interface PreviousClawSweeperReview {
   status: string;
+  verdictDigest: string;
   reviewedAt: string | null;
   reviewedSha: string | null;
   verdictMarker: string | null;
@@ -4802,6 +4804,7 @@ function extractLatestClawSweeperReview(
   const earlierReviewCycles = currentCycle ? history.cycles : history.cycles.slice(0, -1);
   return {
     status: previousReviewStatus(body),
+    verdictDigest: sha256(normalizeDurableReviewVerdictBody(body)),
     reviewedAt: previousReviewReviewedAt(body) ?? latestCompletedCycle?.reviewedAt ?? null,
     reviewedSha:
       markerAttribute(verdictMarker, "sha") ??

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -176,7 +176,6 @@ import {
 import {
   appendReviewHistoryCycle,
   neutralizeReviewControlMarkers,
-  normalizeDurableReviewVerdictBody,
   parseReviewHistory,
   renderReviewHistorySection,
   reviewHistoryCycleFromCommentBody,
@@ -4804,7 +4803,7 @@ function extractLatestClawSweeperReview(
   const earlierReviewCycles = currentCycle ? history.cycles : history.cycles.slice(0, -1);
   return {
     status: previousReviewStatus(body),
-    verdictDigest: sha256(normalizeDurableReviewVerdictBody(body)),
+    verdictDigest: sha256(body),
     reviewedAt: previousReviewReviewedAt(body) ?? latestCompletedCycle?.reviewedAt ?? null,
     reviewedSha:
       markerAttribute(verdictMarker, "sha") ??
@@ -4861,28 +4860,9 @@ export function extractLatestClawSweeperReviewFromHydrationForTest(
   return extractLatestClawSweeperReviewFromHydration(commentsWindow, completeComments, number);
 }
 
-function previousClawSweeperReviewFromReport(
-  markdown: string,
-  number: number,
-): PreviousClawSweeperReview | null {
-  const closeReason =
-    (frontMatterValue(markdown, "close_reason") as CloseReason | undefined) ?? "none";
-  const body = markedReviewCommentBody(
-    number,
-    renderReviewCommentFromReport(markdown, closeReason),
-  );
-  return extractLatestClawSweeperReview(
-    [
-      {
-        id: `state-report-${number}`,
-        body,
-        html_url: "",
-        updated_at: frontMatterValue(markdown, "reviewed_at") ?? "",
-        user: { login: "clawsweeper[bot]" },
-      },
-    ],
-    number,
-  );
+function previousClawSweeperReviewDigestFromReport(markdown: string): string | null {
+  const digest = frontMatterValue(markdown, "review_comment_sha256")?.trim().toLowerCase();
+  return digest && /^[0-9a-f]{64}$/.test(digest) ? digest : null;
 }
 
 function liveClawSweeperReviewDigest(number: number): string | null {
@@ -4893,9 +4873,9 @@ function liveClawSweeperReviewDigest(number: number): string | null {
 
 export function previousClawSweeperReviewDigestFromReportForTest(
   markdown: string,
-  number: number,
+  _number: number,
 ): string | null {
-  return reviewSemanticPriorReviewDigest(previousClawSweeperReviewFromReport(markdown, number));
+  return previousClawSweeperReviewDigestFromReport(markdown);
 }
 
 function compactTimelineEvent(value: unknown): unknown {
@@ -20319,9 +20299,7 @@ function reviewCommand(args: Args): void {
       }
       const priorReview = localRangeData ? null : existingReview(item, itemsDir);
       const expectedPreviousReviewDigest = priorReview
-        ? reviewSemanticPriorReviewDigest(
-            previousClawSweeperReviewFromReport(priorReview.markdown, item.number),
-          )
+        ? previousClawSweeperReviewDigestFromReport(priorReview.markdown)
         : null;
       let acquiredReviewLease: AcquiredReviewStartLease | null = null;
       let structuralRecord: ReviewStructuralRecord | null = null;

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -2602,6 +2602,10 @@ function sha256(text: string): string {
   return createHash("sha256").update(text).digest("hex");
 }
 
+function reviewCommentBodyDigest(body: string): string {
+  return sha256(body.trim());
+}
+
 let reviewPromptTemplateCache: string | undefined;
 let reviewDecisionSchemaCache: string | undefined;
 let prCloseCoverageProofPromptTemplateCache: string | undefined;
@@ -4803,7 +4807,7 @@ function extractLatestClawSweeperReview(
   const earlierReviewCycles = currentCycle ? history.cycles : history.cycles.slice(0, -1);
   return {
     status: previousReviewStatus(body),
-    verdictDigest: sha256(body),
+    verdictDigest: reviewCommentBodyDigest(body),
     reviewedAt: previousReviewReviewedAt(body) ?? latestCompletedCycle?.reviewedAt ?? null,
     reviewedSha:
       markerAttribute(verdictMarker, "sha") ??
@@ -18560,7 +18564,7 @@ function reviewCommentHashMatches(
   ) {
     return false;
   }
-  return storedHash === sha256(actual);
+  return storedHash === reviewCommentBodyDigest(actual);
 }
 
 const PATCHABLE_REVIEW_COMMENT_AUTHORS = new Set(
@@ -18667,7 +18671,11 @@ function updateReviewCommentMetadata(
   comment: Record<string, unknown> | undefined,
   body: string,
 ): string {
-  let next = replaceFrontMatterValue(markdown, "review_comment_sha256", sha256(body));
+  let next = replaceFrontMatterValue(
+    markdown,
+    "review_comment_sha256",
+    reviewCommentBodyDigest(body),
+  );
   const id = commentId(comment);
   const url = commentUrl(comment);
   if (id !== null) next = replaceFrontMatterValue(next, "review_comment_id", String(id));
@@ -23823,7 +23831,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
         continue;
       }
     }
-    let reviewCommentHash = sha256(markedReviewComment);
+    let reviewCommentHash = reviewCommentBodyDigest(markedReviewComment);
     const allowApplyCloseActionUpgrade = isUpgradedCloseCandidate;
     let existingReviewCommentMatches = commentBodyMatches(
       existingReviewComment,
@@ -23909,7 +23917,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
           isCloseProposal = false;
           reviewComment = renderReviewCommentFromReport(markdown, closeReason, renderOptions);
           markedReviewComment = markedReviewCommentForApply(reviewComment);
-          reviewCommentHash = sha256(markedReviewComment);
+          reviewCommentHash = reviewCommentBodyDigest(markedReviewComment);
           existingReviewCommentMatches = commentBodyMatches(
             existingReviewComment,
             markedReviewComment,
@@ -23982,7 +23990,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
       if (!wasStaleCanonicalCommentSyncPending && staleCanonicalCommentSyncPending) {
         reviewComment = renderCurrentReviewComment();
         markedReviewComment = markedReviewCommentForApply(reviewComment);
-        reviewCommentHash = sha256(markedReviewComment);
+        reviewCommentHash = reviewCommentBodyDigest(markedReviewComment);
         existingReviewCommentMatches = commentBodyMatches(
           existingReviewComment,
           markedReviewComment,

--- a/src/review-history.ts
+++ b/src/review-history.ts
@@ -10,6 +10,12 @@ export interface ReviewHistoryLedger {
   totalCompletedCycles: number;
 }
 
+interface ParsedReviewHistory {
+  ledger: ReviewHistoryLedger;
+  start: number;
+  end: number;
+}
+
 export const MAX_REVIEW_HISTORY_CYCLES = 8;
 const MAX_CYCLE_FINDINGS = 6;
 const MAX_HISTORY_FIELD_CHARS = 160;
@@ -97,7 +103,7 @@ function parseReviewHistoryLine(line: string): ReviewHistoryCycle | null {
   return { reviewedAt: head[1].trim(), sha: head[2], verdict, findings };
 }
 
-function parseReviewHistoryAt(body: string, markerIndex: number): ReviewHistoryLedger | null {
+function parseReviewHistoryAt(body: string, markerIndex: number): ParsedReviewHistory | null {
   const markerEnd = body.indexOf("-->", markerIndex + REVIEW_HISTORY_MARKER_PREFIX.length);
   if (markerEnd < 0) return null;
   const marker = body.slice(markerIndex + 4, markerEnd).trim();
@@ -143,21 +149,46 @@ function parseReviewHistoryAt(body: string, markerIndex: number): ReviewHistoryL
   ].join("\n");
   if (summary.replaceAll("\r\n", "\n") !== expectedSummary) return null;
   return {
-    cycles,
-    totalCompletedCycles: parsedTotal,
+    ledger: {
+      cycles,
+      totalCompletedCycles: parsedTotal,
+    },
+    start: detailsStart,
+    end: detailsEnd + "</details>".length,
   };
 }
 
-export function parseReviewHistory(body: string): ReviewHistoryLedger {
+function latestParsedReviewHistory(body: string): ParsedReviewHistory | null {
   let searchFrom = body.length;
   while (searchFrom > 0) {
     const markerIndex = body.lastIndexOf(REVIEW_HISTORY_MARKER_PREFIX, searchFrom - 1);
     if (markerIndex < 0) break;
-    const ledger = parseReviewHistoryAt(body, markerIndex);
-    if (ledger) return ledger;
+    const parsed = parseReviewHistoryAt(body, markerIndex);
+    if (parsed) return parsed;
     searchFrom = markerIndex;
   }
+  return null;
+}
+
+export function parseReviewHistory(body: string): ReviewHistoryLedger {
+  const parsed = latestParsedReviewHistory(body);
+  if (parsed) return parsed.ledger;
   return { cycles: [], totalCompletedCycles: 0 };
+}
+
+export function normalizeDurableReviewVerdictBody(body: string): string {
+  const normalized = body.replace(/\r\n?/g, "\n");
+  const parsed = latestParsedReviewHistory(normalized);
+  const withoutHistory = parsed
+    ? [normalized.slice(0, parsed.start).trimEnd(), normalized.slice(parsed.end).trimStart()]
+        .filter(Boolean)
+        .join("\n\n")
+    : normalized;
+  return withoutHistory
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .join("\n")
+    .trim();
 }
 
 function reviewHistoryCycleKey(cycle: ReviewHistoryCycle): string {

--- a/src/review-semantic-cache.ts
+++ b/src/review-semantic-cache.ts
@@ -8,7 +8,7 @@ import { API } from "typescript/unstable/sync";
 import { REVIEW_CACHE_MAX_AGE_DAYS } from "./scheduler-policy.js";
 import { stableJson } from "./stable-json.js";
 
-export const REVIEW_SEMANTIC_CACHE_VERSION = 8;
+export const REVIEW_SEMANTIC_CACHE_VERSION = 9;
 export const REVIEW_SEMANTIC_CACHE_MAX_AGE_DAYS = REVIEW_CACHE_MAX_AGE_DAYS;
 
 const DAY_MS = 24 * 60 * 60 * 1000;

--- a/src/review-semantic-cache.ts
+++ b/src/review-semantic-cache.ts
@@ -16,7 +16,7 @@ const DIGEST_PATTERN = /^[0-9a-f]{64}$/;
 const MAX_PATCH_CHARS = 512 * 1024;
 const MAX_FILES = 80;
 const DIRECTIVE_COMMENT_PATTERN =
-  /(?:^\/[/*]!|^\/\*(?:::?|\?)|[@#]|\/\/\/\s*<(?:reference|amd-module|amd-dependency)\b|\b(?:babel|biome|c8|coverage|deno-fmt|deno-lint|eslint|esbuild|flow|gql|graphql|istanbul|jshint|jslint|nosonar|oxfmt|oxlint|prettier|rollup|swc|tslint|v8|vite|webpack)[\w-]*|\b(?:exported|globals?)\b)/i;
+  /(?:^\/[/*]!|^\/\*(?:::?|\?)|[@#]|\/\/\/\s*<(?:reference|amd-module|amd-dependency)\b|\b(?:babel|biome|c8|coverage|deno-fmt|deno-lint|eslint|esbuild|flow|gitleaks|gql|graphql|istanbul|jshint|jslint|nosemgrep|nosonar|oxfmt|oxlint|prettier|rollup|semgrep|swc|tslint|v8|vite|webpack)[\w-]*|\b(?:exported|globals?)\b)/i;
 const TYPESCRIPT_EXTENSIONS = new Set([
   ".cjs",
   ".cts",
@@ -117,6 +117,7 @@ export type ReviewSemanticCacheReason =
   | "policy_changed"
   | "model_changed"
   | "stale_review"
+  | "previous_review_changed"
   | "missing_or_invalid_record"
   | "semantic_ineligible"
   | "code_changed"
@@ -856,6 +857,40 @@ function recordFingerprint(record: Omit<ReviewSemanticRecord, "fingerprint">): s
   return sha256(stableJson(record));
 }
 
+export function reviewSemanticPriorReviewDigest(value: unknown): string | null {
+  const review = asRecord(value);
+  const findings = Array.isArray(review.findings)
+    ? review.findings.map((entry) => {
+        const finding = asRecord(entry);
+        return {
+          priority: stringValue(finding.priority),
+          title: stringValue(finding.title),
+        };
+      })
+    : [];
+  const identity = {
+    status: stringValue(review.status),
+    reviewedSha: stringValue(review.reviewedSha),
+    verdictMarker: stringValue(review.verdictMarker),
+    actionMarker: stringValue(review.actionMarker),
+    summary: stringValue(review.summary),
+    proofStatus: stringValue(review.proofStatus),
+    rating: stringValue(review.rating),
+    nextStep: stringValue(review.nextStep),
+    findings,
+  };
+  if (
+    !identity.status &&
+    !identity.reviewedSha &&
+    !identity.verdictMarker &&
+    !identity.actionMarker &&
+    !identity.summary
+  ) {
+    return null;
+  }
+  return sha256(stableJson(identity));
+}
+
 export function createReviewSemanticRecord(input: ReviewSemanticInput): ReviewSemanticRecord {
   const exactDigest = exactDiffDigest(input);
   const code = semanticCode(input);
@@ -888,6 +923,7 @@ export function validReviewSemanticRecord(
     !DIGEST_PATTERN.test(record.codeDigest) ||
     !DIGEST_PATTERN.test(record.exactDigest) ||
     !DIGEST_PATTERN.test(record.contextDigest) ||
+    typeof record.eligible !== "boolean" ||
     !record.reviewPolicy ||
     !record.reviewModel ||
     !ELIGIBILITY_REASONS.has(record.eligibilityReason) ||
@@ -937,6 +973,8 @@ export function reviewSemanticCacheDecision(options: {
   review: ReviewSemanticPriorReview | null;
   priorRecord: ReviewSemanticRecord | null;
   currentRecord: ReviewSemanticRecord | null;
+  expectedPreviousReviewDigest: string | null;
+  currentPreviousReviewDigest: string | null;
   reviewPolicy: string;
   reviewModel: string;
   explicitDispatch: boolean;
@@ -968,6 +1006,13 @@ export function reviewSemanticCacheDecision(options: {
   ) {
     return { hit: false, reason: "stale_review" };
   }
+  if (
+    !options.expectedPreviousReviewDigest ||
+    !options.currentPreviousReviewDigest ||
+    options.expectedPreviousReviewDigest !== options.currentPreviousReviewDigest
+  ) {
+    return { hit: false, reason: "previous_review_changed" };
+  }
   return compareSemanticRecords(
     options.priorRecord,
     options.currentRecord,
@@ -979,9 +1024,18 @@ export function reviewSemanticCacheDecision(options: {
 export function reviewSemanticRevalidationDecision(options: {
   initialRecord: ReviewSemanticRecord | null;
   currentRecord: ReviewSemanticRecord | null;
+  initialPreviousReviewDigest: string | null;
+  currentPreviousReviewDigest: string | null;
   reviewPolicy: string;
   reviewModel: string;
 }): ReviewSemanticCacheDecision {
+  if (
+    !options.initialPreviousReviewDigest ||
+    !options.currentPreviousReviewDigest ||
+    options.initialPreviousReviewDigest !== options.currentPreviousReviewDigest
+  ) {
+    return { hit: false, reason: "previous_review_changed" };
+  }
   return compareSemanticRecords(
     options.initialRecord,
     options.currentRecord,

--- a/src/review-semantic-cache.ts
+++ b/src/review-semantic-cache.ts
@@ -859,35 +859,26 @@ function recordFingerprint(record: Omit<ReviewSemanticRecord, "fingerprint">): s
 
 export function reviewSemanticPriorReviewDigest(value: unknown): string | null {
   const review = asRecord(value);
-  const findings = Array.isArray(review.findings)
-    ? review.findings.map((entry) => {
-        const finding = asRecord(entry);
-        return {
-          priority: stringValue(finding.priority),
-          title: stringValue(finding.title),
-        };
-      })
-    : [];
-  const identity = {
-    status: stringValue(review.status),
-    reviewedSha: stringValue(review.reviewedSha),
-    verdictMarker: stringValue(review.verdictMarker),
-    actionMarker: stringValue(review.actionMarker),
-    summary: stringValue(review.summary),
-    proofStatus: stringValue(review.proofStatus),
-    rating: stringValue(review.rating),
-    nextStep: stringValue(review.nextStep),
-    findings,
+  const verdictDigest = stringValue(review.verdictDigest);
+  if (verdictDigest && DIGEST_PATTERN.test(verdictDigest)) return verdictDigest;
+
+  const excluded = new Set([
+    "verdictDigest",
+    "reviewedAt",
+    "earlierReviewCycles",
+    "completedReviewCycles",
+    "commentId",
+    "commentUrl",
+    "commentUpdatedAt",
+  ]);
+  const identity = Object.fromEntries(Object.entries(review).filter(([key]) => !excluded.has(key)));
+  const hasIdentity = (entry: unknown): boolean => {
+    if (typeof entry === "string") return entry.trim().length > 0;
+    if (typeof entry === "number" || typeof entry === "boolean") return true;
+    if (Array.isArray(entry)) return entry.some(hasIdentity);
+    return Object.values(asRecord(entry)).some(hasIdentity);
   };
-  if (
-    !identity.status &&
-    !identity.reviewedSha &&
-    !identity.verdictMarker &&
-    !identity.actionMarker &&
-    !identity.summary
-  ) {
-    return null;
-  }
+  if (!hasIdentity(identity)) return null;
   return sha256(stableJson(identity));
 }
 

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -7,6 +7,7 @@ import {
   compactMappedSlice,
   compactMappedWindow,
   extractLatestClawSweeperReviewForTest,
+  extractLatestClawSweeperReviewFromHydrationForTest,
   filterReviewContextCommentsForTest,
   ghPagedContextWindow,
   ghPagedLinkHeaderContextWindow,
@@ -333,6 +334,39 @@ Needs real behavior proof before merge.
   assert.equal(review.findings[0]?.priority, "P1");
   assert.equal(review.findings[0]?.title, "Preserve session state");
   assert.doesNotMatch(JSON.stringify(review), /How this review workflow works/);
+});
+
+test("durable review identity uses complete comments outside the prompt window", () => {
+  const comments = Array.from({ length: 30 }, (_, index) =>
+    issueComment(index + 1, `comment ${index + 1}`, "contributor"),
+  );
+  comments[14] = issueComment(
+    15,
+    `Codex review: passed.
+
+**Summary**
+The review in the middle of an active discussion remains authoritative.
+
+<!-- clawsweeper-verdict:pass item=123 sha=abc confidence=high -->
+<!-- clawsweeper-review item=123 -->`,
+    "clawsweeper[bot]",
+    "2026-05-24T02:00:00Z",
+  );
+  const commentsWindow = ghPagedContextWindow<unknown>(
+    "repos/openclaw/openclaw/issues/123/comments",
+    comments.length,
+    24,
+    {
+      page: (_path, page) => comments.slice((page - 1) * 100, page * 100),
+    },
+  );
+
+  assert.equal(extractLatestClawSweeperReviewForTest(commentsWindow.items, 123), null);
+  const review = extractLatestClawSweeperReviewFromHydrationForTest(commentsWindow, comments, 123);
+
+  assert.ok(review);
+  assert.equal(review.reviewedSha, "abc");
+  assert.match(review.summary ?? "", /middle of an active discussion/);
 });
 
 test("latest ClawSweeper durable review parser supports compact merge readiness layout", () => {

--- a/test/local-range-review.test.ts
+++ b/test/local-range-review.test.ts
@@ -366,6 +366,16 @@ test("--local-range defaults to the current checkout and isolates gh config in a
     );
     assert.equal(realpathSync(dirname(dirname(ghConfigDir ?? ""))), realpathSync(gitArtifactRoot));
     assert.ok(existsSync(ghConfigDir ?? ""));
+    const cacheMetrics = JSON.parse(
+      readFileSync(join(dirname(ghConfigDir ?? ""), "review-cache-metrics.json"), "utf8"),
+    ) as Record<string, unknown>;
+    assert.equal(cacheMetrics.semantic_cache_checks, 0);
+    assert.equal(cacheMetrics.semantic_cache_hits, 0);
+    assert.equal(cacheMetrics.semantic_cache_revalidations, 0);
+    assert.match(
+      readFileSync(join(dirname(ghConfigDir ?? ""), "0.md"), "utf8"),
+      /review_semantic_cache_version: unknown/,
+    );
     assert.equal(git(dir, "status", "--porcelain"), "");
   } finally {
     rmSync(codexDir, { recursive: true, force: true });

--- a/test/review-comment-rendering.test.ts
+++ b/test/review-comment-rendering.test.ts
@@ -252,6 +252,10 @@ test("semantic cache runs after hydration and revalidates under the acquired lea
     /reviewSemanticPriorReviewDigest\(\s*revalidatedContext\.previousClawSweeperReview/,
   );
   assert.match(
+    reviewLoop.slice(priorReviewRevalidation, relationRevalidation),
+    /catch \(error\)[\s\S]*durable_review_refresh_failed[\s\S]*deleteOwnedDedicatedReviewStartLease[\s\S]*acquiredReviewLeases\.splice[\s\S]*continue/,
+  );
+  assert.match(
     reviewLoop.slice(semanticRevalidation, semanticWrite),
     /updateReviewSemanticFrontMatter\(carried, semanticRecord, true\)/,
   );

--- a/test/review-comment-rendering.test.ts
+++ b/test/review-comment-rendering.test.ts
@@ -156,6 +156,10 @@ test("structural cache probes before hydration but acquires a lease before carry
     reviewLoop.slice(structuralRevalidation, structuralWrite),
     /git = loadReviewGitInfo\(\)[\s\S]*fetchReviewStructuralRecord\(\{/,
   );
+  assert.match(
+    reviewLoop.slice(structuralRevalidation, structuralWrite),
+    /liveClawSweeperReviewDigest\(item\.number\)[\s\S]*previousReviewIdentityMatches/,
+  );
   const structuralProbeSource = source.slice(
     source.indexOf("function fetchReviewStructuralRecord"),
     source.indexOf("function collectItemContext"),
@@ -191,6 +195,11 @@ test("semantic cache runs after hydration and revalidates under the acquired lea
   );
   const hydration = reviewLoop.indexOf("collectItemContext(item");
   const semanticRecord = reviewLoop.indexOf("createReviewSemanticRecord({", hydration);
+  const issueLease = reviewLoop.indexOf('} else if (item.kind !== "pull_request")', hydration);
+  const issueReviewRevalidation = reviewLoop.indexOf(
+    "fetchIssueReviewComments(item.number)",
+    issueLease,
+  );
   const localRangeGuard = reviewLoop.lastIndexOf("if (!localRangeData)", semanticRecord);
   const semanticDecision = reviewLoop.indexOf("reviewSemanticCacheDecision({", semanticRecord);
   const semanticRevalidation = reviewLoop.indexOf(
@@ -218,6 +227,9 @@ test("semantic cache runs after hydration and revalidates under the acquired lea
 
   assert.ok(hydration >= 0);
   assert.ok(localRangeGuard > hydration);
+  assert.ok(issueLease > hydration);
+  assert.ok(issueReviewRevalidation > issueLease);
+  assert.ok(issueReviewRevalidation < semanticRecord);
   assert.ok(semanticRecord > hydration);
   assert.ok(semanticDecision > semanticRecord);
   assert.ok(semanticRevalidation > semanticDecision);

--- a/test/review-comment-rendering.test.ts
+++ b/test/review-comment-rendering.test.ts
@@ -191,12 +191,17 @@ test("semantic cache runs after hydration and revalidates under the acquired lea
   );
   const hydration = reviewLoop.indexOf("collectItemContext(item");
   const semanticRecord = reviewLoop.indexOf("createReviewSemanticRecord({", hydration);
+  const localRangeGuard = reviewLoop.lastIndexOf("if (!localRangeData)", semanticRecord);
   const semanticDecision = reviewLoop.indexOf("reviewSemanticCacheDecision({", semanticRecord);
   const semanticRevalidation = reviewLoop.indexOf(
     "semanticCacheRevalidations += 1",
     semanticDecision,
   );
   const checkRevalidation = reviewLoop.indexOf("pullChecksContext(", semanticRevalidation);
+  const priorReviewRevalidation = reviewLoop.indexOf(
+    "fetchIssueReviewComments(item.number)",
+    semanticRevalidation,
+  );
   const relationRevalidation = reviewLoop.indexOf(
     "refreshRelatedItemsContext(item, context)",
     semanticRevalidation,
@@ -212,11 +217,13 @@ test("semantic cache runs after hydration and revalidates under the acquired lea
   const contentCache = reviewLoop.indexOf("reviewContentCacheHit({", semanticWrite);
 
   assert.ok(hydration >= 0);
+  assert.ok(localRangeGuard > hydration);
   assert.ok(semanticRecord > hydration);
   assert.ok(semanticDecision > semanticRecord);
   assert.ok(semanticRevalidation > semanticDecision);
   assert.ok(checkRevalidation > semanticRevalidation);
-  assert.ok(relationRevalidation > checkRevalidation);
+  assert.ok(priorReviewRevalidation > checkRevalidation);
+  assert.ok(relationRevalidation > priorReviewRevalidation);
   assert.ok(revalidatedRecord > relationRevalidation);
   assert.ok(semanticWrite > revalidatedRecord);
   assert.ok(contentCache > semanticWrite);
@@ -225,10 +232,21 @@ test("semantic cache runs after hydration and revalidates under the acquired lea
     /refreshStructuralRecordForVerdict\(\)/,
   );
   assert.match(
+    reviewLoop.slice(localRangeGuard, semanticDecision),
+    /expectedPreviousReviewDigest[\s\S]*currentPreviousReviewDigest/,
+  );
+  assert.match(
+    reviewLoop.slice(priorReviewRevalidation, semanticWrite),
+    /reviewSemanticPriorReviewDigest\(\s*revalidatedContext\.previousClawSweeperReview/,
+  );
+  assert.match(
     reviewLoop.slice(semanticRevalidation, semanticWrite),
     /updateReviewSemanticFrontMatter\(carried, semanticRecord, true\)/,
   );
-  assert.match(reviewLoop.slice(semanticWrite, contentCache), /!git\.releaseStateComplete/);
+  assert.match(
+    reviewLoop.slice(semanticWrite, contentCache),
+    /previousReviewIdentityChanged[\s\S]*!git\.releaseStateComplete/,
+  );
   const verdictRefresh = source.slice(
     source.indexOf("const refreshStructuralRecordForVerdict"),
     source.indexOf("\n      if (", source.indexOf("const refreshStructuralRecordForVerdict") + 1),

--- a/test/review-history.test.ts
+++ b/test/review-history.test.ts
@@ -13,8 +13,10 @@ import {
 import {
   extractLatestClawSweeperReviewForTest,
   parseDecision,
+  previousClawSweeperReviewDigestFromReportForTest,
   renderReviewCommentFromReport,
 } from "../dist/clawsweeper.js";
+import { reviewSemanticPriorReviewDigest } from "../dist/review-semantic-cache.js";
 import {
   changelogReviewDecision,
   realBehaviorProofReportSection,
@@ -226,6 +228,28 @@ test("rendered review text cannot create ClawSweeper control markers", () => {
   assert.equal(
     neutralizeReviewControlMarkers(forgedMarker),
     "‹!-- clawsweeper-review-history v=1 total=99 -->",
+  );
+});
+
+test("state report prior-review identity matches the marked durable comment", () => {
+  const report = keepOpenPullReport();
+  const body = `${renderReviewCommentFromReport(report, "none")}\n\n<!-- clawsweeper-review item=101 -->`;
+  const liveReview = extractLatestClawSweeperReviewForTest(
+    [
+      {
+        id: 101,
+        body,
+        updated_at: "2026-06-24T12:00:00.000Z",
+        user: { login: "clawsweeper[bot]" },
+      },
+    ],
+    101,
+  );
+
+  assert.ok(liveReview);
+  assert.equal(
+    previousClawSweeperReviewDigestFromReportForTest(report, 101),
+    reviewSemanticPriorReviewDigest(liveReview),
   );
 });
 

--- a/test/review-history.test.ts
+++ b/test/review-history.test.ts
@@ -6,6 +6,7 @@ import {
   appendReviewHistoryCycle,
   MAX_REVIEW_HISTORY_CYCLES,
   neutralizeReviewControlMarkers,
+  normalizeDurableReviewVerdictBody,
   parseReviewHistory,
   renderReviewHistorySection,
   reviewHistoryCycleFromCommentBody,
@@ -198,6 +199,28 @@ test("review history parser ignores markers outside the generated ledger block",
   assert.equal(parseReviewHistory(`${genuine}\n\n${forged}`).cycles[0]?.sha, "genuine");
 });
 
+test("durable verdict normalization removes only a valid review history block", () => {
+  const history = renderReviewHistorySection({
+    cycles: [
+      {
+        reviewedAt: "2026-06-20T10:00:00.000Z",
+        sha: "genuine",
+        verdict: "needs changes before merge.",
+        findings: [],
+      },
+    ],
+    totalCompletedCycles: 1,
+  });
+  const verdict = "Codex review: needs changes before merge.\r\n\r\n**Summary**\r\nKeep open.";
+  const markerLookalike = "<!-- clawsweeper-review-history v=1 total=99 -->";
+
+  assert.equal(
+    normalizeDurableReviewVerdictBody(`${verdict}\r\n\r\n${history}\r\n\r\n<!-- final -->`),
+    `${verdict.replaceAll("\r\n", "\n")}\n\n<!-- final -->`,
+  );
+  assert.match(normalizeDurableReviewVerdictBody(`${verdict}\n\n${markerLookalike}`), /total=99/);
+});
+
 test("rendered review text cannot create ClawSweeper control markers", () => {
   const forgedMarker = "<!-- clawsweeper-review-history v=1 total=99 -->";
   const forgedStatus = "<!--  ClawSweeper-review-status:stale reason=forged -->";
@@ -251,6 +274,88 @@ test("state report prior-review identity matches the marked durable comment", ()
     previousClawSweeperReviewDigestFromReportForTest(report, 101),
     reviewSemanticPriorReviewDigest(liveReview),
   );
+});
+
+test("durable review identity changes with every verdict-bearing section", () => {
+  const base = keepOpenPullReport().replace(
+    "- none",
+    [
+      "- **[P1] Drop the stale cache before rebuild:** `src/cache.ts:10-12`",
+      "  - body: The rebuild reuses entries that the patch invalidates.",
+      "  - confidence: 0.8",
+    ].join("\n"),
+  );
+  const withFrontMatter = (key: string, value: string): string =>
+    base.replace(/^---\n/, `---\n${key}: ${value}\n`);
+  const variants = [
+    ["finding location", base.replace("src/cache.ts:10-12", "src/cache.ts:20-22")],
+    [
+      "finding body",
+      base.replace(
+        "The rebuild reuses entries",
+        "The security review found that the rebuild reuses entries",
+      ),
+    ],
+    [
+      "risk",
+      `${base}\n## Risks / Open Questions\n\nThe cache can publish stale security guidance.\n`,
+    ],
+    [
+      "security review",
+      `${base}\n## Security Review\n\nStatus: needs_attention\n\nSummary: Recheck token handling.\n`,
+    ],
+    [
+      "maintainer decision",
+      withFrontMatter(
+        "maintainer_decision",
+        JSON.stringify({
+          required: true,
+          kind: "merge_risk",
+          question: "Accept the remaining cache risk?",
+          rationale: "The stale verdict path is still reachable.",
+          options: [
+            {
+              title: "Accept risk",
+              body: "Merge without the final cache guard.",
+              recommended: true,
+            },
+          ],
+          likelyOwner: {
+            person: "@cache-team",
+            reason: "Owns cache invalidation.",
+            confidence: "high",
+          },
+        }),
+      ),
+    ],
+    [
+      "evidence",
+      `${base}\n## Evidence\n\n- **stale entry:** Reproduced stale verdict carry.\n  - file: [src/cache.ts]\n`,
+    ],
+    [
+      "likely owner",
+      `${base}\n## Likely Related People\n\n- **@cache-team:** owns cache invalidation\n  - reason: Maintains the review cache.\n  - confidence: high\n`,
+    ],
+    [
+      "label rationale",
+      withFrontMatter(
+        "triage_priority",
+        `P1\nlabel_justifications: ${JSON.stringify([
+          { label: "P1", reason: "Stale verdicts can suppress merge blockers." },
+        ])}`,
+      ),
+    ],
+  ];
+  const baseDigest = previousClawSweeperReviewDigestFromReportForTest(base, 101);
+
+  assert.ok(baseDigest);
+  for (const [name, variant] of variants) {
+    assert.notEqual(
+      previousClawSweeperReviewDigestFromReportForTest(variant, 101),
+      baseDigest,
+      name,
+    );
+  }
 });
 
 test("rendered close text cannot create a review history ledger", () => {

--- a/test/review-history.test.ts
+++ b/test/review-history.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 
@@ -20,6 +21,7 @@ import {
 import { reviewSemanticPriorReviewDigest } from "../dist/review-semantic-cache.js";
 import {
   changelogReviewDecision,
+  markedReviewCommentForTest,
   realBehaviorProofReportSection,
   reportFrontMatter,
   reviewFinding,
@@ -255,8 +257,13 @@ test("rendered review text cannot create ClawSweeper control markers", () => {
 });
 
 test("state report prior-review identity matches the marked durable comment", () => {
-  const report = keepOpenPullReport();
-  const body = `${renderReviewCommentFromReport(report, "none")}\n\n<!-- clawsweeper-review item=101 -->`;
+  const unsyncedReport = keepOpenPullReport();
+  const body = markedReviewCommentForTest(
+    101,
+    renderReviewCommentFromReport(unsyncedReport, "none"),
+  );
+  const digest = createHash("sha256").update(body).digest("hex");
+  const report = unsyncedReport.replace(/^---\n/, `---\nreview_comment_sha256: ${digest}\n`);
   const liveReview = extractLatestClawSweeperReviewForTest(
     [
       {
@@ -273,6 +280,34 @@ test("state report prior-review identity matches the marked durable comment", ()
   assert.equal(
     previousClawSweeperReviewDigestFromReportForTest(report, 101),
     reviewSemanticPriorReviewDigest(liveReview),
+  );
+});
+
+test("state report prior-review identity preserves the original render context", () => {
+  const unsyncedReport = keepOpenPullReport({ labels: JSON.stringify(["P2"]) });
+  const body = markedReviewCommentForTest(
+    101,
+    renderReviewCommentFromReport(unsyncedReport, "none", {
+      previousLabels: [],
+      prStatusKind: "ready_for_maintainer_look",
+    }),
+  );
+  const digest = createHash("sha256").update(body).digest("hex");
+  const report = unsyncedReport.replace(/^---\n/, `---\nreview_comment_sha256: ${digest}\n`);
+  const reconstructed = markedReviewCommentForTest(
+    101,
+    renderReviewCommentFromReport(unsyncedReport, "none"),
+  );
+
+  assert.notEqual(createHash("sha256").update(reconstructed).digest("hex"), digest);
+  assert.equal(previousClawSweeperReviewDigestFromReportForTest(report, 101), digest);
+  assert.equal(previousClawSweeperReviewDigestFromReportForTest(unsyncedReport, 101), null);
+  assert.equal(
+    previousClawSweeperReviewDigestFromReportForTest(
+      unsyncedReport.replace(/^---\n/, "---\nreview_comment_sha256: stale\n"),
+      101,
+    ),
+    null,
   );
 });
 
@@ -346,15 +381,19 @@ test("durable review identity changes with every verdict-bearing section", () =>
       ),
     ],
   ];
-  const baseDigest = previousClawSweeperReviewDigestFromReportForTest(base, 101);
+  const syncedDigest = (report: string): string | null => {
+    const body = markedReviewCommentForTest(101, renderReviewCommentFromReport(report, "none"));
+    const digest = createHash("sha256").update(body).digest("hex");
+    return previousClawSweeperReviewDigestFromReportForTest(
+      report.replace(/^---\n/, `---\nreview_comment_sha256: ${digest}\n`),
+      101,
+    );
+  };
+  const baseDigest = syncedDigest(base);
 
   assert.ok(baseDigest);
   for (const [name, variant] of variants) {
-    assert.notEqual(
-      previousClawSweeperReviewDigestFromReportForTest(variant, 101),
-      baseDigest,
-      name,
-    );
+    assert.notEqual(syncedDigest(variant), baseDigest, name);
   }
 });
 

--- a/test/review-history.test.ts
+++ b/test/review-history.test.ts
@@ -262,13 +262,14 @@ test("state report prior-review identity matches the marked durable comment", ()
     101,
     renderReviewCommentFromReport(unsyncedReport, "none"),
   );
-  const digest = createHash("sha256").update(body).digest("hex");
+  const persistedBody = `\n${body}\n\n`;
+  const digest = createHash("sha256").update(body.trim()).digest("hex");
   const report = unsyncedReport.replace(/^---\n/, `---\nreview_comment_sha256: ${digest}\n`);
   const liveReview = extractLatestClawSweeperReviewForTest(
     [
       {
         id: 101,
-        body,
+        body: persistedBody,
         updated_at: "2026-06-24T12:00:00.000Z",
         user: { login: "clawsweeper[bot]" },
       },

--- a/test/review-semantic-cache.test.ts
+++ b/test/review-semantic-cache.test.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import test from "node:test";
 
 import {
+  REVIEW_SEMANTIC_CACHE_VERSION,
   createReviewSemanticRecord,
   reviewSemanticCacheDecision,
   reviewSemanticPriorReviewDigest,
@@ -1183,6 +1184,11 @@ test("semantic records require a boolean eligibility value", () => {
 
   assert.equal(validReviewSemanticRecord(valid), true);
   assert.equal(validReviewSemanticRecord(malformed as never), false);
+});
+
+test("semantic record version changes invalidate legacy directive digests", () => {
+  assert.equal(REVIEW_SEMANTIC_CACHE_VERSION, 9);
+  assert.equal(validReviewSemanticRecord({ ...record(), version: 8 } as never), false);
 });
 
 test("stale, failed, and future-dated reviews never reuse", () => {

--- a/test/review-semantic-cache.test.ts
+++ b/test/review-semantic-cache.test.ts
@@ -1,15 +1,37 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import test from "node:test";
 
 import {
   createReviewSemanticRecord,
   reviewSemanticCacheDecision,
+  reviewSemanticPriorReviewDigest,
   reviewSemanticRevalidationDecision,
+  validReviewSemanticRecord,
 } from "../dist/review-semantic-cache.js";
+import { stableJson } from "../dist/stable-json.js";
 
 const NOW = Date.parse("2026-07-12T12:00:00Z");
 const DAY_MS = 24 * 60 * 60 * 1000;
 const STRUCTURAL_CONTEXT = "a".repeat(64);
+const PREVIOUS_REVIEW = {
+  status: "needs changes before merge.",
+  reviewedAt: "2026-07-11T12:00:00Z",
+  reviewedSha: "b".repeat(40),
+  verdictMarker: `<!-- clawsweeper-verdict:keep-open item=123 sha=${"b".repeat(40)} -->`,
+  actionMarker: null,
+  summary: "The prior review found one cache identity issue.",
+  proofStatus: "Status: not_applicable",
+  rating: "Overall: needs changes",
+  nextStep: "Repair the cache identity.",
+  findings: [{ priority: "P1", title: "Bind review identity" }],
+  earlierReviewCycles: [],
+  completedReviewCycles: 1,
+  commentId: 10,
+  commentUrl: "https://example.invalid/review",
+  commentUpdatedAt: "2026-07-11T12:00:00Z",
+};
+const PREVIOUS_REVIEW_DIGEST = reviewSemanticPriorReviewDigest(PREVIOUS_REVIEW);
 
 function input(overrides: Record<string, unknown> = {}) {
   const context = {
@@ -139,6 +161,8 @@ function decision(overrides: Record<string, unknown> = {}) {
     review: review(),
     priorRecord,
     currentRecord: priorRecord,
+    expectedPreviousReviewDigest: PREVIOUS_REVIEW_DIGEST,
+    currentPreviousReviewDigest: PREVIOUS_REVIEW_DIGEST,
     reviewPolicy: "policy-1",
     reviewModel: "gpt-5.6",
     explicitDispatch: false,
@@ -364,11 +388,40 @@ test("TypeScript directives and shebangs remain semantic", () => {
       ],
     },
   });
+  const nosemgrep = record({
+    context: {
+      pullFiles: [
+        {
+          filename: "src/cache.ts",
+          status: "modified",
+          additions: 2,
+          deletions: 1,
+          patch:
+            "@@ -1 +1,2 @@\n-const answer = 41;\n+// nosemgrep: dangerous-eval\n+const answer = 42;",
+        },
+      ],
+    },
+  });
+  const gitleaks = record({
+    context: {
+      pullFiles: [
+        {
+          filename: "src/cache.ts",
+          status: "modified",
+          additions: 2,
+          deletions: 1,
+          patch: "@@ -1 +1,2 @@\n-const answer = 41;\n+// gitleaks:allow\n+const answer = 42;",
+        },
+      ],
+    },
+  });
 
   assert.notEqual(ordinary.codeDigest, directive.codeDigest);
   assert.notEqual(ordinary.codeDigest, shebang.codeDigest);
   assert.notEqual(ordinary.codeDigest, sourceMapDirective.codeDigest);
   assert.notEqual(ordinary.codeDigest, referenceDirective.codeDigest);
+  assert.notEqual(ordinary.codeDigest, nosemgrep.codeDigest);
+  assert.notEqual(ordinary.codeDigest, gitleaks.codeDigest);
 });
 
 test("Flow comment annotations remain semantic", () => {
@@ -1091,6 +1144,47 @@ test("explicit reruns, maintainer prompts, policy changes, and close reports nev
   assert.equal(decision({ review: review({ decision: "close" }) }).reason, "non_keep_open_verdict");
 });
 
+test("prior review identity binds visible verdict content but ignores comment metadata", () => {
+  const sameReview = {
+    ...PREVIOUS_REVIEW,
+    reviewedAt: "2026-07-12T01:00:00Z",
+    commentId: 11,
+    commentUrl: "https://example.invalid/review-updated",
+    commentUpdatedAt: "2026-07-12T01:00:00Z",
+    earlierReviewCycles: [{ sha: "older" }],
+    completedReviewCycles: 2,
+  };
+  const changedReview = {
+    ...sameReview,
+    summary: "A newer completed review found a different blocker.",
+  };
+
+  assert.equal(reviewSemanticPriorReviewDigest(sameReview), PREVIOUS_REVIEW_DIGEST);
+  assert.notEqual(reviewSemanticPriorReviewDigest(changedReview), PREVIOUS_REVIEW_DIGEST);
+  assert.equal(
+    decision({
+      currentPreviousReviewDigest: reviewSemanticPriorReviewDigest(changedReview),
+    }).reason,
+    "previous_review_changed",
+  );
+});
+
+test("semantic records require a boolean eligibility value", () => {
+  const valid = record();
+  const { fingerprint: _, ...withoutFingerprint } = valid;
+  const malformedWithoutFingerprint = {
+    ...withoutFingerprint,
+    eligible: "true",
+  };
+  const malformed = {
+    ...malformedWithoutFingerprint,
+    fingerprint: createHash("sha256").update(stableJson(malformedWithoutFingerprint)).digest("hex"),
+  };
+
+  assert.equal(validReviewSemanticRecord(valid), true);
+  assert.equal(validReviewSemanticRecord(malformed as never), false);
+});
+
 test("stale, failed, and future-dated reviews never reuse", () => {
   assert.equal(
     decision({ review: review({ reviewStatus: "failed" }) }).reason,
@@ -1128,9 +1222,29 @@ test("post-lease revalidation catches mutable context drift", () => {
     reviewSemanticRevalidationDecision({
       initialRecord,
       currentRecord,
+      initialPreviousReviewDigest: PREVIOUS_REVIEW_DIGEST,
+      currentPreviousReviewDigest: PREVIOUS_REVIEW_DIGEST,
       reviewPolicy: "policy-1",
       reviewModel: "gpt-5.6",
     }),
     { hit: false, reason: "context_changed" },
+  );
+});
+
+test("post-lease revalidation catches prior review drift", () => {
+  const semanticRecord = record();
+  assert.deepEqual(
+    reviewSemanticRevalidationDecision({
+      initialRecord: semanticRecord,
+      currentRecord: semanticRecord,
+      initialPreviousReviewDigest: PREVIOUS_REVIEW_DIGEST,
+      currentPreviousReviewDigest: reviewSemanticPriorReviewDigest({
+        ...PREVIOUS_REVIEW,
+        findings: [{ priority: "P1", title: "A newer review finding" }],
+      }),
+      reviewPolicy: "policy-1",
+      reviewModel: "gpt-5.6",
+    }),
+    { hit: false, reason: "previous_review_changed" },
   );
 });

--- a/test/review-semantic-cache.test.ts
+++ b/test/review-semantic-cache.test.ts
@@ -1170,6 +1170,63 @@ test("prior review identity binds visible verdict content but ignores comment me
   );
 });
 
+test("prior review identity prefers the complete durable verdict digest", () => {
+  const verdictDigest = "f".repeat(64);
+  const review = {
+    ...PREVIOUS_REVIEW,
+    verdictDigest,
+  };
+
+  assert.equal(reviewSemanticPriorReviewDigest(review), verdictDigest);
+  assert.equal(
+    reviewSemanticPriorReviewDigest({
+      ...review,
+      summary: "A stale compact projection cannot override the durable verdict.",
+    }),
+    verdictDigest,
+  );
+});
+
+test("prior review identity fallback includes detailed verdict fields", () => {
+  const base = {
+    ...PREVIOUS_REVIEW,
+    findings: [
+      {
+        priority: "P1",
+        title: "Bind review identity",
+        body: "The stale report can replace a newer finding.",
+        location: { path: "src/cache.ts", line: 10 },
+      },
+    ],
+    securityReview: { status: "cleared", summary: "No concerns." },
+    maintainerDecision: { required: false },
+  };
+  const baseDigest = reviewSemanticPriorReviewDigest(base);
+
+  assert.ok(baseDigest);
+  assert.notEqual(
+    reviewSemanticPriorReviewDigest({
+      ...base,
+      findings: [{ ...base.findings[0], body: "A different detailed finding." }],
+    }),
+    baseDigest,
+  );
+  assert.notEqual(
+    reviewSemanticPriorReviewDigest({
+      ...base,
+      securityReview: { status: "needs_attention", summary: "Review token handling." },
+    }),
+    baseDigest,
+  );
+  assert.notEqual(
+    reviewSemanticPriorReviewDigest({
+      ...base,
+      maintainerDecision: { required: true, question: "Accept the remaining risk?" },
+    }),
+    baseDigest,
+  );
+});
+
 test("semantic records require a boolean eligibility value", () => {
   const valid = record();
   const { fingerprint: _, ...withoutFingerprint } = valid;


### PR DESCRIPTION
## Summary

- bind structural, semantic, and content-cache reuse to the live durable review verdict
- revalidate issue verdict identity after lease acquisition and fail closed on refresh errors
- invalidate legacy semantic records after expanding security-directive hashing

## Validation

- `./node_modules/.bin/tsc -p tsconfig.json`
- `node --test test/review-semantic-cache.test.ts test/review-comment-rendering.test.ts test/context.test.ts test/review-history.test.ts test/local-range-review.test.ts` (112 passed)
- `./node_modules/.bin/oxfmt --check ...`
- `./node_modules/.bin/oxlint ... --type-aware --deny-warnings`
- `codex review --commit HEAD` (no actionable regressions)
- local ClawSweeper committed-range review (no findings; patch correct, confidence 0.94)