### PR TITLE
Add Exact Review backlog trends

### DIFF
--- a/dashboard/operational-health.ts
+++ b/dashboard/operational-health.ts
@@ -35,6 +35,13 @@ export type HealthHistorySample = {
   running_over_150m: number;
   oldest_running_minutes: number;
   collection_ok: boolean;
+  exact_review?: ExactReviewHistorySample;
+};
+
+export type ExactReviewHistorySample = {
+  collection_ok: boolean;
+  review?: { pending: number };
+  publication?: { pending: number };
 };
 
 export function summarizeOperationalHealth(
@@ -119,6 +126,7 @@ export function normalizeHealthHistorySample(value: unknown): HealthHistorySampl
     countFields.map((field) => [field, nonNegativeInteger(sample[field])]),
   ) as Record<(typeof countFields)[number], number | null>;
   if (Object.values(counts).some((count) => count === null)) return null;
+  const exactReview = normalizeExactReviewHistorySample(sample.exact_review);
   return {
     at,
     status: rawStatus as HealthHistorySample["status"],
@@ -129,6 +137,35 @@ export function normalizeHealthHistorySample(value: unknown): HealthHistorySampl
     running_over_150m: counts.running_over_150m!,
     oldest_running_minutes: counts.oldest_running_minutes!,
     collection_ok: sample.collection_ok,
+    ...(exactReview ? { exact_review: exactReview } : {}),
+  };
+}
+
+export function exactReviewHistorySample(value: unknown): ExactReviewHistorySample {
+  const lanes = objectValue(objectValue(value).lanes);
+  const reviewPending = nonNegativeInteger(objectValue(lanes.review).pending);
+  const publicationPending = nonNegativeInteger(objectValue(lanes.publication).pending);
+  if (reviewPending === null || publicationPending === null) return { collection_ok: false };
+  return {
+    collection_ok: true,
+    review: { pending: reviewPending },
+    publication: { pending: publicationPending },
+  };
+}
+
+function normalizeExactReviewHistorySample(value: unknown): ExactReviewHistorySample | null {
+  if (value === undefined) return null;
+  if (!value || typeof value !== "object") return null;
+  const sample = value as Record<string, unknown>;
+  if (typeof sample.collection_ok !== "boolean") return null;
+  if (!sample.collection_ok) return { collection_ok: false };
+  const reviewPending = nonNegativeInteger(objectValue(sample.review).pending);
+  const publicationPending = nonNegativeInteger(objectValue(sample.publication).pending);
+  if (reviewPending === null || publicationPending === null) return null;
+  return {
+    collection_ok: true,
+    review: { pending: reviewPending },
+    publication: { pending: publicationPending },
   };
 }
 
@@ -165,6 +202,10 @@ function ageMs(value: string | undefined, now: number) {
 function nonNegativeInteger(value: unknown) {
   const number = Number(value);
   return Number.isFinite(number) ? Math.max(0, Math.round(number)) : null;
+}
+
+function objectValue(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
 }
 
 function oldestMinutes(ages: number[]) {

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -8,6 +8,7 @@ import { bayHtml } from "./bay-page.ts";
 import { summarizeExactReviewHandoff } from "./exact-review-health.ts";
 import {
   HEALTH_HISTORY_RETENTION_DAYS,
+  exactReviewHistorySample,
   healthHistorySample,
   mergeHealthHistorySample,
   normalizeHealthHistorySample,
@@ -1653,10 +1654,7 @@ export default {
     return json({ error: "not_found" }, 404);
   },
   async scheduled(_controller, env: DashboardEnv = {}, ctx?: DashboardContext) {
-    const maintenance = Promise.all([
-      recordScheduledHealthSample(env),
-      exactReviewQueueStatusSnapshot(env).catch(() => null),
-    ]);
+    const maintenance = recordScheduledHealthSample(env);
     if (ctx?.waitUntil) ctx.waitUntil(maintenance);
     else await maintenance;
   },
@@ -1679,8 +1677,14 @@ async function statusJson(request, env, ctx) {
 }
 
 async function healthHistoryJson(request: Request, env: DashboardEnv) {
-  const range = new URL(request.url).searchParams.get("range") === "7d" ? "7d" : "24h";
-  const rangeMs = range === "7d" ? 7 * 24 * 60 * 60 * 1000 : 24 * 60 * 60 * 1000;
+  const requestedRange = new URL(request.url).searchParams.get("range");
+  const range = requestedRange === "6h" || requestedRange === "7d" ? requestedRange : "24h";
+  const rangeMs =
+    range === "6h"
+      ? 6 * 60 * 60 * 1000
+      : range === "7d"
+        ? 7 * 24 * 60 * 60 * 1000
+        : 24 * 60 * 60 * 1000;
   const now = Date.now();
   const groups = await Promise.all(
     healthHistoryDates(now - rangeMs, now).map(async (day) => {
@@ -1725,9 +1729,18 @@ function healthHistoryDates(fromMs: number, toMs: number) {
 }
 
 async function recordScheduledHealthSample(env) {
-  if (!env.STATUS_STORE) return;
-  const health = await collectOperationalHealth(env);
-  await appendHealthHistorySample(env, healthHistorySample(health));
+  const queueSnapshot = exactReviewQueueStatusSnapshot(env).catch(() => null);
+  if (!env.STATUS_STORE) {
+    await queueSnapshot;
+    return;
+  }
+  // The queue snapshot was already part of scheduled maintenance. Folding it
+  // into the same sample preserves one queue read per tick and one time slot.
+  const [health, queue] = await Promise.all([collectOperationalHealth(env), queueSnapshot]);
+  await appendHealthHistorySample(env, {
+    ...healthHistorySample(health),
+    exact_review: exactReviewHistorySample(queue),
+  });
 }
 
 async function collectOperationalHealth(env) {
@@ -9026,7 +9039,7 @@ h2::before { content: ""; flex: 0 0 auto; width: 14px; height: 2px; border-radiu
 .muted { color: var(--muted); }
 .grid {
   display: grid;
-  grid-template-columns: repeat(6, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   margin-top: 30px;
   border-top: 1px solid var(--line);
   border-bottom: 1px solid var(--line);
@@ -9038,9 +9051,8 @@ h2::before { content: ""; flex: 0 0 auto; width: 14px; height: 2px; border-radiu
 .metric > div.muted { margin-top: 4px; font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .band { width: 54px; height: 2px; margin-top: 12px; background: var(--track); border-radius: 999px; overflow: hidden; }
 .band > i { display: block; height: 100%; border-radius: 999px; background: var(--claw); width: 0; transition: width 0.6s ease; }
-.health-trends { margin-top: 30px; }
-.health-trends-head { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
-.health-trends-head h2 { margin: 0; }
+.exact-review-head { display: flex; align-items: center; justify-content: space-between; gap: 16px; margin-top: 22px; }
+.exact-review-head .overview-section-title { margin: 0; }
 .trend-ranges { display: flex; gap: 6px; }
 .trend-range {
   padding: 5px 9px;
@@ -9053,43 +9065,24 @@ h2::before { content: ""; flex: 0 0 auto; width: 14px; height: 2px; border-radiu
   cursor: pointer;
 }
 .trend-range.active { color: var(--text); border-color: var(--claw); }
-.health-trend-summary { margin-top: 8px; color: var(--muted); font-size: 12px; }
-.health-signal-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; margin-top: 14px; }
-.health-signal { min-width: 0; padding: 13px 14px; border: 1px solid var(--line); border-radius: 10px; background: var(--panel); }
-.health-signal-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
-.health-signal-label { color: var(--muted); font-size: 10px; font-weight: 650; letter-spacing: 0.1em; text-transform: uppercase; }
-.health-signal-value { font-size: 13px; font-weight: 650; }
-.health-signal-value.ok { color: var(--green); }
-.health-signal-value.attention { color: var(--amber); }
-.health-signal-value.stalled { color: var(--red); }
-.health-signal-value.unknown { color: var(--muted); }
-.health-signal-detail { margin-top: 6px; color: var(--muted); font-size: 11px; line-height: 1.45; }
-.health-trend-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 18px; margin-top: 14px; }
-.health-trend-panel { min-width: 0; padding: 14px; border: 1px solid var(--line); border-radius: 10px; background: var(--panel); }
-.health-trend-title { display: flex; justify-content: space-between; gap: 12px; margin-bottom: 8px; }
-.health-trend-title strong { font-size: 12px; }
-.health-trend-title span { color: var(--muted); font-size: 11px; }
-.trend-legend { display: flex; flex-wrap: wrap; gap: 10px; min-height: 16px; margin-bottom: 4px; }
-.trend-legend-item { display: flex; align-items: center; gap: 5px; color: var(--muted); font-size: 10px; }
-.trend-swatch { width: 12px; height: 2px; border-radius: 999px; }
-.trend-swatch.trend-total { background: var(--muted); }
-.trend-swatch.trend-warning { background: var(--amber); }
-.trend-swatch.trend-danger { background: var(--red); }
-.health-trend-svg { display: block; width: 100%; height: 170px; overflow: visible; }
+.execution-alert { margin-top: 24px; border: 1px solid color-mix(in srgb, var(--amber) 48%, var(--line)); border-radius: 10px; background: color-mix(in srgb, var(--amber) 7%, var(--panel)); }
+.execution-alert summary { display: flex; justify-content: space-between; gap: 16px; padding: 13px 15px; cursor: pointer; list-style: none; }
+.execution-alert summary::-webkit-details-marker { display: none; }
+.execution-alert-title { display: grid; gap: 4px; }
+.execution-alert-title strong { font-size: 13px; }
+.execution-alert-title span, .execution-alert-toggle, .execution-alert-body { color: var(--muted); font-size: 11px; }
+.execution-alert-body { padding: 0 15px 13px; }
+.exact-trend { margin: 14px 0 16px; }
+.exact-trend-status { font-size: 12px; font-weight: 650; }
+.exact-trend-status.growing { color: var(--amber); }
+.exact-trend-status.draining { color: var(--green); }
+.exact-trend-status.stable, .exact-trend-status.collecting { color: var(--muted); }
+.exact-trend-svg { display: block; width: 100%; height: 150px; margin-top: 6px; overflow: visible; }
 .trend-grid-line { stroke: var(--line-soft); stroke-width: 1; }
 .trend-axis-label { fill: var(--muted); font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; font-size: 10px; }
-.trend-threshold { stroke: var(--red); stroke-width: 1; stroke-dasharray: 4 4; opacity: 0.55; }
-.trend-threshold.warning { stroke: var(--amber); }
-.trend-threshold-label { fill: var(--red); font-size: 9px; font-weight: 650; }
-.trend-threshold-label.warning { fill: var(--amber); }
-.trend-total { fill: none; stroke: var(--muted); stroke-width: 2; vector-effect: non-scaling-stroke; }
-.trend-warning { fill: none; stroke: var(--amber); stroke-width: 2.5; vector-effect: non-scaling-stroke; }
-.trend-danger { fill: none; stroke: var(--red); stroke-width: 2.5; vector-effect: non-scaling-stroke; }
-.trend-total-point { fill: var(--muted); }
-.trend-warning-point { fill: var(--amber); }
-.trend-danger-point { fill: var(--red); }
-.trend-panel-note { min-height: 30px; margin-top: 4px; color: var(--muted); font-size: 10px; line-height: 1.45; }
-.trend-empty { display: grid; place-items: center; height: 150px; color: var(--muted); font-size: 12px; }
+.exact-trend-line { fill: none; stroke: var(--claw); stroke-width: 2.5; vector-effect: non-scaling-stroke; }
+.exact-trend-point { fill: var(--claw); }
+.trend-empty { display: grid; place-items: center; height: 130px; color: var(--muted); font-size: 12px; }
 .overview-shell { margin: 0; padding: 0; border: 0; background: transparent; }
 .overview-head,
 .automatic-head,
@@ -9197,6 +9190,7 @@ h2::before { content: ""; flex: 0 0 auto; width: 14px; height: 2px; border-radiu
 .exact-lane-head span { color: var(--muted); font-size: 11px; }
 .lane-counts { display: grid; gap: 6px; margin-top: 12px; }
 .lane-count { display: flex; justify-content: space-between; gap: 12px; color: var(--muted); font-size: 11px; }
+.exact-lane > .lane-count { margin-top: 14px; }
 .lane-count strong { color: var(--text); font-weight: 600; }
 .lane-bar { height: 6px; margin-top: 12px; overflow: hidden; border-radius: 999px; background: var(--track); }
 .lane-bar i { display: block; height: 100%; background: var(--claw); }
@@ -9798,16 +9792,13 @@ a.pill:hover { color: var(--claw); text-decoration: none; }
   .work-row { grid-template-columns: 1fr; align-items: start; }
   .work-state, .stage-block, .timebox { justify-content: start; justify-items: start; }
   .worker-toolbar { align-items: stretch; flex-direction: column; }
-  .health-signal-grid { grid-template-columns: 1fr; }
-  .health-trend-grid { grid-template-columns: 1fr; }
 }
 @media (max-width: 560px) {
   main { width: min(100vw - 24px, 1280px); padding-top: 18px; }
   .hero { margin-top: 30px; }
   .hero-headline { font-size: 23px; gap: 10px; }
   .hero-dot { width: 10px; height: 10px; }
-  .health-trends-head, .health-signal-head { align-items: flex-start; flex-direction: column; }
-  .health-trend-title { flex-wrap: wrap; }
+  .exact-review-head { align-items: flex-start; flex-direction: column; }
   .grid, .drawer-grid { grid-template-columns: 1fr; }
   .metric, .metric:nth-child(3n + 1) { border-left: 0; border-top: 1px solid var(--line-soft); padding-left: 0; }
   .metric:first-child { border-top: 0; }
@@ -9842,18 +9833,6 @@ a.pill:hover { color: var(--claw); text-decoration: none; }
     <div class="muted" id="subtitle"></div>
   </section>
   <section class="grid" id="metrics"></section>
-  <section class="health-trends" aria-labelledby="health-trends-title">
-    <div class="health-trends-head">
-      <h2 id="health-trends-title">Health Trends</h2>
-      <div class="trend-ranges" id="trend-ranges" aria-label="Health history range">
-        <button class="trend-range active" type="button" data-trend-range="24h">24 hours</button>
-        <button class="trend-range" type="button" data-trend-range="7d">7 days</button>
-      </div>
-    </div>
-    <div class="health-trend-summary" id="health-trend-summary">History starts collecting after deployment.</div>
-    <div class="health-signal-grid" id="health-trend-signals"></div>
-    <div class="health-trend-grid" id="health-trend-grid"></div>
-  </section>
   <section class="overview-shell" aria-labelledby="system-overview-title">
     <div class="overview-head">
       <h2 id="system-overview-title">System Overview</h2>
@@ -9862,7 +9841,15 @@ a.pill:hover { color: var(--claw); text-decoration: none; }
     <div class="flow-map" id="flow-map"></div>
     <h3 class="overview-section-title">Codex Capacity</h3>
     <div class="capacity-rail" id="capacity-rail"></div>
-    <h3 class="overview-section-title">Exact Review</h3>
+    <div id="execution-alert" aria-live="polite"></div>
+    <div class="exact-review-head">
+      <h3 class="overview-section-title">Exact Review</h3>
+      <div class="trend-ranges" id="trend-ranges" aria-label="Exact Review backlog history range">
+        <button class="trend-range active" type="button" data-trend-range="6h">6 hours</button>
+        <button class="trend-range" type="button" data-trend-range="24h">24 hours</button>
+        <button class="trend-range" type="button" data-trend-range="7d">7 days</button>
+      </div>
+    </div>
     <div class="exact-lanes" id="exact-review-lanes" aria-live="polite"></div>
     <h3 class="overview-section-title">Control Plane · GitHub Actions, not Codex</h3>
     <div class="control-plane" id="control-plane" aria-live="polite"></div>
@@ -9991,40 +9978,32 @@ let loading = false;
 let activeWorkerFilter = "all";
 let workerIndex = new Map();
 let automaticIndex = new Map();
-let activeHealthRange = "24h";
+let activeHealthRange = "6h";
 let healthHistoryLoadedAt = 0;
 let healthHistorySamples = [];
 
-function currentHealthSample(health) {
-  if (!health?.checked_at) return null;
-  return {
-    at: health.checked_at,
-    status: health.status,
-    queued: health.queued_runs || 0,
-    queued_over_30m: health.queued_over_threshold || 0,
-    oldest_queued_minutes: health.oldest_queued_minutes || 0,
-    running: health.running_runs || 0,
-    running_over_150m: health.running_over_threshold || 0,
-    oldest_running_minutes: health.oldest_running_minutes || 0,
-    collection_ok: health.telemetry_complete === true,
-  };
+function exactReviewHistory(lane) {
+  return healthHistorySamples.flatMap(sample => {
+    const pending = sample.exact_review?.collection_ok === true
+      ? Number(sample.exact_review?.[lane]?.pending)
+      : NaN;
+    return Number.isFinite(Date.parse(sample.at)) && Number.isFinite(pending)
+      ? [{ at: sample.at, pending: Math.max(0, pending) }]
+      : [];
+  });
 }
 
-function trendGeometry(samples, field, plot, maximum) {
+function trendGeometry(samples, field, plot, maximum, fromAt, toAt) {
   if (!samples.length || maximum <= 0) return [];
-  const firstAt = Date.parse(samples[0].at);
-  const lastAt = Date.parse(samples.at(-1).at);
-  const span = Math.max(1, lastAt - firstAt);
+  const span = Math.max(1, toAt - fromAt);
   let previousAt = null;
   return samples.flatMap(sample => {
     const at = Date.parse(sample.at);
-    if (!sample.collection_ok || !Number.isFinite(at)) {
+    if (!Number.isFinite(at)) {
       previousAt = null;
       return [];
     }
-    const x = samples.length === 1
-      ? plot.left + plot.width / 2
-      : plot.left + ((at - firstAt) / span) * plot.width;
+    const x = plot.left + ((at - fromAt) / span) * plot.width;
     const y = plot.top + plot.height - (Math.max(0, Number(sample[field]) || 0) / maximum) * plot.height;
     const connected = previousAt !== null && at - previousAt <= 12 * 60 * 1000;
     previousAt = at;
@@ -10034,10 +10013,6 @@ function trendGeometry(samples, field, plot, maximum) {
 
 function trendPath(geometry) {
   return geometry.map(point => (point.connected ? "L" : "M") + point.x.toFixed(1) + " " + point.y.toFixed(1)).join(" ");
-}
-
-function trendPoints(geometry, className) {
-  return geometry.map(point => '<circle class="' + esc(className) + '-point" cx="' + point.x.toFixed(1) + '" cy="' + point.y.toFixed(1) + '" r="3"></circle>').join("");
 }
 
 function niceTrendScale(maximum, tickCount) {
@@ -10053,160 +10028,79 @@ function niceTrendScale(maximum, tickCount) {
   };
 }
 
-function formatTrendValue(value, unit) {
-  if (unit !== "minutes") return fmt.format(Math.round(value));
-  if (value >= 1440) return (value / 1440).toFixed(value >= 14400 ? 0 : 1) + "d";
-  if (value >= 120) return (value / 60).toFixed(value >= 600 ? 0 : 1) + "h";
-  return fmt.format(Math.round(value)) + "m";
+function formatTrendValue(value) {
+  return fmt.format(Math.round(value));
 }
 
-function signalCard(label, value, detail, className) {
-  return '<div class="health-signal"><div class="health-signal-head"><span class="health-signal-label">' + esc(label) + '</span><strong class="health-signal-value ' + esc(className) + '">' + esc(value) + '</strong></div><div class="health-signal-detail">' + esc(detail) + '</div></div>';
+function oneHourTrend(samples) {
+  if (!samples.length) return { className: "collecting", label: "Collecting 1h trend" };
+  const latest = samples.at(-1);
+  const cutoff = Date.parse(latest.at) - 60 * 60 * 1000;
+  const baseline = samples.filter(sample => Date.parse(sample.at) <= cutoff).at(-1);
+  if (!baseline || cutoff - Date.parse(baseline.at) > 12 * 60 * 1000) {
+    return { className: "collecting", label: "Collecting 1h trend" };
+  }
+  const delta = latest.pending - baseline.pending;
+  if (delta > 0) return { className: "growing", label: "Growing · +" + fmt.format(delta) + " in the last hour" };
+  if (delta < 0) return { className: "draining", label: "Draining · −" + fmt.format(Math.abs(delta)) + " in the last hour" };
+  return { className: "stable", label: "Stable · no change in the last hour" };
 }
 
-function executionHealthSignal(current) {
-  if (!current || current.telemetry_complete !== true) {
-    return { value: "Unknown", className: "unknown", detail: "Active-run telemetry is incomplete." };
-  }
-  const stalled = Number(current.running_over_threshold) || 0;
-  const oldest = Number(current.oldest_running_minutes) || 0;
-  if (stalled > 0) {
-    return {
-      value: "Stalled",
-      className: "stalled",
-      detail: fmt.format(stalled) + " over 150m · oldest " + formatTrendValue(oldest, "minutes"),
-    };
-  }
-  return {
-    value: "Healthy",
-    className: "ok",
-    detail: fmt.format(Number(current.running_runs) || 0) + " running · none over 150m",
-  };
-}
-
-function queueLoadSignal(samples, current) {
-  if (!current || current.telemetry_complete !== true) {
-    return { value: "Unknown", className: "unknown", detail: "Queue telemetry is incomplete." };
-  }
-  const valid = samples
-    .filter(sample => sample.collection_ok && Number.isFinite(Date.parse(sample.at)))
-    .slice(-7);
-  const queued = Number(current.queued_runs) || 0;
-  const overSlo = Number(current.queued_over_threshold) || 0;
-  if (overSlo === 0) {
-    return queued > 0
-      ? { value: "Busy, within SLO", className: "ok", detail: fmt.format(queued) + " queued · none over 30m" }
-      : { value: "Idle", className: "ok", detail: "No queued workflows." };
-  }
-  if (valid.length < 2) {
-    return { value: "Delayed", className: "attention", detail: fmt.format(overSlo) + " over 30m · collecting trend" };
-  }
-  // Queue size moves with review demand, so direction comes from the over-SLO
-  // backlog while execution health remains an independent signal.
-  const first = Number(valid[0].queued_over_30m) || 0;
-  const latest = Number(valid.at(-1).queued_over_30m) || 0;
-  const delta = latest - first;
-  const meaningful = Math.max(2, Math.ceil(first * 0.05));
-  const windowMinutes = Math.max(
-    5,
-    Math.round((Date.parse(valid.at(-1).at) - Date.parse(valid[0].at)) / 60000),
-  );
-  if (delta <= -meaningful) {
-    return {
-      value: "Recovering",
-      className: "ok",
-      detail: fmt.format(overSlo) + " over 30m · down " + fmt.format(Math.abs(delta)) + " in " + fmt.format(windowMinutes) + "m",
-    };
-  }
-  if (delta >= meaningful) {
-    return {
-      value: "Backlog growing",
-      className: "attention",
-      detail: fmt.format(overSlo) + " over 30m · up " + fmt.format(delta) + " in " + fmt.format(windowMinutes) + "m",
-    };
-  }
-  return {
-    value: "Delayed, stable",
-    className: "attention",
-    detail: fmt.format(overSlo) + " over 30m · broadly flat for " + fmt.format(windowMinutes) + "m",
-  };
-}
-
-function trendPanel(samples, title, detail, series, options) {
+function exactReviewTrend(samples, label) {
   if (!samples.length) {
-    return '<div class="health-trend-panel"><div class="health-trend-title"><strong>' + esc(title) + '</strong><span>' + esc(detail) + '</span></div><div class="trend-empty">Waiting for the first health sample.</div></div>';
+    return '<div class="exact-trend"><div class="exact-trend-status collecting">Collecting 1h trend</div><div class="trend-empty">No backlog history in this range.</div></div>';
   }
-  const config = options || {};
   const width = 600;
-  const height = 170;
-  const plot = { left: 48, top: 10, width: 540, height: 130 };
-  const values = series.flatMap(item => samples.map(sample => Number(sample[item.field]) || 0));
-  const scale = niceTrendScale(Math.max(1, Number(config.threshold) || 0, ...values), 4);
+  const height = 150;
+  const plot = { left: 48, top: 8, width: 540, height: 110 };
+  const rangeMs = activeHealthRange === "7d" ? 7 * 86400000 : activeHealthRange === "24h" ? 86400000 : 6 * 3600000;
+  const latestAt = Date.parse(samples.at(-1).at);
+  const toAt = Math.max(Date.now(), latestAt);
+  const fromAt = toAt - rangeMs;
+  const visible = samples.filter(sample => Date.parse(sample.at) >= fromAt && Date.parse(sample.at) <= toAt);
+  const scale = niceTrendScale(Math.max(1, ...visible.map(sample => sample.pending)), 4);
   const grid = scale.ticks.map(value => {
     const y = plot.top + plot.height - value / scale.maximum * plot.height;
-    return '<line class="trend-grid-line" x1="' + plot.left + '" x2="' + (plot.left + plot.width) + '" y1="' + y.toFixed(1) + '" y2="' + y.toFixed(1) + '"></line><text class="trend-axis-label" x="' + (plot.left - 8) + '" y="' + (y + 3).toFixed(1) + '" text-anchor="end">' + esc(formatTrendValue(value, config.unit)) + '</text>';
+    return '<line class="trend-grid-line" x1="' + plot.left + '" x2="' + (plot.left + plot.width) + '" y1="' + y.toFixed(1) + '" y2="' + y.toFixed(1) + '"></line><text class="trend-axis-label" x="' + (plot.left - 8) + '" y="' + (y + 3).toFixed(1) + '" text-anchor="end">' + esc(formatTrendValue(value)) + '</text>';
   }).join("");
-  const thresholdY = config.threshold
-    ? plot.top + plot.height - config.threshold / scale.maximum * plot.height
-    : null;
-  const thresholdLine = thresholdY !== null
-    ? '<line class="trend-threshold ' + esc(config.thresholdClass || "") + '" x1="' + plot.left + '" x2="' + (plot.left + plot.width) + '" y1="' + thresholdY.toFixed(1) + '" y2="' + thresholdY.toFixed(1) + '"></line><text class="trend-threshold-label ' + esc(config.thresholdClass || "") + '" x="' + (plot.left + 4) + '" y="' + Math.max(plot.top + 9, thresholdY - 4).toFixed(1) + '">' + esc(formatTrendValue(config.threshold, config.unit)) + ' SLO</text>'
-    : "";
-  const geometry = series.map(item => ({
-    item,
-    points: trendGeometry(samples, item.field, plot, scale.maximum),
-  }));
-  const paths = geometry.map(seriesGeometry => '<path class="' + esc(seriesGeometry.item.className) + '" d="' + trendPath(seriesGeometry.points) + '"></path>').join("");
-  const points = geometry.map(seriesGeometry => trendPoints(seriesGeometry.points, seriesGeometry.item.className)).join("");
-  const legend = '<div class="trend-legend">' + series.map(item => '<span class="trend-legend-item"><i class="trend-swatch ' + esc(item.className) + '"></i>' + esc(item.label) + '</span>').join("") + '</div>';
-  const note = '<div class="trend-panel-note">' + esc(config.note || "") + '</div>';
-  return '<div class="health-trend-panel"><div class="health-trend-title"><strong>' + esc(title) + '</strong><span>' + esc(detail) + '</span></div>' + legend + '<svg class="health-trend-svg" viewBox="0 0 ' + width + " " + height + '" role="img" aria-label="' + esc(title) + '">' + grid + thresholdLine + paths + points + '</svg>' + note + '</div>';
+  const geometry = trendGeometry(visible, "pending", plot, scale.maximum, fromAt, toAt);
+  const points = geometry.map(point => '<circle class="exact-trend-point" cx="' + point.x.toFixed(1) + '" cy="' + point.y.toFixed(1) + '" r="3"></circle>').join("");
+  const direction = oneHourTrend(visible);
+  const rangeLabel = activeHealthRange === "7d" ? "7d ago" : activeHealthRange + " ago";
+  const axis = '<text class="trend-axis-label" x="' + plot.left + '" y="' + (height - 7) + '">' + rangeLabel + '</text><text class="trend-axis-label" x="' + (plot.left + plot.width) + '" y="' + (height - 7) + '" text-anchor="end">now</text>';
+  return '<div class="exact-trend"><div class="exact-trend-status ' + direction.className + '">' + esc(direction.label) + '</div><svg class="exact-trend-svg" viewBox="0 0 ' + width + " " + height + '" role="img" aria-label="' + esc(label + " pending backlog over " + activeHealthRange) + '">' + grid + '<path class="exact-trend-line" d="' + trendPath(geometry) + '"></path>' + points + axis + '</svg></div>';
 }
 
-function renderHealthHistory(current) {
-  const latest = currentHealthSample(current);
-  const samples = healthHistorySamples
-    .filter(sample => !latest || Math.floor(Date.parse(sample.at) / 300000) !== Math.floor(Date.parse(latest.at) / 300000))
-    .concat(latest ? [latest] : [])
-    .sort((left, right) => Date.parse(left.at) - Date.parse(right.at));
-  const summary = document.getElementById("health-trend-summary");
-  if (current) {
-    const status = current.status === "stalled" ? "Stalled" : current.status === "degraded" ? "Degraded" : current.status === "healthy" ? "Healthy" : "Telemetry incomplete";
-    summary.textContent = status + " · " + fmt.format(current.queued_over_threshold || 0) + " queued over 30m · " + fmt.format(current.running_over_threshold || 0) + " running over 150m · " + fmt.format(samples.length) + " samples";
+function renderExecutionAlert(current) {
+  const target = document.getElementById("execution-alert");
+  if (!target) return;
+  const incomplete = !current || current.telemetry_complete !== true;
+  const queued = Number(current?.queued_over_threshold) || 0;
+  const running = Number(current?.running_over_threshold) || 0;
+  if (!incomplete && queued === 0 && running === 0) {
+    target.innerHTML = "";
+    return;
   }
-  const execution = executionHealthSignal(current);
-  const queue = queueLoadSignal(samples, current);
-  document.getElementById("health-trend-signals").innerHTML =
-    signalCard("Execution health", execution.value, execution.detail, execution.className) +
-    signalCard("Queue load", queue.value, queue.detail, queue.className);
-  document.getElementById("health-trend-grid").innerHTML =
-    trendPanel(samples, "Queue pressure", "workflows", [
-      { field: "queued", className: "trend-total", label: "Total queued" },
-      { field: "queued_over_30m", className: "trend-warning", label: "Over 30m" },
-    ], {
-      unit: "count",
-      note: "Demand affects total depth; use the over-30m direction for queue health.",
-    }) +
-    trendPanel(samples, "Oldest queued", "diagnostic outlier", [
-      { field: "oldest_queued_minutes", className: "trend-warning", label: "Oldest age" },
-    ], {
-      threshold: 30,
-      thresholdClass: "warning",
-      unit: "minutes",
-      note: "A single stale GitHub queued record can dominate this chart.",
-    }) +
-    trendPanel(samples, "Oldest running", "execution SLO", [
-      { field: "oldest_running_minutes", className: "trend-danger", label: "Oldest age" },
-    ], {
-      threshold: 150,
-      unit: "minutes",
-      note: "Crossing 150m marks execution health as stalled.",
-    });
+  const parts = [];
+  if (queued) parts.push(fmt.format(queued) + " workflow" + (queued === 1 ? "" : "s") + " waiting for a runner over 30m");
+  if (running) parts.push(fmt.format(running) + " execution" + (running === 1 ? "" : "s") + " over 150m");
+  if (incomplete) parts.push("work execution telemetry is incomplete");
+  const details = "Total GitHub queued " + fmt.format(Number(current?.queued_runs) || 0) + " · oldest queued " + formatAgeMinutes(current?.oldest_queued_minutes) + " · oldest running " + formatAgeMinutes(current?.oldest_running_minutes);
+  target.innerHTML = '<details class="execution-alert"><summary><span class="execution-alert-title"><strong>⚠ Work execution needs attention</strong><span>' + esc(parts.join(" · ")) + '</span></span><span class="execution-alert-toggle">Details ▾</span></summary><div class="execution-alert-body">' + esc(details) + '</div></details>';
 }
 
-async function loadHealthHistory(range, current, force) {
+function formatAgeMinutes(value) {
+  const minutes = Number(value);
+  if (!Number.isFinite(minutes)) return "unknown";
+  if (minutes < 90) return fmt.format(Math.round(minutes)) + "m";
+  const hours = Math.floor(minutes / 60);
+  const remainder = Math.round(minutes % 60);
+  return fmt.format(hours) + "h" + (remainder ? " " + fmt.format(remainder) + "m" : "");
+}
+
+async function loadHealthHistory(range, force) {
   if (!force && range === activeHealthRange && Date.now() - healthHistoryLoadedAt < 60000) {
-    renderHealthHistory(current);
+    renderExactReviewLanes(lastData?.exact_review_queue);
     return;
   }
   activeHealthRange = range;
@@ -10222,7 +10116,7 @@ async function loadHealthHistory(range, current, force) {
     if (requestedRange !== activeHealthRange) return;
     healthHistorySamples = [];
   }
-  renderHealthHistory(current);
+  renderExactReviewLanes(lastData?.exact_review_queue);
 }
 
 function workerGroup(worker) {
@@ -10299,11 +10193,14 @@ function renderExactReviewLanes(queue) {
   const target = document.getElementById("exact-review-lanes");
   if (!target) return;
   const lanes = queue?.lanes;
-  if (!lanes?.review || !lanes?.publication) {
-    target.innerHTML = '<div class="empty">Exact-review lane telemetry unavailable.</div>';
-    return;
-  }
-  target.innerHTML = [["Review admission", lanes.review], ["Result publication", lanes.publication]].map(([label, lane]) => {
+  target.innerHTML = [["Review admission", "review", lanes?.review], ["Result publication", "publication", lanes?.publication]].map(([label, laneKey, lane]) => {
+    const samples = exactReviewHistory(laneKey);
+    if (!lane) {
+      const sampledAt = samples.at(-1)?.at;
+      return '<div class="exact-lane"><div class="exact-lane-head"><strong>' + esc(label) + '</strong><span>Live snapshot unavailable</span></div>' +
+        exactReviewTrend(samples, label) +
+        '<div class="lane-foot">' + (sampledAt ? "Last sampled " + esc(since(sampledAt)) : "History starts with the next five-minute sample") + '</div></div>';
+    }
     const capacity = Math.max(0, lane.capacity || 0);
     const active = Math.max(0, lane.active || 0);
     const used = capacity ? Math.min(100, (active / capacity) * 100) : 0;
@@ -10311,8 +10208,9 @@ function renderExactReviewLanes(queue) {
       ? " · oldest " + elapsed(lane.oldest_pending_age_seconds * 1000)
       : "";
     return '<div class="exact-lane"><div class="exact-lane-head"><strong>' + esc(label) + '</strong><span>' + fmt.format(active) + ' of ' + fmt.format(capacity) + ' active</span></div>' +
-      '<div class="lane-counts">' +
       '<div class="lane-count"><span>Pending</span><strong>' + fmt.format(lane.pending || 0) + '</strong></div>' +
+      exactReviewTrend(samples, label) +
+      '<div class="lane-counts">' +
       '<div class="lane-count"><span>Ready</span><strong>' + fmt.format(lane.ready || 0) + '</strong></div>' +
       '<div class="lane-count"><span>Backoff</span><strong>' + fmt.format(lane.backoff || 0) + '</strong></div>' +
       '<div class="lane-count"><span>Dispatching</span><strong>' + fmt.format(lane.dispatching || 0) + '</strong></div>' +
@@ -10534,7 +10432,7 @@ async function load() {
         ? "Updated with partial GitHub telemetry."
         : "",
   );
-  loadHealthHistory(activeHealthRange, data.operational_health, false).catch(() => undefined);
+  loadHealthHistory(activeHealthRange, false).catch(() => undefined);
   } catch (error) {
     if (lastData) {
       renderDashboard(lastData, "Live refresh failed; showing last good status.");
@@ -10568,16 +10466,13 @@ function renderDashboard(data, note) {
   document.getElementById("subtitle").textContent = data.source.target_repositories.join(", ");
   document.getElementById("updated").textContent = "Updated " + since(data.generated_at) + (note ? " \u00b7 " + note : "");
   const fleet = data.fleet;
-  const operational = data.operational_health || {};
   document.getElementById("metrics").innerHTML = [
     metric("Codex Workers", fmt.format(fleet.active_codex_jobs), "Codex budget " + fleet.worker_budget, fleet.budget_used_percent, "var(--green)"),
-    metric("Active Sweeps", fmt.format(fleet.active_workflow_runs), fmt.format(operational.running_over_threshold || 0) + " over 150m", Math.min(100, fleet.active_workflow_runs * 3), operational.running_over_threshold ? "var(--red)" : "var(--claw)"),
-    metric("Queue Depth", fmt.format(fleet.queued_workflow_runs), fmt.format(operational.queued_over_threshold || 0) + " over 30m", Math.min(100, fleet.queued_workflow_runs * 10), operational.queued_over_threshold ? "var(--amber)" : "var(--green)"),
     metric("Error Rate", (data.health?.error_rate_percent || 0) + "%", fmt.format(data.health?.failed_attempts || 0) + " failed / " + fmt.format(data.health?.attempts || 0) + " attempts", Math.min(100, data.health?.error_rate_percent || 0), data.health?.failed_attempts ? "var(--red)" : "var(--green)"),
     metric("Recovery Rate", data.health?.recovery_rate_percent == null ? "n/a" : data.health.recovery_rate_percent + "%", fmt.format(data.health?.unresolved_failures || 0) + " unresolved", data.health?.recovery_rate_percent == null ? 100 : data.health.recovery_rate_percent, data.health?.unresolved_failures ? "var(--amber)" : "var(--green)"),
     metric("Codex Capacity", fleet.budget_used_percent + "%", "Codex slot utilization", fleet.budget_used_percent, "var(--green)")
   ].join("");
-  renderHealthHistory(data.operational_health);
+  renderExecutionAlert(data.operational_health);
   renderSystemMap(data);
   renderExactReviewLanes(data.exact_review_queue);
   renderControlPlane(data.control_plane, fleet.worker_budget);
@@ -11004,7 +10899,7 @@ document.getElementById("trend-ranges").addEventListener("click", event => {
   const button = event.target.closest("button[data-trend-range]");
   if (!button) return;
   document.querySelectorAll("button[data-trend-range]").forEach(item => item.classList.toggle("active", item === button));
-  loadHealthHistory(button.dataset.trendRange || "24h", lastData?.operational_health, true).catch(() => undefined);
+  loadHealthHistory(button.dataset.trendRange || "6h", true).catch(() => undefined);
 });
 document.getElementById("workers").addEventListener("click", event => {
   const button = event.target.closest("button[data-worker-id]");

--- a/test/dashboard-operational-health.test.ts
+++ b/test/dashboard-operational-health.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  exactReviewHistorySample,
   healthHistorySample,
   mergeHealthHistorySample,
   normalizeHealthHistorySample,
@@ -85,6 +86,29 @@ test("health history replaces duplicate five-minute slots", () => {
   assert.equal(preserved.length, 1);
   assert.equal(preserved[0].at, replacement.at);
   assert.equal(preserved[0].queued, 2);
+});
+
+test("health history preserves legacy samples and normalizes exact-review backlog", () => {
+  const legacy = healthHistorySample(summarizeOperationalHealth([], CHECKED_AT, true));
+  assert.deepEqual(normalizeHealthHistorySample(legacy), legacy);
+
+  const exactReview = exactReviewHistorySample({
+    lanes: { review: { pending: 317 }, publication: { pending: 1502 } },
+  });
+  const normalized = normalizeHealthHistorySample({ ...legacy, exact_review: exactReview });
+  assert.deepEqual(normalized?.exact_review, {
+    collection_ok: true,
+    review: { pending: 317 },
+    publication: { pending: 1502 },
+  });
+  assert.deepEqual(exactReviewHistorySample(null), { collection_ok: false });
+  assert.equal(
+    normalizeHealthHistorySample({
+      ...legacy,
+      exact_review: { collection_ok: true, review: { pending: 1 } },
+    })?.exact_review,
+    undefined,
+  );
 });
 
 test("health history rejects non-finite or incomplete samples", () => {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -1436,6 +1436,11 @@ test("dashboard health history persists five-minute samples and serves a bounded
     running_over_150m: 0,
     oldest_running_minutes: 40,
     collection_ok: true,
+    exact_review: {
+      collection_ok: true,
+      review: { pending: 317 },
+      publication: { pending: 1502 },
+    },
   };
 
   for (const queued of [12, 14]) {
@@ -1448,16 +1453,40 @@ test("dashboard health history persists five-minute samples and serves a bounded
     assert.equal(response.status, 200);
   }
 
-  const response = await worker.fetch(
-    new Request("https://clawsweeper.openclaw.ai/api/health-history?range=24h"),
+  await store.fetch(
+    new Request("https://clawsweeper-status-store/health-history", {
+      method: "POST",
+      body: JSON.stringify({
+        sample: { ...sample, at: new Date(Date.now() - 8 * 60 * 60_000).toISOString(), queued: 3 },
+      }),
+    }),
+  );
+
+  const sixHourResponse = await worker.fetch(
+    new Request("https://clawsweeper.openclaw.ai/api/health-history?range=6h"),
     { STATUS_STORE: namespace },
   );
-  const history = await response.json();
-  assert.equal(response.status, 200);
-  assert.equal(history.range, "24h");
-  assert.equal(history.retention_days, 7);
-  assert.equal(history.samples.length, 1);
-  assert.equal(history.samples[0].queued, 14);
+  const sixHourHistory = await sixHourResponse.json();
+  assert.equal(sixHourResponse.status, 200);
+  assert.equal(sixHourHistory.range, "6h");
+  assert.equal(sixHourHistory.retention_days, 7);
+  assert.equal(sixHourHistory.samples.length, 1);
+  assert.equal(sixHourHistory.samples[0].queued, 14);
+  assert.equal(sixHourHistory.samples[0].exact_review.review.pending, 317);
+
+  for (const [query, expectedRange] of [
+    ["24h", "24h"],
+    ["7d", "7d"],
+    ["invalid", "24h"],
+  ]) {
+    const response = await worker.fetch(
+      new Request(`https://clawsweeper.openclaw.ai/api/health-history?range=${query}`),
+      { STATUS_STORE: namespace },
+    );
+    const history = await response.json();
+    assert.equal(history.range, expectedRange);
+    assert.equal(history.samples.length, 2);
+  }
 });
 
 test("dashboard cron records health with status-only GitHub queries", async () => {
@@ -1466,6 +1495,19 @@ test("dashboard cron records health with status-only GitHub queries", async () =
   const store = new StatusStore({ storage });
   const namespace = new MemoryDurableNamespace(store);
   const requests: string[] = [];
+  let queueReads = 0;
+  const exactReviewQueue = {
+    idFromName: () => "global",
+    get: () => ({
+      fetch: async () => {
+        queueReads += 1;
+        return jsonResponse({
+          handoff_health: { status: "healthy" },
+          lanes: { review: { pending: 17 }, publication: { pending: 29 } },
+        });
+      },
+    }),
+  };
   globalThis.fetch = async (input) => {
     const url = new URL(String(input));
     requests.push(url.toString());
@@ -1490,12 +1532,14 @@ test("dashboard cron records health with status-only GitHub queries", async () =
       {},
       {
         CLAWSWEEPER_REPO: "openclaw/clawsweeper",
+        EXACT_REVIEW_QUEUE: exactReviewQueue,
         STATUS_STORE: namespace,
       },
       { waitUntil: (promise) => (recording = promise) },
     );
     await recording;
     assert.equal(requests.length, 5);
+    assert.equal(queueReads, 1);
     assert.ok(requests.every((url) => !url.includes("/jobs")));
 
     const response = await worker.fetch(
@@ -1507,6 +1551,32 @@ test("dashboard cron records health with status-only GitHub queries", async () =
     assert.equal(history.samples[0].status, "unknown");
     assert.equal(history.samples[0].queued, 100);
     assert.equal(history.samples[0].queued_over_30m, 1);
+    assert.equal(history.samples[0].exact_review.collection_ok, true);
+    assert.equal(history.samples[0].exact_review.review.pending, 17);
+    assert.equal(history.samples[0].exact_review.publication.pending, 29);
+
+    let failureRecording: Promise<unknown> | undefined;
+    await worker.scheduled(
+      {},
+      {
+        CLAWSWEEPER_REPO: "openclaw/clawsweeper",
+        EXACT_REVIEW_QUEUE: {
+          idFromName: () => "global",
+          get: () => ({ fetch: async () => Promise.reject(new Error("queue unavailable")) }),
+        },
+        STATUS_STORE: namespace,
+      },
+      { waitUntil: (promise) => (failureRecording = promise) },
+    );
+    await failureRecording;
+    const afterFailure = await worker.fetch(
+      new Request("https://clawsweeper.openclaw.ai/api/health-history?range=6h"),
+      { STATUS_STORE: namespace },
+    );
+    const failedQueueHistory = await afterFailure.json();
+    assert.equal(failedQueueHistory.samples.length, 1);
+    assert.equal(failedQueueHistory.samples[0].queued, 100);
+    assert.deepEqual(failedQueueHistory.samples[0].exact_review, { collection_ok: false });
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -4723,13 +4793,14 @@ test("dashboard HTML preserves UTF-8 emoji labels", async () => {
   assert.match(html, /<title>🦞 ClawSweeper Live<\/title>/);
   assert.match(html, /content: "🦞"/);
   assert.match(html, /Codex Workers/);
-  assert.match(html, /Active Sweeps/);
-  assert.match(html, /Queue Depth/);
-  assert.match(html, /Health Trends/);
-  assert.match(html, /id="health-trend-grid"/);
+  assert.doesNotMatch(html, /Active Sweeps/);
+  assert.doesNotMatch(html, /Queue Depth/);
+  assert.doesNotMatch(html, /Health Trends/);
+  assert.doesNotMatch(html, /id="health-trend-grid"/);
   assert.match(html, /\/api\/health-history\?range=/);
-  assert.match(html, /queued over 30m/);
-  assert.match(html, /running over 150m/);
+  assert.match(html, /Work execution needs attention/);
+  assert.match(html, /data-trend-range="6h"/);
+  assert.match(html, /<details class="execution-alert">/);
   assert.match(html, /Error Rate/);
   assert.match(html, /Recovery Rate/);
   assert.match(html, /Capacity/);
@@ -4973,6 +5044,7 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
   assert.match(elementFor("exact-review-lanes").innerHTML, /52 review admission slots open/);
   assert.match(elementFor("exact-review-lanes").innerHTML, /Result publication/);
   assert.match(elementFor("exact-review-lanes").innerHTML, /3 result publication slots open/);
+  assert.match(elementFor("exact-review-lanes").innerHTML, /No backlog history in this range/);
   assert.match(elementFor("control-plane").innerHTML, /2 running · 1 waiting/);
   assert.match(elementFor("control-plane").innerHTML, /GitHub runners but not the 128-slot/);
 
@@ -5000,6 +5072,32 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
   assert.match(elementFor("hero-headline").textContent, /^Needs attention/);
   assert.match(elementFor("exact-review-handoff").innerHTML, /telemetry unavailable/);
 
+  const healthyOperational = {
+    status: "healthy",
+    telemetry_complete: true,
+    queued_runs: 0,
+    queued_over_threshold: 0,
+    oldest_queued_minutes: 0,
+    running_runs: 0,
+    running_over_threshold: 0,
+    oldest_running_minutes: 0,
+  };
+  context.renderExecutionAlert(healthyOperational);
+  assert.equal(elementFor("execution-alert").innerHTML, "");
+  context.renderExecutionAlert({ ...healthyOperational, queued_runs: 2, queued_over_threshold: 2 });
+  assert.match(
+    elementFor("execution-alert").innerHTML,
+    /2 workflows waiting for a runner over 30m/,
+  );
+  context.renderExecutionAlert({
+    ...healthyOperational,
+    running_runs: 1,
+    running_over_threshold: 1,
+  });
+  assert.match(elementFor("execution-alert").innerHTML, /1 execution over 150m/);
+  context.renderExecutionAlert({ ...healthyOperational, telemetry_complete: false });
+  assert.match(elementFor("execution-alert").innerHTML, /telemetry is incomplete/);
+
   status.diagnostics.exact_review_queue_error = null;
   status.exact_review_queue = { handoff_health: { status: "healthy", phases: {} } };
   status.operational_health = {
@@ -5016,32 +5114,30 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
   context.renderDashboard(status, "");
 
   assert.equal(elementFor("hero-dot").className, "hero-dot red");
-  assert.match(elementFor("metrics").innerHTML, /4 over 30m/);
-  assert.match(elementFor("metrics").innerHTML, /1 over 150m/);
-  assert.match(elementFor("health-trend-summary").textContent, /Stalled/);
-  assert.match(elementFor("health-trend-signals").innerHTML, /Execution health/);
-  assert.match(elementFor("health-trend-signals").innerHTML, /Queue load/);
-  assert.match(elementFor("health-trend-signals").innerHTML, /Stalled/);
-  assert.match(elementFor("health-trend-signals").innerHTML, /Delayed/);
-  assert.match(elementFor("health-trend-grid").innerHTML, /<circle class="trend-danger-point"/);
-  assert.match(elementFor("health-trend-grid").innerHTML, /class="trend-axis-label"/);
-  assert.match(elementFor("health-trend-grid").innerHTML, />100m<\/text>/);
-  assert.match(elementFor("health-trend-grid").innerHTML, />2\.5h SLO<\/text>/);
-  assert.match(elementFor("health-trend-grid").innerHTML, /diagnostic outlier/);
+  assert.doesNotMatch(elementFor("metrics").innerHTML, /over 30m|over 150m/);
+  assert.match(
+    elementFor("execution-alert").innerHTML,
+    /4 workflows waiting for a runner over 30m/,
+  );
+  assert.match(elementFor("execution-alert").innerHTML, /1 execution over 150m/);
+  assert.match(elementFor("execution-alert").innerHTML, /Total GitHub queued 10/);
+  assert.match(elementFor("execution-alert").innerHTML, /oldest running 3h/);
 
   const scale = context.niceTrendScale(95, 4);
   assert.equal(scale.maximum, 100);
   assert.deepEqual([...scale.ticks], [0, 25, 50, 75, 100]);
-  const recovering = context.queueLoadSignal(
-    [
-      { at: "2026-07-05T11:00:00Z", collection_ok: true, queued_over_30m: 20 },
-      { at: "2026-07-05T11:30:00Z", collection_ok: true, queued_over_30m: 12 },
-    ],
-    { ...status.operational_health, queued_over_threshold: 12 },
-  );
-  assert.equal(recovering.value, "Recovering");
 
   let resolve24HourHistory: ((response: unknown) => void) | undefined;
+  const now = Date.now();
+  const samples = Array.from({ length: 13 }, (_, index) => ({
+    at: new Date(now - (12 - index) * 5 * 60_000).toISOString(),
+    collection_ok: true,
+    exact_review: {
+      collection_ok: true,
+      review: { pending: 100 + index },
+      publication: { pending: 200 - index },
+    },
+  }));
   context.fetch = async (input: string) => {
     if (input.includes("range=24h")) {
       return new Promise((resolve) => {
@@ -5050,15 +5146,54 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
     }
     return {
       ok: true,
-      json: async () => ({ samples: [{ collection_ok: true }, { collection_ok: true }] }),
+      json: async () => ({ samples }),
     };
   };
-  const stale24HourRequest = context.loadHealthHistory("24h", status.operational_health, true);
-  const active7DayRequest = context.loadHealthHistory("7d", status.operational_health, true);
+  const stale24HourRequest = context.loadHealthHistory("24h", true);
+  const active7DayRequest = context.loadHealthHistory("7d", true);
   await active7DayRequest;
   resolve24HourHistory?.({ ok: true, json: async () => ({ samples: [] }) });
   await stale24HourRequest;
-  assert.match(elementFor("health-trend-summary").textContent, /3 samples/);
+  const laneHtml = elementFor("exact-review-lanes").innerHTML;
+  assert.match(laneHtml, /Growing · \+12 in the last hour/);
+  assert.match(laneHtml, /Draining · −12 in the last hour/);
+  assert.match(laneHtml, /role="img" aria-label="Review admission pending backlog over 7d"/);
+  assert.match(laneHtml, /Live snapshot unavailable/);
+  assert.match(laneHtml, /Last sampled/);
+
+  const smallAxis = context.exactReviewTrend(
+    [{ at: new Date(now).toISOString(), pending: 8 }],
+    "Small lane",
+  );
+  const largeAxis = context.exactReviewTrend(
+    [{ at: new Date(now).toISOString(), pending: 1500 }],
+    "Large lane",
+  );
+  assert.match(smallAxis, />8<\/text>/);
+  assert.match(largeAxis, />2,000<\/text>/);
+
+  assert.equal(
+    context.oneHourTrend(samples.slice(0, 1).map((sample) => ({ at: sample.at, pending: 4 })))
+      .label,
+    "Collecting 1h trend",
+  );
+  assert.equal(
+    context.oneHourTrend(samples.map((sample) => ({ at: sample.at, pending: 9 }))).label,
+    "Stable · no change in the last hour",
+  );
+  const broken = context.trendGeometry(
+    [
+      { at: new Date(now - 30 * 60_000).toISOString(), pending: 1 },
+      { at: new Date(now - 10 * 60_000).toISOString(), pending: 2 },
+    ],
+    "pending",
+    { left: 0, top: 0, width: 100, height: 100 },
+    2,
+    now - 60 * 60_000,
+    now,
+  );
+  assert.equal(broken[1].connected, false);
+  assert.match(context.trendPath(broken), /^M.* M/);
 });
 
 test("dashboard HTML emits early persistent theme controls", async () => {


### PR DESCRIPTION
## Summary

- replace the standalone operational Health Trends section with business-facing Pending backlog trends inside both Exact Review lanes
- add 6h, 24h, and 7d history ranges, one-hour growth/drain signals, gap-aware SVG rendering, and live-snapshot fallbacks
- surface GitHub Actions execution telemetry only as an expandable alert when thresholds are exceeded or collection is incomplete
- fold the existing scheduled Exact Review queue snapshot into the five-minute health-history sample without adding queue fetches or changing queue behavior

## Design

Desktop layout:

```text
Shown only when execution needs attention
┌──────────────────────────────────────────────────────────────────────────────┐
│ ⚠ Work execution needs attention                                  Details ▾ │
│ 2 workflows waiting for a runner over 30m · 1 execution over 150m            │
│ Expanded: Total GitHub queued 12 · oldest queued 47m · oldest running 3h 12m │
└──────────────────────────────────────────────────────────────────────────────┘

 EXACT REVIEW                                               [ 6h ] [ 24h ] [ 7d ]

┌─────────────────────────────────────┬────────────────────────────────────────┐
│ REVIEW ADMISSION                    │ RESULT PUBLICATION                     │
│ 64 of 64 active                     │ 24 of 24 active                        │
│                                     │                                        │
│ Pending                        317   │ Pending                          1,502   │
│ Growing · +42 in the last hour      │ Draining · −186 in the last hour      │
│                                     │                                        │
│ 350 ┤                    ╭────       │ 1.8k ┤───╮                            │
│ 250 ┤       ╭────────────╯           │ 1.5k ┤   ╰──────────────              │
│ 150 ┼───────╯                        │ 1.2k ┼──────────────────               │
│     6h ago                    now    │      6h ago                    now     │
│                                     │                                        │
│ Ready                          308   │ Ready                            1,480   │
│ Backoff                          9   │ Backoff                             22   │
│ Dispatching                      4   │ Dispatching                          1   │
│ Leased                          60   │ Leased                              23   │
│                                     │                                        │
│ 0 slots open · oldest pending 2h    │ 0 slots open · oldest pending 7h      │
└─────────────────────────────────────┴────────────────────────────────────────┘

 CONTROL PLANE       (unchanged)
 HANDOFF HEALTH      (unchanged)
```

On mobile, the range selector, Review admission, and Result publication stack vertically in that order. The execution alert remains immediately before Exact Review.

## Why

The previous dashboard emphasized GitHub Actions implementation metrics instead of the review backlog operators need to manage. This keeps the operational telemetry available for diagnosis while making review admission and result publication pressure the primary trend surface.

## Compatibility and impact

- keeps `schema_version: 1` and all existing operational history fields
- preserves old history samples without `exact_review`
- leaves queue state, dispatch, leases, retries, capacity, Control Plane, and Handoff Health unchanged
- history begins accumulating after deployment; pre-deployment backlog history is not backfilled

## Validation

- `node --test test/dashboard-operational-health.test.ts test/dashboard-worker.test.ts`
- `pnpm run check`
- `pnpm run format:check`
- `git diff --check`
- autoreview: Codex `gpt-5.6-sol`, clean with no accepted/actionable findings
