### PR TITLE
add dashboard health trends

### DIFF
--- a/dashboard/operational-health.ts
+++ b/dashboard/operational-health.ts
@@ -1,0 +1,172 @@
+export const OPERATIONAL_QUEUE_DEGRADED_MS = 30 * 60 * 1000;
+export const OPERATIONAL_RUNNING_STALLED_MS = 150 * 60 * 1000;
+export const HEALTH_HISTORY_SAMPLE_MS = 5 * 60 * 1000;
+export const HEALTH_HISTORY_RETENTION_DAYS = 7;
+
+const QUEUED_STATUSES = new Set(["queued", "waiting", "requested", "pending"]);
+
+type WorkflowRun = {
+  status?: string;
+  created_at?: string;
+  run_started_at?: string;
+};
+
+export type OperationalHealth = {
+  status: "healthy" | "degraded" | "stalled" | "unknown";
+  checked_at: string;
+  telemetry_complete: boolean;
+  queued_runs: number;
+  queued_over_threshold: number;
+  queued_threshold_minutes: number;
+  oldest_queued_minutes: number;
+  running_runs: number;
+  running_over_threshold: number;
+  running_threshold_minutes: number;
+  oldest_running_minutes: number;
+};
+
+export type HealthHistorySample = {
+  at: string;
+  status: OperationalHealth["status"];
+  queued: number;
+  queued_over_30m: number;
+  oldest_queued_minutes: number;
+  running: number;
+  running_over_150m: number;
+  oldest_running_minutes: number;
+  collection_ok: boolean;
+};
+
+export function summarizeOperationalHealth(
+  runs: WorkflowRun[],
+  checkedAt: string,
+  telemetryComplete: boolean,
+): OperationalHealth {
+  const checkedAtMs = Date.parse(checkedAt);
+  const now = Number.isFinite(checkedAtMs) ? checkedAtMs : Date.now();
+  const queuedRuns = runs.filter((run) => QUEUED_STATUSES.has(String(run.status || "")));
+  const runningRuns = runs.filter((run) => run.status === "in_progress");
+  const queuedAges = queuedRuns.map((run) => ageMs(run.created_at, now));
+  const runningAges = runningRuns
+    // GitHub exposes queue admission and execution start separately. Falling
+    // back keeps older payloads observable without charging queue time when
+    // the authoritative execution timestamp is present.
+    .map((run) => ageMs(run.run_started_at || run.created_at, now));
+  const validQueuedAges = queuedAges.filter((age): age is number => age !== null);
+  const validRunningAges = runningAges.filter((age): age is number => age !== null);
+  const hasCompleteAges =
+    validQueuedAges.length === queuedRuns.length && validRunningAges.length === runningRuns.length;
+  const complete = telemetryComplete && hasCompleteAges;
+  const queuedOverThreshold = validQueuedAges.filter(
+    (age) => age >= OPERATIONAL_QUEUE_DEGRADED_MS,
+  ).length;
+  const runningOverThreshold = validRunningAges.filter(
+    (age) => age >= OPERATIONAL_RUNNING_STALLED_MS,
+  ).length;
+  const status = !complete
+    ? "unknown"
+    : runningOverThreshold
+      ? "stalled"
+      : queuedOverThreshold
+        ? "degraded"
+        : "healthy";
+  return {
+    status,
+    checked_at: new Date(now).toISOString(),
+    telemetry_complete: complete,
+    queued_runs: queuedRuns.length,
+    queued_over_threshold: queuedOverThreshold,
+    queued_threshold_minutes: OPERATIONAL_QUEUE_DEGRADED_MS / 60_000,
+    oldest_queued_minutes: oldestMinutes(validQueuedAges),
+    running_runs: runningRuns.length,
+    running_over_threshold: runningOverThreshold,
+    running_threshold_minutes: OPERATIONAL_RUNNING_STALLED_MS / 60_000,
+    oldest_running_minutes: oldestMinutes(validRunningAges),
+  };
+}
+
+export function healthHistorySample(health: OperationalHealth): HealthHistorySample {
+  return {
+    at: health.checked_at,
+    status: health.status,
+    queued: health.queued_runs,
+    queued_over_30m: health.queued_over_threshold,
+    oldest_queued_minutes: health.oldest_queued_minutes,
+    running: health.running_runs,
+    running_over_150m: health.running_over_threshold,
+    oldest_running_minutes: health.oldest_running_minutes,
+    collection_ok: health.telemetry_complete,
+  };
+}
+
+export function normalizeHealthHistorySample(value: unknown): HealthHistorySample | null {
+  if (!value || typeof value !== "object") return null;
+  const sample = value as Record<string, unknown>;
+  const at = String(sample.at || "");
+  if (!Number.isFinite(Date.parse(at))) return null;
+  const rawStatus = String(sample.status || "");
+  if (!["healthy", "degraded", "stalled", "unknown"].includes(rawStatus)) return null;
+  if (typeof sample.collection_ok !== "boolean") return null;
+  const countFields = [
+    "queued",
+    "queued_over_30m",
+    "oldest_queued_minutes",
+    "running",
+    "running_over_150m",
+    "oldest_running_minutes",
+  ] as const;
+  const counts = Object.fromEntries(
+    countFields.map((field) => [field, nonNegativeInteger(sample[field])]),
+  ) as Record<(typeof countFields)[number], number | null>;
+  if (Object.values(counts).some((count) => count === null)) return null;
+  return {
+    at,
+    status: rawStatus as HealthHistorySample["status"],
+    queued: counts.queued!,
+    queued_over_30m: counts.queued_over_30m!,
+    oldest_queued_minutes: counts.oldest_queued_minutes!,
+    running: counts.running!,
+    running_over_150m: counts.running_over_150m!,
+    oldest_running_minutes: counts.oldest_running_minutes!,
+    collection_ok: sample.collection_ok,
+  };
+}
+
+export function mergeHealthHistorySample(
+  current: unknown,
+  sample: HealthHistorySample,
+): HealthHistorySample[] {
+  const slot = historySlot(sample.at);
+  const entries = Array.isArray(current) ? current : [];
+  const normalized = entries
+    .map((entry) => normalizeHealthHistorySample(entry))
+    .filter((entry): entry is HealthHistorySample => Boolean(entry));
+  const latestInSlot = normalized
+    .filter((entry) => historySlot(entry.at) === slot)
+    .sort((left, right) => Date.parse(right.at) - Date.parse(left.at))[0];
+  // Cron retries may finish out of order. Slot deduplication must not let an
+  // older observation erase a newer health transition that already landed.
+  const winner =
+    latestInSlot && Date.parse(latestInSlot.at) > Date.parse(sample.at) ? latestInSlot : sample;
+  return [...normalized.filter((entry) => historySlot(entry.at) !== slot), winner].sort(
+    (left, right) => Date.parse(left.at) - Date.parse(right.at),
+  );
+}
+
+function historySlot(value: string) {
+  return Math.floor(Date.parse(value) / HEALTH_HISTORY_SAMPLE_MS);
+}
+
+function ageMs(value: string | undefined, now: number) {
+  const timestamp = Date.parse(String(value || ""));
+  return Number.isFinite(timestamp) ? Math.max(0, now - timestamp) : null;
+}
+
+function nonNegativeInteger(value: unknown) {
+  const number = Number(value);
+  return Number.isFinite(number) ? Math.max(0, Math.round(number)) : null;
+}
+
+function oldestMinutes(ages: number[]) {
+  return ages.length ? Math.round(Math.max(...ages) / 60_000) : 0;
+}

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -6,6 +6,13 @@ import { isExactReviewCloseGuardLabel } from "../src/repair/exact-review-guard-l
 import { stableJson } from "../src/stable-json.ts";
 import { bayHtml } from "./bay-page.ts";
 import { summarizeExactReviewHandoff } from "./exact-review-health.ts";
+import {
+  HEALTH_HISTORY_RETENTION_DAYS,
+  healthHistorySample,
+  mergeHealthHistorySample,
+  normalizeHealthHistorySample,
+  summarizeOperationalHealth,
+} from "./operational-health.ts";
 import { TRIAGE_ROUTING_GROUPS, triageRoutingGroupsForLabels } from "./triage-routing-groups.ts";
 
 const ACTIVE_RUN_STATUSES = new Set(["queued", "in_progress", "waiting", "requested", "pending"]);
@@ -142,6 +149,8 @@ const CLOSED_STATS_PAGE_LIMIT = 10;
 const DEFAULT_CLAWSWEEPER_BOT_LOGINS = ["clawsweeper[bot]", "openclaw-clawsweeper[bot]"];
 const GITHUB_TIMEOUT_MS = 4500;
 const DEFAULT_STALE_QUEUED_WORKFLOW_MS = 6 * 60 * 60 * 1000;
+const HEALTH_HISTORY_TTL_SECONDS = (HEALTH_HISTORY_RETENTION_DAYS + 1) * 24 * 60 * 60;
+const HEALTH_HISTORY_KEY_PREFIX = "health-history:";
 const DEFAULT_EXACT_REVIEW_QUEUE_MAX_CONCURRENT = 64;
 const DEFAULT_EXACT_REVIEW_TARGET_MAX_CONCURRENT = 60;
 const DEFAULT_EXACT_REVIEW_DISPATCH_LEASE_MS = 6 * 60 * 1000;
@@ -461,6 +470,28 @@ export class StatusStore {
       });
       await this.scheduleCleanup(expiresAt);
       return json({ ok: true });
+    }
+
+    if (request.method === "POST" && key === "health-history") {
+      const body = await request.json();
+      const sample = normalizeHealthHistorySample(body?.sample);
+      if (!sample) return new Response("invalid health sample", { status: 400 });
+      const bucketKey = `${HEALTH_HISTORY_KEY_PREFIX}${sample.at.slice(0, 10)}`;
+      const current = (await this.storage.get(bucketKey)) as StoredValue | undefined;
+      let currentSamples = [];
+      try {
+        currentSamples = current?.value ? JSON.parse(current.value) : [];
+      } catch {
+        currentSamples = [];
+      }
+      const samples = mergeHealthHistorySample(currentSamples, sample);
+      const expiresAt = Date.now() + HEALTH_HISTORY_TTL_SECONDS * 1000;
+      await this.storage.put(bucketKey, {
+        value: JSON.stringify(samples),
+        expires_at: expiresAt,
+      });
+      await this.scheduleCleanup(expiresAt);
+      return json({ ok: true, samples: samples.length });
     }
 
     return new Response("method not allowed", { status: 405 });
@@ -1574,6 +1605,8 @@ export default {
       return authenticatedExactReviewReconcile(request, env);
     if (url.pathname === "/api/exact-review-queue" && request.method === "GET")
       return exactReviewQueueRequest(env, "/stats");
+    if (url.pathname === "/api/health-history" && request.method === "GET")
+      return healthHistoryJson(request, env);
     if (url.pathname === "/api/status") return statusJson(request, env, ctx);
     if (url.pathname === "/api/triage") return triageJson(request, env, ctx);
     if (url.pathname === "/api/pr-proof-triage") return prProofTriageJson(request, env, ctx);
@@ -1584,6 +1617,11 @@ export default {
     if (url.pathname === "/pr-proof-triage" || url.pathname === "/pr-proof-triage.html")
       return html(triageHtml(prProofTriagePageConfig()));
     return json({ error: "not_found" }, 404);
+  },
+  async scheduled(_controller, env: DashboardEnv = {}, ctx?: DashboardContext) {
+    const recording = recordScheduledHealthSample(env);
+    if (ctx?.waitUntil) ctx.waitUntil(recording);
+    else await recording;
   },
 };
 
@@ -1601,6 +1639,99 @@ async function statusJson(request, env, ctx) {
   const refreshed = await refreshStatus(request, env);
   if (refreshed.looksEmpty && stale) return cachedStatusResponse(stale, "stale", env);
   return statusSnapshotResponse(refreshed.snapshot, "miss", env);
+}
+
+async function healthHistoryJson(request: Request, env: DashboardEnv) {
+  const range = new URL(request.url).searchParams.get("range") === "7d" ? "7d" : "24h";
+  const rangeMs = range === "7d" ? 7 * 24 * 60 * 60 * 1000 : 24 * 60 * 60 * 1000;
+  const now = Date.now();
+  const groups = await Promise.all(
+    healthHistoryDates(now - rangeMs, now).map(async (day) => {
+      if (!env.STATUS_STORE) return [];
+      const text = await readStatusStoreText(
+        env.STATUS_STORE,
+        `${HEALTH_HISTORY_KEY_PREFIX}${day}`,
+      );
+      if (!text) return [];
+      try {
+        const parsed = JSON.parse(text);
+        return Array.isArray(parsed) ? parsed : [];
+      } catch {
+        return [];
+      }
+    }),
+  );
+  const samples = groups
+    .flat()
+    .map((sample) => normalizeHealthHistorySample(sample))
+    .filter((sample) => sample && Date.parse(sample.at) >= now - rangeMs)
+    .sort((left, right) => Date.parse(left.at) - Date.parse(right.at));
+  return cors(
+    json({
+      schema_version: 1,
+      range,
+      retention_days: HEALTH_HISTORY_RETENTION_DAYS,
+      samples,
+    }),
+  );
+}
+
+function healthHistoryDates(fromMs: number, toMs: number) {
+  const dates = [];
+  const cursor = new Date(fromMs);
+  cursor.setUTCHours(0, 0, 0, 0);
+  while (cursor.getTime() <= toMs) {
+    dates.push(cursor.toISOString().slice(0, 10));
+    cursor.setUTCDate(cursor.getUTCDate() + 1);
+  }
+  return dates;
+}
+
+async function recordScheduledHealthSample(env) {
+  if (!env.STATUS_STORE) return;
+  const health = await collectOperationalHealth(env);
+  await appendHealthHistorySample(env, healthHistorySample(health));
+}
+
+async function collectOperationalHealth(env) {
+  const repo = env.CLAWSWEEPER_REPO || "openclaw/clawsweeper";
+  const errors = [];
+  const runs = await activeWorkflowRunCandidates(env, repo, errors, createGithubJsonCache(env));
+  const checkedAt = new Date().toISOString();
+  return summarizeOperationalHealth(
+    runs.filter((run) => !isSupportWorkflowRun(run)),
+    checkedAt,
+    errors.length === 0,
+  );
+}
+
+async function appendHealthHistorySample(env, sample) {
+  const store = env.STATUS_STORE;
+  if (!store) return;
+  if (isDurableStatusStore(store)) {
+    const response = await durableStatusStoreStub(store).fetch(
+      new Request(statusStoreRequest("health-history", "POST"), {
+        method: "POST",
+        body: JSON.stringify({ sample }),
+      }),
+    );
+    if (!response.ok) throw new Error(`health history write failed: ${response.status}`);
+    return;
+  }
+  const key = `${HEALTH_HISTORY_KEY_PREFIX}${sample.at.slice(0, 10)}`;
+  const text = await readStatusStoreText(store, key);
+  let current = [];
+  try {
+    current = text ? JSON.parse(text) : [];
+  } catch {
+    current = [];
+  }
+  await writeStatusStoreText(
+    store,
+    key,
+    JSON.stringify(mergeHealthHistorySample(current, sample)),
+    HEALTH_HISTORY_TTL_SECONDS,
+  );
 }
 
 async function cachedStatusResponse(cached, cacheState, env) {
@@ -3619,7 +3750,8 @@ async function statusSnapshot(env) {
     .map((value) => value.trim())
     .filter(Boolean);
   const budget = numberFrom(env.WORKER_BUDGET, 128);
-  const [runs, completedRuns, filteredActiveRuns] = await Promise.all([
+  const activeRunErrors = [];
+  const [runs, completedRuns, activeRunCandidates] = await Promise.all([
     github(`/repos/${repo}/actions/runs?per_page=100`).catch((error) => {
       errors.push(`workflow runs: ${error.message}`);
       return null;
@@ -3628,19 +3760,25 @@ async function statusSnapshot(env) {
       errors.push(`workflow runs completed: ${error.message}`);
       return null;
     }),
-    activeWorkflowRuns(env, repo, errors, github),
+    activeWorkflowRunCandidates(env, repo, activeRunErrors, github),
   ]);
+  errors.push(...activeRunErrors);
   const workflowRuns = Array.isArray(runs?.workflow_runs) ? runs.workflow_runs : [];
   const completedWorkflowRuns = uniqueWorkflowRuns([
     ...(Array.isArray(completedRuns?.workflow_runs) ? completedRuns.workflow_runs : []),
     ...workflowRuns.filter((run) => run.status === "completed"),
   ]).sort(newestWorkflowRunFirst);
   const activeRuns = uniqueWorkflowRuns([
-    ...filteredActiveRuns,
+    ...activeRunCandidates.filter((run) => isActiveWorkflowRun(run)),
     ...workflowRuns.filter((run) => isActiveWorkflowRun(run)),
   ]).sort(newestWorkflowRunFirst);
   const workerRuns = activeRuns.filter((run) => !isSupportWorkflowRun(run));
   const supportRuns = activeRuns.filter((run) => isSupportWorkflowRun(run));
+  const operationalHealth = summarizeOperationalHealth(
+    activeRunCandidates.filter((run) => !isSupportWorkflowRun(run)),
+    generatedAt,
+    activeRunErrors.length === 0,
+  );
   const failedRuns = completedWorkflowRuns.filter(
     (run) =>
       run.status === "completed" &&
@@ -3747,6 +3885,7 @@ async function statusSnapshot(env) {
       worker_detail_fallbacks: activeJobs.fallbacks,
     },
     health: publicWorkerHealth,
+    operational_health: operationalHealth,
     averages: {
       automerge_command_to_merge_ms: automerge.average_ms,
       automerge_samples: automerge.samples,
@@ -5785,7 +5924,7 @@ function workerStatusRank(status) {
   return 2;
 }
 
-async function activeWorkflowRuns(
+async function activeWorkflowRunCandidates(
   env,
   repo,
   errors,
@@ -5799,10 +5938,15 @@ async function activeWorkflowRuns(
           return null;
         },
       );
-      return Array.isArray(runs?.workflow_runs) ? runs.workflow_runs : [];
+      const workflowRuns = Array.isArray(runs?.workflow_runs) ? runs.workflow_runs : [];
+      // Sampling stays at five cheap status queries. A full page may omit the
+      // oldest (and therefore least healthy) runs, so fail closed instead of
+      // spending an unbounded number of follow-up requests.
+      if (workflowRuns.length >= 100) errors.push(`workflow runs ${status}: page may be truncated`);
+      return workflowRuns;
     }),
   );
-  return uniqueWorkflowRuns(pages.flat()).filter((run) => isActiveWorkflowRun(run));
+  return uniqueWorkflowRuns(pages.flat());
 }
 
 function isActiveWorkflowRun(run) {
@@ -8703,6 +8847,38 @@ h2::before { content: ""; flex: 0 0 auto; width: 14px; height: 2px; border-radiu
 .metric > div.muted { margin-top: 4px; font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .band { width: 54px; height: 2px; margin-top: 12px; background: var(--track); border-radius: 999px; overflow: hidden; }
 .band > i { display: block; height: 100%; border-radius: 999px; background: var(--claw); width: 0; transition: width 0.6s ease; }
+.health-trends { margin-top: 30px; }
+.health-trends-head { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
+.health-trends-head h2 { margin: 0; }
+.trend-ranges { display: flex; gap: 6px; }
+.trend-range {
+  padding: 5px 9px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-size: 11px;
+  cursor: pointer;
+}
+.trend-range.active { color: var(--text); border-color: var(--claw); }
+.health-trend-summary { margin-top: 8px; color: var(--muted); font-size: 12px; }
+.health-trend-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 18px; margin-top: 14px; }
+.health-trend-panel { min-width: 0; padding: 14px; border: 1px solid var(--line); border-radius: 10px; background: var(--panel); }
+.health-trend-title { display: flex; justify-content: space-between; gap: 12px; margin-bottom: 8px; }
+.health-trend-title strong { font-size: 12px; }
+.health-trend-title span { color: var(--muted); font-size: 11px; }
+.health-trend-svg { display: block; width: 100%; height: 150px; overflow: visible; }
+.trend-grid-line { stroke: var(--line-soft); stroke-width: 1; }
+.trend-threshold { stroke: var(--red); stroke-width: 1; stroke-dasharray: 4 4; opacity: 0.55; }
+.trend-threshold.warning { stroke: var(--amber); }
+.trend-total { fill: none; stroke: var(--muted); stroke-width: 2; vector-effect: non-scaling-stroke; }
+.trend-warning { fill: none; stroke: var(--amber); stroke-width: 2.5; vector-effect: non-scaling-stroke; }
+.trend-danger { fill: none; stroke: var(--red); stroke-width: 2.5; vector-effect: non-scaling-stroke; }
+.trend-total-point { fill: var(--muted); }
+.trend-warning-point { fill: var(--amber); }
+.trend-danger-point { fill: var(--red); }
+.trend-empty { display: grid; place-items: center; height: 150px; color: var(--muted); font-size: 12px; }
 .overview-shell { margin: 0; padding: 0; border: 0; background: transparent; }
 .overview-head,
 .automatic-head,
@@ -9376,6 +9552,7 @@ a.pill:hover { color: var(--claw); text-decoration: none; }
   .work-row { grid-template-columns: 1fr; align-items: start; }
   .work-state, .stage-block, .timebox { justify-content: start; justify-items: start; }
   .worker-toolbar { align-items: stretch; flex-direction: column; }
+  .health-trend-grid { grid-template-columns: 1fr; }
 }
 @media (max-width: 560px) {
   main { width: min(100vw - 24px, 1280px); padding-top: 18px; }
@@ -9415,6 +9592,17 @@ a.pill:hover { color: var(--claw); text-decoration: none; }
     <div class="muted" id="subtitle"></div>
   </section>
   <section class="grid" id="metrics"></section>
+  <section class="health-trends" aria-labelledby="health-trends-title">
+    <div class="health-trends-head">
+      <h2 id="health-trends-title">Health Trends</h2>
+      <div class="trend-ranges" id="trend-ranges" aria-label="Health history range">
+        <button class="trend-range active" type="button" data-trend-range="24h">24 hours</button>
+        <button class="trend-range" type="button" data-trend-range="7d">7 days</button>
+      </div>
+    </div>
+    <div class="health-trend-summary" id="health-trend-summary">History starts collecting after deployment.</div>
+    <div class="health-trend-grid" id="health-trend-grid"></div>
+  </section>
   <section class="overview-shell" aria-labelledby="system-overview-title">
     <div class="overview-head">
       <h2 id="system-overview-title">System Overview</h2>
@@ -9546,6 +9734,115 @@ let loading = false;
 let activeWorkerFilter = "all";
 let workerIndex = new Map();
 let automaticIndex = new Map();
+let activeHealthRange = "24h";
+let healthHistoryLoadedAt = 0;
+let healthHistorySamples = [];
+
+function currentHealthSample(health) {
+  if (!health?.checked_at) return null;
+  return {
+    at: health.checked_at,
+    status: health.status,
+    queued: health.queued_runs || 0,
+    queued_over_30m: health.queued_over_threshold || 0,
+    oldest_queued_minutes: health.oldest_queued_minutes || 0,
+    running: health.running_runs || 0,
+    running_over_150m: health.running_over_threshold || 0,
+    oldest_running_minutes: health.oldest_running_minutes || 0,
+    collection_ok: health.telemetry_complete === true,
+  };
+}
+
+function trendGeometry(samples, field, width, height, maximum) {
+  if (!samples.length || maximum <= 0) return [];
+  const firstAt = Date.parse(samples[0].at);
+  const lastAt = Date.parse(samples.at(-1).at);
+  const span = Math.max(1, lastAt - firstAt);
+  let previousAt = null;
+  return samples.flatMap(sample => {
+    const at = Date.parse(sample.at);
+    if (!sample.collection_ok || !Number.isFinite(at)) {
+      previousAt = null;
+      return [];
+    }
+    const x = samples.length === 1 ? width / 2 : ((at - firstAt) / span) * width;
+    const y = height - (Math.max(0, Number(sample[field]) || 0) / maximum) * height;
+    const connected = previousAt !== null && at - previousAt <= 12 * 60 * 1000;
+    previousAt = at;
+    return [{ at, x, y, connected }];
+  });
+}
+
+function trendPath(geometry) {
+  return geometry.map(point => (point.connected ? "L" : "M") + point.x.toFixed(1) + " " + point.y.toFixed(1)).join(" ");
+}
+
+function trendPoints(geometry, className) {
+  return geometry.map(point => '<circle class="' + esc(className) + '-point" cx="' + point.x.toFixed(1) + '" cy="' + point.y.toFixed(1) + '" r="3"></circle>').join("");
+}
+
+function trendPanel(samples, title, detail, series, threshold, thresholdClass) {
+  if (!samples.length) {
+    return '<div class="health-trend-panel"><div class="health-trend-title"><strong>' + esc(title) + '</strong><span>' + esc(detail) + '</span></div><div class="trend-empty">Waiting for the first health sample.</div></div>';
+  }
+  const width = 600;
+  const height = 140;
+  const values = series.flatMap(item => samples.map(sample => Number(sample[item.field]) || 0));
+  const maximum = Math.max(1, Number(threshold) || 0, ...values);
+  const grid = [0.25, 0.5, 0.75].map(ratio => '<line class="trend-grid-line" x1="0" x2="' + width + '" y1="' + (height * ratio) + '" y2="' + (height * ratio) + '"></line>').join("");
+  const thresholdLine = threshold
+    ? '<line class="trend-threshold ' + esc(thresholdClass || "") + '" x1="0" x2="' + width + '" y1="' + (height - threshold / maximum * height) + '" y2="' + (height - threshold / maximum * height) + '"></line>'
+    : "";
+  const geometry = series.map(item => ({ item, points: trendGeometry(samples, item.field, width, height, maximum) }));
+  const paths = geometry.map(seriesGeometry => '<path class="' + esc(seriesGeometry.item.className) + '" d="' + trendPath(seriesGeometry.points) + '"></path>').join("");
+  const points = geometry.map(seriesGeometry => trendPoints(seriesGeometry.points, seriesGeometry.item.className)).join("");
+  return '<div class="health-trend-panel"><div class="health-trend-title"><strong>' + esc(title) + '</strong><span>' + esc(detail) + '</span></div><svg class="health-trend-svg" viewBox="0 0 ' + width + " " + height + '" role="img" aria-label="' + esc(title) + '">' + grid + thresholdLine + paths + points + '</svg></div>';
+}
+
+function renderHealthHistory(current) {
+  const latest = currentHealthSample(current);
+  const samples = healthHistorySamples
+    .filter(sample => !latest || Math.floor(Date.parse(sample.at) / 300000) !== Math.floor(Date.parse(latest.at) / 300000))
+    .concat(latest ? [latest] : [])
+    .sort((left, right) => Date.parse(left.at) - Date.parse(right.at));
+  const summary = document.getElementById("health-trend-summary");
+  if (current) {
+    const status = current.status === "stalled" ? "Stalled" : current.status === "degraded" ? "Degraded" : current.status === "healthy" ? "Healthy" : "Telemetry incomplete";
+    summary.textContent = status + " · " + fmt.format(current.queued_over_threshold || 0) + " queued over 30m · " + fmt.format(current.running_over_threshold || 0) + " running over 150m · " + fmt.format(samples.length) + " samples";
+  }
+  document.getElementById("health-trend-grid").innerHTML =
+    trendPanel(samples, "Queue pressure", "total / over 30m", [
+      { field: "queued", className: "trend-total" },
+      { field: "queued_over_30m", className: "trend-warning" },
+    ]) +
+    trendPanel(samples, "Oldest queued", "minutes · threshold 30", [
+      { field: "oldest_queued_minutes", className: "trend-warning" },
+    ], 30, "warning") +
+    trendPanel(samples, "Oldest running", "minutes · threshold 150", [
+      { field: "oldest_running_minutes", className: "trend-danger" },
+    ], 150);
+}
+
+async function loadHealthHistory(range, current, force) {
+  if (!force && range === activeHealthRange && Date.now() - healthHistoryLoadedAt < 60000) {
+    renderHealthHistory(current);
+    return;
+  }
+  activeHealthRange = range;
+  const requestedRange = range;
+  try {
+    const response = await fetch("/api/health-history?range=" + encodeURIComponent(range), { cache: "no-store" });
+    if (!response.ok) throw new Error("history returned " + response.status);
+    const payload = await response.json();
+    if (requestedRange !== activeHealthRange) return;
+    healthHistorySamples = Array.isArray(payload.samples) ? payload.samples : [];
+    healthHistoryLoadedAt = Date.now();
+  } catch {
+    if (requestedRange !== activeHealthRange) return;
+    healthHistorySamples = [];
+  }
+  renderHealthHistory(current);
+}
 
 function workerGroup(worker) {
   const text = (worker.mode + " " + worker.name + " " + worker.workflow_title).toLowerCase();
@@ -9816,6 +10113,7 @@ async function load() {
         ? "Updated with partial GitHub telemetry."
         : "",
   );
+  loadHealthHistory(activeHealthRange, data.operational_health, false).catch(() => undefined);
   } catch (error) {
     if (lastData) {
       renderDashboard(lastData, "Live refresh failed; showing last good status.");
@@ -9836,10 +10134,12 @@ function renderDashboard(data, note) {
   const handoffTelemetryFailed = Boolean(data.diagnostics?.exact_review_queue_error);
   const handoffAttention =
     handoffTelemetryFailed || handoffStatus === "degraded" || handoffStatus === "stalled";
-  const needsAttention = unresolved || applyAttention || handoffAttention;
+  const operationalStatus = data.operational_health?.status;
+  const operationalAttention = ["degraded", "stalled", "unknown"].includes(operationalStatus);
+  const needsAttention = unresolved || applyAttention || handoffAttention || operationalAttention;
   const workerCount = (data.workers || []).length;
   const repoCount = (data.source.target_repositories || []).length;
-  document.getElementById("hero-dot").className = "hero-dot " + (handoffStatus === "stalled" ? "red" : needsAttention ? "amber" : "ok");
+  document.getElementById("hero-dot").className = "hero-dot " + (handoffStatus === "stalled" || operationalStatus === "stalled" ? "red" : needsAttention ? "amber" : "ok");
   document.getElementById("hero-headline").textContent =
     (needsAttention ? "Needs attention" : "All clear") + " — " +
     fmt.format(workerCount) + " claw worker" + (workerCount === 1 ? "" : "s") + " sweeping " +
@@ -9847,14 +10147,16 @@ function renderDashboard(data, note) {
   document.getElementById("subtitle").textContent = data.source.target_repositories.join(", ");
   document.getElementById("updated").textContent = "Updated " + since(data.generated_at) + (note ? " \u00b7 " + note : "");
   const fleet = data.fleet;
+  const operational = data.operational_health || {};
   document.getElementById("metrics").innerHTML = [
     metric("Claw Workers", fmt.format(fleet.active_codex_jobs), "budget " + fleet.worker_budget, fleet.budget_used_percent, "var(--green)"),
-    metric("Active Sweeps", fmt.format(fleet.active_workflow_runs), "support " + fmt.format(fleet.support_workflow_runs || 0), Math.min(100, fleet.active_workflow_runs * 3), "var(--claw)"),
-    metric("Queue Depth", fmt.format(fleet.queued_workflow_runs), "support queue " + fmt.format(fleet.support_queued_workflow_runs || 0), Math.min(100, fleet.queued_workflow_runs * 10), "var(--amber)"),
+    metric("Active Sweeps", fmt.format(fleet.active_workflow_runs), fmt.format(operational.running_over_threshold || 0) + " over 150m", Math.min(100, fleet.active_workflow_runs * 3), operational.running_over_threshold ? "var(--red)" : "var(--claw)"),
+    metric("Queue Depth", fmt.format(fleet.queued_workflow_runs), fmt.format(operational.queued_over_threshold || 0) + " over 30m", Math.min(100, fleet.queued_workflow_runs * 10), operational.queued_over_threshold ? "var(--amber)" : "var(--green)"),
     metric("Error Rate", (data.health?.error_rate_percent || 0) + "%", fmt.format(data.health?.failed_attempts || 0) + " failed / " + fmt.format(data.health?.attempts || 0) + " attempts", Math.min(100, data.health?.error_rate_percent || 0), data.health?.failed_attempts ? "var(--red)" : "var(--green)"),
     metric("Recovery Rate", data.health?.recovery_rate_percent == null ? "n/a" : data.health.recovery_rate_percent + "%", fmt.format(data.health?.unresolved_failures || 0) + " unresolved", data.health?.recovery_rate_percent == null ? 100 : data.health.recovery_rate_percent, data.health?.unresolved_failures ? "var(--amber)" : "var(--green)"),
     metric("Capacity", fleet.budget_used_percent + "%", "fleet utilization", fleet.budget_used_percent, "var(--green)")
   ].join("");
+  renderHealthHistory(data.operational_health);
   renderSystemMap(data);
   renderExactReviewHandoff(data.exact_review_queue);
   renderApplyHealth(data);
@@ -10274,6 +10576,12 @@ document.getElementById("worker-filters").addEventListener("click", event => {
   if (!button) return;
   activeWorkerFilter = button.dataset.workerFilter || "all";
   renderWorkers(lastData?.workers || []);
+});
+document.getElementById("trend-ranges").addEventListener("click", event => {
+  const button = event.target.closest("button[data-trend-range]");
+  if (!button) return;
+  document.querySelectorAll("button[data-trend-range]").forEach(item => item.classList.toggle("active", item === button));
+  loadHealthHistory(button.dataset.trendRange || "24h", lastData?.operational_health, true).catch(() => undefined);
 });
 document.getElementById("workers").addEventListener("click", event => {
   const button = event.target.closest("button[data-worker-id]");

--- a/dashboard/wrangler.toml
+++ b/dashboard/wrangler.toml
@@ -4,6 +4,9 @@ account_id = "91b59577e757131d68d55a471fe32aca"
 compatibility_date = "2026-05-11"
 workers_dev = true
 
+[triggers]
+crons = ["*/5 * * * *"]
+
 [assets]
 directory = "./public"
 [[durable_objects.bindings]]

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -119,6 +119,11 @@ is absent or a cache event lands in another Cloudflare colo.
 - a budget-sized capacity rail plus lane filters for issue-to-PR, PR repair,
   review, repair, commit, assist, and other workers
 - queued/waiting run count
+- operational health derived from queue age and running age: queued runs become
+  degraded after 30 minutes, and in-progress runs become stalled after 150
+  minutes
+- 24-hour and seven-day health trends for total queue depth, over-age queue
+  depth, and the oldest queued/running ages
 - job-level worker attempt error rate, recovery rate, and unresolved failures,
   including failures hidden by workflow `continue-on-error`
 - active pipeline rows grouped as automerge, repair, exact review, hot review,
@@ -163,6 +168,37 @@ isolate. Recent automerge timing is cached for five minutes and recent
 ClawSweeper-owned closes for five minutes because those historical sections do
 not need worker-step freshness. The deployment smoke output includes cache
 state, fetch time, and current diagnostics.
+
+## Operational health history
+
+A Cloudflare Cron Trigger records one aggregate operational-health sample every
+five minutes. The sampler requests only the five actionable GitHub Actions run
+statuses and never fetches job details, so history collection does not repeat
+the dashboard's bounded worker-detail fanout. Missing status responses make the
+sample `unknown` rather than silently healthy.
+
+Samples are stored in the existing `StatusStore` Durable Object under daily UTC
+keys named `health-history:YYYY-MM-DD`. Writes replace the current five-minute
+slot, making retries and overlapping triggers idempotent. Buckets expire after
+the seven-day retention window plus one day of boundary margin. No health
+history is written to `openclaw/clawsweeper-state`.
+
+`GET /api/health-history?range=24h` returns the default chart range;
+`range=7d` returns the full retention window. The endpoint and the dashboard are
+read-only. A fresh deployment starts with an empty chart and accumulates its
+first point at the next five-minute trigger.
+
+The operational headline uses the same snapshot as the chart:
+
+- `healthy`: complete telemetry and no over-age runs;
+- `degraded`: at least one queued run is 30 minutes old;
+- `stalled`: at least one in-progress run is 150 minutes old;
+- `unknown`: one or more actionable-status reads failed.
+
+This history is intentionally aggregate and low-cost: at five-minute cadence it
+stores at most 2,016 samples over seven days. Use an external metrics backend
+only if longer retention, ad hoc aggregation, or Grafana-compatible querying is
+required.
 
 ## Boundaries
 

--- a/test/dashboard-operational-health.test.ts
+++ b/test/dashboard-operational-health.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  healthHistorySample,
+  mergeHealthHistorySample,
+  normalizeHealthHistorySample,
+  summarizeOperationalHealth,
+} from "../dashboard/operational-health.ts";
+
+const CHECKED_AT = "2026-07-15T14:00:00Z";
+
+function run(status: string, createdAt: string) {
+  return { status, created_at: createdAt };
+}
+
+test("operational health classifies over-age queue pressure and stuck runs", () => {
+  const degraded = summarizeOperationalHealth(
+    [
+      run("queued", "2026-07-15T13:20:00Z"),
+      run("pending", "2026-07-15T13:50:00Z"),
+      run("in_progress", "2026-07-15T12:00:00Z"),
+    ],
+    CHECKED_AT,
+    true,
+  );
+  assert.equal(degraded.status, "degraded");
+  assert.equal(degraded.queued_runs, 2);
+  assert.equal(degraded.queued_over_threshold, 1);
+  assert.equal(degraded.oldest_queued_minutes, 40);
+
+  const stalled = summarizeOperationalHealth(
+    [run("in_progress", "2026-07-15T11:00:00Z")],
+    CHECKED_AT,
+    true,
+  );
+  assert.equal(stalled.status, "stalled");
+  assert.equal(stalled.running_over_threshold, 1);
+  assert.equal(stalled.oldest_running_minutes, 180);
+});
+
+test("operational health fails closed when active-run telemetry is incomplete", () => {
+  const health = summarizeOperationalHealth([], CHECKED_AT, false);
+  assert.equal(health.status, "unknown");
+  assert.equal(health.telemetry_complete, false);
+});
+
+test("operational health fails closed when an active run has no usable age", () => {
+  const health = summarizeOperationalHealth([{ status: "queued" }], CHECKED_AT, true);
+  assert.equal(health.status, "unknown");
+  assert.equal(health.telemetry_complete, false);
+  assert.equal(health.queued_runs, 1);
+});
+
+test("operational health measures execution from run start instead of queue admission", () => {
+  const health = summarizeOperationalHealth(
+    [
+      {
+        status: "in_progress",
+        created_at: "2026-07-15T11:00:00Z",
+        run_started_at: "2026-07-15T13:50:00Z",
+      },
+    ],
+    CHECKED_AT,
+    true,
+  );
+  assert.equal(health.status, "healthy");
+  assert.equal(health.oldest_running_minutes, 10);
+});
+
+test("health history replaces duplicate five-minute slots", () => {
+  const health = summarizeOperationalHealth(
+    [run("queued", "2026-07-15T13:00:00Z")],
+    CHECKED_AT,
+    true,
+  );
+  const first = healthHistorySample(health);
+  const replacement = { ...first, at: "2026-07-15T14:04:59Z", queued: 2 };
+  const next = mergeHealthHistorySample([first], replacement);
+  assert.equal(next.length, 1);
+  assert.equal(next[0].queued, 2);
+
+  const lateOlderSample = { ...first, at: "2026-07-15T14:01:00Z", queued: 1 };
+  const preserved = mergeHealthHistorySample(next, lateOlderSample);
+  assert.equal(preserved.length, 1);
+  assert.equal(preserved[0].at, replacement.at);
+  assert.equal(preserved[0].queued, 2);
+});
+
+test("health history rejects non-finite or incomplete samples", () => {
+  const sample = healthHistorySample(summarizeOperationalHealth([], CHECKED_AT, true));
+  assert.equal(normalizeHealthHistorySample({ ...sample, queued: "Infinity" }), null);
+  const { running, ...incomplete } = sample;
+  assert.equal(running, 0);
+  assert.equal(normalizeHealthHistorySample(incomplete), null);
+});

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -1321,6 +1321,96 @@ test("dashboard reuses a current Bay snapshot from the shared status store", asy
   }
 });
 
+test("dashboard health history persists five-minute samples and serves a bounded range", async () => {
+  const storage = new MemoryDurableStorage();
+  const store = new StatusStore({ storage });
+  const namespace = new MemoryDurableNamespace(store);
+  const sample = {
+    at: new Date().toISOString(),
+    status: "degraded",
+    queued: 12,
+    queued_over_30m: 4,
+    oldest_queued_minutes: 75,
+    running: 3,
+    running_over_150m: 0,
+    oldest_running_minutes: 40,
+    collection_ok: true,
+  };
+
+  for (const queued of [12, 14]) {
+    const response = await store.fetch(
+      new Request("https://clawsweeper-status-store/health-history", {
+        method: "POST",
+        body: JSON.stringify({ sample: { ...sample, queued } }),
+      }),
+    );
+    assert.equal(response.status, 200);
+  }
+
+  const response = await worker.fetch(
+    new Request("https://clawsweeper.openclaw.ai/api/health-history?range=24h"),
+    { STATUS_STORE: namespace },
+  );
+  const history = await response.json();
+  assert.equal(response.status, 200);
+  assert.equal(history.range, "24h");
+  assert.equal(history.retention_days, 7);
+  assert.equal(history.samples.length, 1);
+  assert.equal(history.samples[0].queued, 14);
+});
+
+test("dashboard cron records health with status-only GitHub queries", async () => {
+  const originalFetch = globalThis.fetch;
+  const storage = new MemoryDurableStorage();
+  const store = new StatusStore({ storage });
+  const namespace = new MemoryDurableNamespace(store);
+  const requests: string[] = [];
+  globalThis.fetch = async (input) => {
+    const url = new URL(String(input));
+    requests.push(url.toString());
+    assert.equal(url.pathname, "/repos/openclaw/clawsweeper/actions/runs");
+    const status = url.searchParams.get("status");
+    return jsonResponse({
+      workflow_runs:
+        status === "queued"
+          ? Array.from({ length: 100 }, (_, index) => ({
+              id: 9001 + index,
+              name: "repair cluster worker",
+              display_title: "repair cluster worker",
+              status: "queued",
+              created_at: isoAgo((index === 0 ? 40 : 10) * 60_000),
+            }))
+          : [],
+    });
+  };
+  let recording: Promise<unknown> | undefined;
+  try {
+    await worker.scheduled(
+      {},
+      {
+        CLAWSWEEPER_REPO: "openclaw/clawsweeper",
+        STATUS_STORE: namespace,
+      },
+      { waitUntil: (promise) => (recording = promise) },
+    );
+    await recording;
+    assert.equal(requests.length, 5);
+    assert.ok(requests.every((url) => !url.includes("/jobs")));
+
+    const response = await worker.fetch(
+      new Request("https://clawsweeper.openclaw.ai/api/health-history?range=24h"),
+      { STATUS_STORE: namespace },
+    );
+    const history = await response.json();
+    assert.equal(history.samples.length, 1);
+    assert.equal(history.samples[0].status, "unknown");
+    assert.equal(history.samples[0].queued, 100);
+    assert.equal(history.samples[0].queued_over_30m, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("optional exact-review telemetry failures do not freeze an idle status snapshot", async () => {
   const originalFetch = globalThis.fetch;
   const originalCaches = globalThis.caches;
@@ -4356,6 +4446,11 @@ test("dashboard HTML preserves UTF-8 emoji labels", async () => {
   assert.match(html, /Claw Workers/);
   assert.match(html, /Active Sweeps/);
   assert.match(html, /Queue Depth/);
+  assert.match(html, /Health Trends/);
+  assert.match(html, /id="health-trend-grid"/);
+  assert.match(html, /\/api\/health-history\?range=/);
+  assert.match(html, /queued over 30m/);
+  assert.match(html, /running over 150m/);
   assert.match(html, /Error Rate/);
   assert.match(html, /Recovery Rate/);
   assert.match(html, /Capacity/);
@@ -4574,6 +4669,46 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
   assert.equal(elementFor("hero-dot").className, "hero-dot amber");
   assert.match(elementFor("hero-headline").textContent, /^Needs attention/);
   assert.match(elementFor("exact-review-handoff").innerHTML, /telemetry unavailable/);
+
+  status.diagnostics.exact_review_queue_error = null;
+  status.exact_review_queue = { handoff_health: { status: "healthy", phases: {} } };
+  status.operational_health = {
+    status: "stalled",
+    checked_at: "2026-07-05T11:22:43.934Z",
+    telemetry_complete: true,
+    queued_runs: 10,
+    queued_over_threshold: 4,
+    oldest_queued_minutes: 90,
+    running_runs: 2,
+    running_over_threshold: 1,
+    oldest_running_minutes: 180,
+  };
+  context.renderDashboard(status, "");
+
+  assert.equal(elementFor("hero-dot").className, "hero-dot red");
+  assert.match(elementFor("metrics").innerHTML, /4 over 30m/);
+  assert.match(elementFor("metrics").innerHTML, /1 over 150m/);
+  assert.match(elementFor("health-trend-summary").textContent, /Stalled/);
+  assert.match(elementFor("health-trend-grid").innerHTML, /<circle class="trend-danger-point"/);
+
+  let resolve24HourHistory: ((response: unknown) => void) | undefined;
+  context.fetch = async (input: string) => {
+    if (input.includes("range=24h")) {
+      return new Promise((resolve) => {
+        resolve24HourHistory = resolve;
+      });
+    }
+    return {
+      ok: true,
+      json: async () => ({ samples: [{ collection_ok: true }, { collection_ok: true }] }),
+    };
+  };
+  const stale24HourRequest = context.loadHealthHistory("24h", status.operational_health, true);
+  const active7DayRequest = context.loadHealthHistory("7d", status.operational_health, true);
+  await active7DayRequest;
+  resolve24HourHistory?.({ ok: true, json: async () => ({ samples: [] }) });
+  await stale24HourRequest;
+  assert.match(elementFor("health-trend-summary").textContent, /3 samples/);
 });
 
 test("dashboard HTML emits early persistent theme controls", async () => {
@@ -6448,7 +6583,7 @@ test("dashboard counts active runs that are older than the latest unfiltered pag
   }
 });
 
-test("dashboard ignores stale queued workflow ghosts", async () => {
+test("dashboard hides stale queue ghosts without suppressing queue health", async () => {
   const originalFetch = globalThis.fetch;
   const originalCaches = globalThis.caches;
   Object.defineProperty(globalThis, "caches", {
@@ -6512,10 +6647,65 @@ test("dashboard ignores stale queued workflow ghosts", async () => {
     const status = await response.json();
     assert.equal(status.fleet.active_workflow_runs, 1);
     assert.equal(status.fleet.queued_workflow_runs, 1);
+    assert.equal(status.operational_health.queued_runs, 2);
+    assert.equal(status.operational_health.queued_over_threshold, 1);
+    assert.equal(status.operational_health.status, "degraded");
     assert.deepEqual(
       status.pipeline.map((row: { id: number }) => row.id),
       [2],
     );
+  } finally {
+    globalThis.fetch = originalFetch;
+    Object.defineProperty(globalThis, "caches", { configurable: true, value: originalCaches });
+  }
+});
+
+test("dashboard health retains in-progress runs beyond the queued ghost window", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalCaches = globalThis.caches;
+  Object.defineProperty(globalThis, "caches", {
+    configurable: true,
+    value: { default: { match: async () => undefined, put: async () => undefined } },
+  });
+  globalThis.fetch = async (input) => {
+    const url = new URL(String(input));
+    if (url.pathname === "/repos/openclaw/clawsweeper/actions/runs") {
+      const status = url.searchParams.get("status");
+      if (status === "in_progress") {
+        return jsonResponse({
+          workflow_runs: [
+            {
+              id: 8,
+              name: "repair cluster worker",
+              display_title: "repair cluster worker",
+              status: "in_progress",
+              created_at: isoAgo(8 * 60 * 60_000),
+              run_started_at: isoAgo(7 * 60 * 60_000),
+              updated_at: isoAgo(60_000),
+            },
+          ],
+        });
+      }
+      return jsonResponse({ workflow_runs: [] });
+    }
+    if (url.pathname === "/search/issues") return jsonResponse({ items: [] });
+    throw new Error(`unexpected fetch ${url}`);
+  };
+
+  try {
+    const response = await worker.fetch(
+      new Request("https://clawsweeper.openclaw.ai/api/status"),
+      {
+        CLAWSWEEPER_REPO: "openclaw/clawsweeper",
+        TARGET_REPOS: "openclaw/openclaw",
+        CACHE_TTL_SECONDS: "0",
+      },
+      { waitUntil: () => undefined },
+    );
+    const status = await response.json();
+    assert.equal(status.operational_health.status, "stalled");
+    assert.equal(status.operational_health.running_over_threshold, 1);
+    assert.equal(status.operational_health.oldest_running_minutes, 420);
   } finally {
     globalThis.fetch = originalFetch;
     Object.defineProperty(globalThis, "caches", { configurable: true, value: originalCaches });


### PR DESCRIPTION
## Summary

- add decision-oriented operational health for queued and running workflow pressure
- persist five-minute samples in the existing StatusStore and expose 24-hour / 7-day history
- render health status, thresholds, and visible trend charts on the live dashboard
- fail closed when GitHub telemetry is incomplete or a status page may be truncated

## Health policy

- queued over 30 minutes: degraded
- running over 150 minutes: stalled
- incomplete collection or unusable timestamps: unknown
- seven-day retention, bucketed by UTC day, with newer samples winning within a five-minute slot

## Cost and storage

The Cron Trigger runs every five minutes and makes exactly five status-only GitHub requests. It performs no job-detail queries. Expected steady state is 288 invocations, about 1,440 GitHub requests, and 288 Durable Object writes per day, with at most 2,016 retained samples.

## Validation

- final autoreview: clean, no accepted or actionable findings
- 11 focused operational-health, history, Cron, API, hero, and trend UI tests passed
- dashboard TypeScript build passed
- dashboard lint passed
- git diff --check passed
- full pnpm run check reached 1,184 passing tests and 1 skipped test; the unrelated apply-runtime-budget timing case failed only under the concurrent full suite and passed when rerun in isolation

## Deployment

This PR does not deploy the Worker. Trend history begins accumulating after the updated Worker and Cron Trigger are deployed.