### PR TITLE
fix(ledger): accept package-manager command separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Accepted package-manager argument separators in the action-ledger CLI so
+  command workflows can finalize and publish their immutable receipts.
 - Made action-ledger publication include every transactional import binding,
   added pre-dispatch apply and retry receipts with conservative unknown-outcome
   recovery, failed active apply items on runtime yield, preserved skipped apply

--- a/src/repair/action-ledger-cli.ts
+++ b/src/repair/action-ledger-cli.ts
@@ -10,7 +10,8 @@ import {
 } from "./command-action-ledger-manifest.js";
 import { repoRoot } from "./paths.js";
 
-const [command, ...argv] = process.argv.slice(2);
+const rawArgv = process.argv.slice(2);
+const [command, ...argv] = rawArgv[0] === "--" ? rawArgv.slice(1) : rawArgv;
 const args = parseArgs(argv);
 
 if (command === "finalize") {

--- a/test/repair/action-ledger-cli.test.ts
+++ b/test/repair/action-ledger-cli.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import test from "node:test";
+
+test("action-ledger CLI accepts the package-manager argument separator", () => {
+  const result = spawnSync(
+    process.execPath,
+    [path.resolve("dist/repair/action-ledger-cli.js"), "--", "finalize", "--lane", "INVALID"],
+    { encoding: "utf8" },
+  );
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /invalid command action ledger lane: INVALID/);
+  assert.doesNotMatch(result.stderr, /unknown argument: finalize/);
+});


### PR DESCRIPTION
## What Problem This Solves

Command-action ledger workflows invoke the CLI through `pnpm run ... -- <command>`.
The forwarded separator was interpreted as the command, so `finalize` became an
unknown argument and every comment-router ledger finalization failed.

## Why This Change Was Made

Normalize one leading package-manager separator at the CLI boundary. This fixes
all current callers without duplicating argument workarounds across the comment
router, cluster worker, and sweep workflows.

The regression test executes the compiled CLI with the hosted argv shape and
proves parsing reaches lane validation rather than rejecting `finalize`.

## User Impact

Repair commands can finalize and publish their immutable action receipts again.
This stops the repeated post-command router failures and restores durable command
ledger publication.

## Evidence

- `node scripts/check-active-surface.ts`
- `node scripts/check-limits.ts`
- direct TypeScript builds for main, repair, and dashboard configs
- direct oxlint checks for source, repair, scripts/tests, and dashboard
- direct oxfmt check across repository surfaces
- `node --test test/*.test.ts` (1136 passed, 2 skipped)
- `node --test test/repair/*.test.ts dist/repair/*.test.js` (911 passed)
- focused ledger slice (26 passed)
- autoreview: clean, no accepted/actionable findings

Fixes #528
