### PR TITLE
fix(ledger): create spam intake output root

### DIFF
--- a/.github/workflows/github-activity.yml
+++ b/.github/workflows/github-activity.yml
@@ -186,6 +186,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p .artifacts
+          mkdir -p "$CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT"
           pnpm run --silent repair:action-ledger -- finalize \
             --repair-lane spam-comment-intake \
             --allow-empty \

--- a/test/repair/repair-ops-action-ledger.test.ts
+++ b/test/repair/repair-ops-action-ledger.test.ts
@@ -427,6 +427,7 @@ test("commit review and notification workflows publish their operation receipts"
   );
   assert.ok(spamFinalizer?.id);
   assert.match(spamFinalizer?.run ?? "", /--repair-lane spam-comment-intake/);
+  assert.match(spamFinalizer?.run ?? "", /mkdir -p "\$CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT"/);
   assert.ok(activityFinalizer?.id);
   assert.match(
     activityPublisher?.if ?? "",


### PR DESCRIPTION
## Summary

Create the GitHub-activity spam-intake action-ledger output directory before the always-run finalizer reads it.

## Problem

The GitHub-activity workflow deliberately uses an isolated, per-run spam-intake ledger root. When intake is skipped or produces no output, that override has not created its output directory. The finalizer then fails closed with `missing action event shard output root`, making the `notify` check fail.

## Implementation

- Create the configured output root immediately before finalizing the spam-intake ledger.
- Add a workflow-contract regression assertion for that prerequisite.

## Validation

- `pnpm run build:all`
- `node --test test/repair/repair-ops-action-ledger.test.ts`
- `pnpm exec oxfmt --check test/repair/repair-ops-action-ledger.test.ts`
- `git diff --check`
- `docker run --rm -v "${PWD}:/workspace:ro" -w /workspace rhysd/actionlint:1.7.10 -color .github/workflows/github-activity.yml`
- GitHub `pnpm check` — passed (9m56s).

## CI caveat

The remaining red `notify` check is a `pull_request_target` run. GitHub executes that workflow definition from the base branch, so its log necessarily lacks this PR’s new directory creation and repeats the production failure this PR fixes. The normal branch checks validate this change; the `notify` check cannot turn green until the base workflow contains the fix.

## Codex review

- `codex review --uncommitted` — clean; no actionable findings.
- `codex review --base origin/main` — clean; no actionable findings.

## Risk and rollout

This creates only the already-configured isolated temporary output directory. It does not change App tokens, state publication, event contents, or permission scopes. The ledger finalizer retains its existing safe-read validation and fails closed for an invalid path.
