### PR TITLE
fix(queue): preserve pending backlog across dispatcher pauses

### DIFF
--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -923,7 +923,6 @@ export class ExactReviewQueue {
         checkedAt: now,
         retryAt,
       };
-      deferPausedExactReviewQueue(state, now, retryAt);
       await this.writeState(state);
       await this.scheduleNext(state, now);
       return;
@@ -937,7 +936,6 @@ export class ExactReviewQueue {
         checkedAt: now,
         retryAt,
       };
-      deferPausedExactReviewQueue(state, now, retryAt);
       await this.writeState(state);
       await this.scheduleNext(state, now);
       return;
@@ -2814,14 +2812,6 @@ function exactReviewQueueEnqueueAttemptAt(state: ExactReviewQueueState, now: num
     : now;
 }
 
-function deferPausedExactReviewQueue(state: ExactReviewQueueState, now: number, retryAt: number) {
-  for (const item of Object.values(state.items)) {
-    if (item.state !== "pending" || item.nextAttemptAt >= retryAt) continue;
-    item.nextAttemptAt = retryAt;
-    item.updatedAt = now;
-  }
-}
-
 function exactReviewQueueIsPublication(item: ExactReviewQueueItem) {
   return item.decision.sourceAction === EXACT_REVIEW_ARTIFACT_PUBLISH_SOURCE_ACTION;
 }
@@ -2840,6 +2830,13 @@ function exactReviewQueueAdmittedItems(
   capacity: number,
   targetCapacity: number,
 ) {
+  const dispatcherRetryAt = Number(state.dispatcher?.retryAt || 0);
+  if (
+    (state.dispatcher?.state === "paused" || state.dispatcher?.state === "blocked") &&
+    dispatcherRetryAt > now
+  ) {
+    return [];
+  }
   const reviewSlots = Math.max(0, capacity - exactReviewQueueActiveReviewCount(state));
   const activeTargets = new Map<string, number>();
   let activePublishers = 0;
@@ -2974,6 +2971,10 @@ function exactReviewQueueNextWakeAt(
 ) {
   const items = Object.values(state.items);
   if (!items.length) return null;
+  const dispatcherRetryAt = Number(state.dispatcher?.retryAt || 0);
+  const dispatcherPaused =
+    (state.dispatcher?.state === "paused" || state.dispatcher?.state === "blocked") &&
+    dispatcherRetryAt > now;
   const activeItems = items.filter(
     (item) => item.state === "dispatching" || item.state === "leased",
   );
@@ -3003,6 +3004,7 @@ function exactReviewQueueNextWakeAt(
   }
   const times = items.flatMap((item) => {
     if (item.state === "pending") {
+      if (dispatcherPaused) return [dispatcherRetryAt];
       if (exactReviewQueueIsPublication(item)) {
         const blockedUntil = activePublisherWakeAt.length
           ? Math.min(...activePublisherWakeAt)

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -1481,10 +1481,20 @@ test("exact-review queue coalesces deliveries, dispatches a bound rollout snapsh
       dispatcher: { retryAt: number };
       items: Record<string, { nextAttemptAt: number }>;
     };
-    workflowState = "active";
+    assert.ok(
+      Object.values(pausedState.items).some(
+        (item) => item.nextAttemptAt < pausedState.dispatcher.retryAt,
+      ),
+    );
+    // Simulate the pre-repair persisted state, which moved the whole backlog
+    // to the dispatcher retry. At the scheduled wake, recovery must not need
+    // an operator rewrite.
     pausedState.dispatcher.retryAt = Date.now() - 1;
-    for (const item of Object.values(pausedState.items)) item.nextAttemptAt = Date.now() - 1;
+    for (const item of Object.values(pausedState.items)) {
+      item.nextAttemptAt = pausedState.dispatcher.retryAt;
+    }
     await storage.put("exact-review-queue", pausedState);
+    workflowState = "active";
     await queue.alarm();
     assert.equal(dispatched.length, 1);
     stats = await (
@@ -2787,6 +2797,81 @@ test("exact-review queue wakes while target capacity remains", async () => {
 
     await queue.alarm();
     assert.equal(dispatched.length, 2);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("exact-review queue defers retained backlog until a paused dispatcher retry", async () => {
+  const originalFetch = globalThis.fetch;
+  const storage = new MemoryDurableStorage();
+  const dispatched: Record<string, unknown>[] = [];
+  const { privateKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  });
+  globalThis.fetch = async (input, init) => {
+    const url = new URL(String(input));
+    if (url.pathname === "/repos/openclaw/clawsweeper/actions/workflows/sweep.yml")
+      return jsonResponse({ state: "active" });
+    if (url.pathname === "/repos/openclaw/clawsweeper/installation")
+      return jsonResponse({ id: 999 });
+    if (url.pathname === "/app/installations/999/access_tokens")
+      return jsonResponse({ token: "dispatch-token" });
+    if (url.pathname === "/repos/openclaw/clawsweeper/dispatches") {
+      dispatched.push(JSON.parse(String(init?.body)));
+      return new Response(null, { status: 204 });
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  };
+
+  try {
+    const queue = new ExactReviewQueue(
+      { storage },
+      {
+        CLAWSWEEPER_APP_CLIENT_ID: "Iv23test",
+        CLAWSWEEPER_APP_PRIVATE_KEY: privateKey,
+        EXACT_REVIEW_QUEUE_MAX_CONCURRENT: "4",
+        EXACT_REVIEW_TARGET_MAX_CONCURRENT: "2",
+      },
+    );
+    await queue.fetch(buildExactReviewQueueRequest("delivery-paused-a", 801, "opened"));
+    await queue.alarm();
+    await queue.fetch(buildExactReviewQueueRequest("delivery-paused-b", 802, "opened"));
+    await queue.fetch(buildExactReviewQueueRequest("delivery-paused-c", 803, "opened"));
+
+    const state = (await storage.get("exact-review-queue")) as {
+      dispatcher?: Record<string, unknown>;
+      items: Record<string, { leaseExpiresAt?: number; nextAttemptAt: number }>;
+    };
+    const leaseExpiresAt = Date.now() + 60_000;
+    const retryAt = Date.now() + 15 * 60_000;
+    const retainedAttemptAt = Date.now() - 1;
+    state.dispatcher = {
+      state: "paused",
+      reason: "workflow_not_active",
+      checkedAt: Date.now(),
+      retryAt,
+    };
+    state.items["openclaw/gogcli#801"].leaseExpiresAt = leaseExpiresAt;
+    state.items["openclaw/gogcli#802"].nextAttemptAt = retryAt;
+    state.items["openclaw/gogcli#803"].nextAttemptAt = retainedAttemptAt;
+    await storage.put("exact-review-queue", state);
+    await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"));
+
+    const nextAlarm = await storage.getAlarm();
+    assert.ok(nextAlarm && nextAlarm <= leaseExpiresAt);
+
+    // Emulate a pre-pause alarm that remains scheduled for an active lease,
+    // then fires before the paused dispatcher's retry deadline.
+    state.items["openclaw/gogcli#801"].leaseExpiresAt = Date.now() - 1;
+    await storage.put("exact-review-queue", state);
+    await queue.alarm();
+    assert.equal(dispatched.length, 1);
+    const after = (await storage.get("exact-review-queue")) as typeof state;
+    assert.equal(after.items["openclaw/gogcli#802"].nextAttemptAt, retryAt);
+    assert.equal(after.items["openclaw/gogcli#803"].nextAttemptAt, retainedAttemptAt);
   } finally {
     globalThis.fetch = originalFetch;
   }


### PR DESCRIPTION
## Summary

Preserve each pending exact-review item's own retry time when the dispatcher is paused or blocked, while making the dispatcher's retry deadline an explicit admission barrier.

## Problem

During a dispatcher preflight pause/block, the queue rewrote every pending item's `nextAttemptAt` to the dispatcher retry time. Repeated transient pauses could therefore keep moving an entire backlog forward, even where capacity was available. An alarm already scheduled for an expiring lease could also run before that dispatcher retry and accidentally admit retained due work.

## Implementation

- Stop rewriting all pending rows when the dispatcher is paused or blocked.
- Keep the dispatcher retry as the pending wake deadline while retaining active-lease recovery wakes.
- Refuse admission while a paused or blocked dispatcher has a future retry deadline, including from a stale lease alarm.
- Add focused regression coverage for retained backlog recovery and for an early expired-lease wake with a pending item whose independent retry equals the dispatcher retry.

## Validation

- `node --test test/dashboard-worker.test.ts` — 106 passed, 0 failed.
- `pnpm run build:dashboard`
- `pnpm run lint:dashboard`
- `pnpm exec oxfmt --check dashboard/worker.ts test/dashboard-worker.test.ts`
- `git diff --check`
- `codex review --uncommitted` — clean after focused proof.
- `codex review --base origin/main` — clean after commit.
- `pnpm run review -- --local-range --target-repo openclaw/clawsweeper --target-dir C:\clawsweeper-work\worktrees\csw-041-queue-recovery --base origin/main --artifact-dir C:\clawsweeper-work\local-reviews\csw-041-pr-final2` — final local ClawSweeper review: patch correct, no actionable findings.

The final local review used the known-good reviewer baseline `7d58c63`, which already includes the selected-current-Codex-CLI local-review support from #541. It caught two earlier queue-timing edge cases; both were fixed before this final pass.

## Risks and rollout

This changes internal Durable Object queue scheduling. The local review identifies the remaining limitation accurately: proof is unit-test/source-reproduction only, not a redacted after-fix Durable Object or staging trace. It does not change capacity, GitHub tokens, labels/comments publication, or state-branch publication.

After deployment, rows previously deferred by a pause remain held only until the current dispatcher retry; once active at or after that retry, they are admitted naturally. Monitor pending, dispatching, and leased counts together with exact-review run completion and GitHub label/comment publication.

## Incident alignment

This addresses the queue-admission component of the recent review-backlog incident. It is deliberately scoped and does not claim to fix independent state-publication contention, token/permission errors, or GitHub label/comment publication failures.
