### PR TITLE
fix(review): keep cache identity stable across locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,9 @@ checkpoint, and status-only commits are intentionally omitted.
   parent, terminating the complete credentialed execute process group before
   timeout finalization, and allowing later observed outcomes to supersede stale
   unknown state.
+- Made semantic and structural review cache ordering locale-independent so
+  identical GitHub state cannot produce different reuse identities across
+  workers.
 - Stopped narrow OpenClaw automerge repairs from chasing unrelated full-repository lint and typecheck failures.
 - Removed the synthetic Codex write preflight that could block repair before Codex saw the real task.
 - Kept exact-review handoff health live when the dashboard serves a stale fleet snapshot, so recovered claims no longer leave the operator rail stuck in a delayed or stalled state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,9 +110,6 @@ checkpoint, and status-only commits are intentionally omitted.
   parent, terminating the complete credentialed execute process group before
   timeout finalization, and allowing later observed outcomes to supersede stale
   unknown state.
-- Made semantic and structural review cache ordering locale-independent so
-  identical GitHub state cannot produce different reuse identities across
-  workers.
 - Stopped narrow OpenClaw automerge repairs from chasing unrelated full-repository lint and typecheck failures.
 - Removed the synthetic Codex write preflight that could block repair before Codex saw the real task.
 - Kept exact-review handoff health live when the dashboard serves a stale fleet snapshot, so recovered claims no longer leave the operator rail stuck in a delayed or stalled state.

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -53,7 +53,7 @@ import {
   summarizeGhArgs,
 } from "./github-retry.js";
 import { parseGhJson, parseGhJsonLinesWithRetry, parseGhJsonWithRetry } from "./github-json.js";
-import { stableJson } from "./stable-json.js";
+import { stableJson, stableJsonCodeUnit } from "./stable-json.js";
 import {
   REVIEW_STRUCTURAL_CACHE_VERSION,
   reviewStructuralRecordAtLeastAsFresh,
@@ -5290,6 +5290,41 @@ function compactCommitStatus(value: unknown): unknown {
   };
 }
 
+function compareCanonicalJson(left: unknown, right: unknown): number {
+  const leftJson = stableJsonCodeUnit(left);
+  const rightJson = stableJsonCodeUnit(right);
+  return leftJson < rightJson ? -1 : leftJson > rightJson ? 1 : 0;
+}
+
+function canonicalPullChecksContext(
+  rawCheckRuns: unknown[],
+  rawStatuses: unknown[],
+  checkRunsTruncated: boolean,
+  statusesTruncated: boolean,
+): unknown {
+  const checkRuns = rawCheckRuns.slice(0, 100).map(compactCheckRun).sort(compareCanonicalJson);
+  const statuses = rawStatuses.slice(0, 100).map(compactCommitStatus).sort(compareCanonicalJson);
+  return {
+    complete: !checkRunsTruncated && !statusesTruncated,
+    checkRuns,
+    checkRunsTruncated,
+    statuses,
+    statusesTruncated,
+  };
+}
+
+export function pullChecksContextForTest(checkRuns: unknown[], statuses: unknown[]): unknown {
+  return canonicalPullChecksContext(checkRuns, statuses, false, false);
+}
+
+function canonicalPullChecksDigest(pullChecks: unknown): string {
+  return sha256(stableJsonCodeUnit(pullChecks));
+}
+
+export function pullChecksDigestForTest(pullChecks: unknown): string {
+  return canonicalPullChecksDigest(pullChecks);
+}
+
 function pullChecksContext(number: number, headSha: string): unknown {
   try {
     const checkResponse = asRecord(
@@ -5313,21 +5348,12 @@ function pullChecksContext(number: number, headSha: string): unknown {
     }
     const checkRunsTruncated = checkRunsTotal > rawCheckRuns.length || rawCheckRuns.length > 100;
     const statusesTruncated = statusesTotal > rawStatuses.length || rawStatuses.length > 100;
-    const checkRuns = rawCheckRuns
-      .slice(0, 100)
-      .map(compactCheckRun)
-      .sort((left, right) => stableJson(left).localeCompare(stableJson(right)));
-    const statuses = rawStatuses
-      .slice(0, 100)
-      .map(compactCommitStatus)
-      .sort((left, right) => stableJson(left).localeCompare(stableJson(right)));
-    return {
-      complete: !checkRunsTruncated && !statusesTruncated,
-      checkRuns,
+    return canonicalPullChecksContext(
+      rawCheckRuns,
+      rawStatuses,
       checkRunsTruncated,
-      statuses,
       statusesTruncated,
-    };
+    );
   } catch (error) {
     console.error(
       `[review] ${new Date().toISOString()} check-state=unavailable #${number}: ${
@@ -8129,7 +8155,7 @@ function fetchReviewStructuralRecord(options: {
     if (!headSha) return null;
     const pullChecks = pullChecksContext(options.item.number, headSha);
     if (!completePullChecksContext(pullChecks)) return null;
-    pullChecksDigest = sha256(stableJson(pullChecks));
+    pullChecksDigest = canonicalPullChecksDigest(pullChecks);
   }
   return reviewStructuralRecordFromGraphql({
     response,

--- a/src/review-semantic-cache.ts
+++ b/src/review-semantic-cache.ts
@@ -184,6 +184,10 @@ function sha256(value: string): string {
   return createHash("sha256").update(value).digest("hex");
 }
 
+function compareCodeUnits(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
 function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -689,7 +693,7 @@ function semanticCode(input: ReviewSemanticInput): {
     compiler.close();
   }
   semanticFiles.sort((left, right) =>
-    String(asRecord(left).filename).localeCompare(String(asRecord(right).filename)),
+    compareCodeUnits(String(asRecord(left).filename), String(asRecord(right).filename)),
   );
   return { digest: sha256(stableJson(semanticFiles)), eligible: true, reason: "eligible" };
 }

--- a/src/review-semantic-cache.ts
+++ b/src/review-semantic-cache.ts
@@ -6,9 +6,9 @@ import { createVirtualFileSystem, type FileSystem } from "typescript/unstable/fs
 import { API } from "typescript/unstable/sync";
 
 import { REVIEW_CACHE_MAX_AGE_DAYS } from "./scheduler-policy.js";
-import { stableJson } from "./stable-json.js";
+import { stableJsonCodeUnit as stableJson } from "./stable-json.js";
 
-export const REVIEW_SEMANTIC_CACHE_VERSION = 9;
+export const REVIEW_SEMANTIC_CACHE_VERSION = 10;
 export const REVIEW_SEMANTIC_CACHE_MAX_AGE_DAYS = REVIEW_CACHE_MAX_AGE_DAYS;
 
 const DAY_MS = 24 * 60 * 60 * 1000;

--- a/src/review-structural-cache.ts
+++ b/src/review-structural-cache.ts
@@ -734,6 +734,10 @@ function sha256(value: string): string {
   return createHash("sha256").update(value).digest("hex");
 }
 
+function compareCodeUnits(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
 function validTimestamp(value: string): boolean {
   return value.length > 0 && Number.isFinite(Date.parse(value));
 }
@@ -775,9 +779,9 @@ function normalizedActivities(
     }))
     .sort(
       (left, right) =>
-        left.id.localeCompare(right.id) ||
-        left.updatedAt.localeCompare(right.updatedAt) ||
-        String(left.author).localeCompare(String(right.author)),
+        compareCodeUnits(left.id, right.id) ||
+        compareCodeUnits(left.updatedAt, right.updatedAt) ||
+        compareCodeUnits(String(left.author), String(right.author)),
     );
 }
 
@@ -822,7 +826,7 @@ function sourceRevision(snapshot: ReviewStructuralSnapshot): string {
                   isResolved: thread.isResolved,
                   comments: normalizedActivities(thread.comments),
                 }))
-                .sort((left, right) => left.id.localeCompare(right.id)),
+                .sort((left, right) => compareCodeUnits(left.id, right.id)),
             },
     }),
   );
@@ -865,7 +869,7 @@ function contextRevision(snapshot: ReviewStructuralSnapshot): string {
                   isResolved: thread.isResolved,
                   comments: normalizedActivities(thread.comments),
                 }))
-                .sort((left, right) => left.id.localeCompare(right.id)),
+                .sort((left, right) => compareCodeUnits(left.id, right.id)),
             },
     }),
   );
@@ -905,7 +909,7 @@ export function reviewStructuralItemStateDigest(item: ReviewStructuralItemState)
       authorAssociation: comment.authorAssociation?.toUpperCase() ?? null,
       bodyDigest: comment.bodyDigest,
     }))
-    .sort((left, right) => stableJson(left).localeCompare(stableJson(right)));
+    .sort((left, right) => compareCodeUnits(stableJson(left), stableJson(right)));
   return sha256(
     stableJson({
       titleDigest: item.titleDigest,

--- a/src/review-structural-cache.ts
+++ b/src/review-structural-cache.ts
@@ -1,9 +1,9 @@
 import { createHash } from "node:crypto";
 
 import { REVIEW_CACHE_MAX_AGE_DAYS } from "./scheduler-policy.js";
-import { stableJson } from "./stable-json.js";
+import { stableJsonCodeUnit as stableJson } from "./stable-json.js";
 
-export const REVIEW_STRUCTURAL_CACHE_VERSION = 5;
+export const REVIEW_STRUCTURAL_CACHE_VERSION = 6;
 export const REVIEW_STRUCTURAL_CACHE_MAX_AGE_DAYS = REVIEW_CACHE_MAX_AGE_DAYS;
 
 const DAY_MS = 24 * 60 * 60 * 1000;

--- a/src/stable-json.ts
+++ b/src/stable-json.ts
@@ -3,11 +3,30 @@ export function stableJson(value: unknown): string {
 }
 
 export function sortStable(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(sortStable);
+  return sortStableWith(value, (left, right) => left.localeCompare(right));
+}
+
+export function stableJsonCodeUnit(value: unknown): string {
+  return JSON.stringify(sortStableCodeUnit(value));
+}
+
+export function sortStableCodeUnit(value: unknown): unknown {
+  return sortStableWith(value, compareCodeUnits);
+}
+
+function sortStableWith(
+  value: unknown,
+  compareKeys: (left: string, right: string) => number,
+): unknown {
+  if (Array.isArray(value)) return value.map((item) => sortStableWith(item, compareKeys));
   if (!value || typeof value !== "object") return value;
   return Object.fromEntries(
     Object.entries(value)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([key, item]) => [key, sortStable(item)]),
+      .sort(([left], [right]) => compareKeys(left, right))
+      .map(([key, item]) => [key, sortStableWith(item, compareKeys)]),
   );
+}
+
+function compareCodeUnits(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
 }

--- a/test/review-comment-rendering.test.ts
+++ b/test/review-comment-rendering.test.ts
@@ -165,7 +165,8 @@ test("structural cache probes before hydration but acquires a lease before carry
     source.indexOf("function collectItemContext"),
   );
   assert.match(structuralProbeSource, /pullChecksContext\(options\.item\.number, headSha\)/);
-  assert.match(structuralProbeSource, /pullChecksDigest = sha256\(stableJson\(pullChecks\)\)/);
+  assert.match(structuralProbeSource, /pullChecksDigest = canonicalPullChecksDigest\(pullChecks\)/);
+  assert.match(source, /function canonicalPullChecksDigest[\s\S]*stableJsonCodeUnit\(pullChecks\)/);
   assert.match(structuralProbeSource, /if \(!options\.git\.releaseStateComplete\) return null/);
   const gitInfoBlock = source.slice(
     source.indexOf("function gitInfo("),

--- a/test/review-semantic-cache.test.ts
+++ b/test/review-semantic-cache.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import test from "node:test";
 
@@ -195,6 +196,110 @@ test("TypeScript whitespace and ordinary comments do not perturb the semantic di
   assert.equal(reformatted.eligible, true);
   assert.equal(plain.codeDigest, reformatted.codeDigest);
   assert.notEqual(plain.exactDigest, reformatted.exactDigest);
+});
+
+test("semantic file ordering is locale-independent", () => {
+  const moduleUrl = new URL("../dist/review-semantic-cache.js", import.meta.url).href;
+  const script = `
+    const { createReviewSemanticRecord } = await import(${JSON.stringify(moduleUrl)});
+    const files = ["I", "\\u0131", "i", "\\u0130"].map((name, index) => ({
+      filename: "src/" + name + ".ts",
+      status: "added",
+      additions: 1,
+      deletions: 0,
+      patch: "@@ -0,0 +1 @@\\n+export const value" + index + " = " + index + ";",
+      baseMode: null,
+      baseType: null,
+      headMode: "100644",
+      headType: "blob",
+      treeModesComplete: true,
+    }));
+    const record = createReviewSemanticRecord({
+      item: { repo: "openclaw/openclaw", number: 123, kind: "pull_request" },
+      context: {
+        issue: {
+          number: 123,
+          title: "Locale cache",
+          body: "",
+          state: "open",
+          author: "contributor",
+          authorAssociation: "CONTRIBUTOR",
+          labels: [],
+        },
+        comments: [],
+        timeline: [],
+        timelineRevision: "timeline-1",
+        pullRequest: {
+          number: 123,
+          state: "open",
+          draft: false,
+          merged: false,
+          head: { sha: "b".repeat(40) },
+          base: { sha: "c".repeat(40) },
+        },
+        pullFiles: files,
+        semanticPullFiles: files,
+        pullCommits: [],
+        pullCommitsRevision: "d".repeat(64),
+        pullReviewComments: [],
+        pullReviewCommentsRevision: "review-comments-1",
+        pullChecks: {
+          complete: true,
+          checkRuns: [],
+          checkRunsTruncated: false,
+          statuses: [],
+          statusesTruncated: false,
+        },
+        counts: {
+          comments: 0,
+          commentsTruncated: false,
+          timeline: 0,
+          timelineTruncated: false,
+          pullFiles: files.length,
+          pullFilesHydrated: files.length,
+          pullFilesTruncated: false,
+          pullCommits: 0,
+          pullCommitsHydrated: 0,
+          pullCommitsTruncated: false,
+          pullReviewComments: 0,
+          pullReviewCommentsTruncated: false,
+        },
+      },
+      git: {
+        mainSha: "e".repeat(40),
+        releaseStateComplete: true,
+        latestRelease: { tagName: "v1.0.0", sha: "f".repeat(40) },
+      },
+      structuralContextRevision: "a".repeat(64),
+      reviewPolicy: "policy-1",
+      reviewModel: "gpt-5.6",
+    });
+    console.log(JSON.stringify({
+      locale: Intl.Collator().resolvedOptions().locale,
+      eligible: record.eligible,
+      codeDigest: record.codeDigest,
+    }));
+  `;
+  const run = (locale: string) => {
+    const result = spawnSync(process.execPath, ["--input-type=module", "--eval", script], {
+      encoding: "utf8",
+      env: { ...process.env, LANG: locale, LC_ALL: locale },
+    });
+    assert.equal(result.status, 0, result.stderr);
+    return JSON.parse(result.stdout.trim()) as {
+      locale: string;
+      eligible: boolean;
+      codeDigest: string;
+    };
+  };
+
+  const english = run("en_US.UTF-8");
+  const turkish = run("tr_TR.UTF-8");
+  assert.match(english.locale, /^en(?:-|$)/i);
+  assert.match(turkish.locale, /^tr(?:-|$)/i);
+  assert.equal(english.eligible, true);
+  assert.equal(turkish.eligible, true);
+  assert.equal(turkish.codeDigest, english.codeDigest);
 });
 
 test("semantic fingerprint uses the bounded full patch instead of prompt truncation", () => {

--- a/test/review-semantic-cache.test.ts
+++ b/test/review-semantic-cache.test.ts
@@ -278,6 +278,9 @@ test("semantic file ordering is locale-independent", () => {
       locale: Intl.Collator().resolvedOptions().locale,
       eligible: record.eligible,
       codeDigest: record.codeDigest,
+      exactDigest: record.exactDigest,
+      contextDigest: record.contextDigest,
+      fingerprint: record.fingerprint,
     }));
   `;
   const run = (locale: string) => {
@@ -290,16 +293,21 @@ test("semantic file ordering is locale-independent", () => {
       locale: string;
       eligible: boolean;
       codeDigest: string;
+      exactDigest: string;
+      contextDigest: string;
+      fingerprint: string;
     };
   };
 
   const english = run("en_US.UTF-8");
   const turkish = run("tr_TR.UTF-8");
+  const czech = run("cs_CZ.UTF-8");
   assert.match(english.locale, /^en(?:-|$)/i);
   assert.match(turkish.locale, /^tr(?:-|$)/i);
+  assert.match(czech.locale, /^cs(?:-|$)/i);
   assert.equal(english.eligible, true);
-  assert.equal(turkish.eligible, true);
-  assert.equal(turkish.codeDigest, english.codeDigest);
+  assert.deepEqual(turkish, { ...english, locale: turkish.locale });
+  assert.deepEqual(czech, { ...english, locale: czech.locale });
 });
 
 test("semantic fingerprint uses the bounded full patch instead of prompt truncation", () => {
@@ -1349,8 +1357,8 @@ test("semantic records require a boolean eligibility value", () => {
 });
 
 test("semantic record version changes invalidate legacy directive digests", () => {
-  assert.equal(REVIEW_SEMANTIC_CACHE_VERSION, 9);
-  assert.equal(validReviewSemanticRecord({ ...record(), version: 8 } as never), false);
+  assert.equal(REVIEW_SEMANTIC_CACHE_VERSION, 10);
+  assert.equal(validReviewSemanticRecord({ ...record(), version: 9 } as never), false);
 });
 
 test("stale, failed, and future-dated reviews never reuse", () => {

--- a/test/review-semantic-cache.test.ts
+++ b/test/review-semantic-cache.test.ts
@@ -200,8 +200,12 @@ test("TypeScript whitespace and ordinary comments do not perturb the semantic di
 
 test("semantic file ordering is locale-independent", () => {
   const moduleUrl = new URL("../dist/review-semantic-cache.js", import.meta.url).href;
+  const clawsweeperModuleUrl = new URL("../dist/clawsweeper.js", import.meta.url).href;
   const script = `
     const { createReviewSemanticRecord } = await import(${JSON.stringify(moduleUrl)});
+    const { pullChecksContextForTest, pullChecksDigestForTest } =
+      await import(${JSON.stringify(clawsweeperModuleUrl)});
+    const names = ["I", "\\u0131", "i", "\\u0130"];
     const files = ["I", "\\u0131", "i", "\\u0130"].map((name, index) => ({
       filename: "src/" + name + ".ts",
       status: "added",
@@ -214,6 +218,19 @@ test("semantic file ordering is locale-independent", () => {
       headType: "blob",
       treeModesComplete: true,
     }));
+    const pullChecks = pullChecksContextForTest(
+      names.map((name) => ({
+        name,
+        status: "completed",
+        conclusion: "success",
+        app: { slug: "github-actions" },
+      })),
+      names.map((context) => ({
+        context,
+        state: "success",
+        description: context,
+      })),
+    );
     const record = createReviewSemanticRecord({
       item: { repo: "openclaw/openclaw", number: 123, kind: "pull_request" },
       context: {
@@ -243,13 +260,7 @@ test("semantic file ordering is locale-independent", () => {
         pullCommitsRevision: "d".repeat(64),
         pullReviewComments: [],
         pullReviewCommentsRevision: "review-comments-1",
-        pullChecks: {
-          complete: true,
-          checkRuns: [],
-          checkRunsTruncated: false,
-          statuses: [],
-          statusesTruncated: false,
-        },
+        pullChecks,
         counts: {
           comments: 0,
           commentsTruncated: false,
@@ -281,6 +292,7 @@ test("semantic file ordering is locale-independent", () => {
       exactDigest: record.exactDigest,
       contextDigest: record.contextDigest,
       fingerprint: record.fingerprint,
+      pullChecksDigest: pullChecksDigestForTest(pullChecks),
     }));
   `;
   const run = (locale: string) => {
@@ -296,6 +308,7 @@ test("semantic file ordering is locale-independent", () => {
       exactDigest: string;
       contextDigest: string;
       fingerprint: string;
+      pullChecksDigest: string;
     };
   };
 

--- a/test/review-structural-cache.test.ts
+++ b/test/review-structural-cache.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import test from "node:test";
 
@@ -132,6 +133,97 @@ function record(
   assert.ok(result);
   return result;
 }
+
+test("structural review ordering is locale-independent", () => {
+  const moduleUrl = new URL("../dist/review-structural-cache.js", import.meta.url).href;
+  const script = `
+    const { createReviewStructuralRecord } = await import(${JSON.stringify(moduleUrl)});
+    const { createHash } = await import("node:crypto");
+    const digest = (value) => createHash("sha256").update(value).digest("hex");
+    const names = ["I", "\\u0131", "i", "\\u0130"];
+    const activities = names.map((name, index) => ({
+      id: name,
+      updatedAt: "2026-07-10T08:0" + index + ":00Z",
+      author: name,
+      authorAssociation: "MEMBER",
+      state: "COMMENTED",
+      commitSha: null,
+      bodyDigest: digest("activity-" + index),
+    }));
+    const record = createReviewStructuralRecord({
+      repo: "openclaw/openclaw",
+      number: 123,
+      kind: "pull_request",
+      nodeId: "PR_kwDOPull",
+      author: "contributor",
+      authorAssociation: "CONTRIBUTOR",
+      titleDigest: digest("title"),
+      bodyDigest: digest("body"),
+      state: "OPEN",
+      locked: false,
+      labels: [],
+      labelsTruncated: false,
+      activityUpdatedAt: "2026-07-10T10:00:00Z",
+      comments: activities,
+      commentsTruncated: false,
+      timeline: [],
+      timelineTruncated: false,
+      relationSensitive: false,
+      targetHeadSha: "a".repeat(40),
+      latestReleaseTag: "v1.0.0",
+      latestReleaseSha: "a".repeat(40),
+      pull: {
+        headSha: "b".repeat(40),
+        baseSha: "c".repeat(40),
+        draft: false,
+        mergeable: "MERGEABLE",
+        mergeStateStatus: "CLEAN",
+        additions: 4,
+        deletions: 0,
+        changedFiles: 4,
+        commitCount: 1,
+        checksDigest: "d".repeat(64),
+        reviews: activities,
+        reviewsTruncated: false,
+        reviewThreads: names.map((name, index) => ({
+          id: name,
+          isResolved: index % 2 === 0,
+          comments: [activities[index]],
+          commentsTruncated: false,
+        })),
+        reviewThreadsTruncated: false,
+      },
+    }, {
+      reviewPolicy: "policy-1",
+      reviewModel: "gpt-5.6",
+    });
+    console.log(JSON.stringify({
+      locale: Intl.Collator().resolvedOptions().locale,
+      sourceRevision: record?.sourceRevision,
+      contextRevision: record?.contextRevision,
+      fingerprint: record?.fingerprint,
+    }));
+  `;
+  const run = (locale: string) => {
+    const result = spawnSync(process.execPath, ["--input-type=module", "--eval", script], {
+      encoding: "utf8",
+      env: { ...process.env, LANG: locale, LC_ALL: locale },
+    });
+    assert.equal(result.status, 0, result.stderr);
+    return JSON.parse(result.stdout.trim()) as {
+      locale: string;
+      sourceRevision: string;
+      contextRevision: string;
+      fingerprint: string;
+    };
+  };
+
+  const english = run("en_US.UTF-8");
+  const turkish = run("tr_TR.UTF-8");
+  assert.match(english.locale, /^en(?:-|$)/i);
+  assert.match(turkish.locale, /^tr(?:-|$)/i);
+  assert.deepEqual(turkish, { ...english, locale: turkish.locale });
+});
 
 function review(overrides = {}) {
   return {

--- a/test/review-structural-cache.test.ts
+++ b/test/review-structural-cache.test.ts
@@ -4,6 +4,7 @@ import { createHash } from "node:crypto";
 import test from "node:test";
 
 import {
+  REVIEW_STRUCTURAL_CACHE_VERSION,
   createReviewStructuralRecord,
   reviewStructuralActivitiesForTest,
   reviewStructuralCacheDecision,
@@ -15,6 +16,7 @@ import {
   reviewStructuralRecordMatchesHydratedPull,
   reviewStructuralRecordMatchesObservedUpdate,
   reviewStructuralRecordsDescribeSameVerdictInput,
+  validReviewStructuralRecord,
   type ReviewStructuralRecord,
   type ReviewStructuralSnapshot,
 } from "../dist/review-structural-cache.js";
@@ -25,6 +27,11 @@ const TARGET_SHA = "a".repeat(40);
 const HEAD_SHA = "b".repeat(40);
 const BASE_SHA = "c".repeat(40);
 const CHECKS_DIGEST = "d".repeat(64);
+
+test("structural cache version rejects locale-sensitive legacy records", () => {
+  assert.equal(REVIEW_STRUCTURAL_CACHE_VERSION, 6);
+  assert.equal(validReviewStructuralRecord({ ...record(), version: 5 } as never), false);
+});
 
 function digest(value: string): string {
   return createHash("sha256").update(value).digest("hex");
@@ -200,6 +207,7 @@ test("structural review ordering is locale-independent", () => {
     console.log(JSON.stringify({
       locale: Intl.Collator().resolvedOptions().locale,
       sourceRevision: record?.sourceRevision,
+      itemStateDigest: record?.itemStateDigest,
       contextRevision: record?.contextRevision,
       fingerprint: record?.fingerprint,
     }));
@@ -213,6 +221,7 @@ test("structural review ordering is locale-independent", () => {
     return JSON.parse(result.stdout.trim()) as {
       locale: string;
       sourceRevision: string;
+      itemStateDigest: string;
       contextRevision: string;
       fingerprint: string;
     };
@@ -220,9 +229,12 @@ test("structural review ordering is locale-independent", () => {
 
   const english = run("en_US.UTF-8");
   const turkish = run("tr_TR.UTF-8");
+  const czech = run("cs_CZ.UTF-8");
   assert.match(english.locale, /^en(?:-|$)/i);
   assert.match(turkish.locale, /^tr(?:-|$)/i);
+  assert.match(czech.locale, /^cs(?:-|$)/i);
   assert.deepEqual(turkish, { ...english, locale: turkish.locale });
+  assert.deepEqual(czech, { ...english, locale: czech.locale });
 });
 
 function review(overrides = {}) {

--- a/test/stable-json.test.ts
+++ b/test/stable-json.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { stableJsonCodeUnit } from "../dist/stable-json.js";
+
+test("code-unit stable JSON canonicalizes nested object keys without locale state", () => {
+  assert.equal(
+    stableJsonCodeUnit({
+      I: { changedFiles: 1, checksDigest: "a" },
+      i: { checksDigest: "b", changedFiles: 2 },
+      "\u0130": [{ checksDigest: "c", changedFiles: 3 }],
+      "\u0131": [{ changedFiles: 4, checksDigest: "d" }],
+    }),
+    '{"I":{"changedFiles":1,"checksDigest":"a"},"i":{"changedFiles":2,"checksDigest":"b"},"\u0130":[{"changedFiles":3,"checksDigest":"c"}],"\u0131":[{"changedFiles":4,"checksDigest":"d"}]}',
+  );
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where identical pull-request files, checks, review activity, and review-thread state could produce different semantic or structural cache identities when ClawSweeper workers used different process locales.

## Why This Change Was Made

Uses deterministic UTF-16 code-unit ordering at semantic files, structural activity, nested cache object keys, and the upstream pull-check collection/digest boundary. The shared historical `stableJson` contract remains unchanged for unrelated ledgers. Semantic cache version 9 advances to 10 and structural cache version 5 advances to 6 so locale-sensitive records cannot be reused.

## User Impact

Review workers can reuse or invalidate the same cached verdict consistently across Linux, macOS, and locale settings instead of performing false cache misses or hydration because collation changed.

## Evidence

- 106 focused semantic, structural, stable-JSON, and review-boundary tests pass
- child-process regressions prove identical file, check-run, status, context, structural, and fingerprint digests under `en_US.UTF-8`, `tr_TR.UTF-8`, and `cs_CZ.UTF-8`
- main TypeScript build passes
- focused lint, formatting, and `git diff --check` pass
- exact local ClawSweeper review finding on the upstream pull-check identity is addressed in head `3cc3559a84`
