### PR TITLE
fix(validation): repair handles tracked workspace self-links

### DIFF
--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -2370,8 +2370,8 @@ function worktreeContentSha256(cwd: string, deadlineAt: number) {
   )
     .split("\0")
     .filter(Boolean);
+  const trackedPaths = new Set(tracked);
   const paths = [...new Set([...tracked, ...untracked])].sort();
-  const worktreePaths = new Set(paths);
   for (const relativePath of paths) {
     assertValidationIdentityDeadline(deadlineAt, relativePath);
     const absolutePath = path.join(root, relativePath);
@@ -2394,7 +2394,7 @@ function worktreeContentSha256(cwd: string, deadlineAt: number) {
         absolutePath,
         `${relativePath}\0target`,
         deadlineAt,
-        worktreePaths,
+        trackedPaths,
       );
       continue;
     }
@@ -3179,7 +3179,7 @@ function updateSymlinkTargetDigest(
   symlinkPath: string,
   logicalPath: string,
   deadlineAt: number,
-  worktreePaths: ReadonlySet<string>,
+  trackedPaths: ReadonlySet<string>,
 ) {
   let targetPath: string;
   try {
@@ -3189,7 +3189,7 @@ function updateSymlinkTargetDigest(
   }
   assertPathWithin(root, targetPath, logicalPath);
   updateIdentityHash(hash, "symlink-target-path", path.relative(root, targetPath));
-  const workspaceReference = trackedWorkspaceSelfLink(root, symlinkPath, targetPath, worktreePaths);
+  const workspaceReference = trackedWorkspaceSelfLink(root, symlinkPath, targetPath, trackedPaths);
   if (workspaceReference) {
     updateIdentityHash(hash, "symlink-workspace-reference", workspaceReference);
     return;
@@ -3201,11 +3201,12 @@ function trackedWorkspaceSelfLink(
   root: string,
   symlinkPath: string,
   targetPath: string,
-  worktreePaths: ReadonlySet<string>,
+  trackedPaths: ReadonlySet<string>,
 ) {
   if (!fs.statSync(targetPath).isDirectory()) return null;
-  const relativeLink = path.relative(root, symlinkPath);
-  const linkParts = relativeLink.split(path.sep);
+  const relativeLink = path.relative(root, symlinkPath).split(path.sep).join("/");
+  if (!trackedPaths.has(relativeLink)) return null;
+  const linkParts = relativeLink.split("/");
   const nodeModulesIndex = linkParts.lastIndexOf("node_modules");
   const packageParts = linkParts.slice(nodeModulesIndex + 1);
   const packageName =
@@ -3227,13 +3228,16 @@ function trackedWorkspaceSelfLink(
 
   const targetRelative = path.relative(root, targetPath).split(path.sep).join("/");
   const manifestRelative = targetRelative ? `${targetRelative}/package.json` : "package.json";
-  if (!worktreePaths.has(manifestRelative)) return null;
+  if (!trackedPaths.has(manifestRelative)) return null;
   try {
     const manifest = JSON.parse(fs.readFileSync(path.join(targetPath, "package.json"), "utf8"));
     if (manifest?.name !== packageName) return null;
   } catch {
     return null;
   }
+  // Source identity already binds tracked/untracked worktree content, ignored runtime inputs,
+  // and Git administrative state. Recording this authenticated back-reference avoids an
+  // infinite walk without allowing mutable target content to disappear from the identity.
   return `${packageName}\0${targetRelative}`;
 }
 

--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -2371,6 +2371,7 @@ function worktreeContentSha256(cwd: string, deadlineAt: number) {
     .split("\0")
     .filter(Boolean);
   const paths = [...new Set([...tracked, ...untracked])].sort();
+  const worktreePaths = new Set(paths);
   for (const relativePath of paths) {
     assertValidationIdentityDeadline(deadlineAt, relativePath);
     const absolutePath = path.join(root, relativePath);
@@ -2387,7 +2388,14 @@ function worktreeContentSha256(cwd: string, deadlineAt: number) {
     updateIdentityHash(hash, "worktree-mode", String(stat.mode));
     if (stat.isSymbolicLink()) {
       updateIdentityHash(hash, "worktree-symlink", fs.readlinkSync(absolutePath));
-      updateSymlinkTargetDigest(hash, root, absolutePath, `${relativePath}\0target`, deadlineAt);
+      updateSymlinkTargetDigest(
+        hash,
+        root,
+        absolutePath,
+        `${relativePath}\0target`,
+        deadlineAt,
+        worktreePaths,
+      );
       continue;
     }
     if (stat.isFile()) {
@@ -3171,6 +3179,7 @@ function updateSymlinkTargetDigest(
   symlinkPath: string,
   logicalPath: string,
   deadlineAt: number,
+  worktreePaths: ReadonlySet<string>,
 ) {
   let targetPath: string;
   try {
@@ -3180,7 +3189,52 @@ function updateSymlinkTargetDigest(
   }
   assertPathWithin(root, targetPath, logicalPath);
   updateIdentityHash(hash, "symlink-target-path", path.relative(root, targetPath));
+  const workspaceReference = trackedWorkspaceSelfLink(root, symlinkPath, targetPath, worktreePaths);
+  if (workspaceReference) {
+    updateIdentityHash(hash, "symlink-workspace-reference", workspaceReference);
+    return;
+  }
   updateResolvedPathDigest(hash, root, targetPath, logicalPath, deadlineAt, new Set());
+}
+
+function trackedWorkspaceSelfLink(
+  root: string,
+  symlinkPath: string,
+  targetPath: string,
+  worktreePaths: ReadonlySet<string>,
+) {
+  if (!fs.statSync(targetPath).isDirectory()) return null;
+  const relativeLink = path.relative(root, symlinkPath);
+  const linkParts = relativeLink.split(path.sep);
+  const nodeModulesIndex = linkParts.lastIndexOf("node_modules");
+  const packageParts = linkParts.slice(nodeModulesIndex + 1);
+  const packageName =
+    nodeModulesIndex >= 0 && packageParts.length === 1
+      ? packageParts[0]
+      : nodeModulesIndex >= 0 && packageParts.length === 2 && packageParts[0]?.startsWith("@")
+        ? packageParts.join("/")
+        : null;
+  if (!packageName) return null;
+
+  const linkFromTarget = path.relative(targetPath, symlinkPath);
+  if (
+    !linkFromTarget ||
+    linkFromTarget.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(linkFromTarget)
+  ) {
+    return null;
+  }
+
+  const targetRelative = path.relative(root, targetPath).split(path.sep).join("/");
+  const manifestRelative = targetRelative ? `${targetRelative}/package.json` : "package.json";
+  if (!worktreePaths.has(manifestRelative)) return null;
+  try {
+    const manifest = JSON.parse(fs.readFileSync(path.join(targetPath, "package.json"), "utf8"));
+    if (manifest?.name !== packageName) return null;
+  } catch {
+    return null;
+  }
+  return `${packageName}\0${targetRelative}`;
 }
 
 function updateResolvedPathDigest(

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -4909,6 +4909,69 @@ test(
 );
 
 test(
+  "validation accepts tracked scoped node_modules workspace links back to the checkout",
+  { skip: process.platform === "win32" },
+  () => {
+    const cwd = gitPackageFixture({ check: 'node -e ""' });
+    const packagePath = path.join(cwd, "package.json");
+    const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+    packageJson.name = "@openclaw/root";
+    fs.writeFileSync(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`);
+    const workspaceScope = path.join(cwd, "packages", "speech-core", "node_modules", "@openclaw");
+    fs.mkdirSync(workspaceScope, { recursive: true });
+    fs.symlinkSync("../../../..", path.join(workspaceScope, "root"));
+    git(cwd, "add", "--force", ".");
+    git(cwd, "commit", "-m", "initial");
+
+    const first = captureTargetCheckoutBinding(cwd);
+
+    assert.deepEqual(captureTargetCheckoutBinding(cwd), first);
+  },
+);
+
+test(
+  "validation rejects untracked node_modules workspace self-links",
+  { skip: process.platform === "win32" },
+  () => {
+    const cwd = gitPackageFixture({ check: 'node -e ""' });
+    fs.rmSync(path.join(cwd, ".gitignore"));
+    const packagePath = path.join(cwd, "package.json");
+    const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+    packageJson.name = "openclaw";
+    fs.writeFileSync(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`);
+    git(cwd, "add", ".");
+    git(cwd, "commit", "-m", "initial");
+    const workspaceModules = path.join(cwd, "packages", "speech-core", "node_modules");
+    fs.mkdirSync(workspaceModules, { recursive: true });
+    fs.symlinkSync("../../..", path.join(workspaceModules, "openclaw"));
+
+    assert.throws(() => captureTargetCheckoutBinding(cwd), /validation identity directory cycle/);
+  },
+);
+
+test(
+  "validation rejects workspace self-links with untracked target manifests",
+  { skip: process.platform === "win32" },
+  () => {
+    const cwd = gitPackageFixture({ check: 'node -e ""' });
+    const targetDir = path.join(cwd, "packages", "root-package");
+    const targetModules = path.join(targetDir, "node_modules");
+    fs.mkdirSync(targetModules, { recursive: true });
+    fs.writeFileSync(
+      path.join(targetDir, "package.json"),
+      `${JSON.stringify({ name: "root-package" }, null, 2)}\n`,
+    );
+    const linkPath = path.join(targetModules, "root-package");
+    fs.symlinkSync("..", linkPath);
+    git(cwd, "add", ".gitignore", "package.json");
+    git(cwd, "add", "--force", linkPath);
+    git(cwd, "commit", "-m", "initial");
+
+    assert.throws(() => captureTargetCheckoutBinding(cwd), /validation identity directory cycle/);
+  },
+);
+
+test(
   "validation rejects node_modules self-links with mismatched package identities",
   { skip: process.platform === "win32" },
   () => {

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -4881,6 +4881,72 @@ test("Git identity probes reject target fsmonitor callbacks without executing th
 });
 
 test(
+  "validation accepts tracked node_modules workspace links back to the checkout",
+  { skip: process.platform === "win32" },
+  () => {
+    const cwd = gitPackageFixture({ check: 'node -e ""' });
+    const packagePath = path.join(cwd, "package.json");
+    const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+    packageJson.name = "openclaw";
+    fs.writeFileSync(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`);
+    fs.writeFileSync(path.join(cwd, "source.txt"), "initial\n");
+    const workspaceModules = path.join(cwd, "packages", "speech-core", "node_modules");
+    fs.mkdirSync(workspaceModules, { recursive: true });
+    fs.symlinkSync("../../..", path.join(workspaceModules, "openclaw"));
+    git(cwd, "add", "--force", ".");
+    git(cwd, "commit", "-m", "initial");
+
+    const first = captureTargetCheckoutBinding(cwd);
+    const second = captureTargetCheckoutBinding(cwd);
+
+    assert.deepEqual(second, first);
+    fs.writeFileSync(path.join(cwd, "source.txt"), "changed\n");
+    assert.throws(
+      () => assertTargetCheckoutBinding(cwd, first),
+      /target checkout changed after validation/,
+    );
+  },
+);
+
+test(
+  "validation rejects node_modules self-links with mismatched package identities",
+  { skip: process.platform === "win32" },
+  () => {
+    const cwd = gitPackageFixture({ check: 'node -e ""' });
+    const packagePath = path.join(cwd, "package.json");
+    const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+    packageJson.name = "openclaw";
+    fs.writeFileSync(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`);
+    const workspaceModules = path.join(cwd, "packages", "speech-core", "node_modules");
+    fs.mkdirSync(workspaceModules, { recursive: true });
+    fs.symlinkSync("../../..", path.join(workspaceModules, "not-openclaw"));
+    git(cwd, "add", "--force", ".");
+    git(cwd, "commit", "-m", "initial");
+
+    assert.throws(() => captureTargetCheckoutBinding(cwd), /validation identity directory cycle/);
+  },
+);
+
+test(
+  "validation rejects scoped self-links outside node_modules",
+  { skip: process.platform === "win32" },
+  () => {
+    const cwd = gitPackageFixture({ check: 'node -e ""' });
+    const packagePath = path.join(cwd, "package.json");
+    const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+    packageJson.name = "@openclaw/root";
+    fs.writeFileSync(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`);
+    const scopedPackage = path.join(cwd, "@openclaw");
+    fs.mkdirSync(scopedPackage, { recursive: true });
+    fs.symlinkSync("..", path.join(scopedPackage, "root"));
+    git(cwd, "add", "--force", ".");
+    git(cwd, "commit", "-m", "initial");
+
+    assert.throws(() => captureTargetCheckoutBinding(cwd), /validation identity directory cycle/);
+  },
+);
+
+test(
   "validation rejects tracked symlinks that escape the target checkout",
   { skip: process.platform === "win32" },
   () => {


### PR DESCRIPTION
Closes #605

## What Problem This Solves

Repair validation rejected OpenClaw's tracked `packages/speech-core/node_modules/openclaw -> ../../..` workspace self-link as a directory cycle before any repair command could run.

## Why This Change Was Made

Validation now recognizes a narrow class of tracked workspace package self-links and hashes them as stable references instead of recursively walking back into the checkout. The exception requires an in-checkout directory target, a direct `node_modules` package path, a tracked target manifest, and an exact package-name match. Escaping links, broken links, mismatched package identities, links outside `node_modules`, and unexpected cycles remain fail-closed.

## User Impact

Repair jobs can validate OpenClaw's tracked speech-core workspace link and proceed instead of stopping during target preparation. Later mutations to the linked checkout are still detected by the checkout binding.

## Evidence

- Before: [run 29431617465](https://github.com/openclaw/clawsweeper/actions/runs/29431617465) failed with `validation identity directory cycle: packages/speech-core/node_modules/openclaw` while preparing the target toolchain.
- After: `captureTargetCheckoutBinding` completed against a clean OpenClaw checkout at `e58dc0955f35c8199b6d53d88189fd4764ce2dda`, including the tracked speech-core self-link. It produced `worktreeSha256=36d6ab9034260920277dc6b115e5e58e3ea3c01f12142296ac9a47e1d378c292` and `runtimeInputsSha256=6f73f134ed12ccede3e99909be972517d582d0873d6e021c081d706f0ce24897`.
- Focused regression command: `node --test --test-name-pattern='validation accepts tracked node_modules workspace links|validation rejects node_modules self-links|validation rejects scoped self-links|validation rejects tracked symlinks that escape' test/repair/target-validation.test.ts` (4 passed).
- Build and static checks: `pnpm run build:repair`, `pnpm exec oxlint src/repair/target-validation.ts test/repair/target-validation.test.ts`, and `pnpm exec oxfmt --check src/repair/target-validation.ts test/repair/target-validation.test.ts` passed under Node 24.
- Broader repair suite: 895 passed, 7 skipped, and 4 macOS Landlock/capset probe failures. The same four failures reproduce on untouched `main`; they are unrelated to this change.
- `pnpm run check` completed build and lint, then stalled in the pre-existing `test/command.test.ts` missing-target CLI case and was interrupted. Focused changed-surface validation and the real checkout proof completed successfully.

Disclosure: AI was used to understand the codebase and review the fix.
