### PR TITLE
fix: restore per-target review publishing

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2684,7 +2684,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     concurrency:
-      group: clawsweeper-state-publisher
+      group: clawsweeper-target-review-publish-${{ needs.plan.outputs.target_repo }}
       cancel-in-progress: false
       queue: max
     steps:

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -405,7 +405,10 @@ test("exact event review hands immutable artifacts to one dedicated publisher", 
   assert.equal(publisher.concurrency?.["cancel-in-progress"], false);
   assert.equal(publisher.concurrency?.queue, "max");
   assert.equal(publisher.permissions?.actions, "write");
-  assert.equal(batchPublisher.concurrency?.group, "clawsweeper-state-publisher");
+  assert.equal(
+    batchPublisher.concurrency?.group,
+    "clawsweeper-target-review-publish-${{ needs.plan.outputs.target_repo }}",
+  );
   assert.notEqual(publisher.concurrency?.group, batchPublisher.concurrency?.group);
   const publicationContext = step(publisher, "Claim durable exact review publication");
   assert.match(
@@ -710,7 +713,10 @@ test("publish workflow dispatches immediate apply through the isolated lane", ()
   assert.match(dispatchStep, /gh workflow run sweep\.yml/);
   assert.match(dispatchStep, /-f apply_existing=true/);
   assert.match(dispatchStep, /-f apply_item_numbers="\$item_numbers"/);
-  assert.match(publishJob, /group: clawsweeper-state-publisher/);
+  assert.match(
+    publishJob,
+    /group: clawsweeper-target-review-publish-\$\{\{ needs\.plan\.outputs\.target_repo \}\}/,
+  );
   assert.match(publishJob, /cancel-in-progress: false/);
   assert.match(publishJob, /queue: max/);
 });


### PR DESCRIPTION
## Summary

- restore broad review artifact publication to per-target concurrency
- retain the dedicated exact-review publisher lane
- update workflow assertions for the restored isolation boundary

## Why

PR #592 moved broad target publishers from per-repository groups into one global `clawsweeper-state-publisher` group. Target fanout can enqueue work faster than that single publisher drains it, leaving otherwise-complete reviews pending for hours and causing publisher admission failures.

This restores the prior per-target group while preserving the exact-review serialization introduced for immutable bundle publication.

## Validation

- `node --test test/sweep-workflow.test.ts` (64 passed)
- `pnpm run format:check`
- `git diff --check`
- `pnpm run check` reached the unit phase after build and lint passed; the local macOS run then hit four unrelated environment/baseline failures, including three tests requiring the unavailable GNU `timeout` command and one failed-review dispatch fixture that did not materialize its counter file.