### PR TITLE
fix(repair): preserve successful status contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Kept legacy successful GitHub status contexts compatible with repair apply validation after the action-lifecycle rollback.
 - Stopped narrow OpenClaw automerge repairs from chasing unrelated full-repository lint and typecheck failures.
 - Removed the synthetic Codex write preflight that could block repair before Codex saw the real task.
 - Kept exact-review handoff health live when the dashboard serves a stale fleet snapshot, so recovered claims no longer leave the operator rail stuck in a delayed or stalled state.

--- a/src/repair/apply-result.ts
+++ b/src/repair/apply-result.ts
@@ -1512,8 +1512,10 @@ function validateStatusChecks(checks: LooseRecord[]) {
   const blockers: LooseRecord[] = [];
   for (const check of checks) {
     const name = check.name ?? check.context ?? "unknown check";
+    const state = String(check.state ?? "").toUpperCase();
     const status = String(check.status ?? check.state ?? "").toUpperCase();
     const conclusion = String(check.conclusion ?? "").toUpperCase();
+    if (!check.status && !conclusion && PASSING_CHECK_CONCLUSIONS.has(state)) continue;
     if (status && !["COMPLETED", "SUCCESS"].includes(status)) {
       blockers.push(`${name}: ${status}`);
       continue;

--- a/test/repair/apply-result.test.ts
+++ b/test/repair/apply-result.test.ts
@@ -599,7 +599,7 @@ test("repair apply blocks PR close when open covering PR lacks positive proof", 
   }
 });
 
-test("repair apply executes PR duplicate close when coverage proof says covered", () => {
+test("repair apply accepts a legacy successful status context for a covering PR", () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-apply-result-"));
   try {
     const paths = writeApplyFixture(tmp, {
@@ -625,6 +625,7 @@ test("repair apply executes PR duplicate close when coverage proof says covered"
         101: [comment("alice", "PR A keeps legacy config behavior intact.")],
         202: [comment("bob", "PR B carries forward the legacy config behavior.")],
       },
+      statusCheckRollup: [{ context: "test", state: "SUCCESS" }],
       logPath: paths.ghLogPath,
     });
     writeFakeCodex(paths.binDir);
@@ -1151,6 +1152,7 @@ type FakeGhData = {
   postProofIssueUpdates?: Record<number, string>;
   postProofPulls?: Record<number, Record<string, unknown>>;
   postProofPrViewFailure?: { number: number; message: string };
+  statusCheckRollup?: Record<string, unknown>[];
   logPath: string;
 };
 
@@ -1401,7 +1403,9 @@ if (args[0] === "pr" && args[1] === "view") {
     mergedAt: pull.merged_at || null,
     reviewDecision: null,
     state: String(pull.state || "open").toUpperCase(),
-    statusCheckRollup: [{ name: "test", status: "COMPLETED", conclusion: "SUCCESS" }],
+    statusCheckRollup: data.statusCheckRollup || [
+      { name: "test", status: "COMPLETED", conclusion: "SUCCESS" },
+    ],
     title: pull.title,
     updatedAt: pull.updated_at,
     url: pull.html_url,


### PR DESCRIPTION
## Summary
- accept legacy successful GitHub status contexts during repair apply validation
- retain strict blocking for pending or failed check shapes
- cover the compatibility path in the focused apply-result fixture

## Validation
- TypeScript builds
- 33 focused repair apply tests
- lint, format, limits, and diff checks