### PR TITLE
feat(ledger): instrument review and apply actions

### DIFF
--- a/.github/actions/setup-action-ledger/action.yml
+++ b/.github/actions/setup-action-ledger/action.yml
@@ -1,0 +1,37 @@
+name: Setup ClawSweeper action ledger
+description: Enable action receipts with immutable workflow-run metadata.
+inputs:
+  worktree-path:
+    description: ClawSweeper checkout path relative to the workspace.
+    required: false
+    default: "."
+runs:
+  using: composite
+  steps:
+    - name: Export immutable action ledger context
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        run_started_at="$(
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --jq '.created_at'
+        )"
+        if ! [[ "$run_started_at" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]; then
+          echo "Unable to resolve immutable workflow run creation time." >&2
+          exit 1
+        fi
+        worktree_root="$GITHUB_WORKSPACE"
+        if [ "${{ inputs.worktree-path }}" != "." ]; then
+          worktree_root="$worktree_root/${{ inputs.worktree-path }}"
+        fi
+        worktree_root="$(cd "$worktree_root" && pwd -P)"
+        output_root="$worktree_root/.clawsweeper-repair/action-ledger-state"
+        mkdir -p "$output_root"
+        output_root="$(cd "$output_root" && pwd -P)"
+        {
+          echo "CLAWSWEEPER_ACTION_LEDGER_FORCE=1"
+          echo "CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT=$output_root"
+          echo "GITHUB_RUN_STARTED_AT=$run_started_at"
+        } >> "$GITHUB_ENV"

--- a/.github/actions/setup-action-ledger/action.yml
+++ b/.github/actions/setup-action-ledger/action.yml
@@ -22,12 +22,7 @@ runs:
           echo "Unable to resolve immutable workflow run creation time." >&2
           exit 1
         fi
-        worktree_root="$GITHUB_WORKSPACE"
-        if [ "${{ inputs.worktree-path }}" != "." ]; then
-          worktree_root="$worktree_root/${{ inputs.worktree-path }}"
-        fi
-        worktree_root="$(cd "$worktree_root" && pwd -P)"
-        output_root="$worktree_root/.clawsweeper-repair/action-ledger-state"
+        output_root="$RUNNER_TEMP/clawsweeper-action-ledger/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}"
         mkdir -p "$output_root"
         output_root="$(cd "$output_root" && pwd -P)"
         {

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -3018,6 +3018,7 @@ jobs:
           CLAWSWEEPER_INTERNAL_MODEL: ${{ secrets.CLAWSWEEPER_MODEL }}
 
       - name: Generate bound close coverage proofs
+        id: generate-apply-proofs
         if: ${{ steps.proof-select.outputs.item_numbers != '' }}
         timeout-minutes: 50
         env:
@@ -3056,7 +3057,14 @@ jobs:
 
       - name: Finalize apply proof action ledger
         if: ${{ always() && steps.proof-select.outputs.item_numbers != '' }}
-        run: pnpm run --silent finalize-action-events
+        env:
+          APPLY_PROOF_OUTCOME: ${{ steps.generate-apply-proofs.outcome || 'not_started' }}
+        run: |
+          args=()
+          if [ "$APPLY_PROOF_OUTCOME" != "success" ]; then
+            args=(--interrupt-open-attempts --reason timeout)
+          fi
+          pnpm run --silent finalize-action-events -- "${args[@]}"
 
       - name: Upload bound close coverage proofs
         if: ${{ always() && steps.proof-select.outputs.item_numbers != '' }}
@@ -3266,6 +3274,8 @@ jobs:
           persist_reconciliation "${reconcile_args[@]}"
 
       - name: Apply unchanged proposed decisions with checkpoints
+        id: apply-existing-run
+        timeout-minutes: 350
         env:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
@@ -3634,6 +3644,17 @@ jobs:
             echo "APPLY_ADAPTIVE_SCAN_REASON=$adaptive_apply_scan_reason"
             echo "APPLY_CANDIDATE_QUALITY_SUMMARY=$candidate_quality_summary"
           } >> "$GITHUB_ENV"
+
+      - name: Finalize apply action ledger
+        if: ${{ always() }}
+        env:
+          APPLY_OUTCOME: ${{ steps.apply-existing-run.outcome || 'not_started' }}
+        run: |
+          args=()
+          if [ "$APPLY_OUTCOME" != "success" ]; then
+            args=(--interrupt-open-attempts --reason timeout)
+          fi
+          pnpm run --silent finalize-action-events -- "${args[@]}"
 
       - name: Retry final apply status publication
         run: |

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -768,16 +768,21 @@ jobs:
             echo "::notice::Exact review produced no artifact because the item closed during review."
           fi
 
+      - name: Finalize exact event action ledger
+        if: ${{ always() && steps.live-item.outputs.proceed == 'true' }}
+        run: pnpm run --silent finalize-action-events
+
       - name: Create state token
         id: state-token
-        if: ${{ steps.live-item.outputs.proceed == 'true' && steps.review-exact-event-item.outcome == 'success' }}
+        if: ${{ always() && steps.live-item.outputs.proceed == 'true' }}
         uses: ./.github/actions/create-state-token
         with:
           client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
           private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
 
       - uses: ./.github/actions/setup-state
-        if: ${{ steps.live-item.outputs.proceed == 'true' && steps.review-exact-event-item.outcome == 'success' }}
+        id: setup-state
+        if: ${{ always() && steps.live-item.outputs.proceed == 'true' }}
         with:
           token: ${{ steps.state-token.outputs.token }}
           fetch-depth: 1
@@ -1053,6 +1058,39 @@ jobs:
       - name: Fail unsuccessful exact review
         if: ${{ always() && steps.target.outputs.target_enabled != 'false' && steps.live-item.outputs.proceed != 'false' && steps.publish-event-result.outputs.terminal_noop != 'true' && steps.publish-event-result.outputs.policy_noop != 'true' && steps.publish-event-result.outputs.requeue_latest != 'true' && (steps.review-exact-event-item.outcome != 'success' || steps.publish-event-result.outcome != 'success' || (steps.publish-event-result.outputs.terminal_missing != 'true' && steps.publish-event-result.outputs.terminal_closed != 'true' && steps.publish-event-result.outputs.guarded_open != 'true' && steps.queue-exact-verdict-router.outcome != 'success')) }}
         run: exit 1
+
+      - name: Publish exact event action ledger
+        if: ${{ always() && steps.setup-state.outcome == 'success' }}
+        run: |
+          set -euo pipefail
+          test -n "${CLAWSWEEPER_STATE_DIR:-}"
+          if [ ! -d .clawsweeper-repair/action-ledger-state/ledger ]; then
+            echo "No exact event action shards were finalized."
+            exit 0
+          fi
+          event_paths_file=".artifacts/exact-event-action-ledger-paths.txt"
+          mkdir -p .artifacts
+          pnpm run --silent publish-action-events -- \
+            --source-root .clawsweeper-repair/action-ledger-state \
+            --state-root "$CLAWSWEEPER_STATE_DIR" |
+            jq -r '.paths[]?' |
+            sort -u > "$event_paths_file"
+          if [ ! -s "$event_paths_file" ]; then
+            echo "Exact event action shards existed but no paths were imported." >&2
+            exit 1
+          fi
+          action_ledger_args=()
+          while IFS= read -r event_path; do
+            durable_event_path="$CLAWSWEEPER_STATE_DIR/$event_path"
+            test -f "$durable_event_path"
+            mkdir -p "$(dirname "$event_path")"
+            cp "$durable_event_path" "$event_path"
+            action_ledger_args+=(--path "$event_path")
+          done < "$event_paths_file"
+          pnpm run repair:publish-main -- \
+            --message "chore: append exact event action ledger" \
+            "${action_ledger_args[@]}" \
+            --rebase-strategy normal
 
       - name: Complete exact-review queue lease
         id: complete-exact-review-queue
@@ -1815,6 +1853,11 @@ jobs:
             "${additional_prompt_arg[@]}" \
             "${expected_source_revision_arg[@]}"
 
+      - name: Finalize review action ledger
+        if: always()
+        working-directory: clawsweeper
+        run: node dist/clawsweeper.js finalize-action-events
+
       - name: Record shard metrics
         if: always()
         env:
@@ -1859,6 +1902,14 @@ jobs:
           path: |
             review-artifacts/shard-${{ matrix.shard }}/*.md
             review-artifacts/shard-${{ matrix.shard }}/review-cache-metrics.json
+          if-no-files-found: ignore
+
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: action-ledger-review-${{ matrix.shard }}
+          path: clawsweeper/.clawsweeper-repair/action-ledger-state/**
+          include-hidden-files: true
           if-no-files-found: ignore
 
       - uses: actions/upload-artifact@v7
@@ -2005,10 +2056,55 @@ jobs:
           path: review-metrics
           merge-multiple: true
 
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: action-ledger-review-*
+          path: .clawsweeper-repair/action-ledger-download
+          merge-multiple: true
+
+      - name: Import immutable review action events
+        run: |
+          set -euo pipefail
+          test -n "${CLAWSWEEPER_STATE_DIR:-}"
+          mkdir -p .artifacts
+          : > .artifacts/action-ledger-paths.txt
+          for source_root in \
+            .clawsweeper-repair/action-ledger-download \
+            .clawsweeper-repair/action-ledger-state
+          do
+            pnpm run --silent publish-action-events -- \
+              --source-root "$source_root" \
+              --state-root "$CLAWSWEEPER_STATE_DIR" |
+              jq -r '.paths[]?' >> .artifacts/action-ledger-paths.txt
+          done
+          sort -u -o .artifacts/action-ledger-paths.txt .artifacts/action-ledger-paths.txt
+          while IFS= read -r event_path; do
+            durable_event_path="$CLAWSWEEPER_STATE_DIR/$event_path"
+            test -f "$durable_event_path"
+            mkdir -p "$(dirname "$event_path")"
+            cp "$durable_event_path" "$event_path"
+          done < .artifacts/action-ledger-paths.txt
+
+      - name: Publish immutable review action ledger
+        run: |
+          if [ ! -s .artifacts/action-ledger-paths.txt ]; then
+            echo "No immutable review action events to publish."
+            exit 0
+          fi
+          action_ledger_args=()
+          while IFS= read -r event_path; do
+            action_ledger_args+=(--path "$event_path")
+          done < .artifacts/action-ledger-paths.txt
+          pnpm run repair:publish-main -- \
+            --message "chore: append review action ledger" \
+            "${action_ledger_args[@]}" \
+            --rebase-strategy normal
+
       - name: Sync before applying artifacts
         run: git pull --rebase --autostash
 
       - name: Apply review artifacts
+        id: apply-review-artifacts
         env:
           GH_TOKEN: ${{ github.token }}
           EXACT_ITEM: ${{ github.event.client_payload.item_number || github.event.inputs.item_number || github.event.inputs.item_numbers || '' }}
@@ -2040,6 +2136,40 @@ jobs:
             --due-backlog "${{ needs.plan.outputs.due_backlog }}" \
             --oldest-unreviewed-at "${{ needs.plan.outputs.oldest_unreviewed_at }}" \
             --capacity-reason "${{ needs.plan.outputs.capacity_reason }}"
+
+      - name: Publish review artifact action ledger
+        if: ${{ always() && steps.apply-review-artifacts.outcome != 'skipped' }}
+        run: |
+          set -euo pipefail
+          test -n "${CLAWSWEEPER_STATE_DIR:-}"
+          source_root=".clawsweeper-repair/action-ledger-state"
+          if [ ! -d "$source_root/ledger" ]; then
+            echo "No review artifact action event shards were finalized."
+            exit 0
+          fi
+          event_paths_file=".artifacts/review-artifact-action-ledger-paths.txt"
+          mkdir -p .artifacts
+          pnpm run --silent publish-action-events -- \
+            --source-root "$source_root" \
+            --state-root "$CLAWSWEEPER_STATE_DIR" |
+            jq -r '.paths[]?' |
+            sort -u > "$event_paths_file"
+          if [ ! -s "$event_paths_file" ]; then
+            echo "Review artifact action event shards existed but no paths were imported." >&2
+            exit 1
+          fi
+          action_ledger_args=()
+          while IFS= read -r event_path; do
+            durable_event_path="$CLAWSWEEPER_STATE_DIR/$event_path"
+            test -f "$durable_event_path"
+            mkdir -p "$(dirname "$event_path")"
+            cp "$durable_event_path" "$event_path"
+            action_ledger_args+=(--path "$event_path")
+          done < "$event_paths_file"
+          pnpm run repair:publish-main -- \
+            --message "chore: append review artifact action ledger" \
+            "${action_ledger_args[@]}" \
+            --rebase-strategy normal
 
       - name: Commit review records
         env:
@@ -2250,6 +2380,7 @@ jobs:
           echo "::warning::Unable to dispatch background comment sync after three attempts; apply/comment-sync backstops can pick it up later."
 
       - name: Sync selected review comments
+        id: sync-selected-review-comments
         if: ${{ success() && steps.target-write-token.outputs.token != '' && ((github.event_name == 'repository_dispatch' && github.event.action != 'clawsweeper_target_sweep') || github.event.inputs.item_number != '' || github.event.inputs.item_numbers != '') }}
         timeout-minutes: 15
         env:
@@ -2299,6 +2430,39 @@ jobs:
             --path apply-report.json \
             --path "results/sweep-status/${target_slug}.json" \
             --rebase-strategy theirs
+
+      - name: Publish selected review comment action ledger
+        if: ${{ always() && steps.sync-selected-review-comments.outcome != 'skipped' }}
+        run: |
+          set -euo pipefail
+          test -n "${CLAWSWEEPER_STATE_DIR:-}"
+          if [ ! -d .clawsweeper-repair/action-ledger-state/ledger ]; then
+            echo "No selected review comment action shards were finalized."
+            exit 0
+          fi
+          event_paths_file=".artifacts/selected-comment-action-ledger-paths.txt"
+          mkdir -p .artifacts
+          pnpm run --silent publish-action-events -- \
+            --source-root .clawsweeper-repair/action-ledger-state \
+            --state-root "$CLAWSWEEPER_STATE_DIR" |
+            jq -r '.paths[]?' |
+            sort -u > "$event_paths_file"
+          if [ ! -s "$event_paths_file" ]; then
+            echo "Selected review comment action shards existed but no paths were imported." >&2
+            exit 1
+          fi
+          action_ledger_args=()
+          while IFS= read -r event_path; do
+            durable_event_path="$CLAWSWEEPER_STATE_DIR/$event_path"
+            test -f "$durable_event_path"
+            mkdir -p "$(dirname "$event_path")"
+            cp "$durable_event_path" "$event_path"
+            action_ledger_args+=(--path "$event_path")
+          done < "$event_paths_file"
+          pnpm run repair:publish-main -- \
+            --message "chore: append selected review comment action ledger" \
+            "${action_ledger_args[@]}" \
+            --rebase-strategy normal
 
       - name: Dispatch selected safe close proposals to isolated apply
         if: ${{ success() && steps.target-write-token.outputs.token != '' && github.event.inputs.apply_after_review == 'true' }}
@@ -2522,6 +2686,40 @@ jobs:
             --path results/failed-review-retries/openclaw-openclaw \
             --rebase-strategy theirs
 
+      - name: Publish failed-review retry action ledger
+        if: ${{ always() }}
+        run: |
+          set -euo pipefail
+          test -n "${CLAWSWEEPER_STATE_DIR:-}"
+          source_root=".clawsweeper-repair/action-ledger-state"
+          if [ ! -d "$source_root/ledger" ]; then
+            echo "No failed-review retry action event shards were finalized."
+            exit 0
+          fi
+          event_paths_file=".artifacts/failed-review-retry-action-ledger-paths.txt"
+          mkdir -p .artifacts
+          pnpm run --silent publish-action-events -- \
+            --source-root "$source_root" \
+            --state-root "$CLAWSWEEPER_STATE_DIR" |
+            jq -r '.paths[]?' |
+            sort -u > "$event_paths_file"
+          if [ ! -s "$event_paths_file" ]; then
+            echo "Failed-review retry action shards existed but no paths were imported." >&2
+            exit 1
+          fi
+          action_ledger_args=()
+          while IFS= read -r event_path; do
+            durable_event_path="$CLAWSWEEPER_STATE_DIR/$event_path"
+            test -f "$durable_event_path"
+            mkdir -p "$(dirname "$event_path")"
+            cp "$durable_event_path" "$event_path"
+            action_ledger_args+=(--path "$event_path")
+          done < "$event_paths_file"
+          pnpm run repair:publish-main -- \
+            --message "chore: append failed review retry action ledger" \
+            "${action_ledger_args[@]}" \
+            --rebase-strategy normal
+
       - uses: actions/upload-artifact@v7
         if: ${{ always() }}
         with:
@@ -2667,6 +2865,7 @@ jobs:
     outputs:
       target_repo: ${{ steps.target.outputs.target_repo }}
       artifact_name: ${{ steps.proof-artifact.outputs.name }}
+      action_ledger_artifact_name: ${{ steps.publishable-action-ledger.outputs.name }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -2688,7 +2887,9 @@ jobs:
 
       - name: Resolve proof artifact identity
         id: proof-artifact
-        run: echo "name=apply-coverage-proofs-${{ github.run_id }}-${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "name=apply-coverage-proofs-${{ github.run_id }}-${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
+          echo "action_ledger_name=action-ledger-apply-proof-${{ github.run_id }}-${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
 
       - uses: ./.github/actions/setup-state
         with:
@@ -2813,6 +3014,10 @@ jobs:
             --report-path .artifacts/apply-proof/apply-report.json \
             --progress-every 1
 
+      - name: Finalize apply proof action ledger
+        if: ${{ always() && steps.proof-select.outputs.item_numbers != '' }}
+        run: pnpm run --silent finalize-action-events
+
       - name: Upload bound close coverage proofs
         if: ${{ always() && steps.proof-select.outputs.item_numbers != '' }}
         uses: actions/upload-artifact@v7
@@ -2822,9 +3027,98 @@ jobs:
           if-no-files-found: ignore
           retention-days: 1
 
+      - name: Upload apply proof action events
+        id: upload-action-events
+        if: ${{ always() && steps.proof-select.outputs.item_numbers != '' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ steps.proof-artifact.outputs.action_ledger_name }}
+          path: .clawsweeper-repair/action-ledger-state/**
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Export uploaded apply proof action ledger identity
+        id: publishable-action-ledger
+        if: ${{ always() && steps.upload-action-events.outputs.artifact-id != '' }}
+        run: echo "name=${{ steps.proof-artifact.outputs.action_ledger_name }}" >> "$GITHUB_OUTPUT"
+
+  publish-apply-proof-action-ledger:
+    name: Publish immutable apply proof action ledger
+    needs: apply-proof
+    if: ${{ always() && needs.apply-proof.result != 'skipped' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          filter: blob:none
+
+      - name: Download apply proof action events
+        if: ${{ needs.apply-proof.outputs.action_ledger_artifact_name != '' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ needs.apply-proof.outputs.action_ledger_artifact_name }}
+          path: .clawsweeper-repair/action-ledger-proof
+
+      - name: Create state token
+        if: ${{ needs.apply-proof.outputs.action_ledger_artifact_name != '' }}
+        id: state-token
+        uses: ./.github/actions/create-state-token
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+
+      - uses: ./.github/actions/setup-state
+        if: ${{ needs.apply-proof.outputs.action_ledger_artifact_name != '' }}
+        with:
+          token: ${{ steps.state-token.outputs.token }}
+          filter: blob:none
+          fetch-depth: 1
+
+      - uses: ./.github/actions/setup-pnpm
+        if: ${{ needs.apply-proof.outputs.action_ledger_artifact_name != '' }}
+        with:
+          build-script: build:all
+
+      - name: Publish apply proof action events
+        if: ${{ needs.apply-proof.outputs.action_ledger_artifact_name != '' }}
+        run: |
+          set -euo pipefail
+          test -n "${CLAWSWEEPER_STATE_DIR:-}"
+          source_root=".clawsweeper-repair/action-ledger-proof"
+          if [ ! -d "$source_root/ledger" ]; then
+            echo "The uploaded apply proof artifact did not contain action event shards." >&2
+            exit 1
+          fi
+          event_paths_file=".artifacts/apply-proof-action-ledger-paths.txt"
+          mkdir -p .artifacts
+          pnpm run --silent publish-action-events -- \
+            --source-root "$source_root" \
+            --state-root "$CLAWSWEEPER_STATE_DIR" |
+            jq -r '.paths[]?' |
+            sort -u > "$event_paths_file"
+          if [ ! -s "$event_paths_file" ]; then
+            echo "Apply proof action event shards existed but no paths were imported." >&2
+            exit 1
+          fi
+          action_ledger_args=()
+          while IFS= read -r event_path; do
+            durable_event_path="$CLAWSWEEPER_STATE_DIR/$event_path"
+            test -f "$durable_event_path"
+            mkdir -p "$(dirname "$event_path")"
+            cp "$durable_event_path" "$event_path"
+            action_ledger_args+=(--path "$event_path")
+          done < "$event_paths_file"
+          pnpm run repair:publish-main -- \
+            --message "chore: append apply proof action ledger" \
+            "${action_ledger_args[@]}" \
+            --rebase-strategy normal
+
   apply-existing:
     name: Apply close proposals
-    needs: apply-proof
+    needs: [apply-proof, publish-apply-proof-action-ledger]
     if: ${{ ((github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '3 * * * *' || github.event.schedule == '18 * * * *' || github.event.schedule == '33 * * * *' || github.event.schedule == '48 * * * *' || github.event.schedule == '8,23,38,53 * * * *' || github.event.schedule == '6,21,36,51 * * * *'))) && !(github.event_name == 'repository_dispatch' && github.event.client_payload.target_repo == 'openclaw/clawhub' && vars.CLAWSWEEPER_ENABLE_CLAWHUB != '1') && !(github.event_name == 'schedule' && github.event.schedule == '8,23,38,53 * * * *' && vars.CLAWSWEEPER_ENABLE_CLAWHUB != '1') }}
     runs-on: ubuntu-latest
     timeout-minutes: 360
@@ -3311,6 +3605,40 @@ jobs:
             --message "chore: mark sweep apply finished" \
             --path "results/sweep-status/${target_slug}.json" \
             --rebase-strategy apply-records
+
+      - name: Publish apply action events
+        if: ${{ always() }}
+        run: |
+          set -euo pipefail
+          test -n "${CLAWSWEEPER_STATE_DIR:-}"
+          source_root=".clawsweeper-repair/action-ledger-state"
+          if [ ! -d "$source_root/ledger" ]; then
+            echo "No apply action event shards were finalized."
+            exit 0
+          fi
+          event_paths_file=".artifacts/apply-action-ledger-paths.txt"
+          mkdir -p .artifacts
+          pnpm run --silent publish-action-events -- \
+            --source-root "$source_root" \
+            --state-root "$CLAWSWEEPER_STATE_DIR" |
+            jq -r '.paths[]?' |
+            sort -u > "$event_paths_file"
+          if [ ! -s "$event_paths_file" ]; then
+            echo "Apply action event shards existed but no paths were imported." >&2
+            exit 1
+          fi
+          action_ledger_args=()
+          while IFS= read -r event_path; do
+            durable_event_path="$CLAWSWEEPER_STATE_DIR/$event_path"
+            test -f "$durable_event_path"
+            mkdir -p "$(dirname "$event_path")"
+            cp "$durable_event_path" "$event_path"
+            action_ledger_args+=(--path "$event_path")
+          done < "$event_paths_file"
+          pnpm run repair:publish-main -- \
+            --message "chore: append apply action ledger" \
+            "${action_ledger_args[@]}" \
+            --rebase-strategy normal
 
       - name: Continue apply sweep
         if: ${{ success() }}

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -444,6 +444,7 @@ jobs:
           persist-credentials: false
 
       - uses: ./.github/actions/setup-action-ledger
+        continue-on-error: true
 
       - name: Resolve event payload
         id: target
@@ -779,6 +780,7 @@ jobs:
 
       - name: Finalize exact event action ledger
         if: ${{ always() && steps.live-item.outputs.proceed == 'true' }}
+        continue-on-error: true
         env:
           REVIEW_EXIT_CODE: ${{ steps.review-exact-event-item.outputs.exit_code || '' }}
           REVIEW_OUTCOME: ${{ steps.review-exact-event-item.outcome || 'not_started' }}
@@ -810,7 +812,7 @@ jobs:
 
       - name: Publish event result and apply safe close
         id: publish-event-result
-        if: ${{ steps.review-exact-event-item.outcome == 'success' }}
+        if: ${{ always() && !cancelled() && steps.review-exact-event-item.outcome == 'success' && steps.setup-state.outcome == 'success' }}
         env:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
           REPO_TOKEN: ${{ github.token }}
@@ -1076,6 +1078,50 @@ jobs:
           fi
           remove_own_eyes_reactions
 
+      - name: Export exact review primary result
+        id: exact-review-primary-result
+        if: ${{ always() }}
+        env:
+          JOB_CANCELLED: ${{ cancelled() }}
+          PRIMARY_JOB_STATUS: ${{ job.status }}
+          TARGET_ENABLED: ${{ steps.target.outputs.target_enabled }}
+          LIVE_PROCEED: ${{ steps.live-item.outputs.proceed }}
+          LIVE_TERMINAL_NOOP: ${{ steps.live-item.outputs.terminal_noop }}
+          LIVE_TERMINAL_MISSING: ${{ steps.live-item.outputs.terminal_missing }}
+          LIVE_GUARDED_OPEN: ${{ steps.live-item.outputs.guarded_open }}
+          REVIEW_OUTCOME: ${{ steps.review-exact-event-item.outcome }}
+          PUBLISH_OUTCOME: ${{ steps.publish-event-result.outcome }}
+          TERMINAL_NOOP: ${{ steps.publish-event-result.outputs.terminal_noop }}
+          TERMINAL_MISSING: ${{ steps.publish-event-result.outputs.terminal_missing }}
+          TERMINAL_CLOSED: ${{ steps.publish-event-result.outputs.terminal_closed }}
+          GUARDED_OPEN: ${{ steps.publish-event-result.outputs.guarded_open }}
+          POLICY_NOOP: ${{ steps.publish-event-result.outputs.policy_noop }}
+          REQUEUE_LATEST: ${{ steps.publish-event-result.outputs.requeue_latest }}
+          ROUTE_OUTCOME: ${{ steps.queue-exact-verdict-router.outcome }}
+        run: |
+          outcome=failure
+          if [ "$JOB_CANCELLED" = "true" ] || [ "$REVIEW_OUTCOME" = "cancelled" ]; then
+            outcome=cancelled
+          elif [ "$PRIMARY_JOB_STATUS" != "success" ]; then
+            outcome=failure
+          elif [ "$TARGET_ENABLED" = "false" ] ||
+            [ "$LIVE_PROCEED" = "false" ] ||
+            [ "$LIVE_TERMINAL_NOOP" = "true" ] ||
+            [ "$LIVE_TERMINAL_MISSING" = "true" ] ||
+            [ "$LIVE_GUARDED_OPEN" = "true" ] ||
+            [ "$TERMINAL_NOOP" = "true" ] ||
+            [ "$POLICY_NOOP" = "true" ] ||
+            [ "$REQUEUE_LATEST" = "true" ]; then
+            outcome=success
+          elif [ "$REVIEW_OUTCOME" = "success" ] && [ "$PUBLISH_OUTCOME" = "success" ] &&
+            { [ "$TERMINAL_MISSING" = "true" ] ||
+              [ "$TERMINAL_CLOSED" = "true" ] ||
+              [ "$GUARDED_OPEN" = "true" ] ||
+              [ "$ROUTE_OUTCOME" = "success" ]; }; then
+            outcome=success
+          fi
+          echo "outcome=$outcome" >> "$GITHUB_OUTPUT"
+
       - name: Fail unsuccessful exact review
         if: ${{ always() && steps.target.outputs.target_enabled != 'false' && steps.live-item.outputs.proceed != 'false' && steps.publish-event-result.outputs.terminal_noop != 'true' && steps.publish-event-result.outputs.policy_noop != 'true' && steps.publish-event-result.outputs.requeue_latest != 'true' && (steps.review-exact-event-item.outcome != 'success' || steps.publish-event-result.outcome != 'success' || (steps.publish-event-result.outputs.terminal_missing != 'true' && steps.publish-event-result.outputs.terminal_closed != 'true' && steps.publish-event-result.outputs.guarded_open != 'true' && steps.queue-exact-verdict-router.outcome != 'success')) }}
         run: exit 1
@@ -1116,7 +1162,7 @@ jobs:
         if: ${{ always() }}
         continue-on-error: true
         env:
-          JOB_STATUS: ${{ job.status }}
+          PRIMARY_OUTCOME: ${{ steps.exact-review-primary-result.outputs.outcome || 'failure' }}
           CLAIM_GENERATION: ${{ steps.claim-exact-review-queue.outputs.claim_generation }}
           ITEM_KEY: ${{ steps.claim-exact-review-queue.outputs.item_key }}
           PROTOCOL_VERSION: ${{ steps.claim-exact-review-queue.outputs.protocol_version }}
@@ -1145,11 +1191,10 @@ jobs:
                 !Number.isInteger(claimGeneration) ||
                 claimGeneration < 1)
             ) process.exit(1);
-            const outcome = process.env.JOB_STATUS === "success"
-              ? "success"
-              : process.env.JOB_STATUS === "cancelled"
-                ? "cancelled"
-                : "failure";
+            const primaryOutcome = String(process.env.PRIMARY_OUTCOME || "");
+            const outcome = ["success", "cancelled", "failure"].includes(primaryOutcome)
+              ? primaryOutcome
+              : "failure";
             const retryAt = String(process.env.RETRY_AT || "").trim();
             const requeueLatest = process.env.REQUEUE_LATEST === "true";
             process.stdout.write(JSON.stringify({
@@ -1722,6 +1767,7 @@ jobs:
           persist-credentials: false
 
       - uses: ./clawsweeper/.github/actions/setup-action-ledger
+        continue-on-error: true
         with:
           worktree-path: clawsweeper
 
@@ -1884,6 +1930,7 @@ jobs:
 
       - name: Finalize review action ledger
         if: always()
+        continue-on-error: true
         working-directory: clawsweeper
         env:
           REVIEW_EXIT_CODE: ${{ steps.review-shard.outputs.exit_code || '' }}
@@ -2057,6 +2104,7 @@ jobs:
           persist-credentials: false
 
       - uses: ./.github/actions/setup-action-ledger
+        continue-on-error: true
 
       - name: Create target write token
         id: target-write-token
@@ -2079,20 +2127,24 @@ jobs:
           private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
 
       - uses: ./.github/actions/setup-state
+        id: setup-publish-state
         with:
           token: ${{ steps.state-token.outputs.token }}
 
       - uses: ./.github/actions/setup-pnpm
+        id: setup-publish-pnpm
         with:
           build-script: build:all
 
       - uses: actions/download-artifact@v8
+        id: download-review-artifacts
         with:
           pattern: review-shard-*
           path: artifacts
           merge-multiple: true
 
       - uses: actions/download-artifact@v8
+        id: download-review-metrics
         continue-on-error: true
         with:
           pattern: review-metrics-*
@@ -2100,12 +2152,17 @@ jobs:
           merge-multiple: true
 
       - uses: actions/download-artifact@v8
+        id: download-review-action-ledger
+        continue-on-error: true
         with:
           pattern: action-ledger-review-*
           path: .clawsweeper-repair/action-ledger-download
           merge-multiple: true
 
       - name: Import immutable review action events
+        id: import-review-action-ledger
+        if: ${{ always() && steps.setup-publish-state.outcome == 'success' && steps.setup-publish-pnpm.outcome == 'success' && steps.download-review-action-ledger.outcome == 'success' }}
+        continue-on-error: true
         run: |
           set -euo pipefail
           test -n "${CLAWSWEEPER_STATE_DIR:-}"
@@ -2130,6 +2187,8 @@ jobs:
           done < .artifacts/action-ledger-paths.txt
 
       - name: Publish immutable review action ledger
+        if: ${{ always() && steps.import-review-action-ledger.outcome == 'success' }}
+        continue-on-error: true
         run: |
           if [ ! -s .artifacts/action-ledger-paths.txt ]; then
             echo "No immutable review action events to publish."
@@ -2140,22 +2199,35 @@ jobs:
             --message "chore: append review action ledger"
 
       - name: Sync before applying artifacts
+        id: sync-review-artifacts
+        if: ${{ always() && !cancelled() && steps.setup-publish-state.outcome == 'success' && steps.setup-publish-pnpm.outcome == 'success' && steps.download-review-artifacts.outcome == 'success' }}
         run: git pull --rebase --autostash
 
       - name: Apply review artifacts
         id: apply-review-artifacts
+        if: ${{ always() && !cancelled() && steps.sync-review-artifacts.outcome == 'success' }}
         env:
           GH_TOKEN: ${{ github.token }}
           EXACT_ITEM: ${{ github.event.client_payload.item_number || github.event.inputs.item_number || github.event.inputs.item_numbers || '' }}
+          EXPECTED_METRIC_COUNT: ${{ needs.plan.outputs.planned_shards }}
           HOT_INTAKE: ${{ needs.plan.outputs.hot_intake }}
           MAX_PAGES: ${{ needs.plan.outputs.max_pages }}
           TARGET_REPO: ${{ needs.plan.outputs.target_repo }}
         run: |
+          set -euo pipefail
           apply_artifacts_args=(--target-repo "$TARGET_REPO" --artifact-dir artifacts --skip-dashboard --skip-reconcile)
           publish_state="Review publish complete"
+          mkdir -p review-metrics
           reviewed_count="$(find artifacts -type f -name '*.md' | wc -l | tr -d ' ')"
-          metric_count="$(find review-metrics -type f -name '*.json' 2>/dev/null | wc -l | tr -d ' ')"
-          non_success_metric_count="$(find review-metrics -type f -name '*.json' -print0 2>/dev/null | xargs -0 -r jq -r 'select(.review_outcome != "success") | .shard' | wc -l | tr -d ' ')"
+          metric_count="$(find review-metrics -type f -name '*.json' | wc -l | tr -d ' ')"
+          non_success_metric_count="$(find review-metrics -type f -name '*.json' -print0 | xargs -0 -r jq -r 'select(.review_outcome != "success") | .shard' | wc -l | tr -d ' ')"
+          review_batch_succeeded=false
+          if [[ "$EXPECTED_METRIC_COUNT" =~ ^[1-9][0-9]*$ ]] &&
+            [ "$metric_count" -eq "$EXPECTED_METRIC_COUNT" ] &&
+            [ "$non_success_metric_count" -eq 0 ]; then
+            review_batch_succeeded=true
+          fi
+          echo "review_batch_succeeded=$review_batch_succeeded" >> "$GITHUB_OUTPUT"
           publish_detail="Merged ${reviewed_count} review artifacts for run ${{ github.run_id }}. Captured ${metric_count} shard metrics; ${non_success_metric_count} shards reported non-success review status. Folder reconciliation moved tracked files to match current GitHub open/closed state."
           if [ "$HOT_INTAKE" = "true" ] && [ -z "$EXACT_ITEM" ]; then
             apply_artifacts_args+=(--max-pages "$MAX_PAGES" --skip-reconcile)
@@ -2163,6 +2235,7 @@ jobs:
             publish_detail="Merged ${reviewed_count} hot intake artifacts for run ${{ github.run_id }} without full folder reconciliation. Captured ${metric_count} shard metrics; ${non_success_metric_count} shards reported non-success review status."
           fi
           pnpm run apply-artifacts -- "${apply_artifacts_args[@]}"
+          echo "artifacts_applied=true" >> "$GITHUB_OUTPUT"
           pnpm run status -- \
             --target-repo "$TARGET_REPO" \
             --state "$publish_state" \
@@ -2177,7 +2250,7 @@ jobs:
             --capacity-reason "${{ needs.plan.outputs.capacity_reason }}"
 
       - name: Publish review artifact action ledger
-        if: ${{ always() && steps.apply-review-artifacts.outcome != 'skipped' }}
+        if: ${{ always() && steps.apply-review-artifacts.outputs.artifacts_applied == 'true' }}
         run: |
           set -euo pipefail
           test -n "${CLAWSWEEPER_STATE_DIR:-}"
@@ -2209,6 +2282,8 @@ jobs:
             --message "chore: append review artifact action ledger"
 
       - name: Commit review records
+        id: commit-review-records
+        if: ${{ always() && !cancelled() && steps.apply-review-artifacts.outputs.artifacts_applied == 'true' }}
         env:
           EXACT_ITEM: ${{ github.event.client_payload.item_number || github.event.inputs.item_number || github.event.inputs.item_numbers || '' }}
           GH_TOKEN: ${{ github.token }}
@@ -2226,13 +2301,14 @@ jobs:
             --message "chore: update sweep records" \
             --path "records/${target_slug}" \
             --rebase-strategy reconcile-records
+          echo "records_published=true" >> "$GITHUB_OUTPUT"
           pnpm run repair:publish-main -- \
             --message "chore: update sweep status" \
             --path "results/sweep-status/${target_slug}.json" \
             --rebase-strategy theirs
 
       - name: Dispatch reproducible bug implementation candidates
-        if: ${{ success() && vars.CLAWSWEEPER_AUTO_IMPLEMENT_ISSUES == '1' && needs.plan.outputs.target_repo == 'openclaw/openclaw' && vars.CLAWSWEEPER_AUTO_IMPLEMENT_REPRO_BUGS == '1' }}
+        if: ${{ always() && !cancelled() && steps.commit-review-records.outputs.records_published == 'true' && vars.CLAWSWEEPER_AUTO_IMPLEMENT_ISSUES == '1' && needs.plan.outputs.target_repo == 'openclaw/openclaw' && vars.CLAWSWEEPER_AUTO_IMPLEMENT_REPRO_BUGS == '1' }}
         env:
           GH_TOKEN: ${{ github.token }}
           TARGET_REPO: ${{ needs.plan.outputs.target_repo }}
@@ -2288,7 +2364,7 @@ jobs:
           done < /tmp/issue-implementation-candidates.tsv
 
       - name: Dispatch vision-fit implementation candidates
-        if: ${{ success() && vars.CLAWSWEEPER_AUTO_IMPLEMENT_ISSUES == '1' && needs.plan.outputs.target_repo == 'openclaw/openclaw' && vars.CLAWSWEEPER_AUTO_IMPLEMENT_VISION_FIT == '1' }}
+        if: ${{ always() && !cancelled() && steps.commit-review-records.outputs.records_published == 'true' && vars.CLAWSWEEPER_AUTO_IMPLEMENT_ISSUES == '1' && needs.plan.outputs.target_repo == 'openclaw/openclaw' && vars.CLAWSWEEPER_AUTO_IMPLEMENT_VISION_FIT == '1' }}
         env:
           GH_TOKEN: ${{ github.token }}
           TARGET_REPO: ${{ needs.plan.outputs.target_repo }}
@@ -2344,7 +2420,7 @@ jobs:
           done < /tmp/vision-fit-implementation-candidates.tsv
 
       - name: Backfill viable open issue implementation candidates
-        if: ${{ success() && vars.CLAWSWEEPER_AUTO_IMPLEMENT_ISSUES == '1' && steps.target-write-token.outputs.token != '' && needs.plan.outputs.target_repo != 'openclaw/openclaw' && needs.plan.outputs.target_repo != 'openclaw/clawhub' }}
+        if: ${{ always() && !cancelled() && steps.commit-review-records.outputs.records_published == 'true' && vars.CLAWSWEEPER_AUTO_IMPLEMENT_ISSUES == '1' && steps.target-write-token.outputs.token != '' && needs.plan.outputs.target_repo != 'openclaw/openclaw' && needs.plan.outputs.target_repo != 'openclaw/clawhub' }}
         env:
           GH_TOKEN: ${{ github.token }}
           TARGET_REPO: ${{ needs.plan.outputs.target_repo }}
@@ -2389,7 +2465,7 @@ jobs:
           done < /tmp/viable-implementation-candidates.tsv
 
       - name: Dispatch background review comment sync
-        if: ${{ success() && steps.target-write-token.outputs.token != '' && needs.plan.outputs.hot_intake != 'true' && (github.event_name != 'repository_dispatch' || github.event.action == 'clawsweeper_target_sweep') && (github.event_name != 'workflow_dispatch' || (github.event.inputs.item_number == '' && github.event.inputs.item_numbers == '')) }}
+        if: ${{ always() && !cancelled() && steps.commit-review-records.outputs.records_published == 'true' && steps.target-write-token.outputs.token != '' && needs.plan.outputs.hot_intake != 'true' && (github.event_name != 'repository_dispatch' || github.event.action == 'clawsweeper_target_sweep') && (github.event_name != 'workflow_dispatch' || (github.event.inputs.item_number == '' && github.event.inputs.item_numbers == '')) }}
         env:
           GH_TOKEN: ${{ github.token }}
           TARGET_REPO: ${{ needs.plan.outputs.target_repo }}
@@ -2418,7 +2494,7 @@ jobs:
 
       - name: Sync selected review comments
         id: sync-selected-review-comments
-        if: ${{ success() && steps.target-write-token.outputs.token != '' && ((github.event_name == 'repository_dispatch' && github.event.action != 'clawsweeper_target_sweep') || github.event.inputs.item_number != '' || github.event.inputs.item_numbers != '') }}
+        if: ${{ always() && !cancelled() && steps.commit-review-records.outputs.records_published == 'true' && steps.target-write-token.outputs.token != '' && ((github.event_name == 'repository_dispatch' && github.event.action != 'clawsweeper_target_sweep') || github.event.inputs.item_number != '' || github.event.inputs.item_numbers != '') }}
         timeout-minutes: 15
         env:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
@@ -2561,7 +2637,7 @@ jobs:
           exit 1
 
       - name: Continue sweep
-        if: ${{ success() && needs.plan.outputs.planned_count == needs.plan.outputs.planned_capacity && github.event_name != 'repository_dispatch' && (github.event_name != 'workflow_dispatch' || (github.event.inputs.item_number == '' && github.event.inputs.item_numbers == '')) }}
+        if: ${{ always() && !cancelled() && steps.apply-review-artifacts.outputs.review_batch_succeeded == 'true' && steps.commit-review-records.outputs.records_published == 'true' && needs.plan.outputs.planned_count == needs.plan.outputs.planned_capacity && github.event_name != 'repository_dispatch' && (github.event_name != 'workflow_dispatch' || (github.event.inputs.item_number == '' && github.event.inputs.item_numbers == '')) }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -2693,6 +2769,7 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup-action-ledger
+        continue-on-error: true
 
       - name: Create state token
         id: state-token
@@ -2971,6 +3048,7 @@ jobs:
           persist-credentials: false
 
       - uses: ./.github/actions/setup-action-ledger
+        continue-on-error: true
 
       - name: Resolve proof target repository
         id: target
@@ -3116,7 +3194,7 @@ jobs:
 
       - name: Export primary apply proof result
         id: primary-proof-result
-        if: ${{ success() && (steps.proof-select.outputs.item_numbers == '' || steps.generate-apply-proofs.outcome == 'success') }}
+        if: ${{ always() && !cancelled() && steps.proof-select.outcome == 'success' && (steps.proof-select.outputs.item_numbers == '' || steps.generate-apply-proofs.outcome == 'success') }}
         run: echo "ready=true" >> "$GITHUB_OUTPUT"
 
       - name: Finalize apply proof action ledger
@@ -3249,6 +3327,7 @@ jobs:
           persist-credentials: false
 
       - uses: ./.github/actions/setup-action-ledger
+        continue-on-error: true
 
       - name: Resolve target repository
         id: target
@@ -3709,6 +3788,11 @@ jobs:
             echo "APPLY_CANDIDATE_QUALITY_SUMMARY=$candidate_quality_summary"
           } >> "$GITHUB_ENV"
 
+      - name: Export primary apply result
+        id: primary-apply-result
+        if: ${{ always() && !cancelled() && steps.apply-existing-run.outcome == 'success' }}
+        run: echo "succeeded=true" >> "$GITHUB_OUTPUT"
+
       - name: Finalize apply action ledger
         if: ${{ always() }}
         env:
@@ -3723,6 +3807,7 @@ jobs:
           pnpm run --silent finalize-action-events -- "${args[@]}"
 
       - name: Retry final apply status publication
+        if: ${{ always() && !cancelled() && steps.primary-apply-result.outputs.succeeded == 'true' }}
         run: |
           if [ "${APPLY_NOOP:-false}" = "true" ]; then
             echo "No proposed closes were ready; no final apply status to retry."
@@ -3768,7 +3853,7 @@ jobs:
             --message "chore: append apply action ledger"
 
       - name: Continue apply sweep
-        if: ${{ success() }}
+        if: ${{ always() && !cancelled() && steps.primary-apply-result.outputs.succeeded == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -3859,7 +3944,7 @@ jobs:
             -f apply_checkpoint_size="$APPLY_CHECKPOINT_SIZE"
 
       - name: Queue review backstops
-        if: ${{ success() && steps.target.outputs.target_repo == 'openclaw/openclaw' }}
+        if: ${{ always() && !cancelled() && steps.primary-apply-result.outputs.succeeded == 'true' && steps.target.outputs.target_repo == 'openclaw/openclaw' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2434,7 +2434,8 @@ jobs:
             exit 0
           fi
           git pull --rebase --autostash
-          pnpm run apply-decisions -- \
+          set +e
+          timeout --kill-after=30s 840s pnpm run apply-decisions -- \
             --target-repo "$TARGET_REPO" \
             --skip-dashboard \
             --item-numbers "$item_numbers" \
@@ -2445,6 +2446,12 @@ jobs:
             --max-runtime-ms 720000 \
             --comment-sync-min-age-days 7 \
             --progress-every 25
+          selected_comment_exit_code=$?
+          set -e
+          echo "exit_code=$selected_comment_exit_code" >> "$GITHUB_OUTPUT"
+          if [ "$selected_comment_exit_code" -ne 0 ]; then
+            exit "$selected_comment_exit_code"
+          fi
           synced_count="$(pnpm run --silent workflow -- count-actions --report apply-report.json --action review_comment_synced)"
           pnpm run status -- \
             --target-repo "$TARGET_REPO" \
@@ -2468,8 +2475,25 @@ jobs:
             --path "results/sweep-status/${target_slug}.json" \
             --rebase-strategy theirs
 
-      - name: Publish selected review comment action ledger
+      - name: Finalize selected review comment action ledger
+        id: finalize-selected-review-comment-action-ledger
         if: ${{ always() && steps.sync-selected-review-comments.outcome != 'skipped' }}
+        env:
+          SELECTED_COMMENT_EXIT_CODE: ${{ steps.sync-selected-review-comments.outputs.exit_code || '' }}
+          SELECTED_COMMENT_OUTCOME: ${{ steps.sync-selected-review-comments.outcome || 'not_started' }}
+        run: |
+          args=()
+          if [ "$SELECTED_COMMENT_OUTCOME" = "cancelled" ] || [ "$SELECTED_COMMENT_EXIT_CODE" = "130" ] || [ "$SELECTED_COMMENT_EXIT_CODE" = "143" ]; then
+            args=(--interrupt-open-attempts --reason cancelled)
+          elif [ "$SELECTED_COMMENT_EXIT_CODE" = "124" ] || [ "$SELECTED_COMMENT_EXIT_CODE" = "137" ]; then
+            args=(--interrupt-open-attempts --reason timeout)
+          elif [ "$SELECTED_COMMENT_OUTCOME" != "success" ]; then
+            args=(--interrupt-open-attempts --reason workflow_failed)
+          fi
+          pnpm run --silent finalize-action-events -- "${args[@]}"
+
+      - name: Publish selected review comment action ledger
+        if: ${{ always() && steps.sync-selected-review-comments.outcome != 'skipped' && steps.finalize-selected-review-comment-action-ledger.outcome == 'success' }}
         run: |
           set -euo pipefail
           test -n "${CLAWSWEEPER_STATE_DIR:-}"
@@ -2785,6 +2809,18 @@ jobs:
           path: artifacts/failed-review-retry-report.json
           if-no-files-found: error
           retention-days: 14
+
+      - name: Restore failed-review retry outcome
+        if: ${{ always() && steps.retry-failed-reviews-run.outcome != 'success' && steps.retry-failed-reviews-run.outcome != 'skipped' }}
+        env:
+          RETRY_EXIT_CODE: ${{ steps.retry-failed-reviews-run.outputs.exit_code || '1' }}
+        run: |
+          retry_exit_code="$RETRY_EXIT_CODE"
+          if ! [[ "$retry_exit_code" =~ ^[1-9][0-9]*$ ]] || [ "$retry_exit_code" -gt 255 ]; then
+            retry_exit_code=1
+          fi
+          echo "Restoring failed-review retry exit code $retry_exit_code after ledger cleanup."
+          exit "$retry_exit_code"
 
   audit-dashboard:
     name: Audit state

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1095,18 +1095,15 @@ jobs:
             echo "Exact event action shards existed but no paths were imported." >&2
             exit 1
           fi
-          action_ledger_args=()
           while IFS= read -r event_path; do
             durable_event_path="$CLAWSWEEPER_STATE_DIR/$event_path"
             test -f "$durable_event_path"
             mkdir -p "$(dirname "$event_path")"
             cp "$durable_event_path" "$event_path"
-            action_ledger_args+=(--path "$event_path")
           done < "$event_paths_file"
-          pnpm run repair:publish-main -- \
-            --message "chore: append exact event action ledger" \
-            "${action_ledger_args[@]}" \
-            --rebase-strategy normal
+          node dist/clawsweeper.js publish-action-event-paths \
+            --paths-file "$event_paths_file" \
+            --message "chore: append exact event action ledger"
 
       - name: Complete exact-review queue lease
         id: complete-exact-review-queue
@@ -2126,14 +2123,9 @@ jobs:
             echo "No immutable review action events to publish."
             exit 0
           fi
-          action_ledger_args=()
-          while IFS= read -r event_path; do
-            action_ledger_args+=(--path "$event_path")
-          done < .artifacts/action-ledger-paths.txt
-          pnpm run repair:publish-main -- \
-            --message "chore: append review action ledger" \
-            "${action_ledger_args[@]}" \
-            --rebase-strategy normal
+          node dist/clawsweeper.js publish-action-event-paths \
+            --paths-file .artifacts/action-ledger-paths.txt \
+            --message "chore: append review action ledger"
 
       - name: Sync before applying artifacts
         run: git pull --rebase --autostash
@@ -2193,18 +2185,15 @@ jobs:
             echo "Review artifact action event shards existed but no paths were imported." >&2
             exit 1
           fi
-          action_ledger_args=()
           while IFS= read -r event_path; do
             durable_event_path="$CLAWSWEEPER_STATE_DIR/$event_path"
             test -f "$durable_event_path"
             mkdir -p "$(dirname "$event_path")"
             cp "$durable_event_path" "$event_path"
-            action_ledger_args+=(--path "$event_path")
           done < "$event_paths_file"
-          pnpm run repair:publish-main -- \
-            --message "chore: append review artifact action ledger" \
-            "${action_ledger_args[@]}" \
-            --rebase-strategy normal
+          node dist/clawsweeper.js publish-action-event-paths \
+            --paths-file "$event_paths_file" \
+            --message "chore: append review artifact action ledger"
 
       - name: Commit review records
         env:
@@ -2486,18 +2475,15 @@ jobs:
             echo "Selected review comment action shards existed but no paths were imported." >&2
             exit 1
           fi
-          action_ledger_args=()
           while IFS= read -r event_path; do
             durable_event_path="$CLAWSWEEPER_STATE_DIR/$event_path"
             test -f "$durable_event_path"
             mkdir -p "$(dirname "$event_path")"
             cp "$durable_event_path" "$event_path"
-            action_ledger_args+=(--path "$event_path")
           done < "$event_paths_file"
-          pnpm run repair:publish-main -- \
-            --message "chore: append selected review comment action ledger" \
-            "${action_ledger_args[@]}" \
-            --rebase-strategy normal
+          node dist/clawsweeper.js publish-action-event-paths \
+            --paths-file "$event_paths_file" \
+            --message "chore: append selected review comment action ledger"
 
       - name: Dispatch selected safe close proposals to isolated apply
         if: ${{ success() && steps.target-write-token.outputs.token != '' && github.event.inputs.apply_after_review == 'true' }}
@@ -2685,6 +2671,7 @@ jobs:
           build-script: build:all
 
       - name: Plan or dispatch failed-review retries
+        id: retry-failed-reviews-run
         env:
           GH_TOKEN: ${{ github.token }}
           TARGET_REPO: openclaw/openclaw
@@ -2715,6 +2702,17 @@ jobs:
             --report-path artifacts/failed-review-retry-report.json \
             "${dry_run_arg[@]}"
 
+      - name: Finalize failed-review retry action ledger
+        if: ${{ always() }}
+        env:
+          RETRY_OUTCOME: ${{ steps.retry-failed-reviews-run.outcome || 'not_started' }}
+        run: |
+          args=()
+          if [ "$RETRY_OUTCOME" != "success" ]; then
+            args=(--interrupt-open-attempts --reason timeout)
+          fi
+          pnpm run --silent finalize-action-events -- "${args[@]}"
+
       - name: Publish failed-review retry state
         if: ${{ always() && vars.CLAWSWEEPER_FAILED_REVIEW_RETRY_ENABLED == '1' && hashFiles('results/failed-review-retries/openclaw-openclaw/*.json') != '' }}
         run: |
@@ -2744,18 +2742,15 @@ jobs:
             echo "Failed-review retry action shards existed but no paths were imported." >&2
             exit 1
           fi
-          action_ledger_args=()
           while IFS= read -r event_path; do
             durable_event_path="$CLAWSWEEPER_STATE_DIR/$event_path"
             test -f "$durable_event_path"
             mkdir -p "$(dirname "$event_path")"
             cp "$durable_event_path" "$event_path"
-            action_ledger_args+=(--path "$event_path")
           done < "$event_paths_file"
-          pnpm run repair:publish-main -- \
-            --message "chore: append failed review retry action ledger" \
-            "${action_ledger_args[@]}" \
-            --rebase-strategy normal
+          node dist/clawsweeper.js publish-action-event-paths \
+            --paths-file "$event_paths_file" \
+            --message "chore: append failed review retry action ledger"
 
       - uses: actions/upload-artifact@v7
         if: ${{ always() }}
@@ -3151,18 +3146,15 @@ jobs:
             echo "Apply proof action event shards existed but no paths were imported." >&2
             exit 1
           fi
-          action_ledger_args=()
           while IFS= read -r event_path; do
             durable_event_path="$CLAWSWEEPER_STATE_DIR/$event_path"
             test -f "$durable_event_path"
             mkdir -p "$(dirname "$event_path")"
             cp "$durable_event_path" "$event_path"
-            action_ledger_args+=(--path "$event_path")
           done < "$event_paths_file"
-          pnpm run repair:publish-main -- \
-            --message "chore: append apply proof action ledger" \
-            "${action_ledger_args[@]}" \
-            --rebase-strategy normal
+          node dist/clawsweeper.js publish-action-event-paths \
+            --paths-file "$event_paths_file" \
+            --message "chore: append apply proof action ledger"
 
   apply-existing:
     name: Apply close proposals
@@ -3690,18 +3682,15 @@ jobs:
             echo "Apply action event shards existed but no paths were imported." >&2
             exit 1
           fi
-          action_ledger_args=()
           while IFS= read -r event_path; do
             durable_event_path="$CLAWSWEEPER_STATE_DIR/$event_path"
             test -f "$durable_event_path"
             mkdir -p "$(dirname "$event_path")"
             cp "$durable_event_path" "$event_path"
-            action_ledger_args+=(--path "$event_path")
           done < "$event_paths_file"
-          pnpm run repair:publish-main -- \
-            --message "chore: append apply action ledger" \
-            "${action_ledger_args[@]}" \
-            --rebase-strategy normal
+          node dist/clawsweeper.js publish-action-event-paths \
+            --paths-file "$event_paths_file" \
+            --message "chore: append apply action ledger"
 
       - name: Continue apply sweep
         if: ${{ success() }}

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -443,6 +443,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - uses: ./.github/actions/setup-action-ledger
+
       - name: Resolve event payload
         id: target
         env:
@@ -729,6 +731,7 @@ jobs:
           media_preprocessing_reserve_seconds=480
           review_timeout_seconds=$((codex_timeout_seconds + media_preprocessing_reserve_seconds + 180))
           echo "::notice::Exact event review timeout is ${review_timeout_seconds}s for per-item Codex timeout ${codex_timeout_seconds}s, reserved media preprocessing ${media_preprocessing_reserve_seconds}s, and detected media allowance ${media_proof_timeout_seconds}s."
+          set +e
           timeout --kill-after=30s "${review_timeout_seconds}s" pnpm run review -- \
             --target-repo "${{ steps.target.outputs.target_repo }}" \
             --target-dir "${{ steps.target.outputs.target_checkout_dir }}" \
@@ -744,6 +747,12 @@ jobs:
             --shard-index 0 \
             --shard-count 1 \
             "${additional_prompt_arg[@]}"
+          review_exit_code=$?
+          set -e
+          echo "exit_code=$review_exit_code" >> "$GITHUB_OUTPUT"
+          if [ "$review_exit_code" -ne 0 ]; then
+            exit "$review_exit_code"
+          fi
 
           coordination_held_path="artifacts/event/coordination-held.json"
           if [ -f "$coordination_held_path" ]; then
@@ -770,7 +779,14 @@ jobs:
 
       - name: Finalize exact event action ledger
         if: ${{ always() && steps.live-item.outputs.proceed == 'true' }}
-        run: pnpm run --silent finalize-action-events
+        env:
+          REVIEW_EXIT_CODE: ${{ steps.review-exact-event-item.outputs.exit_code || '' }}
+        run: |
+          args=()
+          if [ "$REVIEW_EXIT_CODE" = "124" ] || [ "$REVIEW_EXIT_CODE" = "137" ]; then
+            args=(--interrupt-open-attempts --reason timeout)
+          fi
+          pnpm run --silent finalize-action-events -- "${args[@]}"
 
       - name: Create state token
         id: state-token
@@ -1684,6 +1700,7 @@ jobs:
     timeout-minutes: 75
     continue-on-error: true
     permissions:
+      actions: read
       checks: read
       contents: read
       issues: read
@@ -1700,6 +1717,10 @@ jobs:
           filter: blob:none
           fetch-depth: 1
           persist-credentials: false
+
+      - uses: ./clawsweeper/.github/actions/setup-action-ledger
+        with:
+          worktree-path: clawsweeper
 
       - name: Create target review token
         id: target-read-token
@@ -1834,6 +1855,7 @@ jobs:
             review_timeout_seconds=4200
           fi
           echo "::notice::Review shard timeout is ${review_timeout_seconds}s for batch size ${{ needs.plan.outputs.batch_size }} and per-item Codex timeout ${codex_timeout_seconds}s."
+          set +e
           timeout --kill-after=30s "${review_timeout_seconds}s" node dist/clawsweeper.js review \
             --target-repo "${{ needs.plan.outputs.target_repo }}" \
             --target-dir "../${{ needs.plan.outputs.target_checkout_dir }}" \
@@ -1852,11 +1874,22 @@ jobs:
             --shard-count ${{ needs.plan.outputs.planned_shards }} \
             "${additional_prompt_arg[@]}" \
             "${expected_source_revision_arg[@]}"
+          review_exit_code=$?
+          set -e
+          echo "exit_code=$review_exit_code" >> "$GITHUB_OUTPUT"
+          exit "$review_exit_code"
 
       - name: Finalize review action ledger
         if: always()
         working-directory: clawsweeper
-        run: node dist/clawsweeper.js finalize-action-events
+        env:
+          REVIEW_EXIT_CODE: ${{ steps.review-shard.outputs.exit_code || '' }}
+        run: |
+          args=()
+          if [ "$REVIEW_EXIT_CODE" = "124" ] || [ "$REVIEW_EXIT_CODE" = "137" ]; then
+            args=(--interrupt-open-attempts --reason timeout)
+          fi
+          node dist/clawsweeper.js finalize-action-events "${args[@]}"
 
       - name: Record shard metrics
         if: always()
@@ -2014,6 +2047,8 @@ jobs:
           filter: blob:none
           fetch-depth: 0
           persist-credentials: false
+
+      - uses: ./.github/actions/setup-action-ledger
 
       - name: Create target write token
         id: target-write-token
@@ -2632,6 +2667,8 @@ jobs:
           filter: blob:none
           fetch-depth: 0
 
+      - uses: ./.github/actions/setup-action-ledger
+
       - name: Create state token
         id: state-token
         uses: ./.github/actions/create-state-token
@@ -2856,6 +2893,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
+      actions: read
       contents: read
       issues: read
       pull-requests: read
@@ -2872,6 +2910,8 @@ jobs:
           filter: blob:none
           fetch-depth: 1
           persist-credentials: false
+
+      - uses: ./.github/actions/setup-action-ledger
 
       - name: Resolve proof target repository
         id: target
@@ -3135,6 +3175,8 @@ jobs:
           filter: blob:none
           fetch-depth: 0
           persist-credentials: false
+
+      - uses: ./.github/actions/setup-action-ledger
 
       - name: Resolve target repository
         id: target

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -740,7 +740,7 @@ jobs:
             --max-pages 1 \
             --codex-model internal \
             --codex-reasoning-effort high \
-            --codex-sandbox danger-full-access \
+            --codex-sandbox read-only \
             --codex-timeout-ms "$codex_timeout_ms" \
             --item-numbers "${{ steps.target.outputs.item_number }}" \
             --readonly-openclaw \
@@ -781,10 +781,15 @@ jobs:
         if: ${{ always() && steps.live-item.outputs.proceed == 'true' }}
         env:
           REVIEW_EXIT_CODE: ${{ steps.review-exact-event-item.outputs.exit_code || '' }}
+          REVIEW_OUTCOME: ${{ steps.review-exact-event-item.outcome || 'not_started' }}
         run: |
           args=()
-          if [ "$REVIEW_EXIT_CODE" = "124" ] || [ "$REVIEW_EXIT_CODE" = "137" ]; then
+          if [ "$REVIEW_OUTCOME" = "cancelled" ] || [ "$REVIEW_EXIT_CODE" = "130" ] || [ "$REVIEW_EXIT_CODE" = "143" ]; then
+            args=(--interrupt-open-attempts --reason cancelled)
+          elif [ "$REVIEW_EXIT_CODE" = "124" ] || [ "$REVIEW_EXIT_CODE" = "137" ]; then
             args=(--interrupt-open-attempts --reason timeout)
+          elif [ "$REVIEW_OUTCOME" != "success" ]; then
+            args=(--interrupt-open-attempts --reason workflow_failed)
           fi
           pnpm run --silent finalize-action-events -- "${args[@]}"
 
@@ -1080,15 +1085,16 @@ jobs:
         run: |
           set -euo pipefail
           test -n "${CLAWSWEEPER_STATE_DIR:-}"
-          if [ ! -d .clawsweeper-repair/action-ledger-state/ledger ]; then
+          if [ ! -d "$CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT/ledger" ]; then
             echo "No exact event action shards were finalized."
             exit 0
           fi
           event_paths_file=".artifacts/exact-event-action-ledger-paths.txt"
           mkdir -p .artifacts
           pnpm run --silent publish-action-events -- \
-            --source-root .clawsweeper-repair/action-ledger-state \
-            --state-root "$CLAWSWEEPER_STATE_DIR" |
+            --source-root "$CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT" \
+            --state-root "$CLAWSWEEPER_STATE_DIR" \
+            --expected-producer-job "$GITHUB_JOB" |
             jq -r '.paths[]?' |
             sort -u > "$event_paths_file"
           if [ ! -s "$event_paths_file" ]; then
@@ -1631,7 +1637,7 @@ jobs:
             --shard-count "$SHARD_COUNT" \
             --codex-model internal \
             --codex-reasoning-effort high \
-            --codex-sandbox danger-full-access \
+            --codex-sandbox read-only \
             --min-active-shards "$MIN_ACTIVE_SHARDS" \
             --min-backfill-review-age-minutes "$MIN_BACKFILL_REVIEW_AGE_MINUTES" \
             "${hot_intake_arg[@]}" \
@@ -1861,7 +1867,7 @@ jobs:
             --max-pages ${{ needs.plan.outputs.max_pages }} \
             --codex-model internal \
             --codex-reasoning-effort high \
-            --codex-sandbox danger-full-access \
+            --codex-sandbox read-only \
             --codex-timeout-ms ${{ needs.plan.outputs.codex_timeout_ms }} \
             --item-numbers "${{ matrix.item_numbers }}" \
             "${planned_automatic_review_arg[@]}" \
@@ -1881,10 +1887,15 @@ jobs:
         working-directory: clawsweeper
         env:
           REVIEW_EXIT_CODE: ${{ steps.review-shard.outputs.exit_code || '' }}
+          REVIEW_OUTCOME: ${{ steps.review-shard.outcome || 'not_started' }}
         run: |
           args=()
-          if [ "$REVIEW_EXIT_CODE" = "124" ] || [ "$REVIEW_EXIT_CODE" = "137" ]; then
+          if [ "$REVIEW_OUTCOME" = "cancelled" ] || [ "$REVIEW_EXIT_CODE" = "130" ] || [ "$REVIEW_EXIT_CODE" = "143" ]; then
+            args=(--interrupt-open-attempts --reason cancelled)
+          elif [ "$REVIEW_EXIT_CODE" = "124" ] || [ "$REVIEW_EXIT_CODE" = "137" ]; then
             args=(--interrupt-open-attempts --reason timeout)
+          elif [ "$REVIEW_OUTCOME" != "success" ]; then
+            args=(--interrupt-open-attempts --reason workflow_failed)
           fi
           node dist/clawsweeper.js finalize-action-events "${args[@]}"
 
@@ -1938,7 +1949,7 @@ jobs:
         if: always()
         with:
           name: action-ledger-review-${{ matrix.shard }}
-          path: clawsweeper/.clawsweeper-repair/action-ledger-state/**
+          path: ${{ runner.temp }}/clawsweeper-action-ledger/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}/**
           include-hidden-files: true
           if-no-files-found: ignore
 
@@ -2100,15 +2111,16 @@ jobs:
           test -n "${CLAWSWEEPER_STATE_DIR:-}"
           mkdir -p .artifacts
           : > .artifacts/action-ledger-paths.txt
-          for source_root in \
-            .clawsweeper-repair/action-ledger-download \
-            .clawsweeper-repair/action-ledger-state
-          do
-            pnpm run --silent publish-action-events -- \
-              --source-root "$source_root" \
-              --state-root "$CLAWSWEEPER_STATE_DIR" |
-              jq -r '.paths[]?' >> .artifacts/action-ledger-paths.txt
-          done
+          pnpm run --silent publish-action-events -- \
+            --source-root .clawsweeper-repair/action-ledger-download \
+            --state-root "$CLAWSWEEPER_STATE_DIR" \
+            --expected-producer-job review |
+            jq -r '.paths[]?' >> .artifacts/action-ledger-paths.txt
+          pnpm run --silent publish-action-events -- \
+            --source-root "$CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT" \
+            --state-root "$CLAWSWEEPER_STATE_DIR" \
+            --expected-producer-job "$GITHUB_JOB" |
+            jq -r '.paths[]?' >> .artifacts/action-ledger-paths.txt
           sort -u -o .artifacts/action-ledger-paths.txt .artifacts/action-ledger-paths.txt
           while IFS= read -r event_path; do
             durable_event_path="$CLAWSWEEPER_STATE_DIR/$event_path"
@@ -2169,7 +2181,7 @@ jobs:
         run: |
           set -euo pipefail
           test -n "${CLAWSWEEPER_STATE_DIR:-}"
-          source_root=".clawsweeper-repair/action-ledger-state"
+          source_root="$CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT"
           if [ ! -d "$source_root/ledger" ]; then
             echo "No review artifact action event shards were finalized."
             exit 0
@@ -2178,7 +2190,8 @@ jobs:
           mkdir -p .artifacts
           pnpm run --silent publish-action-events -- \
             --source-root "$source_root" \
-            --state-root "$CLAWSWEEPER_STATE_DIR" |
+            --state-root "$CLAWSWEEPER_STATE_DIR" \
+            --expected-producer-job "$GITHUB_JOB" |
             jq -r '.paths[]?' |
             sort -u > "$event_paths_file"
           if [ ! -s "$event_paths_file" ]; then
@@ -2460,15 +2473,16 @@ jobs:
         run: |
           set -euo pipefail
           test -n "${CLAWSWEEPER_STATE_DIR:-}"
-          if [ ! -d .clawsweeper-repair/action-ledger-state/ledger ]; then
+          if [ ! -d "$CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT/ledger" ]; then
             echo "No selected review comment action shards were finalized."
             exit 0
           fi
           event_paths_file=".artifacts/selected-comment-action-ledger-paths.txt"
           mkdir -p .artifacts
           pnpm run --silent publish-action-events -- \
-            --source-root .clawsweeper-repair/action-ledger-state \
-            --state-root "$CLAWSWEEPER_STATE_DIR" |
+            --source-root "$CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT" \
+            --state-root "$CLAWSWEEPER_STATE_DIR" \
+            --expected-producer-job "$GITHUB_JOB" |
             jq -r '.paths[]?' |
             sort -u > "$event_paths_file"
           if [ ! -s "$event_paths_file" ]; then
@@ -2672,6 +2686,7 @@ jobs:
 
       - name: Plan or dispatch failed-review retries
         id: retry-failed-reviews-run
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           TARGET_REPO: openclaw/openclaw
@@ -2689,6 +2704,7 @@ jobs:
             dry_run_arg=(--dry-run)
             echo "::notice::Failed-review retry is running in dry-run mode. Set CLAWSWEEPER_FAILED_REVIEW_RETRY_ENABLED=1 to dispatch exact-item retries."
           fi
+          set +e
           pnpm run retry-failed-reviews -- \
             --target-repo "$TARGET_REPO" \
             --limit "$RETRY_LIMIT" \
@@ -2701,15 +2717,24 @@ jobs:
             --state-dir results/failed-review-retries/openclaw-openclaw \
             --report-path artifacts/failed-review-retry-report.json \
             "${dry_run_arg[@]}"
+          retry_exit_code=$?
+          set -e
+          echo "exit_code=$retry_exit_code" >> "$GITHUB_OUTPUT"
+          exit "$retry_exit_code"
 
       - name: Finalize failed-review retry action ledger
         if: ${{ always() }}
         env:
+          RETRY_EXIT_CODE: ${{ steps.retry-failed-reviews-run.outputs.exit_code || '' }}
           RETRY_OUTCOME: ${{ steps.retry-failed-reviews-run.outcome || 'not_started' }}
         run: |
           args=()
-          if [ "$RETRY_OUTCOME" != "success" ]; then
+          if [ "$RETRY_OUTCOME" = "cancelled" ] || [ "$RETRY_EXIT_CODE" = "130" ] || [ "$RETRY_EXIT_CODE" = "143" ]; then
+            args=(--interrupt-open-attempts --reason cancelled)
+          elif [ "$RETRY_EXIT_CODE" = "124" ] || [ "$RETRY_EXIT_CODE" = "137" ]; then
             args=(--interrupt-open-attempts --reason timeout)
+          elif [ "$RETRY_OUTCOME" != "success" ]; then
+            args=(--interrupt-open-attempts --reason workflow_failed)
           fi
           pnpm run --silent finalize-action-events -- "${args[@]}"
 
@@ -2726,7 +2751,7 @@ jobs:
         run: |
           set -euo pipefail
           test -n "${CLAWSWEEPER_STATE_DIR:-}"
-          source_root=".clawsweeper-repair/action-ledger-state"
+          source_root="$CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT"
           if [ ! -d "$source_root/ledger" ]; then
             echo "No failed-review retry action event shards were finalized."
             exit 0
@@ -2735,7 +2760,8 @@ jobs:
           mkdir -p .artifacts
           pnpm run --silent publish-action-events -- \
             --source-root "$source_root" \
-            --state-root "$CLAWSWEEPER_STATE_DIR" |
+            --state-root "$CLAWSWEEPER_STATE_DIR" \
+            --expected-producer-job "$GITHUB_JOB" |
             jq -r '.paths[]?' |
             sort -u > "$event_paths_file"
           if [ ! -s "$event_paths_file" ]; then
@@ -3056,8 +3082,10 @@ jobs:
           APPLY_PROOF_OUTCOME: ${{ steps.generate-apply-proofs.outcome || 'not_started' }}
         run: |
           args=()
-          if [ "$APPLY_PROOF_OUTCOME" != "success" ]; then
-            args=(--interrupt-open-attempts --reason timeout)
+          if [ "$APPLY_PROOF_OUTCOME" = "cancelled" ]; then
+            args=(--interrupt-open-attempts --reason cancelled)
+          elif [ "$APPLY_PROOF_OUTCOME" != "success" ]; then
+            args=(--interrupt-open-attempts --reason workflow_failed)
           fi
           pnpm run --silent finalize-action-events -- "${args[@]}"
 
@@ -3076,7 +3104,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.proof-artifact.outputs.action_ledger_name }}
-          path: .clawsweeper-repair/action-ledger-state/**
+          path: ${{ runner.temp }}/clawsweeper-action-ledger/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}/**
           include-hidden-files: true
           if-no-files-found: error
           retention-days: 7
@@ -3139,7 +3167,8 @@ jobs:
           mkdir -p .artifacts
           pnpm run --silent publish-action-events -- \
             --source-root "$source_root" \
-            --state-root "$CLAWSWEEPER_STATE_DIR" |
+            --state-root "$CLAWSWEEPER_STATE_DIR" \
+            --expected-producer-job apply-proof |
             jq -r '.paths[]?' |
             sort -u > "$event_paths_file"
           if [ ! -s "$event_paths_file" ]; then
@@ -3643,8 +3672,10 @@ jobs:
           APPLY_OUTCOME: ${{ steps.apply-existing-run.outcome || 'not_started' }}
         run: |
           args=()
-          if [ "$APPLY_OUTCOME" != "success" ]; then
-            args=(--interrupt-open-attempts --reason timeout)
+          if [ "$APPLY_OUTCOME" = "cancelled" ]; then
+            args=(--interrupt-open-attempts --reason cancelled)
+          elif [ "$APPLY_OUTCOME" != "success" ]; then
+            args=(--interrupt-open-attempts --reason workflow_failed)
           fi
           pnpm run --silent finalize-action-events -- "${args[@]}"
 
@@ -3666,7 +3697,7 @@ jobs:
         run: |
           set -euo pipefail
           test -n "${CLAWSWEEPER_STATE_DIR:-}"
-          source_root=".clawsweeper-repair/action-ledger-state"
+          source_root="$CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT"
           if [ ! -d "$source_root/ledger" ]; then
             echo "No apply action event shards were finalized."
             exit 0
@@ -3675,7 +3706,8 @@ jobs:
           mkdir -p .artifacts
           pnpm run --silent publish-action-events -- \
             --source-root "$source_root" \
-            --state-root "$CLAWSWEEPER_STATE_DIR" |
+            --state-root "$CLAWSWEEPER_STATE_DIR" \
+            --expected-producer-job "$GITHUB_JOB" |
             jq -r '.paths[]?' |
             sort -u > "$event_paths_file"
           if [ ! -s "$event_paths_file" ]; then

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2452,6 +2452,7 @@ jobs:
           if [ "$selected_comment_exit_code" -ne 0 ]; then
             exit "$selected_comment_exit_code"
           fi
+          echo "sync_succeeded=true" >> "$GITHUB_OUTPUT"
           synced_count="$(pnpm run --silent workflow -- count-actions --report apply-report.json --action review_comment_synced)"
           pnpm run status -- \
             --target-repo "$TARGET_REPO" \
@@ -2524,7 +2525,7 @@ jobs:
             --message "chore: append selected review comment action ledger"
 
       - name: Dispatch selected safe close proposals to isolated apply
-        if: ${{ success() && steps.target-write-token.outputs.token != '' && github.event.inputs.apply_after_review == 'true' }}
+        if: ${{ always() && !cancelled() && steps.sync-selected-review-comments.outputs.sync_succeeded == 'true' && steps.target-write-token.outputs.token != '' && github.event.inputs.apply_after_review == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
           TARGET_REPO: ${{ needs.plan.outputs.target_repo }}
@@ -2960,6 +2961,7 @@ jobs:
     outputs:
       target_repo: ${{ steps.target.outputs.target_repo }}
       artifact_name: ${{ steps.proof-artifact.outputs.name }}
+      proof_ready: ${{ steps.primary-proof-result.outputs.ready }}
       action_ledger_artifact_name: ${{ steps.publishable-action-ledger.outputs.name }}
     steps:
       - uses: actions/checkout@v7
@@ -3112,6 +3114,11 @@ jobs:
             --report-path .artifacts/apply-proof/apply-report.json \
             --progress-every 1
 
+      - name: Export primary apply proof result
+        id: primary-proof-result
+        if: ${{ success() && (steps.proof-select.outputs.item_numbers == '' || steps.generate-apply-proofs.outcome == 'success') }}
+        run: echo "ready=true" >> "$GITHUB_OUTPUT"
+
       - name: Finalize apply proof action ledger
         if: ${{ always() && steps.proof-select.outputs.item_numbers != '' }}
         env:
@@ -3224,7 +3231,7 @@ jobs:
   apply-existing:
     name: Apply close proposals
     needs: [apply-proof, publish-apply-proof-action-ledger]
-    if: ${{ ((github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '3 * * * *' || github.event.schedule == '18 * * * *' || github.event.schedule == '33 * * * *' || github.event.schedule == '48 * * * *' || github.event.schedule == '8,23,38,53 * * * *' || github.event.schedule == '6,21,36,51 * * * *'))) && !(github.event_name == 'repository_dispatch' && github.event.client_payload.target_repo == 'openclaw/clawhub' && vars.CLAWSWEEPER_ENABLE_CLAWHUB != '1') && !(github.event_name == 'schedule' && github.event.schedule == '8,23,38,53 * * * *' && vars.CLAWSWEEPER_ENABLE_CLAWHUB != '1') }}
+    if: ${{ always() && !cancelled() && needs.apply-proof.outputs.proof_ready == 'true' && ((github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '3 * * * *' || github.event.schedule == '18 * * * *' || github.event.schedule == '33 * * * *' || github.event.schedule == '48 * * * *' || github.event.schedule == '8,23,38,53 * * * *' || github.event.schedule == '6,21,36,51 * * * *'))) && !(github.event_name == 'repository_dispatch' && github.event.client_payload.target_repo == 'openclaw/clawhub' && vars.CLAWSWEEPER_ENABLE_CLAWHUB != '1') && !(github.event_name == 'schedule' && github.event.schedule == '8,23,38,53 * * * *' && vars.CLAWSWEEPER_ENABLE_CLAWHUB != '1') }}
     runs-on: ubuntu-latest
     timeout-minutes: 360
     concurrency:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,14 +95,16 @@ checkpoint, and status-only commits are intentionally omitted.
   backstops cannot create permanent parallel continuation chains that overwhelm
   serialized review publication, while exact-item, apply, and comment-sync
   lanes remain independent.
-- Bound apply receipts to each actual GitHub request attempt, recorded lease
+- Bound apply receipts to each actual GitHub request attempt while preserving
+  stable business idempotency across transient retries, recorded review lease
   creation and cleanup independently, bound retry dispatches to review and
   decision digests, aggregated every exact-attempt mutation outcome, and made
-  pre-spawn budget exhaustion a definite no-mutation yield. Selected-comment
-  and failed-review retry lanes now finalize interrupted receipts before
-  publication, scheduled retry failures remain failed after cleanup, active
-  coverage-proof yields cannot become kept-open terminals, and review failure
-  retryability plus cancellation status survive finalization.
+  pre-spawn budget exhaustion a definite no-mutation yield. Interruption
+  recovery now appends causal, collision-free terminal phases; selected-comment
+  and failed-review retry lanes finalize interrupted receipts before
+  publication; scheduled retry failures remain failed after cleanup; active
+  coverage-proof yields cannot become kept-open terminals; and review mutation,
+  retryability, and cancellation status survive finalization.
 - Recovered exact-review intake from Cloudflare SQLite value-size exhaustion by normalizing delivery receipts and queue items into independently bounded rows, committing dedupe and admission atomically, restoring the seven-day idempotency window, and migrating live queue state through a transaction-coupled, generation-aware, size-bounded rollback bridge that retains the complete active dedupe set and safely reimports rollback-era changes. Thanks @brokemac79.
 - Hardened action-ledger privacy, import identity and causal validation,
   multi-shard capacity, crash-safe completion publication, portable paths,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,9 @@ checkpoint, and status-only commits are intentionally omitted.
   bounded shard, marker, and spool reads, producer-lock and finalization races,
   direct shard collection invariants, calendar timestamp parity, single-label
   email and common service-credential rejection, root-scoped projection drains,
-  and bounded optional CrabFleet delivery.
+  bounded optional CrabFleet delivery, eager apply mutation receipts, exact
+  active-item timeout recovery, and item/revision-stable apply and retry
+  idempotency across checkpoint and batch reordering.
 - Bounded every repair git helper subprocess while retaining the shorter configurable network timeout, ordinary nonzero and signal status semantics, platform-aware command launching, and explicit spawn-error reporting. Thanks @hex-AI12.
 - Waited for the exact dashboard Worker commit to reach the live health endpoint before running post-deploy smoke checks, preventing Cloudflare rollout propagation from producing false CI failures.
 - Separated review publication from apply/comment-sync concurrency so long

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Dual-write review batches, items, retries, Codex log publications, durable
+  review comments, apply actions, apply batches, and apply reports into the
+  immutable action ledger, including partial, interrupted, timeout, and failed
+  executions.
 - Short-circuited authenticated duplicate comment deliveries when their exact
   body version is already terminal in the durable router ledger, while edited,
   retryable, and state-drifted commands retain the full routing path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,11 @@ checkpoint, and status-only commits are intentionally omitted.
   backstops cannot create permanent parallel continuation chains that overwhelm
   serialized review publication, while exact-item, apply, and comment-sync
   lanes remain independent.
+- Gated review artifact application, record publication, exact-review queue
+  completion, apply dispatch, and review/apply continuations on explicit
+  primary success markers so action-ledger setup, import, finalization, upload,
+  or publication failures remain visible but fail open, while real review,
+  sync, proof, and apply failures still block dependent mutations.
 - Bound apply receipts to each actual GitHub request attempt while preserving
   stable business idempotency across transient retries, recorded review lease
   creation and cleanup independently, bound retry dispatches to review and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,10 +93,13 @@ checkpoint, and status-only commits are intentionally omitted.
   serialized review publication, while exact-item, apply, and comment-sync
   lanes remain independent.
 - Bound apply receipts to each actual GitHub request attempt, recorded lease
-  creation and cleanup independently, preserved exact retry-dispatch identity
-  and uncertainty, aggregated retry child mutations, authenticated imported
-  workflow producers outside the Codex workspace, and retained cancellation
-  and ordinary workflow-failure reasons during ledger finalization.
+  creation and cleanup independently, bound retry dispatches to review and
+  decision digests, aggregated every exact-attempt mutation outcome, and made
+  pre-spawn budget exhaustion a definite no-mutation yield. Selected-comment
+  and failed-review retry lanes now finalize interrupted receipts before
+  publication, scheduled retry failures remain failed after cleanup, active
+  coverage-proof yields cannot become kept-open terminals, and review failure
+  retryability plus cancellation status survive finalization.
 - Recovered exact-review intake from Cloudflare SQLite value-size exhaustion by normalizing delivery receipts and queue items into independently bounded rows, committing dedupe and admission atomically, restoring the seven-day idempotency window, and migrating live queue state through a transaction-coupled, generation-aware, size-bounded rollback bridge that retains the complete active dedupe set and safely reimports rollback-era changes. Thanks @brokemac79.
 - Hardened action-ledger privacy, import identity and causal validation,
   multi-shard capacity, crash-safe completion publication, portable paths,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Made action-ledger publication include every transactional import binding,
+  added pre-dispatch apply and retry receipts with conservative unknown-outcome
+  recovery, failed active apply items on runtime yield, and made ambiguous retry
+  dispatches fail closed without consuming an attempt or launching twice.
 - Dual-write review batches, items, retries, Codex log publications, durable
   review comments, apply actions, apply batches, and apply reports into the
   immutable action ledger, including partial, interrupted, timeout, and failed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,11 @@ checkpoint, and status-only commits are intentionally omitted.
   backstops cannot create permanent parallel continuation chains that overwhelm
   serialized review publication, while exact-item, apply, and comment-sync
   lanes remain independent.
+- Bound apply receipts to each actual GitHub request attempt, recorded lease
+  creation and cleanup independently, preserved exact retry-dispatch identity
+  and uncertainty, aggregated retry child mutations, authenticated imported
+  workflow producers outside the Codex workspace, and retained cancellation
+  and ordinary workflow-failure reasons during ledger finalization.
 - Recovered exact-review intake from Cloudflare SQLite value-size exhaustion by normalizing delivery receipts and queue items into independently bounded rows, committing dedupe and admission atomically, restoring the seven-day idempotency window, and migrating live queue state through a transaction-coupled, generation-aware, size-bounded rollback bridge that retains the complete active dedupe set and safely reimports rollback-era changes. Thanks @brokemac79.
 - Hardened action-ledger privacy, import identity and causal validation,
   multi-shard capacity, crash-safe completion publication, portable paths,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,11 +100,14 @@ checkpoint, and status-only commits are intentionally omitted.
   creation and cleanup independently, bound retry dispatches to review and
   decision digests, aggregated every exact-attempt mutation outcome, and made
   pre-spawn budget exhaustion a definite no-mutation yield. Interruption
-  recovery now appends causal, collision-free terminal phases; selected-comment
-  and failed-review retry lanes finalize interrupted receipts before
-  publication; scheduled retry failures remain failed after cleanup; active
-  coverage-proof yields cannot become kept-open terminals; and review mutation,
-  retryability, and cancellation status survive finalization.
+  recovery now terminalizes exact open mutation receipts before their enclosing
+  item and batch summaries with causal, collision-free phases; immutable ledger
+  finalization and publisher failures remain visible without suppressing valid
+  isolated apply dispatch or proof-backed apply work; selected-comment and
+  failed-review retry lanes finalize interrupted receipts before publication;
+  scheduled retry failures remain failed after cleanup; active coverage-proof
+  yields cannot become kept-open terminals; and review mutation, retryability,
+  and cancellation status survive finalization.
 - Recovered exact-review intake from Cloudflare SQLite value-size exhaustion by normalizing delivery receipts and queue items into independently bounded rows, committing dedupe and admission atomically, restoring the seven-day idempotency window, and migrating live queue state through a transaction-coupled, generation-aware, size-bounded rollback bridge that retains the complete active dedupe set and safely reimports rollback-era changes. Thanks @brokemac79.
 - Hardened action-ledger privacy, import identity and causal validation,
   multi-shard capacity, crash-safe completion publication, portable paths,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,8 +61,11 @@ checkpoint, and status-only commits are intentionally omitted.
 
 - Made action-ledger publication include every transactional import binding,
   added pre-dispatch apply and retry receipts with conservative unknown-outcome
-  recovery, failed active apply items on runtime yield, and made ambiguous retry
-  dispatches fail closed without consuming an attempt or launching twice.
+  recovery, failed active apply items on runtime yield, preserved skipped apply
+  outcomes independently from incidental mutations, separated durable comment
+  writes from metadata reconciliation, propagated ambiguous retry dispatches
+  and final Codex retryability exactly, and ordered every apply mutation attempt
+  and outcome with monotonic causal phases.
 - Dual-write review batches, items, retries, Codex log publications, durable
   review comments, apply actions, apply batches, and apply reports into the
   immutable action ledger, including partial, interrupted, timeout, and failed

--- a/docs/action-ledger.md
+++ b/docs/action-ledger.md
@@ -91,9 +91,16 @@ confidential-identifier checks as every other durable machine-text field.
 - Mutation events require an explicit business `idempotencyIdentity`; outcome
   status and failure reason never define side-effect identity.
 - Review operation identity binds each selected item's repository, kind, number,
-  and observed `updated_at`. Apply operation and mutation identity bind the item
-  source revision, review content digest, and decision packet digest. A crash
-  result and its retry therefore retain one business idempotency key.
+  and observed `updated_at`, while item starts are written only when processing
+  actually begins. Apply operation identity may retain checkpoint and batch
+  context, but apply and retry-dispatch business idempotency bind only the item,
+  immutable source revision, review content digest, and decision packet digest.
+  Candidate order, checkpoint composition, and list indexes never define those
+  side effects.
+- Apply writes an item start at loop entry and persists a mutation-observed
+  receipt immediately after the first successful durable mutation. Per-item
+  terminals are written as each item finishes, so timeout recovery fails only
+  the genuinely active item and preserves whether that item already mutated.
 - Repository, producer SHA, workflow, job, run, attempt, and component all bind
   shard identity. They do not define the logical operation.
 - Workflow, step, invocation, and component identifiers keep a readable prefix

--- a/docs/action-ledger.md
+++ b/docs/action-ledger.md
@@ -90,6 +90,10 @@ confidential-identifier checks as every other durable machine-text field.
   preserving `operation_id` and mutation idempotency keys.
 - Mutation events require an explicit business `idempotencyIdentity`; outcome
   status and failure reason never define side-effect identity.
+- Review operation identity binds each selected item's repository, kind, number,
+  and observed `updated_at`. Apply operation and mutation identity bind the item
+  source revision, review content digest, and decision packet digest. A crash
+  result and its retry therefore retain one business idempotency key.
 - Repository, producer SHA, workflow, job, run, attempt, and component all bind
   shard identity. They do not define the logical operation.
 - Workflow, step, invocation, and component identifiers keep a readable prefix
@@ -269,6 +273,12 @@ New writers should prefer phase-oriented types from
 reasons from `ACTION_EVENT_REASON_CODES`. The event type identifies what phase
 ran; `action.status` identifies its transition or outcome. Free-form detail
 belongs in neither field.
+
+`published` is reserved for evidence durably visible at its declared external
+destination, such as a synced GitHub comment or an imported immutable ledger
+shard. A log, review record, or apply report that only exists in the current
+workspace is `completed` and identifies its local or worktree destination via
+`publication_kind`; a later publication lane records the durable transition.
 
 ```ts
 recordWorkflowPhaseEvent(root, {

--- a/docs/action-ledger.md
+++ b/docs/action-ledger.md
@@ -97,10 +97,18 @@ confidential-identifier checks as every other durable machine-text field.
   immutable source revision, review content digest, and decision packet digest.
   Candidate order, checkpoint composition, and list indexes never define those
   side effects.
-- Apply writes an item start at loop entry and persists a mutation-observed
-  receipt immediately after the first successful durable mutation. Per-item
-  terminals are written as each item finishes, so timeout recovery fails only
-  the genuinely active item and preserves whether that item already mutated.
+- Apply writes an item start at loop entry and a child mutation-attempt receipt
+  before every GitHub write. Accepted, rejected-before-write, and unknown
+  outcomes close that receipt explicitly. Recovery treats an open attempt as a
+  possible mutation, so a crash after GitHub accepted a write can never be
+  finalized as `mutation: false`. Per-item terminals are written as each item
+  finishes, and runtime-budget yield fails the genuinely active item rather than
+  synthesizing a normal kept-open result.
+- Failed-review dispatch writes the same pre-dispatch boundary, keeps the
+  durable retry count unchanged until `gh` returns success, and leaves an
+  ambiguous dispatch fail-closed for that exact source revision. Operators must
+  reconcile the workflow run before another launch; automatic retry never
+  duplicates an outcome-unknown dispatch.
 - Repository, producer SHA, workflow, job, run, attempt, and component all bind
   shard identity. They do not define the logical operation.
 - Workflow, step, invocation, and component identifiers keep a readable prefix
@@ -211,6 +219,11 @@ confidential-identifier checks as every other durable machine-text field.
   first numbered part cannot expose a partial run. Sequential imports therefore
   cannot move a run, replace a reserved numbered set with a different part
   count, or advertise completion before payload publication finishes.
+- The importer returns one sorted publication manifest containing every event
+  shard plus its producer-run, event, shard-set, and completion binding. Workflow
+  publishers stage and commit that complete bounded manifest, so a fresh state
+  clone retains the same cross-import conflict and causal protections instead
+  of receiving payload files alone.
 
 ## Privacy Boundary
 

--- a/docs/action-ledger.md
+++ b/docs/action-ledger.md
@@ -106,9 +106,11 @@ confidential-identifier checks as every other durable machine-text field.
   synthesizing a normal kept-open result.
 - Failed-review dispatch writes the same pre-dispatch boundary, keeps the
   durable retry count unchanged until `gh` returns success, and leaves an
-  ambiguous dispatch fail-closed for that exact source revision. Operators must
-  reconcile the workflow run before another launch; automatic retry never
-  duplicates an outcome-unknown dispatch.
+  ambiguous dispatch fail-closed for that exact source revision. Its business
+  identity also binds the durable review-content and decision-packet digests,
+  so a changed failed-review record cannot reuse an earlier dispatch receipt.
+  Operators must reconcile the workflow run before another launch; automatic
+  retry never duplicates an outcome-unknown dispatch.
 - Repository, producer SHA, workflow, job, run, attempt, and component all bind
   shard identity. They do not define the logical operation.
 - Workflow, step, invocation, and component identifiers keep a readable prefix

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "retry-failed-reviews": "node dist/clawsweeper.js retry-failed-reviews",
     "apply-artifacts": "node dist/clawsweeper.js apply-artifacts",
     "apply-decisions": "node dist/clawsweeper.js apply-decisions",
+    "finalize-action-events": "node dist/clawsweeper.js finalize-action-events",
+    "publish-action-events": "node dist/clawsweeper.js publish-action-events",
     "proof-nudges": "node dist/clawsweeper.js proof-nudges",
     "bot-proof": "node dist/clawsweeper.js bot-proof",
     "audit": "node dist/clawsweeper.js audit",

--- a/src/action-ledger-runtime.ts
+++ b/src/action-ledger-runtime.ts
@@ -410,6 +410,24 @@ export async function flushWorkflowActionEvents(
   return [...paths].sort();
 }
 
+function workflowActionEventIsRecoverableStart(event: ActionEvent): boolean {
+  return (
+    (event.event_type === ACTION_EVENT_TYPES.reviewBatch ||
+      event.event_type === ACTION_EVENT_TYPES.reviewItem ||
+      event.event_type === ACTION_EVENT_TYPES.applyBatch ||
+      event.event_type === ACTION_EVENT_TYPES.applyAction) &&
+    event.action.status === ACTION_EVENT_STATUSES.started
+  );
+}
+
+function workflowActionEventClosesLifecycle(event: ActionEvent): boolean {
+  if (event.action.status === ACTION_EVENT_STATUSES.started) return false;
+  return !(
+    event.event_type === ACTION_EVENT_TYPES.applyAction &&
+    event.action.status === ACTION_EVENT_STATUSES.executed
+  );
+}
+
 export function interruptOpenWorkflowActionEvents(
   root: string,
   options: {
@@ -427,14 +445,7 @@ export function interruptOpenWorkflowActionEvents(
   }
   const safeRoot = prepareSafeReadRoot(root, "action event spool");
   const groups = [...groupWorkflowActionEvents(readAllSpooledActionEvents(safeRoot)).values()]
-    .filter((group) =>
-      group.some(
-        (event) =>
-          (event.event_type === ACTION_EVENT_TYPES.reviewBatch ||
-            event.event_type === ACTION_EVENT_TYPES.reviewItem) &&
-          event.action.status === ACTION_EVENT_STATUSES.started,
-      ),
-    )
+    .filter((group) => group.some(workflowActionEventIsRecoverableStart))
     .sort((left, right) => {
       const leftKey = actionLedgerJson(left[0]!.producer);
       const rightKey = actionLedgerJson(right[0]!.producer);
@@ -448,42 +459,67 @@ export function interruptOpenWorkflowActionEvents(
         (event) => actionLedgerJson(event.producer) === actionLedgerJson(producer),
       );
       const starts = current
-        .filter(
-          (event) =>
-            (event.event_type === ACTION_EVENT_TYPES.reviewBatch ||
-              event.event_type === ACTION_EVENT_TYPES.reviewItem) &&
-            event.action.status === ACTION_EVENT_STATUSES.started,
-        )
+        .filter(workflowActionEventIsRecoverableStart)
         .sort((left, right) => left.phase_seq - right.phase_seq);
       let written = 0;
       for (const start of starts) {
         const lifecycleKey = workflowActionLifecycleKey(start);
-        if (
-          current.some(
-            (event) =>
-              event.event_id !== start.event_id &&
-              event.action.status !== ACTION_EVENT_STATUSES.started &&
-              workflowActionLifecycleKey(event) === lifecycleKey,
-          )
-        ) {
+        const lifecycleEvents = current.filter(
+          (event) =>
+            event.event_id !== start.event_id && workflowActionLifecycleKey(event) === lifecycleKey,
+        );
+        if (lifecycleEvents.some(workflowActionEventClosesLifecycle)) {
           continue;
         }
+        const mutationEvents = current
+          .filter(
+            (event) =>
+              event.operation_id === start.operation_id &&
+              event.attempt_id === start.attempt_id &&
+              event.action.mutation,
+          )
+          .sort(
+            (left, right) =>
+              left.phase_seq - right.phase_seq || left.event_id.localeCompare(right.event_id),
+          );
+        const lifecycleMutation = lifecycleEvents
+          .filter((event) => event.action.mutation)
+          .sort(
+            (left, right) =>
+              left.phase_seq - right.phase_seq || left.event_id.localeCompare(right.event_id),
+          )
+          .at(-1);
+        const mutationOccurred =
+          start.event_type === ACTION_EVENT_TYPES.applyBatch
+            ? mutationEvents.length > 0
+            : lifecycleMutation !== undefined;
+        const parentEventId =
+          start.event_type === ACTION_EVENT_TYPES.applyAction && lifecycleMutation
+            ? lifecycleMutation.event_id
+            : start.event_id;
         const eventInput: ActionEventInput = {
-          eventKey: actionEventKey("review.interrupted", {
+          eventKey: actionEventKey("workflow.interrupted", {
             startEventId: start.event_id,
             reasonCode,
+            mutationOccurred,
           }),
           operationId: start.operation_id,
           attemptId: start.attempt_id,
-          parentEventId: start.event_id,
+          parentEventId,
           phaseSeq:
-            start.event_type === ACTION_EVENT_TYPES.reviewBatch ? 1_000_000 : start.phase_seq + 2,
-          idempotencyKeySha256: actionIdempotencyKey({
-            operationId: start.operation_id,
-            slot: "interrupted_terminal",
-            eventType: start.event_type,
-            subject: workflowActionSubjectIdentity(start),
-          }),
+            start.event_type === ACTION_EVENT_TYPES.reviewBatch ||
+            start.event_type === ACTION_EVENT_TYPES.applyBatch
+              ? 1_000_000
+              : start.phase_seq + 2,
+          idempotencyKeySha256:
+            start.event_type === ACTION_EVENT_TYPES.applyAction
+              ? start.idempotency_key_sha256
+              : actionIdempotencyKey({
+                  operationId: start.operation_id,
+                  slot: "interrupted_terminal",
+                  eventType: start.event_type,
+                  subject: workflowActionSubjectIdentity(start),
+                }),
           type: start.event_type,
           producer: workflowActionProducerInput(start.producer),
           subject: workflowActionSubjectInput(start.subject),
@@ -492,7 +528,7 @@ export function interruptOpenWorkflowActionEvents(
             status: ACTION_EVENT_STATUSES.failed,
             reasonCode,
             retryable: true,
-            mutation: false,
+            mutation: mutationOccurred,
           },
           ...(start.evidence === undefined
             ? {}
@@ -508,6 +544,7 @@ export function interruptOpenWorkflowActionEvents(
           attributes: {
             completion_reason: "timeout",
             failed_count: 1,
+            ...(mutationOccurred ? { action_count: 1 } : {}),
             partial: true,
           },
           privacy: {

--- a/src/action-ledger-runtime.ts
+++ b/src/action-ledger-runtime.ts
@@ -462,7 +462,8 @@ function workflowActionEventClosesLifecycle(start: ActionEvent, event: ActionEve
     );
   }
   if (
-    start.event_type === ACTION_EVENT_TYPES.applyAction &&
+    (start.event_type === ACTION_EVENT_TYPES.applyAction ||
+      start.event_type === ACTION_EVENT_TYPES.reviewItem) &&
     workflowActionEventIsMutationOutcome(event) &&
     event.idempotency_key_sha256 !== start.idempotency_key_sha256
   ) {
@@ -473,6 +474,40 @@ function workflowActionEventClosesLifecycle(start: ActionEvent, event: ActionEve
     event.action.status === ACTION_EVENT_STATUSES.executed &&
     !workflowActionEventIsUncertainMutationStart(start)
   );
+}
+
+function interruptedWorkflowPhaseSeq(
+  current: readonly ActionEvent[],
+  start: ActionEvent,
+  parentEventId: string,
+): number {
+  const parent = current.find((event) => event.event_id === parentEventId);
+  const reservedTerminalPhase =
+    start.event_type === ACTION_EVENT_TYPES.reviewBatch ||
+    start.event_type === ACTION_EVENT_TYPES.applyBatch ||
+    (start.event_type === ACTION_EVENT_TYPES.reviewRetry && start.subject.kind === "workflow")
+      ? 1_000_000
+      : 0;
+  let phaseSeq = Math.max(
+    reservedTerminalPhase,
+    start.phase_seq + 1,
+    (parent?.phase_seq ?? start.phase_seq) + 1,
+  );
+  const occupied = new Set(
+    current
+      .filter(
+        (event) =>
+          event.operation_id === start.operation_id && event.attempt_id === start.attempt_id,
+      )
+      .map((event) => event.phase_seq),
+  );
+  while (occupied.has(phaseSeq)) {
+    if (phaseSeq === Number.MAX_SAFE_INTEGER) {
+      throw new Error("action event phase sequence exhausted during interruption recovery");
+    }
+    phaseSeq += 1;
+  }
+  return phaseSeq;
 }
 
 export function interruptOpenWorkflowActionEvents(
@@ -577,6 +612,7 @@ export function interruptOpenWorkflowActionEvents(
           workflowActionEventIsUncertainMutationStart(start) ||
           openUncertainMutationStarts.length > 0;
         const aggregatesChildMutations =
+          start.event_type === ACTION_EVENT_TYPES.reviewBatch ||
           start.event_type === ACTION_EVENT_TYPES.applyBatch ||
           (start.event_type === ACTION_EVENT_TYPES.reviewRetry &&
             start.subject.kind === "workflow");
@@ -615,13 +651,7 @@ export function interruptOpenWorkflowActionEvents(
           operationId: start.operation_id,
           attemptId: start.attempt_id,
           parentEventId,
-          phaseSeq:
-            start.event_type === ACTION_EVENT_TYPES.reviewBatch ||
-            start.event_type === ACTION_EVENT_TYPES.applyBatch ||
-            (start.event_type === ACTION_EVENT_TYPES.reviewRetry &&
-              start.subject.kind === "workflow")
-              ? 1_000_000
-              : start.phase_seq + 2,
+          phaseSeq: interruptedWorkflowPhaseSeq(current, start, parentEventId),
           idempotencyKeySha256:
             workflowActionEventIsUncertainMutationStart(start) ||
             start.event_type === ACTION_EVENT_TYPES.applyAction

--- a/src/action-ledger-runtime.ts
+++ b/src/action-ledger-runtime.ts
@@ -444,11 +444,18 @@ function workflowActionEventIsMutationOutcome(event: ActionEvent): boolean {
 }
 
 function workflowActionEventClosesLifecycle(start: ActionEvent, event: ActionEvent): boolean {
+  if (event.phase_seq <= start.phase_seq) return false;
   if (event.action.status === ACTION_EVENT_STATUSES.started) return false;
+  if (workflowActionEventIsUncertainMutationStart(start)) {
+    return (
+      event.parent_event_id === start.event_id &&
+      event.idempotency_key_sha256 === start.idempotency_key_sha256
+    );
+  }
   if (
     start.event_type === ACTION_EVENT_TYPES.applyAction &&
-    !workflowActionEventIsUncertainMutationStart(start) &&
-    workflowActionEventIsMutationOutcome(event)
+    workflowActionEventIsMutationOutcome(event) &&
+    event.idempotency_key_sha256 !== start.idempotency_key_sha256
   ) {
     return false;
   }
@@ -544,17 +551,18 @@ export function interruptOpenWorkflowActionEvents(
               left.phase_seq - right.phase_seq || left.event_id.localeCompare(right.event_id),
           )
           .at(-1);
+        const openUncertainMutationStarts = uncertainMutationStarts.filter((event) => {
+          const eventLifecycleKey = workflowActionLifecycleKey(event);
+          return !current.some(
+            (candidate) =>
+              candidate.event_id !== event.event_id &&
+              workflowActionLifecycleKey(candidate) === eventLifecycleKey &&
+              workflowActionEventClosesLifecycle(event, candidate),
+          );
+        });
         const openUncertainMutation =
           workflowActionEventIsUncertainMutationStart(start) ||
-          uncertainMutationStarts.some((event) => {
-            const eventLifecycleKey = workflowActionLifecycleKey(event);
-            return !current.some(
-              (candidate) =>
-                candidate.event_id !== event.event_id &&
-                workflowActionLifecycleKey(candidate) === eventLifecycleKey &&
-                workflowActionEventClosesLifecycle(event, candidate),
-            );
-          });
+          openUncertainMutationStarts.length > 0;
         const uncertainMutation =
           openUncertainMutation ||
           lifecycleMutation?.attributes?.completion_reason === "mutation_outcome_unknown";
@@ -563,12 +571,14 @@ export function interruptOpenWorkflowActionEvents(
           (start.event_type === ACTION_EVENT_TYPES.applyBatch
             ? mutationEvents.length > 0 || openUncertainMutation
             : lifecycleMutation !== undefined || openUncertainMutation);
+        const openReceipt = workflowActionEventIsUncertainMutationStart(start)
+          ? start
+          : openUncertainMutationStarts.at(-1);
         const parentEventId =
-          start.event_type === ACTION_EVENT_TYPES.applyAction && lifecycleMutation
+          openReceipt?.event_id ??
+          (start.event_type === ACTION_EVENT_TYPES.applyAction && lifecycleMutation
             ? lifecycleMutation.event_id
-            : (lifecycleOutcome?.event_id ??
-              uncertainMutationStarts.at(-1)?.event_id ??
-              start.event_id);
+            : (lifecycleOutcome?.event_id ?? start.event_id));
         const eventInput: ActionEventInput = {
           eventKey: actionEventKey("workflow.interrupted", {
             startEventId: start.event_id,

--- a/src/action-ledger-runtime.ts
+++ b/src/action-ledger-runtime.ts
@@ -17,7 +17,9 @@ import {
 } from "./action-ledger-files.js";
 import {
   ACTION_LEDGER_CANONICAL_JSON_LIMITS,
+  ACTION_EVENT_REASON_CODES,
   ACTION_EVENT_SHARD_FILE_LIMITS,
+  ACTION_EVENT_STATUSES,
   ACTION_EVENT_TYPES,
   actionEventShardsReplayEquivalent,
   actionAttemptId,
@@ -215,7 +217,7 @@ type ActionEventLock = {
 
 export function workflowActionEventsEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   if (env.CLAWSWEEPER_ACTION_LEDGER_DISABLED === "1") return false;
-  return env.GITHUB_ACTIONS === "true" || env.CLAWSWEEPER_ACTION_LEDGER_FORCE === "1";
+  return env.CLAWSWEEPER_ACTION_LEDGER_FORCE === "1";
 }
 
 export function workflowActionProducer(
@@ -406,6 +408,171 @@ export async function flushWorkflowActionEvents(
     paths.add(relativePath);
   }
   return [...paths].sort();
+}
+
+export function interruptOpenWorkflowActionEvents(
+  root: string,
+  options: {
+    env?: NodeJS.ProcessEnv;
+    now?: () => Date;
+    fetchImpl?: typeof fetch;
+    reasonCode?: ActionEventReasonCode;
+  } = {},
+): number {
+  const env = options.env ?? process.env;
+  if (!workflowActionEventsEnabled(env)) return 0;
+  const reasonCode = options.reasonCode ?? ACTION_EVENT_REASON_CODES.timeout;
+  if (reasonCode !== ACTION_EVENT_REASON_CODES.timeout) {
+    throw new Error(`unsupported interrupted workflow action reason: ${reasonCode}`);
+  }
+  const safeRoot = prepareSafeReadRoot(root, "action event spool");
+  const groups = [...groupWorkflowActionEvents(readAllSpooledActionEvents(safeRoot)).values()]
+    .filter((group) =>
+      group.some(
+        (event) =>
+          (event.event_type === ACTION_EVENT_TYPES.reviewBatch ||
+            event.event_type === ACTION_EVENT_TYPES.reviewItem) &&
+          event.action.status === ACTION_EVENT_STATUSES.started,
+      ),
+    )
+    .sort((left, right) => {
+      const leftKey = actionLedgerJson(left[0]!.producer);
+      const rightKey = actionLedgerJson(right[0]!.producer);
+      return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0;
+    });
+  let interrupted = 0;
+  for (const group of groups) {
+    const producer = group[0]!.producer;
+    interrupted += withWorkflowProducerLock(root, producer, () => {
+      const current = readAllSpooledActionEvents(safeRoot).filter(
+        (event) => actionLedgerJson(event.producer) === actionLedgerJson(producer),
+      );
+      const starts = current
+        .filter(
+          (event) =>
+            (event.event_type === ACTION_EVENT_TYPES.reviewBatch ||
+              event.event_type === ACTION_EVENT_TYPES.reviewItem) &&
+            event.action.status === ACTION_EVENT_STATUSES.started,
+        )
+        .sort((left, right) => left.phase_seq - right.phase_seq);
+      let written = 0;
+      for (const start of starts) {
+        const lifecycleKey = workflowActionLifecycleKey(start);
+        if (
+          current.some(
+            (event) =>
+              event.event_id !== start.event_id &&
+              event.action.status !== ACTION_EVENT_STATUSES.started &&
+              workflowActionLifecycleKey(event) === lifecycleKey,
+          )
+        ) {
+          continue;
+        }
+        const eventInput: ActionEventInput = {
+          eventKey: actionEventKey("review.interrupted", {
+            startEventId: start.event_id,
+            reasonCode,
+          }),
+          operationId: start.operation_id,
+          attemptId: start.attempt_id,
+          parentEventId: start.event_id,
+          phaseSeq:
+            start.event_type === ACTION_EVENT_TYPES.reviewBatch ? 1_000_000 : start.phase_seq + 2,
+          idempotencyKeySha256: actionIdempotencyKey({
+            operationId: start.operation_id,
+            slot: "interrupted_terminal",
+            eventType: start.event_type,
+            subject: workflowActionSubjectIdentity(start),
+          }),
+          type: start.event_type,
+          producer: workflowActionProducerInput(start.producer),
+          subject: workflowActionSubjectInput(start.subject),
+          action: {
+            name: start.event_type,
+            status: ACTION_EVENT_STATUSES.failed,
+            reasonCode,
+            retryable: true,
+            mutation: false,
+          },
+          ...(start.evidence === undefined
+            ? {}
+            : {
+                evidence: start.evidence.map((entry) => ({
+                  kind: entry.kind,
+                  ...(entry.sha256 === undefined ? {} : { sha256: entry.sha256 }),
+                  ...(entry.report_path === undefined ? {} : { reportPath: entry.report_path }),
+                  ...(entry.run_url === undefined ? {} : { runUrl: entry.run_url }),
+                  ...(entry.snapshot_id === undefined ? {} : { snapshotId: entry.snapshot_id }),
+                })),
+              }),
+          attributes: {
+            completion_reason: "timeout",
+            failed_count: 1,
+            partial: true,
+          },
+          privacy: {
+            classification: start.privacy.classification,
+            redactionVersion: start.privacy.redaction_version,
+            fieldsDropped: start.privacy.fields_dropped,
+          },
+        };
+        const writeOptions = { now: options.now ?? (() => new Date()) };
+        const candidate = createActionEvent(eventInput, writeOptions);
+        assertWorkflowProducerAcceptsEvent(root, candidate);
+        const partitionDate = readWorkflowPartitionDate(safeRoot, start.producer);
+        ensureWorkflowPartitionDateValue(root, start.producer, partitionDate);
+        const event = writeActionEvent(root, eventInput, writeOptions).event;
+        queueCrabFleetEvent(root, event, env, options.fetchImpl ?? fetch);
+        current.push(event);
+        written += 1;
+      }
+      return written;
+    });
+  }
+  return interrupted;
+}
+
+function workflowActionLifecycleKey(event: ActionEvent): string {
+  return actionLedgerJson({
+    operationId: event.operation_id,
+    attemptId: event.attempt_id,
+    eventType: event.event_type,
+    subject: workflowActionSubjectIdentity(event),
+  });
+}
+
+function workflowActionSubjectIdentity(event: ActionEvent) {
+  return {
+    repository: event.subject.repository,
+    kind: event.subject.kind,
+    ...(event.subject.subject_id === undefined ? {} : { subjectId: event.subject.subject_id }),
+    ...(event.subject.number === undefined ? {} : { number: event.subject.number }),
+    ...(event.subject.cluster_id === undefined ? {} : { clusterId: event.subject.cluster_id }),
+  };
+}
+
+function workflowActionProducerInput(producer: ActionEvent["producer"]): ActionEventProducer {
+  return {
+    repository: producer.repository,
+    sha: producer.sha,
+    workflow: producer.workflow,
+    job: producer.job,
+    runId: producer.run_id,
+    runAttempt: producer.run_attempt,
+    component: producer.component,
+  };
+}
+
+function workflowActionSubjectInput(subject: ActionEvent["subject"]): ActionEventSubject {
+  return {
+    repository: subject.repository,
+    kind: subject.kind,
+    ...(subject.subject_id === undefined ? {} : { subjectId: subject.subject_id }),
+    ...(subject.number === undefined ? {} : { number: subject.number }),
+    ...(subject.cluster_id === undefined ? {} : { clusterId: subject.cluster_id }),
+    ...(subject.source_revision === undefined ? {} : { sourceRevision: subject.source_revision }),
+    ...(subject.record_path === undefined ? {} : { recordPath: subject.record_path }),
+  };
 }
 
 function finalizeWorkflowActionEventSpool(

--- a/src/action-ledger-runtime.ts
+++ b/src/action-ledger-runtime.ts
@@ -103,6 +103,9 @@ export const ACTION_EVENT_SHARD_IMPORT_LIMITS = {
   maxCausalBindings: 256 * ACTION_EVENT_SHARD_FILE_LIMITS.maxEvents,
 } as const;
 
+export const ACTION_EVENT_SHARD_IMPORT_MAX_PUBLISH_PATHS =
+  ACTION_EVENT_SHARD_IMPORT_LIMITS.maxTotalEvents + ACTION_EVENT_SHARD_IMPORT_LIMITS.maxFiles * 4;
+
 export type WorkflowActionEventInput = {
   scope: string;
   identity: unknown;
@@ -143,6 +146,9 @@ export type WorkflowActionPhaseEventInput = Omit<
 export type ActionEventShardImportResult = {
   created: number;
   unchanged: number;
+  eventPaths: string[];
+  reservationPaths: string[];
+  completionPaths: string[];
   paths: string[];
 };
 
@@ -414,17 +420,42 @@ function workflowActionEventIsRecoverableStart(event: ActionEvent): boolean {
   return (
     (event.event_type === ACTION_EVENT_TYPES.reviewBatch ||
       event.event_type === ACTION_EVENT_TYPES.reviewItem ||
+      event.event_type === ACTION_EVENT_TYPES.reviewRetry ||
       event.event_type === ACTION_EVENT_TYPES.applyBatch ||
       event.event_type === ACTION_EVENT_TYPES.applyAction) &&
     event.action.status === ACTION_EVENT_STATUSES.started
   );
 }
 
-function workflowActionEventClosesLifecycle(event: ActionEvent): boolean {
+function workflowActionEventIsUncertainMutationStart(event: ActionEvent): boolean {
+  return (
+    event.action.status === ACTION_EVENT_STATUSES.started &&
+    (event.attributes?.completion_reason === "mutation_attempted" ||
+      event.attributes?.completion_reason === "dispatch_attempted")
+  );
+}
+
+function workflowActionEventIsMutationOutcome(event: ActionEvent): boolean {
+  return (
+    event.attributes?.completion_reason === "mutation_accepted" ||
+    event.attributes?.completion_reason === "mutation_rejected" ||
+    event.attributes?.completion_reason === "mutation_outcome_unknown"
+  );
+}
+
+function workflowActionEventClosesLifecycle(start: ActionEvent, event: ActionEvent): boolean {
   if (event.action.status === ACTION_EVENT_STATUSES.started) return false;
+  if (
+    start.event_type === ACTION_EVENT_TYPES.applyAction &&
+    !workflowActionEventIsUncertainMutationStart(start) &&
+    workflowActionEventIsMutationOutcome(event)
+  ) {
+    return false;
+  }
   return !(
     event.event_type === ACTION_EVENT_TYPES.applyAction &&
-    event.action.status === ACTION_EVENT_STATUSES.executed
+    event.action.status === ACTION_EVENT_STATUSES.executed &&
+    !workflowActionEventIsUncertainMutationStart(start)
   );
 }
 
@@ -468,9 +499,26 @@ export function interruptOpenWorkflowActionEvents(
           (event) =>
             event.event_id !== start.event_id && workflowActionLifecycleKey(event) === lifecycleKey,
         );
-        if (lifecycleEvents.some(workflowActionEventClosesLifecycle)) {
+        if (lifecycleEvents.some((event) => workflowActionEventClosesLifecycle(start, event))) {
           continue;
         }
+        const uncertainMutationStarts = current
+          .filter(
+            (event) =>
+              event.operation_id === start.operation_id &&
+              event.attempt_id === start.attempt_id &&
+              (start.event_type === ACTION_EVENT_TYPES.reviewBatch ||
+                start.event_type === ACTION_EVENT_TYPES.applyBatch ||
+                (start.event_type === ACTION_EVENT_TYPES.reviewRetry &&
+                  start.subject.kind === "workflow") ||
+                actionLedgerJson(workflowActionSubjectIdentity(event)) ===
+                  actionLedgerJson(workflowActionSubjectIdentity(start))) &&
+              workflowActionEventIsUncertainMutationStart(event),
+          )
+          .sort(
+            (left, right) =>
+              left.phase_seq - right.phase_seq || left.event_id.localeCompare(right.event_id),
+          );
         const mutationEvents = current
           .filter(
             (event) =>
@@ -489,14 +537,38 @@ export function interruptOpenWorkflowActionEvents(
               left.phase_seq - right.phase_seq || left.event_id.localeCompare(right.event_id),
           )
           .at(-1);
+        const lifecycleOutcome = lifecycleEvents
+          .filter(workflowActionEventIsMutationOutcome)
+          .sort(
+            (left, right) =>
+              left.phase_seq - right.phase_seq || left.event_id.localeCompare(right.event_id),
+          )
+          .at(-1);
+        const openUncertainMutation =
+          workflowActionEventIsUncertainMutationStart(start) ||
+          uncertainMutationStarts.some((event) => {
+            const eventLifecycleKey = workflowActionLifecycleKey(event);
+            return !current.some(
+              (candidate) =>
+                candidate.event_id !== event.event_id &&
+                workflowActionLifecycleKey(candidate) === eventLifecycleKey &&
+                workflowActionEventClosesLifecycle(event, candidate),
+            );
+          });
+        const uncertainMutation =
+          openUncertainMutation ||
+          lifecycleMutation?.attributes?.completion_reason === "mutation_outcome_unknown";
         const mutationOccurred =
-          start.event_type === ACTION_EVENT_TYPES.applyBatch
-            ? mutationEvents.length > 0
-            : lifecycleMutation !== undefined;
+          workflowActionEventIsUncertainMutationStart(start) ||
+          (start.event_type === ACTION_EVENT_TYPES.applyBatch
+            ? mutationEvents.length > 0 || openUncertainMutation
+            : lifecycleMutation !== undefined || openUncertainMutation);
         const parentEventId =
           start.event_type === ACTION_EVENT_TYPES.applyAction && lifecycleMutation
             ? lifecycleMutation.event_id
-            : start.event_id;
+            : (lifecycleOutcome?.event_id ??
+              uncertainMutationStarts.at(-1)?.event_id ??
+              start.event_id);
         const eventInput: ActionEventInput = {
           eventKey: actionEventKey("workflow.interrupted", {
             startEventId: start.event_id,
@@ -542,7 +614,11 @@ export function interruptOpenWorkflowActionEvents(
                 })),
               }),
           attributes: {
-            completion_reason: "timeout",
+            completion_reason: uncertainMutation
+              ? start.event_type === ACTION_EVENT_TYPES.reviewRetry
+                ? "dispatch_outcome_unknown"
+                : "mutation_outcome_unknown"
+              : "timeout",
             failed_count: 1,
             ...(mutationOccurred ? { action_count: 1 } : {}),
             partial: true,
@@ -804,18 +880,26 @@ export function importActionEventShards(
   sourceRoot: string,
   destinationRoot: string,
 ): ActionEventShardImportResult {
+  const emptyResult = (): ActionEventShardImportResult => ({
+    created: 0,
+    unchanged: 0,
+    eventPaths: [],
+    reservationPaths: [],
+    completionPaths: [],
+    paths: [],
+  });
   let safeSource: SafeReadRoot;
   try {
     safeSource = prepareSafeReadRoot(sourceRoot, "action event shard import source");
   } catch (error) {
-    if (isNotFoundError(error)) return { created: 0, unchanged: 0, paths: [] };
+    if (isNotFoundError(error)) return emptyResult();
     throw error;
   }
   let relativePaths: string[];
   try {
     relativePaths = collectActionEventShardFiles(safeSource);
   } catch (error) {
-    if (isNotFoundError(error)) return { created: 0, unchanged: 0, paths: [] };
+    if (isNotFoundError(error)) return emptyResult();
     throw error;
   }
   const shards = readImportedActionEventShards(safeSource, relativePaths);
@@ -889,7 +973,23 @@ export function importActionEventShards(
       for (const binding of bindings.completions) {
         publishActionEventShardImportBinding(binding);
       }
-      return { created, unchanged, paths: relativePaths };
+      const eventPaths = [...relativePaths].sort();
+      const reservationPaths = bindings.reservations.map((binding) => binding.relativePath).sort();
+      const completionPaths = bindings.completions.map((binding) => binding.relativePath).sort();
+      const paths = [...new Set([...reservationPaths, ...eventPaths, ...completionPaths])].sort();
+      if (paths.length > ACTION_EVENT_SHARD_IMPORT_MAX_PUBLISH_PATHS) {
+        throw new Error(
+          `action event shard import exceeds ${ACTION_EVENT_SHARD_IMPORT_MAX_PUBLISH_PATHS} publish path limit`,
+        );
+      }
+      return {
+        created,
+        unchanged,
+        eventPaths,
+        reservationPaths,
+        completionPaths,
+        paths,
+      };
     },
   );
 }

--- a/src/action-ledger-runtime.ts
+++ b/src/action-ledger-runtime.ts
@@ -550,13 +550,13 @@ export function interruptOpenWorkflowActionEvents(
             (left, right) =>
               left.phase_seq - right.phase_seq || left.event_id.localeCompare(right.event_id),
           );
-        const lifecycleMutation = lifecycleEvents
+        const lifecycleMutations = lifecycleEvents
           .filter((event) => event.action.mutation)
           .sort(
             (left, right) =>
               left.phase_seq - right.phase_seq || left.event_id.localeCompare(right.event_id),
-          )
-          .at(-1);
+          );
+        const lifecycleMutation = lifecycleMutations.at(-1);
         const lifecycleOutcome = lifecycleEvents
           .filter(workflowActionEventIsMutationOutcome)
           .sort(
@@ -576,13 +576,21 @@ export function interruptOpenWorkflowActionEvents(
         const openUncertainMutation =
           workflowActionEventIsUncertainMutationStart(start) ||
           openUncertainMutationStarts.length > 0;
-        const uncertainMutation =
-          openUncertainMutation ||
-          lifecycleMutation?.attributes?.completion_reason === "mutation_outcome_unknown";
         const aggregatesChildMutations =
           start.event_type === ACTION_EVENT_TYPES.applyBatch ||
           (start.event_type === ACTION_EVENT_TYPES.reviewRetry &&
             start.subject.kind === "workflow");
+        const relevantMutationEvents = aggregatesChildMutations
+          ? mutationEvents
+          : lifecycleMutations;
+        const unknownMutationOutcome = relevantMutationEvents
+          .filter(
+            (event) =>
+              event.attributes?.completion_reason === "mutation_outcome_unknown" ||
+              event.attributes?.completion_reason === "dispatch_outcome_unknown",
+          )
+          .at(-1);
+        const uncertainMutation = openUncertainMutation || unknownMutationOutcome !== undefined;
         const mutationOccurred =
           workflowActionEventIsUncertainMutationStart(start) ||
           (aggregatesChildMutations
@@ -593,9 +601,11 @@ export function interruptOpenWorkflowActionEvents(
           : openUncertainMutationStarts.at(-1);
         const parentEventId =
           openReceipt?.event_id ??
-          (start.event_type === ACTION_EVENT_TYPES.applyAction && lifecycleMutation
-            ? lifecycleMutation.event_id
-            : (lifecycleOutcome?.event_id ?? start.event_id));
+          (unknownMutationOutcome
+            ? unknownMutationOutcome.event_id
+            : start.event_type === ACTION_EVENT_TYPES.applyAction && lifecycleMutation
+              ? lifecycleMutation.event_id
+              : (lifecycleOutcome?.event_id ?? start.event_id));
         const eventInput: ActionEventInput = {
           eventKey: actionEventKey("workflow.interrupted", {
             startEventId: start.event_id,
@@ -627,7 +637,10 @@ export function interruptOpenWorkflowActionEvents(
           subject: workflowActionSubjectInput(start.subject),
           action: {
             name: start.event_type,
-            status: ACTION_EVENT_STATUSES.failed,
+            status:
+              reasonCode === ACTION_EVENT_REASON_CODES.cancelled
+                ? ACTION_EVENT_STATUSES.cancelled
+                : ACTION_EVENT_STATUSES.failed,
             reasonCode,
             retryable: !uncertainMutation,
             mutation: mutationOccurred,

--- a/src/action-ledger-runtime.ts
+++ b/src/action-ledger-runtime.ts
@@ -452,6 +452,18 @@ function workflowActionEventIsMutationOutcome(event: ActionEvent): boolean {
   );
 }
 
+function workflowActionRecoveryPriority(event: ActionEvent): number {
+  if (workflowActionEventIsUncertainMutationStart(event)) return 0;
+  if (
+    event.event_type === ACTION_EVENT_TYPES.reviewBatch ||
+    event.event_type === ACTION_EVENT_TYPES.applyBatch ||
+    (event.event_type === ACTION_EVENT_TYPES.reviewRetry && event.subject.kind === "workflow")
+  ) {
+    return 2;
+  }
+  return 1;
+}
+
 function workflowActionEventClosesLifecycle(start: ActionEvent, event: ActionEvent): boolean {
   if (event.phase_seq <= start.phase_seq) return false;
   if (event.action.status === ACTION_EVENT_STATUSES.started) return false;
@@ -546,7 +558,12 @@ export function interruptOpenWorkflowActionEvents(
       );
       const starts = current
         .filter(workflowActionEventIsRecoverableStart)
-        .sort((left, right) => left.phase_seq - right.phase_seq);
+        .sort(
+          (left, right) =>
+            workflowActionRecoveryPriority(left) - workflowActionRecoveryPriority(right) ||
+            left.phase_seq - right.phase_seq ||
+            left.event_id.localeCompare(right.event_id),
+        );
       let written = 0;
       for (const start of starts) {
         const lifecycleKey = workflowActionLifecycleKey(start);

--- a/src/action-ledger-runtime.ts
+++ b/src/action-ledger-runtime.ts
@@ -152,6 +152,15 @@ export type ActionEventShardImportResult = {
   paths: string[];
 };
 
+export type ExpectedActionEventProducer = {
+  repository: string;
+  sha: string;
+  workflow: string;
+  job: string;
+  runId: string;
+  runAttempt: number;
+};
+
 type ImportedActionEventShard = {
   relativePath: string;
   content: string;
@@ -478,7 +487,11 @@ export function interruptOpenWorkflowActionEvents(
   const env = options.env ?? process.env;
   if (!workflowActionEventsEnabled(env)) return 0;
   const reasonCode = options.reasonCode ?? ACTION_EVENT_REASON_CODES.timeout;
-  if (reasonCode !== ACTION_EVENT_REASON_CODES.timeout) {
+  if (
+    reasonCode !== ACTION_EVENT_REASON_CODES.timeout &&
+    reasonCode !== ACTION_EVENT_REASON_CODES.cancelled &&
+    reasonCode !== ACTION_EVENT_REASON_CODES.workflowFailed
+  ) {
     throw new Error(`unsupported interrupted workflow action reason: ${reasonCode}`);
   }
   const safeRoot = prepareSafeReadRoot(root, "action event spool");
@@ -566,9 +579,13 @@ export function interruptOpenWorkflowActionEvents(
         const uncertainMutation =
           openUncertainMutation ||
           lifecycleMutation?.attributes?.completion_reason === "mutation_outcome_unknown";
+        const aggregatesChildMutations =
+          start.event_type === ACTION_EVENT_TYPES.applyBatch ||
+          (start.event_type === ACTION_EVENT_TYPES.reviewRetry &&
+            start.subject.kind === "workflow");
         const mutationOccurred =
           workflowActionEventIsUncertainMutationStart(start) ||
-          (start.event_type === ACTION_EVENT_TYPES.applyBatch
+          (aggregatesChildMutations
             ? mutationEvents.length > 0 || openUncertainMutation
             : lifecycleMutation !== undefined || openUncertainMutation);
         const openReceipt = workflowActionEventIsUncertainMutationStart(start)
@@ -590,10 +607,13 @@ export function interruptOpenWorkflowActionEvents(
           parentEventId,
           phaseSeq:
             start.event_type === ACTION_EVENT_TYPES.reviewBatch ||
-            start.event_type === ACTION_EVENT_TYPES.applyBatch
+            start.event_type === ACTION_EVENT_TYPES.applyBatch ||
+            (start.event_type === ACTION_EVENT_TYPES.reviewRetry &&
+              start.subject.kind === "workflow")
               ? 1_000_000
               : start.phase_seq + 2,
           idempotencyKeySha256:
+            workflowActionEventIsUncertainMutationStart(start) ||
             start.event_type === ACTION_EVENT_TYPES.applyAction
               ? start.idempotency_key_sha256
               : actionIdempotencyKey({
@@ -609,7 +629,7 @@ export function interruptOpenWorkflowActionEvents(
             name: start.event_type,
             status: ACTION_EVENT_STATUSES.failed,
             reasonCode,
-            retryable: true,
+            retryable: !uncertainMutation,
             mutation: mutationOccurred,
           },
           ...(start.evidence === undefined
@@ -628,7 +648,11 @@ export function interruptOpenWorkflowActionEvents(
               ? start.event_type === ACTION_EVENT_TYPES.reviewRetry
                 ? "dispatch_outcome_unknown"
                 : "mutation_outcome_unknown"
-              : "timeout",
+              : reasonCode === ACTION_EVENT_REASON_CODES.timeout
+                ? "timeout"
+                : reasonCode === ACTION_EVENT_REASON_CODES.cancelled
+                  ? "cancelled"
+                  : "workflow_failed",
             failed_count: 1,
             ...(mutationOccurred ? { action_count: 1 } : {}),
             partial: true,
@@ -889,6 +913,7 @@ function startActionEventCrabFleetPost(
 export function importActionEventShards(
   sourceRoot: string,
   destinationRoot: string,
+  options: { expectedProducer?: ExpectedActionEventProducer | undefined } = {},
 ): ActionEventShardImportResult {
   const emptyResult = (): ActionEventShardImportResult => ({
     created: 0,
@@ -913,6 +938,9 @@ export function importActionEventShards(
     throw error;
   }
   const shards = readImportedActionEventShards(safeSource, relativePaths);
+  if (options.expectedProducer) {
+    validateImportedActionEventProducer(shards, options.expectedProducer);
+  }
   const safeDestination = prepareSafeReadRoot(destinationRoot, "action event shard import");
   return withActionEventLock(
     safeDestination.path,
@@ -1002,6 +1030,30 @@ export function importActionEventShards(
       };
     },
   );
+}
+
+function validateImportedActionEventProducer(
+  shards: readonly ImportedActionEventShard[],
+  expected: ExpectedActionEventProducer,
+): void {
+  for (const shard of shards) {
+    const actual = shard.identity;
+    const mismatched = (
+      [
+        ["repository", actual.repository, expected.repository],
+        ["sha", actual.sha, expected.sha],
+        ["workflow", actual.workflow, expected.workflow],
+        ["job", actual.job, expected.job],
+        ["run_id", actual.runId, expected.runId],
+        ["run_attempt", actual.runAttempt, expected.runAttempt],
+      ] as const
+    ).find(([, value, expectedValue]) => value !== expectedValue);
+    if (mismatched) {
+      throw new Error(
+        `action event shard producer provenance mismatch for ${mismatched[0]}: expected ${mismatched[2]}, got ${mismatched[1]}`,
+      );
+    }
+  }
 }
 
 function prepareActionEventShardImportBindings(

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -2621,14 +2621,16 @@ function ghWithRetry(args: string[], attempts = 12, options: GitHubRetryOptions 
   throw lastError;
 }
 
-type ApplyMutationRunner = <T>(options: {
+type MutationRunner = <T>(options: {
   identity: string;
+  idempotencyIdentity: string;
   operation: () => T;
   didMutate?: ((result: T) => boolean) | undefined;
   knownNoMutation?: ((error: unknown) => boolean) | undefined;
 }) => T;
 
-let activeApplyMutationRunner: ApplyMutationRunner | null = null;
+let activeApplyMutationRunner: MutationRunner | null = null;
+let activeReviewMutationRunner: MutationRunner | null = null;
 
 function mutationErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -2636,14 +2638,17 @@ function mutationErrorMessage(error: unknown): string {
 
 function runObservedApplyMutation<T>(options: {
   identity: string;
+  idempotencyIdentity?: string | undefined;
   operation: () => T;
   onMutation?: (() => void) | undefined;
   didMutate?: ((result: T) => boolean) | undefined;
   knownNoMutation?: ((error: unknown) => boolean) | undefined;
 }): T {
-  if (activeApplyMutationRunner) {
-    return activeApplyMutationRunner({
+  const runner = activeApplyMutationRunner ?? activeReviewMutationRunner;
+  if (runner) {
+    return runner({
       identity: options.identity,
+      idempotencyIdentity: options.idempotencyIdentity ?? options.identity,
       operation: options.operation,
       ...(options.didMutate ? { didMutate: options.didMutate } : {}),
       ...(options.knownNoMutation ? { knownNoMutation: options.knownNoMutation } : {}),
@@ -2679,6 +2684,7 @@ function ghObservedMutationCommand(options: {
       }
       return runObservedApplyMutation({
         identity: `${options.identity}:request_attempt:${attempt + 1}`,
+        idempotencyIdentity: options.identity,
         operation,
         ...(options.onMutation ? { onMutation: options.onMutation } : {}),
         ...(options.didMutate ? { didMutate: options.didMutate } : {}),
@@ -2691,14 +2697,20 @@ function ghObservedMutationCommand(options: {
 
 export function observedGitHubMutationAttemptsForTest(
   outcomes: readonly ("not_started" | "transient" | "accepted" | "already_exists")[],
-): Array<{ identity: string; outcome: "accepted" | "rejected" | "unknown" }> {
+): Array<{
+  identity: string;
+  idempotencyIdentity: string;
+  outcome: "accepted" | "rejected" | "unknown";
+}> {
   const receipts: Array<{
     identity: string;
+    idempotencyIdentity: string;
     outcome: "accepted" | "rejected" | "unknown";
   }> = [];
   const previousRunner = activeApplyMutationRunner;
   activeApplyMutationRunner = <T>(options: {
     identity: string;
+    idempotencyIdentity: string;
     operation: () => T;
     didMutate?: ((result: T) => boolean) | undefined;
     knownNoMutation?: ((error: unknown) => boolean) | undefined;
@@ -2707,12 +2719,14 @@ export function observedGitHubMutationAttemptsForTest(
       const result = options.operation();
       receipts.push({
         identity: options.identity,
+        idempotencyIdentity: options.idempotencyIdentity,
         outcome: options.didMutate?.(result) === false ? "rejected" : "accepted",
       });
       return result;
     } catch (error) {
       receipts.push({
         identity: options.identity,
+        idempotencyIdentity: options.idempotencyIdentity,
         outcome: options.knownNoMutation?.(error) === true ? "rejected" : "unknown",
       });
       throw error;
@@ -20572,7 +20586,11 @@ type ReviewLedgerItem = {
   started: boolean;
   startedAtMs: number | null;
   startEventId: string | null;
+  lastEventId: string | null;
   logPublication: boolean;
+  mutationAttemptCount: number;
+  mutationObserved: boolean;
+  uncertainMutationObserved: boolean;
   terminal: boolean;
 };
 
@@ -20591,6 +20609,9 @@ type ReviewActionLedger = {
   };
   batchStartEventId: string | null;
   items: Map<string, ReviewLedgerItem>;
+  nextPhaseSeq: number;
+  mutationObserved: boolean;
+  uncertainMutationObserved: boolean;
   startedAtMs: number;
   terminal: boolean;
 };
@@ -20700,7 +20721,11 @@ function startReviewActionLedger(options: {
       started: false,
       startedAtMs: null,
       startEventId: null,
+      lastEventId: null,
       logPublication: false,
+      mutationAttemptCount: 0,
+      mutationObserved: false,
+      uncertainMutationObserved: false,
       terminal: false,
     });
   }
@@ -20708,14 +20733,27 @@ function startReviewActionLedger(options: {
     operationIdentity,
     batchStartEventId: batchStart?.event_id ?? null,
     items,
+    nextPhaseSeq: 2,
+    mutationObserved: false,
+    uncertainMutationObserved: false,
     startedAtMs: Date.now(),
     terminal: false,
   };
 }
 
+function nextReviewPhaseSeq(ledger: ReviewActionLedger): number {
+  const phaseSeq = ledger.nextPhaseSeq;
+  if (phaseSeq >= 1_000_000) {
+    throw new Error("review action ledger exhausted per-item phase ordinals");
+  }
+  ledger.nextPhaseSeq += 1;
+  return phaseSeq;
+}
+
 function startReviewActionLedgerItem(ledger: ReviewActionLedger, item: Item): ActionEvent | null {
   const state = ledger.items.get(actionLedgerItemKey(item));
   if (!state || state.started) return null;
+  const phaseSeq = nextReviewPhaseSeq(ledger);
   const start = recordWorkflowPhaseEvent(ROOT, {
     phase: ACTION_EVENT_TYPES.reviewItem,
     status: ACTION_EVENT_STATUSES.started,
@@ -20731,7 +20769,7 @@ function startReviewActionLedgerItem(ledger: ReviewActionLedger, item: Item): Ac
     operation: "review",
     operationIdentity: ledger.operationIdentity,
     parentEventId: ledger.batchStartEventId,
-    phaseSeq: 10 + state.index * 10,
+    phaseSeq,
     idempotencyIdentity: {
       operationIdentity: ledger.operationIdentity,
       slot: "item_start",
@@ -20750,7 +20788,190 @@ function startReviewActionLedgerItem(ledger: ReviewActionLedger, item: Item): Ac
   state.started = true;
   state.startedAtMs = Date.now();
   state.startEventId = start?.event_id ?? null;
+  state.lastEventId = state.startEventId;
   return start;
+}
+
+type ReviewMutationAttempt = {
+  state: ReviewLedgerItem;
+  eventId: string | null;
+  idempotencyIdentity: {
+    operation: "review";
+    slot: "coordination_mutation";
+    repository: string;
+    number: number;
+    itemUpdatedAt: string;
+    mutationIdentitySha256: string;
+  };
+  mutationIndex: number;
+  receiptIdentitySha256: string;
+};
+
+function startReviewMutationAttempt(
+  ledger: ReviewActionLedger,
+  item: Item,
+  receiptIdentity: string,
+  idempotencyIdentity: string,
+): ReviewMutationAttempt | null {
+  let state = ledger.items.get(actionLedgerItemKey(item));
+  if (!state) return null;
+  if (!state.started) {
+    startReviewActionLedgerItem(ledger, item);
+    state = ledger.items.get(actionLedgerItemKey(item));
+  }
+  if (!state) return null;
+  const mutationIndex = state.mutationAttemptCount;
+  state.mutationAttemptCount += 1;
+  const businessIdempotencyIdentity = {
+    operation: "review" as const,
+    slot: "coordination_mutation" as const,
+    repository: item.repo,
+    number: item.number,
+    itemUpdatedAt: item.updatedAt,
+    mutationIdentitySha256: sha256(idempotencyIdentity),
+  };
+  const receiptIdentitySha256 = sha256(receiptIdentity);
+  const attempt = recordWorkflowPhaseEvent(ROOT, {
+    phase: ACTION_EVENT_TYPES.reviewItem,
+    status: ACTION_EVENT_STATUSES.started,
+    reasonCode: ACTION_EVENT_REASON_CODES.selected,
+    retryable: true,
+    mutation: false,
+    identity: {
+      slot: "review_coordination_mutation_attempt",
+      index: state.index,
+      mutationIndex,
+      receiptIdentitySha256,
+      repository: item.repo,
+      number: item.number,
+    },
+    operation: "review",
+    operationIdentity: ledger.operationIdentity,
+    parentEventId: state.lastEventId ?? state.startEventId,
+    phaseSeq: nextReviewPhaseSeq(ledger),
+    idempotencyIdentity: businessIdempotencyIdentity,
+    component: "review",
+    subject: actionLedgerItemSubject(item),
+    evidence: workflowRunEvidence(),
+    attributes: {
+      batch_index: state.index,
+      attempt: mutationIndex + 1,
+      action_count: 1,
+      partial: true,
+      completion_reason: "mutation_attempted",
+    },
+    privacy: actionLedgerPrivacy(),
+  });
+  state.lastEventId = attempt?.event_id ?? state.lastEventId;
+  return {
+    state,
+    eventId: attempt?.event_id ?? null,
+    idempotencyIdentity: businessIdempotencyIdentity,
+    mutationIndex,
+    receiptIdentitySha256,
+  };
+}
+
+function finishReviewMutationAttempt(options: {
+  ledger: ReviewActionLedger;
+  item: Item;
+  attempt: ReviewMutationAttempt;
+  outcome: "accepted" | "rejected" | "unknown";
+}): string | null {
+  const mutation = options.outcome !== "rejected";
+  const event = recordWorkflowPhaseEvent(ROOT, {
+    phase: ACTION_EVENT_TYPES.reviewItem,
+    status:
+      options.outcome === "accepted"
+        ? ACTION_EVENT_STATUSES.executed
+        : options.outcome === "rejected"
+          ? ACTION_EVENT_STATUSES.skipped
+          : ACTION_EVENT_STATUSES.failed,
+    reasonCode:
+      options.outcome === "accepted"
+        ? ACTION_EVENT_REASON_CODES.completed
+        : options.outcome === "rejected"
+          ? ACTION_EVENT_REASON_CODES.notApplicable
+          : ACTION_EVENT_REASON_CODES.unavailable,
+    retryable: options.outcome === "unknown",
+    mutation,
+    identity: {
+      slot: "review_coordination_mutation_outcome",
+      index: options.attempt.state.index,
+      mutationIndex: options.attempt.mutationIndex,
+      receiptIdentitySha256: options.attempt.receiptIdentitySha256,
+      outcome: options.outcome,
+      repository: options.item.repo,
+      number: options.item.number,
+    },
+    operation: "review",
+    operationIdentity: options.ledger.operationIdentity,
+    parentEventId: options.attempt.eventId,
+    phaseSeq: nextReviewPhaseSeq(options.ledger),
+    idempotencyIdentity: options.attempt.idempotencyIdentity,
+    component: "review",
+    subject: actionLedgerItemSubject(options.item),
+    evidence: workflowRunEvidence(),
+    attributes: {
+      batch_index: options.attempt.state.index,
+      attempt: options.attempt.mutationIndex + 1,
+      action_count: mutation ? 1 : 0,
+      partial: options.outcome === "unknown",
+      completion_reason:
+        options.outcome === "accepted"
+          ? "mutation_accepted"
+          : options.outcome === "rejected"
+            ? "mutation_rejected"
+            : "mutation_outcome_unknown",
+    },
+    privacy: actionLedgerPrivacy(),
+  });
+  options.attempt.state.lastEventId = event?.event_id ?? options.attempt.state.lastEventId;
+  if (mutation) {
+    options.attempt.state.mutationObserved = true;
+    options.ledger.mutationObserved = true;
+  }
+  if (options.outcome === "unknown") {
+    options.attempt.state.uncertainMutationObserved = true;
+    options.ledger.uncertainMutationObserved = true;
+  }
+  return event?.event_id ?? null;
+}
+
+function reviewMutationRunner(ledger: ReviewActionLedger, item: Item): MutationRunner {
+  return <T>(options: {
+    identity: string;
+    idempotencyIdentity: string;
+    operation: () => T;
+    didMutate?: ((result: T) => boolean) | undefined;
+    knownNoMutation?: ((error: unknown) => boolean) | undefined;
+  }): T => {
+    const attempt = startReviewMutationAttempt(
+      ledger,
+      item,
+      options.identity,
+      options.idempotencyIdentity,
+    );
+    if (!attempt) return options.operation();
+    try {
+      const result = options.operation();
+      finishReviewMutationAttempt({
+        ledger,
+        item,
+        attempt,
+        outcome: options.didMutate?.(result) === false ? "rejected" : "accepted",
+      });
+      return result;
+    } catch (error) {
+      finishReviewMutationAttempt({
+        ledger,
+        item,
+        attempt,
+        outcome: options.knownNoMutation?.(error) === true ? "rejected" : "unknown",
+      });
+      throw error;
+    }
+  };
 }
 
 function recordReviewLogPublication(options: {
@@ -20779,6 +21000,7 @@ function recordReviewLogPublication(options: {
           .filter((entry): entry is ActionEventEvidence => entry !== null)
       : [];
   const captured = logs.length > 0;
+  const phaseSeq = nextReviewPhaseSeq(options.ledger);
   const event = recordWorkflowPhaseEvent(ROOT, {
     phase: ACTION_EVENT_TYPES.reviewLogPublication,
     status: captured
@@ -20800,8 +21022,8 @@ function recordReviewLogPublication(options: {
     },
     operation: "review",
     operationIdentity: options.ledger.operationIdentity,
-    parentEventId: state.startEventId,
-    phaseSeq: 11 + state.index * 10,
+    parentEventId: state.lastEventId ?? state.startEventId,
+    phaseSeq,
     idempotencyIdentity: {
       operationIdentity: options.ledger.operationIdentity,
       slot: "review_logs",
@@ -20821,6 +21043,7 @@ function recordReviewLogPublication(options: {
     privacy: actionLedgerPrivacy(),
   });
   state.logPublication = true;
+  state.lastEventId = event?.event_id ?? state.lastEventId;
   return event;
 }
 
@@ -20863,12 +21086,13 @@ function finishReviewActionLedgerItem(options: {
   const reportEvidence = options.reportPath
     ? actionLedgerFileEvidence("review_record", options.reportPath)
     : null;
+  const phaseSeq = nextReviewPhaseSeq(options.ledger);
   const terminal = recordWorkflowPhaseEvent(ROOT, {
     phase: ACTION_EVENT_TYPES.reviewItem,
     status: options.status,
     reasonCode: options.reasonCode,
-    retryable: options.retryable,
-    mutation: false,
+    retryable: options.retryable && !state.uncertainMutationObserved,
+    mutation: state.mutationObserved,
     identity: {
       slot: "item_terminal",
       index: state.index,
@@ -20877,8 +21101,8 @@ function finishReviewActionLedgerItem(options: {
     },
     operation: "review",
     operationIdentity: options.ledger.operationIdentity,
-    parentEventId: state.startEventId,
-    phaseSeq: 12 + state.index * 10,
+    parentEventId: state.lastEventId ?? state.startEventId,
+    phaseSeq,
     idempotencyIdentity: {
       operationIdentity: options.ledger.operationIdentity,
       slot: "item_terminal",
@@ -20902,6 +21126,7 @@ function finishReviewActionLedgerItem(options: {
     privacy: actionLedgerPrivacy(),
   });
   state.terminal = true;
+  state.lastEventId = terminal?.event_id ?? state.lastEventId;
   return terminal;
 }
 
@@ -20996,8 +21221,8 @@ function finishReviewActionLedger(options: {
     phase: ACTION_EVENT_TYPES.reviewBatch,
     status,
     reasonCode,
-    retryable: failure !== null || partial,
-    mutation: false,
+    retryable: (failure !== null || partial) && !options.ledger.uncertainMutationObserved,
+    mutation: options.ledger.mutationObserved,
     identity: { slot: "batch_terminal" },
     operation: "review",
     operationIdentity: options.ledger.operationIdentity,
@@ -21161,7 +21386,6 @@ function reviewCommand(args: Args): void {
   const maintainerRequest = additionalPrompt.trim().length > 0;
   const readonlyModeSnapshots = readonlyOpenclaw ? makeTreeReadOnly(openclawDir) : [];
   const acquiredReviewLeases: Array<{ itemNumber: number; lease: AcquiredReviewStartLease }> = [];
-  let retainReviewLeasesForPublish = false;
   let reviewLedger: ReviewActionLedger | null = null;
   let activeReviewItem: Item | null = null;
   let completed = 0;
@@ -21243,8 +21467,10 @@ function reviewCommand(args: Args): void {
     for (const item of candidates) {
       activeReviewItem = item;
       let reviewItemFailed = false;
+      const previousReviewMutationRunner = activeReviewMutationRunner;
       try {
       startReviewActionLedgerItem(reviewLedger, item);
+      activeReviewMutationRunner = reviewMutationRunner(reviewLedger, item);
       if (humanLocalReview) {
         console.error("");
         console.error("Collecting GitHub context");
@@ -22204,24 +22430,28 @@ function reviewCommand(args: Args): void {
         reviewItemFailed = true;
         throw error;
       } finally {
-        if (
-          !reviewItemFailed &&
-          activeReviewItem &&
-          actionLedgerItemKey(activeReviewItem) === actionLedgerItemKey(item)
-        ) {
-          finishReviewActionLedgerItem({
-            ledger: reviewLedger,
-            item,
-            status: ACTION_EVENT_STATUSES.blocked,
-            reasonCode: ACTION_EVENT_REASON_CODES.leaseActive,
-            retryable: true,
-            cached: false,
-            startedAtMs:
-              reviewLedger.items.get(actionLedgerItemKey(item))?.startedAtMs ??
-              reviewLedger.startedAtMs,
-            completionReason: "coordination_deferred",
-          });
-          activeReviewItem = null;
+        try {
+          if (
+            !reviewItemFailed &&
+            activeReviewItem &&
+            actionLedgerItemKey(activeReviewItem) === actionLedgerItemKey(item)
+          ) {
+            finishReviewActionLedgerItem({
+              ledger: reviewLedger,
+              item,
+              status: ACTION_EVENT_STATUSES.blocked,
+              reasonCode: ACTION_EVENT_REASON_CODES.leaseActive,
+              retryable: true,
+              cached: false,
+              startedAtMs:
+                reviewLedger.items.get(actionLedgerItemKey(item))?.startedAtMs ??
+                reviewLedger.startedAtMs,
+              completionReason: "coordination_deferred",
+            });
+            activeReviewItem = null;
+          }
+        } finally {
+          activeReviewMutationRunner = previousReviewMutationRunner;
         }
       }
     }
@@ -22316,9 +22546,21 @@ function reviewCommand(args: Args): void {
       completedCount: completed,
       cacheHits,
     });
-    retainReviewLeasesForPublish = true;
   } catch (error) {
     if (reviewLedger) {
+      for (const acquired of acquiredReviewLeases) {
+        const state = [...reviewLedger.items.values()].find(
+          (candidate) => candidate.item.number === acquired.itemNumber,
+        );
+        if (!state) continue;
+        const previousReviewMutationRunner = activeReviewMutationRunner;
+        activeReviewMutationRunner = reviewMutationRunner(reviewLedger, state.item);
+        try {
+          deleteOwnedDedicatedReviewStartLease(acquired.itemNumber, acquired.lease);
+        } finally {
+          activeReviewMutationRunner = previousReviewMutationRunner;
+        }
+      }
       finishReviewActionLedger({
         ledger: reviewLedger,
         error,
@@ -22329,11 +22571,6 @@ function reviewCommand(args: Args): void {
     }
     throw error;
   } finally {
-    if (!retainReviewLeasesForPublish) {
-      for (const acquired of acquiredReviewLeases) {
-        deleteOwnedDedicatedReviewStartLease(acquired.itemNumber, acquired.lease);
-      }
-    }
     restoreTreeModes(readonlyModeSnapshots);
   }
 }
@@ -23584,6 +23821,11 @@ type ApplyItemBusinessIdempotencyIdentity = {
   decisionPacketSha256: string;
 };
 
+type ApplyMutationBusinessIdempotencyIdentity = ApplyItemBusinessIdempotencyIdentity & {
+  slot: "apply_mutation";
+  mutationIdentitySha256: string;
+};
+
 type ApplyLedgerItem = {
   entry: ReportEntry;
   index: number;
@@ -23752,6 +23994,24 @@ function applyItemIdempotencyIdentity(
   });
 }
 
+export function applyMutationBusinessIdempotencyIdentityForTest(options: {
+  repository: string;
+  number: number;
+  sourceRevision: string;
+  reviewContentDigest: string;
+  decisionPacketSha256: string;
+  mutationIdentity: string;
+}): ApplyMutationBusinessIdempotencyIdentity {
+  return {
+    ...applyItemBusinessIdempotencyIdentityForTest({
+      ...options,
+      slot: "apply_mutation",
+    }),
+    slot: "apply_mutation",
+    mutationIdentitySha256: sha256(options.mutationIdentity),
+  };
+}
+
 function applyLedgerItemSubject(
   state: ApplyLedgerItem,
   entry: ReportEntry = state.entry,
@@ -23818,25 +24078,26 @@ function startApplyActionLedgerItem(
 type ApplyMutationAttempt = {
   state: ApplyLedgerItem;
   eventId: string | null;
-  idempotencyIdentity: ApplyItemBusinessIdempotencyIdentity & {
-    mutationIdentitySha256: string;
-  };
+  idempotencyIdentity: ApplyMutationBusinessIdempotencyIdentity;
   mutationIndex: number;
+  receiptIdentitySha256: string;
 };
 
 function startApplyMutationAttempt(
   ledger: ApplyActionLedger,
   entry: ReportEntry,
-  identity: string,
+  receiptIdentity: string,
+  idempotencyIdentity: string,
 ): ApplyMutationAttempt | null {
   const state = startApplyActionLedgerItem(ledger, entry);
   if (!state) return null;
   const mutationIndex = state.mutationAttemptCount;
   state.mutationAttemptCount += 1;
-  const idempotencyIdentity = {
-    ...applyItemIdempotencyIdentity(state, "apply_mutation"),
-    mutationIdentitySha256: sha256(identity),
-  };
+  const businessIdempotencyIdentity = applyMutationBusinessIdempotencyIdentityForTest({
+    ...state.businessIdentity,
+    mutationIdentity: idempotencyIdentity,
+  });
+  const receiptIdentitySha256 = sha256(receiptIdentity);
   const phaseSeq = nextApplyPhaseSeq(ledger);
   const attempt = recordWorkflowPhaseEvent(ROOT, {
     phase: ACTION_EVENT_TYPES.applyAction,
@@ -23848,7 +24109,7 @@ function startApplyMutationAttempt(
       slot: "apply_mutation_attempt",
       index: state.index,
       mutationIndex,
-      mutationIdentitySha256: idempotencyIdentity.mutationIdentitySha256,
+      receiptIdentitySha256,
       repository: entry.repo,
       number: entry.number,
     },
@@ -23856,7 +24117,7 @@ function startApplyMutationAttempt(
     operationIdentity: ledger.operationIdentity,
     parentEventId: state.lastEventId ?? state.startEventId,
     phaseSeq,
-    idempotencyIdentity,
+    idempotencyIdentity: businessIdempotencyIdentity,
     component: "apply_decisions",
     subject: applyLedgerItemSubject(state),
     evidence: workflowRunEvidence(),
@@ -23873,8 +24134,9 @@ function startApplyMutationAttempt(
   return {
     state,
     eventId: attempt?.event_id ?? null,
-    idempotencyIdentity,
+    idempotencyIdentity: businessIdempotencyIdentity,
     mutationIndex,
+    receiptIdentitySha256,
   };
 }
 
@@ -23906,7 +24168,7 @@ function finishApplyMutationAttempt(options: {
       slot: "apply_mutation_outcome",
       index: options.attempt.state.index,
       mutationIndex: options.attempt.mutationIndex,
-      mutationIdentitySha256: options.attempt.idempotencyIdentity.mutationIdentitySha256,
+      receiptIdentitySha256: options.attempt.receiptIdentitySha256,
       outcome: options.outcome,
       repository: options.entry.repo,
       number: options.entry.number,
@@ -24848,12 +25110,18 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
     };
     activeApplyMutationRunner = <T>(options: {
       identity: string;
+      idempotencyIdentity: string;
       operation: () => T;
       didMutate?: ((result: T) => boolean) | undefined;
       knownNoMutation?: ((error: unknown) => boolean) | undefined;
     }): T => {
       if (dryRun) return options.operation();
-      const attempt = startApplyMutationAttempt(applyLedger, entry, options.identity);
+      const attempt = startApplyMutationAttempt(
+        applyLedger,
+        entry,
+        options.identity,
+        options.idempotencyIdentity,
+      );
       if (!attempt) return options.operation();
       try {
         const result = options.operation();

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -23988,6 +23988,7 @@ export function applyActionEventDisposition(
   action: ActionTaken,
   mutationOccurred: boolean,
   dryRun: boolean,
+  commentMutationOccurred = mutationOccurred,
 ): {
   status: ActionEventStatus;
   reasonCode: ActionEventReasonCode;
@@ -24023,6 +24024,15 @@ export function applyActionEventDisposition(
     };
   }
   if (action === "review_comment_synced" || action === "corrected_stale_canonical_comment") {
+    if (!commentMutationOccurred) {
+      return {
+        status: ACTION_EVENT_STATUSES.unchanged,
+        reasonCode: ACTION_EVENT_REASON_CODES.contentUnchanged,
+        retryable: false,
+        mutation: mutationOccurred,
+        completionReason: "comment_unchanged",
+      };
+    }
     return {
       status: ACTION_EVENT_STATUSES.completed,
       reasonCode: ACTION_EVENT_REASON_CODES.published,
@@ -24119,6 +24129,15 @@ export function reviewCommentPublicationEventDisposition(
   completionReason: string;
 } | null {
   if (action === "review_comment_synced" || action === "corrected_stale_canonical_comment") {
+    if (!dryRun && !commentMutationOccurred) {
+      return {
+        status: ACTION_EVENT_STATUSES.unchanged,
+        reasonCode: ACTION_EVENT_REASON_CODES.contentUnchanged,
+        retryable: false,
+        mutation: false,
+        completionReason: "comment_unchanged",
+      };
+    }
     return {
       status: dryRun ? ACTION_EVENT_STATUSES.planned : ACTION_EVENT_STATUSES.published,
       reasonCode: dryRun ? ACTION_EVENT_REASON_CODES.dryRun : ACTION_EVENT_REASON_CODES.published,
@@ -24189,14 +24208,16 @@ function recordApplyActionLedgerItemResults(options: {
           },
         ];
   for (const [resultIndex, result] of results.entries()) {
+    const commentMutationOccurred = result.commentMutationOccurred === true;
     const disposition = applyActionEventDisposition(
       result.action,
       options.mutationOccurred,
       options.dryRun,
+      commentMutationOccurred,
     );
     const commentDisposition = reviewCommentPublicationEventDisposition(
       result.action,
-      result.commentMutationOccurred === true,
+      commentMutationOccurred,
       options.dryRun,
     );
     const actionPhaseSeq = nextApplyPhaseSeq(options.ledger);

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -183,6 +183,21 @@ import {
   type ReviewHistoryLedger,
 } from "./review-history.js";
 import { trailingHtmlComments } from "./review-comment-markers.js";
+import {
+  ACTION_EVENT_REASON_CODES,
+  ACTION_EVENT_STATUSES,
+  ACTION_EVENT_TYPES,
+  type ActionEvent,
+  type ActionEventEvidence,
+  type ActionEventReasonCode,
+  type ActionEventStatus,
+  type ActionEventSubject,
+} from "./action-ledger.js";
+import {
+  flushWorkflowActionEvents,
+  importActionEventShards,
+  recordWorkflowPhaseEvent,
+} from "./action-ledger-runtime.js";
 
 export {
   codexEnv,
@@ -982,6 +997,7 @@ interface ApplyResult {
   number: number;
   action: ActionTaken;
   reason: string;
+  mutationOccurred?: boolean;
   durableReviewSynced?: boolean;
   terminalMissingVerified?: boolean;
   terminalStateVerified?: boolean;
@@ -2338,6 +2354,7 @@ interface GitHubRuntimeBudget {
   startedAtMs: number;
   maxRuntimeMs: number;
   onYield?: (reason: string, resumeCurrent?: boolean) => void;
+  onFailure?: (error: unknown) => void;
   yieldReason?: string;
 }
 
@@ -12895,19 +12912,20 @@ export function mergeRiskLabelsForTest(
   );
 }
 
-function ensurePriorityLabel(label: PriorityLabelSpec): void {
+function ensurePriorityLabel(label: PriorityLabelSpec, onMutation?: () => void): void {
   try {
     ghWithRetry(
       ["label", "create", label.name, "--color", label.color, "--description", label.description],
       2,
     );
+    onMutation?.();
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (!/already exists/i.test(message)) throw error;
   }
 }
 
-function ensureImpactLabel(name: ImpactLabelName): void {
+function ensureImpactLabel(name: ImpactLabelName, onMutation?: () => void): void {
   const definition = IMPACT_LABELS.find((label) => label.name === name);
   if (!definition) return;
   try {
@@ -12923,13 +12941,14 @@ function ensureImpactLabel(name: ImpactLabelName): void {
       ],
       2,
     );
+    onMutation?.();
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (!/already exists/i.test(message)) throw error;
   }
 }
 
-function ensureMergeRiskLabel(name: MergeRiskLabelName): void {
+function ensureMergeRiskLabel(name: MergeRiskLabelName, onMutation?: () => void): void {
   const definition = MERGE_RISK_LABELS.find((label) => label.name === name);
   if (!definition) return;
   try {
@@ -12945,6 +12964,7 @@ function ensureMergeRiskLabel(name: MergeRiskLabelName): void {
       ],
       2,
     );
+    onMutation?.();
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (!/already exists/i.test(message)) throw error;
@@ -13221,7 +13241,7 @@ function issueAdvisoryLabelStateFromReport(
   };
 }
 
-function ensureIssueAdvisorySyncLabel(name: string): void {
+function ensureIssueAdvisorySyncLabel(name: string, onMutation?: () => void): void {
   const definition =
     ISSUE_ADVISORY_LABELS.find((label) => label.name === name) ??
     (name.toLowerCase() === GOOD_FIRST_ISSUE_LABEL
@@ -13244,13 +13264,14 @@ function ensureIssueAdvisorySyncLabel(name: string): void {
       ],
       2,
     );
+    onMutation?.();
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (!/already exists/i.test(message)) throw error;
   }
 }
 
-function ensureMaturityLabel(name: MaturityLabelName): void {
+function ensureMaturityLabel(name: MaturityLabelName, onMutation?: () => void): void {
   const definition = MATURITY_LABELS.find((label) => label.name === name);
   if (!definition) return;
   try {
@@ -13266,6 +13287,7 @@ function ensureMaturityLabel(name: MaturityLabelName): void {
       ],
       2,
     );
+    onMutation?.();
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (!/already exists/i.test(message)) throw error;
@@ -13277,6 +13299,7 @@ function syncPriorityLabel(options: {
   labels: readonly string[];
   triagePriority: TriagePriority;
   dryRun: boolean;
+  onMutation?: () => void;
 }): { labels: string[]; changed: boolean } {
   const nextLabels = nextPriorityLabels(options.labels, options.triagePriority);
   const labelsToRemove = options.labels.filter(
@@ -13290,10 +13313,11 @@ function syncPriorityLabel(options: {
   if (options.dryRun) return { labels: nextLabels, changed };
   if (labelToAdd) {
     const priorityLabel = PRIORITY_LABELS.find((label) => label.name === labelToAdd);
-    if (priorityLabel) ensurePriorityLabel(priorityLabel);
+    if (priorityLabel) ensurePriorityLabel(priorityLabel, options.onMutation);
   }
   for (const label of labelsToRemove) {
     ghWithRetry(["issue", "edit", String(options.number), "--remove-label", label]);
+    options.onMutation?.();
   }
   const syncedLabels = options.labels.filter((label) => !labelsToRemove.includes(label));
   const added =
@@ -13302,6 +13326,7 @@ function syncPriorityLabel(options: {
       number: options.number,
       label: labelToAdd,
       currentLabels: syncedLabels,
+      onMutation: options.onMutation,
     });
   if (added) syncedLabels.push(labelToAdd);
   return { labels: syncedLabels, changed: labelsToRemove.length > 0 || added };
@@ -13312,6 +13337,7 @@ function syncImpactLabels(options: {
   labels: readonly string[];
   impactLabels: readonly ImpactLabelName[];
   dryRun: boolean;
+  onMutation?: () => void;
 }): { labels: string[]; changed: boolean } {
   const nextLabels = nextImpactLabels(options.labels, options.impactLabels);
   const currentLabelKeys = new Set(options.labels.map((label) => label.toLowerCase()));
@@ -13328,12 +13354,20 @@ function syncImpactLabels(options: {
   if (options.dryRun) return { labels: nextLabels, changed };
   for (const label of labelsToRemove) {
     ghWithRetry(["issue", "edit", String(options.number), "--remove-label", label]);
+    options.onMutation?.();
   }
   const syncedLabels = options.labels.filter((label) => !labelsToRemove.includes(label));
   let added = false;
   for (const label of labelsToAdd) {
-    ensureImpactLabel(label);
-    if (tryAddOptionalLabel({ number: options.number, label, currentLabels: syncedLabels })) {
+    ensureImpactLabel(label, options.onMutation);
+    if (
+      tryAddOptionalLabel({
+        number: options.number,
+        label,
+        currentLabels: syncedLabels,
+        onMutation: options.onMutation,
+      })
+    ) {
       syncedLabels.push(label);
       added = true;
     }
@@ -13346,6 +13380,7 @@ function syncMaturityLabels(options: {
   labels: readonly string[];
   maturityLabels: readonly MaturityLabelName[];
   dryRun: boolean;
+  onMutation?: () => void;
 }): { labels: string[]; changed: boolean } {
   const nextLabels = nextMaturityLabels(options.labels, options.maturityLabels);
   const currentLabelKeys = new Set(options.labels.map((label) => label.toLowerCase()));
@@ -13362,12 +13397,20 @@ function syncMaturityLabels(options: {
   if (options.dryRun) return { labels: nextLabels, changed };
   for (const label of labelsToRemove) {
     ghWithRetry(["issue", "edit", String(options.number), "--remove-label", label]);
+    options.onMutation?.();
   }
   const syncedLabels = options.labels.filter((label) => !labelsToRemove.includes(label));
   let added = false;
   for (const label of labelsToAdd) {
-    ensureMaturityLabel(label);
-    if (tryAddOptionalLabel({ number: options.number, label, currentLabels: syncedLabels })) {
+    ensureMaturityLabel(label, options.onMutation);
+    if (
+      tryAddOptionalLabel({
+        number: options.number,
+        label,
+        currentLabels: syncedLabels,
+        onMutation: options.onMutation,
+      })
+    ) {
       syncedLabels.push(label);
       added = true;
     }
@@ -13380,6 +13423,7 @@ function syncMergeRiskLabels(options: {
   labels: readonly string[];
   mergeRiskLabels: readonly MergeRiskLabelName[];
   dryRun: boolean;
+  onMutation?: () => void;
 }): { labels: string[]; changed: boolean } {
   const nextLabels = nextMergeRiskLabels(options.labels, options.mergeRiskLabels);
   const currentLabelKeys = new Set(options.labels.map((label) => label.toLowerCase()));
@@ -13396,12 +13440,20 @@ function syncMergeRiskLabels(options: {
   if (options.dryRun) return { labels: nextLabels, changed };
   for (const label of labelsToRemove) {
     ghWithRetry(["issue", "edit", String(options.number), "--remove-label", label]);
+    options.onMutation?.();
   }
   const syncedLabels = options.labels.filter((label) => !labelsToRemove.includes(label));
   let added = false;
   for (const label of labelsToAdd) {
-    ensureMergeRiskLabel(label);
-    if (tryAddOptionalLabel({ number: options.number, label, currentLabels: syncedLabels })) {
+    ensureMergeRiskLabel(label, options.onMutation);
+    if (
+      tryAddOptionalLabel({
+        number: options.number,
+        label,
+        currentLabels: syncedLabels,
+        onMutation: options.onMutation,
+      })
+    ) {
       syncedLabels.push(label);
       added = true;
     }
@@ -13414,6 +13466,7 @@ function syncIssueAdvisoryLabels(options: {
   labels: readonly string[];
   state: IssueAdvisoryLabelState;
   dryRun: boolean;
+  onMutation?: () => void;
 }): { labels: string[]; changed: boolean } {
   const nextLabels = nextIssueAdvisoryLabels(options.labels, options.state);
   const currentLabelKeys = new Set(options.labels.map((label) => label.toLowerCase()));
@@ -13437,12 +13490,20 @@ function syncIssueAdvisoryLabels(options: {
   if (options.dryRun) return { labels: nextLabels, changed };
   for (const label of labelsToRemove) {
     ghWithRetry(["issue", "edit", String(options.number), "--remove-label", label]);
+    options.onMutation?.();
   }
   const syncedLabels = options.labels.filter((label) => !labelsToRemove.includes(label));
   let added = false;
   for (const label of labelsToAdd) {
-    ensureIssueAdvisorySyncLabel(label);
-    if (tryAddOptionalLabel({ number: options.number, label, currentLabels: syncedLabels })) {
+    ensureIssueAdvisorySyncLabel(label, options.onMutation);
+    if (
+      tryAddOptionalLabel({
+        number: options.number,
+        label,
+        currentLabels: syncedLabels,
+        onMutation: options.onMutation,
+      })
+    ) {
       syncedLabels.push(label);
       added = true;
     }
@@ -13455,6 +13516,7 @@ function syncTelegramVisibleProofLabel(options: {
   labels: readonly string[];
   proof: Pick<TelegramVisibleProof, "status">;
   dryRun: boolean;
+  onMutation?: () => void;
 }): { labels: string[]; changed: boolean } {
   const nextLabels = nextTelegramVisibleProofLabels(options.labels, options.proof);
   const hadLabel = options.labels.includes(TELEGRAM_VISIBLE_PROOF_LABEL);
@@ -13462,13 +13524,14 @@ function syncTelegramVisibleProofLabel(options: {
   const changed = hadLabel !== wantsLabel;
   if (!changed) return { labels: nextLabels, changed };
   if (options.dryRun) return { labels: nextLabels, changed };
-  if (wantsLabel) ensureTelegramVisibleProofLabel();
+  if (wantsLabel) ensureTelegramVisibleProofLabel(options.onMutation);
   if (wantsLabel) {
     if (
       !tryAddOptionalLabel({
         number: options.number,
         label: TELEGRAM_VISIBLE_PROOF_LABEL,
         currentLabels: options.labels,
+        onMutation: options.onMutation,
       })
     ) {
       return { labels: [...options.labels], changed: false };
@@ -13481,11 +13544,12 @@ function syncTelegramVisibleProofLabel(options: {
       "--remove-label",
       TELEGRAM_VISIBLE_PROOF_LABEL,
     ]);
+    options.onMutation?.();
   }
   return { labels: nextLabels, changed };
 }
 
-function ensurePrRatingLabel(tier: PrRatingTier): void {
+function ensurePrRatingLabel(tier: PrRatingTier, onMutation?: () => void): void {
   const definition = ratingLabelForTier(tier);
   try {
     ghWithRetry(
@@ -13500,13 +13564,14 @@ function ensurePrRatingLabel(tier: PrRatingTier): void {
       ],
       2,
     );
+    onMutation?.();
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (!/already exists/i.test(message)) throw error;
   }
 }
 
-function ensureFeatureShowcaseLabel(): void {
+function ensureFeatureShowcaseLabel(onMutation?: () => void): void {
   try {
     ghWithRetry(
       [
@@ -13520,13 +13585,14 @@ function ensureFeatureShowcaseLabel(): void {
       ],
       2,
     );
+    onMutation?.();
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (!/already exists/i.test(message)) throw error;
   }
 }
 
-function ensurePrStatusLabel(kind: PrStatusLabelKind): void {
+function ensurePrStatusLabel(kind: PrStatusLabelKind, onMutation?: () => void): void {
   const definition = prStatusLabelForKind(kind);
   try {
     ghWithRetry(
@@ -13541,6 +13607,7 @@ function ensurePrStatusLabel(kind: PrStatusLabelKind): void {
       ],
       2,
     );
+    onMutation?.();
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (!/already exists/i.test(message)) throw error;
@@ -13557,18 +13624,20 @@ function syncFeatureShowcaseLabel(options: {
   securityReview: Pick<SecurityReview, "status">;
   overallCorrectness: OverallCorrectness;
   dryRun: boolean;
+  onMutation?: () => void;
 }): { labels: string[]; changed: boolean } {
   const nextLabels = nextFeatureShowcaseLabels(options.labels, options);
   const changed =
     nextLabels.includes(FEATURE_SHOWCASE_LABEL) && !options.labels.includes(FEATURE_SHOWCASE_LABEL);
   if (!changed) return { labels: nextLabels, changed };
   if (options.dryRun) return { labels: nextLabels, changed };
-  ensureFeatureShowcaseLabel();
+  ensureFeatureShowcaseLabel(options.onMutation);
   if (
     !tryAddOptionalLabel({
       number: options.number,
       label: FEATURE_SHOWCASE_LABEL,
       currentLabels: options.labels,
+      onMutation: options.onMutation,
     })
   ) {
     return { labels: [...options.labels], changed: false };
@@ -13582,6 +13651,7 @@ function syncPrRatingLabel(options: {
   rating: Pick<PrRating, "overallTier">;
   reviewFailed?: boolean;
   dryRun: boolean;
+  onMutation?: () => void;
 }): { labels: string[]; changed: boolean } {
   const nextLabels = nextPrRatingLabels(options.labels, options.rating, options.reviewFailed);
   const currentLabelKeys = new Set(options.labels.map((label) => label.toLowerCase()));
@@ -13595,9 +13665,10 @@ function syncPrRatingLabel(options: {
   const changed = labelsToRemove.length > 0 || Boolean(labelToAdd);
   if (!changed) return { labels: nextLabels, changed };
   if (options.dryRun) return { labels: nextLabels, changed };
-  if (labelToAdd) ensurePrRatingLabel(options.rating.overallTier);
+  if (labelToAdd) ensurePrRatingLabel(options.rating.overallTier, options.onMutation);
   for (const label of labelsToRemove) {
     ghWithRetry(["issue", "edit", String(options.number), "--remove-label", label]);
+    options.onMutation?.();
   }
   const syncedLabels = options.labels.filter((label) => !labelsToRemove.includes(label));
   const added =
@@ -13606,6 +13677,7 @@ function syncPrRatingLabel(options: {
       number: options.number,
       label: labelToAdd,
       currentLabels: syncedLabels,
+      onMutation: options.onMutation,
     });
   if (added) syncedLabels.push(labelToAdd);
   return { labels: syncedLabels, changed: labelsToRemove.length > 0 || added };
@@ -13616,6 +13688,7 @@ function syncPrStatusLabel(options: {
   labels: readonly string[];
   statusKind: PrStatusLabelKind | null;
   dryRun: boolean;
+  onMutation?: () => void;
 }): { labels: string[]; changed: boolean } {
   const nextLabels = nextPrStatusLabels(options.labels, options.statusKind);
   const currentLabelKeys = new Set(options.labels.map((label) => label.toLowerCase()));
@@ -13629,9 +13702,12 @@ function syncPrStatusLabel(options: {
   const changed = labelsToRemove.length > 0 || Boolean(labelToAdd);
   if (!changed) return { labels: nextLabels, changed };
   if (options.dryRun) return { labels: nextLabels, changed };
-  if (options.statusKind && labelToAdd) ensurePrStatusLabel(options.statusKind);
+  if (options.statusKind && labelToAdd) {
+    ensurePrStatusLabel(options.statusKind, options.onMutation);
+  }
   for (const label of labelsToRemove) {
     ghWithRetry(["issue", "edit", String(options.number), "--remove-label", label]);
+    options.onMutation?.();
   }
   const syncedLabels = options.labels.filter((label) => !labelsToRemove.includes(label));
   const added =
@@ -13640,12 +13716,13 @@ function syncPrStatusLabel(options: {
       number: options.number,
       label: labelToAdd,
       currentLabels: syncedLabels,
+      onMutation: options.onMutation,
     });
   if (added) syncedLabels.push(labelToAdd);
   return { labels: syncedLabels, changed: labelsToRemove.length > 0 || added };
 }
 
-function ensureTelegramVisibleProofLabel(): void {
+function ensureTelegramVisibleProofLabel(onMutation?: () => void): void {
   try {
     ghWithRetry(
       [
@@ -13659,6 +13736,7 @@ function ensureTelegramVisibleProofLabel(): void {
       ],
       2,
     );
+    onMutation?.();
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (!/already exists/i.test(message)) throw error;
@@ -13679,6 +13757,7 @@ function tryAddOptionalLabel(options: {
   number: number;
   label: string;
   currentLabels: readonly string[];
+  onMutation?: (() => void) | undefined;
 }): boolean {
   if (options.currentLabels.length >= 100) {
     console.warn(
@@ -13688,6 +13767,7 @@ function tryAddOptionalLabel(options: {
   }
   try {
     ghWithRetry(["issue", "edit", String(options.number), "--add-label", options.label]);
+    options.onMutation?.();
     return true;
   } catch (error) {
     if (!missingLabelError(error, options.label) && !labelCapacityError(error)) throw error;
@@ -13708,7 +13788,7 @@ export function isGitHubLabelCapacityErrorForTest(message: string): boolean {
   return labelCapacityError(new Error(message));
 }
 
-function ensureRealBehaviorProofSufficientLabel(): boolean {
+function ensureRealBehaviorProofSufficientLabel(onMutation?: () => void): boolean {
   try {
     ghWithRetry(
       [
@@ -13722,6 +13802,7 @@ function ensureRealBehaviorProofSufficientLabel(): boolean {
       ],
       2,
     );
+    onMutation?.();
     return true;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -13731,7 +13812,7 @@ function ensureRealBehaviorProofSufficientLabel(): boolean {
   }
 }
 
-function ensureRealBehaviorProofMediaLabel(name: string): boolean {
+function ensureRealBehaviorProofMediaLabel(name: string, onMutation?: () => void): boolean {
   const definition = PROOF_MEDIA_LABELS.find((label) => label.name === name);
   if (!definition) return false;
   try {
@@ -13747,6 +13828,7 @@ function ensureRealBehaviorProofMediaLabel(name: string): boolean {
       ],
       2,
     );
+    onMutation?.();
     return true;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -13761,6 +13843,7 @@ function syncRealBehaviorProofSufficientLabel(options: {
   labels: readonly string[];
   proof: Pick<RealBehaviorProof, "status">;
   dryRun: boolean;
+  onMutation?: () => void;
 }): { labels: string[]; changed: boolean } {
   const nextLabels = nextRealBehaviorProofSufficientLabels(options.labels, options.proof);
   const hadLabel = options.labels.includes(PROOF_SUFFICIENT_LABEL);
@@ -13768,7 +13851,7 @@ function syncRealBehaviorProofSufficientLabel(options: {
   const changed = hadLabel !== wantsLabel;
   if (!changed) return { labels: nextLabels, changed };
   if (options.dryRun) return { labels: nextLabels, changed };
-  if (wantsLabel && !ensureRealBehaviorProofSufficientLabel()) {
+  if (wantsLabel && !ensureRealBehaviorProofSufficientLabel(options.onMutation)) {
     return { labels: [...options.labels], changed: false };
   }
   if (wantsLabel) {
@@ -13777,6 +13860,7 @@ function syncRealBehaviorProofSufficientLabel(options: {
         number: options.number,
         label: PROOF_SUFFICIENT_LABEL,
         currentLabels: options.labels,
+        onMutation: options.onMutation,
       })
     ) {
       return { labels: [...options.labels], changed: false };
@@ -13790,6 +13874,7 @@ function syncRealBehaviorProofSufficientLabel(options: {
         "--remove-label",
         PROOF_SUFFICIENT_LABEL,
       ]);
+      options.onMutation?.();
     } catch (error) {
       if (!missingLabelError(error, PROOF_SUFFICIENT_LABEL)) throw error;
       console.warn(
@@ -13807,6 +13892,7 @@ function syncRealBehaviorProofMediaLabels(options: {
   labels: readonly string[];
   proof: Pick<RealBehaviorProof, "evidenceKind">;
   dryRun: boolean;
+  onMutation?: () => void;
 }): { labels: string[]; changed: boolean } {
   const nextLabels = nextRealBehaviorProofMediaLabels(options.labels, options.proof);
   const currentLabelKeys = new Set(options.labels.map((label) => label.toLowerCase()));
@@ -13824,6 +13910,7 @@ function syncRealBehaviorProofMediaLabels(options: {
   for (const label of labelsToRemove) {
     try {
       ghWithRetry(["issue", "edit", String(options.number), "--remove-label", label]);
+      options.onMutation?.();
       const index = syncedLabels.indexOf(label);
       if (index >= 0) syncedLabels.splice(index, 1);
     } catch (error) {
@@ -13836,8 +13923,15 @@ function syncRealBehaviorProofMediaLabels(options: {
     }
   }
   for (const label of labelsToAdd) {
-    if (!ensureRealBehaviorProofMediaLabel(label)) continue;
-    if (tryAddOptionalLabel({ number: options.number, label, currentLabels: syncedLabels })) {
+    if (!ensureRealBehaviorProofMediaLabel(label, options.onMutation)) continue;
+    if (
+      tryAddOptionalLabel({
+        number: options.number,
+        label,
+        currentLabels: syncedLabels,
+        onMutation: options.onMutation,
+      })
+    ) {
       syncedLabels.push(label);
     }
   }
@@ -17831,6 +17925,7 @@ function syncStalePullRequestReviewLabels(options: {
   number: number;
   labels: readonly string[];
   dryRun: boolean;
+  onMutation?: () => void;
 }): { labels: string[]; changed: boolean } {
   const labelsToRemove = options.labels.filter(isStalePullRequestReviewLabel);
   if (labelsToRemove.length === 0) return { labels: [...options.labels], changed: false };
@@ -17838,6 +17933,7 @@ function syncStalePullRequestReviewLabels(options: {
   if (!options.dryRun) {
     for (const label of labelsToRemove) {
       ghWithRetry(["issue", "edit", String(options.number), "--remove-label", label]);
+      options.onMutation?.();
     }
   }
   return { labels: nextLabels, changed: true };
@@ -20099,6 +20195,449 @@ export function buildLocalRangeReviewForTest(
   return buildLocalRangeReview(targetDir, repo, baseRef);
 }
 
+const ACTION_LEDGER_DROPPED_FIELDS = [
+  "body",
+  "comments",
+  "diff",
+  "logs",
+  "patch",
+  "prompt",
+] as const;
+
+type ReviewLedgerItem = {
+  item: Item;
+  index: number;
+  startEventId: string | null;
+  logPublication: boolean;
+  terminal: boolean;
+};
+
+type ReviewActionLedger = {
+  operationIdentity: {
+    repository: string;
+    reviewPolicy: string;
+    shardIndex: number;
+    shardCount: number;
+    candidateNumbers: number[];
+  };
+  batchStartEventId: string | null;
+  items: Map<string, ReviewLedgerItem>;
+  startedAtMs: number;
+  terminal: boolean;
+};
+
+function actionLedgerItemKey(item: Pick<Item, "repo" | "number">): string {
+  return `${item.repo}#${item.number}`;
+}
+
+function actionLedgerPrivacy() {
+  return {
+    classification: "internal" as const,
+    redactionVersion: "v1",
+    fieldsDropped: ACTION_LEDGER_DROPPED_FIELDS,
+  };
+}
+
+function workflowRunEvidence(): ActionEventEvidence[] {
+  const repository = String(process.env.GITHUB_REPOSITORY ?? "").trim();
+  const runId = String(process.env.GITHUB_RUN_ID ?? "").trim();
+  if (!/^[a-z0-9_][a-z0-9_.-]*\/[a-z0-9_][a-z0-9_.-]*$/i.test(repository) || !/^\d+$/.test(runId)) {
+    return [];
+  }
+  return [
+    {
+      kind: "workflow_run",
+      runUrl: `https://github.com/${repository}/actions/runs/${runId}`,
+    },
+  ];
+}
+
+function actionLedgerFileEvidence(kind: string, filePath: string): ActionEventEvidence | null {
+  if (!existsSync(filePath)) return null;
+  const recordPath = repoRelativePath(filePath);
+  return {
+    kind,
+    sha256: sha256(readFileSync(filePath, "utf8")),
+    ...(recordPath.startsWith("../") ? {} : { reportPath: recordPath }),
+  };
+}
+
+function actionLedgerItemSubject(
+  item: Item,
+  options: { sourceRevision?: string; recordPath?: string } = {},
+): ActionEventSubject {
+  return {
+    repository: item.repo,
+    kind: item.kind,
+    number: item.number,
+    ...(options.sourceRevision ? { sourceRevision: options.sourceRevision } : {}),
+    ...(options.recordPath && !options.recordPath.startsWith("../")
+      ? { recordPath: options.recordPath }
+      : {}),
+  };
+}
+
+function startReviewActionLedger(options: {
+  candidates: readonly Item[];
+  reviewPolicy: string;
+  shardIndex: number;
+  shardCount: number;
+  batchSize: number;
+}): ReviewActionLedger {
+  const operationIdentity = {
+    repository: targetRepo(),
+    reviewPolicy: options.reviewPolicy,
+    shardIndex: options.shardIndex,
+    shardCount: options.shardCount,
+    candidateNumbers: options.candidates.map((item) => item.number),
+  };
+  const batchStart = recordWorkflowPhaseEvent(ROOT, {
+    phase: ACTION_EVENT_TYPES.reviewBatch,
+    status: ACTION_EVENT_STATUSES.started,
+    reasonCode: ACTION_EVENT_REASON_CODES.selected,
+    retryable: false,
+    mutation: false,
+    identity: { slot: "batch_start" },
+    operation: "review",
+    operationIdentity,
+    phaseSeq: 1,
+    idempotencyIdentity: { operationIdentity, slot: "batch_start" },
+    component: "review",
+    subject: {
+      repository: targetRepo(),
+      kind: "workflow",
+    },
+    evidence: workflowRunEvidence(),
+    attributes: {
+      candidate_count: options.candidates.length,
+      batch_size: options.batchSize,
+      shard_index: options.shardIndex,
+      shard_count: options.shardCount,
+      review_mode: "propose",
+    },
+    privacy: actionLedgerPrivacy(),
+  });
+  const items = new Map<string, ReviewLedgerItem>();
+  for (const [index, item] of options.candidates.entries()) {
+    if (!Number.isSafeInteger(item.number) || item.number <= 0) continue;
+    const start = recordWorkflowPhaseEvent(ROOT, {
+      phase: ACTION_EVENT_TYPES.reviewItem,
+      status: ACTION_EVENT_STATUSES.started,
+      reasonCode: ACTION_EVENT_REASON_CODES.selected,
+      retryable: false,
+      mutation: false,
+      identity: { slot: "item_start", index, repository: item.repo, number: item.number },
+      operation: "review",
+      operationIdentity,
+      parentEventId: batchStart?.event_id ?? null,
+      phaseSeq: 10 + index * 10,
+      idempotencyIdentity: {
+        operationIdentity,
+        slot: "item_start",
+        index,
+        repository: item.repo,
+        number: item.number,
+      },
+      component: "review",
+      subject: actionLedgerItemSubject(item),
+      attributes: {
+        batch_index: index,
+        review_mode: "propose",
+      },
+      privacy: actionLedgerPrivacy(),
+    });
+    items.set(actionLedgerItemKey(item), {
+      item,
+      index,
+      startEventId: start?.event_id ?? null,
+      logPublication: false,
+      terminal: false,
+    });
+  }
+  return {
+    operationIdentity,
+    batchStartEventId: batchStart?.event_id ?? null,
+    items,
+    startedAtMs: Date.now(),
+    terminal: false,
+  };
+}
+
+function recordReviewLogPublication(options: {
+  ledger: ReviewActionLedger;
+  item: Item;
+  codexWorkDir?: string;
+  cached: boolean;
+  missingStatus?: ActionEventStatus;
+  missingReasonCode?: ActionEventReasonCode;
+  retryable?: boolean;
+}): ActionEvent | null {
+  const state = options.ledger.items.get(actionLedgerItemKey(options.item));
+  if (!state || state.logPublication) return null;
+  const prefix = `${options.item.number}.`;
+  const logs =
+    options.codexWorkDir && existsSync(options.codexWorkDir)
+      ? readdirSync(options.codexWorkDir)
+          .filter(
+            (name) =>
+              name.startsWith(prefix) &&
+              (name.endsWith(".codex.stdout.log") || name.endsWith(".codex.stderr.log")),
+          )
+          .sort()
+          .slice(0, 64)
+          .map((name) => actionLedgerFileEvidence("review_log", join(options.codexWorkDir!, name)))
+          .filter((entry): entry is ActionEventEvidence => entry !== null)
+      : [];
+  const published = logs.length > 0;
+  const event = recordWorkflowPhaseEvent(ROOT, {
+    phase: ACTION_EVENT_TYPES.reviewLogPublication,
+    status: published
+      ? ACTION_EVENT_STATUSES.published
+      : (options.missingStatus ?? ACTION_EVENT_STATUSES.skipped),
+    reasonCode: published
+      ? ACTION_EVENT_REASON_CODES.published
+      : (options.missingReasonCode ??
+        (options.cached
+          ? ACTION_EVENT_REASON_CODES.notApplicable
+          : ACTION_EVENT_REASON_CODES.notFound)),
+    retryable: published ? false : (options.retryable ?? false),
+    mutation: false,
+    identity: {
+      slot: "review_logs",
+      index: state.index,
+      repository: options.item.repo,
+      number: options.item.number,
+    },
+    operation: "review",
+    operationIdentity: options.ledger.operationIdentity,
+    parentEventId: state.startEventId,
+    phaseSeq: 11 + state.index * 10,
+    idempotencyIdentity: {
+      operationIdentity: options.ledger.operationIdentity,
+      slot: "review_logs",
+      index: state.index,
+      repository: options.item.repo,
+      number: options.item.number,
+    },
+    component: "review",
+    subject: actionLedgerItemSubject(options.item),
+    evidence: [...workflowRunEvidence(), ...logs],
+    attributes: {
+      cached: options.cached,
+      log_count: logs.length,
+      log_kind: "codex",
+      publication_kind: "artifact",
+    },
+    privacy: actionLedgerPrivacy(),
+  });
+  state.logPublication = true;
+  return event;
+}
+
+function finishReviewActionLedgerItem(options: {
+  ledger: ReviewActionLedger;
+  item: Item;
+  status: ActionEventStatus;
+  reasonCode: ActionEventReasonCode;
+  retryable: boolean;
+  cached: boolean;
+  startedAtMs: number;
+  sourceRevision?: string;
+  reportPath?: string;
+  findingCount?: number;
+  completionReason?: string;
+}): ActionEvent | null {
+  const state = options.ledger.items.get(actionLedgerItemKey(options.item));
+  if (!state || state.terminal) return null;
+  if (!state.logPublication) {
+    recordReviewLogPublication({
+      ledger: options.ledger,
+      item: options.item,
+      cached: options.cached,
+      missingStatus:
+        options.status === ACTION_EVENT_STATUSES.completed ||
+        options.status === ACTION_EVENT_STATUSES.cached
+          ? ACTION_EVENT_STATUSES.skipped
+          : options.status,
+      missingReasonCode:
+        options.status === ACTION_EVENT_STATUSES.completed ||
+        options.status === ACTION_EVENT_STATUSES.cached
+          ? options.cached
+            ? ACTION_EVENT_REASON_CODES.notApplicable
+            : ACTION_EVENT_REASON_CODES.notFound
+          : options.reasonCode,
+      retryable: options.retryable,
+    });
+  }
+  const reportPath = options.reportPath ? repoRelativePath(options.reportPath) : undefined;
+  const reportEvidence = options.reportPath
+    ? actionLedgerFileEvidence("review_record", options.reportPath)
+    : null;
+  const terminal = recordWorkflowPhaseEvent(ROOT, {
+    phase: ACTION_EVENT_TYPES.reviewItem,
+    status: options.status,
+    reasonCode: options.reasonCode,
+    retryable: options.retryable,
+    mutation: false,
+    identity: {
+      slot: "item_terminal",
+      index: state.index,
+      repository: options.item.repo,
+      number: options.item.number,
+    },
+    operation: "review",
+    operationIdentity: options.ledger.operationIdentity,
+    parentEventId: state.startEventId,
+    phaseSeq: 12 + state.index * 10,
+    idempotencyIdentity: {
+      operationIdentity: options.ledger.operationIdentity,
+      slot: "item_terminal",
+      index: state.index,
+      repository: options.item.repo,
+      number: options.item.number,
+    },
+    component: "review",
+    subject: actionLedgerItemSubject(options.item, {
+      ...(options.sourceRevision ? { sourceRevision: options.sourceRevision } : {}),
+      ...(reportPath ? { recordPath: reportPath } : {}),
+    }),
+    evidence: [...workflowRunEvidence(), ...(reportEvidence ? [reportEvidence] : [])],
+    attributes: {
+      cached: options.cached,
+      duration_ms: Math.max(0, Date.now() - options.startedAtMs),
+      review_mode: "propose",
+      ...(options.findingCount === undefined ? {} : { finding_count: options.findingCount }),
+      ...(options.completionReason ? { completion_reason: options.completionReason } : {}),
+    },
+    privacy: actionLedgerPrivacy(),
+  });
+  state.terminal = true;
+  return terminal;
+}
+
+export function actionLedgerFailureDisposition(error: unknown): {
+  status: ActionEventStatus;
+  reasonCode: ActionEventReasonCode;
+  completionReason: string;
+} {
+  const message = error instanceof Error ? error.message : String(error);
+  if (error instanceof GitHubRuntimeBudgetError) {
+    return {
+      status: ACTION_EVENT_STATUSES.yielded,
+      reasonCode: ACTION_EVENT_REASON_CODES.runtimeBudget,
+      completionReason: "runtime_budget",
+    };
+  }
+  if (/timed?\s*out|timeout|etimedout|sigterm|signal 15/i.test(message)) {
+    return {
+      status: ACTION_EVENT_STATUSES.failed,
+      reasonCode: ACTION_EVENT_REASON_CODES.timeout,
+      completionReason: "timeout",
+    };
+  }
+  if (/cancelled|canceled|interrupted|sigint|signal 2/i.test(message)) {
+    return {
+      status: ACTION_EVENT_STATUSES.cancelled,
+      reasonCode: ACTION_EVENT_REASON_CODES.cancelled,
+      completionReason: "interrupted",
+    };
+  }
+  return {
+    status: ACTION_EVENT_STATUSES.failed,
+    reasonCode: ACTION_EVENT_REASON_CODES.exception,
+    completionReason: "failed",
+  };
+}
+
+function finishReviewActionLedger(options: {
+  ledger: ReviewActionLedger;
+  error?: unknown;
+  activeItem?: Item | null;
+  completedCount: number;
+  cacheHits: number;
+}): void {
+  if (options.ledger.terminal) return;
+  const failure =
+    options.error === undefined ? null : actionLedgerFailureDisposition(options.error);
+  let pendingCount = 0;
+  for (const state of options.ledger.items.values()) {
+    if (state.terminal) continue;
+    pendingCount += 1;
+    const active = options.activeItem
+      ? actionLedgerItemKey(options.activeItem) === actionLedgerItemKey(state.item)
+      : false;
+    finishReviewActionLedgerItem({
+      ledger: options.ledger,
+      item: state.item,
+      status: failure
+        ? active
+          ? failure.status
+          : ACTION_EVENT_STATUSES.cancelled
+        : ACTION_EVENT_STATUSES.blocked,
+      reasonCode: failure
+        ? active
+          ? failure.reasonCode
+          : ACTION_EVENT_REASON_CODES.workerLost
+        : ACTION_EVENT_REASON_CODES.leaseActive,
+      retryable: true,
+      cached: false,
+      startedAtMs: options.ledger.startedAtMs,
+      completionReason: failure
+        ? active
+          ? failure.completionReason
+          : "interrupted"
+        : "coordination_blocked",
+    });
+  }
+  const itemCount = options.ledger.items.size;
+  const partial = pendingCount > 0 || options.completedCount < itemCount;
+  const status = failure
+    ? failure.status
+    : partial
+      ? ACTION_EVENT_STATUSES.yielded
+      : ACTION_EVENT_STATUSES.completed;
+  const reasonCode = failure
+    ? failure.reasonCode
+    : partial
+      ? ACTION_EVENT_REASON_CODES.leaseActive
+      : ACTION_EVENT_REASON_CODES.completed;
+  recordWorkflowPhaseEvent(ROOT, {
+    phase: ACTION_EVENT_TYPES.reviewBatch,
+    status,
+    reasonCode,
+    retryable: failure !== null || partial,
+    mutation: false,
+    identity: { slot: "batch_terminal" },
+    operation: "review",
+    operationIdentity: options.ledger.operationIdentity,
+    parentEventId: options.ledger.batchStartEventId,
+    phaseSeq: 1_000_000,
+    idempotencyIdentity: {
+      operationIdentity: options.ledger.operationIdentity,
+      slot: "batch_terminal",
+    },
+    component: "review",
+    subject: {
+      repository: targetRepo(),
+      kind: "workflow",
+    },
+    evidence: workflowRunEvidence(),
+    attributes: {
+      candidate_count: itemCount,
+      processed_count: options.completedCount,
+      skipped_count: pendingCount,
+      failed_count: failure ? 1 : 0,
+      duration_ms: Math.max(0, Date.now() - options.ledger.startedAtMs),
+      cached: options.cacheHits > 0,
+      partial,
+      completion_reason: failure ? failure.completionReason : partial ? "partial" : "completed",
+      review_mode: "propose",
+    },
+    privacy: actionLedgerPrivacy(),
+  });
+  options.ledger.terminal = true;
+}
+
 function reviewCommand(args: Args): void {
   const profile = repoFromArgs(args);
   // `--local-range` is inherently a local, offline operation, so it implies `--local-only`
@@ -20232,6 +20771,10 @@ function reviewCommand(args: Args): void {
   const readonlyModeSnapshots = readonlyOpenclaw ? makeTreeReadOnly(openclawDir) : [];
   const acquiredReviewLeases: Array<{ itemNumber: number; lease: AcquiredReviewStartLease }> = [];
   let retainReviewLeasesForPublish = false;
+  let reviewLedger: ReviewActionLedger | null = null;
+  let activeReviewItem: Item | null = null;
+  let completed = 0;
+  let cacheHits = 0;
   try {
     const selectionOptions: Parameters<typeof selectCandidates>[0] = {
       batchSize,
@@ -20272,11 +20815,16 @@ function reviewCommand(args: Args): void {
       join(artifactDir, "selection.json"),
       JSON.stringify({ shardIndex, shardCount, scannedPages, candidates, reviewPolicy }, null, 2),
     );
-    let completed = 0;
+    reviewLedger = startReviewActionLedger({
+      candidates,
+      reviewPolicy,
+      shardIndex,
+      shardCount,
+      batchSize,
+    });
     let coordinationHeldRetryAt: string | null = null;
     let codexFailures = 0;
     let leaseAcquisitionFailures = 0;
-    let cacheHits = 0;
     let contentCacheHits = 0;
     let structuralCacheChecks = 0;
     let structuralCacheHits = 0;
@@ -20512,6 +21060,29 @@ function reviewCommand(args: Args): void {
               carried = replaceFrontMatterValue(carried, "review_cache_hit", "true");
               carried = updateReviewStructuralFrontMatter(carried, structuralRecord, true);
               writeFileSync(reportPath, carried, "utf8");
+              finishReviewActionLedgerItem({
+                ledger: reviewLedger,
+                item,
+                status: ACTION_EVENT_STATUSES.cached,
+                reasonCode: ACTION_EVENT_REASON_CODES.contentUnchanged,
+                retryable: false,
+                cached: true,
+                startedAtMs: reviewLedger.startedAtMs,
+                ...((
+                  item.kind === "pull_request"
+                    ? confirmedStructuralRecord.pullHeadSha
+                    : priorReview?.itemSourceRevision
+                )
+                  ? {
+                      sourceRevision: (item.kind === "pull_request"
+                        ? confirmedStructuralRecord.pullHeadSha
+                        : priorReview?.itemSourceRevision)!,
+                    }
+                  : {}),
+                reportPath,
+                findingCount: reportReviewFindings(carried).length,
+                completionReason: "structural_cache",
+              });
               completed += 1;
               cacheHits += 1;
               structuralCacheHits += 1;
@@ -20565,6 +21136,7 @@ function reviewCommand(args: Args): void {
           continue;
         }
       }
+      activeReviewItem = item;
       const contextStartedAt = Date.now();
       if (!localRangeData) hydrationRuns += 1;
       const context = localRangeData
@@ -20977,6 +21549,20 @@ function reviewCommand(args: Args): void {
         carried = updateReviewStructuralFrontMatter(carried, structuralRecord, false);
         carried = updateReviewSemanticFrontMatter(carried, semanticRecord, true);
         writeFileSync(reportPath, carried, "utf8");
+        finishReviewActionLedgerItem({
+          ledger: reviewLedger,
+          item,
+          status: ACTION_EVENT_STATUSES.cached,
+          reasonCode: ACTION_EVENT_REASON_CODES.contentUnchanged,
+          retryable: false,
+          cached: true,
+          startedAtMs: contextStartedAt,
+          ...(context.sourceRevision ? { sourceRevision: context.sourceRevision } : {}),
+          reportPath,
+          findingCount: reportReviewFindings(carried).length,
+          completionReason: "semantic_cache",
+        });
+        activeReviewItem = null;
         completed += 1;
         cacheHits += 1;
         semanticCacheHits += 1;
@@ -21035,6 +21621,20 @@ function reviewCommand(args: Args): void {
           : replaceFrontMatterValue(carried, "review_structural_cache_hit", "false");
         carried = updateReviewSemanticFrontMatter(carried, semanticRecord, false);
         writeFileSync(reportPath, carried, "utf8");
+        finishReviewActionLedgerItem({
+          ledger: reviewLedger,
+          item,
+          status: ACTION_EVENT_STATUSES.cached,
+          reasonCode: ACTION_EVENT_REASON_CODES.contentUnchanged,
+          retryable: false,
+          cached: true,
+          startedAtMs: contextStartedAt,
+          ...(context.sourceRevision ? { sourceRevision: context.sourceRevision } : {}),
+          reportPath,
+          findingCount: reportReviewFindings(carried).length,
+          completionReason: "content_cache",
+        });
+        activeReviewItem = null;
         completed += 1;
         cacheHits += 1;
         contentCacheHits += 1;
@@ -21069,6 +21669,7 @@ function reviewCommand(args: Args): void {
       let decision: Decision;
       let codexElapsedMs = 0;
       let codexFailed = false;
+      let codexFailureDisposition: ReturnType<typeof actionLedgerFailureDisposition> | null = null;
       const codexStartedAt = Date.now();
       try {
         if (humanLocalReview) {
@@ -21105,6 +21706,7 @@ function reviewCommand(args: Args): void {
       } catch (error) {
         codexFailures += 1;
         codexFailed = true;
+        codexFailureDisposition = actionLedgerFailureDisposition(error);
         if (error instanceof CodexReviewError) {
           decision = codexFailureDecision(error.status, error.message, error.stdout, error.stderr, {
             errorCode: error.errorCode,
@@ -21157,6 +21759,26 @@ function reviewCommand(args: Args): void {
         }),
         "utf8",
       );
+      recordReviewLogPublication({
+        ledger: reviewLedger,
+        item,
+        codexWorkDir,
+        cached: false,
+      });
+      finishReviewActionLedgerItem({
+        ledger: reviewLedger,
+        item,
+        status: codexFailureDisposition?.status ?? ACTION_EVENT_STATUSES.completed,
+        reasonCode: codexFailureDisposition?.reasonCode ?? ACTION_EVENT_REASON_CODES.completed,
+        retryable: codexFailed,
+        cached: false,
+        startedAtMs: contextStartedAt,
+        ...(context.sourceRevision ? { sourceRevision: context.sourceRevision } : {}),
+        reportPath,
+        findingCount: decision.reviewFindings.length,
+        completionReason: codexFailureDisposition?.completionReason ?? decision.decision,
+      });
+      activeReviewItem = null;
       completed += 1;
       if (codexFailed) codexFailureReports.push(reportPath);
       if (humanLocalReview) {
@@ -21259,7 +21881,23 @@ function reviewCommand(args: Args): void {
       if (humanLocalReview) throw new UserFacingCommandError(message);
       throw new Error(message);
     }
+    finishReviewActionLedger({
+      ledger: reviewLedger,
+      completedCount: completed,
+      cacheHits,
+    });
     retainReviewLeasesForPublish = true;
+  } catch (error) {
+    if (reviewLedger) {
+      finishReviewActionLedger({
+        ledger: reviewLedger,
+        error,
+        activeItem: activeReviewItem,
+        completedCount: completed,
+        cacheHits,
+      });
+    }
+    throw error;
   } finally {
     if (!retainReviewLeasesForPublish) {
       for (const acquired of acquiredReviewLeases) {
@@ -21675,6 +22313,56 @@ function dispatchFailedReviewRetry(options: {
   return dispatchUrl;
 }
 
+type ReviewRetryActionLedger = {
+  operationIdentity: {
+    repository: string;
+    requestedItemNumbers: number[];
+    reportPath: string;
+  };
+  batchStartEventId: string | null;
+  startedAtMs: number;
+  terminal: boolean;
+};
+
+function startFailedReviewRetryLedger(options: {
+  requestedItemNumbers: readonly number[];
+  reportPath: string;
+}): ReviewRetryActionLedger {
+  const operationIdentity = {
+    repository: targetRepo(),
+    requestedItemNumbers: [...options.requestedItemNumbers],
+    reportPath: repoRelativePath(options.reportPath),
+  };
+  const batchStart = recordWorkflowPhaseEvent(ROOT, {
+    phase: ACTION_EVENT_TYPES.reviewRetry,
+    status: ACTION_EVENT_STATUSES.started,
+    reasonCode: ACTION_EVENT_REASON_CODES.selected,
+    retryable: false,
+    mutation: false,
+    identity: { slot: "retry_batch_start" },
+    operation: "review_retry",
+    operationIdentity,
+    phaseSeq: 1,
+    idempotencyIdentity: { operationIdentity, slot: "retry_batch_start" },
+    component: "retry_failed_reviews",
+    subject: {
+      repository: targetRepo(),
+      kind: "workflow",
+    },
+    evidence: workflowRunEvidence(),
+    attributes: {
+      candidate_count: options.requestedItemNumbers.length,
+    },
+    privacy: actionLedgerPrivacy(),
+  });
+  return {
+    operationIdentity,
+    batchStartEventId: batchStart?.event_id ?? null,
+    startedAtMs: Date.now(),
+    terminal: false,
+  };
+}
+
 function retryFailedReviewsCommand(args: Args): void {
   const runtimeBudget: GitHubRuntimeBudget = {
     startedAtMs: Date.now(),
@@ -21707,10 +22395,15 @@ function retryFailedReviewsCommandInner(args: Args): void {
   const now = Date.now();
   const nowIso = new Date(now).toISOString();
   const results: FailedReviewRetryResult[] = [];
+  const retryLedger = startFailedReviewRetryLedger({
+    requestedItemNumbers,
+    reportPath,
+  });
   let attempted = 0;
   let dispatched = 0;
-  ensureDir(dirname(reportPath));
+  let commandError: unknown = null;
   try {
+    ensureDir(dirname(reportPath));
     for (const file of markdownFiles(itemsDir)) {
       ensureGitHubRuntimeAvailable("before failed-review retry item");
       const path = join(itemsDir, file);
@@ -21930,15 +22623,787 @@ function retryFailedReviewsCommandInner(args: Args): void {
       }
     }
   } catch (error) {
-    if (!(error instanceof GitHubRuntimeBudgetError)) throw error;
-    results.push({
-      number: 0,
-      action: "skipped_runtime_budget",
-      reason: error.reason,
+    if (error instanceof GitHubRuntimeBudgetError) {
+      results.push({
+        number: 0,
+        action: "skipped_runtime_budget",
+        reason: error.reason,
+      });
+    } else {
+      commandError = error;
+    }
+  }
+  try {
+    writeFileSync(reportPath, `${JSON.stringify(results, null, 2)}\n`, "utf8");
+  } catch (error) {
+    commandError ??= error;
+  }
+  recordFailedReviewRetryEvents({
+    ledger: retryLedger,
+    results,
+    reportPath,
+    dryRun,
+    failure: commandError,
+  });
+  if (commandError) throw commandError;
+  console.log(JSON.stringify({ results, dryRun, attempted, dispatched }, null, 2));
+}
+
+export function reviewRetryActionDisposition(action: FailedReviewRetryAction): {
+  status: ActionEventStatus;
+  reasonCode: ActionEventReasonCode;
+  retryable: boolean;
+  mutation: boolean;
+} {
+  if (action === "dispatched_failed_review_retry") {
+    return {
+      status: ACTION_EVENT_STATUSES.dispatched,
+      reasonCode: ACTION_EVENT_REASON_CODES.retryScheduled,
+      retryable: true,
+      mutation: true,
+    };
+  }
+  if (action === "planned_failed_review_retry") {
+    return {
+      status: ACTION_EVENT_STATUSES.planned,
+      reasonCode: ACTION_EVENT_REASON_CODES.dryRun,
+      retryable: true,
+      mutation: false,
+    };
+  }
+  if (action === "marked_failed_review_retry_exhausted") {
+    return {
+      status: ACTION_EVENT_STATUSES.blocked,
+      reasonCode: ACTION_EVENT_REASON_CODES.retryExhausted,
+      retryable: false,
+      mutation: true,
+    };
+  }
+  if (action === "skipped_runtime_budget") {
+    return {
+      status: ACTION_EVENT_STATUSES.yielded,
+      reasonCode: ACTION_EVENT_REASON_CODES.runtimeBudget,
+      retryable: true,
+      mutation: false,
+    };
+  }
+  if (action === "skipped_dispatch_failed" || action === "skipped_live_fetch_failed") {
+    return {
+      status: ACTION_EVENT_STATUSES.failed,
+      reasonCode: ACTION_EVENT_REASON_CODES.unavailable,
+      retryable: true,
+      mutation: false,
+    };
+  }
+  if (action === "skipped_retry_cooldown") {
+    return {
+      status: ACTION_EVENT_STATUSES.waiting,
+      reasonCode: ACTION_EVENT_REASON_CODES.leaseActive,
+      retryable: true,
+      mutation: false,
+    };
+  }
+  if (action === "skipped_stale_head" || action === "skipped_stale_revision") {
+    return {
+      status: ACTION_EVENT_STATUSES.blocked,
+      reasonCode: ACTION_EVENT_REASON_CODES.sourceChanged,
+      retryable: false,
+      mutation: false,
+    };
+  }
+  return {
+    status: ACTION_EVENT_STATUSES.skipped,
+    reasonCode: ACTION_EVENT_REASON_CODES.notApplicable,
+    retryable: action !== "skipped_retry_already_exhausted",
+    mutation: false,
+  };
+}
+
+function recordFailedReviewRetryEvents(options: {
+  ledger: ReviewRetryActionLedger;
+  results: readonly FailedReviewRetryResult[];
+  reportPath: string;
+  dryRun: boolean;
+  failure?: unknown;
+}): void {
+  if (options.ledger.terminal) return;
+  const operationIdentity = options.ledger.operationIdentity;
+  for (const [index, result] of options.results.entries()) {
+    const disposition = reviewRetryActionDisposition(result.action);
+    const reportMarkdown =
+      result.reportPath && existsSync(result.reportPath)
+        ? readFileSync(result.reportPath, "utf8")
+        : null;
+    const kind = reportMarkdown ? reportItemKind(reportMarkdown) : undefined;
+    const sourceRevision =
+      result.revision ??
+      (reportMarkdown ? reviewLeaseRevisionFromReport(reportMarkdown) : null) ??
+      undefined;
+    const recordPath = result.reportPath ? repoRelativePath(result.reportPath) : undefined;
+    const subject: ActionEventSubject =
+      result.number > 0 && kind
+        ? {
+            repository: result.repo ?? targetRepo(),
+            kind,
+            number: result.number,
+            ...(sourceRevision ? { sourceRevision } : {}),
+            ...(recordPath && !recordPath.startsWith("../") ? { recordPath } : {}),
+          }
+        : {
+            repository: result.repo ?? targetRepo(),
+            kind: "workflow",
+          };
+    const evidence = [
+      ...workflowRunEvidence(),
+      ...(result.reportPath
+        ? [actionLedgerFileEvidence("review_record", result.reportPath)].filter(
+            (entry): entry is ActionEventEvidence => entry !== null,
+          )
+        : []),
+      ...(result.dispatchUrl?.startsWith("https://github.com/")
+        ? [{ kind: "retry_dispatch", runUrl: result.dispatchUrl }]
+        : []),
+    ];
+    recordWorkflowPhaseEvent(ROOT, {
+      phase: ACTION_EVENT_TYPES.reviewRetry,
+      status: disposition.status,
+      reasonCode: disposition.reasonCode,
+      retryable: disposition.retryable,
+      mutation: !options.dryRun && disposition.mutation,
+      identity: {
+        slot: "retry_result",
+        index,
+        repository: subject.repository,
+        number: result.number,
+      },
+      operation: "review_retry",
+      operationIdentity,
+      parentEventId: options.ledger.batchStartEventId,
+      phaseSeq: 10 + index,
+      idempotencyIdentity: {
+        operationIdentity,
+        slot: "retry_result",
+        index,
+        repository: subject.repository,
+        number: result.number,
+      },
+      component: "retry_failed_reviews",
+      subject,
+      evidence,
+      attributes: {
+        batch_index: index,
+        attempt: Math.max(1, result.attempts ?? 1),
+        retry_count: result.attempts ?? 0,
+        final_attempt:
+          result.action === "marked_failed_review_retry_exhausted" ||
+          result.action === "skipped_retry_already_exhausted",
+        completion_reason: result.action,
+      },
+      privacy: actionLedgerPrivacy(),
     });
   }
-  writeFileSync(reportPath, `${JSON.stringify(results, null, 2)}\n`, "utf8");
-  console.log(JSON.stringify({ results, dryRun, attempted, dispatched }, null, 2));
+  const yielded = options.results.some((result) => result.action === "skipped_runtime_budget");
+  const failed = options.results.some(
+    (result) =>
+      result.action === "skipped_dispatch_failed" || result.action === "skipped_live_fetch_failed",
+  );
+  const failure =
+    options.failure === undefined || options.failure === null
+      ? null
+      : actionLedgerFailureDisposition(options.failure);
+  recordWorkflowPhaseEvent(ROOT, {
+    phase: ACTION_EVENT_TYPES.reviewRetry,
+    status: failure
+      ? failure.status
+      : failed
+        ? ACTION_EVENT_STATUSES.failed
+        : yielded
+          ? ACTION_EVENT_STATUSES.yielded
+          : ACTION_EVENT_STATUSES.completed,
+    reasonCode: failure
+      ? failure.reasonCode
+      : failed
+        ? ACTION_EVENT_REASON_CODES.unavailable
+        : yielded
+          ? ACTION_EVENT_REASON_CODES.runtimeBudget
+          : ACTION_EVENT_REASON_CODES.completed,
+    retryable: Boolean(failure) || failed || yielded,
+    mutation:
+      !options.dryRun &&
+      options.results.some((result) => reviewRetryActionDisposition(result.action).mutation),
+    identity: { slot: "retry_batch_terminal" },
+    operation: "review_retry",
+    operationIdentity,
+    parentEventId: options.ledger.batchStartEventId,
+    phaseSeq: 1_000_000,
+    idempotencyIdentity: { operationIdentity, slot: "retry_batch_terminal" },
+    component: "retry_failed_reviews",
+    subject: {
+      repository: targetRepo(),
+      kind: "workflow",
+    },
+    evidence: [
+      ...workflowRunEvidence(),
+      ...[actionLedgerFileEvidence("review_retry_report", options.reportPath)].filter(
+        (entry): entry is ActionEventEvidence => entry !== null,
+      ),
+    ],
+    attributes: {
+      result_count: options.results.length,
+      retry_count: options.results.filter(
+        (result) =>
+          result.action === "dispatched_failed_review_retry" ||
+          result.action === "planned_failed_review_retry",
+      ).length,
+      failed_count: (failed ? 1 : 0) + (failure ? 1 : 0),
+      skipped_count: options.results.filter((result) => result.action.startsWith("skipped_"))
+        .length,
+      partial: yielded || (failure !== null && options.results.length > 0),
+      duration_ms: Math.max(0, Date.now() - options.ledger.startedAtMs),
+      completion_reason: failure
+        ? failure.completionReason
+        : failed
+          ? "failed"
+          : yielded
+            ? "partial"
+            : "completed",
+    },
+    privacy: actionLedgerPrivacy(),
+  });
+  options.ledger.terminal = true;
+}
+
+type ApplyActionLedger = {
+  operationIdentity: {
+    repository: string;
+    applyKind: ApplyKind;
+    closeReasons: string[];
+    dryRun: boolean;
+    syncCommentsOnly: boolean;
+    requestedItemNumbers: number[];
+    reportPath: string;
+    checkpoint: string;
+  };
+  batchStartEventId: string | null;
+  startedAtMs: number;
+  terminal: boolean;
+};
+
+function startApplyActionLedger(options: {
+  applyKind: ApplyKind;
+  closeReasons: ReadonlySet<CloseReason> | null;
+  dryRun: boolean;
+  syncCommentsOnly: boolean;
+  requestedItemNumbers: readonly number[];
+  reportPath: string;
+  candidateCount: number;
+}): ApplyActionLedger {
+  const operationIdentity = {
+    repository: targetRepo(),
+    applyKind: options.applyKind,
+    closeReasons: options.closeReasons ? [...options.closeReasons].sort() : ["all"],
+    dryRun: options.dryRun,
+    syncCommentsOnly: options.syncCommentsOnly,
+    requestedItemNumbers: [...options.requestedItemNumbers],
+    reportPath: repoRelativePath(options.reportPath),
+    checkpoint: String(process.env.CLAWSWEEPER_APPLY_CHECKPOINT ?? "0"),
+  };
+  const batchStart = recordWorkflowPhaseEvent(ROOT, {
+    phase: ACTION_EVENT_TYPES.applyBatch,
+    status: ACTION_EVENT_STATUSES.started,
+    reasonCode: ACTION_EVENT_REASON_CODES.selected,
+    retryable: false,
+    mutation: false,
+    identity: { slot: "apply_batch_start" },
+    operation: "apply",
+    operationIdentity,
+    phaseSeq: 1,
+    idempotencyIdentity: { operationIdentity, slot: "apply_batch_start" },
+    component: "apply_decisions",
+    subject: {
+      repository: targetRepo(),
+      kind: "workflow",
+    },
+    evidence: workflowRunEvidence(),
+    attributes: {
+      candidate_count: options.candidateCount,
+      review_mode: options.syncCommentsOnly ? "comment_sync" : "apply",
+      work_kind: options.dryRun ? "proof" : "mutation",
+    },
+    privacy: actionLedgerPrivacy(),
+  });
+  return {
+    operationIdentity,
+    batchStartEventId: batchStart?.event_id ?? null,
+    startedAtMs: Date.now(),
+    terminal: false,
+  };
+}
+
+export function applyActionEventDisposition(
+  action: ActionTaken,
+  mutationOccurred: boolean,
+  dryRun: boolean,
+): {
+  status: ActionEventStatus;
+  reasonCode: ActionEventReasonCode;
+  retryable: boolean;
+  mutation: boolean;
+  completionReason: string;
+} {
+  if (action === "skipped_runtime_budget") {
+    return {
+      status: ACTION_EVENT_STATUSES.yielded,
+      reasonCode: ACTION_EVENT_REASON_CODES.runtimeBudget,
+      retryable: true,
+      mutation: false,
+      completionReason: "runtime_budget",
+    };
+  }
+  if (dryRun && (action === "closed" || action === "review_comment_synced")) {
+    return {
+      status: ACTION_EVENT_STATUSES.planned,
+      reasonCode: ACTION_EVENT_REASON_CODES.dryRun,
+      retryable: false,
+      mutation: false,
+      completionReason: "dry_run",
+    };
+  }
+  if (action === "closed") {
+    return {
+      status: ACTION_EVENT_STATUSES.completed,
+      reasonCode: ACTION_EVENT_REASON_CODES.completed,
+      retryable: false,
+      mutation: mutationOccurred,
+      completionReason: "closed",
+    };
+  }
+  if (action === "review_comment_synced" || action === "corrected_stale_canonical_comment") {
+    return {
+      status: ACTION_EVENT_STATUSES.completed,
+      reasonCode: ACTION_EVENT_REASON_CODES.published,
+      retryable: false,
+      mutation: mutationOccurred,
+      completionReason: "comment_published",
+    };
+  }
+  if (action.startsWith("retry_")) {
+    return {
+      status: ACTION_EVENT_STATUSES.waiting,
+      reasonCode: ACTION_EVENT_REASON_CODES.dependencyPending,
+      retryable: true,
+      mutation: mutationOccurred,
+      completionReason: "retry_pending",
+    };
+  }
+  if (action === "skipped_changed_since_review") {
+    return {
+      status: ACTION_EVENT_STATUSES.blocked,
+      reasonCode: ACTION_EVENT_REASON_CODES.sourceChanged,
+      retryable: true,
+      mutation: mutationOccurred,
+      completionReason: "source_changed",
+    };
+  }
+  if (action === "skipped_comment_auth") {
+    return {
+      status: ACTION_EVENT_STATUSES.blocked,
+      reasonCode: ACTION_EVENT_REASON_CODES.authorizationFailed,
+      retryable: true,
+      mutation: mutationOccurred,
+      completionReason: "authorization_failed",
+    };
+  }
+  if (action === "skipped_locked_conversation") {
+    return {
+      status: ACTION_EVENT_STATUSES.blocked,
+      reasonCode: ACTION_EVENT_REASON_CODES.policyBlocked,
+      retryable: false,
+      mutation: mutationOccurred,
+      completionReason: "locked_conversation",
+    };
+  }
+  if (action === "kept_open" || action.startsWith("skipped_")) {
+    return {
+      status: mutationOccurred ? ACTION_EVENT_STATUSES.completed : ACTION_EVENT_STATUSES.skipped,
+      reasonCode: mutationOccurred
+        ? ACTION_EVENT_REASON_CODES.completed
+        : ACTION_EVENT_REASON_CODES.notApplicable,
+      retryable: false,
+      mutation: mutationOccurred,
+      completionReason: mutationOccurred ? "mutation_completed" : "skipped",
+    };
+  }
+  return {
+    status: ACTION_EVENT_STATUSES.completed,
+    reasonCode: ACTION_EVENT_REASON_CODES.completed,
+    retryable: false,
+    mutation: mutationOccurred,
+    completionReason: "completed",
+  };
+}
+
+export function reviewCommentPublicationEventDisposition(
+  action: ActionTaken,
+  mutationOccurred: boolean,
+  dryRun: boolean,
+): {
+  status: ActionEventStatus;
+  reasonCode: ActionEventReasonCode;
+  retryable: boolean;
+  mutation: boolean;
+  completionReason: string;
+} | null {
+  if (action === "review_comment_synced" || action === "corrected_stale_canonical_comment") {
+    return {
+      status: dryRun ? ACTION_EVENT_STATUSES.planned : ACTION_EVENT_STATUSES.published,
+      reasonCode: dryRun ? ACTION_EVENT_REASON_CODES.dryRun : ACTION_EVENT_REASON_CODES.published,
+      retryable: false,
+      mutation: !dryRun && mutationOccurred,
+      completionReason: dryRun ? "dry_run" : "comment_published",
+    };
+  }
+  if (action === "skipped_comment_auth") {
+    return {
+      status: ACTION_EVENT_STATUSES.blocked,
+      reasonCode: ACTION_EVENT_REASON_CODES.authorizationFailed,
+      retryable: true,
+      mutation: false,
+      completionReason: "authorization_failed",
+    };
+  }
+  if (action === "skipped_locked_conversation") {
+    return {
+      status: ACTION_EVENT_STATUSES.blocked,
+      reasonCode: ACTION_EVENT_REASON_CODES.policyBlocked,
+      retryable: false,
+      mutation: false,
+      completionReason: "locked_conversation",
+    };
+  }
+  if (action === "retry_stale_canonical_comment_sync") {
+    return {
+      status: ACTION_EVENT_STATUSES.waiting,
+      reasonCode: ACTION_EVENT_REASON_CODES.dependencyPending,
+      retryable: true,
+      mutation: false,
+      completionReason: "retry_pending",
+    };
+  }
+  if (action === "skipped_stale_review_comment_sync") {
+    return {
+      status: ACTION_EVENT_STATUSES.skipped,
+      reasonCode: ACTION_EVENT_REASON_CODES.sourceChanged,
+      retryable: true,
+      mutation: false,
+      completionReason: "source_changed",
+    };
+  }
+  return null;
+}
+
+function recordApplyActionEvents(options: {
+  ledger: ApplyActionLedger;
+  results: readonly ApplyResult[];
+  entries: ReadonlyMap<number, ReportEntry>;
+  mutationByItem: ReadonlyMap<string, boolean>;
+  dryRun: boolean;
+  reportPath: string;
+  failed?: boolean;
+  failure?: unknown;
+  inFlightItem?: { repo: string; number: number; mutationOccurred: boolean };
+}): void {
+  if (options.ledger.terminal) return;
+  let mutationCount = 0;
+  let closedCount = 0;
+  let skippedCount = 0;
+  for (const [index, result] of options.results.entries()) {
+    const repository = result.repo ?? targetRepo();
+    const mutationOccurred =
+      result.mutationOccurred ??
+      options.mutationByItem.get(`${repository}#${result.number}`) ??
+      false;
+    const disposition = applyActionEventDisposition(
+      result.action,
+      mutationOccurred,
+      options.dryRun,
+    );
+    const commentDisposition = reviewCommentPublicationEventDisposition(
+      result.action,
+      mutationOccurred,
+      options.dryRun,
+    );
+    if (disposition.mutation) mutationCount += 1;
+    if (result.action === "closed") closedCount += 1;
+    if (
+      result.action === "kept_open" ||
+      result.action.startsWith("skipped_") ||
+      result.action.startsWith("retry_")
+    ) {
+      skippedCount += 1;
+    }
+    const entry = result.number > 0 ? options.entries.get(result.number) : undefined;
+    const kind = entry ? reportItemKind(entry.markdown) : undefined;
+    const sourceRevision = entry ? reviewLeaseRevisionFromReport(entry.markdown) : null;
+    const recordPath = entry ? repoRelativePath(entry.path) : null;
+    const subject: ActionEventSubject =
+      result.number > 0 && kind
+        ? {
+            repository,
+            kind,
+            number: result.number,
+            ...(sourceRevision ? { sourceRevision } : {}),
+            ...(recordPath && !recordPath.startsWith("../") ? { recordPath } : {}),
+          }
+        : {
+            repository,
+            kind: "workflow",
+          };
+    const actionEvent = recordWorkflowPhaseEvent(ROOT, {
+      phase: ACTION_EVENT_TYPES.applyAction,
+      status: disposition.status,
+      reasonCode: disposition.reasonCode,
+      retryable: disposition.retryable,
+      mutation: disposition.mutation,
+      identity: {
+        slot: "apply_result",
+        index,
+        repository,
+        number: result.number,
+      },
+      operation: "apply",
+      operationIdentity: options.ledger.operationIdentity,
+      parentEventId: options.ledger.batchStartEventId,
+      phaseSeq: 10 + index * 10,
+      idempotencyIdentity: {
+        operationIdentity: options.ledger.operationIdentity,
+        slot: "apply_result",
+        index,
+        repository,
+        number: result.number,
+      },
+      component: "apply_decisions",
+      subject,
+      evidence: [
+        ...workflowRunEvidence(),
+        ...(entry
+          ? [
+              {
+                kind: "review_record",
+                sha256: sha256(entry.markdown),
+                ...(recordPath && !recordPath.startsWith("../") ? { reportPath: recordPath } : {}),
+              },
+            ]
+          : []),
+      ],
+      attributes: {
+        batch_index: index,
+        item_count: result.number > 0 ? 1 : 0,
+        closed_count: result.action === "closed" ? 1 : 0,
+        skipped_count:
+          result.action === "kept_open" ||
+          result.action.startsWith("skipped_") ||
+          result.action.startsWith("retry_")
+            ? 1
+            : 0,
+        completion_reason: disposition.completionReason,
+        partial: disposition.status === ACTION_EVENT_STATUSES.yielded,
+      },
+      privacy: actionLedgerPrivacy(),
+    });
+    if (commentDisposition) {
+      recordWorkflowPhaseEvent(ROOT, {
+        phase: ACTION_EVENT_TYPES.reviewCommentPublication,
+        status: commentDisposition.status,
+        reasonCode: commentDisposition.reasonCode,
+        retryable: commentDisposition.retryable,
+        mutation: commentDisposition.mutation,
+        identity: {
+          slot: "review_comment_publication",
+          index,
+          repository,
+          number: result.number,
+        },
+        operation: "apply",
+        operationIdentity: options.ledger.operationIdentity,
+        parentEventId: actionEvent?.event_id ?? options.ledger.batchStartEventId,
+        phaseSeq: 11 + index * 10,
+        idempotencyIdentity: {
+          operationIdentity: options.ledger.operationIdentity,
+          slot: "review_comment_publication",
+          index,
+          repository,
+          number: result.number,
+        },
+        component: "apply_decisions",
+        subject,
+        evidence: workflowRunEvidence(),
+        attributes: {
+          publication_kind: "review_comment",
+          comment_count: commentDisposition.mutation ? 1 : 0,
+          completion_reason: commentDisposition.completionReason,
+        },
+        privacy: actionLedgerPrivacy(),
+      });
+    }
+  }
+  if (
+    options.failed &&
+    options.inFlightItem &&
+    !options.results.some(
+      (result) =>
+        (result.repo ?? targetRepo()) === options.inFlightItem?.repo &&
+        result.number === options.inFlightItem?.number,
+    )
+  ) {
+    const entry = options.entries.get(options.inFlightItem.number);
+    const kind = entry ? reportItemKind(entry.markdown) : undefined;
+    const sourceRevision = entry ? reviewLeaseRevisionFromReport(entry.markdown) : null;
+    recordWorkflowPhaseEvent(ROOT, {
+      phase: ACTION_EVENT_TYPES.applyAction,
+      status: ACTION_EVENT_STATUSES.failed,
+      reasonCode: actionLedgerFailureDisposition(options.failure).reasonCode,
+      retryable: true,
+      mutation: options.inFlightItem.mutationOccurred,
+      identity: {
+        slot: "apply_in_flight_failure",
+        repository: options.inFlightItem.repo,
+        number: options.inFlightItem.number,
+      },
+      operation: "apply",
+      operationIdentity: options.ledger.operationIdentity,
+      parentEventId: options.ledger.batchStartEventId,
+      phaseSeq: 900_000,
+      idempotencyIdentity: {
+        operationIdentity: options.ledger.operationIdentity,
+        slot: "apply_in_flight_failure",
+        repository: options.inFlightItem.repo,
+        number: options.inFlightItem.number,
+      },
+      component: "apply_decisions",
+      subject:
+        kind && options.inFlightItem.number > 0
+          ? {
+              repository: options.inFlightItem.repo,
+              kind,
+              number: options.inFlightItem.number,
+              ...(sourceRevision ? { sourceRevision } : {}),
+            }
+          : {
+              repository: options.inFlightItem.repo,
+              kind: "workflow",
+            },
+      evidence: workflowRunEvidence(),
+      attributes: {
+        failed_count: 1,
+        partial: options.inFlightItem.mutationOccurred,
+        completion_reason: actionLedgerFailureDisposition(options.failure).completionReason,
+      },
+      privacy: actionLedgerPrivacy(),
+    });
+    if (options.inFlightItem.mutationOccurred) mutationCount += 1;
+  }
+  const yielded = options.results.some((result) => result.action === "skipped_runtime_budget");
+  const failure = options.failed ? actionLedgerFailureDisposition(options.failure) : null;
+  const partial =
+    yielded ||
+    (options.failed === true &&
+      (options.results.length > 0 || options.inFlightItem?.mutationOccurred === true));
+  const batchStatus = failure
+    ? failure.status
+    : yielded
+      ? ACTION_EVENT_STATUSES.yielded
+      : options.dryRun
+        ? ACTION_EVENT_STATUSES.planned
+        : options.results.length === 0
+          ? ACTION_EVENT_STATUSES.skipped
+          : ACTION_EVENT_STATUSES.completed;
+  const batchReason = failure
+    ? failure.reasonCode
+    : yielded
+      ? ACTION_EVENT_REASON_CODES.runtimeBudget
+      : options.dryRun
+        ? ACTION_EVENT_REASON_CODES.dryRun
+        : options.results.length === 0
+          ? ACTION_EVENT_REASON_CODES.noChanges
+          : ACTION_EVENT_REASON_CODES.completed;
+  const batchTerminal = recordWorkflowPhaseEvent(ROOT, {
+    phase: ACTION_EVENT_TYPES.applyBatch,
+    status: batchStatus,
+    reasonCode: batchReason,
+    retryable: Boolean(failure) || yielded,
+    mutation: !options.dryRun && mutationCount > 0,
+    identity: { slot: "apply_batch_terminal" },
+    operation: "apply",
+    operationIdentity: options.ledger.operationIdentity,
+    parentEventId: options.ledger.batchStartEventId,
+    phaseSeq: 1_000_000,
+    idempotencyIdentity: {
+      operationIdentity: options.ledger.operationIdentity,
+      slot: "apply_batch_terminal",
+    },
+    component: "apply_decisions",
+    subject: {
+      repository: targetRepo(),
+      kind: "workflow",
+    },
+    evidence: workflowRunEvidence(),
+    attributes: {
+      result_count: options.results.length,
+      processed_count: options.results.filter((result) => result.number > 0).length,
+      closed_count: closedCount,
+      skipped_count: skippedCount,
+      failed_count: failure ? 1 : 0,
+      action_count: mutationCount,
+      duration_ms: Math.max(0, Date.now() - options.ledger.startedAtMs),
+      partial,
+      completion_reason: failure
+        ? failure.completionReason
+        : yielded
+          ? "partial"
+          : options.dryRun
+            ? "dry_run"
+            : options.results.length === 0
+              ? "no_changes"
+              : "completed",
+    },
+    privacy: actionLedgerPrivacy(),
+  });
+  const reportEvidence = actionLedgerFileEvidence("apply_report", options.reportPath);
+  recordWorkflowPhaseEvent(ROOT, {
+    phase: ACTION_EVENT_TYPES.applyPublish,
+    status: reportEvidence ? ACTION_EVENT_STATUSES.published : ACTION_EVENT_STATUSES.skipped,
+    reasonCode: reportEvidence
+      ? ACTION_EVENT_REASON_CODES.published
+      : ACTION_EVENT_REASON_CODES.notFound,
+    retryable: !reportEvidence,
+    mutation: false,
+    identity: { slot: "apply_report_publication" },
+    operation: "apply",
+    operationIdentity: options.ledger.operationIdentity,
+    parentEventId: batchTerminal?.event_id ?? options.ledger.batchStartEventId,
+    phaseSeq: 1_000_001,
+    idempotencyIdentity: {
+      operationIdentity: options.ledger.operationIdentity,
+      slot: "apply_report_publication",
+    },
+    component: "apply_decisions",
+    subject: {
+      repository: targetRepo(),
+      kind: "publication",
+      ...(repoRelativePath(options.reportPath).startsWith("../")
+        ? {}
+        : { recordPath: repoRelativePath(options.reportPath) }),
+    },
+    evidence: [...workflowRunEvidence(), ...(reportEvidence ? [reportEvidence] : [])],
+    attributes: {
+      publication_kind: "apply_report",
+      result_count: options.results.length,
+      partial,
+    },
+    privacy: actionLedgerPrivacy(),
+  });
+  options.ledger.terminal = true;
 }
 
 function applyDecisionsCommand(args: Args): void {
@@ -21950,8 +23415,12 @@ function applyDecisionsCommand(args: Args): void {
     try {
       applyDecisionsCommandInner(args, runtimeBudget);
     } catch (error) {
-      if (!(error instanceof GitHubRuntimeBudgetError) || !runtimeBudget.onYield) throw error;
-      runtimeBudget.onYield(error.reason);
+      if (error instanceof GitHubRuntimeBudgetError && runtimeBudget.onYield) {
+        runtimeBudget.onYield(error.reason);
+        return;
+      }
+      runtimeBudget.onFailure?.(error);
+      throw error;
     }
   });
 }
@@ -22092,6 +23561,18 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
   const allOpenFileEntries = applyReportEntriesForDir(itemsDir, "items", false);
   const openFileEntryByNumber = new Map(allOpenFileEntries.map((entry) => [entry.number, entry]));
   const closedThisRun = new Set<string>();
+  const applyLedger = startApplyActionLedger({
+    applyKind,
+    closeReasons: applyCloseReasons,
+    dryRun,
+    syncCommentsOnly,
+    requestedItemNumbers,
+    reportPath,
+    candidateCount: fileEntries.length,
+  });
+  const mutationByItem = new Map<string, boolean>();
+  let activeApplyItem: { repo: string; number: number; mutationOccurred: boolean } | null = null;
+  let applyEventsFinalized = false;
   const writeCursorTrace = (): void => {
     if (!cursorTracePath) return;
     ensureDir(dirname(cursorTracePath));
@@ -22105,12 +23586,41 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
       "utf8",
     );
   };
-  const finishApply = (): void => {
-    ensureDir(dirname(reportPath));
-    writeFileSync(reportPath, JSON.stringify(results, null, 2), "utf8");
-    writeCursorTrace();
-    logProgress("finished apply");
-    console.log(JSON.stringify(results, null, 2));
+  const finishApply = (failed = false, failure?: unknown): void => {
+    if (applyEventsFinalized) return;
+    const publicResults = results.map(
+      ({ mutationOccurred: _mutationOccurred, ...result }) => result,
+    );
+    let publicationError: unknown = null;
+    try {
+      ensureDir(dirname(reportPath));
+      writeFileSync(reportPath, JSON.stringify(publicResults, null, 2), "utf8");
+      writeCursorTrace();
+    } catch (error) {
+      publicationError = error;
+    }
+    const finalEntries = new Map<number, ReportEntry>();
+    for (const finalEntry of [
+      ...reportEntriesForDir(itemsDir),
+      ...reportEntriesForDir(closedDir),
+    ].filter((candidate) => candidate.repo === targetRepo())) {
+      finalEntries.set(finalEntry.number, finalEntry);
+    }
+    recordApplyActionEvents({
+      ledger: applyLedger,
+      results,
+      entries: finalEntries,
+      mutationByItem,
+      dryRun,
+      reportPath,
+      failed: failed || publicationError !== null,
+      failure: failure ?? publicationError,
+      ...(activeApplyItem ? { inFlightItem: activeApplyItem } : {}),
+    });
+    applyEventsFinalized = true;
+    if (publicationError) throw publicationError;
+    logProgress(failed ? "failed apply" : "finished apply");
+    console.log(JSON.stringify(publicResults, null, 2));
   };
   let activeApplyMutationLease: {
     itemNumber: number;
@@ -22120,6 +23630,19 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
     const active = activeApplyMutationLease;
     activeApplyMutationLease = null;
     if (active) deleteOwnedDedicatedReviewStartLease(active.itemNumber, active.lease);
+  };
+  runtimeBudget.onFailure = (error: unknown): void => {
+    releaseActiveApplyMutationLease();
+    if (applyEventsFinalized) return;
+    try {
+      finishApply(true, error);
+    } catch (finalizationError) {
+      console.error(
+        `[action-ledger] failed to finalize partial apply events: ${
+          finalizationError instanceof Error ? finalizationError.message : String(finalizationError)
+        }`,
+      );
+    }
   };
   runtimeBudget.onYield = (reason: string, resumeCurrent = true): void => {
     releaseActiveApplyMutationLease();
@@ -22133,9 +23656,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
   };
   if (fileEntries.length === 0 && !existsSync(itemsDir)) {
     console.log("No items directory.");
-    ensureDir(dirname(reportPath));
-    writeFileSync(reportPath, JSON.stringify(results, null, 2), "utf8");
-    writeCursorTrace();
+    finishApply();
     return;
   }
   logProgress(
@@ -22157,6 +23678,12 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
     let markdown = entry.markdown;
     const repo = entry.repo;
     const number = entry.number;
+    activeApplyItem = { repo, number, mutationOccurred: false };
+    const recordMutation = (): void => {
+      if (dryRun) return;
+      activeApplyItem = { repo, number, mutationOccurred: true };
+      mutationByItem.set(`${repo}#${number}`, true);
+    };
     examinedItemNumbers.push(number);
     const decision = frontMatterValue(markdown, "decision");
     let closeReason = frontMatterValue(markdown, "close_reason") as CloseReason | undefined;
@@ -22745,6 +24272,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
     };
     const recordRuntimeBudgetYield = (reason: string): void => {
       if (clawSweeperLabelsChanged && !dryRun) {
+        recordMutation();
         markdown = replaceFrontMatterValue(markdown, "labels_synced_at", new Date().toISOString());
         writeReportMarkdown(path, markdown);
       }
@@ -23367,6 +24895,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
           number,
           labels: item.labels,
           dryRun,
+          onMutation: recordMutation,
         });
         item.labels = staleLabelSyncResult.labels;
         clawSweeperLabelsChanged ||= staleLabelSyncResult.changed;
@@ -23382,6 +24911,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
           labels: item.labels,
           proof: realBehaviorProof,
           dryRun,
+          onMutation: recordMutation,
         });
         item.labels = proofSufficientSyncResult.labels;
         clawSweeperLabelsChanged ||= proofSufficientSyncResult.changed;
@@ -23390,6 +24920,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
           labels: item.labels,
           proof: realBehaviorProof,
           dryRun,
+          onMutation: recordMutation,
         });
         item.labels = proofMediaSyncResult.labels;
         clawSweeperLabelsChanged ||= proofMediaSyncResult.changed;
@@ -23399,6 +24930,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
           rating: reportPrRating(markdown),
           reviewFailed: frontMatterValue(markdown, "review_status") === "failed",
           dryRun,
+          onMutation: recordMutation,
         });
         item.labels = prRatingSyncResult.labels;
         clawSweeperLabelsChanged ||= prRatingSyncResult.changed;
@@ -23412,6 +24944,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
           securityReview: reportSecurityReview(markdown),
           overallCorrectness: reportOverallCorrectness(markdown),
           dryRun,
+          onMutation: recordMutation,
         });
         item.labels = featureShowcaseSyncResult.labels;
         clawSweeperLabelsChanged ||= featureShowcaseSyncResult.changed;
@@ -23425,6 +24958,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
           labels: item.labels,
           statusKind: currentPrStatusKind,
           dryRun,
+          onMutation: recordMutation,
         });
         item.labels = prStatusSyncResult.labels;
         clawSweeperLabelsChanged ||= prStatusSyncResult.changed;
@@ -23433,6 +24967,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
           labels: item.labels,
           proof: reportTelegramVisibleProof(markdown),
           dryRun,
+          onMutation: recordMutation,
         });
         item.labels = telegramVisibleProofSyncResult.labels;
         clawSweeperLabelsChanged ||= telegramVisibleProofSyncResult.changed;
@@ -23440,6 +24975,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
     }
     markdown = replaceFrontMatterValue(markdown, "labels", JSON.stringify(item.labels));
     if (clawSweeperLabelsChanged && !dryRun) {
+      recordMutation();
       rememberSelfMutationUpdatedAt();
     }
     const renderOptions: ReviewCommentRenderOptions = {
@@ -23731,6 +25267,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
           labels: item.labels,
           triagePriority: triagePriorityFromReport(markdown),
           dryRun,
+          onMutation: recordMutation,
         });
         item.labels = syncResult.labels;
         clawSweeperLabelsChanged ||= syncResult.changed;
@@ -23740,6 +25277,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
           labels: item.labels,
           impactLabels: item.kind === "pull_request" ? [] : impactLabelsFromReport(markdown),
           dryRun,
+          onMutation: recordMutation,
         });
         item.labels = impactSyncResult.labels;
         clawSweeperLabelsChanged ||= impactSyncResult.changed;
@@ -23749,6 +25287,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
           labels: item.labels,
           maturityLabels: item.kind === "pull_request" ? [] : maturityLabelsFromReport(markdown),
           dryRun,
+          onMutation: recordMutation,
         });
         item.labels = maturitySyncResult.labels;
         clawSweeperLabelsChanged ||= maturitySyncResult.changed;
@@ -23760,6 +25299,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
             labels: item.labels,
             mergeRiskLabels: mergeRiskLabelsFromReport(markdown),
             dryRun,
+            onMutation: recordMutation,
           });
           item.labels = mergeRiskSyncResult.labels;
           mergeRiskLabelsChanged = mergeRiskSyncResult.changed;
@@ -23772,6 +25312,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
           maturitySyncResult.changed ||
           mergeRiskLabelsChanged
         ) {
+          recordMutation();
           rememberSelfMutationUpdatedAt();
         }
       } catch (error) {
@@ -23812,12 +25353,16 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
           labels: item.labels,
           state: advisoryState,
           dryRun,
+          onMutation: recordMutation,
         });
         item.labels = syncResult.labels;
         issueAdvisoryLabelsChanged = syncResult.changed;
         clawSweeperLabelsChanged ||= syncResult.changed;
         markdown = replaceFrontMatterValue(markdown, "labels", JSON.stringify(item.labels));
-        if (syncResult.changed) rememberSelfMutationUpdatedAt();
+        if (syncResult.changed) {
+          recordMutation();
+          rememberSelfMutationUpdatedAt();
+        }
       } catch (error) {
         if (!isGitHubRequiresAuthenticationError(error)) throw error;
         if (markLabelSyncAuthSkipped("advisory issue")) break;
@@ -23973,6 +25518,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
       }
     }
     if (clawSweeperLabelsChanged && !dryRun) {
+      recordMutation();
       markdown = replaceFrontMatterValue(markdown, "labels_synced_at", new Date().toISOString());
     }
     const labelSyncReason = issueAdvisoryLabelsChanged
@@ -24120,6 +25666,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
           }
           try {
             syncedComment = upsertReviewComment(number, markedReviewComment, existingReviewComment);
+            recordMutation();
             const syncedCommentUpdatedAt = commentUpdatedAt(syncedComment);
             if (syncedCommentUpdatedAt) {
               allowedSelfMutationUpdatedAts.add(syncedCommentUpdatedAt);
@@ -24382,6 +25929,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
             dryRun,
           })
         : null;
+    if (closeAppliedCommentReason === "posted close-applied comment") recordMutation();
     const preCloseMutationLeaseBlockReason = currentApplyMutationLeaseBlockReason();
     if (preCloseMutationLeaseBlockReason) {
       if (recordReviewLeaseSkip(preCloseMutationLeaseBlockReason, false)) break;
@@ -24389,6 +25937,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
     }
     ensureRuntimeDelayFits(closeDelayMs, "before close");
     closeItem({ number, kind: item.kind, reason: closeReason });
+    recordMutation();
     let postCloseRuntimeYieldReason: string | null = null;
     try {
       ensureRuntimeDelayFits(closeDelayMs, "before close delay");
@@ -24420,6 +25969,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
     if (processedCount >= processedLimit) break;
   }
   releaseActiveApplyMutationLease();
+  activeApplyItem = null;
   if (runtimeBudget.yieldReason) {
     runtimeBudget.onYield?.(runtimeBudget.yieldReason);
     return;
@@ -25107,61 +26657,259 @@ function applyArtifactsCommand(args: Args): void {
   const skipReconcile = boolArg(args.skip_reconcile);
   const replayClosedArtifacts = boolArg(args.replay_closed_artifacts);
   const maxPages = numberArg(args.max_pages, 250);
-  const openNumbers = skipReconcile ? null : fetchOpenItemNumbers(maxPages).numbers;
   let appliedArtifacts = 0;
   let skippedClosedArtifacts = 0;
-  ensureDir(itemsDir);
-  ensureDir(closedDir);
-  if (existsSync(artifactDir)) {
-    for (const entry of readdirSync(artifactDir, { recursive: true })) {
-      const name = String(entry);
-      if (!name.endsWith(".md")) continue;
-      const source = join(artifactDir, name);
-      if (!parseReportFileName(basename(source))) continue;
-      const number = numberForMarkdownFile(basename(source));
-      let markdown = readFileSync(source, "utf8");
-      if (!isMarkdownForActiveRepo(markdown, basename(source))) continue;
-      const destinationFile = reportFileName(
-        markdownRepository(markdown, basename(source)),
-        number,
-      );
-      const action = frontMatterValue(markdown, "action_taken") ?? "unknown";
-      const destination = reviewArtifactDestination(
-        action,
-        replayClosedArtifacts || artifactTargetIsOpen(number, openNumbers),
-      );
-      if (destination === "skip_closed") {
-        skippedClosedArtifacts += 1;
-        continue;
+  const operationIdentity = {
+    repository: targetRepo(),
+    artifactDir: repoRelativePath(artifactDir),
+    itemsDir: repoRelativePath(itemsDir),
+    closedDir: repoRelativePath(closedDir),
+  };
+  const publicationStart = recordWorkflowPhaseEvent(ROOT, {
+    phase: ACTION_EVENT_TYPES.reviewLogPublication,
+    status: ACTION_EVENT_STATUSES.started,
+    reasonCode: ACTION_EVENT_REASON_CODES.selected,
+    retryable: false,
+    mutation: false,
+    identity: { slot: "review_publication_start" },
+    operation: "review_publication",
+    operationIdentity,
+    phaseSeq: 1,
+    idempotencyIdentity: { operationIdentity, slot: "review_publication_start" },
+    component: "apply_artifacts",
+    subject: {
+      repository: targetRepo(),
+      kind: "publication",
+    },
+    evidence: workflowRunEvidence(),
+    attributes: {
+      publication_kind: "review_record",
+    },
+    privacy: actionLedgerPrivacy(),
+  });
+  let publicationIndex = 0;
+  let publicationTerminal = false;
+  let activePublication: {
+    markdown: string;
+    reportPath: string;
+    number: number;
+    destination: string;
+    mutation: boolean;
+  } | null = null;
+  const recordPublication = (options: {
+    markdown: string;
+    reportPath: string;
+    number: number;
+    status: ActionEventStatus;
+    reasonCode: ActionEventReasonCode;
+    mutation: boolean;
+    destination: string;
+  }): void => {
+    const kind = reportItemKind(options.markdown);
+    if (!kind) return;
+    const sourceRevision = reviewLeaseRevisionFromReport(options.markdown);
+    const recordPath = repoRelativePath(options.reportPath);
+    recordWorkflowPhaseEvent(ROOT, {
+      phase: ACTION_EVENT_TYPES.reviewLogPublication,
+      status: options.status,
+      reasonCode: options.reasonCode,
+      retryable:
+        options.status === ACTION_EVENT_STATUSES.failed ||
+        options.status === ACTION_EVENT_STATUSES.yielded ||
+        options.status === ACTION_EVENT_STATUSES.cancelled,
+      mutation: options.mutation,
+      identity: {
+        slot: "review_publication",
+        index: publicationIndex,
+        number: options.number,
+      },
+      operation: "review_publication",
+      operationIdentity,
+      parentEventId: publicationStart?.event_id ?? null,
+      phaseSeq: 10 + publicationIndex,
+      idempotencyIdentity: {
+        operationIdentity,
+        slot: "review_publication",
+        index: publicationIndex,
+        number: options.number,
+      },
+      component: "apply_artifacts",
+      subject: {
+        repository: targetRepo(),
+        kind,
+        number: options.number,
+        ...(sourceRevision ? { sourceRevision } : {}),
+        ...(recordPath.startsWith("../") ? {} : { recordPath }),
+      },
+      evidence: [
+        ...workflowRunEvidence(),
+        {
+          kind: "review_record",
+          sha256: sha256(options.markdown),
+          ...(recordPath.startsWith("../") ? {} : { reportPath: recordPath }),
+        },
+      ],
+      attributes: {
+        publication_kind: "review_record",
+        log_kind: "review",
+        log_count: 1,
+        state: options.destination,
+      },
+      privacy: actionLedgerPrivacy(),
+    });
+    publicationIndex += 1;
+  };
+  const finishPublication = (error?: unknown, interruptedMutation = false): void => {
+    if (publicationTerminal) return;
+    const failure = error === undefined ? null : actionLedgerFailureDisposition(error);
+    recordWorkflowPhaseEvent(ROOT, {
+      phase: ACTION_EVENT_TYPES.reviewLogPublication,
+      status: failure
+        ? failure.status
+        : appliedArtifacts === 0 && skippedClosedArtifacts > 0
+          ? ACTION_EVENT_STATUSES.skipped
+          : ACTION_EVENT_STATUSES.completed,
+      reasonCode: failure
+        ? failure.reasonCode
+        : appliedArtifacts === 0
+          ? ACTION_EVENT_REASON_CODES.noChanges
+          : ACTION_EVENT_REASON_CODES.completed,
+      retryable: failure !== null,
+      mutation: appliedArtifacts > 0 || interruptedMutation,
+      identity: { slot: "review_publication_terminal" },
+      operation: "review_publication",
+      operationIdentity,
+      parentEventId: publicationStart?.event_id ?? null,
+      phaseSeq: 1_000_000,
+      idempotencyIdentity: { operationIdentity, slot: "review_publication_terminal" },
+      component: "apply_artifacts",
+      subject: {
+        repository: targetRepo(),
+        kind: "publication",
+      },
+      evidence: workflowRunEvidence(),
+      attributes: {
+        published_count: appliedArtifacts,
+        skipped_count: skippedClosedArtifacts,
+        failed_count: failure ? 1 : 0,
+        publication_kind: "review_record",
+        partial:
+          failure !== null
+            ? appliedArtifacts > 0 || interruptedMutation
+            : skippedClosedArtifacts > 0 && appliedArtifacts > 0,
+        completion_reason: failure
+          ? failure.completionReason
+          : appliedArtifacts === 0
+            ? "no_changes"
+            : "completed",
+      },
+      privacy: actionLedgerPrivacy(),
+    });
+    publicationTerminal = true;
+  };
+  try {
+    ensureDir(itemsDir);
+    ensureDir(closedDir);
+    const openNumbers = skipReconcile ? null : fetchOpenItemNumbers(maxPages).numbers;
+    if (existsSync(artifactDir)) {
+      for (const entry of readdirSync(artifactDir, { recursive: true })) {
+        const name = String(entry);
+        if (!name.endsWith(".md")) continue;
+        const source = join(artifactDir, name);
+        if (!parseReportFileName(basename(source))) continue;
+        const number = numberForMarkdownFile(basename(source));
+        let markdown = readFileSync(source, "utf8");
+        if (!isMarkdownForActiveRepo(markdown, basename(source))) continue;
+        const destinationFile = reportFileName(
+          markdownRepository(markdown, basename(source)),
+          number,
+        );
+        const action = frontMatterValue(markdown, "action_taken") ?? "unknown";
+        const destination = reviewArtifactDestination(
+          action,
+          replayClosedArtifacts || artifactTargetIsOpen(number, openNumbers),
+        );
+        if (destination === "skip_closed") {
+          recordPublication({
+            markdown,
+            reportPath: source,
+            number,
+            status: ACTION_EVENT_STATUSES.skipped,
+            reasonCode: ACTION_EVENT_REASON_CODES.stateChanged,
+            mutation: false,
+            destination,
+          });
+          skippedClosedArtifacts += 1;
+          continue;
+        }
+        const destinationDir = destination === "closed" ? closedDir : itemsDir;
+        const reportPath = join(destinationDir, destinationFile);
+        activePublication = {
+          markdown,
+          reportPath,
+          number,
+          destination,
+          mutation: false,
+        };
+        const stalePath = join(destinationDir === itemsDir ? closedDir : itemsDir, destinationFile);
+        if (existsSync(stalePath)) {
+          unlinkSync(stalePath);
+          activePublication.mutation = true;
+        }
+        if (existsSync(reportPath)) {
+          markdown = preserveFailedReviewRetryMetadata(readFileSync(reportPath, "utf8"), markdown);
+        }
+        activePublication.mutation = true;
+        const syncedMarkdown = syncDecisionPacketRecord({
+          markdown,
+          reportPath,
+          packetsDir: decisionPacketsDir,
+          repoRoot: ROOT,
+          subjectState: destination === "closed" ? "closed" : "open",
+        }).markdown;
+        activePublication.markdown = syncedMarkdown;
+        writeFileSync(reportPath, syncedMarkdown, "utf8");
+        if (destination === "closed") {
+          const planPath = workPlanPathForReport(reportPath, plansDir);
+          if (existsSync(planPath)) unlinkSync(planPath);
+        } else {
+          syncWorkPlanFromReport({ markdown: syncedMarkdown, reportPath, plansDir });
+        }
+        recordPublication({
+          markdown: syncedMarkdown,
+          reportPath,
+          number,
+          status: ACTION_EVENT_STATUSES.published,
+          reasonCode: ACTION_EVENT_REASON_CODES.published,
+          mutation: true,
+          destination,
+        });
+        activePublication = null;
+        appliedArtifacts += 1;
       }
-      const destinationDir = destination === "closed" ? closedDir : itemsDir;
-      const stalePath = join(destinationDir === itemsDir ? closedDir : itemsDir, destinationFile);
-      if (existsSync(stalePath)) unlinkSync(stalePath);
-      const reportPath = join(destinationDir, destinationFile);
-      if (existsSync(reportPath)) {
-        markdown = preserveFailedReviewRetryMetadata(readFileSync(reportPath, "utf8"), markdown);
-      }
-      const syncedMarkdown = syncDecisionPacketRecord({
-        markdown,
-        reportPath,
-        packetsDir: decisionPacketsDir,
-        repoRoot: ROOT,
-        subjectState: destination === "closed" ? "closed" : "open",
-      }).markdown;
-      writeFileSync(reportPath, syncedMarkdown, "utf8");
-      if (destination === "closed") {
-        const planPath = workPlanPathForReport(reportPath, plansDir);
-        if (existsSync(planPath)) unlinkSync(planPath);
-      } else {
-        syncWorkPlanFromReport({ markdown: syncedMarkdown, reportPath, plansDir });
-      }
-      appliedArtifacts += 1;
     }
+    console.error(
+      `[apply-artifacts] applied=${appliedArtifacts} skipped_closed=${skippedClosedArtifacts}`,
+    );
+    if (!skipReconcile) reconcileFolders({ itemsDir, closedDir, plansDir, decisionPacketsDir });
+    finishPublication();
+  } catch (error) {
+    const interruptedMutation = activePublication?.mutation ?? false;
+    if (activePublication) {
+      recordPublication({
+        markdown: activePublication.markdown,
+        reportPath: activePublication.reportPath,
+        number: activePublication.number,
+        status: actionLedgerFailureDisposition(error).status,
+        reasonCode: actionLedgerFailureDisposition(error).reasonCode,
+        mutation: interruptedMutation,
+        destination: activePublication.destination,
+      });
+      activePublication = null;
+    }
+    finishPublication(error, interruptedMutation);
+    throw error;
   }
-  console.error(
-    `[apply-artifacts] applied=${appliedArtifacts} skipped_closed=${skippedClosedArtifacts}`,
-  );
-  if (!skipReconcile) reconcileFolders({ itemsDir, closedDir, plansDir, decisionPacketsDir });
 }
 
 function artifactTargetIsOpen(number: number, openNumbers: Set<number> | null): boolean {
@@ -26922,34 +28670,74 @@ function checkCommand(): void {
   console.log("ok");
 }
 
+function publishActionEventsCommand(args: Args): void {
+  const sourceRoot = resolve(
+    stringArg(args.source_root, join(ROOT, ".clawsweeper-repair", "action-ledger-download")),
+  );
+  const stateRoot = resolve(stringArg(args.state_root, ROOT));
+  const result = importActionEventShards(sourceRoot, stateRoot);
+  console.log(JSON.stringify(result, null, 2));
+}
+
 export async function main(argv = process.argv.slice(2)): Promise<void> {
   const args = parseArgs(argv);
   const command = args._[0] ?? "review";
-  if (command === "plan") planCommand(args);
-  else if (command === "review") reviewCommand(args);
-  else if (command === "retry-failed-reviews") retryFailedReviewsCommand(args);
-  else if (command === "apply-artifacts") applyArtifactsCommand(args);
-  else if (command === "apply-decisions") applyDecisionsCommand(args);
-  else if (command === "proof-nudges") proofNudgesCommand(args);
-  else if (command === "bot-proof") botProofCommand(args);
-  else if (command === "audit") auditCommand(args);
-  else if (command === "reconcile") reconcileCommand(args);
-  else if (command === "dashboard") {
-    repoFromArgs(args);
-    updateDashboard(
-      resolve(stringArg(args.items_dir, defaultItemsDir())),
-      resolve(stringArg(args.closed_dir, defaultClosedDir())),
+  if (!process.env.CLAWSWEEPER_ACTION_LEDGER_INVOCATION) {
+    process.env.CLAWSWEEPER_ACTION_LEDGER_INVOCATION = sha256(stableJson({ command, args })).slice(
+      0,
+      16,
     );
-  } else if (command === "status") statusCommand(args);
-  else if (command === "assist-target") assistResolveTargetCommand(args);
-  else if (command === "assist" || command === "assist-generate") assistGenerateCommand(args);
-  else if (command === "assist-validate") assistValidateArtifactCommand(args);
-  else if (command === "assist-publish") assistPublishCommand(args);
-  else if (command === "check") checkCommand();
-  else {
-    console.error(`Unknown command: ${command}`);
-    process.exit(1);
   }
+  let commandError: unknown = null;
+  try {
+    if (command === "plan") planCommand(args);
+    else if (command === "review") reviewCommand(args);
+    else if (command === "retry-failed-reviews") retryFailedReviewsCommand(args);
+    else if (command === "apply-artifacts") applyArtifactsCommand(args);
+    else if (command === "apply-decisions") applyDecisionsCommand(args);
+    else if (command === "publish-action-events") publishActionEventsCommand(args);
+    else if (command === "proof-nudges") proofNudgesCommand(args);
+    else if (command === "bot-proof") botProofCommand(args);
+    else if (command === "audit") auditCommand(args);
+    else if (command === "reconcile") reconcileCommand(args);
+    else if (command === "dashboard") {
+      repoFromArgs(args);
+      updateDashboard(
+        resolve(stringArg(args.items_dir, defaultItemsDir())),
+        resolve(stringArg(args.closed_dir, defaultClosedDir())),
+      );
+    } else if (command === "status") statusCommand(args);
+    else if (command === "assist-target") assistResolveTargetCommand(args);
+    else if (command === "assist" || command === "assist-generate") assistGenerateCommand(args);
+    else if (command === "assist-validate") assistValidateArtifactCommand(args);
+    else if (command === "assist-publish") assistPublishCommand(args);
+    else if (command === "check") checkCommand();
+    else if (command !== "finalize-action-events")
+      throw new UserFacingCommandError(`Unknown command: ${command}`);
+  } catch (error) {
+    commandError = error;
+  }
+  try {
+    const shardPaths = await flushWorkflowActionEvents(ROOT);
+    if (shardPaths.length > 0) {
+      console.error(
+        `[action-ledger] finalized ${shardPaths.length} immutable workflow shard${
+          shardPaths.length === 1 ? "" : "s"
+        }`,
+      );
+    }
+  } catch (error) {
+    if (commandError) {
+      console.error(
+        `[action-ledger] finalization failed after command failure: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    } else {
+      commandError = error;
+    }
+  }
+  if (commandError) throw commandError;
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -20208,6 +20208,8 @@ const ACTION_LEDGER_DROPPED_FIELDS = [
 type ReviewLedgerItem = {
   item: Item;
   index: number;
+  started: boolean;
+  startedAtMs: number | null;
   startEventId: string | null;
   logPublication: boolean;
   terminal: boolean;
@@ -20331,36 +20333,12 @@ function startReviewActionLedger(options: {
   const items = new Map<string, ReviewLedgerItem>();
   for (const [index, item] of options.candidates.entries()) {
     if (!Number.isSafeInteger(item.number) || item.number <= 0) continue;
-    const start = recordWorkflowPhaseEvent(ROOT, {
-      phase: ACTION_EVENT_TYPES.reviewItem,
-      status: ACTION_EVENT_STATUSES.started,
-      reasonCode: ACTION_EVENT_REASON_CODES.selected,
-      retryable: false,
-      mutation: false,
-      identity: { slot: "item_start", index, repository: item.repo, number: item.number },
-      operation: "review",
-      operationIdentity,
-      parentEventId: batchStart?.event_id ?? null,
-      phaseSeq: 10 + index * 10,
-      idempotencyIdentity: {
-        operationIdentity,
-        slot: "item_start",
-        index,
-        repository: item.repo,
-        number: item.number,
-      },
-      component: "review",
-      subject: actionLedgerItemSubject(item),
-      attributes: {
-        batch_index: index,
-        review_mode: "propose",
-      },
-      privacy: actionLedgerPrivacy(),
-    });
     items.set(actionLedgerItemKey(item), {
       item,
       index,
-      startEventId: start?.event_id ?? null,
+      started: false,
+      startedAtMs: null,
+      startEventId: null,
       logPublication: false,
       terminal: false,
     });
@@ -20374,6 +20352,46 @@ function startReviewActionLedger(options: {
   };
 }
 
+function startReviewActionLedgerItem(ledger: ReviewActionLedger, item: Item): ActionEvent | null {
+  const state = ledger.items.get(actionLedgerItemKey(item));
+  if (!state || state.started) return null;
+  const start = recordWorkflowPhaseEvent(ROOT, {
+    phase: ACTION_EVENT_TYPES.reviewItem,
+    status: ACTION_EVENT_STATUSES.started,
+    reasonCode: ACTION_EVENT_REASON_CODES.selected,
+    retryable: false,
+    mutation: false,
+    identity: {
+      slot: "item_start",
+      index: state.index,
+      repository: item.repo,
+      number: item.number,
+    },
+    operation: "review",
+    operationIdentity: ledger.operationIdentity,
+    parentEventId: ledger.batchStartEventId,
+    phaseSeq: 10 + state.index * 10,
+    idempotencyIdentity: {
+      operationIdentity: ledger.operationIdentity,
+      slot: "item_start",
+      index: state.index,
+      repository: item.repo,
+      number: item.number,
+    },
+    component: "review",
+    subject: actionLedgerItemSubject(item),
+    attributes: {
+      batch_index: state.index,
+      review_mode: "propose",
+    },
+    privacy: actionLedgerPrivacy(),
+  });
+  state.started = true;
+  state.startedAtMs = Date.now();
+  state.startEventId = start?.event_id ?? null;
+  return start;
+}
+
 function recordReviewLogPublication(options: {
   ledger: ReviewActionLedger;
   item: Item;
@@ -20384,7 +20402,7 @@ function recordReviewLogPublication(options: {
   retryable?: boolean;
 }): ActionEvent | null {
   const state = options.ledger.items.get(actionLedgerItemKey(options.item));
-  if (!state || state.logPublication) return null;
+  if (!state || !state.started || state.logPublication) return null;
   const prefix = `${options.item.number}.`;
   const logs =
     options.codexWorkDir && existsSync(options.codexWorkDir)
@@ -20459,7 +20477,7 @@ function finishReviewActionLedgerItem(options: {
   completionReason?: string;
 }): ActionEvent | null {
   const state = options.ledger.items.get(actionLedgerItemKey(options.item));
-  if (!state || state.terminal) return null;
+  if (!state || !state.started || state.terminal) return null;
   if (!state.logPublication) {
     recordReviewLogPublication({
       ledger: options.ledger,
@@ -20574,6 +20592,7 @@ function finishReviewActionLedger(options: {
   for (const state of options.ledger.items.values()) {
     if (state.terminal) continue;
     pendingCount += 1;
+    if (!state.started) continue;
     const active = options.activeItem
       ? actionLedgerItemKey(options.activeItem) === actionLedgerItemKey(state.item)
       : false;
@@ -20859,7 +20878,12 @@ function reviewCommand(args: Args): void {
     const semanticCacheRevalidationReasons = new Map<string, number>();
     const codexFailureReports: string[] = [];
     const leaseAcquisitionFailureDetails: string[] = [];
+    // oxfmt-ignore
     for (const item of candidates) {
+      activeReviewItem = item;
+      let reviewItemFailed = false;
+      try {
+      startReviewActionLedgerItem(reviewLedger, item);
       if (humanLocalReview) {
         console.error("");
         console.error("Collecting GitHub context");
@@ -21131,7 +21155,9 @@ function reviewCommand(args: Args): void {
           }
           acquiredReviewLease = startComment.lease;
           if (!acquiredReviewLease) {
-            throw new Error(`review lease acquisition returned no identity for PR #${item.number}`);
+            throw new Error(
+              `review lease acquisition returned no identity for PR #${item.number}`,
+            );
           }
           acquiredReviewLeases.push({ itemNumber: item.number, lease: acquiredReviewLease });
         } catch (error) {
@@ -21147,7 +21173,6 @@ function reviewCommand(args: Args): void {
           continue;
         }
       }
-      activeReviewItem = item;
       const contextStartedAt = Date.now();
       if (!localRangeData) hydrationRuns += 1;
       const context = localRangeData
@@ -21680,7 +21705,8 @@ function reviewCommand(args: Args): void {
       let decision: Decision;
       let codexElapsedMs = 0;
       let codexFailed = false;
-      let codexFailureDisposition: ReturnType<typeof actionLedgerFailureDisposition> | null = null;
+      let codexFailureDisposition: ReturnType<typeof actionLedgerFailureDisposition> | null =
+        null;
       const codexStartedAt = Date.now();
       try {
         if (humanLocalReview) {
@@ -21719,10 +21745,16 @@ function reviewCommand(args: Args): void {
         codexFailed = true;
         codexFailureDisposition = actionLedgerFailureDisposition(error);
         if (error instanceof CodexReviewError) {
-          decision = codexFailureDecision(error.status, error.message, error.stdout, error.stderr, {
-            errorCode: error.errorCode,
-            signal: error.signal,
-          });
+          decision = codexFailureDecision(
+            error.status,
+            error.message,
+            error.stdout,
+            error.stderr,
+            {
+              errorCode: error.errorCode,
+              signal: error.signal,
+            },
+          );
         } else {
           decision = codexFailureDecision(
             null,
@@ -21804,6 +21836,30 @@ function reviewCommand(args: Args): void {
         console.error(
           `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} done #${item.number} (${completed}/${candidates.length}) decision=${decision.decision} confidence=${decision.confidence} action=${action.actionTaken}`,
         );
+      }
+      } catch (error) {
+        reviewItemFailed = true;
+        throw error;
+      } finally {
+        if (
+          !reviewItemFailed &&
+          activeReviewItem &&
+          actionLedgerItemKey(activeReviewItem) === actionLedgerItemKey(item)
+        ) {
+          finishReviewActionLedgerItem({
+            ledger: reviewLedger,
+            item,
+            status: ACTION_EVENT_STATUSES.blocked,
+            reasonCode: ACTION_EVENT_REASON_CODES.leaseActive,
+            retryable: true,
+            cached: false,
+            startedAtMs:
+              reviewLedger.items.get(actionLedgerItemKey(item))?.startedAtMs ??
+              reviewLedger.startedAtMs,
+            completionReason: "coordination_deferred",
+          });
+          activeReviewItem = null;
+        }
       }
     }
     if (coordinationHeldRetryAt) {
@@ -22730,6 +22786,38 @@ export function reviewRetryActionDisposition(action: FailedReviewRetryAction): {
   };
 }
 
+export function reviewRetryBusinessIdempotencyIdentityForTest(options: {
+  repository: string;
+  number: number;
+  revisionKind: FailedReviewRetryRevisionKind;
+  sourceRevision: string;
+  slot: "retry_dispatch" | "retry_exhaustion" | "retry_observation";
+}) {
+  return {
+    operation: "review_retry",
+    slot: options.slot,
+    repository: options.repository,
+    number: options.number,
+    revisionKind: options.revisionKind,
+    sourceRevision: options.sourceRevision,
+  };
+}
+
+function reviewRetryIdempotencySlot(
+  action: FailedReviewRetryAction,
+): "retry_dispatch" | "retry_exhaustion" | "retry_observation" {
+  if (
+    action === "dispatched_failed_review_retry" ||
+    action === "planned_failed_review_retry" ||
+    action === "skipped_dispatch_failed"
+  ) {
+    return "retry_dispatch";
+  }
+  return action === "marked_failed_review_retry_exhausted"
+    ? "retry_exhaustion"
+    : "retry_observation";
+}
+
 function recordFailedReviewRetryEvents(options: {
   ledger: ReviewRetryActionLedger;
   results: readonly FailedReviewRetryResult[];
@@ -22750,6 +22838,13 @@ function recordFailedReviewRetryEvents(options: {
       result.revision ??
       (reportMarkdown ? reviewLeaseRevisionFromReport(reportMarkdown) : null) ??
       undefined;
+    const revisionKind =
+      result.revisionKind ??
+      (kind === "pull_request"
+        ? "pull_head_sha"
+        : kind === "issue"
+          ? "item_source_revision"
+          : undefined);
     const recordPath = result.reportPath ? repoRelativePath(result.reportPath) : undefined;
     const subject: ActionEventSubject =
       result.number > 0 && kind
@@ -22775,6 +22870,28 @@ function recordFailedReviewRetryEvents(options: {
         ? [{ kind: "retry_dispatch", runUrl: result.dispatchUrl }]
         : []),
     ];
+    const retrySlot = reviewRetryIdempotencySlot(result.action);
+    const idempotencyIdentity =
+      result.number > 0 && revisionKind && sourceRevision
+        ? reviewRetryBusinessIdempotencyIdentityForTest({
+            repository: subject.repository,
+            number: result.number,
+            revisionKind,
+            sourceRevision,
+            slot: retrySlot,
+          })
+        : {
+            operation: "review_retry",
+            slot: retrySlot,
+            repository: subject.repository,
+            number: result.number,
+            action: result.action,
+          };
+    if (!options.dryRun && disposition.mutation && (!revisionKind || !sourceRevision)) {
+      throw new Error(
+        `retry mutation receipt for ${subject.repository}#${result.number} is missing its source revision`,
+      );
+    }
     recordWorkflowPhaseEvent(ROOT, {
       phase: ACTION_EVENT_TYPES.reviewRetry,
       status: disposition.status,
@@ -22791,13 +22908,7 @@ function recordFailedReviewRetryEvents(options: {
       operationIdentity,
       parentEventId: options.ledger.batchStartEventId,
       phaseSeq: 10 + index,
-      idempotencyIdentity: {
-        operationIdentity,
-        slot: "retry_result",
-        index,
-        repository: subject.repository,
-        number: result.number,
-      },
+      idempotencyIdentity,
       component: "retry_failed_reviews",
       subject,
       evidence,
@@ -22884,6 +22995,27 @@ function recordFailedReviewRetryEvents(options: {
   options.ledger.terminal = true;
 }
 
+type ApplyItemBusinessIdempotencyIdentity = {
+  operation: "apply";
+  slot: "apply_item" | "review_comment";
+  repository: string;
+  number: number;
+  sourceRevision: string;
+  reviewContentDigest: string;
+  decisionPacketSha256: string;
+};
+
+type ApplyLedgerItem = {
+  entry: ReportEntry;
+  index: number;
+  started: boolean;
+  startEventId: string | null;
+  mutationObserved: boolean;
+  mutationEventId: string | null;
+  terminal: boolean;
+  businessIdentity: Omit<ApplyItemBusinessIdempotencyIdentity, "slot">;
+};
+
 type ApplyActionLedger = {
   operationIdentity: {
     repository: string;
@@ -22903,6 +23035,7 @@ type ApplyActionLedger = {
     }>;
   };
   batchStartEventId: string | null;
+  items: Map<string, ApplyLedgerItem>;
   startedAtMs: number;
   terminal: boolean;
 };
@@ -22957,36 +23090,160 @@ function startApplyActionLedger(options: {
     },
     privacy: actionLedgerPrivacy(),
   });
+  const items = new Map<string, ApplyLedgerItem>();
+  for (const [index, entry] of options.candidates.entries()) {
+    const key = actionLedgerItemKey(entry);
+    if (items.has(key)) continue;
+    items.set(key, {
+      entry,
+      index,
+      started: false,
+      startEventId: null,
+      mutationObserved: false,
+      mutationEventId: null,
+      terminal: false,
+      businessIdentity: {
+        operation: "apply",
+        repository: entry.repo,
+        number: entry.number,
+        sourceRevision: reviewLeaseRevisionFromReport(entry.markdown) ?? "unknown",
+        reviewContentDigest: frontMatterValue(entry.markdown, "review_content_digest") ?? "unknown",
+        decisionPacketSha256: frontMatterValue(entry.markdown, "decision_packet_sha256") ?? "none",
+      },
+    });
+  }
   return {
     operationIdentity,
     batchStartEventId: batchStart?.event_id ?? null,
+    items,
     startedAtMs: Date.now(),
     terminal: false,
   };
 }
 
-function applyItemIdempotencyIdentity(options: {
-  ledger: ApplyActionLedger;
+export function applyItemBusinessIdempotencyIdentityForTest(options: {
+  slot: "apply_item" | "review_comment";
   repository: string;
   number: number;
-  entry: ReportEntry | undefined;
-  slot: "apply_item" | "review_comment";
-}) {
+  sourceRevision: string;
+  reviewContentDigest: string;
+  decisionPacketSha256: string;
+}): ApplyItemBusinessIdempotencyIdentity {
   return {
-    operationIdentity: options.ledger.operationIdentity,
+    operation: "apply",
     slot: options.slot,
     repository: options.repository,
     number: options.number,
-    sourceRevision: options.entry
-      ? (reviewLeaseRevisionFromReport(options.entry.markdown) ?? "unknown")
-      : "unknown",
-    reviewContentDigest: options.entry
-      ? (frontMatterValue(options.entry.markdown, "review_content_digest") ?? "unknown")
-      : "unknown",
-    decisionPacketSha256: options.entry
-      ? (frontMatterValue(options.entry.markdown, "decision_packet_sha256") ?? "none")
-      : "none",
+    sourceRevision: options.sourceRevision,
+    reviewContentDigest: options.reviewContentDigest,
+    decisionPacketSha256: options.decisionPacketSha256,
   };
+}
+
+function applyItemIdempotencyIdentity(
+  state: ApplyLedgerItem,
+  slot: "apply_item" | "review_comment",
+): ApplyItemBusinessIdempotencyIdentity {
+  return applyItemBusinessIdempotencyIdentityForTest({
+    ...state.businessIdentity,
+    slot,
+  });
+}
+
+function applyLedgerItemSubject(
+  state: ApplyLedgerItem,
+  entry: ReportEntry = state.entry,
+): ActionEventSubject {
+  const kind = reportItemKind(entry.markdown);
+  if (!kind) {
+    throw new Error(
+      `apply ledger item ${state.businessIdentity.repository}#${state.businessIdentity.number} has no report item kind`,
+    );
+  }
+  const recordPath = repoRelativePath(entry.path);
+  return {
+    repository: state.businessIdentity.repository,
+    kind,
+    number: state.businessIdentity.number,
+    ...(state.businessIdentity.sourceRevision === "unknown"
+      ? {}
+      : { sourceRevision: state.businessIdentity.sourceRevision }),
+    ...(recordPath.startsWith("../") ? {} : { recordPath }),
+  };
+}
+
+function startApplyActionLedgerItem(
+  ledger: ApplyActionLedger,
+  entry: ReportEntry,
+): ApplyLedgerItem | null {
+  const state = ledger.items.get(actionLedgerItemKey(entry));
+  if (!state) return null;
+  if (state.started) return state;
+  const start = recordWorkflowPhaseEvent(ROOT, {
+    phase: ACTION_EVENT_TYPES.applyAction,
+    status: ACTION_EVENT_STATUSES.started,
+    reasonCode: ACTION_EVENT_REASON_CODES.selected,
+    retryable: false,
+    mutation: false,
+    identity: {
+      slot: "apply_item_start",
+      index: state.index,
+      repository: entry.repo,
+      number: entry.number,
+    },
+    operation: "apply",
+    operationIdentity: ledger.operationIdentity,
+    parentEventId: ledger.batchStartEventId,
+    phaseSeq: 10 + state.index * 20,
+    idempotencyIdentity: applyItemIdempotencyIdentity(state, "apply_item"),
+    component: "apply_decisions",
+    subject: applyLedgerItemSubject(state),
+    evidence: workflowRunEvidence(),
+    attributes: {
+      batch_index: state.index,
+      item_count: 1,
+      completion_reason: "started",
+    },
+    privacy: actionLedgerPrivacy(),
+  });
+  state.started = true;
+  state.startEventId = start?.event_id ?? null;
+  return state;
+}
+
+function recordApplyMutationBoundary(ledger: ApplyActionLedger, entry: ReportEntry): void {
+  const state = startApplyActionLedgerItem(ledger, entry);
+  if (!state || state.mutationObserved) return;
+  const mutation = recordWorkflowPhaseEvent(ROOT, {
+    phase: ACTION_EVENT_TYPES.applyAction,
+    status: ACTION_EVENT_STATUSES.executed,
+    reasonCode: ACTION_EVENT_REASON_CODES.completed,
+    retryable: true,
+    mutation: true,
+    identity: {
+      slot: "apply_mutation_observed",
+      index: state.index,
+      repository: entry.repo,
+      number: entry.number,
+    },
+    operation: "apply",
+    operationIdentity: ledger.operationIdentity,
+    parentEventId: state.startEventId,
+    phaseSeq: 11 + state.index * 20,
+    idempotencyIdentity: applyItemIdempotencyIdentity(state, "apply_item"),
+    component: "apply_decisions",
+    subject: applyLedgerItemSubject(state),
+    evidence: workflowRunEvidence(),
+    attributes: {
+      batch_index: state.index,
+      action_count: 1,
+      partial: true,
+      completion_reason: "mutation_observed",
+    },
+    privacy: actionLedgerPrivacy(),
+  });
+  state.mutationObserved = true;
+  state.mutationEventId = mutation?.event_id ?? null;
 }
 
 export function applyActionEventDisposition(
@@ -23151,63 +23408,39 @@ export function reviewCommentPublicationEventDisposition(
   return null;
 }
 
-function recordApplyActionEvents(options: {
+function recordApplyActionLedgerItemResults(options: {
   ledger: ApplyActionLedger;
+  state: ApplyLedgerItem;
   results: readonly ApplyResult[];
-  entries: ReadonlyMap<number, ReportEntry>;
-  mutationByItem: ReadonlyMap<string, boolean>;
+  entry: ReportEntry;
+  mutationOccurred: boolean;
   dryRun: boolean;
-  reportPath: string;
-  failed?: boolean;
-  failure?: unknown;
-  inFlightItem?: { repo: string; number: number; mutationOccurred: boolean };
 }): void {
-  if (options.ledger.terminal) return;
-  let mutationCount = 0;
-  let closedCount = 0;
-  let skippedCount = 0;
-  for (const [index, result] of options.results.entries()) {
-    const repository = result.repo ?? targetRepo();
-    const mutationOccurred =
-      result.mutationOccurred ??
-      options.mutationByItem.get(`${repository}#${result.number}`) ??
-      false;
+  if (options.state.terminal) return;
+  const results =
+    options.results.length > 0
+      ? options.results
+      : [
+          {
+            repo: options.state.businessIdentity.repository,
+            number: options.state.businessIdentity.number,
+            action: "kept_open" as const,
+            reason: options.mutationOccurred
+              ? "apply item completed after a durable mutation"
+              : "apply item required no action",
+          },
+        ];
+  for (const [resultIndex, result] of results.entries()) {
     const disposition = applyActionEventDisposition(
       result.action,
-      mutationOccurred,
+      options.mutationOccurred,
       options.dryRun,
     );
     const commentDisposition = reviewCommentPublicationEventDisposition(
       result.action,
-      mutationOccurred,
+      options.mutationOccurred,
       options.dryRun,
     );
-    if (disposition.mutation) mutationCount += 1;
-    if (result.action === "closed") closedCount += 1;
-    if (
-      result.action === "kept_open" ||
-      result.action.startsWith("skipped_") ||
-      result.action.startsWith("retry_")
-    ) {
-      skippedCount += 1;
-    }
-    const entry = result.number > 0 ? options.entries.get(result.number) : undefined;
-    const kind = entry ? reportItemKind(entry.markdown) : undefined;
-    const sourceRevision = entry ? reviewLeaseRevisionFromReport(entry.markdown) : null;
-    const recordPath = entry ? repoRelativePath(entry.path) : null;
-    const subject: ActionEventSubject =
-      result.number > 0 && kind
-        ? {
-            repository,
-            kind,
-            number: result.number,
-            ...(sourceRevision ? { sourceRevision } : {}),
-            ...(recordPath && !recordPath.startsWith("../") ? { recordPath } : {}),
-          }
-        : {
-            repository,
-            kind: "workflow",
-          };
     const actionEvent = recordWorkflowPhaseEvent(ROOT, {
       phase: ACTION_EVENT_TYPES.applyAction,
       status: disposition.status,
@@ -23216,40 +23449,27 @@ function recordApplyActionEvents(options: {
       mutation: disposition.mutation,
       identity: {
         slot: "apply_result",
-        index,
-        repository,
-        number: result.number,
+        index: options.state.index,
+        resultIndex,
+        repository: options.state.businessIdentity.repository,
+        number: options.state.businessIdentity.number,
       },
       operation: "apply",
       operationIdentity: options.ledger.operationIdentity,
-      parentEventId: options.ledger.batchStartEventId,
-      phaseSeq: 10 + index * 10,
-      idempotencyIdentity: {
-        ...applyItemIdempotencyIdentity({
-          ledger: options.ledger,
-          repository,
-          number: result.number,
-          entry,
-          slot: "apply_item",
-        }),
-      },
+      parentEventId: options.state.mutationEventId ?? options.state.startEventId,
+      phaseSeq: 12 + options.state.index * 20,
+      idempotencyIdentity: applyItemIdempotencyIdentity(options.state, "apply_item"),
       component: "apply_decisions",
-      subject,
+      subject: applyLedgerItemSubject(options.state, options.entry),
       evidence: [
         ...workflowRunEvidence(),
-        ...(entry
-          ? [
-              {
-                kind: "review_record",
-                sha256: sha256(entry.markdown),
-                ...(recordPath && !recordPath.startsWith("../") ? { reportPath: recordPath } : {}),
-              },
-            ]
-          : []),
+        ...[actionLedgerFileEvidence("review_record", options.entry.path)].filter(
+          (entry): entry is ActionEventEvidence => entry !== null,
+        ),
       ],
       attributes: {
-        batch_index: index,
-        item_count: result.number > 0 ? 1 : 0,
+        batch_index: options.state.index,
+        item_count: 1,
         closed_count: result.action === "closed" ? 1 : 0,
         skipped_count:
           result.action === "kept_open" ||
@@ -23271,25 +23491,19 @@ function recordApplyActionEvents(options: {
         mutation: commentDisposition.mutation,
         identity: {
           slot: "review_comment_publication",
-          index,
-          repository,
-          number: result.number,
+          index: options.state.index,
+          resultIndex,
+          repository: options.state.businessIdentity.repository,
+          number: options.state.businessIdentity.number,
         },
         operation: "apply",
         operationIdentity: options.ledger.operationIdentity,
-        parentEventId: actionEvent?.event_id ?? options.ledger.batchStartEventId,
-        phaseSeq: 11 + index * 10,
-        idempotencyIdentity: {
-          ...applyItemIdempotencyIdentity({
-            ledger: options.ledger,
-            repository,
-            number: result.number,
-            entry,
-            slot: "review_comment",
-          }),
-        },
+        parentEventId:
+          actionEvent?.event_id ?? options.state.mutationEventId ?? options.state.startEventId,
+        phaseSeq: 13 + options.state.index * 20,
+        idempotencyIdentity: applyItemIdempotencyIdentity(options.state, "review_comment"),
         component: "apply_decisions",
-        subject,
+        subject: applyLedgerItemSubject(options.state, options.entry),
         evidence: workflowRunEvidence(),
         attributes: {
           publication_kind: "review_comment",
@@ -23300,65 +23514,138 @@ function recordApplyActionEvents(options: {
       });
     }
   }
-  if (
-    options.failed &&
-    options.inFlightItem &&
-    !options.results.some(
-      (result) =>
-        (result.repo ?? targetRepo()) === options.inFlightItem?.repo &&
-        result.number === options.inFlightItem?.number,
-    )
-  ) {
-    const entry = options.entries.get(options.inFlightItem.number);
-    const kind = entry ? reportItemKind(entry.markdown) : undefined;
-    const sourceRevision = entry ? reviewLeaseRevisionFromReport(entry.markdown) : null;
+  options.state.terminal = true;
+}
+
+function recordApplyActionLedgerItemFailure(options: {
+  ledger: ApplyActionLedger;
+  state: ApplyLedgerItem;
+  entry: ReportEntry;
+  failure: unknown;
+  mutationOccurred: boolean;
+}): void {
+  if (options.state.terminal) return;
+  const disposition = actionLedgerFailureDisposition(options.failure);
+  recordWorkflowPhaseEvent(ROOT, {
+    phase: ACTION_EVENT_TYPES.applyAction,
+    status: disposition.status,
+    reasonCode: disposition.reasonCode,
+    retryable: true,
+    mutation: options.mutationOccurred,
+    identity: {
+      slot: "apply_in_flight_failure",
+      index: options.state.index,
+      repository: options.state.businessIdentity.repository,
+      number: options.state.businessIdentity.number,
+    },
+    operation: "apply",
+    operationIdentity: options.ledger.operationIdentity,
+    parentEventId: options.state.mutationEventId ?? options.state.startEventId,
+    phaseSeq: 12 + options.state.index * 20,
+    idempotencyIdentity: applyItemIdempotencyIdentity(options.state, "apply_item"),
+    component: "apply_decisions",
+    subject: applyLedgerItemSubject(options.state, options.entry),
+    evidence: workflowRunEvidence(),
+    attributes: {
+      failed_count: 1,
+      partial: options.mutationOccurred,
+      completion_reason: disposition.completionReason,
+    },
+    privacy: actionLedgerPrivacy(),
+  });
+  options.state.terminal = true;
+}
+
+function recordApplyActionEvents(options: {
+  ledger: ApplyActionLedger;
+  results: readonly ApplyResult[];
+  entries: ReadonlyMap<number, ReportEntry>;
+  mutationByItem: ReadonlyMap<string, boolean>;
+  dryRun: boolean;
+  reportPath: string;
+  failed?: boolean;
+  failure?: unknown;
+  inFlightItem?: { repo: string; number: number; mutationOccurred: boolean };
+}): void {
+  if (options.ledger.terminal) return;
+  const inFlightKey = options.inFlightItem ? actionLedgerItemKey(options.inFlightItem) : null;
+  if (options.failed && options.inFlightItem && inFlightKey) {
+    const state = options.ledger.items.get(inFlightKey);
+    if (state?.started && !state.terminal) {
+      const entry = options.entries.get(options.inFlightItem.number) ?? state.entry;
+      recordApplyActionLedgerItemFailure({
+        ledger: options.ledger,
+        state,
+        entry,
+        failure: options.failure,
+        mutationOccurred: options.inFlightItem.mutationOccurred || state.mutationObserved,
+      });
+    }
+  }
+  for (const state of options.ledger.items.values()) {
+    if (!state.started || state.terminal) continue;
+    const repository = state.businessIdentity.repository;
+    const number = state.businessIdentity.number;
+    const itemResults = options.results.filter(
+      (result) => (result.repo ?? targetRepo()) === repository && result.number === number,
+    );
+    const entry = options.entries.get(number) ?? state.entry;
+    recordApplyActionLedgerItemResults({
+      ledger: options.ledger,
+      state,
+      results: itemResults,
+      entry,
+      mutationOccurred:
+        state.mutationObserved || options.mutationByItem.get(`${repository}#${number}`) === true,
+      dryRun: options.dryRun,
+    });
+  }
+  for (const [index, result] of options.results.entries()) {
+    if (result.number > 0) continue;
+    const disposition = applyActionEventDisposition(result.action, false, options.dryRun);
     recordWorkflowPhaseEvent(ROOT, {
       phase: ACTION_EVENT_TYPES.applyAction,
-      status: ACTION_EVENT_STATUSES.failed,
-      reasonCode: actionLedgerFailureDisposition(options.failure).reasonCode,
-      retryable: true,
-      mutation: options.inFlightItem.mutationOccurred,
+      status: disposition.status,
+      reasonCode: disposition.reasonCode,
+      retryable: disposition.retryable,
+      mutation: false,
       identity: {
-        slot: "apply_in_flight_failure",
-        repository: options.inFlightItem.repo,
-        number: options.inFlightItem.number,
+        slot: "apply_result",
+        index,
+        repository: result.repo ?? targetRepo(),
+        number: result.number,
       },
       operation: "apply",
       operationIdentity: options.ledger.operationIdentity,
       parentEventId: options.ledger.batchStartEventId,
-      phaseSeq: 900_000,
+      phaseSeq: 900_000 + index,
       idempotencyIdentity: {
-        ...applyItemIdempotencyIdentity({
-          ledger: options.ledger,
-          repository: options.inFlightItem.repo,
-          number: options.inFlightItem.number,
-          entry,
-          slot: "apply_item",
-        }),
+        operationIdentity: options.ledger.operationIdentity,
+        slot: "apply_workflow_result",
+        action: result.action,
       },
       component: "apply_decisions",
-      subject:
-        kind && options.inFlightItem.number > 0
-          ? {
-              repository: options.inFlightItem.repo,
-              kind,
-              number: options.inFlightItem.number,
-              ...(sourceRevision ? { sourceRevision } : {}),
-            }
-          : {
-              repository: options.inFlightItem.repo,
-              kind: "workflow",
-            },
+      subject: {
+        repository: result.repo ?? targetRepo(),
+        kind: "workflow",
+      },
       evidence: workflowRunEvidence(),
       attributes: {
-        failed_count: 1,
-        partial: options.inFlightItem.mutationOccurred,
-        completion_reason: actionLedgerFailureDisposition(options.failure).completionReason,
+        item_count: 0,
+        completion_reason: disposition.completionReason,
+        partial: disposition.status === ACTION_EVENT_STATUSES.yielded,
       },
       privacy: actionLedgerPrivacy(),
     });
-    if (options.inFlightItem.mutationOccurred) mutationCount += 1;
   }
+  const mutationCount = [...options.mutationByItem.values()].filter(Boolean).length;
+  const closedCount = options.results.filter((result) => result.action === "closed").length;
+  const skippedCount = options.results.filter(
+    (result) =>
+      result.action === "kept_open" ||
+      result.action.startsWith("skipped_") ||
+      result.action.startsWith("retry_"),
+  ).length;
   const yielded = options.results.some((result) => result.action === "skipped_runtime_budget");
   const failure = options.failed ? actionLedgerFailureDisposition(options.failure) : null;
   const partial =
@@ -23718,6 +24005,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
   logProgress(
     `starting apply: files=${files.length} dry_run=${dryRun} apply_kind=${applyKind} min_age=${minAgeDescription} apply_close_reasons=${closeReasonFilterText(applyCloseReasons)} stale_min_age_days=${staleMinAgeDays} close_delay_ms=${closeDelayMs} sync_comments_only=${syncCommentsOnly} comment_sync_min_age_days=${commentSyncMinAgeDays} max_runtime_ms=${maxRuntimeMs} item_numbers=${requestedItemNumbers.join(",") || "all"}`,
   );
+  // oxfmt-ignore
   for (const entry of fileEntries) {
     releaseActiveApplyMutationLease();
     const file = entry.name;
@@ -23735,10 +24023,15 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
     const repo = entry.repo;
     const number = entry.number;
     activeApplyItem = { repo, number, mutationOccurred: false };
+    startApplyActionLedgerItem(applyLedger, entry);
+    const applyItemResultStart = results.length;
+    let applyItemFailed = false;
+    try {
     const recordMutation = (): void => {
       if (dryRun) return;
       activeApplyItem = { repo, number, mutationOccurred: true };
       mutationByItem.set(`${repo}#${number}`, true);
+      recordApplyMutationBoundary(applyLedger, entry);
     };
     examinedItemNumbers.push(number);
     const decision = frontMatterValue(markdown, "decision");
@@ -24034,7 +24327,9 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
         };
       }
     };
-    const ownedApplyMutationLeaseBlockReason = (lease: AcquiredReviewStartLease): string | null => {
+    const ownedApplyMutationLeaseBlockReason = (
+      lease: AcquiredReviewStartLease,
+    ): string | null => {
       try {
         const revisionBefore = fetchLiveReviewHeadSha();
         const refreshed = issueReviewCommentState(number);
@@ -24329,7 +24624,11 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
     const recordRuntimeBudgetYield = (reason: string): void => {
       if (clawSweeperLabelsChanged && !dryRun) {
         recordMutation();
-        markdown = replaceFrontMatterValue(markdown, "labels_synced_at", new Date().toISOString());
+        markdown = replaceFrontMatterValue(
+          markdown,
+          "labels_synced_at",
+          new Date().toISOString(),
+        );
         writeReportMarkdown(path, markdown);
       }
       removeCurrentCursorTraceItem(examinedItemNumbers, number);
@@ -24444,7 +24743,8 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
             hasAutoCloseAllowedMetadata(counterpartMarkdown) &&
             hasVerifiedLocalCheckoutAccess(counterpartMarkdown)
           ) {
-            const { item: counterpartItem, state: counterpartState } = fetchItem(counterpartNumber);
+            const { item: counterpartItem, state: counterpartState } =
+              fetchItem(counterpartNumber);
             const counterpartReviewedAuthorAssociation = normalizeAuthorAssociation(
               frontMatterValue(counterpartMarkdown, "author_association"),
             );
@@ -24751,7 +25051,10 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
     ) {
       if (!unconfirmedProductDirectionCloseEnabled()) {
         if (
-          recordApplySkipped("kept_open", "unconfirmed product-direction apply policy is disabled")
+          recordApplySkipped(
+            "kept_open",
+            "unconfirmed product-direction apply policy is disabled",
+          )
         ) {
           break;
         }
@@ -25094,7 +25397,11 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
       currentUpdatedAt?: string | undefined;
       currentSnapshotHash?: string | undefined;
     }): boolean => {
-      markdown = replaceFrontMatterValue(markdown, "action_taken", "skipped_changed_since_review");
+      markdown = replaceFrontMatterValue(
+        markdown,
+        "action_taken",
+        "skipped_changed_since_review",
+      );
       if (options.currentUpdatedAt) {
         markdown = replaceFrontMatterValue(
           markdown,
@@ -25145,7 +25452,9 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
       let refreshedContext: ItemContext | null = null;
       const selfMutationMaskedNonAutomationActivity = (): boolean => {
         if (prCloseCoverageProofStartedAtMs === null) return true;
-        refreshedContext ??= collectItemContext(refreshed.item, { fullTimelineForRelations: true });
+        refreshedContext ??= collectItemContext(refreshed.item, {
+          fullTimelineForRelations: true,
+        });
         return contextHasNonAutomationActivityAfter(
           refreshedContext,
           prCloseCoverageProofStartedAtMs,
@@ -25228,7 +25537,11 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
           "applied_at",
           commentUpdatedAt(existingReviewComment) ?? new Date().toISOString(),
         );
-        markdown = replaceFrontMatterValue(markdown, "apply_checked_at", new Date().toISOString());
+        markdown = replaceFrontMatterValue(
+          markdown,
+          "apply_checked_at",
+          new Date().toISOString(),
+        );
         archiveClosed(markdown);
         closedCount += 1;
         processedCount += 1;
@@ -25269,7 +25582,11 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
       continue;
     }
     if (isCloseProposal && updatedSinceReview && !automationOnlyUpdate) {
-      markdown = replaceFrontMatterValue(markdown, "action_taken", "skipped_changed_since_review");
+      markdown = replaceFrontMatterValue(
+        markdown,
+        "action_taken",
+        "skipped_changed_since_review",
+      );
       markdown = replaceFrontMatterValue(markdown, "current_item_updated_at", item.updatedAt);
       markdown = replaceFrontMatterValue(markdown, "apply_checked_at", new Date().toISOString());
       if (!dryRun) writeReportMarkdown(path, markdown);
@@ -25293,7 +25610,11 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
           "skipped_changed_since_review",
         );
         markdown = replaceFrontMatterValue(markdown, "current_item_snapshot_hash", currentHash);
-        markdown = replaceFrontMatterValue(markdown, "apply_checked_at", new Date().toISOString());
+        markdown = replaceFrontMatterValue(
+          markdown,
+          "apply_checked_at",
+          new Date().toISOString(),
+        );
         if (!dryRun) writeReportMarkdown(path, markdown);
         results.push({
           number,
@@ -25377,7 +25698,12 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
         continue;
       }
     }
-    if (state === "open" && item.kind === "issue" && !isCloseProposal && isCurrentCompleteReport) {
+    if (
+      state === "open" &&
+      item.kind === "issue" &&
+      !isCloseProposal &&
+      isCurrentCompleteReport
+    ) {
       const mutationLeaseBlockReason = currentApplyMutationLeaseBlockReason();
       if (mutationLeaseBlockReason) {
         if (recordReviewLeaseSkip(mutationLeaseBlockReason, false)) break;
@@ -25434,7 +25760,8 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
         (pullNumber, pullRepo) => canClosePairCounterpartInThisRun(pullNumber, pullRepo),
       );
       if (openClosingPullRequestReason) {
-        if (markApplySkipped("skipped_open_closing_pr", openClosingPullRequestReason, true)) break;
+        if (markApplySkipped("skipped_open_closing_pr", openClosingPullRequestReason, true))
+          break;
         continue;
       }
     }
@@ -25569,7 +25896,8 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
           canStartSameAuthorPairCloseInThisRun(counterpartNumber, counterpartKind),
       );
       if (sameAuthorCounterpartReason) {
-        if (markApplySkipped("skipped_same_author_pair", sameAuthorCounterpartReason, true)) break;
+        if (markApplySkipped("skipped_same_author_pair", sameAuthorCounterpartReason, true))
+          break;
         continue;
       }
     }
@@ -25587,7 +25915,11 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
     const labelSyncProgressMessage = issueAdvisoryLabelsChanged
       ? `synced advisory issue labels #${number}`
       : `synced ClawSweeper labels #${number}`;
-    if (needsReviewCommentSync && needsReviewCommentBodySync && shouldCheckCanonicalCommentSync()) {
+    if (
+      needsReviewCommentSync &&
+      needsReviewCommentBodySync &&
+      shouldCheckCanonicalCommentSync()
+    ) {
       const wasStaleCanonicalCommentSyncPending = staleCanonicalCommentSyncPending;
       const mutationBoundaryGuard = applyCanonicalCommentSyncGuard(true);
       if (mutationBoundaryGuard.stopApply) break;
@@ -25625,7 +25957,11 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
     if (needsReviewCommentSync) {
       const staleSyncReason = needsReviewCommentBodySync ? staleReviewCommentReason : null;
       if (staleSyncReason) {
-        markdown = replaceFrontMatterValue(markdown, "apply_checked_at", new Date().toISOString());
+        markdown = replaceFrontMatterValue(
+          markdown,
+          "apply_checked_at",
+          new Date().toISOString(),
+        );
         if (!dryRun) writeReportMarkdown(path, markdown);
         results.push({
           number,
@@ -25637,7 +25973,9 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
         if (processedCount >= processedLimit) break;
         continue;
       }
-      const lockedReason = needsReviewCommentBodySync ? lockedConversationApplyReason(item) : null;
+      const lockedReason = needsReviewCommentBodySync
+        ? lockedConversationApplyReason(item)
+        : null;
       if (lockedReason) {
         const actionTaken: ActionTaken = staleCanonicalCommentSyncPending
           ? "retry_stale_canonical_comment_sync"
@@ -25721,7 +26059,11 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
             continue;
           }
           try {
-            syncedComment = upsertReviewComment(number, markedReviewComment, existingReviewComment);
+            syncedComment = upsertReviewComment(
+              number,
+              markedReviewComment,
+              existingReviewComment,
+            );
             recordMutation();
             const syncedCommentUpdatedAt = commentUpdatedAt(syncedComment);
             if (syncedCommentUpdatedAt) {
@@ -25776,7 +26118,11 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
         if (staleCanonicalCommentSyncPending) {
           markdown = completeStaleCanonicalCommentSyncReport(markdown);
         }
-        markdown = replaceFrontMatterValue(markdown, "apply_checked_at", new Date().toISOString());
+        markdown = replaceFrontMatterValue(
+          markdown,
+          "apply_checked_at",
+          new Date().toISOString(),
+        );
         if (!dryRun) writeReportMarkdown(path, markdown);
         results.push({
           number,
@@ -26013,7 +26359,9 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
     results.push({
       number,
       action: "closed",
-      reason: [closeReasonText(closeReason), closeAppliedCommentReason].filter(Boolean).join("; "),
+      reason: [closeReasonText(closeReason), closeAppliedCommentReason]
+        .filter(Boolean)
+        .join("; "),
       ...(emitEventApplyProof ? { terminalStateVerified: true } : {}),
     });
     logProgress(`closed #${number}`);
@@ -26023,6 +26371,42 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
       return;
     }
     if (processedCount >= processedLimit) break;
+    } catch (error) {
+      applyItemFailed = true;
+      throw error;
+    } finally {
+      if (!applyItemFailed) {
+        const state = applyLedger.items.get(actionLedgerItemKey(entry));
+        if (!applyLedger.terminal && state?.started && !state.terminal) {
+          const closedEntryPath = join(closedDir, file);
+          const currentEntryPath = existsSync(path)
+            ? path
+            : existsSync(closedEntryPath)
+              ? closedEntryPath
+              : entry.path;
+          const currentEntry = existsSync(currentEntryPath)
+            ? {
+                ...entry,
+                path: currentEntryPath,
+                markdown: readFileSync(currentEntryPath, "utf8"),
+              }
+            : entry;
+          recordApplyActionLedgerItemResults({
+            ledger: applyLedger,
+            state,
+            results: results
+              .slice(applyItemResultStart)
+              .filter(
+                (result) => (result.repo ?? targetRepo()) === repo && result.number === number,
+              ),
+            entry: currentEntry,
+            mutationOccurred: mutationByItem.get(`${repo}#${number}`) === true,
+            dryRun,
+          });
+        }
+        activeApplyItem = null;
+      }
+    }
   }
   releaseActiveApplyMutationLease();
   activeApplyItem = null;

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -196,6 +196,7 @@ import {
 import {
   flushWorkflowActionEvents,
   importActionEventShards,
+  interruptOpenWorkflowActionEvents,
   recordWorkflowPhaseEvent,
 } from "./action-ledger-runtime.js";
 
@@ -20218,7 +20219,12 @@ type ReviewActionLedger = {
     reviewPolicy: string;
     shardIndex: number;
     shardCount: number;
-    candidateNumbers: number[];
+    candidateSnapshots: Array<{
+      repository: string;
+      number: number;
+      kind: ItemKind;
+      updatedAt: string;
+    }>;
   };
   batchStartEventId: string | null;
   items: Map<string, ReviewLedgerItem>;
@@ -20289,7 +20295,12 @@ function startReviewActionLedger(options: {
     reviewPolicy: options.reviewPolicy,
     shardIndex: options.shardIndex,
     shardCount: options.shardCount,
-    candidateNumbers: options.candidates.map((item) => item.number),
+    candidateSnapshots: options.candidates.map((item) => ({
+      repository: item.repo,
+      number: item.number,
+      kind: item.kind,
+      updatedAt: item.updatedAt,
+    })),
   };
   const batchStart = recordWorkflowPhaseEvent(ROOT, {
     phase: ACTION_EVENT_TYPES.reviewBatch,
@@ -20388,19 +20399,19 @@ function recordReviewLogPublication(options: {
           .map((name) => actionLedgerFileEvidence("review_log", join(options.codexWorkDir!, name)))
           .filter((entry): entry is ActionEventEvidence => entry !== null)
       : [];
-  const published = logs.length > 0;
+  const captured = logs.length > 0;
   const event = recordWorkflowPhaseEvent(ROOT, {
     phase: ACTION_EVENT_TYPES.reviewLogPublication,
-    status: published
-      ? ACTION_EVENT_STATUSES.published
+    status: captured
+      ? ACTION_EVENT_STATUSES.completed
       : (options.missingStatus ?? ACTION_EVENT_STATUSES.skipped),
-    reasonCode: published
-      ? ACTION_EVENT_REASON_CODES.published
+    reasonCode: captured
+      ? ACTION_EVENT_REASON_CODES.completed
       : (options.missingReasonCode ??
         (options.cached
           ? ACTION_EVENT_REASON_CODES.notApplicable
           : ACTION_EVENT_REASON_CODES.notFound)),
-    retryable: published ? false : (options.retryable ?? false),
+    retryable: captured ? false : (options.retryable ?? false),
     mutation: false,
     identity: {
       slot: "review_logs",
@@ -20426,7 +20437,7 @@ function recordReviewLogPublication(options: {
       cached: options.cached,
       log_count: logs.length,
       log_kind: "codex",
-      publication_kind: "artifact",
+      publication_kind: "local_artifact",
     },
     privacy: actionLedgerPrivacy(),
   });
@@ -22883,6 +22894,13 @@ type ApplyActionLedger = {
     requestedItemNumbers: number[];
     reportPath: string;
     checkpoint: string;
+    candidateRevisions: Array<{
+      repository: string;
+      number: number;
+      sourceRevision: string;
+      reviewContentDigest: string;
+      decisionPacketSha256: string;
+    }>;
   };
   batchStartEventId: string | null;
   startedAtMs: number;
@@ -22896,7 +22914,7 @@ function startApplyActionLedger(options: {
   syncCommentsOnly: boolean;
   requestedItemNumbers: readonly number[];
   reportPath: string;
-  candidateCount: number;
+  candidates: readonly ReportEntry[];
 }): ApplyActionLedger {
   const operationIdentity = {
     repository: targetRepo(),
@@ -22907,6 +22925,13 @@ function startApplyActionLedger(options: {
     requestedItemNumbers: [...options.requestedItemNumbers],
     reportPath: repoRelativePath(options.reportPath),
     checkpoint: String(process.env.CLAWSWEEPER_APPLY_CHECKPOINT ?? "0"),
+    candidateRevisions: options.candidates.map((entry) => ({
+      repository: entry.repo,
+      number: entry.number,
+      sourceRevision: reviewLeaseRevisionFromReport(entry.markdown) ?? "unknown",
+      reviewContentDigest: frontMatterValue(entry.markdown, "review_content_digest") ?? "unknown",
+      decisionPacketSha256: frontMatterValue(entry.markdown, "decision_packet_sha256") ?? "none",
+    })),
   };
   const batchStart = recordWorkflowPhaseEvent(ROOT, {
     phase: ACTION_EVENT_TYPES.applyBatch,
@@ -22926,7 +22951,7 @@ function startApplyActionLedger(options: {
     },
     evidence: workflowRunEvidence(),
     attributes: {
-      candidate_count: options.candidateCount,
+      candidate_count: options.candidates.length,
       review_mode: options.syncCommentsOnly ? "comment_sync" : "apply",
       work_kind: options.dryRun ? "proof" : "mutation",
     },
@@ -22937,6 +22962,30 @@ function startApplyActionLedger(options: {
     batchStartEventId: batchStart?.event_id ?? null,
     startedAtMs: Date.now(),
     terminal: false,
+  };
+}
+
+function applyItemIdempotencyIdentity(options: {
+  ledger: ApplyActionLedger;
+  repository: string;
+  number: number;
+  entry: ReportEntry | undefined;
+  slot: "apply_item" | "review_comment";
+}) {
+  return {
+    operationIdentity: options.ledger.operationIdentity,
+    slot: options.slot,
+    repository: options.repository,
+    number: options.number,
+    sourceRevision: options.entry
+      ? (reviewLeaseRevisionFromReport(options.entry.markdown) ?? "unknown")
+      : "unknown",
+    reviewContentDigest: options.entry
+      ? (frontMatterValue(options.entry.markdown, "review_content_digest") ?? "unknown")
+      : "unknown",
+    decisionPacketSha256: options.entry
+      ? (frontMatterValue(options.entry.markdown, "decision_packet_sha256") ?? "none")
+      : "none",
   };
 }
 
@@ -23176,11 +23225,13 @@ function recordApplyActionEvents(options: {
       parentEventId: options.ledger.batchStartEventId,
       phaseSeq: 10 + index * 10,
       idempotencyIdentity: {
-        operationIdentity: options.ledger.operationIdentity,
-        slot: "apply_result",
-        index,
-        repository,
-        number: result.number,
+        ...applyItemIdempotencyIdentity({
+          ledger: options.ledger,
+          repository,
+          number: result.number,
+          entry,
+          slot: "apply_item",
+        }),
       },
       component: "apply_decisions",
       subject,
@@ -23229,11 +23280,13 @@ function recordApplyActionEvents(options: {
         parentEventId: actionEvent?.event_id ?? options.ledger.batchStartEventId,
         phaseSeq: 11 + index * 10,
         idempotencyIdentity: {
-          operationIdentity: options.ledger.operationIdentity,
-          slot: "review_comment_publication",
-          index,
-          repository,
-          number: result.number,
+          ...applyItemIdempotencyIdentity({
+            ledger: options.ledger,
+            repository,
+            number: result.number,
+            entry,
+            slot: "review_comment",
+          }),
         },
         component: "apply_decisions",
         subject,
@@ -23275,10 +23328,13 @@ function recordApplyActionEvents(options: {
       parentEventId: options.ledger.batchStartEventId,
       phaseSeq: 900_000,
       idempotencyIdentity: {
-        operationIdentity: options.ledger.operationIdentity,
-        slot: "apply_in_flight_failure",
-        repository: options.inFlightItem.repo,
-        number: options.inFlightItem.number,
+        ...applyItemIdempotencyIdentity({
+          ledger: options.ledger,
+          repository: options.inFlightItem.repo,
+          number: options.inFlightItem.number,
+          entry,
+          slot: "apply_item",
+        }),
       },
       component: "apply_decisions",
       subject:
@@ -23372,9 +23428,9 @@ function recordApplyActionEvents(options: {
   const reportEvidence = actionLedgerFileEvidence("apply_report", options.reportPath);
   recordWorkflowPhaseEvent(ROOT, {
     phase: ACTION_EVENT_TYPES.applyPublish,
-    status: reportEvidence ? ACTION_EVENT_STATUSES.published : ACTION_EVENT_STATUSES.skipped,
+    status: reportEvidence ? ACTION_EVENT_STATUSES.completed : ACTION_EVENT_STATUSES.skipped,
     reasonCode: reportEvidence
-      ? ACTION_EVENT_REASON_CODES.published
+      ? ACTION_EVENT_REASON_CODES.completed
       : ACTION_EVENT_REASON_CODES.notFound,
     retryable: !reportEvidence,
     mutation: false,
@@ -23397,7 +23453,7 @@ function recordApplyActionEvents(options: {
     },
     evidence: [...workflowRunEvidence(), ...(reportEvidence ? [reportEvidence] : [])],
     attributes: {
-      publication_kind: "apply_report",
+      publication_kind: "local_report",
       result_count: options.results.length,
       partial,
     },
@@ -23568,7 +23624,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
     syncCommentsOnly,
     requestedItemNumbers,
     reportPath,
-    candidateCount: fileEntries.length,
+    candidates: fileEntries,
   });
   const mutationByItem = new Map<string, boolean>();
   let activeApplyItem: { repo: string; number: number; mutationOccurred: boolean } | null = null;
@@ -26789,10 +26845,10 @@ function applyArtifactsCommand(args: Args): void {
       },
       evidence: workflowRunEvidence(),
       attributes: {
-        published_count: appliedArtifacts,
+        action_count: appliedArtifacts,
         skipped_count: skippedClosedArtifacts,
         failed_count: failure ? 1 : 0,
-        publication_kind: "review_record",
+        publication_kind: "state_worktree",
         partial:
           failure !== null
             ? appliedArtifacts > 0 || interruptedMutation
@@ -26879,8 +26935,8 @@ function applyArtifactsCommand(args: Args): void {
           markdown: syncedMarkdown,
           reportPath,
           number,
-          status: ACTION_EVENT_STATUSES.published,
-          reasonCode: ACTION_EVENT_REASON_CODES.published,
+          status: ACTION_EVENT_STATUSES.completed,
+          reasonCode: ACTION_EVENT_REASON_CODES.completed,
           mutation: true,
           destination,
         });
@@ -28712,11 +28768,30 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
     else if (command === "assist-validate") assistValidateArtifactCommand(args);
     else if (command === "assist-publish") assistPublishCommand(args);
     else if (command === "check") checkCommand();
-    else if (command !== "finalize-action-events")
-      throw new UserFacingCommandError(`Unknown command: ${command}`);
+    else if (command === "finalize-action-events") {
+      if (boolArg(args.interrupt_open_attempts)) {
+        const reason = stringArg(args.reason, ACTION_EVENT_REASON_CODES.timeout);
+        if (reason !== ACTION_EVENT_REASON_CODES.timeout) {
+          throw new UserFacingCommandError(
+            `Unsupported --reason for interrupted action events: ${reason}`,
+          );
+        }
+        const interrupted = interruptOpenWorkflowActionEvents(ROOT, {
+          reasonCode: ACTION_EVENT_REASON_CODES.timeout,
+        });
+        if (interrupted > 0) {
+          console.error(
+            `[action-ledger] recorded ${interrupted} timeout terminal event${
+              interrupted === 1 ? "" : "s"
+            }`,
+          );
+        }
+      }
+    } else throw new UserFacingCommandError(`Unknown command: ${command}`);
   } catch (error) {
     commandError = error;
   }
+  if (command === "finalize-action-events" && commandError) throw commandError;
   try {
     const shardPaths = await flushWorkflowActionEvents(ROOT);
     if (shardPaths.length > 0) {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -30307,16 +30307,31 @@ function publishActionEventPathsCommand(args: Args): void {
   console.log(JSON.stringify({ result, path_count: paths.length }));
 }
 
-export async function main(argv = process.argv.slice(2)): Promise<void> {
+function isExplicitActionLedgerCommand(command: string): boolean {
+  return (
+    command === "finalize-action-events" ||
+    command === "publish-action-events" ||
+    command === "publish-action-event-paths"
+  );
+}
+
+export async function main(
+  argv = process.argv.slice(2),
+  dependencies: {
+    flushWorkflowActionEvents?: typeof flushWorkflowActionEvents;
+  } = {},
+): Promise<void> {
   const args = parseArgs(argv);
   const command = args._[0] ?? "review";
+  const flushActionEvents = dependencies.flushWorkflowActionEvents ?? flushWorkflowActionEvents;
   if (!process.env.CLAWSWEEPER_ACTION_LEDGER_INVOCATION) {
     process.env.CLAWSWEEPER_ACTION_LEDGER_INVOCATION = sha256(stableJson({ command, args })).slice(
       0,
       16,
     );
   }
-  let commandError: unknown = null;
+  let commandFailed = false;
+  let commandError: unknown;
   try {
     if (command === "plan") planCommand(args);
     else if (command === "review") reviewCommand(args);
@@ -30366,11 +30381,11 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
       }
     } else throw new UserFacingCommandError(`Unknown command: ${command}`);
   } catch (error) {
+    commandFailed = true;
     commandError = error;
   }
-  if (command === "finalize-action-events" && commandError) throw commandError;
   try {
-    const shardPaths = await flushWorkflowActionEvents(ROOT);
+    const shardPaths = await flushActionEvents(ROOT);
     if (shardPaths.length > 0) {
       console.error(
         `[action-ledger] finalized ${shardPaths.length} immutable workflow shard${
@@ -30379,17 +30394,24 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
       );
     }
   } catch (error) {
-    if (commandError) {
+    if (commandFailed) {
       console.error(
-        `[action-ledger] finalization failed after command failure: ${
+        `[action-ledger] best-effort finalization failed after command failure: ${
           error instanceof Error ? error.message : String(error)
         }`,
       );
-    } else {
+    } else if (isExplicitActionLedgerCommand(command)) {
+      commandFailed = true;
       commandError = error;
+    } else {
+      console.error(
+        `[action-ledger] best-effort finalization failed after successful ${command}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
     }
   }
-  if (commandError) throw commandError;
+  if (commandFailed) throw commandError;
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -2454,10 +2454,13 @@ function sleepBeforeGitHubRetry(waitMs: number): void {
   sleepMs(waitMs);
 }
 
-function gh(args: string[]): string {
-  const timeoutMs = githubCommandTimeoutMs();
+function ghWithPreparedTimeout(args: string[], timeoutMs: number | undefined): string {
   if (args[0] === "api") return run("gh", args, { timeoutMs });
   return run("gh", ["--repo", targetRepo(), ...args], { timeoutMs });
+}
+
+function gh(args: string[]): string {
+  return ghWithPreparedTimeout(args, githubCommandTimeoutMs());
 }
 
 function ghOnce(args: string[], timeoutMs: number): string {
@@ -2658,23 +2661,35 @@ function ghObservedMutationCommand(options: {
   didMutate?: ((result: string) => boolean) | undefined;
   knownNoMutation?: ((error: unknown) => boolean) | undefined;
   request?: ((args: string[], attempt: number) => string) | undefined;
+  prepareRequest?: ((args: string[], attempt: number) => () => string) | undefined;
   sleepBeforeRetry?: ((waitMs: number) => void) | undefined;
 }): string {
   return ghWithRetry(options.args, options.attempts ?? 12, {
-    request: (args, attempt) =>
-      runObservedApplyMutation({
+    request: (args, attempt) => {
+      let operation: () => string;
+      if (options.prepareRequest) {
+        operation = options.prepareRequest(args, attempt);
+      } else if (options.request) {
+        const request = options.request;
+        operation = () => request(args, attempt);
+      } else {
+        const timeoutMs = githubCommandTimeoutMs();
+        operation = () => ghWithPreparedTimeout(args, timeoutMs);
+      }
+      return runObservedApplyMutation({
         identity: `${options.identity}:request_attempt:${attempt + 1}`,
-        operation: () => (options.request ? options.request(args, attempt) : gh(args)),
+        operation,
         ...(options.onMutation ? { onMutation: options.onMutation } : {}),
         ...(options.didMutate ? { didMutate: options.didMutate } : {}),
         ...(options.knownNoMutation ? { knownNoMutation: options.knownNoMutation } : {}),
-      }),
+      });
+    },
     ...(options.sleepBeforeRetry ? { sleepBeforeRetry: options.sleepBeforeRetry } : {}),
   });
 }
 
 export function observedGitHubMutationAttemptsForTest(
-  outcomes: readonly ("transient" | "accepted" | "already_exists")[],
+  outcomes: readonly ("not_started" | "transient" | "accepted" | "already_exists")[],
 ): Array<{ identity: string; outcome: "accepted" | "rejected" | "unknown" }> {
   const receipts: Array<{
     identity: string;
@@ -2708,11 +2723,16 @@ export function observedGitHubMutationAttemptsForTest(
       args: ["api", "test"],
       attempts: outcomes.length,
       knownNoMutation: labelAlreadyExistsError,
-      request: (_args, attempt) => {
+      prepareRequest: (_args, attempt) => {
         const outcome = outcomes[attempt];
-        if (outcome === "accepted") return "ok";
-        if (outcome === "already_exists") throw new Error("label already exists");
-        throw new Error("HTTP 502: transient upstream failure");
+        if (outcome === "not_started") {
+          throw new GitHubRuntimeBudgetError("max runtime reached before GitHub operation");
+        }
+        return () => {
+          if (outcome === "accepted") return "ok";
+          if (outcome === "already_exists") throw new Error("label already exists");
+          throw new Error("HTTP 502: transient upstream failure");
+        };
       },
       sleepBeforeRetry: () => {},
     });
@@ -9246,6 +9266,20 @@ class CodexReviewError extends Error {
     this.signal = options.signal ?? null;
     this.retryable = options.retryable ?? false;
   }
+}
+
+function codexReviewFailureRetryable(error: unknown): boolean {
+  return error instanceof CodexReviewError ? error.retryable : true;
+}
+
+export function codexReviewFailureRetryableForTest(retryable: boolean): boolean {
+  return codexReviewFailureRetryable(
+    new CodexReviewError({
+      message: "test Codex failure",
+      status: 1,
+      retryable,
+    }),
+  );
 }
 
 function openclawDirtyStatus(openclawDir: string): string {
@@ -22004,6 +22038,7 @@ function reviewCommand(args: Args): void {
       let decision: Decision;
       let codexElapsedMs = 0;
       let codexFailed = false;
+      let codexFailureRetryable = false;
       let codexFailureDisposition: ReturnType<typeof actionLedgerFailureDisposition> | null =
         null;
       const codexStartedAt = Date.now();
@@ -22042,6 +22077,7 @@ function reviewCommand(args: Args): void {
       } catch (error) {
         codexFailures += 1;
         codexFailed = true;
+        codexFailureRetryable = codexReviewFailureRetryable(error);
         codexFailureDisposition = actionLedgerFailureDisposition(error);
         if (error instanceof CodexReviewError) {
           decision = codexFailureDecision(
@@ -22112,7 +22148,7 @@ function reviewCommand(args: Args): void {
         item,
         status: codexFailureDisposition?.status ?? ACTION_EVENT_STATUSES.completed,
         reasonCode: codexFailureDisposition?.reasonCode ?? ACTION_EVENT_REASON_CODES.completed,
-        retryable: codexFailed,
+        retryable: codexFailed && codexFailureRetryable,
         cached: false,
         startedAtMs: contextStartedAt,
         ...(context.sourceRevision ? { sourceRevision: context.sourceRevision } : {}),
@@ -22768,7 +22804,8 @@ function startFailedReviewRetryDispatchAttempt(options: {
   if (options.ledger.dispatchAttempts.has(key)) return;
   const phaseSeq = options.ledger.nextDispatchPhaseSeq;
   options.ledger.nextDispatchPhaseSeq += 10;
-  const kind = reportItemKind(readFileSync(options.reportPath, "utf8"));
+  const reportMarkdown = readFileSync(options.reportPath, "utf8");
+  const kind = reportItemKind(reportMarkdown);
   if (!kind) {
     throw new Error(
       `retry dispatch receipt for ${repository}#${options.number} is missing its item kind`,
@@ -22795,6 +22832,8 @@ function startFailedReviewRetryDispatchAttempt(options: {
       number: options.number,
       revisionKind: options.revision.kind,
       sourceRevision: options.revision.value,
+      reviewContentDigest: frontMatterValue(reportMarkdown, "review_content_digest") ?? "unknown",
+      decisionPacketSha256: frontMatterValue(reportMarkdown, "decision_packet_sha256") ?? "none",
       slot: "retry_dispatch",
     }),
     component: "retry_failed_reviews",
@@ -23224,6 +23263,8 @@ export function reviewRetryBusinessIdempotencyIdentityForTest(options: {
   number: number;
   revisionKind: FailedReviewRetryRevisionKind;
   sourceRevision: string;
+  reviewContentDigest: string;
+  decisionPacketSha256: string;
   slot: "retry_dispatch" | "retry_exhaustion" | "retry_observation";
 }) {
   return {
@@ -23233,6 +23274,8 @@ export function reviewRetryBusinessIdempotencyIdentityForTest(options: {
     number: options.number,
     revisionKind: options.revisionKind,
     sourceRevision: options.sourceRevision,
+    reviewContentDigest: options.reviewContentDigest,
+    decisionPacketSha256: options.decisionPacketSha256,
   };
 }
 
@@ -23312,6 +23355,14 @@ function recordFailedReviewRetryEvents(options: {
             number: result.number,
             revisionKind,
             sourceRevision,
+            reviewContentDigest:
+              (reportMarkdown
+                ? frontMatterValue(reportMarkdown, "review_content_digest")
+                : undefined) ?? "unknown",
+            decisionPacketSha256:
+              (reportMarkdown
+                ? frontMatterValue(reportMarkdown, "decision_packet_sha256")
+                : undefined) ?? "none",
             slot: retrySlot,
           })
         : {
@@ -23843,7 +23894,7 @@ export function applyActionEventDisposition(
       status: ACTION_EVENT_STATUSES.yielded,
       reasonCode: ACTION_EVENT_REASON_CODES.runtimeBudget,
       retryable: true,
-      mutation: false,
+      mutation: mutationOccurred,
       completionReason: "runtime_budget",
     };
   }
@@ -23928,6 +23979,28 @@ export function applyActionEventDisposition(
     mutation: mutationOccurred,
     completionReason: "completed",
   };
+}
+
+function applyRuntimeBudgetYieldResults(number: number, reason: string): ApplyResult[] {
+  return [
+    {
+      number,
+      action: "skipped_runtime_budget",
+      reason,
+    },
+    {
+      number: 0,
+      action: "skipped_runtime_budget",
+      reason,
+    },
+  ];
+}
+
+export function applyRuntimeBudgetYieldResultsForTest(
+  number: number,
+  reason: string,
+): ApplyResult[] {
+  return applyRuntimeBudgetYieldResults(number, reason);
 }
 
 export function reviewCommentPublicationEventDisposition(
@@ -25266,7 +25339,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
         writeReportMarkdown(path, markdown);
       }
       removeCurrentCursorTraceItem(examinedItemNumbers, number);
-      results.push({ number: 0, action: "skipped_runtime_budget", reason });
+      results.push(...applyRuntimeBudgetYieldResults(number, reason));
       logProgress(`stopping apply: ${reason}`);
     };
     const sameAuthorPairStartCloseable = new Map<string, boolean>();

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -194,11 +194,13 @@ import {
   type ActionEventSubject,
 } from "./action-ledger.js";
 import {
+  ACTION_EVENT_SHARD_IMPORT_MAX_PUBLISH_PATHS,
   flushWorkflowActionEvents,
   importActionEventShards,
   interruptOpenWorkflowActionEvents,
   recordWorkflowPhaseEvent,
 } from "./action-ledger-runtime.js";
+import { publishMainCommit } from "./repair/git-publish.js";
 
 export {
   codexEnv,
@@ -257,6 +259,7 @@ type FailedReviewRetryAction =
   | "skipped_retry_exhausted"
   | "skipped_live_fetch_failed"
   | "skipped_dispatch_failed"
+  | "skipped_retry_dispatch_uncertain"
   | "skipped_runtime_budget";
 type TriagePriority = "P0" | "P1" | "P2" | "P3" | "none";
 type ImpactLabelName =
@@ -2562,6 +2565,43 @@ function ghWithRetry(args: string[], attempts = 12): string {
     }
   }
   throw lastError;
+}
+
+type ApplyMutationRunner = <T>(options: {
+  identity: string;
+  operation: () => T;
+  didMutate?: ((result: T) => boolean) | undefined;
+  knownNoMutation?: ((error: unknown) => boolean) | undefined;
+}) => T;
+
+let activeApplyMutationRunner: ApplyMutationRunner | null = null;
+
+function mutationErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function runObservedApplyMutation<T>(options: {
+  identity: string;
+  operation: () => T;
+  onMutation?: (() => void) | undefined;
+  didMutate?: ((result: T) => boolean) | undefined;
+  knownNoMutation?: ((error: unknown) => boolean) | undefined;
+}): T {
+  if (activeApplyMutationRunner) {
+    return activeApplyMutationRunner({
+      identity: options.identity,
+      operation: options.operation,
+      ...(options.didMutate ? { didMutate: options.didMutate } : {}),
+      ...(options.knownNoMutation ? { knownNoMutation: options.knownNoMutation } : {}),
+    });
+  }
+  const result = options.operation();
+  if (options.didMutate?.(result) ?? true) options.onMutation?.();
+  return result;
+}
+
+function ghObservedMutationCommand(args: string[], attempts = 12): string {
+  return activeApplyMutationRunner ? gh(args) : ghWithRetry(args, attempts);
 }
 
 function ghRawOnceWithCheckpoint(args: string[], onBeforeRun: () => void): string {
@@ -6987,6 +7027,21 @@ function failedReviewRetryEligibility(options: {
     reportRevision.kind === "pull_head_sha"
       ? `head ${reportRevision.value}`
       : `source revision ${reportRevision.value}`;
+  const storedRevision = storedFailedReviewRetryRevision(options.markdown);
+  if (
+    frontMatterValue(options.markdown, "failed_review_retry_status") === "dispatching" &&
+    storedRevision &&
+    sameFailedReviewRetryRevision(storedRevision, reportRevision)
+  ) {
+    return {
+      repo,
+      number,
+      action: "skipped_retry_dispatch_uncertain",
+      reason: `dispatch outcome is uncertain for ${revisionDescription}; refusing a duplicate launch`,
+      ...failedReviewRetryResultRevision(reportRevision),
+      attempts,
+    };
+  }
   if (attempts >= options.maxAttempts) {
     return {
       repo,
@@ -12913,13 +12968,42 @@ export function mergeRiskLabelsForTest(
   );
 }
 
+function removeIssueLabel(number: number, label: string, onMutation?: () => void): void {
+  runObservedApplyMutation({
+    identity: `issue_label_remove:${number}:${label}`,
+    operation: () => ghWithRetry(["issue", "edit", String(number), "--remove-label", label]),
+    onMutation,
+  });
+}
+
+function addIssueLabel(number: number, label: string, onMutation?: () => void): void {
+  runObservedApplyMutation({
+    identity: `issue_label_add:${number}:${label}`,
+    operation: () => ghWithRetry(["issue", "edit", String(number), "--add-label", label]),
+    onMutation,
+    knownNoMutation: (error) => missingLabelError(error, label) || labelCapacityError(error),
+  });
+}
+
 function ensurePriorityLabel(label: PriorityLabelSpec, onMutation?: () => void): void {
   try {
-    ghWithRetry(
-      ["label", "create", label.name, "--color", label.color, "--description", label.description],
-      2,
-    );
-    onMutation?.();
+    runObservedApplyMutation({
+      identity: `label_create:${label.name}`,
+      operation: () =>
+        ghObservedMutationCommand(
+          [
+            "label",
+            "create",
+            label.name,
+            "--color",
+            label.color,
+            "--description",
+            label.description,
+          ],
+          2,
+        ),
+      onMutation,
+    });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (!/already exists/i.test(message)) throw error;
@@ -12930,19 +13014,23 @@ function ensureImpactLabel(name: ImpactLabelName, onMutation?: () => void): void
   const definition = IMPACT_LABELS.find((label) => label.name === name);
   if (!definition) return;
   try {
-    ghWithRetry(
-      [
-        "label",
-        "create",
-        definition.name,
-        "--color",
-        definition.color,
-        "--description",
-        definition.description,
-      ],
-      2,
-    );
-    onMutation?.();
+    runObservedApplyMutation({
+      identity: `label_create:${definition.name}`,
+      operation: () =>
+        ghObservedMutationCommand(
+          [
+            "label",
+            "create",
+            definition.name,
+            "--color",
+            definition.color,
+            "--description",
+            definition.description,
+          ],
+          2,
+        ),
+      onMutation,
+    });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (!/already exists/i.test(message)) throw error;
@@ -12953,19 +13041,23 @@ function ensureMergeRiskLabel(name: MergeRiskLabelName, onMutation?: () => void)
   const definition = MERGE_RISK_LABELS.find((label) => label.name === name);
   if (!definition) return;
   try {
-    ghWithRetry(
-      [
-        "label",
-        "create",
-        definition.name,
-        "--color",
-        definition.color,
-        "--description",
-        definition.description,
-      ],
-      2,
-    );
-    onMutation?.();
+    runObservedApplyMutation({
+      identity: `label_create:${definition.name}`,
+      operation: () =>
+        ghObservedMutationCommand(
+          [
+            "label",
+            "create",
+            definition.name,
+            "--color",
+            definition.color,
+            "--description",
+            definition.description,
+          ],
+          2,
+        ),
+      onMutation,
+    });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (!/already exists/i.test(message)) throw error;
@@ -13253,19 +13345,23 @@ function ensureIssueAdvisorySyncLabel(name: string, onMutation?: () => void): vo
       : undefined);
   if (!definition) return;
   try {
-    ghWithRetry(
-      [
-        "label",
-        "create",
-        definition.name,
-        "--color",
-        definition.color,
-        "--description",
-        definition.description,
-      ],
-      2,
-    );
-    onMutation?.();
+    runObservedApplyMutation({
+      identity: `label_create:${definition.name}`,
+      operation: () =>
+        ghObservedMutationCommand(
+          [
+            "label",
+            "create",
+            definition.name,
+            "--color",
+            definition.color,
+            "--description",
+            definition.description,
+          ],
+          2,
+        ),
+      onMutation,
+    });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (!/already exists/i.test(message)) throw error;
@@ -13276,19 +13372,23 @@ function ensureMaturityLabel(name: MaturityLabelName, onMutation?: () => void): 
   const definition = MATURITY_LABELS.find((label) => label.name === name);
   if (!definition) return;
   try {
-    ghWithRetry(
-      [
-        "label",
-        "create",
-        definition.name,
-        "--color",
-        definition.color,
-        "--description",
-        definition.description,
-      ],
-      2,
-    );
-    onMutation?.();
+    runObservedApplyMutation({
+      identity: `label_create:${definition.name}`,
+      operation: () =>
+        ghObservedMutationCommand(
+          [
+            "label",
+            "create",
+            definition.name,
+            "--color",
+            definition.color,
+            "--description",
+            definition.description,
+          ],
+          2,
+        ),
+      onMutation,
+    });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (!/already exists/i.test(message)) throw error;
@@ -13317,8 +13417,7 @@ function syncPriorityLabel(options: {
     if (priorityLabel) ensurePriorityLabel(priorityLabel, options.onMutation);
   }
   for (const label of labelsToRemove) {
-    ghWithRetry(["issue", "edit", String(options.number), "--remove-label", label]);
-    options.onMutation?.();
+    removeIssueLabel(options.number, label, options.onMutation);
   }
   const syncedLabels = options.labels.filter((label) => !labelsToRemove.includes(label));
   const added =
@@ -13354,8 +13453,7 @@ function syncImpactLabels(options: {
   if (!changed) return { labels: nextLabels, changed };
   if (options.dryRun) return { labels: nextLabels, changed };
   for (const label of labelsToRemove) {
-    ghWithRetry(["issue", "edit", String(options.number), "--remove-label", label]);
-    options.onMutation?.();
+    removeIssueLabel(options.number, label, options.onMutation);
   }
   const syncedLabels = options.labels.filter((label) => !labelsToRemove.includes(label));
   let added = false;
@@ -13397,8 +13495,7 @@ function syncMaturityLabels(options: {
   if (!changed) return { labels: nextLabels, changed };
   if (options.dryRun) return { labels: nextLabels, changed };
   for (const label of labelsToRemove) {
-    ghWithRetry(["issue", "edit", String(options.number), "--remove-label", label]);
-    options.onMutation?.();
+    removeIssueLabel(options.number, label, options.onMutation);
   }
   const syncedLabels = options.labels.filter((label) => !labelsToRemove.includes(label));
   let added = false;
@@ -13440,8 +13537,7 @@ function syncMergeRiskLabels(options: {
   if (!changed) return { labels: nextLabels, changed };
   if (options.dryRun) return { labels: nextLabels, changed };
   for (const label of labelsToRemove) {
-    ghWithRetry(["issue", "edit", String(options.number), "--remove-label", label]);
-    options.onMutation?.();
+    removeIssueLabel(options.number, label, options.onMutation);
   }
   const syncedLabels = options.labels.filter((label) => !labelsToRemove.includes(label));
   let added = false;
@@ -13490,8 +13586,7 @@ function syncIssueAdvisoryLabels(options: {
   if (!changed) return { labels: nextLabels, changed };
   if (options.dryRun) return { labels: nextLabels, changed };
   for (const label of labelsToRemove) {
-    ghWithRetry(["issue", "edit", String(options.number), "--remove-label", label]);
-    options.onMutation?.();
+    removeIssueLabel(options.number, label, options.onMutation);
   }
   const syncedLabels = options.labels.filter((label) => !labelsToRemove.includes(label));
   let added = false;
@@ -13538,14 +13633,7 @@ function syncTelegramVisibleProofLabel(options: {
       return { labels: [...options.labels], changed: false };
     }
   } else {
-    ghWithRetry([
-      "issue",
-      "edit",
-      String(options.number),
-      "--remove-label",
-      TELEGRAM_VISIBLE_PROOF_LABEL,
-    ]);
-    options.onMutation?.();
+    removeIssueLabel(options.number, TELEGRAM_VISIBLE_PROOF_LABEL, options.onMutation);
   }
   return { labels: nextLabels, changed };
 }
@@ -13553,19 +13641,23 @@ function syncTelegramVisibleProofLabel(options: {
 function ensurePrRatingLabel(tier: PrRatingTier, onMutation?: () => void): void {
   const definition = ratingLabelForTier(tier);
   try {
-    ghWithRetry(
-      [
-        "label",
-        "create",
-        definition.name,
-        "--color",
-        definition.color,
-        "--description",
-        definition.description,
-      ],
-      2,
-    );
-    onMutation?.();
+    runObservedApplyMutation({
+      identity: `label_create:${definition.name}`,
+      operation: () =>
+        ghObservedMutationCommand(
+          [
+            "label",
+            "create",
+            definition.name,
+            "--color",
+            definition.color,
+            "--description",
+            definition.description,
+          ],
+          2,
+        ),
+      onMutation,
+    });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (!/already exists/i.test(message)) throw error;
@@ -13574,19 +13666,23 @@ function ensurePrRatingLabel(tier: PrRatingTier, onMutation?: () => void): void 
 
 function ensureFeatureShowcaseLabel(onMutation?: () => void): void {
   try {
-    ghWithRetry(
-      [
-        "label",
-        "create",
-        FEATURE_SHOWCASE_LABEL,
-        "--color",
-        FEATURE_SHOWCASE_LABEL_COLOR,
-        "--description",
-        FEATURE_SHOWCASE_LABEL_DESCRIPTION,
-      ],
-      2,
-    );
-    onMutation?.();
+    runObservedApplyMutation({
+      identity: `label_create:${FEATURE_SHOWCASE_LABEL}`,
+      operation: () =>
+        ghObservedMutationCommand(
+          [
+            "label",
+            "create",
+            FEATURE_SHOWCASE_LABEL,
+            "--color",
+            FEATURE_SHOWCASE_LABEL_COLOR,
+            "--description",
+            FEATURE_SHOWCASE_LABEL_DESCRIPTION,
+          ],
+          2,
+        ),
+      onMutation,
+    });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (!/already exists/i.test(message)) throw error;
@@ -13596,19 +13692,23 @@ function ensureFeatureShowcaseLabel(onMutation?: () => void): void {
 function ensurePrStatusLabel(kind: PrStatusLabelKind, onMutation?: () => void): void {
   const definition = prStatusLabelForKind(kind);
   try {
-    ghWithRetry(
-      [
-        "label",
-        "create",
-        definition.name,
-        "--color",
-        definition.color,
-        "--description",
-        definition.description,
-      ],
-      2,
-    );
-    onMutation?.();
+    runObservedApplyMutation({
+      identity: `label_create:${definition.name}`,
+      operation: () =>
+        ghObservedMutationCommand(
+          [
+            "label",
+            "create",
+            definition.name,
+            "--color",
+            definition.color,
+            "--description",
+            definition.description,
+          ],
+          2,
+        ),
+      onMutation,
+    });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (!/already exists/i.test(message)) throw error;
@@ -13668,8 +13768,7 @@ function syncPrRatingLabel(options: {
   if (options.dryRun) return { labels: nextLabels, changed };
   if (labelToAdd) ensurePrRatingLabel(options.rating.overallTier, options.onMutation);
   for (const label of labelsToRemove) {
-    ghWithRetry(["issue", "edit", String(options.number), "--remove-label", label]);
-    options.onMutation?.();
+    removeIssueLabel(options.number, label, options.onMutation);
   }
   const syncedLabels = options.labels.filter((label) => !labelsToRemove.includes(label));
   const added =
@@ -13707,8 +13806,7 @@ function syncPrStatusLabel(options: {
     ensurePrStatusLabel(options.statusKind, options.onMutation);
   }
   for (const label of labelsToRemove) {
-    ghWithRetry(["issue", "edit", String(options.number), "--remove-label", label]);
-    options.onMutation?.();
+    removeIssueLabel(options.number, label, options.onMutation);
   }
   const syncedLabels = options.labels.filter((label) => !labelsToRemove.includes(label));
   const added =
@@ -13725,19 +13823,23 @@ function syncPrStatusLabel(options: {
 
 function ensureTelegramVisibleProofLabel(onMutation?: () => void): void {
   try {
-    ghWithRetry(
-      [
-        "label",
-        "create",
-        TELEGRAM_VISIBLE_PROOF_LABEL,
-        "--color",
-        TELEGRAM_VISIBLE_PROOF_LABEL_COLOR,
-        "--description",
-        TELEGRAM_VISIBLE_PROOF_LABEL_DESCRIPTION,
-      ],
-      2,
-    );
-    onMutation?.();
+    runObservedApplyMutation({
+      identity: `label_create:${TELEGRAM_VISIBLE_PROOF_LABEL}`,
+      operation: () =>
+        ghObservedMutationCommand(
+          [
+            "label",
+            "create",
+            TELEGRAM_VISIBLE_PROOF_LABEL,
+            "--color",
+            TELEGRAM_VISIBLE_PROOF_LABEL_COLOR,
+            "--description",
+            TELEGRAM_VISIBLE_PROOF_LABEL_DESCRIPTION,
+          ],
+          2,
+        ),
+      onMutation,
+    });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (!/already exists/i.test(message)) throw error;
@@ -13767,8 +13869,7 @@ function tryAddOptionalLabel(options: {
     return false;
   }
   try {
-    ghWithRetry(["issue", "edit", String(options.number), "--add-label", options.label]);
-    options.onMutation?.();
+    addIssueLabel(options.number, options.label, options.onMutation);
     return true;
   } catch (error) {
     if (!missingLabelError(error, options.label) && !labelCapacityError(error)) throw error;
@@ -13791,19 +13892,23 @@ export function isGitHubLabelCapacityErrorForTest(message: string): boolean {
 
 function ensureRealBehaviorProofSufficientLabel(onMutation?: () => void): boolean {
   try {
-    ghWithRetry(
-      [
-        "label",
-        "create",
-        PROOF_SUFFICIENT_LABEL,
-        "--color",
-        PROOF_SUFFICIENT_LABEL_COLOR,
-        "--description",
-        PROOF_SUFFICIENT_LABEL_DESCRIPTION,
-      ],
-      2,
-    );
-    onMutation?.();
+    runObservedApplyMutation({
+      identity: `label_create:${PROOF_SUFFICIENT_LABEL}`,
+      operation: () =>
+        ghObservedMutationCommand(
+          [
+            "label",
+            "create",
+            PROOF_SUFFICIENT_LABEL,
+            "--color",
+            PROOF_SUFFICIENT_LABEL_COLOR,
+            "--description",
+            PROOF_SUFFICIENT_LABEL_DESCRIPTION,
+          ],
+          2,
+        ),
+      onMutation,
+    });
     return true;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -13817,19 +13922,23 @@ function ensureRealBehaviorProofMediaLabel(name: string, onMutation?: () => void
   const definition = PROOF_MEDIA_LABELS.find((label) => label.name === name);
   if (!definition) return false;
   try {
-    ghWithRetry(
-      [
-        "label",
-        "create",
-        definition.name,
-        "--color",
-        definition.color,
-        "--description",
-        definition.description,
-      ],
-      2,
-    );
-    onMutation?.();
+    runObservedApplyMutation({
+      identity: `label_create:${definition.name}`,
+      operation: () =>
+        ghObservedMutationCommand(
+          [
+            "label",
+            "create",
+            definition.name,
+            "--color",
+            definition.color,
+            "--description",
+            definition.description,
+          ],
+          2,
+        ),
+      onMutation,
+    });
     return true;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -13868,14 +13977,7 @@ function syncRealBehaviorProofSufficientLabel(options: {
     }
   } else {
     try {
-      ghWithRetry([
-        "issue",
-        "edit",
-        String(options.number),
-        "--remove-label",
-        PROOF_SUFFICIENT_LABEL,
-      ]);
-      options.onMutation?.();
+      removeIssueLabel(options.number, PROOF_SUFFICIENT_LABEL, options.onMutation);
     } catch (error) {
       if (!missingLabelError(error, PROOF_SUFFICIENT_LABEL)) throw error;
       console.warn(
@@ -13910,8 +14012,7 @@ function syncRealBehaviorProofMediaLabels(options: {
   const syncedLabels = [...options.labels];
   for (const label of labelsToRemove) {
     try {
-      ghWithRetry(["issue", "edit", String(options.number), "--remove-label", label]);
-      options.onMutation?.();
+      removeIssueLabel(options.number, label, options.onMutation);
       const index = syncedLabels.indexOf(label);
       if (index >= 0) syncedLabels.splice(index, 1);
     } catch (error) {
@@ -17933,8 +18034,7 @@ function syncStalePullRequestReviewLabels(options: {
   const nextLabels = options.labels.filter((label) => !labelsToRemove.includes(label));
   if (!options.dryRun) {
     for (const label of labelsToRemove) {
-      ghWithRetry(["issue", "edit", String(options.number), "--remove-label", label]);
-      options.onMutation?.();
+      removeIssueLabel(options.number, label, options.onMutation);
     }
   }
   return { labels: nextLabels, changed: true };
@@ -18822,7 +18922,7 @@ function upsertReviewComment(
       payload,
     ];
   }
-  const response = ghWithRetry(args);
+  const response = ghObservedMutationCommand(args);
   const written = reviewCommentFromMutationResponse(response, args);
   if (written) return written;
   const fallback = issueReviewCommentWithBody(number, markedBody);
@@ -18922,14 +19022,18 @@ function ensureCloseAppliedComment(options: {
   const body = renderCloseAppliedComment(options);
   if (options.dryRun) return "dry-run: would post close-applied comment";
   const payload = writeCommentPayload(options.number, body);
-  ghWithRetry([
-    "api",
-    `repos/${targetRepo()}/issues/${options.number}/comments`,
-    "--method",
-    "POST",
-    "--input",
-    payload,
-  ]);
+  runObservedApplyMutation({
+    identity: `close_applied_comment:${options.number}:${sha256(body)}`,
+    operation: () =>
+      ghObservedMutationCommand([
+        "api",
+        `repos/${targetRepo()}/issues/${options.number}/comments`,
+        "--method",
+        "POST",
+        "--input",
+        payload,
+      ]),
+  });
   return "posted close-applied comment";
 }
 
@@ -19065,7 +19169,10 @@ function postReviewStartStatusComment(options: {
     "--input",
     payload,
   ];
-  const created = reviewCommentFromMutationResponse(ghWithRetry(createArgs), createArgs);
+  const created = reviewCommentFromMutationResponse(
+    ghObservedMutationCommand(createArgs),
+    createArgs,
+  );
   const createdCommentId = commentId(created);
   if (createdCommentId === null) {
     throw new Error(
@@ -19104,6 +19211,7 @@ function postReviewStartStatusComment(options: {
 function deleteOwnedDedicatedReviewStartLease(
   itemNumber: number,
   lease: AcquiredReviewStartLease,
+  options: { throwOnError?: boolean } = {},
 ): boolean {
   try {
     const matching = issueReviewCommentState(itemNumber).dedicatedLeaseComments.find(
@@ -19121,6 +19229,7 @@ function deleteOwnedDedicatedReviewStartLease(
     ]);
     return true;
   } catch (error) {
+    if (options.throwOnError) throw error;
     console.error(
       `[review] could not delete owned review lease comment ${lease.commentId}: ${
         error instanceof Error ? error.message : String(error)
@@ -22090,7 +22199,9 @@ function failedReviewRetrySection(options: {
       "- next step: needs human review; retry attempts for this exact revision are exhausted.",
     );
   } else if (options.status === "dispatching") {
-    lines.push("- next step: dispatch attempt checkpointed; wait for the retry cooldown.");
+    lines.push(
+      "- next step: dispatch outcome is uncertain; reconcile the workflow run before another retry.",
+    );
   } else if (options.status === "dispatch_failed") {
     lines.push("- next step: dispatch command failed; retry after the cooldown if still eligible.");
   }
@@ -22387,6 +22498,14 @@ type ReviewRetryActionLedger = {
     reportPath: string;
   };
   batchStartEventId: string | null;
+  dispatchAttempts: Map<
+    string,
+    {
+      eventId: string | null;
+      phaseSeq: number;
+    }
+  >;
+  nextDispatchPhaseSeq: number;
   startedAtMs: number;
   terminal: boolean;
 };
@@ -22425,9 +22544,87 @@ function startFailedReviewRetryLedger(options: {
   return {
     operationIdentity,
     batchStartEventId: batchStart?.event_id ?? null,
+    dispatchAttempts: new Map(),
+    nextDispatchPhaseSeq: 100_000,
     startedAtMs: Date.now(),
     terminal: false,
   };
+}
+
+function reviewRetryDispatchAttemptKey(options: {
+  repository: string;
+  number: number;
+  revision: FailedReviewRetryRevision;
+}): string {
+  return `${options.repository}#${options.number}:${options.revision.kind}:${options.revision.value}`;
+}
+
+function startFailedReviewRetryDispatchAttempt(options: {
+  ledger: ReviewRetryActionLedger;
+  number: number;
+  revision: FailedReviewRetryRevision;
+  reportPath: string;
+  attempts: number;
+  dispatchUrl: string;
+}): void {
+  const repository = targetRepo();
+  const key = reviewRetryDispatchAttemptKey({
+    repository,
+    number: options.number,
+    revision: options.revision,
+  });
+  if (options.ledger.dispatchAttempts.has(key)) return;
+  const phaseSeq = options.ledger.nextDispatchPhaseSeq;
+  options.ledger.nextDispatchPhaseSeq += 10;
+  const kind = reportItemKind(readFileSync(options.reportPath, "utf8"));
+  if (!kind) {
+    throw new Error(
+      `retry dispatch receipt for ${repository}#${options.number} is missing its item kind`,
+    );
+  }
+  const recordPath = repoRelativePath(options.reportPath);
+  const event = recordWorkflowPhaseEvent(ROOT, {
+    phase: ACTION_EVENT_TYPES.reviewRetry,
+    status: ACTION_EVENT_STATUSES.started,
+    reasonCode: ACTION_EVENT_REASON_CODES.selected,
+    retryable: false,
+    mutation: false,
+    identity: {
+      slot: "retry_dispatch_attempt",
+      repository,
+      number: options.number,
+    },
+    operation: "review_retry",
+    operationIdentity: options.ledger.operationIdentity,
+    parentEventId: options.ledger.batchStartEventId,
+    phaseSeq,
+    idempotencyIdentity: reviewRetryBusinessIdempotencyIdentityForTest({
+      repository,
+      number: options.number,
+      revisionKind: options.revision.kind,
+      sourceRevision: options.revision.value,
+      slot: "retry_dispatch",
+    }),
+    component: "retry_failed_reviews",
+    subject: {
+      repository,
+      kind,
+      number: options.number,
+      sourceRevision: options.revision.value,
+      ...(recordPath.startsWith("../") ? {} : { recordPath }),
+    },
+    evidence: [...workflowRunEvidence(), { kind: "retry_dispatch", runUrl: options.dispatchUrl }],
+    attributes: {
+      attempt: options.attempts + 1,
+      retry_count: options.attempts,
+      completion_reason: "dispatch_attempted",
+    },
+    privacy: actionLedgerPrivacy(),
+  });
+  options.ledger.dispatchAttempts.set(key, {
+    eventId: event?.event_id ?? null,
+    phaseSeq,
+  });
 }
 
 function retryFailedReviewsCommand(args: Args): void {
@@ -22580,7 +22777,8 @@ function retryFailedReviewsCommandInner(args: Args): void {
         dispatched += 1;
         continue;
       }
-      const attempts = (eligibility.attempts ?? 0) + 1;
+      const attemptsBeforeDispatch = eligibility.attempts ?? 0;
+      const attempts = attemptsBeforeDispatch + 1;
       let dispatchCheckpointed = false;
       let checkpointDispatchUrl: string | undefined;
       try {
@@ -22597,12 +22795,20 @@ function retryFailedReviewsCommandInner(args: Args): void {
           onBeforeDispatch: (nextDispatchUrl) => {
             dispatchCheckpointed = true;
             checkpointDispatchUrl = nextDispatchUrl;
+            startFailedReviewRetryDispatchAttempt({
+              ledger: retryLedger,
+              number,
+              revision: retryRevision,
+              reportPath: path,
+              attempts: attemptsBeforeDispatch,
+              dispatchUrl: nextDispatchUrl,
+            });
             markdown = checkpointFailedReviewRetry({
               markdown,
               status: "dispatching",
               at: nowIso,
               revision: retryRevision,
-              attempts,
+              attempts: attemptsBeforeDispatch,
               maxAttempts,
               reason: retryReason,
               dispatchUrl: nextDispatchUrl,
@@ -22613,7 +22819,7 @@ function retryFailedReviewsCommandInner(args: Args): void {
               status: "dispatching",
               at: nowIso,
               revision: retryRevision,
-              attempts,
+              attempts: attemptsBeforeDispatch,
               maxAttempts,
               reason: retryReason,
               dispatchUrl: nextDispatchUrl,
@@ -22655,27 +22861,18 @@ function retryFailedReviewsCommandInner(args: Args): void {
         dispatched += 1;
       } catch (error) {
         if (dispatchCheckpointed) {
-          markdown = markFailedReviewRetry({
-            markdown,
-            status: "dispatch_failed",
-            at: nowIso,
-            revision: retryRevision,
-            attempts,
-            maxAttempts,
-            reason: error instanceof Error ? error.message : String(error),
-            ...(checkpointDispatchUrl ? { dispatchUrl: checkpointDispatchUrl } : {}),
-          });
-          writeFileSync(path, markdown, "utf8");
-          writeFailedReviewRetryState(statePath, {
+          results.push({
+            repo: targetRepo(),
             number,
-            status: "dispatch_failed",
-            at: nowIso,
-            revision: retryRevision,
-            attempts,
-            maxAttempts,
+            action: "skipped_retry_dispatch_uncertain",
             reason: error instanceof Error ? error.message : String(error),
+            ...failedReviewRetryResultRevision(retryRevision),
+            attempts: attemptsBeforeDispatch,
+            reportPath: path,
             ...(checkpointDispatchUrl ? { dispatchUrl: checkpointDispatchUrl } : {}),
           });
+          if (error instanceof GitHubRuntimeBudgetError) throw error;
+          continue;
         }
         if (error instanceof GitHubRuntimeBudgetError) throw error;
         results.push({
@@ -22684,7 +22881,7 @@ function retryFailedReviewsCommandInner(args: Args): void {
           action: "skipped_dispatch_failed",
           reason: error instanceof Error ? error.message : String(error),
           ...failedReviewRetryResultRevision(retryRevision),
-          attempts: dispatchCheckpointed ? attempts : eligibility.attempts,
+          attempts: eligibility.attempts,
           reportPath: path,
         });
       }
@@ -22762,6 +22959,14 @@ export function reviewRetryActionDisposition(action: FailedReviewRetryAction): {
       mutation: false,
     };
   }
+  if (action === "skipped_retry_dispatch_uncertain") {
+    return {
+      status: ACTION_EVENT_STATUSES.failed,
+      reasonCode: ACTION_EVENT_REASON_CODES.unavailable,
+      retryable: false,
+      mutation: true,
+    };
+  }
   if (action === "skipped_retry_cooldown") {
     return {
       status: ACTION_EVENT_STATUSES.waiting,
@@ -22809,7 +23014,8 @@ function reviewRetryIdempotencySlot(
   if (
     action === "dispatched_failed_review_retry" ||
     action === "planned_failed_review_retry" ||
-    action === "skipped_dispatch_failed"
+    action === "skipped_dispatch_failed" ||
+    action === "skipped_retry_dispatch_uncertain"
   ) {
     return "retry_dispatch";
   }
@@ -22892,6 +23098,16 @@ function recordFailedReviewRetryEvents(options: {
         `retry mutation receipt for ${subject.repository}#${result.number} is missing its source revision`,
       );
     }
+    const dispatchAttempt =
+      result.number > 0 && revisionKind && sourceRevision
+        ? options.ledger.dispatchAttempts.get(
+            reviewRetryDispatchAttemptKey({
+              repository: subject.repository,
+              number: result.number,
+              revision: { kind: revisionKind, value: sourceRevision },
+            }),
+          )
+        : undefined;
     recordWorkflowPhaseEvent(ROOT, {
       phase: ACTION_EVENT_TYPES.reviewRetry,
       status: disposition.status,
@@ -22906,8 +23122,8 @@ function recordFailedReviewRetryEvents(options: {
       },
       operation: "review_retry",
       operationIdentity,
-      parentEventId: options.ledger.batchStartEventId,
-      phaseSeq: 10 + index,
+      parentEventId: dispatchAttempt?.eventId ?? options.ledger.batchStartEventId,
+      phaseSeq: dispatchAttempt ? dispatchAttempt.phaseSeq + 1 : 10 + index,
       idempotencyIdentity,
       component: "retry_failed_reviews",
       subject,
@@ -22927,7 +23143,9 @@ function recordFailedReviewRetryEvents(options: {
   const yielded = options.results.some((result) => result.action === "skipped_runtime_budget");
   const failed = options.results.some(
     (result) =>
-      result.action === "skipped_dispatch_failed" || result.action === "skipped_live_fetch_failed",
+      result.action === "skipped_dispatch_failed" ||
+      result.action === "skipped_retry_dispatch_uncertain" ||
+      result.action === "skipped_live_fetch_failed",
   );
   const failure =
     options.failure === undefined || options.failure === null
@@ -22997,7 +23215,7 @@ function recordFailedReviewRetryEvents(options: {
 
 type ApplyItemBusinessIdempotencyIdentity = {
   operation: "apply";
-  slot: "apply_item" | "review_comment";
+  slot: "apply_item" | "apply_mutation" | "review_comment";
   repository: string;
   number: number;
   sourceRevision: string;
@@ -23011,7 +23229,9 @@ type ApplyLedgerItem = {
   started: boolean;
   startEventId: string | null;
   mutationObserved: boolean;
+  uncertainMutationObserved: boolean;
   mutationEventId: string | null;
+  mutationAttemptCount: number;
   terminal: boolean;
   businessIdentity: Omit<ApplyItemBusinessIdempotencyIdentity, "slot">;
 };
@@ -23100,7 +23320,9 @@ function startApplyActionLedger(options: {
       started: false,
       startEventId: null,
       mutationObserved: false,
+      uncertainMutationObserved: false,
       mutationEventId: null,
+      mutationAttemptCount: 0,
       terminal: false,
       businessIdentity: {
         operation: "apply",
@@ -23122,7 +23344,7 @@ function startApplyActionLedger(options: {
 }
 
 export function applyItemBusinessIdempotencyIdentityForTest(options: {
-  slot: "apply_item" | "review_comment";
+  slot: "apply_item" | "apply_mutation" | "review_comment";
   repository: string;
   number: number;
   sourceRevision: string;
@@ -23142,7 +23364,7 @@ export function applyItemBusinessIdempotencyIdentityForTest(options: {
 
 function applyItemIdempotencyIdentity(
   state: ApplyLedgerItem,
-  slot: "apply_item" | "review_comment",
+  slot: "apply_item" | "apply_mutation" | "review_comment",
 ): ApplyItemBusinessIdempotencyIdentity {
   return applyItemBusinessIdempotencyIdentityForTest({
     ...state.businessIdentity,
@@ -23211,7 +23433,138 @@ function startApplyActionLedgerItem(
   return state;
 }
 
-function recordApplyMutationBoundary(ledger: ApplyActionLedger, entry: ReportEntry): void {
+type ApplyMutationAttempt = {
+  state: ApplyLedgerItem;
+  eventId: string | null;
+  phaseSeq: number;
+  idempotencyIdentity: ApplyItemBusinessIdempotencyIdentity & {
+    mutationIdentitySha256: string;
+  };
+  mutationIndex: number;
+};
+
+function startApplyMutationAttempt(
+  ledger: ApplyActionLedger,
+  entry: ReportEntry,
+  identity: string,
+): ApplyMutationAttempt | null {
+  const state = startApplyActionLedgerItem(ledger, entry);
+  if (!state) return null;
+  const mutationIndex = state.mutationAttemptCount;
+  state.mutationAttemptCount += 1;
+  const idempotencyIdentity = {
+    ...applyItemIdempotencyIdentity(state, "apply_mutation"),
+    mutationIdentitySha256: sha256(identity),
+  };
+  const phaseSeq = 11 + state.index * 20;
+  const attempt = recordWorkflowPhaseEvent(ROOT, {
+    phase: ACTION_EVENT_TYPES.applyAction,
+    status: ACTION_EVENT_STATUSES.started,
+    reasonCode: ACTION_EVENT_REASON_CODES.selected,
+    retryable: true,
+    mutation: false,
+    identity: {
+      slot: "apply_mutation_attempt",
+      index: state.index,
+      mutationIndex,
+      mutationIdentitySha256: idempotencyIdentity.mutationIdentitySha256,
+      repository: entry.repo,
+      number: entry.number,
+    },
+    operation: "apply",
+    operationIdentity: ledger.operationIdentity,
+    parentEventId: state.mutationEventId ?? state.startEventId,
+    phaseSeq,
+    idempotencyIdentity,
+    component: "apply_decisions",
+    subject: applyLedgerItemSubject(state),
+    evidence: workflowRunEvidence(),
+    attributes: {
+      batch_index: state.index,
+      attempt: mutationIndex + 1,
+      action_count: 1,
+      partial: true,
+      completion_reason: "mutation_attempted",
+    },
+    privacy: actionLedgerPrivacy(),
+  });
+  return {
+    state,
+    eventId: attempt?.event_id ?? null,
+    phaseSeq,
+    idempotencyIdentity,
+    mutationIndex,
+  };
+}
+
+function finishApplyMutationAttempt(options: {
+  ledger: ApplyActionLedger;
+  entry: ReportEntry;
+  attempt: ApplyMutationAttempt;
+  outcome: "accepted" | "rejected" | "unknown";
+}): string | null {
+  const mutation = options.outcome !== "rejected";
+  const event = recordWorkflowPhaseEvent(ROOT, {
+    phase: ACTION_EVENT_TYPES.applyAction,
+    status:
+      options.outcome === "accepted"
+        ? ACTION_EVENT_STATUSES.executed
+        : options.outcome === "rejected"
+          ? ACTION_EVENT_STATUSES.skipped
+          : ACTION_EVENT_STATUSES.failed,
+    reasonCode:
+      options.outcome === "accepted"
+        ? ACTION_EVENT_REASON_CODES.completed
+        : options.outcome === "rejected"
+          ? ACTION_EVENT_REASON_CODES.notApplicable
+          : ACTION_EVENT_REASON_CODES.unavailable,
+    retryable: options.outcome === "unknown",
+    mutation,
+    identity: {
+      slot: "apply_mutation_outcome",
+      index: options.attempt.state.index,
+      mutationIndex: options.attempt.mutationIndex,
+      mutationIdentitySha256: options.attempt.idempotencyIdentity.mutationIdentitySha256,
+      outcome: options.outcome,
+      repository: options.entry.repo,
+      number: options.entry.number,
+    },
+    operation: "apply",
+    operationIdentity: options.ledger.operationIdentity,
+    parentEventId: options.attempt.eventId,
+    phaseSeq: options.attempt.phaseSeq + 1,
+    idempotencyIdentity: options.attempt.idempotencyIdentity,
+    component: "apply_decisions",
+    subject: applyLedgerItemSubject(options.attempt.state),
+    evidence: workflowRunEvidence(),
+    attributes: {
+      batch_index: options.attempt.state.index,
+      attempt: options.attempt.mutationIndex + 1,
+      action_count: mutation ? 1 : 0,
+      partial: options.outcome === "unknown",
+      completion_reason:
+        options.outcome === "accepted"
+          ? "mutation_accepted"
+          : options.outcome === "rejected"
+            ? "mutation_rejected"
+            : "mutation_outcome_unknown",
+    },
+    privacy: actionLedgerPrivacy(),
+  });
+  if (mutation) {
+    options.attempt.state.mutationEventId = event?.event_id ?? options.attempt.eventId;
+  }
+  if (options.outcome === "unknown") {
+    options.attempt.state.uncertainMutationObserved = true;
+  }
+  return event?.event_id ?? null;
+}
+
+function recordApplyMutationBoundary(
+  ledger: ApplyActionLedger,
+  entry: ReportEntry,
+  parentEventId?: string | null,
+): void {
   const state = startApplyActionLedgerItem(ledger, entry);
   if (!state || state.mutationObserved) return;
   const mutation = recordWorkflowPhaseEvent(ROOT, {
@@ -23228,7 +23581,7 @@ function recordApplyMutationBoundary(ledger: ApplyActionLedger, entry: ReportEnt
     },
     operation: "apply",
     operationIdentity: ledger.operationIdentity,
-    parentEventId: state.startEventId,
+    parentEventId: parentEventId ?? state.mutationEventId ?? state.startEventId,
     phaseSeq: 11 + state.index * 20,
     idempotencyIdentity: applyItemIdempotencyIdentity(state, "apply_item"),
     component: "apply_decisions",
@@ -23578,7 +23931,10 @@ function recordApplyActionEvents(options: {
         state,
         entry,
         failure: options.failure,
-        mutationOccurred: options.inFlightItem.mutationOccurred || state.mutationObserved,
+        mutationOccurred:
+          options.inFlightItem.mutationOccurred ||
+          state.mutationObserved ||
+          state.uncertainMutationObserved,
       });
     }
   }
@@ -23596,7 +23952,9 @@ function recordApplyActionEvents(options: {
       results: itemResults,
       entry,
       mutationOccurred:
-        state.mutationObserved || options.mutationByItem.get(`${repository}#${number}`) === true,
+        state.mutationObserved ||
+        state.uncertainMutationObserved ||
+        options.mutationByItem.get(`${repository}#${number}`) === true,
       dryRun: options.dryRun,
     });
   }
@@ -23972,7 +24330,21 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
   const releaseActiveApplyMutationLease = (): void => {
     const active = activeApplyMutationLease;
     activeApplyMutationLease = null;
-    if (active) deleteOwnedDedicatedReviewStartLease(active.itemNumber, active.lease);
+    if (!active) return;
+    try {
+      runObservedApplyMutation({
+        identity: `apply_lease_delete:${active.itemNumber}:${active.lease.commentId}`,
+        operation: () =>
+          deleteOwnedDedicatedReviewStartLease(active.itemNumber, active.lease, {
+            throwOnError: true,
+          }),
+        didMutate: (deleted) => deleted,
+      });
+    } catch (error) {
+      console.error(
+        `[apply] could not delete owned review lease comment ${active.lease.commentId}: ${mutationErrorMessage(error)}`,
+      );
+    }
   };
   runtimeBudget.onFailure = (error: unknown): void => {
     releaseActiveApplyMutationLease();
@@ -23989,13 +24361,17 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
   };
   runtimeBudget.onYield = (reason: string, resumeCurrent = true): void => {
     releaseActiveApplyMutationLease();
+    const interruptedItem = resumeCurrent && activeApplyItem !== null;
     const currentNumber = examinedItemNumbers.at(-1);
     if (resumeCurrent && currentNumber !== undefined) {
       removeCurrentCursorTraceItem(examinedItemNumbers, currentNumber);
     }
     results.push({ number: 0, action: "skipped_runtime_budget", reason });
     logProgress(`stopping apply: ${reason}`);
-    finishApply();
+    finishApply(
+      interruptedItem,
+      interruptedItem ? new GitHubRuntimeBudgetError(reason) : undefined,
+    );
   };
   if (fileEntries.length === 0 && !existsSync(itemsDir)) {
     console.log("No items directory.");
@@ -24026,12 +24402,48 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
     startApplyActionLedgerItem(applyLedger, entry);
     const applyItemResultStart = results.length;
     let applyItemFailed = false;
+    const previousApplyMutationRunner = activeApplyMutationRunner;
     try {
-    const recordMutation = (): void => {
+    const markMutationObserved = (): void => {
       if (dryRun) return;
       activeApplyItem = { repo, number, mutationOccurred: true };
       mutationByItem.set(`${repo}#${number}`, true);
-      recordApplyMutationBoundary(applyLedger, entry);
+    };
+    const recordMutation = (parentEventId?: string | null): void => {
+      markMutationObserved();
+      recordApplyMutationBoundary(applyLedger, entry, parentEventId);
+    };
+    activeApplyMutationRunner = <T>(options: {
+      identity: string;
+      operation: () => T;
+      didMutate?: ((result: T) => boolean) | undefined;
+      knownNoMutation?: ((error: unknown) => boolean) | undefined;
+    }): T => {
+      if (dryRun) return options.operation();
+      const attempt = startApplyMutationAttempt(applyLedger, entry, options.identity);
+      if (!attempt) return options.operation();
+      try {
+        const result = options.operation();
+        const mutated = options.didMutate?.(result) ?? true;
+        const outcomeEventId = finishApplyMutationAttempt({
+          ledger: applyLedger,
+          entry,
+          attempt,
+          outcome: mutated ? "accepted" : "rejected",
+        });
+        if (mutated) recordMutation(outcomeEventId);
+        return result;
+      } catch (error) {
+        const rejected = options.knownNoMutation?.(error) === true;
+        finishApplyMutationAttempt({
+          ledger: applyLedger,
+          entry,
+          attempt,
+          outcome: rejected ? "rejected" : "unknown",
+        });
+        if (!rejected) markMutationObserved();
+        throw error;
+      }
     };
     examinedItemNumbers.push(number);
     const decision = frontMatterValue(markdown, "decision");
@@ -24387,15 +24799,19 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
           headSha: leaseState.headSha,
         };
       } else {
-        const posted = postReviewStartStatusComment({
-          item,
-          headSha: leaseState.headSha,
-          reviewTimeoutMs: Math.max(5 * 60 * 1000, closeDelayMs + 60 * 1000),
-          position: 1,
-          total: 1,
-          shardIndex: 1,
-          shardCount: 1,
-          purpose: "apply",
+        const posted = runObservedApplyMutation({
+          identity: `apply_lease_acquire:${number}:${leaseState.headSha}`,
+          operation: () =>
+            postReviewStartStatusComment({
+              item,
+              headSha: leaseState.headSha,
+              reviewTimeoutMs: Math.max(5 * 60 * 1000, closeDelayMs + 60 * 1000),
+              position: 1,
+              total: 1,
+              shardIndex: 1,
+              shardCount: 1,
+              purpose: "apply",
+            }),
         });
         if (posted.status !== "posted") {
           return `${item.kind === "pull_request" ? "same-head" : "same-revision"} ClawSweeper lease was acquired concurrently`;
@@ -24623,7 +25039,6 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
     };
     const recordRuntimeBudgetYield = (reason: string): void => {
       if (clawSweeperLabelsChanged && !dryRun) {
-        recordMutation();
         markdown = replaceFrontMatterValue(
           markdown,
           "labels_synced_at",
@@ -25334,7 +25749,6 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
     }
     markdown = replaceFrontMatterValue(markdown, "labels", JSON.stringify(item.labels));
     if (clawSweeperLabelsChanged && !dryRun) {
-      recordMutation();
       rememberSelfMutationUpdatedAt();
     }
     const renderOptions: ReviewCommentRenderOptions = {
@@ -25689,7 +26103,6 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
           maturitySyncResult.changed ||
           mergeRiskLabelsChanged
         ) {
-          recordMutation();
           rememberSelfMutationUpdatedAt();
         }
       } catch (error) {
@@ -25742,7 +26155,6 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
         clawSweeperLabelsChanged ||= syncResult.changed;
         markdown = replaceFrontMatterValue(markdown, "labels", JSON.stringify(item.labels));
         if (syncResult.changed) {
-          recordMutation();
           rememberSelfMutationUpdatedAt();
         }
       } catch (error) {
@@ -25902,7 +26314,6 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
       }
     }
     if (clawSweeperLabelsChanged && !dryRun) {
-      recordMutation();
       markdown = replaceFrontMatterValue(markdown, "labels_synced_at", new Date().toISOString());
     }
     const labelSyncReason = issueAdvisoryLabelsChanged
@@ -26059,12 +26470,14 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
             continue;
           }
           try {
-            syncedComment = upsertReviewComment(
-              number,
-              markedReviewComment,
-              existingReviewComment,
-            );
-            recordMutation();
+            syncedComment = runObservedApplyMutation({
+              identity: `review_comment_upsert:${number}:${reviewCommentBodyDigest(markedReviewComment)}`,
+              operation: () =>
+                upsertReviewComment(number, markedReviewComment, existingReviewComment),
+              knownNoMutation: (error) =>
+                isGitHubRequiresAuthenticationError(error) ||
+                isLockedConversationCommentError(error),
+            });
             const syncedCommentUpdatedAt = commentUpdatedAt(syncedComment);
             if (syncedCommentUpdatedAt) {
               allowedSelfMutationUpdatedAts.add(syncedCommentUpdatedAt);
@@ -26331,15 +26744,17 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
             dryRun,
           })
         : null;
-    if (closeAppliedCommentReason === "posted close-applied comment") recordMutation();
     const preCloseMutationLeaseBlockReason = currentApplyMutationLeaseBlockReason();
     if (preCloseMutationLeaseBlockReason) {
       if (recordReviewLeaseSkip(preCloseMutationLeaseBlockReason, false)) break;
       continue;
     }
     ensureRuntimeDelayFits(closeDelayMs, "before close");
-    closeItem({ number, kind: item.kind, reason: closeReason });
-    recordMutation();
+    const appliedCloseReason = closeReason;
+    runObservedApplyMutation({
+      identity: `item_close:${number}:${item.kind}:${appliedCloseReason}`,
+      operation: () => closeItem({ number, kind: item.kind, reason: appliedCloseReason }),
+    });
     let postCloseRuntimeYieldReason: string | null = null;
     try {
       ensureRuntimeDelayFits(closeDelayMs, "before close delay");
@@ -26375,6 +26790,8 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
       applyItemFailed = true;
       throw error;
     } finally {
+      releaseActiveApplyMutationLease();
+      activeApplyMutationRunner = previousApplyMutationRunner;
       if (!applyItemFailed) {
         const state = applyLedger.items.get(actionLedgerItemKey(entry));
         if (!applyLedger.terminal && state?.started && !state.terminal) {
@@ -29119,6 +29536,71 @@ function publishActionEventsCommand(args: Args): void {
   console.log(JSON.stringify(result, null, 2));
 }
 
+const ACTION_EVENT_PUBLISH_PATH_PATTERN =
+  /^ledger\/v1\/(?:events\/\d{4}\/\d{2}\/\d{2}\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\.jsonl|import-bindings\/(?:producer-runs|events|shard-sets|completed-shard-sets)\/[a-f0-9]{64}\.json)$/;
+const ACTION_EVENT_PUBLISH_PATH_FILE_MAX_BYTES = ACTION_EVENT_SHARD_IMPORT_MAX_PUBLISH_PATHS * 512;
+
+export function actionEventPublishPathsForTest(content: string): string[] {
+  if (Buffer.byteLength(content, "utf8") > ACTION_EVENT_PUBLISH_PATH_FILE_MAX_BYTES) {
+    throw new Error(
+      `action event publish path manifest exceeds ${ACTION_EVENT_PUBLISH_PATH_FILE_MAX_BYTES} bytes`,
+    );
+  }
+  const paths = content.split("\n").filter(Boolean);
+  if (paths.length === 0) throw new Error("action event publish path manifest is empty");
+  if (paths.length > ACTION_EVENT_SHARD_IMPORT_MAX_PUBLISH_PATHS) {
+    throw new Error(
+      `action event publish path manifest exceeds ${ACTION_EVENT_SHARD_IMPORT_MAX_PUBLISH_PATHS} paths`,
+    );
+  }
+  let previous = "";
+  for (const path of paths) {
+    if (!ACTION_EVENT_PUBLISH_PATH_PATTERN.test(path)) {
+      throw new Error(`invalid action event publish path: ${path}`);
+    }
+    if (previous && path <= previous) {
+      throw new Error("action event publish paths must be sorted and unique");
+    }
+    previous = path;
+  }
+  return paths;
+}
+
+function publishActionEventPathsCommand(args: Args): void {
+  const pathsFile = resolve(stringArg(args.paths_file, ""));
+  const message = stringArg(args.message, "");
+  if (!pathsFile || pathsFile === ROOT) {
+    throw new UserFacingCommandError("--paths-file is required");
+  }
+  if (!message) throw new UserFacingCommandError("--message is required");
+  const stat = statSync(pathsFile);
+  if (!stat.isFile())
+    throw new Error(`action event publish path manifest is not a file: ${pathsFile}`);
+  if (stat.size > ACTION_EVENT_PUBLISH_PATH_FILE_MAX_BYTES) {
+    throw new Error(
+      `action event publish path manifest exceeds ${ACTION_EVENT_PUBLISH_PATH_FILE_MAX_BYTES} bytes`,
+    );
+  }
+  const paths = actionEventPublishPathsForTest(readFileSync(pathsFile, "utf8"));
+  for (const path of paths) {
+    const source = resolve(ROOT, path);
+    const rootRelativeSource = relative(ROOT, source);
+    if (
+      rootRelativeSource.startsWith("..") ||
+      resolve(ROOT, rootRelativeSource) !== source ||
+      !statSync(source).isFile()
+    ) {
+      throw new Error(`action event publish path is not a regular file: ${path}`);
+    }
+  }
+  const result = publishMainCommit({
+    message,
+    paths,
+    rebaseStrategy: "normal",
+  });
+  console.log(JSON.stringify({ result, path_count: paths.length }));
+}
+
 export async function main(argv = process.argv.slice(2)): Promise<void> {
   const args = parseArgs(argv);
   const command = args._[0] ?? "review";
@@ -29136,6 +29618,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
     else if (command === "apply-artifacts") applyArtifactsCommand(args);
     else if (command === "apply-decisions") applyDecisionsCommand(args);
     else if (command === "publish-action-events") publishActionEventsCommand(args);
+    else if (command === "publish-action-event-paths") publishActionEventPathsCommand(args);
     else if (command === "proof-nudges") proofNudgesCommand(args);
     else if (command === "bot-proof") botProofCommand(args);
     else if (command === "audit") auditCommand(args);

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -199,6 +199,7 @@ import {
   importActionEventShards,
   interruptOpenWorkflowActionEvents,
   recordWorkflowPhaseEvent,
+  workflowActionProducer,
 } from "./action-ledger-runtime.js";
 import { publishMainCommit } from "./repair/git-publish.js";
 
@@ -463,7 +464,21 @@ type AcquiredReviewStartLease = {
 
 type ReviewStartStatusCommentResult =
   | { status: "posted"; lease: AcquiredReviewStartLease; didMutate: true }
-  | { status: "held"; lease: null; retryAt: string; didMutate: false };
+  | { status: "held"; lease: null; retryAt: string; didMutate: boolean };
+
+function heldReviewStartStatusCommentResult(
+  retryAt: string,
+  didMutate: boolean,
+): ReviewStartStatusCommentResult {
+  return { status: "held", lease: null, retryAt, didMutate };
+}
+
+export function heldReviewStartStatusCommentResultForTest(
+  retryAt: string,
+  didMutate: boolean,
+): ReviewStartStatusCommentResult {
+  return heldReviewStartStatusCommentResult(retryAt, didMutate);
+}
 
 interface ExistingReview {
   path: string;
@@ -2479,6 +2494,35 @@ function sleepMs(milliseconds: number): void {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
 }
 
+function untrustedCodexEnv(
+  options: {
+    ghToken?: string | undefined;
+    preserveCodexAuth?: boolean | undefined;
+  } = {},
+): NodeJS.ProcessEnv {
+  const env = codexEnv(options);
+  for (const key of Object.keys(env)) {
+    if (key.startsWith("CLAWSWEEPER_ACTION_LEDGER_")) delete env[key];
+  }
+  return env;
+}
+
+export function untrustedCodexEnvForTest(
+  env: NodeJS.ProcessEnv,
+  options: {
+    ghToken?: string | undefined;
+    preserveCodexAuth?: boolean | undefined;
+  } = {},
+): NodeJS.ProcessEnv {
+  const previousEnv = process.env;
+  try {
+    process.env = { ...env };
+    return untrustedCodexEnv(options);
+  } finally {
+    process.env = previousEnv;
+  }
+}
+
 let lastThrottleHeartbeatAt = 0;
 let throttleHeartbeatContext: (() => string) | null = null;
 
@@ -2540,11 +2584,16 @@ function maybePublishThrottleHeartbeat(options: {
   }
 }
 
-function ghWithRetry(args: string[], attempts = 12): string {
+type GitHubRetryOptions = {
+  request?: ((args: string[], attempt: number) => string) | undefined;
+  sleepBeforeRetry?: ((waitMs: number) => void) | undefined;
+};
+
+function ghWithRetry(args: string[], attempts = 12, options: GitHubRetryOptions = {}): string {
   let lastError: unknown;
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     try {
-      return gh(args);
+      return options.request?.(args, attempt) ?? gh(args);
     } catch (error) {
       if (error instanceof GitHubRuntimeBudgetError) throw error;
       lastError = error;
@@ -2561,7 +2610,8 @@ function ghWithRetry(args: string[], attempts = 12): string {
       if (retryKind === "throttle") {
         maybePublishThrottleHeartbeat({ args, attempt, attempts, waitMs });
       }
-      sleepBeforeGitHubRetry(waitMs);
+      if (options.sleepBeforeRetry) options.sleepBeforeRetry(waitMs);
+      else sleepBeforeGitHubRetry(waitMs);
     }
   }
   throw lastError;
@@ -2600,15 +2650,136 @@ function runObservedApplyMutation<T>(options: {
   return result;
 }
 
-function ghObservedMutationCommand(args: string[], attempts = 12): string {
-  return activeApplyMutationRunner ? gh(args) : ghWithRetry(args, attempts);
+function ghObservedMutationCommand(options: {
+  identity: string;
+  args: string[];
+  attempts?: number | undefined;
+  onMutation?: (() => void) | undefined;
+  didMutate?: ((result: string) => boolean) | undefined;
+  knownNoMutation?: ((error: unknown) => boolean) | undefined;
+  request?: ((args: string[], attempt: number) => string) | undefined;
+  sleepBeforeRetry?: ((waitMs: number) => void) | undefined;
+}): string {
+  return ghWithRetry(options.args, options.attempts ?? 12, {
+    request: (args, attempt) =>
+      runObservedApplyMutation({
+        identity: `${options.identity}:request_attempt:${attempt + 1}`,
+        operation: () => (options.request ? options.request(args, attempt) : gh(args)),
+        ...(options.onMutation ? { onMutation: options.onMutation } : {}),
+        ...(options.didMutate ? { didMutate: options.didMutate } : {}),
+        ...(options.knownNoMutation ? { knownNoMutation: options.knownNoMutation } : {}),
+      }),
+    ...(options.sleepBeforeRetry ? { sleepBeforeRetry: options.sleepBeforeRetry } : {}),
+  });
 }
 
-function ghRawOnceWithCheckpoint(args: string[], onBeforeRun: () => void): string {
+export function observedGitHubMutationAttemptsForTest(
+  outcomes: readonly ("transient" | "accepted" | "already_exists")[],
+): Array<{ identity: string; outcome: "accepted" | "rejected" | "unknown" }> {
+  const receipts: Array<{
+    identity: string;
+    outcome: "accepted" | "rejected" | "unknown";
+  }> = [];
+  const previousRunner = activeApplyMutationRunner;
+  activeApplyMutationRunner = <T>(options: {
+    identity: string;
+    operation: () => T;
+    didMutate?: ((result: T) => boolean) | undefined;
+    knownNoMutation?: ((error: unknown) => boolean) | undefined;
+  }): T => {
+    try {
+      const result = options.operation();
+      receipts.push({
+        identity: options.identity,
+        outcome: options.didMutate?.(result) === false ? "rejected" : "accepted",
+      });
+      return result;
+    } catch (error) {
+      receipts.push({
+        identity: options.identity,
+        outcome: options.knownNoMutation?.(error) === true ? "rejected" : "unknown",
+      });
+      throw error;
+    }
+  };
+  try {
+    ghObservedMutationCommand({
+      identity: "test_mutation",
+      args: ["api", "test"],
+      attempts: outcomes.length,
+      knownNoMutation: labelAlreadyExistsError,
+      request: (_args, attempt) => {
+        const outcome = outcomes[attempt];
+        if (outcome === "accepted") return "ok";
+        if (outcome === "already_exists") throw new Error("label already exists");
+        throw new Error("HTTP 502: transient upstream failure");
+      },
+      sleepBeforeRetry: () => {},
+    });
+  } catch {
+    // The receipts are the assertion surface for rejected terminal attempts.
+  } finally {
+    activeApplyMutationRunner = previousRunner;
+  }
+  return receipts;
+}
+
+export type GitHubDispatchOutcome =
+  | "definitely_not_dispatched"
+  | "ambiguous_transport"
+  | "accepted";
+
+class GitHubDispatchError extends Error {
+  readonly outcome: Exclude<GitHubDispatchOutcome, "accepted">;
+  readonly cause: unknown;
+
+  constructor(outcome: Exclude<GitHubDispatchOutcome, "accepted">, cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause));
+    this.name = "GitHubDispatchError";
+    this.outcome = outcome;
+    this.cause = cause;
+  }
+}
+
+function classifyGitHubDispatchResult(options: {
+  status: number | null;
+  signal?: NodeJS.Signals | null | undefined;
+  errorCode?: string | undefined;
+  stderr?: string | undefined;
+}): GitHubDispatchOutcome {
+  if (options.signal) return "ambiguous_transport";
+  if (options.errorCode) {
+    return options.errorCode === "ETIMEDOUT" || options.errorCode === "ENOBUFS"
+      ? "ambiguous_transport"
+      : "definitely_not_dispatched";
+  }
+  if (options.status === 0) return "accepted";
+  if (options.status === null) return "ambiguous_transport";
+  const error = new Error(options.stderr?.trim() || `GitHub dispatch exited ${options.status}`);
+  return ghRetryKind(error) === "none" ? "definitely_not_dispatched" : "ambiguous_transport";
+}
+
+export function classifyGitHubDispatchResultForTest(options: {
+  status: number | null;
+  signal?: NodeJS.Signals | null | undefined;
+  errorCode?: string | undefined;
+  stderr?: string | undefined;
+}): GitHubDispatchOutcome {
+  return classifyGitHubDispatchResult(options);
+}
+
+function ghRawOnceWithCheckpoint(
+  args: string[],
+  onBeforeRun: () => void,
+): { outcome: "accepted"; output: string } {
   const env = { ...process.env };
   const command = resolveCommand("gh", args, env);
   const timeoutMs = githubCommandTimeoutMs();
-  onBeforeRun();
+  try {
+    onBeforeRun();
+  } catch (error) {
+    throw new GitHubDispatchError("definitely_not_dispatched", error);
+  }
   const result = spawnSync(command.command, command.args, {
     cwd: ROOT,
     encoding: "utf8",
@@ -2618,16 +2789,37 @@ function ghRawOnceWithCheckpoint(args: string[], onBeforeRun: () => void): strin
     timeout: timeoutMs,
   });
   if (result.error) {
+    const errorCode = (result.error as NodeJS.ErrnoException).code;
     if (timeoutMs !== undefined && (result.error as NodeJS.ErrnoException).code === "ETIMEDOUT") {
-      throw githubRuntimeBudgetError("during GitHub dispatch");
+      throw new GitHubDispatchError(
+        "ambiguous_transport",
+        githubRuntimeBudgetError("during GitHub dispatch"),
+      );
     }
-    throw result.error;
+    throw new GitHubDispatchError(
+      classifyGitHubDispatchResult({
+        status: result.status,
+        signal: result.signal,
+        ...(errorCode ? { errorCode } : {}),
+      }) as Exclude<GitHubDispatchOutcome, "accepted">,
+      result.error,
+    );
   }
   if (result.status !== 0) {
     const stderr = typeof result.stderr === "string" ? result.stderr.trim() : "";
-    throw new Error([`Command failed: gh ${args.join(" ")}`, stderr].filter(Boolean).join("\n"));
+    const error = new Error(
+      [`Command failed: gh ${args.join(" ")}`, stderr].filter(Boolean).join("\n"),
+    );
+    throw new GitHubDispatchError(
+      classifyGitHubDispatchResult({
+        status: result.status,
+        signal: result.signal,
+        stderr,
+      }) as Exclude<GitHubDispatchOutcome, "accepted">,
+      error,
+    );
   }
-  return (result.stdout ?? "").trim();
+  return { outcome: "accepted", output: (result.stdout ?? "").trim() };
 }
 
 function ghJson<T>(args: string[]): T {
@@ -9207,7 +9399,7 @@ function runCodex(options: {
         ],
         cwd: options.openclawDir,
         env: {
-          ...codexEnv({
+          ...untrustedCodexEnv({
             ghToken: process.env.CLAWSWEEPER_PROOF_INSPECTION_TOKEN,
             preserveCodexAuth: options.preserveCodexAuth,
           }),
@@ -9551,7 +9743,7 @@ function runCodexAssist(options: {
       "-",
     ],
     cwd: ROOT,
-    env: { ...codexEnv(), GH_CONFIG_DIR: emptyGitHubConfigDir },
+    env: { ...untrustedCodexEnv(), GH_CONFIG_DIR: emptyGitHubConfigDir },
     input: prompt,
     timeoutMs: options.timeoutMs,
   });
@@ -12969,17 +13161,17 @@ export function mergeRiskLabelsForTest(
 }
 
 function removeIssueLabel(number: number, label: string, onMutation?: () => void): void {
-  runObservedApplyMutation({
+  ghObservedMutationCommand({
     identity: `issue_label_remove:${number}:${label}`,
-    operation: () => ghWithRetry(["issue", "edit", String(number), "--remove-label", label]),
+    args: ["issue", "edit", String(number), "--remove-label", label],
     onMutation,
   });
 }
 
 function addIssueLabel(number: number, label: string, onMutation?: () => void): void {
-  runObservedApplyMutation({
+  ghObservedMutationCommand({
     identity: `issue_label_add:${number}:${label}`,
-    operation: () => ghWithRetry(["issue", "edit", String(number), "--add-label", label]),
+    args: ["issue", "edit", String(number), "--add-label", label],
     onMutation,
     knownNoMutation: (error) => missingLabelError(error, label) || labelCapacityError(error),
   });
@@ -12996,21 +13188,18 @@ export function isGitHubLabelAlreadyExistsErrorForTest(message: string): boolean
 
 function ensurePriorityLabel(label: PriorityLabelSpec, onMutation?: () => void): void {
   try {
-    runObservedApplyMutation({
+    ghObservedMutationCommand({
       identity: `label_create:${label.name}`,
-      operation: () =>
-        ghObservedMutationCommand(
-          [
-            "label",
-            "create",
-            label.name,
-            "--color",
-            label.color,
-            "--description",
-            label.description,
-          ],
-          2,
-        ),
+      args: [
+        "label",
+        "create",
+        label.name,
+        "--color",
+        label.color,
+        "--description",
+        label.description,
+      ],
+      attempts: 2,
       onMutation,
       knownNoMutation: labelAlreadyExistsError,
     });
@@ -13023,21 +13212,18 @@ function ensureImpactLabel(name: ImpactLabelName, onMutation?: () => void): void
   const definition = IMPACT_LABELS.find((label) => label.name === name);
   if (!definition) return;
   try {
-    runObservedApplyMutation({
+    ghObservedMutationCommand({
       identity: `label_create:${definition.name}`,
-      operation: () =>
-        ghObservedMutationCommand(
-          [
-            "label",
-            "create",
-            definition.name,
-            "--color",
-            definition.color,
-            "--description",
-            definition.description,
-          ],
-          2,
-        ),
+      args: [
+        "label",
+        "create",
+        definition.name,
+        "--color",
+        definition.color,
+        "--description",
+        definition.description,
+      ],
+      attempts: 2,
       onMutation,
       knownNoMutation: labelAlreadyExistsError,
     });
@@ -13050,21 +13236,18 @@ function ensureMergeRiskLabel(name: MergeRiskLabelName, onMutation?: () => void)
   const definition = MERGE_RISK_LABELS.find((label) => label.name === name);
   if (!definition) return;
   try {
-    runObservedApplyMutation({
+    ghObservedMutationCommand({
       identity: `label_create:${definition.name}`,
-      operation: () =>
-        ghObservedMutationCommand(
-          [
-            "label",
-            "create",
-            definition.name,
-            "--color",
-            definition.color,
-            "--description",
-            definition.description,
-          ],
-          2,
-        ),
+      args: [
+        "label",
+        "create",
+        definition.name,
+        "--color",
+        definition.color,
+        "--description",
+        definition.description,
+      ],
+      attempts: 2,
       onMutation,
       knownNoMutation: labelAlreadyExistsError,
     });
@@ -13354,21 +13537,18 @@ function ensureIssueAdvisorySyncLabel(name: string, onMutation?: () => void): vo
       : undefined);
   if (!definition) return;
   try {
-    runObservedApplyMutation({
+    ghObservedMutationCommand({
       identity: `label_create:${definition.name}`,
-      operation: () =>
-        ghObservedMutationCommand(
-          [
-            "label",
-            "create",
-            definition.name,
-            "--color",
-            definition.color,
-            "--description",
-            definition.description,
-          ],
-          2,
-        ),
+      args: [
+        "label",
+        "create",
+        definition.name,
+        "--color",
+        definition.color,
+        "--description",
+        definition.description,
+      ],
+      attempts: 2,
       onMutation,
       knownNoMutation: labelAlreadyExistsError,
     });
@@ -13381,21 +13561,18 @@ function ensureMaturityLabel(name: MaturityLabelName, onMutation?: () => void): 
   const definition = MATURITY_LABELS.find((label) => label.name === name);
   if (!definition) return;
   try {
-    runObservedApplyMutation({
+    ghObservedMutationCommand({
       identity: `label_create:${definition.name}`,
-      operation: () =>
-        ghObservedMutationCommand(
-          [
-            "label",
-            "create",
-            definition.name,
-            "--color",
-            definition.color,
-            "--description",
-            definition.description,
-          ],
-          2,
-        ),
+      args: [
+        "label",
+        "create",
+        definition.name,
+        "--color",
+        definition.color,
+        "--description",
+        definition.description,
+      ],
+      attempts: 2,
       onMutation,
       knownNoMutation: labelAlreadyExistsError,
     });
@@ -13650,21 +13827,18 @@ function syncTelegramVisibleProofLabel(options: {
 function ensurePrRatingLabel(tier: PrRatingTier, onMutation?: () => void): void {
   const definition = ratingLabelForTier(tier);
   try {
-    runObservedApplyMutation({
+    ghObservedMutationCommand({
       identity: `label_create:${definition.name}`,
-      operation: () =>
-        ghObservedMutationCommand(
-          [
-            "label",
-            "create",
-            definition.name,
-            "--color",
-            definition.color,
-            "--description",
-            definition.description,
-          ],
-          2,
-        ),
+      args: [
+        "label",
+        "create",
+        definition.name,
+        "--color",
+        definition.color,
+        "--description",
+        definition.description,
+      ],
+      attempts: 2,
       onMutation,
       knownNoMutation: labelAlreadyExistsError,
     });
@@ -13675,21 +13849,18 @@ function ensurePrRatingLabel(tier: PrRatingTier, onMutation?: () => void): void 
 
 function ensureFeatureShowcaseLabel(onMutation?: () => void): void {
   try {
-    runObservedApplyMutation({
+    ghObservedMutationCommand({
       identity: `label_create:${FEATURE_SHOWCASE_LABEL}`,
-      operation: () =>
-        ghObservedMutationCommand(
-          [
-            "label",
-            "create",
-            FEATURE_SHOWCASE_LABEL,
-            "--color",
-            FEATURE_SHOWCASE_LABEL_COLOR,
-            "--description",
-            FEATURE_SHOWCASE_LABEL_DESCRIPTION,
-          ],
-          2,
-        ),
+      args: [
+        "label",
+        "create",
+        FEATURE_SHOWCASE_LABEL,
+        "--color",
+        FEATURE_SHOWCASE_LABEL_COLOR,
+        "--description",
+        FEATURE_SHOWCASE_LABEL_DESCRIPTION,
+      ],
+      attempts: 2,
       onMutation,
       knownNoMutation: labelAlreadyExistsError,
     });
@@ -13701,21 +13872,18 @@ function ensureFeatureShowcaseLabel(onMutation?: () => void): void {
 function ensurePrStatusLabel(kind: PrStatusLabelKind, onMutation?: () => void): void {
   const definition = prStatusLabelForKind(kind);
   try {
-    runObservedApplyMutation({
+    ghObservedMutationCommand({
       identity: `label_create:${definition.name}`,
-      operation: () =>
-        ghObservedMutationCommand(
-          [
-            "label",
-            "create",
-            definition.name,
-            "--color",
-            definition.color,
-            "--description",
-            definition.description,
-          ],
-          2,
-        ),
+      args: [
+        "label",
+        "create",
+        definition.name,
+        "--color",
+        definition.color,
+        "--description",
+        definition.description,
+      ],
+      attempts: 2,
       onMutation,
       knownNoMutation: labelAlreadyExistsError,
     });
@@ -13832,21 +14000,18 @@ function syncPrStatusLabel(options: {
 
 function ensureTelegramVisibleProofLabel(onMutation?: () => void): void {
   try {
-    runObservedApplyMutation({
+    ghObservedMutationCommand({
       identity: `label_create:${TELEGRAM_VISIBLE_PROOF_LABEL}`,
-      operation: () =>
-        ghObservedMutationCommand(
-          [
-            "label",
-            "create",
-            TELEGRAM_VISIBLE_PROOF_LABEL,
-            "--color",
-            TELEGRAM_VISIBLE_PROOF_LABEL_COLOR,
-            "--description",
-            TELEGRAM_VISIBLE_PROOF_LABEL_DESCRIPTION,
-          ],
-          2,
-        ),
+      args: [
+        "label",
+        "create",
+        TELEGRAM_VISIBLE_PROOF_LABEL,
+        "--color",
+        TELEGRAM_VISIBLE_PROOF_LABEL_COLOR,
+        "--description",
+        TELEGRAM_VISIBLE_PROOF_LABEL_DESCRIPTION,
+      ],
+      attempts: 2,
       onMutation,
       knownNoMutation: labelAlreadyExistsError,
     });
@@ -13901,21 +14066,18 @@ export function isGitHubLabelCapacityErrorForTest(message: string): boolean {
 
 function ensureRealBehaviorProofSufficientLabel(onMutation?: () => void): boolean {
   try {
-    runObservedApplyMutation({
+    ghObservedMutationCommand({
       identity: `label_create:${PROOF_SUFFICIENT_LABEL}`,
-      operation: () =>
-        ghObservedMutationCommand(
-          [
-            "label",
-            "create",
-            PROOF_SUFFICIENT_LABEL,
-            "--color",
-            PROOF_SUFFICIENT_LABEL_COLOR,
-            "--description",
-            PROOF_SUFFICIENT_LABEL_DESCRIPTION,
-          ],
-          2,
-        ),
+      args: [
+        "label",
+        "create",
+        PROOF_SUFFICIENT_LABEL,
+        "--color",
+        PROOF_SUFFICIENT_LABEL_COLOR,
+        "--description",
+        PROOF_SUFFICIENT_LABEL_DESCRIPTION,
+      ],
+      attempts: 2,
       onMutation,
       knownNoMutation: labelAlreadyExistsError,
     });
@@ -13932,21 +14094,18 @@ function ensureRealBehaviorProofMediaLabel(name: string, onMutation?: () => void
   const definition = PROOF_MEDIA_LABELS.find((label) => label.name === name);
   if (!definition) return false;
   try {
-    runObservedApplyMutation({
+    ghObservedMutationCommand({
       identity: `label_create:${definition.name}`,
-      operation: () =>
-        ghObservedMutationCommand(
-          [
-            "label",
-            "create",
-            definition.name,
-            "--color",
-            definition.color,
-            "--description",
-            definition.description,
-          ],
-          2,
-        ),
+      args: [
+        "label",
+        "create",
+        definition.name,
+        "--color",
+        definition.color,
+        "--description",
+        definition.description,
+      ],
+      attempts: 2,
       onMutation,
       knownNoMutation: labelAlreadyExistsError,
     });
@@ -18909,6 +19068,7 @@ function upsertReviewComment(
   number: number,
   body: string,
   existing = issueReviewComment(number, [body]),
+  mutationIdentity = `review_comment_upsert:${number}:${reviewCommentBodyDigest(body)}`,
 ): Record<string, unknown> | undefined {
   const markedBody = markedReviewCommentBody(number, body);
   const id = commentId(existing);
@@ -18933,7 +19093,12 @@ function upsertReviewComment(
       payload,
     ];
   }
-  const response = ghObservedMutationCommand(args);
+  const response = ghObservedMutationCommand({
+    identity: mutationIdentity,
+    args,
+    knownNoMutation: (error) =>
+      isGitHubRequiresAuthenticationError(error) || isLockedConversationCommentError(error),
+  });
   const written = reviewCommentFromMutationResponse(response, args);
   if (written) return written;
   const fallback = issueReviewCommentWithBody(number, markedBody);
@@ -19033,17 +19198,16 @@ function ensureCloseAppliedComment(options: {
   const body = renderCloseAppliedComment(options);
   if (options.dryRun) return "dry-run: would post close-applied comment";
   const payload = writeCommentPayload(options.number, body);
-  runObservedApplyMutation({
+  ghObservedMutationCommand({
     identity: `close_applied_comment:${options.number}:${sha256(body)}`,
-    operation: () =>
-      ghObservedMutationCommand([
-        "api",
-        `repos/${targetRepo()}/issues/${options.number}/comments`,
-        "--method",
-        "POST",
-        "--input",
-        payload,
-      ]),
+    args: [
+      "api",
+      `repos/${targetRepo()}/issues/${options.number}/comments`,
+      "--method",
+      "POST",
+      "--input",
+      payload,
+    ],
   });
   return "posted close-applied comment";
 }
@@ -19163,7 +19327,7 @@ function postReviewStartStatusComment(options: {
     nowMs: startedAtMs,
   })[0];
   if (initialLease) {
-    return { status: "held", lease: null, retryAt: initialLease.expiresAt, didMutate: false };
+    return heldReviewStartStatusCommentResult(initialLease.expiresAt, false);
   }
   reapExpiredDedicatedReviewStartLeases(
     options.item.number,
@@ -19181,7 +19345,10 @@ function postReviewStartStatusComment(options: {
     payload,
   ];
   const created = reviewCommentFromMutationResponse(
-    ghObservedMutationCommand(createArgs),
+    ghObservedMutationCommand({
+      identity: `review_lease_post:${options.item.number}:${leaseOwner}`,
+      args: createArgs,
+    }),
     createArgs,
   );
   const createdCommentId = commentId(created);
@@ -19214,7 +19381,7 @@ function postReviewStartStatusComment(options: {
         `could not identify the winning review lease for #${options.item.number}; retry required`,
       );
     }
-    return { status: "held", lease: null, retryAt: winner.expiresAt, didMutate: false };
+    return heldReviewStartStatusCommentResult(winner.expiresAt, true);
   }
   return { status: "posted", lease: acquired, didMutate: true };
 }
@@ -19232,12 +19399,15 @@ function deleteOwnedDedicatedReviewStartLease(
         (commentBody(comment) ?? "").includes(`sha=${lease.headSha}`),
     );
     if (!matching) return false;
-    ghWithRetry([
-      "api",
-      `repos/${targetRepo()}/issues/comments/${lease.commentId}`,
-      "--method",
-      "DELETE",
-    ]);
+    ghObservedMutationCommand({
+      identity: `review_lease_delete:${itemNumber}:${lease.commentId}`,
+      args: [
+        "api",
+        `repos/${targetRepo()}/issues/comments/${lease.commentId}`,
+        "--method",
+        "DELETE",
+      ],
+    });
     return true;
   } catch (error) {
     if (options.throwOnError) throw error;
@@ -19265,12 +19435,15 @@ function reapExpiredDedicatedReviewStartLeases(
   });
   for (const lease of expired) {
     try {
-      ghWithRetry([
-        "api",
-        `repos/${targetRepo()}/issues/comments/${lease.commentId}`,
-        "--method",
-        "DELETE",
-      ]);
+      ghObservedMutationCommand({
+        identity: `review_lease_reap:${itemNumber}:${lease.commentId}`,
+        args: [
+          "api",
+          `repos/${targetRepo()}/issues/comments/${lease.commentId}`,
+          "--method",
+          "DELETE",
+        ],
+      });
       console.error(
         `[review] reaped expired review lease comment ${lease.commentId} for #${itemNumber} (lease expired ${lease.expiresAt})`,
       );
@@ -19293,7 +19466,10 @@ function pullRequestHeadSha(number: number): string {
 
 function closeItem(options: { number: number; kind: ItemKind; reason: CloseReason }): void {
   if (options.kind === "pull_request") {
-    ghWithRetry(["pr", "close", String(options.number)]);
+    ghObservedMutationCommand({
+      identity: `item_close:${options.number}:${options.kind}:${options.reason}`,
+      args: ["pr", "close", String(options.number)],
+    });
   } else {
     const reason = isImplementationCloseReason(options.reason) ? "completed" : "not_planned";
     const closePayloadFile = join(ROOT, ".artifacts", `close-${options.number}.json`);
@@ -19302,14 +19478,17 @@ function closeItem(options: { number: number; kind: ItemKind; reason: CloseReaso
       JSON.stringify({ state: "closed", state_reason: reason }),
       "utf8",
     );
-    ghWithRetry([
-      "api",
-      `repos/${targetRepo()}/issues/${options.number}`,
-      "--method",
-      "PATCH",
-      "--input",
-      closePayloadFile,
-    ]);
+    ghObservedMutationCommand({
+      identity: `item_close:${options.number}:${options.kind}:${options.reason}`,
+      args: [
+        "api",
+        `repos/${targetRepo()}/issues/${options.number}`,
+        "--method",
+        "PATCH",
+        "--input",
+        closePayloadFile,
+      ],
+    });
   }
 }
 
@@ -22437,7 +22616,7 @@ function dispatchFailedReviewRetry(options: {
       );
     }
     const dispatchUrl = `https://github.com/${options.workflowRepo}/actions/workflows/sweep.yml`;
-    ghRawOnceWithCheckpoint(
+    const dispatch = ghRawOnceWithCheckpoint(
       [
         "api",
         "--method",
@@ -22468,10 +22647,11 @@ function dispatchFailedReviewRetry(options: {
       ],
       () => options.onBeforeDispatch?.(dispatchUrl),
     );
+    if (dispatch.outcome !== "accepted") throw new Error("GitHub dispatch was not accepted");
     return dispatchUrl;
   }
   const dispatchUrl = `https://github.com/${options.workflowRepo}/actions/workflows/sweep.yml`;
-  ghRawOnceWithCheckpoint(
+  const dispatch = ghRawOnceWithCheckpoint(
     [
       "workflow",
       "run",
@@ -22499,6 +22679,7 @@ function dispatchFailedReviewRetry(options: {
     ],
     () => options.onBeforeDispatch?.(dispatchUrl),
   );
+  if (dispatch.outcome !== "accepted") throw new Error("GitHub dispatch was not accepted");
   return dispatchUrl;
 }
 
@@ -22804,7 +22985,6 @@ function retryFailedReviewsCommandInner(args: Args): void {
           maxAttempts,
           codexTimeoutMs,
           onBeforeDispatch: (nextDispatchUrl) => {
-            dispatchCheckpointed = true;
             checkpointDispatchUrl = nextDispatchUrl;
             startFailedReviewRetryDispatchAttempt({
               ledger: retryLedger,
@@ -22835,6 +23015,7 @@ function retryFailedReviewsCommandInner(args: Args): void {
               reason: retryReason,
               dispatchUrl: nextDispatchUrl,
             });
+            dispatchCheckpointed = true;
             attempted += 1;
           },
         });
@@ -22871,7 +23052,13 @@ function retryFailedReviewsCommandInner(args: Args): void {
         });
         dispatched += 1;
       } catch (error) {
-        if (dispatchCheckpointed) {
+        const dispatchOutcome =
+          error instanceof GitHubDispatchError
+            ? error.outcome
+            : dispatchCheckpointed
+              ? "ambiguous_transport"
+              : "definitely_not_dispatched";
+        if (dispatchCheckpointed && dispatchOutcome === "ambiguous_transport") {
           results.push({
             repo: targetRepo(),
             number,
@@ -22882,18 +23069,48 @@ function retryFailedReviewsCommandInner(args: Args): void {
             reportPath: path,
             ...(checkpointDispatchUrl ? { dispatchUrl: checkpointDispatchUrl } : {}),
           });
-          if (error instanceof GitHubRuntimeBudgetError) throw error;
+          if (
+            error instanceof GitHubDispatchError &&
+            error.cause instanceof GitHubRuntimeBudgetError
+          ) {
+            throw error.cause;
+          }
           continue;
         }
         if (error instanceof GitHubRuntimeBudgetError) throw error;
+        const reason = error instanceof Error ? error.message : String(error);
+        if (checkpointDispatchUrl) {
+          markdown = markFailedReviewRetry({
+            markdown,
+            status: "dispatch_failed",
+            at: nowIso,
+            revision: retryRevision,
+            attempts: attemptsBeforeDispatch,
+            maxAttempts,
+            reason,
+            ...(checkpointDispatchUrl ? { dispatchUrl: checkpointDispatchUrl } : {}),
+          });
+          writeFileSync(path, markdown, "utf8");
+          writeFailedReviewRetryState(statePath, {
+            number,
+            status: "dispatch_failed",
+            at: nowIso,
+            revision: retryRevision,
+            attempts: attemptsBeforeDispatch,
+            maxAttempts,
+            reason,
+            ...(checkpointDispatchUrl ? { dispatchUrl: checkpointDispatchUrl } : {}),
+          });
+        }
         results.push({
           repo: targetRepo(),
           number,
           action: "skipped_dispatch_failed",
-          reason: error instanceof Error ? error.message : String(error),
+          reason,
           ...failedReviewRetryResultRevision(retryRevision),
           attempts: eligibility.attempts,
           reportPath: path,
+          ...(checkpointDispatchUrl ? { dispatchUrl: checkpointDispatchUrl } : {}),
         });
       }
     }
@@ -24343,13 +24560,8 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
     activeApplyMutationLease = null;
     if (!active) return;
     try {
-      runObservedApplyMutation({
-        identity: `apply_lease_delete:${active.itemNumber}:${active.lease.commentId}`,
-        operation: () =>
-          deleteOwnedDedicatedReviewStartLease(active.itemNumber, active.lease, {
-            throwOnError: true,
-          }),
-        didMutate: (deleted) => deleted,
+      deleteOwnedDedicatedReviewStartLease(active.itemNumber, active.lease, {
+        throwOnError: true,
       });
     } catch (error) {
       console.error(
@@ -24810,20 +25022,15 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
           headSha: leaseState.headSha,
         };
       } else {
-        const posted = runObservedApplyMutation({
-          identity: `apply_lease_acquire:${number}:${leaseState.headSha}`,
-          operation: () =>
-            postReviewStartStatusComment({
-              item,
-              headSha: leaseState.headSha,
-              reviewTimeoutMs: Math.max(5 * 60 * 1000, closeDelayMs + 60 * 1000),
-              position: 1,
-              total: 1,
-              shardIndex: 1,
-              shardCount: 1,
-              purpose: "apply",
-            }),
-          didMutate: (result) => result.didMutate,
+        const posted = postReviewStartStatusComment({
+          item,
+          headSha: leaseState.headSha,
+          reviewTimeoutMs: Math.max(5 * 60 * 1000, closeDelayMs + 60 * 1000),
+          position: 1,
+          total: 1,
+          shardIndex: 1,
+          shardCount: 1,
+          purpose: "apply",
         });
         if (posted.status !== "posted") {
           return `${item.kind === "pull_request" ? "same-head" : "same-revision"} ClawSweeper lease was acquired concurrently`;
@@ -26482,14 +26689,11 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
             continue;
           }
           try {
-            syncedComment = runObservedApplyMutation({
-              identity: `review_comment_upsert:${number}:${reviewCommentBodyDigest(markedReviewComment)}`,
-              operation: () =>
-                upsertReviewComment(number, markedReviewComment, existingReviewComment),
-              knownNoMutation: (error) =>
-                isGitHubRequiresAuthenticationError(error) ||
-                isLockedConversationCommentError(error),
-            });
+            syncedComment = upsertReviewComment(
+              number,
+              markedReviewComment,
+              existingReviewComment,
+            );
             const syncedCommentUpdatedAt = commentUpdatedAt(syncedComment);
             if (syncedCommentUpdatedAt) {
               allowedSelfMutationUpdatedAts.add(syncedCommentUpdatedAt);
@@ -26763,10 +26967,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
     }
     ensureRuntimeDelayFits(closeDelayMs, "before close");
     const appliedCloseReason = closeReason;
-    runObservedApplyMutation({
-      identity: `item_close:${number}:${item.kind}:${appliedCloseReason}`,
-      operation: () => closeItem({ number, kind: item.kind, reason: appliedCloseReason }),
-    });
+    closeItem({ number, kind: item.kind, reason: appliedCloseReason });
     let postCloseRuntimeYieldReason: string | null = null;
     try {
       ensureRuntimeDelayFits(closeDelayMs, "before close delay");
@@ -29544,7 +29745,21 @@ function publishActionEventsCommand(args: Args): void {
     stringArg(args.source_root, join(ROOT, ".clawsweeper-repair", "action-ledger-download")),
   );
   const stateRoot = resolve(stringArg(args.state_root, ROOT));
-  const result = importActionEventShards(sourceRoot, stateRoot);
+  const expectedProducerJob = stringArg(args.expected_producer_job, "");
+  if (!expectedProducerJob) {
+    throw new UserFacingCommandError("--expected-producer-job is required");
+  }
+  const currentProducer = workflowActionProducer("action_event_publisher");
+  const result = importActionEventShards(sourceRoot, stateRoot, {
+    expectedProducer: {
+      repository: currentProducer.repository,
+      sha: currentProducer.sha,
+      workflow: currentProducer.workflow,
+      job: expectedProducerJob,
+      runId: currentProducer.runId,
+      runAttempt: currentProducer.runAttempt,
+    },
+  });
   console.log(JSON.stringify(result, null, 2));
 }
 
@@ -29650,17 +29865,21 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
     else if (command === "finalize-action-events") {
       if (boolArg(args.interrupt_open_attempts)) {
         const reason = stringArg(args.reason, ACTION_EVENT_REASON_CODES.timeout);
-        if (reason !== ACTION_EVENT_REASON_CODES.timeout) {
+        if (
+          reason !== ACTION_EVENT_REASON_CODES.timeout &&
+          reason !== ACTION_EVENT_REASON_CODES.cancelled &&
+          reason !== ACTION_EVENT_REASON_CODES.workflowFailed
+        ) {
           throw new UserFacingCommandError(
             `Unsupported --reason for interrupted action events: ${reason}`,
           );
         }
         const interrupted = interruptOpenWorkflowActionEvents(ROOT, {
-          reasonCode: ACTION_EVENT_REASON_CODES.timeout,
+          reasonCode: reason,
         });
         if (interrupted > 0) {
           console.error(
-            `[action-ledger] recorded ${interrupted} timeout terminal event${
+            `[action-ledger] recorded ${interrupted} ${reason} terminal event${
               interrupted === 1 ? "" : "s"
             }`,
           );

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -1017,6 +1017,7 @@ interface ApplyResult {
   action: ActionTaken;
   reason: string;
   mutationOccurred?: boolean;
+  commentMutationOccurred?: boolean;
   durableReviewSynced?: boolean;
   terminalMissingVerified?: boolean;
   terminalStateVerified?: boolean;
@@ -9272,6 +9273,22 @@ function codexReviewFailureRetryable(error: unknown): boolean {
   return error instanceof CodexReviewError ? error.retryable : true;
 }
 
+function combinedCodexReviewError(
+  initialError: CodexReviewError,
+  retryError: CodexReviewError,
+  reasoningEffort: string,
+): CodexReviewError {
+  return new CodexReviewError({
+    message: `${initialError.message}\nFinal ${reasoningEffort}-reasoning retry also failed: ${retryError.message}`,
+    status: retryError.status ?? initialError.status,
+    stdout: retryError.stdout || initialError.stdout,
+    stderr: initialError.stderr || retryError.stderr,
+    errorCode: initialError.errorCode ?? retryError.errorCode,
+    signal: initialError.signal ?? retryError.signal,
+    retryable: retryError.retryable,
+  });
+}
+
 export function codexReviewFailureRetryableForTest(retryable: boolean): boolean {
   return codexReviewFailureRetryable(
     new CodexReviewError({
@@ -9280,6 +9297,25 @@ export function codexReviewFailureRetryableForTest(retryable: boolean): boolean 
       retryable,
     }),
   );
+}
+
+export function combinedCodexReviewRetryableForTest(
+  initialRetryable: boolean,
+  finalRetryable: boolean,
+): boolean {
+  return combinedCodexReviewError(
+    new CodexReviewError({
+      message: "initial Codex failure",
+      status: 1,
+      retryable: initialRetryable,
+    }),
+    new CodexReviewError({
+      message: "final Codex failure",
+      status: 1,
+      retryable: finalRetryable,
+    }),
+    "high",
+  ).retryable;
 }
 
 function openclawDirtyStatus(openclawDir: string): string {
@@ -9549,15 +9585,7 @@ function runCodex(options: {
       return runReviewPass(options.reasoningEffort, 1);
     } catch (retryError) {
       if (!(retryError instanceof CodexReviewError)) throw retryError;
-      throw new CodexReviewError({
-        message: `${error.message}\nFinal ${options.reasoningEffort}-reasoning retry also failed: ${retryError.message}`,
-        status: retryError.status ?? error.status,
-        stdout: retryError.stdout || error.stdout,
-        stderr: error.stderr || retryError.stderr,
-        errorCode: error.errorCode ?? retryError.errorCode,
-        signal: error.signal ?? retryError.signal,
-        retryable: error.retryable,
-      });
+      throw combinedCodexReviewError(error, retryError, options.reasoningEffort);
     }
   }
 }
@@ -23295,6 +23323,74 @@ function reviewRetryIdempotencySlot(
     : "retry_observation";
 }
 
+export function reviewRetryBatchEventDisposition(
+  actions: readonly FailedReviewRetryAction[],
+  failure: ReturnType<typeof actionLedgerFailureDisposition> | null = null,
+): {
+  status: ActionEventStatus;
+  reasonCode: ActionEventReasonCode;
+  retryable: boolean;
+  completionReason: string;
+  failedCount: number;
+  partial: boolean;
+} {
+  const dispatchOutcomeUnknown = actions.includes("skipped_retry_dispatch_uncertain");
+  const yielded = actions.includes("skipped_runtime_budget");
+  const failed =
+    dispatchOutcomeUnknown ||
+    actions.some(
+      (action) => action === "skipped_dispatch_failed" || action === "skipped_live_fetch_failed",
+    );
+  if (dispatchOutcomeUnknown) {
+    return {
+      status: ACTION_EVENT_STATUSES.failed,
+      reasonCode: ACTION_EVENT_REASON_CODES.unavailable,
+      retryable: false,
+      completionReason: "dispatch_outcome_unknown",
+      failedCount: 1 + (failure ? 1 : 0),
+      partial: true,
+    };
+  }
+  if (failure) {
+    return {
+      status: failure.status,
+      reasonCode: failure.reasonCode,
+      retryable: true,
+      completionReason: failure.completionReason,
+      failedCount: 1 + (failed ? 1 : 0),
+      partial: actions.length > 0,
+    };
+  }
+  if (failed) {
+    return {
+      status: ACTION_EVENT_STATUSES.failed,
+      reasonCode: ACTION_EVENT_REASON_CODES.unavailable,
+      retryable: true,
+      completionReason: "failed",
+      failedCount: 1,
+      partial: false,
+    };
+  }
+  if (yielded) {
+    return {
+      status: ACTION_EVENT_STATUSES.yielded,
+      reasonCode: ACTION_EVENT_REASON_CODES.runtimeBudget,
+      retryable: true,
+      completionReason: "partial",
+      failedCount: 0,
+      partial: true,
+    };
+  }
+  return {
+    status: ACTION_EVENT_STATUSES.completed,
+    reasonCode: ACTION_EVENT_REASON_CODES.completed,
+    retryable: false,
+    completionReason: "completed",
+    failedCount: 0,
+    partial: false,
+  };
+}
+
 function recordFailedReviewRetryEvents(options: {
   ledger: ReviewRetryActionLedger;
   results: readonly FailedReviewRetryResult[];
@@ -23304,6 +23400,7 @@ function recordFailedReviewRetryEvents(options: {
 }): void {
   if (options.ledger.terminal) return;
   const operationIdentity = options.ledger.operationIdentity;
+  let dispatchOutcomeUnknownEventId: string | null = null;
   for (const [index, result] of options.results.entries()) {
     const disposition = reviewRetryActionDisposition(result.action);
     const reportMarkdown =
@@ -23387,7 +23484,7 @@ function recordFailedReviewRetryEvents(options: {
             }),
           )
         : undefined;
-    recordWorkflowPhaseEvent(ROOT, {
+    const event = recordWorkflowPhaseEvent(ROOT, {
       phase: ACTION_EVENT_TYPES.reviewRetry,
       status: disposition.status,
       reasonCode: disposition.reasonCode,
@@ -23414,46 +23511,37 @@ function recordFailedReviewRetryEvents(options: {
         final_attempt:
           result.action === "marked_failed_review_retry_exhausted" ||
           result.action === "skipped_retry_already_exhausted",
-        completion_reason: result.action,
+        completion_reason:
+          result.action === "skipped_retry_dispatch_uncertain"
+            ? "dispatch_outcome_unknown"
+            : result.action,
       },
       privacy: actionLedgerPrivacy(),
     });
+    if (result.action === "skipped_retry_dispatch_uncertain") {
+      dispatchOutcomeUnknownEventId = event?.event_id ?? dispatchAttempt?.eventId ?? null;
+    }
   }
-  const yielded = options.results.some((result) => result.action === "skipped_runtime_budget");
-  const failed = options.results.some(
-    (result) =>
-      result.action === "skipped_dispatch_failed" ||
-      result.action === "skipped_retry_dispatch_uncertain" ||
-      result.action === "skipped_live_fetch_failed",
-  );
   const failure =
     options.failure === undefined || options.failure === null
       ? null
       : actionLedgerFailureDisposition(options.failure);
+  const batchDisposition = reviewRetryBatchEventDisposition(
+    options.results.map((result) => result.action),
+    failure,
+  );
   recordWorkflowPhaseEvent(ROOT, {
     phase: ACTION_EVENT_TYPES.reviewRetry,
-    status: failure
-      ? failure.status
-      : failed
-        ? ACTION_EVENT_STATUSES.failed
-        : yielded
-          ? ACTION_EVENT_STATUSES.yielded
-          : ACTION_EVENT_STATUSES.completed,
-    reasonCode: failure
-      ? failure.reasonCode
-      : failed
-        ? ACTION_EVENT_REASON_CODES.unavailable
-        : yielded
-          ? ACTION_EVENT_REASON_CODES.runtimeBudget
-          : ACTION_EVENT_REASON_CODES.completed,
-    retryable: Boolean(failure) || failed || yielded,
+    status: batchDisposition.status,
+    reasonCode: batchDisposition.reasonCode,
+    retryable: batchDisposition.retryable,
     mutation:
       !options.dryRun &&
       options.results.some((result) => reviewRetryActionDisposition(result.action).mutation),
     identity: { slot: "retry_batch_terminal" },
     operation: "review_retry",
     operationIdentity,
-    parentEventId: options.ledger.batchStartEventId,
+    parentEventId: dispatchOutcomeUnknownEventId ?? options.ledger.batchStartEventId,
     phaseSeq: 1_000_000,
     idempotencyIdentity: { operationIdentity, slot: "retry_batch_terminal" },
     component: "retry_failed_reviews",
@@ -23474,18 +23562,12 @@ function recordFailedReviewRetryEvents(options: {
           result.action === "dispatched_failed_review_retry" ||
           result.action === "planned_failed_review_retry",
       ).length,
-      failed_count: (failed ? 1 : 0) + (failure ? 1 : 0),
+      failed_count: batchDisposition.failedCount,
       skipped_count: options.results.filter((result) => result.action.startsWith("skipped_"))
         .length,
-      partial: yielded || (failure !== null && options.results.length > 0),
+      partial: batchDisposition.partial,
       duration_ms: Math.max(0, Date.now() - options.ledger.startedAtMs),
-      completion_reason: failure
-        ? failure.completionReason
-        : failed
-          ? "failed"
-          : yielded
-            ? "partial"
-            : "completed",
+      completion_reason: batchDisposition.completionReason,
     },
     privacy: actionLedgerPrivacy(),
   });
@@ -23507,6 +23589,7 @@ type ApplyLedgerItem = {
   index: number;
   started: boolean;
   startEventId: string | null;
+  lastEventId: string | null;
   mutationObserved: boolean;
   uncertainMutationObserved: boolean;
   mutationEventId: string | null;
@@ -23536,8 +23619,24 @@ type ApplyActionLedger = {
   batchStartEventId: string | null;
   items: Map<string, ApplyLedgerItem>;
   startedAtMs: number;
+  nextPhaseSeq: number;
   terminal: boolean;
 };
+
+type ApplyPhaseCursor = {
+  nextPhaseSeq: number;
+};
+
+function nextApplyPhaseSeq(cursor: ApplyPhaseCursor): number {
+  const phaseSeq = cursor.nextPhaseSeq;
+  cursor.nextPhaseSeq += 1;
+  return phaseSeq;
+}
+
+export function applyPhaseSequenceForTest(count: number): number[] {
+  const cursor: ApplyPhaseCursor = { nextPhaseSeq: 2 };
+  return Array.from({ length: Math.max(0, count) }, () => nextApplyPhaseSeq(cursor));
+}
 
 function startApplyActionLedger(options: {
   applyKind: ApplyKind;
@@ -23598,6 +23697,7 @@ function startApplyActionLedger(options: {
       index,
       started: false,
       startEventId: null,
+      lastEventId: null,
       mutationObserved: false,
       uncertainMutationObserved: false,
       mutationEventId: null,
@@ -23618,6 +23718,7 @@ function startApplyActionLedger(options: {
     batchStartEventId: batchStart?.event_id ?? null,
     items,
     startedAtMs: Date.now(),
+    nextPhaseSeq: 2,
     terminal: false,
   };
 }
@@ -23680,6 +23781,7 @@ function startApplyActionLedgerItem(
   const state = ledger.items.get(actionLedgerItemKey(entry));
   if (!state) return null;
   if (state.started) return state;
+  const phaseSeq = nextApplyPhaseSeq(ledger);
   const start = recordWorkflowPhaseEvent(ROOT, {
     phase: ACTION_EVENT_TYPES.applyAction,
     status: ACTION_EVENT_STATUSES.started,
@@ -23695,7 +23797,7 @@ function startApplyActionLedgerItem(
     operation: "apply",
     operationIdentity: ledger.operationIdentity,
     parentEventId: ledger.batchStartEventId,
-    phaseSeq: 10 + state.index * 20,
+    phaseSeq,
     idempotencyIdentity: applyItemIdempotencyIdentity(state, "apply_item"),
     component: "apply_decisions",
     subject: applyLedgerItemSubject(state),
@@ -23709,13 +23811,13 @@ function startApplyActionLedgerItem(
   });
   state.started = true;
   state.startEventId = start?.event_id ?? null;
+  state.lastEventId = state.startEventId;
   return state;
 }
 
 type ApplyMutationAttempt = {
   state: ApplyLedgerItem;
   eventId: string | null;
-  phaseSeq: number;
   idempotencyIdentity: ApplyItemBusinessIdempotencyIdentity & {
     mutationIdentitySha256: string;
   };
@@ -23735,7 +23837,7 @@ function startApplyMutationAttempt(
     ...applyItemIdempotencyIdentity(state, "apply_mutation"),
     mutationIdentitySha256: sha256(identity),
   };
-  const phaseSeq = 11 + state.index * 20;
+  const phaseSeq = nextApplyPhaseSeq(ledger);
   const attempt = recordWorkflowPhaseEvent(ROOT, {
     phase: ACTION_EVENT_TYPES.applyAction,
     status: ACTION_EVENT_STATUSES.started,
@@ -23752,7 +23854,7 @@ function startApplyMutationAttempt(
     },
     operation: "apply",
     operationIdentity: ledger.operationIdentity,
-    parentEventId: state.mutationEventId ?? state.startEventId,
+    parentEventId: state.lastEventId ?? state.startEventId,
     phaseSeq,
     idempotencyIdentity,
     component: "apply_decisions",
@@ -23767,10 +23869,10 @@ function startApplyMutationAttempt(
     },
     privacy: actionLedgerPrivacy(),
   });
+  state.lastEventId = attempt?.event_id ?? state.lastEventId;
   return {
     state,
     eventId: attempt?.event_id ?? null,
-    phaseSeq,
     idempotencyIdentity,
     mutationIndex,
   };
@@ -23783,6 +23885,7 @@ function finishApplyMutationAttempt(options: {
   outcome: "accepted" | "rejected" | "unknown";
 }): string | null {
   const mutation = options.outcome !== "rejected";
+  const phaseSeq = nextApplyPhaseSeq(options.ledger);
   const event = recordWorkflowPhaseEvent(ROOT, {
     phase: ACTION_EVENT_TYPES.applyAction,
     status:
@@ -23811,7 +23914,7 @@ function finishApplyMutationAttempt(options: {
     operation: "apply",
     operationIdentity: options.ledger.operationIdentity,
     parentEventId: options.attempt.eventId,
-    phaseSeq: options.attempt.phaseSeq + 1,
+    phaseSeq,
     idempotencyIdentity: options.attempt.idempotencyIdentity,
     component: "apply_decisions",
     subject: applyLedgerItemSubject(options.attempt.state),
@@ -23830,6 +23933,7 @@ function finishApplyMutationAttempt(options: {
     },
     privacy: actionLedgerPrivacy(),
   });
+  options.attempt.state.lastEventId = event?.event_id ?? options.attempt.state.lastEventId;
   if (mutation) {
     options.attempt.state.mutationEventId = event?.event_id ?? options.attempt.eventId;
   }
@@ -23846,6 +23950,7 @@ function recordApplyMutationBoundary(
 ): void {
   const state = startApplyActionLedgerItem(ledger, entry);
   if (!state || state.mutationObserved) return;
+  const phaseSeq = nextApplyPhaseSeq(ledger);
   const mutation = recordWorkflowPhaseEvent(ROOT, {
     phase: ACTION_EVENT_TYPES.applyAction,
     status: ACTION_EVENT_STATUSES.executed,
@@ -23860,8 +23965,8 @@ function recordApplyMutationBoundary(
     },
     operation: "apply",
     operationIdentity: ledger.operationIdentity,
-    parentEventId: parentEventId ?? state.mutationEventId ?? state.startEventId,
-    phaseSeq: 11 + state.index * 20,
+    parentEventId: parentEventId ?? state.lastEventId ?? state.startEventId,
+    phaseSeq,
     idempotencyIdentity: applyItemIdempotencyIdentity(state, "apply_item"),
     component: "apply_decisions",
     subject: applyLedgerItemSubject(state),
@@ -23875,7 +23980,8 @@ function recordApplyMutationBoundary(
     privacy: actionLedgerPrivacy(),
   });
   state.mutationObserved = true;
-  state.mutationEventId = mutation?.event_id ?? null;
+  state.lastEventId = mutation?.event_id ?? state.lastEventId;
+  state.mutationEventId = mutation?.event_id ?? state.mutationEventId;
 }
 
 export function applyActionEventDisposition(
@@ -23963,13 +24069,11 @@ export function applyActionEventDisposition(
   }
   if (action === "kept_open" || action.startsWith("skipped_")) {
     return {
-      status: mutationOccurred ? ACTION_EVENT_STATUSES.completed : ACTION_EVENT_STATUSES.skipped,
-      reasonCode: mutationOccurred
-        ? ACTION_EVENT_REASON_CODES.completed
-        : ACTION_EVENT_REASON_CODES.notApplicable,
+      status: ACTION_EVENT_STATUSES.skipped,
+      reasonCode: ACTION_EVENT_REASON_CODES.notApplicable,
       retryable: false,
       mutation: mutationOccurred,
-      completionReason: mutationOccurred ? "mutation_completed" : "skipped",
+      completionReason: action,
     };
   }
   return {
@@ -24005,7 +24109,7 @@ export function applyRuntimeBudgetYieldResultsForTest(
 
 export function reviewCommentPublicationEventDisposition(
   action: ActionTaken,
-  mutationOccurred: boolean,
+  commentMutationOccurred: boolean,
   dryRun: boolean,
 ): {
   status: ActionEventStatus;
@@ -24019,7 +24123,7 @@ export function reviewCommentPublicationEventDisposition(
       status: dryRun ? ACTION_EVENT_STATUSES.planned : ACTION_EVENT_STATUSES.published,
       reasonCode: dryRun ? ACTION_EVENT_REASON_CODES.dryRun : ACTION_EVENT_REASON_CODES.published,
       retryable: false,
-      mutation: !dryRun && mutationOccurred,
+      mutation: !dryRun && commentMutationOccurred,
       completionReason: dryRun ? "dry_run" : "comment_published",
     };
   }
@@ -24092,9 +24196,10 @@ function recordApplyActionLedgerItemResults(options: {
     );
     const commentDisposition = reviewCommentPublicationEventDisposition(
       result.action,
-      options.mutationOccurred,
+      result.commentMutationOccurred === true,
       options.dryRun,
     );
+    const actionPhaseSeq = nextApplyPhaseSeq(options.ledger);
     const actionEvent = recordWorkflowPhaseEvent(ROOT, {
       phase: ACTION_EVENT_TYPES.applyAction,
       status: disposition.status,
@@ -24110,8 +24215,8 @@ function recordApplyActionLedgerItemResults(options: {
       },
       operation: "apply",
       operationIdentity: options.ledger.operationIdentity,
-      parentEventId: options.state.mutationEventId ?? options.state.startEventId,
-      phaseSeq: 12 + options.state.index * 20,
+      parentEventId: options.state.lastEventId ?? options.state.startEventId,
+      phaseSeq: actionPhaseSeq,
       idempotencyIdentity: applyItemIdempotencyIdentity(options.state, "apply_item"),
       component: "apply_decisions",
       subject: applyLedgerItemSubject(options.state, options.entry),
@@ -24136,8 +24241,10 @@ function recordApplyActionLedgerItemResults(options: {
       },
       privacy: actionLedgerPrivacy(),
     });
+    options.state.lastEventId = actionEvent?.event_id ?? options.state.lastEventId;
     if (commentDisposition) {
-      recordWorkflowPhaseEvent(ROOT, {
+      const commentPhaseSeq = nextApplyPhaseSeq(options.ledger);
+      const commentEvent = recordWorkflowPhaseEvent(ROOT, {
         phase: ACTION_EVENT_TYPES.reviewCommentPublication,
         status: commentDisposition.status,
         reasonCode: commentDisposition.reasonCode,
@@ -24152,9 +24259,8 @@ function recordApplyActionLedgerItemResults(options: {
         },
         operation: "apply",
         operationIdentity: options.ledger.operationIdentity,
-        parentEventId:
-          actionEvent?.event_id ?? options.state.mutationEventId ?? options.state.startEventId,
-        phaseSeq: 13 + options.state.index * 20,
+        parentEventId: options.state.lastEventId ?? options.state.startEventId,
+        phaseSeq: commentPhaseSeq,
         idempotencyIdentity: applyItemIdempotencyIdentity(options.state, "review_comment"),
         component: "apply_decisions",
         subject: applyLedgerItemSubject(options.state, options.entry),
@@ -24166,6 +24272,7 @@ function recordApplyActionLedgerItemResults(options: {
         },
         privacy: actionLedgerPrivacy(),
       });
+      options.state.lastEventId = commentEvent?.event_id ?? options.state.lastEventId;
     }
   }
   options.state.terminal = true;
@@ -24180,7 +24287,8 @@ function recordApplyActionLedgerItemFailure(options: {
 }): void {
   if (options.state.terminal) return;
   const disposition = actionLedgerFailureDisposition(options.failure);
-  recordWorkflowPhaseEvent(ROOT, {
+  const phaseSeq = nextApplyPhaseSeq(options.ledger);
+  const event = recordWorkflowPhaseEvent(ROOT, {
     phase: ACTION_EVENT_TYPES.applyAction,
     status: disposition.status,
     reasonCode: disposition.reasonCode,
@@ -24194,8 +24302,8 @@ function recordApplyActionLedgerItemFailure(options: {
     },
     operation: "apply",
     operationIdentity: options.ledger.operationIdentity,
-    parentEventId: options.state.mutationEventId ?? options.state.startEventId,
-    phaseSeq: 12 + options.state.index * 20,
+    parentEventId: options.state.lastEventId ?? options.state.startEventId,
+    phaseSeq,
     idempotencyIdentity: applyItemIdempotencyIdentity(options.state, "apply_item"),
     component: "apply_decisions",
     subject: applyLedgerItemSubject(options.state, options.entry),
@@ -24207,6 +24315,7 @@ function recordApplyActionLedgerItemFailure(options: {
     },
     privacy: actionLedgerPrivacy(),
   });
+  options.state.lastEventId = event?.event_id ?? options.state.lastEventId;
   options.state.terminal = true;
 }
 
@@ -24262,6 +24371,7 @@ function recordApplyActionEvents(options: {
   for (const [index, result] of options.results.entries()) {
     if (result.number > 0) continue;
     const disposition = applyActionEventDisposition(result.action, false, options.dryRun);
+    const phaseSeq = nextApplyPhaseSeq(options.ledger);
     recordWorkflowPhaseEvent(ROOT, {
       phase: ACTION_EVENT_TYPES.applyAction,
       status: disposition.status,
@@ -24277,7 +24387,7 @@ function recordApplyActionEvents(options: {
       operation: "apply",
       operationIdentity: options.ledger.operationIdentity,
       parentEventId: options.ledger.batchStartEventId,
-      phaseSeq: 900_000 + index,
+      phaseSeq,
       idempotencyIdentity: {
         operationIdentity: options.ledger.operationIdentity,
         slot: "apply_workflow_result",
@@ -24329,6 +24439,7 @@ function recordApplyActionEvents(options: {
         : options.results.length === 0
           ? ACTION_EVENT_REASON_CODES.noChanges
           : ACTION_EVENT_REASON_CODES.completed;
+  const batchTerminalPhaseSeq = nextApplyPhaseSeq(options.ledger);
   const batchTerminal = recordWorkflowPhaseEvent(ROOT, {
     phase: ACTION_EVENT_TYPES.applyBatch,
     status: batchStatus,
@@ -24339,7 +24450,7 @@ function recordApplyActionEvents(options: {
     operation: "apply",
     operationIdentity: options.ledger.operationIdentity,
     parentEventId: options.ledger.batchStartEventId,
-    phaseSeq: 1_000_000,
+    phaseSeq: batchTerminalPhaseSeq,
     idempotencyIdentity: {
       operationIdentity: options.ledger.operationIdentity,
       slot: "apply_batch_terminal",
@@ -24372,6 +24483,7 @@ function recordApplyActionEvents(options: {
     privacy: actionLedgerPrivacy(),
   });
   const reportEvidence = actionLedgerFileEvidence("apply_report", options.reportPath);
+  const reportPublicationPhaseSeq = nextApplyPhaseSeq(options.ledger);
   recordWorkflowPhaseEvent(ROOT, {
     phase: ACTION_EVENT_TYPES.applyPublish,
     status: reportEvidence ? ACTION_EVENT_STATUSES.completed : ACTION_EVENT_STATUSES.skipped,
@@ -24384,7 +24496,7 @@ function recordApplyActionEvents(options: {
     operation: "apply",
     operationIdentity: options.ledger.operationIdentity,
     parentEventId: batchTerminal?.event_id ?? options.ledger.batchStartEventId,
-    phaseSeq: 1_000_001,
+    phaseSeq: reportPublicationPhaseSeq,
     idempotencyIdentity: {
       operationIdentity: options.ledger.operationIdentity,
       slot: "apply_report_publication",
@@ -24591,7 +24703,11 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
   const finishApply = (failed = false, failure?: unknown): void => {
     if (applyEventsFinalized) return;
     const publicResults = results.map(
-      ({ mutationOccurred: _mutationOccurred, ...result }) => result,
+      ({
+        mutationOccurred: _mutationOccurred,
+        commentMutationOccurred: _commentMutationOccurred,
+        ...result
+      }) => result,
     );
     let publicationError: unknown = null;
     try {
@@ -26809,6 +26925,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
         reason: closeBlockedForCommentSync
           ? [closeBlockedForCommentSync.reason, ...syncReasons].join("; ")
           : syncReasons.join("; "),
+        commentMutationOccurred: !dryRun && needsReviewCommentBodySync,
         ...(emitEventApplyProof ? { durableReviewSynced: true } : {}),
       });
       processedCount += 1;

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -462,8 +462,8 @@ type AcquiredReviewStartLease = {
 };
 
 type ReviewStartStatusCommentResult =
-  | { status: "posted"; lease: AcquiredReviewStartLease }
-  | { status: "held"; lease: null; retryAt: string };
+  | { status: "posted"; lease: AcquiredReviewStartLease; didMutate: true }
+  | { status: "held"; lease: null; retryAt: string; didMutate: false };
 
 interface ExistingReview {
   path: string;
@@ -12985,6 +12985,15 @@ function addIssueLabel(number: number, label: string, onMutation?: () => void): 
   });
 }
 
+function labelAlreadyExistsError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /already exists/i.test(message);
+}
+
+export function isGitHubLabelAlreadyExistsErrorForTest(message: string): boolean {
+  return labelAlreadyExistsError(new Error(message));
+}
+
 function ensurePriorityLabel(label: PriorityLabelSpec, onMutation?: () => void): void {
   try {
     runObservedApplyMutation({
@@ -13003,10 +13012,10 @@ function ensurePriorityLabel(label: PriorityLabelSpec, onMutation?: () => void):
           2,
         ),
       onMutation,
+      knownNoMutation: labelAlreadyExistsError,
     });
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    if (!/already exists/i.test(message)) throw error;
+    if (!labelAlreadyExistsError(error)) throw error;
   }
 }
 
@@ -13030,10 +13039,10 @@ function ensureImpactLabel(name: ImpactLabelName, onMutation?: () => void): void
           2,
         ),
       onMutation,
+      knownNoMutation: labelAlreadyExistsError,
     });
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    if (!/already exists/i.test(message)) throw error;
+    if (!labelAlreadyExistsError(error)) throw error;
   }
 }
 
@@ -13057,10 +13066,10 @@ function ensureMergeRiskLabel(name: MergeRiskLabelName, onMutation?: () => void)
           2,
         ),
       onMutation,
+      knownNoMutation: labelAlreadyExistsError,
     });
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    if (!/already exists/i.test(message)) throw error;
+    if (!labelAlreadyExistsError(error)) throw error;
   }
 }
 
@@ -13361,10 +13370,10 @@ function ensureIssueAdvisorySyncLabel(name: string, onMutation?: () => void): vo
           2,
         ),
       onMutation,
+      knownNoMutation: labelAlreadyExistsError,
     });
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    if (!/already exists/i.test(message)) throw error;
+    if (!labelAlreadyExistsError(error)) throw error;
   }
 }
 
@@ -13388,10 +13397,10 @@ function ensureMaturityLabel(name: MaturityLabelName, onMutation?: () => void): 
           2,
         ),
       onMutation,
+      knownNoMutation: labelAlreadyExistsError,
     });
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    if (!/already exists/i.test(message)) throw error;
+    if (!labelAlreadyExistsError(error)) throw error;
   }
 }
 
@@ -13657,10 +13666,10 @@ function ensurePrRatingLabel(tier: PrRatingTier, onMutation?: () => void): void 
           2,
         ),
       onMutation,
+      knownNoMutation: labelAlreadyExistsError,
     });
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    if (!/already exists/i.test(message)) throw error;
+    if (!labelAlreadyExistsError(error)) throw error;
   }
 }
 
@@ -13682,10 +13691,10 @@ function ensureFeatureShowcaseLabel(onMutation?: () => void): void {
           2,
         ),
       onMutation,
+      knownNoMutation: labelAlreadyExistsError,
     });
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    if (!/already exists/i.test(message)) throw error;
+    if (!labelAlreadyExistsError(error)) throw error;
   }
 }
 
@@ -13708,10 +13717,10 @@ function ensurePrStatusLabel(kind: PrStatusLabelKind, onMutation?: () => void): 
           2,
         ),
       onMutation,
+      knownNoMutation: labelAlreadyExistsError,
     });
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    if (!/already exists/i.test(message)) throw error;
+    if (!labelAlreadyExistsError(error)) throw error;
   }
 }
 
@@ -13839,10 +13848,10 @@ function ensureTelegramVisibleProofLabel(onMutation?: () => void): void {
           2,
         ),
       onMutation,
+      knownNoMutation: labelAlreadyExistsError,
     });
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    if (!/already exists/i.test(message)) throw error;
+    if (!labelAlreadyExistsError(error)) throw error;
   }
 }
 
@@ -13908,11 +13917,12 @@ function ensureRealBehaviorProofSufficientLabel(onMutation?: () => void): boolea
           2,
         ),
       onMutation,
+      knownNoMutation: labelAlreadyExistsError,
     });
     return true;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    if (/already exists/i.test(message)) return true;
+    if (labelAlreadyExistsError(error)) return true;
     console.warn(`Skipping optional label sync for ${PROOF_SUFFICIENT_LABEL}: ${message}`);
     return false;
   }
@@ -13938,11 +13948,12 @@ function ensureRealBehaviorProofMediaLabel(name: string, onMutation?: () => void
           2,
         ),
       onMutation,
+      knownNoMutation: labelAlreadyExistsError,
     });
     return true;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    if (/already exists/i.test(message)) return true;
+    if (labelAlreadyExistsError(error)) return true;
     console.warn(`Skipping optional label sync for ${definition.name}: ${message}`);
     return false;
   }
@@ -19152,7 +19163,7 @@ function postReviewStartStatusComment(options: {
     nowMs: startedAtMs,
   })[0];
   if (initialLease) {
-    return { status: "held", lease: null, retryAt: initialLease.expiresAt };
+    return { status: "held", lease: null, retryAt: initialLease.expiresAt, didMutate: false };
   }
   reapExpiredDedicatedReviewStartLeases(
     options.item.number,
@@ -19203,9 +19214,9 @@ function postReviewStartStatusComment(options: {
         `could not identify the winning review lease for #${options.item.number}; retry required`,
       );
     }
-    return { status: "held", lease: null, retryAt: winner.expiresAt };
+    return { status: "held", lease: null, retryAt: winner.expiresAt, didMutate: false };
   }
-  return { status: "posted", lease: acquired };
+  return { status: "posted", lease: acquired, didMutate: true };
 }
 
 function deleteOwnedDedicatedReviewStartLease(
@@ -24812,6 +24823,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
               shardCount: 1,
               purpose: "apply",
             }),
+          didMutate: (result) => result.didMutate,
         });
         if (posted.status !== "posted") {
           return `${item.kind === "pull_request" ? "same-head" : "same-revision"} ClawSweeper lease was acquired concurrently`;

--- a/test/action-ledger-runtime.test.ts
+++ b/test/action-ledger-runtime.test.ts
@@ -1113,6 +1113,19 @@ test("timeout recovery binds an open mutation receipt after an accepted attempt 
   assert.ok(rejectedRecovery);
   assert.equal(rejectedRecovery.action.mutation, false);
   assert.equal(rejectedRecovery.parent_event_id, rejectedOutcome.event_id);
+  const recoveredTerminals = events.filter(
+    (event) =>
+      event.action.status === ACTION_EVENT_STATUSES.failed && event.attributes?.partial === true,
+  );
+  assert.equal(recoveredTerminals.length, 4);
+  const eventsById = new Map(events.map((event) => [event.event_id, event]));
+  for (const terminal of recoveredTerminals) {
+    const parent = terminal.parent_event_id ? eventsById.get(terminal.parent_event_id) : null;
+    assert.ok(parent);
+    assert.ok(terminal.phase_seq > parent.phase_seq);
+  }
+  const phaseSeqs = events.map((event) => event.phase_seq);
+  assert.equal(new Set(phaseSeqs).size, phaseSeqs.length);
   assert.equal(interruptOpenWorkflowActionEvents(root, { env }), 0);
 });
 
@@ -1255,8 +1268,159 @@ test("interruption recovery follows the latest accepted mutation ordinal", () =>
   );
   assert.ok(recoveredItem);
   assert.equal(recoveredItem.parent_event_id, latestOutcome.event_id);
+  assert.ok(recoveredItem.phase_seq > latestOutcome.phase_seq);
+  const attemptPhases = readAllSpooledActionEvents(root)
+    .filter(
+      (event) =>
+        event.operation_id === recoveredItem.operation_id &&
+        event.attempt_id === recoveredItem.attempt_id,
+    )
+    .map((event) => event.phase_seq);
+  assert.equal(new Set(attemptPhases).size, attemptPhases.length);
   assert.equal(recoveredItem.action.mutation, true);
   assert.equal(recoveredItem.action.retryable, true);
+});
+
+test("review interruption recovery aggregates coordination comment mutations", () => {
+  const root = tempRoot();
+  const env = workflowEnv({
+    CLAWSWEEPER_ACTION_LEDGER_INVOCATION: "review-coordination-mutation",
+    GITHUB_ACTION: "__review",
+    GITHUB_JOB: "review",
+  });
+  const operationIdentity = {
+    repository: "openclaw/openclaw",
+    candidateSnapshots: [
+      {
+        repository: "openclaw/openclaw",
+        kind: "pull_request",
+        number: 54,
+        updatedAt: "2026-07-12T12:00:00Z",
+      },
+    ],
+  };
+  const batch = recordWorkflowPhaseEvent(
+    root,
+    {
+      phase: ACTION_EVENT_TYPES.reviewBatch,
+      status: ACTION_EVENT_STATUSES.started,
+      reasonCode: ACTION_EVENT_REASON_CODES.selected,
+      retryable: false,
+      mutation: false,
+      identity: { slot: "review_batch_start" },
+      operation: "review",
+      operationIdentity,
+      phaseSeq: 1,
+      idempotencyIdentity: { operationIdentity, slot: "review_batch_start" },
+      component: "review",
+      subject: { repository: "openclaw/openclaw", kind: "workflow" },
+    },
+    { env },
+  );
+  assert.ok(batch);
+  const item = recordWorkflowPhaseEvent(
+    root,
+    {
+      phase: ACTION_EVENT_TYPES.reviewItem,
+      status: ACTION_EVENT_STATUSES.started,
+      reasonCode: ACTION_EVENT_REASON_CODES.selected,
+      retryable: false,
+      mutation: false,
+      identity: { slot: "review_item_start", number: 54 },
+      operation: "review",
+      operationIdentity,
+      parentEventId: batch.event_id,
+      phaseSeq: 2,
+      idempotencyIdentity: {
+        operation: "review",
+        slot: "review_item",
+        repository: "openclaw/openclaw",
+        number: 54,
+      },
+      component: "review",
+      subject: {
+        repository: "openclaw/openclaw",
+        kind: "pull_request",
+        number: 54,
+        sourceRevision: "a".repeat(40),
+      },
+    },
+    { env },
+  );
+  assert.ok(item);
+  const mutationIdentity = {
+    operation: "review",
+    slot: "coordination_mutation",
+    repository: "openclaw/openclaw",
+    number: 54,
+    mutationIdentitySha256: "b".repeat(64),
+  };
+  const attempt = recordWorkflowPhaseEvent(
+    root,
+    {
+      phase: ACTION_EVENT_TYPES.reviewItem,
+      status: ACTION_EVENT_STATUSES.started,
+      reasonCode: ACTION_EVENT_REASON_CODES.selected,
+      retryable: true,
+      mutation: false,
+      identity: { slot: "review_coordination_mutation_attempt", number: 54 },
+      operation: "review",
+      operationIdentity,
+      parentEventId: item.event_id,
+      phaseSeq: 3,
+      idempotencyIdentity: mutationIdentity,
+      component: "review",
+      subject: {
+        repository: "openclaw/openclaw",
+        kind: "pull_request",
+        number: 54,
+        sourceRevision: "a".repeat(40),
+      },
+      attributes: { completion_reason: "mutation_attempted" },
+    },
+    { env },
+  );
+  assert.ok(attempt);
+  const outcome = recordWorkflowPhaseEvent(
+    root,
+    {
+      phase: ACTION_EVENT_TYPES.reviewItem,
+      status: ACTION_EVENT_STATUSES.executed,
+      reasonCode: ACTION_EVENT_REASON_CODES.completed,
+      retryable: false,
+      mutation: true,
+      identity: { slot: "review_coordination_mutation_outcome", number: 54 },
+      operation: "review",
+      operationIdentity,
+      parentEventId: attempt.event_id,
+      phaseSeq: 4,
+      idempotencyIdentity: mutationIdentity,
+      component: "review",
+      subject: {
+        repository: "openclaw/openclaw",
+        kind: "pull_request",
+        number: 54,
+        sourceRevision: "a".repeat(40),
+      },
+      attributes: { completion_reason: "mutation_accepted" },
+    },
+    { env },
+  );
+  assert.ok(outcome);
+
+  assert.equal(interruptOpenWorkflowActionEvents(root, { env }), 2);
+  const recovered = readAllSpooledActionEvents(root).filter(
+    (event) =>
+      event.attributes?.completion_reason === "timeout" && event.action.status === "failed",
+  );
+  const recoveredItem = recovered.find((event) => event.subject.number === 54);
+  const recoveredBatch = recovered.find((event) => event.subject.kind === "workflow");
+  assert.ok(recoveredItem);
+  assert.ok(recoveredBatch);
+  assert.equal(recoveredItem.parent_event_id, outcome.event_id);
+  assert.ok(recoveredItem.phase_seq > outcome.phase_seq);
+  assert.equal(recoveredItem.action.mutation, true);
+  assert.equal(recoveredBatch.action.mutation, true);
 });
 
 test("interruption recovery preserves any earlier unknown mutation outcome", () => {

--- a/test/action-ledger-runtime.test.ts
+++ b/test/action-ledger-runtime.test.ts
@@ -446,6 +446,12 @@ test("timeout recovery closes only start-only review attempts before finalizatio
         kind: "issue",
         updatedAt: "2026-07-12T09:01:00Z",
       },
+      {
+        repository: "openclaw/openclaw",
+        number: 44,
+        kind: "pull_request",
+        updatedAt: "2026-07-12T09:02:00Z",
+      },
     ],
   };
   const batch = recordWorkflowPhaseEvent(
@@ -566,11 +572,205 @@ test("timeout recovery closes only start-only review attempts before finalizatio
     events.filter(
       (event) =>
         event.event_type === ACTION_EVENT_TYPES.reviewItem &&
-        event.subject.number === 43 &&
+        (event.subject.number === 43 || event.subject.number === 44) &&
         event.action.status === ACTION_EVENT_STATUSES.failed,
     ).length,
     0,
   );
+  assert.equal(events.filter((event) => event.subject.number === 44).length, 0);
+});
+
+test("timeout recovery preserves hard-killed apply mutation truth and ignores untouched items", () => {
+  const root = tempRoot();
+  const env = workflowEnv({
+    CLAWSWEEPER_ACTION_LEDGER_INVOCATION: "apply-0",
+    GITHUB_ACTION: "__apply",
+    GITHUB_JOB: "apply-existing",
+  });
+  const operationIdentity = {
+    repository: "openclaw/openclaw",
+    checkpoint: "2",
+    candidateRevisions: [
+      { number: 41, sourceRevision: "revision-41" },
+      { number: 42, sourceRevision: "revision-42" },
+      { number: 43, sourceRevision: "revision-43" },
+    ],
+  };
+  const batch = recordWorkflowPhaseEvent(
+    root,
+    {
+      phase: ACTION_EVENT_TYPES.applyBatch,
+      status: ACTION_EVENT_STATUSES.started,
+      reasonCode: ACTION_EVENT_REASON_CODES.selected,
+      retryable: false,
+      mutation: false,
+      identity: { slot: "apply_batch_start" },
+      operation: "apply",
+      operationIdentity,
+      phaseSeq: 1,
+      idempotencyIdentity: { operationIdentity, slot: "apply_batch_start" },
+      component: "apply_decisions",
+      subject: { repository: "openclaw/openclaw", kind: "workflow" },
+    },
+    { env },
+  );
+  assert.ok(batch);
+  const completedStart = recordWorkflowPhaseEvent(
+    root,
+    {
+      phase: ACTION_EVENT_TYPES.applyAction,
+      status: ACTION_EVENT_STATUSES.started,
+      reasonCode: ACTION_EVENT_REASON_CODES.selected,
+      retryable: false,
+      mutation: false,
+      identity: { slot: "apply_item_start", number: 41 },
+      operation: "apply",
+      operationIdentity,
+      parentEventId: batch.event_id,
+      phaseSeq: 10,
+      idempotencyIdentity: {
+        operation: "apply",
+        slot: "apply_item",
+        repository: "openclaw/openclaw",
+        number: 41,
+        sourceRevision: "revision-41",
+      },
+      component: "apply_decisions",
+      subject: {
+        repository: "openclaw/openclaw",
+        kind: "pull_request",
+        number: 41,
+        sourceRevision: "revision-41",
+      },
+    },
+    { env },
+  );
+  assert.ok(completedStart);
+  recordWorkflowPhaseEvent(
+    root,
+    {
+      phase: ACTION_EVENT_TYPES.applyAction,
+      status: ACTION_EVENT_STATUSES.completed,
+      reasonCode: ACTION_EVENT_REASON_CODES.completed,
+      retryable: false,
+      mutation: false,
+      identity: { slot: "apply_result", number: 41 },
+      operation: "apply",
+      operationIdentity,
+      parentEventId: completedStart.event_id,
+      phaseSeq: 12,
+      idempotencyIdentity: {
+        operation: "apply",
+        slot: "apply_item",
+        repository: "openclaw/openclaw",
+        number: 41,
+        sourceRevision: "revision-41",
+      },
+      component: "apply_decisions",
+      subject: {
+        repository: "openclaw/openclaw",
+        kind: "pull_request",
+        number: 41,
+        sourceRevision: "revision-41",
+      },
+    },
+    { env },
+  );
+  const activeStart = recordWorkflowPhaseEvent(
+    root,
+    {
+      phase: ACTION_EVENT_TYPES.applyAction,
+      status: ACTION_EVENT_STATUSES.started,
+      reasonCode: ACTION_EVENT_REASON_CODES.selected,
+      retryable: false,
+      mutation: false,
+      identity: { slot: "apply_item_start", number: 42 },
+      operation: "apply",
+      operationIdentity,
+      parentEventId: batch.event_id,
+      phaseSeq: 30,
+      idempotencyIdentity: {
+        operation: "apply",
+        slot: "apply_item",
+        repository: "openclaw/openclaw",
+        number: 42,
+        sourceRevision: "revision-42",
+      },
+      component: "apply_decisions",
+      subject: {
+        repository: "openclaw/openclaw",
+        kind: "pull_request",
+        number: 42,
+        sourceRevision: "revision-42",
+      },
+    },
+    { env },
+  );
+  assert.ok(activeStart);
+  const mutation = recordWorkflowPhaseEvent(
+    root,
+    {
+      phase: ACTION_EVENT_TYPES.applyAction,
+      status: ACTION_EVENT_STATUSES.executed,
+      reasonCode: ACTION_EVENT_REASON_CODES.completed,
+      retryable: true,
+      mutation: true,
+      identity: { slot: "apply_mutation_observed", number: 42 },
+      operation: "apply",
+      operationIdentity,
+      parentEventId: activeStart.event_id,
+      phaseSeq: 31,
+      idempotencyIdentity: {
+        operation: "apply",
+        slot: "apply_item",
+        repository: "openclaw/openclaw",
+        number: 42,
+        sourceRevision: "revision-42",
+      },
+      component: "apply_decisions",
+      subject: {
+        repository: "openclaw/openclaw",
+        kind: "pull_request",
+        number: 42,
+        sourceRevision: "revision-42",
+      },
+    },
+    { env },
+  );
+  assert.ok(mutation);
+
+  assert.equal(
+    interruptOpenWorkflowActionEvents(root, {
+      env,
+      now: () => new Date("2026-07-12T10:05:00Z"),
+    }),
+    2,
+  );
+  assert.equal(interruptOpenWorkflowActionEvents(root, { env }), 0);
+
+  const events = readAllSpooledActionEvents(root);
+  const interrupted = events.filter(
+    (event) =>
+      event.action.status === ACTION_EVENT_STATUSES.failed &&
+      event.action.reason_code === ACTION_EVENT_REASON_CODES.timeout,
+  );
+  assert.equal(interrupted.length, 2);
+  assert.ok(interrupted.every((event) => event.action.mutation));
+  const interruptedItem = interrupted.find(
+    (event) => event.event_type === ACTION_EVENT_TYPES.applyAction && event.subject.number === 42,
+  );
+  assert.ok(interruptedItem);
+  assert.equal(interruptedItem.parent_event_id, mutation.event_id);
+  assert.equal(interruptedItem.idempotency_key_sha256, activeStart.idempotency_key_sha256);
+  assert.equal(
+    interrupted.filter(
+      (event) =>
+        event.event_type === ACTION_EVENT_TYPES.applyAction &&
+        (event.subject.number === 41 || event.subject.number === 43),
+    ).length,
+    0,
+  );
+  assert.equal(events.filter((event) => event.subject.number === 43).length, 0);
 });
 
 test("workflow retries preserve operation and idempotency identity but change attempts", () => {

--- a/test/action-ledger-runtime.test.ts
+++ b/test/action-ledger-runtime.test.ts
@@ -13,6 +13,7 @@ import {
   flushPendingCrabFleetPosts,
   flushWorkflowActionEvents,
   importActionEventShards,
+  interruptOpenWorkflowActionEvents,
   postActionEventToCrabFleet,
   recordWorkflowActionEvent,
   recordWorkflowPhaseEvent,
@@ -28,6 +29,7 @@ import {
   actionEventShardRelativePath,
   actionLedgerJson,
   createActionEvent,
+  readAllSpooledActionEvents,
   readActionEventShard,
   readActionEventShardAt,
   writeActionEventShard,
@@ -332,30 +334,32 @@ function recreateActionEvent(
 }
 
 test("workflow event telemetry is disabled outside an explicit workflow context", () => {
-  assert.equal(
-    recordWorkflowActionEvent(
-      tempRoot(),
-      {
-        scope: "review.completed",
-        identity: { number: 42 },
-        type: ACTION_EVENT_TYPES.reviewCompleted,
-        component: "review",
-        subject: {
-          repository: "openclaw/openclaw",
-          kind: "pull_request",
-          number: 42,
+  for (const env of [{}, { GITHUB_ACTIONS: "true" }]) {
+    assert.equal(
+      recordWorkflowActionEvent(
+        tempRoot(),
+        {
+          scope: "review.completed",
+          identity: { number: 42 },
+          type: ACTION_EVENT_TYPES.reviewCompleted,
+          component: "review",
+          subject: {
+            repository: "openclaw/openclaw",
+            kind: "pull_request",
+            number: 42,
+          },
+          action: {
+            name: "review",
+            status: "completed",
+            retryable: false,
+            mutation: false,
+          },
         },
-        action: {
-          name: "review",
-          status: "completed",
-          retryable: false,
-          mutation: false,
-        },
-      },
-      { env: {} },
-    ),
-    null,
-  );
+        { env },
+      ),
+      null,
+    );
+  }
 });
 
 test("phase event helpers derive canonical types, action names, and replay identities", () => {
@@ -422,6 +426,151 @@ test("phase event helpers derive canonical types, action names, and replay ident
   assert.equal(first.parent_event_id, null);
   assert.equal(first.phase_seq, 3);
   assert.match(first.idempotency_key_sha256, /^[a-f0-9]{64}$/);
+});
+
+test("timeout recovery closes only start-only review attempts before finalization", () => {
+  const root = tempRoot();
+  const env = workflowEnv();
+  const operationIdentity = {
+    repository: "openclaw/openclaw",
+    candidateSnapshots: [
+      {
+        repository: "openclaw/openclaw",
+        number: 42,
+        kind: "pull_request",
+        updatedAt: "2026-07-12T09:00:00Z",
+      },
+      {
+        repository: "openclaw/openclaw",
+        number: 43,
+        kind: "issue",
+        updatedAt: "2026-07-12T09:01:00Z",
+      },
+    ],
+  };
+  const batch = recordWorkflowPhaseEvent(
+    root,
+    {
+      phase: ACTION_EVENT_TYPES.reviewBatch,
+      status: ACTION_EVENT_STATUSES.started,
+      reasonCode: ACTION_EVENT_REASON_CODES.selected,
+      retryable: false,
+      mutation: false,
+      identity: { slot: "batch_start" },
+      operation: "review",
+      operationIdentity,
+      phaseSeq: 1,
+      component: "review",
+      subject: { repository: "openclaw/openclaw", kind: "workflow" },
+    },
+    { env },
+  );
+  assert.ok(batch);
+  const openItem = recordWorkflowPhaseEvent(
+    root,
+    {
+      phase: ACTION_EVENT_TYPES.reviewItem,
+      status: ACTION_EVENT_STATUSES.started,
+      reasonCode: ACTION_EVENT_REASON_CODES.selected,
+      retryable: false,
+      mutation: false,
+      identity: { slot: "item_start", number: 42 },
+      operation: "review",
+      operationIdentity,
+      parentEventId: batch.event_id,
+      phaseSeq: 10,
+      component: "review",
+      subject: { repository: "openclaw/openclaw", kind: "pull_request", number: 42 },
+    },
+    { env },
+  );
+  assert.ok(openItem);
+  const completedItem = recordWorkflowPhaseEvent(
+    root,
+    {
+      phase: ACTION_EVENT_TYPES.reviewItem,
+      status: ACTION_EVENT_STATUSES.started,
+      reasonCode: ACTION_EVENT_REASON_CODES.selected,
+      retryable: false,
+      mutation: false,
+      identity: { slot: "item_start", number: 43 },
+      operation: "review",
+      operationIdentity,
+      parentEventId: batch.event_id,
+      phaseSeq: 20,
+      component: "review",
+      subject: { repository: "openclaw/openclaw", kind: "issue", number: 43 },
+    },
+    { env },
+  );
+  assert.ok(completedItem);
+  recordWorkflowPhaseEvent(
+    root,
+    {
+      phase: ACTION_EVENT_TYPES.reviewItem,
+      status: ACTION_EVENT_STATUSES.completed,
+      reasonCode: ACTION_EVENT_REASON_CODES.completed,
+      retryable: false,
+      mutation: false,
+      identity: { slot: "item_terminal", number: 43 },
+      operation: "review",
+      operationIdentity,
+      parentEventId: completedItem.event_id,
+      phaseSeq: 22,
+      component: "review",
+      subject: {
+        repository: "openclaw/openclaw",
+        kind: "issue",
+        number: 43,
+        sourceRevision: "revision-43",
+      },
+    },
+    { env },
+  );
+
+  assert.equal(
+    interruptOpenWorkflowActionEvents(root, {
+      env,
+      now: () => new Date("2026-07-12T10:05:00Z"),
+    }),
+    2,
+  );
+  assert.equal(interruptOpenWorkflowActionEvents(root, { env }), 0);
+
+  const events = readAllSpooledActionEvents(root);
+  const interrupted = events.filter(
+    (event) =>
+      event.action.status === ACTION_EVENT_STATUSES.failed &&
+      event.action.reason_code === ACTION_EVENT_REASON_CODES.timeout,
+  );
+  assert.equal(interrupted.length, 2);
+  assert.deepEqual(
+    interrupted
+      .map((event) => [event.event_type, event.subject.number ?? null] as const)
+      .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0)),
+    [
+      [ACTION_EVENT_TYPES.reviewBatch, null],
+      [ACTION_EVENT_TYPES.reviewItem, 42],
+    ],
+  );
+  assert.ok(
+    interrupted.every(
+      (event) =>
+        event.operation_id === batch.operation_id &&
+        event.attempt_id === batch.attempt_id &&
+        event.action.retryable &&
+        !event.action.mutation,
+    ),
+  );
+  assert.equal(
+    events.filter(
+      (event) =>
+        event.event_type === ACTION_EVENT_TYPES.reviewItem &&
+        event.subject.number === 43 &&
+        event.action.status === ACTION_EVENT_STATUSES.failed,
+    ).length,
+    0,
+  );
 });
 
 test("workflow retries preserve operation and idempotency identity but change attempts", () => {

--- a/test/action-ledger-runtime.test.ts
+++ b/test/action-ledger-runtime.test.ts
@@ -65,6 +65,57 @@ async function waitForPath(filePath: string, timeoutMs = 2_000): Promise<void> {
   }
 }
 
+function errnoCode(error: unknown): string | undefined {
+  return error instanceof Error && "code" in error
+    ? (error as NodeJS.ErrnoException).code
+    : undefined;
+}
+
+async function waitForPositivePidFile(filePath: string, timeoutMs = 2_000): Promise<number> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      const value = fs.readFileSync(filePath, "utf8").trim();
+      if (/^[1-9]\d*$/.test(value)) {
+        const pid = Number(value);
+        if (Number.isSafeInteger(pid)) return pid;
+      }
+    } catch (error) {
+      if (errnoCode(error) !== "ENOENT") throw error;
+    }
+    if (Date.now() >= deadline)
+      throw new Error(`timed out waiting for positive PID in ${filePath}`);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+async function waitForLinuxProcessState(
+  pid: number,
+  expectedState: string,
+  timeoutMs = 2_000,
+): Promise<boolean> {
+  if (!Number.isSafeInteger(pid) || pid < 1) throw new Error(`invalid Linux process PID: ${pid}`);
+  const statPath = `/proc/${pid}/stat`;
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      const stat = fs.readFileSync(statPath, "utf8");
+      const commandEnd = stat.lastIndexOf(")");
+      if (commandEnd >= 0) {
+        const state = stat
+          .slice(commandEnd + 1)
+          .trim()
+          .split(/\s+/)[0];
+        if (state === expectedState) return true;
+      }
+    } catch (error) {
+      if (errnoCode(error) !== "ENOENT") throw error;
+    }
+    if (Date.now() >= deadline) return false;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
 async function childResult(
   child: ChildProcess,
 ): Promise<{ code: number | null; stdout: string; stderr: string }> {
@@ -774,7 +825,7 @@ test("timeout recovery preserves hard-killed apply mutation truth and ignores un
   assert.equal(events.filter((event) => event.subject.number === 43).length, 0);
 });
 
-test("timeout recovery treats an open pre-dispatch mutation receipt as outcome unknown", () => {
+test("timeout recovery binds an open mutation receipt after an accepted attempt exactly", () => {
   const root = tempRoot();
   const env = workflowEnv({
     CLAWSWEEPER_ACTION_LEDGER_INVOCATION: "apply-uncertain",
@@ -835,7 +886,7 @@ test("timeout recovery treats an open pre-dispatch mutation receipt as outcome u
     { env },
   );
   assert.ok(item);
-  const attempt = recordWorkflowPhaseEvent(
+  const acceptedAttempt = recordWorkflowPhaseEvent(
     root,
     {
       phase: ACTION_EVENT_TYPES.applyAction,
@@ -855,6 +906,72 @@ test("timeout recovery treats an open pre-dispatch mutation receipt as outcome u
         number: 52,
         sourceRevision: "revision-52",
         mutationIdentitySha256: "a".repeat(64),
+      },
+      component: "apply_decisions",
+      subject: {
+        repository: "openclaw/openclaw",
+        kind: "pull_request",
+        number: 52,
+        sourceRevision: "revision-52",
+      },
+      attributes: { completion_reason: "mutation_attempted" },
+    },
+    { env },
+  );
+  assert.ok(acceptedAttempt);
+  const acceptedOutcome = recordWorkflowPhaseEvent(
+    root,
+    {
+      phase: ACTION_EVENT_TYPES.applyAction,
+      status: ACTION_EVENT_STATUSES.executed,
+      reasonCode: ACTION_EVENT_REASON_CODES.completed,
+      retryable: false,
+      mutation: true,
+      identity: { slot: "apply_mutation_outcome", outcome: "accepted" },
+      operation: "apply",
+      operationIdentity,
+      parentEventId: acceptedAttempt.event_id,
+      phaseSeq: 12,
+      idempotencyIdentity: {
+        operation: "apply",
+        slot: "apply_mutation",
+        repository: "openclaw/openclaw",
+        number: 52,
+        sourceRevision: "revision-52",
+        mutationIdentitySha256: "a".repeat(64),
+      },
+      component: "apply_decisions",
+      subject: {
+        repository: "openclaw/openclaw",
+        kind: "pull_request",
+        number: 52,
+        sourceRevision: "revision-52",
+      },
+      attributes: { completion_reason: "mutation_accepted" },
+    },
+    { env },
+  );
+  assert.ok(acceptedOutcome);
+  const attempt = recordWorkflowPhaseEvent(
+    root,
+    {
+      phase: ACTION_EVENT_TYPES.applyAction,
+      status: ACTION_EVENT_STATUSES.started,
+      reasonCode: ACTION_EVENT_REASON_CODES.selected,
+      retryable: false,
+      mutation: false,
+      identity: { slot: "apply_mutation_attempt", mutationIdentitySha256: "c".repeat(64) },
+      operation: "apply",
+      operationIdentity,
+      parentEventId: acceptedOutcome.event_id,
+      phaseSeq: 13,
+      idempotencyIdentity: {
+        operation: "apply",
+        slot: "apply_mutation",
+        repository: "openclaw/openclaw",
+        number: 52,
+        sourceRevision: "revision-52",
+        mutationIdentitySha256: "c".repeat(64),
       },
       component: "apply_decisions",
       subject: {
@@ -966,14 +1083,14 @@ test("timeout recovery treats an open pre-dispatch mutation receipt as outcome u
   );
   assert.ok(rejectedOutcome);
 
-  assert.equal(interruptOpenWorkflowActionEvents(root, { env }), 3);
+  assert.equal(interruptOpenWorkflowActionEvents(root, { env }), 4);
   const events = readAllSpooledActionEvents(root);
   const recovered = events.filter(
     (event) =>
       event.action.status === ACTION_EVENT_STATUSES.failed &&
       event.attributes?.completion_reason === "mutation_outcome_unknown",
   );
-  assert.equal(recovered.length, 2);
+  assert.equal(recovered.length, 3);
   assert.ok(recovered.every((event) => event.action.mutation));
   const recoveredItem = recovered.find(
     (event) =>
@@ -981,6 +1098,12 @@ test("timeout recovery treats an open pre-dispatch mutation receipt as outcome u
   );
   assert.ok(recoveredItem);
   assert.equal(recoveredItem.parent_event_id, attempt.event_id);
+  const recoveredAttempt = recovered.find(
+    (event) => event.idempotency_key_sha256 === attempt.idempotency_key_sha256,
+  );
+  assert.ok(recoveredAttempt);
+  assert.equal(recoveredAttempt.parent_event_id, attempt.event_id);
+  assert.notEqual(recoveredAttempt.parent_event_id, acceptedOutcome.event_id);
   const rejectedRecovery = events.find(
     (event) =>
       event.subject.number === 53 &&
@@ -990,6 +1113,7 @@ test("timeout recovery treats an open pre-dispatch mutation receipt as outcome u
   assert.ok(rejectedRecovery);
   assert.equal(rejectedRecovery.action.mutation, false);
   assert.equal(rejectedRecovery.parent_event_id, rejectedOutcome.event_id);
+  assert.equal(interruptOpenWorkflowActionEvents(root, { env }), 0);
 });
 
 test("workflow retries preserve operation and idempotency identity but change attempts", () => {
@@ -1798,6 +1922,10 @@ test(
   },
 );
 
+test("Linux zombie-lock polling rejects PID 0 before probing procfs", async () => {
+  await assert.rejects(waitForLinuxProcessState(0, "Z"), /invalid Linux process PID: 0/);
+});
+
 test(
   "Linux producer locks reclaim zombie owners",
   { skip: process.platform === "linux" ? false : "requires Linux procfs zombie state" },
@@ -1828,19 +1956,10 @@ test(
     );
     const keeperDone = childResult(keeper);
     try {
-      await waitForPath(pidPath);
-      const zombiePid = Number(fs.readFileSync(pidPath, "utf8"));
-      const deadline = Date.now() + 2_000;
-      for (;;) {
-        const stat = fs.readFileSync(`/proc/${zombiePid}/stat`, "utf8");
-        const commandEnd = stat.lastIndexOf(")");
-        const state = stat
-          .slice(commandEnd + 1)
-          .trim()
-          .split(/\s+/)[0];
-        if (state === "Z") break;
-        if (Date.now() >= deadline) throw new Error("child did not enter zombie state");
-        await new Promise((resolve) => setTimeout(resolve, 5));
+      const zombiePid = await waitForPositivePidFile(pidPath);
+      if (!(await waitForLinuxProcessState(zombiePid, "Z"))) {
+        t.skip("zombie child disappeared before its state could be observed");
+        return;
       }
 
       const target = prepareSafeWriteTarget(

--- a/test/action-ledger-runtime.test.ts
+++ b/test/action-ledger-runtime.test.ts
@@ -1116,6 +1116,163 @@ test("timeout recovery binds an open mutation receipt after an accepted attempt 
   assert.equal(interruptOpenWorkflowActionEvents(root, { env }), 0);
 });
 
+test("interruption recovery preserves any earlier unknown mutation outcome", () => {
+  const root = tempRoot();
+  const env = workflowEnv({
+    CLAWSWEEPER_ACTION_LEDGER_INVOCATION: "apply-unknown-then-accepted",
+    GITHUB_ACTION: "__apply",
+    GITHUB_JOB: "apply-existing",
+  });
+  const operationIdentity = {
+    repository: "openclaw/openclaw",
+    candidateRevisions: [{ number: 54, sourceRevision: "revision-54" }],
+  };
+  const batch = recordWorkflowPhaseEvent(
+    root,
+    {
+      phase: ACTION_EVENT_TYPES.applyBatch,
+      status: ACTION_EVENT_STATUSES.started,
+      reasonCode: ACTION_EVENT_REASON_CODES.selected,
+      retryable: false,
+      mutation: false,
+      identity: { slot: "apply_batch_start" },
+      operation: "apply",
+      operationIdentity,
+      phaseSeq: 1,
+      idempotencyIdentity: { operationIdentity, slot: "apply_batch_start" },
+      component: "apply_decisions",
+      subject: { repository: "openclaw/openclaw", kind: "workflow" },
+    },
+    { env },
+  );
+  assert.ok(batch);
+  const item = recordWorkflowPhaseEvent(
+    root,
+    {
+      phase: ACTION_EVENT_TYPES.applyAction,
+      status: ACTION_EVENT_STATUSES.started,
+      reasonCode: ACTION_EVENT_REASON_CODES.selected,
+      retryable: false,
+      mutation: false,
+      identity: { slot: "apply_item_start", number: 54 },
+      operation: "apply",
+      operationIdentity,
+      parentEventId: batch.event_id,
+      phaseSeq: 10,
+      idempotencyIdentity: {
+        operation: "apply",
+        slot: "apply_item",
+        repository: "openclaw/openclaw",
+        number: 54,
+        sourceRevision: "revision-54",
+      },
+      component: "apply_decisions",
+      subject: {
+        repository: "openclaw/openclaw",
+        kind: "pull_request",
+        number: 54,
+        sourceRevision: "revision-54",
+      },
+    },
+    { env },
+  );
+  assert.ok(item);
+
+  const recordAttempt = (
+    mutationIdentitySha256: string,
+    outcome: "unknown" | "accepted",
+    phaseSeq: number,
+  ): ActionEvent => {
+    const idempotencyIdentity = {
+      operation: "apply",
+      slot: "apply_mutation",
+      repository: "openclaw/openclaw",
+      number: 54,
+      sourceRevision: "revision-54",
+      mutationIdentitySha256,
+    };
+    const attempt = recordWorkflowPhaseEvent(
+      root,
+      {
+        phase: ACTION_EVENT_TYPES.applyAction,
+        status: ACTION_EVENT_STATUSES.started,
+        reasonCode: ACTION_EVENT_REASON_CODES.selected,
+        retryable: true,
+        mutation: false,
+        identity: { slot: "apply_mutation_attempt", mutationIdentitySha256 },
+        operation: "apply",
+        operationIdentity,
+        parentEventId: item.event_id,
+        phaseSeq,
+        idempotencyIdentity,
+        component: "apply_decisions",
+        subject: {
+          repository: "openclaw/openclaw",
+          kind: "pull_request",
+          number: 54,
+          sourceRevision: "revision-54",
+        },
+        attributes: { completion_reason: "mutation_attempted" },
+      },
+      { env },
+    );
+    assert.ok(attempt);
+    const terminal = recordWorkflowPhaseEvent(
+      root,
+      {
+        phase: ACTION_EVENT_TYPES.applyAction,
+        status:
+          outcome === "accepted" ? ACTION_EVENT_STATUSES.executed : ACTION_EVENT_STATUSES.failed,
+        reasonCode:
+          outcome === "accepted"
+            ? ACTION_EVENT_REASON_CODES.completed
+            : ACTION_EVENT_REASON_CODES.unavailable,
+        retryable: outcome === "unknown",
+        mutation: true,
+        identity: { slot: "apply_mutation_outcome", mutationIdentitySha256, outcome },
+        operation: "apply",
+        operationIdentity,
+        parentEventId: attempt.event_id,
+        phaseSeq: phaseSeq + 1,
+        idempotencyIdentity,
+        component: "apply_decisions",
+        subject: {
+          repository: "openclaw/openclaw",
+          kind: "pull_request",
+          number: 54,
+          sourceRevision: "revision-54",
+        },
+        attributes: {
+          completion_reason:
+            outcome === "accepted" ? "mutation_accepted" : "mutation_outcome_unknown",
+        },
+      },
+      { env },
+    );
+    assert.ok(terminal);
+    return terminal;
+  };
+
+  const unknown = recordAttempt("a".repeat(64), "unknown", 11);
+  recordAttempt("b".repeat(64), "accepted", 21);
+
+  assert.equal(interruptOpenWorkflowActionEvents(root, { env }), 2);
+  const allEvents = readAllSpooledActionEvents(root);
+  const recovered = allEvents.filter(
+    (event) =>
+      event.attributes?.completion_reason === "mutation_outcome_unknown" &&
+      event.attributes.partial === true,
+  );
+  assert.equal(recovered.length, 2);
+  assert.ok(recovered.every((event) => event.action.mutation));
+  assert.ok(recovered.every((event) => event.action.retryable === false));
+  const itemTerminal = recovered.find((event) => event.subject.number === 54);
+  assert.equal(itemTerminal?.parent_event_id, unknown.event_id);
+  const batchTerminal = recovered.find((event) => event.subject.kind === "workflow");
+  assert.equal(batchTerminal?.parent_event_id, unknown.event_id);
+  assert.equal(interruptOpenWorkflowActionEvents(root, { env }), 0);
+});
+
 test("interruption recovery closes the exact retry dispatch and aggregates it into the batch", () => {
   const root = tempRoot();
   const env = workflowEnv({
@@ -1239,7 +1396,7 @@ test("interruption recovery preserves cancellation instead of rewriting it as ti
     1,
   );
   const terminal = readAllSpooledActionEvents(root).find(
-    (event) => event.action.status === ACTION_EVENT_STATUSES.failed,
+    (event) => event.action.status === ACTION_EVENT_STATUSES.cancelled,
   );
   assert.equal(terminal?.action.reason_code, ACTION_EVENT_REASON_CODES.cancelled);
   assert.equal(terminal?.attributes?.completion_reason, "cancelled");

--- a/test/action-ledger-runtime.test.ts
+++ b/test/action-ledger-runtime.test.ts
@@ -1116,6 +1116,149 @@ test("timeout recovery binds an open mutation receipt after an accepted attempt 
   assert.equal(interruptOpenWorkflowActionEvents(root, { env }), 0);
 });
 
+test("interruption recovery follows the latest accepted mutation ordinal", () => {
+  const root = tempRoot();
+  const env = workflowEnv({
+    CLAWSWEEPER_ACTION_LEDGER_INVOCATION: "apply-ordered-mutations",
+    GITHUB_ACTION: "__apply",
+    GITHUB_JOB: "apply-existing",
+  });
+  const operationIdentity = {
+    repository: "openclaw/openclaw",
+    candidateRevisions: [{ number: 53, sourceRevision: "revision-53" }],
+  };
+  const batch = recordWorkflowPhaseEvent(
+    root,
+    {
+      phase: ACTION_EVENT_TYPES.applyBatch,
+      status: ACTION_EVENT_STATUSES.started,
+      reasonCode: ACTION_EVENT_REASON_CODES.selected,
+      retryable: false,
+      mutation: false,
+      identity: { slot: "apply_batch_start" },
+      operation: "apply",
+      operationIdentity,
+      phaseSeq: 1,
+      idempotencyIdentity: { operationIdentity, slot: "apply_batch_start" },
+      component: "apply_decisions",
+      subject: { repository: "openclaw/openclaw", kind: "workflow" },
+    },
+    { env },
+  );
+  assert.ok(batch);
+  const item = recordWorkflowPhaseEvent(
+    root,
+    {
+      phase: ACTION_EVENT_TYPES.applyAction,
+      status: ACTION_EVENT_STATUSES.started,
+      reasonCode: ACTION_EVENT_REASON_CODES.selected,
+      retryable: false,
+      mutation: false,
+      identity: { slot: "apply_item_start", number: 53 },
+      operation: "apply",
+      operationIdentity,
+      parentEventId: batch.event_id,
+      phaseSeq: 2,
+      idempotencyIdentity: {
+        operation: "apply",
+        slot: "apply_item",
+        repository: "openclaw/openclaw",
+        number: 53,
+        sourceRevision: "revision-53",
+      },
+      component: "apply_decisions",
+      subject: {
+        repository: "openclaw/openclaw",
+        kind: "pull_request",
+        number: 53,
+        sourceRevision: "revision-53",
+      },
+    },
+    { env },
+  );
+  assert.ok(item);
+
+  let parentEventId = item.event_id;
+  let latestOutcome: ActionEvent | null = null;
+  for (const [index, mutationIdentitySha256] of ["f".repeat(64), "0".repeat(64)].entries()) {
+    const idempotencyIdentity = {
+      operation: "apply",
+      slot: "apply_mutation",
+      repository: "openclaw/openclaw",
+      number: 53,
+      sourceRevision: "revision-53",
+      mutationIdentitySha256,
+    };
+    const attempt = recordWorkflowPhaseEvent(
+      root,
+      {
+        phase: ACTION_EVENT_TYPES.applyAction,
+        status: ACTION_EVENT_STATUSES.started,
+        reasonCode: ACTION_EVENT_REASON_CODES.selected,
+        retryable: true,
+        mutation: false,
+        identity: { slot: "apply_mutation_attempt", mutationIdentitySha256 },
+        operation: "apply",
+        operationIdentity,
+        parentEventId,
+        phaseSeq: 3 + index * 2,
+        idempotencyIdentity,
+        component: "apply_decisions",
+        subject: {
+          repository: "openclaw/openclaw",
+          kind: "pull_request",
+          number: 53,
+          sourceRevision: "revision-53",
+        },
+        attributes: { completion_reason: "mutation_attempted" },
+      },
+      { env },
+    );
+    assert.ok(attempt);
+    const outcome = recordWorkflowPhaseEvent(
+      root,
+      {
+        phase: ACTION_EVENT_TYPES.applyAction,
+        status: ACTION_EVENT_STATUSES.executed,
+        reasonCode: ACTION_EVENT_REASON_CODES.completed,
+        retryable: false,
+        mutation: true,
+        identity: { slot: "apply_mutation_outcome", mutationIdentitySha256, outcome: "accepted" },
+        operation: "apply",
+        operationIdentity,
+        parentEventId: attempt.event_id,
+        phaseSeq: 4 + index * 2,
+        idempotencyIdentity,
+        component: "apply_decisions",
+        subject: {
+          repository: "openclaw/openclaw",
+          kind: "pull_request",
+          number: 53,
+          sourceRevision: "revision-53",
+        },
+        attributes: { completion_reason: "mutation_accepted" },
+      },
+      { env },
+    );
+    assert.ok(outcome);
+    parentEventId = outcome.event_id;
+    latestOutcome = outcome;
+  }
+
+  assert.ok(latestOutcome);
+  assert.equal(interruptOpenWorkflowActionEvents(root, { env }), 2);
+  const recoveredItem = readAllSpooledActionEvents(root).find(
+    (event) =>
+      event.subject.number === 53 &&
+      event.attributes?.completion_reason === "timeout" &&
+      event.attributes.partial === true,
+  );
+  assert.ok(recoveredItem);
+  assert.equal(recoveredItem.parent_event_id, latestOutcome.event_id);
+  assert.equal(recoveredItem.action.mutation, true);
+  assert.equal(recoveredItem.action.retryable, true);
+});
+
 test("interruption recovery preserves any earlier unknown mutation outcome", () => {
   const root = tempRoot();
   const env = workflowEnv({

--- a/test/action-ledger-runtime.test.ts
+++ b/test/action-ledger-runtime.test.ts
@@ -825,7 +825,7 @@ test("timeout recovery preserves hard-killed apply mutation truth and ignores un
   assert.equal(events.filter((event) => event.subject.number === 43).length, 0);
 });
 
-test("timeout recovery binds an open mutation receipt after an accepted attempt exactly", () => {
+test("timeout recovery terminalizes the latest open mutation before its item summary", () => {
   const root = tempRoot();
   const env = workflowEnv({
     CLAWSWEEPER_ACTION_LEDGER_INVOCATION: "apply-uncertain",
@@ -1092,18 +1092,21 @@ test("timeout recovery binds an open mutation receipt after an accepted attempt 
   );
   assert.equal(recovered.length, 3);
   assert.ok(recovered.every((event) => event.action.mutation));
-  const recoveredItem = recovered.find(
-    (event) =>
-      event.subject.number === 52 && event.idempotency_key_sha256 === item.idempotency_key_sha256,
-  );
-  assert.ok(recoveredItem);
-  assert.equal(recoveredItem.parent_event_id, attempt.event_id);
   const recoveredAttempt = recovered.find(
     (event) => event.idempotency_key_sha256 === attempt.idempotency_key_sha256,
   );
   assert.ok(recoveredAttempt);
   assert.equal(recoveredAttempt.parent_event_id, attempt.event_id);
   assert.notEqual(recoveredAttempt.parent_event_id, acceptedOutcome.event_id);
+  assert.ok(acceptedOutcome.phase_seq < attempt.phase_seq);
+  assert.ok(attempt.phase_seq < recoveredAttempt.phase_seq);
+  const recoveredItem = recovered.find(
+    (event) =>
+      event.subject.number === 52 && event.idempotency_key_sha256 === item.idempotency_key_sha256,
+  );
+  assert.ok(recoveredItem);
+  assert.equal(recoveredItem.parent_event_id, recoveredAttempt.event_id);
+  assert.ok(recoveredAttempt.phase_seq < recoveredItem.phase_seq);
   const rejectedRecovery = events.find(
     (event) =>
       event.subject.number === 53 &&
@@ -1574,9 +1577,13 @@ test("interruption recovery preserves any earlier unknown mutation outcome", () 
   assert.ok(recovered.every((event) => event.action.mutation));
   assert.ok(recovered.every((event) => event.action.retryable === false));
   const itemTerminal = recovered.find((event) => event.subject.number === 54);
+  assert.ok(itemTerminal);
   assert.equal(itemTerminal?.parent_event_id, unknown.event_id);
+  assert.ok(unknown.phase_seq < itemTerminal.phase_seq);
   const batchTerminal = recovered.find((event) => event.subject.kind === "workflow");
-  assert.equal(batchTerminal?.parent_event_id, unknown.event_id);
+  assert.ok(batchTerminal);
+  assert.equal(batchTerminal.parent_event_id, itemTerminal.event_id);
+  assert.ok(itemTerminal.phase_seq < batchTerminal.phase_seq);
   assert.equal(interruptOpenWorkflowActionEvents(root, { env }), 0);
 });
 
@@ -1669,6 +1676,8 @@ test("interruption recovery closes the exact retry dispatch and aggregates it in
       event.phase_seq === 1_000_000,
   );
   assert.ok(batchTerminal);
+  assert.equal(batchTerminal.parent_event_id, dispatchTerminal.event_id);
+  assert.ok(dispatchTerminal.phase_seq < batchTerminal.phase_seq);
   assert.equal(batchTerminal.action.mutation, true);
   assert.equal(batchTerminal.action.retryable, false);
   assert.equal(interruptOpenWorkflowActionEvents(root, { env }), 0);

--- a/test/action-ledger-runtime.test.ts
+++ b/test/action-ledger-runtime.test.ts
@@ -8,6 +8,7 @@ import test from "node:test";
 import { pathToFileURL } from "node:url";
 
 import {
+  ACTION_EVENT_SHARD_IMPORT_MAX_PUBLISH_PATHS,
   ACTION_EVENT_SHARD_IMPORT_LIMITS,
   CRABFLEET_PROJECTION_LIMITS,
   flushPendingCrabFleetPosts,
@@ -771,6 +772,224 @@ test("timeout recovery preserves hard-killed apply mutation truth and ignores un
     0,
   );
   assert.equal(events.filter((event) => event.subject.number === 43).length, 0);
+});
+
+test("timeout recovery treats an open pre-dispatch mutation receipt as outcome unknown", () => {
+  const root = tempRoot();
+  const env = workflowEnv({
+    CLAWSWEEPER_ACTION_LEDGER_INVOCATION: "apply-uncertain",
+    GITHUB_ACTION: "__apply",
+    GITHUB_JOB: "apply-existing",
+  });
+  const operationIdentity = {
+    repository: "openclaw/openclaw",
+    candidateRevisions: [{ number: 52, sourceRevision: "revision-52" }],
+  };
+  const batch = recordWorkflowPhaseEvent(
+    root,
+    {
+      phase: ACTION_EVENT_TYPES.applyBatch,
+      status: ACTION_EVENT_STATUSES.started,
+      reasonCode: ACTION_EVENT_REASON_CODES.selected,
+      retryable: false,
+      mutation: false,
+      identity: { slot: "apply_batch_start" },
+      operation: "apply",
+      operationIdentity,
+      phaseSeq: 1,
+      idempotencyIdentity: { operationIdentity, slot: "apply_batch_start" },
+      component: "apply_decisions",
+      subject: { repository: "openclaw/openclaw", kind: "workflow" },
+    },
+    { env },
+  );
+  assert.ok(batch);
+  const item = recordWorkflowPhaseEvent(
+    root,
+    {
+      phase: ACTION_EVENT_TYPES.applyAction,
+      status: ACTION_EVENT_STATUSES.started,
+      reasonCode: ACTION_EVENT_REASON_CODES.selected,
+      retryable: false,
+      mutation: false,
+      identity: { slot: "apply_item_start", number: 52 },
+      operation: "apply",
+      operationIdentity,
+      parentEventId: batch.event_id,
+      phaseSeq: 10,
+      idempotencyIdentity: {
+        operation: "apply",
+        slot: "apply_item",
+        repository: "openclaw/openclaw",
+        number: 52,
+        sourceRevision: "revision-52",
+      },
+      component: "apply_decisions",
+      subject: {
+        repository: "openclaw/openclaw",
+        kind: "pull_request",
+        number: 52,
+        sourceRevision: "revision-52",
+      },
+    },
+    { env },
+  );
+  assert.ok(item);
+  const attempt = recordWorkflowPhaseEvent(
+    root,
+    {
+      phase: ACTION_EVENT_TYPES.applyAction,
+      status: ACTION_EVENT_STATUSES.started,
+      reasonCode: ACTION_EVENT_REASON_CODES.selected,
+      retryable: false,
+      mutation: false,
+      identity: { slot: "apply_mutation_attempt", mutationIdentitySha256: "a".repeat(64) },
+      operation: "apply",
+      operationIdentity,
+      parentEventId: item.event_id,
+      phaseSeq: 11,
+      idempotencyIdentity: {
+        operation: "apply",
+        slot: "apply_mutation",
+        repository: "openclaw/openclaw",
+        number: 52,
+        sourceRevision: "revision-52",
+        mutationIdentitySha256: "a".repeat(64),
+      },
+      component: "apply_decisions",
+      subject: {
+        repository: "openclaw/openclaw",
+        kind: "pull_request",
+        number: 52,
+        sourceRevision: "revision-52",
+      },
+      attributes: { completion_reason: "mutation_attempted" },
+    },
+    { env },
+  );
+  assert.ok(attempt);
+  const rejectedItem = recordWorkflowPhaseEvent(
+    root,
+    {
+      phase: ACTION_EVENT_TYPES.applyAction,
+      status: ACTION_EVENT_STATUSES.started,
+      reasonCode: ACTION_EVENT_REASON_CODES.selected,
+      retryable: false,
+      mutation: false,
+      identity: { slot: "apply_item_start", number: 53 },
+      operation: "apply",
+      operationIdentity,
+      parentEventId: batch.event_id,
+      phaseSeq: 30,
+      idempotencyIdentity: {
+        operation: "apply",
+        slot: "apply_item",
+        repository: "openclaw/openclaw",
+        number: 53,
+        sourceRevision: "revision-53",
+      },
+      component: "apply_decisions",
+      subject: {
+        repository: "openclaw/openclaw",
+        kind: "pull_request",
+        number: 53,
+        sourceRevision: "revision-53",
+      },
+    },
+    { env },
+  );
+  assert.ok(rejectedItem);
+  const rejectedAttempt = recordWorkflowPhaseEvent(
+    root,
+    {
+      phase: ACTION_EVENT_TYPES.applyAction,
+      status: ACTION_EVENT_STATUSES.started,
+      reasonCode: ACTION_EVENT_REASON_CODES.selected,
+      retryable: false,
+      mutation: false,
+      identity: { slot: "apply_mutation_attempt", mutationIdentitySha256: "b".repeat(64) },
+      operation: "apply",
+      operationIdentity,
+      parentEventId: rejectedItem.event_id,
+      phaseSeq: 31,
+      idempotencyIdentity: {
+        operation: "apply",
+        slot: "apply_mutation",
+        repository: "openclaw/openclaw",
+        number: 53,
+        sourceRevision: "revision-53",
+        mutationIdentitySha256: "b".repeat(64),
+      },
+      component: "apply_decisions",
+      subject: {
+        repository: "openclaw/openclaw",
+        kind: "pull_request",
+        number: 53,
+        sourceRevision: "revision-53",
+      },
+      attributes: { completion_reason: "mutation_attempted" },
+    },
+    { env },
+  );
+  assert.ok(rejectedAttempt);
+  const rejectedOutcome = recordWorkflowPhaseEvent(
+    root,
+    {
+      phase: ACTION_EVENT_TYPES.applyAction,
+      status: ACTION_EVENT_STATUSES.skipped,
+      reasonCode: ACTION_EVENT_REASON_CODES.notApplicable,
+      retryable: false,
+      mutation: false,
+      identity: { slot: "apply_mutation_outcome", outcome: "rejected" },
+      operation: "apply",
+      operationIdentity,
+      parentEventId: rejectedAttempt.event_id,
+      phaseSeq: 32,
+      idempotencyIdentity: {
+        operation: "apply",
+        slot: "apply_mutation",
+        repository: "openclaw/openclaw",
+        number: 53,
+        sourceRevision: "revision-53",
+        mutationIdentitySha256: "b".repeat(64),
+      },
+      component: "apply_decisions",
+      subject: {
+        repository: "openclaw/openclaw",
+        kind: "pull_request",
+        number: 53,
+        sourceRevision: "revision-53",
+      },
+      attributes: { completion_reason: "mutation_rejected" },
+    },
+    { env },
+  );
+  assert.ok(rejectedOutcome);
+
+  assert.equal(interruptOpenWorkflowActionEvents(root, { env }), 3);
+  const events = readAllSpooledActionEvents(root);
+  const recovered = events.filter(
+    (event) =>
+      event.action.status === ACTION_EVENT_STATUSES.failed &&
+      event.attributes?.completion_reason === "mutation_outcome_unknown",
+  );
+  assert.equal(recovered.length, 2);
+  assert.ok(recovered.every((event) => event.action.mutation));
+  const recoveredItem = recovered.find(
+    (event) =>
+      event.subject.number === 52 && event.idempotency_key_sha256 === item.idempotency_key_sha256,
+  );
+  assert.ok(recoveredItem);
+  assert.equal(recoveredItem.parent_event_id, attempt.event_id);
+  const rejectedRecovery = events.find(
+    (event) =>
+      event.subject.number === 53 &&
+      event.action.status === ACTION_EVENT_STATUSES.failed &&
+      event.attributes?.completion_reason === "timeout",
+  );
+  assert.ok(rejectedRecovery);
+  assert.equal(rejectedRecovery.action.mutation, false);
+  assert.equal(rejectedRecovery.parent_event_id, rejectedOutcome.event_id);
 });
 
 test("workflow retries preserve operation and idempotency identity but change attempts", () => {
@@ -1818,7 +2037,7 @@ test("full producer identity prevents cross-repository shard collisions", async 
 
   const imported = importActionEventShards(outputRoot, destination);
   assert.equal(imported.created, 2);
-  assert.deepEqual(imported.paths, paths);
+  assert.deepEqual(imported.eventPaths, paths);
 });
 
 test("CrabFleet projection sends the validated ledger event and bearer token", async () => {
@@ -2887,7 +3106,7 @@ test("state shard imports are validated, create-only, and conflict detecting", a
   });
 
   const created = importActionEventShards(source, destination);
-  const destinationDirectory = path.dirname(path.join(destination, created.paths[0]!));
+  const destinationDirectory = path.dirname(path.join(destination, created.eventPaths[0]!));
   const replayed = importActionEventShards(source, destination);
   assert.equal(created.created, 1);
   assert.equal(replayed.unchanged, 1);
@@ -2896,7 +3115,7 @@ test("state shard imports are validated, create-only, and conflict detecting", a
     [],
   );
 
-  const shard = path.join(source, created.paths[0]!);
+  const shard = path.join(source, created.eventPaths[0]!);
   fs.appendFileSync(shard, "\n", "utf8");
   assert.throws(
     () => importActionEventShards(source, destination),
@@ -3331,7 +3550,7 @@ test("state shard imports accept a complete 4097-event producer run", () => {
   const imported = importActionEventShards(source, destination);
   assert.equal(imported.created, shards.length);
   assert.equal(
-    imported.paths.reduce(
+    imported.eventPaths.reduce(
       (count, relativePath) =>
         count +
         fs.readFileSync(path.join(destination, relativePath), "utf8").trim().split("\n").length,
@@ -3385,7 +3604,7 @@ test("state shard imports preserve chronological ordering across timestamp offse
   const imported = importActionEventShards(source, destination);
   assert.equal(imported.created, 1);
   const eventTypes = fs
-    .readFileSync(path.join(destination, imported.paths[0]!), "utf8")
+    .readFileSync(path.join(destination, imported.eventPaths[0]!), "utf8")
     .trim()
     .split("\n")
     .map((line) => JSON.parse(line).event_type);
@@ -3459,7 +3678,7 @@ test("state shard imports accept exact sub-millisecond canonical ordering", asyn
   const imported = importActionEventShards(source, destination);
   assert.equal(imported.created, 1);
   const occurredAt = fs
-    .readFileSync(path.join(destination, imported.paths[0]!), "utf8")
+    .readFileSync(path.join(destination, imported.eventPaths[0]!), "utf8")
     .trim()
     .split("\n")
     .map((line) => JSON.parse(line).occurred_at);
@@ -3548,6 +3767,9 @@ test("state shard imports ignore unrelated entries and reject links in the ledge
   assert.deepEqual(importActionEventShards(source, emptyDestination), {
     created: 0,
     unchanged: 0,
+    eventPaths: [],
+    reservationPaths: [],
+    completionPaths: [],
     paths: [],
   });
   createDirectoryLink(linked, path.join(source, "ledger"));
@@ -3688,7 +3910,24 @@ importActionEventShards(process.argv[1], process.argv[2]);`;
     const replay = importActionEventShards(source, destination);
     assert.equal(replay.created, 1);
     assert.equal(replay.unchanged, 1);
-    assert.deepEqual(replay.paths, sourceShards.map((shard) => shard.relativePath).sort());
+    assert.deepEqual(replay.eventPaths, sourceShards.map((shard) => shard.relativePath).sort());
+    assert.ok(replay.reservationPaths.length > 0);
+    assert.ok(replay.completionPaths.length > 0);
+    assert.deepEqual(
+      replay.paths,
+      [...replay.eventPaths, ...replay.reservationPaths, ...replay.completionPaths].sort(),
+    );
+    assert.ok(replay.paths.length <= ACTION_EVENT_SHARD_IMPORT_MAX_PUBLISH_PATHS);
+    const freshState = trustedChildRoot(root, "fresh-state");
+    for (const relativePath of replay.paths) {
+      const target = path.join(freshState, relativePath);
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.copyFileSync(path.join(destination, relativePath), target);
+    }
+    assert.throws(
+      () => importActionEventShards(replacementSource, freshState),
+      /producer shard-set binding conflict/,
+    );
     for (const shard of sourceShards) {
       assert.equal(
         fs.readFileSync(path.join(destination, shard.relativePath), "utf8"),

--- a/test/action-ledger-runtime.test.ts
+++ b/test/action-ledger-runtime.test.ts
@@ -1116,6 +1116,135 @@ test("timeout recovery binds an open mutation receipt after an accepted attempt 
   assert.equal(interruptOpenWorkflowActionEvents(root, { env }), 0);
 });
 
+test("interruption recovery closes the exact retry dispatch and aggregates it into the batch", () => {
+  const root = tempRoot();
+  const env = workflowEnv({
+    CLAWSWEEPER_ACTION_LEDGER_INVOCATION: "retry-0",
+    GITHUB_ACTION: "__retry",
+    GITHUB_JOB: "retry-failed-reviews",
+  });
+  const operationIdentity = {
+    repository: "openclaw/openclaw",
+    requestedItemNumbers: [42],
+  };
+  const batch = recordWorkflowPhaseEvent(
+    root,
+    {
+      phase: ACTION_EVENT_TYPES.reviewRetry,
+      status: ACTION_EVENT_STATUSES.started,
+      reasonCode: ACTION_EVENT_REASON_CODES.selected,
+      retryable: false,
+      mutation: false,
+      identity: { slot: "retry_batch_start" },
+      operation: "review_retry",
+      operationIdentity,
+      phaseSeq: 1,
+      idempotencyIdentity: { operationIdentity, slot: "retry_batch_start" },
+      component: "retry_failed_reviews",
+      subject: { repository: "openclaw/openclaw", kind: "workflow" },
+    },
+    { env },
+  );
+  assert.ok(batch);
+  const dispatch = recordWorkflowPhaseEvent(
+    root,
+    {
+      phase: ACTION_EVENT_TYPES.reviewRetry,
+      status: ACTION_EVENT_STATUSES.started,
+      reasonCode: ACTION_EVENT_REASON_CODES.selected,
+      retryable: false,
+      mutation: false,
+      identity: { slot: "retry_dispatch_attempt", number: 42 },
+      operation: "review_retry",
+      operationIdentity,
+      parentEventId: batch.event_id,
+      phaseSeq: 100_000,
+      idempotencyIdentity: {
+        operation: "review_retry",
+        slot: "retry_dispatch",
+        repository: "openclaw/openclaw",
+        number: 42,
+        sourceRevision: "revision-42",
+      },
+      component: "retry_failed_reviews",
+      subject: {
+        repository: "openclaw/openclaw",
+        kind: "issue",
+        number: 42,
+        sourceRevision: "revision-42",
+      },
+      attributes: { completion_reason: "dispatch_attempted" },
+    },
+    { env },
+  );
+  assert.ok(dispatch);
+
+  assert.equal(
+    interruptOpenWorkflowActionEvents(root, {
+      env,
+      reasonCode: ACTION_EVENT_REASON_CODES.workflowFailed,
+    }),
+    2,
+  );
+  const events = readAllSpooledActionEvents(root);
+  const dispatchTerminal = events.find(
+    (event) =>
+      event.parent_event_id === dispatch.event_id &&
+      event.subject.number === 42 &&
+      event.attributes?.completion_reason === "dispatch_outcome_unknown",
+  );
+  assert.ok(dispatchTerminal);
+  assert.equal(dispatchTerminal.idempotency_key_sha256, dispatch.idempotency_key_sha256);
+  assert.equal(dispatchTerminal.action.retryable, false);
+  assert.equal(dispatchTerminal.action.mutation, true);
+
+  const batchTerminal = events.find(
+    (event) =>
+      event.subject.kind === "workflow" &&
+      event.action.status === ACTION_EVENT_STATUSES.failed &&
+      event.phase_seq === 1_000_000,
+  );
+  assert.ok(batchTerminal);
+  assert.equal(batchTerminal.action.mutation, true);
+  assert.equal(batchTerminal.action.retryable, false);
+  assert.equal(interruptOpenWorkflowActionEvents(root, { env }), 0);
+});
+
+test("interruption recovery preserves cancellation instead of rewriting it as timeout", () => {
+  const root = tempRoot();
+  const env = workflowEnv({ CLAWSWEEPER_ACTION_LEDGER_INVOCATION: "cancelled-review" });
+  recordWorkflowPhaseEvent(
+    root,
+    {
+      phase: ACTION_EVENT_TYPES.reviewBatch,
+      status: ACTION_EVENT_STATUSES.started,
+      reasonCode: ACTION_EVENT_REASON_CODES.selected,
+      retryable: false,
+      mutation: false,
+      identity: { slot: "review_batch_start" },
+      operation: "review",
+      operationIdentity: { repository: "openclaw/openclaw" },
+      phaseSeq: 1,
+      component: "review",
+      subject: { repository: "openclaw/openclaw", kind: "workflow" },
+    },
+    { env },
+  );
+
+  assert.equal(
+    interruptOpenWorkflowActionEvents(root, {
+      env,
+      reasonCode: ACTION_EVENT_REASON_CODES.cancelled,
+    }),
+    1,
+  );
+  const terminal = readAllSpooledActionEvents(root).find(
+    (event) => event.action.status === ACTION_EVENT_STATUSES.failed,
+  );
+  assert.equal(terminal?.action.reason_code, ACTION_EVENT_REASON_CODES.cancelled);
+  assert.equal(terminal?.attributes?.completion_reason, "cancelled");
+});
+
 test("workflow retries preserve operation and idempotency identity but change attempts", () => {
   const root = tempRoot();
   const input = {
@@ -3239,6 +3368,48 @@ test("state shard imports are validated, create-only, and conflict detecting", a
   assert.throws(
     () => importActionEventShards(source, destination),
     /action event shard content is not canonical/,
+  );
+});
+
+test("state shard imports reject producer provenance outside the authenticated workflow job", async () => {
+  const root = tempRoot();
+  const source = trustedChildRoot(root, "source");
+  const destination = trustedChildRoot(root, "destination");
+  const event = recordReview(root);
+  assert.ok(event);
+  await flushWorkflowActionEvents(root, {
+    env: workflowEnv(),
+    outputRoot: source,
+  });
+
+  assert.throws(
+    () =>
+      importActionEventShards(source, destination, {
+        expectedProducer: {
+          repository: event.producer.repository,
+          sha: event.producer.sha,
+          workflow: event.producer.workflow,
+          job: "publish",
+          runId: event.producer.run_id,
+          runAttempt: event.producer.run_attempt,
+        },
+      }),
+    /producer provenance mismatch for job/,
+  );
+  assert.deepEqual(fs.readdirSync(destination), []);
+
+  assert.equal(
+    importActionEventShards(source, destination, {
+      expectedProducer: {
+        repository: event.producer.repository,
+        sha: event.producer.sha,
+        workflow: event.producer.workflow,
+        job: event.producer.job,
+        runId: event.producer.run_id,
+        runAttempt: event.producer.run_attempt,
+      },
+    }).created,
+    1,
   );
 });
 

--- a/test/action-ledger.test.ts
+++ b/test/action-ledger.test.ts
@@ -1790,7 +1790,7 @@ test("durable shard writers split deterministically within importer event and by
     ["unchanged", "unchanged"],
   );
   assert.equal(imported.created, 2);
-  assert.deepEqual(imported.paths, first.map((result) => result.relativePath).sort());
+  assert.deepEqual(imported.eventPaths, first.map((result) => result.relativePath).sort());
   for (const result of first) {
     assert.ok(fs.statSync(result.path).size <= ACTION_EVENT_SHARD_FILE_LIMITS.maxBytes);
     assert.ok(result.eventCount <= ACTION_EVENT_SHARD_FILE_LIMITS.maxEvents);

--- a/test/clawsweeper-action-ledger.test.ts
+++ b/test/clawsweeper-action-ledger.test.ts
@@ -6,6 +6,7 @@ import {
   actionLedgerFailureDisposition,
   applyActionEventDisposition,
   applyItemBusinessIdempotencyIdentityForTest,
+  applyMutationBusinessIdempotencyIdentityForTest,
   applyPhaseSequenceForTest,
   applyRuntimeBudgetYieldResultsForTest,
   classifyGitHubDispatchResultForTest,
@@ -225,6 +226,30 @@ test("apply and retry business idempotency ignore batch order but bind source re
     ),
     applyKey,
   );
+  const mutationIdentity = {
+    repository: applyIdentity.repository,
+    number: applyIdentity.number,
+    sourceRevision: applyIdentity.sourceRevision,
+    reviewContentDigest: applyIdentity.reviewContentDigest,
+    decisionPacketSha256: applyIdentity.decisionPacketSha256,
+    mutationIdentity: "review_comment_post:512",
+  };
+  const mutationKey = actionIdempotencyKey(
+    applyMutationBusinessIdempotencyIdentityForTest(mutationIdentity),
+  );
+  assert.equal(
+    actionIdempotencyKey(applyMutationBusinessIdempotencyIdentityForTest(mutationIdentity)),
+    mutationKey,
+  );
+  assert.notEqual(
+    actionIdempotencyKey(
+      applyMutationBusinessIdempotencyIdentityForTest({
+        ...mutationIdentity,
+        mutationIdentity: "review_comment_delete:512",
+      }),
+    ),
+    mutationKey,
+  );
 
   const retryIdentity = {
     repository: "openclaw/openclaw",
@@ -292,14 +317,13 @@ test("lane instrumentation uses stable slots with explicit parent and phase orde
   }
 
   assert.match(source, /parentEventId: ledger\.batchStartEventId/);
-  assert.match(source, /parentEventId: state\.startEventId/);
+  assert.match(source, /parentEventId: state\.lastEventId \?\? state\.startEventId/);
   assert.match(
     source,
     /parentEventId: options\.state\.lastEventId \?\? options\.state\.startEventId/,
   );
-  assert.match(source, /phaseSeq: 10 \+ state\.index \* 10/);
-  assert.match(source, /phaseSeq: 11 \+ state\.index \* 10/);
-  assert.match(source, /phaseSeq: 12 \+ state\.index \* 10/);
+  assert.match(source, /function nextReviewPhaseSeq\(/);
+  assert.match(source, /phaseSeq: nextReviewPhaseSeq\(options\.ledger\)/);
   assert.match(source, /phaseSeq: 1_000_000/);
   assert.match(source, /if \(!state\.logPublication\) \{\s*recordReviewLogPublication\(/);
 
@@ -348,11 +372,50 @@ test("review candidates start lazily and deferred items cannot remain active", (
     reviewLoop,
     /activeReviewItem = item;[\s\S]*startReviewActionLedgerItem\(reviewLedger, item\)/,
   );
+  assert.match(
+    reviewLoop,
+    /activeReviewMutationRunner = reviewMutationRunner\(reviewLedger, item\)/,
+  );
   assert.match(reviewLoop, /catch \(error\) \{\s*reviewItemFailed = true;\s*throw error;/);
   assert.match(
     reviewLoop,
     /finally \{[\s\S]*!reviewItemFailed[\s\S]*finishReviewActionLedgerItem\(\{[\s\S]*completionReason: "coordination_deferred"[\s\S]*activeReviewItem = null;/,
   );
+  const reviewMutationAttempt = source.slice(
+    source.indexOf("function startReviewMutationAttempt("),
+    source.indexOf("function recordReviewLogPublication("),
+  );
+  assert.match(reviewMutationAttempt, /completion_reason: "mutation_attempted"/);
+  assert.match(reviewMutationAttempt, /"mutation_accepted"/);
+  assert.match(reviewMutationAttempt, /"mutation_rejected"/);
+  assert.match(reviewMutationAttempt, /"mutation_outcome_unknown"/);
+  assert.match(reviewMutationAttempt, /mutationIdentitySha256: sha256\(idempotencyIdentity\)/);
+  const reviewItemTerminal = source.slice(
+    source.indexOf("function finishReviewActionLedgerItem("),
+    source.indexOf("export function actionLedgerFailureDisposition("),
+  );
+  assert.match(reviewItemTerminal, /mutation: state\.mutationObserved/);
+  const reviewBatchTerminal = source.slice(
+    source.indexOf("function finishReviewActionLedger(options:"),
+    source.indexOf("function reviewCommand(args:"),
+  );
+  assert.match(reviewBatchTerminal, /mutation: options\.ledger\.mutationObserved/);
+
+  const reviewCommandStart = source.indexOf("function reviewCommand(args:");
+  const reviewCatchStart = source.indexOf(
+    "  } catch (error) {\n    if (reviewLedger) {",
+    reviewCommandStart,
+  );
+  const reviewCatch = source.slice(
+    reviewCatchStart,
+    source.indexOf("restoreTreeModes(readonlyModeSnapshots)", reviewCatchStart),
+  );
+  const cleanup = reviewCatch.indexOf(
+    "deleteOwnedDedicatedReviewStartLease(acquired.itemNumber, acquired.lease)",
+  );
+  const finalization = reviewCatch.indexOf("finishReviewActionLedger({");
+  assert.ok(cleanup >= 0);
+  assert.ok(finalization > cleanup);
 });
 
 test("apply receipts start per item and persist mutation observation before finalization", () => {
@@ -381,16 +444,17 @@ test("apply receipts start per item and persist mutation observation before fina
   assert.match(applyLoop, /closeItem\(\{ number, kind: item\.kind/);
   const mutationAttemptStart = source.indexOf("function startApplyMutationAttempt(");
   const mutationIdentityStart = source.indexOf(
-    "const idempotencyIdentity = {",
+    "const businessIdempotencyIdentity = applyMutationBusinessIdempotencyIdentityForTest({",
     mutationAttemptStart,
   );
   const mutationIdentity = source.slice(
     mutationIdentityStart,
-    source.indexOf("const phaseSeq =", mutationIdentityStart),
+    source.indexOf("const receiptIdentitySha256 =", mutationIdentityStart),
   );
-  assert.match(mutationIdentity, /mutationIdentitySha256: sha256\(identity\)/);
+  assert.match(mutationIdentity, /mutationIdentity: idempotencyIdentity/);
   assert.doesNotMatch(mutationIdentity, /mutationIndex/);
   assert.match(source, /identity: `\$\{options\.identity\}:request_attempt:\$\{attempt \+ 1\}`/);
+  assert.match(source, /idempotencyIdentity: options\.identity/);
   assert.match(
     applyLoop,
     /finally \{[\s\S]*recordApplyActionLedgerItemResults\(\{[\s\S]*activeApplyItem = null;/,
@@ -415,12 +479,27 @@ test("apply mutation receipts bind every GitHub request attempt and preserve no-
     true,
   );
   assert.equal(isGitHubLabelAlreadyExistsErrorForTest("HTTP 500: unavailable"), false);
-  assert.deepEqual(observedGitHubMutationAttemptsForTest(["transient", "accepted"]), [
-    { identity: "test_mutation:request_attempt:1", outcome: "unknown" },
-    { identity: "test_mutation:request_attempt:2", outcome: "accepted" },
+  const retriedMutation = observedGitHubMutationAttemptsForTest(["transient", "accepted"]);
+  assert.deepEqual(retriedMutation, [
+    {
+      identity: "test_mutation:request_attempt:1",
+      idempotencyIdentity: "test_mutation",
+      outcome: "unknown",
+    },
+    {
+      identity: "test_mutation:request_attempt:2",
+      idempotencyIdentity: "test_mutation",
+      outcome: "accepted",
+    },
   ]);
+  assert.notEqual(retriedMutation[0]?.identity, retriedMutation[1]?.identity);
+  assert.equal(retriedMutation[0]?.idempotencyIdentity, retriedMutation[1]?.idempotencyIdentity);
   assert.deepEqual(observedGitHubMutationAttemptsForTest(["already_exists"]), [
-    { identity: "test_mutation:request_attempt:1", outcome: "rejected" },
+    {
+      identity: "test_mutation:request_attempt:1",
+      idempotencyIdentity: "test_mutation",
+      outcome: "rejected",
+    },
   ]);
   assert.deepEqual(observedGitHubMutationAttemptsForTest(["not_started"]), []);
   assert.deepEqual(heldReviewStartStatusCommentResultForTest("2026-07-12T12:00:00Z", false), {

--- a/test/clawsweeper-action-ledger.test.ts
+++ b/test/clawsweeper-action-ledger.test.ts
@@ -99,13 +99,20 @@ test("review and apply outcome classifiers cover terminal and resumable states",
   assert.deepEqual(
     reviewCommentPublicationEventDisposition("review_comment_synced", false, false),
     {
-      status: "published",
-      reasonCode: "published",
+      status: "unchanged",
+      reasonCode: "content_unchanged",
       retryable: false,
       mutation: false,
-      completionReason: "comment_published",
+      completionReason: "comment_unchanged",
     },
   );
+  assert.deepEqual(applyActionEventDisposition("review_comment_synced", true, false, false), {
+    status: "unchanged",
+    reasonCode: "content_unchanged",
+    retryable: false,
+    mutation: true,
+    completionReason: "comment_unchanged",
+  });
   assert.deepEqual(reviewCommentPublicationEventDisposition("skipped_comment_auth", true, false), {
     status: "blocked",
     reasonCode: "authorization_failed",
@@ -369,7 +376,7 @@ test("apply receipts start per item and persist mutation observation before fina
   assert.match(applyLoop, /commentMutationOccurred: !dryRun && needsReviewCommentBodySync/);
   assert.match(
     source,
-    /reviewCommentPublicationEventDisposition\(\s*result\.action,\s*result\.commentMutationOccurred === true,/,
+    /const commentMutationOccurred = result\.commentMutationOccurred === true;[\s\S]*applyActionEventDisposition\([\s\S]*commentMutationOccurred,[\s\S]*reviewCommentPublicationEventDisposition\([\s\S]*commentMutationOccurred,/,
   );
   assert.match(applyLoop, /closeItem\(\{ number, kind: item\.kind/);
   const mutationAttemptStart = source.indexOf("function startApplyMutationAttempt(");

--- a/test/clawsweeper-action-ledger.test.ts
+++ b/test/clawsweeper-action-ledger.test.ts
@@ -4,9 +4,12 @@ import test from "node:test";
 import {
   actionLedgerFailureDisposition,
   applyActionEventDisposition,
+  applyItemBusinessIdempotencyIdentityForTest,
   reviewCommentPublicationEventDisposition,
   reviewRetryActionDisposition,
+  reviewRetryBusinessIdempotencyIdentityForTest,
 } from "../dist/clawsweeper.js";
+import { actionIdempotencyKey } from "../dist/action-ledger.js";
 import { readText } from "./helpers.ts";
 
 test("review and apply outcome classifiers cover terminal and resumable states", () => {
@@ -107,6 +110,63 @@ test("failed-review retry events distinguish dispatch, exhaustion, and backpress
   });
 });
 
+test("apply and retry business idempotency ignore batch order but bind source revision", () => {
+  const applyIdentity = {
+    slot: "apply_item" as const,
+    repository: "openclaw/openclaw",
+    number: 512,
+    sourceRevision: "a".repeat(40),
+    reviewContentDigest: "b".repeat(64),
+    decisionPacketSha256: "c".repeat(64),
+  };
+  const applyKey = actionIdempotencyKey(applyItemBusinessIdempotencyIdentityForTest(applyIdentity));
+  assert.equal(
+    actionIdempotencyKey(
+      applyItemBusinessIdempotencyIdentityForTest({
+        ...applyIdentity,
+      }),
+    ),
+    applyKey,
+  );
+  assert.notEqual(
+    actionIdempotencyKey(
+      applyItemBusinessIdempotencyIdentityForTest({
+        ...applyIdentity,
+        sourceRevision: "d".repeat(40),
+      }),
+    ),
+    applyKey,
+  );
+
+  const retryIdentity = {
+    repository: "openclaw/openclaw",
+    number: 512,
+    revisionKind: "pull_head_sha" as const,
+    sourceRevision: "e".repeat(40),
+    slot: "retry_dispatch" as const,
+  };
+  const retryKey = actionIdempotencyKey(
+    reviewRetryBusinessIdempotencyIdentityForTest(retryIdentity),
+  );
+  assert.equal(
+    actionIdempotencyKey(
+      reviewRetryBusinessIdempotencyIdentityForTest({
+        ...retryIdentity,
+      }),
+    ),
+    retryKey,
+  );
+  assert.notEqual(
+    actionIdempotencyKey(
+      reviewRetryBusinessIdempotencyIdentityForTest({
+        ...retryIdentity,
+        sourceRevision: "f".repeat(40),
+      }),
+    ),
+    retryKey,
+  );
+});
+
 test("lane instrumentation uses stable slots with explicit parent and phase ordering", () => {
   const source = readText("src/clawsweeper.ts");
 
@@ -123,14 +183,14 @@ test("lane instrumentation uses stable slots with explicit parent and phase orde
     assert.match(source, new RegExp(`ACTION_EVENT_TYPES\\.${phase}`));
   }
 
-  assert.match(source, /parentEventId: batchStart\?\.event_id \?\? null/);
+  assert.match(source, /parentEventId: ledger\.batchStartEventId/);
   assert.match(source, /parentEventId: state\.startEventId/);
   assert.match(
     source,
-    /parentEventId: actionEvent\?\.event_id \?\? options\.ledger\.batchStartEventId/,
+    /parentEventId:\s*actionEvent\?\.event_id \?\? options\.state\.mutationEventId \?\? options\.state\.startEventId/,
   );
-  assert.match(source, /phaseSeq: 10 \+ index \* 10/);
-  assert.match(source, /phaseSeq: 11 \+ index \* 10/);
+  assert.match(source, /phaseSeq: 10 \+ state\.index \* 10/);
+  assert.match(source, /phaseSeq: 11 \+ state\.index \* 10/);
   assert.match(source, /phaseSeq: 12 \+ state\.index \* 10/);
   assert.match(source, /phaseSeq: 1_000_000/);
   assert.match(source, /if \(!state\.logPublication\) \{\s*recordReviewLogPublication\(/);
@@ -142,6 +202,14 @@ test("lane instrumentation uses stable slots with explicit parent and phase orde
   assert.match(source, /candidateSnapshots: options\.candidates\.map/);
   assert.match(source, /candidateRevisions: options\.candidates\.map/);
   assert.match(source, /slot: "apply_item"/);
+  assert.match(source, /operation: "apply",\s*slot: options\.slot/);
+  assert.doesNotMatch(
+    source.slice(
+      source.indexOf("function applyItemIdempotencyIdentity("),
+      source.indexOf("function applyLedgerItemSubject("),
+    ),
+    /operationIdentity|checkpoint|index/,
+  );
   assert.doesNotMatch(
     source,
     /idempotencyIdentity: \{[^}]{0,300}slot: "apply_(?:result|in_flight_failure)"/,
@@ -153,6 +221,47 @@ test("lane instrumentation uses stable slots with explicit parent and phase orde
   assert.doesNotMatch(
     source,
     /idempotencyIdentity: \{[^}]{0,300}(?:status|reasonCode|completionReason)/,
+  );
+});
+
+test("review candidates start lazily and deferred items cannot remain active", () => {
+  const source = readText("src/clawsweeper.ts");
+  const ledgerStart = source.slice(
+    source.indexOf("function startReviewActionLedger(options:"),
+    source.indexOf("function startReviewActionLedgerItem("),
+  );
+  const reviewLoop = source.slice(
+    source.indexOf("for (const item of candidates) {"),
+    source.indexOf("if (coordinationHeldRetryAt) {"),
+  );
+
+  assert.doesNotMatch(ledgerStart, /status: ACTION_EVENT_STATUSES\.started[\s\S]*reviewItem/);
+  assert.match(
+    reviewLoop,
+    /activeReviewItem = item;[\s\S]*startReviewActionLedgerItem\(reviewLedger, item\)/,
+  );
+  assert.match(reviewLoop, /catch \(error\) \{\s*reviewItemFailed = true;\s*throw error;/);
+  assert.match(
+    reviewLoop,
+    /finally \{[\s\S]*!reviewItemFailed[\s\S]*finishReviewActionLedgerItem\(\{[\s\S]*completionReason: "coordination_deferred"[\s\S]*activeReviewItem = null;/,
+  );
+});
+
+test("apply receipts start per item and persist mutation observation before finalization", () => {
+  const source = readText("src/clawsweeper.ts");
+  const applyLoop = source.slice(
+    source.indexOf("for (const entry of fileEntries) {"),
+    source.indexOf("if (runtimeBudget.yieldReason) {"),
+  );
+
+  assert.match(applyLoop, /startApplyActionLedgerItem\(applyLedger, entry\)/);
+  assert.match(
+    applyLoop,
+    /const recordMutation = \(\): void => \{[\s\S]*mutationByItem\.set[\s\S]*recordApplyMutationBoundary\(applyLedger, entry\)/,
+  );
+  assert.match(
+    applyLoop,
+    /finally \{[\s\S]*recordApplyActionLedgerItemResults\(\{[\s\S]*activeApplyItem = null;/,
   );
 });
 
@@ -220,6 +329,11 @@ test("sweep publishes complete immutable shards for every review and apply produ
   const reviewStep = workflow.indexOf("- name: Review shard");
   const reviewFinalizer = workflow.indexOf("- name: Finalize review action ledger");
   const reviewUpload = workflow.indexOf("name: action-ledger-review-${{ matrix.shard }}");
+  const applyProofStep = workflow.indexOf("- name: Generate bound close coverage proofs");
+  const applyProofFinalizer = workflow.indexOf("- name: Finalize apply proof action ledger");
+  const applyStep = workflow.indexOf("- name: Apply unchanged proposed decisions with checkpoints");
+  const applyFinalizer = workflow.indexOf("- name: Finalize apply action ledger");
+  const applyPublish = workflow.indexOf("- name: Publish apply action events");
 
   assert.ok(reviewStep >= 0);
   assert.ok(reviewFinalizer > reviewStep);
@@ -227,6 +341,27 @@ test("sweep publishes complete immutable shards for every review and apply produ
   assert.match(
     workflow.slice(reviewFinalizer, reviewUpload),
     /if: always\(\)[\s\S]*node dist\/clawsweeper\.js finalize-action-events/,
+  );
+  assert.ok(applyProofStep >= 0);
+  assert.ok(applyProofFinalizer > applyProofStep);
+  assert.match(
+    workflow.slice(applyProofStep, applyProofFinalizer),
+    /id: generate-apply-proofs[\s\S]*timeout-minutes: 50/,
+  );
+  assert.match(
+    workflow.slice(applyProofFinalizer, applyProofFinalizer + 500),
+    /APPLY_PROOF_OUTCOME:[\s\S]*--interrupt-open-attempts --reason timeout/,
+  );
+  assert.ok(applyStep >= 0);
+  assert.ok(applyFinalizer > applyStep);
+  assert.ok(applyPublish > applyFinalizer);
+  assert.match(
+    workflow.slice(applyStep, applyFinalizer),
+    /id: apply-existing-run[\s\S]*timeout-minutes: 350/,
+  );
+  assert.match(
+    workflow.slice(applyFinalizer, applyPublish),
+    /if: \$\{\{ always\(\) \}\}[\s\S]*APPLY_OUTCOME:[\s\S]*--interrupt-open-attempts --reason timeout/,
   );
 
   for (const name of [

--- a/test/clawsweeper-action-ledger.test.ts
+++ b/test/clawsweeper-action-ledger.test.ts
@@ -1,0 +1,253 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  actionLedgerFailureDisposition,
+  applyActionEventDisposition,
+  reviewCommentPublicationEventDisposition,
+  reviewRetryActionDisposition,
+} from "../dist/clawsweeper.js";
+import { readText } from "./helpers.ts";
+
+test("review and apply outcome classifiers cover terminal and resumable states", () => {
+  assert.deepEqual(actionLedgerFailureDisposition(new Error("worker timed out after 30s")), {
+    status: "failed",
+    reasonCode: "timeout",
+    completionReason: "timeout",
+  });
+  assert.deepEqual(actionLedgerFailureDisposition(new Error("process interrupted by SIGINT")), {
+    status: "cancelled",
+    reasonCode: "cancelled",
+    completionReason: "interrupted",
+  });
+  assert.deepEqual(actionLedgerFailureDisposition(new Error("unexpected failure")), {
+    status: "failed",
+    reasonCode: "exception",
+    completionReason: "failed",
+  });
+
+  assert.deepEqual(applyActionEventDisposition("closed", true, false), {
+    status: "completed",
+    reasonCode: "completed",
+    retryable: false,
+    mutation: true,
+    completionReason: "closed",
+  });
+  assert.deepEqual(applyActionEventDisposition("closed", false, true), {
+    status: "planned",
+    reasonCode: "dry_run",
+    retryable: false,
+    mutation: false,
+    completionReason: "dry_run",
+  });
+  assert.deepEqual(applyActionEventDisposition("skipped_runtime_budget", false, false), {
+    status: "yielded",
+    reasonCode: "runtime_budget",
+    retryable: true,
+    mutation: false,
+    completionReason: "runtime_budget",
+  });
+  assert.deepEqual(applyActionEventDisposition("skipped_changed_since_review", false, false), {
+    status: "blocked",
+    reasonCode: "source_changed",
+    retryable: true,
+    mutation: false,
+    completionReason: "source_changed",
+  });
+  assert.deepEqual(reviewCommentPublicationEventDisposition("review_comment_synced", true, false), {
+    status: "published",
+    reasonCode: "published",
+    retryable: false,
+    mutation: true,
+    completionReason: "comment_published",
+  });
+  assert.deepEqual(reviewCommentPublicationEventDisposition("skipped_comment_auth", true, false), {
+    status: "blocked",
+    reasonCode: "authorization_failed",
+    retryable: true,
+    mutation: false,
+    completionReason: "authorization_failed",
+  });
+  assert.deepEqual(
+    reviewCommentPublicationEventDisposition("retry_stale_canonical_comment_sync", false, false),
+    {
+      status: "waiting",
+      reasonCode: "dependency_pending",
+      retryable: true,
+      mutation: false,
+      completionReason: "retry_pending",
+    },
+  );
+});
+
+test("failed-review retry events distinguish dispatch, exhaustion, and backpressure", () => {
+  assert.deepEqual(reviewRetryActionDisposition("dispatched_failed_review_retry"), {
+    status: "dispatched",
+    reasonCode: "retry_scheduled",
+    retryable: true,
+    mutation: true,
+  });
+  assert.deepEqual(reviewRetryActionDisposition("marked_failed_review_retry_exhausted"), {
+    status: "blocked",
+    reasonCode: "retry_exhausted",
+    retryable: false,
+    mutation: true,
+  });
+  assert.deepEqual(reviewRetryActionDisposition("skipped_runtime_budget"), {
+    status: "yielded",
+    reasonCode: "runtime_budget",
+    retryable: true,
+    mutation: false,
+  });
+  assert.deepEqual(reviewRetryActionDisposition("skipped_stale_revision"), {
+    status: "blocked",
+    reasonCode: "source_changed",
+    retryable: false,
+    mutation: false,
+  });
+});
+
+test("lane instrumentation uses stable slots with explicit parent and phase ordering", () => {
+  const source = readText("src/clawsweeper.ts");
+
+  for (const phase of [
+    "reviewBatch",
+    "reviewItem",
+    "reviewRetry",
+    "reviewLogPublication",
+    "reviewCommentPublication",
+    "applyAction",
+    "applyBatch",
+    "applyPublish",
+  ]) {
+    assert.match(source, new RegExp(`ACTION_EVENT_TYPES\\.${phase}`));
+  }
+
+  assert.match(source, /parentEventId: batchStart\?\.event_id \?\? null/);
+  assert.match(source, /parentEventId: state\.startEventId/);
+  assert.match(
+    source,
+    /parentEventId: actionEvent\?\.event_id \?\? options\.ledger\.batchStartEventId/,
+  );
+  assert.match(source, /phaseSeq: 10 \+ index \* 10/);
+  assert.match(source, /phaseSeq: 11 \+ index \* 10/);
+  assert.match(source, /phaseSeq: 12 \+ state\.index \* 10/);
+  assert.match(source, /phaseSeq: 1_000_000/);
+  assert.match(source, /if \(!state\.logPublication\) \{\s*recordReviewLogPublication\(/);
+
+  assert.match(
+    source,
+    /idempotencyIdentity: \{\s*operationIdentity: options\.ledger\.operationIdentity,\s*slot: "apply_batch_terminal"/,
+  );
+  assert.match(
+    source,
+    /idempotencyIdentity: \{\s*operationIdentity: options\.ledger\.operationIdentity,\s*slot: "batch_terminal"/,
+  );
+  assert.doesNotMatch(
+    source,
+    /idempotencyIdentity: \{[^}]{0,300}(?:status|reasonCode|completionReason)/,
+  );
+});
+
+test("apply failure finalization survives report publication errors", () => {
+  const source = readText("src/clawsweeper.ts");
+  const finishApplyStart = source.indexOf(
+    "const finishApply = (failed = false, failure?: unknown): void => {",
+  );
+  const onFailureStart = source.indexOf(
+    "runtimeBudget.onFailure = (error: unknown): void => {",
+    finishApplyStart,
+  );
+  const finishApply = source.slice(finishApplyStart, onFailureStart);
+
+  assert.ok(finishApplyStart >= 0);
+  assert.ok(onFailureStart > finishApplyStart);
+  assert.match(finishApply, /catch \(error\) \{\s*publicationError = error;\s*\}/);
+  assert.ok(
+    finishApply.indexOf("recordApplyActionEvents({") > finishApply.indexOf("catch (error)"),
+  );
+  assert.ok(finishApply.indexOf("if (publicationError) throw publicationError;") > 0);
+  assert.match(
+    source.slice(onFailureStart, source.indexOf("runtimeBudget.onYield", onFailureStart)),
+    /finishApply\(true, error\)/,
+  );
+});
+
+test("retry and review publication lanes finalize unexpected failures", () => {
+  const source = readText("src/clawsweeper.ts");
+  const retryStart = source.indexOf("const retryLedger = startFailedReviewRetryLedger({");
+  const retryRecord = source.indexOf("recordFailedReviewRetryEvents({", retryStart);
+  const retryThrow = source.indexOf("if (commandError) throw commandError;", retryRecord);
+  assert.ok(retryStart >= 0);
+  assert.ok(retryRecord > retryStart);
+  assert.ok(retryThrow > retryRecord);
+  assert.match(
+    source.slice(retryRecord, retryThrow),
+    /ledger: retryLedger[\s\S]*failure: commandError/,
+  );
+
+  const publicationStart = source.indexOf("function applyArtifactsCommand(args: Args): void {");
+  const publicationCatch = source.indexOf("} catch (error) {", publicationStart);
+  const publicationFinish = source.indexOf(
+    "finishPublication(error, interruptedMutation);",
+    publicationCatch,
+  );
+  const publicationThrow = source.indexOf("throw error;", publicationFinish);
+  assert.ok(publicationCatch > publicationStart);
+  assert.ok(publicationFinish > publicationCatch);
+  assert.ok(publicationThrow > publicationFinish);
+  assert.match(
+    source.slice(publicationCatch, publicationFinish),
+    /recordPublication\(\{[\s\S]*status: actionLedgerFailureDisposition\(error\)\.status/,
+  );
+  assert.match(
+    source,
+    /syncStalePullRequestReviewLabels\(\{[\s\S]{0,240}onMutation: recordMutation/,
+  );
+  assert.match(source, /syncPriorityLabel\(\{[\s\S]{0,240}onMutation: recordMutation/);
+  assert.match(source, /tryAddOptionalLabel\(\{[\s\S]{0,220}onMutation: options\.onMutation/);
+});
+
+test("sweep publishes complete immutable shards for every review and apply producer", () => {
+  const workflow = readText(".github/workflows/sweep.yml");
+  const reviewStep = workflow.indexOf("- name: Review shard");
+  const reviewFinalizer = workflow.indexOf("- name: Finalize review action ledger");
+  const reviewUpload = workflow.indexOf("name: action-ledger-review-${{ matrix.shard }}");
+
+  assert.ok(reviewStep >= 0);
+  assert.ok(reviewFinalizer > reviewStep);
+  assert.ok(reviewUpload > reviewFinalizer);
+  assert.match(
+    workflow.slice(reviewFinalizer, reviewUpload),
+    /if: always\(\)[\s\S]*node dist\/clawsweeper\.js finalize-action-events/,
+  );
+
+  for (const name of [
+    "Import immutable review action events",
+    "Publish immutable review action ledger",
+    "Publish review artifact action ledger",
+    "Publish selected review comment action ledger",
+    "Publish failed-review retry action ledger",
+    "Finalize exact event action ledger",
+    "Publish exact event action ledger",
+    "Finalize apply proof action ledger",
+    "Publish apply proof action events",
+    "Publish apply action events",
+  ]) {
+    assert.match(workflow, new RegExp(`- name: ${name}`));
+  }
+
+  assert.match(
+    workflow,
+    /publish-apply-proof-action-ledger:\s*\n\s*name: Publish immutable apply proof action ledger/,
+  );
+  assert.match(workflow, /pattern: action-ledger-review-\*/);
+  assert.match(workflow, /include-hidden-files: true/);
+  assert.match(workflow, /--state-root "\$CLAWSWEEPER_STATE_DIR"/);
+  assert.match(workflow, /durable_event_path="\$CLAWSWEEPER_STATE_DIR\/\$event_path"/);
+  assert.match(workflow, /action_ledger_args\+=\(--path "\$event_path"\)/);
+  assert.doesNotMatch(
+    workflow,
+    /--message "chore: append (?:review|apply).*action ledger"[\s\S]{0,180}--path "ledger\/v1\/events"/,
+  );
+});

--- a/test/clawsweeper-action-ledger.test.ts
+++ b/test/clawsweeper-action-ledger.test.ts
@@ -139,6 +139,13 @@ test("lane instrumentation uses stable slots with explicit parent and phase orde
     source,
     /idempotencyIdentity: \{\s*operationIdentity: options\.ledger\.operationIdentity,\s*slot: "apply_batch_terminal"/,
   );
+  assert.match(source, /candidateSnapshots: options\.candidates\.map/);
+  assert.match(source, /candidateRevisions: options\.candidates\.map/);
+  assert.match(source, /slot: "apply_item"/);
+  assert.doesNotMatch(
+    source,
+    /idempotencyIdentity: \{[^}]{0,300}slot: "apply_(?:result|in_flight_failure)"/,
+  );
   assert.match(
     source,
     /idempotencyIdentity: \{\s*operationIdentity: options\.ledger\.operationIdentity,\s*slot: "batch_terminal"/,

--- a/test/clawsweeper-action-ledger.test.ts
+++ b/test/clawsweeper-action-ledger.test.ts
@@ -6,6 +6,7 @@ import {
   actionLedgerFailureDisposition,
   applyActionEventDisposition,
   applyItemBusinessIdempotencyIdentityForTest,
+  isGitHubLabelAlreadyExistsErrorForTest,
   reviewCommentPublicationEventDisposition,
   reviewRetryActionDisposition,
   reviewRetryBusinessIdempotencyIdentityForTest,
@@ -315,6 +316,37 @@ test("apply receipts start per item and persist mutation observation before fina
   assert.match(yieldHandler, /const interruptedItem = resumeCurrent && activeApplyItem !== null/);
   assert.match(yieldHandler, /finishApply\(\s*interruptedItem,/);
   assert.doesNotMatch(yieldHandler, /finishApply\(\);/);
+});
+
+test("apply mutation receipts classify existing labels and held leases as no-ops", () => {
+  assert.equal(
+    isGitHubLabelAlreadyExistsErrorForTest(
+      'HTTP 422: Validation Failed (label "priority: high" already exists)',
+    ),
+    true,
+  );
+  assert.equal(isGitHubLabelAlreadyExistsErrorForTest("HTTP 500: unavailable"), false);
+
+  const source = readText("src/clawsweeper.ts");
+  const labelCreates = source.match(/identity: `label_create:/g) ?? [];
+  const labelNoMutationClassifiers =
+    source.match(/knownNoMutation: labelAlreadyExistsError/g) ?? [];
+  assert.ok(labelCreates.length > 0);
+  assert.equal(labelNoMutationClassifiers.length, labelCreates.length);
+
+  const leaseAcquireStart = source.indexOf("const posted = runObservedApplyMutation({");
+  const leaseAcquireEnd = source.indexOf("if (posted.status !==", leaseAcquireStart);
+  const leaseAcquire = source.slice(leaseAcquireStart, leaseAcquireEnd);
+  assert.match(leaseAcquire, /didMutate: \(result\) => result\.didMutate/);
+  assert.match(
+    source,
+    /return \{ status: "held", lease: null, retryAt: initialLease\.expiresAt, didMutate: false \}/,
+  );
+  assert.match(
+    source,
+    /return \{ status: "held", lease: null, retryAt: winner\.expiresAt, didMutate: false \}/,
+  );
+  assert.match(source, /return \{ status: "posted", lease: acquired, didMutate: true \}/);
 });
 
 test("apply failure finalization survives report publication errors", () => {

--- a/test/clawsweeper-action-ledger.test.ts
+++ b/test/clawsweeper-action-ledger.test.ts
@@ -6,7 +6,9 @@ import {
   actionLedgerFailureDisposition,
   applyActionEventDisposition,
   applyItemBusinessIdempotencyIdentityForTest,
+  applyRuntimeBudgetYieldResultsForTest,
   classifyGitHubDispatchResultForTest,
+  codexReviewFailureRetryableForTest,
   heldReviewStartStatusCommentResultForTest,
   isGitHubLabelAlreadyExistsErrorForTest,
   observedGitHubMutationAttemptsForTest,
@@ -54,6 +56,13 @@ test("review and apply outcome classifiers cover terminal and resumable states",
     reasonCode: "runtime_budget",
     retryable: true,
     mutation: false,
+    completionReason: "runtime_budget",
+  });
+  assert.deepEqual(applyActionEventDisposition("skipped_runtime_budget", true, false), {
+    status: "yielded",
+    reasonCode: "runtime_budget",
+    retryable: true,
+    mutation: true,
     completionReason: "runtime_budget",
   });
   assert.deepEqual(applyActionEventDisposition("skipped_changed_since_review", false, false), {
@@ -174,6 +183,8 @@ test("apply and retry business idempotency ignore batch order but bind source re
     number: 512,
     revisionKind: "pull_head_sha" as const,
     sourceRevision: "e".repeat(40),
+    reviewContentDigest: "f".repeat(64),
+    decisionPacketSha256: "1".repeat(64),
     slot: "retry_dispatch" as const,
   };
   const retryKey = actionIdempotencyKey(
@@ -191,7 +202,25 @@ test("apply and retry business idempotency ignore batch order but bind source re
     actionIdempotencyKey(
       reviewRetryBusinessIdempotencyIdentityForTest({
         ...retryIdentity,
-        sourceRevision: "f".repeat(40),
+        sourceRevision: "2".repeat(40),
+      }),
+    ),
+    retryKey,
+  );
+  assert.notEqual(
+    actionIdempotencyKey(
+      reviewRetryBusinessIdempotencyIdentityForTest({
+        ...retryIdentity,
+        reviewContentDigest: "3".repeat(64),
+      }),
+    ),
+    retryKey,
+  );
+  assert.notEqual(
+    actionIdempotencyKey(
+      reviewRetryBusinessIdempotencyIdentityForTest({
+        ...retryIdentity,
+        decisionPacketSha256: "4".repeat(64),
       }),
     ),
     retryKey,
@@ -337,6 +366,7 @@ test("apply mutation receipts bind every GitHub request attempt and preserve no-
   assert.deepEqual(observedGitHubMutationAttemptsForTest(["already_exists"]), [
     { identity: "test_mutation:request_attempt:1", outcome: "rejected" },
   ]);
+  assert.deepEqual(observedGitHubMutationAttemptsForTest(["not_started"]), []);
   assert.deepEqual(heldReviewStartStatusCommentResultForTest("2026-07-12T12:00:00Z", false), {
     status: "held",
     lease: null,
@@ -360,6 +390,26 @@ test("apply mutation receipts bind every GitHub request attempt and preserve no-
   assert.match(source, /identity: `review_lease_delete:/);
   assert.doesNotMatch(source, /identity: `apply_lease_acquire:/);
   assert.match(source, /return \{ status: "posted", lease: acquired, didMutate: true \}/);
+});
+
+test("runtime yields bind the active item and terminal Codex failures preserve retryability", () => {
+  assert.deepEqual(
+    applyRuntimeBudgetYieldResultsForTest(512, "max runtime reached during coverage proof"),
+    [
+      {
+        number: 512,
+        action: "skipped_runtime_budget",
+        reason: "max runtime reached during coverage proof",
+      },
+      {
+        number: 0,
+        action: "skipped_runtime_budget",
+        reason: "max runtime reached during coverage proof",
+      },
+    ],
+  );
+  assert.equal(codexReviewFailureRetryableForTest(false), false);
+  assert.equal(codexReviewFailureRetryableForTest(true), true);
 });
 
 test("retry dispatch outcomes distinguish definite rejection, ambiguity, and acceptance", () => {

--- a/test/clawsweeper-action-ledger.test.ts
+++ b/test/clawsweeper-action-ledger.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  actionEventPublishPathsForTest,
   actionLedgerFailureDisposition,
   applyActionEventDisposition,
   applyItemBusinessIdempotencyIdentityForTest,
@@ -108,6 +109,31 @@ test("failed-review retry events distinguish dispatch, exhaustion, and backpress
     retryable: false,
     mutation: false,
   });
+  assert.deepEqual(reviewRetryActionDisposition("skipped_retry_dispatch_uncertain"), {
+    status: "failed",
+    reasonCode: "unavailable",
+    retryable: false,
+    mutation: true,
+  });
+});
+
+test("action event publication accepts only sorted canonical event and binding paths", () => {
+  const paths = [
+    "ledger/v1/events/2026/07/12/openclaw-clawsweeper/review/run-part-1-of-1.jsonl",
+    `ledger/v1/import-bindings/completed-shard-sets/${"a".repeat(64)}.json`,
+    `ledger/v1/import-bindings/events/${"b".repeat(64)}.json`,
+    `ledger/v1/import-bindings/producer-runs/${"c".repeat(64)}.json`,
+    `ledger/v1/import-bindings/shard-sets/${"d".repeat(64)}.json`,
+  ].sort();
+  assert.deepEqual(actionEventPublishPathsForTest(`${paths.join("\n")}\n`), paths);
+  assert.throws(
+    () => actionEventPublishPathsForTest(`${paths[1]}\n${paths[0]}\n`),
+    /sorted and unique/,
+  );
+  assert.throws(
+    () => actionEventPublishPathsForTest("ledger/v1/import-bindings/private/raw.json\n"),
+    /invalid action event publish path/,
+  );
 });
 
 test("apply and retry business idempotency ignore batch order but bind source revision", () => {
@@ -255,14 +281,40 @@ test("apply receipts start per item and persist mutation observation before fina
   );
 
   assert.match(applyLoop, /startApplyActionLedgerItem\(applyLedger, entry\)/);
+  assert.match(applyLoop, /mutationByItem\.set\(`\$\{repo\}#\$\{number\}`, true\)/);
   assert.match(
     applyLoop,
-    /const recordMutation = \(\): void => \{[\s\S]*mutationByItem\.set[\s\S]*recordApplyMutationBoundary\(applyLedger, entry\)/,
+    /const recordMutation = \(parentEventId\?: string \| null\): void => \{[\s\S]*recordApplyMutationBoundary\(applyLedger, entry, parentEventId\)/,
   );
+  assert.match(source, /completion_reason: "mutation_attempted"/);
+  assert.match(applyLoop, /runObservedApplyMutation\(\{[\s\S]*review_comment_upsert:/);
+  assert.match(applyLoop, /runObservedApplyMutation\(\{[\s\S]*item_close:/);
+  const mutationAttemptStart = source.indexOf("function startApplyMutationAttempt(");
+  const mutationIdentityStart = source.indexOf(
+    "const idempotencyIdentity = {",
+    mutationAttemptStart,
+  );
+  const mutationIdentity = source.slice(
+    mutationIdentityStart,
+    source.indexOf("const phaseSeq =", mutationIdentityStart),
+  );
+  assert.match(mutationIdentity, /mutationIdentitySha256: sha256\(identity\)/);
+  assert.doesNotMatch(mutationIdentity, /mutationIndex/);
+  assert.match(source, /activeApplyMutationRunner \? gh\(args\) : ghWithRetry\(args, attempts\)/);
   assert.match(
     applyLoop,
     /finally \{[\s\S]*recordApplyActionLedgerItemResults\(\{[\s\S]*activeApplyItem = null;/,
   );
+  const yieldStart = source.indexOf(
+    "runtimeBudget.onYield = (reason: string, resumeCurrent = true): void => {",
+  );
+  const yieldHandler = source.slice(
+    yieldStart,
+    source.indexOf("if (fileEntries.length === 0", yieldStart),
+  );
+  assert.match(yieldHandler, /const interruptedItem = resumeCurrent && activeApplyItem !== null/);
+  assert.match(yieldHandler, /finishApply\(\s*interruptedItem,/);
+  assert.doesNotMatch(yieldHandler, /finishApply\(\);/);
 });
 
 test("apply failure finalization survives report publication errors", () => {
@@ -334,6 +386,9 @@ test("sweep publishes complete immutable shards for every review and apply produ
   const applyStep = workflow.indexOf("- name: Apply unchanged proposed decisions with checkpoints");
   const applyFinalizer = workflow.indexOf("- name: Finalize apply action ledger");
   const applyPublish = workflow.indexOf("- name: Publish apply action events");
+  const retryStep = workflow.indexOf("- name: Plan or dispatch failed-review retries");
+  const retryFinalizer = workflow.indexOf("- name: Finalize failed-review retry action ledger");
+  const retryPublish = workflow.indexOf("- name: Publish failed-review retry action ledger");
 
   assert.ok(reviewStep >= 0);
   assert.ok(reviewFinalizer > reviewStep);
@@ -363,6 +418,14 @@ test("sweep publishes complete immutable shards for every review and apply produ
     workflow.slice(applyFinalizer, applyPublish),
     /if: \$\{\{ always\(\) \}\}[\s\S]*APPLY_OUTCOME:[\s\S]*--interrupt-open-attempts --reason timeout/,
   );
+  assert.ok(retryStep >= 0);
+  assert.ok(retryFinalizer > retryStep);
+  assert.ok(retryPublish > retryFinalizer);
+  assert.match(workflow.slice(retryStep, retryFinalizer), /id: retry-failed-reviews-run/);
+  assert.match(
+    workflow.slice(retryFinalizer, retryPublish),
+    /RETRY_OUTCOME:[\s\S]*--interrupt-open-attempts --reason timeout/,
+  );
 
   for (const name of [
     "Import immutable review action events",
@@ -387,7 +450,8 @@ test("sweep publishes complete immutable shards for every review and apply produ
   assert.match(workflow, /include-hidden-files: true/);
   assert.match(workflow, /--state-root "\$CLAWSWEEPER_STATE_DIR"/);
   assert.match(workflow, /durable_event_path="\$CLAWSWEEPER_STATE_DIR\/\$event_path"/);
-  assert.match(workflow, /action_ledger_args\+=\(--path "\$event_path"\)/);
+  assert.equal((workflow.match(/publish-action-event-paths/g) ?? []).length, 7);
+  assert.doesNotMatch(workflow, /action_ledger_args/);
   assert.doesNotMatch(
     workflow,
     /--message "chore: append (?:review|apply).*action ledger"[\s\S]{0,180}--path "ledger\/v1\/events"/,

--- a/test/clawsweeper-action-ledger.test.ts
+++ b/test/clawsweeper-action-ledger.test.ts
@@ -14,6 +14,7 @@ import {
   codexReviewFailureRetryableForTest,
   heldReviewStartStatusCommentResultForTest,
   isGitHubLabelAlreadyExistsErrorForTest,
+  main,
   observedGitHubMutationAttemptsForTest,
   reviewCommentPublicationEventDisposition,
   reviewRetryActionDisposition,
@@ -23,6 +24,68 @@ import {
 } from "../dist/clawsweeper.js";
 import { actionIdempotencyKey } from "../dist/action-ledger.js";
 import { readText } from "./helpers.ts";
+
+test("primary command success survives best-effort action ledger flush failure", async (t) => {
+  const errors: string[] = [];
+  let flushCalls = 0;
+  t.mock.method(console, "error", (...args: unknown[]) => {
+    errors.push(args.map(String).join(" "));
+  });
+
+  await main(["check"], {
+    flushWorkflowActionEvents: async () => {
+      flushCalls += 1;
+      throw new Error("simulated flush failure");
+    },
+  });
+
+  assert.equal(flushCalls, 1);
+  assert.match(
+    errors.join("\n"),
+    /\[action-ledger\] best-effort finalization failed after successful check: simulated flush failure/,
+  );
+});
+
+test("primary command failure is not masked by action ledger flush failure", async (t) => {
+  const errors: string[] = [];
+  let flushCalls = 0;
+  t.mock.method(console, "error", (...args: unknown[]) => {
+    errors.push(args.map(String).join(" "));
+  });
+
+  await assert.rejects(
+    main(["unknown-primary-command"], {
+      flushWorkflowActionEvents: async () => {
+        flushCalls += 1;
+        throw new Error("simulated flush failure");
+      },
+    }),
+    (error: unknown) => {
+      assert.equal(
+        error instanceof Error ? error.message : String(error),
+        "Unknown command: unknown-primary-command",
+      );
+      return true;
+    },
+  );
+
+  assert.equal(flushCalls, 1);
+  assert.match(
+    errors.join("\n"),
+    /\[action-ledger\] best-effort finalization failed after command failure: simulated flush failure/,
+  );
+});
+
+test("explicit action ledger finalization keeps flush failure strict", async () => {
+  await assert.rejects(
+    main(["finalize-action-events"], {
+      flushWorkflowActionEvents: async () => {
+        throw new Error("simulated flush failure");
+      },
+    }),
+    /simulated flush failure/,
+  );
+});
 
 test("review and apply outcome classifiers cover terminal and resumable states", () => {
   assert.deepEqual(actionLedgerFailureDisposition(new Error("worker timed out after 30s")), {

--- a/test/clawsweeper-action-ledger.test.ts
+++ b/test/clawsweeper-action-ledger.test.ts
@@ -6,14 +6,17 @@ import {
   actionLedgerFailureDisposition,
   applyActionEventDisposition,
   applyItemBusinessIdempotencyIdentityForTest,
+  applyPhaseSequenceForTest,
   applyRuntimeBudgetYieldResultsForTest,
   classifyGitHubDispatchResultForTest,
+  combinedCodexReviewRetryableForTest,
   codexReviewFailureRetryableForTest,
   heldReviewStartStatusCommentResultForTest,
   isGitHubLabelAlreadyExistsErrorForTest,
   observedGitHubMutationAttemptsForTest,
   reviewCommentPublicationEventDisposition,
   reviewRetryActionDisposition,
+  reviewRetryBatchEventDisposition,
   reviewRetryBusinessIdempotencyIdentityForTest,
   untrustedCodexEnvForTest,
 } from "../dist/clawsweeper.js";
@@ -72,6 +75,20 @@ test("review and apply outcome classifiers cover terminal and resumable states",
     mutation: false,
     completionReason: "source_changed",
   });
+  assert.deepEqual(applyActionEventDisposition("kept_open", true, false), {
+    status: "skipped",
+    reasonCode: "not_applicable",
+    retryable: false,
+    mutation: true,
+    completionReason: "kept_open",
+  });
+  assert.deepEqual(applyActionEventDisposition("skipped_protected_label", true, false), {
+    status: "skipped",
+    reasonCode: "not_applicable",
+    retryable: false,
+    mutation: true,
+    completionReason: "skipped_protected_label",
+  });
   assert.deepEqual(reviewCommentPublicationEventDisposition("review_comment_synced", true, false), {
     status: "published",
     reasonCode: "published",
@@ -79,6 +96,16 @@ test("review and apply outcome classifiers cover terminal and resumable states",
     mutation: true,
     completionReason: "comment_published",
   });
+  assert.deepEqual(
+    reviewCommentPublicationEventDisposition("review_comment_synced", false, false),
+    {
+      status: "published",
+      reasonCode: "published",
+      retryable: false,
+      mutation: false,
+      completionReason: "comment_published",
+    },
+  );
   assert.deepEqual(reviewCommentPublicationEventDisposition("skipped_comment_auth", true, false), {
     status: "blocked",
     reasonCode: "authorization_failed",
@@ -129,6 +156,20 @@ test("failed-review retry events distinguish dispatch, exhaustion, and backpress
     retryable: false,
     mutation: true,
   });
+  assert.deepEqual(
+    reviewRetryBatchEventDisposition([
+      "skipped_dispatch_failed",
+      "skipped_retry_dispatch_uncertain",
+    ]),
+    {
+      status: "failed",
+      reasonCode: "unavailable",
+      retryable: false,
+      completionReason: "dispatch_outcome_unknown",
+      failedCount: 1,
+      partial: true,
+    },
+  );
 });
 
 test("action event publication accepts only sorted canonical event and binding paths", () => {
@@ -247,7 +288,7 @@ test("lane instrumentation uses stable slots with explicit parent and phase orde
   assert.match(source, /parentEventId: state\.startEventId/);
   assert.match(
     source,
-    /parentEventId:\s*actionEvent\?\.event_id \?\? options\.state\.mutationEventId \?\? options\.state\.startEventId/,
+    /parentEventId: options\.state\.lastEventId \?\? options\.state\.startEventId/,
   );
   assert.match(source, /phaseSeq: 10 \+ state\.index \* 10/);
   assert.match(source, /phaseSeq: 11 \+ state\.index \* 10/);
@@ -321,7 +362,15 @@ test("apply receipts start per item and persist mutation observation before fina
     /const recordMutation = \(parentEventId\?: string \| null\): void => \{[\s\S]*recordApplyMutationBoundary\(applyLedger, entry, parentEventId\)/,
   );
   assert.match(source, /completion_reason: "mutation_attempted"/);
+  assert.match(source, /parentEventId: state\.lastEventId \?\? state\.startEventId/);
+  assert.match(source, /const phaseSeq = nextApplyPhaseSeq\(ledger\)/);
+  assert.doesNotMatch(source, /11 \+ state\.index \* 20/);
   assert.match(applyLoop, /syncedComment = upsertReviewComment\(/);
+  assert.match(applyLoop, /commentMutationOccurred: !dryRun && needsReviewCommentBodySync/);
+  assert.match(
+    source,
+    /reviewCommentPublicationEventDisposition\(\s*result\.action,\s*result\.commentMutationOccurred === true,/,
+  );
   assert.match(applyLoop, /closeItem\(\{ number, kind: item\.kind/);
   const mutationAttemptStart = source.indexOf("function startApplyMutationAttempt(");
   const mutationIdentityStart = source.indexOf(
@@ -390,6 +439,7 @@ test("apply mutation receipts bind every GitHub request attempt and preserve no-
   assert.match(source, /identity: `review_lease_delete:/);
   assert.doesNotMatch(source, /identity: `apply_lease_acquire:/);
   assert.match(source, /return \{ status: "posted", lease: acquired, didMutate: true \}/);
+  assert.deepEqual(applyPhaseSequenceForTest(6), [2, 3, 4, 5, 6, 7]);
 });
 
 test("runtime yields bind the active item and terminal Codex failures preserve retryability", () => {
@@ -410,6 +460,8 @@ test("runtime yields bind the active item and terminal Codex failures preserve r
   );
   assert.equal(codexReviewFailureRetryableForTest(false), false);
   assert.equal(codexReviewFailureRetryableForTest(true), true);
+  assert.equal(combinedCodexReviewRetryableForTest(true, false), false);
+  assert.equal(combinedCodexReviewRetryableForTest(false, true), true);
 });
 
 test("retry dispatch outcomes distinguish definite rejection, ambiguity, and acceptance", () => {

--- a/test/clawsweeper-action-ledger.test.ts
+++ b/test/clawsweeper-action-ledger.test.ts
@@ -6,10 +6,14 @@ import {
   actionLedgerFailureDisposition,
   applyActionEventDisposition,
   applyItemBusinessIdempotencyIdentityForTest,
+  classifyGitHubDispatchResultForTest,
+  heldReviewStartStatusCommentResultForTest,
   isGitHubLabelAlreadyExistsErrorForTest,
+  observedGitHubMutationAttemptsForTest,
   reviewCommentPublicationEventDisposition,
   reviewRetryActionDisposition,
   reviewRetryBusinessIdempotencyIdentityForTest,
+  untrustedCodexEnvForTest,
 } from "../dist/clawsweeper.js";
 import { actionIdempotencyKey } from "../dist/action-ledger.js";
 import { readText } from "./helpers.ts";
@@ -288,8 +292,8 @@ test("apply receipts start per item and persist mutation observation before fina
     /const recordMutation = \(parentEventId\?: string \| null\): void => \{[\s\S]*recordApplyMutationBoundary\(applyLedger, entry, parentEventId\)/,
   );
   assert.match(source, /completion_reason: "mutation_attempted"/);
-  assert.match(applyLoop, /runObservedApplyMutation\(\{[\s\S]*review_comment_upsert:/);
-  assert.match(applyLoop, /runObservedApplyMutation\(\{[\s\S]*item_close:/);
+  assert.match(applyLoop, /syncedComment = upsertReviewComment\(/);
+  assert.match(applyLoop, /closeItem\(\{ number, kind: item\.kind/);
   const mutationAttemptStart = source.indexOf("function startApplyMutationAttempt(");
   const mutationIdentityStart = source.indexOf(
     "const idempotencyIdentity = {",
@@ -301,7 +305,7 @@ test("apply receipts start per item and persist mutation observation before fina
   );
   assert.match(mutationIdentity, /mutationIdentitySha256: sha256\(identity\)/);
   assert.doesNotMatch(mutationIdentity, /mutationIndex/);
-  assert.match(source, /activeApplyMutationRunner \? gh\(args\) : ghWithRetry\(args, attempts\)/);
+  assert.match(source, /identity: `\$\{options\.identity\}:request_attempt:\$\{attempt \+ 1\}`/);
   assert.match(
     applyLoop,
     /finally \{[\s\S]*recordApplyActionLedgerItemResults\(\{[\s\S]*activeApplyItem = null;/,
@@ -318,7 +322,7 @@ test("apply receipts start per item and persist mutation observation before fina
   assert.doesNotMatch(yieldHandler, /finishApply\(\);/);
 });
 
-test("apply mutation receipts classify existing labels and held leases as no-ops", () => {
+test("apply mutation receipts bind every GitHub request attempt and preserve no-op truth", () => {
   assert.equal(
     isGitHubLabelAlreadyExistsErrorForTest(
       'HTTP 422: Validation Failed (label "priority: high" already exists)',
@@ -326,27 +330,65 @@ test("apply mutation receipts classify existing labels and held leases as no-ops
     true,
   );
   assert.equal(isGitHubLabelAlreadyExistsErrorForTest("HTTP 500: unavailable"), false);
+  assert.deepEqual(observedGitHubMutationAttemptsForTest(["transient", "accepted"]), [
+    { identity: "test_mutation:request_attempt:1", outcome: "unknown" },
+    { identity: "test_mutation:request_attempt:2", outcome: "accepted" },
+  ]);
+  assert.deepEqual(observedGitHubMutationAttemptsForTest(["already_exists"]), [
+    { identity: "test_mutation:request_attempt:1", outcome: "rejected" },
+  ]);
+  assert.deepEqual(heldReviewStartStatusCommentResultForTest("2026-07-12T12:00:00Z", false), {
+    status: "held",
+    lease: null,
+    retryAt: "2026-07-12T12:00:00Z",
+    didMutate: false,
+  });
+  assert.deepEqual(heldReviewStartStatusCommentResultForTest("2026-07-12T12:00:00Z", true), {
+    status: "held",
+    lease: null,
+    retryAt: "2026-07-12T12:00:00Z",
+    didMutate: true,
+  });
 
   const source = readText("src/clawsweeper.ts");
   const labelCreates = source.match(/identity: `label_create:/g) ?? [];
   const labelNoMutationClassifiers =
     source.match(/knownNoMutation: labelAlreadyExistsError/g) ?? [];
   assert.ok(labelCreates.length > 0);
-  assert.equal(labelNoMutationClassifiers.length, labelCreates.length);
-
-  const leaseAcquireStart = source.indexOf("const posted = runObservedApplyMutation({");
-  const leaseAcquireEnd = source.indexOf("if (posted.status !==", leaseAcquireStart);
-  const leaseAcquire = source.slice(leaseAcquireStart, leaseAcquireEnd);
-  assert.match(leaseAcquire, /didMutate: \(result\) => result\.didMutate/);
-  assert.match(
-    source,
-    /return \{ status: "held", lease: null, retryAt: initialLease\.expiresAt, didMutate: false \}/,
-  );
-  assert.match(
-    source,
-    /return \{ status: "held", lease: null, retryAt: winner\.expiresAt, didMutate: false \}/,
-  );
+  assert.ok(labelNoMutationClassifiers.length >= labelCreates.length);
+  assert.match(source, /identity: `review_lease_post:/);
+  assert.match(source, /identity: `review_lease_delete:/);
+  assert.doesNotMatch(source, /identity: `apply_lease_acquire:/);
   assert.match(source, /return \{ status: "posted", lease: acquired, didMutate: true \}/);
+});
+
+test("retry dispatch outcomes distinguish definite rejection, ambiguity, and acceptance", () => {
+  assert.equal(
+    classifyGitHubDispatchResultForTest({ status: 1, stderr: "HTTP 422: validation failed" }),
+    "definitely_not_dispatched",
+  );
+  assert.equal(
+    classifyGitHubDispatchResultForTest({ status: 1, stderr: "HTTP 502: bad gateway" }),
+    "ambiguous_transport",
+  );
+  assert.equal(
+    classifyGitHubDispatchResultForTest({ status: null, errorCode: "ETIMEDOUT" }),
+    "ambiguous_transport",
+  );
+  assert.equal(classifyGitHubDispatchResultForTest({ status: 0 }), "accepted");
+});
+
+test("untrusted Codex processes cannot inherit action-ledger producer authority", () => {
+  const env = untrustedCodexEnvForTest({
+    CLAWSWEEPER_ACTION_LEDGER_FORCE: "1",
+    CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT: "/tmp/privileged-ledger",
+    CLAWSWEEPER_ACTION_LEDGER_INVOCATION: "review-0",
+    GH_TOKEN: "ambient",
+  });
+  assert.equal(env.CLAWSWEEPER_ACTION_LEDGER_FORCE, undefined);
+  assert.equal(env.CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT, undefined);
+  assert.equal(env.CLAWSWEEPER_ACTION_LEDGER_INVOCATION, undefined);
+  assert.equal(env.GH_TOKEN, undefined);
 });
 
 test("apply failure finalization survives report publication errors", () => {
@@ -436,8 +478,8 @@ test("sweep publishes complete immutable shards for every review and apply produ
     /id: generate-apply-proofs[\s\S]*timeout-minutes: 50/,
   );
   assert.match(
-    workflow.slice(applyProofFinalizer, applyProofFinalizer + 500),
-    /APPLY_PROOF_OUTCOME:[\s\S]*--interrupt-open-attempts --reason timeout/,
+    workflow.slice(applyProofFinalizer, applyProofFinalizer + 700),
+    /APPLY_PROOF_OUTCOME:[\s\S]*--interrupt-open-attempts --reason cancelled[\s\S]*--interrupt-open-attempts --reason workflow_failed/,
   );
   assert.ok(applyStep >= 0);
   assert.ok(applyFinalizer > applyStep);
@@ -448,7 +490,7 @@ test("sweep publishes complete immutable shards for every review and apply produ
   );
   assert.match(
     workflow.slice(applyFinalizer, applyPublish),
-    /if: \$\{\{ always\(\) \}\}[\s\S]*APPLY_OUTCOME:[\s\S]*--interrupt-open-attempts --reason timeout/,
+    /if: \$\{\{ always\(\) \}\}[\s\S]*APPLY_OUTCOME:[\s\S]*--interrupt-open-attempts --reason cancelled[\s\S]*--interrupt-open-attempts --reason workflow_failed/,
   );
   assert.ok(retryStep >= 0);
   assert.ok(retryFinalizer > retryStep);
@@ -456,7 +498,7 @@ test("sweep publishes complete immutable shards for every review and apply produ
   assert.match(workflow.slice(retryStep, retryFinalizer), /id: retry-failed-reviews-run/);
   assert.match(
     workflow.slice(retryFinalizer, retryPublish),
-    /RETRY_OUTCOME:[\s\S]*--interrupt-open-attempts --reason timeout/,
+    /RETRY_EXIT_CODE:[\s\S]*--interrupt-open-attempts --reason cancelled[\s\S]*--interrupt-open-attempts --reason timeout[\s\S]*--interrupt-open-attempts --reason workflow_failed/,
   );
 
   for (const name of [

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2164,6 +2164,7 @@ test("sweep workflow executes only durable queue leases without runner-side admi
   );
   const setupCodexIndex = eventReviewBlock.indexOf("- uses: ./.github/actions/setup-codex");
   const exactReviewIndex = eventReviewBlock.indexOf("- name: Review exact event item");
+  const primaryResultIndex = eventReviewBlock.indexOf("- name: Export exact review primary result");
   const failReviewIndex = eventReviewBlock.indexOf("- name: Fail unsuccessful exact review");
   const completeLeaseIndex = eventReviewBlock.indexOf("- name: Complete exact-review queue lease");
   const claimStep = eventReviewBlock.slice(
@@ -2174,6 +2175,7 @@ test("sweep workflow executes only durable queue leases without runner-side admi
     completeLeaseIndex,
     eventReviewBlock.indexOf("\n      - ", completeLeaseIndex + 1),
   );
+  const primaryResultStep = eventReviewBlock.slice(primaryResultIndex, failReviewIndex);
   const exactReviewStep = eventReviewBlock.slice(
     exactReviewIndex,
     eventReviewBlock.indexOf("- name: Create state token", exactReviewIndex),
@@ -2197,8 +2199,9 @@ test("sweep workflow executes only durable queue leases without runner-side admi
   assert.ok(inProgressStatusIndex > setupPnpmIndex);
   assert.ok(setupCodexIndex > inProgressStatusIndex);
   assert.ok(exactReviewIndex > setupCodexIndex);
+  assert.ok(primaryResultIndex > exactReviewIndex);
   assert.equal(eventReviewBlock.match(/- name: Fail unsuccessful exact review/g)?.length, 1);
-  assert.ok(failReviewIndex > exactReviewIndex);
+  assert.ok(failReviewIndex > primaryResultIndex);
   assert.ok(completeLeaseIndex > failReviewIndex);
   assert.match(eventReviewBlock, /\/internal\/exact-review\/claim/);
   assert.match(eventReviewBlock, /\/internal\/exact-review\/complete/);
@@ -2222,7 +2225,13 @@ test("sweep workflow executes only durable queue leases without runner-side admi
     eventReviewBlock.slice(failReviewIndex, completeLeaseIndex),
     /steps\.queue-exact-verdict-router\.outcome != 'success'/,
   );
-  assert.match(completeLeaseStep, /JOB_STATUS: \$\{\{ job\.status \}\}/);
+  assert.match(primaryResultStep, /PRIMARY_JOB_STATUS: \$\{\{ job\.status \}\}/);
+  assert.match(primaryResultStep, /echo "outcome=\$outcome" >> "\$GITHUB_OUTPUT"/);
+  assert.match(
+    completeLeaseStep,
+    /PRIMARY_OUTCOME: \$\{\{ steps\.exact-review-primary-result\.outputs\.outcome \|\| 'failure' \}\}/,
+  );
+  assert.doesNotMatch(completeLeaseStep, /JOB_STATUS:/);
   assert.match(completeLeaseStep, /if: \$\{\{ always\(\) \}\}/);
   assert.match(completeLeaseStep, /continue-on-error: true/);
   assert.match(completeLeaseStep, /RUN_ATTEMPT: \$\{\{ github\.run_attempt \}\}/);
@@ -2230,7 +2239,8 @@ test("sweep workflow executes only durable queue leases without runner-side admi
     completeLeaseStep,
     /PROTOCOL_VERSION: \$\{\{ steps\.claim-exact-review-queue\.outputs\.protocol_version \}\}/,
   );
-  assert.match(completeLeaseStep, /process\.env\.JOB_STATUS === "cancelled"/);
+  assert.match(completeLeaseStep, /const primaryOutcome = String\(process\.env\.PRIMARY_OUTCOME/);
+  assert.match(completeLeaseStep, /\["success", "cancelled", "failure"\]\.includes/);
   assert.match(completeLeaseStep, /claim_generation: claimGeneration/);
   assert.match(completeLeaseStep, /item_key: process\.env\.ITEM_KEY/);
   assert.match(completeLeaseStep, /lease_revision: leaseRevision/);

--- a/test/failed-review-retry.test.ts
+++ b/test/failed-review-retry.test.ts
@@ -172,6 +172,22 @@ test("failed review retry eligibility requires infrastructure failure and matchi
     }).action,
     "skipped_not_failed_review",
   );
+  const uncertain = failedReviewRetryEligibilityForTest({
+    markdown: failedReviewReport({
+      failed_review_retry_status: "dispatching",
+      failed_review_retry_count: 0,
+      failed_review_retry_last_at: "2026-06-05T19:59:00Z",
+      failed_review_retry_revision_kind: "pull_head_sha",
+      failed_review_retry_revision: "abc123def456",
+    }),
+    liveState: "open",
+    liveHeadSha: "abc123def456",
+    now,
+    maxAttempts: 2,
+    cooldownMs: 0,
+  });
+  assert.equal(uncertain.action, "skipped_retry_dispatch_uncertain");
+  assert.equal(uncertain.attempts, 0);
 });
 
 test("failed review retry does not redispatch locked or closed no-action items", () => {
@@ -577,7 +593,7 @@ test("failed issue retry bounds a hung GitHub fetch and flushes its report", () 
   }
 });
 
-test("failed issue retry checkpoints an ambiguous dispatch and prevents an immediate duplicate", () => {
+test("failed issue retry leaves an ambiguous dispatch unconsumed and prevents a duplicate", () => {
   const root = mkdtempSync(tmpPrefix);
   const fixture = failedIssueRetryFixture(root, 4345);
   const originalMarkdown = readFileSync(fixture.itemPath, "utf8");
@@ -601,14 +617,14 @@ fs.writeFileSync(counter, String(count + 1));
     }>;
     assert.equal(firstReport.at(-1)?.action, "skipped_runtime_budget", JSON.stringify(firstReport));
     const checkpointed = readFileSync(fixture.itemPath, "utf8");
-    assert.match(checkpointed, /^failed_review_retry_status: dispatch_failed$/m);
-    assert.match(checkpointed, /^failed_review_retry_count: 1$/m);
+    assert.match(checkpointed, /^failed_review_retry_status: dispatching$/m);
+    assert.match(checkpointed, /^failed_review_retry_count: 0$/m);
     assert.match(checkpointed, /^failed_review_retry_revision_kind: item_source_revision$/m);
     assert.match(
       checkpointed,
       new RegExp(`^failed_review_retry_revision: ${fixture.sourceRevision}$`, "m"),
     );
-    assert.equal((checkpointed.match(/^## Failed Review Retry$/gm) ?? []).length, 1);
+    assert.equal((checkpointed.match(/^## Failed Review Retry$/gm) ?? []).length, 0);
     assert.equal(readFileSync(dispatchCountPath, "utf8"), "1");
     const retryState = JSON.parse(readFileSync(fixture.statePath, "utf8")) as {
       status: string;
@@ -621,7 +637,7 @@ fs.writeFileSync(counter, String(count + 1));
         attempts: retryState.attempts,
         revision: retryState.revision,
       },
-      { status: "dispatch_failed", attempts: 1, revision: fixture.sourceRevision },
+      { status: "dispatching", attempts: 0, revision: fixture.sourceRevision },
     );
 
     // The generated sidecar is authoritative; review records are not published by this lane.
@@ -636,8 +652,8 @@ fs.writeFileSync(counter, String(count + 1));
       action: string;
       attempts?: number;
     }>;
-    assert.equal(secondReport[0]?.action, "skipped_retry_cooldown");
-    assert.equal(secondReport[0]?.attempts, 1);
+    assert.equal(secondReport[0]?.action, "skipped_retry_dispatch_uncertain");
+    assert.equal(secondReport[0]?.attempts, 0);
     assert.equal(readFileSync(dispatchCountPath, "utf8"), "1");
   } finally {
     rmSync(root, { recursive: true, force: true });
@@ -703,7 +719,7 @@ fs.writeFileSync(counter, String(count + 1));
   }
 });
 
-test("failed issue retry limit counts checkpointed ambiguous dispatches", () => {
+test("failed issue retry limit stops after one uncertain dispatch without consuming an attempt", () => {
   const root = mkdtempSync(tmpPrefix);
   const first = failedIssueRetryFixture(root, 4347);
   const second = failedIssueRetryFixture(root, 4348);
@@ -762,10 +778,10 @@ process.exit(1);
     }>;
     assert.deepEqual(
       report.map(({ number, action, attempts }) => ({ number, action, attempts })),
-      [{ number: 4347, action: "skipped_dispatch_failed", attempts: 1 }],
+      [{ number: 4347, action: "skipped_retry_dispatch_uncertain", attempts: 0 }],
     );
     assert.equal(readFileSync(dispatchCountPath, "utf8"), "1");
-    assert.match(readFileSync(first.itemPath, "utf8"), /^failed_review_retry_count: 1$/m);
+    assert.match(readFileSync(first.itemPath, "utf8"), /^failed_review_retry_count: 0$/m);
     assert.doesNotMatch(readFileSync(second.itemPath, "utf8"), /^failed_review_retry_count:/m);
   } finally {
     rmSync(root, { recursive: true, force: true });

--- a/test/failed-review-retry.test.ts
+++ b/test/failed-review-retry.test.ts
@@ -747,7 +747,7 @@ if (path.endsWith("/dispatches") && args.includes("POST")) {
   const counter = ${JSON.stringify(dispatchCountPath)};
   const count = fs.existsSync(counter) ? Number(fs.readFileSync(counter, "utf8")) : 0;
   fs.writeFileSync(counter, String(count + 1));
-  console.error("dispatch response lost after acceptance");
+  console.error("HTTP 502: dispatch response lost after acceptance");
   process.exit(1);
 }
 console.error("unexpected gh args: " + args.join(" "));
@@ -783,6 +783,44 @@ process.exit(1);
     assert.equal(readFileSync(dispatchCountPath, "utf8"), "1");
     assert.match(readFileSync(first.itemPath, "utf8"), /^failed_review_retry_count: 0$/m);
     assert.doesNotMatch(readFileSync(second.itemPath, "utf8"), /^failed_review_retry_count:/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("definite failed dispatch clears uncertainty without consuming the retry attempt", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const fixture = failedIssueRetryFixture(root, 4349);
+  try {
+    withMockGh(
+      root,
+      issueRetryGhMock(
+        fixture.issue,
+        'console.error("HTTP 422: validation failed"); process.exit(1);',
+      ),
+      () => runFailedIssueRetry(fixture),
+    );
+
+    const report = JSON.parse(readFileSync(fixture.reportPath, "utf8")) as Array<{
+      action: string;
+      attempts?: number;
+    }>;
+    assert.equal(report[0]?.action, "skipped_dispatch_failed");
+    assert.equal(report[0]?.attempts, 0);
+    const markdown = readFileSync(fixture.itemPath, "utf8");
+    assert.match(markdown, /^failed_review_retry_status: dispatch_failed$/m);
+    assert.match(markdown, /^failed_review_retry_count: 0$/m);
+    assert.equal(
+      failedReviewRetryEligibilityForTest({
+        markdown,
+        liveState: "open",
+        liveSourceRevision: fixture.sourceRevision,
+        now: Date.now() + 1,
+        maxAttempts: 2,
+        cooldownMs: 0,
+      }).action,
+      "planned_failed_review_retry",
+    );
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/review-comment-rendering.test.ts
+++ b/test/review-comment-rendering.test.ts
@@ -458,10 +458,7 @@ test("concurrent review lease election uses server comment order, not client tim
 test("apply retains its mutation lease until the item action is complete", () => {
   const source = readFileSync("src/clawsweeper.ts", "utf8");
   const acquire = source.indexOf("const mutationLeaseBlockReason = acquireApplyMutationLease");
-  const commentSync = source.indexOf(
-    "syncedComment = upsertReviewComment(number, markedReviewComment",
-    acquire,
-  );
+  const commentSync = source.indexOf("syncedComment = upsertReviewComment(", acquire);
   const close = source.indexOf("closeItem({ number, kind: item.kind", commentSync);
   const release = source.indexOf("releaseActiveApplyMutationLease();", close);
   assert.ok(acquire >= 0);

--- a/test/review-comment-rendering.test.ts
+++ b/test/review-comment-rendering.test.ts
@@ -297,7 +297,10 @@ test("spoofed durable markers cannot suppress a bot-owned start lease", () => {
   );
   assert.match(postStart, /issueReviewCommentState\(options\.item\.number\)/);
   assert.match(postStart, /freshDedicatedReviewStartLeases\(\{/);
-  assert.match(postStart, /return \{ status: "held", lease: null, retryAt: [^}]+\.expiresAt \}/);
+  assert.match(
+    postStart,
+    /return \{ status: "held", lease: null, retryAt: [^}]+\.expiresAt, didMutate: false \}/,
+  );
   assert.match(postStart, /issues\/\$\{options\.item\.number\}\/comments/);
 });
 
@@ -458,7 +461,7 @@ test("concurrent review lease election uses server comment order, not client tim
 test("apply retains its mutation lease until the item action is complete", () => {
   const source = readFileSync("src/clawsweeper.ts", "utf8");
   const acquire = source.indexOf("const mutationLeaseBlockReason = acquireApplyMutationLease");
-  const commentSync = source.indexOf("syncedComment = upsertReviewComment(", acquire);
+  const commentSync = source.indexOf("identity: `review_comment_upsert:", acquire);
   const close = source.indexOf("closeItem({ number, kind: item.kind", commentSync);
   const release = source.indexOf("releaseActiveApplyMutationLease();", close);
   assert.ok(acquire >= 0);

--- a/test/review-comment-rendering.test.ts
+++ b/test/review-comment-rendering.test.ts
@@ -297,10 +297,8 @@ test("spoofed durable markers cannot suppress a bot-owned start lease", () => {
   );
   assert.match(postStart, /issueReviewCommentState\(options\.item\.number\)/);
   assert.match(postStart, /freshDedicatedReviewStartLeases\(\{/);
-  assert.match(
-    postStart,
-    /return \{ status: "held", lease: null, retryAt: [^}]+\.expiresAt, didMutate: false \}/,
-  );
+  assert.match(postStart, /heldReviewStartStatusCommentResult\(initialLease\.expiresAt, false\)/);
+  assert.match(postStart, /heldReviewStartStatusCommentResult\(winner\.expiresAt, true\)/);
   assert.match(postStart, /issues\/\$\{options\.item\.number\}\/comments/);
 });
 
@@ -461,7 +459,7 @@ test("concurrent review lease election uses server comment order, not client tim
 test("apply retains its mutation lease until the item action is complete", () => {
   const source = readFileSync("src/clawsweeper.ts", "utf8");
   const acquire = source.indexOf("const mutationLeaseBlockReason = acquireApplyMutationLease");
-  const commentSync = source.indexOf("identity: `review_comment_upsert:", acquire);
+  const commentSync = source.indexOf("syncedComment = upsertReviewComment(", acquire);
   const close = source.indexOf("closeItem({ number, kind: item.kind", commentSync);
   const release = source.indexOf("releaseActiveApplyMutationLease();", close);
   assert.ok(acquire >= 0);

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -596,12 +596,15 @@ test("apply workflow isolates Codex proof from the credentialed mutation runner"
     workflow.indexOf("\njobs:"),
   );
   const proofJobStart = workflow.indexOf("\n  apply-proof:");
+  const proofPublisherStart = workflow.indexOf("\n  publish-apply-proof-action-ledger:");
   const applyJobStart = workflow.indexOf("\n  apply-existing:");
   assert.notEqual(proofJobStart, -1);
+  assert.notEqual(proofPublisherStart, -1);
   assert.notEqual(applyJobStart, -1);
   assert.doesNotMatch(workflowConcurrency, /queue: max/);
   assert.match(workflowConcurrency, /cancel-in-progress: false/);
-  const proofJob = workflow.slice(proofJobStart, applyJobStart);
+  const proofJob = workflow.slice(proofJobStart, proofPublisherStart);
+  const proofPublisherJob = workflow.slice(proofPublisherStart, applyJobStart);
   const applyJob = workflow.slice(applyJobStart);
 
   assert.match(proofJob, /permissions:\s+contents: read\s+issues: read\s+pull-requests: read/);
@@ -619,16 +622,47 @@ test("apply workflow isolates Codex proof from the credentialed mutation runner"
   assert.match(proofJob, /artifact_name: \$\{\{ steps\.proof-artifact\.outputs\.name \}\}/);
   assert.match(
     proofJob,
+    /action_ledger_artifact_name: \$\{\{ steps\.publishable-action-ledger\.outputs\.name \}\}/,
+  );
+  assert.match(
+    proofJob,
     /name=apply-coverage-proofs-\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}/,
   );
   assert.match(proofJob, /name: \$\{\{ steps\.proof-artifact\.outputs\.name \}\}/);
+  assert.match(
+    proofJob,
+    /action_ledger_name=action-ledger-apply-proof-\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}/,
+  );
+  assert.match(proofJob, /id: upload-action-events/);
+  assert.match(proofJob, /name: \$\{\{ steps\.proof-artifact\.outputs\.action_ledger_name \}\}/);
+  assert.match(proofJob, /path: \.clawsweeper-repair\/action-ledger-state\/\*\*/);
+  assert.match(proofJob, /include-hidden-files: true/);
+  assert.match(proofJob, /if-no-files-found: error/);
+  assert.match(
+    proofJob,
+    /if: \$\{\{ always\(\) && steps\.upload-action-events\.outputs\.artifact-id != '' \}\}/,
+  );
 
-  assert.match(applyJob, /needs: apply-proof/);
+  assert.match(proofPublisherJob, /needs: apply-proof/);
+  assert.match(
+    proofPublisherJob,
+    /if: \$\{\{ always\(\) && needs\.apply-proof\.result != 'skipped' \}\}/,
+  );
+  assert.match(
+    proofPublisherJob,
+    /name: \$\{\{ needs\.apply-proof\.outputs\.action_ledger_artifact_name \}\}/,
+  );
+  assert.match(proofPublisherJob, /path: \.clawsweeper-repair\/action-ledger-proof/);
+  assert.match(proofPublisherJob, /Publish apply proof action events/);
+  assert.doesNotMatch(proofPublisherJob, /github\.run_attempt/);
+
+  assert.match(applyJob, /needs: \[apply-proof, publish-apply-proof-action-ledger\]/);
   assert.doesNotMatch(applyJob, /setup-codex|OPENAI_API_KEY|CLAWSWEEPER_INTERNAL_MODEL/);
   assert.match(applyJob, /Create target write token/);
   assert.match(applyJob, /Create state token/);
   assert.match(applyJob, /actions\/download-artifact@v8/);
   assert.match(applyJob, /name: \$\{\{ needs\.apply-proof\.outputs\.artifact_name \}\}/);
+  assert.doesNotMatch(applyJob, /action-ledger-proof/);
   assert.match(applyJob, /validate_coverage_proof_tree .* 8 262144 2097152/);
   assert.doesNotMatch(applyJob, /COVERAGE_PROOF_TRUSTED_STARTED_AT|proof-trust/);
   assert.match(applyJob, /target_repo.*PROOF_TARGET_REPO/);
@@ -1027,12 +1061,15 @@ test("apply workflow finalization retries only target status after checkpointed 
     "- name: Apply unchanged proposed decisions with checkpoints",
   );
   const finalStatusStart = applyJob.indexOf("- name: Retry final apply status publication");
+  const actionLedgerStart = applyJob.indexOf("- name: Publish apply action events");
   const continueStart = applyJob.indexOf("- name: Continue apply sweep");
   assert.ok(applyStart !== -1);
   assert.ok(finalStatusStart > applyStart);
-  assert.ok(continueStart > finalStatusStart);
+  assert.ok(actionLedgerStart > finalStatusStart);
+  assert.ok(continueStart > actionLedgerStart);
   const applyStep = applyJob.slice(applyStart, finalStatusStart);
-  const finalStatusStep = applyJob.slice(finalStatusStart, continueStart);
+  const finalStatusStep = applyJob.slice(finalStatusStart, actionLedgerStart);
+  const actionLedgerStep = applyJob.slice(actionLedgerStart, continueStart);
 
   const commentCheckpoint = applyStep.indexOf(
     'publish_changes "chore: sync sweep review comments checkpoint $checkpoint" records apply-report.json results/comment-sync-cursors',
@@ -1066,6 +1103,16 @@ test("apply workflow finalization retries only target status after checkpointed 
   assert.doesNotMatch(finalStatusStep, /--path\s+"?records(?:\/|\s)/);
   assert.doesNotMatch(finalStatusStep, /apply-report\.json/);
   assert.doesNotMatch(finalStatusStep, /results\/(?:apply|comment-sync)-cursors/);
+  assert.match(actionLedgerStep, /publish-action-events/);
+  assert.doesNotMatch(actionLedgerStep, /action-ledger-proof/);
+  assert.match(actionLedgerStep, /action-ledger-state/);
+  assert.match(actionLedgerStep, /--state-root "\$CLAWSWEEPER_STATE_DIR"/);
+  assert.match(actionLedgerStep, /cp "\$durable_event_path" "\$event_path"/);
+  assert.match(actionLedgerStep, /--message "chore: append apply action ledger"/);
+  assert.match(actionLedgerStep, /action_ledger_args\+=\(--path "\$event_path"\)/);
+  assert.match(actionLedgerStep, /--rebase-strategy normal/);
+  assert.doesNotMatch(actionLedgerStep, /continue-on-error: true/);
+  assert.match(actionLedgerStep, /no paths were imported[\s\S]*exit 1/i);
 });
 
 test("apply workflow does not queue runtime-yield continuation without cursor progress", () => {
@@ -1178,10 +1225,12 @@ test("apply workflow drops a coverage-proof tail only after exact trace examinat
 test("apply proof and mutation start from fresh non-persisted source checkouts", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const proofJobStart = workflow.indexOf("\n  apply-proof:");
+  const proofPublisherStart = workflow.indexOf("\n  publish-apply-proof-action-ledger:");
   const applyJobStart = workflow.indexOf("\n  apply-existing:");
   assert.notEqual(proofJobStart, -1);
+  assert.notEqual(proofPublisherStart, -1);
   assert.notEqual(applyJobStart, -1);
-  const proofJob = workflow.slice(proofJobStart, applyJobStart);
+  const proofJob = workflow.slice(proofJobStart, proofPublisherStart);
   const applyJob = workflow.slice(applyJobStart);
 
   assert.match(proofJob, /actions\/checkout@v7[\s\S]*?persist-credentials: false/);

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1437,14 +1437,15 @@ test("event re-review status lets the durable queue reconcile interruptions", ()
   assert.doesNotMatch(block, /state="Superseded"/);
 });
 
-test("trusted comment router owns event ledger publication and capacity retries", () => {
+test("trusted comment router owns command ledger capacity retries", () => {
   const sweepWorkflow = readText(".github/workflows/sweep.yml");
   const routerWorkflow = readText(".github/workflows/repair-comment-router.yml");
   const eventStart = sweepWorkflow.indexOf("\n  event-review-apply:");
   const eventEnd = sweepWorkflow.indexOf("\n  target-fanout:", eventStart);
   const eventJob = sweepWorkflow.slice(eventStart, eventEnd);
 
-  assert.doesNotMatch(eventJob, /repair:publish-main/);
+  assert.match(eventJob, /publish-action-events/);
+  assert.match(eventJob, /repair:publish-main/);
   assert.doesNotMatch(eventJob, /count-command-actions/);
   assert.doesNotMatch(eventJob, /--wait-for-capacity/);
   assert.match(routerWorkflow, /Commit comment router ledger/);

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -11,6 +11,7 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 import test from "node:test";
+import YAML from "yaml";
 
 import { makeTreeReadOnlyForTest, restoreTreeModesForTest } from "../dist/clawsweeper.js";
 import { readText, tmpPrefix } from "./helpers.ts";
@@ -54,6 +55,164 @@ test("ledger-producing jobs initialize immutable workflow context", () => {
   assert.match(action, /CLAWSWEEPER_ACTION_LEDGER_FORCE=1/);
   assert.match(action, /CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT=\$output_root/);
   assert.match(action, /GITHUB_RUN_STARTED_AT=\$run_started_at/);
+});
+
+test("review and apply primary boundaries ignore ledger-only failures", () => {
+  type WorkflowStep = {
+    name?: string;
+    uses?: string;
+    id?: string;
+    if?: string;
+    run?: string;
+    env?: Record<string, string>;
+    "continue-on-error"?: boolean;
+  };
+  type WorkflowJob = {
+    if?: string;
+    steps: WorkflowStep[];
+  };
+
+  const workflow = YAML.parse(readText(".github/workflows/sweep.yml")) as {
+    jobs: Record<string, WorkflowJob>;
+  };
+  const job = (name: string): WorkflowJob => {
+    const value = workflow.jobs[name];
+    assert.ok(value, `missing ${name} job`);
+    return value;
+  };
+  const step = (jobName: string, name: string): WorkflowStep => {
+    const value = job(jobName).steps.find((candidate) => candidate.name === name);
+    assert.ok(value, `missing ${jobName} step ${name}`);
+    return value;
+  };
+  const setupLedger = (jobName: string): WorkflowStep => {
+    const value = job(jobName).steps.find((candidate) =>
+      candidate.uses?.endsWith("/setup-action-ledger"),
+    );
+    assert.ok(value, `missing ${jobName} ledger setup`);
+    return value;
+  };
+
+  for (const jobName of [
+    "event-review-apply",
+    "review",
+    "publish",
+    "retry-failed-reviews",
+    "apply-proof",
+    "apply-existing",
+  ]) {
+    assert.equal(
+      setupLedger(jobName)["continue-on-error"],
+      true,
+      `${jobName} ledger setup must fail open`,
+    );
+  }
+  for (const [jobName, stepName] of [
+    ["event-review-apply", "Finalize exact event action ledger"],
+    ["review", "Finalize review action ledger"],
+  ] as const) {
+    assert.equal(
+      step(jobName, stepName)["continue-on-error"],
+      true,
+      `${stepName} must not poison primary review publication`,
+    );
+  }
+
+  const exactPublish = step("event-review-apply", "Publish event result and apply safe close");
+  assert.match(exactPublish.if ?? "", /always\(\) && !cancelled\(\)/);
+  assert.match(exactPublish.if ?? "", /review-exact-event-item\.outcome == 'success'/);
+  assert.match(exactPublish.if ?? "", /setup-state\.outcome == 'success'/);
+  assert.doesNotMatch(exactPublish.if ?? "", /action-ledger/);
+  const exactPrimary = step("event-review-apply", "Export exact review primary result");
+  const exactQueue = step("event-review-apply", "Complete exact-review queue lease");
+  assert.equal(exactPrimary.env?.PRIMARY_JOB_STATUS, "${{ job.status }}");
+  assert.match(exactPrimary.run ?? "", /outcome=(?:failure|cancelled|success)/);
+  assert.match(exactPrimary.run ?? "", /PRIMARY_JOB_STATUS.*success/);
+  assert.match(exactQueue.env?.PRIMARY_OUTCOME ?? "", /exact-review-primary-result/);
+  assert.doesNotMatch(exactQueue.run ?? "", /JOB_STATUS|job\.status/);
+
+  const ledgerDownload = job("publish").steps.find(
+    (candidate) => candidate.id === "download-review-action-ledger",
+  );
+  assert.ok(ledgerDownload);
+  assert.equal(ledgerDownload["continue-on-error"], true);
+  for (const name of [
+    "Import immutable review action events",
+    "Publish immutable review action ledger",
+  ]) {
+    assert.equal(step("publish", name)["continue-on-error"], true, `${name} must fail open`);
+  }
+  const artifactSync = step("publish", "Sync before applying artifacts");
+  assert.match(artifactSync.if ?? "", /setup-publish-state\.outcome == 'success'/);
+  assert.match(artifactSync.if ?? "", /setup-publish-pnpm\.outcome == 'success'/);
+  assert.match(artifactSync.if ?? "", /download-review-artifacts\.outcome == 'success'/);
+  assert.doesNotMatch(artifactSync.if ?? "", /action-ledger/);
+  const artifactApply = step("publish", "Apply review artifacts");
+  assert.match(artifactApply.if ?? "", /sync-review-artifacts\.outcome == 'success'/);
+  assert.match(artifactApply.run ?? "", /review_batch_succeeded=/);
+  assert.match(artifactApply.run ?? "", /artifacts_applied=true/);
+  const artifactLedger = step("publish", "Publish review artifact action ledger");
+  assert.match(artifactLedger.if ?? "", /apply-review-artifacts\.outputs\.artifacts_applied/);
+  const recordPublish = step("publish", "Commit review records");
+  assert.match(recordPublish.if ?? "", /always\(\) && !cancelled\(\)/);
+  assert.match(recordPublish.if ?? "", /apply-review-artifacts\.outputs\.artifacts_applied/);
+  assert.match(recordPublish.run ?? "", /records_published=true/);
+
+  for (const name of [
+    "Dispatch reproducible bug implementation candidates",
+    "Dispatch vision-fit implementation candidates",
+    "Backfill viable open issue implementation candidates",
+    "Dispatch background review comment sync",
+    "Sync selected review comments",
+  ]) {
+    const condition = step("publish", name).if ?? "";
+    assert.match(condition, /always\(\) && !cancelled\(\)/, name);
+    assert.match(condition, /commit-review-records\.outputs\.records_published == 'true'/, name);
+    assert.doesNotMatch(condition, /success\(\)|action-ledger/, name);
+  }
+  const selectedApply = step("publish", "Dispatch selected safe close proposals to isolated apply");
+  assert.match(selectedApply.if ?? "", /sync-selected-review-comments\.outputs\.sync_succeeded/);
+  assert.doesNotMatch(selectedApply.if ?? "", /success\(\)|action-ledger/);
+  const reviewContinuation = step("publish", "Continue sweep");
+  assert.match(
+    reviewContinuation.if ?? "",
+    /apply-review-artifacts\.outputs\.review_batch_succeeded/,
+  );
+  assert.match(reviewContinuation.if ?? "", /commit-review-records\.outputs\.records_published/);
+  assert.doesNotMatch(reviewContinuation.if ?? "", /success\(\)|action-ledger/);
+
+  const proofMarker = step("apply-proof", "Export primary apply proof result");
+  assert.match(proofMarker.if ?? "", /always\(\) && !cancelled\(\)/);
+  assert.match(proofMarker.if ?? "", /proof-select\.outcome == 'success'/);
+  assert.match(proofMarker.if ?? "", /generate-apply-proofs\.outcome == 'success'/);
+  assert.doesNotMatch(proofMarker.if ?? "", /success\(\)|action-ledger/);
+  assert.match(job("apply-existing").if ?? "", /needs\.apply-proof\.outputs\.proof_ready/);
+  assert.doesNotMatch(
+    job("apply-existing").if ?? "",
+    /needs\.apply-proof\.result|publish-apply-proof-action-ledger/,
+  );
+
+  const applySteps = job("apply-existing").steps;
+  const applyMarkerIndex = applySteps.findIndex(
+    (candidate) => candidate.name === "Export primary apply result",
+  );
+  const applyFinalizerIndex = applySteps.findIndex(
+    (candidate) => candidate.name === "Finalize apply action ledger",
+  );
+  assert.ok(applyMarkerIndex >= 0);
+  assert.ok(applyFinalizerIndex > applyMarkerIndex);
+  const applyMarker = applySteps[applyMarkerIndex]!;
+  assert.match(applyMarker.if ?? "", /apply-existing-run\.outcome == 'success'/);
+  for (const name of [
+    "Retry final apply status publication",
+    "Continue apply sweep",
+    "Queue review backstops",
+  ]) {
+    const condition = step("apply-existing", name).if ?? "";
+    assert.match(condition, /always\(\) && !cancelled\(\)/, name);
+    assert.match(condition, /primary-apply-result\.outputs\.succeeded == 'true'/, name);
+    assert.doesNotMatch(condition, /success\(\)|action-ledger/, name);
+  }
 });
 
 test("review workflow gives Codex a read-only inspection token", () => {
@@ -169,6 +328,7 @@ test("exact event publish and routing require a successful fresh review artifact
   );
   const routeStart = eventReviewJob.indexOf("- name: Queue exact verdict router");
   const reactStart = eventReviewJob.indexOf("- name: React to target item completion");
+  const primaryResultStart = eventReviewJob.indexOf("- name: Export exact review primary result");
   const releaseLeaseStart = eventReviewJob.indexOf("- name: Release terminal review leases");
   const confirmTerminalStart = eventReviewJob.indexOf(
     "- name: Confirm terminal item remains closed",
@@ -185,7 +345,7 @@ test("exact event publish and routing require a successful fresh review artifact
   const publishStep = eventReviewJob.slice(publishStart, releaseUnsuccessfulStart);
   const releaseUnsuccessfulStep = eventReviewJob.slice(releaseUnsuccessfulStart, routeStart);
   const routeStep = eventReviewJob.slice(routeStart, releaseLeaseStart);
-  const reactStep = eventReviewJob.slice(reactStart, failStart);
+  const reactStep = eventReviewJob.slice(reactStart, primaryResultStart);
   const releaseLeaseStep = eventReviewJob.slice(releaseLeaseStart, confirmTerminalStart);
   const confirmTerminalStep = eventReviewJob.slice(confirmTerminalStart, completeStart);
   const failStep = eventReviewJob.slice(failStart, leaseCompleteStart);
@@ -225,7 +385,10 @@ test("exact event publish and routing require a successful fresh review artifact
   );
   assert.match(setupCodexStep, /if: \$\{\{ steps\.live-item\.outputs\.proceed == 'true' \}\}/);
   assert.match(exactReviewStep, /if: \$\{\{ steps\.live-item\.outputs\.proceed == 'true' \}\}/);
-  assert.match(publishStep, /if: \$\{\{ steps\.review-exact-event-item\.outcome == 'success' \}\}/);
+  assert.match(
+    publishStep,
+    /if: \$\{\{ always\(\) && !cancelled\(\) && steps\.review-exact-event-item\.outcome == 'success' && steps\.setup-state\.outcome == 'success' \}\}/,
+  );
   assert.match(publishStep, /if \[ ! -f "artifacts\/event\/\$ITEM_NUMBER\.md" \]/);
   assert.match(publishStep, /live_state="\$\(gh api/);
   assert.match(publishStep, /echo "terminal_noop=true" >> "\$GITHUB_OUTPUT"/);
@@ -763,7 +926,7 @@ test("apply workflow isolates Codex proof from the credentialed mutation runner"
   assert.ok(proofFinalizerStart > primaryProofResultStart);
   assert.match(
     proofJob,
-    /id: primary-proof-result[\s\S]*if: \$\{\{ success\(\) && \(steps\.proof-select\.outputs\.item_numbers == '' \|\| steps\.generate-apply-proofs\.outcome == 'success'\) \}\}[\s\S]*echo "ready=true" >> "\$GITHUB_OUTPUT"/,
+    /id: primary-proof-result[\s\S]*if: \$\{\{ always\(\) && !cancelled\(\) && steps\.proof-select\.outcome == 'success' && \(steps\.proof-select\.outputs\.item_numbers == '' \|\| steps\.generate-apply-proofs\.outcome == 'success'\) \}\}[\s\S]*echo "ready=true" >> "\$GITHUB_OUTPUT"/,
   );
   assert.match(
     proofJob,
@@ -1415,12 +1578,12 @@ test("sweep target tokens fall back when an org app installation is missing", ()
   );
   assert.ok(
     workflow.includes(
-      "if: ${{ success() && steps.target-write-token.outputs.token != '' && needs.plan.outputs.hot_intake != 'true'",
+      "if: ${{ always() && !cancelled() && steps.commit-review-records.outputs.records_published == 'true' && steps.target-write-token.outputs.token != '' && needs.plan.outputs.hot_intake != 'true'",
     ),
   );
   assert.ok(
     workflow.includes(
-      "if: ${{ success() && steps.target-write-token.outputs.token != '' && ((github.event_name == 'repository_dispatch'",
+      "if: ${{ always() && !cancelled() && steps.commit-review-records.outputs.records_published == 'true' && steps.target-write-token.outputs.token != '' && ((github.event_name == 'repository_dispatch'",
     ),
   );
   assert.ok(

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1144,8 +1144,9 @@ test("apply workflow finalization retries only target status after checkpointed 
   assert.match(actionLedgerStep, /--state-root "\$CLAWSWEEPER_STATE_DIR"/);
   assert.match(actionLedgerStep, /cp "\$durable_event_path" "\$event_path"/);
   assert.match(actionLedgerStep, /--message "chore: append apply action ledger"/);
-  assert.match(actionLedgerStep, /action_ledger_args\+=\(--path "\$event_path"\)/);
-  assert.match(actionLedgerStep, /--rebase-strategy normal/);
+  assert.match(actionLedgerStep, /publish-action-event-paths/);
+  assert.match(actionLedgerStep, /--paths-file "\$event_paths_file"/);
+  assert.doesNotMatch(actionLedgerStep, /repair:publish-main/);
   assert.doesNotMatch(actionLedgerStep, /continue-on-error: true/);
   assert.match(actionLedgerStep, /no paths were imported[\s\S]*exit 1/i);
 });
@@ -1480,7 +1481,8 @@ test("trusted comment router owns command ledger capacity retries", () => {
   const eventJob = sweepWorkflow.slice(eventStart, eventEnd);
 
   assert.match(eventJob, /publish-action-events/);
-  assert.match(eventJob, /repair:publish-main/);
+  assert.match(eventJob, /publish-action-event-paths/);
+  assert.doesNotMatch(eventJob, /repair:publish-main/);
   assert.doesNotMatch(eventJob, /count-command-actions/);
   assert.doesNotMatch(eventJob, /--wait-for-capacity/);
   assert.match(routerWorkflow, /Commit comment router ledger/);

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -592,6 +592,62 @@ test("publish workflow dispatches immediate apply through the isolated lane", ()
   assert.match(publishJob, /queue: max/);
 });
 
+test("selected comment sync finalizes interrupted receipts before publication", () => {
+  const workflow = readText(".github/workflows/sweep.yml");
+  const publishJobStart = workflow.indexOf("\n  publish:");
+  const recoverJobStart = workflow.indexOf("\n  recover-review-failures:", publishJobStart);
+  const publishJob = workflow.slice(publishJobStart, recoverJobStart);
+  const syncStart = publishJob.indexOf("- name: Sync selected review comments");
+  const finalizerStart = publishJob.indexOf(
+    "- name: Finalize selected review comment action ledger",
+  );
+  const publicationStart = publishJob.indexOf(
+    "- name: Publish selected review comment action ledger",
+  );
+
+  assert.ok(syncStart >= 0);
+  assert.ok(finalizerStart > syncStart);
+  assert.ok(publicationStart > finalizerStart);
+  assert.match(
+    publishJob.slice(syncStart, finalizerStart),
+    /timeout --kill-after=30s 840s pnpm run apply-decisions[\s\S]*echo "exit_code=\$selected_comment_exit_code" >> "\$GITHUB_OUTPUT"[\s\S]*exit "\$selected_comment_exit_code"/,
+  );
+  assert.match(
+    publishJob.slice(finalizerStart, publicationStart),
+    /if: \$\{\{ always\(\)[\s\S]*SELECTED_COMMENT_EXIT_CODE:[\s\S]*--interrupt-open-attempts --reason cancelled[\s\S]*--interrupt-open-attempts --reason timeout[\s\S]*--interrupt-open-attempts --reason workflow_failed[\s\S]*finalize-action-events/,
+  );
+  assert.match(
+    publishJob.slice(publicationStart, publicationStart + 400),
+    /steps\.finalize-selected-review-comment-action-ledger\.outcome == 'success'/,
+  );
+});
+
+test("failed-review retry cleanup restores the captured command failure", () => {
+  const workflow = readText(".github/workflows/sweep.yml");
+  const retryJobStart = workflow.indexOf("\n  retry-failed-reviews:");
+  const auditJobStart = workflow.indexOf("\n  audit-dashboard:", retryJobStart);
+  const retryJob = workflow.slice(retryJobStart, auditJobStart);
+  const commandStart = retryJob.indexOf("- name: Plan or dispatch failed-review retries");
+  const finalizerStart = retryJob.indexOf("- name: Finalize failed-review retry action ledger");
+  const publicationStart = retryJob.indexOf("- name: Publish failed-review retry action ledger");
+  const artifactStart = retryJob.indexOf("uses: actions/upload-artifact@v7", publicationStart);
+  const restoreStart = retryJob.indexOf("- name: Restore failed-review retry outcome");
+
+  assert.ok(commandStart >= 0);
+  assert.ok(finalizerStart > commandStart);
+  assert.ok(publicationStart > finalizerStart);
+  assert.ok(artifactStart > publicationStart);
+  assert.ok(restoreStart > artifactStart);
+  assert.match(
+    retryJob.slice(commandStart, finalizerStart),
+    /continue-on-error: true[\s\S]*echo "exit_code=\$retry_exit_code" >> "\$GITHUB_OUTPUT"[\s\S]*exit "\$retry_exit_code"/,
+  );
+  assert.match(
+    retryJob.slice(restoreStart),
+    /steps\.retry-failed-reviews-run\.outcome != 'success'[\s\S]*RETRY_EXIT_CODE:[\s\S]*exit "\$retry_exit_code"/,
+  );
+});
+
 test("broad record publishers isolate tuple reconciliation from status and auxiliary state", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   for (const stepName of [

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -577,10 +577,18 @@ test("publish workflow dispatches immediate apply through the isolated lane", ()
   );
   const dispatchEnd = publishJob.indexOf("\n      - ", dispatchStart + 1);
   const dispatchStep = publishJob.slice(dispatchStart, dispatchEnd);
+  const dispatchCondition = dispatchStep.match(/^\s+if: (.+)$/m)?.[1] ?? "";
 
   assert.doesNotMatch(publishJob, /setup-codex/);
   assert.match(publishJob, /name: Dispatch selected safe close proposals to isolated apply/);
   assert.doesNotMatch(dispatchStep, /pnpm run apply-decisions/);
+  assert.match(
+    dispatchCondition,
+    /^\$\{\{ always\(\) && !cancelled\(\) && steps\.sync-selected-review-comments\.outputs\.sync_succeeded == 'true'/,
+  );
+  assert.doesNotMatch(dispatchCondition, /sync-selected-review-comments\.outcome/);
+  assert.doesNotMatch(dispatchCondition, /finalize-selected-review-comment-action-ledger/);
+  assert.doesNotMatch(dispatchCondition, /publish-selected-review-comment-action-ledger/);
   assert.match(dispatchStep, /gh workflow run sweep\.yml/);
   assert.match(dispatchStep, /-f apply_existing=true/);
   assert.match(dispatchStep, /-f apply_item_numbers="\$item_numbers"/);
@@ -604,8 +612,15 @@ test("selected comment sync finalizes interrupted receipts before publication", 
   const publicationStart = publishJob.indexOf(
     "- name: Publish selected review comment action ledger",
   );
+  const primarySyncSuccess = publishJob.indexOf(
+    'echo "sync_succeeded=true" >> "$GITHUB_OUTPUT"',
+    syncStart,
+  );
+  const statusPublishStart = publishJob.indexOf("pnpm run status --", syncStart);
 
   assert.ok(syncStart >= 0);
+  assert.ok(primarySyncSuccess > syncStart);
+  assert.ok(statusPublishStart > primarySyncSuccess);
   assert.ok(finalizerStart > syncStart);
   assert.ok(publicationStart > finalizerStart);
   assert.match(
@@ -700,6 +715,10 @@ test("apply workflow isolates Codex proof from the credentialed mutation runner"
   const proofJob = workflow.slice(proofJobStart, proofPublisherStart);
   const proofPublisherJob = workflow.slice(proofPublisherStart, applyJobStart);
   const applyJob = workflow.slice(applyJobStart);
+  const applyCondition = applyJob.match(/^\s+if: (.+)$/m)?.[1] ?? "";
+  const proofGenerationStart = proofJob.indexOf("- name: Generate bound close coverage proofs");
+  const primaryProofResultStart = proofJob.indexOf("- name: Export primary apply proof result");
+  const proofFinalizerStart = proofJob.indexOf("- name: Finalize apply proof action ledger");
 
   assert.match(
     proofJob,
@@ -721,6 +740,7 @@ test("apply workflow isolates Codex proof from the credentialed mutation runner"
     proofJob,
     /action_ledger_artifact_name: \$\{\{ steps\.publishable-action-ledger\.outputs\.name \}\}/,
   );
+  assert.match(proofJob, /proof_ready: \$\{\{ steps\.primary-proof-result\.outputs\.ready \}\}/);
   assert.match(
     proofJob,
     /name=apply-coverage-proofs-\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}/,
@@ -738,6 +758,13 @@ test("apply workflow isolates Codex proof from the credentialed mutation runner"
   );
   assert.match(proofJob, /include-hidden-files: true/);
   assert.match(proofJob, /if-no-files-found: error/);
+  assert.ok(proofGenerationStart >= 0);
+  assert.ok(primaryProofResultStart > proofGenerationStart);
+  assert.ok(proofFinalizerStart > primaryProofResultStart);
+  assert.match(
+    proofJob,
+    /id: primary-proof-result[\s\S]*if: \$\{\{ success\(\) && \(steps\.proof-select\.outputs\.item_numbers == '' \|\| steps\.generate-apply-proofs\.outcome == 'success'\) \}\}[\s\S]*echo "ready=true" >> "\$GITHUB_OUTPUT"/,
+  );
   assert.match(
     proofJob,
     /if: \$\{\{ always\(\) && steps\.upload-action-events\.outputs\.artifact-id != '' \}\}/,
@@ -757,6 +784,12 @@ test("apply workflow isolates Codex proof from the credentialed mutation runner"
   assert.doesNotMatch(proofPublisherJob, /github\.run_attempt/);
 
   assert.match(applyJob, /needs: \[apply-proof, publish-apply-proof-action-ledger\]/);
+  assert.match(
+    applyCondition,
+    /^\$\{\{ always\(\) && !cancelled\(\) && needs\.apply-proof\.outputs\.proof_ready == 'true' &&/,
+  );
+  assert.doesNotMatch(applyCondition, /needs\.apply-proof\.result/);
+  assert.doesNotMatch(applyCondition, /needs\.publish-apply-proof-action-ledger/);
   assert.doesNotMatch(applyJob, /setup-codex|OPENAI_API_KEY|CLAWSWEEPER_INTERNAL_MODEL/);
   assert.match(applyJob, /Create target write token/);
   assert.match(applyJob, /Create state token/);
@@ -1392,7 +1425,7 @@ test("sweep target tokens fall back when an org app installation is missing", ()
   );
   assert.ok(
     workflow.includes(
-      "if: ${{ success() && steps.target-write-token.outputs.token != '' && github.event.inputs.apply_after_review == 'true' }}",
+      "if: ${{ always() && !cancelled() && steps.sync-selected-review-comments.outputs.sync_succeeded == 'true' && steps.target-write-token.outputs.token != '' && github.event.inputs.apply_after_review == 'true' }}",
     ),
   );
   assert.doesNotMatch(workflow, new RegExp("OPENCLAW_" + "GH_TOKEN"));

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -46,8 +46,11 @@ test("ledger-producing jobs initialize immutable workflow context", () => {
 
   const action = readText(".github/actions/setup-action-ledger/action.yml");
   assert.match(action, /actions\/runs\/\$\{GITHUB_RUN_ID\}/);
-  assert.match(action, /worktree_root="\$\(cd "\$worktree_root" && pwd -P\)"/);
-  assert.doesNotMatch(action, /GITHUB_WORKSPACE\/\$\{\{ inputs\.worktree-path \}\}/);
+  assert.match(
+    action,
+    /RUNNER_TEMP\/clawsweeper-action-ledger\/\$\{GITHUB_RUN_ID\}\/\$\{GITHUB_RUN_ATTEMPT\}\/\$\{GITHUB_JOB\}/,
+  );
+  assert.doesNotMatch(action, /GITHUB_WORKSPACE/);
   assert.match(action, /CLAWSWEEPER_ACTION_LEDGER_FORCE=1/);
   assert.match(action, /CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT=\$output_root/);
   assert.match(action, /GITHUB_RUN_STARTED_AT=\$run_started_at/);
@@ -81,6 +84,9 @@ test("review workflow gives Codex a read-only inspection token", () => {
   assert.match(exactReviewStep, /Exact review produced no artifact for open item/);
   assert.match(reviewJob, /uses: \.\/clawsweeper\/\.github\/actions\/setup-codex/);
   assert.doesNotMatch(reviewJob, /uses: \.\/\.github\/actions\/setup-codex/);
+  assert.match(exactReviewStep, /--codex-sandbox read-only/);
+  assert.match(reviewJob, /--codex-sandbox read-only/);
+  assert.doesNotMatch(workflow, /--codex-sandbox danger-full-access/);
 });
 
 test("review execution tokens can read check runs and commit statuses", () => {
@@ -670,7 +676,10 @@ test("apply workflow isolates Codex proof from the credentialed mutation runner"
   );
   assert.match(proofJob, /id: upload-action-events/);
   assert.match(proofJob, /name: \$\{\{ steps\.proof-artifact\.outputs\.action_ledger_name \}\}/);
-  assert.match(proofJob, /path: \.clawsweeper-repair\/action-ledger-state\/\*\*/);
+  assert.match(
+    proofJob,
+    /path: \$\{\{ runner\.temp \}\}\/clawsweeper-action-ledger\/\$\{\{ github\.run_id \}\}\/\$\{\{ github\.run_attempt \}\}\/\$\{\{ github\.job \}\}\/\*\*/,
+  );
   assert.match(proofJob, /include-hidden-files: true/);
   assert.match(proofJob, /if-no-files-found: error/);
   assert.match(
@@ -1140,8 +1149,9 @@ test("apply workflow finalization retries only target status after checkpointed 
   assert.doesNotMatch(finalStatusStep, /results\/(?:apply|comment-sync)-cursors/);
   assert.match(actionLedgerStep, /publish-action-events/);
   assert.doesNotMatch(actionLedgerStep, /action-ledger-proof/);
-  assert.match(actionLedgerStep, /action-ledger-state/);
+  assert.match(actionLedgerStep, /CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT/);
   assert.match(actionLedgerStep, /--state-root "\$CLAWSWEEPER_STATE_DIR"/);
+  assert.match(actionLedgerStep, /--expected-producer-job "\$GITHUB_JOB"/);
   assert.match(actionLedgerStep, /cp "\$durable_event_path" "\$event_path"/);
   assert.match(actionLedgerStep, /--message "chore: append apply action ledger"/);
   assert.match(actionLedgerStep, /publish-action-event-paths/);
@@ -1987,7 +1997,25 @@ test("review finalizers recover start-only ledger attempts after hard timeout", 
     assert.match(block, /"124"/);
     assert.match(block, /"137"/);
     assert.match(block, /--interrupt-open-attempts --reason timeout/);
+    assert.match(block, /--interrupt-open-attempts --reason cancelled/);
+    assert.match(block, /--interrupt-open-attempts --reason workflow_failed/);
+    assert.ok(
+      block.indexOf("--reason cancelled") < block.indexOf("--reason timeout"),
+      "explicit cancellation must outrank timeout-like signal exits",
+    );
   }
+});
+
+test("every action-ledger publication authenticates the expected producer job", () => {
+  const workflow = readText(".github/workflows/sweep.yml");
+  const commands = workflow.match(
+    /pnpm run --silent publish-action-events -- \\\n(?:\s+.*\\\n)*\s+--expected-producer-job [^\n]+/g,
+  );
+  assert.ok(commands);
+  assert.equal(commands.length, 8);
+  assert.ok(commands.every((command) => command.includes("--expected-producer-job")));
+  assert.match(workflow, /--expected-producer-job review/);
+  assert.match(workflow, /--expected-producer-job apply-proof/);
 });
 
 test("sweep exact event reviews preserve the configured fallback without an adaptive payload", () => {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -21,6 +21,38 @@ test("sweep keeps optional media tooling out of review startup", () => {
   assert.doesNotMatch(workflow, /setup-media-proof-tools/);
 });
 
+test("ledger-producing jobs initialize immutable workflow context", () => {
+  const workflow = readText(".github/workflows/sweep.yml");
+  for (const jobName of [
+    "event-review-apply",
+    "review",
+    "publish",
+    "retry-failed-reviews",
+    "apply-proof",
+    "apply-existing",
+  ]) {
+    const start = workflow.indexOf(`\n  ${jobName}:`);
+    assert.notEqual(start, -1, `missing ${jobName} job`);
+    const remaining = workflow.slice(start + 1);
+    const nextJob = remaining.match(/\n  [a-z0-9_-]+:\n/);
+    const end = nextJob?.index === undefined ? workflow.length : start + 1 + nextJob.index;
+    const job = workflow.slice(start, end);
+    assert.match(
+      job,
+      /uses: \.\/(?:clawsweeper\/)?\.github\/actions\/setup-action-ledger/,
+      `${jobName} must initialize the action ledger`,
+    );
+  }
+
+  const action = readText(".github/actions/setup-action-ledger/action.yml");
+  assert.match(action, /actions\/runs\/\$\{GITHUB_RUN_ID\}/);
+  assert.match(action, /worktree_root="\$\(cd "\$worktree_root" && pwd -P\)"/);
+  assert.doesNotMatch(action, /GITHUB_WORKSPACE\/\$\{\{ inputs\.worktree-path \}\}/);
+  assert.match(action, /CLAWSWEEPER_ACTION_LEDGER_FORCE=1/);
+  assert.match(action, /CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT=\$output_root/);
+  assert.match(action, /GITHUB_RUN_STARTED_AT=\$run_started_at/);
+});
+
 test("review workflow gives Codex a read-only inspection token", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const eventReviewJobStart = workflow.indexOf("\n  event-review-apply:");
@@ -607,7 +639,10 @@ test("apply workflow isolates Codex proof from the credentialed mutation runner"
   const proofPublisherJob = workflow.slice(proofPublisherStart, applyJobStart);
   const applyJob = workflow.slice(applyJobStart);
 
-  assert.match(proofJob, /permissions:\s+contents: read\s+issues: read\s+pull-requests: read/);
+  assert.match(
+    proofJob,
+    /permissions:\s+actions: read\s+contents: read\s+issues: read\s+pull-requests: read/,
+  );
   assert.match(proofJob, /persist-credentials: false/);
   assert.match(proofJob, /persist-credentials: "false"/);
   assert.doesNotMatch(proofJob, /Create target write token|Create state token/);
@@ -1931,9 +1966,26 @@ test("sweep exact event reviews consume only the immutable claimed decision", ()
   assert.match(reviewBlock, /detected media allowance \$\{media_proof_timeout_seconds\}s/);
   assert.doesNotMatch(reviewBlock, /review_timeout_seconds=.*media_proof_timeout_seconds/);
   assert.match(reviewBlock, /timeout --kill-after=30s "\$\{review_timeout_seconds\}s"/);
+  assert.match(reviewBlock, /echo "exit_code=\$review_exit_code" >> "\$GITHUB_OUTPUT"/);
   assert.match(reviewBlock, /--codex-timeout-ms "\$codex_timeout_ms"/);
   assert.doesNotMatch(reviewBlock, /timeout --kill-after=30s 12m/);
   assert.doesNotMatch(reviewBlock, /--codex-timeout-ms 600000/);
+});
+
+test("review finalizers recover start-only ledger attempts after hard timeout", () => {
+  const workflow = readText(".github/workflows/sweep.yml");
+  for (const finalizerName of [
+    "Finalize exact event action ledger",
+    "Finalize review action ledger",
+  ]) {
+    const start = workflow.indexOf(`- name: ${finalizerName}`);
+    assert.ok(start >= 0, `missing ${finalizerName}`);
+    const block = workflow.slice(start, workflow.indexOf("\n      - name:", start + 1));
+    assert.match(block, /REVIEW_EXIT_CODE:/);
+    assert.match(block, /"124"/);
+    assert.match(block, /"137"/);
+    assert.match(block, /--interrupt-open-attempts --reason timeout/);
+  }
 });
 
 test("sweep exact event reviews preserve the configured fallback without an adaptive payload", () => {


### PR DESCRIPTION
## Summary

- dual-write immutable action receipts for review batches/items/retries, review logs/comments, apply actions/batches, and publication phases
- bind operation and idempotency identities to immutable review/apply inputs, keeping retry and comment-publication keys stable and separate
- recover start-only review attempts deterministically on timeout before sealing/publishing ledger state
- reserve `published` for externally durable receipts; local review records, logs, and apply reports terminate as `completed`
- wire explicit workflow activation, proof artifacts, and focused identity, retry, interruption, timeout, and workflow coverage

## Validation

- `pnpm --config.verify-deps-before-run=false run check`
  - unit: 1,097 passed, 2 platform skips, 0 failed
  - repair: 884 passed, 0 failed
  - changed coverage: 100% lines, 86.90% branches, 100% functions
  - full coverage: 74.58% lines, 73.28% branches, 84.48% functions
  - all 362 files matched formatting
- `pnpm --config.verify-deps-before-run=false run build:all`
- focused runtime/workflow suites: 135 passed, 2 platform skips
- `test/sweep-workflow.test.ts`: 57 passed
- `git diff --check`

The branch is rebased onto current `main`; hosted CI and exact-head autoreview are the remaining gates.