### PR TITLE
fix(state): harden immutable publish bursts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,8 +59,8 @@ checkpoint, and status-only commits are intentionally omitted.
 ### Changed
 
 - Bounded immutable action-ledger publishers' priority yield to exclusive state
-  leases so a valid long-lived lease cannot starve a shorter immutable
-  publication deadline; exclusive publishers still rebuild around branch races.
+  leases and expanded their retry budget for 64-worker bursts; exclusive
+  publishers still rebuild around branch races.
 - Kept immutable action-ledger publication available in repair-only workflow
   jobs by moving shard import and path-manifest admission behind repair-native
   CLIs, while retaining the root commands as compatibility entrypoints.

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -83,6 +83,7 @@ const STATE_PUBLISH_LEASE_REF_ROOT = "refs/heads/clawsweeper-publish-lease";
 export const STATE_PUBLISH_TIMING_DEFAULTS = Object.freeze({
   acquisitionDeadlineMs: 3 * 60 * 1000,
   operationDeadlineMs: 90 * 1000,
+  immutableOperationDeadlineMs: 3 * 60 * 1000,
   commandTimeoutMs: 30 * 1000,
   immutableLeasePriorityMaxMs: 15 * 1000,
   leaseTtlMs: 2 * 60 * 1000,
@@ -96,6 +97,7 @@ const STATE_PUBLISH_LEASE_ISSUED_AT_SKEW_MS = 5 * 1000;
 const STATE_PUBLISH_LEASE_ATTEMPTS = 24;
 const STATE_PUBLISH_LEASE_WAIT_MS = 3 * 1000;
 const STATE_PUBLISH_STALE_RECOVERY_ATTEMPTS = 2;
+const IMMUTABLE_PUBLISH_MAX_ATTEMPTS = 128;
 const SKIP_CI_DIRECTIVE_PATTERN =
   /\[(?:skip ci|ci skip|no ci|skip actions|actions skip)\]|^skip-checks:\s*true$/im;
 
@@ -319,10 +321,14 @@ export function publishMainCommit(options: GitPublishOptions): PublishResult {
   const metrics: GitPublishMetrics = {
     startedAtMs,
     deadlineAtMs: timing
-      ? startedAtMs + (leased ? timing.acquisitionDeadlineMs : timing.operationDeadlineMs)
+      ? startedAtMs +
+        (boundedImmutable ? timing.immutableOperationDeadlineMs : timing.acquisitionDeadlineMs)
       : null,
     commandTimeoutMs: timing?.commandTimeoutMs ?? null,
-    operationDeadlineMs: timing?.operationDeadlineMs ?? null,
+    operationDeadlineMs:
+      timing && boundedImmutable
+        ? timing.immutableOperationDeadlineMs
+        : (timing?.operationDeadlineMs ?? null),
     leaseTtlMs: leased ? (timing?.leaseTtlMs ?? null) : null,
     processes: 0,
     actions: new Map(),
@@ -385,7 +391,7 @@ function validatePublishCoordination(
 function publishImmutableMainCommit(options: GitPublishOptions): PublishResult {
   const remote = options.remote ?? "origin";
   const branch = options.branch ?? publishDefaultBranch();
-  const maxAttempts = positiveInt(options.maxAttempts, 32);
+  const maxAttempts = positiveInt(options.maxAttempts, IMMUTABLE_PUBLISH_MAX_ATTEMPTS);
   const paths = uniqueNonEmpty(options.paths);
   const stateBaseCommit = captureStatePublishBaseline();
   const stateRoot = publishRoot();
@@ -1434,11 +1440,17 @@ function validateStatePublishTimingDefaults(): void {
   if (workflowBoundMs > timing.workflowTimeoutMs) {
     throw new Error("Default state publish deadlines exceed the workflow timeout margin");
   }
+  const immutableWorkflowBoundMs =
+    timing.immutableOperationDeadlineMs + timing.commandTimeoutMs + timing.workflowMarginMs;
+  if (immutableWorkflowBoundMs > timing.workflowTimeoutMs) {
+    throw new Error("Default immutable publish deadlines exceed the workflow timeout margin");
+  }
 }
 
 function statePublishTiming(): {
   acquisitionDeadlineMs: number;
   operationDeadlineMs: number;
+  immutableOperationDeadlineMs: number;
   commandTimeoutMs: number;
   leaseTtlMs: number;
 } {
@@ -1449,6 +1461,15 @@ function statePublishTiming(): {
   const operationDeadlineMs = positiveEnvInt(
     "CLAWSWEEPER_PUBLISH_DEADLINE_MS",
     STATE_PUBLISH_TIMING_DEFAULTS.operationDeadlineMs,
+  );
+  const legacyOperationDeadlineConfigured = Boolean(
+    process.env.CLAWSWEEPER_PUBLISH_DEADLINE_MS?.trim(),
+  );
+  const immutableOperationDeadlineMs = positiveEnvInt(
+    "CLAWSWEEPER_IMMUTABLE_PUBLISH_DEADLINE_MS",
+    legacyOperationDeadlineConfigured
+      ? operationDeadlineMs
+      : STATE_PUBLISH_TIMING_DEFAULTS.immutableOperationDeadlineMs,
   );
   const commandTimeoutMs = positiveEnvInt(
     "CLAWSWEEPER_PUBLISH_COMMAND_TIMEOUT_MS",
@@ -1471,6 +1492,7 @@ function statePublishTiming(): {
   return {
     acquisitionDeadlineMs,
     operationDeadlineMs,
+    immutableOperationDeadlineMs,
     commandTimeoutMs,
     leaseTtlMs,
   };

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -37,6 +37,7 @@ for (const key of [
   "CLAWSWEEPER_PUBLISH_LEASE",
   "CLAWSWEEPER_PUBLISH_ACQUIRE_DEADLINE_MS",
   "CLAWSWEEPER_PUBLISH_DEADLINE_MS",
+  "CLAWSWEEPER_IMMUTABLE_PUBLISH_DEADLINE_MS",
   "CLAWSWEEPER_PUBLISH_COMMAND_TIMEOUT_MS",
   "CLAWSWEEPER_PUBLISH_LEASE_TTL_MS",
   "CLAWSWEEPER_PUBLISH_LEASE_ATTEMPTS",
@@ -138,6 +139,10 @@ test("default lease timing can recover a crashed owner within the workflow budge
       timing.operationDeadlineMs +
       timing.commandTimeoutMs +
       timing.workflowMarginMs <=
+      timing.workflowTimeoutMs,
+  );
+  assert.ok(
+    timing.immutableOperationDeadlineMs + timing.commandTimeoutMs + timing.workflowMarginMs <=
       timing.workflowTimeoutMs,
   );
 });
@@ -3709,7 +3714,7 @@ test("immutable publisher verifies an accepted branch push after client timeout"
   const result = withEnv(
     leasedPublishEnv({
       CLAWSWEEPER_STATE_DIR: state,
-      CLAWSWEEPER_PUBLISH_DEADLINE_MS: "3000",
+      CLAWSWEEPER_IMMUTABLE_PUBLISH_DEADLINE_MS: "3000",
       CLAWSWEEPER_PUBLISH_COMMAND_TIMEOUT_MS: "100",
     }),
     () =>
@@ -3729,35 +3734,41 @@ test("immutable publisher verifies an accepted branch push after client timeout"
   );
 });
 
-test("immutable publishers converge concurrent disjoint action ledger paths without a lease", async () => {
+test("64 bursty immutable publishers converge in production-shaped cohorts", async () => {
   const fixture = createStatePublishRemote("immutable-concurrency");
-  const publisherCount = 12;
+  const publisherCount = 64;
+  const cohortSize = 16;
   const env = leasedPublishEnv({
-    CLAWSWEEPER_PUBLISH_DEADLINE_MS: "15000",
-    CLAWSWEEPER_PUBLISH_COMMAND_TIMEOUT_MS: "3000",
+    CLAWSWEEPER_PUBLISH_COMMAND_TIMEOUT_MS: "10000",
   });
-  const publishers = Array.from({ length: publisherCount }, (_, index) => {
+  const preparedPublishers = Array.from({ length: publisherCount }, (_, index) => {
     const state = path.join(fixture.root, `state-${index}`);
     const source = path.join(fixture.root, `source-${index}`);
     const publishPath = `ledger/v1/events/2026/07/14/openclaw-clawsweeper/review/run-${index + 1}-review-${String(index).padStart(2, "0")}.jsonl`;
     cloneState(fixture.origin, state);
     fs.mkdirSync(source);
     write(path.join(source, publishPath), `event ${index}\n`);
-    return {
-      publishPath,
-      child: startImmutablePublishProcess(
-        source,
-        state,
-        `chore: append immutable event ${index}`,
-        publishPath,
-        env,
-      ),
-    };
+    return { index, state, source, publishPath };
   });
-
-  const completed = await Promise.all(publishers.map(({ child }) => waitForChild(child)));
-  for (const result of completed) {
-    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  const publishers = [];
+  for (let cohortStart = 0; cohortStart < publisherCount; cohortStart += cohortSize) {
+    const cohort = preparedPublishers
+      .slice(cohortStart, cohortStart + cohortSize)
+      .map(({ index, state, source, publishPath }) => ({
+        publishPath,
+        child: startImmutablePublishProcess(
+          source,
+          state,
+          `chore: append immutable event ${index}`,
+          publishPath,
+          env,
+        ),
+      }));
+    publishers.push(...cohort);
+    const completed = await Promise.all(cohort.map(({ child }) => waitForChild(child)));
+    for (const result of completed) {
+      assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+    }
   }
   for (const [index, { publishPath }] of publishers.entries()) {
     assert.equal(
@@ -3768,7 +3779,7 @@ test("immutable publishers converge concurrent disjoint action ledger paths with
   assert.equal(remoteRefExists(fixture.origin, STATE_PUBLISH_LEASE_REF), false);
 });
 
-test("immutable publisher converges through unrelated mutable branch updates", () => {
+test("immutable publisher survives more than the former 32-attempt race ceiling", () => {
   const fixture = createStatePublishRemote("immutable-mutable-storm");
   const state = path.join(fixture.root, "state");
   const other = path.join(fixture.root, "other");
@@ -3778,13 +3789,14 @@ test("immutable publisher converges through unrelated mutable branch updates", (
   cloneState(fixture.origin, other);
   fs.mkdirSync(source);
   write(path.join(source, publishPath), '{"event":"storm"}\n');
-  installRepeatedStateRaceHook(state, other, 3);
+  const raceCount = 33;
+  installRepeatedStateRaceHook(state, other, raceCount);
 
   const result = withEnv(
     leasedPublishEnv({
       CLAWSWEEPER_STATE_DIR: state,
-      CLAWSWEEPER_PUBLISH_DEADLINE_MS: "5000",
-      CLAWSWEEPER_PUBLISH_COMMAND_TIMEOUT_MS: "2000",
+      CLAWSWEEPER_IMMUTABLE_PUBLISH_DEADLINE_MS: "60000",
+      CLAWSWEEPER_PUBLISH_COMMAND_TIMEOUT_MS: "5000",
     }),
     () =>
       withCwd(source, () =>
@@ -3801,7 +3813,7 @@ test("immutable publisher converges through unrelated mutable branch updates", (
     run("git", ["--git-dir", fixture.origin, "show", `state:${publishPath}`], fixture.root),
     '{"event":"storm"}\n',
   );
-  for (let race = 1; race <= 3; race += 1) {
+  for (let race = 1; race <= raceCount; race += 1) {
     assert.equal(
       run(
         "git",
@@ -4138,6 +4150,7 @@ test("immutable publisher converges when an exclusive lease appears before its p
         CLAWSWEEPER_STATE_DIR: immutableState,
         CLAWSWEEPER_PUBLISH_ACQUIRE_DEADLINE_MS: "5000",
         CLAWSWEEPER_PUBLISH_DEADLINE_MS: "3000",
+        CLAWSWEEPER_IMMUTABLE_PUBLISH_DEADLINE_MS: "3000",
         CLAWSWEEPER_PUBLISH_COMMAND_TIMEOUT_MS: "1000",
         CLAWSWEEPER_PUBLISH_LEASE_TTL_MS: "4000",
         CLAWSWEEPER_PUBLISH_LEASE_WAIT_MS: "10",
@@ -4155,7 +4168,7 @@ test("immutable publisher converges when an exclusive lease appears before its p
 
   assert.equal(fs.existsSync(marker), true);
   assert.equal(
-    lines.some((line) => line.includes("Immutable publish lost state race attempt=1/32")),
+    lines.some((line) => line.includes("Immutable publish lost state race attempt=1/128")),
     true,
   );
   assert.equal(
@@ -4186,7 +4199,7 @@ test("immutable publication deadline bounds continuous rejected branch pushes", 
       withEnv(
         leasedPublishEnv({
           CLAWSWEEPER_STATE_DIR: state,
-          CLAWSWEEPER_PUBLISH_DEADLINE_MS: "120",
+          CLAWSWEEPER_IMMUTABLE_PUBLISH_DEADLINE_MS: "120",
           CLAWSWEEPER_PUBLISH_COMMAND_TIMEOUT_MS: "100",
         }),
         () =>


### PR DESCRIPTION
## Summary

Standalone burst hardening based directly on current `main` and its bounded immutable lease-priority publisher.

- raise the default absolute immutable publication budget from 90 seconds to 3 minutes while leaving exclusive publication at 90 seconds
- raise immutable convergence attempts from 32 to 128
- preserve `CLAWSWEEPER_PUBLISH_DEADLINE_MS` as a backwards-compatible explicit override, with an immutable-specific override available when needed
- keep immutable path admission, collision detection, replay equivalence, bounded exclusive priority, and exclusive-publisher rebuild behavior unchanged

This PR does not stack on or depend on any other open PR. It does not enable immutable exact-review publication.

## Evidence

- `pnpm run build:worker`
- 64 publishers converge in four synchronized 16-writer cohorts (64/64 paths verified)
- one immutable publisher survives 33 forced consecutive branch races, proving progress beyond the former 32-attempt ceiling
- local focused stress run passed 2/2 in 99 seconds
- bounded deadline, accepted-push-timeout, and exclusive-acquisition-race paths remain fail-closed and remotely verified

## Rollout

Merge this standalone hardening, then observe the already-wired low-volume GitHub-activity immutable publisher. Exact-review immutable publication remains a separate hard-wired workflow change only after that canary produces successful publication evidence.