### PR TITLE
fix: forward exact review bundle commands

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -841,7 +841,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p .artifacts
-          pnpm run --silent repair:exact-review-bundle -- create > .artifacts/exact-review-bundle-create.json
+          pnpm run --silent repair:exact-review-bundle create > .artifacts/exact-review-bundle-create.json
           artifact_name="exact-review-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           {
             echo "artifact_name=$artifact_name"
@@ -1241,7 +1241,7 @@ jobs:
           EXACT_REVIEW_SOURCE_SHA: ${{ steps.publication-context.outputs.source_sha }}
           EXACT_REVIEW_TARGET_BRANCH: ${{ steps.publication-context.outputs.target_branch }}
           EXACT_REVIEW_TARGET_REPO: ${{ steps.publication-context.outputs.target_repo }}
-        run: pnpm run --silent repair:exact-review-bundle -- validate
+        run: pnpm run --silent repair:exact-review-bundle validate
 
       - name: Stage validated exact review artifact
         run: |

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -385,7 +385,7 @@ test("exact event review hands immutable artifacts to one state publisher", () =
   assert.match(create.run ?? "", /mkdir -p \.artifacts/);
   assert.ok(
     (create.run ?? "").indexOf("mkdir -p .artifacts") <
-      (create.run ?? "").indexOf("exact-review-bundle -- create"),
+      (create.run ?? "").indexOf("exact-review-bundle create"),
   );
   assert.equal(upload.uses, "actions/upload-artifact@v7");
   assert.equal(upload.with?.["retention-days"], 90);
@@ -423,7 +423,9 @@ test("exact event review hands immutable artifacts to one state publisher", () =
     download.with?.["run-id"],
     "${{ steps.publication-context.outputs.producer_run_id }}",
   );
-  assert.match(validate.run ?? "", /repair:exact-review-bundle -- validate/);
+  assert.match(validate.run ?? "", /repair:exact-review-bundle validate/);
+  assert.doesNotMatch(create.run ?? "", /repair:exact-review-bundle -- create/);
+  assert.doesNotMatch(validate.run ?? "", /repair:exact-review-bundle -- validate/);
   assert.ok(publisher.steps.indexOf(validate) < publisher.steps.indexOf(targetWriteStep));
   assert.ok(publisher.steps.indexOf(validate) < publisher.steps.indexOf(stateSetup));
 


### PR DESCRIPTION
## Summary

- pass exact-review bundle create/validate commands as pnpm script arguments
- prevent the literal separator from reaching the positional CLI parser
- add workflow regression assertions for both producer and publisher paths

## Proof

- Live failure: https://github.com/openclaw/clawsweeper/actions/runs/29408876859
- `pnpm run build:all`
- `node --test test/sweep-workflow.test.ts test/repair/exact-review-bundle.test.ts` (69 passed)
- `pnpm run lint`
- `pnpm run format:check`
- autoreview clean
