### PR TITLE
Add Blacksmith containment smoke workflow

### DIFF
--- a/.github/workflows/repair-cluster-worker.yml
+++ b/.github/workflows/repair-cluster-worker.yml
@@ -29,7 +29,7 @@ on:
         default: blacksmith-4vcpu-ubuntu-2404
         type: string
       execution_runner:
-        description: "Linux runner label for fix/apply execution work with delegated user/mount/network namespaces, recursive mount hardening, and Landlock ABI 3+"
+        description: "Linux runner label for fix/apply execution work with delegated namespaces, recursive mount hardening, and optional Landlock defense in depth"
         required: true
         default: blacksmith-16vcpu-ubuntu-2404
         type: string
@@ -569,106 +569,7 @@ jobs:
 
       - name: Verify Linux validation containment
         if: ${{ steps.check_job.outputs.job_exists == '1' && steps.self_heal_head.outputs.matched != 'false' && env.CLAWSWEEPER_ALLOW_EXECUTE == '1' && env.CLAWSWEEPER_ALLOW_FIX_PR == '1' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ "${RUNNER_OS:-}" != "Linux" ]; then
-            echo "Repair target execution requires Linux validation containment." >&2
-            exit 1
-          fi
-          for tool in /usr/bin/unshare /usr/bin/python3; do
-            if [ ! -x "$tool" ]; then
-              echo "Repair target execution requires $tool." >&2
-              exit 1
-            fi
-          done
-
-          # The compiled worker owns the enforced /usr/bin/unshare sequence:
-          # --map-root-user, --kill-child=SIGKILL, recursive mount hardening,
-          # loopback setup, ctypes.c_long(444), the "Landlock ABI 3 or newer is required"
-          # fail-closed check, and capability drop.
-          probe_root="$(mktemp -d "$RUNNER_TEMP/clawsweeper-containment-preflight.XXXXXX")"
-          host_secret="${probe_root}.host-secret"
-          trap 'rm -rf "$probe_root" "$host_secret"' EXIT
-          mkdir -p "$probe_root/work" "$probe_root/profile"
-          printf 'host-only\n' > "$host_secret"
-          CONTAINMENT_PROBE_ROOT="$probe_root" \
-          CONTAINMENT_HOST_SECRET="$host_secret" \
-            node --input-type=module <<'NODE'
-          import { spawnSync } from "node:child_process";
-          import path from "node:path";
-
-          const root = process.env.CONTAINMENT_PROBE_ROOT;
-          const hostSecret = process.env.CONTAINMENT_HOST_SECRET;
-          if (!root || !hostSecret) throw new Error("containment preflight paths are missing");
-          const work = path.join(root, "work");
-          const profile = path.join(root, "profile");
-          // The child runs from the isolated work directory, so resolve the trusted worker first.
-          const workerPath = path.resolve("dist/repair/contained-command-worker.js");
-          const probe = [
-            "import os, socket, sys",
-            "host_secret, work, profile = sys.argv[1:]",
-            "assert not os.path.exists(host_secret), 'host filesystem remained visible'",
-            "assert os.listdir('/run') == [], 'host /run entries remained visible'",
-            "open(os.path.join(work, 'work-write'), 'w').write('ok')",
-            "open(os.path.join(profile, 'profile-write'), 'w').write('ok')",
-            "try:",
-            "    open('/tmp/escape', 'w').write('unsafe')",
-            "    raise AssertionError('non-writable path accepted a write')",
-            "except OSError:",
-            "    pass",
-            "status = open('/proc/self/status', encoding='ascii').read().splitlines()",
-            "caps = {line.split(':', 1)[0]: int(line.split(':', 1)[1].strip(), 16) for line in status if line.split(':', 1)[0] in {'CapInh', 'CapPrm', 'CapEff', 'CapBnd', 'CapAmb'}}",
-            "assert set(caps) == {'CapInh', 'CapPrm', 'CapEff', 'CapBnd', 'CapAmb'}",
-            "assert not any(caps.values()), 'validation capabilities were not fully dropped'",
-            "with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:",
-            "    listener.bind(('127.0.0.1', 0))",
-            "print('contained')",
-          ].join("\n");
-          const worker = spawnSync(
-            process.execPath,
-            [workerPath],
-            {
-              cwd: work,
-              env: {
-                CI: "true",
-                HOME: profile,
-                LANG: "C.UTF-8",
-                PATH: process.env.PATH ?? "/usr/bin:/bin",
-                TEMP: profile,
-                TMP: profile,
-                TMPDIR: profile,
-              },
-              input: JSON.stringify({
-                args: ["-c", probe, hostSecret, work, profile],
-                command: "/usr/bin/python3",
-                cwd: work,
-                isolateNetwork: true,
-                maxBuffer: 1024 * 1024,
-                timeoutMs: 30_000,
-                writableRoots: [work, profile],
-                windowsVerbatimArguments: false,
-              }),
-              encoding: "utf8",
-              maxBuffer: 2 * 1024 * 1024,
-              timeout: 35_000,
-            },
-          );
-          if (worker.error) throw worker.error;
-          if (worker.status !== 0) {
-            throw new Error(worker.stderr.trim() || `containment worker exited ${worker.status}`);
-          }
-          const result = JSON.parse(worker.stdout);
-          if (
-            result.status !== 0 ||
-            result.signal !== null ||
-            result.error !== undefined ||
-            result.backgroundProcesses !== 0 ||
-            result.stdout !== "contained\n"
-          ) {
-            throw new Error(`containment preflight failed closed: ${JSON.stringify(result)}`);
-          }
-          NODE
+        run: pnpm run repair:containment-smoke
 
       - name: Setup pinned Bun for target validation
         if: ${{ steps.check_job.outputs.job_exists == '1' && steps.self_heal_head.outputs.matched != 'false' && env.CLAWSWEEPER_ALLOW_EXECUTE == '1' && env.CLAWSWEEPER_ALLOW_FIX_PR == '1' }}

--- a/.github/workflows/repair-containment-smoke.yml
+++ b/.github/workflows/repair-containment-smoke.yml
@@ -1,0 +1,78 @@
+name: repair containment smoke
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/actions/setup-pnpm/**"
+      - ".github/workflows/repair-cluster-worker.yml"
+      - ".github/workflows/repair-containment-smoke.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "src/command.ts"
+      - "src/repair/command-runner.ts"
+      - "src/repair/contained-command-sandbox.ts"
+      - "src/repair/contained-command-worker.ts"
+      - "src/repair/containment-preflight.ts"
+      - "src/repair/process-tree-containment.ts"
+      - "test/repair/command-runner.test.ts"
+      - "test/repair/containment-preflight.test.ts"
+      - "test/repair/process-tree-containment.test.ts"
+      - "test/repair/repair-cluster-worker-containment.test.ts"
+      - "test/repair/repair-containment-smoke-workflow.test.ts"
+      - "test/repair/target-validation.test.ts"
+      - "tsconfig.repair.json"
+  pull_request:
+    paths:
+      - ".github/actions/setup-pnpm/**"
+      - ".github/workflows/repair-cluster-worker.yml"
+      - ".github/workflows/repair-containment-smoke.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "src/command.ts"
+      - "src/repair/command-runner.ts"
+      - "src/repair/contained-command-sandbox.ts"
+      - "src/repair/contained-command-worker.ts"
+      - "src/repair/containment-preflight.ts"
+      - "src/repair/process-tree-containment.ts"
+      - "test/repair/command-runner.test.ts"
+      - "test/repair/containment-preflight.test.ts"
+      - "test/repair/process-tree-containment.test.ts"
+      - "test/repair/repair-cluster-worker-containment.test.ts"
+      - "test/repair/repair-containment-smoke-workflow.test.ts"
+      - "test/repair/target-validation.test.ts"
+      - "tsconfig.repair.json"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: repair-containment-smoke-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  containment-smoke:
+    name: containment smoke (sample ${{ matrix.sample }})
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        sample: [1, 2]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-pnpm
+        with:
+          build-script: build:repair
+
+      - name: Run compiled containment preflight
+        run: pnpm run repair:containment-smoke

--- a/docs/repair/containment-validation-todo.md
+++ b/docs/repair/containment-validation-todo.md
@@ -43,8 +43,8 @@ evidence current as each PR progresses.
 ### PR 1: deterministic policy and one compiled preflight
 
 Status: [PR openclaw/clawsweeper#599](https://github.com/openclaw/clawsweeper/pull/599)
-is open from `agent/containment-preflight`. Implementation and Node 24
-validation are complete, and autoreview completed with no actionable findings.
+merged as `98c8c4bdc613bd452e8c55ccb8bf1ec29907b8fd`. Node 24 validation and
+autoreview completed with no actionable findings before merge.
 
 Combine the code-owned work behind one authoritative containment implementation:
 
@@ -62,7 +62,11 @@ live repair mutations.
 
 ### PR 2: production-runner smoke workflow
 
-Status: pending PR 1.
+Status: ready to publish from `agent/containment-blacksmith-smoke`. Full local
+`pnpm run check` and autoreview pass with no actionable findings. The repository's
+existing Crabbox hydration workflow does not contain a Blacksmith Testbox action,
+so delegated Testbox validation stops before lease allocation; the pull request's
+own two-sample workflow is the authoritative remote Blacksmith proof for this PR.
 
 - run the compiled CLI on `blacksmith-16vcpu-ubuntu-2404` with two independent
   runner samples;
@@ -73,22 +77,25 @@ Status: pending PR 1.
 - fail when containment is skipped or unavailable;
 - do not dispatch repair, push branches, apply results, or close items.
 
+The initial workflow admits pushes to `main`, manual dispatches, and
+same-repository pull requests. Fork pull requests are skipped until the fresh
+ephemeral VM and no-secrets contract has independent evidence.
+
 Before enabling pull-request execution from forks, prove that Blacksmith uses a
 fresh ephemeral VM and exposes no repository or organization secrets. Otherwise
 restrict the workflow to trusted branches or the existing trusted remote
 validation path.
 
-## Evidence-backed test gap
+## Evidence-backed test gaps closed by PR 1
 
-`test/repair/command-runner.test.ts` uses
+`test/repair/command-runner.test.ts` previously used
 `linuxValidationContainmentAvailable()` to gate the real Linux containment
-tests. That helper calls syscall 444 and requires an ABI result of at least 3.
-Consequently, the precise production condition that should exercise the new
-fallback instead skips the entire integration test.
+tests. PR 1 replaced that with a namespace-only availability probe, so the
+unsupported-Landlock mount fallback now executes instead of skipping.
 
-`test/repair/process-tree-containment.test.ts` currently protects the fallback
-boundary with source-text assertions. These are useful drift guards, but they
-do not execute the embedded Python decision path.
+`test/repair/process-tree-containment.test.ts` previously protected the fallback
+boundary only with source-text assertions. PR 1 now imports the authoritative
+embedded runtime and executes its syscall decision path deterministically.
 
 The runtime is also difficult to test and diagnose because the path spans:
 
@@ -97,20 +104,21 @@ The runtime is also difficult to test and diagnose because the path spans:
 3. the embedded Python in `src/repair/process-tree-containment.ts`
 4. host kernel syscalls and provider seccomp policy
 
-The containment protocol reports only an exception string, so both syscall 442
-and syscall 444 surfaced as the same generic `[Errno 38] Function not
-implemented` message.
+The containment protocol previously reported only an exception string, so both
+syscall 442 and syscall 444 surfaced as the same generic `[Errno 38] Function
+not implemented` message. PR 1 replaced that with validated stage, syscall, and
+errno fields.
 
 ## Required work
 
 ### P0: deterministic fallback tests
 
-- [ ] Make the actual embedded Python definitions importable without executing
+- [x] Make the actual embedded Python definitions importable without executing
       `main()`, while preserving the production `python3 -c` entrypoint.
-- [ ] Exercise the real `landlock_abi()` decision logic with an injected or
+- [x] Exercise the real `landlock_abi()` decision logic with an injected or
       monkey-patched syscall adapter; do not duplicate the decision in a
       TypeScript-only model.
-- [ ] Cover this decision table:
+- [x] Cover this decision table:
 
 | Probe/result                                       | Required behavior                     |
 | -------------------------------------------------- | ------------------------------------- |
@@ -121,26 +129,26 @@ implemented` message.
 | probe returns ABI 3 or newer                       | create and apply the Landlock ruleset |
 | ruleset creation, add-rule, or restrict-self fails | fail closed                           |
 
-- [ ] Split namespace availability from Landlock availability in
+- [x] Split namespace availability from Landlock availability in
       `linuxValidationContainmentAvailable()`. When delegated namespaces are
       usable but Landlock is unavailable, run the mount-only containment tests
       instead of skipping them.
-- [ ] Keep assertions that the sandbox exposes only configured writable roots,
+- [x] Keep assertions that the sandbox exposes only configured writable roots,
       hides host paths and `/run`, drops all capabilities, isolates networking,
       and reaps descendant processes.
 
 ### P1: production-equivalent non-mutating smoke check
 
-- [ ] Add a narrowly scoped `containment-smoke` CI job or workflow using the
+- [x] Add a narrowly scoped `containment-smoke` CI job or workflow using the
       same `blacksmith-16vcpu-ubuntu-2404` runner class as repair execution.
-- [ ] Run the compiled containment preflight only. Do not dispatch a repair,
+- [x] Run the compiled containment preflight only. Do not dispatch a repair,
       push target branches, apply results, close items, or use target write
       credentials.
-- [ ] Trigger it only when the containment worker, its tests, or the relevant
+- [x] Trigger it only when the containment worker, its tests, or the relevant
       workflow surface changes.
-- [ ] Consider two independent runner samples because the observed Blacksmith
+- [x] Run two independent runner samples because the observed Blacksmith
       fleet exposed different capabilities for the same ClawSweeper SHA.
-- [ ] In this production-compatible job, treat a skipped containment test as a
+- [x] In this production-compatible job, treat a skipped containment test as a
       failure rather than a green result.
 
 Before enabling this job for fork pull requests, verify that it runs on a fresh
@@ -150,23 +158,23 @@ remote-validation path.
 
 ### P1: actionable containment diagnostics
 
-- [ ] Report the failing containment stage, syscall number, and errno without
+- [x] Report the failing containment stage, syscall number, and errno without
       including local paths, command contents, or secrets.
-- [ ] Distinguish at least `mount_setattr`, legacy remount,
+- [x] Distinguish at least `mount_setattr`, legacy remount,
       `landlock_capability_probe`, ruleset creation, add-rule, restrict-self,
       namespace setup, and capability drop.
-- [ ] Emit a safe capability summary such as `mount_readonly=native|legacy` and
+- [x] Emit a safe capability summary such as `mount_readonly=native|legacy` and
       `landlock=abi-N|unavailable` from the smoke preflight.
-- [ ] Preserve fail-closed behavior for every mandatory containment stage.
+- [x] Preserve fail-closed behavior for every mandatory containment stage.
 
 ### P2: reduce workflow/runtime duplication
 
-- [ ] Move the inline Node preflight in
+- [x] Move the inline Node preflight in
       `.github/workflows/repair-cluster-worker.yml` behind one compiled,
       locally callable CLI so workflow and local tests execute the same probe.
-- [ ] Keep workflow YAML responsible for orchestration and gates, not the
+- [x] Keep workflow YAML responsible for orchestration and gates, not the
       containment implementation.
-- [ ] Preserve one authoritative copy of the Python runtime. Do not create a
+- [x] Preserve one authoritative copy of the Python runtime. Do not create a
       separate test-only implementation that can drift from production.
 
 ## Capability policy to preserve

--- a/docs/repair/containment-validation-todo.md
+++ b/docs/repair/containment-validation-todo.md
@@ -62,10 +62,11 @@ live repair mutations.
 
 ### PR 2: production-runner smoke workflow
 
-Status: ready to publish from `agent/containment-blacksmith-smoke`. Full local
-`pnpm run check` and autoreview pass with no actionable findings. The repository's
-existing Crabbox hydration workflow does not contain a Blacksmith Testbox action,
-so delegated Testbox validation stops before lease allocation; the pull request's
+Status: [PR openclaw/clawsweeper#602](https://github.com/openclaw/clawsweeper/pull/602)
+is open from `agent/containment-blacksmith-smoke`. Full local `pnpm run check`
+and autoreview pass with no actionable findings. The repository's existing
+Crabbox hydration workflow does not contain a Blacksmith Testbox action, so
+delegated Testbox validation stops before lease allocation; the pull request's
 own two-sample workflow is the authoritative remote Blacksmith proof for this PR.
 
 - run the compiled CLI on `blacksmith-16vcpu-ubuntu-2404` with two independent

--- a/docs/repair/containment-validation-todo.md
+++ b/docs/repair/containment-validation-todo.md
@@ -69,6 +69,14 @@ Crabbox hydration workflow does not contain a Blacksmith Testbox action, so
 delegated Testbox validation stops before lease allocation; the pull request's
 own two-sample workflow is the authoritative remote Blacksmith proof for this PR.
 
+Remote proof for code commit `53304c7ce452e6accc2e0edc866c8131d7900c19`:
+[Actions run 29432924949](https://github.com/openclaw/clawsweeper/actions/runs/29432924949)
+completed both matrix jobs on distinct Blacksmith Actions runners
+`blacksmith-scale2-01kxk9vc8hkwy8gwphs6gpwxwg-16vcpu` and
+`blacksmith-scale2-01kxk9yxny7j6vxrax1hyxmt2j-16vcpu`. Both reported
+`mount_readonly=native landlock=unavailable`. This proof used Blacksmith Actions,
+not Testbox-through-Crabbox, so it has no `tbx_...` Testbox ID.
+
 - run the compiled CLI on `blacksmith-16vcpu-ubuntu-2404` with two independent
   runner samples;
 - replace the existing repair worker's inline Node preflight with the same

--- a/test/repair/repair-cluster-worker-containment.test.ts
+++ b/test/repair/repair-cluster-worker-containment.test.ts
@@ -20,21 +20,9 @@ test("repair target containment preflight runs the enforced worker only for fix 
   const executionCondition =
     "steps.check_job.outputs.job_exists == '1' && steps.self_heal_head.outputs.matched != 'false' && env.CLAWSWEEPER_ALLOW_EXECUTE == '1' && env.CLAWSWEEPER_ALLOW_FIX_PR == '1'";
   assert.match(preflight, new RegExp(escapeRegExp(`if: \${{ ${executionCondition} }}`)));
-  assert.match(
-    preflight,
-    /const workerPath = path\.resolve\("dist\/repair\/contained-command-worker\.js"\);/,
-  );
-  assert.match(preflight, /\[workerPath\],\s*\{\s*cwd: work,/s);
-  assert.doesNotMatch(preflight, /\["dist\/repair\/contained-command-worker\.js"\]/);
-  assert.match(preflight, /host filesystem remained visible/);
-  assert.match(preflight, /host \/run entries remained visible/);
-  assert.match(preflight, /non-writable path accepted a write/);
-  assert.match(preflight, /validation capabilities were not fully dropped/);
-  assert.match(preflight, /listener\.bind\(\('127\.0\.0\.1', 0\)\)/);
-  assert.match(preflight, /result\.status !== 0/);
-  assert.match(preflight, /result\.backgroundProcesses !== 0/);
+  assert.match(preflight, /run: pnpm run repair:containment-smoke/);
+  assert.doesNotMatch(preflight, /node --input-type=module|spawnSync|CONTAINMENT_PROBE_ROOT/);
   assert.doesNotMatch(preflight, /continue-on-error/);
-  assert.doesNotMatch(preflight, /mount_probe|mount_errno|assert not \(mount_probe/);
 });
 
 test("closure-only apply does not depend on target containment or target tool setup", () => {
@@ -60,7 +48,7 @@ test("privileged execution requires the captured execution gate", () => {
   assert.match(executeJob, /if:.*needs\.cluster\.outputs\.allow_execute == '1'/);
   assert.match(
     workflow,
-    /description: "Linux runner label for fix\/apply execution work with delegated user\/mount\/network namespaces, recursive mount hardening, and Landlock ABI 3\+"/,
+    /description: "Linux runner label for fix\/apply execution work with delegated namespaces, recursive mount hardening, and optional Landlock defense in depth"/,
   );
 });
 

--- a/test/repair/repair-containment-smoke-workflow.test.ts
+++ b/test/repair/repair-containment-smoke-workflow.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+const workflow = fs.readFileSync(".github/workflows/repair-containment-smoke.yml", "utf8");
+
+test("containment smoke uses two production-class runner samples", () => {
+  assert.match(workflow, /runs-on: blacksmith-16vcpu-ubuntu-2404/);
+  assert.match(workflow, /max-parallel: 2/);
+  assert.match(workflow, /sample: \[1, 2\]/);
+  assert.match(workflow, /run: pnpm run repair:containment-smoke/);
+  assert.doesNotMatch(workflow, /continue-on-error/);
+});
+
+test("containment smoke is read-only and excludes untrusted fork pull requests", () => {
+  assert.match(workflow, /permissions:\n  contents: read/);
+  assert.match(
+    workflow,
+    /github\.event\.pull_request\.head\.repo\.full_name == github\.repository/,
+  );
+  assert.match(workflow, /persist-credentials: false/);
+  assert.doesNotMatch(workflow, /\$\{\{\s*secrets\.|create-github-app-token|GH_TOKEN:/);
+  assert.doesNotMatch(
+    workflow,
+    /repair:dispatch|repair:worker|repair:execute-fix|repair:apply-result|git push|gh pr/,
+  );
+});
+
+test("containment changes trigger the smoke workflow", () => {
+  for (const changedPath of [
+    ".github/workflows/repair-cluster-worker.yml",
+    ".github/workflows/repair-containment-smoke.yml",
+    "src/repair/contained-command-worker.ts",
+    "src/repair/containment-preflight.ts",
+    "src/repair/process-tree-containment.ts",
+    "test/repair/containment-preflight.test.ts",
+  ]) {
+    assert.equal(workflow.match(new RegExp(escapeRegExp(`- "${changedPath}"`), "g"))?.length, 2);
+  }
+  assert.match(workflow, /workflow_dispatch:/);
+});
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -2161,12 +2161,16 @@ test("repair execution provisions pinned Bun before target validation can invoke
   assert.ok(setupBunIndex < executeFixIndex, "expected Bun setup before repair:execute-fix");
 
   const containmentStep = workflow.slice(containmentIndex, setupBunIndex);
-  assert.match(containmentStep, /\$\{RUNNER_OS:-\}" != "Linux"/);
-  assert.match(containmentStep, /\/usr\/bin\/unshare/);
-  assert.match(containmentStep, /--map-root-user/);
-  assert.match(containmentStep, /--kill-child=SIGKILL/);
-  assert.match(containmentStep, /ctypes\.c_long\(444\)/);
-  assert.match(containmentStep, /Landlock ABI 3 or newer is required/);
+  assert.match(containmentStep, /pnpm run repair:containment-smoke/);
+  const preflight = fs.readFileSync("src/repair/containment-preflight.ts", "utf8");
+  const worker = fs.readFileSync("src/repair/contained-command-worker.ts", "utf8");
+  const runtime = fs.readFileSync("src/repair/process-tree-containment.ts", "utf8");
+  assert.match(preflight, /process\.platform !== "linux"/);
+  assert.match(worker, /command: "\/usr\/bin\/unshare"/);
+  assert.match(worker, /"--map-root-user"/);
+  assert.match(worker, /"--kill-child=SIGKILL"/);
+  assert.match(runtime, /SYS_LANDLOCK_CREATE_RULESET = 444/);
+  assert.match(runtime, /if error\.errno not in \{errno\.ENOSYS, errno\.EOPNOTSUPP\}/);
   const setupBunStep = workflow.slice(setupBunIndex, executeFixIndex);
   assert.match(setupBunStep, /uses: oven-sh\/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6/);
   assert.match(setupBunStep, /bun-version: 1\.3\.14/);


### PR DESCRIPTION
## Summary

- add a read-only two-sample containment smoke workflow on `blacksmith-16vcpu-ubuntu-2404`
- make the repair execution preflight call the same compiled `repair:containment-smoke` CLI
- keep fork pull requests excluded until ephemeral/no-secrets behavior has independent evidence
- update the durable containment validation handoff after https://github.com/openclaw/clawsweeper/pull/599

## Why

Containment capability drift previously surfaced first in live repair execution. This moves the production-runner proof into a non-mutating workflow and removes the duplicated inline workflow implementation.

## Safety

The workflow grants only `contents: read`, disables persisted checkout credentials, uses no secrets, and contains no repair dispatch, branch push, apply, or close operation. The production repair execution gate is unchanged.

## Validation

- `pnpm run check`
- local `pnpm run repair:containment-smoke` (`mount_readonly=native landlock=unavailable`)
- actionlint 1.7.12 using the CI-pinned release
- autoreview: clean, no accepted/actionable findings

A delegated `provider=blacksmith-testbox` Crabbox attempt created no lease because the repository hydration workflow is not a Testbox workflow. This PRs own two-sample Actions workflow is therefore the authoritative Blacksmith remote proof.