### PR TITLE
fix(queue): shorten exact delivery dedupe retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Recovered exact-review intake from Cloudflare SQLite value-size exhaustion by pruning delivery receipts after five days while preserving the pending queue. Thanks @brokemac79.
 - Hardened action-ledger privacy, import identity and causal validation,
   multi-shard capacity, crash-safe completion publication, portable paths,
   bounded shard, marker, and spool reads, producer-lock and finalization races,

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -110,7 +110,9 @@ const EXACT_REVIEW_COMPLETION_RETRY_MAX_MS = 2 * 60 * 60 * 1000;
 const EXACT_REVIEW_RECONCILE_RUN_LIMIT = 32;
 const EXACT_REVIEW_RECONCILE_CLAIM_MATCH_LIMIT = EXACT_REVIEW_RECONCILE_RUN_LIMIT * 2;
 const EXACT_REVIEW_RECONCILE_CONCURRENCY = 4;
-const EXACT_REVIEW_QUEUE_DELIVERY_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+// Keep a multi-day idempotency window for delayed GitHub/Actions retries while
+// limiting the singleton queue record until delivery receipts move to bounded storage.
+const EXACT_REVIEW_QUEUE_DELIVERY_TTL_MS = 5 * 24 * 60 * 60 * 1000;
 const EXACT_REVIEW_QUEUE_STATE_KEY = "exact-review-queue";
 const EXACT_REVIEW_QUEUE_NAME = "global";
 const EXACT_REVIEW_COMMAND_STATUS_MARKER_PATTERN =

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -889,6 +889,32 @@ test("exact-review queue coalesces deliveries, dispatches a bound rollout snapsh
   }
 });
 
+test("exact-review queue retains delivery dedupe records for five days", async () => {
+  const storage = new MemoryDurableStorage();
+  const fiveDaysMs = 5 * 24 * 60 * 60 * 1000;
+  await storage.put("exact-review-queue", {
+    deliveries: {
+      "delivery-expired": Date.now() - fiveDaysMs - 60_000,
+      "delivery-within-window": Date.now() - fiveDaysMs + 60_000,
+    },
+    items: {},
+  });
+  const queue = new ExactReviewQueue({ storage }, {});
+
+  assert.equal(
+    (await queue.fetch(buildExactReviewQueueRequest("delivery-fresh", 619, "opened"))).status,
+    202,
+  );
+
+  const state = (await storage.get("exact-review-queue")) as {
+    deliveries: Record<string, number>;
+  };
+  assert.deepEqual(Object.keys(state.deliveries).sort(), [
+    "delivery-fresh",
+    "delivery-within-window",
+  ]);
+});
+
 test("exact-review claim preserves its immutable decision across a newer enqueue", async () => {
   const storage = new MemoryDurableStorage();
   const item = unclaimedExactReviewQueueItem(620);


### PR DESCRIPTION
## Summary

- Reduce exact-review delivery receipt retention from seven days to five days.
- Preserve delayed-delivery idempotency inside the new five-day window.
- Add an exact queue test proving that a six-day-old receipt is pruned while a receipt inside the five-day window is retained.

## Problem

The global `ExactReviewQueue` Durable Object stores delivery IDs and queue items in one `exact-review-queue` value. Every accepted enqueue prunes expired IDs, adds the new delivery ID, and rewrites that complete value.

The queue returned HTTP 500 during exact-review enqueue after the review-intake outage affecting #515 and #516. Cloudflare SQLite-backed Durable Objects limit a single key and value to 2 MiB: <https://developers.cloudflare.com/durable-objects/platform/limits/>.

There were 60,789 `repository_dispatch` workflow runs from 2026-07-05 through 2026-07-12, and 46,857 from 2026-07-07 through 2026-07-12. Those are traffic indicators rather than an exact count of durable queue writes because target-sweep events bypass legacy enqueue. A conservative JSON-equivalent estimate of 60,742 legacy receipt IDs is 2,247,481 bytes before queue items, above the 2,097,152-byte limit. This makes the seven-day unbounded receipt ledger the leading explanation for the 500, pending a Cloudflare error-tail confirmation.

## Decision

PR #317 introduced the durable queue but did not document a product requirement for a seven-day receipt window. Five days keeps a 120-hour GitHub/Actions replay and retry-deduplication window, while allowing receipts aged from five to seven days to be compacted by the next successful enqueue.

This is an emergency mitigation, not the durable design: it does not reset storage, drop pending items, or change queue leases. It will not help if the retained five-day receipt set itself is still too large.

## Risks and follow-up

- A redelivery more than five days old can be accepted as a fresh exact review; this is preferable to leaving all intake unavailable, but is weaker duplicate protection than before.
- Replace the monolithic receipt object with bounded SQLite rows or per-receipt keys with expiry, preserving the pending-item queue and existing receipts during migration.
- Add receipt count/serialized-size telemetry and sanitized enqueue-failure diagnostics. Obtain a read-only Cloudflare error tail to confirm the current 500's precise storage or alarm exception.

## Validation

- `pnpm exec node --test test/dashboard-worker.test.ts` — 81 passed.
- `pnpm run build:dashboard` — passed.
- `pnpm run lint:dashboard` — passed.
- `pnpm exec oxfmt --check dashboard/worker.ts test/dashboard-worker.test.ts` — passed.
- `git diff --check` — passed.
- `codex review --uncommitted` — clean; no actionable findings.
- `codex review --base origin/main` — clean; no actionable findings.

`pnpm run format:check` remains baseline-red in this checkout across 360 repository files; the two changed files pass the targeted formatter check above.

## Rollout

After the dashboard deployment, verify the deployed SHA, one normal maintainer `@clawsweeper review` command, and `/api/exact-review-queue`. If enqueue still returns HTTP 500, do not reduce the retention further blindly; capture the Cloudflare exception and move directly to the bounded-storage repair.

Related: #317, #515, #516, #517.
