### PR TITLE
fix(repair): resolve containment worker before isolation

### DIFF
--- a/.github/workflows/repair-cluster-worker.yml
+++ b/.github/workflows/repair-cluster-worker.yml
@@ -603,6 +603,8 @@ jobs:
           if (!root || !hostSecret) throw new Error("containment preflight paths are missing");
           const work = path.join(root, "work");
           const profile = path.join(root, "profile");
+          // The child runs from the isolated work directory, so resolve the trusted worker first.
+          const workerPath = path.resolve("dist/repair/contained-command-worker.js");
           const probe = [
             "import os, socket, sys",
             "host_secret, work, profile = sys.argv[1:]",
@@ -625,7 +627,7 @@ jobs:
           ].join("\n");
           const worker = spawnSync(
             process.execPath,
-            ["dist/repair/contained-command-worker.js"],
+            [workerPath],
             {
               cwd: work,
               env: {

--- a/test/repair/repair-cluster-worker-containment.test.ts
+++ b/test/repair/repair-cluster-worker-containment.test.ts
@@ -20,7 +20,12 @@ test("repair target containment preflight runs the enforced worker only for fix 
   const executionCondition =
     "steps.check_job.outputs.job_exists == '1' && steps.self_heal_head.outputs.matched != 'false' && env.CLAWSWEEPER_ALLOW_EXECUTE == '1' && env.CLAWSWEEPER_ALLOW_FIX_PR == '1'";
   assert.match(preflight, new RegExp(escapeRegExp(`if: \${{ ${executionCondition} }}`)));
-  assert.match(preflight, /dist\/repair\/contained-command-worker\.js/);
+  assert.match(
+    preflight,
+    /const workerPath = path\.resolve\("dist\/repair\/contained-command-worker\.js"\);/,
+  );
+  assert.match(preflight, /\[workerPath\],\s*\{\s*cwd: work,/s);
+  assert.doesNotMatch(preflight, /\["dist\/repair\/contained-command-worker\.js"\]/);
   assert.match(preflight, /host filesystem remained visible/);
   assert.match(preflight, /host \/run entries remained visible/);
   assert.match(preflight, /non-writable path accepted a write/);


### PR DESCRIPTION
## Summary

- resolve the trusted containment worker path before changing the child process working directory
- add regression coverage that rejects the relative worker invocation

## Root cause

The repair containment preflight launched `dist/repair/contained-command-worker.js` as a relative path while setting the child `cwd` to the isolated work directory. Node therefore searched inside that temporary directory and failed with `MODULE_NOT_FOUND` before review or repair execution could start.

## Impact

Repair jobs can reach the existing containment preflight again. The isolation policy, namespace and Landlock setup, capability dropping, network restrictions, writable roots, execution gates, and fail-closed checks are unchanged.

## Validation

- autoreview (`--mode uncommitted`): clean, no actionable findings
- focused containment regression test: 6 passed
- related containment and target-validation tests: 149 passed, 3 capability skips
- unit tests: 1174 passed, 1 platform skip
- `pnpm run build:repair`
- build/lint portions of `pnpm check`
- `pnpm run format:check`
- `git diff --check`

The workflow preflight no longer fails on the worker module path locally. This container lacks the required Landlock/namespace capability, so hosted Linux remains the environment for the complete containment probe.