### PR TITLE
fix(review): bind mutations to reviewed activity

### DIFF
--- a/.github/workflows/repair-comment-router.yml
+++ b/.github/workflows/repair-comment-router.yml
@@ -111,6 +111,8 @@ jobs:
             src/github-json.ts
             src/github-retry.ts
             src/pr-close-coverage-proof.ts
+            src/review-activity-cursor.ts
+            src/stable-json.ts
             src/action-ledger-files.ts
             src/action-ledger-runtime.ts
             src/action-ledger.ts

--- a/.github/workflows/spam-comment-intake.yml
+++ b/.github/workflows/spam-comment-intake.yml
@@ -66,6 +66,8 @@ jobs:
             src/github-json.ts
             src/github-retry.ts
             src/pr-close-coverage-proof.ts
+            src/review-activity-cursor.ts
+            src/stable-json.ts
             src/repair
             src/repository-profiles.ts
             package.json

--- a/.github/workflows/spam-scanner.yml
+++ b/.github/workflows/spam-scanner.yml
@@ -89,6 +89,8 @@ jobs:
             src/github-json.ts
             src/github-retry.ts
             src/pr-close-coverage-proof.ts
+            src/review-activity-cursor.ts
+            src/stable-json.ts
             src/repair
             src/repository-profiles.ts
             package.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ checkpoint, and status-only commits are intentionally omitted.
 ## 0.3.1 - Unreleased
 
 ### Added
+
 - Added end-to-end exact-review handoff health with phase ages, delayed/stalled claim classification, and a phase-aware operator rail on the live dashboard.
 - Added a maintainer-only two-runner workflow that builds a hash-bound
   crawl-remote release artifact without production credentials, then requires
@@ -56,6 +57,7 @@ checkpoint, and status-only commits are intentionally omitted.
 - Added a system, light, and dark theme switcher to the generated documentation site. Thanks @joshka.
 
 ### Changed
+
 - Preserved crawl-remote's reviewed `limits.cpu_ms` value through immutable
   release packaging and post-transfer deployment verification.
 - Reverted the action-lifecycle expansion from PR #521, restoring the pre-merge ClawSweeper paths while retaining later exact-review throughput fixes and retrying coalesced reconciliations after any partial lookup failure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ checkpoint, and status-only commits are intentionally omitted.
   attempt-scoped artifact so bounded requeues and failed-run self-heal retries
   reuse the actual effective mode, runners, sandbox, model, and dry-run state
   instead of mutable workflow defaults.
+- Bound pull-request apply and automerge actions to a bounded digest of the reviewed reviews and inline comments, so same-second or late review activity now forces a fresh verdict before mutation.
 - Stopped narrow OpenClaw automerge repairs from chasing unrelated full-repository lint and typecheck failures.
 - Removed the synthetic Codex write preflight that could block repair before Codex saw the real task.
 - Kept exact-review handoff health live when the dashboard serves a stale fleet snapshot, so recovered claims no longer leave the operator rail stuck in a delayed or stalled state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,7 +114,7 @@ checkpoint, and status-only commits are intentionally omitted.
   attempt-scoped artifact so bounded requeues and failed-run self-heal retries
   reuse the actual effective mode, runners, sandbox, model, and dry-run state
   instead of mutable workflow defaults.
-- Bound pull-request apply and automerge actions to a bounded digest of the reviewed reviews and inline comments, so same-second or late review activity now forces a fresh verdict before mutation.
+- Bound pull-request review reuse, apply, and automerge actions to a size-capped digest of reviews, inline comments, and review-thread resolution state, so legacy reports, late activity, or resolved-thread drift force a fresh verdict before mutation.
 - Stopped narrow OpenClaw automerge repairs from chasing unrelated full-repository lint and typecheck failures.
 - Removed the synthetic Codex write preflight that could block repair before Codex saw the real task.
 - Kept exact-review handoff health live when the dashboard serves a stale fleet snapshot, so recovered claims no longer leave the operator rail stuck in a delayed or stalled state.

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -183,7 +183,10 @@ import {
   type ReviewHistoryLedger,
 } from "./review-history.js";
 import { trailingHtmlComments } from "./review-comment-markers.js";
-import { createReviewedPrActivityCursor } from "./review-activity-cursor.js";
+import {
+  createReviewedPrActivityCursor,
+  isReviewedPrActivityCursor,
+} from "./review-activity-cursor.js";
 import {
   ACTION_EVENT_REASON_CODES,
   ACTION_EVENT_STATUSES,
@@ -25486,10 +25489,12 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
         };
       }
     };
-    const ownedApplyMutationLeaseBlockReason = (
+    const ownedApplyMutationLeaseBlock = (
       lease: AcquiredReviewStartLease,
-    ): string | null => {
+    ): { sourceChanged: boolean; reason: string } | null => {
       try {
+        const reviewActivityBlock = currentReviewActivityBlock();
+        if (reviewActivityBlock) return reviewActivityBlock;
         const revisionBefore = fetchLiveReviewHeadSha();
         const refreshed = issueReviewCommentState(number);
         const revisionAfter = fetchLiveReviewHeadSha();
@@ -25501,7 +25506,10 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
             reportReviewRevision !== null &&
             revisionAfter !== reportReviewRevision)
         ) {
-          return `${item.kind === "pull_request" ? "PR head" : "issue source revision"} changed while holding the apply mutation lease`;
+          return {
+            sourceChanged: true,
+            reason: `${item.kind === "pull_request" ? "PR head" : "issue source revision"} changed while holding the apply mutation lease`,
+          };
         }
         const winner = freshExactHeadReviewStartLease({
           comments: refreshed.leaseComments,
@@ -25516,29 +25524,39 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
           winner.commentId !== lease.commentId ||
           lease.headSha !== revisionAfter
         ) {
-          return `apply mutation lease ${lease.commentId} is no longer the elected ${item.kind === "pull_request" ? "same-head" : "same-revision"} lease`;
+          return {
+            sourceChanged: false,
+            reason: `apply mutation lease ${lease.commentId} is no longer the elected ${item.kind === "pull_request" ? "same-head" : "same-revision"} lease`,
+          };
         }
-        return canonicalBoundStaleReviewReason(
+        const staleReviewReason = canonicalBoundStaleReviewReason(
           markdownBeforeApplyDecisionMutations,
           refreshed.reviewComment,
         );
+        return staleReviewReason ? { sourceChanged: false, reason: staleReviewReason } : null;
       } catch (error) {
         if (error instanceof GitHubRuntimeBudgetError) throw error;
         const detail = trimMiddle(
           (error instanceof Error ? error.message : String(error)).replace(/\s+/g, " "),
           180,
         );
-        return `apply mutation lease verification failed; next apply will retry: ${detail}`;
+        return {
+          sourceChanged: false,
+          reason: `apply mutation lease verification failed; next apply will retry: ${detail}`,
+        };
       }
     };
     const acquireApplyMutationLease = (
       leaseState: ReturnType<typeof refreshReviewStartLeaseState>,
-    ): string | null => {
+    ): { sourceChanged: boolean; reason: string } | null => {
       if (dryRun || !requiresApplyMutationLease) return null;
       let lease: AcquiredReviewStartLease | null = null;
       if (leaseState.lease && !leaseState.preserve) {
         if (!leaseState.lease.owner || leaseState.lease.commentId === null) {
-          return "matching review lease lacks a server-confirmed owner and comment id";
+          return {
+            sourceChanged: false,
+            reason: "matching review lease lacks a server-confirmed owner and comment id",
+          };
         }
         lease = {
           owner: leaseState.lease.owner,
@@ -25557,18 +25575,28 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
           purpose: "apply",
         });
         if (posted.status !== "posted") {
-          return `${item.kind === "pull_request" ? "same-head" : "same-revision"} ClawSweeper lease was acquired concurrently`;
+          return {
+            sourceChanged: false,
+            reason: `${item.kind === "pull_request" ? "same-head" : "same-revision"} ClawSweeper lease was acquired concurrently`,
+          };
         }
         lease = posted.lease;
       }
       activeApplyMutationLease = { itemNumber: number, lease };
-      return ownedApplyMutationLeaseBlockReason(lease);
+      return ownedApplyMutationLeaseBlock(lease);
     };
-    const currentApplyMutationLeaseBlockReason = (): string | null => {
+    const currentApplyMutationLeaseBlock = (): {
+      sourceChanged: boolean;
+      reason: string;
+    } | null => {
+      const reviewActivityBlock = currentReviewActivityBlock();
+      if (reviewActivityBlock) return reviewActivityBlock;
       if (dryRun || !requiresApplyMutationLease) return null;
       const active = activeApplyMutationLease;
-      if (!active || active.itemNumber !== number) return "apply mutation lease is not held";
-      return ownedApplyMutationLeaseBlockReason(active.lease);
+      if (!active || active.itemNumber !== number) {
+        return { sourceChanged: false, reason: "apply mutation lease is not held" };
+      }
+      return ownedApplyMutationLeaseBlock(active.lease);
     };
     const recordReviewGuardSkip = (
       action: "kept_open" | "skipped_stale_review_comment_sync",
@@ -25593,6 +25621,100 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
             `${reason}; stale canonical comment correction remains pending`,
           )
         : recordReviewGuardSkip("kept_open", reason, restoreOriginal);
+    const markChangedSinceReview = (options: {
+      reason: string;
+      currentUpdatedAt?: string | undefined;
+      currentSnapshotHash?: string | undefined;
+    }): boolean => {
+      markdown = replaceFrontMatterValue(
+        markdown,
+        "action_taken",
+        "skipped_changed_since_review",
+      );
+      if (options.currentUpdatedAt) {
+        markdown = replaceFrontMatterValue(
+          markdown,
+          "current_item_updated_at",
+          options.currentUpdatedAt,
+        );
+      }
+      if (options.currentSnapshotHash) {
+        markdown = replaceFrontMatterValue(
+          markdown,
+          "current_item_snapshot_hash",
+          options.currentSnapshotHash,
+        );
+      }
+      markdown = replaceFrontMatterValue(markdown, "apply_checked_at", new Date().toISOString());
+      if (!dryRun) writeReportMarkdown(path, markdown);
+      results.push({
+        number,
+        action: "skipped_changed_since_review",
+        reason: options.reason,
+        ...eventApplyDispositionProof("skipped_changed_since_review"),
+      });
+      processedCount += 1;
+      maybeLogProgress(`skipped #${number}: ${options.reason}`);
+      return processedCount >= processedLimit;
+    };
+    const expectedReviewActivityCursor = frontMatterValue(
+      markdownBeforeApplyDecisionMutations,
+      "review_activity_cursor",
+    );
+    const currentReviewActivityBlock = (): {
+      sourceChanged: boolean;
+      reason: string;
+    } | null => {
+      if (item.kind !== "pull_request") return null;
+      if (!expectedReviewActivityCursor || expectedReviewActivityCursor === "unknown") {
+        return {
+          sourceChanged: false,
+          reason: "stored pull request review activity cursor is missing; fresh review required",
+        };
+      }
+      if (!isReviewedPrActivityCursor(expectedReviewActivityCursor)) {
+        return {
+          sourceChanged: false,
+          reason: "stored pull request review activity cursor is invalid; fresh review required",
+        };
+      }
+      try {
+        const currentReviewActivityCursor = createReviewedPrActivityCursor({
+          reviews: ghPaged<unknown>(`repos/${targetRepo()}/pulls/${number}/reviews`),
+          inlineComments: ghPaged<unknown>(`repos/${targetRepo()}/pulls/${number}/comments`),
+        });
+        if (!currentReviewActivityCursor) {
+          return {
+            sourceChanged: true,
+            reason: "pull request review activity exceeds the bounded reviewed cursor",
+          };
+        }
+        if (currentReviewActivityCursor !== expectedReviewActivityCursor) {
+          return {
+            sourceChanged: true,
+            reason: "pull request review activity changed since review",
+          };
+        }
+        return null;
+      } catch (error) {
+        if (error instanceof GitHubRuntimeBudgetError) throw error;
+        const detail = trimMiddle(
+          (error instanceof Error ? error.message : String(error)).replace(/\s+/g, " "),
+          180,
+        );
+        return {
+          sourceChanged: false,
+          reason: `pull request review activity could not be refreshed; next apply will retry: ${detail}`,
+        };
+      }
+    };
+    const recordReviewActivityBlock = (
+      block: { sourceChanged: boolean; reason: string },
+      restoreOriginal = true,
+    ): boolean =>
+      block.sourceChanged
+        ? markChangedSinceReview({ reason: block.reason })
+        : recordReviewLeaseSkip(block.reason, restoreOriginal);
     const recordActiveReviewLeaseSkip = (expiresAt: string): boolean =>
       recordReviewLeaseSkip(
         `${item.kind === "pull_request" ? "same-head" : "same-revision"} ClawSweeper review is active until ${expiresAt}`,
@@ -26389,6 +26511,11 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
         : null;
     let currentPrStatusKind: PrStatusLabelKind | null = null;
     if (state === "open") {
+      const reviewActivityBlock = currentReviewActivityBlock();
+      if (reviewActivityBlock) {
+        if (recordReviewActivityBlock(reviewActivityBlock)) break;
+        continue;
+      }
       const lateLeaseState = refreshReviewStartLeaseState();
       if (lateLeaseState.blockReason) {
         if (recordReviewLeaseSkip(lateLeaseState.blockReason)) break;
@@ -26403,9 +26530,9 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
         if (recordActiveReviewLeaseSkip(lateLeaseState.lease.expiresAt)) break;
         continue;
       }
-      const mutationLeaseBlockReason = acquireApplyMutationLease(lateLeaseState);
-      if (mutationLeaseBlockReason) {
-        if (recordReviewLeaseSkip(mutationLeaseBlockReason)) break;
+      const mutationLeaseBlock = acquireApplyMutationLease(lateLeaseState);
+      if (mutationLeaseBlock) {
+        if (recordReviewActivityBlock(mutationLeaseBlock)) break;
         continue;
       }
     }
@@ -26553,42 +26680,6 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
         break;
       continue;
     }
-    const markChangedSinceReview = (options: {
-      reason: string;
-      currentUpdatedAt?: string | undefined;
-      currentSnapshotHash?: string | undefined;
-    }): boolean => {
-      markdown = replaceFrontMatterValue(
-        markdown,
-        "action_taken",
-        "skipped_changed_since_review",
-      );
-      if (options.currentUpdatedAt) {
-        markdown = replaceFrontMatterValue(
-          markdown,
-          "current_item_updated_at",
-          options.currentUpdatedAt,
-        );
-      }
-      if (options.currentSnapshotHash) {
-        markdown = replaceFrontMatterValue(
-          markdown,
-          "current_item_snapshot_hash",
-          options.currentSnapshotHash,
-        );
-      }
-      markdown = replaceFrontMatterValue(markdown, "apply_checked_at", new Date().toISOString());
-      if (!dryRun) writeReportMarkdown(path, markdown);
-      results.push({
-        number,
-        action: "skipped_changed_since_review",
-        reason: options.reason,
-        ...eventApplyDispositionProof("skipped_changed_since_review"),
-      });
-      processedCount += 1;
-      maybeLogProgress(`skipped #${number}: ${options.reason}`);
-      return processedCount >= processedLimit;
-    };
     const postProofFreshnessBlock = (): {
       reason: string;
       currentUpdatedAt?: string;
@@ -26794,9 +26885,9 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
       !stalePrReviewHead &&
       labelSyncFreshEnough();
     if (state === "open" && isCurrentCompleteReport) {
-      const mutationLeaseBlockReason = currentApplyMutationLeaseBlockReason();
-      if (mutationLeaseBlockReason) {
-        if (recordReviewLeaseSkip(mutationLeaseBlockReason, false)) break;
+      const mutationLeaseBlock = currentApplyMutationLeaseBlock();
+      if (mutationLeaseBlock) {
+        if (recordReviewActivityBlock(mutationLeaseBlock, false)) break;
         continue;
       }
       try {
@@ -26864,9 +26955,9 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
       !isCloseProposal &&
       isCurrentCompleteReport
     ) {
-      const mutationLeaseBlockReason = currentApplyMutationLeaseBlockReason();
-      if (mutationLeaseBlockReason) {
-        if (recordReviewLeaseSkip(mutationLeaseBlockReason, false)) break;
+      const mutationLeaseBlock = currentApplyMutationLeaseBlock();
+      if (mutationLeaseBlock) {
+        if (recordReviewActivityBlock(mutationLeaseBlock, false)) break;
         continue;
       }
       currentClosingPullRequests = closingPullRequestsForIssue(number);
@@ -27158,9 +27249,9 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
           const preLeaseCanonicalGuard = applyCanonicalCommentSyncGuard(true);
           if (preLeaseCanonicalGuard.stopApply) break;
           if (preLeaseCanonicalGuard.skipCurrentItem) continue;
-          const mutationLeaseBlockReason = currentApplyMutationLeaseBlockReason();
-          if (mutationLeaseBlockReason) {
-            if (recordReviewLeaseSkip(mutationLeaseBlockReason, false)) break;
+          const mutationLeaseBlock = currentApplyMutationLeaseBlock();
+          if (mutationLeaseBlock) {
+            if (recordReviewActivityBlock(mutationLeaseBlock, false)) break;
             continue;
           }
           const latestLeaseState = refreshReviewStartLeaseState();
@@ -27445,9 +27536,9 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
       if (markApplySkipped("kept_open", inactivityCloseBlockReason)) break;
       continue;
     }
-    const closeMutationLeaseBlockReason = currentApplyMutationLeaseBlockReason();
-    if (closeMutationLeaseBlockReason) {
-      if (recordReviewLeaseSkip(closeMutationLeaseBlockReason, false)) break;
+    const closeMutationLeaseBlock = currentApplyMutationLeaseBlock();
+    if (closeMutationLeaseBlock) {
+      if (recordReviewActivityBlock(closeMutationLeaseBlock, false)) break;
       continue;
     }
     logProgress(`closing #${number}`);
@@ -27489,9 +27580,9 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
             dryRun,
           })
         : null;
-    const preCloseMutationLeaseBlockReason = currentApplyMutationLeaseBlockReason();
-    if (preCloseMutationLeaseBlockReason) {
-      if (recordReviewLeaseSkip(preCloseMutationLeaseBlockReason, false)) break;
+    const preCloseMutationLeaseBlock = currentApplyMutationLeaseBlock();
+    if (preCloseMutationLeaseBlock) {
+      if (recordReviewActivityBlock(preCloseMutationLeaseBlock, false)) break;
       continue;
     }
     ensureRuntimeDelayFits(closeDelayMs, "before close");

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -184,8 +184,11 @@ import {
 } from "./review-history.js";
 import { trailingHtmlComments } from "./review-comment-markers.js";
 import {
+  MAX_REVIEWED_PR_ACTIVITY,
+  REVIEWED_PR_ACTIVITY_THREADS_QUERY,
   createReviewedPrActivityCursor,
   isReviewedPrActivityCursor,
+  reviewedPrActivityThreadsPageFromGraphql,
 } from "./review-activity-cursor.js";
 import {
   ACTION_EVENT_REASON_CODES,
@@ -6514,6 +6517,74 @@ function ghPaged<T>(path: string): T[] {
   return pages.flatMap((page) => (Array.isArray(page) ? (page as T[]) : []));
 }
 
+function ghPagedLimit<T>(path: string, limit: number): T[] {
+  const max = Number.isFinite(limit) ? Math.max(0, Math.floor(limit)) : 0;
+  if (max === 0) return [];
+  const entries: T[] = [];
+  for (let page = 1; entries.length < max; page += 1) {
+    const current = ghPage<T>(path, page);
+    entries.push(...current);
+    if (current.length < 100) break;
+  }
+  return entries.slice(0, max);
+}
+
+function reviewedPrActivityThreads(number: number, limit: number): unknown[] {
+  const max = Number.isFinite(limit) ? Math.max(0, Math.floor(limit)) : 0;
+  if (max === 0) return [];
+  const [owner, name] = targetRepo().split("/");
+  if (!owner || !name) throw new Error(`invalid target repository: ${targetRepo()}`);
+  const threads: unknown[] = [];
+  const seenCursors = new Set<string>();
+  let after: string | null = null;
+  while (threads.length < max) {
+    const args = [
+      "api",
+      "graphql",
+      "-f",
+      `owner=${owner}`,
+      "-f",
+      `name=${name}`,
+      "-F",
+      `number=${number}`,
+      "-f",
+      `query=${REVIEWED_PR_ACTIVITY_THREADS_QUERY}`,
+    ];
+    if (after) args.push("-f", `after=${after}`);
+    const page = reviewedPrActivityThreadsPageFromGraphql(ghJson<unknown>(args));
+    if (!page) throw new Error(`malformed review thread response for PR #${number}`);
+    threads.push(...page.threads);
+    if (!page.hasNextPage) break;
+    if (!page.endCursor || seenCursors.has(page.endCursor) || page.threads.length === 0) {
+      throw new Error(`review thread pagination did not advance for PR #${number}`);
+    }
+    seenCursors.add(page.endCursor);
+    after = page.endCursor;
+  }
+  return threads.slice(0, max);
+}
+
+function fetchReviewedPrActivityCursor(
+  number: number,
+  prefetchedInlineComments?: unknown[],
+): string | null {
+  let remaining = MAX_REVIEWED_PR_ACTIVITY;
+  const reviews = ghPagedLimit<unknown>(
+    `repos/${targetRepo()}/pulls/${number}/reviews`,
+    remaining + 1,
+  );
+  if (reviews.length > remaining) return null;
+  remaining -= reviews.length;
+  const inlineComments =
+    prefetchedInlineComments ??
+    ghPagedLimit<unknown>(`repos/${targetRepo()}/pulls/${number}/comments`, remaining + 1);
+  if (inlineComments.length > remaining) return null;
+  remaining -= inlineComments.length;
+  const reviewThreads = reviewedPrActivityThreads(number, remaining + 1);
+  if (reviewThreads.length > remaining) return null;
+  return createReviewedPrActivityCursor({ reviews, inlineComments, reviewThreads });
+}
+
 export interface ContextHydration<T> {
   items: T[];
   total: number;
@@ -8303,7 +8374,10 @@ function collectItemContext(
     filteredPullReviewComments = filterReviewContextComments(pullReviewComments, item.number);
     const fullPullReviewComments =
       options.reviewCacheDigest && pullReviewCommentsWindow.truncated
-        ? ghPaged<unknown>(`repos/${targetRepo()}/pulls/${item.number}/comments`)
+        ? ghPagedLimit<unknown>(
+            `repos/${targetRepo()}/pulls/${item.number}/comments`,
+            MAX_REVIEWED_PR_ACTIVITY + 1,
+          )
         : pullReviewComments;
     digestPullReviewComments =
       fullPullReviewComments === pullReviewComments
@@ -8347,13 +8421,15 @@ function collectItemContext(
       compactComment,
     );
     if (options.reviewCacheDigest) {
-      context.pullReviewCommentsRevision = reviewCommentContentRevision(
-        digestPullReviewComments.included.map(compactComment),
+      if (fullPullReviewComments.length <= MAX_REVIEWED_PR_ACTIVITY) {
+        context.pullReviewCommentsRevision = reviewCommentContentRevision(
+          digestPullReviewComments.included.map(compactComment),
+        );
+      }
+      const pullReviewActivityCursor = fetchReviewedPrActivityCursor(
+        item.number,
+        fullPullReviewComments,
       );
-      const pullReviewActivityCursor = createReviewedPrActivityCursor({
-        reviews: ghPaged<unknown>(`repos/${targetRepo()}/pulls/${item.number}/reviews`),
-        inlineComments: fullPullReviewComments,
-      });
       if (pullReviewActivityCursor) context.pullReviewActivityCursor = pullReviewActivityCursor;
       const headSha = stringOrUndefined(asRecord(pullRecord.head).sha);
       context.pullChecks = headSha
@@ -21522,6 +21598,13 @@ function reviewCommand(args: Args): void {
         );
       }
       const priorReview = localRangeData ? null : existingReview(item, itemsDir);
+      const priorReviewActivityCursor = priorReview
+        ? frontMatterValue(priorReview.markdown, "review_activity_cursor")
+        : null;
+      const cacheReview =
+        item.kind === "pull_request" && !isReviewedPrActivityCursor(priorReviewActivityCursor)
+          ? null
+          : priorReview;
       const expectedPreviousReviewDigest = priorReview
         ? previousClawSweeperReviewDigestFromReport(priorReview.markdown)
         : null;
@@ -21533,7 +21616,7 @@ function reviewCommand(args: Args): void {
       if (!localRangeData) {
         structuralCacheChecks += 1;
         const structuralProbeDecision = reviewStructuralCacheProbeDecision({
-          review: priorReview,
+          review: cacheReview,
           reviewPolicy,
           reviewModel: PUBLIC_CODEX_MODEL,
           explicitDispatch,
@@ -21571,7 +21654,7 @@ function reviewCommand(args: Args): void {
           preHydrationStructuralRecord = structuralRecord;
           if (structuralRecord) item.updatedAt = structuralRecord.activityUpdatedAt;
           const structuralDecision = reviewStructuralCacheDecision({
-            review: priorReview,
+            review: cacheReview,
             priorRecord: priorReview?.structuralRecord ?? null,
             currentRecord: structuralRecord,
             reviewPolicy,
@@ -21630,6 +21713,7 @@ function reviewCommand(args: Args): void {
             const structuralRevalidationStartedAt = Date.now();
             let revalidatedStructuralRecord: ReviewStructuralRecord | null = null;
             let revalidatedPreviousReviewDigest: string | null = null;
+            let revalidatedReviewActivityCursor: string | null = null;
             try {
               git = loadReviewGitInfo();
               revalidatedStructuralRecord = fetchReviewStructuralRecord({
@@ -21644,6 +21728,9 @@ function reviewCommand(args: Args): void {
                 revalidatedStructuralRecord = null;
               }
               revalidatedPreviousReviewDigest = liveClawSweeperReviewDigest(item.number);
+              if (item.kind === "pull_request") {
+                revalidatedReviewActivityCursor = fetchReviewedPrActivityCursor(item.number);
+              }
             } catch (error) {
               structuralCacheRevalidationFailures += 1;
               console.error(
@@ -21655,9 +21742,9 @@ function reviewCommand(args: Args): void {
               structuralCacheRevalidationMs += Date.now() - structuralRevalidationStartedAt;
             }
             const revalidationDecision = reviewStructuralCacheDecision({
-              review: priorReview
+              review: cacheReview
                 ? {
-                    ...priorReview,
+                    ...cacheReview,
                     reviewCommentSyncedAt: new Date().toISOString(),
                   }
                 : null,
@@ -21673,14 +21760,20 @@ function reviewCommand(args: Args): void {
               expectedPreviousReviewDigest !== null &&
               revalidatedPreviousReviewDigest !== null &&
               expectedPreviousReviewDigest === revalidatedPreviousReviewDigest;
-            const revalidationReason = previousReviewIdentityMatches
-              ? revalidationDecision.reason
-              : "previous_review_changed";
+            const reviewActivityMatches =
+              item.kind !== "pull_request" ||
+              (revalidatedReviewActivityCursor !== null &&
+                revalidatedReviewActivityCursor === priorReviewActivityCursor);
+            const revalidationReason = !previousReviewIdentityMatches
+              ? "previous_review_changed"
+              : !reviewActivityMatches
+                ? "review_activity_changed"
+                : revalidationDecision.reason;
             structuralCacheRevalidationReasons.set(
               revalidationReason,
               (structuralCacheRevalidationReasons.get(revalidationReason) ?? 0) + 1,
             );
-            if (!revalidationDecision.hit || !previousReviewIdentityMatches) {
+            if (!revalidationDecision.hit || !previousReviewIdentityMatches || !reviewActivityMatches) {
               const leaseToRelease = acquiredReviewLease!;
               if (!deleteOwnedDedicatedReviewStartLease(item.number, leaseToRelease)) {
                 leaseAcquisitionFailures += 1;
@@ -21711,6 +21804,13 @@ function reviewCommand(args: Args): void {
               let carried = priorReview!.markdown;
               carried = replaceFrontMatterValue(carried, "reviewed_at", new Date().toISOString());
               carried = replaceFrontMatterValue(carried, "item_updated_at", item.updatedAt);
+              if (item.kind === "pull_request") {
+                carried = replaceFrontMatterValue(
+                  carried,
+                  "review_activity_cursor",
+                  revalidatedReviewActivityCursor!,
+                );
+              }
               carried = replaceFrontMatterValue(
                 carried,
                 "review_lease_owner",
@@ -21812,6 +21912,9 @@ function reviewCommand(args: Args): void {
             reviewCacheGitDir: openclawDir,
           });
       const contextElapsedMs = Date.now() - contextStartedAt;
+      const hydratedReviewActivityCursorAvailable =
+        item.kind !== "pull_request" ||
+        isReviewedPrActivityCursor(context.pullReviewActivityCursor);
       const contextItemUpdatedAt = stringOrUndefined(asRecord(context.issue).updatedAt);
       if (contextItemUpdatedAt) item.updatedAt = contextItemUpdatedAt;
       if (!localRangeData && contextItemUpdatedAt && preHydrationStructuralRecord) {
@@ -22032,7 +22135,7 @@ function reviewCommand(args: Args): void {
           !currentPreviousReviewDigest ||
           expectedPreviousReviewDigest !== currentPreviousReviewDigest;
         semanticDecision = reviewSemanticCacheDecision({
-          review: priorReview,
+          review: cacheReview,
           priorRecord: priorReview?.semanticRecord ?? null,
           currentRecord: semanticRecord,
           expectedPreviousReviewDigest,
@@ -22048,7 +22151,7 @@ function reviewCommand(args: Args): void {
           (semanticCacheReasons.get(semanticDecision.reason) ?? 0) + 1,
         );
       }
-      if (semanticDecision?.hit) {
+      if (semanticDecision?.hit && hydratedReviewActivityCursorAvailable) {
         semanticCacheRevalidations += 1;
         const initialSemanticRecord = semanticRecord;
         const semanticRevalidationStartedAt = Date.now();
@@ -22072,11 +22175,15 @@ function reviewCommand(args: Args): void {
           pullChecks: revalidatedChecks,
         };
         let revalidatedPreviousReview: PreviousClawSweeperReview | null;
+        let revalidatedReviewActivityCursor: string | null = null;
         try {
           revalidatedPreviousReview = extractLatestClawSweeperReview(
             fetchIssueReviewComments(item.number),
             item.number,
           );
+          if (item.kind === "pull_request") {
+            revalidatedReviewActivityCursor = fetchReviewedPrActivityCursor(item.number);
+          }
         } catch (error) {
           const revalidationReason = "durable_review_refresh_failed";
           semanticCacheRevalidationFailures += 1;
@@ -22147,14 +22254,24 @@ function reviewCommand(args: Args): void {
           reviewModel: PUBLIC_CODEX_MODEL,
         });
         semanticCacheRevalidationMs += Date.now() - semanticRevalidationStartedAt;
-        const revalidationReason = revalidatedStructuralRecord
-          ? semanticRevalidationDecision.reason
-          : "structural_verdict_input_changed";
+        const reviewActivityMatches =
+          item.kind !== "pull_request" ||
+          (revalidatedReviewActivityCursor !== null &&
+            revalidatedReviewActivityCursor === context.pullReviewActivityCursor);
+        const revalidationReason = !revalidatedStructuralRecord
+          ? "structural_verdict_input_changed"
+          : !reviewActivityMatches
+            ? "review_activity_changed"
+            : semanticRevalidationDecision.reason;
         semanticCacheRevalidationReasons.set(
           revalidationReason,
           (semanticCacheRevalidationReasons.get(revalidationReason) ?? 0) + 1,
         );
-        if (!revalidatedStructuralRecord || !semanticRevalidationDecision.hit) {
+        if (
+          !revalidatedStructuralRecord ||
+          !semanticRevalidationDecision.hit ||
+          !reviewActivityMatches
+        ) {
           const leaseToRelease = acquiredReviewLease!;
           if (!deleteOwnedDedicatedReviewStartLease(item.number, leaseToRelease)) {
             leaseAcquisitionFailures += 1;
@@ -22199,6 +22316,13 @@ function reviewCommand(args: Args): void {
           itemSnapshotHash(item, context),
         );
         carried = replaceFrontMatterValue(carried, "review_content_digest", contentDigest);
+        if (item.kind === "pull_request") {
+          carried = replaceFrontMatterValue(
+            carried,
+            "review_activity_cursor",
+            revalidatedReviewActivityCursor!,
+          );
+        }
         carried = replaceFrontMatterValue(
           carried,
           "item_source_revision",
@@ -22247,10 +22371,30 @@ function reviewCommand(args: Args): void {
         maintainerRequest ||
         previousReviewIdentityChanged ||
         !git.releaseStateComplete ||
-        (item.kind === "pull_request" && !completePullChecksContext(context.pullChecks))
+        (item.kind === "pull_request" &&
+          (!completePullChecksContext(context.pullChecks) ||
+            !hydratedReviewActivityCursorAvailable))
           ? null
-          : priorReview;
+          : cacheReview;
+      let contentCacheReviewActivityMatches = true;
+      let revalidatedContentCacheReviewActivityCursor: string | null = null;
+      if (item.kind === "pull_request" && contentCacheReview) {
+        try {
+          revalidatedContentCacheReviewActivityCursor = fetchReviewedPrActivityCursor(item.number);
+          contentCacheReviewActivityMatches =
+            revalidatedContentCacheReviewActivityCursor !== null &&
+            revalidatedContentCacheReviewActivityCursor === context.pullReviewActivityCursor;
+        } catch (error) {
+          contentCacheReviewActivityMatches = false;
+          console.error(
+            `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} content-cache=activity-refresh-failed #${item.number}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        }
+      }
       if (
+        contentCacheReviewActivityMatches &&
         reviewContentCacheHit({
           review: contentCacheReview,
           reviewPolicy,
@@ -22280,6 +22424,13 @@ function reviewCommand(args: Args): void {
           "item_snapshot_hash",
           itemSnapshotHash(item, context),
         );
+        if (item.kind === "pull_request") {
+          carried = replaceFrontMatterValue(
+            carried,
+            "review_activity_cursor",
+            revalidatedContentCacheReviewActivityCursor!,
+          );
+        }
         carried = replaceFrontMatterValue(carried, "review_cache_hit", "true");
         carried = structuralRecord
           ? updateReviewStructuralFrontMatter(carried, structuralRecord, false)
@@ -25679,10 +25830,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
         };
       }
       try {
-        const currentReviewActivityCursor = createReviewedPrActivityCursor({
-          reviews: ghPaged<unknown>(`repos/${targetRepo()}/pulls/${number}/reviews`),
-          inlineComments: ghPaged<unknown>(`repos/${targetRepo()}/pulls/${number}/comments`),
-        });
+        const currentReviewActivityCursor = fetchReviewedPrActivityCursor(number);
         if (!currentReviewActivityCursor) {
           return {
             sourceChanged: true,

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -6522,11 +6522,15 @@ function ghPagedLimit<T>(path: string, limit: number): T[] {
   if (max === 0) return [];
   const entries: T[] = [];
   for (let page = 1; entries.length < max; page += 1) {
-    const current = ghPage<T>(path, page);
+    const current = normalizeLimitedPage(ghPage<T>(path, page));
     entries.push(...current);
     if (current.length < 100) break;
   }
   return entries.slice(0, max);
+}
+
+function normalizeLimitedPage<T>(entries: T[]): T[] {
+  return entries.length === 1 && Array.isArray(entries[0]) ? (entries[0] as T[]) : entries;
 }
 
 function reviewedPrActivityThreads(number: number, limit: number): unknown[] {
@@ -6580,7 +6584,8 @@ function fetchReviewedPrActivityCursor(
     ghPagedLimit<unknown>(`repos/${targetRepo()}/pulls/${number}/comments`, remaining + 1);
   if (inlineComments.length > remaining) return null;
   remaining -= inlineComments.length;
-  const reviewThreads = reviewedPrActivityThreads(number, remaining + 1);
+  const reviewThreads =
+    inlineComments.length === 0 ? [] : reviewedPrActivityThreads(number, remaining + 1);
   if (reviewThreads.length > remaining) return null;
   return createReviewedPrActivityCursor({ reviews, inlineComments, reviewThreads });
 }

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -186,8 +186,10 @@ import { trailingHtmlComments } from "./review-comment-markers.js";
 import {
   MAX_REVIEWED_PR_ACTIVITY,
   REVIEWED_PR_ACTIVITY_THREADS_QUERY,
+  ReviewedPrActivityChangedDuringReadError,
   createReviewedPrActivityCursor,
   isReviewedPrActivityCursor,
+  readStableReviewedPrActivityCursor,
   reviewedPrActivityThreadsPageFromGraphql,
 } from "./review-activity-cursor.js";
 import {
@@ -2637,6 +2639,21 @@ type MutationRunner = <T>(options: {
   didMutate?: ((result: T) => boolean) | undefined;
   knownNoMutation?: ((error: unknown) => boolean) | undefined;
 }) => T;
+
+type ApplyMutationReviewBlock = {
+  sourceChanged: boolean;
+  reason: string;
+};
+
+class ApplyMutationReviewGuardError extends Error {
+  readonly block: ApplyMutationReviewBlock;
+
+  constructor(block: ApplyMutationReviewBlock) {
+    super(block.reason);
+    this.name = "ApplyMutationReviewGuardError";
+    this.block = block;
+  }
+}
 
 let activeApplyMutationRunner: MutationRunner | null = null;
 let activeReviewMutationRunner: MutationRunner | null = null;
@@ -25302,6 +25319,9 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
     startApplyActionLedgerItem(applyLedger, entry);
     const applyItemResultStart = results.length;
     let applyItemFailed = false;
+    let recordApplyMutationGuardBlock:
+      | ((block: ApplyMutationReviewBlock) => boolean)
+      | null = null;
     const previousApplyMutationRunner = activeApplyMutationRunner;
     try {
     const markMutationObserved = (): void => {
@@ -25329,6 +25349,10 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
       );
       if (!attempt) return options.operation();
       try {
+        if (!options.identity.startsWith("review_lease_")) {
+          const mutationLeaseBlock = currentApplyMutationLeaseBlock();
+          if (mutationLeaseBlock) throw new ApplyMutationReviewGuardError(mutationLeaseBlock);
+        }
         const result = options.operation();
         const mutated = options.didMutate?.(result) ?? true;
         const outcomeEventId = finishApplyMutationAttempt({
@@ -25340,7 +25364,9 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
         if (mutated) recordMutation(outcomeEventId);
         return result;
       } catch (error) {
-        const rejected = options.knownNoMutation?.(error) === true;
+        const rejected =
+          error instanceof ApplyMutationReviewGuardError ||
+          options.knownNoMutation?.(error) === true;
         finishApplyMutationAttempt({
           ledger: applyLedger,
           entry,
@@ -25835,7 +25861,9 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
         };
       }
       try {
-        const currentReviewActivityCursor = fetchReviewedPrActivityCursor(number);
+        const currentReviewActivityCursor = readStableReviewedPrActivityCursor(() =>
+          fetchReviewedPrActivityCursor(number),
+        );
         if (!currentReviewActivityCursor) {
           return {
             sourceChanged: true,
@@ -25851,6 +25879,12 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
         return null;
       } catch (error) {
         if (error instanceof GitHubRuntimeBudgetError) throw error;
+        if (error instanceof ReviewedPrActivityChangedDuringReadError) {
+          return {
+            sourceChanged: true,
+            reason: "pull request review activity changed since review",
+          };
+        }
         const detail = trimMiddle(
           (error instanceof Error ? error.message : String(error)).replace(/\s+/g, " "),
           180,
@@ -25868,6 +25902,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
       block.sourceChanged
         ? markChangedSinceReview({ reason: block.reason })
         : recordReviewLeaseSkip(block.reason, restoreOriginal);
+    recordApplyMutationGuardBlock = (block) => recordReviewActivityBlock(block, false);
     const recordActiveReviewLeaseSkip = (expiresAt: string): boolean =>
       recordReviewLeaseSkip(
         `${item.kind === "pull_request" ? "same-head" : "same-revision"} ClawSweeper review is active until ${expiresAt}`,
@@ -27773,6 +27808,10 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
     }
     if (processedCount >= processedLimit) break;
     } catch (error) {
+      if (error instanceof ApplyMutationReviewGuardError && recordApplyMutationGuardBlock) {
+        if (recordApplyMutationGuardBlock(error.block)) break;
+        continue;
+      }
       applyItemFailed = true;
       throw error;
     } finally {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -183,6 +183,7 @@ import {
   type ReviewHistoryLedger,
 } from "./review-history.js";
 import { trailingHtmlComments } from "./review-comment-markers.js";
+import { createReviewedPrActivityCursor } from "./review-activity-cursor.js";
 import {
   ACTION_EVENT_REASON_CODES,
   ACTION_EVENT_STATUSES,
@@ -735,6 +736,7 @@ interface ItemContext {
   pullCommitsRevision?: string;
   pullReviewComments?: unknown[];
   pullReviewCommentsRevision?: string;
+  pullReviewActivityCursor?: string;
   pullChecks?: unknown;
   counts?: {
     comments: number;
@@ -8345,6 +8347,11 @@ function collectItemContext(
       context.pullReviewCommentsRevision = reviewCommentContentRevision(
         digestPullReviewComments.included.map(compactComment),
       );
+      const pullReviewActivityCursor = createReviewedPrActivityCursor({
+        reviews: ghPaged<unknown>(`repos/${targetRepo()}/pulls/${item.number}/reviews`),
+        inlineComments: fullPullReviewComments,
+      });
+      if (pullReviewActivityCursor) context.pullReviewActivityCursor = pullReviewActivityCursor;
       const headSha = stringOrUndefined(asRecord(pullRecord.head).sha);
       context.pullChecks = headSha
         ? pullChecksContext(item.number, headSha)
@@ -18350,6 +18357,7 @@ function reviewVersionMarkerFromReport(markdown: string): string {
   const reviewedAt = frontMatterValue(markdown, "reviewed_at") ?? "unknown";
   const headSha = pullHeadShaFromReport(markdown) ?? "na";
   const sourceRevision = frontMatterValue(markdown, "item_source_revision") ?? "unknown";
+  const reviewActivityCursor = frontMatterValue(markdown, "review_activity_cursor") ?? "unknown";
   const leaseOwner = frontMatterValue(markdown, "review_lease_owner") ?? "unknown";
   const leaseCommentId = frontMatterValue(markdown, "review_lease_comment_id") ?? "unknown";
   const attrs = [
@@ -18357,6 +18365,7 @@ function reviewVersionMarkerFromReport(markdown: string): string {
     `reviewed_at=${markerAttributeValue(reviewedAt)}`,
     `sha=${markerAttributeValue(headSha)}`,
     `source_revision=${markerAttributeValue(sourceRevision)}`,
+    `review_activity_cursor=${markerAttributeValue(reviewActivityCursor)}`,
     `lease_owner=${markerAttributeValue(leaseOwner)}`,
     `lease_comment_id=${markerAttributeValue(leaseCommentId)}`,
     "v=1",
@@ -18394,6 +18403,7 @@ export function reviewAutomationMarkersFromReport(markdown: string): string {
   const reviewLeaseOwner = frontMatterValue(markdown, "review_lease_owner") ?? "unknown";
   const reviewLeaseCommentId = frontMatterValue(markdown, "review_lease_comment_id") ?? "unknown";
   const sourceRevision = frontMatterValue(markdown, "item_source_revision") ?? "unknown";
+  const reviewActivityCursor = frontMatterValue(markdown, "review_activity_cursor") ?? "unknown";
   const baseAttrs = [
     `item=${markerAttributeValue(number)}`,
     `sha=${markerAttributeValue(headSha)}`,
@@ -18403,6 +18413,7 @@ export function reviewAutomationMarkersFromReport(markdown: string): string {
     `lease_owner=${markerAttributeValue(reviewLeaseOwner)}`,
     `lease_comment_id=${markerAttributeValue(reviewLeaseCommentId)}`,
     `source_revision=${markerAttributeValue(sourceRevision)}`,
+    `review_activity_cursor=${markerAttributeValue(reviewActivityCursor)}`,
   ].join(" ");
   const securityNeedsAttention = reportSecurityReview(markdown).status === "needs_attention";
   const humanReviewMarkers = (): string => {
@@ -20147,6 +20158,7 @@ review_semantic_eligible: ${options.semanticRecord?.eligible ?? false}
 review_semantic_eligibility_reason: ${options.semanticRecord?.eligibilityReason ?? "unknown"}
 review_semantic_cache_hit: false
 item_source_revision: ${options.context.sourceRevision ?? "unknown"}
+review_activity_cursor: ${options.context.pullReviewActivityCursor ?? "unknown"}
 close_comment_sha256: ${options.action.closeComment ? sha256(options.action.closeComment) : "none"}
 review_comment_sha256: none
 review_comment_id: unknown

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -21751,7 +21751,9 @@ function reviewCommand(args: Args): void {
               }
               revalidatedPreviousReviewDigest = liveClawSweeperReviewDigest(item.number);
               if (item.kind === "pull_request") {
-                revalidatedReviewActivityCursor = fetchReviewedPrActivityCursor(item.number);
+                revalidatedReviewActivityCursor = readStableReviewedPrActivityCursor(() =>
+                  fetchReviewedPrActivityCursor(item.number),
+                );
               }
             } catch (error) {
               structuralCacheRevalidationFailures += 1;
@@ -22204,7 +22206,9 @@ function reviewCommand(args: Args): void {
             item.number,
           );
           if (item.kind === "pull_request") {
-            revalidatedReviewActivityCursor = fetchReviewedPrActivityCursor(item.number);
+            revalidatedReviewActivityCursor = readStableReviewedPrActivityCursor(() =>
+              fetchReviewedPrActivityCursor(item.number),
+            );
           }
         } catch (error) {
           const revalidationReason = "durable_review_refresh_failed";
@@ -22402,7 +22406,9 @@ function reviewCommand(args: Args): void {
       let revalidatedContentCacheReviewActivityCursor: string | null = null;
       if (item.kind === "pull_request" && contentCacheReview) {
         try {
-          revalidatedContentCacheReviewActivityCursor = fetchReviewedPrActivityCursor(item.number);
+          revalidatedContentCacheReviewActivityCursor = readStableReviewedPrActivityCursor(() =>
+            fetchReviewedPrActivityCursor(item.number),
+          );
           contentCacheReviewActivityMatches =
             revalidatedContentCacheReviewActivityCursor !== null &&
             revalidatedContentCacheReviewActivityCursor === context.pullReviewActivityCursor;

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -2847,6 +2847,7 @@ function trustedHumanReview({ author, reason, marker = null }: LooseRecord) {
     review_lease_owner: marker?.attrs?.lease_owner ?? null,
     review_lease_comment_id: marker?.attrs?.lease_comment_id ?? null,
     expected_source_revision: marker?.attrs?.source_revision ?? null,
+    expected_review_activity_cursor: marker?.attrs?.review_activity_cursor ?? null,
     finding_id: marker?.attrs?.finding ?? null,
   };
 }

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -2787,6 +2787,7 @@ function trustedRepair({ author, reason, marker = null }: LooseRecord) {
     review_lease_owner: marker?.attrs?.lease_owner ?? null,
     review_lease_comment_id: marker?.attrs?.lease_comment_id ?? null,
     expected_source_revision: marker?.attrs?.source_revision ?? null,
+    expected_review_activity_cursor: marker?.attrs?.review_activity_cursor ?? null,
     finding_id: marker?.attrs?.finding ?? null,
   };
 }

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -2805,6 +2805,7 @@ function trustedMerge({ author, reason, marker = null }: LooseRecord) {
     review_lease_owner: marker?.attrs?.lease_owner ?? null,
     review_lease_comment_id: marker?.attrs?.lease_comment_id ?? null,
     expected_source_revision: marker?.attrs?.source_revision ?? null,
+    expected_review_activity_cursor: marker?.attrs?.review_activity_cursor ?? null,
     finding_id: marker?.attrs?.finding ?? null,
   };
 }

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -2830,6 +2830,7 @@ function trustedClose({ author, reason, marker = null }: LooseRecord) {
     review_lease_comment_id: marker?.attrs?.lease_comment_id ?? null,
     expected_item_updated_at: marker?.attrs?.updated_at ?? null,
     expected_source_revision: marker?.attrs?.source_revision ?? null,
+    expected_review_activity_cursor: marker?.attrs?.review_activity_cursor ?? null,
     finding_id: marker?.attrs?.finding ?? null,
   };
 }

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -1905,7 +1905,7 @@ function executeCommand(command: LooseRecord) {
       }));
       return;
     }
-    const trustedAutomationActivityBlock = trustedAutomergeReviewActivityBlockReason(command);
+    const trustedAutomationActivityBlock = trustedAutomationReviewActivityBlockReason(command);
     if (trustedAutomationActivityBlock) {
       const status = trustedAutomationActivityBlock.retryable ? "waiting" : "skipped";
       command.status = status;
@@ -2395,7 +2395,7 @@ function runGitHubTextMutation(
     runReviewedPrActivityGuardedMutation({
       intent: String(command.intent ?? ""),
       mutationKind: kind,
-      refresh: () => trustedAutomergeReviewActivityBlockReason(command),
+      refresh: () => trustedAutomationReviewActivityBlockReason(command),
       operation: () => ghText(ghArgs, runOptions),
     });
   return runCommandMutationWithRetry(command, {
@@ -2433,7 +2433,7 @@ function runGitHubTextMutationOnce(
       runReviewedPrActivityGuardedMutation({
         intent: String(command.intent ?? ""),
         mutationKind: kind,
-        refresh: () => trustedAutomergeReviewActivityBlockReason(command),
+        refresh: () => trustedAutomationReviewActivityBlockReason(command),
         operation: () => ghText(ghArgs, options),
       }),
     knownNoMutation: (error) =>
@@ -2455,7 +2455,7 @@ function runGitHubSpawnMutation(
       runReviewedPrActivityGuardedMutation({
         intent: String(command.intent ?? ""),
         mutationKind: kind,
-        refresh: () => trustedAutomergeReviewActivityBlockReason(command),
+        refresh: () => trustedAutomationReviewActivityBlockReason(command),
         operation: () => ghSpawn(ghArgs, options),
       }),
     outcome: (result) => (result.status === 0 && !result.error ? "accepted" : "unknown"),
@@ -3719,7 +3719,7 @@ function executeAutomerge(command: LooseRecord) {
   if (stoppedReason) {
     return { action: "merge", status: "blocked", reason: stoppedReason, merge_method: "squash" };
   }
-  const initialReviewActivityBlock = trustedAutomergeReviewActivityBlockReason(command);
+  const initialReviewActivityBlock = trustedAutomationReviewActivityBlockReason(command);
   if (initialReviewActivityBlock) {
     return {
       action: "merge",
@@ -3821,7 +3821,7 @@ function executeAutomerge(command: LooseRecord) {
       merge_method: "squash",
     };
   }
-  const reviewActivityBlock = trustedAutomergeReviewActivityBlockReason(command);
+  const reviewActivityBlock = trustedAutomationReviewActivityBlockReason(command);
   if (reviewActivityBlock) {
     return {
       action: "merge",
@@ -4365,7 +4365,7 @@ function fetchIssue(number: JsonValue) {
   });
 }
 
-function trustedAutomergeReviewThreads(number: number, limit: number): unknown[] {
+function trustedAutomationReviewThreads(number: number, limit: number): unknown[] {
   const max = Number.isFinite(limit) ? Math.max(0, Math.floor(limit)) : 0;
   if (max === 0) return [];
   const [owner, name] = targetRepo.split("/");
@@ -4400,7 +4400,7 @@ function trustedAutomergeReviewThreads(number: number, limit: number): unknown[]
   return threads.slice(0, max);
 }
 
-function trustedAutomergeReviewActivityCursorOnce(number: number): string | null {
+function trustedAutomationReviewActivityCursorOnce(number: number): string | null {
   let remaining = MAX_REVIEWED_PR_ACTIVITY;
   const reviews = ghPagedLimit<unknown>(
     `repos/${targetRepo}/pulls/${number}/reviews`,
@@ -4415,19 +4415,23 @@ function trustedAutomergeReviewActivityCursorOnce(number: number): string | null
   if (inlineComments.length > remaining) return null;
   remaining -= inlineComments.length;
   const reviewThreads =
-    inlineComments.length === 0 ? [] : trustedAutomergeReviewThreads(number, remaining + 1);
+    inlineComments.length === 0 ? [] : trustedAutomationReviewThreads(number, remaining + 1);
   if (reviewThreads.length > remaining) return null;
   return createReviewedPrActivityCursor({ reviews, inlineComments, reviewThreads });
 }
 
-function trustedAutomergeReviewActivityCursor(number: number): string | null {
-  return readStableReviewedPrActivityCursor(() => trustedAutomergeReviewActivityCursorOnce(number));
+function trustedAutomationReviewActivityCursor(number: number): string | null {
+  return readStableReviewedPrActivityCursor(() =>
+    trustedAutomationReviewActivityCursorOnce(number),
+  );
 }
 
-function trustedAutomergeReviewActivityBlockReason(
+function trustedAutomationReviewActivityBlockReason(
   command: LooseRecord,
 ): { reason: string; retryable: boolean } | null {
-  if (command.intent !== "clawsweeper_auto_merge") return null;
+  if (!["clawsweeper_auto_merge", "clawsweeper_auto_repair"].includes(String(command.intent))) {
+    return null;
+  }
   const expected = command.expected_review_activity_cursor;
   if (!isReviewedPrActivityCursor(expected)) {
     return {
@@ -4436,10 +4440,10 @@ function trustedAutomergeReviewActivityBlockReason(
     };
   }
   try {
-    const current = trustedAutomergeReviewActivityCursor(Number(command.issue_number));
+    const current = trustedAutomationReviewActivityCursor(Number(command.issue_number));
     if (!current) {
       return {
-        reason: "pull request review activity exceeds the bounded automerge cursor",
+        reason: "pull request review activity exceeds the bounded trusted-automation cursor",
         retryable: false,
       };
     }

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -132,9 +132,12 @@ import { compactText, escapeRegExp } from "./text-utils.js";
 import {
   MAX_REVIEWED_PR_ACTIVITY,
   REVIEWED_PR_ACTIVITY_THREADS_QUERY,
+  ReviewedPrActivityGuardError,
   createReviewedPrActivityCursor,
   isReviewedPrActivityCursor,
+  readStableReviewedPrActivityCursor,
   reviewedPrActivityThreadsPageFromGraphql,
+  runReviewedPrActivityGuardedMutation,
 } from "../review-activity-cursor.js";
 import {
   flushCommandActionEvents,
@@ -2350,6 +2353,19 @@ function executeCommand(command: LooseRecord) {
       : commandHasWaitingRepairDispatch(command)
         ? "waiting"
         : "executed";
+  } catch (error) {
+    if (!(error instanceof ReviewedPrActivityGuardError)) throw error;
+    const status = error.block.retryable ? "waiting" : "skipped";
+    command.status = status;
+    command.reason = error.block.reason;
+    command.review_activity_blocked_mutation = error.mutationKind;
+    command.actions = command.actions.map((action: JsonValue) => {
+      const actionStatus = String(action.status ?? "");
+      if (["active", "claimed", "dispatched", "executed", "recovered"].includes(actionStatus)) {
+        return action;
+      }
+      return { ...action, status, reason: error.block.reason };
+    });
   } finally {
     clearTerminalMaintainerCommandReaction(command);
   }
@@ -2375,12 +2391,20 @@ function runGitHubTextMutation(
 ) {
   const attempts = githubMutationRetryAttempts(options);
   const { attempts: _attempts, ...runOptions } = options;
+  const operation = () =>
+    runReviewedPrActivityGuardedMutation({
+      intent: String(command.intent ?? ""),
+      mutationKind: kind,
+      refresh: () => trustedAutomergeReviewActivityBlockReason(command),
+      operation: () => ghText(ghArgs, runOptions),
+    });
   return runCommandMutationWithRetry(command, {
     kind,
     identity,
-    operation: () => ghText(ghArgs, runOptions),
+    operation,
     attempts,
     shouldRetry: (error) => {
+      if (error instanceof ReviewedPrActivityGuardError) return false;
       try {
         if (knownNoMutation?.(error)) return false;
       } catch {
@@ -2389,7 +2413,8 @@ function runGitHubTextMutation(
       return ghRetryKind(error) !== "none";
     },
     beforeRetry: (error, attempt) => sleepMs(ghRetryWaitMs(ghRetryKind(error), attempt - 1)),
-    ...(knownNoMutation ? { knownNoMutation } : {}),
+    knownNoMutation: (error) =>
+      error instanceof ReviewedPrActivityGuardError || knownNoMutation?.(error) === true,
   });
 }
 
@@ -2404,8 +2429,15 @@ function runGitHubTextMutationOnce(
   return runCommandMutation(command, {
     kind,
     identity,
-    operation: () => ghText(ghArgs, options),
-    ...(knownNoMutation ? { knownNoMutation } : {}),
+    operation: () =>
+      runReviewedPrActivityGuardedMutation({
+        intent: String(command.intent ?? ""),
+        mutationKind: kind,
+        refresh: () => trustedAutomergeReviewActivityBlockReason(command),
+        operation: () => ghText(ghArgs, options),
+      }),
+    knownNoMutation: (error) =>
+      error instanceof ReviewedPrActivityGuardError || knownNoMutation?.(error) === true,
   });
 }
 
@@ -2419,8 +2451,15 @@ function runGitHubSpawnMutation(
   return runCommandMutation(command, {
     kind,
     identity,
-    operation: () => ghSpawn(ghArgs, options),
+    operation: () =>
+      runReviewedPrActivityGuardedMutation({
+        intent: String(command.intent ?? ""),
+        mutationKind: kind,
+        refresh: () => trustedAutomergeReviewActivityBlockReason(command),
+        operation: () => ghSpawn(ghArgs, options),
+      }),
     outcome: (result) => (result.status === 0 && !result.error ? "accepted" : "unknown"),
+    knownNoMutation: (error) => error instanceof ReviewedPrActivityGuardError,
   });
 }
 
@@ -2434,7 +2473,8 @@ function runGitHubBestEffortMutation(
   try {
     runGitHubTextMutationOnce(command, kind, identity, ghArgs, {}, knownNoMutation);
     return true;
-  } catch {
+  } catch (error) {
+    if (error instanceof ReviewedPrActivityGuardError) throw error;
     return false;
   }
 }
@@ -4360,7 +4400,7 @@ function trustedAutomergeReviewThreads(number: number, limit: number): unknown[]
   return threads.slice(0, max);
 }
 
-function trustedAutomergeReviewActivityCursor(number: number): string | null {
+function trustedAutomergeReviewActivityCursorOnce(number: number): string | null {
   let remaining = MAX_REVIEWED_PR_ACTIVITY;
   const reviews = ghPagedLimit<unknown>(
     `repos/${targetRepo}/pulls/${number}/reviews`,
@@ -4378,6 +4418,10 @@ function trustedAutomergeReviewActivityCursor(number: number): string | null {
     inlineComments.length === 0 ? [] : trustedAutomergeReviewThreads(number, remaining + 1);
   if (reviewThreads.length > remaining) return null;
   return createReviewedPrActivityCursor({ reviews, inlineComments, reviewThreads });
+}
+
+function trustedAutomergeReviewActivityCursor(number: number): string | null {
+  return readStableReviewedPrActivityCursor(() => trustedAutomergeReviewActivityCursorOnce(number));
 }
 
 function trustedAutomergeReviewActivityBlockReason(

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -119,6 +119,7 @@ import {
   ghErrorText,
   ghJsonWithRetry as ghJson,
   ghJsonWithRetryAsync as ghJsonAsync,
+  ghPagedLimitWithRetry as ghPagedLimit,
   ghPagedWithRetry as ghPaged,
   ghPagedWithRetryAsync as ghPagedAsync,
   ghSpawn,
@@ -129,8 +130,11 @@ import { ghRetryKind, ghRetryWaitMs } from "../github-retry.js";
 import { issueSourceRevisionSha256 } from "./issue-source-guard.js";
 import { compactText, escapeRegExp } from "./text-utils.js";
 import {
+  MAX_REVIEWED_PR_ACTIVITY,
+  REVIEWED_PR_ACTIVITY_THREADS_QUERY,
   createReviewedPrActivityCursor,
   isReviewedPrActivityCursor,
+  reviewedPrActivityThreadsPageFromGraphql,
 } from "../review-activity-cursor.js";
 import {
   flushCommandActionEvents,
@@ -4298,6 +4302,60 @@ function fetchIssue(number: JsonValue) {
   });
 }
 
+function trustedAutomergeReviewThreads(number: number, limit: number): unknown[] {
+  const max = Number.isFinite(limit) ? Math.max(0, Math.floor(limit)) : 0;
+  if (max === 0) return [];
+  const [owner, name] = targetRepo.split("/");
+  if (!owner || !name) throw new Error(`invalid target repository: ${targetRepo}`);
+  const threads: unknown[] = [];
+  const seenCursors = new Set<string>();
+  let after: string | null = null;
+  while (threads.length < max) {
+    const args = [
+      "api",
+      "graphql",
+      "-f",
+      `owner=${owner}`,
+      "-f",
+      `name=${name}`,
+      "-F",
+      `number=${number}`,
+      "-f",
+      `query=${REVIEWED_PR_ACTIVITY_THREADS_QUERY}`,
+    ];
+    if (after) args.push("-f", `after=${after}`);
+    const page = reviewedPrActivityThreadsPageFromGraphql(ghJson<unknown>(args));
+    if (!page) throw new Error(`malformed review thread response for PR #${number}`);
+    threads.push(...page.threads);
+    if (!page.hasNextPage) break;
+    if (!page.endCursor || seenCursors.has(page.endCursor) || page.threads.length === 0) {
+      throw new Error(`review thread pagination did not advance for PR #${number}`);
+    }
+    seenCursors.add(page.endCursor);
+    after = page.endCursor;
+  }
+  return threads.slice(0, max);
+}
+
+function trustedAutomergeReviewActivityCursor(number: number): string | null {
+  let remaining = MAX_REVIEWED_PR_ACTIVITY;
+  const reviews = ghPagedLimit<unknown>(
+    `repos/${targetRepo}/pulls/${number}/reviews`,
+    remaining + 1,
+  );
+  if (reviews.length > remaining) return null;
+  remaining -= reviews.length;
+  const inlineComments = ghPagedLimit<unknown>(
+    `repos/${targetRepo}/pulls/${number}/comments`,
+    remaining + 1,
+  );
+  if (inlineComments.length > remaining) return null;
+  remaining -= inlineComments.length;
+  const reviewThreads = trustedAutomergeReviewThreads(number, remaining + 1);
+  if (reviewThreads.length > remaining) return null;
+  return createReviewedPrActivityCursor({ reviews, inlineComments, reviewThreads });
+}
+
 function trustedAutomergeReviewActivityBlockReason(
   command: LooseRecord,
 ): { reason: string; retryable: boolean } | null {
@@ -4310,12 +4368,7 @@ function trustedAutomergeReviewActivityBlockReason(
     };
   }
   try {
-    const current = createReviewedPrActivityCursor({
-      reviews: ghPaged<unknown>(`repos/${targetRepo}/pulls/${command.issue_number}/reviews`),
-      inlineComments: ghPaged<unknown>(
-        `repos/${targetRepo}/pulls/${command.issue_number}/comments`,
-      ),
-    });
+    const current = trustedAutomergeReviewActivityCursor(Number(command.issue_number));
     if (!current) {
       return {
         reason: "pull request review activity exceeds the bounded automerge cursor",

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -4429,9 +4429,19 @@ function trustedAutomationReviewActivityCursor(number: number): string | null {
 function trustedAutomationReviewActivityBlockReason(
   command: LooseRecord,
 ): { reason: string; retryable: boolean } | null {
-  if (!["clawsweeper_auto_merge", "clawsweeper_auto_repair"].includes(String(command.intent))) {
+  if (!command.trusted_bot) return null;
+  const intent = String(command.intent);
+  if (
+    ![
+      "autoclose",
+      "clawsweeper_auto_merge",
+      "clawsweeper_auto_repair",
+      "clawsweeper_needs_human",
+    ].includes(intent)
+  ) {
     return null;
   }
+  if (intent === "autoclose" && command.target?.kind !== "pull_request") return null;
   const expected = command.expected_review_activity_cursor;
   if (!isReviewedPrActivityCursor(expected)) {
     return {

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -129,6 +129,10 @@ import { ghRetryKind, ghRetryWaitMs } from "../github-retry.js";
 import { issueSourceRevisionSha256 } from "./issue-source-guard.js";
 import { compactText, escapeRegExp } from "./text-utils.js";
 import {
+  createReviewedPrActivityCursor,
+  isReviewedPrActivityCursor,
+} from "../review-activity-cursor.js";
+import {
   flushCommandActionEvents,
   recordCommandClaimed,
   recordCommandClaimRefreshed,
@@ -478,6 +482,7 @@ function routedCommandForComment(comment: JsonValue): LooseRecord | null {
     review_lease_comment_id: parsed.review_lease_comment_id ?? null,
     expected_item_updated_at: parsed.expected_item_updated_at ?? null,
     expected_source_revision: parsed.expected_source_revision ?? null,
+    expected_review_activity_cursor: parsed.expected_review_activity_cursor ?? null,
     finding_id: parsed.finding_id ?? null,
     ...forcedReplayCommandFields({ forceReprocess, attemptId }),
     status: "pending",
@@ -3749,6 +3754,15 @@ function executeAutomerge(command: LooseRecord) {
       merge_method: "squash",
     };
   }
+  const reviewActivityBlock = trustedAutomergeReviewActivityBlockReason(command);
+  if (reviewActivityBlock) {
+    return {
+      action: "merge",
+      status: reviewActivityBlock.retryable ? "waiting" : "blocked",
+      reason: reviewActivityBlock.reason,
+      merge_method: "squash",
+    };
+  }
   const result = runGitHubSpawnMutation(
     command,
     "pull_request_merge",
@@ -4282,6 +4296,45 @@ function fetchIssue(number: JsonValue) {
   return ghJson(["api", `repos/${targetRepo}/issues/${number}`], {
     attempts: TARGET_LOOKUP_RETRY_ATTEMPTS,
   });
+}
+
+function trustedAutomergeReviewActivityBlockReason(
+  command: LooseRecord,
+): { reason: string; retryable: boolean } | null {
+  if (command.intent !== "clawsweeper_auto_merge") return null;
+  const expected = command.expected_review_activity_cursor;
+  if (!isReviewedPrActivityCursor(expected)) {
+    return {
+      reason: "trusted ClawSweeper verdict is missing the reviewed PR activity cursor",
+      retryable: false,
+    };
+  }
+  try {
+    const current = createReviewedPrActivityCursor({
+      reviews: ghPaged<unknown>(`repos/${targetRepo}/pulls/${command.issue_number}/reviews`),
+      inlineComments: ghPaged<unknown>(
+        `repos/${targetRepo}/pulls/${command.issue_number}/comments`,
+      ),
+    });
+    if (!current) {
+      return {
+        reason: "pull request review activity exceeds the bounded automerge cursor",
+        retryable: false,
+      };
+    }
+    if (current !== expected) {
+      return {
+        reason: "pull request review activity changed since the trusted ClawSweeper verdict",
+        retryable: false,
+      };
+    }
+    return null;
+  } catch (error) {
+    return {
+      reason: `pull request review activity could not be refreshed: ${compactGhError(error)}`,
+      retryable: true,
+    };
+  }
 }
 
 function fetchIssueAsync(number: JsonValue) {

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -1148,6 +1148,7 @@ function classifyCommand(command: LooseRecord): JsonValue {
         ? {
             intent: "clawsweeper_auto_merge",
             expected_head_sha: approvedProofOverride.expected_head_sha,
+            expected_review_activity_cursor: approvedProofOverride.expected_review_activity_cursor,
             repair_reason: approvedProofOverride.reason,
           }
         : activationRepairReason
@@ -1721,6 +1722,7 @@ function approvedMissingProofNeedsHuman(command: LooseRecord, target: LooseRecor
   return {
     reason,
     expected_head_sha: latest.parsed.expected_head_sha,
+    expected_review_activity_cursor: (latest.parsed as LooseRecord).expected_review_activity_cursor,
     note: proofOverrideDescriptionNote({
       ...command,
       repair_reason: reason,
@@ -1897,6 +1899,18 @@ function executeCommand(command: LooseRecord) {
         ...action,
         status,
         reason: trustedAutomationLeaseBlock.reason,
+      }));
+      return;
+    }
+    const trustedAutomationActivityBlock = trustedAutomergeReviewActivityBlockReason(command);
+    if (trustedAutomationActivityBlock) {
+      const status = trustedAutomationActivityBlock.retryable ? "waiting" : "skipped";
+      command.status = status;
+      command.reason = trustedAutomationActivityBlock.reason;
+      command.actions = command.actions.map((action: JsonValue) => ({
+        ...action,
+        status,
+        reason: trustedAutomationActivityBlock.reason,
       }));
       return;
     }
@@ -3665,6 +3679,15 @@ function executeAutomerge(command: LooseRecord) {
   if (stoppedReason) {
     return { action: "merge", status: "blocked", reason: stoppedReason, merge_method: "squash" };
   }
+  const initialReviewActivityBlock = trustedAutomergeReviewActivityBlockReason(command);
+  if (initialReviewActivityBlock) {
+    return {
+      action: "merge",
+      status: initialReviewActivityBlock.retryable ? "waiting" : "blocked",
+      reason: initialReviewActivityBlock.reason,
+      merge_method: "squash",
+    };
+  }
   const transientWait = automergeTransientWaitConfig(process.env);
   const transientObservations: LooseRecord[] = [];
   let waitedMs = 0;
@@ -4351,7 +4374,8 @@ function trustedAutomergeReviewActivityCursor(number: number): string | null {
   );
   if (inlineComments.length > remaining) return null;
   remaining -= inlineComments.length;
-  const reviewThreads = trustedAutomergeReviewThreads(number, remaining + 1);
+  const reviewThreads =
+    inlineComments.length === 0 ? [] : trustedAutomergeReviewThreads(number, remaining + 1);
   if (reviewThreads.length > remaining) return null;
   return createReviewedPrActivityCursor({ reviews, inlineComments, reviewThreads });
 }

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -3678,7 +3678,7 @@ function postIssueComment(command: LooseRecord, number: number, body: string) {
   const payloadPath = writePayload(repoRoot(), `autoclose-comment-${number}`, { body });
   runGitHubTextMutation(
     command,
-    "comment_create",
+    "autoclose_preclose_comment",
     { repository: command.repo, number, bodySha256: commentBodySha256(body) },
     [
       "api",

--- a/src/repair/github-cli.ts
+++ b/src/repair/github-cli.ts
@@ -122,9 +122,11 @@ export function ghPagedLimit<T = JsonValue>(
       ["api", githubLimitedPagePath(apiPath, perPage, page)],
       options,
     );
-    if (!Array.isArray(entries) || entries.length === 0) break;
-    out.push(...(entries as T[]));
-    if (entries.length < perPage) break;
+    if (!Array.isArray(entries)) break;
+    const pageEntries = entries.length === 1 && Array.isArray(entries[0]) ? entries[0] : entries;
+    if (pageEntries.length === 0) break;
+    out.push(...(pageEntries as T[]));
+    if (pageEntries.length < perPage) break;
   }
   return out.slice(0, max);
 }

--- a/src/review-activity-cursor.ts
+++ b/src/review-activity-cursor.ts
@@ -86,7 +86,7 @@ export function createReviewedPrActivityCursor(options: {
     ...options.inlineComments.map((comment) => compactReviewActivity("inline_comment", comment)),
     ...options.reviewThreads.map(compactReviewThread),
   ].map((entry) => stableJson(entry));
-  entries.sort((left, right) => left.localeCompare(right));
+  entries.sort((left, right) => (left < right ? -1 : left > right ? 1 : 0));
   const canonical = `[${entries.join(",")}]`;
   if (Buffer.byteLength(canonical, "utf8") > MAX_REVIEWED_PR_ACTIVITY_CURSOR_BYTES) return null;
   const digest = createHash("sha256").update(canonical).digest("hex");

--- a/src/review-activity-cursor.ts
+++ b/src/review-activity-cursor.ts
@@ -2,23 +2,61 @@ import { createHash } from "node:crypto";
 import { stableJson } from "./stable-json.js";
 
 export const MAX_REVIEWED_PR_ACTIVITY = 1_000;
+export const MAX_REVIEWED_PR_ACTIVITY_CURSOR_BYTES = 1024 * 1024;
 
-const CURSOR_PATTERN = /^v1:([0-9]+):([0-9a-f]{64})$/;
+const CURSOR_PATTERN = /^v2:([0-9]+):([0-9a-f]{64})$/;
+
+export const REVIEWED_PR_ACTIVITY_THREADS_QUERY = `
+  query ReviewedPrActivityThreads(
+    $owner: String!
+    $name: String!
+    $number: Int!
+    $after: String
+  ) {
+    repository(owner: $owner, name: $name) {
+      pullRequest(number: $number) {
+        reviewThreads(first: 100, after: $after) {
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+          nodes {
+            id
+            isResolved
+          }
+        }
+      }
+    }
+  }
+`;
+
+export interface ReviewedPrActivityThreadsPage {
+  threads: Array<{ id: string; isResolved: boolean }>;
+  hasNextPage: boolean;
+  endCursor: string | null;
+}
 
 export function createReviewedPrActivityCursor(options: {
   reviews: unknown[];
   inlineComments: unknown[];
+  reviewThreads: unknown[];
 }): string | null {
-  if (options.reviews.length + options.inlineComments.length > MAX_REVIEWED_PR_ACTIVITY) {
+  if (
+    options.reviews.length + options.inlineComments.length + options.reviewThreads.length >
+    MAX_REVIEWED_PR_ACTIVITY
+  ) {
     return null;
   }
   const entries = [
     ...options.reviews.map((review) => compactReviewActivity("review", review)),
     ...options.inlineComments.map((comment) => compactReviewActivity("inline_comment", comment)),
-  ];
-  entries.sort((left, right) => stableJson(left).localeCompare(stableJson(right)));
-  const digest = createHash("sha256").update(stableJson(entries)).digest("hex");
-  return `v1:${entries.length}:${digest}`;
+    ...options.reviewThreads.map(compactReviewThread),
+  ].map((entry) => stableJson(entry));
+  entries.sort((left, right) => left.localeCompare(right));
+  const canonical = `[${entries.join(",")}]`;
+  if (Buffer.byteLength(canonical, "utf8") > MAX_REVIEWED_PR_ACTIVITY_CURSOR_BYTES) return null;
+  const digest = createHash("sha256").update(canonical).digest("hex");
+  return `v2:${entries.length}:${digest}`;
 }
 
 export function isReviewedPrActivityCursor(value: unknown): value is string {
@@ -27,6 +65,39 @@ export function isReviewedPrActivityCursor(value: unknown): value is string {
   if (!match) return false;
   const count = Number(match[1]);
   return Number.isSafeInteger(count) && count >= 0 && count <= MAX_REVIEWED_PR_ACTIVITY;
+}
+
+export function reviewedPrActivityThreadsPageFromGraphql(
+  value: unknown,
+): ReviewedPrActivityThreadsPage | null {
+  const response = record(value);
+  if (Array.isArray(response.errors) && response.errors.length > 0) return null;
+  const data = record(response.data);
+  const repository = record(data.repository);
+  const pullRequest = record(repository.pullRequest);
+  const connection = record(pullRequest.reviewThreads);
+  const nodes = connection.nodes;
+  const pageInfo = record(connection.pageInfo);
+  if (!Array.isArray(nodes) || typeof pageInfo.hasNextPage !== "boolean") return null;
+  const threads: ReviewedPrActivityThreadsPage["threads"] = [];
+  for (const node of nodes) {
+    const thread = record(node);
+    if (
+      typeof thread.id !== "string" ||
+      thread.id.length === 0 ||
+      typeof thread.isResolved !== "boolean"
+    ) {
+      return null;
+    }
+    threads.push({ id: thread.id, isResolved: thread.isResolved });
+  }
+  const endCursor = typeof pageInfo.endCursor === "string" ? pageInfo.endCursor : null;
+  if (pageInfo.hasNextPage && !endCursor) return null;
+  return {
+    threads,
+    hasNextPage: pageInfo.hasNextPage,
+    endCursor,
+  };
 }
 
 function compactReviewActivity(kind: "review" | "inline_comment", value: unknown) {
@@ -38,7 +109,7 @@ function compactReviewActivity(kind: "review" | "inline_comment", value: unknown
       id: scalar(activity.id),
       user: scalar(user.login),
       state: scalar(activity.state),
-      body: scalar(activity.body),
+      body_sha256: digestScalar(activity.body),
       submitted_at: scalar(activity.submitted_at ?? activity.submittedAt),
       commit_id: scalar(activity.commit_id ?? activity.commitId),
     };
@@ -49,7 +120,7 @@ function compactReviewActivity(kind: "review" | "inline_comment", value: unknown
     review_id: scalar(activity.pull_request_review_id),
     reply_to_id: scalar(activity.in_reply_to_id),
     user: scalar(user.login),
-    body: scalar(activity.body),
+    body_sha256: digestScalar(activity.body),
     created_at: scalar(activity.created_at),
     updated_at: scalar(activity.updated_at ?? activity.created_at),
     path: scalar(activity.path),
@@ -60,6 +131,15 @@ function compactReviewActivity(kind: "review" | "inline_comment", value: unknown
     original_line: scalar(activity.original_line),
     original_commit_id: scalar(activity.original_commit_id),
     commit_id: scalar(activity.commit_id),
+  };
+}
+
+function compactReviewThread(value: unknown) {
+  const thread = record(value);
+  return {
+    kind: "review_thread",
+    id: scalar(thread.id),
+    is_resolved: scalar(thread.isResolved ?? thread.is_resolved),
   };
 }
 
@@ -74,4 +154,8 @@ function scalar(value: unknown): string {
   if (typeof value === "string") return value;
   if (typeof value === "number" || typeof value === "boolean") return String(value);
   return stableJson(value);
+}
+
+function digestScalar(value: unknown): string {
+  return createHash("sha256").update(scalar(value)).digest("hex");
 }

--- a/src/review-activity-cursor.ts
+++ b/src/review-activity-cursor.ts
@@ -62,17 +62,21 @@ export class ReviewedPrActivityGuardError extends Error {
 
 const REVIEW_ACTIVITY_AUTHORIZED_MUTATIONS = new Set([
   "description_update",
+  "issue_close",
   "label_add",
   "label_create",
   "label_remove",
+  "pull_request_close",
   "pull_request_merge",
   "repair_dispatch",
   "review_dispatch",
 ]);
 
 const REVIEW_ACTIVITY_AUTHORIZED_INTENTS = new Set([
+  "autoclose",
   "clawsweeper_auto_merge",
   "clawsweeper_auto_repair",
+  "clawsweeper_needs_human",
 ]);
 
 export function createReviewedPrActivityCursor(options: {

--- a/src/review-activity-cursor.ts
+++ b/src/review-activity-cursor.ts
@@ -36,6 +36,33 @@ export interface ReviewedPrActivityThreadsPage {
   endCursor: string | null;
 }
 
+export interface ReviewedPrActivityBlock {
+  reason: string;
+  retryable: boolean;
+}
+
+export class ReviewedPrActivityGuardError extends Error {
+  readonly block: ReviewedPrActivityBlock;
+  readonly mutationKind: string;
+
+  constructor(mutationKind: string, block: ReviewedPrActivityBlock) {
+    super(`${block.reason} before ${mutationKind}`);
+    this.name = "ReviewedPrActivityGuardError";
+    this.block = block;
+    this.mutationKind = mutationKind;
+  }
+}
+
+const REVIEW_ACTIVITY_AUTHORIZED_MUTATIONS = new Set([
+  "description_update",
+  "label_add",
+  "label_create",
+  "label_remove",
+  "pull_request_merge",
+  "repair_dispatch",
+  "review_dispatch",
+]);
+
 export function createReviewedPrActivityCursor(options: {
   reviews: unknown[];
   inlineComments: unknown[];
@@ -57,6 +84,31 @@ export function createReviewedPrActivityCursor(options: {
   if (Buffer.byteLength(canonical, "utf8") > MAX_REVIEWED_PR_ACTIVITY_CURSOR_BYTES) return null;
   const digest = createHash("sha256").update(canonical).digest("hex");
   return `v2:${entries.length}:${digest}`;
+}
+
+export function readStableReviewedPrActivityCursor(readCursor: () => string | null): string | null {
+  const first = readCursor();
+  const second = readCursor();
+  if (first !== second) {
+    throw new Error("pull request review activity changed while refreshing the bounded cursor");
+  }
+  return second;
+}
+
+export function runReviewedPrActivityGuardedMutation<T>(options: {
+  intent: string;
+  mutationKind: string;
+  refresh: () => ReviewedPrActivityBlock | null;
+  operation: () => T;
+}): T {
+  if (
+    options.intent === "clawsweeper_auto_merge" &&
+    REVIEW_ACTIVITY_AUTHORIZED_MUTATIONS.has(options.mutationKind)
+  ) {
+    const block = options.refresh();
+    if (block) throw new ReviewedPrActivityGuardError(options.mutationKind, block);
+  }
+  return options.operation();
 }
 
 export function isReviewedPrActivityCursor(value: unknown): value is string {

--- a/src/review-activity-cursor.ts
+++ b/src/review-activity-cursor.ts
@@ -70,6 +70,11 @@ const REVIEW_ACTIVITY_AUTHORIZED_MUTATIONS = new Set([
   "review_dispatch",
 ]);
 
+const REVIEW_ACTIVITY_AUTHORIZED_INTENTS = new Set([
+  "clawsweeper_auto_merge",
+  "clawsweeper_auto_repair",
+]);
+
 export function createReviewedPrActivityCursor(options: {
   reviews: unknown[];
   inlineComments: unknown[];
@@ -109,7 +114,7 @@ export function runReviewedPrActivityGuardedMutation<T>(options: {
   operation: () => T;
 }): T {
   if (
-    options.intent === "clawsweeper_auto_merge" &&
+    REVIEW_ACTIVITY_AUTHORIZED_INTENTS.has(options.intent) &&
     REVIEW_ACTIVITY_AUTHORIZED_MUTATIONS.has(options.mutationKind)
   ) {
     const block = options.refresh();

--- a/src/review-activity-cursor.ts
+++ b/src/review-activity-cursor.ts
@@ -61,6 +61,7 @@ export class ReviewedPrActivityGuardError extends Error {
 }
 
 const REVIEW_ACTIVITY_AUTHORIZED_MUTATIONS = new Set([
+  "autoclose_preclose_comment",
   "description_update",
   "issue_close",
   "label_add",

--- a/src/review-activity-cursor.ts
+++ b/src/review-activity-cursor.ts
@@ -41,6 +41,13 @@ export interface ReviewedPrActivityBlock {
   retryable: boolean;
 }
 
+export class ReviewedPrActivityChangedDuringReadError extends Error {
+  constructor() {
+    super("pull request review activity changed while refreshing the bounded cursor");
+    this.name = "ReviewedPrActivityChangedDuringReadError";
+  }
+}
+
 export class ReviewedPrActivityGuardError extends Error {
   readonly block: ReviewedPrActivityBlock;
   readonly mutationKind: string;
@@ -90,7 +97,7 @@ export function readStableReviewedPrActivityCursor(readCursor: () => string | nu
   const first = readCursor();
   const second = readCursor();
   if (first !== second) {
-    throw new Error("pull request review activity changed while refreshing the bounded cursor");
+    throw new ReviewedPrActivityChangedDuringReadError();
   }
   return second;
 }

--- a/src/review-activity-cursor.ts
+++ b/src/review-activity-cursor.ts
@@ -1,0 +1,77 @@
+import { createHash } from "node:crypto";
+import { stableJson } from "./stable-json.js";
+
+export const MAX_REVIEWED_PR_ACTIVITY = 1_000;
+
+const CURSOR_PATTERN = /^v1:([0-9]+):([0-9a-f]{64})$/;
+
+export function createReviewedPrActivityCursor(options: {
+  reviews: unknown[];
+  inlineComments: unknown[];
+}): string | null {
+  if (options.reviews.length + options.inlineComments.length > MAX_REVIEWED_PR_ACTIVITY) {
+    return null;
+  }
+  const entries = [
+    ...options.reviews.map((review) => compactReviewActivity("review", review)),
+    ...options.inlineComments.map((comment) => compactReviewActivity("inline_comment", comment)),
+  ];
+  entries.sort((left, right) => stableJson(left).localeCompare(stableJson(right)));
+  const digest = createHash("sha256").update(stableJson(entries)).digest("hex");
+  return `v1:${entries.length}:${digest}`;
+}
+
+export function isReviewedPrActivityCursor(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const match = value.match(CURSOR_PATTERN);
+  if (!match) return false;
+  const count = Number(match[1]);
+  return Number.isSafeInteger(count) && count >= 0 && count <= MAX_REVIEWED_PR_ACTIVITY;
+}
+
+function compactReviewActivity(kind: "review" | "inline_comment", value: unknown) {
+  const activity = record(value);
+  const user = record(activity.user);
+  if (kind === "review") {
+    return {
+      kind,
+      id: scalar(activity.id),
+      user: scalar(user.login),
+      state: scalar(activity.state),
+      body: scalar(activity.body),
+      submitted_at: scalar(activity.submitted_at ?? activity.submittedAt),
+      commit_id: scalar(activity.commit_id ?? activity.commitId),
+    };
+  }
+  return {
+    kind,
+    id: scalar(activity.id),
+    review_id: scalar(activity.pull_request_review_id),
+    reply_to_id: scalar(activity.in_reply_to_id),
+    user: scalar(user.login),
+    body: scalar(activity.body),
+    created_at: scalar(activity.created_at),
+    updated_at: scalar(activity.updated_at ?? activity.created_at),
+    path: scalar(activity.path),
+    line: scalar(activity.line),
+    side: scalar(activity.side),
+    start_line: scalar(activity.start_line),
+    start_side: scalar(activity.start_side),
+    original_line: scalar(activity.original_line),
+    original_commit_id: scalar(activity.original_commit_id),
+    commit_id: scalar(activity.commit_id),
+  };
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function scalar(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return stableJson(value);
+}

--- a/test/apply-close-retry-policy.test.ts
+++ b/test/apply-close-retry-policy.test.ts
@@ -90,7 +90,7 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
     base: { sha: "base-sha", ref: "main", repo: { full_name: "openclaw/clawsweeper" } },
     user: { login: "maintainer" }
   }));
-} else if (args[0] === "api" && /\\/pulls\\/321\\/(files|commits|comments)(?:\\?|$)/.test(path)) {
+} else if (args[0] === "api" && /\\/pulls\\/321\\/(files|commits|reviews|comments)(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "label" || args[0] === "issue") {
   console.log("");
@@ -193,7 +193,7 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
     base: { sha: "base-sha", ref: "main", repo: { full_name: "openclaw/clawsweeper" } },
     user: { login: "reporter" }
   }));
-} else if (args[0] === "api" && /\\/pulls\\/321\\/(files|commits|comments)(?:\\?|$)/.test(path)) {
+} else if (args[0] === "api" && /\\/pulls\\/321\\/(files|commits|reviews|comments)(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "label" || args[0] === "issue") {
   console.log("");
@@ -338,7 +338,7 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/(320|321)\\/timeline(?
     base: { sha: "base-sha", ref: "main", repo: { full_name: "openclaw/clawsweeper" } },
     user: { login: "reporter" }
   }));
-} else if (args[0] === "api" && /\\/pulls\\/321\\/(files|commits|comments)(?:\\?|$)/.test(path)) {
+} else if (args[0] === "api" && /\\/pulls\\/321\\/(files|commits|reviews|comments)(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "label" || args[0] === "issue") {
   console.log("");

--- a/test/apply-label-sync.test.ts
+++ b/test/apply-label-sync.test.ts
@@ -776,7 +776,7 @@ if (args[0] === "api" && /\\/issues\\/74478$/.test(path)) {
     base: { sha: "base-sha", ref: "main", repo: { full_name: "openclaw/clawsweeper" } },
     user: { login: "contributor" }
   }));
-} else if (args[0] === "api" && /\\/pulls\\/74478\\/(files|commits|comments)(?:\\?|$)/.test(path)) {
+} else if (args[0] === "api" && /\\/pulls\\/74478\\/(files|commits|reviews|comments)(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "api" && /\\/issues\\/74478\\/comments(?:\\?|$)/.test(path)) {
   if (args.includes("--method") && args.includes("POST")) {
@@ -944,7 +944,7 @@ if (args[0] === "api" && /\\/issues\\/74481$/.test(path)) {
     base: { sha: "base-sha", ref: "main", repo: { full_name: "openclaw/openclaw" } },
     user: { login: "contributor" }
   }));
-} else if (args[0] === "api" && /\\/pulls\\/74481\\/(files|commits|comments)(?:\\?|$)/.test(path)) {
+} else if (args[0] === "api" && /\\/pulls\\/74481\\/(files|commits|reviews|comments)(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "api" && /\\/issues\\/74481\\/comments(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[
@@ -1137,7 +1137,7 @@ if (args[0] === "api" && /\\/issues\\/74483$/.test(path)) {
     base: { sha: "base-sha", ref: "main", repo: { full_name: "openclaw/openclaw" } },
     user: { login: "contributor" }
   }));
-} else if (args[0] === "api" && /\\/pulls\\/74483\\/(files|commits|comments)(?:\\?|$)/.test(path)) {
+} else if (args[0] === "api" && /\\/pulls\\/74483\\/(files|commits|reviews|comments)(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "api" && /\\/issues\\/74483\\/comments(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[
@@ -1307,7 +1307,7 @@ if (args[0] === "api" && /\\/issues\\/74482$/.test(path)) {
     base: { sha: "base-sha", ref: "main", repo: { full_name: "openclaw/openclaw" } },
     user: { login: "contributor" }
   }));
-} else if (args[0] === "api" && /\\/pulls\\/74482\\/(files|commits|comments)(?:\\?|$)/.test(path)) {
+} else if (args[0] === "api" && /\\/pulls\\/74482\\/(files|commits|reviews|comments)(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "api" && /\\/issues\\/74482\\/comments(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[
@@ -1527,7 +1527,7 @@ if (args[0] === "api" && /\\/issues\\/74483$/.test(path)) {
     base: { sha: "base-sha", ref: "main", repo: { full_name: "openclaw/openclaw" } },
     user: { login: "contributor" }
   }));
-} else if (args[0] === "api" && /\\/pulls\\/74483\\/(files|commits|comments)(?:\\?|$)/.test(path)) {
+} else if (args[0] === "api" && /\\/pulls\\/74483\\/(files|commits|reviews|comments)(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "api" && /\\/issues\\/74483\\/comments(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[
@@ -1702,7 +1702,7 @@ if (args[0] === "api" && /\\/issues\\/74484$/.test(path)) {
   }));
 } else if (args[0] === "api" && /\\/pulls\\/74484\\/reviews(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[]]));
-} else if (args[0] === "api" && /\\/pulls\\/74484\\/(files|commits|comments)(?:\\?|$)/.test(path)) {
+} else if (args[0] === "api" && /\\/pulls\\/74484\\/(files|commits|reviews|comments)(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "api" && /\\/issues\\/74484\\/comments(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[
@@ -1973,7 +1973,7 @@ if (args[0] === "api" && /\\/issues\\/74479$/.test(path)) {
     base: { sha: "base-sha", ref: "main", repo: { full_name: "openclaw/clawsweeper" } },
     user: { login: "contributor" }
   }));
-} else if (args[0] === "api" && /\\/pulls\\/74479\\/(files|commits|comments)(?:\\?|$)/.test(path)) {
+} else if (args[0] === "api" && /\\/pulls\\/74479\\/(files|commits|reviews|comments)(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "api" && /\\/issues\\/74479\\/comments(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[
@@ -2542,7 +2542,7 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
     base: { sha: "base-sha", ref: "main", repo: { full_name: "openclaw/clawsweeper" } },
     user: { login: "reporter" }
   }));
-} else if (args[0] === "api" && /\\/pulls\\/321\\/(files|commits|comments)(?:\\?|$)/.test(path)) {
+} else if (args[0] === "api" && /\\/pulls\\/321\\/(files|commits|reviews|comments)(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "pr" && args[1] === "close" && args[2] === "321") {
   console.log("");
@@ -2689,7 +2689,7 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/322\\/timeline(?:\\?|$
   }));
 } else if (args[0] === "api" && /\\/pulls\\/322\\/reviews(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[]]));
-} else if (args[0] === "api" && /\\/pulls\\/322\\/(files|commits|comments)(?:\\?|$)/.test(path)) {
+} else if (args[0] === "api" && /\\/pulls\\/322\\/(files|commits|reviews|comments)(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "issue" && args[1] === "edit") {
   console.log("");

--- a/test/apply-live-state.test.ts
+++ b/test/apply-live-state.test.ts
@@ -4,9 +4,12 @@ import { join } from "node:path";
 import test from "node:test";
 
 import { guardedOpenApplyProofFields } from "../dist/clawsweeper.js";
+import { createReviewedPrActivityCursor } from "../dist/review-activity-cursor.js";
 import {
   implementedCloseReport,
+  promotionGhMock,
   readText,
+  reportWithSyncedReviewComment,
   runApplyDecisionsForTest,
   tmpPrefix,
   withMockGh,
@@ -59,6 +62,262 @@ test("event apply proof marks only live deterministic remain-open guards", () =>
       {},
       action,
     );
+  }
+});
+
+test("apply-decisions rejects recorded PR review activity drift before mutations", () => {
+  const reviewedCursor = createReviewedPrActivityCursor({
+    reviews: [],
+    inlineComments: [],
+  });
+  assert.ok(reviewedCursor);
+
+  for (const scenario of [
+    {
+      name: "review",
+      reviews: [
+        {
+          id: 7001,
+          user: { login: "maintainer" },
+          state: "COMMENTED",
+          body: "please recheck this",
+          submitted_at: "2026-05-01T00:30:00Z",
+          commit_id: "head-sha",
+        },
+      ],
+      inlineComments: [],
+    },
+    {
+      name: "inline comment",
+      reviews: [],
+      inlineComments: [
+        {
+          id: 7002,
+          pull_request_review_id: 7001,
+          user: { login: "maintainer" },
+          body: "this line still needs work",
+          created_at: "2026-05-01T00:30:00Z",
+          updated_at: "2026-05-01T00:30:00Z",
+          path: "src/example.ts",
+          line: 12,
+          side: "RIGHT",
+          commit_id: "head-sha",
+        },
+      ],
+    },
+  ]) {
+    const root = mkdtempSync(tmpPrefix);
+    try {
+      const itemsDir = join(root, "items");
+      const closedDir = join(root, "closed");
+      const plansDir = join(root, "plans");
+      const reportPath = join(root, "apply-report.json");
+      const mutationLogPath = join(root, "mutations.log");
+      mkdirSync(itemsDir, { recursive: true });
+      mkdirSync(plansDir, { recursive: true });
+
+      const synced = reportWithSyncedReviewComment(
+        implementedCloseReport({
+          repository: "openclaw/openclaw",
+          number: 321,
+          type: "pull_request",
+          title: "Reviewed PR",
+          url: "https://github.com/openclaw/openclaw/pull/321",
+          author: "reporter",
+          author_association: "CONTRIBUTOR",
+          labels: JSON.stringify([]),
+          pull_head_sha: "head-sha",
+          review_activity_cursor: reviewedCursor,
+        }),
+        321,
+        "implemented_on_main",
+      );
+      writeFileSync(join(itemsDir, "321.md"), synced.report, "utf8");
+
+      withMockGh(
+        root,
+        promotionGhMock({
+          number: 321,
+          title: "Reviewed PR",
+          labels: [],
+          comment: synced.comment,
+          reviews: scenario.reviews,
+          pullReviewComments: scenario.inlineComments,
+          itemUpdatedAtAfterLabelSyncLogPath: mutationLogPath,
+        }),
+        () => {
+          runApplyDecisionsForTest({
+            targetRepo: "openclaw/openclaw",
+            itemsDir,
+            closedDir,
+            plansDir,
+            reportPath,
+          });
+        },
+      );
+
+      assert.deepEqual(
+        JSON.parse(readText(reportPath)),
+        [
+          {
+            number: 321,
+            action: "skipped_changed_since_review",
+            reason: "pull request review activity changed since review",
+          },
+        ],
+        scenario.name,
+      );
+      assert.equal(existsSync(mutationLogPath), false, scenario.name);
+      assert.match(
+        readText(join(itemsDir, "321.md")),
+        /^action_taken: skipped_changed_since_review$/m,
+        scenario.name,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+test("apply-decisions records review activity that changes after lease acquisition", () => {
+  const reviewedCursor = createReviewedPrActivityCursor({
+    reviews: [],
+    inlineComments: [],
+  });
+  assert.ok(reviewedCursor);
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+
+    const synced = reportWithSyncedReviewComment(
+      implementedCloseReport({
+        repository: "openclaw/openclaw",
+        number: 321,
+        type: "pull_request",
+        title: "Reviewed PR",
+        url: "https://github.com/openclaw/openclaw/pull/321",
+        author: "reporter",
+        author_association: "CONTRIBUTOR",
+        labels: JSON.stringify([]),
+        pull_head_sha: "head-sha",
+        review_activity_cursor: reviewedCursor,
+      }),
+      321,
+      "implemented_on_main",
+    );
+    writeFileSync(join(itemsDir, "321.md"), synced.report, "utf8");
+
+    withMockGh(
+      root,
+      promotionGhMock({
+        number: 321,
+        title: "Reviewed PR",
+        labels: [],
+        comment: synced.comment,
+        reviews: [],
+        reviewsAfterFirstRead: [
+          {
+            id: 7001,
+            user: { login: "maintainer" },
+            state: "COMMENTED",
+            body: "please recheck this",
+            submitted_at: "2026-05-01T00:30:00Z",
+            commit_id: "head-sha",
+          },
+        ],
+        pullReviewComments: [],
+      }),
+      () => {
+        runApplyDecisionsForTest({
+          targetRepo: "openclaw/openclaw",
+          itemsDir,
+          closedDir,
+          plansDir,
+          reportPath,
+        });
+      },
+    );
+
+    assert.deepEqual(JSON.parse(readText(reportPath)), [
+      {
+        number: 321,
+        action: "skipped_changed_since_review",
+        reason: "pull request review activity changed since review",
+      },
+    ]);
+    assert.match(
+      readText(join(itemsDir, "321.md")),
+      /^action_taken: skipped_changed_since_review$/m,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions fails closed without a reviewed PR activity cursor", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const mutationLogPath = join(root, "mutations.log");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const synced = reportWithSyncedReviewComment(
+      implementedCloseReport({
+        repository: "openclaw/openclaw",
+        number: 321,
+        type: "pull_request",
+        title: "Legacy reviewed PR",
+        url: "https://github.com/openclaw/openclaw/pull/321",
+        author: "reporter",
+        author_association: "CONTRIBUTOR",
+        labels: JSON.stringify([]),
+        pull_head_sha: "head-sha",
+        review_activity_cursor: "unknown",
+      }),
+      321,
+      "implemented_on_main",
+    );
+    writeFileSync(join(itemsDir, "321.md"), synced.report, "utf8");
+
+    withMockGh(
+      root,
+      promotionGhMock({
+        number: 321,
+        title: "Legacy reviewed PR",
+        labels: [],
+        comment: synced.comment,
+        itemUpdatedAtAfterLabelSyncLogPath: mutationLogPath,
+      }),
+      () => {
+        runApplyDecisionsForTest({
+          targetRepo: "openclaw/openclaw",
+          itemsDir,
+          closedDir,
+          plansDir,
+          reportPath,
+        });
+      },
+    );
+
+    assert.deepEqual(JSON.parse(readText(reportPath)), [
+      {
+        number: 321,
+        action: "kept_open",
+        reason: "stored pull request review activity cursor is missing; fresh review required",
+      },
+    ]);
+    assert.equal(existsSync(mutationLogPath), false);
+    assert.match(readText(join(itemsDir, "321.md")), /^action_taken: proposed_close$/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
   }
 });
 

--- a/test/apply-live-state.test.ts
+++ b/test/apply-live-state.test.ts
@@ -69,6 +69,7 @@ test("apply-decisions rejects recorded PR review activity drift before mutations
   const reviewedCursor = createReviewedPrActivityCursor({
     reviews: [],
     inlineComments: [],
+    reviewThreads: [],
   });
   assert.ok(reviewedCursor);
 
@@ -104,6 +105,13 @@ test("apply-decisions rejects recorded PR review activity drift before mutations
           commit_id: "head-sha",
         },
       ],
+      reviewThreads: [],
+    },
+    {
+      name: "review thread resolution",
+      reviews: [],
+      inlineComments: [],
+      reviewThreads: [{ id: "thread-1", isResolved: true }],
     },
   ]) {
     const root = mkdtempSync(tmpPrefix);
@@ -143,6 +151,7 @@ test("apply-decisions rejects recorded PR review activity drift before mutations
           comment: synced.comment,
           reviews: scenario.reviews,
           pullReviewComments: scenario.inlineComments,
+          reviewThreads: scenario.reviewThreads,
           itemUpdatedAtAfterLabelSyncLogPath: mutationLogPath,
         }),
         () => {
@@ -183,6 +192,7 @@ test("apply-decisions records review activity that changes after lease acquisiti
   const reviewedCursor = createReviewedPrActivityCursor({
     reviews: [],
     inlineComments: [],
+    reviewThreads: [],
   });
   assert.ok(reviewedCursor);
   const root = mkdtempSync(tmpPrefix);

--- a/test/apply-live-state.test.ts
+++ b/test/apply-live-state.test.ts
@@ -66,16 +66,24 @@ test("event apply proof marks only live deterministic remain-open guards", () =>
 });
 
 test("apply-decisions rejects recorded PR review activity drift before mutations", () => {
-  const reviewedCursor = createReviewedPrActivityCursor({
-    reviews: [],
-    inlineComments: [],
-    reviewThreads: [],
-  });
-  assert.ok(reviewedCursor);
+  const reviewThreadComment = {
+    id: 7003,
+    pull_request_review_id: 7001,
+    user: { login: "maintainer" },
+    body: "thread state must remain reviewed",
+    created_at: "2026-05-01T00:30:00Z",
+    updated_at: "2026-05-01T00:30:00Z",
+    path: "src/example.ts",
+    line: 14,
+    side: "RIGHT",
+    commit_id: "head-sha",
+  };
 
   for (const scenario of [
     {
       name: "review",
+      reviewedInlineComments: [],
+      reviewedThreads: [],
       reviews: [
         {
           id: 7001,
@@ -90,6 +98,8 @@ test("apply-decisions rejects recorded PR review activity drift before mutations
     },
     {
       name: "inline comment",
+      reviewedInlineComments: [],
+      reviewedThreads: [],
       reviews: [],
       inlineComments: [
         {
@@ -109,8 +119,10 @@ test("apply-decisions rejects recorded PR review activity drift before mutations
     },
     {
       name: "review thread resolution",
+      reviewedInlineComments: [reviewThreadComment],
+      reviewedThreads: [{ id: "thread-1", isResolved: false }],
       reviews: [],
-      inlineComments: [],
+      inlineComments: [reviewThreadComment],
       reviewThreads: [{ id: "thread-1", isResolved: true }],
     },
   ]) {
@@ -123,6 +135,12 @@ test("apply-decisions rejects recorded PR review activity drift before mutations
       const mutationLogPath = join(root, "mutations.log");
       mkdirSync(itemsDir, { recursive: true });
       mkdirSync(plansDir, { recursive: true });
+      const reviewedCursor = createReviewedPrActivityCursor({
+        reviews: [],
+        inlineComments: scenario.reviewedInlineComments,
+        reviewThreads: scenario.reviewedThreads,
+      });
+      assert.ok(reviewedCursor);
 
       const synced = reportWithSyncedReviewComment(
         implementedCloseReport({

--- a/test/apply-live-state.test.ts
+++ b/test/apply-live-state.test.ts
@@ -287,6 +287,92 @@ test("apply-decisions records review activity that changes after lease acquisiti
   }
 });
 
+test("apply-decisions revalidates review activity before each mutation request", () => {
+  const reviewedCursor = createReviewedPrActivityCursor({
+    reviews: [],
+    inlineComments: [],
+    reviewThreads: [],
+  });
+  assert.ok(reviewedCursor);
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const mutationLogPath = join(root, "mutations.log");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+
+    const synced = reportWithSyncedReviewComment(
+      implementedCloseReport({
+        repository: "openclaw/openclaw",
+        number: 321,
+        type: "pull_request",
+        title: "Reviewed PR",
+        url: "https://github.com/openclaw/openclaw/pull/321",
+        author: "reporter",
+        author_association: "CONTRIBUTOR",
+        labels: JSON.stringify([]),
+        pull_head_sha: "head-sha",
+        review_activity_cursor: reviewedCursor,
+        triage_priority: "P1",
+        merge_risk_labels: JSON.stringify(["merge-risk: 🚨 automation"]),
+      }),
+      321,
+      "implemented_on_main",
+    );
+    writeFileSync(join(itemsDir, "321.md"), synced.report, "utf8");
+
+    withMockGh(
+      root,
+      promotionGhMock({
+        number: 321,
+        title: "Reviewed PR",
+        labels: [],
+        comment: synced.comment,
+        reviews: [],
+        reviewsAfterFirstMutation: [
+          {
+            id: 7001,
+            user: { login: "maintainer" },
+            state: "COMMENTED",
+            body: "stop before the next mutation",
+            submitted_at: "2026-05-01T00:30:00Z",
+            commit_id: "head-sha",
+          },
+        ],
+        pullReviewComments: [],
+        itemUpdatedAtAfterLabelSyncLogPath: mutationLogPath,
+      }),
+      () => {
+        runApplyDecisionsForTest({
+          targetRepo: "openclaw/openclaw",
+          itemsDir,
+          closedDir,
+          plansDir,
+          reportPath,
+        });
+      },
+    );
+
+    assert.deepEqual(JSON.parse(readText(reportPath)), [
+      {
+        number: 321,
+        action: "skipped_changed_since_review",
+        reason: "pull request review activity changed since review",
+      },
+    ]);
+    assert.equal(readText(mutationLogPath).trim().split("\n").length, 1);
+    assert.match(
+      readText(join(itemsDir, "321.md")),
+      /^action_taken: skipped_changed_since_review$/m,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("apply-decisions fails closed without a reviewed PR activity cursor", () => {
   const root = mkdtempSync(tmpPrefix);
   try {

--- a/test/apply-pr-promotion.test.ts
+++ b/test/apply-pr-promotion.test.ts
@@ -446,7 +446,7 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/322\\/timeline(?:\\?|$
   const files = [{ filename: "src/runtime.ts" }];
   if (args.includes("--jq")) console.log(JSON.stringify(files.map((file) => file.filename)));
   else console.log(JSON.stringify([files]));
-} else if (args[0] === "api" && /\\/pulls\\/322\\/(files|commits|comments)(?:\\?|$)/.test(path)) {
+} else if (args[0] === "api" && /\\/pulls\\/322\\/(files|commits|reviews|comments)(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "label" || args[0] === "issue") {
   console.log("");

--- a/test/apply-same-author-pair-close.test.ts
+++ b/test/apply-same-author-pair-close.test.ts
@@ -124,7 +124,7 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/(320|321)\\/timeline(?
     base: { sha: "base-sha", ref: "main", repo: { full_name: "openclaw/openclaw" } },
     user: { login: "reporter" }
   }));
-} else if (args[0] === "api" && /\\/pulls\\/321\\/(files|commits|comments)(?:\\?|$)/.test(path)) {
+} else if (args[0] === "api" && /\\/pulls\\/321\\/(files|commits|reviews|comments)(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "label" || args[0] === "issue") {
   console.log("");
@@ -289,7 +289,7 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/(320|321)\\/timeline(?
     merged_at: null,
     labels: [{ name: "bug" }]
   }));
-} else if (args[0] === "api" && /\\/pulls\\/321\\/(files|commits|comments)(?:\\?|$)/.test(path)) {
+} else if (args[0] === "api" && /\\/pulls\\/321\\/(files|commits|reviews|comments)(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "label" || args[0] === "issue") {
   console.log("");
@@ -450,7 +450,7 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
     comments: 0,
     pull_request: { url: "https://api.github.com/repos/openclaw/openclaw/pulls/400" }
   }));
-} else if (args[0] === "api" && /\\/pulls\\/321\\/(files|commits|comments)(?:\\?|$)/.test(path)) {
+} else if (args[0] === "api" && /\\/pulls\\/321\\/(files|commits|reviews|comments)(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "issue" && args[1] === "view") {
   console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
@@ -613,7 +613,7 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/(320|321)\\/timeline(?
     base: { sha: "base-sha", ref: "main", repo: { full_name: "openclaw/openclaw" } },
     user: { login: "reporter" }
   }));
-} else if (args[0] === "api" && /\\/pulls\\/321\\/(files|commits|comments)(?:\\?|$)/.test(path)) {
+} else if (args[0] === "api" && /\\/pulls\\/321\\/(files|commits|reviews|comments)(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "label" || args[0] === "issue") {
   console.log("");
@@ -794,7 +794,7 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/(320|321)\\/timeline(?
     base: { sha: "base-sha", ref: "main", repo: { full_name: "openclaw/openclaw" } },
     user: { login: "reporter" }
   }));
-} else if (args[0] === "api" && /\\/pulls\\/321\\/(files|commits|comments)(?:\\?|$)/.test(path)) {
+} else if (args[0] === "api" && /\\/pulls\\/321\\/(files|commits|reviews|comments)(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "label" || args[0] === "issue") {
   console.log("");
@@ -943,7 +943,7 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
     base: { sha: "base-sha", ref: "main", repo: { full_name: "openclaw/openclaw" } },
     user: { login: "reporter" }
   }));
-} else if (args[0] === "api" && /\\/pulls\\/321\\/(files|commits|comments)(?:\\?|$)/.test(path)) {
+} else if (args[0] === "api" && /\\/pulls\\/321\\/(files|commits|reviews|comments)(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "label" || args[0] === "issue") {
   console.log("");

--- a/test/clawsweeper-action-ledger.test.ts
+++ b/test/clawsweeper-action-ledger.test.ts
@@ -520,6 +520,18 @@ test("apply receipts start per item and persist mutation observation before fina
   assert.match(source, /idempotencyIdentity: options\.identity/);
   assert.match(
     applyLoop,
+    /if \(!options\.identity\.startsWith\("review_lease_"\)\) \{[\s\S]*currentApplyMutationLeaseBlock\(\)[\s\S]*throw new ApplyMutationReviewGuardError/,
+  );
+  assert.match(
+    applyLoop,
+    /error instanceof ApplyMutationReviewGuardError \|\|[\s\S]*options\.knownNoMutation\?\.\(error\) === true/,
+  );
+  assert.match(
+    applyLoop,
+    /error instanceof ApplyMutationReviewGuardError && recordApplyMutationGuardBlock[\s\S]*recordApplyMutationGuardBlock\(error\.block\)/,
+  );
+  assert.match(
+    applyLoop,
     /finally \{[\s\S]*recordApplyActionLedgerItemResults\(\{[\s\S]*activeApplyItem = null;/,
   );
   const yieldStart = source.indexOf(

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -1469,7 +1469,7 @@ if (args[0] === "api" && /\\/issues\\/comments\\/\\d+$/.test(path)) {
     base: { sha: "base-sha", ref: "main", repo: { full_name: "openclaw/openclaw" } },
     user: { login: "reporter" }
   }));
-} else if (args[0] === "api" && /\\/pulls\\/321\\/(files|commits|comments)(?:\\?|$)/.test(path)) {
+} else if (args[0] === "api" && /\\/pulls\\/321\\/(files|commits|reviews|comments)(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "api" && /\\/issues\\/321\\/timeline/.test(path)) {
   console.log(JSON.stringify([]));
@@ -1622,7 +1622,7 @@ if (args[0] === "api" && /\\/issues\\/321\\/comments$/.test(path) && args.includ
     base: { sha: "base-sha", ref: "main", repo: { full_name: "openclaw/openclaw" } },
     user: { login: "reporter" }
   }));
-} else if (args[0] === "api" && /\\/pulls\\/321\\/(files|commits|comments)(?:\\?|$)/.test(path)) {
+} else if (args[0] === "api" && /\\/pulls\\/321\\/(files|commits|reviews|comments)(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "api" && /\\/issues\\/321\\/timeline/.test(path)) {
   console.log(JSON.stringify([]));
@@ -1774,7 +1774,7 @@ if (args[0] === "api" && /\\/issues\\/comments\\/\\d+$/.test(path)) {
     base: { sha: "base-sha", ref: "main", repo: { full_name: "openclaw/openclaw" } },
     user: { login: "reporter" }
   }));
-} else if (args[0] === "api" && /\\/pulls\\/321\\/(files|commits|comments)(?:\\?|$)/.test(path)) {
+} else if (args[0] === "api" && /\\/pulls\\/321\\/(files|commits|reviews|comments)(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "api" && /\\/issues\\/321\\/timeline/.test(path)) {
   console.log(JSON.stringify([]));

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -312,6 +312,16 @@ if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/pulls/96221") {
   console.log(JSON.stringify(pull));
   process.exit(0);
 }
+if (
+  args[0] === "api" &&
+  (
+    args[1].startsWith("repos/openclaw/openclaw/pulls/96221/reviews") ||
+    args[1].startsWith("repos/openclaw/openclaw/pulls/96221/comments")
+  )
+) {
+  console.log(JSON.stringify([[]]));
+  process.exit(0);
+}
 if (args[0] === "api" && args[1] === "-i" && args[2].startsWith("repos/openclaw/openclaw/issues/96221/timeline")) {
   process.stdout.write("HTTP/2 200\\nlink: <https://api.github.test?page=1>; rel=\\"last\\"\\n\\n[]");
   process.exit(0);

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -6,8 +6,14 @@ import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 
 import { renderReviewCommentFromReport } from "../dist/clawsweeper.js";
+import { createReviewedPrActivityCursor } from "../dist/review-activity-cursor.js";
 
 export const tmpPrefix = join(tmpdir(), "clawsweeper-test-");
+export const emptyReviewedPrActivityCursor =
+  createReviewedPrActivityCursor({ reviews: [], inlineComments: [] }) ??
+  (() => {
+    throw new Error("empty reviewed PR activity must produce a cursor");
+  })();
 
 export function readText(filePath: string): string {
   return readFileSync(filePath, "utf8").replace(/\r\n/g, "\n");
@@ -334,6 +340,12 @@ export function workPlanCandidateReport(overrides = {}) {
     work_cluster_refs: JSON.stringify(["openclaw/clawsweeper#26"]),
     ...overrides,
   };
+  if (
+    frontmatter.type === "pull_request" &&
+    !Object.hasOwn(frontmatter, "review_activity_cursor")
+  ) {
+    Object.assign(frontmatter, { review_activity_cursor: emptyReviewedPrActivityCursor });
+  }
   return `---
 ${Object.entries(frontmatter)
   .map(([key, value]) => `${key}: ${value}`)
@@ -446,6 +458,7 @@ export function promotionGhMock(options: {
   commentsAfterFirstRead?: unknown[];
   commentsAfterCommentWrite?: unknown[];
   reviews?: unknown[];
+  reviewsAfterFirstRead?: unknown[];
   pullReviewComments?: unknown[];
   timeline?: unknown[];
   mergeable?: boolean | null;
@@ -491,6 +504,7 @@ export function promotionGhMock(options: {
 	const commentsAfterFirstRead = ${JSON.stringify(options.commentsAfterFirstRead ?? null)};
 	const commentsAfterCommentWrite = ${JSON.stringify(options.commentsAfterCommentWrite ?? null)};
 	const reviews = ${JSON.stringify(options.reviews ?? [])};
+	const reviewsAfterFirstRead = ${JSON.stringify(options.reviewsAfterFirstRead ?? null)};
 	const pullReviewComments = ${JSON.stringify(options.pullReviewComments ?? [])};
 	const timeline = ${JSON.stringify(timeline)};
 	const linkedPulls = ${JSON.stringify(linkedPulls)};
@@ -505,6 +519,7 @@ export function promotionGhMock(options: {
 	const number = ${options.number};
 	const commentStatePath = join(__dirname, "..", "comment-state-" + number + ".json");
 	const commentReadStatePath = join(__dirname, "..", "comment-read-" + number);
+	const reviewReadStatePath = join(__dirname, "..", "review-read-" + number);
 	const mutationComment = (id, body) => ({
 	  id,
 	  html_url: "https://github.com/openclaw/openclaw/pull/" + number + "#issuecomment-" + id,
@@ -609,7 +624,11 @@ export function promotionGhMock(options: {
 } else if (args[0] === "api" && new RegExp("/issues/" + number + "/timeline(?:\\\\?|$)").test(path)) {
   console.log(JSON.stringify(slurp ? [timeline] : timeline));
 } else if (args[0] === "api" && new RegExp("/pulls/" + number + "/reviews(?:\\\\?|$)").test(path)) {
-  console.log(JSON.stringify(slurp ? [reviews] : reviews));
+  const currentReviews = reviewsAfterFirstRead && existsSync(reviewReadStatePath)
+    ? reviewsAfterFirstRead
+    : reviews;
+  if (!existsSync(reviewReadStatePath)) writeFileSync(reviewReadStatePath, "read", "utf8");
+  console.log(JSON.stringify(slurp ? [currentReviews] : currentReviews));
 } else if (args[0] === "api" && new RegExp("/issues/" + number + "$").test(path)) {
   console.log(JSON.stringify({
     number,

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -10,7 +10,7 @@ import { createReviewedPrActivityCursor } from "../dist/review-activity-cursor.j
 
 export const tmpPrefix = join(tmpdir(), "clawsweeper-test-");
 export const emptyReviewedPrActivityCursor =
-  createReviewedPrActivityCursor({ reviews: [], inlineComments: [] }) ??
+  createReviewedPrActivityCursor({ reviews: [], inlineComments: [], reviewThreads: [] }) ??
   (() => {
     throw new Error("empty reviewed PR activity must produce a cursor");
   })();
@@ -463,6 +463,8 @@ export function promotionGhMock(options: {
   reviews?: unknown[];
   reviewsAfterFirstRead?: unknown[];
   pullReviewComments?: unknown[];
+  reviewThreads?: unknown[];
+  reviewThreadsAfterFirstRead?: unknown[];
   timeline?: unknown[];
   mergeable?: boolean | null;
   mergeableState?: string | null;
@@ -507,8 +509,10 @@ export function promotionGhMock(options: {
 	const commentsAfterFirstRead = ${JSON.stringify(options.commentsAfterFirstRead ?? null)};
 	const commentsAfterCommentWrite = ${JSON.stringify(options.commentsAfterCommentWrite ?? null)};
 	const reviews = ${JSON.stringify(options.reviews ?? [])};
-	const reviewsAfterFirstRead = ${JSON.stringify(options.reviewsAfterFirstRead ?? null)};
-	const pullReviewComments = ${JSON.stringify(options.pullReviewComments ?? [])};
+		const reviewsAfterFirstRead = ${JSON.stringify(options.reviewsAfterFirstRead ?? null)};
+		const pullReviewComments = ${JSON.stringify(options.pullReviewComments ?? [])};
+		const reviewThreads = ${JSON.stringify(options.reviewThreads ?? [])};
+		const reviewThreadsAfterFirstRead = ${JSON.stringify(options.reviewThreadsAfterFirstRead ?? null)};
 	const timeline = ${JSON.stringify(timeline)};
 	const linkedPulls = ${JSON.stringify(linkedPulls)};
 	const linkedPullsAfterProof = ${JSON.stringify(options.linkedPullsAfterProof ?? {})};
@@ -522,7 +526,8 @@ export function promotionGhMock(options: {
 	const number = ${options.number};
 	const commentStatePath = join(__dirname, "..", "comment-state-" + number + ".json");
 	const commentReadStatePath = join(__dirname, "..", "comment-read-" + number);
-	const reviewReadStatePath = join(__dirname, "..", "review-read-" + number);
+		const reviewReadStatePath = join(__dirname, "..", "review-read-" + number);
+		const reviewThreadReadStatePath = join(__dirname, "..", "review-thread-read-" + number);
 	const mutationComment = (id, body) => ({
 	  id,
 	  html_url: "https://github.com/openclaw/openclaw/pull/" + number + "#issuecomment-" + id,
@@ -597,7 +602,25 @@ export function promotionGhMock(options: {
 		      ? itemUpdatedAtAfterLabelSync
 		      : itemUpdatedAt;
 	const issueCommentCount = ${issueCommentCount};
-	if (args[0] === "api" && args[1] === "-i" && new RegExp("/issues/" + number + "/timeline(?:\\\\?|$)").test(args[2] || "")) {
+		if (args[0] === "api" && args[1] === "graphql") {
+		  const currentReviewThreads =
+		    reviewThreadsAfterFirstRead && existsSync(reviewThreadReadStatePath)
+		      ? reviewThreadsAfterFirstRead
+		      : reviewThreads;
+		  if (!existsSync(reviewThreadReadStatePath)) writeFileSync(reviewThreadReadStatePath, "read", "utf8");
+		  console.log(JSON.stringify({
+		    data: {
+		      repository: {
+		        pullRequest: {
+		          reviewThreads: {
+		            nodes: currentReviewThreads,
+		            pageInfo: { hasNextPage: false, endCursor: null }
+		          }
+		        }
+		      }
+		    }
+		  }));
+		} else if (args[0] === "api" && args[1] === "-i" && new RegExp("/issues/" + number + "/timeline(?:\\\\?|$)").test(args[2] || "")) {
 	  console.log("HTTP/2 200\\n\\n" + JSON.stringify(timeline));
 	} else if (args[0] === "api" && new RegExp("/issues/" + number + "/comments$").test(path) && args.includes("--method")) {
 	  if (commentWriteLogPath) appendFileSync(commentWriteLogPath, args.join(" ") + "\\n");

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -229,6 +229,9 @@ export function reportFrontMatter(overrides = {}) {
     action_taken: "kept_open",
     ...overrides,
   };
+  if (values.type === "pull_request" && !Object.hasOwn(values, "review_activity_cursor")) {
+    Object.assign(values, { review_activity_cursor: emptyReviewedPrActivityCursor });
+  }
   return `---
 ${Object.entries(values)
   .map(([key, value]) => `${key}: ${value}`)

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -462,6 +462,7 @@ export function promotionGhMock(options: {
   commentsAfterCommentWrite?: unknown[];
   reviews?: unknown[];
   reviewsAfterFirstRead?: unknown[];
+  reviewsAfterFirstMutation?: unknown[];
   pullReviewComments?: unknown[];
   reviewThreads?: unknown[];
   reviewThreadsAfterFirstRead?: unknown[];
@@ -510,6 +511,7 @@ export function promotionGhMock(options: {
 	const commentsAfterCommentWrite = ${JSON.stringify(options.commentsAfterCommentWrite ?? null)};
 	const reviews = ${JSON.stringify(options.reviews ?? [])};
 		const reviewsAfterFirstRead = ${JSON.stringify(options.reviewsAfterFirstRead ?? null)};
+		const reviewsAfterFirstMutation = ${JSON.stringify(options.reviewsAfterFirstMutation ?? null)};
 		const pullReviewComments = ${JSON.stringify(options.pullReviewComments ?? [])};
 		const reviewThreads = ${JSON.stringify(options.reviewThreads ?? [])};
 		const reviewThreadsAfterFirstRead = ${JSON.stringify(options.reviewThreadsAfterFirstRead ?? null)};
@@ -650,9 +652,14 @@ export function promotionGhMock(options: {
 } else if (args[0] === "api" && new RegExp("/issues/" + number + "/timeline(?:\\\\?|$)").test(path)) {
   console.log(JSON.stringify(slurp ? [timeline] : timeline));
 } else if (args[0] === "api" && new RegExp("/pulls/" + number + "/reviews(?:\\\\?|$)").test(path)) {
-  const currentReviews = reviewsAfterFirstRead && existsSync(reviewReadStatePath)
-    ? reviewsAfterFirstRead
-    : reviews;
+  const currentReviews =
+    reviewsAfterFirstMutation &&
+    itemUpdatedAtAfterLabelSyncLogPath &&
+    existsSync(itemUpdatedAtAfterLabelSyncLogPath)
+      ? reviewsAfterFirstMutation
+      : reviewsAfterFirstRead && existsSync(reviewReadStatePath)
+        ? reviewsAfterFirstRead
+        : reviews;
   if (!existsSync(reviewReadStatePath)) writeFileSync(reviewReadStatePath, "read", "utf8");
   console.log(JSON.stringify(slurp ? [currentReviews] : currentReviews));
 } else if (args[0] === "api" && new RegExp("/issues/" + number + "$").test(path)) {

--- a/test/repair/comment-router-action-ledger.test.ts
+++ b/test/repair/comment-router-action-ledger.test.ts
@@ -54,7 +54,7 @@ test("comment router wraps every GitHub mutation at the request boundary", () =>
   }
 });
 
-test("trusted verdict automerge refreshes reviewed PR activity before merge dispatch", () => {
+test("trusted verdict mutations refresh reviewed PR activity before dispatch", () => {
   const source = readText("src/repair/comment-router.ts");
   const executeCommand = source.slice(
     source.indexOf("function executeCommand("),
@@ -65,18 +65,18 @@ test("trusted verdict automerge refreshes reviewed PR activity before merge disp
     source.indexOf("function latestAutomergeTarget("),
   );
   const commandPreflight = executeCommand.indexOf(
-    "const trustedAutomationActivityBlock = trustedAutomergeReviewActivityBlockReason(command)",
+    "const trustedAutomationActivityBlock = trustedAutomationReviewActivityBlockReason(command)",
   );
   const labelMutation = executeCommand.indexOf("applyLabelActions(command)");
   const waitLoop = executeAutomerge.indexOf("while (block && isTransientAutomergeBlock(block)");
   const initialReviewActivity = executeAutomerge.indexOf(
-    "const initialReviewActivityBlock = trustedAutomergeReviewActivityBlockReason(command)",
+    "const initialReviewActivityBlock = trustedAutomationReviewActivityBlockReason(command)",
   );
   const reviewLease = executeAutomerge.indexOf(
     "const reviewLeaseBlock = trustedAutomationReviewLeaseBlockReason(command)",
   );
   const reviewActivity = executeAutomerge.indexOf(
-    "const reviewActivityBlock = trustedAutomergeReviewActivityBlockReason(command)",
+    "const reviewActivityBlock = trustedAutomationReviewActivityBlockReason(command)",
   );
   const merge = executeAutomerge.indexOf("const result = runGitHubSpawnMutation(");
 
@@ -94,11 +94,11 @@ test("trusted verdict automerge refreshes reviewed PR activity before merge disp
   );
   assert.match(
     source,
-    /function trustedAutomergeReviewActivityCursorOnce[\s\S]*pulls\/\$\{number\}\/reviews[\s\S]*pulls\/\$\{number\}\/comments[\s\S]*function trustedAutomergeReviewActivityCursor[\s\S]*readStableReviewedPrActivityCursor[\s\S]*function trustedAutomergeReviewActivityBlockReason[\s\S]*isReviewedPrActivityCursor\(expected\)/,
+    /function trustedAutomationReviewActivityCursorOnce[\s\S]*pulls\/\$\{number\}\/reviews[\s\S]*pulls\/\$\{number\}\/comments[\s\S]*function trustedAutomationReviewActivityCursor[\s\S]*readStableReviewedPrActivityCursor[\s\S]*function trustedAutomationReviewActivityBlockReason[\s\S]*clawsweeper_auto_repair[\s\S]*isReviewedPrActivityCursor\(expected\)/,
   );
   assert.match(
     source,
-    /inlineComments\.length === 0 \? \[\] : trustedAutomergeReviewThreads\(number, remaining \+ 1\)/,
+    /inlineComments\.length === 0 \? \[\] : trustedAutomationReviewThreads\(number, remaining \+ 1\)/,
   );
   for (const wrapper of [
     "runGitHubTextMutation",
@@ -111,12 +111,16 @@ test("trusted verdict automerge refreshes reviewed PR activity before merge disp
     assert.match(implementation, /runReviewedPrActivityGuardedMutation/);
     assert.match(
       implementation,
-      /refresh: \(\) => trustedAutomergeReviewActivityBlockReason\(command\)/,
+      /refresh: \(\) => trustedAutomationReviewActivityBlockReason\(command\)/,
     );
   }
   assert.match(
     source,
     /function runGitHubBestEffortMutation[\s\S]*error instanceof ReviewedPrActivityGuardError[\s\S]*throw error/,
+  );
+  assert.match(
+    readText("src/repair/comment-router-core.ts"),
+    /function trustedRepair[\s\S]*expected_review_activity_cursor: marker\?\.attrs\?\.review_activity_cursor \?\? null/,
   );
 });
 

--- a/test/repair/comment-router-action-ledger.test.ts
+++ b/test/repair/comment-router-action-ledger.test.ts
@@ -122,6 +122,14 @@ test("trusted verdict mutations refresh reviewed PR activity before dispatch", (
     readText("src/repair/comment-router-core.ts"),
     /function trustedRepair[\s\S]*expected_review_activity_cursor: marker\?\.attrs\?\.review_activity_cursor \?\? null/,
   );
+  assert.match(
+    readText("src/repair/comment-router-core.ts"),
+    /function trustedClose[\s\S]*expected_review_activity_cursor: marker\?\.attrs\?\.review_activity_cursor \?\? null/,
+  );
+  assert.match(
+    source,
+    /function trustedAutomationReviewActivityBlockReason[\s\S]*!command\.trusted_bot[\s\S]*"autoclose"[\s\S]*"clawsweeper_needs_human"[\s\S]*intent === "autoclose" && command\.target\?\.kind !== "pull_request"/,
+  );
 });
 
 test("exact comment convergence classifies a missing comment as no mutation", () => {

--- a/test/repair/comment-router-action-ledger.test.ts
+++ b/test/repair/comment-router-action-ledger.test.ts
@@ -56,11 +56,22 @@ test("comment router wraps every GitHub mutation at the request boundary", () =>
 
 test("trusted verdict automerge refreshes reviewed PR activity before merge dispatch", () => {
   const source = readText("src/repair/comment-router.ts");
+  const executeCommand = source.slice(
+    source.indexOf("function executeCommand("),
+    source.indexOf("function executeCommandWithReceipt("),
+  );
   const executeAutomerge = source.slice(
     source.indexOf("function executeAutomerge("),
     source.indexOf("function latestAutomergeTarget("),
   );
+  const commandPreflight = executeCommand.indexOf(
+    "const trustedAutomationActivityBlock = trustedAutomergeReviewActivityBlockReason(command)",
+  );
+  const labelMutation = executeCommand.indexOf("applyLabelActions(command)");
   const waitLoop = executeAutomerge.indexOf("while (block && isTransientAutomergeBlock(block)");
+  const initialReviewActivity = executeAutomerge.indexOf(
+    "const initialReviewActivityBlock = trustedAutomergeReviewActivityBlockReason(command)",
+  );
   const reviewLease = executeAutomerge.indexOf(
     "const reviewLeaseBlock = trustedAutomationReviewLeaseBlockReason(command)",
   );
@@ -69,6 +80,10 @@ test("trusted verdict automerge refreshes reviewed PR activity before merge disp
   );
   const merge = executeAutomerge.indexOf("const result = runGitHubSpawnMutation(");
 
+  assert.ok(commandPreflight >= 0);
+  assert.ok(labelMutation > commandPreflight);
+  assert.ok(initialReviewActivity >= 0);
+  assert.ok(waitLoop > initialReviewActivity);
   assert.ok(waitLoop >= 0);
   assert.ok(reviewLease > waitLoop);
   assert.ok(reviewActivity > reviewLease);
@@ -79,7 +94,11 @@ test("trusted verdict automerge refreshes reviewed PR activity before merge disp
   );
   assert.match(
     source,
-    /function trustedAutomergeReviewActivityBlockReason[\s\S]*isReviewedPrActivityCursor\(expected\)[\s\S]*pulls\/\$\{command\.issue_number\}\/reviews[\s\S]*pulls\/\$\{command\.issue_number\}\/comments/,
+    /function trustedAutomergeReviewActivityCursor[\s\S]*pulls\/\$\{number\}\/reviews[\s\S]*pulls\/\$\{number\}\/comments[\s\S]*function trustedAutomergeReviewActivityBlockReason[\s\S]*isReviewedPrActivityCursor\(expected\)/,
+  );
+  assert.match(
+    source,
+    /inlineComments\.length === 0 \? \[\] : trustedAutomergeReviewThreads\(number, remaining \+ 1\)/,
   );
 });
 

--- a/test/repair/comment-router-action-ledger.test.ts
+++ b/test/repair/comment-router-action-ledger.test.ts
@@ -54,6 +54,35 @@ test("comment router wraps every GitHub mutation at the request boundary", () =>
   }
 });
 
+test("trusted verdict automerge refreshes reviewed PR activity before merge dispatch", () => {
+  const source = readText("src/repair/comment-router.ts");
+  const executeAutomerge = source.slice(
+    source.indexOf("function executeAutomerge("),
+    source.indexOf("function latestAutomergeTarget("),
+  );
+  const waitLoop = executeAutomerge.indexOf("while (block && isTransientAutomergeBlock(block)");
+  const reviewLease = executeAutomerge.indexOf(
+    "const reviewLeaseBlock = trustedAutomationReviewLeaseBlockReason(command)",
+  );
+  const reviewActivity = executeAutomerge.indexOf(
+    "const reviewActivityBlock = trustedAutomergeReviewActivityBlockReason(command)",
+  );
+  const merge = executeAutomerge.indexOf("const result = runGitHubSpawnMutation(");
+
+  assert.ok(waitLoop >= 0);
+  assert.ok(reviewLease > waitLoop);
+  assert.ok(reviewActivity > reviewLease);
+  assert.ok(merge > reviewActivity);
+  assert.match(
+    source,
+    /expected_review_activity_cursor: parsed\.expected_review_activity_cursor \?\? null/,
+  );
+  assert.match(
+    source,
+    /function trustedAutomergeReviewActivityBlockReason[\s\S]*isReviewedPrActivityCursor\(expected\)[\s\S]*pulls\/\$\{command\.issue_number\}\/reviews[\s\S]*pulls\/\$\{command\.issue_number\}\/comments/,
+  );
+});
+
 test("exact comment convergence classifies a missing comment as no mutation", () => {
   const source = readText("src/repair/comment-router.ts");
   const fastPath = source.slice(source.indexOf("function convergeExactCommentVersionFastPathAck"));

--- a/test/repair/comment-router-action-ledger.test.ts
+++ b/test/repair/comment-router-action-ledger.test.ts
@@ -94,11 +94,29 @@ test("trusted verdict automerge refreshes reviewed PR activity before merge disp
   );
   assert.match(
     source,
-    /function trustedAutomergeReviewActivityCursor[\s\S]*pulls\/\$\{number\}\/reviews[\s\S]*pulls\/\$\{number\}\/comments[\s\S]*function trustedAutomergeReviewActivityBlockReason[\s\S]*isReviewedPrActivityCursor\(expected\)/,
+    /function trustedAutomergeReviewActivityCursorOnce[\s\S]*pulls\/\$\{number\}\/reviews[\s\S]*pulls\/\$\{number\}\/comments[\s\S]*function trustedAutomergeReviewActivityCursor[\s\S]*readStableReviewedPrActivityCursor[\s\S]*function trustedAutomergeReviewActivityBlockReason[\s\S]*isReviewedPrActivityCursor\(expected\)/,
   );
   assert.match(
     source,
     /inlineComments\.length === 0 \? \[\] : trustedAutomergeReviewThreads\(number, remaining \+ 1\)/,
+  );
+  for (const wrapper of [
+    "runGitHubTextMutation",
+    "runGitHubTextMutationOnce",
+    "runGitHubSpawnMutation",
+  ]) {
+    const start = source.indexOf(`function ${wrapper}(`);
+    const end = source.indexOf("\nfunction ", start + 1);
+    const implementation = source.slice(start, end);
+    assert.match(implementation, /runReviewedPrActivityGuardedMutation/);
+    assert.match(
+      implementation,
+      /refresh: \(\) => trustedAutomergeReviewActivityBlockReason\(command\)/,
+    );
+  }
+  assert.match(
+    source,
+    /function runGitHubBestEffortMutation[\s\S]*error instanceof ReviewedPrActivityGuardError[\s\S]*throw error/,
   );
 });
 

--- a/test/repair/comment-router-action-ledger.test.ts
+++ b/test/repair/comment-router-action-ledger.test.ts
@@ -33,6 +33,7 @@ test("comment router wraps every GitHub mutation at the request boundary", () =>
   assert.match(source, /function runGitHubBestEffortMutation[\s\S]*runGitHubTextMutationOnce/);
   assert.match(source, /function runGitHubSpawnMutation[\s\S]*runCommandMutation/);
   for (const kind of [
+    "autoclose_preclose_comment",
     "label_create",
     "label_add",
     "label_remove",
@@ -129,6 +130,10 @@ test("trusted verdict mutations refresh reviewed PR activity before dispatch", (
   assert.match(
     source,
     /function trustedAutomationReviewActivityBlockReason[\s\S]*!command\.trusted_bot[\s\S]*"autoclose"[\s\S]*"clawsweeper_needs_human"[\s\S]*intent === "autoclose" && command\.target\?\.kind !== "pull_request"/,
+  );
+  assert.match(
+    source,
+    /function postIssueComment[\s\S]*"autoclose_preclose_comment"[\s\S]*function closeIssueOrPullRequest/,
   );
 });
 

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -2487,7 +2487,7 @@ test("parseTrustedAutomation treats trusted ClawSweeper needs-human as a pause",
   const parsed = parseTrustedAutomation(
     {
       user: { login: "clawsweeper[bot]" },
-      body: "ClawSweeper needs maintainer judgment.\n<!-- clawsweeper-verdict:needs-human sha=abc123 source_revision=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef reviewed_at=2026-07-09T21:00:00.000Z -->",
+      body: "ClawSweeper needs maintainer judgment.\n<!-- clawsweeper-verdict:needs-human sha=abc123 source_revision=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef review_activity_cursor=v2:0:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef reviewed_at=2026-07-09T21:00:00.000Z -->",
     },
     { trustedAuthors },
   );
@@ -2499,6 +2499,10 @@ test("parseTrustedAutomation treats trusted ClawSweeper needs-human as a pause",
   );
   assert.equal(parsed.expected_head_sha, "abc123");
   assert.equal(parsed.reviewed_at, "2026-07-09T21:00:00.000Z");
+  assert.equal(
+    parsed.expected_review_activity_cursor,
+    "v2:0:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  );
   assert.match(parsed.repair_reason, /needs-human/);
 });
 

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -1386,7 +1386,7 @@ test("parseTrustedAutomation accepts trusted ClawSweeper pass verdicts for autom
   const parsed = parseTrustedAutomation(
     {
       user: { login: "clawsweeper[bot]" },
-      body: "ClawSweeper review passed.\n<!-- clawsweeper-verdict:pass sha=abc123 source_revision=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef review_activity_cursor=v1:0:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef reviewed_at=2026-07-09T21:00:00.000Z -->",
+      body: "ClawSweeper review passed.\n<!-- clawsweeper-verdict:pass sha=abc123 source_revision=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef review_activity_cursor=v2:0:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef reviewed_at=2026-07-09T21:00:00.000Z -->",
     },
     { trustedAuthors },
   );
@@ -1400,7 +1400,7 @@ test("parseTrustedAutomation accepts trusted ClawSweeper pass verdicts for autom
   );
   assert.equal(
     parsed.expected_review_activity_cursor,
-    "v1:0:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    "v2:0:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
   );
   assert.match(parsed.repair_reason, /verdict: pass/);
 });

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -1285,7 +1285,7 @@ test("parseTrustedAutomation accepts only trusted ClawSweeper repair signals", (
   const trustedAuthors = new Set(["clawsweeper[bot]"]);
   const comment = {
     user: { login: "clawsweeper[bot]" },
-    body: "Codex review:\n<!-- clawsweeper-action: fix-required reviewed_at=2026-07-09T21:00:00.000Z -->\nPlease fix this before merge.",
+    body: "Codex review:\n<!-- clawsweeper-action: fix-required review_activity_cursor=v2:0:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef reviewed_at=2026-07-09T21:00:00.000Z -->\nPlease fix this before merge.",
   };
 
   const parsed = parseTrustedAutomation(comment, { trustedAuthors });
@@ -1293,6 +1293,10 @@ test("parseTrustedAutomation accepts only trusted ClawSweeper repair signals", (
   assert.equal(parsed.trusted_bot, true);
   assert.equal(parsed.trusted_bot_author, "clawsweeper[bot]");
   assert.equal(parsed.reviewed_at, "2026-07-09T21:00:00.000Z");
+  assert.equal(
+    parsed.expected_review_activity_cursor,
+    "v2:0:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  );
   assert.match(parsed.repair_reason, /structured ClawSweeper/);
 
   assert.equal(

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -1386,7 +1386,7 @@ test("parseTrustedAutomation accepts trusted ClawSweeper pass verdicts for autom
   const parsed = parseTrustedAutomation(
     {
       user: { login: "clawsweeper[bot]" },
-      body: "ClawSweeper review passed.\n<!-- clawsweeper-verdict:pass sha=abc123 source_revision=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef reviewed_at=2026-07-09T21:00:00.000Z -->",
+      body: "ClawSweeper review passed.\n<!-- clawsweeper-verdict:pass sha=abc123 source_revision=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef review_activity_cursor=v1:0:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef reviewed_at=2026-07-09T21:00:00.000Z -->",
     },
     { trustedAuthors },
   );
@@ -1397,6 +1397,10 @@ test("parseTrustedAutomation accepts trusted ClawSweeper pass verdicts for autom
   assert.equal(
     parsed.expected_source_revision,
     "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  );
+  assert.equal(
+    parsed.expected_review_activity_cursor,
+    "v1:0:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
   );
   assert.match(parsed.repair_reason, /verdict: pass/);
 });

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -1416,8 +1416,8 @@ test("parseTrustedAutomation accepts trusted ClawSweeper close markers for autoc
       user: { login: "clawsweeper[bot]" },
       body: [
         "ClawSweeper proposed closing this PR.",
-        "<!-- clawsweeper-verdict:close item=96097 sha=abc123 confidence=high reason=duplicate_or_superseded -->",
-        "<!-- clawsweeper-action:close-required item=96097 sha=abc123 confidence=high reason=duplicate_or_superseded -->",
+        "<!-- clawsweeper-verdict:close item=96097 sha=abc123 confidence=high review_activity_cursor=v2:0:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef reason=duplicate_or_superseded -->",
+        "<!-- clawsweeper-action:close-required item=96097 sha=abc123 confidence=high review_activity_cursor=v2:0:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef reason=duplicate_or_superseded -->",
       ].join("\n"),
     },
     { trustedAuthors },
@@ -1427,6 +1427,10 @@ test("parseTrustedAutomation accepts trusted ClawSweeper close markers for autoc
   assert.equal(parsed.trusted_bot, true);
   assert.equal(parsed.expected_head_sha, "abc123");
   assert.equal(parsed.close_reason, "duplicate_or_superseded");
+  assert.equal(
+    parsed.expected_review_activity_cursor,
+    "v2:0:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  );
   assert.match(parsed.autoclose_message, /close-required/);
 
   const issueParsed = parseTrustedAutomation(

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -2117,6 +2117,8 @@ test("trusted autoclose markers are live close gated before close execution", ()
   assert.match(autocloseClassifier, /fetchPullRequestApi\(command\.issue_number\)/);
   assert.match(autocloseClassifier, /requestedReviewers:\s*pullApi\.requested_reviewers/);
   assert.match(autocloseExecutor, /liveTrustedCloseBlockReason\(command,\s*liveTarget\)/);
+  assert.match(autocloseExecutor, /postIssueComment\(/);
+  assert.match(source, /function postIssueComment[\s\S]*"autoclose_preclose_comment"/);
   assert.match(trustedCloseGate, /reviewedHeadShaBlockReason\(\{/);
   assert.match(trustedCloseGate, /markerName:\s*"close"/);
   assert.match(autocloseClassifier, /status:\s*"skipped"/);

--- a/test/repair/github-cli.test.ts
+++ b/test/repair/github-cli.test.ts
@@ -1,7 +1,15 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 
-import { githubLimitedPagePath, githubPaginatedPath } from "../../dist/repair/github-cli.js";
+import {
+  ghPagedLimit,
+  githubLimitedPagePath,
+  githubPaginatedPath,
+} from "../../dist/repair/github-cli.js";
+import { withMockGh } from "../helpers.ts";
 
 test("githubPaginatedPath requests maximum REST page size by default", () => {
   assert.equal(
@@ -35,4 +43,29 @@ test("githubLimitedPagePath caps one REST page and preserves existing filters", 
     githubLimitedPagePath("repos/openclaw/openclaw/pulls/123/files", 0, 0),
     "repos/openclaw/openclaw/pulls/123/files?per_page=1&page=1",
   );
+});
+
+test("ghPagedLimit accepts legacy slurp-shaped single-page responses", () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-github-cli-"));
+  try {
+    withMockGh(
+      root,
+      `#!/usr/bin/env node
+const path = process.argv[3] || "";
+if (path.includes("page=1")) {
+  console.log(JSON.stringify([[{ id: 1 }, { id: 2 }]]));
+} else {
+  console.log(JSON.stringify([[]]));
+}
+`,
+      () => {
+        assert.deepEqual(ghPagedLimit<{ id: number }>("repos/example/repo/pulls/1/files", 3), [
+          { id: 1 },
+          { id: 2 },
+        ]);
+      },
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });

--- a/test/repair/workflow-sparse-checkout.test.ts
+++ b/test/repair/workflow-sparse-checkout.test.ts
@@ -16,6 +16,8 @@ const REPAIR_RUNTIME_PATHS = [
   "src/codex-transient.ts",
   "src/github-json.ts",
   "src/pr-close-coverage-proof.ts",
+  "src/review-activity-cursor.ts",
+  "src/stable-json.ts",
 ] as const;
 
 const SPARSE_REPAIR_BUILD_WORKFLOWS = [

--- a/test/review-activity-cursor.test.ts
+++ b/test/review-activity-cursor.test.ts
@@ -4,9 +4,12 @@ import test from "node:test";
 import {
   MAX_REVIEWED_PR_ACTIVITY,
   MAX_REVIEWED_PR_ACTIVITY_CURSOR_BYTES,
+  ReviewedPrActivityGuardError,
   createReviewedPrActivityCursor,
   isReviewedPrActivityCursor,
+  readStableReviewedPrActivityCursor,
   reviewedPrActivityThreadsPageFromGraphql,
+  runReviewedPrActivityGuardedMutation,
 } from "../dist/review-activity-cursor.js";
 
 test("review activity cursors bind same-second reviews and inline comments", () => {
@@ -179,4 +182,91 @@ test("review thread GraphQL pages are parsed fail-closed", () => {
     }),
     null,
   );
+});
+
+test("review activity cursor refresh rejects an interleaved review", () => {
+  const cursors = [
+    createReviewedPrActivityCursor({
+      reviews: [],
+      inlineComments: [],
+      reviewThreads: [],
+    }),
+    createReviewedPrActivityCursor({
+      reviews: [{ id: 1, user: { login: "reviewer" }, state: "COMMENTED" }],
+      inlineComments: [],
+      reviewThreads: [],
+    }),
+  ];
+  let reads = 0;
+
+  assert.throws(
+    () => readStableReviewedPrActivityCursor(() => cursors[reads++] ?? null),
+    /review activity changed while refreshing/,
+  );
+  assert.equal(reads, 2);
+});
+
+test("review activity cursor refresh accepts two matching complete scans", () => {
+  const cursor = createReviewedPrActivityCursor({
+    reviews: [{ id: 1, user: { login: "reviewer" }, state: "APPROVED" }],
+    inlineComments: [],
+    reviewThreads: [],
+  });
+  let reads = 0;
+
+  assert.equal(
+    readStableReviewedPrActivityCursor(() => {
+      reads += 1;
+      return cursor;
+    }),
+    cursor,
+  );
+  assert.equal(reads, 2);
+});
+
+test("trusted review activity is revalidated at the mutation boundary", () => {
+  let operationCalls = 0;
+  const preflight = () => null;
+  const changedAtMutation = () => ({
+    reason: "pull request review activity changed since the trusted ClawSweeper verdict",
+    retryable: false,
+  });
+
+  assert.equal(preflight(), null);
+  for (const mutationKind of [
+    "description_update",
+    "label_add",
+    "label_create",
+    "label_remove",
+    "pull_request_merge",
+    "repair_dispatch",
+    "review_dispatch",
+  ]) {
+    assert.throws(
+      () =>
+        runReviewedPrActivityGuardedMutation({
+          intent: "clawsweeper_auto_merge",
+          mutationKind,
+          refresh: changedAtMutation,
+          operation: () => {
+            operationCalls += 1;
+          },
+        }),
+      (error) =>
+        error instanceof ReviewedPrActivityGuardError &&
+        error.mutationKind === mutationKind &&
+        error.block.retryable === false,
+    );
+  }
+  assert.equal(operationCalls, 0);
+
+  runReviewedPrActivityGuardedMutation({
+    intent: "clawsweeper_auto_merge",
+    mutationKind: "comment_update",
+    refresh: changedAtMutation,
+    operation: () => {
+      operationCalls += 1;
+    },
+  });
+  assert.equal(operationCalls, 1);
 });

--- a/test/review-activity-cursor.test.ts
+++ b/test/review-activity-cursor.test.ts
@@ -3,8 +3,10 @@ import test from "node:test";
 
 import {
   MAX_REVIEWED_PR_ACTIVITY,
+  MAX_REVIEWED_PR_ACTIVITY_CURSOR_BYTES,
   createReviewedPrActivityCursor,
   isReviewedPrActivityCursor,
+  reviewedPrActivityThreadsPageFromGraphql,
 } from "../dist/review-activity-cursor.js";
 
 test("review activity cursors bind same-second reviews and inline comments", () => {
@@ -19,6 +21,7 @@ test("review activity cursors bind same-second reviews and inline comments", () 
       },
     ],
     inlineComments: [],
+    reviewThreads: [],
   });
   const changed = createReviewedPrActivityCursor({
     reviews: [
@@ -30,6 +33,7 @@ test("review activity cursors bind same-second reviews and inline comments", () 
         body: "looks close",
       },
     ],
+    reviewThreads: [],
     inlineComments: [
       {
         id: 2,
@@ -68,14 +72,17 @@ test("review activity cursors are order-independent and edit-sensitive", () => {
   const forward = createReviewedPrActivityCursor({
     reviews: [],
     inlineComments: [first, second],
+    reviewThreads: [],
   });
   const reverse = createReviewedPrActivityCursor({
     reviews: [],
     inlineComments: [second, first],
+    reviewThreads: [],
   });
   const edited = createReviewedPrActivityCursor({
     reviews: [],
     inlineComments: [first, { ...second, body: "edited" }],
+    reviewThreads: [],
   });
 
   assert.equal(reverse, forward);
@@ -85,10 +92,91 @@ test("review activity cursors are order-independent and edit-sensitive", () => {
 test("review activity cursors fail closed beyond the bounded history", () => {
   const inlineComments = Array.from({ length: MAX_REVIEWED_PR_ACTIVITY + 1 }, (_, id) => ({ id }));
 
-  assert.equal(createReviewedPrActivityCursor({ reviews: [], inlineComments }), null);
+  assert.equal(
+    createReviewedPrActivityCursor({ reviews: [], inlineComments, reviewThreads: [] }),
+    null,
+  );
   assert.equal(isReviewedPrActivityCursor({ toString: () => `v1:0:${"a".repeat(64)}` }), false);
   assert.equal(
-    isReviewedPrActivityCursor(`v1:${MAX_REVIEWED_PR_ACTIVITY + 1}:${"a".repeat(64)}`),
+    isReviewedPrActivityCursor(`v2:${MAX_REVIEWED_PR_ACTIVITY + 1}:${"a".repeat(64)}`),
     false,
+  );
+});
+
+test("review activity cursors bind review thread resolution", () => {
+  const open = createReviewedPrActivityCursor({
+    reviews: [],
+    inlineComments: [],
+    reviewThreads: [{ id: "thread-1", isResolved: false }],
+  });
+  const resolved = createReviewedPrActivityCursor({
+    reviews: [],
+    inlineComments: [],
+    reviewThreads: [{ id: "thread-1", isResolved: true }],
+  });
+
+  assert.ok(isReviewedPrActivityCursor(open));
+  assert.ok(isReviewedPrActivityCursor(resolved));
+  assert.notEqual(resolved, open);
+});
+
+test("review activity cursors digest bodies and bound canonical metadata", () => {
+  const largeBody = "x".repeat(MAX_REVIEWED_PR_ACTIVITY_CURSOR_BYTES * 2);
+  assert.ok(
+    createReviewedPrActivityCursor({
+      reviews: [{ id: 1, body: largeBody }],
+      inlineComments: [],
+      reviewThreads: [],
+    }),
+  );
+
+  const oversizedMetadata = Array.from({ length: MAX_REVIEWED_PR_ACTIVITY }, (_, id) => ({
+    id,
+    path: `src/${"x".repeat(2_000)}/${id}.ts`,
+  }));
+  assert.equal(
+    createReviewedPrActivityCursor({
+      reviews: [],
+      inlineComments: oversizedMetadata,
+      reviewThreads: [],
+    }),
+    null,
+  );
+});
+
+test("review thread GraphQL pages are parsed fail-closed", () => {
+  assert.deepEqual(
+    reviewedPrActivityThreadsPageFromGraphql({
+      data: {
+        repository: {
+          pullRequest: {
+            reviewThreads: {
+              nodes: [{ id: "thread-1", isResolved: false }],
+              pageInfo: { hasNextPage: true, endCursor: "cursor-1" },
+            },
+          },
+        },
+      },
+    }),
+    {
+      threads: [{ id: "thread-1", isResolved: false }],
+      hasNextPage: true,
+      endCursor: "cursor-1",
+    },
+  );
+  assert.equal(
+    reviewedPrActivityThreadsPageFromGraphql({
+      data: {
+        repository: {
+          pullRequest: {
+            reviewThreads: {
+              nodes: [{ id: "thread-1", isResolved: "false" }],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        },
+      },
+    }),
+    null,
   );
 });

--- a/test/review-activity-cursor.test.ts
+++ b/test/review-activity-cursor.test.ts
@@ -269,30 +269,32 @@ test("trusted review activity is revalidated at the mutation boundary", () => {
   });
 
   assert.equal(preflight(), null);
-  for (const mutationKind of [
-    "description_update",
-    "label_add",
-    "label_create",
-    "label_remove",
-    "pull_request_merge",
-    "repair_dispatch",
-    "review_dispatch",
-  ]) {
-    assert.throws(
-      () =>
-        runReviewedPrActivityGuardedMutation({
-          intent: "clawsweeper_auto_merge",
-          mutationKind,
-          refresh: changedAtMutation,
-          operation: () => {
-            operationCalls += 1;
-          },
-        }),
-      (error) =>
-        error instanceof ReviewedPrActivityGuardError &&
-        error.mutationKind === mutationKind &&
-        error.block.retryable === false,
-    );
+  for (const intent of ["clawsweeper_auto_merge", "clawsweeper_auto_repair"]) {
+    for (const mutationKind of [
+      "description_update",
+      "label_add",
+      "label_create",
+      "label_remove",
+      "pull_request_merge",
+      "repair_dispatch",
+      "review_dispatch",
+    ]) {
+      assert.throws(
+        () =>
+          runReviewedPrActivityGuardedMutation({
+            intent,
+            mutationKind,
+            refresh: changedAtMutation,
+            operation: () => {
+              operationCalls += 1;
+            },
+          }),
+        (error) =>
+          error instanceof ReviewedPrActivityGuardError &&
+          error.mutationKind === mutationKind &&
+          error.block.retryable === false,
+      );
+    }
   }
   assert.equal(operationCalls, 0);
 

--- a/test/review-activity-cursor.test.ts
+++ b/test/review-activity-cursor.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  MAX_REVIEWED_PR_ACTIVITY,
+  createReviewedPrActivityCursor,
+  isReviewedPrActivityCursor,
+} from "../dist/review-activity-cursor.js";
+
+test("review activity cursors bind same-second reviews and inline comments", () => {
+  const baseline = createReviewedPrActivityCursor({
+    reviews: [
+      {
+        id: 1,
+        user: { login: "reviewer" },
+        state: "COMMENTED",
+        submitted_at: "2026-07-13T08:00:00Z",
+        body: "looks close",
+      },
+    ],
+    inlineComments: [],
+  });
+  const changed = createReviewedPrActivityCursor({
+    reviews: [
+      {
+        id: 1,
+        user: { login: "reviewer" },
+        state: "COMMENTED",
+        submitted_at: "2026-07-13T08:00:00Z",
+        body: "looks close",
+      },
+    ],
+    inlineComments: [
+      {
+        id: 2,
+        user: { login: "reviewer" },
+        created_at: "2026-07-13T08:00:00Z",
+        updated_at: "2026-07-13T08:00:00Z",
+        path: "src/example.ts",
+        line: 10,
+        body: "please fix this",
+      },
+    ],
+  });
+
+  assert.ok(isReviewedPrActivityCursor(baseline));
+  assert.ok(isReviewedPrActivityCursor(changed));
+  assert.notEqual(changed, baseline);
+});
+
+test("review activity cursors are order-independent and edit-sensitive", () => {
+  const first = {
+    id: 10,
+    user: { login: "reviewer" },
+    created_at: "2026-07-13T08:00:00Z",
+    updated_at: "2026-07-13T08:00:00Z",
+    path: "src/a.ts",
+    body: "first",
+  };
+  const second = {
+    id: 11,
+    user: { login: "reviewer" },
+    created_at: "2026-07-13T08:00:00Z",
+    updated_at: "2026-07-13T08:00:00Z",
+    path: "src/b.ts",
+    body: "second",
+  };
+  const forward = createReviewedPrActivityCursor({
+    reviews: [],
+    inlineComments: [first, second],
+  });
+  const reverse = createReviewedPrActivityCursor({
+    reviews: [],
+    inlineComments: [second, first],
+  });
+  const edited = createReviewedPrActivityCursor({
+    reviews: [],
+    inlineComments: [first, { ...second, body: "edited" }],
+  });
+
+  assert.equal(reverse, forward);
+  assert.notEqual(edited, forward);
+});
+
+test("review activity cursors fail closed beyond the bounded history", () => {
+  const inlineComments = Array.from({ length: MAX_REVIEWED_PR_ACTIVITY + 1 }, (_, id) => ({ id }));
+
+  assert.equal(createReviewedPrActivityCursor({ reviews: [], inlineComments }), null);
+  assert.equal(isReviewedPrActivityCursor({ toString: () => `v1:0:${"a".repeat(64)}` }), false);
+  assert.equal(
+    isReviewedPrActivityCursor(`v1:${MAX_REVIEWED_PR_ACTIVITY + 1}:${"a".repeat(64)}`),
+    false,
+  );
+});

--- a/test/review-activity-cursor.test.ts
+++ b/test/review-activity-cursor.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import test from "node:test";
 
 import {
@@ -90,6 +91,41 @@ test("review activity cursors are order-independent and edit-sensitive", () => {
 
   assert.equal(reverse, forward);
   assert.notEqual(edited, forward);
+});
+
+test("review activity cursor ordering is locale-independent", () => {
+  const moduleUrl = new URL("../dist/review-activity-cursor.js", import.meta.url).href;
+  const script = `
+    const { createReviewedPrActivityCursor } = await import(${JSON.stringify(moduleUrl)});
+    const cursor = createReviewedPrActivityCursor({
+      reviews: [],
+      inlineComments: [],
+      reviewThreads: [
+        { id: "I", isResolved: false },
+        { id: "\\u0131", isResolved: false },
+        { id: "i", isResolved: false },
+        { id: "\\u0130", isResolved: false },
+      ],
+    });
+    console.log(JSON.stringify({
+      locale: Intl.Collator().resolvedOptions().locale,
+      cursor,
+    }));
+  `;
+  const run = (locale: string) => {
+    const result = spawnSync(process.execPath, ["--input-type=module", "--eval", script], {
+      encoding: "utf8",
+      env: { ...process.env, LANG: locale, LC_ALL: locale },
+    });
+    assert.equal(result.status, 0, result.stderr);
+    return JSON.parse(result.stdout.trim()) as { locale: string; cursor: string };
+  };
+
+  const english = run("en_US.UTF-8");
+  const turkish = run("tr_TR.UTF-8");
+  assert.match(english.locale, /^en(?:-|$)/i);
+  assert.match(turkish.locale, /^tr(?:-|$)/i);
+  assert.equal(turkish.cursor, english.cursor);
 });
 
 test("review activity cursors fail closed beyond the bounded history", () => {

--- a/test/review-activity-cursor.test.ts
+++ b/test/review-activity-cursor.test.ts
@@ -298,6 +298,29 @@ test("trusted review activity is revalidated at the mutation boundary", () => {
   }
   assert.equal(operationCalls, 0);
 
+  for (const [intent, mutationKind] of [
+    ["autoclose", "issue_close"],
+    ["autoclose", "pull_request_close"],
+    ["clawsweeper_needs_human", "label_add"],
+  ]) {
+    assert.throws(
+      () =>
+        runReviewedPrActivityGuardedMutation({
+          intent,
+          mutationKind,
+          refresh: changedAtMutation,
+          operation: () => {
+            operationCalls += 1;
+          },
+        }),
+      (error) =>
+        error instanceof ReviewedPrActivityGuardError &&
+        error.mutationKind === mutationKind &&
+        error.block.retryable === false,
+    );
+  }
+  assert.equal(operationCalls, 0);
+
   runReviewedPrActivityGuardedMutation({
     intent: "clawsweeper_auto_merge",
     mutationKind: "comment_update",

--- a/test/review-activity-cursor.test.ts
+++ b/test/review-activity-cursor.test.ts
@@ -299,6 +299,7 @@ test("trusted review activity is revalidated at the mutation boundary", () => {
   assert.equal(operationCalls, 0);
 
   for (const [intent, mutationKind] of [
+    ["autoclose", "autoclose_preclose_comment"],
     ["autoclose", "issue_close"],
     ["autoclose", "pull_request_close"],
     ["clawsweeper_needs_human", "label_add"],

--- a/test/review-comment-rendering.test.ts
+++ b/test/review-comment-rendering.test.ts
@@ -33,7 +33,7 @@ function implementedCloseReport(overrides = {}) {
     work_status: "none",
     item_snapshot_hash: "reviewed-snapshot",
     item_source_revision: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-    review_activity_cursor: "v1:0:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    review_activity_cursor: "v2:0:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
     item_created_at: "2026-05-01T00:00:00Z",
     item_updated_at: "2026-05-01T00:00:00Z",
     reproduction_status: "reproduced",
@@ -111,6 +111,7 @@ test("structural cache probes before hydration but acquires a lease before carry
     source.indexOf("for (const item of candidates)"),
     source.indexOf("let decision: Decision", source.indexOf("for (const item of candidates)")),
   );
+  const cacheEligibility = reviewLoop.indexOf("const cacheReview =");
   const structuralEligibility = reviewLoop.indexOf("reviewStructuralCacheProbeDecision({");
   const structuralProbe = reviewLoop.indexOf(
     "structuralRecord = fetchReviewStructuralRecord({",
@@ -128,7 +129,13 @@ test("structural cache probes before hydration but acquires a lease before carry
   const hydration = reviewLoop.indexOf("collectItemContext(item");
   const mediaPrep = reviewLoop.indexOf("prepareMediaProofArtifacts(context", contentCache);
 
-  assert.ok(structuralEligibility >= 0);
+  assert.ok(cacheEligibility >= 0);
+  assert.ok(structuralEligibility > cacheEligibility);
+  assert.match(
+    reviewLoop.slice(cacheEligibility, structuralEligibility),
+    /isReviewedPrActivityCursor\(priorReviewActivityCursor\)/,
+  );
+  assert.match(reviewLoop.slice(structuralEligibility, structuralProbe), /review: cacheReview/);
   assert.ok(structuralProbe > structuralEligibility);
   assert.ok(structuralCache >= 0);
   assert.ok(structuralCache < hydration);
@@ -160,6 +167,10 @@ test("structural cache probes before hydration but acquires a lease before carry
   assert.match(
     reviewLoop.slice(structuralRevalidation, structuralWrite),
     /liveClawSweeperReviewDigest\(item\.number\)[\s\S]*previousReviewIdentityMatches/,
+  );
+  assert.match(
+    reviewLoop.slice(structuralRevalidation, structuralWrite),
+    /fetchReviewedPrActivityCursor\(item\.number\)[\s\S]*reviewActivityMatches[\s\S]*review_activity_cursor/,
   );
   const structuralProbeSource = source.slice(
     source.indexOf("function fetchReviewStructuralRecord"),
@@ -246,6 +257,10 @@ test("semantic cache runs after hydration and revalidates under the acquired lea
     /refreshStructuralRecordForVerdict\(\)/,
   );
   assert.match(
+    reviewLoop.slice(semanticRevalidation, semanticWrite),
+    /fetchReviewedPrActivityCursor\(item\.number\)[\s\S]*reviewActivityMatches[\s\S]*review_activity_cursor/,
+  );
+  assert.match(
     reviewLoop.slice(localRangeGuard, semanticDecision),
     /expectedPreviousReviewDigest[\s\S]*currentPreviousReviewDigest/,
   );
@@ -263,7 +278,7 @@ test("semantic cache runs after hydration and revalidates under the acquired lea
   );
   assert.match(
     reviewLoop.slice(semanticWrite, contentCache),
-    /previousReviewIdentityChanged[\s\S]*!git\.releaseStateComplete/,
+    /previousReviewIdentityChanged[\s\S]*!git\.releaseStateComplete[\s\S]*contentCacheReviewActivityMatches/,
   );
   const verdictRefresh = source.slice(
     source.indexOf("const refreshStructuralRecordForVerdict"),
@@ -856,11 +871,11 @@ test("pull request close comments emit close-required automation markers", () =>
 
   assert.match(
     comment,
-    /<!-- clawsweeper-verdict:close item=74270 sha=abc123def456 confidence=high updated_at=2026-05-01T00:00:00Z reviewed_at=[^ ]+ lease_owner=unknown lease_comment_id=unknown source_revision=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef review_activity_cursor=v1:0:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef action_taken=proposed_close reason=implemented_on_main -->/,
+    /<!-- clawsweeper-verdict:close item=74270 sha=abc123def456 confidence=high updated_at=2026-05-01T00:00:00Z reviewed_at=[^ ]+ lease_owner=unknown lease_comment_id=unknown source_revision=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef review_activity_cursor=v2:0:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef action_taken=proposed_close reason=implemented_on_main -->/,
   );
   assert.match(
     comment,
-    /<!-- clawsweeper-action:close-required item=74270 sha=abc123def456 confidence=high updated_at=2026-05-01T00:00:00Z reviewed_at=[^ ]+ lease_owner=unknown lease_comment_id=unknown source_revision=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef review_activity_cursor=v1:0:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef action_taken=proposed_close reason=implemented_on_main -->/,
+    /<!-- clawsweeper-action:close-required item=74270 sha=abc123def456 confidence=high updated_at=2026-05-01T00:00:00Z reviewed_at=[^ ]+ lease_owner=unknown lease_comment_id=unknown source_revision=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef review_activity_cursor=v2:0:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef action_taken=proposed_close reason=implemented_on_main -->/,
   );
   assert.doesNotMatch(comment, /clawsweeper-verdict:needs-human/);
 });

--- a/test/review-comment-rendering.test.ts
+++ b/test/review-comment-rendering.test.ts
@@ -460,7 +460,7 @@ test("concurrent review lease election uses server comment order, not client tim
 
 test("apply retains its mutation lease until the item action is complete", () => {
   const source = readFileSync("src/clawsweeper.ts", "utf8");
-  const acquire = source.indexOf("const mutationLeaseBlockReason = acquireApplyMutationLease");
+  const acquire = source.indexOf("const mutationLeaseBlock = acquireApplyMutationLease");
   const commentSync = source.indexOf("syncedComment = upsertReviewComment(", acquire);
   const close = source.indexOf("closeItem({ number, kind: item.kind", commentSync);
   const release = source.indexOf("releaseActiveApplyMutationLease();", close);

--- a/test/review-comment-rendering.test.ts
+++ b/test/review-comment-rendering.test.ts
@@ -33,6 +33,7 @@ function implementedCloseReport(overrides = {}) {
     work_status: "none",
     item_snapshot_hash: "reviewed-snapshot",
     item_source_revision: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    review_activity_cursor: "v1:0:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
     item_created_at: "2026-05-01T00:00:00Z",
     item_updated_at: "2026-05-01T00:00:00Z",
     reproduction_status: "reproduced",
@@ -855,11 +856,11 @@ test("pull request close comments emit close-required automation markers", () =>
 
   assert.match(
     comment,
-    /<!-- clawsweeper-verdict:close item=74270 sha=abc123def456 confidence=high updated_at=2026-05-01T00:00:00Z reviewed_at=[^ ]+ lease_owner=unknown lease_comment_id=unknown source_revision=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef action_taken=proposed_close reason=implemented_on_main -->/,
+    /<!-- clawsweeper-verdict:close item=74270 sha=abc123def456 confidence=high updated_at=2026-05-01T00:00:00Z reviewed_at=[^ ]+ lease_owner=unknown lease_comment_id=unknown source_revision=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef review_activity_cursor=v1:0:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef action_taken=proposed_close reason=implemented_on_main -->/,
   );
   assert.match(
     comment,
-    /<!-- clawsweeper-action:close-required item=74270 sha=abc123def456 confidence=high updated_at=2026-05-01T00:00:00Z reviewed_at=[^ ]+ lease_owner=unknown lease_comment_id=unknown source_revision=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef action_taken=proposed_close reason=implemented_on_main -->/,
+    /<!-- clawsweeper-action:close-required item=74270 sha=abc123def456 confidence=high updated_at=2026-05-01T00:00:00Z reviewed_at=[^ ]+ lease_owner=unknown lease_comment_id=unknown source_revision=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef review_activity_cursor=v1:0:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef action_taken=proposed_close reason=implemented_on_main -->/,
   );
   assert.doesNotMatch(comment, /clawsweeper-verdict:needs-human/);
 });

--- a/test/review-comment-rendering.test.ts
+++ b/test/review-comment-rendering.test.ts
@@ -170,7 +170,7 @@ test("structural cache probes before hydration but acquires a lease before carry
   );
   assert.match(
     reviewLoop.slice(structuralRevalidation, structuralWrite),
-    /fetchReviewedPrActivityCursor\(item\.number\)[\s\S]*reviewActivityMatches[\s\S]*review_activity_cursor/,
+    /readStableReviewedPrActivityCursor\(\(\) =>[\s\S]*fetchReviewedPrActivityCursor\(item\.number\)[\s\S]*reviewActivityMatches[\s\S]*review_activity_cursor/,
   );
   const structuralProbeSource = source.slice(
     source.indexOf("function fetchReviewStructuralRecord"),
@@ -258,7 +258,11 @@ test("semantic cache runs after hydration and revalidates under the acquired lea
   );
   assert.match(
     reviewLoop.slice(semanticRevalidation, semanticWrite),
-    /fetchReviewedPrActivityCursor\(item\.number\)[\s\S]*reviewActivityMatches[\s\S]*review_activity_cursor/,
+    /readStableReviewedPrActivityCursor\(\(\) =>[\s\S]*fetchReviewedPrActivityCursor\(item\.number\)[\s\S]*reviewActivityMatches[\s\S]*review_activity_cursor/,
+  );
+  assert.match(
+    reviewLoop.slice(semanticWrite, contentCache),
+    /readStableReviewedPrActivityCursor\(\(\) =>[\s\S]*fetchReviewedPrActivityCursor\(item\.number\)[\s\S]*contentCacheReviewActivityMatches/,
   );
   assert.match(
     reviewLoop.slice(localRangeGuard, semanticDecision),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where ClawSweeper could reuse a trusted pull-request verdict and continue apply or automerge mutations after a human added a review, inline comment, or review-thread resolution change.

## Why This Change Was Made

Adds a bounded digest-only cursor over reviews, inline comments, and thread resolution state. Review reuse performs stable two-scan reads; trusted automerge and apply revalidate immediately before each mutation request; incomplete, unstable, or cursor-less legacy state fails closed for a fresh review. Cursor ordering is locale-independent.

This restores only review-activity freshness from the reverted lifecycle work. It does not restore raw review logs, broad workflow transactions, or the wider https://github.com/openclaw/clawsweeper/pull/521 architecture.

## User Impact

Maintainers can rely on new review activity stopping stale labels, repair/review dispatch, apply, and merge actions before the next GitHub mutation. Existing cursor-less verdicts pause until refreshed instead of being trusted silently.

## Evidence

- both TypeScript builds pass
- focused final suite: 29 passed, 0 failed
- full repair suite: 718 passed, 0 failed
- broader apply/review suite: 197 passed, 0 failed
- real English and Turkish child processes produce the same cursor digest
- focused lint, format, and `git diff --check` pass
- GitHub CI has no failures; final `pnpm check` is still running
- exact-head ClawSweeper review: correctness 0.95, no findings, security cleared
