### PR TITLE
feat(gitcrawl): add six-query evidence core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,6 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Added
 
-- Added a fail-closed, read-only Gitcrawl evidence core for six snapshot-bound
-  local, cloud, and parity queries with repository- and argument-bound claims,
-  complete-or-rejected graph packets, strict parity, and bounded transport
-  behavior.
 - Added end-to-end exact-review handoff health with phase ages, delayed/stalled claim classification, and a phase-aware operator rail on the live dashboard.
 - Added a maintainer-only two-runner workflow that builds a hash-bound
   crawl-remote release artifact without production credentials, then requires

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Added
 
+- Added a fail-closed, read-only Gitcrawl evidence core for six snapshot-bound
+  local, cloud, and parity queries with digest-bound claims and graph packets.
 - Added end-to-end exact-review handoff health with phase ages, delayed/stalled claim classification, and a phase-aware operator rail on the live dashboard.
 - Added a maintainer-only two-runner workflow that builds a hash-bound
   crawl-remote release artifact without production credentials, then requires

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ checkpoint, and status-only commits are intentionally omitted.
 ### Added
 
 - Added a fail-closed, read-only Gitcrawl evidence core for six snapshot-bound
-  local, cloud, and parity queries with digest-bound claims and graph packets.
+  local, cloud, and parity queries with repository- and argument-bound claims,
+  complete-or-rejected graph packets, strict parity, and bounded transport
+  behavior.
 - Added end-to-end exact-review handoff health with phase ages, delayed/stalled claim classification, and a phase-aware operator rail on the live dashboard.
 - Added a maintainer-only two-runner workflow that builds a hash-bound
   crawl-remote release artifact without production credentials, then requires

--- a/docs/repair/gitcrawl-evidence.md
+++ b/docs/repair/gitcrawl-evidence.md
@@ -53,6 +53,10 @@ Local freshness is accepted only from a completed, repository-scoped full/open
 sync or a complete open-reconciliation tuple. Export timestamps and database
 mtime are not freshness proof.
 
+Cluster coverage additionally requires the latest successful cluster run to
+have started at or after the accepted source sync. Portable exports that omit
+cluster-run provenance cannot certify cluster queries.
+
 ## Evidence Binding
 
 Normalized rows become digest-bound claims containing:

--- a/docs/repair/gitcrawl-evidence.md
+++ b/docs/repair/gitcrawl-evidence.md
@@ -1,0 +1,100 @@
+# Gitcrawl Query Evidence
+
+ClawSweeper has a read-only, provider-neutral Gitcrawl evidence core for six
+queries:
+
+- `gitcrawl.clusters.list`
+- `gitcrawl.clusters.members`
+- `gitcrawl.clusters.related`
+- `gitcrawl.threads.search`
+- `gitcrawl.pull_requests.review_context`
+- `gitcrawl.coverage`
+
+The core snapshots, validates, normalizes, and digest-binds query results. It
+does not mutate Gitcrawl, GitHub, repair jobs, workflows, or durable state.
+
+## Providers
+
+`local` opens the configured SQLite database read-only, creates a private
+`VACUUM INTO` snapshot, verifies it with `pragma quick_check`, and serves all
+queries from that snapshot. The snapshot file digest becomes its identity.
+Legacy cluster tables are rejected unless explicitly allowed.
+
+`cloud` posts the versioned query contract to a crawl-remote HTTPS endpoint.
+It requires a bearer token, a complete Cloudflare Access service-token pair,
+or both. Redirects, origin changes, unbounded responses, malformed row
+projections, and response bodies over 512 KiB are rejected.
+
+`parity` treats cloud as primary and compares normalized rows and required
+coverage against a local snapshot before returning evidence.
+
+## Snapshot Contract
+
+Every response is bound to one repository, archive, snapshot, source sync,
+dataset generation, schema, capability set, and coverage state. The cloud
+snapshot id must be the same lowercase SHA-256 digest as `source_sha256`.
+
+The initial `gitcrawl.coverage` query pins the session. Later pages or queries
+that change any pinned identity field fail closed. Opaque pagination is
+transport-local and bounded by page and row limits; this core does not expose
+or persist repair scan cursors.
+
+Coverage is query-specific:
+
+- cluster queries require repository, thread, cluster-group, and membership
+  coverage;
+- thread search requires repository and thread coverage;
+- pull-request review context additionally requires complete PR detail and file
+  coverage.
+
+Local freshness is accepted only from a completed, repository-scoped full/open
+sync or a complete open-reconciliation tuple. Export timestamps and database
+mtime are not freshness proof.
+
+## Evidence Binding
+
+Normalized rows become digest-bound claims containing:
+
+- provider and snapshot identity;
+- query name and canonical argument digest;
+- canonical repository subject;
+- source revision and thread fingerprint when available;
+- graph relations;
+- bounded normalized data;
+- semantic and full claim SHA-256 digests.
+
+Claims can be assembled into a bounded evidence packet with coverage, graph
+nodes, graph edges, included counts, and a packet digest. Verification rebuilds
+the graph from verified claims and rejects mixed snapshots, missing required
+coverage, malformed persisted coverage, and digest tampering.
+
+Thread safety classification uses the complete source title, body, labels,
+assignees, actor identity, and author association before prompt fields are
+bounded. HTML comments are removed recursively from prompt-facing values, and
+sanitized object-key collisions are rejected.
+
+## Fail-Closed Rules
+
+The query core rejects:
+
+- stale, incomplete, mixed, or malformed snapshot provenance;
+- unsupported query names or contract versions;
+- incomplete required dataset coverage;
+- provider cursor replay or page-limit exhaustion;
+- cloud authentication, HTTPS, redirect, origin, envelope, or size failures;
+- cloud/local parity drift;
+- cluster members from another cluster or incomplete declared membership;
+- related rows bound to another source or to themselves;
+- search rows that are not open pull requests or violate requested ordering;
+- review context without one exact pull request and its complete contiguous
+  file set;
+- malformed revision, fingerprint, Git object, timestamp, actor, or numeric
+  fields;
+- hidden HTML-comment content reaching a claim;
+- mixed or tampered claims, coverage, graph data, or packet digests.
+
+## Deliberate Non-Goals
+
+This core does not include repair-action-ledger events, job publication
+transactions, importer state, durable scan cursors, workflow activation,
+GitHub mutation, PR lifecycle handling, or raw provider logs.

--- a/docs/repair/gitcrawl-evidence.md
+++ b/docs/repair/gitcrawl-evidence.md
@@ -36,8 +36,10 @@ snapshot id must be the same lowercase SHA-256 digest as `source_sha256`.
 
 The initial `gitcrawl.coverage` query pins the session. Later pages or queries
 that change any pinned identity field fail closed. Opaque pagination is
-transport-local and bounded by page and row limits; this core does not expose
-or persist repair scan cursors.
+transport-local and bounded by page and row limits. Row limits are part of the
+canonical query arguments, and reaching one before the provider's terminal page
+is rejected rather than represented as complete evidence. This core does not
+expose or persist repair scan cursors.
 
 Coverage is query-specific:
 
@@ -72,8 +74,9 @@ missing required coverage, malformed persisted coverage, and digest tampering.
 
 Thread safety classification uses the complete source title, body, labels,
 assignees, actor identity, and author association before prompt fields are
-bounded. HTML comments are removed recursively from prompt-facing values, and
-sanitized object-key collisions are rejected.
+bounded. Every query shape for one thread must produce the same safety
+projection. Nested HTML comments are removed completely from prompt-facing
+values, and sanitized object-key collisions are rejected.
 
 ## Fail-Closed Rules
 
@@ -82,19 +85,21 @@ The query core rejects:
 - stale, incomplete, mixed, or malformed snapshot provenance;
 - unsupported query names or contract versions;
 - incomplete required dataset coverage;
-- provider cursor replay or page-limit exhaustion;
+- provider cursor replay, duplicate row identity, nonterminal row truncation, or
+  page-limit exhaustion;
 - cloud authentication, HTTPS, redirect, origin, envelope, or size failures;
 - server throttling windows that exceed the configured retry wait budget;
 - cloud/local parity drift;
-- cluster members from another cluster or incomplete declared membership;
+- active clusters without valid active memberships, or cluster members from
+  another cluster or incomplete declared membership;
 - duplicate related threads reached through multiple shared clusters;
 - related rows bound to another source or to themselves;
 - unknown issue or pull-request thread kinds;
 - search rows that are not open pull requests or violate requested ordering;
 - review context without one exact pull request and its complete contiguous
   file set;
-- malformed revision, fingerprint, Git object, timestamp, actor, or numeric
-  fields;
+- malformed or cross-repository graph identity, revision, fingerprint, Git
+  object, timestamp, actor, or numeric fields;
 - hidden HTML-comment content reaching a claim;
 - mixed, partial, relabeled, or tampered claims, coverage, graph data, or
   packet digests.

--- a/docs/repair/gitcrawl-evidence.md
+++ b/docs/repair/gitcrawl-evidence.md
@@ -55,7 +55,7 @@ mtime are not freshness proof.
 
 Normalized rows become digest-bound claims containing:
 
-- provider and snapshot identity;
+- provider, repository, and snapshot identity;
 - query name and canonical argument digest;
 - canonical repository subject;
 - source revision and thread fingerprint when available;
@@ -64,9 +64,11 @@ Normalized rows become digest-bound claims containing:
 - semantic and full claim SHA-256 digests.
 
 Claims can be assembled into a bounded evidence packet with coverage, graph
-nodes, graph edges, included counts, and a packet digest. Verification rebuilds
-the graph from verified claims and rejects mixed snapshots, missing required
-coverage, malformed persisted coverage, and digest tampering.
+nodes, graph edges, included counts, and a packet digest. Version 2 packets are
+complete or rejected: claim, graph, and byte bounds never silently discard
+evidence. Verification rebuilds the full canonical graph from verified claims
+and rejects repository relabeling, unknown claim fields, mixed snapshots,
+missing required coverage, malformed persisted coverage, and digest tampering.
 
 Thread safety classification uses the complete source title, body, labels,
 assignees, actor identity, and author association before prompt fields are
@@ -82,16 +84,20 @@ The query core rejects:
 - incomplete required dataset coverage;
 - provider cursor replay or page-limit exhaustion;
 - cloud authentication, HTTPS, redirect, origin, envelope, or size failures;
+- server throttling windows that exceed the configured retry wait budget;
 - cloud/local parity drift;
 - cluster members from another cluster or incomplete declared membership;
+- duplicate related threads reached through multiple shared clusters;
 - related rows bound to another source or to themselves;
+- unknown issue or pull-request thread kinds;
 - search rows that are not open pull requests or violate requested ordering;
 - review context without one exact pull request and its complete contiguous
   file set;
 - malformed revision, fingerprint, Git object, timestamp, actor, or numeric
   fields;
 - hidden HTML-comment content reaching a claim;
-- mixed or tampered claims, coverage, graph data, or packet digests.
+- mixed, partial, relabeled, or tampered claims, coverage, graph data, or
+  packet digests.
 
 ## Deliberate Non-Goals
 

--- a/docs/repair/gitcrawl-evidence.md
+++ b/docs/repair/gitcrawl-evidence.md
@@ -92,7 +92,8 @@ The query core rejects:
 - cloud/local parity drift;
 - active clusters without valid active memberships, or cluster members from
   another cluster or incomplete declared membership;
-- duplicate related threads reached through multiple shared clusters;
+- conflicting or replayed related rows; duplicate threads reached through
+  multiple shared clusters are deduplicated by canonical thread identity;
 - related rows bound to another source or to themselves;
 - unknown issue or pull-request thread kinds;
 - search rows that are not open pull requests or violate requested ordering;

--- a/src/repair/gitcrawl-evidence-adapter.ts
+++ b/src/repair/gitcrawl-evidence-adapter.ts
@@ -1083,6 +1083,11 @@ function normalizeCoverageRow(
   row: Record<string, unknown>,
   snapshotId: string,
 ): GitcrawlCoverageRow {
+  if (row.snapshot_id !== snapshotId) {
+    throw new Error(
+      `Gitcrawl coverage returned mismatched snapshot for ${String(row.dataset ?? "")}`,
+    );
+  }
   const dataset = String(row.dataset ?? "");
   if (!GITCRAWL_DATASETS.includes(dataset as GitcrawlCoverageRow["dataset"])) {
     throw new Error(`Gitcrawl coverage returned unknown dataset ${dataset}`);

--- a/src/repair/gitcrawl-evidence-adapter.ts
+++ b/src/repair/gitcrawl-evidence-adapter.ts
@@ -1265,6 +1265,9 @@ function normalizeThread(row: Record<string, unknown>): GitcrawlThreadEvidence {
     hasAuthorAssociation &&
     authorLogin.length > 0 &&
     authorType.length > 0;
+  if (!securityMetadataComplete) {
+    throw new Error("Gitcrawl thread security metadata is incomplete");
+  }
   const securityProjection = {
     state: threadState,
     title: safetyTitle,

--- a/src/repair/gitcrawl-evidence-adapter.ts
+++ b/src/repair/gitcrawl-evidence-adapter.ts
@@ -27,6 +27,7 @@ import {
 import { CloudGitcrawlQuerySource } from "./gitcrawl-evidence-cloud.js";
 import { LocalGitcrawlQuerySource } from "./gitcrawl-evidence-local.js";
 import {
+  assertGitcrawlThreadSafetyProjectionMatches,
   deriveGitcrawlThreadPolicySignals,
   sanitizeGitcrawlPromptValue,
   stripGitcrawlHtmlComments,
@@ -222,6 +223,7 @@ export class GitcrawlEvidenceAdapter {
   private readonly pageSize: number;
   private readonly maxPages: number;
   private readonly clusterMemberCounts = new Map<number, number>();
+  private readonly threadSafetyProjections = new Map<number, GitcrawlThreadEvidence>();
   private closePromise: Promise<void> | undefined;
 
   private constructor(input: {
@@ -433,6 +435,7 @@ export class GitcrawlEvidenceAdapter {
       normalizeThread,
       clusterMemberParityView,
     );
+    this.rememberThreadSafetyProjections(rows);
     for (const row of rows) {
       if (row.clusterId !== clusterId) {
         throw new Error(`Gitcrawl cluster ${clusterId} returned a member from another cluster`);
@@ -510,6 +513,7 @@ export class GitcrawlEvidenceAdapter {
       },
       relatedThreadParityView,
     );
+    this.rememberThreadSafetyProjections(rows);
     return this.claimResult(
       "gitcrawl.clusters.related",
       rows.map((data) => ({
@@ -565,6 +569,7 @@ export class GitcrawlEvidenceAdapter {
     }
     const context = normalizeReviewContext(contextRows[0]!);
     context.thread.kind = "pull_request";
+    this.rememberThreadSafetyProjections([context.thread]);
     const files = raw
       .filter((row) => row.row_kind === "file")
       .map(normalizeReviewFile)
@@ -603,7 +608,7 @@ export class GitcrawlEvidenceAdapter {
       },
       ...boundedFiles.map((file) => ({
         data: file,
-        subject: `${pullSubject}@file:${file.position}:${file.path}`,
+        subject: `${pullSubject}@file:${file.position}`,
         relations: [{ predicate: "evidence_for" as const, target: pullSubject }],
       })),
     ];
@@ -622,6 +627,7 @@ export class GitcrawlEvidenceAdapter {
       kind: "pull_request",
       state: "open",
       order,
+      ...(maxRows === undefined ? {} : { max_rows: maxRows }),
     };
     const rows = await this.queryNormalized(
       "gitcrawl.threads.search",
@@ -630,6 +636,7 @@ export class GitcrawlEvidenceAdapter {
       searchThreadParityView,
       maxRows,
     );
+    this.rememberThreadSafetyProjections(rows);
     assertOpenPullRequestRows(rows);
     assertThreadOrder(rows, order);
     return this.claimResult(
@@ -717,6 +724,17 @@ export class GitcrawlEvidenceAdapter {
         throw new Error(`Gitcrawl cluster ${row.id} changed member count within one snapshot`);
       }
       this.clusterMemberCounts.set(row.id, row.memberCount);
+    }
+  }
+
+  private rememberThreadSafetyProjections(rows: GitcrawlThreadEvidence[]): void {
+    for (const row of rows) {
+      const previous = this.threadSafetyProjections.get(row.threadId);
+      if (previous !== undefined) {
+        assertGitcrawlThreadSafetyProjectionMatches(previous, row);
+      } else {
+        this.threadSafetyProjections.set(row.threadId, row);
+      }
     }
   }
 }
@@ -889,6 +907,7 @@ async function queryAll(
 ): Promise<Record<string, unknown>[]> {
   const rows: Record<string, unknown>[] = [];
   const seenCursors = new Set<string>();
+  const seenRows = new Set<string>();
   let cursor = "";
   for (let page = 0; page < maxPages; page += 1) {
     const remaining = maxRows === undefined ? pageSize : Math.min(pageSize, maxRows - rows.length);
@@ -910,16 +929,47 @@ async function queryAll(
     if (envelope.values.length > remaining) {
       throw new Error(`Gitcrawl ${name} returned more rows than requested`);
     }
-    rows.push(...envelope.values);
+    for (const row of envelope.values) {
+      const identity = queryRowIdentity(name, row);
+      if (seenRows.has(identity)) {
+        throw new Error(`Gitcrawl ${name} returned duplicate row identity ${identity}`);
+      }
+      seenRows.add(identity);
+      rows.push(row);
+    }
     const next = envelope.stats.next_cursor;
     if (next && (next === cursor || seenCursors.has(next))) {
       throw new Error(`Gitcrawl cursor drift detected for ${name}`);
     }
-    if (maxRows !== undefined && rows.length >= maxRows) return rows.slice(0, maxRows);
+    if (maxRows !== undefined && rows.length >= maxRows) {
+      if (next) {
+        throw new Error(`Gitcrawl ${name} truncated a nonterminal result at max_rows=${maxRows}`);
+      }
+      return rows;
+    }
     if (!next) return rows;
     cursor = next;
   }
   throw new Error(`Gitcrawl ${name} pagination exceeded ${maxPages} pages`);
+}
+
+function queryRowIdentity(name: GitcrawlQueryName, row: Record<string, unknown>): string {
+  switch (name) {
+    case "gitcrawl.coverage":
+      return `dataset:${String(row.dataset ?? "")}`;
+    case "gitcrawl.clusters.list":
+      return `cluster:${String(row.cluster_id ?? "")}`;
+    case "gitcrawl.clusters.members":
+      return `cluster-thread:${String(row.cluster_id ?? "")}:${String(row.thread_id ?? "")}`;
+    case "gitcrawl.clusters.related":
+      return `related-thread:${String(row.thread_id ?? "")}`;
+    case "gitcrawl.pull_requests.review_context":
+      return row.row_kind === "file"
+        ? `review-file:${String(row.thread_id ?? "")}:${String(row.file_position ?? "")}`
+        : `review-context:${String(row.thread_id ?? "")}`;
+    case "gitcrawl.threads.search":
+      return `thread:${String(row.thread_id ?? "")}`;
+  }
 }
 
 function bindEnvelope(
@@ -1084,8 +1134,8 @@ function requireDatasets(
 
 function clusterListQueryArgs(
   repository: string,
-  options: { status?: string; minSize?: number },
-): { owner: string; repo: string; status: string; min_size: number } {
+  options: { status?: string; minSize?: number; maxRows?: number },
+): { owner: string; repo: string; status: string; min_size: number; max_rows?: number } {
   const requestedStatus = options.status ?? "active";
   const status = boundedString(requestedStatus, 64);
   if (!status || status !== requestedStatus) {
@@ -1095,6 +1145,9 @@ function clusterListQueryArgs(
     ...ownerRepo(repository),
     status,
     min_size: positiveInteger(options.minSize ?? 1, "minimum cluster size"),
+    ...(options.maxRows === undefined
+      ? {}
+      : { max_rows: positiveInteger(options.maxRows, "max rows") }),
   };
 }
 

--- a/src/repair/gitcrawl-evidence-adapter.ts
+++ b/src/repair/gitcrawl-evidence-adapter.ts
@@ -446,7 +446,7 @@ export class GitcrawlEvidenceAdapter {
     const rows = await this.queryNormalized(
       "gitcrawl.clusters.members",
       queryArgs,
-      normalizeThread,
+      (row) => normalizeThread(row, this.repository),
       clusterMemberParityView,
     );
     this.rememberThreadSafetyProjections(rows);
@@ -520,7 +520,7 @@ export class GitcrawlEvidenceAdapter {
             `Gitcrawl related evidence for thread ${requestedNumber} was returned for thread ${sourceNumber}`,
           );
         }
-        const data = normalizeThread(row);
+        const data = normalizeThread(row, this.repository);
         if (data.number === requestedNumber) {
           throw new Error(
             `Gitcrawl related evidence cannot relate thread ${requestedNumber} to itself`,
@@ -562,7 +562,7 @@ export class GitcrawlEvidenceAdapter {
       "gitcrawl.pull_requests.review_context",
       queryArgs,
       (row) => ({ ...row }),
-      reviewRawParityView,
+      (row) => reviewRawParityView(row, this.repository),
     );
     const contextRows = raw.filter((row) => row.row_kind === "context");
     if (contextRows.length !== 1) {
@@ -584,7 +584,7 @@ export class GitcrawlEvidenceAdapter {
         throw new Error(`Gitcrawl review context for #${number} mixed pull request file rows`);
       }
     }
-    const context = normalizeReviewContext(contextRows[0]!);
+    const context = normalizeReviewContext(contextRows[0]!, this.repository);
     context.thread.kind = "pull_request";
     this.rememberThreadSafetyProjections([context.thread]);
     const files = raw
@@ -649,7 +649,7 @@ export class GitcrawlEvidenceAdapter {
     const rows = await this.queryNormalized(
       "gitcrawl.threads.search",
       queryArgs,
-      normalizeThread,
+      (row) => normalizeThread(row, this.repository),
       searchThreadParityView,
       maxRows,
     );
@@ -1219,7 +1219,10 @@ function normalizeRequestedCluster(
   return cluster;
 }
 
-function normalizeThread(row: Record<string, unknown>): GitcrawlThreadEvidence {
+function normalizeThread(row: Record<string, unknown>, repository: string): GitcrawlThreadEvidence {
+  const number = safePositive(row.number, "thread number");
+  const kind = supportedThreadKind(row.kind);
+  const htmlUrl = exactThreadHtmlUrl(row.html_url, repository, kind, number);
   const completeSecurityMetadata = booleanValue(row.security_metadata_complete);
   if (completeSecurityMetadata && typeof row.title !== "string") {
     throw new Error("Gitcrawl thread title is missing from complete security metadata");
@@ -1348,15 +1351,15 @@ function normalizeThread(row: Record<string, unknown>): GitcrawlThreadEvidence {
           ),
         }),
     threadId: safePositive(row.thread_id, "thread id"),
-    number: safePositive(row.number, "thread number"),
-    kind: supportedThreadKind(row.kind),
+    number,
+    kind,
     state: threadState,
     title: boundedString(promptTitle, 512),
     body: boundedString(promptBody, 2_048),
     authorLogin,
     authorType,
     ...(authorAssociation ? { authorAssociation } : {}),
-    htmlUrl: boundedString(row.html_url, 2_048),
+    htmlUrl,
     ...(hasLabelsField ? { labels: boundedJsonArray(promptLabels, 32, 256) } : {}),
     ...(hasAssigneesField ? { assignees: boundedJsonArray(promptAssignees, 16, 256) } : {}),
     isDraft: booleanValue(row.is_draft),
@@ -1377,9 +1380,10 @@ function normalizeThread(row: Record<string, unknown>): GitcrawlThreadEvidence {
 
 function normalizeReviewContext(
   row: Record<string, unknown>,
+  repository: string,
 ): Omit<GitcrawlReviewContext, "files" | "filesOmitted"> {
   return {
-    thread: normalizeThread(row),
+    thread: normalizeThread(row, repository),
     baseSha: gitObjectId(row.base_sha, "PR base revision"),
     headSha: gitObjectId(row.head_sha, "PR head revision"),
     headRef: boundedString(row.head_ref, 512),
@@ -1500,14 +1504,14 @@ function relatedThreadParityView(row: GitcrawlThreadEvidence): unknown {
   return common;
 }
 
-function reviewRawParityView(row: Record<string, unknown>): unknown {
+function reviewRawParityView(row: Record<string, unknown>, repository: string): unknown {
   if (row.row_kind === "file") {
     return {
       rowKind: "file",
       ...normalizeReviewFile(row),
     };
   }
-  const context = normalizeReviewContext(row);
+  const context = normalizeReviewContext(row, repository);
   return {
     rowKind: "context",
     ...context,
@@ -1594,6 +1598,19 @@ function supportedThreadKind(value: unknown): "issue" | "pull_request" {
     throw new Error(`unsupported Gitcrawl thread kind: ${kind || "missing"}`);
   }
   return kind;
+}
+
+function exactThreadHtmlUrl(
+  value: unknown,
+  repository: string,
+  kind: "issue" | "pull_request",
+  number: number,
+): string {
+  const expected = `https://github.com/${repository}/${kind === "pull_request" ? "pull" : "issues"}/${number}`;
+  if (typeof value !== "string" || value !== expected) {
+    throw new Error(`Gitcrawl thread identity does not match ${repository} ${kind} #${number}`);
+  }
+  return value;
 }
 
 function boundedString(value: unknown, maxLength: number): string {

--- a/src/repair/gitcrawl-evidence-adapter.ts
+++ b/src/repair/gitcrawl-evidence-adapter.ts
@@ -223,7 +223,7 @@ export class GitcrawlEvidenceAdapter {
   private readonly pageSize: number;
   private readonly maxPages: number;
   private readonly clusterMemberCounts = new Map<number, number>();
-  private readonly threadSafetyProjections = new Map<number, GitcrawlThreadEvidence>();
+  private readonly threadSafetyProjections = new Map<string, GitcrawlThreadEvidence>();
   private closePromise: Promise<void> | undefined;
 
   private constructor(input: {
@@ -746,11 +746,12 @@ export class GitcrawlEvidenceAdapter {
 
   private rememberThreadSafetyProjections(rows: GitcrawlThreadEvidence[]): void {
     for (const row of rows) {
-      const previous = this.threadSafetyProjections.get(row.threadId);
+      const identity = threadSubject(this.repository, row.kind, row.number);
+      const previous = this.threadSafetyProjections.get(identity);
       if (previous !== undefined) {
         assertGitcrawlThreadSafetyProjectionMatches(previous, row);
       } else {
-        this.threadSafetyProjections.set(row.threadId, row);
+        this.threadSafetyProjections.set(identity, row);
       }
     }
   }

--- a/src/repair/gitcrawl-evidence-adapter.ts
+++ b/src/repair/gitcrawl-evidence-adapter.ts
@@ -947,7 +947,7 @@ async function queryAll(
       throw new Error(`Gitcrawl ${name} returned more rows than requested`);
     }
     for (const row of envelope.values) {
-      const identity = queryRowIdentity(name, row);
+      const identity = queryRowIdentity(state.repository, name, args, row);
       if (seenRows.has(identity)) {
         throw new Error(`Gitcrawl ${name} returned duplicate row identity ${identity}`);
       }
@@ -970,23 +970,32 @@ async function queryAll(
   throw new Error(`Gitcrawl ${name} pagination exceeded ${maxPages} pages`);
 }
 
-function queryRowIdentity(name: GitcrawlQueryName, row: Record<string, unknown>): string {
+function queryRowIdentity(
+  repository: string,
+  name: GitcrawlQueryName,
+  args: Record<string, unknown>,
+  row: Record<string, unknown>,
+): string {
   switch (name) {
     case "gitcrawl.coverage":
       return `dataset:${String(row.dataset ?? "")}`;
     case "gitcrawl.clusters.list":
       return `cluster:${String(row.cluster_id ?? "")}`;
     case "gitcrawl.clusters.members":
-      return `cluster-thread:${String(row.cluster_id ?? "")}:${String(row.thread_id ?? "")}`;
+      return `cluster-thread:${String(row.cluster_id ?? "")}:${canonicalThreadRowIdentity(repository, row)}`;
     case "gitcrawl.clusters.related":
-      return `related-thread:${String(row.thread_id ?? "")}`;
+      return `related-thread:${canonicalThreadRowIdentity(repository, row)}`;
     case "gitcrawl.pull_requests.review_context":
       return row.row_kind === "file"
-        ? `review-file:${String(row.thread_id ?? "")}:${String(row.file_position ?? "")}`
-        : `review-context:${String(row.thread_id ?? "")}`;
+        ? `review-file:${repository}:pull_request:${safePositive(args.number, "review request number")}:${String(row.file_position ?? "")}`
+        : `review-context:${canonicalThreadRowIdentity(repository, row)}`;
     case "gitcrawl.threads.search":
-      return `thread:${String(row.thread_id ?? "")}`;
+      return `thread:${canonicalThreadRowIdentity(repository, row)}`;
   }
+}
+
+function canonicalThreadRowIdentity(repository: string, row: Record<string, unknown>): string {
+  return `${repository}:${supportedThreadKind(row.kind)}:${safePositive(row.number, "thread number")}`;
 }
 
 function bindEnvelope(

--- a/src/repair/gitcrawl-evidence-adapter.ts
+++ b/src/repair/gitcrawl-evidence-adapter.ts
@@ -1156,6 +1156,9 @@ function clusterListQueryArgs(
 }
 
 function normalizeCluster(row: Record<string, unknown>): GitcrawlClusterEvidence {
+  const createdAt = requiredTimestamp(row.created_at, "Gitcrawl cluster created_at");
+  const updatedAt = requiredTimestamp(row.updated_at, "Gitcrawl cluster updated_at");
+  const closedAt = optionalTimestamp(row.closed_at, "Gitcrawl cluster closed_at");
   return {
     id: safePositive(row.cluster_id, "cluster id"),
     stableSlug: boundedString(row.stable_slug, 512),
@@ -1175,9 +1178,9 @@ function normalizeCluster(row: Record<string, unknown>): GitcrawlClusterEvidence
       ),
     },
     memberCount: safeNonNegative(row.member_count, "member count"),
-    createdAt: boundedString(row.created_at, 64),
-    updatedAt: boundedString(row.updated_at, 64),
-    closedAt: boundedString(row.closed_at, 64),
+    createdAt,
+    updatedAt,
+    closedAt,
   };
 }
 
@@ -1270,6 +1273,14 @@ function normalizeThread(row: Record<string, unknown>): GitcrawlThreadEvidence {
     row.revision_source_updated_at || row.updated_at_gh || row.updated_at,
     64,
   );
+  if (revisionUpdatedAt) {
+    assertTimestamp(revisionUpdatedAt, "Gitcrawl source revision updated_at");
+  }
+  const createdAt = requiredTimestamp(row.created_at_gh, "Gitcrawl thread created_at");
+  const updatedAt = requiredTimestamp(
+    row.updated_at_gh || row.updated_at,
+    "Gitcrawl thread updated_at",
+  );
   const sourceRevision =
     revisionId === null && !revisionHash && !revisionUpdatedAt
       ? undefined
@@ -1326,8 +1337,8 @@ function normalizeThread(row: Record<string, unknown>): GitcrawlThreadEvidence {
     ...(hasLabelsField ? { labels: boundedJsonArray(promptLabels, 32, 256) } : {}),
     ...(hasAssigneesField ? { assignees: boundedJsonArray(promptAssignees, 16, 256) } : {}),
     isDraft: booleanValue(row.is_draft),
-    createdAt: boundedString(row.created_at_gh, 64),
-    updatedAt: boundedString(row.updated_at_gh || row.updated_at, 64),
+    createdAt,
+    updatedAt,
     keySummary: boundedString(
       stripGitcrawlHtmlComments(safetyString(row.key_summary, "thread key summary")),
       2_048,
@@ -1487,7 +1498,7 @@ function assertRowsParity<T>(
   parity: T[],
   project: (row: T) => unknown,
 ): void {
-  const normalize = (rows: T[]) => rows.map(project).map(canonicalJson).sort(compareCanonicalText);
+  const normalize = (rows: T[]) => rows.map(project).map(canonicalJson);
   if (canonicalJson(normalize(primary)) !== canonicalJson(normalize(parity))) {
     throw new Error(`Gitcrawl cloud/local parity mismatch for ${name}`);
   }
@@ -1504,6 +1515,19 @@ function assertFreshTimestamp(value: string, label: string, maxAge: number, now:
 
 function assertTimestamp(value: string, label: string): void {
   parseRfc3339Timestamp(value, label);
+}
+
+function requiredTimestamp(value: unknown, label: string): string {
+  const normalized = boundedString(value, 64);
+  if (!normalized) throw new Error(`${label} is required`);
+  assertTimestamp(normalized, label);
+  return normalized;
+}
+
+function optionalTimestamp(value: unknown, label: string): string {
+  const normalized = boundedString(value, 64);
+  if (normalized) assertTimestamp(normalized, label);
+  return normalized;
 }
 
 function assertSourceTopology(options: GitcrawlEvidenceSourceOptions): void {

--- a/src/repair/gitcrawl-evidence-adapter.ts
+++ b/src/repair/gitcrawl-evidence-adapter.ts
@@ -1,0 +1,1605 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  GITCRAWL_DATASETS,
+  GITCRAWL_QUERY_COVERAGE,
+  GITCRAWL_QUERY_CONTRACT_VERSION,
+  type GitcrawlCoverageRow,
+  type GitcrawlDataset,
+  type GitcrawlEvidenceRelation,
+  type GitcrawlEvidenceResult,
+  type GitcrawlProvider,
+  type GitcrawlQueryEnvelope,
+  type GitcrawlQueryName,
+  type GitcrawlQuerySource,
+  type GitcrawlSourceRevision,
+  type GitcrawlThreadFingerprint,
+  assertSha256,
+  assertSnapshotId,
+  canonicalJson,
+  compareCanonicalText,
+  createGitcrawlEvidenceClaim,
+  gitcrawlQueryDigest,
+  parseRfc3339Timestamp,
+  sha256Canonical,
+} from "./gitcrawl-evidence-contract.js";
+import { CloudGitcrawlQuerySource } from "./gitcrawl-evidence-cloud.js";
+import { LocalGitcrawlQuerySource } from "./gitcrawl-evidence-local.js";
+import {
+  deriveGitcrawlThreadPolicySignals,
+  sanitizeGitcrawlPromptValue,
+  stripGitcrawlHtmlComments,
+  type GitcrawlThreadPolicySignals,
+} from "./gitcrawl-evidence-policy.js";
+import { hasSecuritySignalText } from "./security-signals.js";
+
+const DEFAULT_MAX_SNAPSHOT_AGE_MS = 6 * 60 * 60 * 1000;
+const DEFAULT_PAGE_SIZE = 50;
+const DEFAULT_MAX_PAGES = 128;
+const MAX_CLOCK_SKEW_MS = 5 * 60 * 1000;
+const MAX_REVIEW_FILES_IN_PACKET = 24;
+const MAX_SAFETY_FIELD_BYTES = 512 * 1024;
+const GITHUB_AUTHOR_ASSOCIATIONS = new Set([
+  "COLLABORATOR",
+  "CONTRIBUTOR",
+  "FIRST_TIMER",
+  "FIRST_TIME_CONTRIBUTOR",
+  "MANNEQUIN",
+  "MEMBER",
+  "NONE",
+  "OWNER",
+]);
+
+export type GitcrawlEvidenceAdapterOptions = {
+  repository: string;
+  provider: GitcrawlProvider;
+  dbPath?: string;
+  allowLegacyLocal?: boolean;
+  cloudUrl?: string;
+  cloudArchive?: string;
+  cloudToken?: string;
+  cloudAccessClientId?: string;
+  cloudAccessClientSecret?: string;
+  expectedSnapshotId?: string;
+  fetch?: typeof fetch;
+  maxSnapshotAgeMs?: number;
+  pageSize?: number;
+  maxPages?: number;
+  now?: () => Date;
+};
+
+export type GitcrawlEvidenceProvenance = {
+  schema: "gitcrawl-evidence-source-v1";
+  identity_sha256: string;
+  provider: GitcrawlProvider;
+  repository: string;
+  archive: string;
+  snapshot_id: string;
+  source_sha256: string;
+  source_sync_at: string;
+  dataset_generated_at: string;
+  query: {
+    contract_version: typeof GITCRAWL_QUERY_CONTRACT_VERSION;
+    name: "gitcrawl.coverage";
+    sha256: string;
+  };
+  parity?: {
+    archive: string;
+    snapshot_id: string;
+    source_sha256: string;
+  };
+};
+
+export type GitcrawlEvidenceSourceOptions = {
+  repository: string;
+  provider: GitcrawlProvider;
+  primarySource: GitcrawlQuerySource;
+  paritySource?: GitcrawlQuerySource;
+  expectedSnapshotId?: string;
+  maxSnapshotAgeMs?: number;
+  pageSize?: number;
+  maxPages?: number;
+  now?: () => Date;
+};
+
+export type GitcrawlClusterEvidence = {
+  id: number;
+  stableSlug: string;
+  status: string;
+  clusterType: string;
+  title: string;
+  representative: {
+    threadId: number | null;
+    number: number | null;
+    kind: string;
+    state: string;
+    title: string;
+  };
+  memberCount: number;
+  createdAt: string;
+  updatedAt: string;
+  closedAt: string;
+};
+
+export type GitcrawlThreadEvidence = {
+  clusterId?: number;
+  clusterSlug?: string;
+  clusterStatus?: string;
+  clusterMemberCount?: number;
+  role?: string;
+  membershipState?: string;
+  scoreToRepresentative?: number | null;
+  threadId: number;
+  number: number;
+  kind: string;
+  state: string;
+  title: string;
+  body: string;
+  authorLogin: string;
+  authorType: string;
+  authorAssociation?: string;
+  htmlUrl: string;
+  labels?: unknown[];
+  assignees?: unknown[];
+  isDraft: boolean;
+  createdAt: string;
+  updatedAt: string;
+  keySummary: string;
+  securitySensitive: boolean;
+  securityMetadataComplete: boolean;
+  securityProjectionSha256: string;
+  policySignals: GitcrawlThreadPolicySignals;
+  sourceRevision?: GitcrawlSourceRevision;
+  threadFingerprint?: GitcrawlThreadFingerprint;
+};
+
+export type GitcrawlReviewContext = {
+  thread: GitcrawlThreadEvidence;
+  baseSha: string;
+  headSha: string;
+  headRef: string;
+  headRepoFullName: string;
+  mergeableState: string;
+  additions: number;
+  deletions: number;
+  changedFiles: number;
+  detailsFetchedAt: string;
+  detailsUpdatedAt: string;
+  clusterId: number | null;
+  clusterSlug: string;
+  clusterTitle: string;
+  clusterStatus: string;
+  clusterRole: string;
+  scoreToRepresentative: number | null;
+  files: GitcrawlReviewFile[];
+  filesOmitted: number;
+};
+
+export type GitcrawlReviewFile = {
+  position: number;
+  path: string;
+  status: string;
+  additions: number;
+  deletions: number;
+  changes: number;
+  previousPath: string;
+  fetchedAt: string;
+};
+
+type SessionState = {
+  source: GitcrawlQuerySource;
+  repository: string;
+  archive: string;
+  snapshotId: string;
+  sourceSha256: string;
+  snapshotSchemaName: string;
+  snapshotSchemaVersion: number;
+  snapshotSchemaHash: string;
+  snapshotCapabilities: string[];
+  snapshotPublishedAt: string;
+  snapshotCutoverAt: string;
+  snapshotCoverageComplete: boolean;
+  sourceSyncAt: string;
+  datasetGeneratedAt: string;
+  coverage: GitcrawlCoverageRow[];
+};
+
+type ClaimInput<T> = {
+  data: T;
+  subject: string;
+  sourceRevision?: GitcrawlSourceRevision;
+  threadFingerprint?: GitcrawlThreadFingerprint;
+  relations?: GitcrawlEvidenceRelation[];
+};
+
+export class GitcrawlEvidenceAdapter {
+  readonly repository: string;
+  readonly provider: GitcrawlProvider;
+
+  private readonly primary: SessionState;
+  private readonly parity: SessionState | undefined;
+  private readonly pageSize: number;
+  private readonly maxPages: number;
+  private readonly clusterMemberCounts = new Map<number, number>();
+  private closePromise: Promise<void> | undefined;
+
+  private constructor(input: {
+    repository: string;
+    provider: GitcrawlProvider;
+    primary: SessionState;
+    parity?: SessionState;
+    pageSize: number;
+    maxPages: number;
+  }) {
+    this.repository = input.repository;
+    this.provider = input.provider;
+    this.primary = input.primary;
+    this.parity = input.parity;
+    this.pageSize = input.pageSize;
+    this.maxPages = input.maxPages;
+  }
+
+  static async open(options: GitcrawlEvidenceAdapterOptions): Promise<GitcrawlEvidenceAdapter> {
+    let primarySource: GitcrawlQuerySource | undefined;
+    let paritySource: GitcrawlQuerySource | undefined;
+    try {
+      if (options.provider === "local") {
+        primarySource = await openLocalSource(options);
+      } else {
+        primarySource = openCloudSource(options);
+        if (options.provider === "parity") paritySource = await openLocalSource(options);
+      }
+    } catch (error) {
+      await Promise.allSettled([primarySource?.close(), paritySource?.close()].filter(Boolean));
+      throw error;
+    }
+    return GitcrawlEvidenceAdapter.fromSources({
+      repository: options.repository,
+      provider: options.provider,
+      primarySource,
+      ...(paritySource === undefined ? {} : { paritySource }),
+      ...(options.maxSnapshotAgeMs === undefined
+        ? {}
+        : { maxSnapshotAgeMs: options.maxSnapshotAgeMs }),
+      ...(options.expectedSnapshotId === undefined
+        ? {}
+        : { expectedSnapshotId: options.expectedSnapshotId }),
+      ...(options.pageSize === undefined ? {} : { pageSize: options.pageSize }),
+      ...(options.maxPages === undefined ? {} : { maxPages: options.maxPages }),
+      ...(options.now === undefined ? {} : { now: options.now }),
+    });
+  }
+
+  static async fromSources(
+    options: GitcrawlEvidenceSourceOptions,
+  ): Promise<GitcrawlEvidenceAdapter> {
+    try {
+      assertSourceTopology(options);
+      const pageSize = positiveInteger(options.pageSize ?? DEFAULT_PAGE_SIZE, "page size");
+      const maxPages = positiveInteger(options.maxPages ?? DEFAULT_MAX_PAGES, "max pages");
+      const maxAge = nonNegativeInteger(
+        options.maxSnapshotAgeMs ?? DEFAULT_MAX_SNAPSHOT_AGE_MS,
+        "max snapshot age",
+      );
+      const now = options.now ?? (() => new Date());
+      const primary = await initializeSession(options.primarySource, {
+        repository: options.repository,
+        pageSize,
+        maxPages,
+        maxAge,
+        now,
+        ...(options.expectedSnapshotId === undefined
+          ? {}
+          : { expectedSnapshotId: options.expectedSnapshotId }),
+      });
+      const parity =
+        options.paritySource === undefined
+          ? undefined
+          : await initializeSession(options.paritySource, {
+              repository: options.repository,
+              pageSize,
+              maxPages,
+              maxAge,
+              now,
+            });
+      if (parity !== undefined) {
+        assertCoverageParity(
+          primary.coverage,
+          parity.coverage,
+          GITCRAWL_QUERY_COVERAGE["gitcrawl.coverage"],
+        );
+      }
+      return new GitcrawlEvidenceAdapter({
+        repository: options.repository,
+        provider: options.provider,
+        primary,
+        ...(parity === undefined ? {} : { parity }),
+        pageSize,
+        maxPages,
+      });
+    } catch (error) {
+      await Promise.allSettled([options.primarySource.close(), options.paritySource?.close()]);
+      throw error;
+    }
+  }
+
+  get snapshotId(): string {
+    return this.primary.snapshotId;
+  }
+
+  get archive(): string {
+    return this.primary.archive;
+  }
+
+  get paritySnapshotId(): string | undefined {
+    return this.parity?.snapshotId;
+  }
+
+  get parityArchive(): string | undefined {
+    return this.parity?.archive;
+  }
+
+  get provenance(): GitcrawlEvidenceProvenance {
+    const query = {
+      contract_version: GITCRAWL_QUERY_CONTRACT_VERSION,
+      name: "gitcrawl.coverage" as const,
+      sha256: gitcrawlQueryDigest("gitcrawl.coverage", {}),
+    } as const;
+    const identity = {
+      schema: "gitcrawl-evidence-source-v1" as const,
+      provider: this.provider,
+      repository: this.repository,
+      archive: this.primary.archive,
+      snapshot_id: this.primary.snapshotId,
+      source_sha256: this.primary.sourceSha256,
+      query,
+      ...(this.parity === undefined
+        ? {}
+        : {
+            parity: {
+              archive: this.parity.archive,
+              snapshot_id: this.parity.snapshotId,
+              source_sha256: this.parity.sourceSha256,
+            },
+          }),
+    };
+    return {
+      ...identity,
+      identity_sha256: sha256Canonical(identity),
+      source_sync_at: this.primary.sourceSyncAt,
+      dataset_generated_at: this.primary.datasetGeneratedAt,
+    };
+  }
+
+  get coverage(): GitcrawlCoverageRow[] {
+    return this.primary.coverage.map((row) => ({ ...row }));
+  }
+
+  get requiredCoverage(): GitcrawlDataset[] {
+    return this.requiredCoverageFor("gitcrawl.coverage");
+  }
+
+  requiredCoverageFor(...queries: GitcrawlQueryName[]): GitcrawlDataset[] {
+    const required = new Set<GitcrawlDataset>();
+    for (const query of queries) {
+      for (const dataset of GITCRAWL_QUERY_COVERAGE[query]) required.add(dataset);
+    }
+    const datasets = [...required].sort(compareCanonicalText);
+    requireDatasets(this.primary.coverage, datasets);
+    if (this.parity !== undefined) {
+      requireDatasets(this.parity.coverage, datasets);
+      assertCoverageParity(this.primary.coverage, this.parity.coverage, datasets);
+    }
+    return datasets;
+  }
+
+  async listClusters(
+    options: {
+      status?: string;
+      minSize?: number;
+      maxRows?: number;
+    } = {},
+  ): Promise<GitcrawlEvidenceResult<GitcrawlClusterEvidence>> {
+    const maxRows =
+      options.maxRows === undefined ? undefined : positiveInteger(options.maxRows, "max rows");
+    const queryArgs = clusterListQueryArgs(this.repository, options);
+    const rows = await this.queryNormalized(
+      "gitcrawl.clusters.list",
+      queryArgs,
+      (row) => normalizeRequestedCluster(row, queryArgs.status, queryArgs.min_size),
+      clusterParityView,
+      maxRows,
+    );
+    this.rememberClusterCounts(rows);
+    return this.claimResult(
+      "gitcrawl.clusters.list",
+      rows.map((data) => ({
+        data,
+        subject: clusterSubject(this.repository, data.id),
+      })),
+      queryArgs,
+    );
+  }
+
+  async clusterMembers(clusterId: number): Promise<GitcrawlEvidenceResult<GitcrawlThreadEvidence>> {
+    const rows = await this.queryNormalized(
+      "gitcrawl.clusters.members",
+      {
+        ...ownerRepo(this.repository),
+        cluster_id: positiveInteger(clusterId, "cluster id"),
+      },
+      normalizeThread,
+      clusterMemberParityView,
+    );
+    for (const row of rows) {
+      if (row.clusterId !== clusterId) {
+        throw new Error(`Gitcrawl cluster ${clusterId} returned a member from another cluster`);
+      }
+      if (row.membershipState !== "active") {
+        throw new Error(
+          `Gitcrawl cluster ${clusterId} returned member #${row.number} with non-active membership`,
+        );
+      }
+    }
+    const declaredCounts = new Set(
+      rows.map((row) => row.clusterMemberCount).filter((count) => count !== undefined),
+    );
+    const cachedCount = this.clusterMemberCounts.get(clusterId);
+    if (cachedCount !== undefined) declaredCounts.add(cachedCount);
+    if (rows.some((row) => row.clusterMemberCount === undefined)) {
+      throw new Error(`Gitcrawl cluster ${clusterId} members are missing their declared count`);
+    }
+    if (declaredCounts.size > 1) {
+      throw new Error(`Gitcrawl cluster ${clusterId} returned conflicting member counts`);
+    }
+    const declaredCount = [...declaredCounts][0];
+    if (declaredCount === undefined) {
+      throw new Error(`Gitcrawl cluster ${clusterId} members are missing their declared count`);
+    }
+    if (rows.length !== declaredCount) {
+      throw new Error(
+        `Gitcrawl cluster ${clusterId} returned ${rows.length}/${declaredCount} members`,
+      );
+    }
+    this.clusterMemberCounts.set(clusterId, declaredCount);
+    return this.claimResult(
+      "gitcrawl.clusters.members",
+      rows.map((data) => ({
+        data,
+        subject: threadSubject(this.repository, data.kind, data.number),
+        ...(data.sourceRevision === undefined ? {} : { sourceRevision: data.sourceRevision }),
+        ...(data.threadFingerprint === undefined
+          ? {}
+          : { threadFingerprint: data.threadFingerprint }),
+        relations: [
+          {
+            predicate: "member_of",
+            target: clusterSubject(this.repository, clusterId),
+          },
+        ],
+      })),
+    );
+  }
+
+  async related(number: number): Promise<GitcrawlEvidenceResult<GitcrawlThreadEvidence>> {
+    const requestedNumber = positiveInteger(number, "thread number");
+    const rows = await this.queryNormalized(
+      "gitcrawl.clusters.related",
+      {
+        ...ownerRepo(this.repository),
+        number: requestedNumber,
+      },
+      (row) => {
+        const sourceNumber = safePositive(row.source_number, "related source number");
+        if (sourceNumber !== requestedNumber) {
+          throw new Error(
+            `Gitcrawl related evidence for thread ${requestedNumber} was returned for thread ${sourceNumber}`,
+          );
+        }
+        const data = normalizeThread(row);
+        if (data.number === requestedNumber) {
+          throw new Error(
+            `Gitcrawl related evidence cannot relate thread ${requestedNumber} to itself`,
+          );
+        }
+        return data;
+      },
+      relatedThreadParityView,
+    );
+    return this.claimResult(
+      "gitcrawl.clusters.related",
+      rows.map((data) => ({
+        data,
+        subject: threadSubject(this.repository, data.kind, data.number),
+        ...(data.sourceRevision === undefined ? {} : { sourceRevision: data.sourceRevision }),
+        ...(data.threadFingerprint === undefined
+          ? {}
+          : { threadFingerprint: data.threadFingerprint }),
+        relations: [
+          {
+            predicate: "related_to",
+            target: `${this.repository}#thread:${requestedNumber}`,
+          },
+        ],
+      })),
+    );
+  }
+
+  async reviewContext(
+    number: number,
+  ): Promise<GitcrawlEvidenceResult<GitcrawlReviewContext | GitcrawlReviewFile>> {
+    const raw = await this.queryNormalized(
+      "gitcrawl.pull_requests.review_context",
+      {
+        ...ownerRepo(this.repository),
+        number: positiveInteger(number, "pull request number"),
+      },
+      (row) => ({ ...row }),
+      reviewRawParityView,
+    );
+    const contextRows = raw.filter((row) => row.row_kind === "context");
+    if (contextRows.length !== 1) {
+      throw new Error(`Gitcrawl review context for #${number} requires exactly one context row`);
+    }
+    const contextThreadId = safePositive(contextRows[0]!.thread_id, "review context thread id");
+    if (safePositive(contextRows[0]!.number, "review context number") !== number) {
+      throw new Error(`Gitcrawl review context for #${number} returned a different pull request`);
+    }
+    const contextKind = boundedString(contextRows[0]!.kind, 32);
+    if (contextKind !== "pull_request") {
+      throw new Error(`Gitcrawl review context for #${number} returned a non-pull-request row`);
+    }
+    for (const row of raw.filter((candidate) => candidate.row_kind === "file")) {
+      if (safePositive(row.thread_id, "review file thread id") !== contextThreadId) {
+        throw new Error(`Gitcrawl review context for #${number} mixed pull request file rows`);
+      }
+      if (row.number !== undefined && safePositive(row.number, "review file number") !== number) {
+        throw new Error(`Gitcrawl review context for #${number} mixed pull request file rows`);
+      }
+    }
+    const context = normalizeReviewContext(contextRows[0]!);
+    context.thread.kind = "pull_request";
+    const files = raw
+      .filter((row) => row.row_kind === "file")
+      .map(normalizeReviewFile)
+      .sort((left, right) => left.position - right.position);
+    if (!context.baseSha || !context.headSha || !context.detailsFetchedAt) {
+      throw new Error(`Gitcrawl review context for #${number} is missing PR details`);
+    }
+    assertTimestamp(context.detailsFetchedAt, `Gitcrawl review context for #${number} fetched_at`);
+    if (context.detailsUpdatedAt) {
+      assertTimestamp(
+        context.detailsUpdatedAt,
+        `Gitcrawl review context for #${number} updated_at`,
+      );
+    }
+    for (const file of files) {
+      assertTimestamp(file.fetchedAt, `Gitcrawl review context for #${number} file fetched_at`);
+    }
+    assertCompleteReviewFiles(number, files, context.changedFiles);
+    const boundedFiles = files.slice(0, MAX_REVIEW_FILES_IN_PACKET);
+    const combined: GitcrawlReviewContext = {
+      ...context,
+      files: boundedFiles,
+      filesOmitted: files.length - boundedFiles.length,
+    };
+    const pullSubject = threadSubject(this.repository, "pull_request", number);
+    const claims: ClaimInput<GitcrawlReviewContext | GitcrawlReviewFile>[] = [
+      {
+        data: combined,
+        subject: pullSubject,
+        ...(combined.thread.sourceRevision === undefined
+          ? {}
+          : { sourceRevision: combined.thread.sourceRevision }),
+        ...(combined.thread.threadFingerprint === undefined
+          ? {}
+          : { threadFingerprint: combined.thread.threadFingerprint }),
+      },
+      ...boundedFiles.map((file) => ({
+        data: file,
+        subject: `${pullSubject}@file:${file.position}:${file.path}`,
+        relations: [{ predicate: "evidence_for" as const, target: pullSubject }],
+      })),
+    ];
+    return this.claimResult("gitcrawl.pull_requests.review_context", claims);
+  }
+
+  async searchOpenPullRequests(
+    options: { maxRows?: number; order?: "newest" | "oldest" } = {},
+  ): Promise<GitcrawlEvidenceResult<GitcrawlThreadEvidence>> {
+    const maxRows =
+      options.maxRows === undefined ? undefined : positiveInteger(options.maxRows, "max rows");
+    const order = options.order ?? "newest";
+    const rows = await this.queryNormalized(
+      "gitcrawl.threads.search",
+      {
+        ...ownerRepo(this.repository),
+        query: "",
+        kind: "pull_request",
+        state: "open",
+        order,
+      },
+      normalizeThread,
+      searchThreadParityView,
+      maxRows,
+    );
+    assertOpenPullRequestRows(rows);
+    assertThreadOrder(rows, order);
+    return this.claimResult(
+      "gitcrawl.threads.search",
+      rows.map((data) => ({
+        data,
+        subject: threadSubject(this.repository, "pull_request", data.number),
+        ...(data.sourceRevision === undefined ? {} : { sourceRevision: data.sourceRevision }),
+        ...(data.threadFingerprint === undefined
+          ? {}
+          : { threadFingerprint: data.threadFingerprint }),
+      })),
+    );
+  }
+
+  async close(): Promise<void> {
+    if (this.closePromise !== undefined) {
+      await this.closePromise;
+      return;
+    }
+    const closePromise = Promise.all(
+      [this.primary.source, this.parity?.source]
+        .filter((source): source is GitcrawlQuerySource => source !== undefined)
+        .map((source) => source.close()),
+    ).then(() => undefined);
+    this.closePromise = closePromise;
+    try {
+      await closePromise;
+    } catch (error) {
+      if (this.closePromise === closePromise) this.closePromise = undefined;
+      throw error;
+    }
+  }
+
+  private async queryNormalized<T>(
+    name: GitcrawlQueryName,
+    args: Record<string, unknown>,
+    normalize: (row: Record<string, unknown>) => T,
+    parityView: (row: T) => unknown = (row) => row,
+    maxRows?: number,
+  ): Promise<T[]> {
+    this.requiredCoverageFor(name);
+    const primaryRows = (
+      await queryAll(this.primary, name, args, this.pageSize, this.maxPages, maxRows)
+    ).map(normalize);
+    if (this.parity !== undefined) {
+      const parityRows = (
+        await queryAll(this.parity, name, args, this.pageSize, this.maxPages, maxRows)
+      ).map(normalize);
+      assertRowsParity(name, primaryRows, parityRows, parityView);
+    }
+    return primaryRows;
+  }
+
+  private claimResult<T>(
+    queryName: GitcrawlQueryName,
+    inputs: ClaimInput<T>[],
+    queryArgs?: Record<string, unknown>,
+  ): GitcrawlEvidenceResult<T> {
+    const claims = inputs.map((input) =>
+      createGitcrawlEvidenceClaim({
+        provider: this.provider,
+        snapshotId: this.primary.snapshotId,
+        ...(this.parity === undefined ? {} : { paritySnapshotId: this.parity.snapshotId }),
+        queryName,
+        ...(queryArgs === undefined ? {} : { queryArgs }),
+        subject: input.subject,
+        ...(input.sourceRevision === undefined ? {} : { sourceRevision: input.sourceRevision }),
+        ...(input.threadFingerprint === undefined
+          ? {}
+          : { threadFingerprint: input.threadFingerprint }),
+        ...(input.relations === undefined ? {} : { relations: input.relations }),
+        data: input.data,
+      }),
+    );
+    return { rows: inputs.map((input) => input.data), claims };
+  }
+
+  private rememberClusterCounts(rows: GitcrawlClusterEvidence[]): void {
+    for (const row of rows) {
+      const previous = this.clusterMemberCounts.get(row.id);
+      if (previous !== undefined && previous !== row.memberCount) {
+        throw new Error(`Gitcrawl cluster ${row.id} changed member count within one snapshot`);
+      }
+      this.clusterMemberCounts.set(row.id, row.memberCount);
+    }
+  }
+}
+
+export function resolveGitcrawlDbPath(
+  repository: string,
+  repoRoot: string,
+  explicitDb?: string,
+): string {
+  const configured = explicitDb?.trim() || process.env.CLAWSWEEPER_GITCRAWL_DB?.trim();
+  if (configured) return path.resolve(configured);
+  const fileName = `${repository
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_.-]+/g, "__")}.sync.db`;
+  const candidates = [
+    path.join(repoRoot, "..", "gitcrawl-store", "data", fileName),
+    path.join(os.homedir(), ".config", "gitcrawl", "stores", "gitcrawl-store", "data", fileName),
+    path.join(os.homedir(), ".config", "gitcrawl", "gitcrawl.db"),
+  ];
+  return candidates.find((candidate) => pathExists(candidate)) ?? candidates.at(-1)!;
+}
+
+export function gitcrawlEvidenceOptionsFromArgs(input: {
+  repository: string;
+  repoRoot: string;
+  args: Record<string, unknown>;
+}): GitcrawlEvidenceAdapterOptions {
+  const provider = String(
+    input.args["gitcrawl-provider"] ?? process.env.CLAWSWEEPER_GITCRAWL_PROVIDER ?? "local",
+  ) as GitcrawlProvider;
+  if (!["local", "cloud", "parity"].includes(provider)) {
+    throw new Error("--gitcrawl-provider must be local, cloud, or parity");
+  }
+  const explicitDb =
+    typeof input.args.db === "string"
+      ? input.args.db
+      : typeof input.args["parity-db"] === "string"
+        ? input.args["parity-db"]
+        : undefined;
+  const maxAgeHours = Number(
+    input.args["max-snapshot-age-hours"] ??
+      process.env.CLAWSWEEPER_GITCRAWL_MAX_SNAPSHOT_AGE_HOURS ??
+      6,
+  );
+  if (!Number.isFinite(maxAgeHours) || maxAgeHours < 0) {
+    throw new Error("--max-snapshot-age-hours must be non-negative");
+  }
+  const options: GitcrawlEvidenceAdapterOptions = {
+    repository: input.repository,
+    provider,
+    dbPath: resolveGitcrawlDbPath(input.repository, input.repoRoot, explicitDb),
+    allowLegacyLocal:
+      input.args["allow-legacy-local"] === true ||
+      process.env.CLAWSWEEPER_GITCRAWL_ALLOW_LEGACY_LOCAL === "1",
+    maxSnapshotAgeMs: maxAgeHours * 60 * 60 * 1000,
+  };
+  if (provider !== "local") {
+    options.cloudUrl = String(
+      input.args["cloud-url"] ?? process.env.CLAWSWEEPER_GITCRAWL_CLOUD_URL ?? "",
+    );
+    options.cloudArchive = String(
+      input.args["cloud-archive"] ??
+        process.env.CLAWSWEEPER_GITCRAWL_CLOUD_ARCHIVE ??
+        `gitcrawl/${input.repository.replace("/", "__")}`,
+    );
+    const cloudCredential = process.env.CLAWSWEEPER_GITCRAWL_CLOUD_TOKEN ?? "";
+    const accessCredential = process.env.CLAWSWEEPER_GITCRAWL_CLOUD_ACCESS_CLIENT_SECRET ?? "";
+    options.cloudToken = cloudCredential;
+    options.cloudAccessClientId = process.env.CLAWSWEEPER_GITCRAWL_CLOUD_ACCESS_CLIENT_ID ?? "";
+    options.cloudAccessClientSecret = accessCredential;
+  }
+  const expectedSnapshotId = String(
+    input.args["snapshot-id"] ?? process.env.CLAWSWEEPER_GITCRAWL_EXPECTED_SNAPSHOT_ID ?? "",
+  ).trim();
+  if (expectedSnapshotId) {
+    assertSnapshotId(expectedSnapshotId);
+    options.expectedSnapshotId = expectedSnapshotId;
+  }
+  return options;
+}
+
+function openCloudSource(options: GitcrawlEvidenceAdapterOptions): GitcrawlQuerySource {
+  const accessCredential = options.cloudAccessClientSecret ?? "";
+  return new CloudGitcrawlQuerySource({
+    baseUrl: options.cloudUrl ?? "",
+    archive: options.cloudArchive ?? "",
+    repository: options.repository,
+    token: options.cloudToken ?? "",
+    accessClientId: options.cloudAccessClientId ?? "",
+    accessClientSecret: accessCredential,
+    ...(options.fetch === undefined ? {} : { fetch: options.fetch }),
+  });
+}
+
+async function openLocalSource(
+  options: GitcrawlEvidenceAdapterOptions,
+): Promise<GitcrawlQuerySource> {
+  return LocalGitcrawlQuerySource.open({
+    dbPath: options.dbPath ?? "",
+    repository: options.repository,
+    allowLegacy: options.allowLegacyLocal ?? false,
+  });
+}
+
+async function initializeSession(
+  source: GitcrawlQuerySource,
+  options: {
+    repository: string;
+    pageSize: number;
+    maxPages: number;
+    maxAge: number;
+    now: () => Date;
+    expectedSnapshotId?: string;
+  },
+): Promise<SessionState> {
+  const state: SessionState = {
+    source,
+    repository: options.repository,
+    archive: "",
+    snapshotId: "",
+    sourceSha256: "",
+    snapshotSchemaName: "",
+    snapshotSchemaVersion: 0,
+    snapshotSchemaHash: "",
+    snapshotCapabilities: [],
+    snapshotPublishedAt: "",
+    snapshotCutoverAt: "",
+    snapshotCoverageComplete: false,
+    sourceSyncAt: "",
+    datasetGeneratedAt: "",
+    coverage: [],
+  };
+  const rows = await queryAll(
+    state,
+    "gitcrawl.coverage",
+    {},
+    options.pageSize,
+    options.maxPages,
+    undefined,
+    options.expectedSnapshotId,
+  );
+  if (options.expectedSnapshotId && state.snapshotId !== options.expectedSnapshotId) {
+    throw new Error("Gitcrawl source did not return the expected snapshot");
+  }
+  const coverage = rows.map(normalizeCoverageRow);
+  assertCoverage(coverage);
+  if (coverage.some((row) => row.dataset_generated_at !== state.datasetGeneratedAt)) {
+    throw new Error("Gitcrawl coverage mixes dataset generations");
+  }
+  assertFreshTimestamp(state.sourceSyncAt, "source sync", options.maxAge, options.now());
+  assertFreshTimestamp(
+    state.datasetGeneratedAt,
+    "dataset generation",
+    options.maxAge,
+    options.now(),
+  );
+  state.coverage = coverage;
+  return state;
+}
+
+async function queryAll(
+  state: SessionState,
+  name: GitcrawlQueryName,
+  args: Record<string, unknown>,
+  pageSize: number,
+  maxPages: number,
+  maxRows?: number,
+  initialSnapshotId = "",
+): Promise<Record<string, unknown>[]> {
+  const rows: Record<string, unknown>[] = [];
+  const seenCursors = new Set<string>();
+  let cursor = "";
+  for (let page = 0; page < maxPages; page += 1) {
+    const remaining = maxRows === undefined ? pageSize : Math.min(pageSize, maxRows - rows.length);
+    if (remaining <= 0) return rows;
+    if (cursor) {
+      if (seenCursors.has(cursor)) {
+        throw new Error(`Gitcrawl cursor replay detected for ${name}`);
+      }
+      seenCursors.add(cursor);
+    }
+    const envelope = await state.source.query({
+      name,
+      args,
+      limit: remaining,
+      cursor,
+      snapshot_id: state.snapshotId || initialSnapshotId,
+    });
+    bindEnvelope(state, envelope, name);
+    if (envelope.values.length > remaining) {
+      throw new Error(`Gitcrawl ${name} returned more rows than requested`);
+    }
+    rows.push(...envelope.values);
+    const next = envelope.stats.next_cursor;
+    if (next && (next === cursor || seenCursors.has(next))) {
+      throw new Error(`Gitcrawl cursor drift detected for ${name}`);
+    }
+    if (maxRows !== undefined && rows.length >= maxRows) return rows.slice(0, maxRows);
+    if (!next) return rows;
+    cursor = next;
+  }
+  throw new Error(`Gitcrawl ${name} pagination exceeded ${maxPages} pages`);
+}
+
+function bindEnvelope(
+  state: SessionState,
+  envelope: GitcrawlQueryEnvelope,
+  name: GitcrawlQueryName,
+): void {
+  const stats = envelope.stats;
+  if (stats.contract_version !== GITCRAWL_QUERY_CONTRACT_VERSION) {
+    throw new Error(
+      `Gitcrawl ${name} returned incompatible safety contract ${String(stats.contract_version)}`,
+    );
+  }
+  if (
+    stats.repository !== state.repository ||
+    !stats.archive.trim() ||
+    stats.archive !== stats.archive.trim()
+  ) {
+    throw new Error(`Gitcrawl ${name} returned mismatched source identity`);
+  }
+  assertSnapshotId(stats.snapshot_id);
+  const snapshotValue: unknown = envelope.snapshot;
+  if (typeof snapshotValue !== "object" || snapshotValue === null || Array.isArray(snapshotValue)) {
+    throw new Error(`Gitcrawl ${name} returned no snapshot provenance`);
+  }
+  const snapshot = snapshotValue as GitcrawlQueryEnvelope["snapshot"];
+  if (
+    !Array.isArray(snapshot.capabilities) ||
+    snapshot.capabilities.some((capability) => typeof capability !== "string")
+  ) {
+    throw new Error(`Gitcrawl ${name} returned malformed snapshot capabilities`);
+  }
+  assertSha256(snapshot.source_sha256, "Gitcrawl snapshot source sha256");
+  if (
+    snapshot.id !== stats.snapshot_id ||
+    snapshot.source_sync_at !== stats.source_sync_at ||
+    snapshot.dataset_generated_at !== stats.dataset_generated_at ||
+    snapshot.coverage_complete !== stats.coverage_complete
+  ) {
+    throw new Error(`Gitcrawl ${name} returned mismatched snapshot provenance`);
+  }
+  if (state.source.provider === "cloud") {
+    assertSha256(snapshot.id, "Gitcrawl cloud snapshot id");
+    if (
+      snapshot.id !== snapshot.source_sha256 ||
+      !snapshot.schema_name.trim() ||
+      !Number.isSafeInteger(snapshot.schema_version) ||
+      snapshot.schema_version <= 0 ||
+      !snapshot.schema_hash.trim() ||
+      !snapshot.capabilities.includes(name) ||
+      !snapshot.published_at ||
+      !snapshot.cutover_at
+    ) {
+      throw new Error(`Gitcrawl ${name} returned incomplete cloud snapshot provenance`);
+    }
+    parseRfc3339Timestamp(snapshot.published_at, "Gitcrawl cloud snapshot published_at");
+    parseRfc3339Timestamp(snapshot.cutover_at, "Gitcrawl cloud snapshot cutover_at");
+  }
+  if (!stats.coverage_complete && name !== "gitcrawl.coverage") {
+    throw new Error(`Gitcrawl ${name} returned incomplete coverage`);
+  }
+  if (!state.snapshotId) {
+    state.archive = stats.archive;
+    state.snapshotId = stats.snapshot_id;
+    state.sourceSha256 = snapshot.source_sha256;
+    state.snapshotSchemaName = snapshot.schema_name;
+    state.snapshotSchemaVersion = snapshot.schema_version;
+    state.snapshotSchemaHash = snapshot.schema_hash;
+    state.snapshotCapabilities = [...snapshot.capabilities];
+    state.snapshotPublishedAt = snapshot.published_at;
+    state.snapshotCutoverAt = snapshot.cutover_at;
+    state.snapshotCoverageComplete = snapshot.coverage_complete;
+    state.sourceSyncAt = stats.source_sync_at;
+    state.datasetGeneratedAt = stats.dataset_generated_at;
+  } else if (
+    stats.snapshot_id !== state.snapshotId ||
+    snapshot.source_sha256 !== state.sourceSha256 ||
+    snapshot.schema_name !== state.snapshotSchemaName ||
+    snapshot.schema_version !== state.snapshotSchemaVersion ||
+    snapshot.schema_hash !== state.snapshotSchemaHash ||
+    canonicalJson(snapshot.capabilities) !== canonicalJson(state.snapshotCapabilities) ||
+    snapshot.published_at !== state.snapshotPublishedAt ||
+    snapshot.cutover_at !== state.snapshotCutoverAt ||
+    snapshot.coverage_complete !== state.snapshotCoverageComplete ||
+    stats.archive !== state.archive ||
+    stats.source_sync_at !== state.sourceSyncAt ||
+    stats.dataset_generated_at !== state.datasetGeneratedAt
+  ) {
+    throw new Error(`Gitcrawl ${name} mixed snapshot generation`);
+  }
+}
+
+function normalizeCoverageRow(row: Record<string, unknown>): GitcrawlCoverageRow {
+  const dataset = String(row.dataset ?? "");
+  if (!GITCRAWL_DATASETS.includes(dataset as GitcrawlCoverageRow["dataset"])) {
+    throw new Error(`Gitcrawl coverage returned unknown dataset ${dataset}`);
+  }
+  const normalized = {
+    dataset: dataset as GitcrawlCoverageRow["dataset"],
+    row_count: safeNonNegative(row.row_count, `${dataset} row_count`),
+    eligible_count: safeNonNegative(row.eligible_count, `${dataset} eligible_count`),
+    covered_count: safeNonNegative(row.covered_count, `${dataset} covered_count`),
+    max_source_at: boundedString(row.max_source_at, 64),
+    dataset_generated_at: boundedString(row.dataset_generated_at, 64),
+    complete: booleanValue(row.complete),
+  };
+  if (normalized.complete && normalized.eligible_count > normalized.row_count) {
+    throw new Error(`Gitcrawl coverage ${dataset} has more eligible rows than total rows`);
+  }
+  if (normalized.covered_count > normalized.eligible_count) {
+    throw new Error(`Gitcrawl coverage ${dataset} exceeds eligible rows`);
+  }
+  if (normalized.complete && normalized.covered_count !== normalized.eligible_count) {
+    throw new Error(`Gitcrawl coverage ${dataset} is marked complete with missing rows`);
+  }
+  return normalized;
+}
+
+function assertCoverage(coverage: GitcrawlCoverageRow[]): void {
+  const byDataset = new Map(coverage.map((row) => [row.dataset, row]));
+  if (coverage.length !== new Set(coverage.map((row) => row.dataset)).size) {
+    throw new Error("Gitcrawl coverage contains duplicate datasets");
+  }
+  for (const dataset of GITCRAWL_DATASETS) {
+    if (!byDataset.has(dataset)) throw new Error(`Gitcrawl coverage is missing ${dataset}`);
+  }
+  requireDatasets(coverage, GITCRAWL_QUERY_COVERAGE["gitcrawl.coverage"]);
+}
+
+function assertCoverageParity(
+  primary: GitcrawlCoverageRow[],
+  parity: GitcrawlCoverageRow[],
+  datasets: readonly GitcrawlDataset[],
+): void {
+  const included = new Set(datasets);
+  const projection = (rows: GitcrawlCoverageRow[]) =>
+    rows
+      .filter((row) => included.has(row.dataset))
+      .map((row) => ({
+        dataset: row.dataset,
+        row_count: row.row_count,
+        eligible_count: row.eligible_count,
+        covered_count: row.covered_count,
+        complete: row.complete,
+      }))
+      .sort((left, right) => compareCanonicalText(left.dataset, right.dataset));
+  if (canonicalJson(projection(primary)) !== canonicalJson(projection(parity))) {
+    throw new Error("Gitcrawl cloud/local coverage parity mismatch");
+  }
+}
+
+function requireDatasets(
+  coverage: GitcrawlCoverageRow[],
+  datasets: readonly GitcrawlCoverageRow["dataset"][],
+): void {
+  for (const dataset of datasets) {
+    if (!coverage.find((row) => row.dataset === dataset)?.complete) {
+      throw new Error(`Gitcrawl ${dataset} coverage is incomplete`);
+    }
+  }
+}
+
+function clusterListQueryArgs(
+  repository: string,
+  options: { status?: string; minSize?: number },
+): { owner: string; repo: string; status: string; min_size: number } {
+  const requestedStatus = options.status ?? "active";
+  const status = boundedString(requestedStatus, 64);
+  if (!status || status !== requestedStatus) {
+    throw new Error("Gitcrawl cluster status must be a canonical bounded value");
+  }
+  return {
+    ...ownerRepo(repository),
+    status,
+    min_size: positiveInteger(options.minSize ?? 1, "minimum cluster size"),
+  };
+}
+
+function normalizeCluster(row: Record<string, unknown>): GitcrawlClusterEvidence {
+  return {
+    id: safePositive(row.cluster_id, "cluster id"),
+    stableSlug: boundedString(row.stable_slug, 512),
+    status: boundedString(row.status, 64),
+    clusterType: boundedString(row.cluster_type, 64),
+    title: boundedString(stripGitcrawlHtmlComments(safetyString(row.title, "cluster title")), 512),
+    representative: {
+      threadId: optionalPositive(row.representative_thread_id, "representative thread id"),
+      number: optionalPositive(row.representative_number, "representative thread number"),
+      kind: boundedString(row.representative_kind, 32),
+      state: boundedString(row.representative_state, 32),
+      title: boundedString(
+        stripGitcrawlHtmlComments(
+          safetyString(row.representative_title, "cluster representative title"),
+        ),
+        512,
+      ),
+    },
+    memberCount: safeNonNegative(row.member_count, "member count"),
+    createdAt: boundedString(row.created_at, 64),
+    updatedAt: boundedString(row.updated_at, 64),
+    closedAt: boundedString(row.closed_at, 64),
+  };
+}
+
+function normalizeRequestedCluster(
+  row: Record<string, unknown>,
+  status: string,
+  minSize: number,
+): GitcrawlClusterEvidence {
+  const cluster = normalizeCluster(row);
+  if (status !== "all" && cluster.status !== status) {
+    throw new Error(`Gitcrawl cluster ${cluster.id} does not match requested status ${status}`);
+  }
+  if (cluster.memberCount < minSize) {
+    throw new Error(`Gitcrawl cluster ${cluster.id} is smaller than requested minimum ${minSize}`);
+  }
+  return cluster;
+}
+
+function normalizeThread(row: Record<string, unknown>): GitcrawlThreadEvidence {
+  const completeSecurityMetadata = booleanValue(row.security_metadata_complete);
+  if (completeSecurityMetadata && typeof row.title !== "string") {
+    throw new Error("Gitcrawl thread title is missing from complete security metadata");
+  }
+  if (completeSecurityMetadata && typeof row.body !== "string") {
+    throw new Error("Gitcrawl thread body is missing from complete security metadata");
+  }
+  if (
+    completeSecurityMetadata &&
+    (typeof row.author_login !== "string" || !row.author_login.trim())
+  ) {
+    throw new Error("Gitcrawl thread author login is missing from complete security metadata");
+  }
+  if (
+    completeSecurityMetadata &&
+    (typeof row.author_type !== "string" || !row.author_type.trim())
+  ) {
+    throw new Error("Gitcrawl thread author type is missing from complete security metadata");
+  }
+  const safetyTitle = safetyString(row.title, "thread title");
+  const safetyBody = safetyString(row.body, "thread body");
+  const threadState = boundedString(row.state, 32);
+  const promptTitle = stripGitcrawlHtmlComments(safetyTitle);
+  const promptBody = stripGitcrawlHtmlComments(safetyBody);
+  const hasBodyField = typeof row.body === "string";
+  const hasLabelsField = row.labels_json !== undefined && row.labels_json !== null;
+  const hasAssigneesField = row.assignees_json !== undefined && row.assignees_json !== null;
+  const authorAssociation = optionalAuthorAssociation(row.author_association);
+  const hasAuthorAssociation = authorAssociation.length > 0;
+  const authorLogin = boundedString(row.author_login, 256);
+  const authorType = boundedString(row.author_type, 64);
+  const safetyLabels = hasLabelsField ? unboundedJsonArray(row.labels_json, "thread labels") : [];
+  const safetyAssignees = hasAssigneesField
+    ? unboundedJsonArray(row.assignees_json, "thread assignees")
+    : [];
+  const promptLabels = sanitizeGitcrawlPromptValue(safetyLabels);
+  const promptAssignees = sanitizeGitcrawlPromptValue(safetyAssignees);
+  const securityMetadataComplete =
+    completeSecurityMetadata &&
+    hasBodyField &&
+    hasLabelsField &&
+    hasAssigneesField &&
+    hasAuthorAssociation &&
+    authorLogin.length > 0 &&
+    authorType.length > 0;
+  const securityProjection = {
+    state: threadState,
+    title: safetyTitle,
+    body: safetyBody,
+    author_login: authorLogin,
+    author_type: authorType,
+    labels: safetyLabels,
+    assignees: safetyAssignees,
+    author_association: authorAssociation || null,
+    complete: securityMetadataComplete,
+  };
+  const fingerprintHash = boundedString(row.fingerprint_hash, 256);
+  const fingerprintAlgorithm = boundedString(row.fingerprint_algorithm, 64);
+  const revisionHash = boundedString(row.revision_content_hash, 256);
+  if (fingerprintHash) {
+    if (fingerprintAlgorithm !== "thread-fingerprint-v2") {
+      throw new Error(
+        `unsupported Gitcrawl thread fingerprint algorithm: ${fingerprintAlgorithm || "missing"}`,
+      );
+    }
+    assertSha256(fingerprintHash, "Gitcrawl thread fingerprint");
+  }
+  if (revisionHash) assertSha256(revisionHash, "Gitcrawl source revision");
+  const revisionId = optionalPositive(row.revision_id, "source revision id");
+  const revisionUpdatedAt = boundedString(
+    row.revision_source_updated_at || row.updated_at_gh || row.updated_at,
+    64,
+  );
+  const sourceRevision =
+    revisionId === null && !revisionHash && !revisionUpdatedAt
+      ? undefined
+      : {
+          ...(revisionId === null ? {} : { id: revisionId }),
+          ...(revisionHash ? { sha256: revisionHash } : {}),
+          ...(revisionUpdatedAt ? { updated_at: revisionUpdatedAt } : {}),
+        };
+  const threadFingerprint = fingerprintHash
+    ? {
+        algorithm: fingerprintAlgorithm,
+        sha256: fingerprintHash,
+      }
+    : undefined;
+  return {
+    ...(optionalPositive(row.cluster_id, "cluster id") === null
+      ? {}
+      : { clusterId: optionalPositive(row.cluster_id, "cluster id")! }),
+    ...(boundedString(row.stable_slug ?? row.cluster_slug, 512)
+      ? { clusterSlug: boundedString(row.stable_slug ?? row.cluster_slug, 512) }
+      : {}),
+    ...(boundedString(row.cluster_status, 64)
+      ? { clusterStatus: boundedString(row.cluster_status, 64) }
+      : {}),
+    ...(row.cluster_member_count === undefined
+      ? {}
+      : {
+          clusterMemberCount: safeNonNegative(row.cluster_member_count, "cluster member count"),
+        }),
+    ...(boundedString(row.role ?? row.cluster_role, 64)
+      ? { role: boundedString(row.role ?? row.cluster_role, 64) }
+      : {}),
+    ...(boundedString(row.membership_state, 64)
+      ? { membershipState: boundedString(row.membership_state, 64) }
+      : {}),
+    ...(row.score_to_representative === undefined
+      ? {}
+      : {
+          scoreToRepresentative: optionalNumber(
+            row.score_to_representative,
+            "score to representative",
+          ),
+        }),
+    threadId: safePositive(row.thread_id, "thread id"),
+    number: safePositive(row.number, "thread number"),
+    kind: boundedString(row.kind, 32),
+    state: threadState,
+    title: boundedString(promptTitle, 512),
+    body: boundedString(promptBody, 2_048),
+    authorLogin,
+    authorType,
+    ...(authorAssociation ? { authorAssociation } : {}),
+    htmlUrl: boundedString(row.html_url, 2_048),
+    ...(hasLabelsField ? { labels: boundedJsonArray(promptLabels, 32, 256) } : {}),
+    ...(hasAssigneesField ? { assignees: boundedJsonArray(promptAssignees, 16, 256) } : {}),
+    isDraft: booleanValue(row.is_draft),
+    createdAt: boundedString(row.created_at_gh, 64),
+    updatedAt: boundedString(row.updated_at_gh || row.updated_at, 64),
+    keySummary: boundedString(
+      stripGitcrawlHtmlComments(safetyString(row.key_summary, "thread key summary")),
+      2_048,
+    ),
+    securitySensitive: hasSecuritySignalText(safetyTitle, safetyBody, safetyLabels),
+    securityMetadataComplete,
+    securityProjectionSha256: sha256Canonical(securityProjection),
+    policySignals: deriveGitcrawlThreadPolicySignals(safetyTitle, safetyBody),
+    ...(sourceRevision === undefined ? {} : { sourceRevision }),
+    ...(threadFingerprint === undefined ? {} : { threadFingerprint }),
+  };
+}
+
+function normalizeReviewContext(
+  row: Record<string, unknown>,
+): Omit<GitcrawlReviewContext, "files" | "filesOmitted"> {
+  return {
+    thread: normalizeThread(row),
+    baseSha: gitObjectId(row.base_sha, "PR base revision"),
+    headSha: gitObjectId(row.head_sha, "PR head revision"),
+    headRef: boundedString(row.head_ref, 512),
+    headRepoFullName: boundedString(row.head_repo_full_name, 512),
+    mergeableState: boundedString(row.mergeable_state, 64),
+    additions: safeNonNegative(row.additions, "PR additions"),
+    deletions: safeNonNegative(row.deletions, "PR deletions"),
+    changedFiles: safeNonNegative(row.changed_files, "PR changed files"),
+    detailsFetchedAt: boundedString(row.details_fetched_at, 64),
+    detailsUpdatedAt: boundedString(row.details_updated_at, 64),
+    clusterId: optionalPositive(row.cluster_id, "cluster id"),
+    clusterSlug: boundedString(row.cluster_slug, 512),
+    clusterTitle: boundedString(
+      stripGitcrawlHtmlComments(safetyString(row.cluster_title, "review cluster title")),
+      512,
+    ),
+    clusterStatus: boundedString(row.cluster_status, 64),
+    clusterRole: boundedString(row.cluster_role, 64),
+    scoreToRepresentative: optionalNumber(row.score_to_representative, "score to representative"),
+  };
+}
+
+function normalizeReviewFile(row: Record<string, unknown>): GitcrawlReviewFile {
+  return {
+    position: safeNonNegative(row.file_position, "file position"),
+    path: exactFilePath(row.file_path, "file path"),
+    status: boundedString(row.file_status, 64),
+    additions: safeNonNegative(row.file_additions, "file additions"),
+    deletions: safeNonNegative(row.file_deletions, "file deletions"),
+    changes: safeNonNegative(row.file_changes, "file changes"),
+    previousPath: exactFilePath(row.file_previous_path, "previous file path", true),
+    fetchedAt: boundedString(row.file_fetched_at, 64),
+  };
+}
+
+function assertCompleteReviewFiles(
+  number: number,
+  files: GitcrawlReviewFile[],
+  changedFiles: number,
+): void {
+  if (files.length !== changedFiles) {
+    throw new Error(
+      `Gitcrawl review context for #${number} has ${files.length}/${changedFiles} files`,
+    );
+  }
+  // Gitcrawl positions are the snapshot-local identity; paths can legitimately repeat.
+  for (let index = 0; index < files.length; index += 1) {
+    const file = files[index]!;
+    if (file.position !== index) {
+      throw new Error(`Gitcrawl review context for #${number} has incomplete file positions`);
+    }
+    if (!file.path || !file.fetchedAt) {
+      throw new Error(`Gitcrawl review context for #${number} has incomplete file identity`);
+    }
+  }
+}
+
+function assertThreadOrder(rows: GitcrawlThreadEvidence[], order: "newest" | "oldest"): void {
+  const keys = rows.map((row) => validatedThreadOrderKey(threadOrderKey(row)));
+  for (let index = 1; index < keys.length; index += 1) {
+    const previous = keys[index - 1]!;
+    const current = keys[index]!;
+    const direction = previous.timestamp - current.timestamp || previous.number - current.number;
+    if (
+      direction === 0 ||
+      (order === "newest" && direction < 0) ||
+      (order === "oldest" && direction > 0)
+    ) {
+      throw new Error(`Gitcrawl pull request search did not honor ${order}-first ordering`);
+    }
+  }
+}
+
+type GitcrawlThreadOrderKey = {
+  updatedAt: string;
+  number: number;
+};
+
+function threadOrderKey(row: GitcrawlThreadEvidence): GitcrawlThreadOrderKey {
+  return { updatedAt: row.updatedAt, number: row.number };
+}
+
+function validatedThreadOrderKey(
+  key: GitcrawlThreadOrderKey,
+): GitcrawlThreadOrderKey & { timestamp: number } {
+  return {
+    ...key,
+    timestamp: parseRfc3339Timestamp(key.updatedAt, "Gitcrawl thread updated_at"),
+  };
+}
+
+function assertOpenPullRequestRows(rows: GitcrawlThreadEvidence[]): void {
+  for (const row of rows) {
+    if (row.kind !== "pull_request" || row.state !== "open") {
+      throw new Error(
+        `Gitcrawl open pull request search returned ${row.kind || "unknown"} #${row.number} in ${row.state || "unknown"} state`,
+      );
+    }
+  }
+}
+
+function clusterParityView(row: GitcrawlClusterEvidence): unknown {
+  return row;
+}
+
+function searchThreadParityView(row: GitcrawlThreadEvidence): unknown {
+  const { sourceRevision: _sourceRevision, ...common } = row;
+  return common;
+}
+
+function clusterMemberParityView(row: GitcrawlThreadEvidence): unknown {
+  const { sourceRevision: _sourceRevision, ...common } = row;
+  return common;
+}
+
+function relatedThreadParityView(row: GitcrawlThreadEvidence): unknown {
+  const {
+    sourceRevision: _sourceRevision,
+    clusterStatus: _clusterStatus,
+    membershipState: _membershipState,
+    createdAt: _createdAt,
+    isDraft: _isDraft,
+    ...common
+  } = row;
+  return common;
+}
+
+function reviewRawParityView(row: Record<string, unknown>): unknown {
+  if (row.row_kind === "file") {
+    return {
+      rowKind: "file",
+      ...normalizeReviewFile(row),
+    };
+  }
+  const context = normalizeReviewContext(row);
+  return {
+    rowKind: "context",
+    ...context,
+    thread: clusterMemberParityView(context.thread),
+  };
+}
+
+function assertRowsParity<T>(
+  name: GitcrawlQueryName,
+  primary: T[],
+  parity: T[],
+  project: (row: T) => unknown,
+): void {
+  const normalize = (rows: T[]) => rows.map(project).map(canonicalJson).sort(compareCanonicalText);
+  if (canonicalJson(normalize(primary)) !== canonicalJson(normalize(parity))) {
+    throw new Error(`Gitcrawl cloud/local parity mismatch for ${name}`);
+  }
+}
+
+function assertFreshTimestamp(value: string, label: string, maxAge: number, now: Date): void {
+  const timestamp = parseRfc3339Timestamp(value, `Gitcrawl ${label} timestamp`);
+  const age = now.getTime() - timestamp;
+  if (age < -MAX_CLOCK_SKEW_MS) throw new Error(`Gitcrawl ${label} timestamp is in the future`);
+  if (age > maxAge) {
+    throw new Error(`Gitcrawl ${label} is stale by ${Math.floor(age / 60_000)} minutes`);
+  }
+}
+
+function assertTimestamp(value: string, label: string): void {
+  parseRfc3339Timestamp(value, label);
+}
+
+function assertSourceTopology(options: GitcrawlEvidenceSourceOptions): void {
+  if (options.provider === "local") {
+    if (options.primarySource.provider !== "local" || options.paritySource !== undefined) {
+      throw new Error("Gitcrawl local mode requires one local source");
+    }
+    return;
+  }
+  if (options.primarySource.provider !== "cloud") {
+    throw new Error(`Gitcrawl ${options.provider} mode requires a cloud primary source`);
+  }
+  if (options.provider === "cloud" && options.paritySource !== undefined) {
+    throw new Error("Gitcrawl cloud mode does not accept a parity source");
+  }
+  if (options.provider === "parity" && options.paritySource?.provider !== "local") {
+    throw new Error("Gitcrawl parity mode requires a local parity source");
+  }
+}
+
+function ownerRepo(repository: string): { owner: string; repo: string } {
+  const [owner, repo, ...rest] = repository.split("/");
+  if (!owner || !repo || rest.length > 0) {
+    throw new Error(`invalid Gitcrawl repository: ${repository}`);
+  }
+  return { owner, repo };
+}
+
+function clusterSubject(repository: string, clusterId: number): string {
+  return `${repository}#cluster:${clusterId}`;
+}
+
+function threadSubject(repository: string, kind: string, number: number): string {
+  return `${repository}#${kind === "pull_request" ? "pull" : "issue"}:${number}`;
+}
+
+function boundedString(value: unknown, maxLength: number): string {
+  return String(value ?? "")
+    .trim()
+    .slice(0, maxLength);
+}
+
+function optionalAuthorAssociation(value: unknown): string {
+  if (value === undefined || value === null || value === "") return "";
+  if (typeof value !== "string" || !GITHUB_AUTHOR_ASSOCIATIONS.has(value)) {
+    throw new Error("Gitcrawl thread author association is invalid");
+  }
+  return value;
+}
+
+function gitObjectId(value: unknown, label: string): string {
+  if (value === undefined || value === null || value === "") return "";
+  if (typeof value !== "string" || !/^(?:[a-f0-9]{40}|[a-f0-9]{64})$/.test(value)) {
+    throw new Error(`Gitcrawl ${label} is not a valid Git object ID`);
+  }
+  return value;
+}
+
+function exactFilePath(value: unknown, label: string, allowEmpty = false): string {
+  if (value === undefined || value === null) {
+    if (allowEmpty) return "";
+    throw new Error(`Gitcrawl ${label} is missing`);
+  }
+  if (typeof value !== "string" || value.includes("\0")) {
+    throw new Error(`Gitcrawl ${label} is invalid`);
+  }
+  if (Buffer.byteLength(value, "utf8") > 1_024) {
+    throw new Error(`Gitcrawl ${label} exceeds the safety bound`);
+  }
+  if (!allowEmpty && value.length === 0) throw new Error(`Gitcrawl ${label} is missing`);
+  return value;
+}
+
+function boundedJsonArray(value: unknown, maxItems: number, maxItemBytes: number): unknown[] {
+  return unboundedJsonArray(value, "JSON array field")
+    .slice(0, maxItems)
+    .map((entry) => {
+      const text = canonicalJson(entry);
+      if (Buffer.byteLength(text, "utf8") <= maxItemBytes) return entry;
+      return text.slice(0, maxItemBytes);
+    });
+}
+
+function unboundedJsonArray(value: unknown, label: string): unknown[] {
+  let parsed = value;
+  if (typeof value === "string") {
+    if (Buffer.byteLength(value, "utf8") > MAX_SAFETY_FIELD_BYTES) {
+      throw new Error(`Gitcrawl ${label} exceeds the safety bound`);
+    }
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      throw new Error(`Gitcrawl ${label} is malformed`);
+    }
+  }
+  if (!Array.isArray(parsed)) throw new Error(`Gitcrawl ${label} is malformed`);
+  return parsed;
+}
+
+function safetyString(value: unknown, label: string): string {
+  const text = String(value ?? "");
+  if (Buffer.byteLength(text, "utf8") > MAX_SAFETY_FIELD_BYTES) {
+    throw new Error(`Gitcrawl ${label} exceeds the safety bound`);
+  }
+  return text.trim();
+}
+
+function safePositive(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${label} is invalid`);
+  }
+  return value;
+}
+
+function optionalPositive(value: unknown, label: string): number | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${label} is invalid`);
+  }
+  return value;
+}
+
+function safeNonNegative(value: unknown, label: string): number {
+  if (value === undefined || value === null) {
+    throw new Error(`${label} is missing`);
+  }
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${label} is invalid`);
+  }
+  return value;
+}
+
+function optionalNumber(value: unknown, label: string): number | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`Gitcrawl ${label} is invalid`);
+  }
+  return value;
+}
+
+function booleanValue(value: unknown): boolean {
+  return value === true || value === 1 || value === "1";
+}
+
+function positiveInteger(value: number, label: string): number {
+  if (!Number.isSafeInteger(value) || value < 1) throw new Error(`${label} must be positive`);
+  return value;
+}
+
+function nonNegativeInteger(value: number, label: string): number {
+  if (!Number.isSafeInteger(value) || value < 0) throw new Error(`${label} must be non-negative`);
+  return value;
+}
+
+function pathExists(value: string): boolean {
+  return Boolean(value) && path.isAbsolute(value) && fs.existsSync(value);
+}

--- a/src/repair/gitcrawl-evidence-adapter.ts
+++ b/src/repair/gitcrawl-evidence-adapter.ts
@@ -321,7 +321,21 @@ export class GitcrawlEvidenceAdapter {
         maxPages,
       });
     } catch (error) {
-      await Promise.allSettled([options.primarySource.close(), options.paritySource?.close()]);
+      const cleanup = await Promise.allSettled(
+        [options.primarySource, options.paritySource]
+          .filter((source): source is GitcrawlQuerySource => source !== undefined)
+          .map((source) => source.close()),
+      );
+      const cleanupErrors = cleanup.flatMap((result) =>
+        result.status === "rejected" ? [result.reason] : [],
+      );
+      if (cleanupErrors.length > 0) {
+        throw new AggregateError(
+          [error, ...cleanupErrors],
+          "failed to initialize and clean up Gitcrawl evidence sources",
+          { cause: error },
+        );
+      }
       throw error;
     }
   }
@@ -444,6 +458,9 @@ export class GitcrawlEvidenceAdapter {
         throw new Error(
           `Gitcrawl cluster ${clusterId} returned member #${row.number} with non-active membership`,
         );
+      }
+      if (row.clusterStatus !== "active") {
+        throw new Error(`Gitcrawl cluster ${clusterId} returned a non-active cluster`);
       }
     }
     const declaredCounts = new Set(
@@ -1144,6 +1161,9 @@ function clusterListQueryArgs(
   const status = boundedString(requestedStatus, 64);
   if (!status || status !== requestedStatus) {
     throw new Error("Gitcrawl cluster status must be a canonical bounded value");
+  }
+  if (status !== "active") {
+    throw new Error("Gitcrawl evidence currently certifies only active cluster queries");
   }
   return {
     ...ownerRepo(repository),

--- a/src/repair/gitcrawl-evidence-adapter.ts
+++ b/src/repair/gitcrawl-evidence-adapter.ts
@@ -423,12 +423,13 @@ export class GitcrawlEvidenceAdapter {
   }
 
   async clusterMembers(clusterId: number): Promise<GitcrawlEvidenceResult<GitcrawlThreadEvidence>> {
+    const queryArgs = {
+      ...ownerRepo(this.repository),
+      cluster_id: positiveInteger(clusterId, "cluster id"),
+    };
     const rows = await this.queryNormalized(
       "gitcrawl.clusters.members",
-      {
-        ...ownerRepo(this.repository),
-        cluster_id: positiveInteger(clusterId, "cluster id"),
-      },
+      queryArgs,
       normalizeThread,
       clusterMemberParityView,
     );
@@ -479,17 +480,19 @@ export class GitcrawlEvidenceAdapter {
           },
         ],
       })),
+      queryArgs,
     );
   }
 
   async related(number: number): Promise<GitcrawlEvidenceResult<GitcrawlThreadEvidence>> {
     const requestedNumber = positiveInteger(number, "thread number");
+    const queryArgs = {
+      ...ownerRepo(this.repository),
+      number: requestedNumber,
+    };
     const rows = await this.queryNormalized(
       "gitcrawl.clusters.related",
-      {
-        ...ownerRepo(this.repository),
-        number: requestedNumber,
-      },
+      queryArgs,
       (row) => {
         const sourceNumber = safePositive(row.source_number, "related source number");
         if (sourceNumber !== requestedNumber) {
@@ -523,18 +526,20 @@ export class GitcrawlEvidenceAdapter {
           },
         ],
       })),
+      queryArgs,
     );
   }
 
   async reviewContext(
     number: number,
   ): Promise<GitcrawlEvidenceResult<GitcrawlReviewContext | GitcrawlReviewFile>> {
+    const queryArgs = {
+      ...ownerRepo(this.repository),
+      number: positiveInteger(number, "pull request number"),
+    };
     const raw = await this.queryNormalized(
       "gitcrawl.pull_requests.review_context",
-      {
-        ...ownerRepo(this.repository),
-        number: positiveInteger(number, "pull request number"),
-      },
+      queryArgs,
       (row) => ({ ...row }),
       reviewRawParityView,
     );
@@ -602,7 +607,7 @@ export class GitcrawlEvidenceAdapter {
         relations: [{ predicate: "evidence_for" as const, target: pullSubject }],
       })),
     ];
-    return this.claimResult("gitcrawl.pull_requests.review_context", claims);
+    return this.claimResult("gitcrawl.pull_requests.review_context", claims, queryArgs);
   }
 
   async searchOpenPullRequests(
@@ -611,15 +616,16 @@ export class GitcrawlEvidenceAdapter {
     const maxRows =
       options.maxRows === undefined ? undefined : positiveInteger(options.maxRows, "max rows");
     const order = options.order ?? "newest";
+    const queryArgs = {
+      ...ownerRepo(this.repository),
+      query: "",
+      kind: "pull_request",
+      state: "open",
+      order,
+    };
     const rows = await this.queryNormalized(
       "gitcrawl.threads.search",
-      {
-        ...ownerRepo(this.repository),
-        query: "",
-        kind: "pull_request",
-        state: "open",
-        order,
-      },
+      queryArgs,
       normalizeThread,
       searchThreadParityView,
       maxRows,
@@ -636,6 +642,7 @@ export class GitcrawlEvidenceAdapter {
           ? {}
           : { threadFingerprint: data.threadFingerprint }),
       })),
+      queryArgs,
     );
   }
 
@@ -681,15 +688,16 @@ export class GitcrawlEvidenceAdapter {
   private claimResult<T>(
     queryName: GitcrawlQueryName,
     inputs: ClaimInput<T>[],
-    queryArgs?: Record<string, unknown>,
+    queryArgs: Record<string, unknown>,
   ): GitcrawlEvidenceResult<T> {
     const claims = inputs.map((input) =>
       createGitcrawlEvidenceClaim({
         provider: this.provider,
+        repository: this.repository,
         snapshotId: this.primary.snapshotId,
         ...(this.parity === undefined ? {} : { paritySnapshotId: this.parity.snapshotId }),
         queryName,
-        ...(queryArgs === undefined ? {} : { queryArgs }),
+        queryArgs,
         subject: input.subject,
         ...(input.sourceRevision === undefined ? {} : { sourceRevision: input.sourceRevision }),
         ...(input.threadFingerprint === undefined
@@ -1250,7 +1258,7 @@ function normalizeThread(row: Record<string, unknown>): GitcrawlThreadEvidence {
         }),
     threadId: safePositive(row.thread_id, "thread id"),
     number: safePositive(row.number, "thread number"),
-    kind: boundedString(row.kind, 32),
+    kind: supportedThreadKind(row.kind),
     state: threadState,
     title: boundedString(promptTitle, 512),
     body: boundedString(promptBody, 2_048),
@@ -1397,14 +1405,7 @@ function clusterMemberParityView(row: GitcrawlThreadEvidence): unknown {
 }
 
 function relatedThreadParityView(row: GitcrawlThreadEvidence): unknown {
-  const {
-    sourceRevision: _sourceRevision,
-    clusterStatus: _clusterStatus,
-    membershipState: _membershipState,
-    createdAt: _createdAt,
-    isDraft: _isDraft,
-    ...common
-  } = row;
+  const { sourceRevision: _sourceRevision, ...common } = row;
   return common;
 }
 
@@ -1479,7 +1480,16 @@ function clusterSubject(repository: string, clusterId: number): string {
 }
 
 function threadSubject(repository: string, kind: string, number: number): string {
-  return `${repository}#${kind === "pull_request" ? "pull" : "issue"}:${number}`;
+  const supportedKind = supportedThreadKind(kind);
+  return `${repository}#${supportedKind === "pull_request" ? "pull" : "issue"}:${number}`;
+}
+
+function supportedThreadKind(value: unknown): "issue" | "pull_request" {
+  const kind = boundedString(value, 32);
+  if (kind !== "issue" && kind !== "pull_request") {
+    throw new Error(`unsupported Gitcrawl thread kind: ${kind || "missing"}`);
+  }
+  return kind;
 }
 
 function boundedString(value: unknown, maxLength: number): string {
@@ -1525,7 +1535,14 @@ function boundedJsonArray(value: unknown, maxItems: number, maxItemBytes: number
     .map((entry) => {
       const text = canonicalJson(entry);
       if (Buffer.byteLength(text, "utf8") <= maxItemBytes) return entry;
-      return text.slice(0, maxItemBytes);
+      const marker = {
+        truncated: true,
+        sha256: sha256Canonical(entry),
+      };
+      if (Buffer.byteLength(canonicalJson(marker), "utf8") > maxItemBytes) {
+        throw new Error("Gitcrawl JSON array item digest exceeds the safety bound");
+      }
+      return marker;
     });
 }
 

--- a/src/repair/gitcrawl-evidence-adapter.ts
+++ b/src/repair/gitcrawl-evidence-adapter.ts
@@ -880,7 +880,7 @@ async function initializeSession(
   if (options.expectedSnapshotId && state.snapshotId !== options.expectedSnapshotId) {
     throw new Error("Gitcrawl source did not return the expected snapshot");
   }
-  const coverage = rows.map(normalizeCoverageRow);
+  const coverage = rows.map((row) => normalizeCoverageRow(row, state.snapshotId));
   assertCoverage(coverage);
   if (coverage.some((row) => row.dataset_generated_at !== state.datasetGeneratedAt)) {
     throw new Error("Gitcrawl coverage mixes dataset generations");
@@ -1062,12 +1062,16 @@ function bindEnvelope(
   }
 }
 
-function normalizeCoverageRow(row: Record<string, unknown>): GitcrawlCoverageRow {
+function normalizeCoverageRow(
+  row: Record<string, unknown>,
+  snapshotId: string,
+): GitcrawlCoverageRow {
   const dataset = String(row.dataset ?? "");
   if (!GITCRAWL_DATASETS.includes(dataset as GitcrawlCoverageRow["dataset"])) {
     throw new Error(`Gitcrawl coverage returned unknown dataset ${dataset}`);
   }
   const normalized = {
+    snapshot_id: snapshotId,
     dataset: dataset as GitcrawlCoverageRow["dataset"],
     row_count: safeNonNegative(row.row_count, `${dataset} row_count`),
     eligible_count: safeNonNegative(row.eligible_count, `${dataset} eligible_count`),

--- a/src/repair/gitcrawl-evidence-cloud.ts
+++ b/src/repair/gitcrawl-evidence-cloud.ts
@@ -111,7 +111,7 @@ export class CloudGitcrawlQuerySource implements GitcrawlQuerySource {
       try {
         response = await this.fetchImpl(queryUrl, {
           method: "POST",
-          redirect: "error",
+          redirect: "manual",
           headers: this.requestHeaders(),
           body: JSON.stringify({
             contract_version: GITCRAWL_QUERY_CONTRACT_VERSION,
@@ -138,6 +138,10 @@ export class CloudGitcrawlQuerySource implements GitcrawlQuerySource {
       } catch (error) {
         await response.body?.cancel().catch(() => undefined);
         throw error;
+      }
+      if (response.status >= 300 && response.status <= 399) {
+        await response.body?.cancel().catch(() => undefined);
+        throw new Error(`Gitcrawl cloud query ${request.name} refused a redirected response`);
       }
       if (response.ok) {
         try {

--- a/src/repair/gitcrawl-evidence-cloud.ts
+++ b/src/repair/gitcrawl-evidence-cloud.ts
@@ -1,0 +1,497 @@
+import {
+  GITCRAWL_QUERY_CONTRACT_VERSION,
+  type GitcrawlQueryEnvelope,
+  type GitcrawlQueryRequest,
+  type GitcrawlQuerySource,
+  assertGitcrawlProviderCursor,
+  assertSha256,
+  canonicalJson,
+  parseRfc3339Timestamp,
+} from "./gitcrawl-evidence-contract.js";
+
+const MAX_CLOUD_RESPONSE_BYTES = 512 * 1024;
+const DEFAULT_CLOUD_MAX_ATTEMPTS = 4;
+const DEFAULT_CLOUD_RETRY_BASE_DELAY_MS = 250;
+const DEFAULT_CLOUD_RETRY_MAX_DELAY_MS = 2_000;
+
+export type CloudGitcrawlQuerySourceOptions = {
+  baseUrl: string;
+  archive: string;
+  repository: string;
+  token?: string;
+  accessClientId?: string;
+  accessClientSecret?: string;
+  fetch?: typeof fetch;
+  timeoutMs?: number;
+  maxAttempts?: number;
+  retryBaseDelayMs?: number;
+  retryMaxDelayMs?: number;
+  sleep?: (delayMs: number) => Promise<void>;
+};
+
+export class CloudGitcrawlQuerySource implements GitcrawlQuerySource {
+  readonly provider = "cloud";
+  readonly legacy = false;
+
+  private readonly baseUrl: string;
+  private readonly archive: string;
+  private readonly repository: string;
+  private readonly token: string;
+  private readonly accessClientId: string;
+  private readonly accessClientSecret: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly timeoutMs: number;
+  private readonly maxAttempts: number;
+  private readonly retryBaseDelayMs: number;
+  private readonly retryMaxDelayMs: number;
+  private readonly sleepImpl: (delayMs: number) => Promise<void>;
+
+  constructor(options: CloudGitcrawlQuerySourceOptions) {
+    const baseUrl = parseCloudUrl(options.baseUrl);
+    this.baseUrl = baseUrl.toString().replace(/\/+$/, "");
+    this.archive = options.archive.trim();
+    this.repository = options.repository.trim();
+    this.token = options.token?.trim() ?? "";
+    this.accessClientId = options.accessClientId?.trim() ?? "";
+    this.accessClientSecret = options.accessClientSecret?.trim() ?? "";
+    this.fetchImpl = options.fetch ?? fetch;
+    this.timeoutMs = positiveInteger(options.timeoutMs ?? 20_000, "timeout");
+    this.maxAttempts = positiveInteger(
+      options.maxAttempts ?? DEFAULT_CLOUD_MAX_ATTEMPTS,
+      "max attempts",
+    );
+    this.retryBaseDelayMs = nonNegativeInteger(
+      options.retryBaseDelayMs ?? DEFAULT_CLOUD_RETRY_BASE_DELAY_MS,
+      "retry base delay",
+    );
+    this.retryMaxDelayMs = nonNegativeInteger(
+      options.retryMaxDelayMs ?? DEFAULT_CLOUD_RETRY_MAX_DELAY_MS,
+      "retry max delay",
+    );
+    this.sleepImpl = options.sleep ?? sleep;
+    if (!this.archive) throw new Error("Gitcrawl cloud archive is required");
+    if (!/^[^/]+\/[^/]+$/.test(this.repository)) {
+      throw new Error("Gitcrawl cloud repository is required");
+    }
+    if (this.retryMaxDelayMs < this.retryBaseDelayMs) {
+      throw new Error("Gitcrawl cloud retry max delay must be at least the base delay");
+    }
+    if (Boolean(this.accessClientId) !== Boolean(this.accessClientSecret)) {
+      throw new Error(
+        "Gitcrawl cloud Access authentication requires both client id and client secret",
+      );
+    }
+    if (!this.token && !this.accessClientId) {
+      throw new Error(
+        "Gitcrawl cloud authentication requires a bearer token or Cloudflare Access service token",
+      );
+    }
+  }
+
+  async query(request: GitcrawlQueryRequest): Promise<GitcrawlQueryEnvelope> {
+    const queryUrl = `${this.baseUrl}/v1/apps/gitcrawl/archives/${encodeURIComponent(this.archive)}/query`;
+    const text = await this.fetchTextWithRetry(queryUrl, request);
+    let body: unknown;
+    try {
+      body = JSON.parse(text);
+    } catch {
+      throw new Error(`Gitcrawl cloud query ${request.name} returned malformed JSON`);
+    }
+    return parseCloudEnvelope(body, request.name, this.repository, this.archive);
+  }
+
+  async close(): Promise<void> {}
+
+  private async fetchTextWithRetry(
+    queryUrl: string,
+    request: GitcrawlQueryRequest,
+  ): Promise<string> {
+    for (let attempt = 1; attempt <= this.maxAttempts; attempt += 1) {
+      let response: Response;
+      try {
+        response = await this.fetchImpl(queryUrl, {
+          method: "POST",
+          redirect: "error",
+          headers: this.requestHeaders(),
+          body: JSON.stringify({
+            contract_version: GITCRAWL_QUERY_CONTRACT_VERSION,
+            repository: this.repository,
+            archive: this.archive,
+            name: request.name,
+            args: request.args,
+            limit: request.limit,
+            ...(request.cursor ? { cursor: request.cursor } : {}),
+            ...(request.snapshot_id ? { snapshot_id: request.snapshot_id } : {}),
+          }),
+          signal: AbortSignal.timeout(this.timeoutMs),
+        });
+      } catch (error) {
+        if (!isTransientFetchError(error) || attempt === this.maxAttempts) {
+          throw cloudNetworkError(request.name, attempt);
+        }
+        await this.sleepImpl(this.retryDelayMs(attempt));
+        continue;
+      }
+
+      try {
+        assertResponseOrigin(response, queryUrl, request.name);
+      } catch (error) {
+        await response.body?.cancel().catch(() => undefined);
+        throw error;
+      }
+      if (response.ok) {
+        try {
+          return await readBoundedResponse(response, request.name);
+        } catch (error) {
+          await response.body?.cancel().catch(() => undefined);
+          if (!isTransientFetchError(error) || attempt === this.maxAttempts) {
+            if (isTransientFetchError(error)) {
+              throw cloudNetworkError(request.name, attempt);
+            }
+            throw error;
+          }
+          await this.sleepImpl(this.retryDelayMs(attempt));
+          continue;
+        }
+      }
+
+      const retryable = isRetryableStatus(response.status);
+      const delayMs = retryable ? this.retryDelayMs(attempt, response) : 0;
+      await response.body?.cancel().catch(() => undefined);
+      if (retryable && attempt < this.maxAttempts) {
+        await this.sleepImpl(delayMs);
+        continue;
+      }
+      throw new Error(
+        `Gitcrawl cloud query ${request.name} failed (${response.status}; code=${cloudHttpErrorCode(response.status)})`,
+      );
+    }
+    throw cloudNetworkError(request.name, this.maxAttempts);
+  }
+
+  private requestHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      accept: "application/json",
+      "content-type": "application/json",
+    };
+    if (this.token) headers.authorization = `Bearer ${this.token}`;
+    if (this.accessClientId) {
+      headers["CF-Access-Client-Id"] = this.accessClientId;
+      headers["CF-Access-Client-Secret"] = this.accessClientSecret;
+    }
+    return headers;
+  }
+
+  private retryDelayMs(attempt: number, response?: Response): number {
+    const retryAfter = response === undefined ? undefined : parseRetryAfter(response);
+    if (retryAfter !== undefined) return Math.min(retryAfter, this.retryMaxDelayMs);
+    return Math.min(this.retryBaseDelayMs * 2 ** Math.max(0, attempt - 1), this.retryMaxDelayMs);
+  }
+}
+
+function assertResponseOrigin(response: Response, queryUrl: string, queryName: string): void {
+  if (response.redirected) {
+    throw new Error(`Gitcrawl cloud query ${queryName} refused a redirected response`);
+  }
+  if (!response.url) return;
+  const expected = new URL(queryUrl);
+  const actual = new URL(response.url);
+  if (actual.protocol !== "https:" || actual.origin !== expected.origin) {
+    throw new Error(`Gitcrawl cloud query ${queryName} returned from an unexpected origin`);
+  }
+}
+
+function parseCloudEnvelope(
+  value: unknown,
+  queryName: string,
+  expectedRepository: string,
+  expectedArchive: string,
+): GitcrawlQueryEnvelope {
+  const body = record(value, `Gitcrawl cloud ${queryName} response`);
+  if (!Array.isArray(body.values)) {
+    throw new Error(`Gitcrawl cloud ${queryName} response is missing values`);
+  }
+  const values = body.values.map((row, index) =>
+    record(row, `Gitcrawl cloud ${queryName} value ${index}`),
+  );
+  const columns = optionalStringArray(body.columns, "columns");
+  const rows = optionalRows(body.rows);
+  if (columns === undefined || rows === undefined) {
+    throw new Error(`Gitcrawl cloud ${queryName} response is missing columns or rows`);
+  }
+  if (columns.length !== new Set(columns).size) {
+    throw new Error(`Gitcrawl cloud ${queryName} response has duplicate columns`);
+  }
+  if (rows.length !== values.length) {
+    throw new Error(`Gitcrawl cloud ${queryName} rows/values length mismatch`);
+  }
+  for (const [index, row] of rows.entries()) {
+    if (row.length !== columns.length) {
+      throw new Error(`Gitcrawl cloud ${queryName} row ${index} column count mismatch`);
+    }
+    const projected = Object.fromEntries(
+      columns.map((column, columnIndex) => [column, row[columnIndex]]),
+    );
+    if (canonicalJson(projected) !== canonicalJson(values[index])) {
+      throw new Error(`Gitcrawl cloud ${queryName} rows/values parity mismatch at row ${index}`);
+    }
+  }
+  const rawStats = record(body.stats, `Gitcrawl cloud ${queryName} stats`);
+  const contractVersion = requiredString(rawStats.contract_version, "contract_version");
+  if (contractVersion !== GITCRAWL_QUERY_CONTRACT_VERSION) {
+    throw new Error(
+      `Gitcrawl cloud query ${queryName} requires safety contract ${GITCRAWL_QUERY_CONTRACT_VERSION}`,
+    );
+  }
+  const repository = requiredString(rawStats.repository, "repository");
+  const archive = requiredString(rawStats.archive, "archive");
+  if (repository !== expectedRepository || archive !== expectedArchive) {
+    throw new Error(`Gitcrawl cloud query ${queryName} returned mismatched source identity`);
+  }
+  const nextCursor = requiredString(rawStats.next_cursor, "next_cursor", true);
+  assertGitcrawlProviderCursor(nextCursor, `Gitcrawl cloud ${queryName} stats next_cursor`);
+  const snapshot = parseSnapshotProvenance(body.snapshot, queryName, rawStats);
+  const stats: GitcrawlQueryEnvelope["stats"] = {
+    contract_version: GITCRAWL_QUERY_CONTRACT_VERSION,
+    repository,
+    archive,
+    snapshot_id: requiredString(rawStats.snapshot_id, "snapshot_id"),
+    source_sync_at: requiredString(rawStats.source_sync_at, "source_sync_at"),
+    dataset_generated_at: requiredString(rawStats.dataset_generated_at, "dataset_generated_at"),
+    coverage_complete: requiredBoolean(rawStats.coverage_complete, "coverage_complete"),
+    next_cursor: nextCursor,
+  };
+  return { columns, rows, values, snapshot, stats };
+}
+
+function parseSnapshotProvenance(
+  value: unknown,
+  queryName: string,
+  stats: Record<string, unknown>,
+): GitcrawlQueryEnvelope["snapshot"] {
+  const snapshot = record(value, `Gitcrawl cloud ${queryName} snapshot`);
+  const id = requiredSnapshotString(snapshot.id, "id");
+  const sourceSha256 = requiredSnapshotString(snapshot.source_sha256, "source_sha256");
+  assertSha256(id, "Gitcrawl cloud snapshot id");
+  assertSha256(sourceSha256, "Gitcrawl cloud snapshot source sha256");
+  if (id !== sourceSha256 || id !== stats.snapshot_id) {
+    throw new Error(`Gitcrawl cloud query ${queryName} returned mismatched snapshot provenance`);
+  }
+  const schemaName = requiredSnapshotString(snapshot.schema_name, "schema_name");
+  const schemaVersion = snapshot.schema_version;
+  if (!Number.isSafeInteger(schemaVersion) || Number(schemaVersion) <= 0) {
+    throw new Error("Gitcrawl cloud snapshot schema_version must be a positive integer");
+  }
+  const schemaHash = requiredSnapshotString(snapshot.schema_hash, "schema_hash");
+  const capabilities = requiredSnapshotStringArray(snapshot.capabilities, "capabilities");
+  if (!capabilities.includes(queryName)) {
+    throw new Error(`Gitcrawl cloud snapshot does not declare ${queryName} capability`);
+  }
+  const sourceSyncAt = requiredSnapshotString(snapshot.source_sync_at, "source_sync_at");
+  const datasetGeneratedAt = requiredSnapshotString(
+    snapshot.dataset_generated_at,
+    "dataset_generated_at",
+  );
+  const publishedAt = requiredSnapshotString(snapshot.published_at, "published_at");
+  const cutoverAt = requiredSnapshotString(snapshot.cutover_at, "cutover_at");
+  for (const [timestamp, label] of [
+    [sourceSyncAt, "source_sync_at"],
+    [datasetGeneratedAt, "dataset_generated_at"],
+    [publishedAt, "published_at"],
+    [cutoverAt, "cutover_at"],
+  ] as const) {
+    parseRfc3339Timestamp(timestamp, `Gitcrawl cloud snapshot ${label}`);
+  }
+  const coverageComplete = requiredBoolean(
+    snapshot.coverage_complete,
+    "snapshot coverage_complete",
+  );
+  if (
+    sourceSyncAt !== stats.source_sync_at ||
+    datasetGeneratedAt !== stats.dataset_generated_at ||
+    coverageComplete !== stats.coverage_complete
+  ) {
+    throw new Error(`Gitcrawl cloud query ${queryName} returned mismatched snapshot metadata`);
+  }
+  return {
+    id,
+    source_sha256: sourceSha256,
+    schema_name: schemaName,
+    schema_version: Number(schemaVersion),
+    schema_hash: schemaHash,
+    capabilities,
+    source_sync_at: sourceSyncAt,
+    dataset_generated_at: datasetGeneratedAt,
+    coverage_complete: coverageComplete,
+    published_at: publishedAt,
+    cutover_at: cutoverAt,
+  };
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function optionalStringArray(value: unknown, label: string): string[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
+    throw new Error(`Gitcrawl cloud ${label} must be a string array`);
+  }
+  return value;
+}
+
+function optionalRows(value: unknown): unknown[][] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || value.some((entry) => !Array.isArray(entry))) {
+    throw new Error("Gitcrawl cloud rows must be arrays");
+  }
+  return value as unknown[][];
+}
+
+function parseCloudUrl(value: string): URL {
+  let url: URL;
+  try {
+    url = new URL(value.trim());
+  } catch {
+    throw new Error("Gitcrawl cloud URL must be a valid HTTPS URL");
+  }
+  if (url.protocol !== "https:") {
+    throw new Error("Gitcrawl cloud URL must use HTTPS");
+  }
+  if (url.username || url.password) {
+    throw new Error("Gitcrawl cloud URL must not contain credentials");
+  }
+  if (url.search || url.hash) {
+    throw new Error("Gitcrawl cloud URL must not contain a query or fragment");
+  }
+  return url;
+}
+
+async function readBoundedResponse(response: Response, queryName: string): Promise<string> {
+  const declaredLength = Number(response.headers.get("content-length") ?? 0);
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_CLOUD_RESPONSE_BYTES) {
+    await response.body?.cancel().catch(() => undefined);
+    throw responseTooLarge(queryName);
+  }
+  if (!response.body) return "";
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      total += value.byteLength;
+      if (total > MAX_CLOUD_RESPONSE_BYTES) {
+        await reader.cancel().catch(() => undefined);
+        throw responseTooLarge(queryName);
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return Buffer.concat(chunks.map((chunk) => Buffer.from(chunk))).toString("utf8");
+}
+
+function responseTooLarge(queryName: string): Error {
+  return new Error(`Gitcrawl cloud query ${queryName} exceeded ${MAX_CLOUD_RESPONSE_BYTES} bytes`);
+}
+
+function cloudHttpErrorCode(status: number): string {
+  if (status === 401) return "unauthorized";
+  if (status === 403) return "forbidden";
+  if (status === 404) return "not_found";
+  if (status === 408) return "request_timeout";
+  if (status === 409) return "conflict";
+  if (status === 429) return "rate_limited";
+  if (status >= 500) return "server_error";
+  if (status >= 400) return "client_error";
+  return "unexpected_status";
+}
+
+function isRetryableStatus(status: number): boolean {
+  return status === 408 || status === 429 || (status >= 500 && status <= 599);
+}
+
+function isTransientFetchError(error: unknown): boolean {
+  if (error instanceof TypeError) return true;
+  if (!(error instanceof Error)) return false;
+  return error.name === "AbortError" || error.name === "TimeoutError";
+}
+
+function cloudNetworkError(queryName: string, attempts: number): Error {
+  return new Error(
+    `Gitcrawl cloud query ${queryName} failed (network; code=transient_network; attempts=${attempts})`,
+  );
+}
+
+function parseRetryAfter(response: Response): number | undefined {
+  const value = response.headers.get("retry-after")?.trim();
+  if (!value) return undefined;
+  if (/^[0-9]+$/.test(value)) return Number(value) * 1_000;
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) return undefined;
+  return Math.max(0, timestamp - Date.now());
+}
+
+function sleep(delayMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+function positiveInteger(value: number, label: string): number {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`Gitcrawl cloud ${label} must be a positive integer`);
+  }
+  return value;
+}
+
+function nonNegativeInteger(value: number, label: string): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`Gitcrawl cloud ${label} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function requiredString(value: unknown, field: string, allowEmpty = false): string {
+  if (typeof value !== "string" || (!allowEmpty && !value.trim())) {
+    throw new Error(
+      `Gitcrawl cloud stats ${field} must be a${allowEmpty ? "" : " non-empty"} string`,
+    );
+  }
+  return value;
+}
+
+function requiredBoolean(value: unknown, field: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new Error(`Gitcrawl cloud stats ${field} must be a boolean`);
+  }
+  return value;
+}
+
+function requiredSnapshotString(value: unknown, field: string): string {
+  if (typeof value !== "string" || !value.trim() || value !== value.trim()) {
+    throw new Error(`Gitcrawl cloud snapshot ${field} must be a non-empty trimmed string`);
+  }
+  return value;
+}
+
+function requiredSnapshotStringArray(value: unknown, field: string): string[] {
+  if (
+    !Array.isArray(value) ||
+    value.length === 0 ||
+    value.some((entry) => typeof entry !== "string" || !entry.trim() || entry !== entry.trim())
+  ) {
+    throw new Error(`Gitcrawl cloud snapshot ${field} must be non-empty trimmed strings`);
+  }
+  const strings = value as string[];
+  if (new Set(strings).size !== strings.length) {
+    throw new Error(`Gitcrawl cloud snapshot ${field} must not contain duplicates`);
+  }
+  return strings;
+}

--- a/src/repair/gitcrawl-evidence-cloud.ts
+++ b/src/repair/gitcrawl-evidence-cloud.ts
@@ -159,6 +159,11 @@ export class CloudGitcrawlQuerySource implements GitcrawlQuerySource {
       const delayMs = retryable ? this.retryDelayMs(attempt, response) : 0;
       await response.body?.cancel().catch(() => undefined);
       if (retryable && attempt < this.maxAttempts) {
+        if (delayMs > this.retryMaxDelayMs) {
+          throw new Error(
+            `Gitcrawl cloud query ${request.name} refused Retry-After beyond the configured wait budget`,
+          );
+        }
         await this.sleepImpl(delayMs);
         continue;
       }
@@ -184,7 +189,7 @@ export class CloudGitcrawlQuerySource implements GitcrawlQuerySource {
 
   private retryDelayMs(attempt: number, response?: Response): number {
     const retryAfter = response === undefined ? undefined : parseRetryAfter(response);
-    if (retryAfter !== undefined) return Math.min(retryAfter, this.retryMaxDelayMs);
+    if (retryAfter !== undefined) return retryAfter;
     return Math.min(this.retryBaseDelayMs * 2 ** Math.max(0, attempt - 1), this.retryMaxDelayMs);
   }
 }

--- a/src/repair/gitcrawl-evidence-cloud.ts
+++ b/src/repair/gitcrawl-evidence-cloud.ts
@@ -106,6 +106,21 @@ export class CloudGitcrawlQuerySource implements GitcrawlQuerySource {
     queryUrl: string,
     request: GitcrawlQueryRequest,
   ): Promise<string> {
+    let requestBody: string;
+    try {
+      requestBody = JSON.stringify({
+        contract_version: GITCRAWL_QUERY_CONTRACT_VERSION,
+        repository: this.repository,
+        archive: this.archive,
+        name: request.name,
+        args: request.args,
+        limit: request.limit,
+        ...(request.cursor ? { cursor: request.cursor } : {}),
+        ...(request.snapshot_id ? { snapshot_id: request.snapshot_id } : {}),
+      });
+    } catch {
+      throw new Error(`Gitcrawl cloud query ${request.name} request is not JSON serializable`);
+    }
     for (let attempt = 1; attempt <= this.maxAttempts; attempt += 1) {
       let response: Response;
       try {
@@ -113,16 +128,7 @@ export class CloudGitcrawlQuerySource implements GitcrawlQuerySource {
           method: "POST",
           redirect: "manual",
           headers: this.requestHeaders(),
-          body: JSON.stringify({
-            contract_version: GITCRAWL_QUERY_CONTRACT_VERSION,
-            repository: this.repository,
-            archive: this.archive,
-            name: request.name,
-            args: request.args,
-            limit: request.limit,
-            ...(request.cursor ? { cursor: request.cursor } : {}),
-            ...(request.snapshot_id ? { snapshot_id: request.snapshot_id } : {}),
-          }),
+          body: requestBody,
           signal: AbortSignal.timeout(this.timeoutMs),
         });
       } catch (error) {
@@ -143,7 +149,7 @@ export class CloudGitcrawlQuerySource implements GitcrawlQuerySource {
         await response.body?.cancel().catch(() => undefined);
         throw new Error(`Gitcrawl cloud query ${request.name} refused a redirected response`);
       }
-      if (response.ok) {
+      if (response.status === 200) {
         try {
           return await readBoundedResponse(response, request.name);
         } catch (error) {
@@ -202,7 +208,9 @@ function assertResponseOrigin(response: Response, queryUrl: string, queryName: s
   if (response.redirected) {
     throw new Error(`Gitcrawl cloud query ${queryName} refused a redirected response`);
   }
-  if (!response.url) return;
+  if (!response.url) {
+    throw new Error(`Gitcrawl cloud query ${queryName} response is missing origin metadata`);
+  }
   const expected = new URL(queryUrl);
   const actual = new URL(response.url);
   if (actual.protocol !== "https:" || actual.origin !== expected.origin) {
@@ -405,7 +413,12 @@ async function readBoundedResponse(response: Response, queryName: string): Promi
   } finally {
     reader.releaseLock();
   }
-  return Buffer.concat(chunks.map((chunk) => Buffer.from(chunk))).toString("utf8");
+  const bytes = Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)));
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    throw new Error(`Gitcrawl cloud query ${queryName} returned malformed UTF-8`);
+  }
 }
 
 function responseTooLarge(queryName: string): Error {
@@ -444,6 +457,13 @@ function parseRetryAfter(response: Response): number | undefined {
   const value = response.headers.get("retry-after")?.trim();
   if (!value) return undefined;
   if (/^[0-9]+$/.test(value)) return Number(value) * 1_000;
+  if (
+    !/^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{2} (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} GMT$/.test(
+      value,
+    )
+  ) {
+    return undefined;
+  }
   const timestamp = Date.parse(value);
   if (!Number.isFinite(timestamp)) return undefined;
   return Math.max(0, timestamp - Date.now());

--- a/src/repair/gitcrawl-evidence-contract.ts
+++ b/src/repair/gitcrawl-evidence-contract.ts
@@ -17,6 +17,13 @@ export const GITCRAWL_QUERY_NAMES = [
   "gitcrawl.threads.search",
 ] as const;
 
+const GITCRAWL_EVIDENCE_RELATION_PREDICATES = [
+  "member_of",
+  "related_to",
+  "evidence_for",
+  "describes",
+] as const;
+
 export const GITCRAWL_DATASETS = [
   "repositories",
   "threads",
@@ -167,7 +174,14 @@ export function createGitcrawlEvidenceClaim<T>(input: {
   }
   assertGitcrawlRepository(input.repository);
   assertSnapshotId(input.snapshotId);
-  if (input.paritySnapshotId !== undefined) assertSnapshotId(input.paritySnapshotId);
+  if (input.provider === "parity") {
+    if (input.paritySnapshotId === undefined) {
+      throw new Error("Gitcrawl parity claim is missing its local snapshot");
+    }
+    assertSnapshotId(input.paritySnapshotId);
+  } else if (input.paritySnapshotId !== undefined) {
+    throw new Error("Gitcrawl non-parity claim has a parity snapshot");
+  }
   assertNoGitcrawlHtmlCommentMarkers(input.subject, "Gitcrawl claim subject");
   assertNoGitcrawlHtmlCommentMarkers(input.relations ?? [], "Gitcrawl claim relations");
   assertNoGitcrawlHtmlCommentMarkers(input.data, "Gitcrawl claim data");
@@ -194,6 +208,23 @@ export function createGitcrawlEvidenceClaim<T>(input: {
       throw new Error("thread fingerprint algorithm is required");
     }
     assertSha256(input.threadFingerprint.sha256, "thread fingerprint sha256");
+  }
+  for (const relation of input.relations ?? []) {
+    if (!GITCRAWL_EVIDENCE_RELATION_PREDICATES.includes(relation.predicate)) {
+      throw new Error(`unsupported Gitcrawl evidence relation: ${relation.predicate}`);
+    }
+    if (
+      typeof relation.target !== "string" ||
+      !relation.target ||
+      relation.target !== relation.target.trim() ||
+      Buffer.byteLength(relation.target, "utf8") > 2_048 ||
+      [...relation.target].some((character) => {
+        const code = character.codePointAt(0) ?? 0;
+        return code < 32 || code === 127;
+      })
+    ) {
+      throw new Error("Gitcrawl evidence relation target is missing or malformed");
+    }
   }
   const relations = [...(input.relations ?? [])]
     .map((relation) => ({ ...relation }))

--- a/src/repair/gitcrawl-evidence-contract.ts
+++ b/src/repair/gitcrawl-evidence-contract.ts
@@ -182,6 +182,11 @@ export function createGitcrawlEvidenceClaim<T>(input: {
   } else if (input.paritySnapshotId !== undefined) {
     throw new Error("Gitcrawl non-parity claim has a parity snapshot");
   }
+  assertCanonicalGitcrawlEvidenceIdentity(
+    input.repository,
+    input.subject,
+    "Gitcrawl claim subject",
+  );
   assertNoGitcrawlHtmlCommentMarkers(input.subject, "Gitcrawl claim subject");
   assertNoGitcrawlHtmlCommentMarkers(input.relations ?? [], "Gitcrawl claim relations");
   assertNoGitcrawlHtmlCommentMarkers(input.data, "Gitcrawl claim data");
@@ -200,8 +205,8 @@ export function createGitcrawlEvidenceClaim<T>(input: {
     version: GITCRAWL_QUERY_VERSION,
     args_sha256: queryArgsSha256!,
   };
-  if (input.sourceRevision?.sha256 !== undefined) {
-    assertSha256(input.sourceRevision.sha256, "source revision sha256");
+  if (input.sourceRevision !== undefined) {
+    assertSourceRevision(input.sourceRevision);
   }
   if (input.threadFingerprint !== undefined) {
     if (!input.threadFingerprint.algorithm.trim()) {
@@ -213,18 +218,11 @@ export function createGitcrawlEvidenceClaim<T>(input: {
     if (!GITCRAWL_EVIDENCE_RELATION_PREDICATES.includes(relation.predicate)) {
       throw new Error(`unsupported Gitcrawl evidence relation: ${relation.predicate}`);
     }
-    if (
-      typeof relation.target !== "string" ||
-      !relation.target ||
-      relation.target !== relation.target.trim() ||
-      Buffer.byteLength(relation.target, "utf8") > 2_048 ||
-      [...relation.target].some((character) => {
-        const code = character.codePointAt(0) ?? 0;
-        return code < 32 || code === 127;
-      })
-    ) {
-      throw new Error("Gitcrawl evidence relation target is missing or malformed");
-    }
+    assertCanonicalGitcrawlEvidenceIdentity(
+      input.repository,
+      relation.target,
+      "Gitcrawl evidence relation target",
+    );
   }
   const relations = [...(input.relations ?? [])]
     .map((relation) => ({ ...relation }))
@@ -260,6 +258,53 @@ export function createGitcrawlEvidenceClaim<T>(input: {
     ...unsigned,
     sha256: sha256Canonical(unsigned),
   };
+}
+
+function assertSourceRevision(sourceRevision: GitcrawlSourceRevision): void {
+  assertExactObjectKeys(sourceRevision, ["id", "sha256", "updated_at"], "Gitcrawl source revision");
+  if (
+    sourceRevision.id === undefined &&
+    sourceRevision.sha256 === undefined &&
+    sourceRevision.updated_at === undefined
+  ) {
+    throw new Error("Gitcrawl source revision is empty");
+  }
+  if (
+    sourceRevision.id !== undefined &&
+    (!Number.isSafeInteger(sourceRevision.id) || sourceRevision.id <= 0)
+  ) {
+    throw new Error("Gitcrawl source revision id must be a positive safe integer");
+  }
+  if (sourceRevision.sha256 !== undefined) {
+    assertSha256(sourceRevision.sha256, "source revision sha256");
+  }
+  if (sourceRevision.updated_at !== undefined) {
+    parseRfc3339Timestamp(sourceRevision.updated_at, "Gitcrawl source revision updated_at");
+  }
+}
+
+function assertCanonicalGitcrawlEvidenceIdentity(
+  repository: string,
+  value: string,
+  label: string,
+): void {
+  if (
+    typeof value !== "string" ||
+    value !== value.trim() ||
+    Buffer.byteLength(value, "utf8") > 2_048 ||
+    !value.startsWith(`${repository}#`)
+  ) {
+    throw new Error(`${label} is missing or malformed`);
+  }
+  const suffix = value.slice(repository.length + 1);
+  const datasetPattern = GITCRAWL_DATASETS.join("|");
+  const canonical =
+    /^(?:cluster|thread|pull|issue):[1-9]\d*$/.test(suffix) ||
+    /^(?:pull|issue):[1-9]\d*@file:(?:0|[1-9]\d*)$/.test(suffix) ||
+    new RegExp(`^dataset:(?:${datasetPattern})$`).test(suffix);
+  if (!canonical) {
+    throw new Error(`${label} is missing or malformed`);
+  }
 }
 
 export function verifyGitcrawlEvidenceClaim(claim: GitcrawlEvidenceClaim): void {

--- a/src/repair/gitcrawl-evidence-contract.ts
+++ b/src/repair/gitcrawl-evidence-contract.ts
@@ -1,0 +1,399 @@
+import crypto from "node:crypto";
+
+export const GITCRAWL_QUERY_VERSION = "gitcrawl-evidence-v1";
+export const GITCRAWL_QUERY_CONTRACT_VERSION = "gitcrawl-query-safety-v3";
+export const GITCRAWL_CLAIM_VERSION = "gitcrawl-evidence-claim-v1";
+export const GITCRAWL_PACKET_VERSION_V1 = "gitcrawl-evidence-packet-v1";
+export const GITCRAWL_PACKET_VERSION = "gitcrawl-evidence-packet-v2";
+export const GITCRAWL_PROVIDER_CURSOR_MAX_LENGTH = 8 * 1024;
+export const GITCRAWL_CANONICAL_JSON_MAX_DEPTH = 64;
+
+export const GITCRAWL_QUERY_NAMES = [
+  "gitcrawl.clusters.list",
+  "gitcrawl.clusters.members",
+  "gitcrawl.clusters.related",
+  "gitcrawl.pull_requests.review_context",
+  "gitcrawl.coverage",
+  "gitcrawl.threads.search",
+] as const;
+
+export const GITCRAWL_DATASETS = [
+  "repositories",
+  "threads",
+  "thread_revisions",
+  "thread_fingerprints",
+  "thread_key_summaries",
+  "cluster_groups",
+  "cluster_memberships",
+  "pull_request_details",
+  "pull_request_files",
+] as const;
+
+export type GitcrawlDataset = (typeof GITCRAWL_DATASETS)[number];
+
+export type GitcrawlQueryName = (typeof GITCRAWL_QUERY_NAMES)[number];
+
+export type GitcrawlProvider = "local" | "cloud" | "parity";
+
+export const GITCRAWL_QUERY_COVERAGE: Record<GitcrawlQueryName, readonly GitcrawlDataset[]> = {
+  "gitcrawl.coverage": ["repositories", "threads"],
+  "gitcrawl.clusters.list": ["repositories", "threads", "cluster_groups", "cluster_memberships"],
+  "gitcrawl.clusters.members": ["repositories", "threads", "cluster_groups", "cluster_memberships"],
+  "gitcrawl.clusters.related": ["repositories", "threads", "cluster_groups", "cluster_memberships"],
+  "gitcrawl.pull_requests.review_context": [
+    "repositories",
+    "threads",
+    "pull_request_details",
+    "pull_request_files",
+  ],
+  "gitcrawl.threads.search": ["repositories", "threads"],
+};
+
+export type GitcrawlQueryStats = {
+  contract_version: typeof GITCRAWL_QUERY_CONTRACT_VERSION;
+  repository: string;
+  archive: string;
+  snapshot_id: string;
+  source_sync_at: string;
+  dataset_generated_at: string;
+  coverage_complete: boolean;
+  next_cursor: string;
+};
+
+export type GitcrawlSnapshotProvenance = {
+  id: string;
+  source_sha256: string;
+  schema_name: string;
+  schema_version: number;
+  schema_hash: string;
+  capabilities: string[];
+  source_sync_at: string;
+  dataset_generated_at: string;
+  coverage_complete: boolean;
+  published_at: string;
+  cutover_at: string;
+};
+
+export type GitcrawlQueryEnvelope = {
+  columns?: string[];
+  rows?: unknown[][];
+  values: Record<string, unknown>[];
+  snapshot: GitcrawlSnapshotProvenance;
+  stats: GitcrawlQueryStats;
+};
+
+export type GitcrawlQueryRequest = {
+  name: GitcrawlQueryName;
+  args: Record<string, unknown>;
+  limit: number;
+  cursor: string;
+  snapshot_id: string;
+};
+
+export interface GitcrawlQuerySource {
+  readonly provider: "local" | "cloud";
+  readonly legacy: boolean;
+  query(request: GitcrawlQueryRequest): Promise<GitcrawlQueryEnvelope>;
+  close(): Promise<void>;
+}
+
+export type GitcrawlCoverageRow = {
+  dataset: GitcrawlDataset;
+  row_count: number;
+  eligible_count: number;
+  covered_count: number;
+  max_source_at: string;
+  dataset_generated_at: string;
+  complete: boolean;
+};
+
+export type GitcrawlSourceRevision = {
+  id?: number;
+  sha256?: string;
+  updated_at?: string;
+};
+
+export type GitcrawlThreadFingerprint = {
+  algorithm: string;
+  sha256: string;
+};
+
+export type GitcrawlEvidenceRelation = {
+  predicate: "member_of" | "related_to" | "evidence_for" | "describes";
+  target: string;
+};
+
+export type GitcrawlEvidenceClaim<T = Record<string, unknown>> = {
+  version: typeof GITCRAWL_CLAIM_VERSION;
+  provider: GitcrawlProvider;
+  snapshot_id: string;
+  parity_snapshot_id?: string;
+  query: {
+    name: GitcrawlQueryName;
+    version: typeof GITCRAWL_QUERY_VERSION;
+    args_sha256?: string;
+  };
+  subject: string;
+  source_revision?: GitcrawlSourceRevision;
+  thread_fingerprint?: GitcrawlThreadFingerprint;
+  relations: GitcrawlEvidenceRelation[];
+  data: T;
+  semantic_sha256: string;
+  sha256: string;
+};
+
+export type GitcrawlEvidenceResult<T> = {
+  rows: T[];
+  claims: GitcrawlEvidenceClaim<T>[];
+};
+
+export function createGitcrawlEvidenceClaim<T>(input: {
+  provider: GitcrawlProvider;
+  snapshotId: string;
+  paritySnapshotId?: string;
+  queryName: GitcrawlQueryName;
+  queryArgs?: Record<string, unknown>;
+  queryArgsSha256?: string;
+  subject: string;
+  sourceRevision?: GitcrawlSourceRevision;
+  threadFingerprint?: GitcrawlThreadFingerprint;
+  relations?: GitcrawlEvidenceRelation[];
+  data: T;
+}): GitcrawlEvidenceClaim<T> {
+  assertSnapshotId(input.snapshotId);
+  if (input.paritySnapshotId !== undefined) assertSnapshotId(input.paritySnapshotId);
+  assertNoGitcrawlHtmlCommentMarkers(input.subject, "Gitcrawl claim subject");
+  assertNoGitcrawlHtmlCommentMarkers(input.relations ?? [], "Gitcrawl claim relations");
+  assertNoGitcrawlHtmlCommentMarkers(input.data, "Gitcrawl claim data");
+  if (!GITCRAWL_QUERY_NAMES.includes(input.queryName)) {
+    throw new Error(`unsupported Gitcrawl query: ${input.queryName}`);
+  }
+  if (input.queryArgs !== undefined && input.queryArgsSha256 !== undefined) {
+    throw new Error("Gitcrawl claim query arguments must have one digest source");
+  }
+  assertNoGitcrawlHtmlCommentMarkers(input.queryArgs ?? {}, "Gitcrawl claim query arguments");
+  const queryArgsSha256 =
+    input.queryArgs === undefined ? input.queryArgsSha256 : sha256Canonical(input.queryArgs);
+  if (queryArgsSha256 !== undefined) {
+    assertSha256(queryArgsSha256, "claim query arguments sha256");
+  }
+  const query: GitcrawlEvidenceClaim["query"] = {
+    name: input.queryName,
+    version: GITCRAWL_QUERY_VERSION,
+    ...(queryArgsSha256 === undefined ? {} : { args_sha256: queryArgsSha256 }),
+  };
+  if (input.sourceRevision?.sha256 !== undefined) {
+    assertSha256(input.sourceRevision.sha256, "source revision sha256");
+  }
+  if (input.threadFingerprint !== undefined) {
+    if (!input.threadFingerprint.algorithm.trim()) {
+      throw new Error("thread fingerprint algorithm is required");
+    }
+    assertSha256(input.threadFingerprint.sha256, "thread fingerprint sha256");
+  }
+  const relations = [...(input.relations ?? [])]
+    .map((relation) => ({ ...relation }))
+    .sort((left, right) =>
+      compareCanonicalText(
+        `${left.predicate}:${left.target}`,
+        `${right.predicate}:${right.target}`,
+      ),
+    );
+  const semanticPayload = {
+    query,
+    subject: input.subject,
+    data: input.data,
+  };
+  const unsigned = {
+    version: GITCRAWL_CLAIM_VERSION,
+    provider: input.provider,
+    snapshot_id: input.snapshotId,
+    ...(input.paritySnapshotId === undefined ? {} : { parity_snapshot_id: input.paritySnapshotId }),
+    query,
+    subject: input.subject,
+    ...(input.sourceRevision === undefined ? {} : { source_revision: input.sourceRevision }),
+    ...(input.threadFingerprint === undefined
+      ? {}
+      : { thread_fingerprint: input.threadFingerprint }),
+    relations,
+    data: input.data,
+    semantic_sha256: sha256Canonical(semanticPayload),
+  } satisfies Omit<GitcrawlEvidenceClaim<T>, "sha256">;
+  return {
+    ...unsigned,
+    sha256: sha256Canonical(unsigned),
+  };
+}
+
+export function verifyGitcrawlEvidenceClaim(claim: GitcrawlEvidenceClaim): void {
+  assertSha256(claim.semantic_sha256, "claim semantic sha256");
+  assertSha256(claim.sha256, "claim sha256");
+  const expected = createGitcrawlEvidenceClaim({
+    provider: claim.provider,
+    snapshotId: claim.snapshot_id,
+    ...(claim.parity_snapshot_id === undefined
+      ? {}
+      : { paritySnapshotId: claim.parity_snapshot_id }),
+    queryName: claim.query.name,
+    ...(claim.query.args_sha256 === undefined ? {} : { queryArgsSha256: claim.query.args_sha256 }),
+    subject: claim.subject,
+    ...(claim.source_revision === undefined ? {} : { sourceRevision: claim.source_revision }),
+    ...(claim.thread_fingerprint === undefined
+      ? {}
+      : { threadFingerprint: claim.thread_fingerprint }),
+    relations: claim.relations,
+    data: claim.data,
+  });
+  if (claim.query.version !== GITCRAWL_QUERY_VERSION) {
+    throw new Error(`unsupported Gitcrawl query version: ${claim.query.version}`);
+  }
+  if (claim.version !== GITCRAWL_CLAIM_VERSION) {
+    throw new Error(`unsupported Gitcrawl claim version: ${claim.version}`);
+  }
+  if (claim.semantic_sha256 !== expected.semantic_sha256 || claim.sha256 !== expected.sha256) {
+    throw new Error(`Gitcrawl evidence claim digest mismatch for ${claim.subject}`);
+  }
+}
+
+export function sha256Canonical(value: unknown): string {
+  return crypto.createHash("sha256").update(canonicalJson(value)).digest("hex");
+}
+
+export function gitcrawlQueryDigest(
+  name: GitcrawlQueryName,
+  args: Record<string, unknown>,
+): string {
+  return sha256Canonical({ name, args });
+}
+
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalValue(value));
+}
+
+export function assertSha256(value: string, label: string): void {
+  if (!/^[a-f0-9]{64}$/.test(value)) {
+    throw new Error(`${label} must be a lowercase hexadecimal SHA-256 digest`);
+  }
+}
+
+export function assertSnapshotId(value: string): void {
+  if (
+    !value.trim() ||
+    value.length > 256 ||
+    [...value].some((character) => {
+      const code = character.codePointAt(0) ?? 0;
+      return code < 32 || code === 127;
+    })
+  ) {
+    throw new Error("Gitcrawl snapshot id is missing or malformed");
+  }
+}
+
+export function assertNoGitcrawlHtmlCommentMarkers(value: unknown, label: string): void {
+  const pending: unknown[] = [value];
+  const seen = new Set<object>();
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (typeof current === "string") {
+      if (current.includes("<!--") || current.includes("-->")) {
+        throw new Error(`${label} contains quarantined HTML comment content`);
+      }
+      continue;
+    }
+    if (current === null || typeof current !== "object") continue;
+    if (seen.has(current)) continue;
+    seen.add(current);
+    if (Array.isArray(current)) pending.push(...current);
+    else {
+      for (const [key, child] of Object.entries(current as Record<string, unknown>)) {
+        pending.push(key, child);
+      }
+    }
+  }
+}
+
+export function assertGitcrawlProviderCursor(
+  value: string,
+  label: string,
+  allowEmpty = true,
+): void {
+  if (
+    (!allowEmpty && value === "") ||
+    value.length > GITCRAWL_PROVIDER_CURSOR_MAX_LENGTH ||
+    [...value].some((character) => {
+      const code = character.codePointAt(0) ?? 0;
+      return code < 32 || code === 127;
+    })
+  ) {
+    throw new Error(`${label} is malformed`);
+  }
+}
+
+export function parseRfc3339Timestamp(value: string, label: string): number {
+  const match =
+    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d{1,9})?(?:Z|([+-])(\d{2}):(\d{2}))$/.exec(
+      value,
+    );
+  if (!match) throw new Error(`${label} is invalid`);
+  const [, yearText, monthText, dayText, hourText, minuteText, secondText, , zoneHour, zoneMinute] =
+    match;
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const hour = Number(hourText);
+  const minute = Number(minuteText);
+  const second = Number(secondText);
+  const offsetHour = zoneHour === undefined ? 0 : Number(zoneHour);
+  const offsetMinute = zoneMinute === undefined ? 0 : Number(zoneMinute);
+  const daysInMonth =
+    month < 1 || month > 12
+      ? 0
+      : month === 2
+        ? year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0)
+          ? 29
+          : 28
+        : [4, 6, 9, 11].includes(month)
+          ? 30
+          : 31;
+  if (
+    day < 1 ||
+    day > daysInMonth ||
+    hour > 23 ||
+    minute > 59 ||
+    second > 59 ||
+    offsetHour > 23 ||
+    offsetMinute > 59
+  ) {
+    throw new Error(`${label} is invalid`);
+  }
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) throw new Error(`${label} is invalid`);
+  return timestamp;
+}
+
+export function compareCanonicalText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function canonicalValue(value: unknown, depth = 0): unknown {
+  if (depth > GITCRAWL_CANONICAL_JSON_MAX_DEPTH) {
+    throw new Error(
+      `canonical JSON exceeds ${GITCRAWL_CANONICAL_JSON_MAX_DEPTH} levels of nesting`,
+    );
+  }
+  if (value === null || typeof value === "string" || typeof value === "boolean") return value;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new Error("canonical JSON rejects non-finite numbers");
+    return value;
+  }
+  if (Array.isArray(value)) return value.map((child) => canonicalValue(child, depth + 1));
+  if (typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([, child]) => child !== undefined)
+        .sort(([left], [right]) => compareCanonicalText(left, right))
+        .map(([key, child]) => [key, canonicalValue(child, depth + 1)]),
+    );
+  }
+  throw new Error(`canonical JSON rejects ${typeof value} values`);
+}

--- a/src/repair/gitcrawl-evidence-contract.ts
+++ b/src/repair/gitcrawl-evidence-contract.ts
@@ -126,12 +126,13 @@ export type GitcrawlEvidenceRelation = {
 export type GitcrawlEvidenceClaim<T = Record<string, unknown>> = {
   version: typeof GITCRAWL_CLAIM_VERSION;
   provider: GitcrawlProvider;
+  repository: string;
   snapshot_id: string;
   parity_snapshot_id?: string;
   query: {
     name: GitcrawlQueryName;
     version: typeof GITCRAWL_QUERY_VERSION;
-    args_sha256?: string;
+    args_sha256: string;
   };
   subject: string;
   source_revision?: GitcrawlSourceRevision;
@@ -149,6 +150,7 @@ export type GitcrawlEvidenceResult<T> = {
 
 export function createGitcrawlEvidenceClaim<T>(input: {
   provider: GitcrawlProvider;
+  repository: string;
   snapshotId: string;
   paritySnapshotId?: string;
   queryName: GitcrawlQueryName;
@@ -160,6 +162,10 @@ export function createGitcrawlEvidenceClaim<T>(input: {
   relations?: GitcrawlEvidenceRelation[];
   data: T;
 }): GitcrawlEvidenceClaim<T> {
+  if (!["local", "cloud", "parity"].includes(input.provider)) {
+    throw new Error(`unsupported Gitcrawl provider: ${input.provider}`);
+  }
+  assertGitcrawlRepository(input.repository);
   assertSnapshotId(input.snapshotId);
   if (input.paritySnapshotId !== undefined) assertSnapshotId(input.paritySnapshotId);
   assertNoGitcrawlHtmlCommentMarkers(input.subject, "Gitcrawl claim subject");
@@ -168,19 +174,17 @@ export function createGitcrawlEvidenceClaim<T>(input: {
   if (!GITCRAWL_QUERY_NAMES.includes(input.queryName)) {
     throw new Error(`unsupported Gitcrawl query: ${input.queryName}`);
   }
-  if (input.queryArgs !== undefined && input.queryArgsSha256 !== undefined) {
-    throw new Error("Gitcrawl claim query arguments must have one digest source");
+  if ((input.queryArgs === undefined) === (input.queryArgsSha256 === undefined)) {
+    throw new Error("Gitcrawl claim query arguments must have exactly one digest source");
   }
   assertNoGitcrawlHtmlCommentMarkers(input.queryArgs ?? {}, "Gitcrawl claim query arguments");
   const queryArgsSha256 =
     input.queryArgs === undefined ? input.queryArgsSha256 : sha256Canonical(input.queryArgs);
-  if (queryArgsSha256 !== undefined) {
-    assertSha256(queryArgsSha256, "claim query arguments sha256");
-  }
+  assertSha256(queryArgsSha256!, "claim query arguments sha256");
   const query: GitcrawlEvidenceClaim["query"] = {
     name: input.queryName,
     version: GITCRAWL_QUERY_VERSION,
-    ...(queryArgsSha256 === undefined ? {} : { args_sha256: queryArgsSha256 }),
+    args_sha256: queryArgsSha256!,
   };
   if (input.sourceRevision?.sha256 !== undefined) {
     assertSha256(input.sourceRevision.sha256, "source revision sha256");
@@ -200,6 +204,7 @@ export function createGitcrawlEvidenceClaim<T>(input: {
       ),
     );
   const semanticPayload = {
+    repository: input.repository,
     query,
     subject: input.subject,
     data: input.data,
@@ -207,6 +212,7 @@ export function createGitcrawlEvidenceClaim<T>(input: {
   const unsigned = {
     version: GITCRAWL_CLAIM_VERSION,
     provider: input.provider,
+    repository: input.repository,
     snapshot_id: input.snapshotId,
     ...(input.paritySnapshotId === undefined ? {} : { parity_snapshot_id: input.paritySnapshotId }),
     query,
@@ -226,16 +232,61 @@ export function createGitcrawlEvidenceClaim<T>(input: {
 }
 
 export function verifyGitcrawlEvidenceClaim(claim: GitcrawlEvidenceClaim): void {
+  assertExactObjectKeys(
+    claim,
+    [
+      "version",
+      "provider",
+      "repository",
+      "snapshot_id",
+      "parity_snapshot_id",
+      "query",
+      "subject",
+      "source_revision",
+      "thread_fingerprint",
+      "relations",
+      "data",
+      "semantic_sha256",
+      "sha256",
+    ],
+    "Gitcrawl evidence claim",
+  );
+  assertExactObjectKeys(
+    claim.query,
+    ["name", "version", "args_sha256"],
+    "Gitcrawl evidence claim query",
+  );
+  if (claim.source_revision !== undefined) {
+    assertExactObjectKeys(
+      claim.source_revision,
+      ["id", "sha256", "updated_at"],
+      "Gitcrawl evidence claim source revision",
+    );
+  }
+  if (claim.thread_fingerprint !== undefined) {
+    assertExactObjectKeys(
+      claim.thread_fingerprint,
+      ["algorithm", "sha256"],
+      "Gitcrawl evidence claim thread fingerprint",
+    );
+  }
+  if (!Array.isArray(claim.relations)) {
+    throw new Error("Gitcrawl evidence claim relations must be an array");
+  }
+  for (const relation of claim.relations) {
+    assertExactObjectKeys(relation, ["predicate", "target"], "Gitcrawl evidence claim relation");
+  }
   assertSha256(claim.semantic_sha256, "claim semantic sha256");
   assertSha256(claim.sha256, "claim sha256");
   const expected = createGitcrawlEvidenceClaim({
     provider: claim.provider,
+    repository: claim.repository,
     snapshotId: claim.snapshot_id,
     ...(claim.parity_snapshot_id === undefined
       ? {}
       : { paritySnapshotId: claim.parity_snapshot_id }),
     queryName: claim.query.name,
-    ...(claim.query.args_sha256 === undefined ? {} : { queryArgsSha256: claim.query.args_sha256 }),
+    queryArgsSha256: claim.query.args_sha256,
     subject: claim.subject,
     ...(claim.source_revision === undefined ? {} : { sourceRevision: claim.source_revision }),
     ...(claim.thread_fingerprint === undefined
@@ -286,6 +337,12 @@ export function assertSnapshotId(value: string): void {
     })
   ) {
     throw new Error("Gitcrawl snapshot id is missing or malformed");
+  }
+}
+
+export function assertGitcrawlRepository(value: string): void {
+  if (typeof value !== "string" || value !== value.trim() || !/^[^/\s]+\/[^/\s]+$/.test(value)) {
+    throw new Error("Gitcrawl repository is missing or malformed");
   }
 }
 
@@ -373,6 +430,17 @@ export function parseRfc3339Timestamp(value: string, label: string): number {
 
 export function compareCanonicalText(left: string, right: string): number {
   return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function assertExactObjectKeys(value: unknown, allowed: readonly string[], label: string): void {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  const allowedKeys = new Set(allowed);
+  const unknown = Object.keys(value).filter((key) => !allowedKeys.has(key));
+  if (unknown.length > 0) {
+    throw new Error(`${label} contains unsupported field ${unknown.sort(compareCanonicalText)[0]}`);
+  }
 }
 
 function canonicalValue(value: unknown, depth = 0): unknown {

--- a/src/repair/gitcrawl-evidence-contract.ts
+++ b/src/repair/gitcrawl-evidence-contract.ts
@@ -105,6 +105,7 @@ export interface GitcrawlQuerySource {
 }
 
 export type GitcrawlCoverageRow = {
+  snapshot_id: string;
   dataset: GitcrawlDataset;
   row_count: number;
   eligible_count: number;
@@ -532,6 +533,10 @@ function canonicalValue(value: unknown, depth = 0): unknown {
   }
   if (Array.isArray(value)) return value.map((child) => canonicalValue(child, depth + 1));
   if (typeof value === "object") {
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new Error("canonical JSON rejects non-plain objects");
+    }
     return Object.fromEntries(
       Object.entries(value as Record<string, unknown>)
         .filter(([, child]) => child !== undefined)

--- a/src/repair/gitcrawl-evidence-graph.ts
+++ b/src/repair/gitcrawl-evidence-graph.ts
@@ -457,8 +457,20 @@ function validatePacketBindings(input: {
   } else if (input.paritySnapshotId !== undefined) {
     throw new Error("Gitcrawl non-parity evidence packet has a parity snapshot");
   }
+  const claimHashes = new Set<string>();
+  const canonicalClaims = new Map<string, string>();
   for (const claim of input.claims) {
     verifyGitcrawlEvidenceClaim(claim);
+    if (claimHashes.has(claim.sha256)) {
+      throw new Error(`Gitcrawl evidence packet repeats claim ${claim.sha256}`);
+    }
+    claimHashes.add(claim.sha256);
+    const canonicalIdentity = `${claim.subject}:${claim.query.name}`;
+    const previousClaim = canonicalClaims.get(canonicalIdentity);
+    if (previousClaim !== undefined) {
+      throw new Error(`Gitcrawl evidence packet has conflicting claims for ${canonicalIdentity}`);
+    }
+    canonicalClaims.set(canonicalIdentity, claim.sha256);
     if (
       claim.provider !== input.provider ||
       claim.repository !== input.repository ||

--- a/src/repair/gitcrawl-evidence-graph.ts
+++ b/src/repair/gitcrawl-evidence-graph.ts
@@ -101,13 +101,17 @@ export function buildGitcrawlEvidencePacket(input: {
   };
   const generatedAt = input.generatedAt ?? new Date().toISOString();
   parseRfc3339Timestamp(generatedAt, "Gitcrawl evidence packet generated_at");
+  const requiredCoverage = input.requiredCoverage ?? [...requiredCoverageForClaims(input.claims)];
+  if (requiredCoverage.length === 0) {
+    throw new Error("Gitcrawl evidence packets without claims require explicit coverage");
+  }
   validatePacketBindings({
     provider: input.provider,
     repository: input.repository,
     snapshotId: input.snapshotId,
     ...(input.paritySnapshotId === undefined ? {} : { paritySnapshotId: input.paritySnapshotId }),
     coverage: input.coverage,
-    requiredCoverage: input.requiredCoverage ?? [...GITCRAWL_DATASETS],
+    requiredCoverage,
     claims: input.claims,
   });
   const sortedClaims = [...input.claims].sort((left, right) => {
@@ -137,9 +141,7 @@ export function buildGitcrawlEvidencePacket(input: {
     ...(input.paritySnapshotId === undefined ? {} : { parity_snapshot_id: input.paritySnapshotId }),
     query_version: GITCRAWL_QUERY_VERSION,
     generated_at: generatedAt,
-    required_coverage: [...(input.requiredCoverage ?? GITCRAWL_DATASETS)].sort(
-      compareCanonicalText,
-    ),
+    required_coverage: [...requiredCoverage].sort(compareCanonicalText),
     coverage: [...input.coverage].sort((left, right) =>
       compareCanonicalText(left.dataset, right.dataset),
     ),

--- a/src/repair/gitcrawl-evidence-graph.ts
+++ b/src/repair/gitcrawl-evidence-graph.ts
@@ -1,0 +1,508 @@
+import {
+  GITCRAWL_DATASETS,
+  GITCRAWL_PACKET_VERSION,
+  GITCRAWL_PACKET_VERSION_V1,
+  GITCRAWL_QUERY_COVERAGE,
+  GITCRAWL_QUERY_VERSION,
+  type GitcrawlCoverageRow,
+  type GitcrawlDataset,
+  type GitcrawlEvidenceClaim,
+  type GitcrawlProvider,
+  assertSha256,
+  assertSnapshotId,
+  canonicalJson,
+  compareCanonicalText,
+  parseRfc3339Timestamp,
+  sha256Canonical,
+  verifyGitcrawlEvidenceClaim,
+} from "./gitcrawl-evidence-contract.js";
+
+export const DEFAULT_EVIDENCE_PACKET_MAX_CLAIMS = 64;
+export const DEFAULT_EVIDENCE_PACKET_MAX_NODES = 64;
+export const DEFAULT_EVIDENCE_PACKET_MAX_EDGES = 128;
+export const DEFAULT_EVIDENCE_PACKET_MAX_BYTES = 64 * 1024;
+
+export type GitcrawlEvidenceNode = {
+  id: string;
+  kind: "cluster" | "issue" | "pull_request" | "file" | "dataset" | "unknown";
+  label: string;
+};
+
+export type GitcrawlEvidenceEdge = {
+  from: string;
+  predicate: string;
+  to: string;
+  claim_sha256: string;
+};
+
+type GitcrawlEvidencePacketBase = {
+  provider: GitcrawlProvider;
+  repository: string;
+  snapshot_id: string;
+  parity_snapshot_id?: string;
+  query_version: typeof GITCRAWL_QUERY_VERSION;
+  generated_at: string;
+  required_coverage: GitcrawlDataset[];
+  coverage: GitcrawlCoverageRow[];
+  claims: GitcrawlEvidenceClaim[];
+  graph: {
+    nodes: GitcrawlEvidenceNode[];
+    edges: GitcrawlEvidenceEdge[];
+  };
+};
+
+export type GitcrawlEvidencePacketV1 = GitcrawlEvidencePacketBase & {
+  version: typeof GITCRAWL_PACKET_VERSION_V1;
+  totals: {
+    claims: number;
+    nodes: number;
+    edges: number;
+  };
+  omitted: {
+    claims: number;
+    nodes: number;
+    edges: number;
+  };
+  sha256: string;
+};
+
+export type GitcrawlEvidencePacketV2 = GitcrawlEvidencePacketBase & {
+  version: typeof GITCRAWL_PACKET_VERSION;
+  included: {
+    claims: number;
+    nodes: number;
+    edges: number;
+  };
+  sha256: string;
+};
+
+export type GitcrawlEvidencePacket = GitcrawlEvidencePacketV1 | GitcrawlEvidencePacketV2;
+
+export function buildGitcrawlEvidencePacket(input: {
+  provider: GitcrawlProvider;
+  repository: string;
+  snapshotId: string;
+  paritySnapshotId?: string;
+  coverage: GitcrawlCoverageRow[];
+  requiredCoverage?: GitcrawlDataset[];
+  claims: GitcrawlEvidenceClaim[];
+  generatedAt?: string;
+  maxClaims?: number;
+  maxNodes?: number;
+  maxEdges?: number;
+  maxBytes?: number;
+}): GitcrawlEvidencePacketV2 {
+  const limits = {
+    claims: boundedLimit(input.maxClaims, DEFAULT_EVIDENCE_PACKET_MAX_CLAIMS),
+    nodes: boundedLimit(input.maxNodes, DEFAULT_EVIDENCE_PACKET_MAX_NODES),
+    edges: boundedLimit(input.maxEdges, DEFAULT_EVIDENCE_PACKET_MAX_EDGES),
+    bytes: boundedLimit(input.maxBytes, DEFAULT_EVIDENCE_PACKET_MAX_BYTES),
+  };
+  validatePacketBindings({
+    provider: input.provider,
+    snapshotId: input.snapshotId,
+    ...(input.paritySnapshotId === undefined ? {} : { paritySnapshotId: input.paritySnapshotId }),
+    coverage: input.coverage,
+    requiredCoverage: input.requiredCoverage ?? [...GITCRAWL_DATASETS],
+    claims: input.claims,
+  });
+  const sortedClaims = [...input.claims].sort((left, right) => {
+    const priority = claimPriority(left) - claimPriority(right);
+    if (priority !== 0) return priority;
+    return compareCanonicalText(
+      `${left.subject}:${left.query.name}:${left.sha256}`,
+      `${right.subject}:${right.query.name}:${right.sha256}`,
+    );
+  });
+  let claimLimit = Math.min(sortedClaims.length, limits.claims);
+  for (;;) {
+    const claims = sortedClaims.slice(0, claimLimit);
+    const graph = buildGraph(claims, limits.nodes, limits.edges);
+    const unsigned = {
+      version: GITCRAWL_PACKET_VERSION,
+      provider: input.provider,
+      repository: input.repository,
+      snapshot_id: input.snapshotId,
+      ...(input.paritySnapshotId === undefined
+        ? {}
+        : { parity_snapshot_id: input.paritySnapshotId }),
+      query_version: GITCRAWL_QUERY_VERSION,
+      generated_at: input.generatedAt ?? new Date().toISOString(),
+      required_coverage: [...(input.requiredCoverage ?? GITCRAWL_DATASETS)].sort(
+        compareCanonicalText,
+      ),
+      coverage: [...input.coverage].sort((left, right) =>
+        compareCanonicalText(left.dataset, right.dataset),
+      ),
+      claims,
+      graph: {
+        nodes: graph.nodes,
+        edges: graph.edges,
+      },
+      included: {
+        claims: claims.length,
+        nodes: graph.nodes.length,
+        edges: graph.edges.length,
+      },
+    } satisfies Omit<GitcrawlEvidencePacketV2, "sha256">;
+    const packet = {
+      ...unsigned,
+      sha256: sha256Canonical(unsigned),
+    };
+    if (renderedPacketBytes(packet) <= limits.bytes) return packet;
+    if (claimLimit === 0) {
+      throw new Error(`Gitcrawl evidence packet metadata exceeds ${limits.bytes} bytes`);
+    }
+    claimLimit -= 1;
+  }
+}
+
+export function verifyGitcrawlEvidencePacket(
+  packet: GitcrawlEvidencePacket,
+  maxBytes = DEFAULT_EVIDENCE_PACKET_MAX_BYTES,
+): void {
+  assertSha256(packet.sha256, "packet sha256");
+  const packetVersion = (packet as unknown as { version?: unknown }).version;
+  if (packetVersion !== GITCRAWL_PACKET_VERSION && packetVersion !== GITCRAWL_PACKET_VERSION_V1) {
+    throw new Error(`unsupported Gitcrawl packet version: ${String(packetVersion)}`);
+  }
+  const rawPacket = packet as unknown as Record<string, unknown>;
+  if (packet.version === GITCRAWL_PACKET_VERSION) {
+    if (!("included" in rawPacket) || "totals" in rawPacket || "omitted" in rawPacket) {
+      throw new Error("Gitcrawl v2 evidence packet has incompatible count metadata");
+    }
+  } else if ("included" in rawPacket) {
+    throw new Error("Gitcrawl v1 evidence packet has incompatible count metadata");
+  }
+  if (packet.query_version !== GITCRAWL_QUERY_VERSION) {
+    throw new Error(`unsupported Gitcrawl packet query version: ${packet.query_version}`);
+  }
+  assertPacketCardinality(packet);
+  validatePacketBindings({
+    provider: packet.provider,
+    snapshotId: packet.snapshot_id,
+    ...(packet.parity_snapshot_id === undefined
+      ? {}
+      : { paritySnapshotId: packet.parity_snapshot_id }),
+    coverage: packet.coverage,
+    requiredCoverage: packet.required_coverage,
+    claims: packet.claims,
+  });
+  const { sha256: _sha256, ...unsigned } = packet;
+  if (sha256Canonical(unsigned) !== packet.sha256) {
+    throw new Error("Gitcrawl evidence packet digest mismatch");
+  }
+  if (renderedPacketBytes(packet) > maxBytes) {
+    throw new Error(`Gitcrawl evidence packet exceeds ${maxBytes} bytes`);
+  }
+  const reconstructed = buildGraph(
+    packet.claims,
+    packet.graph.nodes.length,
+    packet.graph.edges.length,
+  );
+  if (
+    canonicalJson(packet.graph.nodes) !== canonicalJson(reconstructed.nodes) ||
+    canonicalJson(packet.graph.edges) !== canonicalJson(reconstructed.edges)
+  ) {
+    throw new Error("Gitcrawl evidence packet graph does not match its verified claims");
+  }
+  if (packet.version === GITCRAWL_PACKET_VERSION_V1) {
+    verifyLegacyPacketCounts(packet, reconstructed);
+  } else {
+    verifyIncludedPacketCounts(packet);
+  }
+}
+
+function verifyIncludedPacketCounts(packet: GitcrawlEvidencePacketV2): void {
+  assertNonnegativePacketCounts([
+    ["included claims", packet.included?.claims],
+    ["included nodes", packet.included?.nodes],
+    ["included edges", packet.included?.edges],
+  ]);
+  if (
+    packet.included.claims !== packet.claims.length ||
+    packet.included.nodes !== packet.graph.nodes.length ||
+    packet.included.edges !== packet.graph.edges.length
+  ) {
+    throw new Error("Gitcrawl evidence packet included counts do not match its bounded data");
+  }
+}
+
+function verifyLegacyPacketCounts(
+  packet: GitcrawlEvidencePacketV1,
+  reconstructed: ReturnType<typeof buildGraph>,
+): void {
+  assertNonnegativePacketCounts([
+    ["total claims", packet.totals?.claims],
+    ["total nodes", packet.totals?.nodes],
+    ["total edges", packet.totals?.edges],
+    ["omitted claims", packet.omitted?.claims],
+    ["omitted nodes", packet.omitted?.nodes],
+    ["omitted edges", packet.omitted?.edges],
+  ]);
+  if (
+    packet.totals.claims !== packet.claims.length + packet.omitted.claims ||
+    packet.totals.nodes < reconstructed.totalNodes ||
+    packet.totals.edges < reconstructed.totalEdges ||
+    packet.omitted.nodes !== packet.totals.nodes - packet.graph.nodes.length ||
+    packet.omitted.edges !== packet.totals.edges - packet.graph.edges.length ||
+    (packet.omitted.claims === 0 &&
+      (packet.totals.nodes !== reconstructed.totalNodes ||
+        packet.totals.edges !== reconstructed.totalEdges))
+  ) {
+    throw new Error("Gitcrawl v1 evidence packet declared totals or omissions do not match");
+  }
+}
+
+function assertNonnegativePacketCounts(
+  entries: readonly (readonly [label: string, value: unknown])[],
+): void {
+  for (const [label, value] of entries) {
+    if (!Number.isSafeInteger(value) || Number(value) < 0) {
+      throw new Error(`Gitcrawl evidence packet ${label} must be a nonnegative safe integer`);
+    }
+  }
+}
+
+function renderedPacketBytes(packet: GitcrawlEvidencePacket): number {
+  return Buffer.byteLength(JSON.stringify(packet, null, 2), "utf8");
+}
+
+function buildGraph(
+  claims: GitcrawlEvidenceClaim[],
+  maxNodes: number,
+  maxEdges: number,
+): {
+  nodes: GitcrawlEvidenceNode[];
+  edges: GitcrawlEvidenceEdge[];
+  omittedNodes: number;
+  omittedEdges: number;
+  totalNodes: number;
+  totalEdges: number;
+} {
+  const allNodes = new Map<string, GitcrawlEvidenceNode>();
+  const allEdges: GitcrawlEvidenceEdge[] = [];
+  for (const claim of claims) {
+    addNode(allNodes, claim.subject);
+    for (const relation of claim.relations) {
+      addNode(allNodes, relation.target);
+      allEdges.push({
+        from: claim.subject,
+        predicate: relation.predicate,
+        to: relation.target,
+        claim_sha256: claim.sha256,
+      });
+    }
+  }
+  const sortedNodes = [...allNodes.values()].sort((left, right) =>
+    compareCanonicalText(left.id, right.id),
+  );
+  const nodes = sortedNodes.slice(0, maxNodes);
+  const includedNodeIds = new Set(nodes.map((node) => node.id));
+  const sortedEdges = allEdges
+    .filter((edge) => includedNodeIds.has(edge.from) && includedNodeIds.has(edge.to))
+    .sort((left, right) =>
+      compareCanonicalText(
+        `${left.from}:${left.predicate}:${left.to}:${left.claim_sha256}`,
+        `${right.from}:${right.predicate}:${right.to}:${right.claim_sha256}`,
+      ),
+    );
+  const edges = sortedEdges.slice(0, maxEdges);
+  return {
+    nodes,
+    edges,
+    omittedNodes: Math.max(0, sortedNodes.length - maxNodes),
+    omittedEdges: Math.max(0, allEdges.length - edges.length),
+    totalNodes: sortedNodes.length,
+    totalEdges: allEdges.length,
+  };
+}
+
+function addNode(target: Map<string, GitcrawlEvidenceNode>, id: string): void {
+  if (target.has(id)) return;
+  target.set(id, {
+    id,
+    kind: nodeKind(id),
+    label: id.length > 160 ? `${id.slice(0, 157)}...` : id,
+  });
+}
+
+function nodeKind(id: string): GitcrawlEvidenceNode["kind"] {
+  if (id.includes("#cluster:")) return "cluster";
+  if (id.includes("#dataset:")) return "dataset";
+  if (id.includes("@file:")) return "file";
+  if (id.includes("/pull/") || id.includes("#pull:")) return "pull_request";
+  if (id.includes("/issues/") || id.includes("#issue:")) return "issue";
+  return "unknown";
+}
+
+function claimPriority(claim: GitcrawlEvidenceClaim): number {
+  return claim.relations.length === 0 ? 0 : 1;
+}
+
+function validatePacketBindings(input: {
+  provider: GitcrawlProvider;
+  snapshotId: string;
+  paritySnapshotId?: string;
+  coverage: GitcrawlCoverageRow[];
+  requiredCoverage: GitcrawlDataset[];
+  claims: GitcrawlEvidenceClaim[];
+}): void {
+  if (!["local", "cloud", "parity"].includes(input.provider)) {
+    throw new Error(`Gitcrawl evidence packet has unknown provider ${input.provider}`);
+  }
+  assertSnapshotId(input.snapshotId);
+  if (input.provider === "parity") {
+    if (input.paritySnapshotId === undefined) {
+      throw new Error("Gitcrawl parity evidence packet is missing its local snapshot");
+    }
+    assertSnapshotId(input.paritySnapshotId);
+  } else if (input.paritySnapshotId !== undefined) {
+    throw new Error("Gitcrawl non-parity evidence packet has a parity snapshot");
+  }
+  for (const claim of input.claims) {
+    verifyGitcrawlEvidenceClaim(claim);
+    if (
+      claim.provider !== input.provider ||
+      claim.snapshot_id !== input.snapshotId ||
+      claim.parity_snapshot_id !== input.paritySnapshotId
+    ) {
+      throw new Error(`Gitcrawl evidence packet mixes claim bindings for ${claim.subject}`);
+    }
+  }
+  const datasets = new Set<string>();
+  const required = new Set(input.requiredCoverage);
+  if (required.size === 0 || required.size !== input.requiredCoverage.length) {
+    throw new Error("Gitcrawl evidence packet required coverage is empty or duplicated");
+  }
+  for (const dataset of required) {
+    if (!GITCRAWL_DATASETS.includes(dataset)) {
+      throw new Error(`Gitcrawl evidence packet requires unknown coverage ${dataset}`);
+    }
+  }
+  for (const dataset of requiredCoverageForClaims(input.claims)) {
+    if (!required.has(dataset)) {
+      throw new Error(`Gitcrawl evidence packet omits required claim coverage ${dataset}`);
+    }
+  }
+  let generation = "";
+  for (const row of input.coverage) {
+    assertPersistedCoverageRow(row);
+    if (datasets.has(row.dataset)) {
+      throw new Error(`Gitcrawl evidence packet repeats coverage for ${row.dataset}`);
+    }
+    datasets.add(row.dataset);
+    if (required.has(row.dataset) && (!row.complete || row.covered_count !== row.eligible_count)) {
+      throw new Error(`Gitcrawl evidence packet has incomplete coverage for ${row.dataset}`);
+    }
+    if (row.complete && row.covered_count !== row.eligible_count) {
+      throw new Error(`Gitcrawl evidence packet has invalid complete coverage for ${row.dataset}`);
+    }
+    if (!row.dataset_generated_at) {
+      throw new Error(`Gitcrawl evidence packet coverage ${row.dataset} has no generation`);
+    }
+    generation ||= row.dataset_generated_at;
+    if (row.dataset_generated_at !== generation) {
+      throw new Error("Gitcrawl evidence packet mixes coverage generations");
+    }
+  }
+  if (input.coverage.length === 0) {
+    throw new Error("Gitcrawl evidence packet has no coverage");
+  }
+  for (const dataset of GITCRAWL_DATASETS) {
+    if (!datasets.has(dataset)) {
+      throw new Error(`Gitcrawl evidence packet is missing coverage for ${dataset}`);
+    }
+  }
+}
+
+function assertPersistedCoverageRow(row: GitcrawlCoverageRow): void {
+  if (typeof row !== "object" || row === null || Array.isArray(row)) {
+    throw new Error("Gitcrawl evidence packet contains malformed coverage");
+  }
+  if (!GITCRAWL_DATASETS.includes(row.dataset)) {
+    throw new Error(`Gitcrawl evidence packet contains unknown coverage ${String(row.dataset)}`);
+  }
+  for (const field of ["row_count", "eligible_count", "covered_count"] as const) {
+    if (!Number.isSafeInteger(row[field]) || row[field] < 0) {
+      throw new Error(
+        `Gitcrawl evidence packet coverage ${row.dataset} ${field} must be a nonnegative safe integer`,
+      );
+    }
+  }
+  if (row.covered_count > row.eligible_count) {
+    throw new Error(`Gitcrawl evidence packet coverage ${row.dataset} exceeds eligible rows`);
+  }
+  if (typeof row.complete !== "boolean") {
+    throw new Error(`Gitcrawl evidence packet coverage ${row.dataset} complete must be boolean`);
+  }
+  if (row.complete && row.eligible_count > row.row_count) {
+    throw new Error(
+      `Gitcrawl evidence packet coverage ${row.dataset} has more eligible rows than total rows`,
+    );
+  }
+  if (typeof row.max_source_at !== "string") {
+    throw new Error(
+      `Gitcrawl evidence packet coverage ${row.dataset} max_source_at must be string`,
+    );
+  }
+  if (row.max_source_at) {
+    parseRfc3339Timestamp(
+      row.max_source_at,
+      `Gitcrawl evidence packet coverage ${row.dataset} max_source_at`,
+    );
+  }
+  if (typeof row.dataset_generated_at !== "string" || !row.dataset_generated_at) {
+    throw new Error(
+      `Gitcrawl evidence packet coverage ${row.dataset} dataset_generated_at must be a timestamp`,
+    );
+  }
+  parseRfc3339Timestamp(
+    row.dataset_generated_at,
+    `Gitcrawl evidence packet coverage ${row.dataset} dataset_generated_at`,
+  );
+}
+
+function boundedLimit(value: number | undefined, fallback: number): number {
+  const resolved = value ?? fallback;
+  if (!Number.isSafeInteger(resolved) || resolved < 1 || resolved > fallback) {
+    throw new Error(`Gitcrawl evidence packet limit must be an integer from 1 to ${fallback}`);
+  }
+  return resolved;
+}
+
+function assertPacketCardinality(packet: GitcrawlEvidencePacket): void {
+  if (!Array.isArray(packet.claims) || packet.claims.length > DEFAULT_EVIDENCE_PACKET_MAX_CLAIMS) {
+    throw new Error(
+      `Gitcrawl evidence packet includes more than ${DEFAULT_EVIDENCE_PACKET_MAX_CLAIMS} claims`,
+    );
+  }
+  if (
+    typeof packet.graph !== "object" ||
+    packet.graph === null ||
+    !Array.isArray(packet.graph.nodes) ||
+    packet.graph.nodes.length > DEFAULT_EVIDENCE_PACKET_MAX_NODES
+  ) {
+    throw new Error(
+      `Gitcrawl evidence packet includes more than ${DEFAULT_EVIDENCE_PACKET_MAX_NODES} nodes`,
+    );
+  }
+  if (
+    !Array.isArray(packet.graph.edges) ||
+    packet.graph.edges.length > DEFAULT_EVIDENCE_PACKET_MAX_EDGES
+  ) {
+    throw new Error(
+      `Gitcrawl evidence packet includes more than ${DEFAULT_EVIDENCE_PACKET_MAX_EDGES} edges`,
+    );
+  }
+}
+
+function requiredCoverageForClaims(claims: GitcrawlEvidenceClaim[]): Set<GitcrawlDataset> {
+  const required = new Set<GitcrawlDataset>();
+  for (const claim of claims) {
+    for (const dataset of GITCRAWL_QUERY_COVERAGE[claim.query.name] ?? []) {
+      required.add(dataset);
+    }
+  }
+  return required;
+}

--- a/src/repair/gitcrawl-evidence-graph.ts
+++ b/src/repair/gitcrawl-evidence-graph.ts
@@ -623,7 +623,7 @@ function assertPersistedCoverageRow(row: GitcrawlCoverageRow): void {
   if (typeof row.complete !== "boolean") {
     throw new Error(`Gitcrawl evidence packet coverage ${row.dataset} complete must be boolean`);
   }
-  if (row.complete && row.eligible_count > row.row_count) {
+  if (row.eligible_count > row.row_count) {
     throw new Error(
       `Gitcrawl evidence packet coverage ${row.dataset} has more eligible rows than total rows`,
     );

--- a/src/repair/gitcrawl-evidence-graph.ts
+++ b/src/repair/gitcrawl-evidence-graph.ts
@@ -173,6 +173,7 @@ export function verifyGitcrawlEvidencePacket(
   if (packetVersion !== GITCRAWL_PACKET_VERSION && packetVersion !== GITCRAWL_PACKET_VERSION_V1) {
     throw new Error(`unsupported Gitcrawl packet version: ${String(packetVersion)}`);
   }
+  assertPacketSchema(packet);
   const rawPacket = packet as unknown as Record<string, unknown>;
   if (packet.version === GITCRAWL_PACKET_VERSION) {
     if (!("included" in rawPacket) || "totals" in rawPacket || "omitted" in rawPacket) {
@@ -228,6 +229,80 @@ export function verifyGitcrawlEvidencePacket(
     verifyLegacyPacketCounts(packet, reconstructed);
   } else {
     verifyIncludedPacketCounts(packet);
+  }
+}
+
+function assertPacketSchema(packet: GitcrawlEvidencePacket): void {
+  const commonFields = [
+    "version",
+    "provider",
+    "repository",
+    "snapshot_id",
+    "parity_snapshot_id",
+    "query_version",
+    "generated_at",
+    "required_coverage",
+    "coverage",
+    "claims",
+    "graph",
+    "sha256",
+  ] as const;
+  if (packet.version === GITCRAWL_PACKET_VERSION) {
+    assertExactObjectKeys(packet, [...commonFields, "included"], "Gitcrawl v2 evidence packet");
+    assertExactObjectKeys(
+      packet.included,
+      ["claims", "nodes", "edges"],
+      "Gitcrawl v2 evidence packet included counts",
+    );
+  } else {
+    assertExactObjectKeys(
+      packet,
+      [...commonFields, "totals", "omitted"],
+      "Gitcrawl v1 evidence packet",
+    );
+    assertExactObjectKeys(
+      packet.totals,
+      ["claims", "nodes", "edges"],
+      "Gitcrawl v1 evidence packet totals",
+    );
+    assertExactObjectKeys(
+      packet.omitted,
+      ["claims", "nodes", "edges"],
+      "Gitcrawl v1 evidence packet omissions",
+    );
+  }
+  assertExactObjectKeys(packet.graph, ["nodes", "edges"], "Gitcrawl evidence packet graph");
+  if (!Array.isArray(packet.graph.nodes) || !Array.isArray(packet.graph.edges)) {
+    throw new Error("Gitcrawl evidence packet graph is malformed");
+  }
+  for (const node of packet.graph.nodes) {
+    assertExactObjectKeys(node, ["id", "kind", "label"], "Gitcrawl evidence packet graph node");
+  }
+  for (const edge of packet.graph.edges) {
+    assertExactObjectKeys(
+      edge,
+      ["from", "predicate", "to", "claim_sha256"],
+      "Gitcrawl evidence packet graph edge",
+    );
+  }
+  if (!Array.isArray(packet.coverage)) {
+    throw new Error("Gitcrawl evidence packet coverage is malformed");
+  }
+  for (const row of packet.coverage) {
+    assertExactObjectKeys(
+      row,
+      [
+        "snapshot_id",
+        "dataset",
+        "row_count",
+        "eligible_count",
+        "covered_count",
+        "max_source_at",
+        "dataset_generated_at",
+        "complete",
+      ],
+      "Gitcrawl evidence packet coverage row",
+    );
   }
 }
 
@@ -486,6 +561,17 @@ function assertPersistedCoverageRow(row: GitcrawlCoverageRow): void {
     row.dataset_generated_at,
     `Gitcrawl evidence packet coverage ${row.dataset} dataset_generated_at`,
   );
+}
+
+function assertExactObjectKeys(value: unknown, allowed: readonly string[], label: string): void {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${label} is malformed`);
+  }
+  const allowedKeys = new Set(allowed);
+  const unknown = Object.keys(value).filter((key) => !allowedKeys.has(key));
+  if (unknown.length > 0) {
+    throw new Error(`${label} contains unsupported field ${unknown.sort(compareCanonicalText)[0]}`);
+  }
 }
 
 function boundedLimit(value: number | undefined, fallback: number): number {

--- a/src/repair/gitcrawl-evidence-graph.ts
+++ b/src/repair/gitcrawl-evidence-graph.ts
@@ -8,6 +8,7 @@ import {
   type GitcrawlDataset,
   type GitcrawlEvidenceClaim,
   type GitcrawlProvider,
+  assertGitcrawlRepository,
   assertSha256,
   assertSnapshotId,
   canonicalJson,
@@ -100,6 +101,7 @@ export function buildGitcrawlEvidencePacket(input: {
   };
   validatePacketBindings({
     provider: input.provider,
+    repository: input.repository,
     snapshotId: input.snapshotId,
     ...(input.paritySnapshotId === undefined ? {} : { paritySnapshotId: input.paritySnapshotId }),
     coverage: input.coverage,
@@ -114,47 +116,50 @@ export function buildGitcrawlEvidencePacket(input: {
       `${right.subject}:${right.query.name}:${right.sha256}`,
     );
   });
-  let claimLimit = Math.min(sortedClaims.length, limits.claims);
-  for (;;) {
-    const claims = sortedClaims.slice(0, claimLimit);
-    const graph = buildGraph(claims, limits.nodes, limits.edges);
-    const unsigned = {
-      version: GITCRAWL_PACKET_VERSION,
-      provider: input.provider,
-      repository: input.repository,
-      snapshot_id: input.snapshotId,
-      ...(input.paritySnapshotId === undefined
-        ? {}
-        : { parity_snapshot_id: input.paritySnapshotId }),
-      query_version: GITCRAWL_QUERY_VERSION,
-      generated_at: input.generatedAt ?? new Date().toISOString(),
-      required_coverage: [...(input.requiredCoverage ?? GITCRAWL_DATASETS)].sort(
-        compareCanonicalText,
-      ),
-      coverage: [...input.coverage].sort((left, right) =>
-        compareCanonicalText(left.dataset, right.dataset),
-      ),
-      claims,
-      graph: {
-        nodes: graph.nodes,
-        edges: graph.edges,
-      },
-      included: {
-        claims: claims.length,
-        nodes: graph.nodes.length,
-        edges: graph.edges.length,
-      },
-    } satisfies Omit<GitcrawlEvidencePacketV2, "sha256">;
-    const packet = {
-      ...unsigned,
-      sha256: sha256Canonical(unsigned),
-    };
-    if (renderedPacketBytes(packet) <= limits.bytes) return packet;
-    if (claimLimit === 0) {
-      throw new Error(`Gitcrawl evidence packet metadata exceeds ${limits.bytes} bytes`);
-    }
-    claimLimit -= 1;
+  if (sortedClaims.length > limits.claims) {
+    throw new Error(
+      `Gitcrawl evidence packet requires ${sortedClaims.length} claims but the limit is ${limits.claims}`,
+    );
   }
+  const graph = buildGraph(sortedClaims, limits.nodes, limits.edges);
+  if (graph.omittedNodes > 0 || graph.omittedEdges > 0) {
+    throw new Error(
+      `Gitcrawl evidence packet graph exceeds its complete bounds (${graph.totalNodes} nodes, ${graph.totalEdges} edges)`,
+    );
+  }
+  const unsigned = {
+    version: GITCRAWL_PACKET_VERSION,
+    provider: input.provider,
+    repository: input.repository,
+    snapshot_id: input.snapshotId,
+    ...(input.paritySnapshotId === undefined ? {} : { parity_snapshot_id: input.paritySnapshotId }),
+    query_version: GITCRAWL_QUERY_VERSION,
+    generated_at: input.generatedAt ?? new Date().toISOString(),
+    required_coverage: [...(input.requiredCoverage ?? GITCRAWL_DATASETS)].sort(
+      compareCanonicalText,
+    ),
+    coverage: [...input.coverage].sort((left, right) =>
+      compareCanonicalText(left.dataset, right.dataset),
+    ),
+    claims: sortedClaims,
+    graph: {
+      nodes: graph.nodes,
+      edges: graph.edges,
+    },
+    included: {
+      claims: sortedClaims.length,
+      nodes: graph.nodes.length,
+      edges: graph.edges.length,
+    },
+  } satisfies Omit<GitcrawlEvidencePacketV2, "sha256">;
+  const packet = {
+    ...unsigned,
+    sha256: sha256Canonical(unsigned),
+  };
+  if (renderedPacketBytes(packet) > limits.bytes) {
+    throw new Error(`Gitcrawl evidence packet exceeds ${limits.bytes} bytes`);
+  }
+  return packet;
 }
 
 export function verifyGitcrawlEvidencePacket(
@@ -180,6 +185,7 @@ export function verifyGitcrawlEvidencePacket(
   assertPacketCardinality(packet);
   validatePacketBindings({
     provider: packet.provider,
+    repository: packet.repository,
     snapshotId: packet.snapshot_id,
     ...(packet.parity_snapshot_id === undefined
       ? {}
@@ -195,11 +201,20 @@ export function verifyGitcrawlEvidencePacket(
   if (renderedPacketBytes(packet) > maxBytes) {
     throw new Error(`Gitcrawl evidence packet exceeds ${maxBytes} bytes`);
   }
-  const reconstructed = buildGraph(
-    packet.claims,
-    packet.graph.nodes.length,
-    packet.graph.edges.length,
-  );
+  const reconstructed =
+    packet.version === GITCRAWL_PACKET_VERSION_V1
+      ? buildGraph(packet.claims, packet.graph.nodes.length, packet.graph.edges.length)
+      : buildGraph(
+          packet.claims,
+          DEFAULT_EVIDENCE_PACKET_MAX_NODES,
+          DEFAULT_EVIDENCE_PACKET_MAX_EDGES,
+        );
+  if (
+    packet.version === GITCRAWL_PACKET_VERSION &&
+    (reconstructed.omittedNodes > 0 || reconstructed.omittedEdges > 0)
+  ) {
+    throw new Error("Gitcrawl v2 evidence packet claims exceed the canonical graph bounds");
+  }
   if (
     canonicalJson(packet.graph.nodes) !== canonicalJson(reconstructed.nodes) ||
     canonicalJson(packet.graph.edges) !== canonicalJson(reconstructed.edges)
@@ -342,6 +357,7 @@ function claimPriority(claim: GitcrawlEvidenceClaim): number {
 
 function validatePacketBindings(input: {
   provider: GitcrawlProvider;
+  repository: string;
   snapshotId: string;
   paritySnapshotId?: string;
   coverage: GitcrawlCoverageRow[];
@@ -351,6 +367,7 @@ function validatePacketBindings(input: {
   if (!["local", "cloud", "parity"].includes(input.provider)) {
     throw new Error(`Gitcrawl evidence packet has unknown provider ${input.provider}`);
   }
+  assertGitcrawlRepository(input.repository);
   assertSnapshotId(input.snapshotId);
   if (input.provider === "parity") {
     if (input.paritySnapshotId === undefined) {
@@ -364,6 +381,7 @@ function validatePacketBindings(input: {
     verifyGitcrawlEvidenceClaim(claim);
     if (
       claim.provider !== input.provider ||
+      claim.repository !== input.repository ||
       claim.snapshot_id !== input.snapshotId ||
       claim.parity_snapshot_id !== input.paritySnapshotId
     ) {

--- a/src/repair/gitcrawl-evidence-graph.ts
+++ b/src/repair/gitcrawl-evidence-graph.ts
@@ -99,6 +99,8 @@ export function buildGitcrawlEvidencePacket(input: {
     edges: boundedLimit(input.maxEdges, DEFAULT_EVIDENCE_PACKET_MAX_EDGES),
     bytes: boundedLimit(input.maxBytes, DEFAULT_EVIDENCE_PACKET_MAX_BYTES),
   };
+  const generatedAt = input.generatedAt ?? new Date().toISOString();
+  parseRfc3339Timestamp(generatedAt, "Gitcrawl evidence packet generated_at");
   validatePacketBindings({
     provider: input.provider,
     repository: input.repository,
@@ -134,7 +136,7 @@ export function buildGitcrawlEvidencePacket(input: {
     snapshot_id: input.snapshotId,
     ...(input.paritySnapshotId === undefined ? {} : { parity_snapshot_id: input.paritySnapshotId }),
     query_version: GITCRAWL_QUERY_VERSION,
-    generated_at: input.generatedAt ?? new Date().toISOString(),
+    generated_at: generatedAt,
     required_coverage: [...(input.requiredCoverage ?? GITCRAWL_DATASETS)].sort(
       compareCanonicalText,
     ),
@@ -182,6 +184,7 @@ export function verifyGitcrawlEvidencePacket(
   if (packet.query_version !== GITCRAWL_QUERY_VERSION) {
     throw new Error(`unsupported Gitcrawl packet query version: ${packet.query_version}`);
   }
+  parseRfc3339Timestamp(packet.generated_at, "Gitcrawl evidence packet generated_at");
   assertPacketCardinality(packet);
   validatePacketBindings({
     provider: packet.provider,
@@ -406,6 +409,9 @@ function validatePacketBindings(input: {
   let generation = "";
   for (const row of input.coverage) {
     assertPersistedCoverageRow(row);
+    if (row.snapshot_id !== input.snapshotId) {
+      throw new Error(`Gitcrawl evidence packet mixes coverage snapshots for ${row.dataset}`);
+    }
     if (datasets.has(row.dataset)) {
       throw new Error(`Gitcrawl evidence packet repeats coverage for ${row.dataset}`);
     }
@@ -441,6 +447,7 @@ function assertPersistedCoverageRow(row: GitcrawlCoverageRow): void {
   if (!GITCRAWL_DATASETS.includes(row.dataset)) {
     throw new Error(`Gitcrawl evidence packet contains unknown coverage ${String(row.dataset)}`);
   }
+  assertSnapshotId(row.snapshot_id);
   for (const field of ["row_count", "eligible_count", "covered_count"] as const) {
     if (!Number.isSafeInteger(row[field]) || row[field] < 0) {
       throw new Error(

--- a/src/repair/gitcrawl-evidence-graph.ts
+++ b/src/repair/gitcrawl-evidence-graph.ts
@@ -170,6 +170,8 @@ export function verifyGitcrawlEvidencePacket(
   packet: GitcrawlEvidencePacket,
   maxBytes = DEFAULT_EVIDENCE_PACKET_MAX_BYTES,
 ): void {
+  const byteLimit = boundedLimit(maxBytes, DEFAULT_EVIDENCE_PACKET_MAX_BYTES);
+  assertBoundedPacketInput(packet, byteLimit);
   assertSha256(packet.sha256, "packet sha256");
   const packetVersion = (packet as unknown as { version?: unknown }).version;
   if (packetVersion !== GITCRAWL_PACKET_VERSION && packetVersion !== GITCRAWL_PACKET_VERSION_V1) {
@@ -189,6 +191,9 @@ export function verifyGitcrawlEvidencePacket(
   }
   parseRfc3339Timestamp(packet.generated_at, "Gitcrawl evidence packet generated_at");
   assertPacketCardinality(packet);
+  if (renderedPacketBytes(packet) > byteLimit) {
+    throw new Error(`Gitcrawl evidence packet exceeds ${byteLimit} bytes`);
+  }
   validatePacketBindings({
     provider: packet.provider,
     repository: packet.repository,
@@ -203,9 +208,6 @@ export function verifyGitcrawlEvidencePacket(
   const { sha256: _sha256, ...unsigned } = packet;
   if (sha256Canonical(unsigned) !== packet.sha256) {
     throw new Error("Gitcrawl evidence packet digest mismatch");
-  }
-  if (renderedPacketBytes(packet) > maxBytes) {
-    throw new Error(`Gitcrawl evidence packet exceeds ${maxBytes} bytes`);
   }
   const reconstructed =
     packet.version === GITCRAWL_PACKET_VERSION_V1
@@ -361,6 +363,77 @@ function assertNonnegativePacketCounts(
 
 function renderedPacketBytes(packet: GitcrawlEvidencePacket): number {
   return Buffer.byteLength(JSON.stringify(packet, null, 2), "utf8");
+}
+
+function assertBoundedPacketInput(packet: unknown, maxBytes: number): void {
+  let bytes = 0;
+  const activeObjects = new WeakSet<object>();
+  const addBytes = (value: number): void => {
+    bytes += value;
+    if (bytes > maxBytes) {
+      throw new Error(`Gitcrawl evidence packet exceeds ${maxBytes} bytes`);
+    }
+  };
+  const visit = (value: unknown, depth: number, arrayValue: boolean): boolean => {
+    if (depth > 128) {
+      throw new Error("Gitcrawl evidence packet exceeds the maximum JSON depth");
+    }
+    if (value === null) {
+      addBytes(4);
+      return true;
+    }
+    switch (typeof value) {
+      case "string":
+        addBytes(Buffer.byteLength(JSON.stringify(value), "utf8"));
+        return true;
+      case "number":
+        addBytes(Buffer.byteLength(JSON.stringify(value), "utf8"));
+        return true;
+      case "boolean":
+        addBytes(value ? 4 : 5);
+        return true;
+      case "undefined":
+      case "function":
+      case "symbol":
+        if (arrayValue) addBytes(4);
+        return arrayValue;
+      case "bigint":
+        throw new Error("Gitcrawl evidence packet contains an unsupported JSON value");
+      case "object":
+        break;
+    }
+    if (activeObjects.has(value)) {
+      throw new Error("Gitcrawl evidence packet contains a JSON cycle");
+    }
+    activeObjects.add(value);
+    if (Array.isArray(value)) {
+      addBytes(2);
+      for (let index = 0; index < value.length; index += 1) {
+        if (index > 0) addBytes(1);
+        if (Object.hasOwn(value, index)) {
+          visit(value[index], depth + 1, true);
+        } else {
+          addBytes(4);
+        }
+      }
+    } else {
+      addBytes(2);
+      let emitted = 0;
+      for (const key of Object.keys(value)) {
+        const child = (value as Record<string, unknown>)[key];
+        if (child === undefined || typeof child === "function" || typeof child === "symbol") {
+          continue;
+        }
+        if (emitted > 0) addBytes(1);
+        addBytes(Buffer.byteLength(JSON.stringify(key), "utf8") + 1);
+        visit(child, depth + 1, false);
+        emitted += 1;
+      }
+    }
+    activeObjects.delete(value);
+    return true;
+  };
+  visit(packet, 0, false);
 }
 
 function buildGraph(

--- a/src/repair/gitcrawl-evidence-local.ts
+++ b/src/repair/gitcrawl-evidence-local.ts
@@ -739,11 +739,15 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
     const latestRunAt = clusterRunSupport
       ? String(latestRun?.finished_at ?? "")
       : portableExportedAt;
+    const latestRunInputAt = clusterRunSupport
+      ? String(latestRun?.started_at ?? "")
+      : portableExportedAt;
     const hasLatestRun =
       Number.isSafeInteger(latestRunId) &&
       latestRunId > 0 &&
       latestRunAt !== "" &&
-      timestampAtOrAfter(latestRunAt, this.sourceSyncAt);
+      latestRunInputAt !== "" &&
+      timestampAtOrAfter(latestRunInputAt, this.sourceSyncAt);
     const groupEligible = this.scalarNumber(
       "select count(*) as value from cluster_groups where repo_id = ? and status = 'active'",
       this.repoId,

--- a/src/repair/gitcrawl-evidence-local.ts
+++ b/src/repair/gitcrawl-evidence-local.ts
@@ -692,14 +692,7 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
       columnExists(this.db, "cluster_runs", "started_at") &&
       columnExists(this.db, "cluster_runs", "finished_at") &&
       columnExists(this.db, "cluster_memberships", "last_seen_run_id");
-    const portableExportedAt = this.portableMetadata("exported_at");
-    const portableGenerationSupport =
-      this.portable &&
-      !clusterRunSupport &&
-      portableExportedAt !== "" &&
-      columnExists(this.db, "cluster_memberships", "last_seen_run_id");
-    const currentSchema = clusterRunSupport || portableGenerationSupport;
-    if (!currentSchema) {
+    if (!clusterRunSupport) {
       return [
         metric(
           this.snapshotId,
@@ -724,31 +717,18 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
       ];
     }
 
-    const latestRun = clusterRunSupport
-      ? this.db
-          .prepare(
-            `select id, started_at, finished_at
-             from cluster_runs
-             where repo_id = ? and status in ('success', 'completed') and finished_at is not null
-             order by id desc
-             limit 1`,
-          )
-          .get(this.repoId)
-      : this.db
-          .prepare(
-            `select max(cm.last_seen_run_id) as id
-             from cluster_memberships cm
-             join cluster_groups c on c.id = cm.cluster_id
-             where c.repo_id = ? and c.status = 'active' and cm.state = 'active'`,
-          )
-          .get(this.repoId);
+    const latestRun = this.db
+      .prepare(
+        `select id, started_at, finished_at
+         from cluster_runs
+         where repo_id = ? and status in ('success', 'completed') and finished_at is not null
+         order by id desc
+         limit 1`,
+      )
+      .get(this.repoId);
     const latestRunId = Number(latestRun?.id ?? 0);
-    const latestRunAt = clusterRunSupport
-      ? String(latestRun?.finished_at ?? "")
-      : portableExportedAt;
-    const latestRunInputAt = clusterRunSupport
-      ? String(latestRun?.started_at ?? "")
-      : portableExportedAt;
+    const latestRunAt = String(latestRun?.finished_at ?? "");
+    const latestRunInputAt = String(latestRun?.started_at ?? "");
     const hasLatestRun =
       Number.isSafeInteger(latestRunId) &&
       latestRunId > 0 &&

--- a/src/repair/gitcrawl-evidence-local.ts
+++ b/src/repair/gitcrawl-evidence-local.ts
@@ -939,17 +939,20 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
        from threads t
        left join pull_request_details detail on detail.thread_id = t.id
        left join (
-         select thread_id,
+         select file.thread_id,
                 count(*) as file_count,
-                count(distinct position) as distinct_positions,
-                min(position) as minimum_position,
-                max(position) as maximum_position,
-                min(fetched_at) as oldest_fetched_at
-         from pull_request_files
-         group by thread_id
+                count(distinct file.position) as distinct_positions,
+                min(file.position) as minimum_position,
+                max(file.position) as maximum_position,
+                min(file.fetched_at) as oldest_fetched_at
+         from threads file_thread
+         join pull_request_files file on file.thread_id = file_thread.id
+         where file_thread.repo_id = ?
+         group by file.thread_id
        ) files on files.thread_id = t.id
        ${fileReservationJoin}
        where t.repo_id = ? and t.kind = 'pull_request'`,
+      this.repoId,
       this.repoId,
     );
     let fileEligible = 0;

--- a/src/repair/gitcrawl-evidence-local.ts
+++ b/src/repair/gitcrawl-evidence-local.ts
@@ -679,11 +679,19 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
       clusterTable,
       columnExists(this.db, clusterTable, "updated_at") ? "updated_at" : "created_at",
     );
-    const currentSchema =
+    const clusterRunSupport =
       this.portable &&
       tableExists(this.db, "cluster_runs") &&
+      columnExists(this.db, "cluster_runs", "started_at") &&
       columnExists(this.db, "cluster_runs", "finished_at") &&
       columnExists(this.db, "cluster_memberships", "last_seen_run_id");
+    const portableExportedAt = this.portableMetadata("exported_at");
+    const portableGenerationSupport =
+      this.portable &&
+      !clusterRunSupport &&
+      portableExportedAt !== "" &&
+      columnExists(this.db, "cluster_memberships", "last_seen_run_id");
+    const currentSchema = clusterRunSupport || portableGenerationSupport;
     if (!currentSchema) {
       return [
         metric(
@@ -709,17 +717,28 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
       ];
     }
 
-    const latestRun = this.db
-      .prepare(
-        `select id, finished_at
-         from cluster_runs
-         where repo_id = ? and status in ('success', 'completed') and finished_at is not null
-         order by id desc
-         limit 1`,
-      )
-      .get(this.repoId);
+    const latestRun = clusterRunSupport
+      ? this.db
+          .prepare(
+            `select id, started_at, finished_at
+             from cluster_runs
+             where repo_id = ? and status in ('success', 'completed') and finished_at is not null
+             order by id desc
+             limit 1`,
+          )
+          .get(this.repoId)
+      : this.db
+          .prepare(
+            `select max(cm.last_seen_run_id) as id
+             from cluster_memberships cm
+             join cluster_groups c on c.id = cm.cluster_id
+             where c.repo_id = ? and c.status = 'active' and cm.state = 'active'`,
+          )
+          .get(this.repoId);
     const latestRunId = Number(latestRun?.id ?? 0);
-    const latestRunAt = String(latestRun?.finished_at ?? "");
+    const latestRunAt = clusterRunSupport
+      ? String(latestRun?.finished_at ?? "")
+      : portableExportedAt;
     const hasLatestRun =
       Number.isSafeInteger(latestRunId) &&
       latestRunId > 0 &&
@@ -1096,7 +1115,23 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
       ),
       this.repositoryTableMax("pull_request_details", "fetched_at"),
       this.repositoryTableMax("pull_request_files", "fetched_at"),
+      this.portableMetadata("exported_at"),
     );
+  }
+
+  private portableMetadata(key: string): string {
+    if (
+      !this.portable ||
+      !tableExists(this.db, "portable_metadata") ||
+      !columnExists(this.db, "portable_metadata", "key") ||
+      !columnExists(this.db, "portable_metadata", "value")
+    ) {
+      return "";
+    }
+    const value = this.db
+      .prepare("select value from portable_metadata where key = ?")
+      .get(key)?.value;
+    return typeof value === "string" ? value : "";
   }
 
   private enrichmentSelects(alias: string): string {
@@ -1576,6 +1611,12 @@ function localSourceSyncAt(db: DatabaseSync, repoId: number, repository: string)
   }
   const reconciled = completeOpenReconciliationAt(db, repoId);
   if (reconciled) candidates.push(reconciled);
+  if (candidates.length === 0 && tableExists(db, "portable_metadata")) {
+    const exportedAt = db
+      .prepare("select value from portable_metadata where key = 'exported_at'")
+      .get()?.value;
+    if (typeof exportedAt === "string") candidates.push(exportedAt);
+  }
   return latestTimestamp(...candidates);
 }
 

--- a/src/repair/gitcrawl-evidence-local.ts
+++ b/src/repair/gitcrawl-evidence-local.ts
@@ -1,0 +1,1349 @@
+import crypto from "node:crypto";
+import fs, { createReadStream } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync, type SQLOutputValue } from "node:sqlite";
+import {
+  GITCRAWL_QUERY_COVERAGE,
+  GITCRAWL_QUERY_CONTRACT_VERSION,
+  GITCRAWL_QUERY_NAMES,
+  type GitcrawlCoverageRow,
+  type GitcrawlQueryEnvelope,
+  type GitcrawlQueryName,
+  type GitcrawlQueryRequest,
+  type GitcrawlQuerySource,
+  gitcrawlQueryDigest,
+} from "./gitcrawl-evidence-contract.js";
+
+export type LocalGitcrawlQuerySourceOptions = {
+  dbPath: string;
+  repository: string;
+  allowLegacy: boolean;
+};
+
+export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
+  readonly provider = "local";
+  readonly legacy: boolean;
+
+  readonly snapshotId: string;
+
+  private readonly db: DatabaseSync;
+  private readonly tempDir: string;
+  private readonly repository: string;
+  private readonly repoId: number;
+  private readonly portable: boolean;
+  private readonly sourceSyncAt: string;
+  private readonly datasetGeneratedAt: string;
+  private readonly coverage: GitcrawlCoverageRow[];
+  private databaseClosed = false;
+  private cleanupComplete = false;
+  private closePromise: Promise<void> | undefined;
+
+  private constructor(input: {
+    db: DatabaseSync;
+    tempDir: string;
+    snapshotId: string;
+    repository: string;
+    repoId: number;
+    portable: boolean;
+    legacy: boolean;
+    sourceSyncAt: string;
+  }) {
+    this.db = input.db;
+    this.tempDir = input.tempDir;
+    this.snapshotId = input.snapshotId;
+    this.repository = input.repository;
+    this.repoId = input.repoId;
+    this.portable = input.portable;
+    this.legacy = input.legacy;
+    this.sourceSyncAt = input.sourceSyncAt;
+    this.datasetGeneratedAt = this.resolveDatasetGeneratedAt();
+    this.coverage = this.buildCoverage();
+  }
+
+  static async open(options: LocalGitcrawlQuerySourceOptions): Promise<LocalGitcrawlQuerySource> {
+    const dbPath = path.resolve(options.dbPath);
+    if (!fs.existsSync(dbPath)) throw new Error(`Gitcrawl database not found: ${dbPath}`);
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "clawsweeper-gitcrawl-"));
+    const snapshotPath = path.join(tempDir, "snapshot.db");
+    let source: DatabaseSync | undefined;
+    let snapshotDb: DatabaseSync | undefined;
+    try {
+      source = new DatabaseSync(dbPath, {
+        readOnly: true,
+        enableForeignKeyConstraints: false,
+        timeout: 5_000,
+      });
+      source.exec(`vacuum into ${sqliteString(snapshotPath)}`);
+      source.close();
+      source = undefined;
+      const snapshotId = `local:${await sha256File(snapshotPath)}`;
+      snapshotDb = new DatabaseSync(snapshotPath, {
+        readOnly: true,
+        enableForeignKeyConstraints: false,
+        timeout: 5_000,
+      });
+      const quickCheck = String(snapshotDb.prepare("pragma quick_check").get()?.quick_check ?? "");
+      if (quickCheck !== "ok")
+        throw new Error(`Gitcrawl snapshot quick_check failed: ${quickCheck}`);
+      const repoId = repositoryId(snapshotDb, options.repository);
+      const portableTable = tableExists(snapshotDb, "cluster_groups");
+      const legacyTable = tableExists(snapshotDb, "clusters");
+      const portableRows = portableTable
+        ? Number(
+            snapshotDb
+              .prepare("select count(*) as value from cluster_groups where repo_id = ?")
+              .get(repoId)?.value ?? 0,
+          )
+        : 0;
+      const legacyRows = legacyTable
+        ? Number(
+            snapshotDb
+              .prepare("select count(*) as value from clusters where repo_id = ?")
+              .get(repoId)?.value ?? 0,
+          )
+        : 0;
+      if (portableRows > 0 && legacyRows > 0) {
+        throw new Error(
+          "Gitcrawl snapshot has mixed populated cluster schemas; select one authoritative export before intake",
+        );
+      }
+      const portable = portableTable && (portableRows > 0 || legacyRows === 0);
+      const legacy = legacyTable && !portable;
+      if (!portable && !legacy) {
+        throw new Error("Gitcrawl snapshot has no supported cluster tables");
+      }
+      if (legacy && !options.allowLegacy) {
+        throw new Error(
+          "legacy Gitcrawl schema requires --allow-legacy-local after explicit coverage review",
+        );
+      }
+      const sourceSyncAt = localSourceSyncAt(snapshotDb, repoId, options.repository);
+      const opened = new LocalGitcrawlQuerySource({
+        db: snapshotDb,
+        tempDir,
+        snapshotId,
+        repository: options.repository,
+        repoId,
+        portable,
+        legacy,
+        sourceSyncAt,
+      });
+      snapshotDb = undefined;
+      return opened;
+    } catch (error) {
+      try {
+        source?.close();
+      } catch {}
+      try {
+        snapshotDb?.close();
+      } catch {}
+      await rm(tempDir, { force: true, recursive: true }).catch(() => undefined);
+      throw error;
+    }
+  }
+
+  async query(request: GitcrawlQueryRequest): Promise<GitcrawlQueryEnvelope> {
+    if (request.snapshot_id && request.snapshot_id !== this.snapshotId) {
+      throw new Error(
+        `local Gitcrawl snapshot mismatch: ${request.snapshot_id} != ${this.snapshotId}`,
+      );
+    }
+    const offset = decodeCursor(request.cursor, request.name, request.args, this.snapshotId);
+    if (request.name === "gitcrawl.clusters.list" || request.name === "gitcrawl.threads.search") {
+      const pageRows =
+        request.name === "gitcrawl.clusters.list"
+          ? this.clusterListRows(request.args, request.limit + 1, offset)
+          : this.threadSearchRows(request.args, request.limit + 1, offset);
+      const hasNext = pageRows.length > request.limit;
+      return this.envelope(
+        request.name,
+        request.args,
+        pageRows.slice(0, request.limit),
+        hasNext ? offset + request.limit : null,
+      );
+    }
+    const pageRows = this.queryRows(request.name, request.args, request.limit + 1, offset);
+    const hasNext = pageRows.length > request.limit;
+    return this.envelope(
+      request.name,
+      request.args,
+      pageRows.slice(0, request.limit),
+      hasNext ? offset + request.limit : null,
+    );
+  }
+
+  async close(): Promise<void> {
+    if (this.cleanupComplete) return;
+    if (this.closePromise !== undefined) return this.closePromise;
+    const closePromise = this.closeOnce();
+    this.closePromise = closePromise;
+    try {
+      await closePromise;
+    } finally {
+      if (this.closePromise === closePromise) this.closePromise = undefined;
+    }
+  }
+
+  private async closeOnce(): Promise<void> {
+    if (!this.databaseClosed) {
+      this.db.close();
+      this.databaseClosed = true;
+    }
+    await rm(this.tempDir, { force: true, recursive: true });
+    this.cleanupComplete = true;
+  }
+
+  private queryRows(
+    name: GitcrawlQueryName,
+    args: Record<string, unknown>,
+    limit = -1,
+    offset = 0,
+  ): Record<string, unknown>[] {
+    switch (name) {
+      case "gitcrawl.coverage":
+        return sliceRows(
+          this.coverage.filter(
+            (row) => !args.dataset || row.dataset === String(args.dataset),
+          ) as unknown as Record<string, unknown>[],
+          limit,
+          offset,
+        );
+      case "gitcrawl.clusters.list":
+        return this.clusterListRows(args, limit, offset);
+      case "gitcrawl.clusters.members":
+        return this.clusterMemberRows(
+          positiveInteger(args.cluster_id, "cluster_id"),
+          limit,
+          offset,
+        );
+      case "gitcrawl.clusters.related":
+        return this.relatedRows(positiveInteger(args.number, "number"), limit, offset);
+      case "gitcrawl.pull_requests.review_context":
+        return this.reviewContextRows(positiveInteger(args.number, "number"), limit, offset);
+      case "gitcrawl.threads.search":
+        return this.threadSearchRows(args, limit, offset);
+    }
+  }
+
+  private clusterListRows(
+    args: Record<string, unknown>,
+    limit = -1,
+    offset = 0,
+  ): Record<string, unknown>[] {
+    const status = String(args.status ?? "active");
+    const minSize = nonNegativeInteger(args.min_size, 1);
+    if (this.portable) {
+      const filters = ["cg.repo_id = ?"];
+      const binds: (string | number)[] = [this.repoId];
+      if (status !== "all") {
+        filters.push("cg.status = ?");
+        binds.push(status);
+      }
+      const having = ["count(mt.id) >= ?"];
+      const havingBinds: (string | number)[] = [minSize];
+      binds.push(...havingBinds, limit, offset);
+      return this.all(
+        `select cg.id as cluster_id, cg.stable_key, cg.stable_slug, cg.status,
+                cg.cluster_type, cg.title, cg.representative_thread_id,
+                rt.number as representative_number, rt.kind as representative_kind,
+                rt.state as representative_state, rt.title as representative_title,
+                count(mt.id) as member_count, cg.created_at, cg.updated_at, cg.closed_at
+         from cluster_groups cg
+         left join cluster_memberships cm on cm.cluster_id = cg.id and cm.state = 'active'
+         left join threads mt on mt.id = cm.thread_id and mt.repo_id = cg.repo_id
+         left join threads rt on rt.id = cg.representative_thread_id and rt.repo_id = cg.repo_id
+         where ${filters.join(" and ")}
+         group by cg.id
+         having ${having.join(" and ")}
+         order by member_count desc, julianday(cg.updated_at) desc, cg.id asc
+         limit ? offset ?`,
+        ...binds,
+      );
+    }
+    const filters = ["c.repo_id = ?", "c.member_count >= ?"];
+    const binds: (string | number)[] = [this.repoId, minSize];
+    const updatedAt = columnExists(this.db, "clusters", "updated_at")
+      ? "c.updated_at"
+      : "c.created_at";
+    if (status === "active") filters.push("c.closed_at_local is null");
+    if (status === "closed") filters.push("c.closed_at_local is not null");
+    binds.push(limit, offset);
+    return this.all(
+      `select c.id as cluster_id, '' as stable_key,
+              'legacy-' || c.id as stable_slug,
+              case when c.closed_at_local is null then 'active' else 'closed' end as status,
+              '' as cluster_type, rt.title as title, c.representative_thread_id,
+              rt.number as representative_number, rt.kind as representative_kind,
+              rt.state as representative_state, rt.title as representative_title,
+              c.member_count, c.created_at, ${updatedAt} as updated_at,
+              c.closed_at_local as closed_at
+       from clusters c
+       left join threads rt on rt.id = c.representative_thread_id and rt.repo_id = c.repo_id
+       where ${filters.join(" and ")}
+       order by c.member_count desc, julianday(${updatedAt}) desc, c.id asc
+       limit ? offset ?`,
+      ...binds,
+    );
+  }
+
+  private clusterMemberRows(clusterId: number, limit = -1, offset = 0): Record<string, unknown>[] {
+    const body = this.threadBody("t");
+    const labels = this.threadColumn("t", "labels_json", "null");
+    const assignees = this.threadColumn("t", "assignees_json", "null");
+    const association = this.threadColumn("t", "author_association", "null");
+    const authorLogin = this.threadColumn("t", "author_login", "''");
+    const authorType = this.threadColumn("t", "author_type", "''");
+    const htmlUrl = this.threadColumn("t", "html_url", "''");
+    const isDraft = this.threadColumn("t", "is_draft", "0");
+    const createdAtGh = this.threadColumn("t", "created_at_gh", "''");
+    const updatedAtGh = this.threadColumn("t", "updated_at_gh", "''");
+    const updatedAt = this.threadUpdatedAt("t");
+    const enrichment = this.enrichmentSelects("t");
+    const securityMetadataComplete = this.securityMetadataComplete();
+    if (this.portable) {
+      return this.all(
+        `select cg.id as cluster_id, cg.stable_slug, cg.status as cluster_status,
+                cm.role, cm.state as membership_state, cm.score_to_representative,
+                count(*) over () as cluster_member_count,
+                t.id as thread_id, t.number, t.kind, t.state, t.title,
+                ${body} as body, ${authorLogin} as author_login, ${authorType} as author_type,
+                ${association} as author_association, ${htmlUrl} as html_url,
+                ${labels} as labels_json, ${assignees} as assignees_json,
+                ${securityMetadataComplete} as security_metadata_complete,
+                ${isDraft} as is_draft, ${createdAtGh} as created_at_gh,
+                ${updatedAtGh} as updated_at_gh, ${updatedAt} as updated_at,
+                ${enrichment}
+         from cluster_groups cg
+         join cluster_memberships cm on cm.cluster_id = cg.id
+         join threads t on t.id = cm.thread_id and t.repo_id = cg.repo_id
+         where cg.repo_id = ? and cg.id = ? and cm.state = 'active'
+         order by case cm.role when 'canonical' then 0 when 'representative' then 1 else 2 end,
+                  coalesce(cm.score_to_representative, 0) desc, t.number asc
+         limit ? offset ?`,
+        this.repoId,
+        clusterId,
+        limit,
+        offset,
+      );
+    }
+    return this.all(
+      `select c.id as cluster_id, 'legacy-' || c.id as stable_slug,
+              case when c.closed_at_local is null then 'active' else 'closed' end as cluster_status,
+              case when c.representative_thread_id = t.id then 'representative' else 'member' end as role,
+              'active' as membership_state, null as score_to_representative,
+              count(*) over () as cluster_member_count,
+              t.id as thread_id, t.number, t.kind, t.state, t.title,
+              ${body} as body, ${authorLogin} as author_login, ${authorType} as author_type,
+              ${association} as author_association, ${htmlUrl} as html_url,
+              ${labels} as labels_json, ${assignees} as assignees_json,
+              ${securityMetadataComplete} as security_metadata_complete,
+              ${isDraft} as is_draft, ${createdAtGh} as created_at_gh,
+              ${updatedAtGh} as updated_at_gh, ${updatedAt} as updated_at,
+              ${enrichment}
+       from clusters c
+       join cluster_members cm on cm.cluster_id = c.id
+       join threads t on t.id = cm.thread_id and t.repo_id = c.repo_id
+       where c.repo_id = ? and c.id = ?
+       order by case when c.representative_thread_id = t.id then 0 else 1 end, t.number asc
+       limit ? offset ?`,
+      this.repoId,
+      clusterId,
+      limit,
+      offset,
+    );
+  }
+
+  private relatedRows(number: number, limit: number, offset: number): Record<string, unknown>[] {
+    const membershipTable = this.portable ? "cluster_memberships" : "cluster_members";
+    const stateFilter = this.portable ? "and cm.state = 'active'" : "";
+    const rows: Record<string, unknown>[] = [];
+    let remainingOffset = offset;
+    const clusters = this.db
+      .prepare(
+        `select cm.cluster_id
+         from ${membershipTable} cm
+         join threads t on t.id = cm.thread_id
+         where t.repo_id = ? and t.number = ? ${stateFilter}
+         order by cm.cluster_id`,
+      )
+      .iterate(this.repoId, number);
+    for (const rawCluster of clusters) {
+      const clusterId = Number(rawCluster.cluster_id);
+      let memberOffset = 0;
+      while (rows.length < limit) {
+        const members = this.clusterMemberRows(clusterId, Math.min(128, limit + 1), memberOffset);
+        if (members.length === 0) break;
+        for (const member of members) {
+          if (Number(member.number) === number) continue;
+          if (remainingOffset > 0) {
+            remainingOffset -= 1;
+            continue;
+          }
+          rows.push({ source_number: number, ...member });
+          if (rows.length >= limit) break;
+        }
+        memberOffset += members.length;
+        if (members.length < Math.min(128, limit + 1)) break;
+      }
+      if (rows.length >= limit) break;
+    }
+    return rows;
+  }
+
+  private reviewContextRows(
+    number: number,
+    limit: number,
+    offset: number,
+  ): Record<string, unknown>[] {
+    if (!tableExists(this.db, "pull_request_details")) return [];
+    const body = this.threadBody("t");
+    const labels = this.threadColumn("t", "labels_json", "null");
+    const assignees = this.threadColumn("t", "assignees_json", "null");
+    const association = this.threadColumn("t", "author_association", "null");
+    const authorLogin = this.threadColumn("t", "author_login", "''");
+    const authorType = this.threadColumn("t", "author_type", "''");
+    const htmlUrl = this.threadColumn("t", "html_url", "''");
+    const isDraft = this.threadColumn("t", "is_draft", "0");
+    const createdAtGh = this.threadColumn("t", "created_at_gh", "''");
+    const updatedAtGh = this.threadColumn("t", "updated_at_gh", "''");
+    const mergedAtGh = this.threadColumn("t", "merged_at_gh", "''");
+    const enrichment = this.enrichmentSelects("t");
+    const securityMetadataComplete = this.securityMetadataComplete();
+    const clusterContext = this.reviewClusterContext();
+    const detailsFetchedAt = this.tableColumn("pull_request_details", "pr", "fetched_at", "''");
+    const detailsUpdatedAt = this.tableColumn("pull_request_details", "pr", "updated_at", "''");
+    const context = this.all(
+      `select 'context' as row_kind, t.id as thread_id, t.number, t.kind, t.state, t.title,
+              ${body} as body, ${authorLogin} as author_login, ${authorType} as author_type,
+              ${association} as author_association, ${htmlUrl} as html_url,
+              ${labels} as labels_json, ${assignees} as assignees_json,
+              ${securityMetadataComplete} as security_metadata_complete,
+              ${isDraft} as is_draft, ${createdAtGh} as created_at_gh,
+              ${updatedAtGh} as updated_at_gh, ${mergedAtGh} as merged_at_gh,
+              pr.base_sha, pr.head_sha, pr.head_ref, pr.head_repo_full_name,
+              pr.mergeable_state, pr.additions, pr.deletions, pr.changed_files,
+              ${detailsFetchedAt} as details_fetched_at,
+              ${detailsUpdatedAt} as details_updated_at,
+              ${clusterContext.select},
+              ${enrichment}
+       from threads t
+       left join pull_request_details pr on pr.thread_id = t.id
+       ${clusterContext.joins}
+       where t.repo_id = ? and t.number = ? and t.kind = 'pull_request'
+       limit 1`,
+      this.repoId,
+      number,
+    );
+    if (context.length === 0) return [];
+    const threadId = Number(context[0]!.thread_id);
+    const returnedContext = offset === 0 ? context : [];
+    const fileLimit = Math.max(0, limit - returnedContext.length);
+    const files =
+      tableExists(this.db, "pull_request_files") && fileLimit > 0
+        ? this.all(
+            `select 'file' as row_kind, thread_id, position as file_position,
+                  path as file_path, status as file_status,
+                  additions as file_additions, deletions as file_deletions,
+                  changes as file_changes, previous_path as file_previous_path,
+                  fetched_at as file_fetched_at
+           from pull_request_files
+           where thread_id = ?
+           order by position
+           limit ? offset ?`,
+            threadId,
+            fileLimit,
+            Math.max(0, offset - 1),
+          )
+        : [];
+    return [...returnedContext, ...files];
+  }
+
+  private threadSearchRows(
+    args: Record<string, unknown>,
+    limit = -1,
+    offset = 0,
+  ): Record<string, unknown>[] {
+    const body = this.threadBody("t");
+    const labels = this.threadColumn("t", "labels_json", "null");
+    const assignees = this.threadColumn("t", "assignees_json", "null");
+    const association = this.threadColumn("t", "author_association", "null");
+    const authorLogin = this.threadColumn("t", "author_login", "''");
+    const authorType = this.threadColumn("t", "author_type", "''");
+    const htmlUrl = this.threadColumn("t", "html_url", "''");
+    const isDraft = this.threadColumn("t", "is_draft", "0");
+    const createdAtGh = this.threadColumn("t", "created_at_gh", "''");
+    const updatedAtGh = this.threadColumn("t", "updated_at_gh", "''");
+    const closedAtGh = this.threadColumn("t", "closed_at_gh", "''");
+    const mergedAtGh = this.threadColumn("t", "merged_at_gh", "''");
+    const enrichment = this.enrichmentSelects("t");
+    const securityMetadataComplete = this.securityMetadataComplete();
+    const filters = ["t.repo_id = ?"];
+    const binds: (string | number)[] = [this.repoId];
+    const query = String(args.query ?? "")
+      .trim()
+      .toLowerCase();
+    if (query) {
+      filters.push(`(lower(t.title) like ? escape '\\' or lower(${body}) like ? escape '\\')`);
+      const pattern = `%${query.replaceAll("\\", "\\\\").replaceAll("%", "\\%").replaceAll("_", "\\_")}%`;
+      binds.push(pattern, pattern);
+    }
+    const kind = String(args.kind ?? "");
+    if (kind) {
+      filters.push("t.kind = ?");
+      binds.push(kind);
+    }
+    const state = String(args.state ?? "");
+    if (state && state !== "all") {
+      filters.push("t.state = ?");
+      binds.push(state);
+    }
+    const order = String(args.order ?? "newest");
+    if (!["newest", "oldest"].includes(order)) {
+      throw new Error("Gitcrawl thread search order must be newest or oldest");
+    }
+    const direction = order === "oldest" ? "asc" : "desc";
+    const updatedAt = this.threadUpdatedAt("t");
+    binds.push(limit, offset);
+    return this.all(
+      `select t.id as thread_id, t.number, t.kind, t.state, t.title, ${body} as body,
+              ${authorLogin} as author_login, ${authorType} as author_type,
+              ${association} as author_association, ${htmlUrl} as html_url,
+              ${labels} as labels_json, ${assignees} as assignees_json,
+              ${securityMetadataComplete} as security_metadata_complete,
+              ${isDraft} as is_draft, ${createdAtGh} as created_at_gh,
+              ${updatedAtGh} as updated_at_gh, ${closedAtGh} as closed_at_gh,
+              ${mergedAtGh} as merged_at_gh, ${updatedAt} as updated_at,
+              ${enrichment}
+       from threads t
+       where ${filters.join(" and ")}
+       order by julianday(${updatedAt}) ${direction}, t.number ${direction}
+       limit ? offset ?`,
+      ...binds,
+    );
+  }
+
+  private buildCoverage(): GitcrawlCoverageRow[] {
+    const rows: GitcrawlCoverageRow[] = [];
+    const generatedAt = this.datasetGeneratedAt;
+    const repoCount = this.scalarNumber(
+      "select count(*) as value from repositories where id = ?",
+      this.repoId,
+    );
+    const threadCount = this.scalarNumber(
+      "select count(*) as value from threads where repo_id = ?",
+      this.repoId,
+    );
+    rows.push(
+      metric("repositories", repoCount, repoCount, repoCount, this.sourceSyncAt, generatedAt),
+    );
+    rows.push(
+      metric("threads", threadCount, threadCount, threadCount, this.sourceSyncAt, generatedAt),
+    );
+
+    const revisions = this.threadChildCoverage("thread_revisions", "");
+    rows.push(
+      metric(
+        "thread_revisions",
+        revisions.rows,
+        threadCount,
+        revisions.covered,
+        revisions.latest,
+        generatedAt,
+      ),
+    );
+    const fingerprints = this.threadRevisionChildCoverage(
+      "thread_fingerprints",
+      "and child.algorithm_version = 'thread-fingerprint-v2'",
+    );
+    rows.push(
+      metric(
+        "thread_fingerprints",
+        fingerprints.rows,
+        threadCount,
+        fingerprints.covered,
+        fingerprints.latest,
+        generatedAt,
+      ),
+    );
+    const summaries = this.threadRevisionChildCoverage("thread_key_summaries", "");
+    rows.push(
+      metric(
+        "thread_key_summaries",
+        summaries.rows,
+        threadCount,
+        summaries.covered,
+        summaries.latest,
+        generatedAt,
+      ),
+    );
+
+    const clusterTable = this.portable ? "cluster_groups" : "clusters";
+    const membershipTable = this.portable ? "cluster_memberships" : "cluster_members";
+    const membershipWhere = this.portable ? "cm.state = 'active'" : "1 = 1";
+    const clusterRows = tableExists(this.db, clusterTable)
+      ? this.scalarNumber(
+          `select count(*) as value from ${clusterTable} where repo_id = ?`,
+          this.repoId,
+        )
+      : 0;
+    const clusterCovered = tableExists(this.db, membershipTable)
+      ? this.scalarNumber(
+          `select count(*) as value
+             from ${clusterTable} c
+             where c.repo_id = ?
+               and not exists (
+                 select 1
+                 from ${membershipTable} cm
+                 left join threads t on t.id = cm.thread_id and t.repo_id = c.repo_id
+                 where cm.cluster_id = c.id and ${membershipWhere}
+                   and t.id is null
+               )`,
+          this.repoId,
+        )
+      : 0;
+    rows.push(
+      metric(
+        "cluster_groups",
+        clusterRows,
+        clusterRows,
+        clusterCovered,
+        this.repositoryTableMax(
+          clusterTable,
+          columnExists(this.db, clusterTable, "updated_at") ? "updated_at" : "created_at",
+        ),
+        generatedAt,
+      ),
+    );
+    const membershipRows = tableExists(this.db, membershipTable)
+      ? this.scalarNumber(
+          `select count(*) as value
+           from ${membershipTable} cm
+           join ${clusterTable} c on c.id = cm.cluster_id
+           where c.repo_id = ? and ${membershipWhere}`,
+          this.repoId,
+        )
+      : 0;
+    const membershipCovered = tableExists(this.db, membershipTable)
+      ? this.scalarNumber(
+          `select count(*) as value
+           from ${membershipTable} cm
+           join ${clusterTable} c on c.id = cm.cluster_id
+           join threads t on t.id = cm.thread_id and t.repo_id = c.repo_id
+           where c.repo_id = ? and ${membershipWhere}`,
+          this.repoId,
+        )
+      : 0;
+    rows.push(
+      metric(
+        "cluster_memberships",
+        membershipRows,
+        membershipRows,
+        membershipCovered,
+        this.repositoryTableMax(
+          membershipTable,
+          columnExists(this.db, membershipTable, "updated_at") ? "updated_at" : "created_at",
+        ),
+        generatedAt,
+      ),
+    );
+
+    const prEligible = this.scalarNumber(
+      "select count(*) as value from threads where repo_id = ? and kind = 'pull_request'",
+      this.repoId,
+    );
+    const prRows = tableExists(this.db, "pull_request_details")
+      ? this.scalarNumber(
+          `select count(*) as value
+           from pull_request_details pr
+           join threads t on t.id = pr.thread_id
+           where t.repo_id = ?`,
+          this.repoId,
+        )
+      : 0;
+    const prFreshness = this.pullRequestFreshness("pr");
+    const prCovered =
+      tableExists(this.db, "pull_request_details") && prFreshness !== "''"
+        ? this.scalarNumber(
+            `select count(*) as value
+           from pull_request_details pr
+           join threads t on t.id = pr.thread_id
+           where t.repo_id = ?
+             and julianday(${prFreshness})
+                 >= julianday(${this.threadUpdatedAt("t")})`,
+            this.repoId,
+          )
+        : 0;
+    rows.push(
+      metric(
+        "pull_request_details",
+        prRows,
+        prEligible,
+        prCovered,
+        this.repositoryTableMax("pull_request_details", "fetched_at"),
+        generatedAt,
+      ),
+    );
+    const hasChangedFiles =
+      tableExists(this.db, "pull_request_details") &&
+      columnExists(this.db, "pull_request_details", "changed_files");
+    const fileEligible = hasChangedFiles
+      ? this.scalarNumber(
+          `select coalesce(sum(pr.changed_files), 0) as value
+           from pull_request_details pr
+           join threads t on t.id = pr.thread_id
+           where t.repo_id = ?`,
+          this.repoId,
+        )
+      : 0;
+    const fileRows = tableExists(this.db, "pull_request_files")
+      ? this.scalarNumber(
+          `select count(*) as value
+           from pull_request_files pf
+           join threads t on t.id = pf.thread_id
+           where t.repo_id = ?`,
+          this.repoId,
+        )
+      : 0;
+    const fileCovered =
+      tableExists(this.db, "pull_request_files") &&
+      tableExists(this.db, "pull_request_details") &&
+      hasChangedFiles &&
+      columnExists(this.db, "pull_request_files", "position") &&
+      columnExists(this.db, "pull_request_files", "fetched_at") &&
+      prFreshness !== "''"
+        ? this.scalarNumber(
+            `select coalesce(sum(pr.changed_files), 0) as value
+             from pull_request_details pr
+             join threads t on t.id = pr.thread_id
+             where t.repo_id = ?
+               and (
+                 select count(*)
+                 from pull_request_files pf
+                 where pf.thread_id = pr.thread_id
+               ) = pr.changed_files
+               and (
+                 select count(distinct pf.position)
+                 from pull_request_files pf
+                 where pf.thread_id = pr.thread_id
+               ) = pr.changed_files
+               and (
+                 pr.changed_files = 0 or (
+                   select min(pf.position) = 0 and max(pf.position) = pr.changed_files - 1
+                   from pull_request_files pf
+                   where pf.thread_id = pr.thread_id
+                 )
+               )
+               and julianday(${prFreshness}) is not null
+               and not exists (
+                 select 1
+                 from pull_request_files pf
+                 where pf.thread_id = pr.thread_id
+                   and (
+                     julianday(pf.fetched_at) is null
+                     or julianday(pf.fetched_at)
+                        < julianday(${prFreshness})
+                   )
+               )`,
+            this.repoId,
+          )
+        : 0;
+    const fileCoverage = metric(
+      "pull_request_files",
+      fileRows,
+      fileEligible,
+      fileCovered,
+      this.repositoryTableMax("pull_request_files", "fetched_at"),
+      generatedAt,
+    );
+    fileCoverage.complete =
+      hasChangedFiles &&
+      columnExists(this.db, "pull_request_files", "position") &&
+      columnExists(this.db, "pull_request_files", "fetched_at") &&
+      prFreshness !== "''" &&
+      fileRows === fileEligible &&
+      fileCovered === fileEligible;
+    rows.push(fileCoverage);
+    return rows;
+  }
+
+  private threadChildCoverage(
+    table: string,
+    condition: string,
+  ): { rows: number; covered: number; latest: string } {
+    if (!tableExists(this.db, table)) return { rows: 0, covered: 0, latest: "" };
+    const rows = this.scalarNumber(
+      `select count(*) as value
+       from ${table} child join threads t on t.id = child.thread_id
+       where t.repo_id = ? ${condition}`,
+      this.repoId,
+    );
+    const covered = this.scalarNumber(
+      `select count(*) as value
+       from threads t
+       where t.repo_id = ? and exists (
+         select 1 from ${table} child
+         where child.thread_id = t.id ${condition}
+           and julianday(coalesce(nullif(child.source_updated_at, ''), child.created_at))
+               >= julianday(${this.threadUpdatedAt("t")})
+       )`,
+      this.repoId,
+    );
+    return { rows, covered, latest: this.repositoryTableMax(table, "created_at") };
+  }
+
+  private threadRevisionChildCoverage(
+    table: string,
+    condition: string,
+  ): { rows: number; covered: number; latest: string } {
+    if (!tableExists(this.db, table) || !tableExists(this.db, "thread_revisions")) {
+      return { rows: 0, covered: 0, latest: "" };
+    }
+    const rows = this.scalarNumber(
+      `select count(*) as value
+       from ${table} child
+       join thread_revisions revision on revision.id = child.thread_revision_id
+       join threads t on t.id = revision.thread_id
+       where t.repo_id = ? ${condition}`,
+      this.repoId,
+    );
+    const covered = this.scalarNumber(
+      `select count(*) as value
+       from threads t
+       where t.repo_id = ? and exists (
+         select 1
+         from thread_revisions revision
+         join ${table} child on child.thread_revision_id = revision.id
+         where revision.thread_id = t.id ${condition}
+           and julianday(coalesce(nullif(revision.source_updated_at, ''), revision.created_at))
+               >= julianday(${this.threadUpdatedAt("t")})
+       )`,
+      this.repoId,
+    );
+    return { rows, covered, latest: this.repositoryTableMax(table, "created_at") };
+  }
+
+  private resolveDatasetGeneratedAt(): string {
+    return latestTimestamp(
+      this.sourceSyncAt,
+      this.repositoryTableMax("thread_revisions", "created_at"),
+      this.repositoryTableMax("thread_fingerprints", "created_at"),
+      this.repositoryTableMax("thread_key_summaries", "created_at"),
+      this.repositoryTableMax(
+        this.portable ? "cluster_groups" : "clusters",
+        columnExists(this.db, this.portable ? "cluster_groups" : "clusters", "updated_at")
+          ? "updated_at"
+          : "created_at",
+      ),
+      this.repositoryTableMax("pull_request_details", "fetched_at"),
+      this.repositoryTableMax("pull_request_files", "fetched_at"),
+    );
+  }
+
+  private enrichmentSelects(alias: string): string {
+    if (!tableExists(this.db, "thread_revisions")) {
+      return `null as revision_id, '' as revision_content_hash,
+              '' as revision_source_updated_at, '' as key_summary,
+              '' as fingerprint_algorithm, '' as fingerprint_hash, '' as fingerprint_slug`;
+    }
+    const latestRevision = `(select revision.id from thread_revisions revision
+      where revision.thread_id = ${alias}.id
+      order by julianday(coalesce(nullif(revision.source_updated_at, ''), revision.created_at)) desc,
+               revision.id desc limit 1)`;
+    const revisionId = latestRevision;
+    const revisionHash = `(select revision.content_hash from thread_revisions revision
+      where revision.id = ${latestRevision})`;
+    const revisionUpdated = `(select coalesce(nullif(revision.source_updated_at, ''), revision.created_at)
+      from thread_revisions revision
+      where revision.id = ${latestRevision})`;
+    const summary = tableExists(this.db, "thread_key_summaries")
+      ? `(select summary.key_text from thread_key_summaries summary
+          where summary.thread_revision_id = ${latestRevision}
+          order by summary.created_at desc, summary.id desc limit 1)`
+      : "''";
+    const fingerprintAlgorithm = tableExists(this.db, "thread_fingerprints")
+      ? `(select fingerprint.algorithm_version from thread_fingerprints fingerprint
+          where fingerprint.thread_revision_id = ${latestRevision}
+            and fingerprint.algorithm_version = 'thread-fingerprint-v2'
+          order by fingerprint.created_at desc, fingerprint.id desc limit 1)`
+      : "''";
+    const fingerprintHash = tableExists(this.db, "thread_fingerprints")
+      ? `(select fingerprint.fingerprint_hash from thread_fingerprints fingerprint
+          where fingerprint.thread_revision_id = ${latestRevision}
+            and fingerprint.algorithm_version = 'thread-fingerprint-v2'
+          order by fingerprint.created_at desc, fingerprint.id desc limit 1)`
+      : "''";
+    const fingerprintSlug = tableExists(this.db, "thread_fingerprints")
+      ? `(select fingerprint.fingerprint_slug from thread_fingerprints fingerprint
+          where fingerprint.thread_revision_id = ${latestRevision}
+            and fingerprint.algorithm_version = 'thread-fingerprint-v2'
+          order by fingerprint.created_at desc, fingerprint.id desc limit 1)`
+      : "''";
+    return `${revisionId} as revision_id,
+            ${revisionHash} as revision_content_hash,
+            ${revisionUpdated} as revision_source_updated_at,
+            ${summary} as key_summary,
+            ${fingerprintAlgorithm} as fingerprint_algorithm,
+            ${fingerprintHash} as fingerprint_hash,
+            ${fingerprintSlug} as fingerprint_slug`;
+  }
+
+  private threadColumn(alias: string, column: string, fallback: string): string {
+    return columnExists(this.db, "threads", column) ? `${alias}.${column}` : fallback;
+  }
+
+  private threadBody(alias: string): string {
+    if (columnExists(this.db, "threads", "body")) return `coalesce(${alias}.body, '')`;
+    if (columnExists(this.db, "threads", "body_excerpt")) {
+      return `coalesce(${alias}.body_excerpt, '')`;
+    }
+    return "''";
+  }
+
+  private tableColumn(table: string, alias: string, column: string, fallback: string): string {
+    return columnExists(this.db, table, column) ? `${alias}.${column}` : fallback;
+  }
+
+  private pullRequestFreshness(alias: string): string {
+    const candidates = ["fetched_at", "updated_at"]
+      .filter((column) => columnExists(this.db, "pull_request_details", column))
+      .map((column) => `nullif(${alias}.${column}, '')`);
+    return candidates.length === 0 ? "''" : `coalesce(${candidates.join(", ")}, '')`;
+  }
+
+  private reviewClusterContext(): { select: string; joins: string } {
+    if (this.portable) {
+      return {
+        select: `cg.id as cluster_id, cg.stable_slug as cluster_slug,
+                 cg.title as cluster_title, cg.status as cluster_status,
+                 cm.role as cluster_role, cm.score_to_representative`,
+        joins: `left join cluster_memberships cm
+                  on cm.thread_id = t.id and cm.state = 'active' and cm.cluster_id = (
+                    select candidate.cluster_id
+                    from cluster_memberships candidate
+                    join cluster_groups candidate_group on candidate_group.id = candidate.cluster_id
+                    where candidate.thread_id = t.id and candidate.state = 'active'
+                      and candidate_group.repo_id = t.repo_id
+                    order by case candidate.role
+                               when 'canonical' then 0
+                               when 'representative' then 1
+                               else 2
+                             end,
+                             candidate.cluster_id
+                    limit 1
+                  )
+                left join cluster_groups cg
+                  on cg.id = cm.cluster_id and cg.repo_id = t.repo_id`,
+      };
+    }
+    return {
+      select: `c.id as cluster_id, 'legacy-' || c.id as cluster_slug,
+               rt.title as cluster_title,
+               case when c.closed_at_local is null then 'active' else 'closed' end as cluster_status,
+               case when c.representative_thread_id = t.id
+                    then 'representative' else 'member' end as cluster_role,
+               cm.score_to_representative`,
+      joins: `left join cluster_members cm
+                on cm.thread_id = t.id and cm.cluster_id = (
+                  select candidate.cluster_id
+                  from cluster_members candidate
+                  join clusters candidate_cluster on candidate_cluster.id = candidate.cluster_id
+                  where candidate.thread_id = t.id and candidate_cluster.repo_id = t.repo_id
+                  order by case when candidate_cluster.representative_thread_id = t.id
+                                then 0 else 1 end,
+                           candidate.cluster_id
+                  limit 1
+                )
+              left join clusters c on c.id = cm.cluster_id and c.repo_id = t.repo_id
+              left join threads rt
+                on rt.id = c.representative_thread_id and rt.repo_id = c.repo_id`,
+    };
+  }
+
+  private securityMetadataComplete(): number {
+    return columnExists(this.db, "threads", "title") &&
+      columnExists(this.db, "threads", "body") &&
+      columnExists(this.db, "threads", "labels_json")
+      ? 1
+      : 0;
+  }
+
+  private queryCoverageComplete(name: GitcrawlQueryName): boolean {
+    const coverage = new Map(this.coverage.map((row) => [row.dataset, row.complete]));
+    return GITCRAWL_QUERY_COVERAGE[name].every((dataset) => coverage.get(dataset) === true);
+  }
+
+  private envelope(
+    name: GitcrawlQueryName,
+    args: Record<string, unknown>,
+    rows: Record<string, unknown>[],
+    nextOffset: number | null,
+  ): GitcrawlQueryEnvelope {
+    const columns: string[] = [];
+    const seenColumns = new Set<string>();
+    for (const row of rows) {
+      for (const column of Object.keys(row)) {
+        if (seenColumns.has(column)) continue;
+        seenColumns.add(column);
+        columns.push(column);
+      }
+    }
+    return {
+      columns,
+      rows: rows.map((row) => columns.map((column) => row[column])),
+      values: rows,
+      snapshot: {
+        id: this.snapshotId,
+        source_sha256: this.snapshotId.slice("local:".length),
+        schema_name: this.portable ? "gitcrawl-portable-sqlite" : "gitcrawl-legacy-sqlite",
+        schema_version: Number(this.db.prepare("pragma user_version").get()?.user_version ?? 0),
+        schema_hash: this.portable ? "gitcrawl-portable-sqlite" : "gitcrawl-legacy-sqlite",
+        capabilities: [...GITCRAWL_QUERY_NAMES],
+        source_sync_at: this.sourceSyncAt,
+        dataset_generated_at: this.datasetGeneratedAt,
+        coverage_complete: this.queryCoverageComplete(name),
+        published_at: this.datasetGeneratedAt,
+        cutover_at: this.datasetGeneratedAt,
+      },
+      stats: {
+        contract_version: GITCRAWL_QUERY_CONTRACT_VERSION,
+        repository: this.repository,
+        archive: "local-sqlite",
+        snapshot_id: this.snapshotId,
+        source_sync_at: this.sourceSyncAt,
+        dataset_generated_at: this.datasetGeneratedAt,
+        coverage_complete: this.queryCoverageComplete(name),
+        next_cursor:
+          nextOffset === null ? "" : encodeCursor(name, args, this.snapshotId, nextOffset),
+      },
+    };
+  }
+
+  private threadUpdatedAt(alias: string): string {
+    const candidates = ["updated_at_gh", "updated_at", "last_pulled_at"]
+      .filter((column) => columnExists(this.db, "threads", column))
+      .map((column) => `nullif(${alias}.${column}, '')`);
+    if (candidates.length === 0) return sqliteString(this.sourceSyncAt);
+    return `coalesce(${candidates.join(", ")}, '')`;
+  }
+
+  private repositoryTableMax(table: string, column: string): string {
+    if (!tableExists(this.db, table) || !columnExists(this.db, table, column)) return "";
+    const sources: Record<string, { from: string; where: string }> = {
+      repositories: { from: "repositories source", where: "source.id = ?" },
+      threads: { from: "threads source", where: "source.repo_id = ?" },
+      thread_revisions: {
+        from: "thread_revisions source join threads t on t.id = source.thread_id",
+        where: "t.repo_id = ?",
+      },
+      thread_fingerprints: {
+        from: `thread_fingerprints source
+               join thread_revisions revision on revision.id = source.thread_revision_id
+               join threads t on t.id = revision.thread_id`,
+        where: "t.repo_id = ?",
+      },
+      thread_key_summaries: {
+        from: `thread_key_summaries source
+               join thread_revisions revision on revision.id = source.thread_revision_id
+               join threads t on t.id = revision.thread_id`,
+        where: "t.repo_id = ?",
+      },
+      cluster_groups: { from: "cluster_groups source", where: "source.repo_id = ?" },
+      clusters: { from: "clusters source", where: "source.repo_id = ?" },
+      cluster_memberships: {
+        from: "cluster_memberships source join cluster_groups c on c.id = source.cluster_id",
+        where: "c.repo_id = ?",
+      },
+      cluster_members: {
+        from: "cluster_members source join clusters c on c.id = source.cluster_id",
+        where: "c.repo_id = ?",
+      },
+      pull_request_details: {
+        from: "pull_request_details source join threads t on t.id = source.thread_id",
+        where: "t.repo_id = ?",
+      },
+      pull_request_files: {
+        from: "pull_request_files source join threads t on t.id = source.thread_id",
+        where: "t.repo_id = ?",
+      },
+    };
+    const source = sources[table];
+    if (!source) throw new Error(`unsupported Gitcrawl repository-scoped table: ${table}`);
+    return String(
+      this.db
+        .prepare(`select max(source.${column}) as value from ${source.from} where ${source.where}`)
+        .get(this.repoId)?.value ?? "",
+    );
+  }
+
+  private scalarNumber(sql: string, ...params: (string | number)[]): number {
+    return Number(this.db.prepare(sql).get(...params)?.value ?? 0);
+  }
+
+  private all(sql: string, ...params: (string | number)[]): Record<string, unknown>[] {
+    return this.db
+      .prepare(sql)
+      .all(...params)
+      .map(normalizeSqliteRow);
+  }
+}
+
+function metric(
+  dataset: GitcrawlCoverageRow["dataset"],
+  rowCount: number,
+  eligibleCount: number,
+  coveredCount: number,
+  maxSourceAt: string,
+  generatedAt: string,
+): GitcrawlCoverageRow {
+  return {
+    dataset,
+    row_count: rowCount,
+    eligible_count: eligibleCount,
+    covered_count: coveredCount,
+    max_source_at: maxSourceAt,
+    dataset_generated_at: generatedAt,
+    complete: eligibleCount === coveredCount,
+  };
+}
+
+function sliceRows(
+  rows: Record<string, unknown>[],
+  limit: number,
+  offset: number,
+): Record<string, unknown>[] {
+  return limit < 0 ? rows.slice(offset) : rows.slice(offset, offset + limit);
+}
+
+function repositoryId(db: DatabaseSync, repository: string): number {
+  let row: Record<string, SQLOutputValue> | undefined;
+  if (columnExists(db, "repositories", "full_name")) {
+    row = db.prepare("select id from repositories where full_name = ?").get(repository);
+  } else {
+    const [owner, name] = repository.split("/", 2);
+    row = db.prepare("select id from repositories where owner = ? and name = ?").get(owner!, name!);
+  }
+  const id = Number(row?.id ?? 0);
+  if (!Number.isSafeInteger(id) || id <= 0) {
+    throw new Error(`Gitcrawl repository not found in snapshot: ${repository}`);
+  }
+  return id;
+}
+
+function sqliteString(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+async function sha256File(filePath: string): Promise<string> {
+  const hash = crypto.createHash("sha256");
+  for await (const chunk of createReadStream(filePath)) hash.update(chunk);
+  return hash.digest("hex");
+}
+
+function localSourceSyncAt(db: DatabaseSync, repoId: number, repository: string): string {
+  const candidates: string[] = [];
+  if (
+    tableExists(db, "sync_runs") &&
+    columnExists(db, "sync_runs", "repo_id") &&
+    columnExists(db, "sync_runs", "started_at") &&
+    columnExists(db, "sync_runs", "finished_at") &&
+    columnExists(db, "sync_runs", "scope") &&
+    columnExists(db, "sync_runs", "status") &&
+    columnExists(db, "sync_runs", "stats_json")
+  ) {
+    const runs = db
+      .prepare(
+        `select scope, status, started_at, finished_at, stats_json
+         from sync_runs
+         where repo_id = ?
+           and status in ('success', 'completed', 'complete')
+           and scope in ('open', 'all')`,
+      )
+      .iterate(repoId);
+    for (const run of runs) {
+      const finished = trustworthyRepositorySyncAt(run, repository);
+      if (finished) candidates.push(finished);
+    }
+  }
+  const reconciled = completeOpenReconciliationAt(db, repoId);
+  if (reconciled) candidates.push(reconciled);
+  return latestTimestamp(...candidates);
+}
+
+function trustworthyRepositorySyncAt(
+  run: Record<string, SQLOutputValue>,
+  repository: string,
+): string {
+  if (run.scope !== "open" && run.scope !== "all") return "";
+  if (!["success", "completed", "complete"].includes(String(run.status ?? ""))) return "";
+  if (
+    typeof run.started_at !== "string" ||
+    typeof run.finished_at !== "string" ||
+    typeof run.stats_json !== "string"
+  ) {
+    return "";
+  }
+  const startedAt = Date.parse(run.started_at);
+  const finishedAt = Date.parse(run.finished_at);
+  if (!Number.isFinite(startedAt) || !Number.isFinite(finishedAt) || finishedAt < startedAt) {
+    return "";
+  }
+  let stats: unknown;
+  try {
+    stats = JSON.parse(run.stats_json);
+  } catch {
+    return "";
+  }
+  if (typeof stats !== "object" || stats === null || Array.isArray(stats)) return "";
+  const value = stats as Record<string, unknown>;
+  if (
+    value.repository !== repository ||
+    value.metadata_only !== false ||
+    typeof value.started_at !== "string" ||
+    typeof value.finished_at !== "string" ||
+    Date.parse(value.started_at) !== startedAt ||
+    Date.parse(value.finished_at) !== finishedAt
+  ) {
+    return "";
+  }
+  if (
+    (value.requested_since !== undefined && value.requested_since !== "") ||
+    (value.limit !== undefined && value.limit !== 0) ||
+    (value.numbers !== undefined && (!Array.isArray(value.numbers) || value.numbers.length !== 0))
+  ) {
+    return "";
+  }
+  return run.finished_at;
+}
+
+function completeOpenReconciliationAt(db: DatabaseSync, repoId: number): string {
+  const columns = [
+    "last_full_open_scan_started_at",
+    "last_overlapping_open_scan_completed_at",
+    "last_non_overlapping_scan_completed_at",
+    "last_open_close_reconciled_at",
+  ] as const;
+  if (
+    !tableExists(db, "repo_sync_state") ||
+    !columnExists(db, "repo_sync_state", "repo_id") ||
+    !columns.every((column) => columnExists(db, "repo_sync_state", column))
+  ) {
+    return "";
+  }
+  const row = db
+    .prepare(
+      `select ${columns.join(", ")}
+       from repo_sync_state
+       where repo_id = ?`,
+    )
+    .get(repoId);
+  if (!row) return "";
+  const timestamps = columns.map((column) => (typeof row[column] === "string" ? row[column] : ""));
+  const parsed = timestamps.map((timestamp) => Date.parse(timestamp));
+  if (parsed.some((timestamp) => !Number.isFinite(timestamp))) return "";
+  const [startedAt, ...completedAt] = parsed;
+  if (completedAt.some((timestamp) => timestamp < startedAt!)) return "";
+  return timestamps.slice(1).sort((left, right) => Date.parse(left) - Date.parse(right))[0]!;
+}
+
+function tableExists(db: DatabaseSync, table: string): boolean {
+  return (
+    Number(
+      db
+        .prepare("select count(*) as value from sqlite_master where type = 'table' and name = ?")
+        .get(table)?.value ?? 0,
+    ) > 0
+  );
+}
+
+function columnExists(db: DatabaseSync, table: string, column: string): boolean {
+  if (!tableExists(db, table)) return false;
+  return db
+    .prepare(`pragma table_info(${table})`)
+    .all()
+    .some((row) => row.name === column);
+}
+
+function normalizeSqliteRow(row: Record<string, SQLOutputValue>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(row).map(([key, value]) => [
+      key,
+      typeof value === "bigint" ? Number(value) : value,
+    ]),
+  );
+}
+
+function positiveInteger(value: unknown, label: string): number {
+  const number = Number(value);
+  if (!Number.isSafeInteger(number) || number <= 0) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+  return number;
+}
+
+function nonNegativeInteger(value: unknown, fallback: number): number {
+  if (value === undefined || value === null || value === "") return fallback;
+  const number = Number(value);
+  if (!Number.isSafeInteger(number) || number < 0) {
+    throw new Error("Gitcrawl query integer must be non-negative");
+  }
+  return number;
+}
+
+function latestTimestamp(...values: string[]): string {
+  return (
+    values
+      .filter((value) => Number.isFinite(Date.parse(value)))
+      .sort((left, right) => Date.parse(right) - Date.parse(left))[0] ?? ""
+  );
+}
+
+function encodeCursor(
+  query: GitcrawlQueryName,
+  args: Record<string, unknown>,
+  snapshotId: string,
+  offset: number,
+): string {
+  return Buffer.from(
+    JSON.stringify({
+      v: 2,
+      q: query,
+      d: gitcrawlQueryDigest(query, args),
+      s: snapshotId,
+      o: offset,
+    }),
+  ).toString("base64url");
+}
+
+function decodeCursor(
+  cursor: string,
+  query: GitcrawlQueryName,
+  args: Record<string, unknown>,
+  snapshotId: string,
+): number {
+  if (!cursor) return 0;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(cursor, "base64url").toString("utf8"));
+  } catch {
+    throw new Error("invalid local Gitcrawl cursor");
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("invalid local Gitcrawl cursor");
+  }
+  const value = parsed as Record<string, unknown>;
+  if (
+    value.v !== 2 ||
+    value.q !== query ||
+    value.d !== gitcrawlQueryDigest(query, args) ||
+    value.s !== snapshotId
+  ) {
+    throw new Error("local Gitcrawl cursor drift");
+  }
+  const offset = Number(value.o);
+  if (!Number.isSafeInteger(offset) || offset < 0) {
+    throw new Error("invalid local Gitcrawl cursor offset");
+  }
+  return offset;
+}

--- a/src/repair/gitcrawl-evidence-local.ts
+++ b/src/repair/gitcrawl-evidence-local.ts
@@ -357,7 +357,11 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
 
   private relatedRows(number: number, limit: number, offset: number): Record<string, unknown>[] {
     const membershipTable = this.portable ? "cluster_memberships" : "cluster_members";
+    const clusterTable = this.portable ? "cluster_groups" : "clusters";
     const stateFilter = this.portable ? "and cm.state = 'active'" : "";
+    const activeClusterFilter = this.portable
+      ? "and c.status = 'active'"
+      : "and c.closed_at_local is null";
     const rows: Record<string, unknown>[] = [];
     const seenThreadIds = new Set<number>();
     let remainingOffset = offset;
@@ -366,7 +370,8 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
         `select cm.cluster_id
          from ${membershipTable} cm
          join threads t on t.id = cm.thread_id
-         where t.repo_id = ? and t.number = ? ${stateFilter}
+         join ${clusterTable} c on c.id = cm.cluster_id and c.repo_id = t.repo_id
+         where t.repo_id = ? and t.number = ? ${stateFilter} ${activeClusterFilter}
          order by cm.cluster_id`,
       )
       .iterate(this.repoId, number);
@@ -586,17 +591,34 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
     const clusterTable = this.portable ? "cluster_groups" : "clusters";
     const membershipTable = this.portable ? "cluster_memberships" : "cluster_members";
     const membershipWhere = this.portable ? "cm.state = 'active'" : "1 = 1";
+    const activeClusterWhere = this.portable ? "c.status = 'active'" : "c.closed_at_local is null";
     const clusterRows = tableExists(this.db, clusterTable)
       ? this.scalarNumber(
           `select count(*) as value from ${clusterTable} where repo_id = ?`,
           this.repoId,
         )
       : 0;
-    const clusterCovered = tableExists(this.db, membershipTable)
+    const clusterEligible = tableExists(this.db, clusterTable)
       ? this.scalarNumber(
           `select count(*) as value
+           from ${clusterTable} c
+           where c.repo_id = ? and ${activeClusterWhere}`,
+          this.repoId,
+        )
+      : 0;
+    const clusterCovered =
+      tableExists(this.db, clusterTable) && tableExists(this.db, membershipTable)
+        ? this.scalarNumber(
+            `select count(*) as value
              from ${clusterTable} c
              where c.repo_id = ?
+               and ${activeClusterWhere}
+               and exists (
+                 select 1
+                 from ${membershipTable} cm
+                 join threads t on t.id = cm.thread_id and t.repo_id = c.repo_id
+                 where cm.cluster_id = c.id and ${membershipWhere}
+               )
                and not exists (
                  select 1
                  from ${membershipTable} cm
@@ -604,14 +626,14 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
                  where cm.cluster_id = c.id and ${membershipWhere}
                    and t.id is null
                )`,
-          this.repoId,
-        )
-      : 0;
+            this.repoId,
+          )
+        : 0;
     rows.push(
       metric(
         "cluster_groups",
         clusterRows,
-        clusterRows,
+        clusterEligible,
         clusterCovered,
         this.repositoryTableMax(
           clusterTable,
@@ -620,30 +642,42 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
         generatedAt,
       ),
     );
-    const membershipRows = tableExists(this.db, membershipTable)
-      ? this.scalarNumber(
-          `select count(*) as value
+    const membershipRows =
+      tableExists(this.db, clusterTable) && tableExists(this.db, membershipTable)
+        ? this.scalarNumber(
+            `select count(*) as value
            from ${membershipTable} cm
            join ${clusterTable} c on c.id = cm.cluster_id
-           where c.repo_id = ? and ${membershipWhere}`,
-          this.repoId,
-        )
-      : 0;
-    const membershipCovered = tableExists(this.db, membershipTable)
-      ? this.scalarNumber(
-          `select count(*) as value
+           where c.repo_id = ?`,
+            this.repoId,
+          )
+        : 0;
+    const membershipEligible =
+      tableExists(this.db, clusterTable) && tableExists(this.db, membershipTable)
+        ? this.scalarNumber(
+            `select count(*) as value
+             from ${membershipTable} cm
+             join ${clusterTable} c on c.id = cm.cluster_id
+             where c.repo_id = ? and ${activeClusterWhere} and ${membershipWhere}`,
+            this.repoId,
+          )
+        : 0;
+    const membershipCovered =
+      tableExists(this.db, clusterTable) && tableExists(this.db, membershipTable)
+        ? this.scalarNumber(
+            `select count(*) as value
            from ${membershipTable} cm
            join ${clusterTable} c on c.id = cm.cluster_id
            join threads t on t.id = cm.thread_id and t.repo_id = c.repo_id
-           where c.repo_id = ? and ${membershipWhere}`,
-          this.repoId,
-        )
-      : 0;
+           where c.repo_id = ? and ${activeClusterWhere} and ${membershipWhere}`,
+            this.repoId,
+          )
+        : 0;
     rows.push(
       metric(
         "cluster_memberships",
         membershipRows,
-        membershipRows,
+        membershipEligible,
         membershipCovered,
         this.repositoryTableMax(
           membershipTable,

--- a/src/repair/gitcrawl-evidence-local.ts
+++ b/src/repair/gitcrawl-evidence-local.ts
@@ -450,7 +450,13 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
     limit: number,
     offset: number,
   ): Record<string, unknown>[] {
-    if (!tableExists(this.db, "pull_request_details")) return [];
+    if (
+      !tableExists(this.db, "pull_request_details") ||
+      !columnExists(this.db, "pull_request_details", "repo_id") ||
+      !columnExists(this.db, "pull_request_details", "number")
+    ) {
+      return [];
+    }
     const body = this.threadBody("t");
     const labels = this.threadColumn("t", "labels_json", "null");
     const assignees = this.threadColumn("t", "assignees_json", "null");
@@ -482,7 +488,8 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
               ${clusterContext.select},
               ${enrichment}
        from threads t
-       left join pull_request_details pr on pr.thread_id = t.id
+       left join pull_request_details pr
+         on pr.thread_id = t.id and pr.repo_id = t.repo_id and pr.number = t.number
        ${clusterContext.joins}
        where t.repo_id = ? and t.number = ? and t.kind = 'pull_request'
        limit 1`,
@@ -833,7 +840,10 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
       ? this.scalarNumber(
           `select count(*) as value
            from pull_request_details detail
-           join threads t on t.id = detail.thread_id
+           join threads t
+             on t.id = detail.thread_id
+            and t.repo_id = detail.repo_id
+            and t.number = detail.number
            where t.repo_id = ?`,
           this.repoId,
         )
@@ -850,6 +860,8 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
     const detailSupport =
       tableExists(this.db, "pull_request_details") &&
       columnExists(this.db, "pull_request_details", "thread_id") &&
+      columnExists(this.db, "pull_request_details", "repo_id") &&
+      columnExists(this.db, "pull_request_details", "number") &&
       columnExists(this.db, "pull_request_details", "fetched_at");
     const fileSupport =
       detailSupport &&
@@ -913,7 +925,8 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
                 reservationSupport ? "coalesce(detail_reservation.observation_sequence, 0)" : "0"
               } as detail_reserved_sequence
        from threads t
-       left join pull_request_details detail on detail.thread_id = t.id
+       left join pull_request_details detail
+         on detail.thread_id = t.id and detail.repo_id = t.repo_id and detail.number = t.number
        ${detailReservationJoin}
        where t.repo_id = ? and t.kind = 'pull_request'`,
       this.repoId,
@@ -986,7 +999,8 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
                 reservationSupport ? "coalesce(file_reservation.observation_sequence, 0)" : "0"
               } as file_reserved_sequence
        from threads t
-       left join pull_request_details detail on detail.thread_id = t.id
+       left join pull_request_details detail
+         on detail.thread_id = t.id and detail.repo_id = t.repo_id and detail.number = t.number
        left join (
          select file.thread_id,
                 count(*) as file_count,
@@ -1442,7 +1456,7 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
       },
       pull_request_details: {
         from: "pull_request_details source join threads t on t.id = source.thread_id",
-        where: "t.repo_id = ?",
+        where: "t.repo_id = ? and source.repo_id = t.repo_id and source.number = t.number",
       },
       pull_request_files: {
         from: "pull_request_files source join threads t on t.id = source.thread_id",

--- a/src/repair/gitcrawl-evidence-local.ts
+++ b/src/repair/gitcrawl-evidence-local.ts
@@ -720,7 +720,11 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
       .get(this.repoId);
     const latestRunId = Number(latestRun?.id ?? 0);
     const latestRunAt = String(latestRun?.finished_at ?? "");
-    const hasLatestRun = Number.isSafeInteger(latestRunId) && latestRunId > 0 && latestRunAt !== "";
+    const hasLatestRun =
+      Number.isSafeInteger(latestRunId) &&
+      latestRunId > 0 &&
+      latestRunAt !== "" &&
+      timestampAtOrAfter(latestRunAt, this.sourceSyncAt);
     const groupEligible = this.scalarNumber(
       "select count(*) as value from cluster_groups where repo_id = ? and status = 'active'",
       this.repoId,

--- a/src/repair/gitcrawl-evidence-local.ts
+++ b/src/repair/gitcrawl-evidence-local.ts
@@ -545,15 +545,32 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
       this.repoId,
     );
     rows.push(
-      metric("repositories", repoCount, repoCount, repoCount, this.sourceSyncAt, generatedAt),
+      metric(
+        this.snapshotId,
+        "repositories",
+        repoCount,
+        repoCount,
+        repoCount,
+        this.sourceSyncAt,
+        generatedAt,
+      ),
     );
     rows.push(
-      metric("threads", threadCount, threadCount, threadCount, this.sourceSyncAt, generatedAt),
+      metric(
+        this.snapshotId,
+        "threads",
+        threadCount,
+        threadCount,
+        threadCount,
+        this.sourceSyncAt,
+        generatedAt,
+      ),
     );
 
     const revisions = this.threadChildCoverage("thread_revisions", "");
     rows.push(
       metric(
+        this.snapshotId,
         "thread_revisions",
         revisions.rows,
         threadCount,
@@ -568,6 +585,7 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
     );
     rows.push(
       metric(
+        this.snapshotId,
         "thread_fingerprints",
         fingerprints.rows,
         threadCount,
@@ -579,6 +597,7 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
     const summaries = this.threadRevisionChildCoverage("thread_key_summaries", "");
     rows.push(
       metric(
+        this.snapshotId,
         "thread_key_summaries",
         summaries.rows,
         threadCount,
@@ -631,6 +650,7 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
         : 0;
     rows.push(
       metric(
+        this.snapshotId,
         "cluster_groups",
         clusterRows,
         clusterEligible,
@@ -675,6 +695,7 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
         : 0;
     rows.push(
       metric(
+        this.snapshotId,
         "cluster_memberships",
         membershipRows,
         membershipEligible,
@@ -715,6 +736,7 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
         : 0;
     rows.push(
       metric(
+        this.snapshotId,
         "pull_request_details",
         prRows,
         prEligible,
@@ -788,6 +810,7 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
           )
         : 0;
     const fileCoverage = metric(
+      this.snapshotId,
       "pull_request_files",
       fileRows,
       fileEligible,
@@ -1128,6 +1151,7 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
 }
 
 function metric(
+  snapshotId: string,
   dataset: GitcrawlCoverageRow["dataset"],
   rowCount: number,
   eligibleCount: number,
@@ -1136,6 +1160,7 @@ function metric(
   generatedAt: string,
 ): GitcrawlCoverageRow {
   return {
+    snapshot_id: snapshotId,
     dataset,
     row_count: rowCount,
     eligible_count: eligibleCount,

--- a/src/repair/gitcrawl-evidence-local.ts
+++ b/src/repair/gitcrawl-evidence-local.ts
@@ -209,12 +209,34 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
   }
 
   private async closeOnce(): Promise<void> {
+    const cleanupErrors: unknown[] = [];
     if (!this.databaseClosed) {
-      this.db.close();
-      this.databaseClosed = true;
+      try {
+        this.db.close();
+        this.databaseClosed = true;
+      } catch (error) {
+        cleanupErrors.push(error);
+      }
     }
-    await rm(this.tempDir, { force: true, recursive: true });
-    this.cleanupComplete = true;
+    try {
+      await rm(this.tempDir, { force: true, recursive: true });
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
+    if (cleanupErrors.length === 0) {
+      this.cleanupComplete = true;
+      return;
+    }
+    if (cleanupErrors.length === 1) {
+      throw cleanupErrors[0];
+    }
+    throw new AggregateError(
+      cleanupErrors,
+      "failed to close and clean up the local Gitcrawl snapshot",
+      {
+        cause: cleanupErrors[0],
+      },
+    );
   }
 
   private queryRows(

--- a/src/repair/gitcrawl-evidence-local.ts
+++ b/src/repair/gitcrawl-evidence-local.ts
@@ -1629,12 +1629,6 @@ function localSourceSyncAt(db: DatabaseSync, repoId: number, repository: string)
   }
   const reconciled = completeOpenReconciliationAt(db, repoId);
   if (reconciled) candidates.push(reconciled);
-  if (candidates.length === 0 && tableExists(db, "portable_metadata")) {
-    const exportedAt = db
-      .prepare("select value from portable_metadata where key = 'exported_at'")
-      .get()?.value;
-    if (typeof exportedAt === "string") candidates.push(exportedAt);
-  }
   return latestTimestamp(...candidates);
 }
 

--- a/src/repair/gitcrawl-evidence-local.ts
+++ b/src/repair/gitcrawl-evidence-local.ts
@@ -359,6 +359,7 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
     const membershipTable = this.portable ? "cluster_memberships" : "cluster_members";
     const stateFilter = this.portable ? "and cm.state = 'active'" : "";
     const rows: Record<string, unknown>[] = [];
+    const seenThreadIds = new Set<number>();
     let remainingOffset = offset;
     const clusters = this.db
       .prepare(
@@ -377,6 +378,9 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
         if (members.length === 0) break;
         for (const member of members) {
           if (Number(member.number) === number) continue;
+          const threadId = Number(member.thread_id);
+          if (seenThreadIds.has(threadId)) continue;
+          seenThreadIds.add(threadId);
           if (remainingOffset > 0) {
             remainingOffset -= 1;
             continue;

--- a/src/repair/gitcrawl-evidence-local.ts
+++ b/src/repair/gitcrawl-evidence-local.ts
@@ -3,7 +3,7 @@ import fs, { createReadStream } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { DatabaseSync, type SQLOutputValue } from "node:sqlite";
+import { DatabaseSync, type SQLInputValue, type SQLOutputValue } from "node:sqlite";
 import {
   GITCRAWL_QUERY_COVERAGE,
   GITCRAWL_QUERY_CONTRACT_VERSION,
@@ -14,6 +14,7 @@ import {
   type GitcrawlQueryRequest,
   type GitcrawlQuerySource,
   gitcrawlQueryDigest,
+  parseRfc3339Timestamp,
 } from "./gitcrawl-evidence-contract.js";
 
 export type LocalGitcrawlQuerySourceOptions = {
@@ -58,6 +59,11 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
     this.portable = input.portable;
     this.legacy = input.legacy;
     this.sourceSyncAt = input.sourceSyncAt;
+    this.db.function(
+      "clawsweeper_observation_at_or_after",
+      { deterministic: true },
+      observationAtOrAfterSql,
+    );
     this.datasetGeneratedAt = this.resolveDatasetGeneratedAt();
     this.coverage = this.buildCoverage();
   }
@@ -133,13 +139,29 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
       snapshotDb = undefined;
       return opened;
     } catch (error) {
+      const cleanupErrors: unknown[] = [];
       try {
         source?.close();
-      } catch {}
+      } catch (cleanupError) {
+        cleanupErrors.push(cleanupError);
+      }
       try {
         snapshotDb?.close();
-      } catch {}
-      await rm(tempDir, { force: true, recursive: true }).catch(() => undefined);
+      } catch (cleanupError) {
+        cleanupErrors.push(cleanupError);
+      }
+      try {
+        await rm(tempDir, { force: true, recursive: true });
+      } catch (cleanupError) {
+        cleanupErrors.push(cleanupError);
+      }
+      if (cleanupErrors.length > 0) {
+        throw new AggregateError(
+          [error, ...cleanupErrors],
+          "failed to open and clean up the local Gitcrawl snapshot",
+          { cause: error },
+        );
+      }
       throw error;
     }
   }
@@ -607,152 +629,162 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
       ),
     );
 
+    rows.push(...this.clusterCoverage(generatedAt));
+    rows.push(...this.pullRequestCoverage(generatedAt));
+    return rows;
+  }
+
+  private clusterCoverage(generatedAt: string): GitcrawlCoverageRow[] {
     const clusterTable = this.portable ? "cluster_groups" : "clusters";
     const membershipTable = this.portable ? "cluster_memberships" : "cluster_members";
-    const membershipWhere = this.portable ? "cm.state = 'active'" : "1 = 1";
-    const activeClusterWhere = this.portable ? "c.status = 'active'" : "c.closed_at_local is null";
     const clusterRows = tableExists(this.db, clusterTable)
       ? this.scalarNumber(
           `select count(*) as value from ${clusterTable} where repo_id = ?`,
           this.repoId,
         )
       : 0;
-    const clusterEligible = tableExists(this.db, clusterTable)
-      ? this.scalarNumber(
-          `select count(*) as value
-           from ${clusterTable} c
-           where c.repo_id = ? and ${activeClusterWhere}`,
-          this.repoId,
-        )
-      : 0;
-    const clusterCovered =
-      tableExists(this.db, clusterTable) && tableExists(this.db, membershipTable)
-        ? this.scalarNumber(
-            `select count(*) as value
-             from ${clusterTable} c
-             where c.repo_id = ?
-               and ${activeClusterWhere}
-               and exists (
-                 select 1
-                 from ${membershipTable} cm
-                 join threads t on t.id = cm.thread_id and t.repo_id = c.repo_id
-                 where cm.cluster_id = c.id and ${membershipWhere}
-               )
-               and not exists (
-                 select 1
-                 from ${membershipTable} cm
-                 left join threads t on t.id = cm.thread_id and t.repo_id = c.repo_id
-                 where cm.cluster_id = c.id and ${membershipWhere}
-                   and t.id is null
-               )`,
-            this.repoId,
-          )
-        : 0;
-    rows.push(
-      metric(
-        this.snapshotId,
-        "cluster_groups",
-        clusterRows,
-        clusterEligible,
-        clusterCovered,
-        this.repositoryTableMax(
-          clusterTable,
-          columnExists(this.db, clusterTable, "updated_at") ? "updated_at" : "created_at",
-        ),
-        generatedAt,
-      ),
-    );
     const membershipRows =
-      tableExists(this.db, clusterTable) && tableExists(this.db, membershipTable)
-        ? this.scalarNumber(
-            `select count(*) as value
-           from ${membershipTable} cm
-           join ${clusterTable} c on c.id = cm.cluster_id
-           where c.repo_id = ?`,
-            this.repoId,
-          )
-        : 0;
-    const membershipEligible =
       tableExists(this.db, clusterTable) && tableExists(this.db, membershipTable)
         ? this.scalarNumber(
             `select count(*) as value
              from ${membershipTable} cm
              join ${clusterTable} c on c.id = cm.cluster_id
-             where c.repo_id = ? and ${activeClusterWhere} and ${membershipWhere}`,
+             where c.repo_id = ?`,
             this.repoId,
           )
         : 0;
-    const membershipCovered =
-      tableExists(this.db, clusterTable) && tableExists(this.db, membershipTable)
-        ? this.scalarNumber(
-            `select count(*) as value
-           from ${membershipTable} cm
-           join ${clusterTable} c on c.id = cm.cluster_id
-           join threads t on t.id = cm.thread_id and t.repo_id = c.repo_id
-           where c.repo_id = ? and ${activeClusterWhere} and ${membershipWhere}`,
-            this.repoId,
-          )
-        : 0;
-    rows.push(
+    const maxSourceAt = this.repositoryTableMax(
+      clusterTable,
+      columnExists(this.db, clusterTable, "updated_at") ? "updated_at" : "created_at",
+    );
+    const currentSchema =
+      this.portable &&
+      tableExists(this.db, "cluster_runs") &&
+      columnExists(this.db, "cluster_runs", "finished_at") &&
+      columnExists(this.db, "cluster_memberships", "last_seen_run_id");
+    if (!currentSchema) {
+      return [
+        metric(
+          this.snapshotId,
+          "cluster_groups",
+          clusterRows,
+          0,
+          0,
+          maxSourceAt,
+          generatedAt,
+          false,
+        ),
+        metric(
+          this.snapshotId,
+          "cluster_memberships",
+          membershipRows,
+          0,
+          0,
+          maxSourceAt,
+          generatedAt,
+          false,
+        ),
+      ];
+    }
+
+    const latestRun = this.db
+      .prepare(
+        `select id, finished_at
+         from cluster_runs
+         where repo_id = ? and status in ('success', 'completed') and finished_at is not null
+         order by id desc
+         limit 1`,
+      )
+      .get(this.repoId);
+    const latestRunId = Number(latestRun?.id ?? 0);
+    const latestRunAt = String(latestRun?.finished_at ?? "");
+    const hasLatestRun = Number.isSafeInteger(latestRunId) && latestRunId > 0 && latestRunAt !== "";
+    const groupEligible = this.scalarNumber(
+      "select count(*) as value from cluster_groups where repo_id = ? and status = 'active'",
+      this.repoId,
+    );
+    const groupCovered = hasLatestRun
+      ? this.scalarNumber(
+          `select count(*) as value
+           from cluster_groups c
+           where c.repo_id = ? and c.status = 'active'
+             and exists (
+               select 1
+               from cluster_memberships cm
+               join threads t on t.id = cm.thread_id and t.repo_id = c.repo_id
+               where cm.cluster_id = c.id and cm.state = 'active'
+             )
+             and not exists (
+               select 1
+               from cluster_memberships cm
+               left join threads t on t.id = cm.thread_id and t.repo_id = c.repo_id
+               where cm.cluster_id = c.id and cm.state = 'active'
+                 and (t.id is null or coalesce(cm.last_seen_run_id, 0) != ?)
+             )`,
+          this.repoId,
+          latestRunId,
+        )
+      : 0;
+    const openThreadWhere = columnExists(this.db, "threads", "closed_at_local")
+      ? "t.state = 'open' and t.closed_at_local is null"
+      : "t.state = 'open'";
+    const membershipEligible = this.scalarNumber(
+      `select count(*) as value from threads t where t.repo_id = ? and ${openThreadWhere}`,
+      this.repoId,
+    );
+    const membershipCovered = hasLatestRun
+      ? this.scalarNumber(
+          `select count(*) as value
+           from threads t
+           where t.repo_id = ? and ${openThreadWhere}
+             and exists (
+               select 1
+               from cluster_memberships cm
+               join cluster_groups c on c.id = cm.cluster_id
+               where cm.thread_id = t.id
+                 and cm.state = 'active'
+                 and cm.last_seen_run_id = ?
+                 and c.repo_id = t.repo_id
+                 and c.status = 'active'
+             )`,
+          this.repoId,
+          latestRunId,
+        )
+      : 0;
+    return [
+      metric(
+        this.snapshotId,
+        "cluster_groups",
+        clusterRows,
+        groupEligible,
+        groupCovered,
+        latestRunAt || maxSourceAt,
+        generatedAt,
+        hasLatestRun && groupCovered === groupEligible,
+      ),
       metric(
         this.snapshotId,
         "cluster_memberships",
         membershipRows,
         membershipEligible,
         membershipCovered,
-        this.repositoryTableMax(
-          membershipTable,
-          columnExists(this.db, membershipTable, "updated_at") ? "updated_at" : "created_at",
-        ),
+        latestRunAt || maxSourceAt,
         generatedAt,
+        hasLatestRun && membershipCovered === membershipEligible,
       ),
-    );
+    ];
+  }
 
-    const prEligible = this.scalarNumber(
+  private pullRequestCoverage(generatedAt: string): GitcrawlCoverageRow[] {
+    const eligible = this.scalarNumber(
       "select count(*) as value from threads where repo_id = ? and kind = 'pull_request'",
       this.repoId,
     );
-    const prRows = tableExists(this.db, "pull_request_details")
+    const detailRows = tableExists(this.db, "pull_request_details")
       ? this.scalarNumber(
           `select count(*) as value
-           from pull_request_details pr
-           join threads t on t.id = pr.thread_id
-           where t.repo_id = ?`,
-          this.repoId,
-        )
-      : 0;
-    const prFreshness = this.pullRequestFreshness("pr");
-    const prCovered =
-      tableExists(this.db, "pull_request_details") && prFreshness !== "''"
-        ? this.scalarNumber(
-            `select count(*) as value
-           from pull_request_details pr
-           join threads t on t.id = pr.thread_id
-           where t.repo_id = ?
-             and julianday(${prFreshness})
-                 >= julianday(${this.threadUpdatedAt("t")})`,
-            this.repoId,
-          )
-        : 0;
-    rows.push(
-      metric(
-        this.snapshotId,
-        "pull_request_details",
-        prRows,
-        prEligible,
-        prCovered,
-        this.repositoryTableMax("pull_request_details", "fetched_at"),
-        generatedAt,
-      ),
-    );
-    const hasChangedFiles =
-      tableExists(this.db, "pull_request_details") &&
-      columnExists(this.db, "pull_request_details", "changed_files");
-    const fileEligible = hasChangedFiles
-      ? this.scalarNumber(
-          `select coalesce(sum(pr.changed_files), 0) as value
-           from pull_request_details pr
-           join threads t on t.id = pr.thread_id
+           from pull_request_details detail
+           join threads t on t.id = detail.thread_id
            where t.repo_id = ?`,
           this.repoId,
         )
@@ -760,73 +792,213 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
     const fileRows = tableExists(this.db, "pull_request_files")
       ? this.scalarNumber(
           `select count(*) as value
-           from pull_request_files pf
-           join threads t on t.id = pf.thread_id
+           from pull_request_files file
+           join threads t on t.id = file.thread_id
            where t.repo_id = ?`,
           this.repoId,
         )
       : 0;
-    const fileCovered =
-      tableExists(this.db, "pull_request_files") &&
+    const detailSupport =
       tableExists(this.db, "pull_request_details") &&
-      hasChangedFiles &&
+      columnExists(this.db, "pull_request_details", "thread_id") &&
+      columnExists(this.db, "pull_request_details", "fetched_at");
+    const fileSupport =
+      detailSupport &&
+      columnExists(this.db, "pull_request_details", "changed_files") &&
+      tableExists(this.db, "pull_request_files") &&
+      columnExists(this.db, "pull_request_files", "thread_id") &&
       columnExists(this.db, "pull_request_files", "position") &&
-      columnExists(this.db, "pull_request_files", "fetched_at") &&
-      prFreshness !== "''"
-        ? this.scalarNumber(
-            `select coalesce(sum(pr.changed_files), 0) as value
-             from pull_request_details pr
-             join threads t on t.id = pr.thread_id
-             where t.repo_id = ?
-               and (
-                 select count(*)
-                 from pull_request_files pf
-                 where pf.thread_id = pr.thread_id
-               ) = pr.changed_files
-               and (
-                 select count(distinct pf.position)
-                 from pull_request_files pf
-                 where pf.thread_id = pr.thread_id
-               ) = pr.changed_files
-               and (
-                 pr.changed_files = 0 or (
-                   select min(pf.position) = 0 and max(pf.position) = pr.changed_files - 1
-                   from pull_request_files pf
-                   where pf.thread_id = pr.thread_id
-                 )
-               )
-               and julianday(${prFreshness}) is not null
-               and not exists (
-                 select 1
-                 from pull_request_files pf
-                 where pf.thread_id = pr.thread_id
-                   and (
-                     julianday(pf.fetched_at) is null
-                     or julianday(pf.fetched_at)
-                        < julianday(${prFreshness})
-                   )
-               )`,
-            this.repoId,
-          )
-        : 0;
-    const fileCoverage = metric(
-      this.snapshotId,
-      "pull_request_files",
-      fileRows,
-      fileEligible,
-      fileCovered,
-      this.repositoryTableMax("pull_request_files", "fetched_at"),
-      generatedAt,
+      columnExists(this.db, "pull_request_files", "fetched_at");
+    const reservationSupport = this.hasObservationReservations();
+    const observationAware =
+      columnExists(this.db, "threads", "observation_sequence") &&
+      columnExists(this.db, "threads", "evidence_observation_sequence") &&
+      columnExists(this.db, "threads", "evidence_source_updated_at");
+    const detailMaxSourceAt = this.repositoryTableMax("pull_request_details", "fetched_at");
+    const fileMaxSourceAt = this.repositoryTableMax("pull_request_files", "fetched_at");
+    if (!detailSupport || (observationAware && !reservationSupport)) {
+      return [
+        metric(
+          this.snapshotId,
+          "pull_request_details",
+          detailRows,
+          eligible,
+          0,
+          detailMaxSourceAt,
+          generatedAt,
+          false,
+        ),
+        metric(
+          this.snapshotId,
+          "pull_request_files",
+          fileRows,
+          0,
+          0,
+          fileMaxSourceAt,
+          generatedAt,
+          false,
+        ),
+      ];
+    }
+
+    const accepted = this.acceptedThreadObservation("t");
+    const detailReservationJoin = reservationSupport
+      ? `left join thread_child_observation_reservations detail_reservation
+           on detail_reservation.thread_id = t.id
+          and detail_reservation.family = 'pull_request_details'`
+      : "";
+    const detailRecords = this.all(
+      `select case when detail.thread_id is null then 0 else 1 end as has_detail,
+              coalesce(detail.fetched_at, '') as detail_fetched_at,
+              ${accepted.source} as accepted_source_at,
+              ${accepted.sequence} as accepted_sequence,
+              ${
+                reservationSupport
+                  ? "case when detail_reservation.thread_id is null then 0 else 1 end"
+                  : "0"
+              } as has_detail_reservation,
+              ${
+                reservationSupport ? "coalesce(detail_reservation.source_updated_at, '')" : "''"
+              } as detail_reserved_source_at,
+              ${
+                reservationSupport ? "coalesce(detail_reservation.observation_sequence, 0)" : "0"
+              } as detail_reserved_sequence
+       from threads t
+       left join pull_request_details detail on detail.thread_id = t.id
+       ${detailReservationJoin}
+       where t.repo_id = ? and t.kind = 'pull_request'`,
+      this.repoId,
     );
-    fileCoverage.complete =
-      hasChangedFiles &&
-      columnExists(this.db, "pull_request_files", "position") &&
-      columnExists(this.db, "pull_request_files", "fetched_at") &&
-      prFreshness !== "''" &&
-      fileRows === fileEligible &&
-      fileCovered === fileEligible;
-    rows.push(fileCoverage);
-    return rows;
+    let detailCovered = 0;
+    for (const row of detailRecords) {
+      if (Number(row.has_detail) !== 1) continue;
+      const fresh = reservationSupport
+        ? Number(row.has_detail_reservation) === 1 &&
+          observationAtOrAfter(
+            row.detail_reserved_source_at,
+            row.detail_reserved_sequence,
+            row.accepted_source_at,
+            row.accepted_sequence,
+          )
+        : timestampAtOrAfter(row.detail_fetched_at, row.accepted_source_at);
+      if (fresh) detailCovered += 1;
+    }
+    const detailCoverage = metric(
+      this.snapshotId,
+      "pull_request_details",
+      detailRows,
+      eligible,
+      detailCovered,
+      detailMaxSourceAt,
+      generatedAt,
+      detailRecords.length === eligible && detailCovered === eligible,
+    );
+
+    if (!fileSupport) {
+      return [
+        detailCoverage,
+        metric(
+          this.snapshotId,
+          "pull_request_files",
+          fileRows,
+          0,
+          0,
+          fileMaxSourceAt,
+          generatedAt,
+          false,
+        ),
+      ];
+    }
+    const fileReservationJoin = reservationSupport
+      ? `left join thread_child_observation_reservations file_reservation
+           on file_reservation.thread_id = t.id
+          and file_reservation.family = 'pull_request_files'`
+      : "";
+    const fileRecords = this.all(
+      `select case when detail.thread_id is null then 0 else 1 end as has_detail,
+              coalesce(detail.changed_files, 0) as changed_files,
+              coalesce(detail.fetched_at, '') as detail_fetched_at,
+              coalesce(files.file_count, 0) as file_count,
+              coalesce(files.distinct_positions, 0) as distinct_positions,
+              coalesce(files.minimum_position, -1) as minimum_position,
+              coalesce(files.maximum_position, -1) as maximum_position,
+              coalesce(files.oldest_fetched_at, '') as oldest_fetched_at,
+              ${accepted.source} as accepted_source_at,
+              ${accepted.sequence} as accepted_sequence,
+              ${
+                reservationSupport
+                  ? "case when file_reservation.thread_id is null then 0 else 1 end"
+                  : "0"
+              } as has_file_reservation,
+              ${
+                reservationSupport ? "coalesce(file_reservation.source_updated_at, '')" : "''"
+              } as file_reserved_source_at,
+              ${
+                reservationSupport ? "coalesce(file_reservation.observation_sequence, 0)" : "0"
+              } as file_reserved_sequence
+       from threads t
+       left join pull_request_details detail on detail.thread_id = t.id
+       left join (
+         select thread_id,
+                count(*) as file_count,
+                count(distinct position) as distinct_positions,
+                min(position) as minimum_position,
+                max(position) as maximum_position,
+                min(fetched_at) as oldest_fetched_at
+         from pull_request_files
+         group by thread_id
+       ) files on files.thread_id = t.id
+       ${fileReservationJoin}
+       where t.repo_id = ? and t.kind = 'pull_request'`,
+      this.repoId,
+    );
+    let fileEligible = 0;
+    let fileCovered = 0;
+    let freshPullRequests = 0;
+    for (const row of fileRecords) {
+      const changedFiles = Number(row.changed_files);
+      if (Number(row.has_detail) !== 1 || !Number.isSafeInteger(changedFiles) || changedFiles < 0) {
+        continue;
+      }
+      fileEligible += changedFiles;
+      const exactFiles =
+        Number(row.file_count) === changedFiles &&
+        Number(row.distinct_positions) === changedFiles &&
+        (changedFiles === 0 ||
+          (Number(row.minimum_position) === 0 &&
+            Number(row.maximum_position) === changedFiles - 1));
+      const detailFresh = timestampAtOrAfter(row.detail_fetched_at, row.accepted_source_at);
+      const filesFresh =
+        changedFiles === 0 || timestampAtOrAfter(row.oldest_fetched_at, row.accepted_source_at);
+      const reservationFresh =
+        !reservationSupport ||
+        (Number(row.has_file_reservation) === 1 &&
+          observationAtOrAfter(
+            row.file_reserved_source_at,
+            row.file_reserved_sequence,
+            row.accepted_source_at,
+            row.accepted_sequence,
+          ));
+      if (!exactFiles || !detailFresh || !filesFresh || !reservationFresh) continue;
+      freshPullRequests += 1;
+      fileCovered += changedFiles;
+    }
+    return [
+      detailCoverage,
+      metric(
+        this.snapshotId,
+        "pull_request_files",
+        fileRows,
+        fileEligible,
+        fileCovered,
+        fileMaxSourceAt,
+        generatedAt,
+        fileRecords.length === eligible &&
+          freshPullRequests === eligible &&
+          fileRows === fileEligible &&
+          fileCovered === fileEligible,
+      ),
+    ];
   }
 
   private threadChildCoverage(
@@ -840,17 +1012,15 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
        where t.repo_id = ? ${condition}`,
       this.repoId,
     );
-    const covered = this.scalarNumber(
-      `select count(*) as value
-       from threads t
-       where t.repo_id = ? and exists (
-         select 1 from ${table} child
-         where child.thread_id = t.id ${condition}
-           and julianday(coalesce(nullif(child.source_updated_at, ''), child.created_at))
-               >= julianday(${this.threadUpdatedAt("t")})
-       )`,
-      this.repoId,
-    );
+    const covered =
+      table === "thread_revisions"
+        ? this.scalarNumber(
+            `select count(*) as value
+             from threads t
+             where t.repo_id = ? and ${this.acceptedRevisionId("t")} is not null`,
+            this.repoId,
+          )
+        : 0;
     return { rows, covered, latest: this.repositoryTableMax(table, "created_at") };
   }
 
@@ -869,16 +1039,14 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
        where t.repo_id = ? ${condition}`,
       this.repoId,
     );
+    const acceptedRevision = this.acceptedRevisionId("t");
     const covered = this.scalarNumber(
       `select count(*) as value
        from threads t
        where t.repo_id = ? and exists (
          select 1
-         from thread_revisions revision
-         join ${table} child on child.thread_revision_id = revision.id
-         where revision.thread_id = t.id ${condition}
-           and julianday(coalesce(nullif(revision.source_updated_at, ''), revision.created_at))
-               >= julianday(${this.threadUpdatedAt("t")})
+         from ${table} child
+         where child.thread_revision_id = ${acceptedRevision} ${condition}
        )`,
       this.repoId,
     );
@@ -908,10 +1076,7 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
               '' as revision_source_updated_at, '' as key_summary,
               '' as fingerprint_algorithm, '' as fingerprint_hash, '' as fingerprint_slug`;
     }
-    const latestRevision = `(select revision.id from thread_revisions revision
-      where revision.thread_id = ${alias}.id
-      order by julianday(coalesce(nullif(revision.source_updated_at, ''), revision.created_at)) desc,
-               revision.id desc limit 1)`;
+    const latestRevision = this.acceptedRevisionId(alias);
     const revisionId = latestRevision;
     const revisionHash = `(select revision.content_hash from thread_revisions revision
       where revision.id = ${latestRevision})`;
@@ -950,6 +1115,99 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
             ${fingerprintSlug} as fingerprint_slug`;
   }
 
+  private acceptedRevisionId(threadAlias: string): string {
+    const revisionFresh = this.revisionFreshnessPredicate("revision", threadAlias);
+    const sequenceOrder = columnExists(this.db, "thread_revisions", "observation_sequence")
+      ? "revision.observation_sequence desc,"
+      : "";
+    return `(select revision.id
+      from thread_revisions revision
+      where revision.thread_id = ${threadAlias}.id
+        and (${revisionFresh})
+      order by ${sequenceOrder}
+               revision.id desc
+      limit 1)`;
+  }
+
+  private revisionFreshnessPredicate(revisionAlias: string, threadAlias: string): string {
+    const revisionSource = columnExists(this.db, "thread_revisions", "source_updated_at")
+      ? `coalesce(nullif(${revisionAlias}.source_updated_at, ''), ${revisionAlias}.created_at)`
+      : `${revisionAlias}.created_at`;
+    const revisionSequence = columnExists(this.db, "thread_revisions", "observation_sequence")
+      ? `coalesce(${revisionAlias}.observation_sequence, 0)`
+      : "0";
+    const legacyFresh = `clawsweeper_observation_at_or_after(
+      ${revisionSource},
+      0,
+      ${this.threadUpdatedAt(threadAlias)},
+      0
+    ) = 1`;
+    if (
+      columnExists(this.db, "thread_revisions", "observation_sequence") &&
+      columnExists(this.db, "threads", "evidence_observation_sequence") &&
+      columnExists(this.db, "threads", "evidence_source_updated_at")
+    ) {
+      return `(case
+        when coalesce(${threadAlias}.evidence_observation_sequence, 0) > 0
+          then ${revisionSequence} = ${threadAlias}.evidence_observation_sequence
+            and clawsweeper_observation_at_or_after(
+              ${revisionSource},
+              ${revisionSequence},
+              coalesce(${threadAlias}.evidence_source_updated_at, ''),
+              ${threadAlias}.evidence_observation_sequence
+            ) = 1
+        else ${legacyFresh}
+      end)`;
+    }
+    if (
+      columnExists(this.db, "thread_revisions", "observation_sequence") &&
+      columnExists(this.db, "threads", "observation_sequence")
+    ) {
+      return `${revisionSequence} = ${threadAlias}.observation_sequence
+        and clawsweeper_observation_at_or_after(
+          ${revisionSource},
+          ${revisionSequence},
+          ${this.threadUpdatedAt(threadAlias)},
+          ${threadAlias}.observation_sequence
+        ) = 1`;
+    }
+    return legacyFresh;
+  }
+
+  private acceptedThreadObservation(alias: string): { source: string; sequence: string } {
+    const fallbackSource = this.threadUpdatedAt(alias);
+    const fallbackSequence = columnExists(this.db, "threads", "observation_sequence")
+      ? `coalesce(${alias}.observation_sequence, 0)`
+      : "0";
+    if (
+      columnExists(this.db, "threads", "evidence_observation_sequence") &&
+      columnExists(this.db, "threads", "evidence_source_updated_at")
+    ) {
+      return {
+        source: `case
+          when coalesce(${alias}.evidence_observation_sequence, 0) > 0
+            then coalesce(${alias}.evidence_source_updated_at, '')
+          else ${fallbackSource}
+        end`,
+        sequence: `case
+          when coalesce(${alias}.evidence_observation_sequence, 0) > 0
+            then ${alias}.evidence_observation_sequence
+          else ${fallbackSequence}
+        end`,
+      };
+    }
+    return { source: fallbackSource, sequence: fallbackSequence };
+  }
+
+  private hasObservationReservations(): boolean {
+    return (
+      tableExists(this.db, "thread_child_observation_reservations") &&
+      ["thread_id", "family", "source_updated_at", "observation_sequence"].every((column) =>
+        columnExists(this.db, "thread_child_observation_reservations", column),
+      )
+    );
+  }
+
   private threadColumn(alias: string, column: string, fallback: string): string {
     return columnExists(this.db, "threads", column) ? `${alias}.${column}` : fallback;
   }
@@ -966,13 +1224,6 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
     return columnExists(this.db, table, column) ? `${alias}.${column}` : fallback;
   }
 
-  private pullRequestFreshness(alias: string): string {
-    const candidates = ["fetched_at", "updated_at"]
-      .filter((column) => columnExists(this.db, "pull_request_details", column))
-      .map((column) => `nullif(${alias}.${column}, '')`);
-    return candidates.length === 0 ? "''" : `coalesce(${candidates.join(", ")}, '')`;
-  }
-
   private reviewClusterContext(): { select: string; joins: string } {
     if (this.portable) {
       return {
@@ -986,6 +1237,7 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
                     join cluster_groups candidate_group on candidate_group.id = candidate.cluster_id
                     where candidate.thread_id = t.id and candidate.state = 'active'
                       and candidate_group.repo_id = t.repo_id
+                      and candidate_group.status = 'active'
                     order by case candidate.role
                                when 'canonical' then 0
                                when 'representative' then 1
@@ -995,7 +1247,7 @@ export class LocalGitcrawlQuerySource implements GitcrawlQuerySource {
                     limit 1
                   )
                 left join cluster_groups cg
-                  on cg.id = cm.cluster_id and cg.repo_id = t.repo_id`,
+                  on cg.id = cm.cluster_id and cg.repo_id = t.repo_id and cg.status = 'active'`,
       };
     }
     return {
@@ -1158,6 +1410,7 @@ function metric(
   coveredCount: number,
   maxSourceAt: string,
   generatedAt: string,
+  complete = eligibleCount === coveredCount,
 ): GitcrawlCoverageRow {
   return {
     snapshot_id: snapshotId,
@@ -1167,8 +1420,71 @@ function metric(
     covered_count: coveredCount,
     max_source_at: maxSourceAt,
     dataset_generated_at: generatedAt,
-    complete: eligibleCount === coveredCount,
+    complete,
   };
+}
+
+function observationAtOrAfterSql(
+  observedSource: SQLInputValue,
+  observedSequence: SQLInputValue,
+  acceptedSource: SQLInputValue,
+  acceptedSequence: SQLInputValue,
+): number {
+  return observationAtOrAfter(observedSource, observedSequence, acceptedSource, acceptedSequence)
+    ? 1
+    : 0;
+}
+
+function observationAtOrAfter(
+  observedSourceValue: unknown,
+  observedSequenceValue: unknown,
+  acceptedSourceValue: unknown,
+  acceptedSequenceValue: unknown,
+): boolean {
+  const observedSource = String(observedSourceValue ?? "").trim();
+  const acceptedSource = String(acceptedSourceValue ?? "").trim();
+  const observedTimestamp = timestampOrderKey(observedSource);
+  const acceptedTimestamp = timestampOrderKey(acceptedSource);
+  const observedSequence = safeObservationSequence(observedSequenceValue);
+  const acceptedSequence = safeObservationSequence(acceptedSequenceValue);
+  if (observedSequence === null || acceptedSequence === null) return false;
+  if (observedTimestamp !== null && acceptedTimestamp !== null) {
+    if (observedTimestamp > acceptedTimestamp) return true;
+    if (observedTimestamp < acceptedTimestamp) return false;
+    return observedSequence >= acceptedSequence;
+  }
+  if (observedTimestamp !== null || acceptedTimestamp !== null) return false;
+  return observedSource === acceptedSource && observedSequence >= acceptedSequence;
+}
+
+function timestampAtOrAfter(observedValue: unknown, acceptedValue: unknown): boolean {
+  const observed = timestampOrderKey(String(observedValue ?? "").trim());
+  const acceptedText = String(acceptedValue ?? "").trim();
+  if (observed === null) return false;
+  if (!acceptedText) return true;
+  const accepted = timestampOrderKey(acceptedText);
+  return accepted !== null && observed >= accepted;
+}
+
+function timestampOrderKey(value: string): bigint | null {
+  try {
+    parseRfc3339Timestamp(value, "Gitcrawl observation timestamp");
+  } catch {
+    return null;
+  }
+  const match = /^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})(?:\.(\d{1,9}))?(Z|[+-]\d{2}:\d{2})$/.exec(
+    value,
+  );
+  if (!match) return null;
+  const milliseconds = Date.parse(`${match[1]}T${match[2]}${match[4]}`);
+  if (!Number.isFinite(milliseconds)) return null;
+  const fraction = BigInt((match[3] ?? "").padEnd(9, "0"));
+  return BigInt(milliseconds) * 1_000_000n + fraction;
+}
+
+function safeObservationSequence(value: unknown): number | null {
+  const sequence = Number(value);
+  return Number.isSafeInteger(sequence) && sequence >= 0 ? sequence : null;
 }
 
 function sliceRows(

--- a/src/repair/gitcrawl-evidence-policy.ts
+++ b/src/repair/gitcrawl-evidence-policy.ts
@@ -30,7 +30,7 @@ export function deriveGitcrawlThreadPolicySignals(
   return {
     blankTemplate: blankTemplateSignal(body),
     issueReference: /#\d+\b/.test(text),
-    concreteFix: /\b(fixes|fixes?|root cause|repro|regression|bug|problem)\b/i.test(text),
+    concreteFix: /\b(fix(?:es)?|root cause|repro|regression|bug|problem)\b/i.test(text),
     thirdPartyCapability: /\b(new|add|feat).*(plugin|provider|channel|skill|tool|app)\b/i.test(
       text,
     ),

--- a/src/repair/gitcrawl-evidence-policy.ts
+++ b/src/repair/gitcrawl-evidence-policy.ts
@@ -134,18 +134,32 @@ function templateAnswerIsBlank(answer: string): boolean {
 export function stripGitcrawlHtmlComments(value: string): string {
   const chunks: string[] = [];
   let cursor = 0;
+  let depth = 0;
   while (cursor < value.length) {
     const commentStart = value.indexOf("<!--", cursor);
-    if (commentStart === -1) {
-      chunks.push(value.slice(cursor));
+    const commentEnd = value.indexOf("-->", cursor);
+    const nextMarker =
+      commentStart === -1
+        ? commentEnd
+        : commentEnd === -1
+          ? commentStart
+          : Math.min(commentStart, commentEnd);
+    if (nextMarker === -1) {
+      if (depth === 0) chunks.push(value.slice(cursor));
       break;
     }
-    chunks.push(value.slice(cursor, commentStart), "\n");
-    const commentEnd = value.indexOf("-->", commentStart + 4);
-    if (commentEnd === -1) break;
-    cursor = commentEnd + 3;
+    if (depth === 0) chunks.push(value.slice(cursor, nextMarker));
+    if (nextMarker === commentStart) {
+      if (depth === 0) chunks.push("\n");
+      depth += 1;
+      cursor = nextMarker + 4;
+    } else {
+      if (depth > 0) depth -= 1;
+      else chunks.push("\n");
+      cursor = nextMarker + 3;
+    }
   }
-  return chunks.join("").replaceAll("<!--", "\n").replaceAll("-->", "\n");
+  return chunks.join("");
 }
 
 export function sanitizeGitcrawlPromptValue<T>(value: T, depth = 0): T {

--- a/src/repair/gitcrawl-evidence-policy.ts
+++ b/src/repair/gitcrawl-evidence-policy.ts
@@ -1,0 +1,176 @@
+import { GITCRAWL_CANONICAL_JSON_MAX_DEPTH, canonicalJson } from "./gitcrawl-evidence-contract.js";
+
+export type GitcrawlThreadPolicySignals = {
+  blankTemplate: boolean;
+  issueReference: boolean;
+  concreteFix: boolean;
+  thirdPartyCapability: boolean;
+};
+
+export type GitcrawlThreadSafetyProjection = {
+  state: string;
+  title: string;
+  body: string;
+  authorLogin?: string;
+  authorType: string;
+  authorAssociation?: string;
+  labels?: unknown[];
+  assignees?: unknown[];
+  securitySensitive: boolean;
+  securityMetadataComplete: boolean;
+  securityProjectionSha256: string;
+  policySignals: GitcrawlThreadPolicySignals;
+};
+
+export function deriveGitcrawlThreadPolicySignals(
+  title: string,
+  body: string,
+): GitcrawlThreadPolicySignals {
+  const text = `${stripGitcrawlHtmlComments(title)}\n${stripGitcrawlHtmlComments(body)}`;
+  return {
+    blankTemplate: blankTemplateSignal(body),
+    issueReference: /#\d+\b/.test(text),
+    concreteFix: /\b(fixes|fixes?|root cause|repro|regression|bug|problem)\b/i.test(text),
+    thirdPartyCapability: /\b(new|add|feat).*(plugin|provider|channel|skill|tool|app)\b/i.test(
+      text,
+    ),
+  };
+}
+
+export function assertGitcrawlThreadSafetyProjectionMatches(
+  search: GitcrawlThreadSafetyProjection,
+  review: GitcrawlThreadSafetyProjection,
+): void {
+  if (canonicalJson(safetyProjection(search)) !== canonicalJson(safetyProjection(review))) {
+    throw new Error("Gitcrawl search and review safety projections diverge");
+  }
+}
+
+function safetyProjection(thread: GitcrawlThreadSafetyProjection): Record<string, unknown> {
+  return {
+    state: thread.state,
+    title: thread.title,
+    body: thread.body,
+    author_login: thread.authorLogin ?? null,
+    author_type: thread.authorType,
+    author_association: thread.authorAssociation ?? null,
+    labels: thread.labels ?? null,
+    assignees: thread.assignees ?? null,
+    security_sensitive: thread.securitySensitive,
+    security_metadata_complete: thread.securityMetadataComplete,
+    security_projection_sha256: thread.securityProjectionSha256,
+    policy_signals: thread.policySignals,
+  };
+}
+
+function blankTemplateSignal(body: string): boolean {
+  const fields = [
+    "Describe the problem and fix in 2-5 bullets",
+    "Describe the problem and fix",
+    "Problem",
+    "Why it matters",
+    "Fix",
+  ];
+  const answers: string[] = [];
+  let active = false;
+  let substantiveOutsideTemplate = false;
+  const withoutComments = stripGitcrawlHtmlComments(body);
+  for (const line of withoutComments.split(/\r?\n/)) {
+    const match = /^\s*(?:[-*]\s*)?([^:]+):\s*(.*)$/.exec(line);
+    const label = match?.[1]?.trim().replace(/[–—]/g, "-");
+    const bareLabel = line
+      .trim()
+      .replace(/^[-*]\s*/, "")
+      .replace(/[–—]/g, "-");
+    const templateLabel = label ?? bareLabel;
+    if (fields.some((field) => field.toLowerCase() === templateLabel.toLowerCase())) {
+      active = true;
+      answers.push(match?.[2]?.trim() ?? "");
+      continue;
+    }
+    if (!active && !templatePreambleLineIsBlank(line)) {
+      substantiveOutsideTemplate = true;
+      continue;
+    }
+    if (active && !/^\s*[-*_]?\s*$/.test(line)) {
+      answers[answers.length - 1] = `${answers.at(-1) ?? ""}\n${line.trim()}`.trim();
+    }
+  }
+  return (
+    !substantiveOutsideTemplate &&
+    answers.length >= 2 &&
+    answers.every((answer) => templateAnswerIsBlank(answer))
+  );
+}
+
+function templatePreambleLineIsBlank(line: string): boolean {
+  if (/^\s*[-*_]?\s*$/.test(line)) return true;
+  const heading = /^#{1,6}\s+(.+?)\s*#*\s*$/.exec(line)?.[1]?.trim().toLowerCase();
+  return (
+    heading !== undefined &&
+    [
+      "description",
+      "pull request description",
+      "summary",
+      "change summary",
+      "problem and fix",
+    ].includes(heading)
+  );
+}
+
+function templateAnswerIsBlank(answer: string): boolean {
+  const normalized = stripGitcrawlHtmlComments(answer)
+    .replace(/^[-*_`\s]+|[-*_`\s]+$/g, "")
+    .trim()
+    .toLowerCase();
+  return (
+    normalized === "" ||
+    normalized === "n/a" ||
+    normalized === "none" ||
+    normalized === "no response"
+  );
+}
+
+export function stripGitcrawlHtmlComments(value: string): string {
+  const chunks: string[] = [];
+  let cursor = 0;
+  while (cursor < value.length) {
+    const commentStart = value.indexOf("<!--", cursor);
+    if (commentStart === -1) {
+      chunks.push(value.slice(cursor));
+      break;
+    }
+    chunks.push(value.slice(cursor, commentStart), "\n");
+    const commentEnd = value.indexOf("-->", commentStart + 4);
+    if (commentEnd === -1) break;
+    cursor = commentEnd + 3;
+  }
+  return chunks.join("").replaceAll("<!--", "\n").replaceAll("-->", "\n");
+}
+
+export function sanitizeGitcrawlPromptValue<T>(value: T, depth = 0): T {
+  if (depth > GITCRAWL_CANONICAL_JSON_MAX_DEPTH) {
+    throw new Error(
+      `Gitcrawl prompt data exceeds ${GITCRAWL_CANONICAL_JSON_MAX_DEPTH} levels of nesting`,
+    );
+  }
+  if (typeof value === "string") return stripGitcrawlHtmlComments(value) as T;
+  if (Array.isArray(value)) {
+    return value.map((entry) => sanitizeGitcrawlPromptValue(entry, depth + 1)) as T;
+  }
+  if (typeof value === "object" && value !== null) {
+    const entries: [string, unknown][] = [];
+    const keys = new Set<string>();
+    for (const [key, entry] of Object.entries(value)) {
+      const sanitizedKey = stripGitcrawlHtmlComments(key).replace(/\s+/g, " ").trim();
+      if (!sanitizedKey) throw new Error("Gitcrawl prompt data contains an empty sanitized key");
+      if (keys.has(sanitizedKey)) {
+        throw new Error(`Gitcrawl prompt data contains a sanitized key collision: ${sanitizedKey}`);
+      }
+      keys.add(sanitizedKey);
+      entries.push([sanitizedKey, sanitizeGitcrawlPromptValue(entry, depth + 1)]);
+    }
+    return Object.fromEntries(entries) as T;
+  }
+  return value;
+}

--- a/src/repair/gitcrawl-evidence-policy.ts
+++ b/src/repair/gitcrawl-evidence-policy.ts
@@ -26,7 +26,9 @@ export function deriveGitcrawlThreadPolicySignals(
   title: string,
   body: string,
 ): GitcrawlThreadPolicySignals {
-  const text = `${stripGitcrawlHtmlComments(title)}\n${stripGitcrawlHtmlComments(body)}`;
+  const text = `${stripGitcrawlHtmlComments(title)}\n${stripGitcrawlHtmlComments(body)}`
+    .replace(/\s+/g, " ")
+    .trim();
   return {
     blankTemplate: blankTemplateSignal(body),
     issueReference: /#\d+\b/.test(text),

--- a/src/repair/import-gitcrawl-low-signal-prs.ts
+++ b/src/repair/import-gitcrawl-low-signal-prs.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { execFileSync } from "node:child_process";
 import { hasSecuritySignalText, parseArgs, repoRoot } from "./lib.js";
 import { renderJobIntentFrontmatter } from "./job-intent.js";
+import { deriveGitcrawlThreadPolicySignals } from "./gitcrawl-evidence-policy.js";
 
 const args = parseArgs(process.argv.slice(2));
 const repo = String(args.repo ?? "openclaw/openclaw");
@@ -125,6 +126,7 @@ function scoreCandidate(row: LooseRecord) {
   );
   const title = String(row.title ?? "");
   const body = String(row.body ?? "");
+  const policySignals = deriveGitcrawlThreadPolicySignals(title, body);
   const signals: LooseRecord[] = [];
   const blockers: LooseRecord[] = [];
 
@@ -134,22 +136,23 @@ function scoreCandidate(row: LooseRecord) {
   if (hasSecuritySignalText(title, body, labels))
     blockers.push("security-sensitive text or labels");
 
-  addSignal(signals, blankTemplateSignal(body), "blank_template");
+  addSignal(signals, policySignals.blankTemplate, "blank_template");
   addSignal(signals, docsOnlySignal(title, files), "docs_only");
   addSignal(signals, testsOnlySignal(title, files), "test_only");
-  addSignal(signals, refactorOnlySignal(title, body, files), "refactor_or_cleanup");
   addSignal(
     signals,
-    thirdPartyCoreSignal(title, body, files),
+    refactorOnlySignal(title, files, policySignals.issueReference),
+    "refactor_or_cleanup",
+  );
+  addSignal(
+    signals,
+    thirdPartyCoreSignal(files, policySignals.thirdPartyCapability),
     "third_party_or_external_capability",
   );
   addSignal(signals, riskyInfraSignal(title, files), "risky_infra");
   addSignal(signals, dirtyBranchSignal(files), "dirty_branch");
 
-  const hasConcreteFix = /\b(fixes|fixes?|root cause|repro|regression|bug|problem)\b/i.test(
-    `${title}\n${body}`,
-  );
-  if (hasConcreteFix && signals.length === 1 && !signals.includes("blank_template")) {
+  if (policySignals.concreteFix && signals.length === 1 && !policySignals.blankTemplate) {
     blockers.push("possible focused fix needs human review");
   }
 
@@ -280,22 +283,6 @@ function staleCompare(left: JsonValue, right: JsonValue) {
   return String(left.updated_at).localeCompare(String(right.updated_at));
 }
 
-function blankTemplateSignal(body: string) {
-  const text = String(body ?? "");
-  if (
-    /Describe the problem and fix in 2.?5 bullets:\s*[\r\n]+\s*-\s*Problem:\s*[\r\n]+\s*-\s*Fix:/i.test(
-      text,
-    )
-  ) {
-    return true;
-  }
-  const placeholders = ["Problem:", "Why it matters:", "Describe the problem and fix"];
-  return (
-    placeholders.filter((placeholder: JsonValue) => text.includes(placeholder)).length >= 2 &&
-    text.length < 700
-  );
-}
-
 function docsOnlySignal(title: JsonValue, files: LooseRecord[]) {
   return (
     /\bdocs?\b/i.test(title) &&
@@ -312,18 +299,15 @@ function testsOnlySignal(title: JsonValue, files: LooseRecord[]) {
   );
 }
 
-function refactorOnlySignal(title: JsonValue, body: string, files: LooseRecord[]) {
+function refactorOnlySignal(title: JsonValue, files: LooseRecord[], hasIssueReference: boolean) {
   return (
-    /\b(refactor|cleanup|format|chore)\b/i.test(title) &&
-    !/#\d+\b/.test(`${title}\n${body}`) &&
-    files.length > 0
+    /\b(refactor|cleanup|format|chore)\b/i.test(title) && !hasIssueReference && files.length > 0
   );
 }
 
-function thirdPartyCoreSignal(title: JsonValue, body: string, files: LooseRecord[]) {
-  const text = `${title}\n${body}`.toLowerCase();
+function thirdPartyCoreSignal(files: LooseRecord[], hasThirdPartyCapability: boolean) {
   return (
-    /\b(new|add|feat).*(plugin|provider|channel|skill|tool|app)\b/.test(text) ||
+    hasThirdPartyCapability ||
     files.some((file: JsonValue) => String(file).startsWith("apps/linux/"))
   );
 }

--- a/test/repair/gitcrawl-query-evidence.test.ts
+++ b/test/repair/gitcrawl-query-evidence.test.ts
@@ -12,6 +12,7 @@ import {
   GITCRAWL_QUERY_CONTRACT_VERSION,
   GITCRAWL_QUERY_NAMES,
   canonicalJson,
+  createGitcrawlEvidenceClaim,
   sha256Canonical,
   type GitcrawlCoverageRow,
   type GitcrawlQueryEnvelope,
@@ -191,6 +192,63 @@ test("query evidence fails closed on source, relation, review, and packet drift"
       /query contains unsupported field ignored/,
     );
     await adapter.close();
+  });
+
+  await t.test("standalone claims have inconsistent parity bindings", () => {
+    const base = {
+      repository,
+      snapshotId,
+      queryName: "gitcrawl.coverage" as const,
+      queryArgs: {},
+      subject: `${repository}#dataset:threads`,
+      data: { dataset: "threads" },
+    };
+    assert.throws(
+      () => createGitcrawlEvidenceClaim({ ...base, provider: "parity" }),
+      /missing its local snapshot/,
+    );
+    assert.throws(
+      () =>
+        createGitcrawlEvidenceClaim({
+          ...base,
+          provider: "cloud",
+          paritySnapshotId: "d".repeat(64),
+        }),
+      /non-parity claim has a parity snapshot/,
+    );
+  });
+
+  await t.test("claim relations have unsupported semantics", () => {
+    const base = {
+      provider: "cloud" as const,
+      repository,
+      snapshotId,
+      queryName: "gitcrawl.coverage" as const,
+      queryArgs: {},
+      subject: `${repository}#dataset:threads`,
+      data: { dataset: "threads" },
+    };
+    assert.throws(
+      () =>
+        createGitcrawlEvidenceClaim({
+          ...base,
+          relations: [
+            {
+              predicate: "owns" as "member_of",
+              target: `${repository}#dataset:repositories`,
+            },
+          ],
+        }),
+      /unsupported Gitcrawl evidence relation/,
+    );
+    assert.throws(
+      () =>
+        createGitcrawlEvidenceClaim({
+          ...base,
+          relations: [{ predicate: "describes", target: " " }],
+        }),
+      /relation target is missing or malformed/,
+    );
   });
 
   await t.test("packet repository is relabeled", async () => {
@@ -494,6 +552,10 @@ test("policy sanitization removes hidden instructions before scoring or claims",
   assert.throws(
     () => sanitizeGitcrawlPromptValue({ "a<!-- x -->": 1, a: 2 }),
     /sanitized key collision/,
+  );
+  assert.equal(
+    deriveGitcrawlThreadPolicySignals("maintenance", "Fix: refresh tokens").concreteFix,
+    true,
   );
 });
 

--- a/test/repair/gitcrawl-query-evidence.test.ts
+++ b/test/repair/gitcrawl-query-evidence.test.ts
@@ -1069,6 +1069,38 @@ test("local coverage rejects active clusters without valid memberships", async (
   }
 });
 
+test("local portable cluster coverage binds to exported metadata", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-query-portable-"));
+  const dbPath = path.join(directory, "gitcrawl.db");
+  seedLocalDatabase(dbPath);
+  const db = new DatabaseSync(dbPath);
+  db.exec(`
+    drop table cluster_runs;
+    drop table sync_runs;
+  `);
+  db.close();
+  const source = await LocalGitcrawlQuerySource.open({
+    dbPath,
+    repository,
+    allowLegacy: false,
+  });
+  const adapter = await GitcrawlEvidenceAdapter.fromSources({
+    repository,
+    provider: "local",
+    primarySource: source,
+    now: () => now,
+  });
+  try {
+    assert.equal((await adapter.listClusters()).rows[0]?.id, 7);
+    assert.equal((await adapter.clusterMembers(7)).rows[0]?.number, 42);
+    assert.equal(adapter.provenance.source_sync_at, generatedAt);
+    assert.equal(adapter.provenance.dataset_generated_at, generatedAt);
+  } finally {
+    await adapter.close();
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+});
+
 test("local cluster coverage requires the latest successful run", async (t) => {
   for (const scenario of ["missing", "stale", "predates-source"] as const) {
     await t.test(scenario, async () => {

--- a/test/repair/gitcrawl-query-evidence.test.ts
+++ b/test/repair/gitcrawl-query-evidence.test.ts
@@ -130,6 +130,22 @@ test("query evidence fails closed on source, relation, review, and packet drift"
     await adapter.close();
   });
 
+  await t.test("coverage rows use another snapshot", async () => {
+    const coverage = completeCoverage();
+    coverage[0]!.snapshot_id = "d".repeat(64);
+    const source = new FixtureSource({ coverage });
+    await assert.rejects(
+      GitcrawlEvidenceAdapter.fromSources({
+        repository,
+        provider: "cloud",
+        primarySource: source,
+        now: () => now,
+      }),
+      /coverage returned mismatched snapshot/,
+    );
+    assert.equal(source.closeCount, 1);
+  });
+
   await t.test("source initialization surfaces cleanup failures", async () => {
     const source = new FixtureSource({
       closeError: new Error("fixture close failed"),
@@ -1296,6 +1312,7 @@ class FixtureSource implements GitcrawlQuerySource {
   closeCount = 0;
 
   private readonly rows: Partial<Record<GitcrawlQueryRequest["name"], Record<string, unknown>[]>>;
+  private readonly coverage: GitcrawlCoverageRow[];
   private readonly snapshotForQuery: (request: GitcrawlQueryRequest) => string;
   private readonly overlapSecondPageFor: GitcrawlQueryRequest["name"] | undefined;
   private readonly closeError: Error | undefined;
@@ -1304,6 +1321,7 @@ class FixtureSource implements GitcrawlQuerySource {
     options: {
       provider?: "local" | "cloud";
       rows?: Partial<Record<GitcrawlQueryRequest["name"], Record<string, unknown>[]>>;
+      coverage?: GitcrawlCoverageRow[];
       snapshotForQuery?: (request: GitcrawlQueryRequest) => string;
       overlapSecondPageFor?: GitcrawlQueryRequest["name"];
       closeError?: Error;
@@ -1311,6 +1329,7 @@ class FixtureSource implements GitcrawlQuerySource {
   ) {
     this.provider = options.provider ?? "cloud";
     this.rows = options.rows ?? {};
+    this.coverage = options.coverage ?? completeCoverage();
     this.snapshotForQuery = options.snapshotForQuery ?? (() => snapshotId);
     this.overlapSecondPageFor = options.overlapSecondPageFor;
     this.closeError = options.closeError;
@@ -1319,7 +1338,7 @@ class FixtureSource implements GitcrawlQuerySource {
   async query(request: GitcrawlQueryRequest): Promise<GitcrawlQueryEnvelope> {
     this.requests.push(request);
     const rows =
-      request.name === "gitcrawl.coverage" ? completeCoverage() : (this.rows[request.name] ?? []);
+      request.name === "gitcrawl.coverage" ? this.coverage : (this.rows[request.name] ?? []);
     const requestedOffset = request.cursor ? Number(request.cursor) : 0;
     const offset =
       request.name === this.overlapSecondPageFor && requestedOffset > 0

--- a/test/repair/gitcrawl-query-evidence.test.ts
+++ b/test/repair/gitcrawl-query-evidence.test.ts
@@ -965,6 +965,41 @@ test("local SQLite source snapshots and serves the six-query contract", async ()
   }
 });
 
+test("local PR file aggregation is scoped to the selected repository", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-query-multi-repo-"));
+  const dbPath = path.join(directory, "gitcrawl.db");
+  seedLocalDatabase(dbPath);
+  seedUnrelatedRepositoryFiles(dbPath);
+  const localSource = await LocalGitcrawlQuerySource.open({
+    dbPath,
+    repository,
+    allowLegacy: false,
+  });
+  const adapter = await GitcrawlEvidenceAdapter.fromSources({
+    repository,
+    provider: "local",
+    primarySource: localSource,
+    now: () => now,
+  });
+  try {
+    const fileCoverage = adapter.coverage.find((row) => row.dataset === "pull_request_files");
+    assert.deepEqual(fileCoverage, {
+      snapshot_id: adapter.snapshotId,
+      dataset: "pull_request_files",
+      row_count: 1,
+      eligible_count: 1,
+      covered_count: 1,
+      max_source_at: generatedAt,
+      dataset_generated_at: generatedAt,
+      complete: true,
+    });
+    assert.equal((await adapter.reviewContext(42)).rows.length, 2);
+  } finally {
+    await adapter.close();
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+});
+
 test("local coverage rejects active clusters without valid memberships", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-query-coverage-"));
   const dbPath = path.join(directory, "gitcrawl.db");
@@ -1775,6 +1810,42 @@ function seedDuplicateRelatedMemberships(dbPath: string): void {
     values (8, 42, 'representative', 'active', 1, 1, 1, '${generatedAt}', '${generatedAt}');
     insert into cluster_memberships
     values (8, 43, 'member', 'active', 0.7, 1, 1, '${generatedAt}', '${generatedAt}');
+  `);
+  db.close();
+}
+
+function seedUnrelatedRepositoryFiles(dbPath: string): void {
+  const db = new DatabaseSync(dbPath);
+  db.prepare("insert into repositories values (?, ?, ?, ?)").run(
+    2,
+    "openclaw/other",
+    "openclaw",
+    "other",
+  );
+  db.exec(`
+    insert into threads
+    select 84, 2, 84, 'pull_request', state, 'Unrelated provider change', body,
+           author_login, author_type, author_association,
+           'https://github.com/openclaw/other/pull/84',
+           labels_json, assignees_json, is_draft, created_at_gh, updated_at_gh,
+           closed_at_gh, merged_at_gh, last_pulled_at, observation_sequence,
+           evidence_observation_sequence, evidence_source_updated_at, updated_at
+    from threads where id = 42;
+
+    insert into pull_request_details
+    select 84, base_sha, head_sha, head_ref, 'contributor/other', mergeable_state,
+           additions, deletions, 2, fetched_at, updated_at
+    from pull_request_details where thread_id = 42;
+
+    insert into pull_request_files
+    select 84, 0, 'src/unrelated-a.ts', status, additions, deletions, changes,
+           previous_path, fetched_at
+    from pull_request_files where thread_id = 42;
+
+    insert into pull_request_files
+    select 84, 1, 'src/unrelated-b.ts', status, additions, deletions, changes,
+           previous_path, fetched_at
+    from pull_request_files where thread_id = 42;
   `);
   db.close();
 }

--- a/test/repair/gitcrawl-query-evidence.test.ts
+++ b/test/repair/gitcrawl-query-evidence.test.ts
@@ -1122,6 +1122,7 @@ test("local cluster coverage requires the latest successful run", async (t) => {
         );
       } else {
         const sourceAt = "2026-07-14T09:56:00.000Z";
+        const clusterFinishedAt = "2026-07-14T09:57:00.000Z";
         db.prepare(
           `update sync_runs
            set started_at = ?, finished_at = ?, stats_json = ?
@@ -1140,6 +1141,10 @@ test("local cluster coverage requires the latest successful run", async (t) => {
         );
         db.prepare("update portable_metadata set value = ? where key = 'exported_at'").run(
           sourceAt,
+        );
+        db.prepare("update cluster_runs set finished_at = ? where repo_id = ?").run(
+          clusterFinishedAt,
+          1,
         );
       }
       db.close();

--- a/test/repair/gitcrawl-query-evidence.test.ts
+++ b/test/repair/gitcrawl-query-evidence.test.ts
@@ -558,6 +558,40 @@ test("query evidence fails closed on source, relation, review, and packet drift"
     );
   });
 
+  await t.test("packets reject duplicate canonical claims", () => {
+    const base = {
+      provider: "cloud" as const,
+      repository,
+      snapshotId,
+      queryName: "gitcrawl.threads.search" as const,
+      queryArgs: { owner: "openclaw", repo: "openclaw" },
+      subject: `${repository}#pull:42`,
+    };
+    const claim = createGitcrawlEvidenceClaim({
+      ...base,
+      data: memberRow(),
+    });
+    const conflicting = createGitcrawlEvidenceClaim({
+      ...base,
+      data: memberRow({ title: "Conflicting title" }),
+    });
+    const packetInput = {
+      provider: "cloud" as const,
+      repository,
+      snapshotId,
+      coverage: completeCoverage(),
+      generatedAt,
+    };
+    assert.throws(
+      () => buildGitcrawlEvidencePacket({ ...packetInput, claims: [claim, claim] }),
+      /repeats claim/,
+    );
+    assert.throws(
+      () => buildGitcrawlEvidencePacket({ ...packetInput, claims: [claim, conflicting] }),
+      /conflicting claims/,
+    );
+  });
+
   await t.test("packet repository is relabeled", async () => {
     const adapter = await adapterFor({ "gitcrawl.clusters.list": [clusterRow()] });
     const claim = (await adapter.listClusters()).claims[0]!;

--- a/test/repair/gitcrawl-query-evidence.test.ts
+++ b/test/repair/gitcrawl-query-evidence.test.ts
@@ -239,6 +239,24 @@ test("query evidence fails closed on source, relation, review, and packet drift"
     await adapter.close();
   });
 
+  await t.test("thread rows require complete safety metadata", async () => {
+    for (const incomplete of [
+      { security_metadata_complete: 0 },
+      { body: undefined },
+      { labels_json: undefined },
+      { assignees_json: undefined },
+      { author_association: undefined },
+      { author_login: "" },
+      { author_type: "" },
+    ]) {
+      const adapter = await adapterFor({
+        "gitcrawl.threads.search": [memberRow(incomplete)],
+      });
+      await assert.rejects(adapter.searchOpenPullRequests(), /security metadata/);
+      await adapter.close();
+    }
+  });
+
   await t.test("packet claims are mutated after binding", () => {
     const packet = buildGitcrawlEvidencePacket({
       provider: "cloud",

--- a/test/repair/gitcrawl-query-evidence.test.ts
+++ b/test/repair/gitcrawl-query-evidence.test.ts
@@ -1,0 +1,751 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+
+import { GitcrawlEvidenceAdapter } from "../../dist/repair/gitcrawl-evidence-adapter.js";
+import { CloudGitcrawlQuerySource } from "../../dist/repair/gitcrawl-evidence-cloud.js";
+import {
+  GITCRAWL_DATASETS,
+  GITCRAWL_QUERY_CONTRACT_VERSION,
+  GITCRAWL_QUERY_NAMES,
+  type GitcrawlCoverageRow,
+  type GitcrawlQueryEnvelope,
+  type GitcrawlQueryRequest,
+  type GitcrawlQuerySource,
+} from "../../dist/repair/gitcrawl-evidence-contract.js";
+import {
+  buildGitcrawlEvidencePacket,
+  verifyGitcrawlEvidencePacket,
+} from "../../dist/repair/gitcrawl-evidence-graph.js";
+import { LocalGitcrawlQuerySource } from "../../dist/repair/gitcrawl-evidence-local.js";
+import {
+  deriveGitcrawlThreadPolicySignals,
+  sanitizeGitcrawlPromptValue,
+  stripGitcrawlHtmlComments,
+} from "../../dist/repair/gitcrawl-evidence-policy.js";
+
+const now = new Date("2026-07-14T10:00:00.000Z");
+const generatedAt = "2026-07-14T09:55:00.000Z";
+const snapshotId = "a".repeat(64);
+const revision = "b".repeat(64);
+const fingerprint = "c".repeat(64);
+const repository = "openclaw/openclaw";
+const archive = "gitcrawl/openclaw__openclaw";
+
+test("six-query adapter binds read-only evidence into verified claims and graph packets", async () => {
+  const source = new FixtureSource({
+    rows: {
+      "gitcrawl.clusters.list": [clusterRow()],
+      "gitcrawl.clusters.members": [memberRow()],
+      "gitcrawl.clusters.related": [
+        { source_number: 42, ...memberRow({ thread_id: 43, number: 43, kind: "issue" }) },
+      ],
+      "gitcrawl.threads.search": [memberRow()],
+      "gitcrawl.pull_requests.review_context": [
+        reviewContextRow({ changed_files: 1 }),
+        reviewFileRow(0, "src/provider.ts"),
+      ],
+    },
+  });
+  const adapter = await GitcrawlEvidenceAdapter.fromSources({
+    repository,
+    provider: "cloud",
+    primarySource: source,
+    now: () => now,
+  });
+
+  const clusters = await adapter.listClusters();
+  const members = await adapter.clusterMembers(7);
+  const related = await adapter.related(42);
+  const search = await adapter.searchOpenPullRequests();
+  const review = await adapter.reviewContext(42);
+
+  assert.deepEqual(
+    [...new Set(source.requests.map((request) => request.name))].sort(),
+    [...GITCRAWL_QUERY_NAMES].sort(),
+  );
+  assert.equal(clusters.rows[0]?.id, 7);
+  assert.equal(members.rows[0]?.threadFingerprint?.sha256, fingerprint);
+  assert.equal(related.rows[0]?.number, 43);
+  assert.equal(search.rows[0]?.sourceRevision?.sha256, revision);
+  assert.equal(review.rows.length, 2);
+  assert.deepEqual(adapter.requiredCoverageFor(...GITCRAWL_QUERY_NAMES), [
+    "cluster_groups",
+    "cluster_memberships",
+    "pull_request_details",
+    "pull_request_files",
+    "repositories",
+    "threads",
+  ]);
+
+  const claims = [
+    ...clusters.claims,
+    ...members.claims,
+    ...related.claims,
+    ...search.claims,
+    ...review.claims,
+  ];
+  const packet = buildGitcrawlEvidencePacket({
+    provider: "cloud",
+    repository,
+    snapshotId: adapter.snapshotId,
+    coverage: adapter.coverage,
+    claims,
+    generatedAt,
+  });
+  assert.doesNotThrow(() => verifyGitcrawlEvidencePacket(packet));
+  assert(packet.graph.nodes.some((node) => node.id === `${repository}#cluster:7`));
+  assert(packet.graph.edges.some((edge) => edge.predicate === "member_of"));
+  await adapter.close();
+  assert.equal(source.closeCount, 1);
+});
+
+test("query evidence fails closed on source, relation, review, and packet drift", async (t) => {
+  await t.test("snapshot generation changes", async () => {
+    const adapter = await GitcrawlEvidenceAdapter.fromSources({
+      repository,
+      provider: "cloud",
+      primarySource: new FixtureSource({
+        snapshotForQuery: (request) =>
+          request.name === "gitcrawl.coverage" ? snapshotId : "d".repeat(64),
+        rows: { "gitcrawl.clusters.list": [clusterRow()] },
+      }),
+      now: () => now,
+    });
+    await assert.rejects(adapter.listClusters(), /mixed snapshot generation/);
+    await adapter.close();
+  });
+
+  await t.test("cluster members escape the requested cluster", async () => {
+    const adapter = await adapterFor({
+      "gitcrawl.clusters.members": [memberRow({ cluster_id: 8 })],
+    });
+    await assert.rejects(
+      adapter.clusterMembers(7),
+      /cluster 7 returned a member from another cluster/,
+    );
+    await adapter.close();
+  });
+
+  await t.test("related results point back to themselves", async () => {
+    const adapter = await adapterFor({
+      "gitcrawl.clusters.related": [{ source_number: 42, ...memberRow() }],
+    });
+    await assert.rejects(adapter.related(42), /cannot relate thread 42 to itself/);
+    await adapter.close();
+  });
+
+  await t.test("review files are incomplete", async () => {
+    const adapter = await adapterFor({
+      "gitcrawl.pull_requests.review_context": [
+        reviewContextRow({ changed_files: 2 }),
+        reviewFileRow(0, "src/provider.ts"),
+      ],
+    });
+    await assert.rejects(adapter.reviewContext(42), /has 1\/2 files/);
+    await adapter.close();
+  });
+
+  await t.test("search returns a non-pull-request row", async () => {
+    const adapter = await adapterFor({
+      "gitcrawl.threads.search": [memberRow({ kind: "issue" })],
+    });
+    await assert.rejects(adapter.searchOpenPullRequests(), /open pull request search returned/);
+    await adapter.close();
+  });
+
+  await t.test("packet claims are mutated after binding", () => {
+    const packet = buildGitcrawlEvidencePacket({
+      provider: "cloud",
+      repository,
+      snapshotId,
+      coverage: completeCoverage(),
+      claims: [],
+      generatedAt,
+    });
+    packet.coverage[0]!.covered_count = 0;
+    assert.throws(
+      () => verifyGitcrawlEvidencePacket(packet),
+      /digest mismatch|incomplete coverage/,
+    );
+  });
+});
+
+test("cloud source authenticates, binds identity, and refuses unsafe transport", async () => {
+  const requests: Array<Record<string, unknown>> = [];
+  const headers: Headers[] = [];
+  const source = new CloudGitcrawlQuerySource({
+    baseUrl: "https://crawl.example.test",
+    archive,
+    repository,
+    token: "reader-token",
+    accessClientId: "access-id",
+    accessClientSecret: "access-secret",
+    fetch: async (_input, init) => {
+      requests.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      headers.push(new Headers(init?.headers));
+      return jsonResponse(completeCoverage());
+    },
+  });
+  const result = await source.query({
+    name: "gitcrawl.coverage",
+    args: {},
+    limit: 50,
+    cursor: "",
+    snapshot_id: "",
+  });
+  assert.equal(result.snapshot.id, snapshotId);
+  assert.equal(requests[0]?.contract_version, GITCRAWL_QUERY_CONTRACT_VERSION);
+  assert.equal(requests[0]?.repository, repository);
+  assert.equal(requests[0]?.archive, archive);
+  assert.equal(headers[0]?.get("authorization"), "Bearer reader-token");
+  assert.equal(headers[0]?.get("CF-Access-Client-Id"), "access-id");
+  assert.equal(headers[0]?.get("CF-Access-Client-Secret"), "access-secret");
+
+  assert.throws(
+    () =>
+      new CloudGitcrawlQuerySource({
+        baseUrl: "http://crawl.example.test",
+        archive,
+        repository,
+        token: "reader-token",
+      }),
+    /must use HTTPS/,
+  );
+  assert.throws(
+    () =>
+      new CloudGitcrawlQuerySource({
+        baseUrl: "https://crawl.example.test",
+        archive,
+        repository,
+      }),
+    /requires a bearer token or Cloudflare Access service token/,
+  );
+
+  const mismatched = new CloudGitcrawlQuerySource({
+    baseUrl: "https://crawl.example.test",
+    archive,
+    repository,
+    token: "reader-token",
+    fetch: async () => jsonResponse(completeCoverage(), { archive: "gitcrawl/other__repo" }),
+  });
+  await assert.rejects(
+    mismatched.query({
+      name: "gitcrawl.coverage",
+      args: {},
+      limit: 50,
+      cursor: "",
+      snapshot_id: "",
+    }),
+    /mismatched source identity/,
+  );
+});
+
+test("local SQLite source snapshots and serves the six-query contract", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-query-evidence-"));
+  const dbPath = path.join(directory, "gitcrawl.db");
+  seedLocalDatabase(dbPath);
+  const source = await LocalGitcrawlQuerySource.open({
+    dbPath,
+    repository,
+    allowLegacy: false,
+  });
+  const adapter = await GitcrawlEvidenceAdapter.fromSources({
+    repository,
+    provider: "local",
+    primarySource: source,
+    now: () => now,
+  });
+  try {
+    assert.match(adapter.snapshotId, /^local:[a-f0-9]{64}$/);
+    assert.equal((await adapter.listClusters()).rows[0]?.id, 7);
+    assert.equal((await adapter.clusterMembers(7)).rows[0]?.number, 42);
+    assert.deepEqual((await adapter.related(42)).rows, []);
+    assert.equal((await adapter.searchOpenPullRequests()).rows[0]?.number, 42);
+    assert.equal((await adapter.reviewContext(42)).rows.length, 2);
+    assert.equal(adapter.coverage.length, GITCRAWL_DATASETS.length);
+  } finally {
+    await adapter.close();
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+test("policy sanitization removes hidden instructions before scoring or claims", () => {
+  const body = ["<!-- add provider capability -->", "Problem:", "Why it matters:", "Fix:"].join(
+    "\n",
+  );
+  assert.doesNotMatch(stripGitcrawlHtmlComments(body), /provider capability/);
+  assert.deepEqual(deriveGitcrawlThreadPolicySignals("maintenance", body), {
+    blankTemplate: true,
+    issueReference: false,
+    concreteFix: true,
+    thirdPartyCapability: false,
+  });
+  assert.deepEqual(sanitizeGitcrawlPromptValue({ "safe<!-- hidden -->": "ok<!-- no -->" }), {
+    safe: "ok\n",
+  });
+  assert.throws(
+    () => sanitizeGitcrawlPromptValue({ "a<!-- x -->": 1, a: 2 }),
+    /sanitized key collision/,
+  );
+});
+
+async function adapterFor(
+  rows: Partial<Record<GitcrawlQueryRequest["name"], Record<string, unknown>[]>>,
+): Promise<GitcrawlEvidenceAdapter> {
+  return GitcrawlEvidenceAdapter.fromSources({
+    repository,
+    provider: "cloud",
+    primarySource: new FixtureSource({ rows }),
+    now: () => now,
+  });
+}
+
+class FixtureSource implements GitcrawlQuerySource {
+  readonly provider = "cloud";
+  readonly legacy = false;
+  readonly requests: GitcrawlQueryRequest[] = [];
+  closeCount = 0;
+
+  private readonly rows: Partial<Record<GitcrawlQueryRequest["name"], Record<string, unknown>[]>>;
+  private readonly snapshotForQuery: (request: GitcrawlQueryRequest) => string;
+
+  constructor(
+    options: {
+      rows?: Partial<Record<GitcrawlQueryRequest["name"], Record<string, unknown>[]>>;
+      snapshotForQuery?: (request: GitcrawlQueryRequest) => string;
+    } = {},
+  ) {
+    this.rows = options.rows ?? {};
+    this.snapshotForQuery = options.snapshotForQuery ?? (() => snapshotId);
+  }
+
+  async query(request: GitcrawlQueryRequest): Promise<GitcrawlQueryEnvelope> {
+    this.requests.push(request);
+    const rows =
+      request.name === "gitcrawl.coverage" ? completeCoverage() : (this.rows[request.name] ?? []);
+    const values = orderRows(request, rows).slice(0, request.limit);
+    const querySnapshotId = this.snapshotForQuery(request);
+    return {
+      values,
+      snapshot: snapshotProvenance(querySnapshotId),
+      stats: {
+        contract_version: GITCRAWL_QUERY_CONTRACT_VERSION,
+        repository,
+        archive,
+        snapshot_id: querySnapshotId,
+        source_sync_at: generatedAt,
+        dataset_generated_at: generatedAt,
+        coverage_complete: true,
+        next_cursor: "",
+      },
+    };
+  }
+
+  async close(): Promise<void> {
+    this.closeCount += 1;
+  }
+}
+
+function orderRows(
+  request: GitcrawlQueryRequest,
+  rows: Record<string, unknown>[],
+): Record<string, unknown>[] {
+  if (request.name === "gitcrawl.threads.search") {
+    const direction = request.args.order === "oldest" ? 1 : -1;
+    return [...rows].sort(
+      (left, right) =>
+        direction *
+        (Date.parse(String(left.updated_at_gh ?? "")) -
+          Date.parse(String(right.updated_at_gh ?? ""))),
+    );
+  }
+  if (request.name === "gitcrawl.clusters.list") {
+    return [...rows].sort(
+      (left, right) =>
+        Number(right.member_count ?? 0) - Number(left.member_count ?? 0) ||
+        Number(left.cluster_id ?? 0) - Number(right.cluster_id ?? 0),
+    );
+  }
+  return rows;
+}
+
+function completeCoverage(): GitcrawlCoverageRow[] {
+  return GITCRAWL_DATASETS.map((dataset) => ({
+    dataset,
+    row_count: 1,
+    eligible_count: 1,
+    covered_count: 1,
+    max_source_at: generatedAt,
+    dataset_generated_at: generatedAt,
+    complete: true,
+  }));
+}
+
+function clusterRow(): Record<string, unknown> {
+  return {
+    cluster_id: 7,
+    stable_slug: "cluster-7",
+    status: "active",
+    cluster_type: "duplicate_candidate",
+    title: "Provider refresh",
+    representative_thread_id: 42,
+    representative_number: 42,
+    representative_kind: "pull_request",
+    representative_state: "open",
+    representative_title: "Fix provider refresh",
+    member_count: 1,
+    created_at: generatedAt,
+    updated_at: generatedAt,
+    closed_at: "",
+  };
+}
+
+function memberRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    cluster_id: 7,
+    cluster_member_count: 1,
+    stable_slug: "cluster-7",
+    cluster_status: "active",
+    role: "representative",
+    membership_state: "active",
+    score_to_representative: 1,
+    thread_id: 42,
+    number: 42,
+    kind: "pull_request",
+    state: "open",
+    title: "Fix provider refresh",
+    body: "Fixes token refresh after expiry.",
+    author_login: "contributor",
+    author_type: "User",
+    author_association: "CONTRIBUTOR",
+    html_url: "https://github.com/openclaw/openclaw/pull/42",
+    labels_json: "[]",
+    assignees_json: "[]",
+    security_metadata_complete: 1,
+    is_draft: 0,
+    created_at_gh: generatedAt,
+    updated_at_gh: generatedAt,
+    key_summary: "Fixes token refresh",
+    revision_id: 9,
+    revision_content_hash: revision,
+    revision_source_updated_at: generatedAt,
+    fingerprint_algorithm: "thread-fingerprint-v2",
+    fingerprint_hash: fingerprint,
+    ...overrides,
+  };
+}
+
+function reviewContextRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    row_kind: "context",
+    ...memberRow(),
+    cluster_member_count: undefined,
+    base_sha: "1".repeat(40),
+    head_sha: "2".repeat(40),
+    head_ref: "fix/provider-refresh",
+    head_repo_full_name: "contributor/openclaw",
+    mergeable_state: "clean",
+    additions: 5,
+    deletions: 2,
+    changed_files: 0,
+    details_fetched_at: generatedAt,
+    details_updated_at: generatedAt,
+    cluster_slug: "cluster-7",
+    cluster_title: "Provider refresh",
+    cluster_role: "representative",
+    ...overrides,
+  };
+}
+
+function reviewFileRow(position: number, filePath: string): Record<string, unknown> {
+  return {
+    row_kind: "file",
+    thread_id: 42,
+    file_position: position,
+    file_path: filePath,
+    file_status: "modified",
+    file_additions: 1,
+    file_deletions: 1,
+    file_changes: 2,
+    file_previous_path: "",
+    file_fetched_at: generatedAt,
+  };
+}
+
+function snapshotProvenance(id: string): GitcrawlQueryEnvelope["snapshot"] {
+  return {
+    id,
+    source_sha256: id,
+    schema_name: "gitcrawl-cloud-v2",
+    schema_version: 2,
+    schema_hash: "gitcrawl-cloud-v2",
+    capabilities: [...GITCRAWL_QUERY_NAMES],
+    source_sync_at: generatedAt,
+    dataset_generated_at: generatedAt,
+    coverage_complete: true,
+    published_at: generatedAt,
+    cutover_at: generatedAt,
+  };
+}
+
+function jsonResponse(
+  values: Record<string, unknown>[],
+  stats: Record<string, unknown> = {},
+): Response {
+  const columns = values.length > 0 ? Object.keys(values[0]!) : [];
+  return new Response(
+    JSON.stringify({
+      columns,
+      rows: values.map((row) => columns.map((column) => row[column])),
+      values,
+      snapshot: snapshotProvenance(snapshotId),
+      stats: {
+        contract_version: GITCRAWL_QUERY_CONTRACT_VERSION,
+        repository,
+        archive,
+        snapshot_id: snapshotId,
+        source_sync_at: generatedAt,
+        dataset_generated_at: generatedAt,
+        coverage_complete: true,
+        next_cursor: "",
+        ...stats,
+      },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+function seedLocalDatabase(dbPath: string): void {
+  const db = new DatabaseSync(dbPath);
+  db.exec(`
+    create table repositories (
+      id integer primary key,
+      full_name text not null,
+      owner text not null,
+      name text not null
+    );
+    create table threads (
+      id integer primary key,
+      repo_id integer not null,
+      number integer not null,
+      kind text not null,
+      state text not null,
+      title text not null,
+      body text,
+      author_login text not null,
+      author_type text not null,
+      author_association text not null,
+      html_url text not null,
+      labels_json text not null,
+      assignees_json text not null,
+      is_draft integer not null,
+      created_at_gh text not null,
+      updated_at_gh text not null,
+      closed_at_gh text not null,
+      merged_at_gh text not null,
+      last_pulled_at text not null,
+      updated_at text not null
+    );
+    create table thread_revisions (
+      id integer primary key,
+      thread_id integer not null,
+      source_updated_at text not null,
+      content_hash text not null,
+      created_at text not null
+    );
+    create table thread_fingerprints (
+      id integer primary key,
+      thread_revision_id integer not null,
+      algorithm_version text not null,
+      fingerprint_hash text not null,
+      fingerprint_slug text not null,
+      created_at text not null
+    );
+    create table thread_key_summaries (
+      id integer primary key,
+      thread_revision_id integer not null,
+      key_text text not null,
+      created_at text not null
+    );
+    create table cluster_groups (
+      id integer primary key,
+      repo_id integer not null,
+      stable_key text not null,
+      stable_slug text not null,
+      status text not null,
+      cluster_type text not null,
+      representative_thread_id integer not null,
+      title text not null,
+      created_at text not null,
+      updated_at text not null,
+      closed_at text not null,
+      member_count integer not null
+    );
+    create table cluster_memberships (
+      cluster_id integer not null,
+      thread_id integer not null,
+      role text not null,
+      state text not null,
+      score_to_representative real,
+      created_at text not null,
+      updated_at text not null
+    );
+    create table pull_request_details (
+      thread_id integer primary key,
+      base_sha text not null,
+      head_sha text not null,
+      head_ref text not null,
+      head_repo_full_name text not null,
+      mergeable_state text not null,
+      additions integer not null,
+      deletions integer not null,
+      changed_files integer not null,
+      fetched_at text not null,
+      updated_at text not null
+    );
+    create table pull_request_files (
+      thread_id integer not null,
+      position integer not null,
+      path text not null,
+      status text not null,
+      additions integer not null,
+      deletions integer not null,
+      changes integer not null,
+      previous_path text not null,
+      fetched_at text not null
+    );
+    create table sync_runs (
+      id integer primary key,
+      repo_id integer not null,
+      scope text not null,
+      status text not null,
+      started_at text not null,
+      finished_at text not null,
+      stats_json text not null
+    );
+    create table portable_metadata (key text primary key, value text not null);
+  `);
+  db.prepare("insert into repositories values (?, ?, ?, ?)").run(
+    1,
+    repository,
+    "openclaw",
+    "openclaw",
+  );
+  db.prepare(
+    `insert into threads(
+       id, repo_id, number, kind, state, title, body, author_login, author_type,
+       author_association, html_url, labels_json, assignees_json, is_draft,
+       created_at_gh, updated_at_gh, closed_at_gh, merged_at_gh, last_pulled_at, updated_at
+     ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    42,
+    1,
+    42,
+    "pull_request",
+    "open",
+    "Fix provider refresh",
+    "Fixes token refresh after expiry.",
+    "contributor",
+    "User",
+    "CONTRIBUTOR",
+    "https://github.com/openclaw/openclaw/pull/42",
+    "[]",
+    "[]",
+    0,
+    generatedAt,
+    generatedAt,
+    "",
+    "",
+    generatedAt,
+    generatedAt,
+  );
+  db.prepare("insert into thread_revisions values (?, ?, ?, ?, ?)").run(
+    9,
+    42,
+    generatedAt,
+    revision,
+    generatedAt,
+  );
+  db.prepare("insert into thread_fingerprints values (?, ?, ?, ?, ?, ?)").run(
+    10,
+    9,
+    "thread-fingerprint-v2",
+    fingerprint,
+    "fp",
+    generatedAt,
+  );
+  db.prepare("insert into thread_key_summaries values (?, ?, ?, ?)").run(
+    11,
+    9,
+    "Fixes token refresh",
+    generatedAt,
+  );
+  db.prepare("insert into cluster_groups values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").run(
+    7,
+    1,
+    "cluster-key",
+    "cluster-7",
+    "active",
+    "duplicate_candidate",
+    42,
+    "Provider refresh",
+    generatedAt,
+    generatedAt,
+    "",
+    1,
+  );
+  db.prepare("insert into cluster_memberships values (?, ?, ?, ?, ?, ?, ?)").run(
+    7,
+    42,
+    "representative",
+    "active",
+    1,
+    generatedAt,
+    generatedAt,
+  );
+  db.prepare("insert into pull_request_details values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").run(
+    42,
+    "1".repeat(40),
+    "2".repeat(40),
+    "fix/provider-refresh",
+    "contributor/openclaw",
+    "clean",
+    5,
+    2,
+    1,
+    generatedAt,
+    generatedAt,
+  );
+  db.prepare("insert into pull_request_files values (?, ?, ?, ?, ?, ?, ?, ?, ?)").run(
+    42,
+    0,
+    "src/provider.ts",
+    "modified",
+    1,
+    1,
+    2,
+    "",
+    generatedAt,
+  );
+  db.prepare("insert into portable_metadata values ('exported_at', ?)").run(generatedAt);
+  db.prepare("insert into sync_runs values (?, ?, ?, ?, ?, ?, ?)").run(
+    1,
+    1,
+    "open",
+    "success",
+    generatedAt,
+    generatedAt,
+    JSON.stringify({
+      repository,
+      threads_synced: 1,
+      metadata_only: false,
+      started_at: generatedAt,
+      finished_at: generatedAt,
+    }),
+  );
+  db.close();
+}

--- a/test/repair/gitcrawl-query-evidence.test.ts
+++ b/test/repair/gitcrawl-query-evidence.test.ts
@@ -1183,7 +1183,7 @@ test("local portable export timestamps are not source freshness proof", async ()
   }
 });
 
-test("local portable cluster coverage binds to exported metadata", async () => {
+test("local portable cluster coverage requires explicit run provenance", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-query-portable-"));
   const dbPath = path.join(directory, "gitcrawl.db");
   seedLocalDatabase(dbPath);
@@ -1219,10 +1219,10 @@ test("local portable cluster coverage binds to exported metadata", async () => {
     now: () => now,
   });
   try {
-    assert.equal((await adapter.listClusters()).rows[0]?.id, 7);
-    assert.equal((await adapter.clusterMembers(7)).rows[0]?.number, 42);
     assert.equal(adapter.provenance.source_sync_at, generatedAt);
     assert.equal(adapter.provenance.dataset_generated_at, generatedAt);
+    await assert.rejects(adapter.listClusters(), /cluster_groups coverage is incomplete/);
+    await assert.rejects(adapter.clusterMembers(7), /cluster_groups coverage is incomplete/);
   } finally {
     await adapter.close();
     fs.rmSync(directory, { force: true, recursive: true });

--- a/test/repair/gitcrawl-query-evidence.test.ts
+++ b/test/repair/gitcrawl-query-evidence.test.ts
@@ -516,6 +516,45 @@ test("query evidence fails closed on source, relation, review, and packet drift"
     await adapter.close();
   });
 
+  await t.test("parity reverses an ordered result", async () => {
+    const first = memberRow({ cluster_member_count: 2 });
+    const second = memberRow({
+      cluster_member_count: 2,
+      thread_id: 43,
+      number: 43,
+      updated_at_gh: "2026-07-14T09:54:00.000Z",
+    });
+    const adapter = await GitcrawlEvidenceAdapter.fromSources({
+      repository,
+      provider: "parity",
+      primarySource: new FixtureSource({
+        provider: "cloud",
+        rows: { "gitcrawl.clusters.members": [first, second] },
+      }),
+      paritySource: new FixtureSource({
+        provider: "local",
+        rows: { "gitcrawl.clusters.members": [second, first] },
+      }),
+      now: () => now,
+    });
+    await assert.rejects(adapter.clusterMembers(7), /cloud\/local parity mismatch/);
+    await adapter.close();
+  });
+
+  await t.test("cluster and thread timestamps are canonical", async () => {
+    const clusters = await adapterFor({
+      "gitcrawl.clusters.list": [clusterRow({ created_at: "not-a-timestamp" })],
+    });
+    await assert.rejects(clusters.listClusters(), /cluster created_at is invalid/);
+    await clusters.close();
+
+    const threads = await adapterFor({
+      "gitcrawl.threads.search": [memberRow({ created_at_gh: "not-a-timestamp" })],
+    });
+    await assert.rejects(threads.searchOpenPullRequests(), /thread created_at is invalid/);
+    await threads.close();
+  });
+
   await t.test("thread kind is unknown", async () => {
     const adapter = await adapterFor({
       "gitcrawl.clusters.related": [

--- a/test/repair/gitcrawl-query-evidence.test.ts
+++ b/test/repair/gitcrawl-query-evidence.test.ts
@@ -287,6 +287,33 @@ test("query evidence fails closed on source, relation, review, and packet drift"
     );
   });
 
+  await t.test("packets and coverage rows reject unsupported fields", () => {
+    const packet = buildGitcrawlEvidencePacket({
+      provider: "cloud",
+      repository,
+      snapshotId,
+      coverage: completeCoverage(),
+      claims: [],
+      generatedAt,
+    });
+    (packet as unknown as Record<string, unknown>).ignored = true;
+    let { sha256: _sha256, ...unsigned } = packet as unknown as Record<string, unknown>;
+    packet.sha256 = sha256Canonical(unsigned);
+    assert.throws(
+      () => verifyGitcrawlEvidencePacket(packet),
+      /packet contains unsupported field ignored/,
+    );
+
+    delete (packet as unknown as Record<string, unknown>).ignored;
+    (packet.coverage[0] as unknown as Record<string, unknown>).ignored = true;
+    ({ sha256: _sha256, ...unsigned } = packet as unknown as Record<string, unknown>);
+    packet.sha256 = sha256Canonical(unsigned);
+    assert.throws(
+      () => verifyGitcrawlEvidencePacket(packet),
+      /coverage row contains unsupported field ignored/,
+    );
+  });
+
   await t.test("claims contain unsupported fields", async () => {
     const adapter = await adapterFor({ "gitcrawl.clusters.list": [clusterRow()] });
     const claim = (await adapter.listClusters()).claims[0]!;

--- a/test/repair/gitcrawl-query-evidence.test.ts
+++ b/test/repair/gitcrawl-query-evidence.test.ts
@@ -140,6 +140,51 @@ test("query evidence fails closed on source, relation, review, and packet drift"
     await adapter.close();
   });
 
+  await t.test("bounded queries reject nonterminal truncation and bind max_rows", async () => {
+    const source = new FixtureSource({
+      rows: {
+        "gitcrawl.clusters.list": [clusterRow(), clusterRow({ cluster_id: 8 })],
+      },
+    });
+    const adapter = await GitcrawlEvidenceAdapter.fromSources({
+      repository,
+      provider: "cloud",
+      primarySource: source,
+      pageSize: 1,
+      now: () => now,
+    });
+    await assert.rejects(
+      adapter.listClusters({ maxRows: 1 }),
+      /truncated a nonterminal result at max_rows=1/,
+    );
+    const request = source.requests.find(
+      (candidate) => candidate.name === "gitcrawl.clusters.list",
+    );
+    assert.equal(request?.args.max_rows, 1);
+    await adapter.close();
+  });
+
+  await t.test("overlapping pages cannot satisfy declared membership", async () => {
+    const source = new FixtureSource({
+      overlapSecondPageFor: "gitcrawl.clusters.members",
+      rows: {
+        "gitcrawl.clusters.members": [
+          memberRow({ cluster_member_count: 2 }),
+          memberRow({ cluster_member_count: 2, thread_id: 43, number: 43 }),
+        ],
+      },
+    });
+    const adapter = await GitcrawlEvidenceAdapter.fromSources({
+      repository,
+      provider: "cloud",
+      primarySource: source,
+      pageSize: 1,
+      now: () => now,
+    });
+    await assert.rejects(adapter.clusterMembers(7), /duplicate row identity/);
+    await adapter.close();
+  });
+
   await t.test("related results point back to themselves", async () => {
     const adapter = await adapterFor({
       "gitcrawl.clusters.related": [{ source_number: 42, ...memberRow() }],
@@ -248,6 +293,55 @@ test("query evidence fails closed on source, relation, review, and packet drift"
           relations: [{ predicate: "describes", target: " " }],
         }),
       /relation target is missing or malformed/,
+    );
+    assert.throws(
+      () =>
+        createGitcrawlEvidenceClaim({
+          ...base,
+          subject: "openclaw/other#dataset:threads",
+        }),
+      /claim subject is missing or malformed/,
+    );
+    assert.throws(
+      () =>
+        createGitcrawlEvidenceClaim({
+          ...base,
+          relations: [
+            {
+              predicate: "describes",
+              target: "openclaw/other#dataset:repositories",
+            },
+          ],
+        }),
+      /relation target is missing or malformed/,
+    );
+  });
+
+  await t.test("source revision metadata is canonical", () => {
+    const base = {
+      provider: "cloud" as const,
+      repository,
+      snapshotId,
+      queryName: "gitcrawl.coverage" as const,
+      queryArgs: {},
+      subject: `${repository}#dataset:threads`,
+      data: { dataset: "threads" },
+    };
+    assert.throws(
+      () =>
+        createGitcrawlEvidenceClaim({
+          ...base,
+          sourceRevision: { id: -1, updated_at: generatedAt },
+        }),
+      /id must be a positive safe integer/,
+    );
+    assert.throws(
+      () =>
+        createGitcrawlEvidenceClaim({
+          ...base,
+          sourceRevision: { id: 1, updated_at: "not-a-timestamp" },
+        }),
+      /source revision updated_at is invalid/,
     );
   });
 
@@ -478,6 +572,40 @@ test("cloud source does not retry before a long Retry-After window", async () =>
   assert.deepEqual(sleeps, []);
 });
 
+test("cloud source rejects redirects without retrying authenticated requests", async () => {
+  let requests = 0;
+  const sleeps: number[] = [];
+  const source = new CloudGitcrawlQuerySource({
+    baseUrl: "https://crawl.example.test",
+    archive,
+    repository,
+    token: "reader-token",
+    maxAttempts: 3,
+    sleep: async (delayMs) => {
+      sleeps.push(delayMs);
+    },
+    fetch: async () => {
+      requests += 1;
+      return new Response("", {
+        status: 302,
+        headers: { location: "https://other.example.test/query" },
+      });
+    },
+  });
+  await assert.rejects(
+    source.query({
+      name: "gitcrawl.coverage",
+      args: {},
+      limit: 50,
+      cursor: "",
+      snapshot_id: "",
+    }),
+    /refused a redirected response/,
+  );
+  assert.equal(requests, 1);
+  assert.deepEqual(sleeps, []);
+});
+
 test("local SQLite source snapshots and serves the six-query contract", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-query-evidence-"));
   const dbPath = path.join(directory, "gitcrawl.db");
@@ -501,6 +629,56 @@ test("local SQLite source snapshots and serves the six-query contract", async ()
     assert.equal((await adapter.searchOpenPullRequests()).rows[0]?.number, 42);
     assert.equal((await adapter.reviewContext(42)).rows.length, 2);
     assert.equal(adapter.coverage.length, GITCRAWL_DATASETS.length);
+  } finally {
+    await adapter.close();
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+test("local coverage rejects active clusters without valid memberships", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-query-coverage-"));
+  const dbPath = path.join(directory, "gitcrawl.db");
+  seedLocalDatabase(dbPath);
+  const db = new DatabaseSync(dbPath);
+  db.exec("delete from cluster_memberships");
+  db.close();
+  const source = await LocalGitcrawlQuerySource.open({
+    dbPath,
+    repository,
+    allowLegacy: false,
+  });
+  const adapter = await GitcrawlEvidenceAdapter.fromSources({
+    repository,
+    provider: "local",
+    primarySource: source,
+    now: () => now,
+  });
+  try {
+    await assert.rejects(adapter.listClusters(), /cluster_groups coverage is incomplete/);
+  } finally {
+    await adapter.close();
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+test("local related query ignores memberships in closed clusters", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-query-closed-related-"));
+  const dbPath = path.join(directory, "gitcrawl.db");
+  seedLocalDatabase(dbPath);
+  seedClosedRelatedMembership(dbPath);
+  const source = await LocalGitcrawlQuerySource.open({
+    dbPath,
+    repository,
+    allowLegacy: false,
+  });
+  const adapter = await GitcrawlEvidenceAdapter.fromSources({
+    repository,
+    provider: "local",
+    primarySource: source,
+    now: () => now,
+  });
+  try {
+    assert.deepEqual((await adapter.related(42)).rows, []);
   } finally {
     await adapter.close();
     fs.rmSync(directory, { force: true, recursive: true });
@@ -557,6 +735,20 @@ test("policy sanitization removes hidden instructions before scoring or claims",
     deriveGitcrawlThreadPolicySignals("maintenance", "Fix: refresh tokens").concreteFix,
     true,
   );
+  assert.equal(
+    stripGitcrawlHtmlComments("safe<!-- outer <!-- nested --> hidden -->tail"),
+    "safe\ntail",
+  );
+});
+
+test("search and review evidence must agree on one thread safety projection", async () => {
+  const adapter = await adapterFor({
+    "gitcrawl.threads.search": [memberRow()],
+    "gitcrawl.pull_requests.review_context": [reviewContextRow({ body: "Different review body" })],
+  });
+  await adapter.searchOpenPullRequests();
+  await assert.rejects(adapter.reviewContext(42), /search and review safety projections diverge/);
+  await adapter.close();
 });
 
 test("oversized multibyte label evidence becomes a bounded digest marker", async () => {
@@ -594,24 +786,34 @@ class FixtureSource implements GitcrawlQuerySource {
 
   private readonly rows: Partial<Record<GitcrawlQueryRequest["name"], Record<string, unknown>[]>>;
   private readonly snapshotForQuery: (request: GitcrawlQueryRequest) => string;
+  private readonly overlapSecondPageFor: GitcrawlQueryRequest["name"] | undefined;
 
   constructor(
     options: {
       provider?: "local" | "cloud";
       rows?: Partial<Record<GitcrawlQueryRequest["name"], Record<string, unknown>[]>>;
       snapshotForQuery?: (request: GitcrawlQueryRequest) => string;
+      overlapSecondPageFor?: GitcrawlQueryRequest["name"];
     } = {},
   ) {
     this.provider = options.provider ?? "cloud";
     this.rows = options.rows ?? {};
     this.snapshotForQuery = options.snapshotForQuery ?? (() => snapshotId);
+    this.overlapSecondPageFor = options.overlapSecondPageFor;
   }
 
   async query(request: GitcrawlQueryRequest): Promise<GitcrawlQueryEnvelope> {
     this.requests.push(request);
     const rows =
       request.name === "gitcrawl.coverage" ? completeCoverage() : (this.rows[request.name] ?? []);
-    const values = orderRows(request, rows).slice(0, request.limit);
+    const requestedOffset = request.cursor ? Number(request.cursor) : 0;
+    const offset =
+      request.name === this.overlapSecondPageFor && requestedOffset > 0
+        ? requestedOffset - 1
+        : requestedOffset;
+    const ordered = orderRows(request, rows);
+    const values = ordered.slice(offset, offset + request.limit);
+    const nextOffset = requestedOffset + values.length;
     const querySnapshotId = this.snapshotForQuery(request);
     return {
       values,
@@ -624,7 +826,7 @@ class FixtureSource implements GitcrawlQuerySource {
         source_sync_at: generatedAt,
         dataset_generated_at: generatedAt,
         coverage_complete: true,
-        next_cursor: "",
+        next_cursor: nextOffset < ordered.length ? String(nextOffset) : "",
       },
     };
   }
@@ -669,7 +871,7 @@ function completeCoverage(): GitcrawlCoverageRow[] {
   }));
 }
 
-function clusterRow(): Record<string, unknown> {
+function clusterRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
     cluster_id: 7,
     stable_slug: "cluster-7",
@@ -685,6 +887,7 @@ function clusterRow(): Record<string, unknown> {
     created_at: generatedAt,
     updated_at: generatedAt,
     closed_at: "",
+    ...overrides,
   };
 }
 
@@ -1053,6 +1256,30 @@ function seedDuplicateRelatedMemberships(dbPath: string): void {
     values (
       8, 1, 'cluster-key-8', 'cluster-8', 'active', 'duplicate_candidate', 42,
       'Second provider cluster', '${generatedAt}', '${generatedAt}', '', 2
+    );
+    insert into cluster_memberships
+    values (8, 42, 'representative', 'active', 1, '${generatedAt}', '${generatedAt}');
+    insert into cluster_memberships
+    values (8, 43, 'member', 'active', 0.7, '${generatedAt}', '${generatedAt}');
+  `);
+  db.close();
+}
+
+function seedClosedRelatedMembership(dbPath: string): void {
+  const db = new DatabaseSync(dbPath);
+  db.exec(`
+    insert into threads
+    select 43, repo_id, 43, 'issue', state, 'Related provider issue', body,
+           author_login, author_type, author_association,
+           'https://github.com/openclaw/openclaw/issues/43',
+           labels_json, assignees_json, is_draft, created_at_gh, updated_at_gh,
+           closed_at_gh, merged_at_gh, last_pulled_at, updated_at
+    from threads where id = 42;
+
+    insert into cluster_groups
+    values (
+      8, 1, 'cluster-key-8', 'cluster-8', 'closed', 'duplicate_candidate', 42,
+      'Closed provider cluster', '${generatedAt}', '${generatedAt}', '${generatedAt}', 2
     );
     insert into cluster_memberships
     values (8, 42, 'representative', 'active', 1, '${generatedAt}', '${generatedAt}');

--- a/test/repair/gitcrawl-query-evidence.test.ts
+++ b/test/repair/gitcrawl-query-evidence.test.ts
@@ -491,6 +491,29 @@ test("query evidence fails closed on source, relation, review, and packet drift"
     );
   });
 
+  await t.test("incomplete packet coverage cannot exceed total rows", () => {
+    const coverage = completeCoverage();
+    const clusterCoverage = coverage.find((row) => row.dataset === "cluster_groups");
+    assert(clusterCoverage);
+    clusterCoverage.row_count = 1;
+    clusterCoverage.eligible_count = 2;
+    clusterCoverage.covered_count = 0;
+    clusterCoverage.complete = false;
+    assert.throws(
+      () =>
+        buildGitcrawlEvidencePacket({
+          provider: "cloud",
+          repository,
+          snapshotId,
+          coverage,
+          requiredCoverage: ["repositories", "threads"],
+          claims: [],
+          generatedAt,
+        }),
+      /more eligible rows than total rows/,
+    );
+  });
+
   await t.test("packet generation is an RFC 3339 timestamp", () => {
     assert.throws(
       () =>

--- a/test/repair/gitcrawl-query-evidence.test.ts
+++ b/test/repair/gitcrawl-query-evidence.test.ts
@@ -1070,7 +1070,7 @@ test("local coverage rejects active clusters without valid memberships", async (
 });
 
 test("local cluster coverage requires the latest successful run", async (t) => {
-  for (const scenario of ["missing", "stale"] as const) {
+  for (const scenario of ["missing", "stale", "predates-source"] as const) {
     await t.test(scenario, async () => {
       const directory = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-query-run-"));
       const dbPath = path.join(directory, "gitcrawl.db");
@@ -1078,7 +1078,7 @@ test("local cluster coverage requires the latest successful run", async (t) => {
       const db = new DatabaseSync(dbPath);
       if (scenario === "missing") {
         db.exec("delete from cluster_runs");
-      } else {
+      } else if (scenario === "stale") {
         db.prepare("insert into cluster_runs values (?, ?, ?, ?, ?, ?, ?)").run(
           2,
           1,
@@ -1087,6 +1087,27 @@ test("local cluster coverage requires the latest successful run", async (t) => {
           generatedAt,
           generatedAt,
           "{}",
+        );
+      } else {
+        const sourceAt = "2026-07-14T09:56:00.000Z";
+        db.prepare(
+          `update sync_runs
+           set started_at = ?, finished_at = ?, stats_json = ?
+           where repo_id = ?`,
+        ).run(
+          sourceAt,
+          sourceAt,
+          JSON.stringify({
+            repository,
+            threads_synced: 1,
+            metadata_only: false,
+            started_at: sourceAt,
+            finished_at: sourceAt,
+          }),
+          1,
+        );
+        db.prepare("update portable_metadata set value = ? where key = 'exported_at'").run(
+          sourceAt,
         );
       }
       db.close();

--- a/test/repair/gitcrawl-query-evidence.test.ts
+++ b/test/repair/gitcrawl-query-evidence.test.ts
@@ -228,6 +228,14 @@ test("query evidence fails closed on source, relation, review, and packet drift"
     await adapter.close();
   });
 
+  await t.test("replayed canonical threads cannot hide behind provider row ids", async () => {
+    const adapter = await adapterFor({
+      "gitcrawl.threads.search": [memberRow(), memberRow({ thread_id: 43 })],
+    });
+    await assert.rejects(adapter.searchOpenPullRequests(), /duplicate row identity/);
+    await adapter.close();
+  });
+
   await t.test("related results point back to themselves", async () => {
     const adapter = await adapterFor({
       "gitcrawl.clusters.related": [{ source_number: 42, ...memberRow() }],

--- a/test/repair/gitcrawl-query-evidence.test.ts
+++ b/test/repair/gitcrawl-query-evidence.test.ts
@@ -1416,7 +1416,9 @@ test("policy sanitization removes hidden instructions before scoring or claims",
 test("search and review evidence must agree on one thread safety projection", async () => {
   const adapter = await adapterFor({
     "gitcrawl.threads.search": [memberRow()],
-    "gitcrawl.pull_requests.review_context": [reviewContextRow({ body: "Different review body" })],
+    "gitcrawl.pull_requests.review_context": [
+      reviewContextRow({ body: "Different review body", thread_id: 43 }),
+    ],
   });
   await adapter.searchOpenPullRequests();
   await assert.rejects(adapter.reviewContext(42), /search and review safety projections diverge/);

--- a/test/repair/gitcrawl-query-evidence.test.ts
+++ b/test/repair/gitcrawl-query-evidence.test.ts
@@ -257,6 +257,20 @@ test("query evidence fails closed on source, relation, review, and packet drift"
     }
   });
 
+  await t.test("thread rows bind repository, kind, and number to their URL", async () => {
+    for (const mismatched of [
+      { html_url: "https://github.com/openclaw/other/pull/42" },
+      { kind: "issue", html_url: "https://github.com/openclaw/openclaw/pull/42" },
+      { number: 43, html_url: "https://github.com/openclaw/openclaw/pull/42" },
+    ]) {
+      const adapter = await adapterFor({
+        "gitcrawl.threads.search": [memberRow(mismatched)],
+      });
+      await assert.rejects(adapter.searchOpenPullRequests(), /thread identity does not match/);
+      await adapter.close();
+    }
+  });
+
   await t.test("packet claims are mutated after binding", () => {
     const packet = buildGitcrawlEvidencePacket({
       provider: "cloud",
@@ -1261,6 +1275,8 @@ function clusterRow(overrides: Record<string, unknown> = {}): Record<string, unk
 }
 
 function memberRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const number = Number(overrides.number ?? 42);
+  const kind = String(overrides.kind ?? "pull_request");
   return {
     cluster_id: 7,
     cluster_member_count: 1,
@@ -1270,15 +1286,15 @@ function memberRow(overrides: Record<string, unknown> = {}): Record<string, unkn
     membership_state: "active",
     score_to_representative: 1,
     thread_id: 42,
-    number: 42,
-    kind: "pull_request",
+    number,
+    kind,
     state: "open",
     title: "Fix provider refresh",
     body: "Fixes token refresh after expiry.",
     author_login: "contributor",
     author_type: "User",
     author_association: "CONTRIBUTOR",
-    html_url: "https://github.com/openclaw/openclaw/pull/42",
+    html_url: `https://github.com/openclaw/openclaw/${kind === "pull_request" ? "pull" : "issues"}/${number}`,
     labels_json: "[]",
     assignees_json: "[]",
     security_metadata_complete: 1,

--- a/test/repair/gitcrawl-query-evidence.test.ts
+++ b/test/repair/gitcrawl-query-evidence.test.ts
@@ -277,13 +277,14 @@ test("query evidence fails closed on source, relation, review, and packet drift"
       repository,
       snapshotId,
       coverage: completeCoverage(),
+      requiredCoverage: ["repositories", "threads"],
       claims: [],
       generatedAt,
     });
     packet.coverage[0]!.covered_count = 0;
     assert.throws(
       () => verifyGitcrawlEvidencePacket(packet),
-      /digest mismatch|incomplete coverage/,
+      /digest mismatch|incomplete coverage|invalid complete coverage/,
     );
   });
 
@@ -293,6 +294,7 @@ test("query evidence fails closed on source, relation, review, and packet drift"
       repository,
       snapshotId,
       coverage: completeCoverage(),
+      requiredCoverage: ["repositories", "threads"],
       claims: [],
       generatedAt,
     });
@@ -456,6 +458,7 @@ test("query evidence fails closed on source, relation, review, and packet drift"
           repository,
           snapshotId,
           coverage,
+          requiredCoverage: ["repositories", "threads"],
           claims: [],
           generatedAt,
         }),
@@ -471,6 +474,7 @@ test("query evidence fails closed on source, relation, review, and packet drift"
           repository,
           snapshotId,
           coverage: completeCoverage(),
+          requiredCoverage: ["repositories", "threads"],
           claims: [],
           generatedAt: "not-a-timestamp",
         }),
@@ -481,6 +485,7 @@ test("query evidence fails closed on source, relation, review, and packet drift"
       repository,
       snapshotId,
       coverage: completeCoverage(),
+      requiredCoverage: ["repositories", "threads"],
       claims: [],
       generatedAt,
     });
@@ -488,6 +493,45 @@ test("query evidence fails closed on source, relation, review, and packet drift"
     const { sha256: _sha256, ...unsigned } = packet;
     packet.sha256 = sha256Canonical(unsigned);
     assert.throws(() => verifyGitcrawlEvidencePacket(packet), /packet generated_at is invalid/);
+  });
+
+  await t.test("packet coverage defaults to the included claim queries", () => {
+    const coverage = completeCoverage();
+    const unrelated = coverage.find((row) => row.dataset === "cluster_groups");
+    assert(unrelated);
+    unrelated.covered_count = 0;
+    unrelated.complete = false;
+    const claim = createGitcrawlEvidenceClaim({
+      provider: "cloud",
+      repository,
+      snapshotId,
+      queryName: "gitcrawl.threads.search",
+      queryArgs: { owner: "openclaw", repo: "openclaw" },
+      subject: `${repository}#pull:42`,
+      data: memberRow(),
+    });
+    const packet = buildGitcrawlEvidencePacket({
+      provider: "cloud",
+      repository,
+      snapshotId,
+      coverage,
+      claims: [claim],
+      generatedAt,
+    });
+    assert.deepEqual(packet.required_coverage, ["repositories", "threads"]);
+    assert.doesNotThrow(() => verifyGitcrawlEvidencePacket(packet));
+    assert.throws(
+      () =>
+        buildGitcrawlEvidencePacket({
+          provider: "cloud",
+          repository,
+          snapshotId,
+          coverage,
+          claims: [],
+          generatedAt,
+        }),
+      /without claims require explicit coverage/,
+    );
   });
 
   await t.test("packet repository is relabeled", async () => {

--- a/test/repair/gitcrawl-query-evidence.test.ts
+++ b/test/repair/gitcrawl-query-evidence.test.ts
@@ -1238,6 +1238,32 @@ test("local PR file coverage requires its own current child reservation", async 
   }
 });
 
+test("local PR details require canonical repository and number identity", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-query-pr-identity-"));
+  const dbPath = path.join(directory, "gitcrawl.db");
+  seedLocalDatabase(dbPath);
+  const db = new DatabaseSync(dbPath);
+  db.exec("update pull_request_details set number = 43 where thread_id = 42");
+  db.close();
+  const source = await LocalGitcrawlQuerySource.open({
+    dbPath,
+    repository,
+    allowLegacy: false,
+  });
+  const adapter = await GitcrawlEvidenceAdapter.fromSources({
+    repository,
+    provider: "local",
+    primarySource: source,
+    now: () => now,
+  });
+  try {
+    await assert.rejects(adapter.reviewContext(42), /pull_request_details coverage is incomplete/);
+  } finally {
+    await adapter.close();
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+});
+
 test("local related query ignores memberships in closed clusters", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-query-closed-related-"));
   const dbPath = path.join(directory, "gitcrawl.db");
@@ -1691,6 +1717,8 @@ function seedLocalDatabase(dbPath: string): void {
     );
     create table pull_request_details (
       thread_id integer primary key,
+      repo_id integer not null,
+      number integer not null,
       base_sha text not null,
       head_sha text not null,
       head_ref text not null,
@@ -1825,7 +1853,9 @@ function seedLocalDatabase(dbPath: string): void {
     generatedAt,
     generatedAt,
   );
-  db.prepare("insert into pull_request_details values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").run(
+  db.prepare("insert into pull_request_details values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").run(
+    42,
+    1,
     42,
     "1".repeat(40),
     "2".repeat(40),
@@ -1937,7 +1967,7 @@ function seedUnrelatedRepositoryFiles(dbPath: string): void {
     from threads where id = 42;
 
     insert into pull_request_details
-    select 84, base_sha, head_sha, head_ref, 'contributor/other', mergeable_state,
+    select 84, 2, 84, base_sha, head_sha, head_ref, 'contributor/other', mergeable_state,
            additions, deletions, 2, fetched_at, updated_at
     from pull_request_details where thread_id = 42;
 

--- a/test/repair/gitcrawl-query-evidence.test.ts
+++ b/test/repair/gitcrawl-query-evidence.test.ts
@@ -21,6 +21,7 @@ import {
   verifyGitcrawlEvidenceClaim,
 } from "../../dist/repair/gitcrawl-evidence-contract.js";
 import {
+  DEFAULT_EVIDENCE_PACKET_MAX_BYTES,
   buildGitcrawlEvidencePacket,
   verifyGitcrawlEvidencePacket,
 } from "../../dist/repair/gitcrawl-evidence-graph.js";
@@ -664,6 +665,24 @@ test("query evidence fails closed on source, relation, review, and packet drift"
       /packet exceeds 1024 bytes/,
     );
     await adapter.close();
+  });
+
+  await t.test("packet verification bounds input before canonicalization", () => {
+    const packet = buildGitcrawlEvidencePacket({
+      provider: "cloud",
+      repository,
+      snapshotId,
+      coverage: completeCoverage(),
+      requiredCoverage: ["repositories", "threads"],
+      claims: [],
+      generatedAt,
+    });
+    packet.coverage[0]!.max_source_at = "x".repeat(DEFAULT_EVIDENCE_PACKET_MAX_BYTES);
+    assert.throws(() => verifyGitcrawlEvidencePacket(packet), /packet exceeds 65536 bytes/);
+    assert.throws(
+      () => verifyGitcrawlEvidencePacket(packet, DEFAULT_EVIDENCE_PACKET_MAX_BYTES + 1),
+      /packet limit must be an integer from 1 to 65536/,
+    );
   });
 
   await t.test("parity hides policy-relevant relationship status", async () => {

--- a/test/repair/gitcrawl-query-evidence.test.ts
+++ b/test/repair/gitcrawl-query-evidence.test.ts
@@ -38,6 +38,7 @@ const revision = "b".repeat(64);
 const fingerprint = "c".repeat(64);
 const repository = "openclaw/openclaw";
 const archive = "gitcrawl/openclaw__openclaw";
+const cloudQueryUrl = `https://crawl.example.test/v1/apps/gitcrawl/archives/${encodeURIComponent(archive)}/query`;
 
 test("six-query adapter binds read-only evidence into verified claims and graph packets", async () => {
   const source = new FixtureSource({
@@ -552,10 +553,12 @@ test("cloud source does not retry before a long Retry-After window", async () =>
     },
     fetch: async () => {
       requests += 1;
-      return new Response("", {
-        status: 429,
-        headers: { "retry-after": "60" },
-      });
+      return cloudResponse(
+        new Response("", {
+          status: 429,
+          headers: { "retry-after": "60" },
+        }),
+      );
     },
   });
   await assert.rejects(
@@ -586,10 +589,12 @@ test("cloud source rejects redirects without retrying authenticated requests", a
     },
     fetch: async () => {
       requests += 1;
-      return new Response("", {
-        status: 302,
-        headers: { location: "https://other.example.test/query" },
-      });
+      return cloudResponse(
+        new Response("", {
+          status: 302,
+          headers: { location: "https://other.example.test/query" },
+        }),
+      );
     },
   });
   await assert.rejects(
@@ -604,6 +609,95 @@ test("cloud source rejects redirects without retrying authenticated requests", a
   );
   assert.equal(requests, 1);
   assert.deepEqual(sleeps, []);
+});
+
+test("cloud source requires exact successful status, origin metadata, and strict UTF-8", async () => {
+  const request = {
+    name: "gitcrawl.coverage" as const,
+    args: {},
+    limit: 50,
+    cursor: "",
+    snapshot_id: "",
+  };
+  for (const [response, pattern] of [
+    [cloudResponse(new Response("{}", { status: 202 })), /failed \(202;/],
+    [new Response("{}", { status: 200 }), /missing origin metadata/],
+    [
+      cloudResponse(
+        new Response(Uint8Array.from([0xc3, 0x28]), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+      /malformed UTF-8/,
+    ],
+  ] as const) {
+    const source = new CloudGitcrawlQuerySource({
+      baseUrl: "https://crawl.example.test",
+      archive,
+      repository,
+      token: "reader-token",
+      fetch: async () => response,
+    });
+    await assert.rejects(source.query(request), pattern);
+  }
+});
+
+test("cloud source validates request JSON before retrying and ignores malformed Retry-After", async () => {
+  let serializationRequests = 0;
+  const serializationSource = new CloudGitcrawlQuerySource({
+    baseUrl: "https://crawl.example.test",
+    archive,
+    repository,
+    token: "reader-token",
+    fetch: async () => {
+      serializationRequests += 1;
+      return jsonResponse(completeCoverage());
+    },
+  });
+  const circular: Record<string, unknown> = {};
+  circular.self = circular;
+  await assert.rejects(
+    serializationSource.query({
+      name: "gitcrawl.coverage",
+      args: circular,
+      limit: 50,
+      cursor: "",
+      snapshot_id: "",
+    }),
+    /request is not JSON serializable/,
+  );
+  assert.equal(serializationRequests, 0);
+
+  let retryRequests = 0;
+  const sleeps: number[] = [];
+  const retrySource = new CloudGitcrawlQuerySource({
+    baseUrl: "https://crawl.example.test",
+    archive,
+    repository,
+    token: "reader-token",
+    maxAttempts: 2,
+    retryBaseDelayMs: 25,
+    retryMaxDelayMs: 100,
+    sleep: async (delayMs) => {
+      sleeps.push(delayMs);
+    },
+    fetch: async () => {
+      retryRequests += 1;
+      return retryRequests === 1
+        ? cloudResponse(new Response("", { status: 429, headers: { "retry-after": "tomorrow" } }))
+        : jsonResponse(completeCoverage());
+    },
+  });
+  await retrySource.query({
+    name: "gitcrawl.coverage",
+    args: {},
+    limit: 50,
+    cursor: "",
+    snapshot_id: "",
+  });
+  assert.equal(retryRequests, 2);
+  assert.deepEqual(sleeps, [25]);
 });
 
 test("local SQLite source snapshots and serves the six-query contract", async () => {
@@ -984,26 +1078,33 @@ function jsonResponse(
   stats: Record<string, unknown> = {},
 ): Response {
   const columns = values.length > 0 ? Object.keys(values[0]!) : [];
-  return new Response(
-    JSON.stringify({
-      columns,
-      rows: values.map((row) => columns.map((column) => row[column])),
-      values,
-      snapshot: snapshotProvenance(snapshotId),
-      stats: {
-        contract_version: GITCRAWL_QUERY_CONTRACT_VERSION,
-        repository,
-        archive,
-        snapshot_id: snapshotId,
-        source_sync_at: generatedAt,
-        dataset_generated_at: generatedAt,
-        coverage_complete: true,
-        next_cursor: "",
-        ...stats,
-      },
-    }),
-    { status: 200, headers: { "content-type": "application/json" } },
+  return cloudResponse(
+    new Response(
+      JSON.stringify({
+        columns,
+        rows: values.map((row) => columns.map((column) => row[column])),
+        values,
+        snapshot: snapshotProvenance(snapshotId),
+        stats: {
+          contract_version: GITCRAWL_QUERY_CONTRACT_VERSION,
+          repository,
+          archive,
+          snapshot_id: snapshotId,
+          source_sync_at: generatedAt,
+          dataset_generated_at: generatedAt,
+          coverage_complete: true,
+          next_cursor: "",
+          ...stats,
+        },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    ),
   );
+}
+
+function cloudResponse(response: Response, url = cloudQueryUrl): Response {
+  Object.defineProperty(response, "url", { configurable: true, value: url });
+  return response;
 }
 
 function seedLocalDatabase(dbPath: string): void {

--- a/test/repair/gitcrawl-query-evidence.test.ts
+++ b/test/repair/gitcrawl-query-evidence.test.ts
@@ -346,6 +346,65 @@ test("query evidence fails closed on source, relation, review, and packet drift"
     );
   });
 
+  await t.test("claims reject non-JSON object values", () => {
+    const base = {
+      provider: "cloud" as const,
+      repository,
+      snapshotId,
+      queryName: "gitcrawl.coverage" as const,
+      queryArgs: {},
+      subject: `${repository}#dataset:threads`,
+    };
+    assert.throws(
+      () => createGitcrawlEvidenceClaim({ ...base, data: { observed_at: new Date(generatedAt) } }),
+      /canonical JSON rejects non-plain objects/,
+    );
+  });
+
+  await t.test("packet coverage is bound to its snapshot", () => {
+    const coverage = completeCoverage();
+    coverage[0]!.snapshot_id = "d".repeat(64);
+    assert.throws(
+      () =>
+        buildGitcrawlEvidencePacket({
+          provider: "cloud",
+          repository,
+          snapshotId,
+          coverage,
+          claims: [],
+          generatedAt,
+        }),
+      /mixes coverage snapshots/,
+    );
+  });
+
+  await t.test("packet generation is an RFC 3339 timestamp", () => {
+    assert.throws(
+      () =>
+        buildGitcrawlEvidencePacket({
+          provider: "cloud",
+          repository,
+          snapshotId,
+          coverage: completeCoverage(),
+          claims: [],
+          generatedAt: "not-a-timestamp",
+        }),
+      /packet generated_at is invalid/,
+    );
+    const packet = buildGitcrawlEvidencePacket({
+      provider: "cloud",
+      repository,
+      snapshotId,
+      coverage: completeCoverage(),
+      claims: [],
+      generatedAt,
+    });
+    packet.generated_at = "not-a-timestamp";
+    const { sha256: _sha256, ...unsigned } = packet;
+    packet.sha256 = sha256Canonical(unsigned);
+    assert.throws(() => verifyGitcrawlEvidencePacket(packet), /packet generated_at is invalid/);
+  });
+
   await t.test("packet repository is relabeled", async () => {
     const adapter = await adapterFor({ "gitcrawl.clusters.list": [clusterRow()] });
     const claim = (await adapter.listClusters()).claims[0]!;
@@ -955,6 +1014,7 @@ function orderRows(
 
 function completeCoverage(): GitcrawlCoverageRow[] {
   return GITCRAWL_DATASETS.map((dataset) => ({
+    snapshot_id: snapshotId,
     dataset,
     row_count: 1,
     eligible_count: 1,

--- a/test/repair/gitcrawl-query-evidence.test.ts
+++ b/test/repair/gitcrawl-query-evidence.test.ts
@@ -11,10 +11,13 @@ import {
   GITCRAWL_DATASETS,
   GITCRAWL_QUERY_CONTRACT_VERSION,
   GITCRAWL_QUERY_NAMES,
+  canonicalJson,
+  sha256Canonical,
   type GitcrawlCoverageRow,
   type GitcrawlQueryEnvelope,
   type GitcrawlQueryRequest,
   type GitcrawlQuerySource,
+  verifyGitcrawlEvidenceClaim,
 } from "../../dist/repair/gitcrawl-evidence-contract.js";
 import {
   buildGitcrawlEvidencePacket,
@@ -88,6 +91,12 @@ test("six-query adapter binds read-only evidence into verified claims and graph 
     ...search.claims,
     ...review.claims,
   ];
+  for (const claim of claims) {
+    assert.equal(claim.repository, repository);
+    const request = source.requests.find((candidate) => candidate.name === claim.query.name);
+    assert(request);
+    assert.equal(claim.query.args_sha256, sha256Canonical(request.args));
+  }
   const packet = buildGitcrawlEvidencePacket({
     provider: "cloud",
     repository,
@@ -172,6 +181,138 @@ test("query evidence fails closed on source, relation, review, and packet drift"
       /digest mismatch|incomplete coverage/,
     );
   });
+
+  await t.test("claims contain unsupported fields", async () => {
+    const adapter = await adapterFor({ "gitcrawl.clusters.list": [clusterRow()] });
+    const claim = (await adapter.listClusters()).claims[0]!;
+    (claim.query as unknown as Record<string, unknown>).ignored = true;
+    assert.throws(
+      () => verifyGitcrawlEvidenceClaim(claim),
+      /query contains unsupported field ignored/,
+    );
+    await adapter.close();
+  });
+
+  await t.test("packet repository is relabeled", async () => {
+    const adapter = await adapterFor({ "gitcrawl.clusters.list": [clusterRow()] });
+    const claim = (await adapter.listClusters()).claims[0]!;
+    assert.throws(
+      () =>
+        buildGitcrawlEvidencePacket({
+          provider: "cloud",
+          repository: "openclaw/other",
+          snapshotId,
+          coverage: completeCoverage(),
+          claims: [claim],
+          generatedAt,
+        }),
+      /mixes claim bindings/,
+    );
+    await adapter.close();
+  });
+
+  await t.test("v2 packet graph is recomputed as empty", async () => {
+    const adapter = await adapterFor({ "gitcrawl.clusters.list": [clusterRow()] });
+    const claim = (await adapter.listClusters()).claims[0]!;
+    const packet = buildGitcrawlEvidencePacket({
+      provider: "cloud",
+      repository,
+      snapshotId,
+      coverage: completeCoverage(),
+      claims: [claim],
+      generatedAt,
+    });
+    packet.graph = { nodes: [], edges: [] };
+    packet.included = { claims: 1, nodes: 0, edges: 0 };
+    const { sha256: _sha256, ...unsigned } = packet;
+    packet.sha256 = sha256Canonical(unsigned);
+    assert.throws(
+      () => verifyGitcrawlEvidencePacket(packet),
+      /graph does not match its verified claims/,
+    );
+    await adapter.close();
+  });
+
+  await t.test("packet bounds would discard claims or graph nodes", async () => {
+    const adapter = await adapterFor({
+      "gitcrawl.clusters.members": [memberRow()],
+    });
+    const claims = (await adapter.clusterMembers(7)).claims;
+    assert.throws(
+      () =>
+        buildGitcrawlEvidencePacket({
+          provider: "cloud",
+          repository,
+          snapshotId,
+          coverage: completeCoverage(),
+          claims,
+          generatedAt,
+          maxNodes: 1,
+        }),
+      /graph exceeds its complete bounds/,
+    );
+    assert.throws(
+      () =>
+        buildGitcrawlEvidencePacket({
+          provider: "cloud",
+          repository,
+          snapshotId,
+          coverage: completeCoverage(),
+          claims,
+          generatedAt,
+          maxBytes: 1_024,
+        }),
+      /packet exceeds 1024 bytes/,
+    );
+    await adapter.close();
+  });
+
+  await t.test("parity hides policy-relevant relationship status", async () => {
+    const primary = new FixtureSource({
+      provider: "cloud",
+      rows: {
+        "gitcrawl.clusters.related": [
+          { source_number: 42, ...memberRow({ thread_id: 43, number: 43, kind: "issue" }) },
+        ],
+      },
+    });
+    const parity = new FixtureSource({
+      provider: "local",
+      rows: {
+        "gitcrawl.clusters.related": [
+          {
+            source_number: 42,
+            ...memberRow({
+              thread_id: 43,
+              number: 43,
+              kind: "issue",
+              cluster_status: "closed",
+              membership_state: "inactive",
+            }),
+          },
+        ],
+      },
+    });
+    const adapter = await GitcrawlEvidenceAdapter.fromSources({
+      repository,
+      provider: "parity",
+      primarySource: primary,
+      paritySource: parity,
+      now: () => now,
+    });
+    await assert.rejects(adapter.related(42), /cloud\/local parity mismatch/);
+    await adapter.close();
+  });
+
+  await t.test("thread kind is unknown", async () => {
+    const adapter = await adapterFor({
+      "gitcrawl.clusters.related": [
+        { source_number: 42, ...memberRow({ thread_id: 43, number: 43, kind: "discussion" }) },
+      ],
+    });
+    await assert.rejects(adapter.related(42), /unsupported Gitcrawl thread kind/);
+    await adapter.close();
+  });
 });
 
 test("cloud source authenticates, binds identity, and refuses unsafe transport", async () => {
@@ -244,6 +385,41 @@ test("cloud source authenticates, binds identity, and refuses unsafe transport",
   );
 });
 
+test("cloud source does not retry before a long Retry-After window", async () => {
+  let requests = 0;
+  const sleeps: number[] = [];
+  const source = new CloudGitcrawlQuerySource({
+    baseUrl: "https://crawl.example.test",
+    archive,
+    repository,
+    token: "reader-token",
+    maxAttempts: 2,
+    retryMaxDelayMs: 2_000,
+    sleep: async (delayMs) => {
+      sleeps.push(delayMs);
+    },
+    fetch: async () => {
+      requests += 1;
+      return new Response("", {
+        status: 429,
+        headers: { "retry-after": "60" },
+      });
+    },
+  });
+  await assert.rejects(
+    source.query({
+      name: "gitcrawl.coverage",
+      args: {},
+      limit: 50,
+      cursor: "",
+      snapshot_id: "",
+    }),
+    /Retry-After beyond the configured wait budget/,
+  );
+  assert.equal(requests, 1);
+  assert.deepEqual(sleeps, []);
+});
+
 test("local SQLite source snapshots and serves the six-query contract", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-query-evidence-"));
   const dbPath = path.join(directory, "gitcrawl.db");
@@ -273,6 +449,34 @@ test("local SQLite source snapshots and serves the six-query contract", async ()
   }
 });
 
+test("local related query deduplicates one thread shared through multiple clusters", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-query-related-"));
+  const dbPath = path.join(directory, "gitcrawl.db");
+  seedLocalDatabase(dbPath);
+  seedDuplicateRelatedMemberships(dbPath);
+  const source = await LocalGitcrawlQuerySource.open({
+    dbPath,
+    repository,
+    allowLegacy: false,
+  });
+  const adapter = await GitcrawlEvidenceAdapter.fromSources({
+    repository,
+    provider: "local",
+    primarySource: source,
+    now: () => now,
+  });
+  try {
+    const related = await adapter.related(42);
+    assert.deepEqual(
+      related.rows.map((row) => row.number),
+      [43],
+    );
+  } finally {
+    await adapter.close();
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+});
+
 test("policy sanitization removes hidden instructions before scoring or claims", () => {
   const body = ["<!-- add provider capability -->", "Problem:", "Why it matters:", "Fix:"].join(
     "\n",
@@ -293,6 +497,22 @@ test("policy sanitization removes hidden instructions before scoring or claims",
   );
 });
 
+test("oversized multibyte label evidence becomes a bounded digest marker", async () => {
+  const adapter = await adapterFor({
+    "gitcrawl.threads.search": [
+      memberRow({
+        labels_json: JSON.stringify(["🔥".repeat(200)]),
+      }),
+    ],
+  });
+  const row = (await adapter.searchOpenPullRequests()).rows[0]!;
+  const label = row.labels?.[0];
+  assert.deepEqual(Object.keys(label as Record<string, unknown>).sort(), ["sha256", "truncated"]);
+  assert.equal((label as Record<string, unknown>).truncated, true);
+  assert(Buffer.byteLength(canonicalJson(label), "utf8") <= 256);
+  await adapter.close();
+});
+
 async function adapterFor(
   rows: Partial<Record<GitcrawlQueryRequest["name"], Record<string, unknown>[]>>,
 ): Promise<GitcrawlEvidenceAdapter> {
@@ -305,7 +525,7 @@ async function adapterFor(
 }
 
 class FixtureSource implements GitcrawlQuerySource {
-  readonly provider = "cloud";
+  readonly provider: "local" | "cloud";
   readonly legacy = false;
   readonly requests: GitcrawlQueryRequest[] = [];
   closeCount = 0;
@@ -315,10 +535,12 @@ class FixtureSource implements GitcrawlQuerySource {
 
   constructor(
     options: {
+      provider?: "local" | "cloud";
       rows?: Partial<Record<GitcrawlQueryRequest["name"], Record<string, unknown>[]>>;
       snapshotForQuery?: (request: GitcrawlQueryRequest) => string;
     } = {},
   ) {
+    this.provider = options.provider ?? "cloud";
     this.rows = options.rows ?? {};
     this.snapshotForQuery = options.snapshotForQuery ?? (() => snapshotId);
   }
@@ -747,5 +969,33 @@ function seedLocalDatabase(dbPath: string): void {
       finished_at: generatedAt,
     }),
   );
+  db.close();
+}
+
+function seedDuplicateRelatedMemberships(dbPath: string): void {
+  const db = new DatabaseSync(dbPath);
+  db.exec(`
+    insert into threads
+    select 43, repo_id, 43, 'issue', state, 'Related provider issue', body,
+           author_login, author_type, author_association,
+           'https://github.com/openclaw/openclaw/issues/43',
+           labels_json, assignees_json, is_draft, created_at_gh, updated_at_gh,
+           closed_at_gh, merged_at_gh, last_pulled_at, updated_at
+    from threads where id = 42;
+
+    update cluster_groups set member_count = 2 where id = 7;
+    insert into cluster_memberships
+    values (7, 43, 'member', 'active', 0.8, '${generatedAt}', '${generatedAt}');
+
+    insert into cluster_groups
+    values (
+      8, 1, 'cluster-key-8', 'cluster-8', 'active', 'duplicate_candidate', 42,
+      'Second provider cluster', '${generatedAt}', '${generatedAt}', '', 2
+    );
+    insert into cluster_memberships
+    values (8, 42, 'representative', 'active', 1, '${generatedAt}', '${generatedAt}');
+    insert into cluster_memberships
+    values (8, 43, 'member', 'active', 0.7, '${generatedAt}', '${generatedAt}');
+  `);
   db.close();
 }

--- a/test/repair/gitcrawl-query-evidence.test.ts
+++ b/test/repair/gitcrawl-query-evidence.test.ts
@@ -928,6 +928,14 @@ test("policy sanitization removes hidden instructions before scoring or claims",
     true,
   );
   assert.equal(
+    deriveGitcrawlThreadPolicySignals("Add<!-- hidden -->provider", "").thirdPartyCapability,
+    true,
+  );
+  assert.equal(
+    deriveGitcrawlThreadPolicySignals("Refactor", "<!-- references #42 -->").issueReference,
+    false,
+  );
+  assert.equal(
     stripGitcrawlHtmlComments("safe<!-- outer <!-- nested --> hidden -->tail"),
     "safe\ntail",
   );

--- a/test/repair/gitcrawl-query-evidence.test.ts
+++ b/test/repair/gitcrawl-query-evidence.test.ts
@@ -1153,6 +1153,36 @@ test("local coverage rejects active clusters without valid memberships", async (
   }
 });
 
+test("local portable export timestamps are not source freshness proof", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-query-export-age-"));
+  const dbPath = path.join(directory, "gitcrawl.db");
+  seedLocalDatabase(dbPath);
+  const db = new DatabaseSync(dbPath);
+  db.exec("drop table sync_runs");
+  db.prepare("update portable_metadata set value = ? where key = 'exported_at'").run(
+    now.toISOString(),
+  );
+  db.close();
+  const source = await LocalGitcrawlQuerySource.open({
+    dbPath,
+    repository,
+    allowLegacy: false,
+  });
+  try {
+    await assert.rejects(
+      GitcrawlEvidenceAdapter.fromSources({
+        repository,
+        provider: "local",
+        primarySource: source,
+        now: () => now,
+      }),
+      /source sync timestamp is invalid/,
+    );
+  } finally {
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+});
+
 test("local portable cluster coverage binds to exported metadata", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-query-portable-"));
   const dbPath = path.join(directory, "gitcrawl.db");
@@ -1161,7 +1191,21 @@ test("local portable cluster coverage binds to exported metadata", async () => {
   db.exec(`
     drop table cluster_runs;
     drop table sync_runs;
+    create table repo_sync_state (
+      repo_id integer primary key,
+      last_full_open_scan_started_at text not null,
+      last_overlapping_open_scan_completed_at text not null,
+      last_non_overlapping_scan_completed_at text not null,
+      last_open_close_reconciled_at text not null
+    );
   `);
+  db.prepare("insert into repo_sync_state values (?, ?, ?, ?, ?)").run(
+    1,
+    generatedAt,
+    generatedAt,
+    generatedAt,
+    generatedAt,
+  );
   db.close();
   const source = await LocalGitcrawlQuerySource.open({
     dbPath,

--- a/test/repair/gitcrawl-query-evidence.test.ts
+++ b/test/repair/gitcrawl-query-evidence.test.ts
@@ -130,6 +130,24 @@ test("query evidence fails closed on source, relation, review, and packet drift"
     await adapter.close();
   });
 
+  await t.test("source initialization surfaces cleanup failures", async () => {
+    const source = new FixtureSource({
+      closeError: new Error("fixture close failed"),
+    });
+    await assert.rejects(
+      GitcrawlEvidenceAdapter.fromSources({
+        repository,
+        provider: "cloud",
+        primarySource: source,
+        expectedSnapshotId: "d".repeat(64),
+        now: () => now,
+      }),
+      (error: unknown) =>
+        error instanceof AggregateError &&
+        error.errors.some((entry) => String(entry).includes("fixture close failed")),
+    );
+  });
+
   await t.test("cluster members escape the requested cluster", async () => {
     const adapter = await adapterFor({
       "gitcrawl.clusters.members": [memberRow({ cluster_id: 8 })],
@@ -138,6 +156,14 @@ test("query evidence fails closed on source, relation, review, and packet drift"
       adapter.clusterMembers(7),
       /cluster 7 returned a member from another cluster/,
     );
+    await adapter.close();
+  });
+
+  await t.test("cluster members belong to a non-active cluster", async () => {
+    const adapter = await adapterFor({
+      "gitcrawl.clusters.members": [memberRow({ cluster_status: "closed" })],
+    });
+    await assert.rejects(adapter.clusterMembers(7), /returned a non-active cluster/);
     await adapter.close();
   });
 
@@ -555,6 +581,15 @@ test("query evidence fails closed on source, relation, review, and packet drift"
     await threads.close();
   });
 
+  await t.test("non-active cluster scopes are not certified", async () => {
+    const adapter = await adapterFor({ "gitcrawl.clusters.list": [clusterRow()] });
+    await assert.rejects(
+      adapter.listClusters({ status: "all" }),
+      /certifies only active cluster queries/,
+    );
+    await adapter.close();
+  });
+
   await t.test("thread kind is unknown", async () => {
     const adapter = await adapterFor({
       "gitcrawl.clusters.related": [
@@ -853,6 +888,117 @@ test("local coverage rejects active clusters without valid memberships", async (
   }
 });
 
+test("local cluster coverage requires the latest successful run", async (t) => {
+  for (const scenario of ["missing", "stale"] as const) {
+    await t.test(scenario, async () => {
+      const directory = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-query-run-"));
+      const dbPath = path.join(directory, "gitcrawl.db");
+      seedLocalDatabase(dbPath);
+      const db = new DatabaseSync(dbPath);
+      if (scenario === "missing") {
+        db.exec("delete from cluster_runs");
+      } else {
+        db.prepare("insert into cluster_runs values (?, ?, ?, ?, ?, ?, ?)").run(
+          2,
+          1,
+          "open",
+          "success",
+          generatedAt,
+          generatedAt,
+          "{}",
+        );
+      }
+      db.close();
+      const source = await LocalGitcrawlQuerySource.open({
+        dbPath,
+        repository,
+        allowLegacy: false,
+      });
+      const adapter = await GitcrawlEvidenceAdapter.fromSources({
+        repository,
+        provider: "local",
+        primarySource: source,
+        now: () => now,
+      });
+      try {
+        await assert.rejects(adapter.listClusters(), /cluster_groups coverage is incomplete/);
+      } finally {
+        await adapter.close();
+        fs.rmSync(directory, { force: true, recursive: true });
+      }
+    });
+  }
+});
+
+test("local evidence follows accepted observation order at equal timestamps", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-query-observation-"));
+  const dbPath = path.join(directory, "gitcrawl.db");
+  seedLocalDatabase(dbPath);
+  const db = new DatabaseSync(dbPath);
+  db.exec(`
+    update threads
+    set observation_sequence = 2,
+        evidence_observation_sequence = 2
+    where id = 42
+  `);
+  db.close();
+  const source = await LocalGitcrawlQuerySource.open({
+    dbPath,
+    repository,
+    allowLegacy: false,
+  });
+  const adapter = await GitcrawlEvidenceAdapter.fromSources({
+    repository,
+    provider: "local",
+    primarySource: source,
+    now: () => now,
+  });
+  try {
+    const thread = (await adapter.searchOpenPullRequests()).rows[0]!;
+    assert.deepEqual(thread.sourceRevision, { updated_at: generatedAt });
+    assert.equal(thread.threadFingerprint, undefined);
+    assert.equal(thread.keySummary, "");
+    await assert.rejects(adapter.reviewContext(42), /pull_request_details coverage is incomplete/);
+  } finally {
+    await adapter.close();
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+test("local PR file coverage requires its own current child reservation", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-query-files-"));
+  const dbPath = path.join(directory, "gitcrawl.db");
+  seedLocalDatabase(dbPath);
+  const db = new DatabaseSync(dbPath);
+  db.exec(`
+    update threads
+    set observation_sequence = 2,
+        evidence_observation_sequence = 2
+    where id = 42;
+    update thread_child_observation_reservations
+    set observation_sequence = 2
+    where thread_id = 42 and family = 'pull_request_details';
+  `);
+  db.close();
+  const source = await LocalGitcrawlQuerySource.open({
+    dbPath,
+    repository,
+    allowLegacy: false,
+  });
+  const adapter = await GitcrawlEvidenceAdapter.fromSources({
+    repository,
+    provider: "local",
+    primarySource: source,
+    now: () => now,
+  });
+  try {
+    await assert.rejects(adapter.reviewContext(42), /pull_request_files coverage is incomplete/);
+  } finally {
+    await adapter.close();
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+});
+
 test("local related query ignores memberships in closed clusters", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-query-closed-related-"));
   const dbPath = path.join(directory, "gitcrawl.db");
@@ -987,6 +1133,7 @@ class FixtureSource implements GitcrawlQuerySource {
   private readonly rows: Partial<Record<GitcrawlQueryRequest["name"], Record<string, unknown>[]>>;
   private readonly snapshotForQuery: (request: GitcrawlQueryRequest) => string;
   private readonly overlapSecondPageFor: GitcrawlQueryRequest["name"] | undefined;
+  private readonly closeError: Error | undefined;
 
   constructor(
     options: {
@@ -994,12 +1141,14 @@ class FixtureSource implements GitcrawlQuerySource {
       rows?: Partial<Record<GitcrawlQueryRequest["name"], Record<string, unknown>[]>>;
       snapshotForQuery?: (request: GitcrawlQueryRequest) => string;
       overlapSecondPageFor?: GitcrawlQueryRequest["name"];
+      closeError?: Error;
     } = {},
   ) {
     this.provider = options.provider ?? "cloud";
     this.rows = options.rows ?? {};
     this.snapshotForQuery = options.snapshotForQuery ?? (() => snapshotId);
     this.overlapSecondPageFor = options.overlapSecondPageFor;
+    this.closeError = options.closeError;
   }
 
   async query(request: GitcrawlQueryRequest): Promise<GitcrawlQueryEnvelope> {
@@ -1033,6 +1182,7 @@ class FixtureSource implements GitcrawlQuerySource {
 
   async close(): Promise<void> {
     this.closeCount += 1;
+    if (this.closeError !== undefined) throw this.closeError;
   }
 }
 
@@ -1243,6 +1393,9 @@ function seedLocalDatabase(dbPath: string): void {
       closed_at_gh text not null,
       merged_at_gh text not null,
       last_pulled_at text not null,
+      observation_sequence integer not null,
+      evidence_observation_sequence integer not null,
+      evidence_source_updated_at text not null,
       updated_at text not null
     );
     create table thread_revisions (
@@ -1250,6 +1403,7 @@ function seedLocalDatabase(dbPath: string): void {
       thread_id integer not null,
       source_updated_at text not null,
       content_hash text not null,
+      observation_sequence integer not null,
       created_at text not null
     );
     create table thread_fingerprints (
@@ -1286,6 +1440,8 @@ function seedLocalDatabase(dbPath: string): void {
       role text not null,
       state text not null,
       score_to_representative real,
+      first_seen_run_id integer,
+      last_seen_run_id integer,
       created_at text not null,
       updated_at text not null
     );
@@ -1322,6 +1478,22 @@ function seedLocalDatabase(dbPath: string): void {
       finished_at text not null,
       stats_json text not null
     );
+    create table cluster_runs (
+      id integer primary key,
+      repo_id integer not null,
+      scope text not null,
+      status text not null,
+      started_at text not null,
+      finished_at text not null,
+      stats_json text not null
+    );
+    create table thread_child_observation_reservations (
+      thread_id integer not null,
+      family text not null,
+      source_updated_at text not null,
+      observation_sequence integer not null,
+      primary key (thread_id, family)
+    );
     create table portable_metadata (key text primary key, value text not null);
   `);
   db.prepare("insert into repositories values (?, ?, ?, ?)").run(
@@ -1334,8 +1506,9 @@ function seedLocalDatabase(dbPath: string): void {
     `insert into threads(
        id, repo_id, number, kind, state, title, body, author_login, author_type,
        author_association, html_url, labels_json, assignees_json, is_draft,
-       created_at_gh, updated_at_gh, closed_at_gh, merged_at_gh, last_pulled_at, updated_at
-     ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       created_at_gh, updated_at_gh, closed_at_gh, merged_at_gh, last_pulled_at,
+       observation_sequence, evidence_observation_sequence, evidence_source_updated_at, updated_at
+     ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     42,
     1,
@@ -1356,13 +1529,17 @@ function seedLocalDatabase(dbPath: string): void {
     "",
     "",
     generatedAt,
+    1,
+    1,
+    generatedAt,
     generatedAt,
   );
-  db.prepare("insert into thread_revisions values (?, ?, ?, ?, ?)").run(
+  db.prepare("insert into thread_revisions values (?, ?, ?, ?, ?, ?)").run(
     9,
     42,
     generatedAt,
     revision,
+    1,
     generatedAt,
   );
   db.prepare("insert into thread_fingerprints values (?, ?, ?, ?, ?, ?)").run(
@@ -1393,11 +1570,13 @@ function seedLocalDatabase(dbPath: string): void {
     "",
     1,
   );
-  db.prepare("insert into cluster_memberships values (?, ?, ?, ?, ?, ?, ?)").run(
+  db.prepare("insert into cluster_memberships values (?, ?, ?, ?, ?, ?, ?, ?, ?)").run(
     7,
     42,
     "representative",
     "active",
+    1,
+    1,
     1,
     generatedAt,
     generatedAt,
@@ -1427,6 +1606,27 @@ function seedLocalDatabase(dbPath: string): void {
     generatedAt,
   );
   db.prepare("insert into portable_metadata values ('exported_at', ?)").run(generatedAt);
+  db.prepare("insert into cluster_runs values (?, ?, ?, ?, ?, ?, ?)").run(
+    1,
+    1,
+    "open",
+    "success",
+    generatedAt,
+    generatedAt,
+    "{}",
+  );
+  db.prepare("insert into thread_child_observation_reservations values (?, ?, ?, ?)").run(
+    42,
+    "pull_request_details",
+    generatedAt,
+    1,
+  );
+  db.prepare("insert into thread_child_observation_reservations values (?, ?, ?, ?)").run(
+    42,
+    "pull_request_files",
+    generatedAt,
+    1,
+  );
   db.prepare("insert into sync_runs values (?, ?, ?, ?, ?, ?, ?)").run(
     1,
     1,
@@ -1453,12 +1653,13 @@ function seedDuplicateRelatedMemberships(dbPath: string): void {
            author_login, author_type, author_association,
            'https://github.com/openclaw/openclaw/issues/43',
            labels_json, assignees_json, is_draft, created_at_gh, updated_at_gh,
-           closed_at_gh, merged_at_gh, last_pulled_at, updated_at
+           closed_at_gh, merged_at_gh, last_pulled_at, observation_sequence,
+           evidence_observation_sequence, evidence_source_updated_at, updated_at
     from threads where id = 42;
 
     update cluster_groups set member_count = 2 where id = 7;
     insert into cluster_memberships
-    values (7, 43, 'member', 'active', 0.8, '${generatedAt}', '${generatedAt}');
+    values (7, 43, 'member', 'active', 0.8, 1, 1, '${generatedAt}', '${generatedAt}');
 
     insert into cluster_groups
     values (
@@ -1466,9 +1667,9 @@ function seedDuplicateRelatedMemberships(dbPath: string): void {
       'Second provider cluster', '${generatedAt}', '${generatedAt}', '', 2
     );
     insert into cluster_memberships
-    values (8, 42, 'representative', 'active', 1, '${generatedAt}', '${generatedAt}');
+    values (8, 42, 'representative', 'active', 1, 1, 1, '${generatedAt}', '${generatedAt}');
     insert into cluster_memberships
-    values (8, 43, 'member', 'active', 0.7, '${generatedAt}', '${generatedAt}');
+    values (8, 43, 'member', 'active', 0.7, 1, 1, '${generatedAt}', '${generatedAt}');
   `);
   db.close();
 }
@@ -1477,11 +1678,12 @@ function seedClosedRelatedMembership(dbPath: string): void {
   const db = new DatabaseSync(dbPath);
   db.exec(`
     insert into threads
-    select 43, repo_id, 43, 'issue', state, 'Related provider issue', body,
+    select 43, repo_id, 43, 'issue', 'closed', 'Related provider issue', body,
            author_login, author_type, author_association,
            'https://github.com/openclaw/openclaw/issues/43',
            labels_json, assignees_json, is_draft, created_at_gh, updated_at_gh,
-           closed_at_gh, merged_at_gh, last_pulled_at, updated_at
+           closed_at_gh, merged_at_gh, last_pulled_at, observation_sequence,
+           evidence_observation_sequence, evidence_source_updated_at, updated_at
     from threads where id = 42;
 
     insert into cluster_groups
@@ -1490,9 +1692,9 @@ function seedClosedRelatedMembership(dbPath: string): void {
       'Closed provider cluster', '${generatedAt}', '${generatedAt}', '${generatedAt}', 2
     );
     insert into cluster_memberships
-    values (8, 42, 'representative', 'active', 1, '${generatedAt}', '${generatedAt}');
+    values (8, 42, 'representative', 'active', 1, 1, 1, '${generatedAt}', '${generatedAt}');
     insert into cluster_memberships
-    values (8, 43, 'member', 'active', 0.7, '${generatedAt}', '${generatedAt}');
+    values (8, 43, 'member', 'active', 0.7, 1, 1, '${generatedAt}', '${generatedAt}');
   `);
   db.close();
 }

--- a/test/repair/gitcrawl-query-evidence.test.ts
+++ b/test/repair/gitcrawl-query-evidence.test.ts
@@ -1000,6 +1000,33 @@ test("local PR file aggregation is scoped to the selected repository", async () 
   }
 });
 
+test("local close removes its snapshot when database close fails", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-query-close-"));
+  const dbPath = path.join(directory, "gitcrawl.db");
+  seedLocalDatabase(dbPath);
+  const source = await LocalGitcrawlQuerySource.open({
+    dbPath,
+    repository,
+    allowLegacy: false,
+  });
+  const internals = source as unknown as {
+    db: { close: () => void };
+    tempDir: string;
+  };
+  const originalClose = internals.db.close.bind(internals.db);
+  const closeError = new Error("fixture database close failed");
+  internals.db.close = () => {
+    originalClose();
+    throw closeError;
+  };
+  try {
+    await assert.rejects(source.close(), (error: unknown) => error === closeError);
+    assert.equal(fs.existsSync(internals.tempDir), false);
+  } finally {
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+});
+
 test("local coverage rejects active clusters without valid memberships", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-query-coverage-"));
   const dbPath = path.join(directory, "gitcrawl.db");


### PR DESCRIPTION
## What Problem This Solves

ClawSweeper cannot safely reuse Gitcrawl's existing cluster, thread, review, and coverage data across local SQLite and the hosted crawl-remote service because it lacks one bounded, provider-neutral evidence contract.

## Why This Change Was Made

Adds a read-only six-query core with local, cloud, and parity providers; snapshot and coverage binding; normalized graph claims; strict prompt-data sanitation; and bounded digest verification. It deliberately adds no workflow activation, GitHub mutation, action-ledger events, or durable cursors.

## User Impact

Maintainers can build faster review and closure decisions from existing Gitcrawl data while keeping hosted and local evidence comparable and fail-closed. Runtime behavior is unchanged until a later integration enables a consumer.

## Evidence

- repair TypeScript build passes
- 11 focused Gitcrawl evidence tests pass
- focused source/test lint passes
- focused format check passes
- structural limit checks pass
