### PR TITLE
fix(proof): prevent stale or unrecoverable mutations

### DIFF
--- a/.github/workflows/proof-nudges.yml
+++ b/.github/workflows/proof-nudges.yml
@@ -163,7 +163,8 @@ jobs:
           : > "$cursor_paths_file"
           target_slug="$TARGET_REPO"
           target_slug="${target_slug//\//-}"
-          mutation_state_path="results/proof-nudge-mutations/${target_slug}"
+          proof_mutation_state_path="results/proof-nudge-mutations/${target_slug}"
+          bot_mutation_state_path="results/bot-proof-mutations/${target_slug}"
           if [ -n "$PROOF_NUDGES_ITEM_NUMBERS" ]; then
             if [[ ! "$PROOF_NUDGES_ITEM_NUMBERS" =~ ^[0-9]+([[:space:]]*,[[:space:]]*[0-9]+)*$ ]]; then
               echo "::error::item_numbers must be a comma-separated list of pull request numbers"
@@ -180,7 +181,7 @@ jobs:
             --min-age-days "$PROOF_NUDGES_MIN_AGE_DAYS" \
             --cooldown-days "$PROOF_NUDGES_COOLDOWN_DAYS" \
             --report-path proof-nudge-report.json \
-            --mutation-state-dir "$mutation_state_path" \
+            --mutation-state-dir "$proof_mutation_state_path" \
             "${processed_limit_arg[@]}" \
             "${item_numbers_arg[@]}" \
             "${cursor_arg[@]}" \
@@ -199,6 +200,7 @@ jobs:
               --target-repo "$TARGET_REPO" \
               --limit "$PROOF_NUDGES_LIMIT" \
               --report-path bot-proof-report.json \
+              --mutation-state-dir "$bot_mutation_state_path" \
               "${processed_limit_arg[@]}" \
               "${item_numbers_arg[@]}" \
               "${bot_cursor_arg[@]}" \
@@ -268,7 +270,8 @@ jobs:
 
       - name: Publish proof mutation recovery state
         id: publish-mutation-state
-        if: ${{ always() && steps.setup-state.outcome == 'success' && steps.finalize-action-ledger.outcome == 'success' && steps.upload-finalized-ledger.outcome == 'success' && steps.publish-action-ledger.outcome == 'success' }}
+        if: ${{ always() && steps.setup-state.outcome == 'success' && steps.setup-pnpm.outcome == 'success' && steps.run-proof-nudges.outcome != 'skipped' }}
+        continue-on-error: true
         env:
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
         run: |
@@ -278,7 +281,8 @@ jobs:
           pnpm run repair:publish-main -- \
             --message "chore: update proof mutation recovery state" \
             --rebase-strategy theirs \
-            --path "results/proof-nudge-mutations/${target_slug}"
+            --path "results/proof-nudge-mutations/${target_slug}" \
+            --path "results/bot-proof-mutations/${target_slug}"
 
       - name: Publish proof handling cursors
         if: ${{ always() && steps.run-proof-nudges.outcome == 'success' && steps.finalize-action-ledger.outcome == 'success' && steps.upload-finalized-ledger.outcome == 'success' && steps.publish-action-ledger.outcome == 'success' && steps.publish-mutation-state.outcome == 'success' }}

--- a/.github/workflows/proof-nudges.yml
+++ b/.github/workflows/proof-nudges.yml
@@ -163,6 +163,7 @@ jobs:
           : > "$cursor_paths_file"
           target_slug="$TARGET_REPO"
           target_slug="${target_slug//\//-}"
+          mutation_state_path="results/proof-nudge-mutations/${target_slug}"
           if [ -n "$PROOF_NUDGES_ITEM_NUMBERS" ]; then
             if [[ ! "$PROOF_NUDGES_ITEM_NUMBERS" =~ ^[0-9]+([[:space:]]*,[[:space:]]*[0-9]+)*$ ]]; then
               echo "::error::item_numbers must be a comma-separated list of pull request numbers"
@@ -179,6 +180,7 @@ jobs:
             --min-age-days "$PROOF_NUDGES_MIN_AGE_DAYS" \
             --cooldown-days "$PROOF_NUDGES_COOLDOWN_DAYS" \
             --report-path proof-nudge-report.json \
+            --mutation-state-dir "$mutation_state_path" \
             "${processed_limit_arg[@]}" \
             "${item_numbers_arg[@]}" \
             "${cursor_arg[@]}" \
@@ -263,6 +265,19 @@ jobs:
           node dist/clawsweeper.js publish-action-event-paths \
             --paths-file "$paths_file" \
             --message "chore: append proof handling action ledger"
+
+      - name: Publish proof mutation recovery state
+        if: ${{ always() && steps.setup-state.outcome == 'success' && steps.finalize-action-ledger.outcome == 'success' && steps.upload-finalized-ledger.outcome == 'success' && steps.publish-action-ledger.outcome == 'success' }}
+        env:
+          TARGET_REPO: ${{ steps.target.outputs.target_repo }}
+        run: |
+          set -euo pipefail
+          target_slug="$TARGET_REPO"
+          target_slug="${target_slug//\//-}"
+          pnpm run repair:publish-main -- \
+            --message "chore: update proof mutation recovery state" \
+            --rebase-strategy theirs \
+            --path "results/proof-nudge-mutations/${target_slug}"
 
       - name: Publish proof handling cursors
         if: ${{ always() && steps.run-proof-nudges.outcome == 'success' && steps.finalize-action-ledger.outcome == 'success' && steps.upload-finalized-ledger.outcome == 'success' && steps.publish-action-ledger.outcome == 'success' }}

--- a/.github/workflows/proof-nudges.yml
+++ b/.github/workflows/proof-nudges.yml
@@ -45,6 +45,7 @@ on:
     - cron: "0 10 * * *"
 
 permissions:
+  actions: read
   contents: read
   issues: write
   pull-requests: read
@@ -68,6 +69,7 @@ jobs:
         with:
           filter: blob:none
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Resolve target repository
         id: target
@@ -107,14 +109,20 @@ jobs:
           private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
 
       - uses: ./.github/actions/setup-state
+        id: setup-state
         with:
           token: ${{ steps.state-token.outputs.token }}
 
+      - uses: ./.github/actions/setup-action-ledger
+        id: setup-action-ledger
+
       - uses: ./.github/actions/setup-pnpm
+        id: setup-pnpm
         with:
           build-script: build:all
 
       - name: Run proof nudges
+        id: run-proof-nudges
         env:
           GH_TOKEN: ${{ steps.target-proof-token.outputs.token }}
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
@@ -202,6 +210,43 @@ jobs:
               --rebase-strategy theirs \
               "${cursor_publish_args[@]}"
           fi
+
+      - name: Finalize proof handling action ledger
+        id: finalize-action-ledger
+        if: ${{ always() && steps.setup-action-ledger.outcome == 'success' && steps.setup-pnpm.outcome == 'success' }}
+        run: pnpm run --silent finalize-action-events
+
+      - name: Publish immutable proof handling action ledger
+        if: ${{ always() && steps.setup-state.outcome == 'success' && steps.finalize-action-ledger.outcome == 'success' }}
+        run: |
+          set -euo pipefail
+          test -n "${CLAWSWEEPER_STATE_DIR:-}"
+          source_root="${CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT:?setup-action-ledger output root is required}"
+          if [ ! -d "$source_root/ledger" ]; then
+            echo "No immutable proof handling action events to publish."
+            exit 0
+          fi
+          paths_file=".artifacts/proof-action-ledger-paths.txt"
+          mkdir -p .artifacts
+          pnpm run --silent publish-action-events -- \
+            --source-root "$source_root" \
+            --state-root "$CLAWSWEEPER_STATE_DIR" \
+            --expected-producer-job "$GITHUB_JOB" |
+            jq -r '.paths[]?' |
+            sort -u > "$paths_file"
+          if [ ! -s "$paths_file" ]; then
+            echo "Proof action event shards existed but no paths were imported." >&2
+            exit 1
+          fi
+          while IFS= read -r event_path; do
+            durable_event_path="$CLAWSWEEPER_STATE_DIR/$event_path"
+            test -f "$durable_event_path"
+            mkdir -p "$(dirname "$event_path")"
+            cp "$durable_event_path" "$event_path"
+          done < "$paths_file"
+          node dist/clawsweeper.js publish-action-event-paths \
+            --paths-file "$paths_file" \
+            --message "chore: append proof handling action ledger"
 
       - uses: actions/upload-artifact@v7
         if: ${{ always() }}

--- a/.github/workflows/proof-nudges.yml
+++ b/.github/workflows/proof-nudges.yml
@@ -225,6 +225,15 @@ jobs:
           fi
           pnpm run --silent finalize-action-events -- "${args[@]}"
 
+      - name: Upload finalized proof handling action ledger
+        if: ${{ always() && steps.finalize-action-ledger.outcome == 'success' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: proof-handling-action-ledger-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT }}/ledger
+          if-no-files-found: ignore
+          retention-days: 14
+
       - name: Publish immutable proof handling action ledger
         if: ${{ always() && steps.setup-state.outcome == 'success' && steps.finalize-action-ledger.outcome == 'success' }}
         run: |

--- a/.github/workflows/proof-nudges.yml
+++ b/.github/workflows/proof-nudges.yml
@@ -267,6 +267,7 @@ jobs:
             --message "chore: append proof handling action ledger"
 
       - name: Publish proof mutation recovery state
+        id: publish-mutation-state
         if: ${{ always() && steps.setup-state.outcome == 'success' && steps.finalize-action-ledger.outcome == 'success' && steps.upload-finalized-ledger.outcome == 'success' && steps.publish-action-ledger.outcome == 'success' }}
         env:
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
@@ -280,7 +281,7 @@ jobs:
             --path "results/proof-nudge-mutations/${target_slug}"
 
       - name: Publish proof handling cursors
-        if: ${{ always() && steps.run-proof-nudges.outcome == 'success' && steps.finalize-action-ledger.outcome == 'success' && steps.upload-finalized-ledger.outcome == 'success' && steps.publish-action-ledger.outcome == 'success' }}
+        if: ${{ always() && steps.run-proof-nudges.outcome == 'success' && steps.finalize-action-ledger.outcome == 'success' && steps.upload-finalized-ledger.outcome == 'success' && steps.publish-action-ledger.outcome == 'success' && steps.publish-mutation-state.outcome == 'success' }}
         run: |
           set -euo pipefail
           paths_file=".artifacts/proof-cursor-paths.txt"

--- a/.github/workflows/proof-nudges.yml
+++ b/.github/workflows/proof-nudges.yml
@@ -158,7 +158,9 @@ jobs:
           item_numbers_arg=()
           cursor_arg=()
           bot_cursor_arg=()
-          cursor_publish_args=()
+          cursor_paths_file=".artifacts/proof-cursor-paths.txt"
+          mkdir -p .artifacts
+          : > "$cursor_paths_file"
           target_slug="$TARGET_REPO"
           target_slug="${target_slug//\//-}"
           if [ -n "$PROOF_NUDGES_ITEM_NUMBERS" ]; then
@@ -183,7 +185,7 @@ jobs:
             "${execute_arg[@]}"
           proof_cursor_path="results/proof-nudge-cursors/${target_slug}.json"
           if [ "$PROOF_NUDGES_EXECUTE" = "true" ] && [ -f "$proof_cursor_path" ]; then
-            cursor_publish_args+=(--path "$proof_cursor_path")
+            printf '%s\n' "$proof_cursor_path" >> "$cursor_paths_file"
           fi
 
           if [ "$BOT_PROOF_ENABLED" = "true" ]; then
@@ -201,14 +203,8 @@ jobs:
               "${bot_proof_execute_arg[@]}"
             bot_cursor_path="results/bot-proof-cursors/${target_slug}.json"
             if [ "$BOT_PROOF_EXECUTE" = "true" ] && [ -f "$bot_cursor_path" ]; then
-              cursor_publish_args+=(--path "$bot_cursor_path")
+              printf '%s\n' "$bot_cursor_path" >> "$cursor_paths_file"
             fi
-          fi
-          if [ ${#cursor_publish_args[@]} -gt 0 ]; then
-            pnpm run repair:publish-main -- \
-              --message "chore: update proof handling cursors" \
-              --rebase-strategy theirs \
-              "${cursor_publish_args[@]}"
           fi
 
       - name: Finalize proof handling action ledger
@@ -226,6 +222,7 @@ jobs:
           pnpm run --silent finalize-action-events -- "${args[@]}"
 
       - name: Upload finalized proof handling action ledger
+        id: upload-finalized-ledger
         if: ${{ always() && steps.finalize-action-ledger.outcome == 'success' }}
         uses: actions/upload-artifact@v7
         with:
@@ -235,6 +232,7 @@ jobs:
           retention-days: 14
 
       - name: Publish immutable proof handling action ledger
+        id: publish-action-ledger
         if: ${{ always() && steps.setup-state.outcome == 'success' && steps.finalize-action-ledger.outcome == 'success' }}
         run: |
           set -euo pipefail
@@ -265,6 +263,25 @@ jobs:
           node dist/clawsweeper.js publish-action-event-paths \
             --paths-file "$paths_file" \
             --message "chore: append proof handling action ledger"
+
+      - name: Publish proof handling cursors
+        if: ${{ always() && steps.run-proof-nudges.outcome == 'success' && steps.finalize-action-ledger.outcome == 'success' && steps.upload-finalized-ledger.outcome == 'success' && steps.publish-action-ledger.outcome == 'success' }}
+        run: |
+          set -euo pipefail
+          paths_file=".artifacts/proof-cursor-paths.txt"
+          if [ ! -s "$paths_file" ]; then
+            echo "No proof handling cursors to publish."
+            exit 0
+          fi
+          cursor_publish_args=()
+          while IFS= read -r cursor_path; do
+            test -f "$cursor_path"
+            cursor_publish_args+=(--path "$cursor_path")
+          done < "$paths_file"
+          pnpm run repair:publish-main -- \
+            --message "chore: update proof handling cursors" \
+            --rebase-strategy theirs \
+            "${cursor_publish_args[@]}"
 
       - uses: actions/upload-artifact@v7
         if: ${{ always() }}

--- a/.github/workflows/proof-nudges.yml
+++ b/.github/workflows/proof-nudges.yml
@@ -214,7 +214,16 @@ jobs:
       - name: Finalize proof handling action ledger
         id: finalize-action-ledger
         if: ${{ always() && steps.setup-action-ledger.outcome == 'success' && steps.setup-pnpm.outcome == 'success' }}
-        run: pnpm run --silent finalize-action-events
+        env:
+          PROOF_OUTCOME: ${{ steps.run-proof-nudges.outcome || 'not_started' }}
+        run: |
+          args=()
+          if [ "$PROOF_OUTCOME" = "cancelled" ]; then
+            args=(--interrupt-open-attempts --reason cancelled)
+          elif [ "$PROOF_OUTCOME" != "success" ]; then
+            args=(--interrupt-open-attempts --reason workflow_failed)
+          fi
+          pnpm run --silent finalize-action-events -- "${args[@]}"
 
       - name: Publish immutable proof handling action ledger
         if: ${{ always() && steps.setup-state.outcome == 'success' && steps.finalize-action-ledger.outcome == 'success' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,7 +123,9 @@ checkpoint, and status-only commits are intentionally omitted.
   conversation activity before every proof comment or label request, including
   a post-hydration head read, fresh contributor activity, and bound live
   policy/label state, with privacy-bounded immutable request receipts,
-  conservative unknown outcomes, and exact comment/label crash reconciliation.
+  conservative unknown outcomes, exact comment/label crash reconciliation,
+  replay-safe bot-proof POST/PATCH recovery, and best-effort recovery-state
+  publication before cursor progress.
 - Bound pull-request review reuse, apply, and automerge actions to a size-capped digest of reviews, inline comments, and review-thread resolution state, so legacy reports, late activity, or resolved-thread drift force a fresh verdict before mutation.
 - Stopped narrow OpenClaw automerge repairs from chasing unrelated full-repository lint and typecheck failures.
 - Removed the synthetic Codex write preflight that could block repair before Codex saw the real task.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,9 +121,9 @@ checkpoint, and status-only commits are intentionally omitted.
   instead of mutable workflow defaults.
 - Revalidated the exact pull request head and bounded review, thread, and
   conversation activity before every proof comment or label request, including
-  a post-hydration head read and live policy gates, with privacy-bounded
-  immutable request receipts, conservative unknown outcomes, and exact
-  comment/label crash reconciliation.
+  a post-hydration head read, fresh contributor activity, and bound live
+  policy/label state, with privacy-bounded immutable request receipts,
+  conservative unknown outcomes, and exact comment/label crash reconciliation.
 - Bound pull-request review reuse, apply, and automerge actions to a size-capped digest of reviews, inline comments, and review-thread resolution state, so legacy reports, late activity, or resolved-thread drift force a fresh verdict before mutation.
 - Stopped narrow OpenClaw automerge repairs from chasing unrelated full-repository lint and typecheck failures.
 - Removed the synthetic Codex write preflight that could block repair before Codex saw the real task.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,9 +120,10 @@ checkpoint, and status-only commits are intentionally omitted.
   reuse the actual effective mode, runners, sandbox, model, and dry-run state
   instead of mutable workflow defaults.
 - Revalidated the exact pull request head and bounded review, thread, and
-  conversation activity before every proof comment or label request, with
-  privacy-bounded immutable request receipts, conservative unknown outcomes,
-  and same-head crash reconciliation.
+  conversation activity before every proof comment or label request, including
+  a post-hydration head read and live policy gates, with privacy-bounded
+  immutable request receipts, conservative unknown outcomes, and exact
+  comment/label crash reconciliation.
 - Bound pull-request review reuse, apply, and automerge actions to a size-capped digest of reviews, inline comments, and review-thread resolution state, so legacy reports, late activity, or resolved-thread drift force a fresh verdict before mutation.
 - Stopped narrow OpenClaw automerge repairs from chasing unrelated full-repository lint and typecheck failures.
 - Removed the synthetic Codex write preflight that could block repair before Codex saw the real task.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,10 @@ checkpoint, and status-only commits are intentionally omitted.
   attempt-scoped artifact so bounded requeues and failed-run self-heal retries
   reuse the actual effective mode, runners, sandbox, model, and dry-run state
   instead of mutable workflow defaults.
+- Revalidated the exact pull request head and bounded review, thread, and
+  conversation activity before every proof comment or label request, with
+  privacy-bounded immutable request receipts, conservative unknown outcomes,
+  and same-head crash reconciliation.
 - Bound pull-request review reuse, apply, and automerge actions to a size-capped digest of reviews, inline comments, and review-thread resolution state, so legacy reports, late activity, or resolved-thread drift force a fresh verdict before mutation.
 - Stopped narrow OpenClaw automerge repairs from chasing unrelated full-repository lint and typecheck failures.
 - Removed the synthetic Codex write preflight that could block repair before Codex saw the real task.

--- a/docs/action-ledger.md
+++ b/docs/action-ledger.md
@@ -100,7 +100,10 @@ confidential-identifier checks as every other durable machine-text field.
   automatic retry. Same-head comment markers and desired label state reconcile
   response loss or crash-open attempts under the original hashed business
   idempotency key without storing raw prompts, logs, review bodies, or comment
-  bodies and without claiming a second mutation.
+  bodies and without claiming a second mutation. Same-run recovery follows and
+  parents the request outcome; a later workflow run records a new recovery
+  attempt under that same business idempotency key. The proof workflow publishes
+  its finalized shards to the state repository.
 - Explicit command replays require a durable command `attempt_id` derived from
   or forwarded through the production workflow. It scopes command operation,
   attempt, mutation idempotency, dispatch claims, and worker receipt keys to that

--- a/docs/action-ledger.md
+++ b/docs/action-ledger.md
@@ -105,10 +105,12 @@ confidential-identifier checks as every other durable machine-text field.
   exact label-operation postconditions reconcile response loss or crash-open
   attempts under the original hashed business idempotency key without storing
   raw prompts, logs, review bodies, or comment bodies and without claiming a
-  second mutation. Same-run recovery follows and parents the request outcome; a
-  later workflow run records a new recovery attempt under that same business
-  idempotency key. The proof workflow publishes its finalized shards to the
-  state repository.
+  second mutation. Contributor nudges persist the original marker timestamp
+  before the request. An unresolved same-head cycle blocks another POST while a
+  later workflow run records a non-mutating pending-reconciliation event under
+  that same business idempotency key. Same-run recovery follows and parents the
+  request outcome. The proof workflow publishes both finalized shards and the
+  bounded per-PR recovery state to the state repository before cursor progress.
 - Explicit command replays require a durable command `attempt_id` derived from
   or forwarded through the production workflow. It scopes command operation,
   attempt, mutation idempotency, dispatch claims, and worker receipt keys to that

--- a/docs/action-ledger.md
+++ b/docs/action-ledger.md
@@ -106,11 +106,14 @@ confidential-identifier checks as every other durable machine-text field.
   attempts under the original hashed business idempotency key without storing
   raw prompts, logs, review bodies, or comment bodies and without claiming a
   second mutation. Contributor nudges persist the original marker timestamp
-  before the request. An unresolved same-head cycle blocks another POST while a
-  later workflow run records a non-mutating pending-reconciliation event under
-  that same business idempotency key. Same-run recovery follows and parents the
-  request outcome. The proof workflow publishes both finalized shards and the
-  bounded per-PR recovery state to the state repository before cursor progress.
+  before the request. Bot-proof comments persist the desired body digest before
+  either a POST or PATCH. An unresolved same-head cycle blocks another comment
+  request while a later workflow run records a non-mutating
+  pending-reconciliation event under that same business idempotency key.
+  Same-run recovery follows and parents the request outcome. The proof workflow
+  publishes bounded per-PR recovery state best-effort even if finalized shard
+  upload or publication fails, while cursor progress remains gated on all three
+  durable publications.
 - Explicit command replays require a durable command `attempt_id` derived from
   or forwarded through the production workflow. It scopes command operation,
   attempt, mutation idempotency, dispatch claims, and worker receipt keys to that

--- a/docs/action-ledger.md
+++ b/docs/action-ledger.md
@@ -98,14 +98,17 @@ confidential-identifier checks as every other durable machine-text field.
   boundary after revalidating the exact head before and after bounded review,
   inline-comment, review-thread, and conversation activity hydration. Live
   open, locked, draft, proof-policy, and protected-label state is enforced at
-  that same request boundary. Outcome-unknown requests stop automatic retry.
-  Same-head comment markers and exact label-operation postconditions reconcile
-  response loss or crash-open attempts under the original hashed business
-  idempotency key without storing raw prompts, logs, review bodies, or comment
-  bodies and without claiming a second mutation. Same-run recovery follows and
-  parents the request outcome; a later workflow run records a new recovery
-  attempt under that same business idempotency key. The proof workflow
-  publishes its finalized shards to the state repository.
+  that same request boundary. Contributor activity used by nudge eligibility is
+  hydrated there as well. Bot-proof label plans are bound to the live label
+  cursor, which advances only for accepted owned label requests.
+  Outcome-unknown requests stop automatic retry. Same-head comment markers and
+  exact label-operation postconditions reconcile response loss or crash-open
+  attempts under the original hashed business idempotency key without storing
+  raw prompts, logs, review bodies, or comment bodies and without claiming a
+  second mutation. Same-run recovery follows and parents the request outcome; a
+  later workflow run records a new recovery attempt under that same business
+  idempotency key. The proof workflow publishes its finalized shards to the
+  state repository.
 - Explicit command replays require a durable command `attempt_id` derived from
   or forwarded through the production workflow. It scopes command operation,
   attempt, mutation idempotency, dispatch claims, and worker receipt keys to that

--- a/docs/action-ledger.md
+++ b/docs/action-ledger.md
@@ -95,15 +95,17 @@ confidential-identifier checks as every other durable machine-text field.
   metadata writes remain one-shot. A later command failure inherits accepted or
   uncertain mutation state instead of being finalized as `mutation: false`.
 - Proof-nudge and bot-proof comment and label writes use the same receipt
-  boundary after revalidating the exact head plus bounded review, inline-comment,
-  review-thread, and conversation activity. Outcome-unknown requests stop
-  automatic retry. Same-head comment markers and desired label state reconcile
+  boundary after revalidating the exact head before and after bounded review,
+  inline-comment, review-thread, and conversation activity hydration. Live
+  open, locked, draft, proof-policy, and protected-label state is enforced at
+  that same request boundary. Outcome-unknown requests stop automatic retry.
+  Same-head comment markers and exact label-operation postconditions reconcile
   response loss or crash-open attempts under the original hashed business
   idempotency key without storing raw prompts, logs, review bodies, or comment
   bodies and without claiming a second mutation. Same-run recovery follows and
   parents the request outcome; a later workflow run records a new recovery
-  attempt under that same business idempotency key. The proof workflow publishes
-  its finalized shards to the state repository.
+  attempt under that same business idempotency key. The proof workflow
+  publishes its finalized shards to the state repository.
 - Explicit command replays require a durable command `attempt_id` derived from
   or forwarded through the production workflow. It scopes command operation,
   attempt, mutation idempotency, dispatch claims, and worker receipt keys to that

--- a/docs/action-ledger.md
+++ b/docs/action-ledger.md
@@ -94,6 +94,13 @@ confidential-identifier checks as every other durable machine-text field.
   idempotency identity but receive separate causal receipt pairs; best-effort
   metadata writes remain one-shot. A later command failure inherits accepted or
   uncertain mutation state instead of being finalized as `mutation: false`.
+- Proof-nudge and bot-proof comment and label writes use the same receipt
+  boundary after revalidating the exact head plus bounded review, inline-comment,
+  review-thread, and conversation activity. Outcome-unknown requests stop
+  automatic retry. Same-head comment markers and desired label state reconcile
+  response loss or crash-open attempts under the original hashed business
+  idempotency key without storing raw prompts, logs, review bodies, or comment
+  bodies and without claiming a second mutation.
 - Explicit command replays require a durable command `attempt_id` derived from
   or forwarded through the production workflow. It scopes command operation,
   attempt, mutation idempotency, dispatch claims, and worker receipt keys to that

--- a/docs/proof-nudges.md
+++ b/docs/proof-nudges.md
@@ -93,6 +93,15 @@ the same hashed business idempotency key. Label recovery uses the exact
 the public postcondition satisfies. Existing same-head nudge markers are
 reconciled even after their cooldown expires, before a new reminder is posted.
 
+Contributor nudges also write one bounded per-PR recovery record before the
+comment request. It contains only repository, PR number, head SHA, and the
+original marker timestamp. If the outcome is unknown and the marker is still
+not visible, later runs report `proof_nudge_reconciliation_pending`, reuse the
+same hashed business identity, and do not send another POST. The record is
+cleared only after rejection, confirmed publication, reconciliation, or a head
+change. Recovery-state publication runs after immutable receipt publication and
+does not advance the proof scan cursor.
+
 Reports expose only bounded status and reason strings:
 
 - `skipped_changed_before_mutation` when head or bounded activity changed;

--- a/docs/proof-nudges.md
+++ b/docs/proof-nudges.md
@@ -70,11 +70,13 @@ incomplete read, or any head, review, thread, or conversation drift blocks the
 request. A successful earlier label request does not authorize the next one;
 each request gets its own freshness check.
 
-When action-ledger context is enabled, every request writes an immutable
-pre-request receipt and then one accepted, rejected-before-write, or
-outcome-unknown receipt. Retries retain one business idempotency key while each
-request attempt has a distinct receipt pair. An outcome-unknown response is not
-automatically retried, even when it resembles a transient GitHub error.
+The production proof workflow enables the action ledger before either command.
+Every request writes an immutable pre-request receipt and then one accepted,
+rejected-before-write, or outcome-unknown receipt. Retries retain one business
+idempotency key while each request attempt has a distinct receipt pair. An
+outcome-unknown response is not automatically retried, even when it resembles a
+transient GitHub error. The workflow finalizes, imports, and publishes the exact
+proof-job shards to the state repository before completing.
 
 Proof comments contain same-head markers, and bot-proof comments use a stable
 body plus the desired label state. After a response loss or process crash, a

--- a/docs/proof-nudges.md
+++ b/docs/proof-nudges.md
@@ -93,14 +93,17 @@ the same hashed business idempotency key. Label recovery uses the exact
 the public postcondition satisfies. Existing same-head nudge markers are
 reconciled even after their cooldown expires, before a new reminder is posted.
 
-Contributor nudges also write one bounded per-PR recovery record before the
-comment request. It contains only repository, PR number, head SHA, and the
-original marker timestamp. If the outcome is unknown and the marker is still
-not visible, later runs report `proof_nudge_reconciliation_pending`, reuse the
-same hashed business identity, and do not send another POST. The record is
-cleared only after rejection, confirmed publication, reconciliation, or a head
-change. Recovery-state publication runs after immutable receipt publication and
-does not advance the proof scan cursor.
+Both lanes write one bounded per-PR recovery record before the comment request.
+Contributor records contain repository, PR number, head SHA, and the original
+marker timestamp. Bot-proof records replace the timestamp with the desired
+comment-body digest, so the same fence covers both POST and PATCH attempts
+without storing comment text. If an unknown outcome is not yet visible, later
+runs report `proof_nudge_reconciliation_pending` or
+`bot_proof_reconciliation_pending`, reuse the same hashed business identity,
+and do not send another request. Records clear only after rejection, confirmed
+publication, reconciliation, or a head change. Recovery-state publication is
+best-effort even when receipt artifact or state publication fails, and it does
+not advance the proof scan cursor.
 
 Reports expose only bounded status and reason strings:
 
@@ -176,6 +179,8 @@ The workflow publishes only the exact target cursor files, for example
 `results/proof-nudge-cursors/openclaw-openclaw.json`, and only after the
 corresponding lane executed and wrote that file. Dry-runs do not publish cursor
 paths, and one target repo run does not replace another target's cursor file.
+Cursor publication also requires finalized receipt upload, immutable receipt
+publication, and successful recovery-state publication.
 
 Suggested rollout:
 

--- a/docs/proof-nudges.md
+++ b/docs/proof-nudges.md
@@ -68,9 +68,12 @@ The activity snapshots are SHA-256 cursors. Raw comment and review bodies are
 never written to reports or receipts. Activity beyond either bound, an
 incomplete read, or any head, review, thread, or conversation drift blocks the
 request. The same boundary also revalidates open, unlocked, non-draft, and
-non-protected proof eligibility from live state. A successful earlier label
-request does not authorize the next one; each request gets its own freshness
-check.
+non-protected proof eligibility from live state. Nudge author comments, PR body
+edits, and review activity are hydrated inside that boundary instead of reused
+from the earlier planning read. Bot-proof label plans start from the bound live
+label set, and the expected label cursor advances only after an accepted owned
+label operation. A successful earlier label request does not authorize the next
+one; each request gets its own freshness check.
 
 The production proof workflow enables the action ledger before either command.
 Every request writes an immutable pre-request receipt and then one accepted,

--- a/docs/proof-nudges.md
+++ b/docs/proof-nudges.md
@@ -59,7 +59,7 @@ Immediately before every proof comment, label creation, label addition, and
 label removal request, ClawSweeper reads two consecutive live snapshots and
 requires both to match the baseline:
 
-- the exact pull request head SHA;
+- the exact pull request head SHA, read before and after activity hydration;
 - at most 1,000 combined reviews, inline comments, and review threads,
   including thread resolution state;
 - at most 1,000 pull request conversation comments.
@@ -67,8 +67,10 @@ requires both to match the baseline:
 The activity snapshots are SHA-256 cursors. Raw comment and review bodies are
 never written to reports or receipts. Activity beyond either bound, an
 incomplete read, or any head, review, thread, or conversation drift blocks the
-request. A successful earlier label request does not authorize the next one;
-each request gets its own freshness check.
+request. The same boundary also revalidates open, unlocked, non-draft, and
+non-protected proof eligibility from live state. A successful earlier label
+request does not authorize the next one; each request gets its own freshness
+check.
 
 The production proof workflow enables the action ledger before either command.
 Every request writes an immutable pre-request receipt and then one accepted,
@@ -83,7 +85,10 @@ body plus the desired label state. After a response loss or process crash, a
 later run checks those public facts before another write. A match records
 `proof_nudge_reconciled` or `bot_proof_decision_reconciled` without claiming a
 new mutation. An open pre-request receipt and its later reconciliation share
-the same hashed business idempotency key.
+the same hashed business idempotency key. Label recovery uses the exact
+`label_create`, `issue_label_add`, or `issue_label_remove` request identity that
+the public postcondition satisfies. Existing same-head nudge markers are
+reconciled even after their cooldown expires, before a new reminder is posted.
 
 Reports expose only bounded status and reason strings:
 

--- a/docs/proof-nudges.md
+++ b/docs/proof-nudges.md
@@ -52,6 +52,47 @@ requests use `bot_proof_mantis_request_planned` or
 `bot_proof_mantis_request_posted`. Hosted dashboard events with those tokens are
 counted in the proof operation counters.
 
+## Mutation Freshness And Receipts
+
+Execute mode establishes one exact-head baseline before proof eligibility reads.
+Immediately before every proof comment, label creation, label addition, and
+label removal request, ClawSweeper reads two consecutive live snapshots and
+requires both to match the baseline:
+
+- the exact pull request head SHA;
+- at most 1,000 combined reviews, inline comments, and review threads,
+  including thread resolution state;
+- at most 1,000 pull request conversation comments.
+
+The activity snapshots are SHA-256 cursors. Raw comment and review bodies are
+never written to reports or receipts. Activity beyond either bound, an
+incomplete read, or any head, review, thread, or conversation drift blocks the
+request. A successful earlier label request does not authorize the next one;
+each request gets its own freshness check.
+
+When action-ledger context is enabled, every request writes an immutable
+pre-request receipt and then one accepted, rejected-before-write, or
+outcome-unknown receipt. Retries retain one business idempotency key while each
+request attempt has a distinct receipt pair. An outcome-unknown response is not
+automatically retried, even when it resembles a transient GitHub error.
+
+Proof comments contain same-head markers, and bot-proof comments use a stable
+body plus the desired label state. After a response loss or process crash, a
+later run checks those public facts before another write. A match records
+`proof_nudge_reconciled` or `bot_proof_decision_reconciled` without claiming a
+new mutation. An open pre-request receipt and its later reconciliation share
+the same hashed business idempotency key.
+
+Reports expose only bounded status and reason strings:
+
+- `skipped_changed_before_mutation` when head or bounded activity changed;
+- `proof_nudge_outcome_unknown` or `bot_proof_mutation_outcome_unknown` when
+  GitHub may have accepted a request but public state cannot confirm it;
+- the reconciliation actions above when public state confirms completion.
+
+Receipts and reports do not contain raw prompts, command logs, comment bodies,
+or review bodies.
+
 ## Marker
 
 Cooldown state lives in the reminder comment body:

--- a/src/action-ledger-runtime.ts
+++ b/src/action-ledger-runtime.ts
@@ -2397,14 +2397,22 @@ function actionEventMessage(event: ActionEvent): string {
 
 function machineIdentifier(value: string, maxLength: number): string {
   const source = value.trim();
-  const readable = source.replace(/[^A-Za-z0-9_.:/@+-]+/g, "-").replace(/^-+|-+$/g, "");
+  const readable = trimHyphenEdges(source.replace(/[^A-Za-z0-9_.:/@+-]+/g, "-"));
   if (!readable) throw new Error("workflow action identifier is required");
   if (readable === source && readable.length <= maxLength) return readable;
   const digest = createHash("sha256").update(source).digest("hex").slice(0, 12);
   const prefixLength = maxLength - digest.length - 1;
   if (prefixLength < 1) throw new Error("workflow action identifier limit is too small");
-  const prefix = readable.slice(0, prefixLength).replace(/-+$/g, "") || "id";
+  const prefix = trimHyphenEdges(readable.slice(0, prefixLength)) || "id";
   return `${prefix}-${digest}`;
+}
+
+function trimHyphenEdges(value: string): string {
+  let start = 0;
+  while (start < value.length && value.charCodeAt(start) === 45) start += 1;
+  let end = value.length;
+  while (end > start && value.charCodeAt(end - 1) === 45) end -= 1;
+  return value.slice(start, end);
 }
 
 function workflowPathFromRef(workflowRef: string): string {

--- a/src/action-ledger-runtime.ts
+++ b/src/action-ledger-runtime.ts
@@ -433,7 +433,8 @@ function workflowActionEventIsRecoverableStart(event: ActionEvent): boolean {
       event.event_type === ACTION_EVENT_TYPES.reviewRetry ||
       event.event_type === ACTION_EVENT_TYPES.repairExecute ||
       event.event_type === ACTION_EVENT_TYPES.applyBatch ||
-      event.event_type === ACTION_EVENT_TYPES.applyAction) &&
+      event.event_type === ACTION_EVENT_TYPES.applyAction ||
+      event.event_type === ACTION_EVENT_TYPES.proofStage) &&
     event.action.status === ACTION_EVENT_STATUSES.started
   );
 }

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -29591,8 +29591,7 @@ function botProofCommand(args: Args): void {
     } catch (error) {
       results.push({
         ...resultBase,
-        action: "skipped_live_fetch_failed",
-        reason: proofNudgeLiveFetchFailureReason(error),
+        ...proofMutationFailureResult(error),
       });
       markProcessed(candidate);
       continue;

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -197,6 +197,7 @@ import {
   createProofConversationActivityCursor,
   finishProofMutationReceipt,
   proofMutationFreshnessBlock,
+  recordProofMutationPendingReconciliation,
   recordProofMutationReconciliation,
   startProofMutationReceipt,
   type ProofMutationFreshnessBlock,
@@ -1080,6 +1081,7 @@ type ProofNudgeAction =
   | "proof_nudge_posted"
   | "proof_nudge_planned"
   | "proof_nudge_reconciled"
+  | "proof_nudge_reconciliation_pending"
   | "proof_nudge_outcome_unknown"
   | "skipped_not_pull_request"
   | "skipped_not_open"
@@ -1125,6 +1127,15 @@ interface ProofNudgeResult {
   url?: string | undefined;
   headSha?: string | undefined;
   reviewedAt?: string | undefined;
+}
+
+interface ProofNudgeMutationCycle {
+  schema_version: 1;
+  repository: string;
+  number: number;
+  head_sha: string;
+  marker_timestamp: string;
+  created_at: string;
 }
 
 interface BotProofResult {
@@ -1198,6 +1209,7 @@ interface ProofNudgeEligibility {
     | "skipped_not_open"
     | "skipped_runtime_budget"
     | "proof_nudge_reconciled"
+    | "proof_nudge_reconciliation_pending"
     | "proof_nudge_outcome_unknown"
     | "skipped_changed_before_mutation"
   >;
@@ -14989,6 +15001,18 @@ function latestProofNudgeAt(
   );
 }
 
+function proofNudgeMarkerExistsAt(
+  comments: readonly ProofNudgeComment[],
+  options: { number: number; headSha: string; timestamp: string },
+): boolean {
+  return proofNudgeMarkersFromComments(comments).some(
+    (marker) =>
+      marker.item === options.number &&
+      marker.sha === options.headSha &&
+      marker.at === options.timestamp,
+  );
+}
+
 function proofNudgeCommentsWithLiveMarkers(
   comments: readonly ProofNudgeComment[],
   liveComments: readonly ProofNudgeComment[],
@@ -28505,6 +28529,69 @@ function proofLaneCursorPath(args: Args, requestedItemNumbers: readonly number[]
   return rawPath ? resolve(rawPath) : null;
 }
 
+function proofNudgeMutationStateDir(args: Args, reportPath: string): string {
+  const targetSlug = targetRepo().replace("/", "-");
+  return resolve(
+    stringArg(
+      args.mutation_state_dir,
+      join(dirname(reportPath), "proof-nudge-mutations", targetSlug),
+    ),
+  );
+}
+
+function proofNudgeMutationCyclePath(stateDir: string, number: number): string {
+  return join(stateDir, `${number}.json`);
+}
+
+function readProofNudgeMutationCycle(path: string, number: number): ProofNudgeMutationCycle | null {
+  if (!existsSync(path)) return null;
+  const parsed = asRecord(
+    JSON.parse(readBoundedUtf8File(path, 4_096, "proof nudge mutation cycle")),
+  );
+  const headSha = stringOrUndefined(parsed.head_sha)?.trim().toLowerCase();
+  const markerTimestamp = stringOrUndefined(parsed.marker_timestamp);
+  const createdAt = stringOrUndefined(parsed.created_at);
+  if (
+    parsed.schema_version !== 1 ||
+    parsed.repository !== targetRepo() ||
+    parsed.number !== number ||
+    !headSha ||
+    !/^[0-9a-f]{40}$/.test(headSha) ||
+    !markerTimestamp ||
+    timestampMs(markerTimestamp) === null ||
+    !createdAt ||
+    timestampMs(createdAt) === null
+  ) {
+    throw new Error(`invalid proof nudge mutation cycle for #${number}`);
+  }
+  return {
+    schema_version: 1,
+    repository: targetRepo(),
+    number,
+    head_sha: headSha,
+    marker_timestamp: markerTimestamp,
+    created_at: createdAt,
+  };
+}
+
+function writeProofNudgeMutationCycle(path: string, cycle: ProofNudgeMutationCycle): void {
+  ensureDir(dirname(path));
+  const temporaryPath = join(
+    dirname(path),
+    `.${basename(path)}.${process.pid}.${randomUUID()}.tmp`,
+  );
+  try {
+    writeFileSync(temporaryPath, `${JSON.stringify(cycle, null, 2)}\n`, "utf8");
+    renameSync(temporaryPath, path);
+  } finally {
+    if (existsSync(temporaryPath)) unlinkSync(temporaryPath);
+  }
+}
+
+function clearProofNudgeMutationCycle(path: string): void {
+  if (existsSync(path)) unlinkSync(path);
+}
+
 function proofLaneProcessedLimit(args: Args, fallback: number): number {
   const value = numberArg(args.processed_limit, fallback);
   if (!Number.isInteger(value) || value < 1) {
@@ -28813,6 +28900,7 @@ function proofNudgesCommand(args: Args): void {
   const dryRun = !execute;
   const maxRuntimeMs = numberArg(args.max_runtime_ms, 0);
   const reportPath = resolve(stringArg(args.report_path, join(ROOT, "proof-nudge-report.json")));
+  const mutationStateDir = proofNudgeMutationStateDir(args, reportPath);
   const requestedItemNumbers = itemNumbersArg(args.item_numbers, args.item_number);
   const cursorPath = proofLaneCursorPath(args, requestedItemNumbers);
 
@@ -28902,6 +28990,8 @@ function proofNudgesCommand(args: Args): void {
     let authorEditedAt: string | undefined;
     let authorReviewActivityAt: string | undefined;
     let mutationSession: ProofMutationSession | null = null;
+    let pendingMutationCycle: ProofNudgeMutationCycle | null = null;
+    const mutationCyclePath = proofNudgeMutationCyclePath(mutationStateDir, candidate.number);
     try {
       pullDetails =
         item.kind === "pull_request" ? fetchPullRequestProofNudgeDetails(candidate.number) : {};
@@ -28928,6 +29018,14 @@ function proofNudgesCommand(args: Args): void {
               cooldownDays,
             }),
         });
+        pendingMutationCycle = readProofNudgeMutationCycle(mutationCyclePath, candidate.number);
+        if (
+          pendingMutationCycle &&
+          pendingMutationCycle.head_sha !== pullDetails.headSha.trim().toLowerCase()
+        ) {
+          clearProofNudgeMutationCycle(mutationCyclePath);
+          pendingMutationCycle = null;
+        }
       }
     } catch (error) {
       results.push({
@@ -28939,6 +29037,58 @@ function proofNudgesCommand(args: Args): void {
     }
     const hydratedComments =
       execute && mutationSession ? mutationSession.expectedFreshness.comments : comments;
+    if (
+      execute &&
+      mutationSession &&
+      pullDetails.headSha &&
+      pendingMutationCycle &&
+      !proofNudgeMarkerExistsAt(hydratedComments, {
+        number: candidate.number,
+        headSha: pullDetails.headSha,
+        timestamp: pendingMutationCycle.marker_timestamp,
+      })
+    ) {
+      recordProofMutationPendingReconciliation({
+        context: mutationSession.context,
+        mutationIdentity: proofNudgeCommentMutationIdentity({
+          number: candidate.number,
+          headSha: pullDetails.headSha,
+          timestamp: pendingMutationCycle.marker_timestamp,
+        }),
+      });
+      results.push({
+        ...resultBase,
+        action: "proof_nudge_reconciliation_pending",
+        reason:
+          "a prior same-head proof nudge outcome is still unknown; waiting for its exact marker before any retry",
+        headSha: pullDetails.headSha,
+      });
+      markProcessed(candidate);
+      logProgress(`proof_nudge_reconciliation_pending proof nudge #${candidate.number}`);
+      continue;
+    }
+    const reconciledPendingNudge = Boolean(
+      execute &&
+      mutationSession &&
+      pullDetails.headSha &&
+      pendingMutationCycle &&
+      proofNudgeMarkerExistsAt(hydratedComments, {
+        number: candidate.number,
+        headSha: pullDetails.headSha,
+        timestamp: pendingMutationCycle.marker_timestamp,
+      }),
+    );
+    if (reconciledPendingNudge && mutationSession && pullDetails.headSha && pendingMutationCycle) {
+      reconcileProofMutation(
+        mutationSession,
+        proofNudgeCommentMutationIdentity({
+          number: candidate.number,
+          headSha: pullDetails.headSha,
+          timestamp: pendingMutationCycle.marker_timestamp,
+        }),
+      );
+      clearProofNudgeMutationCycle(mutationCyclePath);
+    }
     const sameHeadNudgeAt = pullDetails.headSha
       ? latestProofNudgeAt(hydratedComments, {
           number: candidate.number,
@@ -28946,9 +29096,15 @@ function proofNudgesCommand(args: Args): void {
         })
       : undefined;
     const reconciledPriorNudge = Boolean(
-      execute && mutationSession && pullDetails.headSha && sameHeadNudgeAt,
+      reconciledPendingNudge ||
+      (execute && mutationSession && pullDetails.headSha && sameHeadNudgeAt),
     );
-    if (reconciledPriorNudge && mutationSession && pullDetails.headSha && sameHeadNudgeAt) {
+    if (
+      mutationSession &&
+      pullDetails.headSha &&
+      sameHeadNudgeAt &&
+      sameHeadNudgeAt !== pendingMutationCycle?.marker_timestamp
+    ) {
       reconcileProofMutation(
         mutationSession,
         proofNudgeCommentMutationIdentity({
@@ -29034,6 +29190,14 @@ function proofNudgesCommand(args: Args): void {
       const previousProofMutationRunner = activeProofMutationRunner;
       activeProofMutationRunner = proofMutationRunner(mutationSession);
       try {
+        writeProofNudgeMutationCycle(mutationCyclePath, {
+          schema_version: 1,
+          repository: targetRepo(),
+          number: candidate.number,
+          head_sha: headSha.trim().toLowerCase(),
+          marker_timestamp: timestamp,
+          created_at: timestamp,
+        });
         const mutation = postProofNudgeComment({
           number: candidate.number,
           headSha,
@@ -29041,6 +29205,7 @@ function proofNudgesCommand(args: Args): void {
           body,
           session: mutationSession,
         });
+        clearProofNudgeMutationCycle(mutationCyclePath);
         results.push({
           ...resultBase,
           action: mutation.reconciled ? "proof_nudge_reconciled" : "proof_nudge_posted",
@@ -29074,6 +29239,7 @@ function proofNudgesCommand(args: Args): void {
               timestamp,
             }),
           );
+          clearProofNudgeMutationCycle(mutationCyclePath);
           results.push({
             ...resultBase,
             action: "proof_nudge_reconciled",
@@ -29082,6 +29248,7 @@ function proofNudgesCommand(args: Args): void {
             headSha,
           });
         } else if (error instanceof ProofMutationFreshnessError) {
+          clearProofNudgeMutationCycle(mutationCyclePath);
           results.push({
             ...resultBase,
             action:
@@ -29099,6 +29266,7 @@ function proofNudgesCommand(args: Args): void {
             headSha,
           });
         } else {
+          clearProofNudgeMutationCycle(mutationCyclePath);
           results.push({
             ...resultBase,
             action: "skipped_live_fetch_failed",

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -2706,6 +2706,7 @@ type ProofMutationSession = {
   expectedFreshness: ProofMutationFreshnessSnapshot;
   refreshFreshness: () => ProofMutationFreshnessSnapshot;
   nextAttemptByMutation: Map<string, number>;
+  latestEventIdByMutation: Map<string, string>;
   unknownMutationObserved: boolean;
 };
 
@@ -2776,20 +2777,26 @@ function proofMutationRunner(session: ProofMutationSession): MutationRunner {
     }
     try {
       const result = options.operation();
-      finishProofMutationReceipt({
+      const outcome = finishProofMutationReceipt({
         attempt,
         outcome: options.didMutate?.(result) === false ? "rejected" : "accepted",
       });
+      if (outcome) {
+        session.latestEventIdByMutation.set(options.idempotencyIdentity, outcome.event_id);
+      }
       return result;
     } catch (error) {
       const rejected =
         isGitHubRequiresAuthenticationError(error) ||
         isLockedConversationCommentError(error) ||
         options.knownNoMutation?.(error) === true;
-      finishProofMutationReceipt({
+      const outcome = finishProofMutationReceipt({
         attempt,
         outcome: rejected ? "rejected" : "unknown",
       });
+      if (outcome) {
+        session.latestEventIdByMutation.set(options.idempotencyIdentity, outcome.event_id);
+      }
       if (!rejected) {
         session.unknownMutationObserved = true;
         throw new ProofMutationOutcomeUnknownError(error);
@@ -2800,9 +2807,12 @@ function proofMutationRunner(session: ProofMutationSession): MutationRunner {
 }
 
 function reconcileProofMutation(session: ProofMutationSession, mutationIdentity: string): void {
+  const requestAttempt = session.nextAttemptByMutation.get(mutationIdentity) ?? 0;
   recordProofMutationReconciliation({
     context: session.context,
     mutationIdentity,
+    parentEventId: session.latestEventIdByMutation.get(mutationIdentity) ?? null,
+    phaseSeq: requestAttempt * 2 + 1,
   });
 }
 
@@ -28427,6 +28437,7 @@ function createProofMutationSession(options: {
     expectedFreshness,
     refreshFreshness: () => readProofMutationFreshnessSnapshot(options.number),
     nextAttemptByMutation: new Map(),
+    latestEventIdByMutation: new Map(),
     unknownMutationObserved: false,
   };
 }

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -2778,20 +2778,10 @@ function proofMutationRunner(session: ProofMutationSession): MutationRunner {
     didMutate?: ((result: T) => boolean) | undefined;
     knownNoMutation?: ((error: unknown) => boolean) | undefined;
   }): T => {
-    const requestAttempt =
-      (session.nextAttemptByMutation.get(options.idempotencyIdentity) ?? 0) + 1;
-    session.nextAttemptByMutation.set(options.idempotencyIdentity, requestAttempt);
-    const attempt = startProofMutationReceipt({
-      context: session.context,
-      receiptIdentity: options.identity,
-      mutationIdentity: options.idempotencyIdentity,
-      requestAttempt,
-    });
     let currentFreshness: ProofMutationRequestSnapshot;
     try {
       currentFreshness = session.refreshFreshness();
     } catch (error) {
-      finishProofMutationReceipt({ attempt, outcome: "rejected" });
       if (error instanceof ProofMutationFreshnessError) throw error;
       throw new ProofMutationFreshnessError({
         reason: "freshness_unavailable",
@@ -2806,9 +2796,17 @@ function proofMutationRunner(session: ProofMutationSession): MutationRunner {
         : null) ??
       session.validateRequest(currentFreshness);
     if (block) {
-      finishProofMutationReceipt({ attempt, outcome: "rejected" });
       throw new ProofMutationFreshnessError(block);
     }
+    const requestAttempt =
+      (session.nextAttemptByMutation.get(options.idempotencyIdentity) ?? 0) + 1;
+    session.nextAttemptByMutation.set(options.idempotencyIdentity, requestAttempt);
+    const attempt = startProofMutationReceipt({
+      context: session.context,
+      receiptIdentity: options.identity,
+      mutationIdentity: options.idempotencyIdentity,
+      requestAttempt,
+    });
     try {
       const result = options.operation();
       const outcome = finishProofMutationReceipt({

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -2707,6 +2707,7 @@ type ProofMutationSession = {
   expectedFreshness: ProofMutationRequestSnapshot;
   refreshFreshness: () => ProofMutationRequestSnapshot;
   validateRequest: (snapshot: ProofMutationRequestSnapshot) => ProofMutationFreshnessBlock | null;
+  bindLabelState: boolean;
   nextAttemptByMutation: Map<string, number>;
   latestEventIdByMutation: Map<string, string>;
   unknownMutationIdentities: Set<string>;
@@ -2716,6 +2717,29 @@ type ProofMutationSession = {
 let activeApplyMutationRunner: MutationRunner | null = null;
 let activeReviewMutationRunner: MutationRunner | null = null;
 let activeProofMutationRunner: MutationRunner | null = null;
+
+function expectedProofMutationSnapshotAfterLabelRequest(
+  snapshot: ProofMutationRequestSnapshot,
+  mutationIdentity: string,
+): ProofMutationRequestSnapshot {
+  const match = mutationIdentity.match(/^issue_label_(add|remove):(\d+):([\s\S]+)$/);
+  if (!match || Number(match[2]) !== snapshot.item.number) return snapshot;
+  const operation = match[1];
+  const label = match[3];
+  if (!operation || !label) return snapshot;
+  const normalizedLabel = normalizeLabelName(label);
+  const labels =
+    operation === "add"
+      ? snapshot.item.labels.some((entry) => normalizeLabelName(entry) === normalizedLabel)
+        ? [...snapshot.item.labels]
+        : [...snapshot.item.labels, label]
+      : snapshot.item.labels.filter((entry) => normalizeLabelName(entry) !== normalizedLabel);
+  return {
+    ...snapshot,
+    item: { ...snapshot.item, labels },
+    labelStateCursor: proofMutationLabelStateCursor(labels),
+  };
+}
 
 function mutationErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -2775,6 +2799,10 @@ function proofMutationRunner(session: ProofMutationSession): MutationRunner {
     }
     const block =
       proofMutationFreshnessBlock(session.expectedFreshness, currentFreshness) ??
+      (session.bindLabelState &&
+      currentFreshness.labelStateCursor !== session.expectedFreshness.labelStateCursor
+        ? proofMutationEligibilityChanged("live labels changed before the request")
+        : null) ??
       session.validateRequest(currentFreshness);
     if (block) {
       finishProofMutationReceipt({ attempt, outcome: "rejected" });
@@ -2788,6 +2816,12 @@ function proofMutationRunner(session: ProofMutationSession): MutationRunner {
       });
       if (outcome) {
         session.latestEventIdByMutation.set(options.idempotencyIdentity, outcome.event_id);
+      }
+      if (session.bindLabelState && options.didMutate?.(result) !== false) {
+        session.expectedFreshness = expectedProofMutationSnapshotAfterLabelRequest(
+          currentFreshness,
+          options.idempotencyIdentity,
+        );
       }
       return result;
     } catch (error) {
@@ -6758,6 +6792,10 @@ type ProofMutationRequestSnapshot = ProofMutationFreshnessSnapshot & {
   item: Item;
   state: string;
   draft: boolean;
+  labelStateCursor: string;
+  comments: ProofNudgeComment[];
+  authorEditedAt?: string | undefined;
+  authorReviewActivityAt?: string | undefined;
 };
 
 function fetchProofMutationClosingPullState(number: number): {
@@ -6776,7 +6814,14 @@ function fetchProofMutationClosingPullState(number: number): {
   return { headSha, draft: pull.draft === true };
 }
 
-function readProofMutationFreshnessSnapshot(number: number): ProofMutationRequestSnapshot {
+function proofMutationLabelStateCursor(labels: readonly string[]): string {
+  return sha256(stableJson([...normalizedLabelSet(labels)].sort()));
+}
+
+function readProofMutationFreshnessSnapshot(
+  number: number,
+  activityAuthor?: string,
+): ProofMutationRequestSnapshot {
   const readOnce = (): ProofMutationRequestSnapshot => {
     const openingHeadSha = pullRequestHeadSha(number);
     if (!openingHeadSha) throw new Error(`live PR head could not be read for #${number}`);
@@ -6791,6 +6836,13 @@ function readProofMutationFreshnessSnapshot(number: number): ProofMutationReques
       );
     }
     const live = fetchItem(number);
+    const comments = activityAuthor ? proofNudgeComments(number) : [];
+    const authorEditedAt = activityAuthor
+      ? latestAuthorPullRequestEditAt(number, activityAuthor)
+      : undefined;
+    const authorReviewActivityAt = activityAuthor
+      ? latestAuthorPullRequestReviewActivityAt(number, activityAuthor)
+      : undefined;
     const closingPull = fetchProofMutationClosingPullState(number);
     if (!closingPull.headSha) throw new Error(`live PR head could not be re-read for #${number}`);
     if (closingPull.headSha !== openingHeadSha) {
@@ -6806,6 +6858,10 @@ function readProofMutationFreshnessSnapshot(number: number): ProofMutationReques
       item: live.item,
       state: live.state,
       draft: closingPull.draft,
+      labelStateCursor: proofMutationLabelStateCursor(live.item.labels),
+      comments,
+      authorEditedAt,
+      authorReviewActivityAt,
     };
   };
   const first = readOnce();
@@ -28475,10 +28531,7 @@ function proofNudgeRequestBoundaryBlock(
   snapshot: ProofMutationRequestSnapshot,
   options: {
     markdown: string;
-    comments: readonly ProofNudgeComment[];
     headCommittedAt?: string | undefined;
-    authorEditedAt?: string | undefined;
-    authorReviewActivityAt?: string | undefined;
     minAgeDays: number;
     cooldownDays: number;
   },
@@ -28489,11 +28542,11 @@ function proofNudgeRequestBoundaryBlock(
   const eligibility = proofNudgeEligibility({
     item: snapshot.item,
     markdown: options.markdown,
-    comments: options.comments,
+    comments: snapshot.comments,
     headSha: snapshot.headSha,
     headCommittedAt: options.headCommittedAt,
-    authorEditedAt: options.authorEditedAt,
-    authorReviewActivityAt: options.authorReviewActivityAt,
+    authorEditedAt: snapshot.authorEditedAt,
+    authorReviewActivityAt: snapshot.authorReviewActivityAt,
     minAgeDays: options.minAgeDays,
     cooldownDays: options.cooldownDays,
   });
@@ -28520,9 +28573,14 @@ function createProofMutationSession(options: {
   lane: ProofMutationLane;
   number: number;
   headSha: string;
+  activityAuthor?: string | undefined;
+  bindLabelState?: boolean | undefined;
   validateRequest: (snapshot: ProofMutationRequestSnapshot) => ProofMutationFreshnessBlock | null;
 }): ProofMutationSession {
-  const expectedFreshness = readProofMutationFreshnessSnapshot(options.number);
+  const expectedFreshness = readProofMutationFreshnessSnapshot(
+    options.number,
+    options.activityAuthor,
+  );
   if (expectedFreshness.headSha !== options.headSha.trim().toLowerCase()) {
     throw new ProofMutationFreshnessError({
       reason: "head_changed",
@@ -28541,8 +28599,10 @@ function createProofMutationSession(options: {
       privacy: actionLedgerPrivacy(),
     },
     expectedFreshness,
-    refreshFreshness: () => readProofMutationFreshnessSnapshot(options.number),
+    refreshFreshness: () =>
+      readProofMutationFreshnessSnapshot(options.number, options.activityAuthor),
     validateRequest: options.validateRequest,
+    bindLabelState: options.bindLabelState === true,
     nextAttemptByMutation: new Map(),
     latestEventIdByMutation: new Map(),
     unknownMutationIdentities: new Set(),
@@ -28761,13 +28821,11 @@ function proofNudgesCommand(args: Args): void {
           lane: "proof_nudges",
           number: candidate.number,
           headSha: pullDetails.headSha,
+          activityAuthor: item.author,
           validateRequest: (snapshot) =>
             proofNudgeRequestBoundaryBlock(snapshot, {
               markdown: candidate.markdown,
-              comments,
               headCommittedAt: pullDetails.headCommittedAt,
-              authorEditedAt,
-              authorReviewActivityAt,
               minAgeDays,
               cooldownDays,
             }),
@@ -29047,6 +29105,7 @@ function botProofCommand(args: Args): void {
           lane: "bot_proof",
           number: candidate.number,
           headSha: pullDetails.headSha,
+          bindLabelState: true,
           validateRequest: (snapshot) => botProofRequestBoundaryBlock(snapshot, candidate.markdown),
         });
       }
@@ -29132,7 +29191,7 @@ function botProofCommand(args: Args): void {
       try {
         const labelResult = syncBotProofDecisionLabels({
           number: candidate.number,
-          labels: item.labels,
+          labels: mutationSession.expectedFreshness.item.labels,
           dryRun: false,
         });
         if (botProofDecisionLabelsAreSynchronized(labelResult.labels)) {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -6822,6 +6822,22 @@ function proofMutationLabelStateCursor(labels: readonly string[]): string {
   return sha256(stableJson([...normalizedLabelSet(labels)].sort()));
 }
 
+function proofMutationEligibilityStateCursor(item: Item, state: string): string {
+  return sha256(
+    stableJson({
+      state,
+      number: item.number,
+      kind: item.kind,
+      title: item.title,
+      author: item.author,
+      authorAssociation: item.authorAssociation,
+      labels: [...normalizedLabelSet(item.labels)].sort(),
+      locked: item.locked === true,
+      activeLockReason: item.activeLockReason ?? null,
+    }),
+  );
+}
+
 function readProofMutationFreshnessSnapshot(
   number: number,
   activityAuthor?: string,
@@ -6839,7 +6855,11 @@ function readProofMutationFreshnessSnapshot(
         `conversation activity exceeds the bounded proof mutation cursor for #${number}`,
       );
     }
-    const live = fetchItem(number);
+    const openingLive = fetchItem(number);
+    const openingEligibilityCursor = proofMutationEligibilityStateCursor(
+      openingLive.item,
+      openingLive.state,
+    );
     const comments = activityAuthor ? proofNudgeComments(number) : [];
     const authorEditedAt = activityAuthor
       ? latestAuthorPullRequestEditAt(number, activityAuthor)
@@ -6855,14 +6875,25 @@ function readProofMutationFreshnessSnapshot(
         message: "live PR head changed while hydrating proof mutation activity",
       });
     }
+    const closingLive = fetchItem(number);
+    if (
+      proofMutationEligibilityStateCursor(closingLive.item, closingLive.state) !==
+      openingEligibilityCursor
+    ) {
+      throw new ProofMutationFreshnessError(
+        proofMutationEligibilityChanged(
+          "live PR eligibility changed while hydrating proof mutation activity",
+        ),
+      );
+    }
     return {
       headSha: closingPull.headSha,
       reviewActivityCursor,
       conversationActivityCursor,
-      item: live.item,
-      state: live.state,
+      item: closingLive.item,
+      state: closingLive.state,
       draft: closingPull.draft,
-      labelStateCursor: proofMutationLabelStateCursor(live.item.labels),
+      labelStateCursor: proofMutationLabelStateCursor(closingLive.item.labels),
       comments,
       authorEditedAt,
       authorReviewActivityAt,
@@ -28525,6 +28556,25 @@ function proofNudgeLiveFetchFailureReason(error: unknown): string {
   return `live GitHub state could not be fetched: ${detail.slice(0, 300)}`;
 }
 
+function proofMutationFailureResult(error: unknown): {
+  action: "skipped_changed_before_mutation" | "skipped_live_fetch_failed";
+  reason: string;
+} {
+  if (error instanceof ProofMutationFreshnessError) {
+    return {
+      action:
+        error.block.reason === "freshness_unavailable"
+          ? "skipped_live_fetch_failed"
+          : "skipped_changed_before_mutation",
+      reason: error.block.message,
+    };
+  }
+  return {
+    action: "skipped_live_fetch_failed",
+    reason: proofNudgeLiveFetchFailureReason(error),
+  };
+}
+
 function proofMutationEligibilityChanged(message: string): ProofMutationFreshnessBlock {
   return {
     reason: "eligibility_changed",
@@ -28796,8 +28846,7 @@ function proofNudgesCommand(args: Args): void {
     } catch (error) {
       results.push({
         ...resultBase,
-        action: "skipped_live_fetch_failed",
-        reason: proofNudgeLiveFetchFailureReason(error),
+        ...proofMutationFailureResult(error),
       });
       markProcessed(candidate);
       continue;
@@ -28846,8 +28895,7 @@ function proofNudgesCommand(args: Args): void {
     } catch (error) {
       results.push({
         ...resultBase,
-        action: "skipped_live_fetch_failed",
-        reason: proofNudgeLiveFetchFailureReason(error),
+        ...proofMutationFailureResult(error),
       });
       markProcessed(candidate);
       continue;
@@ -29021,7 +29069,6 @@ function proofNudgesCommand(args: Args): void {
     if (
       finalAction === "proof_nudge_planned" ||
       finalAction === "proof_nudge_posted" ||
-      finalAction === "proof_nudge_reconciled" ||
       finalAction === "proof_nudge_outcome_unknown"
     ) {
       nudgeCount += 1;

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -1112,6 +1112,7 @@ type BotProofAction =
   | "skipped_stale_report_head"
   | "skipped_no_live_head"
   | "skipped_locked_conversation"
+  | "skipped_protected_label"
   | "skipped_changed_before_mutation"
   | "skipped_live_fetch_failed"
   | "skipped_runtime_budget";
@@ -2703,10 +2704,12 @@ class ProofMutationOutcomeUnknownError extends Error {
 
 type ProofMutationSession = {
   context: ProofMutationReceiptContext;
-  expectedFreshness: ProofMutationFreshnessSnapshot;
-  refreshFreshness: () => ProofMutationFreshnessSnapshot;
+  expectedFreshness: ProofMutationRequestSnapshot;
+  refreshFreshness: () => ProofMutationRequestSnapshot;
+  validateRequest: (snapshot: ProofMutationRequestSnapshot) => ProofMutationFreshnessBlock | null;
   nextAttemptByMutation: Map<string, number>;
   latestEventIdByMutation: Map<string, string>;
+  unknownMutationIdentities: Set<string>;
   unknownMutationObserved: boolean;
 };
 
@@ -2759,7 +2762,7 @@ function proofMutationRunner(session: ProofMutationSession): MutationRunner {
       mutationIdentity: options.idempotencyIdentity,
       requestAttempt,
     });
-    let currentFreshness: ProofMutationFreshnessSnapshot;
+    let currentFreshness: ProofMutationRequestSnapshot;
     try {
       currentFreshness = session.refreshFreshness();
     } catch (error) {
@@ -2770,7 +2773,9 @@ function proofMutationRunner(session: ProofMutationSession): MutationRunner {
         message: "proof mutation freshness could not be refreshed before the request",
       });
     }
-    const block = proofMutationFreshnessBlock(session.expectedFreshness, currentFreshness);
+    const block =
+      proofMutationFreshnessBlock(session.expectedFreshness, currentFreshness) ??
+      session.validateRequest(currentFreshness);
     if (block) {
       finishProofMutationReceipt({ attempt, outcome: "rejected" });
       throw new ProofMutationFreshnessError(block);
@@ -2798,6 +2803,7 @@ function proofMutationRunner(session: ProofMutationSession): MutationRunner {
         session.latestEventIdByMutation.set(options.idempotencyIdentity, outcome.event_id);
       }
       if (!rejected) {
+        session.unknownMutationIdentities.add(options.idempotencyIdentity);
         session.unknownMutationObserved = true;
         throw new ProofMutationOutcomeUnknownError(error);
       }
@@ -2814,6 +2820,8 @@ function reconcileProofMutation(session: ProofMutationSession, mutationIdentity:
     parentEventId: session.latestEventIdByMutation.get(mutationIdentity) ?? null,
     phaseSeq: requestAttempt * 2 + 1,
   });
+  session.unknownMutationIdentities.delete(mutationIdentity);
+  session.unknownMutationObserved = session.unknownMutationIdentities.size > 0;
 }
 
 function ghObservedMutationCommand(options: {
@@ -6746,10 +6754,32 @@ function fetchProofConversationActivityCursor(number: number): string | null {
   return createProofConversationActivityCursor(comments);
 }
 
-function readProofMutationFreshnessSnapshot(number: number): ProofMutationFreshnessSnapshot {
-  const readOnce = (): ProofMutationFreshnessSnapshot => {
-    const headSha = pullRequestHeadSha(number);
-    if (!headSha) throw new Error(`live PR head could not be read for #${number}`);
+type ProofMutationRequestSnapshot = ProofMutationFreshnessSnapshot & {
+  item: Item;
+  state: string;
+  draft: boolean;
+};
+
+function fetchProofMutationClosingPullState(number: number): {
+  headSha: string;
+  draft: boolean;
+} {
+  const pull = asRecord(
+    ghJson<unknown>([
+      "api",
+      `repos/${targetRepo()}/pulls/${number}`,
+      "--jq",
+      "{draft,head:{sha:.head.sha}}",
+    ]),
+  );
+  const headSha = stringOrUndefined(asRecord(pull.head).sha)?.trim().toLowerCase() ?? "";
+  return { headSha, draft: pull.draft === true };
+}
+
+function readProofMutationFreshnessSnapshot(number: number): ProofMutationRequestSnapshot {
+  const readOnce = (): ProofMutationRequestSnapshot => {
+    const openingHeadSha = pullRequestHeadSha(number);
+    if (!openingHeadSha) throw new Error(`live PR head could not be read for #${number}`);
     const reviewActivityCursor = fetchReviewedPrActivityCursor(number);
     if (!reviewActivityCursor) {
       throw new Error(`review activity exceeds the bounded proof mutation cursor for #${number}`);
@@ -6760,7 +6790,23 @@ function readProofMutationFreshnessSnapshot(number: number): ProofMutationFreshn
         `conversation activity exceeds the bounded proof mutation cursor for #${number}`,
       );
     }
-    return { headSha, reviewActivityCursor, conversationActivityCursor };
+    const live = fetchItem(number);
+    const closingPull = fetchProofMutationClosingPullState(number);
+    if (!closingPull.headSha) throw new Error(`live PR head could not be re-read for #${number}`);
+    if (closingPull.headSha !== openingHeadSha) {
+      throw new ProofMutationFreshnessError({
+        reason: "head_changed",
+        message: "live PR head changed while hydrating proof mutation activity",
+      });
+    }
+    return {
+      headSha: closingPull.headSha,
+      reviewActivityCursor,
+      conversationActivityCursor,
+      item: live.item,
+      state: live.state,
+      draft: closingPull.draft,
+    };
   };
   const first = readOnce();
   const second = readOnce();
@@ -15074,6 +15120,13 @@ function botProofEligibility(options: BotProofEligibilityOptions): BotProofEligi
       action: "skipped_policy_exempt",
       reason: "proof is already sufficient or overridden",
     };
+  }
+  const protectedLabelsForDecision = proofNudgeProtectedLabels(options.item.labels);
+  if (protectedLabelsForDecision.length > 0 || isReleaseTitle(options.item.title)) {
+    const reason = protectedLabelsForDecision.length
+      ? `protected label: ${protectedLabelsForDecision.join(", ")}`
+      : "release-style PR title";
+    return { eligible: false, action: "skipped_protected_label", reason };
   }
   if (!realBehaviorProofBlocksBotOwnedMerge(options.markdown)) {
     return {
@@ -28411,10 +28464,63 @@ function proofNudgeLiveFetchFailureReason(error: unknown): string {
   return `live GitHub state could not be fetched: ${detail.slice(0, 300)}`;
 }
 
+function proofMutationEligibilityChanged(message: string): ProofMutationFreshnessBlock {
+  return {
+    reason: "eligibility_changed",
+    message: `proof mutation is no longer eligible before the request: ${message}`,
+  };
+}
+
+function proofNudgeRequestBoundaryBlock(
+  snapshot: ProofMutationRequestSnapshot,
+  options: {
+    markdown: string;
+    comments: readonly ProofNudgeComment[];
+    headCommittedAt?: string | undefined;
+    authorEditedAt?: string | undefined;
+    authorReviewActivityAt?: string | undefined;
+    minAgeDays: number;
+    cooldownDays: number;
+  },
+): ProofMutationFreshnessBlock | null {
+  if (snapshot.state !== "open") {
+    return proofMutationEligibilityChanged(`state is ${snapshot.state}`);
+  }
+  const eligibility = proofNudgeEligibility({
+    item: snapshot.item,
+    markdown: options.markdown,
+    comments: options.comments,
+    headSha: snapshot.headSha,
+    headCommittedAt: options.headCommittedAt,
+    authorEditedAt: options.authorEditedAt,
+    authorReviewActivityAt: options.authorReviewActivityAt,
+    minAgeDays: options.minAgeDays,
+    cooldownDays: options.cooldownDays,
+  });
+  return eligibility.eligible ? null : proofMutationEligibilityChanged(eligibility.reason);
+}
+
+function botProofRequestBoundaryBlock(
+  snapshot: ProofMutationRequestSnapshot,
+  markdown: string,
+): ProofMutationFreshnessBlock | null {
+  if (snapshot.state !== "open") {
+    return proofMutationEligibilityChanged(`state is ${snapshot.state}`);
+  }
+  const eligibility = botProofEligibility({
+    item: snapshot.item,
+    markdown,
+    headSha: snapshot.headSha,
+    draft: snapshot.draft,
+  });
+  return eligibility.eligible ? null : proofMutationEligibilityChanged(eligibility.reason);
+}
+
 function createProofMutationSession(options: {
   lane: ProofMutationLane;
   number: number;
   headSha: string;
+  validateRequest: (snapshot: ProofMutationRequestSnapshot) => ProofMutationFreshnessBlock | null;
 }): ProofMutationSession {
   const expectedFreshness = readProofMutationFreshnessSnapshot(options.number);
   if (expectedFreshness.headSha !== options.headSha.trim().toLowerCase()) {
@@ -28436,8 +28542,10 @@ function createProofMutationSession(options: {
     },
     expectedFreshness,
     refreshFreshness: () => readProofMutationFreshnessSnapshot(options.number),
+    validateRequest: options.validateRequest,
     nextAttemptByMutation: new Map(),
     latestEventIdByMutation: new Map(),
+    unknownMutationIdentities: new Set(),
     unknownMutationObserved: false,
   };
 }
@@ -28450,12 +28558,48 @@ function proofNudgeCommentMutationIdentity(options: {
   return `proof_nudge_comment:${options.number}:${options.headSha}:${options.timestamp}`;
 }
 
-function botProofLabelStateMutationIdentity(number: number, headSha: string): string {
-  return `bot_proof_label_state:${number}:${headSha}:needs_maintainer_proof_decision`;
-}
-
 function botProofCommentMutationIdentity(number: number, headSha: string, body: string): string {
   return `bot_proof_comment:${number}:${headSha}:${sha256(body)}`;
+}
+
+function satisfiedBotProofLabelMutationIdentities(
+  number: number,
+  labels: readonly string[],
+): string[] {
+  const target = prStatusLabelForKind("needs_maintainer_proof_decision").name;
+  const normalized = normalizedLabelSet(labels);
+  const identities: string[] = [];
+  if (normalized.has(normalizeLabelName(target))) {
+    identities.push(`label_create:${target}`, `issue_label_add:${number}:${target}`);
+  }
+  for (const label of PR_STATUS_LABELS) {
+    if (label.name !== target && !normalized.has(normalizeLabelName(label.name))) {
+      identities.push(`issue_label_remove:${number}:${label.name}`);
+    }
+  }
+  if (!normalized.has("stale")) {
+    identities.push(`issue_label_remove:${number}:stale`);
+  }
+  return identities;
+}
+
+export function satisfiedBotProofLabelMutationIdentitiesForTest(
+  number: number,
+  labels: readonly string[],
+): string[] {
+  return satisfiedBotProofLabelMutationIdentities(number, labels);
+}
+
+function reconcileSatisfiedBotProofLabelMutations(
+  session: ProofMutationSession,
+  number: number,
+  labels: readonly string[],
+): void {
+  for (const identity of satisfiedBotProofLabelMutationIdentities(number, labels)) {
+    const attempted = (session.nextAttemptByMutation.get(identity) ?? 0) > 0;
+    if (attempted && !session.unknownMutationIdentities.has(identity)) continue;
+    reconcileProofMutation(session, identity);
+  }
 }
 
 function botProofDecisionLabelsAreSynchronized(labels: readonly string[]): boolean {
@@ -28603,13 +28747,6 @@ function proofNudgesCommand(args: Args): void {
     try {
       pullDetails =
         item.kind === "pull_request" ? fetchPullRequestProofNudgeDetails(candidate.number) : {};
-      if (execute && pullDetails.headSha) {
-        mutationSession = createProofMutationSession({
-          lane: "proof_nudges",
-          number: candidate.number,
-          headSha: pullDetails.headSha,
-        });
-      }
       comments = item.kind === "pull_request" ? proofNudgeComments(candidate.number) : [];
       authorEditedAt =
         item.kind === "pull_request"
@@ -28619,6 +28756,23 @@ function proofNudgesCommand(args: Args): void {
         item.kind === "pull_request"
           ? latestAuthorPullRequestReviewActivityAt(candidate.number, item.author)
           : undefined;
+      if (execute && pullDetails.headSha) {
+        mutationSession = createProofMutationSession({
+          lane: "proof_nudges",
+          number: candidate.number,
+          headSha: pullDetails.headSha,
+          validateRequest: (snapshot) =>
+            proofNudgeRequestBoundaryBlock(snapshot, {
+              markdown: candidate.markdown,
+              comments,
+              headCommittedAt: pullDetails.headCommittedAt,
+              authorEditedAt,
+              authorReviewActivityAt,
+              minAgeDays,
+              cooldownDays,
+            }),
+        });
+      }
     } catch (error) {
       results.push({
         ...resultBase,
@@ -28627,6 +28781,25 @@ function proofNudgesCommand(args: Args): void {
       });
       markProcessed(candidate);
       continue;
+    }
+    const sameHeadNudgeAt = pullDetails.headSha
+      ? latestProofNudgeAt(comments, {
+          number: candidate.number,
+          headSha: pullDetails.headSha,
+        })
+      : undefined;
+    const reconciledPriorNudge = Boolean(
+      execute && mutationSession && pullDetails.headSha && sameHeadNudgeAt,
+    );
+    if (reconciledPriorNudge && mutationSession && pullDetails.headSha && sameHeadNudgeAt) {
+      reconcileProofMutation(
+        mutationSession,
+        proofNudgeCommentMutationIdentity({
+          number: candidate.number,
+          headSha: pullDetails.headSha,
+          timestamp: sameHeadNudgeAt,
+        }),
+      );
     }
     const eligibility = proofNudgeEligibility({
       item,
@@ -28641,20 +28814,11 @@ function proofNudgesCommand(args: Args): void {
     });
     if (!eligibility.eligible) {
       if (
-        execute &&
-        mutationSession &&
+        reconciledPriorNudge &&
         pullDetails.headSha &&
         eligibility.action === "skipped_recent_nudge" &&
         eligibility.latestNudgeAt
       ) {
-        reconcileProofMutation(
-          mutationSession,
-          proofNudgeCommentMutationIdentity({
-            number: candidate.number,
-            headSha: pullDetails.headSha,
-            timestamp: eligibility.latestNudgeAt,
-          }),
-        );
         results.push({
           ...resultBase,
           action: "proof_nudge_reconciled",
@@ -28718,7 +28882,12 @@ function proofNudgesCommand(args: Args): void {
           action: mutation.reconciled ? "proof_nudge_reconciled" : "proof_nudge_posted",
           reason: mutation.reconciled
             ? "same-head proof nudge marker already exists"
-            : eligibility.reason,
+            : [
+                reconciledPriorNudge ? "prior same-head proof nudge receipt reconciled" : null,
+                eligibility.reason,
+              ]
+                .filter(Boolean)
+                .join("; "),
           url: commentUrl(mutation.comment) ?? undefined,
           headSha,
         });
@@ -28878,6 +29047,7 @@ function botProofCommand(args: Args): void {
           lane: "bot_proof",
           number: candidate.number,
           headSha: pullDetails.headSha,
+          validateRequest: (snapshot) => botProofRequestBoundaryBlock(snapshot, candidate.markdown),
         });
       }
     } catch (error) {
@@ -28965,10 +29135,11 @@ function botProofCommand(args: Args): void {
           labels: item.labels,
           dryRun: false,
         });
-        if (!labelResult.changed) {
-          reconcileProofMutation(
+        if (botProofDecisionLabelsAreSynchronized(labelResult.labels)) {
+          reconcileSatisfiedBotProofLabelMutations(
             mutationSession,
-            botProofLabelStateMutationIdentity(candidate.number, headSha),
+            candidate.number,
+            labelResult.labels,
           );
         }
         const mutation = upsertBotProofDecisionComment(
@@ -29005,6 +29176,13 @@ function botProofCommand(args: Args): void {
             reconciledLabels =
               refreshed.state === "open" &&
               botProofDecisionLabelsAreSynchronized(refreshed.item.labels);
+            if (reconciledLabels) {
+              reconcileSatisfiedBotProofLabelMutations(
+                mutationSession,
+                candidate.number,
+                refreshed.item.labels,
+              );
+            }
           } catch {
             reconciledComment = undefined;
             reconciledLabels = false;
@@ -29014,10 +29192,6 @@ function botProofCommand(args: Args): void {
           reconcileProofMutation(
             mutationSession,
             botProofCommentMutationIdentity(candidate.number, headSha, renderedCommentBody),
-          );
-          reconcileProofMutation(
-            mutationSession,
-            botProofLabelStateMutationIdentity(candidate.number, headSha),
           );
           results.push({
             ...resultBase,
@@ -29042,6 +29216,14 @@ function botProofCommand(args: Args): void {
             ...resultBase,
             action: "bot_proof_mutation_outcome_unknown",
             reason: proofMutationUnknownReason(),
+            headSha,
+          });
+        } else if (error instanceof ProofMutationOutcomeUnknownError) {
+          results.push({
+            ...resultBase,
+            action: "skipped_live_fetch_failed",
+            reason:
+              "the uncertain proof mutation was reconciled, but proof decision publication remains incomplete",
             headSha,
           });
         } else {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -15091,7 +15091,7 @@ function proofNudgeCommentsWithLiveMarkers(
       )
       .map((marker) => marker.at),
   );
-  return comments.filter((comment) => {
+  const reconciledComments = comments.filter((comment) => {
     if (!isProofNudgeMarkerCommentAuthor(comment.author)) return true;
     const matchingMarkers = proofNudgeMarkersFromCommentBody(comment.body).filter(
       (marker) =>
@@ -15104,6 +15104,29 @@ function proofNudgeCommentsWithLiveMarkers(
       matchingMarkers.some((marker) => liveMarkerTimestamps.has(marker.at))
     );
   });
+  const reconciledMarkerTimestamps = new Set(
+    proofNudgeMarkersFromComments(reconciledComments)
+      .filter(
+        (marker) =>
+          marker.item === options.number &&
+          marker.sha === options.headSha &&
+          timestampMs(marker.at) !== null,
+      )
+      .map((marker) => marker.at),
+  );
+  for (const liveComment of liveComments) {
+    if (!isProofNudgeMarkerCommentAuthor(liveComment.author)) continue;
+    const matchingMarkers = proofNudgeMarkersFromCommentBody(liveComment.body).filter(
+      (marker) =>
+        marker.item === options.number &&
+        marker.sha === options.headSha &&
+        timestampMs(marker.at) !== null,
+    );
+    if (!matchingMarkers.some((marker) => !reconciledMarkerTimestamps.has(marker.at))) continue;
+    reconciledComments.push(liveComment);
+    for (const marker of matchingMarkers) reconciledMarkerTimestamps.add(marker.at);
+  }
+  return reconciledComments;
 }
 
 function staleProofNudgeReportHead(markdown: string, headSha: string | undefined): boolean {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -2770,6 +2770,30 @@ function runObservedApplyMutation<T>(options: {
   return result;
 }
 
+function refreshProofMutationSession(session: ProofMutationSession): ProofMutationRequestSnapshot {
+  let currentFreshness: ProofMutationRequestSnapshot;
+  try {
+    currentFreshness = session.refreshFreshness();
+  } catch (error) {
+    if (error instanceof ProofMutationFreshnessError) throw error;
+    throw new ProofMutationFreshnessError({
+      reason: "freshness_unavailable",
+      message: "proof mutation freshness could not be refreshed before the request",
+    });
+  }
+  const block =
+    proofMutationFreshnessBlock(session.expectedFreshness, currentFreshness) ??
+    (session.bindLabelState &&
+    currentFreshness.labelStateCursor !== session.expectedFreshness.labelStateCursor
+      ? proofMutationEligibilityChanged("live labels changed before the request")
+      : null) ??
+    session.validateRequest(currentFreshness);
+  if (block) {
+    throw new ProofMutationFreshnessError(block);
+  }
+  return currentFreshness;
+}
+
 function proofMutationRunner(session: ProofMutationSession): MutationRunner {
   return <T>(options: {
     identity: string;
@@ -2778,26 +2802,7 @@ function proofMutationRunner(session: ProofMutationSession): MutationRunner {
     didMutate?: ((result: T) => boolean) | undefined;
     knownNoMutation?: ((error: unknown) => boolean) | undefined;
   }): T => {
-    let currentFreshness: ProofMutationRequestSnapshot;
-    try {
-      currentFreshness = session.refreshFreshness();
-    } catch (error) {
-      if (error instanceof ProofMutationFreshnessError) throw error;
-      throw new ProofMutationFreshnessError({
-        reason: "freshness_unavailable",
-        message: "proof mutation freshness could not be refreshed before the request",
-      });
-    }
-    const block =
-      proofMutationFreshnessBlock(session.expectedFreshness, currentFreshness) ??
-      (session.bindLabelState &&
-      currentFreshness.labelStateCursor !== session.expectedFreshness.labelStateCursor
-        ? proofMutationEligibilityChanged("live labels changed before the request")
-        : null) ??
-      session.validateRequest(currentFreshness);
-    if (block) {
-      throw new ProofMutationFreshnessError(block);
-    }
+    const currentFreshness = refreshProofMutationSession(session);
     const requestAttempt =
       (session.nextAttemptByMutation.get(options.idempotencyIdentity) ?? 0) + 1;
     session.nextAttemptByMutation.set(options.idempotencyIdentity, requestAttempt);
@@ -14982,6 +14987,36 @@ function latestProofNudgeAt(
       )
       .map((marker) => marker.at),
   );
+}
+
+function proofNudgeCommentsWithLiveMarkers(
+  comments: readonly ProofNudgeComment[],
+  liveComments: readonly ProofNudgeComment[],
+  options: { number: number; headSha: string },
+): ProofNudgeComment[] {
+  const liveMarkerTimestamps = new Set(
+    proofNudgeMarkersFromComments(liveComments)
+      .filter(
+        (marker) =>
+          marker.item === options.number &&
+          marker.sha === options.headSha &&
+          timestampMs(marker.at) !== null,
+      )
+      .map((marker) => marker.at),
+  );
+  return comments.filter((comment) => {
+    if (!isProofNudgeMarkerCommentAuthor(comment.author)) return true;
+    const matchingMarkers = proofNudgeMarkersFromCommentBody(comment.body).filter(
+      (marker) =>
+        marker.item === options.number &&
+        marker.sha === options.headSha &&
+        timestampMs(marker.at) !== null,
+    );
+    return (
+      matchingMarkers.length === 0 ||
+      matchingMarkers.some((marker) => liveMarkerTimestamps.has(marker.at))
+    );
+  });
 }
 
 function staleProofNudgeReportHead(markdown: string, headSha: string | undefined): boolean {
@@ -28281,6 +28316,7 @@ function postProofNudgeComment(options: {
   const mutationIdentity = proofNudgeCommentMutationIdentity(options);
   const existing = ownedIssueCommentWithMarker(options.number, marker);
   if (existing) {
+    refreshProofMutationSession(options.session);
     reconcileProofMutation(options.session, mutationIdentity);
     return { comment: existing, reconciled: true };
   }
@@ -28334,6 +28370,7 @@ function upsertBotProofDecisionComment(
     );
   const mutationIdentity = botProofCommentMutationIdentity(number, headSha, body);
   if (existing && commentBody(existing)?.trim() === body.trim()) {
+    refreshProofMutationSession(session);
     reconcileProofMutation(session, mutationIdentity);
     return { comment: existing, reconciled: true };
   }
@@ -28900,8 +28937,10 @@ function proofNudgesCommand(args: Args): void {
       markProcessed(candidate);
       continue;
     }
+    const hydratedComments =
+      execute && mutationSession ? mutationSession.expectedFreshness.comments : comments;
     const sameHeadNudgeAt = pullDetails.headSha
-      ? latestProofNudgeAt(comments, {
+      ? latestProofNudgeAt(hydratedComments, {
           number: candidate.number,
           headSha: pullDetails.headSha,
         })
@@ -28919,10 +28958,17 @@ function proofNudgesCommand(args: Args): void {
         }),
       );
     }
+    const eligibilityComments =
+      execute && mutationSession && pullDetails.headSha
+        ? proofNudgeCommentsWithLiveMarkers(comments, hydratedComments, {
+            number: candidate.number,
+            headSha: pullDetails.headSha,
+          })
+        : comments;
     const eligibility = proofNudgeEligibility({
       item,
       markdown: candidate.markdown,
-      comments,
+      comments: eligibilityComments,
       headSha: pullDetails.headSha,
       headCommittedAt: pullDetails.headCommittedAt,
       authorEditedAt,

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -2710,6 +2710,7 @@ type ProofMutationSession = {
   bindLabelState: boolean;
   nextAttemptByMutation: Map<string, number>;
   latestEventIdByMutation: Map<string, string>;
+  knownNoMutationIdentities: Set<string>;
   unknownMutationIdentities: Set<string>;
   unknownMutationObserved: boolean;
 };
@@ -2825,16 +2826,20 @@ function proofMutationRunner(session: ProofMutationSession): MutationRunner {
       }
       return result;
     } catch (error) {
+      const knownNoMutation = options.knownNoMutation?.(error) === true;
       const rejected =
         isGitHubRequiresAuthenticationError(error) ||
         isLockedConversationCommentError(error) ||
-        options.knownNoMutation?.(error) === true;
+        knownNoMutation;
       const outcome = finishProofMutationReceipt({
         attempt,
         outcome: rejected ? "rejected" : "unknown",
       });
       if (outcome) {
         session.latestEventIdByMutation.set(options.idempotencyIdentity, outcome.event_id);
+      }
+      if (knownNoMutation) {
+        session.knownNoMutationIdentities.add(options.idempotencyIdentity);
       }
       if (!rejected) {
         session.unknownMutationIdentities.add(options.idempotencyIdentity);
@@ -2855,6 +2860,7 @@ function reconcileProofMutation(session: ProofMutationSession, mutationIdentity:
     phaseSeq: requestAttempt * 2 + 1,
   });
   session.unknownMutationIdentities.delete(mutationIdentity);
+  session.knownNoMutationIdentities.delete(mutationIdentity);
   session.unknownMutationObserved = session.unknownMutationIdentities.size > 0;
 }
 
@@ -28291,20 +28297,21 @@ function upsertBotProofDecisionComment(
   }
   const existing = comments
     .map(asRecord)
-    .find((comment) => typeof comment.body === "string" && comment.body.includes(marker));
+    .find(
+      (comment) =>
+        canPatchReviewComment(comment) &&
+        typeof comment.body === "string" &&
+        comment.body.includes(marker),
+    );
   const mutationIdentity = botProofCommentMutationIdentity(number, headSha, body);
-  if (
-    existing &&
-    canPatchReviewComment(existing) &&
-    commentBody(existing)?.trim() === body.trim()
-  ) {
+  if (existing && commentBody(existing)?.trim() === body.trim()) {
     reconcileProofMutation(session, mutationIdentity);
     return { comment: existing, reconciled: true };
   }
   const payload = writeCommentPayload(number, body);
   const existingId = commentId(existing);
   let args: string[];
-  if (existingId !== null && canPatchReviewComment(existing)) {
+  if (existingId !== null) {
     args = [
       "api",
       `repos/${targetRepo()}/issues/comments/${existingId}`,
@@ -28605,6 +28612,7 @@ function createProofMutationSession(options: {
     bindLabelState: options.bindLabelState === true,
     nextAttemptByMutation: new Map(),
     latestEventIdByMutation: new Map(),
+    knownNoMutationIdentities: new Set(),
     unknownMutationIdentities: new Set(),
     unknownMutationObserved: false,
   };
@@ -28654,12 +28662,18 @@ function reconcileSatisfiedBotProofLabelMutations(
   session: ProofMutationSession,
   number: number,
   labels: readonly string[],
-): void {
+): number {
+  let recoveredAttempts = 0;
   for (const identity of satisfiedBotProofLabelMutationIdentities(number, labels)) {
     const attempted = (session.nextAttemptByMutation.get(identity) ?? 0) > 0;
-    if (attempted && !session.unknownMutationIdentities.has(identity)) continue;
+    const recoverableAttempt =
+      session.unknownMutationIdentities.has(identity) ||
+      session.knownNoMutationIdentities.has(identity);
+    if (attempted && !recoverableAttempt) continue;
     reconcileProofMutation(session, identity);
+    if (attempted) recoveredAttempts += 1;
   }
+  return recoveredAttempts;
 }
 
 function botProofDecisionLabelsAreSynchronized(labels: readonly string[]): boolean {
@@ -28951,9 +28965,14 @@ function proofNudgesCommand(args: Args): void {
         });
       } catch (error) {
         const marker = proofNudgeMarker({ number: candidate.number, headSha, timestamp });
-        const reconciled = mutationSession.unknownMutationObserved
-          ? ownedIssueCommentWithMarker(candidate.number, marker)
-          : undefined;
+        let reconciled: Record<string, unknown> | undefined;
+        if (mutationSession.unknownMutationObserved) {
+          try {
+            reconciled = ownedIssueCommentWithMarker(candidate.number, marker);
+          } catch {
+            reconciled = undefined;
+          }
+        }
         if (reconciled) {
           reconcileProofMutation(
             mutationSession,
@@ -29194,13 +29213,13 @@ function botProofCommand(args: Args): void {
           labels: mutationSession.expectedFreshness.item.labels,
           dryRun: false,
         });
-        if (botProofDecisionLabelsAreSynchronized(labelResult.labels)) {
-          reconcileSatisfiedBotProofLabelMutations(
-            mutationSession,
-            candidate.number,
-            labelResult.labels,
-          );
-        }
+        const recoveredLabelAttempts = botProofDecisionLabelsAreSynchronized(labelResult.labels)
+          ? reconcileSatisfiedBotProofLabelMutations(
+              mutationSession,
+              candidate.number,
+              labelResult.labels,
+            )
+          : 0;
         const mutation = upsertBotProofDecisionComment(
           candidate.number,
           headSha,
@@ -29217,7 +29236,15 @@ function botProofCommand(args: Args): void {
               : "bot_proof_decision_posted",
           reason: reconciled
             ? "same-head proof decision comment and label state already exist"
-            : [eligibility.reason, labelResult.reason].filter(Boolean).join("; "),
+            : [
+                eligibility.reason,
+                labelResult.reason,
+                recoveredLabelAttempts > 0
+                  ? `reconciled ${recoveredLabelAttempts} completed label operation receipt(s)`
+                  : null,
+              ]
+                .filter(Boolean)
+                .join("; "),
           url: commentUrl(mutation.comment) ?? undefined,
           headSha,
         });

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -193,6 +193,18 @@ import {
   reviewedPrActivityThreadsPageFromGraphql,
 } from "./review-activity-cursor.js";
 import {
+  MAX_PROOF_CONVERSATION_ACTIVITY,
+  createProofConversationActivityCursor,
+  finishProofMutationReceipt,
+  proofMutationFreshnessBlock,
+  recordProofMutationReconciliation,
+  startProofMutationReceipt,
+  type ProofMutationFreshnessBlock,
+  type ProofMutationFreshnessSnapshot,
+  type ProofMutationLane,
+  type ProofMutationReceiptContext,
+} from "./proof-mutation-safety.js";
+import {
   ACTION_EVENT_REASON_CODES,
   ACTION_EVENT_STATUSES,
   ACTION_EVENT_TYPES,
@@ -1067,6 +1079,8 @@ interface FailedReviewRetryState {
 type ProofNudgeAction =
   | "proof_nudge_posted"
   | "proof_nudge_planned"
+  | "proof_nudge_reconciled"
+  | "proof_nudge_outcome_unknown"
   | "skipped_not_pull_request"
   | "skipped_not_open"
   | "skipped_policy_exempt"
@@ -1079,6 +1093,7 @@ type ProofNudgeAction =
   | "skipped_protected_label"
   | "skipped_locked_conversation"
   | "skipped_no_live_head"
+  | "skipped_changed_before_mutation"
   | "skipped_live_fetch_failed"
   | "skipped_runtime_budget";
 
@@ -1087,6 +1102,8 @@ type BotProofAction =
   | "bot_proof_mantis_request_planned"
   | "bot_proof_decision_posted"
   | "bot_proof_decision_planned"
+  | "bot_proof_decision_reconciled"
+  | "bot_proof_mutation_outcome_unknown"
   | "skipped_not_pull_request"
   | "skipped_not_open"
   | "skipped_not_bot_authored"
@@ -1095,6 +1112,7 @@ type BotProofAction =
   | "skipped_stale_report_head"
   | "skipped_no_live_head"
   | "skipped_locked_conversation"
+  | "skipped_changed_before_mutation"
   | "skipped_live_fetch_failed"
   | "skipped_runtime_budget";
 
@@ -1175,7 +1193,12 @@ interface ProofNudgeEligibility {
   eligible: boolean;
   action: Exclude<
     ProofNudgeAction,
-    "proof_nudge_posted" | "skipped_not_open" | "skipped_runtime_budget"
+    | "proof_nudge_posted"
+    | "skipped_not_open"
+    | "skipped_runtime_budget"
+    | "proof_nudge_reconciled"
+    | "proof_nudge_outcome_unknown"
+    | "skipped_changed_before_mutation"
   >;
   reason: string;
   latestActivityAt?: string | undefined;
@@ -1198,8 +1221,11 @@ interface BotProofEligibility {
     BotProofAction,
     | "bot_proof_mantis_request_posted"
     | "bot_proof_decision_posted"
+    | "bot_proof_decision_reconciled"
+    | "bot_proof_mutation_outcome_unknown"
     | "skipped_not_open"
     | "skipped_runtime_budget"
+    | "skipped_changed_before_mutation"
     | "skipped_live_fetch_failed"
   >;
   reason: string;
@@ -2655,8 +2681,37 @@ class ApplyMutationReviewGuardError extends Error {
   }
 }
 
+class ProofMutationFreshnessError extends Error {
+  readonly block: ProofMutationFreshnessBlock;
+
+  constructor(block: ProofMutationFreshnessBlock) {
+    super(block.message);
+    this.name = "ProofMutationFreshnessError";
+    this.block = block;
+  }
+}
+
+class ProofMutationOutcomeUnknownError extends Error {
+  readonly cause: unknown;
+
+  constructor(cause: unknown) {
+    super("proof mutation request outcome is unknown");
+    this.name = "ProofMutationOutcomeUnknownError";
+    this.cause = cause;
+  }
+}
+
+type ProofMutationSession = {
+  context: ProofMutationReceiptContext;
+  expectedFreshness: ProofMutationFreshnessSnapshot;
+  refreshFreshness: () => ProofMutationFreshnessSnapshot;
+  nextAttemptByMutation: Map<string, number>;
+  unknownMutationObserved: boolean;
+};
+
 let activeApplyMutationRunner: MutationRunner | null = null;
 let activeReviewMutationRunner: MutationRunner | null = null;
+let activeProofMutationRunner: MutationRunner | null = null;
 
 function mutationErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -2670,7 +2725,8 @@ function runObservedApplyMutation<T>(options: {
   didMutate?: ((result: T) => boolean) | undefined;
   knownNoMutation?: ((error: unknown) => boolean) | undefined;
 }): T {
-  const runner = activeApplyMutationRunner ?? activeReviewMutationRunner;
+  const runner =
+    activeApplyMutationRunner ?? activeReviewMutationRunner ?? activeProofMutationRunner;
   if (runner) {
     return runner({
       identity: options.identity,
@@ -2683,6 +2739,71 @@ function runObservedApplyMutation<T>(options: {
   const result = options.operation();
   if (options.didMutate?.(result) ?? true) options.onMutation?.();
   return result;
+}
+
+function proofMutationRunner(session: ProofMutationSession): MutationRunner {
+  return <T>(options: {
+    identity: string;
+    idempotencyIdentity: string;
+    operation: () => T;
+    didMutate?: ((result: T) => boolean) | undefined;
+    knownNoMutation?: ((error: unknown) => boolean) | undefined;
+  }): T => {
+    const requestAttempt =
+      (session.nextAttemptByMutation.get(options.idempotencyIdentity) ?? 0) + 1;
+    session.nextAttemptByMutation.set(options.idempotencyIdentity, requestAttempt);
+    const attempt = startProofMutationReceipt({
+      context: session.context,
+      receiptIdentity: options.identity,
+      mutationIdentity: options.idempotencyIdentity,
+      requestAttempt,
+    });
+    let currentFreshness: ProofMutationFreshnessSnapshot;
+    try {
+      currentFreshness = session.refreshFreshness();
+    } catch (error) {
+      finishProofMutationReceipt({ attempt, outcome: "rejected" });
+      if (error instanceof ProofMutationFreshnessError) throw error;
+      throw new ProofMutationFreshnessError({
+        reason: "freshness_unavailable",
+        message: "proof mutation freshness could not be refreshed before the request",
+      });
+    }
+    const block = proofMutationFreshnessBlock(session.expectedFreshness, currentFreshness);
+    if (block) {
+      finishProofMutationReceipt({ attempt, outcome: "rejected" });
+      throw new ProofMutationFreshnessError(block);
+    }
+    try {
+      const result = options.operation();
+      finishProofMutationReceipt({
+        attempt,
+        outcome: options.didMutate?.(result) === false ? "rejected" : "accepted",
+      });
+      return result;
+    } catch (error) {
+      const rejected =
+        isGitHubRequiresAuthenticationError(error) ||
+        isLockedConversationCommentError(error) ||
+        options.knownNoMutation?.(error) === true;
+      finishProofMutationReceipt({
+        attempt,
+        outcome: rejected ? "rejected" : "unknown",
+      });
+      if (!rejected) {
+        session.unknownMutationObserved = true;
+        throw new ProofMutationOutcomeUnknownError(error);
+      }
+      throw error;
+    }
+  };
+}
+
+function reconcileProofMutation(session: ProofMutationSession, mutationIdentity: string): void {
+  recordProofMutationReconciliation({
+    context: session.context,
+    mutationIdentity,
+  });
 }
 
 function ghObservedMutationCommand(options: {
@@ -6605,6 +6726,37 @@ function fetchReviewedPrActivityCursor(
     inlineComments.length === 0 ? [] : reviewedPrActivityThreads(number, remaining + 1);
   if (reviewThreads.length > remaining) return null;
   return createReviewedPrActivityCursor({ reviews, inlineComments, reviewThreads });
+}
+
+function fetchProofConversationActivityCursor(number: number): string | null {
+  const comments = ghPagedLimit<unknown>(
+    `repos/${targetRepo()}/issues/${number}/comments`,
+    MAX_PROOF_CONVERSATION_ACTIVITY + 1,
+  );
+  return createProofConversationActivityCursor(comments);
+}
+
+function readProofMutationFreshnessSnapshot(number: number): ProofMutationFreshnessSnapshot {
+  const readOnce = (): ProofMutationFreshnessSnapshot => {
+    const headSha = pullRequestHeadSha(number);
+    if (!headSha) throw new Error(`live PR head could not be read for #${number}`);
+    const reviewActivityCursor = fetchReviewedPrActivityCursor(number);
+    if (!reviewActivityCursor) {
+      throw new Error(`review activity exceeds the bounded proof mutation cursor for #${number}`);
+    }
+    const conversationActivityCursor = fetchProofConversationActivityCursor(number);
+    if (!conversationActivityCursor) {
+      throw new Error(
+        `conversation activity exceeds the bounded proof mutation cursor for #${number}`,
+      );
+    }
+    return { headSha, reviewActivityCursor, conversationActivityCursor };
+  };
+  const first = readOnce();
+  const second = readOnce();
+  const block = proofMutationFreshnessBlock(first, second);
+  if (block) throw new ProofMutationFreshnessError(block);
+  return second;
 }
 
 export interface ContextHydration<T> {
@@ -19352,6 +19504,27 @@ function issueCommentWithMarker(
   });
 }
 
+function ownedIssueCommentWithMarker(
+  number: number,
+  marker: string,
+): Record<string, unknown> | undefined {
+  const comments = ghPagedLimit<unknown>(
+    `repos/${targetRepo()}/issues/${number}/comments`,
+    MAX_PROOF_CONVERSATION_ACTIVITY + 1,
+  );
+  if (comments.length > MAX_PROOF_CONVERSATION_ACTIVITY) {
+    throw new Error(`conversation activity exceeds the bounded proof lane limit for #${number}`);
+  }
+  return comments
+    .map(asRecord)
+    .find(
+      (comment) =>
+        canPatchReviewComment(comment) &&
+        typeof comment.body === "string" &&
+        comment.body.includes(marker),
+    );
+}
+
 function closeAppliedEvidenceLink(markdown: string, itemUrl: string): string {
   const reviewCommentUrl = frontMatterValue(markdown, "review_comment_url");
   if (reviewCommentUrl && reviewCommentUrl !== "unknown") {
@@ -27885,7 +28058,14 @@ function orderedApplyItemNumbers(
 }
 
 function proofNudgeComments(number: number): ProofNudgeComment[] {
-  return ghPaged<unknown>(`repos/${targetRepo()}/issues/${number}/comments`).map((comment) => {
+  const comments = ghPagedLimit<unknown>(
+    `repos/${targetRepo()}/issues/${number}/comments`,
+    MAX_PROOF_CONVERSATION_ACTIVITY + 1,
+  );
+  if (comments.length > MAX_PROOF_CONVERSATION_ACTIVITY) {
+    throw new Error(`conversation activity exceeds the bounded proof lane limit for #${number}`);
+  }
+  return comments.map((comment) => {
     const record = asRecord(comment);
     return {
       author: login(record.user),
@@ -27931,33 +28111,82 @@ function fetchPullRequestProofNudgeDetails(number: number): ProofNudgePullReques
   return details;
 }
 
-function postProofNudgeComment(number: number, body: string): Record<string, unknown> {
-  const payload = writeCommentPayload(number, body);
-  return ghJson<Record<string, unknown>>([
+interface ProofCommentMutationResult {
+  comment: Record<string, unknown>;
+  reconciled: boolean;
+}
+
+function postProofNudgeComment(options: {
+  number: number;
+  headSha: string;
+  timestamp: string;
+  body: string;
+  session: ProofMutationSession;
+}): ProofCommentMutationResult {
+  const marker = proofNudgeMarker(options);
+  const mutationIdentity = proofNudgeCommentMutationIdentity(options);
+  const existing = ownedIssueCommentWithMarker(options.number, marker);
+  if (existing) {
+    reconcileProofMutation(options.session, mutationIdentity);
+    return { comment: existing, reconciled: true };
+  }
+  const payload = writeCommentPayload(options.number, options.body);
+  const args = [
     "api",
-    `repos/${targetRepo()}/issues/${number}/comments`,
+    `repos/${targetRepo()}/issues/${options.number}/comments`,
     "--method",
     "POST",
     "--input",
     payload,
     "--jq",
     "{id,html_url}",
-  ]);
+  ];
+  const response = ghObservedMutationCommand({
+    identity: mutationIdentity,
+    args,
+    knownNoMutation: (error) =>
+      isGitHubRequiresAuthenticationError(error) || isLockedConversationCommentError(error),
+  });
+  const written = reviewCommentFromMutationResponse(response, args);
+  if (written) return { comment: written, reconciled: false };
+  const fallback = ownedIssueCommentWithMarker(options.number, marker);
+  if (fallback) return { comment: fallback, reconciled: false };
+  throw new Error(
+    `GitHub proof nudge mutation for #${options.number} did not return or expose the posted comment`,
+  );
 }
 
 function upsertBotProofDecisionComment(
   number: number,
   headSha: string,
   body: string,
-): Record<string, unknown> {
+  session: ProofMutationSession,
+): ProofCommentMutationResult {
   const marker = botProofDecisionMarker({ number, headSha });
-  const existing = ghPaged<unknown>(`repos/${targetRepo()}/issues/${number}/comments?per_page=100`)
+  const comments = ghPagedLimit<unknown>(
+    `repos/${targetRepo()}/issues/${number}/comments`,
+    MAX_PROOF_CONVERSATION_ACTIVITY + 1,
+  );
+  if (comments.length > MAX_PROOF_CONVERSATION_ACTIVITY) {
+    throw new Error(`conversation activity exceeds the bounded proof lane limit for #${number}`);
+  }
+  const existing = comments
     .map(asRecord)
     .find((comment) => typeof comment.body === "string" && comment.body.includes(marker));
+  const mutationIdentity = botProofCommentMutationIdentity(number, headSha, body);
+  if (
+    existing &&
+    canPatchReviewComment(existing) &&
+    commentBody(existing)?.trim() === body.trim()
+  ) {
+    reconcileProofMutation(session, mutationIdentity);
+    return { comment: existing, reconciled: true };
+  }
   const payload = writeCommentPayload(number, body);
   const existingId = commentId(existing);
+  let args: string[];
   if (existingId !== null && canPatchReviewComment(existing)) {
-    return ghJson<Record<string, unknown>>([
+    args = [
       "api",
       `repos/${targetRepo()}/issues/comments/${existingId}`,
       "--method",
@@ -27966,18 +28195,32 @@ function upsertBotProofDecisionComment(
       payload,
       "--jq",
       "{id,html_url}",
-    ]);
+    ];
+  } else {
+    args = [
+      "api",
+      `repos/${targetRepo()}/issues/${number}/comments`,
+      "--method",
+      "POST",
+      "--input",
+      payload,
+      "--jq",
+      "{id,html_url}",
+    ];
   }
-  return ghJson<Record<string, unknown>>([
-    "api",
-    `repos/${targetRepo()}/issues/${number}/comments`,
-    "--method",
-    "POST",
-    "--input",
-    payload,
-    "--jq",
-    "{id,html_url}",
-  ]);
+  const response = ghObservedMutationCommand({
+    identity: mutationIdentity,
+    args,
+    knownNoMutation: (error) =>
+      isGitHubRequiresAuthenticationError(error) || isLockedConversationCommentError(error),
+  });
+  const written = reviewCommentFromMutationResponse(response, args);
+  if (written) return { comment: written, reconciled: false };
+  const fallback = ownedIssueCommentWithMarker(number, marker);
+  if (fallback) return { comment: fallback, reconciled: false };
+  throw new Error(
+    `GitHub bot proof mutation for #${number} did not return or expose the synced comment`,
+  );
 }
 
 function syncBotProofDecisionLabels(options: {
@@ -27995,7 +28238,7 @@ function syncBotProofDecisionLabels(options: {
   const nextLabels = statusResult.labels.filter((label) => normalizeLabelName(label) !== "stale");
   if (!options.dryRun) {
     for (const label of staleLabels) {
-      ghWithRetry(["issue", "edit", String(options.number), "--remove-label", label]);
+      removeIssueLabel(options.number, label);
     }
   }
   const changed = statusResult.changed || staleLabels.length > 0;
@@ -28158,6 +28401,69 @@ function proofNudgeLiveFetchFailureReason(error: unknown): string {
   return `live GitHub state could not be fetched: ${detail.slice(0, 300)}`;
 }
 
+function createProofMutationSession(options: {
+  lane: ProofMutationLane;
+  number: number;
+  headSha: string;
+}): ProofMutationSession {
+  const expectedFreshness = readProofMutationFreshnessSnapshot(options.number);
+  if (expectedFreshness.headSha !== options.headSha.trim().toLowerCase()) {
+    throw new ProofMutationFreshnessError({
+      reason: "head_changed",
+      message: "live PR head changed while preparing the proof mutation",
+    });
+  }
+  return {
+    context: {
+      root: ROOT,
+      lane: options.lane,
+      repository: targetRepo(),
+      number: options.number,
+      headSha: expectedFreshness.headSha,
+      component: options.lane,
+      evidence: workflowRunEvidence(),
+      privacy: actionLedgerPrivacy(),
+    },
+    expectedFreshness,
+    refreshFreshness: () => readProofMutationFreshnessSnapshot(options.number),
+    nextAttemptByMutation: new Map(),
+    unknownMutationObserved: false,
+  };
+}
+
+function proofNudgeCommentMutationIdentity(options: {
+  number: number;
+  headSha: string;
+  timestamp: string;
+}): string {
+  return `proof_nudge_comment:${options.number}:${options.headSha}:${options.timestamp}`;
+}
+
+function botProofLabelStateMutationIdentity(number: number, headSha: string): string {
+  return `bot_proof_label_state:${number}:${headSha}:needs_maintainer_proof_decision`;
+}
+
+function botProofCommentMutationIdentity(number: number, headSha: string, body: string): string {
+  return `bot_proof_comment:${number}:${headSha}:${sha256(body)}`;
+}
+
+function botProofDecisionLabelsAreSynchronized(labels: readonly string[]): boolean {
+  const expected = syncBotProofDecisionLabels({
+    number: 1,
+    labels,
+    dryRun: true,
+  }).labels;
+  const current = [...labels].map(normalizeLabelName).sort();
+  const desired = [...expected].map(normalizeLabelName).sort();
+  return (
+    current.length === desired.length && current.every((label, index) => label === desired[index])
+  );
+}
+
+function proofMutationUnknownReason(): string {
+  return "GitHub may have accepted the proof mutation, but the response was not conclusive; same-head marker reconciliation is required before retry";
+}
+
 export function proofNudgeCandidateRecordsForTest(
   itemsDir: string,
   requestedItemNumbers: readonly number[] = [],
@@ -28282,9 +28588,17 @@ function proofNudgesCommand(args: Args): void {
     let comments: ProofNudgeComment[] = [];
     let authorEditedAt: string | undefined;
     let authorReviewActivityAt: string | undefined;
+    let mutationSession: ProofMutationSession | null = null;
     try {
       pullDetails =
         item.kind === "pull_request" ? fetchPullRequestProofNudgeDetails(candidate.number) : {};
+      if (execute && pullDetails.headSha) {
+        mutationSession = createProofMutationSession({
+          lane: "proof_nudges",
+          number: candidate.number,
+          headSha: pullDetails.headSha,
+        });
+      }
       comments = item.kind === "pull_request" ? proofNudgeComments(candidate.number) : [];
       authorEditedAt =
         item.kind === "pull_request"
@@ -28315,12 +28629,35 @@ function proofNudgesCommand(args: Args): void {
       cooldownDays,
     });
     if (!eligibility.eligible) {
-      results.push({
-        ...resultBase,
-        action: eligibility.action,
-        reason: eligibility.reason,
-        headSha: pullDetails.headSha,
-      });
+      if (
+        execute &&
+        mutationSession &&
+        pullDetails.headSha &&
+        eligibility.action === "skipped_recent_nudge" &&
+        eligibility.latestNudgeAt
+      ) {
+        reconcileProofMutation(
+          mutationSession,
+          proofNudgeCommentMutationIdentity({
+            number: candidate.number,
+            headSha: pullDetails.headSha,
+            timestamp: eligibility.latestNudgeAt,
+          }),
+        );
+        results.push({
+          ...resultBase,
+          action: "proof_nudge_reconciled",
+          reason: "same-head proof nudge marker already exists",
+          headSha: pullDetails.headSha,
+        });
+      } else {
+        results.push({
+          ...resultBase,
+          action: eligibility.action,
+          reason: eligibility.reason,
+          headSha: pullDetails.headSha,
+        });
+      }
       markProcessed(candidate);
       continue;
     }
@@ -28345,18 +28682,96 @@ function proofNudgesCommand(args: Args): void {
         headSha,
       });
     } else {
-      const comment = postProofNudgeComment(candidate.number, body);
-      results.push({
-        ...resultBase,
-        action: "proof_nudge_posted",
-        reason: eligibility.reason,
-        url: commentUrl(comment) ?? undefined,
-        headSha,
-      });
+      if (!mutationSession) {
+        results.push({
+          ...resultBase,
+          action: "skipped_live_fetch_failed",
+          reason: "live proof mutation freshness could not be established",
+          headSha,
+        });
+        markProcessed(candidate);
+        continue;
+      }
+      const previousProofMutationRunner = activeProofMutationRunner;
+      activeProofMutationRunner = proofMutationRunner(mutationSession);
+      try {
+        const mutation = postProofNudgeComment({
+          number: candidate.number,
+          headSha,
+          timestamp,
+          body,
+          session: mutationSession,
+        });
+        results.push({
+          ...resultBase,
+          action: mutation.reconciled ? "proof_nudge_reconciled" : "proof_nudge_posted",
+          reason: mutation.reconciled
+            ? "same-head proof nudge marker already exists"
+            : eligibility.reason,
+          url: commentUrl(mutation.comment) ?? undefined,
+          headSha,
+        });
+      } catch (error) {
+        const marker = proofNudgeMarker({ number: candidate.number, headSha, timestamp });
+        const reconciled = mutationSession.unknownMutationObserved
+          ? ownedIssueCommentWithMarker(candidate.number, marker)
+          : undefined;
+        if (reconciled) {
+          reconcileProofMutation(
+            mutationSession,
+            proofNudgeCommentMutationIdentity({
+              number: candidate.number,
+              headSha,
+              timestamp,
+            }),
+          );
+          results.push({
+            ...resultBase,
+            action: "proof_nudge_reconciled",
+            reason: "same-head proof nudge marker confirmed after an inconclusive response",
+            url: commentUrl(reconciled) ?? undefined,
+            headSha,
+          });
+        } else if (error instanceof ProofMutationFreshnessError) {
+          results.push({
+            ...resultBase,
+            action:
+              error.block.reason === "freshness_unavailable"
+                ? "skipped_live_fetch_failed"
+                : "skipped_changed_before_mutation",
+            reason: error.block.message,
+            headSha,
+          });
+        } else if (mutationSession.unknownMutationObserved) {
+          results.push({
+            ...resultBase,
+            action: "proof_nudge_outcome_unknown",
+            reason: proofMutationUnknownReason(),
+            headSha,
+          });
+        } else {
+          results.push({
+            ...resultBase,
+            action: "skipped_live_fetch_failed",
+            reason: proofNudgeLiveFetchFailureReason(error),
+            headSha,
+          });
+        }
+      } finally {
+        activeProofMutationRunner = previousProofMutationRunner;
+      }
     }
     markProcessed(candidate);
-    nudgeCount += 1;
-    logProgress(`${dryRun ? "planned" : "posted"} proof nudge #${candidate.number}`);
+    const finalAction = results.at(-1)?.action;
+    if (
+      finalAction === "proof_nudge_planned" ||
+      finalAction === "proof_nudge_posted" ||
+      finalAction === "proof_nudge_reconciled" ||
+      finalAction === "proof_nudge_outcome_unknown"
+    ) {
+      nudgeCount += 1;
+    }
+    logProgress(`${finalAction ?? "processed"} proof nudge #${candidate.number}`);
   }
   if (!dryRun && cursorPath && lastProcessedCandidate) {
     writeProofLaneCursor(cursorPath, "proof_nudges", lastProcessedCandidate);
@@ -28440,12 +28855,20 @@ function botProofCommand(args: Args): void {
     let item: Item;
     let state: string;
     let pullDetails: Partial<ProofNudgePullRequestDetails> = {};
+    let mutationSession: ProofMutationSession | null = null;
     try {
       const fetched = fetchItem(candidate.number);
       item = fetched.item;
       state = fetched.state;
       pullDetails =
         item.kind === "pull_request" ? fetchPullRequestProofNudgeDetails(candidate.number) : {};
+      if (execute && pullDetails.headSha) {
+        mutationSession = createProofMutationSession({
+          lane: "bot_proof",
+          number: candidate.number,
+          headSha: pullDetails.headSha,
+        });
+      }
     } catch (error) {
       results.push({
         ...resultBase,
@@ -28490,19 +28913,22 @@ function botProofCommand(args: Args): void {
       markProcessed(candidate);
       continue;
     }
-    const commentBody = renderBotProofDecisionComment({
+    const renderedCommentBody = renderBotProofDecisionComment({
       item,
       headSha,
       markdown: candidate.markdown,
-      timestamp: new Date().toISOString(),
+      timestamp:
+        candidate.reviewedAt ??
+        frontMatterValue(candidate.markdown, "item_updated_at") ??
+        "unknown",
       mantisRecommendation: eligibility.mantisRecommendation,
     });
-    const labelResult = syncBotProofDecisionLabels({
-      number: candidate.number,
-      labels: item.labels,
-      dryRun,
-    });
     if (dryRun) {
+      const labelResult = syncBotProofDecisionLabels({
+        number: candidate.number,
+        labels: item.labels,
+        dryRun: true,
+      });
       results.push({
         ...resultBase,
         action: eligibility.action,
@@ -28510,21 +28936,128 @@ function botProofCommand(args: Args): void {
         headSha,
       });
     } else {
-      const comment = upsertBotProofDecisionComment(candidate.number, headSha, commentBody);
-      results.push({
-        ...resultBase,
-        action:
-          eligibility.action === "bot_proof_mantis_request_planned"
-            ? "bot_proof_mantis_request_posted"
-            : "bot_proof_decision_posted",
-        reason: [eligibility.reason, labelResult.reason].filter(Boolean).join("; "),
-        url: commentUrl(comment) ?? undefined,
-        headSha,
-      });
+      if (!mutationSession) {
+        results.push({
+          ...resultBase,
+          action: "skipped_live_fetch_failed",
+          reason: "live proof mutation freshness could not be established",
+          headSha,
+        });
+        markProcessed(candidate);
+        continue;
+      }
+      const previousProofMutationRunner = activeProofMutationRunner;
+      activeProofMutationRunner = proofMutationRunner(mutationSession);
+      try {
+        const labelResult = syncBotProofDecisionLabels({
+          number: candidate.number,
+          labels: item.labels,
+          dryRun: false,
+        });
+        if (!labelResult.changed) {
+          reconcileProofMutation(
+            mutationSession,
+            botProofLabelStateMutationIdentity(candidate.number, headSha),
+          );
+        }
+        const mutation = upsertBotProofDecisionComment(
+          candidate.number,
+          headSha,
+          renderedCommentBody,
+          mutationSession,
+        );
+        const reconciled = mutation.reconciled && !labelResult.changed;
+        results.push({
+          ...resultBase,
+          action: reconciled
+            ? "bot_proof_decision_reconciled"
+            : eligibility.action === "bot_proof_mantis_request_planned"
+              ? "bot_proof_mantis_request_posted"
+              : "bot_proof_decision_posted",
+          reason: reconciled
+            ? "same-head proof decision comment and label state already exist"
+            : [eligibility.reason, labelResult.reason].filter(Boolean).join("; "),
+          url: commentUrl(mutation.comment) ?? undefined,
+          headSha,
+        });
+      } catch (error) {
+        let reconciledComment: Record<string, unknown> | undefined;
+        let reconciledLabels = false;
+        if (mutationSession.unknownMutationObserved) {
+          try {
+            const marker = botProofDecisionMarker({ number: candidate.number, headSha });
+            const existing = ownedIssueCommentWithMarker(candidate.number, marker);
+            if (existing && commentBody(existing)?.trim() === renderedCommentBody.trim()) {
+              reconciledComment = existing;
+            }
+            const refreshed = fetchItem(candidate.number);
+            reconciledLabels =
+              refreshed.state === "open" &&
+              botProofDecisionLabelsAreSynchronized(refreshed.item.labels);
+          } catch {
+            reconciledComment = undefined;
+            reconciledLabels = false;
+          }
+        }
+        if (reconciledComment && reconciledLabels) {
+          reconcileProofMutation(
+            mutationSession,
+            botProofCommentMutationIdentity(candidate.number, headSha, renderedCommentBody),
+          );
+          reconcileProofMutation(
+            mutationSession,
+            botProofLabelStateMutationIdentity(candidate.number, headSha),
+          );
+          results.push({
+            ...resultBase,
+            action: "bot_proof_decision_reconciled",
+            reason:
+              "same-head proof decision comment and label state were confirmed after an inconclusive response",
+            url: commentUrl(reconciledComment) ?? undefined,
+            headSha,
+          });
+        } else if (error instanceof ProofMutationFreshnessError) {
+          results.push({
+            ...resultBase,
+            action:
+              error.block.reason === "freshness_unavailable"
+                ? "skipped_live_fetch_failed"
+                : "skipped_changed_before_mutation",
+            reason: error.block.message,
+            headSha,
+          });
+        } else if (mutationSession.unknownMutationObserved) {
+          results.push({
+            ...resultBase,
+            action: "bot_proof_mutation_outcome_unknown",
+            reason: proofMutationUnknownReason(),
+            headSha,
+          });
+        } else {
+          results.push({
+            ...resultBase,
+            action: "skipped_live_fetch_failed",
+            reason: proofNudgeLiveFetchFailureReason(error),
+            headSha,
+          });
+        }
+      } finally {
+        activeProofMutationRunner = previousProofMutationRunner;
+      }
     }
     markProcessed(candidate);
-    actionCount += 1;
-    logProgress(`${dryRun ? "planned" : "posted"} bot proof handling #${candidate.number}`);
+    const finalAction = results.at(-1)?.action;
+    if (
+      finalAction === "bot_proof_mantis_request_planned" ||
+      finalAction === "bot_proof_mantis_request_posted" ||
+      finalAction === "bot_proof_decision_planned" ||
+      finalAction === "bot_proof_decision_posted" ||
+      finalAction === "bot_proof_decision_reconciled" ||
+      finalAction === "bot_proof_mutation_outcome_unknown"
+    ) {
+      actionCount += 1;
+    }
+    logProgress(`${finalAction ?? "processed"} bot proof handling #${candidate.number}`);
   }
   if (!dryRun && cursorPath && lastProcessedCandidate) {
     writeProofLaneCursor(cursorPath, "bot_proof", lastProcessedCandidate);

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -1105,6 +1105,7 @@ type BotProofAction =
   | "bot_proof_decision_posted"
   | "bot_proof_decision_planned"
   | "bot_proof_decision_reconciled"
+  | "bot_proof_reconciliation_pending"
   | "bot_proof_mutation_outcome_unknown"
   | "skipped_not_pull_request"
   | "skipped_not_open"
@@ -1135,6 +1136,15 @@ interface ProofNudgeMutationCycle {
   number: number;
   head_sha: string;
   marker_timestamp: string;
+  created_at: string;
+}
+
+interface BotProofCommentMutationCycle {
+  schema_version: 1;
+  repository: string;
+  number: number;
+  head_sha: string;
+  comment_body_sha256: string;
   created_at: string;
 }
 
@@ -1235,6 +1245,7 @@ interface BotProofEligibility {
     | "bot_proof_mantis_request_posted"
     | "bot_proof_decision_posted"
     | "bot_proof_decision_reconciled"
+    | "bot_proof_reconciliation_pending"
     | "bot_proof_mutation_outcome_unknown"
     | "skipped_not_open"
     | "skipped_runtime_budget"
@@ -28591,7 +28602,21 @@ function proofNudgeMutationStateDir(args: Args, reportPath: string): string {
   );
 }
 
+function botProofMutationStateDir(args: Args, reportPath: string): string {
+  const targetSlug = targetRepo().replace("/", "-");
+  return resolve(
+    stringArg(
+      args.mutation_state_dir,
+      join(dirname(reportPath), "bot-proof-mutations", targetSlug),
+    ),
+  );
+}
+
 function proofNudgeMutationCyclePath(stateDir: string, number: number): string {
+  return join(stateDir, `${number}.json`);
+}
+
+function botProofCommentMutationCyclePath(stateDir: string, number: number): string {
   return join(stateDir, `${number}.json`);
 }
 
@@ -28641,6 +28666,61 @@ function writeProofNudgeMutationCycle(path: string, cycle: ProofNudgeMutationCyc
 }
 
 function clearProofNudgeMutationCycle(path: string): void {
+  if (existsSync(path)) unlinkSync(path);
+}
+
+function readBotProofCommentMutationCycle(
+  path: string,
+  number: number,
+): BotProofCommentMutationCycle | null {
+  if (!existsSync(path)) return null;
+  const parsed = asRecord(
+    JSON.parse(readBoundedUtf8File(path, 4_096, "bot proof comment mutation cycle")),
+  );
+  const headSha = stringOrUndefined(parsed.head_sha)?.trim().toLowerCase();
+  const commentBodySha256 = stringOrUndefined(parsed.comment_body_sha256)?.trim().toLowerCase();
+  const createdAt = stringOrUndefined(parsed.created_at);
+  if (
+    parsed.schema_version !== 1 ||
+    parsed.repository !== targetRepo() ||
+    parsed.number !== number ||
+    !headSha ||
+    !/^[0-9a-f]{40}$/.test(headSha) ||
+    !commentBodySha256 ||
+    !/^[0-9a-f]{64}$/.test(commentBodySha256) ||
+    !createdAt ||
+    timestampMs(createdAt) === null
+  ) {
+    throw new Error(`invalid bot proof comment mutation cycle for #${number}`);
+  }
+  return {
+    schema_version: 1,
+    repository: targetRepo(),
+    number,
+    head_sha: headSha,
+    comment_body_sha256: commentBodySha256,
+    created_at: createdAt,
+  };
+}
+
+function writeBotProofCommentMutationCycle(
+  path: string,
+  cycle: BotProofCommentMutationCycle,
+): void {
+  ensureDir(dirname(path));
+  const temporaryPath = join(
+    dirname(path),
+    `.${basename(path)}.${process.pid}.${randomUUID()}.tmp`,
+  );
+  try {
+    writeFileSync(temporaryPath, `${JSON.stringify(cycle, null, 2)}\n`, "utf8");
+    renameSync(temporaryPath, path);
+  } finally {
+    if (existsSync(temporaryPath)) unlinkSync(temporaryPath);
+  }
+}
+
+function clearBotProofCommentMutationCycle(path: string): void {
   if (existsSync(path)) unlinkSync(path);
 }
 
@@ -28852,6 +28932,37 @@ function proofNudgeCommentMutationIdentity(options: {
 
 function botProofCommentMutationIdentity(number: number, headSha: string, body: string): string {
   return `bot_proof_comment:${number}:${headSha}:${sha256(body)}`;
+}
+
+function botProofCommentMutationIdentityFromCycle(cycle: BotProofCommentMutationCycle): string {
+  return `bot_proof_comment:${cycle.number}:${cycle.head_sha}:${cycle.comment_body_sha256}`;
+}
+
+function ownedBotProofCommentMatchingCycle(
+  cycle: BotProofCommentMutationCycle,
+): Record<string, unknown> | undefined {
+  const marker = botProofDecisionMarker({
+    number: cycle.number,
+    headSha: cycle.head_sha,
+  });
+  const comments = ghPagedLimit<unknown>(
+    `repos/${targetRepo()}/issues/${cycle.number}/comments`,
+    MAX_PROOF_CONVERSATION_ACTIVITY + 1,
+  );
+  if (comments.length > MAX_PROOF_CONVERSATION_ACTIVITY) {
+    throw new Error(
+      `conversation activity exceeds the bounded proof lane limit for #${cycle.number}`,
+    );
+  }
+  return comments.map(asRecord).find((comment) => {
+    const body = commentBody(comment);
+    return (
+      canPatchReviewComment(comment) &&
+      typeof body === "string" &&
+      body.includes(marker) &&
+      sha256(body) === cycle.comment_body_sha256
+    );
+  });
 }
 
 function satisfiedBotProofLabelMutationIdentities(
@@ -29360,6 +29471,7 @@ function botProofCommand(args: Args): void {
   const dryRun = !execute;
   const maxRuntimeMs = numberArg(args.max_runtime_ms, 0);
   const reportPath = resolve(stringArg(args.report_path, join(ROOT, "bot-proof-report.json")));
+  const mutationStateDir = botProofMutationStateDir(args, reportPath);
   const requestedItemNumbers = itemNumbersArg(args.item_numbers, args.item_number);
   const cursorPath = proofLaneCursorPath(args, requestedItemNumbers);
 
@@ -29425,6 +29537,8 @@ function botProofCommand(args: Args): void {
     let state: string;
     let pullDetails: Partial<ProofNudgePullRequestDetails> = {};
     let mutationSession: ProofMutationSession | null = null;
+    let pendingCommentMutation: BotProofCommentMutationCycle | null = null;
+    const mutationCyclePath = botProofCommentMutationCyclePath(mutationStateDir, candidate.number);
     try {
       const fetched = fetchItem(candidate.number);
       item = fetched.item;
@@ -29439,6 +29553,17 @@ function botProofCommand(args: Args): void {
           bindLabelState: true,
           validateRequest: (snapshot) => botProofRequestBoundaryBlock(snapshot, candidate.markdown),
         });
+        pendingCommentMutation = readBotProofCommentMutationCycle(
+          mutationCyclePath,
+          candidate.number,
+        );
+        if (
+          pendingCommentMutation &&
+          pendingCommentMutation.head_sha !== pullDetails.headSha.trim().toLowerCase()
+        ) {
+          clearBotProofCommentMutationCycle(mutationCyclePath);
+          pendingCommentMutation = null;
+        }
       }
     } catch (error) {
       results.push({
@@ -29494,6 +29619,42 @@ function botProofCommand(args: Args): void {
         "unknown",
       mantisRecommendation: eligibility.mantisRecommendation,
     });
+    if (execute && mutationSession && pendingCommentMutation) {
+      let reconciledComment: Record<string, unknown> | undefined;
+      try {
+        reconciledComment = ownedBotProofCommentMatchingCycle(pendingCommentMutation);
+      } catch {
+        reconciledComment = undefined;
+      }
+      if (!reconciledComment) {
+        recordProofMutationPendingReconciliation({
+          context: mutationSession.context,
+          mutationIdentity: botProofCommentMutationIdentityFromCycle(pendingCommentMutation),
+        });
+        results.push({
+          ...resultBase,
+          action: "bot_proof_reconciliation_pending",
+          reason:
+            "a prior same-head bot proof comment outcome is still unknown; waiting for its exact body before any retry",
+          headSha,
+        });
+        markProcessed(candidate);
+        logProgress(`bot_proof_reconciliation_pending bot proof handling #${candidate.number}`);
+        continue;
+      }
+      const pendingMutationIdentity =
+        botProofCommentMutationIdentityFromCycle(pendingCommentMutation);
+      const desiredMutationIdentity = botProofCommentMutationIdentity(
+        candidate.number,
+        headSha,
+        renderedCommentBody,
+      );
+      if (pendingMutationIdentity !== desiredMutationIdentity) {
+        reconcileProofMutation(mutationSession, pendingMutationIdentity);
+        clearBotProofCommentMutationCycle(mutationCyclePath);
+        pendingCommentMutation = null;
+      }
+    }
     if (dryRun) {
       const labelResult = syncBotProofDecisionLabels({
         number: candidate.number,
@@ -29518,7 +29679,22 @@ function botProofCommand(args: Args): void {
         continue;
       }
       const previousProofMutationRunner = activeProofMutationRunner;
-      activeProofMutationRunner = proofMutationRunner(mutationSession);
+      const commentMutationIdentity = botProofCommentMutationIdentity(
+        candidate.number,
+        headSha,
+        renderedCommentBody,
+      );
+      activeProofMutationRunner = proofMutationRunner(mutationSession, (mutationIdentity) => {
+        if (mutationIdentity !== commentMutationIdentity) return;
+        writeBotProofCommentMutationCycle(mutationCyclePath, {
+          schema_version: 1,
+          repository: targetRepo(),
+          number: candidate.number,
+          head_sha: headSha.trim().toLowerCase(),
+          comment_body_sha256: sha256(renderedCommentBody),
+          created_at: new Date().toISOString(),
+        });
+      });
       try {
         const labelResult = syncBotProofDecisionLabels({
           number: candidate.number,
@@ -29539,6 +29715,7 @@ function botProofCommand(args: Args): void {
           mutationSession,
         );
         const reconciled = mutation.reconciled && !labelResult.changed;
+        clearBotProofCommentMutationCycle(mutationCyclePath);
         results.push({
           ...resultBase,
           action: reconciled
@@ -29591,6 +29768,7 @@ function botProofCommand(args: Args): void {
             mutationSession,
             botProofCommentMutationIdentity(candidate.number, headSha, renderedCommentBody),
           );
+          clearBotProofCommentMutationCycle(mutationCyclePath);
           results.push({
             ...resultBase,
             action: "bot_proof_decision_reconciled",
@@ -29600,6 +29778,7 @@ function botProofCommand(args: Args): void {
             headSha,
           });
         } else if (error instanceof ProofMutationFreshnessError) {
+          clearBotProofCommentMutationCycle(mutationCyclePath);
           results.push({
             ...resultBase,
             action:
@@ -29617,6 +29796,7 @@ function botProofCommand(args: Args): void {
             headSha,
           });
         } else if (error instanceof ProofMutationOutcomeUnknownError) {
+          clearBotProofCommentMutationCycle(mutationCyclePath);
           results.push({
             ...resultBase,
             action: "skipped_live_fetch_failed",
@@ -29625,6 +29805,7 @@ function botProofCommand(args: Args): void {
             headSha,
           });
         } else {
+          clearBotProofCommentMutationCycle(mutationCyclePath);
           results.push({
             ...resultBase,
             action: "skipped_live_fetch_failed",

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -2806,7 +2806,10 @@ function refreshProofMutationSession(session: ProofMutationSession): ProofMutati
   return currentFreshness;
 }
 
-function proofMutationRunner(session: ProofMutationSession): MutationRunner {
+function proofMutationRunner(
+  session: ProofMutationSession,
+  beforeRequest?: (mutationIdentity: string) => void,
+): MutationRunner {
   return <T>(options: {
     identity: string;
     idempotencyIdentity: string;
@@ -2824,7 +2827,10 @@ function proofMutationRunner(session: ProofMutationSession): MutationRunner {
       mutationIdentity: options.idempotencyIdentity,
       requestAttempt,
     });
+    let requestStarted = false;
     try {
+      beforeRequest?.(options.idempotencyIdentity);
+      requestStarted = true;
       const result = options.operation();
       const outcome = finishProofMutationReceipt({
         attempt,
@@ -2841,7 +2847,7 @@ function proofMutationRunner(session: ProofMutationSession): MutationRunner {
       }
       return result;
     } catch (error) {
-      const knownNoMutation = options.knownNoMutation?.(error) === true;
+      const knownNoMutation = !requestStarted || options.knownNoMutation?.(error) === true;
       const rejected =
         isGitHubRequiresAuthenticationError(error) ||
         isLockedConversationCommentError(error) ||
@@ -2864,6 +2870,52 @@ function proofMutationRunner(session: ProofMutationSession): MutationRunner {
       throw error;
     }
   };
+}
+
+export function runProofMutationPreRequestForTest(options: {
+  context: ProofMutationReceiptContext;
+  beforeRequest: () => void;
+  operation: () => string;
+}): string {
+  const snapshot: ProofMutationRequestSnapshot = {
+    item: {
+      repo: options.context.repository,
+      kind: "pull_request",
+      number: options.context.number,
+      title: "proof mutation pre-request test",
+      url: `https://github.com/${options.context.repository}/pull/${options.context.number}`,
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+      author: "contributor",
+      authorAssociation: "CONTRIBUTOR",
+      locked: false,
+      labels: [],
+    },
+    state: "OPEN",
+    draft: false,
+    headSha: options.context.headSha,
+    reviewActivityCursor: "v2:0:test",
+    conversationActivityCursor: "v1:0:test",
+    labelStateCursor: proofMutationLabelStateCursor([]),
+    comments: [],
+  };
+  const session: ProofMutationSession = {
+    context: options.context,
+    expectedFreshness: snapshot,
+    refreshFreshness: () => snapshot,
+    validateRequest: () => null,
+    bindLabelState: false,
+    nextAttemptByMutation: new Map(),
+    latestEventIdByMutation: new Map(),
+    knownNoMutationIdentities: new Set(),
+    unknownMutationIdentities: new Set(),
+    unknownMutationObserved: false,
+  };
+  return proofMutationRunner(session, () => options.beforeRequest())({
+    identity: "proof_test_mutation:request_attempt:1",
+    idempotencyIdentity: "proof_test_mutation",
+    operation: options.operation,
+  });
 }
 
 function reconcileProofMutation(session: ProofMutationSession, mutationIdentity: string): void {
@@ -29188,8 +29240,7 @@ function proofNudgesCommand(args: Args): void {
         continue;
       }
       const previousProofMutationRunner = activeProofMutationRunner;
-      activeProofMutationRunner = proofMutationRunner(mutationSession);
-      try {
+      activeProofMutationRunner = proofMutationRunner(mutationSession, () => {
         writeProofNudgeMutationCycle(mutationCyclePath, {
           schema_version: 1,
           repository: targetRepo(),
@@ -29198,6 +29249,8 @@ function proofNudgesCommand(args: Args): void {
           marker_timestamp: timestamp,
           created_at: timestamp,
         });
+      });
+      try {
         const mutation = postProofNudgeComment({
           number: candidate.number,
           headSha,

--- a/src/proof-mutation-safety.ts
+++ b/src/proof-mutation-safety.ts
@@ -231,6 +231,8 @@ export function finishProofMutationReceipt(options: {
 export function recordProofMutationReconciliation(options: {
   context: ProofMutationReceiptContext;
   mutationIdentity: string;
+  parentEventId?: string | null;
+  phaseSeq?: number;
 }): ActionEvent | null {
   const operationIdentity = proofMutationBusinessIdentityForTest({
     lane: options.context.lane,
@@ -253,7 +255,8 @@ export function recordProofMutationReconciliation(options: {
       },
       operation: "proof",
       operationIdentity,
-      phaseSeq: 1,
+      ...(options.parentEventId ? { parentEventId: options.parentEventId } : {}),
+      phaseSeq: options.phaseSeq ?? 1,
       idempotencyIdentity: operationIdentity,
       component: options.context.component,
       subject: proofMutationSubject(options.context),

--- a/src/proof-mutation-safety.ts
+++ b/src/proof-mutation-safety.ts
@@ -274,6 +274,48 @@ export function recordProofMutationReconciliation(options: {
   );
 }
 
+export function recordProofMutationPendingReconciliation(options: {
+  context: ProofMutationReceiptContext;
+  mutationIdentity: string;
+}): ActionEvent | null {
+  const operationIdentity = proofMutationBusinessIdentityForTest({
+    lane: options.context.lane,
+    repository: options.context.repository,
+    number: options.context.number,
+    headSha: options.context.headSha,
+    mutationIdentity: options.mutationIdentity,
+  });
+  return recordWorkflowPhaseEvent(
+    options.context.root,
+    {
+      phase: ACTION_EVENT_TYPES.proofStage,
+      status: ACTION_EVENT_STATUSES.waiting,
+      reasonCode: ACTION_EVENT_REASON_CODES.unavailable,
+      retryable: false,
+      mutation: false,
+      identity: {
+        slot: "proof_mutation_reconciliation_pending",
+        mutationIdentitySha256: operationIdentity.mutationIdentitySha256,
+      },
+      operation: "proof",
+      operationIdentity,
+      phaseSeq: 1,
+      idempotencyIdentity: operationIdentity,
+      component: options.context.component,
+      subject: proofMutationSubject(options.context),
+      evidence: options.context.evidence,
+      attributes: {
+        action_count: 0,
+        partial: true,
+        completion_reason: "mutation_reconciliation_pending",
+        work_kind: options.context.lane,
+      },
+      privacy: options.context.privacy,
+    },
+    options.context.env ? { env: options.context.env } : {},
+  );
+}
+
 function proofMutationSubject(context: ProofMutationReceiptContext): ActionEventSubject {
   return {
     repository: context.repository,

--- a/src/proof-mutation-safety.ts
+++ b/src/proof-mutation-safety.ts
@@ -28,6 +28,7 @@ export interface ProofMutationFreshnessBlock {
     | "head_changed"
     | "review_activity_changed"
     | "conversation_activity_changed"
+    | "eligibility_changed"
     | "freshness_unavailable";
   message: string;
 }

--- a/src/proof-mutation-safety.ts
+++ b/src/proof-mutation-safety.ts
@@ -1,0 +1,310 @@
+import { createHash } from "node:crypto";
+
+import {
+  ACTION_EVENT_REASON_CODES,
+  ACTION_EVENT_STATUSES,
+  ACTION_EVENT_TYPES,
+  type ActionEvent,
+  type ActionEventEvidence,
+  type ActionEventPrivacy,
+  type ActionEventSubject,
+} from "./action-ledger.js";
+import { recordWorkflowPhaseEvent } from "./action-ledger-runtime.js";
+import { stableJson } from "./stable-json.js";
+
+export const MAX_PROOF_CONVERSATION_ACTIVITY = 1_000;
+export const MAX_PROOF_CONVERSATION_CURSOR_BYTES = 1024 * 1024;
+
+export type ProofMutationLane = "proof_nudges" | "bot_proof";
+
+export interface ProofMutationFreshnessSnapshot {
+  headSha: string;
+  reviewActivityCursor: string;
+  conversationActivityCursor: string;
+}
+
+export interface ProofMutationFreshnessBlock {
+  reason:
+    | "head_changed"
+    | "review_activity_changed"
+    | "conversation_activity_changed"
+    | "freshness_unavailable";
+  message: string;
+}
+
+export interface ProofMutationReceiptContext {
+  root: string;
+  lane: ProofMutationLane;
+  repository: string;
+  number: number;
+  headSha: string;
+  component: string;
+  evidence: readonly ActionEventEvidence[];
+  privacy: ActionEventPrivacy;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface ProofMutationReceiptAttempt {
+  eventId: string | null;
+  context: ProofMutationReceiptContext;
+  operationIdentity: ProofMutationBusinessIdentity;
+  requestAttempt: number;
+  receiptIdentitySha256: string;
+}
+
+export type ProofMutationReceiptOutcome = "accepted" | "rejected" | "unknown";
+
+interface ProofMutationBusinessIdentity {
+  operation: "proof";
+  lane: ProofMutationLane;
+  repository: string;
+  number: number;
+  sourceRevision: string;
+  mutationIdentitySha256: string;
+}
+
+export function createProofConversationActivityCursor(comments: readonly unknown[]): string | null {
+  if (comments.length > MAX_PROOF_CONVERSATION_ACTIVITY) return null;
+  const entries = comments
+    .map((comment) => stableJson(compactConversationComment(comment)))
+    .sort((left, right) => (left < right ? -1 : left > right ? 1 : 0));
+  const canonical = `[${entries.join(",")}]`;
+  if (Buffer.byteLength(canonical, "utf8") > MAX_PROOF_CONVERSATION_CURSOR_BYTES) return null;
+  return `v1:${entries.length}:${sha256(canonical)}`;
+}
+
+export function proofMutationFreshnessBlock(
+  expected: ProofMutationFreshnessSnapshot,
+  current: ProofMutationFreshnessSnapshot,
+): ProofMutationFreshnessBlock | null {
+  if (current.headSha !== expected.headSha) {
+    return {
+      reason: "head_changed",
+      message: "live PR head changed before the proof mutation request",
+    };
+  }
+  if (current.reviewActivityCursor !== expected.reviewActivityCursor) {
+    return {
+      reason: "review_activity_changed",
+      message:
+        "review, inline-comment, or review-thread activity changed before the proof mutation request",
+    };
+  }
+  if (current.conversationActivityCursor !== expected.conversationActivityCursor) {
+    return {
+      reason: "conversation_activity_changed",
+      message: "pull request conversation activity changed before the proof mutation request",
+    };
+  }
+  return null;
+}
+
+export function proofMutationBusinessIdentityForTest(options: {
+  lane: ProofMutationLane;
+  repository: string;
+  number: number;
+  headSha: string;
+  mutationIdentity: string;
+}): ProofMutationBusinessIdentity {
+  return {
+    operation: "proof",
+    lane: options.lane,
+    repository: options.repository,
+    number: options.number,
+    sourceRevision: options.headSha,
+    mutationIdentitySha256: sha256(options.mutationIdentity),
+  };
+}
+
+export function startProofMutationReceipt(options: {
+  context: ProofMutationReceiptContext;
+  receiptIdentity: string;
+  mutationIdentity: string;
+  requestAttempt: number;
+}): ProofMutationReceiptAttempt {
+  if (!Number.isSafeInteger(options.requestAttempt) || options.requestAttempt < 1) {
+    throw new Error("proof mutation request attempt must be a positive integer");
+  }
+  const operationIdentity = proofMutationBusinessIdentityForTest({
+    lane: options.context.lane,
+    repository: options.context.repository,
+    number: options.context.number,
+    headSha: options.context.headSha,
+    mutationIdentity: options.mutationIdentity,
+  });
+  const receiptIdentitySha256 = sha256(options.receiptIdentity);
+  const event = recordWorkflowPhaseEvent(
+    options.context.root,
+    {
+      phase: ACTION_EVENT_TYPES.proofStage,
+      status: ACTION_EVENT_STATUSES.started,
+      reasonCode: ACTION_EVENT_REASON_CODES.selected,
+      retryable: true,
+      mutation: false,
+      identity: {
+        slot: "proof_mutation_attempt",
+        requestAttempt: options.requestAttempt,
+        receiptIdentitySha256,
+      },
+      operation: "proof",
+      operationIdentity,
+      phaseSeq: options.requestAttempt * 2 - 1,
+      idempotencyIdentity: operationIdentity,
+      component: options.context.component,
+      subject: proofMutationSubject(options.context),
+      evidence: options.context.evidence,
+      attributes: {
+        attempt: options.requestAttempt,
+        action_count: 1,
+        partial: true,
+        completion_reason: "mutation_attempted",
+        work_kind: options.context.lane,
+      },
+      privacy: options.context.privacy,
+    },
+    options.context.env ? { env: options.context.env } : {},
+  );
+  return {
+    eventId: event?.event_id ?? null,
+    context: options.context,
+    operationIdentity,
+    requestAttempt: options.requestAttempt,
+    receiptIdentitySha256,
+  };
+}
+
+export function finishProofMutationReceipt(options: {
+  attempt: ProofMutationReceiptAttempt;
+  outcome: ProofMutationReceiptOutcome;
+}): ActionEvent | null {
+  const mutation = options.outcome !== "rejected";
+  return recordWorkflowPhaseEvent(
+    options.attempt.context.root,
+    {
+      phase: ACTION_EVENT_TYPES.proofStage,
+      status:
+        options.outcome === "accepted"
+          ? ACTION_EVENT_STATUSES.executed
+          : options.outcome === "rejected"
+            ? ACTION_EVENT_STATUSES.skipped
+            : ACTION_EVENT_STATUSES.failed,
+      reasonCode:
+        options.outcome === "accepted"
+          ? ACTION_EVENT_REASON_CODES.completed
+          : options.outcome === "rejected"
+            ? ACTION_EVENT_REASON_CODES.mutationGuard
+            : ACTION_EVENT_REASON_CODES.unavailable,
+      retryable: false,
+      mutation,
+      identity: {
+        slot: "proof_mutation_outcome",
+        requestAttempt: options.attempt.requestAttempt,
+        receiptIdentitySha256: options.attempt.receiptIdentitySha256,
+        outcome: options.outcome,
+      },
+      operation: "proof",
+      operationIdentity: options.attempt.operationIdentity,
+      parentEventId: options.attempt.eventId,
+      phaseSeq: options.attempt.requestAttempt * 2,
+      idempotencyIdentity: options.attempt.operationIdentity,
+      component: options.attempt.context.component,
+      subject: proofMutationSubject(options.attempt.context),
+      evidence: options.attempt.context.evidence,
+      attributes: {
+        attempt: options.attempt.requestAttempt,
+        action_count: mutation ? 1 : 0,
+        partial: options.outcome === "unknown",
+        completion_reason:
+          options.outcome === "accepted"
+            ? "mutation_accepted"
+            : options.outcome === "rejected"
+              ? "mutation_rejected"
+              : "mutation_outcome_unknown",
+        work_kind: options.attempt.context.lane,
+      },
+      privacy: options.attempt.context.privacy,
+    },
+    options.attempt.context.env ? { env: options.attempt.context.env } : {},
+  );
+}
+
+export function recordProofMutationReconciliation(options: {
+  context: ProofMutationReceiptContext;
+  mutationIdentity: string;
+}): ActionEvent | null {
+  const operationIdentity = proofMutationBusinessIdentityForTest({
+    lane: options.context.lane,
+    repository: options.context.repository,
+    number: options.context.number,
+    headSha: options.context.headSha,
+    mutationIdentity: options.mutationIdentity,
+  });
+  return recordWorkflowPhaseEvent(
+    options.context.root,
+    {
+      phase: ACTION_EVENT_TYPES.proofStage,
+      status: ACTION_EVENT_STATUSES.recovered,
+      reasonCode: ACTION_EVENT_REASON_CODES.alreadyComplete,
+      retryable: false,
+      mutation: false,
+      identity: {
+        slot: "proof_mutation_reconciled",
+        mutationIdentitySha256: operationIdentity.mutationIdentitySha256,
+      },
+      operation: "proof",
+      operationIdentity,
+      phaseSeq: 1,
+      idempotencyIdentity: operationIdentity,
+      component: options.context.component,
+      subject: proofMutationSubject(options.context),
+      evidence: options.context.evidence,
+      attributes: {
+        action_count: 0,
+        partial: false,
+        completion_reason: "mutation_reconciled",
+        work_kind: options.context.lane,
+      },
+      privacy: options.context.privacy,
+    },
+    options.context.env ? { env: options.context.env } : {},
+  );
+}
+
+function proofMutationSubject(context: ProofMutationReceiptContext): ActionEventSubject {
+  return {
+    repository: context.repository,
+    kind: "pull_request",
+    number: context.number,
+    sourceRevision: context.headSha,
+  };
+}
+
+function compactConversationComment(value: unknown) {
+  const comment = record(value);
+  const user = record(comment.user);
+  return {
+    id: scalar(comment.id),
+    user: scalar(user.login),
+    author_association: scalar(comment.author_association),
+    body_sha256: sha256(scalar(comment.body)),
+    created_at: scalar(comment.created_at),
+    updated_at: scalar(comment.updated_at ?? comment.created_at),
+  };
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function scalar(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return stableJson(value);
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}

--- a/test/action-ledger-runtime.test.ts
+++ b/test/action-ledger-runtime.test.ts
@@ -2270,6 +2270,12 @@ test("workflow producer normalization preserves distinct original identities", (
   assert.ok(first.component.length <= 120 + 1 + 64 + 1 + 64);
   assert.match(first.component, /-[a-f0-9]{12}\.__run_5\.review-0$/);
 
+  const repeatedHyphens = workflowActionProducer(
+    `${"-".repeat(100_000)}review${"-".repeat(100_000)}`,
+    workflowEnv(),
+  );
+  assert.match(repeatedHyphens.component, /^review-[a-f0-9]{12}\.__run_5\.review-0$/);
+
   const root = tempRoot();
   const firstEvent = recordWorkflowActionEvent(
     root,

--- a/test/proof-action-ledger.test.ts
+++ b/test/proof-action-ledger.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { readText } from "./helpers.ts";
+
+test("proof workflow enables and publishes immutable mutation receipts", () => {
+  const workflow = readText(".github/workflows/proof-nudges.yml");
+  const setup = workflow.indexOf("- uses: ./.github/actions/setup-action-ledger");
+  const run = workflow.indexOf("- name: Run proof nudges");
+  const finalize = workflow.indexOf("- name: Finalize proof handling action ledger");
+  const publish = workflow.indexOf("- name: Publish immutable proof handling action ledger");
+
+  assert.match(workflow, /permissions:\n  actions: read/);
+  assert.ok(setup >= 0);
+  assert.ok(setup < run);
+  assert.ok(run < finalize);
+  assert.ok(finalize < publish);
+  assert.match(workflow.slice(finalize, publish), /finalize-action-events/);
+  assert.match(
+    workflow.slice(publish),
+    /publish-action-events -- \\\n\s+--source-root "\$source_root" \\\n\s+--state-root "\$CLAWSWEEPER_STATE_DIR" \\\n\s+--expected-producer-job "\$GITHUB_JOB"/,
+  );
+  assert.match(workflow.slice(publish), /publish-action-event-paths/);
+});

--- a/test/proof-action-ledger.test.ts
+++ b/test/proof-action-ledger.test.ts
@@ -8,16 +8,22 @@ test("proof workflow enables and publishes immutable mutation receipts", () => {
   const setup = workflow.indexOf("- uses: ./.github/actions/setup-action-ledger");
   const run = workflow.indexOf("- name: Run proof nudges");
   const finalize = workflow.indexOf("- name: Finalize proof handling action ledger");
+  const upload = workflow.indexOf("- name: Upload finalized proof handling action ledger");
   const publish = workflow.indexOf("- name: Publish immutable proof handling action ledger");
 
   assert.match(workflow, /permissions:\n  actions: read/);
   assert.ok(setup >= 0);
   assert.ok(setup < run);
   assert.ok(run < finalize);
-  assert.ok(finalize < publish);
+  assert.ok(finalize < upload);
+  assert.ok(upload < publish);
   assert.match(
     workflow.slice(finalize, publish),
     /PROOF_OUTCOME:[\s\S]*--interrupt-open-attempts --reason cancelled[\s\S]*--interrupt-open-attempts --reason workflow_failed[\s\S]*finalize-action-events/,
+  );
+  assert.match(
+    workflow.slice(upload, publish),
+    /uses: actions\/upload-artifact@v7[\s\S]*proof-handling-action-ledger-\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}[\s\S]*CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT \}\}\/ledger/,
   );
   assert.match(
     workflow.slice(publish),

--- a/test/proof-action-ledger.test.ts
+++ b/test/proof-action-ledger.test.ts
@@ -10,6 +10,7 @@ test("proof workflow enables and publishes immutable mutation receipts", () => {
   const finalize = workflow.indexOf("- name: Finalize proof handling action ledger");
   const upload = workflow.indexOf("- name: Upload finalized proof handling action ledger");
   const publish = workflow.indexOf("- name: Publish immutable proof handling action ledger");
+  const publishCursors = workflow.indexOf("- name: Publish proof handling cursors");
 
   assert.match(workflow, /permissions:\n  actions: read/);
   assert.ok(setup >= 0);
@@ -17,6 +18,8 @@ test("proof workflow enables and publishes immutable mutation receipts", () => {
   assert.ok(run < finalize);
   assert.ok(finalize < upload);
   assert.ok(upload < publish);
+  assert.ok(publish < publishCursors);
+  assert.doesNotMatch(workflow.slice(run, finalize), /repair:publish-main/);
   assert.match(
     workflow.slice(finalize, publish),
     /PROOF_OUTCOME:[\s\S]*--interrupt-open-attempts --reason cancelled[\s\S]*--interrupt-open-attempts --reason workflow_failed[\s\S]*finalize-action-events/,
@@ -30,4 +33,9 @@ test("proof workflow enables and publishes immutable mutation receipts", () => {
     /publish-action-events -- \\\n\s+--source-root "\$source_root" \\\n\s+--state-root "\$CLAWSWEEPER_STATE_DIR" \\\n\s+--expected-producer-job "\$GITHUB_JOB"/,
   );
   assert.match(workflow.slice(publish), /publish-action-event-paths/);
+  assert.match(
+    workflow.slice(publishCursors),
+    /steps\.run-proof-nudges\.outcome == 'success'[\s\S]*steps\.finalize-action-ledger\.outcome == 'success'[\s\S]*steps\.upload-finalized-ledger\.outcome == 'success'[\s\S]*steps\.publish-action-ledger\.outcome == 'success'/,
+  );
+  assert.match(workflow.slice(publishCursors), /proof-cursor-paths\.txt[\s\S]*repair:publish-main/);
 });

--- a/test/proof-action-ledger.test.ts
+++ b/test/proof-action-ledger.test.ts
@@ -15,7 +15,10 @@ test("proof workflow enables and publishes immutable mutation receipts", () => {
   assert.ok(setup < run);
   assert.ok(run < finalize);
   assert.ok(finalize < publish);
-  assert.match(workflow.slice(finalize, publish), /finalize-action-events/);
+  assert.match(
+    workflow.slice(finalize, publish),
+    /PROOF_OUTCOME:[\s\S]*--interrupt-open-attempts --reason cancelled[\s\S]*--interrupt-open-attempts --reason workflow_failed[\s\S]*finalize-action-events/,
+  );
   assert.match(
     workflow.slice(publish),
     /publish-action-events -- \\\n\s+--source-root "\$source_root" \\\n\s+--state-root "\$CLAWSWEEPER_STATE_DIR" \\\n\s+--expected-producer-job "\$GITHUB_JOB"/,

--- a/test/proof-mutation-safety.test.ts
+++ b/test/proof-mutation-safety.test.ts
@@ -9,6 +9,7 @@ import {
   finishProofMutationReceipt,
   proofMutationBusinessIdentityForTest,
   proofMutationFreshnessBlock,
+  recordProofMutationPendingReconciliation,
   recordProofMutationReconciliation,
   startProofMutationReceipt,
   type ProofMutationReceiptContext,
@@ -232,6 +233,39 @@ test("same-run proof reconciliation follows and parents the unknown outcome", ()
     assert.equal(reconciliation?.phase_seq, 3);
     assert.equal(reconciliation?.parent_event_id, outcome?.event_id);
     assert.equal(outcome?.idempotency_key_sha256, reconciliation?.idempotency_key_sha256);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a later workflow waits under the original unknown mutation idempotency key", () => {
+  const root = realpathSync(mkdtempSync(tmpPrefix));
+  try {
+    const firstRun = receiptContext(root, "4208");
+    const secondRun = receiptContext(root, "4209");
+    const mutationIdentity = `proof_nudge_comment:42:${"b".repeat(40)}:2026-07-14T12:00:00Z`;
+    const attempt = startProofMutationReceipt({
+      context: firstRun,
+      receiptIdentity: `${mutationIdentity}:request_attempt:1`,
+      mutationIdentity,
+      requestAttempt: 1,
+    });
+    finishProofMutationReceipt({ attempt, outcome: "unknown" });
+    recordProofMutationPendingReconciliation({
+      context: secondRun,
+      mutationIdentity,
+    });
+
+    const events = readAllSpooledActionEvents(root);
+    assert.equal(new Set(events.map((event) => event.idempotency_key_sha256)).size, 1);
+    const pending = events.find(
+      (event) => event.attributes?.completion_reason === "mutation_reconciliation_pending",
+    );
+    assert.equal(pending?.action.status, "waiting");
+    assert.equal(pending?.action.mutation, false);
+    assert.equal(pending?.action.retryable, false);
+    assert.notEqual(attempt.eventId, pending?.event_id);
+    assert.doesNotMatch(JSON.stringify(events), /proof_nudge_comment|2026-07-14T12:00:00Z/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/proof-mutation-safety.test.ts
+++ b/test/proof-mutation-safety.test.ts
@@ -185,18 +185,50 @@ test("proof reconciliation reuses the business idempotency identity without clai
   }
 });
 
-test("a crash-open proof attempt reconciles under the same business idempotency key", () => {
+test("same-run proof reconciliation follows and parents the unknown outcome", () => {
   const root = realpathSync(mkdtempSync(tmpPrefix));
   try {
     const context = receiptContext(root, "4202");
-    const mutationIdentity = `proof_nudge_comment:42:${"b".repeat(40)}:2026-07-14T12:00:00Z`;
-    startProofMutationReceipt({
+    const mutationIdentity = `bot_proof_comment:42:${"b".repeat(40)}:${"c".repeat(64)}`;
+    const attempt = startProofMutationReceipt({
       context,
       receiptIdentity: `${mutationIdentity}:request_attempt:1`,
       mutationIdentity,
       requestAttempt: 1,
     });
-    recordProofMutationReconciliation({ context, mutationIdentity });
+    const outcome = finishProofMutationReceipt({ attempt, outcome: "unknown" });
+    const reconciliation = recordProofMutationReconciliation({
+      context,
+      mutationIdentity,
+      parentEventId: outcome?.event_id,
+      phaseSeq: 3,
+    });
+
+    assert.equal(outcome?.phase_seq, 2);
+    assert.equal(reconciliation?.phase_seq, 3);
+    assert.equal(reconciliation?.parent_event_id, outcome?.event_id);
+    assert.equal(outcome?.idempotency_key_sha256, reconciliation?.idempotency_key_sha256);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a crash-open proof attempt reconciles under the same business idempotency key", () => {
+  const root = realpathSync(mkdtempSync(tmpPrefix));
+  try {
+    const attemptContext = receiptContext(root, "4203");
+    const reconciliationContext = receiptContext(root, "4204");
+    const mutationIdentity = `proof_nudge_comment:42:${"b".repeat(40)}:2026-07-14T12:00:00Z`;
+    startProofMutationReceipt({
+      context: attemptContext,
+      receiptIdentity: `${mutationIdentity}:request_attempt:1`,
+      mutationIdentity,
+      requestAttempt: 1,
+    });
+    recordProofMutationReconciliation({
+      context: reconciliationContext,
+      mutationIdentity,
+    });
 
     const events = readAllSpooledActionEvents(root);
     const attempt = events.find(
@@ -210,6 +242,7 @@ test("a crash-open proof attempt reconciles under the same business idempotency 
     assert.equal(reconciliation?.action.status, "recovered");
     assert.equal(reconciliation?.action.mutation, false);
     assert.equal(attempt?.idempotency_key_sha256, reconciliation?.idempotency_key_sha256);
+    assert.notEqual(attempt?.attempt_id, reconciliation?.attempt_id);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/proof-mutation-safety.test.ts
+++ b/test/proof-mutation-safety.test.ts
@@ -113,18 +113,23 @@ test("proof freshness distinguishes head, review, and conversation drift", () =>
 
 test("proof mutation receipts start only after request-boundary validation", () => {
   const source = readFileSync("src/clawsweeper.ts", "utf8");
+  const freshnessStart = source.indexOf("function refreshProofMutationSession(");
   const runnerStart = source.indexOf("function proofMutationRunner(");
   const runnerEnd = source.indexOf("\nfunction reconcileProofMutation(", runnerStart);
+  const freshness = source.slice(freshnessStart, runnerStart);
   const runner = source.slice(runnerStart, runnerEnd);
 
-  const refresh = runner.indexOf("session.refreshFreshness()");
-  const validate = runner.indexOf("session.validateRequest(currentFreshness)");
+  const refresh = freshness.indexOf("session.refreshFreshness()");
+  const validate = freshness.indexOf("session.validateRequest(currentFreshness)");
+  const boundaryValidation = runner.indexOf("refreshProofMutationSession(session)");
   const receipt = runner.indexOf("startProofMutationReceipt({");
   const request = runner.indexOf("const result = options.operation()");
 
+  assert.ok(freshnessStart >= 0);
   assert.ok(refresh >= 0);
   assert.ok(refresh < validate);
-  assert.ok(validate < receipt);
+  assert.ok(boundaryValidation >= 0);
+  assert.ok(boundaryValidation < receipt);
   assert.ok(receipt < request);
 });
 

--- a/test/proof-mutation-safety.test.ts
+++ b/test/proof-mutation-safety.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs";
 import test from "node:test";
 
 import { readAllSpooledActionEvents } from "../dist/action-ledger.js";
@@ -109,6 +109,23 @@ test("proof freshness distinguishes head, review, and conversation drift", () =>
     })?.reason,
     "conversation_activity_changed",
   );
+});
+
+test("proof mutation receipts start only after request-boundary validation", () => {
+  const source = readFileSync("src/clawsweeper.ts", "utf8");
+  const runnerStart = source.indexOf("function proofMutationRunner(");
+  const runnerEnd = source.indexOf("\nfunction reconcileProofMutation(", runnerStart);
+  const runner = source.slice(runnerStart, runnerEnd);
+
+  const refresh = runner.indexOf("session.refreshFreshness()");
+  const validate = runner.indexOf("session.validateRequest(currentFreshness)");
+  const receipt = runner.indexOf("startProofMutationReceipt({");
+  const request = runner.indexOf("const result = options.operation()");
+
+  assert.ok(refresh >= 0);
+  assert.ok(refresh < validate);
+  assert.ok(validate < receipt);
+  assert.ok(receipt < request);
 });
 
 test("proof mutation receipts pair attempts with stable privacy-bounded idempotency", () => {

--- a/test/proof-mutation-safety.test.ts
+++ b/test/proof-mutation-safety.test.ts
@@ -12,6 +12,7 @@ import {
   startProofMutationReceipt,
   type ProofMutationReceiptContext,
 } from "../dist/proof-mutation-safety.js";
+import { satisfiedBotProofLabelMutationIdentitiesForTest } from "../dist/clawsweeper.js";
 import { tmpPrefix } from "./helpers.ts";
 
 function ledgerEnv(runId: string): NodeJS.ProcessEnv {
@@ -243,6 +244,39 @@ test("a crash-open proof attempt reconciles under the same business idempotency 
     assert.equal(reconciliation?.action.mutation, false);
     assert.equal(attempt?.idempotency_key_sha256, reconciliation?.idempotency_key_sha256);
     assert.notEqual(attempt?.attempt_id, reconciliation?.attempt_id);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("bot proof label recovery receipts use concrete private mutation identities", () => {
+  const root = realpathSync(mkdtempSync(tmpPrefix));
+  try {
+    const context: ProofMutationReceiptContext = {
+      ...receiptContext(root, "4205"),
+      lane: "bot_proof",
+      component: "bot_proof",
+    };
+    const identities = satisfiedBotProofLabelMutationIdentitiesForTest(42, [
+      "triage: needs-real-behavior-proof",
+      "status: needs maintainer proof decision",
+    ]);
+    for (const mutationIdentity of identities) {
+      recordProofMutationReconciliation({ context, mutationIdentity });
+    }
+
+    const events = readAllSpooledActionEvents(root);
+    assert.equal(events.length, identities.length);
+    assert.equal(
+      new Set(events.map((event) => event.idempotency_key_sha256)).size,
+      identities.length,
+    );
+    const serialized = JSON.stringify(events);
+    assert.doesNotMatch(
+      serialized,
+      /issue_label_(?:add|remove)|label_create|maintainer proof|stale/,
+    );
+    assert.doesNotMatch(identities.join("\n"), /bot_proof_label_state/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/proof-mutation-safety.test.ts
+++ b/test/proof-mutation-safety.test.ts
@@ -184,3 +184,33 @@ test("proof reconciliation reuses the business idempotency identity without clai
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+test("a crash-open proof attempt reconciles under the same business idempotency key", () => {
+  const root = realpathSync(mkdtempSync(tmpPrefix));
+  try {
+    const context = receiptContext(root, "4202");
+    const mutationIdentity = `proof_nudge_comment:42:${"b".repeat(40)}:2026-07-14T12:00:00Z`;
+    startProofMutationReceipt({
+      context,
+      receiptIdentity: `${mutationIdentity}:request_attempt:1`,
+      mutationIdentity,
+      requestAttempt: 1,
+    });
+    recordProofMutationReconciliation({ context, mutationIdentity });
+
+    const events = readAllSpooledActionEvents(root);
+    const attempt = events.find(
+      (event) => event.attributes?.completion_reason === "mutation_attempted",
+    );
+    const reconciliation = events.find(
+      (event) => event.attributes?.completion_reason === "mutation_reconciled",
+    );
+
+    assert.equal(attempt?.action.status, "started");
+    assert.equal(reconciliation?.action.status, "recovered");
+    assert.equal(reconciliation?.action.mutation, false);
+    assert.equal(attempt?.idempotency_key_sha256, reconciliation?.idempotency_key_sha256);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/proof-mutation-safety.test.ts
+++ b/test/proof-mutation-safety.test.ts
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import test from "node:test";
+
+import { readAllSpooledActionEvents } from "../dist/action-ledger.js";
+import {
+  createProofConversationActivityCursor,
+  finishProofMutationReceipt,
+  proofMutationBusinessIdentityForTest,
+  proofMutationFreshnessBlock,
+  recordProofMutationReconciliation,
+  startProofMutationReceipt,
+  type ProofMutationReceiptContext,
+} from "../dist/proof-mutation-safety.js";
+import { tmpPrefix } from "./helpers.ts";
+
+function ledgerEnv(runId: string): NodeJS.ProcessEnv {
+  return {
+    CLAWSWEEPER_ACTION_LEDGER_FORCE: "1",
+    CLAWSWEEPER_ACTION_LEDGER_PARTITION_DATE: "2026-07-14",
+    CLAWSWEEPER_ACTION_LEDGER_INVOCATION: "proof-mutation-test",
+    GITHUB_ACTION: "proof-mutation-test",
+    GITHUB_JOB: "proof-nudges",
+    GITHUB_REPOSITORY: "openclaw/clawsweeper",
+    GITHUB_RUN_ATTEMPT: "1",
+    GITHUB_RUN_ID: runId,
+    GITHUB_SHA: "a".repeat(40),
+    GITHUB_WORKFLOW: "ClawSweeper Proof Nudges",
+  };
+}
+
+function receiptContext(root: string, runId = "4200"): ProofMutationReceiptContext {
+  return {
+    root,
+    lane: "proof_nudges",
+    repository: "openclaw/openclaw",
+    number: 42,
+    headSha: "b".repeat(40),
+    component: "proof_nudges",
+    evidence: [],
+    privacy: {
+      classification: "internal",
+      redactionVersion: "v1",
+      fieldsDropped: ["body", "comments", "logs", "prompt"],
+    },
+    env: ledgerEnv(runId),
+  };
+}
+
+test("proof conversation cursors are bounded, deterministic, and content-sensitive", () => {
+  const comments = [
+    {
+      id: 2,
+      user: { login: "reviewer" },
+      author_association: "MEMBER",
+      body: "second body",
+      created_at: "2026-07-14T10:00:00Z",
+      updated_at: "2026-07-14T10:01:00Z",
+    },
+    {
+      id: 1,
+      user: { login: "author" },
+      author_association: "CONTRIBUTOR",
+      body: "first body",
+      created_at: "2026-07-14T09:00:00Z",
+      updated_at: "2026-07-14T09:00:00Z",
+    },
+  ];
+  const cursor = createProofConversationActivityCursor(comments);
+
+  assert.match(cursor ?? "", /^v1:2:[0-9a-f]{64}$/);
+  assert.equal(createProofConversationActivityCursor([...comments].reverse()), cursor);
+  assert.notEqual(
+    createProofConversationActivityCursor([comments[0], { ...comments[1], body: "edited body" }]),
+    cursor,
+  );
+  assert.equal(createProofConversationActivityCursor(Array.from({ length: 1_001 })), null);
+  assert.doesNotMatch(cursor ?? "", /first body|second body/);
+});
+
+test("proof freshness distinguishes head, review, and conversation drift", () => {
+  const expected = {
+    headSha: "a".repeat(40),
+    reviewActivityCursor: `v2:0:${"b".repeat(64)}`,
+    conversationActivityCursor: `v1:0:${"c".repeat(64)}`,
+  };
+
+  assert.equal(proofMutationFreshnessBlock(expected, expected), null);
+  assert.equal(
+    proofMutationFreshnessBlock(expected, {
+      ...expected,
+      headSha: "d".repeat(40),
+    })?.reason,
+    "head_changed",
+  );
+  assert.equal(
+    proofMutationFreshnessBlock(expected, {
+      ...expected,
+      reviewActivityCursor: `v2:1:${"e".repeat(64)}`,
+    })?.reason,
+    "review_activity_changed",
+  );
+  assert.equal(
+    proofMutationFreshnessBlock(expected, {
+      ...expected,
+      conversationActivityCursor: `v1:1:${"f".repeat(64)}`,
+    })?.reason,
+    "conversation_activity_changed",
+  );
+});
+
+test("proof mutation receipts pair attempts with stable privacy-bounded idempotency", () => {
+  const root = realpathSync(mkdtempSync(tmpPrefix));
+  try {
+    const context = receiptContext(root);
+    const mutationIdentity = `proof_nudge_comment:42:${"b".repeat(40)}:2026-07-14T12:00:00Z`;
+    const first = startProofMutationReceipt({
+      context,
+      receiptIdentity: `${mutationIdentity}:request_attempt:1`,
+      mutationIdentity,
+      requestAttempt: 1,
+    });
+    finishProofMutationReceipt({ attempt: first, outcome: "accepted" });
+    const second = startProofMutationReceipt({
+      context,
+      receiptIdentity: `${mutationIdentity}:request_attempt:2`,
+      mutationIdentity,
+      requestAttempt: 2,
+    });
+    finishProofMutationReceipt({ attempt: second, outcome: "unknown" });
+
+    const events = readAllSpooledActionEvents(root).sort(
+      (left, right) => left.phase_seq - right.phase_seq,
+    );
+    assert.deepEqual(
+      events.map((event) => [
+        event.phase_seq,
+        event.action.status,
+        event.action.mutation,
+        event.action.retryable,
+        event.attributes?.completion_reason,
+      ]),
+      [
+        [1, "started", false, true, "mutation_attempted"],
+        [2, "executed", true, false, "mutation_accepted"],
+        [3, "started", false, true, "mutation_attempted"],
+        [4, "failed", true, false, "mutation_outcome_unknown"],
+      ],
+    );
+    assert.equal(events[0]?.idempotency_key_sha256, events[1]?.idempotency_key_sha256);
+    assert.equal(events[0]?.idempotency_key_sha256, events[2]?.idempotency_key_sha256);
+    assert.equal(events[2]?.idempotency_key_sha256, events[3]?.idempotency_key_sha256);
+    assert.equal(events[1]?.parent_event_id, events[0]?.event_id);
+    assert.equal(events[3]?.parent_event_id, events[2]?.event_id);
+    const serialized = JSON.stringify(events);
+    assert.doesNotMatch(serialized, /proof_nudge_comment|2026-07-14T12:00:00Z/);
+    assert.deepEqual(events[0]?.privacy.fields_dropped, ["body", "comments", "logs", "prompt"]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("proof reconciliation reuses the business idempotency identity without claiming a write", () => {
+  const root = realpathSync(mkdtempSync(tmpPrefix));
+  try {
+    const context = receiptContext(root, "4201");
+    const mutationIdentity = `bot_proof_comment:42:${"b".repeat(40)}:${"c".repeat(64)}`;
+    const event = recordProofMutationReconciliation({ context, mutationIdentity });
+    const expectedIdentity = proofMutationBusinessIdentityForTest({
+      lane: context.lane,
+      repository: context.repository,
+      number: context.number,
+      headSha: context.headSha,
+      mutationIdentity,
+    });
+
+    assert.equal(event?.action.status, "recovered");
+    assert.equal(event?.action.reason_code, "already_complete");
+    assert.equal(event?.action.mutation, false);
+    assert.equal(event?.attributes?.completion_reason, "mutation_reconciled");
+    assert.match(expectedIdentity.mutationIdentitySha256, /^[0-9a-f]{64}$/);
+    assert.doesNotMatch(JSON.stringify(event), /bot_proof_comment/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/proof-mutation-safety.test.ts
+++ b/test/proof-mutation-safety.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, realpathSync, rmSync } from "node:fs";
 import test from "node:test";
 
 import { readAllSpooledActionEvents } from "../dist/action-ledger.js";
+import { interruptOpenWorkflowActionEvents } from "../dist/action-ledger-runtime.js";
 import {
   createProofConversationActivityCursor,
   finishProofMutationReceipt,
@@ -279,5 +280,45 @@ test("bot proof label recovery receipts use concrete private mutation identities
     assert.doesNotMatch(identities.join("\n"), /bot_proof_label_state/);
   } finally {
     rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("failed and cancelled workflows terminalize open proof mutation receipts as unknown", () => {
+  for (const reasonCode of ["workflow_failed", "cancelled"] as const) {
+    const root = realpathSync(mkdtempSync(tmpPrefix));
+    try {
+      const context = receiptContext(root, reasonCode === "cancelled" ? "4206" : "4207");
+      const mutationIdentity = `proof_nudge_comment:42:${"b".repeat(40)}:2026-07-14T12:00:00Z`;
+      const attempt = startProofMutationReceipt({
+        context,
+        receiptIdentity: `${mutationIdentity}:request_attempt:1`,
+        mutationIdentity,
+        requestAttempt: 1,
+      });
+
+      assert.equal(
+        interruptOpenWorkflowActionEvents(root, {
+          env: context.env,
+          reasonCode,
+        }),
+        1,
+      );
+      const events = readAllSpooledActionEvents(root);
+      const start = events.find((event) => event.event_id === attempt.eventId);
+      const terminal = events.find(
+        (event) => event.attributes?.completion_reason === "mutation_outcome_unknown",
+      );
+      assert.ok(start);
+      assert.ok(terminal);
+      assert.equal(terminal.parent_event_id, attempt.eventId);
+      assert.equal(terminal.idempotency_key_sha256, start.idempotency_key_sha256);
+      assert.equal(terminal.action.mutation, true);
+      assert.equal(terminal.action.retryable, false);
+      assert.equal(terminal.action.reason_code, reasonCode);
+      assert.equal(terminal.action.status, reasonCode === "cancelled" ? "cancelled" : "failed");
+      assert.equal(interruptOpenWorkflowActionEvents(root, { env: context.env, reasonCode }), 0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   }
 });

--- a/test/proof-mutation-safety.test.ts
+++ b/test/proof-mutation-safety.test.ts
@@ -14,7 +14,10 @@ import {
   startProofMutationReceipt,
   type ProofMutationReceiptContext,
 } from "../dist/proof-mutation-safety.js";
-import { satisfiedBotProofLabelMutationIdentitiesForTest } from "../dist/clawsweeper.js";
+import {
+  runProofMutationPreRequestForTest,
+  satisfiedBotProofLabelMutationIdentitiesForTest,
+} from "../dist/clawsweeper.js";
 import { tmpPrefix } from "./helpers.ts";
 
 function ledgerEnv(runId: string): NodeJS.ProcessEnv {
@@ -266,6 +269,44 @@ test("a later workflow waits under the original unknown mutation idempotency key
     assert.equal(pending?.action.retryable, false);
     assert.notEqual(attempt.eventId, pending?.event_id);
     assert.doesNotMatch(JSON.stringify(events), /proof_nudge_comment|2026-07-14T12:00:00Z/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("proof mutation recovery state opens only after its durable request attempt", () => {
+  const root = realpathSync(mkdtempSync(tmpPrefix));
+  try {
+    const context = receiptContext(root, "4210");
+    let requestStarted = false;
+    assert.throws(
+      () =>
+        runProofMutationPreRequestForTest({
+          context,
+          beforeRequest: () => {
+            const events = readAllSpooledActionEvents(root);
+            assert.equal(events.length, 1);
+            assert.equal(events[0]?.action.status, "started");
+            throw new Error("crash before request");
+          },
+          operation: () => {
+            requestStarted = true;
+            return "accepted";
+          },
+        }),
+      /crash before request/,
+    );
+
+    assert.equal(requestStarted, false);
+    const events = readAllSpooledActionEvents(root);
+    assert.deepEqual(
+      events.map((event) => [event.action.status, event.action.mutation]),
+      [
+        ["started", false],
+        ["skipped", false],
+      ],
+    );
+    assert.equal(events.at(-1)?.attributes?.completion_reason, "mutation_rejected");
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/proof-nudge-policy.test.ts
+++ b/test/proof-nudge-policy.test.ts
@@ -1576,6 +1576,61 @@ test("bot proof revalidates before each label request and stops after head drift
   }
 });
 
+test("bot proof preserves head drift detected during mutation baseline hydration", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const reportPath = join(root, "bot-proof-report.json");
+    const statePath = join(root, "gh-state.json");
+    const mutationLogPath = join(root, "mutations.log");
+    mkdirSync(itemsDir, { recursive: true });
+    writeFileSync(
+      join(itemsDir, "42.md"),
+      proofNudgeReport({
+        author: "app/clawsweeper",
+        authorAssociation: "NONE",
+        headSha: "a".repeat(40),
+      }),
+    );
+
+    withMockGh(
+      root,
+      proofMutationGhMockScript({
+        statePath,
+        mutationLogPath,
+        bot: true,
+        driftHeadAtPullRead: 2,
+      }),
+      () => {
+        execFileSync(process.execPath, [
+          "dist/clawsweeper.js",
+          "bot-proof",
+          "--target-repo",
+          "openclaw/openclaw",
+          "--items-dir",
+          itemsDir,
+          "--item-numbers",
+          "42",
+          "--limit",
+          "1",
+          "--processed-limit",
+          "1",
+          "--report-path",
+          reportPath,
+          "--execute",
+        ]);
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    assert.equal(report[0].action, "skipped_changed_before_mutation");
+    assert.match(report[0].reason, /head changed while preparing/);
+    assert.equal(existsSync(mutationLogPath), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("bot proof revalidates draft state before its first mutation", () => {
   const root = mkdtempSync(tmpPrefix);
   try {

--- a/test/proof-nudge-policy.test.ts
+++ b/test/proof-nudge-policy.test.ts
@@ -151,6 +151,7 @@ function proofMutationGhMockScript(options: {
   initialComments?: unknown[];
   initialLabels?: string[];
   deleteCommentsAtConversationRead?: number;
+  hideUnknownPostComment?: boolean;
   failConversationReadsAfterUnknownPost?: boolean;
   itemNumbers?: number[];
 }): string {
@@ -236,7 +237,10 @@ const currentComments = () => {
         html_url: "https://github.com/openclaw/openclaw/pull/42#issuecomment-8"
       }]
     : [];
-  return [...state.comments, ...injected];
+  const visibleComments = config.hideUnknownPostComment && state.unknownPostAccepted
+    ? state.comments.filter((comment) => comment.id !== 99)
+    : state.comments;
+  return [...visibleComments, ...injected];
 };
 if (commandArgs[0] === "label" && commandArgs[1] === "create") {
   const label = commandArgs[2];
@@ -1250,6 +1254,72 @@ test("proof nudges preserve unknown outcomes when marker reconciliation cannot b
     const report = JSON.parse(readFileSync(reportPath, "utf8"));
     assert.equal(report[0].action, "proof_nudge_outcome_unknown");
     assert.equal(readFileSync(mutationLogPath, "utf8").trim(), "comment_post");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("proof nudges keep an unknown mutation cycle stable across workflow runs", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const firstReportPath = join(root, "proof-nudge-first.json");
+    const secondReportPath = join(root, "proof-nudge-second.json");
+    const mutationStateDir = join(root, "proof-nudge-mutations");
+    const statePath = join(root, "gh-state.json");
+    const mutationLogPath = join(root, "mutations.log");
+    mkdirSync(itemsDir, { recursive: true });
+    writeFileSync(join(itemsDir, "42.md"), proofNudgeReport({ headSha: "a".repeat(40) }));
+
+    const run = (reportPath: string) => {
+      execFileSync(process.execPath, [
+        "dist/clawsweeper.js",
+        "proof-nudges",
+        "--target-repo",
+        "openclaw/openclaw",
+        "--items-dir",
+        itemsDir,
+        "--item-numbers",
+        "42",
+        "--limit",
+        "1",
+        "--processed-limit",
+        "1",
+        "--min-age-days",
+        "0",
+        "--report-path",
+        reportPath,
+        "--mutation-state-dir",
+        mutationStateDir,
+        "--execute",
+      ]);
+    };
+
+    withMockGh(
+      root,
+      proofMutationGhMockScript({
+        statePath,
+        mutationLogPath,
+        postUnknown: true,
+        hideUnknownPostComment: true,
+      }),
+      () => {
+        run(firstReportPath);
+        run(secondReportPath);
+      },
+    );
+
+    const firstReport = JSON.parse(readFileSync(firstReportPath, "utf8"));
+    const secondReport = JSON.parse(readFileSync(secondReportPath, "utf8"));
+    assert.equal(firstReport[0].action, "proof_nudge_outcome_unknown");
+    assert.equal(secondReport[0].action, "proof_nudge_reconciliation_pending");
+    assert.match(secondReport[0].reason, /waiting for its exact marker/);
+    assert.equal(readFileSync(mutationLogPath, "utf8").trim(), "comment_post");
+    const cycle = JSON.parse(readFileSync(join(mutationStateDir, "42.json"), "utf8"));
+    assert.equal(cycle.repository, "openclaw/openclaw");
+    assert.equal(cycle.number, 42);
+    assert.equal(cycle.head_sha, "a".repeat(40));
+    assert.match(cycle.marker_timestamp, /^20\d{2}-/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/proof-nudge-policy.test.ts
+++ b/test/proof-nudge-policy.test.ts
@@ -19,6 +19,7 @@ import { item, tmpPrefix, withMockGh } from "./helpers.ts";
 
 function proofNudgeReport(overrides = {}) {
   const values = {
+    number: 42,
     labels: JSON.stringify(["triage: needs-real-behavior-proof"]),
     authorAssociation: "CONTRIBUTOR",
     author: "contributor",
@@ -41,7 +42,7 @@ function proofNudgeReport(overrides = {}) {
   };
   return `---
 repository: openclaw/openclaw
-number: 42
+number: ${values.number}
 type: pull_request
 title: Proof nudge sample
 author: ${values.author}
@@ -150,10 +151,12 @@ function proofMutationGhMockScript(options: {
   initialComments?: unknown[];
   initialLabels?: string[];
   failConversationReadsAfterUnknownPost?: boolean;
+  itemNumbers?: number[];
 }): string {
   return `#!/usr/bin/env node
 const fs = require("node:fs");
 const config = ${JSON.stringify(options)};
+const handledNumbers = new Set(config.itemNumbers || [42]);
 const oldHead = "${"a".repeat(40)}";
 const newHead = "${"b".repeat(40)}";
 const initialLabels = config.initialLabels || (config.bot
@@ -258,7 +261,9 @@ if (commandArgs[0] === "issue" && commandArgs[1] === "edit") {
   }
   output({ labels: state.labels });
 }
-if (path === "repos/openclaw/openclaw/issues/42") {
+const issueMatch = path.match(/^repos\\/openclaw\\/openclaw\\/issues\\/(\\d+)$/);
+if (issueMatch && handledNumbers.has(Number(issueMatch[1]))) {
+  const number = Number(issueMatch[1]);
   state.issueReads = (state.issueReads || 0) + 1;
   if (
     config.driftLabelAtIssueRead &&
@@ -270,9 +275,9 @@ if (path === "repos/openclaw/openclaw/issues/42") {
     state.driftLabelInjected = true;
   }
   output({
-    number: 42,
+    number,
     title: "Proof nudge sample",
-    html_url: "https://github.com/openclaw/openclaw/pull/42",
+    html_url: "https://github.com/openclaw/openclaw/pull/" + number,
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-02T00:00:00Z",
     state: config.closeAtIssueRead && state.issueReads >= config.closeAtIssueRead ? "closed" : "open",
@@ -284,7 +289,8 @@ if (path === "repos/openclaw/openclaw/issues/42") {
     pull_request: {}
   });
 }
-if (path === "repos/openclaw/openclaw/pulls/42") {
+const pullMatch = path.match(/^repos\\/openclaw\\/openclaw\\/pulls\\/(\\d+)$/);
+if (pullMatch && handledNumbers.has(Number(pullMatch[1]))) {
   const head = currentHead();
   output({
     draft: Boolean(config.draftAtPullRead && state.pullReads >= config.draftAtPullRead),
@@ -302,16 +308,23 @@ if (path === "repos/openclaw/openclaw/commits/" + oldHead ||
     committerDate: "2026-01-01T00:00:00Z"
   });
 }
-if (path.startsWith("repos/openclaw/openclaw/pulls/42/reviews")) {
+const reviewMatch = path.match(/^repos\\/openclaw\\/openclaw\\/pulls\\/(\\d+)\\/reviews/);
+if (reviewMatch && handledNumbers.has(Number(reviewMatch[1]))) {
   output(currentReviews());
 }
-if (path.startsWith("repos/openclaw/openclaw/pulls/42/comments")) {
+const reviewCommentMatch = path.match(
+  /^repos\\/openclaw\\/openclaw\\/pulls\\/(\\d+)\\/comments/,
+);
+if (reviewCommentMatch && handledNumbers.has(Number(reviewCommentMatch[1]))) {
   output([]);
 }
-if (path.startsWith("repos/openclaw/openclaw/issues/42/timeline")) {
+const timelineMatch = path.match(/^repos\\/openclaw\\/openclaw\\/issues\\/(\\d+)\\/timeline/);
+if (timelineMatch && handledNumbers.has(Number(timelineMatch[1]))) {
   output([]);
 }
-if (path.startsWith("repos/openclaw/openclaw/issues/42/comments") && method === "POST") {
+const issueCommentMatch = path.match(/^repos\\/openclaw\\/openclaw\\/issues\\/(\\d+)\\/comments/);
+if (issueCommentMatch && handledNumbers.has(Number(issueCommentMatch[1])) && method === "POST") {
+  const number = Number(issueCommentMatch[1]);
   const inputIndex = commandArgs.indexOf("--input");
   const payload = JSON.parse(fs.readFileSync(commandArgs[inputIndex + 1], "utf8"));
   const comment = {
@@ -321,7 +334,7 @@ if (path.startsWith("repos/openclaw/openclaw/issues/42/comments") && method === 
     body: payload.body,
     created_at: "2026-07-14T12:00:00Z",
     updated_at: "2026-07-14T12:00:00Z",
-    html_url: "https://github.com/openclaw/openclaw/pull/42#issuecomment-99"
+    html_url: "https://github.com/openclaw/openclaw/pull/" + number + "#issuecomment-99"
   };
   state.comments = state.comments.filter((entry) => entry.id !== 99);
   state.comments.push(comment);
@@ -334,7 +347,7 @@ if (path.startsWith("repos/openclaw/openclaw/issues/42/comments") && method === 
   }
   output({ id: comment.id, html_url: comment.html_url });
 }
-if (path.startsWith("repos/openclaw/openclaw/issues/42/comments")) {
+if (issueCommentMatch && handledNumbers.has(Number(issueCommentMatch[1]))) {
   output(currentComments());
 }
 if (path === "graphql") {
@@ -926,22 +939,23 @@ test("proof nudges block when the head changes after request-boundary activity h
   }
 });
 
-test("proof nudges revalidate open, unlocked, and unprotected state before posting", () => {
+test("proof nudges block final eligibility drift after activity hydration", () => {
   const scenarios = [
     {
       name: "protected label",
-      config: { driftLabelAtIssueRead: 4, driftLabel: "security" },
-      reason: /protected label: security/,
+      config: { driftLabelAtIssueRead: 3, driftLabel: "security" },
     },
     {
       name: "locked conversation",
-      config: { lockAtIssueRead: 4 },
-      reason: /conversation is locked/,
+      config: { lockAtIssueRead: 3 },
     },
     {
       name: "closed pull request",
-      config: { closeAtIssueRead: 4 },
-      reason: /state is closed/,
+      config: { closeAtIssueRead: 3 },
+    },
+    {
+      name: "proof override",
+      config: { driftLabelAtIssueRead: 3, driftLabel: "proof: override" },
     },
   ];
   for (const scenario of scenarios) {
@@ -990,7 +1004,7 @@ test("proof nudges revalidate open, unlocked, and unprotected state before posti
         "skipped_changed_before_mutation",
         `${scenario.name}: ${JSON.stringify(report)}`,
       );
-      assert.match(report[0].reason, scenario.reason);
+      assert.match(report[0].reason, /live PR eligibility changed while hydrating/);
       assert.equal(existsSync(mutationLogPath), false);
     } finally {
       rmSync(root, { recursive: true, force: true });
@@ -1041,6 +1055,79 @@ test("proof nudges reconcile a marker when GitHub accepts the comment before los
     const report = JSON.parse(readFileSync(reportPath, "utf8"));
     assert.equal(report[0].action, "proof_nudge_reconciled");
     assert.match(report[0].reason, /confirmed after an inconclusive response/);
+    assert.equal(readFileSync(mutationLogPath, "utf8").trim(), "comment_post");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("reconciled proof nudges do not consume the delivery limit", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const reportPath = join(root, "proof-nudge-report.json");
+    const statePath = join(root, "gh-state.json");
+    const mutationLogPath = join(root, "mutations.log");
+    const headSha = "a".repeat(40);
+    mkdirSync(itemsDir, { recursive: true });
+    writeFileSync(
+      join(itemsDir, "42.md"),
+      proofNudgeReport({ number: 42, headSha, reviewedAt: "2026-01-01T00:00:00Z" }),
+    );
+    writeFileSync(
+      join(itemsDir, "43.md"),
+      proofNudgeReport({ number: 43, headSha, reviewedAt: "2026-01-02T00:00:00Z" }),
+    );
+
+    withMockGh(
+      root,
+      proofMutationGhMockScript({
+        statePath,
+        mutationLogPath,
+        itemNumbers: [42, 43],
+        initialComments: [
+          {
+            id: 98,
+            user: { login: "clawsweeper[bot]" },
+            author_association: "NONE",
+            body: `<!-- clawsweeper-proof-nudge item="42" sha="${headSha}" at="2026-07-14T12:00:00.000Z" v="1" -->`,
+            created_at: "2026-07-14T12:00:00.000Z",
+            updated_at: "2026-07-14T12:00:00.000Z",
+            html_url: "https://github.com/openclaw/openclaw/pull/42#issuecomment-98",
+          },
+        ],
+      }),
+      () => {
+        execFileSync(process.execPath, [
+          "dist/clawsweeper.js",
+          "proof-nudges",
+          "--target-repo",
+          "openclaw/openclaw",
+          "--items-dir",
+          itemsDir,
+          "--item-numbers",
+          "42,43",
+          "--limit",
+          "1",
+          "--processed-limit",
+          "2",
+          "--min-age-days",
+          "0",
+          "--report-path",
+          reportPath,
+          "--execute",
+        ]);
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    assert.deepEqual(
+      report.map((entry: { number: number; action: string }) => [entry.number, entry.action]),
+      [
+        [42, "proof_nudge_reconciled"],
+        [43, "proof_nudge_posted"],
+      ],
+    );
     assert.equal(readFileSync(mutationLogPath, "utf8").trim(), "comment_post");
   } finally {
     rmSync(root, { recursive: true, force: true });
@@ -1370,7 +1457,7 @@ test("bot proof stops when labels change between its own requests", () => {
         statePath,
         mutationLogPath,
         bot: true,
-        driftLabelAtIssueRead: 6,
+        driftLabelAtIssueRead: 10,
         driftLabel: "status: 📣 needs proof",
       }),
       () => {

--- a/test/proof-nudge-policy.test.ts
+++ b/test/proof-nudge-policy.test.ts
@@ -152,6 +152,7 @@ function proofMutationGhMockScript(options: {
   initialComments?: unknown[];
   initialLabels?: string[];
   deleteCommentsAtConversationRead?: number;
+  revealCommentsAtConversationRead?: number;
   hideUnknownPostComment?: boolean;
   failConversationReadsAfterUnknownPost?: boolean;
   itemNumbers?: number[];
@@ -241,6 +242,12 @@ const currentComments = () => {
   const visibleComments = config.hideUnknownPostComment && state.unknownPostAccepted
     ? state.comments.filter((comment) => comment.id !== 99)
     : state.comments;
+  if (
+    config.revealCommentsAtConversationRead &&
+    state.conversationReads < config.revealCommentsAtConversationRead
+  ) {
+    return injected;
+  }
   return [...visibleComments, ...injected];
 };
 if (commandArgs[0] === "label" && commandArgs[1] === "create") {
@@ -1164,6 +1171,91 @@ test("reconciled proof nudges do not consume the delivery limit", () => {
       ],
     );
     assert.equal(readFileSync(mutationLogPath, "utf8").trim(), "comment_post");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("proof nudges apply hydrated same-head markers to cooldown eligibility", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const reportPath = join(root, "proof-nudge-report.json");
+    const mutationStateDir = join(root, "proof-nudge-mutations");
+    const statePath = join(root, "gh-state.json");
+    const mutationLogPath = join(root, "mutations.log");
+    const headSha = "a".repeat(40);
+    const markerTimestamp = "2026-07-14T12:00:00.000Z";
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(mutationStateDir, { recursive: true });
+    writeFileSync(join(itemsDir, "42.md"), proofNudgeReport({ headSha }));
+    writeFileSync(
+      join(mutationStateDir, "42.json"),
+      JSON.stringify({
+        schema_version: 1,
+        repository: "openclaw/openclaw",
+        number: 42,
+        head_sha: headSha,
+        marker_timestamp: markerTimestamp,
+        created_at: markerTimestamp,
+      }),
+    );
+
+    withMockGh(
+      root,
+      proofMutationGhMockScript({
+        statePath,
+        mutationLogPath,
+        revealCommentsAtConversationRead: 2,
+        initialComments: [
+          {
+            id: 98,
+            user: { login: "clawsweeper[bot]" },
+            author_association: "NONE",
+            body: renderProofNudgeCommentForTest({
+              number: 42,
+              author: "contributor",
+              headSha,
+              timestamp: markerTimestamp,
+            }),
+            created_at: markerTimestamp,
+            updated_at: markerTimestamp,
+            html_url: "https://github.com/openclaw/openclaw/pull/42#issuecomment-98",
+          },
+        ],
+      }),
+      () => {
+        execFileSync(process.execPath, [
+          "dist/clawsweeper.js",
+          "proof-nudges",
+          "--target-repo",
+          "openclaw/openclaw",
+          "--items-dir",
+          itemsDir,
+          "--item-numbers",
+          "42",
+          "--limit",
+          "1",
+          "--processed-limit",
+          "1",
+          "--min-age-days",
+          "0",
+          "--cooldown-days",
+          "36500",
+          "--report-path",
+          reportPath,
+          "--mutation-state-dir",
+          mutationStateDir,
+          "--execute",
+        ]);
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    assert.equal(report[0].action, "proof_nudge_reconciled");
+    assert.match(report[0].reason, /same-head proof nudge marker already exists/);
+    assert.equal(existsSync(mutationLogPath), false);
+    assert.equal(existsSync(join(mutationStateDir, "42.json")), false);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/proof-nudge-policy.test.ts
+++ b/test/proof-nudge-policy.test.ts
@@ -13,6 +13,7 @@ import {
   renderBotProofDecisionCommentForTest,
   renderProofNudgeCommentForTest,
   rotateProofLaneCandidatesForTest,
+  satisfiedBotProofLabelMutationIdentitiesForTest,
 } from "../dist/clawsweeper.js";
 import { item, tmpPrefix, withMockGh } from "./helpers.ts";
 
@@ -139,7 +140,14 @@ function proofMutationGhMockScript(options: {
   driftHeadAtPullRead?: number;
   driftReviewAtRead?: number;
   driftConversationAtRead?: number;
+  driftLabelAtIssueRead?: number;
+  driftLabel?: string;
+  lockAtIssueRead?: number;
+  closeAtIssueRead?: number;
+  draftAtPullRead?: number;
   postUnknown?: boolean;
+  unknownMutation?: string;
+  initialComments?: unknown[];
 }): string {
   return `#!/usr/bin/env node
 const fs = require("node:fs");
@@ -151,7 +159,14 @@ const initialLabels = config.bot
   : ["triage: needs-real-behavior-proof"];
 const state = fs.existsSync(config.statePath)
   ? JSON.parse(fs.readFileSync(config.statePath, "utf8"))
-  : { pullReads: 0, reviewReads: 0, conversationReads: 0, labels: initialLabels, comments: [] };
+  : {
+      pullReads: 0,
+      issueReads: 0,
+      reviewReads: 0,
+      conversationReads: 0,
+      labels: initialLabels,
+      comments: config.initialComments || []
+    };
 const save = () => fs.writeFileSync(config.statePath, JSON.stringify(state));
 const logMutation = (value) => fs.appendFileSync(config.mutationLogPath, value + "\\n");
 const output = (value) => {
@@ -169,6 +184,12 @@ const currentHead = () => {
   return config.driftHeadAtPullRead && state.pullReads >= config.driftHeadAtPullRead
     ? newHead
     : oldHead;
+};
+const unknownAfterMutation = (identity) => {
+  if (config.unknownMutation !== identity) return;
+  save();
+  console.error("HTTP 502: write acknowledgement unavailable");
+  process.exit(1);
 };
 const currentReviews = () => {
   state.reviewReads += 1;
@@ -201,6 +222,7 @@ const currentComments = () => {
 };
 if (commandArgs[0] === "label" && commandArgs[1] === "create") {
   logMutation("label_create:" + commandArgs[2]);
+  unknownAfterMutation("label_create:" + commandArgs[2]);
   output({ name: commandArgs[2] });
 }
 if (commandArgs[0] === "issue" && commandArgs[1] === "edit") {
@@ -210,23 +232,34 @@ if (commandArgs[0] === "issue" && commandArgs[1] === "edit") {
     const label = commandArgs[addIndex + 1];
     logMutation("label_add:" + label);
     if (!state.labels.includes(label)) state.labels.push(label);
+    unknownAfterMutation("label_add:" + label);
   }
   if (removeIndex >= 0) {
     const label = commandArgs[removeIndex + 1];
     logMutation("label_remove:" + label);
     state.labels = state.labels.filter((entry) => entry !== label);
+    unknownAfterMutation("label_remove:" + label);
   }
   output({ labels: state.labels });
 }
 if (path === "repos/openclaw/openclaw/issues/42") {
+  state.issueReads = (state.issueReads || 0) + 1;
+  if (
+    config.driftLabelAtIssueRead &&
+    state.issueReads >= config.driftLabelAtIssueRead &&
+    config.driftLabel &&
+    !state.labels.includes(config.driftLabel)
+  ) {
+    state.labels.push(config.driftLabel);
+  }
   output({
     number: 42,
     title: "Proof nudge sample",
     html_url: "https://github.com/openclaw/openclaw/pull/42",
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-02T00:00:00Z",
-    state: "open",
-    locked: false,
+    state: config.closeAtIssueRead && state.issueReads >= config.closeAtIssueRead ? "closed" : "open",
+    locked: Boolean(config.lockAtIssueRead && state.issueReads >= config.lockAtIssueRead),
     active_lock_reason: null,
     author_association: config.bot ? "NONE" : "CONTRIBUTOR",
     user: { login: config.bot ? "app/clawsweeper" : "contributor" },
@@ -235,9 +268,10 @@ if (path === "repos/openclaw/openclaw/issues/42") {
   });
 }
 if (path === "repos/openclaw/openclaw/pulls/42") {
+  const head = currentHead();
   output({
-    draft: false,
-    head: { sha: currentHead(), repo: { full_name: "openclaw/openclaw" } }
+    draft: Boolean(config.draftAtPullRead && state.pullReads >= config.draftAtPullRead),
+    head: { sha: head, repo: { full_name: "openclaw/openclaw" } }
   });
 }
 if (path === "repos/openclaw/openclaw/commits/" + oldHead ||
@@ -499,6 +533,17 @@ test("bot proof handling skips overrides, stale heads, drafts, and non-ClawSweep
       "skipped_policy_exempt",
     );
   }
+  assert.equal(
+    botProofEligibilityForTest({
+      item: proofNudgeItem({
+        author: "app/clawsweeper",
+        labels: ["triage: needs-real-behavior-proof", "security"],
+      }),
+      markdown: proofNudgeReport({ author: "app/clawsweeper" }),
+      headSha: "abc123def456",
+    }).action,
+    "skipped_protected_label",
+  );
   assert.equal(
     botProofEligibilityForTest({
       item: baseItem,
@@ -765,6 +810,127 @@ test("proof nudges block a comment when conversation activity changes at the req
   }
 });
 
+test("proof nudges block when the head changes after request-boundary activity hydration", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const reportPath = join(root, "proof-nudge-report.json");
+    const statePath = join(root, "gh-state.json");
+    const mutationLogPath = join(root, "mutations.log");
+    mkdirSync(itemsDir, { recursive: true });
+    writeFileSync(join(itemsDir, "42.md"), proofNudgeReport({ headSha: "a".repeat(40) }));
+
+    withMockGh(
+      root,
+      proofMutationGhMockScript({
+        statePath,
+        mutationLogPath,
+        driftHeadAtPullRead: 7,
+      }),
+      () => {
+        execFileSync(process.execPath, [
+          "dist/clawsweeper.js",
+          "proof-nudges",
+          "--target-repo",
+          "openclaw/openclaw",
+          "--items-dir",
+          itemsDir,
+          "--item-numbers",
+          "42",
+          "--limit",
+          "1",
+          "--processed-limit",
+          "1",
+          "--min-age-days",
+          "0",
+          "--report-path",
+          reportPath,
+          "--execute",
+        ]);
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    assert.equal(report[0].action, "skipped_changed_before_mutation");
+    assert.match(report[0].reason, /head changed while hydrating/);
+    assert.equal(existsSync(mutationLogPath), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("proof nudges revalidate open, unlocked, and unprotected state before posting", () => {
+  const scenarios = [
+    {
+      name: "protected label",
+      config: { driftLabelAtIssueRead: 4, driftLabel: "security" },
+      reason: /protected label: security/,
+    },
+    {
+      name: "locked conversation",
+      config: { lockAtIssueRead: 4 },
+      reason: /conversation is locked/,
+    },
+    {
+      name: "closed pull request",
+      config: { closeAtIssueRead: 4 },
+      reason: /state is closed/,
+    },
+  ];
+  for (const scenario of scenarios) {
+    const root = mkdtempSync(tmpPrefix);
+    try {
+      const itemsDir = join(root, "items");
+      const reportPath = join(root, "proof-nudge-report.json");
+      const statePath = join(root, "gh-state.json");
+      const mutationLogPath = join(root, "mutations.log");
+      mkdirSync(itemsDir, { recursive: true });
+      writeFileSync(join(itemsDir, "42.md"), proofNudgeReport({ headSha: "a".repeat(40) }));
+
+      withMockGh(
+        root,
+        proofMutationGhMockScript({
+          statePath,
+          mutationLogPath,
+          ...scenario.config,
+        }),
+        () => {
+          execFileSync(process.execPath, [
+            "dist/clawsweeper.js",
+            "proof-nudges",
+            "--target-repo",
+            "openclaw/openclaw",
+            "--items-dir",
+            itemsDir,
+            "--item-numbers",
+            "42",
+            "--limit",
+            "1",
+            "--processed-limit",
+            "1",
+            "--min-age-days",
+            "0",
+            "--report-path",
+            reportPath,
+            "--execute",
+          ]);
+        },
+      );
+
+      const report = JSON.parse(readFileSync(reportPath, "utf8"));
+      assert.equal(
+        report[0].action,
+        "skipped_changed_before_mutation",
+        `${scenario.name}: ${JSON.stringify(report)}`,
+      );
+      assert.match(report[0].reason, scenario.reason);
+      assert.equal(existsSync(mutationLogPath), false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
 test("proof nudges reconcile a marker when GitHub accepts the comment before losing the response", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
@@ -814,6 +980,74 @@ test("proof nudges reconcile a marker when GitHub accepts the comment before los
   }
 });
 
+test("proof nudges reconcile an expired same-head marker before posting the next nudge", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const reportPath = join(root, "proof-nudge-report.json");
+    const statePath = join(root, "gh-state.json");
+    const mutationLogPath = join(root, "mutations.log");
+    const headSha = "a".repeat(40);
+    const priorBody = renderProofNudgeCommentForTest({
+      number: 42,
+      author: "contributor",
+      headSha,
+      timestamp: "2026-01-01T00:00:00.000Z",
+    });
+    mkdirSync(itemsDir, { recursive: true });
+    writeFileSync(join(itemsDir, "42.md"), proofNudgeReport({ headSha }));
+
+    withMockGh(
+      root,
+      proofMutationGhMockScript({
+        statePath,
+        mutationLogPath,
+        initialComments: [
+          {
+            id: 71,
+            user: { login: "clawsweeper[bot]" },
+            author_association: "NONE",
+            body: priorBody,
+            created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:00:00Z",
+            html_url: "https://github.com/openclaw/openclaw/pull/42#issuecomment-71",
+          },
+        ],
+      }),
+      () => {
+        execFileSync(process.execPath, [
+          "dist/clawsweeper.js",
+          "proof-nudges",
+          "--target-repo",
+          "openclaw/openclaw",
+          "--items-dir",
+          itemsDir,
+          "--item-numbers",
+          "42",
+          "--limit",
+          "1",
+          "--processed-limit",
+          "1",
+          "--min-age-days",
+          "0",
+          "--cooldown-days",
+          "0",
+          "--report-path",
+          reportPath,
+          "--execute",
+        ]);
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    assert.equal(report[0].action, "proof_nudge_posted");
+    assert.match(report[0].reason, /prior same-head proof nudge receipt reconciled/);
+    assert.equal(readFileSync(mutationLogPath, "utf8").trim(), "comment_post");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("bot proof revalidates before each label request and stops after head drift", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
@@ -837,7 +1071,7 @@ test("bot proof revalidates before each label request and stops after head drift
         statePath,
         mutationLogPath,
         bot: true,
-        driftHeadAtPullRead: 6,
+        driftHeadAtPullRead: 10,
       }),
       () => {
         execFileSync(process.execPath, [
@@ -876,6 +1110,149 @@ test("bot proof revalidates before each label request and stops after head drift
       readFileSync(mutationLogPath, "utf8"),
       /label_add|label_remove|comment_post/,
     );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("bot proof revalidates draft state before its first mutation", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const reportPath = join(root, "bot-proof-report.json");
+    const statePath = join(root, "gh-state.json");
+    const mutationLogPath = join(root, "mutations.log");
+    mkdirSync(itemsDir, { recursive: true });
+    writeFileSync(
+      join(itemsDir, "42.md"),
+      proofNudgeReport({
+        author: "app/clawsweeper",
+        authorAssociation: "NONE",
+        headSha: "a".repeat(40),
+      }),
+    );
+
+    withMockGh(
+      root,
+      proofMutationGhMockScript({
+        statePath,
+        mutationLogPath,
+        bot: true,
+        draftAtPullRead: 6,
+      }),
+      () => {
+        execFileSync(process.execPath, [
+          "dist/clawsweeper.js",
+          "bot-proof",
+          "--target-repo",
+          "openclaw/openclaw",
+          "--items-dir",
+          itemsDir,
+          "--item-numbers",
+          "42",
+          "--limit",
+          "1",
+          "--processed-limit",
+          "1",
+          "--report-path",
+          reportPath,
+          "--execute",
+        ]);
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    assert.equal(report[0].action, "skipped_changed_before_mutation");
+    assert.match(report[0].reason, /pull request is draft/);
+    assert.equal(existsSync(mutationLogPath), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("bot proof reconciles an applied label removal under its concrete mutation identity", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const reportPath = join(root, "bot-proof-report.json");
+    const statePath = join(root, "gh-state.json");
+    const mutationLogPath = join(root, "mutations.log");
+    const headSha = "a".repeat(40);
+    const body = renderBotProofDecisionCommentForTest({
+      number: 42,
+      title: "Proof nudge sample",
+      headSha,
+      timestamp: "2026-01-01T00:00:00Z",
+      markdown: proofNudgeReport({
+        author: "app/clawsweeper",
+        authorAssociation: "NONE",
+        headSha,
+      }),
+    });
+    mkdirSync(itemsDir, { recursive: true });
+    writeFileSync(
+      join(itemsDir, "42.md"),
+      proofNudgeReport({
+        author: "app/clawsweeper",
+        authorAssociation: "NONE",
+        headSha,
+      }),
+    );
+
+    withMockGh(
+      root,
+      proofMutationGhMockScript({
+        statePath,
+        mutationLogPath,
+        bot: true,
+        unknownMutation: "label_remove:stale",
+        initialComments: [
+          {
+            id: 77,
+            user: { login: "clawsweeper[bot]" },
+            author_association: "NONE",
+            body,
+            created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:00:00Z",
+            html_url: "https://github.com/openclaw/openclaw/pull/42#issuecomment-77",
+          },
+        ],
+      }),
+      () => {
+        execFileSync(process.execPath, [
+          "dist/clawsweeper.js",
+          "bot-proof",
+          "--target-repo",
+          "openclaw/openclaw",
+          "--items-dir",
+          itemsDir,
+          "--item-numbers",
+          "42",
+          "--limit",
+          "1",
+          "--processed-limit",
+          "1",
+          "--report-path",
+          reportPath,
+          "--execute",
+        ]);
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    assert.equal(report[0].action, "bot_proof_decision_reconciled");
+    assert.deepEqual(readFileSync(mutationLogPath, "utf8").trim().split("\n"), [
+      "label_create:status: needs maintainer proof decision",
+      "label_add:status: needs maintainer proof decision",
+      "label_remove:stale",
+    ]);
+    const identities = satisfiedBotProofLabelMutationIdentitiesForTest(42, [
+      "triage: needs-real-behavior-proof",
+      "status: needs maintainer proof decision",
+    ]);
+    assert.ok(identities.includes("issue_label_remove:42:stale"));
+    assert.ok(identities.includes("issue_label_add:42:status: needs maintainer proof decision"));
+    assert.doesNotMatch(identities.join("\n"), /bot_proof_label_state/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/proof-nudge-policy.test.ts
+++ b/test/proof-nudge-policy.test.ts
@@ -248,9 +248,10 @@ if (path === "repos/openclaw/openclaw/issues/42") {
     config.driftLabelAtIssueRead &&
     state.issueReads >= config.driftLabelAtIssueRead &&
     config.driftLabel &&
-    !state.labels.includes(config.driftLabel)
+    !state.driftLabelInjected
   ) {
-    state.labels.push(config.driftLabel);
+    if (!state.labels.includes(config.driftLabel)) state.labels.push(config.driftLabel);
+    state.driftLabelInjected = true;
   }
   output({
     number: 42,
@@ -776,7 +777,7 @@ test("proof nudges block a comment when conversation activity changes at the req
       proofMutationGhMockScript({
         statePath,
         mutationLogPath,
-        driftConversationAtRead: 4,
+        driftConversationAtRead: 6,
       }),
       () => {
         execFileSync(process.execPath, [
@@ -804,6 +805,55 @@ test("proof nudges block a comment when conversation activity changes at the req
     const report = JSON.parse(readFileSync(reportPath, "utf8"));
     assert.equal(report[0].action, "skipped_changed_before_mutation");
     assert.match(report[0].reason, /conversation activity changed/);
+    assert.equal(existsSync(mutationLogPath), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("proof nudges use author activity hydrated into the mutation baseline", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const reportPath = join(root, "proof-nudge-report.json");
+    const statePath = join(root, "gh-state.json");
+    const mutationLogPath = join(root, "mutations.log");
+    mkdirSync(itemsDir, { recursive: true });
+    writeFileSync(join(itemsDir, "42.md"), proofNudgeReport({ headSha: "a".repeat(40) }));
+
+    withMockGh(
+      root,
+      proofMutationGhMockScript({
+        statePath,
+        mutationLogPath,
+        driftConversationAtRead: 2,
+      }),
+      () => {
+        execFileSync(process.execPath, [
+          "dist/clawsweeper.js",
+          "proof-nudges",
+          "--target-repo",
+          "openclaw/openclaw",
+          "--items-dir",
+          itemsDir,
+          "--item-numbers",
+          "42",
+          "--limit",
+          "1",
+          "--processed-limit",
+          "1",
+          "--min-age-days",
+          "5",
+          "--report-path",
+          reportPath,
+          "--execute",
+        ]);
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    assert.equal(report[0].action, "skipped_changed_before_mutation");
+    assert.match(report[0].reason, /author comment.*newer/);
     assert.equal(existsSync(mutationLogPath), false);
   } finally {
     rmSync(root, { recursive: true, force: true });
@@ -1165,6 +1215,126 @@ test("bot proof revalidates draft state before its first mutation", () => {
     assert.equal(report[0].action, "skipped_changed_before_mutation");
     assert.match(report[0].reason, /pull request is draft/);
     assert.equal(existsSync(mutationLogPath), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("bot proof plans label synchronization from its fresh mutation baseline", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const reportPath = join(root, "bot-proof-report.json");
+    const statePath = join(root, "gh-state.json");
+    const mutationLogPath = join(root, "mutations.log");
+    mkdirSync(itemsDir, { recursive: true });
+    writeFileSync(
+      join(itemsDir, "42.md"),
+      proofNudgeReport({
+        author: "app/clawsweeper",
+        authorAssociation: "NONE",
+        headSha: "a".repeat(40),
+      }),
+    );
+
+    withMockGh(
+      root,
+      proofMutationGhMockScript({
+        statePath,
+        mutationLogPath,
+        bot: true,
+        driftLabelAtIssueRead: 2,
+        driftLabel: "status: 📣 needs proof",
+      }),
+      () => {
+        execFileSync(process.execPath, [
+          "dist/clawsweeper.js",
+          "bot-proof",
+          "--target-repo",
+          "openclaw/openclaw",
+          "--items-dir",
+          itemsDir,
+          "--item-numbers",
+          "42",
+          "--limit",
+          "1",
+          "--processed-limit",
+          "1",
+          "--report-path",
+          reportPath,
+          "--execute",
+        ]);
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    assert.equal(report[0].action, "bot_proof_decision_posted");
+    assert.deepEqual(readFileSync(mutationLogPath, "utf8").trim().split("\n"), [
+      "label_create:status: needs maintainer proof decision",
+      "label_remove:status: 📣 needs proof",
+      "label_add:status: needs maintainer proof decision",
+      "label_remove:stale",
+      "comment_post",
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("bot proof stops when labels change between its own requests", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const reportPath = join(root, "bot-proof-report.json");
+    const statePath = join(root, "gh-state.json");
+    const mutationLogPath = join(root, "mutations.log");
+    mkdirSync(itemsDir, { recursive: true });
+    writeFileSync(
+      join(itemsDir, "42.md"),
+      proofNudgeReport({
+        author: "app/clawsweeper",
+        authorAssociation: "NONE",
+        headSha: "a".repeat(40),
+      }),
+    );
+
+    withMockGh(
+      root,
+      proofMutationGhMockScript({
+        statePath,
+        mutationLogPath,
+        bot: true,
+        driftLabelAtIssueRead: 6,
+        driftLabel: "status: 📣 needs proof",
+      }),
+      () => {
+        execFileSync(process.execPath, [
+          "dist/clawsweeper.js",
+          "bot-proof",
+          "--target-repo",
+          "openclaw/openclaw",
+          "--items-dir",
+          itemsDir,
+          "--item-numbers",
+          "42",
+          "--limit",
+          "1",
+          "--processed-limit",
+          "1",
+          "--report-path",
+          reportPath,
+          "--execute",
+        ]);
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    assert.equal(report[0].action, "skipped_changed_before_mutation");
+    assert.match(report[0].reason, /live labels changed/);
+    assert.equal(
+      readFileSync(mutationLogPath, "utf8").trim(),
+      "label_create:status: needs maintainer proof decision",
+    );
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/proof-nudge-policy.test.ts
+++ b/test/proof-nudge-policy.test.ts
@@ -147,6 +147,7 @@ function proofMutationGhMockScript(options: {
   closeAtIssueRead?: number;
   draftAtPullRead?: number;
   postUnknown?: boolean;
+  patchUnknown?: boolean;
   unknownMutation?: string;
   initialComments?: unknown[];
   initialLabels?: string[];
@@ -334,6 +335,29 @@ if (timelineMatch && handledNumbers.has(Number(timelineMatch[1]))) {
   output([]);
 }
 const issueCommentMatch = path.match(/^repos\\/openclaw\\/openclaw\\/issues\\/(\\d+)\\/comments/);
+const issueCommentPatchMatch = path.match(
+  /^repos\\/openclaw\\/openclaw\\/issues\\/comments\\/(\\d+)$/,
+);
+if (issueCommentPatchMatch && method === "PATCH") {
+  const commentId = Number(issueCommentPatchMatch[1]);
+  const inputIndex = commandArgs.indexOf("--input");
+  const payload = JSON.parse(fs.readFileSync(commandArgs[inputIndex + 1], "utf8"));
+  const comment = state.comments.find((entry) => entry.id === commentId);
+  if (!comment) {
+    save();
+    console.error("Not Found");
+    process.exit(1);
+  }
+  logMutation("comment_patch");
+  if (config.patchUnknown) {
+    save();
+    console.error("HTTP 502: write acknowledgement unavailable");
+    process.exit(1);
+  }
+  comment.body = payload.body;
+  comment.updated_at = "2026-07-14T12:00:00Z";
+  output({ id: comment.id, html_url: comment.html_url });
+}
 if (issueCommentMatch && handledNumbers.has(Number(issueCommentMatch[1])) && method === "POST") {
   const number = Number(issueCommentMatch[1]);
   const inputIndex = commandArgs.indexOf("--input");
@@ -1943,6 +1967,171 @@ test("bot proof reconciles an unknown label create when the retry proves it alre
       "label_remove:stale",
       "comment_post",
     ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("bot proof does not replay an unknown comment POST across workflow runs", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const firstReportPath = join(root, "bot-proof-first.json");
+    const secondReportPath = join(root, "bot-proof-second.json");
+    const mutationStateDir = join(root, "bot-proof-mutations");
+    const statePath = join(root, "gh-state.json");
+    const mutationLogPath = join(root, "mutations.log");
+    mkdirSync(itemsDir, { recursive: true });
+    writeFileSync(
+      join(itemsDir, "42.md"),
+      proofNudgeReport({
+        author: "app/clawsweeper",
+        authorAssociation: "NONE",
+        headSha: "a".repeat(40),
+      }),
+    );
+    const run = (reportPath: string) => {
+      execFileSync(process.execPath, [
+        "dist/clawsweeper.js",
+        "bot-proof",
+        "--target-repo",
+        "openclaw/openclaw",
+        "--items-dir",
+        itemsDir,
+        "--item-numbers",
+        "42",
+        "--limit",
+        "1",
+        "--processed-limit",
+        "1",
+        "--report-path",
+        reportPath,
+        "--mutation-state-dir",
+        mutationStateDir,
+        "--execute",
+      ]);
+    };
+
+    withMockGh(
+      root,
+      proofMutationGhMockScript({
+        statePath,
+        mutationLogPath,
+        bot: true,
+        postUnknown: true,
+        hideUnknownPostComment: true,
+        initialLabels: [
+          "triage: needs-real-behavior-proof",
+          "status: needs maintainer proof decision",
+        ],
+      }),
+      () => {
+        run(firstReportPath);
+        run(secondReportPath);
+      },
+    );
+
+    const firstReport = JSON.parse(readFileSync(firstReportPath, "utf8"));
+    const secondReport = JSON.parse(readFileSync(secondReportPath, "utf8"));
+    assert.equal(firstReport[0].action, "bot_proof_mutation_outcome_unknown");
+    assert.equal(secondReport[0].action, "bot_proof_reconciliation_pending");
+    assert.match(secondReport[0].reason, /waiting for its exact body/);
+    assert.equal(readFileSync(mutationLogPath, "utf8").trim(), "comment_post");
+    const cycle = JSON.parse(readFileSync(join(mutationStateDir, "42.json"), "utf8"));
+    assert.equal(cycle.repository, "openclaw/openclaw");
+    assert.equal(cycle.number, 42);
+    assert.equal(cycle.head_sha, "a".repeat(40));
+    assert.match(cycle.comment_body_sha256, /^[0-9a-f]{64}$/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("bot proof does not replay an unknown comment PATCH across workflow runs", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const firstReportPath = join(root, "bot-proof-first.json");
+    const secondReportPath = join(root, "bot-proof-second.json");
+    const mutationStateDir = join(root, "bot-proof-mutations");
+    const statePath = join(root, "gh-state.json");
+    const mutationLogPath = join(root, "mutations.log");
+    const headSha = "a".repeat(40);
+    const markdown = proofNudgeReport({
+      author: "app/clawsweeper",
+      authorAssociation: "NONE",
+      headSha,
+    });
+    const priorBody = `${renderBotProofDecisionCommentForTest({
+      number: 42,
+      title: "Proof nudge sample",
+      headSha,
+      timestamp: "2026-01-01T00:00:00Z",
+      markdown,
+    })}\n\nLegacy decision detail.`;
+    mkdirSync(itemsDir, { recursive: true });
+    writeFileSync(join(itemsDir, "42.md"), markdown);
+    const run = (reportPath: string) => {
+      execFileSync(process.execPath, [
+        "dist/clawsweeper.js",
+        "bot-proof",
+        "--target-repo",
+        "openclaw/openclaw",
+        "--items-dir",
+        itemsDir,
+        "--item-numbers",
+        "42",
+        "--limit",
+        "1",
+        "--processed-limit",
+        "1",
+        "--report-path",
+        reportPath,
+        "--mutation-state-dir",
+        mutationStateDir,
+        "--execute",
+      ]);
+    };
+
+    withMockGh(
+      root,
+      proofMutationGhMockScript({
+        statePath,
+        mutationLogPath,
+        bot: true,
+        patchUnknown: true,
+        initialLabels: [
+          "triage: needs-real-behavior-proof",
+          "status: needs maintainer proof decision",
+        ],
+        initialComments: [
+          {
+            id: 77,
+            user: { login: "clawsweeper[bot]" },
+            author_association: "NONE",
+            body: priorBody,
+            created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:00:00Z",
+            html_url: "https://github.com/openclaw/openclaw/pull/42#issuecomment-77",
+          },
+        ],
+      }),
+      () => {
+        run(firstReportPath);
+        run(secondReportPath);
+      },
+    );
+
+    const firstReport = JSON.parse(readFileSync(firstReportPath, "utf8"));
+    const secondReport = JSON.parse(readFileSync(secondReportPath, "utf8"));
+    assert.equal(firstReport[0].action, "bot_proof_mutation_outcome_unknown");
+    assert.equal(secondReport[0].action, "bot_proof_reconciliation_pending");
+    assert.match(secondReport[0].reason, /waiting for its exact body/);
+    assert.equal(readFileSync(mutationLogPath, "utf8").trim(), "comment_patch");
+    assert.match(
+      JSON.parse(readFileSync(join(mutationStateDir, "42.json"), "utf8")).comment_body_sha256,
+      /^[0-9a-f]{64}$/,
+    );
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/proof-nudge-policy.test.ts
+++ b/test/proof-nudge-policy.test.ts
@@ -148,15 +148,17 @@ function proofMutationGhMockScript(options: {
   postUnknown?: boolean;
   unknownMutation?: string;
   initialComments?: unknown[];
+  initialLabels?: string[];
+  failConversationReadsAfterUnknownPost?: boolean;
 }): string {
   return `#!/usr/bin/env node
 const fs = require("node:fs");
 const config = ${JSON.stringify(options)};
 const oldHead = "${"a".repeat(40)}";
 const newHead = "${"b".repeat(40)}";
-const initialLabels = config.bot
+const initialLabels = config.initialLabels || (config.bot
   ? ["triage: needs-real-behavior-proof", "stale"]
-  : ["triage: needs-real-behavior-proof"];
+  : ["triage: needs-real-behavior-proof"]);
 const state = fs.existsSync(config.statePath)
   ? JSON.parse(fs.readFileSync(config.statePath, "utf8"))
   : {
@@ -165,6 +167,7 @@ const state = fs.existsSync(config.statePath)
       reviewReads: 0,
       conversationReads: 0,
       labels: initialLabels,
+      createdLabels: [],
       comments: config.initialComments || []
     };
 const save = () => fs.writeFileSync(config.statePath, JSON.stringify(state));
@@ -206,6 +209,11 @@ const currentReviews = () => {
 };
 const currentComments = () => {
   state.conversationReads += 1;
+  if (config.failConversationReadsAfterUnknownPost && state.unknownPostAccepted) {
+    save();
+    console.error("fatal: simulated reconciliation read failure");
+    process.exit(1);
+  }
   const injected = config.driftConversationAtRead &&
       state.conversationReads >= config.driftConversationAtRead
     ? [{
@@ -221,9 +229,17 @@ const currentComments = () => {
   return [...state.comments, ...injected];
 };
 if (commandArgs[0] === "label" && commandArgs[1] === "create") {
-  logMutation("label_create:" + commandArgs[2]);
-  unknownAfterMutation("label_create:" + commandArgs[2]);
-  output({ name: commandArgs[2] });
+  const label = commandArgs[2];
+  state.createdLabels = state.createdLabels || [];
+  logMutation("label_create:" + label);
+  if (state.createdLabels.includes(label)) {
+    save();
+    console.error("label already exists");
+    process.exit(1);
+  }
+  state.createdLabels.push(label);
+  unknownAfterMutation("label_create:" + label);
+  output({ name: label });
 }
 if (commandArgs[0] === "issue" && commandArgs[1] === "edit") {
   const addIndex = commandArgs.indexOf("--add-label");
@@ -310,6 +326,7 @@ if (path.startsWith("repos/openclaw/openclaw/issues/42/comments") && method === 
   state.comments = state.comments.filter((entry) => entry.id !== 99);
   state.comments.push(comment);
   logMutation("comment_post");
+  state.unknownPostAccepted = config.postUnknown === true;
   save();
   if (config.postUnknown) {
     console.error("HTTP 502: write acknowledgement unavailable");
@@ -1030,6 +1047,55 @@ test("proof nudges reconcile a marker when GitHub accepts the comment before los
   }
 });
 
+test("proof nudges preserve unknown outcomes when marker reconciliation cannot be read", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const reportPath = join(root, "proof-nudge-report.json");
+    const statePath = join(root, "gh-state.json");
+    const mutationLogPath = join(root, "mutations.log");
+    mkdirSync(itemsDir, { recursive: true });
+    writeFileSync(join(itemsDir, "42.md"), proofNudgeReport({ headSha: "a".repeat(40) }));
+
+    withMockGh(
+      root,
+      proofMutationGhMockScript({
+        statePath,
+        mutationLogPath,
+        postUnknown: true,
+        failConversationReadsAfterUnknownPost: true,
+      }),
+      () => {
+        execFileSync(process.execPath, [
+          "dist/clawsweeper.js",
+          "proof-nudges",
+          "--target-repo",
+          "openclaw/openclaw",
+          "--items-dir",
+          itemsDir,
+          "--item-numbers",
+          "42",
+          "--limit",
+          "1",
+          "--processed-limit",
+          "1",
+          "--min-age-days",
+          "0",
+          "--report-path",
+          reportPath,
+          "--execute",
+        ]);
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    assert.equal(report[0].action, "proof_nudge_outcome_unknown");
+    assert.equal(readFileSync(mutationLogPath, "utf8").trim(), "comment_post");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("proof nudges reconcile an expired same-head marker before posting the next nudge", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
@@ -1340,6 +1406,90 @@ test("bot proof stops when labels change between its own requests", () => {
   }
 });
 
+test("bot proof ignores unowned markers before selecting its upsert target", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const reportPath = join(root, "bot-proof-report.json");
+    const statePath = join(root, "gh-state.json");
+    const mutationLogPath = join(root, "mutations.log");
+    const headSha = "a".repeat(40);
+    const markdown = proofNudgeReport({
+      author: "app/clawsweeper",
+      authorAssociation: "NONE",
+      headSha,
+    });
+    const body = renderBotProofDecisionCommentForTest({
+      number: 42,
+      title: "Proof nudge sample",
+      headSha,
+      timestamp: "2026-01-01T00:00:00Z",
+      markdown,
+    });
+    mkdirSync(itemsDir, { recursive: true });
+    writeFileSync(join(itemsDir, "42.md"), markdown);
+
+    withMockGh(
+      root,
+      proofMutationGhMockScript({
+        statePath,
+        mutationLogPath,
+        bot: true,
+        initialLabels: [
+          "triage: needs-real-behavior-proof",
+          "status: needs maintainer proof decision",
+        ],
+        initialComments: [
+          {
+            id: 70,
+            user: { login: "contributor" },
+            author_association: "CONTRIBUTOR",
+            body,
+            created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:00:00Z",
+            html_url: "https://github.com/openclaw/openclaw/pull/42#issuecomment-70",
+          },
+          {
+            id: 71,
+            user: { login: "clawsweeper[bot]" },
+            author_association: "NONE",
+            body,
+            created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:00:00Z",
+            html_url: "https://github.com/openclaw/openclaw/pull/42#issuecomment-71",
+          },
+        ],
+      }),
+      () => {
+        execFileSync(process.execPath, [
+          "dist/clawsweeper.js",
+          "bot-proof",
+          "--target-repo",
+          "openclaw/openclaw",
+          "--items-dir",
+          itemsDir,
+          "--item-numbers",
+          "42",
+          "--limit",
+          "1",
+          "--processed-limit",
+          "1",
+          "--report-path",
+          reportPath,
+          "--execute",
+        ]);
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    assert.equal(report[0].action, "bot_proof_decision_reconciled");
+    assert.equal(report[0].url, "https://github.com/openclaw/openclaw/pull/42#issuecomment-71");
+    assert.equal(existsSync(mutationLogPath), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("bot proof reconciles an applied label removal under its concrete mutation identity", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
@@ -1423,6 +1573,71 @@ test("bot proof reconciles an applied label removal under its concrete mutation 
     assert.ok(identities.includes("issue_label_remove:42:stale"));
     assert.ok(identities.includes("issue_label_add:42:status: needs maintainer proof decision"));
     assert.doesNotMatch(identities.join("\n"), /bot_proof_label_state/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("bot proof reconciles an unknown label create when the retry proves it already exists", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const firstReportPath = join(root, "bot-proof-first.json");
+    const secondReportPath = join(root, "bot-proof-second.json");
+    const statePath = join(root, "gh-state.json");
+    const mutationLogPath = join(root, "mutations.log");
+    mkdirSync(itemsDir, { recursive: true });
+    writeFileSync(
+      join(itemsDir, "42.md"),
+      proofNudgeReport({
+        author: "app/clawsweeper",
+        authorAssociation: "NONE",
+        headSha: "a".repeat(40),
+      }),
+    );
+    const script = proofMutationGhMockScript({
+      statePath,
+      mutationLogPath,
+      bot: true,
+      unknownMutation: "label_create:status: needs maintainer proof decision",
+    });
+    const run = (reportPath: string) => {
+      execFileSync(process.execPath, [
+        "dist/clawsweeper.js",
+        "bot-proof",
+        "--target-repo",
+        "openclaw/openclaw",
+        "--items-dir",
+        itemsDir,
+        "--item-numbers",
+        "42",
+        "--limit",
+        "1",
+        "--processed-limit",
+        "1",
+        "--report-path",
+        reportPath,
+        "--execute",
+      ]);
+    };
+
+    withMockGh(root, script, () => {
+      run(firstReportPath);
+      run(secondReportPath);
+    });
+
+    const firstReport = JSON.parse(readFileSync(firstReportPath, "utf8"));
+    const secondReport = JSON.parse(readFileSync(secondReportPath, "utf8"));
+    assert.equal(firstReport[0].action, "bot_proof_mutation_outcome_unknown");
+    assert.equal(secondReport[0].action, "bot_proof_decision_posted");
+    assert.match(secondReport[0].reason, /reconciled 1 completed label operation receipt/);
+    assert.deepEqual(readFileSync(mutationLogPath, "utf8").trim().split("\n"), [
+      "label_create:status: needs maintainer proof decision",
+      "label_create:status: needs maintainer proof decision",
+      "label_add:status: needs maintainer proof decision",
+      "label_remove:stale",
+      "comment_post",
+    ]);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/proof-nudge-policy.test.ts
+++ b/test/proof-nudge-policy.test.ts
@@ -132,6 +132,179 @@ process.exit(1);
 `;
 }
 
+function proofMutationGhMockScript(options: {
+  statePath: string;
+  mutationLogPath: string;
+  bot?: boolean;
+  driftHeadAtPullRead?: number;
+  driftReviewAtRead?: number;
+  driftConversationAtRead?: number;
+  postUnknown?: boolean;
+}): string {
+  return `#!/usr/bin/env node
+const fs = require("node:fs");
+const config = ${JSON.stringify(options)};
+const oldHead = "${"a".repeat(40)}";
+const newHead = "${"b".repeat(40)}";
+const initialLabels = config.bot
+  ? ["triage: needs-real-behavior-proof", "stale"]
+  : ["triage: needs-real-behavior-proof"];
+const state = fs.existsSync(config.statePath)
+  ? JSON.parse(fs.readFileSync(config.statePath, "utf8"))
+  : { pullReads: 0, reviewReads: 0, conversationReads: 0, labels: initialLabels, comments: [] };
+const save = () => fs.writeFileSync(config.statePath, JSON.stringify(state));
+const logMutation = (value) => fs.appendFileSync(config.mutationLogPath, value + "\\n");
+const output = (value) => {
+  save();
+  console.log(JSON.stringify(value));
+  process.exit(0);
+};
+const args = process.argv.slice(2);
+const commandArgs = args[0] === "--repo" ? args.slice(2) : args;
+const path = commandArgs[1] || "";
+const methodIndex = commandArgs.indexOf("--method");
+const method = methodIndex >= 0 ? commandArgs[methodIndex + 1] : "GET";
+const currentHead = () => {
+  state.pullReads += 1;
+  return config.driftHeadAtPullRead && state.pullReads >= config.driftHeadAtPullRead
+    ? newHead
+    : oldHead;
+};
+const currentReviews = () => {
+  state.reviewReads += 1;
+  return config.driftReviewAtRead && state.reviewReads >= config.driftReviewAtRead
+    ? [{
+        id: 9,
+        user: { login: "reviewer" },
+        state: "COMMENTED",
+        body: "new review activity",
+        submitted_at: "2026-07-14T12:00:00Z",
+        commit_id: oldHead
+      }]
+    : [];
+};
+const currentComments = () => {
+  state.conversationReads += 1;
+  const injected = config.driftConversationAtRead &&
+      state.conversationReads >= config.driftConversationAtRead
+    ? [{
+        id: 8,
+        user: { login: "contributor" },
+        author_association: "CONTRIBUTOR",
+        body: "new proof conversation activity",
+        created_at: "2026-07-14T12:00:00Z",
+        updated_at: "2026-07-14T12:00:00Z",
+        html_url: "https://github.com/openclaw/openclaw/pull/42#issuecomment-8"
+      }]
+    : [];
+  return [...state.comments, ...injected];
+};
+if (commandArgs[0] === "label" && commandArgs[1] === "create") {
+  logMutation("label_create:" + commandArgs[2]);
+  output({ name: commandArgs[2] });
+}
+if (commandArgs[0] === "issue" && commandArgs[1] === "edit") {
+  const addIndex = commandArgs.indexOf("--add-label");
+  const removeIndex = commandArgs.indexOf("--remove-label");
+  if (addIndex >= 0) {
+    const label = commandArgs[addIndex + 1];
+    logMutation("label_add:" + label);
+    if (!state.labels.includes(label)) state.labels.push(label);
+  }
+  if (removeIndex >= 0) {
+    const label = commandArgs[removeIndex + 1];
+    logMutation("label_remove:" + label);
+    state.labels = state.labels.filter((entry) => entry !== label);
+  }
+  output({ labels: state.labels });
+}
+if (path === "repos/openclaw/openclaw/issues/42") {
+  output({
+    number: 42,
+    title: "Proof nudge sample",
+    html_url: "https://github.com/openclaw/openclaw/pull/42",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-02T00:00:00Z",
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: config.bot ? "NONE" : "CONTRIBUTOR",
+    user: { login: config.bot ? "app/clawsweeper" : "contributor" },
+    labels: state.labels,
+    pull_request: {}
+  });
+}
+if (path === "repos/openclaw/openclaw/pulls/42") {
+  output({
+    draft: false,
+    head: { sha: currentHead(), repo: { full_name: "openclaw/openclaw" } }
+  });
+}
+if (path === "repos/openclaw/openclaw/commits/" + oldHead ||
+    path === "repos/openclaw/openclaw/commits/" + newHead) {
+  output({
+    commit: {
+      author: { date: "2026-01-01T00:00:00Z" },
+      committer: { date: "2026-01-01T00:00:00Z" }
+    },
+    authorDate: "2026-01-01T00:00:00Z",
+    committerDate: "2026-01-01T00:00:00Z"
+  });
+}
+if (path.startsWith("repos/openclaw/openclaw/pulls/42/reviews")) {
+  output(currentReviews());
+}
+if (path.startsWith("repos/openclaw/openclaw/pulls/42/comments")) {
+  output([]);
+}
+if (path.startsWith("repos/openclaw/openclaw/issues/42/timeline")) {
+  output([]);
+}
+if (path.startsWith("repos/openclaw/openclaw/issues/42/comments") && method === "POST") {
+  const inputIndex = commandArgs.indexOf("--input");
+  const payload = JSON.parse(fs.readFileSync(commandArgs[inputIndex + 1], "utf8"));
+  const comment = {
+    id: 99,
+    user: { login: "clawsweeper[bot]" },
+    author_association: "NONE",
+    body: payload.body,
+    created_at: "2026-07-14T12:00:00Z",
+    updated_at: "2026-07-14T12:00:00Z",
+    html_url: "https://github.com/openclaw/openclaw/pull/42#issuecomment-99"
+  };
+  state.comments = state.comments.filter((entry) => entry.id !== 99);
+  state.comments.push(comment);
+  logMutation("comment_post");
+  save();
+  if (config.postUnknown) {
+    console.error("HTTP 502: write acknowledgement unavailable");
+    process.exit(1);
+  }
+  output({ id: comment.id, html_url: comment.html_url });
+}
+if (path.startsWith("repos/openclaw/openclaw/issues/42/comments")) {
+  output(currentComments());
+}
+if (path === "graphql") {
+  output({
+    data: {
+      repository: {
+        pullRequest: {
+          reviewThreads: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: []
+          }
+        }
+      }
+    }
+  });
+}
+save();
+console.error("unexpected gh args: " + args.join(" "));
+process.exit(1);
+`;
+}
+
 test("bot proof candidate scan prioritizes ClawSweeper proof blockers", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
@@ -538,6 +711,171 @@ test("targeted proof lane execute scans ignore cursor paths", () => {
         assert.equal(existsSync(cursorPath), false);
       }
     });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("proof nudges block a comment when conversation activity changes at the request boundary", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const reportPath = join(root, "proof-nudge-report.json");
+    const statePath = join(root, "gh-state.json");
+    const mutationLogPath = join(root, "mutations.log");
+    mkdirSync(itemsDir, { recursive: true });
+    writeFileSync(join(itemsDir, "42.md"), proofNudgeReport({ headSha: "a".repeat(40) }));
+
+    withMockGh(
+      root,
+      proofMutationGhMockScript({
+        statePath,
+        mutationLogPath,
+        driftConversationAtRead: 4,
+      }),
+      () => {
+        execFileSync(process.execPath, [
+          "dist/clawsweeper.js",
+          "proof-nudges",
+          "--target-repo",
+          "openclaw/openclaw",
+          "--items-dir",
+          itemsDir,
+          "--item-numbers",
+          "42",
+          "--limit",
+          "1",
+          "--processed-limit",
+          "1",
+          "--min-age-days",
+          "0",
+          "--report-path",
+          reportPath,
+          "--execute",
+        ]);
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    assert.equal(report[0].action, "skipped_changed_before_mutation");
+    assert.match(report[0].reason, /conversation activity changed/);
+    assert.equal(existsSync(mutationLogPath), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("proof nudges reconcile a marker when GitHub accepts the comment before losing the response", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const reportPath = join(root, "proof-nudge-report.json");
+    const statePath = join(root, "gh-state.json");
+    const mutationLogPath = join(root, "mutations.log");
+    mkdirSync(itemsDir, { recursive: true });
+    writeFileSync(join(itemsDir, "42.md"), proofNudgeReport({ headSha: "a".repeat(40) }));
+
+    withMockGh(
+      root,
+      proofMutationGhMockScript({
+        statePath,
+        mutationLogPath,
+        postUnknown: true,
+      }),
+      () => {
+        execFileSync(process.execPath, [
+          "dist/clawsweeper.js",
+          "proof-nudges",
+          "--target-repo",
+          "openclaw/openclaw",
+          "--items-dir",
+          itemsDir,
+          "--item-numbers",
+          "42",
+          "--limit",
+          "1",
+          "--processed-limit",
+          "1",
+          "--min-age-days",
+          "0",
+          "--report-path",
+          reportPath,
+          "--execute",
+        ]);
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    assert.equal(report[0].action, "proof_nudge_reconciled");
+    assert.match(report[0].reason, /confirmed after an inconclusive response/);
+    assert.equal(readFileSync(mutationLogPath, "utf8").trim(), "comment_post");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("bot proof revalidates before each label request and stops after head drift", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const reportPath = join(root, "bot-proof-report.json");
+    const statePath = join(root, "gh-state.json");
+    const mutationLogPath = join(root, "mutations.log");
+    mkdirSync(itemsDir, { recursive: true });
+    writeFileSync(
+      join(itemsDir, "42.md"),
+      proofNudgeReport({
+        author: "app/clawsweeper",
+        authorAssociation: "NONE",
+        headSha: "a".repeat(40),
+      }),
+    );
+
+    withMockGh(
+      root,
+      proofMutationGhMockScript({
+        statePath,
+        mutationLogPath,
+        bot: true,
+        driftHeadAtPullRead: 6,
+      }),
+      () => {
+        execFileSync(process.execPath, [
+          "dist/clawsweeper.js",
+          "bot-proof",
+          "--target-repo",
+          "openclaw/openclaw",
+          "--items-dir",
+          itemsDir,
+          "--item-numbers",
+          "42",
+          "--limit",
+          "1",
+          "--processed-limit",
+          "1",
+          "--report-path",
+          reportPath,
+          "--execute",
+        ]);
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    assert.equal(
+      report[0].action,
+      "skipped_changed_before_mutation",
+      JSON.stringify({
+        report,
+        mutations: existsSync(mutationLogPath) ? readFileSync(mutationLogPath, "utf8") : "",
+        state: JSON.parse(readFileSync(statePath, "utf8")),
+      }),
+    );
+    assert.match(report[0].reason, /head changed/);
+    assert.match(readFileSync(mutationLogPath, "utf8"), /^label_create:/);
+    assert.doesNotMatch(
+      readFileSync(mutationLogPath, "utf8"),
+      /label_add|label_remove|comment_post/,
+    );
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/proof-nudge-policy.test.ts
+++ b/test/proof-nudge-policy.test.ts
@@ -150,6 +150,7 @@ function proofMutationGhMockScript(options: {
   unknownMutation?: string;
   initialComments?: unknown[];
   initialLabels?: string[];
+  deleteCommentsAtConversationRead?: number;
   failConversationReadsAfterUnknownPost?: boolean;
   itemNumbers?: number[];
 }): string {
@@ -216,6 +217,12 @@ const currentComments = () => {
     save();
     console.error("fatal: simulated reconciliation read failure");
     process.exit(1);
+  }
+  if (
+    config.deleteCommentsAtConversationRead &&
+    state.conversationReads >= config.deleteCommentsAtConversationRead
+  ) {
+    state.comments = [];
   }
   const injected = config.driftConversationAtRead &&
       state.conversationReads >= config.driftConversationAtRead
@@ -1134,6 +1141,71 @@ test("reconciled proof nudges do not consume the delivery limit", () => {
   }
 });
 
+test("proof nudges do not reconcile a marker deleted during mutation hydration", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const reportPath = join(root, "proof-nudge-report.json");
+    const statePath = join(root, "gh-state.json");
+    const mutationLogPath = join(root, "mutations.log");
+    const headSha = "a".repeat(40);
+    mkdirSync(itemsDir, { recursive: true });
+    writeFileSync(join(itemsDir, "42.md"), proofNudgeReport({ headSha }));
+
+    withMockGh(
+      root,
+      proofMutationGhMockScript({
+        statePath,
+        mutationLogPath,
+        deleteCommentsAtConversationRead: 2,
+        initialComments: [
+          {
+            id: 98,
+            user: { login: "clawsweeper[bot]" },
+            author_association: "NONE",
+            body: renderProofNudgeCommentForTest({
+              number: 42,
+              author: "contributor",
+              headSha,
+              timestamp: "2026-01-01T00:00:00.000Z",
+            }),
+            created_at: "2026-01-01T00:00:00.000Z",
+            updated_at: "2026-01-01T00:00:00.000Z",
+            html_url: "https://github.com/openclaw/openclaw/pull/42#issuecomment-98",
+          },
+        ],
+      }),
+      () => {
+        execFileSync(process.execPath, [
+          "dist/clawsweeper.js",
+          "proof-nudges",
+          "--target-repo",
+          "openclaw/openclaw",
+          "--items-dir",
+          itemsDir,
+          "--item-numbers",
+          "42",
+          "--limit",
+          "1",
+          "--processed-limit",
+          "1",
+          "--min-age-days",
+          "0",
+          "--report-path",
+          reportPath,
+          "--execute",
+        ]);
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    assert.equal(report[0].action, "proof_nudge_posted");
+    assert.equal(readFileSync(mutationLogPath, "utf8").trim(), "comment_post");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("proof nudges preserve unknown outcomes when marker reconciliation cannot be read", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
@@ -1571,6 +1643,82 @@ test("bot proof ignores unowned markers before selecting its upsert target", () 
     const report = JSON.parse(readFileSync(reportPath, "utf8"));
     assert.equal(report[0].action, "bot_proof_decision_reconciled");
     assert.equal(report[0].url, "https://github.com/openclaw/openclaw/pull/42#issuecomment-71");
+    assert.equal(existsSync(mutationLogPath), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("bot proof revalidates a matching comment before no-op reconciliation", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const reportPath = join(root, "bot-proof-report.json");
+    const statePath = join(root, "gh-state.json");
+    const mutationLogPath = join(root, "mutations.log");
+    const headSha = "a".repeat(40);
+    const markdown = proofNudgeReport({
+      author: "app/clawsweeper",
+      authorAssociation: "NONE",
+      headSha,
+    });
+    const body = renderBotProofDecisionCommentForTest({
+      number: 42,
+      title: "Proof nudge sample",
+      headSha,
+      timestamp: "2026-01-01T00:00:00Z",
+      markdown,
+    });
+    mkdirSync(itemsDir, { recursive: true });
+    writeFileSync(join(itemsDir, "42.md"), markdown);
+
+    withMockGh(
+      root,
+      proofMutationGhMockScript({
+        statePath,
+        mutationLogPath,
+        bot: true,
+        driftHeadAtPullRead: 6,
+        initialLabels: [
+          "triage: needs-real-behavior-proof",
+          "status: needs maintainer proof decision",
+        ],
+        initialComments: [
+          {
+            id: 71,
+            user: { login: "clawsweeper[bot]" },
+            author_association: "NONE",
+            body,
+            created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:00:00Z",
+            html_url: "https://github.com/openclaw/openclaw/pull/42#issuecomment-71",
+          },
+        ],
+      }),
+      () => {
+        execFileSync(process.execPath, [
+          "dist/clawsweeper.js",
+          "bot-proof",
+          "--target-repo",
+          "openclaw/openclaw",
+          "--items-dir",
+          itemsDir,
+          "--item-numbers",
+          "42",
+          "--limit",
+          "1",
+          "--processed-limit",
+          "1",
+          "--report-path",
+          reportPath,
+          "--execute",
+        ]);
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    assert.equal(report[0].action, "skipped_changed_before_mutation");
+    assert.match(report[0].reason, /head changed/);
     assert.equal(existsSync(mutationLogPath), false);
   } finally {
     rmSync(root, { recursive: true, force: true });

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1677,7 +1677,8 @@ test("proof nudge workflow is manual-first and scheduled behind repo vars", () =
   assert.match(job, /--processed-limit "\$PROOF_NUDGES_PROCESSED_LIMIT"/);
   assert.match(job, /--cursor-path "results\/proof-nudge-cursors\/\$\{target_slug\}\.json"/);
   assert.match(job, /--cursor-path "results\/bot-proof-cursors\/\$\{target_slug\}\.json"/);
-  assert.match(job, /--mutation-state-dir "\$mutation_state_path"/);
+  assert.match(job, /--mutation-state-dir "\$proof_mutation_state_path"/);
+  assert.match(job, /--mutation-state-dir "\$bot_mutation_state_path"/);
   assert.match(job, /pnpm run proof-nudges/);
   assert.match(job, /vars\.CLAWSWEEPER_PROOF_NUDGES_LIMIT/);
   assert.match(job, /vars\.CLAWSWEEPER_PROOF_NUDGES_PROCESSED_LIMIT/);
@@ -1685,11 +1686,13 @@ test("proof nudge workflow is manual-first and scheduled behind repo vars", () =
   assert.match(job, /results\/proof-nudge-cursors/);
   assert.match(job, /results\/bot-proof-cursors/);
   assert.match(job, /results\/proof-nudge-mutations/);
+  assert.match(job, /results\/bot-proof-mutations/);
 });
 
 test("proof nudge workflow defers exact executed-lane cursors until receipts are durable", () => {
   const workflow = readFileSync(".github/workflows/proof-nudges.yml", "utf8");
   const job = workflow.slice(workflow.indexOf("  proof-nudges:"), workflow.length);
+  const uploadLedger = job.indexOf("- name: Upload finalized proof handling action ledger");
   const publishLedger = job.indexOf("- name: Publish immutable proof handling action ledger");
   const publishMutationState = job.indexOf("- name: Publish proof mutation recovery state");
   const publishCursors = job.indexOf("- name: Publish proof handling cursors");
@@ -1705,18 +1708,29 @@ test("proof nudge workflow defers exact executed-lane cursors until receipts are
   );
   assert.match(
     job.slice(publishMutationState, publishCursors),
-    /always\(\)[\s\S]*--path "results\/proof-nudge-mutations\/\$\{target_slug\}"/,
+    /always\(\)[\s\S]*--path "results\/proof-nudge-mutations\/\$\{target_slug\}"[\s\S]*--path "results\/bot-proof-mutations\/\$\{target_slug\}"/,
   );
+  const mutationStateBlock = job.slice(publishMutationState, publishCursors);
+  assert.match(mutationStateBlock, /steps\.setup-state\.outcome == 'success'/);
+  assert.match(mutationStateBlock, /steps\.setup-pnpm\.outcome == 'success'/);
+  assert.match(mutationStateBlock, /steps\.run-proof-nudges\.outcome != 'skipped'/);
+  assert.match(mutationStateBlock, /continue-on-error: true/);
   assert.doesNotMatch(
-    job.slice(publishMutationState, publishCursors),
-    /steps\.run-proof-nudges\.outcome == 'success'/,
+    mutationStateBlock,
+    /steps\.(?:finalize-action-ledger|upload-finalized-ledger|publish-action-ledger)\.outcome/,
   );
-  assert.match(job.slice(publishMutationState, publishCursors), /id: publish-mutation-state/);
-  assert.match(job.slice(publishCursors), /steps\.publish-mutation-state\.outcome == 'success'/);
+  assert.match(mutationStateBlock, /id: publish-mutation-state/);
+  const cursorBlock = job.slice(publishCursors);
+  assert.match(cursorBlock, /steps\.run-proof-nudges\.outcome == 'success'/);
+  assert.match(cursorBlock, /steps\.finalize-action-ledger\.outcome == 'success'/);
+  assert.match(cursorBlock, /steps\.upload-finalized-ledger\.outcome == 'success'/);
+  assert.match(cursorBlock, /steps\.publish-action-ledger\.outcome == 'success'/);
+  assert.match(cursorBlock, /steps\.publish-mutation-state\.outcome == 'success'/);
   assert.match(
-    job.slice(publishCursors),
+    cursorBlock,
     /while IFS= read -r cursor_path[\s\S]*cursor_publish_args\+=\(--path "\$cursor_path"\)[\s\S]*repair:publish-main/,
   );
+  assert.ok(uploadLedger >= 0 && uploadLedger < publishMutationState);
   assert.doesNotMatch(job, /printf '%s\\n' "results\/(?:proof-nudge|bot-proof)-cursors/);
 });
 

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1677,25 +1677,40 @@ test("proof nudge workflow is manual-first and scheduled behind repo vars", () =
   assert.match(job, /--processed-limit "\$PROOF_NUDGES_PROCESSED_LIMIT"/);
   assert.match(job, /--cursor-path "results\/proof-nudge-cursors\/\$\{target_slug\}\.json"/);
   assert.match(job, /--cursor-path "results\/bot-proof-cursors\/\$\{target_slug\}\.json"/);
+  assert.match(job, /--mutation-state-dir "\$mutation_state_path"/);
   assert.match(job, /pnpm run proof-nudges/);
   assert.match(job, /vars\.CLAWSWEEPER_PROOF_NUDGES_LIMIT/);
   assert.match(job, /vars\.CLAWSWEEPER_PROOF_NUDGES_PROCESSED_LIMIT/);
   assert.match(job, /repair:publish-main/);
   assert.match(job, /results\/proof-nudge-cursors/);
   assert.match(job, /results\/bot-proof-cursors/);
+  assert.match(job, /results\/proof-nudge-mutations/);
 });
 
 test("proof nudge workflow defers exact executed-lane cursors until receipts are durable", () => {
   const workflow = readFileSync(".github/workflows/proof-nudges.yml", "utf8");
   const job = workflow.slice(workflow.indexOf("  proof-nudges:"), workflow.length);
   const publishLedger = job.indexOf("- name: Publish immutable proof handling action ledger");
+  const publishMutationState = job.indexOf("- name: Publish proof mutation recovery state");
   const publishCursors = job.indexOf("- name: Publish proof handling cursors");
   assert.match(job, /proof_cursor_path="results\/proof-nudge-cursors\/\$\{target_slug\}\.json"/);
   assert.match(job, /bot_cursor_path="results\/bot-proof-cursors\/\$\{target_slug\}\.json"/);
   assert.match(job, /if \[ "\$PROOF_NUDGES_EXECUTE" = "true" \] && \[ -f "\$proof_cursor_path" \]/);
   assert.match(job, /if \[ "\$BOT_PROOF_EXECUTE" = "true" \] && \[ -f "\$bot_cursor_path" \]/);
   assert.match(job, /printf '%s\\n' "\$(?:proof|bot)_cursor_path" >> "\$cursor_paths_file"/);
-  assert.ok(publishLedger >= 0 && publishLedger < publishCursors);
+  assert.ok(
+    publishLedger >= 0 &&
+      publishLedger < publishMutationState &&
+      publishMutationState < publishCursors,
+  );
+  assert.match(
+    job.slice(publishMutationState, publishCursors),
+    /always\(\)[\s\S]*--path "results\/proof-nudge-mutations\/\$\{target_slug\}"/,
+  );
+  assert.doesNotMatch(
+    job.slice(publishMutationState, publishCursors),
+    /steps\.run-proof-nudges\.outcome == 'success'/,
+  );
   assert.match(
     job.slice(publishCursors),
     /while IFS= read -r cursor_path[\s\S]*cursor_publish_args\+=\(--path "\$cursor_path"\)[\s\S]*repair:publish-main/,

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1711,6 +1711,8 @@ test("proof nudge workflow defers exact executed-lane cursors until receipts are
     job.slice(publishMutationState, publishCursors),
     /steps\.run-proof-nudges\.outcome == 'success'/,
   );
+  assert.match(job.slice(publishMutationState, publishCursors), /id: publish-mutation-state/);
+  assert.match(job.slice(publishCursors), /steps\.publish-mutation-state\.outcome == 'success'/);
   assert.match(
     job.slice(publishCursors),
     /while IFS= read -r cursor_path[\s\S]*cursor_publish_args\+=\(--path "\$cursor_path"\)[\s\S]*repair:publish-main/,

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1685,18 +1685,22 @@ test("proof nudge workflow is manual-first and scheduled behind repo vars", () =
   assert.match(job, /results\/bot-proof-cursors/);
 });
 
-test("proof nudge workflow publishes exact cursor files only for executed lanes", () => {
+test("proof nudge workflow defers exact executed-lane cursors until receipts are durable", () => {
   const workflow = readFileSync(".github/workflows/proof-nudges.yml", "utf8");
   const job = workflow.slice(workflow.indexOf("  proof-nudges:"), workflow.length);
+  const publishLedger = job.indexOf("- name: Publish immutable proof handling action ledger");
+  const publishCursors = job.indexOf("- name: Publish proof handling cursors");
   assert.match(job, /proof_cursor_path="results\/proof-nudge-cursors\/\$\{target_slug\}\.json"/);
   assert.match(job, /bot_cursor_path="results\/bot-proof-cursors\/\$\{target_slug\}\.json"/);
   assert.match(job, /if \[ "\$PROOF_NUDGES_EXECUTE" = "true" \] && \[ -f "\$proof_cursor_path" \]/);
   assert.match(job, /if \[ "\$BOT_PROOF_EXECUTE" = "true" \] && \[ -f "\$bot_cursor_path" \]/);
-  assert.match(job, /cursor_publish_args\+=\(--path "\$(?:proof|bot)_cursor_path"\)/);
-  assert.doesNotMatch(
-    job,
-    /cursor_publish_args\+=\(--path results\/(?:proof-nudge|bot-proof)-cursors\)/,
+  assert.match(job, /printf '%s\\n' "\$(?:proof|bot)_cursor_path" >> "\$cursor_paths_file"/);
+  assert.ok(publishLedger >= 0 && publishLedger < publishCursors);
+  assert.match(
+    job.slice(publishCursors),
+    /while IFS= read -r cursor_path[\s\S]*cursor_publish_args\+=\(--path "\$cursor_path"\)[\s\S]*repair:publish-main/,
   );
+  assert.doesNotMatch(job, /printf '%s\\n' "results\/(?:proof-nudge|bot-proof)-cursors/);
 });
 
 test(


### PR DESCRIPTION
Depends on https://github.com/openclaw/clawsweeper/pull/557

## What Problem This Solves

Proof nudge and proof decision comments or labels could be published after the reviewed PR state changed, could advance a durable cursor before their receipt ledger was finalized, or could consume delivery capacity while merely reconciling an already-delivered nudge.

## Why This Change Was Made

Every proof mutation now revalidates the exact head and bounded review, comment, thread, and eligibility state before opening a mutation receipt. The activity hydration performs a final target eligibility reread, covering state, labels, lock state, author authority, title policy, and item kind. Immutable attempt, outcome, and reconciliation receipts use stable idempotency identities, preserve unknown-after-request outcomes, and let later runs reconcile crash-after-publication without retrying blindly.

The workflow now treats cursor progress as the commit record: run proof work, finalize receipts, upload the finalized ledger, publish the immutable ledger, and only then publish exact cursor files. A failure at any earlier boundary leaves the cursor unchanged. Reconciled proof nudges no longer consume the real delivery limit. Receipts store hashes and structured status only, never raw logs, prompts, comment bodies, or review bodies.

## User Impact

Operators can trust that proof automation stops on stale authority, exposes inconclusive writes explicitly, preserves finalized mutation evidence before cursor progress, and does not starve new contributor nudges behind reconciliation bookkeeping.

## Evidence

- Node v26.5.0
- `tsc -p tsconfig.json`
- `tsc -p tsconfig.repair.json`
- Proof action-ledger, mutation-safety, proof-policy, and workflow tests: 159/159 passed
- Final eligibility drift regressions cover protected labels, lock state, closure, and proof override after activity hydration
- Two-PR quota regression proves a reconciled marker does not consume the only delivery slot
- Focused type-aware lint and configured format checks passed
- Pinned actionlint v1.7.12 passed for `.github/workflows/proof-nudges.yml`
- `git diff --check`
- The direct full gate reached one stale workflow assertion from the old immediate-cursor contract; that assertion was replaced and the affected 106-test workflow suite then passed

- Reconciliation regressions prove deleted same-head markers do not suppress delivery and matching bot-proof comments are revalidated against current head, activity, eligibility, and labels before no-op receipt reconciliation
- Final focused proof policy suite: 35/35 passed

- Hosted CI exposed a stale source-structure assertion after freshness validation moved into the shared reconciliation fence; the regression now verifies helper validation before runner receipt creation and both proof suites pass 44/44

- Unknown-outcome recovery regression: two workflow runs, one POST, one persisted marker timestamp, one business idempotency hash\n- Focused proof mutation/policy/workflow suites: 109/109 passed\n- TypeScript builds, type-aware lint, configured formatting, pinned actionlint v1.7.12, and `git diff --check` passed\n\n- Exact review on `d1776e9566` found a cursor/recovery-state causal gap; `c3ea67efec` gives the state publication step an ID and gates cursor publication on its successful outcome\n- Focused workflow suite after the fix: 63/63 passed; pinned actionlint v1.7.12 and formatting passed\n\n- Exact review on `c3ea67efec` found recovery state was persisted before the request receipt opened; `5474976a84` moves persistence into the post-receipt pre-request hook and classifies hook failure as a rejected non-mutation\n- Crash-before-request regression proves the durable start receipt exists before state persistence and the GitHub operation is not called on hook failure\n- Focused proof mutation/policy/workflow suites after the fix: 110/110 passed\n\n- CodeQL then exposed the inherited polynomial hyphen-trimming regex through the new receipt path; `d297fcfabe` replaces it with a linear edge scan and adds a 200,000-hyphen regression\n- Targeted lifecycle/normalization tests, focused proof suites (110/110), both TypeScript builds, lint, format, actionlint, and diff checks pass\n\nExact local ClawSweeper rereview completed on `d297fcfabe`: patch correct, confidence `0.93` / high, no findings, and security review cleared.

- Exact local ClawSweeper rereview completed on `d6f6895f94`: patch correct, confidence `0.93` / high, no findings, security review cleared.