### PR TITLE
fix(deploy): preserve Worker CPU limits

### DIFF
--- a/.github/workflows/deploy-crawl-remote.yml
+++ b/.github/workflows/deploy-crawl-remote.yml
@@ -244,6 +244,7 @@ jobs:
               '$schema',
               'compatibility_date',
               'd1_databases',
+              'limits',
               'main',
               'name',
               'observability',
@@ -258,6 +259,7 @@ jobs:
             sourceConfig.name !== 'crawl-remote' ||
             sourceConfig.main !== 'src/index.ts' ||
             sourceConfig.workers_dev !== true ||
+            JSON.stringify(sourceConfig.limits) !== JSON.stringify({ cpu_ms: 300000 }) ||
             sourceConfig.vars?.CRAWL_REMOTE_RELEASE_SHA !== undefined
           ) {
             throw new Error('source Wrangler config has an unexpected deployment identity');
@@ -294,6 +296,7 @@ jobs:
             compatibility_date: sourceConfig.compatibility_date,
             workers_dev: sourceConfig.workers_dev,
             observability: sourceConfig.observability,
+            limits: sourceConfig.limits,
             vars: sourceConfig.vars,
             routes: sourceConfig.routes,
             d1_databases: sourceConfig.d1_databases,
@@ -1180,6 +1183,7 @@ jobs:
             [
               'compatibility_date',
               'd1_databases',
+              'limits',
               'name',
               'observability',
               'r2_buckets',
@@ -1192,6 +1196,7 @@ jobs:
           if (
             config.name !== 'crawl-remote' ||
             config.workers_dev !== true ||
+            JSON.stringify(config.limits) !== JSON.stringify({ cpu_ms: 300000 }) ||
             config.vars?.CRAWL_REMOTE_RELEASE_SHA !== undefined ||
             Object.hasOwn(config, 'main') ||
             Object.hasOwn(config, 'build')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Preserved crawl-remote's reviewed `limits.cpu_ms` value through immutable
+  release packaging and post-transfer deployment verification.
 - Reverted the action-lifecycle expansion from PR #521, restoring the pre-merge ClawSweeper paths while retaining later exact-review throughput fixes and retrying coalesced reconciliations after any partial lookup failure.
 - Raised exact-review capacity from 48/44 global/per-target workers to 64/60, shortened unclaimed dispatch recovery from ten to six minutes, and coalesced terminal-run reconciliation bursts into one bounded aggregate claim scan.
 - Expanded exact-review backlog capacity while making background review yield, released exact-review leases before ledger publication, and aggregated healthy retry scans into one bounded ledger summary.

--- a/test/crawl-remote-deploy-workflow.test.ts
+++ b/test/crawl-remote-deploy-workflow.test.ts
@@ -959,6 +959,8 @@ test("release artifact is immutable, bounded, canonical, and hash verified", () 
   assert.match(packaging, /entry\.isFile\(\)/);
   assert.match(packaging, /isSymbolicLink\(\)/);
   assert.match(packaging, /source Wrangler config has an unexpected deployment identity/);
+  assert.match(packaging, /sourceConfig\.limits.*cpu_ms: 300000/s);
+  assert.match(packaging, /limits: sourceConfig\.limits/);
   assert.match(packaging, /sourceConfig\.vars\?\.CRAWL_REMOTE_RELEASE_SHA/);
   assert.match(packaging, /source Wrangler config targets unexpected production resources/);
   assert.match(packaging, /allowedBundleEntries/);
@@ -1013,6 +1015,7 @@ test("release artifact is immutable, bounded, canonical, and hash verified", () 
   assert.match(verify, /wrangler\.json/);
   assert.match(verify, /\^migrations\\\/\[0-9\]\{4\}/);
   assert.match(verify, /deployment Wrangler config has unsafe execution fields/);
+  assert.match(verify, /config\.limits.*cpu_ms: 300000/s);
   assert.match(verify, /config\.vars\?\.CRAWL_REMOTE_RELEASE_SHA/);
   assert.match(verify, /Object\.hasOwn\(config, 'build'\)/);
   assert.match(verify, /deployment Wrangler config targets unexpected resources/);
@@ -1068,6 +1071,7 @@ test("release packaging accepts Wrangler metadata and rejects unsupported output
       compatibility_date: "2026-05-27",
       workers_dev: true,
       observability: { enabled: true },
+      limits: { cpu_ms: 300000 },
       vars: {},
       routes: [
         {
@@ -1120,6 +1124,22 @@ test("release packaging accepts Wrangler metadata and rejects unsupported output
 
   try {
     assert.equal(packageBundle().status, 0);
+    const packagedConfig = JSON.parse(readFileSync(join(artifactRoot, "wrangler.json"), "utf8"));
+    assert.deepEqual(packagedConfig.limits, { cpu_ms: 300000 });
+
+    const sourceConfigPath = join(directory, "wrangler.jsonc");
+    const sourceConfig = JSON.parse(readFileSync(sourceConfigPath, "utf8"));
+    writeFileSync(
+      sourceConfigPath,
+      JSON.stringify({ ...sourceConfig, limits: { cpu_ms: 299999 } }),
+    );
+    const changedLimit = packageBundle();
+    assert.notEqual(changedLimit.status, 0);
+    assert.match(
+      changedLimit.stdout + changedLimit.stderr,
+      /source Wrangler config has an unexpected deployment identity/,
+    );
+    writeFileSync(sourceConfigPath, JSON.stringify(sourceConfig));
 
     rmSync(join(directory, "migrations", "0007_gitcrawl_snapshot_provenance.sql"));
     const missingMigration = packageBundle();
@@ -1204,6 +1224,7 @@ test("artifact verifier rejects tampering, extras, cross-state reuse, and oversi
         compatibility_date: "2026-05-27",
         workers_dev: true,
         observability: { enabled: true },
+        limits: { cpu_ms: 300000 },
         vars: {},
         routes: [
           {


### PR DESCRIPTION
## What Problem This Solves

The protected crawl-remote deployment rejected the current reviewed Worker config because `limits.cpu_ms` was absent from ClawSweeper's exact Wrangler allowlist. Simply accepting the field would still have dropped it from the generated deployment artifact.

The fail-closed production repro is visible in:
https://github.com/openclaw/clawsweeper/actions/runs/29321683975

## Why This Change Was Made

- admit only the exact reviewed `limits: { cpu_ms: 300000 }` value
- preserve that value in the immutable deployment config
- verify the same value again after artifact transfer
- reject any changed CPU limit before privileged deployment

## User Impact

The current crawl-remote main can pass protected release packaging without silently losing its five-minute CPU budget. Future limit changes remain fail-closed and require an explicit reviewed workflow update.

## Evidence

- `node --test test/crawl-remote-deploy-workflow.test.ts`: 27/27 passed
- local ClawSweeper whole-range review against `9b54a94f448fa923422dcda34c4c6fc6aec37d69`: no correctness or security findings
- actual crawl-remote `31a59f516c8a352ec8dedfc28303673449672ac6` bundle built with pinned Wrangler `4.107.1`
- exact inline packager and artifact verifier both passed with all eight production migrations
- emitted `wrangler.json` contains `limits.cpu_ms = 300000`
- emitted Wrangler config SHA-256: `766723443612ef2b6915db0bc90cb88e21c31f379092354b4aa1edd04e45de69`
- emitted manifest SHA-256: `1a38289129992e72f5842cf9d426af3be2d3c7b0ca1dd5d37d6034192251e16e`
- changelog updated under `0.3.1 - Unreleased`
