### PR TITLE
fix(ci): restore sweep workflow intake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,22 @@ jobs:
             tsconfig.repair.json
           sparse-checkout-cone-mode: false
 
+      - name: Validate workflow semantics
+        env:
+          ACTIONLINT_VERSION: "1.7.12"
+          ACTIONLINT_LINUX_AMD64_SHA256: "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+        run: |
+          actionlint_archive="${RUNNER_TEMP}/actionlint.tar.gz"
+          curl --fail --show-error --silent --location \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+            --output "$actionlint_archive"
+          printf '%s  %s\n' "$ACTIONLINT_LINUX_AMD64_SHA256" "$actionlint_archive" | sha256sum --check -
+          tar -xzf "$actionlint_archive" -C "$RUNNER_TEMP" actionlint
+          "$RUNNER_TEMP/actionlint" \
+            -shellcheck= \
+            -ignore 'unexpected key "queue" for "concurrency" section' \
+            .github/workflows/*.yml
+
       - uses: ./.github/actions/setup-pnpm
 
       - name: Run check

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1082,7 +1082,6 @@ jobs:
         id: exact-review-primary-result
         if: ${{ always() }}
         env:
-          JOB_CANCELLED: ${{ cancelled() }}
           PRIMARY_JOB_STATUS: ${{ job.status }}
           TARGET_ENABLED: ${{ steps.target.outputs.target_enabled }}
           LIVE_PROCEED: ${{ steps.live-item.outputs.proceed }}
@@ -1100,7 +1099,7 @@ jobs:
           ROUTE_OUTCOME: ${{ steps.queue-exact-verdict-router.outcome }}
         run: |
           outcome=failure
-          if [ "$JOB_CANCELLED" = "true" ] || [ "$REVIEW_OUTCOME" = "cancelled" ]; then
+          if [ "$PRIMARY_JOB_STATUS" = "cancelled" ] || [ "$REVIEW_OUTCOME" = "cancelled" ]; then
             outcome=cancelled
           elif [ "$PRIMARY_JOB_STATUS" != "success" ]; then
             outcome=failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Restored exact-review intake by deriving cancellation from `job.status`, avoiding an unsupported status-check function in step environment expressions that made GitHub reject the sweep workflow, and added checksum-pinned workflow-semantic linting to CI.
 - Completed exact-review events when a fresh low-signal close guard keeps the
   item open, instead of retrying the same safely rejected close forever.
 - Coalesced self-continuing hot and normal review runs per target so scheduled

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2226,6 +2226,8 @@ test("sweep workflow executes only durable queue leases without runner-side admi
     /steps\.queue-exact-verdict-router\.outcome != 'success'/,
   );
   assert.match(primaryResultStep, /PRIMARY_JOB_STATUS: \$\{\{ job\.status \}\}/);
+  assert.doesNotMatch(primaryResultStep, /JOB_CANCELLED|\$\{\{ cancelled\(\) \}\}/);
+  assert.match(primaryResultStep, /PRIMARY_JOB_STATUS" = "cancelled"/);
   assert.match(primaryResultStep, /echo "outcome=\$outcome" >> "\$GITHUB_OUTPUT"/);
   assert.match(
     completeLeaseStep,

--- a/test/crawl-remote-deploy-workflow.test.ts
+++ b/test/crawl-remote-deploy-workflow.test.ts
@@ -1459,6 +1459,22 @@ test("networked CI installs the pinned Wrangler lock and exercises its dry-run o
   assert.doesNotMatch(ciSource, /CRAWL_REMOTE_PRODUCTION_CLOUDFLARE_API_TOKEN/);
 });
 
+test("CI validates workflow semantics with a checksum-pinned actionlint", () => {
+  const check = ciWorkflow.jobs.check;
+  const actionlint = step(check, "Validate workflow semantics");
+
+  assert.equal(actionlint.env?.ACTIONLINT_VERSION, "1.7.12");
+  assert.equal(
+    actionlint.env?.ACTIONLINT_LINUX_AMD64_SHA256,
+    "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8",
+  );
+  assert.match(actionlint.run ?? "", /curl --fail --show-error --silent --location/);
+  assert.match(actionlint.run ?? "", /sha256sum --check -/);
+  assert.match(actionlint.run ?? "", /-shellcheck=/);
+  assert.match(actionlint.run ?? "", /unexpected key "queue" for "concurrency" section/);
+  assert.match(actionlint.run ?? "", /\.github\/workflows\/\*\.yml/);
+});
+
 test("deploy reauthorizes exact current main before and after privileged mutations", () => {
   const token = step(deploy, "Create exact-repository reauthorization token");
   assert.equal(

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -126,7 +126,9 @@ test("review and apply primary boundaries ignore ledger-only failures", () => {
   const exactPrimary = step("event-review-apply", "Export exact review primary result");
   const exactQueue = step("event-review-apply", "Complete exact-review queue lease");
   assert.equal(exactPrimary.env?.PRIMARY_JOB_STATUS, "${{ job.status }}");
+  assert.equal(exactPrimary.env?.JOB_CANCELLED, undefined);
   assert.match(exactPrimary.run ?? "", /outcome=(?:failure|cancelled|success)/);
+  assert.match(exactPrimary.run ?? "", /PRIMARY_JOB_STATUS.*cancelled/);
   assert.match(exactPrimary.run ?? "", /PRIMARY_JOB_STATUS.*success/);
   assert.match(exactQueue.env?.PRIMARY_OUTCOME ?? "", /exact-review-primary-result/);
   assert.doesNotMatch(exactQueue.run ?? "", /JOB_STATUS|job\.status/);


### PR DESCRIPTION
## Summary

- restore exact-review workflow parsing by deriving cancellation from `job.status`
- add regression assertions for cancellation outcome propagation
- validate all workflows in CI with checksum-pinned Actionlint

## Root cause

GitHub status-check functions such as `cancelled()` are valid in job and step `if` expressions, but not in a step `env` expression. The invalid expression made GitHub reject `sweep.yml`; repository dispatch calls returned without producing runs, so exact-review items accumulated in `dispatching` until lease expiry.

## Validation

- `actionlint -shellcheck= -ignore 'unexpected key "queue" for "concurrency" section' .github/workflows/*.yml`
- focused Node tests: 3 passed
- pinned Linux Actionlint archive checksum verified against the release asset
- `pnpm exec oxfmt --check` on all changed files
- `git diff --check`
- structured autoreview: clean
- full `pnpm run check`: 1,133 passed, 1 unrelated local-runtime failure because npm 12 changed `npm pack --json` shape; CI uses the repository runtime

## Live evidence

- exact-review queue reached 19 pending, 19 dispatching, 9 leased
- no new repository-dispatch sweep run appeared after 2026-07-12T22:42:41Z
- manual recovery returned HTTP 422: `cancelled()` is not allowed at line 1085
