### PR TITLE
fix(ci): separate sweep publish and apply queues

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2036,7 +2036,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     concurrency:
-      group: clawsweeper-target-publish-${{ needs.plan.outputs.target_repo }}
+      group: clawsweeper-target-review-publish-${{ needs.plan.outputs.target_repo }}
       cancel-in-progress: false
       queue: max
     steps:
@@ -2911,7 +2911,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 360
     concurrency:
-      group: clawsweeper-target-publish-${{ needs.apply-proof.outputs.target_repo }}
+      group: clawsweeper-target-apply-${{ needs.apply-proof.outputs.target_repo }}
       cancel-in-progress: false
       queue: max
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Separated review publication from apply/comment-sync concurrency so long
+  mutation runs no longer block completed reviews from publishing, and retried
+  GitHub CLI commands whose jq process reports truncated JSON.
 - Bound structural, semantic, and content review reuse to the canonical
   persisted durable-comment body hash under the acquired lease, normalizing
   surrounding whitespace while preserving label

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -64,6 +64,10 @@ Manual exact-item `workflow_dispatch` reviews use an exact-item concurrency
 group with the same single-pending policy, so newer revisions replace stale
 pending work instead of building a duplicate queue. Durable exact-review leases
 use lease-scoped workflow groups and remain owned by the Worker admission lane.
+Review publication and apply/comment sync use separate non-dropping per-target
+job queues. Each lane stays serialized, while tuple-aware state reconciliation
+allows one review publisher and one apply runner to make progress concurrently
+without stale review snapshots reviving closed records.
 
 ## Schedules
 

--- a/src/github-retry.ts
+++ b/src/github-retry.ts
@@ -9,6 +9,7 @@ const GH_THROTTLE_PATTERNS = [
 
 const GH_TRANSIENT_PATTERNS = [
   /unexpected EOF/i,
+  /unexpected end of JSON input/i,
   /connection reset/i,
   /connection reset by peer/i,
   /error connecting to api\.github\.com/i,

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -3026,6 +3026,13 @@ test("GitHub retry classifier distinguishes throttle and transient failures", ()
   assert.equal(ghRetryKind(eof), "transient");
   assert.equal(shouldRetryGh(eof), true);
 
+  const truncatedJq = Object.assign(
+    new Error("Command failed: gh api repos/openclaw/openclaw/issues --jq .[]"),
+    { stderr: "unexpected end of JSON input\n" },
+  );
+  assert.equal(ghRetryKind(truncatedJq), "transient");
+  assert.equal(shouldRetryGh(truncatedJq), true);
+
   const connectionReset = new Error(
     "Post https://api.github.com/graphql: read: connection reset by peer",
   );

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -551,7 +551,7 @@ test("publish workflow dispatches immediate apply through the isolated lane", ()
   assert.match(dispatchStep, /-f apply_item_numbers="\$item_numbers"/);
   assert.match(
     publishJob,
-    /group: clawsweeper-target-publish-\$\{\{ needs\.plan\.outputs\.target_repo \}\}/,
+    /group: clawsweeper-target-review-publish-\$\{\{ needs\.plan\.outputs\.target_repo \}\}/,
   );
   assert.match(publishJob, /cancel-in-progress: false/);
   assert.match(publishJob, /queue: max/);
@@ -639,7 +639,7 @@ test("apply workflow isolates Codex proof from the credentialed mutation runner"
   assert.match(applyJob, /--artifact-dir \.artifacts\/apply-proof/);
   assert.match(
     applyJob,
-    /group: clawsweeper-target-publish-\$\{\{ needs\.apply-proof\.outputs\.target_repo \}\}/,
+    /group: clawsweeper-target-apply-\$\{\{ needs\.apply-proof\.outputs\.target_repo \}\}/,
   );
   assert.match(applyJob, /cancel-in-progress: false/);
   assert.match(applyJob, /queue: max/);


### PR DESCRIPTION
## What Problem This Solves

OpenClaw sweep publishes and applies currently share one per-target concurrency group. Since that mutex landed on July 10, review publish admission after dependencies increased from a 2-second median to 2 hours 17 minutes, with a 2 hour 50 minute p95 and 3 hour 4 minute maximum. Long apply jobs consume the same serial lane and remove the burst headroom needed for incoming reviews.

One delayed apply also failed after roughly three hours because `gh api --jq` exited with `unexpected end of JSON input`. The existing malformed-JSON retry only handled parsing after a successful command, so this command-level transient escaped retry.

Fixes #505

## Why This Change Was Made

- Give review publishing and mutation applies distinct non-dropping per-target concurrency groups.
- Preserve serialization within each lane and rely on the existing tuple-aware state reconciliation for cross-lane writes.
- Treat truncated JSON emitted by `gh --jq` as a transient GitHub CLI failure.

This restores review throughput without increasing the ClawSweeper worker or Blacksmith runner limits. Capacity was available; the shared workflow mutex was the bottleneck.

## User Impact

New review publishes no longer wait behind unrelated multi-minute apply jobs for the same target repository. Apply mutations remain serialized, and transient truncated GitHub responses are retried instead of wasting a multi-hour queue wait.

## Evidence

- Before shared mutex, July 9 publish admission: p50 2s, p95 7s.
- Current shared mutex: p50 2h17m, p95 2h50m, max 3h04m.
- 304 OpenClaw arrivals in approximately 15.9 hours, with about 85% demand on one serial lane.
- Failing delayed run: https://github.com/openclaw/clawsweeper/actions/runs/29175446812
- `pnpm run check`
- `node --test --test-name-pattern='GitHub retry classifier distinguishes throttle and transient failures' test/clawsweeper.test.ts`
- `PATH="/tmp/clawsweeper-test-bin:$PATH" node --test test/sweep-workflow.test.ts` (55/55)
- Autoreview: clean, no accepted/actionable findings.
