### PR TITLE
feat: serialize exact review publication

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -235,13 +235,32 @@ jobs:
       - name: Enqueue legacy event through the durable control plane
         env:
           CLIENT_PAYLOAD: ${{ toJson(github.event.client_payload) }}
+          GH_TOKEN: ${{ github.token }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
         run: |
           set -euo pipefail
           test -n "$CLAWSWEEPER_WEBHOOK_SECRET"
           queue_url="${QUEUE_URL%/}"
-          payload="$(node <<'NODE'
+          IFS=$'\t' read -r target_repo target_branch < <(node <<'NODE'
+          const payload = JSON.parse(process.env.CLIENT_PAYLOAD || "{}");
+          process.stdout.write(
+            `${String(payload.target_repo || "openclaw/openclaw").trim()}\t${String(payload.target_branch || "").trim()}\n`,
+          );
+          NODE
+          )
+          if ! printf '%s' "$target_repo" | grep -Eq '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'; then
+            echo "Invalid legacy target repository: $target_repo" >&2
+            exit 1
+          fi
+          if [ -z "$target_branch" ]; then
+            target_branch="$(gh api "repos/$target_repo" --jq .default_branch)"
+          fi
+          if ! printf '%s' "$target_branch" | grep -Eq '^[A-Za-z0-9_.\/-]+$'; then
+            echo "Invalid legacy target branch for $target_repo: $target_branch" >&2
+            exit 1
+          fi
+          payload="$(TARGET_REPO="$target_repo" TARGET_BRANCH="$target_branch" node <<'NODE'
           const payload = JSON.parse(process.env.CLIENT_PAYLOAD || "{}");
           const itemKind = payload.item_kind === "pull_request" ? "pull_request" : "issue";
           const sourceEvent = payload.source_event === "pull_request" ? "pull_request" : "issues";
@@ -252,8 +271,8 @@ jobs:
                 ? `router:${dispatchKey}`
                 : `legacy:${process.env.GITHUB_RUN_ID}:${process.env.GITHUB_RUN_ATTEMPT}`,
               decision: {
-                targetRepo: payload.target_repo || "openclaw/openclaw",
-                targetBranch: payload.target_branch || "main",
+                targetRepo: process.env.TARGET_REPO,
+                targetBranch: process.env.TARGET_BRANCH,
                 itemNumber: Number(payload.item_number),
                 itemKind,
                 sourceEvent,

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1152,7 +1152,7 @@ jobs:
                   item_number: decision.itemNumber,
                   item_kind: decision.itemKind,
                   has_command_context: Boolean(
-                    producerDecision.commandStatusMarker && producerDecision.statusCommentId,
+                    producerDecision.commandStatusMarker || producerDecision.statusCommentId,
                   ),
                   live_proceeded: publication.liveProceeded,
                   live_terminal_noop: publication.liveTerminalNoop,

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -288,8 +288,8 @@ jobs:
             "$queue_url/internal/exact-review/enqueue" >/dev/null
 
   event-review-apply:
-    name: Review, comment, and apply event item
-    if: ${{ github.event_name == 'repository_dispatch' && github.event.action != 'clawsweeper_target_sweep' && github.event.client_payload.queue_lease_id != '' }}
+    name: Review exact event item
+    if: ${{ github.event_name == 'repository_dispatch' && github.event.action != 'clawsweeper_target_sweep' && github.event.client_payload.queue_lease_id != '' && github.event.client_payload.source_action != 'exact_review_artifact_publish' }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
     concurrency:
@@ -298,9 +298,9 @@ jobs:
     permissions:
       actions: write
       checks: read
-      contents: write
-      issues: write
-      pull-requests: write
+      contents: read
+      issues: read
+      pull-requests: read
       statuses: read
     steps:
       - name: Claim exact-review queue lease
@@ -523,11 +523,11 @@ jobs:
           GH_TOKEN: ${{ steps.target-read-token.outputs.token }}
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
           ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
-          RECOVERY_TARGET_BRANCH: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).sourceAction == 'failed_review_shard_recovery' && fromJSON(steps.claim-exact-review-queue.outputs.decision).targetBranch || '' }}
+          CLAIM_TARGET_BRANCH: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).targetBranch }}
         run: |
           set -euo pipefail
           test -n "$GH_TOKEN"
-          target_branch="${RECOVERY_TARGET_BRANCH:-$(gh api "repos/$TARGET_REPO" --jq .default_branch)}"
+          target_branch="$CLAIM_TARGET_BRANCH"
           if ! printf '%s' "$target_branch" | grep -Eq '^[A-Za-z0-9_.\/-]+$'; then
             echo "Invalid target branch for $TARGET_REPO: $target_branch" >&2
             exit 1
@@ -601,7 +601,7 @@ jobs:
 
       - uses: ./.github/actions/setup-pnpm
         id: setup-pnpm
-        if: ${{ steps.live-item.outputs.proceed == 'true' || ((steps.live-item.outputs.terminal_noop == 'true' || steps.live-item.outputs.terminal_missing == 'true' || steps.live-item.outputs.guarded_open == 'true') && steps.target.outputs.has_command_context == 'true') }}
+        if: ${{ steps.live-item.outcome == 'success' }}
         with:
           build-script: ${{ steps.live-item.outputs.proceed == 'true' && 'build:all' || 'build:repair' }}
 
@@ -710,7 +710,7 @@ jobs:
         if: ${{ steps.live-item.outputs.proceed == 'true' }}
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          GH_TOKEN: ${{ steps.target-read-token.outputs.token }}
           CLAWSWEEPER_PROOF_INSPECTION_TOKEN: ${{ steps.target-read-token.outputs.token || github.token }}
           ADDITIONAL_PROMPT: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).additionalPrompt || '' }}
           CLAWSWEEPER_RELATED_GITHUB_SEARCH: ${{ vars.CLAWSWEEPER_RELATED_GITHUB_SEARCH || '1' }}
@@ -776,6 +776,7 @@ jobs:
               exit 1
             fi
             echo "::notice::Exact review produced no artifact because the item closed during review."
+            echo "terminal_during_review=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Finalize exact event action ledger
@@ -795,69 +796,126 @@ jobs:
           fi
           pnpm run --silent finalize-action-events -- "${args[@]}"
 
-      - name: Create state token
-        id: state-token
-        if: ${{ always() && steps.live-item.outputs.proceed == 'true' }}
-        uses: ./.github/actions/create-state-token
-        with:
-          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
-          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
-
-      - uses: ./.github/actions/setup-state
-        id: setup-state
-        if: ${{ always() && steps.live-item.outputs.proceed == 'true' }}
-        with:
-          token: ${{ steps.state-token.outputs.token }}
-          fetch-depth: 1
-
-      - name: Publish event result and apply safe close
-        id: publish-event-result
-        if: ${{ always() && !cancelled() && steps.review-exact-event-item.outcome == 'success' && steps.setup-state.outcome == 'success' }}
+      - name: Create exact review artifact bundle
+        id: create-exact-review-bundle
+        if: ${{ always() && !cancelled() && steps.target.outputs.target_enabled == 'true' && steps.live-item.outcome == 'success' && steps.setup-pnpm.outcome == 'success' && (steps.live-item.outputs.proceed != 'true' || (steps.review-exact-event-item.outcome == 'success' && steps.review-exact-event-item.outputs.retry_at == '')) }}
         env:
-          GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
-          REPO_TOKEN: ${{ github.token }}
-          TARGET_REPO: ${{ steps.target.outputs.target_repo }}
-          ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
-          CLOSE_REASONS: implemented_on_main,duplicate_or_superseded,low_signal_unmergeable_pr
-          MIN_AGE_MINUTES: "0"
-          REVIEW_ONLY: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).sourceAction == 'failed_review_shard_recovery' && 'true' || 'false' }}
+          EXACT_REVIEW_ACTION_LEDGER_ROOT: ${{ env.CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT }}
+          EXACT_REVIEW_BUNDLE_DIR: .artifacts/exact-review-bundle
+          EXACT_REVIEW_CLAIM_GENERATION: ${{ steps.claim-exact-review-queue.outputs.claim_generation }}
+          EXACT_REVIEW_DECISION: ${{ steps.claim-exact-review-queue.outputs.decision }}
+          EXACT_REVIEW_GENERATION_ATTEMPT: ${{ github.run_attempt }}
+          EXACT_REVIEW_ITEM_KEY: ${{ steps.claim-exact-review-queue.outputs.item_key }}
+          EXACT_REVIEW_ITEM_KIND: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).itemKind }}
+          EXACT_REVIEW_ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
+          EXACT_REVIEW_LEASE_REVISION: ${{ steps.claim-exact-review-queue.outputs.lease_revision }}
+          EXACT_REVIEW_LIVE_GUARDED_OPEN: ${{ steps.live-item.outputs.guarded_open }}
+          EXACT_REVIEW_LIVE_PROCEEDED: ${{ steps.review-exact-event-item.outputs.terminal_during_review == 'true' && 'false' || steps.live-item.outputs.proceed }}
+          EXACT_REVIEW_LIVE_TERMINAL_MISSING: ${{ steps.live-item.outputs.terminal_missing }}
+          EXACT_REVIEW_LIVE_TERMINAL_NOOP: ${{ steps.review-exact-event-item.outputs.terminal_during_review == 'true' && 'true' || steps.live-item.outputs.terminal_noop }}
+          EXACT_REVIEW_PRODUCER_JOB: event-review-apply
+          EXACT_REVIEW_PROTOCOL_VERSION: ${{ steps.claim-exact-review-queue.outputs.protocol_version }}
+          EXACT_REVIEW_REPORT_PATH: artifacts/event/${{ steps.target.outputs.item_number }}.md
+          EXACT_REVIEW_TARGET_BRANCH: ${{ steps.live-item.outputs.target_branch }}
+          EXACT_REVIEW_TARGET_REPO: ${{ steps.target.outputs.target_repo }}
         run: |
           set -euo pipefail
-          live_item_error="$(mktemp)"
-          if ! live_state="$(gh api "repos/$TARGET_REPO/issues/$ITEM_NUMBER" --jq .state 2>"$live_item_error")"; then
-            if grep -Eqi 'HTTP 404|Not Found' "$live_item_error" && gh api "repos/$TARGET_REPO" >/dev/null; then
-              rm -f "$live_item_error"
-              echo "terminal_noop=false" >> "$GITHUB_OUTPUT"
-              echo "terminal_missing=true" >> "$GITHUB_OUTPUT"
-              echo "terminal_closed=false" >> "$GITHUB_OUTPUT"
-              echo "guarded_open=false" >> "$GITHUB_OUTPUT"
-              echo "guarded_open_action=" >> "$GITHUB_OUTPUT"
-              echo "remote_tuple_verified=false" >> "$GITHUB_OUTPUT"
-              echo "routing_deferred=false" >> "$GITHUB_OUTPUT"
-              echo "::notice::Treating $TARGET_REPO#$ITEM_NUMBER as terminal because the repository is accessible but the item is missing."
+          mkdir -p .artifacts
+          pnpm run --silent repair:exact-review-bundle -- create > .artifacts/exact-review-bundle-create.json
+          artifact_name="exact-review-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          {
+            echo "artifact_name=$artifact_name"
+            echo "generation_attempt=$GITHUB_RUN_ATTEMPT"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload exact review artifact bundle
+        id: upload-exact-review-bundle
+        if: ${{ always() && !cancelled() && steps.create-exact-review-bundle.outcome == 'success' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ steps.create-exact-review-bundle.outputs.artifact_name }}
+          path: .artifacts/exact-review-bundle
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Queue durable exact review publication
+        id: queue-exact-review-publication
+        if: ${{ always() && !cancelled() && steps.upload-exact-review-bundle.outcome == 'success' }}
+        env:
+          ARTIFACT_NAME: ${{ steps.create-exact-review-bundle.outputs.artifact_name }}
+          CLAIM_DECISION: ${{ steps.claim-exact-review-queue.outputs.decision }}
+          CLAIM_GENERATION: ${{ steps.claim-exact-review-queue.outputs.claim_generation }}
+          ITEM_KEY: ${{ steps.claim-exact-review-queue.outputs.item_key }}
+          LEASE_REVISION: ${{ steps.claim-exact-review-queue.outputs.lease_revision }}
+          LIVE_GUARDED_OPEN: ${{ steps.live-item.outputs.guarded_open }}
+          LIVE_PROCEEDED: ${{ steps.review-exact-event-item.outputs.terminal_during_review == 'true' && 'false' || steps.live-item.outputs.proceed }}
+          LIVE_TERMINAL_MISSING: ${{ steps.live-item.outputs.terminal_missing }}
+          LIVE_TERMINAL_NOOP: ${{ steps.review-exact-event-item.outputs.terminal_during_review == 'true' && 'true' || steps.live-item.outputs.terminal_noop }}
+          PROTOCOL_VERSION: ${{ steps.claim-exact-review-queue.outputs.protocol_version }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+        run: |
+          set -euo pipefail
+          test -n "$CLAWSWEEPER_WEBHOOK_SECRET"
+          queue_url="${QUEUE_URL%/}"
+          payload="$(node <<'NODE'
+          const producerDecision = JSON.parse(process.env.CLAIM_DECISION || "{}");
+          const producerRunAttempt = Number(process.env.GITHUB_RUN_ATTEMPT);
+          const protocolVersion = Number(process.env.PROTOCOL_VERSION);
+          const leaseRevision = process.env.LEASE_REVISION ? Number(process.env.LEASE_REVISION) : null;
+          const claimGeneration = process.env.CLAIM_GENERATION ? Number(process.env.CLAIM_GENERATION) : null;
+          const flag = (name) => {
+            const value = process.env[name];
+            if (value === "true") return true;
+            if (value === "false") return false;
+            process.exit(1);
+          };
+          if (!Number.isInteger(producerRunAttempt) || producerRunAttempt < 1) process.exit(1);
+          process.stdout.write(JSON.stringify({
+            delivery_id: `publisher:${process.env.GITHUB_RUN_ID}:${producerRunAttempt}`,
+            decision: {
+              ...producerDecision,
+              sourceAction: "exact_review_artifact_publish",
+              supersedesInProgress: false,
+              publication: {
+                artifactName: process.env.ARTIFACT_NAME,
+                producerRunId: process.env.GITHUB_RUN_ID,
+                producerRunAttempt,
+                sourceSha: process.env.GITHUB_SHA,
+                itemKey: process.env.ITEM_KEY,
+                protocolVersion,
+                leaseRevision,
+                claimGeneration,
+                liveProceeded: flag("LIVE_PROCEEDED"),
+                liveTerminalNoop: flag("LIVE_TERMINAL_NOOP"),
+                liveTerminalMissing: flag("LIVE_TERMINAL_MISSING"),
+                liveGuardedOpen: flag("LIVE_GUARDED_OPEN"),
+                producerDecision,
+              },
+            },
+          }));
+          NODE
+          )"
+          signature="$(PAYLOAD="$payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
+          for attempt in 1 2 3; do
+            if response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+              --request POST \
+              --header "content-type: application/json" \
+              --header "x-clawsweeper-exact-review-signature: $signature" \
+              --data "$payload" \
+              "$queue_url/internal/exact-review/enqueue")" &&
+              jq -e '.ok == true and (.queued == true or .deduped == true)' <<< "$response" >/dev/null; then
               exit 0
             fi
-            cat "$live_item_error" >&2
-            rm -f "$live_item_error"
-            exit 1
-          fi
-          rm -f "$live_item_error"
-          if [ "$live_state" = "closed" ]; then
-            echo "terminal_noop=true" >> "$GITHUB_OUTPUT"
-            echo "remote_tuple_verified=false" >> "$GITHUB_OUTPUT"
-            echo "routing_deferred=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Treating $TARGET_REPO#$ITEM_NUMBER as terminal because it closed during review."
-            exit 0
-          fi
-          if [ ! -f "artifacts/event/$ITEM_NUMBER.md" ]; then
-            echo "Exact review produced no artifact for open item $TARGET_REPO#$ITEM_NUMBER." >&2
-            exit 1
-          fi
-          echo "terminal_noop=false" >> "$GITHUB_OUTPUT"
-          pnpm run repair:publish-event-result
+            if [ "$attempt" -lt 3 ]; then
+              sleep "$((attempt * 5))"
+            fi
+          done
+          exit 1
 
       - name: Release unsuccessful workflow-owned review lease
-        if: ${{ always() && steps.live-item.outputs.proceed == 'true' && (steps.review-exact-event-item.outcome != 'success' || steps.publish-event-result.outcome != 'success') }}
+        if: ${{ always() && steps.live-item.outputs.proceed == 'true' && steps.queue-exact-review-publication.outcome != 'success' }}
         env:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
@@ -874,114 +932,19 @@ jobs:
           while IFS= read -r lease_id; do
             [ -n "$lease_id" ] || continue
             gh api "repos/$TARGET_REPO/issues/comments/$lease_id" --method DELETE
-            echo "Released unsuccessful review lease comment $lease_id owned by $LEASE_OWNER."
           done <<< "$lease_ids"
-          reaction_ids="$(
-            gh api "repos/$TARGET_REPO/issues/$ITEM_NUMBER/reactions?content=eyes&per_page=100" \
-              --paginate \
-              --jq '.[] | select(.content == "eyes") | select(.user.login == "clawsweeper" or .user.login == "clawsweeper[bot]" or .user.login == "openclaw-clawsweeper[bot]") | .id'
-          )"
+          reaction_ids="$(gh api -X GET \
+            -H "Accept: application/vnd.github+json" \
+            "repos/$TARGET_REPO/issues/$ITEM_NUMBER/reactions" \
+            -f content="eyes" -F per_page=100 --paginate \
+            --jq '.[] | select(.content == "eyes") | select(.user.login == "clawsweeper" or .user.login == "clawsweeper[bot]" or .user.login == "openclaw-clawsweeper[bot]") | .id')"
           while IFS= read -r reaction_id; do
             [ -n "$reaction_id" ] || continue
             gh api "repos/$TARGET_REPO/issues/$ITEM_NUMBER/reactions/$reaction_id" --method DELETE
-            echo "Removed unsuccessful eyes reaction $reaction_id from $TARGET_REPO#$ITEM_NUMBER."
           done <<< "$reaction_ids"
 
-      - name: Route synced ClawSweeper verdict
-        id: route-synced-verdict
-        if: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).sourceAction != 'failed_review_shard_recovery' && steps.review-exact-event-item.outcome == 'success' && steps.publish-event-result.outcome == 'success' && steps.publish-event-result.outputs.terminal_noop != 'true' && steps.publish-event-result.outputs.terminal_missing != 'true' && steps.publish-event-result.outputs.terminal_closed != 'true' && steps.publish-event-result.outputs.guarded_open != 'true' && steps.publish-event-result.outputs.policy_noop != 'true' && steps.publish-event-result.outputs.requeue_latest != 'true' && steps.publish-event-result.outputs.remote_tuple_verified == 'true' && steps.publish-event-result.outputs.routing_deferred == 'false' }}
-        timeout-minutes: 4
-        env:
-          GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
-          CLAWSWEEPER_DISPATCH_TOKEN: ${{ github.token }}
-          TARGET_REPO: ${{ steps.target.outputs.target_repo }}
-          ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
-          CLAWSWEEPER_MUTATION_TOKEN_SOURCE: clawsweeper-app
-          CLAWSWEEPER_ALLOW_MERGE: ${{ vars.CLAWSWEEPER_ALLOW_MERGE || '0' }}
-          CLAWSWEEPER_UNSPONSORED_FEATURE_CLOSE_ENABLED: ${{ vars.CLAWSWEEPER_UNSPONSORED_FEATURE_CLOSE_ENABLED || 'false' }}
-          CLAWSWEEPER_COMMENT_LOOKBACK_MINUTES: ${{ vars.CLAWSWEEPER_COMMENT_LOOKBACK_MINUTES || '180' }}
-          CLAWSWEEPER_COMMENT_MAX_COMMENTS: ${{ vars.CLAWSWEEPER_COMMENT_MAX_COMMENTS || '1000' }}
-        run: |
-          set -euo pipefail
-          pnpm run repair:comment-router -- \
-            --write-report \
-            --repo "$TARGET_REPO" \
-            --item-number "$ITEM_NUMBER" \
-            --lookback-minutes "$CLAWSWEEPER_COMMENT_LOOKBACK_MINUTES" \
-            --max-comments "$CLAWSWEEPER_COMMENT_MAX_COMMENTS" \
-            --execute
-
-      - name: Queue deferred exact verdict router
-        id: queue-deferred-verdict-router
-        if: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).sourceAction != 'failed_review_shard_recovery' && steps.review-exact-event-item.outcome == 'success' && steps.publish-event-result.outcome == 'success' && steps.publish-event-result.outputs.remote_tuple_verified == 'true' && steps.publish-event-result.outputs.routing_deferred == 'true' }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TARGET_REPO: ${{ steps.target.outputs.target_repo }}
-          TARGET_BRANCH: ${{ steps.live-item.outputs.target_branch }}
-          CLAWSWEEPER_COMMENT_LOOKBACK_MINUTES: ${{ vars.CLAWSWEEPER_COMMENT_LOOKBACK_MINUTES || '180' }}
-          CLAWSWEEPER_COMMENT_MAX_COMMENTS: ${{ vars.CLAWSWEEPER_COMMENT_MAX_COMMENTS || '1000' }}
-        run: |
-          set -euo pipefail
-          gh workflow run repair-comment-router.yml \
-            --repo "$GITHUB_REPOSITORY" \
-            --ref main \
-            -f execute=true \
-            -f target_repo="$TARGET_REPO" \
-            -f target_branch="$TARGET_BRANCH" \
-            -f lookback_minutes="$CLAWSWEEPER_COMMENT_LOOKBACK_MINUTES" \
-            -f max_comments="$CLAWSWEEPER_COMMENT_MAX_COMMENTS"
-
-      - name: Release terminal review leases
-        id: release-terminal-review-leases
-        if: ${{ always() && (steps.live-item.outputs.terminal_noop == 'true' || steps.publish-event-result.outputs.terminal_noop == 'true' || steps.publish-event-result.outputs.terminal_closed == 'true') }}
-        env:
-          GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
-          TARGET_REPO: ${{ steps.target.outputs.target_repo }}
-          ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
-        run: |
-          set -euo pipefail
-          test -n "$GH_TOKEN"
-          lease_ids="$(
-            gh api "repos/$TARGET_REPO/issues/$ITEM_NUMBER/comments?per_page=100" \
-              --paginate \
-              --jq ".[] | select(.user.login == \"clawsweeper[bot]\" or .user.login == \"openclaw-clawsweeper[bot]\") | select(.body | contains(\"<!-- clawsweeper-review-lease item=$ITEM_NUMBER -->\")) | .id"
-          )"
-          reaction_ids="$(
-            gh api "repos/$TARGET_REPO/issues/$ITEM_NUMBER/reactions?content=eyes&per_page=100" \
-              --paginate \
-              --jq '.[] | select(.content == "eyes") | select(.user.login == "clawsweeper" or .user.login == "clawsweeper[bot]" or .user.login == "openclaw-clawsweeper[bot]") | .id'
-          )"
-          test "$(gh api "repos/$TARGET_REPO/issues/$ITEM_NUMBER" --jq .state)" = "closed"
-          while IFS= read -r lease_id; do
-            [ -n "$lease_id" ] || continue
-            gh api "repos/$TARGET_REPO/issues/comments/$lease_id" --method DELETE
-            echo "Released terminal review lease comment $lease_id for $TARGET_REPO#$ITEM_NUMBER."
-          done <<< "$lease_ids"
-          while IFS= read -r reaction_id; do
-            [ -n "$reaction_id" ] || continue
-            gh api "repos/$TARGET_REPO/issues/$ITEM_NUMBER/reactions/$reaction_id" --method DELETE
-            echo "Removed terminal eyes reaction $reaction_id from $TARGET_REPO#$ITEM_NUMBER."
-          done <<< "$reaction_ids"
-
-      - name: Confirm terminal item remains closed
-        id: confirm-terminal-item
-        if: ${{ always() && steps.release-terminal-review-leases.outcome == 'success' }}
-        env:
-          GH_TOKEN: ${{ steps.target-read-token.outputs.token }}
-          TARGET_REPO: ${{ steps.target.outputs.target_repo }}
-          ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
-        run: |
-          set -euo pipefail
-          test -n "$GH_TOKEN"
-          live_state="$(gh api "repos/$TARGET_REPO/issues/$ITEM_NUMBER" --jq .state)"
-          if [ "$live_state" != "closed" ]; then
-            echo "$TARGET_REPO#$ITEM_NUMBER is $live_state after terminal cleanup; requeueing exact review." >&2
-            exit 1
-          fi
-          echo "confirmed=true" >> "$GITHUB_OUTPUT"
-
-      - name: Mark re-review complete
-        if: ${{ always() && steps.setup-pnpm.outcome == 'success' && steps.publish-event-result.outputs.requeue_latest != 'true' && (steps.live-item.outputs.proceed == 'true' || steps.live-item.outputs.terminal_missing == 'true' || steps.live-item.outputs.guarded_open == 'true' || steps.confirm-terminal-item.outputs.confirmed == 'true') }}
+      - name: Mark unsuccessful re-review
+        if: ${{ always() && steps.target.outputs.has_command_context == 'true' && steps.setup-pnpm.outcome == 'success' && steps.queue-exact-review-publication.outcome != 'success' && steps.target-write-token.outputs.token != '' }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
@@ -991,65 +954,14 @@ jobs:
           STATUS_COMMENT_ID: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).statusCommentId || '' }}
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           REVIEW_OUTCOME: ${{ steps.review-exact-event-item.outcome }}
-          PUBLISH_OUTCOME: ${{ steps.publish-event-result.outcome }}
-          ROUTE_OUTCOME: ${{ steps.route-synced-verdict.outcome }}
-          ROUTE_HANDOFF_OUTCOME: ${{ steps.queue-deferred-verdict-router.outcome }}
-          INTAKE_GUARDED_OPEN: ${{ steps.live-item.outputs.guarded_open }}
-          INTAKE_TERMINAL_MISSING: ${{ steps.live-item.outputs.terminal_missing }}
-          TERMINAL_MISSING: ${{ steps.publish-event-result.outputs.terminal_missing }}
-          TERMINAL_CLOSED: ${{ steps.publish-event-result.outputs.terminal_closed }}
-          GUARDED_OPEN: ${{ steps.publish-event-result.outputs.guarded_open }}
-          REMOTE_TUPLE_VERIFIED: ${{ steps.publish-event-result.outputs.remote_tuple_verified }}
-          ROUTING_DEFERRED: ${{ steps.publish-event-result.outputs.routing_deferred }}
-          POLICY_NOOP: ${{ steps.publish-event-result.outputs.policy_noop }}
-          REQUEUE_LATEST: ${{ steps.publish-event-result.outputs.requeue_latest }}
-          REVIEW_ONLY: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).sourceAction == 'failed_review_shard_recovery' && 'true' || 'false' }}
+          RETRY_AT: ${{ steps.review-exact-event-item.outputs.retry_at }}
+          CLAWSWEEPER_ACTION_LEDGER_DISABLED: "1"
         run: |
           state="Failed"
-          detail="The targeted re-review did not finish cleanly. Check the workflow run for details."
-          if [ "$REVIEW_OUTCOME" = "cancelled" ]; then
+          detail="The exact review did not produce a publishable artifact. The durable queue will retry it."
+          if [ "$REVIEW_OUTCOME" = "cancelled" ] || [ -n "$RETRY_AT" ]; then
             state="Interrupted"
-            detail="The targeted re-review was interrupted. The exact-review queue will reconcile a newer pending item if one arrived."
-          fi
-          if [ "$POLICY_NOOP" = "true" ]; then
-            state="Complete"
-            detail="The exact review reached a deterministic same-author pair policy veto; no action was taken and the queue item is terminal."
-          fi
-          if [ "$REQUEUE_LATEST" = "true" ]; then
-            state="Interrupted"
-            detail="The item changed after review. This run is returning it to the exact-review queue; the workflow will fail if that handoff is not acknowledged."
-          fi
-          if [ "${{ steps.confirm-terminal-item.outputs.confirmed }}" = "true" ]; then
-            state="Complete"
-            detail="The item is closed, terminal review leases were released, and no stale verdict was published or routed."
-          fi
-          if [ "$REVIEW_OUTCOME" = "success" ] && [ "$PUBLISH_OUTCOME" = "success" ] && [ "$ROUTE_OUTCOME" = "success" ]; then
-            state="Complete"
-            detail="The targeted re-review finished, the durable review comment was updated, and the synced verdict was routed."
-          fi
-          if [ "$REVIEW_OUTCOME" = "success" ] && [ "$PUBLISH_OUTCOME" = "success" ] && [ "$REMOTE_TUPLE_VERIFIED" = "true" ] && [ "$ROUTING_DEFERRED" = "true" ] && [ "$ROUTE_HANDOFF_OUTCOME" = "success" ]; then
-            state="Complete"
-            detail="The targeted re-review published an exact durable review comment and queued an executing target-wide serialized router scan."
-          fi
-          if [ "$REVIEW_OUTCOME" = "success" ] && [ "$PUBLISH_OUTCOME" = "success" ] && [ "$REMOTE_TUPLE_VERIFIED" = "true" ] && [ "$REVIEW_ONLY" = "true" ]; then
-            state="Complete"
-            detail="The failed-shard recovery published a durable review comment without routing any close verdict."
-          fi
-          if [ "$REVIEW_OUTCOME" = "success" ] && [ "$PUBLISH_OUTCOME" = "success" ] && [ "$TERMINAL_CLOSED" = "true" ] && [ "${{ steps.confirm-terminal-item.outputs.confirmed }}" = "true" ]; then
-            state="Complete"
-            detail="The targeted re-review applied a verified terminal close, published the authoritative record tuple, and suppressed stale verdict routing."
-          fi
-          if [ "$INTAKE_TERMINAL_MISSING" = "true" ] || [ "$TERMINAL_MISSING" = "true" ]; then
-            state="Complete"
-            detail="The targeted re-review confirmed that the repository is accessible but the item is missing; no stale verdict was published or routed."
-          fi
-          if [ "$REVIEW_OUTCOME" = "success" ] && [ "$PUBLISH_OUTCOME" = "success" ] && [ "$GUARDED_OPEN" = "true" ]; then
-            state="Complete"
-            detail="The targeted re-review finished with a deterministic remain-open guard; durable state was published without routing an older close verdict."
-          fi
-          if [ "$INTAKE_GUARDED_OPEN" = "true" ]; then
-            state="Complete"
-            detail="The targeted re-review finished before Codex because the open conversation is locked; no stale verdict was published or routed."
+            detail="The exact review was interrupted. The durable queue will retry it."
           fi
           pnpm run repair:update-command-status -- \
             --repo "$TARGET_REPO" \
@@ -1060,122 +972,21 @@ jobs:
             --detail "$detail" \
             --run-url "$RUN_URL"
 
-      - name: Commit event comment router ledger
-        if: ${{ !cancelled() && steps.setup-pnpm.outcome == 'success' && steps.review-exact-event-item.outcome == 'success' && steps.publish-event-result.outcome == 'success' && steps.route-synced-verdict.outcome == 'success' }}
-        run: |
-          pnpm run repair:publish-main -- \
-            --message "chore: record ClawSweeper event comment routing" \
-            --path results/comment-router.json \
-            --path results/comment-router-latest.json \
-            --path jobs \
-            --rebase-strategy theirs
-
-      - name: React to target item completion
-        if: ${{ steps.live-item.outputs.guarded_open == 'true' || (steps.review-exact-event-item.outcome == 'success' && steps.publish-event-result.outcome == 'success' && (steps.publish-event-result.outputs.terminal_closed == 'true' || steps.publish-event-result.outputs.guarded_open == 'true' || steps.publish-event-result.outputs.policy_noop == 'true' || steps.queue-deferred-verdict-router.outcome == 'success' || steps.route-synced-verdict.outcome == 'success' || (fromJSON(steps.claim-exact-review-queue.outputs.decision).sourceAction == 'failed_review_shard_recovery' && steps.publish-event-result.outputs.remote_tuple_verified == 'true'))) }}
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
-          TARGET_REPO: ${{ steps.target.outputs.target_repo }}
-          ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
-          POLICY_NOOP: ${{ steps.publish-event-result.outputs.policy_noop }}
-          REVIEW_ONLY: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).sourceAction == 'failed_review_shard_recovery' && 'true' || 'false' }}
-        run: |
-          set -euo pipefail
-          test -n "$GH_TOKEN"
-          add_completion_reaction() {
-            local err
-            err="$(mktemp)"
-            if gh api -X POST \
-              -H "Accept: application/vnd.github+json" \
-              "repos/$TARGET_REPO/issues/$ITEM_NUMBER/reactions" \
-              -f content="+1" 2>"$err" >/dev/null; then
-              echo "Added +1 reaction to $TARGET_REPO#$ITEM_NUMBER."
-            elif grep -qi "HTTP 422\\|already exists" "$err"; then
-              echo "+1 reaction already exists on $TARGET_REPO#$ITEM_NUMBER."
-            else
-              cat "$err" >&2
-              rm -f "$err"
-              exit 1
-            fi
-            rm -f "$err"
-          }
-          remove_own_eyes_reactions() {
-            local ids
-            local err
-            err="$(mktemp)"
-            if ! ids="$(gh api -X GET \
-              -H "Accept: application/vnd.github+json" \
-              "repos/$TARGET_REPO/issues/$ITEM_NUMBER/reactions" \
-              -f content="eyes" \
-              -F per_page=100 \
-              --paginate \
-              --jq '.[] | select(.content == "eyes") | select(.user.login == "clawsweeper" or .user.login == "clawsweeper[bot]" or .user.login == "openclaw-clawsweeper[bot]") | .id' 2>"$err")"; then
-              cat "$err" >&2
-              rm -f "$err"
-              return 0
-            fi
-            rm -f "$err"
-            while IFS= read -r reaction_id; do
-              [ -n "$reaction_id" ] || continue
-              err="$(mktemp)"
-              if gh api -X DELETE \
-                -H "Accept: application/vnd.github+json" \
-                "repos/$TARGET_REPO/issues/$ITEM_NUMBER/reactions/$reaction_id" 2>"$err" >/dev/null; then
-                echo "Removed eyes reaction $reaction_id from $TARGET_REPO#$ITEM_NUMBER."
-              else
-                cat "$err" >&2
-              fi
-              rm -f "$err"
-            done <<< "$ids"
-          }
-          if [ "$POLICY_NOOP" != "true" ] && [ "$REVIEW_ONLY" != "true" ]; then
-            add_completion_reaction
-          fi
-          remove_own_eyes_reactions
-
-      - name: Export exact review primary result
-        id: exact-review-primary-result
+      - name: Export exact review generation result
+        id: exact-review-generation-result
         if: ${{ always() }}
         env:
-          PRIMARY_JOB_STATUS: ${{ job.status }}
           TARGET_ENABLED: ${{ steps.target.outputs.target_enabled }}
-          LIVE_PROCEED: ${{ steps.live-item.outputs.proceed }}
-          LIVE_TERMINAL_NOOP: ${{ steps.live-item.outputs.terminal_noop }}
-          LIVE_TERMINAL_MISSING: ${{ steps.live-item.outputs.terminal_missing }}
-          LIVE_GUARDED_OPEN: ${{ steps.live-item.outputs.guarded_open }}
+          LIVE_OUTCOME: ${{ steps.live-item.outcome }}
           REVIEW_OUTCOME: ${{ steps.review-exact-event-item.outcome }}
-          PUBLISH_OUTCOME: ${{ steps.publish-event-result.outcome }}
-          TERMINAL_NOOP: ${{ steps.publish-event-result.outputs.terminal_noop }}
-          TERMINAL_MISSING: ${{ steps.publish-event-result.outputs.terminal_missing }}
-          TERMINAL_CLOSED: ${{ steps.publish-event-result.outputs.terminal_closed }}
-          GUARDED_OPEN: ${{ steps.publish-event-result.outputs.guarded_open }}
-          POLICY_NOOP: ${{ steps.publish-event-result.outputs.policy_noop }}
-          REQUEUE_LATEST: ${{ steps.publish-event-result.outputs.requeue_latest }}
-          DIRECT_ROUTE_OUTCOME: ${{ steps.route-synced-verdict.outcome }}
-          DEFERRED_ROUTE_OUTCOME: ${{ steps.queue-deferred-verdict-router.outcome }}
-          REVIEW_ONLY: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).sourceAction == 'failed_review_shard_recovery' && 'true' || 'false' }}
+          PUBLICATION_QUEUE_OUTCOME: ${{ steps.queue-exact-review-publication.outcome }}
         run: |
           outcome=failure
-          if [ "$PRIMARY_JOB_STATUS" = "cancelled" ] || [ "$REVIEW_OUTCOME" = "cancelled" ]; then
-            outcome=cancelled
-          elif [ "$PRIMARY_JOB_STATUS" != "success" ]; then
-            outcome=failure
-          elif [ "$TARGET_ENABLED" = "false" ] ||
-            [ "$LIVE_PROCEED" = "false" ] ||
-            [ "$LIVE_TERMINAL_NOOP" = "true" ] ||
-            [ "$LIVE_TERMINAL_MISSING" = "true" ] ||
-            [ "$LIVE_GUARDED_OPEN" = "true" ] ||
-            [ "$TERMINAL_NOOP" = "true" ] ||
-            [ "$POLICY_NOOP" = "true" ] ||
-            [ "$REQUEUE_LATEST" = "true" ]; then
+          if [ "$TARGET_ENABLED" = "false" ]; then
             outcome=success
-          elif [ "$REVIEW_OUTCOME" = "success" ] && [ "$PUBLISH_OUTCOME" = "success" ] &&
-            { [ "$TERMINAL_MISSING" = "true" ] ||
-              [ "$TERMINAL_CLOSED" = "true" ] ||
-              [ "$GUARDED_OPEN" = "true" ] ||
-              [ "$REVIEW_ONLY" = "true" ] ||
-              [ "$DIRECT_ROUTE_OUTCOME" = "success" ] ||
-              [ "$DEFERRED_ROUTE_OUTCOME" = "success" ]; }; then
+          elif [ "$REVIEW_OUTCOME" = "cancelled" ]; then
+            outcome=cancelled
+          elif [ "$LIVE_OUTCOME" = "success" ] && [ "$PUBLICATION_QUEUE_OUTCOME" = "success" ]; then
             outcome=success
           fi
           echo "outcome=$outcome" >> "$GITHUB_OUTPUT"
@@ -1185,7 +996,7 @@ jobs:
         if: ${{ always() }}
         continue-on-error: true
         env:
-          PRIMARY_OUTCOME: ${{ steps.exact-review-primary-result.outputs.outcome || 'failure' }}
+          PRIMARY_OUTCOME: ${{ steps.exact-review-generation-result.outputs.outcome || 'failure' }}
           CLAIM_GENERATION: ${{ steps.claim-exact-review-queue.outputs.claim_generation }}
           ITEM_KEY: ${{ steps.claim-exact-review-queue.outputs.item_key }}
           PROTOCOL_VERSION: ${{ steps.claim-exact-review-queue.outputs.protocol_version }}
@@ -1193,7 +1004,6 @@ jobs:
           QUEUE_LEASE_REVISION: ${{ steps.claim-exact-review-queue.outputs.lease_revision }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           RETRY_AT: ${{ steps.review-exact-event-item.outputs.retry_at }}
-          REQUEUE_LATEST: ${{ steps.publish-event-result.outputs.requeue_latest }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
@@ -1219,7 +1029,6 @@ jobs:
               ? primaryOutcome
               : "failure";
             const retryAt = String(process.env.RETRY_AT || "").trim();
-            const requeueLatest = process.env.REQUEUE_LATEST === "true";
             process.stdout.write(JSON.stringify({
               lease_id: process.env.QUEUE_LEASE_ID,
               ...(protocolVersion === 2
@@ -1233,7 +1042,6 @@ jobs:
               run_attempt: runAttempt,
               outcome,
               ...(retryAt ? { retry_at: retryAt } : {}),
-              ...(requeueLatest ? { requeue_latest: true } : {}),
             }));
           ')"
           for attempt in 1 2 3; do
@@ -1250,115 +1058,677 @@ jobs:
           done
           exit 1
 
-      - name: Fail unsuccessful exact review
-        if: ${{ always() && steps.target.outputs.target_enabled != 'false' && steps.live-item.outputs.proceed != 'false' && steps.publish-event-result.outputs.terminal_noop != 'true' && steps.publish-event-result.outputs.policy_noop != 'true' && steps.publish-event-result.outputs.requeue_latest != 'true' && (steps.review-exact-event-item.outcome != 'success' || steps.publish-event-result.outcome != 'success' || (steps.publish-event-result.outputs.terminal_missing != 'true' && steps.publish-event-result.outputs.terminal_closed != 'true' && steps.publish-event-result.outputs.guarded_open != 'true' && fromJSON(steps.claim-exact-review-queue.outputs.decision).sourceAction != 'failed_review_shard_recovery' && steps.route-synced-verdict.outcome != 'success' && steps.queue-deferred-verdict-router.outcome != 'success')) }}
+      - name: Fail unsuccessful exact review generation
+        if: ${{ always() && (steps.exact-review-generation-result.outputs.outcome != 'success' || steps.complete-exact-review-queue.outcome != 'success') }}
         run: exit 1
 
-      - name: Publish exact event action ledger
-        if: ${{ always() && steps.setup-state.outcome == 'success' }}
+  event-review-publish:
+    name: Publish exact review artifact
+    if: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.queue_lease_id != '' && github.event.client_payload.source_action == 'exact_review_artifact_publish' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    concurrency:
+      group: clawsweeper-state-publisher
+      cancel-in-progress: false
+      queue: max
+    permissions:
+      actions: write
+      contents: write
+      issues: write
+      pull-requests: write
+      statuses: read
+    steps:
+      - name: Claim durable exact review publication
+        id: publication-context
+        env:
+          ITEM_KEY: ${{ github.event.client_payload.queue_claim.item_key }}
+          QUEUE_LEASE_ID: ${{ github.event.client_payload.queue_lease_id }}
+          QUEUE_LEASE_REVISION: ${{ github.event.client_payload.queue_claim.lease_revision }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
-          test -n "${CLAWSWEEPER_STATE_DIR:-}"
-          if [ ! -d "$CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT/ledger" ]; then
-            echo "No exact event action shards were finalized."
+          queue_url="${QUEUE_URL%/}"
+          payload="$(node -e '
+            const leaseRevision = Number(process.env.QUEUE_LEASE_REVISION);
+            const runAttempt = Number(process.env.RUN_ATTEMPT);
+            if (!process.env.QUEUE_LEASE_ID || !process.env.ITEM_KEY) process.exit(1);
+            if (!Number.isInteger(leaseRevision) || leaseRevision < 1) process.exit(1);
+            if (!Number.isInteger(runAttempt) || runAttempt < 1) process.exit(1);
+            process.stdout.write(JSON.stringify({
+              lease_id: process.env.QUEUE_LEASE_ID,
+              item_key: process.env.ITEM_KEY,
+              lease_revision: leaseRevision,
+              run_id: process.env.GITHUB_RUN_ID,
+              run_attempt: runAttempt,
+            }));
+          ')"
+          for attempt in 1 2 3; do
+            if response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+              --request POST \
+              --header "content-type: application/json" \
+              --data "$payload" \
+              "$queue_url/internal/exact-review/claim")" &&
+              RESPONSE="$response" node <<'NODE'
+                const fs = require("node:fs");
+                const response = JSON.parse(process.env.RESPONSE || "{}");
+                const decision = response.decision;
+                const publication = decision?.publication;
+                const producerDecision = publication?.producerDecision;
+                const expectedItemKey = `${decision?.targetRepo}#${decision?.itemNumber}@publish:${publication?.producerRunId}:${publication?.producerRunAttempt}`;
+                if (
+                  response.claimed !== true ||
+                  response.protocol_version !== 2 ||
+                  response.item_key !== process.env.ITEM_KEY ||
+                  response.item_key !== expectedItemKey ||
+                  decision?.sourceAction !== "exact_review_artifact_publish" ||
+                  !publication ||
+                  !producerDecision ||
+                  producerDecision.targetRepo !== decision.targetRepo ||
+                  producerDecision.targetBranch !== decision.targetBranch ||
+                  producerDecision.itemNumber !== decision.itemNumber ||
+                  producerDecision.itemKind !== decision.itemKind
+                ) process.exit(1);
+                const leaseRevision = Number(response.lease_revision);
+                const claimGeneration = Number(response.claim_generation);
+                if (!Number.isInteger(leaseRevision) || leaseRevision < 1) process.exit(1);
+                if (!Number.isInteger(claimGeneration) || claimGeneration < 1) process.exit(1);
+                const targetRepo = String(decision.targetRepo);
+                const [targetRepoOwner, targetRepoName] = targetRepo.split("/");
+                const values = {
+                  artifact_name: publication.artifactName,
+                  generation_attempt: publication.producerRunAttempt,
+                  producer_run_id: publication.producerRunId,
+                  source_sha: publication.sourceSha,
+                  decision: JSON.stringify(producerDecision),
+                  item_key: publication.itemKey,
+                  protocol_version: publication.protocolVersion,
+                  lease_revision: publication.leaseRevision ?? "",
+                  claim_generation: publication.claimGeneration ?? "",
+                  target_repo: targetRepo,
+                  target_repo_owner: targetRepoOwner,
+                  target_repo_name: targetRepoName,
+                  target_branch: decision.targetBranch,
+                  item_number: decision.itemNumber,
+                  item_kind: decision.itemKind,
+                  has_command_context: Boolean(
+                    producerDecision.commandStatusMarker && producerDecision.statusCommentId,
+                  ),
+                  live_proceeded: publication.liveProceeded,
+                  live_terminal_noop: publication.liveTerminalNoop,
+                  live_terminal_missing: publication.liveTerminalMissing,
+                  live_guarded_open: publication.liveGuardedOpen,
+                  publisher_lease_id: process.env.QUEUE_LEASE_ID,
+                  publisher_item_key: response.item_key,
+                  publisher_lease_revision: leaseRevision,
+                  publisher_claim_generation: claimGeneration,
+                };
+                for (const [key, value] of Object.entries(values)) {
+                  fs.appendFileSync(process.env.GITHUB_OUTPUT, `${key}=${value}\n`);
+                }
+          NODE
+            then
+              exit 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              sleep "$((attempt * 5))"
+            fi
+          done
+          exit 1
+
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ steps.publication-context.outputs.source_sha }}
+          filter: blob:none
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-action-ledger
+        continue-on-error: true
+
+      - uses: ./.github/actions/setup-pnpm
+        id: setup-publish-pnpm
+        with:
+          build-script: build:all
+
+      - name: Download exact review artifact bundle
+        id: download-exact-review-bundle
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ steps.publication-context.outputs.artifact_name }}
+          run-id: ${{ steps.publication-context.outputs.producer_run_id }}
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          path: .artifacts/exact-review-bundle
+
+      - name: Validate exact review artifact bundle
+        env:
+          EXACT_REVIEW_BUNDLE_DIR: .artifacts/exact-review-bundle
+          EXACT_REVIEW_CLAIM_GENERATION: ${{ steps.publication-context.outputs.claim_generation }}
+          EXACT_REVIEW_DECISION: ${{ steps.publication-context.outputs.decision }}
+          EXACT_REVIEW_GENERATION_ATTEMPT: ${{ steps.publication-context.outputs.generation_attempt }}
+          EXACT_REVIEW_ITEM_KEY: ${{ steps.publication-context.outputs.item_key }}
+          EXACT_REVIEW_ITEM_KIND: ${{ steps.publication-context.outputs.item_kind }}
+          EXACT_REVIEW_ITEM_NUMBER: ${{ steps.publication-context.outputs.item_number }}
+          EXACT_REVIEW_LEASE_REVISION: ${{ steps.publication-context.outputs.lease_revision }}
+          EXACT_REVIEW_LIVE_GUARDED_OPEN: ${{ steps.publication-context.outputs.live_guarded_open }}
+          EXACT_REVIEW_LIVE_PROCEEDED: ${{ steps.publication-context.outputs.live_proceeded }}
+          EXACT_REVIEW_LIVE_TERMINAL_MISSING: ${{ steps.publication-context.outputs.live_terminal_missing }}
+          EXACT_REVIEW_LIVE_TERMINAL_NOOP: ${{ steps.publication-context.outputs.live_terminal_noop }}
+          EXACT_REVIEW_PRODUCER_JOB: event-review-apply
+          EXACT_REVIEW_PRODUCER_RUN_ID: ${{ steps.publication-context.outputs.producer_run_id }}
+          EXACT_REVIEW_PROTOCOL_VERSION: ${{ steps.publication-context.outputs.protocol_version }}
+          EXACT_REVIEW_SOURCE_SHA: ${{ steps.publication-context.outputs.source_sha }}
+          EXACT_REVIEW_TARGET_BRANCH: ${{ steps.publication-context.outputs.target_branch }}
+          EXACT_REVIEW_TARGET_REPO: ${{ steps.publication-context.outputs.target_repo }}
+        run: pnpm run --silent repair:exact-review-bundle -- validate
+
+      - name: Stage validated exact review artifact
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/event
+          report=".artifacts/exact-review-bundle/review/${{ steps.publication-context.outputs.item_number }}.md"
+          if [ -f "$report" ]; then
+            cp "$report" "artifacts/event/${{ steps.publication-context.outputs.item_number }}.md"
+          fi
+
+      - name: Create target write token
+        id: target-write-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+          owner: ${{ steps.publication-context.outputs.target_repo_owner }}
+          repositories: ${{ steps.publication-context.outputs.target_repo_name }}
+          permission-checks: read
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+          permission-statuses: read
+
+      - name: Create state token
+        id: state-token
+        uses: ./.github/actions/create-state-token
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+
+      - uses: ./.github/actions/setup-state
+        id: setup-state
+        with:
+          token: ${{ steps.state-token.outputs.token }}
+          fetch-depth: 1
+
+      - name: Publish event result and apply safe close
+        id: publish-event-result
+        env:
+          GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          REPO_TOKEN: ${{ github.token }}
+          TARGET_REPO: ${{ steps.publication-context.outputs.target_repo }}
+          ITEM_NUMBER: ${{ steps.publication-context.outputs.item_number }}
+          CLOSE_REASONS: implemented_on_main,duplicate_or_superseded,low_signal_unmergeable_pr
+          MIN_AGE_MINUTES: "0"
+          REVIEW_ONLY: ${{ fromJSON(steps.publication-context.outputs.decision).sourceAction == 'failed_review_shard_recovery' && 'true' || 'false' }}
+          LIVE_PROCEEDED: ${{ steps.publication-context.outputs.live_proceeded }}
+          LIVE_TERMINAL_NOOP: ${{ steps.publication-context.outputs.live_terminal_noop }}
+          LIVE_TERMINAL_MISSING: ${{ steps.publication-context.outputs.live_terminal_missing }}
+          LIVE_GUARDED_OPEN: ${{ steps.publication-context.outputs.live_guarded_open }}
+        run: |
+          set -euo pipefail
+          if [ "$LIVE_PROCEEDED" != "true" ]; then
+            terminal_noop="$LIVE_TERMINAL_NOOP"
+            terminal_missing="$LIVE_TERMINAL_MISSING"
+            guarded_open="$LIVE_GUARDED_OPEN"
+            requeue_latest=false
+            if [ "$LIVE_TERMINAL_NOOP" = "true" ] || [ "$LIVE_TERMINAL_MISSING" = "true" ] || [ "$LIVE_GUARDED_OPEN" = "true" ]; then
+              live_item_error="$(mktemp)"
+              live_locked=false
+              if ! live_item="$(gh api "repos/$TARGET_REPO/issues/$ITEM_NUMBER" 2>"$live_item_error")"; then
+                if grep -Eqi 'HTTP 404|Not Found' "$live_item_error" && gh api "repos/$TARGET_REPO" >/dev/null; then
+                  live_state=missing
+                else
+                  cat "$live_item_error" >&2
+                  rm -f "$live_item_error"
+                  exit 1
+                fi
+              else
+                live_state="$(jq -r '.state' <<< "$live_item")"
+                live_locked="$(jq -r '.locked == true' <<< "$live_item")"
+              fi
+              rm -f "$live_item_error"
+              case "$live_state" in
+                open)
+                  terminal_noop=false
+                  terminal_missing=false
+                  if [ "$live_locked" = "true" ]; then
+                    guarded_open=true
+                  else
+                    guarded_open=false
+                    requeue_latest=true
+                  fi
+                  ;;
+                closed)
+                  terminal_noop=true
+                  terminal_missing=false
+                  guarded_open=false
+                  ;;
+                missing)
+                  terminal_noop=false
+                  terminal_missing=true
+                  guarded_open=false
+                  ;;
+                *)
+                  echo "Unexpected live state for $TARGET_REPO#$ITEM_NUMBER: $live_state" >&2
+                  exit 1
+                  ;;
+              esac
+            fi
+            {
+              echo "terminal_noop=$terminal_noop"
+              echo "terminal_missing=$terminal_missing"
+              echo "terminal_closed=false"
+              echo "guarded_open=$guarded_open"
+              echo "policy_noop=false"
+              echo "requeue_latest=$requeue_latest"
+              echo "remote_tuple_verified=false"
+              echo "routing_deferred=false"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          event_paths_file=".artifacts/exact-event-action-ledger-paths.txt"
-          mkdir -p .artifacts
-          pnpm run --silent publish-action-events -- \
-            --source-root "$CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT" \
-            --state-root "$CLAWSWEEPER_STATE_DIR" \
-            --expected-producer-job "$GITHUB_JOB" |
-            jq -r '.paths[]?' |
-            sort -u > "$event_paths_file"
-          if [ ! -s "$event_paths_file" ]; then
-            echo "Exact event action shards existed but no paths were imported." >&2
+          live_item_error="$(mktemp)"
+          if ! live_state="$(gh api "repos/$TARGET_REPO/issues/$ITEM_NUMBER" --jq .state 2>"$live_item_error")"; then
+            if grep -Eqi 'HTTP 404|Not Found' "$live_item_error" && gh api "repos/$TARGET_REPO" >/dev/null; then
+              rm -f "$live_item_error"
+              {
+                echo "terminal_noop=false"
+                echo "terminal_missing=true"
+                echo "terminal_closed=false"
+                echo "guarded_open=false"
+                echo "policy_noop=false"
+                echo "requeue_latest=false"
+                echo "remote_tuple_verified=false"
+                echo "routing_deferred=false"
+              } >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            cat "$live_item_error" >&2
+            rm -f "$live_item_error"
             exit 1
           fi
-          while IFS= read -r event_path; do
-            durable_event_path="$CLAWSWEEPER_STATE_DIR/$event_path"
-            test -f "$durable_event_path"
-            mkdir -p "$(dirname "$event_path")"
-            cp "$durable_event_path" "$event_path"
-          done < "$event_paths_file"
-          node dist/clawsweeper.js publish-action-event-paths \
-            --paths-file "$event_paths_file" \
-            --message "chore: append exact event action ledger"
+          rm -f "$live_item_error"
+          if [ "$live_state" = "closed" ]; then
+            {
+              echo "terminal_noop=true"
+              echo "terminal_missing=false"
+              echo "terminal_closed=false"
+              echo "guarded_open=false"
+              echo "policy_noop=false"
+              echo "requeue_latest=false"
+              echo "remote_tuple_verified=false"
+              echo "routing_deferred=false"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          test -f "artifacts/event/$ITEM_NUMBER.md"
+          echo "terminal_noop=false" >> "$GITHUB_OUTPUT"
+          pnpm run repair:publish-event-result
 
-      - name: Mark source-drift re-review queued
-        if: ${{ always() && steps.setup-pnpm.outcome == 'success' && steps.publish-event-result.outputs.requeue_latest == 'true' && steps.complete-exact-review-queue.outcome == 'success' }}
+      - name: Route synced ClawSweeper verdict
+        id: route-synced-verdict
+        if: ${{ fromJSON(steps.publication-context.outputs.decision).sourceAction != 'failed_review_shard_recovery' && steps.publish-event-result.outcome == 'success' && steps.publish-event-result.outputs.terminal_noop != 'true' && steps.publish-event-result.outputs.terminal_missing != 'true' && steps.publish-event-result.outputs.terminal_closed != 'true' && steps.publish-event-result.outputs.guarded_open != 'true' && steps.publish-event-result.outputs.policy_noop != 'true' && steps.publish-event-result.outputs.requeue_latest != 'true' && steps.publish-event-result.outputs.remote_tuple_verified == 'true' && steps.publish-event-result.outputs.routing_deferred == 'false' }}
+        timeout-minutes: 4
+        env:
+          GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          CLAWSWEEPER_DISPATCH_TOKEN: ${{ github.token }}
+          TARGET_REPO: ${{ steps.publication-context.outputs.target_repo }}
+          ITEM_NUMBER: ${{ steps.publication-context.outputs.item_number }}
+          CLAWSWEEPER_MUTATION_TOKEN_SOURCE: clawsweeper-app
+          CLAWSWEEPER_ALLOW_MERGE: ${{ vars.CLAWSWEEPER_ALLOW_MERGE || '0' }}
+          CLAWSWEEPER_UNSPONSORED_FEATURE_CLOSE_ENABLED: ${{ vars.CLAWSWEEPER_UNSPONSORED_FEATURE_CLOSE_ENABLED || 'false' }}
+          CLAWSWEEPER_COMMENT_LOOKBACK_MINUTES: ${{ vars.CLAWSWEEPER_COMMENT_LOOKBACK_MINUTES || '180' }}
+          CLAWSWEEPER_COMMENT_MAX_COMMENTS: ${{ vars.CLAWSWEEPER_COMMENT_MAX_COMMENTS || '1000' }}
+        run: |
+          pnpm run repair:comment-router -- \
+            --write-report \
+            --repo "$TARGET_REPO" \
+            --item-number "$ITEM_NUMBER" \
+            --lookback-minutes "$CLAWSWEEPER_COMMENT_LOOKBACK_MINUTES" \
+            --max-comments "$CLAWSWEEPER_COMMENT_MAX_COMMENTS" \
+            --execute
+
+      - name: Queue deferred exact verdict router
+        id: queue-deferred-verdict-router
+        if: ${{ fromJSON(steps.publication-context.outputs.decision).sourceAction != 'failed_review_shard_recovery' && steps.publish-event-result.outcome == 'success' && steps.publish-event-result.outputs.remote_tuple_verified == 'true' && steps.publish-event-result.outputs.routing_deferred == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_REPO: ${{ steps.publication-context.outputs.target_repo }}
+          TARGET_BRANCH: ${{ steps.publication-context.outputs.target_branch }}
+          CLAWSWEEPER_COMMENT_LOOKBACK_MINUTES: ${{ vars.CLAWSWEEPER_COMMENT_LOOKBACK_MINUTES || '180' }}
+          CLAWSWEEPER_COMMENT_MAX_COMMENTS: ${{ vars.CLAWSWEEPER_COMMENT_MAX_COMMENTS || '1000' }}
+        run: |
+          gh workflow run repair-comment-router.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref main \
+            -f execute=true \
+            -f target_repo="$TARGET_REPO" \
+            -f target_branch="$TARGET_BRANCH" \
+            -f lookback_minutes="$CLAWSWEEPER_COMMENT_LOOKBACK_MINUTES" \
+            -f max_comments="$CLAWSWEEPER_COMMENT_MAX_COMMENTS"
+
+      - name: Queue fresh review after source drift
+        id: queue-source-drift-review
+        if: ${{ steps.publish-event-result.outputs.requeue_latest == 'true' }}
+        env:
+          CLAIM_DECISION: ${{ steps.publication-context.outputs.decision }}
+          PRODUCER_RUN_ATTEMPT: ${{ steps.publication-context.outputs.generation_attempt }}
+          PRODUCER_RUN_ID: ${{ steps.publication-context.outputs.producer_run_id }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+        run: |
+          set -euo pipefail
+          test -n "$CLAWSWEEPER_WEBHOOK_SECRET"
+          queue_url="${QUEUE_URL%/}"
+          payload="$(node <<'NODE'
+          const decision = JSON.parse(process.env.CLAIM_DECISION || "{}");
+          process.stdout.write(JSON.stringify({
+            delivery_id: `publisher-source-drift:${process.env.PRODUCER_RUN_ID}:${process.env.PRODUCER_RUN_ATTEMPT}`,
+            decision: {
+              ...decision,
+              sourceAction:
+                decision.sourceAction === "failed_review_shard_recovery"
+                  ? decision.sourceAction
+                  : "source_drift_requeue",
+              supersedesInProgress: true,
+            },
+          }));
+          NODE
+          )"
+          signature="$(PAYLOAD="$payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
+          curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+            --request POST \
+            --header "content-type: application/json" \
+            --header "x-clawsweeper-exact-review-signature: $signature" \
+            --data "$payload" \
+            "$queue_url/internal/exact-review/enqueue" | jq -e '.ok == true and (.queued == true or .deduped == true)'
+
+      - name: Release terminal review leases
+        id: release-terminal-review-leases
+        if: ${{ always() && (steps.publish-event-result.outputs.terminal_noop == 'true' || steps.publish-event-result.outputs.terminal_closed == 'true') }}
+        env:
+          GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          TARGET_REPO: ${{ steps.publication-context.outputs.target_repo }}
+          ITEM_NUMBER: ${{ steps.publication-context.outputs.item_number }}
+        run: |
+          set -euo pipefail
+          test -n "$GH_TOKEN"
+          test "$(gh api "repos/$TARGET_REPO/issues/$ITEM_NUMBER" --jq .state)" = "closed"
+          lease_ids="$(gh api "repos/$TARGET_REPO/issues/$ITEM_NUMBER/comments?per_page=100" --paginate --jq ".[] | select(.user.login == \"clawsweeper[bot]\" or .user.login == \"openclaw-clawsweeper[bot]\") | select(.body | contains(\"<!-- clawsweeper-review-lease item=$ITEM_NUMBER -->\")) | .id")"
+          while IFS= read -r lease_id; do
+            [ -n "$lease_id" ] || continue
+            gh api "repos/$TARGET_REPO/issues/comments/$lease_id" --method DELETE
+          done <<< "$lease_ids"
+          reaction_ids="$(gh api -X GET \
+            -H "Accept: application/vnd.github+json" \
+            "repos/$TARGET_REPO/issues/$ITEM_NUMBER/reactions" \
+            -f content="eyes" \
+            -F per_page=100 \
+            --paginate \
+            --jq '.[] | select(.content == "eyes") | select(.user.login == "clawsweeper" or .user.login == "clawsweeper[bot]" or .user.login == "openclaw-clawsweeper[bot]") | .id')"
+          while IFS= read -r reaction_id; do
+            [ -n "$reaction_id" ] || continue
+            gh api "repos/$TARGET_REPO/issues/$ITEM_NUMBER/reactions/$reaction_id" --method DELETE
+          done <<< "$reaction_ids"
+
+      - name: Confirm terminal item remains closed
+        id: confirm-terminal-item
+        if: ${{ always() && steps.release-terminal-review-leases.outcome == 'success' }}
+        env:
+          GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          TARGET_REPO: ${{ steps.publication-context.outputs.target_repo }}
+          ITEM_NUMBER: ${{ steps.publication-context.outputs.item_number }}
+        run: |
+          test "$(gh api "repos/$TARGET_REPO/issues/$ITEM_NUMBER" --jq .state)" = "closed"
+          echo "confirmed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Mark re-review complete
+        if: ${{ always() && steps.publication-context.outputs.has_command_context == 'true' }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
-          TARGET_REPO: ${{ steps.target.outputs.target_repo }}
-          ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
-          COMMAND_STATUS_MARKER: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).commandStatusMarker || '' }}
-          STATUS_COMMENT_ID: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).statusCommentId || '' }}
+          TARGET_REPO: ${{ steps.publication-context.outputs.target_repo }}
+          ITEM_NUMBER: ${{ steps.publication-context.outputs.item_number }}
+          COMMAND_STATUS_MARKER: ${{ fromJSON(steps.publication-context.outputs.decision).commandStatusMarker || '' }}
+          STATUS_COMMENT_ID: ${{ fromJSON(steps.publication-context.outputs.decision).statusCommentId || '' }}
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PUBLISH_OUTCOME: ${{ steps.publish-event-result.outcome }}
+          ROUTE_OUTCOME: ${{ steps.route-synced-verdict.outcome }}
+          ROUTE_HANDOFF_OUTCOME: ${{ steps.queue-deferred-verdict-router.outcome }}
+          TERMINAL_MISSING: ${{ steps.publish-event-result.outputs.terminal_missing }}
+          TERMINAL_CLOSED: ${{ steps.publish-event-result.outputs.terminal_closed }}
+          GUARDED_OPEN: ${{ steps.publish-event-result.outputs.guarded_open }}
+          REMOTE_TUPLE_VERIFIED: ${{ steps.publish-event-result.outputs.remote_tuple_verified }}
+          ROUTING_DEFERRED: ${{ steps.publish-event-result.outputs.routing_deferred }}
+          POLICY_NOOP: ${{ steps.publish-event-result.outputs.policy_noop }}
+          REQUEUE_LATEST: ${{ steps.publish-event-result.outputs.requeue_latest }}
+          REVIEW_ONLY: ${{ fromJSON(steps.publication-context.outputs.decision).sourceAction == 'failed_review_shard_recovery' && 'true' || 'false' }}
         run: |
+          state="Failed"
+          detail="The review artifact was captured, but publication did not finish cleanly."
+          if [ "$POLICY_NOOP" = "true" ]; then
+            state="Complete"
+            detail="The exact review reached a deterministic policy veto; no action was taken."
+          elif [ "$REQUEUE_LATEST" = "true" ] && [ "${{ steps.queue-source-drift-review.outcome }}" = "success" ]; then
+            state="Complete"
+            detail="The item changed after review; one fresh exact review was queued."
+          elif [ "${{ steps.confirm-terminal-item.outputs.confirmed }}" = "true" ]; then
+            state="Complete"
+            detail="The item is closed; no stale verdict was published."
+          elif [ "$TERMINAL_MISSING" = "true" ]; then
+            state="Complete"
+            detail="The repository is accessible but the item is missing; no stale verdict was published."
+          elif [ "$GUARDED_OPEN" = "true" ]; then
+            state="Complete"
+            detail="A deterministic remain-open guard blocked publication of a stale close verdict."
+          elif [ "$PUBLISH_OUTCOME" = "success" ] && [ "$REMOTE_TUPLE_VERIFIED" = "true" ] && [ "$REVIEW_ONLY" = "true" ]; then
+            state="Complete"
+            detail="The failed-shard recovery published a durable review comment without close routing."
+          elif [ "$PUBLISH_OUTCOME" = "success" ] && { [ "$ROUTE_OUTCOME" = "success" ] || { [ "$ROUTING_DEFERRED" = "true" ] && [ "$ROUTE_HANDOFF_OUTCOME" = "success" ]; }; }; then
+            state="Complete"
+            detail="The durable review comment was published and its synced verdict was routed."
+          fi
           pnpm run repair:update-command-status -- \
             --repo "$TARGET_REPO" \
             --item-number "$ITEM_NUMBER" \
             --marker "$COMMAND_STATUS_MARKER" \
             --status-comment-id "$STATUS_COMMENT_ID" \
-            --state "Complete" \
-            --detail "The item changed after review; the queue acknowledged one fresh review of the latest state." \
+            --state "$state" \
+            --detail "$detail" \
             --run-url "$RUN_URL"
 
-      - name: Fail unacknowledged source-drift requeue
-        if: ${{ always() && steps.publish-event-result.outputs.requeue_latest == 'true' && steps.complete-exact-review-queue.outcome != 'success' }}
-        run: exit 1
+      - name: Commit event comment router ledger
+        if: ${{ steps.publish-event-result.outcome == 'success' && steps.route-synced-verdict.outcome == 'success' }}
+        run: |
+          pnpm run repair:publish-main -- \
+            --message "chore: record ClawSweeper event comment routing" \
+            --path results/comment-router.json \
+            --path results/comment-router-latest.json \
+            --path jobs \
+            --rebase-strategy theirs
 
-      - name: Finalize late command status action ledger
-        if: ${{ always() && steps.setup-state.outcome == 'success' && steps.setup-pnpm.outcome == 'success' && steps.publish-event-result.outputs.requeue_latest == 'true' && steps.complete-exact-review-queue.outcome == 'success' }}
+      - name: React to target item completion
+        if: ${{ steps.publish-event-result.outputs.requeue_latest != 'true' && (steps.publish-event-result.outputs.terminal_closed == 'true' || steps.publish-event-result.outputs.guarded_open == 'true' || steps.publish-event-result.outputs.policy_noop == 'true' || steps.queue-deferred-verdict-router.outcome == 'success' || steps.route-synced-verdict.outcome == 'success' || (fromJSON(steps.publication-context.outputs.decision).sourceAction == 'failed_review_shard_recovery' && steps.publish-event-result.outputs.remote_tuple_verified == 'true')) }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          TARGET_REPO: ${{ steps.publication-context.outputs.target_repo }}
+          ITEM_NUMBER: ${{ steps.publication-context.outputs.item_number }}
+          POLICY_NOOP: ${{ steps.publish-event-result.outputs.policy_noop }}
+          REVIEW_ONLY: ${{ fromJSON(steps.publication-context.outputs.decision).sourceAction == 'failed_review_shard_recovery' && 'true' || 'false' }}
         run: |
           set -euo pipefail
-          : "${CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT:?setup-action-ledger output root is required}"
-          mkdir -p .artifacts
-          pnpm run --silent repair:action-ledger -- finalize \
-            --lane late-command-status \
-            > .artifacts/late-command-status-action-ledger-manifest.json
+          if [ "$POLICY_NOOP" != "true" ] && [ "$REVIEW_ONLY" != "true" ]; then
+            gh api -X POST -H "Accept: application/vnd.github+json" \
+              "repos/$TARGET_REPO/issues/$ITEM_NUMBER/reactions" -f content="+1" >/dev/null || true
+          fi
+          reaction_ids="$(gh api -X GET -H "Accept: application/vnd.github+json" \
+            "repos/$TARGET_REPO/issues/$ITEM_NUMBER/reactions" \
+            -f content="eyes" -F per_page=100 --paginate \
+            --jq '.[] | select(.content == "eyes") | select(.user.login == "clawsweeper" or .user.login == "clawsweeper[bot]" or .user.login == "openclaw-clawsweeper[bot]") | .id')"
+          while IFS= read -r reaction_id; do
+            [ -n "$reaction_id" ] || continue
+            gh api "repos/$TARGET_REPO/issues/$ITEM_NUMBER/reactions/$reaction_id" --method DELETE || true
+          done <<< "$reaction_ids"
 
-      - name: Publish late command status action ledger
-        if: ${{ always() && steps.setup-state.outcome == 'success' && steps.setup-pnpm.outcome == 'success' && steps.publish-event-result.outputs.requeue_latest == 'true' && steps.complete-exact-review-queue.outcome == 'success' }}
+      - name: Publish exact review action ledger
+        if: ${{ always() && steps.setup-state.outcome == 'success' }}
+        continue-on-error: true
+        env:
+          GENERATION_ATTEMPT: ${{ steps.publication-context.outputs.generation_attempt }}
         run: |
           set -euo pipefail
           test -n "${CLAWSWEEPER_STATE_DIR:-}"
-          source_root="${CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT:?setup-action-ledger output root is required}"
-          manifest_file=".artifacts/late-command-status-action-ledger-manifest.json"
-          test -s "$manifest_file"
-          event_paths_file=".artifacts/late-command-status-action-ledger-paths.txt"
-          import_result_file=".artifacts/late-command-status-action-ledger-import.json"
-          pnpm run --silent repair:action-ledger -- publish \
-            --lane late-command-status \
-            --manifest "$manifest_file" \
-            --source-root "$source_root" \
-            --state-root "$CLAWSWEEPER_STATE_DIR" > "$import_result_file"
-          if ! jq -e --slurpfile manifest "$manifest_file" \
-            '.eventPaths == $manifest[0].event_paths' \
-            "$import_result_file" >/dev/null; then
-            echo "Imported late command status paths do not match the finalized manifest." >&2
-            exit 1
+          mkdir -p .artifacts
+          event_paths_file=".artifacts/exact-review-action-ledger-paths.txt"
+          : > "$event_paths_file"
+          source_root=".artifacts/exact-review-bundle/action-ledger"
+          if [ -d "$source_root/ledger" ]; then
+            pnpm run --silent publish-action-events -- \
+              --source-root "$source_root" \
+              --state-root "$CLAWSWEEPER_STATE_DIR" \
+              --expected-producer-job event-review-apply \
+              --expected-producer-run-id "${{ steps.publication-context.outputs.producer_run_id }}" \
+              --expected-producer-sha "${{ steps.publication-context.outputs.source_sha }}" \
+              --expected-producer-run-attempt "$GENERATION_ATTEMPT" | jq -r '.paths[]?' >> "$event_paths_file"
           fi
-          jq -r '.paths[]?' "$import_result_file" |
-            sort -u > "$event_paths_file"
+          publisher_ledger_root="${CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT:-}"
+          if [ -n "$publisher_ledger_root" ] && [ -d "$publisher_ledger_root/ledger" ]; then
+            pnpm run --silent publish-action-events -- \
+              --source-root "$publisher_ledger_root" \
+              --state-root "$CLAWSWEEPER_STATE_DIR" \
+              --expected-producer-job "$GITHUB_JOB" | jq -r '.paths[]?' >> "$event_paths_file"
+          fi
+          sort -u -o "$event_paths_file" "$event_paths_file"
           if [ ! -s "$event_paths_file" ]; then
-            echo "Late command status action shards existed but no paths were imported." >&2
-            exit 1
+            echo "No exact review action events to publish."
+            exit 0
           fi
-          action_ledger_args=()
           while IFS= read -r event_path; do
-            durable_event_path="$CLAWSWEEPER_STATE_DIR/$event_path"
-            test -f "$durable_event_path"
+            test -f "$CLAWSWEEPER_STATE_DIR/$event_path"
             mkdir -p "$(dirname "$event_path")"
-            cp "$durable_event_path" "$event_path"
-            action_ledger_args+=(--path "$event_path")
+            cp "$CLAWSWEEPER_STATE_DIR/$event_path" "$event_path"
           done < "$event_paths_file"
-          pnpm run repair:publish-main -- \
-            --message "chore: append command status action ledger" \
-            "${action_ledger_args[@]}" \
-            --rebase-strategy normal
+          node dist/clawsweeper.js publish-action-event-paths \
+            --paths-file "$event_paths_file" \
+            --message "chore: append exact review action ledger"
 
+      - name: Release unsuccessful publisher-owned review lease
+        if: ${{ always() && steps.publication-context.outputs.live_proceeded == 'true' && (steps.publish-event-result.outcome != 'success' || (steps.publish-event-result.outputs.requeue_latest == 'true' && steps.queue-source-drift-review.outcome != 'success')) }}
+        env:
+          GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          TARGET_REPO: ${{ steps.publication-context.outputs.target_repo }}
+          ITEM_NUMBER: ${{ steps.publication-context.outputs.item_number }}
+          LEASE_OWNER: github-run-${{ steps.publication-context.outputs.producer_run_id }}-${{ steps.publication-context.outputs.generation_attempt }}
+        run: |
+          lease_ids="$(gh api "repos/$TARGET_REPO/issues/$ITEM_NUMBER/comments?per_page=100" --paginate --jq ".[] | select(.user.login == \"clawsweeper[bot]\" or .user.login == \"openclaw-clawsweeper[bot]\") | select(.body | contains(\"<!-- clawsweeper-review-lease item=$ITEM_NUMBER -->\")) | select(.body | contains(\"owner=$LEASE_OWNER \")) | .id")"
+          while IFS= read -r lease_id; do
+            [ -n "$lease_id" ] || continue
+            gh api "repos/$TARGET_REPO/issues/comments/$lease_id" --method DELETE
+          done <<< "$lease_ids"
+          reaction_ids="$(gh api -X GET \
+            -H "Accept: application/vnd.github+json" \
+            "repos/$TARGET_REPO/issues/$ITEM_NUMBER/reactions" \
+            -f content="eyes" -F per_page=100 --paginate \
+            --jq '.[] | select(.content == "eyes") | select(.user.login == "clawsweeper" or .user.login == "clawsweeper[bot]" or .user.login == "openclaw-clawsweeper[bot]") | .id')"
+          while IFS= read -r reaction_id; do
+            [ -n "$reaction_id" ] || continue
+            gh api "repos/$TARGET_REPO/issues/$ITEM_NUMBER/reactions/$reaction_id" --method DELETE
+          done <<< "$reaction_ids"
+
+      - name: Export exact review publication result
+        id: exact-review-publication-result
+        if: ${{ always() }}
+        env:
+          PRIOR_JOB_STATUS: ${{ job.status }}
+          PUBLISH_OUTCOME: ${{ steps.publish-event-result.outcome }}
+          TERMINAL_NOOP: ${{ steps.publish-event-result.outputs.terminal_noop }}
+          TERMINAL_MISSING: ${{ steps.publish-event-result.outputs.terminal_missing }}
+          TERMINAL_CLOSED: ${{ steps.publish-event-result.outputs.terminal_closed }}
+          GUARDED_OPEN: ${{ steps.publish-event-result.outputs.guarded_open }}
+          POLICY_NOOP: ${{ steps.publish-event-result.outputs.policy_noop }}
+          REQUEUE_LATEST: ${{ steps.publish-event-result.outputs.requeue_latest }}
+          SOURCE_DRIFT_OUTCOME: ${{ steps.queue-source-drift-review.outcome }}
+          DIRECT_ROUTE_OUTCOME: ${{ steps.route-synced-verdict.outcome }}
+          DEFERRED_ROUTE_OUTCOME: ${{ steps.queue-deferred-verdict-router.outcome }}
+          REVIEW_ONLY: ${{ fromJSON(steps.publication-context.outputs.decision).sourceAction == 'failed_review_shard_recovery' && 'true' || 'false' }}
+        run: |
+          outcome=failure
+          if [ "$PRIOR_JOB_STATUS" = "cancelled" ]; then
+            outcome=cancelled
+          elif [ "$PRIOR_JOB_STATUS" = "success" ]; then
+            if [ "$PUBLISH_OUTCOME" = "success" ] && [ "$REQUEUE_LATEST" = "true" ] && [ "$SOURCE_DRIFT_OUTCOME" = "success" ]; then
+              outcome=success
+            elif [ "$PUBLISH_OUTCOME" = "success" ] && { [ "$TERMINAL_NOOP" = "true" ] || [ "$TERMINAL_MISSING" = "true" ] || [ "$TERMINAL_CLOSED" = "true" ] || [ "$GUARDED_OPEN" = "true" ] || [ "$POLICY_NOOP" = "true" ] || [ "$REVIEW_ONLY" = "true" ]; }; then
+              outcome=success
+            elif [ "$PUBLISH_OUTCOME" = "success" ] && { [ "$DIRECT_ROUTE_OUTCOME" = "success" ] || [ "$DEFERRED_ROUTE_OUTCOME" = "success" ]; }; then
+              outcome=success
+            fi
+          fi
+          echo "outcome=$outcome" >> "$GITHUB_OUTPUT"
+
+      - name: Complete durable exact review publication
+        id: complete-exact-review-publication
+        if: ${{ always() }}
+        continue-on-error: true
+        env:
+          CLAIM_GENERATION: ${{ steps.publication-context.outputs.publisher_claim_generation }}
+          ITEM_KEY: ${{ steps.publication-context.outputs.publisher_item_key }}
+          LEASE_REVISION: ${{ steps.publication-context.outputs.publisher_lease_revision }}
+          OUTCOME: ${{ steps.exact-review-publication-result.outputs.outcome || 'failure' }}
+          QUEUE_LEASE_ID: ${{ steps.publication-context.outputs.publisher_lease_id }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+          queue_url="${QUEUE_URL%/}"
+          payload="$(node -e '
+            const leaseRevision = Number(process.env.LEASE_REVISION);
+            const claimGeneration = Number(process.env.CLAIM_GENERATION);
+            const runAttempt = Number(process.env.RUN_ATTEMPT);
+            if (!process.env.QUEUE_LEASE_ID || !process.env.ITEM_KEY) process.exit(1);
+            if (!Number.isInteger(leaseRevision) || leaseRevision < 1) process.exit(1);
+            if (!Number.isInteger(claimGeneration) || claimGeneration < 1) process.exit(1);
+            if (!Number.isInteger(runAttempt) || runAttempt < 1) process.exit(1);
+            const outcome = ["success", "failure", "cancelled"].includes(process.env.OUTCOME)
+              ? process.env.OUTCOME
+              : "failure";
+            process.stdout.write(JSON.stringify({
+              lease_id: process.env.QUEUE_LEASE_ID,
+              item_key: process.env.ITEM_KEY,
+              lease_revision: leaseRevision,
+              claim_generation: claimGeneration,
+              run_id: process.env.GITHUB_RUN_ID,
+              run_attempt: runAttempt,
+              outcome,
+            }));
+          ')"
+          for attempt in 1 2 3; do
+            if curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+              --request POST \
+              --header "content-type: application/json" \
+              --data "$payload" \
+              "$queue_url/internal/exact-review/complete" >/dev/null; then
+              exit 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              sleep "$((attempt * 5))"
+            fi
+          done
+          exit 1
+
+      - name: Fail unsuccessful exact review publication
+        if: ${{ always() && (steps.exact-review-publication-result.outputs.outcome != 'success' || steps.complete-exact-review-publication.outcome != 'success') }}
+        run: exit 1
   target-fanout:
     name: Fan out target repository sweeps
     if: ${{ github.event_name == 'schedule' && (github.event.schedule == '4/15 * * * *' || github.event.schedule == '41 * * * *' || github.event.schedule == '37 */6 * * *') }}
@@ -2201,7 +2571,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     concurrency:
-      group: clawsweeper-target-review-publish-${{ needs.plan.outputs.target_repo }}
+      group: clawsweeper-state-publisher
       cancel-in-progress: false
       queue: max
     steps:

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -764,6 +764,7 @@ jobs:
             --codex-timeout-ms "$codex_timeout_ms" \
             --item-numbers "${{ steps.target.outputs.item_number }}" \
             --readonly-openclaw \
+            --skip-start-comment \
             --shard-index 0 \
             --shard-count 1 \
             "${additional_prompt_arg[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Split exact-item review from Git-backed publication: read-only reviewers now upload hash-bound, 90-day artifacts and enqueue separate durable publication leases before one globally serialized publisher validates, comments, routes, and commits state without rerunning Codex after ordinary publisher failure; handoffs still blocked after 80 days safely fall back to one fresh exact review.
 - Reverted the action-lifecycle expansion from PR #521, restoring the pre-merge ClawSweeper paths while retaining later exact-review throughput fixes and retrying coalesced reconciliations after any partial lookup failure.
 - Raised exact-review capacity from 48/44 global/per-target workers to 64/60, shortened unclaimed dispatch recovery from ten to six minutes, and coalesced terminal-run reconciliation bursts into one bounded aggregate claim scan.
 - Expanded exact-review backlog capacity while making background review yield, released exact-review leases before ledger publication, and aggregated healthy retry scans into one bounded ledger summary.

--- a/README.md
+++ b/README.md
@@ -425,19 +425,31 @@ retries, and inconsistent records. Its cycle estimate covers work actionable in
 the current scheduler window rather than presenting every probe as immediately
 closable.
 
-Exact event runs skip the bulk planner, shard matrix, artifact upload, and
-separate publish job. They still use the same review and apply code paths, but
-only for the selected item number and only with immediate-safe reasons enabled
-by default: `implemented_on_main`, `duplicate_or_superseded`, and
-`low_signal_unmergeable_pr`.
-Deterministic terminal and remain-open outcomes complete in that exact run.
-Ordinary synced verdicts publish their exact durable comment immediately, then
-queue an executing target-wide comment-router scan. Target-wide serialization
-coalesces concurrent handoffs without losing older durable verdicts, while the
-review and publication work remains parallel. Direct exact-event viable-issue
+Exact event runs skip the bulk planner and shard matrix. The read-only reviewer
+handles only the selected item, uploads a hash-bound GitHub Actions artifact,
+enqueues a separate durable publication lease, and then releases its review
+lease without checking out or pushing the state repository. The queue retries
+publication independently, so a cancelled publisher does not rerun Codex. A
+globally serialized publisher validates that artifact's workflow run, queue
+tuple, target, decision digest, file inventory, sizes, and SHA-256 hashes before
+it receives write tokens. Publication leases reserve the global publisher
+lane's maximum queue wait; terminal-run reconciliation releases dead dispatches
+early. The publisher then uses the same review and apply paths with only the
+immediate-safe reasons enabled by default:
+`implemented_on_main`, `duplicate_or_superseded`, and
+`low_signal_unmergeable_pr`. Artifacts remain available for 90 days. A
+publication that still cannot finish after 80 days expires its artifact handoff
+and queues one fresh exact review, avoiding an unrecoverable missing-artifact
+loop while leaving a ten-day retention margin.
+
+Deterministic terminal and remain-open outcomes flow through the same publisher.
+Ordinary synced verdicts publish their exact durable comment, then queue an
+executing target-wide comment-router scan. Exact and batch review publishers
+share one state-publisher concurrency lane, so review generation stays parallel
+while Git-backed publication is serialized. Direct exact-event viable-issue
 implementation dispatch stays disabled; the bounded broad publish/backfill lane
-owns that separately revalidated intake. The exact run does not claim an atomic
-state-publish-and-route boundary.
+owns that separately revalidated intake. Publication still does not claim an
+atomic state-publish-and-route boundary.
 `stale_insufficient_info` issue reports and `mostly_implemented_on_main` PR
 reports are never applied to young items; apply requires those reports to be at
 least 60 days old unless a manual run explicitly changes the threshold. A stale

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -2822,9 +2822,15 @@ function deferPausedExactReviewQueue(state: ExactReviewQueueState, now: number, 
   }
 }
 
-function exactReviewQueueActiveCount(state: ExactReviewQueueState) {
+function exactReviewQueueIsPublication(item: ExactReviewQueueItem) {
+  return item.decision.sourceAction === EXACT_REVIEW_ARTIFACT_PUBLISH_SOURCE_ACTION;
+}
+
+function exactReviewQueueActiveReviewCount(state: ExactReviewQueueState) {
   return Object.values(state.items).filter(
-    (item) => item.state === "dispatching" || item.state === "leased",
+    (item) =>
+      !exactReviewQueueIsPublication(item) &&
+      (item.state === "dispatching" || item.state === "leased"),
   ).length;
 }
 
@@ -2834,30 +2840,37 @@ function exactReviewQueueAdmittedItems(
   capacity: number,
   targetCapacity: number,
 ) {
-  const slots = Math.max(0, capacity - exactReviewQueueActiveCount(state));
+  const reviewSlots = Math.max(0, capacity - exactReviewQueueActiveReviewCount(state));
   const activeTargets = new Map<string, number>();
   let activePublishers = 0;
   for (const item of Object.values(state.items)) {
     if (item.state !== "dispatching" && item.state !== "leased") continue;
+    if (exactReviewQueueIsPublication(item)) {
+      activePublishers += 1;
+      continue;
+    }
     const target = item.decision.targetRepo;
     activeTargets.set(target, (activeTargets.get(target) || 0) + 1);
-    if (item.decision.sourceAction === EXACT_REVIEW_ARTIFACT_PUBLISH_SOURCE_ACTION) {
-      activePublishers += 1;
-    }
   }
   const admitted: ExactReviewQueueItem[] = [];
+  let admittedReviews = 0;
   const pending = Object.values(state.items)
     .filter((item) => item.state === "pending" && item.nextAttemptAt <= now)
     .sort((left, right) => left.createdAt - right.createdAt || left.key.localeCompare(right.key));
   for (const item of pending) {
-    if (admitted.length >= slots) break;
-    const publication = item.decision.sourceAction === EXACT_REVIEW_ARTIFACT_PUBLISH_SOURCE_ACTION;
-    if (publication && activePublishers >= 1) continue;
+    const publication = exactReviewQueueIsPublication(item);
+    if (publication) {
+      if (activePublishers >= 1) continue;
+      activePublishers += 1;
+      admitted.push(item);
+      continue;
+    }
+    if (admittedReviews >= reviewSlots) continue;
     const target = item.decision.targetRepo;
     const active = activeTargets.get(target) || 0;
     if (active >= targetCapacity) continue;
     activeTargets.set(target, active + 1);
-    if (publication) activePublishers += 1;
+    admittedReviews += 1;
     admitted.push(item);
   }
   return admitted;
@@ -2964,23 +2977,21 @@ function exactReviewQueueNextWakeAt(
   const activeItems = items.filter(
     (item) => item.state === "dispatching" || item.state === "leased",
   );
-  const activeLeaseWakeAt = activeItems
-    .map((item) => item.leaseExpiresAt)
-    .filter((value): value is number => Boolean(value && value > now));
   if (activeItems.some((item) => !item.leaseExpiresAt || item.leaseExpiresAt <= now)) {
     return now + 1_000;
   }
-  if (activeItems.length >= capacity && activeLeaseWakeAt.length) {
-    return Math.max(now + 1_000, Math.min(...activeLeaseWakeAt));
-  }
+  const activeReviews = activeItems.filter((item) => !exactReviewQueueIsPublication(item));
+  const activePublishers = activeItems.filter(exactReviewQueueIsPublication);
+  const activeReviewWakeAt = activeReviews
+    .map((item) => item.leaseExpiresAt)
+    .filter((value): value is number => Boolean(value && value > now));
+  const activePublisherWakeAt = activePublishers
+    .map((item) => item.leaseExpiresAt)
+    .filter((value): value is number => Boolean(value && value > now));
   const activeTargetWakeAt = new Map<string, number>();
   const activeTargetCounts = new Map<string, number>();
-  for (const item of items) {
-    if (
-      (item.state === "dispatching" || item.state === "leased") &&
-      item.leaseExpiresAt &&
-      item.leaseExpiresAt > now
-    ) {
+  for (const item of activeReviews) {
+    if (item.leaseExpiresAt && item.leaseExpiresAt > now) {
       const target = item.decision.targetRepo;
       activeTargetCounts.set(target, (activeTargetCounts.get(target) || 0) + 1);
       const current = activeTargetWakeAt.get(item.decision.targetRepo);
@@ -2992,12 +3003,28 @@ function exactReviewQueueNextWakeAt(
   }
   const times = items.flatMap((item) => {
     if (item.state === "pending") {
+      if (exactReviewQueueIsPublication(item)) {
+        const blockedUntil = activePublisherWakeAt.length
+          ? Math.min(...activePublisherWakeAt)
+          : item.nextAttemptAt;
+        return [Math.max(item.nextAttemptAt, blockedUntil)];
+      }
       const target = item.decision.targetRepo;
-      const blockedUntil =
-        (activeTargetCounts.get(target) || 0) >= targetCapacity
-          ? activeTargetWakeAt.get(target)
-          : undefined;
-      return [blockedUntil ?? item.nextAttemptAt];
+      const blockedUntil = [
+        ...(activeReviews.length >= capacity && activeReviewWakeAt.length
+          ? [Math.min(...activeReviewWakeAt)]
+          : []),
+        ...((activeTargetCounts.get(target) || 0) >= targetCapacity &&
+        activeTargetWakeAt.has(target)
+          ? [activeTargetWakeAt.get(target) as number]
+          : []),
+      ];
+      return [
+        Math.max(
+          item.nextAttemptAt,
+          blockedUntil.length ? Math.min(...blockedUntil) : item.nextAttemptAt,
+        ),
+      ];
     }
     return item.leaseExpiresAt ? [item.leaseExpiresAt] : [];
   });

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -27,8 +27,10 @@ type WorkflowRunSummary = {
 };
 
 const FAILED_REVIEW_SHARD_RECOVERY_SOURCE_ACTION = "failed_review_shard_recovery";
+const EXACT_REVIEW_ARTIFACT_PUBLISH_SOURCE_ACTION = "exact_review_artifact_publish";
+const EXACT_REVIEW_ARTIFACT_RETENTION_RECOVERY_SOURCE_ACTION = "artifact_retention_recovery";
 
-type ExactReviewDecision = {
+type ExactReviewBaseDecision = {
   targetRepo: string;
   targetBranch: string;
   itemNumber: number;
@@ -41,6 +43,24 @@ type ExactReviewDecision = {
   commandStatusMarker?: string;
   statusCommentId?: number;
   additionalPrompt?: string;
+};
+type ExactReviewPublication = {
+  artifactName: string;
+  producerRunId: string;
+  producerRunAttempt: number;
+  sourceSha: string;
+  itemKey: string;
+  protocolVersion: 1 | 2;
+  leaseRevision: number | null;
+  claimGeneration: number | null;
+  liveProceeded: boolean;
+  liveTerminalNoop: boolean;
+  liveTerminalMissing: boolean;
+  liveGuardedOpen: boolean;
+  producerDecision: ExactReviewBaseDecision;
+};
+type ExactReviewDecision = ExactReviewBaseDecision & {
+  publication?: ExactReviewPublication;
 };
 type ExactReviewQueueItem = {
   key: string;
@@ -125,10 +145,14 @@ const DEFAULT_STALE_QUEUED_WORKFLOW_MS = 6 * 60 * 60 * 1000;
 const DEFAULT_EXACT_REVIEW_QUEUE_MAX_CONCURRENT = 64;
 const DEFAULT_EXACT_REVIEW_TARGET_MAX_CONCURRENT = 60;
 const DEFAULT_EXACT_REVIEW_DISPATCH_LEASE_MS = 6 * 60 * 1000;
+// Covers the global publisher lane's 100 queued 60-minute jobs plus scheduling margin.
+// Terminal-run reconciliation still releases failed or cancelled dispatches early.
+const DEFAULT_EXACT_REVIEW_PUBLICATION_DISPATCH_LEASE_MS = 7 * 24 * 60 * 60 * 1000;
 const DEFAULT_EXACT_REVIEW_EXECUTION_LEASE_MS = 130 * 60 * 1000;
 const DEFAULT_EXACT_REVIEW_RETRY_MS = 30_000;
 const DEFAULT_EXACT_REVIEW_WORKFLOW_PAUSED_RETRY_MS = 60_000;
 const EXACT_REVIEW_COMPLETION_RETRY_MAX_MS = 2 * 60 * 60 * 1000;
+const EXACT_REVIEW_ARTIFACT_RETRY_MAX_MS = 80 * 24 * 60 * 60 * 1000;
 const EXACT_REVIEW_RECONCILE_RUN_LIMIT = 128;
 const EXACT_REVIEW_RECONCILE_CLAIM_MATCH_LIMIT = EXACT_REVIEW_RECONCILE_RUN_LIMIT * 2;
 const EXACT_REVIEW_RECONCILE_CONCURRENCY = 8;
@@ -625,14 +649,12 @@ export class ExactReviewQueue {
             return json({ error: "claim_protocol_mismatch" }, 409);
           }
           const claimGeneration = Math.max(1, exactReviewClaimGeneration(item.claimGeneration));
-          if (
-            item.claimGeneration !== claimGeneration ||
-            item.claimProtocolVersion !== claimProtocolVersion
-          ) {
-            item.claimGeneration = claimGeneration;
-            item.claimProtocolVersion = claimProtocolVersion;
-            await this.writeState(state);
-          }
+          item.claimGeneration = claimGeneration;
+          item.claimProtocolVersion = claimProtocolVersion;
+          item.leaseExpiresAt = now + exactReviewExecutionLeaseMs(this.env);
+          item.updatedAt = now;
+          await this.writeState(state);
+          await this.scheduleNext(state, now);
           return json(exactReviewClaimResponse(item, claimProtocolVersion, claimGeneration));
         }
       } else if (item.claimedRunId && runAttempt === null) {
@@ -859,7 +881,9 @@ export class ExactReviewQueue {
       this.syncLegacyCompatibilitySync(this.readStateSync());
     });
     const snapshot = this.readStateSync();
-    const snapshotChanged = reclaimExpiredExactReviewLeases(snapshot, startedAt);
+    const reclaimedSnapshot = reclaimExpiredExactReviewLeases(snapshot, startedAt);
+    const expiredSnapshot = expireExactReviewPublicationItems(snapshot, startedAt);
+    const snapshotChanged = reclaimedSnapshot || expiredSnapshot;
     const capacity = exactReviewQueueCapacity(this.env);
     const targetCapacity = exactReviewTargetCapacity(this.env);
     const snapshotAdmission = exactReviewQueueAdmittedItems(
@@ -889,6 +913,7 @@ export class ExactReviewQueue {
     const now = Date.now();
     const state = this.readStateSync();
     reclaimExpiredExactReviewLeases(state, now);
+    expireExactReviewPublicationItems(state, now);
     const admitted = exactReviewQueueAdmittedItems(state, now, capacity, targetCapacity);
     if (!preflight.ok) {
       const retryAt = now + exactReviewWorkflowPausedRetryMs(this.env);
@@ -928,7 +953,14 @@ export class ExactReviewQueue {
       item.leaseId = crypto.randomUUID();
       item.leaseRevision = item.revision;
       item.leaseDecision = { ...item.decision };
-      item.leaseExpiresAt = now + exactReviewDispatchLeaseMs(this.env);
+      item.leaseExpiresAt =
+        now +
+        (item.decision.sourceAction === EXACT_REVIEW_ARTIFACT_PUBLISH_SOURCE_ACTION
+          ? Math.max(
+              exactReviewDispatchLeaseMs(this.env),
+              DEFAULT_EXACT_REVIEW_PUBLICATION_DISPATCH_LEASE_MS,
+            )
+          : exactReviewDispatchLeaseMs(this.env));
       item.claimedRunId = undefined;
       item.claimedRunAttempt = undefined;
       item.claimGeneration = undefined;
@@ -2342,6 +2374,32 @@ async function enqueueExactReview({
 }
 
 function exactReviewDecisionFrom(value): ExactReviewDecision | null {
+  const base = exactReviewBaseDecisionFrom(value);
+  if (!base) return null;
+  const decision = objectValue(value);
+  const hasPublication = Object.hasOwn(decision, "publication");
+  const publication = hasPublication ? exactReviewPublicationFrom(decision.publication) : undefined;
+  if (hasPublication && !publication) return null;
+  if (publication) {
+    if (base.sourceAction !== EXACT_REVIEW_ARTIFACT_PUBLISH_SOURCE_ACTION) return null;
+    if (
+      publication.producerDecision.sourceAction === EXACT_REVIEW_ARTIFACT_PUBLISH_SOURCE_ACTION ||
+      publication.producerDecision.targetRepo !== base.targetRepo ||
+      publication.producerDecision.targetBranch !== base.targetBranch ||
+      publication.producerDecision.itemNumber !== base.itemNumber ||
+      publication.producerDecision.itemKind !== base.itemKind ||
+      publication.producerDecision.sourceEvent !== base.sourceEvent ||
+      publication.itemKey !== `${base.targetRepo}#${base.itemNumber}`
+    ) {
+      return null;
+    }
+  } else if (base.sourceAction === EXACT_REVIEW_ARTIFACT_PUBLISH_SOURCE_ACTION) {
+    return null;
+  }
+  return { ...base, ...(publication ? { publication } : {}) };
+}
+
+function exactReviewBaseDecisionFrom(value): ExactReviewBaseDecision | null {
   const decision = objectValue(value);
   const targetRepo = String(decision.targetRepo || "").trim();
   const targetBranch = String(decision.targetBranch || "").trim();
@@ -2402,6 +2460,58 @@ function exactReviewDecisionFrom(value): ExactReviewDecision | null {
   };
 }
 
+function exactReviewPublicationFrom(value): ExactReviewPublication | null {
+  const publication = objectValue(value);
+  const artifactName = String(publication.artifactName || "").trim();
+  const producerRunId = String(publication.producerRunId || "").trim();
+  const producerRunAttempt = Number(publication.producerRunAttempt);
+  const sourceSha = String(publication.sourceSha || "").trim();
+  const itemKey = String(publication.itemKey || "").trim();
+  const protocolVersion = Number(publication.protocolVersion);
+  const leaseRevision =
+    publication.leaseRevision === null ? null : Number(publication.leaseRevision);
+  const claimGeneration =
+    publication.claimGeneration === null ? null : Number(publication.claimGeneration);
+  const producerDecision = exactReviewBaseDecisionFrom(publication.producerDecision);
+  const liveProceeded = publication.liveProceeded;
+  const liveTerminalNoop = publication.liveTerminalNoop;
+  const liveTerminalMissing = publication.liveTerminalMissing;
+  const liveGuardedOpen = publication.liveGuardedOpen;
+  if (!/^exact-review-\d{1,30}-[1-9]\d*$/.test(artifactName)) return null;
+  if (!/^\d{1,30}$/.test(producerRunId)) return null;
+  if (!Number.isSafeInteger(producerRunAttempt) || producerRunAttempt < 1) return null;
+  if (artifactName !== `exact-review-${producerRunId}-${producerRunAttempt}`) return null;
+  if (!/^[0-9a-f]{40}$/.test(sourceSha)) return null;
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+#[1-9]\d*$/.test(itemKey)) return null;
+  if (protocolVersion !== 1 && protocolVersion !== 2) return null;
+  if (
+    (leaseRevision !== null && (!Number.isSafeInteger(leaseRevision) || leaseRevision < 1)) ||
+    (claimGeneration !== null && (!Number.isSafeInteger(claimGeneration) || claimGeneration < 1))
+  ) {
+    return null;
+  }
+  if (protocolVersion === 2 && (leaseRevision === null || claimGeneration === null)) return null;
+  if (!producerDecision) return null;
+  const liveOutcomes = [liveProceeded, liveTerminalNoop, liveTerminalMissing, liveGuardedOpen];
+  if (liveOutcomes.some((outcome) => typeof outcome !== "boolean")) return null;
+  if (liveOutcomes.filter(Boolean).length !== 1) return null;
+  return {
+    artifactName,
+    producerRunId,
+    producerRunAttempt,
+    sourceSha,
+    itemKey,
+    protocolVersion,
+    leaseRevision,
+    claimGeneration,
+    liveProceeded,
+    liveTerminalNoop,
+    liveTerminalMissing,
+    liveGuardedOpen,
+    producerDecision,
+  };
+}
+
 function mergePendingExactReviewDecision(
   current: ExactReviewDecision,
   next: ExactReviewDecision,
@@ -2418,7 +2528,10 @@ function mergePendingExactReviewDecision(
 }
 
 function exactReviewItemKey(decision: ExactReviewDecision) {
-  return `${decision.targetRepo}#${decision.itemNumber}`;
+  const base = `${decision.targetRepo}#${decision.itemNumber}`;
+  return decision.publication
+    ? `${base}@publish:${decision.publication.producerRunId}:${decision.publication.producerRunAttempt}`
+    : base;
 }
 
 function isExactReviewQueueTargetEnabled(decision: ExactReviewDecision, env) {
@@ -2648,6 +2761,51 @@ function reclaimExpiredExactReviewLeases(state: ExactReviewQueueState, now: numb
   return changed;
 }
 
+function expireExactReviewPublicationItems(state: ExactReviewQueueState, now: number) {
+  let changed = false;
+  for (const [key, item] of Object.entries(state.items)) {
+    const publication = item.decision.publication;
+    if (
+      item.state !== "pending" ||
+      !publication ||
+      now < item.createdAt + EXACT_REVIEW_ARTIFACT_RETRY_MAX_MS
+    ) {
+      continue;
+    }
+    delete state.items[key];
+    const decision: ExactReviewDecision = {
+      ...publication.producerDecision,
+      sourceAction:
+        publication.producerDecision.sourceAction === FAILED_REVIEW_SHARD_RECOVERY_SOURCE_ACTION
+          ? FAILED_REVIEW_SHARD_RECOVERY_SOURCE_ACTION
+          : EXACT_REVIEW_ARTIFACT_RETENTION_RECOVERY_SOURCE_ACTION,
+      supersedesInProgress: true,
+    };
+    const recoveryKey = exactReviewItemKey(decision);
+    const current = state.items[recoveryKey];
+    if (current?.state === "pending") {
+      current.decision = mergePendingExactReviewDecision(current.decision, decision);
+      current.revision += 1;
+      current.updatedAt = now;
+      current.nextAttemptAt = exactReviewQueueEnqueueAttemptAt(state, now);
+      current.attempts = 0;
+    } else if (!current) {
+      state.items[recoveryKey] = {
+        key: recoveryKey,
+        decision,
+        state: "pending",
+        revision: 1,
+        createdAt: now,
+        updatedAt: now,
+        nextAttemptAt: exactReviewQueueEnqueueAttemptAt(state, now),
+        attempts: 0,
+      };
+    }
+    changed = true;
+  }
+  return changed;
+}
+
 function exactReviewQueueEnqueueAttemptAt(state: ExactReviewQueueState, now: number) {
   const retryAt = Number(state.dispatcher?.retryAt || 0);
   return (state.dispatcher?.state === "paused" || state.dispatcher?.state === "blocked") &&
@@ -2678,10 +2836,14 @@ function exactReviewQueueAdmittedItems(
 ) {
   const slots = Math.max(0, capacity - exactReviewQueueActiveCount(state));
   const activeTargets = new Map<string, number>();
+  let activePublishers = 0;
   for (const item of Object.values(state.items)) {
     if (item.state !== "dispatching" && item.state !== "leased") continue;
     const target = item.decision.targetRepo;
     activeTargets.set(target, (activeTargets.get(target) || 0) + 1);
+    if (item.decision.sourceAction === EXACT_REVIEW_ARTIFACT_PUBLISH_SOURCE_ACTION) {
+      activePublishers += 1;
+    }
   }
   const admitted: ExactReviewQueueItem[] = [];
   const pending = Object.values(state.items)
@@ -2689,10 +2851,13 @@ function exactReviewQueueAdmittedItems(
     .sort((left, right) => left.createdAt - right.createdAt || left.key.localeCompare(right.key));
   for (const item of pending) {
     if (admitted.length >= slots) break;
+    const publication = item.decision.sourceAction === EXACT_REVIEW_ARTIFACT_PUBLISH_SOURCE_ACTION;
+    if (publication && activePublishers >= 1) continue;
     const target = item.decision.targetRepo;
     const active = activeTargets.get(target) || 0;
     if (active >= targetCapacity) continue;
     activeTargets.set(target, active + 1);
+    if (publication) activePublishers += 1;
     admitted.push(item);
   }
   return admitted;
@@ -3262,6 +3427,7 @@ async function dispatchClawsweeperItem({
       : {}),
     ...(decision.statusCommentId ? { status_comment_id: decision.statusCommentId } : {}),
     ...(decision.additionalPrompt ? { additional_prompt: decision.additionalPrompt } : {}),
+    ...(decision.publication ? { publication: decision.publication } : {}),
   };
   await githubTokenJson({
     token,

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "repair:notify-github-activity": "node dist/repair/notify-github-activity.js",
     "repair:spam-comment-intake": "node dist/repair/spam-comment-intake.js",
     "repair:spam-scan": "node dist/repair/spam-scanner.js",
+    "repair:exact-review-bundle": "node dist/repair/exact-review-bundle-cli.js",
     "repair:publish-event-result": "node dist/repair/publish-event-result.js",
     "repair:update-command-status": "node dist/repair/update-command-status.js",
     "workflow": "node dist/repair/workflow-utils.js",

--- a/scripts/apply-workflow-helpers.sh
+++ b/scripts/apply-workflow-helpers.sh
@@ -65,7 +65,8 @@ publish_changes_with_strategy() {
 publish_changes() {
   local message="$1"
   shift
-  local target_slug="${TARGET_REPO,,}"
+  local target_slug
+  target_slug="$(printf '%s' "$TARGET_REPO" | tr '[:upper:]' '[:lower:]')"
   target_slug="${target_slug//\//-}"
   local record_paths=()
   local other_paths=()
@@ -98,7 +99,8 @@ publish_status() {
 publish_reconciled_records() {
   local message="$1"
   local reconcile_json="$2"
-  local target_slug="${TARGET_REPO,,}"
+  local target_slug
+  target_slug="$(printf '%s' "$TARGET_REPO" | tr '[:upper:]' '[:lower:]')"
   target_slug="${target_slug//\//-}"
   local publish_paths=()
   local record_file

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -30406,15 +30406,32 @@ function publishActionEventsCommand(args: Args): void {
   if (!expectedProducerJob) {
     throw new UserFacingCommandError("--expected-producer-job is required");
   }
+  const expectedProducerRunAttempt = optionalNumberArg(args.expected_producer_run_attempt);
+  if (
+    expectedProducerRunAttempt !== undefined &&
+    (!Number.isInteger(expectedProducerRunAttempt) || expectedProducerRunAttempt < 1)
+  ) {
+    throw new UserFacingCommandError("--expected-producer-run-attempt must be a positive integer");
+  }
+  const expectedProducerRunId = stringArg(args.expected_producer_run_id, "");
+  if (expectedProducerRunId && !/^\d{1,30}$/.test(expectedProducerRunId)) {
+    throw new UserFacingCommandError(
+      "--expected-producer-run-id must be a numeric workflow run ID",
+    );
+  }
+  const expectedProducerSha = stringArg(args.expected_producer_sha, "");
+  if (expectedProducerSha && !/^[0-9a-f]{40}$/.test(expectedProducerSha)) {
+    throw new UserFacingCommandError("--expected-producer-sha must be a lowercase commit SHA");
+  }
   const currentProducer = workflowActionProducer("action_event_publisher");
   const result = importActionEventShards(sourceRoot, stateRoot, {
     expectedProducer: {
       repository: currentProducer.repository,
-      sha: currentProducer.sha,
+      sha: expectedProducerSha || currentProducer.sha,
       workflow: currentProducer.workflow,
       job: expectedProducerJob,
-      runId: currentProducer.runId,
-      runAttempt: currentProducer.runAttempt,
+      runId: expectedProducerRunId || currentProducer.runId,
+      runAttempt: expectedProducerRunAttempt ?? currentProducer.runAttempt,
     },
   });
   console.log(JSON.stringify(result, null, 2));

--- a/src/repair/exact-review-bundle-cli.ts
+++ b/src/repair/exact-review-bundle-cli.ts
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+import {
+  createExactReviewBundle,
+  exactReviewDecisionSha256,
+  validateExactReviewBundle,
+  type ExactReviewBundleContext,
+} from "./exact-review-bundle.js";
+
+const [command] = process.argv.slice(2);
+if (command !== "create" && command !== "validate") {
+  throw new Error("usage: exact-review-bundle-cli.ts <create|validate>");
+}
+
+const context = contextFromEnv(process.env);
+const bundleDir = requiredEnv(process.env, "EXACT_REVIEW_BUNDLE_DIR");
+if (command === "create") {
+  const reviewPath = optionalEnv(process.env, "EXACT_REVIEW_REPORT_PATH");
+  const actionLedgerRoot = optionalEnv(process.env, "EXACT_REVIEW_ACTION_LEDGER_ROOT");
+  const manifest = createExactReviewBundle({
+    bundleDir,
+    ...(reviewPath ? { reviewPath } : {}),
+    ...(actionLedgerRoot ? { actionLedgerRoot } : {}),
+    createdAt: new Date().toISOString(),
+    context,
+  });
+  process.stdout.write(`${JSON.stringify(manifest)}\n`);
+} else {
+  const manifest = validateExactReviewBundle(bundleDir, context);
+  process.stdout.write(`${JSON.stringify(manifest)}\n`);
+}
+
+function contextFromEnv(env: NodeJS.ProcessEnv): ExactReviewBundleContext {
+  const protocolVersion = positiveIntegerEnv(env, "EXACT_REVIEW_PROTOCOL_VERSION");
+  if (protocolVersion !== 1 && protocolVersion !== 2) {
+    throw new Error("EXACT_REVIEW_PROTOCOL_VERSION must be 1 or 2");
+  }
+  return {
+    repository: requiredEnv(env, "GITHUB_REPOSITORY"),
+    sourceSha: optionalEnv(env, "EXACT_REVIEW_SOURCE_SHA") || requiredEnv(env, "GITHUB_SHA"),
+    runId: optionalEnv(env, "EXACT_REVIEW_PRODUCER_RUN_ID") || requiredEnv(env, "GITHUB_RUN_ID"),
+    runAttempt: positiveIntegerEnv(env, "EXACT_REVIEW_GENERATION_ATTEMPT"),
+    producerJob: requiredEnv(env, "EXACT_REVIEW_PRODUCER_JOB"),
+    decisionSha256: exactReviewDecisionSha256(requiredEnv(env, "EXACT_REVIEW_DECISION")),
+    targetRepo: requiredEnv(env, "EXACT_REVIEW_TARGET_REPO"),
+    targetBranch: requiredEnv(env, "EXACT_REVIEW_TARGET_BRANCH"),
+    itemNumber: positiveIntegerEnv(env, "EXACT_REVIEW_ITEM_NUMBER"),
+    itemKind: itemKindEnv(env),
+    itemKey: requiredEnv(env, "EXACT_REVIEW_ITEM_KEY"),
+    protocolVersion,
+    leaseRevision: optionalPositiveIntegerEnv(env, "EXACT_REVIEW_LEASE_REVISION"),
+    claimGeneration: optionalPositiveIntegerEnv(env, "EXACT_REVIEW_CLAIM_GENERATION"),
+    liveProceeded: booleanEnv(env, "EXACT_REVIEW_LIVE_PROCEEDED"),
+    liveTerminalNoop: booleanEnv(env, "EXACT_REVIEW_LIVE_TERMINAL_NOOP"),
+    liveTerminalMissing: booleanEnv(env, "EXACT_REVIEW_LIVE_TERMINAL_MISSING"),
+    liveGuardedOpen: booleanEnv(env, "EXACT_REVIEW_LIVE_GUARDED_OPEN"),
+  };
+}
+
+function requiredEnv(env: NodeJS.ProcessEnv, name: string): string {
+  const value = optionalEnv(env, name);
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function optionalEnv(env: NodeJS.ProcessEnv, name: string): string {
+  return String(env[name] ?? "").trim();
+}
+
+function positiveIntegerEnv(env: NodeJS.ProcessEnv, name: string): number {
+  const value = Number(requiredEnv(env, name));
+  if (!Number.isInteger(value) || value < 1) throw new Error(`${name} must be a positive integer`);
+  return value;
+}
+
+function optionalPositiveIntegerEnv(env: NodeJS.ProcessEnv, name: string): number | null {
+  const raw = optionalEnv(env, name);
+  if (!raw) return null;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 1) throw new Error(`${name} must be a positive integer`);
+  return value;
+}
+
+function booleanEnv(env: NodeJS.ProcessEnv, name: string): boolean {
+  const value = requiredEnv(env, name);
+  if (value === "true") return true;
+  if (value === "false") return false;
+  throw new Error(`${name} must be true or false`);
+}
+
+function itemKindEnv(env: NodeJS.ProcessEnv): "issue" | "pull_request" {
+  const value = requiredEnv(env, "EXACT_REVIEW_ITEM_KIND");
+  if (value === "issue" || value === "pull_request") return value;
+  throw new Error("EXACT_REVIEW_ITEM_KIND must be issue or pull_request");
+}

--- a/src/repair/exact-review-bundle.ts
+++ b/src/repair/exact-review-bundle.ts
@@ -1,0 +1,536 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+export const EXACT_REVIEW_BUNDLE_SCHEMA_VERSION = 1 as const;
+export const EXACT_REVIEW_BUNDLE_MAX_FILES = 512;
+export const EXACT_REVIEW_BUNDLE_MAX_FILE_BYTES = 2 * 1024 * 1024;
+export const EXACT_REVIEW_BUNDLE_MAX_TOTAL_BYTES = 16 * 1024 * 1024;
+
+const REPO_PATTERN = /^[A-Za-z0-9_.-]{1,100}\/[A-Za-z0-9_.-]{1,100}$/;
+const BRANCH_PATTERN = /^[A-Za-z0-9_./-]{1,255}$/;
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+const ITEM_KEY_PATTERN = /^[A-Za-z0-9_.-]{1,100}\/[A-Za-z0-9_.-]{1,100}#[1-9]\d*$/;
+const FILE_PATH_PATTERN = /^(?:review\/[1-9]\d*\.md|action-ledger\/ledger\/[A-Za-z0-9_./-]+)$/;
+
+export interface ExactReviewBundleContext {
+  repository: string;
+  sourceSha: string;
+  runId: string;
+  runAttempt: number;
+  producerJob: string;
+  decisionSha256: string;
+  targetRepo: string;
+  targetBranch: string;
+  itemNumber: number;
+  itemKind: "issue" | "pull_request";
+  itemKey: string;
+  protocolVersion: 1 | 2;
+  leaseRevision: number | null;
+  claimGeneration: number | null;
+  liveProceeded: boolean;
+  liveTerminalNoop: boolean;
+  liveTerminalMissing: boolean;
+  liveGuardedOpen: boolean;
+}
+
+export interface ExactReviewBundleFile {
+  path: string;
+  bytes: number;
+  sha256: string;
+}
+
+export interface ExactReviewBundleManifest {
+  schema_version: typeof EXACT_REVIEW_BUNDLE_SCHEMA_VERSION;
+  created_at: string;
+  workflow: {
+    repository: string;
+    source_sha: string;
+    run_id: string;
+    run_attempt: number;
+    producer_job: string;
+  };
+  queue: {
+    item_key: string;
+    protocol_version: 1 | 2;
+    lease_revision: number | null;
+    claim_generation: number | null;
+  };
+  target: {
+    repo: string;
+    branch: string;
+    item_number: number;
+    item_kind: "issue" | "pull_request";
+  };
+  review: {
+    decision_sha256: string;
+    live_proceeded: boolean;
+    live_terminal_noop: boolean;
+    live_terminal_missing: boolean;
+    live_guarded_open: boolean;
+    artifact_present: boolean;
+  };
+  files: ExactReviewBundleFile[];
+}
+
+export interface CreateExactReviewBundleOptions {
+  bundleDir: string;
+  reviewPath?: string;
+  actionLedgerRoot?: string;
+  createdAt: string;
+  context: ExactReviewBundleContext;
+}
+
+export function exactReviewDecisionSha256(decisionJson: string): string {
+  let value: unknown;
+  try {
+    value = JSON.parse(decisionJson);
+  } catch {
+    throw new Error("exact review decision is not valid JSON");
+  }
+  return sha256(canonicalJson(value));
+}
+
+export function createExactReviewBundle(
+  options: CreateExactReviewBundleOptions,
+): ExactReviewBundleManifest {
+  const context = validateContext(options.context);
+  const bundleDir = path.resolve(options.bundleDir);
+  fs.rmSync(bundleDir, { force: true, recursive: true });
+  fs.mkdirSync(bundleDir, { recursive: true });
+
+  let artifactPresent = false;
+  if (options.reviewPath && fs.existsSync(options.reviewPath)) {
+    const reviewDestination = path.join(bundleDir, "review", `${context.itemNumber}.md`);
+    copyRegularFile(options.reviewPath, reviewDestination);
+    artifactPresent = true;
+  }
+  if (options.actionLedgerRoot && fs.existsSync(options.actionLedgerRoot)) {
+    copyTree(options.actionLedgerRoot, path.join(bundleDir, "action-ledger"));
+  }
+
+  const files = collectBundleFiles(bundleDir);
+  if (context.liveProceeded && !artifactPresent) {
+    throw new Error("a proceeded exact review bundle requires a review artifact");
+  }
+  const manifest = validateManifest({
+    schema_version: EXACT_REVIEW_BUNDLE_SCHEMA_VERSION,
+    created_at: canonicalTimestamp(options.createdAt),
+    workflow: {
+      repository: context.repository,
+      source_sha: context.sourceSha,
+      run_id: context.runId,
+      run_attempt: context.runAttempt,
+      producer_job: context.producerJob,
+    },
+    queue: {
+      item_key: context.itemKey,
+      protocol_version: context.protocolVersion,
+      lease_revision: context.leaseRevision,
+      claim_generation: context.claimGeneration,
+    },
+    target: {
+      repo: context.targetRepo,
+      branch: context.targetBranch,
+      item_number: context.itemNumber,
+      item_kind: context.itemKind,
+    },
+    review: {
+      decision_sha256: context.decisionSha256,
+      live_proceeded: context.liveProceeded,
+      live_terminal_noop: context.liveTerminalNoop,
+      live_terminal_missing: context.liveTerminalMissing,
+      live_guarded_open: context.liveGuardedOpen,
+      artifact_present: artifactPresent,
+    },
+    files,
+  });
+  fs.writeFileSync(
+    path.join(bundleDir, "manifest.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    {
+      encoding: "utf8",
+      flag: "wx",
+    },
+  );
+  return manifest;
+}
+
+export function validateExactReviewBundle(
+  bundleDirInput: string,
+  expected: ExactReviewBundleContext,
+): ExactReviewBundleManifest {
+  const bundleDir = path.resolve(bundleDirInput);
+  const manifestPath = path.join(bundleDir, "manifest.json");
+  const stat = fs.lstatSync(manifestPath);
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new Error("exact review bundle manifest must be a regular file");
+  }
+  if (stat.size > EXACT_REVIEW_BUNDLE_MAX_FILE_BYTES) {
+    throw new Error("exact review bundle manifest is too large");
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  } catch {
+    throw new Error("exact review bundle manifest is not valid JSON");
+  }
+  const manifest = validateManifest(parsed);
+  const context = validateContext(expected);
+  assertExpectedManifest(manifest, context);
+
+  const actualFiles = collectBundleFiles(bundleDir);
+  if (JSON.stringify(actualFiles) !== JSON.stringify(manifest.files)) {
+    throw new Error("exact review bundle file inventory does not match its manifest");
+  }
+  const expectedReviewPath = `review/${context.itemNumber}.md`;
+  const hasReview = actualFiles.some((file) => file.path === expectedReviewPath);
+  if (hasReview !== manifest.review.artifact_present) {
+    throw new Error("exact review bundle review artifact presence does not match its manifest");
+  }
+  return manifest;
+}
+
+function assertExpectedManifest(
+  manifest: ExactReviewBundleManifest,
+  expected: ExactReviewBundleContext,
+): void {
+  const actual = {
+    repository: manifest.workflow.repository,
+    sourceSha: manifest.workflow.source_sha,
+    runId: manifest.workflow.run_id,
+    runAttempt: manifest.workflow.run_attempt,
+    producerJob: manifest.workflow.producer_job,
+    decisionSha256: manifest.review.decision_sha256,
+    targetRepo: manifest.target.repo,
+    targetBranch: manifest.target.branch,
+    itemNumber: manifest.target.item_number,
+    itemKind: manifest.target.item_kind,
+    itemKey: manifest.queue.item_key,
+    protocolVersion: manifest.queue.protocol_version,
+    leaseRevision: manifest.queue.lease_revision,
+    claimGeneration: manifest.queue.claim_generation,
+    liveProceeded: manifest.review.live_proceeded,
+    liveTerminalNoop: manifest.review.live_terminal_noop,
+    liveTerminalMissing: manifest.review.live_terminal_missing,
+    liveGuardedOpen: manifest.review.live_guarded_open,
+  } satisfies ExactReviewBundleContext;
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error("exact review bundle does not match the trusted workflow context");
+  }
+}
+
+function validateContext(value: ExactReviewBundleContext): ExactReviewBundleContext {
+  if (!REPO_PATTERN.test(value.repository)) throw new Error("repository is invalid");
+  if (!SHA_PATTERN.test(value.sourceSha)) throw new Error("source SHA is invalid");
+  if (!/^\d{1,30}$/.test(value.runId)) throw new Error("run ID is invalid");
+  positiveInteger(value.runAttempt, "run attempt");
+  if (!/^[A-Za-z0-9_.-]{1,100}$/.test(value.producerJob)) {
+    throw new Error("producer job is invalid");
+  }
+  if (!SHA256_PATTERN.test(value.decisionSha256)) {
+    throw new Error("decision digest is invalid");
+  }
+  if (!REPO_PATTERN.test(value.targetRepo)) throw new Error("target repository is invalid");
+  if (!BRANCH_PATTERN.test(value.targetBranch) || value.targetBranch.includes("..")) {
+    throw new Error("target branch is invalid");
+  }
+  positiveInteger(value.itemNumber, "item number");
+  if (value.itemKind !== "issue" && value.itemKind !== "pull_request") {
+    throw new Error("item kind is invalid");
+  }
+  if (!ITEM_KEY_PATTERN.test(value.itemKey)) throw new Error("item key is invalid");
+  if (value.itemKey !== `${value.targetRepo}#${value.itemNumber}`) {
+    throw new Error("item key does not match the target");
+  }
+  if (value.protocolVersion !== 1 && value.protocolVersion !== 2) {
+    throw new Error("queue protocol version is invalid");
+  }
+  nullablePositiveInteger(value.leaseRevision, "lease revision");
+  nullablePositiveInteger(value.claimGeneration, "claim generation");
+  if (
+    value.protocolVersion === 2 &&
+    (value.leaseRevision === null || value.claimGeneration === null)
+  ) {
+    throw new Error("queue protocol v2 requires the full claim tuple");
+  }
+  for (const [label, flag] of [
+    ["live proceeded", value.liveProceeded],
+    ["live terminal noop", value.liveTerminalNoop],
+    ["live terminal missing", value.liveTerminalMissing],
+    ["live guarded open", value.liveGuardedOpen],
+  ] as const) {
+    if (typeof flag !== "boolean") throw new Error(`${label} must be boolean`);
+  }
+  const liveOutcomes = [
+    value.liveProceeded,
+    value.liveTerminalNoop,
+    value.liveTerminalMissing,
+    value.liveGuardedOpen,
+  ].filter(Boolean).length;
+  if (liveOutcomes !== 1) throw new Error("exact review bundle requires one live outcome");
+  return { ...value };
+}
+
+function validateManifest(value: unknown): ExactReviewBundleManifest {
+  const manifest = record(value, "manifest");
+  exactKeys(manifest, [
+    "schema_version",
+    "created_at",
+    "workflow",
+    "queue",
+    "target",
+    "review",
+    "files",
+  ]);
+  if (manifest.schema_version !== EXACT_REVIEW_BUNDLE_SCHEMA_VERSION) {
+    throw new Error("unsupported exact review bundle schema version");
+  }
+  const createdAt = canonicalTimestamp(stringValue(manifest.created_at, "created_at"));
+
+  const workflow = record(manifest.workflow, "workflow");
+  exactKeys(workflow, ["repository", "source_sha", "run_id", "run_attempt", "producer_job"]);
+  const queue = record(manifest.queue, "queue");
+  exactKeys(queue, ["item_key", "protocol_version", "lease_revision", "claim_generation"]);
+  const target = record(manifest.target, "target");
+  exactKeys(target, ["repo", "branch", "item_number", "item_kind"]);
+  const review = record(manifest.review, "review");
+  exactKeys(review, [
+    "decision_sha256",
+    "live_proceeded",
+    "live_terminal_noop",
+    "live_terminal_missing",
+    "live_guarded_open",
+    "artifact_present",
+  ]);
+
+  const context = validateContext({
+    repository: stringValue(workflow.repository, "workflow.repository"),
+    sourceSha: stringValue(workflow.source_sha, "workflow.source_sha"),
+    runId: stringValue(workflow.run_id, "workflow.run_id"),
+    runAttempt: numberValue(workflow.run_attempt, "workflow.run_attempt"),
+    producerJob: stringValue(workflow.producer_job, "workflow.producer_job"),
+    decisionSha256: stringValue(review.decision_sha256, "review.decision_sha256"),
+    targetRepo: stringValue(target.repo, "target.repo"),
+    targetBranch: stringValue(target.branch, "target.branch"),
+    itemNumber: numberValue(target.item_number, "target.item_number"),
+    itemKind: target.item_kind as "issue" | "pull_request",
+    itemKey: stringValue(queue.item_key, "queue.item_key"),
+    protocolVersion: queue.protocol_version as 1 | 2,
+    leaseRevision: nullableNumber(queue.lease_revision, "queue.lease_revision"),
+    claimGeneration: nullableNumber(queue.claim_generation, "queue.claim_generation"),
+    liveProceeded: booleanValue(review.live_proceeded, "review.live_proceeded"),
+    liveTerminalNoop: booleanValue(review.live_terminal_noop, "review.live_terminal_noop"),
+    liveTerminalMissing: booleanValue(review.live_terminal_missing, "review.live_terminal_missing"),
+    liveGuardedOpen: booleanValue(review.live_guarded_open, "review.live_guarded_open"),
+  });
+  const artifactPresent = booleanValue(review.artifact_present, "review.artifact_present");
+  if (context.liveProceeded && !artifactPresent) {
+    throw new Error("a proceeded exact review bundle requires a review artifact");
+  }
+  if (!Array.isArray(manifest.files)) throw new Error("manifest.files must be an array");
+  if (manifest.files.length > EXACT_REVIEW_BUNDLE_MAX_FILES) {
+    throw new Error("exact review bundle has too many files");
+  }
+  let totalBytes = 0;
+  const files = manifest.files.map((entry, index) => {
+    const file = record(entry, `files[${index}]`);
+    exactKeys(file, ["path", "bytes", "sha256"]);
+    const relativePath = stringValue(file.path, `files[${index}].path`);
+    if (!FILE_PATH_PATTERN.test(relativePath) || relativePath.includes("..")) {
+      throw new Error(`files[${index}].path is invalid`);
+    }
+    const bytes = numberValue(file.bytes, `files[${index}].bytes`);
+    if (!Number.isInteger(bytes) || bytes < 0 || bytes > EXACT_REVIEW_BUNDLE_MAX_FILE_BYTES) {
+      throw new Error(`files[${index}].bytes is invalid`);
+    }
+    const digest = stringValue(file.sha256, `files[${index}].sha256`);
+    if (!SHA256_PATTERN.test(digest)) throw new Error(`files[${index}].sha256 is invalid`);
+    totalBytes += bytes;
+    return { path: relativePath, bytes, sha256: digest };
+  });
+  if (totalBytes > EXACT_REVIEW_BUNDLE_MAX_TOTAL_BYTES) {
+    throw new Error("exact review bundle exceeds its total byte limit");
+  }
+  const sorted = [...files].sort((left, right) => left.path.localeCompare(right.path));
+  if (JSON.stringify(sorted) !== JSON.stringify(files)) {
+    throw new Error("exact review bundle files must be sorted");
+  }
+  if (new Set(files.map((file) => file.path)).size !== files.length) {
+    throw new Error("exact review bundle contains duplicate file paths");
+  }
+  return {
+    schema_version: EXACT_REVIEW_BUNDLE_SCHEMA_VERSION,
+    created_at: createdAt,
+    workflow: {
+      repository: context.repository,
+      source_sha: context.sourceSha,
+      run_id: context.runId,
+      run_attempt: context.runAttempt,
+      producer_job: context.producerJob,
+    },
+    queue: {
+      item_key: context.itemKey,
+      protocol_version: context.protocolVersion,
+      lease_revision: context.leaseRevision,
+      claim_generation: context.claimGeneration,
+    },
+    target: {
+      repo: context.targetRepo,
+      branch: context.targetBranch,
+      item_number: context.itemNumber,
+      item_kind: context.itemKind,
+    },
+    review: {
+      decision_sha256: context.decisionSha256,
+      live_proceeded: context.liveProceeded,
+      live_terminal_noop: context.liveTerminalNoop,
+      live_terminal_missing: context.liveTerminalMissing,
+      live_guarded_open: context.liveGuardedOpen,
+      artifact_present: artifactPresent,
+    },
+    files,
+  };
+}
+
+function collectBundleFiles(root: string): ExactReviewBundleFile[] {
+  const files: ExactReviewBundleFile[] = [];
+  let totalBytes = 0;
+  const visit = (directory: string) => {
+    const entries = fs.readdirSync(directory, { withFileTypes: true });
+    for (const entry of entries) {
+      const absolute = path.join(directory, entry.name);
+      const relative = path.relative(root, absolute).split(path.sep).join("/");
+      if (relative === "manifest.json") continue;
+      if (entry.isSymbolicLink()) throw new Error("exact review bundle must not contain symlinks");
+      if (entry.isDirectory()) {
+        visit(absolute);
+        continue;
+      }
+      if (!entry.isFile()) throw new Error("exact review bundle contains a non-file entry");
+      if (!FILE_PATH_PATTERN.test(relative) || relative.includes("..")) {
+        throw new Error(`exact review bundle contains an unexpected path: ${relative}`);
+      }
+      const stat = fs.statSync(absolute);
+      if (stat.size > EXACT_REVIEW_BUNDLE_MAX_FILE_BYTES) {
+        throw new Error(`exact review bundle file is too large: ${relative}`);
+      }
+      totalBytes += stat.size;
+      if (totalBytes > EXACT_REVIEW_BUNDLE_MAX_TOTAL_BYTES) {
+        throw new Error("exact review bundle exceeds its total byte limit");
+      }
+      files.push({
+        path: relative,
+        bytes: stat.size,
+        sha256: sha256(fs.readFileSync(absolute)),
+      });
+      if (files.length > EXACT_REVIEW_BUNDLE_MAX_FILES) {
+        throw new Error("exact review bundle has too many files");
+      }
+    }
+  };
+  visit(root);
+  return files.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function copyTree(sourceRoot: string, destinationRoot: string): void {
+  const stat = fs.lstatSync(sourceRoot);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error("action ledger root must be a regular directory");
+  }
+  for (const entry of fs.readdirSync(sourceRoot, { withFileTypes: true })) {
+    const source = path.join(sourceRoot, entry.name);
+    const destination = path.join(destinationRoot, entry.name);
+    if (entry.isSymbolicLink()) throw new Error("action ledger root must not contain symlinks");
+    if (entry.isDirectory()) copyTree(source, destination);
+    else if (entry.isFile()) copyRegularFile(source, destination);
+    else throw new Error("action ledger root contains a non-file entry");
+  }
+}
+
+function copyRegularFile(source: string, destination: string): void {
+  const stat = fs.lstatSync(source);
+  if (!stat.isFile() || stat.isSymbolicLink())
+    throw new Error("bundle source must be a regular file");
+  if (stat.size > EXACT_REVIEW_BUNDLE_MAX_FILE_BYTES) throw new Error("bundle source is too large");
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.copyFileSync(source, destination, fs.constants.COPYFILE_EXCL);
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value === "string" || typeof value === "boolean") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value))
+      throw new Error("exact review decision contains a non-finite number");
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (typeof value === "object") {
+    const object = value as Record<string, unknown>;
+    return `{${Object.keys(object)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(object[key])}`)
+      .join(",")}}`;
+  }
+  throw new Error("exact review decision contains an unsupported value");
+}
+
+function canonicalTimestamp(value: string): string {
+  const parsed = new Date(value);
+  if (!Number.isFinite(parsed.valueOf())) throw new Error("created_at must be an ISO timestamp");
+  const canonical = parsed.toISOString();
+  if (value !== canonical && value !== canonical.replace(".000Z", "Z")) {
+    throw new Error("created_at must be a canonical ISO timestamp");
+  }
+  return value;
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(value: Record<string, unknown>, expected: readonly string[]): void {
+  const actual = Object.keys(value).sort();
+  const sortedExpected = [...expected].sort();
+  if (JSON.stringify(actual) !== JSON.stringify(sortedExpected)) {
+    throw new Error("exact review bundle contains unexpected manifest fields");
+  }
+}
+
+function stringValue(value: unknown, label: string): string {
+  if (typeof value !== "string" || !value) throw new Error(`${label} must be a string`);
+  return value;
+}
+
+function numberValue(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) throw new Error(`${label} is invalid`);
+  return value;
+}
+
+function nullableNumber(value: unknown, label: string): number | null {
+  if (value === null) return null;
+  return numberValue(value, label);
+}
+
+function booleanValue(value: unknown, label: string): boolean {
+  if (typeof value !== "boolean") throw new Error(`${label} must be boolean`);
+  return value;
+}
+
+function positiveInteger(value: number, label: string): void {
+  if (!Number.isInteger(value) || value < 1) throw new Error(`${label} is invalid`);
+}
+
+function nullablePositiveInteger(value: number | null, label: string): void {
+  if (value !== null) positiveInteger(value, label);
+}
+
+function sha256(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}

--- a/test/clawsweeper-action-ledger.test.ts
+++ b/test/clawsweeper-action-ledger.test.ts
@@ -87,6 +87,32 @@ test("explicit action ledger finalization keeps flush failure strict", async () 
   );
 });
 
+test("action event import rejects an invalid expected producer run ID", async () => {
+  await assert.rejects(
+    main([
+      "publish-action-events",
+      "--expected-producer-job",
+      "event-review-apply",
+      "--expected-producer-run-id",
+      "not-a-run",
+    ]),
+    /expected-producer-run-id must be a numeric workflow run ID/,
+  );
+});
+
+test("action event import rejects an invalid expected producer SHA", async () => {
+  await assert.rejects(
+    main([
+      "publish-action-events",
+      "--expected-producer-job",
+      "event-review-apply",
+      "--expected-producer-sha",
+      "not-a-sha",
+    ]),
+    /expected-producer-sha must be a lowercase commit SHA/,
+  );
+});
+
 test("review and apply outcome classifiers cover terminal and resumable states", () => {
   assert.deepEqual(actionLedgerFailureDisposition(new Error("worker timed out after 30s")), {
     status: "failed",
@@ -759,8 +785,7 @@ test("sweep publishes complete immutable shards for every review and apply produ
     "Publish selected review comment action ledger",
     "Publish failed-review retry action ledger",
     "Finalize exact event action ledger",
-    "Publish exact event action ledger",
-    "Publish late command status action ledger",
+    "Publish exact review action ledger",
     "Finalize apply proof action ledger",
     "Publish apply proof action events",
     "Publish apply action events",

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2205,6 +2205,7 @@ test("sweep workflow executes only durable queue leases without runner-side admi
   assert.match(legacyIntakeBlock, /statusCommentId: payload\.status_comment_id/);
   assert.match(legacyIntakeBlock, /additionalPrompt: payload\.additional_prompt/);
   assert.match(eventReviewBlock, /cancel-in-progress: false/);
+  assert.match(exactReviewStep, /--skip-start-comment/);
   assert.ok(claimIndex >= 0);
   assert.ok(setupPnpmIndex > claimIndex);
   assert.ok(inProgressStatusIndex > setupPnpmIndex);

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2198,6 +2198,9 @@ test("sweep workflow executes only durable queue leases without runner-side admi
   assert.match(legacyIntakeBlock, /\/internal\/exact-review\/enqueue/);
   assert.match(legacyIntakeBlock, /x-clawsweeper-exact-review-signature/);
   assert.match(legacyIntakeBlock, /CLAWSWEEPER_WEBHOOK_SECRET/);
+  assert.match(legacyIntakeBlock, /gh api "repos\/\$target_repo" --jq \.default_branch/);
+  assert.match(legacyIntakeBlock, /targetBranch: process\.env\.TARGET_BRANCH/);
+  assert.doesNotMatch(legacyIntakeBlock, /targetBranch: payload\.target_branch \|\| "main"/);
   assert.match(legacyIntakeBlock, /commandStatusMarker: payload\.command_status_marker/);
   assert.match(legacyIntakeBlock, /statusCommentId: payload\.status_comment_id/);
   assert.match(legacyIntakeBlock, /additionalPrompt: payload\.additional_prompt/);

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2157,7 +2157,7 @@ test("sweep workflow executes only durable queue leases without runner-side admi
   );
   const eventReviewBlock = workflow.slice(
     workflow.indexOf("\n  event-review-apply:"),
-    workflow.indexOf("\n  plan:"),
+    workflow.indexOf("\n  event-review-publish:"),
   );
   const claimIndex = eventReviewBlock.indexOf("- name: Claim exact-review queue lease");
   const setupPnpmIndex = eventReviewBlock.indexOf("- uses: ./.github/actions/setup-pnpm");
@@ -2166,10 +2166,14 @@ test("sweep workflow executes only durable queue leases without runner-side admi
   );
   const setupCodexIndex = eventReviewBlock.indexOf("- uses: ./.github/actions/setup-codex");
   const exactReviewIndex = eventReviewBlock.indexOf("- name: Review exact event item");
-  const primaryResultIndex = eventReviewBlock.indexOf("- name: Export exact review primary result");
-  const failReviewIndex = eventReviewBlock.indexOf("- name: Fail unsuccessful exact review");
+  const primaryResultIndex = eventReviewBlock.indexOf(
+    "- name: Export exact review generation result",
+  );
+  const failReviewIndex = eventReviewBlock.indexOf(
+    "- name: Fail unsuccessful exact review generation",
+  );
   const completeLeaseIndex = eventReviewBlock.indexOf("- name: Complete exact-review queue lease");
-  const publishLedgerIndex = eventReviewBlock.indexOf("- name: Publish exact event action ledger");
+  const uploadBundleIndex = eventReviewBlock.indexOf("- name: Upload exact review artifact bundle");
   const claimStep = eventReviewBlock.slice(
     claimIndex,
     eventReviewBlock.indexOf("\n      - ", claimIndex + 1),
@@ -2179,10 +2183,10 @@ test("sweep workflow executes only durable queue leases without runner-side admi
     eventReviewBlock.indexOf("\n      - ", completeLeaseIndex + 1),
   );
   const primaryResultStep = eventReviewBlock.slice(primaryResultIndex, completeLeaseIndex);
-  const failReviewStep = eventReviewBlock.slice(failReviewIndex, publishLedgerIndex);
+  const failReviewStep = eventReviewBlock.slice(failReviewIndex);
   const exactReviewStep = eventReviewBlock.slice(
     exactReviewIndex,
-    eventReviewBlock.indexOf("- name: Create state token", exactReviewIndex),
+    eventReviewBlock.indexOf("- name: Create exact review artifact bundle", exactReviewIndex),
   );
 
   assert.match(
@@ -2204,10 +2208,15 @@ test("sweep workflow executes only durable queue leases without runner-side admi
   assert.ok(setupCodexIndex > inProgressStatusIndex);
   assert.ok(exactReviewIndex > setupCodexIndex);
   assert.ok(primaryResultIndex > exactReviewIndex);
-  assert.equal(eventReviewBlock.match(/- name: Fail unsuccessful exact review/g)?.length, 1);
+  assert.equal(
+    eventReviewBlock.match(/- name: Fail unsuccessful exact review generation/g)?.length,
+    1,
+  );
+  assert.ok(uploadBundleIndex > exactReviewIndex);
+  assert.ok(primaryResultIndex > uploadBundleIndex);
   assert.ok(completeLeaseIndex > primaryResultIndex);
   assert.ok(failReviewIndex > completeLeaseIndex);
-  assert.ok(publishLedgerIndex > failReviewIndex);
+  assert.doesNotMatch(eventReviewBlock, /\.github\/actions\/setup-state/);
   assert.match(eventReviewBlock, /\/internal\/exact-review\/claim/);
   assert.match(eventReviewBlock, /\/internal\/exact-review\/complete/);
   assert.match(claimStep, /RUN_ATTEMPT: \$\{\{ github\.run_attempt \}\}/);
@@ -2218,16 +2227,15 @@ test("sweep workflow executes only durable queue leases without runner-side admi
   assert.match(claimStep, /response\.protocol_version \|\| 1/);
   assert.match(claimStep, /const legacyDecision = \{/);
   assert.match(claimStep, /run_attempt: runAttempt/);
-  assert.match(failReviewStep, /steps\.review-exact-event-item\.outcome != 'success'/);
-  assert.match(failReviewStep, /steps\.publish-event-result\.outcome != 'success'/);
-  assert.match(failReviewStep, /steps\.route-synced-verdict\.outcome != 'success'/);
-  assert.match(primaryResultStep, /PRIMARY_JOB_STATUS: \$\{\{ job\.status \}\}/);
-  assert.doesNotMatch(primaryResultStep, /JOB_CANCELLED|\$\{\{ cancelled\(\) \}\}/);
-  assert.match(primaryResultStep, /PRIMARY_JOB_STATUS" = "cancelled"/);
+  assert.match(failReviewStep, /exact-review-generation-result\.outputs\.outcome != 'success'/);
+  assert.match(failReviewStep, /complete-exact-review-queue\.outcome != 'success'/);
+  assert.match(primaryResultStep, /REVIEW_OUTCOME:/);
+  assert.match(primaryResultStep, /PUBLICATION_QUEUE_OUTCOME:/);
+  assert.match(primaryResultStep, /REVIEW_OUTCOME" = "cancelled"/);
   assert.match(primaryResultStep, /echo "outcome=\$outcome" >> "\$GITHUB_OUTPUT"/);
   assert.match(
     completeLeaseStep,
-    /PRIMARY_OUTCOME: \$\{\{ steps\.exact-review-primary-result\.outputs\.outcome \|\| 'failure' \}\}/,
+    /PRIMARY_OUTCOME: \$\{\{ steps\.exact-review-generation-result\.outputs\.outcome \|\| 'failure' \}\}/,
   );
   assert.doesNotMatch(completeLeaseStep, /JOB_STATUS:/);
   assert.match(completeLeaseStep, /if: \$\{\{ always\(\) \}\}/);
@@ -2515,7 +2523,7 @@ test("sweep target write tokens can merge pull requests", () => {
     .slice(1)
     .map((block) => block.split("\n      - ")[0]);
 
-  assert.equal(targetWriteTokenBlocks.length, 3);
+  assert.equal(targetWriteTokenBlocks.length, 4);
   for (const block of targetWriteTokenBlocks) {
     assert.match(block, /permission-contents: write/);
     assert.match(block, /permission-pull-requests: write/);
@@ -2575,8 +2583,8 @@ test("sweep review recovery uses explicit failed shard artifacts", () => {
   assert.match(recoveryJob, /iconv -f UTF-8 -t UTF-8 -c/);
   assert.doesNotMatch(recoveryJob, /workflow run sweep\.yml/);
   assert.doesNotMatch(recoveryJob, /repos\/\$GITHUB_REPOSITORY\/dispatches/);
-  assert.match(eventReviewJob, /RECOVERY_TARGET_BRANCH:/);
-  assert.match(eventReviewJob, /RECOVERY_TARGET_BRANCH:-\$\(gh api/);
+  assert.match(eventReviewJob, /CLAIM_TARGET_BRANCH:/);
+  assert.match(eventReviewJob, /target_branch="\$CLAIM_TARGET_BRANCH"/);
   assert.match(eventReviewJob, /REVIEW_ONLY:/);
   assert.match(
     eventReviewJob,
@@ -2590,19 +2598,13 @@ test("sweep review recovery uses explicit failed shard artifacts", () => {
     eventReviewJob,
     /Queue deferred exact verdict router[\s\S]*sourceAction != 'failed_review_shard_recovery'/,
   );
-  assert.match(
-    eventReviewJob,
-    /Fail unsuccessful exact review[\s\S]*sourceAction != 'failed_review_shard_recovery'/,
-  );
+  assert.match(eventReviewJob, /Export exact review publication result[\s\S]*REVIEW_ONLY:/);
   assert.match(
     eventReviewJob,
     /React to target item completion[\s\S]*sourceAction == 'failed_review_shard_recovery'/,
   );
   assert.match(eventReviewJob, /\[ "\$REVIEW_ONLY" != "true" \]/);
-  assert.match(
-    eventReviewJob,
-    /Export exact review primary result[\s\S]*REVIEW_ONLY:[\s\S]*\[ "\$REVIEW_ONLY" = "true" \]/,
-  );
+  assert.match(eventReviewJob, /\[ "\$REVIEW_ONLY" = "true" \]/);
   assert.match(publishEventResult, /reviewOnly: process\.env\.REVIEW_ONLY === "true"/);
   assert.match(
     publishEventResult,

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -2568,7 +2568,7 @@ test("exact-review queue can use the global capacity for one target", async () =
   }
 });
 
-test("exact-review queue keeps publication artifacts durable and admits one publisher", async () => {
+test("exact-review queue keeps publication artifacts durable outside review capacity", async () => {
   const originalFetch = globalThis.fetch;
   const storage = new MemoryDurableStorage();
   const dispatched: Record<string, unknown>[] = [];
@@ -2598,8 +2598,8 @@ test("exact-review queue keeps publication artifacts durable and admits one publ
       {
         CLAWSWEEPER_APP_CLIENT_ID: "Iv23test",
         CLAWSWEEPER_APP_PRIVATE_KEY: privateKey,
-        EXACT_REVIEW_QUEUE_MAX_CONCURRENT: "5",
-        EXACT_REVIEW_TARGET_MAX_CONCURRENT: "5",
+        EXACT_REVIEW_QUEUE_MAX_CONCURRENT: "4",
+        EXACT_REVIEW_TARGET_MAX_CONCURRENT: "4",
       },
     );
     await queue.fetch(

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -2282,9 +2282,17 @@ test("exact-review claims advance generations only for newer run attempts", asyn
   assert.equal(firstPayload.claim_generation, 1);
   assert.equal(firstPayload.lease_revision, 1);
 
+  const beforeReplay = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { leaseExpiresAt: number }>;
+  };
+  beforeReplay.items["openclaw/openclaw#621"].leaseExpiresAt = Date.now() + 1_000;
+  await storage.put("exact-review-queue", beforeReplay);
+
   const replay = await claim(1);
   assert.equal(replay.status, 200);
   assert.deepEqual(await replay.json(), firstPayload);
+  const afterReplay = (await storage.get("exact-review-queue")) as typeof beforeReplay;
+  assert.ok(afterReplay.items["openclaw/openclaw#621"].leaseExpiresAt - Date.now() > 120 * 60_000);
 
   const nextAttempt = await claim(2);
   assert.equal(nextAttempt.status, 200);
@@ -2554,6 +2562,182 @@ test("exact-review queue can use the global capacity for one target", async () =
         ),
       ).size,
       1,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("exact-review queue keeps publication artifacts durable and admits one publisher", async () => {
+  const originalFetch = globalThis.fetch;
+  const storage = new MemoryDurableStorage();
+  const dispatched: Record<string, unknown>[] = [];
+  const { privateKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  });
+  globalThis.fetch = async (input, init) => {
+    const url = new URL(String(input));
+    if (url.pathname === "/repos/openclaw/clawsweeper/actions/workflows/sweep.yml")
+      return jsonResponse({ state: "active" });
+    if (url.pathname === "/repos/openclaw/clawsweeper/installation")
+      return jsonResponse({ id: 999 });
+    if (url.pathname === "/app/installations/999/access_tokens")
+      return jsonResponse(Object.fromEntries([["token", "t"]]));
+    if (url.pathname === "/repos/openclaw/clawsweeper/dispatches") {
+      dispatched.push(JSON.parse(String(init?.body)));
+      return new Response(null, { status: 204 });
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  };
+
+  try {
+    const queue = new ExactReviewQueue(
+      { storage },
+      {
+        CLAWSWEEPER_APP_CLIENT_ID: "Iv23test",
+        CLAWSWEEPER_APP_PRIVATE_KEY: privateKey,
+        EXACT_REVIEW_QUEUE_MAX_CONCURRENT: "5",
+        EXACT_REVIEW_TARGET_MAX_CONCURRENT: "5",
+      },
+    );
+    await queue.fetch(
+      buildExactReviewQueueRequest(
+        "publisher:100:1",
+        801,
+        "exact_review_artifact_publish",
+        "issue",
+        "openclaw/gogcli",
+        exactReviewPublicationOverrides(801, "100"),
+      ),
+    );
+    await queue.fetch(
+      buildExactReviewQueueRequest(
+        "publisher:101:1",
+        802,
+        "exact_review_artifact_publish",
+        "issue",
+        "openclaw/gogcli",
+        exactReviewPublicationOverrides(802, "101"),
+      ),
+    );
+    await queue.fetch(
+      buildExactReviewQueueRequest(
+        "publisher:102:1",
+        803,
+        "exact_review_artifact_publish",
+        "issue",
+        "openclaw/gogcli",
+        exactReviewPublicationOverrides(803, "102"),
+      ),
+    );
+    await queue.fetch(
+      buildExactReviewQueueRequest(
+        "publisher:103:1",
+        804,
+        "exact_review_artifact_publish",
+        "issue",
+        "openclaw/gogcli",
+        exactReviewPublicationOverrides(804, "103", "failed_review_shard_recovery"),
+      ),
+    );
+    await queue.fetch(buildExactReviewQueueRequest("ordinary-801", 801, "edited"));
+    await queue.fetch(buildExactReviewQueueRequest("ordinary-803", 803, "edited"));
+
+    const state = (await storage.get("exact-review-queue")) as {
+      items: Record<
+        string,
+        {
+          createdAt: number;
+          decision: Record<string, unknown>;
+          leaseDecision?: Record<string, unknown>;
+          leaseExpiresAt?: number;
+          leaseId?: string;
+          leaseRevision?: number;
+          nextAttemptAt: number;
+          revision: number;
+          state: string;
+        }
+      >;
+    };
+    assert.deepEqual(Object.keys(state.items).sort(), [
+      "openclaw/gogcli#801",
+      "openclaw/gogcli#801@publish:100:1",
+      "openclaw/gogcli#802@publish:101:1",
+      "openclaw/gogcli#803",
+      "openclaw/gogcli#803@publish:102:1",
+      "openclaw/gogcli#804@publish:103:1",
+    ]);
+    state.items["openclaw/gogcli#802@publish:101:1"].createdAt =
+      Date.now() - 81 * 24 * 60 * 60 * 1000;
+    state.items["openclaw/gogcli#802@publish:101:1"].nextAttemptAt = Date.now() - 1;
+    state.items["openclaw/gogcli#803@publish:102:1"].createdAt =
+      Date.now() - 81 * 24 * 60 * 60 * 1000;
+    state.items["openclaw/gogcli#803@publish:102:1"].nextAttemptAt = Date.now() - 1;
+    state.items["openclaw/gogcli#804@publish:103:1"].createdAt =
+      Date.now() - 81 * 24 * 60 * 60 * 1000;
+    state.items["openclaw/gogcli#804@publish:103:1"].nextAttemptAt = Date.now() - 1;
+    const activeFreshReview = state.items["openclaw/gogcli#803"];
+    activeFreshReview.state = "leased";
+    activeFreshReview.decision = {
+      ...activeFreshReview.decision,
+      additionalPrompt: "newer maintainer context",
+    };
+    activeFreshReview.revision = 4;
+    activeFreshReview.leaseId = "lease-fresh-803";
+    activeFreshReview.leaseRevision = 4;
+    activeFreshReview.leaseDecision = { ...activeFreshReview.decision };
+    activeFreshReview.leaseExpiresAt = Date.now() + 60_000;
+    const activeFreshReviewBeforeExpiry = structuredClone(activeFreshReview);
+    await storage.put("exact-review-queue", state);
+
+    await queue.alarm();
+    const sourceActions = dispatched.map((payload) =>
+      String((payload.client_payload as Record<string, unknown>).source_action),
+    );
+    assert.equal(
+      sourceActions.filter((action) => action === "exact_review_artifact_publish").length,
+      1,
+    );
+    assert.equal(sourceActions.filter((action) => action === "edited").length, 1);
+    assert.equal(
+      sourceActions.filter((action) => action === "artifact_retention_recovery").length,
+      1,
+    );
+    assert.equal(
+      sourceActions.filter((action) => action === "failed_review_shard_recovery").length,
+      1,
+    );
+    assert.equal(
+      dispatched.some(
+        (payload) =>
+          Number((payload.client_payload as Record<string, unknown>).item_number) === 803,
+      ),
+      false,
+    );
+    const afterExpiry = (await storage.get("exact-review-queue")) as typeof state;
+    assert.deepEqual(afterExpiry.items["openclaw/gogcli#803"], activeFreshReviewBeforeExpiry);
+    assert.equal(afterExpiry.items["openclaw/gogcli#803@publish:102:1"], undefined);
+    const reservedPublisher = afterExpiry.items["openclaw/gogcli#801@publish:100:1"];
+    assert.equal(reservedPublisher.state, "dispatching");
+    assert.ok((reservedPublisher.leaseExpiresAt ?? 0) - Date.now() > 6 * 24 * 60 * 60_000);
+    const publicationPayload = dispatched.find(
+      (payload) =>
+        (payload.client_payload as Record<string, unknown>).source_action ===
+        "exact_review_artifact_publish",
+    )?.client_payload as Record<string, unknown>;
+    assert.match(
+      String((publicationPayload.queue_claim as Record<string, unknown>).item_key),
+      /@publish:/,
+    );
+    assert.ok(
+      (
+        (publicationPayload.review_options as Record<string, unknown>).publication as Record<
+          string,
+          unknown
+        >
+      ).producerDecision,
     );
   } finally {
     globalThis.fetch = originalFetch;
@@ -7982,6 +8166,39 @@ function buildExactReviewQueueRequest(
       },
     }),
   });
+}
+
+function exactReviewPublicationOverrides(
+  itemNumber: number,
+  producerRunId: string,
+  producerSourceAction = "opened",
+) {
+  const producerDecision = {
+    targetRepo: "openclaw/gogcli",
+    targetBranch: "main",
+    itemNumber,
+    itemKind: "issue",
+    sourceEvent: "issues",
+    sourceAction: producerSourceAction,
+    supersedesInProgress: false,
+  };
+  return {
+    publication: {
+      artifactName: `exact-review-${producerRunId}-1`,
+      producerRunId,
+      producerRunAttempt: 1,
+      sourceSha: "a".repeat(40),
+      itemKey: `openclaw/gogcli#${itemNumber}`,
+      protocolVersion: 2,
+      leaseRevision: 1,
+      claimGeneration: 1,
+      liveProceeded: true,
+      liveTerminalNoop: false,
+      liveTerminalMissing: false,
+      liveGuardedOpen: false,
+      producerDecision,
+    },
+  };
 }
 
 function leasedExactReviewQueueItem(itemNumber: number, runId: string, runAttempt = 1) {

--- a/test/repair/command-ops-action-ledger.test.ts
+++ b/test/repair/command-ops-action-ledger.test.ts
@@ -76,32 +76,39 @@ test("direct repair requeues forward a stable dispatch receipt and publish it", 
   assert.match(workflow, /--max-requeue-depth 1/);
 });
 
-test("exact review publishes status receipts created after its first ledger publication", () => {
+test("exact review publisher includes command status receipts after the status mutation", () => {
   const setupAction = readText(".github/actions/setup-action-ledger/action.yml");
   const source = readText("src/repair/update-command-status.ts");
   const workflow = readText(".github/workflows/sweep.yml");
-  const sourceDriftStatus = workflow.indexOf("- name: Mark source-drift re-review queued");
-  const lateFinalize = workflow.indexOf("- name: Finalize late command status action ledger");
-  const latePublish = workflow.indexOf("- name: Publish late command status action ledger");
-  const targetFanout = workflow.indexOf("\n  target-fanout:", latePublish);
-  const finalizeStep = workflow.slice(lateFinalize, latePublish);
-  const publishStep = workflow.slice(latePublish, targetFanout);
+  const publisherJob = workflow.indexOf("\n  event-review-publish:");
+  const statusMutation = workflow.indexOf("- name: Mark re-review complete", publisherJob);
+  const ledgerPublish = workflow.indexOf(
+    "- name: Publish exact review action ledger",
+    publisherJob,
+  );
+  const nextStep = workflow.indexOf(
+    "- name: Release unsuccessful publisher-owned review lease",
+    ledgerPublish,
+  );
+  const publishStep = workflow.slice(ledgerPublish, nextStep);
 
-  assert.ok(sourceDriftStatus >= 0);
-  assert.ok(lateFinalize > sourceDriftStatus);
-  assert.ok(latePublish > lateFinalize);
-  assert.ok(targetFanout > latePublish);
+  assert.ok(publisherJob >= 0);
+  assert.ok(statusMutation > publisherJob);
+  assert.ok(ledgerPublish > statusMutation);
+  assert.ok(nextStep > ledgerPublish);
   assert.match(setupAction, /CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT=\$output_root/);
   assert.match(source, /await flushCommandActionEvents\(\)/);
   assert.match(
     publishStep,
-    /if: \$\{\{ always\(\) && steps\.setup-state\.outcome == 'success' && steps\.setup-pnpm\.outcome == 'success' && steps\.publish-event-result\.outputs\.requeue_latest == 'true' && steps\.complete-exact-review-queue\.outcome == 'success' \}\}/,
+    /if: \$\{\{ always\(\) && steps\.setup-state\.outcome == 'success' \}\}/,
   );
-  assertCommandFinalizerUsesCanonicalRoot(finalizeStep);
-  assertCommandPublisherUsesCanonicalRoot(publishStep);
-  assert.match(finalizeStep, /--lane late-command-status/);
-  assert.match(publishStep, /--lane late-command-status/);
-  assert.match(publishStep, /--message "chore: append command status action ledger"/);
+  assert.match(publishStep, /continue-on-error: true/);
+  assert.match(publishStep, /source_root="\.artifacts\/exact-review-bundle\/action-ledger"/);
+  assert.match(publishStep, /CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT:-/);
+  assert.match(publishStep, /publisher_ledger_root\/ledger/);
+  assert.match(publishStep, /--expected-producer-job "\$GITHUB_JOB"/);
+  assert.match(publishStep, /sort -u -o "\$event_paths_file" "\$event_paths_file"/);
+  assert.match(publishStep, /--message "chore: append exact review action ledger"/);
 });
 
 function assertCommandFinalizerUsesCanonicalRoot(step: string): void {

--- a/test/repair/exact-review-bundle.test.ts
+++ b/test/repair/exact-review-bundle.test.ts
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+import {
+  createExactReviewBundle,
+  exactReviewDecisionSha256,
+  validateExactReviewBundle,
+  type ExactReviewBundleContext,
+} from "../../dist/repair/exact-review-bundle.js";
+
+function fixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-exact-review-"));
+  const report = path.join(root, "42.md");
+  const ledgerRoot = path.join(root, "ledger-root");
+  const ledger = path.join(
+    ledgerRoot,
+    "ledger/v1/events/2026/07/15/openclaw/openclaw/events.jsonl",
+  );
+  fs.writeFileSync(report, "# Review\n\nVerified.\n");
+  fs.mkdirSync(path.dirname(ledger), { recursive: true });
+  fs.writeFileSync(ledger, '{"schema_version":1}\n');
+  const context: ExactReviewBundleContext = {
+    repository: "openclaw/clawsweeper",
+    sourceSha: "a".repeat(40),
+    runId: "29380556291",
+    runAttempt: 2,
+    producerJob: "event-review-apply",
+    decisionSha256: exactReviewDecisionSha256(
+      JSON.stringify({
+        targetRepo: "openclaw/openclaw",
+        targetBranch: "main",
+        itemNumber: 42,
+        itemKind: "issue",
+      }),
+    ),
+    targetRepo: "openclaw/openclaw",
+    targetBranch: "main",
+    itemNumber: 42,
+    itemKind: "issue",
+    itemKey: "openclaw/openclaw#42",
+    protocolVersion: 2,
+    leaseRevision: 7,
+    claimGeneration: 3,
+    liveProceeded: true,
+    liveTerminalNoop: false,
+    liveTerminalMissing: false,
+    liveGuardedOpen: false,
+  };
+  return { root, report, ledgerRoot, bundleDir: path.join(root, "bundle"), context };
+}
+
+test("exact review bundle binds immutable workflow and queue context", () => {
+  const value = fixture();
+  const created = createExactReviewBundle({
+    bundleDir: value.bundleDir,
+    reviewPath: value.report,
+    actionLedgerRoot: value.ledgerRoot,
+    createdAt: "2026-07-15T12:00:00Z",
+    context: value.context,
+  });
+  const validated = validateExactReviewBundle(value.bundleDir, value.context);
+
+  assert.deepEqual(validated, created);
+  assert.equal(validated.review.artifact_present, true);
+  assert.deepEqual(
+    validated.files.map((file) => file.path),
+    ["action-ledger/ledger/v1/events/2026/07/15/openclaw/openclaw/events.jsonl", "review/42.md"],
+  );
+});
+
+test("exact review bundle rejects redirected and modified publication", () => {
+  const value = fixture();
+  createExactReviewBundle({
+    bundleDir: value.bundleDir,
+    reviewPath: value.report,
+    actionLedgerRoot: value.ledgerRoot,
+    createdAt: "2026-07-15T12:00:00Z",
+    context: value.context,
+  });
+
+  assert.throws(
+    () =>
+      validateExactReviewBundle(value.bundleDir, {
+        ...value.context,
+        targetRepo: "openclaw/clawhub",
+        itemKey: "openclaw/clawhub#42",
+      }),
+    /trusted workflow context/,
+  );
+  fs.appendFileSync(path.join(value.bundleDir, "review/42.md"), "changed\n");
+  assert.throws(
+    () => validateExactReviewBundle(value.bundleDir, value.context),
+    /file inventory does not match/,
+  );
+});
+
+test("exact review bundle rejects extras and symlinks", () => {
+  const value = fixture();
+  createExactReviewBundle({
+    bundleDir: value.bundleDir,
+    reviewPath: value.report,
+    createdAt: "2026-07-15T12:00:00Z",
+    context: value.context,
+  });
+  fs.writeFileSync(path.join(value.bundleDir, "payload.sh"), "exit 0\n");
+  assert.throws(() => validateExactReviewBundle(value.bundleDir, value.context), /unexpected path/);
+
+  fs.rmSync(path.join(value.bundleDir, "payload.sh"));
+  fs.symlinkSync(value.report, path.join(value.bundleDir, "review", "43.md"));
+  assert.throws(
+    () => validateExactReviewBundle(value.bundleDir, value.context),
+    /must not contain symlinks/,
+  );
+});
+
+test("exact review decision digest ignores object key ordering", () => {
+  assert.equal(
+    exactReviewDecisionSha256('{"targetRepo":"openclaw/openclaw","itemNumber":42}'),
+    exactReviewDecisionSha256('{"itemNumber":42,"targetRepo":"openclaw/openclaw"}'),
+  );
+});
+
+test("exact review bundle requires a report after review proceeds", () => {
+  const value = fixture();
+  assert.throws(
+    () =>
+      createExactReviewBundle({
+        bundleDir: value.bundleDir,
+        createdAt: "2026-07-15T12:00:00Z",
+        context: value.context,
+      }),
+    /requires a review artifact/,
+  );
+});
+
+test("bundle validation uses the producer workflow identity across runs", () => {
+  const value = fixture();
+  createExactReviewBundle({
+    bundleDir: value.bundleDir,
+    reviewPath: value.report,
+    createdAt: "2026-07-15T12:00:00Z",
+    context: value.context,
+  });
+  const decision = JSON.stringify({
+    targetRepo: value.context.targetRepo,
+    targetBranch: value.context.targetBranch,
+    itemNumber: value.context.itemNumber,
+    itemKind: value.context.itemKind,
+  });
+  const result = spawnSync(
+    process.execPath,
+    ["dist/repair/exact-review-bundle-cli.js", "validate"],
+    {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GITHUB_REPOSITORY: value.context.repository,
+        GITHUB_RUN_ID: "99999999",
+        GITHUB_SHA: "b".repeat(40),
+        EXACT_REVIEW_BUNDLE_DIR: value.bundleDir,
+        EXACT_REVIEW_CLAIM_GENERATION: String(value.context.claimGeneration),
+        EXACT_REVIEW_DECISION: decision,
+        EXACT_REVIEW_GENERATION_ATTEMPT: String(value.context.runAttempt),
+        EXACT_REVIEW_ITEM_KEY: value.context.itemKey,
+        EXACT_REVIEW_ITEM_KIND: value.context.itemKind,
+        EXACT_REVIEW_ITEM_NUMBER: String(value.context.itemNumber),
+        EXACT_REVIEW_LEASE_REVISION: String(value.context.leaseRevision),
+        EXACT_REVIEW_LIVE_GUARDED_OPEN: String(value.context.liveGuardedOpen),
+        EXACT_REVIEW_LIVE_PROCEEDED: String(value.context.liveProceeded),
+        EXACT_REVIEW_LIVE_TERMINAL_MISSING: String(value.context.liveTerminalMissing),
+        EXACT_REVIEW_LIVE_TERMINAL_NOOP: String(value.context.liveTerminalNoop),
+        EXACT_REVIEW_PRODUCER_JOB: value.context.producerJob,
+        EXACT_REVIEW_PRODUCER_RUN_ID: value.context.runId,
+        EXACT_REVIEW_PROTOCOL_VERSION: String(value.context.protocolVersion),
+        EXACT_REVIEW_SOURCE_SHA: value.context.sourceSha,
+        EXACT_REVIEW_TARGET_BRANCH: value.context.targetBranch,
+        EXACT_REVIEW_TARGET_REPO: value.context.targetRepo,
+      },
+    },
+  );
+  assert.equal(result.status, 0, result.stderr);
+});

--- a/test/repair/workflow-sparse-checkout.test.ts
+++ b/test/repair/workflow-sparse-checkout.test.ts
@@ -82,7 +82,7 @@ test("repair comment router sparse checkout includes action ledger runtime", () 
   }
 });
 
-test("sweep workflow preserves manual target branches and hydrates exact branches live", () => {
+test("sweep workflow preserves one claimed target branch through exact review", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const dispatchTargetBranchResolver =
     /target_branch="\$\{\{ github\.event_name == 'workflow_dispatch' && github\.event\.inputs\.target_branch \|\| github\.event\.client_payload\.target_branch \|\| 'main' \}\}"/g;
@@ -97,8 +97,9 @@ test("sweep workflow preserves manual target branches and hydrates exact branche
   assert.equal([...workflow.matchAll(recoveryTargetBranch)].length, 1);
   assert.match(
     workflow,
-    /target_branch="\$\{RECOVERY_TARGET_BRANCH:-\$\(gh api "repos\/\$TARGET_REPO" --jq \.default_branch\)\}"/,
+    /CLAIM_TARGET_BRANCH: \$\{\{ fromJSON\(steps\.claim-exact-review-queue\.outputs\.decision\)\.targetBranch \}\}/,
   );
+  assert.match(workflow, /target_branch="\$CLAIM_TARGET_BRANCH"/);
   assert.match(workflow, /target_branch="\$\{\{ steps\.live-item\.outputs\.target_branch \}\}"/);
 });
 

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -256,6 +256,7 @@ test("review workflow gives Codex a read-only inspection token", () => {
   assert.match(reviewJob, /uses: \.\/clawsweeper\/\.github\/actions\/setup-codex/);
   assert.doesNotMatch(reviewJob, /uses: \.\/\.github\/actions\/setup-codex/);
   assert.match(exactReviewStep, /--codex-sandbox read-only/);
+  assert.match(exactReviewStep, /--skip-start-comment/);
   assert.match(reviewJob, /--codex-sandbox read-only/);
   assert.doesNotMatch(workflow, /--codex-sandbox danger-full-access/);
 });
@@ -270,7 +271,7 @@ test("review execution tokens can read check runs and commit statuses", () => {
   const scheduledReviewJob = workflow.slice(reviewStart, publishStart);
 
   for (const [job, tokenId] of [
-    [eventReviewJob, "target-write-token"],
+    [eventReviewJob, "target-read-token"],
     [scheduledReviewJob, "target-read-token"],
   ] as const) {
     const permissions = job.slice(job.indexOf("\n    permissions:"), job.indexOf("\n    steps:"));
@@ -285,7 +286,7 @@ test("review execution tokens can read check runs and commit statuses", () => {
   }
   assert.match(
     eventReviewJob,
-    /Review exact event item[\s\S]*GH_TOKEN: \$\{\{ steps\.target-write-token\.outputs\.token \}\}/,
+    /Review exact event item[\s\S]*GH_TOKEN: \$\{\{ steps\.target-read-token\.outputs\.token \}\}/,
   );
 });
 
@@ -367,6 +368,7 @@ test("exact event review hands immutable artifacts to one state publisher", () =
     step(reviewer, "Review exact event item").env?.GH_TOKEN,
     "${{ steps.target-read-token.outputs.token }}",
   );
+  assert.match(step(reviewer, "Review exact event item").run ?? "", /--skip-start-comment/);
 
   const create = step(reviewer, "Create exact review artifact bundle");
   const upload = step(reviewer, "Upload exact review artifact bundle");

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -26,6 +26,7 @@ test("ledger-producing jobs initialize immutable workflow context", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   for (const jobName of [
     "event-review-apply",
+    "event-review-publish",
     "review",
     "publish",
     "retry-failed-reviews",
@@ -95,6 +96,7 @@ test("review and apply primary boundaries ignore ledger-only failures", () => {
 
   for (const jobName of [
     "event-review-apply",
+    "event-review-publish",
     "review",
     "publish",
     "retry-failed-reviews",
@@ -118,24 +120,28 @@ test("review and apply primary boundaries ignore ledger-only failures", () => {
     );
   }
 
-  const exactPublish = step("event-review-apply", "Publish event result and apply safe close");
-  assert.match(exactPublish.if ?? "", /always\(\) && !cancelled\(\)/);
-  assert.match(exactPublish.if ?? "", /review-exact-event-item\.outcome == 'success'/);
-  assert.match(exactPublish.if ?? "", /setup-state\.outcome == 'success'/);
-  assert.doesNotMatch(exactPublish.if ?? "", /action-ledger/);
-  const exactPrimary = step("event-review-apply", "Export exact review primary result");
+  const exactBundle = step("event-review-apply", "Create exact review artifact bundle");
+  assert.match(exactBundle.if ?? "", /review-exact-event-item\.outcome == 'success'/);
+  assert.doesNotMatch(exactBundle.if ?? "", /action-ledger/);
+  const exactPrimary = step("event-review-apply", "Export exact review generation result");
   const exactQueue = step("event-review-apply", "Complete exact-review queue lease");
-  const exactLedger = step("event-review-apply", "Publish exact event action ledger");
+  const exactUpload = step("event-review-apply", "Upload exact review artifact bundle");
+  const exactPublicationQueue = step(
+    "event-review-apply",
+    "Queue durable exact review publication",
+  );
+  const exactLedger = step("event-review-publish", "Publish exact review action ledger");
   const exactSteps = job("event-review-apply").steps;
-  assert.equal(exactPrimary.env?.PRIMARY_JOB_STATUS, "${{ job.status }}");
-  assert.equal(exactPrimary.env?.JOB_CANCELLED, undefined);
   assert.match(exactPrimary.run ?? "", /outcome=(?:failure|cancelled|success)/);
-  assert.match(exactPrimary.run ?? "", /PRIMARY_JOB_STATUS.*cancelled/);
-  assert.match(exactPrimary.run ?? "", /PRIMARY_JOB_STATUS.*success/);
-  assert.match(exactQueue.env?.PRIMARY_OUTCOME ?? "", /exact-review-primary-result/);
+  assert.match(exactPrimary.run ?? "", /REVIEW_OUTCOME.*cancelled/);
+  assert.match(exactPrimary.run ?? "", /PUBLICATION_QUEUE_OUTCOME.*success/);
+  assert.match(exactQueue.env?.PRIMARY_OUTCOME ?? "", /exact-review-generation-result/);
   assert.doesNotMatch(exactQueue.run ?? "", /JOB_STATUS|job\.status/);
+  assert.ok(exactSteps.indexOf(exactUpload) < exactSteps.indexOf(exactQueue));
+  assert.ok(exactSteps.indexOf(exactUpload) < exactSteps.indexOf(exactPublicationQueue));
+  assert.ok(exactSteps.indexOf(exactPublicationQueue) < exactSteps.indexOf(exactQueue));
   assert.ok(exactSteps.indexOf(exactQueue) > exactSteps.indexOf(exactPrimary));
-  assert.ok(exactSteps.indexOf(exactLedger) > exactSteps.indexOf(exactQueue));
+  assert.match(exactLedger.run ?? "", /expected-producer-run-attempt/);
 
   const ledgerDownload = job("publish").steps.find(
     (candidate) => candidate.id === "download-review-action-ledger",
@@ -316,293 +322,161 @@ test("scheduled review shards receive the compiler-backed runtime artifact", () 
   assert.doesNotMatch(reviewJob, /npm pack "@typescript/);
 });
 
-test("exact event publish and routing require a successful fresh review artifact", () => {
-  const workflow = readText(".github/workflows/sweep.yml");
-  const routerWorkflow = readText(".github/workflows/repair-comment-router.yml");
-  const publisher = readText("src/repair/publish-event-result.ts");
-  const eventReviewJobStart = workflow.indexOf("\n  event-review-apply:");
-  const planJobStart = workflow.indexOf("\n  plan:", eventReviewJobStart);
-  const eventReviewJob = workflow.slice(eventReviewJobStart, planJobStart);
-  const liveItemStart = eventReviewJob.indexOf("- name: Check live target item state");
-  const setupPnpmStart = eventReviewJob.indexOf("- uses: ./.github/actions/setup-pnpm");
-  const setupCodexStart = eventReviewJob.indexOf("- uses: ./.github/actions/setup-codex");
-  const exactReviewStart = eventReviewJob.indexOf("- name: Review exact event item");
-  const publishStart = eventReviewJob.indexOf("- name: Publish event result and apply safe close");
-  const releaseUnsuccessfulStart = eventReviewJob.indexOf(
-    "- name: Release unsuccessful workflow-owned review lease",
-    publishStart,
+test("exact event review hands immutable artifacts to one state publisher", () => {
+  type Step = {
+    "continue-on-error"?: boolean;
+    name?: string;
+    uses?: string;
+    id?: string;
+    if?: string;
+    run?: string;
+    env?: Record<string, string>;
+    with?: Record<string, string | number | boolean>;
+  };
+  type Job = {
+    needs?: string | string[];
+    if?: string;
+    permissions?: Record<string, string>;
+    concurrency?: { group?: string; "cancel-in-progress"?: boolean; queue?: string };
+    steps: Step[];
+  };
+  const source = readText(".github/workflows/sweep.yml");
+  const workflow = YAML.parse(source) as { jobs: Record<string, Job> };
+  const reviewer = workflow.jobs["event-review-apply"]!;
+  const publisher = workflow.jobs["event-review-publish"]!;
+  const batchPublisher = workflow.jobs.publish!;
+  const step = (job: Job, name: string) => {
+    const value = job.steps.find((candidate) => candidate.name === name);
+    assert.ok(value, `missing step: ${name}`);
+    return value;
+  };
+
+  assert.equal(reviewer.permissions?.contents, "read");
+  assert.equal(reviewer.permissions?.issues, "read");
+  assert.equal(
+    reviewer.steps.some((candidate) => candidate.uses?.endsWith("/setup-state")),
+    false,
   );
-  const routeStart = eventReviewJob.indexOf("- name: Route synced ClawSweeper verdict");
-  const deferredRouteStart = eventReviewJob.indexOf(
-    "- name: Queue deferred exact verdict router",
-    routeStart,
+  assert.equal(
+    reviewer.steps.some(
+      (candidate) => candidate.name === "Publish event result and apply safe close",
+    ),
+    false,
   );
-  const reactStart = eventReviewJob.indexOf("- name: React to target item completion");
-  const primaryResultStart = eventReviewJob.indexOf("- name: Export exact review primary result");
-  const releaseLeaseStart = eventReviewJob.indexOf("- name: Release terminal review leases");
-  const confirmTerminalStart = eventReviewJob.indexOf(
-    "- name: Confirm terminal item remains closed",
-  );
-  const completeStart = eventReviewJob.indexOf("- name: Mark re-review complete", routeStart);
-  const failStart = eventReviewJob.indexOf("- name: Fail unsuccessful exact review");
-  const leaseCompleteStart = eventReviewJob.indexOf("- name: Complete exact-review queue lease");
-  const exactLedgerStart = eventReviewJob.indexOf("- name: Publish exact event action ledger");
-  const liveItemStep = eventReviewJob.slice(liveItemStart, setupPnpmStart);
-  const setupCodexStep = eventReviewJob.slice(setupCodexStart, exactReviewStart);
-  const exactReviewStep = eventReviewJob.slice(exactReviewStart, publishStart);
-  const publishStep = eventReviewJob.slice(publishStart, releaseUnsuccessfulStart);
-  const releaseUnsuccessfulStep = eventReviewJob.slice(releaseUnsuccessfulStart, routeStart);
-  const routeStep = eventReviewJob.slice(routeStart, deferredRouteStart);
-  const deferredRouteStep = eventReviewJob.slice(deferredRouteStart, releaseLeaseStart);
-  const reactStep = eventReviewJob.slice(reactStart, primaryResultStart);
-  const releaseLeaseStep = eventReviewJob.slice(releaseLeaseStart, confirmTerminalStart);
-  const confirmTerminalStep = eventReviewJob.slice(confirmTerminalStart, completeStart);
-  const failStep = eventReviewJob.slice(failStart, exactLedgerStart);
-  const publisherCompleteStart = publisher.indexOf("const complete =");
-  const authoritativeReset = publisher.indexOf("hardResetToRemoteMain();", publisherCompleteStart);
-  const authoritativeRefresh = publisher.indexOf(
-    "refreshSourceAfterStatePublish(commitPaths, stateBaseCommit);",
-    publisherCompleteStart,
-  );
-  const finalTupleMatch = publisher.indexOf(
-    "eventSnapshotMatchesCurrent(paths)",
-    publisherCompleteStart,
+  assert.equal(
+    step(reviewer, "Review exact event item").env?.GH_TOKEN,
+    "${{ steps.target-read-token.outputs.token }}",
   );
 
-  assert.ok(liveItemStart > 0);
-  assert.ok(setupPnpmStart > liveItemStart);
-  assert.ok(deferredRouteStart > routeStart);
-  assert.ok(releaseLeaseStart > routeStart);
-  assert.ok(confirmTerminalStart > releaseLeaseStart);
-  assert.ok(leaseCompleteStart > primaryResultStart);
-  assert.ok(failStart > leaseCompleteStart);
-  assert.ok(exactLedgerStart > failStart);
-  assert.match(liveItemStep, /id: live-item/);
-  assert.match(liveItemStep, /repos\/\$TARGET_REPO\/issues\/\$ITEM_NUMBER/);
-  assert.match(liveItemStep, /echo "proceed=false" >> "\$GITHUB_OUTPUT"/);
-  assert.match(liveItemStep, /grep -Eqi 'HTTP 404\|Not Found'/);
-  assert.match(liveItemStep, /gh api "repos\/\$TARGET_REPO" >\/dev\/null/);
-  assert.match(liveItemStep, /echo "terminal_missing=true" >> "\$GITHUB_OUTPUT"/);
-  assert.match(liveItemStep, /repository is accessible but the item is missing/);
-  assert.match(liveItemStep, /cat "\$live_item_error" >&2/);
-  assert.match(liveItemStep, /live_locked=.*\.locked == true/);
-  assert.match(liveItemStep, /echo "guarded_open=true" >> "\$GITHUB_OUTPUT"/);
-  assert.match(
-    liveItemStep,
-    /echo "guarded_open_action=skipped_locked_conversation" >> "\$GITHUB_OUTPUT"/,
+  const create = step(reviewer, "Create exact review artifact bundle");
+  const upload = step(reviewer, "Upload exact review artifact bundle");
+  const queuePublication = step(reviewer, "Queue durable exact review publication");
+  const complete = step(reviewer, "Complete exact-review queue lease");
+  const releaseGeneration = step(reviewer, "Release unsuccessful workflow-owned review lease");
+  assert.match(create.if ?? "", /review-exact-event-item\.outcome == 'success'/);
+  assert.match(create.if ?? "", /review-exact-event-item\.outputs\.retry_at == ''/);
+  assert.equal(create.env?.EXACT_REVIEW_PRODUCER_JOB, "event-review-apply");
+  assert.equal(
+    create.env?.EXACT_REVIEW_DECISION,
+    "${{ steps.claim-exact-review-queue.outputs.decision }}",
   );
-  assert.match(liveItemStep, /without Codex because the open conversation is locked/);
-  assert.match(
-    eventReviewJob,
-    /- uses: \.\/\.github\/actions\/setup-pnpm\s+id: setup-pnpm\s+if: \$\{\{ steps\.live-item\.outputs\.proceed == 'true' \|\| \(\(steps\.live-item\.outputs\.terminal_noop == 'true' \|\| steps\.live-item\.outputs\.terminal_missing == 'true' \|\| steps\.live-item\.outputs\.guarded_open == 'true'\)/,
+  assert.match(create.run ?? "", /mkdir -p \.artifacts/);
+  assert.ok(
+    (create.run ?? "").indexOf("mkdir -p .artifacts") <
+      (create.run ?? "").indexOf("exact-review-bundle -- create"),
   );
-  assert.match(setupCodexStep, /if: \$\{\{ steps\.live-item\.outputs\.proceed == 'true' \}\}/);
-  assert.match(exactReviewStep, /if: \$\{\{ steps\.live-item\.outputs\.proceed == 'true' \}\}/);
+  assert.equal(upload.uses, "actions/upload-artifact@v7");
+  assert.equal(upload.with?.["retention-days"], 90);
+  assert.match(queuePublication.run ?? "", /for attempt in 1 2 3/);
+  assert.match(queuePublication.run ?? "", /\.queued == true or \.deduped == true/);
+  assert.match(complete.env?.PRIMARY_OUTCOME ?? "", /exact-review-generation-result/);
+  assert.match(releaseGeneration.run ?? "", /content == "eyes"/);
+  assert.ok(reviewer.steps.indexOf(upload) < reviewer.steps.indexOf(complete));
+
+  assert.equal(publisher.needs, undefined);
+  assert.match(publisher.if ?? "", /source_action == 'exact_review_artifact_publish'/);
   assert.match(
-    publishStep,
-    /if: \$\{\{ always\(\) && !cancelled\(\) && steps\.review-exact-event-item\.outcome == 'success' && steps\.setup-state\.outcome == 'success' \}\}/,
+    step(publisher, "Claim durable exact review publication").run ?? "",
+    /internal\/exact-review\/claim/,
   );
-  assert.match(publishStep, /if \[ ! -f "artifacts\/event\/\$ITEM_NUMBER\.md" \]/);
-  assert.match(publishStep, /live_state="\$\(gh api/);
-  assert.match(publishStep, /echo "terminal_noop=true" >> "\$GITHUB_OUTPUT"/);
-  assert.match(publishStep, /echo "terminal_missing=true" >> "\$GITHUB_OUTPUT"/);
-  assert.match(publishStep, /echo "remote_tuple_verified=false" >> "\$GITHUB_OUTPUT"/);
-  assert.match(publishStep, /echo "routing_deferred=false" >> "\$GITHUB_OUTPUT"/);
-  assert.match(publishStep, /gh api "repos\/\$TARGET_REPO" >\/dev\/null/);
-  assert.match(publishStep, /cat "\$live_item_error" >&2/);
-  assert.match(publishStep, /Exact review produced no artifact for open item/);
-  assert.ok(releaseUnsuccessfulStart > publishStart);
-  assert.match(releaseUnsuccessfulStep, /always\(\)/);
-  assert.match(
-    releaseUnsuccessfulStep,
-    /github-run-\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}/,
+  assert.equal(publisher.concurrency?.group, "clawsweeper-state-publisher");
+  assert.equal(publisher.concurrency?.["cancel-in-progress"], false);
+  assert.equal(publisher.concurrency?.queue, "max");
+  assert.equal(publisher.permissions?.actions, "write");
+  assert.equal(batchPublisher.concurrency?.group, "clawsweeper-state-publisher");
+
+  const download = step(publisher, "Download exact review artifact bundle");
+  const validate = step(publisher, "Validate exact review artifact bundle");
+  const targetWriteStep = step(publisher, "Create target write token");
+  const stateSetup = publisher.steps.find((candidate) => candidate.uses?.endsWith("/setup-state"));
+  assert.ok(stateSetup);
+  assert.equal(download.uses, "actions/download-artifact@v8");
+  assert.equal(download.with?.name, "${{ steps.publication-context.outputs.artifact_name }}");
+  assert.equal(
+    download.with?.["run-id"],
+    "${{ steps.publication-context.outputs.producer_run_id }}",
   );
-  assert.match(releaseUnsuccessfulStep, /clawsweeper-review-lease item=\$ITEM_NUMBER/);
-  assert.match(releaseUnsuccessfulStep, /owner=\$LEASE_OWNER/);
-  assert.match(releaseUnsuccessfulStep, /issues\/comments\/\$lease_id/);
-  assert.match(releaseUnsuccessfulStep, /--method DELETE/);
-  assert.match(releaseUnsuccessfulStep, /reactions\?content=eyes/);
-  assert.match(releaseUnsuccessfulStep, /Removed unsuccessful eyes reaction/);
-  assert.match(publisher, /"--event-apply-proof"/);
-  assert.match(publisher, /exactEventApplyProof\(/);
-  assert.match(publisher, /const requeueLatestExpected = applyDisposition === "source_drift"/);
-  assert.match(publisher, /terminal_missing=/);
-  assert.match(publisher, /terminal_closed=/);
-  assert.match(publisher, /guarded_open=/);
-  assert.match(publisher, /remote_tuple_verified=/);
-  assert.match(publisher, /routing_deferred=/);
-  assert.match(publisher, /class GuardedOpenPublishRaceError extends Error/);
-  assert.match(publisher, /class RoutableSyncPublishRaceError extends Error/);
-  assert.match(publisher, /class SourceDriftPublishRaceError extends Error/);
-  assert.match(publisher, /class TerminalClosedPublishRaceError extends Error/);
-  assert.match(publisher, /class TerminalMissingPublishRaceError extends Error/);
-  assert.match(publisher, /terminalClosedExpected: closedCount > 0/);
-  assert.match(publisher, /terminalMissingExpected: missingCount > 0/);
-  assert.match(publisher, /syncedCount > 0/);
-  assert.match(publisher, /routableSyncExpected && !published\.routableSyncVerified/);
-  assert.match(publisher, /eventSnapshotMatchesCurrent\(paths\)/);
-  assert.match(publisher, /candidateEventTupleState\(paths\)/);
-  assert.match(publisher, /fs\.existsSync\(paths\.snapshotClosed\)/);
-  assert.match(publisher, /fs\.existsSync\(paths\.snapshotItem\)/);
-  assert.match(publisher, /terminalClosedExpected && !published\.terminalClosed/);
-  assert.match(publisher, /guardedOpenAction !== null/);
-  assert.match(publisher, /error instanceof GuardedOpenPublishRaceError/);
-  assert.match(publisher, /error instanceof RoutableSyncPublishRaceError/);
-  assert.match(publisher, /error instanceof SourceDriftPublishRaceError/);
-  assert.match(publisher, /error instanceof TerminalClosedPublishRaceError/);
-  assert.match(publisher, /error instanceof TerminalMissingPublishRaceError/);
-  assert.match(publisher, /Event state .* was not applied because .*requeue/);
-  assert.match(publisher, /policy_noop=/);
-  assert.match(publisher, /requeue_latest=/);
-  assert.doesNotMatch(publisher, /entry\.action === "review_comment_synced"/);
-  assert.ok(authoritativeReset > publisherCompleteStart);
-  assert.ok(authoritativeRefresh > authoritativeReset);
-  assert.ok(finalTupleMatch > authoritativeRefresh);
-  assert.doesNotMatch(eventReviewJob, /- name: Dispatch viable issue implementation/);
-  assert.match(routeStep, /steps\.publish-event-result\.outputs\.terminal_noop != 'true'/);
-  assert.match(routeStep, /steps\.publish-event-result\.outputs\.terminal_missing != 'true'/);
-  assert.match(routeStep, /steps\.publish-event-result\.outputs\.terminal_closed != 'true'/);
-  assert.match(routeStep, /steps\.publish-event-result\.outputs\.guarded_open != 'true'/);
-  assert.match(routeStep, /steps\.publish-event-result\.outputs\.remote_tuple_verified == 'true'/);
-  assert.match(routeStep, /steps\.publish-event-result\.outputs\.routing_deferred == 'false'/);
-  assert.match(routeStep, /steps\.publish-event-result\.outputs\.policy_noop != 'true'/);
-  assert.match(routeStep, /steps\.publish-event-result\.outputs\.requeue_latest != 'true'/);
-  assert.doesNotMatch(routeStep, /outputs\.routing_deferred != 'true'/);
-  assert.match(
-    deferredRouteStep,
-    /steps\.publish-event-result\.outputs\.remote_tuple_verified == 'true'/,
-  );
-  assert.match(
-    deferredRouteStep,
-    /steps\.publish-event-result\.outputs\.routing_deferred == 'true'/,
-  );
-  assert.match(deferredRouteStep, /gh workflow run repair-comment-router\.yml/);
-  assert.match(deferredRouteStep, /-f execute=true/);
-  assert.match(deferredRouteStep, /-f target_repo="\$TARGET_REPO"/);
-  assert.match(deferredRouteStep, /-f target_branch="\$TARGET_BRANCH"/);
-  assert.doesNotMatch(deferredRouteStep, /-f item_numbers=/);
-  assert.match(
-    routerWorkflow,
-    /format\('repair-comment-router-\{0\}', github\.event\.inputs\.target_repo \|\| github\.event\.client_payload\.target_repo \|\| 'openclaw\/openclaw'\)/,
-  );
-  assert.doesNotMatch(routerWorkflow, /repair-comment-router-\{0\}-items/);
-  assert.match(
-    eventReviewJob,
-    /INTAKE_TERMINAL_MISSING: \$\{\{ steps\.live-item\.outputs\.terminal_missing \}\}/,
-  );
-  assert.match(
-    eventReviewJob,
-    /TERMINAL_MISSING: \$\{\{ steps\.publish-event-result\.outputs\.terminal_missing \}\}/,
-  );
-  assert.match(
-    eventReviewJob,
-    /TERMINAL_CLOSED: \$\{\{ steps\.publish-event-result\.outputs\.terminal_closed \}\}/,
-  );
-  assert.match(
-    eventReviewJob,
-    /INTAKE_GUARDED_OPEN: \$\{\{ steps\.live-item\.outputs\.guarded_open \}\}/,
-  );
-  assert.match(
-    eventReviewJob,
-    /GUARDED_OPEN: \$\{\{ steps\.publish-event-result\.outputs\.guarded_open \}\}/,
-  );
-  assert.match(
-    eventReviewJob,
-    /ROUTING_DEFERRED: \$\{\{ steps\.publish-event-result\.outputs\.routing_deferred \}\}/,
-  );
-  assert.match(
-    eventReviewJob,
-    /REMOTE_TUPLE_VERIFIED: \$\{\{ steps\.publish-event-result\.outputs\.remote_tuple_verified \}\}/,
-  );
-  assert.match(
-    eventReviewJob,
-    /ROUTE_HANDOFF_OUTCOME: \$\{\{ steps\.queue-deferred-verdict-router\.outcome \}\}/,
-  );
-  assert.match(
-    eventReviewJob,
-    /DIRECT_ROUTE_OUTCOME: \$\{\{ steps\.route-synced-verdict\.outcome \}\}/,
-  );
-  assert.match(
-    eventReviewJob,
-    /DEFERRED_ROUTE_OUTCOME: \$\{\{ steps\.queue-deferred-verdict-router\.outcome \}\}/,
-  );
-  assert.match(eventReviewJob, /queued an executing target-wide serialized router scan/);
-  assert.match(eventReviewJob, /deterministic remain-open guard/);
-  assert.match(eventReviewJob, /verified terminal close/);
-  assert.match(eventReviewJob, /repository is accessible but the item is missing/);
-  assert.match(eventReviewJob, /finished before Codex because the open conversation is locked/);
-  assert.match(
-    eventReviewJob,
-    /steps\.live-item\.outputs\.proceed == 'true' \|\| steps\.live-item\.outputs\.terminal_missing == 'true' \|\| steps\.live-item\.outputs\.guarded_open == 'true' \|\| steps\.confirm-terminal-item\.outputs\.confirmed == 'true'/,
-  );
-  assert.match(
-    eventReviewJob,
-    /\[ "\$TERMINAL_CLOSED" = "true" \] && \[ "\$\{\{ steps\.confirm-terminal-item\.outputs\.confirmed \}\}" = "true" \]/,
-  );
-  assert.match(reactStep, /steps\.publish-event-result\.outputs\.terminal_closed == 'true'/);
-  assert.match(reactStep, /steps\.publish-event-result\.outputs\.guarded_open == 'true'/);
-  assert.match(reactStep, /steps\.queue-deferred-verdict-router\.outcome == 'success'/);
-  assert.match(reactStep, /steps\.live-item\.outputs\.guarded_open == 'true'/);
-  assert.doesNotMatch(reactStep, /terminal_missing/);
-  assert.match(releaseLeaseStep, /steps\.live-item\.outputs\.terminal_noop == 'true'/);
-  assert.match(releaseLeaseStep, /steps\.publish-event-result\.outputs\.terminal_noop == 'true'/);
-  assert.match(releaseLeaseStep, /steps\.publish-event-result\.outputs\.terminal_closed == 'true'/);
-  assert.doesNotMatch(releaseLeaseStep, /terminal_missing/);
-  assert.doesNotMatch(releaseLeaseStep, /steps\.live-item\.outputs\.proceed == 'false'/);
-  assert.match(releaseLeaseStep, /clawsweeper-review-lease item=\$ITEM_NUMBER/);
-  assert.match(releaseLeaseStep, /--method DELETE/);
-  assert.match(releaseLeaseStep, /reactions\?content=eyes/);
-  assert.match(releaseLeaseStep, /Removed terminal eyes reaction/);
-  assert.ok(releaseLeaseStep.indexOf("lease_ids=") < releaseLeaseStep.indexOf('test "$(gh api'));
-  assert.match(confirmTerminalStep, /steps\.release-terminal-review-leases\.outcome == 'success'/);
-  assert.match(confirmTerminalStep, /live_state.*gh api/);
-  assert.match(confirmTerminalStep, /echo "confirmed=true" >> "\$GITHUB_OUTPUT"/);
-  assert.match(eventReviewJob, /terminal review leases were released/);
-  assert.match(failStep, /steps\.live-item\.outputs\.proceed != 'false'/);
-  assert.match(failStep, /steps\.publish-event-result\.outputs\.terminal_noop != 'true'/);
-  assert.match(failStep, /steps\.publish-event-result\.outputs\.terminal_missing != 'true'/);
-  assert.match(failStep, /steps\.publish-event-result\.outputs\.terminal_closed != 'true'/);
-  assert.match(failStep, /steps\.publish-event-result\.outputs\.guarded_open != 'true'/);
-  assert.match(failStep, /steps\.route-synced-verdict\.outcome != 'success'/);
-  assert.match(failStep, /steps\.queue-deferred-verdict-router\.outcome != 'success'/);
-  assert.match(failStep, /steps\.publish-event-result\.outputs\.policy_noop != 'true'/);
-  assert.match(failStep, /steps\.publish-event-result\.outputs\.requeue_latest != 'true'/);
-  assert.match(
-    eventReviewJob,
-    /RETRY_AT: \$\{\{ steps\.review-exact-event-item\.outputs\.retry_at \}\}/,
-  );
-  assert.match(eventReviewJob, /\.\.\.\(retryAt \? \{ retry_at: retryAt \} : \{\}\)/);
-  assert.match(
-    eventReviewJob,
-    /REQUEUE_LATEST: \$\{\{ steps\.publish-event-result\.outputs\.requeue_latest \}\}/,
-  );
-  assert.match(eventReviewJob, /\.\.\.\(requeueLatest \? \{ requeue_latest: true \} : \{\}\)/);
-  assert.match(eventReviewJob, /id: complete-exact-review-queue/);
-  assert.match(
-    eventReviewJob,
-    /Fail unacknowledged source-drift requeue[\s\S]*steps\.complete-exact-review-queue\.outcome != 'success'/,
-  );
-  const reReviewStatus = eventReviewJob.indexOf("- name: Mark source-drift re-review queued");
-  const completeQueue = eventReviewJob.indexOf("- name: Complete exact-review queue lease");
-  assert.ok(completeQueue > 0 && reReviewStatus > completeQueue);
-  assert.match(
-    eventReviewJob,
-    /Mark source-drift re-review queued[\s\S]*steps\.complete-exact-review-queue\.outcome == 'success'/,
-  );
-  assert.match(
-    eventReviewJob,
-    /React to target item completion[\s\S]*steps\.publish-event-result\.outputs\.policy_noop == 'true'/,
-  );
-  assert.match(
-    eventReviewJob,
-    /if \[ "\$POLICY_NOOP" != "true" \] && \[ "\$REVIEW_ONLY" != "true" \]; then/,
+  assert.match(validate.run ?? "", /repair:exact-review-bundle -- validate/);
+  assert.ok(publisher.steps.indexOf(validate) < publisher.steps.indexOf(targetWriteStep));
+  assert.ok(publisher.steps.indexOf(validate) < publisher.steps.indexOf(stateSetup));
+
+  const publish = step(publisher, "Publish event result and apply safe close");
+  assert.match(publish.run ?? "", /live_state=.*gh api/);
+  assert.match(publish.run ?? "", /LIVE_TERMINAL_NOOP.*LIVE_TERMINAL_MISSING/);
+  assert.match(publish.run ?? "", /LIVE_GUARDED_OPEN/);
+  assert.match(publish.run ?? "", /live_locked=.*jq -r '\.locked == true'/);
+  assert.match(publish.run ?? "", /live_locked.*true[\s\S]*guarded_open=true/);
+  assert.match(publish.run ?? "", /open\)[\s\S]*?requeue_latest=true/);
+  assert.match(publish.run ?? "", /test -f "artifacts\/event\/\$ITEM_NUMBER\.md"/);
+  assert.match(publish.run ?? "", /repair:publish-event-result/);
+  const route = step(publisher, "Route synced ClawSweeper verdict");
+  assert.match(route.if ?? "", /publish-event-result\.outcome == 'success'/);
+  assert.match(route.if ?? "", /remote_tuple_verified == 'true'/);
+  const drift = step(publisher, "Queue fresh review after source drift");
+  assert.match(drift.if ?? "", /requeue_latest == 'true'/);
+  assert.match(drift.run ?? "", /x-clawsweeper-exact-review-signature/);
+  assert.match(drift.run ?? "", /internal\/exact-review\/enqueue/);
+  assert.match(drift.run ?? "", /decision\.sourceAction === "failed_review_shard_recovery"/);
+  assert.match(drift.run ?? "", /\.queued == true or \.deduped == true/);
+  const status = step(publisher, "Mark re-review complete");
+  assert.equal(status.env?.LIVE_TERMINAL_MISSING, undefined);
+  assert.equal(status.env?.LIVE_GUARDED_OPEN, undefined);
+  assert.doesNotMatch(status.run ?? "", /LIVE_TERMINAL_MISSING|LIVE_GUARDED_OPEN/);
+  const reaction = step(publisher, "React to target item completion");
+  assert.match(reaction.if ?? "", /requeue_latest != 'true'/);
+  assert.doesNotMatch(reaction.if ?? "", /publication-context.*live_guarded_open/);
+  const ledger = step(publisher, "Publish exact review action ledger");
+  assert.equal(ledger["continue-on-error"], true);
+  assert.match(ledger.run ?? "", /CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT:-/);
+  assert.match(ledger.run ?? "", /--expected-producer-job event-review-apply/);
+  assert.match(ledger.run ?? "", /--expected-producer-run-id/);
+  assert.match(ledger.run ?? "", /--expected-producer-sha/);
+  assert.match(ledger.run ?? "", /--expected-producer-run-attempt "\$GENERATION_ATTEMPT"/);
+  const publishResult = step(publisher, "Export exact review publication result");
+  const publishComplete = step(publisher, "Complete durable exact review publication");
+  const releaseTerminal = step(publisher, "Release terminal review leases");
+  const releaseUnsuccessful = step(publisher, "Release unsuccessful publisher-owned review lease");
+  assert.doesNotMatch(releaseTerminal.if ?? "", /publication-context.*live_terminal_noop/);
+  assert.match(releaseTerminal.if ?? "", /publish-event-result.*terminal_noop/);
+  assert.match(releaseUnsuccessful.run ?? "", /\.user\.login == \\"clawsweeper\[bot\]\\"/);
+  assert.match(releaseUnsuccessful.run ?? "", /content == "eyes"/);
+  assert.match(publishResult.env?.PRIOR_JOB_STATUS ?? "", /job\.status/);
+  assert.match(publishResult.run ?? "", /REQUEUE_LATEST.*SOURCE_DRIFT_OUTCOME/);
+  assert.doesNotMatch(publishResult.run ?? "", /LIVE_TERMINAL_NOOP/);
+  assert.match(publishComplete.run ?? "", /internal\/exact-review\/complete/);
+  assert.ok(publisher.steps.indexOf(publishResult) < publisher.steps.indexOf(publishComplete));
+
+  const publisherSource = readText("src/repair/publish-event-result.ts");
+  const completeStart = publisherSource.indexOf("const complete =");
+  assert.ok(publisherSource.indexOf("hardResetToRemoteMain();", completeStart) > completeStart);
+  assert.ok(
+    publisherSource.indexOf("eventSnapshotMatchesCurrent(paths)", completeStart) > completeStart,
   );
 });
-
 test("exact event workflow binds all work to the canonical queue claim", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const eventStart = workflow.indexOf("\n  event-review-apply:");
-  const eventEnd = workflow.indexOf("\n  target-fanout:", eventStart);
+  const eventEnd = workflow.indexOf("\n  event-review-publish:", eventStart);
   const eventJob = workflow.slice(eventStart, eventEnd);
   const claimStart = eventJob.indexOf("- name: Claim exact-review queue lease");
   const checkoutStart = eventJob.indexOf("- uses: actions/checkout@v7", claimStart);
@@ -628,7 +502,11 @@ test("exact event workflow binds all work to the canonical queue claim", () => {
   assert.match(claimStep, /protocol_version=\$\{responseProtocol\}/);
   assert.match(claimStep, /decision=\$\{JSON\.stringify\(decision\)\}/);
   assert.doesNotMatch(claimedWork, /github\.event\.client_payload/);
-  assert.match(claimedWork, /gh api "repos\/\$TARGET_REPO" --jq \.default_branch/);
+  assert.match(
+    claimedWork,
+    /CLAIM_TARGET_BRANCH: \$\{\{ fromJSON\(steps\.claim-exact-review-queue\.outputs\.decision\)\.targetBranch \}\}/,
+  );
+  assert.match(claimedWork, /target_branch="\$CLAIM_TARGET_BRANCH"/);
   assert.match(claimedWork, /if \.pull_request then "pull_request" else "issue" end/);
   assert.match(claimedWork, /steps\.live-item\.outputs\.target_branch/);
   assert.match(
@@ -653,7 +531,7 @@ test("exact event workflow binds all work to the canonical queue claim", () => {
   );
   assert.match(
     claimedWork,
-    /Fail unsuccessful exact review[\s\S]*steps\.target\.outputs\.target_enabled != 'false'/,
+    /Create exact review artifact bundle[\s\S]*steps\.target\.outputs\.target_enabled == 'true'/,
   );
   assert.match(
     claimedWork,
@@ -784,10 +662,7 @@ test("publish workflow dispatches immediate apply through the isolated lane", ()
   assert.match(dispatchStep, /gh workflow run sweep\.yml/);
   assert.match(dispatchStep, /-f apply_existing=true/);
   assert.match(dispatchStep, /-f apply_item_numbers="\$item_numbers"/);
-  assert.match(
-    publishJob,
-    /group: clawsweeper-target-review-publish-\$\{\{ needs\.plan\.outputs\.target_repo \}\}/,
-  );
+  assert.match(publishJob, /group: clawsweeper-state-publisher/);
   assert.match(publishJob, /cancel-in-progress: false/);
   assert.match(publishJob, /queue: max/);
 });
@@ -1765,13 +1640,13 @@ test("event review completion removes ClawSweeper eyes reaction", () => {
 test("event re-review status lets the durable queue reconcile interruptions", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const block = workflow.slice(
-    workflow.indexOf("- name: Mark re-review complete"),
-    workflow.indexOf("- name: Commit event comment router ledger"),
+    workflow.indexOf("- name: Mark unsuccessful re-review"),
+    workflow.indexOf("- name: Export exact review generation result"),
   );
 
   assert.match(block, /\[ "\$REVIEW_OUTCOME" = "cancelled" \]/);
   assert.match(block, /state="Interrupted"/);
-  assert.match(block, /The exact-review queue will reconcile a newer pending item if one arrived/);
+  assert.match(block, /The durable queue will retry it/);
   assert.doesNotMatch(block, /CAPACITY_OUTCOME/);
   assert.doesNotMatch(block, /state="Superseded"/);
 });
@@ -2327,7 +2202,7 @@ test("every action-ledger publication authenticates the expected producer job", 
     /pnpm run --silent publish-action-events -- \\\n(?:\s+.*\\\n)*\s+--expected-producer-job [^\n]+/g,
   );
   assert.ok(commands);
-  assert.equal(commands.length, 8);
+  assert.equal(commands.length, 9);
   assert.ok(commands.every((command) => command.includes("--expected-producer-job")));
   assert.match(workflow, /--expected-producer-job review/);
   assert.match(workflow, /--expected-producer-job apply-proof/);

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -2109,6 +2109,9 @@ test("sweep event reviews and target fanout avoid storm amplification", () => {
   assert.match(eventBlock, /cancel-in-progress: false/);
   assert.match(legacyIntakeBlock, /legacy-event-queue-intake:/);
   assert.match(legacyIntakeBlock, /\/internal\/exact-review\/enqueue/);
+  assert.match(legacyIntakeBlock, /gh api "repos\/\$target_repo" --jq \.default_branch/);
+  assert.match(legacyIntakeBlock, /targetBranch: process\.env\.TARGET_BRANCH/);
+  assert.doesNotMatch(legacyIntakeBlock, /targetBranch: payload\.target_branch \|\| "main"/);
   assert.match(legacyIntakeBlock, /commandStatusMarker: payload\.command_status_marker/);
   assert.match(legacyIntakeBlock, /statusCommentId: payload\.status_comment_id/);
   assert.match(legacyIntakeBlock, /additionalPrompt: payload\.additional_prompt/);

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -404,6 +404,11 @@ test("exact event review hands immutable artifacts to one state publisher", () =
   assert.equal(publisher.concurrency?.queue, "max");
   assert.equal(publisher.permissions?.actions, "write");
   assert.equal(batchPublisher.concurrency?.group, "clawsweeper-state-publisher");
+  const publicationContext = step(publisher, "Claim durable exact review publication");
+  assert.match(
+    publicationContext.run ?? "",
+    /producerDecision\.commandStatusMarker \|\| producerDecision\.statusCommentId/,
+  );
 
   const download = step(publisher, "Download exact review artifact bundle");
   const validate = step(publisher, "Validate exact review artifact bundle");


### PR DESCRIPTION
## Summary

- keep exact reviewers read-only and upload immutable, hash-bound review bundles
- enqueue durable publication work independently from review generation
- serialize Git-backed publication, validate producer and queue identity, and retry without rerunning Codex
- recover source drift, reopened or unlocked items, expired artifacts, failed handoffs, and publisher interruptions safely

## Validation

- `pnpm run build:all`
- `pnpm run lint`
- focused workflow, bundle, queue, ledger, and recovery tests
- `pnpm run format:check`
- `git diff --check`
- autoreview clean
