### PR TITLE
fix(state): keep immutable publication live behind leases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Bounded immutable action-ledger publishers' priority yield to exclusive state
+  leases so a valid long-lived lease cannot starve a shorter immutable
+  publication deadline; exclusive publishers still rebuild around branch races.
 - Kept immutable action-ledger publication available in repair-only workflow
   jobs by moving shard import and path-manifest admission behind repair-native
   CLIs, while retaining the root commands as compatibility entrypoints.

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -690,6 +690,7 @@ function waitForExclusiveStatePublishLeaseGap(
 }
 
 function immutableExclusiveLeasePriorityDeadlineMs(): number {
+  const startedAtMs = activeGitPublishMetrics?.startedAtMs ?? Date.now();
   const operationDeadlineMs =
     activeGitPublishMetrics?.operationDeadlineMs ??
     STATE_PUBLISH_TIMING_DEFAULTS.operationDeadlineMs;
@@ -697,7 +698,7 @@ function immutableExclusiveLeasePriorityDeadlineMs(): number {
     STATE_PUBLISH_TIMING_DEFAULTS.immutableLeasePriorityMaxMs,
     Math.max(1, Math.floor(operationDeadlineMs / 6)),
   );
-  const priorityDeadlineMs = Date.now() + priorityBudgetMs;
+  const priorityDeadlineMs = startedAtMs + priorityBudgetMs;
   return Math.min(priorityDeadlineMs, activeGitPublishMetrics?.deadlineAtMs ?? priorityDeadlineMs);
 }
 

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -57,6 +57,7 @@ export type RebaseStrategy = "normal" | "theirs" | "apply-records" | "reconcile-
 
 export type GitRunOptions = {
   allowFailure?: boolean;
+  deadlineAtMs?: number;
   displayArgs?: readonly string[];
   ignorePublishDeadline?: boolean;
   input?: string;
@@ -83,6 +84,7 @@ export const STATE_PUBLISH_TIMING_DEFAULTS = Object.freeze({
   acquisitionDeadlineMs: 3 * 60 * 1000,
   operationDeadlineMs: 90 * 1000,
   commandTimeoutMs: 30 * 1000,
+  immutableLeasePriorityMaxMs: 15 * 1000,
   leaseTtlMs: 2 * 60 * 1000,
   leaseMaxWaitMs: 15 * 1000,
   leaseProtocolVersion: 1,
@@ -198,15 +200,31 @@ export function spawnGit(args: readonly string[], options: GitRunOptions = {}): 
 
 function gitCommandTimeoutMs(options: GitRunOptions): number | undefined {
   const metrics = activeGitPublishMetrics;
-  if (!metrics?.commandTimeoutMs) return undefined;
-  if (options.ignorePublishDeadline || metrics.deadlineAtMs === null) {
-    return metrics.commandTimeoutMs;
+  const publishDeadlineAtMs =
+    options.ignorePublishDeadline || metrics?.deadlineAtMs === null
+      ? undefined
+      : (metrics?.deadlineAtMs ?? undefined);
+  const deadlineAtMs =
+    options.deadlineAtMs === undefined
+      ? publishDeadlineAtMs
+      : Math.min(options.deadlineAtMs, publishDeadlineAtMs ?? options.deadlineAtMs);
+  if (!metrics?.commandTimeoutMs && deadlineAtMs === undefined) return undefined;
+  if (deadlineAtMs === undefined) {
+    return metrics?.commandTimeoutMs ?? undefined;
   }
-  const remaining = metrics.deadlineAtMs - Date.now();
+  const remaining = deadlineAtMs - Date.now();
   if (remaining <= 0) {
+    if (
+      options.deadlineAtMs !== undefined &&
+      (publishDeadlineAtMs === undefined || options.deadlineAtMs < publishDeadlineAtMs)
+    ) {
+      const error = new Error("Git command-specific deadline elapsed during state publication");
+      (error as NodeJS.ErrnoException).code = "ETIMEDOUT";
+      throw error;
+    }
     throw new Error("State publication deadline exceeded before the next git command");
   }
-  return Math.max(1, Math.min(metrics.commandTimeoutMs, remaining));
+  return Math.max(1, Math.min(metrics?.commandTimeoutMs ?? remaining, remaining));
 }
 
 function recordGitProcess(action: string | undefined): void {
@@ -433,9 +451,22 @@ function convergeImmutablePublish(options: {
   maxAttempts: number;
 }): PublishResult {
   const observedLeases = new Map<string, ObservedStatePublishLease>();
+  const exclusiveLeasePriorityDeadlineMs = immutableExclusiveLeasePriorityDeadlineMs();
+  let exclusiveLeasePriorityExhausted = false;
+  let exclusiveLeaseObserved = false;
   for (let attempt = 1; attempt <= options.maxAttempts; attempt += 1) {
     assertStatePublishDeadline("publishing immutable action ledger paths");
-    waitForExclusiveStatePublishLeaseGap(options.remote, options.branch, observedLeases);
+    if (!exclusiveLeasePriorityExhausted) {
+      const priority = waitForExclusiveStatePublishLeaseGap(
+        options.remote,
+        options.branch,
+        observedLeases,
+        exclusiveLeasePriorityDeadlineMs,
+        exclusiveLeaseObserved,
+      );
+      exclusiveLeasePriorityExhausted = priority.exhausted;
+      exclusiveLeaseObserved = priority.observed;
+    }
     const compatibility = immutableRemoteCompatibility({
       remote: options.remote,
       branch: options.branch,
@@ -608,19 +639,66 @@ function waitForExclusiveStatePublishLeaseGap(
   remote: string,
   branch: string,
   observedByOid: Map<string, ObservedStatePublishLease>,
-): void {
+  priorityDeadlineMs: number,
+  previouslyObserved: boolean,
+): { exhausted: boolean; observed: boolean } {
   const leaseRef = `${STATE_PUBLISH_LEASE_REF_ROOT}/${branch}`;
+  let lastObserved: ObservedStatePublishLease | null = null;
   for (;;) {
     assertStatePublishDeadline("waiting for exclusive state publication");
-    const observed = observeStatePublishLease(remote, leaseRef, observedByOid);
-    const remainingMs = observed ? observed.expiresAtMs - Date.now() : 0;
-    if (!observed || remainingMs <= 0) return;
-    const waitMs = Math.min(remainingMs, 1_000);
+    if (Date.now() >= priorityDeadlineMs) {
+      if (lastObserved) {
+        console.log(
+          `Immutable publish priority yield exhausted; proceeding alongside active exclusive state lease owner=${lastObserved.owner}`,
+        );
+      } else if (previouslyObserved) {
+        console.log(
+          "Immutable publish priority yield exhausted after earlier exclusive lease contention; proceeding without further lease preference",
+        );
+      }
+      return { exhausted: true, observed: previouslyObserved || lastObserved !== null };
+    }
+    let observed: ObservedStatePublishLease | null;
+    try {
+      observed = observeStatePublishLease(remote, leaseRef, observedByOid, priorityDeadlineMs);
+    } catch (error) {
+      if (!isGitTimeoutError(error)) throw error;
+      console.log(
+        "Immutable publish priority yield exhausted during lease observation; proceeding without further exclusive lease preference",
+      );
+      return { exhausted: true, observed: true };
+    }
+    lastObserved = observed;
+    const now = Date.now();
+    const remainingMs = observed ? observed.expiresAtMs - now : 0;
+    if (!observed || remainingMs <= 0) {
+      return { exhausted: false, observed: previouslyObserved || observed !== null };
+    }
+    const priorityRemainingMs = priorityDeadlineMs - now;
+    if (priorityRemainingMs <= 0) {
+      console.log(
+        `Immutable publish priority yield exhausted; proceeding alongside active exclusive state lease owner=${observed.owner}`,
+      );
+      return { exhausted: true, observed: true };
+    }
+    const waitMs = Math.min(remainingMs, priorityRemainingMs, 1_000);
     console.log(
       `Immutable publish yielding to exclusive state lease owner=${observed.owner} wait_ms=${waitMs}`,
     );
     sleepWithinStatePublishDeadline(waitMs, "waiting for exclusive state publication");
   }
+}
+
+function immutableExclusiveLeasePriorityDeadlineMs(): number {
+  const operationDeadlineMs =
+    activeGitPublishMetrics?.operationDeadlineMs ??
+    STATE_PUBLISH_TIMING_DEFAULTS.operationDeadlineMs;
+  const priorityBudgetMs = Math.min(
+    STATE_PUBLISH_TIMING_DEFAULTS.immutableLeasePriorityMaxMs,
+    Math.max(1, Math.floor(operationDeadlineMs / 6)),
+  );
+  const priorityDeadlineMs = Date.now() + priorityBudgetMs;
+  return Math.min(priorityDeadlineMs, activeGitPublishMetrics?.deadlineAtMs ?? priorityDeadlineMs);
 }
 
 function immutablePublishRetryWaitMs(attempt: number): number {
@@ -1342,6 +1420,11 @@ function validateStatePublishTimingDefaults(): void {
   if (timing.operationDeadlineMs >= timing.leaseTtlMs) {
     throw new Error("Default state publish operation deadline must be shorter than the lease TTL");
   }
+  if (timing.immutableLeasePriorityMaxMs >= timing.operationDeadlineMs) {
+    throw new Error(
+      "Default immutable lease priority budget must be shorter than the operation deadline",
+    );
+  }
   const workflowBoundMs =
     timing.acquisitionDeadlineMs +
     timing.operationDeadlineMs +
@@ -1491,18 +1574,20 @@ function observeStatePublishLease(
   remote: string,
   leaseRef: string,
   observedByOid: Map<string, ObservedStatePublishLease>,
+  deadlineAtMs?: number,
 ): ObservedStatePublishLease | null {
-  const oid = remoteRefOid(remote, leaseRef);
+  const oid = remoteRefOid(remote, leaseRef, deadlineAtMs);
   if (!oid) return null;
   const cached = observedByOid.get(oid);
   if (cached) return cached;
 
   const fetch = spawnGit(["fetch", "--no-tags", "--quiet", remote, leaseRef], {
     allowFailure: true,
+    ...(deadlineAtMs === undefined ? {} : { deadlineAtMs }),
     quiet: true,
   });
   if (fetch.status !== 0) {
-    if (!remoteRefOid(remote, leaseRef)) {
+    if (!remoteRefOid(remote, leaseRef, deadlineAtMs)) {
       observedByOid.delete(oid);
       return null;
     }
@@ -1511,6 +1596,7 @@ function observeStatePublishLease(
     );
   }
   const raw = runGit(["show", "-s", "--format=%H%x00%ct%x00%B", "FETCH_HEAD"], {
+    ...(deadlineAtMs === undefined ? {} : { deadlineAtMs }),
     quiet: true,
   });
   const [fetchedOid, committedAtRaw, ...messageParts] = raw.split("\0");
@@ -1616,9 +1702,10 @@ function assertStatePublishLeaseOwner(remote: string, lease: StatePublishLease):
   }
 }
 
-function remoteRefOid(remote: string, ref: string): string | null {
+function remoteRefOid(remote: string, ref: string, deadlineAtMs?: number): string | null {
   const result = spawnGit(["ls-remote", "--refs", remote, ref], {
     allowFailure: true,
+    ...(deadlineAtMs === undefined ? {} : { deadlineAtMs }),
     quiet: true,
   });
   if (result.status !== 0) {

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -4065,6 +4065,54 @@ test("slow lease observation cannot consume the immutable CAS reserve", async ()
   );
 });
 
+test("pre-convergence work consumes the shared immutable priority budget", async () => {
+  const fixture = createStatePublishRemote("immutable-pre-convergence-priority");
+  const leaseState = path.join(fixture.root, "state-lease");
+  const immutableState = path.join(fixture.root, "state-immutable");
+  const immutableSource = path.join(fixture.root, "source-immutable");
+  const immutablePath =
+    "ledger/v1/events/2026/07/14/openclaw-clawsweeper/review/run-pre-convergence-review-a.jsonl";
+  const ttlMs = 10_000;
+  cloneState(fixture.origin, leaseState);
+  cloneState(fixture.origin, immutableState);
+  fs.mkdirSync(immutableSource);
+  write(path.join(immutableSource, immutablePath), "immutable\n");
+  const issuedAt = new Date();
+  createRemoteLease(leaseState, {
+    owner: "44444444-4444-4444-8444-444444444444",
+    issuedAt: issuedAt.toISOString(),
+    expiresAt: new Date(issuedAt.getTime() + ttlMs).toISOString(),
+    ttlMs,
+  });
+  const wrapper = installDelayedPreConvergenceGitWrapper(fixture.root, 1);
+  const env = leasedPublishEnv({
+    CLAWSWEEPER_PUBLISH_DEADLINE_MS: "3000",
+    CLAWSWEEPER_PUBLISH_COMMAND_TIMEOUT_MS: "2000",
+    CLAWSWEEPER_PUBLISH_LEASE_TTL_MS: String(ttlMs),
+    PATH: `${wrapper.bin}:${process.env.PATH ?? ""}`,
+    REAL_GIT: wrapper.realGit,
+  });
+
+  const immutable = startImmutablePublishProcess(
+    immutableSource,
+    immutableState,
+    "chore: append after delayed pre-convergence work",
+    immutablePath,
+    env,
+  );
+  const immutableCompleted = await waitForChild(immutable);
+
+  assert.equal(immutableCompleted.status, 0, immutableCompleted.stderr);
+  assert.equal(fs.existsSync(wrapper.delayMarker), true);
+  assert.equal(fs.existsSync(wrapper.leaseProbeMarker), false);
+  assert.doesNotMatch(immutableCompleted.stdout, /State publication deadline exceeded/);
+  assert.equal(remoteRefExists(fixture.origin, STATE_PUBLISH_LEASE_REF), true);
+  assert.equal(
+    run("git", ["--git-dir", fixture.origin, "show", `state:${immutablePath}`], fixture.root),
+    "immutable\n",
+  );
+});
+
 test("immutable publisher converges when an exclusive lease appears before its push", () => {
   const fixture = createStatePublishRemote("immutable-exclusive-acquisition-race");
   const immutableState = path.join(fixture.root, "state-immutable");
@@ -4430,6 +4478,36 @@ exec "$REAL_GIT" "$@"
   );
   fs.chmodSync(wrapper, 0o755);
   return { bin, marker, realGit };
+}
+
+function installDelayedPreConvergenceGitWrapper(root, seconds) {
+  const bin = path.join(root, "git-wrapper-delayed-pre-convergence");
+  const delayMarker = path.join(root, "pre-convergence-delay");
+  const leaseProbeMarker = path.join(root, "pre-convergence-lease-probe");
+  const realGit = run("sh", ["-c", "command -v git"], root).trim();
+  fs.mkdirSync(bin);
+  const wrapper = path.join(bin, "git");
+  fs.writeFileSync(
+    wrapper,
+    `#!/bin/sh
+: "\${REAL_GIT:?real git path is required}"
+if test "$1" = "fetch" &&
+   test "$2" = "origin" &&
+   test "$3" = "state" &&
+   test ! -f "${delayMarker}"; then
+  touch "${delayMarker}"
+  sleep "${seconds}"
+fi
+if test "$1" = "ls-remote" &&
+   test "$2" = "--refs" &&
+   test "$4" = "${STATE_PUBLISH_LEASE_REF}"; then
+  touch "${leaseProbeMarker}"
+fi
+exec "$REAL_GIT" "$@"
+`,
+  );
+  fs.chmodSync(wrapper, 0o755);
+  return { bin, delayMarker, leaseProbeMarker, realGit };
 }
 
 function installAcceptedStatePushTimeoutHook(origin, seconds) {

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -132,6 +132,7 @@ test("default lease timing can recover a crashed owner within the workflow budge
       timing.leaseProtocolMaxTtlMs + timing.leaseMaxWaitMs + timing.commandTimeoutMs,
   );
   assert.ok(timing.operationDeadlineMs < timing.leaseTtlMs);
+  assert.ok(timing.immutableLeasePriorityMaxMs < timing.operationDeadlineMs);
   assert.ok(
     timing.acquisitionDeadlineMs +
       timing.operationDeadlineMs +
@@ -3855,6 +3856,9 @@ test("immutable publishers yield to an active exclusive state mutation", async (
   );
   const immutableResult = waitForChild(immutable);
   await waitForChildOutput(immutable, "Immutable publish yielding to exclusive state lease");
+  assert.throws(() =>
+    run("git", ["--git-dir", fixture.origin, "show", `state:${immutablePath}`], fixture.root),
+  );
   write(releaseSignal, "release\n");
 
   const [exclusiveCompleted, immutableCompleted] = await Promise.all([
@@ -3865,6 +3869,196 @@ test("immutable publishers yield to an active exclusive state mutation", async (
   assert.equal(immutableCompleted.status, 0, immutableCompleted.stderr);
   assert.equal(fs.existsSync(releaseObserved), true);
   assert.equal(remoteRefExists(fixture.origin, STATE_PUBLISH_LEASE_REF), false);
+  assert.equal(
+    run("git", ["--git-dir", fixture.origin, "show", `state:${immutablePath}`], fixture.root),
+    "immutable\n",
+  );
+  const subjects = run(
+    "git",
+    ["--git-dir", fixture.origin, "log", "--reverse", "--format=%s", "state"],
+    fixture.root,
+  );
+  assert.ok(
+    subjects.indexOf("chore: publish exclusive mutation") <
+      subjects.indexOf("chore: append priority event"),
+  );
+});
+
+test("immutable publishers make progress after the exclusive priority budget", async () => {
+  const fixture = createStatePublishRemote("immutable-exclusive-bounded-priority");
+  const exclusiveState = path.join(fixture.root, "state-exclusive");
+  const immutableState = path.join(fixture.root, "state-immutable");
+  const exclusiveSource = path.join(fixture.root, "source-exclusive");
+  const immutableSource = path.join(fixture.root, "source-immutable");
+  const releaseSignal = path.join(fixture.root, "release-exclusive");
+  const releaseObserved = path.join(fixture.root, "exclusive-released");
+  const exclusivePath = "results/exclusive-bounded-priority.txt";
+  const immutablePath =
+    "ledger/v1/events/2026/07/14/openclaw-clawsweeper/review/run-bounded-priority-review-a.jsonl";
+  cloneState(fixture.origin, exclusiveState);
+  cloneState(fixture.origin, immutableState);
+  fs.mkdirSync(exclusiveSource);
+  fs.mkdirSync(immutableSource);
+  write(path.join(exclusiveSource, exclusivePath), "exclusive\n");
+  write(path.join(immutableSource, immutablePath), "immutable\n");
+  installStatePushReleaseHook(exclusiveState, releaseSignal, releaseObserved);
+  const env = leasedPublishEnv({
+    CLAWSWEEPER_PUBLISH_ACQUIRE_DEADLINE_MS: "5000",
+    CLAWSWEEPER_PUBLISH_DEADLINE_MS: "3000",
+    CLAWSWEEPER_PUBLISH_COMMAND_TIMEOUT_MS: "1000",
+    CLAWSWEEPER_PUBLISH_LEASE_TTL_MS: "4000",
+    CLAWSWEEPER_PUBLISH_LEASE_WAIT_MS: "10",
+  });
+
+  const exclusive = startPublishCli(
+    exclusiveSource,
+    exclusiveState,
+    "chore: publish bounded-priority exclusive mutation",
+    env,
+  );
+  const exclusiveResult = waitForChild(exclusive);
+  await waitForRemoteRef(fixture.origin, STATE_PUBLISH_LEASE_REF);
+  const immutable = startImmutablePublishProcess(
+    immutableSource,
+    immutableState,
+    "chore: append bounded-priority event",
+    immutablePath,
+    env,
+  );
+  const immutableResult = waitForChild(immutable);
+  await waitForChildOutput(
+    immutable,
+    "Immutable publish priority yield exhausted",
+    "proceeding alongside active exclusive state lease",
+  );
+  const immutableCompleted = await immutableResult;
+  assert.equal(immutableCompleted.status, 0, immutableCompleted.stderr);
+  assert.equal(fs.existsSync(releaseObserved), false);
+
+  write(releaseSignal, "release\n");
+  const exclusiveCompleted = await exclusiveResult;
+  assert.equal(exclusiveCompleted.status, 0, exclusiveCompleted.stderr);
+  assert.equal(fs.existsSync(releaseObserved), true);
+  assert.equal(remoteRefExists(fixture.origin, STATE_PUBLISH_LEASE_REF), false);
+  assert.equal(
+    run("git", ["--git-dir", fixture.origin, "show", `state:${exclusivePath}`], fixture.root),
+    "exclusive\n",
+  );
+  assert.equal(
+    run("git", ["--git-dir", fixture.origin, "show", `state:${immutablePath}`], fixture.root),
+    "immutable\n",
+  );
+});
+
+test("replacement exclusive leases share one immutable priority budget", async () => {
+  const fixture = createStatePublishRemote("immutable-replacement-lease-priority");
+  const leaseState = path.join(fixture.root, "state-lease");
+  const immutableState = path.join(fixture.root, "state-immutable");
+  const immutableSource = path.join(fixture.root, "source-immutable");
+  const immutablePath =
+    "ledger/v1/events/2026/07/14/openclaw-clawsweeper/review/run-replacement-priority-review-a.jsonl";
+  const firstOwner = "11111111-1111-4111-8111-111111111111";
+  const secondOwner = "22222222-2222-4222-8222-222222222222";
+  const ttlMs = 12_000;
+  cloneState(fixture.origin, leaseState);
+  cloneState(fixture.origin, immutableState);
+  fs.mkdirSync(immutableSource);
+  write(path.join(immutableSource, immutablePath), "immutable\n");
+  const firstIssuedAt = new Date();
+  const firstLeaseOid = createRemoteLease(leaseState, {
+    owner: firstOwner,
+    issuedAt: firstIssuedAt.toISOString(),
+    expiresAt: new Date(firstIssuedAt.getTime() + ttlMs).toISOString(),
+    ttlMs,
+  });
+  const env = leasedPublishEnv({
+    CLAWSWEEPER_PUBLISH_DEADLINE_MS: "9000",
+    CLAWSWEEPER_PUBLISH_COMMAND_TIMEOUT_MS: "2000",
+    CLAWSWEEPER_PUBLISH_LEASE_TTL_MS: String(ttlMs),
+  });
+
+  const immutable = startImmutablePublishProcess(
+    immutableSource,
+    immutableState,
+    "chore: append replacement-priority event",
+    immutablePath,
+    env,
+  );
+  const immutableResult = waitForChild(immutable);
+  await waitForChildOutput(immutable, `owner=${firstOwner}`);
+  const secondIssuedAt = new Date();
+  createRemoteLease(leaseState, {
+    owner: secondOwner,
+    issuedAt: secondIssuedAt.toISOString(),
+    expiresAt: new Date(secondIssuedAt.getTime() + ttlMs).toISOString(),
+    ttlMs,
+    expectedOid: firstLeaseOid,
+  });
+  await waitForChildOutput(immutable, `owner=${secondOwner}`);
+
+  const immutableCompleted = await immutableResult;
+  assert.equal(immutableCompleted.status, 0, immutableCompleted.stderr);
+  const firstWaitMs = Number(
+    new RegExp(`owner=${firstOwner} wait_ms=(\\d+)`).exec(immutableCompleted.stdout)?.[1],
+  );
+  const secondWaitMs = Number(
+    new RegExp(`owner=${secondOwner} wait_ms=(\\d+)`).exec(immutableCompleted.stdout)?.[1],
+  );
+  assert.ok(firstWaitMs > 0);
+  assert.ok(secondWaitMs > 0 && secondWaitMs < firstWaitMs);
+  assert.match(immutableCompleted.stdout, /Immutable publish priority yield exhausted/);
+  assert.equal(remoteRefExists(fixture.origin, STATE_PUBLISH_LEASE_REF), true);
+  assert.equal(
+    run("git", ["--git-dir", fixture.origin, "show", `state:${immutablePath}`], fixture.root),
+    "immutable\n",
+  );
+});
+
+test("slow lease observation cannot consume the immutable CAS reserve", async () => {
+  const fixture = createStatePublishRemote("immutable-slow-lease-observation");
+  const leaseState = path.join(fixture.root, "state-lease");
+  const immutableState = path.join(fixture.root, "state-immutable");
+  const immutableSource = path.join(fixture.root, "source-immutable");
+  const immutablePath =
+    "ledger/v1/events/2026/07/14/openclaw-clawsweeper/review/run-slow-observation-review-a.jsonl";
+  const ttlMs = 10_000;
+  cloneState(fixture.origin, leaseState);
+  cloneState(fixture.origin, immutableState);
+  fs.mkdirSync(immutableSource);
+  write(path.join(immutableSource, immutablePath), "immutable\n");
+  const issuedAt = new Date();
+  createRemoteLease(leaseState, {
+    owner: "33333333-3333-4333-8333-333333333333",
+    issuedAt: issuedAt.toISOString(),
+    expiresAt: new Date(issuedAt.getTime() + ttlMs).toISOString(),
+    ttlMs,
+  });
+  const wrapper = installSlowLeaseObservationGitWrapper(fixture.root, 2);
+  const env = leasedPublishEnv({
+    CLAWSWEEPER_PUBLISH_DEADLINE_MS: "3000",
+    CLAWSWEEPER_PUBLISH_COMMAND_TIMEOUT_MS: "2000",
+    CLAWSWEEPER_PUBLISH_LEASE_TTL_MS: String(ttlMs),
+    PATH: `${wrapper.bin}:${process.env.PATH ?? ""}`,
+    REAL_GIT: wrapper.realGit,
+  });
+
+  const immutable = startImmutablePublishProcess(
+    immutableSource,
+    immutableState,
+    "chore: append after slow lease observation",
+    immutablePath,
+    env,
+  );
+  const immutableCompleted = await waitForChild(immutable);
+
+  assert.equal(immutableCompleted.status, 0, immutableCompleted.stderr);
+  assert.equal(fs.existsSync(wrapper.marker), true);
+  assert.match(
+    immutableCompleted.stdout,
+    /priority yield exhausted during lease observation; proceeding without further exclusive lease preference/,
+  );
+  assert.doesNotMatch(immutableCompleted.stdout, /State publication deadline exceeded/);
+  assert.equal(remoteRefExists(fixture.origin, STATE_PUBLISH_LEASE_REF), true);
   assert.equal(
     run("git", ["--git-dir", fixture.origin, "show", `state:${immutablePath}`], fixture.root),
     "immutable\n",
@@ -4143,7 +4337,7 @@ function readRemoteLeaseMessage(origin) {
   );
 }
 
-function createRemoteLease(state, { owner, issuedAt, expiresAt, ttlMs }) {
+function createRemoteLease(state, { owner, issuedAt, expiresAt, ttlMs, expectedOid = "" }) {
   const tree = run("git", ["rev-parse", "HEAD^{tree}"], state).trim();
   const parent = run("git", ["rev-parse", "HEAD"], state).trim();
   const lease = execFileSync(
@@ -4180,7 +4374,7 @@ function createRemoteLease(state, { owner, issuedAt, expiresAt, ttlMs }) {
     "git",
     [
       "push",
-      `--force-with-lease=${STATE_PUBLISH_LEASE_REF}:`,
+      `--force-with-lease=${STATE_PUBLISH_LEASE_REF}:${expectedOid}`,
       "origin",
       `${lease}:${STATE_PUBLISH_LEASE_REF}`,
     ],
@@ -4206,6 +4400,30 @@ if test "$1" = "fetch" &&
    test ! -f "\${VANISHING_LEASE_MARKER}"; then
   touch "\${VANISHING_LEASE_MARKER}"
   "$REAL_GIT" --git-dir="\${VANISHING_LEASE_ORIGIN}" update-ref -d "${STATE_PUBLISH_LEASE_REF}"
+fi
+exec "$REAL_GIT" "$@"
+`,
+  );
+  fs.chmodSync(wrapper, 0o755);
+  return { bin, marker, realGit };
+}
+
+function installSlowLeaseObservationGitWrapper(root, seconds) {
+  const bin = path.join(root, "git-wrapper-slow-lease");
+  const marker = path.join(root, "slow-lease-observation");
+  const realGit = run("sh", ["-c", "command -v git"], root).trim();
+  fs.mkdirSync(bin);
+  const wrapper = path.join(bin, "git");
+  fs.writeFileSync(
+    wrapper,
+    `#!/bin/sh
+: "\${REAL_GIT:?real git path is required}"
+if test "$1" = "ls-remote" &&
+   test "$2" = "--refs" &&
+   test "$4" = "${STATE_PUBLISH_LEASE_REF}" &&
+   test ! -f "${marker}"; then
+  touch "${marker}"
+  sleep "${seconds}"
 fi
 exec "$REAL_GIT" "$@"
 `,

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -4199,7 +4199,7 @@ test("immutable publication deadline bounds continuous rejected branch pushes", 
             }),
           ),
       ),
-    /State publication deadline exceeded/,
+    /State publication deadline exceeded|git \S+ timed out after \d+ms during state publication/,
   );
   assert.ok(Date.now() - startedAt < 1500);
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where action-ledger publication could miss its 90-second operation deadline whenever it arrived behind a valid 120-second exclusive state lease. The staged production canary reproduced this on GitHub activity and historical replay publishers.

## Why This Change Was Made

Immutable publishers now grant exclusive state mutations one shared, bounded priority window anchored to the start of the publication operation: at most 15 seconds and at most one-sixth of the immutable operation budget. The absolute budget includes pre-convergence work, is shared across retries and replacement lease owners, and bounds lease-observation Git commands. Once exhausted, immutable publication proceeds through the existing optimistic CAS/rebuild path without deleting or replacing the exclusive lease.

## User Impact

Action, review, repair, and replay ledger shards can make progress during long exclusive state mutations while short exclusive work still commits first. Existing collision checks and branch-race convergence remain unchanged.

## Evidence

- full GitHub `pnpm check`: passed in 11m25s
- `node --test test/repair/git-publish.test.ts`: 67/67 passed
- focused deadline assertion: 5/5 repeated runs passed
- direct TypeScript builds passed for main, repair, and dashboard configs
- repair/source lint and formatting checks passed
- exact local ClawSweeper review against `3d4e0f246b6857f86de0ad39a4f6ace8c5a37c86` and head `159c0fe0134489aacb1e8161a405002e5625d194`: complete, patch correct, confidence 0.94, zero findings, security cleared
- regression coverage proves short-lease priority, progress under a held live lease, one budget across replacement owners, command-bounded slow lease observation, pre-convergence work consuming the same absolute budget, 12 concurrent immutable writers, acquisition races, and the global operation deadline