### PR TITLE
fix(ledger): namespace apply decision reports

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2563,6 +2563,7 @@ jobs:
           timeout --kill-after=30s 840s pnpm run apply-decisions -- \
             --target-repo "$TARGET_REPO" \
             --skip-dashboard \
+            --report-path artifacts/selected-review-comment-apply-report.json \
             --item-numbers "$item_numbers" \
             --sync-comments-only \
             --apply-kind all \
@@ -2577,6 +2578,7 @@ jobs:
           if [ "$selected_comment_exit_code" -ne 0 ]; then
             exit "$selected_comment_exit_code"
           fi
+          cp artifacts/selected-review-comment-apply-report.json apply-report.json
           echo "sync_succeeded=true" >> "$GITHUB_OUTPUT"
           synced_count="$(pnpm run --silent workflow -- count-actions --report apply-report.json --action review_comment_synced)"
           pnpm run status -- \
@@ -3635,6 +3637,7 @@ jobs:
             pnpm run apply-decisions -- \
               --target-repo "$TARGET_REPO" \
               --skip-dashboard \
+              --report-path ".artifacts/apply-reports/apply-report-$checkpoint.json" \
               --limit 0 \
               --min-age-days "$min_age_days" \
               "${min_age_minutes_arg[@]}" \
@@ -3647,7 +3650,7 @@ jobs:
               --comment-sync-min-age-days "$comment_sync_min_age_days" \
               "${item_numbers_arg[@]}" \
               "${sync_comments_arg[@]}"
-            cp apply-report.json ".artifacts/apply-reports/apply-report-$checkpoint.json"
+            cp ".artifacts/apply-reports/apply-report-$checkpoint.json" apply-report.json
             result_count="$(pnpm run --silent workflow -- count-report --report ".artifacts/apply-reports/apply-report-$checkpoint.json")"
             synced_count="$(pnpm run --silent workflow -- count-actions --report ".artifacts/apply-reports/apply-report-$checkpoint.json" --action review_comment_synced)"
             if [ "$sync_open_pr_batch" = "true" ]; then
@@ -3694,6 +3697,7 @@ jobs:
             CLAWSWEEPER_APPLY_CHECKPOINT="$checkpoint" pnpm run apply-decisions -- \
               --target-repo "$TARGET_REPO" \
               --skip-dashboard \
+              --report-path ".artifacts/apply-reports/apply-report-$checkpoint.json" \
               --limit "$chunk_limit" \
               --min-age-days "$min_age_days" \
               "${min_age_minutes_arg[@]}" \
@@ -3710,7 +3714,6 @@ jobs:
               "${sync_comments_arg[@]}" \
               --artifact-dir .artifacts/apply-proof \
               --require-precomputed-pr-close-coverage-proof
-            cp apply-report.json ".artifacts/apply-reports/apply-report-$checkpoint.json"
             pnpm run workflow -- merge-apply-reports --dir .artifacts/apply-reports --output apply-report.json
             closed_in_chunk="$(pnpm run --silent workflow -- count-actions --report ".artifacts/apply-reports/apply-report-$checkpoint.json" --action closed)"
             result_count="$(pnpm run --silent workflow -- count-report --report ".artifacts/apply-reports/apply-report-$checkpoint.json")"

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -13,6 +13,7 @@ import { dirname, join } from "node:path";
 import test from "node:test";
 import YAML from "yaml";
 
+import { ACTION_EVENT_RELATIVE_DATA_PATH_PATTERN_SOURCE } from "../dist/action-ledger.js";
 import { makeTreeReadOnlyForTest, restoreTreeModesForTest } from "../dist/clawsweeper.js";
 import { readText, tmpPrefix } from "./helpers.ts";
 
@@ -55,6 +56,73 @@ test("ledger-producing jobs initialize immutable workflow context", () => {
   assert.match(action, /CLAWSWEEPER_ACTION_LEDGER_FORCE=1/);
   assert.match(action, /CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT=\$output_root/);
   assert.match(action, /GITHUB_RUN_STARTED_AT=\$run_started_at/);
+});
+
+test("ledger-enabled apply commands use namespaced reports and preserve state projections", () => {
+  type WorkflowStep = { name?: string; uses?: string; run?: string };
+  type WorkflowJob = { steps?: WorkflowStep[] };
+  const workflow = YAML.parse(readText(".github/workflows/sweep.yml")) as {
+    jobs: Record<string, WorkflowJob>;
+  };
+  const reportPathPattern = new RegExp(ACTION_EVENT_RELATIVE_DATA_PATH_PATTERN_SOURCE);
+  const applyCommands: Array<{ job: string; step: string; command: string }> = [];
+
+  for (const [jobName, job] of Object.entries(workflow.jobs)) {
+    const steps = job.steps ?? [];
+    if (!steps.some((step) => step.uses?.endsWith("/setup-action-ledger"))) continue;
+    for (const step of steps) {
+      const lines = step.run?.split("\n") ?? [];
+      for (let index = 0; index < lines.length; index += 1) {
+        if (!lines[index]!.includes("pnpm run apply-decisions --")) continue;
+        const command = [lines[index]!];
+        while (command.at(-1)!.trimEnd().endsWith("\\") && index + 1 < lines.length) {
+          index += 1;
+          command.push(lines[index]!);
+        }
+        applyCommands.push({
+          job: jobName,
+          step: step.name ?? "unnamed",
+          command: command.join("\n"),
+        });
+      }
+    }
+  }
+
+  assert.equal(applyCommands.length, 4);
+  for (const { job, step, command } of applyCommands) {
+    const reportPathArgument = command.match(/--report-path\s+("[^"]+"|'[^']+'|[^\s\\]+)/)?.[1];
+    assert.ok(reportPathArgument, `${job}/${step} must set --report-path`);
+    const reportPath = reportPathArgument.replace(/^(['"])(.*)\1$/, "$2");
+    const representativePath = reportPath.replace(/\$\{?[A-Za-z_][A-Za-z0-9_]*\}?/g, "1");
+    assert.match(
+      representativePath,
+      reportPathPattern,
+      `${job}/${step} report path must satisfy the action-ledger namespace contract`,
+    );
+  }
+
+  const selectedSync = workflow.jobs.publish?.steps?.find(
+    (step) => step.name === "Sync selected review comments",
+  )?.run;
+  assert.ok(selectedSync);
+  assert.match(
+    selectedSync,
+    /--report-path artifacts\/selected-review-comment-apply-report\.json[\s\S]*cp artifacts\/selected-review-comment-apply-report\.json apply-report\.json[\s\S]*--report apply-report\.json/,
+  );
+
+  const checkpointApply = workflow.jobs["apply-existing"]?.steps?.find(
+    (step) => step.name === "Apply unchanged proposed decisions with checkpoints",
+  )?.run;
+  assert.ok(checkpointApply);
+  assert.match(
+    checkpointApply,
+    /--report-path "\.artifacts\/apply-reports\/apply-report-\$checkpoint\.json"[\s\S]*cp "\.artifacts\/apply-reports\/apply-report-\$checkpoint\.json" apply-report\.json/,
+  );
+  assert.match(
+    checkpointApply,
+    /merge-apply-reports --dir \.artifacts\/apply-reports --output apply-report\.json/,
+  );
+  assert.match(checkpointApply, /apply_publish_paths=\(records apply-report\.json\)/);
 });
 
 test("review and apply primary boundaries ignore ledger-only failures", () => {


### PR DESCRIPTION
## Summary

- write the three previously unsafe ledger-enabled `apply-decisions` reports to namespaced artifact paths
- preserve the root `apply-report.json` projections consumed by existing status and state publishers
- verify every ledger-enabled workflow invocation against the action-ledger path contract

## Rationale

`apply-decisions` defaults to the repository-root `apply-report.json`. When the
action ledger records that path as `subject.recordPath`, publication rejects it
because ledger record paths must use a supported namespace.

The apply-proof lane already supplies a valid namespaced path. This change aligns
the remaining selected-comment and checkpointed apply invocations without
weakening ledger validation or changing apply behavior.

Reproduced on upstream run 29254106392: the exact-item review job succeeded, then
the publisher rejected the root report path.

## Testing

- focused workflow regression: passed
- `pnpm run test:coverage:changed`: 913 passed; 100% lines, 86.9% branches, 100% functions for the enforced target
- `pnpm run format:check`: passed across 373 files
- `git diff --check`: passed
- autoreview: no actionable findings (0.97 confidence)

`pnpm run check` completed build and lint lanes and ran 1,148 unit tests; seven
wall-clock-sensitive assertions in three untouched files failed under aggregate
host load. Each affected file passed in isolation (action-ledger runtime: 82
passed, 2 skipped; apply runtime budget: 8 passed; failed-review retry: 19
passed).

The full coverage run exceeded all configured thresholds (74.75% lines, 73.47%
branches, 84.73% functions) but reported eight timing/concurrency failures in
those same untouched areas. Every exact failed case then passed with coverage
instrumentation in focused reruns (2 action-ledger, 4 apply-runtime, 2
failed-review cases).

No identity, routing, runner, fork-overlay, or downstream-specific behavior is
included in this patch.
