### PR TITLE
fix(state): prevent action ledger publication starvation

### DIFF
--- a/.github/workflows/github-activity-receipt-replay.yml
+++ b/.github/workflows/github-activity-receipt-replay.yml
@@ -181,6 +181,7 @@ jobs:
 
       - name: Replay GitHub activity dispatch action ledger
         env:
+          CLAWSWEEPER_ACTION_LEDGER_IMMUTABLE_PUBLISH: "1"
           PUBLISH_TOKEN: ${{ steps.replay-state-token.outputs.token }}
         run: |
           set -euo pipefail

--- a/.github/workflows/github-activity-receipt-replay.yml
+++ b/.github/workflows/github-activity-receipt-replay.yml
@@ -208,19 +208,16 @@ jobs:
             echo "GitHub activity dispatch replay imported no paths." >&2
             exit 1
           fi
-          action_ledger_args=()
           while IFS= read -r event_path; do
             durable_event_path="$CLAWSWEEPER_STATE_DIR/$event_path"
             test -f "$durable_event_path"
             mkdir -p "$(dirname "$event_path")"
             cp "$durable_event_path" "$event_path"
-            action_ledger_args+=(--path "$event_path")
           done < "$event_paths_file"
           auth_header="$(printf 'x-access-token:%s' "$PUBLISH_TOKEN" | base64 | tr -d '\n')"
           export GIT_CONFIG_COUNT=1
           export GIT_CONFIG_KEY_0=http.https://github.com/.extraheader
           export GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $auth_header"
-          pnpm run repair:publish-main -- \
-            --message "chore: replay GitHub activity dispatch action ledger" \
-            "${action_ledger_args[@]}" \
-            --rebase-strategy normal
+          node dist/clawsweeper.js publish-action-event-paths \
+            --paths-file "$event_paths_file" \
+            --message "chore: replay GitHub activity dispatch action ledger"

--- a/.github/workflows/github-activity.yml
+++ b/.github/workflows/github-activity.yml
@@ -254,22 +254,19 @@ jobs:
             echo "GitHub activity dispatch shards existed but no paths were imported." >&2
             exit 1
           fi
-          action_ledger_args=()
           while IFS= read -r event_path; do
             durable_event_path="$CLAWSWEEPER_STATE_DIR/$event_path"
             test -f "$durable_event_path"
             mkdir -p "$(dirname "$event_path")"
             cp "$durable_event_path" "$event_path"
-            action_ledger_args+=(--path "$event_path")
           done < "$event_paths_file"
           auth_header="$(printf 'x-access-token:%s' "$PUBLISH_TOKEN" | base64 | tr -d '\n')"
           export GIT_CONFIG_COUNT=1
           export GIT_CONFIG_KEY_0=http.https://github.com/.extraheader
           export GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $auth_header"
-          pnpm run repair:publish-main -- \
-            --message "chore: append GitHub activity dispatch action ledger" \
-            "${action_ledger_args[@]}" \
-            --rebase-strategy normal
+          node dist/clawsweeper.js publish-action-event-paths \
+            --paths-file "$event_paths_file" \
+            --message "chore: append GitHub activity dispatch action ledger"
 
       - name: Feed activity to OpenClaw
         id: notify-openclaw

--- a/.github/workflows/github-activity.yml
+++ b/.github/workflows/github-activity.yml
@@ -228,6 +228,7 @@ jobs:
         if: ${{ always() && steps.core-budget.outputs.skip != 'true' && steps.setup-activity-state.outcome == 'success' && steps.setup-activity-pnpm.outcome == 'success' && steps.bundle-activity-dispatch-ledger.outputs.ready == 'true' }}
         continue-on-error: true
         env:
+          CLAWSWEEPER_ACTION_LEDGER_IMMUTABLE_PUBLISH: "1"
           PUBLISH_TOKEN: ${{ steps.activity-state-token.outputs.token }}
         run: |
           set -euo pipefail

--- a/.github/workflows/repair-cluster-worker.yml
+++ b/.github/workflows/repair-cluster-worker.yml
@@ -1120,18 +1120,15 @@ jobs:
             echo "Repair requeue action event shards existed but no paths were imported." >&2
             exit 1
           fi
-          action_ledger_args=()
           while IFS= read -r event_path; do
             durable_event_path="$CLAWSWEEPER_STATE_DIR/$event_path"
             test -f "$durable_event_path"
             mkdir -p "$(dirname "$event_path")"
             cp "$durable_event_path" "$event_path"
-            action_ledger_args+=(--path "$event_path")
           done < "$event_paths_file"
-          pnpm run repair:publish-main -- \
-            --message "chore: append repair requeue action ledger" \
-            "${action_ledger_args[@]}" \
-            --rebase-strategy normal
+          node dist/clawsweeper.js publish-action-event-paths \
+            --paths-file "$event_paths_file" \
+            --message "chore: append repair requeue action ledger"
 
       - name: Record requeued work
         if: ${{ always() && steps.crabfleet_session.outcome == 'success' && steps.repair_requeue.outputs.count != '' && steps.repair_requeue.outputs.count != '0' && steps.requeue_dispatch.outcome == 'success' }}

--- a/.github/workflows/repair-comment-router.yml
+++ b/.github/workflows/repair-comment-router.yml
@@ -484,15 +484,12 @@ jobs:
             echo "Command action event shards existed but no paths were imported." >&2
             exit 1
           fi
-          action_ledger_args=()
           while IFS= read -r event_path; do
             durable_event_path="$CLAWSWEEPER_STATE_DIR/$event_path"
             test -f "$durable_event_path"
             mkdir -p "$(dirname "$event_path")"
             cp "$durable_event_path" "$event_path"
-            action_ledger_args+=(--path "$event_path")
           done < "$event_paths_file"
-          pnpm run repair:publish-main -- \
-            --message "chore: append command action ledger" \
-            "${action_ledger_args[@]}" \
-            --rebase-strategy normal
+          node dist/clawsweeper.js publish-action-event-paths \
+            --paths-file "$event_paths_file" \
+            --message "chore: append command action ledger"

--- a/.github/workflows/repair-self-heal.yml
+++ b/.github/workflows/repair-self-heal.yml
@@ -153,18 +153,15 @@ jobs:
             echo "Self-heal dispatch shards existed but no paths were imported." >&2
             exit 1
           fi
-          action_ledger_args=()
           while IFS= read -r event_path; do
             durable_event_path="$CLAWSWEEPER_STATE_DIR/$event_path"
             test -f "$durable_event_path"
             mkdir -p "$(dirname "$event_path")"
             cp "$durable_event_path" "$event_path"
-            action_ledger_args+=(--path "$event_path")
           done < "$event_paths_file"
-          pnpm run repair:publish-main -- \
-            --message "chore: append self-heal dispatch action ledger" \
-            "${action_ledger_args[@]}" \
-            --rebase-strategy normal
+          node dist/clawsweeper.js publish-action-event-paths \
+            --paths-file "$event_paths_file" \
+            --message "chore: append self-heal dispatch action ledger"
 
       - name: Commit self-heal ledger
         if: ${{ always() && ((github.event_name == 'workflow_dispatch' && inputs.execute) || (github.event_name == 'schedule' && vars.CLAWSWEEPER_SELF_HEAL_EXECUTE == '1')) }}

--- a/.github/workflows/spam-comment-intake.yml
+++ b/.github/workflows/spam-comment-intake.yml
@@ -168,19 +168,16 @@ jobs:
             echo "Spam intake dispatch shards existed but no paths were imported." >&2
             exit 1
           fi
-          action_ledger_args=()
           while IFS= read -r event_path; do
             durable_event_path="$CLAWSWEEPER_STATE_DIR/$event_path"
             test -f "$durable_event_path"
             mkdir -p "$(dirname "$event_path")"
             cp "$durable_event_path" "$event_path"
-            action_ledger_args+=(--path "$event_path")
           done < "$event_paths_file"
           auth_header="$(printf 'x-access-token:%s' "$PUBLISH_TOKEN" | base64 | tr -d '\n')"
           export GIT_CONFIG_COUNT=1
           export GIT_CONFIG_KEY_0=http.https://github.com/.extraheader
           export GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $auth_header"
-          pnpm run repair:publish-main -- \
-            --message "chore: append spam intake dispatch action ledger" \
-            "${action_ledger_args[@]}" \
-            --rebase-strategy normal
+          node dist/clawsweeper.js publish-action-event-paths \
+            --paths-file "$event_paths_file" \
+            --message "chore: append spam intake dispatch action ledger"

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -3597,6 +3597,7 @@ jobs:
     needs: apply-proof
     if: ${{ always() && needs.apply-proof.result != 'skipped' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1350,18 +1350,15 @@ jobs:
             echo "Late command status action shards existed but no paths were imported." >&2
             exit 1
           fi
-          action_ledger_args=()
           while IFS= read -r event_path; do
             durable_event_path="$CLAWSWEEPER_STATE_DIR/$event_path"
             test -f "$durable_event_path"
             mkdir -p "$(dirname "$event_path")"
             cp "$durable_event_path" "$event_path"
-            action_ledger_args+=(--path "$event_path")
           done < "$event_paths_file"
-          pnpm run repair:publish-main -- \
-            --message "chore: append command status action ledger" \
-            "${action_ledger_args[@]}" \
-            --rebase-strategy normal
+          node dist/clawsweeper.js publish-action-event-paths \
+            --paths-file "$event_paths_file" \
+            --message "chore: append command status action ledger"
 
   target-fanout:
     name: Fan out target repository sweeps
@@ -1473,18 +1470,15 @@ jobs:
             echo "Target fanout dispatch shards existed but no paths were imported." >&2
             exit 1
           fi
-          action_ledger_args=()
           while IFS= read -r event_path; do
             durable_event_path="$CLAWSWEEPER_STATE_DIR/$event_path"
             test -f "$durable_event_path"
             mkdir -p "$(dirname "$event_path")"
             cp "$durable_event_path" "$event_path"
-            action_ledger_args+=(--path "$event_path")
           done < "$event_paths_file"
-          pnpm run repair:publish-main -- \
-            --message "chore: append target fanout dispatch action ledger" \
-            "${action_ledger_args[@]}" \
-            --rebase-strategy normal
+          node dist/clawsweeper.js publish-action-event-paths \
+            --paths-file "$event_paths_file" \
+            --message "chore: append target fanout dispatch action ledger"
 
       - name: Publish fanout cursor
         if: ${{ always() && steps.setup-target-fanout-state.outcome == 'success' && steps.setup-target-fanout-pnpm.outcome == 'success' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,12 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Added a priority-aware optimistic publisher for immutable action ledgers that
+  yields to exclusive state mutations, accepts replay-equivalent event shards,
+  rejects content collisions, and converges disjoint branch races without the
+  global state lease. GitHub activity publication and receipt replay use the
+  staged mode first; every action, review, and repair ledger now enters through
+  the same validated path-manifest boundary.
 - Serialized generated-state publishers through lightweight detached,
   versioned, protocol-bounded remote leases with composable workflow
   deadlines, bounded stale-owner recovery, deadline-bounded multi-race

--- a/src/action-ledger.ts
+++ b/src/action-ledger.ts
@@ -851,6 +851,32 @@ export function actionEventShardRelativePath(
   );
 }
 
+const ACTION_EVENT_PUBLISH_PATH_PATTERN =
+  /^ledger\/v1\/(?:events\/\d{4}\/\d{2}\/\d{2}\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\.jsonl|import-bindings\/(?:producer-runs|events|shard-sets|completed-shard-sets)\/[a-f0-9]{64}\.json)$/;
+
+export function isActionEventPublishPath(value: string): boolean {
+  return ACTION_EVENT_PUBLISH_PATH_PATTERN.test(value);
+}
+
+export function actionEventPublishContentsEquivalent(
+  relativePath: string,
+  left: string,
+  right: string,
+): boolean {
+  if (left === right) return true;
+  if (!relativePath.startsWith("ledger/v1/events/")) return false;
+  try {
+    const rightEvents = parseActionEventShardContent(right, `${relativePath} (remote)`);
+    const canonicalRight = `${rightEvents.map((event) => actionLedgerJson(event)).join("\n")}\n`;
+    return (
+      right === canonicalRight &&
+      actionEventShardContentReplayEquivalent(left, rightEvents, `${relativePath} (candidate)`)
+    );
+  } catch {
+    return false;
+  }
+}
+
 export function actionEventShardImportBindingRelativePaths(identity: ActionEventShardIdentity): {
   reservation: string;
   completion: string;

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -6,6 +6,7 @@ import {
   closeSync,
   existsSync,
   fstatSync,
+  lstatSync,
   mkdirSync,
   openSync,
   readSync,
@@ -209,6 +210,7 @@ import {
   ACTION_EVENT_REASON_CODES,
   ACTION_EVENT_STATUSES,
   ACTION_EVENT_TYPES,
+  isActionEventPublishPath,
   type ActionEvent,
   type ActionEventEvidence,
   type ActionEventReasonCode,
@@ -31908,8 +31910,6 @@ function publishActionEventsCommand(args: Args): void {
   console.log(JSON.stringify(result, null, 2));
 }
 
-const ACTION_EVENT_PUBLISH_PATH_PATTERN =
-  /^ledger\/v1\/(?:events\/\d{4}\/\d{2}\/\d{2}\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\.jsonl|import-bindings\/(?:producer-runs|events|shard-sets|completed-shard-sets)\/[a-f0-9]{64}\.json)$/;
 const ACTION_EVENT_PUBLISH_PATH_FILE_MAX_BYTES = ACTION_EVENT_SHARD_IMPORT_MAX_PUBLISH_PATHS * 512;
 
 export function actionEventPublishPathsForTest(content: string): string[] {
@@ -31927,7 +31927,7 @@ export function actionEventPublishPathsForTest(content: string): string[] {
   }
   let previous = "";
   for (const path of paths) {
-    if (!ACTION_EVENT_PUBLISH_PATH_PATTERN.test(path)) {
+    if (!isActionEventPublishPath(path)) {
       throw new Error(`invalid action event publish path: ${path}`);
     }
     if (previous && path <= previous) {
@@ -31936,6 +31936,12 @@ export function actionEventPublishPathsForTest(content: string): string[] {
     previous = path;
   }
   return paths;
+}
+
+export function actionEventPublishCoordinationForTest(
+  env: NodeJS.ProcessEnv = process.env,
+): "exclusive" | "immutable" {
+  return env.CLAWSWEEPER_ACTION_LEDGER_IMMUTABLE_PUBLISH === "1" ? "immutable" : "exclusive";
 }
 
 function publishActionEventPathsCommand(args: Args): void {
@@ -31960,17 +31966,25 @@ function publishActionEventPathsCommand(args: Args): void {
     if (
       rootRelativeSource.startsWith("..") ||
       resolve(ROOT, rootRelativeSource) !== source ||
-      !statSync(source).isFile()
+      !lstatSync(source).isFile()
     ) {
       throw new Error(`action event publish path is not a regular file: ${path}`);
     }
   }
+  const coordination = actionEventPublishCoordinationForTest();
   const result = publishMainCommit({
     message,
     paths,
+    coordination,
     rebaseStrategy: "normal",
   });
-  console.log(JSON.stringify({ result, path_count: paths.length }));
+  console.log(
+    JSON.stringify({
+      result,
+      path_count: paths.length,
+      coordination,
+    }),
+  );
 }
 
 function isExplicitActionLedgerCommand(command: string): boolean {

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -14,6 +14,10 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 
+import {
+  actionEventPublishContentsEquivalent,
+  isActionEventPublishPath,
+} from "../action-ledger.js";
 import { clawsweeperGitUserEmail, clawsweeperGitUserName } from "./process-env.js";
 import {
   chooseRecordTupleWinner,
@@ -44,9 +48,11 @@ export type GitPublishOptions = {
   pushAttempts?: number | undefined;
   remote?: string;
   branch?: string;
+  coordination?: PublishCoordination | undefined;
   rebaseStrategy?: RebaseStrategy | undefined;
 };
 
+export type PublishCoordination = "exclusive" | "immutable";
 export type RebaseStrategy = "normal" | "theirs" | "apply-records" | "reconcile-records";
 
 export type GitRunOptions = {
@@ -66,6 +72,7 @@ const GENERATED_PUBLISH_PATHS = [
   "records",
   "results",
   "assets",
+  "ledger",
 ] as const;
 const GIT_PATHSPEC_BATCH_SIZE = 256;
 const GIT_OBJECT_BATCH_SIZE = 512;
@@ -286,14 +293,19 @@ export function hasWorktreePath(path: string): boolean {
 export function publishMainCommit(options: GitPublishOptions): PublishResult {
   const previousMetrics = activeGitPublishMetrics;
   const startedAtMs = Date.now();
-  const leased = statePublishLeaseEnabled();
-  const timing = leased ? statePublishTiming() : null;
+  const coordination = options.coordination ?? "exclusive";
+  validatePublishCoordination(options, coordination);
+  const leased = coordination === "exclusive" && statePublishLeaseEnabled();
+  const boundedImmutable = coordination === "immutable" && publishRoot() !== undefined;
+  const timing = leased || boundedImmutable ? statePublishTiming() : null;
   const metrics: GitPublishMetrics = {
     startedAtMs,
-    deadlineAtMs: timing ? startedAtMs + timing.acquisitionDeadlineMs : null,
+    deadlineAtMs: timing
+      ? startedAtMs + (leased ? timing.acquisitionDeadlineMs : timing.operationDeadlineMs)
+      : null,
     commandTimeoutMs: timing?.commandTimeoutMs ?? null,
     operationDeadlineMs: timing?.operationDeadlineMs ?? null,
-    leaseTtlMs: timing?.leaseTtlMs ?? null,
+    leaseTtlMs: leased ? (timing?.leaseTtlMs ?? null) : null,
     processes: 0,
     actions: new Map(),
     phase: "start",
@@ -319,6 +331,9 @@ export function publishMainCommit(options: GitPublishOptions): PublishResult {
 }
 
 function publishMainCommitInternal(options: GitPublishOptions): PublishResult {
+  if (options.coordination === "immutable") {
+    return publishImmutableMainCommit(options);
+  }
   if (!statePublishLeaseEnabled()) return publishMainCommitWithoutLease(options);
   const remote = options.remote ?? "origin";
   const branch = options.branch ?? publishDefaultBranch();
@@ -331,6 +346,286 @@ function publishMainCommitInternal(options: GitPublishOptions): PublishResult {
   } finally {
     releaseStatePublishLease(remote, lease);
   }
+}
+
+function validatePublishCoordination(
+  options: GitPublishOptions,
+  coordination: PublishCoordination,
+): void {
+  if (coordination !== "immutable") return;
+  if ((options.rebaseStrategy ?? "normal") !== "normal") {
+    throw new Error("Immutable action ledger publication requires the normal rebase strategy");
+  }
+  const paths = uniqueNonEmpty(options.paths);
+  if (paths.length === 0 || paths.some((path) => !isActionEventPublishPath(path))) {
+    throw new Error(
+      "Immutable publication accepts only exact action ledger event and import-binding paths",
+    );
+  }
+}
+
+function publishImmutableMainCommit(options: GitPublishOptions): PublishResult {
+  const remote = options.remote ?? "origin";
+  const branch = options.branch ?? publishDefaultBranch();
+  const maxAttempts = positiveInt(options.maxAttempts, 32);
+  const paths = uniqueNonEmpty(options.paths);
+  const stateBaseCommit = captureStatePublishBaseline();
+  const stateRoot = publishRoot();
+  let stateCheckoutAdvanced = false;
+
+  gitPublishPhase("sync", `paths=${paths.length} coordination=immutable`);
+  try {
+    if (stateRoot && resolve(stateRoot) !== resolve(process.cwd())) {
+      runGit(["fetch", remote, branch]);
+      runGit(["reset", "--hard", `${remote}/${branch}`]);
+      stateCheckoutAdvanced = true;
+    }
+
+    syncPublishPaths(paths, { rebaseStrategy: "normal" });
+    configureGitUser();
+    gitPublishPhase("stage", `paths=${paths.length} coordination=immutable`);
+    stagePaths(paths);
+    if (!hasStagedChanges()) {
+      console.log("No immutable publish changes");
+      verifyRemotePublishedPaths("HEAD", remote, branch, paths);
+      return completeStatePublish("unchanged", paths, stateBaseCommit);
+    }
+
+    const message = commitMessageForPublishedPaths(options.message, paths);
+    runGit(["commit", "-m", message]);
+    const sourceCommit = runGit(["rev-parse", "HEAD"], { quiet: true }).trim();
+    restoreWorktree(options.restorePaths ?? []);
+    gitPublishPhase("push", `coordination=immutable`);
+    const result = convergeImmutablePublish({
+      remote,
+      branch,
+      paths,
+      message,
+      sourceCommit,
+      maxAttempts,
+    });
+    return completeStatePublish(result, paths, stateBaseCommit);
+  } catch (error) {
+    if (stateCheckoutAdvanced) {
+      try {
+        restoreFailedLeasedStatePublish({
+          remote,
+          branch,
+          paths,
+          stateBaseCommit,
+        });
+      } catch (recoveryError) {
+        throw new Error(
+          `Immutable state publish failed: ${errorMessage(error)}; state/source recovery failed: ${errorMessage(recoveryError)}`,
+        );
+      }
+    }
+    throw error;
+  }
+}
+
+function convergeImmutablePublish(options: {
+  remote: string;
+  branch: string;
+  paths: readonly string[];
+  message: string;
+  sourceCommit: string;
+  maxAttempts: number;
+}): PublishResult {
+  const observedLeases = new Map<string, ObservedStatePublishLease>();
+  for (let attempt = 1; attempt <= options.maxAttempts; attempt += 1) {
+    assertStatePublishDeadline("publishing immutable action ledger paths");
+    waitForExclusiveStatePublishLeaseGap(options.remote, options.branch, observedLeases);
+    const compatibility = immutableRemoteCompatibility({
+      remote: options.remote,
+      branch: options.branch,
+      paths: options.paths,
+      sourceCommit: options.sourceCommit,
+    });
+    if (compatibility.missing.length === 0) {
+      verifyRemoteImmutablePaths(
+        options.sourceCommit,
+        options.remote,
+        options.branch,
+        options.paths,
+      );
+      return "unchanged";
+    }
+    const expectedCommit = runGit(["rev-parse", "HEAD"], { quiet: true }).trim();
+    let pushed = false;
+    try {
+      pushed =
+        spawnGit(["push", options.remote, `HEAD:${options.branch}`], {
+          allowFailure: true,
+        }).status === 0;
+    } catch (error) {
+      if (!isGitTimeoutError(error)) throw error;
+      console.log(
+        `Immutable ${options.branch} push timed out attempt=${attempt}; verifying remote blobs`,
+      );
+    }
+    if (
+      pushed ||
+      remotePublishedPathsMatch(expectedCommit, options.remote, options.branch, options.paths)
+    ) {
+      verifyRemoteImmutablePaths(expectedCommit, options.remote, options.branch, options.paths);
+      return "committed";
+    }
+
+    const rebuild = rebuildImmutablePublishCommit({
+      remote: options.remote,
+      branch: options.branch,
+      paths: options.paths,
+      message: options.message,
+      sourceCommit: options.sourceCommit,
+    });
+    if (rebuild === "unchanged") {
+      verifyRemoteImmutablePaths(
+        options.sourceCommit,
+        options.remote,
+        options.branch,
+        options.paths,
+      );
+      return "unchanged";
+    }
+    if (attempt === options.maxAttempts) break;
+    const waitMs = immutablePublishRetryWaitMs(attempt);
+    console.log(
+      `Immutable publish lost ${options.branch} race attempt=${attempt}/${options.maxAttempts}; retrying in ${waitMs}ms`,
+    );
+    sleepWithinStatePublishDeadline(waitMs, "waiting to retry immutable action ledger publication");
+  }
+  throw new Error(
+    `Failed to publish immutable action ledger paths after ${options.maxAttempts} attempts`,
+  );
+}
+
+function verifyRemoteImmutablePaths(
+  sourceCommit: string,
+  remote: string,
+  branch: string,
+  paths: readonly string[],
+): void {
+  gitPublishPhase("verify", `paths=${uniqueNonEmpty(paths).length} coordination=immutable`);
+  const compatibility = immutableRemoteCompatibility({
+    remote,
+    branch,
+    paths,
+    sourceCommit,
+  });
+  if (compatibility.missing.length > 0) {
+    throw new Error(`Remote ${remote}/${branch} is missing immutable action ledger paths`);
+  }
+  adoptVerifiedRemoteHead(remote, branch);
+}
+
+function rebuildImmutablePublishCommit(options: {
+  remote: string;
+  branch: string;
+  paths: readonly string[];
+  message: string;
+  sourceCommit: string;
+}): PublishResult {
+  const compatibility = immutableRemoteCompatibility(options);
+  const remoteCommit = compatibility.remoteCommit;
+  const missing = compatibility.missing;
+
+  runGit(["reset", "--hard", remoteCommit]);
+  if (missing.length === 0) {
+    console.log("Immutable action ledger paths are already published");
+    return "unchanged";
+  }
+  for (const batch of chunked(missing, GIT_PATHSPEC_BATCH_SIZE)) {
+    runGit(["checkout", options.sourceCommit, "--", ...batch]);
+  }
+  stagePaths(missing);
+  if (!hasStagedChanges()) {
+    throw new Error("Immutable action ledger rebuild produced no candidate changes");
+  }
+  runGit(["commit", "-m", options.message]);
+  return "committed";
+}
+
+function immutableRemoteCompatibility(options: {
+  remote: string;
+  branch: string;
+  paths: readonly string[];
+  sourceCommit: string;
+}): { remoteCommit: string; missing: string[] } {
+  runGit(["fetch", options.remote, options.branch]);
+  const remoteCommit = runGit(["rev-parse", `${options.remote}/${options.branch}`], {
+    quiet: true,
+  }).trim();
+  const sourceObjects = gitObjectOids(
+    options.paths.map((path) => ({ commit: options.sourceCommit, path })),
+  );
+  const remoteObjects = gitObjectOids(
+    options.paths.map((path) => ({ commit: remoteCommit, path })),
+  );
+  const missing: string[] = [];
+  const differing: string[] = [];
+  for (const path of options.paths) {
+    const sourceSpec = gitObjectSpec(options.sourceCommit, path);
+    const remoteSpec = gitObjectSpec(remoteCommit, path);
+    const sourceOid = sourceObjects.get(sourceSpec);
+    if (!sourceOid) {
+      throw new Error(`Immutable action ledger source path is missing: ${path}`);
+    }
+    const remoteOid = remoteObjects.get(remoteSpec);
+    if (!remoteOid) {
+      missing.push(path);
+      continue;
+    }
+    if (remoteOid !== sourceOid) {
+      differing.push(path);
+    }
+  }
+  if (differing.length > 0) {
+    const contents = readGitObjects(
+      differing.flatMap((path) => [
+        { commit: options.sourceCommit, path },
+        { commit: remoteCommit, path },
+      ]),
+    );
+    for (const path of differing) {
+      const sourceContent = contents.get(gitObjectSpec(options.sourceCommit, path));
+      const remoteContent = contents.get(gitObjectSpec(remoteCommit, path));
+      if (
+        sourceContent === null ||
+        sourceContent === undefined ||
+        remoteContent === null ||
+        remoteContent === undefined ||
+        !actionEventPublishContentsEquivalent(path, sourceContent, remoteContent)
+      ) {
+        throw new Error(`Immutable action ledger path conflict: ${path}`);
+      }
+    }
+  }
+  return { remoteCommit, missing };
+}
+
+function waitForExclusiveStatePublishLeaseGap(
+  remote: string,
+  branch: string,
+  observedByOid: Map<string, ObservedStatePublishLease>,
+): void {
+  const leaseRef = `${STATE_PUBLISH_LEASE_REF_ROOT}/${branch}`;
+  for (;;) {
+    assertStatePublishDeadline("waiting for exclusive state publication");
+    const observed = observeStatePublishLease(remote, leaseRef, observedByOid);
+    const remainingMs = observed ? observed.expiresAtMs - Date.now() : 0;
+    if (!observed || remainingMs <= 0) return;
+    const waitMs = Math.min(remainingMs, 1_000);
+    console.log(
+      `Immutable publish yielding to exclusive state lease owner=${observed.owner} wait_ms=${waitMs}`,
+    );
+    sleepWithinStatePublishDeadline(waitMs, "waiting for exclusive state publication");
+  }
+}
+
+function immutablePublishRetryWaitMs(attempt: number): number {
+  const ceilingMs = Math.min(50 * 2 ** Math.min(Math.max(attempt - 1, 0), 5), 1_000);
+  return Math.max(25, Math.floor(Math.random() * ceilingMs));
 }
 
 function publishMainCommitWithoutLease(options: GitPublishOptions): PublishResult {
@@ -1343,14 +1638,17 @@ function assertStatePublishDeadline(action: string): void {
   }
 }
 
-function sleepWithinStatePublishDeadline(milliseconds: number): void {
+function sleepWithinStatePublishDeadline(
+  milliseconds: number,
+  action = "waiting for the remote lease",
+): void {
   const deadlineAtMs = activeGitPublishMetrics?.deadlineAtMs;
   const remaining =
     deadlineAtMs === null || deadlineAtMs === undefined
       ? milliseconds
       : Math.min(milliseconds, deadlineAtMs - Date.now());
   if (remaining <= 0) {
-    throw new Error("State publication deadline exceeded while waiting for the remote lease");
+    throw new Error(`State publication deadline exceeded while ${action}`);
   }
   sleep(remaining);
 }
@@ -2015,8 +2313,14 @@ function readGitObjects(requests: readonly GitObjectRequest[]): Map<string, stri
 }
 
 function gitObjectExistence(requests: readonly GitObjectRequest[]): Set<string> {
+  return new Set(
+    [...gitObjectOids(requests)].filter(([, oid]) => oid !== null).map(([spec]) => spec),
+  );
+}
+
+function gitObjectOids(requests: readonly GitObjectRequest[]): Map<string, string | null> {
   const specs = uniqueNonEmpty(requests.map(({ commit, path }) => gitObjectSpec(commit, path)));
-  const existing = new Set<string>();
+  const objects = new Map<string, string | null>();
   for (const batch of chunked(specs, GIT_OBJECT_BATCH_SIZE)) {
     const lines = runGitObjectBatch("--batch-check", batch).toString("utf8").split("\n");
     if (lines.at(-1) === "") lines.pop();
@@ -2026,14 +2330,19 @@ function gitObjectExistence(requests: readonly GitObjectRequest[]): Set<string> 
       );
     }
     for (const [index, line] of lines.entries()) {
-      if (line!.endsWith(" missing")) continue;
-      if (!/^[0-9a-f]+ [^ ]+ \d+$/.test(line!)) {
+      const spec = batch[index]!;
+      if (line!.endsWith(" missing")) {
+        objects.set(spec, null);
+        continue;
+      }
+      const match = /^([0-9a-f]+) [^ ]+ \d+$/.exec(line!);
+      if (!match) {
         throw new Error(`Unexpected git cat-file batch-check response: ${line}`);
       }
-      existing.add(batch[index]!);
+      objects.set(spec, match[1]!);
     }
   }
-  return existing;
+  return objects;
 }
 
 function runGitObjectBatch(mode: "--batch" | "--batch-check", specs: readonly string[]): Buffer {

--- a/test/actions-checkout-v7.test.ts
+++ b/test/actions-checkout-v7.test.ts
@@ -68,7 +68,8 @@ const checkoutReferences = actionFiles.flatMap((path) =>
     })),
 );
 const checkoutV7Commit = "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0";
-const statePublisherPattern = /\bpnpm run repair:publish-main\b/g;
+const statePublisherPattern =
+  /\b(?:pnpm run repair:publish-main|node dist\/clawsweeper\.js publish-action-event-paths)\b/g;
 const statePublishTimingEnv = {
   acquisitionDeadlineMs: "CLAWSWEEPER_PUBLISH_ACQUIRE_DEADLINE_MS",
   commandTimeoutMs: "CLAWSWEEPER_PUBLISH_COMMAND_TIMEOUT_MS",
@@ -202,7 +203,7 @@ test("every state publisher job composes all calls within its timeout", () => {
   assert.equal(new Set(publisherJobs.map(({ workflowPath }) => workflowPath)).size, 16);
   assert.equal(
     publisherJobs.reduce((total, { calls }) => total + calls.length, 0),
-    33,
+    42,
   );
   for (const { calls, job, jobName, workflowPath } of publisherJobs) {
     const timeoutMinutes = job["timeout-minutes"];

--- a/test/clawsweeper-action-ledger.test.ts
+++ b/test/clawsweeper-action-ledger.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  actionEventPublishCoordinationForTest,
   actionEventPublishPathsForTest,
   actionLedgerFailureDisposition,
   applyActionEventDisposition,
@@ -259,6 +260,22 @@ test("action event publication accepts only sorted canonical event and binding p
   assert.throws(
     () => actionEventPublishPathsForTest("ledger/v1/import-bindings/private/raw.json\n"),
     /invalid action event publish path/,
+  );
+});
+
+test("immutable action event publication is explicitly staged", () => {
+  assert.equal(actionEventPublishCoordinationForTest({}), "exclusive");
+  assert.equal(
+    actionEventPublishCoordinationForTest({
+      CLAWSWEEPER_ACTION_LEDGER_IMMUTABLE_PUBLISH: "1",
+    }),
+    "immutable",
+  );
+  assert.equal(
+    actionEventPublishCoordinationForTest({
+      CLAWSWEEPER_ACTION_LEDGER_IMMUTABLE_PUBLISH: "true",
+    }),
+    "exclusive",
   );
 });
 

--- a/test/clawsweeper-action-ledger.test.ts
+++ b/test/clawsweeper-action-ledger.test.ts
@@ -788,7 +788,7 @@ test("sweep publishes complete immutable shards for every review and apply produ
   assert.match(workflow, /include-hidden-files: true/);
   assert.match(workflow, /--state-root "\$CLAWSWEEPER_STATE_DIR"/);
   assert.match(workflow, /durable_event_path="\$CLAWSWEEPER_STATE_DIR\/\$event_path"/);
-  assert.equal((workflow.match(/publish-action-event-paths/g) ?? []).length, 7);
+  assert.equal((workflow.match(/publish-action-event-paths/g) ?? []).length, 9);
   assert.doesNotMatch(
     workflow,
     /--message "chore: append (?:review|apply).*action ledger"[\s\S]{0,180}--path "ledger\/v1\/events"/,
@@ -820,7 +820,10 @@ test("comment router publishes immutable command receipts for initial and retry 
   assert.match(publishStep, /--lane comment-router/);
   assert.match(publishStep, /repair:action-ledger -- publish/);
   assert.match(publishStep, /--message "chore: append command action ledger"/);
-  assert.match(publishStep, /action_ledger_args\+=\(--path "\$event_path"\)/);
+  assert.match(publishStep, /cp "\$durable_event_path" "\$event_path"/);
+  assert.match(publishStep, /publish-action-event-paths/);
+  assert.match(publishStep, /--paths-file "\$event_paths_file"/);
+  assert.doesNotMatch(publishStep, /action_ledger_args|repair:publish-main/);
   assert.doesNotMatch(
     publishStep,
     /--message "chore: append command action ledger"[\s\S]{0,180}--path "ledger\/v1\/events"/,

--- a/test/repair/command-ops-action-ledger.test.ts
+++ b/test/repair/command-ops-action-ledger.test.ts
@@ -250,6 +250,10 @@ function assertCommandPublisherUsesCanonicalRoot(step: string): void {
   );
   assert.match(step, /jq -r '\.paths\[\]\?' "\$import_result_file"/);
   assert.match(step, /if \[ ! -s "\$event_paths_file" \]; then[\s\S]*?exit 1[\s\S]*?fi/);
+  assert.match(step, /cp "\$durable_event_path" "\$event_path"/);
+  assert.match(step, /publish-action-event-paths/);
+  assert.match(step, /--paths-file "\$event_paths_file"/);
+  assert.doesNotMatch(step, /action_ledger_args|repair:publish-main/);
   assert.doesNotMatch(step, /command_shard_found/);
   assert.doesNotMatch(step, /\.created > 0/);
   assert.doesNotMatch(step, /exit 0/);

--- a/test/repair/dispatch-action-receipts.test.ts
+++ b/test/repair/dispatch-action-receipts.test.ts
@@ -711,7 +711,8 @@ test("every workflow-backed dispatch producer publishes finalized receipt shards
     assert.match(workflow, new RegExp(`--lane ${lane}`));
     assert.match(workflow, /dist\/repair\/dispatch-action-ledger-cli\.js finalize/);
     assert.match(workflow, /dist\/repair\/dispatch-action-ledger-cli\.js publish/);
-    assert.match(workflow, /repair:publish-main/);
+    assert.match(workflow, /publish-action-event-paths/);
+    assert.doesNotMatch(workflow, /repair:publish-main[\s\S]{0,240}--rebase-strategy normal/);
   }
 });
 
@@ -846,7 +847,9 @@ test("failed, cancelled, and timed-out GitHub activity runs replay receipts", ()
     /run-id: \$\{\{ steps\.select-activity-dispatch-ledger\.outputs\.source_run_id \}\}/,
   );
   assert.match(workflow, /dispatch-action-ledger-cli\.js replay/);
-  assert.match(workflow, /repair:publish-main/);
+  assert.match(workflow, /publish-action-event-paths/);
+  assert.match(workflow, /--paths-file "\$event_paths_file"/);
+  assert.doesNotMatch(workflow, /repair:publish-main|action_ledger_args/);
   assert.match(workflow, /\.run_id == \$run_id/);
   assert.match(workflow, /\.run_attempt == \$run_attempt/);
   assert.doesNotMatch(workflow, /continue-on-error/);

--- a/test/repair/dispatch-action-receipts.test.ts
+++ b/test/repair/dispatch-action-receipts.test.ts
@@ -793,6 +793,7 @@ test("activity dispatch publishes receipts before the noncritical notifier", () 
   assert.match(publishStep, /bundle-activity-dispatch-ledger\.outputs\.ready == 'true'/);
   assert.doesNotMatch(publishStep, /upload-activity-dispatch-ledger\.outcome/);
   assert.match(publishStep, /continue-on-error: true/);
+  assert.match(publishStep, /CLAWSWEEPER_ACTION_LEDGER_IMMUTABLE_PUBLISH: "1"/);
   assert.match(
     workflow,
     /- name: Feed activity to OpenClaw\n\s+id: notify-openclaw\n\s+if: \$\{\{ always\(\)[^\n]+\}\}\n\s+continue-on-error: true/,
@@ -848,6 +849,7 @@ test("failed, cancelled, and timed-out GitHub activity runs replay receipts", ()
   );
   assert.match(workflow, /dispatch-action-ledger-cli\.js replay/);
   assert.match(workflow, /publish-action-event-paths/);
+  assert.match(workflow.slice(replayOffset), /CLAWSWEEPER_ACTION_LEDGER_IMMUTABLE_PUBLISH: "1"/);
   assert.match(workflow, /--paths-file "\$event_paths_file"/);
   assert.doesNotMatch(workflow, /repair:publish-main|action_ledger_args/);
   assert.match(workflow, /\.run_id == \$run_id/);

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -3871,6 +3871,62 @@ test("immutable publishers yield to an active exclusive state mutation", async (
   );
 });
 
+test("immutable publisher converges when an exclusive lease appears before its push", () => {
+  const fixture = createStatePublishRemote("immutable-exclusive-acquisition-race");
+  const immutableState = path.join(fixture.root, "state-immutable");
+  const exclusiveState = path.join(fixture.root, "state-exclusive");
+  const immutableSource = path.join(fixture.root, "source-immutable");
+  const exclusiveSource = path.join(fixture.root, "source-exclusive");
+  const immutablePath = `ledger/v1/import-bindings/events/${"e".repeat(64)}.json`;
+  const exclusivePath = "results/exclusive-after-check.txt";
+  cloneState(fixture.origin, immutableState);
+  cloneState(fixture.origin, exclusiveState);
+  fs.mkdirSync(immutableSource);
+  fs.mkdirSync(exclusiveSource);
+  write(path.join(immutableSource, immutablePath), '{"event":"immutable"}\n');
+  write(path.join(exclusiveSource, exclusivePath), "exclusive\n");
+  const marker = installExclusivePublishDuringStatePushHook(
+    immutableState,
+    exclusiveSource,
+    exclusiveState,
+  );
+  const lines = captureConsoleLog(() =>
+    withEnv(
+      leasedPublishEnv({
+        CLAWSWEEPER_STATE_DIR: immutableState,
+        CLAWSWEEPER_PUBLISH_ACQUIRE_DEADLINE_MS: "5000",
+        CLAWSWEEPER_PUBLISH_DEADLINE_MS: "3000",
+        CLAWSWEEPER_PUBLISH_COMMAND_TIMEOUT_MS: "1000",
+        CLAWSWEEPER_PUBLISH_LEASE_TTL_MS: "4000",
+        CLAWSWEEPER_PUBLISH_LEASE_WAIT_MS: "10",
+      }),
+      () =>
+        withCwd(immutableSource, () =>
+          publishMainCommit({
+            message: "chore: append immutable event after exclusive acquisition",
+            paths: [immutablePath],
+            coordination: "immutable",
+          }),
+        ),
+    ),
+  );
+
+  assert.equal(fs.existsSync(marker), true);
+  assert.equal(
+    lines.some((line) => line.includes("Immutable publish lost state race attempt=1/32")),
+    true,
+  );
+  assert.equal(
+    run("git", ["--git-dir", fixture.origin, "show", `state:${immutablePath}`], fixture.root),
+    '{"event":"immutable"}\n',
+  );
+  assert.equal(
+    run("git", ["--git-dir", fixture.origin, "show", `state:${exclusivePath}`], fixture.root),
+    "exclusive\n",
+  );
+  assert.equal(remoteRefExists(fixture.origin, STATE_PUBLISH_LEASE_REF), false);
+});
+
 test("immutable publication deadline bounds continuous rejected branch pushes", () => {
   const fixture = createStatePublishRemote("immutable-deadline");
   const state = path.join(fixture.root, "state");
@@ -4268,6 +4324,31 @@ done
 `,
   );
   fs.chmodSync(hook, 0o755);
+}
+
+function installExclusivePublishDuringStatePushHook(state, source, exclusiveState) {
+  const hook = path.join(state, ".git/hooks/pre-push");
+  const marker = path.join(state, ".git/hooks/exclusive-publish-completed");
+  const publishCli = path.resolve("dist/repair/publish-main.js");
+  fs.writeFileSync(
+    hook,
+    `#!/bin/sh
+while read -r local_ref local_oid remote_ref remote_oid; do
+  if test "$remote_ref" = "refs/heads/state" && test ! -f "${marker}"; then
+    (
+      cd "${source}"
+      CLAWSWEEPER_STATE_DIR="${exclusiveState}" \
+      "${process.execPath}" "${publishCli}" \
+        --message "chore: publish exclusive mutation during immutable push" \
+        --path "results/exclusive-after-check.txt"
+    )
+    touch "${marker}"
+  fi
+done
+`,
+  );
+  fs.chmodSync(hook, 0o755);
+  return marker;
 }
 
 function installLeasePushSleepHook(state, seconds) {

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { execFileSync, spawn } from "node:child_process";
 import test from "node:test";
+import { pathToFileURL } from "node:url";
 
 import {
   captureStatePublishBaseline,
@@ -17,6 +18,17 @@ import {
   stagePaths,
   uniqueNonEmpty,
 } from "../../dist/repair/git-publish.js";
+import {
+  ACTION_EVENT_TYPES,
+  actionAttemptId,
+  actionEventKey,
+  actionEventShardRelativePath,
+  actionIdempotencyKey,
+  actionLedgerJson,
+  actionOperationId,
+  createActionEvent,
+  type ActionEventInput,
+} from "../../dist/action-ledger.js";
 
 for (const key of [
   "CLAWSWEEPER_STATE_DIR",
@@ -35,6 +47,81 @@ for (const key of [
 }
 process.env.CLAWSWEEPER_PUBLISH_LEASE = "false";
 
+function replayEquivalentActionShards() {
+  const repository = "openclaw/clawsweeper";
+  const sourceRevision = "a".repeat(40);
+  const operationId = actionOperationId(repository, "review", {
+    number: 1,
+    sourceRevision,
+  });
+  const attemptId = actionAttemptId(operationId, { runId: "1", runAttempt: 1 });
+  const input: ActionEventInput = {
+    eventKey: actionEventKey("review.completed", {
+      repository,
+      number: 1,
+      sourceRevision,
+    }),
+    operationId,
+    attemptId,
+    parentEventId: null,
+    phaseSeq: 1,
+    idempotencyKeySha256: actionIdempotencyKey({
+      repository,
+      number: 1,
+      sourceRevision,
+      action: "review",
+    }),
+    type: ACTION_EVENT_TYPES.reviewCompleted,
+    producer: {
+      repository,
+      sha: sourceRevision,
+      workflow: "sweep.yml",
+      job: "review",
+      runId: "1",
+      runAttempt: 1,
+      component: "review.test",
+    },
+    subject: {
+      repository,
+      kind: "pull_request",
+      number: 1,
+      sourceRevision,
+    },
+    action: {
+      name: "review",
+      status: "completed",
+      reasonCode: "completed",
+      retryable: false,
+      mutation: false,
+    },
+    evidence: [],
+  };
+  const first = createActionEvent(input, {
+    now: () => new Date("2026-07-14T20:00:00.000Z"),
+  });
+  const second = createActionEvent(input, {
+    now: () => new Date("2026-07-14T20:00:01.000Z"),
+  });
+  const publishPath = actionEventShardRelativePath(
+    {
+      repository,
+      sha: sourceRevision,
+      producer: "review.test",
+      workflow: "sweep.yml",
+      job: "review",
+      runId: "1",
+      runAttempt: 1,
+      partitionDate: "2026-07-14",
+    },
+    [first],
+  ).replaceAll(path.sep, "/");
+  return {
+    publishPath,
+    first: `${actionLedgerJson(first)}\n`,
+    second: `${actionLedgerJson(second)}\n`,
+  };
+}
+
 const STATE_PUBLISH_LEASE_REF = "refs/heads/clawsweeper-publish-lease/state";
 
 test("default lease timing can recover a crashed owner within the workflow budget", () => {
@@ -51,6 +138,28 @@ test("default lease timing can recover a crashed owner within the workflow budge
       timing.commandTimeoutMs +
       timing.workflowMarginMs <=
       timing.workflowTimeoutMs,
+  );
+});
+
+test("immutable coordination accepts only exact action ledger paths", () => {
+  assert.throws(
+    () =>
+      publishMainCommit({
+        message: "chore: reject mutable optimistic state",
+        paths: ["results/latest.json"],
+        coordination: "immutable",
+      }),
+    /only exact action ledger event and import-binding paths/,
+  );
+  assert.throws(
+    () =>
+      publishMainCommit({
+        message: "chore: reject mutable optimistic strategy",
+        paths: ["ledger/v1/events/2026/07/14/openclaw-clawsweeper/review/run-1-review-a.jsonl"],
+        coordination: "immutable",
+        rebaseStrategy: "theirs",
+      }),
+    /requires the normal rebase strategy/,
   );
 });
 
@@ -104,6 +213,12 @@ test("commitMessageForPublishedPaths skips CI for generated-only publishes", () 
   assert.equal(
     commitMessageForPublishedPaths("fix: update scheduler", ["src/repair/git-publish.ts"]),
     "fix: update scheduler",
+  );
+  assert.equal(
+    commitMessageForPublishedPaths("chore: append action ledger", [
+      "ledger/v1/events/2026/07/14/openclaw-clawsweeper/review/run-1-review-a.jsonl",
+    ]),
+    "chore: append action ledger\n\n[skip ci]",
   );
 });
 
@@ -3485,6 +3600,312 @@ test("publish-main CLI accepts package-manager double dash separators", () => {
   );
 });
 
+test("immutable publisher treats identical paths as idempotent and rejects collisions", () => {
+  const fixture = createStatePublishRemote("immutable-collision");
+  const state = path.join(fixture.root, "state");
+  const source = path.join(fixture.root, "source");
+  const shard = replayEquivalentActionShards();
+  const publishPath = shard.publishPath;
+  cloneState(fixture.origin, state);
+  write(path.join(state, publishPath), shard.first);
+  run("git", ["add", publishPath], state);
+  run("git", ["commit", "-m", "seed immutable event"], state);
+  run("git", ["push", "origin", "HEAD:state"], state);
+  fs.mkdirSync(source);
+  write(path.join(source, publishPath), shard.first);
+
+  const replay = withEnv(leasedPublishEnv({ CLAWSWEEPER_STATE_DIR: state }), () =>
+    withCwd(source, () =>
+      publishMainCommit({
+        message: "chore: replay immutable event",
+        paths: [publishPath],
+        coordination: "immutable",
+      }),
+    ),
+  );
+  assert.equal(replay, "unchanged");
+  assert.equal(remoteRefExists(fixture.origin, STATE_PUBLISH_LEASE_REF), false);
+
+  write(path.join(source, publishPath), shard.second);
+  const equivalentReplay = withEnv(leasedPublishEnv({ CLAWSWEEPER_STATE_DIR: state }), () =>
+    withCwd(source, () =>
+      publishMainCommit({
+        message: "chore: replay equivalent immutable event",
+        paths: [publishPath],
+        coordination: "immutable",
+      }),
+    ),
+  );
+  assert.equal(equivalentReplay, "unchanged");
+
+  write(path.join(source, publishPath), "conflicting event\n");
+  assert.throws(
+    () =>
+      withEnv(leasedPublishEnv({ CLAWSWEEPER_STATE_DIR: state }), () =>
+        withCwd(source, () =>
+          publishMainCommit({
+            message: "chore: reject immutable collision",
+            paths: [publishPath],
+            coordination: "immutable",
+          }),
+        ),
+      ),
+    /Immutable action ledger path conflict/,
+  );
+  assert.equal(
+    run("git", ["--git-dir", fixture.origin, "show", `state:${publishPath}`], fixture.root),
+    shard.first,
+  );
+});
+
+test("immutable publisher adds only missing paths during a partial replay", () => {
+  const fixture = createStatePublishRemote("immutable-partial-replay");
+  const state = path.join(fixture.root, "state");
+  const source = path.join(fixture.root, "source");
+  const existingPath = `ledger/v1/import-bindings/events/${"a".repeat(64)}.json`;
+  const missingPath = `ledger/v1/import-bindings/events/${"b".repeat(64)}.json`;
+  cloneState(fixture.origin, state);
+  write(path.join(state, existingPath), '{"event":"existing"}\n');
+  run("git", ["add", existingPath], state);
+  run("git", ["commit", "-m", "seed immutable binding"], state);
+  run("git", ["push", "origin", "HEAD:state"], state);
+  fs.mkdirSync(source);
+  write(path.join(source, existingPath), '{"event":"existing"}\n');
+  write(path.join(source, missingPath), '{"event":"missing"}\n');
+
+  const result = withEnv(leasedPublishEnv({ CLAWSWEEPER_STATE_DIR: state }), () =>
+    withCwd(source, () =>
+      publishMainCommit({
+        message: "chore: partially replay immutable bindings",
+        paths: [existingPath, missingPath],
+        coordination: "immutable",
+      }),
+    ),
+  );
+
+  assert.equal(result, "committed");
+  assert.equal(
+    run("git", ["--git-dir", fixture.origin, "show", `state:${existingPath}`], fixture.root),
+    '{"event":"existing"}\n',
+  );
+  assert.equal(
+    run("git", ["--git-dir", fixture.origin, "show", `state:${missingPath}`], fixture.root),
+    '{"event":"missing"}\n',
+  );
+  assert.equal(remoteRefExists(fixture.origin, STATE_PUBLISH_LEASE_REF), false);
+});
+
+test("immutable publisher verifies an accepted branch push after client timeout", () => {
+  const fixture = createStatePublishRemote("immutable-accepted-timeout");
+  const state = path.join(fixture.root, "state");
+  const source = path.join(fixture.root, "source");
+  const publishPath = `ledger/v1/import-bindings/events/${"c".repeat(64)}.json`;
+  cloneState(fixture.origin, state);
+  fs.mkdirSync(source);
+  write(path.join(source, publishPath), '{"event":"accepted"}\n');
+  installAcceptedStatePushTimeoutHook(fixture.origin, 0.3);
+
+  const result = withEnv(
+    leasedPublishEnv({
+      CLAWSWEEPER_STATE_DIR: state,
+      CLAWSWEEPER_PUBLISH_DEADLINE_MS: "3000",
+      CLAWSWEEPER_PUBLISH_COMMAND_TIMEOUT_MS: "100",
+    }),
+    () =>
+      withCwd(source, () =>
+        publishMainCommit({
+          message: "chore: verify immutable accepted timeout",
+          paths: [publishPath],
+          coordination: "immutable",
+        }),
+      ),
+  );
+
+  assert.equal(result, "committed");
+  assert.equal(
+    run("git", ["--git-dir", fixture.origin, "show", `state:${publishPath}`], fixture.root),
+    '{"event":"accepted"}\n',
+  );
+});
+
+test("immutable publishers converge concurrent disjoint action ledger paths without a lease", async () => {
+  const fixture = createStatePublishRemote("immutable-concurrency");
+  const publisherCount = 12;
+  const env = leasedPublishEnv({
+    CLAWSWEEPER_PUBLISH_DEADLINE_MS: "15000",
+    CLAWSWEEPER_PUBLISH_COMMAND_TIMEOUT_MS: "3000",
+  });
+  const publishers = Array.from({ length: publisherCount }, (_, index) => {
+    const state = path.join(fixture.root, `state-${index}`);
+    const source = path.join(fixture.root, `source-${index}`);
+    const publishPath = `ledger/v1/events/2026/07/14/openclaw-clawsweeper/review/run-${index + 1}-review-${String(index).padStart(2, "0")}.jsonl`;
+    cloneState(fixture.origin, state);
+    fs.mkdirSync(source);
+    write(path.join(source, publishPath), `event ${index}\n`);
+    return {
+      publishPath,
+      child: startImmutablePublishProcess(
+        source,
+        state,
+        `chore: append immutable event ${index}`,
+        publishPath,
+        env,
+      ),
+    };
+  });
+
+  const completed = await Promise.all(publishers.map(({ child }) => waitForChild(child)));
+  for (const result of completed) {
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  }
+  for (const [index, { publishPath }] of publishers.entries()) {
+    assert.equal(
+      run("git", ["--git-dir", fixture.origin, "show", `state:${publishPath}`], fixture.root),
+      `event ${index}\n`,
+    );
+  }
+  assert.equal(remoteRefExists(fixture.origin, STATE_PUBLISH_LEASE_REF), false);
+});
+
+test("immutable publisher converges through unrelated mutable branch updates", () => {
+  const fixture = createStatePublishRemote("immutable-mutable-storm");
+  const state = path.join(fixture.root, "state");
+  const other = path.join(fixture.root, "other");
+  const source = path.join(fixture.root, "source");
+  const publishPath = `ledger/v1/import-bindings/events/${"d".repeat(64)}.json`;
+  cloneState(fixture.origin, state);
+  cloneState(fixture.origin, other);
+  fs.mkdirSync(source);
+  write(path.join(source, publishPath), '{"event":"storm"}\n');
+  installRepeatedStateRaceHook(state, other, 3);
+
+  const result = withEnv(
+    leasedPublishEnv({
+      CLAWSWEEPER_STATE_DIR: state,
+      CLAWSWEEPER_PUBLISH_DEADLINE_MS: "5000",
+      CLAWSWEEPER_PUBLISH_COMMAND_TIMEOUT_MS: "2000",
+    }),
+    () =>
+      withCwd(source, () =>
+        publishMainCommit({
+          message: "chore: append immutable event through mutable storm",
+          paths: [publishPath],
+          coordination: "immutable",
+        }),
+      ),
+  );
+
+  assert.equal(result, "committed");
+  assert.equal(
+    run("git", ["--git-dir", fixture.origin, "show", `state:${publishPath}`], fixture.root),
+    '{"event":"storm"}\n',
+  );
+  for (let race = 1; race <= 3; race += 1) {
+    assert.equal(
+      run(
+        "git",
+        ["--git-dir", fixture.origin, "show", `state:results/remote-race-${race}.txt`],
+        fixture.root,
+      ),
+      `remote race ${race}\n`,
+    );
+  }
+  assert.equal(remoteRefExists(fixture.origin, STATE_PUBLISH_LEASE_REF), false);
+});
+
+test("immutable publishers yield to an active exclusive state mutation", async () => {
+  const fixture = createStatePublishRemote("immutable-exclusive-priority");
+  const exclusiveState = path.join(fixture.root, "state-exclusive");
+  const immutableState = path.join(fixture.root, "state-immutable");
+  const exclusiveSource = path.join(fixture.root, "source-exclusive");
+  const immutableSource = path.join(fixture.root, "source-immutable");
+  const releaseSignal = path.join(fixture.root, "release-exclusive");
+  const releaseObserved = path.join(fixture.root, "exclusive-released");
+  const immutablePath =
+    "ledger/v1/events/2026/07/14/openclaw-clawsweeper/review/run-priority-review-a.jsonl";
+  cloneState(fixture.origin, exclusiveState);
+  cloneState(fixture.origin, immutableState);
+  fs.mkdirSync(exclusiveSource);
+  fs.mkdirSync(immutableSource);
+  write(path.join(exclusiveSource, "results/exclusive.txt"), "exclusive\n");
+  write(path.join(immutableSource, immutablePath), "immutable\n");
+  installStatePushReleaseHook(exclusiveState, releaseSignal, releaseObserved);
+  const env = leasedPublishEnv({
+    CLAWSWEEPER_PUBLISH_ACQUIRE_DEADLINE_MS: "5000",
+    CLAWSWEEPER_PUBLISH_DEADLINE_MS: "3000",
+    CLAWSWEEPER_PUBLISH_COMMAND_TIMEOUT_MS: "1000",
+    CLAWSWEEPER_PUBLISH_LEASE_TTL_MS: "4000",
+    CLAWSWEEPER_PUBLISH_LEASE_WAIT_MS: "10",
+  });
+
+  const exclusive = startPublishCli(
+    exclusiveSource,
+    exclusiveState,
+    "chore: publish exclusive mutation",
+    env,
+  );
+  const exclusiveResult = waitForChild(exclusive);
+  await waitForRemoteRef(fixture.origin, STATE_PUBLISH_LEASE_REF);
+  const immutable = startImmutablePublishProcess(
+    immutableSource,
+    immutableState,
+    "chore: append priority event",
+    immutablePath,
+    env,
+  );
+  const immutableResult = waitForChild(immutable);
+  await waitForChildOutput(immutable, "Immutable publish yielding to exclusive state lease");
+  write(releaseSignal, "release\n");
+
+  const [exclusiveCompleted, immutableCompleted] = await Promise.all([
+    exclusiveResult,
+    immutableResult,
+  ]);
+  assert.equal(exclusiveCompleted.status, 0, exclusiveCompleted.stderr);
+  assert.equal(immutableCompleted.status, 0, immutableCompleted.stderr);
+  assert.equal(fs.existsSync(releaseObserved), true);
+  assert.equal(remoteRefExists(fixture.origin, STATE_PUBLISH_LEASE_REF), false);
+  assert.equal(
+    run("git", ["--git-dir", fixture.origin, "show", `state:${immutablePath}`], fixture.root),
+    "immutable\n",
+  );
+});
+
+test("immutable publication deadline bounds continuous rejected branch pushes", () => {
+  const fixture = createStatePublishRemote("immutable-deadline");
+  const state = path.join(fixture.root, "state");
+  const source = path.join(fixture.root, "source");
+  const publishPath =
+    "ledger/v1/events/2026/07/14/openclaw-clawsweeper/review/run-deadline-review-a.jsonl";
+  cloneState(fixture.origin, state);
+  fs.mkdirSync(source);
+  write(path.join(source, publishPath), "deadline event\n");
+  installStatePushRejectHook(fixture.origin);
+  const startedAt = Date.now();
+
+  assert.throws(
+    () =>
+      withEnv(
+        leasedPublishEnv({
+          CLAWSWEEPER_STATE_DIR: state,
+          CLAWSWEEPER_PUBLISH_DEADLINE_MS: "120",
+          CLAWSWEEPER_PUBLISH_COMMAND_TIMEOUT_MS: "100",
+        }),
+        () =>
+          withCwd(source, () =>
+            publishMainCommit({
+              message: "chore: bound immutable retries",
+              paths: [publishPath],
+              coordination: "immutable",
+              maxAttempts: 100,
+            }),
+          ),
+      ),
+    /State publication deadline exceeded/,
+  );
+  assert.ok(Date.now() - startedAt < 1500);
+});
+
 test("setTokenOrigin redacts tokens from command logs", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
   run("git", ["init"], root);
@@ -3547,6 +3968,26 @@ function startPublishCli(cwd, stateDir, message, env) {
       stdio: ["ignore", "pipe", "pipe"],
     },
   );
+}
+
+function startImmutablePublishProcess(cwd, stateDir, message, publishPath, env) {
+  const moduleUrl = pathToFileURL(path.resolve("dist/repair/git-publish.js")).href;
+  const script = `const { publishMainCommit } = await import(${JSON.stringify(moduleUrl)});
+publishMainCommit({
+  message: process.argv[1],
+  paths: [process.argv[2]],
+  coordination: "immutable",
+});`;
+  return spawn(process.execPath, ["--input-type=module", "--eval", script, message, publishPath], {
+    cwd,
+    detached: true,
+    env: {
+      ...process.env,
+      ...env,
+      CLAWSWEEPER_STATE_DIR: stateDir,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
 }
 
 function listFixtureFiles(root) {

--- a/test/repair/self-heal-recovery-inputs.test.ts
+++ b/test/repair/self-heal-recovery-inputs.test.ts
@@ -194,7 +194,13 @@ test("self-heal writes and publishes dispatch attempts before legacy summaries",
   assert.match(setupAction, /CLAWSWEEPER_ACTION_LEDGER_ROOT=\$ledger_root/);
   assert.match(workflow, /uses: \.\/\.github\/actions\/setup-action-ledger/);
   assert.match(workflow, /--lane self-heal-dispatch/);
+  assert.match(workflow, /publish-action-event-paths/);
+  assert.match(workflow, /--paths-file "\$event_paths_file"/);
   assert.match(workflow, /--message "chore: append self-heal dispatch action ledger"/);
+  assert.doesNotMatch(
+    workflow,
+    /repair:publish-main[\s\S]{0,240}--rebase-strategy normal|action_ledger_args/,
+  );
 });
 
 test("executing self-heal uses durable local dispatch receipts outside Actions", () => {

--- a/test/repair/spam-comment-intake.test.ts
+++ b/test/repair/spam-comment-intake.test.ts
@@ -292,7 +292,12 @@ test("spam intake workflows publish authoritative dispatch receipts", () => {
     assert.match(workflow, new RegExp(`--lane ${lane}`));
     assert.match(workflow, /dist\/repair\/dispatch-action-ledger-cli\.js finalize/);
     assert.match(workflow, /dist\/repair\/dispatch-action-ledger-cli\.js publish/);
-    assert.match(workflow, /repair:publish-main/);
+    assert.match(workflow, /publish-action-event-paths/);
+    assert.match(workflow, /--paths-file "\$event_paths_file"/);
+    assert.doesNotMatch(
+      workflow,
+      /repair:publish-main[\s\S]{0,240}--rebase-strategy normal|action_ledger_args/,
+    );
   }
 });
 

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -22,6 +22,70 @@ test("sweep keeps optional media tooling out of review startup", () => {
   assert.doesNotMatch(workflow, /setup-media-proof-tools/);
 });
 
+test("immutable action ledger publishers use path-manifest admission", () => {
+  type WorkflowStep = {
+    name?: string;
+    run?: string;
+  };
+  type WorkflowJob = {
+    steps?: WorkflowStep[];
+  };
+
+  const inventory = [
+    [".github/workflows/github-activity.yml", ["Publish GitHub activity dispatch action ledger"]],
+    [
+      ".github/workflows/github-activity-receipt-replay.yml",
+      ["Replay GitHub activity dispatch action ledger"],
+    ],
+    [".github/workflows/spam-comment-intake.yml", ["Publish spam intake dispatch action ledger"]],
+    [".github/workflows/repair-self-heal.yml", ["Publish self-heal dispatch action ledger"]],
+    [".github/workflows/repair-comment-router.yml", ["Publish immutable command action ledger"]],
+    [
+      ".github/workflows/repair-cluster-worker.yml",
+      [
+        "Publish immutable execute-fix action ledger",
+        "Publish immutable repair requeue action ledger",
+      ],
+    ],
+    [
+      ".github/workflows/sweep.yml",
+      [
+        "Publish exact event action ledger",
+        "Publish late command status action ledger",
+        "Publish target fanout dispatch action ledger",
+        "Publish immutable review action ledger",
+        "Publish review artifact action ledger",
+        "Publish selected review comment action ledger",
+        "Publish failed-review retry action ledger",
+        "Publish apply proof action events",
+        "Publish apply action events",
+      ],
+    ],
+  ] as const;
+
+  for (const [workflowPath, publisherNames] of inventory) {
+    const workflow = YAML.parse(readText(workflowPath)) as {
+      jobs: Record<string, WorkflowJob>;
+    };
+    const steps = Object.values(workflow.jobs).flatMap((job) => job.steps ?? []);
+    for (const publisherName of publisherNames) {
+      const publisher = steps.find((step) => step.name === publisherName);
+      assert.ok(publisher, `missing ${workflowPath} step ${publisherName}`);
+      assert.match(publisher.run ?? "", /publish-action-event-paths/);
+      assert.match(publisher.run ?? "", /--paths-file /);
+      assert.doesNotMatch(publisher.run ?? "", /repair:publish-main|action_ledger_args/);
+    }
+    for (const step of steps) {
+      if (!/(?:action (?:ledger|events)|dispatch receipt)/i.test(step.name ?? "")) continue;
+      assert.doesNotMatch(
+        step.run ?? "",
+        /repair:publish-main[\s\S]*--rebase-strategy normal/,
+        `${workflowPath} step ${step.name} bypasses path-manifest admission`,
+      );
+    }
+  }
+});
+
 test("ledger-producing jobs initialize immutable workflow context", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   for (const jobName of [


### PR DESCRIPTION
## Summary

- route every action, review, and repair ledger publication through the validated immutable path-manifest boundary
- add a create-only optimistic publisher that converges disjoint state-branch races without taking the global mutation lease
- stage the new coordination mode on GitHub activity publication and receipt replay before broad activation
- cover all 42 state-publisher workflow calls with timeout composition checks

## Why

Concurrent production activity runs froze valid receipt bundles, then both source publication and replay exhausted the 180-second global state lease deadline:

- https://github.com/openclaw/clawsweeper/actions/runs/29365759179
- https://github.com/openclaw/clawsweeper/actions/runs/29365759384
- https://github.com/openclaw/clawsweeper/actions/runs/29366094046
- https://github.com/openclaw/clawsweeper/actions/runs/29366096954

The lease serialized append-only ledger writes behind unrelated mutable state, while direct event result publishers were not actually fenced by that lease. This change separates the conflict classes instead of extending the timeout.

## Algorithm

- immutable action paths are admitted by canonical path shape and regular-file checks
- exact and replay-equivalent event shards are idempotent
- conflicting event or binding content fails closed
- branch updates use fast-forward compare-and-swap with bounded fetch/rebuild/jitter retries
- immutable writers yield while a live exclusive mutation lease exists but never create a lease
- accepted push timeouts are verified against remote blobs

## Verification

- TypeScript compiler: main and repair configs
- formatter and `git diff --check`
- publisher suite: 63/63
- workflow/receipt suite: 131/131
- publisher timeout inventory: 16 workflows / 42 calls
- exact local ClawSweeper review at `a6033b93ac65dcbfe9c645b0b62bc4ff8afc4530`: no findings, security cleared
- stress coverage: 12 concurrent disjoint publishers, repeated unrelated branch races, collision rejection, partial replay, accepted timeout verification, live exclusive lease yield, post-admission exclusive lease acquisition, and deadline bounding

## Rollout

1. canary GitHub activity source publication and receipt replay
2. inspect state-branch timing and ledger integrity
3. remove the staging flag in a follow-up PR after the live canary is clean