### PR TITLE
fix(queue): prevent expired publications from starving later results

### DIFF
--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -2960,10 +2960,21 @@ function reclaimExpiredExactReviewLease(
     delete state.items[key];
     return true;
   }
+  const publication = exactReviewQueueIsPublication(item);
   clearExactReviewLease(item);
   item.state = "pending";
-  item.nextAttemptAt = now;
-  if (hasNewerRevision) item.attempts = 0;
+  if (hasNewerRevision) {
+    item.attempts = 0;
+    item.nextAttemptAt = exactReviewQueueEnqueueAttemptAt(state, now);
+  } else if (publication) {
+    item.attempts += 1;
+    item.nextAttemptAt = Math.max(
+      exactReviewQueueEnqueueAttemptAt(state, now),
+      now + exactReviewRetryDelayMs(item.attempts),
+    );
+  } else {
+    item.nextAttemptAt = exactReviewQueueEnqueueAttemptAt(state, now);
+  }
   item.updatedAt = now;
   return true;
 }

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -155,8 +155,10 @@ workflows holding the expired lease cannot claim it.
 Run-attempt binding and a per-claim generation check keep delayed terminal
 decisions from releasing a later rerun; queued and in-progress runs are never
 released. If a workflow never claims or completes, the Durable Object reclaims
-the expired lease. This keeps capacity waiting and retry state out of GitHub
-Actions runners.
+the expired lease. Unclaimed exact-review publications use a 15-minute claim
+window and enter bounded retry backoff before re-admission, so repeatedly
+unclaimed older artifacts yield publication capacity to later results. This
+keeps capacity waiting and retry state out of GitHub Actions runners.
 
 Examples with the current config:
 

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -2962,7 +2962,11 @@ test("exact-review queue keeps publication artifacts durable outside review capa
     const scheduledPublisher = afterScheduledMaintenance.items["openclaw/gogcli#801@publish:100:1"];
     assert.equal(scheduledPublisher.state, "pending");
     assert.equal(scheduledPublisher.leaseId, undefined);
-    assert.ok(((await storage.getAlarm()) ?? Number.POSITIVE_INFINITY) <= Date.now() + 1_000);
+    assert.equal(scheduledPublisher.attempts, 1);
+    assert.ok(scheduledPublisher.nextAttemptAt > Date.now());
+    assert.ok(((await storage.getAlarm()) ?? Number.POSITIVE_INFINITY) <= Date.now() + 31_000);
+    scheduledPublisher.nextAttemptAt = Date.now() - 1;
+    await storage.put("exact-review-queue", afterScheduledMaintenance);
 
     await queue.alarm();
     const afterScheduledRedispatch = (await storage.get("exact-review-queue")) as typeof state;
@@ -3004,7 +3008,11 @@ test("exact-review queue keeps publication artifacts durable outside review capa
     const reclaimedPublisher = afterExpiredClaim.items["openclaw/gogcli#801@publish:100:1"];
     assert.equal(reclaimedPublisher.state, "pending");
     assert.equal(reclaimedPublisher.leaseId, undefined);
-    assert.ok(((await storage.getAlarm()) ?? Number.POSITIVE_INFINITY) <= Date.now() + 1_000);
+    assert.equal(reclaimedPublisher.attempts, 2);
+    assert.ok(reclaimedPublisher.nextAttemptAt > Date.now());
+    assert.ok(((await storage.getAlarm()) ?? Number.POSITIVE_INFINITY) <= Date.now() + 61_000);
+    reclaimedPublisher.nextAttemptAt = Date.now() - 1;
+    await storage.put("exact-review-queue", afterExpiredClaim);
 
     await queue.alarm();
 
@@ -3026,6 +3034,122 @@ test("exact-review queue keeps publication artifacts durable outside review capa
           lease_id: firstPublicationLease.leaseId,
           item_key: "openclaw/gogcli#801@publish:100:1",
           lease_revision: firstPublicationLease.leaseRevision,
+          run_id: "999999",
+          run_attempt: 1,
+        }),
+      }),
+    );
+    assert.equal(staleClaim.status, 409);
+    assert.deepEqual(await staleClaim.json(), { error: "lease_not_active" });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("expired exact-review publications yield bounded capacity to later artifacts", async () => {
+  const originalFetch = globalThis.fetch;
+  const storage = new MemoryDurableStorage();
+  const dispatched: Record<string, unknown>[] = [];
+  const { privateKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  });
+  globalThis.fetch = async (input, init) => {
+    const url = new URL(String(input));
+    if (url.pathname === "/repos/openclaw/clawsweeper/actions/workflows/sweep.yml")
+      return jsonResponse({ state: "active" });
+    if (url.pathname === "/repos/openclaw/clawsweeper/installation")
+      return jsonResponse({ id: 999 });
+    if (url.pathname === "/app/installations/999/access_tokens")
+      return jsonResponse({ token: "dispatch-token" });
+    if (url.pathname === "/repos/openclaw/clawsweeper/dispatches") {
+      dispatched.push(JSON.parse(String(init?.body)));
+      return new Response(null, { status: 204 });
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  };
+
+  try {
+    const queue = new ExactReviewQueue(
+      { storage },
+      {
+        CLAWSWEEPER_APP_CLIENT_ID: "Iv23test",
+        CLAWSWEEPER_APP_PRIVATE_KEY: privateKey,
+        EXACT_REVIEW_PUBLICATION_MAX_CONCURRENT: "1",
+        EXACT_REVIEW_QUEUE_MAX_CONCURRENT: "4",
+        EXACT_REVIEW_TARGET_MAX_CONCURRENT: "4",
+      },
+    );
+    await queue.fetch(
+      buildExactReviewQueueRequest(
+        "publisher:200:1",
+        901,
+        "exact_review_artifact_publish",
+        "issue",
+        "openclaw/gogcli",
+        exactReviewPublicationOverrides(901, "200"),
+      ),
+    );
+    await queue.alarm();
+    await queue.fetch(
+      buildExactReviewQueueRequest(
+        "publisher:201:1",
+        902,
+        "exact_review_artifact_publish",
+        "issue",
+        "openclaw/gogcli",
+        exactReviewPublicationOverrides(902, "201"),
+      ),
+    );
+
+    const state = (await storage.get("exact-review-queue")) as {
+      items: Record<
+        string,
+        {
+          attempts: number;
+          dispatchedAt?: number;
+          leaseExpiresAt?: number;
+          leaseId?: string;
+          leaseRevision?: number;
+          nextAttemptAt: number;
+          state: string;
+        }
+      >;
+    };
+    const firstKey = "openclaw/gogcli#901@publish:200:1";
+    const secondKey = "openclaw/gogcli#902@publish:201:1";
+    const firstLease = {
+      leaseId: state.items[firstKey].leaseId,
+      leaseRevision: state.items[firstKey].leaseRevision,
+    };
+    assert.ok(firstLease.leaseId);
+    assert.ok(firstLease.leaseRevision);
+    state.items[firstKey].dispatchedAt = Date.now() - 16 * 60_000;
+    state.items[firstKey].leaseExpiresAt = Date.now() - 1;
+    await storage.put("exact-review-queue", state);
+
+    await queue.alarm();
+
+    assert.deepEqual(
+      dispatched.map((payload) =>
+        Number((payload.client_payload as Record<string, unknown>).item_number),
+      ),
+      [901, 902],
+    );
+    const recovered = (await storage.get("exact-review-queue")) as typeof state;
+    assert.equal(recovered.items[firstKey].state, "pending");
+    assert.equal(recovered.items[firstKey].attempts, 1);
+    assert.ok(recovered.items[firstKey].nextAttemptAt > Date.now());
+    assert.equal(recovered.items[secondKey].state, "dispatching");
+
+    const staleClaim = await queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/claim", {
+        method: "POST",
+        body: JSON.stringify({
+          lease_id: firstLease.leaseId,
+          item_key: firstKey,
+          lease_revision: firstLease.leaseRevision,
           run_id: "999999",
           run_attempt: 1,
         }),


### PR DESCRIPTION
<!-- submission-timestamps:start -->
First submitted: July 15, 2026, 12:57 PM (US Eastern Time) / 16:57 UTC.
Last body edit: July 15, 2026, 11:23 PM (US Eastern Time) / 03:23 UTC.
Latest head commit: July 15, 2026, 11:08 PM (US Eastern Time) / 03:08 UTC.
<!-- submission-timestamps:end -->

Related: #606

## Summary

Prevent repeatedly unclaimed exact-review publications from monopolizing the bounded publication lane after their claim leases expire.

The original broad #607 patch has been rebased onto current `main` and reduced to the one fairness gap not already covered by #610, #614, #616, and #617.

## Breaking changes

None. Queue payloads, stored item schema, publication capacity, claim and completion tuples, stale-lease rejection, workflow permissions, immutable artifact validation, and target-serialized routing are unchanged.

## What Problem This Solves

Fixes an issue where later completed review results could remain unpublished when the oldest publication artifacts repeatedly failed to claim a publisher lease.

Current `main` admits up to 24 exact publishers. When an unchanged publication lease expires, however, the item was returned to `pending` with `nextAttemptAt = now`. Admission sorts ready work by original creation time, so the same oldest item could immediately consume the slot again. One repeatedly unclaimed artifact can starve later results when capacity is configured to one; 24 such artifacts can monopolize the production lane.

## Why This Change Was Made

Expired unchanged publications now use the queue's existing bounded exponential retry backoff before re-admission. Newer source revisions still become immediately eligible, ordinary review recovery remains immediate, and one-shot failed-shard recovery behavior is unchanged.

## User Impact

Later completed reviews can reach their durable comments even when older publication dispatches repeatedly fail before claim. The change improves fairness without reducing the current 24-publication throughput limit.

## Implementation

- Detect publication items in `reclaimExpiredExactReviewLease` before clearing the expired tuple.
- Increment the existing attempt counter and schedule unchanged publications with `exactReviewRetryDelayMs`.
- Keep newer revisions immediately eligible so current maintainer or source context is not delayed.
- Add a capacity-one regression that expires the oldest publication, proves the later artifact is dispatched, and proves the stale tuple still receives `409 lease_not_active`.
- Document the 15-minute publication claim window and fairness backoff.

## Code-path analysis

- Runtime entry and owner: `ExactReviewQueue.alarm` in `dashboard/worker.ts` reclaims expired leases, computes admitted items, and dispatches signed `repository_dispatch` payloads.
- Reclaim callee: `reclaimExpiredExactReviewLease` owns state transition from expired `dispatching`/`leased` work back to `pending`.
- Admission caller: `exactReviewQueueAdmittedItems` selects ready publications up to `EXACT_REVIEW_PUBLICATION_MAX_CONCURRENT`, ordered by `createdAt` and key.
- Retry sibling: `finishExactReviewQueueItem` already uses `exactReviewRetryDelayMs` for failed attempts; this patch applies the same bounded policy to unclaimed publication expiry.
- Workflow boundary: `.github/workflows/sweep.yml` keeps exact publication on current `main`, validates immutable producer artifacts, rejects stale tuples, and defers verdict routing through the target-serialized router. This PR does not change that workflow.
- Tests: `test/dashboard-worker.test.ts` covers publication capacity, legacy lease recovery, stale claims, and the new fairness behavior.

## Mainline comparison

- Official repository/default branch: `openclaw/clawsweeper:main`
- Base SHA: `0a17516dd286800c2cca4d818b2a75255f4b5c70`
- Base commit time: July 15, 2026, 10:03 PM US Eastern / 02:03 UTC
- Comparison refreshed: July 15, 2026, 11:22 PM US Eastern / 03:22 UTC
- #610 added the 15-minute effective publication lease and stale-tuple recovery.
- #614 raised publication capacity to 24 and preserved target-serialized verdict routing.
- #616 made queued publishers run repaired code from current `main` while validating immutable producer artifacts.
- #617 corrected Codex/control-plane capacity accounting.
- None of those changes backs off an unchanged expired publication before the creation-ordered admission pass.

## Branch / base provenance

- Base: `openclaw/clawsweeper:main@0a17516dd286800c2cca4d818b2a75255f4b5c70`
- Head: `snowzlmbot/clawsweeper:fix/exact-review-publication-starvation@258c1279d0aa6a65a3edd59b58290d6e60138a19`
- The branch contains one dedicated commit changing three files.
- The previous overlapping workflow, lease, health, config, and serialization changes were dropped during rebase because current `main` already contains stronger replacements.
- The fork default branch was not modified by this work.

## Dependency / contract verification

- No dependency, lockfile, workflow, permission, token, schema, or configuration changes.
- Protocol v2 item key, lease revision, run attempt, claim generation, immutable decision, and stale-claim checks are unchanged.
- Publication capacity remains bounded and configurable; production remains at 24.
- The backoff is capped by the existing retry helper and only affects unchanged expired publication leases.

## Labels considered

- `bug`
- `impact:other`
- `merge-risk: availability`
- `merge-risk: automation`

These are contributor suggestions; no upstream metadata change is assumed.

## Validation

GitHub-hosted validation:

- [Exact PR-head CI](https://github.com/snowzlmbot/clawsweeper/actions/runs/29468295972) on `258c1279d0aa6a65a3edd59b58290d6e60138a19` — both affected queue tests passed, including the new fairness regression; Windows launcher and crawl-remote toolchain jobs passed. The aggregate `pnpm check` job reported only five established fork-context failures in `test/failed-review-retry.test.ts` because the fixture models `openclaw/clawsweeper` while `GITHUB_REPOSITORY` names the fork.
- [Full CI proof](https://github.com/snowzlmbot/clawsweeper/actions/runs/29468372352) on evidence head `6042fbd4b9ff7b8e53426c4417c1c5252cd8eab5` — success; `pnpm check` completed in 9m31s and the Windows launcher and crawl-remote toolchain jobs passed. The evidence branch differs from the PR head only by the historical public screenshot/report and a three-line proof-only test normalization of `GITHUB_REPOSITORY`; all three PR-changed files are byte-identical.
- [CodeQL proof](https://github.com/snowzlmbot/clawsweeper/actions/runs/29468296766) on the exact PR head — success for both Actions and JavaScript/TypeScript.

Local pre-submit checks were limited to static gates:

- `git diff --check` — passed.
- Focused `oxfmt --check` for all three changed files — passed.
- Sensitive-data diff scan — passed; only synthetic test fixture identifiers were present.

## Evidence source map

- [Live queue status](https://clawsweeper.openclaw.ai/api/status), sampled July 16, 2026 at 02:53 UTC: publication lane at 24/24 active with 1,886 ready items and zero items in publication backoff.
- [Exact PR-head CI](https://github.com/snowzlmbot/clawsweeper/actions/runs/29468295972): both changed queue tests passed; the five remaining failures are the existing fork repository-name fixture mismatch described above.
- [Full CI proof](https://github.com/snowzlmbot/clawsweeper/actions/runs/29468372352): repository-wide build, lint, unit, repair, coverage, workflow, formatting, Windows launcher, and toolchain gates with the proof-only repository-context normalization.
- [CodeQL proof](https://github.com/snowzlmbot/clawsweeper/actions/runs/29468296766): JavaScript/TypeScript and Actions security analysis for the exact PR head.
- The focused regression configures publication capacity to one, dispatches artifact 901, expires its unclaimed lease, enqueues artifact 902, and verifies dispatch order `[901, 902]` while 901 enters backoff.

## Sanitized logs

```text
observed_at=2026-07-16T02:53:35Z
publication.capacity=24
publication.active=24
publication.pending=1886
publication.ready=1886
publication.backoff=0
publication.available_slots=0

regression.expected_dispatch_order=901,902
expired_artifact.state=pending
expired_artifact.attempts=1
expired_artifact.next_attempt_at=future
later_artifact.state=dispatching
stale_claim.status=409
stale_claim.error=lease_not_active
```

## Media evidence

No visual surface changes. The behavior is a deterministic Durable Object scheduling transition; the public Actions run and focused assertion provide the inspectable proof. No production mutation or private environment was used.

## Risk

- A repeatedly unclaimed publication waits 30 seconds after its first expired handoff, increasing to the existing five-minute cap on repeated failures. This is intentional fairness and remains much shorter than artifact retention.
- Newer revisions bypass the backoff and reset attempts, preserving current source context.
- Stale jobs still fail closed because clearing the old tuple is unchanged and explicitly asserted.
- No authorization, artifact trust, target mutation, state schema, or routing ownership boundary changes.

## Rollback

Revert the single commit. No data migration, configuration migration, workflow change, or irreversible mutation is introduced. Existing queue rows remain compatible in either direction.

## Docs updated

- `docs/limits.md` now documents the publication-specific 15-minute claim window and bounded fairness backoff.

## Related issue / PR

- Related: #606.
- Superseding mainline work retained: #610, #614, #616, and #617.
- Historical origin of split publication: #592.

## Review context addressed

- The earlier review found no discrete correctness or security defect in the original patch but required stronger proof.
- Current-main comparison showed that the workflow serialization, 15-minute lease, health correction, and config changes were superseded; they have been removed from this PR.
- The remaining fairness behavior is now isolated in one owner function and covered by a capacity-bound regression plus stale-claim assertion.

## Not tested / limitations

- No production deployment was performed from this contribution.
- The hosted regression proves deterministic queue behavior; production backlog drain remains an operational post-deploy observation.
- Upstream pull-request CI may remain in GitHub's external-contribution state; the linked downstream CI and CodeQL runs execute the exact head publicly.
