### PR TITLE
feat(repair): plan dependency-ordered closures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ checkpoint, and status-only commits are intentionally omitted.
 ## 0.3.1 - Unreleased
 
 ### Added
+- Added a pure, bounded closure dependency planner with fail-closed canonical selection, Tarjan cycle detection, and deterministic topological layers.
 - Added end-to-end exact-review handoff health with phase ages, delayed/stalled claim classification, and a phase-aware operator rail on the live dashboard.
 - Added a maintainer-only two-runner workflow that builds a hash-bound
   crawl-remote release artifact without production credentials, then requires

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ checkpoint, and status-only commits are intentionally omitted.
 ## 0.3.1 - Unreleased
 
 ### Added
-- Added a pure, bounded closure dependency planner with fail-closed canonical selection, Tarjan cycle detection, and deterministic topological layers.
 - Added end-to-end exact-review handoff health with phase ages, delayed/stalled claim classification, and a phase-aware operator rail on the live dashboard.
 - Added a maintainer-only two-runner workflow that builds a hash-bound
   crawl-remote release artifact without production credentials, then requires

--- a/docs/repair/closure-dependency-planner.md
+++ b/docs/repair/closure-dependency-planner.md
@@ -1,0 +1,49 @@
+# Closure dependency planner
+
+`planClosureDependencies` is a pure, fail-closed planning primitive for a future
+root-cause closeout lane. It does not read or mutate GitHub and is not wired
+into review or apply.
+
+## Contract
+
+The input contains bounded node declarations and dependency edges:
+
+```ts
+{
+  nodes: [
+    { id: "#100", kind: "canonical_root", canonicalCandidates: [] },
+    { id: "#101", kind: "closure_candidate", canonicalCandidates: ["#100"] },
+    { id: "#102", kind: "closure_candidate", canonicalCandidates: ["#100"] },
+  ],
+  edges: [
+    { prerequisite: "#101", dependent: "#102" },
+  ],
+}
+```
+
+Exactly one `canonical_root` must remain open. Every `closure_candidate` must
+select that root and only that root. An edge means its `prerequisite` must close
+successfully before its `dependent` is attempted. The canonical root is treated
+as already satisfied and never appears in a closure layer.
+
+A safe result names the canonical root and returns deterministic Kahn layers.
+Members of one layer have no dependency ordering between them and are sorted by
+binary ASCII order. Exact duplicate edges are collapsed.
+
+## Failure behavior
+
+Tarjan strongly connected components detect multi-node cycles and self-cycles
+before layering. The planner returns sorted `needs_human` diagnostics, never a
+partial plan, for:
+
+- cycles or self-cycles;
+- missing referenced nodes;
+- absent or multiple canonical roots;
+- ambiguous or non-root canonical selections;
+- duplicate or conflicting node declarations;
+- dependencies pointing into the canonical root;
+- non-printable or non-ASCII identifiers; or
+- inputs above the exported node, edge, candidate, or identifier bounds.
+
+Input arrays and declarations are copied before sorting. Caller-owned data is
+not mutated, and input permutation does not change plans or diagnostics.

--- a/src/repair/closure-dependency-planner.ts
+++ b/src/repair/closure-dependency-planner.ts
@@ -1,0 +1,447 @@
+export const CLOSURE_DEPENDENCY_PLANNER_LIMITS = {
+  maxNodes: 256,
+  maxEdges: 2_048,
+  maxCanonicalCandidatesPerNode: 8,
+  maxNodeIdBytes: 200,
+} as const;
+
+export type ClosureDependencyNode = Readonly<{
+  id: string;
+  kind: "canonical_root" | "closure_candidate";
+  canonicalCandidates: readonly string[];
+}>;
+
+export type ClosureDependencyEdge = Readonly<{
+  prerequisite: string;
+  dependent: string;
+}>;
+
+export type ClosureDependencyPlannerInput = Readonly<{
+  nodes: readonly ClosureDependencyNode[];
+  edges: readonly ClosureDependencyEdge[];
+}>;
+
+export type ClosureDependencyDiagnosticCode =
+  | "unsafe_bounds"
+  | "invalid_node_id"
+  | "duplicate_node_declaration"
+  | "conflicting_node_declaration"
+  | "missing_referenced_node"
+  | "multiple_canonical_roots"
+  | "ambiguous_canonical_selection"
+  | "canonical_root_has_dependency"
+  | "self_cycle"
+  | "dependency_cycle";
+
+export type ClosureDependencyDiagnostic = Readonly<{
+  code: ClosureDependencyDiagnosticCode;
+  message: string;
+  nodes: readonly string[];
+}>;
+
+export type ClosureDependencyPlan =
+  | Readonly<{
+      status: "safe";
+      canonicalRoot: string;
+      closureLayers: readonly (readonly string[])[];
+      nodeCount: number;
+      edgeCount: number;
+    }>
+  | Readonly<{
+      status: "needs_human";
+      diagnostics: readonly ClosureDependencyDiagnostic[];
+    }>;
+
+const DIAGNOSTIC_ORDER: readonly ClosureDependencyDiagnosticCode[] = [
+  "unsafe_bounds",
+  "invalid_node_id",
+  "duplicate_node_declaration",
+  "conflicting_node_declaration",
+  "missing_referenced_node",
+  "multiple_canonical_roots",
+  "ambiguous_canonical_selection",
+  "canonical_root_has_dependency",
+  "self_cycle",
+  "dependency_cycle",
+];
+
+const DIAGNOSTIC_RANK = new Map(DIAGNOSTIC_ORDER.map((code, index) => [code, index] as const));
+const PRINTABLE_ASCII_ID = /^[\x21-\x7e]+$/;
+
+export function planClosureDependencies(
+  input: ClosureDependencyPlannerInput,
+): ClosureDependencyPlan {
+  if (
+    input.nodes.length > CLOSURE_DEPENDENCY_PLANNER_LIMITS.maxNodes ||
+    input.edges.length > CLOSURE_DEPENDENCY_PLANNER_LIMITS.maxEdges
+  ) {
+    return needsHuman([
+      diagnostic(
+        "unsafe_bounds",
+        `input exceeds planner bounds: nodes=${input.nodes.length}/${CLOSURE_DEPENDENCY_PLANNER_LIMITS.maxNodes}, edges=${input.edges.length}/${CLOSURE_DEPENDENCY_PLANNER_LIMITS.maxEdges}`,
+      ),
+    ]);
+  }
+
+  const diagnostics: ClosureDependencyDiagnostic[] = [];
+  const nodesById = new Map<string, ClosureDependencyNode>();
+  const declarationSignatures = new Map<string, string>();
+
+  for (const node of input.nodes) {
+    if (!isSafeId(node.id)) {
+      diagnostics.push(
+        diagnostic(
+          "invalid_node_id",
+          `node id ${JSON.stringify(node.id)} must be printable ASCII and at most ${CLOSURE_DEPENDENCY_PLANNER_LIMITS.maxNodeIdBytes} bytes`,
+          [node.id],
+        ),
+      );
+      continue;
+    }
+    if (
+      node.canonicalCandidates.length >
+      CLOSURE_DEPENDENCY_PLANNER_LIMITS.maxCanonicalCandidatesPerNode
+    ) {
+      diagnostics.push(
+        diagnostic(
+          "unsafe_bounds",
+          `${node.id} declares ${node.canonicalCandidates.length} canonical candidates; maximum is ${CLOSURE_DEPENDENCY_PLANNER_LIMITS.maxCanonicalCandidatesPerNode}`,
+          [node.id],
+        ),
+      );
+      continue;
+    }
+
+    const signature = nodeDeclarationSignature(node);
+    const previousSignature = declarationSignatures.get(node.id);
+    if (previousSignature !== undefined) {
+      diagnostics.push(
+        previousSignature === signature
+          ? diagnostic("duplicate_node_declaration", `${node.id} is declared more than once`, [
+              node.id,
+            ])
+          : diagnostic("conflicting_node_declaration", `${node.id} has conflicting declarations`, [
+              node.id,
+            ]),
+      );
+      continue;
+    }
+
+    declarationSignatures.set(node.id, signature);
+    nodesById.set(node.id, {
+      ...node,
+      canonicalCandidates: [...node.canonicalCandidates].sort(compareAscii),
+    });
+  }
+
+  if (diagnostics.length > 0) return needsHuman(diagnostics);
+
+  const canonicalRoots = [...nodesById.values()]
+    .filter((node) => node.kind === "canonical_root")
+    .map((node) => node.id)
+    .sort(compareAscii);
+  if (canonicalRoots.length > 1) {
+    diagnostics.push(
+      diagnostic(
+        "multiple_canonical_roots",
+        `expected one canonical root, found ${canonicalRoots.length}`,
+        canonicalRoots,
+      ),
+    );
+  }
+
+  const canonicalRoot = canonicalRoots.length === 1 ? canonicalRoots[0] : undefined;
+  for (const node of [...nodesById.values()].sort((left, right) =>
+    compareAscii(left.id, right.id),
+  )) {
+    for (const candidate of node.canonicalCandidates) {
+      if (!isSafeId(candidate)) {
+        diagnostics.push(
+          diagnostic(
+            "invalid_node_id",
+            `canonical reference ${JSON.stringify(candidate)} must be printable ASCII and at most ${CLOSURE_DEPENDENCY_PLANNER_LIMITS.maxNodeIdBytes} bytes`,
+            [node.id, candidate],
+          ),
+        );
+      } else if (!nodesById.has(candidate)) {
+        diagnostics.push(
+          diagnostic(
+            "missing_referenced_node",
+            `${node.id} references missing canonical candidate ${candidate}`,
+            [node.id, candidate],
+          ),
+        );
+      }
+    }
+
+    if (node.kind === "canonical_root") {
+      if (node.canonicalCandidates.length > 0) {
+        diagnostics.push(
+          diagnostic(
+            "ambiguous_canonical_selection",
+            `${node.id} is a canonical root and must not select another canonical`,
+            [node.id, ...node.canonicalCandidates],
+          ),
+        );
+      }
+      continue;
+    }
+
+    if (
+      node.canonicalCandidates.length !== 1 ||
+      canonicalRoot === undefined ||
+      node.canonicalCandidates[0] !== canonicalRoot
+    ) {
+      diagnostics.push(
+        diagnostic(
+          "ambiguous_canonical_selection",
+          canonicalRoot === undefined
+            ? `${node.id} cannot select a canonical root because the root declaration is not unique`
+            : `${node.id} must select only canonical root ${canonicalRoot}`,
+          [node.id, ...node.canonicalCandidates],
+        ),
+      );
+    }
+  }
+
+  if (nodesById.size === 0 || canonicalRoot === undefined) {
+    diagnostics.push(
+      diagnostic(
+        "ambiguous_canonical_selection",
+        "expected exactly one declared canonical root",
+        canonicalRoots,
+      ),
+    );
+  }
+
+  const adjacency = new Map<string, Set<string>>();
+  for (const id of nodesById.keys()) adjacency.set(id, new Set());
+
+  for (const edge of input.edges) {
+    const edgeNodes = [edge.prerequisite, edge.dependent].sort(compareAscii);
+    let edgeIsValid = true;
+    for (const reference of edgeNodes) {
+      if (!isSafeId(reference)) {
+        diagnostics.push(
+          diagnostic(
+            "invalid_node_id",
+            `edge reference ${JSON.stringify(reference)} must be printable ASCII and at most ${CLOSURE_DEPENDENCY_PLANNER_LIMITS.maxNodeIdBytes} bytes`,
+            edgeNodes,
+          ),
+        );
+        edgeIsValid = false;
+      } else if (!nodesById.has(reference)) {
+        diagnostics.push(
+          diagnostic(
+            "missing_referenced_node",
+            `dependency edge references missing node ${reference}`,
+            edgeNodes,
+          ),
+        );
+        edgeIsValid = false;
+      }
+    }
+    if (!edgeIsValid) continue;
+
+    adjacency.get(edge.prerequisite)?.add(edge.dependent);
+    if (edge.dependent === canonicalRoot) {
+      diagnostics.push(
+        diagnostic(
+          "canonical_root_has_dependency",
+          `canonical root ${canonicalRoot} cannot depend on ${edge.prerequisite}`,
+          edgeNodes,
+        ),
+      );
+    }
+  }
+
+  for (const component of tarjanStronglyConnectedComponents(adjacency)) {
+    if (component.length > 1) {
+      diagnostics.push(
+        diagnostic(
+          "dependency_cycle",
+          `dependency cycle contains ${component.join(", ")}`,
+          component,
+        ),
+      );
+      continue;
+    }
+
+    const id = component[0];
+    if (id !== undefined && adjacency.get(id)?.has(id)) {
+      diagnostics.push(diagnostic("self_cycle", `${id} depends on itself`, [id]));
+    }
+  }
+
+  if (diagnostics.length > 0 || canonicalRoot === undefined) {
+    return needsHuman(diagnostics);
+  }
+
+  const closureLayers = kahnClosureLayers(adjacency, canonicalRoot);
+  if (closureLayers === null) {
+    return needsHuman([
+      diagnostic(
+        "dependency_cycle",
+        "dependency graph could not be fully ordered",
+        [...nodesById.keys()].sort(compareAscii),
+      ),
+    ]);
+  }
+
+  return {
+    status: "safe",
+    canonicalRoot,
+    closureLayers,
+    nodeCount: nodesById.size,
+    edgeCount: [...adjacency.values()].reduce((total, dependents) => total + dependents.size, 0),
+  };
+}
+
+function tarjanStronglyConnectedComponents(
+  adjacency: ReadonlyMap<string, ReadonlySet<string>>,
+): string[][] {
+  const components: string[][] = [];
+  const indexes = new Map<string, number>();
+  const lowLinks = new Map<string, number>();
+  const stack: string[] = [];
+  const onStack = new Set<string>();
+  let nextIndex = 0;
+
+  function visit(id: string) {
+    indexes.set(id, nextIndex);
+    lowLinks.set(id, nextIndex);
+    nextIndex += 1;
+    stack.push(id);
+    onStack.add(id);
+
+    const dependents = [...(adjacency.get(id) ?? [])].sort(compareAscii);
+    for (const dependent of dependents) {
+      if (!indexes.has(dependent)) {
+        visit(dependent);
+        lowLinks.set(id, Math.min(lowLinks.get(id) ?? 0, lowLinks.get(dependent) ?? 0));
+      } else if (onStack.has(dependent)) {
+        lowLinks.set(id, Math.min(lowLinks.get(id) ?? 0, indexes.get(dependent) ?? 0));
+      }
+    }
+
+    if (lowLinks.get(id) !== indexes.get(id)) return;
+    const component: string[] = [];
+    while (stack.length > 0) {
+      const member = stack.pop();
+      if (member === undefined) break;
+      onStack.delete(member);
+      component.push(member);
+      if (member === id) break;
+    }
+    component.sort(compareAscii);
+    components.push(component);
+  }
+
+  for (const id of [...adjacency.keys()].sort(compareAscii)) {
+    if (!indexes.has(id)) visit(id);
+  }
+  return components.sort(compareStringArrays);
+}
+
+function kahnClosureLayers(
+  adjacency: ReadonlyMap<string, ReadonlySet<string>>,
+  canonicalRoot: string,
+): string[][] | null {
+  const indegree = new Map<string, number>();
+  for (const id of adjacency.keys()) {
+    if (id !== canonicalRoot) indegree.set(id, 0);
+  }
+  for (const [prerequisite, dependents] of adjacency) {
+    if (prerequisite === canonicalRoot) continue;
+    for (const dependent of dependents) {
+      indegree.set(dependent, (indegree.get(dependent) ?? 0) + 1);
+    }
+  }
+
+  const layers: string[][] = [];
+  let remaining = indegree.size;
+  let ready = [...indegree.entries()]
+    .filter(([, degree]) => degree === 0)
+    .map(([id]) => id)
+    .sort(compareAscii);
+
+  while (ready.length > 0) {
+    const currentLayer = ready;
+    ready = [];
+    const nextReady = new Set<string>();
+    layers.push(currentLayer);
+
+    for (const id of currentLayer) {
+      remaining -= 1;
+      for (const dependent of [...(adjacency.get(id) ?? [])].sort(compareAscii)) {
+        const nextDegree = (indegree.get(dependent) ?? 0) - 1;
+        indegree.set(dependent, nextDegree);
+        if (nextDegree === 0) nextReady.add(dependent);
+      }
+    }
+    ready = [...nextReady].sort(compareAscii);
+  }
+
+  return remaining === 0 ? layers : null;
+}
+
+function nodeDeclarationSignature(node: ClosureDependencyNode): string {
+  return JSON.stringify([node.kind, [...node.canonicalCandidates].sort(compareAscii)]);
+}
+
+function isSafeId(id: string): boolean {
+  return (
+    id.length > 0 &&
+    id.length <= CLOSURE_DEPENDENCY_PLANNER_LIMITS.maxNodeIdBytes &&
+    PRINTABLE_ASCII_ID.test(id)
+  );
+}
+
+function diagnostic(
+  code: ClosureDependencyDiagnosticCode,
+  message: string,
+  nodes: readonly string[] = [],
+): ClosureDependencyDiagnostic {
+  return {
+    code,
+    message,
+    nodes: [...nodes].sort(compareAscii),
+  };
+}
+
+function needsHuman(diagnostics: readonly ClosureDependencyDiagnostic[]): ClosureDependencyPlan {
+  const unique = new Map<string, ClosureDependencyDiagnostic>();
+  for (const entry of diagnostics) {
+    const key = JSON.stringify([entry.code, entry.nodes, entry.message]);
+    unique.set(key, entry);
+  }
+  return {
+    status: "needs_human",
+    diagnostics: [...unique.values()].sort(compareDiagnostics),
+  };
+}
+
+function compareDiagnostics(
+  left: ClosureDependencyDiagnostic,
+  right: ClosureDependencyDiagnostic,
+): number {
+  const rankDifference =
+    (DIAGNOSTIC_RANK.get(left.code) ?? Number.MAX_SAFE_INTEGER) -
+    (DIAGNOSTIC_RANK.get(right.code) ?? Number.MAX_SAFE_INTEGER);
+  if (rankDifference !== 0) return rankDifference;
+  const nodeDifference = compareStringArrays(left.nodes, right.nodes);
+  return nodeDifference !== 0 ? nodeDifference : compareAscii(left.message, right.message);
+}
+
+function compareStringArrays(left: readonly string[], right: readonly string[]): number {
+  const length = Math.min(left.length, right.length);
+  for (let index = 0; index < length; index += 1) {
+    const difference = compareAscii(left[index] ?? "", right[index] ?? "");
+    if (difference !== 0) return difference;
+  }
+  return left.length - right.length;
+}
+
+function compareAscii(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}

--- a/test/repair/closure-dependency-planner.test.ts
+++ b/test/repair/closure-dependency-planner.test.ts
@@ -1,0 +1,272 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  CLOSURE_DEPENDENCY_PLANNER_LIMITS,
+  planClosureDependencies,
+} from "../../dist/repair/closure-dependency-planner.js";
+
+function canonical(id = "root") {
+  return { id, kind: "canonical_root", canonicalCandidates: [] };
+}
+
+function closure(id: string, canonicalCandidates = ["root"]) {
+  return { id, kind: "closure_candidate", canonicalCandidates };
+}
+
+function edge(prerequisite: string, dependent: string) {
+  return { prerequisite, dependent };
+}
+
+function diagnosticCodes(result: ReturnType<typeof planClosureDependencies>) {
+  assert.equal(result.status, "needs_human");
+  return result.diagnostics.map((entry) => entry.code);
+}
+
+test("plans deterministic dependency-first closure layers with ASCII ordering", () => {
+  const result = planClosureDependencies({
+    nodes: [closure("a"), closure("Z"), canonical(), closure("A"), closure("final")],
+    edges: [
+      edge("Z", "final"),
+      edge("root", "a"),
+      edge("A", "final"),
+      edge("root", "Z"),
+      edge("root", "A"),
+      edge("a", "final"),
+      edge("root", "A"),
+    ],
+  });
+
+  assert.deepEqual(result, {
+    status: "safe",
+    canonicalRoot: "root",
+    closureLayers: [["A", "Z", "a"], ["final"]],
+    nodeCount: 5,
+    edgeCount: 6,
+  });
+});
+
+test("treats the canonical root as already satisfied", () => {
+  const result = planClosureDependencies({
+    nodes: [canonical(), closure("depends-on-root"), closure("independent")],
+    edges: [edge("root", "depends-on-root")],
+  });
+
+  assert.equal(result.status, "safe");
+  assert.deepEqual(result.closureLayers, [["depends-on-root", "independent"]]);
+});
+
+test("safe plans are invariant across node and edge permutations", () => {
+  const nodes = [canonical(), closure("alpha"), closure("beta"), closure("final")];
+  const edges = [
+    edge("root", "alpha"),
+    edge("root", "beta"),
+    edge("alpha", "final"),
+    edge("beta", "final"),
+  ];
+  const expected = planClosureDependencies({ nodes, edges });
+  assert.equal(expected.status, "safe");
+
+  for (const nodeOrder of permutations(nodes)) {
+    for (const edgeOrder of permutations(edges)) {
+      assert.deepEqual(planClosureDependencies({ nodes: nodeOrder, edges: edgeOrder }), expected);
+    }
+  }
+});
+
+test("needs-human cycle diagnostics are invariant across input permutations", () => {
+  const nodes = [closure("b"), canonical(), closure("a")];
+  const edges = [edge("a", "b"), edge("b", "a")];
+  const expected = planClosureDependencies({ nodes, edges });
+
+  for (const nodeOrder of permutations(nodes)) {
+    for (const edgeOrder of permutations(edges)) {
+      assert.deepEqual(planClosureDependencies({ nodes: nodeOrder, edges: edgeOrder }), expected);
+    }
+  }
+  assert.deepEqual(expected, {
+    status: "needs_human",
+    diagnostics: [
+      {
+        code: "dependency_cycle",
+        message: "dependency cycle contains a, b",
+        nodes: ["a", "b"],
+      },
+    ],
+  });
+});
+
+test("fails closed on self-cycles", () => {
+  const result = planClosureDependencies({
+    nodes: [canonical(), closure("a")],
+    edges: [edge("a", "a")],
+  });
+
+  assert.deepEqual(result, {
+    status: "needs_human",
+    diagnostics: [
+      {
+        code: "self_cycle",
+        message: "a depends on itself",
+        nodes: ["a"],
+      },
+    ],
+  });
+});
+
+test("fails closed when dependencies or canonical selections reference missing nodes", () => {
+  const result = planClosureDependencies({
+    nodes: [canonical(), closure("a", ["missing"])],
+    edges: [edge("a", "also-missing")],
+  });
+
+  assert.equal(result.status, "needs_human");
+  assert.deepEqual(
+    result.diagnostics.filter((entry) => entry.code === "missing_referenced_node"),
+    [
+      {
+        code: "missing_referenced_node",
+        message: "dependency edge references missing node also-missing",
+        nodes: ["a", "also-missing"],
+      },
+      {
+        code: "missing_referenced_node",
+        message: "a references missing canonical candidate missing",
+        nodes: ["a", "missing"],
+      },
+    ],
+  );
+  assert.ok(result.diagnostics.some((entry) => entry.code === "ambiguous_canonical_selection"));
+});
+
+test("fails closed on multiple canonical roots", () => {
+  const result = planClosureDependencies({
+    nodes: [canonical("root-b"), closure("a", ["root-a"]), canonical("root-a")],
+    edges: [],
+  });
+
+  assert.ok(diagnosticCodes(result).includes("multiple_canonical_roots"));
+});
+
+test("fails closed on absent, multiple, or non-root canonical selections", () => {
+  const cases = [
+    {
+      nodes: [closure("a", [])],
+      edges: [],
+    },
+    {
+      nodes: [canonical(), closure("other"), closure("a", ["root", "other"])],
+      edges: [],
+    },
+    {
+      nodes: [canonical(), closure("other"), closure("a", ["other"])],
+      edges: [],
+    },
+    {
+      nodes: [{ ...canonical(), canonicalCandidates: ["a"] }, closure("a")],
+      edges: [],
+    },
+  ];
+
+  for (const input of cases) {
+    assert.ok(
+      diagnosticCodes(planClosureDependencies(input)).includes("ambiguous_canonical_selection"),
+    );
+  }
+});
+
+test("fails closed on duplicate and conflicting node declarations", () => {
+  const duplicate = planClosureDependencies({
+    nodes: [canonical(), closure("a"), closure("a")],
+    edges: [],
+  });
+  const conflicting = planClosureDependencies({
+    nodes: [canonical(), closure("a"), canonical("a")],
+    edges: [],
+  });
+
+  assert.deepEqual(diagnosticCodes(duplicate), ["duplicate_node_declaration"]);
+  assert.deepEqual(diagnosticCodes(conflicting), ["conflicting_node_declaration"]);
+});
+
+test("fails closed when the canonical root has a prerequisite", () => {
+  const result = planClosureDependencies({
+    nodes: [canonical(), closure("a")],
+    edges: [edge("a", "root")],
+  });
+
+  assert.deepEqual(diagnosticCodes(result), ["canonical_root_has_dependency"]);
+});
+
+test("fails closed on unsafe collection, candidate, and identifier bounds", () => {
+  const tooManyNodes = Array.from(
+    { length: CLOSURE_DEPENDENCY_PLANNER_LIMITS.maxNodes + 1 },
+    (_, index) => closure(`node-${index}`),
+  );
+  const tooManyEdges = Array.from({ length: CLOSURE_DEPENDENCY_PLANNER_LIMITS.maxEdges + 1 }, () =>
+    edge("root", "a"),
+  );
+  const tooManyCandidates = Array.from(
+    { length: CLOSURE_DEPENDENCY_PLANNER_LIMITS.maxCanonicalCandidatesPerNode + 1 },
+    (_, index) => `root-${index}`,
+  );
+
+  assert.deepEqual(diagnosticCodes(planClosureDependencies({ nodes: tooManyNodes, edges: [] })), [
+    "unsafe_bounds",
+  ]);
+  assert.deepEqual(
+    diagnosticCodes(
+      planClosureDependencies({
+        nodes: [canonical(), closure("a")],
+        edges: tooManyEdges,
+      }),
+    ),
+    ["unsafe_bounds"],
+  );
+  assert.deepEqual(
+    diagnosticCodes(
+      planClosureDependencies({
+        nodes: [canonical(), closure("a", tooManyCandidates)],
+        edges: [],
+      }),
+    ),
+    ["unsafe_bounds"],
+  );
+  assert.deepEqual(
+    diagnosticCodes(
+      planClosureDependencies({
+        nodes: [canonical(), closure("not ascii: \u00e9")],
+        edges: [],
+      }),
+    ),
+    ["invalid_node_id"],
+  );
+});
+
+test("does not mutate caller-owned nodes, candidates, or edges", () => {
+  const canonicalCandidates = Object.freeze(["root"]);
+  const nodes = Object.freeze([
+    Object.freeze(canonical()),
+    Object.freeze({ ...closure("b"), canonicalCandidates }),
+    Object.freeze({ ...closure("a"), canonicalCandidates }),
+  ]);
+  const edges = Object.freeze([Object.freeze(edge("root", "b")), Object.freeze(edge("root", "a"))]);
+  const before = JSON.stringify({ nodes, edges });
+
+  const result = planClosureDependencies({ nodes, edges });
+
+  assert.equal(result.status, "safe");
+  assert.equal(JSON.stringify({ nodes, edges }), before);
+});
+
+function permutations<T>(values: readonly T[]): T[][] {
+  if (values.length <= 1) return [[...values]];
+  const results: T[][] = [];
+  for (let index = 0; index < values.length; index += 1) {
+    const value = values[index];
+    if (value === undefined) continue;
+    const rest = [...values.slice(0, index), ...values.slice(index + 1)];
+    for (const tail of permutations(rest)) results.push([value, ...tail]);
+  }
+  return results;
+}


### PR DESCRIPTION
## What Problem This Solves

ClawSweeper has evidence for related and duplicate items, but no deterministic primitive for ordering dependent closures or failing closed on ambiguous roots and dependency cycles.

## Why This Change Was Made

Adds a pure bounded planner that validates one canonical root, condenses cycle detection with Tarjan SCCs, and emits deterministic dependency-first Kahn layers. It is intentionally not connected to review, apply, or GitHub mutation yet.

## User Impact

Future closure lanes can plan safe, repeatable closeout batches and route cycles or ambiguous canonical choices to a maintainer instead of guessing. Current production behavior is unchanged.

## Evidence

- repair TypeScript build and no-emit typecheck pass
- 12 focused planner tests pass
- focused repair/test lint passes
- focused format check passes
- structural guard checks pass
