### PR TITLE
fix(ledger): allow proven no-op router finalization

### DIFF
--- a/.github/workflows/repair-comment-router.yml
+++ b/.github/workflows/repair-comment-router.yml
@@ -220,6 +220,7 @@ jobs:
           echo "app_id=$app_id" >> "$GITHUB_OUTPUT"
 
       - name: Route ClawSweeper comments
+        id: route-comments
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           CLAWSWEEPER_AUTHENTICATED_APP_ID: ${{ steps.mutation-app.outputs.app_id }}
@@ -482,17 +483,31 @@ jobs:
             --rebase-strategy theirs
 
       - name: Finalize command action ledger
+        id: finalize-command-action-ledger
         if: ${{ always() && steps.setup-pnpm.outcome == 'success' }}
         run: |
           set -euo pipefail
           : "${CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT:?setup-action-ledger output root is required}"
           mkdir -p .artifacts
+          allow_empty_args=()
+          # Empty is valid only when this run's report proves no command lifecycle started.
+          if [ "${{ steps.route-comments.outcome }}" = "success" ] &&
+             jq -e '.commands_seen == 0' results/comment-router-latest.json >/dev/null 2>&1; then
+            allow_empty_args+=(--allow-empty)
+          fi
+          manifest_file=".artifacts/comment-router-command-action-ledger-manifest.json"
           pnpm run --silent repair:action-ledger -- finalize \
             --lane comment-router \
-            > .artifacts/comment-router-command-action-ledger-manifest.json
+            "${allow_empty_args[@]}" \
+            > "$manifest_file"
+          if [ -s "$manifest_file" ]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Publish immutable command action ledger
-        if: ${{ always() && steps.setup-pnpm.outcome == 'success' }}
+        if: ${{ always() && steps.setup-pnpm.outcome == 'success' && steps.finalize-command-action-ledger.outputs.publish == 'true' }}
         run: |
           set -euo pipefail
           test -n "${CLAWSWEEPER_STATE_DIR:-}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,8 +59,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
-- Accepted package-manager argument separators in the action-ledger CLI so
-  command workflows can finalize and publish their immutable receipts.
+- Accepted package-manager argument separators in the action-ledger CLI and
+  allowed proven zero-command router runs to finish without empty publication.
 - Made action-ledger publication include every transactional import binding,
   added pre-dispatch apply and retry receipts with conservative unknown-outcome
   recovery, failed active apply items on runtime yield, preserved skipped apply

--- a/src/repair/action-ledger-cli.ts
+++ b/src/repair/action-ledger-cli.ts
@@ -16,8 +16,10 @@ const args = parseArgs(argv);
 
 if (command === "finalize") {
   const lane = requiredArg(args.lane, "--lane");
-  const manifest = await finalizeCommandActionLedgerManifest(lane);
-  process.stdout.write(serializeCommandActionLedgerManifest(manifest));
+  const manifest = await finalizeCommandActionLedgerManifest(lane, {
+    allowEmpty: args.allowEmpty === true,
+  });
+  if (manifest) process.stdout.write(serializeCommandActionLedgerManifest(manifest));
 } else if (command === "publish") {
   const lane = requiredArg(args.lane, "--lane");
   const manifestPath = path.resolve(requiredArg(args.manifest, "--manifest"));
@@ -43,7 +45,7 @@ if (command === "finalize") {
   );
 } else {
   throw new Error(
-    "usage: action-ledger-cli.ts <finalize|publish> --lane name [--manifest path --source-root path --state-root path]",
+    "usage: action-ledger-cli.ts <finalize|publish> --lane name [--allow-empty --manifest path --source-root path --state-root path]",
   );
 }
 
@@ -55,13 +57,20 @@ function actionLedgerOutputRoot(): string {
 }
 
 function parseArgs(argv: readonly string[]) {
-  const parsed: { lane?: string; manifest?: string; sourceRoot?: string; stateRoot?: string } = {};
+  const parsed: {
+    lane?: string;
+    manifest?: string;
+    sourceRoot?: string;
+    stateRoot?: string;
+    allowEmpty?: boolean;
+  } = {};
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === "--lane") parsed.lane = requiredValue(argv, ++index, arg);
     else if (arg === "--manifest") parsed.manifest = requiredValue(argv, ++index, arg);
     else if (arg === "--source-root") parsed.sourceRoot = requiredValue(argv, ++index, arg);
     else if (arg === "--state-root") parsed.stateRoot = requiredValue(argv, ++index, arg);
+    else if (arg === "--allow-empty") parsed.allowEmpty = true;
     else throw new Error(`unknown argument: ${arg}`);
   }
   return parsed;

--- a/src/repair/command-action-ledger-manifest.ts
+++ b/src/repair/command-action-ledger-manifest.ts
@@ -33,7 +33,8 @@ export type CommandActionLedgerManifest = CommandActionLedgerManifestIdentity & 
 
 export async function finalizeCommandActionLedgerManifest(
   lane: string,
-): Promise<CommandActionLedgerManifest> {
+  options: { allowEmpty?: boolean } = {},
+): Promise<CommandActionLedgerManifest | null> {
   assertCommandActionLedgerLane(lane);
   const outputRoot = commandActionLedgerOutputRoot();
   const finalizedPaths = await flushCommandActionEvents();
@@ -44,6 +45,7 @@ export async function finalizeCommandActionLedgerManifest(
     }))
     .filter(({ events }) => events.some(commandActionEvent));
   if (commandShards.length === 0) {
+    if (options.allowEmpty) return null;
     throw new Error(`command action ledger lane ${lane} finalized no command event shards`);
   }
   for (const shard of commandShards) {

--- a/test/clawsweeper-action-ledger.test.ts
+++ b/test/clawsweeper-action-ledger.test.ts
@@ -800,6 +800,11 @@ test("comment router publishes immutable command receipts for initial and retry 
   assertCommandFinalizerUsesCanonicalRoot(finalizeStep);
   assertCommandPublisherUsesCanonicalRoot(publishStep);
   assert.match(finalizeStep, /--lane comment-router/);
+  assert.match(finalizeStep, /steps\.route-comments\.outcome.*success/);
+  assert.match(finalizeStep, /\.commands_seen == 0/);
+  assert.match(finalizeStep, /allow_empty_args\+=\(--allow-empty\)/);
+  assert.match(finalizeStep, /echo "publish=false" >> "\$GITHUB_OUTPUT"/);
+  assert.match(publishStep, /steps\.finalize-command-action-ledger\.outputs\.publish == 'true'/);
   assert.match(publishStep, /--lane comment-router/);
   assert.match(publishStep, /repair:action-ledger -- publish/);
   assert.match(publishStep, /--message "chore: append command action ledger"/);
@@ -816,7 +821,7 @@ function assertCommandFinalizerUsesCanonicalRoot(step: string): void {
     /CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT:\?setup-action-ledger output root is required/,
   );
   assert.match(step, /repair:action-ledger -- finalize \\\n\s+--lane [a-z0-9-]+ \\\n/);
-  assert.match(step, /> \.artifacts\/[a-z0-9-]+-action-ledger-manifest\.json/);
+  assert.match(step, /> "\$manifest_file"/);
 }
 
 function assertCommandPublisherUsesCanonicalRoot(step: string): void {
@@ -838,5 +843,4 @@ function assertCommandPublisherUsesCanonicalRoot(step: string): void {
   assert.match(step, /if \[ ! -s "\$event_paths_file" \]; then[\s\S]*?exit 1[\s\S]*?fi/);
   assert.doesNotMatch(step, /command_shard_found/);
   assert.doesNotMatch(step, /\.created > 0/);
-  assert.doesNotMatch(step, /exit 0/);
 }

--- a/test/repair/action-ledger-cli.test.ts
+++ b/test/repair/action-ledger-cli.test.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
@@ -13,4 +15,35 @@ test("action-ledger CLI accepts the package-manager argument separator", () => {
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /invalid command action ledger lane: INVALID/);
   assert.doesNotMatch(result.stderr, /unknown argument: finalize/);
+});
+
+test("action-ledger CLI accepts an explicitly empty finalization", () => {
+  const outputRoot = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "command-action-ledger-empty-")),
+  );
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        path.resolve("dist/repair/action-ledger-cli.js"),
+        "finalize",
+        "--lane",
+        "comment-router",
+        "--allow-empty",
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CLAWSWEEPER_ACTION_LEDGER_FORCE: "1",
+          CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT: outputRoot,
+        },
+      },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout, "");
+  } finally {
+    fs.rmSync(outputRoot, { force: true, recursive: true });
+  }
 });

--- a/test/repair/command-action-ledger.test.ts
+++ b/test/repair/command-action-ledger.test.ts
@@ -21,6 +21,34 @@ import {
 } from "../../dist/repair/command-action-ledger-manifest.js";
 import { forcedReplayCommandFields, readCommentRouterConfig } from "../../dist/repair/config.js";
 
+test("command manifest permits only explicitly empty finalization", async () => {
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "command-manifest-empty-")));
+  const outputRoot = path.join(root, "output");
+  fs.mkdirSync(outputRoot);
+  const previous = { ...process.env };
+  Object.assign(process.env, {
+    CLAWSWEEPER_ACTION_LEDGER_FORCE: "1",
+    CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT: outputRoot,
+  });
+
+  try {
+    assert.equal(
+      await finalizeCommandActionLedgerManifest("comment-router", { allowEmpty: true }),
+      null,
+    );
+    await assert.rejects(
+      finalizeCommandActionLedgerManifest("comment-router"),
+      /finalized no command event shards/,
+    );
+  } finally {
+    for (const key of Object.keys(process.env)) {
+      if (!(key in previous)) delete process.env[key];
+    }
+    Object.assign(process.env, previous);
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+});
+
 test("command receipts preserve operation identity across explicit retry attempts", async () => {
   const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "command-action-ledger-")));
   const outputRoot = path.join(root, "output");
@@ -80,6 +108,7 @@ test("command receipts preserve operation identity across explicit retry attempt
     await flushCommandActionEvents();
 
     const manifest = await finalizeCommandActionLedgerManifest("comment-router");
+    assert.ok(manifest);
     assert.equal(manifest.event_paths.length, 2);
     assert.deepEqual(
       parseCommandActionLedgerManifest(


### PR DESCRIPTION
## What Problem This Solves

After #529 restored command-bearing ledger publication, legitimate no-op
comment-router scans still failed because strict finalization required at least
one command event shard.

The failing current-main workflow dispatch completed routing with zero commands,
then failed only during ledger finalization.

## Why This Change Was Made

Add an explicit `--allow-empty` finalization mode and enable it only when:

- the current `Route ClawSweeper comments` step succeeded; and
- its current report proves `commands_seen == 0`.

The finalizer emits no manifest for that proven no-op, and the workflow skips
publication. Command-bearing runs remain strict: missing receipts still fail.
The successful current-step guard prevents hydrated stale reports from
authorizing an empty result.

## User Impact

Scheduled and manual router scans with nothing to process finish successfully,
while immutable receipt enforcement remains fail-closed for every routed
command.

## Evidence

- `node scripts/check-active-surface.ts`
- `node scripts/check-limits.ts`
- direct main and repair TypeScript builds
- focused CLI, manifest, workflow, and command-operation tests: 28 passed
- scoped oxlint and oxfmt checks
- autoreview: clean, no accepted/actionable findings, 0.93 confidence
- failing no-op baseline: https://github.com/openclaw/clawsweeper/actions/runs/29216516648
- successful command-bearing controls:
  https://github.com/openclaw/clawsweeper/actions/runs/29216519145 and
  https://github.com/openclaw/clawsweeper/actions/runs/29216529088

Fixes #530
