### PR TITLE
fix(repair): accept forwarded argument separator

### DIFF
--- a/src/repair/resolve-run-artifact.ts
+++ b/src/repair/resolve-run-artifact.ts
@@ -50,6 +50,7 @@ writeOutputs({
 });
 
 function parseArgs(values: string[]): Map<string, string> {
+  if (values[0] === "--") values = values.slice(1);
   const parsed = new Map<string, string>();
   for (let index = 0; index < values.length; index += 2) {
     const name = values[index];

--- a/src/repair/resolve-run-artifact.ts
+++ b/src/repair/resolve-run-artifact.ts
@@ -5,7 +5,9 @@ import { runCommand as run } from "./command-runner.js";
 import type { LooseRecord } from "./json-types.js";
 import { resolveRunArtifact } from "./run-artifact.js";
 
-const args = parseArgs(process.argv.slice(2));
+const argv = process.argv.slice(2);
+// pnpm forwards the script argument separator to the child process.
+const args = parseArgs(argv[0] === "--" ? argv.slice(1) : argv);
 const repository = requiredArg(args, "repository");
 if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)) {
   throw new Error("repository is invalid");
@@ -50,7 +52,6 @@ writeOutputs({
 });
 
 function parseArgs(values: string[]): Map<string, string> {
-  if (values[0] === "--") values = values.slice(1);
   const parsed = new Map<string, string>();
   for (let index = 0; index < values.length; index += 2) {
     const name = values[index];

--- a/test/repair/run-artifact.test.ts
+++ b/test/repair/run-artifact.test.ts
@@ -13,6 +13,7 @@ const digest2 = "2".repeat(64);
 test("artifact resolver accepts pnpm's forwarded argument separator", () => {
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-artifact-cli-"));
   const ghPath = path.join(binDir, "gh");
+  const outputPath = path.join(binDir, "github-output");
   fs.writeFileSync(
     ghPath,
     `#!/usr/bin/env node
@@ -27,7 +28,7 @@ process.stdout.write(JSON.stringify([{ artifacts: [{
   fs.chmodSync(ghPath, 0o755);
 
   try {
-    const output = execFileSync(
+    execFileSync(
       process.execPath,
       [
         "dist/repair/resolve-run-artifact.js",
@@ -43,9 +44,14 @@ process.stdout.write(JSON.stringify([{ artifacts: [{
       ],
       {
         encoding: "utf8",
-        env: { ...process.env, PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}` },
+        env: {
+          ...process.env,
+          GITHUB_OUTPUT: outputPath,
+          PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        },
       },
     );
+    const output = fs.readFileSync(outputPath, "utf8");
 
     assert.match(output, /artifact_id=101/);
     assert.match(output, /producer_attempt=1/);

--- a/test/repair/run-artifact.test.ts
+++ b/test/repair/run-artifact.test.ts
@@ -1,11 +1,58 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 import { resolveRunArtifact } from "../../dist/repair/run-artifact.js";
 
 const digest1 = "1".repeat(64);
 const digest2 = "2".repeat(64);
+
+test("artifact resolver accepts pnpm's forwarded argument separator", () => {
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-artifact-cli-"));
+  const ghPath = path.join(binDir, "gh");
+  fs.writeFileSync(
+    ghPath,
+    `#!/usr/bin/env node
+process.stdout.write(JSON.stringify([{ artifacts: [{
+  id: 101,
+  name: "clawsweeper-repair-worker-9001-1",
+  digest: "sha256:${digest1}",
+  workflow_run: { id: 9001, run_attempt: 1 }
+}] }]));
+`,
+  );
+  fs.chmodSync(ghPath, 0o755);
+
+  try {
+    const output = execFileSync(
+      process.execPath,
+      [
+        "dist/repair/resolve-run-artifact.js",
+        "--",
+        "--repository",
+        "openclaw/clawsweeper",
+        "--run-id",
+        "9001",
+        "--current-attempt",
+        "1",
+        "--prefix",
+        "clawsweeper-repair-worker",
+      ],
+      {
+        encoding: "utf8",
+        env: { ...process.env, PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}` },
+      },
+    );
+
+    assert.match(output, /artifact_id=101/);
+    assert.match(output, /producer_attempt=1/);
+  } finally {
+    fs.rmSync(binDir, { recursive: true, force: true });
+  }
+});
 
 test("reruns select the latest trusted producer attempt instead of the consumer attempt", () => {
   assert.deepEqual(


### PR DESCRIPTION
## Summary

- ignore the leading `--` forwarded by `pnpm run ... --` before parsing resolver options
- add an integration regression test covering the exact CLI argument shape from the failed workflow

## Validation

- `node --test test/repair/run-artifact.test.ts` (10/10 passed)
- `pnpm run build:repair`
- `autoreview --mode local --stream-engine-output` (clean, no actionable findings)
- `pnpm run check` reaches and passes build/lint, but the existing `test/codex-review-runner.test.ts` mock suite invokes an unauthenticated Codex subprocess and fails with HTTP 401; unrelated to this two-file change