### PR TITLE
fix(local-review): use selected Codex CLI

### DIFF
--- a/.agents/skills/local-clawsweeper-review/SKILL.md
+++ b/.agents/skills/local-clawsweeper-review/SKILL.md
@@ -68,8 +68,8 @@ unset OPENAI_API_KEY
 ```
 
 If the wrong Codex binary is used, set `CODEX_BIN` in the local shell for that
-run. On Windows, the runner prefers the Codex app binary under
-`%LOCALAPPDATA%\OpenAI\Codex\bin\codex.exe` when `--local-only` is used.
+run. Otherwise, `--local-only` uses the first spawnable `codex` command on
+`PATH`, including on Windows.
 
 ## Target Checkout Modes
 

--- a/.agents/skills/local-clawsweeper-review/SKILL.md
+++ b/.agents/skills/local-clawsweeper-review/SKILL.md
@@ -69,7 +69,8 @@ unset OPENAI_API_KEY
 
 If the wrong Codex binary is used, set `CODEX_BIN` in the local shell for that
 run. Otherwise, `--local-only` uses the first spawnable `codex` command on
-`PATH`, including on Windows.
+`PATH`, including on Windows. If no Windows PATH command is spawnable, it falls
+back to the installed Codex Desktop binary.
 
 ## Target Checkout Modes
 

--- a/scripts/check-local-codex.mjs
+++ b/scripts/check-local-codex.mjs
@@ -3,7 +3,7 @@ import { spawnSync } from "node:child_process";
 
 const model = argValue("--model") ?? process.env.CLAWSWEEPER_LOCAL_CODEX_MODEL ?? "gpt-5.6-sol";
 const { codexSpawnInvocation } = await loadCodexLauncher();
-const codexEnv = { ...process.env, CLAWSWEEPER_PREFER_WINDOWS_CODEX_APP: "1" };
+const codexEnv = { ...process.env };
 const codex = codexInvocation([]);
 
 console.log(`Codex binary: ${codex.command}${codex.args.length ? ` ${codex.args.join(" ")}` : ""}`);

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -9403,7 +9403,6 @@ function runCodex(options: {
   serviceTier: string;
   forcedLoginMethod?: string;
   preserveCodexAuth?: boolean;
-  preferWindowsAppBinary?: boolean;
   timeoutMs: number;
   workDir: string;
   additionalPrompt?: string;
@@ -9488,7 +9487,6 @@ function runCodex(options: {
             preserveCodexAuth: options.preserveCodexAuth,
           }),
           CLAWSWEEPER_PROOF_SCRATCH_DIR: proofScratchDir,
-          ...(options.preferWindowsAppBinary ? { CLAWSWEEPER_PREFER_WINDOWS_CODEX_APP: "1" } : {}),
         },
         input: prompt,
         stderrPath: join(options.workDir, `${options.item.number}.${attempt}.codex.stderr.log`),
@@ -21257,7 +21255,7 @@ function finishReviewActionLedger(options: {
 function reviewCommand(args: Args): void {
   const profile = repoFromArgs(args);
   // `--local-range` is inherently a local, offline operation, so it implies `--local-only`
-  // (no GitHub writes, and the local Codex auth / Windows-launcher path in runCodex below).
+  // (no GitHub writes, and the local Codex auth path in runCodex below).
   const localRange = boolArg(args.local_range);
   const localOnly = boolArg(args.local_only) || localRange;
   const verbose = boolArg(args.verbose);
@@ -22319,7 +22317,6 @@ function reviewCommand(args: Args): void {
           serviceTier,
           forcedLoginMethod,
           preserveCodexAuth: localOnly,
-          preferWindowsAppBinary: localOnly,
           timeoutMs,
           workDir: codexWorkDir,
           additionalPrompt,

--- a/src/codex-process.ts
+++ b/src/codex-process.ts
@@ -90,7 +90,7 @@ export function runCodexProcess(options: {
       optionsPath,
       JSON.stringify({
         args: [...options.args],
-        command: codexProcessCommand(options.env),
+        command: codexProcessCommand(options.env, process.platform, options.cwd),
         timeoutMs: options.timeoutMs,
         resultPath,
         stdoutPath,

--- a/src/codex-spawn.ts
+++ b/src/codex-spawn.ts
@@ -15,10 +15,25 @@ import {
 
 export type CodexSpawnInvocation = CommandInvocation;
 
-export function codexProcessCommand(env: NodeJS.ProcessEnv = process.env): string {
+export function codexProcessCommand(
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+  cwd = process.cwd(),
+): string {
   const configured = env.CODEX_BIN?.trim();
   if (configured) return configured;
-  if (process.platform === "win32" && env.CLAWSWEEPER_PREFER_WINDOWS_CODEX_APP === "1") {
+  if (platform === "win32") {
+    try {
+      const pathInvocation = resolveSpawnCommand("codex", [], {
+        cwd,
+        env,
+        missingCommandMessage: "Unable to resolve Windows Codex command: codex",
+        platform,
+      });
+      if (windowsInvocationIsSpawnable(pathInvocation)) return "codex";
+    } catch {
+      // Fall through to the Desktop app fallback below.
+    }
     const appBinary = windowsCodexAppBinary(env);
     if (appBinary) return appBinary;
   }
@@ -31,7 +46,7 @@ export function codexSpawnInvocation(
   platform: NodeJS.Platform = process.platform,
   cwd = process.cwd(),
 ): CodexSpawnInvocation {
-  const configuredCommand = codexProcessCommand(env);
+  const configuredCommand = codexProcessCommand(env, platform, cwd);
   return resolveSpawnCommand(configuredCommand, args, {
     cwd,
     env,
@@ -113,4 +128,8 @@ function windowsCodexAppBinary(env: NodeJS.ProcessEnv): string | null {
   if (!localAppData) return null;
   const candidate = join(localAppData, "OpenAI", "Codex", "bin", "codex.exe");
   return existsSync(candidate) ? candidate : null;
+}
+
+function windowsInvocationIsSpawnable(invocation: CommandInvocation): boolean {
+  return invocation.command === process.execPath || /\.(?:com|exe)$/i.test(invocation.command);
 }

--- a/src/command.ts
+++ b/src/command.ts
@@ -163,18 +163,23 @@ function resolveWindowsCommand(
   const extensions = (windowsEnvironmentValue(env, "PATHEXT") || ".COM;.EXE;.BAT;.CMD")
     .split(";")
     .filter(Boolean);
-  const candidates = [command, ...extensions.map((extension) => `${command}${extension}`)];
+  let unsupportedExtensionlessCommand: string | undefined;
   for (const directory of (windowsEnvironmentValue(env, "PATH") || "")
     .split(delimiter)
     .filter(Boolean)) {
-    for (const candidate of candidates) {
-      const parent = resolve(cwd, directory);
+    const parent = resolve(cwd, directory);
+    for (const candidate of extensions.map((extension) => `${command}${extension}`)) {
       const filePath = resolve(parent, candidate);
       const actualPath = actualCasePath(parent, candidate);
       if (actualPath || existsSync(filePath)) return actualPath ?? filePath;
     }
+    const extensionlessCommand = actualCasePath(parent, command) ?? resolve(parent, command);
+    if (existsSync(extensionlessCommand)) {
+      if (nodeShebangScript(extensionlessCommand)) return extensionlessCommand;
+      unsupportedExtensionlessCommand ??= extensionlessCommand;
+    }
   }
-  return undefined;
+  return unsupportedExtensionlessCommand;
 }
 
 function actualCasePath(parent: string, candidate: string): string | undefined {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2293,6 +2293,7 @@ test("Codex workflows install pinned CLI releases and keep the model secret", ()
   assert.doesNotMatch(action, /@latest/);
   assert.match(localCheck, /CLAWSWEEPER_LOCAL_CODEX_MODEL \?\? "gpt-5\.6-sol"/);
   assert.match(localCheck, /model_reasoning_effort="high"/);
+  assert.doesNotMatch(localCheck, /CLAWSWEEPER_PREFER_WINDOWS_CODEX_APP/);
   assert.doesNotMatch(localCheck, /gpt-5\.5/);
   assert.match(action, /env -u OPENAI_API_KEY[\s\S]*-u CLAWSWEEPER_INTERNAL_MODEL/);
   assert.equal(action.match(/--ignore-scripts/g)?.length, 2);

--- a/test/codex-process.test.ts
+++ b/test/codex-process.test.ts
@@ -25,10 +25,13 @@ test("Codex process resolves command overrides and escaped Windows launchers", (
   assert.equal(codexProcessCommand({}), "codex");
   assert.equal(codexProcessCommand({ CODEX_BIN: "  custom-codex  " }), "custom-codex");
   assert.equal(
-    codexProcessCommand({
-      CODEX_BIN: "custom-codex",
-      CLAWSWEEPER_PREFER_WINDOWS_CODEX_APP: "1",
-    }),
+    codexProcessCommand(
+      {
+        CODEX_BIN: "custom-codex",
+        CLAWSWEEPER_PREFER_WINDOWS_CODEX_APP: "1",
+      },
+      "win32",
+    ),
     "custom-codex",
   );
   assert.deepEqual(codexSpawnInvocation(["exec", "-"], { CODEX_BIN: "codex" }, "linux"), {
@@ -52,6 +55,7 @@ test("Codex process resolves command overrides and escaped Windows launchers", (
   const root = mkdtempSync(tmpPrefix);
   const binDir = join(root, "bin");
   mkdirSync(binDir);
+  writeFileSync(join(binDir, "codex"), "#!/bin/sh\r\n");
   writeFileSync(join(binDir, "codex.cmd"), "@echo off\r\n");
   try {
     const invocation = codexSpawnInvocation(
@@ -79,6 +83,74 @@ test("Codex process resolves command overrides and escaped Windows launchers", (
       ),
     /Unable to resolve Windows Codex command/,
   );
+});
+
+test("Windows Codex selection prefers PATH and falls back to the Desktop app", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const pathBin = join(root, "path-bin");
+  const unsupportedBin = join(root, "unsupported-bin");
+  const fallbackPathBin = join(root, "fallback-path-bin");
+  const localAppData = join(root, "local-app-data");
+  const desktopCodex = join(localAppData, "OpenAI", "Codex", "bin", "codex.exe");
+  mkdirSync(pathBin);
+  mkdirSync(unsupportedBin);
+  mkdirSync(fallbackPathBin);
+  mkdirSync(join(localAppData, "OpenAI", "Codex", "bin"), { recursive: true });
+  writeFileSync(join(pathBin, "codex.exe"), "");
+  writeFileSync(join(unsupportedBin, "codex"), "#!/bin/sh\r\n");
+  writeFileSync(join(fallbackPathBin, "codex.exe"), "");
+  writeFileSync(desktopCodex, "");
+  try {
+    const pathEnv = {
+      LOCALAPPDATA: localAppData,
+      Path: pathBin,
+      PATHEXT: ".EXE",
+      SystemRoot: String.raw`C:\Windows`,
+    };
+    const pathInvocation = codexSpawnInvocation(["exec"], pathEnv, "win32", root);
+    assert.equal(pathInvocation.command, join(pathBin, "codex.exe"));
+
+    const desktopEnv = { ...pathEnv, Path: "" };
+    assert.equal(codexProcessCommand(desktopEnv, "win32", root), desktopCodex);
+    const desktopInvocation = codexSpawnInvocation(["exec"], desktopEnv, "win32", root);
+    assert.equal(desktopInvocation.command, desktopCodex);
+
+    const unsupportedEnv = { ...pathEnv, Path: unsupportedBin };
+    assert.equal(codexProcessCommand(unsupportedEnv, "win32", root), desktopCodex);
+    const unsupportedInvocation = codexSpawnInvocation(["exec"], unsupportedEnv, "win32", root);
+    assert.equal(unsupportedInvocation.command, desktopCodex);
+
+    const laterPathEnv = { ...pathEnv, Path: `${unsupportedBin}${delimiter}${fallbackPathBin}` };
+    const laterPathInvocation = codexSpawnInvocation(["exec"], laterPathEnv, "win32", root);
+    assert.equal(laterPathInvocation.command, join(fallbackPathBin, "codex.exe"));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("Windows Codex selection resolves relative PATH entries from the launch cwd", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const launcherDir = join(root, "launcher");
+  const targetDir = join(root, "target");
+  const localAppData = join(root, "local-app-data");
+  const desktopCodex = join(localAppData, "OpenAI", "Codex", "bin", "codex.exe");
+  mkdirSync(launcherDir);
+  mkdirSync(join(targetDir, "bin"), { recursive: true });
+  mkdirSync(join(localAppData, "OpenAI", "Codex", "bin"), { recursive: true });
+  writeFileSync(join(targetDir, "bin", "codex.exe"), "");
+  writeFileSync(desktopCodex, "");
+  try {
+    const env = {
+      LOCALAPPDATA: localAppData,
+      Path: "bin",
+      PATHEXT: ".EXE",
+      SystemRoot: String.raw`C:\Windows`,
+    };
+    assert.equal(codexProcessCommand(env, "win32", launcherDir), desktopCodex);
+    assert.equal(codexProcessCommand(env, "win32", targetDir), "codex");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("Codex process resolves extensionless Windows node shebang shims", () => {

--- a/test/codex-process.test.ts
+++ b/test/codex-process.test.ts
@@ -24,6 +24,13 @@ const tmpPrefix = join(tmpdir(), "clawsweeper-codex-process-test-");
 test("Codex process resolves command overrides and escaped Windows launchers", () => {
   assert.equal(codexProcessCommand({}), "codex");
   assert.equal(codexProcessCommand({ CODEX_BIN: "  custom-codex  " }), "custom-codex");
+  assert.equal(
+    codexProcessCommand({
+      CODEX_BIN: "custom-codex",
+      CLAWSWEEPER_PREFER_WINDOWS_CODEX_APP: "1",
+    }),
+    "custom-codex",
+  );
   assert.deepEqual(codexSpawnInvocation(["exec", "-"], { CODEX_BIN: "codex" }, "linux"), {
     command: "codex",
     args: ["exec", "-"],

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -240,12 +240,14 @@ process.exit(1);
   }
 });
 
-test("local exact review labels Codex failures without a stack trace", () => {
+test("local exact review selects PATH Codex instead of the Desktop app binary", () => {
   const root = mkdtempSync(join(tmpdir(), "cmd-"));
   const origin = join(root, "origin.git");
   const targetDir = join(root, "target");
   const artifactDir = join(root, "artifacts");
   const binDir = join(root, "bin");
+  const localAppData = join(root, "local-app-data");
+  const codexMarker = join(root, "path-codex-ran.txt");
   try {
     execFileSync("git", ["init", "--bare", origin], { stdio: "ignore" });
     execFileSync("git", ["init", targetDir], { stdio: "ignore" });
@@ -324,9 +326,13 @@ process.exit(1);
     chmodSync(ghPath, 0o755);
 
     const codexPath = join(binDir, "codex");
+    const desktopCodexDir = join(localAppData, "OpenAI", "Codex", "bin");
+    mkdirSync(desktopCodexDir, { recursive: true });
+    writeFileSync(join(desktopCodexDir, "codex.exe"), "");
     writeFileSync(
       codexPath,
       `#!/usr/bin/env node
+require("node:fs").writeFileSync(${JSON.stringify(codexMarker)}, "path\\n");
 process.stdin.resume();
 process.stdin.on("end", () => process.exit(1));
 `,
@@ -350,7 +356,7 @@ process.stdin.on("end", () => process.exit(1));
         encoding: "utf8",
         env: {
           ...process.env,
-          CODEX_BIN: codexPath,
+          LOCALAPPDATA: localAppData,
           ...mockGhBinEnv(ghPath),
           PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}`,
         },
@@ -369,6 +375,7 @@ process.stdin.on("end", () => process.exit(1));
     assert.doesNotMatch(result.stderr, /Review complete/);
     assert.doesNotMatch(result.stderr, /\n\s+at /);
     assert.match(readFileSync(join(artifactDir, "96221.md"), "utf8"), /review_status: failed/);
+    assert.equal(readFileSync(codexMarker, "utf8"), "path\n");
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Use the operator-selected Codex CLI for local-only reviews and matching local preflight, while preserving a Windows Desktop Codex fallback when no runnable PATH launcher exists.

## Problem

`review --local-only` injected `CLAWSWEEPER_PREFER_WINDOWS_CODEX_APP=1`, forcing the Windows Desktop app binary at `%LOCALAPPDATA%\OpenAI\Codex\bin\codex.exe`. On the reported host that binary is stale and rejects the requested model, while the user's normal `PATH` Codex CLI works. The local preflight selected the same Desktop binary, which could validate a different executable than the review runner.

## Implementation

- Stop forcing the Desktop app binary for local-only reviews and local preflight.
- Preserve explicit `CODEX_BIN` precedence.
- On Windows, resolve in order: explicit `CODEX_BIN`, the first spawnable PATH `codex`, then the installed Desktop binary only if PATH has no runnable launcher.
- Prefer a real `PATHEXT` launcher over npm's co-located extensionless shell shim; skip unsupported shims and continue searching later PATH entries.
- Resolve relative PATH entries from the worker's actual launch directory so preflight and the review subprocess make the same selection.
- Document the ordered behavior and add focused regression coverage.

Production `.github/actions/setup-codex` remains separate and pinned at `@openai/codex` `0.139.0`; this PR does not modify it.

## Validation

- `node --test test/codex-process.test.ts test/command.test.ts test/clawsweeper.test.ts` — passed (90 tests).
- `pnpm run build:all` — passed.
- `pnpm run lint:scripts` — passed for the original local-preflight script change; the follow-up changes no scripts.
- Focused `oxfmt --check` for all changed source, documentation, and test files — passed.
- `git diff --check` — passed.
- Native Windows preflight: `pnpm run codex:local:check` — passed. It selected `C:\Windows\System32\cmd.exe ... C:\Users\marti\AppData\Roaming\npm\codex.cmd` and completed the `gpt-5.6-sol` smoke test.
- Native Windows local runner: `pnpm run review -- --local-only --target-repo openclaw/clawsweeper --target-dir <clean detached checkout> --item-number 541 --artifact-dir <temp>` — completed successfully in 3m54s with local-only artifacts only; no GitHub comment, label, or branch mutation was performed.
- `pnpm run check` previously completed build and lint, then hit unrelated native-Windows prerequisite failures in existing unit tests: unavailable WSL `/bin/bash` for Bash-helper tests, Windows symlink permissions, and `npm.cmd` `EINVAL` in runtime packaging. This PR does not broaden into test-harness or platform-policy changes.

Proof boundary: native Windows local launcher selection only; no workflow or CI-matrix changes.

## Codex review closeout

- `codex review --uncommitted` initially identified three accepted P2 edge cases: an unspawnable extensionless shim, relative PATH entries resolved from the wrong cwd, and a valid later PATH launcher shadowed by an unsupported earlier shim. Each was fixed with regression coverage.
- Final `codex review --uncommitted`: clean — no blocking correctness issues.
- `codex review --base origin/main` after commit `a6163ddff2`: clean — explicit overrides, runnable PATH selection, and Desktop fallback were all verified.

## Risks and rollout

Windows local-only review now preserves desktop-only installations while preventing a stale Desktop binary from overriding the user's working PATH CLI. The behavior is limited to local launcher selection and uses no local CLI pin or update. Production setup remains unchanged. This branch is independent of #539.
