### PR TITLE
fix(state): keep publishers converging during concurrent updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,9 +58,10 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
-- Serialized generated-state publishers through a versioned, protocol-bounded
-  remote lease with composable workflow deadlines, bounded stale-owner
-  recovery, one rebuild retry, and remote blob verification.
+- Serialized generated-state publishers through lightweight detached,
+  versioned, protocol-bounded remote leases with composable workflow
+  deadlines, bounded stale-owner recovery, deadline-bounded multi-race
+  convergence, and remote blob verification.
 - Preserved finalized GitHub activity dispatch receipts as a replayable artifact
   before state publication, while keeping direct publication independent of the
   recovery-copy upload and automatically replaying failed, cancelled, or

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -166,6 +166,12 @@ export function spawnGit(args: readonly string[], options: GitRunOptions = {}): 
   });
   if (child.error) {
     if ("code" in child.error && child.error.code === "ETIMEDOUT") {
+      const deadlineAtMs = activeGitPublishMetrics?.deadlineAtMs;
+      if (deadlineAtMs !== null && deadlineAtMs !== undefined && Date.now() >= deadlineAtMs) {
+        throw new Error(
+          `State publication deadline exceeded while running git ${safeGitDisplayAction(args[0])}`,
+        );
+      }
       const error = new Error(
         `git ${safeGitDisplayAction(args[0])} timed out after ${timeout ?? 0}ms during state publication`,
       );
@@ -597,40 +603,36 @@ function publishLeasedCommit(options: {
   sourceCommit: string;
   rebaseStrategy: RebaseStrategy;
 }): PublishResult {
-  const expectedCommit = runGit(["rev-parse", "HEAD"], { quiet: true }).trim();
-  if (pushLeasedHead(options.remote, options.branch, options.lease)) {
-    verifyRemotePublishedPaths(expectedCommit, options.remote, options.branch, options.paths);
-    return "committed";
-  }
-  if (remotePublishedPathsMatch(expectedCommit, options.remote, options.branch, options.paths)) {
-    console.log("Leased publish push was ambiguous but the expected blobs are remote");
-    adoptVerifiedRemoteHead(options.remote, options.branch);
-    return "committed";
-  }
+  for (let attempt = 1; ; attempt += 1) {
+    const expectedCommit = runGit(["rev-parse", "HEAD"], { quiet: true }).trim();
+    const pushed = pushLeasedHead(options.remote, options.branch, options.lease);
+    if (remotePublishedPathsMatch(expectedCommit, options.remote, options.branch, options.paths)) {
+      if (!pushed) {
+        console.log("Leased publish push was ambiguous but the expected blobs are remote");
+      }
+      adoptVerifiedRemoteHead(options.remote, options.branch);
+      return "committed";
+    }
 
-  console.log(`Leased publish lost one unexpected ${options.branch} race; rebuilding once`);
-  const rebuildResult = rebuildPublishCommit({
-    remote: options.remote,
-    branch: options.branch,
-    message: options.message,
-    paths: options.paths,
-    sourceCommit: options.sourceCommit,
-    rebaseStrategy: options.rebaseStrategy,
-  });
-  if (rebuildResult === "unchanged") {
-    verifyRemotePublishedPaths("HEAD", options.remote, options.branch, options.paths);
-    return "unchanged";
+    console.log(
+      `Leased publish ${pushed ? "was superseded after an accepted push" : `lost an unexpected ${options.branch} race`}; rebuilding attempt=${attempt}`,
+    );
+    const rebuildResult = rebuildPublishCommit({
+      remote: options.remote,
+      branch: options.branch,
+      message: options.message,
+      paths: options.paths,
+      sourceCommit: options.sourceCommit,
+      rebaseStrategy: options.rebaseStrategy,
+    });
+    if (rebuildResult === "unchanged") {
+      const rebuiltCommit = runGit(["rev-parse", "HEAD"], { quiet: true }).trim();
+      if (remotePublishedPathsMatch(rebuiltCommit, options.remote, options.branch, options.paths)) {
+        adoptVerifiedRemoteHead(options.remote, options.branch);
+        return "unchanged";
+      }
+    }
   }
-
-  const rebuiltCommit = runGit(["rev-parse", "HEAD"], { quiet: true }).trim();
-  if (
-    !pushLeasedHead(options.remote, options.branch, options.lease) &&
-    !remotePublishedPathsMatch(rebuiltCommit, options.remote, options.branch, options.paths)
-  ) {
-    throw new Error("Leased state publish failed after its single rebuild/push retry");
-  }
-  verifyRemotePublishedPaths(rebuiltCommit, options.remote, options.branch, options.paths);
-  return "committed";
 }
 
 function publishLeasedReconciliationHead(options: {
@@ -641,39 +643,34 @@ function publishLeasedReconciliationHead(options: {
   reconciliationSourceCommit?: string;
   reconciliationTupleKeys?: ReadonlySet<string>;
 }): void {
-  const expectedCommit = runGit(["rev-parse", "HEAD"], { quiet: true }).trim();
-  if (pushLeasedHead(options.remote, options.branch, options.lease)) {
-    verifyRemotePublishExpectation(expectedCommit, options.remote, options.branch, options.paths);
-    return;
-  }
-  if (
-    remotePublishExpectationMatches(expectedCommit, options.remote, options.branch, options.paths)
-  ) {
-    console.log("Leased reconciliation push was ambiguous but the expected state is remote");
-    adoptVerifiedRemoteHead(options.remote, options.branch);
-    return;
-  }
+  for (let attempt = 1; ; attempt += 1) {
+    const expectedCommit = runGit(["rev-parse", "HEAD"], { quiet: true }).trim();
+    const pushed = pushLeasedHead(options.remote, options.branch, options.lease);
+    if (
+      remotePublishExpectationMatches(expectedCommit, options.remote, options.branch, options.paths)
+    ) {
+      if (!pushed) {
+        console.log("Leased reconciliation push was ambiguous but the expected state is remote");
+      }
+      adoptVerifiedRemoteHead(options.remote, options.branch);
+      return;
+    }
 
-  console.log(`Leased reconciliation lost one unexpected ${options.branch} race; rebuilding once`);
-  runGit(["fetch", options.remote, options.branch]);
-  const remoteRef = `${options.remote}/${options.branch}`;
-  if (
-    !rebuildReconciliationCommit(
-      remoteRef,
-      options.reconciliationSourceCommit,
-      options.reconciliationTupleKeys,
-    )
-  ) {
-    throw new Error("Failed to rebuild leased reconciliation publish");
+    console.log(
+      `Leased reconciliation ${pushed ? "was superseded after an accepted push" : `lost an unexpected ${options.branch} race`}; rebuilding attempt=${attempt}`,
+    );
+    runGit(["fetch", options.remote, options.branch]);
+    const remoteRef = `${options.remote}/${options.branch}`;
+    if (
+      !rebuildReconciliationCommit(
+        remoteRef,
+        options.reconciliationSourceCommit,
+        options.reconciliationTupleKeys,
+      )
+    ) {
+      throw new Error("Failed to rebuild leased reconciliation publish");
+    }
   }
-  const rebuiltCommit = runGit(["rev-parse", "HEAD"], { quiet: true }).trim();
-  if (
-    !pushLeasedHead(options.remote, options.branch, options.lease) &&
-    !remotePublishExpectationMatches(rebuiltCommit, options.remote, options.branch, options.paths)
-  ) {
-    throw new Error("Leased reconciliation failed after its single rebuild/push retry");
-  }
-  verifyRemotePublishExpectation(rebuiltCommit, options.remote, options.branch, options.paths);
 }
 
 function pushLeasedHead(remote: string, branch: string, lease: StatePublishLease): boolean {
@@ -714,18 +711,6 @@ function remotePublishedPathsMatch(
   if (result.status === 0) return true;
   if (result.status === 1) return false;
   throw new Error(result.stderr.trim() || `Failed to verify expected blobs on ${remote}/${branch}`);
-}
-
-function verifyRemotePublishExpectation(
-  expectedCommit: string,
-  remote: string,
-  branch: string,
-  paths?: readonly string[],
-): void {
-  if (!remotePublishExpectationMatches(expectedCommit, remote, branch, paths)) {
-    throw new Error(`Remote ${remote}/${branch} failed expected-state verification`);
-  }
-  adoptVerifiedRemoteHead(remote, branch);
 }
 
 function remotePublishExpectationMatches(
@@ -1283,10 +1268,8 @@ function createStatePublishLeaseCommit(options: {
   expiresAtMs: number;
   ttlMs: number;
 }): string {
-  const [parent, tree] = runGit(["rev-parse", "HEAD", "HEAD^{tree}"], { quiet: true })
-    .trim()
-    .split(/\r?\n/);
-  if (!parent || !tree) throw new Error("Failed to resolve state publish lease commit objects");
+  const tree = runGit(["mktree"], { input: "", quiet: true }).trim();
+  if (!tree) throw new Error("Failed to create the state publish lease tree");
   const message = [
     "ClawSweeper state publish lease",
     "",
@@ -1298,7 +1281,7 @@ function createStatePublishLeaseCommit(options: {
     `expires_at: ${new Date(options.expiresAtMs).toISOString()}`,
     "",
   ].join("\n");
-  return runGit(["commit-tree", tree, "-p", parent], {
+  return runGit(["commit-tree", tree], {
     input: message,
     quiet: true,
   }).trim();

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -1527,6 +1527,62 @@ test("publishMainCommit rebuilds generated state commits without deleting concur
   assert.equal(run("git", ["--git-dir", origin, "show", "main:keep.txt"], root), "keep remote\n");
 });
 
+test("state publisher uses a detached empty-tree lease commit", async () => {
+  const fixture = createStatePublishRemote("detached-lease");
+  const state = path.join(fixture.root, "state");
+  const source = path.join(fixture.root, "source");
+  const releaseSignal = path.join(fixture.root, "release-publisher");
+  const releaseObserved = path.join(fixture.root, "publisher-released");
+  cloneState(fixture.origin, state);
+  fs.mkdirSync(source);
+  write(path.join(source, "results/detached-lease.txt"), "published\n");
+  installStatePushReleaseHook(state, releaseSignal, releaseObserved);
+
+  const child = startPublishCli(
+    source,
+    state,
+    "chore: publish through detached lease",
+    leasedPublishEnv({
+      CLAWSWEEPER_PUBLISH_ACQUIRE_DEADLINE_MS: "5000",
+      CLAWSWEEPER_PUBLISH_DEADLINE_MS: "2000",
+      CLAWSWEEPER_PUBLISH_COMMAND_TIMEOUT_MS: "1000",
+      CLAWSWEEPER_PUBLISH_LEASE_TTL_MS: "3000",
+      CLAWSWEEPER_PUBLISH_LEASE_WAIT_MS: "10",
+    }),
+  );
+  const childResult = waitForChild(child);
+  let inspectionError;
+  try {
+    await waitForRemoteRef(fixture.origin, STATE_PUBLISH_LEASE_REF);
+    const commitAndParents = run(
+      "git",
+      ["--git-dir", fixture.origin, "rev-list", "--parents", "-n", "1", STATE_PUBLISH_LEASE_REF],
+      fixture.root,
+    )
+      .trim()
+      .split(/\s+/);
+    assert.equal(commitAndParents.length, 1);
+    assert.equal(
+      run(
+        "git",
+        ["--git-dir", fixture.origin, "ls-tree", "-r", STATE_PUBLISH_LEASE_REF],
+        fixture.root,
+      ),
+      "",
+    );
+  } catch (error) {
+    inspectionError = error;
+  } finally {
+    write(releaseSignal, "release\n");
+  }
+
+  const completed = await childResult;
+  if (inspectionError) throw inspectionError;
+  assert.equal(completed.status, 0, completed.stderr);
+  assert.equal(fs.existsSync(releaseObserved), true);
+  assert.equal(remoteRefExists(fixture.origin, STATE_PUBLISH_LEASE_REF), false);
+});
+
 test("state publishers serialize concurrent workflow commits through the remote lease", async () => {
   const fixture = createStatePublishRemote("concurrent");
   const firstState = path.join(fixture.root, "state-first");
@@ -2251,7 +2307,7 @@ test("leased publisher adopts a path-equivalent remote race before source refres
   assert.equal(remoteRefExists(fixture.origin, STATE_PUBLISH_LEASE_REF), false);
 });
 
-test("leased publisher performs only one rebuild after an unexpected state race", () => {
+test("leased publisher rebuilds after an unexpected state race", () => {
   const fixture = createStatePublishRemote("single-rebuild");
   const state = path.join(fixture.root, "state");
   const other = path.join(fixture.root, "other");
@@ -2294,7 +2350,113 @@ test("leased publisher performs only one rebuild after an unexpected state race"
     Number(fs.readFileSync(path.join(state, ".git/hooks/state-push-count"), "utf8").trim()),
     2,
   );
-  assert.equal(lines.filter((line) => line.includes("rebuilding once")).length, 1);
+  assert.equal(lines.filter((line) => line.includes("rebuilding attempt=1")).length, 1);
+});
+
+test("leased publisher converges after repeated unexpected state races", () => {
+  const fixture = createStatePublishRemote("repeated-races");
+  const state = path.join(fixture.root, "state");
+  const other = path.join(fixture.root, "other");
+  const source = path.join(fixture.root, "source");
+  cloneState(fixture.origin, state);
+  cloneState(fixture.origin, other);
+  fs.mkdirSync(source);
+  write(path.join(source, "results/local.txt"), "local\n");
+  installRepeatedStateRaceHook(state, other, 4);
+
+  const lines = captureConsoleLog(() =>
+    withEnv(
+      leasedPublishEnv({
+        CLAWSWEEPER_STATE_DIR: state,
+        CLAWSWEEPER_PUBLISH_DEADLINE_MS: "5000",
+        CLAWSWEEPER_PUBLISH_COMMAND_TIMEOUT_MS: "2000",
+      }),
+      () =>
+        withCwd(source, () =>
+          publishMainCommit({
+            message: "chore: converge leased publish",
+            paths: ["results/local.txt"],
+          }),
+        ),
+    ),
+  );
+
+  assert.equal(
+    run("git", ["--git-dir", fixture.origin, "show", "state:results/local.txt"], fixture.root),
+    "local\n",
+  );
+  for (let race = 1; race <= 4; race += 1) {
+    assert.equal(
+      run(
+        "git",
+        ["--git-dir", fixture.origin, "show", `state:results/remote-race-${race}.txt`],
+        fixture.root,
+      ),
+      `remote race ${race}\n`,
+    );
+  }
+  assert.equal(
+    Number(fs.readFileSync(path.join(state, ".git/hooks/state-push-count"), "utf8").trim()),
+    5,
+  );
+  assert.equal(lines.filter((line) => line.includes("rebuilding attempt=")).length, 4);
+});
+
+test("leased reconciliation converges after repeated unexpected state races", () => {
+  const fixture = createStatePublishRemote("repeated-reconciliation-races");
+  const state = path.join(fixture.root, "state");
+  const other = path.join(fixture.root, "other");
+  const source = path.join(fixture.root, "source");
+  const recordsRoot = "records/openclaw-openclaw";
+  const tuplePaths = [
+    `${recordsRoot}/items/1.md`,
+    `${recordsRoot}/plans/1.md`,
+    `${recordsRoot}/decision-packets/1.json`,
+  ];
+  cloneState(fixture.origin, state);
+  cloneState(fixture.origin, other);
+  fs.mkdirSync(source);
+  const localTuple = writeRecordTuple(source, {
+    number: 1,
+    marker: "local reconciliation",
+    reviewedAt: "2026-07-14T20:00:00.000Z",
+    itemUpdatedAt: "2026-07-14T19:59:00Z",
+  });
+  installRepeatedStateRaceHook(state, other, 2);
+
+  const lines = captureConsoleLog(() =>
+    withEnv(
+      leasedPublishEnv({
+        CLAWSWEEPER_STATE_DIR: state,
+        CLAWSWEEPER_PUBLISH_DEADLINE_MS: "5000",
+        CLAWSWEEPER_PUBLISH_COMMAND_TIMEOUT_MS: "2000",
+      }),
+      () =>
+        withCwd(source, () =>
+          publishMainCommit({
+            message: "chore: converge leased reconciliation",
+            paths: tuplePaths,
+            rebaseStrategy: "reconcile-records",
+          }),
+        ),
+    ),
+  );
+
+  assert.equal(
+    run("git", ["--git-dir", fixture.origin, "show", `state:${tuplePaths[0]}`], fixture.root),
+    localTuple.primary,
+  );
+  for (let race = 1; race <= 2; race += 1) {
+    assert.equal(
+      run(
+        "git",
+        ["--git-dir", fixture.origin, "show", `state:results/remote-race-${race}.txt`],
+        fixture.root,
+      ),
+      `remote race ${race}\n`,
+    );
+  }
+  assert.equal(lines.filter((line) => line.includes("rebuilding attempt=")).length, 2);
 });
 
 test("leased apply-records rebuild preserves a concurrent remote close", () => {
@@ -2364,7 +2526,7 @@ test("leased apply-records rebuild preserves a concurrent remote close", () => {
   );
 });
 
-test("leased publisher rejects a successful push whose remote blobs changed", () => {
+test("leased publisher rebuilds when an accepted push is overwritten before verification", () => {
   const fixture = createStatePublishRemote("verify");
   const state = path.join(fixture.root, "state");
   const poison = path.join(fixture.root, "poison");
@@ -2379,27 +2541,29 @@ test("leased publisher rejects a successful push whose remote blobs changed", ()
   installStatePoisonHook(fixture.origin);
   write(path.join(source, "results/verified.txt"), "expected\n");
 
-  assert.throws(
-    () =>
-      withEnv(
-        leasedPublishEnv({
-          CLAWSWEEPER_STATE_DIR: state,
-          CLAWSWEEPER_PUBLISH_DEADLINE_MS: "5000",
-          CLAWSWEEPER_PUBLISH_COMMAND_TIMEOUT_MS: "2000",
-        }),
-        () =>
-          withCwd(source, () =>
-            publishMainCommit({
-              message: "chore: verify remote blobs",
-              paths: ["results/verified.txt"],
-            }),
-          ),
-      ),
-    /expected-blob verification/,
+  const lines = captureConsoleLog(() =>
+    withEnv(
+      leasedPublishEnv({
+        CLAWSWEEPER_STATE_DIR: state,
+        CLAWSWEEPER_PUBLISH_DEADLINE_MS: "5000",
+        CLAWSWEEPER_PUBLISH_COMMAND_TIMEOUT_MS: "2000",
+      }),
+      () =>
+        withCwd(source, () =>
+          publishMainCommit({
+            message: "chore: verify remote blobs",
+            paths: ["results/verified.txt"],
+          }),
+        ),
+    ),
   );
   assert.equal(
     run("git", ["--git-dir", fixture.origin, "show", "state:results/verified.txt"], fixture.root),
-    "poison\n",
+    "expected\n",
+  );
+  assert.equal(
+    lines.some((line) => line.includes("superseded after an accepted push")),
+    true,
   );
   assert.equal(remoteRefExists(fixture.origin, STATE_PUBLISH_LEASE_REF), false);
 });
@@ -2420,18 +2584,33 @@ test("failed leased publish refreshes advanced remote state before a later broad
   write(path.join(source, "results/local-checkpoint.txt"), "local\n");
   const rejectingHook = installStatePushRejectHook(fixture.origin);
 
-  assert.throws(
-    () =>
-      withEnv(leasedPublishEnv({ CLAWSWEEPER_STATE_DIR: state }), () =>
-        withCwd(source, () =>
-          publishMainCommit({
-            message: "chore: fail narrow checkpoint",
-            paths: ["results/local-checkpoint.txt"],
+  const startedAt = Date.now();
+  const lines = captureConsoleLog(() =>
+    assert.throws(
+      () =>
+        withEnv(
+          leasedPublishEnv({
+            CLAWSWEEPER_STATE_DIR: state,
+            CLAWSWEEPER_PUBLISH_ACQUIRE_DEADLINE_MS: "3000",
+            CLAWSWEEPER_PUBLISH_DEADLINE_MS: "300",
+            CLAWSWEEPER_PUBLISH_COMMAND_TIMEOUT_MS: "500",
+            CLAWSWEEPER_PUBLISH_LEASE_TTL_MS: "1000",
           }),
+          () =>
+            withCwd(source, () =>
+              publishMainCommit({
+                message: "chore: fail narrow checkpoint",
+                paths: ["results/local-checkpoint.txt"],
+              }),
+            ),
         ),
-      ),
-    /single rebuild\/push retry/,
+      /State publication deadline exceeded/,
+    ),
   );
+  assert.ok(Date.now() - startedAt < 3000);
+  const metrics = lines.find((line) => line.includes("Git publish metrics:")) ?? "";
+  const processCount = Number(/processes=(\d+)/.exec(metrics)?.[1]);
+  assert.ok(Number.isInteger(processCount) && processCount < 256, metrics);
   fs.rmSync(rejectingHook);
 
   assert.equal(fs.readFileSync(path.join(source, remoteJob), "utf8"), "remote job\n");
@@ -3680,6 +3859,32 @@ while read -r local_ref local_oid remote_ref remote_oid; do
   count=$((count + 1))
   printf '%s\\n' "$count" > "${counter}"
   if test "$count" -eq 1; then
+    git -C "${other}" push origin HEAD:state
+  fi
+done
+`,
+  );
+  fs.chmodSync(hook, 0o755);
+}
+
+function installRepeatedStateRaceHook(state, other, races) {
+  const hook = path.join(state, ".git/hooks/pre-push");
+  const counter = path.join(state, ".git/hooks/state-push-count");
+  fs.writeFileSync(
+    hook,
+    `#!/bin/sh
+while read -r local_ref local_oid remote_ref remote_oid; do
+  if test "$remote_ref" != "refs/heads/state"; then
+    continue
+  fi
+  count=0
+  if test -f "${counter}"; then count=$(cat "${counter}"); fi
+  count=$((count + 1))
+  printf '%s\\n' "$count" > "${counter}"
+  if test "$count" -le "${races}"; then
+    printf 'remote race %s\\n' "$count" > "${other}/results/remote-race-$count.txt"
+    git -C "${other}" add "results/remote-race-$count.txt"
+    git -C "${other}" commit -m "remote state race $count"
     git -C "${other}" push origin HEAD:state
   fi
 done


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where concurrent generated-state publishers could exhaust their lease acquisition or fail after one branch race, leaving finalized GitHub activity receipts available only in replay artifacts instead of the durable state branch.

Observed in the production canary runs https://github.com/openclaw/clawsweeper/actions/runs/29363481721 and https://github.com/openclaw/clawsweeper/actions/runs/29363482337, followed by failed automatic replays https://github.com/openclaw/clawsweeper/actions/runs/29363815312 and https://github.com/openclaw/clawsweeper/actions/runs/29363846354.

## Why This Change Was Made

State publication now uses detached empty-tree lease commits, avoiding negotiation of the large state history for a tiny lock update. Once leased, normal and reconciliation publishers verify every remote outcome and rebuild against the latest state until the existing operation deadline or lease expiry, instead of stopping after one race.

The deadline remains the hard convergence bound; acquisition deadlines are not extended and mutation semantics are unchanged.

## User Impact

Operators can expect overlapping action, review, repair, replay, and dashboard publishers to serialize quickly and converge through finite state-branch churn without losing durable receipt publication. Permanent contention still fails closed within the configured workflow budget.

## Evidence

- `node --test test/repair/git-publish.test.ts`: 54 passed
- `tsc -p tsconfig.repair.json`
- `oxlint src/repair --tsconfig tsconfig.repair.json --deny-warnings --report-unused-disable-directives -D correctness`
- focused test lint, format check, `check-active-surface`, `check-limits`, and `git diff --check`
- regression coverage for detached leases, four consecutive state races, reconciliation races, accepted-push overwrite, deadline-bounded permanent rejection, lease cleanup, and source refresh
- production concurrent receipt/replay canary will be repeated on the merged head before dependent mutation work lands