### PR TITLE
fix: normalize exact-review queue storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
-- Recovered exact-review intake from Cloudflare SQLite value-size exhaustion by pruning delivery receipts after five days while preserving the pending queue. Thanks @brokemac79.
+- Recovered exact-review intake from Cloudflare SQLite value-size exhaustion by normalizing delivery receipts and queue items into independently bounded rows, committing dedupe and admission atomically, restoring the seven-day idempotency window, and migrating live queue state through a transaction-coupled, generation-aware, size-bounded rollback bridge that retains the complete active dedupe set and safely reimports rollback-era changes. Thanks @brokemac79.
 - Hardened action-ledger privacy, import identity and causal validation,
   multi-shard capacity, crash-safe completion publication, portable paths,
   bounded shard, marker, and spool reads, producer-lock and finalization races,

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -3,6 +3,7 @@ import {
   isClawSweeperReReviewCommandText,
 } from "../src/repair/comment-command-text.ts";
 import { isExactReviewCloseGuardLabel } from "../src/repair/exact-review-guard-labels.ts";
+import { stableJson } from "../src/stable-json.ts";
 import { bayHtml } from "./bay-page.ts";
 import { TRIAGE_ROUTING_GROUPS, triageRoutingGroupsForLabels } from "./triage-routing-groups.ts";
 
@@ -62,7 +63,6 @@ type ExactReviewClaimedRun = {
   claimGeneration: number;
 };
 type ExactReviewQueueState = {
-  deliveries: Record<string, number>;
   items: Record<string, ExactReviewQueueItem>;
   dispatcher?: {
     state: "active" | "paused" | "blocked" | "unknown";
@@ -71,6 +71,19 @@ type ExactReviewQueueState = {
     checkedAt: number;
     retryAt?: number;
   };
+};
+type LegacyExactReviewQueueState = ExactReviewQueueState & {
+  deliveries?: Record<string, number>;
+};
+type ExactReviewQueueBaseline = {
+  items: Map<string, string>;
+  dispatcherJson: string | null;
+};
+type ExactReviewQueueStorageMeta = {
+  schema_version: number;
+  migrated_at: number;
+  storage_generation: number;
+  dispatcher_json: string | null;
 };
 type DurableObjectStub = { fetch: (request: Request) => Promise<Response> };
 type DurableObjectNamespace = {
@@ -110,10 +123,23 @@ const EXACT_REVIEW_COMPLETION_RETRY_MAX_MS = 2 * 60 * 60 * 1000;
 const EXACT_REVIEW_RECONCILE_RUN_LIMIT = 32;
 const EXACT_REVIEW_RECONCILE_CLAIM_MATCH_LIMIT = EXACT_REVIEW_RECONCILE_RUN_LIMIT * 2;
 const EXACT_REVIEW_RECONCILE_CONCURRENCY = 4;
-// Keep a multi-day idempotency window for delayed GitHub/Actions retries while
-// limiting the singleton queue record until delivery receipts move to bounded storage.
-const EXACT_REVIEW_QUEUE_DELIVERY_TTL_MS = 5 * 24 * 60 * 60 * 1000;
+// This is an idempotency policy, not a storage-size control. Receipts live in
+// individual indexed SQLite rows and are pruned in bounded batches.
+const EXACT_REVIEW_QUEUE_DELIVERY_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const EXACT_REVIEW_QUEUE_DELIVERY_PRUNE_BATCH = 1_000;
+const EXACT_REVIEW_QUEUE_DELIVERY_PRUNE_MAX_BATCHES = 5;
+const EXACT_REVIEW_QUEUE_SQL_BINDING_ROW_BATCH = 50;
+const EXACT_REVIEW_QUEUE_STORAGE_SCHEMA_VERSION = 1;
+const EXACT_REVIEW_QUEUE_LEGACY_ROLLBACK_MS = 24 * 60 * 60 * 1000;
+const EXACT_REVIEW_QUEUE_LEGACY_SHADOW_MAX_BYTES = 1 * 1024 * 1024;
+const EXACT_REVIEW_QUEUE_LEGACY_RECEIPT_ROW_LIMIT = 20_000;
+const EXACT_REVIEW_QUEUE_LEGACY_RECEIPT_SHIFT_MS = 2 * 24 * 60 * 60 * 1000;
+const EXACT_REVIEW_QUEUE_ROLLBACK_CLOCK_SKEW_MS = 5 * 60 * 1000;
+const EXACT_REVIEW_QUEUE_LEGACY_GENERATION_PREFIX = "__clawsweeper_sql_generation:";
 const EXACT_REVIEW_QUEUE_STATE_KEY = "exact-review-queue";
+const EXACT_REVIEW_QUEUE_META_TABLE = "exact_review_queue_meta";
+const EXACT_REVIEW_QUEUE_ITEM_TABLE = "exact_review_queue_items";
+const EXACT_REVIEW_QUEUE_DELIVERY_TABLE = "exact_review_queue_deliveries";
 const EXACT_REVIEW_QUEUE_NAME = "global";
 const EXACT_REVIEW_COMMAND_STATUS_MARKER_PATTERN =
   /^<!-- clawsweeper-command-status:[^<>\r\n]{1,200} -->$/;
@@ -401,63 +427,98 @@ export class StatusStore {
 export class ExactReviewQueue {
   private storage;
   private env;
+  private ready: Promise<void>;
+  private migratedAt = 0;
+  private legacyMirrorDisabled = false;
+  private legacyMirrorWarningReported = false;
+  private readonly baselines = new WeakMap<ExactReviewQueueState, ExactReviewQueueBaseline>();
 
   constructor(state, env) {
     this.storage = state.storage;
     this.env = env;
+    const initialize = () => this.initializeStorage();
+    this.ready =
+      typeof state.blockConcurrencyWhile === "function"
+        ? Promise.resolve(state.blockConcurrencyWhile(initialize))
+        : initialize();
   }
 
   async fetch(request: Request) {
+    await this.ready;
+    this.cleanupLegacyCompatibilitySync();
     const url = new URL(request.url);
     if (request.method === "POST" && url.pathname === "/enqueue") {
       const body = objectValue(await request.json().catch(() => null));
       const deliveryId = String(body.delivery_id || "").trim();
       const decision = exactReviewDecisionFrom(body.decision);
       if (!deliveryId) return json({ error: "missing_delivery_id" }, 400);
+      if (deliveryId.startsWith(EXACT_REVIEW_QUEUE_LEGACY_GENERATION_PREFIX)) {
+        return json({ error: "reserved_delivery_id" }, 400);
+      }
       if (!decision) return json({ error: "invalid_exact_review_item" }, 400);
       if (!isExactReviewQueueTargetEnabled(decision, this.env)) {
         return json({ ok: true, accepted: false, reason: "target not enabled" }, 202);
       }
 
       const now = Date.now();
-      const state = await this.readState();
-      pruneExactReviewDeliveries(state, now);
-      const existingDelivery = state.deliveries[deliveryId];
-      if (existingDelivery) {
+      const accepted = this.storage.transactionSync(() => {
+        this.pruneDeliveryReceiptsSync(now);
+        this.storage.sql.exec(
+          `DELETE FROM ${EXACT_REVIEW_QUEUE_DELIVERY_TABLE}
+            WHERE delivery_id = ? AND received_at <= ?`,
+          deliveryId,
+          now - EXACT_REVIEW_QUEUE_DELIVERY_TTL_MS,
+        );
+        const insertedReceipts = Array.from(
+          this.storage.sql.exec(
+            `INSERT OR IGNORE INTO ${EXACT_REVIEW_QUEUE_DELIVERY_TABLE}
+             (delivery_id, received_at) VALUES (?, ?)
+           RETURNING delivery_id`,
+            deliveryId,
+            now,
+          ),
+        );
+        if (insertedReceipts.length !== 1) {
+          this.syncLegacyCompatibilitySync(this.readStateSync());
+          return { deduped: true as const };
+        }
+
+        const state = this.readStateSync();
+        const key = exactReviewItemKey(decision);
+        const current = state.items[key];
+        const nextAttemptAt = exactReviewQueueEnqueueAttemptAt(state, now);
+        if (current) {
+          // A pending command has no executor yet, so an ordinary item event must not erase its
+          // acknowledgement context. Once dispatched, that lease already owns the context and a
+          // newer revision should start clean unless it carries its own command fields.
+          current.decision =
+            current.state === "pending"
+              ? mergePendingExactReviewDecision(current.decision, decision)
+              : decision;
+          current.revision += 1;
+          current.updatedAt = now;
+          current.nextAttemptAt = nextAttemptAt;
+          if (current.state === "pending") current.attempts = 0;
+        } else {
+          state.items[key] = {
+            key,
+            decision,
+            state: "pending",
+            revision: 1,
+            createdAt: now,
+            updatedAt: now,
+            nextAttemptAt,
+            attempts: 0,
+          };
+        }
+        this.writeStateSync(state);
+        return { deduped: false as const, key, state };
+      });
+      if (accepted.deduped) {
         return json({ ok: true, deduped: true, item_key: exactReviewItemKey(decision) }, 202);
       }
-
-      state.deliveries[deliveryId] = now;
-      const key = exactReviewItemKey(decision);
-      const current = state.items[key];
-      const nextAttemptAt = exactReviewQueueEnqueueAttemptAt(state, now);
-      if (current) {
-        // A pending command has no executor yet, so an ordinary item event must not erase its
-        // acknowledgement context. Once dispatched, that lease already owns the context and a
-        // newer revision should start clean unless it carries its own command fields.
-        current.decision =
-          current.state === "pending"
-            ? mergePendingExactReviewDecision(current.decision, decision)
-            : decision;
-        current.revision += 1;
-        current.updatedAt = now;
-        current.nextAttemptAt = nextAttemptAt;
-        if (current.state === "pending") current.attempts = 0;
-      } else {
-        state.items[key] = {
-          key,
-          decision,
-          state: "pending",
-          revision: 1,
-          createdAt: now,
-          updatedAt: now,
-          nextAttemptAt,
-          attempts: 0,
-        };
-      }
-      await this.writeState(state);
-      await this.scheduleNext(state, now);
-      return json({ ok: true, queued: true, item_key: key }, 202);
+      await this.scheduleNext(accepted.state, now);
+      return json({ ok: true, queued: true, item_key: accepted.key }, 202);
     }
 
     if (request.method === "POST" && url.pathname === "/claim") {
@@ -479,7 +540,7 @@ export class ExactReviewQueue {
       }
 
       const now = Date.now();
-      const state = await this.readState();
+      const state = this.readStateSync();
       const item = tupleClaim ? state.items[itemKey] : exactReviewItemForLease(state, leaseId);
       if (
         !item ||
@@ -597,7 +658,7 @@ export class ExactReviewQueue {
       if (body.retry_at !== undefined && requestedRetryAt === null) {
         return json({ error: "invalid_retry_at" }, 400);
       }
-      const state = await this.readState();
+      const state = this.readStateSync();
       const item = tupleCompletion ? state.items[itemKey] : exactReviewItemForLease(state, leaseId);
       if (
         !item ||
@@ -655,7 +716,7 @@ export class ExactReviewQueue {
       // the durable queue to be reconciled.
       const requestedRunIds = new Set(requestedRuns.map((run) => run.runId));
       const matchesByRunId = new Map<string, ExactReviewQueueItem[]>();
-      const state = await this.readState();
+      const state = this.readStateSync();
       for (const item of Object.values(state.items)) {
         if (
           item.state !== "leased" ||
@@ -684,7 +745,7 @@ export class ExactReviewQueue {
       if (!runs) return json({ error: "invalid_terminal_runs" }, 400);
 
       const now = Date.now();
-      const state = await this.readState();
+      const state = this.readStateSync();
       let reconciled = 0;
       let requeued = 0;
       let completed = 0;
@@ -712,29 +773,45 @@ export class ExactReviewQueue {
 
     if (request.method === "GET" && url.pathname === "/stats") {
       const now = Date.now();
-      const state = await this.readState();
-      // Dashboard reads are also the operational heartbeat. Reclaim leases and
-      // restore the alarm here so a deploy or lost alarm cannot strand backlog.
-      const changed = reclaimExpiredExactReviewLeases(state, now);
-      if (changed) await this.writeState(state);
+      const state = this.storage.transactionSync(() => {
+        this.pruneDeliveryReceiptsSync(now);
+        const current = this.readStateSync();
+        // Dashboard reads are also the operational heartbeat. Reclaim leases and
+        // restore the alarm here so a deploy or lost alarm cannot strand backlog.
+        const changed = reclaimExpiredExactReviewLeases(current, now);
+        if (changed) this.writeStateSync(current);
+        else this.syncLegacyCompatibilitySync(current);
+        return current;
+      });
       await this.scheduleNext(state, now);
-      return json(
-        exactReviewQueueStats(
+      return json({
+        ...exactReviewQueueStats(
           state,
           now,
           exactReviewQueueCapacity(this.env),
           exactReviewTargetCapacity(this.env),
         ),
-      );
+        delivery_receipts: this.deliveryReceiptCountSync(),
+        storage_schema_version: EXACT_REVIEW_QUEUE_STORAGE_SCHEMA_VERSION,
+        legacy_rollback_available:
+          !this.legacyMirrorDisabled &&
+          now < this.migratedAt + EXACT_REVIEW_QUEUE_LEGACY_ROLLBACK_MS,
+      });
     }
 
     return new Response("not found", { status: 404 });
   }
 
   async alarm() {
+    await this.ready;
+    this.cleanupLegacyCompatibilitySync();
     const startedAt = Date.now();
     await this.storage.deleteAlarm();
-    const snapshot = await this.readState();
+    this.storage.transactionSync(() => {
+      this.pruneDeliveryReceiptsSync(startedAt);
+      this.syncLegacyCompatibilitySync(this.readStateSync());
+    });
+    const snapshot = this.readStateSync();
     const snapshotChanged = reclaimExpiredExactReviewLeases(snapshot, startedAt);
     const capacity = exactReviewQueueCapacity(this.env);
     const targetCapacity = exactReviewTargetCapacity(this.env);
@@ -763,7 +840,7 @@ export class ExactReviewQueue {
     // External fetches release the Durable Object input gate. Re-read before any
     // write so concurrent enqueue, claim, or complete requests cannot be lost.
     const now = Date.now();
-    const state = await this.readState();
+    const state = this.readStateSync();
     reclaimExpiredExactReviewLeases(state, now);
     const admitted = exactReviewQueueAdmittedItems(state, now, capacity, targetCapacity);
     if (!preflight.ok) {
@@ -833,7 +910,7 @@ export class ExactReviewQueue {
     // Dispatch calls also release the input gate. Merge failures into current
     // state only when the exact lease still owns the item.
     const completedAt = Date.now();
-    const current = await this.readState();
+    const current = this.readStateSync();
     let currentChanged = false;
     for (const failure of failures) {
       const item = current.items[failure.key];
@@ -857,21 +934,510 @@ export class ExactReviewQueue {
     await this.scheduleNext(current, completedAt);
   }
 
-  private async readState(): Promise<ExactReviewQueueState> {
-    const stored = (await this.storage.get(EXACT_REVIEW_QUEUE_STATE_KEY)) as
-      | ExactReviewQueueState
+  private async initializeStorage() {
+    this.ensureStorageSchemaSync();
+    let meta = this.readStorageMetaSync();
+    let migratedLegacy = false;
+    const legacy = this.storage.kv.get(EXACT_REVIEW_QUEUE_STATE_KEY) as
+      | LegacyExactReviewQueueState
       | undefined;
+    if (!meta) {
+      const migratedAt = Date.now();
+      this.migratedAt = migratedAt;
+      this.storage.transactionSync(() => {
+        if (this.readStorageMetaSync()) return;
+
+        const itemRows = Object.entries(
+          legacy?.items && typeof legacy.items === "object" ? legacy.items : {},
+        ).map(([itemKey, item]) => [itemKey, JSON.stringify({ ...item, key: itemKey })]);
+        this.insertMigrationRowsSync(
+          EXACT_REVIEW_QUEUE_ITEM_TABLE,
+          ["item_key", "item_json"],
+          itemRows,
+        );
+
+        const receiptCutoff = migratedAt - EXACT_REVIEW_QUEUE_DELIVERY_TTL_MS;
+        const receiptRows = Object.entries(
+          legacy?.deliveries && typeof legacy.deliveries === "object" ? legacy.deliveries : {},
+        )
+          .filter(
+            ([deliveryId, receivedAt]) =>
+              !deliveryId.startsWith(EXACT_REVIEW_QUEUE_LEGACY_GENERATION_PREFIX) &&
+              Number.isSafeInteger(receivedAt) &&
+              receivedAt > receiptCutoff,
+          )
+          .map(([deliveryId, receivedAt]) => [deliveryId, receivedAt]);
+        this.insertMigrationRowsSync(
+          EXACT_REVIEW_QUEUE_DELIVERY_TABLE,
+          ["delivery_id", "received_at"],
+          receiptRows,
+        );
+
+        const dispatcherJson =
+          legacy?.dispatcher && typeof legacy.dispatcher === "object"
+            ? JSON.stringify(legacy.dispatcher)
+            : null;
+        this.storage.sql.exec(
+          `INSERT INTO ${EXACT_REVIEW_QUEUE_META_TABLE}
+             (singleton_id, schema_version, migrated_at, storage_generation, dispatcher_json)
+           VALUES (1, ?, ?, 1, ?)`,
+          EXACT_REVIEW_QUEUE_STORAGE_SCHEMA_VERSION,
+          migratedAt,
+          dispatcherJson,
+        );
+        migratedLegacy = true;
+        this.syncLegacyCompatibilitySync(this.readStateSync());
+      });
+      meta = this.readStorageMetaSync();
+    }
+    if (!meta || Number(meta.schema_version) !== EXACT_REVIEW_QUEUE_STORAGE_SCHEMA_VERSION) {
+      throw new Error(`unsupported exact-review queue storage schema ${meta?.schema_version}`);
+    }
+    if (!Number.isSafeInteger(meta.storage_generation) || meta.storage_generation < 1) {
+      throw new Error("invalid exact-review queue storage generation");
+    }
+    if (!Number.isSafeInteger(meta.migrated_at) || meta.migrated_at < 1) {
+      throw new Error("invalid exact-review queue migration time");
+    }
+    this.migratedAt = Number(meta.migrated_at);
+    // Reconcile a surviving generation even after the ordinary shadow window:
+    // an actual rollback can keep mutating it while the new Worker is absent.
+    if (!migratedLegacy) {
+      this.storage.transactionSync(() => {
+        if (legacy) this.reconcileLegacyRollbackSync(legacy, meta);
+        this.syncLegacyCompatibilitySync(this.readStateSync());
+      });
+    }
+  }
+
+  private ensureStorageSchemaSync() {
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_QUEUE_META_TABLE} (
+         singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+         schema_version INTEGER NOT NULL,
+         migrated_at INTEGER NOT NULL,
+         storage_generation INTEGER NOT NULL,
+         dispatcher_json TEXT
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_QUEUE_ITEM_TABLE} (
+         item_key TEXT PRIMARY KEY,
+         item_json TEXT NOT NULL
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_QUEUE_DELIVERY_TABLE} (
+         delivery_id TEXT PRIMARY KEY,
+         received_at INTEGER NOT NULL
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `CREATE INDEX IF NOT EXISTS exact_review_queue_deliveries_received_at
+         ON ${EXACT_REVIEW_QUEUE_DELIVERY_TABLE} (received_at, delivery_id)`,
+    );
+  }
+
+  private readStorageMetaSync() {
+    return Array.from(
+      this.storage.sql.exec(
+        `SELECT schema_version, migrated_at, storage_generation, dispatcher_json
+           FROM ${EXACT_REVIEW_QUEUE_META_TABLE}
+          WHERE singleton_id = 1`,
+      ),
+    )[0] as ExactReviewQueueStorageMeta | undefined;
+  }
+
+  private insertMigrationRowsSync(table: string, columns: string[], rows: unknown[][]) {
+    for (let offset = 0; offset < rows.length; offset += EXACT_REVIEW_QUEUE_SQL_BINDING_ROW_BATCH) {
+      const batch = rows.slice(offset, offset + EXACT_REVIEW_QUEUE_SQL_BINDING_ROW_BATCH);
+      const placeholders = batch.map(() => `(${columns.map(() => "?").join(", ")})`).join(", ");
+      this.storage.sql.exec(
+        `INSERT OR REPLACE INTO ${table} (${columns.join(", ")}) VALUES ${placeholders}`,
+        ...batch.flat(),
+      );
+    }
+  }
+
+  private readDeliveryReceiptsByIdSync(deliveryIds: string[]) {
+    const receipts = new Map<string, number>();
+    for (
+      let offset = 0;
+      offset < deliveryIds.length;
+      offset += EXACT_REVIEW_QUEUE_SQL_BINDING_ROW_BATCH
+    ) {
+      const batch = deliveryIds.slice(offset, offset + EXACT_REVIEW_QUEUE_SQL_BINDING_ROW_BATCH);
+      const placeholders = batch.map(() => "?").join(", ");
+      for (const row of this.storage.sql.exec(
+        `SELECT delivery_id, received_at
+           FROM ${EXACT_REVIEW_QUEUE_DELIVERY_TABLE}
+          WHERE delivery_id IN (${placeholders})`,
+        ...batch,
+      ) as Iterable<{ delivery_id: string; received_at: number }>) {
+        receipts.set(row.delivery_id, row.received_at);
+      }
+    }
+    return receipts;
+  }
+
+  private reconcileLegacyRollbackSync(
+    legacy: LegacyExactReviewQueueState,
+    meta: ExactReviewQueueStorageMeta,
+  ) {
+    const legacyState = this.normalizeLegacyState(legacy);
+    const sqlState = this.readStateSync();
+    const stateMatches = stableJson(legacyState) === stableJson(sqlState);
+    const { generation: legacyGeneration, receipts } = this.readLegacyBridge(legacy);
+    const sqlGeneration = Number(meta.storage_generation);
+
+    if (legacyGeneration !== undefined && legacyGeneration > sqlGeneration) {
+      throw new Error(
+        `invalid exact-review legacy rollback generation ${legacyGeneration} > ${sqlGeneration}`,
+      );
+    }
+    if (legacyGeneration !== undefined && legacyGeneration < sqlGeneration && !stateMatches) {
+      // A stale shadow can mean either a failed mirror write by this version or
+      // rollback-era mutations by the old version. Neither side is safe to discard.
+      throw new Error(
+        `ambiguous exact-review legacy rollback state at generations ${legacyGeneration} and ${sqlGeneration}`,
+      );
+    }
+    if (legacyGeneration === undefined && !stateMatches) {
+      throw new Error("ambiguous exact-review legacy rollback state without a generation marker");
+    }
+
+    const replaceState = legacyGeneration === sqlGeneration && !stateMatches;
+    const sqlReceipts = this.readDeliveryReceiptsByIdSync(
+      receipts.map(([deliveryId]) => String(deliveryId)),
+    );
+    const receiptChanges: unknown[][] = [];
+    if (legacyGeneration === sqlGeneration) {
+      const latestRollbackTime = Date.now() + EXACT_REVIEW_QUEUE_ROLLBACK_CLOCK_SKEW_MS;
+      for (const [deliveryId, receivedAt] of receipts) {
+        const sqlReceivedAt = sqlReceipts.get(String(deliveryId));
+        if (
+          sqlReceivedAt !== undefined &&
+          Number(receivedAt) === this.legacyReceiptTimestamp(sqlReceivedAt)
+        ) {
+          continue;
+        }
+        if (!Number.isSafeInteger(receivedAt) || Number(receivedAt) > latestRollbackTime) {
+          throw new Error(`invalid exact-review rollback receipt ${deliveryId}`);
+        }
+        receiptChanges.push([deliveryId, receivedAt]);
+      }
+    } else if (legacyGeneration !== undefined) {
+      for (const [deliveryId, receivedAt] of receipts) {
+        const sqlReceivedAt = sqlReceipts.get(String(deliveryId));
+        if (
+          sqlReceivedAt === undefined ||
+          Number(receivedAt) !== this.legacyReceiptTimestamp(sqlReceivedAt)
+        ) {
+          throw new Error(
+            `ambiguous exact-review legacy rollback receipt at generations ${legacyGeneration} and ${sqlGeneration}`,
+          );
+        }
+      }
+    }
+
+    if (replaceState) {
+      this.storage.sql.exec(`DELETE FROM ${EXACT_REVIEW_QUEUE_ITEM_TABLE}`);
+      this.insertMigrationRowsSync(
+        EXACT_REVIEW_QUEUE_ITEM_TABLE,
+        ["item_key", "item_json"],
+        Object.entries(legacyState.items).map(([itemKey, item]) => [itemKey, JSON.stringify(item)]),
+      );
+    }
+    this.insertMigrationRowsSync(
+      EXACT_REVIEW_QUEUE_DELIVERY_TABLE,
+      ["delivery_id", "received_at"],
+      receiptChanges,
+    );
+    if (!replaceState && receiptChanges.length === 0) return;
+    this.storage.sql.exec(
+      `UPDATE ${EXACT_REVIEW_QUEUE_META_TABLE}
+          SET dispatcher_json = ?, storage_generation = storage_generation + 1
+        WHERE singleton_id = 1 AND storage_generation = ?`,
+      replaceState && legacyState.dispatcher
+        ? JSON.stringify(legacyState.dispatcher)
+        : replaceState
+          ? null
+          : meta.dispatcher_json,
+      sqlGeneration,
+    );
+    const reconciledGeneration = this.readStorageMetaSync()?.storage_generation;
+    if (reconciledGeneration !== sqlGeneration + 1) {
+      throw new Error("exact-review legacy rollback reconciliation lost its generation race");
+    }
+  }
+
+  private normalizeLegacyState(legacy: LegacyExactReviewQueueState): ExactReviewQueueState {
+    const items = Object.fromEntries(
+      Object.entries(legacy.items && typeof legacy.items === "object" ? legacy.items : {}).map(
+        ([itemKey, item]) => [itemKey, { ...item, key: itemKey }],
+      ),
+    ) as Record<string, ExactReviewQueueItem>;
     return {
-      deliveries:
-        stored?.deliveries && typeof stored.deliveries === "object" ? stored.deliveries : {},
-      items: stored?.items && typeof stored.items === "object" ? stored.items : {},
-      dispatcher:
-        stored?.dispatcher && typeof stored.dispatcher === "object" ? stored.dispatcher : undefined,
+      items,
+      ...(legacy.dispatcher && typeof legacy.dispatcher === "object"
+        ? { dispatcher: legacy.dispatcher }
+        : {}),
     };
   }
 
-  private async writeState(state: ExactReviewQueueState) {
-    await this.storage.put(EXACT_REVIEW_QUEUE_STATE_KEY, state);
+  private readLegacyBridge(legacy: LegacyExactReviewQueueState) {
+    const deliveries =
+      legacy.deliveries && typeof legacy.deliveries === "object" ? legacy.deliveries : {};
+    const generationMarkers = Object.entries(deliveries).filter(([deliveryId]) =>
+      deliveryId.startsWith(EXACT_REVIEW_QUEUE_LEGACY_GENERATION_PREFIX),
+    );
+    if (generationMarkers.length > 1) {
+      throw new Error("invalid exact-review legacy rollback generation markers");
+    }
+
+    let generation: number | undefined;
+    if (generationMarkers.length === 1) {
+      const [deliveryId, markedAt] = generationMarkers[0];
+      const rawGeneration = deliveryId.slice(EXACT_REVIEW_QUEUE_LEGACY_GENERATION_PREFIX.length);
+      generation = Number(rawGeneration);
+      if (
+        !/^\d+$/.test(rawGeneration) ||
+        !Number.isSafeInteger(generation) ||
+        generation < 1 ||
+        markedAt !== Number.MAX_SAFE_INTEGER
+      ) {
+        throw new Error("invalid exact-review legacy rollback generation marker");
+      }
+    }
+
+    const receiptCutoff = Date.now() - EXACT_REVIEW_QUEUE_DELIVERY_TTL_MS;
+    const receipts = Object.entries(deliveries)
+      .filter(
+        ([deliveryId, receivedAt]) =>
+          !deliveryId.startsWith(EXACT_REVIEW_QUEUE_LEGACY_GENERATION_PREFIX) &&
+          Number.isSafeInteger(receivedAt) &&
+          receivedAt > receiptCutoff,
+      )
+      .map(([deliveryId, receivedAt]) => [deliveryId, receivedAt]);
+    return { generation, receipts };
+  }
+
+  private readStateSync(): ExactReviewQueueState {
+    const meta = this.readStorageMetaSync();
+    if (!meta || Number(meta.schema_version) !== EXACT_REVIEW_QUEUE_STORAGE_SCHEMA_VERSION) {
+      throw new Error("exact-review queue storage is not initialized");
+    }
+
+    const items: Record<string, ExactReviewQueueItem> = {};
+    const baselineItems = new Map<string, string>();
+    for (const row of this.storage.sql.exec(
+      `SELECT item_key, item_json FROM ${EXACT_REVIEW_QUEUE_ITEM_TABLE}`,
+    ) as Iterable<{ item_key: string; item_json: string }>) {
+      let item: ExactReviewQueueItem;
+      try {
+        item = JSON.parse(row.item_json) as ExactReviewQueueItem;
+      } catch {
+        throw new Error(`invalid exact-review queue item JSON for ${row.item_key}`);
+      }
+      if (!item || typeof item !== "object" || item.key !== row.item_key) {
+        throw new Error(`invalid exact-review queue item for ${row.item_key}`);
+      }
+      items[row.item_key] = item;
+      baselineItems.set(row.item_key, row.item_json);
+    }
+
+    let dispatcher: ExactReviewQueueState["dispatcher"];
+    if (meta.dispatcher_json) {
+      try {
+        dispatcher = JSON.parse(meta.dispatcher_json) as ExactReviewQueueState["dispatcher"];
+      } catch {
+        throw new Error("invalid exact-review queue dispatcher JSON");
+      }
+    }
+    const state = { items, dispatcher };
+    this.baselines.set(state, {
+      items: baselineItems,
+      dispatcherJson: meta.dispatcher_json,
+    });
+    return state;
+  }
+
+  private writeState(state: ExactReviewQueueState) {
+    this.storage.transactionSync(() => this.writeStateSync(state));
+  }
+
+  private writeStateSync(state: ExactReviewQueueState) {
+    const baseline = this.baselines.get(state) || this.readStateBaselineSync();
+    const nextItems = new Map<string, string>();
+    for (const [itemKey, item] of Object.entries(state.items)) {
+      const itemJson = JSON.stringify(item);
+      nextItems.set(itemKey, itemJson);
+      if (baseline.items.get(itemKey) === itemJson) continue;
+      this.storage.sql.exec(
+        `INSERT INTO ${EXACT_REVIEW_QUEUE_ITEM_TABLE} (item_key, item_json)
+         VALUES (?, ?)
+         ON CONFLICT(item_key) DO UPDATE SET item_json = excluded.item_json`,
+        itemKey,
+        itemJson,
+      );
+    }
+    for (const itemKey of baseline.items.keys()) {
+      if (!nextItems.has(itemKey)) {
+        this.storage.sql.exec(
+          `DELETE FROM ${EXACT_REVIEW_QUEUE_ITEM_TABLE} WHERE item_key = ?`,
+          itemKey,
+        );
+      }
+    }
+
+    const dispatcherJson = state.dispatcher ? JSON.stringify(state.dispatcher) : null;
+    this.storage.sql.exec(
+      `UPDATE ${EXACT_REVIEW_QUEUE_META_TABLE}
+          SET dispatcher_json = ?, storage_generation = storage_generation + 1
+        WHERE singleton_id = 1`,
+      dispatcherJson,
+    );
+    this.syncLegacyCompatibilitySync(state);
+    this.baselines.set(state, { items: nextItems, dispatcherJson });
+  }
+
+  private readStateBaselineSync(): ExactReviewQueueBaseline {
+    const items = new Map<string, string>();
+    for (const row of this.storage.sql.exec(
+      `SELECT item_key, item_json FROM ${EXACT_REVIEW_QUEUE_ITEM_TABLE}`,
+    ) as Iterable<{ item_key: string; item_json: string }>) {
+      items.set(row.item_key, row.item_json);
+    }
+    return {
+      items,
+      dispatcherJson: this.readStorageMetaSync()?.dispatcher_json ?? null,
+    };
+  }
+
+  private pruneDeliveryReceiptsSync(now: number) {
+    const cutoff = now - EXACT_REVIEW_QUEUE_DELIVERY_TTL_MS;
+    for (let batch = 0; batch < EXACT_REVIEW_QUEUE_DELIVERY_PRUNE_MAX_BATCHES; batch += 1) {
+      const deleted = Array.from(
+        this.storage.sql.exec(
+          `DELETE FROM ${EXACT_REVIEW_QUEUE_DELIVERY_TABLE}
+          WHERE delivery_id IN (
+            SELECT delivery_id
+              FROM ${EXACT_REVIEW_QUEUE_DELIVERY_TABLE}
+             WHERE received_at <= ?
+             ORDER BY received_at, delivery_id
+             LIMIT ${EXACT_REVIEW_QUEUE_DELIVERY_PRUNE_BATCH}
+          )
+        RETURNING delivery_id`,
+          cutoff,
+        ),
+      );
+      if (deleted.length < EXACT_REVIEW_QUEUE_DELIVERY_PRUNE_BATCH) break;
+    }
+  }
+
+  private deliveryReceiptCountSync() {
+    const row = Array.from(
+      this.storage.sql.exec(
+        `SELECT COUNT(*) AS receipt_count FROM ${EXACT_REVIEW_QUEUE_DELIVERY_TABLE}`,
+      ),
+    )[0] as { receipt_count?: number } | undefined;
+    return Number(row?.receipt_count || 0);
+  }
+
+  private legacyReceiptTimestamp(receivedAt: number) {
+    return Math.min(
+      Number.MAX_SAFE_INTEGER,
+      receivedAt + EXACT_REVIEW_QUEUE_LEGACY_RECEIPT_SHIFT_MS,
+    );
+  }
+
+  private legacyDeliverySnapshotSync(now: number) {
+    const rows = Array.from(
+      this.storage.sql.exec(
+        `SELECT delivery_id, received_at
+           FROM ${EXACT_REVIEW_QUEUE_DELIVERY_TABLE}
+          WHERE received_at > ?
+          ORDER BY delivery_id
+          LIMIT ${EXACT_REVIEW_QUEUE_LEGACY_RECEIPT_ROW_LIMIT + 1}`,
+        now - EXACT_REVIEW_QUEUE_DELIVERY_TTL_MS,
+      ) as Iterable<{ delivery_id: string; received_at: number }>,
+    );
+    if (rows.length > EXACT_REVIEW_QUEUE_LEGACY_RECEIPT_ROW_LIMIT) return undefined;
+    return Object.fromEntries(
+      rows.map((row) => [row.delivery_id, this.legacyReceiptTimestamp(row.received_at)]),
+    );
+  }
+
+  private syncLegacyCompatibilitySync(state: ExactReviewQueueState) {
+    const now = Date.now();
+    if (now >= this.migratedAt + EXACT_REVIEW_QUEUE_LEGACY_ROLLBACK_MS) {
+      this.cleanupLegacyCompatibilitySync();
+      return;
+    }
+    const generation = this.readStorageMetaSync()?.storage_generation;
+    if (!Number.isSafeInteger(generation) || Number(generation) < 1) {
+      throw new Error("invalid exact-review queue storage generation");
+    }
+    const deliveries = this.legacyDeliverySnapshotSync(now);
+    if (!deliveries) {
+      this.disableLegacyMirrorSync(
+        `active receipt count exceeds ${EXACT_REVIEW_QUEUE_LEGACY_RECEIPT_ROW_LIMIT}`,
+      );
+      return;
+    }
+    // Old Worker code preserves the marker as an inert receipt. If it mutates
+    // this shadow after a rollback, the next upgrade can reconcile that exact
+    // generation instead of silently choosing one side. Its five-day receipt
+    // pruner sees timestamps shifted by two days, preserving the restored
+    // seven-day contract without changing the normalized SQL timestamps.
+    const shadow = {
+      deliveries: {
+        ...deliveries,
+        [`${EXACT_REVIEW_QUEUE_LEGACY_GENERATION_PREFIX}${generation}`]: Number.MAX_SAFE_INTEGER,
+      },
+      items: state.items,
+      dispatcher: state.dispatcher,
+    };
+    const shadowBytes = new TextEncoder().encode(JSON.stringify(shadow)).byteLength;
+    if (shadowBytes > EXACT_REVIEW_QUEUE_LEGACY_SHADOW_MAX_BYTES) {
+      this.disableLegacyMirrorSync(`shadow is ${shadowBytes} bytes`);
+      return;
+    }
+    try {
+      this.storage.kv.put(EXACT_REVIEW_QUEUE_STATE_KEY, shadow);
+      this.legacyMirrorDisabled = false;
+    } catch (error) {
+      this.disableLegacyMirrorSync(error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  private disableLegacyMirrorSync(reason: string) {
+    try {
+      // A failed refresh must not leave a stale generation that becomes
+      // indistinguishable from rollback-era mutations on the next upgrade.
+      this.storage.kv.delete(EXACT_REVIEW_QUEUE_STATE_KEY);
+    } catch (error) {
+      console.warn(
+        "exact-review stale legacy rollback shadow could not be removed",
+        error instanceof Error ? error.message : String(error),
+      );
+      throw error;
+    }
+    this.reportLegacyMirrorUnavailable(reason);
+  }
+
+  private reportLegacyMirrorUnavailable(reason: string) {
+    this.legacyMirrorDisabled = true;
+    if (this.legacyMirrorWarningReported) return;
+    this.legacyMirrorWarningReported = true;
+    console.warn("exact-review legacy rollback shadow unavailable", reason);
+  }
+
+  private cleanupLegacyCompatibilitySync() {
+    if (!this.migratedAt || Date.now() < this.migratedAt + EXACT_REVIEW_QUEUE_LEGACY_ROLLBACK_MS) {
+      return;
+    }
+    this.storage.kv.delete(EXACT_REVIEW_QUEUE_STATE_KEY);
   }
 
   private async scheduleNext(state: ExactReviewQueueState, now: number) {
@@ -2079,14 +2645,6 @@ function exactReviewQueueNextWakeAt(
   });
   if (!times.length) return now + DEFAULT_EXACT_REVIEW_RETRY_MS;
   return Math.max(now + 1_000, Math.min(...times));
-}
-
-function pruneExactReviewDeliveries(state: ExactReviewQueueState, now: number) {
-  for (const [deliveryId, receivedAt] of Object.entries(state.deliveries)) {
-    if (!Number.isFinite(receivedAt) || receivedAt + EXACT_REVIEW_QUEUE_DELIVERY_TTL_MS <= now) {
-      delete state.deliveries[deliveryId];
-    }
-  }
 }
 
 export function exactReviewQueueCapacity(env) {

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -182,6 +182,34 @@ command-status identifiers so the leased GitHub Actions executor can update the
 original acknowledgement through completion. GitHub Actions remains the
 executor and the existing review/apply safety model remains unchanged.
 
+The singleton Durable Object stores each delivery receipt and queue item in its
+own SQLite row. Receipt insertion and item coalescing commit in one transaction,
+so a crash cannot record a duplicate-suppression receipt without its queued
+work. Receipts retain the seven-day idempotency window and expire through the
+indexed timestamp path in bounded batches; `/api/exact-review-queue` reports
+`delivery_receipts`, `storage_schema_version`, and
+`legacy_rollback_available` for operational proof. On the first upgraded
+request, the Worker transactionally imports the former `exact-review-queue`
+value. For 24 hours it maintains a generation-marked legacy shadow containing
+the queue and the complete active seven-day receipt set. Receipt timestamps are
+translated by two days so the immediately previous Worker's five-day pruner
+preserves their original seven-day expiry, and the reserved generation marker
+cannot expire. SQL state, its generation, and the synchronous KV shadow update
+in one SQLite transaction, so no committed generation can leave an older shadow
+readable. A later re-upgrade uses the generation plus deterministic timestamp
+translation to distinguish unchanged shadow receipts from receipts accepted or
+refreshed by the rolled-back Worker. It imports authoritative queue and receipt
+changes; a surviving generation is reconciled before deletion even when the
+rollback outlives the ordinary window. A divergent stale generation fails
+closed instead of discarding either side.
+
+The Worker publishes that compatibility shadow only when the complete active
+set stays within 20,000 receipts and 1 MiB. If it cannot publish the complete
+shadow, it deletes any stale copy, reports rollback unavailable, and keeps the
+normalized queue serving; it never emits a lossy rollback state or retries the
+oversized write. The rollback bridge therefore cannot recreate the normalized
+queue's intake failure.
+
 Before each dispatch batch, the queue reads the `sweep.yml` workflow state once.
 If the workflow is disabled, or GitHub cannot confirm its state, due items stay
 pending and retry after `EXACT_REVIEW_WORKFLOW_PAUSED_RETRY_MS` (60 seconds by

--- a/test/action-ledger-runtime.test.ts
+++ b/test/action-ledger-runtime.test.ts
@@ -1369,7 +1369,6 @@ test("finalization publishes local shards before a bounded projection drain and 
     });
     assert.ok(event);
     const primaryPath = actionEventShardRelativePath(shardIdentity(event), [event], 1, 1);
-    const startedAt = Date.now();
     const flush = flushWorkflowActionEvents(root, {
       env,
       outputRoot,
@@ -1405,7 +1404,6 @@ test("finalization publishes local shards before a bounded projection drain and 
     );
 
     const paths = await flush;
-    assert.ok(Date.now() - startedAt < 1_000);
     assert.equal(aborted, true);
     assert.deepEqual(
       readOutputEvents(outputRoot, paths)

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import { createHash, createHmac, generateKeyPairSync } from "node:crypto";
+import { DatabaseSync } from "node:sqlite";
 import test from "node:test";
+import { isDeepStrictEqual } from "node:util";
 import { createContext, Script } from "node:vm";
 
 import worker, {
@@ -405,22 +407,212 @@ class MemoryKv {
   }
 }
 
+class MemorySqlCursor<T extends Record<string, unknown>> implements Iterable<T> {
+  rowsRead = 0;
+  readonly rowsWritten: number;
+  private readonly rows: T[];
+
+  constructor(rows: T[], rowsWritten: number) {
+    this.rows = rows;
+    this.rowsWritten = rowsWritten;
+  }
+
+  *[Symbol.iterator]() {
+    for (const row of this.rows) {
+      this.rowsRead += 1;
+      yield row;
+    }
+  }
+}
+
+class MemorySqlStorage {
+  private readonly database = new DatabaseSync(":memory:");
+  private failure: { pattern: RegExp; error: Error } | undefined;
+
+  exec(query: string, ...bindings: unknown[]) {
+    if (this.failure?.pattern.test(query)) {
+      const { error } = this.failure;
+      this.failure = undefined;
+      throw error;
+    }
+    const statement = this.database.prepare(query);
+    if (/^\s*(?:SELECT|WITH)\b/i.test(query) || /\bRETURNING\b/i.test(query)) {
+      const rows = statement.all(...bindings) as Record<string, unknown>[];
+      return new MemorySqlCursor(rows, rows.length);
+    }
+    const result = statement.run(...bindings);
+    return new MemorySqlCursor([], Number(result.changes));
+  }
+
+  transactionSync<T>(callback: () => T) {
+    this.database.exec("BEGIN IMMEDIATE");
+    try {
+      const result = callback();
+      this.database.exec("COMMIT");
+      return result;
+    } catch (error) {
+      this.database.exec("ROLLBACK");
+      throw error;
+    }
+  }
+
+  failNext(pattern: RegExp, error = new Error("injected SQL failure")) {
+    this.failure = { pattern, error };
+  }
+
+  hasNormalizedQueue() {
+    const table = this.database
+      .prepare(
+        "SELECT 1 AS found FROM sqlite_master WHERE type = 'table' AND name = 'exact_review_queue_meta'",
+      )
+      .get() as { found?: number } | undefined;
+    if (!table) return false;
+    return Boolean(
+      this.database
+        .prepare("SELECT 1 AS found FROM exact_review_queue_meta WHERE singleton_id = 1")
+        .get(),
+    );
+  }
+
+  readNormalizedQueue() {
+    const meta = this.database
+      .prepare("SELECT dispatcher_json FROM exact_review_queue_meta WHERE singleton_id = 1")
+      .get() as { dispatcher_json?: string | null } | undefined;
+    const items = Object.fromEntries(
+      (
+        this.database
+          .prepare("SELECT item_key, item_json FROM exact_review_queue_items ORDER BY item_key")
+          .all() as Array<{ item_key: string; item_json: string }>
+      ).map((row) => [row.item_key, JSON.parse(row.item_json)]),
+    );
+    const deliveries = Object.fromEntries(
+      (
+        this.database
+          .prepare(
+            "SELECT delivery_id, received_at FROM exact_review_queue_deliveries ORDER BY delivery_id",
+          )
+          .all() as Array<{ delivery_id: string; received_at: number }>
+      ).map((row) => [row.delivery_id, row.received_at]),
+    );
+    const state: {
+      deliveries: Record<string, number>;
+      items: Record<string, unknown>;
+      dispatcher?: unknown;
+    } = { deliveries, items };
+    if (meta?.dispatcher_json) state.dispatcher = JSON.parse(meta.dispatcher_json);
+    return state;
+  }
+
+  replaceNormalizedQueue(value: unknown) {
+    const state = (value && typeof value === "object" ? value : {}) as {
+      deliveries?: Record<string, number>;
+      items?: Record<string, unknown>;
+      dispatcher?: unknown;
+    };
+    this.transactionSync(() => {
+      this.database.exec("DELETE FROM exact_review_queue_deliveries");
+      this.database.exec("DELETE FROM exact_review_queue_items");
+      const insertDelivery = this.database.prepare(
+        "INSERT INTO exact_review_queue_deliveries (delivery_id, received_at) VALUES (?, ?)",
+      );
+      for (const [deliveryId, receivedAt] of Object.entries(state.deliveries || {})) {
+        insertDelivery.run(deliveryId, receivedAt);
+      }
+      const insertItem = this.database.prepare(
+        "INSERT INTO exact_review_queue_items (item_key, item_json) VALUES (?, ?)",
+      );
+      for (const [itemKey, item] of Object.entries(state.items || {})) {
+        insertItem.run(itemKey, JSON.stringify(item));
+      }
+      this.database
+        .prepare("UPDATE exact_review_queue_meta SET dispatcher_json = ? WHERE singleton_id = 1")
+        .run(state.dispatcher === undefined ? null : JSON.stringify(state.dispatcher));
+    });
+  }
+
+  setMigrationTime(migratedAt: number) {
+    this.database
+      .prepare("UPDATE exact_review_queue_meta SET migrated_at = ? WHERE singleton_id = 1")
+      .run(migratedAt);
+  }
+
+  setReceiptTime(deliveryId: string, receivedAt: number) {
+    this.database
+      .prepare("UPDATE exact_review_queue_deliveries SET received_at = ? WHERE delivery_id = ?")
+      .run(receivedAt, deliveryId);
+  }
+}
+
 class MemoryDurableStorage {
   private values = new Map<string, unknown>();
   private putCounts = new Map<string, number>();
+  private putFailure: { key: string; error: Error } | undefined;
+  private deleteFailure: { key: string; error: Error } | undefined;
   private alarmAt: number | null = null;
+  readonly sql = new MemorySqlStorage();
+  readonly kv = {
+    get: (key: string) => this.values.get(key),
+    put: (key: string, value: unknown) => this.putRawSync(key, value),
+    delete: (key: string) => this.deleteRawSync(key),
+  };
 
-  async get(key: string) {
+  transactionSync<T>(callback: () => T) {
+    const valuesBefore = new Map(
+      Array.from(this.values, ([key, value]) => [key, structuredClone(value)]),
+    );
+    const putCountsBefore = new Map(this.putCounts);
+    try {
+      return this.sql.transactionSync(callback);
+    } catch (error) {
+      this.values = valuesBefore;
+      this.putCounts = putCountsBefore;
+      throw error;
+    }
+  }
+
+  async get(key: string, options?: { noCache?: boolean }) {
+    if (key === "exact-review-queue" && this.sql.hasNormalizedQueue() && !options?.noCache) {
+      return this.sql.readNormalizedQueue();
+    }
     return this.values.get(key);
   }
 
   async put(key: string, value: unknown) {
-    this.values.set(key, value);
-    this.putCounts.set(key, (this.putCounts.get(key) || 0) + 1);
+    this.throwPutFailure(key);
+    if (key === "exact-review-queue" && this.sql.hasNormalizedQueue()) {
+      const normalized = this.sql.readNormalizedQueue();
+      const candidate = (value && typeof value === "object" ? value : {}) as {
+        deliveries?: Record<string, number>;
+        items?: Record<string, unknown>;
+        dispatcher?: unknown;
+      };
+      const deliveryEntries = Object.entries(candidate.deliveries || {});
+      const markerEntries = deliveryEntries.filter(([deliveryId]) =>
+        /^__clawsweeper_sql_generation:\d+$/.test(deliveryId),
+      );
+      const candidateReceipts = Object.fromEntries(
+        deliveryEntries.filter(
+          ([deliveryId]) => !deliveryId.startsWith("__clawsweeper_sql_generation:"),
+        ),
+      );
+      const normalizedReceiptIds = Object.keys(normalized.deliveries).sort();
+      const rollbackShadow =
+        markerEntries.length === 1 &&
+        markerEntries[0][1] === Number.MAX_SAFE_INTEGER &&
+        isDeepStrictEqual(Object.keys(candidateReceipts).sort(), normalizedReceiptIds) &&
+        normalizedReceiptIds.every(
+          (deliveryId) =>
+            Number(candidateReceipts[deliveryId]) >= Number(normalized.deliveries[deliveryId]),
+        ) &&
+        isDeepStrictEqual(candidate.items || {}, normalized.items) &&
+        isDeepStrictEqual(candidate.dispatcher, normalized.dispatcher);
+      if (!rollbackShadow) this.sql.replaceNormalizedQueue(candidate);
+    }
+    this.storeRaw(key, value);
   }
 
   async delete(key: string) {
-    this.values.delete(key);
+    return this.deleteRawSync(key);
   }
 
   async list() {
@@ -445,6 +637,64 @@ class MemoryDurableStorage {
 
   putCount(key: string) {
     return this.putCounts.get(key) || 0;
+  }
+
+  rawHas(key: string) {
+    return this.values.has(key);
+  }
+
+  rawGet(key: string) {
+    return this.values.get(key);
+  }
+
+  rawPut(key: string, value: unknown) {
+    this.values.set(key, structuredClone(value));
+  }
+
+  private throwPutFailure(key: string) {
+    if (this.putFailure?.key !== key) return;
+    const { error } = this.putFailure;
+    this.putFailure = undefined;
+    throw error;
+  }
+
+  private putRawSync(key: string, value: unknown) {
+    this.throwPutFailure(key);
+    this.storeRaw(key, value);
+  }
+
+  private storeRaw(key: string, value: unknown) {
+    this.values.set(key, structuredClone(value));
+    this.putCounts.set(key, (this.putCounts.get(key) || 0) + 1);
+  }
+
+  private deleteRawSync(key: string) {
+    if (this.deleteFailure?.key === key) {
+      const { error } = this.deleteFailure;
+      this.deleteFailure = undefined;
+      throw error;
+    }
+    return this.values.delete(key);
+  }
+
+  failNextPut(key: string, error = new Error("injected storage put failure")) {
+    this.putFailure = { key, error };
+  }
+
+  failNextDelete(key: string, error = new Error("injected storage delete failure")) {
+    this.deleteFailure = { key, error };
+  }
+
+  failNextSql(pattern: RegExp, error?: Error) {
+    this.sql.failNext(pattern, error);
+  }
+
+  setExactReviewMigrationTime(migratedAt: number) {
+    this.sql.setMigrationTime(migratedAt);
+  }
+
+  setExactReviewReceiptTime(deliveryId: string, receivedAt: number) {
+    this.sql.setReceiptTime(deliveryId, receivedAt);
   }
 }
 
@@ -889,13 +1139,13 @@ test("exact-review queue coalesces deliveries, dispatches a bound rollout snapsh
   }
 });
 
-test("exact-review queue retains delivery dedupe records for five days", async () => {
+test("exact-review queue migrates delivery receipts and retains them for seven days", async () => {
   const storage = new MemoryDurableStorage();
-  const fiveDaysMs = 5 * 24 * 60 * 60 * 1000;
+  const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
   await storage.put("exact-review-queue", {
     deliveries: {
-      "delivery-expired": Date.now() - fiveDaysMs - 60_000,
-      "delivery-within-window": Date.now() - fiveDaysMs + 60_000,
+      "delivery-expired": Date.now() - sevenDaysMs - 60_000,
+      "delivery-within-window": Date.now() - sevenDaysMs + 60_000,
     },
     items: {},
   });
@@ -913,6 +1163,432 @@ test("exact-review queue retains delivery dedupe records for five days", async (
     "delivery-fresh",
     "delivery-within-window",
   ]);
+  const stats = await (
+    await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(stats.delivery_receipts, 2);
+  assert.equal(stats.storage_schema_version, 1);
+  assert.equal(stats.legacy_rollback_available, true);
+  const shadowDeliveries = (
+    storage.rawGet("exact-review-queue") as { deliveries: Record<string, number> }
+  ).deliveries;
+  const shadowGenerationIds = Object.keys(shadowDeliveries).filter((deliveryId) =>
+    deliveryId.startsWith("__clawsweeper_sql_generation:"),
+  );
+  assert.equal(shadowGenerationIds.length, 1);
+  assert.equal(shadowDeliveries[shadowGenerationIds[0]], Number.MAX_SAFE_INTEGER);
+  assert.deepEqual(
+    Object.keys(shadowDeliveries)
+      .filter((deliveryId) => !deliveryId.startsWith("__clawsweeper_sql_generation:"))
+      .sort(),
+    ["delivery-fresh", "delivery-within-window"],
+  );
+  assert.ok(shadowDeliveries["delivery-within-window"] > Date.now() - 5 * 24 * 60 * 60 * 1000);
+
+  const restarted = new ExactReviewQueue({ storage }, {});
+  const duplicate = await restarted.fetch(
+    buildExactReviewQueueRequest("delivery-within-window", 619, "edited"),
+  );
+  assert.deepEqual(await duplicate.json(), {
+    ok: true,
+    deduped: true,
+    item_key: "openclaw/gogcli#619",
+  });
+});
+
+test("exact-review receipt acceptance and queue mutation commit atomically", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"));
+  storage.failNextSql(/INSERT INTO exact_review_queue_items/);
+
+  await assert.rejects(
+    queue.fetch(buildExactReviewQueueRequest("delivery-atomic", 625, "opened")),
+    /injected SQL failure/,
+  );
+  let state = (await storage.get("exact-review-queue")) as {
+    deliveries: Record<string, number>;
+    items: Record<string, unknown>;
+  };
+  assert.deepEqual(state.deliveries, {});
+  assert.deepEqual(state.items, {});
+
+  assert.equal(
+    (await queue.fetch(buildExactReviewQueueRequest("delivery-atomic", 625, "opened"))).status,
+    202,
+  );
+  state = (await storage.get("exact-review-queue")) as {
+    deliveries: Record<string, number>;
+    items: Record<string, unknown>;
+  };
+  assert.deepEqual(Object.keys(state.deliveries), ["delivery-atomic"]);
+  assert.deepEqual(Object.keys(state.items), ["openclaw/gogcli#625"]);
+});
+
+test("exact-review re-upgrade imports rollback-era queue mutations and receipts", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  assert.equal(
+    (await queue.fetch(buildExactReviewQueueRequest("delivery-before-rollback", 626, "opened")))
+      .status,
+    202,
+  );
+
+  const shadow = structuredClone(
+    storage.rawGet("exact-review-queue") as {
+      deliveries: Record<string, number>;
+      items: Record<string, Record<string, unknown>>;
+    },
+  );
+  const oldGenerationId = Object.keys(shadow.deliveries).find((deliveryId) =>
+    deliveryId.startsWith("__clawsweeper_sql_generation:"),
+  );
+  assert.ok(oldGenerationId);
+  const rollbackItem = structuredClone(shadow.items["openclaw/gogcli#626"]);
+  rollbackItem.key = "openclaw/gogcli#627";
+  rollbackItem.decision = {
+    ...(rollbackItem.decision as Record<string, unknown>),
+    itemNumber: 627,
+  };
+  delete shadow.items["openclaw/gogcli#626"];
+  shadow.items["openclaw/gogcli#627"] = rollbackItem;
+  shadow.deliveries["delivery-during-rollback"] = Date.now();
+  storage.rawPut("exact-review-queue", shadow);
+
+  const upgraded = new ExactReviewQueue({ storage }, {});
+  const stats = await (
+    await upgraded.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(stats.pending, 1);
+  assert.equal(stats.delivery_receipts, 2);
+  const state = (await storage.get("exact-review-queue")) as {
+    deliveries: Record<string, number>;
+    items: Record<string, unknown>;
+  };
+  assert.deepEqual(Object.keys(state.items), ["openclaw/gogcli#627"]);
+  assert.deepEqual(Object.keys(state.deliveries).sort(), [
+    "delivery-before-rollback",
+    "delivery-during-rollback",
+  ]);
+  const upgradedShadow = storage.rawGet("exact-review-queue") as {
+    deliveries: Record<string, number>;
+  };
+  const upgradedGenerationIds = Object.keys(upgradedShadow.deliveries).filter((deliveryId) =>
+    deliveryId.startsWith("__clawsweeper_sql_generation:"),
+  );
+  assert.equal(upgradedGenerationIds.length, 1);
+  assert.match(upgradedGenerationIds[0], /^__clawsweeper_sql_generation:\d+$/);
+  assert.notEqual(upgradedGenerationIds[0], oldGenerationId);
+  assert.deepEqual(
+    Object.keys(upgradedShadow.deliveries)
+      .filter((deliveryId) => !deliveryId.startsWith("__clawsweeper_sql_generation:"))
+      .sort(),
+    ["delivery-before-rollback", "delivery-during-rollback"],
+  );
+});
+
+test("exact-review re-upgrade distinguishes a refreshed rollback receipt", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  assert.equal(
+    (await queue.fetch(buildExactReviewQueueRequest("delivery-refreshed", 634, "opened"))).status,
+    202,
+  );
+  const oldReceivedAt = Date.now() - 8 * 24 * 60 * 60 * 1000;
+  const refreshedAt = Date.now();
+  storage.setExactReviewReceiptTime("delivery-refreshed", oldReceivedAt);
+  const rollback = structuredClone(
+    storage.rawGet("exact-review-queue") as {
+      deliveries: Record<string, number>;
+      items: Record<string, { revision: number; updatedAt: number }>;
+    },
+  );
+  rollback.deliveries["delivery-refreshed"] = refreshedAt;
+  rollback.items["openclaw/gogcli#634"].revision += 1;
+  rollback.items["openclaw/gogcli#634"].updatedAt = refreshedAt;
+  storage.rawPut("exact-review-queue", rollback);
+
+  const upgraded = new ExactReviewQueue({ storage }, {});
+  const stats = await (
+    await upgraded.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(stats.pending, 1);
+  assert.equal(stats.delivery_receipts, 1);
+  const state = (await storage.get("exact-review-queue")) as {
+    deliveries: Record<string, number>;
+    items: Record<string, { revision: number }>;
+  };
+  assert.equal(state.deliveries["delivery-refreshed"], refreshedAt);
+  assert.equal(state.items["openclaw/gogcli#634"].revision, 2);
+  assert.deepEqual(
+    await (
+      await upgraded.fetch(buildExactReviewQueueRequest("delivery-refreshed", 634, "edited"))
+    ).json(),
+    { ok: true, deduped: true, item_key: "openclaw/gogcli#634" },
+  );
+});
+
+test("exact-review receipt pruning removes its translated shadow atomically", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  assert.equal(
+    (await queue.fetch(buildExactReviewQueueRequest("delivery-pruned", 635, "opened"))).status,
+    202,
+  );
+  const expiredAt = Date.now() - 7 * 24 * 60 * 60 * 1000 - 1;
+  storage.setExactReviewReceiptTime("delivery-pruned", expiredAt);
+  const staleShadow = structuredClone(
+    storage.rawGet("exact-review-queue") as { deliveries: Record<string, number> },
+  );
+  staleShadow.deliveries["delivery-pruned"] = expiredAt + 2 * 24 * 60 * 60 * 1000;
+  storage.rawPut("exact-review-queue", staleShadow);
+
+  let stats = await (
+    await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(stats.delivery_receipts, 0);
+  const refreshedShadow = storage.rawGet("exact-review-queue") as {
+    deliveries: Record<string, number>;
+  };
+  assert.deepEqual(
+    Object.keys(refreshedShadow.deliveries).filter(
+      (deliveryId) => !deliveryId.startsWith("__clawsweeper_sql_generation:"),
+    ),
+    [],
+  );
+
+  const restarted = new ExactReviewQueue({ storage }, {});
+  stats = await (
+    await restarted.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(stats.delivery_receipts, 0);
+});
+
+test("exact-review re-upgrade fails closed for a divergent stale rollback shadow", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  assert.equal(
+    (await queue.fetch(buildExactReviewQueueRequest("delivery-stale-1", 628, "opened"))).status,
+    202,
+  );
+  const staleShadow = structuredClone(storage.rawGet("exact-review-queue"));
+  assert.equal(
+    (await queue.fetch(buildExactReviewQueueRequest("delivery-stale-2", 629, "opened"))).status,
+    202,
+  );
+  storage.rawPut("exact-review-queue", staleShadow);
+
+  const upgraded = new ExactReviewQueue({ storage }, {});
+  await assert.rejects(
+    upgraded.fetch(new Request("https://clawsweeper-exact-review-queue/stats")),
+    /ambiguous exact-review legacy rollback state/,
+  );
+  const sqlState = (await storage.get("exact-review-queue")) as {
+    items: Record<string, unknown>;
+  };
+  assert.deepEqual(Object.keys(sqlState.items).sort(), [
+    "openclaw/gogcli#628",
+    "openclaw/gogcli#629",
+  ]);
+  assert.deepEqual(storage.rawGet("exact-review-queue"), staleShadow);
+});
+
+test("exact-review discards a stale rollback shadow when its refresh fails", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"));
+  assert.equal(storage.rawHas("exact-review-queue"), true);
+  storage.failNextPut("exact-review-queue");
+  const warnings: unknown[][] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => warnings.push(args);
+  try {
+    assert.equal(
+      (await queue.fetch(buildExactReviewQueueRequest("delivery-mirror-failure", 630, "opened")))
+        .status,
+      202,
+    );
+  } finally {
+    console.warn = originalWarn;
+  }
+  assert.equal(storage.rawHas("exact-review-queue"), false);
+  assert.match(String(warnings[0][0]), /legacy rollback shadow unavailable/);
+
+  const restarted = new ExactReviewQueue({ storage }, {});
+  const stats = await (
+    await restarted.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(stats.pending, 1);
+  assert.equal(stats.delivery_receipts, 1);
+  assert.equal(storage.rawHas("exact-review-queue"), true);
+});
+
+test("exact-review rolls SQL back when an obsolete shadow cannot be removed", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"));
+  const originalShadow = structuredClone(storage.rawGet("exact-review-queue"));
+  storage.failNextPut("exact-review-queue");
+  storage.failNextDelete("exact-review-queue");
+  const warnings: unknown[][] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => warnings.push(args);
+  try {
+    await assert.rejects(
+      queue.fetch(buildExactReviewQueueRequest("delivery-atomic-shadow", 633, "opened")),
+      /injected storage delete failure/,
+    );
+  } finally {
+    console.warn = originalWarn;
+  }
+  assert.match(String(warnings[0][0]), /stale legacy rollback shadow could not be removed/);
+  assert.deepEqual(storage.rawGet("exact-review-queue"), originalShadow);
+  let state = (await storage.get("exact-review-queue")) as {
+    deliveries: Record<string, number>;
+    items: Record<string, unknown>;
+  };
+  assert.deepEqual(state.deliveries, {});
+  assert.deepEqual(state.items, {});
+
+  assert.equal(
+    (await queue.fetch(buildExactReviewQueueRequest("delivery-atomic-shadow", 633, "opened")))
+      .status,
+    202,
+  );
+  state = (await storage.get("exact-review-queue")) as {
+    deliveries: Record<string, number>;
+    items: Record<string, unknown>;
+  };
+  assert.deepEqual(Object.keys(state.deliveries), ["delivery-atomic-shadow"]);
+  assert.deepEqual(Object.keys(state.items), ["openclaw/gogcli#633"]);
+});
+
+test("exact-review SQL rows outgrow the bounded rollback shadow without blocking intake", async () => {
+  const storage = new MemoryDurableStorage();
+  const now = Date.now();
+  const items = Object.fromEntries(
+    Array.from({ length: 220 }, (_, index) => {
+      const itemNumber = 10_000 + index;
+      const key = `openclaw/openclaw#${itemNumber}`;
+      return [
+        key,
+        {
+          key,
+          decision: {
+            targetRepo: "openclaw/openclaw",
+            targetBranch: "main",
+            itemNumber,
+            itemKind: "issue",
+            sourceEvent: "issues",
+            sourceAction: "opened",
+            supersedesInProgress: false,
+            additionalPrompt: "x".repeat(5_000),
+          },
+          state: "pending",
+          revision: 1,
+          createdAt: now,
+          updatedAt: now,
+          nextAttemptAt: now,
+          attempts: 0,
+        },
+      ];
+    }),
+  );
+  await storage.put("exact-review-queue", { deliveries: {}, items });
+  const warnings: unknown[][] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => warnings.push(args);
+  let queue: ExactReviewQueue;
+  try {
+    queue = new ExactReviewQueue({ storage }, {});
+    const response = await queue.fetch(
+      buildExactReviewQueueRequest("delivery-after-large-migration", 20_000, "opened"),
+    );
+    assert.equal(response.status, 202);
+  } finally {
+    console.warn = originalWarn;
+  }
+
+  const stats = await (
+    await queue!.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(stats.pending, 221);
+  assert.equal(stats.delivery_receipts, 1);
+  assert.equal(stats.legacy_rollback_available, false);
+  assert.equal(warnings.length, 1);
+  assert.match(String(warnings[0][0]), /legacy rollback shadow unavailable/);
+  assert.match(String(warnings[0][1]), /shadow is \d+ bytes/);
+  assert.equal(storage.rawHas("exact-review-queue"), false);
+});
+
+test("exact-review migration removes its rollback shadow after one day", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  assert.equal(
+    (await queue.fetch(buildExactReviewQueueRequest("delivery-shadow", 626, "opened"))).status,
+    202,
+  );
+  assert.equal(storage.rawHas("exact-review-queue"), true);
+
+  storage.setExactReviewMigrationTime(Date.now() - 24 * 60 * 60 * 1000 - 1);
+  const restarted = new ExactReviewQueue({ storage }, {});
+  const stats = await (
+    await restarted.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(stats.pending, 1);
+  assert.equal(stats.delivery_receipts, 1);
+  assert.equal(stats.legacy_rollback_available, false);
+  assert.equal(storage.rawHas("exact-review-queue"), false);
+});
+
+test("exact-review imports an active rollback before expiring an old bridge", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  assert.equal(
+    (await queue.fetch(buildExactReviewQueueRequest("delivery-old-bridge", 631, "opened"))).status,
+    202,
+  );
+  const shadow = structuredClone(
+    storage.rawGet("exact-review-queue") as {
+      deliveries: Record<string, number>;
+      items: Record<string, Record<string, unknown>>;
+    },
+  );
+  const oldMigrationTime = Date.now() - 24 * 60 * 60 * 1000 - 1;
+  storage.setExactReviewMigrationTime(oldMigrationTime);
+  const generationId = Object.keys(shadow.deliveries).find((deliveryId) =>
+    deliveryId.startsWith("__clawsweeper_sql_generation:"),
+  );
+  assert.ok(generationId);
+  assert.equal(shadow.deliveries[generationId], Number.MAX_SAFE_INTEGER);
+  for (const [deliveryId, receivedAt] of Object.entries(shadow.deliveries)) {
+    if (receivedAt <= Date.now() - 5 * 24 * 60 * 60 * 1000) {
+      delete shadow.deliveries[deliveryId];
+    }
+  }
+  assert.equal(shadow.deliveries[generationId], Number.MAX_SAFE_INTEGER);
+  shadow.deliveries["delivery-old-bridge-rollback"] = Date.now();
+  const rollbackItem = structuredClone(shadow.items["openclaw/gogcli#631"]);
+  rollbackItem.key = "openclaw/gogcli#632";
+  rollbackItem.decision = {
+    ...(rollbackItem.decision as Record<string, unknown>),
+    itemNumber: 632,
+  };
+  delete shadow.items["openclaw/gogcli#631"];
+  shadow.items["openclaw/gogcli#632"] = rollbackItem;
+  storage.rawPut("exact-review-queue", shadow);
+
+  const upgraded = new ExactReviewQueue({ storage }, {});
+  const stats = await (
+    await upgraded.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(stats.pending, 1);
+  assert.equal(stats.delivery_receipts, 2);
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<string, unknown>;
+  };
+  assert.deepEqual(Object.keys(state.items), ["openclaw/gogcli#632"]);
+  assert.equal(storage.rawHas("exact-review-queue"), false);
 });
 
 test("exact-review claim preserves its immutable decision across a newer enqueue", async () => {
@@ -1202,6 +1878,7 @@ test("exact-review claim and completion reject forged or incomplete lease tuples
     },
   });
   const queue = new ExactReviewQueue({ storage }, {});
+  await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"));
   const claimBase = {
     lease_id: "lease-622",
     item_key: "openclaw/openclaw#622",
@@ -1543,6 +2220,12 @@ test("exact-review queue rejects unbounded or unsafe command context", async () 
     assert.equal(response.status, 400);
     assert.deepEqual(await response.json(), { error: "invalid_exact_review_item" });
   }
+
+  const reservedDelivery = await queue.fetch(
+    buildExactReviewQueueRequest("__clawsweeper_sql_generation:99", 597, "opened"),
+  );
+  assert.equal(reservedDelivery.status, 400);
+  assert.deepEqual(await reservedDelivery.json(), { error: "reserved_delivery_id" });
 });
 
 test("exact-review queue retries dispatch failures and reclaims an unclaimed lease", async () => {
@@ -2506,7 +3189,6 @@ test("exact-review reconciliation cannot release a later attempt with the same r
 
 test("exact-review stats heals a missing or stale alarm and expired lease", async () => {
   const storage = new MemoryDurableStorage();
-  const queue = new ExactReviewQueue({ storage }, {});
   await storage.put("exact-review-queue", {
     deliveries: {},
     items: {
@@ -2534,6 +3216,7 @@ test("exact-review stats heals a missing or stale alarm and expired lease", asyn
       },
     },
   });
+  const queue = new ExactReviewQueue({ storage }, {});
 
   const response = await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"));
   assert.equal(response.status, 200);


### PR DESCRIPTION
## Summary

- replace the exact-review queue's single growing Durable Object KV value with normalized SQLite tables for metadata, queue items, and delivery receipts
- restore seven-day delivery deduplication with indexed, bounded receipt pruning and atomic receipt-plus-queue mutations
- migrate legacy state live and maintain a complete-or-disabled, generation-aware rollback shadow for safe rolling deploys
- expose the storage schema and rollback availability in queue stats, and document the migration/rollback contract
- remove an unrelated scheduler-sensitive wall-clock assertion uncovered by the full parallel suite while preserving the behavioral abort proof

## Bug

The queue previously serialized all items and delivery receipts into one `exact-review-queue` value. Delivery receipts grew without a structural bound, so the value eventually crossed Cloudflare Durable Objects' 2 MiB per-value limit and queue writes began failing. PR #519 reduced receipt retention to five days as an emergency pressure release, but it did not remove the single-value failure mode.

## Fix

Each queue item and delivery receipt is now an independent SQLite row. Enqueue, deduplication, coalescing, and rollback-shadow maintenance happen in one synchronous storage transaction. Receipt expiry is restored to seven days and pruned through the timestamp index in bounded batches.

The first upgraded request imports the legacy value. For the first 24 hours, the worker writes a generation-marked legacy shadow only when it can include the complete active dedupe set within strict item/byte limits; otherwise rollback is explicitly unavailable and the ambiguous shadow is removed. A rolled-back worker's queue mutations and delivery receipts are deterministically reimported on re-upgrade.

## Proof

- `pnpm run check` — green: build, lint, 1,101 unit tests, 884 repair tests, changed/full coverage, formatting
- `node --test test/dashboard-worker.test.ts` — 91/91 green
- focused action-ledger drain test — green
- autoreview — clean, no actionable findings (0.91 confidence)

## Rollout

Deploy and verify this branch before merge. After merge, verify the main deployment revision, queue schema/stats, intake, workflows, and worker error rate. The branch and main deployments are both SQL-capable, so the immediate post-merge rollback target remains compatible.
