### PR TITLE
fix: tolerate unavailable Landlock probes

### DIFF
--- a/src/repair/process-tree-containment.ts
+++ b/src/repair/process-tree-containment.ts
@@ -103,12 +103,20 @@ def checked_syscall(number, *arguments):
 
 
 def landlock_abi():
-    return checked_syscall(
-        SYS_LANDLOCK_CREATE_RULESET,
-        ctypes.c_void_p(),
-        ctypes.c_size_t(0),
-        ctypes.c_uint32(LANDLOCK_CREATE_RULESET_VERSION),
-    )
+    try:
+        return checked_syscall(
+            SYS_LANDLOCK_CREATE_RULESET,
+            ctypes.c_void_p(),
+            ctypes.c_size_t(0),
+            ctypes.c_uint32(LANDLOCK_CREATE_RULESET_VERSION),
+        )
+    except OSError as error:
+        if error.errno not in {errno.ENOSYS, errno.EOPNOTSUPP}:
+            raise
+        # Blacksmith hosts vary in whether Landlock is exposed through their
+        # syscall policy. The mount namespace has already established the same
+        # write allowlist; only the capability probe may select that fallback.
+        return None
 
 
 def checked_mount(source, target, flags, filesystem_type=None, data=None):
@@ -507,6 +515,8 @@ def canonical_writable_roots(writable_roots):
 
 def restrict_filesystem_writes(canonical_roots):
     abi = landlock_abi()
+    if abi is None:
+        return
     if abi < 3:
         raise RuntimeError("Landlock ABI 3 or newer is required")
     ruleset = LandlockRulesetAttr(handled_access_fs=LANDLOCK_WRITE_ACCESS)

--- a/test/repair/process-tree-containment.test.ts
+++ b/test/repair/process-tree-containment.test.ts
@@ -38,6 +38,9 @@ test("Linux validation containment uses an externally owned PID namespace and su
   assert.match(containment, /validation writable root is unsafe/);
   assert.doesNotMatch(containment, /checked_mount\("\/", "\/", MS_BIND/);
   assert.match(containment, /bring_up_loopback\(\)/);
+  assert.match(containment, /error\.errno not in \{errno\.ENOSYS, errno\.EOPNOTSUPP\}/);
+  assert.match(containment, /if abi is None:\s+return/);
+  assert.match(containment, /ruleset_fd = checked_syscall/);
   assert.match(containment, /PR_CAPBSET_DROP/);
   assert.match(containment, /PR_CAP_AMBIENT_CLEAR_ALL/);
   assert.match(containment, /libc\.capset/);


### PR DESCRIPTION
## Summary

- treat `ENOSYS` and `EOPNOTSUPP` from the Landlock ABI capability probe as an unavailable optional defense-in-depth layer
- preserve fail-closed behavior for all other probe errors, ABI versions below 3, and every later Landlock ruleset operation
- add a narrow regression assertion for the fallback boundary

## Root cause

After https://github.com/openclaw/clawsweeper/pull/596 added the `mount_setattr(2)` fallback, repair workers still failed intermittently on Blacksmith hosts where syscall 444 (`landlock_create_ruleset`) is filtered or unavailable. The mount namespace, chroot, read-only mount allowlist, network namespace, capability drop, and containment preflight remain mandatory.

Observed failures:

- https://github.com/openclaw/clawsweeper/actions/runs/29418723701
- https://github.com/openclaw/clawsweeper/actions/runs/29419775915
- https://github.com/openclaw/clawsweeper/actions/runs/29420021518

## Validation

- Node 24: `corepack enable`, `pnpm install`, `pnpm run check`
- focused containment tests: 2 passed
- autoreview: clean, no accepted/actionable findings (confidence 0.97)