### PR TITLE
fix: keep exact-review health live across stale fleet cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Kept exact-review handoff health live when the dashboard serves a stale fleet snapshot, so recovered claims no longer leave the operator rail stuck in a delayed or stalled state.
 - Restored exact-review intake by deriving cancellation from `job.status`, avoiding an unsupported status-check function in step environment expressions that made GitHub reject the sweep workflow, and added checksum-pinned workflow-semantic linting to CI.
 - Made comment-router ledger updates retain refreshed claims at the bounded
   history limit, publish through fsynced atomic replacement, and fail closed on

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -1518,32 +1518,32 @@ export default {
 async function statusJson(request, env, ctx) {
   const cache = caches.default;
   const cached = await cache.match(statusCacheRequest(request, "fresh"));
-  if (cached) return cachedStatusResponse(cached, "fresh");
+  if (cached) return cachedStatusResponse(cached, "fresh", env);
 
   const stale = await cache.match(statusCacheRequest(request, "stale"));
   if (stale && ctx?.waitUntil) {
     ctx.waitUntil(refreshStatus(request, env).catch(() => undefined));
-    return cachedStatusResponse(stale, "stale");
+    return cachedStatusResponse(stale, "stale", env);
   }
 
   const refreshed = await refreshStatus(request, env);
-  if (refreshed.looksEmpty && stale) return cachedStatusResponse(stale, "stale");
-  return cors(
-    new Response(refreshed.body, {
-      headers: {
-        "content-type": "application/json; charset=utf-8",
-        "cache-control": "no-store",
-        "x-clawsweeper-cache": "miss",
-      },
-    }),
-  );
+  if (refreshed.looksEmpty && stale) return cachedStatusResponse(stale, "stale", env);
+  return statusSnapshotResponse(refreshed.snapshot, "miss", env);
 }
 
-function cachedStatusResponse(cached, cacheState) {
+async function cachedStatusResponse(cached, cacheState, env) {
+  const snapshot = await cached.json();
   const headers = new Headers(cached.headers);
-  headers.set("x-clawsweeper-cache", cacheState);
-  if (cacheState === "stale") headers.set("cache-control", "no-store");
-  return cors(new Response(cached.body, { status: cached.status, headers }));
+  return statusSnapshotResponse(snapshot, cacheState, env, cached.status, headers);
+}
+
+async function statusSnapshotResponse(snapshot, cacheState, env, status = 200, headers?) {
+  const current = await attachExactReviewQueueStatus(snapshot, env);
+  const responseHeaders = new Headers(headers);
+  responseHeaders.set("content-type", "application/json; charset=utf-8");
+  responseHeaders.set("cache-control", "no-store");
+  responseHeaders.set("x-clawsweeper-cache", cacheState);
+  return cors(new Response(JSON.stringify(current, null, 2), { status, headers: responseHeaders }));
 }
 
 function refreshStatus(request, env) {
@@ -3208,7 +3208,7 @@ async function statusSnapshot(env) {
   const ttl = numberFrom(env.CACHE_TTL_SECONDS, 20);
   const cached = await readCachedSnapshot(env, ttl);
   if (cached?.bay?.timings?.sample_kind === "latest_completed_jobs") {
-    return attachExactReviewQueueStatus(cached, env);
+    return cached;
   }
 
   const github = createGithubJsonCache(env);
@@ -3368,7 +3368,7 @@ async function statusSnapshot(env) {
       errors: errors.slice(0, 20),
     },
   };
-  return attachExactReviewQueueStatus(snapshot, env);
+  return snapshot;
 }
 
 async function attachExactReviewQueueStatus(snapshot, env) {

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -230,7 +230,9 @@ requeues. A blocked dispatcher with pending work is stalled; an intentionally
 paused dispatcher is degraded. `/api/status` includes this snapshot and the live
 dashboard renders the three phases, oldest age, available exact-review slots,
 and the current classification without changing queue capacity or storage
-schema. If the optional queue read fails, `/api/status` reports
+schema. Fleet snapshots may use the longer stale fallback during a GitHub API
+outage, but `/api/status` attaches queue telemetry after selecting that snapshot
+so handoff recovery stays live. If the optional queue read fails, it reports
 `exact_review_queue: null` and `diagnostics.exact_review_queue_error` without
 making the otherwise-current fleet snapshot eligible for stale fallback.
 

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -4770,9 +4770,34 @@ test("dashboard serves stale status while coalescing one background refresh", as
       fleet: { active_workflow_runs: 1 },
       workers: [],
       pipeline: [{ id: "stale-row" }],
-      diagnostics: { errors: [] },
+      exact_review_queue: {
+        pending: 1,
+        dispatching: 1,
+        leased: 0,
+        handoff_health: { status: "stalled" },
+      },
+      diagnostics: { errors: [], exact_review_queue_error: null },
     }),
   );
+
+  const currentQueue = {
+    pending: 7,
+    dispatching: 0,
+    leased: 28,
+    storage_schema_version: 1,
+    handoff_health: {
+      status: "healthy",
+      reason: "handoff_current",
+      phases: {
+        pending: { count: 7 },
+        dispatching: { count: 0 },
+        leased: { count: 28 },
+      },
+    },
+  };
+  const exactReviewQueue = new MemoryDurableNamespace({
+    fetch: async () => jsonResponse(currentQueue),
+  });
 
   let releaseFetch!: () => void;
   const fetchGate = new Promise<void>((resolve) => {
@@ -4799,6 +4824,7 @@ test("dashboard serves stale status while coalescing one background refresh", as
       CLAWSWEEPER_REPO: "openclaw/clawsweeper",
       TARGET_REPOS: "openclaw/openclaw",
       CACHE_TTL_SECONDS: "20",
+      EXACT_REVIEW_QUEUE: exactReviewQueue,
     };
     const context = {
       waitUntil(promise: Promise<unknown>) {
@@ -4813,7 +4839,12 @@ test("dashboard serves stale status while coalescing one background refresh", as
 
     assert.equal(first.headers.get("x-clawsweeper-cache"), "stale");
     assert.equal(second.headers.get("x-clawsweeper-cache"), "stale");
-    assert.equal((await first.json()).pipeline[0].id, "stale-row");
+    const firstStatus = await first.json();
+    const secondStatus = await second.json();
+    assert.equal(firstStatus.pipeline[0].id, "stale-row");
+    assert.equal(firstStatus.exact_review_queue.pending, 7);
+    assert.equal(firstStatus.exact_review_queue.handoff_health.status, "healthy");
+    assert.equal(secondStatus.exact_review_queue.handoff_health.status, "healthy");
     assert.equal(waitUntilPromises.length, 2);
 
     releaseFetch();


### PR DESCRIPTION
## Summary

- keep the fleet/status snapshot cache independent from exact-review queue telemetry
- attach current queue health after selecting a fresh, stale, or newly built fleet snapshot
- force the composed response to `no-store` while retaining internal fleet-cache coalescing

## Why

Live production verification of #532 caught `/api/status` serving an eight-minute stale fleet fallback with an old `stalled` handoff state even though `/api/exact-review-queue` had recovered to `healthy`. The dashboard rail therefore lagged the state it was meant to diagnose.

## Validation

- `pnpm run build:dashboard`
- `node --test test/exact-review-health.test.ts test/dashboard-worker.test.ts` — 100 passed
- regression proves a stale fleet row is retained while its stale queue payload is replaced by current healthy telemetry
- autoreview clean