### PR TITLE
Bound git helper subprocess runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Bounded every repair git helper subprocess while retaining the shorter configurable network timeout, ordinary nonzero and signal status semantics, platform-aware command launching, and explicit spawn-error reporting. Thanks @hex-AI12.
 - Waited for the exact dashboard Worker commit to reach the live health endpoint before running post-deploy smoke checks, preventing Cloudflare rollout propagation from producing false CI failures.
 - Separated review publication from apply/comment-sync concurrency so long
   mutation runs no longer block completed reviews from publishing, and retried

--- a/src/repair/command-runner.ts
+++ b/src/repair/command-runner.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from "node:child_process";
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
 import { resolveSpawnCommand } from "../command.js";
 
 const DEFAULT_COMMAND_MAX_BUFFER = 64 * 1024 * 1024;
@@ -16,6 +16,19 @@ export function runCommand(
   commandArgs: string[],
   options: CommandRunOptions = {},
 ): string {
+  const child = runCommandResult(command, commandArgs, options);
+  const detail = commandResultDetail(child);
+  if (child.status !== 0) {
+    throw new Error(detail || `${command} exited ${child.status ?? `with signal ${child.signal}`}`);
+  }
+  return child.stdout ?? "";
+}
+
+export function runCommandResult(
+  command: string,
+  commandArgs: string[],
+  options: CommandRunOptions = {},
+): SpawnSyncReturns<string> {
   const env = options.env ?? process.env;
   const invocation = resolveSpawnCommand(command, commandArgs, {
     ...(options.cwd ? { cwd: options.cwd } : {}),
@@ -31,7 +44,7 @@ export function runCommand(
     windowsHide: true,
     ...(invocation.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
   });
-  const detail = [child.stderr, child.stdout].filter(Boolean).join("\n").trim();
+  const detail = commandResultDetail(child);
   if (child.error) {
     if ((child.error as NodeJS.ErrnoException).code === "ETIMEDOUT") {
       const rendered = [command, ...commandArgs].join(" ");
@@ -40,8 +53,9 @@ export function runCommand(
     }
     throw new Error(detail ? `${child.error.message}\n${detail}` : child.error.message);
   }
-  if (child.status !== 0) {
-    throw new Error(detail || `${command} exited ${child.status ?? `with signal ${child.signal}`}`);
-  }
-  return child.stdout ?? "";
+  return child;
+}
+
+function commandResultDetail(child: SpawnSyncReturns<string>): string {
+  return [child.stderr, child.stdout].filter(Boolean).join("\n").trim();
 }

--- a/src/repair/git-repo-utils.ts
+++ b/src/repair/git-repo-utils.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
 import { runCommand as run } from "./command-runner.js";
 import { uniqueStrings } from "./validation-command-utils.js";
 
@@ -12,6 +12,7 @@ const gitNetworkTimeoutMs = Math.max(
       5 * 60 * 1000,
   ),
 );
+const DEFAULT_GIT_TIMEOUT_MS = 10 * 60 * 1000;
 
 type TargetDir = {
   targetDir: string;
@@ -45,16 +46,35 @@ export function currentHead(targetDir: string): string {
   return run("git", ["rev-parse", "HEAD"], { cwd: targetDir }).trim();
 }
 
+function runGit(
+  args: string[],
+  { targetDir, timeoutMs = DEFAULT_GIT_TIMEOUT_MS }: TargetDir & { timeoutMs?: number },
+): SpawnSyncReturns<string> {
+  const child = spawnSync("git", args, {
+    cwd: targetDir,
+    env: process.env,
+    encoding: "utf8",
+    timeout: timeoutMs,
+  });
+  if ((child.error as NodeJS.ErrnoException | undefined)?.code === "ETIMEDOUT") {
+    const rendered = ["git", ...args].join(" ");
+    const detail = [child.stderr, child.stdout].filter(Boolean).join("\n").trim();
+    const message = `git command timed out after ${timeoutMs}ms: ${rendered}`;
+    throw new Error(detail ? `${message}\n${detail}` : message);
+  }
+  if (child.error) {
+    const detail = [child.stderr, child.stdout].filter(Boolean).join("\n").trim();
+    throw new Error(detail ? `${child.error.message}\n${detail}` : child.error.message);
+  }
+  return child;
+}
+
 export function isAncestor({
   targetDir,
   ancestor,
   descendant,
 }: TargetDir & { ancestor: string; descendant: string }): boolean {
-  const child = spawnSync("git", ["merge-base", "--is-ancestor", ancestor, descendant], {
-    cwd: targetDir,
-    env: process.env,
-    encoding: "utf8",
-  });
+  const child = runGit(["merge-base", "--is-ancestor", ancestor, descendant], { targetDir });
   return child.status === 0;
 }
 
@@ -63,11 +83,9 @@ export function remoteBranchExists(options: TargetBranch): boolean {
 }
 
 export function remoteBranchSha({ targetDir, branch }: TargetBranch): string {
-  const child = spawnSync("git", ["ls-remote", "--heads", "origin", branch], {
-    cwd: targetDir,
-    env: process.env,
-    encoding: "utf8",
-    timeout: gitNetworkTimeoutMs,
+  const child = runGit(["ls-remote", "--heads", "origin", branch], {
+    targetDir,
+    timeoutMs: gitNetworkTimeoutMs,
   });
   if (child.status !== 0) return "";
   const sha = child.stdout.trim().split(/\s+/)[0] ?? "";
@@ -76,21 +94,13 @@ export function remoteBranchSha({ targetDir, branch }: TargetBranch): string {
 
 export function branchHasBaseDiff({ targetDir, baseBranch }: TargetBaseBranch): boolean {
   const range = `origin/${baseBranch}...HEAD`;
-  const first = spawnSync("git", ["diff", "--name-only", range], {
-    cwd: targetDir,
-    env: process.env,
-    encoding: "utf8",
-  });
+  const first = runGit(["diff", "--name-only", range], { targetDir });
   if (first.status === 0) return Boolean(first.stdout.trim());
   const detail = `${first.stderr ?? ""}\n${first.stdout ?? ""}`;
   if (!/no merge base/i.test(detail)) throw new Error(detail.trim());
 
   fetchDeeperHistory({ targetDir, baseBranch });
-  const retry = spawnSync("git", ["diff", "--name-only", range], {
-    cwd: targetDir,
-    env: process.env,
-    encoding: "utf8",
-  });
+  const retry = runGit(["diff", "--name-only", range], { targetDir });
   if (retry.status === 0) return Boolean(retry.stdout.trim());
   const retryDetail = `${retry.stderr ?? ""}\n${retry.stdout ?? ""}`;
   if (/no merge base/i.test(retryDetail)) return true;
@@ -100,19 +110,11 @@ export function branchHasBaseDiff({ targetDir, baseBranch }: TargetBaseBranch): 
 export function ensureMergeBaseAvailable({ targetDir, baseBranch }: TargetBaseBranch): string {
   gitFetch(targetDir, ["origin", `${baseBranch}:refs/remotes/origin/${baseBranch}`]);
   const baseRef = `origin/${baseBranch}`;
-  const first = spawnSync("git", ["merge-base", baseRef, "HEAD"], {
-    cwd: targetDir,
-    env: process.env,
-    encoding: "utf8",
-  });
+  const first = runGit(["merge-base", baseRef, "HEAD"], { targetDir });
   if (first.status === 0 && first.stdout.trim()) return first.stdout.trim();
 
   fetchDeeperHistory({ targetDir, baseBranch });
-  const retry = spawnSync("git", ["merge-base", baseRef, "HEAD"], {
-    cwd: targetDir,
-    env: process.env,
-    encoding: "utf8",
-  });
+  const retry = runGit(["merge-base", baseRef, "HEAD"], { targetDir });
   if (retry.status === 0 && retry.stdout.trim()) return retry.stdout.trim();
 
   const detail = `${retry.stderr ?? ""}\n${retry.stdout ?? ""}`.trim();
@@ -134,11 +136,7 @@ export function rebaseOntoBase({ targetDir, baseBranch }: TargetBaseBranch): Reb
     };
   }
 
-  const child = spawnSync("git", ["rebase", baseRef], {
-    cwd: targetDir,
-    env: process.env,
-    encoding: "utf8",
-  });
+  const child = runGit(["rebase", baseRef], { targetDir });
   const detail = `${child.stderr ?? ""}\n${child.stdout ?? ""}`.trim();
   if (child.status === 0) {
     return {
@@ -181,11 +179,7 @@ export function completeRebaseIfResolved({ targetDir }: TargetDir): CompleteReba
   }
   let detail = "";
   while (hasRebaseInProgress(targetDir)) {
-    const child = spawnSync("git", ["-c", "core.editor=true", "rebase", "--continue"], {
-      cwd: targetDir,
-      env: process.env,
-      encoding: "utf8",
-    });
+    const child = runGit(["-c", "core.editor=true", "rebase", "--continue"], { targetDir });
     detail = `${detail}\n${child.stderr ?? ""}\n${child.stdout ?? ""}`.trim();
     if (child.status !== 0) {
       const remaining = unmergedPaths(targetDir);
@@ -226,11 +220,7 @@ export function hasRebaseInProgress(targetDir: string): boolean {
 }
 
 export function unmergedPaths(targetDir: string): string[] {
-  const child = spawnSync("git", ["diff", "--name-only", "--diff-filter=U"], {
-    cwd: targetDir,
-    env: process.env,
-    encoding: "utf8",
-  });
+  const child = runGit(["diff", "--name-only", "--diff-filter=U"], { targetDir });
   if (child.status !== 0) return [];
   return child.stdout
     .split("\n")
@@ -239,11 +229,7 @@ export function unmergedPaths(targetDir: string): string[] {
 }
 
 function fetchDeeperHistory({ targetDir, baseBranch }: TargetBaseBranch): void {
-  const shallow = spawnSync("git", ["rev-parse", "--is-shallow-repository"], {
-    cwd: targetDir,
-    env: process.env,
-    encoding: "utf8",
-  }).stdout.trim();
+  const shallow = runGit(["rev-parse", "--is-shallow-repository"], { targetDir }).stdout.trim();
   if (shallow === "true" || fs.existsSync(path.join(targetDir, ".git", "shallow"))) {
     gitFetch(targetDir, ["--unshallow", "origin"]);
   } else {

--- a/src/repair/git-repo-utils.ts
+++ b/src/repair/git-repo-utils.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
-import { spawnSync, type SpawnSyncReturns } from "node:child_process";
-import { runCommand as run } from "./command-runner.js";
+import type { SpawnSyncReturns } from "node:child_process";
+import { runCommandResult } from "./command-runner.js";
 import { uniqueStrings } from "./validation-command-utils.js";
 
 const gitNetworkTimeoutMs = Math.max(
@@ -43,30 +43,22 @@ export type CompleteRebaseResult = {
 };
 
 export function currentHead(targetDir: string): string {
-  return run("git", ["rev-parse", "HEAD"], { cwd: targetDir }).trim();
+  return gitOutput(["rev-parse", "HEAD"], { targetDir }).trim();
 }
 
-function runGit(
+export function runGitCommand(
   args: string[],
-  { targetDir, timeoutMs = DEFAULT_GIT_TIMEOUT_MS }: TargetDir & { timeoutMs?: number },
+  {
+    targetDir,
+    timeoutMs = DEFAULT_GIT_TIMEOUT_MS,
+    env = process.env,
+  }: TargetDir & { timeoutMs?: number; env?: NodeJS.ProcessEnv },
 ): SpawnSyncReturns<string> {
-  const child = spawnSync("git", args, {
+  return runCommandResult("git", args, {
     cwd: targetDir,
-    env: process.env,
-    encoding: "utf8",
-    timeout: timeoutMs,
+    env,
+    timeoutMs,
   });
-  if ((child.error as NodeJS.ErrnoException | undefined)?.code === "ETIMEDOUT") {
-    const rendered = ["git", ...args].join(" ");
-    const detail = [child.stderr, child.stdout].filter(Boolean).join("\n").trim();
-    const message = `git command timed out after ${timeoutMs}ms: ${rendered}`;
-    throw new Error(detail ? `${message}\n${detail}` : message);
-  }
-  if (child.error) {
-    const detail = [child.stderr, child.stdout].filter(Boolean).join("\n").trim();
-    throw new Error(detail ? `${child.error.message}\n${detail}` : child.error.message);
-  }
-  return child;
 }
 
 export function isAncestor({
@@ -74,7 +66,9 @@ export function isAncestor({
   ancestor,
   descendant,
 }: TargetDir & { ancestor: string; descendant: string }): boolean {
-  const child = runGit(["merge-base", "--is-ancestor", ancestor, descendant], { targetDir });
+  const child = runGitCommand(["merge-base", "--is-ancestor", ancestor, descendant], {
+    targetDir,
+  });
   return child.status === 0;
 }
 
@@ -83,7 +77,7 @@ export function remoteBranchExists(options: TargetBranch): boolean {
 }
 
 export function remoteBranchSha({ targetDir, branch }: TargetBranch): string {
-  const child = runGit(["ls-remote", "--heads", "origin", branch], {
+  const child = runGitCommand(["ls-remote", "--heads", "origin", branch], {
     targetDir,
     timeoutMs: gitNetworkTimeoutMs,
   });
@@ -94,13 +88,13 @@ export function remoteBranchSha({ targetDir, branch }: TargetBranch): string {
 
 export function branchHasBaseDiff({ targetDir, baseBranch }: TargetBaseBranch): boolean {
   const range = `origin/${baseBranch}...HEAD`;
-  const first = runGit(["diff", "--name-only", range], { targetDir });
+  const first = runGitCommand(["diff", "--name-only", range], { targetDir });
   if (first.status === 0) return Boolean(first.stdout.trim());
   const detail = `${first.stderr ?? ""}\n${first.stdout ?? ""}`;
   if (!/no merge base/i.test(detail)) throw new Error(detail.trim());
 
   fetchDeeperHistory({ targetDir, baseBranch });
-  const retry = runGit(["diff", "--name-only", range], { targetDir });
+  const retry = runGitCommand(["diff", "--name-only", range], { targetDir });
   if (retry.status === 0) return Boolean(retry.stdout.trim());
   const retryDetail = `${retry.stderr ?? ""}\n${retry.stdout ?? ""}`;
   if (/no merge base/i.test(retryDetail)) return true;
@@ -110,11 +104,11 @@ export function branchHasBaseDiff({ targetDir, baseBranch }: TargetBaseBranch): 
 export function ensureMergeBaseAvailable({ targetDir, baseBranch }: TargetBaseBranch): string {
   gitFetch(targetDir, ["origin", `${baseBranch}:refs/remotes/origin/${baseBranch}`]);
   const baseRef = `origin/${baseBranch}`;
-  const first = runGit(["merge-base", baseRef, "HEAD"], { targetDir });
+  const first = runGitCommand(["merge-base", baseRef, "HEAD"], { targetDir });
   if (first.status === 0 && first.stdout.trim()) return first.stdout.trim();
 
   fetchDeeperHistory({ targetDir, baseBranch });
-  const retry = runGit(["merge-base", baseRef, "HEAD"], { targetDir });
+  const retry = runGitCommand(["merge-base", baseRef, "HEAD"], { targetDir });
   if (retry.status === 0 && retry.stdout.trim()) return retry.stdout.trim();
 
   const detail = `${retry.stderr ?? ""}\n${retry.stdout ?? ""}`.trim();
@@ -124,7 +118,7 @@ export function ensureMergeBaseAvailable({ targetDir, baseBranch }: TargetBaseBr
 export function rebaseOntoBase({ targetDir, baseBranch }: TargetBaseBranch): RebaseOntoBaseResult {
   ensureMergeBaseAvailable({ targetDir, baseBranch });
   const baseRef = `origin/${baseBranch}`;
-  const baseSha = run("git", ["rev-parse", baseRef], { cwd: targetDir }).trim();
+  const baseSha = gitOutput(["rev-parse", baseRef], { targetDir }).trim();
   const previousHead = currentHead(targetDir);
   if (isAncestor({ targetDir, ancestor: baseRef, descendant: "HEAD" })) {
     return {
@@ -136,7 +130,7 @@ export function rebaseOntoBase({ targetDir, baseBranch }: TargetBaseBranch): Reb
     };
   }
 
-  const child = runGit(["rebase", baseRef], { targetDir });
+  const child = runGitCommand(["rebase", baseRef], { targetDir });
   const detail = `${child.stderr ?? ""}\n${child.stdout ?? ""}`.trim();
   if (child.status === 0) {
     return {
@@ -172,14 +166,16 @@ export function completeRebaseIfResolved({ targetDir }: TargetDir): CompleteReba
   }
 
   assertNoConflictMarkers({ targetDir, paths: unmergedPaths(targetDir) });
-  run("git", ["add", "--all"], { cwd: targetDir });
+  gitOutput(["add", "--all"], { targetDir });
   const unresolved = unmergedPaths(targetDir);
   if (unresolved.length > 0) {
     throw new Error(`rebase conflicts remain unresolved: ${unresolved.join(", ")}`);
   }
   let detail = "";
   while (hasRebaseInProgress(targetDir)) {
-    const child = runGit(["-c", "core.editor=true", "rebase", "--continue"], { targetDir });
+    const child = runGitCommand(["-c", "core.editor=true", "rebase", "--continue"], {
+      targetDir,
+    });
     detail = `${detail}\n${child.stderr ?? ""}\n${child.stdout ?? ""}`.trim();
     if (child.status !== 0) {
       const remaining = unmergedPaths(targetDir);
@@ -211,7 +207,7 @@ function assertNoConflictMarkers({ targetDir, paths }: TargetDir & { paths: stri
 }
 
 export function hasRebaseInProgress(targetDir: string): boolean {
-  const gitDir = run("git", ["rev-parse", "--git-dir"], { cwd: targetDir }).trim();
+  const gitDir = gitOutput(["rev-parse", "--git-dir"], { targetDir }).trim();
   const absoluteGitDir = path.isAbsolute(gitDir) ? gitDir : path.join(targetDir, gitDir);
   return (
     fs.existsSync(path.join(absoluteGitDir, "rebase-merge")) ||
@@ -220,7 +216,7 @@ export function hasRebaseInProgress(targetDir: string): boolean {
 }
 
 export function unmergedPaths(targetDir: string): string[] {
-  const child = runGit(["diff", "--name-only", "--diff-filter=U"], { targetDir });
+  const child = runGitCommand(["diff", "--name-only", "--diff-filter=U"], { targetDir });
   if (child.status !== 0) return [];
   return child.stdout
     .split("\n")
@@ -229,7 +225,9 @@ export function unmergedPaths(targetDir: string): string[] {
 }
 
 function fetchDeeperHistory({ targetDir, baseBranch }: TargetBaseBranch): void {
-  const shallow = runGit(["rev-parse", "--is-shallow-repository"], { targetDir }).stdout.trim();
+  const shallow = runGitCommand(["rev-parse", "--is-shallow-repository"], {
+    targetDir,
+  }).stdout.trim();
   if (shallow === "true" || fs.existsSync(path.join(targetDir, ".git", "shallow"))) {
     gitFetch(targetDir, ["--unshallow", "origin"]);
   } else {
@@ -239,16 +237,16 @@ function fetchDeeperHistory({ targetDir, baseBranch }: TargetBaseBranch): void {
 }
 
 function gitFetch(targetDir: string, args: string[]): void {
-  run("git", ["fetch", ...args], { cwd: targetDir, timeoutMs: gitNetworkTimeoutMs });
+  gitOutput(["fetch", ...args], { targetDir, timeoutMs: gitNetworkTimeoutMs });
 }
 
 export function gitChangedFiles(targetDir: string, baseBranch: string): string[] {
   const baseRef = `origin/${baseBranch}`;
-  const committed = run("git", ["diff", "--name-only", `${baseRef}...HEAD`], { cwd: targetDir })
+  const committed = gitOutput(["diff", "--name-only", `${baseRef}...HEAD`], { targetDir })
     .split("\n")
     .map((line) => line.trim())
     .filter(Boolean);
-  const uncommitted = run("git", ["status", "--porcelain"], { cwd: targetDir })
+  const uncommitted = gitOutput(["status", "--porcelain"], { targetDir })
     .split("\n")
     .map((line) => line.trim())
     .map((line) => line.replace(/^.. /, ""))
@@ -258,8 +256,18 @@ export function gitChangedFiles(targetDir: string, baseBranch: string): string[]
 }
 
 export function gitLsFiles(targetDir: string): string[] {
-  return run("git", ["ls-files"], { cwd: targetDir })
+  return gitOutput(["ls-files"], { targetDir })
     .split("\n")
     .map((line) => line.trim())
     .filter(Boolean);
+}
+
+function gitOutput(
+  args: string[],
+  options: TargetDir & { timeoutMs?: number; env?: NodeJS.ProcessEnv },
+): string {
+  const child = runGitCommand(args, options);
+  if (child.status === 0) return child.stdout ?? "";
+  const detail = [child.stderr, child.stdout].filter(Boolean).join("\n").trim();
+  throw new Error(detail || `git exited ${child.status ?? `with signal ${child.signal}`}`);
 }

--- a/test/repair/git-repo-utils.test.ts
+++ b/test/repair/git-repo-utils.test.ts
@@ -4,12 +4,78 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
 
 import {
   completeRebaseIfResolved,
   rebaseOntoBase,
+  runGitCommand,
   unmergedPaths,
 } from "../../dist/repair/git-repo-utils.js";
+import { mockCommandBinEnv } from "../helpers.ts";
+
+test("git helper bounds execution and terminates the timed-out process", async () => {
+  const fixture = fakeGitFixture();
+  const marker = path.join(fixture.root, "late-marker");
+
+  assert.throws(
+    () =>
+      runGitCommand(["stall", marker], {
+        targetDir: fixture.root,
+        timeoutMs: 25,
+        env: fixture.env,
+      }),
+    /command timed out after 25ms: git stall.*waiting for timeout/s,
+  );
+  await delay(250);
+  assert.equal(fs.existsSync(marker), false);
+});
+
+test("git helper preserves ordinary nonzero status and stderr", () => {
+  const fixture = fakeGitFixture();
+  const child = runGitCommand(["fail"], {
+    targetDir: fixture.root,
+    timeoutMs: 1_000,
+    env: fixture.env,
+  });
+
+  assert.equal(child.status, 23);
+  assert.equal(child.signal, null);
+  assert.match(child.stderr, /ordinary git failure/);
+});
+
+test("git helper reports spawn errors instead of returning an empty status", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-git-spawn-"));
+  assert.throws(
+    () =>
+      runGitCommand(["status"], {
+        targetDir: root,
+        timeoutMs: 1_000,
+        env: {
+          ...process.env,
+          GIT_BIN: path.join(root, "missing-git-command"),
+          GIT_BIN_ARGS: "[]",
+        },
+      }),
+    /ENOENT|not found/i,
+  );
+});
+
+test(
+  "git helper preserves signal termination semantics",
+  { skip: process.platform === "win32" },
+  () => {
+    const fixture = fakeGitFixture();
+    const child = runGitCommand(["signal"], {
+      targetDir: fixture.root,
+      timeoutMs: 1_000,
+      env: fixture.env,
+    });
+
+    assert.equal(child.status, null);
+    assert.equal(child.signal, "SIGTERM");
+  },
+);
 
 test("rebaseOntoBase rebases a repair branch onto latest origin main", () => {
   const { work } = fixtureRepo();
@@ -96,6 +162,29 @@ function fixtureRepo() {
   run("git", ["commit", "-m", "base"], { cwd: work });
   run("git", ["push", "-u", "origin", "main"], { cwd: work });
   return { root, remote, work };
+}
+
+function fakeGitFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-fake-git-"));
+  const scriptPath = path.join(root, "fake-git.cjs");
+  fs.writeFileSync(
+    scriptPath,
+    [
+      'const fs = require("node:fs");',
+      "const [mode, marker] = process.argv.slice(2);",
+      'if (mode === "fail") { process.stderr.write("ordinary git failure\\n"); process.exit(23); }',
+      'if (mode === "signal") process.kill(process.pid, "SIGTERM");',
+      'if (mode === "stall") {',
+      '  process.stderr.write("waiting for timeout\\n");',
+      '  setTimeout(() => fs.writeFileSync(marker, "late\\n"), 150);',
+      "}",
+      "",
+    ].join("\n"),
+  );
+  return {
+    root,
+    env: { ...process.env, ...mockCommandBinEnv("git", scriptPath) },
+  };
 }
 
 function run(command, args, options = {}) {

--- a/test/repair/git-repo-utils.test.ts
+++ b/test/repair/git-repo-utils.test.ts
@@ -22,12 +22,12 @@ test("git helper bounds execution and terminates the timed-out process", async (
     () =>
       runGitCommand(["stall", marker], {
         targetDir: fixture.root,
-        timeoutMs: 25,
+        timeoutMs: 250,
         env: fixture.env,
       }),
-    /command timed out after 25ms: git stall.*waiting for timeout/s,
+    /command timed out after 250ms: git stall.*waiting for timeout/s,
   );
-  await delay(250);
+  await delay(750);
   assert.equal(fs.existsSync(marker), false);
 });
 
@@ -176,7 +176,7 @@ function fakeGitFixture() {
       'if (mode === "signal") process.kill(process.pid, "SIGTERM");',
       'if (mode === "stall") {',
       '  process.stderr.write("waiting for timeout\\n");',
-      '  setTimeout(() => fs.writeFileSync(marker, "late\\n"), 150);',
+      '  setTimeout(() => fs.writeFileSync(marker, "late\\n"), 600);',
       "}",
       "",
     ].join("\n"),


### PR DESCRIPTION
## Summary
- add a timeout-aware git helper for repair git utilities
- route direct git spawnSync calls through the helper so credential/network hangs fail with a clear timeout
- preserve existing status-return semantics for non-timeout git failures

Critique: /Users/ryan/.openclaw/workspace/memory/nightly-reviews/2026-07-11-clawsweeper-critique.md

## Validation
- pnpm run build:repair
- node --test test/repair/git-repo-utils.test.ts test/repair/command-runner.test.ts