### PR TITLE
test(repair): validate containment fallback locally

### DIFF
--- a/docs/repair/containment-validation-todo.md
+++ b/docs/repair/containment-validation-todo.md
@@ -1,0 +1,216 @@
+# Repair containment validation TODO
+
+## Purpose
+
+Move Linux repair-containment failures left from live repair jobs into
+deterministic local tests and a non-mutating production-runner smoke check.
+Live workers should confirm a fix after merge, not be the first place that an
+unsupported syscall or runner capability is discovered.
+
+This document is a handoff for a follow-up session. It does not authorize live
+apply/close operations or changes to external pull-request branches.
+
+## Current status
+
+- PR [openclaw/clawsweeper#596](https://github.com/openclaw/clawsweeper/pull/596)
+  fixed exact-review lease contention handling and added a legacy readonly
+  remount fallback when `mount_setattr(2)` returns `ENOSYS`.
+- Repair workers on the same merged SHA subsequently failed in the Landlock ABI
+  capability probe, most likely syscall 444 (`landlock_create_ruleset`):
+  - [run 29418723701](https://github.com/openclaw/clawsweeper/actions/runs/29418723701)
+  - [run 29419775915](https://github.com/openclaw/clawsweeper/actions/runs/29419775915)
+  - [run 29420021518](https://github.com/openclaw/clawsweeper/actions/runs/29420021518)
+- PR [openclaw/clawsweeper#598](https://github.com/openclaw/clawsweeper/pull/598)
+  merged on 2026-07-15 and makes Landlock an optional defense-in-depth layer
+  only when its capability probe returns `ENOSYS` or `EOPNOTSUPP`. Other probe
+  errors, ABI versions below 3, and later Landlock operations remain fail closed.
+- Its green CI does not execute the unsupported-Landlock fallback path. The
+  `ubuntu-latest` job skips the critical Linux containment integration tests
+  because its availability helper requires both delegated namespaces and
+  Landlock ABI 3+:
+  [CI job 87373830736](https://github.com/openclaw/clawsweeper/actions/runs/29421789537/job/87373830736).
+- Two naturally dispatched repair workflows on the merged SHA completed
+  successfully, but their execute jobs were skipped, so they did not exercise
+  the containment preflight:
+  - [run 29423502149](https://github.com/openclaw/clawsweeper/actions/runs/29423502149)
+  - [run 29423499463](https://github.com/openclaw/clawsweeper/actions/runs/29423499463)
+
+## Two-PR execution plan
+
+This file is the durable cross-session handoff. Keep completion boxes and live
+evidence current as each PR progresses.
+
+### PR 1: deterministic policy and one compiled preflight
+
+Status: implementation and Node 24 validation complete on
+`agent/containment-preflight`. Autoreview completed with no actionable findings;
+publication is pending.
+
+Combine the code-owned work behind one authoritative containment implementation:
+
+- make the embedded Python definitions importable while preserving the
+  production `python3 -c` entrypoint;
+- execute the real Landlock fallback and fail-closed decision table in
+  deterministic tests;
+- gate Linux integration coverage on delegated namespaces rather than Landlock
+  availability;
+- report safe stage, syscall, and errno diagnostics plus a capability summary;
+- expose one compiled `repair:containment-smoke` CLI for workflow callers.
+
+This PR must not add a new runner job, change repair/apply authority, or perform
+live repair mutations.
+
+### PR 2: production-runner smoke workflow
+
+Status: pending PR 1.
+
+- run the compiled CLI on `blacksmith-16vcpu-ubuntu-2404` with two independent
+  runner samples;
+- replace the existing repair worker's inline Node preflight with the same
+  compiled CLI;
+- trigger only for containment runtime, tests, CLI, or relevant workflow changes;
+- use no repository or organization secrets and grant only read permissions;
+- fail when containment is skipped or unavailable;
+- do not dispatch repair, push branches, apply results, or close items.
+
+Before enabling pull-request execution from forks, prove that Blacksmith uses a
+fresh ephemeral VM and exposes no repository or organization secrets. Otherwise
+restrict the workflow to trusted branches or the existing trusted remote
+validation path.
+
+## Evidence-backed test gap
+
+`test/repair/command-runner.test.ts` uses
+`linuxValidationContainmentAvailable()` to gate the real Linux containment
+tests. That helper calls syscall 444 and requires an ABI result of at least 3.
+Consequently, the precise production condition that should exercise the new
+fallback instead skips the entire integration test.
+
+`test/repair/process-tree-containment.test.ts` currently protects the fallback
+boundary with source-text assertions. These are useful drift guards, but they
+do not execute the embedded Python decision path.
+
+The runtime is also difficult to test and diagnose because the path spans:
+
+1. `.github/workflows/repair-cluster-worker.yml`
+2. `src/repair/contained-command-worker.ts`
+3. the embedded Python in `src/repair/process-tree-containment.ts`
+4. host kernel syscalls and provider seccomp policy
+
+The containment protocol reports only an exception string, so both syscall 442
+and syscall 444 surfaced as the same generic `[Errno 38] Function not
+implemented` message.
+
+## Required work
+
+### P0: deterministic fallback tests
+
+- [ ] Make the actual embedded Python definitions importable without executing
+      `main()`, while preserving the production `python3 -c` entrypoint.
+- [ ] Exercise the real `landlock_abi()` decision logic with an injected or
+      monkey-patched syscall adapter; do not duplicate the decision in a
+      TypeScript-only model.
+- [ ] Cover this decision table:
+
+| Probe/result                                       | Required behavior                     |
+| -------------------------------------------------- | ------------------------------------- |
+| syscall 444 returns `ENOSYS`                       | select mount-only fallback            |
+| syscall 444 returns `EOPNOTSUPP`                   | select mount-only fallback            |
+| probe returns `EPERM`, `EACCES`, or `EINVAL`       | fail closed                           |
+| probe returns ABI below 3                          | fail closed                           |
+| probe returns ABI 3 or newer                       | create and apply the Landlock ruleset |
+| ruleset creation, add-rule, or restrict-self fails | fail closed                           |
+
+- [ ] Split namespace availability from Landlock availability in
+      `linuxValidationContainmentAvailable()`. When delegated namespaces are
+      usable but Landlock is unavailable, run the mount-only containment tests
+      instead of skipping them.
+- [ ] Keep assertions that the sandbox exposes only configured writable roots,
+      hides host paths and `/run`, drops all capabilities, isolates networking,
+      and reaps descendant processes.
+
+### P1: production-equivalent non-mutating smoke check
+
+- [ ] Add a narrowly scoped `containment-smoke` CI job or workflow using the
+      same `blacksmith-16vcpu-ubuntu-2404` runner class as repair execution.
+- [ ] Run the compiled containment preflight only. Do not dispatch a repair,
+      push target branches, apply results, close items, or use target write
+      credentials.
+- [ ] Trigger it only when the containment worker, its tests, or the relevant
+      workflow surface changes.
+- [ ] Consider two independent runner samples because the observed Blacksmith
+      fleet exposed different capabilities for the same ClawSweeper SHA.
+- [ ] In this production-compatible job, treat a skipped containment test as a
+      failure rather than a green result.
+
+Before enabling this job for fork pull requests, verify that it runs on a fresh
+ephemeral VM with no repository or organization secrets. If that contract is
+not proven, restrict the job to trusted branches or use the existing trusted
+remote-validation path.
+
+### P1: actionable containment diagnostics
+
+- [ ] Report the failing containment stage, syscall number, and errno without
+      including local paths, command contents, or secrets.
+- [ ] Distinguish at least `mount_setattr`, legacy remount,
+      `landlock_capability_probe`, ruleset creation, add-rule, restrict-self,
+      namespace setup, and capability drop.
+- [ ] Emit a safe capability summary such as `mount_readonly=native|legacy` and
+      `landlock=abi-N|unavailable` from the smoke preflight.
+- [ ] Preserve fail-closed behavior for every mandatory containment stage.
+
+### P2: reduce workflow/runtime duplication
+
+- [ ] Move the inline Node preflight in
+      `.github/workflows/repair-cluster-worker.yml` behind one compiled,
+      locally callable CLI so workflow and local tests execute the same probe.
+- [ ] Keep workflow YAML responsible for orchestration and gates, not the
+      containment implementation.
+- [ ] Preserve one authoritative copy of the Python runtime. Do not create a
+      separate test-only implementation that can drift from production.
+
+## Capability policy to preserve
+
+Mandatory containment remains:
+
+- delegated user, mount, PID, and requested network namespaces;
+- chroot and the minimal runtime bind mounts;
+- recursive readonly mount policy with only explicit writable roots;
+- host-path and write-escape preflight checks;
+- capability bounding, effective, permitted, inheritable, and ambient sets all
+  dropped;
+- descendant process containment and reaping.
+
+Landlock may be optional only as defense in depth after the mandatory mount
+write allowlist is established and verified. An unsupported capability probe
+may choose the fallback; an operational failure after Landlock is known to be
+available must still fail closed.
+
+## Acceptance criteria
+
+- The unsupported-Landlock path is executed deterministically in local tests;
+  it is not proven solely with regular-expression assertions.
+- `ENOSYS` can be attributed to a named syscall and stage from one failure log.
+- A non-mutating check runs the real compiled worker on the production runner
+  class before merge, or the documented trusted equivalent is used.
+- Critical containment coverage cannot silently turn green by skipping all
+  environment-dependent tests.
+- Node 24 validation passes:
+
+  ```bash
+  corepack enable
+  pnpm install
+  pnpm run check
+  ```
+
+- Run autoreview before publishing the follow-up PR.
+- After merge, observe naturally scheduled repair workers. Do not manually run
+  live apply/close and do not pause the sweep workflow.
+
+## Out of scope
+
+- Changes to `openclaw/clawsweeper-state`; its dashboard/schema work is
+  independent of repair containment.
+- Direct edits to external OpenClaw contributor branches.
+- Weakening mandatory isolation merely to accommodate a runner.
+- Requiring OpenClaw contributors to modify `CHANGELOG.md`.

--- a/docs/repair/containment-validation-todo.md
+++ b/docs/repair/containment-validation-todo.md
@@ -42,9 +42,9 @@ evidence current as each PR progresses.
 
 ### PR 1: deterministic policy and one compiled preflight
 
-Status: implementation and Node 24 validation complete on
-`agent/containment-preflight`. Autoreview completed with no actionable findings;
-publication is pending.
+Status: [PR openclaw/clawsweeper#599](https://github.com/openclaw/clawsweeper/pull/599)
+is open from `agent/containment-preflight`. Implementation and Node 24
+validation are complete, and autoreview completed with no actionable findings.
 
 Combine the code-owned work behind one authoritative containment implementation:
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "commit-reports": "node dist/commit-sweeper.js reports",
     "local-review": "node dist/commit-sweeper.js local-review",
     "repair:validate": "node dist/repair/validate-all.js",
+    "repair:containment-smoke": "node dist/repair/containment-preflight.js",
     "repair:validate-job": "node dist/repair/validate-job.js",
     "repair:render": "node dist/repair/render-prompt.js",
     "repair:create-job": "node dist/repair/create-job.js",

--- a/src/repair/command-runner.ts
+++ b/src/repair/command-runner.ts
@@ -2,6 +2,7 @@ import { spawnSync, type SpawnSyncReturns } from "node:child_process";
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
 import { resolveSpawnCommand } from "../command.js";
+import type { ContainmentCapabilitySummary } from "./contained-command-worker.js";
 
 const DEFAULT_COMMAND_MAX_BUFFER = 64 * 1024 * 1024;
 
@@ -13,6 +14,16 @@ export type CommandRunOptions = {
   maxBuffer?: number;
   timeoutMs?: number;
   writableRoots?: readonly string[];
+};
+
+export type ContainedCommandResult = {
+  backgroundProcesses: number;
+  capabilitySummary?: ContainmentCapabilitySummary;
+  error?: { code: string | undefined; message: string };
+  signal: NodeJS.Signals | null;
+  status: number | null;
+  stderr: string;
+  stdout: string;
 };
 
 export function runCommand(
@@ -33,6 +44,32 @@ export function runContainedCommand(
   commandArgs: string[],
   options: CommandRunOptions = {},
 ): string {
+  const child = runContainedCommandResult(command, commandArgs, options);
+  const detail = [child.stderr, child.stdout].filter(Boolean).join("\n").trim();
+  if (child.error) {
+    if (child.error.code === "ETIMEDOUT") {
+      const rendered = [command, ...commandArgs].join(" ");
+      const message = `command timed out after ${options.timeoutMs}ms: ${rendered}`;
+      throw new Error(detail ? `${message}\n${detail}` : message);
+    }
+    throw new Error(detail ? `${child.error.message}\n${detail}` : child.error.message);
+  }
+  if (child.status !== 0) {
+    throw new Error(detail || `${command} exited ${child.status ?? `with signal ${child.signal}`}`);
+  }
+  if (child.backgroundProcesses > 0) {
+    throw new Error(
+      `validation command left ${child.backgroundProcesses} background process(es) after exit`,
+    );
+  }
+  return child.stdout;
+}
+
+export function runContainedCommandResult(
+  command: string,
+  commandArgs: string[],
+  options: CommandRunOptions = {},
+): ContainedCommandResult {
   const env = options.env ?? process.env;
   const invocation = resolveSpawnCommand(command, commandArgs, {
     ...(options.cwd ? { cwd: options.cwd } : {}),
@@ -66,32 +103,7 @@ export function runContainedCommand(
   if (worker.status !== 0) {
     throw new Error(worker.stderr?.trim() || `validation supervisor exited ${worker.status}`);
   }
-  const child = JSON.parse(worker.stdout) as {
-    backgroundProcesses: number;
-    error?: { code: string | undefined; message: string };
-    signal: NodeJS.Signals | null;
-    status: number | null;
-    stderr: string;
-    stdout: string;
-  };
-  const detail = [child.stderr, child.stdout].filter(Boolean).join("\n").trim();
-  if (child.error) {
-    if (child.error.code === "ETIMEDOUT") {
-      const rendered = [command, ...commandArgs].join(" ");
-      const message = `command timed out after ${options.timeoutMs}ms: ${rendered}`;
-      throw new Error(detail ? `${message}\n${detail}` : message);
-    }
-    throw new Error(detail ? `${child.error.message}\n${detail}` : child.error.message);
-  }
-  if (child.status !== 0) {
-    throw new Error(detail || `${command} exited ${child.status ?? `with signal ${child.signal}`}`);
-  }
-  if (child.backgroundProcesses > 0) {
-    throw new Error(
-      `validation command left ${child.backgroundProcesses} background process(es) after exit`,
-    );
-  }
-  return child.stdout;
+  return JSON.parse(worker.stdout) as ContainedCommandResult;
 }
 
 function serializedWorkerMaxBuffer(maxBuffer: number) {

--- a/src/repair/contained-command-worker.ts
+++ b/src/repair/contained-command-worker.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { windowsSystemExecutable } from "../command.js";
 import { createTrustedSandboxRoot } from "./contained-command-sandbox.js";
@@ -20,6 +22,7 @@ type WorkerInput = {
 
 type WorkerResult = {
   backgroundProcesses: number;
+  capabilitySummary?: ContainmentCapabilitySummary;
   error?: { code: string | undefined; message: string };
   signal: NodeJS.Signals | null;
   status: number | null;
@@ -27,16 +30,31 @@ type WorkerResult = {
   stdout: string;
 };
 
+export type ContainmentCapabilitySummary = {
+  landlock: string;
+  mountReadonly: "legacy" | "native";
+};
+
 type ContainmentProtocol = {
   backgroundProcesses?: number;
-  containmentError?: string;
+  capabilitySummary?: {
+    landlock?: unknown;
+    mount_readonly?: unknown;
+  };
+  containmentError?: {
+    errno?: unknown;
+    stage?: unknown;
+    syscall?: unknown;
+  };
   signal?: NodeJS.Signals | null;
   status?: number | null;
 };
 
-const input = JSON.parse(await readStdin()) as WorkerInput;
-const result = await runContained(input);
-process.stdout.write(JSON.stringify(result));
+async function main(): Promise<void> {
+  const input = JSON.parse(await readStdin()) as WorkerInput;
+  const result = await runContained(input);
+  process.stdout.write(JSON.stringify(result));
+}
 
 async function runContained(input: WorkerInput): Promise<WorkerResult> {
   if (process.platform !== "linux" && process.env.NODE_TEST_CONTEXT === undefined) {
@@ -162,6 +180,7 @@ async function runContained(input: WorkerInput): Promise<WorkerResult> {
 
   let contained: {
     backgroundProcesses: number;
+    capabilitySummary?: ContainmentCapabilitySummary;
     signal: NodeJS.Signals | null;
     status: number | null;
   };
@@ -188,6 +207,7 @@ async function runContained(input: WorkerInput): Promise<WorkerResult> {
         : undefined;
   return {
     backgroundProcesses: contained.backgroundProcesses,
+    ...(contained.capabilitySummary ? { capabilitySummary: contained.capabilitySummary } : {}),
     ...(error ? { error } : {}),
     signal: contained.signal,
     status: contained.status,
@@ -196,14 +216,14 @@ async function runContained(input: WorkerInput): Promise<WorkerResult> {
   };
 }
 
-function parseContainmentProtocol(
+export function parseContainmentProtocol(
   chunks: readonly Buffer[],
   exit: { signal: NodeJS.Signals | null; status: number | null },
 ) {
   const raw = Buffer.concat(chunks).toString("utf8").trim();
   if (!raw) {
     throw new Error(
-      `validation subreaper exited without a result (${exit.status ?? exit.signal ?? "unknown"})`,
+      `validation process containment failed: stage=namespace_setup exit=${exit.status ?? exit.signal ?? "unknown"}`,
     );
   }
   let result: ContainmentProtocol;
@@ -213,22 +233,49 @@ function parseContainmentProtocol(
     throw new Error("validation subreaper returned an invalid result");
   }
   if (result.containmentError) {
-    throw new Error(`validation process containment failed: ${result.containmentError}`);
+    const stage = safeDiagnosticToken(result.containmentError.stage, "unknown");
+    const syscall = safeDiagnosticInteger(result.containmentError.syscall);
+    const errorNumber = safeDiagnosticInteger(result.containmentError.errno);
+    throw new Error(
+      [
+        "validation process containment failed:",
+        `stage=${stage}`,
+        ...(syscall === undefined ? [] : [`syscall=${syscall}`]),
+        ...(errorNumber === undefined ? [] : [`errno=${errorNumber}`]),
+      ].join(" "),
+    );
   }
+  const mountReadonly = result.capabilitySummary?.mount_readonly;
+  const landlock = result.capabilitySummary?.landlock;
   if (
     exit.status !== 0 ||
     !Number.isInteger(result.backgroundProcesses) ||
     result.backgroundProcesses! < 0 ||
     (result.status !== null && !Number.isInteger(result.status)) ||
-    (result.signal !== null && typeof result.signal !== "string")
+    (result.signal !== null && typeof result.signal !== "string") ||
+    (mountReadonly !== "native" && mountReadonly !== "legacy") ||
+    typeof landlock !== "string" ||
+    !/^(?:abi-[0-9]+|unavailable)$/.test(landlock)
   ) {
     throw new Error("validation subreaper returned an invalid result");
   }
   return {
     backgroundProcesses: result.backgroundProcesses!,
+    capabilitySummary: {
+      landlock: landlock as string,
+      mountReadonly: mountReadonly as "legacy" | "native",
+    },
     signal: result.signal ?? null,
     status: result.status ?? null,
   };
+}
+
+function safeDiagnosticInteger(value: unknown): number | undefined {
+  return Number.isInteger(value) && Number(value) >= 0 ? Number(value) : undefined;
+}
+
+function safeDiagnosticToken(value: unknown, fallback: string): string {
+  return typeof value === "string" && /^[a-z_]+$/.test(value) ? value : fallback;
 }
 
 async function reapProcessGroup(pid: number | undefined) {
@@ -296,4 +343,17 @@ async function readStdin() {
   const chunks: Buffer[] = [];
   for await (const chunk of process.stdin) chunks.push(Buffer.from(chunk));
   return Buffer.concat(chunks).toString("utf8");
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  try {
+    await main();
+  } catch (error) {
+    // The worker is a security boundary: return its validated diagnostic only,
+    // never a stack trace containing runner paths or target command details.
+    process.stderr.write(
+      error instanceof Error ? error.message : "validation process containment failed",
+    );
+    process.exitCode = 1;
+  }
 }

--- a/src/repair/containment-preflight.ts
+++ b/src/repair/containment-preflight.ts
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { runContainedCommandResult } from "./command-runner.js";
+
+const PREFLIGHT_PROBE = [
+  "import os, socket, sys",
+  "host_marker, work, profile = sys.argv[1:]",
+  "assert not os.path.exists(host_marker), 'host marker remained visible'",
+  "assert os.listdir('/run') == [], 'host /run entries remained visible'",
+  "open(os.path.join(work, 'work-write'), 'w').write('ok')",
+  "open(os.path.join(profile, 'profile-write'), 'w').write('ok')",
+  "try:",
+  "    open('/tmp/escape', 'w').write('unsafe')",
+  "    raise AssertionError('non-writable path accepted a write')",
+  "except OSError:",
+  "    pass",
+  "status = open('/proc/self/status', encoding='ascii').read().splitlines()",
+  "caps = {line.split(':', 1)[0]: int(line.split(':', 1)[1].strip(), 16) for line in status if line.split(':', 1)[0] in {'CapInh', 'CapPrm', 'CapEff', 'CapBnd', 'CapAmb'}}",
+  "assert set(caps) == {'CapInh', 'CapPrm', 'CapEff', 'CapBnd', 'CapAmb'}",
+  "assert not any(caps.values()), 'validation capabilities were not fully dropped'",
+  "with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:",
+  "    listener.bind(('127.0.0.1', 0))",
+  "print('contained')",
+].join("\n");
+
+export function runContainmentPreflight(): string {
+  if (process.platform !== "linux") {
+    throw new Error("containment preflight requires Linux");
+  }
+  for (const tool of ["/usr/bin/unshare", "/usr/bin/python3"]) {
+    if (!fs.existsSync(tool)) throw new Error(`containment preflight requires ${tool}`);
+  }
+
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-containment-preflight-"));
+  const hostMarker = `${root}.host-marker`;
+  const work = path.join(root, "work");
+  const profile = path.join(root, "profile");
+  try {
+    fs.mkdirSync(work);
+    fs.mkdirSync(profile);
+    fs.writeFileSync(hostMarker, "host-visible\n");
+    const result = runContainedCommandResult(
+      "/usr/bin/python3",
+      ["-c", PREFLIGHT_PROBE, hostMarker, work, profile],
+      {
+        cwd: work,
+        env: {
+          CI: "true",
+          HOME: profile,
+          LANG: "C.UTF-8",
+          PATH: process.env.PATH ?? "/usr/bin:/bin",
+          TEMP: profile,
+          TMP: profile,
+          TMPDIR: profile,
+        },
+        isolateNetwork: true,
+        maxBuffer: 1024 * 1024,
+        timeoutMs: 30_000,
+        writableRoots: [work, profile],
+      },
+    );
+    // Worker transport and target-process errors are not part of the validated
+    // containment protocol, so keep them opaque instead of echoing their text.
+    if (
+      result.status !== 0 ||
+      result.signal !== null ||
+      result.error !== undefined ||
+      result.backgroundProcesses !== 0 ||
+      result.stdout !== "contained\n" ||
+      result.capabilitySummary === undefined
+    ) {
+      throw new Error("containment preflight failed closed");
+    }
+    return `mount_readonly=${result.capabilitySummary.mountReadonly} landlock=${result.capabilitySummary.landlock}`;
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+    fs.rmSync(hostMarker, { force: true });
+  }
+}
+
+function main(): void {
+  process.stdout.write(`${runContainmentPreflight()}\n`);
+}
+
+export function safePreflightErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : "";
+  if (
+    /^validation process containment failed: stage=[a-z_]+(?:(?: syscall| errno)=[0-9]+)*(?: exit=(?:[0-9]+|[A-Z0-9]+|unknown))?$/.test(
+      message,
+    ) ||
+    message === "containment preflight requires Linux" ||
+    /^containment preflight requires \/usr\/bin\/(?:python3|unshare)$/.test(message)
+  ) {
+    return message;
+  }
+  return "containment preflight failed closed";
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`${safePreflightErrorMessage(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/src/repair/process-tree-containment.ts
+++ b/src/repair/process-tree-containment.ts
@@ -66,6 +66,7 @@ SYS_LANDLOCK_CREATE_RULESET = 444
 SYS_LANDLOCK_ADD_RULE = 445
 SYS_LANDLOCK_RESTRICT_SELF = 446
 SYS_MOUNT_SETATTR = 442
+SYS_MOUNT = 165
 LINUX_CAPABILITY_VERSION_3 = 0x20080522
 SIOCGIFFLAGS = 0x8913
 SIOCSIFFLAGS = 0x8914
@@ -86,6 +87,14 @@ class CapabilityData(ctypes.Structure):
         ("permitted", ctypes.c_uint32),
         ("inheritable", ctypes.c_uint32),
     ]
+
+
+class ContainmentStageError(RuntimeError):
+    def __init__(self, stage, error, syscall_number=None):
+        super().__init__(stage)
+        self.stage = stage
+        self.syscall_number = syscall_number
+        self.error_number = getattr(error, "errno", None)
 
 
 libc = ctypes.CDLL(None, use_errno=True)
@@ -112,7 +121,11 @@ def landlock_abi():
         )
     except OSError as error:
         if error.errno not in {errno.ENOSYS, errno.EOPNOTSUPP}:
-            raise
+            raise ContainmentStageError(
+                "landlock_capability_probe",
+                error,
+                SYS_LANDLOCK_CREATE_RULESET,
+            ) from error
         # Blacksmith hosts vary in whether Landlock is exposed through their
         # syscall policy. The mount namespace has already established the same
         # write allowlist; only the capability probe may select that fallback.
@@ -157,11 +170,25 @@ def set_mount_readonly(path, readonly, recursive=True):
         )
     except OSError as error:
         if error.errno != errno.ENOSYS:
-            raise
+            raise ContainmentStageError(
+                "mount_setattr",
+                error,
+                SYS_MOUNT_SETATTR,
+            ) from error
         # Some ephemeral VM kernels expose delegated mount namespaces but not
         # mount_setattr. Preserve the same fail-closed policy by remounting every
         # concrete mount below the bind target; do not weaken other syscall errors.
-        legacy_set_mount_readonly(path, readonly, recursive)
+        try:
+            legacy_set_mount_readonly(path, readonly, recursive)
+        except BaseException as legacy_error:
+            syscall_number = SYS_MOUNT if isinstance(legacy_error, OSError) else None
+            raise ContainmentStageError(
+                "legacy_remount",
+                legacy_error,
+                syscall_number,
+            ) from legacy_error
+        return "legacy"
+    return "native"
 
 
 def decoded_mountinfo_path(value):
@@ -459,16 +486,17 @@ def isolate_filesystem(canonical_roots, sandbox_root, original_cwd, command):
         )
         if os.path.exists(device)
     ]
-    set_mount_readonly(sandbox_root, True)
+    readonly_modes = {set_mount_readonly(sandbox_root, True)}
     for target, recursive in writable_targets:
-        set_mount_readonly(target, False, recursive)
+        readonly_modes.add(set_mount_readonly(target, False, recursive))
     for target, recursive in runtime_targets:
-        set_mount_readonly(target, True, recursive)
-    set_mount_readonly(proc_target[0], True, proc_target[1])
+        readonly_modes.add(set_mount_readonly(target, True, recursive))
+    readonly_modes.add(set_mount_readonly(proc_target[0], True, proc_target[1]))
     for target, recursive in device_targets:
-        set_mount_readonly(target, False, recursive)
+        readonly_modes.add(set_mount_readonly(target, False, recursive))
     os.chroot(sandbox_root)
     os.chdir(original_cwd)
+    return "legacy" if "legacy" in readonly_modes else "native"
 
 
 def bring_up_loopback():
@@ -489,13 +517,20 @@ def add_writable_path(ruleset_fd, path, allowed_access):
         rule = (ctypes.c_ubyte * 12).from_buffer_copy(
             struct.pack("=Qi", allowed_access, path_fd)
         )
-        checked_syscall(
-            SYS_LANDLOCK_ADD_RULE,
-            ctypes.c_int(ruleset_fd),
-            ctypes.c_int(LANDLOCK_RULE_PATH_BENEATH),
-            ctypes.byref(rule),
-            ctypes.c_uint32(0),
-        )
+        try:
+            checked_syscall(
+                SYS_LANDLOCK_ADD_RULE,
+                ctypes.c_int(ruleset_fd),
+                ctypes.c_int(LANDLOCK_RULE_PATH_BENEATH),
+                ctypes.byref(rule),
+                ctypes.c_uint32(0),
+            )
+        except OSError as error:
+            raise ContainmentStageError(
+                "landlock_add_rule",
+                error,
+                SYS_LANDLOCK_ADD_RULE,
+            ) from error
     finally:
         os.close(path_fd)
 
@@ -516,16 +551,28 @@ def canonical_writable_roots(writable_roots):
 def restrict_filesystem_writes(canonical_roots):
     abi = landlock_abi()
     if abi is None:
-        return
+        return "unavailable"
     if abi < 3:
-        raise RuntimeError("Landlock ABI 3 or newer is required")
+        error = RuntimeError("Landlock ABI 3 or newer is required")
+        raise ContainmentStageError(
+            "landlock_capability_probe",
+            error,
+            SYS_LANDLOCK_CREATE_RULESET,
+        ) from error
     ruleset = LandlockRulesetAttr(handled_access_fs=LANDLOCK_WRITE_ACCESS)
-    ruleset_fd = checked_syscall(
-        SYS_LANDLOCK_CREATE_RULESET,
-        ctypes.byref(ruleset),
-        ctypes.sizeof(ruleset),
-        ctypes.c_uint32(0),
-    )
+    try:
+        ruleset_fd = checked_syscall(
+            SYS_LANDLOCK_CREATE_RULESET,
+            ctypes.byref(ruleset),
+            ctypes.sizeof(ruleset),
+            ctypes.c_uint32(0),
+        )
+    except OSError as error:
+        raise ContainmentStageError(
+            "landlock_ruleset_creation",
+            error,
+            SYS_LANDLOCK_CREATE_RULESET,
+        ) from error
     try:
         for root in canonical_roots:
             add_writable_path(ruleset_fd, root, LANDLOCK_WRITE_ACCESS)
@@ -538,14 +585,23 @@ def restrict_filesystem_writes(canonical_roots):
                 )
         if libc.prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0:
             error_number = ctypes.get_errno()
-            raise OSError(error_number, os.strerror(error_number))
-        checked_syscall(
-            SYS_LANDLOCK_RESTRICT_SELF,
-            ctypes.c_int(ruleset_fd),
-            ctypes.c_uint32(0),
-        )
+            error = OSError(error_number, os.strerror(error_number))
+            raise ContainmentStageError("landlock_restrict_self", error) from error
+        try:
+            checked_syscall(
+                SYS_LANDLOCK_RESTRICT_SELF,
+                ctypes.c_int(ruleset_fd),
+                ctypes.c_uint32(0),
+            )
+        except OSError as error:
+            raise ContainmentStageError(
+                "landlock_restrict_self",
+                error,
+                SYS_LANDLOCK_RESTRICT_SELF,
+            ) from error
     finally:
         os.close(ruleset_fd)
+    return "abi-" + str(abi)
 
 
 def drop_capabilities():
@@ -581,6 +637,25 @@ def write_protocol(payload):
     while encoded:
         written = os.write(PROTOCOL_FD, encoded)
         encoded = encoded[written:]
+
+
+def containment_error_payload(error):
+    if isinstance(error, ContainmentStageError):
+        return {
+            "stage": error.stage,
+            "syscall": error.syscall_number,
+            "errno": error.error_number,
+        }
+    return {"stage": "unknown", "syscall": None, "errno": getattr(error, "errno", None)}
+
+
+def run_stage(stage, operation):
+    try:
+        return operation()
+    except ContainmentStageError:
+        raise
+    except BaseException as error:
+        raise ContainmentStageError(stage, error) from error
 
 
 def process_rows():
@@ -670,11 +745,14 @@ def terminate_and_reap_descendants(primary_pid, background_pids):
 
 
 def main():
-    if libc.prctl(PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) != 0:
-        error_number = ctypes.get_errno()
-        raise OSError(error_number, os.strerror(error_number))
-    signal.signal(signal.SIGTERM, request_termination)
-    signal.signal(signal.SIGUSR1, request_termination)
+    def configure_namespace_init():
+        if libc.prctl(PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) != 0:
+            error_number = ctypes.get_errno()
+            raise OSError(error_number, os.strerror(error_number))
+        signal.signal(signal.SIGTERM, request_termination)
+        signal.signal(signal.SIGUSR1, request_termination)
+
+    run_stage("namespace_setup", configure_namespace_init)
     writable_roots = json.loads(sys.argv[1])
     if not isinstance(writable_roots, list) or not all(
         isinstance(root, str) and root for root in writable_roots
@@ -692,15 +770,18 @@ def main():
     canonical_roots = canonical_writable_roots(writable_roots)
     original_cwd = os.path.realpath(os.getcwd())
     if isolate_network:
-        bring_up_loopback()
-    isolate_filesystem(
-        canonical_roots,
-        sandbox_root,
-        original_cwd,
-        command,
+        run_stage("namespace_setup", bring_up_loopback)
+    mount_readonly = run_stage(
+        "filesystem_isolation",
+        lambda: isolate_filesystem(
+            canonical_roots,
+            sandbox_root,
+            original_cwd,
+            command,
+        ),
     )
-    restrict_filesystem_writes(canonical_roots)
-    drop_capabilities()
+    landlock = restrict_filesystem_writes(canonical_roots)
+    run_stage("capability_drop", drop_capabilities)
     child = subprocess.Popen(command, close_fds=True)
     background_pids = set()
     while True:
@@ -715,17 +796,26 @@ def main():
     write_protocol(
         {
             "backgroundProcesses": background_processes,
+            "capabilitySummary": {
+                "mount_readonly": mount_readonly,
+                "landlock": landlock,
+            },
             "signal": signal.Signals(-return_code).name if return_code < 0 else None,
             "status": return_code if return_code >= 0 else None,
         }
     )
 
 
-try:
-    main()
-except BaseException as error:
+def run_entrypoint():
     try:
-        write_protocol({"containmentError": str(error)})
-    finally:
-        sys.exit(125)
+        main()
+    except BaseException as error:
+        try:
+            write_protocol({"containmentError": containment_error_payload(error)})
+        finally:
+            sys.exit(125)
+
+
+if __name__ == "__main__":
+    run_entrypoint()
 `;

--- a/test/repair/command-runner.test.ts
+++ b/test/repair/command-runner.test.ts
@@ -87,8 +87,8 @@ test(
   "Linux containment exposes only configured writable roots and minimal runtime files",
   { skip: process.platform !== "linux" },
   (context) => {
-    if (!linuxValidationContainmentAvailable()) {
-      context.skip("runner does not provide delegated user namespaces and Landlock ABI 3+");
+    if (!linuxValidationNamespacesAvailable()) {
+      context.skip("runner does not provide delegated validation namespaces");
       return;
     }
     const root = mkdtempSync(join(tmpdir(), "clawsweeper-filesystem-isolation-"));
@@ -189,8 +189,8 @@ test(
   "Linux containment protects namespace init from target termination",
   { skip: process.platform !== "linux" },
   (context) => {
-    if (!linuxValidationContainmentAvailable()) {
-      context.skip("runner does not provide delegated user namespaces and Landlock ABI 3+");
+    if (!linuxValidationNamespacesAvailable()) {
+      context.skip("runner does not provide delegated validation namespaces");
       return;
     }
     const root = mkdtempSync(join(tmpdir(), "clawsweeper-supervisor-kill-"));
@@ -234,7 +234,7 @@ test(
   "Linux network containment preserves isolated loopback communication",
   { skip: process.platform !== "linux" },
   (context) => {
-    if (!linuxValidationContainmentAvailable()) {
+    if (!linuxValidationNamespacesAvailable()) {
       context.skip("runner does not provide delegated validation namespaces");
       return;
     }
@@ -282,7 +282,7 @@ test(
   "Linux containment cannot reach host-local listeners",
   { skip: process.platform !== "linux" },
   (context) => {
-    if (!linuxValidationContainmentAvailable()) {
+    if (!linuxValidationNamespacesAvailable()) {
       context.skip("runner does not provide delegated validation namespaces");
       return;
     }
@@ -420,7 +420,7 @@ test("shared spawn resolver escapes Windows batch launcher arguments", () => {
   }
 });
 
-function linuxValidationContainmentAvailable() {
+function linuxValidationNamespacesAvailable() {
   const probe = spawnSync(
     "/usr/bin/unshare",
     [
@@ -434,14 +434,7 @@ function linuxValidationContainmentAvailable() {
       "--kill-child=SIGKILL",
       "/usr/bin/python3",
       "-c",
-      [
-        "import ctypes, os",
-        "libc = ctypes.CDLL(None, use_errno=True)",
-        "libc.syscall.restype = ctypes.c_long",
-        "abi = libc.syscall(ctypes.c_long(444), ctypes.c_void_p(), ctypes.c_size_t(0), ctypes.c_uint32(1))",
-        "assert os.getpid() == 1",
-        "assert abi >= 3",
-      ].join("; "),
+      ["import os", "assert os.getpid() == 1"].join("; "),
     ],
     { stdio: "ignore" },
   );

--- a/test/repair/containment-preflight.test.ts
+++ b/test/repair/containment-preflight.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { safePreflightErrorMessage } from "../../dist/repair/containment-preflight.js";
+
+test("containment preflight preserves only validated safe diagnostics", () => {
+  assert.equal(
+    safePreflightErrorMessage(
+      new Error(
+        "validation process containment failed: stage=landlock_capability_probe syscall=444 errno=38",
+      ),
+    ),
+    "validation process containment failed: stage=landlock_capability_probe syscall=444 errno=38",
+  );
+  assert.equal(
+    safePreflightErrorMessage(
+      new Error("validation process containment failed: stage=namespace_setup exit=125"),
+    ),
+    "validation process containment failed: stage=namespace_setup exit=125",
+  );
+  assert.equal(
+    safePreflightErrorMessage(new Error("failed near /home/runner/target-work command")),
+    "containment preflight failed closed",
+  );
+});

--- a/test/repair/process-tree-containment.test.ts
+++ b/test/repair/process-tree-containment.test.ts
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 
+import { LINUX_SUBREAPER_SCRIPT } from "../../dist/repair/process-tree-containment.js";
+import { parseContainmentProtocol } from "../../dist/repair/contained-command-worker.js";
 import { readText } from "../helpers.ts";
 
 test("Linux validation containment uses an externally owned PID namespace and subreaper", () => {
@@ -72,10 +77,10 @@ test("Linux validation containment applies every fail-closed stage before target
   const containment = readText(path.join(process.cwd(), "src/repair/process-tree-containment.ts"));
   const main = containment.slice(containment.indexOf("def main():"));
 
-  const loopback = main.indexOf("bring_up_loopback()");
+  const loopback = main.indexOf('run_stage("namespace_setup", bring_up_loopback)');
   const filesystem = main.indexOf("isolate_filesystem(");
   const landlock = main.indexOf("restrict_filesystem_writes(canonical_roots)");
-  const capabilities = main.indexOf("drop_capabilities()");
+  const capabilities = main.indexOf('run_stage("capability_drop", drop_capabilities)');
   const spawn = main.indexOf("subprocess.Popen(command, close_fds=True)");
 
   assert.ok(loopback >= 0);
@@ -87,3 +92,223 @@ test("Linux validation containment applies every fail-closed stage before target
   assert.match(containment, /"\/run",/);
   assert.match(containment, /os\.symlink\("\/run", root_path\(sandbox_root, "\/var\/run"\)\)/);
 });
+
+test("embedded containment runtime imports without executing its production entrypoint", () => {
+  const result = runLandlockScenario("import");
+
+  assert.deepEqual(result, { status: "imported" });
+});
+
+test("Landlock capability probe selects fallback only for unsupported syscalls", () => {
+  for (const scenario of ["probe_enosys", "probe_eopnotsupp"]) {
+    const result = runLandlockScenario(scenario);
+    assert.deepEqual(result, { calls: [444], result: "unavailable", status: "ok" });
+  }
+
+  for (const [scenario, errorNumber] of [
+    ["probe_eperm", 1],
+    ["probe_eacces", 13],
+    ["probe_einval", 22],
+  ] as const) {
+    const result = runLandlockScenario(scenario);
+    assert.deepEqual(result, {
+      errno: errorNumber,
+      stage: "landlock_capability_probe",
+      status: "error",
+      syscall: 444,
+    });
+  }
+});
+
+test("Landlock enforcement remains fail closed after a successful probe", () => {
+  assert.deepEqual(runLandlockScenario("abi_2"), {
+    errno: null,
+    stage: "landlock_capability_probe",
+    status: "error",
+    syscall: 444,
+  });
+  assert.deepEqual(runLandlockScenario("success"), {
+    calls: [444, 444, 445, 446],
+    result: "abi-3",
+    status: "ok",
+  });
+
+  for (const [scenario, stage, syscall, errorNumber] of [
+    ["create_enosys", "landlock_ruleset_creation", 444, 38],
+    ["add_eacces", "landlock_add_rule", 445, 13],
+    ["restrict_eperm", "landlock_restrict_self", 446, 1],
+  ] as const) {
+    const result = runLandlockScenario(scenario);
+    assert.deepEqual(result, {
+      errno: errorNumber,
+      stage,
+      status: "error",
+      syscall,
+    });
+  }
+});
+
+test("mount and mandatory-stage failures retain actionable safe diagnostics", () => {
+  assert.deepEqual(runLandlockScenario("mount_native"), {
+    result: "native",
+    status: "ok",
+  });
+  assert.deepEqual(runLandlockScenario("mount_legacy"), {
+    result: "legacy",
+    status: "ok",
+  });
+  assert.deepEqual(runLandlockScenario("mount_eperm"), {
+    errno: 1,
+    stage: "mount_setattr",
+    status: "error",
+    syscall: 442,
+  });
+  assert.deepEqual(runLandlockScenario("legacy_eacces"), {
+    errno: 13,
+    stage: "legacy_remount",
+    status: "error",
+    syscall: 165,
+  });
+  assert.deepEqual(runLandlockScenario("capability_drop_eperm"), {
+    errno: 1,
+    stage: "capability_drop",
+    status: "error",
+    syscall: null,
+  });
+});
+
+test("containment diagnostics expose only validated stage, syscall, and errno fields", () => {
+  assert.throws(
+    () =>
+      parseContainmentProtocol(
+        [
+          Buffer.from(
+            JSON.stringify({
+              containmentError: {
+                errno: 38,
+                stage: "landlock_capability_probe",
+                syscall: 444,
+                unsafe: "/home/runner/secret command",
+              },
+            }),
+          ),
+        ],
+        { signal: null, status: 125 },
+      ),
+    (error: Error) => {
+      assert.equal(
+        error.message,
+        "validation process containment failed: stage=landlock_capability_probe syscall=444 errno=38",
+      );
+      assert.doesNotMatch(error.message, /runner|secret|command/);
+      return true;
+    },
+  );
+
+  assert.throws(
+    () => parseContainmentProtocol([], { signal: null, status: 1 }),
+    /stage=namespace_setup exit=1/,
+  );
+});
+
+function runLandlockScenario(scenario: string): Record<string, unknown> {
+  const root = mkdtempSync(path.join(tmpdir(), "clawsweeper-containment-python-"));
+  const modulePath = path.join(root, "containment_runtime.py");
+  writeFileSync(modulePath, LINUX_SUBREAPER_SCRIPT);
+  try {
+    const harness = String.raw`
+import errno
+import importlib.util
+import json
+import sys
+
+module_path, scenario = sys.argv[1:]
+spec = importlib.util.spec_from_file_location("containment_runtime", module_path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+if scenario == "import":
+    print(json.dumps({"status": "imported"}, separators=(",", ":")))
+    raise SystemExit(0)
+
+def error_payload(error):
+    return {
+        "errno": error.error_number,
+        "stage": error.stage,
+        "status": "error",
+        "syscall": error.syscall_number,
+    }
+
+if scenario.startswith("mount_") or scenario == "legacy_eacces":
+    def mount_syscall(_number, *_arguments):
+        if scenario in {"mount_legacy", "legacy_eacces"}:
+            raise OSError(errno.ENOSYS, "mount_setattr")
+        if scenario == "mount_eperm":
+            raise OSError(errno.EPERM, "mount_setattr")
+        return 0
+    def legacy_mount(_path, _readonly, _recursive):
+        if scenario == "legacy_eacces":
+            raise OSError(errno.EACCES, "legacy")
+    module.checked_syscall = mount_syscall
+    module.legacy_set_mount_readonly = legacy_mount
+    try:
+        payload = {"result": module.set_mount_readonly("/sandbox", True), "status": "ok"}
+    except module.ContainmentStageError as error:
+        payload = error_payload(error)
+    print(json.dumps(payload, separators=(",", ":")))
+    raise SystemExit(0)
+
+if scenario == "capability_drop_eperm":
+    def fail_capability_drop():
+        raise OSError(errno.EPERM, "capability")
+    try:
+        module.run_stage("capability_drop", fail_capability_drop)
+    except module.ContainmentStageError as error:
+        print(json.dumps(error_payload(error), separators=(",", ":")))
+        raise SystemExit(0)
+
+calls = []
+probe_errors = {
+    "probe_enosys": errno.ENOSYS,
+    "probe_eopnotsupp": errno.EOPNOTSUPP,
+    "probe_eperm": errno.EPERM,
+    "probe_eacces": errno.EACCES,
+    "probe_einval": errno.EINVAL,
+}
+
+def fake_syscall(number, *arguments):
+    calls.append(number)
+    if len(calls) == 1:
+        if scenario in probe_errors:
+            raise OSError(probe_errors[scenario], "probe")
+        return 2 if scenario == "abi_2" else 3
+    if number == module.SYS_LANDLOCK_CREATE_RULESET:
+        if scenario == "create_enosys":
+            raise OSError(errno.ENOSYS, "create")
+        return 91
+    if number == module.SYS_LANDLOCK_ADD_RULE and scenario == "add_eacces":
+        raise OSError(errno.EACCES, "add")
+    if number == module.SYS_LANDLOCK_RESTRICT_SELF and scenario == "restrict_eperm":
+        raise OSError(errno.EPERM, "restrict")
+    return 0
+
+module.checked_syscall = fake_syscall
+module.os.open = lambda _path, _flags: 17
+module.os.close = lambda _fd: None
+module.os.path.exists = lambda _path: False
+module.libc.prctl = lambda *_arguments: 0
+try:
+    result = module.restrict_filesystem_writes(["/work"])
+    payload = {"calls": calls, "result": result, "status": "ok"}
+except module.ContainmentStageError as error:
+    payload = error_payload(error)
+print(json.dumps(payload, separators=(",", ":")))
+`;
+    const child = spawnSync("/usr/bin/python3", ["-c", harness, modulePath, scenario], {
+      encoding: "utf8",
+    });
+    assert.equal(child.status, 0, child.stderr);
+    return JSON.parse(child.stdout) as Record<string, unknown>;
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
## Summary

- execute the authoritative embedded Python Landlock fallback and fail-closed policy in deterministic tests
- split delegated namespace availability from optional Landlock availability for containment integration coverage
- add safe stage/syscall/errno diagnostics and a compiled non-mutating `repair:containment-smoke` CLI
- persist the two-PR execution plan; workflow wiring and the Blacksmith runner job remain in PR 2

This follows https://github.com/openclaw/clawsweeper/pull/598. It does not dispatch repairs, mutate target branches, apply results, or close items.

## Validation

- `pnpm run check`
- focused containment suite: 23 tests passed before review fixes
- post-review focused suite: 18 tests passed
- `pnpm run repair:containment-smoke` -> `mount_readonly=native landlock=unavailable`
- `pnpm run lint:scripts`
- `pnpm run format:check`
- autoreview: clean, no accepted/actionable findings