### PR TITLE
feat: add exact-review handoff health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Added
 
+- Added end-to-end exact-review handoff health with phase ages, delayed/stalled claim classification, and a phase-aware operator rail on the live dashboard.
 - Added versioned staged repair proof plans with deterministic cheap-to-expensive validation, behavioral profile-command staging, concrete-argv environment resolution and revalidation, structured package-manager option parsing, checkout immutability checks, retention of every allowlisted required command, exact-command deduplication, explicit-only non-live subsumption with digest provenance, fail-closed canonical-gate stalls and runtime budgets, topology-stable retry traces, and bounded machine-readable proof bound to the exact validated head/base after final or fallback history compaction. Thanks @vincentkoc.
 - Required every repair merge owner to verify a non-bypass GitHub App credential and server-enforced strict base-branch status checks from repository rulesets or classic protection before merging, using a fresh trusted finalizer with exact-repository mutation and administration verifier tokens while keeping Codex credentials administration-free.
 - Added a maintainer-only two-runner workflow that builds a hash-bound

--- a/dashboard/exact-review-health.ts
+++ b/dashboard/exact-review-health.ts
@@ -1,0 +1,204 @@
+export type ExactReviewPhase = "pending" | "dispatching" | "leased";
+
+export type ExactReviewHealthItem = {
+  state: ExactReviewPhase;
+  createdAt: number;
+  updatedAt: number;
+  leaseExpiresAt?: number;
+  dispatchedAt?: number;
+  claimedAt?: number;
+};
+
+export type ExactReviewHealthDispatcher = {
+  state?: "active" | "paused" | "blocked" | "unknown";
+};
+
+export type ExactReviewPhaseSummary = {
+  count: number;
+  oldest_at: string | null;
+  oldest_age_seconds: number | null;
+};
+
+export type ExactReviewHandoffHealth = {
+  status: "idle" | "healthy" | "degraded" | "stalled";
+  reason:
+    | "queue_empty"
+    | "handoff_current"
+    | "claim_delayed"
+    | "claim_stalled"
+    | "dispatcher_paused"
+    | "dispatcher_blocked";
+  message: string;
+  observed_at: string;
+  warning_after_seconds: number;
+  stalled_after_seconds: number;
+  capacity: number;
+  active: number;
+  available_slots: number;
+  phases: Record<ExactReviewPhase, ExactReviewPhaseSummary>;
+};
+
+const PHASES: ExactReviewPhase[] = ["pending", "dispatching", "leased"];
+
+export function summarizeExactReviewHandoff({
+  items,
+  dispatcher,
+  now = Date.now(),
+  capacity,
+  dispatchLeaseMs,
+  executionLeaseMs,
+}: {
+  items: ExactReviewHealthItem[];
+  dispatcher?: ExactReviewHealthDispatcher;
+  now?: number;
+  capacity: number;
+  dispatchLeaseMs: number;
+  executionLeaseMs: number;
+}): ExactReviewHandoffHealth {
+  const safeNow = finiteTimestamp(now, Date.now());
+  const safeCapacity = Math.max(0, Math.floor(finiteNumber(capacity, 0)));
+  const safeLeaseMs = Math.max(1_000, finiteNumber(dispatchLeaseMs, 10 * 60_000));
+  const safeExecutionLeaseMs = Math.max(1_000, finiteNumber(executionLeaseMs, 130 * 60_000));
+  const warningMs = Math.min(2 * 60_000, Math.max(30_000, Math.floor(safeLeaseMs / 3)));
+  const stalledMs = Math.min(
+    5 * 60_000,
+    Math.max(warningMs + 1_000, Math.floor((safeLeaseMs * 2) / 3)),
+  );
+  const phaseValues: Record<ExactReviewPhase, { count: number; oldestAt: number | null }> = {
+    pending: { count: 0, oldestAt: null },
+    dispatching: { count: 0, oldestAt: null },
+    leased: { count: 0, oldestAt: null },
+  };
+
+  for (const item of items) {
+    const startedAt = exactReviewPhaseStartedAt(item, safeNow, safeLeaseMs, safeExecutionLeaseMs);
+    const phase = phaseValues[item.state];
+    if (!phase) continue;
+    phase.count += 1;
+    phase.oldestAt = phase.oldestAt === null ? startedAt : Math.min(phase.oldestAt, startedAt);
+  }
+
+  const phases = Object.fromEntries(
+    PHASES.map((phase) => {
+      const { count, oldestAt } = phaseValues[phase];
+      return [
+        phase,
+        {
+          count,
+          oldest_at: oldestAt === null ? null : new Date(oldestAt).toISOString(),
+          oldest_age_seconds:
+            oldestAt === null ? null : Math.max(0, Math.floor((safeNow - oldestAt) / 1_000)),
+        },
+      ];
+    }),
+  ) as Record<ExactReviewPhase, ExactReviewPhaseSummary>;
+
+  const active = phases.dispatching.count + phases.leased.count;
+  const common = {
+    observed_at: new Date(safeNow).toISOString(),
+    warning_after_seconds: Math.floor(warningMs / 1_000),
+    stalled_after_seconds: Math.floor(stalledMs / 1_000),
+    capacity: safeCapacity,
+    active,
+    available_slots: Math.max(0, safeCapacity - active),
+    phases,
+  };
+  if (items.length === 0) {
+    return {
+      status: "idle",
+      reason: "queue_empty",
+      message: "No exact-review work is queued or active.",
+      ...common,
+    };
+  }
+
+  const dispatchingAgeMs = (phases.dispatching.oldest_age_seconds || 0) * 1_000;
+  if (dispatchingAgeMs >= stalledMs) {
+    return {
+      status: "stalled",
+      reason: "claim_stalled",
+      message: "A dispatched review has not been claimed within the expected handoff window.",
+      ...common,
+    };
+  }
+  if (dispatcher?.state === "blocked" && phases.pending.count > 0) {
+    return {
+      status: "stalled",
+      reason: "dispatcher_blocked",
+      message: "The dispatcher cannot verify workflow availability while reviews are pending.",
+      ...common,
+    };
+  }
+  if (dispatcher?.state === "paused" && phases.pending.count > 0) {
+    return {
+      status: "degraded",
+      reason: "dispatcher_paused",
+      message: "The exact-review workflow is paused while reviews are pending.",
+      ...common,
+    };
+  }
+  if (dispatchingAgeMs >= warningMs) {
+    return {
+      status: "degraded",
+      reason: "claim_delayed",
+      message: "A dispatched review is taking longer than expected to claim.",
+      ...common,
+    };
+  }
+  return {
+    status: "healthy",
+    reason: "handoff_current",
+    message: "Dispatch-to-claim handoffs are within the expected window.",
+    ...common,
+  };
+}
+
+function exactReviewPhaseStartedAt(
+  item: ExactReviewHealthItem,
+  now: number,
+  dispatchLeaseMs: number,
+  executionLeaseMs: number,
+) {
+  if (item.state === "dispatching") {
+    const dispatchedAt = validTimestamp(item.dispatchedAt);
+    const leaseExpiresAt = validTimestamp(item.leaseExpiresAt);
+    const leaseStartedAt =
+      leaseExpiresAt === null ? null : validTimestamp(leaseExpiresAt - dispatchLeaseMs);
+    // Rolling deploys can expose rows created before dispatchedAt existed, while a rollback can
+    // leave an old dispatchedAt behind. The current lease start is the reliable compatibility
+    // marker; prefer the newest plausible transition and keep an unknown age non-alarming.
+    return newestTimestamp(dispatchedAt, leaseStartedAt) ?? now;
+  }
+  if (item.state === "leased") {
+    const claimedAt = validTimestamp(item.claimedAt);
+    const leaseExpiresAt = validTimestamp(item.leaseExpiresAt);
+    const leaseStartedAt =
+      leaseExpiresAt === null ? null : validTimestamp(leaseExpiresAt - executionLeaseMs);
+    return newestTimestamp(claimedAt, leaseStartedAt) ?? now;
+  }
+  return finiteTimestamp(item.createdAt, finiteTimestamp(item.updatedAt, now));
+}
+
+function newestTimestamp(...values: Array<number | null>) {
+  let newest: number | null = null;
+  for (const value of values) {
+    if (value === null) continue;
+    newest = newest === null ? value : Math.max(newest, value);
+  }
+  return newest;
+}
+
+function validTimestamp(value: unknown): number | null {
+  if (value === null || value === undefined || value === "") return null;
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 && number <= 8_640_000_000_000_000 ? number : null;
+}
+
+function finiteTimestamp(value: unknown, fallback: number) {
+  return validTimestamp(value) ?? fallback;
+}
+
+function finiteNumber(value: unknown, fallback: number) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -5,6 +5,7 @@ import {
 import { isExactReviewCloseGuardLabel } from "../src/repair/exact-review-guard-labels.ts";
 import { stableJson } from "../src/stable-json.ts";
 import { bayHtml } from "./bay-page.ts";
+import { summarizeExactReviewHandoff } from "./exact-review-health.ts";
 import { TRIAGE_ROUTING_GROUPS, triageRoutingGroupsForLabels } from "./triage-routing-groups.ts";
 
 const ACTIVE_RUN_STATUSES = new Set(["queued", "in_progress", "waiting", "requested", "pending"]);
@@ -55,6 +56,8 @@ type ExactReviewQueueItem = {
   claimedRunAttempt?: number;
   claimGeneration?: number;
   claimProtocolVersion?: 1 | 2;
+  dispatchedAt?: number;
+  claimedAt?: number;
 };
 type ExactReviewCompletionOutcome = "success" | "failure" | "cancelled";
 type ExactReviewClaimedRun = {
@@ -612,6 +615,8 @@ export class ExactReviewQueue {
       item.claimGeneration = exactReviewClaimGeneration(item.claimGeneration) + 1;
       item.claimProtocolVersion = claimProtocolVersion;
       item.leaseExpiresAt = now + exactReviewExecutionLeaseMs(this.env);
+      item.claimedAt = now;
+      item.updatedAt = now;
       await this.writeState(state);
       await this.scheduleNext(state, now);
       return json(exactReviewClaimResponse(item, claimProtocolVersion, item.claimGeneration));
@@ -790,6 +795,8 @@ export class ExactReviewQueue {
           now,
           exactReviewQueueCapacity(this.env),
           exactReviewTargetCapacity(this.env),
+          exactReviewDispatchLeaseMs(this.env),
+          exactReviewExecutionLeaseMs(this.env),
         ),
         delivery_receipts: this.deliveryReceiptCountSync(),
         storage_schema_version: EXACT_REVIEW_QUEUE_STORAGE_SCHEMA_VERSION,
@@ -885,6 +892,9 @@ export class ExactReviewQueue {
       item.claimedRunId = undefined;
       item.claimedRunAttempt = undefined;
       item.claimGeneration = undefined;
+      item.dispatchedAt = now;
+      item.claimedAt = undefined;
+      item.updatedAt = now;
     }
     await this.writeState(state);
     if (!admitted.length) {
@@ -2022,6 +2032,20 @@ async function exactReviewQueueRequest(env, path, request?: Request) {
   );
 }
 
+export async function exactReviewQueueStatusSnapshot(env) {
+  if (!exactReviewQueueStub(env)) return null;
+  const response = await exactReviewQueueRequest(env, "/stats");
+  const body = objectValue(await response.json().catch(() => null));
+  const health = objectValue(body.handoff_health);
+  if (
+    !response.ok ||
+    !["idle", "healthy", "degraded", "stalled"].includes(String(health.status || ""))
+  ) {
+    throw new Error(String(body.error || "exact-review queue status unavailable"));
+  }
+  return body;
+}
+
 async function authenticatedExactReviewEnqueue(request, env) {
   const secret = stringEnv(env.CLAWSWEEPER_WEBHOOK_SECRET);
   if (!secret) return json({ error: "webhook_not_configured" }, 503);
@@ -2442,6 +2466,8 @@ function clearExactReviewLease(item: ExactReviewQueueItem) {
   item.claimedRunAttempt = undefined;
   item.claimGeneration = undefined;
   item.claimProtocolVersion = undefined;
+  item.dispatchedAt = undefined;
+  item.claimedAt = undefined;
 }
 
 function isLiveExactReviewLease(item: ExactReviewQueueItem, now: number) {
@@ -2520,9 +2546,18 @@ function exactReviewQueueStats(
   now = Date.now(),
   capacity = Number.POSITIVE_INFINITY,
   targetCapacity = Number.POSITIVE_INFINITY,
+  dispatchLeaseMs = DEFAULT_EXACT_REVIEW_DISPATCH_LEASE_MS,
+  executionLeaseMs = DEFAULT_EXACT_REVIEW_EXECUTION_LEASE_MS,
 ) {
   const items = Object.values(state.items);
-  const pending = items.filter((item) => item.state === "pending");
+  const handoffHealth = summarizeExactReviewHandoff({
+    items,
+    dispatcher: state.dispatcher,
+    now,
+    capacity,
+    dispatchLeaseMs,
+    executionLeaseMs,
+  });
   const targets = new Map<
     string,
     {
@@ -2572,15 +2607,16 @@ function exactReviewQueueStats(
     );
   const nextWakeAt = exactReviewQueueNextWakeAt(state, now, capacity, targetCapacity);
   return {
-    pending: pending.length,
-    dispatching: items.filter((item) => item.state === "dispatching").length,
-    leased: items.filter((item) => item.state === "leased").length,
-    oldest_pending_at: pending.length
-      ? new Date(Math.min(...pending.map((item) => item.createdAt))).toISOString()
-      : null,
-    oldest_pending_age_seconds: pending.length
-      ? Math.max(0, Math.floor((now - Math.min(...pending.map((item) => item.createdAt))) / 1000))
-      : null,
+    pending: handoffHealth.phases.pending.count,
+    dispatching: handoffHealth.phases.dispatching.count,
+    leased: handoffHealth.phases.leased.count,
+    oldest_pending_at: handoffHealth.phases.pending.oldest_at,
+    oldest_pending_age_seconds: handoffHealth.phases.pending.oldest_age_seconds,
+    oldest_dispatching_at: handoffHealth.phases.dispatching.oldest_at,
+    oldest_dispatching_age_seconds: handoffHealth.phases.dispatching.oldest_age_seconds,
+    oldest_leased_at: handoffHealth.phases.leased.oldest_at,
+    oldest_leased_age_seconds: handoffHealth.phases.leased.oldest_age_seconds,
+    handoff_health: handoffHealth,
     next_wake_at: nextWakeAt === null ? null : new Date(nextWakeAt).toISOString(),
     dispatcher: {
       state: state.dispatcher?.state || "unknown",
@@ -3171,7 +3207,9 @@ function constantTimeEqual(left, right) {
 async function statusSnapshot(env) {
   const ttl = numberFrom(env.CACHE_TTL_SECONDS, 20);
   const cached = await readCachedSnapshot(env, ttl);
-  if (cached?.bay?.timings?.sample_kind === "latest_completed_jobs") return cached;
+  if (cached?.bay?.timings?.sample_kind === "latest_completed_jobs") {
+    return attachExactReviewQueueStatus(cached, env);
+  }
 
   const github = createGithubJsonCache(env);
   const generatedAt = new Date().toISOString();
@@ -3330,7 +3368,30 @@ async function statusSnapshot(env) {
       errors: errors.slice(0, 20),
     },
   };
-  return snapshot;
+  return attachExactReviewQueueStatus(snapshot, env);
+}
+
+async function attachExactReviewQueueStatus(snapshot, env) {
+  const diagnostics = objectValue(snapshot.diagnostics);
+  let exactReviewQueue = null;
+  let exactReviewQueueError = null;
+  try {
+    exactReviewQueue = await withTimeout(
+      exactReviewQueueStatusSnapshot(env),
+      OPTIONAL_SECTION_TIMEOUT_MS,
+      "exact-review queue",
+    );
+  } catch (error) {
+    exactReviewQueueError = error instanceof Error ? error.message : String(error);
+  }
+  return {
+    ...snapshot,
+    exact_review_queue: exactReviewQueue,
+    diagnostics: {
+      ...diagnostics,
+      exact_review_queue_error: exactReviewQueueError,
+    },
+  };
 }
 
 async function triageSnapshot(env) {
@@ -8056,6 +8117,65 @@ h2::before { content: ""; flex: 0 0 auto; width: 14px; height: 2px; border-radiu
 .capacity-bar .active { background: var(--claw); }
 .capacity-bar .waiting { background: var(--amber); }
 .capacity-meta { margin-top: 8px; color: var(--muted); font-size: 12px; }
+.exact-handoff {
+  margin-top: 18px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--panel);
+}
+.exact-handoff-head {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 16px;
+}
+.exact-handoff-title { display: grid; gap: 3px; }
+.exact-handoff-title strong { font-size: 13px; font-weight: 650; }
+.exact-handoff-title span { color: var(--muted); font-size: 12px; }
+.health-badge {
+  flex: 0 0 auto;
+  padding: 3px 8px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.health-badge.healthy,
+.health-badge.idle { color: var(--green); border-color: color-mix(in srgb, var(--green) 40%, transparent); }
+.health-badge.degraded { color: var(--amber); border-color: color-mix(in srgb, var(--amber) 45%, transparent); }
+.health-badge.stalled { color: var(--red); border-color: color-mix(in srgb, var(--red) 45%, transparent); }
+.handoff-phases {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  margin-top: 14px;
+  overflow: hidden;
+  border: 1px solid var(--line-soft);
+  border-radius: 8px;
+  background: var(--line-soft);
+}
+.handoff-phase { padding: 11px 12px; background: var(--bg); }
+.handoff-phase span {
+  display: block;
+  color: var(--muted);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.handoff-phase strong { display: block; margin-top: 4px; font-size: 21px; font-weight: 560; line-height: 1; }
+.handoff-phase small { display: block; margin-top: 5px; color: var(--muted); font-size: 11px; }
+.handoff-foot {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 10px;
+  color: var(--muted);
+  font-size: 11px;
+}
 .status-dot {
   display: inline-block;
   flex: 0 0 auto;
@@ -8606,6 +8726,8 @@ a.pill:hover { color: var(--claw); text-decoration: none; }
   .side-meta { justify-content: flex-start; }
   .worker-row-sub { grid-template-columns: auto minmax(0, 1fr); }
   .worker-progress { display: none; }
+  .exact-handoff-head, .handoff-foot { align-items: start; flex-direction: column; }
+  .handoff-phases { grid-template-columns: 1fr; }
   dialog { margin: 7px; max-height: calc(100vh - 14px); }
 }
 </style>
@@ -8634,6 +8756,7 @@ a.pill:hover { color: var(--claw); text-decoration: none; }
     </div>
     <div class="flow-map" id="flow-map"></div>
     <div class="capacity-rail" id="capacity-rail"></div>
+    <div id="exact-review-handoff" aria-live="polite"></div>
     <div id="apply-health"></div>
     <div class="automatic-head">
       <h2>Automatic Builds</h2>
@@ -8825,6 +8948,31 @@ function renderSystemMap(data) {
   document.getElementById("overview-note").textContent = fallbacks
     ? "Live jobs with " + fallbacks + " workflow fallback" + (fallbacks === 1 ? "" : "s")
     : "Live GitHub job and step telemetry";
+}
+function renderExactReviewHandoff(queue) {
+  const target = document.getElementById("exact-review-handoff");
+  if (!target) return;
+  const health = queue?.handoff_health;
+  if (!health?.phases) {
+    target.innerHTML = '<div class="exact-handoff"><div class="exact-handoff-head"><div class="exact-handoff-title"><strong>Exact-review handoff</strong><span>Queue telemetry unavailable in this snapshot.</span></div><span class="health-badge">unknown</span></div></div>';
+    return;
+  }
+  const status = ["idle", "healthy", "degraded", "stalled"].includes(health.status) ? health.status : "unknown";
+  const labels = {
+    pending: ["Pending", "waiting for admission"],
+    dispatching: ["Dispatching", "waiting for run claim"],
+    leased: ["Leased", "run owns the review"]
+  };
+  const phases = ["pending", "dispatching", "leased"].map(phase => {
+    const summary = health.phases[phase] || {};
+    const age = Number.isFinite(summary.oldest_age_seconds)
+      ? "oldest " + elapsed(summary.oldest_age_seconds * 1000)
+      : "none waiting";
+    return '<div class="handoff-phase"><span>' + esc(labels[phase][0]) + '</span><strong>' + fmt.format(summary.count || 0) + '</strong><small>' + esc(labels[phase][1] + " · " + age) + '</small></div>';
+  }).join("");
+  const slots = fmt.format(health.available_slots || 0) + " of " + fmt.format(health.capacity || 0) + " exact-review slots open";
+  const threshold = "stalled after " + elapsed((health.stalled_after_seconds || 0) * 1000);
+  target.innerHTML = '<div class="exact-handoff"><div class="exact-handoff-head"><div class="exact-handoff-title"><strong>Exact-review handoff</strong><span>' + esc(health.message || "Queue phase telemetry") + '</span></div><span class="health-badge ' + esc(status) + '">' + esc(status) + '</span></div><div class="handoff-phases">' + phases + '</div><div class="handoff-foot"><span>' + esc(slots) + '</span><span>' + esc(threshold) + '</span></div></div>';
 }
 function renderWorkers(rows) {
   workerIndex = new Map(rows.map(worker => [String(worker.id), worker]));
@@ -9018,10 +9166,14 @@ function renderDashboard(data, note) {
   const applyAttention = (data.recent?.apply_health?.items || []).filter(item =>
     applyHealthNeedsAttention(item.status)
   ).length;
-  const needsAttention = unresolved || applyAttention;
+  const handoffStatus = data.exact_review_queue?.handoff_health?.status;
+  const handoffTelemetryFailed = Boolean(data.diagnostics?.exact_review_queue_error);
+  const handoffAttention =
+    handoffTelemetryFailed || handoffStatus === "degraded" || handoffStatus === "stalled";
+  const needsAttention = unresolved || applyAttention || handoffAttention;
   const workerCount = (data.workers || []).length;
   const repoCount = (data.source.target_repositories || []).length;
-  document.getElementById("hero-dot").className = "hero-dot " + (needsAttention ? "amber" : "ok");
+  document.getElementById("hero-dot").className = "hero-dot " + (handoffStatus === "stalled" ? "red" : needsAttention ? "amber" : "ok");
   document.getElementById("hero-headline").textContent =
     (needsAttention ? "Needs attention" : "All clear") + " — " +
     fmt.format(workerCount) + " claw worker" + (workerCount === 1 ? "" : "s") + " sweeping " +
@@ -9038,6 +9190,7 @@ function renderDashboard(data, note) {
     metric("Capacity", fleet.budget_used_percent + "%", "fleet utilization", fleet.budget_used_percent, "var(--green)")
   ].join("");
   renderSystemMap(data);
+  renderExactReviewHandoff(data.exact_review_queue);
   renderApplyHealth(data);
   renderAutomaticWork(data.automatic_work || []);
   renderWorkers(data.workers || []);

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -218,6 +218,22 @@ workflow state, check time, and retry time so an intentional pause cannot look
 like occupied executor capacity. Re-enabling the workflow does not require a
 queue mutation; the next status check resumes normal admission.
 
+The same endpoint exposes `handoff_health` plus oldest timestamps and ages for
+the pending, dispatching, and leased phases. New dispatch and claim transitions
+carry explicit phase timestamps. Rows written by an older deployment derive
+their phase start from the active dispatch or execution lease; a stale timestamp
+left by a rollback cannot override that newer lease, and a wholly unknown legacy
+age stays non-alarming. A claim is degraded after one third of the dispatch
+lease (bounded to 30-120 seconds) and stalled after two thirds (bounded to
+31-300 seconds), so operators see the failure before the lease expires and
+requeues. A blocked dispatcher with pending work is stalled; an intentionally
+paused dispatcher is degraded. `/api/status` includes this snapshot and the live
+dashboard renders the three phases, oldest age, available exact-review slots,
+and the current classification without changing queue capacity or storage
+schema. If the optional queue read fails, `/api/status` reports
+`exact_review_queue: null` and `diagnostics.exact_review_queue_error` without
+making the otherwise-current fleet snapshot eligible for stale fallback.
+
 Executors report the GitHub job outcome from their finalizer. Failure or
 cancellation clears the lease and requeues the item. Finalizer success remains
 provisional because GitHub can still cancel the run or fail a post-action; only

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -9,6 +9,7 @@ import worker, {
   automaticIssueWork,
   ExactReviewQueue,
   exactReviewQueueCapacity,
+  exactReviewQueueStatusSnapshot,
   mergeBayTerminalState,
   StatusStore,
   summarizeBayTimings,
@@ -23,6 +24,23 @@ test("exact-review queue defaults to 28 of the 128 global workers", () => {
   assert.equal(exactReviewQueueCapacity({}), 28);
   assert.equal(exactReviewQueueCapacity({ EXACT_REVIEW_QUEUE_MAX_CONCURRENT: "32" }), 32);
   assert.equal(exactReviewQueueCapacity({ EXACT_REVIEW_QUEUE_MAX_CONCURRENT: "100" }), 32);
+});
+
+test("dashboard status reads the exact-review handoff model from the durable queue", async () => {
+  const queue = new ExactReviewQueue({ storage: new MemoryDurableStorage() }, {});
+  await queue.fetch(buildExactReviewQueueRequest("handoff-status", 597, "opened"));
+
+  const status = await exactReviewQueueStatusSnapshot({
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+  });
+
+  assert.ok(status);
+  assert.equal(status.pending, 1);
+  assert.equal(status.dispatching, 0);
+  assert.equal(status.leased, 0);
+  assert.equal(status.handoff_health.status, "healthy");
+  assert.equal(status.handoff_health.phases.pending.count, 1);
+  assert.equal(await exactReviewQueueStatusSnapshot({}), null);
 });
 
 test("triage routing groups classify impact labels without forcing one primary group", () => {
@@ -936,6 +954,66 @@ test("dashboard reuses a current Bay snapshot from the shared status store", asy
   }
 });
 
+test("optional exact-review telemetry failures do not freeze an idle status snapshot", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalCaches = globalThis.caches;
+  Object.defineProperty(globalThis, "caches", {
+    configurable: true,
+    value: { default: new MemoryCache() },
+  });
+  const statusStore = new MemoryKv();
+  await statusStore.put(
+    "snapshot",
+    JSON.stringify({
+      schema_version: 1,
+      generated_at: new Date().toISOString(),
+      health: {},
+      bay: { timings: { sample_kind: "latest_completed_jobs" } },
+      pipeline: [],
+      fleet: { active_workflow_runs: 0 },
+      diagnostics: { errors: [] },
+    }),
+  );
+  globalThis.fetch = async () => {
+    throw new Error("shared snapshot should avoid GitHub requests");
+  };
+  const failingQueue = {
+    fetch: async () =>
+      new Response(JSON.stringify({ error: "queue_read_failed" }), {
+        status: 503,
+        headers: { "content-type": "application/json" },
+      }),
+  };
+  const env = {
+    CACHE_TTL_SECONDS: "60",
+    STATUS_STORE: statusStore,
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(failingQueue),
+  };
+
+  try {
+    const response = await worker.fetch(
+      new Request("https://clawsweeper.openclaw.ai/api/status"),
+      env,
+      { waitUntil: () => undefined },
+    );
+    const status = await response.json();
+    assert.equal(status.exact_review_queue, null);
+    assert.deepEqual(status.diagnostics.errors, []);
+    assert.equal(status.diagnostics.exact_review_queue_error, "queue_read_failed");
+
+    const cached = await worker.fetch(
+      new Request("https://clawsweeper.openclaw.ai/api/status"),
+      env,
+      { waitUntil: () => undefined },
+    );
+    assert.equal(cached.headers.get("x-clawsweeper-cache"), "fresh");
+    assert.equal((await cached.json()).diagnostics.exact_review_queue_error, "queue_read_failed");
+  } finally {
+    globalThis.fetch = originalFetch;
+    Object.defineProperty(globalThis, "caches", { configurable: true, value: originalCaches });
+  }
+});
+
 test("exact-review queue coalesces deliveries, dispatches a bound rollout snapshot, and rejects duplicate claims", async () => {
   const originalFetch = globalThis.fetch;
   const storage = new MemoryDurableStorage();
@@ -1042,6 +1120,14 @@ test("exact-review queue coalesces deliveries, dispatches a bound rollout snapsh
     await storage.put("exact-review-queue", pausedState);
     await queue.alarm();
     assert.equal(dispatched.length, 1);
+    stats = await (
+      await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+    ).json();
+    assert.equal(stats.dispatching, 1);
+    assert.equal(stats.leased, 0);
+    assert.equal(stats.handoff_health.status, "healthy");
+    assert.equal(stats.handoff_health.phases.dispatching.count, 1);
+    assert.equal(typeof stats.oldest_dispatching_age_seconds, "number");
     const nextAlarm = await storage.getAlarm();
     assert.ok(nextAlarm && nextAlarm > Date.now() + 60_000);
     const payload = dispatched[0].client_payload as Record<string, unknown>;
@@ -1109,6 +1195,13 @@ test("exact-review queue coalesces deliveries, dispatches a bound rollout snapsh
         mediaProofTimeoutMs: 480_000,
       },
     });
+    stats = await (
+      await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+    ).json();
+    assert.equal(stats.dispatching, 0);
+    assert.equal(stats.leased, 1);
+    assert.equal(stats.handoff_health.phases.leased.count, 1);
+    assert.equal(typeof stats.oldest_leased_age_seconds, "number");
     assert.equal(
       (
         await queue.fetch(
@@ -3356,6 +3449,9 @@ test("dashboard HTML preserves UTF-8 emoji labels", async () => {
   assert.match(html, /href="https:\/\/fleet\.example\.test\/terminal\?view=live&amp;mode=all"/);
   assert.match(html, /Loading pipeline state/);
   assert.match(html, /System Overview/);
+  assert.match(html, /id="exact-review-handoff"/);
+  assert.match(html, /function renderExactReviewHandoff/);
+  assert.match(html, /waiting for run claim/);
   assert.match(html, /id="apply-health"/);
   assert.match(html, /function renderApplyHealth/);
   assert.match(html, /candidate examined count unavailable for this lane/);
@@ -3382,7 +3478,7 @@ test("dashboard HTML preserves UTF-8 emoji labels", async () => {
   assert.doesNotMatch(html, /ðŸ|â|âš|âœ/);
 });
 
-test("dashboard hero treats apply health attention as needs attention", async () => {
+test("dashboard hero treats apply and exact-review handoff health as attention", async () => {
   const response = await worker.fetch(new Request("https://clawsweeper.openclaw.ai/"));
   const html = await response.text();
   const script = [...html.matchAll(/<script>\n([\s\S]*?)\n<\/script>/g)].at(-1)?.[1];
@@ -3435,7 +3531,21 @@ test("dashboard hero treats apply health attention as needs attention", async ()
     workers: [],
     automatic_work: [],
     pipeline: [],
-    diagnostics: { errors: [] },
+    exact_review_queue: {
+      handoff_health: {
+        status: "healthy",
+        message: "Dispatch-to-claim handoffs are within the expected window.",
+        available_slots: 2,
+        capacity: 28,
+        stalled_after_seconds: 300,
+        phases: {
+          pending: { count: 4, oldest_age_seconds: 60 },
+          dispatching: { count: 2, oldest_age_seconds: 10 },
+          leased: { count: 24, oldest_age_seconds: 240 },
+        },
+      },
+    },
+    diagnostics: { errors: [], exact_review_queue_error: null as string | null },
     recent: {
       apply_health: {
         attention_count: 1,
@@ -3529,6 +3639,27 @@ test("dashboard hero treats apply health attention as needs attention", async ()
   assert.equal(elementFor("hero-dot").className, "hero-dot amber");
   assert.match(elementFor("hero-headline").textContent, /^Needs attention/);
   assert.match(elementFor("apply-health").innerHTML, /Pruning sweep blocked/);
+  assert.match(elementFor("exact-review-handoff").innerHTML, /Dispatching/);
+  assert.match(elementFor("exact-review-handoff").innerHTML, /2 of 28 exact-review slots open/);
+  assert.match(elementFor("exact-review-handoff").innerHTML, /health-badge healthy/);
+
+  status.recent.apply_health.items = [];
+  status.exact_review_queue.handoff_health.status = "stalled";
+  status.exact_review_queue.handoff_health.message =
+    "A dispatched review has not been claimed within the expected handoff window.";
+  context.renderDashboard(status, "");
+
+  assert.equal(elementFor("hero-dot").className, "hero-dot red");
+  assert.match(elementFor("hero-headline").textContent, /^Needs attention/);
+  assert.match(elementFor("exact-review-handoff").innerHTML, /health-badge stalled/);
+
+  Object.assign(status, { exact_review_queue: null });
+  status.diagnostics.exact_review_queue_error = "exact-review queue timed out";
+  context.renderDashboard(status, "");
+
+  assert.equal(elementFor("hero-dot").className, "hero-dot amber");
+  assert.match(elementFor("hero-headline").textContent, /^Needs attention/);
+  assert.match(elementFor("exact-review-handoff").innerHTML, /telemetry unavailable/);
 });
 
 test("dashboard HTML emits early persistent theme controls", async () => {

--- a/test/exact-review-health.test.ts
+++ b/test/exact-review-health.test.ts
@@ -1,0 +1,172 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { summarizeExactReviewHandoff } from "../dashboard/exact-review-health.ts";
+
+const NOW = Date.parse("2026-07-13T02:00:00.000Z");
+const DISPATCH_LEASE_MS = 10 * 60_000;
+const EXECUTION_LEASE_MS = 130 * 60_000;
+
+function summarize(overrides: Partial<Parameters<typeof summarizeExactReviewHandoff>[0]> = {}) {
+  return summarizeExactReviewHandoff({
+    items: [],
+    now: NOW,
+    capacity: 28,
+    dispatchLeaseMs: DISPATCH_LEASE_MS,
+    executionLeaseMs: EXECUTION_LEASE_MS,
+    ...overrides,
+  });
+}
+
+test("exact-review handoff health reports an empty queue as idle", () => {
+  const health = summarize();
+
+  assert.equal(health.status, "idle");
+  assert.equal(health.reason, "queue_empty");
+  assert.equal(health.active, 0);
+  assert.equal(health.available_slots, 28);
+  assert.deepEqual(health.phases, {
+    pending: { count: 0, oldest_at: null, oldest_age_seconds: null },
+    dispatching: { count: 0, oldest_at: null, oldest_age_seconds: null },
+    leased: { count: 0, oldest_at: null, oldest_age_seconds: null },
+  });
+});
+
+test("exact-review handoff health exposes phase counts, ages, and available capacity", () => {
+  const health = summarize({
+    capacity: 4,
+    dispatcher: { state: "active" },
+    items: [
+      { state: "pending", createdAt: NOW - 90_000, updatedAt: NOW - 90_000 },
+      {
+        state: "dispatching",
+        createdAt: NOW - 5 * 60_000,
+        updatedAt: NOW - 20_000,
+        dispatchedAt: NOW - 20_000,
+      },
+      {
+        state: "leased",
+        createdAt: NOW - 6 * 60_000,
+        updatedAt: NOW - 40_000,
+        claimedAt: NOW - 40_000,
+      },
+    ],
+  });
+
+  assert.equal(health.status, "healthy");
+  assert.equal(health.reason, "handoff_current");
+  assert.equal(health.active, 2);
+  assert.equal(health.available_slots, 2);
+  assert.deepEqual(health.phases.pending, {
+    count: 1,
+    oldest_at: "2026-07-13T01:58:30.000Z",
+    oldest_age_seconds: 90,
+  });
+  assert.equal(health.phases.dispatching.oldest_age_seconds, 20);
+  assert.equal(health.phases.leased.oldest_age_seconds, 40);
+  assert.equal(health.warning_after_seconds, 120);
+  assert.equal(health.stalled_after_seconds, 300);
+});
+
+test("exact-review handoff health distinguishes delayed and stalled claims", () => {
+  const delayed = summarize({
+    items: [
+      {
+        state: "dispatching",
+        createdAt: NOW - 10 * 60_000,
+        updatedAt: NOW - 121_000,
+        dispatchedAt: NOW - 121_000,
+      },
+    ],
+  });
+  const stalled = summarize({
+    items: [
+      {
+        state: "dispatching",
+        createdAt: NOW - 10 * 60_000,
+        updatedAt: NOW - 301_000,
+        dispatchedAt: NOW - 301_000,
+      },
+    ],
+  });
+
+  assert.equal(delayed.status, "degraded");
+  assert.equal(delayed.reason, "claim_delayed");
+  assert.equal(stalled.status, "stalled");
+  assert.equal(stalled.reason, "claim_stalled");
+});
+
+test("exact-review handoff health surfaces paused and blocked dispatchers with pending work", () => {
+  const items = [{ state: "pending" as const, createdAt: NOW - 60_000, updatedAt: NOW - 60_000 }];
+
+  const paused = summarize({ items, dispatcher: { state: "paused" } });
+  const blocked = summarize({ items, dispatcher: { state: "blocked" } });
+
+  assert.equal(paused.status, "degraded");
+  assert.equal(paused.reason, "dispatcher_paused");
+  assert.equal(blocked.status, "stalled");
+  assert.equal(blocked.reason, "dispatcher_blocked");
+});
+
+test("exact-review handoff health derives legacy dispatch age from its active lease", () => {
+  const health = summarize({
+    items: [
+      {
+        state: "dispatching",
+        createdAt: NOW - 60 * 60_000,
+        updatedAt: NOW - 60 * 60_000,
+        leaseExpiresAt: NOW + DISPATCH_LEASE_MS - 20_000,
+      },
+    ],
+  });
+
+  assert.equal(health.status, "healthy");
+  assert.equal(health.phases.dispatching.oldest_at, "2026-07-13T01:59:40.000Z");
+  assert.equal(health.phases.dispatching.oldest_age_seconds, 20);
+});
+
+test("exact-review handoff health ignores stale rollback telemetry and unknown legacy ages", () => {
+  const rolledBack = summarize({
+    items: [
+      {
+        state: "dispatching",
+        createdAt: NOW - 60 * 60_000,
+        updatedAt: NOW - 60 * 60_000,
+        dispatchedAt: NOW - 60 * 60_000,
+        leaseExpiresAt: NOW + DISPATCH_LEASE_MS - 20_000,
+      },
+    ],
+  });
+  const unknown = summarize({
+    items: [
+      {
+        state: "dispatching",
+        createdAt: NOW - 60 * 60_000,
+        updatedAt: NOW - 60 * 60_000,
+      },
+    ],
+  });
+
+  assert.equal(rolledBack.status, "healthy");
+  assert.equal(rolledBack.phases.dispatching.oldest_age_seconds, 20);
+  assert.equal(unknown.status, "healthy");
+  assert.equal(unknown.phases.dispatching.oldest_age_seconds, 0);
+});
+
+test("exact-review handoff health derives legacy leased age from its execution lease", () => {
+  const health = summarize({
+    items: [
+      {
+        state: "leased",
+        createdAt: NOW - 60 * 60_000,
+        updatedAt: NOW - 60 * 60_000,
+        claimedAt: NOW - 60 * 60_000,
+        leaseExpiresAt: NOW + EXECUTION_LEASE_MS - 40_000,
+      },
+    ],
+  });
+
+  assert.equal(health.status, "healthy");
+  assert.equal(health.phases.leased.oldest_at, "2026-07-13T01:59:20.000Z");
+  assert.equal(health.phases.leased.oldest_age_seconds, 40);
+});


### PR DESCRIPTION
## Summary

- stamp exact-review dispatch and claim transitions, then expose phase counts, oldest ages, capacity, and classified handoff health
- add a phase-aware operator rail and make degraded, stalled, or unavailable queue telemetry visible in dashboard attention state
- extract the pure health model from the Worker, with rolling-deploy and rollback-safe lease-derived timestamps

## Compatibility

- additive API fields only; existing queue counts and `storage_schema_version: 1` remain unchanged
- no queue-capacity, admission, claim, completion, or workflow behavior change

## Validation

- `pnpm run build:dashboard`
- `node --test test/exact-review-health.test.ts test/dashboard-worker.test.ts` — 100 passed
- source-blind local Worker contract: empty queue, synthetic pending/blocked queue, phase-count invariants, status embedding, and invalid-route behavior
- autoreview clean after fixing stale status fallback, rolling-deploy/rollback phase timing, and unavailable-telemetry attention state

## Local environment note

`pnpm run check` reached the existing review-runtime packaging test and failed there because this machine's npm emits a JSON package object while that unchanged test expects a one-element array. The same test reproduces alone; exact-head CI is the supported-environment gate.
