### PR TITLE
feat(release): add deterministic release-train audits

### DIFF
--- a/config/release-control.json
+++ b/config/release-control.json
@@ -3,10 +3,13 @@
   "repositories": {
     "openclaw/openclaw": {
       "release_preparation": {
-        "exact_paths": ["package.json", "pnpm-lock.yaml"],
-        "prefixes": [
-          "apps/macos/Sources/OpenClaw/Resources/",
-          "apps/macos/OpenClaw/Assets.xcassets/"
+        "exact_paths": ["package.json", "npm-shrinkwrap.json", "pnpm-lock.yaml"],
+        "prefixes": ["apps/macos/Sources/OpenClaw/Resources/"],
+        "patterns": [
+          "extensions/*/package.json",
+          "extensions/*/npm-shrinkwrap.json",
+          "packages/*/package.json",
+          "packages/*/npm-shrinkwrap.json"
         ]
       },
       "release_infrastructure": {

--- a/config/release-control.json
+++ b/config/release-control.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "repositories": {
+    "openclaw/openclaw": {
+      "release_preparation": {
+        "exact_paths": ["package.json", "pnpm-lock.yaml"],
+        "prefixes": [
+          "apps/macos/Sources/OpenClaw/Resources/",
+          "apps/macos/OpenClaw/Assets.xcassets/"
+        ]
+      },
+      "release_infrastructure": {
+        "exact_paths": [
+          ".agents/skills/release-openclaw-maintainer/SKILL.md",
+          "docs/reference/RELEASING.md"
+        ],
+        "prefixes": [
+          ".github/workflows/release-",
+          ".github/actions/release-",
+          "scripts/release",
+          "scripts/package",
+          "scripts/notarize"
+        ]
+      },
+      "product_path_prefixes": ["src/", "apps/", "packages/", "extensions/"]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "proof-nudges": "node dist/clawsweeper.js proof-nudges",
     "bot-proof": "node dist/clawsweeper.js bot-proof",
     "audit": "node dist/clawsweeper.js audit",
+    "release-control:audit": "node dist/clawsweeper.js release-control-audit",
     "reconcile": "node dist/clawsweeper.js reconcile",
     "status": "node dist/clawsweeper.js status",
     "commit-review": "node dist/commit-sweeper.js",

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -54,6 +54,7 @@ import {
 } from "./github-retry.js";
 import { parseGhJson, parseGhJsonLinesWithRetry, parseGhJsonWithRetry } from "./github-json.js";
 import { stableJson } from "./stable-json.js";
+import { releaseControlAuditCommand } from "./release-control/cli.js";
 import {
   REVIEW_STRUCTURAL_CACHE_VERSION,
   reviewStructuralRecordAtLeastAsFresh,
@@ -30323,8 +30324,9 @@ export async function main(
 ): Promise<void> {
   const args = parseArgs(argv);
   const command = args._[0] ?? "review";
+  const readOnlyReleaseControlAudit = command === "release-control-audit";
   const flushActionEvents = dependencies.flushWorkflowActionEvents ?? flushWorkflowActionEvents;
-  if (!process.env.CLAWSWEEPER_ACTION_LEDGER_INVOCATION) {
+  if (!readOnlyReleaseControlAudit && !process.env.CLAWSWEEPER_ACTION_LEDGER_INVOCATION) {
     process.env.CLAWSWEEPER_ACTION_LEDGER_INVOCATION = sha256(stableJson({ command, args })).slice(
       0,
       16,
@@ -30343,6 +30345,7 @@ export async function main(
     else if (command === "proof-nudges") proofNudgesCommand(args);
     else if (command === "bot-proof") botProofCommand(args);
     else if (command === "audit") auditCommand(args);
+    else if (command === "release-control-audit") releaseControlAuditCommand(args);
     else if (command === "reconcile") reconcileCommand(args);
     else if (command === "dashboard") {
       repoFromArgs(args);
@@ -30384,31 +30387,33 @@ export async function main(
     commandFailed = true;
     commandError = error;
   }
-  try {
-    const shardPaths = await flushActionEvents(ROOT);
-    if (shardPaths.length > 0) {
-      console.error(
-        `[action-ledger] finalized ${shardPaths.length} immutable workflow shard${
-          shardPaths.length === 1 ? "" : "s"
-        }`,
-      );
-    }
-  } catch (error) {
-    if (commandFailed) {
-      console.error(
-        `[action-ledger] best-effort finalization failed after command failure: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
-    } else if (isExplicitActionLedgerCommand(command)) {
-      commandFailed = true;
-      commandError = error;
-    } else {
-      console.error(
-        `[action-ledger] best-effort finalization failed after successful ${command}: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
+  if (!readOnlyReleaseControlAudit) {
+    try {
+      const shardPaths = await flushActionEvents(ROOT);
+      if (shardPaths.length > 0) {
+        console.error(
+          `[action-ledger] finalized ${shardPaths.length} immutable workflow shard${
+            shardPaths.length === 1 ? "" : "s"
+          }`,
+        );
+      }
+    } catch (error) {
+      if (commandFailed) {
+        console.error(
+          `[action-ledger] best-effort finalization failed after command failure: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      } else if (isExplicitActionLedgerCommand(command)) {
+        commandFailed = true;
+        commandError = error;
+      } else {
+        console.error(
+          `[action-ledger] best-effort finalization failed after successful ${command}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
     }
   }
   if (commandFailed) throw commandError;

--- a/src/release-control/classifier.ts
+++ b/src/release-control/classifier.ts
@@ -3,6 +3,7 @@ import type { ReleaseContract, ReleasePullMetadata } from "./contract.js";
 export interface ReleasePathPolicy {
   exactPaths: readonly string[];
   prefixes: readonly string[];
+  patterns?: readonly string[];
 }
 
 export interface ReleaseRepositoryPolicy {
@@ -120,9 +121,13 @@ function classifyException(
   metadata: ReleasePullMetadata,
   signals: string[],
 ): ReleaseChangeDecision {
-  const exception = input.contract.approvedExceptions.find(
+  const matchingExceptions = input.contract.approvedExceptions.filter(
     (candidate) => candidate.number === input.prNumber,
   );
+  if (matchingExceptions.length > 1) {
+    return decision("incomplete", "release contract contains duplicate exception entries", signals);
+  }
+  const exception = matchingExceptions[0];
   if (!exception) {
     return decision("blocked", "pull request is not listed under Approved exceptions", signals);
   }
@@ -164,8 +169,18 @@ function pathsMatch(paths: readonly string[], policy: ReleasePathPolicy): boolea
     paths.every(
       (path) =>
         policy.exactPaths.includes(path) ||
-        policy.prefixes.some((prefix) => path.startsWith(prefix)),
+        policy.prefixes.some((prefix) => path.startsWith(prefix)) ||
+        (policy.patterns ?? []).some((pattern) => pathMatchesPattern(path, pattern)),
     )
+  );
+}
+
+function pathMatchesPattern(path: string, pattern: string): boolean {
+  const pathSegments = path.split("/");
+  const patternSegments = pattern.split("/");
+  return (
+    pathSegments.length === patternSegments.length &&
+    patternSegments.every((segment, index) => segment === "*" || segment === pathSegments[index])
   );
 }
 

--- a/src/release-control/classifier.ts
+++ b/src/release-control/classifier.ts
@@ -1,0 +1,197 @@
+import type { ReleaseContract, ReleasePullMetadata } from "./contract.js";
+
+export interface ReleasePathPolicy {
+  exactPaths: readonly string[];
+  prefixes: readonly string[];
+}
+
+export interface ReleaseRepositoryPolicy {
+  releasePreparation: ReleasePathPolicy;
+  releaseInfrastructure: ReleasePathPolicy;
+  productPathPrefixes?: readonly string[];
+}
+
+export type ReleaseChangeStatus =
+  | "allowed"
+  | "unclassified"
+  | "pending-exception"
+  | "blocked"
+  | "incomplete";
+
+export interface ReleaseChangeInput {
+  sha: string;
+  prNumber?: number;
+  title: string;
+  paths: readonly string[];
+  contractIssue: number;
+  contract: ReleaseContract;
+  policy: ReleaseRepositoryPolicy;
+  metadata?: ReleasePullMetadata;
+  metadataMissingFields?: readonly string[];
+  pathsComplete?: boolean;
+  sourceMainReachable?: boolean;
+  patchEquivalent?: boolean;
+  collectionComplete?: boolean;
+}
+
+export interface ReleaseChangeDecision {
+  status: ReleaseChangeStatus;
+  reason: string;
+  signals: string[];
+}
+
+export function classifyReleaseChange(input: ReleaseChangeInput): ReleaseChangeDecision {
+  const signals = changeSignals(input.title, input.paths, input.policy);
+  if (input.collectionComplete === false || input.pathsComplete === false) {
+    return decision("incomplete", "change collection is incomplete", signals);
+  }
+  if (!input.prNumber) {
+    return decision(
+      "unclassified",
+      "change is not associated with a release-target pull request",
+      signals,
+    );
+  }
+  if (!input.metadata) {
+    const detail = input.metadataMissingFields?.join(", ") || "required release metadata";
+    return decision("incomplete", `pull request is missing ${detail}`, signals);
+  }
+  if (input.metadata.contractIssue !== input.contractIssue) {
+    return decision("blocked", "pull request references a different release contract", signals);
+  }
+  const releaseClass = input.metadata.releaseClass;
+  if (!input.contract.allowedChangeClasses.includes(releaseClass)) {
+    return decision(
+      "blocked",
+      `release class ${releaseClass} is not allowed by the contract`,
+      signals,
+    );
+  }
+
+  switch (releaseClass) {
+    case "release-preparation":
+      return pathsMatch(input.paths, input.policy.releasePreparation)
+        ? decision("allowed", "paths match the repository release-preparation policy", signals)
+        : decision("blocked", "paths exceed the repository release-preparation policy", signals);
+    case "release-blocker":
+      return input.metadata.blockerIssue
+        ? decision("allowed", `release blocker cites #${input.metadata.blockerIssue}`, signals)
+        : decision("incomplete", "release blocker does not cite a GitHub issue", signals);
+    case "exact-backport":
+      if (!input.metadata.sourceSha || !input.metadata.sourcePull) {
+        return decision(
+          "incomplete",
+          "exact backport is missing a full source SHA or pull request",
+          signals,
+        );
+      }
+      if (input.sourceMainReachable === undefined || input.patchEquivalent === undefined) {
+        return decision(
+          "incomplete",
+          "exact backport proof requires a complete target checkout",
+          signals,
+        );
+      }
+      if (!input.sourceMainReachable) {
+        return decision("blocked", "exact backport source SHA is not reachable from main", signals);
+      }
+      return input.patchEquivalent
+        ? decision("allowed", "source is on main and stable patch-id is equivalent", signals)
+        : decision(
+            "blocked",
+            "release change is not patch-equivalent to its source on main",
+            signals,
+          );
+    case "release-infrastructure":
+      return pathsMatch(input.paths, input.policy.releaseInfrastructure)
+        ? decision("allowed", "paths match the repository release-infrastructure policy", signals)
+        : decision("blocked", "paths exceed the repository release-infrastructure policy", signals);
+    case "changelog-only":
+      return input.paths.length === 1 && input.paths[0] === "CHANGELOG.md"
+        ? decision("allowed", "complete path set is exactly CHANGELOG.md", signals)
+        : decision("blocked", "changelog-only changes must modify exactly CHANGELOG.md", signals);
+    case "exception":
+      return classifyException(input, input.metadata, signals);
+  }
+}
+
+function classifyException(
+  input: ReleaseChangeInput,
+  metadata: ReleasePullMetadata,
+  signals: string[],
+): ReleaseChangeDecision {
+  const exception = input.contract.approvedExceptions.find(
+    (candidate) => candidate.number === input.prNumber,
+  );
+  if (!exception) {
+    return decision("blocked", "pull request is not listed under Approved exceptions", signals);
+  }
+  if (exception.decision === "pending") {
+    if (!exception.decisionUrl || !metadata.exceptionDecisionUrl) {
+      return decision("incomplete", "pending exception is missing its decision link", signals);
+    }
+    if (exception.decisionUrl !== metadata.exceptionDecisionUrl) {
+      return decision(
+        "blocked",
+        "exception decision link does not match the release contract",
+        signals,
+      );
+    }
+    return decision("pending-exception", "exception decision is pending", signals);
+  }
+  if (exception.decision === "rejected") {
+    return decision("blocked", "exception decision was rejected", signals);
+  }
+  if (exception.approver !== input.contract.captain) {
+    return decision("blocked", "exception was not approved by the release captain", signals);
+  }
+  if (!exception.decisionUrl || !metadata.exceptionDecisionUrl) {
+    return decision("incomplete", "approved exception is missing its decision link", signals);
+  }
+  if (exception.decisionUrl !== metadata.exceptionDecisionUrl) {
+    return decision(
+      "blocked",
+      "exception decision link does not match the release contract",
+      signals,
+    );
+  }
+  return decision("allowed", "exception is listed and approved by the release captain", signals);
+}
+
+function pathsMatch(paths: readonly string[], policy: ReleasePathPolicy): boolean {
+  return (
+    paths.length > 0 &&
+    paths.every(
+      (path) =>
+        policy.exactPaths.includes(path) ||
+        policy.prefixes.some((prefix) => path.startsWith(prefix)),
+    )
+  );
+}
+
+function changeSignals(
+  title: string,
+  paths: readonly string[],
+  policy: ReleaseRepositoryPolicy,
+): string[] {
+  const signals: string[] = [];
+  if (/^feat(?:\([^)]*\))?[!:]/i.test(title.trim())) signals.push("feature-title");
+  if (
+    paths.some((path) =>
+      (policy.productPathPrefixes ?? ["src/", "apps/", "packages/"]).some((prefix) =>
+        path.startsWith(prefix),
+      ),
+    )
+  ) {
+    signals.push("product-or-runtime-path");
+  }
+  return signals;
+}
+
+function decision(
+  status: ReleaseChangeStatus,
+  reason: string,
+  signals: string[],
+): ReleaseChangeDecision {
+  return { status, reason, signals };
+}

--- a/src/release-control/cli.ts
+++ b/src/release-control/cli.ts
@@ -96,10 +96,16 @@ interface GitHubIssue {
 }
 
 interface GitHubRef {
-  object?: { sha?: string };
+  object?: { sha?: string; type?: string };
+}
+
+interface GitHubTag {
+  sha?: string;
+  object?: { sha?: string; type?: string };
 }
 
 interface GitHubRelease {
+  id?: number;
   tag_name?: string;
   prerelease?: boolean;
   draft?: boolean;
@@ -112,6 +118,8 @@ interface GitHubCompare {
   status?: string;
   total_commits?: number;
   commits?: Array<{ sha?: string }>;
+  base_commit?: { sha?: string };
+  merge_base_commit?: { sha?: string };
 }
 
 interface GitHubCommit {
@@ -161,6 +169,9 @@ interface ReleasePolicyFile {
   >;
 }
 
+const MAX_RELEASE_PAGES = 10;
+const MAX_TAG_DEREFERENCE_DEPTH = 5;
+
 function collectReleaseReportInput(options: ReleaseControlOptions): ReleaseReportInput {
   let collectionComplete = true;
   const evidenceTimes: string[] = [];
@@ -183,18 +194,24 @@ function collectReleaseReportInput(options: ReleaseControlOptions): ReleaseRepor
   const headSha = fullSha(refResult.value?.object?.sha) ?? "";
   if (!headSha) collectionComplete = false;
 
-  const releasesResult = tryGhJson<GitHubRelease[]>(`repos/${options.repo}/releases?per_page=100`);
-  if (!releasesResult.value) collectionComplete = false;
-  const latestBeta = (releasesResult.value ?? [])
+  const releasesResult = collectReleases(options.repo);
+  if (!releasesResult.complete) collectionComplete = false;
+  const latestBeta = releasesResult.releases
     .filter(
       (release) =>
         release.prerelease === true &&
         release.draft !== true &&
         releaseTagMatchesTrain(release.tag_name, options.train),
     )
-    .sort((left, right) => releaseTime(right).localeCompare(releaseTime(left)))[0];
+    .sort(
+      (left, right) =>
+        releaseTime(right).localeCompare(releaseTime(left)) || (right.id ?? 0) - (left.id ?? 0),
+    )[0];
   if (latestBeta && releaseTime(latestBeta)) evidenceTimes.push(releaseTime(latestBeta));
   const releaseSha = labeledSha(latestBeta?.body ?? "", "Release SHA") ?? "";
+  const releaseTagSha = latestBeta?.tag_name
+    ? resolveTagCommit(options.repo, latestBeta.tag_name)
+    : undefined;
   const releaseCommitCollection = releaseSha
     ? collectCommit(options.repo, releaseSha)
     : { value: null, paths: [], complete: false };
@@ -216,8 +233,19 @@ function collectReleaseReportInput(options: ReleaseControlOptions): ReleaseRepor
     !codeSha ||
     !releaseSha ||
     !latestBeta.tag_name ||
+    releaseTagSha !== releaseSha ||
     fullSha(releaseCommit?.sha) !== releaseSha
   ) {
+    collectionComplete = false;
+  }
+  if (
+    !contract.cutSha ||
+    !codeSha ||
+    !completeAncestorRelation(options.repo, contract.cutSha, codeSha)
+  ) {
+    collectionComplete = false;
+  }
+  if (!releaseSha || !headSha || !completeAncestorRelation(options.repo, releaseSha, headSha)) {
     collectionComplete = false;
   }
 
@@ -227,14 +255,11 @@ function collectReleaseReportInput(options: ReleaseControlOptions): ReleaseRepor
       `repos/${options.repo}/compare/${contract.cutSha}...${headSha}`,
     );
     const compare = compareResult.value;
-    if (!compare || !Array.isArray(compare.commits)) {
+    const commits = compare?.commits;
+    if (!completeCompare(compare, contract.cutSha, headSha) || !commits) {
       collectionComplete = false;
     } else {
-      if (compare.status !== "ahead" && compare.status !== "identical") {
-        collectionComplete = false;
-      }
-      if (compare.total_commits !== compare.commits.length) collectionComplete = false;
-      for (const summary of compare.commits) {
+      for (const summary of commits) {
         const sha = fullSha(summary.sha) ?? "";
         if (!sha) {
           collectionComplete = false;
@@ -269,6 +294,95 @@ function collectReleaseReportInput(options: ReleaseControlOptions): ReleaseRepor
     collectionComplete,
     changes,
   };
+}
+
+function collectReleases(repo: string): { releases: GitHubRelease[]; complete: boolean } {
+  const releases: GitHubRelease[] = [];
+  const ids = new Set<number>();
+  const tags = new Set<string>();
+  for (let page = 1; page <= MAX_RELEASE_PAGES; page += 1) {
+    const result = tryGhJson<unknown>(`repos/${repo}/releases?per_page=100&page=${page}`);
+    if (!Array.isArray(result.value) || result.value.length > 100) {
+      return { releases, complete: false };
+    }
+    for (const value of result.value) {
+      if (!validRelease(value)) return { releases, complete: false };
+      const id = value.id!;
+      const tag = value.tag_name!.toLowerCase();
+      if (ids.has(id) || tags.has(tag)) return { releases, complete: false };
+      ids.add(id);
+      tags.add(tag);
+      releases.push(value);
+    }
+    if (result.value.length < 100) return { releases, complete: true };
+  }
+  return { releases, complete: false };
+}
+
+function validRelease(value: unknown): value is GitHubRelease {
+  if (!value || typeof value !== "object") return false;
+  const release = value as GitHubRelease;
+  return (
+    Number.isSafeInteger(release.id) &&
+    (release.id ?? 0) > 0 &&
+    typeof release.tag_name === "string" &&
+    release.tag_name.length > 0 &&
+    release.tag_name === release.tag_name.trim() &&
+    typeof release.prerelease === "boolean" &&
+    typeof release.draft === "boolean" &&
+    typeof release.created_at === "string" &&
+    release.created_at.length > 0 &&
+    (release.published_at === undefined ||
+      release.published_at === null ||
+      typeof release.published_at === "string") &&
+    (release.body === undefined || release.body === null || typeof release.body === "string")
+  );
+}
+
+function resolveTagCommit(repo: string, tag: string): string | undefined {
+  let object = tryGhJson<GitHubRef>(`repos/${repo}/git/ref/tags/${encodeURIComponent(tag)}`).value
+    ?.object;
+  const seen = new Set<string>();
+  for (let depth = 0; depth < MAX_TAG_DEREFERENCE_DEPTH; depth += 1) {
+    const sha = fullSha(object?.sha);
+    if (!sha) return undefined;
+    if (object?.type === "commit") return sha;
+    if (object?.type !== "tag" || seen.has(sha)) return undefined;
+    seen.add(sha);
+    const tagObject = tryGhJson<GitHubTag>(`repos/${repo}/git/tags/${sha}`).value;
+    if (!tagObject || fullSha(tagObject.sha) !== sha) return undefined;
+    object = tagObject.object;
+  }
+  return undefined;
+}
+
+function completeAncestorRelation(repo: string, base: string, head: string): boolean {
+  return completeCompare(
+    tryGhJson<GitHubCompare>(`repos/${repo}/compare/${base}...${head}`).value,
+    base,
+    head,
+  );
+}
+
+function completeCompare(compare: GitHubCompare | null, base: string, head: string): boolean {
+  if (
+    !compare ||
+    !Array.isArray(compare.commits) ||
+    !Number.isSafeInteger(compare.total_commits) ||
+    (compare.total_commits ?? -1) < 0 ||
+    compare.total_commits !== compare.commits.length ||
+    fullSha(compare.base_commit?.sha) !== base ||
+    fullSha(compare.merge_base_commit?.sha) !== base ||
+    compare.commits.some((commit) => !fullSha(commit.sha))
+  ) {
+    return false;
+  }
+  if (compare.status === "identical") {
+    return base === head && compare.commits.length === 0;
+  }
+  return (
+    compare.status === "ahead" && base !== head && fullSha(compare.commits.at(-1)?.sha) === head
+  );
 }
 
 function collectChange(

--- a/src/release-control/cli.ts
+++ b/src/release-control/cli.ts
@@ -700,14 +700,17 @@ function fullSha(value: string | undefined): string | undefined {
 
 function labeledSha(body: string, label: string): string | undefined {
   const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return body
-    .match(
-      new RegExp(
-        `(?:^|\\n)\\s*(?:[-*]\\s+)?${escaped}\\s*:\\s*\`?([0-9a-f]{40})\`?\\s*(?:$|\\n)`,
-        "i",
-      ),
-    )?.[1]
-    ?.toLowerCase();
+  const declaration = new RegExp(`^\\s*(?:[-*]\\s+)?${escaped}\\s*:\\s*(.*?)\\s*$`, "i");
+  const values = body
+    .replaceAll("\r\n", "\n")
+    .split("\n")
+    .flatMap((line) => {
+      const match = line.match(declaration);
+      return match?.[1] === undefined ? [] : [match[1]];
+    });
+  if (values.length !== 1) return undefined;
+  const sha = values[0]?.match(/^(?:`([0-9a-f]{40})`|([0-9a-f]{40}))$/i);
+  return (sha?.[1] ?? sha?.[2])?.toLowerCase();
 }
 
 function releaseTagMatchesTrain(tag: string | undefined, train: string): boolean {

--- a/src/release-control/cli.ts
+++ b/src/release-control/cli.ts
@@ -154,8 +154,8 @@ interface ReleasePolicyFile {
   repositories: Record<
     string,
     {
-      release_preparation: { exact_paths: string[]; prefixes: string[] };
-      release_infrastructure: { exact_paths: string[]; prefixes: string[] };
+      release_preparation: { exact_paths: string[]; prefixes: string[]; patterns?: string[] };
+      release_infrastructure: { exact_paths: string[]; prefixes: string[]; patterns?: string[] };
       product_path_prefixes?: string[];
     }
   >;
@@ -300,7 +300,12 @@ function collectChange(
   if (pull && !parsedMetadata.value) collectionComplete = false;
   const proof =
     parsedMetadata.value?.releaseClass === "exact-backport"
-      ? exactBackportProof(options.targetCheckout, parsedMetadata.value.sourceSha, sha)
+      ? exactBackportProof(
+          options.repo,
+          options.targetCheckout,
+          parsedMetadata.value.sourceSha,
+          sha,
+        )
       : {};
 
   return {
@@ -349,7 +354,7 @@ function collectCommit(
 
 function associatedPulls(repo: string, sha: string): { pulls: GitHubPull[]; complete: boolean } {
   const [owner, name] = repo.split("/", 2);
-  const query = `query($owner:String!,$name:String!,$sha:GitObjectID!){repository(owner:$owner,name:$name){object(oid:$sha){... on Commit{associatedPullRequests(first:100,states:[OPEN,MERGED]){nodes{number url body baseRefName}pageInfo{hasNextPage}}}}}}`;
+  const query = `query($owner:String!,$name:String!,$sha:GitObjectID!){repository(owner:$owner,name:$name){object(oid:$sha){... on Commit{associatedPullRequests(first:100){nodes{number url body baseRefName}pageInfo{hasNextPage}}}}}}`;
   const args = [
     "api",
     "graphql",
@@ -380,32 +385,72 @@ function associatedPulls(repo: string, sha: string): { pulls: GitHubPull[]; comp
   return { pulls, complete: true };
 }
 
-function exactBackportProof(
+export function exactBackportProof(
+  repo: string,
   checkout: string | undefined,
   sourceSha: string | undefined,
   releaseSha: string,
 ): Pick<ReleaseReportChangeInput, "sourceMainReachable" | "patchEquivalent"> {
   if (!checkout || !sourceSha) return {};
+  const githubMainSha = fullSha(
+    tryGhJson<GitHubRef>(`repos/${repo}/git/ref/heads/main`).value?.object?.sha,
+  );
+  if (!githubMainSha) return {};
+  return verifyExactBackport(checkout, sourceSha, releaseSha, githubMainSha);
+}
+
+export function verifyExactBackport(
+  checkout: string,
+  sourceSha: string,
+  releaseSha: string,
+  githubMainSha: string,
+): Pick<ReleaseReportChangeInput, "sourceMainReachable" | "patchEquivalent"> {
   try {
-    runText("git", ["rev-parse", "--is-inside-work-tree"], { cwd: checkout, trim: "both" });
-    runText("git", ["rev-parse", "--verify", "main^{commit}"], { cwd: checkout, trim: "both" });
-    runText("git", ["rev-parse", "--verify", `${sourceSha}^{commit}`], {
+    const insideWorktree = runText("git", ["rev-parse", "--is-inside-work-tree"], {
       cwd: checkout,
       trim: "both",
     });
-    runText("git", ["rev-parse", "--verify", `${releaseSha}^{commit}`], {
+    const shallow = runText("git", ["rev-parse", "--is-shallow-repository"], {
       cwd: checkout,
       trim: "both",
     });
+    const localMainSha = fullSha(
+      runText("git", ["rev-parse", "--verify", "refs/remotes/origin/main^{commit}"], {
+        cwd: checkout,
+        trim: "both",
+      }),
+    );
+    const localSourceSha = fullSha(
+      runText("git", ["rev-parse", "--verify", `${sourceSha}^{commit}`], {
+        cwd: checkout,
+        trim: "both",
+      }),
+    );
+    const localReleaseSha = fullSha(
+      runText("git", ["rev-parse", "--verify", `${releaseSha}^{commit}`], {
+        cwd: checkout,
+        trim: "both",
+      }),
+    );
+    if (
+      insideWorktree !== "true" ||
+      shallow !== "false" ||
+      localMainSha !== githubMainSha ||
+      localSourceSha !== sourceSha ||
+      localReleaseSha !== releaseSha
+    ) {
+      return {};
+    }
   } catch {
     return {};
   }
-  const sourceMainReachable = gitExitZero(checkout, [
+  const sourceMainReachable = gitAncestorResult(checkout, [
     "merge-base",
     "--is-ancestor",
     sourceSha,
-    "main",
+    "refs/remotes/origin/main",
   ]);
+  if (sourceMainReachable === undefined) return {};
   const sourcePatchId = gitPatchId(checkout, sourceSha);
   const releasePatchId = gitPatchId(checkout, releaseSha);
   return {
@@ -416,9 +461,17 @@ function exactBackportProof(
   };
 }
 
-function gitExitZero(cwd: string, args: string[]): boolean {
-  const command = resolveCommand("git", args);
-  return spawnSync(command.command, command.args, { cwd, stdio: "ignore" }).status === 0;
+function gitAncestorResult(cwd: string, args: string[]): boolean | undefined {
+  try {
+    const command = resolveCommand("git", args);
+    const result = spawnSync(command.command, command.args, { cwd, stdio: "ignore" });
+    if (result.error || result.signal) return undefined;
+    if (result.status === 0) return true;
+    if (result.status === 1) return false;
+    return undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function gitPatchId(cwd: string, sha: string): string | undefined {
@@ -465,6 +518,14 @@ function releasePolicyFor(repo: string): ReleaseRepositoryPolicy {
         "release_preparation.exact_paths",
       ),
       prefixes: stringArray(policy.release_preparation.prefixes, "release_preparation.prefixes"),
+      ...(policy.release_preparation.patterns
+        ? {
+            patterns: stringArray(
+              policy.release_preparation.patterns,
+              "release_preparation.patterns",
+            ),
+          }
+        : {}),
     },
     releaseInfrastructure: {
       exactPaths: stringArray(
@@ -475,6 +536,14 @@ function releasePolicyFor(repo: string): ReleaseRepositoryPolicy {
         policy.release_infrastructure.prefixes,
         "release_infrastructure.prefixes",
       ),
+      ...(policy.release_infrastructure.patterns
+        ? {
+            patterns: stringArray(
+              policy.release_infrastructure.patterns,
+              "release_infrastructure.patterns",
+            ),
+          }
+        : {}),
     },
     ...(policy.product_path_prefixes
       ? {

--- a/src/release-control/cli.ts
+++ b/src/release-control/cli.ts
@@ -1,0 +1,542 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { parseArgs, type Args } from "../clawsweeper-args.js";
+import { runText, resolveCommand } from "../command.js";
+import { parseGhJson } from "../github-json.js";
+import type { ReleaseRepositoryPolicy } from "./classifier.js";
+import {
+  RELEASE_CLASSES,
+  parseReleaseContract,
+  parseReleasePullMetadata,
+  type ReleaseContract,
+} from "./contract.js";
+import {
+  buildReleaseReport,
+  renderReleaseReportJson,
+  renderReleaseReportMarkdown,
+  type ReleaseAuditMode,
+  type ReleaseReportChangeInput,
+  type ReleaseReportInput,
+} from "./report.js";
+
+export interface ReleaseControlOptions {
+  repo: string;
+  releaseBranch: string;
+  train: string;
+  contractIssue: number;
+  mode: ReleaseAuditMode;
+  output: string;
+  targetCheckout?: string;
+}
+
+export function parseReleaseControlArgs(argv: string[]): ReleaseControlOptions {
+  return releaseControlOptions(parseArgs(argv));
+}
+
+export function releaseControlAuditCommand(args: Args): void {
+  const options = releaseControlOptions(args);
+  const report = buildReleaseReport(collectReleaseReportInput(options));
+  mkdirSync(options.output, { recursive: true });
+  const jsonPath = join(options.output, `${options.train}.json`);
+  const markdownPath = join(options.output, `${options.train}.md`);
+  writeFileSync(jsonPath, renderReleaseReportJson(report), "utf8");
+  writeFileSync(markdownPath, renderReleaseReportMarkdown(report), "utf8");
+  console.log(JSON.stringify({ json: jsonPath, markdown: markdownPath, status: report.status }));
+}
+
+function releaseControlOptions(args: Args): ReleaseControlOptions {
+  const repo = requiredString(args, "repo");
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) {
+    throw new Error("--repo must be owner/repo");
+  }
+  const releaseBranch = requiredString(args, "release_branch");
+  const train = releaseBranch.match(/^release\/([0-9]{4}\.[0-9]+\.[0-9]+)$/)?.[1];
+  if (!train) throw new Error("--release-branch must match release/YYYY.M.PATCH");
+  const contractIssue = Number(requiredString(args, "contract_issue"));
+  if (!Number.isSafeInteger(contractIssue) || contractIssue <= 0) {
+    throw new Error("--contract-issue must be a positive integer");
+  }
+  const mode = requiredString(args, "mode");
+  if (mode !== "advisory" && mode !== "enforced") {
+    throw new Error("--mode must be advisory or enforced");
+  }
+  const output = resolve(requiredString(args, "output"));
+  const targetCheckoutValue = args.target_checkout;
+  const options: ReleaseControlOptions = {
+    repo: repo.toLowerCase(),
+    releaseBranch,
+    train,
+    contractIssue,
+    mode,
+    output,
+  };
+  if (typeof targetCheckoutValue === "string" && targetCheckoutValue.trim()) {
+    options.targetCheckout = resolve(targetCheckoutValue);
+  }
+  return options;
+}
+
+function requiredString(args: Args, key: string): string {
+  const value = args[key];
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`--${key.replaceAll("_", "-")} is required`);
+  }
+  return value.trim();
+}
+
+interface GitHubIssue {
+  number?: number;
+  html_url?: string;
+  updated_at?: string;
+  body?: string | null;
+}
+
+interface GitHubRef {
+  object?: { sha?: string };
+}
+
+interface GitHubRelease {
+  tag_name?: string;
+  prerelease?: boolean;
+  draft?: boolean;
+  published_at?: string | null;
+  created_at?: string;
+  body?: string | null;
+}
+
+interface GitHubCompare {
+  status?: string;
+  total_commits?: number;
+  commits?: Array<{ sha?: string }>;
+}
+
+interface GitHubCommit {
+  sha?: string;
+  parents?: Array<{ sha?: string }>;
+  commit?: {
+    message?: string;
+    committer?: { date?: string };
+  };
+  files?: Array<{ filename?: string }>;
+}
+
+interface GitHubPull {
+  number?: number;
+  html_url?: string;
+  body?: string | null;
+  base?: { ref?: string };
+}
+
+interface GitHubAssociatedPulls {
+  data?: {
+    repository?: {
+      object?: {
+        associatedPullRequests?: {
+          nodes?: Array<{
+            number?: number;
+            url?: string;
+            body?: string | null;
+            baseRefName?: string;
+          }>;
+          pageInfo?: { hasNextPage?: boolean };
+        };
+      };
+    };
+  };
+}
+
+interface ReleasePolicyFile {
+  schema_version: number;
+  repositories: Record<
+    string,
+    {
+      release_preparation: { exact_paths: string[]; prefixes: string[] };
+      release_infrastructure: { exact_paths: string[]; prefixes: string[] };
+      product_path_prefixes?: string[];
+    }
+  >;
+}
+
+function collectReleaseReportInput(options: ReleaseControlOptions): ReleaseReportInput {
+  let collectionComplete = true;
+  const evidenceTimes: string[] = [];
+  const policy = releasePolicyFor(options.repo);
+  const issueResult = tryGhJson<GitHubIssue>(
+    `repos/${options.repo}/issues/${options.contractIssue}`,
+  );
+  if (!issueResult.value) collectionComplete = false;
+  const issue = issueResult.value ?? {};
+  if (issue.updated_at) evidenceTimes.push(issue.updated_at);
+  const body = issue.body ?? "";
+  const parsedContract = parseReleaseContract(body);
+  if (!parsedContract.value) collectionComplete = false;
+  const contract = parsedContract.value ?? fallbackContract(options.train);
+  if (contract.train !== options.train) collectionComplete = false;
+
+  const refResult = tryGhJson<GitHubRef>(
+    `repos/${options.repo}/git/ref/heads/${encodeURIComponent(options.releaseBranch)}`,
+  );
+  const headSha = fullSha(refResult.value?.object?.sha) ?? "";
+  if (!headSha) collectionComplete = false;
+
+  const releasesResult = tryGhJson<GitHubRelease[]>(`repos/${options.repo}/releases?per_page=100`);
+  if (!releasesResult.value) collectionComplete = false;
+  const latestBeta = (releasesResult.value ?? [])
+    .filter(
+      (release) =>
+        release.prerelease === true &&
+        release.draft !== true &&
+        releaseTagMatchesTrain(release.tag_name, options.train),
+    )
+    .sort((left, right) => releaseTime(right).localeCompare(releaseTime(left)))[0];
+  if (latestBeta && releaseTime(latestBeta)) evidenceTimes.push(releaseTime(latestBeta));
+  const releaseSha = labeledSha(latestBeta?.body ?? "", "Release SHA") ?? "";
+  const releaseCommitCollection = releaseSha
+    ? collectCommit(options.repo, releaseSha)
+    : { value: null, paths: [], complete: false };
+  const releaseCommit = releaseCommitCollection.value;
+  const releasePaths = releaseCommitCollection.paths;
+  const releaseParentSha =
+    releaseCommit?.parents?.length === 1 ? fullSha(releaseCommit.parents[0]?.sha) : undefined;
+  const codeSha =
+    releaseCommitCollection.complete &&
+    releasePaths.length === 1 &&
+    releasePaths[0] === "CHANGELOG.md"
+      ? (releaseParentSha ?? "")
+      : "";
+  if (releaseCommit?.commit?.committer?.date) {
+    evidenceTimes.push(releaseCommit.commit.committer.date);
+  }
+  if (
+    !latestBeta ||
+    !codeSha ||
+    !releaseSha ||
+    !latestBeta.tag_name ||
+    fullSha(releaseCommit?.sha) !== releaseSha
+  ) {
+    collectionComplete = false;
+  }
+
+  const changes: ReleaseReportChangeInput[] = [];
+  if (contract.cutSha && headSha) {
+    const compareResult = tryGhJson<GitHubCompare>(
+      `repos/${options.repo}/compare/${contract.cutSha}...${headSha}`,
+    );
+    const compare = compareResult.value;
+    if (!compare || !Array.isArray(compare.commits)) {
+      collectionComplete = false;
+    } else {
+      if (compare.status !== "ahead" && compare.status !== "identical") {
+        collectionComplete = false;
+      }
+      if (compare.total_commits !== compare.commits.length) collectionComplete = false;
+      for (const summary of compare.commits) {
+        const sha = fullSha(summary.sha) ?? "";
+        if (!sha) {
+          collectionComplete = false;
+          continue;
+        }
+        changes.push(collectChange(options, contract, sha, evidenceTimes));
+      }
+    }
+  } else {
+    collectionComplete = false;
+  }
+  if (changes.some((change) => change.collectionComplete === false)) collectionComplete = false;
+
+  return {
+    targetRepo: options.repo,
+    train: options.train,
+    releaseBranch: options.releaseBranch,
+    contractIssue: {
+      number: options.contractIssue,
+      url: issue.html_url ?? `https://github.com/${options.repo}/issues/${options.contractIssue}`,
+      updatedAt: issue.updated_at ?? "",
+      bodyDigest: `sha256:${createHash("sha256").update(body).digest("hex")}`,
+    },
+    contract,
+    policy,
+    codeSha,
+    releaseSha,
+    headSha,
+    latestBeta: latestBeta?.tag_name ?? null,
+    mode: options.mode,
+    evidenceTimestamp: deterministicEvidenceTimestamp(evidenceTimes),
+    collectionComplete,
+    changes,
+  };
+}
+
+function collectChange(
+  options: ReleaseControlOptions,
+  contract: ReleaseContract,
+  sha: string,
+  evidenceTimes: string[],
+): ReleaseReportChangeInput {
+  let collectionComplete = true;
+  const commitResult = collectCommit(options.repo, sha);
+  const commit = commitResult.value;
+  if (!commit) collectionComplete = false;
+  const title = commit?.commit?.message?.split("\n", 1)[0]?.trim() || sha;
+  if (commit?.commit?.committer?.date) evidenceTimes.push(commit.commit.committer.date);
+  const paths = commitResult.paths;
+  const pathsComplete = commitResult.complete;
+  if (!pathsComplete) collectionComplete = false;
+
+  const pullsResult = associatedPulls(options.repo, sha);
+  if (!pullsResult.complete) collectionComplete = false;
+  const pulls = pullsResult.pulls
+    .filter((pull) => pull.base?.ref === options.releaseBranch && Number.isSafeInteger(pull.number))
+    .sort((left, right) => (left.number ?? 0) - (right.number ?? 0));
+  if (pulls.length > 1) collectionComplete = false;
+  const pull = pulls[0];
+  const parsedMetadata = pull
+    ? parseReleasePullMetadata(pull.body ?? "")
+    : { value: null, missingFields: [] as string[] };
+  if (pull && !parsedMetadata.value) collectionComplete = false;
+  const proof =
+    parsedMetadata.value?.releaseClass === "exact-backport"
+      ? exactBackportProof(options.targetCheckout, parsedMetadata.value.sourceSha, sha)
+      : {};
+
+  return {
+    sha,
+    title,
+    paths,
+    pathsComplete,
+    collectionComplete,
+    ...(pull?.number === undefined ? {} : { prNumber: pull.number }),
+    ...(pull?.html_url === undefined ? {} : { prUrl: pull.html_url }),
+    ...(parsedMetadata.value === null ? {} : { metadata: parsedMetadata.value }),
+    ...(pull && parsedMetadata.missingFields.length > 0
+      ? { metadataMissingFields: parsedMetadata.missingFields }
+      : {}),
+    ...proof,
+  };
+}
+
+function collectCommit(
+  repo: string,
+  sha: string,
+): { value: GitHubCommit | null; paths: string[]; complete: boolean } {
+  let first: GitHubCommit | null = null;
+  const paths: string[] = [];
+  for (let page = 1; page <= 3; page += 1) {
+    const result = tryGhJson<GitHubCommit>(
+      `repos/${repo}/commits/${sha}?per_page=100&page=${page}`,
+    );
+    const commit = result.value;
+    if (!commit || fullSha(commit.sha) !== sha || !Array.isArray(commit.files)) {
+      return { value: first, paths: [...new Set(paths)].sort(), complete: false };
+    }
+    first ??= commit;
+    const pagePaths = commit.files.flatMap((file) => (file.filename ? [file.filename] : []));
+    if (pagePaths.length !== commit.files.length) {
+      return { value: first, paths: [...new Set(paths)].sort(), complete: false };
+    }
+    paths.push(...pagePaths);
+    if (commit.files.length < 100) {
+      const uniquePaths = [...new Set(paths)].sort();
+      return { value: first, paths: uniquePaths, complete: uniquePaths.length === paths.length };
+    }
+  }
+  return { value: first, paths: [...new Set(paths)].sort(), complete: false };
+}
+
+function associatedPulls(repo: string, sha: string): { pulls: GitHubPull[]; complete: boolean } {
+  const [owner, name] = repo.split("/", 2);
+  const query = `query($owner:String!,$name:String!,$sha:GitObjectID!){repository(owner:$owner,name:$name){object(oid:$sha){... on Commit{associatedPullRequests(first:100,states:[OPEN,MERGED]){nodes{number url body baseRefName}pageInfo{hasNextPage}}}}}}`;
+  const args = [
+    "api",
+    "graphql",
+    "-f",
+    `query=${query}`,
+    "-F",
+    `owner=${owner}`,
+    "-F",
+    `name=${name}`,
+    "-F",
+    `sha=${sha}`,
+  ];
+  const result = tryGhJsonArgs<GitHubAssociatedPulls>(args);
+  const connection = result.value?.data?.repository?.object?.associatedPullRequests;
+  if (
+    !connection ||
+    !Array.isArray(connection.nodes) ||
+    connection.pageInfo?.hasNextPage !== false
+  ) {
+    return { pulls: [], complete: false };
+  }
+  const pulls = connection.nodes.map((pull) => ({
+    ...(pull.number === undefined ? {} : { number: pull.number }),
+    ...(pull.url === undefined ? {} : { html_url: pull.url }),
+    ...(pull.body === undefined ? {} : { body: pull.body }),
+    ...(pull.baseRefName === undefined ? {} : { base: { ref: pull.baseRefName } }),
+  }));
+  return { pulls, complete: true };
+}
+
+function exactBackportProof(
+  checkout: string | undefined,
+  sourceSha: string | undefined,
+  releaseSha: string,
+): Pick<ReleaseReportChangeInput, "sourceMainReachable" | "patchEquivalent"> {
+  if (!checkout || !sourceSha) return {};
+  try {
+    runText("git", ["rev-parse", "--is-inside-work-tree"], { cwd: checkout, trim: "both" });
+    runText("git", ["rev-parse", "--verify", "main^{commit}"], { cwd: checkout, trim: "both" });
+    runText("git", ["rev-parse", "--verify", `${sourceSha}^{commit}`], {
+      cwd: checkout,
+      trim: "both",
+    });
+    runText("git", ["rev-parse", "--verify", `${releaseSha}^{commit}`], {
+      cwd: checkout,
+      trim: "both",
+    });
+  } catch {
+    return {};
+  }
+  const sourceMainReachable = gitExitZero(checkout, [
+    "merge-base",
+    "--is-ancestor",
+    sourceSha,
+    "main",
+  ]);
+  const sourcePatchId = gitPatchId(checkout, sourceSha);
+  const releasePatchId = gitPatchId(checkout, releaseSha);
+  return {
+    sourceMainReachable,
+    ...(sourcePatchId && releasePatchId
+      ? { patchEquivalent: sourcePatchId === releasePatchId }
+      : {}),
+  };
+}
+
+function gitExitZero(cwd: string, args: string[]): boolean {
+  const command = resolveCommand("git", args);
+  return spawnSync(command.command, command.args, { cwd, stdio: "ignore" }).status === 0;
+}
+
+function gitPatchId(cwd: string, sha: string): string | undefined {
+  try {
+    const diff = runText("git", ["show", "--first-parent", "--format=", "--binary", sha], {
+      cwd,
+      trim: "none",
+    });
+    const command = resolveCommand("git", ["patch-id", "--stable"]);
+    const result = spawnSync(command.command, command.args, {
+      cwd,
+      input: diff,
+      encoding: "utf8",
+    });
+    if (result.status !== 0) return undefined;
+    return result.stdout.trim().split(/\s+/, 1)[0] || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function tryGhJson<T>(endpoint: string): { value: T | null } {
+  return tryGhJsonArgs<T>(["api", endpoint]);
+}
+
+function tryGhJsonArgs<T>(args: string[]): { value: T | null } {
+  try {
+    return { value: parseGhJson<T>(runText("gh", args, { trim: "none" }), args) };
+  } catch {
+    return { value: null };
+  }
+}
+
+function releasePolicyFor(repo: string): ReleaseRepositoryPolicy {
+  const configPath = join(repositoryRoot(), "config", "release-control.json");
+  const config = JSON.parse(readFileSync(configPath, "utf8")) as ReleasePolicyFile;
+  if (config.schema_version !== 1) throw new Error("Unsupported release-control policy schema");
+  const policy = config.repositories[repo];
+  if (!policy) throw new Error(`No release-control path policy for ${repo}`);
+  return {
+    releasePreparation: {
+      exactPaths: stringArray(
+        policy.release_preparation.exact_paths,
+        "release_preparation.exact_paths",
+      ),
+      prefixes: stringArray(policy.release_preparation.prefixes, "release_preparation.prefixes"),
+    },
+    releaseInfrastructure: {
+      exactPaths: stringArray(
+        policy.release_infrastructure.exact_paths,
+        "release_infrastructure.exact_paths",
+      ),
+      prefixes: stringArray(
+        policy.release_infrastructure.prefixes,
+        "release_infrastructure.prefixes",
+      ),
+    },
+    ...(policy.product_path_prefixes
+      ? {
+          productPathPrefixes: stringArray(policy.product_path_prefixes, "product_path_prefixes"),
+        }
+      : {}),
+  };
+}
+
+function stringArray(value: unknown, label: string): string[] {
+  if (
+    !Array.isArray(value) ||
+    !value.every((item) => typeof item === "string" && item.length > 0)
+  ) {
+    throw new Error(`${label} must be a non-empty string array`);
+  }
+  return [...value];
+}
+
+function repositoryRoot(): string {
+  return resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+}
+
+function fallbackContract(train: string): ReleaseContract {
+  return {
+    train,
+    captain: "unknown",
+    goal: "missing",
+    nonGoals: "missing",
+    cutSha: "",
+    allowedChangeClasses: [...RELEASE_CLASSES],
+    exitCriteria: "missing",
+    approvedExceptions: [],
+  };
+}
+
+function fullSha(value: string | undefined): string | undefined {
+  return value?.match(/^[0-9a-f]{40}$/i)?.[0]?.toLowerCase();
+}
+
+function labeledSha(body: string, label: string): string | undefined {
+  const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return body
+    .match(
+      new RegExp(
+        `(?:^|\\n)\\s*(?:[-*]\\s+)?${escaped}\\s*:\\s*\`?([0-9a-f]{40})\`?\\s*(?:$|\\n)`,
+        "i",
+      ),
+    )?.[1]
+    ?.toLowerCase();
+}
+
+function releaseTagMatchesTrain(tag: string | undefined, train: string): boolean {
+  if (!tag) return false;
+  const escaped = train.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^v?${escaped}-beta(?:[.-][0-9A-Za-z.-]+)?$`, "i").test(tag);
+}
+
+function releaseTime(release: GitHubRelease): string {
+  return release.published_at ?? release.created_at ?? "";
+}
+
+function deterministicEvidenceTimestamp(values: string[]): string {
+  return [...values].filter(Boolean).sort().at(-1) ?? "1970-01-01T00:00:00.000Z";
+}

--- a/src/release-control/contract.ts
+++ b/src/release-control/contract.ts
@@ -113,6 +113,9 @@ export function parseReleasePullMetadata(body: string): ParseResult<ReleasePullM
   const collected = inlineFields(body, PULL_FIELDS);
   const fields = collected.values;
   const missingFields = missingOrDuplicateFields(collected, PULL_FIELDS);
+  for (const field of PULL_FIELDS) {
+    if (!fields.get(field)?.trim()) addMissing(missingFields, field);
+  }
   const contractIssue = issueNumberFrom(fields.get("Release train") ?? "");
   const releaseClass = releaseClassFrom(fields.get("Release class") ?? "");
   if (!contractIssue) addMissing(missingFields, "Release train");

--- a/src/release-control/contract.ts
+++ b/src/release-control/contract.ts
@@ -41,6 +41,11 @@ export interface ParseResult<T> {
   missingFields: string[];
 }
 
+interface ApprovedExceptionsParseResult {
+  value: ApprovedException[];
+  valid: boolean;
+}
+
 const CONTRACT_FIELDS = [
   "Release train",
   "Release captain",
@@ -67,7 +72,8 @@ export function parseReleaseContract(body: string): ParseResult<ReleaseContract>
   const captain = loginFrom(fields.get("Release captain") ?? "");
   const cutSha = fullShaFrom(fields.get("Cut SHA") ?? "");
   const allowedChangeClasses = releaseClassesFrom(fields.get("Allowed change classes") ?? "");
-  const approvedExceptions = approvedExceptionsFrom(fields.get("Approved exceptions") ?? "");
+  const approvedExceptionsResult = approvedExceptionsFrom(fields.get("Approved exceptions") ?? "");
+  const approvedExceptions = approvedExceptionsResult.value;
   if (!train) addMissing(missingFields, "Release train");
   if (!captain) addMissing(missingFields, "Release captain");
   if (!fields.get("Goal")?.trim()) addMissing(missingFields, "Goal");
@@ -76,6 +82,7 @@ export function parseReleaseContract(body: string): ParseResult<ReleaseContract>
   if (allowedChangeClasses.length === 0) addMissing(missingFields, "Allowed change classes");
   if (!fields.get("Exit criteria")?.trim()) addMissing(missingFields, "Exit criteria");
   if (!fields.get("Approved exceptions")?.trim()) addMissing(missingFields, "Approved exceptions");
+  if (!approvedExceptionsResult.valid) addMissing(missingFields, "Approved exceptions");
   if (new Set(approvedExceptions.map((entry) => entry.number)).size !== approvedExceptions.length) {
     addMissing(missingFields, "Approved exceptions");
   }
@@ -164,25 +171,55 @@ function releaseClassFrom(value: string): ReleaseClass | undefined {
   return RELEASE_CLASSES.find((candidate) => candidate === normalized);
 }
 
-function approvedExceptionsFrom(value: string): ApprovedException[] {
+const GITHUB_LOGIN = "[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?";
+const DECISION_URL =
+  "https:\\/\\/github\\.com\\/[A-Za-z0-9_.-]+\\/[A-Za-z0-9_.-]+\\/(?:issues|pull)\\/[1-9]\\d*#issuecomment-[1-9]\\d*";
+const DECIDED_EXCEPTION = new RegExp(
+  `^\\s*(?:[-*]\\s+)?#([1-9]\\d*):\\s*(approved|rejected)\\s+by\\s+@(${GITHUB_LOGIN})\\s+\\((${DECISION_URL})\\)\\s*$`,
+  "i",
+);
+const PENDING_EXCEPTION = new RegExp(
+  `^\\s*(?:[-*]\\s+)?#([1-9]\\d*):\\s*pending\\s+\\((${DECISION_URL})\\)\\s*$`,
+  "i",
+);
+
+function approvedExceptionsFrom(value: string): ApprovedExceptionsParseResult {
+  const trimmed = value.trim();
+  if (/^None\.$/i.test(trimmed)) return { value: [], valid: true };
+
   const exceptions: ApprovedException[] = [];
-  for (const line of value.split("\n")) {
-    const number = issueNumberFrom(line);
-    if (!number) continue;
-    const normalized = line.toLowerCase();
-    const decision = normalized.includes("reject")
-      ? "rejected"
-      : normalized.includes("pending")
-        ? "pending"
-        : "approved";
-    const entry: ApprovedException = { number, decision };
-    const approverMatch = line.match(/(?:approved|rejected)\s+by\s+@?([A-Za-z0-9-]+)/i);
-    const decisionUrl = urlFrom(line);
-    if (approverMatch?.[1]) entry.approver = approverMatch[1];
-    if (decisionUrl) entry.decisionUrl = decisionUrl;
-    exceptions.push(entry);
+  const lines = trimmed.split("\n").filter((line) => line.trim());
+  if (lines.length === 0) return { value: [], valid: false };
+
+  for (const line of lines) {
+    const decided = line.match(DECIDED_EXCEPTION);
+    if (decided?.[1] && decided[2] && decided[3] && decided[4]) {
+      const number = Number(decided[1]);
+      if (!Number.isSafeInteger(number)) return { value: [], valid: false };
+      exceptions.push({
+        number,
+        decision: decided[2].toLowerCase() as "approved" | "rejected",
+        approver: decided[3],
+        decisionUrl: decided[4],
+      });
+      continue;
+    }
+
+    const pending = line.match(PENDING_EXCEPTION);
+    if (pending?.[1] && pending[2]) {
+      const number = Number(pending[1]);
+      if (!Number.isSafeInteger(number)) return { value: [], valid: false };
+      exceptions.push({ number, decision: "pending", decisionUrl: pending[2] });
+      continue;
+    }
+
+    return { value: [], valid: false };
   }
-  return exceptions.sort((left, right) => left.number - right.number);
+
+  return {
+    value: exceptions.sort((left, right) => left.number - right.number),
+    valid: true,
+  };
 }
 
 function issueNumberFrom(value: string): number | undefined {

--- a/src/release-control/contract.ts
+++ b/src/release-control/contract.ts
@@ -46,6 +46,11 @@ interface ApprovedExceptionsParseResult {
   valid: boolean;
 }
 
+interface CollectedFields {
+  values: Map<string, string>;
+  duplicates: Set<string>;
+}
+
 const CONTRACT_FIELDS = [
   "Release train",
   "Release captain",
@@ -66,8 +71,9 @@ const PULL_FIELDS = [
 ] as const;
 
 export function parseReleaseContract(body: string): ParseResult<ReleaseContract> {
-  const fields = markdownFields(body, CONTRACT_FIELDS);
-  const missingFields = CONTRACT_FIELDS.filter((field) => fields.get(field) === undefined);
+  const collected = markdownFields(body, CONTRACT_FIELDS);
+  const fields = collected.values;
+  const missingFields = missingOrDuplicateFields(collected, CONTRACT_FIELDS);
   const train = fields.get("Release train")?.trim() ?? "";
   const captain = loginFrom(fields.get("Release captain") ?? "");
   const cutSha = fullShaFrom(fields.get("Cut SHA") ?? "");
@@ -104,8 +110,9 @@ export function parseReleaseContract(body: string): ParseResult<ReleaseContract>
 }
 
 export function parseReleasePullMetadata(body: string): ParseResult<ReleasePullMetadata> {
-  const fields = inlineFields(body, PULL_FIELDS);
-  const missingFields = PULL_FIELDS.filter((field) => fields.get(field) === undefined);
+  const collected = inlineFields(body, PULL_FIELDS);
+  const fields = collected.values;
+  const missingFields = missingOrDuplicateFields(collected, PULL_FIELDS);
   const contractIssue = issueNumberFrom(fields.get("Release train") ?? "");
   const releaseClass = releaseClassFrom(fields.get("Release class") ?? "");
   if (!contractIssue) addMissing(missingFields, "Release train");
@@ -129,7 +136,7 @@ export function parseReleasePullMetadata(body: string): ParseResult<ReleasePullM
   return { value, missingFields: [] };
 }
 
-function markdownFields(body: string, names: readonly string[]): Map<string, string> {
+function markdownFields(body: string, names: readonly string[]): CollectedFields {
   const result = inlineFields(body, names);
   const lines = body.replaceAll("\r\n", "\n").split("\n");
   for (let index = 0; index < lines.length; index += 1) {
@@ -141,22 +148,34 @@ function markdownFields(body: string, names: readonly string[]): Map<string, str
       if (/^#{1,6}\s+/.test(lines[cursor] ?? "")) break;
       content.push(lines[cursor] ?? "");
     }
-    result.set(name, content.join("\n").trim());
+    addCollectedField(result, name, content.join("\n").trim());
   }
   return result;
 }
 
-function inlineFields(body: string, names: readonly string[]): Map<string, string> {
-  const result = new Map<string, string>();
+function inlineFields(body: string, names: readonly string[]): CollectedFields {
+  const result: CollectedFields = { values: new Map(), duplicates: new Set() };
   for (const line of body.replaceAll("\r\n", "\n").split("\n")) {
     const match = line.match(/^\s*(?:[-*]\s+)?(?:\*\*)?([^:*]+?)(?:\*\*)?\s*:\s*(.*?)\s*$/);
     if (!match) continue;
     const name = names.find(
       (candidate) => candidate.toLowerCase() === (match[1] ?? "").trim().toLowerCase(),
     );
-    if (name) result.set(name, (match[2] ?? "").trim());
+    if (name) addCollectedField(result, name, (match[2] ?? "").trim());
   }
   return result;
+}
+
+function addCollectedField(result: CollectedFields, name: string, value: string): void {
+  if (result.values.has(name)) {
+    result.duplicates.add(name);
+    return;
+  }
+  result.values.set(name, value);
+}
+
+function missingOrDuplicateFields(fields: CollectedFields, names: readonly string[]): string[] {
+  return names.filter((name) => !fields.values.has(name) || fields.duplicates.has(name));
 }
 
 function releaseClassesFrom(value: string): ReleaseClass[] {

--- a/src/release-control/contract.ts
+++ b/src/release-control/contract.ts
@@ -1,0 +1,205 @@
+export const RELEASE_CLASSES = [
+  "release-preparation",
+  "release-blocker",
+  "exact-backport",
+  "release-infrastructure",
+  "changelog-only",
+  "exception",
+] as const;
+
+export type ReleaseClass = (typeof RELEASE_CLASSES)[number];
+
+export interface ApprovedException {
+  number: number;
+  decision: "approved" | "pending" | "rejected";
+  approver?: string;
+  decisionUrl?: string;
+}
+
+export interface ReleaseContract {
+  train: string;
+  captain: string;
+  goal: string;
+  nonGoals: string;
+  cutSha: string;
+  allowedChangeClasses: ReleaseClass[];
+  exitCriteria: string;
+  approvedExceptions: ApprovedException[];
+}
+
+export interface ReleasePullMetadata {
+  contractIssue: number;
+  releaseClass: ReleaseClass;
+  blockerIssue?: number;
+  sourceSha?: string;
+  sourcePull?: number;
+  exceptionDecisionUrl?: string;
+}
+
+export interface ParseResult<T> {
+  value: T | null;
+  missingFields: string[];
+}
+
+const CONTRACT_FIELDS = [
+  "Release train",
+  "Release captain",
+  "Goal",
+  "Non-goals",
+  "Cut SHA",
+  "Allowed change classes",
+  "Exit criteria",
+  "Approved exceptions",
+] as const;
+
+const PULL_FIELDS = [
+  "Release train",
+  "Release class",
+  "Blocker",
+  "Source on main",
+  "Exception decision",
+] as const;
+
+export function parseReleaseContract(body: string): ParseResult<ReleaseContract> {
+  const fields = markdownFields(body, CONTRACT_FIELDS);
+  const missingFields = CONTRACT_FIELDS.filter((field) => fields.get(field) === undefined);
+  const train = fields.get("Release train")?.trim() ?? "";
+  const captain = loginFrom(fields.get("Release captain") ?? "");
+  const cutSha = fullShaFrom(fields.get("Cut SHA") ?? "");
+  const allowedChangeClasses = releaseClassesFrom(fields.get("Allowed change classes") ?? "");
+  if (!train) addMissing(missingFields, "Release train");
+  if (!captain) addMissing(missingFields, "Release captain");
+  if (!fields.get("Goal")?.trim()) addMissing(missingFields, "Goal");
+  if (!fields.get("Non-goals")?.trim()) addMissing(missingFields, "Non-goals");
+  if (!cutSha) addMissing(missingFields, "Cut SHA");
+  if (allowedChangeClasses.length === 0) addMissing(missingFields, "Allowed change classes");
+  if (!fields.get("Exit criteria")?.trim()) addMissing(missingFields, "Exit criteria");
+  if (!fields.get("Approved exceptions")?.trim()) addMissing(missingFields, "Approved exceptions");
+  if (!captain || !cutSha || missingFields.length > 0) return { value: null, missingFields };
+
+  return {
+    value: {
+      train,
+      captain,
+      goal: fields.get("Goal")!.trim(),
+      nonGoals: fields.get("Non-goals")!.trim(),
+      cutSha,
+      allowedChangeClasses,
+      exitCriteria: fields.get("Exit criteria")!.trim(),
+      approvedExceptions: approvedExceptionsFrom(fields.get("Approved exceptions")!),
+    },
+    missingFields: [],
+  };
+}
+
+export function parseReleasePullMetadata(body: string): ParseResult<ReleasePullMetadata> {
+  const fields = inlineFields(body, PULL_FIELDS);
+  const missingFields = PULL_FIELDS.filter((field) => fields.get(field) === undefined);
+  const contractIssue = issueNumberFrom(fields.get("Release train") ?? "");
+  const releaseClass = releaseClassFrom(fields.get("Release class") ?? "");
+  if (!contractIssue) addMissing(missingFields, "Release train");
+  if (!releaseClass) addMissing(missingFields, "Release class");
+  if (!contractIssue || !releaseClass || missingFields.length > 0) {
+    return { value: null, missingFields };
+  }
+
+  const blocker = fields.get("Blocker")!;
+  const source = fields.get("Source on main")!;
+  const exceptionDecision = fields.get("Exception decision")!;
+  const value: ReleasePullMetadata = { contractIssue, releaseClass };
+  const blockerIssue = issueNumberFrom(blocker);
+  const sourceSha = fullShaFrom(source);
+  const sourcePull = issueNumberFrom(source);
+  const exceptionDecisionUrl = urlFrom(exceptionDecision);
+  if (blockerIssue) value.blockerIssue = blockerIssue;
+  if (sourceSha) value.sourceSha = sourceSha;
+  if (sourcePull) value.sourcePull = sourcePull;
+  if (exceptionDecisionUrl) value.exceptionDecisionUrl = exceptionDecisionUrl;
+  return { value, missingFields: [] };
+}
+
+function markdownFields(body: string, names: readonly string[]): Map<string, string> {
+  const result = inlineFields(body, names);
+  const lines = body.replaceAll("\r\n", "\n").split("\n");
+  for (let index = 0; index < lines.length; index += 1) {
+    const heading = lines[index]?.match(/^#{1,6}\s+(.+?)\s*$/)?.[1]?.trim();
+    const name = names.find((candidate) => candidate.toLowerCase() === heading?.toLowerCase());
+    if (!name) continue;
+    const content: string[] = [];
+    for (let cursor = index + 1; cursor < lines.length; cursor += 1) {
+      if (/^#{1,6}\s+/.test(lines[cursor] ?? "")) break;
+      content.push(lines[cursor] ?? "");
+    }
+    result.set(name, content.join("\n").trim());
+  }
+  return result;
+}
+
+function inlineFields(body: string, names: readonly string[]): Map<string, string> {
+  const result = new Map<string, string>();
+  for (const line of body.replaceAll("\r\n", "\n").split("\n")) {
+    const match = line.match(/^\s*(?:[-*]\s+)?(?:\*\*)?([^:*]+?)(?:\*\*)?\s*:\s*(.*?)\s*$/);
+    if (!match) continue;
+    const name = names.find(
+      (candidate) => candidate.toLowerCase() === (match[1] ?? "").trim().toLowerCase(),
+    );
+    if (name) result.set(name, (match[2] ?? "").trim());
+  }
+  return result;
+}
+
+function releaseClassesFrom(value: string): ReleaseClass[] {
+  const found = RELEASE_CLASSES.filter((releaseClass) =>
+    new RegExp(`(?:^|[^a-z-])${releaseClass}(?:$|[^a-z-])`, "i").test(value),
+  );
+  return [...found];
+}
+
+function releaseClassFrom(value: string): ReleaseClass | undefined {
+  const normalized = value.trim().toLowerCase();
+  return RELEASE_CLASSES.find((candidate) => candidate === normalized);
+}
+
+function approvedExceptionsFrom(value: string): ApprovedException[] {
+  const exceptions: ApprovedException[] = [];
+  for (const line of value.split("\n")) {
+    const number = issueNumberFrom(line);
+    if (!number) continue;
+    const normalized = line.toLowerCase();
+    const decision = normalized.includes("reject")
+      ? "rejected"
+      : normalized.includes("pending")
+        ? "pending"
+        : "approved";
+    const entry: ApprovedException = { number, decision };
+    const approverMatch = line.match(/(?:approved|rejected)\s+by\s+@?([A-Za-z0-9-]+)/i);
+    const decisionUrl = urlFrom(line);
+    if (approverMatch?.[1]) entry.approver = approverMatch[1];
+    if (decisionUrl) entry.decisionUrl = decisionUrl;
+    exceptions.push(entry);
+  }
+  return exceptions.sort((left, right) => left.number - right.number);
+}
+
+function issueNumberFrom(value: string): number | undefined {
+  const match = value.match(/#(\d+)/);
+  if (!match?.[1]) return undefined;
+  const parsed = Number(match[1]);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function fullShaFrom(value: string): string | undefined {
+  return value.match(/\b[0-9a-f]{40}\b/i)?.[0]?.toLowerCase();
+}
+
+function loginFrom(value: string): string | undefined {
+  return value.match(/@?([A-Za-z0-9](?:[A-Za-z0-9-]{0,38}))/)?.[1];
+}
+
+function urlFrom(value: string): string | undefined {
+  return value.match(/https:\/\/github\.com\/[^\s)]+/)?.[0];
+}
+
+function addMissing(fields: string[], field: string): void {
+  if (!fields.includes(field)) fields.push(field);
+}

--- a/src/release-control/contract.ts
+++ b/src/release-control/contract.ts
@@ -67,6 +67,7 @@ export function parseReleaseContract(body: string): ParseResult<ReleaseContract>
   const captain = loginFrom(fields.get("Release captain") ?? "");
   const cutSha = fullShaFrom(fields.get("Cut SHA") ?? "");
   const allowedChangeClasses = releaseClassesFrom(fields.get("Allowed change classes") ?? "");
+  const approvedExceptions = approvedExceptionsFrom(fields.get("Approved exceptions") ?? "");
   if (!train) addMissing(missingFields, "Release train");
   if (!captain) addMissing(missingFields, "Release captain");
   if (!fields.get("Goal")?.trim()) addMissing(missingFields, "Goal");
@@ -75,6 +76,9 @@ export function parseReleaseContract(body: string): ParseResult<ReleaseContract>
   if (allowedChangeClasses.length === 0) addMissing(missingFields, "Allowed change classes");
   if (!fields.get("Exit criteria")?.trim()) addMissing(missingFields, "Exit criteria");
   if (!fields.get("Approved exceptions")?.trim()) addMissing(missingFields, "Approved exceptions");
+  if (new Set(approvedExceptions.map((entry) => entry.number)).size !== approvedExceptions.length) {
+    addMissing(missingFields, "Approved exceptions");
+  }
   if (!captain || !cutSha || missingFields.length > 0) return { value: null, missingFields };
 
   return {
@@ -86,7 +90,7 @@ export function parseReleaseContract(body: string): ParseResult<ReleaseContract>
       cutSha,
       allowedChangeClasses,
       exitCriteria: fields.get("Exit criteria")!.trim(),
-      approvedExceptions: approvedExceptionsFrom(fields.get("Approved exceptions")!),
+      approvedExceptions,
     },
     missingFields: [],
   };

--- a/src/release-control/report.ts
+++ b/src/release-control/report.ts
@@ -1,0 +1,300 @@
+import { sortStable } from "../stable-json.js";
+import {
+  classifyReleaseChange,
+  type ReleaseChangeStatus,
+  type ReleaseRepositoryPolicy,
+} from "./classifier.js";
+import type { ReleaseClass, ReleaseContract, ReleasePullMetadata } from "./contract.js";
+
+export type ReleaseAuditMode = "advisory" | "enforced";
+export type ReleaseAuditStatus = "clear" | "attention" | "blocked" | "incomplete";
+
+export interface ReleaseReportChangeInput {
+  sha: string;
+  prNumber?: number;
+  prUrl?: string;
+  title: string;
+  paths: string[];
+  pathsComplete?: boolean;
+  metadata?: ReleasePullMetadata;
+  metadataMissingFields?: string[];
+  sourceMainReachable?: boolean;
+  patchEquivalent?: boolean;
+  collectionComplete?: boolean;
+}
+
+export interface ReleaseReportInput {
+  targetRepo: string;
+  train: string;
+  releaseBranch: string;
+  contractIssue: {
+    number: number;
+    url: string;
+    updatedAt: string;
+    bodyDigest: string;
+  };
+  contract: ReleaseContract;
+  policy: ReleaseRepositoryPolicy;
+  codeSha: string;
+  releaseSha: string;
+  headSha: string;
+  latestBeta: string | null;
+  mode: ReleaseAuditMode;
+  evidenceTimestamp: string;
+  collectionComplete: boolean;
+  changes: ReleaseReportChangeInput[];
+}
+
+export interface ReleaseReportChange {
+  sha: string;
+  pr: { number: number; url: string } | null;
+  title: string;
+  paths: string[];
+  declared_class: ReleaseClass | null;
+  blocker: number | null;
+  source: {
+    sha: string;
+    pr: number | null;
+    main_reachable: boolean | null;
+    patch_equivalent: boolean | null;
+  } | null;
+  signals: string[];
+  status: ReleaseChangeStatus;
+  reason: string;
+  decision_packet_url: string | null;
+}
+
+export interface ReleaseReport {
+  schema_version: 1;
+  target_repo: string;
+  train: string;
+  release_branch: string;
+  contract: {
+    issue_number: number;
+    issue_url: string;
+    updated_at: string;
+    body_digest: string;
+  };
+  cut_sha: string;
+  code_sha: string;
+  release_sha: string;
+  head_sha: string;
+  latest_beta: string | null;
+  mode: ReleaseAuditMode;
+  status: ReleaseAuditStatus;
+  counts: {
+    commits: number;
+    prs: number;
+    allowed: number;
+    unclassified: number;
+    pending_exceptions: number;
+    product_change_signals: number;
+    candidate_resets: number;
+  };
+  changes: ReleaseReportChange[];
+  evidence: {
+    timestamp: string;
+    source_shas: {
+      cut: string;
+      code: string;
+      release: string;
+      head: string;
+    };
+  };
+}
+
+export function buildReleaseReport(input: ReleaseReportInput): ReleaseReport {
+  const changes = input.changes
+    .map((change) => releaseReportChange(input, change))
+    .sort(
+      (left, right) =>
+        left.sha.localeCompare(right.sha) || (left.pr?.number ?? 0) - (right.pr?.number ?? 0),
+    );
+  const productChangeSignals = changes.reduce(
+    (total, change) =>
+      total +
+      change.signals.filter(
+        (signal) => signal === "feature-title" || signal === "product-or-runtime-path",
+      ).length,
+    0,
+  );
+  const candidateResets = changes.filter((change) =>
+    /\b(?:reset|revert)\b/i.test(change.title),
+  ).length;
+  const status = reportStatus(
+    input.collectionComplete,
+    changes,
+    productChangeSignals,
+    candidateResets,
+  );
+  return {
+    schema_version: 1,
+    target_repo: input.targetRepo,
+    train: input.train,
+    release_branch: input.releaseBranch,
+    contract: {
+      issue_number: input.contractIssue.number,
+      issue_url: input.contractIssue.url,
+      updated_at: input.contractIssue.updatedAt,
+      body_digest: input.contractIssue.bodyDigest,
+    },
+    cut_sha: input.contract.cutSha,
+    code_sha: input.codeSha,
+    release_sha: input.releaseSha,
+    head_sha: input.headSha,
+    latest_beta: input.latestBeta,
+    mode: input.mode,
+    status,
+    counts: {
+      commits: changes.length,
+      prs: new Set(changes.flatMap((change) => (change.pr ? [change.pr.number] : []))).size,
+      allowed: changes.filter((change) => change.status === "allowed").length,
+      unclassified: changes.filter((change) => change.status === "unclassified").length,
+      pending_exceptions: changes.filter((change) => change.status === "pending-exception").length,
+      product_change_signals: productChangeSignals,
+      candidate_resets: candidateResets,
+    },
+    changes,
+    evidence: {
+      timestamp: input.evidenceTimestamp,
+      source_shas: {
+        cut: input.contract.cutSha,
+        code: input.codeSha,
+        release: input.releaseSha,
+        head: input.headSha,
+      },
+    },
+  };
+}
+
+export function renderReleaseReportJson(report: ReleaseReport): string {
+  return `${JSON.stringify(sortStable(report), null, 2)}\n`;
+}
+
+export function renderReleaseReportMarkdown(report: ReleaseReport): string {
+  const lines = [
+    `# Release control audit: ${report.train}`,
+    "",
+    `Status: **${report.status}**`,
+    "",
+    `- Target: \`${report.target_repo}\``,
+    `- Release branch: \`${report.release_branch}\``,
+    `- Mode: \`${report.mode}\``,
+    `- Contract: [#${report.contract.issue_number}](${report.contract.issue_url})`,
+    `- Cut SHA: \`${report.cut_sha}\``,
+    `- Code SHA: \`${report.code_sha}\``,
+    `- Release SHA: \`${report.release_sha}\``,
+    `- Head SHA: \`${report.head_sha}\``,
+    `- Latest beta: ${report.latest_beta ? `\`${report.latest_beta}\`` : "none"}`,
+    `- Evidence timestamp: \`${report.evidence.timestamp}\``,
+    "",
+    "## Counts",
+    "",
+    "| Commits | PRs | Allowed | Unclassified | Pending exceptions | Product signals | Candidate resets |",
+    "| ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    `| ${report.counts.commits} | ${report.counts.prs} | ${report.counts.allowed} | ${report.counts.unclassified} | ${report.counts.pending_exceptions} | ${report.counts.product_change_signals} | ${report.counts.candidate_resets} |`,
+    "",
+    "## Changes",
+    "",
+  ];
+  if (report.changes.length === 0) {
+    lines.push("No cut-to-head changes found.", "");
+  } else {
+    lines.push(
+      "| SHA | PR | Class | Status | Title | Paths | Signals | Reason |",
+      "| --- | ---: | --- | --- | --- | --- | --- | --- |",
+    );
+    for (const change of report.changes) {
+      lines.push(
+        `| \`${change.sha.slice(0, 12)}\` | ${change.pr ? `[#${change.pr.number}](${change.pr.url})` : "—"} | ${change.declared_class ?? "—"} | ${change.status} | ${escapeCell(change.title)} | ${escapeCell(change.paths.join("<br>"))} | ${escapeCell(change.signals.join(", ") || "—")} | ${escapeCell(change.reason)} |`,
+      );
+    }
+    lines.push("");
+  }
+  lines.push(
+    "This report is read-only. It does not publish GitHub checks, comments, labels, or state.",
+    "",
+  );
+  return lines.join("\n");
+}
+
+function releaseReportChange(
+  input: ReleaseReportInput,
+  change: ReleaseReportChangeInput,
+): ReleaseReportChange {
+  const classification = classifyReleaseChange({
+    sha: change.sha,
+    title: change.title,
+    paths: change.paths,
+    contractIssue: input.contractIssue.number,
+    contract: input.contract,
+    policy: input.policy,
+    ...(change.prNumber === undefined ? {} : { prNumber: change.prNumber }),
+    ...(change.metadata === undefined ? {} : { metadata: change.metadata }),
+    ...(change.metadataMissingFields === undefined
+      ? {}
+      : { metadataMissingFields: change.metadataMissingFields }),
+    ...(change.sourceMainReachable === undefined
+      ? {}
+      : { sourceMainReachable: change.sourceMainReachable }),
+    ...(change.patchEquivalent === undefined ? {} : { patchEquivalent: change.patchEquivalent }),
+    ...(change.collectionComplete === undefined
+      ? {}
+      : { collectionComplete: change.collectionComplete }),
+    ...(change.pathsComplete === undefined ? {} : { pathsComplete: change.pathsComplete }),
+  });
+  const paths = [...new Set(change.paths)].sort();
+  const metadata = change.metadata;
+  return {
+    sha: change.sha.toLowerCase(),
+    pr:
+      change.prNumber === undefined
+        ? null
+        : {
+            number: change.prNumber,
+            url: change.prUrl ?? `https://github.com/${input.targetRepo}/pull/${change.prNumber}`,
+          },
+    title: change.title,
+    paths,
+    declared_class: metadata?.releaseClass ?? null,
+    blocker: metadata?.blockerIssue ?? null,
+    source: metadata?.sourceSha
+      ? {
+          sha: metadata.sourceSha,
+          pr: metadata.sourcePull ?? null,
+          main_reachable: change.sourceMainReachable ?? null,
+          patch_equivalent: change.patchEquivalent ?? null,
+        }
+      : null,
+    signals: [...new Set(classification.signals)].sort(),
+    status: classification.status,
+    reason: classification.reason,
+    decision_packet_url: metadata?.exceptionDecisionUrl ?? null,
+  };
+}
+
+function reportStatus(
+  collectionComplete: boolean,
+  changes: readonly ReleaseReportChange[],
+  productChangeSignals: number,
+  candidateResets: number,
+): ReleaseAuditStatus {
+  if (!collectionComplete || changes.some((change) => change.status === "incomplete")) {
+    return "incomplete";
+  }
+  if (changes.some((change) => change.status === "blocked")) return "blocked";
+  if (
+    changes.some(
+      (change) => change.status === "unclassified" || change.status === "pending-exception",
+    ) ||
+    productChangeSignals > 0 ||
+    candidateResets > 0
+  ) {
+    return "attention";
+  }
+  return "clear";
+}
+
+function escapeCell(value: string): string {
+  return value.replaceAll("|", "\\|").replaceAll("\n", "<br>");
+}

--- a/test/fixtures/release-control-2026.7.1.json
+++ b/test/fixtures/release-control-2026.7.1.json
@@ -1,0 +1,58 @@
+{
+  "targetRepo": "openclaw/openclaw",
+  "train": "2026.7.1",
+  "releaseBranch": "release/2026.7.1",
+  "contractIssue": {
+    "number": 900,
+    "url": "https://github.com/openclaw/openclaw/issues/900",
+    "updatedAt": "2026-07-10T12:00:00Z",
+    "bodyDigest": "sha256:contract"
+  },
+  "contract": {
+    "train": "2026.7.1",
+    "captain": "alice",
+    "goal": "Ship 2026.7.1",
+    "nonGoals": "No new product scope",
+    "cutSha": "1111111111111111111111111111111111111111",
+    "allowedChangeClasses": [
+      "release-preparation",
+      "release-blocker",
+      "exact-backport",
+      "release-infrastructure",
+      "changelog-only",
+      "exception"
+    ],
+    "exitCriteria": "Checks pass",
+    "approvedExceptions": []
+  },
+  "policy": {
+    "releasePreparation": { "exactPaths": ["package.json"], "prefixes": [] },
+    "releaseInfrastructure": { "exactPaths": [], "prefixes": [".github/workflows/release-"] },
+    "productPathPrefixes": ["src/", "packages/"]
+  },
+  "codeSha": "2222222222222222222222222222222222222222",
+  "releaseSha": "3333333333333333333333333333333333333333",
+  "headSha": "4444444444444444444444444444444444444444",
+  "latestBeta": "2026.7.1-beta.2",
+  "mode": "advisory",
+  "evidenceTimestamp": "2026-07-10T12:30:00Z",
+  "collectionComplete": true,
+  "changes": [
+    {
+      "sha": "a978c06c939afec9bef590d5d1b4029094333009",
+      "prNumber": 102873,
+      "prUrl": "https://github.com/openclaw/openclaw/pull/102873",
+      "title": "feat(providers): add Meta Model API - muse-spark-1.1 (#102873)",
+      "paths": ["extensions/meta-model-api/index.ts", "src/config/zod-schema.core.ts"],
+      "pathsComplete": true
+    },
+    {
+      "sha": "62ba1f63e60fa99b8ec0a90e879b06eecbed31a0",
+      "prNumber": 98021,
+      "prUrl": "https://github.com/openclaw/openclaw/pull/98021",
+      "title": "feat: support GPT-5.6 Ultra across OpenClaw and Codex runtimes (#98021)",
+      "paths": ["extensions/openai/thinking-policy.ts", "src/agents/model-thinking-default.ts"],
+      "pathsComplete": true
+    }
+  ]
+}

--- a/test/fixtures/release-preparation-2026.7.1.json
+++ b/test/fixtures/release-preparation-2026.7.1.json
@@ -1,0 +1,27 @@
+{
+  "sha": "970bbc7e5b2719cdb67761deb6c65e76c3025e24",
+  "file_count": 215,
+  "path_counts": {
+    "extension_package_json": 138,
+    "extension_npm_shrinkwrap": 73,
+    "root_package_json": 1,
+    "root_npm_shrinkwrap": 1,
+    "package_package_json": 1,
+    "package_npm_shrinkwrap": 1
+  },
+  "representative_allowed_paths": [
+    "package.json",
+    "npm-shrinkwrap.json",
+    "pnpm-lock.yaml",
+    "extensions/meta-model-api/package.json",
+    "extensions/meta-model-api/npm-shrinkwrap.json",
+    "packages/ai/package.json",
+    "packages/ai/npm-shrinkwrap.json",
+    "apps/macos/Sources/OpenClaw/Resources/Info.plist"
+  ],
+  "representative_blocked_paths": [
+    "extensions/foo/src/index.ts",
+    "extensions/foo/nested/package.json",
+    "packages/ai/nested/npm-shrinkwrap.json"
+  ]
+}

--- a/test/release-control-backport.test.ts
+++ b/test/release-control-backport.test.ts
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { exactBackportProof, verifyExactBackport } from "../dist/release-control/cli.js";
+import { mockGhBinEnv } from "./helpers.ts";
+
+interface BackportFixture {
+  root: string;
+  baseSha: string;
+  sourceSha: string;
+  releaseSha: string;
+  mainSha: string;
+}
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+function commit(cwd: string, content: string, message: string): string {
+  writeFileSync(join(cwd, "change.txt"), content, "utf8");
+  git(cwd, ["add", "change.txt"]);
+  git(cwd, ["commit", "-m", message]);
+  return git(cwd, ["rev-parse", "HEAD"]);
+}
+
+function backportFixture(sourceOnMain: boolean): BackportFixture {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-release-backport-"));
+  git(root, ["init"]);
+  git(root, ["config", "user.name", "Release Test"]);
+  git(root, ["config", "user.email", "release-test@example.com"]);
+  git(root, ["branch", "-M", "main"]);
+  const baseSha = commit(root, "base\n", "base");
+  if (!sourceOnMain) git(root, ["switch", "-c", "source"]);
+  const sourceSha = commit(root, "backport payload\n", "source change");
+  const mainSha = sourceOnMain ? sourceSha : baseSha;
+  git(root, ["update-ref", "refs/remotes/origin/main", mainSha]);
+  git(root, ["switch", "-c", "release", baseSha]);
+  const releaseSha = commit(root, "backport payload\n", "release backport");
+  return { root, baseSha, sourceSha, releaseSha, mainSha };
+}
+
+function withGhMock<T>(ghMock: string, callback: () => T): T {
+  const previousBin = process.env.GH_BIN;
+  const previousArgs = process.env.GH_BIN_ARGS;
+  Object.assign(process.env, mockGhBinEnv(ghMock));
+  try {
+    return callback();
+  } finally {
+    if (previousBin === undefined) delete process.env.GH_BIN;
+    else process.env.GH_BIN = previousBin;
+    if (previousArgs === undefined) delete process.env.GH_BIN_ARGS;
+    else process.env.GH_BIN_ARGS = previousArgs;
+  }
+}
+
+test("uses the read-only GitHub main ref for fresh exact-backport proof", () => {
+  const fixture = backportFixture(true);
+  const ghMock = join(fixture.root, "gh-mock.mjs");
+  const ghLog = join(fixture.root, "gh-calls.jsonl");
+  writeFileSync(
+    ghMock,
+    `import { appendFileSync } from "node:fs";
+const args = process.argv.slice(2);
+appendFileSync(process.env.GH_LOG, JSON.stringify(args) + "\\n");
+if (args.length !== 2 || args[0] !== "api" || args[1] !== "repos/openclaw/openclaw/git/ref/heads/main") process.exit(2);
+process.stdout.write(JSON.stringify({ object: { sha: ${JSON.stringify(fixture.mainSha)} } }));
+`,
+    "utf8",
+  );
+  const previousLog = process.env.GH_LOG;
+  process.env.GH_LOG = ghLog;
+  try {
+    assert.deepEqual(
+      withGhMock(ghMock, () =>
+        exactBackportProof(
+          "openclaw/openclaw",
+          fixture.root,
+          fixture.sourceSha,
+          fixture.releaseSha,
+        ),
+      ),
+      { sourceMainReachable: true, patchEquivalent: true },
+    );
+    assert.deepEqual(JSON.parse(readFileSync(ghLog, "utf8").trim()), [
+      "api",
+      "repos/openclaw/openclaw/git/ref/heads/main",
+    ]);
+  } finally {
+    if (previousLog === undefined) delete process.env.GH_LOG;
+    else process.env.GH_LOG = previousLog;
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("distinguishes a genuine source commit that is not on canonical main", () => {
+  const fixture = backportFixture(false);
+  try {
+    assert.deepEqual(
+      verifyExactBackport(fixture.root, fixture.sourceSha, fixture.releaseSha, fixture.mainSha),
+      { sourceMainReachable: false, patchEquivalent: true },
+    );
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("treats stale, missing, shallow, and operationally unavailable checkouts as incomplete", () => {
+  const stale = backportFixture(true);
+  const missing = backportFixture(true);
+  const shallow = backportFixture(true);
+  try {
+    git(stale.root, ["update-ref", "refs/remotes/origin/main", stale.baseSha]);
+    assert.deepEqual(
+      verifyExactBackport(stale.root, stale.sourceSha, stale.releaseSha, stale.mainSha),
+      {},
+    );
+
+    git(missing.root, ["update-ref", "-d", "refs/remotes/origin/main"]);
+    assert.deepEqual(
+      verifyExactBackport(missing.root, missing.sourceSha, missing.releaseSha, missing.mainSha),
+      {},
+    );
+    assert.deepEqual(
+      verifyExactBackport(missing.root, "f".repeat(40), missing.releaseSha, missing.mainSha),
+      {},
+    );
+
+    writeFileSync(join(shallow.root, ".git", "shallow"), `${shallow.baseSha}\n`, "utf8");
+    assert.deepEqual(
+      verifyExactBackport(shallow.root, shallow.sourceSha, shallow.releaseSha, shallow.mainSha),
+      {},
+    );
+
+    assert.deepEqual(
+      verifyExactBackport(
+        join(stale.root, "missing-checkout"),
+        stale.sourceSha,
+        stale.releaseSha,
+        stale.mainSha,
+      ),
+      {},
+    );
+  } finally {
+    rmSync(stale.root, { recursive: true, force: true });
+    rmSync(missing.root, { recursive: true, force: true });
+    rmSync(shallow.root, { recursive: true, force: true });
+  }
+});
+
+test("treats a merge-base operational exit as incomplete rather than not-on-main", () => {
+  const fixture = backportFixture(true);
+  const gitMock = join(fixture.root, "git-mock.mjs");
+  const realGit = execFileSync("which", ["git"], { encoding: "utf8" }).trim();
+  writeFileSync(
+    gitMock,
+    `import { spawnSync } from "node:child_process";
+const args = process.argv.slice(2);
+if (args[0] === "merge-base") process.exit(2);
+const result = spawnSync(${JSON.stringify(realGit)}, args, { encoding: "utf8" });
+if (result.stdout) process.stdout.write(result.stdout);
+if (result.stderr) process.stderr.write(result.stderr);
+process.exit(result.status ?? 2);
+`,
+    "utf8",
+  );
+  const previousBin = process.env.GIT_BIN;
+  const previousArgs = process.env.GIT_BIN_ARGS;
+  process.env.GIT_BIN = process.execPath;
+  process.env.GIT_BIN_ARGS = JSON.stringify([gitMock]);
+  try {
+    assert.deepEqual(
+      verifyExactBackport(fixture.root, fixture.sourceSha, fixture.releaseSha, fixture.mainSha),
+      {},
+    );
+  } finally {
+    if (previousBin === undefined) delete process.env.GIT_BIN;
+    else process.env.GIT_BIN = previousBin;
+    if (previousArgs === undefined) delete process.env.GIT_BIN_ARGS;
+    else process.env.GIT_BIN_ARGS = previousArgs;
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});

--- a/test/release-control-classifier.test.ts
+++ b/test/release-control-classifier.test.ts
@@ -1,8 +1,23 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 import { classifyReleaseChange } from "../dist/release-control/classifier.js";
 import type { ReleaseContract, ReleasePullMetadata } from "../dist/release-control/contract.js";
+
+const releasePreparationFixture = JSON.parse(
+  readFileSync(
+    fileURLToPath(new URL("fixtures/release-preparation-2026.7.1.json", import.meta.url)),
+    "utf8",
+  ),
+) as {
+  sha: string;
+  file_count: number;
+  path_counts: Record<string, number>;
+  representative_allowed_paths: string[];
+  representative_blocked_paths: string[];
+};
 
 const contract: ReleaseContract = {
   train: "2026.7.2",
@@ -31,8 +46,14 @@ const contract: ReleaseContract = {
 
 const policy = {
   releasePreparation: {
-    exactPaths: ["package.json", "pnpm-lock.yaml"],
+    exactPaths: ["package.json", "npm-shrinkwrap.json", "pnpm-lock.yaml"],
     prefixes: ["apps/macos/Sources/OpenClaw/Resources/"],
+    patterns: [
+      "extensions/*/package.json",
+      "extensions/*/npm-shrinkwrap.json",
+      "packages/*/package.json",
+      "packages/*/npm-shrinkwrap.json",
+    ],
   },
   releaseInfrastructure: {
     exactPaths: [".agents/skills/release-openclaw-maintainer/SKILL.md"],
@@ -104,6 +125,33 @@ test("allows each declared release class only with its required deterministic pr
       ...scenario,
     });
     assert.equal(result.status, "allowed", scenario.name);
+  }
+});
+
+test("matches only the narrow 2026.7.1 release-preparation package surfaces", () => {
+  const base = {
+    sha: "d".repeat(40),
+    prNumber: 301,
+    title: "chore(release): prepare 2026.7.1 beta",
+    contractIssue: 900,
+    contract,
+    policy,
+    metadata: metadata("release-preparation"),
+  };
+  assert.equal(releasePreparationFixture.sha, "970bbc7e5b2719cdb67761deb6c65e76c3025e24");
+  assert.equal(
+    Object.values(releasePreparationFixture.path_counts).reduce((sum, count) => sum + count, 0),
+    releasePreparationFixture.file_count,
+  );
+  assert.equal(
+    classifyReleaseChange({
+      ...base,
+      paths: releasePreparationFixture.representative_allowed_paths,
+    }).status,
+    "allowed",
+  );
+  for (const path of releasePreparationFixture.representative_blocked_paths) {
+    assert.equal(classifyReleaseChange({ ...base, paths: [path] }).status, "blocked", path);
   }
 });
 
@@ -270,6 +318,33 @@ test("requires exception listing, captain approval, and a matching decision link
       metadata: metadata("exception", {
         exceptionDecisionUrl: "https://github.com/openclaw/openclaw/issues/900#issuecomment-203",
       }),
+    }).status,
+    "incomplete",
+  );
+
+  const duplicateExceptionUrl = "https://github.com/openclaw/openclaw/issues/900#issuecomment-204";
+  assert.equal(
+    classifyReleaseChange({
+      ...base,
+      prNumber: 204,
+      contract: {
+        ...contract,
+        approvedExceptions: [
+          {
+            number: 204,
+            decision: "approved" as const,
+            approver: "alice",
+            decisionUrl: duplicateExceptionUrl,
+          },
+          {
+            number: 204,
+            decision: "rejected" as const,
+            approver: "alice",
+            decisionUrl: "https://github.com/openclaw/openclaw/issues/900#issuecomment-205",
+          },
+        ],
+      },
+      metadata: metadata("exception", { exceptionDecisionUrl: duplicateExceptionUrl }),
     }).status,
     "incomplete",
   );

--- a/test/release-control-classifier.test.ts
+++ b/test/release-control-classifier.test.ts
@@ -1,0 +1,276 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { classifyReleaseChange } from "../dist/release-control/classifier.js";
+import type { ReleaseContract, ReleasePullMetadata } from "../dist/release-control/contract.js";
+
+const contract: ReleaseContract = {
+  train: "2026.7.2",
+  captain: "alice",
+  goal: "Ship a narrow beta.",
+  nonGoals: "No unrelated product changes.",
+  cutSha: "0123456789abcdef0123456789abcdef01234567",
+  allowedChangeClasses: [
+    "release-preparation",
+    "release-blocker",
+    "exact-backport",
+    "release-infrastructure",
+    "changelog-only",
+    "exception",
+  ],
+  exitCriteria: "Release checks pass.",
+  approvedExceptions: [
+    {
+      number: 106,
+      decision: "approved",
+      approver: "alice",
+      decisionUrl: "https://github.com/openclaw/openclaw/issues/900#issuecomment-106",
+    },
+  ],
+};
+
+const policy = {
+  releasePreparation: {
+    exactPaths: ["package.json", "pnpm-lock.yaml"],
+    prefixes: ["apps/macos/Sources/OpenClaw/Resources/"],
+  },
+  releaseInfrastructure: {
+    exactPaths: [".agents/skills/release-openclaw-maintainer/SKILL.md"],
+    prefixes: [".github/workflows/release-", "scripts/release", "docs/reference/RELEASING"],
+  },
+};
+
+function metadata(
+  releaseClass: ReleasePullMetadata["releaseClass"],
+  extra: Partial<ReleasePullMetadata> = {},
+): ReleasePullMetadata {
+  return { contractIssue: 900, releaseClass, ...extra };
+}
+
+test("allows each declared release class only with its required deterministic proof", () => {
+  const cases = [
+    {
+      name: "release preparation",
+      prNumber: 101,
+      paths: ["package.json", "pnpm-lock.yaml"],
+      metadata: metadata("release-preparation"),
+    },
+    {
+      name: "release blocker",
+      prNumber: 102,
+      paths: ["src/daemon.ts"],
+      metadata: metadata("release-blocker", { blockerIssue: 800 }),
+    },
+    {
+      name: "exact backport",
+      prNumber: 103,
+      paths: ["src/daemon.ts"],
+      metadata: metadata("exact-backport", {
+        sourceSha: "89abcdef0123456789abcdef0123456789abcdef",
+        sourcePull: 700,
+      }),
+      sourceMainReachable: true,
+      patchEquivalent: true,
+    },
+    {
+      name: "release infrastructure",
+      prNumber: 104,
+      paths: [".github/workflows/release-publish.yml"],
+      metadata: metadata("release-infrastructure"),
+    },
+    {
+      name: "changelog only",
+      prNumber: 105,
+      paths: ["CHANGELOG.md"],
+      metadata: metadata("changelog-only"),
+    },
+    {
+      name: "approved exception",
+      prNumber: 106,
+      paths: ["src/new-api.ts"],
+      metadata: metadata("exception", {
+        exceptionDecisionUrl: "https://github.com/openclaw/openclaw/issues/900#issuecomment-106",
+      }),
+    },
+  ] as const;
+
+  for (const scenario of cases) {
+    const result = classifyReleaseChange({
+      sha: "a".repeat(40),
+      title: scenario.name,
+      contractIssue: 900,
+      contract,
+      policy,
+      ...scenario,
+    });
+    assert.equal(result.status, "allowed", scenario.name);
+  }
+});
+
+test("fails closed for invalid class variants and incomplete evidence", () => {
+  const base = {
+    sha: "b".repeat(40),
+    prNumber: 200,
+    title: "release adjustment",
+    paths: ["src/runtime.ts"],
+    contractIssue: 900,
+    contract,
+    policy,
+  };
+
+  assert.equal(
+    classifyReleaseChange({ ...base, metadata: metadata("release-preparation") }).status,
+    "blocked",
+  );
+  assert.equal(
+    classifyReleaseChange({ ...base, metadata: metadata("release-blocker") }).status,
+    "incomplete",
+  );
+  assert.equal(
+    classifyReleaseChange({
+      ...base,
+      metadata: metadata("exact-backport", {
+        sourceSha: "89abcdef0123456789abcdef0123456789abcdef",
+        sourcePull: 700,
+      }),
+    }).status,
+    "incomplete",
+  );
+  assert.equal(
+    classifyReleaseChange({
+      ...base,
+      metadata: metadata("exact-backport", {
+        sourceSha: "89abcdef0123456789abcdef0123456789abcdef",
+        sourcePull: 700,
+      }),
+      sourceMainReachable: false,
+      patchEquivalent: true,
+    }).status,
+    "blocked",
+  );
+  assert.equal(
+    classifyReleaseChange({
+      ...base,
+      metadata: metadata("exact-backport", {
+        sourceSha: "89abcdef0123456789abcdef0123456789abcdef",
+        sourcePull: 700,
+      }),
+      sourceMainReachable: true,
+      patchEquivalent: false,
+    }).status,
+    "blocked",
+  );
+  assert.equal(
+    classifyReleaseChange({ ...base, metadata: metadata("release-infrastructure") }).status,
+    "blocked",
+  );
+  assert.equal(
+    classifyReleaseChange({
+      ...base,
+      paths: ["CHANGELOG.md", "src/runtime.ts"],
+      metadata: metadata("changelog-only"),
+    }).status,
+    "blocked",
+  );
+  assert.equal(
+    classifyReleaseChange({ ...base, prNumber: undefined, metadata: undefined }).status,
+    "unclassified",
+  );
+  assert.equal(
+    classifyReleaseChange({ ...base, metadataMissingFields: ["Release class"] }).status,
+    "incomplete",
+  );
+
+  const incompletePaths = {
+    ...base,
+    paths: ["CHANGELOG.md"],
+    pathsComplete: false,
+    metadata: metadata("changelog-only"),
+  };
+  assert.equal(classifyReleaseChange(incompletePaths).status, "incomplete");
+});
+
+test("requires exception listing, captain approval, and a matching decision link", () => {
+  const base = {
+    sha: "c".repeat(40),
+    title: "exception candidate",
+    paths: ["src/runtime.ts"],
+    contractIssue: 900,
+    policy,
+  };
+  const pendingContract = {
+    ...contract,
+    approvedExceptions: [{ number: 201, decision: "pending" as const }],
+  };
+  assert.equal(
+    classifyReleaseChange({
+      ...base,
+      prNumber: 201,
+      contract: pendingContract,
+      metadata: metadata("exception"),
+    }).status,
+    "incomplete",
+  );
+  const pendingDecisionUrl = "https://github.com/openclaw/openclaw/issues/900#issuecomment-201";
+  assert.equal(
+    classifyReleaseChange({
+      ...base,
+      prNumber: 201,
+      contract: {
+        ...pendingContract,
+        approvedExceptions: [
+          {
+            number: 201,
+            decision: "pending" as const,
+            decisionUrl: pendingDecisionUrl,
+          },
+        ],
+      },
+      metadata: metadata("exception", { exceptionDecisionUrl: pendingDecisionUrl }),
+    }).status,
+    "pending-exception",
+  );
+
+  const wrongApproverContract = {
+    ...contract,
+    approvedExceptions: [
+      {
+        number: 202,
+        decision: "approved" as const,
+        approver: "bob",
+        decisionUrl: "https://github.com/openclaw/openclaw/issues/900#issuecomment-202",
+      },
+    ],
+  };
+  assert.equal(
+    classifyReleaseChange({
+      ...base,
+      prNumber: 202,
+      contract: wrongApproverContract,
+      metadata: metadata("exception", {
+        exceptionDecisionUrl: "https://github.com/openclaw/openclaw/issues/900#issuecomment-202",
+      }),
+    }).status,
+    "blocked",
+  );
+  assert.equal(
+    classifyReleaseChange({
+      ...base,
+      prNumber: 203,
+      contract: {
+        ...contract,
+        approvedExceptions: [
+          {
+            number: 203,
+            decision: "approved" as const,
+            approver: "alice",
+          },
+        ],
+      },
+      metadata: metadata("exception", {
+        exceptionDecisionUrl: "https://github.com/openclaw/openclaw/issues/900#issuecomment-203",
+      }),
+    }).status,
+    "incomplete",
+  );
+});

--- a/test/release-control-cli.test.ts
+++ b/test/release-control-cli.test.ts
@@ -115,6 +115,26 @@ Exception decision: not required
     { length: 100 },
     (_, index) => `extensions/fixture-${String(index).padStart(3, "0")}/package.json`,
   );
+  const releases = [
+    {
+      id: 2,
+      tag_name: "v2026.7.3-beta.1",
+      prerelease: true,
+      draft: false,
+      published_at: "2026-07-11T12:20:00Z",
+      created_at: "2026-07-11T12:10:00Z",
+      body: `- release SHA: \`${"9".repeat(40)}\``,
+    },
+    {
+      id: 1,
+      tag_name: "v2026.7.2-beta.1",
+      prerelease: true,
+      draft: false,
+      published_at: "2026-07-10T12:20:00Z",
+      created_at: "2026-07-10T12:10:00Z",
+      body: `### Release verification\n\n- release SHA: \`${releaseSha}\``,
+    },
+  ];
   const responses = {
     "repos/openclaw/openclaw/issues/900": {
       number: 900,
@@ -125,22 +145,11 @@ Exception decision: not required
     "repos/openclaw/openclaw/git/ref/heads/release%2F2026.7.2": {
       object: { sha: headSha },
     },
-    "repos/openclaw/openclaw/releases?per_page=100": [
-      {
-        tag_name: "v2026.7.3-beta.1",
-        prerelease: true,
-        draft: false,
-        published_at: "2026-07-11T12:20:00Z",
-        body: `- release SHA: \`${"9".repeat(40)}\``,
-      },
-      {
-        tag_name: "v2026.7.2-beta.1",
-        prerelease: true,
-        draft: false,
-        published_at: "2026-07-10T12:20:00Z",
-        body: `### Release verification\n\n- release SHA: \`${releaseSha}\``,
-      },
-    ],
+    "repos/openclaw/openclaw/releases?per_page=100": releases,
+    "repos/openclaw/openclaw/releases?per_page=100&page=1": releases,
+    "repos/openclaw/openclaw/git/ref/tags/v2026.7.2-beta.1": {
+      object: { type: "commit", sha: releaseSha },
+    },
     [`repos/openclaw/openclaw/commits/${releaseSha}?per_page=100&page=1`]: {
       sha: releaseSha,
       parents: [{ sha: codeSha }],
@@ -154,6 +163,22 @@ Exception decision: not required
       status: "ahead",
       total_commits: 1,
       commits: [{ sha: headSha }],
+      base_commit: { sha: cutSha },
+      merge_base_commit: { sha: cutSha },
+    },
+    [`repos/openclaw/openclaw/compare/${cutSha}...${codeSha}`]: {
+      status: "ahead",
+      total_commits: 1,
+      commits: [{ sha: codeSha }],
+      base_commit: { sha: cutSha },
+      merge_base_commit: { sha: cutSha },
+    },
+    [`repos/openclaw/openclaw/compare/${releaseSha}...${headSha}`]: {
+      status: "ahead",
+      total_commits: 1,
+      commits: [{ sha: headSha }],
+      base_commit: { sha: releaseSha },
+      merge_base_commit: { sha: releaseSha },
     },
     [`repos/openclaw/openclaw/commits/${headSha}?per_page=100&page=1`]: {
       sha: headSha,
@@ -261,4 +286,309 @@ process.stdout.write(JSON.stringify(responses[args[1]]));
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+const PROVENANCE_CUT_SHA = "4".repeat(40);
+const PROVENANCE_RELEASE_SHA = "5".repeat(40);
+const PROVENANCE_TAG_OBJECT_SHA = "6".repeat(40);
+const PROVENANCE_OTHER_SHA = "7".repeat(40);
+const PROVENANCE_TAG = "v2026.7.2-beta.9";
+
+interface ReleaseAuditScenario {
+  releasePages?: Record<number, unknown>;
+  legacyReleases?: unknown;
+  tagRef?: unknown;
+  tagObjects?: Record<string, unknown>;
+  compareOverrides?: Record<string, unknown>;
+}
+
+interface ReleaseAuditScenarioResult {
+  report: { status: string; latest_beta: string | null };
+  calls: string[][];
+}
+
+function betaRelease(id = 500): Record<string, unknown> {
+  return {
+    id,
+    tag_name: PROVENANCE_TAG,
+    prerelease: true,
+    draft: false,
+    published_at: "2026-07-10T12:20:00Z",
+    created_at: "2026-07-10T12:10:00Z",
+    body: `- Release SHA: \`${PROVENANCE_RELEASE_SHA}\``,
+  };
+}
+
+function otherTrainReleases(count: number): Array<Record<string, unknown>> {
+  return Array.from({ length: count }, (_, index) => ({
+    id: index + 1,
+    tag_name: `v2026.8.0-beta.${index + 1}`,
+    prerelease: true,
+    draft: false,
+    published_at: `2026-07-09T${String(Math.floor(index / 60)).padStart(2, "0")}:${String(index % 60).padStart(2, "0")}:00Z`,
+    created_at: `2026-07-09T${String(Math.floor(index / 60)).padStart(2, "0")}:${String(index % 60).padStart(2, "0")}:00Z`,
+    body: "",
+  }));
+}
+
+function compareResponse(base: string, head: string): Record<string, unknown> {
+  return base === head
+    ? {
+        status: "identical",
+        total_commits: 0,
+        commits: [],
+        base_commit: { sha: base },
+        merge_base_commit: { sha: base },
+      }
+    : {
+        status: "ahead",
+        total_commits: 1,
+        commits: [{ sha: head }],
+        base_commit: { sha: base },
+        merge_base_commit: { sha: base },
+      };
+}
+
+function runReleaseAuditScenario(scenario: ReleaseAuditScenario = {}): ReleaseAuditScenarioResult {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-release-provenance-"));
+  const output = join(root, "output");
+  const ghMock = join(root, "gh-mock.mjs");
+  const ghLog = join(root, "gh-calls.jsonl");
+  const contractBody = `
+## Release train
+2026.7.2
+## Release captain
+@alice
+## Goal
+Ship a narrow beta.
+## Non-goals
+No unrelated product changes.
+## Cut SHA
+${PROVENANCE_CUT_SHA}
+## Allowed change classes
+- changelog-only
+## Exit criteria
+All checks pass.
+## Approved exceptions
+None.
+`;
+  const prBody = `
+Release train: #900
+Release class: changelog-only
+Blocker: not applicable
+Source on main: not applicable
+Exception decision: not required
+`;
+  const release = betaRelease();
+  const responses: Record<string, unknown> = {
+    "repos/openclaw/openclaw/issues/900": {
+      number: 900,
+      html_url: "https://github.com/openclaw/openclaw/issues/900",
+      updated_at: "2026-07-10T12:00:00Z",
+      body: contractBody,
+    },
+    "repos/openclaw/openclaw/git/ref/heads/release%2F2026.7.2": {
+      object: { type: "commit", sha: PROVENANCE_RELEASE_SHA },
+    },
+    "repos/openclaw/openclaw/releases?per_page=100": scenario.legacyReleases ?? [release],
+    "repos/openclaw/openclaw/git/ref/tags/v2026.7.2-beta.9": scenario.tagRef ?? {
+      object: { type: "tag", sha: PROVENANCE_TAG_OBJECT_SHA },
+    },
+    [`repos/openclaw/openclaw/git/tags/${PROVENANCE_TAG_OBJECT_SHA}`]: {
+      sha: PROVENANCE_TAG_OBJECT_SHA,
+      object: { type: "commit", sha: PROVENANCE_RELEASE_SHA },
+    },
+    [`repos/openclaw/openclaw/commits/${PROVENANCE_RELEASE_SHA}?per_page=100&page=1`]: {
+      sha: PROVENANCE_RELEASE_SHA,
+      parents: [{ sha: PROVENANCE_CUT_SHA }],
+      commit: {
+        message: "docs(changelog): publish 2026.7.2 beta 9",
+        committer: { date: "2026-07-10T12:15:00Z" },
+      },
+      files: [{ filename: "CHANGELOG.md" }],
+    },
+    [`repos/openclaw/openclaw/compare/${PROVENANCE_CUT_SHA}...${PROVENANCE_CUT_SHA}`]:
+      compareResponse(PROVENANCE_CUT_SHA, PROVENANCE_CUT_SHA),
+    [`repos/openclaw/openclaw/compare/${PROVENANCE_RELEASE_SHA}...${PROVENANCE_RELEASE_SHA}`]:
+      compareResponse(PROVENANCE_RELEASE_SHA, PROVENANCE_RELEASE_SHA),
+    [`repos/openclaw/openclaw/compare/${PROVENANCE_CUT_SHA}...${PROVENANCE_RELEASE_SHA}`]:
+      compareResponse(PROVENANCE_CUT_SHA, PROVENANCE_RELEASE_SHA),
+  };
+  for (const [page, value] of Object.entries(scenario.releasePages ?? { 1: [release] })) {
+    responses[`repos/openclaw/openclaw/releases?per_page=100&page=${page}`] = value;
+  }
+  Object.assign(responses, scenario.tagObjects, scenario.compareOverrides);
+
+  try {
+    writeFileSync(
+      ghMock,
+      `import { appendFileSync } from "node:fs";
+const args = process.argv.slice(2);
+appendFileSync(process.env.GH_LOG, JSON.stringify(args) + "\\n");
+const responses = ${JSON.stringify(responses)};
+if (args[0] === "api" && args[1] === "graphql") {
+  process.stdout.write(JSON.stringify({ data: { repository: { object: { associatedPullRequests: {
+    nodes: [{ number: 901, url: "https://github.com/openclaw/openclaw/pull/901", body: ${JSON.stringify(prBody)}, baseRefName: "release/2026.7.2" }],
+    pageInfo: { hasNextPage: false }
+  } } } } }));
+  process.exit(0);
+}
+if (args[0] !== "api" || !(args[1] in responses)) {
+  console.error("unexpected gh args " + JSON.stringify(args));
+  process.exit(2);
+}
+process.stdout.write(JSON.stringify(responses[args[1]]));
+`,
+    );
+    const result = spawnSync(
+      process.execPath,
+      [
+        CLI,
+        "release-control-audit",
+        "--repo",
+        "openclaw/openclaw",
+        "--release-branch",
+        "release/2026.7.2",
+        "--contract-issue",
+        "900",
+        "--mode",
+        "advisory",
+        "--output",
+        output,
+      ],
+      {
+        encoding: "utf8",
+        env: { ...process.env, ...mockGhBinEnv(ghMock), GH_LOG: ghLog },
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    return {
+      report: JSON.parse(readFileSync(join(output, "2026.7.2.json"), "utf8")) as {
+        status: string;
+        latest_beta: string | null;
+      },
+      calls: readFileSync(ghLog, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as string[]),
+    };
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test("verifies an annotated beta tag and proper release lineage", () => {
+  const { report, calls } = runReleaseAuditScenario();
+  assert.equal(report.status, "clear");
+  assert.equal(report.latest_beta, PROVENANCE_TAG);
+  for (const endpoint of [
+    "repos/openclaw/openclaw/releases?per_page=100&page=1",
+    `repos/openclaw/openclaw/git/ref/tags/${PROVENANCE_TAG}`,
+    `repos/openclaw/openclaw/git/tags/${PROVENANCE_TAG_OBJECT_SHA}`,
+    `repos/openclaw/openclaw/compare/${PROVENANCE_CUT_SHA}...${PROVENANCE_CUT_SHA}`,
+    `repos/openclaw/openclaw/compare/${PROVENANCE_RELEASE_SHA}...${PROVENANCE_RELEASE_SHA}`,
+  ]) {
+    assert.ok(
+      calls.some((args) => args[1] === endpoint),
+      endpoint,
+    );
+  }
+});
+
+test("fails closed for a wrong beta tag, unrelated lineage, or tag-object SHA mismatch", () => {
+  const invalidScenarios: Array<[string, ReleaseAuditScenario]> = [
+    ["wrong tag", { tagRef: { object: { type: "commit", sha: PROVENANCE_OTHER_SHA } } }],
+    [
+      "unrelated lineage",
+      {
+        compareOverrides: {
+          [`repos/openclaw/openclaw/compare/${PROVENANCE_CUT_SHA}...${PROVENANCE_CUT_SHA}`]: {
+            status: "diverged",
+            total_commits: 0,
+            commits: [],
+            base_commit: { sha: PROVENANCE_CUT_SHA },
+            merge_base_commit: { sha: PROVENANCE_OTHER_SHA },
+          },
+        },
+      },
+    ],
+    [
+      "tag object mismatch",
+      {
+        tagObjects: {
+          [`repos/openclaw/openclaw/git/tags/${PROVENANCE_TAG_OBJECT_SHA}`]: {
+            sha: PROVENANCE_OTHER_SHA,
+            object: { type: "commit", sha: PROVENANCE_RELEASE_SHA },
+          },
+        },
+      },
+    ],
+    [
+      "missing lineage response",
+      {
+        compareOverrides: {
+          [`repos/openclaw/openclaw/compare/${PROVENANCE_CUT_SHA}...${PROVENANCE_CUT_SHA}`]: null,
+        },
+      },
+    ],
+    [
+      "tag indirection cycle",
+      {
+        tagObjects: {
+          [`repos/openclaw/openclaw/git/tags/${PROVENANCE_TAG_OBJECT_SHA}`]: {
+            sha: PROVENANCE_TAG_OBJECT_SHA,
+            object: { type: "tag", sha: PROVENANCE_TAG_OBJECT_SHA },
+          },
+        },
+      },
+    ],
+  ];
+  for (const [label, scenario] of invalidScenarios) {
+    assert.equal(runReleaseAuditScenario(scenario).report.status, "incomplete", label);
+  }
+});
+
+test("finds the named beta on the second complete release page", () => {
+  const firstPage = otherTrainReleases(100);
+  const { report, calls } = runReleaseAuditScenario({
+    legacyReleases: firstPage,
+    releasePages: { 1: firstPage, 2: [betaRelease()] },
+  });
+  assert.equal(report.status, "clear");
+  assert.equal(report.latest_beta, PROVENANCE_TAG);
+  assert.ok(
+    calls.some((args) => args[1] === "repos/openclaw/openclaw/releases?per_page=100&page=2"),
+  );
+});
+
+test("fails closed for missing release pages and duplicate release identities", () => {
+  const fullPage = [betaRelease(), ...otherTrainReleases(99)];
+  assert.equal(
+    runReleaseAuditScenario({ releasePages: { 1: fullPage } }).report.status,
+    "incomplete",
+    "missing page 2",
+  );
+  assert.equal(
+    runReleaseAuditScenario({
+      releasePages: {
+        1: [betaRelease(), { ...betaRelease(501), id: 501 }],
+      },
+    }).report.status,
+    "incomplete",
+    "duplicate tag identity",
+  );
+  assert.equal(
+    runReleaseAuditScenario({
+      releasePages: {
+        1: [betaRelease(), { ...betaRelease(), tag_name: "v2026.8.0-beta.1" }],
+      },
+    }).report.status,
+    "incomplete",
+    "duplicate numeric identity",
+  );
+  assert.equal(
+    runReleaseAuditScenario({ releasePages: { 1: { invalid: true } } }).report.status,
+    "incomplete",
+    "invalid page",
+  );
 });

--- a/test/release-control-cli.test.ts
+++ b/test/release-control-cli.test.ts
@@ -592,3 +592,20 @@ test("fails closed for missing release pages and duplicate release identities", 
     "invalid page",
   );
 });
+
+test("fails closed for duplicate Release SHA declarations", () => {
+  for (const [label, secondSha] of [
+    ["duplicate same SHA", PROVENANCE_RELEASE_SHA],
+    ["conflicting SHA", PROVENANCE_OTHER_SHA],
+  ] as const) {
+    const release = {
+      ...betaRelease(),
+      body: `- Release SHA: \`${PROVENANCE_RELEASE_SHA}\`\n- Release SHA: \`${secondSha}\``,
+    };
+    const report = runReleaseAuditScenario({
+      legacyReleases: [release],
+      releasePages: { 1: [release] },
+    }).report;
+    assert.equal(report.status, "incomplete", label);
+  }
+});

--- a/test/release-control-cli.test.ts
+++ b/test/release-control-cli.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -106,14 +106,14 @@ None.
 `;
   const prBody = `
 Release train: #900
-Release class: release-infrastructure
+Release class: release-preparation
 Blocker: not applicable
 Source on main: not applicable
 Exception decision: not required
 `;
   const firstPagePaths = Array.from(
     { length: 100 },
-    (_, index) => `.github/workflows/release-${String(index).padStart(3, "0")}.yml`,
+    (_, index) => `extensions/fixture-${String(index).padStart(3, "0")}/package.json`,
   );
   const responses = {
     "repos/openclaw/openclaw/issues/900": {
@@ -165,7 +165,7 @@ Exception decision: not required
     },
     [`repos/openclaw/openclaw/commits/${headSha}?per_page=100&page=2`]: {
       sha: headSha,
-      files: [{ filename: "scripts/release-followup.mjs" }],
+      files: [{ filename: "npm-shrinkwrap.json" }],
     },
   };
 
@@ -177,6 +177,15 @@ const args = process.argv.slice(2);
 appendFileSync(process.env.GH_LOG, JSON.stringify(args) + "\\n");
 const responses = ${JSON.stringify(responses)};
 if (args[0] === "api" && args[1] === "graphql") {
+  const query = args.find((arg) => arg.startsWith("query=")) ?? "";
+  if (query.includes("associatedPullRequests(first:100,states:")) {
+    console.error("unsupported associatedPullRequests states argument");
+    process.exit(2);
+  }
+  if (!query.includes("associatedPullRequests(first:100){nodes{number url body baseRefName}pageInfo{hasNextPage}}")) {
+    console.error("unexpected associatedPullRequests query shape");
+    process.exit(2);
+  }
   process.stdout.write(JSON.stringify({ data: { repository: { object: { associatedPullRequests: {
     nodes: [{ number: 901, url: "https://github.com/openclaw/openclaw/pull/901", body: ${JSON.stringify(prBody)}, baseRefName: "release/2026.7.2" }],
     pageInfo: { hasNextPage: false }
@@ -214,7 +223,9 @@ process.stdout.write(JSON.stringify(responses[args[1]]));
     assert.equal(second.status, 0, second.stderr);
     assert.equal(readFileSync(join(output, "2026.7.2.json"), "utf8"), firstJson);
     assert.equal(readFileSync(join(output, "2026.7.2.md"), "utf8"), firstMarkdown);
-    assert.equal(JSON.parse(firstJson).status, "clear");
+    assert.deepEqual(readdirSync(output).sort(), ["2026.7.2.json", "2026.7.2.md"]);
+    assert.equal(JSON.parse(firstJson).status, "attention");
+    assert.equal(JSON.parse(firstJson).changes[0].status, "allowed");
     assert.equal(JSON.parse(firstJson).code_sha, codeSha);
     assert.equal(JSON.parse(firstJson).release_sha, releaseSha);
     assert.equal(JSON.parse(firstJson).latest_beta, "v2026.7.2-beta.1");
@@ -233,6 +244,13 @@ process.stdout.write(JSON.stringify(responses[args[1]]));
       ),
     );
     assert.ok(calls.some((args) => args[1] === "graphql"));
+    assert.ok(
+      calls.every(
+        (args) =>
+          args[1] !== "graphql" ||
+          args.some((arg) => arg.startsWith("query=query(") && !arg.includes("mutation")),
+      ),
+    );
     const packageJson = JSON.parse(readFileSync("package.json", "utf8")) as {
       scripts: Record<string, string>;
     };

--- a/test/release-control-cli.test.ts
+++ b/test/release-control-cli.test.ts
@@ -1,0 +1,246 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { parseReleaseControlArgs } from "../dist/release-control/cli.js";
+import { main } from "../dist/clawsweeper.js";
+import { mockGhBinEnv } from "./helpers.ts";
+
+const CLI = fileURLToPath(new URL("../dist/clawsweeper.js", import.meta.url));
+
+test("parses the release-control audit CLI contract", () => {
+  assert.deepEqual(
+    parseReleaseControlArgs([
+      "release-control-audit",
+      "--repo",
+      "openclaw/openclaw",
+      "--release-branch",
+      "release/2026.7.2",
+      "--contract-issue",
+      "900",
+      "--mode",
+      "advisory",
+      "--output",
+      "/tmp/audit",
+      "--target-checkout",
+      "/tmp/openclaw",
+    ]),
+    {
+      repo: "openclaw/openclaw",
+      releaseBranch: "release/2026.7.2",
+      train: "2026.7.2",
+      contractIssue: 900,
+      mode: "advisory",
+      output: "/tmp/audit",
+      targetCheckout: "/tmp/openclaw",
+    },
+  );
+  assert.throws(
+    () =>
+      parseReleaseControlArgs([
+        "release-control-audit",
+        "--repo",
+        "openclaw/openclaw",
+        "--release-branch",
+        "main",
+        "--contract-issue",
+        "0",
+        "--mode",
+        "write",
+        "--output",
+        "/tmp/audit",
+      ]),
+    /release\/YYYY\.M\.PATCH/,
+  );
+});
+
+test("does not finalize or publish action-ledger state for the read-only audit", async () => {
+  let flushCalls = 0;
+  await assert.rejects(
+    main(["release-control-audit"], {
+      flushWorkflowActionEvents: async () => {
+        flushCalls += 1;
+        return ["unexpected-state-shard.jsonl"];
+      },
+    }),
+    /--repo is required/,
+  );
+  assert.equal(flushCalls, 0);
+});
+
+test("writes idempotent local reports using GitHub reads only", () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-release-control-"));
+  const output = join(root, "output");
+  const ghMock = join(root, "gh-mock.mjs");
+  const ghLog = join(root, "gh-calls.jsonl");
+  const cutSha = "1".repeat(40);
+  const codeSha = "2".repeat(40);
+  const releaseSha = "3".repeat(40);
+  const headSha = "a".repeat(40);
+  const contractBody = `
+## Release train
+2026.7.2
+## Release captain
+@alice
+## Goal
+Ship a narrow beta.
+## Non-goals
+No unrelated product changes.
+## Cut SHA
+${cutSha}
+## Allowed change classes
+- release-preparation
+- release-blocker
+- exact-backport
+- release-infrastructure
+- changelog-only
+- exception
+## Exit criteria
+All checks pass.
+## Approved exceptions
+None.
+`;
+  const prBody = `
+Release train: #900
+Release class: release-infrastructure
+Blocker: not applicable
+Source on main: not applicable
+Exception decision: not required
+`;
+  const firstPagePaths = Array.from(
+    { length: 100 },
+    (_, index) => `.github/workflows/release-${String(index).padStart(3, "0")}.yml`,
+  );
+  const responses = {
+    "repos/openclaw/openclaw/issues/900": {
+      number: 900,
+      html_url: "https://github.com/openclaw/openclaw/issues/900",
+      updated_at: "2026-07-10T12:00:00Z",
+      body: contractBody,
+    },
+    "repos/openclaw/openclaw/git/ref/heads/release%2F2026.7.2": {
+      object: { sha: headSha },
+    },
+    "repos/openclaw/openclaw/releases?per_page=100": [
+      {
+        tag_name: "v2026.7.3-beta.1",
+        prerelease: true,
+        draft: false,
+        published_at: "2026-07-11T12:20:00Z",
+        body: `- release SHA: \`${"9".repeat(40)}\``,
+      },
+      {
+        tag_name: "v2026.7.2-beta.1",
+        prerelease: true,
+        draft: false,
+        published_at: "2026-07-10T12:20:00Z",
+        body: `### Release verification\n\n- release SHA: \`${releaseSha}\``,
+      },
+    ],
+    [`repos/openclaw/openclaw/commits/${releaseSha}?per_page=100&page=1`]: {
+      sha: releaseSha,
+      parents: [{ sha: codeSha }],
+      commit: {
+        message: "docs(changelog): publish 2026.7.2 beta 1",
+        committer: { date: "2026-07-10T12:15:00Z" },
+      },
+      files: [{ filename: "CHANGELOG.md" }],
+    },
+    [`repos/openclaw/openclaw/compare/${cutSha}...${headSha}`]: {
+      status: "ahead",
+      total_commits: 1,
+      commits: [{ sha: headSha }],
+    },
+    [`repos/openclaw/openclaw/commits/${headSha}?per_page=100&page=1`]: {
+      sha: headSha,
+      commit: {
+        message: "ci: update release infrastructure",
+        committer: { date: "2026-07-10T12:10:00Z" },
+      },
+      files: firstPagePaths.map((filename) => ({ filename })),
+    },
+    [`repos/openclaw/openclaw/commits/${headSha}?per_page=100&page=2`]: {
+      sha: headSha,
+      files: [{ filename: "scripts/release-followup.mjs" }],
+    },
+  };
+
+  try {
+    writeFileSync(
+      ghMock,
+      `import { appendFileSync } from "node:fs";
+const args = process.argv.slice(2);
+appendFileSync(process.env.GH_LOG, JSON.stringify(args) + "\\n");
+const responses = ${JSON.stringify(responses)};
+if (args[0] === "api" && args[1] === "graphql") {
+  process.stdout.write(JSON.stringify({ data: { repository: { object: { associatedPullRequests: {
+    nodes: [{ number: 901, url: "https://github.com/openclaw/openclaw/pull/901", body: ${JSON.stringify(prBody)}, baseRefName: "release/2026.7.2" }],
+    pageInfo: { hasNextPage: false }
+  } } } } }));
+  process.exit(0);
+}
+if (args[0] !== "api" || !(args[1] in responses)) {
+  console.error("unexpected gh args " + JSON.stringify(args));
+  process.exit(2);
+}
+process.stdout.write(JSON.stringify(responses[args[1]]));
+`,
+    );
+    const argv = [
+      CLI,
+      "release-control-audit",
+      "--repo",
+      "openclaw/openclaw",
+      "--release-branch",
+      "release/2026.7.2",
+      "--contract-issue",
+      "900",
+      "--mode",
+      "advisory",
+      "--output",
+      output,
+    ];
+    const env = { ...process.env, ...mockGhBinEnv(ghMock), GH_LOG: ghLog };
+    const first = spawnSync(process.execPath, argv, { encoding: "utf8", env });
+    assert.equal(first.status, 0, first.stderr);
+    const firstJson = readFileSync(join(output, "2026.7.2.json"), "utf8");
+    const firstMarkdown = readFileSync(join(output, "2026.7.2.md"), "utf8");
+
+    const second = spawnSync(process.execPath, argv, { encoding: "utf8", env });
+    assert.equal(second.status, 0, second.stderr);
+    assert.equal(readFileSync(join(output, "2026.7.2.json"), "utf8"), firstJson);
+    assert.equal(readFileSync(join(output, "2026.7.2.md"), "utf8"), firstMarkdown);
+    assert.equal(JSON.parse(firstJson).status, "clear");
+    assert.equal(JSON.parse(firstJson).code_sha, codeSha);
+    assert.equal(JSON.parse(firstJson).release_sha, releaseSha);
+    assert.equal(JSON.parse(firstJson).latest_beta, "v2026.7.2-beta.1");
+    assert.equal(JSON.parse(firstJson).changes[0].paths.length, 101);
+
+    const calls = readFileSync(ghLog, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as string[]);
+    assert.ok(calls.length > 0);
+    assert.ok(calls.every((args) => args[0] === "api"));
+    assert.ok(calls.every((args) => !args.includes("--method")));
+    assert.ok(
+      calls.some(
+        (args) => args[1] === `repos/openclaw/openclaw/commits/${headSha}?per_page=100&page=2`,
+      ),
+    );
+    assert.ok(calls.some((args) => args[1] === "graphql"));
+    const packageJson = JSON.parse(readFileSync("package.json", "utf8")) as {
+      scripts: Record<string, string>;
+    };
+    assert.equal(
+      packageJson.scripts["release-control:audit"],
+      "node dist/clawsweeper.js release-control-audit",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/release-control-contract.test.ts
+++ b/test/release-control-contract.test.ts
@@ -99,3 +99,28 @@ Exception decision: not required
   assert.equal(metadata.value, null);
   assert.deepEqual(metadata.missingFields, ["Release class"]);
 });
+
+test("rejects duplicate and conflicting approved-exception entries", () => {
+  const contract = parseReleaseContract(`
+## Release train
+2026.7.2
+## Release captain
+@alice
+## Goal
+Ship a narrow beta.
+## Non-goals
+No product work.
+## Cut SHA
+0123456789abcdef0123456789abcdef01234567
+## Allowed change classes
+- exception
+## Exit criteria
+Checks pass.
+## Approved exceptions
+- #991: approved by @alice (https://github.com/openclaw/openclaw/issues/900#issuecomment-1)
+- #991: rejected by @alice (https://github.com/openclaw/openclaw/issues/900#issuecomment-2)
+`);
+
+  assert.equal(contract.value, null);
+  assert.deepEqual(contract.missingFields, ["Approved exceptions"]);
+});

--- a/test/release-control-contract.test.ts
+++ b/test/release-control-contract.test.ts
@@ -6,6 +6,27 @@ import {
   parseReleasePullMetadata,
 } from "../dist/release-control/contract.js";
 
+function contractWithExceptions(approvedExceptions: string): string {
+  return `
+## Release train
+2026.7.2
+## Release captain
+@alice
+## Goal
+Ship a narrow beta.
+## Non-goals
+No product work.
+## Cut SHA
+0123456789abcdef0123456789abcdef01234567
+## Allowed change classes
+- exception
+## Exit criteria
+Checks pass.
+## Approved exceptions
+${approvedExceptions}
+`;
+}
+
 test("parses the release contract and release-target pull request metadata", () => {
   const contract = parseReleaseContract(`
 ## Release train
@@ -101,26 +122,49 @@ Exception decision: not required
 });
 
 test("rejects duplicate and conflicting approved-exception entries", () => {
-  const contract = parseReleaseContract(`
-## Release train
-2026.7.2
-## Release captain
-@alice
-## Goal
-Ship a narrow beta.
-## Non-goals
-No product work.
-## Cut SHA
-0123456789abcdef0123456789abcdef01234567
-## Allowed change classes
-- exception
-## Exit criteria
-Checks pass.
-## Approved exceptions
+  const contract = parseReleaseContract(
+    contractWithExceptions(`
 - #991: approved by @alice (https://github.com/openclaw/openclaw/issues/900#issuecomment-1)
 - #991: rejected by @alice (https://github.com/openclaw/openclaw/issues/900#issuecomment-2)
-`);
+`),
+  );
 
   assert.equal(contract.value, null);
   assert.deepEqual(contract.missingFields, ["Approved exceptions"]);
+});
+
+test("accepts only explicit approved, rejected, pending, or None exception grammar", () => {
+  const contract = parseReleaseContract(
+    contractWithExceptions(`
+- #991: APPROVED by @alice (https://github.com/openclaw/openclaw/issues/900#issuecomment-1)
+* #992: Rejected BY @alice (https://github.com/openclaw/openclaw/pull/992#issuecomment-2)
+#993: Pending (https://github.com/openclaw/openclaw/issues/900#issuecomment-3)
+`),
+  );
+  assert.deepEqual(contract.missingFields, []);
+  assert.deepEqual(
+    contract.value?.approvedExceptions.map(({ number, decision }) => ({ number, decision })),
+    [
+      { number: 991, decision: "approved" },
+      { number: 992, decision: "rejected" },
+      { number: 993, decision: "pending" },
+    ],
+  );
+  assert.deepEqual(parseReleaseContract(contractWithExceptions("None.")).missingFields, []);
+
+  const decisionUrl = "https://github.com/openclaw/openclaw/issues/900#issuecomment-106";
+  for (const invalid of [
+    `#106: not approved by @alice (${decisionUrl})`,
+    `#106: maybe (${decisionUrl})`,
+    "#106: approved by @alice",
+    `#106: approved (${decisionUrl})`,
+    `#106: approved by @alice (${decisionUrl}) after review`,
+    "#106: approved by @alice (https://github.com/openclaw/openclaw/issues/900)",
+    `Decision #106: approved by @alice (${decisionUrl})`,
+    `None.\n#106: approved by @alice (${decisionUrl})`,
+  ]) {
+    const result = parseReleaseContract(contractWithExceptions(invalid));
+    assert.equal(result.value, null, invalid);
+    assert.deepEqual(result.missingFields, ["Approved exceptions"], invalid);
+  }
 });

--- a/test/release-control-contract.test.ts
+++ b/test/release-control-contract.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  parseReleaseContract,
+  parseReleasePullMetadata,
+} from "../dist/release-control/contract.js";
+
+test("parses the release contract and release-target pull request metadata", () => {
+  const contract = parseReleaseContract(`
+## Release train
+2026.7.2
+
+## Release captain
+@alice
+
+## Goal
+Ship a narrow beta.
+
+## Non-goals
+No new runtime features.
+
+## Cut SHA
+0123456789abcdef0123456789abcdef01234567
+
+## Allowed change classes
+- release-preparation
+- release-blocker
+- exact-backport
+- release-infrastructure
+- changelog-only
+- exception
+
+## Exit criteria
+All release checks pass.
+
+## Approved exceptions
+- #991: approved by @alice (https://github.com/openclaw/openclaw/issues/900#issuecomment-1)
+`);
+
+  assert.deepEqual(contract.missingFields, []);
+  assert.equal(contract.value?.train, "2026.7.2");
+  assert.equal(contract.value?.captain, "alice");
+  assert.equal(contract.value?.cutSha, "0123456789abcdef0123456789abcdef01234567");
+  assert.deepEqual(contract.value?.approvedExceptions, [
+    {
+      number: 991,
+      approver: "alice",
+      decisionUrl: "https://github.com/openclaw/openclaw/issues/900#issuecomment-1",
+      decision: "approved",
+    },
+  ]);
+
+  const metadata = parseReleasePullMetadata(`
+Release train: #900
+Release class: exact-backport
+Blocker: not applicable
+Source on main: 89abcdef0123456789abcdef0123456789abcdef and #881
+Exception decision: not required
+`);
+
+  assert.deepEqual(metadata.missingFields, []);
+  assert.equal(metadata.value?.contractIssue, 900);
+  assert.equal(metadata.value?.releaseClass, "exact-backport");
+  assert.equal(metadata.value?.sourceSha, "89abcdef0123456789abcdef0123456789abcdef");
+  assert.equal(metadata.value?.sourcePull, 881);
+});
+
+test("treats blank required contract fields and malformed pull metadata as incomplete", () => {
+  const contract = parseReleaseContract(`
+## Release train
+2026.7.2
+## Release captain
+@alice
+## Goal
+
+## Non-goals
+No product work.
+## Cut SHA
+not-a-full-sha
+## Allowed change classes
+- changelog-only
+## Exit criteria
+Checks pass.
+## Approved exceptions
+None.
+`);
+
+  assert.equal(contract.value, null);
+  assert.deepEqual(contract.missingFields.sort(), ["Cut SHA", "Goal"]);
+
+  const metadata = parseReleasePullMetadata(`
+Release train: #900
+Release class: feature
+Blocker: not applicable
+Source on main: not applicable
+Exception decision: not required
+`);
+  assert.equal(metadata.value, null);
+  assert.deepEqual(metadata.missingFields, ["Release class"]);
+});

--- a/test/release-control-contract.test.ts
+++ b/test/release-control-contract.test.ts
@@ -165,6 +165,24 @@ Exception decision: not required
   }
 });
 
+test("rejects blank values for every authoritative pull-request metadata field", () => {
+  const fields = new Map([
+    ["Release train", "#900"],
+    ["Release class", "changelog-only"],
+    ["Blocker", "not applicable"],
+    ["Source on main", "not applicable"],
+    ["Exception decision", "not required"],
+  ]);
+  for (const field of fields.keys()) {
+    const body = [...fields]
+      .map(([name, value]) => `${name}: ${name === field ? "   " : value}`)
+      .join("\n");
+    const metadata = parseReleasePullMetadata(body);
+    assert.equal(metadata.value, null, field);
+    assert.deepEqual(metadata.missingFields, [field], field);
+  }
+});
+
 test("accepts only explicit approved, rejected, pending, or None exception grammar", () => {
   const contract = parseReleaseContract(
     contractWithExceptions(`

--- a/test/release-control-contract.test.ts
+++ b/test/release-control-contract.test.ts
@@ -133,6 +133,38 @@ test("rejects duplicate and conflicting approved-exception entries", () => {
   assert.deepEqual(contract.missingFields, ["Approved exceptions"]);
 });
 
+test("rejects duplicate contract and pull-request metadata fields", () => {
+  for (const body of [
+    contractWithExceptions("None.").replace(
+      "## Release train\n2026.7.2",
+      "## Release train\n2026.7.2\n## Release train\n2026.7.2",
+    ),
+    contractWithExceptions("None.").replace(
+      "## Release train\n2026.7.2",
+      "Release train: 2026.7.2\n## Release train\n2026.7.2",
+    ),
+  ]) {
+    const contract = parseReleaseContract(body);
+    assert.equal(contract.value, null);
+    assert.deepEqual(contract.missingFields, ["Release train"]);
+  }
+
+  for (const releaseClasses of [
+    "Release class: release-blocker\nRelease class: release-blocker",
+    "Release class: release-blocker\nRelease class: changelog-only",
+  ]) {
+    const metadata = parseReleasePullMetadata(`
+Release train: #900
+${releaseClasses}
+Blocker: #901
+Source on main: not applicable
+Exception decision: not required
+`);
+    assert.equal(metadata.value, null);
+    assert.deepEqual(metadata.missingFields, ["Release class"]);
+  }
+});
+
 test("accepts only explicit approved, rejected, pending, or None exception grammar", () => {
   const contract = parseReleaseContract(
     contractWithExceptions(`

--- a/test/release-control-report.test.ts
+++ b/test/release-control-report.test.ts
@@ -9,7 +9,10 @@ import {
   renderReleaseReportMarkdown,
   type ReleaseReportInput,
 } from "../dist/release-control/report.js";
-import { parseReleaseContract } from "../dist/release-control/contract.js";
+import {
+  parseReleaseContract,
+  parseReleasePullMetadata,
+} from "../dist/release-control/contract.js";
 
 const historicalFixture = JSON.parse(
   readFileSync(
@@ -121,6 +124,65 @@ Checks pass.
 
   const report = buildReleaseReport(input);
   assert.equal(parsed.value, null);
+  assert.equal(report.status, "incomplete");
+  assert.notEqual(report.changes[0]?.status, "allowed");
+});
+
+test("cannot clear a contract with duplicate authoritative headings", () => {
+  const parsed = parseReleaseContract(`
+## Release train
+2026.7.1
+## Release train
+2026.7.1
+## Release captain
+@alice
+## Goal
+Ship a narrow beta.
+## Non-goals
+No product work.
+## Cut SHA
+1111111111111111111111111111111111111111
+## Allowed change classes
+- changelog-only
+## Exit criteria
+Checks pass.
+## Approved exceptions
+None.
+`);
+  const input = structuredClone(historicalFixture);
+  input.collectionComplete = parsed.value !== null;
+
+  const report = buildReleaseReport(input);
+  assert.equal(parsed.value, null);
+  assert.deepEqual(parsed.missingFields, ["Release train"]);
+  assert.equal(report.status, "incomplete");
+});
+
+test("cannot allow a change with conflicting duplicate release-class metadata", () => {
+  const parsed = parseReleasePullMetadata(`
+Release train: #900
+Release class: release-blocker
+Release class: changelog-only
+Blocker: #901
+Source on main: not applicable
+Exception decision: not required
+`);
+  const input = structuredClone(historicalFixture);
+  input.changes = [
+    {
+      sha: "d".repeat(40),
+      prNumber: 106,
+      title: "docs: release note",
+      paths: ["CHANGELOG.md"],
+      pathsComplete: true,
+      collectionComplete: parsed.value !== null,
+      metadataMissingFields: parsed.missingFields,
+    },
+  ];
+
+  const report = buildReleaseReport(input);
+  assert.equal(parsed.value, null);
+  assert.deepEqual(parsed.missingFields, ["Release class"]);
   assert.equal(report.status, "incomplete");
   assert.notEqual(report.changes[0]?.status, "allowed");
 });

--- a/test/release-control-report.test.ts
+++ b/test/release-control-report.test.ts
@@ -186,3 +186,41 @@ Exception decision: not required
   assert.equal(report.status, "incomplete");
   assert.notEqual(report.changes[0]?.status, "allowed");
 });
+
+test("cannot allow or clear changelog-only metadata with blank proof fields", () => {
+  for (const blankField of ["Blocker", "Source on main", "Exception decision"] as const) {
+    const values = {
+      Blocker: "not applicable",
+      "Source on main": "not applicable",
+      "Exception decision": "not required",
+    };
+    values[blankField] = "   ";
+    const parsed = parseReleasePullMetadata(`
+Release train: #900
+Release class: changelog-only
+Blocker: ${values.Blocker}
+Source on main: ${values["Source on main"]}
+Exception decision: ${values["Exception decision"]}
+`);
+    const input = structuredClone(historicalFixture);
+    input.changes = [
+      {
+        sha: "e".repeat(40),
+        prNumber: 107,
+        title: "docs: release note",
+        paths: ["CHANGELOG.md"],
+        pathsComplete: true,
+        collectionComplete: parsed.value !== null,
+        ...(parsed.value
+          ? { metadata: parsed.value }
+          : { metadataMissingFields: parsed.missingFields }),
+      },
+    ];
+
+    const report = buildReleaseReport(input);
+    assert.equal(parsed.value, null, blankField);
+    assert.deepEqual(parsed.missingFields, [blankField], blankField);
+    assert.equal(report.status, "incomplete", blankField);
+    assert.notEqual(report.changes[0]?.status, "allowed", blankField);
+  }
+});

--- a/test/release-control-report.test.ts
+++ b/test/release-control-report.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  buildReleaseReport,
+  renderReleaseReportJson,
+  renderReleaseReportMarkdown,
+  type ReleaseReportInput,
+} from "../dist/release-control/report.js";
+
+const historicalFixture = JSON.parse(
+  readFileSync(
+    fileURLToPath(new URL("fixtures/release-control-2026.7.1.json", import.meta.url)),
+    "utf8",
+  ),
+) as ReleaseReportInput;
+
+test("renders stable deterministic JSON and Markdown for unchanged inputs", () => {
+  const first = buildReleaseReport(historicalFixture);
+  const second = buildReleaseReport(structuredClone(historicalFixture));
+
+  assert.equal(renderReleaseReportJson(first), renderReleaseReportJson(second));
+  assert.equal(renderReleaseReportMarkdown(first), renderReleaseReportMarkdown(second));
+  assert.equal(first.schema_version, 1);
+  assert.equal(first.status, "incomplete");
+  assert.deepEqual(first.counts, {
+    allowed: 0,
+    candidate_resets: 0,
+    commits: 2,
+    pending_exceptions: 0,
+    product_change_signals: 4,
+    prs: 2,
+    unclassified: 0,
+  });
+  assert.deepEqual(
+    first.changes.map((change) => change.title),
+    [
+      "feat: support GPT-5.6 Ultra across OpenClaw and Codex runtimes (#98021)",
+      "feat(providers): add Meta Model API - muse-spark-1.1 (#102873)",
+    ],
+  );
+  assert.ok(first.changes.every((change) => change.signals.includes("feature-title")));
+  assert.match(renderReleaseReportMarkdown(first), /Meta Model API/);
+  assert.match(renderReleaseReportMarkdown(first), /GPT-5\.6 Ultra/);
+});
+
+test("applies report status precedence incomplete over blocked over attention over clear", () => {
+  const base = structuredClone(historicalFixture);
+  base.changes = [];
+  assert.equal(buildReleaseReport(base).status, "clear");
+
+  base.changes = [
+    {
+      sha: "d".repeat(40),
+      title: "docs: unclassified release note",
+      paths: ["docs/note.md"],
+      pathsComplete: true,
+    },
+  ];
+  assert.equal(buildReleaseReport(base).status, "attention");
+
+  base.changes = [
+    {
+      sha: "e".repeat(40),
+      prNumber: 990,
+      title: "docs: invalid changelog-only declaration",
+      paths: ["docs/note.md"],
+      pathsComplete: true,
+      metadata: {
+        contractIssue: 900,
+        releaseClass: "changelog-only",
+      },
+    },
+  ];
+  assert.equal(buildReleaseReport(base).status, "blocked");
+
+  base.collectionComplete = false;
+  assert.equal(buildReleaseReport(base).status, "incomplete");
+});

--- a/test/release-control-report.test.ts
+++ b/test/release-control-report.test.ts
@@ -9,6 +9,7 @@ import {
   renderReleaseReportMarkdown,
   type ReleaseReportInput,
 } from "../dist/release-control/report.js";
+import { parseReleaseContract } from "../dist/release-control/contract.js";
 
 const historicalFixture = JSON.parse(
   readFileSync(
@@ -78,4 +79,48 @@ test("applies report status precedence incomplete over blocked over attention ov
 
   base.collectionComplete = false;
   assert.equal(buildReleaseReport(base).status, "incomplete");
+});
+
+test("cannot allow or clear a negated approved-exception contract line", () => {
+  const decisionUrl = "https://github.com/openclaw/openclaw/issues/900#issuecomment-106";
+  const parsed = parseReleaseContract(`
+## Release train
+2026.7.1
+## Release captain
+@alice
+## Goal
+Ship a narrow beta.
+## Non-goals
+No product work.
+## Cut SHA
+1111111111111111111111111111111111111111
+## Allowed change classes
+- exception
+## Exit criteria
+Checks pass.
+## Approved exceptions
+#106: not approved by @alice (${decisionUrl})
+`);
+  const input = structuredClone(historicalFixture);
+  input.collectionComplete = parsed.value !== null;
+  input.contract.approvedExceptions = parsed.value?.approvedExceptions ?? [];
+  input.changes = [
+    {
+      sha: "c".repeat(40),
+      prNumber: 106,
+      title: "docs: exception candidate",
+      paths: ["docs/release-note.md"],
+      pathsComplete: true,
+      metadata: {
+        contractIssue: input.contractIssue.number,
+        releaseClass: "exception",
+        exceptionDecisionUrl: decisionUrl,
+      },
+    },
+  ];
+
+  const report = buildReleaseReport(input);
+  assert.equal(parsed.value, null);
+  assert.equal(report.status, "incomplete");
+  assert.notEqual(report.changes[0]?.status, "allowed");
 });


### PR DESCRIPTION
Part of #535. Companion policy draft: openclaw/openclaw#106128.

## What this adds

This is the read-only foundation for advisory release-train visibility. It adds a deterministic `release-control:audit` command that:

- reads a maintainer-owned release-train issue and PR metadata;
- classifies the six proposed release change classes;
- verifies beta tag, Code SHA, Release SHA, branch lineage, and exact-backport provenance;
- writes stable local Markdown and JSON reports to a caller-selected directory.

The collector fails closed: missing, duplicated, ambiguous, stale, truncated, or unavailable evidence produces `incomplete`, never `clear`.

## Boundaries

- Read-only GitHub and local Git inspection only.
- Local writes are limited to the two requested report files.
- No state-branch publishing, workflows, Check Runs, dashboard changes, labels, rulesets, merges, releases, or current-train gates.
- `2026.7.1` is a retrospective fixture only.
- Normal development on `main` remains unchanged.

The later report-publishing and advisory-check stages remain separate, dependency-ordered PRs. A required check remains conditional on one complete shadow train and explicit maintainer-admin approval.

## Validation

- 28 focused release-control tests at the reviewed candidate head
- `pnpm run build:all`
- `pnpm run lint`
- `pnpm run format:check`
- `git diff --check`
- two sequential read-only reviews: architecture/correctness, then workflow/permissions/safety

The exact-head local `pnpm run check` reached 1,171 passing unit tests, with two non-release-control failures (`write EPIPE` in a mocked Codex subprocess and a retry-state timing assertion). Both affected test files passed together `35/35` in an immediate narrow replay at the same commit. The full local suite was not repeated.

Canonical exact-head remote [`pnpm check`](https://github.com/openclaw/clawsweeper/actions/runs/29236257592/job/86771517789) passed on Node 24, along with CodeQL, action analysis, the Windows Codex launcher, and crawl-remote integration.

Passing checks establish advisory-classification and PR readiness only; they do not approve a merge or release.

## Maintainer ownership

Release goals, approved exceptions, and final inclusion/release decisions remain maintainer-owned. This command supplies complementary visibility and durable evidence; it does not make those decisions.
