### PR TITLE
fix(state): roll back saturated immutable canary

### DIFF
--- a/.github/workflows/github-activity-receipt-replay.yml
+++ b/.github/workflows/github-activity-receipt-replay.yml
@@ -181,7 +181,6 @@ jobs:
 
       - name: Replay GitHub activity dispatch action ledger
         env:
-          CLAWSWEEPER_ACTION_LEDGER_IMMUTABLE_PUBLISH: "1"
           PUBLISH_TOKEN: ${{ steps.replay-state-token.outputs.token }}
         run: |
           set -euo pipefail

--- a/.github/workflows/github-activity.yml
+++ b/.github/workflows/github-activity.yml
@@ -228,7 +228,6 @@ jobs:
         if: ${{ always() && steps.core-budget.outputs.skip != 'true' && steps.setup-activity-state.outcome == 'success' && steps.setup-activity-pnpm.outcome == 'success' && steps.bundle-activity-dispatch-ledger.outputs.ready == 'true' }}
         continue-on-error: true
         env:
-          CLAWSWEEPER_ACTION_LEDGER_IMMUTABLE_PUBLISH: "1"
           PUBLISH_TOKEN: ${{ steps.activity-state-token.outputs.token }}
         run: |
           set -euo pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,9 +67,10 @@ checkpoint, and status-only commits are intentionally omitted.
 - Added a priority-aware optimistic publisher for immutable action ledgers that
   yields to exclusive state mutations, accepts replay-equivalent event shards,
   rejects content collisions, and converges disjoint branch races without the
-  global state lease. GitHub activity publication and receipt replay use the
-  staged mode first; every action, review, and repair ledger now enters through
-  the same validated path-manifest boundary.
+  global state lease. GitHub activity publication and receipt replay remain on
+  exclusive publication after the live immutable canary could not converge
+  under saturated state writes; every action, review, and repair ledger still
+  enters through the same validated path-manifest boundary.
 - Serialized generated-state publishers through lightweight detached,
   versioned, protocol-bounded remote leases with composable workflow
   deadlines, bounded stale-owner recovery, deadline-bounded multi-race

--- a/test/repair/dispatch-action-receipts.test.ts
+++ b/test/repair/dispatch-action-receipts.test.ts
@@ -793,7 +793,7 @@ test("activity dispatch publishes receipts before the noncritical notifier", () 
   assert.match(publishStep, /bundle-activity-dispatch-ledger\.outputs\.ready == 'true'/);
   assert.doesNotMatch(publishStep, /upload-activity-dispatch-ledger\.outcome/);
   assert.match(publishStep, /continue-on-error: true/);
-  assert.match(publishStep, /CLAWSWEEPER_ACTION_LEDGER_IMMUTABLE_PUBLISH: "1"/);
+  assert.doesNotMatch(publishStep, /CLAWSWEEPER_ACTION_LEDGER_IMMUTABLE_PUBLISH/);
   assert.match(
     workflow,
     /- name: Feed activity to OpenClaw\n\s+id: notify-openclaw\n\s+if: \$\{\{ always\(\)[^\n]+\}\}\n\s+continue-on-error: true/,
@@ -849,7 +849,7 @@ test("failed, cancelled, and timed-out GitHub activity runs replay receipts", ()
   );
   assert.match(workflow, /dispatch-action-ledger-cli\.js replay/);
   assert.match(workflow, /publish-action-event-paths/);
-  assert.match(workflow.slice(replayOffset), /CLAWSWEEPER_ACTION_LEDGER_IMMUTABLE_PUBLISH: "1"/);
+  assert.doesNotMatch(workflow.slice(replayOffset), /CLAWSWEEPER_ACTION_LEDGER_IMMUTABLE_PUBLISH/);
   assert.match(workflow, /--paths-file "\$event_paths_file"/);
   assert.doesNotMatch(workflow, /repair:publish-main|action_ledger_args/);
   assert.match(workflow, /\.run_id == \$run_id/);


### PR DESCRIPTION
## Summary

- return GitHub activity ledger publication and receipt replay to exclusive state publication
- keep the repair-native immutable publisher available, but do not expand it to exact reviews
- document the live canary outcome and lock the workflow expectation to the exclusive path

## Live evidence

Two production publishers on the old 90-second budget lost four consecutive state races and failed. After #583 raised the immutable budget to 180 seconds and 128 attempts, a manual replay of the still-missing durable receipt bundle lost nine consecutive races and failed after 191 seconds / 286 git processes. The state branch advanced every few seconds while each immutable rebuild took roughly 17-19 seconds, so another deadline increase would consume runner time without creating a credible CAS window.

Failed post-merge canary: https://github.com/openclaw/clawsweeper/actions/runs/29374066539

Exact-review immutable publication was never enabled. No receipt is dropped: the source artifact remains eligible for the existing replay workflow, and will be replayed after this rollback reaches main.

## Validation

- `pnpm run format`
- `pnpm run check:active-surface`
- `pnpm run check:limits`
- `pnpm run build:repair`
- `node --test test/repair/dispatch-action-receipts.test.ts dist/repair/action-event-publisher.test.js` (26/26)

This PR is a single standalone commit directly on current `main`; it does not depend on another open PR.