### PR TITLE
fix(sweep): allow PR review lease comments

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1832,7 +1832,7 @@ jobs:
           permission-checks: read
           permission-contents: read
           permission-issues: write
-          permission-pull-requests: read
+          permission-pull-requests: write
           permission-statuses: read
 
       - name: Create target Codex inspection token

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1596,6 +1596,19 @@ test("sweep target tokens fall back when an org app installation is missing", ()
   assert.doesNotMatch(workflow, new RegExp("OPENCLAW_" + "GH_TOKEN"));
 });
 
+test("sweep target review token can post pull request review leases", () => {
+  const workflow = readText(".github/workflows/sweep.yml");
+  const targetReviewTokenBlocks = workflow
+    .split("- name: Create target review token")
+    .slice(1)
+    .map((block) => block.split("\n      - ")[0]);
+
+  assert.equal(targetReviewTokenBlocks.length, 1);
+  const [targetReviewToken] = targetReviewTokenBlocks;
+  assert.match(targetReviewToken ?? "", /permission-issues: write/);
+  assert.match(targetReviewToken ?? "", /permission-pull-requests: write/);
+});
+
 test("proof nudge workflow is manual-first and scheduled behind repo vars", () => {
   const sweepWorkflow = readText(".github/workflows/sweep.yml");
   const workflow = readText(".github/workflows/proof-nudges.yml");


### PR DESCRIPTION
# Summary

- Grants the scheduled review shard's target App token `pull-requests: write`, while retaining its existing `issues: write` scope.
- Adds a focused workflow regression test that requires both write permissions in the `Create target review token` block.

# Problem

The scheduled ClawHub sweep in [run 29261805316](https://github.com/openclaw/clawsweeper/actions/runs/29261805316) minted a token with `issues: write` but `pull-requests: read`. Review-shard lease/status comments use `POST /repos/{target}/issues/{number}/comments`; on PR items that endpoint needs the App's Pull requests write permission. All 29 ClawHub PR shards therefore received `403 Resource not accessible by integration`, while the one ordinary issue succeeded.

This is independent of [PR #518](https://github.com/openclaw/clawsweeper/pull/518)'s recovery/fanout handling and [PR #521](https://github.com/openclaw/clawsweeper/pull/521)'s ledger lifecycle work.

# Implementation

Only the review-shard `Create target review token` block in `.github/workflows/sweep.yml` changes:

- `permission-pull-requests: read` becomes `permission-pull-requests: write`.
- No recovery, queue, state publication, labels, gates, application credentials, or other token scopes change.

# Validation

- `pnpm run build:all` — passed.
- `node --test --test-name-pattern "sweep target review token can post pull request review leases" test/sweep-workflow.test.ts` — passed (1/1).
- `node --test --test-name-pattern "sweep target review token can post pull request review leases|review workflow gives Codex a read-only inspection token" test/sweep-workflow.test.ts` — passed (2/2).
- `node --test --test-name-pattern "codex subprocess env strips GitHub and App credentials|codex subprocess env can expose an explicit read-only GitHub token" test/clawsweeper.test.ts` — passed (2/2).
- `node --test test/sweep-workflow.test.ts` — passed (62/62) in Linux local-container Crabbox proof, provider `local-container`, lease `cbx_8c70bf6e5438`, commit `f38ac5bb6d75f01ea21fdf2d70927b0965dedde4`. The one-shot lease stopped automatically.
- Docker clean-copy proof (`node:24-bookworm`, Debian 12): mounted the PR worktree read-only, copied source into `/work`, installed with `pnpm install --frozen-lockfile`, then passed:
  - `node --test --test-name-pattern "sweep target review token can post pull request review leases|review workflow gives Codex a read-only inspection token" test/sweep-workflow.test.ts` — passed (2/2).
  - `node --test --test-name-pattern "codex subprocess env strips GitHub and App credentials|codex subprocess env can expose an explicit read-only GitHub token" test/clawsweeper.test.ts` — passed (2/2).
  - `node --test --test-name-pattern "review start status comment is marker-backed and crustacean-friendly|spoofed durable markers cannot suppress a bot-owned start lease|concurrent review lease election uses server comment order, not client timestamps" test/review-comment-rendering.test.ts` — passed (3/3).
- `pnpm exec oxlint test/sweep-workflow.test.ts --deny-warnings` — passed.
- YAML parse of `.github/workflows/sweep.yml` — passed.
- `git diff --check origin/main...HEAD` — passed.
- `actionlint` — unavailable on this host: executable is not on `PATH`.
- `pnpm run format:check` reports pre-existing formatting differences across 373 files, including both unchanged full files touched here; no repository-wide formatting rewrite was applied.

# Credential-boundary proof

- The review shard still receives the short-lived target review token as `GH_TOKEN` only for deterministic review orchestration and lease/status publication.
- A distinct `Create target Codex inspection token` step requests only `contents: read`, `issues: read`, and `pull-requests: read`. The `Review shard` step passes that token separately as `CLAWSWEEPER_PROOF_INSPECTION_TOKEN`.
- `src/codex-env.ts` deletes inherited `GH_TOKEN`, `GITHUB_TOKEN`, App credentials, and `CLAWSWEEPER_PROOF_INSPECTION_TOKEN` before reinjecting only the explicit inspection token for the Codex subprocess. Existing tests cover both stripping inherited credentials and passing an explicit inspection token.

This preserves the intended boundary: deterministic workflow code can post the lease/status comment; the untrusted Codex subprocess receives the separate read-only inspection credential.

# Deployment prerequisite and installation evidence

The ClawSweeper GitHub App installation for `openclaw/clawhub` must allow **Pull requests: Read & write**. `actions/create-github-app-token` can narrow an installation permission but cannot grant a permission that the installation does not have.

The installation settings endpoint is not readable with the available user authentication: `GET /repos/openclaw/clawhub/installation` returns `401 A JSON web token could not be decoded`. The capability is nevertheless proven by redacted live workflow evidence from the failing parent run itself: [run 29261805316](https://github.com/openclaw/clawsweeper/actions/runs/29261805316), job `Publish review artifacts` ([86858453103](https://github.com/openclaw/clawsweeper/actions/runs/29261805316/job/86858453103)), ran `Create target write token` at 2026-07-13T15:27:35Z for `openclaw/clawhub` with `permission-pull-requests: write`; that step succeeded and its normal post-step cleanup revoked the token. The pinned workflow at the run head requested the same write scope. This establishes that the installation could mint a ClawHub PR-write token at incident time; the remaining defect was that the review shard requested only PR read.

# Post-merge behavior proof

The Docker proof above is deterministic local-container evidence for the workflow/token boundary and lease-comment behavior. It is not claimed as the requested live post-deployment App-token proof; the real lease/status comment URLs still require a normal default-branch run after merge or an explicit maintainer proof override.

The requested real App-token proof cannot be produced from this unmerged branch: scheduled review shards execute the default-branch workflow, and this PR does not dispatch or rerun workflows. Before treating the rollout as complete, a maintainer must:

1. Let a normal scheduled or maintainer-requested review process one ClawHub PR and one ordinary issue after this change is deployed.
2. Capture redacted run output and the two resulting lease/status comment URLs, then request `@clawsweeper re-review`.

# Maintainer rollout decision

Maintainer decision recorded 2026-07-14:

Authenticated approval: [proof: override comment](https://github.com/openclaw/clawsweeper/pull/539#issuecomment-4964860415) by `brokemac79`.

- Approve a monitored rollout of this single short-lived target-review-token change: `pull-requests: write` alongside its existing `issues: write` scope.
- Accept a pre-merge real-behavior proof override because the required real App-token evidence necessarily depends on the default-branch workflow after deployment.
- Do not widen any other token, credential, workflow, state-publication, recovery, or Codex subprocess capability.
- Require the first normal post-merge review cycle to capture redacted run output plus both a pull-request and ordinary-issue lease/status comment URL, then request a normal `@clawsweeper re-review`.

# Risks and rollout

The additional scope is limited to the short-lived review token already used for deterministic lease/status comments. Repository contents, checks, statuses, and the Codex inspection token remain read-only. The remaining proof is a post-deployment normal-run observation; this PR does not dispatch or rerun anything.

# Codex review closeout

- `codex review --uncommitted` — clean; no accepted or actionable findings.
- `codex review --base origin/main` — clean; no accepted or actionable findings.
