### PR TITLE
feat(dashboard): expose exact-review pressure telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Added
 
+- Added observation-only exact-review queue telemetry for total, retry-ready,
+  and target-admissible backlog plus deterministic pressure classification,
+  without changing scheduling or admission behavior. Thanks @brokemac79.
 - Added end-to-end exact-review handoff health with phase ages, delayed/stalled claim classification, and a phase-aware operator rail on the live dashboard.
 - Added a maintainer-only two-runner workflow that builds a hash-bound
   crawl-remote release artifact without production credentials, then requires

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,6 @@ checkpoint, and status-only commits are intentionally omitted.
 ## 0.3.1 - Unreleased
 
 ### Added
-
-- Added observation-only exact-review queue telemetry for total, retry-ready,
-  and target-admissible backlog plus deterministic pressure classification,
-  without changing scheduling or admission behavior. Thanks @brokemac79.
 - Added end-to-end exact-review handoff health with phase ages, delayed/stalled claim classification, and a phase-aware operator rail on the live dashboard.
 - Added a maintainer-only two-runner workflow that builds a hash-bound
   crawl-remote release artifact without production credentials, then requires

--- a/dashboard/exact-review-health.ts
+++ b/dashboard/exact-review-health.ts
@@ -38,6 +38,25 @@ export type ExactReviewHandoffHealth = {
   phases: Record<ExactReviewPhase, ExactReviewPhaseSummary>;
 };
 
+export type ExactReviewPressureStatus = "idle" | "congested" | "saturated" | "unknown";
+
+export type ExactReviewPressureSummary = {
+  status: ExactReviewPressureStatus;
+  reason:
+    | "capacity_unavailable"
+    | "capacity_available"
+    | "no_ready_backlog"
+    | "no_admissible_backlog"
+    | "dispatcher_inactive"
+    | "handoff_unknown"
+    | "capacity_full_with_backlog";
+  capacity: number;
+  active: number;
+  pending: number;
+  ready_pending: number;
+  admissible_pending: number;
+};
+
 const PHASES: ExactReviewPhase[] = ["pending", "dispatching", "leased"];
 
 export function summarizeExactReviewHandoff({
@@ -153,6 +172,57 @@ export function summarizeExactReviewHandoff({
   };
 }
 
+export function summarizeExactReviewPressure({
+  pending,
+  readyPending,
+  admissiblePending,
+  dispatching,
+  leased,
+  capacity,
+  dispatcherState,
+  handoffStatus,
+}: {
+  pending: number;
+  readyPending: number;
+  admissiblePending: number;
+  dispatching: number;
+  leased: number;
+  capacity: number;
+  dispatcherState?: string;
+  handoffStatus?: string;
+}): ExactReviewPressureSummary {
+  const safePending = nonNegativeInteger(pending);
+  const safeReadyPending = Math.min(safePending, nonNegativeInteger(readyPending));
+  const safeAdmissiblePending = Math.min(safeReadyPending, nonNegativeInteger(admissiblePending));
+  const safeCapacity = nonNegativeInteger(capacity);
+  const active = nonNegativeInteger(dispatching) + nonNegativeInteger(leased);
+  const common = {
+    capacity: safeCapacity,
+    active,
+    pending: safePending,
+    ready_pending: safeReadyPending,
+    admissible_pending: safeAdmissiblePending,
+  };
+
+  if (safeCapacity < 1) return { status: "unknown", reason: "capacity_unavailable", ...common };
+  if (safeReadyPending < 1) return { status: "idle", reason: "no_ready_backlog", ...common };
+  if (safeAdmissiblePending < 1) {
+    return { status: "idle", reason: "no_admissible_backlog", ...common };
+  }
+  if (active < safeCapacity) return { status: "idle", reason: "capacity_available", ...common };
+  if (dispatcherState !== "active") {
+    return { status: "unknown", reason: "dispatcher_inactive", ...common };
+  }
+  if (!["healthy", "degraded", "stalled"].includes(String(handoffStatus || ""))) {
+    return { status: "unknown", reason: "handoff_unknown", ...common };
+  }
+  return {
+    status: safeAdmissiblePending >= safeCapacity ? "saturated" : "congested",
+    reason: "capacity_full_with_backlog",
+    ...common,
+  };
+}
+
 function exactReviewPhaseStartedAt(
   item: ExactReviewHealthItem,
   now: number,
@@ -201,4 +271,9 @@ function finiteTimestamp(value: unknown, fallback: number) {
 function finiteNumber(value: unknown, fallback: number) {
   const number = Number(value);
   return Number.isFinite(number) ? number : fallback;
+}
+
+function nonNegativeInteger(value: unknown) {
+  const number = Number(value);
+  return Number.isFinite(number) ? Math.max(0, Math.floor(number)) : 0;
 }

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -8642,6 +8642,7 @@ h2::before { content: ""; flex: 0 0 auto; width: 14px; height: 2px; border-radiu
 .exact-handoff-title { display: grid; gap: 3px; }
 .exact-handoff-title strong { font-size: 13px; font-weight: 650; }
 .exact-handoff-title span { color: var(--muted); font-size: 12px; }
+.exact-handoff-badges { display: flex; flex-wrap: wrap; gap: 6px; }
 .health-badge {
   flex: 0 0 auto;
   padding: 3px 8px;
@@ -8654,8 +8655,10 @@ h2::before { content: ""; flex: 0 0 auto; width: 14px; height: 2px; border-radiu
 }
 .health-badge.healthy,
 .health-badge.idle { color: var(--green); border-color: color-mix(in srgb, var(--green) 40%, transparent); }
-.health-badge.degraded { color: var(--amber); border-color: color-mix(in srgb, var(--amber) 45%, transparent); }
-.health-badge.stalled { color: var(--red); border-color: color-mix(in srgb, var(--red) 45%, transparent); }
+.health-badge.degraded,
+.health-badge.congested { color: var(--amber); border-color: color-mix(in srgb, var(--amber) 45%, transparent); }
+.health-badge.stalled,
+.health-badge.saturated { color: var(--red); border-color: color-mix(in srgb, var(--red) 45%, transparent); }
 .handoff-phases {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -9467,6 +9470,8 @@ function renderExactReviewHandoff(queue) {
     return;
   }
   const status = ["idle", "healthy", "degraded", "stalled"].includes(health.status) ? health.status : "unknown";
+  const pressure = queue?.pressure;
+  const pressureStatus = ["idle", "congested", "saturated", "unknown"].includes(pressure?.status) ? pressure.status : "unknown";
   const labels = {
     pending: ["Pending", "waiting for admission"],
     dispatching: ["Dispatching", "waiting for run claim"],
@@ -9480,8 +9485,9 @@ function renderExactReviewHandoff(queue) {
     return '<div class="handoff-phase"><span>' + esc(labels[phase][0]) + '</span><strong>' + fmt.format(summary.count || 0) + '</strong><small>' + esc(labels[phase][1] + " · " + age) + '</small></div>';
   }).join("");
   const slots = fmt.format(health.available_slots || 0) + " of " + fmt.format(health.capacity || 0) + " exact-review slots open";
+  const backlog = fmt.format(queue?.pending || 0) + " total · " + fmt.format(queue?.ready_pending || 0) + " ready · " + fmt.format(queue?.admissible_pending || 0) + " admissible";
   const threshold = "stalled after " + elapsed((health.stalled_after_seconds || 0) * 1000);
-  target.innerHTML = '<div class="exact-handoff"><div class="exact-handoff-head"><div class="exact-handoff-title"><strong>Exact-review handoff</strong><span>' + esc(health.message || "Queue phase telemetry") + '</span></div><span class="health-badge ' + esc(status) + '">' + esc(status) + '</span></div><div class="handoff-phases">' + phases + '</div><div class="handoff-foot"><span>' + esc(slots) + '</span><span>' + esc(threshold) + '</span></div></div>';
+  target.innerHTML = '<div class="exact-handoff"><div class="exact-handoff-head"><div class="exact-handoff-title"><strong>Exact-review handoff</strong><span>' + esc(health.message || "Queue phase telemetry") + '</span></div><div class="exact-handoff-badges"><span class="health-badge ' + esc(status) + '">' + esc(status) + '</span><span class="health-badge ' + esc(pressureStatus) + '">pressure ' + esc(pressureStatus) + '</span></div></div><div class="handoff-phases">' + phases + '</div><div class="handoff-foot"><span>' + esc(slots) + '</span><span>' + esc(backlog) + '</span><span>' + esc(threshold) + '</span></div></div>';
 }
 function renderWorkers(rows) {
   workerIndex = new Map(rows.map(worker => [String(worker.id), worker]));

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -5,7 +5,10 @@ import {
 import { isExactReviewCloseGuardLabel } from "../src/repair/exact-review-guard-labels.ts";
 import { stableJson } from "../src/stable-json.ts";
 import { bayHtml } from "./bay-page.ts";
-import { summarizeExactReviewHandoff } from "./exact-review-health.ts";
+import {
+  summarizeExactReviewHandoff,
+  summarizeExactReviewPressure,
+} from "./exact-review-health.ts";
 import { TRIAGE_ROUTING_GROUPS, triageRoutingGroupsForLabels } from "./triage-routing-groups.ts";
 
 const ACTIVE_RUN_STATUSES = new Set(["queued", "in_progress", "waiting", "requested", "pending"]);
@@ -2773,8 +2776,30 @@ function exactReviewQueueStats(
         left.target_repo.localeCompare(right.target_repo),
     );
   const nextWakeAt = exactReviewQueueNextWakeAt(state, now, capacity, targetCapacity);
-  return {
+  const readyPending = items.filter(
+    (item) => item.state === "pending" && item.nextAttemptAt <= now,
+  ).length;
+  const admissiblePending = exactReviewQueueAdmittedItems(
+    state,
+    now,
+    Number.MAX_SAFE_INTEGER,
+    targetCapacity,
+  ).length;
+  const pressure = summarizeExactReviewPressure({
     pending: handoffHealth.phases.pending.count,
+    readyPending,
+    admissiblePending,
+    dispatching: handoffHealth.phases.dispatching.count,
+    leased: handoffHealth.phases.leased.count,
+    capacity,
+    dispatcherState: state.dispatcher?.state,
+    handoffStatus: handoffHealth.status,
+  });
+  return {
+    generated_at: handoffHealth.observed_at,
+    pending: handoffHealth.phases.pending.count,
+    ready_pending: readyPending,
+    admissible_pending: admissiblePending,
     dispatching: handoffHealth.phases.dispatching.count,
     leased: handoffHealth.phases.leased.count,
     oldest_pending_at: handoffHealth.phases.pending.oldest_at,
@@ -2784,6 +2809,7 @@ function exactReviewQueueStats(
     oldest_leased_at: handoffHealth.phases.leased.oldest_at,
     oldest_leased_age_seconds: handoffHealth.phases.leased.oldest_age_seconds,
     handoff_health: handoffHealth,
+    pressure,
     next_wake_at: nextWakeAt === null ? null : new Date(nextWakeAt).toISOString(),
     dispatcher: {
       state: state.dispatcher?.state || "unknown",

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -140,6 +140,8 @@ is absent or a cache event lands in another Cloudflare colo.
   apply-ready candidate count and an estimated number of cursor windows to
   revisit the close queue; scheduled cadence time is explanatory only because
   successful windows can dispatch immediate continuations
+- exact-review queue backlog, retry-ready backlog, target-admissible backlog,
+  and pressure classification from the current durable queue snapshot
 
 The Worker fetches job details only for the bounded active-run set, limits that
 GitHub fanout to 12 concurrent requests, and caches each run's jobs for 60
@@ -218,9 +220,17 @@ workflow state, check time, and retry time so an intentional pause cannot look
 like occupied executor capacity. Re-enabling the workflow does not require a
 queue mutation; the next status check resumes normal admission.
 
-The same endpoint exposes `handoff_health` plus oldest timestamps and ages for
-the pending, dispatching, and leased phases. New dispatch and claim transitions
-carry explicit phase timestamps. Rows written by an older deployment derive
+The same endpoint exposes `generated_at`, `ready_pending`,
+`admissible_pending`, `pressure`, `handoff_health`, and oldest timestamps and
+ages for the pending, dispatching, and leased phases. `ready_pending` excludes
+retry-delayed items. `admissible_pending` further excludes ready items blocked
+by their target's exact-review cap. `pressure` is a deterministic observation
+from that same queue snapshot: it reports `congested` or `saturated` only when
+capacity is full, the dispatcher and handoff telemetry are known, and
+target-admissible backlog remains. The snapshot adds no GitHub API fanout, and
+no workflow, planner, admission, continuation, or dispatch decision consumes
+the pressure value. New dispatch and claim transitions carry explicit phase
+timestamps. Rows written by an older deployment derive
 their phase start from the active dispatch or execution lease; a stale timestamp
 left by a rollback cannot override that newer lease, and a wholly unknown legacy
 age stays non-alarming. A claim is degraded after one third of the dispatch

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -4330,6 +4330,18 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
     automatic_work: [],
     pipeline: [],
     exact_review_queue: {
+      pending: 4,
+      ready_pending: 3,
+      admissible_pending: 2,
+      pressure: {
+        status: "congested",
+        reason: "capacity_full_with_backlog",
+        capacity: 28,
+        active: 28,
+        pending: 4,
+        ready_pending: 3,
+        admissible_pending: 2,
+      },
       handoff_health: {
         status: "healthy",
         message: "Dispatch-to-claim handoffs are within the expected window.",
@@ -4440,9 +4452,12 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
   assert.match(elementFor("exact-review-handoff").innerHTML, /Dispatching/);
   assert.match(elementFor("exact-review-handoff").innerHTML, /2 of 28 exact-review slots open/);
   assert.match(elementFor("exact-review-handoff").innerHTML, /health-badge healthy/);
+  assert.match(elementFor("exact-review-handoff").innerHTML, /pressure congested/);
+  assert.match(elementFor("exact-review-handoff").innerHTML, /4 total · 3 ready · 2 admissible/);
 
   status.recent.apply_health.items = [];
   status.exact_review_queue.handoff_health.status = "stalled";
+  status.exact_review_queue.pressure.status = "saturated";
   status.exact_review_queue.handoff_health.message =
     "A dispatched review has not been claimed within the expected handoff window.";
   context.renderDashboard(status, "");
@@ -4450,6 +4465,7 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
   assert.equal(elementFor("hero-dot").className, "hero-dot red");
   assert.match(elementFor("hero-headline").textContent, /^Needs attention/);
   assert.match(elementFor("exact-review-handoff").innerHTML, /health-badge stalled/);
+  assert.match(elementFor("exact-review-handoff").innerHTML, /pressure saturated/);
 
   Object.assign(status, { exact_review_queue: null });
   status.diagnostics.exact_review_queue_error = "exact-review queue timed out";

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -43,12 +43,99 @@ test("dashboard status reads the exact-review handoff model from the durable que
   });
 
   assert.ok(status);
+  assert.match(status.generated_at, /^\d{4}-\d{2}-\d{2}T/);
   assert.equal(status.pending, 1);
+  assert.equal(status.ready_pending, 1);
+  assert.equal(status.admissible_pending, 1);
   assert.equal(status.dispatching, 0);
   assert.equal(status.leased, 0);
   assert.equal(status.handoff_health.status, "healthy");
   assert.equal(status.handoff_health.phases.pending.count, 1);
+  assert.equal(status.pressure.status, "idle");
+  assert.equal(status.pressure.reason, "capacity_available");
   assert.equal(await exactReviewQueueStatusSnapshot({}), null);
+});
+
+test("dashboard status excludes retry-delayed exact reviews from dispatchable backlog", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  await queue.fetch(buildExactReviewQueueRequest("delayed-status", 598, "opened"));
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { nextAttemptAt: number }>;
+  };
+  state.items["openclaw/gogcli#598"].nextAttemptAt = Date.now() + 60_000;
+  await storage.put("exact-review-queue", state);
+
+  const status = await exactReviewQueueStatusSnapshot({
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+  });
+
+  assert.ok(status);
+  assert.equal(status.pending, 1);
+  assert.equal(status.ready_pending, 0);
+  assert.equal(status.admissible_pending, 0);
+  assert.equal(status.pressure.reason, "no_ready_backlog");
+});
+
+test("dashboard status excludes ready reviews blocked by a target exact-review cap", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, { EXACT_REVIEW_TARGET_MAX_CONCURRENT: "1" });
+  await queue.fetch(
+    buildExactReviewQueueRequest("target-cap-status", 599, "opened", "issue", "openclaw/openclaw"),
+  );
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<string, ReturnType<typeof leasedExactReviewQueueItem>>;
+  };
+  state.items["openclaw/openclaw#600"] = leasedExactReviewQueueItem(600, "run-600");
+  await storage.put("exact-review-queue", state);
+
+  const status = await exactReviewQueueStatusSnapshot({
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+  });
+
+  assert.ok(status);
+  assert.equal(status.pending, 1);
+  assert.equal(status.ready_pending, 1);
+  assert.equal(status.admissible_pending, 0);
+  assert.equal(status.pressure.reason, "no_admissible_backlog");
+});
+
+test("dashboard status reports saturated exact-review pressure at full capacity", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue(
+    { storage },
+    {
+      EXACT_REVIEW_QUEUE_MAX_CONCURRENT: "1",
+      EXACT_REVIEW_TARGET_MAX_CONCURRENT: "1",
+    },
+  );
+  await queue.fetch(
+    buildExactReviewQueueRequest("pressure-status", 601, "opened", "issue", "openclaw/gogcli"),
+  );
+  const state = (await storage.get("exact-review-queue")) as {
+    dispatcher?: { state: "active"; checkedAt: number; workflowState: string };
+    items: Record<string, ReturnType<typeof leasedExactReviewQueueItem>>;
+  };
+  state.dispatcher = { state: "active", checkedAt: Date.now(), workflowState: "active" };
+  state.items["openclaw/openclaw#602"] = leasedExactReviewQueueItem(602, "run-602");
+  await storage.put("exact-review-queue", state);
+
+  const status = await exactReviewQueueStatusSnapshot({
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+  });
+
+  assert.ok(status);
+  assert.equal(status.ready_pending, 1);
+  assert.equal(status.admissible_pending, 1);
+  assert.deepEqual(status.pressure, {
+    status: "saturated",
+    reason: "capacity_full_with_backlog",
+    capacity: 1,
+    active: 1,
+    pending: 1,
+    ready_pending: 1,
+    admissible_pending: 1,
+  });
 });
 
 test("triage routing groups classify impact labels without forcing one primary group", () => {

--- a/test/exact-review-health.test.ts
+++ b/test/exact-review-health.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { summarizeExactReviewHandoff } from "../dashboard/exact-review-health.ts";
+import {
+  summarizeExactReviewHandoff,
+  summarizeExactReviewPressure,
+} from "../dashboard/exact-review-health.ts";
 
 const NOW = Date.parse("2026-07-13T02:00:00.000Z");
 const DISPATCH_LEASE_MS = 10 * 60_000;
@@ -169,4 +172,73 @@ test("exact-review handoff health derives legacy leased age from its execution l
   assert.equal(health.status, "healthy");
   assert.equal(health.phases.leased.oldest_at, "2026-07-13T01:59:20.000Z");
   assert.equal(health.phases.leased.oldest_age_seconds, 40);
+});
+
+test("exact-review pressure distinguishes available, congested, and saturated capacity", () => {
+  const base = {
+    pending: 4,
+    readyPending: 4,
+    admissiblePending: 4,
+    dispatching: 4,
+    leased: 60,
+    capacity: 64,
+    dispatcherState: "active",
+    handoffStatus: "healthy",
+  };
+
+  assert.deepEqual(summarizeExactReviewPressure({ ...base, leased: 59 }), {
+    status: "idle",
+    reason: "capacity_available",
+    capacity: 64,
+    active: 63,
+    pending: 4,
+    ready_pending: 4,
+    admissible_pending: 4,
+  });
+  assert.equal(summarizeExactReviewPressure({ ...base, admissiblePending: 3 }).status, "congested");
+  assert.equal(
+    summarizeExactReviewPressure({ ...base, pending: 64, readyPending: 64, admissiblePending: 64 })
+      .status,
+    "saturated",
+  );
+});
+
+test("exact-review pressure preserves non-dispatchable and unknown states", () => {
+  const base = {
+    pending: 5,
+    readyPending: 5,
+    admissiblePending: 5,
+    dispatching: 4,
+    leased: 60,
+    capacity: 64,
+    dispatcherState: "active",
+    handoffStatus: "healthy",
+  };
+
+  assert.equal(
+    summarizeExactReviewPressure({ ...base, readyPending: 0 }).reason,
+    "no_ready_backlog",
+  );
+  assert.equal(
+    summarizeExactReviewPressure({ ...base, admissiblePending: 0 }).reason,
+    "no_admissible_backlog",
+  );
+  assert.deepEqual(
+    summarizeExactReviewPressure({
+      ...base,
+      pending: 2.9,
+      readyPending: 9,
+      admissiblePending: 8,
+      dispatcherState: "paused",
+    }),
+    {
+      status: "unknown",
+      reason: "dispatcher_inactive",
+      capacity: 64,
+      active: 64,
+      pending: 2,
+      ready_pending: 2,
+      admissible_pending: 2,
+    },
+  );
 });


### PR DESCRIPTION
Related: https://github.com/openclaw/clawsweeper/pull/542

## What Problem This Solves

Maintainers can see exact-review queue counts and handoff age, but cannot distinguish retry-delayed work, target-cap-blocked work, ordinary congestion, and genuine full-capacity saturation.

## Why This Change Was Made

Extracts the observation-only portion of contributor PR 542 into the existing durable queue status surface. It reports total, retry-ready, and target-admissible backlog plus a deterministic pressure state, while changing no workflow, limit, admission, continuation, dispatch, or scheduler decision.

## User Impact

The live dashboard and status API can explain whether exact-review backlog is actionable and capacity-bound before any adaptive scheduler behavior is enabled. Existing scheduling remains byte-for-byte unchanged outside dashboard rendering.

## Evidence

- dashboard build passes
- 14 focused pressure and status tests pass
- focused dashboard/test lint and format checks pass
- limits and diff checks pass
- zero diff under `.github/workflows`, `config/automation-limits.json`, `src/repair`, or scheduler policy
- commits preserve `brokemac79` as co-author

## Maintainer follow-up — 2026-07-14

- Supersedes the telemetry portion of closed PR #542. The paired scheduler policy is in #559 and must land only after this PR.
- Removed the contributor-added unreleased `CHANGELOG.md` entry; release notes are release-owned in this repository.
- Focused proof: `git diff --check` passed.
- Codex review closeout: `codex review --uncommitted` clean for the changelog cleanup; `codex review --base origin/main` clean with no actionable findings.
