### PR TITLE
fix(workflow): initialize empty spam ledgers

### DIFF
--- a/.github/workflows/github-activity.yml
+++ b/.github/workflows/github-activity.yml
@@ -185,7 +185,10 @@ jobs:
           CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT: ${{ runner.temp }}/clawsweeper-spam-comment-intake/${{ github.run_id }}/${{ github.run_attempt }}/output
         run: |
           set -euo pipefail
-          mkdir -p .artifacts
+          mkdir -p \
+            "$CLAWSWEEPER_ACTION_LEDGER_ROOT" \
+            "$CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT" \
+            .artifacts
           pnpm run --silent repair:action-ledger -- finalize \
             --repair-lane spam-comment-intake \
             --allow-empty \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ checkpoint, and status-only commits are intentionally omitted.
 - Expanded exact-review backlog capacity while making background review yield, released exact-review leases before ledger publication, and aggregated healthy retry scans into one bounded ledger summary.
 - Accepted package-manager argument separators in the action-ledger CLI and
   allowed proven zero-command router runs to finish without empty publication.
+- Initialized the spam-intake ledger roots before allowed-empty finalization so
+  unsupported GitHub activity events no longer fail the notification workflow.
 - Made action-ledger publication include every transactional import binding,
   added pre-dispatch apply and retry receipts with conservative unknown-outcome
   recovery, failed active apply items on runtime yield, preserved skipped apply

--- a/test/repair/repair-ops-action-ledger.test.ts
+++ b/test/repair/repair-ops-action-ledger.test.ts
@@ -426,6 +426,10 @@ test("commit review and notification workflows publish their operation receipts"
     /clawsweeper-spam-comment-intake/,
   );
   assert.ok(spamFinalizer?.id);
+  assert.match(
+    spamFinalizer?.run ?? "",
+    /mkdir -p[\s\S]*"\$CLAWSWEEPER_ACTION_LEDGER_ROOT"[\s\S]*"\$CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT"[\s\S]*--allow-empty/,
+  );
   assert.match(spamFinalizer?.run ?? "", /--repair-lane spam-comment-intake/);
   assert.ok(activityFinalizer?.id);
   assert.match(


### PR DESCRIPTION
## What Problem This Solves

The `github activity to openclaw` workflow fails on normal `pull_request_target` deliveries after spam intake correctly reports that the event type is unsupported. The allowed-empty action-ledger finalizer then rejects the spam lane because its isolated spool and output roots were never created.

Failing production run:
https://github.com/openclaw/clawsweeper/actions/runs/29322213365

## Why This Change Was Made

The workflow now creates its exact run-scoped spam ledger roots before allowed-empty finalization. This keeps the action-ledger reader fail-closed while making the explicitly supported empty lane valid.

## User Impact

Routine pull-request activity no longer leaves a failing notification check solely because no spam-intake action was applicable.

## Evidence

- `node --test test/repair/repair-ops-action-ledger.test.ts`: 11/11 passed
- focused workflow assertion requires both isolated roots before `--allow-empty`
- exact workflow-shaped empty finalization succeeded with `event_paths: []`
- generated manifest SHA-256: `01d06ad67d3fea7214327e77ba902fc74a07b6b4339b4ed24ddfa07652f7b67e`
- local ClawSweeper whole-range review found no correctness or security issues
- changelog updated under `0.3.1 - Unreleased`
