### PR TITLE
draft: optional exact-review background-yield experiment

### DIFF
--- a/.github/workflows/commit-review.yml
+++ b/.github/workflows/commit-review.yml
@@ -64,8 +64,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 40
     concurrency:
-      # Match the broad sweep planner lock; exact-item plans use a different group.
-      group: clawsweeper-review-admission-background
+      # The shared admission lock is an opt-in experiment. With the variable
+      # unset, each commit plan keeps its current independent admission group.
+      group: ${{ vars.CLAWSWEEPER_ENABLE_EXACT_REVIEW_BACKGROUND_YIELD == '1' && 'clawsweeper-review-admission-background' || format('commit-review-plan-{0}', github.run_id) }}
       cancel-in-progress: false
       queue: max
     outputs:
@@ -173,6 +174,7 @@ jobs:
           PAGE_SIZE: ${{ vars.CLAWSWEEPER_COMMIT_REVIEW_PAGE_SIZE || '' }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           CLAWSWEEPER_EXACT_REVIEW_QUEUE_MAX_AGE_SECONDS: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_MAX_AGE_SECONDS || '900' }}
+          EXACT_REVIEW_BACKGROUND_YIELD_ENABLED: ${{ vars.CLAWSWEEPER_ENABLE_EXACT_REVIEW_BACKGROUND_YIELD || '0' }}
         run: |
           set -euo pipefail
           limit() {
@@ -405,17 +407,19 @@ jobs:
           exact_review_capacity=0
           exact_review_dispatcher_state="unknown"
           exact_review_handoff_health="unknown"
-          if exact_review_stats="$(exact_review_queue_stats)" && IFS=$'\t' read -r exact_review_pending exact_review_admissible_pending exact_review_dispatching exact_review_leased exact_review_capacity exact_review_dispatcher_state exact_review_handoff_health <<< "$exact_review_stats"; then
-            exact_review_pressure="$(pnpm --dir clawsweeper run --silent workflow -- exact-review-pressure \
-              --pending "$exact_review_pending" \
-              --admissible-pending "$exact_review_admissible_pending" \
-              --dispatching "$exact_review_dispatching" \
-              --leased "$exact_review_leased" \
-              --capacity "$exact_review_capacity" \
-              --dispatcher-state "$exact_review_dispatcher_state" \
-              --handoff-health "$exact_review_handoff_health")" || exact_review_pressure="idle"
-          else
-            echo "::warning::Exact-review queue telemetry was unavailable; using idle pressure (fail open)."
+          if [ "$EXACT_REVIEW_BACKGROUND_YIELD_ENABLED" = "1" ]; then
+            if exact_review_stats="$(exact_review_queue_stats)" && IFS=$'\t' read -r exact_review_pending exact_review_admissible_pending exact_review_dispatching exact_review_leased exact_review_capacity exact_review_dispatcher_state exact_review_handoff_health <<< "$exact_review_stats"; then
+              exact_review_pressure="$(pnpm --dir clawsweeper run --silent workflow -- exact-review-pressure \
+                --pending "$exact_review_pending" \
+                --admissible-pending "$exact_review_admissible_pending" \
+                --dispatching "$exact_review_dispatching" \
+                --leased "$exact_review_leased" \
+                --capacity "$exact_review_capacity" \
+                --dispatcher-state "$exact_review_dispatcher_state" \
+                --handoff-health "$exact_review_handoff_health")" || exact_review_pressure="idle"
+            else
+              echo "::warning::Exact-review queue telemetry was unavailable; using idle pressure (fail open)."
+            fi
           fi
           scheduler_page_size="$(pnpm --dir clawsweeper run --silent workflow -- worker-limit commit_review --active-critical "$active_critical_workers" --active-background "$active_background_workers" --exact-review-pressure "$exact_review_pressure")"
           if [ -z "$PAGE_SIZE" ]; then

--- a/.github/workflows/commit-review.yml
+++ b/.github/workflows/commit-review.yml
@@ -279,6 +279,8 @@ jobs:
               --dispatching "$exact_review_dispatching" \
               --leased "$exact_review_leased" \
               --capacity "$exact_review_capacity")" || exact_review_pressure="idle"
+          else
+            echo "::warning::Exact-review queue telemetry was unavailable; using idle pressure (fail open)."
           fi
           scheduler_page_size="$(pnpm --dir clawsweeper run --silent workflow -- worker-limit commit_review --active-critical "$active_critical_workers" --active-background "$active_background_workers" --exact-review-pressure "$exact_review_pressure")"
           if [ -z "$PAGE_SIZE" ]; then
@@ -288,7 +290,7 @@ jobs:
             PAGE_SIZE="$scheduler_page_size"
           fi
           if [ "$exact_review_pressure" != "idle" ]; then
-            echo "::notice::Exact-review queue is $exact_review_pressure (pending=$exact_review_pending, dispatching=$exact_review_dispatching, leased=$exact_review_leased, capacity=$exact_review_capacity); throttling commit review intake."
+            echo "::notice::Exact-review queue is $exact_review_pressure (pending=$exact_review_pending, dispatching=$exact_review_dispatching, leased=$exact_review_leased, capacity=$exact_review_capacity); throttling commit review intake to page_size=$PAGE_SIZE."
           fi
           page_size_hard_cap="$(pnpm --dir clawsweeper run --silent workflow -- limit commit_review.page_size_hard_cap)"
           if [ "$ENABLED" = "false" ]; then

--- a/.github/workflows/commit-review.yml
+++ b/.github/workflows/commit-review.yml
@@ -63,6 +63,11 @@ jobs:
     if: ${{ !(github.event_name == 'repository_dispatch' && github.event.client_payload.target_repo == 'openclaw/clawhub' && vars.CLAWSWEEPER_ENABLE_CLAWHUB != '1') }}
     runs-on: ubuntu-latest
     timeout-minutes: 40
+    concurrency:
+      # Match the broad sweep planner lock; exact-item plans use a different group.
+      group: clawsweeper-review-admission-background
+      cancel-in-progress: false
+      queue: max
     outputs:
       create_checks: ${{ steps.mode.outputs.create_checks }}
       enabled: ${{ steps.mode.outputs.enabled }}
@@ -160,7 +165,9 @@ jobs:
           COMMIT_SHA: ${{ github.event.inputs.commit_sha || github.event.client_payload.after_sha || github.event.client_payload.commit_sha || '' }}
           BEFORE_SHA: ${{ github.event.inputs.before_sha || github.event.client_payload.before_sha || '' }}
           COMMIT_OFFSET: ${{ github.event.inputs.commit_offset || github.event.client_payload.commit_offset || '0' }}
+          CREATE_CHECKS: ${{ steps.mode.outputs.create_checks }}
           ENABLED: ${{ steps.mode.outputs.enabled }}
+          ADDITIONAL_PROMPT: ${{ github.event.inputs.additional_prompt || github.event.client_payload.additional_prompt || '' }}
           SOURCE_REF: ${{ github.event.client_payload.ref || 'refs/heads/main' }}
           SETTLE_SECONDS: ${{ vars.CLAWSWEEPER_COMMIT_REVIEW_SETTLE_SECONDS || '60' }}
           PAGE_SIZE: ${{ vars.CLAWSWEEPER_COMMIT_REVIEW_PAGE_SIZE || '' }}
@@ -168,6 +175,17 @@ jobs:
           CLAWSWEEPER_EXACT_REVIEW_QUEUE_MAX_AGE_SECONDS: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_MAX_AGE_SECONDS || '900' }}
         run: |
           set -euo pipefail
+          limit() {
+            pnpm --dir clawsweeper run --silent workflow -- limit "$1"
+          }
+          page_size_hard_cap="$(limit commit_review.page_size_hard_cap)"
+          reservation_page_size="$PAGE_SIZE"
+          if ! [[ "$reservation_page_size" =~ ^[0-9]+$ ]] || [ "$reservation_page_size" -lt 1 ]; then
+            reservation_page_size="$(limit commit_review.page_size_default)"
+          fi
+          if [ "$reservation_page_size" -gt "$page_size_hard_cap" ]; then
+            reservation_page_size="$page_size_hard_cap"
+          fi
           active_runs_json() {
             {
               for run_status in in_progress pending queued waiting requested; do
@@ -227,11 +245,9 @@ jobs:
           }
           active_sweep_background_workers() {
             local runs total id title status jobs_json active_shards total_shards
-            local reserved_shards hard_cap requested_shards item_numbers commas item_count
             total=0
-            hard_cap="$(pnpm --dir clawsweeper run --silent workflow -- limit review_shards.hard_cap)"
             runs="$(printf '%s' "$ACTIVE_RUNS_JSON" \
-              | STALE_QUEUED_CUTOFF="$STALE_QUEUED_CUTOFF" jq -r '.[] | select(.workflowPath == ".github/workflows/sweep.yml") | select(.status == "in_progress" or ((.status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") and ((.updatedAt // .createdAt // "") >= env.STALE_QUEUED_CUTOFF))) | select(.displayTitle == "Review ClawSweeper items" or .displayTitle == "Review hot ClawSweeper items" or (.displayTitle | startswith("Review event items "))) | [.databaseId, .displayTitle, .status] | @tsv' 2>/dev/null || true)"
+              | jq -r '.[] | select(.workflowPath == ".github/workflows/sweep.yml" and .status == "in_progress") | select(.displayTitle == "Review ClawSweeper items" or .displayTitle == "Review hot ClawSweeper items" or (.displayTitle | startswith("Review target repo ")) or (.displayTitle | startswith("Review hot target repo "))) | [.databaseId, .displayTitle, .status] | @tsv' 2>/dev/null || true)"
             while IFS=$'\t' read -r id title status; do
               if [ -z "$id" ]; then
                 continue
@@ -256,30 +272,8 @@ jobs:
               # Planning, queued, and not-yet-expanded matrix runs reserve their lane
               # size. Completed matrices are publishing and consume no Codex slots.
               if [ "$active_shards" -lt 1 ] && [ "$total_shards" -lt 1 ]; then
-                if [ "$title" = "Review hot ClawSweeper items" ]; then
+                if [ "$title" = "Review hot ClawSweeper items" ] || [[ "$title" == Review\ hot\ target\ repo\ * ]]; then
                   active_shards="$(pnpm --dir clawsweeper run --silent workflow -- limit review_shards.hot_intake_default)"
-                elif [[ "$title" == Review\ event\ items\ * ]]; then
-                  reserved_shards="$hard_cap"
-                  if [[ "$title" =~ \[shards=([0-9]+)\]$ ]]; then
-                    requested_shards="${BASH_REMATCH[1]}"
-                    item_numbers="${title#*#}"
-                    item_numbers="${item_numbers%% *}"
-                    if [[ "$item_numbers" =~ ^[0-9]+(,[0-9]+)*$ ]]; then
-                      if [ "$requested_shards" -lt 1 ]; then
-                        requested_shards=1
-                      fi
-                      commas="${item_numbers//[^,]/}"
-                      item_count=$((${#commas} + 1))
-                      reserved_shards="$requested_shards"
-                      if [ "$reserved_shards" -gt "$item_count" ]; then
-                        reserved_shards="$item_count"
-                      fi
-                      if [ "$reserved_shards" -gt "$hard_cap" ]; then
-                        reserved_shards="$hard_cap"
-                      fi
-                    fi
-                  fi
-                  active_shards="$reserved_shards"
                 else
                   active_shards="$(pnpm --dir clawsweeper run --silent workflow -- limit review_shards.normal_default)"
                 fi
@@ -288,13 +282,121 @@ jobs:
             done <<< "$runs"
             printf '%s' "$total"
           }
-          active_sweep_exact_count() {
-            printf '%s' "$ACTIVE_RUNS_JSON" \
-              | STALE_QUEUED_CUTOFF="$STALE_QUEUED_CUTOFF" jq '[.[] | select(.workflowPath == ".github/workflows/sweep.yml") | select((.status == "in_progress" or ((.status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") and ((.updatedAt // .createdAt // "") >= env.STALE_QUEUED_CUTOFF))) and (.displayTitle | startswith("Review event item ")))] | length' 2>/dev/null \
-              || printf '0'
+          active_sweep_exact_workers() {
+            local runs total id title status jobs_json active_shards total_shards
+            local reserved_shards hard_cap requested_shards item_numbers commas item_count
+            total=0
+            hard_cap="$(pnpm --dir clawsweeper run --silent workflow -- limit review_shards.hard_cap)"
+            runs="$(printf '%s' "$ACTIVE_RUNS_JSON" \
+              | STALE_QUEUED_CUTOFF="$STALE_QUEUED_CUTOFF" jq -r '.[] | select(.workflowPath == ".github/workflows/sweep.yml") | select(.status == "in_progress" or ((.status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") and ((.updatedAt // .createdAt // "") >= env.STALE_QUEUED_CUTOFF))) | select((.displayTitle | startswith("Review event item ")) or (.displayTitle | startswith("Review event items "))) | [.databaseId, .displayTitle, .status] | @tsv' 2>/dev/null || true)"
+            while IFS=$'\t' read -r id title status; do
+              if [ -z "$id" ]; then
+                continue
+              fi
+              active_shards=0
+              total_shards=0
+              if [[ "$title" == Review\ event\ item\ * ]]; then
+                total=$((total + 1))
+                continue
+              fi
+              if [ "$status" = "in_progress" ]; then
+                jobs_json="$(gh run view "$id" --repo "${{ github.repository }}" --json jobs 2>/dev/null || printf '{"jobs":[]}')"
+                active_shards="$(printf '%s' "$jobs_json" \
+                  | jq '[.jobs[]? | select(.name | startswith("Review shard ")) | select(.status == "in_progress" or .status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested")] | length' 2>/dev/null \
+                  || printf '0')"
+                total_shards="$(printf '%s' "$jobs_json" \
+                  | jq '[.jobs[]? | select(.name | startswith("Review shard "))] | length' 2>/dev/null \
+                  || printf '0')"
+              fi
+              if ! [[ "$active_shards" =~ ^[0-9]+$ ]]; then
+                active_shards=0
+              fi
+              if ! [[ "$total_shards" =~ ^[0-9]+$ ]]; then
+                total_shards=0
+              fi
+              # Explicit exact batches are priority work. Reserve the batch shape
+              # until its matrix exists, then account only for live shard jobs.
+              if [ "$active_shards" -lt 1 ] && [ "$total_shards" -lt 1 ]; then
+                reserved_shards="$hard_cap"
+                if [[ "$title" =~ \[shards=([0-9]+)\]$ ]]; then
+                  requested_shards="${BASH_REMATCH[1]}"
+                  item_numbers="${title#*#}"
+                  item_numbers="${item_numbers%% *}"
+                  if [[ "$item_numbers" =~ ^[0-9]+(,[0-9]+)*$ ]]; then
+                    if [ "$requested_shards" -lt 1 ]; then
+                      requested_shards=1
+                    fi
+                    commas="${item_numbers//[^,]/}"
+                    item_count=$((${#commas} + 1))
+                    reserved_shards="$requested_shards"
+                    if [ "$reserved_shards" -gt "$item_count" ]; then
+                      reserved_shards="$item_count"
+                    fi
+                    if [ "$reserved_shards" -gt "$hard_cap" ]; then
+                      reserved_shards="$hard_cap"
+                    fi
+                  fi
+                fi
+                active_shards="$reserved_shards"
+              fi
+              total=$((total + active_shards))
+            done <<< "$runs"
+            printf '%s' "$total"
           }
-          active_critical_workers="$(( $(active_run_count ".github/workflows/repair-cluster-worker.yml") + $(active_sweep_exact_count) ))"
-          active_background_workers="$(active_sweep_background_workers)"
+          active_commit_review_workers() {
+            local runs total id status jobs_json active_reviews total_reviews zero_review_plan zero_review_name
+            total=0
+            runs="$(printf '%s' "$ACTIVE_RUNS_JSON" \
+              | CURRENT_RUN_ID="${GITHUB_RUN_ID:-0}" jq -r '.[] | select((.databaseId | tostring) != env.CURRENT_RUN_ID) | select(.workflowPath == ".github/workflows/commit-review.yml" and .status == "in_progress") | [.databaseId, .status] | @tsv' 2>/dev/null || true)"
+            while IFS=$'\t' read -r id status; do
+              if [ -z "$id" ]; then
+                continue
+              fi
+              active_reviews=0
+              total_reviews=0
+              zero_review_plan=false
+              if [ "$status" = "in_progress" ]; then
+                if ! jobs_json="$(gh run view "$id" --repo "${{ github.repository }}" --json jobs 2>/dev/null)"; then
+                  # An unavailable job list cannot identify a completed zero
+                  # matrix, so retain the conservative planner reservation.
+                  jobs_json='{"jobs":[]}'
+                fi
+                active_reviews="$(printf '%s' "$jobs_json" \
+                  | jq '[.jobs[]? | select(.name | startswith("Review commit ")) | select(.status == "in_progress" or .status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested")] | length' 2>/dev/null \
+                  || printf '0')"
+                total_reviews="$(printf '%s' "$jobs_json" \
+                  | jq '[.jobs[]? | select(.name | startswith("Review commit "))] | length' 2>/dev/null \
+                  || printf '0')"
+                # GitHub represents an empty dynamic matrix as this literal,
+                # skipped job. Construct the name in Bash so Actions does not
+                # evaluate the literal matrix expression in this plan job.
+                zero_review_name='Review commit $'
+                zero_review_name+='{{ matrix.sha }}'
+                if printf '%s' "$jobs_json" | ZERO_REVIEW_NAME="$zero_review_name" \
+                  jq -e '[.jobs[]? | select(.name == env.ZERO_REVIEW_NAME) | select(.status == "completed" and .conclusion == "skipped")] | length > 0' >/dev/null 2>&1; then
+                  zero_review_plan=true
+                fi
+              fi
+              if ! [[ "$active_reviews" =~ ^[0-9]+$ ]]; then
+                active_reviews=0
+              fi
+              if ! [[ "$total_reviews" =~ ^[0-9]+$ ]]; then
+                total_reviews=0
+              fi
+              # An absent review job is either a queued/planning run or a matrix
+              # that GitHub is still materializing, so reserve its configured,
+              # hard-capped page size. The literal skipped job above proves an
+              # empty matrix and releases the reservation while it publishes.
+              if [ "$active_reviews" -lt 1 ] && [ "$total_reviews" -lt 1 ] \
+                && [ "$zero_review_plan" != "true" ]; then
+                active_reviews="$reservation_page_size"
+              fi
+              total=$((total + active_reviews))
+            done <<< "$runs"
+            printf '%s' "$total"
+          }
+          active_critical_workers="$(( $(active_run_count ".github/workflows/repair-cluster-worker.yml") + $(active_sweep_exact_workers) ))"
+          active_background_workers="$(( $(active_sweep_background_workers) + $(active_commit_review_workers) ))"
           exact_review_pressure="idle"
           exact_review_pending=0
           exact_review_admissible_pending=0
@@ -325,7 +427,6 @@ jobs:
           if [ "$exact_review_pressure" != "idle" ]; then
             echo "::notice::Exact-review queue is $exact_review_pressure (pending=$exact_review_pending, admissible_pending=$exact_review_admissible_pending, dispatching=$exact_review_dispatching, leased=$exact_review_leased, capacity=$exact_review_capacity, dispatcher=$exact_review_dispatcher_state, handoff=$exact_review_handoff_health); throttling commit review intake to page_size=$PAGE_SIZE."
           fi
-          page_size_hard_cap="$(pnpm --dir clawsweeper run --silent workflow -- limit commit_review.page_size_hard_cap)"
           if [ "$ENABLED" = "false" ]; then
             {
               echo "matrix=[]"
@@ -365,6 +466,42 @@ jobs:
             exit 1
           fi
           if [ "$PAGE_SIZE" -lt 1 ]; then
+            if [ "$exact_review_pressure" != "idle" ]; then
+              echo "::notice::Deferring commit review because the exact-review pressure cap is occupied."
+              # Keep this plan job in the shared admission group while it waits,
+              # then requeue the same range instead of treating it as exhausted.
+              sleep 300
+              requeued=false
+              for attempt in 1 2 3; do
+                if gh workflow run commit-review.yml \
+                  --repo "${{ github.repository }}" \
+                  -f enabled=true \
+                  -f target_repo="$TARGET_REPO" \
+                  -f commit_sha="$COMMIT_SHA" \
+                  -f before_sha="$BEFORE_SHA" \
+                  -f commit_offset="$COMMIT_OFFSET" \
+                  -f create_checks="$CREATE_CHECKS" \
+                  -f additional_prompt="$ADDITIONAL_PROMPT"; then
+                  requeued=true
+                  break
+                fi
+                echo "::warning::Deferred commit-review requeue attempt $attempt failed."
+                sleep "$((attempt * 10))"
+              done
+              if [ "$requeued" != "true" ]; then
+                echo "Unable to requeue the deferred commit-review range after three attempts." >&2
+                exit 1
+              fi
+              echo "::notice::Requeued deferred commit-review range at offset $COMMIT_OFFSET."
+              {
+                echo "matrix=[]"
+                echo "has_more=false"
+                echo "next_offset=0"
+                echo "planned_count=0"
+                echo "skipped_count=0"
+              } >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
             PAGE_SIZE=1
           fi
           if [ "$PAGE_SIZE" -gt "$page_size_hard_cap" ]; then

--- a/.github/workflows/commit-review.yml
+++ b/.github/workflows/commit-review.yml
@@ -165,6 +165,7 @@ jobs:
           SETTLE_SECONDS: ${{ vars.CLAWSWEEPER_COMMIT_REVIEW_SETTLE_SECONDS || '60' }}
           PAGE_SIZE: ${{ vars.CLAWSWEEPER_COMMIT_REVIEW_PAGE_SIZE || '' }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          CLAWSWEEPER_EXACT_REVIEW_QUEUE_MAX_AGE_SECONDS: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_MAX_AGE_SECONDS || '900' }}
         run: |
           set -euo pipefail
           active_runs_json() {
@@ -185,9 +186,32 @@ jobs:
               || printf '0'
           }
           exact_review_queue_stats() {
-            local queue_url response
+            local queue_url response generated_at generated_epoch now_epoch queue_max_age_seconds age_seconds
             queue_url="${QUEUE_URL%/}"
             response="$(curl --fail --silent --connect-timeout 5 --max-time 10 "$queue_url/api/status" 2>/dev/null)" || return 1
+            generated_at="$(printf '%s' "$response" | jq -r '.exact_review_queue.generated_at // "" | if type == "string" then . else "" end' 2>/dev/null)" || return 1
+            if [ -z "$generated_at" ]; then
+              echo "::warning::Exact-review queue telemetry missing exact_review_queue.generated_at; using idle pressure (fail open)." >&2
+              return 1
+            fi
+            if ! generated_epoch="$(date -u -d "$generated_at" '+%s' 2>/dev/null)"; then
+              echo "::warning::Exact-review queue telemetry has invalid generated_at; using idle pressure (fail open)." >&2
+              return 1
+            fi
+            now_epoch="$(date -u '+%s')"
+            queue_max_age_seconds="${CLAWSWEEPER_EXACT_REVIEW_QUEUE_MAX_AGE_SECONDS:-900}"
+            if ! [[ "$queue_max_age_seconds" =~ ^[0-9]+$ ]] || [ "$queue_max_age_seconds" -lt 60 ]; then
+              queue_max_age_seconds=900
+            fi
+            age_seconds=$((now_epoch - generated_epoch))
+            if [ "$age_seconds" -gt "$queue_max_age_seconds" ]; then
+              echo "::warning::Exact-review queue telemetry snapshot is stale (generated_at=$generated_at, age_seconds=$age_seconds); using idle pressure (fail open)." >&2
+              return 1
+            fi
+            if [ "$age_seconds" -lt -300 ]; then
+              echo "::warning::Exact-review queue telemetry generated_at is too far in the future (generated_at=$generated_at); using idle pressure (fail open)." >&2
+              return 1
+            fi
             printf '%s' "$response" | jq -r '
               def count: if type == "number" and . >= 0 then floor else 0 end;
               [

--- a/.github/workflows/commit-review.yml
+++ b/.github/workflows/commit-review.yml
@@ -164,6 +164,7 @@ jobs:
           SOURCE_REF: ${{ github.event.client_payload.ref || 'refs/heads/main' }}
           SETTLE_SECONDS: ${{ vars.CLAWSWEEPER_COMMIT_REVIEW_SETTLE_SECONDS || '60' }}
           PAGE_SIZE: ${{ vars.CLAWSWEEPER_COMMIT_REVIEW_PAGE_SIZE || '' }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
         run: |
           set -euo pipefail
           active_runs_json() {
@@ -182,6 +183,20 @@ jobs:
             printf '%s' "$ACTIVE_RUNS_JSON" \
               | WORKFLOW_PATH="$1" STALE_QUEUED_CUTOFF="$STALE_QUEUED_CUTOFF" jq '[.[] | select(.workflowPath == env.WORKFLOW_PATH) | select(.status == "in_progress" or ((.status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") and ((.updatedAt // .createdAt // "") >= env.STALE_QUEUED_CUTOFF)))] | length' 2>/dev/null \
               || printf '0'
+          }
+          exact_review_queue_stats() {
+            local queue_url response
+            queue_url="${QUEUE_URL%/}"
+            response="$(curl --fail --silent --connect-timeout 5 --max-time 10 "$queue_url/api/status" 2>/dev/null)" || return 1
+            printf '%s' "$response" | jq -r '
+              def count: if type == "number" and . >= 0 then floor else 0 end;
+              [
+                (.exact_review_queue.pending // 0 | count),
+                (.exact_review_queue.dispatching // 0 | count),
+                (.exact_review_queue.leased // 0 | count),
+                (.exact_review_queue.handoff_health.capacity // 0 | count)
+              ] | @tsv
+            ' 2>/dev/null
           }
           active_sweep_background_workers() {
             local runs total id title status jobs_json active_shards total_shards
@@ -251,10 +266,29 @@ jobs:
               | STALE_QUEUED_CUTOFF="$STALE_QUEUED_CUTOFF" jq '[.[] | select(.workflowPath == ".github/workflows/sweep.yml") | select((.status == "in_progress" or ((.status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") and ((.updatedAt // .createdAt // "") >= env.STALE_QUEUED_CUTOFF))) and (.displayTitle | startswith("Review event item ")))] | length' 2>/dev/null \
               || printf '0'
           }
+          active_critical_workers="$(( $(active_run_count ".github/workflows/repair-cluster-worker.yml") + $(active_sweep_exact_count) ))"
+          active_background_workers="$(active_sweep_background_workers)"
+          exact_review_pressure="idle"
+          exact_review_pending=0
+          exact_review_dispatching=0
+          exact_review_leased=0
+          exact_review_capacity=0
+          if exact_review_stats="$(exact_review_queue_stats)" && IFS=$'\t' read -r exact_review_pending exact_review_dispatching exact_review_leased exact_review_capacity <<< "$exact_review_stats"; then
+            exact_review_pressure="$(pnpm --dir clawsweeper run --silent workflow -- exact-review-pressure \
+              --pending "$exact_review_pending" \
+              --dispatching "$exact_review_dispatching" \
+              --leased "$exact_review_leased" \
+              --capacity "$exact_review_capacity")" || exact_review_pressure="idle"
+          fi
+          scheduler_page_size="$(pnpm --dir clawsweeper run --silent workflow -- worker-limit commit_review --active-critical "$active_critical_workers" --active-background "$active_background_workers" --exact-review-pressure "$exact_review_pressure")"
           if [ -z "$PAGE_SIZE" ]; then
-            active_critical_workers="$(( $(active_run_count ".github/workflows/repair-cluster-worker.yml") + $(active_sweep_exact_count) ))"
-            active_background_workers="$(active_sweep_background_workers)"
-            PAGE_SIZE="$(pnpm --dir clawsweeper run --silent workflow -- worker-limit commit_review --active-critical "$active_critical_workers" --active-background "$active_background_workers")"
+            PAGE_SIZE="$scheduler_page_size"
+          elif [ "$exact_review_pressure" != "idle" ] && [[ "$PAGE_SIZE" =~ ^[0-9]+$ ]] && [ "$PAGE_SIZE" -gt "$scheduler_page_size" ]; then
+            echo "::notice::Capping commit-review page size from $PAGE_SIZE to $scheduler_page_size because exact-review queue is $exact_review_pressure."
+            PAGE_SIZE="$scheduler_page_size"
+          fi
+          if [ "$exact_review_pressure" != "idle" ]; then
+            echo "::notice::Exact-review queue is $exact_review_pressure (pending=$exact_review_pending, dispatching=$exact_review_dispatching, leased=$exact_review_leased, capacity=$exact_review_capacity); throttling commit review intake."
           fi
           page_size_hard_cap="$(pnpm --dir clawsweeper run --silent workflow -- limit commit_review.page_size_hard_cap)"
           if [ "$ENABLED" = "false" ]; then

--- a/.github/workflows/commit-review.yml
+++ b/.github/workflows/commit-review.yml
@@ -192,9 +192,12 @@ jobs:
               def count: if type == "number" and . >= 0 then floor else 0 end;
               [
                 (.exact_review_queue.pending // 0 | count),
+                (.exact_review_queue.admissible_pending // 0 | count),
                 (.exact_review_queue.dispatching // 0 | count),
                 (.exact_review_queue.leased // 0 | count),
-                (.exact_review_queue.handoff_health.capacity // 0 | count)
+                (.exact_review_queue.handoff_health.capacity // 0 | count),
+                (.exact_review_queue.dispatcher.state // "" | if type == "string" then . else "" end),
+                (.exact_review_queue.handoff_health.status // "" | if type == "string" then . else "" end)
               ] | @tsv
             ' 2>/dev/null
           }
@@ -270,15 +273,21 @@ jobs:
           active_background_workers="$(active_sweep_background_workers)"
           exact_review_pressure="idle"
           exact_review_pending=0
+          exact_review_admissible_pending=0
           exact_review_dispatching=0
           exact_review_leased=0
           exact_review_capacity=0
-          if exact_review_stats="$(exact_review_queue_stats)" && IFS=$'\t' read -r exact_review_pending exact_review_dispatching exact_review_leased exact_review_capacity <<< "$exact_review_stats"; then
+          exact_review_dispatcher_state="unknown"
+          exact_review_handoff_health="unknown"
+          if exact_review_stats="$(exact_review_queue_stats)" && IFS=$'\t' read -r exact_review_pending exact_review_admissible_pending exact_review_dispatching exact_review_leased exact_review_capacity exact_review_dispatcher_state exact_review_handoff_health <<< "$exact_review_stats"; then
             exact_review_pressure="$(pnpm --dir clawsweeper run --silent workflow -- exact-review-pressure \
               --pending "$exact_review_pending" \
+              --admissible-pending "$exact_review_admissible_pending" \
               --dispatching "$exact_review_dispatching" \
               --leased "$exact_review_leased" \
-              --capacity "$exact_review_capacity")" || exact_review_pressure="idle"
+              --capacity "$exact_review_capacity" \
+              --dispatcher-state "$exact_review_dispatcher_state" \
+              --handoff-health "$exact_review_handoff_health")" || exact_review_pressure="idle"
           else
             echo "::warning::Exact-review queue telemetry was unavailable; using idle pressure (fail open)."
           fi
@@ -290,7 +299,7 @@ jobs:
             PAGE_SIZE="$scheduler_page_size"
           fi
           if [ "$exact_review_pressure" != "idle" ]; then
-            echo "::notice::Exact-review queue is $exact_review_pressure (pending=$exact_review_pending, dispatching=$exact_review_dispatching, leased=$exact_review_leased, capacity=$exact_review_capacity); throttling commit review intake to page_size=$PAGE_SIZE."
+            echo "::notice::Exact-review queue is $exact_review_pressure (pending=$exact_review_pending, admissible_pending=$exact_review_admissible_pending, dispatching=$exact_review_dispatching, leased=$exact_review_leased, capacity=$exact_review_capacity, dispatcher=$exact_review_dispatcher_state, handoff=$exact_review_handoff_health); throttling commit review intake to page_size=$PAGE_SIZE."
           fi
           page_size_hard_cap="$(pnpm --dir clawsweeper run --silent workflow -- limit commit_review.page_size_hard_cap)"
           if [ "$ENABLED" = "false" ]; then

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1550,12 +1550,27 @@ jobs:
       - id: mode
         env:
           GH_TOKEN: ${{ github.token }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
         run: |
           limit() {
             pnpm --dir clawsweeper run --silent workflow -- limit "$1"
           }
           worker_limit() {
             pnpm --dir clawsweeper run --silent workflow -- worker-limit "$@"
+          }
+          exact_review_queue_stats() {
+            local queue_url response
+            queue_url="${QUEUE_URL%/}"
+            response="$(curl --fail --silent --connect-timeout 5 --max-time 10 "$queue_url/api/status" 2>/dev/null)" || return 1
+            printf '%s' "$response" | jq -r '
+              def count: if type == "number" and . >= 0 then floor else 0 end;
+              [
+                (.exact_review_queue.pending // 0 | count),
+                (.exact_review_queue.dispatching // 0 | count),
+                (.exact_review_queue.leased // 0 | count),
+                (.exact_review_queue.handoff_health.capacity // 0 | count)
+              ] | @tsv
+            ' 2>/dev/null
           }
           active_runs_json() {
             {
@@ -1684,10 +1699,25 @@ jobs:
           normal_active_floor="$(limit review_shards.normal_active_floor)"
           hard_shard_cap="$(limit review_shards.hard_cap)"
           commit_page_size="$(limit commit_review.page_size_default)"
+          exact_review_pressure="idle"
+          exact_review_pending=0
+          exact_review_dispatching=0
+          exact_review_leased=0
+          exact_review_capacity=0
+          if exact_review_stats="$(exact_review_queue_stats)" && IFS=$'\t' read -r exact_review_pending exact_review_dispatching exact_review_leased exact_review_capacity <<< "$exact_review_stats"; then
+            exact_review_pressure="$(pnpm --dir clawsweeper run --silent workflow -- exact-review-pressure \
+              --pending "$exact_review_pending" \
+              --dispatching "$exact_review_dispatching" \
+              --leased "$exact_review_leased" \
+              --capacity "$exact_review_capacity")" || exact_review_pressure="idle"
+          fi
           active_critical_workers="$(( $(active_run_count ".github/workflows/repair-cluster-worker.yml") + $(active_sweep_exact_workers) ))"
           active_background_workers="$(( $(active_run_count ".github/workflows/commit-review.yml") * commit_page_size + $(active_sweep_background_workers) ))"
-          hot_intake_shards="$(worker_limit hot_intake --active-critical "$active_critical_workers" --active-background "$active_background_workers")"
-          normal_shards="$(worker_limit normal_review --active-critical "$active_critical_workers" --active-background "$active_background_workers")"
+          hot_intake_shards="$(worker_limit hot_intake --active-critical "$active_critical_workers" --active-background "$active_background_workers" --exact-review-pressure "$exact_review_pressure")"
+          normal_shards="$(worker_limit normal_review --active-critical "$active_critical_workers" --active-background "$active_background_workers" --exact-review-pressure "$exact_review_pressure")"
+          if [ "$exact_review_pressure" != "idle" ]; then
+            echo "::notice::Exact-review queue is $exact_review_pressure (pending=$exact_review_pending, dispatching=$exact_review_dispatching, leased=$exact_review_leased, capacity=$exact_review_capacity); throttling broad review intake."
+          fi
           hot_intake="${{ ((github.event_name == 'repository_dispatch' && github.event.client_payload.hot_intake == 'true') || (github.event_name == 'workflow_dispatch' && github.event.inputs.hot_intake == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '*/5 * * * *' || github.event.schedule == '2/5 * * * *'))) && 'true' || 'false' }}"
           exact_item="${{ github.event.client_payload.item_number || github.event.inputs.item_number || github.event.inputs.item_numbers || '' }}"
           target_repo="${{ steps.target.outputs.target_repo }}"

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1435,8 +1435,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     concurrency:
-      group: ${{ format('clawsweeper-planner-{0}', (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.item_number == '' && github.event.inputs.item_numbers == '')) && (github.event.inputs.target_repo || ((github.event.schedule == '2/5 * * * *' || github.event.schedule == '22 * * * *') && 'openclaw/clawhub' || 'openclaw/openclaw')) || github.run_id) }}
+      # Broad sweep and commit-review plans share this global admission lock.
+      # Exact items use an individual run group and remain independently admitted.
+      group: ${{ format('clawsweeper-review-admission-{0}', (github.event.client_payload.item_number || github.event.client_payload.item_numbers || github.event.inputs.item_number || github.event.inputs.item_numbers) && github.run_id || 'background') }}
       cancel-in-progress: false
+      queue: max
     outputs:
       batch_size: ${{ steps.mode.outputs.batch_size }}
       codex_timeout_ms: ${{ steps.mode.outputs.codex_timeout_ms }}
@@ -1550,6 +1553,7 @@ jobs:
       - id: mode
         env:
           GH_TOKEN: ${{ github.token }}
+          COMMIT_REVIEW_PAGE_SIZE: ${{ vars.CLAWSWEEPER_COMMIT_REVIEW_PAGE_SIZE || '' }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           CLAWSWEEPER_EXACT_REVIEW_QUEUE_MAX_AGE_SECONDS: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_MAX_AGE_SECONDS || '900' }}
         run: |
@@ -1686,7 +1690,7 @@ jobs:
             local runs total id title status jobs_json active_shards total_shards
             total=0
             runs="$(printf '%s' "$ACTIVE_RUNS_JSON" \
-              | CURRENT_RUN_ID="${GITHUB_RUN_ID:-0}" STALE_QUEUED_CUTOFF="$STALE_QUEUED_CUTOFF" jq -r '.[] | select((.databaseId | tostring) != env.CURRENT_RUN_ID) | select(.workflowPath == ".github/workflows/sweep.yml") | select(.status == "in_progress" or ((.status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") and ((.updatedAt // .createdAt // "") >= env.STALE_QUEUED_CUTOFF))) | select(.displayTitle == "Review ClawSweeper items" or .displayTitle == "Review hot ClawSweeper items" or (.displayTitle | startswith("Review target repo ")) or (.displayTitle | startswith("Review hot target repo "))) | [.databaseId, .displayTitle, .status] | @tsv' 2>/dev/null || true)"
+              | CURRENT_RUN_ID="${GITHUB_RUN_ID:-0}" jq -r '.[] | select((.databaseId | tostring) != env.CURRENT_RUN_ID) | select(.workflowPath == ".github/workflows/sweep.yml") | select(.status == "in_progress") | select(.displayTitle == "Review ClawSweeper items" or .displayTitle == "Review hot ClawSweeper items" or (.displayTitle | startswith("Review target repo ")) or (.displayTitle | startswith("Review hot target repo "))) | [.databaseId, .displayTitle, .status] | @tsv' 2>/dev/null || true)"
             while IFS=$'\t' read -r id title status; do
               if [ -z "$id" ]; then
                 continue
@@ -1722,10 +1726,61 @@ jobs:
             done <<< "$runs"
             printf '%s' "$total"
           }
+          active_commit_review_workers() {
+            local runs total id jobs_json active_reviews total_reviews zero_review_plan zero_review_name
+            local reservation_page_size page_size_hard_cap
+            total=0
+            page_size_hard_cap="$(limit commit_review.page_size_hard_cap)"
+            reservation_page_size="${COMMIT_REVIEW_PAGE_SIZE:-}"
+            if ! [[ "$reservation_page_size" =~ ^[0-9]+$ ]] || [ "$reservation_page_size" -lt 1 ]; then
+              reservation_page_size="$(limit commit_review.page_size_default)"
+            fi
+            if [ "$reservation_page_size" -gt "$page_size_hard_cap" ]; then
+              reservation_page_size="$page_size_hard_cap"
+            fi
+            runs="$(printf '%s' "$ACTIVE_RUNS_JSON" \
+              | CURRENT_RUN_ID="${GITHUB_RUN_ID:-0}" jq -r '.[] | select((.databaseId | tostring) != env.CURRENT_RUN_ID) | select(.workflowPath == ".github/workflows/commit-review.yml" and .status == "in_progress") | .databaseId' 2>/dev/null || true)"
+            while IFS= read -r id; do
+              if [ -z "$id" ]; then
+                continue
+              fi
+              jobs_json="$(gh run view "$id" --repo "${{ github.repository }}" --json jobs 2>/dev/null || printf '{"jobs":[]}')"
+              total_reviews="$(printf '%s' "$jobs_json" \
+                | jq '[.jobs[]? | select(.name | startswith("Review commit "))] | length' 2>/dev/null \
+                || printf '0')"
+              active_reviews="$(printf '%s' "$jobs_json" \
+                | jq '[.jobs[]? | select(.name | startswith("Review commit ")) | select(.status == "in_progress" or .status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested")] | length' 2>/dev/null \
+                || printf '0')"
+              zero_review_plan=false
+              # A skipped dynamic-matrix job proves this run planned no review
+              # workers, so its publishing phase should not reserve capacity.
+              zero_review_name='Review commit $'
+              zero_review_name+='{{ matrix.sha }}'
+              if printf '%s' "$jobs_json" | ZERO_REVIEW_NAME="$zero_review_name" \
+                jq -e '[.jobs[]? | select(.name == env.ZERO_REVIEW_NAME) | select(.status == "completed" and .conclusion == "skipped")] | length > 0' >/dev/null 2>&1; then
+                zero_review_plan=true
+              fi
+              if ! [[ "$active_reviews" =~ ^[0-9]+$ ]]; then
+                active_reviews=0
+              fi
+              if ! [[ "$total_reviews" =~ ^[0-9]+$ ]]; then
+                total_reviews=0
+              fi
+              # Between plan completion and matrix materialization, reserve the
+              # configured page size so the next serialized broad planner cannot
+              # claim the same pressure allowance. Queued whole workflows are
+              # excluded above; only an in-progress planner can reserve here.
+              if [ "$active_reviews" -lt 1 ] && [ "$total_reviews" -lt 1 ] \
+                && [ "$zero_review_plan" != "true" ]; then
+                active_reviews="$reservation_page_size"
+              fi
+              total=$((total + active_reviews))
+            done <<< "$runs"
+            printf '%s' "$total"
+          }
           exact_item_shards="$(limit review_shards.exact_item_default)"
           normal_active_floor="$(limit review_shards.normal_active_floor)"
           hard_shard_cap="$(limit review_shards.hard_cap)"
-          commit_page_size="$(limit commit_review.page_size_default)"
           exact_review_pressure="idle"
           exact_review_pending=0
           exact_review_admissible_pending=0
@@ -1747,7 +1802,7 @@ jobs:
             echo "::warning::Exact-review queue telemetry was unavailable; using idle pressure (fail open)."
           fi
           active_critical_workers="$(( $(active_run_count ".github/workflows/repair-cluster-worker.yml") + $(active_sweep_exact_workers) ))"
-          active_background_workers="$(( $(active_run_count ".github/workflows/commit-review.yml") * commit_page_size + $(active_sweep_background_workers) ))"
+          active_background_workers="$(( $(active_commit_review_workers) + $(active_sweep_background_workers) ))"
           hot_intake_shards="$(worker_limit hot_intake --active-critical "$active_critical_workers" --active-background "$active_background_workers" --exact-review-pressure "$exact_review_pressure")"
           normal_shards="$(worker_limit normal_review --active-critical "$active_critical_workers" --active-background "$active_background_workers" --exact-review-pressure "$exact_review_pressure")"
           if [ "$exact_review_pressure" != "idle" ]; then
@@ -1802,10 +1857,13 @@ jobs:
             if [ "$hot_intake" = "true" ]; then
               lane_shard_cap="$hot_intake_shards"
             fi
-            if ! [[ "$lane_shard_cap" =~ ^[0-9]+$ ]] || [ "$lane_shard_cap" -lt 1 ]; then
-              lane_shard_cap="1"
+            if ! [[ "$lane_shard_cap" =~ ^[0-9]+$ ]]; then
+              lane_shard_cap="0"
             fi
-            if [ "$shard_count" -gt "$lane_shard_cap" ]; then
+            if [ "$lane_shard_cap" -lt 1 ]; then
+              echo "::notice::Deferring broad background review because the exact-review pressure cap is occupied."
+              shard_count="0"
+            elif [ "$shard_count" -gt "$lane_shard_cap" ]; then
               echo "::notice::Capping broad background review shards from $shard_count to scheduler allowance $lane_shard_cap."
               shard_count="$lane_shard_cap"
             fi
@@ -1837,6 +1895,19 @@ jobs:
           GH_TOKEN: ${{ steps.target-read-token.outputs.token || github.token }}
         run: |
           set -euo pipefail
+          if ! [[ "$SHARD_COUNT" =~ ^[0-9]+$ ]]; then
+            echo "Invalid review shard count: $SHARD_COUNT" >&2
+            exit 1
+          fi
+          if [ "$SHARD_COUNT" -lt 1 ]; then
+            echo "::notice::Deferring broad review planning because the exact-review pressure cap is occupied."
+            printf '%s\n' '{"matrix":[],"candidates":[],"capacity":0,"activeCodexTarget":0,"dueBacklog":0,"capacityReason":"deferred: exact-review background cap occupied"}' > plan.json
+            pnpm run --silent workflow -- plan-output \
+              --plan plan.json \
+              --batch-size "$BATCH_SIZE" \
+              --shard-count 1 >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           item_arg=()
           if [ -n "$ITEM_NUMBER" ]; then
             item_arg=(--item-number "$ITEM_NUMBER")

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1710,13 +1710,15 @@ jobs:
               --dispatching "$exact_review_dispatching" \
               --leased "$exact_review_leased" \
               --capacity "$exact_review_capacity")" || exact_review_pressure="idle"
+          else
+            echo "::warning::Exact-review queue telemetry was unavailable; using idle pressure (fail open)."
           fi
           active_critical_workers="$(( $(active_run_count ".github/workflows/repair-cluster-worker.yml") + $(active_sweep_exact_workers) ))"
           active_background_workers="$(( $(active_run_count ".github/workflows/commit-review.yml") * commit_page_size + $(active_sweep_background_workers) ))"
           hot_intake_shards="$(worker_limit hot_intake --active-critical "$active_critical_workers" --active-background "$active_background_workers" --exact-review-pressure "$exact_review_pressure")"
           normal_shards="$(worker_limit normal_review --active-critical "$active_critical_workers" --active-background "$active_background_workers" --exact-review-pressure "$exact_review_pressure")"
           if [ "$exact_review_pressure" != "idle" ]; then
-            echo "::notice::Exact-review queue is $exact_review_pressure (pending=$exact_review_pending, dispatching=$exact_review_dispatching, leased=$exact_review_leased, capacity=$exact_review_capacity); throttling broad review intake."
+            echo "::notice::Exact-review queue is $exact_review_pressure (pending=$exact_review_pending, dispatching=$exact_review_dispatching, leased=$exact_review_leased, capacity=$exact_review_capacity); throttling broad review intake to normal=$normal_shards and hot=$hot_intake_shards."
           fi
           hot_intake="${{ ((github.event_name == 'repository_dispatch' && github.event.client_payload.hot_intake == 'true') || (github.event_name == 'workflow_dispatch' && github.event.inputs.hot_intake == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '*/5 * * * *' || github.event.schedule == '2/5 * * * *'))) && 'true' || 'false' }}"
           exact_item="${{ github.event.client_payload.item_number || github.event.inputs.item_number || github.event.inputs.item_numbers || '' }}"

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1551,6 +1551,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          CLAWSWEEPER_EXACT_REVIEW_QUEUE_MAX_AGE_SECONDS: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_MAX_AGE_SECONDS || '900' }}
         run: |
           limit() {
             pnpm --dir clawsweeper run --silent workflow -- limit "$1"
@@ -1559,9 +1560,32 @@ jobs:
             pnpm --dir clawsweeper run --silent workflow -- worker-limit "$@"
           }
           exact_review_queue_stats() {
-            local queue_url response
+            local queue_url response generated_at generated_epoch now_epoch queue_max_age_seconds age_seconds
             queue_url="${QUEUE_URL%/}"
             response="$(curl --fail --silent --connect-timeout 5 --max-time 10 "$queue_url/api/status" 2>/dev/null)" || return 1
+            generated_at="$(printf '%s' "$response" | jq -r '.exact_review_queue.generated_at // "" | if type == "string" then . else "" end' 2>/dev/null)" || return 1
+            if [ -z "$generated_at" ]; then
+              echo "::warning::Exact-review queue telemetry missing exact_review_queue.generated_at; using idle pressure (fail open)." >&2
+              return 1
+            fi
+            if ! generated_epoch="$(date -u -d "$generated_at" '+%s' 2>/dev/null)"; then
+              echo "::warning::Exact-review queue telemetry has invalid generated_at; using idle pressure (fail open)." >&2
+              return 1
+            fi
+            now_epoch="$(date -u '+%s')"
+            queue_max_age_seconds="${CLAWSWEEPER_EXACT_REVIEW_QUEUE_MAX_AGE_SECONDS:-900}"
+            if ! [[ "$queue_max_age_seconds" =~ ^[0-9]+$ ]] || [ "$queue_max_age_seconds" -lt 60 ]; then
+              queue_max_age_seconds=900
+            fi
+            age_seconds=$((now_epoch - generated_epoch))
+            if [ "$age_seconds" -gt "$queue_max_age_seconds" ]; then
+              echo "::warning::Exact-review queue telemetry snapshot is stale (generated_at=$generated_at, age_seconds=$age_seconds); using idle pressure (fail open)." >&2
+              return 1
+            fi
+            if [ "$age_seconds" -lt -300 ]; then
+              echo "::warning::Exact-review queue telemetry generated_at is too far in the future (generated_at=$generated_at); using idle pressure (fail open)." >&2
+              return 1
+            fi
             printf '%s' "$response" | jq -r '
               def count: if type == "number" and . >= 0 then floor else 0 end;
               [

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1435,9 +1435,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     concurrency:
-      # Broad sweep and commit-review plans share this global admission lock.
-      # Exact items use an individual run group and remain independently admitted.
-      group: ${{ format('clawsweeper-review-admission-{0}', (github.event.client_payload.item_number || github.event.client_payload.item_numbers || github.event.inputs.item_number || github.event.inputs.item_numbers) && github.run_id || 'background') }}
+      # The shared background-admission lock is an opt-in experiment. With the
+      # variable unset, preserve the current-main per-target planner grouping.
+      group: ${{ (github.event.client_payload.item_number || github.event.client_payload.item_numbers || github.event.inputs.item_number || github.event.inputs.item_numbers) && format('clawsweeper-review-admission-{0}', github.run_id) || vars.CLAWSWEEPER_ENABLE_EXACT_REVIEW_BACKGROUND_YIELD == '1' && 'clawsweeper-review-admission-background' || format('clawsweeper-planner-{0}', (github.event_name == 'repository_dispatch' && github.event.client_payload.target_repo) || ((github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.item_number == '' && github.event.inputs.item_numbers == '')) && (github.event.inputs.target_repo || ((github.event.schedule == '2/5 * * * *' || github.event.schedule == '22 * * * *') && 'openclaw/clawhub' || 'openclaw/openclaw'))) || github.run_id) }}
       cancel-in-progress: false
       queue: max
     outputs:
@@ -1556,6 +1556,7 @@ jobs:
           COMMIT_REVIEW_PAGE_SIZE: ${{ vars.CLAWSWEEPER_COMMIT_REVIEW_PAGE_SIZE || '' }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           CLAWSWEEPER_EXACT_REVIEW_QUEUE_MAX_AGE_SECONDS: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_MAX_AGE_SECONDS || '900' }}
+          EXACT_REVIEW_BACKGROUND_YIELD_ENABLED: ${{ vars.CLAWSWEEPER_ENABLE_EXACT_REVIEW_BACKGROUND_YIELD || '0' }}
         run: |
           limit() {
             pnpm --dir clawsweeper run --silent workflow -- limit "$1"
@@ -1789,17 +1790,19 @@ jobs:
           exact_review_capacity=0
           exact_review_dispatcher_state="unknown"
           exact_review_handoff_health="unknown"
-          if exact_review_stats="$(exact_review_queue_stats)" && IFS=$'\t' read -r exact_review_pending exact_review_admissible_pending exact_review_dispatching exact_review_leased exact_review_capacity exact_review_dispatcher_state exact_review_handoff_health <<< "$exact_review_stats"; then
-            exact_review_pressure="$(pnpm --dir clawsweeper run --silent workflow -- exact-review-pressure \
-              --pending "$exact_review_pending" \
-              --admissible-pending "$exact_review_admissible_pending" \
-              --dispatching "$exact_review_dispatching" \
-              --leased "$exact_review_leased" \
-              --capacity "$exact_review_capacity" \
-              --dispatcher-state "$exact_review_dispatcher_state" \
-              --handoff-health "$exact_review_handoff_health")" || exact_review_pressure="idle"
-          else
-            echo "::warning::Exact-review queue telemetry was unavailable; using idle pressure (fail open)."
+          if [ "$EXACT_REVIEW_BACKGROUND_YIELD_ENABLED" = "1" ]; then
+            if exact_review_stats="$(exact_review_queue_stats)" && IFS=$'\t' read -r exact_review_pending exact_review_admissible_pending exact_review_dispatching exact_review_leased exact_review_capacity exact_review_dispatcher_state exact_review_handoff_health <<< "$exact_review_stats"; then
+              exact_review_pressure="$(pnpm --dir clawsweeper run --silent workflow -- exact-review-pressure \
+                --pending "$exact_review_pending" \
+                --admissible-pending "$exact_review_admissible_pending" \
+                --dispatching "$exact_review_dispatching" \
+                --leased "$exact_review_leased" \
+                --capacity "$exact_review_capacity" \
+                --dispatcher-state "$exact_review_dispatcher_state" \
+                --handoff-health "$exact_review_handoff_health")" || exact_review_pressure="idle"
+            else
+              echo "::warning::Exact-review queue telemetry was unavailable; using idle pressure (fail open)."
+            fi
           fi
           active_critical_workers="$(( $(active_run_count ".github/workflows/repair-cluster-worker.yml") + $(active_sweep_exact_workers) ))"
           active_background_workers="$(( $(active_commit_review_workers) + $(active_sweep_background_workers) ))"

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1566,9 +1566,12 @@ jobs:
               def count: if type == "number" and . >= 0 then floor else 0 end;
               [
                 (.exact_review_queue.pending // 0 | count),
+                (.exact_review_queue.admissible_pending // 0 | count),
                 (.exact_review_queue.dispatching // 0 | count),
                 (.exact_review_queue.leased // 0 | count),
-                (.exact_review_queue.handoff_health.capacity // 0 | count)
+                (.exact_review_queue.handoff_health.capacity // 0 | count),
+                (.exact_review_queue.dispatcher.state // "" | if type == "string" then . else "" end),
+                (.exact_review_queue.handoff_health.status // "" | if type == "string" then . else "" end)
               ] | @tsv
             ' 2>/dev/null
           }
@@ -1701,15 +1704,21 @@ jobs:
           commit_page_size="$(limit commit_review.page_size_default)"
           exact_review_pressure="idle"
           exact_review_pending=0
+          exact_review_admissible_pending=0
           exact_review_dispatching=0
           exact_review_leased=0
           exact_review_capacity=0
-          if exact_review_stats="$(exact_review_queue_stats)" && IFS=$'\t' read -r exact_review_pending exact_review_dispatching exact_review_leased exact_review_capacity <<< "$exact_review_stats"; then
+          exact_review_dispatcher_state="unknown"
+          exact_review_handoff_health="unknown"
+          if exact_review_stats="$(exact_review_queue_stats)" && IFS=$'\t' read -r exact_review_pending exact_review_admissible_pending exact_review_dispatching exact_review_leased exact_review_capacity exact_review_dispatcher_state exact_review_handoff_health <<< "$exact_review_stats"; then
             exact_review_pressure="$(pnpm --dir clawsweeper run --silent workflow -- exact-review-pressure \
               --pending "$exact_review_pending" \
+              --admissible-pending "$exact_review_admissible_pending" \
               --dispatching "$exact_review_dispatching" \
               --leased "$exact_review_leased" \
-              --capacity "$exact_review_capacity")" || exact_review_pressure="idle"
+              --capacity "$exact_review_capacity" \
+              --dispatcher-state "$exact_review_dispatcher_state" \
+              --handoff-health "$exact_review_handoff_health")" || exact_review_pressure="idle"
           else
             echo "::warning::Exact-review queue telemetry was unavailable; using idle pressure (fail open)."
           fi
@@ -1718,7 +1727,7 @@ jobs:
           hot_intake_shards="$(worker_limit hot_intake --active-critical "$active_critical_workers" --active-background "$active_background_workers" --exact-review-pressure "$exact_review_pressure")"
           normal_shards="$(worker_limit normal_review --active-critical "$active_critical_workers" --active-background "$active_background_workers" --exact-review-pressure "$exact_review_pressure")"
           if [ "$exact_review_pressure" != "idle" ]; then
-            echo "::notice::Exact-review queue is $exact_review_pressure (pending=$exact_review_pending, dispatching=$exact_review_dispatching, leased=$exact_review_leased, capacity=$exact_review_capacity); throttling broad review intake to normal=$normal_shards and hot=$hot_intake_shards."
+            echo "::notice::Exact-review queue is $exact_review_pressure (pending=$exact_review_pending, admissible_pending=$exact_review_admissible_pending, dispatching=$exact_review_dispatching, leased=$exact_review_leased, capacity=$exact_review_capacity, dispatcher=$exact_review_dispatcher_state, handoff=$exact_review_handoff_health); throttling broad review intake to normal=$normal_shards and hot=$hot_intake_shards."
           fi
           hot_intake="${{ ((github.event_name == 'repository_dispatch' && github.event.client_payload.hot_intake == 'true') || (github.event_name == 'workflow_dispatch' && github.event.inputs.hot_intake == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '*/5 * * * *' || github.event.schedule == '2/5 * * * *'))) && 'true' || 'false' }}"
           exact_item="${{ github.event.client_payload.item_number || github.event.inputs.item_number || github.event.inputs.item_numbers || '' }}"

--- a/config/automation-limits.json
+++ b/config/automation-limits.json
@@ -8,7 +8,9 @@
   "lanes": {
     "exact_review": {
       "max_concurrent": 64,
-      "target_max_concurrent": 60
+      "target_max_concurrent": 60,
+      "background_congested_max_workers": 16,
+      "background_saturated_max_workers": 4
     },
     "assist": {
       "max": 10

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -2179,7 +2179,7 @@ export async function exactReviewQueueStatusSnapshot(env) {
   ) {
     throw new Error(String(body.error || "exact-review queue status unavailable"));
   }
-  return body;
+  return { ...body, generated_at: new Date().toISOString() };
 }
 
 async function authenticatedExactReviewEnqueue(request, env) {

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -2773,8 +2773,19 @@ function exactReviewQueueStats(
         left.target_repo.localeCompare(right.target_repo),
     );
   const nextWakeAt = exactReviewQueueNextWakeAt(state, now, capacity, targetCapacity);
+  const readyPending = items.filter(
+    (item) => item.state === "pending" && item.nextAttemptAt <= now,
+  ).length;
+  const admissiblePending = exactReviewQueueAdmittedItems(
+    state,
+    now,
+    Number.MAX_SAFE_INTEGER,
+    targetCapacity,
+  ).length;
   return {
     pending: handoffHealth.phases.pending.count,
+    ready_pending: readyPending,
+    admissible_pending: admissiblePending,
     dispatching: handoffHealth.phases.dispatching.count,
     leased: handoffHealth.phases.leased.count,
     oldest_pending_at: handoffHealth.phases.pending.oldest_at,

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -27,25 +27,25 @@ The mental model:
 - Assist has a small fixed cap because it is lightweight maintainer Q&A, not a
   derived review or repair lane.
 - Background lanes shrink when priority work is already active.
-- A saturated exact-review queue further reduces broad review work so its
-  backlog can recover without competing for Codex, GitHub, or state-publish
-  capacity.
+- A healthy, active exact-review queue with target-admissible pending work
+  further reduces broad review work so its dispatchable backlog can recover
+  without competing for Codex, GitHub, or state-publish capacity.
 - Runtime overrides are escape hatches, not the normal tuning surface.
 
 ## Worker Budget
 
-| Name                                                  | Current | Meaning                                                                                         |
-| ----------------------------------------------------- | ------: | ----------------------------------------------------------------------------------------------- |
-| `workers.max`                                         |     128 | Maximum global Codex worker budget used to derive lane limits.                                  |
-| `workers.reserve_for_interactive`                     |      16 | Worker slots background lanes leave open for exact/manual/urgent work.                          |
-| `workers.expansion_reserve`                           |       8 | Extra slots background lanes leave open for independently planned matrix expansion.             |
-| `workers.minimum_background`                          |      16 | Target floor for background progress when enough global capacity is available.                  |
-| `lanes.exact_review.max_concurrent`                   |      64 | Maximum concurrent exact-item review workflow runs admitted to Codex.                           |
-| `lanes.exact_review.target_max_concurrent`            |      60 | Maximum concurrent exact-item review workflow runs one target repository may consume.           |
-| `lanes.exact_review.background_congested_max_workers` |      16 | Broad review cap while every exact-review slot is active and work is waiting.                   |
-| `lanes.exact_review.background_saturated_max_workers` |       4 | Broad review cap while every exact-review slot is active and at least one full lane is waiting. |
-| `lanes.assist.max`                                    |      10 | Maximum concurrent lightweight assist jobs.                                                     |
-| `lanes.repair.cluster_max_live_runs`                  |       2 | Default live repair workflow cap for imported gitcrawl cluster dispatches.                      |
+| Name                                                  | Current | Meaning                                                                                       |
+| ----------------------------------------------------- | ------: | --------------------------------------------------------------------------------------------- |
+| `workers.max`                                         |     128 | Maximum global Codex worker budget used to derive lane limits.                                |
+| `workers.reserve_for_interactive`                     |      16 | Worker slots background lanes leave open for exact/manual/urgent work.                        |
+| `workers.expansion_reserve`                           |       8 | Extra slots background lanes leave open for independently planned matrix expansion.           |
+| `workers.minimum_background`                          |      16 | Target floor for background progress when enough global capacity is available.                |
+| `lanes.exact_review.max_concurrent`                   |      64 | Maximum concurrent exact-item review workflow runs admitted to Codex.                         |
+| `lanes.exact_review.target_max_concurrent`            |      60 | Maximum concurrent exact-item review workflow runs one target repository may consume.         |
+| `lanes.exact_review.background_congested_max_workers` |      16 | Broad review cap while a healthy, full exact-review queue has target-admissible pending work. |
+| `lanes.exact_review.background_saturated_max_workers` |       4 | Broad review cap while a healthy, full queue has one lane's worth of admissible pending work. |
+| `lanes.assist.max`                                    |      10 | Maximum concurrent lightweight assist jobs.                                                   |
+| `lanes.repair.cluster_max_live_runs`                  |       2 | Default live repair workflow cap for imported gitcrawl cluster dispatches.                    |
 
 ## Derived Limits
 
@@ -60,8 +60,8 @@ by default.
 | --------------------------------------------------- | ------: | ------------------------------------------------------------------------------------- |
 | `exact_review.concurrent_max`                       |      64 | Exact-item review admission cap, clamped to `workers.max`.                            |
 | `exact_review.target_concurrent_max`                |      60 | Exact-item per-target admission cap, clamped to global exact-review capacity.         |
-| `exact_review.background_congested_max_workers`     |      16 | Broad review worker cap for a full exact-review queue with pending work.              |
-| `exact_review.background_saturated_max_workers`     |       4 | Broad review worker cap for a full queue with at least one lane's worth waiting.      |
+| `exact_review.background_congested_max_workers`     |      16 | Broad review worker cap for a healthy, full queue with admissible pending work.       |
+| `exact_review.background_saturated_max_workers`     |       4 | Broad review worker cap for a healthy, full queue with one lane's worth admissible.   |
 | `assist.default`                                    |      10 | Maintainer assist job cap.                                                            |
 | `review_shards.normal_default`                      |      89 | Quiet-system normal review shard ceiling.                                             |
 | `review_shards.normal_active_floor`                 |      38 | Minimum active normal review shards to keep queued for `openclaw/openclaw`.           |
@@ -106,19 +106,24 @@ The scheduler does this for background lanes:
 4. reserve `workers.reserve_for_interactive`
 5. reserve `workers.expansion_reserve` for independently planned matrix waves
 6. cap the result at the lane's derived quiet-system ceiling
-7. when the durable exact-review queue is full with pending work, cap broad
-   lanes at `lanes.exact_review.background_congested_max_workers`
-8. when that full queue has at least one queue-capacity worth of pending work,
-   cap broad lanes at `lanes.exact_review.background_saturated_max_workers`
+7. when the durable exact-review queue is full, its dispatcher and handoff are
+   healthy, and it has target-admissible pending work, cap broad lanes at
+   `lanes.exact_review.background_congested_max_workers`
+8. when that healthy full queue has at least one queue-capacity worth of
+   target-admissible pending work, cap broad lanes at
+   `lanes.exact_review.background_saturated_max_workers`
 9. return at least 1 so an enabled lane can still make slow progress
 
 The workflow reads the public queue snapshot before admitting normal review,
-hot intake, or commit-review work. A failed or malformed snapshot is fail-open:
-the existing active-worker calculation remains in effect. Exact-review admission
-itself remains governed by the durable queue's separate global and per-target
-caps; these background caps reduce competing work rather than raising those
-admission limits. An explicit commit-review page-size override remains unchanged
-while the queue is idle, but is capped while exact-review pressure is present.
+hot intake, or commit-review work. A failed or malformed snapshot, a paused or
+blocked dispatcher, a non-healthy handoff, retry-delayed pending work, or work
+blocked by its target's exact-review cap is fail-open: the existing active-worker
+calculation remains in effect.
+Exact-review admission itself remains governed by the durable queue's separate
+global and per-target caps; these background caps reduce competing work rather
+than raising those admission limits. An explicit commit-review page-size override
+remains unchanged while the queue is idle, but is capped while exact-review
+pressure is present.
 
 Background planner jobs serialize per target repository. A sweep that is still
 planning, queued, or expanding its matrix reserves its quiet lane size. Once

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -27,6 +27,9 @@ The mental model:
 - Assist has a small fixed cap because it is lightweight maintainer Q&A, not a
   derived review or repair lane.
 - Background lanes shrink when priority work is already active.
+- A saturated exact-review queue further reduces broad review work so its
+  backlog can recover without competing for Codex, GitHub, or state-publish
+  capacity.
 - Runtime overrides are escape hatches, not the normal tuning surface.
 
 ## Worker Budget
@@ -39,6 +42,8 @@ The mental model:
 | `workers.minimum_background`               |      16 | Target floor for background progress when enough global capacity is available.        |
 | `lanes.exact_review.max_concurrent`        |      64 | Maximum concurrent exact-item review workflow runs admitted to Codex.                 |
 | `lanes.exact_review.target_max_concurrent` |      60 | Maximum concurrent exact-item review workflow runs one target repository may consume. |
+| `lanes.exact_review.background_congested_max_workers` | 16 | Broad review cap while every exact-review slot is active and work is waiting. |
+| `lanes.exact_review.background_saturated_max_workers` | 4 | Broad review cap while every exact-review slot is active and at least one full lane is waiting. |
 | `lanes.assist.max`                         |      10 | Maximum concurrent lightweight assist jobs.                                           |
 | `lanes.repair.cluster_max_live_runs`       |       2 | Default live repair workflow cap for imported gitcrawl cluster dispatches.            |
 
@@ -55,6 +60,8 @@ by default.
 | --------------------------------------------------- | ------: | ------------------------------------------------------------------------------------- |
 | `exact_review.concurrent_max`                       |      64 | Exact-item review admission cap, clamped to `workers.max`.                            |
 | `exact_review.target_concurrent_max`                |      60 | Exact-item per-target admission cap, clamped to global exact-review capacity.         |
+| `exact_review.background_congested_max_workers`     |      16 | Broad review worker cap for a full exact-review queue with pending work.              |
+| `exact_review.background_saturated_max_workers`     |       4 | Broad review worker cap for a full queue with at least one lane's worth waiting.      |
 | `assist.default`                                    |      10 | Maintainer assist job cap.                                                            |
 | `review_shards.normal_default`                      |      89 | Quiet-system normal review shard ceiling.                                             |
 | `review_shards.normal_active_floor`                 |      38 | Minimum active normal review shards to keep queued for `openclaw/openclaw`.           |
@@ -99,7 +106,19 @@ The scheduler does this for background lanes:
 4. reserve `workers.reserve_for_interactive`
 5. reserve `workers.expansion_reserve` for independently planned matrix waves
 6. cap the result at the lane's derived quiet-system ceiling
-7. return at least 1 so an enabled lane can still make slow progress
+7. when the durable exact-review queue is full with pending work, cap broad
+   lanes at `lanes.exact_review.background_congested_max_workers`
+8. when that full queue has at least one queue-capacity worth of pending work,
+   cap broad lanes at `lanes.exact_review.background_saturated_max_workers`
+9. return at least 1 so an enabled lane can still make slow progress
+
+The workflow reads the public queue snapshot before admitting normal review,
+hot intake, or commit-review work. A failed or malformed snapshot is fail-open:
+the existing active-worker calculation remains in effect. Exact-review admission
+itself remains governed by the durable queue's separate global and per-target
+caps; these background caps reduce competing work rather than raising those
+admission limits. An explicit commit-review page-size override remains unchanged
+while the queue is idle, but is capped while exact-review pressure is present.
 
 Background planner jobs serialize per target repository. A sweep that is still
 planning, queued, or expanding its matrix reserves its quiet lane size. Once

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -34,18 +34,18 @@ The mental model:
 
 ## Worker Budget
 
-| Name                                       | Current | Meaning                                                                               |
-| ------------------------------------------ | ------: | ------------------------------------------------------------------------------------- |
-| `workers.max`                              |     128 | Maximum global Codex worker budget used to derive lane limits.                        |
-| `workers.reserve_for_interactive`          |      16 | Worker slots background lanes leave open for exact/manual/urgent work.                |
-| `workers.expansion_reserve`                |       8 | Extra slots background lanes leave open for independently planned matrix expansion.   |
-| `workers.minimum_background`               |      16 | Target floor for background progress when enough global capacity is available.        |
-| `lanes.exact_review.max_concurrent`        |      64 | Maximum concurrent exact-item review workflow runs admitted to Codex.                 |
-| `lanes.exact_review.target_max_concurrent` |      60 | Maximum concurrent exact-item review workflow runs one target repository may consume. |
-| `lanes.exact_review.background_congested_max_workers` | 16 | Broad review cap while every exact-review slot is active and work is waiting. |
-| `lanes.exact_review.background_saturated_max_workers` | 4 | Broad review cap while every exact-review slot is active and at least one full lane is waiting. |
-| `lanes.assist.max`                         |      10 | Maximum concurrent lightweight assist jobs.                                           |
-| `lanes.repair.cluster_max_live_runs`       |       2 | Default live repair workflow cap for imported gitcrawl cluster dispatches.            |
+| Name                                                  | Current | Meaning                                                                                         |
+| ----------------------------------------------------- | ------: | ----------------------------------------------------------------------------------------------- |
+| `workers.max`                                         |     128 | Maximum global Codex worker budget used to derive lane limits.                                  |
+| `workers.reserve_for_interactive`                     |      16 | Worker slots background lanes leave open for exact/manual/urgent work.                          |
+| `workers.expansion_reserve`                           |       8 | Extra slots background lanes leave open for independently planned matrix expansion.             |
+| `workers.minimum_background`                          |      16 | Target floor for background progress when enough global capacity is available.                  |
+| `lanes.exact_review.max_concurrent`                   |      64 | Maximum concurrent exact-item review workflow runs admitted to Codex.                           |
+| `lanes.exact_review.target_max_concurrent`            |      60 | Maximum concurrent exact-item review workflow runs one target repository may consume.           |
+| `lanes.exact_review.background_congested_max_workers` |      16 | Broad review cap while every exact-review slot is active and work is waiting.                   |
+| `lanes.exact_review.background_saturated_max_workers` |       4 | Broad review cap while every exact-review slot is active and at least one full lane is waiting. |
+| `lanes.assist.max`                                    |      10 | Maximum concurrent lightweight assist jobs.                                                     |
+| `lanes.repair.cluster_max_live_runs`                  |       2 | Default live repair workflow cap for imported gitcrawl cluster dispatches.                      |
 
 ## Derived Limits
 

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -27,9 +27,10 @@ The mental model:
 - Assist has a small fixed cap because it is lightweight maintainer Q&A, not a
   derived review or repair lane.
 - Background lanes shrink when priority work is already active.
-- A healthy, active exact-review queue with target-admissible pending work
-  further reduces broad review work so its dispatchable backlog can recover
-  without competing for Codex, GitHub, or state-publish capacity.
+- The optional exact-review background-yield experiment can further reduce
+  broad review work while a healthy, active exact-review queue has
+  target-admissible pending work. It is disabled unless a maintainer sets
+  `CLAWSWEEPER_ENABLE_EXACT_REVIEW_BACKGROUND_YIELD=1`.
 - Runtime overrides are escape hatches, not the normal tuning surface.
 
 ## Worker Budget
@@ -42,8 +43,8 @@ The mental model:
 | `workers.minimum_background`                          |      16 | Target floor for background progress when enough global capacity is available.                |
 | `lanes.exact_review.max_concurrent`                   |      64 | Maximum concurrent exact-item review workflow runs admitted to Codex.                         |
 | `lanes.exact_review.target_max_concurrent`            |      60 | Maximum concurrent exact-item review workflow runs one target repository may consume.         |
-| `lanes.exact_review.background_congested_max_workers` |      16 | Broad review cap while a healthy, full exact-review queue has target-admissible pending work. |
-| `lanes.exact_review.background_saturated_max_workers` |       4 | Broad review cap while a healthy, full queue has one lane's worth of admissible pending work. |
+| `lanes.exact_review.background_congested_max_workers` |      16 | Experimental broad-review cap while the explicit background-yield opt-in sees a healthy, full queue with admissible work. |
+| `lanes.exact_review.background_saturated_max_workers` |       4 | Experimental broad-review cap while the explicit background-yield opt-in sees one lane's worth of admissible work. |
 | `lanes.assist.max`                                    |      10 | Maximum concurrent lightweight assist jobs.                                                   |
 | `lanes.repair.cluster_max_live_runs`                  |       2 | Default live repair workflow cap for imported gitcrawl cluster dispatches.                    |
 
@@ -60,8 +61,8 @@ by default.
 | --------------------------------------------------- | ------: | ------------------------------------------------------------------------------------- |
 | `exact_review.concurrent_max`                       |      64 | Exact-item review admission cap, clamped to `workers.max`.                            |
 | `exact_review.target_concurrent_max`                |      60 | Exact-item per-target admission cap, clamped to global exact-review capacity.         |
-| `exact_review.background_congested_max_workers`     |      16 | Broad review worker cap for a healthy, full queue with admissible pending work.       |
-| `exact_review.background_saturated_max_workers`     |       4 | Broad review worker cap for a healthy, full queue with one lane's worth admissible.   |
+| `exact_review.background_congested_max_workers`     |      16 | Experimental broad-review cap for a healthy, full queue with admissible work.         |
+| `exact_review.background_saturated_max_workers`     |       4 | Experimental broad-review cap for a healthy, full queue with one lane's worth of work. |
 | `assist.default`                                    |      10 | Maintainer assist job cap.                                                            |
 | `review_shards.normal_default`                      |      89 | Quiet-system normal review shard ceiling.                                             |
 | `review_shards.normal_active_floor`                 |      38 | Minimum active normal review shards to keep queued for `openclaw/openclaw`.           |

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -112,7 +112,24 @@ The scheduler does this for background lanes:
 8. when that full queue has at least one queue-capacity worth of
    target-admissible pending work, cap broad lanes at
    `lanes.exact_review.background_saturated_max_workers`
-9. return at least 1 so an enabled lane can still make slow progress
+9. return zero when the exact-pressure cap is already consumed, so no further
+   broad worker is admitted until the current matrices drain
+
+The pressure cap is a shared residual allowance, not a fresh allowance for
+each concurrently planning background workflow. Existing broad review matrices
+are subtracted before calculating new intake; once the cap is already occupied,
+the scheduler defers new broad work until in-flight jobs drain. Sweep and
+commit-review planners share one broad-admission lock so concurrent snapshots
+cannot each claim the same allowance. Queued planners are held by that lock;
+only in-progress review matrices consume the live pressure allowance.
+Manual exact-review batches remain priority work and are never charged against
+that background allowance.
+An unexpanded commit-review planner reserves its configured, hard-capped page
+size until its review matrix is visible. A literal skipped matrix job identifies
+a completed zero-review plan so its report-publishing phase holds no reservation.
+When exact pressure consumes the allowance, commit review keeps the shared
+admission lock for a short delay and requeues the same commit range; it is
+deferred rather than marked reviewed or exhausted.
 
 The workflow reads the public queue snapshot before admitting normal review,
 hot intake, or commit-review work. A failed, stale, malformed, or unknown

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -106,19 +106,21 @@ The scheduler does this for background lanes:
 4. reserve `workers.reserve_for_interactive`
 5. reserve `workers.expansion_reserve` for independently planned matrix waves
 6. cap the result at the lane's derived quiet-system ceiling
-7. when the durable exact-review queue is full, its dispatcher and handoff are
-   healthy, and it has target-admissible pending work, cap broad lanes at
+7. when the durable exact-review queue is full, its dispatcher is active, its
+   handoff state is known, and it has target-admissible pending work, cap broad lanes at
    `lanes.exact_review.background_congested_max_workers`
-8. when that healthy full queue has at least one queue-capacity worth of
+8. when that full queue has at least one queue-capacity worth of
    target-admissible pending work, cap broad lanes at
    `lanes.exact_review.background_saturated_max_workers`
 9. return at least 1 so an enabled lane can still make slow progress
 
 The workflow reads the public queue snapshot before admitting normal review,
-hot intake, or commit-review work. A failed or malformed snapshot, a paused or
-blocked dispatcher, a non-healthy handoff, retry-delayed pending work, or work
+hot intake, or commit-review work. A failed, stale, malformed, or unknown
+snapshot; a paused or blocked dispatcher; retry-delayed pending work; or work
 blocked by its target's exact-review cap is fail-open: the existing active-worker
-calculation remains in effect.
+calculation remains in effect. A valid `degraded` or `stalled` handoff does not
+cause recovery work or lease mutation, but it does preserve the protective
+background cap while the exact-review lane is full and has admissible backlog.
 Exact-review admission itself remains governed by the durable queue's separate
 global and per-target caps; these background caps reduce competing work rather
 than raising those admission limits. An explicit commit-review page-size override
@@ -202,6 +204,9 @@ hot intake `14`, and commit review `2`. Existing repair lanes keep their
 
 - `CLAWSWEEPER_COMMIT_REVIEW_PAGE_SIZE` overrides
   `commit_review.page_size_default`.
+- `CLAWSWEEPER_EXACT_REVIEW_QUEUE_MAX_AGE_SECONDS` sets the maximum age of a
+  trusted exact-review queue snapshot for scheduler reshuffling. The default is
+  900 seconds; values below 60 seconds fall back to that default.
 - `CLAWSWEEPER_FEATURE_CLUSTER_REPAIR_ENABLED=1` enables the scheduled
   `repair-cluster-intake.yml` imported-cluster intake. Direct repair import and
   dispatch commands are not blocked by this variable; they keep the existing

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -218,9 +218,13 @@ workflow state, check time, and retry time so an intentional pause cannot look
 like occupied executor capacity. Re-enabling the workflow does not require a
 queue mutation; the next status check resumes normal admission.
 
-The same endpoint exposes `handoff_health` plus oldest timestamps and ages for
-the pending, dispatching, and leased phases. New dispatch and claim transitions
-carry explicit phase timestamps. Rows written by an older deployment derive
+The same endpoint exposes `ready_pending`, `admissible_pending`, `handoff_health`,
+and oldest timestamps and ages for the pending, dispatching, and leased phases.
+`ready_pending` excludes retry-delayed queue entries; `admissible_pending` further
+excludes work blocked by its target's exact-review cap, so schedulers can distinguish
+actionable backlog from work deliberately waiting for retry or target capacity. New
+dispatch and claim transitions carry explicit phase timestamps. Rows written by an
+older deployment derive
 their phase start from the active dispatch or execution lease; a stale timestamp
 left by a rollback cannot override that newer lease, and a wholly unknown legacy
 age stays non-alarming. A claim is degraded after one third of the dispatch

--- a/scripts/check-limits.ts
+++ b/scripts/check-limits.ts
@@ -13,6 +13,8 @@ type WorkerConfig = {
     exact_review: {
       max_concurrent: number;
       target_max_concurrent: number;
+      background_congested_max_workers: number;
+      background_saturated_max_workers: number;
     };
     assist: {
       max: number;
@@ -27,6 +29,8 @@ type AutomationLimits = {
   exact_review: {
     concurrent_max: number;
     target_concurrent_max: number;
+    background_congested_max_workers: number;
+    background_saturated_max_workers: number;
   };
   assist: {
     default: number;
@@ -237,6 +241,14 @@ function deriveAutomationLimits(workerConfig: WorkerConfig): AutomationLimits {
       target_concurrent_max: Math.min(
         workerConfig.lanes.exact_review.target_max_concurrent,
         workerConfig.lanes.exact_review.max_concurrent,
+        max,
+      ),
+      background_congested_max_workers: Math.min(
+        workerConfig.lanes.exact_review.background_congested_max_workers,
+        max,
+      ),
+      background_saturated_max_workers: Math.min(
+        workerConfig.lanes.exact_review.background_saturated_max_workers,
         max,
       ),
     },

--- a/src/repair/limits.ts
+++ b/src/repair/limits.ts
@@ -196,22 +196,35 @@ export function workerLimit(
 
 export function exactReviewQueuePressure({
   pending,
+  admissiblePending,
   dispatching,
   leased,
   capacity,
+  dispatcherState,
+  handoffHealth,
 }: {
   pending: number;
+  admissiblePending: number;
   dispatching: number;
   leased: number;
   capacity: number;
+  dispatcherState: string;
+  handoffHealth: string;
 }): ExactReviewQueuePressure {
   const normalizedCapacity = nonNegative(capacity);
   const active = nonNegative(dispatching) + nonNegative(leased);
   const normalizedPending = nonNegative(pending);
-  if (normalizedCapacity < 1 || normalizedPending < 1 || active < normalizedCapacity) {
+  const normalizedAdmissiblePending = Math.min(normalizedPending, nonNegative(admissiblePending));
+  if (
+    normalizedCapacity < 1 ||
+    normalizedAdmissiblePending < 1 ||
+    active < normalizedCapacity ||
+    dispatcherState !== "active" ||
+    handoffHealth !== "healthy"
+  ) {
     return "idle";
   }
-  return normalizedPending >= normalizedCapacity ? "saturated" : "congested";
+  return normalizedAdmissiblePending >= normalizedCapacity ? "saturated" : "congested";
 }
 
 function validateWorkerConfig(value: unknown): WorkerConfig {

--- a/src/repair/limits.ts
+++ b/src/repair/limits.ts
@@ -184,11 +184,16 @@ export function workerLimit(
   }
 
   function pressureLimitedBackground(limit: number): number {
-    if (exactReviewPressure === "saturated") {
-      return Math.min(limit, limits.exact_review.background_saturated_max_workers);
-    }
-    if (exactReviewPressure === "congested") {
-      return Math.min(limit, limits.exact_review.background_congested_max_workers);
+    const pressureCap =
+      exactReviewPressure === "saturated"
+        ? limits.exact_review.background_saturated_max_workers
+        : exactReviewPressure === "congested"
+          ? limits.exact_review.background_congested_max_workers
+          : undefined;
+    if (pressureCap !== undefined) {
+      // The pressure cap is shared by broad lanes. Once in-flight matrices use
+      // that allowance, admit no more background workers until capacity drains.
+      return Math.min(limit, Math.max(0, pressureCap - nonNegative(activeBackground)));
     }
     return limit;
   }

--- a/src/repair/limits.ts
+++ b/src/repair/limits.ts
@@ -215,12 +215,14 @@ export function exactReviewQueuePressure({
   const active = nonNegative(dispatching) + nonNegative(leased);
   const normalizedPending = nonNegative(pending);
   const normalizedAdmissiblePending = Math.min(normalizedPending, nonNegative(admissiblePending));
+  const knownHandoffState =
+    handoffHealth === "healthy" || handoffHealth === "degraded" || handoffHealth === "stalled";
   if (
     normalizedCapacity < 1 ||
     normalizedAdmissiblePending < 1 ||
     active < normalizedCapacity ||
     dispatcherState !== "active" ||
-    handoffHealth !== "healthy"
+    !knownHandoffState
   ) {
     return "idle";
   }

--- a/src/repair/limits.ts
+++ b/src/repair/limits.ts
@@ -13,6 +13,8 @@ export type WorkerConfig = {
     exact_review: {
       max_concurrent: number;
       target_max_concurrent: number;
+      background_congested_max_workers: number;
+      background_saturated_max_workers: number;
     };
     assist: {
       max: number;
@@ -27,6 +29,8 @@ export type AutomationLimits = {
   exact_review: {
     concurrent_max: number;
     target_concurrent_max: number;
+    background_congested_max_workers: number;
+    background_saturated_max_workers: number;
   };
   assist: {
     default: number;
@@ -65,6 +69,8 @@ export type WorkerLane =
   | "exact_item"
   | "assist";
 
+export type ExactReviewQueuePressure = "idle" | "congested" | "saturated";
+
 export const WORKER_CONFIG = readWorkerConfig();
 export const AUTOMATION_LIMITS = deriveAutomationLimits(WORKER_CONFIG);
 
@@ -84,6 +90,14 @@ export function deriveAutomationLimits(config: WorkerConfig): AutomationLimits {
       target_concurrent_max: Math.min(
         config.lanes.exact_review.target_max_concurrent,
         config.lanes.exact_review.max_concurrent,
+        max,
+      ),
+      background_congested_max_workers: Math.min(
+        config.lanes.exact_review.background_congested_max_workers,
+        max,
+      ),
+      background_saturated_max_workers: Math.min(
+        config.lanes.exact_review.background_saturated_max_workers,
         max,
       ),
     },
@@ -119,11 +133,13 @@ export function workerLimit(
   {
     activeCritical = 0,
     activeBackground = 0,
+    exactReviewPressure = "idle",
     config = WORKER_CONFIG,
     limits = AUTOMATION_LIMITS,
   }: {
     activeCritical?: number;
     activeBackground?: number;
+    exactReviewPressure?: ExactReviewQueuePressure;
     config?: WorkerConfig;
     limits?: AutomationLimits;
   } = {},
@@ -138,18 +154,16 @@ export function workerLimit(
   if (lane === "cluster_repair")
     return priorityLimit(limits.repair_live_runs.cluster_default, activeCritical);
   if (lane === "commit_review")
-    return backgroundLimit(
-      limits.commit_review.page_size_default,
-      activeCritical,
-      activeBackground,
+    return pressureLimitedBackground(
+      backgroundLimit(limits.commit_review.page_size_default, activeCritical, activeBackground),
     );
   if (lane === "hot_intake")
-    return backgroundLimit(
-      limits.review_shards.hot_intake_default,
-      activeCritical,
-      activeBackground,
+    return pressureLimitedBackground(
+      backgroundLimit(limits.review_shards.hot_intake_default, activeCritical, activeBackground),
     );
-  return backgroundLimit(limits.review_shards.normal_default, activeCritical, activeBackground);
+  return pressureLimitedBackground(
+    backgroundLimit(limits.review_shards.normal_default, activeCritical, activeBackground),
+  );
 
   function priorityLimit(laneMax: number, active: number): number {
     const available = Math.max(1, config.workers.max - nonNegative(active));
@@ -168,25 +182,74 @@ export function workerLimit(
       rawAvailable >= config.workers.minimum_background ? rawAvailable : Math.max(1, rawAvailable);
     return Math.max(1, Math.min(laneMax, withFloor));
   }
+
+  function pressureLimitedBackground(limit: number): number {
+    if (exactReviewPressure === "saturated") {
+      return Math.min(limit, limits.exact_review.background_saturated_max_workers);
+    }
+    if (exactReviewPressure === "congested") {
+      return Math.min(limit, limits.exact_review.background_congested_max_workers);
+    }
+    return limit;
+  }
+}
+
+export function exactReviewQueuePressure({
+  pending,
+  dispatching,
+  leased,
+  capacity,
+}: {
+  pending: number;
+  dispatching: number;
+  leased: number;
+  capacity: number;
+}): ExactReviewQueuePressure {
+  const normalizedCapacity = nonNegative(capacity);
+  const active = nonNegative(dispatching) + nonNegative(leased);
+  const normalizedPending = nonNegative(pending);
+  if (normalizedCapacity < 1 || normalizedPending < 1 || active < normalizedCapacity) {
+    return "idle";
+  }
+  return normalizedPending >= normalizedCapacity ? "saturated" : "congested";
 }
 
 function validateWorkerConfig(value: unknown): WorkerConfig {
   if (!isRecord(value)) throw new Error("automation limits must be an object");
+  const workerMax = positiveInteger(value, "workers.max");
+  const exactReviewMax = positiveInteger(value, "lanes.exact_review.max_concurrent");
+  const backgroundCongestedMax = optionalPositiveInteger(
+    value,
+    "lanes.exact_review.background_congested_max_workers",
+    workerMax,
+  );
+  const backgroundSaturatedMax = optionalPositiveInteger(
+    value,
+    "lanes.exact_review.background_saturated_max_workers",
+    backgroundCongestedMax,
+  );
+  if (backgroundSaturatedMax > backgroundCongestedMax) {
+    throw new Error(
+      "automation limit lanes.exact_review.background_saturated_max_workers must not exceed lanes.exact_review.background_congested_max_workers",
+    );
+  }
   return {
     workers: {
-      max: positiveInteger(value, "workers.max"),
+      max: workerMax,
       reserve_for_interactive: nonNegativeInteger(value, "workers.reserve_for_interactive"),
       expansion_reserve: nonNegativeInteger(value, "workers.expansion_reserve"),
       minimum_background: positiveInteger(value, "workers.minimum_background"),
     },
     lanes: {
       exact_review: {
-        max_concurrent: positiveInteger(value, "lanes.exact_review.max_concurrent"),
+        max_concurrent: exactReviewMax,
         target_max_concurrent: optionalPositiveInteger(
           value,
           "lanes.exact_review.target_max_concurrent",
-          positiveInteger(value, "lanes.exact_review.max_concurrent"),
+          exactReviewMax,
         ),
+        background_congested_max_workers: backgroundCongestedMax,
+        background_saturated_max_workers: backgroundSaturatedMax,
       },
       assist: {
         max: positiveInteger(value, "lanes.assist.max"),

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -5,7 +5,14 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { parseArgs } from "./lib.js";
 import { isJsonObject } from "./json-types.js";
-import { AUTOMATION_LIMITS, WORKER_CONFIG, workerLimit, type WorkerLane } from "./limits.js";
+import {
+  AUTOMATION_LIMITS,
+  WORKER_CONFIG,
+  exactReviewQueuePressure,
+  workerLimit,
+  type ExactReviewQueuePressure,
+  type WorkerLane,
+} from "./limits.js";
 
 type ApplyAction = {
   action: string;
@@ -267,8 +274,21 @@ function runCli(): void {
           workerLimit(requiredWorkerLane(optionalString("lane") || positionalString(1)), {
             activeCritical: numberArg("active-critical", 0),
             activeBackground: numberArg("active-background", 0),
+            exactReviewPressure: optionalExactReviewQueuePressure(
+              optionalString("exact-review-pressure"),
+            ),
           }),
         ),
+      );
+      break;
+    case "exact-review-pressure":
+      process.stdout.write(
+        exactReviewQueuePressure({
+          pending: nonNegativeIntegerArg("pending"),
+          dispatching: nonNegativeIntegerArg("dispatching"),
+          leased: nonNegativeIntegerArg("leased"),
+          capacity: nonNegativeIntegerArg("capacity"),
+        }),
       );
       break;
     case "worker-config":
@@ -331,6 +351,12 @@ function requiredWorkerLane(value: string): WorkerLane {
   ]);
   if (allowed.has(value as WorkerLane)) return value as WorkerLane;
   throw new Error(`unknown worker lane: ${value}`);
+}
+
+function optionalExactReviewQueuePressure(value: string): ExactReviewQueuePressure {
+  if (!value || value === "idle") return "idle";
+  if (value === "congested" || value === "saturated") return value;
+  throw new Error(`unknown exact-review pressure: ${value}`);
 }
 
 export function automationLimit(limitPath: string): number {

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -285,9 +285,12 @@ function runCli(): void {
       process.stdout.write(
         exactReviewQueuePressure({
           pending: nonNegativeIntegerArg("pending"),
+          admissiblePending: nonNegativeIntegerArg("admissible-pending"),
           dispatching: nonNegativeIntegerArg("dispatching"),
           leased: nonNegativeIntegerArg("leased"),
           capacity: nonNegativeIntegerArg("capacity"),
+          dispatcherState: requiredString("dispatcher-state"),
+          handoffHealth: requiredString("handoff-health"),
         }),
       );
       break;

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -35,7 +35,8 @@ test("exact-review queue defaults to 64 of the 128 global workers", () => {
 });
 
 test("dashboard status reads the exact-review handoff model from the durable queue", async () => {
-  const queue = new ExactReviewQueue({ storage: new MemoryDurableStorage() }, {});
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
   await queue.fetch(buildExactReviewQueueRequest("handoff-status", 597, "opened"));
 
   const status = await exactReviewQueueStatusSnapshot({
@@ -44,11 +45,55 @@ test("dashboard status reads the exact-review handoff model from the durable que
 
   assert.ok(status);
   assert.equal(status.pending, 1);
+  assert.equal(status.ready_pending, 1);
+  assert.equal(status.admissible_pending, 1);
   assert.equal(status.dispatching, 0);
   assert.equal(status.leased, 0);
   assert.equal(status.handoff_health.status, "healthy");
   assert.equal(status.handoff_health.phases.pending.count, 1);
   assert.equal(await exactReviewQueueStatusSnapshot({}), null);
+});
+
+test("dashboard status excludes retry-delayed exact reviews from ready pending", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  await queue.fetch(buildExactReviewQueueRequest("delayed-status", 598, "opened"));
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { nextAttemptAt: number }>;
+  };
+  state.items["openclaw/gogcli#598"].nextAttemptAt = Date.now() + 60_000;
+  await storage.put("exact-review-queue", state);
+
+  const status = await exactReviewQueueStatusSnapshot({
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+  });
+
+  assert.ok(status);
+  assert.equal(status.pending, 1);
+  assert.equal(status.ready_pending, 0);
+  assert.equal(status.admissible_pending, 0);
+});
+
+test("dashboard status excludes ready reviews blocked by a target exact-review cap", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, { EXACT_REVIEW_TARGET_MAX_CONCURRENT: "1" });
+  await queue.fetch(
+    buildExactReviewQueueRequest("target-cap-status", 599, "opened", "issue", "openclaw/openclaw"),
+  );
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<string, ReturnType<typeof leasedExactReviewQueueItem>>;
+  };
+  state.items["openclaw/openclaw#600"] = leasedExactReviewQueueItem(600, "run-600");
+  await storage.put("exact-review-queue", state);
+
+  const status = await exactReviewQueueStatusSnapshot({
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+  });
+
+  assert.ok(status);
+  assert.equal(status.pending, 1);
+  assert.equal(status.ready_pending, 1);
+  assert.equal(status.admissible_pending, 0);
 });
 
 test("triage routing groups classify impact labels without forcing one primary group", () => {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -51,6 +51,7 @@ test("dashboard status reads the exact-review handoff model from the durable que
   assert.equal(status.leased, 0);
   assert.equal(status.handoff_health.status, "healthy");
   assert.equal(status.handoff_health.phases.pending.count, 1);
+  assert.match(status.generated_at, /^\d{4}-\d{2}-\d{2}T/);
   assert.equal(await exactReviewQueueStatusSnapshot({}), null);
 });
 
@@ -5598,8 +5599,12 @@ test("dashboard serves stale status while coalescing one background refresh", as
     const firstStatus = await first.json();
     const secondStatus = await second.json();
     assert.equal(firstStatus.pipeline[0].id, "stale-row");
+    assert.equal(firstStatus.generated_at, "2026-06-13T18:00:00Z");
     assert.equal(firstStatus.exact_review_queue.pending, 7);
+    assert.match(firstStatus.exact_review_queue.generated_at, /^\d{4}-\d{2}-\d{2}T/);
+    assert.notEqual(firstStatus.exact_review_queue.generated_at, firstStatus.generated_at);
     assert.equal(firstStatus.exact_review_queue.handoff_health.status, "healthy");
+    assert.match(secondStatus.exact_review_queue.generated_at, /^\d{4}-\d{2}-\d{2}T/);
     assert.equal(secondStatus.exact_review_queue.handoff_health.status, "healthy");
     assert.equal(waitUntilPromises.length, 2);
 

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -30,6 +30,7 @@ import {
 import {
   AUTOMATION_LIMITS,
   WORKER_CONFIG,
+  exactReviewQueuePressure,
   readWorkerConfig,
   workerLimit,
 } from "../../dist/repair/limits.js";
@@ -247,6 +248,62 @@ test("worker scheduler keeps 104 slots available for steady background work", ()
     WORKER_CONFIG.workers.expansion_reserve;
   assert.equal(quietBackgroundCapacity, 104);
   assert.ok(quietBackgroundCapacity >= Math.floor(WORKER_CONFIG.workers.max * 0.8));
+});
+
+test("exact-review queue pressure throttles only background review lanes", () => {
+  assert.equal(
+    exactReviewQueuePressure({ pending: 0, dispatching: 0, leased: 28, capacity: 28 }),
+    "idle",
+  );
+  assert.equal(
+    exactReviewQueuePressure({ pending: 1, dispatching: 0, leased: 27, capacity: 28 }),
+    "idle",
+  );
+  assert.equal(
+    exactReviewQueuePressure({ pending: 3, dispatching: 1, leased: 27, capacity: 28 }),
+    "congested",
+  );
+  assert.equal(
+    exactReviewQueuePressure({ pending: 28, dispatching: 0, leased: 28, capacity: 28 }),
+    "saturated",
+  );
+
+  assert.equal(
+    workerLimit("normal_review", { exactReviewPressure: "congested" }),
+    AUTOMATION_LIMITS.exact_review.background_congested_max_workers,
+  );
+  assert.equal(
+    workerLimit("hot_intake", { exactReviewPressure: "saturated" }),
+    AUTOMATION_LIMITS.exact_review.background_saturated_max_workers,
+  );
+  assert.equal(
+    workerLimit("commit_review", { exactReviewPressure: "saturated" }),
+    AUTOMATION_LIMITS.exact_review.background_saturated_max_workers,
+  );
+  assert.equal(
+    workerLimit("repair", { exactReviewPressure: "saturated" }),
+    AUTOMATION_LIMITS.repair_live_runs.default,
+  );
+});
+
+test("workflow utility CLI classifies exact-review queue pressure", () => {
+  const output = execFileSync(
+    process.execPath,
+    [
+      path.resolve("dist/repair/workflow-utils.js"),
+      "exact-review-pressure",
+      "--pending",
+      "28",
+      "--dispatching",
+      "0",
+      "--leased",
+      "28",
+      "--capacity",
+      "28",
+    ],
+    { cwd: process.cwd(), encoding: "utf8" },
+  );
+  assert.equal(output, "saturated");
 });
 
 test("worker config defaults imported cluster repair capacity for older configs", () => {

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -251,21 +251,85 @@ test("worker scheduler keeps 104 slots available for steady background work", ()
 });
 
 test("exact-review queue pressure throttles only background review lanes", () => {
+  const healthyDispatcher = { dispatcherState: "active", handoffHealth: "healthy" };
   assert.equal(
-    exactReviewQueuePressure({ pending: 0, dispatching: 0, leased: 28, capacity: 28 }),
+    exactReviewQueuePressure({
+      pending: 0,
+      admissiblePending: 0,
+      dispatching: 0,
+      leased: 28,
+      capacity: 28,
+      ...healthyDispatcher,
+    }),
     "idle",
   );
   assert.equal(
-    exactReviewQueuePressure({ pending: 1, dispatching: 0, leased: 27, capacity: 28 }),
+    exactReviewQueuePressure({
+      pending: 1,
+      admissiblePending: 1,
+      dispatching: 0,
+      leased: 27,
+      capacity: 28,
+      ...healthyDispatcher,
+    }),
     "idle",
   );
   assert.equal(
-    exactReviewQueuePressure({ pending: 3, dispatching: 1, leased: 27, capacity: 28 }),
+    exactReviewQueuePressure({
+      pending: 3,
+      admissiblePending: 3,
+      dispatching: 1,
+      leased: 27,
+      capacity: 28,
+      ...healthyDispatcher,
+    }),
     "congested",
   );
   assert.equal(
-    exactReviewQueuePressure({ pending: 28, dispatching: 0, leased: 28, capacity: 28 }),
+    exactReviewQueuePressure({
+      pending: 28,
+      admissiblePending: 28,
+      dispatching: 0,
+      leased: 28,
+      capacity: 28,
+      ...healthyDispatcher,
+    }),
     "saturated",
+  );
+  assert.equal(
+    exactReviewQueuePressure({
+      pending: 28,
+      admissiblePending: 0,
+      dispatching: 0,
+      leased: 28,
+      capacity: 28,
+      ...healthyDispatcher,
+    }),
+    "idle",
+  );
+  assert.equal(
+    exactReviewQueuePressure({
+      pending: 28,
+      admissiblePending: 28,
+      dispatching: 0,
+      leased: 28,
+      capacity: 28,
+      dispatcherState: "paused",
+      handoffHealth: "healthy",
+    }),
+    "idle",
+  );
+  assert.equal(
+    exactReviewQueuePressure({
+      pending: 28,
+      admissiblePending: 28,
+      dispatching: 0,
+      leased: 28,
+      capacity: 28,
+      dispatcherState: "active",
+      handoffHealth: "stalled",
+    }),
+    "idle",
   );
 
   assert.equal(
@@ -294,12 +358,18 @@ test("workflow utility CLI classifies exact-review queue pressure", () => {
       "exact-review-pressure",
       "--pending",
       "28",
+      "--admissible-pending",
+      "28",
       "--dispatching",
       "0",
       "--leased",
       "28",
       "--capacity",
       "28",
+      "--dispatcher-state",
+      "active",
+      "--handoff-health",
+      "healthy",
     ],
     { cwd: process.cwd(), encoding: "utf8" },
   );

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -329,6 +329,30 @@ test("exact-review queue pressure throttles only background review lanes", () =>
       dispatcherState: "active",
       handoffHealth: "stalled",
     }),
+    "saturated",
+  );
+  assert.equal(
+    exactReviewQueuePressure({
+      pending: 3,
+      admissiblePending: 3,
+      dispatching: 1,
+      leased: 27,
+      capacity: 28,
+      dispatcherState: "active",
+      handoffHealth: "degraded",
+    }),
+    "congested",
+  );
+  assert.equal(
+    exactReviewQueuePressure({
+      pending: 28,
+      admissiblePending: 28,
+      dispatching: 0,
+      leased: 28,
+      capacity: 28,
+      dispatcherState: "active",
+      handoffHealth: "unknown",
+    }),
     "idle",
   );
 

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -369,6 +369,20 @@ test("exact-review queue pressure throttles only background review lanes", () =>
     AUTOMATION_LIMITS.exact_review.background_saturated_max_workers,
   );
   assert.equal(
+    workerLimit("commit_review", {
+      activeBackground: AUTOMATION_LIMITS.exact_review.background_saturated_max_workers - 1,
+      exactReviewPressure: "saturated",
+    }),
+    1,
+  );
+  assert.equal(
+    workerLimit("normal_review", {
+      activeBackground: AUTOMATION_LIMITS.exact_review.background_saturated_max_workers,
+      exactReviewPressure: "saturated",
+    }),
+    0,
+  );
+  assert.equal(
     workerLimit("repair", { exactReviewPressure: "saturated" }),
     AUTOMATION_LIMITS.repair_live_runs.default,
   );
@@ -1079,6 +1093,33 @@ test("workflow utilities expose review capacity telemetry from plans", () => {
       due_backlog: "17",
       oldest_unreviewed_at: "2026-01-01T00:00:00Z",
       capacity_reason: "under capacity: due backlog below planned capacity",
+    },
+  );
+});
+
+test("workflow utilities preserve a zero-capacity deferred review plan", () => {
+  assert.deepEqual(
+    planOutputFields(
+      {
+        capacity: 0,
+        candidates: [],
+        matrix: [],
+        activeCodexTarget: 0,
+        dueBacklog: 0,
+        capacityReason: "deferred: exact-review background cap occupied",
+      },
+      { batchSize: 3, shardCount: 1 },
+    ),
+    {
+      matrix: "[]",
+      planned_count: "0",
+      planned_capacity: "0",
+      planned_item_numbers: "",
+      planned_shards: "0",
+      active_codex_target: "0",
+      due_backlog: "0",
+      oldest_unreviewed_at: "",
+      capacity_reason: "deferred: exact-review background cap occupied",
     },
   );
 });

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -2134,8 +2134,14 @@ test("background review schedulers yield to a saturated exact-review queue", () 
     assert.match(block, /QUEUE_URL: \$\{\{ vars\.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL/);
     assert.match(block, /exact_review_queue_stats\(\)/);
     assert.match(block, /\$queue_url\/api\/status/);
+    assert.match(block, /admissible_pending/);
+    assert.match(block, /dispatcher\.state/);
+    assert.match(block, /handoff_health\.status/);
     assert.match(block, /exact-review-pressure/);
     assert.match(block, /--exact-review-pressure "\$exact_review_pressure"/);
+    assert.match(block, /--admissible-pending "\$exact_review_admissible_pending"/);
+    assert.match(block, /--dispatcher-state "\$exact_review_dispatcher_state"/);
+    assert.match(block, /--handoff-health "\$exact_review_handoff_health"/);
     assert.match(block, /queue telemetry was unavailable; using idle pressure \(fail open\)/);
     assert.match(block, /throttling .*review intake/);
   }

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -2118,6 +2118,36 @@ test("background review capacity reserves expanding matrices and caps broad manu
   assert.match(commitBlock, /reserved_shards="\$item_count"/);
 });
 
+test("background review schedulers yield to a saturated exact-review queue", () => {
+  const sweepWorkflow = readText(".github/workflows/sweep.yml");
+  const sweepBlock = sweepWorkflow.slice(
+    sweepWorkflow.indexOf("- id: mode"),
+    sweepWorkflow.indexOf("- id: select"),
+  );
+  const commitWorkflow = readText(".github/workflows/commit-review.yml");
+  const commitBlock = commitWorkflow.slice(
+    commitWorkflow.indexOf("- name: Select commits"),
+    commitWorkflow.indexOf('if [ "$ENABLED" = "false" ]'),
+  );
+
+  for (const block of [sweepBlock, commitBlock]) {
+    assert.match(block, /QUEUE_URL: \$\{\{ vars\.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL/);
+    assert.match(block, /exact_review_queue_stats\(\)/);
+    assert.match(block, /\$queue_url\/api\/status/);
+    assert.match(block, /exact-review-pressure/);
+    assert.match(block, /--exact-review-pressure "\$exact_review_pressure"/);
+    assert.match(block, /throttling .*review intake/);
+  }
+  assert.match(sweepBlock, /worker_limit hot_intake.*--exact-review-pressure/);
+  assert.match(sweepBlock, /worker_limit normal_review.*--exact-review-pressure/);
+  assert.match(commitBlock, /scheduler_page_size=.*worker-limit commit_review/);
+  assert.match(
+    commitBlock,
+    /elif \[ "\$exact_review_pressure" != "idle" \] && \[\[ "\$PAGE_SIZE" =~ \^\[0-9\]\+\$ \]\]/,
+  );
+  assert.match(commitBlock, /Capping commit-review page size/);
+});
+
 test("review backstops identify sweep runs by stable workflow path", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const block = workflow.slice(workflow.indexOf("- name: Queue review backstops"));

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -2074,7 +2074,6 @@ test("review capacity probes use REST actions run listing", () => {
     commitWorkflow.indexOf("- name: Select commits"),
     commitWorkflow.indexOf('if [ "$ENABLED" = "false" ]'),
   );
-
   for (const block of [sweepBlock, commitBlock]) {
     assert.match(block, /active_runs_json\(\)/);
     assert.match(block, /actions\/runs\?per_page=100/);
@@ -2102,6 +2101,17 @@ test("background review capacity reserves expanding matrices and caps broad manu
     commitWorkflow.indexOf("- name: Select commits"),
     commitWorkflow.indexOf('if [ "$ENABLED" = "false" ]'),
   );
+  const selectBlock = workflow.slice(
+    workflow.indexOf("- id: select"),
+    workflow.indexOf("- name: Prepare review runtime artifact"),
+  );
+  const commitSelectBlock = commitWorkflow.slice(
+    commitWorkflow.indexOf("- name: Select commits"),
+    commitWorkflow.indexOf(
+      'url="https://x-access-token:',
+      commitWorkflow.indexOf("- name: Select commits"),
+    ),
+  );
 
   assert.match(modeBlock, /limit review_shards\.hot_intake_default/);
   assert.match(modeBlock, /limit review_shards\.normal_default/);
@@ -2116,13 +2126,21 @@ test("background review capacity reserves expanding matrices and caps broad manu
   assert.match(modeBlock, /\[ "\$active_shards" -lt 1 \] && \[ "\$total_shards" -lt 1 \]/);
   assert.match(modeBlock, /lane_shard_cap="\$normal_shards"/);
   assert.match(modeBlock, /lane_shard_cap="\$hot_intake_shards"/);
+  assert.match(modeBlock, /if \[ "\$lane_shard_cap" -lt 1 \]; then/);
+  assert.match(modeBlock, /shard_count="0"/);
+  assert.match(modeBlock, /Deferring broad background review/);
   assert.match(modeBlock, /Capping broad background review shards/);
+  assert.match(selectBlock, /if \[ "\$SHARD_COUNT" -lt 1 \]; then/);
+  assert.match(selectBlock, /"capacity":0/);
+  assert.match(selectBlock, /deferred: exact-review background cap occupied/);
   assert.match(commitBlock, /limit review_shards\.hot_intake_default/);
   assert.match(commitBlock, /limit review_shards\.normal_default/);
   assert.match(commitBlock, /STALE_QUEUED_CUTOFF/);
   assert.match(commitBlock, /updatedAt:\.updated_at/);
   assert.match(commitBlock, /workflowPath == "\.github\/workflows\/sweep\.yml"/);
   assert.match(commitBlock, /\.displayTitle \| startswith\("Review event items "\)/);
+  assert.match(commitBlock, /\.displayTitle \| startswith\("Review target repo "\)/);
+  assert.match(commitBlock, /\.displayTitle \| startswith\("Review hot target repo "\)/);
   assert.match(commitBlock, /WORKFLOW_PATH="\$1"/);
   assert.doesNotMatch(commitBlock, /workflowName == "ClawSweeper"/);
   assert.doesNotMatch(commitBlock, /WORKFLOW_NAME="\$1"/);
@@ -2130,6 +2148,72 @@ test("background review capacity reserves expanding matrices and caps broad manu
   assert.match(commitBlock, /limit review_shards\.hard_cap/);
   assert.match(commitBlock, /reserved_shards="\$requested_shards"/);
   assert.match(commitBlock, /reserved_shards="\$item_count"/);
+  assert.match(commitBlock, /active_commit_review_workers\(\)/);
+  assert.match(commitBlock, /workflowPath == "\.github\/workflows\/commit-review\.yml"/);
+  assert.match(commitBlock, /\(\.databaseId \| tostring\) != env\.CURRENT_RUN_ID/);
+  assert.match(commitBlock, /startswith\("Review commit "\)/);
+  assert.match(modeBlock, /COMMIT_REVIEW_PAGE_SIZE/);
+  assert.match(modeBlock, /page_size_hard_cap="\$\(limit commit_review\.page_size_hard_cap\)"/);
+  assert.match(modeBlock, /reservation_page_size="\$\(limit commit_review\.page_size_default\)"/);
+  assert.match(modeBlock, /zero_review_name='Review commit \$'/);
+  assert.match(modeBlock, /zero_review_name\+='\{\{ matrix\.sha \}\}'/);
+  assert.match(modeBlock, /only an in-progress planner can reserve here/);
+  assert.doesNotMatch(
+    modeBlock,
+    /active_run_count "\.github\/workflows\/commit-review\.yml"\) \* commit_page_size/,
+  );
+  for (const liveWorkerFunction of [
+    extractWorkflowShellFunction(modeBlock, "active_sweep_background_workers"),
+    extractWorkflowShellFunction(modeBlock, "active_commit_review_workers"),
+    extractWorkflowShellFunction(commitBlock, "active_sweep_background_workers"),
+    extractWorkflowShellFunction(commitBlock, "active_commit_review_workers"),
+  ]) {
+    assert.match(liveWorkerFunction, /(?:select\(|and )\.status == "in_progress"/);
+    assert.doesNotMatch(
+      liveWorkerFunction,
+      /(?:select\(|and \()\.status == "in_progress" or \(\(\.status == "pending"/,
+    );
+  }
+  const commitBackgroundWorkers = extractWorkflowShellFunction(
+    commitBlock,
+    "active_sweep_background_workers",
+  );
+  const commitExactWorkers = extractWorkflowShellFunction(
+    commitBlock,
+    "active_sweep_exact_workers",
+  );
+  assert.match(commitBackgroundWorkers, /Review\\ hot\\ target\\ repo/);
+  assert.doesNotMatch(commitBackgroundWorkers, /Review event items/);
+  assert.match(commitExactWorkers, /startswith\("Review event item "\)/);
+  assert.match(commitExactWorkers, /startswith\("Review event items "\)/);
+  assert.match(commitExactWorkers, /Explicit exact batches are priority work/);
+  assert.match(commitBlock, /\$\(active_sweep_exact_workers\)/);
+  assert.match(commitBlock, /page_size_hard_cap="\$\(limit commit_review\.page_size_hard_cap\)"/);
+  assert.match(commitBlock, /reservation_page_size="\$PAGE_SIZE"/);
+  assert.match(commitBlock, /reservation_page_size="\$\(limit commit_review\.page_size_default\)"/);
+  assert.match(commitSelectBlock, /if \[ "\$PAGE_SIZE" -lt 1 \]; then/);
+  assert.match(commitSelectBlock, /Deferring commit review/);
+  assert.match(commitSelectBlock, /sleep 300/);
+  assert.match(commitSelectBlock, /gh workflow run commit-review\.yml/);
+  assert.match(commitSelectBlock, /for attempt in 1 2 3; do/);
+  assert.match(commitSelectBlock, /Deferred commit-review requeue attempt \$attempt failed/);
+  assert.match(
+    commitSelectBlock,
+    /Unable to requeue the deferred commit-review range after three attempts/,
+  );
+  assert.match(commitSelectBlock, /-f commit_offset="\$COMMIT_OFFSET"/);
+  assert.match(commitSelectBlock, /Requeued deferred commit-review range/);
+  assert.match(commitSelectBlock, /echo "matrix=\[\]"/);
+  assert.match(commitBlock, /zero_review_plan=false/);
+  assert.match(commitBlock, /zero_review_name='Review commit \$'/);
+  assert.match(commitBlock, /zero_review_name\+='\{\{ matrix\.sha \}\}'/);
+  assert.match(commitBlock, /\.name == env\.ZERO_REVIEW_NAME/);
+  assert.match(commitBlock, /\[ "\$zero_review_plan" != "true" \]/);
+  assert.match(commitBlock, /active_reviews="\$reservation_page_size"/);
+  assert.match(
+    commitBlock,
+    /active_background_workers="\$\(\( \$\(active_sweep_background_workers\) \+ \$\(active_commit_review_workers\) \)\)"/,
+  );
 });
 
 test("background review schedulers yield to a saturated exact-review queue", () => {
@@ -2272,7 +2356,7 @@ test("review backstops identify sweep runs by stable workflow path", () => {
   assert.doesNotMatch(block, /run\.workflowName/);
 });
 
-test("target review queues coalesce background work without delaying exact planners", () => {
+test("broad review planners serialize admission without delaying exact planners", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const concurrencyBlock = workflow.slice(
     workflow.indexOf("concurrency:"),
@@ -2281,6 +2365,11 @@ test("target review queues coalesce background work without delaying exact plann
   const planHeader = workflow.slice(
     workflow.indexOf("\n  plan:"),
     workflow.indexOf("\n    outputs:", workflow.indexOf("\n  plan:")),
+  );
+  const commitWorkflow = readText(".github/workflows/commit-review.yml");
+  const commitPlanHeader = commitWorkflow.slice(
+    commitWorkflow.indexOf("\n  plan:"),
+    commitWorkflow.indexOf("\n    outputs:", commitWorkflow.indexOf("\n  plan:")),
   );
 
   assert.match(concurrencyBlock, /&& 'clawsweeper-intake-v2'/);
@@ -2296,16 +2385,16 @@ test("target review queues coalesce background work without delaying exact plann
   assert.match(concurrencyBlock, /format\('clawsweeper-comment-sync-\{0\}', github\.run_id\)/);
   assert.match(concurrencyBlock, /format\('clawsweeper-apply-\{0\}', github\.run_id\)/);
   assert.doesNotMatch(concurrencyBlock, /queue: max/);
-  assert.match(planHeader, /group: \$\{\{ format\('clawsweeper-planner-\{0\}'/);
-  assert.match(
-    planHeader,
-    /github\.event_name == 'schedule' \|\| \(github\.event_name == 'workflow_dispatch'/,
-  );
-  assert.match(planHeader, /github\.event\.inputs\.item_number == ''/);
-  assert.match(planHeader, /github\.event\.inputs\.item_numbers == ''/);
-  assert.match(planHeader, /\|\| github\.run_id/);
-  assert.doesNotMatch(planHeader, /queue: max/);
+  assert.match(planHeader, /group: \$\{\{ format\('clawsweeper-review-admission-\{0\}'/);
+  assert.match(planHeader, /github\.event\.client_payload\.item_number/);
+  assert.match(planHeader, /github\.event\.client_payload\.item_numbers/);
+  assert.match(planHeader, /github\.event\.inputs\.item_number/);
+  assert.match(planHeader, /github\.event\.inputs\.item_numbers/);
+  assert.match(planHeader, /&& github\.run_id \|\| 'background'/);
+  assert.match(commitPlanHeader, /group: clawsweeper-review-admission-background/);
+  assert.match(planHeader, /queue: max/);
   assert.match(planHeader, /cancel-in-progress: false/);
+  assert.match(commitPlanHeader, /queue: max/);
 });
 
 test("scheduled normal review uses one item per shard for lease coverage", () => {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -2132,8 +2132,16 @@ test("background review schedulers yield to a saturated exact-review queue", () 
 
   for (const block of [sweepBlock, commitBlock]) {
     assert.match(block, /QUEUE_URL: \$\{\{ vars\.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL/);
+    assert.match(
+      block,
+      /CLAWSWEEPER_EXACT_REVIEW_QUEUE_MAX_AGE_SECONDS: \$\{\{ vars\.CLAWSWEEPER_EXACT_REVIEW_QUEUE_MAX_AGE_SECONDS/,
+    );
     assert.match(block, /exact_review_queue_stats\(\)/);
     assert.match(block, /\$queue_url\/api\/status/);
+    assert.match(block, /exact_review_queue\.generated_at/);
+    assert.match(block, /CLAWSWEEPER_EXACT_REVIEW_QUEUE_MAX_AGE_SECONDS/);
+    assert.match(block, /date -u -d "\$generated_at" '\+%s'/);
+    assert.match(block, /queue telemetry snapshot is stale/);
     assert.match(block, /admissible_pending/);
     assert.match(block, /dispatcher\.state/);
     assert.match(block, /handoff_health\.status/);
@@ -2158,6 +2166,85 @@ test("background review schedulers yield to a saturated exact-review queue", () 
     sweepBlock,
     /throttling broad review intake to normal=\$normal_shards and hot=\$hot_intake_shards/,
   );
+});
+
+function extractWorkflowShellFunction(block: string, functionName: string): string {
+  const header = `${functionName}() {`;
+  const start = block.indexOf(header);
+  assert.notEqual(start, -1, `missing shell function ${functionName}`);
+  const rest = block.slice(start);
+  const next = rest.slice(header.length).search(/\n          [a-zA-Z0-9_]+\(\) \{/);
+  const end = next === -1 ? rest.length : header.length + next;
+  return rest.slice(0, end).replace(/^          /gm, "");
+}
+
+function runExactReviewQueueStats(block: string, response: Record<string, unknown>): string {
+  const functionBody = extractWorkflowShellFunction(block, "exact_review_queue_stats");
+  const script = [
+    functionBody,
+    `jq() {
+      if [[ "$*" == *generated_at* ]]; then
+        node -e 'const fs=require("fs");const data=JSON.parse(fs.readFileSync(0,"utf8"));const q=data.exact_review_queue||{};const value=typeof q.generated_at==="string"?q.generated_at:"";process.stdout.write(value+"\\n");'
+      else
+        node -e 'const fs=require("fs");const data=JSON.parse(fs.readFileSync(0,"utf8"));const q=data.exact_review_queue||{};const count=(value)=>Number.isFinite(value)&&value>=0?Math.floor(value):0;const text=(value)=>typeof value==="string"?value:"";console.log([count(q.pending),count(q.admissible_pending),count(q.dispatching),count(q.leased),count(q.handoff_health&&q.handoff_health.capacity),text(q.dispatcher&&q.dispatcher.state),text(q.handoff_health&&q.handoff_health.status)].join("\\t"));'
+      fi
+    }`,
+    'curl() { printf "%s" "$QUEUE_RESPONSE"; }',
+    'QUEUE_URL="https://queue.example"',
+    'output="$(exact_review_queue_stats 2>&1)"',
+    "status=$?",
+    'printf "status=%s\\n%s" "$status" "$output"',
+  ].join("\n");
+  return execFileSync("bash", ["-lc", script], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CLAWSWEEPER_EXACT_REVIEW_QUEUE_MAX_AGE_SECONDS: "60",
+      QUEUE_RESPONSE: JSON.stringify(response),
+    },
+  });
+}
+
+test("background review schedulers fail open on stale exact-review telemetry", () => {
+  const sweepWorkflow = readText(".github/workflows/sweep.yml");
+  const sweepBlock = sweepWorkflow.slice(
+    sweepWorkflow.indexOf("- id: mode"),
+    sweepWorkflow.indexOf("- id: select"),
+  );
+  const commitWorkflow = readText(".github/workflows/commit-review.yml");
+  const commitBlock = commitWorkflow.slice(
+    commitWorkflow.indexOf("- name: Select commits"),
+    commitWorkflow.indexOf('if [ "$ENABLED" = "false" ]'),
+  );
+  const freshGeneratedAt = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  const healthyFullQueue = {
+    generated_at: "1970-01-01T00:00:00Z",
+    exact_review_queue: {
+      generated_at: freshGeneratedAt,
+      pending: 243,
+      admissible_pending: 243,
+      dispatching: 0,
+      leased: 28,
+      handoff_health: { capacity: 28, status: "healthy" },
+      dispatcher: { state: "active" },
+    },
+  };
+  const staleHealthyQueue = {
+    ...healthyFullQueue,
+    exact_review_queue: {
+      ...healthyFullQueue.exact_review_queue,
+      generated_at: "1970-01-01T00:00:00Z",
+    },
+  };
+
+  for (const block of [sweepBlock, commitBlock]) {
+    const freshOutput = runExactReviewQueueStats(block, healthyFullQueue);
+    assert.match(freshOutput, /^status=0\n243\t243\t0\t28\t28\tactive\thealthy$/);
+
+    const staleOutput = runExactReviewQueueStats(block, staleHealthyQueue);
+    assert.match(staleOutput, /^status=1\n/);
+    assert.match(staleOutput, /queue telemetry snapshot is stale/);
+  }
 });
 
 test("review backstops identify sweep runs by stable workflow path", () => {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -2136,6 +2136,7 @@ test("background review schedulers yield to a saturated exact-review queue", () 
     assert.match(block, /\$queue_url\/api\/status/);
     assert.match(block, /exact-review-pressure/);
     assert.match(block, /--exact-review-pressure "\$exact_review_pressure"/);
+    assert.match(block, /queue telemetry was unavailable; using idle pressure \(fail open\)/);
     assert.match(block, /throttling .*review intake/);
   }
   assert.match(sweepBlock, /worker_limit hot_intake.*--exact-review-pressure/);
@@ -2146,6 +2147,11 @@ test("background review schedulers yield to a saturated exact-review queue", () 
     /elif \[ "\$exact_review_pressure" != "idle" \] && \[\[ "\$PAGE_SIZE" =~ \^\[0-9\]\+\$ \]\]/,
   );
   assert.match(commitBlock, /Capping commit-review page size/);
+  assert.match(commitBlock, /throttling commit review intake to page_size=\$PAGE_SIZE/);
+  assert.match(
+    sweepBlock,
+    /throttling broad review intake to normal=\$normal_shards and hot=\$hot_intake_shards/,
+  );
 });
 
 test("review backstops identify sweep runs by stable workflow path", () => {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -2229,6 +2229,14 @@ test("background review schedulers yield to a saturated exact-review queue", () 
   );
 
   for (const block of [sweepBlock, commitBlock]) {
+    assert.match(
+      block,
+      /EXACT_REVIEW_BACKGROUND_YIELD_ENABLED: \$\{\{ vars\.CLAWSWEEPER_ENABLE_EXACT_REVIEW_BACKGROUND_YIELD \|\| '0' \}\}/,
+    );
+    assert.match(
+      block,
+      /if \[ "\$EXACT_REVIEW_BACKGROUND_YIELD_ENABLED" = "1" \]; then\s+if exact_review_stats=/,
+    );
     assert.match(block, /QUEUE_URL: \$\{\{ vars\.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL/);
     assert.match(
       block,
@@ -2356,7 +2364,7 @@ test("review backstops identify sweep runs by stable workflow path", () => {
   assert.doesNotMatch(block, /run\.workflowName/);
 });
 
-test("broad review planners serialize admission without delaying exact planners", () => {
+test("background-yield admission is opt-in and keeps exact planners independent", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const concurrencyBlock = workflow.slice(
     workflow.indexOf("concurrency:"),
@@ -2385,13 +2393,25 @@ test("broad review planners serialize admission without delaying exact planners"
   assert.match(concurrencyBlock, /format\('clawsweeper-comment-sync-\{0\}', github\.run_id\)/);
   assert.match(concurrencyBlock, /format\('clawsweeper-apply-\{0\}', github\.run_id\)/);
   assert.doesNotMatch(concurrencyBlock, /queue: max/);
-  assert.match(planHeader, /group: \$\{\{ format\('clawsweeper-review-admission-\{0\}'/);
+  assert.match(planHeader, /format\('clawsweeper-review-admission-\{0\}', github\.run_id\)/);
   assert.match(planHeader, /github\.event\.client_payload\.item_number/);
   assert.match(planHeader, /github\.event\.client_payload\.item_numbers/);
   assert.match(planHeader, /github\.event\.inputs\.item_number/);
   assert.match(planHeader, /github\.event\.inputs\.item_numbers/);
-  assert.match(planHeader, /&& github\.run_id \|\| 'background'/);
-  assert.match(commitPlanHeader, /group: clawsweeper-review-admission-background/);
+  assert.match(
+    planHeader,
+    /vars\.CLAWSWEEPER_ENABLE_EXACT_REVIEW_BACKGROUND_YIELD == '1' && 'clawsweeper-review-admission-background'/,
+  );
+  assert.match(planHeader, /format\('clawsweeper-planner-\{0\}'/);
+  assert.match(
+    planHeader,
+    /github\.event_name == 'repository_dispatch' && github\.event\.client_payload\.target_repo/,
+  );
+  assert.match(
+    commitPlanHeader,
+    /vars\.CLAWSWEEPER_ENABLE_EXACT_REVIEW_BACKGROUND_YIELD == '1' && 'clawsweeper-review-admission-background'/,
+  );
+  assert.match(commitPlanHeader, /format\('commit-review-plan-\{0\}', github\.run_id\)/);
   assert.match(planHeader, /queue: max/);
   assert.match(planHeader, /cancel-in-progress: false/);
   assert.match(commitPlanHeader, /queue: max/);

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1984,15 +1984,29 @@ test("sweep workflow_dispatch input count stays under GitHub limit", () => {
   assert.ok(inputNames.length <= 25, `workflow_dispatch has ${inputNames.length} inputs`);
 });
 
-test("sweep review continuations stay workflow-dispatch compatible", () => {
+test("sweep review continuations reapply the current pressure cap", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const continueBlock = workflow.slice(
     workflow.indexOf("- name: Continue sweep"),
     workflow.indexOf("\n\n  recover-review-failures:"),
   );
-
   assert.match(continueBlock, /-f target_repo="\$\{\{ needs\.plan\.outputs\.target_repo \}\}"/);
   assert.match(continueBlock, /-f target_branch="\$\{\{ needs\.plan\.outputs\.target_branch \}\}"/);
+  const modeBlock = workflow.slice(
+    workflow.indexOf("- id: mode"),
+    workflow.indexOf("- id: select"),
+  );
+
+  assert.match(continueBlock, /-f shard_count="\$\{\{ needs\.plan\.outputs\.shard_count \}\}"/);
+  assert.match(
+    modeBlock,
+    /shard_count="\$\{\{ github\.event\.client_payload\.shard_count \|\| github\.event\.inputs\.shard_count \|\| '' \}\}"/,
+  );
+  assert.match(modeBlock, /if \[ -z "\$exact_item" \]; then/);
+  assert.match(modeBlock, /lane_shard_cap="\$normal_shards"/);
+  assert.match(modeBlock, /lane_shard_cap="\$hot_intake_shards"/);
+  assert.match(modeBlock, /if \[ "\$shard_count" -gt "\$lane_shard_cap" \]; then/);
+  assert.match(modeBlock, /Capping broad background review shards/);
 });
 
 test("failed review recovery waits for durable exact-review queue acknowledgement", () => {


### PR DESCRIPTION
## Status

**Draft — do not merge or enable yet.** This is an optional scheduler experiment,
not the production repair for the exact-review backlog incident.

## Relationship to the incident work

- [#545](https://github.com/openclaw/clawsweeper/pull/545) is the deployed
  recovery work: it increased exact-review admission/recovery capacity and
  reconciles completion pressure. This branch is rebased on current `main`,
  which includes that PR.
- Current incident evidence showed leases being held after useful review work
  while state/action-ledger publication and lease completion were blocked. This
  PR does **not** repair that state-publication path and cannot create another
  exact-review slot.
- Current `main` also includes the rollback of #521's action-lifecycle
  expansion. This branch preserves that rollback rather than restoring it.

## Proposed optional behavior

The experiment is disabled unless a maintainer explicitly sets this repository
variable to exactly `1`:

```text
CLAWSWEEPER_ENABLE_EXACT_REVIEW_BACKGROUND_YIELD=1
```

With the variable unset, the changed planners retain their ordinary
per-target/independent admission groups, do not fetch exact-review pressure,
and pass `idle` pressure to the scheduler. Exact-item planners remain
independently admitted.

With the variable enabled, healthy, fresh exact-review telemetry can reduce
broad background review allowance to the configured 16/4 caps while the
exact-review lane is full and has admissible pending work. Missing, malformed,
or stale telemetry fails open. Continuations are admitted again and re-evaluate
the cap; background target-sweep fanouts preserve per-target planner grouping.

The supporting limits, dashboard telemetry, and tests are included so a future
controlled rollout can measure that policy. No variable, gate, or production
workflow setting is changed by this PR.

## Non-goals

- It does not raise the exact-review global cap (64) or per-target cap (60).
- It does not fix state-ledger contention, post-review publication, or stuck
  lease completion.
- It does not claim that yielding broad work alone drains the current backlog.

## Rollout decision

Keep this PR draft. Before considering a limited maintainer-owned trial, agree
the policy values and collect runtime evidence for: fresh-pressure throttling,
stale-telemetry fail-open behavior, bounded deferral/requeue, automatic broad
work resumption, exact backlog slope, and publish-to-lease-completion latency.
Do not enable the variable as part of this PR.

## Validation

- `node --test --test-name-pattern "sweep review continuations reapply|background review schedulers yield|background-yield admission" test/sweep-workflow.test.ts` — 3 passed.
- `node --test test/repair/workflow-utils.test.ts test/dashboard-worker.test.ts` — 155 passed.
- `pnpm check:limits` and `git diff --check origin/main...HEAD` — passed.
- `pnpm run check` completed active-surface, limits, build, and lint. Its unit
  stage is not runnable on this Windows host because the default WSL image has
  no `/bin/bash`; a raw Linux Node 24 container reached the same stage but lacks
  `jq` required by unrelated shell-fixture tests. No platform or line-ending
  change is included here.
- `codex review --uncommitted` — final clean after accepting and fixing the
  target-fanout admission finding.
- `codex review --base origin/main` — clean: no actionable correctness issues.

`actionlint` was not installed in the local environment; workflow syntax and
the static workflow assertions above were exercised instead.
