### PR TITLE
fix(queue): unblock exact review publication

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1131,7 +1131,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     concurrency:
-      group: clawsweeper-state-publisher
+      group: clawsweeper-exact-review-publisher
       cancel-in-progress: false
       queue: max
     permissions:

--- a/dashboard/exact-review-health.ts
+++ b/dashboard/exact-review-health.ts
@@ -163,7 +163,7 @@ function exactReviewPhaseStartedAt(
     const dispatchedAt = validTimestamp(item.dispatchedAt);
     const leaseExpiresAt = validTimestamp(item.leaseExpiresAt);
     const leaseStartedAt =
-      leaseExpiresAt === null ? null : validTimestamp(leaseExpiresAt - dispatchLeaseMs);
+      leaseExpiresAt === null ? null : timestampAtOrBefore(leaseExpiresAt - dispatchLeaseMs, now);
     // Rolling deploys can expose rows created before dispatchedAt existed, while a rollback can
     // leave an old dispatchedAt behind. The current lease start is the reliable compatibility
     // marker; prefer the newest plausible transition and keep an unknown age non-alarming.
@@ -192,6 +192,11 @@ function validTimestamp(value: unknown): number | null {
   if (value === null || value === undefined || value === "") return null;
   const number = Number(value);
   return Number.isFinite(number) && number > 0 && number <= 8_640_000_000_000_000 ? number : null;
+}
+
+function timestampAtOrBefore(value: unknown, maximum: number): number | null {
+  const timestamp = validTimestamp(value);
+  return timestamp !== null && timestamp <= maximum ? timestamp : null;
 }
 
 function finiteTimestamp(value: unknown, fallback: number) {

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -154,9 +154,9 @@ const HEALTH_HISTORY_KEY_PREFIX = "health-history:";
 const DEFAULT_EXACT_REVIEW_QUEUE_MAX_CONCURRENT = 64;
 const DEFAULT_EXACT_REVIEW_TARGET_MAX_CONCURRENT = 60;
 const DEFAULT_EXACT_REVIEW_DISPATCH_LEASE_MS = 6 * 60 * 1000;
-// Covers the global publisher lane's 100 queued 60-minute jobs plus scheduling margin.
-// Terminal-run reconciliation still releases failed or cancelled dispatches early.
-const DEFAULT_EXACT_REVIEW_PUBLICATION_DISPATCH_LEASE_MS = 7 * 24 * 60 * 60 * 1000;
+// Exact publications have a dedicated serial lane. Bound the unclaimed handoff so a run that
+// never reaches its claim step is re-dispatched; stale runs lose the lease tuple safely.
+const DEFAULT_EXACT_REVIEW_PUBLICATION_DISPATCH_LEASE_MS = 15 * 60 * 1000;
 const DEFAULT_EXACT_REVIEW_EXECUTION_LEASE_MS = 130 * 60 * 1000;
 const DEFAULT_EXACT_REVIEW_RETRY_MS = 30_000;
 const DEFAULT_EXACT_REVIEW_WORKFLOW_PAUSED_RETRY_MS = 60_000;
@@ -580,7 +580,11 @@ export class ExactReviewQueue {
         const state = this.readStateSync();
         // A delayed or lost alarm must not let an expired one-shot recovery
         // suppress the next failed shard's recovery delivery.
-        reclaimExpiredExactReviewLeases(state, now);
+        reclaimExpiredExactReviewLeases(
+          state,
+          now,
+          exactReviewPublicationDispatchLeaseMs(this.env),
+        );
         const key = exactReviewItemKey(decision);
         const current = state.items[key];
         const nextAttemptAt = exactReviewQueueEnqueueAttemptAt(state, now);
@@ -646,10 +650,24 @@ export class ExactReviewQueue {
       const state = this.readStateSync();
       const item = tupleClaim ? state.items[itemKey] : exactReviewItemForLease(state, leaseId);
       if (
+        item &&
+        reclaimExpiredExactReviewLease(
+          state,
+          item.key,
+          item,
+          now,
+          exactReviewPublicationDispatchLeaseMs(this.env),
+        )
+      ) {
+        this.writeStateSync(state);
+        await this.scheduleNext(state, now);
+        return json({ error: "lease_not_active" }, 409);
+      }
+      if (
         !item ||
         item.leaseId !== leaseId ||
         (tupleClaim && item.leaseRevision !== leaseRevision) ||
-        !isLiveExactReviewLease(item, now)
+        !isLiveExactReviewLease(item, now, exactReviewPublicationDispatchLeaseMs(this.env))
       ) {
         return json({ error: "lease_not_active" }, 409);
       }
@@ -876,7 +894,11 @@ export class ExactReviewQueue {
         const current = this.readStateSync();
         // Dashboard reads are also the operational heartbeat. Reclaim leases and
         // restore the alarm here so a deploy or lost alarm cannot strand backlog.
-        const changed = reclaimExpiredExactReviewLeases(current, now);
+        const changed = reclaimExpiredExactReviewLeases(
+          current,
+          now,
+          exactReviewPublicationDispatchLeaseMs(this.env),
+        );
         if (changed) this.writeStateSync(current);
         else this.syncLegacyCompatibilitySync(current);
         return current;
@@ -890,6 +912,7 @@ export class ExactReviewQueue {
           exactReviewTargetCapacity(this.env),
           exactReviewDispatchLeaseMs(this.env),
           exactReviewExecutionLeaseMs(this.env),
+          exactReviewPublicationDispatchLeaseMs(this.env),
         ),
         delivery_receipts: this.deliveryReceiptCountSync(),
         storage_schema_version: EXACT_REVIEW_QUEUE_STORAGE_SCHEMA_VERSION,
@@ -912,7 +935,11 @@ export class ExactReviewQueue {
       this.syncLegacyCompatibilitySync(this.readStateSync());
     });
     const snapshot = this.readStateSync();
-    const reclaimedSnapshot = reclaimExpiredExactReviewLeases(snapshot, startedAt);
+    const reclaimedSnapshot = reclaimExpiredExactReviewLeases(
+      snapshot,
+      startedAt,
+      exactReviewPublicationDispatchLeaseMs(this.env),
+    );
     const expiredSnapshot = expireExactReviewPublicationItems(snapshot, startedAt);
     const snapshotChanged = reclaimedSnapshot || expiredSnapshot;
     const capacity = exactReviewQueueCapacity(this.env);
@@ -943,7 +970,7 @@ export class ExactReviewQueue {
     // write so concurrent enqueue, claim, or complete requests cannot be lost.
     const now = Date.now();
     const state = this.readStateSync();
-    reclaimExpiredExactReviewLeases(state, now);
+    reclaimExpiredExactReviewLeases(state, now, exactReviewPublicationDispatchLeaseMs(this.env));
     expireExactReviewPublicationItems(state, now);
     const admitted = exactReviewQueueAdmittedItems(state, now, capacity, targetCapacity);
     if (!preflight.ok) {
@@ -985,10 +1012,7 @@ export class ExactReviewQueue {
       item.leaseExpiresAt =
         now +
         (item.decision.sourceAction === EXACT_REVIEW_ARTIFACT_PUBLISH_SOURCE_ACTION
-          ? Math.max(
-              exactReviewDispatchLeaseMs(this.env),
-              DEFAULT_EXACT_REVIEW_PUBLICATION_DISPATCH_LEASE_MS,
-            )
+          ? exactReviewPublicationDispatchLeaseMs(this.env)
           : exactReviewDispatchLeaseMs(this.env));
       item.claimedRunId = undefined;
       item.claimedRunAttempt = undefined;
@@ -1557,6 +1581,7 @@ export class ExactReviewQueue {
       now,
       exactReviewQueueCapacity(this.env),
       exactReviewTargetCapacity(this.env),
+      exactReviewPublicationDispatchLeaseMs(this.env),
     );
     if (next === null) {
       await this.storage.deleteAlarm();
@@ -1617,9 +1642,12 @@ export default {
     return json({ error: "not_found" }, 404);
   },
   async scheduled(_controller, env: DashboardEnv = {}, ctx?: DashboardContext) {
-    const recording = recordScheduledHealthSample(env);
-    if (ctx?.waitUntil) ctx.waitUntil(recording);
-    else await recording;
+    const maintenance = Promise.all([
+      recordScheduledHealthSample(env),
+      exactReviewQueueStatusSnapshot(env).catch(() => null),
+    ]);
+    if (ctx?.waitUntil) ctx.waitUntil(maintenance);
+    else await maintenance;
   },
 };
 
@@ -2859,35 +2887,74 @@ function clearExactReviewLease(item: ExactReviewQueueItem) {
   item.claimedAt = undefined;
 }
 
-function isLiveExactReviewLease(item: ExactReviewQueueItem, now: number) {
-  return Boolean(item.leaseId && item.leaseExpiresAt && item.leaseExpiresAt > now);
+function exactReviewEffectiveLeaseExpiresAt(
+  item: ExactReviewQueueItem,
+  publicationDispatchLeaseMs: number,
+) {
+  const leaseExpiresAt = Number(item.leaseExpiresAt || 0);
+  if (
+    !leaseExpiresAt ||
+    item.state !== "dispatching" ||
+    !exactReviewQueueIsPublication(item) ||
+    item.claimedRunId ||
+    !item.dispatchedAt
+  ) {
+    return leaseExpiresAt;
+  }
+  return Math.min(leaseExpiresAt, item.dispatchedAt + publicationDispatchLeaseMs);
 }
 
-function reclaimExpiredExactReviewLeases(state: ExactReviewQueueState, now: number) {
+function isLiveExactReviewLease(
+  item: ExactReviewQueueItem,
+  now: number,
+  publicationDispatchLeaseMs = DEFAULT_EXACT_REVIEW_PUBLICATION_DISPATCH_LEASE_MS,
+) {
+  return Boolean(
+    item.leaseId && exactReviewEffectiveLeaseExpiresAt(item, publicationDispatchLeaseMs) > now,
+  );
+}
+
+function reclaimExpiredExactReviewLeases(
+  state: ExactReviewQueueState,
+  now: number,
+  publicationDispatchLeaseMs = DEFAULT_EXACT_REVIEW_PUBLICATION_DISPATCH_LEASE_MS,
+) {
   let changed = false;
   for (const [key, item] of Object.entries(state.items)) {
-    if (
-      (item.state === "dispatching" || item.state === "leased") &&
-      !isLiveExactReviewLease(item, now)
-    ) {
-      const oneShotRecovery =
-        (item.leaseDecision || item.decision).sourceAction ===
-        FAILED_REVIEW_SHARD_RECOVERY_SOURCE_ACTION;
-      const hasNewerRevision = item.revision > Number(item.leaseRevision || 0);
-      if (oneShotRecovery && !hasNewerRevision) {
-        delete state.items[key];
-        changed = true;
-        continue;
-      }
-      clearExactReviewLease(item);
-      item.state = "pending";
-      item.nextAttemptAt = now;
-      if (hasNewerRevision) item.attempts = 0;
-      item.updatedAt = now;
+    if (reclaimExpiredExactReviewLease(state, key, item, now, publicationDispatchLeaseMs)) {
       changed = true;
     }
   }
   return changed;
+}
+
+function reclaimExpiredExactReviewLease(
+  state: ExactReviewQueueState,
+  key: string,
+  item: ExactReviewQueueItem,
+  now: number,
+  publicationDispatchLeaseMs: number,
+) {
+  if (
+    (item.state !== "dispatching" && item.state !== "leased") ||
+    isLiveExactReviewLease(item, now, publicationDispatchLeaseMs)
+  ) {
+    return false;
+  }
+  const oneShotRecovery =
+    (item.leaseDecision || item.decision).sourceAction ===
+    FAILED_REVIEW_SHARD_RECOVERY_SOURCE_ACTION;
+  const hasNewerRevision = item.revision > Number(item.leaseRevision || 0);
+  if (oneShotRecovery && !hasNewerRevision) {
+    delete state.items[key];
+    return true;
+  }
+  clearExactReviewLease(item);
+  item.state = "pending";
+  item.nextAttemptAt = now;
+  if (hasNewerRevision) item.attempts = 0;
+  item.updatedAt = now;
+  return true;
 }
 
 function expireExactReviewPublicationItems(state: ExactReviewQueueState, now: number) {
@@ -3011,6 +3078,7 @@ function exactReviewQueueStats(
   targetCapacity = Number.POSITIVE_INFINITY,
   dispatchLeaseMs = DEFAULT_EXACT_REVIEW_DISPATCH_LEASE_MS,
   executionLeaseMs = DEFAULT_EXACT_REVIEW_EXECUTION_LEASE_MS,
+  publicationDispatchLeaseMs = DEFAULT_EXACT_REVIEW_PUBLICATION_DISPATCH_LEASE_MS,
 ) {
   const items = Object.values(state.items);
   const handoffHealth = summarizeExactReviewHandoff({
@@ -3068,7 +3136,13 @@ function exactReviewQueueStats(
         right.dispatching + right.leased - (left.dispatching + left.leased) ||
         left.target_repo.localeCompare(right.target_repo),
     );
-  const nextWakeAt = exactReviewQueueNextWakeAt(state, now, capacity, targetCapacity);
+  const nextWakeAt = exactReviewQueueNextWakeAt(
+    state,
+    now,
+    capacity,
+    targetCapacity,
+    publicationDispatchLeaseMs,
+  );
   return {
     pending: handoffHealth.phases.pending.count,
     dispatching: handoffHealth.phases.dispatching.count,
@@ -3099,6 +3173,7 @@ function exactReviewQueueNextWakeAt(
   now: number,
   capacity = Number.POSITIVE_INFINITY,
   targetCapacity = Number.POSITIVE_INFINITY,
+  publicationDispatchLeaseMs = DEFAULT_EXACT_REVIEW_PUBLICATION_DISPATCH_LEASE_MS,
 ) {
   const items = Object.values(state.items);
   if (!items.length) return null;
@@ -3109,7 +3184,13 @@ function exactReviewQueueNextWakeAt(
   const activeItems = items.filter(
     (item) => item.state === "dispatching" || item.state === "leased",
   );
-  if (activeItems.some((item) => !item.leaseExpiresAt || item.leaseExpiresAt <= now)) {
+  if (
+    activeItems.some(
+      (item) =>
+        !item.leaseExpiresAt ||
+        exactReviewEffectiveLeaseExpiresAt(item, publicationDispatchLeaseMs) <= now,
+    )
+  ) {
     return now + 1_000;
   }
   const activeReviews = activeItems.filter((item) => !exactReviewQueueIsPublication(item));
@@ -3118,7 +3199,7 @@ function exactReviewQueueNextWakeAt(
     .map((item) => item.leaseExpiresAt)
     .filter((value): value is number => Boolean(value && value > now));
   const activePublisherWakeAt = activePublishers
-    .map((item) => item.leaseExpiresAt)
+    .map((item) => exactReviewEffectiveLeaseExpiresAt(item, publicationDispatchLeaseMs))
     .filter((value): value is number => Boolean(value && value > now));
   const activeTargetWakeAt = new Map<string, number>();
   const activeTargetCounts = new Map<string, number>();
@@ -3159,7 +3240,8 @@ function exactReviewQueueNextWakeAt(
         ),
       ];
     }
-    return item.leaseExpiresAt ? [item.leaseExpiresAt] : [];
+    const leaseExpiresAt = exactReviewEffectiveLeaseExpiresAt(item, publicationDispatchLeaseMs);
+    return leaseExpiresAt ? [leaseExpiresAt] : [];
   });
   if (!times.length) return now + DEFAULT_EXACT_REVIEW_RETRY_MS;
   return Math.max(now + 1_000, Math.min(...times));
@@ -3192,6 +3274,13 @@ function exactReviewDispatchLeaseMs(env) {
   return Math.max(
     60_000,
     numberFrom(env.EXACT_REVIEW_DISPATCH_LEASE_MS, DEFAULT_EXACT_REVIEW_DISPATCH_LEASE_MS),
+  );
+}
+
+function exactReviewPublicationDispatchLeaseMs(env) {
+  return Math.max(
+    exactReviewDispatchLeaseMs(env),
+    DEFAULT_EXACT_REVIEW_PUBLICATION_DISPATCH_LEASE_MS,
   );
 }
 

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -2751,6 +2751,7 @@ test("exact-review queue keeps publication artifacts durable outside review capa
         {
           createdAt: number;
           decision: Record<string, unknown>;
+          dispatchedAt?: number;
           leaseDecision?: Record<string, unknown>;
           leaseExpiresAt?: number;
           leaseId?: string;
@@ -2821,7 +2822,8 @@ test("exact-review queue keeps publication artifacts durable outside review capa
     assert.equal(afterExpiry.items["openclaw/gogcli#803@publish:102:1"], undefined);
     const reservedPublisher = afterExpiry.items["openclaw/gogcli#801@publish:100:1"];
     assert.equal(reservedPublisher.state, "dispatching");
-    assert.ok((reservedPublisher.leaseExpiresAt ?? 0) - Date.now() > 6 * 24 * 60 * 60_000);
+    assert.ok((reservedPublisher.leaseExpiresAt ?? 0) - Date.now() > 14 * 60_000);
+    assert.ok((reservedPublisher.leaseExpiresAt ?? 0) - Date.now() <= 15 * 60_000);
     const publicationPayload = dispatched.find(
       (payload) =>
         (payload.client_payload as Record<string, unknown>).source_action ===
@@ -2839,6 +2841,97 @@ test("exact-review queue keeps publication artifacts durable outside review capa
         >
       ).producerDecision,
     );
+
+    const firstPublicationLease = {
+      leaseId: reservedPublisher.leaseId,
+      leaseRevision: reservedPublisher.leaseRevision,
+    };
+    reservedPublisher.dispatchedAt = Date.now() - 16 * 60_000;
+    reservedPublisher.leaseExpiresAt = Date.now() + 7 * 24 * 60 * 60_000;
+    await storage.put("exact-review-queue", afterExpiry);
+
+    let queueMaintenance: Promise<unknown> | undefined;
+    await worker.scheduled(
+      {},
+      { EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue) },
+      { waitUntil: (promise) => (queueMaintenance = promise) },
+    );
+    await queueMaintenance;
+    const afterScheduledMaintenance = (await storage.get("exact-review-queue")) as typeof state;
+    const scheduledPublisher = afterScheduledMaintenance.items["openclaw/gogcli#801@publish:100:1"];
+    assert.equal(scheduledPublisher.state, "pending");
+    assert.equal(scheduledPublisher.leaseId, undefined);
+    assert.ok(((await storage.getAlarm()) ?? Number.POSITIVE_INFINITY) <= Date.now() + 1_000);
+
+    await queue.alarm();
+    const afterScheduledRedispatch = (await storage.get("exact-review-queue")) as typeof state;
+    const scheduledRedispatch = afterScheduledRedispatch.items["openclaw/gogcli#801@publish:100:1"];
+    assert.equal(scheduledRedispatch.state, "dispatching");
+    assert.notEqual(scheduledRedispatch.leaseId, firstPublicationLease.leaseId);
+    assert.equal(
+      dispatched.filter(
+        (payload) =>
+          (payload.client_payload as Record<string, unknown>).source_action ===
+          "exact_review_artifact_publish",
+      ).length,
+      2,
+    );
+
+    const scheduledPublicationLease = {
+      leaseId: scheduledRedispatch.leaseId,
+      leaseRevision: scheduledRedispatch.leaseRevision,
+    };
+    scheduledRedispatch.dispatchedAt = Date.now() - 16 * 60_000;
+    scheduledRedispatch.leaseExpiresAt = Date.now() + 7 * 24 * 60 * 60_000;
+    await storage.put("exact-review-queue", afterScheduledRedispatch);
+
+    const expiredLegacyClaim = await queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/claim", {
+        method: "POST",
+        body: JSON.stringify({
+          lease_id: scheduledPublicationLease.leaseId,
+          item_key: "openclaw/gogcli#801@publish:100:1",
+          lease_revision: scheduledPublicationLease.leaseRevision,
+          run_id: "999998",
+          run_attempt: 1,
+        }),
+      }),
+    );
+    assert.equal(expiredLegacyClaim.status, 409);
+    assert.deepEqual(await expiredLegacyClaim.json(), { error: "lease_not_active" });
+    const afterExpiredClaim = (await storage.get("exact-review-queue")) as typeof state;
+    const reclaimedPublisher = afterExpiredClaim.items["openclaw/gogcli#801@publish:100:1"];
+    assert.equal(reclaimedPublisher.state, "pending");
+    assert.equal(reclaimedPublisher.leaseId, undefined);
+    assert.ok(((await storage.getAlarm()) ?? Number.POSITIVE_INFINITY) <= Date.now() + 1_000);
+
+    await queue.alarm();
+
+    const publicationDispatches = dispatched.filter(
+      (payload) =>
+        (payload.client_payload as Record<string, unknown>).source_action ===
+        "exact_review_artifact_publish",
+    );
+    assert.equal(publicationDispatches.length, 3);
+    const afterRedispatch = (await storage.get("exact-review-queue")) as typeof state;
+    const redispatchedPublisher = afterRedispatch.items["openclaw/gogcli#801@publish:100:1"];
+    assert.equal(redispatchedPublisher.state, "dispatching");
+    assert.notEqual(redispatchedPublisher.leaseId, scheduledPublicationLease.leaseId);
+    assert.ok((redispatchedPublisher.leaseExpiresAt ?? 0) - Date.now() > 14 * 60_000);
+    const staleClaim = await queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/claim", {
+        method: "POST",
+        body: JSON.stringify({
+          lease_id: firstPublicationLease.leaseId,
+          item_key: "openclaw/gogcli#801@publish:100:1",
+          lease_revision: firstPublicationLease.leaseRevision,
+          run_id: "999999",
+          run_attempt: 1,
+        }),
+      }),
+    );
+    assert.equal(staleClaim.status, 409);
+    assert.deepEqual(await staleClaim.json(), { error: "lease_not_active" });
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/test/exact-review-health.test.ts
+++ b/test/exact-review-health.test.ts
@@ -125,6 +125,25 @@ test("exact-review handoff health derives legacy dispatch age from its active le
   assert.equal(health.phases.dispatching.oldest_age_seconds, 20);
 });
 
+test("exact-review handoff health uses dispatch time when a longer lease has a future derived start", () => {
+  const health = summarize({
+    items: [
+      {
+        state: "dispatching",
+        createdAt: NOW - 10 * 60_000,
+        updatedAt: NOW - 6 * 60_000,
+        dispatchedAt: NOW - 6 * 60_000,
+        leaseExpiresAt: NOW + 15 * 60_000,
+      },
+    ],
+  });
+
+  assert.equal(health.status, "stalled");
+  assert.equal(health.reason, "claim_stalled");
+  assert.equal(health.phases.dispatching.oldest_at, "2026-07-13T01:54:00.000Z");
+  assert.equal(health.phases.dispatching.oldest_age_seconds, 360);
+});
+
 test("exact-review handoff health ignores stale rollback telemetry and unknown legacy ages", () => {
   const rolledBack = summarize({
     items: [

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -323,7 +323,7 @@ test("scheduled review shards receive the compiler-backed runtime artifact", () 
   assert.doesNotMatch(reviewJob, /npm pack "@typescript/);
 });
 
-test("exact event review hands immutable artifacts to one state publisher", () => {
+test("exact event review hands immutable artifacts to one dedicated publisher", () => {
   type Step = {
     "continue-on-error"?: boolean;
     name?: string;
@@ -401,11 +401,12 @@ test("exact event review hands immutable artifacts to one state publisher", () =
     step(publisher, "Claim durable exact review publication").run ?? "",
     /internal\/exact-review\/claim/,
   );
-  assert.equal(publisher.concurrency?.group, "clawsweeper-state-publisher");
+  assert.equal(publisher.concurrency?.group, "clawsweeper-exact-review-publisher");
   assert.equal(publisher.concurrency?.["cancel-in-progress"], false);
   assert.equal(publisher.concurrency?.queue, "max");
   assert.equal(publisher.permissions?.actions, "write");
   assert.equal(batchPublisher.concurrency?.group, "clawsweeper-state-publisher");
+  assert.notEqual(publisher.concurrency?.group, batchPublisher.concurrency?.group);
   const publicationContext = step(publisher, "Claim durable exact review publication");
   assert.match(
     publicationContext.run ?? "",


### PR DESCRIPTION
## Summary

- give exact-review artifact publication its own serial GitHub Actions concurrency lane instead of placing it behind every bulk state publisher
- recover both new and already-persisted unclaimed publication dispatches after 15 minutes, with stale lease tuples rejected safely
- use the existing five-minute dashboard Worker cron as a guaranteed post-deploy queue heartbeat, and correct the false future/zero-age dispatch telemetry

This fixes the confirmed path where a review completed successfully but its final ClawSweeper comment and labels could not be published. It deliberately does **not** bulk-rewrite every pending review row; the separate stale-pending recovery/capacity follow-up remains necessary if the producer backlog does not drain normally.

## Incident evidence

At `2026-07-15T18:00:34Z`, the live queue API reported:

- `pending=1961`, `dispatching=1`, `leased=15`
- oldest pending item `2026-07-15T11:01:02Z`
- 48 of 64 review slots shown as available
- a false `oldest_dispatching_at=2026-07-22T13:10:22Z` with age zero
- `next_wake_at=2026-07-15T20:05:52Z`

The false future timestamp came from deriving the dispatch start by subtracting the normal six-minute lease from the seven-day publication lease introduced with #592. It made a multi-hour stuck handoff look healthy, but it was telemetry fallout rather than the cause.

The publication failure itself is directly visible in Actions:

- [run 29418496158](https://github.com/openclaw/clawsweeper/actions/runs/29418496158), `Review event item openclaw/openclaw#107676@publish:29409874087:1`, was created at `13:16:24Z` and was still pending at `18:00Z`
- its only relevant job, [87362614333](https://github.com/openclaw/clawsweeper/actions/runs/29418496158/job/87362614333), had no runner and had never completed
- an earlier exact publisher, [job 87336341784](https://github.com/openclaw/clawsweeper/actions/runs/29410554983/job/87336341784), was created at `11:07:50Z` but did not start until `13:14:06Z`
- a representative bulk publisher, [job 87350685065](https://github.com/openclaw/clawsweeper/actions/runs/29414724394/job/87350685065), was created at `12:22:22Z` and did not start until `16:10:32Z`

The live GitHub concurrency endpoint initially showed 19 members in `clawsweeper-state-publisher`, with the exact publisher last behind 18 generic publishers. At `18:00Z` it still showed three members in order: one running generic publisher, one pending generic publisher, then exact job `87362614333`. That proves the final publisher was queued behind bulk state work, not waiting for Codex or a runner after a claim. The current endpoint is [here](https://api.github.com/repos/openclaw/clawsweeper/actions/concurrency_groups/clawsweeper-state-publisher?ahead_of_job=87362614333).

Representative producer runs succeeded:

- [openclaw/openclaw#107785 producer run 29411365434](https://github.com/openclaw/clawsweeper/actions/runs/29411365434), created `11:21:51Z`, completed successfully
- [openclaw/openclaw#107787 producer run 29412181317](https://github.com/openclaw/clawsweeper/actions/runs/29412181317), created `11:35:41Z`, completed successfully

Those runs reached real Codex completion, artifact upload, and durable publication enqueue. This rules out a global Codex/GPT, Cloudflare intake, token, or GitHub permission outage as the cause of the missing final comments/labels. It does not claim that every individual review run was healthy.

The issue timestamps are also not a reliable merge boundary: [#107785](https://github.com/openclaw/openclaw/issues/107785) received its recorded labels at `10:41Z`, and [#107787](https://github.com/openclaw/openclaw/issues/107787) has a durable review comment at `10:46Z`, before the later producer runs above. The Actions concurrency evidence provides the actual causal boundary.

## Causal timeline

- `00:11:35Z`: Vincent's [#586](https://github.com/openclaw/clawsweeper/pull/586) revert merged. It predates the publisher regression and is not on the causal path.
- `10:38:45Z`: Peter's [#592](https://github.com/openclaw/clawsweeper/pull/592) merged as `30502fdf4e8acdcbf022302278af0e78a307eb65`. It placed exact `event-review-publish` and generic `publish` jobs in `clawsweeper-state-publisher`, both serial with `queue: max`, and extended unclaimed publication leases to seven days to tolerate that queue.
- `10:55:39Z`: [#593](https://github.com/openclaw/clawsweeper/pull/593) merged. It forwards exact-review bundle CLI commands; it does not separate or prioritize publishers.
- `11:07:50Z`: exact publisher job `87336341784` entered the shared group and waited over two hours.
- `11:21Z` / `11:35Z`: representative #107785/#107787 producer runs started and later succeeded.
- `12:22:22Z`: representative generic publisher job `87350685065` entered the same group and waited nearly four hours.
- `13:16:24Z`: run `29418496158` entered for an already-produced exact artifact and remained pending with no runner.
- `13:17:47Z`: [#596](https://github.com/openclaw/clawsweeper/pull/596) merged. Its Landlock fallback and exact-claim conflict handling are independently valid, but it does not change the shared publisher group.
- `15:44:33Z`: [#601](https://github.com/openclaw/clawsweeper/pull/601) merged as `68f83c25fc564ebfb76ac75ed3d64a7cb1c07bb8`. It stops dispatcher pauses from repeatedly deferring the whole pending backlog. It came after the publisher starvation and is not its cause.
- `16:32:18Z`: live queue sample: `pending=1717`, `dispatching=1`, `leased=19`, with the same future dispatch timestamp.
- `18:00:34Z`: live queue sample: `pending=1961`, `dispatching=1`, `leased=15`; exact run `29418496158` was still last in the shared publisher group.

## Why #601 is retained

#601 was evaluated specifically because it was not the publication root cause. Reverting it would restore a separate confirmed defect: a paused dispatcher rewriting retained pending rows' `nextAttemptAt` on every pass. The focused regression `exact-review queue defers retained backlog until a paused dispatcher retry` passes on this branch. This PR therefore keeps #601 and documents the distinction rather than combining a known regression into the incident repair.

Other nearby work is also not causal:

- [#589](https://github.com/openclaw/clawsweeper/pull/589) and [#591](https://github.com/openclaw/clawsweeper/pull/591) are open and unmerged
- [#581](https://github.com/openclaw/clawsweeper/issues/581) explicitly reports inaccurate re-review acknowledgement wording, not queue latency; it is independently valid but separate from this outage

## Implementation

1. Exact `event-review-publish` jobs use `clawsweeper-exact-review-publisher`; bulk `publish` jobs remain in `clawsweeper-state-publisher`. Both lanes stay serial and non-cancelling.
2. Unclaimed publication handoffs use an effective 15-minute lease (or a longer configured ordinary dispatch lease). Claimed executions retain the existing execution lease and are not shortened.
3. Existing seven-day rows are capped using their persisted `dispatchedAt`. Reclamation, claim validation, queue wake scheduling, and stats all use the same effective expiry.
4. If an old queued job arrives first, its expired lease is persisted back to pending, an immediate alarm is scheduled, and the stale claim receives `409 lease_not_active`.
5. If no request arrives, the normal five-minute dashboard Worker cron calls the queue stats heartbeat, reclaims the old row, and re-arms the alarm. The new dispatch uses the dedicated lane.
6. Handoff health no longer accepts a derived start time in the future, so a long legacy lease falls back to the real `dispatchedAt` and reports its actual age.

## Automatic recovery and backlog scope

After merge, the normal dashboard push workflow deploys the Worker because this PR changes `dashboard/**`. Within one five-minute cron interval, an old unclaimed seven-day publication row is re-admitted and redispatched. New exact publisher jobs use the dedicated lane immediately. A late job from the old shared lane cannot publish twice because its lease tuple has been replaced.

This should restore final comments and labels for completed reviews without a manual Actions dispatch or gate change. It will not immediately reprocess all `pending=1961` producer rows. Those remain governed by normal exact-review capacity plus #601; bounded stale-pending recovery and the observed capacity under-utilization should be diagnosed separately before any bulk mutation.

## Validation

Windows focused proof on the final branch:

```text
corepack pnpm build:all
node --test test/dashboard-worker.test.ts test/exact-review-health.test.ts
# 117 passed, 0 failed
node --test --test-name-pattern "exact event review hands immutable artifacts to one dedicated publisher" test/sweep-workflow.test.ts
# 1 passed, 0 failed
corepack pnpm lint
corepack pnpm exec oxfmt --check <six touched files>
git diff --check origin/main...HEAD
```

The queue regression recreates both live rollout paths: a persisted publication whose stored lease is seven days in the future but whose `dispatchedAt` is 16 minutes old is recovered by the scheduled heartbeat; a second expired legacy dispatch is recovered when its stale job claims first. Both are redispatched with new tuples, and stale claims return 409.

Hosted-Linux proof used Crabbox `local-container`, image `mcr.microsoft.com/playwright:v1.60.0-noble`, lease `cbx_02442d834d3d`:

- build, lint, and six-file format check passed
- queue/dashboard health tests: 117 passed
- dedicated publisher workflow assertion: 1 passed
- continuous `reconcile-records` state-race tests: 3 passed
- pinned actionlint v1.7.12 passed for `sweep.yml` (archive SHA-256 `8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8`)

Five unrelated full `sweep-workflow` Bash-fixture tests cannot run natively on this Windows host because its default `docker-desktop` WSL distro has no `/bin/bash`; the touched workflow assertion and state-race proof passed in the Linux container. No platform policy or production shell surface was changed.

## Codex review closeout

- `codex review --uncommitted` initially found the valid rollout gap that old seven-day leases were not migrated; fixed and proved
- the next pass found that a stale claim returned 409 without persisting/scheduling recovery; fixed and proved
- the next pass found that deployment alone did not instantiate the Durable Object or re-arm its old alarm; the five-minute scheduled heartbeat was added and proved
- final `codex review --uncommitted`: clean, no actionable findings
- final `codex review --base origin/main`: clean, no actionable findings; confirmed the dedicated lane and recovery do not affect claimed executions

## Risks and rollout

- Exact and generic state publishers may now overlap, at most one in each lane. The existing tuple-aware `reconcile-records` writer handles disjoint state races; all three continuous race tests passed on Linux.
- A GitHub delay longer than 15 minutes can produce another dispatch attempt, but only the current lease tuple can claim and publish.
- This touches `.github/workflows/sweep.yml`; OAuth tokens without workflow scope may not be able to update the branch. The maintainer branch push succeeded, and CI/actionlint still need to remain green.
- No gates, direct workflow dispatches, Actions reruns, or manual state mutations are part of rollout.
- No changelog change; release-note context is contained here.

## Links

- Live queue API: https://clawsweeper.openclaw.ai/api/exact-review-queue
- Root regression: https://github.com/openclaw/clawsweeper/pull/592
- Stuck exact publisher: https://github.com/openclaw/clawsweeper/actions/runs/29418496158
- GitHub concurrency behavior: https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency
- Related, retained backlog fix: https://github.com/openclaw/clawsweeper/pull/601
- Adjacent repairs reviewed: https://github.com/openclaw/clawsweeper/pull/586, https://github.com/openclaw/clawsweeper/pull/593, https://github.com/openclaw/clawsweeper/pull/596
