### PR TITLE
feat: yield background review under exact pressure

### DIFF
--- a/.github/workflows/commit-review.yml
+++ b/.github/workflows/commit-review.yml
@@ -63,6 +63,12 @@ jobs:
     if: ${{ !(github.event_name == 'repository_dispatch' && github.event.client_payload.target_repo == 'openclaw/clawhub' && vars.CLAWSWEEPER_ENABLE_CLAWHUB != '1') }}
     runs-on: ubuntu-latest
     timeout-minutes: 40
+    concurrency:
+      # The shared admission lock is an opt-in experiment. With the variable
+      # unset, each commit plan keeps its current independent admission group.
+      group: ${{ vars.CLAWSWEEPER_ENABLE_EXACT_REVIEW_BACKGROUND_YIELD == '1' && 'clawsweeper-review-admission-background' || format('commit-review-plan-{0}', github.run_id) }}
+      cancel-in-progress: false
+      queue: max
     outputs:
       create_checks: ${{ steps.mode.outputs.create_checks }}
       enabled: ${{ steps.mode.outputs.enabled }}
@@ -160,12 +166,28 @@ jobs:
           COMMIT_SHA: ${{ github.event.inputs.commit_sha || github.event.client_payload.after_sha || github.event.client_payload.commit_sha || '' }}
           BEFORE_SHA: ${{ github.event.inputs.before_sha || github.event.client_payload.before_sha || '' }}
           COMMIT_OFFSET: ${{ github.event.inputs.commit_offset || github.event.client_payload.commit_offset || '0' }}
+          CREATE_CHECKS: ${{ steps.mode.outputs.create_checks }}
           ENABLED: ${{ steps.mode.outputs.enabled }}
+          ADDITIONAL_PROMPT: ${{ github.event.inputs.additional_prompt || github.event.client_payload.additional_prompt || '' }}
           SOURCE_REF: ${{ github.event.client_payload.ref || 'refs/heads/main' }}
           SETTLE_SECONDS: ${{ vars.CLAWSWEEPER_COMMIT_REVIEW_SETTLE_SECONDS || '60' }}
           PAGE_SIZE: ${{ vars.CLAWSWEEPER_COMMIT_REVIEW_PAGE_SIZE || '' }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          CLAWSWEEPER_EXACT_REVIEW_QUEUE_MAX_AGE_SECONDS: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_MAX_AGE_SECONDS || '900' }}
+          EXACT_REVIEW_BACKGROUND_YIELD_ENABLED: ${{ vars.CLAWSWEEPER_ENABLE_EXACT_REVIEW_BACKGROUND_YIELD || '0' }}
         run: |
           set -euo pipefail
+          limit() {
+            pnpm --dir clawsweeper run --silent workflow -- limit "$1"
+          }
+          page_size_hard_cap="$(limit commit_review.page_size_hard_cap)"
+          reservation_page_size="$PAGE_SIZE"
+          if ! [[ "$reservation_page_size" =~ ^[0-9]+$ ]] || [ "$reservation_page_size" -lt 1 ]; then
+            reservation_page_size="$(limit commit_review.page_size_default)"
+          fi
+          if [ "$reservation_page_size" -gt "$page_size_hard_cap" ]; then
+            reservation_page_size="$page_size_hard_cap"
+          fi
           active_runs_json() {
             {
               for run_status in in_progress pending queued waiting requested; do
@@ -183,13 +205,59 @@ jobs:
               | WORKFLOW_PATH="$1" STALE_QUEUED_CUTOFF="$STALE_QUEUED_CUTOFF" jq '[.[] | select(.workflowPath == env.WORKFLOW_PATH) | select(.status == "in_progress" or ((.status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") and ((.updatedAt // .createdAt // "") >= env.STALE_QUEUED_CUTOFF)))] | length' 2>/dev/null \
               || printf '0'
           }
+          exact_review_pressure_status() {
+            local queue_url response generated_at generated_epoch now_epoch queue_max_age_seconds age_seconds pressure
+            queue_url="${QUEUE_URL%/}"
+            response="$(curl --fail --silent --connect-timeout 5 --max-time 10 "$queue_url/api/status" 2>/dev/null)" || return 1
+            generated_at="$(printf '%s' "$response" | jq -r '.exact_review_queue.generated_at // "" | if type == "string" then . else "" end' 2>/dev/null)" || return 1
+            if [ -z "$generated_at" ]; then
+              echo "::warning::Exact-review queue telemetry missing exact_review_queue.generated_at; using idle pressure (fail open)." >&2
+              return 1
+            fi
+            if ! generated_epoch="$(GENERATED_AT="$generated_at" node -e '
+              const value = process.env.GENERATED_AT || "";
+              if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$/.test(value)) process.exit(1);
+              const timestamp = Date.parse(value);
+              if (!Number.isFinite(timestamp)) process.exit(1);
+              process.stdout.write(String(Math.floor(timestamp / 1000)));
+            ' 2>/dev/null)"; then
+              echo "::warning::Exact-review queue telemetry has invalid generated_at; using idle pressure (fail open)." >&2
+              return 1
+            fi
+            now_epoch="$(node -e 'process.stdout.write(String(Math.floor(Date.now() / 1000)))')"
+            queue_max_age_seconds="${CLAWSWEEPER_EXACT_REVIEW_QUEUE_MAX_AGE_SECONDS:-900}"
+            if ! [[ "$queue_max_age_seconds" =~ ^[0-9]+$ ]] || [ "$queue_max_age_seconds" -lt 60 ]; then
+              queue_max_age_seconds=900
+            fi
+            age_seconds=$((now_epoch - generated_epoch))
+            if [ "$age_seconds" -gt "$queue_max_age_seconds" ]; then
+              echo "::warning::Exact-review queue telemetry snapshot is stale (generated_at=$generated_at, age_seconds=$age_seconds); using idle pressure (fail open)." >&2
+              return 1
+            fi
+            if [ "$age_seconds" -lt -300 ]; then
+              echo "::warning::Exact-review queue telemetry generated_at is too far in the future (generated_at=$generated_at); using idle pressure (fail open)." >&2
+              return 1
+            fi
+            pressure="$(printf '%s' "$response" | jq -r '.exact_review_queue.pressure.status // "" | if type == "string" then . else "" end' 2>/dev/null)" || return 1
+            case "$pressure" in
+              idle|congested|saturated)
+                printf '%s' "$pressure"
+                ;;
+              unknown|"")
+                echo "::warning::Exact-review pressure is unavailable; using idle pressure (fail open)." >&2
+                return 1
+                ;;
+              *)
+                echo "::warning::Exact-review pressure has unknown status '$pressure'; using idle pressure (fail open)." >&2
+                return 1
+                ;;
+            esac
+          }
           active_sweep_background_workers() {
             local runs total id title status jobs_json active_shards total_shards
-            local reserved_shards hard_cap requested_shards item_numbers commas item_count
             total=0
-            hard_cap="$(pnpm --dir clawsweeper run --silent workflow -- limit review_shards.hard_cap)"
             runs="$(printf '%s' "$ACTIVE_RUNS_JSON" \
-              | STALE_QUEUED_CUTOFF="$STALE_QUEUED_CUTOFF" jq -r '.[] | select(.workflowPath == ".github/workflows/sweep.yml") | select(.status == "in_progress" or ((.status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") and ((.updatedAt // .createdAt // "") >= env.STALE_QUEUED_CUTOFF))) | select(.displayTitle == "Review ClawSweeper items" or .displayTitle == "Review hot ClawSweeper items" or (.displayTitle | startswith("Review event items "))) | [.databaseId, .displayTitle, .status] | @tsv' 2>/dev/null || true)"
+              | jq -r '.[] | select(.workflowPath == ".github/workflows/sweep.yml" and .status == "in_progress") | select(.displayTitle == "Review ClawSweeper items" or .displayTitle == "Review hot ClawSweeper items" or (.displayTitle | startswith("Review target repo ")) or (.displayTitle | startswith("Review hot target repo "))) | [.databaseId, .displayTitle, .status] | @tsv' 2>/dev/null || true)"
             while IFS=$'\t' read -r id title status; do
               if [ -z "$id" ]; then
                 continue
@@ -214,30 +282,8 @@ jobs:
               # Planning, queued, and not-yet-expanded matrix runs reserve their lane
               # size. Completed matrices are publishing and consume no Codex slots.
               if [ "$active_shards" -lt 1 ] && [ "$total_shards" -lt 1 ]; then
-                if [ "$title" = "Review hot ClawSweeper items" ]; then
+                if [ "$title" = "Review hot ClawSweeper items" ] || [[ "$title" == Review\ hot\ target\ repo\ * ]]; then
                   active_shards="$(pnpm --dir clawsweeper run --silent workflow -- limit review_shards.hot_intake_default)"
-                elif [[ "$title" == Review\ event\ items\ * ]]; then
-                  reserved_shards="$hard_cap"
-                  if [[ "$title" =~ \[shards=([0-9]+)\]$ ]]; then
-                    requested_shards="${BASH_REMATCH[1]}"
-                    item_numbers="${title#*#}"
-                    item_numbers="${item_numbers%% *}"
-                    if [[ "$item_numbers" =~ ^[0-9]+(,[0-9]+)*$ ]]; then
-                      if [ "$requested_shards" -lt 1 ]; then
-                        requested_shards=1
-                      fi
-                      commas="${item_numbers//[^,]/}"
-                      item_count=$((${#commas} + 1))
-                      reserved_shards="$requested_shards"
-                      if [ "$reserved_shards" -gt "$item_count" ]; then
-                        reserved_shards="$item_count"
-                      fi
-                      if [ "$reserved_shards" -gt "$hard_cap" ]; then
-                        reserved_shards="$hard_cap"
-                      fi
-                    fi
-                  fi
-                  active_shards="$reserved_shards"
                 else
                   active_shards="$(pnpm --dir clawsweeper run --silent workflow -- limit review_shards.normal_default)"
                 fi
@@ -246,17 +292,138 @@ jobs:
             done <<< "$runs"
             printf '%s' "$total"
           }
-          active_sweep_exact_count() {
-            printf '%s' "$ACTIVE_RUNS_JSON" \
-              | STALE_QUEUED_CUTOFF="$STALE_QUEUED_CUTOFF" jq '[.[] | select(.workflowPath == ".github/workflows/sweep.yml") | select((.status == "in_progress" or ((.status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") and ((.updatedAt // .createdAt // "") >= env.STALE_QUEUED_CUTOFF))) and (.displayTitle | startswith("Review event item ")))] | length' 2>/dev/null \
-              || printf '0'
+          active_sweep_exact_workers() {
+            local runs total id title status jobs_json active_shards total_shards
+            local reserved_shards hard_cap requested_shards item_numbers commas item_count
+            total=0
+            hard_cap="$(pnpm --dir clawsweeper run --silent workflow -- limit review_shards.hard_cap)"
+            runs="$(printf '%s' "$ACTIVE_RUNS_JSON" \
+              | STALE_QUEUED_CUTOFF="$STALE_QUEUED_CUTOFF" jq -r '.[] | select(.workflowPath == ".github/workflows/sweep.yml") | select(.status == "in_progress" or ((.status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") and ((.updatedAt // .createdAt // "") >= env.STALE_QUEUED_CUTOFF))) | select((.displayTitle | startswith("Review event item ")) or (.displayTitle | startswith("Review event items "))) | [.databaseId, .displayTitle, .status] | @tsv' 2>/dev/null || true)"
+            while IFS=$'\t' read -r id title status; do
+              if [ -z "$id" ]; then
+                continue
+              fi
+              active_shards=0
+              total_shards=0
+              if [[ "$title" == Review\ event\ item\ * ]]; then
+                total=$((total + 1))
+                continue
+              fi
+              if [ "$status" = "in_progress" ]; then
+                jobs_json="$(gh run view "$id" --repo "${{ github.repository }}" --json jobs 2>/dev/null || printf '{"jobs":[]}')"
+                active_shards="$(printf '%s' "$jobs_json" \
+                  | jq '[.jobs[]? | select(.name | startswith("Review shard ")) | select(.status == "in_progress" or .status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested")] | length' 2>/dev/null \
+                  || printf '0')"
+                total_shards="$(printf '%s' "$jobs_json" \
+                  | jq '[.jobs[]? | select(.name | startswith("Review shard "))] | length' 2>/dev/null \
+                  || printf '0')"
+              fi
+              if ! [[ "$active_shards" =~ ^[0-9]+$ ]]; then
+                active_shards=0
+              fi
+              if ! [[ "$total_shards" =~ ^[0-9]+$ ]]; then
+                total_shards=0
+              fi
+              # Explicit exact batches are priority work. Reserve the batch shape
+              # until its matrix exists, then account only for live shard jobs.
+              if [ "$active_shards" -lt 1 ] && [ "$total_shards" -lt 1 ]; then
+                reserved_shards="$hard_cap"
+                if [[ "$title" =~ \[shards=([0-9]+)\]$ ]]; then
+                  requested_shards="${BASH_REMATCH[1]}"
+                  item_numbers="${title#*#}"
+                  item_numbers="${item_numbers%% *}"
+                  if [[ "$item_numbers" =~ ^[0-9]+(,[0-9]+)*$ ]]; then
+                    if [ "$requested_shards" -lt 1 ]; then
+                      requested_shards=1
+                    fi
+                    commas="${item_numbers//[^,]/}"
+                    item_count=$((${#commas} + 1))
+                    reserved_shards="$requested_shards"
+                    if [ "$reserved_shards" -gt "$item_count" ]; then
+                      reserved_shards="$item_count"
+                    fi
+                    if [ "$reserved_shards" -gt "$hard_cap" ]; then
+                      reserved_shards="$hard_cap"
+                    fi
+                  fi
+                fi
+                active_shards="$reserved_shards"
+              fi
+              total=$((total + active_shards))
+            done <<< "$runs"
+            printf '%s' "$total"
           }
-          if [ -z "$PAGE_SIZE" ]; then
-            active_critical_workers="$(( $(active_run_count ".github/workflows/repair-cluster-worker.yml") + $(active_sweep_exact_count) ))"
-            active_background_workers="$(active_sweep_background_workers)"
-            PAGE_SIZE="$(pnpm --dir clawsweeper run --silent workflow -- worker-limit commit_review --active-critical "$active_critical_workers" --active-background "$active_background_workers")"
+          active_commit_review_workers() {
+            local runs total id status jobs_json active_reviews total_reviews zero_review_plan zero_review_name
+            total=0
+            runs="$(printf '%s' "$ACTIVE_RUNS_JSON" \
+              | CURRENT_RUN_ID="${GITHUB_RUN_ID:-0}" jq -r '.[] | select((.databaseId | tostring) != env.CURRENT_RUN_ID) | select(.workflowPath == ".github/workflows/commit-review.yml" and .status == "in_progress") | [.databaseId, .status] | @tsv' 2>/dev/null || true)"
+            while IFS=$'\t' read -r id status; do
+              if [ -z "$id" ]; then
+                continue
+              fi
+              active_reviews=0
+              total_reviews=0
+              zero_review_plan=false
+              if [ "$status" = "in_progress" ]; then
+                if ! jobs_json="$(gh run view "$id" --repo "${{ github.repository }}" --json jobs 2>/dev/null)"; then
+                  # An unavailable job list cannot identify a completed zero
+                  # matrix, so retain the conservative planner reservation.
+                  jobs_json='{"jobs":[]}'
+                fi
+                active_reviews="$(printf '%s' "$jobs_json" \
+                  | jq '[.jobs[]? | select(.name | startswith("Review commit ")) | select(.status == "in_progress" or .status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested")] | length' 2>/dev/null \
+                  || printf '0')"
+                total_reviews="$(printf '%s' "$jobs_json" \
+                  | jq '[.jobs[]? | select(.name | startswith("Review commit "))] | length' 2>/dev/null \
+                  || printf '0')"
+                # GitHub represents an empty dynamic matrix as this literal,
+                # skipped job. Construct the name in Bash so Actions does not
+                # evaluate the literal matrix expression in this plan job.
+                zero_review_name='Review commit $'
+                zero_review_name+='{{ matrix.sha }}'
+                if printf '%s' "$jobs_json" | ZERO_REVIEW_NAME="$zero_review_name" \
+                  jq -e '[.jobs[]? | select(.name == env.ZERO_REVIEW_NAME) | select(.status == "completed" and .conclusion == "skipped")] | length > 0' >/dev/null 2>&1; then
+                  zero_review_plan=true
+                fi
+              fi
+              if ! [[ "$active_reviews" =~ ^[0-9]+$ ]]; then
+                active_reviews=0
+              fi
+              if ! [[ "$total_reviews" =~ ^[0-9]+$ ]]; then
+                total_reviews=0
+              fi
+              # An absent review job is either a queued/planning run or a matrix
+              # that GitHub is still materializing, so reserve its configured,
+              # hard-capped page size. The literal skipped job above proves an
+              # empty matrix and releases the reservation while it publishes.
+              if [ "$active_reviews" -lt 1 ] && [ "$total_reviews" -lt 1 ] \
+                && [ "$zero_review_plan" != "true" ]; then
+                active_reviews="$reservation_page_size"
+              fi
+              total=$((total + active_reviews))
+            done <<< "$runs"
+            printf '%s' "$total"
+          }
+          active_critical_workers="$(( $(active_run_count ".github/workflows/repair-cluster-worker.yml") + $(active_sweep_exact_workers) ))"
+          active_background_workers="$(( $(active_sweep_background_workers) + $(active_commit_review_workers) ))"
+          exact_review_pressure="idle"
+          if [ "$EXACT_REVIEW_BACKGROUND_YIELD_ENABLED" = "1" ]; then
+            if ! exact_review_pressure="$(exact_review_pressure_status)"; then
+              exact_review_pressure="idle"
+              echo "::warning::Exact-review queue telemetry was unavailable; using idle pressure (fail open)."
+            fi
           fi
-          page_size_hard_cap="$(pnpm --dir clawsweeper run --silent workflow -- limit commit_review.page_size_hard_cap)"
+          scheduler_page_size="$(pnpm --dir clawsweeper run --silent workflow -- worker-limit commit_review --active-critical "$active_critical_workers" --active-background "$active_background_workers" --exact-review-pressure "$exact_review_pressure")"
+          if [ -z "$PAGE_SIZE" ]; then
+            PAGE_SIZE="$scheduler_page_size"
+          elif [ "$exact_review_pressure" != "idle" ] && [[ "$PAGE_SIZE" =~ ^[0-9]+$ ]] && [ "$PAGE_SIZE" -gt "$scheduler_page_size" ]; then
+            echo "::notice::Capping commit-review page size from $PAGE_SIZE to $scheduler_page_size because exact-review queue is $exact_review_pressure."
+            PAGE_SIZE="$scheduler_page_size"
+          fi
+          if [ "$exact_review_pressure" != "idle" ]; then
+            echo "::notice::Exact-review pressure is $exact_review_pressure; throttling commit review intake to page_size=$PAGE_SIZE."
+          fi
           if [ "$ENABLED" = "false" ]; then
             {
               echo "matrix=[]"
@@ -296,6 +463,42 @@ jobs:
             exit 1
           fi
           if [ "$PAGE_SIZE" -lt 1 ]; then
+            if [ "$exact_review_pressure" != "idle" ]; then
+              echo "::notice::Deferring commit review because the exact-review pressure cap is occupied."
+              # Keep this plan job in the shared admission group while it waits,
+              # then requeue the same range instead of treating it as exhausted.
+              sleep 300
+              requeued=false
+              for attempt in 1 2 3; do
+                if gh workflow run commit-review.yml \
+                  --repo "${{ github.repository }}" \
+                  -f enabled=true \
+                  -f target_repo="$TARGET_REPO" \
+                  -f commit_sha="$COMMIT_SHA" \
+                  -f before_sha="$BEFORE_SHA" \
+                  -f commit_offset="$COMMIT_OFFSET" \
+                  -f create_checks="$CREATE_CHECKS" \
+                  -f additional_prompt="$ADDITIONAL_PROMPT"; then
+                  requeued=true
+                  break
+                fi
+                echo "::warning::Deferred commit-review requeue attempt $attempt failed."
+                sleep "$((attempt * 10))"
+              done
+              if [ "$requeued" != "true" ]; then
+                echo "Unable to requeue the deferred commit-review range after three attempts." >&2
+                exit 1
+              fi
+              echo "::notice::Requeued deferred commit-review range at offset $COMMIT_OFFSET."
+              {
+                echo "matrix=[]"
+                echo "has_more=false"
+                echo "next_offset=0"
+                echo "planned_count=0"
+                echo "skipped_count=0"
+              } >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
             PAGE_SIZE=1
           fi
           if [ "$PAGE_SIZE" -gt "$page_size_hard_cap" ]; then

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -11,6 +11,10 @@ run-name: >-
       'Retry failed Codex reviews' ||
     (github.event_name == 'repository_dispatch' &&
       github.event.action == 'clawsweeper_target_sweep' &&
+      github.event.client_payload.item_number != '') &&
+      format('Review event item {0}#{1}', github.event.client_payload.target_repo || 'openclaw/openclaw', github.event.client_payload.item_number) ||
+    (github.event_name == 'repository_dispatch' &&
+      github.event.action == 'clawsweeper_target_sweep' &&
       github.event.client_payload.hot_intake == 'true') &&
       format('Review hot target repo {0}', github.event.client_payload.target_repo || 'openclaw/openclaw') ||
     (github.event_name == 'repository_dispatch' &&

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2461,7 +2461,9 @@ jobs:
           set -euo pipefail
           apply_artifacts_args=(--target-repo "$TARGET_REPO" --artifact-dir artifacts --skip-dashboard --skip-reconcile)
           publish_state="Review publish complete"
-          mkdir -p review-metrics
+          # download-artifact succeeds without creating its destination when a
+          # zero-cap plan produces no matrix, so initialize both empty inputs.
+          mkdir -p artifacts review-metrics
           reviewed_count="$(find artifacts -type f -name '*.md' | wc -l | tr -d ' ')"
           metric_count="$(find review-metrics -type f -name '*.json' | wc -l | tr -d ' ')"
           non_success_metric_count="$(find review-metrics -type f -name '*.json' -print0 | xargs -0 -r jq -r 'select(.review_outcome != "success") | .shard' | wc -l | tr -d ' ')"

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1435,8 +1435,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     concurrency:
-      group: ${{ format('clawsweeper-planner-{0}', (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.item_number == '' && github.event.inputs.item_numbers == '')) && (github.event.inputs.target_repo || ((github.event.schedule == '2/5 * * * *' || github.event.schedule == '22 * * * *') && 'openclaw/clawhub' || 'openclaw/openclaw')) || github.run_id) }}
+      # The shared background-admission lock is an opt-in experiment. With the
+      # variable unset, preserve the current-main per-target planner grouping.
+      group: ${{ (github.event.client_payload.item_number || github.event.client_payload.item_numbers || github.event.inputs.item_number || github.event.inputs.item_numbers) && format('clawsweeper-review-admission-{0}', github.run_id) || vars.CLAWSWEEPER_ENABLE_EXACT_REVIEW_BACKGROUND_YIELD == '1' && 'clawsweeper-review-admission-background' || format('clawsweeper-planner-{0}', (github.event_name == 'repository_dispatch' && github.event.client_payload.target_repo) || ((github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.item_number == '' && github.event.inputs.item_numbers == '')) && (github.event.inputs.target_repo || ((github.event.schedule == '2/5 * * * *' || github.event.schedule == '22 * * * *') && 'openclaw/clawhub' || 'openclaw/openclaw'))) || github.run_id) }}
       cancel-in-progress: false
+      queue: max
     outputs:
       batch_size: ${{ steps.mode.outputs.batch_size }}
       codex_timeout_ms: ${{ steps.mode.outputs.codex_timeout_ms }}
@@ -1550,12 +1553,64 @@ jobs:
       - id: mode
         env:
           GH_TOKEN: ${{ github.token }}
+          COMMIT_REVIEW_PAGE_SIZE: ${{ vars.CLAWSWEEPER_COMMIT_REVIEW_PAGE_SIZE || '' }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          CLAWSWEEPER_EXACT_REVIEW_QUEUE_MAX_AGE_SECONDS: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_MAX_AGE_SECONDS || '900' }}
+          EXACT_REVIEW_BACKGROUND_YIELD_ENABLED: ${{ vars.CLAWSWEEPER_ENABLE_EXACT_REVIEW_BACKGROUND_YIELD || '0' }}
         run: |
           limit() {
             pnpm --dir clawsweeper run --silent workflow -- limit "$1"
           }
           worker_limit() {
             pnpm --dir clawsweeper run --silent workflow -- worker-limit "$@"
+          }
+          exact_review_pressure_status() {
+            local queue_url response generated_at generated_epoch now_epoch queue_max_age_seconds age_seconds pressure
+            queue_url="${QUEUE_URL%/}"
+            response="$(curl --fail --silent --connect-timeout 5 --max-time 10 "$queue_url/api/status" 2>/dev/null)" || return 1
+            generated_at="$(printf '%s' "$response" | jq -r '.exact_review_queue.generated_at // "" | if type == "string" then . else "" end' 2>/dev/null)" || return 1
+            if [ -z "$generated_at" ]; then
+              echo "::warning::Exact-review queue telemetry missing exact_review_queue.generated_at; using idle pressure (fail open)." >&2
+              return 1
+            fi
+            if ! generated_epoch="$(GENERATED_AT="$generated_at" node -e '
+              const value = process.env.GENERATED_AT || "";
+              if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$/.test(value)) process.exit(1);
+              const timestamp = Date.parse(value);
+              if (!Number.isFinite(timestamp)) process.exit(1);
+              process.stdout.write(String(Math.floor(timestamp / 1000)));
+            ' 2>/dev/null)"; then
+              echo "::warning::Exact-review queue telemetry has invalid generated_at; using idle pressure (fail open)." >&2
+              return 1
+            fi
+            now_epoch="$(node -e 'process.stdout.write(String(Math.floor(Date.now() / 1000)))')"
+            queue_max_age_seconds="${CLAWSWEEPER_EXACT_REVIEW_QUEUE_MAX_AGE_SECONDS:-900}"
+            if ! [[ "$queue_max_age_seconds" =~ ^[0-9]+$ ]] || [ "$queue_max_age_seconds" -lt 60 ]; then
+              queue_max_age_seconds=900
+            fi
+            age_seconds=$((now_epoch - generated_epoch))
+            if [ "$age_seconds" -gt "$queue_max_age_seconds" ]; then
+              echo "::warning::Exact-review queue telemetry snapshot is stale (generated_at=$generated_at, age_seconds=$age_seconds); using idle pressure (fail open)." >&2
+              return 1
+            fi
+            if [ "$age_seconds" -lt -300 ]; then
+              echo "::warning::Exact-review queue telemetry generated_at is too far in the future (generated_at=$generated_at); using idle pressure (fail open)." >&2
+              return 1
+            fi
+            pressure="$(printf '%s' "$response" | jq -r '.exact_review_queue.pressure.status // "" | if type == "string" then . else "" end' 2>/dev/null)" || return 1
+            case "$pressure" in
+              idle|congested|saturated)
+                printf '%s' "$pressure"
+                ;;
+              unknown|"")
+                echo "::warning::Exact-review pressure is unavailable; using idle pressure (fail open)." >&2
+                return 1
+                ;;
+              *)
+                echo "::warning::Exact-review pressure has unknown status '$pressure'; using idle pressure (fail open)." >&2
+                return 1
+                ;;
+            esac
           }
           active_runs_json() {
             {
@@ -1644,7 +1699,7 @@ jobs:
             local runs total id title status jobs_json active_shards total_shards
             total=0
             runs="$(printf '%s' "$ACTIVE_RUNS_JSON" \
-              | CURRENT_RUN_ID="${GITHUB_RUN_ID:-0}" STALE_QUEUED_CUTOFF="$STALE_QUEUED_CUTOFF" jq -r '.[] | select((.databaseId | tostring) != env.CURRENT_RUN_ID) | select(.workflowPath == ".github/workflows/sweep.yml") | select(.status == "in_progress" or ((.status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") and ((.updatedAt // .createdAt // "") >= env.STALE_QUEUED_CUTOFF))) | select(.displayTitle == "Review ClawSweeper items" or .displayTitle == "Review hot ClawSweeper items" or (.displayTitle | startswith("Review target repo ")) or (.displayTitle | startswith("Review hot target repo "))) | [.databaseId, .displayTitle, .status] | @tsv' 2>/dev/null || true)"
+              | CURRENT_RUN_ID="${GITHUB_RUN_ID:-0}" jq -r '.[] | select((.databaseId | tostring) != env.CURRENT_RUN_ID) | select(.workflowPath == ".github/workflows/sweep.yml") | select(.status == "in_progress") | select(.displayTitle == "Review ClawSweeper items" or .displayTitle == "Review hot ClawSweeper items" or (.displayTitle | startswith("Review target repo ")) or (.displayTitle | startswith("Review hot target repo "))) | [.databaseId, .displayTitle, .status] | @tsv' 2>/dev/null || true)"
             while IFS=$'\t' read -r id title status; do
               if [ -z "$id" ]; then
                 continue
@@ -1680,14 +1735,75 @@ jobs:
             done <<< "$runs"
             printf '%s' "$total"
           }
+          active_commit_review_workers() {
+            local runs total id jobs_json active_reviews total_reviews zero_review_plan zero_review_name
+            local reservation_page_size page_size_hard_cap
+            total=0
+            page_size_hard_cap="$(limit commit_review.page_size_hard_cap)"
+            reservation_page_size="${COMMIT_REVIEW_PAGE_SIZE:-}"
+            if ! [[ "$reservation_page_size" =~ ^[0-9]+$ ]] || [ "$reservation_page_size" -lt 1 ]; then
+              reservation_page_size="$(limit commit_review.page_size_default)"
+            fi
+            if [ "$reservation_page_size" -gt "$page_size_hard_cap" ]; then
+              reservation_page_size="$page_size_hard_cap"
+            fi
+            runs="$(printf '%s' "$ACTIVE_RUNS_JSON" \
+              | CURRENT_RUN_ID="${GITHUB_RUN_ID:-0}" jq -r '.[] | select((.databaseId | tostring) != env.CURRENT_RUN_ID) | select(.workflowPath == ".github/workflows/commit-review.yml" and .status == "in_progress") | .databaseId' 2>/dev/null || true)"
+            while IFS= read -r id; do
+              if [ -z "$id" ]; then
+                continue
+              fi
+              jobs_json="$(gh run view "$id" --repo "${{ github.repository }}" --json jobs 2>/dev/null || printf '{"jobs":[]}')"
+              total_reviews="$(printf '%s' "$jobs_json" \
+                | jq '[.jobs[]? | select(.name | startswith("Review commit "))] | length' 2>/dev/null \
+                || printf '0')"
+              active_reviews="$(printf '%s' "$jobs_json" \
+                | jq '[.jobs[]? | select(.name | startswith("Review commit ")) | select(.status == "in_progress" or .status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested")] | length' 2>/dev/null \
+                || printf '0')"
+              zero_review_plan=false
+              # A skipped dynamic-matrix job proves this run planned no review
+              # workers, so its publishing phase should not reserve capacity.
+              zero_review_name='Review commit $'
+              zero_review_name+='{{ matrix.sha }}'
+              if printf '%s' "$jobs_json" | ZERO_REVIEW_NAME="$zero_review_name" \
+                jq -e '[.jobs[]? | select(.name == env.ZERO_REVIEW_NAME) | select(.status == "completed" and .conclusion == "skipped")] | length > 0' >/dev/null 2>&1; then
+                zero_review_plan=true
+              fi
+              if ! [[ "$active_reviews" =~ ^[0-9]+$ ]]; then
+                active_reviews=0
+              fi
+              if ! [[ "$total_reviews" =~ ^[0-9]+$ ]]; then
+                total_reviews=0
+              fi
+              # Between plan completion and matrix materialization, reserve the
+              # configured page size so the next serialized broad planner cannot
+              # claim the same pressure allowance. Queued whole workflows are
+              # excluded above; only an in-progress planner can reserve here.
+              if [ "$active_reviews" -lt 1 ] && [ "$total_reviews" -lt 1 ] \
+                && [ "$zero_review_plan" != "true" ]; then
+                active_reviews="$reservation_page_size"
+              fi
+              total=$((total + active_reviews))
+            done <<< "$runs"
+            printf '%s' "$total"
+          }
           exact_item_shards="$(limit review_shards.exact_item_default)"
           normal_active_floor="$(limit review_shards.normal_active_floor)"
           hard_shard_cap="$(limit review_shards.hard_cap)"
-          commit_page_size="$(limit commit_review.page_size_default)"
+          exact_review_pressure="idle"
+          if [ "$EXACT_REVIEW_BACKGROUND_YIELD_ENABLED" = "1" ]; then
+            if ! exact_review_pressure="$(exact_review_pressure_status)"; then
+              exact_review_pressure="idle"
+              echo "::warning::Exact-review queue telemetry was unavailable; using idle pressure (fail open)."
+            fi
+          fi
           active_critical_workers="$(( $(active_run_count ".github/workflows/repair-cluster-worker.yml") + $(active_sweep_exact_workers) ))"
-          active_background_workers="$(( $(active_run_count ".github/workflows/commit-review.yml") * commit_page_size + $(active_sweep_background_workers) ))"
-          hot_intake_shards="$(worker_limit hot_intake --active-critical "$active_critical_workers" --active-background "$active_background_workers")"
-          normal_shards="$(worker_limit normal_review --active-critical "$active_critical_workers" --active-background "$active_background_workers")"
+          active_background_workers="$(( $(active_commit_review_workers) + $(active_sweep_background_workers) ))"
+          hot_intake_shards="$(worker_limit hot_intake --active-critical "$active_critical_workers" --active-background "$active_background_workers" --exact-review-pressure "$exact_review_pressure")"
+          normal_shards="$(worker_limit normal_review --active-critical "$active_critical_workers" --active-background "$active_background_workers" --exact-review-pressure "$exact_review_pressure")"
+          if [ "$exact_review_pressure" != "idle" ]; then
+            echo "::notice::Exact-review pressure is $exact_review_pressure; throttling broad review intake to normal=$normal_shards and hot=$hot_intake_shards."
+          fi
           hot_intake="${{ ((github.event_name == 'repository_dispatch' && github.event.client_payload.hot_intake == 'true') || (github.event_name == 'workflow_dispatch' && github.event.inputs.hot_intake == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '*/5 * * * *' || github.event.schedule == '2/5 * * * *'))) && 'true' || 'false' }}"
           exact_item="${{ github.event.client_payload.item_number || github.event.inputs.item_number || github.event.inputs.item_numbers || '' }}"
           target_repo="${{ steps.target.outputs.target_repo }}"
@@ -1737,10 +1853,13 @@ jobs:
             if [ "$hot_intake" = "true" ]; then
               lane_shard_cap="$hot_intake_shards"
             fi
-            if ! [[ "$lane_shard_cap" =~ ^[0-9]+$ ]] || [ "$lane_shard_cap" -lt 1 ]; then
-              lane_shard_cap="1"
+            if ! [[ "$lane_shard_cap" =~ ^[0-9]+$ ]]; then
+              lane_shard_cap="0"
             fi
-            if [ "$shard_count" -gt "$lane_shard_cap" ]; then
+            if [ "$lane_shard_cap" -lt 1 ]; then
+              echo "::notice::Deferring broad background review because the exact-review pressure cap is occupied."
+              shard_count="0"
+            elif [ "$shard_count" -gt "$lane_shard_cap" ]; then
               echo "::notice::Capping broad background review shards from $shard_count to scheduler allowance $lane_shard_cap."
               shard_count="$lane_shard_cap"
             fi
@@ -1772,6 +1891,19 @@ jobs:
           GH_TOKEN: ${{ steps.target-read-token.outputs.token || github.token }}
         run: |
           set -euo pipefail
+          if ! [[ "$SHARD_COUNT" =~ ^[0-9]+$ ]]; then
+            echo "Invalid review shard count: $SHARD_COUNT" >&2
+            exit 1
+          fi
+          if [ "$SHARD_COUNT" -lt 1 ]; then
+            echo "::notice::Deferring broad review planning because the exact-review pressure cap is occupied."
+            printf '%s\n' '{"matrix":[],"candidates":[],"capacity":0,"activeCodexTarget":0,"dueBacklog":0,"capacityReason":"deferred: exact-review background cap occupied"}' > plan.json
+            pnpm run --silent workflow -- plan-output \
+              --plan plan.json \
+              --batch-size "$BATCH_SIZE" \
+              --shard-count 1 >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           item_arg=()
           if [ -n "$ITEM_NUMBER" ]; then
             item_arg=(--item-number "$ITEM_NUMBER")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,11 +57,6 @@ checkpoint, and status-only commits are intentionally omitted.
 - Added a system, light, and dark theme switcher to the generated documentation site. Thanks @joshka.
 
 ### Changed
-
-- Added a default-off shared admission policy that consumes fresh exact-review
-  pressure to cap normal, hot-intake, and commit review at 16 or 4 background
-  workers, re-evaluates continuations, and defers saturated work without
-  changing exact-review capacity. Thanks @brokemac79.
 - Preserved crawl-remote's reviewed `limits.cpu_ms` value through immutable
   release packaging and post-transfer deployment verification.
 - Reverted the action-lifecycle expansion from PR #521, restoring the pre-merge ClawSweeper paths while retaining later exact-review throughput fixes and retrying coalesced reconciliations after any partial lookup failure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Added a default-off shared admission policy that consumes fresh exact-review
+  pressure to cap normal, hot-intake, and commit review at 16 or 4 background
+  workers, re-evaluates continuations, and defers saturated work without
+  changing exact-review capacity. Thanks @brokemac79.
 - Preserved crawl-remote's reviewed `limits.cpu_ms` value through immutable
   release packaging and post-transfer deployment verification.
 - Reverted the action-lifecycle expansion from PR #521, restoring the pre-merge ClawSweeper paths while retaining later exact-review throughput fixes and retrying coalesced reconciliations after any partial lookup failure.

--- a/config/automation-limits.json
+++ b/config/automation-limits.json
@@ -8,7 +8,9 @@
   "lanes": {
     "exact_review": {
       "max_concurrent": 64,
-      "target_max_concurrent": 60
+      "target_max_concurrent": 60,
+      "background_congested_max_workers": 16,
+      "background_saturated_max_workers": 4
     },
     "assist": {
       "max": 10

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -27,20 +27,26 @@ The mental model:
 - Assist has a small fixed cap because it is lightweight maintainer Q&A, not a
   derived review or repair lane.
 - Background lanes shrink when priority work is already active.
+- The optional exact-review background-yield experiment can further reduce
+  broad review work when the queue publishes `congested` or `saturated`
+  pressure. It is disabled unless a maintainer sets
+  `CLAWSWEEPER_ENABLE_EXACT_REVIEW_BACKGROUND_YIELD=1`.
 - Runtime overrides are escape hatches, not the normal tuning surface.
 
 ## Worker Budget
 
-| Name                                       | Current | Meaning                                                                               |
-| ------------------------------------------ | ------: | ------------------------------------------------------------------------------------- |
-| `workers.max`                              |     128 | Maximum global Codex worker budget used to derive lane limits.                        |
-| `workers.reserve_for_interactive`          |      16 | Worker slots background lanes leave open for exact/manual/urgent work.                |
-| `workers.expansion_reserve`                |       8 | Extra slots background lanes leave open for independently planned matrix expansion.   |
-| `workers.minimum_background`               |      16 | Target floor for background progress when enough global capacity is available.        |
-| `lanes.exact_review.max_concurrent`        |      64 | Maximum concurrent exact-item review workflow runs admitted to Codex.                 |
-| `lanes.exact_review.target_max_concurrent` |      60 | Maximum concurrent exact-item review workflow runs one target repository may consume. |
-| `lanes.assist.max`                         |      10 | Maximum concurrent lightweight assist jobs.                                           |
-| `lanes.repair.cluster_max_live_runs`       |       2 | Default live repair workflow cap for imported gitcrawl cluster dispatches.            |
+| Name                                                  | Current | Meaning                                                                                       |
+| ----------------------------------------------------- | ------: | --------------------------------------------------------------------------------------------- |
+| `workers.max`                                         |     128 | Maximum global Codex worker budget used to derive lane limits.                                |
+| `workers.reserve_for_interactive`                     |      16 | Worker slots background lanes leave open for exact/manual/urgent work.                        |
+| `workers.expansion_reserve`                           |       8 | Extra slots background lanes leave open for independently planned matrix expansion.           |
+| `workers.minimum_background`                          |      16 | Target floor for background progress when enough global capacity is available.                |
+| `lanes.exact_review.max_concurrent`                   |      64 | Maximum concurrent exact-item review workflow runs admitted to Codex.                         |
+| `lanes.exact_review.target_max_concurrent`            |      60 | Maximum concurrent exact-item review workflow runs one target repository may consume.         |
+| `lanes.exact_review.background_congested_max_workers` |      16 | Experimental broad-review cap while the queue publishes `congested` pressure. |
+| `lanes.exact_review.background_saturated_max_workers` |       4 | Experimental broad-review cap while the queue publishes `saturated` pressure. |
+| `lanes.assist.max`                                    |      10 | Maximum concurrent lightweight assist jobs.                                                   |
+| `lanes.repair.cluster_max_live_runs`                  |       2 | Default live repair workflow cap for imported gitcrawl cluster dispatches.                    |
 
 ## Derived Limits
 
@@ -55,6 +61,8 @@ by default.
 | --------------------------------------------------- | ------: | ------------------------------------------------------------------------------------- |
 | `exact_review.concurrent_max`                       |      64 | Exact-item review admission cap, clamped to `workers.max`.                            |
 | `exact_review.target_concurrent_max`                |      60 | Exact-item per-target admission cap, clamped to global exact-review capacity.         |
+| `exact_review.background_congested_max_workers`     |      16 | Experimental broad-review cap for published `congested` pressure.                     |
+| `exact_review.background_saturated_max_workers`     |       4 | Experimental broad-review cap for published `saturated` pressure.                     |
 | `assist.default`                                    |      10 | Maintainer assist job cap.                                                            |
 | `review_shards.normal_default`                      |      89 | Quiet-system normal review shard ceiling.                                             |
 | `review_shards.normal_active_floor`                 |      38 | Minimum active normal review shards to keep queued for `openclaw/openclaw`.           |
@@ -99,7 +107,44 @@ The scheduler does this for background lanes:
 4. reserve `workers.reserve_for_interactive`
 5. reserve `workers.expansion_reserve` for independently planned matrix waves
 6. cap the result at the lane's derived quiet-system ceiling
-7. return at least 1 so an enabled lane can still make slow progress
+7. when the fresh queue snapshot publishes `congested` pressure, cap broad lanes at
+   `lanes.exact_review.background_congested_max_workers`
+8. when the fresh queue snapshot publishes `saturated` pressure, cap broad lanes at
+   `lanes.exact_review.background_saturated_max_workers`
+9. return zero when the exact-pressure cap is already consumed, so no further
+   broad worker is admitted until the current matrices drain
+
+The pressure cap is a shared residual allowance, not a fresh allowance for
+each concurrently planning background workflow. Existing broad review matrices
+are subtracted before calculating new intake; once the cap is already occupied,
+the scheduler defers new broad work until in-flight jobs drain. With the
+experiment enabled, sweep and commit-review planners share one broad-admission
+lock so concurrent snapshots cannot each claim the same allowance. Queued
+planners are held by that lock; only in-progress review matrices consume the
+live pressure allowance.
+Manual exact-review batches remain priority work and are never charged against
+that background allowance.
+An unexpanded commit-review planner reserves its configured, hard-capped page
+size until its review matrix is visible. A literal skipped matrix job identifies
+a completed zero-review plan so its report-publishing phase holds no reservation.
+When exact pressure consumes the allowance, commit review keeps the shared
+admission lock for a short delay and requeues the same commit range; it is
+deferred rather than marked reviewed or exhausted.
+
+The workflow reads `exact_review_queue.generated_at` and
+`exact_review_queue.pressure.status` from the public queue snapshot before
+admitting normal review, hot intake, or commit-review work. Pressure production
+and explanation remain owned by the dashboard queue surface; the workflow does
+not reconstruct pressure from raw queue counts. A failed, stale, malformed,
+missing, or `unknown` snapshot is fail-open: the existing active-worker
+calculation remains in effect. The queue's pressure contract already excludes
+retry-delayed or target-cap-blocked work and reports inactive dispatch or
+unknown handoff state as `idle` or `unknown`.
+Exact-review admission itself remains governed by the durable queue's separate
+global and per-target caps; these background caps reduce competing work rather
+than raising those admission limits. An explicit commit-review page-size override
+remains unchanged while the queue is idle, but is capped while exact-review
+pressure is present.
 
 Background planner jobs serialize per target repository. A sweep that is still
 planning, queued, or expanding its matrix reserves its quiet lane size. Once
@@ -158,6 +203,9 @@ Examples with the current config:
   - 96 background = 4`.
 - 105 active priority workers: commit review gets 1, so commit review yields but
   does not fully stall.
+- Saturated exact-review pressure with four active background workers: the
+  shared four-worker allowance is occupied, so new broad planners defer until
+  one of those workers drains.
 
 Use these commands to inspect the effective values from a checkout:
 
@@ -178,6 +226,11 @@ hot intake `14`, and commit review `2`. Existing repair lanes keep their
 
 - `CLAWSWEEPER_COMMIT_REVIEW_PAGE_SIZE` overrides
   `commit_review.page_size_default`.
+- `CLAWSWEEPER_ENABLE_EXACT_REVIEW_BACKGROUND_YIELD=1` enables shared
+  background admission and pressure-based caps. The default is disabled.
+- `CLAWSWEEPER_EXACT_REVIEW_QUEUE_MAX_AGE_SECONDS` sets the maximum age of a
+  trusted exact-review queue snapshot for scheduler reshuffling. The default is
+  900 seconds; values below 60 seconds fall back to that default.
 - `CLAWSWEEPER_FEATURE_CLUSTER_REPAIR_ENABLED=1` enables the scheduled
   `repair-cluster-intake.yml` imported-cluster intake. Direct repair import and
   dispatch commands are not blocked by this variable; they keep the existing

--- a/scripts/check-limits.ts
+++ b/scripts/check-limits.ts
@@ -13,6 +13,8 @@ type WorkerConfig = {
     exact_review: {
       max_concurrent: number;
       target_max_concurrent: number;
+      background_congested_max_workers: number;
+      background_saturated_max_workers: number;
     };
     assist: {
       max: number;
@@ -27,6 +29,8 @@ type AutomationLimits = {
   exact_review: {
     concurrent_max: number;
     target_concurrent_max: number;
+    background_congested_max_workers: number;
+    background_saturated_max_workers: number;
   };
   assist: {
     default: number;
@@ -237,6 +241,14 @@ function deriveAutomationLimits(workerConfig: WorkerConfig): AutomationLimits {
       target_concurrent_max: Math.min(
         workerConfig.lanes.exact_review.target_max_concurrent,
         workerConfig.lanes.exact_review.max_concurrent,
+        max,
+      ),
+      background_congested_max_workers: Math.min(
+        workerConfig.lanes.exact_review.background_congested_max_workers,
+        max,
+      ),
+      background_saturated_max_workers: Math.min(
+        workerConfig.lanes.exact_review.background_saturated_max_workers,
         max,
       ),
     },

--- a/src/repair/limits.ts
+++ b/src/repair/limits.ts
@@ -13,6 +13,8 @@ export type WorkerConfig = {
     exact_review: {
       max_concurrent: number;
       target_max_concurrent: number;
+      background_congested_max_workers: number;
+      background_saturated_max_workers: number;
     };
     assist: {
       max: number;
@@ -27,6 +29,8 @@ export type AutomationLimits = {
   exact_review: {
     concurrent_max: number;
     target_concurrent_max: number;
+    background_congested_max_workers: number;
+    background_saturated_max_workers: number;
   };
   assist: {
     default: number;
@@ -65,6 +69,8 @@ export type WorkerLane =
   | "exact_item"
   | "assist";
 
+export type ExactReviewQueuePressure = "idle" | "congested" | "saturated";
+
 export const WORKER_CONFIG = readWorkerConfig();
 export const AUTOMATION_LIMITS = deriveAutomationLimits(WORKER_CONFIG);
 
@@ -84,6 +90,14 @@ export function deriveAutomationLimits(config: WorkerConfig): AutomationLimits {
       target_concurrent_max: Math.min(
         config.lanes.exact_review.target_max_concurrent,
         config.lanes.exact_review.max_concurrent,
+        max,
+      ),
+      background_congested_max_workers: Math.min(
+        config.lanes.exact_review.background_congested_max_workers,
+        max,
+      ),
+      background_saturated_max_workers: Math.min(
+        config.lanes.exact_review.background_saturated_max_workers,
         max,
       ),
     },
@@ -119,11 +133,13 @@ export function workerLimit(
   {
     activeCritical = 0,
     activeBackground = 0,
+    exactReviewPressure = "idle",
     config = WORKER_CONFIG,
     limits = AUTOMATION_LIMITS,
   }: {
     activeCritical?: number;
     activeBackground?: number;
+    exactReviewPressure?: ExactReviewQueuePressure;
     config?: WorkerConfig;
     limits?: AutomationLimits;
   } = {},
@@ -138,18 +154,16 @@ export function workerLimit(
   if (lane === "cluster_repair")
     return priorityLimit(limits.repair_live_runs.cluster_default, activeCritical);
   if (lane === "commit_review")
-    return backgroundLimit(
-      limits.commit_review.page_size_default,
-      activeCritical,
-      activeBackground,
+    return pressureLimitedBackground(
+      backgroundLimit(limits.commit_review.page_size_default, activeCritical, activeBackground),
     );
   if (lane === "hot_intake")
-    return backgroundLimit(
-      limits.review_shards.hot_intake_default,
-      activeCritical,
-      activeBackground,
+    return pressureLimitedBackground(
+      backgroundLimit(limits.review_shards.hot_intake_default, activeCritical, activeBackground),
     );
-  return backgroundLimit(limits.review_shards.normal_default, activeCritical, activeBackground);
+  return pressureLimitedBackground(
+    backgroundLimit(limits.review_shards.normal_default, activeCritical, activeBackground),
+  );
 
   function priorityLimit(laneMax: number, active: number): number {
     const available = Math.max(1, config.workers.max - nonNegative(active));
@@ -168,25 +182,59 @@ export function workerLimit(
       rawAvailable >= config.workers.minimum_background ? rawAvailable : Math.max(1, rawAvailable);
     return Math.max(1, Math.min(laneMax, withFloor));
   }
+
+  function pressureLimitedBackground(limit: number): number {
+    const pressureCap =
+      exactReviewPressure === "saturated"
+        ? limits.exact_review.background_saturated_max_workers
+        : exactReviewPressure === "congested"
+          ? limits.exact_review.background_congested_max_workers
+          : undefined;
+    if (pressureCap !== undefined) {
+      // The pressure cap is shared by broad lanes. Once in-flight matrices use
+      // that allowance, admit no more background workers until capacity drains.
+      return Math.min(limit, Math.max(0, pressureCap - nonNegative(activeBackground)));
+    }
+    return limit;
+  }
 }
 
 function validateWorkerConfig(value: unknown): WorkerConfig {
   if (!isRecord(value)) throw new Error("automation limits must be an object");
+  const workerMax = positiveInteger(value, "workers.max");
+  const exactReviewMax = positiveInteger(value, "lanes.exact_review.max_concurrent");
+  const backgroundCongestedMax = optionalPositiveInteger(
+    value,
+    "lanes.exact_review.background_congested_max_workers",
+    workerMax,
+  );
+  const backgroundSaturatedMax = optionalPositiveInteger(
+    value,
+    "lanes.exact_review.background_saturated_max_workers",
+    backgroundCongestedMax,
+  );
+  if (backgroundSaturatedMax > backgroundCongestedMax) {
+    throw new Error(
+      "automation limit lanes.exact_review.background_saturated_max_workers must not exceed lanes.exact_review.background_congested_max_workers",
+    );
+  }
   return {
     workers: {
-      max: positiveInteger(value, "workers.max"),
+      max: workerMax,
       reserve_for_interactive: nonNegativeInteger(value, "workers.reserve_for_interactive"),
       expansion_reserve: nonNegativeInteger(value, "workers.expansion_reserve"),
       minimum_background: positiveInteger(value, "workers.minimum_background"),
     },
     lanes: {
       exact_review: {
-        max_concurrent: positiveInteger(value, "lanes.exact_review.max_concurrent"),
+        max_concurrent: exactReviewMax,
         target_max_concurrent: optionalPositiveInteger(
           value,
           "lanes.exact_review.target_max_concurrent",
-          positiveInteger(value, "lanes.exact_review.max_concurrent"),
+          exactReviewMax,
         ),
+        background_congested_max_workers: backgroundCongestedMax,
+        background_saturated_max_workers: backgroundSaturatedMax,
       },
       assist: {
         max: positiveInteger(value, "lanes.assist.max"),

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -5,7 +5,13 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { parseArgs } from "./lib.js";
 import { isJsonObject } from "./json-types.js";
-import { AUTOMATION_LIMITS, WORKER_CONFIG, workerLimit, type WorkerLane } from "./limits.js";
+import {
+  AUTOMATION_LIMITS,
+  WORKER_CONFIG,
+  workerLimit,
+  type ExactReviewQueuePressure,
+  type WorkerLane,
+} from "./limits.js";
 
 type ApplyAction = {
   action: string;
@@ -267,6 +273,9 @@ function runCli(): void {
           workerLimit(requiredWorkerLane(optionalString("lane") || positionalString(1)), {
             activeCritical: numberArg("active-critical", 0),
             activeBackground: numberArg("active-background", 0),
+            exactReviewPressure: optionalExactReviewQueuePressure(
+              optionalString("exact-review-pressure"),
+            ),
           }),
         ),
       );
@@ -331,6 +340,12 @@ function requiredWorkerLane(value: string): WorkerLane {
   ]);
   if (allowed.has(value as WorkerLane)) return value as WorkerLane;
   throw new Error(`unknown worker lane: ${value}`);
+}
+
+function optionalExactReviewQueuePressure(value: string): ExactReviewQueuePressure {
+  if (!value || value === "idle") return "idle";
+  if (value === "congested" || value === "saturated") return value;
+  throw new Error(`unknown exact-review pressure: ${value}`);
 }
 
 export function automationLimit(limitPath: string): number {

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -249,6 +249,57 @@ test("worker scheduler keeps 104 slots available for steady background work", ()
   assert.ok(quietBackgroundCapacity >= Math.floor(WORKER_CONFIG.workers.max * 0.8));
 });
 
+test("exact-review pressure caps only background review lanes", () => {
+  assert.equal(
+    workerLimit("normal_review", { exactReviewPressure: "congested" }),
+    AUTOMATION_LIMITS.exact_review.background_congested_max_workers,
+  );
+  assert.equal(
+    workerLimit("hot_intake", { exactReviewPressure: "saturated" }),
+    AUTOMATION_LIMITS.exact_review.background_saturated_max_workers,
+  );
+  assert.equal(
+    workerLimit("commit_review", { exactReviewPressure: "saturated" }),
+    AUTOMATION_LIMITS.exact_review.background_saturated_max_workers,
+  );
+  assert.equal(
+    workerLimit("commit_review", {
+      activeBackground: AUTOMATION_LIMITS.exact_review.background_saturated_max_workers - 1,
+      exactReviewPressure: "saturated",
+    }),
+    1,
+  );
+  assert.equal(
+    workerLimit("normal_review", {
+      activeBackground: AUTOMATION_LIMITS.exact_review.background_saturated_max_workers,
+      exactReviewPressure: "saturated",
+    }),
+    0,
+  );
+  assert.equal(
+    workerLimit("repair", { exactReviewPressure: "saturated" }),
+    AUTOMATION_LIMITS.repair_live_runs.default,
+  );
+});
+
+test("workflow utility CLI rejects pressure states outside the dashboard contract", () => {
+  assert.throws(
+    () =>
+      execFileSync(
+        process.execPath,
+        [
+          path.resolve("dist/repair/workflow-utils.js"),
+          "worker-limit",
+          "normal_review",
+          "--exact-review-pressure",
+          "unknown",
+        ],
+        { cwd: process.cwd(), encoding: "utf8", stdio: "pipe" },
+      ),
+    /Command failed/,
+  );
+});
+
 test("worker config defaults imported cluster repair capacity for older configs", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-limits-"));
   const configPath = path.join(root, "automation-limits.json");
@@ -928,6 +979,33 @@ test("workflow utilities expose review capacity telemetry from plans", () => {
       due_backlog: "17",
       oldest_unreviewed_at: "2026-01-01T00:00:00Z",
       capacity_reason: "under capacity: due backlog below planned capacity",
+    },
+  );
+});
+
+test("workflow utilities preserve a zero-capacity deferred review plan", () => {
+  assert.deepEqual(
+    planOutputFields(
+      {
+        capacity: 0,
+        candidates: [],
+        matrix: [],
+        activeCodexTarget: 0,
+        dueBacklog: 0,
+        capacityReason: "deferred: exact-review background cap occupied",
+      },
+      { batchSize: 3, shardCount: 1 },
+    ),
+    {
+      matrix: "[]",
+      planned_count: "0",
+      planned_capacity: "0",
+      planned_item_numbers: "",
+      planned_shards: "0",
+      active_codex_target: "0",
+      due_backlog: "0",
+      oldest_unreviewed_at: "",
+      capacity_reason: "deferred: exact-review background cap occupied",
     },
   );
 });

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -151,6 +151,7 @@ test("review and apply primary boundaries ignore ledger-only failures", () => {
   assert.doesNotMatch(artifactSync.if ?? "", /action-ledger/);
   const artifactApply = step("publish", "Apply review artifacts");
   assert.match(artifactApply.if ?? "", /sync-review-artifacts\.outcome == 'success'/);
+  assert.match(artifactApply.run ?? "", /mkdir -p artifacts review-metrics/);
   assert.match(artifactApply.run ?? "", /review_batch_succeeded=/);
   assert.match(artifactApply.run ?? "", /artifacts_applied=true/);
   const artifactLedger = step("publish", "Publish review artifact action ledger");

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1934,7 +1934,7 @@ test("sweep target checkouts retry without cached references", () => {
   }
 });
 
-test("target sweep runs count as background review capacity", () => {
+test("broad target sweep runs count as background review capacity", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const capacityBlock = workflow.slice(
     workflow.indexOf("active_sweep_background_workers()"),
@@ -1948,6 +1948,53 @@ test("target sweep runs count as background review capacity", () => {
   assert.match(capacityBlock, /startswith\("Review target repo "\)/);
   assert.match(capacityBlock, /startswith\("Review hot target repo "\)/);
   assert.match(capacityBlock, /Review\\ hot\\ target\\ repo/);
+});
+
+test("item-bearing target sweeps count as exact review capacity", () => {
+  const sweepWorkflow = readText(".github/workflows/sweep.yml");
+  const runName = sweepWorkflow.slice(
+    sweepWorkflow.indexOf("run-name:"),
+    sweepWorkflow.indexOf("\non:"),
+  );
+  const exactTargetName = runName.indexOf(
+    "github.event.action == 'clawsweeper_target_sweep' &&\n" +
+      "      github.event.client_payload.item_number != ''",
+  );
+  const broadTargetName = runName.indexOf("github.event.action == 'clawsweeper_target_sweep') &&");
+  const sweepModeBlock = sweepWorkflow.slice(
+    sweepWorkflow.indexOf("- id: mode"),
+    sweepWorkflow.indexOf("- id: select"),
+  );
+  const commitWorkflow = readText(".github/workflows/commit-review.yml");
+  const commitBlock = commitWorkflow.slice(
+    commitWorkflow.indexOf("- name: Select commits"),
+    commitWorkflow.indexOf('if [ "$ENABLED" = "false" ]'),
+  );
+  const requeueBlock = sweepWorkflow.slice(
+    sweepWorkflow.indexOf("\n  requeue-source-revision-drift:"),
+    sweepWorkflow.indexOf(
+      "\n  publish:",
+      sweepWorkflow.indexOf("\n  requeue-source-revision-drift:"),
+    ),
+  );
+
+  assert.ok(exactTargetName >= 0);
+  assert.ok(exactTargetName < broadTargetName);
+  assert.match(
+    runName,
+    /format\('Review event item \{0\}#\{1\}', github\.event\.client_payload\.target_repo \|\| 'openclaw\/openclaw', github\.event\.client_payload\.item_number\)/,
+  );
+  for (const block of [sweepModeBlock, commitBlock]) {
+    const exactWorkers = extractWorkflowShellFunction(block, "active_sweep_exact_workers");
+    const backgroundWorkers = extractWorkflowShellFunction(
+      block,
+      "active_sweep_background_workers",
+    );
+    assert.match(exactWorkers, /startswith\("Review event item "\)/);
+    assert.doesNotMatch(backgroundWorkers, /Review event item/);
+  }
+  assert.match(requeueBlock, /event_type: "clawsweeper_target_sweep"/);
+  assert.match(requeueBlock, /item_number: \$item_number/);
 });
 
 test("target hot sweep dispatches honor shard cap payload", () => {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1984,15 +1984,29 @@ test("sweep workflow_dispatch input count stays under GitHub limit", () => {
   assert.ok(inputNames.length <= 25, `workflow_dispatch has ${inputNames.length} inputs`);
 });
 
-test("sweep review continuations stay workflow-dispatch compatible", () => {
+test("sweep review continuations reapply the current pressure cap", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const continueBlock = workflow.slice(
     workflow.indexOf("- name: Continue sweep"),
     workflow.indexOf("\n\n  recover-review-failures:"),
   );
-
   assert.match(continueBlock, /-f target_repo="\$\{\{ needs\.plan\.outputs\.target_repo \}\}"/);
   assert.match(continueBlock, /-f target_branch="\$\{\{ needs\.plan\.outputs\.target_branch \}\}"/);
+  const modeBlock = workflow.slice(
+    workflow.indexOf("- id: mode"),
+    workflow.indexOf("- id: select"),
+  );
+
+  assert.match(continueBlock, /-f shard_count="\$\{\{ needs\.plan\.outputs\.shard_count \}\}"/);
+  assert.match(
+    modeBlock,
+    /shard_count="\$\{\{ github\.event\.client_payload\.shard_count \|\| github\.event\.inputs\.shard_count \|\| '' \}\}"/,
+  );
+  assert.match(modeBlock, /if \[ -z "\$exact_item" \]; then/);
+  assert.match(modeBlock, /lane_shard_cap="\$normal_shards"/);
+  assert.match(modeBlock, /lane_shard_cap="\$hot_intake_shards"/);
+  assert.match(modeBlock, /if \[ "\$shard_count" -gt "\$lane_shard_cap" \]; then/);
+  assert.match(modeBlock, /Capping broad background review shards/);
 });
 
 test("failed review recovery waits for durable exact-review queue acknowledgement", () => {
@@ -2060,7 +2074,6 @@ test("review capacity probes use REST actions run listing", () => {
     commitWorkflow.indexOf("- name: Select commits"),
     commitWorkflow.indexOf('if [ "$ENABLED" = "false" ]'),
   );
-
   for (const block of [sweepBlock, commitBlock]) {
     assert.match(block, /active_runs_json\(\)/);
     assert.match(block, /actions\/runs\?per_page=100/);
@@ -2088,6 +2101,17 @@ test("background review capacity reserves expanding matrices and caps broad manu
     commitWorkflow.indexOf("- name: Select commits"),
     commitWorkflow.indexOf('if [ "$ENABLED" = "false" ]'),
   );
+  const selectBlock = workflow.slice(
+    workflow.indexOf("- id: select"),
+    workflow.indexOf("- name: Prepare review runtime artifact"),
+  );
+  const commitSelectBlock = commitWorkflow.slice(
+    commitWorkflow.indexOf("- name: Select commits"),
+    commitWorkflow.indexOf(
+      'url="https://x-access-token:',
+      commitWorkflow.indexOf("- name: Select commits"),
+    ),
+  );
 
   assert.match(modeBlock, /limit review_shards\.hot_intake_default/);
   assert.match(modeBlock, /limit review_shards\.normal_default/);
@@ -2102,13 +2126,21 @@ test("background review capacity reserves expanding matrices and caps broad manu
   assert.match(modeBlock, /\[ "\$active_shards" -lt 1 \] && \[ "\$total_shards" -lt 1 \]/);
   assert.match(modeBlock, /lane_shard_cap="\$normal_shards"/);
   assert.match(modeBlock, /lane_shard_cap="\$hot_intake_shards"/);
+  assert.match(modeBlock, /if \[ "\$lane_shard_cap" -lt 1 \]; then/);
+  assert.match(modeBlock, /shard_count="0"/);
+  assert.match(modeBlock, /Deferring broad background review/);
   assert.match(modeBlock, /Capping broad background review shards/);
+  assert.match(selectBlock, /if \[ "\$SHARD_COUNT" -lt 1 \]; then/);
+  assert.match(selectBlock, /"capacity":0/);
+  assert.match(selectBlock, /deferred: exact-review background cap occupied/);
   assert.match(commitBlock, /limit review_shards\.hot_intake_default/);
   assert.match(commitBlock, /limit review_shards\.normal_default/);
   assert.match(commitBlock, /STALE_QUEUED_CUTOFF/);
   assert.match(commitBlock, /updatedAt:\.updated_at/);
   assert.match(commitBlock, /workflowPath == "\.github\/workflows\/sweep\.yml"/);
   assert.match(commitBlock, /\.displayTitle \| startswith\("Review event items "\)/);
+  assert.match(commitBlock, /\.displayTitle \| startswith\("Review target repo "\)/);
+  assert.match(commitBlock, /\.displayTitle \| startswith\("Review hot target repo "\)/);
   assert.match(commitBlock, /WORKFLOW_PATH="\$1"/);
   assert.doesNotMatch(commitBlock, /workflowName == "ClawSweeper"/);
   assert.doesNotMatch(commitBlock, /WORKFLOW_NAME="\$1"/);
@@ -2116,6 +2148,214 @@ test("background review capacity reserves expanding matrices and caps broad manu
   assert.match(commitBlock, /limit review_shards\.hard_cap/);
   assert.match(commitBlock, /reserved_shards="\$requested_shards"/);
   assert.match(commitBlock, /reserved_shards="\$item_count"/);
+  assert.match(commitBlock, /active_commit_review_workers\(\)/);
+  assert.match(commitBlock, /workflowPath == "\.github\/workflows\/commit-review\.yml"/);
+  assert.match(commitBlock, /\(\.databaseId \| tostring\) != env\.CURRENT_RUN_ID/);
+  assert.match(commitBlock, /startswith\("Review commit "\)/);
+  assert.match(modeBlock, /COMMIT_REVIEW_PAGE_SIZE/);
+  assert.match(modeBlock, /page_size_hard_cap="\$\(limit commit_review\.page_size_hard_cap\)"/);
+  assert.match(modeBlock, /reservation_page_size="\$\(limit commit_review\.page_size_default\)"/);
+  assert.match(modeBlock, /zero_review_name='Review commit \$'/);
+  assert.match(modeBlock, /zero_review_name\+='\{\{ matrix\.sha \}\}'/);
+  assert.match(modeBlock, /only an in-progress planner can reserve here/);
+  assert.doesNotMatch(
+    modeBlock,
+    /active_run_count "\.github\/workflows\/commit-review\.yml"\) \* commit_page_size/,
+  );
+  for (const liveWorkerFunction of [
+    extractWorkflowShellFunction(modeBlock, "active_sweep_background_workers"),
+    extractWorkflowShellFunction(modeBlock, "active_commit_review_workers"),
+    extractWorkflowShellFunction(commitBlock, "active_sweep_background_workers"),
+    extractWorkflowShellFunction(commitBlock, "active_commit_review_workers"),
+  ]) {
+    assert.match(liveWorkerFunction, /(?:select\(|and )\.status == "in_progress"/);
+    assert.doesNotMatch(
+      liveWorkerFunction,
+      /(?:select\(|and \()\.status == "in_progress" or \(\(\.status == "pending"/,
+    );
+  }
+  const commitBackgroundWorkers = extractWorkflowShellFunction(
+    commitBlock,
+    "active_sweep_background_workers",
+  );
+  const commitExactWorkers = extractWorkflowShellFunction(
+    commitBlock,
+    "active_sweep_exact_workers",
+  );
+  assert.match(commitBackgroundWorkers, /Review\\ hot\\ target\\ repo/);
+  assert.doesNotMatch(commitBackgroundWorkers, /Review event items/);
+  assert.match(commitExactWorkers, /startswith\("Review event item "\)/);
+  assert.match(commitExactWorkers, /startswith\("Review event items "\)/);
+  assert.match(commitExactWorkers, /Explicit exact batches are priority work/);
+  assert.match(commitBlock, /\$\(active_sweep_exact_workers\)/);
+  assert.match(commitBlock, /page_size_hard_cap="\$\(limit commit_review\.page_size_hard_cap\)"/);
+  assert.match(commitBlock, /reservation_page_size="\$PAGE_SIZE"/);
+  assert.match(commitBlock, /reservation_page_size="\$\(limit commit_review\.page_size_default\)"/);
+  assert.match(commitSelectBlock, /if \[ "\$PAGE_SIZE" -lt 1 \]; then/);
+  assert.match(commitSelectBlock, /Deferring commit review/);
+  assert.match(commitSelectBlock, /sleep 300/);
+  assert.match(commitSelectBlock, /gh workflow run commit-review\.yml/);
+  assert.match(commitSelectBlock, /for attempt in 1 2 3; do/);
+  assert.match(commitSelectBlock, /Deferred commit-review requeue attempt \$attempt failed/);
+  assert.match(
+    commitSelectBlock,
+    /Unable to requeue the deferred commit-review range after three attempts/,
+  );
+  assert.match(commitSelectBlock, /-f commit_offset="\$COMMIT_OFFSET"/);
+  assert.match(commitSelectBlock, /Requeued deferred commit-review range/);
+  assert.match(commitSelectBlock, /echo "matrix=\[\]"/);
+  assert.match(commitBlock, /zero_review_plan=false/);
+  assert.match(commitBlock, /zero_review_name='Review commit \$'/);
+  assert.match(commitBlock, /zero_review_name\+='\{\{ matrix\.sha \}\}'/);
+  assert.match(commitBlock, /\.name == env\.ZERO_REVIEW_NAME/);
+  assert.match(commitBlock, /\[ "\$zero_review_plan" != "true" \]/);
+  assert.match(commitBlock, /active_reviews="\$reservation_page_size"/);
+  assert.match(
+    commitBlock,
+    /active_background_workers="\$\(\( \$\(active_sweep_background_workers\) \+ \$\(active_commit_review_workers\) \)\)"/,
+  );
+});
+
+test("background review schedulers yield to a saturated exact-review queue", () => {
+  const sweepWorkflow = readText(".github/workflows/sweep.yml");
+  const sweepBlock = sweepWorkflow.slice(
+    sweepWorkflow.indexOf("- id: mode"),
+    sweepWorkflow.indexOf("- id: select"),
+  );
+  const commitWorkflow = readText(".github/workflows/commit-review.yml");
+  const commitBlock = commitWorkflow.slice(
+    commitWorkflow.indexOf("- name: Select commits"),
+    commitWorkflow.indexOf('if [ "$ENABLED" = "false" ]'),
+  );
+
+  for (const block of [sweepBlock, commitBlock]) {
+    assert.match(
+      block,
+      /EXACT_REVIEW_BACKGROUND_YIELD_ENABLED: \$\{\{ vars\.CLAWSWEEPER_ENABLE_EXACT_REVIEW_BACKGROUND_YIELD \|\| '0' \}\}/,
+    );
+    assert.match(
+      block,
+      /if \[ "\$EXACT_REVIEW_BACKGROUND_YIELD_ENABLED" = "1" \]; then\s+if ! exact_review_pressure=/,
+    );
+    assert.match(block, /QUEUE_URL: \$\{\{ vars\.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL/);
+    assert.match(
+      block,
+      /CLAWSWEEPER_EXACT_REVIEW_QUEUE_MAX_AGE_SECONDS: \$\{\{ vars\.CLAWSWEEPER_EXACT_REVIEW_QUEUE_MAX_AGE_SECONDS/,
+    );
+    assert.match(block, /exact_review_pressure_status\(\)/);
+    assert.match(block, /\$queue_url\/api\/status/);
+    assert.match(block, /exact_review_queue\.generated_at/);
+    assert.match(block, /exact_review_queue\.pressure\.status/);
+    assert.match(block, /CLAWSWEEPER_EXACT_REVIEW_QUEUE_MAX_AGE_SECONDS/);
+    assert.match(block, /GENERATED_AT="\$generated_at" node -e/);
+    assert.match(block, /Date\.parse\(value\)/);
+    assert.match(block, /queue telemetry snapshot is stale/);
+    assert.doesNotMatch(block, /admissible_pending/);
+    assert.doesNotMatch(block, /dispatcher\.state/);
+    assert.doesNotMatch(block, /handoff_health\.status/);
+    assert.match(block, /--exact-review-pressure "\$exact_review_pressure"/);
+    assert.doesNotMatch(block, /workflow -- exact-review-pressure/);
+    assert.match(block, /queue telemetry was unavailable; using idle pressure \(fail open\)/);
+    assert.match(block, /throttling .*review intake/);
+  }
+  assert.match(sweepBlock, /worker_limit hot_intake.*--exact-review-pressure/);
+  assert.match(sweepBlock, /worker_limit normal_review.*--exact-review-pressure/);
+  assert.match(commitBlock, /scheduler_page_size=.*worker-limit commit_review/);
+  assert.match(
+    commitBlock,
+    /elif \[ "\$exact_review_pressure" != "idle" \] && \[\[ "\$PAGE_SIZE" =~ \^\[0-9\]\+\$ \]\]/,
+  );
+  assert.match(commitBlock, /Capping commit-review page size/);
+  assert.match(commitBlock, /throttling commit review intake to page_size=\$PAGE_SIZE/);
+  assert.match(
+    sweepBlock,
+    /throttling broad review intake to normal=\$normal_shards and hot=\$hot_intake_shards/,
+  );
+});
+
+function extractWorkflowShellFunction(block: string, functionName: string): string {
+  const header = `${functionName}() {`;
+  const start = block.indexOf(header);
+  assert.notEqual(start, -1, `missing shell function ${functionName}`);
+  const rest = block.slice(start);
+  const next = rest.slice(header.length).search(/\n          [a-zA-Z0-9_]+\(\) \{/);
+  const end = next === -1 ? rest.length : header.length + next;
+  return rest.slice(0, end).replace(/^          /gm, "");
+}
+
+function runExactReviewPressureStatus(block: string, response: Record<string, unknown>): string {
+  const functionBody = extractWorkflowShellFunction(block, "exact_review_pressure_status");
+  const script = [
+    functionBody,
+    `jq() {
+      if [[ "$*" == *generated_at* ]]; then
+        node -e 'const fs=require("fs");const data=JSON.parse(fs.readFileSync(0,"utf8"));const q=data.exact_review_queue||{};const value=typeof q.generated_at==="string"?q.generated_at:"";process.stdout.write(value+"\\n");'
+      else
+        node -e 'const fs=require("fs");const data=JSON.parse(fs.readFileSync(0,"utf8"));const value=data.exact_review_queue?.pressure?.status;process.stdout.write((typeof value==="string"?value:"")+"\\n");'
+      fi
+    }`,
+    'curl() { printf "%s" "$QUEUE_RESPONSE"; }',
+    'QUEUE_URL="https://queue.example"',
+    'output="$(exact_review_pressure_status 2>&1)"',
+    "status=$?",
+    'printf "status=%s\\n%s" "$status" "$output"',
+  ].join("\n");
+  return execFileSync("bash", ["-lc", script], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CLAWSWEEPER_EXACT_REVIEW_QUEUE_MAX_AGE_SECONDS: "60",
+      QUEUE_RESPONSE: JSON.stringify(response),
+    },
+  });
+}
+
+test("background review schedulers consume fresh pressure and fail open otherwise", () => {
+  const sweepWorkflow = readText(".github/workflows/sweep.yml");
+  const sweepBlock = sweepWorkflow.slice(
+    sweepWorkflow.indexOf("- id: mode"),
+    sweepWorkflow.indexOf("- id: select"),
+  );
+  const commitWorkflow = readText(".github/workflows/commit-review.yml");
+  const commitBlock = commitWorkflow.slice(
+    commitWorkflow.indexOf("- name: Select commits"),
+    commitWorkflow.indexOf('if [ "$ENABLED" = "false" ]'),
+  );
+  const freshGeneratedAt = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  const saturatedQueue = {
+    generated_at: "1970-01-01T00:00:00Z",
+    exact_review_queue: {
+      generated_at: freshGeneratedAt,
+      pressure: { status: "saturated" },
+    },
+  };
+  const staleSaturatedQueue = {
+    ...saturatedQueue,
+    exact_review_queue: {
+      ...saturatedQueue.exact_review_queue,
+      generated_at: "1970-01-01T00:00:00Z",
+    },
+  };
+  const unknownQueue = {
+    ...saturatedQueue,
+    exact_review_queue: {
+      ...saturatedQueue.exact_review_queue,
+      pressure: { status: "unknown" },
+    },
+  };
+
+  for (const block of [sweepBlock, commitBlock]) {
+    const freshOutput = runExactReviewPressureStatus(block, saturatedQueue);
+    assert.match(freshOutput, /^status=0\nsaturated$/);
+
+    const staleOutput = runExactReviewPressureStatus(block, staleSaturatedQueue);
+    assert.match(staleOutput, /^status=1\n/);
+    assert.match(staleOutput, /queue telemetry snapshot is stale/);
+
+    const unknownOutput = runExactReviewPressureStatus(block, unknownQueue);
+    assert.match(unknownOutput, /^status=1\n/);
+    assert.match(unknownOutput, /pressure is unavailable/);
+  }
 });
 
 test("review backstops identify sweep runs by stable workflow path", () => {
@@ -2129,7 +2369,7 @@ test("review backstops identify sweep runs by stable workflow path", () => {
   assert.doesNotMatch(block, /run\.workflowName/);
 });
 
-test("target review queues coalesce background work without delaying exact planners", () => {
+test("background-yield admission is opt-in and keeps exact planners independent", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const concurrencyBlock = workflow.slice(
     workflow.indexOf("concurrency:"),
@@ -2138,6 +2378,11 @@ test("target review queues coalesce background work without delaying exact plann
   const planHeader = workflow.slice(
     workflow.indexOf("\n  plan:"),
     workflow.indexOf("\n    outputs:", workflow.indexOf("\n  plan:")),
+  );
+  const commitWorkflow = readText(".github/workflows/commit-review.yml");
+  const commitPlanHeader = commitWorkflow.slice(
+    commitWorkflow.indexOf("\n  plan:"),
+    commitWorkflow.indexOf("\n    outputs:", commitWorkflow.indexOf("\n  plan:")),
   );
 
   assert.match(concurrencyBlock, /&& 'clawsweeper-intake-v2'/);
@@ -2153,16 +2398,28 @@ test("target review queues coalesce background work without delaying exact plann
   assert.match(concurrencyBlock, /format\('clawsweeper-comment-sync-\{0\}', github\.run_id\)/);
   assert.match(concurrencyBlock, /format\('clawsweeper-apply-\{0\}', github\.run_id\)/);
   assert.doesNotMatch(concurrencyBlock, /queue: max/);
-  assert.match(planHeader, /group: \$\{\{ format\('clawsweeper-planner-\{0\}'/);
+  assert.match(planHeader, /format\('clawsweeper-review-admission-\{0\}', github\.run_id\)/);
+  assert.match(planHeader, /github\.event\.client_payload\.item_number/);
+  assert.match(planHeader, /github\.event\.client_payload\.item_numbers/);
+  assert.match(planHeader, /github\.event\.inputs\.item_number/);
+  assert.match(planHeader, /github\.event\.inputs\.item_numbers/);
   assert.match(
     planHeader,
-    /github\.event_name == 'schedule' \|\| \(github\.event_name == 'workflow_dispatch'/,
+    /vars\.CLAWSWEEPER_ENABLE_EXACT_REVIEW_BACKGROUND_YIELD == '1' && 'clawsweeper-review-admission-background'/,
   );
-  assert.match(planHeader, /github\.event\.inputs\.item_number == ''/);
-  assert.match(planHeader, /github\.event\.inputs\.item_numbers == ''/);
-  assert.match(planHeader, /\|\| github\.run_id/);
-  assert.doesNotMatch(planHeader, /queue: max/);
+  assert.match(planHeader, /format\('clawsweeper-planner-\{0\}'/);
+  assert.match(
+    planHeader,
+    /github\.event_name == 'repository_dispatch' && github\.event\.client_payload\.target_repo/,
+  );
+  assert.match(
+    commitPlanHeader,
+    /vars\.CLAWSWEEPER_ENABLE_EXACT_REVIEW_BACKGROUND_YIELD == '1' && 'clawsweeper-review-admission-background'/,
+  );
+  assert.match(commitPlanHeader, /format\('commit-review-plan-\{0\}', github\.run_id\)/);
+  assert.match(planHeader, /queue: max/);
   assert.match(planHeader, /cancel-in-progress: false/);
+  assert.match(commitPlanHeader, /queue: max/);
 });
 
 test("scheduled normal review uses one item per shard for lease coverage", () => {


### PR DESCRIPTION
Related: https://github.com/openclaw/clawsweeper/pull/542 (closed; superseded)

Depends on: https://github.com/openclaw/clawsweeper/pull/555 (merged as `41ea43b`)

## What Problem This Solves

Periodic and commit-review background work can consume the worker budget needed to drain an exact-review backlog. Operators had no opt-in admission policy that causes lower-priority broad-review lanes to yield when exact review is congested or saturated.

## Why This Change Was Made

This is the scheduler/admission-policy portion of closed contributor PR #542. It deliberately consumes the durable `exact_review_queue.generated_at` and `exact_review_queue.pressure.status` contract published by #555 instead of duplicating pressure classification.

When explicitly enabled, the policy:

- caps shared background review at 16 workers when exact review is congested and 4 when it is saturated;
- subtracts already-active background workers before admitting another broad planner;
- serializes background admission through one shared workflow lock;
- re-evaluates caps on continuation and defers zero-cap commit work by requeueing the same range;
- fails open to normal capacity when telemetry is missing, malformed, stale, or unknown.

Exact-review, repair, apply, and other priority lanes remain outside this background cap. The default behavior remains unchanged until `CLAWSWEEPER_ENABLE_EXACT_REVIEW_BACKGROUND_YIELD=1` is explicitly set.

## User Impact

With the opt-in variable enabled, broad work yields capacity when the exact-review lane is under pressure. This is a safe guardrail, not a replacement for #545's recovery work and not a fix for post-review state-ledger/lease-completion contention.

## Evidence

- The original exact-head GitHub CI passed `7/7`, including `pnpm check`.
- After integrating merged #555, disposable Linux-container proof passed: `pnpm run build:all` and `node --test test/sweep-workflow.test.ts test/repair/workflow-utils.test.ts dist/repair/workflow-utils.test.js` — `115/115` passing. The container copy normalized Windows checkout CRLF only; no tracked file was changed.
- `pnpm run check:limits` passed in the same Linux container.
- `git diff --check origin/main...HEAD` passed.
- Codex cleanup review: `codex review --uncommitted` clean for the release-owned changelog removal.
- Codex final review: `codex review --base origin/main` clean with no actionable findings after #555 integration.
- The local `actionlint` image reports the repository's pre-existing `queue: max` concurrency extension, including occurrences already on `main`; GitHub Actions' own `Analyze (actions)` check is the authoritative validation for this workflow syntax.

## Maintainer follow-up — 2026-07-14

- Removed the contributor-added unreleased `CHANGELOG.md` entry; release notes are release-owned in this repository.
- #542 was closed because #555 is the observation/telemetry slice and this PR is the dependent scheduler-policy slice.
- Keep the feature disabled until maintainers decide to trial it and observe queue-drain, lease-completion, and publisher-health metrics.
- The policy and extraction retain attribution to `brokemac79` in the original commits.
