### PR TITLE
fix(queue): rearm stale exact review alarms

### DIFF
--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -884,7 +884,9 @@ export class ExactReviewQueue {
       return;
     }
     const scheduled = await this.storage.getAlarm();
-    if (scheduled === null || next < scheduled) await this.storage.setAlarm(next);
+    if (scheduled === null || scheduled <= now || next < scheduled) {
+      await this.storage.setAlarm(next);
+    }
   }
 }
 

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -2478,7 +2478,7 @@ test("exact-review reconciliation cannot release a later attempt with the same r
   }
 });
 
-test("exact-review stats heals a missing alarm and expired lease", async () => {
+test("exact-review stats heals a missing or stale alarm and expired lease", async () => {
   const storage = new MemoryDurableStorage();
   const queue = new ExactReviewQueue({ storage }, {});
   await storage.put("exact-review-queue", {
@@ -2560,6 +2560,12 @@ test("exact-review stats heals a missing alarm and expired lease", async () => {
   const scheduledAfterPoll = await storage.getAlarm();
   assert.ok(scheduledBeforePoll !== null && scheduledAfterPoll !== null);
   assert.ok(scheduledAfterPoll <= scheduledBeforePoll);
+
+  await storage.setAlarm(Date.now() - 1_000);
+  const staleAlarmPollStartedAt = Date.now();
+  await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"));
+  const rescheduledAlarm = await storage.getAlarm();
+  assert.ok(rescheduledAlarm !== null && rescheduledAlarm > staleAlarmPollStartedAt);
 });
 
 function isoAgo(ms: number) {


### PR DESCRIPTION
## Summary

- Re-arm an exact-review Durable Object alarm when its stored timestamp has already passed.
- Add regression coverage for the dashboard heartbeat recovering a stale alarm.

## Problem

`ExactReviewQueue.scheduleNext()` previously retained any non-null scheduled alarm unless the next wake-up was earlier. A concurrent enqueue can leave an already-expired alarm stored while `alarm()` is awaiting GitHub preflight or dispatch work. The completed alarm then fails to schedule the queue's required future wake-up, stranding pending exact reviews.

The July 12 incident showed the resulting failure: event-item runs for `openclaw/openclaw#105422` through `#105426` were dispatched, but `#105427` (opened three seconds later) and subsequent issue/PR events remained unreviewed. The queue later reported pending work with no active lease or dispatch.

## Implementation

Treat `scheduled <= now` exactly like a missing alarm and set the computed next wake-up. Valid earlier future alarms remain untouched.

## Validation

- `pnpm exec node --test test/dashboard-worker.test.ts`
- `pnpm run build:dashboard`
- `pnpm run lint:dashboard`
- `git diff --check`
- `codex review --uncommitted` — clean; no actionable findings.
- `codex review --base origin/main` — clean; no actionable findings.

## Risks / rollout

This changes only stale Durable Object alarm recovery. It does not change queue capacity, target selection, review publication, or command routing. It preserves an existing valid earlier alarm and introduces no changelog change.
