### PR TITLE
fix(review): stop requiring routine PR rebases

### DIFF
--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -234,13 +234,19 @@ or absent. Use it only when the PR diff changes automation behavior or
 plausibly causes CI, automerge, proof capture, label sync, or related automation
 to fail after merge.
 Do not treat a branch being behind the current base as proof that merging the
-PR will delete current-base-only files or commits. When GitHub reports the PR as
-mergeable or clean and the only concern is stale base drift, describe it as
-needing rebase or review refresh in `risks`, `workReason`, or `bestSolution`,
-but leave `reviewFindings` and `mergeRiskLabels` focused on defects or risks
-that survive the actual three-way merge result. Use deletion/drop wording for
-current-base behavior only when a merge result, merge ref, conflict, or concrete
-patch evidence shows that the merged PR would remove or regress it.
+PR will delete current-base-only files or commits. Ordinary `behind` state is
+not a contributor blocker: do not recommend rebase or base refresh in `risks`,
+`workReason`, `bestSolution`, `reviewFindings`, `mergeRiskLabels`, or
+`prRating.nextSteps`, and do not claim that rebasing will fix a failing check.
+Only ask the contributor to rebase or resolve the base when GitHub reports a
+real merge conflict (`dirty`/`conflicting`), a merge tree cannot be produced, or
+concrete merge-result evidence shows an integration failure. Describe failing
+checks independently by their actual failure. When `pullBaseDrift.stale` is
+true, ClawSweeper adds a non-blocking `Base freshness` review metric for
+maintainers or merge automation; do not repeat it elsewhere or lower the PR
+rating. Use deletion/drop wording for current-base behavior only when a merge
+result, merge ref, conflict, or concrete patch evidence shows that the merged PR
+would remove or regress it.
 When merge risk is present, explain it in `risks` in maintainer-facing language
 and make `bestSolution` the best end state. Fill `mergeRiskOptions` with 1-3
 risk-specific maintainer options. Do not use a fixed menu. Each option needs a

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -746,6 +746,7 @@ interface ItemContext {
   pullReviewCommentsRevision?: string;
   pullReviewActivityCursor?: string;
   pullChecks?: unknown;
+  pullBaseDrift?: unknown;
   counts?: {
     comments: number;
     commentsHydrated?: number;
@@ -3109,6 +3110,18 @@ function reviewTimelineDigestParts(entries: unknown): unknown {
     }));
 }
 
+function pullBaseDriftDigestParts(value: unknown): unknown {
+  if (value === undefined) return null;
+  const drift = asRecord(value);
+  // Age changes every day, but only the stale threshold and a new merge base
+  // change the review decision. Excluding raw age avoids daily cache churn.
+  return {
+    status: drift.status ?? null,
+    mergeBaseSha: drift.mergeBaseSha ?? null,
+    stale: drift.stale ?? null,
+  };
+}
+
 function itemContentDigest(item: Item, context: ItemContext, git?: GitInfo): string {
   const isPull = item.kind === "pull_request";
   const pull = asRecord(context.pullRequest);
@@ -3148,6 +3161,7 @@ function itemContentDigest(item: Item, context: ItemContext, git?: GitInfo): str
           reviewCommentDigestParts(context.pullReviewComments))
         : null,
       checks: isPull ? (context.pullChecks ?? null) : null,
+      baseDrift: isPull ? pullBaseDriftDigestParts(context.pullBaseDrift) : null,
     }),
   );
 }
@@ -5286,6 +5300,59 @@ function compactPullRequest(value: unknown): unknown {
 
 export function compactPullRequestForTest(value: unknown): unknown {
   return compactPullRequest(value);
+}
+
+const STALE_PULL_BASE_AGE_DAYS = 7;
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function pullBaseDriftFromComparison(value: unknown, nowMs = Date.now()): unknown {
+  const comparison = asRecord(value);
+  const mergeBase = asRecord(comparison.merge_base_commit);
+  const commit = asRecord(mergeBase.commit);
+  const committedAt =
+    stringOrUndefined(asRecord(commit.committer).date) ??
+    stringOrUndefined(asRecord(commit.author).date) ??
+    null;
+  const committedAtMs = committedAt ? timestampValueMs(committedAt) : 0;
+  const baseAgeDays = committedAtMs
+    ? Math.max(0, Math.floor((nowMs - committedAtMs) / MILLISECONDS_PER_DAY))
+    : null;
+  return {
+    status: "behind",
+    behindCommits: githubCount(comparison.behind_by),
+    mergeBaseSha: stringOrUndefined(mergeBase.sha) ?? null,
+    mergeBaseAt: committedAt,
+    baseAgeDays,
+    stale: baseAgeDays !== null && baseAgeDays >= STALE_PULL_BASE_AGE_DAYS,
+    staleAfterDays: STALE_PULL_BASE_AGE_DAYS,
+    contributorActionRequired: false,
+  };
+}
+
+export function pullBaseDriftFromComparisonForTest(value: unknown, nowMs: number): unknown {
+  return pullBaseDriftFromComparison(value, nowMs);
+}
+
+function pullBaseDriftContext(number: number, pullRequest: unknown): unknown {
+  const pull = asRecord(pullRequest);
+  if (stringOrUndefined(pull.mergeable_state)?.toLowerCase() !== "behind") return null;
+  const baseSha = stringOrUndefined(asRecord(pull.base).sha);
+  const headSha = stringOrUndefined(asRecord(pull.head).sha);
+  if (!baseSha || !headSha) return null;
+  try {
+    const comparison = ghJson<unknown>([
+      "api",
+      `repos/${targetRepo()}/compare/${baseSha}...${headSha}`,
+    ]);
+    return pullBaseDriftFromComparison(comparison);
+  } catch (error) {
+    console.error(
+      `[review] ${new Date().toISOString()} base-drift=unavailable #${number}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return null;
+  }
 }
 
 function compactCheckRun(value: unknown): unknown {
@@ -8369,6 +8436,8 @@ function collectItemContext(
         ? filteredPullReviewComments
         : filterReviewContextComments(fullPullReviewComments, item.number);
     context.pullRequest = compactPullRequest(pullRequest);
+    const pullBaseDrift = pullBaseDriftContext(item.number, pullRequest);
+    if (pullBaseDrift) context.pullBaseDrift = pullBaseDrift;
     context.pullFiles = compactMappedWindow(pullFiles, pullFilesWindow.total, 80, compactPullFile);
     context.semanticPullFiles =
       options.reviewCacheDigest &&
@@ -9696,6 +9765,34 @@ function runCodex(options: {
       throw combinedCodexReviewError(error, retryError, options.reasoningEffort);
     }
   }
+}
+
+function attachPullBaseDriftMetric(decision: Decision, context: ItemContext): Decision {
+  const drift = asRecord(context.pullBaseDrift);
+  const baseAgeDays = githubCount(drift.baseAgeDays);
+  if (drift.status !== "behind" || drift.stale !== true || baseAgeDays === null) return decision;
+  const reviewMetrics = decision.reviewMetrics.filter(
+    (metric) => metric.label.trim().toLowerCase() !== "base freshness",
+  );
+  return {
+    ...decision,
+    reviewMetrics: [
+      ...reviewMetrics,
+      {
+        label: "Base freshness",
+        value: `${baseAgeDays} days since merge base`,
+        reason:
+          "Maintainers or merge automation should refresh validation before landing; no contributor action is required.",
+      },
+    ],
+  };
+}
+
+export function attachPullBaseDriftMetricForTest(
+  decision: Decision,
+  context: ItemContext,
+): Decision {
+  return attachPullBaseDriftMetric(decision, context);
 }
 
 function stripTextFence(markdown: string): string {
@@ -17133,6 +17230,12 @@ function reviewContextLedger(context: ItemContext): ReviewContextLedgerEntry[] {
       entries: context.pullChecks === undefined ? 0 : 1,
     }),
     reviewContextLedgerEntry({
+      section: "pullBaseDrift",
+      label: "PR base freshness",
+      value: context.pullBaseDrift ?? null,
+      entries: context.pullBaseDrift === undefined ? 0 : 1,
+    }),
+    reviewContextLedgerEntry({
       section: "counts",
       label: "context counts",
       value: counts ?? {},
@@ -22459,6 +22562,7 @@ function reviewCommand(args: Args): void {
         codexElapsedMs = Date.now() - codexStartedAt;
       }
       decision = attachFixedPullRequest(decision, item, context);
+      decision = attachPullBaseDriftMetric(decision, context);
       const runtime = {
         model: PUBLIC_CODEX_MODEL,
         reasoningEffort,

--- a/test/review-content-cache.test.ts
+++ b/test/review-content-cache.test.ts
@@ -131,6 +131,38 @@ test("content digest busts when the PR base sha changes", () => {
   assert.notEqual(a, b);
 });
 
+test("content digest busts when base drift becomes stale", () => {
+  const pull = item({ kind: "pull_request", number: 200 });
+  const fresh = itemContentDigestForTest(
+    pull,
+    pullContext({ pullBaseDrift: { status: "behind", baseAgeDays: 6, stale: false } }),
+  );
+  const stale = itemContentDigestForTest(
+    pull,
+    pullContext({ pullBaseDrift: { status: "behind", baseAgeDays: 7, stale: true } }),
+  );
+
+  assert.notEqual(fresh, stale);
+});
+
+test("content digest ignores base drift age changes within the same freshness state", () => {
+  const pull = item({ kind: "pull_request", number: 200 });
+  const a = itemContentDigestForTest(
+    pull,
+    pullContext({
+      pullBaseDrift: { status: "behind", mergeBaseSha: "base-sha", baseAgeDays: 7, stale: true },
+    }),
+  );
+  const b = itemContentDigestForTest(
+    pull,
+    pullContext({
+      pullBaseDrift: { status: "behind", mergeBaseSha: "base-sha", baseAgeDays: 8, stale: true },
+    }),
+  );
+
+  assert.equal(a, b);
+});
+
 test("issue digest ignores pull-request-only fields", () => {
   const issue = item({ kind: "issue", number: 300 });
   const a = itemContentDigestForTest(

--- a/test/review-prompt-context.test.ts
+++ b/test/review-prompt-context.test.ts
@@ -3,7 +3,9 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import {
+  attachPullBaseDriftMetricForTest,
   compactPullRequestForTest,
+  pullBaseDriftFromComparisonForTest,
   renderReviewContextBudgetForTest,
   reviewContextLedgerForTest,
   reviewDecisionSchemaText,
@@ -12,7 +14,7 @@ import {
   reviewPromptTemplate,
 } from "../dist/clawsweeper.js";
 import { parseArgs as parseClawsweeperArgs } from "../dist/clawsweeper-args.js";
-import { git, item } from "./helpers.ts";
+import { closeDecision, git, item } from "./helpers.ts";
 
 test("review prompt assets match tracked files", () => {
   assert.equal(reviewPromptTemplate(), readFileSync("prompts/review-item.md", "utf8"));
@@ -137,7 +139,75 @@ test("review prompt includes merge state and guards clean behind-branch drift", 
   assert.deepEqual((compactPullRequest as { mergeableState?: unknown }).mergeableState, "clean");
   assert.match(prompt, /"mergeableState": "clean"/);
   assert.match(prompt, /Do not treat a branch being behind the current base as proof/);
-  assert.match(prompt, /actual three-way merge result/);
+  assert.match(prompt, /Ordinary\s+`behind` state is\s+not a contributor blocker/);
+  assert.match(prompt, /do not claim that rebasing will fix a failing check/);
+  assert.match(
+    prompt,
+    /Only ask the contributor to rebase or resolve the base when GitHub reports a/,
+  );
+  assert.match(prompt, /concrete merge-result evidence shows an integration failure/);
+});
+
+test("base drift becomes stale after seven days", () => {
+  const nowMs = Date.parse("2026-07-15T00:00:00Z");
+  const comparison = (mergeBaseAt: string) => ({
+    behind_by: 1200,
+    merge_base_commit: {
+      sha: "base123",
+      commit: { committer: { date: mergeBaseAt } },
+    },
+  });
+
+  assert.deepEqual(pullBaseDriftFromComparisonForTest(comparison("2026-07-13T00:00:00Z"), nowMs), {
+    status: "behind",
+    behindCommits: 1200,
+    mergeBaseSha: "base123",
+    mergeBaseAt: "2026-07-13T00:00:00Z",
+    baseAgeDays: 2,
+    stale: false,
+    staleAfterDays: 7,
+    contributorActionRequired: false,
+  });
+  assert.equal(
+    (
+      pullBaseDriftFromComparisonForTest(comparison("2026-07-05T00:00:00Z"), nowMs) as {
+        stale: boolean;
+      }
+    ).stale,
+    true,
+  );
+});
+
+test("stale base drift adds a non-blocking maintainer metric", () => {
+  const decision = attachPullBaseDriftMetricForTest(closeDecision(), {
+    issue: {},
+    comments: [],
+    timeline: [],
+    pullBaseDrift: { status: "behind", baseAgeDays: 10, stale: true },
+  });
+
+  assert.deepEqual(decision.reviewMetrics.at(-1), {
+    label: "Base freshness",
+    value: "10 days since merge base",
+    reason:
+      "Maintainers or merge automation should refresh validation before landing; no contributor action is required.",
+  });
+  assert.deepEqual(decision.risks, []);
+  assert.deepEqual(decision.prRating.nextSteps, []);
+});
+
+test("fresh base drift does not add a review metric", () => {
+  const decision = closeDecision();
+
+  assert.deepEqual(
+    attachPullBaseDriftMetricForTest(decision, {
+      issue: {},
+      comments: [],
+      timeline: [],
+      pullBaseDrift: { status: "behind", baseAgeDays: 6, stale: false },
+    }),
+    decision,
+  );
 });
 
 test("review context ledger records ordered section budgets", () => {
@@ -152,6 +222,7 @@ test("review context ledger records ordered section budgets", () => {
     },
     relatedItems: [{ number: 122, title: "Related issue" }],
     pullRequest: { number: 123, additions: 12 },
+    pullBaseDrift: { status: "behind", baseAgeDays: 10, stale: true },
     pullFiles: [
       { filename: "src/example.ts", patch: "line\n".repeat(20) },
       { filename: "test/example.test.ts", patch: "test\n".repeat(20) },
@@ -197,6 +268,7 @@ test("review context ledger records ordered section budgets", () => {
       ["pullRequest", 1, undefined, undefined, undefined],
       ["pullFiles", 2, 120, 2, true],
       ["pullCommits", 1, 1, 1, false],
+      ["pullBaseDrift", 1, undefined, undefined, undefined],
       ["counts", 16, undefined, undefined, undefined],
     ],
   );


### PR DESCRIPTION
## Summary

- stop treating an ordinary behind branch as a contributor blocker or recommending a routine rebase
- reserve rebase/resolve guidance for conflicts, unavailable merge trees, or concrete merge-result integration failures
- add a non-blocking maintainer-facing Base freshness metric when the merge base is at least 7 days old
- avoid daily review-cache churn by invalidating only when freshness state or merge-base identity changes

## Motivation

High-throughput repositories can advance by thousands of commits per day. Commit-count drift alone therefore creates noisy, repeated contributor work without proving that a PR is unsafe to merge. This keeps contributor action tied to concrete integration evidence while retaining a simple signal for genuinely old branches.

## Impact

Only PRs whose GitHub mergeable state is behind trigger the compare lookup. A stale result adds review context and a non-blocking metric for maintainers or merge automation; it does not lower the PR rating or add contributor next steps. Compare failures fail soft.

## Validation

- Node 24.15.0: build passed
- Node 24.15.0: 49 focused review prompt/content-cache tests passed
- formatting, TypeScript compilation, and lint passed as part of `pnpm run check`
- full `pnpm run check` did not complete because Codex runner tests reached the real Codex API and received 401 Unauthorized
- autoreview was attempted with the bundled helper, but the same Codex API 401 prevented a review result
