### PR TITLE
fix(repair): preserve immutable retry inputs

### DIFF
--- a/.github/workflows/repair-cluster-worker.yml
+++ b/.github/workflows/repair-cluster-worker.yml
@@ -128,6 +128,7 @@ jobs:
       allow_fix_pr: ${{ steps.capture_gates.outputs.allow_fix_pr }}
       allow_merge: ${{ steps.capture_gates.outputs.allow_merge }}
       job_exists: ${{ steps.check_job.outputs.job_exists }}
+      effective_mode: ${{ steps.recovery_inputs.outputs.effective_mode }}
     env:
       CLAWSWEEPER_ALLOWED_OWNER: ${{ vars.CLAWSWEEPER_ALLOWED_OWNER || 'openclaw' }}
       CLAWSWEEPER_ALLOW_EXECUTE: ${{ (inputs.mode == 'execute' || inputs.mode == 'autonomous') && vars.CLAWSWEEPER_ALLOW_EXECUTE == '1' && '1' || '0' }}
@@ -148,6 +149,117 @@ jobs:
       - uses: actions/checkout@v7
         with:
           filter: blob:none
+
+      - name: Persist immutable recovery inputs
+        id: recovery_inputs
+        env:
+          SOURCE_JOB: ${{ inputs.job }}
+          SOURCE_DISPATCH_KEY: ${{ inputs.dispatch_key }}
+          REQUESTED_MODE: ${{ inputs.mode }}
+          RUNNER_LABEL: ${{ inputs.runner }}
+          EXECUTION_RUNNER_LABEL: ${{ inputs.execution_runner }}
+          PLANNER_SANDBOX: ${{ inputs.planner_sandbox }}
+          MODEL: ${{ inputs.model }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          REQUEUE: ${{ inputs.requeue }}
+          REQUEUE_DEPTH: ${{ inputs.requeue_depth }}
+        run: |
+          set -euo pipefail
+          effective_mode="$REQUESTED_MODE"
+          if [ "$effective_mode" != "plan" ] && [ "${CLAWSWEEPER_ALLOW_EXECUTE}" != "1" ]; then
+            echo "CLAWSWEEPER_ALLOW_EXECUTE is not explicitly 1; persisting plan-only mode for requested $effective_mode run"
+            effective_mode="plan"
+          fi
+          mkdir -p .clawsweeper-repair/recovery-inputs
+          EFFECTIVE_MODE="$effective_mode" node <<'NODE'
+          const fs = require("node:fs");
+          const path = require("node:path");
+          const boolean = (name) => {
+            const value = process.env[name];
+            if (value === "true") return true;
+            if (value === "false") return false;
+            throw new Error(`${name} must be true or false`);
+          };
+          const bounded = (name, maxLength, allowEmpty = false) => {
+            const value = process.env[name] || "";
+            if (
+              (!allowEmpty && value.length === 0) ||
+              value !== value.trim() ||
+              value.length > maxLength ||
+              /[\u0000-\u001f\u007f]/.test(value)
+            ) {
+              throw new Error(`${name} is invalid`);
+            }
+            return value;
+          };
+          const sourceJob = process.env.SOURCE_JOB || "";
+          const normalizedJob = path.posix.normalize(sourceJob.replaceAll("\\", "/"));
+          if (
+            !normalizedJob.startsWith("jobs/") ||
+            !normalizedJob.endsWith(".md") ||
+            normalizedJob !== sourceJob
+          ) {
+            throw new Error("SOURCE_JOB must be a normalized relative jobs/... markdown path");
+          }
+          if (!["plan", "execute", "autonomous"].includes(process.env.REQUESTED_MODE || "")) {
+            throw new Error("REQUESTED_MODE is invalid");
+          }
+          if (!["plan", "execute", "autonomous"].includes(process.env.EFFECTIVE_MODE || "")) {
+            throw new Error("EFFECTIVE_MODE is invalid");
+          }
+          if (
+            process.env.EFFECTIVE_MODE !== process.env.REQUESTED_MODE &&
+            process.env.EFFECTIVE_MODE !== "plan"
+          ) {
+            throw new Error("EFFECTIVE_MODE must preserve or safely downgrade REQUESTED_MODE");
+          }
+          if (!["read-only", "danger-full-access"].includes(process.env.PLANNER_SANDBOX || "")) {
+            throw new Error("PLANNER_SANDBOX is invalid");
+          }
+          bounded("SOURCE_DISPATCH_KEY", 256, true);
+          bounded("RUNNER_LABEL", 256);
+          bounded("EXECUTION_RUNNER_LABEL", 256);
+          bounded("MODEL", 128);
+          const requeue = boolean("REQUEUE");
+          const requeueDepth = Number(process.env.REQUEUE_DEPTH);
+          if (
+            !Number.isSafeInteger(requeueDepth) ||
+            requeueDepth < 0 ||
+            requeueDepth > 1 ||
+            (requeue && requeueDepth !== 1) ||
+            (!requeue && requeueDepth !== 0)
+          ) {
+            throw new Error("REQUEUE_DEPTH is outside the bounded workflow contract");
+          }
+          const input = {
+            schema_version: 1,
+            source_job: sourceJob,
+            source_dispatch_key: process.env.SOURCE_DISPATCH_KEY || "",
+            requested_mode: process.env.REQUESTED_MODE,
+            effective_mode: process.env.EFFECTIVE_MODE,
+            runner: process.env.RUNNER_LABEL,
+            execution_runner: process.env.EXECUTION_RUNNER_LABEL,
+            planner_sandbox: process.env.PLANNER_SANDBOX,
+            model: process.env.MODEL,
+            dry_run: boolean("DRY_RUN"),
+            requeue,
+            requeue_depth: requeueDepth,
+          };
+          fs.writeFileSync(
+            ".clawsweeper-repair/recovery-inputs/workflow-inputs.json",
+            `${JSON.stringify(input, null, 2)}\n`,
+          );
+          NODE
+          echo "effective_mode=$effective_mode" >> "$GITHUB_OUTPUT"
+
+      - name: Upload immutable recovery inputs
+        uses: actions/upload-artifact@v7
+        with:
+          name: clawsweeper-repair-inputs-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .clawsweeper-repair/recovery-inputs/workflow-inputs.json
+          if-no-files-found: error
+          retention-days: 90
+          include-hidden-files: true
 
       - name: Resolve target owner
         id: target
@@ -308,12 +420,12 @@ jobs:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           CLAWSWEEPER_ALLOWED_OWNER: ${{ steps.target.outputs.target_owner }}
         run: |
-          worker_mode="${{ inputs.mode }}"
-          if [ "$worker_mode" != "plan" ] && [ "${CLAWSWEEPER_ALLOW_EXECUTE}" != "1" ]; then
-            echo "CLAWSWEEPER_ALLOW_EXECUTE is not explicitly 1; rendering plan-only output for requested $worker_mode run"
-            worker_mode="plan"
+          worker_mode="${{ steps.recovery_inputs.outputs.effective_mode }}"
+          if [ -z "$worker_mode" ]; then
+            echo "Persisted effective repair mode is missing." >&2
+            exit 1
           fi
-          args=("${{ inputs.job }}" --mode "$worker_mode")
+          args=("${{ inputs.job }}" --mode "$worker_mode" --model "${{ inputs.model }}")
           if [ "${{ inputs.dry_run }}" = "true" ]; then
             args+=(--dry-run)
           fi
@@ -350,7 +462,7 @@ jobs:
           retention-days: 7
 
       - name: Upload worker transfer artifacts
-        if: ${{ always() && (inputs.mode == 'execute' || inputs.mode == 'autonomous') && !inputs.dry_run }}
+        if: ${{ always() && (steps.recovery_inputs.outputs.effective_mode == 'execute' || steps.recovery_inputs.outputs.effective_mode == 'autonomous') && !inputs.dry_run }}
         uses: actions/upload-artifact@v7
         with:
           name: clawsweeper-repair-worker-${{ github.run_id }}-${{ github.run_attempt }}
@@ -358,7 +470,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Upload final worker artifacts
-        if: ${{ always() && (!((inputs.mode == 'execute' || inputs.mode == 'autonomous') && !inputs.dry_run) || failure() || cancelled()) }}
+        if: ${{ always() && (!((steps.recovery_inputs.outputs.effective_mode == 'execute' || steps.recovery_inputs.outputs.effective_mode == 'autonomous') && !inputs.dry_run) || failure() || cancelled()) }}
         uses: actions/upload-artifact@v7
         with:
           name: clawsweeper-repair-${{ github.run_id }}-${{ github.run_attempt }}
@@ -378,7 +490,7 @@ jobs:
       - name: Record planning completion
         if: ${{ success() && steps.crabfleet_session.outcome == 'success' }}
         run: |
-          if [[ "${{ inputs.mode }}" == "plan" || "${{ inputs.dry_run }}" == "true" ]]; then
+          if [[ "${{ steps.recovery_inputs.outputs.effective_mode }}" == "plan" || "${{ inputs.dry_run }}" == "true" ]]; then
             pnpm run repair:action-session -- update \
               --state completed \
               --phase "done" \
@@ -399,7 +511,7 @@ jobs:
   execute:
     name: Execute and apply cluster actions
     needs: cluster
-    if: ${{ needs.cluster.result == 'success' && needs.cluster.outputs.job_exists == '1' && (inputs.mode == 'execute' || inputs.mode == 'autonomous') && !inputs.dry_run }}
+    if: ${{ needs.cluster.result == 'success' && needs.cluster.outputs.job_exists == '1' && (needs.cluster.outputs.effective_mode == 'execute' || needs.cluster.outputs.effective_mode == 'autonomous') && !inputs.dry_run }}
     runs-on: ${{ inputs.execution_runner }}
     timeout-minutes: 120
     permissions:
@@ -857,7 +969,7 @@ jobs:
           set -euo pipefail
           echo "Requeueing ${{ steps.repair_requeue.outputs.count }} source-head race repair result(s) against the latest head."
           pnpm run repair:requeue -- "${{ inputs.job }}" \
-            --mode "${{ inputs.mode }}" \
+            --mode "${{ needs.cluster.outputs.effective_mode }}" \
             --execute \
             --open-execute-window \
             --wait-for-capacity \
@@ -866,6 +978,8 @@ jobs:
             --max-requeue-depth 1 \
             --runner "${{ inputs.runner }}" \
             --execution-runner "${{ inputs.execution_runner }}" \
+            --planner-sandbox "${{ inputs.planner_sandbox }}" \
+            --dry-run "${{ inputs.dry_run }}" \
             --model "${{ inputs.model }}"
 
       - name: Finalize repair requeue action ledger

--- a/.github/workflows/repair-self-heal.yml
+++ b/.github/workflows/repair-self-heal.yml
@@ -85,19 +85,22 @@ jobs:
           CLAWSWEEPER_ALLOW_EXECUTE: ${{ vars.CLAWSWEEPER_ALLOW_EXECUTE || '0' }}
           CLAWSWEEPER_ALLOW_FIX_PR: ${{ vars.CLAWSWEEPER_ALLOW_FIX_PR || '0' }}
           CLAWSWEEPER_MODEL: internal
+          CLAWSWEEPER_WORKER_RUNNER: ${{ vars.CLAWSWEEPER_WORKER_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+          CLAWSWEEPER_EXECUTION_RUNNER: ${{ vars.CLAWSWEEPER_EXECUTION_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
           CLAWSWEEPER_SELF_HEAL_MAX_ATTEMPTS_PER_JOB: ${{ vars.CLAWSWEEPER_SELF_HEAL_MAX_ATTEMPTS_PER_JOB || '3' }}
         run: |
           execute="false"
           max_jobs="${{ github.event_name == 'workflow_dispatch' && inputs.max_jobs || vars.CLAWSWEEPER_SELF_HEAL_MAX_JOBS || '5' }}"
           max_age_hours="${{ github.event_name == 'workflow_dispatch' && inputs.max_age_hours || vars.CLAWSWEEPER_SELF_HEAL_MAX_AGE_HOURS || '6' }}"
-          runner="${{ github.event_name == 'workflow_dispatch' && inputs.runner || vars.CLAWSWEEPER_WORKER_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}"
-          execution_runner="${{ github.event_name == 'workflow_dispatch' && inputs.execution_runner || vars.CLAWSWEEPER_EXECUTION_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}"
           if { [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.execute }}" = "true" ]; } ||
              { [ "${{ github.event_name }}" = "schedule" ] && [ "${{ vars.CLAWSWEEPER_SELF_HEAL_EXECUTE || '0' }}" = "1" ]; }; then
             execute="true"
           fi
 
-          args=(--max-jobs "$max_jobs" --max-age-hours "$max_age_hours" --runner "$runner" --execution-runner "$execution_runner" --wait-for-capacity)
+          args=(--max-jobs "$max_jobs" --max-age-hours "$max_age_hours" --wait-for-capacity)
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            args+=(--runner "${{ inputs.runner }}" --execution-runner "${{ inputs.execution_runner }}")
+          fi
           if [ "$execute" = "true" ]; then
             args+=(--execute)
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,10 @@ checkpoint, and status-only commits are intentionally omitted.
   parent, terminating the complete credentialed execute process group before
   timeout finalization, and allowing later observed outcomes to supersede stale
   unknown state.
+- Preserved the repair worker's original replay-safe Action inputs in an early,
+  attempt-scoped artifact so bounded requeues and failed-run self-heal retries
+  reuse the actual effective mode, runners, sandbox, model, and dry-run state
+  instead of mutable workflow defaults.
 - Stopped narrow OpenClaw automerge repairs from chasing unrelated full-repository lint and typecheck failures.
 - Removed the synthetic Codex write preflight that could block repair before Codex saw the real task.
 - Kept exact-review handoff health live when the dashboard serves a stale fleet snapshot, so recovered claims no longer leave the operator rail stuck in a delayed or stalled state.

--- a/src/repair/requeue-job.ts
+++ b/src/repair/requeue-job.ts
@@ -31,6 +31,13 @@ import {
   deterministicRequeueDispatchKey,
   normalizedRequeueSourceJobPath,
 } from "./requeue-job-key.js";
+import {
+  isRepairWorkflowArtifactUnavailable,
+  readNewestRepairLegacyRecoveryInputs,
+  readNewestRepairWorkflowRecoveryInputs,
+  resolveRepairWorkflowRetryMode,
+  type RepairWorkflowRecoveryInputs,
+} from "./workflow-recovery-inputs.js";
 
 const DEFAULT_REPO = currentProjectRepo();
 const DEFAULT_WORKFLOW = REPAIR_CLUSTER_WORKFLOW;
@@ -38,39 +45,62 @@ const DEFAULT_RUNNER = process.env.CLAWSWEEPER_WORKER_RUNNER ?? "blacksmith-4vcp
 const DEFAULT_EXECUTION_RUNNER =
   process.env.CLAWSWEEPER_EXECUTION_RUNNER ?? "blacksmith-16vcpu-ubuntu-2404";
 const QUEUED_STATUSES = new Set(["queued", "requested", "waiting", "pending"]);
+const WORKFLOW_INPUT_DOWNLOAD_TIMEOUT_MS = 60_000;
 
 const args = parseArgs(process.argv.slice(2));
 const repo = String(args.repo ?? DEFAULT_REPO);
 const workflow = String(args.workflow ?? DEFAULT_WORKFLOW);
-const runner = String(args.runner ?? DEFAULT_RUNNER);
+const requestedMode = typeof args.mode === "string" ? args.mode : null;
+const requestedRunId = args["run-id"] ?? (looksLikeRunId(args._[0]) ? args._[0] : null);
+const resolved: ResolvedRequeueSource = requestedRunId
+  ? resolveFromRunId(String(requestedRunId))
+  : { source_job: args._[0], mode: requestedMode, workflow_inputs: null };
+const recoveredInputs = resolved.workflow_inputs;
+const runner = String(args.runner ?? recoveredInputs?.runner ?? DEFAULT_RUNNER);
 const executionRunner = String(
-  args["execution-runner"] ?? args.execution_runner ?? DEFAULT_EXECUTION_RUNNER,
+  args["execution-runner"] ??
+    args.execution_runner ??
+    recoveredInputs?.execution_runner ??
+    DEFAULT_EXECUTION_RUNNER,
 );
-const model = String(args.model ?? process.env.CLAWSWEEPER_MODEL ?? "internal");
+const plannerSandbox = String(
+  args["planner-sandbox"] ??
+    args.planner_sandbox ??
+    recoveredInputs?.planner_sandbox ??
+    "read-only",
+);
+if (!["read-only", "danger-full-access"].includes(plannerSandbox)) {
+  throw new Error(`unsupported planner sandbox: ${plannerSandbox}`);
+}
+const model = String(
+  args.model ?? recoveredInputs?.model ?? process.env.CLAWSWEEPER_MODEL ?? "internal",
+);
+const dryRun = booleanArg(
+  args["dry-run"] ?? args.dry_run,
+  recoveredInputs?.dry_run ?? Boolean(requestedRunId),
+);
 const maxLiveWorkers = readMaxLiveWorkers(args);
 const waitForCapacity = Boolean(args["wait-for-capacity"]);
 const execute = Boolean(args.execute || args.live);
 const openExecuteWindow = Boolean(args["open-execute-window"] || args.live);
-const requestedMode = typeof args.mode === "string" ? args.mode : null;
-const requestedRunId = args["run-id"] ?? (looksLikeRunId(args._[0]) ? args._[0] : null);
 const sourceRunId = String(
   args["source-run-id"] ?? requestedRunId ?? process.env.GITHUB_RUN_ID ?? "",
 ).trim();
-const requeueDepth = nonNegativeIntegerArg(args["requeue-depth"], "requeue-depth", 0);
+const requeueDepth = nonNegativeIntegerArg(
+  args["requeue-depth"],
+  "requeue-depth",
+  recoveredInputs?.requeue_depth ?? 0,
+);
 const maxRequeueDepth = nonNegativeIntegerArg(args["max-requeue-depth"], "max-requeue-depth", 1);
-
-const resolved = requestedRunId
-  ? resolveFromRunId(String(requestedRunId))
-  : { source_job: args._[0], mode: requestedMode };
 
 if (!resolved.source_job) {
   console.error(
-    `usage: node scripts/requeue-job.ts <job.md|run-id> [--mode plan|execute|autonomous] [--execute] [--open-execute-window] [--source-run-id id] [--source-job-path path] [--requeue-depth n] [--max-requeue-depth n] [--runner label] [--execution-runner label] [--model model] [--max-live-workers ${AUTOMATION_LIMITS.repair_live_runs.default}] [--wait-for-capacity]`,
+    `usage: node scripts/requeue-job.ts <job.md|run-id> [--mode plan|execute|autonomous] [--execute] [--open-execute-window] [--source-run-id id] [--source-job-path path] [--requeue-depth n] [--max-requeue-depth n] [--runner label] [--execution-runner label] [--planner-sandbox read-only|danger-full-access] [--model model] [--dry-run true|false] [--max-live-workers ${AUTOMATION_LIMITS.repair_live_runs.default}] [--wait-for-capacity]`,
   );
   process.exit(2);
 }
 
-const job = parseJob(resolved.source_job);
+const job = parseJob(String(resolved.source_job));
 const sourceJobPath = normalizedRequeueSourceJobPath(args["source-job-path"], job.relativePath);
 const authorizationSha256 = createHash("sha256").update(job.raw).digest("hex");
 const errors = validateJob(job);
@@ -80,10 +110,11 @@ if (errors.length > 0) {
   process.exit(1);
 }
 
-const mode = requestedMode ?? resolved.mode ?? job.frontmatter.mode;
-if (!["plan", "execute", "autonomous"].includes(mode)) {
-  throw new Error(`unsupported mode: ${mode}`);
-}
+const mode = resolveRepairWorkflowRetryMode({
+  requestedMode,
+  recoveredMode: recoveredInputs?.effective_mode ?? (requestedRunId ? "plan" : null),
+  fallbackMode: resolved.mode ?? job.frontmatter.mode,
+});
 
 const summary: LooseRecord = {
   status: execute ? "dispatching" : "dry_run",
@@ -97,7 +128,9 @@ const summary: LooseRecord = {
   mode,
   runner,
   execution_runner: executionRunner,
+  planner_sandbox: plannerSandbox,
   model,
+  dry_run: dryRun,
   max_live_workers: maxLiveWorkers,
 };
 
@@ -127,14 +160,14 @@ const requeueLifecycle: CommandLifecycleInput = {
 let commandError: unknown = null;
 
 try {
-  if (openExecuteWindow && ["execute", "autonomous"].includes(mode)) {
+  if (!dryRun && openExecuteWindow && ["execute", "autonomous"].includes(mode)) {
     openGate("CLAWSWEEPER_ALLOW_EXECUTE", requeueLifecycle);
     if (job.frontmatter.allow_fix_pr === true || job.frontmatter.allowed_actions.includes("fix")) {
       openGate("CLAWSWEEPER_ALLOW_FIX_PR", requeueLifecycle);
     }
   }
 
-  assertGateOpenIfNeeded(mode);
+  assertGateOpenIfNeeded(mode, dryRun);
   summary.live_worker_capacity_before_dispatch = waitForCapacity
     ? waitForLiveWorkerCapacity({ repo, workflow, requested: 1, maxLiveWorkers })
     : assertLiveWorkerCapacity({ repo, workflow, requested: 1, maxLiveWorkers });
@@ -197,41 +230,100 @@ if (commandError) throw commandError;
 
 function resolveFromRunId(runId: string) {
   const fromLedger = readPublishedRunRecord(runId);
-  if (fromLedger?.source_job) {
-    return { source_job: fromLedger.source_job, mode: fromLedger.mode };
-  }
-
   const artifactDir = fs.mkdtempSync(
     path.join(os.tmpdir(), `clawsweeper-repair-requeue-${runId}-`),
   );
-  const downloaded = spawnSync(
-    "gh",
-    ["run", "download", runId, "--repo", repo, "--dir", artifactDir],
-    { cwd: repoRoot(), encoding: "utf8", stdio: "pipe" },
-  );
-  if (downloaded.status !== 0) {
-    throw new Error(`could not resolve run ${runId}: ${downloaded.stderr || downloaded.stdout}`);
+  try {
+    const recoveryDir = path.join(artifactDir, "recovery");
+    fs.mkdirSync(recoveryDir);
+    const recoveryDownload = downloadRunArtifacts(
+      runId,
+      recoveryDir,
+      `clawsweeper-repair-inputs-${runId}-*`,
+    );
+    if (recoveryDownload.status === 0) {
+      const workflowInputs = readNewestRepairWorkflowRecoveryInputs(recoveryDir, runId);
+      if (!workflowInputs) {
+        throw new Error(`run ${runId} recovery artifact did not contain immutable inputs`);
+      }
+      const ledgerSourceJob = String(fromLedger?.source_job ?? "").trim();
+      if (ledgerSourceJob && ledgerSourceJob !== workflowInputs.source_job) {
+        throw new Error(`run ${runId} record conflicts with its immutable workflow inputs`);
+      }
+      return {
+        source_job: workflowInputs.source_job,
+        mode: workflowInputs.effective_mode,
+        workflow_inputs: workflowInputs,
+      };
+    }
+    if (!isRepairWorkflowArtifactUnavailable(recoveryDownload.stderr, recoveryDownload.stdout)) {
+      throw new Error(`could not resolve run ${runId}: ${artifactDownloadError(recoveryDownload)}`);
+    }
+    if (fromLedger?.source_job) {
+      return {
+        source_job: fromLedger.source_job,
+        mode: fromLedger.mode,
+        workflow_inputs: null,
+      };
+    }
+
+    const legacyDir = path.join(artifactDir, "legacy");
+    fs.mkdirSync(legacyDir);
+    const legacyDownloads = [
+      `clawsweeper-repair-${runId}-*`,
+      `clawsweeper-repair-worker-${runId}-*`,
+    ].map((pattern) => downloadRunArtifacts(runId, legacyDir, pattern));
+    const failedLegacyDownload = legacyDownloads.find(
+      (download) =>
+        download.status !== 0 &&
+        !isRepairWorkflowArtifactUnavailable(download.stderr, download.stdout),
+    );
+    if (failedLegacyDownload) {
+      throw new Error(
+        `could not resolve run ${runId}: ${artifactDownloadError(failedLegacyDownload)}`,
+      );
+    }
+    if (legacyDownloads.some((download) => download.status === 0)) {
+      const legacyInputs = readNewestRepairLegacyRecoveryInputs(legacyDir, runId);
+      if (legacyInputs) {
+        return {
+          source_job: legacyInputs.source_job,
+          mode: legacyInputs.mode,
+          workflow_inputs: null,
+        };
+      }
+      throw new Error(`run ${runId} legacy artifact did not contain one complete repair cohort`);
+    }
+    throw new Error(
+      `could not resolve run ${runId}: ${legacyDownloads.map(artifactDownloadError).join("; ")}`,
+    );
+  } finally {
+    fs.rmSync(artifactDir, { recursive: true, force: true });
   }
-  const planPath = findFirstFile(artifactDir, "cluster-plan.json");
-  const resultPath = findFirstFile(artifactDir, "result.json");
-  if (!planPath) throw new Error(`run ${runId} artifact did not include cluster-plan.json`);
-  const plan = JSON.parse(fs.readFileSync(planPath, "utf8"));
-  const result = resultPath ? JSON.parse(fs.readFileSync(resultPath, "utf8")) : null;
-  return { source_job: plan.source_job, mode: result?.mode ?? plan.mode };
+}
+
+function downloadRunArtifacts(runId: string, outputDir: string, pattern: string) {
+  return spawnSync(
+    "gh",
+    ["run", "download", runId, "--repo", repo, "--dir", outputDir, "--pattern", pattern],
+    {
+      cwd: repoRoot(),
+      encoding: "utf8",
+      stdio: "pipe",
+      timeout: WORKFLOW_INPUT_DOWNLOAD_TIMEOUT_MS,
+      maxBuffer: 1024 * 1024,
+    },
+  );
+}
+
+function artifactDownloadError(result: ReturnType<typeof downloadRunArtifacts>) {
+  return result.stderr || result.stdout || result.error?.message || "artifact unavailable";
 }
 
 function readPublishedRunRecord(runId: string) {
   const file = path.join(repoRoot(), "results", "runs", `${runId}.json`);
   if (!fs.existsSync(file)) return null;
   return JSON.parse(fs.readFileSync(file, "utf8"));
-}
-
-function findFirstFile(root: string, basename: string) {
-  for (const entry of fs.readdirSync(root, { recursive: true })) {
-    const candidate = path.join(root, String(entry));
-    if (path.basename(candidate) === basename && fs.statSync(candidate).isFile()) return candidate;
-  }
-  return null;
 }
 
 function dispatchJob(
@@ -271,7 +363,11 @@ function dispatchJob(
           "-f",
           `execution_runner=${executionRunner}`,
           "-f",
+          `planner_sandbox=${plannerSandbox}`,
+          "-f",
           `model=${model}`,
+          "-f",
+          `dry_run=${dryRun}`,
           "-f",
           "requeue=true",
           "-f",
@@ -308,7 +404,8 @@ function waitForStartedRuns({ expectedCount, headSha, since }: LooseRecord) {
   return latest.slice(-expectedCount);
 }
 
-function assertGateOpenIfNeeded(mode: string) {
+function assertGateOpenIfNeeded(mode: string, isDryRun: boolean) {
+  if (isDryRun) return;
   if (!["execute", "autonomous"].includes(mode)) return;
   if (readGate("CLAWSWEEPER_ALLOW_EXECUTE") !== "1") {
     throw new Error(
@@ -378,3 +475,16 @@ function nonNegativeIntegerArg(value: JsonValue, name: string, fallback: number)
   }
   return parsed;
 }
+
+function booleanArg(value: JsonValue, fallback: boolean): boolean {
+  if (value === undefined || value === null || value === "") return fallback;
+  if (value === true || value === "true") return true;
+  if (value === false || value === "false") return false;
+  throw new Error("boolean arguments must be true or false");
+}
+
+type ResolvedRequeueSource = {
+  source_job: JsonValue;
+  mode: string | null;
+  workflow_inputs: RepairWorkflowRecoveryInputs | null;
+};

--- a/src/repair/self-heal-failed-runs.ts
+++ b/src/repair/self-heal-failed-runs.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import type { JsonValue, LooseRecord } from "./json-types.js";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { execFileSync, spawnSync } from "node:child_process";
 import {
@@ -16,6 +17,13 @@ import {
 import { ghErrorText, ghJson, ghText } from "./github-cli.js";
 import { sleepMs } from "./timing.js";
 import { REPAIR_CLUSTER_WORKFLOW } from "./constants.js";
+import {
+  boundedRecoveryTimeoutMs,
+  isRepairWorkflowArtifactUnavailable,
+  readNewestRepairWorkflowRecoveryInputs,
+  resolveRepairWorkflowRetryMode,
+  type RepairWorkflowRecoveryInputs,
+} from "./workflow-recovery-inputs.js";
 
 const DEFAULT_REPO = currentProjectRepo();
 const DEFAULT_WORKFLOW = REPAIR_CLUSTER_WORKFLOW;
@@ -24,6 +32,9 @@ const DEFAULT_EXECUTION_RUNNER =
   process.env.CLAWSWEEPER_EXECUTION_RUNNER ?? "blacksmith-16vcpu-ubuntu-2404";
 const QUEUED_STATUSES = new Set(["queued", "requested", "waiting", "pending"]);
 const ACTIVE_STATUSES = new Set([...QUEUED_STATUSES, "in_progress"]);
+const WORKFLOW_INPUT_DOWNLOAD_TIMEOUT_MS = 60_000;
+const RECOVERY_SCAN_BUDGET_MS = 3 * 60_000;
+const MAX_RECOVERY_CANDIDATE_SCANS = 200;
 
 const args = parseArgs(process.argv.slice(2));
 const repo = String(args.repo ?? DEFAULT_REPO);
@@ -59,7 +70,7 @@ if (!Number.isInteger(maxAttemptsPerJob) || maxAttemptsPerJob < 1) {
   throw new Error("CLAWSWEEPER_SELF_HEAL_MAX_ATTEMPTS_PER_JOB must be a positive integer");
 }
 
-const candidates = selectCandidates().slice(0, maxJobs);
+const candidates = selectCandidates();
 const summary: LooseRecord = {
   status: execute ? "dispatching" : "dry_run",
   repo,
@@ -96,10 +107,15 @@ const attempts: LooseRecord[] = candidates.map((candidate: JsonValue) => ({
   source_run_id: candidate.run_id,
   cluster_id: candidate.cluster_id,
   source_job: candidate.source_job,
+  source_dispatch_key: candidate.source_dispatch_key,
   mode: candidate.mode,
-  runner,
-  execution_runner: executionRunner,
-  model,
+  runner: candidate.runner,
+  execution_runner: candidate.execution_runner,
+  planner_sandbox: candidate.planner_sandbox,
+  model: candidate.model,
+  dry_run: candidate.dry_run,
+  requeue: candidate.requeue,
+  requeue_depth: candidate.requeue_depth,
   workflow,
   repo,
   dispatched_at: new Date().toISOString(),
@@ -178,12 +194,18 @@ function selectCandidates() {
       continue;
     }
     const current = latestByJob.get(sourceJob);
-    if (!current || runSortKey(record) > runSortKey(current)) {
+    const recordSortKey = runSortKey(record);
+    const currentSortKey = current ? runSortKey(current) : Number.NEGATIVE_INFINITY;
+    if (
+      !current ||
+      recordSortKey > currentSortKey ||
+      (recordSortKey === currentSortKey && record.live_run_record === true)
+    ) {
       latestByJob.set(sourceJob, record);
     }
   }
 
-  return [...latestByJob.values()]
+  const eligible = [...latestByJob.values()]
     .filter((record: JsonValue) => record.workflow_conclusion === "failure")
     .filter((record: JsonValue) => {
       const timestamp = recordTimestampMs(record);
@@ -224,29 +246,80 @@ function selectCandidates() {
       });
       return false;
     })
-    .map((record: JsonValue) => {
-      const sourceJob = String(record.source_job ?? "");
-      const jobPath = sourceJobPath(sourceJob);
-      if (!fs.existsSync(jobPath)) {
-        skippedCandidates.push({
-          reason: "missing_job_file",
-          run_id: record.run_id ?? null,
-          source_job: sourceJob,
-        });
-        return null;
-      }
-      const job = parseJob(jobPath);
-      const errors = validateJob(job);
-      if (errors.length > 0) {
-        throw new Error(`invalid job ${record.source_job}: ${errors.join("; ")}`);
-      }
-      return {
-        ...record,
-        mode: requestedMode ?? record.mode ?? job.frontmatter.mode,
-      };
-    })
-    .filter(Boolean)
     .sort((left: JsonValue, right: JsonValue) => runSortKey(right) - runSortKey(left));
+  const boundedEligible = eligible.slice(0, MAX_RECOVERY_CANDIDATE_SCANS);
+  const recoveryDeadlineMs = Date.now() + RECOVERY_SCAN_BUDGET_MS;
+  const selected: LooseRecord[] = [];
+  for (const record of boundedEligible) {
+    if (selected.length >= maxJobs) break;
+    const sourceJob = String(record.source_job ?? "");
+    const jobPath = sourceJobPath(sourceJob);
+    if (!fs.existsSync(jobPath)) {
+      skippedCandidates.push({
+        reason: "missing_job_file",
+        run_id: record.run_id ?? null,
+        source_job: sourceJob,
+      });
+      continue;
+    }
+    const job = parseJob(jobPath);
+    const errors = validateJob(job);
+    if (errors.length > 0) {
+      throw new Error(`invalid job ${record.source_job}: ${errors.join("; ")}`);
+    }
+    let recoveredInputs: RepairWorkflowRecoveryInputs | null = null;
+    const recoveryTimeoutMs = boundedRecoveryTimeoutMs({
+      deadlineMs: recoveryDeadlineMs,
+      nowMs: Date.now(),
+      maxTimeoutMs: WORKFLOW_INPUT_DOWNLOAD_TIMEOUT_MS,
+    });
+    if (recoveryTimeoutMs === 0) {
+      skippedCandidates.push({
+        reason: "recovery_budget_exhausted",
+        run_id: record.run_id ?? null,
+        source_job: sourceJob,
+      });
+      break;
+    }
+    try {
+      recoveredInputs = recoverWorkflowInputs(record, recoveryTimeoutMs);
+    } catch (error) {
+      skippedCandidates.push({
+        reason: "immutable_inputs_invalid",
+        run_id: record.run_id ?? null,
+        source_job: sourceJob,
+        detail: error instanceof Error ? error.message : String(error),
+      });
+      continue;
+    }
+    selected.push({
+      ...record,
+      mode: resolveRepairWorkflowRetryMode({
+        requestedMode,
+        recoveredMode: recoveredInputs?.effective_mode ?? "plan",
+        fallbackMode: record.mode ?? job.frontmatter.mode,
+      }),
+      runner: String(args.runner ?? recoveredInputs?.runner ?? runner),
+      execution_runner: String(
+        args["execution-runner"] ??
+          args.execution_runner ??
+          recoveredInputs?.execution_runner ??
+          executionRunner,
+      ),
+      planner_sandbox: String(
+        args["planner-sandbox"] ??
+          args.planner_sandbox ??
+          recoveredInputs?.planner_sandbox ??
+          "read-only",
+      ),
+      model: String(args.model ?? recoveredInputs?.model ?? model),
+      dry_run: booleanArg(args["dry-run"] ?? args.dry_run, recoveredInputs?.dry_run ?? true),
+      requeue: recoveredInputs?.requeue ?? false,
+      requeue_depth: recoveredInputs?.requeue_depth ?? 0,
+      source_dispatch_key: recoveredInputs?.source_dispatch_key ?? null,
+    });
+  }
+  return selected;
 }
 
 function sourceJobPath(sourceJob: string) {
@@ -276,7 +349,7 @@ function activeRepairSourceJobs() {
 function sourceJobFromRunTitle(title: string) {
   const index = title.indexOf("jobs/");
   if (index < 0) return null;
-  return title.slice(index).trim();
+  return title.slice(index).match(/^jobs\/[A-Za-z0-9_./-]+\.md\b/)?.[0] ?? null;
 }
 
 function dispatchCandidate(candidate: LooseRecord) {
@@ -293,11 +366,19 @@ function dispatchCandidate(candidate: LooseRecord) {
       "-f",
       `mode=${candidate.mode}`,
       "-f",
-      `runner=${runner}`,
+      `runner=${candidate.runner}`,
       "-f",
-      `execution_runner=${executionRunner}`,
+      `execution_runner=${candidate.execution_runner}`,
       "-f",
-      `model=${model}`,
+      `planner_sandbox=${candidate.planner_sandbox}`,
+      "-f",
+      `model=${candidate.model}`,
+      "-f",
+      `dry_run=${candidate.dry_run}`,
+      "-f",
+      `requeue=${candidate.requeue}`,
+      "-f",
+      `requeue_depth=${candidate.requeue_depth}`,
     ],
     { cwd: repoRoot(), encoding: "utf8", stdio: "pipe" },
   );
@@ -333,7 +414,10 @@ function waitForStartedRuns({ expectedCount, headSha, since }: LooseRecord) {
 
 function assertExecuteGateOpenIfNeeded(candidates: LooseRecord[]) {
   if (
-    !candidates.some((candidate: JsonValue) => ["execute", "autonomous"].includes(candidate.mode))
+    !candidates.some(
+      (candidate: JsonValue) =>
+        candidate.dry_run !== true && ["execute", "autonomous"].includes(candidate.mode),
+    )
   )
     return;
   const current = readExecuteGate();
@@ -374,6 +458,7 @@ function liveRunRecords() {
           workflow_created_at: run.createdAt ?? null,
           workflow_updated_at: run.updatedAt ?? null,
           run_url: run.url ?? null,
+          live_run_record: true,
         };
       })
       .filter(Boolean);
@@ -496,7 +581,73 @@ function summarizeCandidate(candidate: LooseRecord) {
     cluster_id: candidate.cluster_id,
     source_job: candidate.source_job,
     mode: candidate.mode,
+    runner: candidate.runner,
+    execution_runner: candidate.execution_runner,
+    planner_sandbox: candidate.planner_sandbox,
+    model: candidate.model,
+    dry_run: candidate.dry_run,
+    requeue: candidate.requeue,
+    requeue_depth: candidate.requeue_depth,
     result_status: candidate.result_status,
     run_url: candidate.run_url,
   };
+}
+
+function recoverWorkflowInputs(
+  record: LooseRecord,
+  timeoutMs: number,
+): RepairWorkflowRecoveryInputs | null {
+  const runId = String(record.run_id ?? "").trim();
+  if (!/^[1-9][0-9]*$/.test(runId)) return null;
+  const artifactDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), `clawsweeper-self-heal-inputs-${runId}-`),
+  );
+  try {
+    const downloaded = spawnSync(
+      "gh",
+      [
+        "run",
+        "download",
+        runId,
+        "--repo",
+        repo,
+        "--dir",
+        artifactDir,
+        "--pattern",
+        `clawsweeper-repair-inputs-${runId}-*`,
+      ],
+      {
+        cwd: repoRoot(),
+        encoding: "utf8",
+        stdio: "pipe",
+        timeout: timeoutMs,
+        maxBuffer: 1024 * 1024,
+      },
+    );
+    if (downloaded.status !== 0) {
+      if (isRepairWorkflowArtifactUnavailable(downloaded.stderr, downloaded.stdout)) return null;
+      throw new Error(
+        `could not recover run ${runId} inputs: ${
+          downloaded.stderr ||
+          downloaded.stdout ||
+          downloaded.error?.message ||
+          "artifact unavailable"
+        }`,
+      );
+    }
+    const recovered = readNewestRepairWorkflowRecoveryInputs(artifactDir, runId);
+    if (recovered && recovered.source_job !== String(record.source_job ?? "")) {
+      throw new Error(`run ${runId} immutable inputs conflict with the selected source job`);
+    }
+    return recovered;
+  } finally {
+    fs.rmSync(artifactDir, { recursive: true, force: true });
+  }
+}
+
+function booleanArg(value: JsonValue, fallback: boolean): boolean {
+  if (value === undefined || value === null || value === "") return fallback;
+  if (value === true || value === "true") return true;
+  if (value === false || value === "false") return false;
+  throw new Error("boolean arguments must be true or false");
 }

--- a/src/repair/workflow-recovery-inputs.ts
+++ b/src/repair/workflow-recovery-inputs.ts
@@ -1,0 +1,398 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import type { LooseRecord } from "./json-types.js";
+
+const MAX_INPUT_BYTES = 16 * 1024;
+const MAX_ARTIFACT_ENTRIES = 256;
+const MAX_ARTIFACT_DEPTH = 4;
+const REPAIR_MODES = new Set(["plan", "execute", "autonomous"]);
+const PLANNER_SANDBOXES = new Set(["read-only", "danger-full-access"]);
+const CURRENT_INPUT_KEYS = [
+  "dry_run",
+  "effective_mode",
+  "execution_runner",
+  "model",
+  "planner_sandbox",
+  "requested_mode",
+  "requeue",
+  "requeue_depth",
+  "runner",
+  "schema_version",
+  "source_dispatch_key",
+  "source_job",
+].sort();
+const LEGACY_INPUT_KEYS = [
+  "effective_mode",
+  "job_sha256",
+  "requested_mode",
+  "schema_version",
+  "source_job",
+  "state_revision",
+].sort();
+
+export const REPAIR_WORKFLOW_INPUTS_BASENAME = "workflow-inputs.json";
+
+export type RepairWorkflowMode = "plan" | "execute" | "autonomous";
+
+type CurrentRepairWorkflowRecoveryInputs = {
+  schema_version: 1;
+  source_job: string;
+  source_dispatch_key: string;
+  requested_mode: RepairWorkflowMode;
+  effective_mode: RepairWorkflowMode;
+  runner: string;
+  execution_runner: string;
+  planner_sandbox: "read-only" | "danger-full-access";
+  model: string;
+  dry_run: boolean;
+  requeue: boolean;
+  requeue_depth: number;
+  state_revision?: never;
+  job_sha256?: never;
+};
+
+type LegacyRepairWorkflowRecoveryInputs = {
+  schema_version: 1;
+  source_job: string;
+  requested_mode: RepairWorkflowMode;
+  effective_mode: RepairWorkflowMode;
+  state_revision: string;
+  job_sha256: string;
+  source_dispatch_key?: never;
+  runner?: never;
+  execution_runner?: never;
+  planner_sandbox?: never;
+  model?: never;
+  dry_run?: never;
+  requeue?: never;
+  requeue_depth?: never;
+};
+
+export type RepairWorkflowRecoveryInputs =
+  | CurrentRepairWorkflowRecoveryInputs
+  | LegacyRepairWorkflowRecoveryInputs;
+
+export type RepairLegacyRecoveryInputs = {
+  source_job: string;
+  mode: RepairWorkflowMode;
+  producer_attempt: number;
+};
+
+export function boundedRecoveryTimeoutMs({
+  deadlineMs,
+  nowMs,
+  maxTimeoutMs,
+}: {
+  deadlineMs: number;
+  nowMs: number;
+  maxTimeoutMs: number;
+}): number {
+  if (![deadlineMs, nowMs, maxTimeoutMs].every(Number.isFinite) || maxTimeoutMs <= 0) {
+    throw new Error("recovery timeout bounds must be finite positive values");
+  }
+  return Math.max(0, Math.min(maxTimeoutMs, deadlineMs - nowMs));
+}
+
+export function resolveRepairWorkflowRetryMode({
+  requestedMode,
+  recoveredMode,
+  fallbackMode,
+}: {
+  requestedMode: unknown;
+  recoveredMode: unknown;
+  fallbackMode: unknown;
+}): RepairWorkflowMode {
+  const requested =
+    requestedMode === null || requestedMode === undefined
+      ? null
+      : repairMode(requestedMode, "requested mode");
+  const recovered =
+    recoveredMode === null || recoveredMode === undefined
+      ? null
+      : repairMode(recoveredMode, "recovered mode");
+  if (recovered === "plan") return "plan";
+  return requested ?? recovered ?? repairMode(fallbackMode, "fallback mode");
+}
+
+export function parseRepairWorkflowRecoveryInputs(value: unknown): RepairWorkflowRecoveryInputs {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("immutable workflow inputs must be a JSON object");
+  }
+  const input = value as LooseRecord;
+  const keys = JSON.stringify(Object.keys(input).sort());
+  const currentShape = keys === JSON.stringify(CURRENT_INPUT_KEYS);
+  const legacyShape = keys === JSON.stringify(LEGACY_INPUT_KEYS);
+  if (!currentShape && !legacyShape) {
+    throw new Error("immutable workflow inputs have unexpected fields");
+  }
+  if (input.schema_version !== 1) {
+    throw new Error("immutable workflow inputs use an unsupported schema version");
+  }
+
+  const sourceJob = normalizedSourceJob(input.source_job);
+  const requestedMode = repairMode(input.requested_mode, "requested mode");
+  const effectiveMode = repairMode(input.effective_mode, "effective mode");
+  if (effectiveMode !== requestedMode && effectiveMode !== "plan") {
+    throw new Error("immutable workflow inputs contain an invalid effective mode");
+  }
+  if (legacyShape) {
+    const stateRevision = boundedString(input.state_revision, "state revision", 40);
+    const jobSha256 = boundedString(input.job_sha256, "job SHA-256", 64);
+    if (!/^[a-f0-9]{40}$/.test(stateRevision) || !/^[a-f0-9]{64}$/.test(jobSha256)) {
+      throw new Error("immutable workflow inputs contain invalid legacy provenance");
+    }
+    return {
+      schema_version: 1,
+      source_job: sourceJob,
+      state_revision: stateRevision,
+      job_sha256: jobSha256,
+      requested_mode: requestedMode,
+      effective_mode: effectiveMode,
+    };
+  }
+  const sourceDispatchKey = boundedString(input.source_dispatch_key, "source dispatch key", 256, {
+    allowEmpty: true,
+  });
+  const runner = boundedString(input.runner, "runner", 256);
+  const executionRunner = boundedString(input.execution_runner, "execution runner", 256);
+  const plannerSandbox = boundedString(input.planner_sandbox, "planner sandbox", 64);
+  if (!PLANNER_SANDBOXES.has(plannerSandbox)) {
+    throw new Error("immutable workflow inputs contain an invalid planner sandbox");
+  }
+  const model = boundedString(input.model, "model", 128);
+  const dryRun = booleanField(input.dry_run, "dry_run");
+  const requeue = booleanField(input.requeue, "requeue");
+  const requeueDepth = nonNegativeInteger(input.requeue_depth, "requeue_depth");
+  if (requeueDepth > 1 || (requeue && requeueDepth !== 1) || (!requeue && requeueDepth !== 0)) {
+    throw new Error("immutable workflow inputs contain an invalid bounded requeue state");
+  }
+
+  return {
+    schema_version: 1,
+    source_job: sourceJob,
+    source_dispatch_key: sourceDispatchKey,
+    requested_mode: requestedMode,
+    effective_mode: effectiveMode,
+    runner,
+    execution_runner: executionRunner,
+    planner_sandbox: plannerSandbox as "read-only" | "danger-full-access",
+    model,
+    dry_run: dryRun,
+    requeue,
+    requeue_depth: requeueDepth,
+  };
+}
+
+export function readNewestRepairWorkflowRecoveryInputs(
+  artifactRoot: string,
+  runId: string,
+): RepairWorkflowRecoveryInputs | null {
+  if (!/^[1-9][0-9]*$/.test(runId)) {
+    throw new Error("workflow run id must be a positive integer");
+  }
+  const prefix = `clawsweeper-repair-inputs-${runId}-`;
+  const candidates = fs
+    .readdirSync(artifactRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name.startsWith(prefix))
+    .map((entry) => ({
+      attempt: artifactAttempt(entry.name, runId),
+      root: path.join(artifactRoot, entry.name),
+    }))
+    .filter(
+      (candidate): candidate is { attempt: number; root: string } => candidate.attempt !== null,
+    )
+    .sort((left, right) => right.attempt - left.attempt);
+
+  const newest = candidates[0];
+  if (!newest) {
+    const directMatches = findNamedFiles(artifactRoot, REPAIR_WORKFLOW_INPUTS_BASENAME);
+    if (directMatches.length === 0) return null;
+    if (directMatches.length !== 1) {
+      throw new Error(
+        `workflow run ${runId} direct artifact must contain exactly one immutable input snapshot`,
+      );
+    }
+    return readRepairWorkflowRecoveryInputFile(directMatches[0]!);
+  }
+  const matches = findNamedFiles(newest.root, REPAIR_WORKFLOW_INPUTS_BASENAME);
+  if (matches.length !== 1) {
+    throw new Error(
+      `workflow run ${runId} attempt ${newest.attempt} must contain exactly one immutable input snapshot`,
+    );
+  }
+  return readRepairWorkflowRecoveryInputFile(matches[0]!);
+}
+
+function readRepairWorkflowRecoveryInputFile(file: string): RepairWorkflowRecoveryInputs {
+  const stat = fs.statSync(file);
+  if (!stat.isFile() || stat.size > MAX_INPUT_BYTES) {
+    throw new Error("immutable workflow inputs exceed the bounded file size");
+  }
+  return parseRepairWorkflowRecoveryInputs(JSON.parse(fs.readFileSync(file, "utf8")));
+}
+
+export function readNewestRepairLegacyRecoveryInputs(
+  artifactRoot: string,
+  runId: string,
+): RepairLegacyRecoveryInputs | null {
+  if (!/^[1-9][0-9]*$/.test(runId)) {
+    throw new Error("workflow run id must be a positive integer");
+  }
+  const candidatesByAttempt = new Map<number, RepairLegacyRecoveryInputs[]>();
+  for (const entry of fs.readdirSync(artifactRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const attempt = legacyArtifactAttempt(entry.name, runId);
+    if (attempt === null) continue;
+    const artifactDir = path.join(artifactRoot, entry.name);
+    for (const planPath of findNamedFiles(artifactDir, "cluster-plan.json")) {
+      const resultPath = path.join(path.dirname(planPath), "result.json");
+      if (!fs.existsSync(resultPath)) continue;
+      const plan = readBoundedJsonObject(planPath, "legacy cluster plan");
+      const result = readBoundedJsonObject(resultPath, "legacy repair result");
+      const candidate = {
+        source_job: normalizedSourceJob(plan.source_job),
+        mode: repairMode(result.mode ?? plan.mode, "legacy effective mode"),
+        producer_attempt: attempt,
+      };
+      candidatesByAttempt.set(attempt, [...(candidatesByAttempt.get(attempt) ?? []), candidate]);
+    }
+  }
+
+  for (const attempt of [...candidatesByAttempt.keys()].sort((left, right) => right - left)) {
+    const unique = new Map(
+      (candidatesByAttempt.get(attempt) ?? []).map(
+        (candidate) => [JSON.stringify(candidate), candidate] as const,
+      ),
+    );
+    if (unique.size > 1) {
+      throw new Error(`workflow run ${runId} has an ambiguous legacy cohort at attempt ${attempt}`);
+    }
+    const selected = unique.values().next().value;
+    if (selected) return selected;
+  }
+  return null;
+}
+
+export function isRepairWorkflowArtifactUnavailable(stderr: unknown, stdout: unknown): boolean {
+  const detail = `${String(stderr ?? "")}\n${String(stdout ?? "")}`.toLowerCase();
+  return [
+    "artifact has expired",
+    "artifacts expired",
+    "no artifacts found",
+    "no valid artifacts",
+    "http 404",
+  ].some((message) => detail.includes(message));
+}
+
+function artifactAttempt(name: string, runId: string): number | null {
+  const match = name.match(new RegExp(`^clawsweeper-repair-inputs-${runId}-([1-9][0-9]*)$`));
+  if (!match) return null;
+  const attempt = Number(match[1]);
+  return Number.isSafeInteger(attempt) ? attempt : null;
+}
+
+function legacyArtifactAttempt(name: string, runId: string): number | null {
+  if (!name.startsWith("clawsweeper-repair-")) return null;
+  const match = name.match(new RegExp(`-${runId}-([1-9][0-9]*)$`));
+  if (!match) return null;
+  const attempt = Number(match[1]);
+  return Number.isSafeInteger(attempt) ? attempt : null;
+}
+
+function findNamedFiles(root: string, basename: string): string[] {
+  const matches: string[] = [];
+  const pending = [{ directory: root, depth: 0 }];
+  let visited = 0;
+  while (pending.length > 0) {
+    const current = pending.pop()!;
+    for (const entry of fs.readdirSync(current.directory, { withFileTypes: true })) {
+      visited += 1;
+      if (visited > MAX_ARTIFACT_ENTRIES) {
+        throw new Error("immutable workflow input artifact exceeds the traversal bound");
+      }
+      const candidate = path.join(current.directory, entry.name);
+      if (entry.isSymbolicLink()) continue;
+      if (entry.isDirectory()) {
+        if (current.depth < MAX_ARTIFACT_DEPTH) {
+          pending.push({ directory: candidate, depth: current.depth + 1 });
+        }
+      } else if (entry.isFile() && entry.name === basename) {
+        matches.push(candidate);
+      }
+    }
+  }
+  return matches.sort();
+}
+
+function normalizedSourceJob(value: unknown): string {
+  const candidate = boundedString(value, "source job", 512);
+  const normalized = path.posix.normalize(candidate.replaceAll("\\", "/"));
+  if (
+    candidate !== normalized ||
+    path.posix.isAbsolute(normalized) ||
+    normalized.startsWith("../") ||
+    !normalized.startsWith("jobs/") ||
+    !normalized.endsWith(".md")
+  ) {
+    throw new Error("immutable workflow inputs contain an invalid source job");
+  }
+  return normalized;
+}
+
+function readBoundedJsonObject(file: string, label: string): LooseRecord {
+  const stat = fs.statSync(file);
+  if (!stat.isFile() || stat.size > MAX_INPUT_BYTES) {
+    throw new Error(`${label} exceeds the bounded file size`);
+  }
+  const value = JSON.parse(fs.readFileSync(file, "utf8"));
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be a JSON object`);
+  }
+  return value as LooseRecord;
+}
+
+function repairMode(value: unknown, label: string): RepairWorkflowMode {
+  const mode = boundedString(value, label, 16);
+  if (!REPAIR_MODES.has(mode)) {
+    throw new Error(`immutable workflow inputs contain an invalid ${label}`);
+  }
+  return mode as RepairWorkflowMode;
+}
+
+function boundedString(
+  value: unknown,
+  label: string,
+  maxLength: number,
+  options: { allowEmpty?: boolean } = {},
+): string {
+  if (typeof value !== "string" || value !== value.trim() || value.length > maxLength) {
+    throw new Error(`immutable workflow inputs contain an invalid ${label}`);
+  }
+  if (!options.allowEmpty && value.length === 0) {
+    throw new Error(`immutable workflow inputs contain an invalid ${label}`);
+  }
+  if (
+    [...value].some((character) => {
+      const codePoint = character.codePointAt(0) ?? 0;
+      return codePoint <= 31 || codePoint === 127;
+    })
+  ) {
+    throw new Error(`immutable workflow inputs contain an invalid ${label}`);
+  }
+  return value;
+}
+
+function booleanField(value: unknown, label: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new Error(`immutable workflow inputs contain an invalid ${label}`);
+  }
+  return value;
+}
+
+function nonNegativeInteger(value: unknown, label: string): number {
+  if (!Number.isSafeInteger(value) || Number(value) < 0) {
+    throw new Error(`immutable workflow inputs contain an invalid ${label}`);
+  }
+  return Number(value);
+}

--- a/test/repair/self-heal-recovery-inputs.test.ts
+++ b/test/repair/self-heal-recovery-inputs.test.ts
@@ -1,0 +1,319 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+test("self-heal replays recovered runners and preserves a plan-only downgrade", () => {
+  const fixture = createRecoveryFixture("self-heal");
+  try {
+    const result = runFixture(fixture, [
+      "self-heal-failed-runs.js",
+      "--max-age-hours",
+      "24",
+      "--mode",
+      "autonomous",
+    ]);
+
+    assert.equal(result.status, 0, result.stderr);
+    const summary = JSON.parse(result.stdout);
+    assert.equal(summary.candidates.length, 1);
+    assert.deepEqual(
+      {
+        mode: summary.candidates[0].mode,
+        runner: summary.candidates[0].runner,
+        execution_runner: summary.candidates[0].execution_runner,
+        planner_sandbox: summary.candidates[0].planner_sandbox,
+        model: summary.candidates[0].model,
+        dry_run: summary.candidates[0].dry_run,
+      },
+      {
+        mode: "plan",
+        runner: "original-runner",
+        execution_runner: "original-execution-runner",
+        planner_sandbox: "read-only",
+        model: "original-model",
+        dry_run: false,
+      },
+    );
+  } finally {
+    cleanupFixture(fixture);
+  }
+});
+
+test("direct requeue cannot promote a recovered plan-only run", () => {
+  const fixture = createRecoveryFixture("requeue");
+  try {
+    const result = runFixture(fixture, ["requeue-job.js", fixture.runId, "--mode", "autonomous"]);
+
+    assert.equal(result.status, 0, result.stderr);
+    const summary = JSON.parse(result.stdout);
+    assert.deepEqual(
+      {
+        mode: summary.mode,
+        runner: summary.runner,
+        execution_runner: summary.execution_runner,
+        planner_sandbox: summary.planner_sandbox,
+        model: summary.model,
+        dry_run: summary.dry_run,
+      },
+      {
+        mode: "plan",
+        runner: "original-runner",
+        execution_runner: "original-execution-runner",
+        planner_sandbox: "read-only",
+        model: "original-model",
+        dry_run: false,
+      },
+    );
+  } finally {
+    cleanupFixture(fixture);
+  }
+});
+
+test("snapshot-less self-heal remains plan-only", () => {
+  const fixture = createRecoveryFixture("snapshot-less", { snapshot: false });
+  try {
+    const result = runFixture(fixture, [
+      "self-heal-failed-runs.js",
+      "--max-age-hours",
+      "24",
+      "--mode",
+      "autonomous",
+    ]);
+
+    assert.equal(result.status, 0, result.stderr);
+    const summary = JSON.parse(result.stdout);
+    assert.equal(summary.candidates.length, 1);
+    assert.equal(summary.candidates[0].mode, "plan");
+    assert.equal(summary.candidates[0].dry_run, true);
+  } finally {
+    cleanupFixture(fixture);
+  }
+});
+
+test("snapshot-less direct requeue remains dry", () => {
+  const fixture = createRecoveryFixture("snapshot-less-requeue", { snapshot: false });
+  try {
+    const result = runFixture(fixture, ["requeue-job.js", fixture.runId, "--mode", "autonomous"]);
+
+    assert.equal(result.status, 0, result.stderr);
+    const summary = JSON.parse(result.stdout);
+    assert.equal(summary.mode, "plan");
+    assert.equal(summary.dry_run, true);
+  } finally {
+    cleanupFixture(fixture);
+  }
+});
+
+test("direct requeue recovers historical worker-only artifact cohorts", () => {
+  const fixture = createRecoveryFixture("legacy-worker", {
+    snapshot: false,
+    runRecord: false,
+    legacyWorker: true,
+  });
+  try {
+    const result = runFixture(fixture, ["requeue-job.js", fixture.runId, "--mode", "autonomous"]);
+
+    assert.equal(result.status, 0, result.stderr);
+    const summary = JSON.parse(result.stdout);
+    assert.equal(summary.source_job, "jobs/test/inbox/recovery.md");
+    assert.equal(summary.mode, "plan");
+    assert.equal(summary.dry_run, true);
+  } finally {
+    cleanupFixture(fixture);
+  }
+});
+
+test("self-heal backfills quota after a newer invalid candidate", () => {
+  const fixture = createRecoveryFixture("quota-backfill");
+  try {
+    fs.writeFileSync(
+      path.join(fixture.root, "results", "runs", "910002.json"),
+      `${JSON.stringify({
+        run_id: "910002",
+        source_job: "jobs/test/inbox/missing.md",
+        workflow_conclusion: "failure",
+        workflow_updated_at: new Date().toISOString(),
+        mode: "autonomous",
+      })}\n`,
+    );
+
+    const result = runFixture(fixture, [
+      "self-heal-failed-runs.js",
+      "--max-age-hours",
+      "24",
+      "--max-jobs",
+      "1",
+    ]);
+
+    assert.equal(result.status, 0, result.stderr);
+    const summary = JSON.parse(result.stdout);
+    assert.equal(summary.candidates.length, 1);
+    assert.equal(summary.candidates[0].source_run_id, fixture.runId);
+    assert.equal(summary.skipped_candidates[0].reason, "missing_job_file");
+  } finally {
+    cleanupFixture(fixture);
+  }
+});
+
+function createRecoveryFixture(
+  label: string,
+  options: { snapshot?: boolean; runRecord?: boolean; legacyWorker?: boolean } = {},
+) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), `clawsweeper-${label}-recovery-`));
+  fs.cpSync("dist", path.join(root, "dist"), { recursive: true });
+  fs.cpSync("config", path.join(root, "config"), { recursive: true });
+
+  const sourceJob = "jobs/test/inbox/recovery.md";
+  const jobPath = path.join(root, sourceJob);
+  fs.mkdirSync(path.dirname(jobPath), { recursive: true });
+  fs.writeFileSync(
+    jobPath,
+    `---
+repo: openclaw/openclaw
+cluster_id: recovery
+mode: autonomous
+allowed_actions:
+  - fix
+candidates:
+  - "#1"
+---
+
+# recovery fixture
+`,
+  );
+
+  const runId = "910001";
+  const runsDir = path.join(root, "results", "runs");
+  fs.mkdirSync(runsDir, { recursive: true });
+  if (options.runRecord !== false) {
+    fs.writeFileSync(
+      path.join(runsDir, `${runId}.json`),
+      `${JSON.stringify({
+        run_id: runId,
+        source_job: sourceJob,
+        workflow_conclusion: "failure",
+        workflow_updated_at: new Date().toISOString(),
+        mode: "autonomous",
+      })}\n`,
+    );
+  }
+
+  const recoveredInputs = {
+    schema_version: 1,
+    source_job: sourceJob,
+    source_dispatch_key: "original-dispatch",
+    requested_mode: "autonomous",
+    effective_mode: "plan",
+    runner: "original-runner",
+    execution_runner: "original-execution-runner",
+    planner_sandbox: "read-only",
+    model: "original-model",
+    dry_run: false,
+    requeue: false,
+    requeue_depth: 0,
+  };
+  const binDir = path.join(root, "bin");
+  fs.mkdirSync(binDir);
+  writeFakeGh(binDir, {
+    recoveredInputs: options.snapshot === false ? null : recoveredInputs,
+    legacyWorker: options.legacyWorker === true ? { runId, sourceJob } : null,
+  });
+  return { root, binDir, runId };
+}
+
+function runFixture(fixture: ReturnType<typeof createRecoveryFixture>, args: string[]) {
+  const [script, ...scriptArgs] = args;
+  return spawnSync(
+    process.execPath,
+    [path.join(fixture.root, "dist", "repair", script!), ...scriptArgs],
+    {
+      cwd: fixture.root,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        CLAWSWEEPER_REPO: "openclaw/clawsweeper",
+        CLAWSWEEPER_WORKER_RUNNER: "current-default-runner",
+        CLAWSWEEPER_EXECUTION_RUNNER: "current-default-execution-runner",
+      },
+    },
+  );
+}
+
+function cleanupFixture(fixture: ReturnType<typeof createRecoveryFixture>) {
+  fs.rmSync(fixture.root, { recursive: true, force: true });
+}
+
+function writeFakeGh(
+  binDir: string,
+  {
+    recoveredInputs,
+    legacyWorker,
+  }: {
+    recoveredInputs: Record<string, unknown> | null;
+    legacyWorker: { runId: string; sourceJob: string } | null;
+  },
+) {
+  const file = path.join(binDir, "gh");
+  fs.writeFileSync(
+    file,
+    `#!/bin/sh
+set -eu
+if [ "$1" = "run" ] && [ "$2" = "list" ]; then
+  printf '[]\\n'
+  exit 0
+fi
+if [ "$1" = "run" ] && [ "$2" = "download" ]; then
+  output_dir=""
+  pattern=""
+  previous=""
+  for argument in "$@"; do
+    if [ "$previous" = "--dir" ]; then
+      output_dir="$argument"
+    fi
+    if [ "$previous" = "--pattern" ]; then
+      pattern="$argument"
+    fi
+    previous="$argument"
+  done
+  ${
+    recoveredInputs
+      ? `case "$pattern" in
+    clawsweeper-repair-inputs-*)
+      artifact_dir="$output_dir/recovery-inputs"
+      mkdir -p "$artifact_dir"
+      cat > "$artifact_dir/workflow-inputs.json" <<'JSON'
+${JSON.stringify(recoveredInputs)}
+JSON
+      exit 0
+      ;;
+  esac`
+      : ""
+  }
+  ${
+    legacyWorker
+      ? `if [ "$pattern" = "clawsweeper-repair-worker-${legacyWorker.runId}-*" ]; then
+    artifact_dir="$output_dir/clawsweeper-repair-worker-${legacyWorker.runId}-2/run"
+    mkdir -p "$artifact_dir"
+    cat > "$artifact_dir/cluster-plan.json" <<'JSON'
+${JSON.stringify({ source_job: legacyWorker.sourceJob, mode: "autonomous" })}
+JSON
+    cat > "$artifact_dir/result.json" <<'JSON'
+${JSON.stringify({ mode: "autonomous" })}
+JSON
+    exit 0
+  fi`
+      : ""
+  }
+  echo "no valid artifacts found to download" >&2
+  exit 1
+fi
+echo "unsupported gh invocation: $*" >&2
+exit 1
+`,
+  );
+  fs.chmodSync(file, 0o755);
+}

--- a/test/repair/workflow-recovery-inputs.test.ts
+++ b/test/repair/workflow-recovery-inputs.test.ts
@@ -1,0 +1,318 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  boundedRecoveryTimeoutMs,
+  isRepairWorkflowArtifactUnavailable,
+  parseRepairWorkflowRecoveryInputs,
+  readNewestRepairLegacyRecoveryInputs,
+  readNewestRepairWorkflowRecoveryInputs,
+  resolveRepairWorkflowRetryMode,
+} from "../../dist/repair/workflow-recovery-inputs.js";
+
+const base = {
+  schema_version: 1,
+  source_job: "jobs/openclaw/inbox/cluster-42.md",
+  source_dispatch_key: "command-42",
+  requested_mode: "autonomous",
+  effective_mode: "plan",
+  runner: "blacksmith-4vcpu-ubuntu-2404",
+  execution_runner: "blacksmith-16vcpu-ubuntu-2404",
+  planner_sandbox: "read-only",
+  model: "internal",
+  dry_run: false,
+  requeue: false,
+  requeue_depth: 0,
+} as const;
+const legacyBase = {
+  schema_version: 1,
+  source_job: base.source_job,
+  state_revision: "a".repeat(40),
+  job_sha256: "b".repeat(64),
+  requested_mode: "autonomous",
+  effective_mode: "plan",
+} as const;
+
+test("recovery timeouts cannot exceed the shared deadline", () => {
+  assert.equal(
+    boundedRecoveryTimeoutMs({
+      deadlineMs: 10_000,
+      nowMs: 2_000,
+      maxTimeoutMs: 3_000,
+    }),
+    3_000,
+  );
+  assert.equal(
+    boundedRecoveryTimeoutMs({
+      deadlineMs: 10_000,
+      nowMs: 9_500,
+      maxTimeoutMs: 3_000,
+    }),
+    500,
+  );
+  assert.equal(
+    boundedRecoveryTimeoutMs({
+      deadlineMs: 10_000,
+      nowMs: 10_001,
+      maxTimeoutMs: 3_000,
+    }),
+    0,
+  );
+});
+
+test("immutable workflow inputs accept only the exact bounded replay contract", () => {
+  assert.deepEqual(parseRepairWorkflowRecoveryInputs(base), base);
+  assert.deepEqual(parseRepairWorkflowRecoveryInputs(legacyBase), legacyBase);
+  assert.throws(
+    () => parseRepairWorkflowRecoveryInputs({ ...base, extra: true }),
+    /unexpected fields/,
+  );
+  assert.throws(
+    () => parseRepairWorkflowRecoveryInputs({ ...base, source_job: "jobs/../private.md" }),
+    /invalid source job/,
+  );
+  assert.throws(
+    () =>
+      parseRepairWorkflowRecoveryInputs({
+        ...base,
+        requested_mode: "plan",
+        effective_mode: "execute",
+      }),
+    /invalid effective mode/,
+  );
+  assert.throws(
+    () => parseRepairWorkflowRecoveryInputs({ ...base, requeue: true }),
+    /invalid bounded requeue state/,
+  );
+});
+
+test("immutable workflow input recovery selects the newest complete attempt", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-recovery-inputs-"));
+  try {
+    writeInputs(root, "910001", 1, base);
+    writeInputs(root, "910001", 2, {
+      ...base,
+      runner: "new-runner",
+      requeue: true,
+      requeue_depth: 1,
+    });
+
+    const recovered = readNewestRepairWorkflowRecoveryInputs(root, "910001");
+    assert.equal(recovered?.runner, "new-runner");
+    assert.equal(recovered?.requeue_depth, 1);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("immutable workflow input recovery accepts direct single-artifact extraction", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-recovery-direct-"));
+  try {
+    const inputRoot = path.join(root, "recovery-inputs");
+    fs.mkdirSync(inputRoot);
+    fs.writeFileSync(path.join(inputRoot, "workflow-inputs.json"), `${JSON.stringify(base)}\n`);
+
+    assert.deepEqual(readNewestRepairWorkflowRecoveryInputs(root, "910005"), base);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("immutable workflow input recovery fails closed on an ambiguous newest attempt", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-recovery-ambiguous-"));
+  try {
+    const attemptRoot = writeInputs(root, "910002", 2, base);
+    const duplicate = path.join(attemptRoot, "duplicate");
+    fs.mkdirSync(duplicate);
+    fs.writeFileSync(path.join(duplicate, "workflow-inputs.json"), `${JSON.stringify(base)}\n`);
+
+    assert.throws(
+      () => readNewestRepairWorkflowRecoveryInputs(root, "910002"),
+      /exactly one immutable input snapshot/,
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("immutable workflow input fallback distinguishes absence from transient failure", () => {
+  assert.equal(
+    isRepairWorkflowArtifactUnavailable("no valid artifacts found to download", ""),
+    true,
+  );
+  assert.equal(isRepairWorkflowArtifactUnavailable("HTTP 404", ""), true);
+  assert.equal(isRepairWorkflowArtifactUnavailable("secondary rate limit", ""), false);
+  assert.equal(isRepairWorkflowArtifactUnavailable("authentication failed", ""), false);
+});
+
+test("legacy recovery selects one newest complete producer attempt", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-legacy-recovery-"));
+  try {
+    writeLegacyCohort(root, "910003", 1, "plan");
+    writeLegacyCohort(root, "910003", 2, "autonomous");
+
+    assert.deepEqual(readNewestRepairLegacyRecoveryInputs(root, "910003"), {
+      source_job: base.source_job,
+      mode: "autonomous",
+      producer_attempt: 2,
+    });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("legacy recovery never combines plan and result from different attempts", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-legacy-split-"));
+  try {
+    const planRoot = legacyRunRoot(root, "910004", 1);
+    const resultRoot = legacyRunRoot(root, "910004", 2);
+    fs.mkdirSync(planRoot, { recursive: true });
+    fs.mkdirSync(resultRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(planRoot, "cluster-plan.json"),
+      `${JSON.stringify({ source_job: base.source_job, mode: "autonomous" })}\n`,
+    );
+    fs.writeFileSync(path.join(resultRoot, "result.json"), '{"mode":"autonomous"}\n');
+
+    assert.equal(readNewestRepairLegacyRecoveryInputs(root, "910004"), null);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("immutable retry mode never promotes a recovered plan downgrade", () => {
+  assert.equal(
+    resolveRepairWorkflowRetryMode({
+      requestedMode: "autonomous",
+      recoveredMode: "plan",
+      fallbackMode: "autonomous",
+    }),
+    "plan",
+  );
+  assert.equal(
+    resolveRepairWorkflowRetryMode({
+      requestedMode: "plan",
+      recoveredMode: "autonomous",
+      fallbackMode: "autonomous",
+    }),
+    "plan",
+  );
+});
+
+test("repair retries reuse immutable Action inputs without restoring lifecycle machinery", () => {
+  const workflow = readText(".github/workflows/repair-cluster-worker.yml");
+  const selfHealWorkflow = readText(".github/workflows/repair-self-heal.yml");
+  const requeue = readText("src/repair/requeue-job.ts");
+  const selfHeal = readText("src/repair/self-heal-failed-runs.ts");
+  const persistIndex = workflow.indexOf("- name: Persist immutable recovery inputs");
+  const uploadIndex = workflow.indexOf("- name: Upload immutable recovery inputs");
+  const tokenIndex = workflow.indexOf("- name: Create GitHub App token");
+  const setupIndex = workflow.indexOf("- uses: ./.github/actions/setup-pnpm");
+
+  assert.ok(persistIndex >= 0);
+  assert.ok(uploadIndex > persistIndex);
+  assert.ok(tokenIndex > uploadIndex);
+  assert.ok(setupIndex > uploadIndex);
+  assert.match(workflow.slice(uploadIndex, tokenIndex), /include-hidden-files: true/);
+  for (const field of [
+    "source_job",
+    "source_dispatch_key",
+    "requested_mode",
+    "effective_mode",
+    "runner",
+    "execution_runner",
+    "planner_sandbox",
+    "model",
+    "dry_run",
+    "requeue",
+    "requeue_depth",
+  ]) {
+    assert.match(workflow, new RegExp(`${field}:`));
+  }
+  assert.match(
+    workflow,
+    /effective_mode: \$\{\{ steps\.recovery_inputs\.outputs\.effective_mode \}\}/,
+  );
+  assert.match(workflow, /needs\.cluster\.outputs\.effective_mode == 'execute'/);
+  assert.match(
+    workflow,
+    /args=\("\$\{\{ inputs\.job \}\}" --mode "\$worker_mode" --model "\$\{\{ inputs\.model \}\}"\)/,
+  );
+  assert.match(requeue, /readNewestRepairWorkflowRecoveryInputs\(recoveryDir, runId\)/);
+  assert.match(requeue, /recoveredInputs\?\.requeue_depth \?\? 0/);
+  assert.match(requeue, /timeout: WORKFLOW_INPUT_DOWNLOAD_TIMEOUT_MS/);
+  assert.match(
+    requeue,
+    /if \(!dryRun && openExecuteWindow && \["execute", "autonomous"\]\.includes\(mode\)\)/,
+  );
+  assert.match(requeue, /assertGateOpenIfNeeded\(mode, dryRun\)/);
+  assert.match(requeue, /function assertGateOpenIfNeeded\(mode: string, isDryRun: boolean\)/);
+  assert.match(requeue, /if \(isDryRun\) return/);
+  assert.match(requeue, /`planner_sandbox=\$\{plannerSandbox\}`/);
+  assert.match(requeue, /`dry_run=\$\{dryRun\}`/);
+  assert.match(
+    selfHeal,
+    /const boundedEligible = eligible\.slice\(0, MAX_RECOVERY_CANDIDATE_SCANS\)/,
+  );
+  assert.match(selfHeal, /const recoveryDeadlineMs = Date\.now\(\) \+ RECOVERY_SCAN_BUDGET_MS/);
+  assert.match(selfHeal, /boundedRecoveryTimeoutMs\(\{/);
+  assert.match(selfHeal, /reason: "recovery_budget_exhausted"/);
+  assert.match(selfHeal, /recoverWorkflowInputs\(record, recoveryTimeoutMs\)/);
+  assert.match(selfHeal, /for \(const record of boundedEligible\)/);
+  assert.match(selfHeal, /if \(selected\.length >= maxJobs\) break/);
+  assert.match(selfHeal, /timeout: timeoutMs/);
+  assert.match(selfHeal, /"--pattern",\s*`clawsweeper-repair-inputs-\$\{runId\}-\*`/);
+  assert.match(requeue, /`clawsweeper-repair-inputs-\$\{runId\}-\*`/);
+  assert.match(requeue, /`clawsweeper-repair-\$\{runId\}-\*`/);
+  assert.match(requeue, /`clawsweeper-repair-worker-\$\{runId\}-\*`/);
+  assert.match(selfHeal, /recordSortKey === currentSortKey && record\.live_run_record === true/);
+  assert.match(selfHeal, /candidate\.dry_run !== true/);
+  assert.match(selfHeal, /`planner_sandbox=\$\{candidate\.planner_sandbox\}`/);
+  assert.match(selfHeal, /`requeue_depth=\$\{candidate\.requeue_depth\}`/);
+  assert.match(
+    selfHealWorkflow,
+    /if \[ "\$\{\{ github\.event_name \}\}" = "workflow_dispatch" \]; then[\s\S]*args\+=\(--runner/,
+  );
+});
+
+function writeInputs(
+  root: string,
+  runId: string,
+  attempt: number,
+  value: Record<string, unknown>,
+): string {
+  const attemptRoot = path.join(root, `clawsweeper-repair-inputs-${runId}-${attempt}`);
+  const inputRoot = path.join(attemptRoot, "recovery-inputs");
+  fs.mkdirSync(inputRoot, { recursive: true });
+  fs.writeFileSync(
+    path.join(inputRoot, "workflow-inputs.json"),
+    `${JSON.stringify(value, null, 2)}\n`,
+  );
+  return attemptRoot;
+}
+
+function writeLegacyCohort(
+  root: string,
+  runId: string,
+  attempt: number,
+  mode: "plan" | "autonomous",
+) {
+  const runRoot = legacyRunRoot(root, runId, attempt);
+  fs.mkdirSync(runRoot, { recursive: true });
+  fs.writeFileSync(
+    path.join(runRoot, "cluster-plan.json"),
+    `${JSON.stringify({ source_job: base.source_job, mode })}\n`,
+  );
+  fs.writeFileSync(path.join(runRoot, "result.json"), `${JSON.stringify({ mode })}\n`);
+}
+
+function legacyRunRoot(root: string, runId: string, attempt: number) {
+  return path.join(root, `clawsweeper-repair-${runId}-${attempt}`, "run");
+}
+
+function readText(file: string): string {
+  return fs.readFileSync(file, "utf8");
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where retry and self-heal dispatches could reconstruct repair jobs from mutable defaults or incomplete legacy artifacts, changing the original runner, mode, sandbox, model, or dry-run behavior.

## Why This Change Was Made

Each repair attempt now records a bounded immutable input snapshot and retry paths recover the newest exact snapshot before considering durable or legacy fallback data. Recovery fails closed to plan-only, dry-run behavior when exact inputs are unavailable; historical final and worker artifact families remain supported without restoring the reverted action-lifecycle ledger or raw review-log machinery.

Self-heal recovery uses a shared three-minute scan deadline, so unavailable artifacts cannot consume the workflow's entire runtime budget.

## User Impact

Operators can requeue failed repair jobs without silently promoting permissions or changing the original execution inputs. Older runs remain recoverable through a narrow compatibility parser, while ambiguous or incomplete artifacts are rejected.

## Evidence

- TypeScript builds: `tsc -p tsconfig.json` and `tsc -p tsconfig.repair.json`
- Focused recovery tests: 16 passed
- Full repair suite: 732 passed, 0 failed
- `oxlint src/repair test/repair`
- `oxfmt --check` on all changed files
- active-surface and source-limit checks
- workflow YAML parsing and `git diff --check`
- Exact local range review: high confidence, 0 actionable findings
