### PR TITLE
Show Exact Review publication speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -765,7 +765,7 @@ is active. Throughput defaults live in
 ClawSweeper has one main capacity knob:
 `config/automation-limits.json` -> `workers.max`. The current value is `128`.
 This is a Codex worker budget, not a GitHub Actions runner limit. Deterministic
-exact-review publishers, comment routers, and lease reconcilers are shown as
+exact-review publishers, comment routers, and lease reconcilers are
 control-plane workflows and do not consume these 128 slots.
 Lane limits are derived from that number: normal review defaults to 89 shards
 for manual/backstop and scheduled runs, hot intake up to 44 shards, commit

--- a/dashboard/operational-health.ts
+++ b/dashboard/operational-health.ts
@@ -27,21 +27,21 @@ export type OperationalHealth = {
 
 export type HealthHistorySample = {
   at: string;
-  status: OperationalHealth["status"];
-  queued: number;
-  queued_over_30m: number;
-  oldest_queued_minutes: number;
-  running: number;
-  running_over_150m: number;
-  oldest_running_minutes: number;
-  collection_ok: boolean;
+  status?: OperationalHealth["status"];
+  queued?: number;
+  queued_over_30m?: number;
+  oldest_queued_minutes?: number;
+  running?: number;
+  running_over_150m?: number;
+  oldest_running_minutes?: number;
+  collection_ok?: boolean;
   exact_review?: ExactReviewHistorySample;
 };
 
 export type ExactReviewHistorySample = {
   collection_ok: boolean;
   review?: { pending: number };
-  publication?: { pending: number };
+  publication?: { pending: number; completed_total?: number };
 };
 
 export function summarizeOperationalHealth(
@@ -92,28 +92,11 @@ export function summarizeOperationalHealth(
   };
 }
 
-export function healthHistorySample(health: OperationalHealth): HealthHistorySample {
-  return {
-    at: health.checked_at,
-    status: health.status,
-    queued: health.queued_runs,
-    queued_over_30m: health.queued_over_threshold,
-    oldest_queued_minutes: health.oldest_queued_minutes,
-    running: health.running_runs,
-    running_over_150m: health.running_over_threshold,
-    oldest_running_minutes: health.oldest_running_minutes,
-    collection_ok: health.telemetry_complete,
-  };
-}
-
 export function normalizeHealthHistorySample(value: unknown): HealthHistorySample | null {
   if (!value || typeof value !== "object") return null;
   const sample = value as Record<string, unknown>;
   const at = String(sample.at || "");
   if (!Number.isFinite(Date.parse(at))) return null;
-  const rawStatus = String(sample.status || "");
-  if (!["healthy", "degraded", "stalled", "unknown"].includes(rawStatus)) return null;
-  if (typeof sample.collection_ok !== "boolean") return null;
   const countFields = [
     "queued",
     "queued_over_30m",
@@ -122,21 +105,34 @@ export function normalizeHealthHistorySample(value: unknown): HealthHistorySampl
     "running_over_150m",
     "oldest_running_minutes",
   ] as const;
-  const counts = Object.fromEntries(
-    countFields.map((field) => [field, nonNegativeInteger(sample[field])]),
-  ) as Record<(typeof countFields)[number], number | null>;
-  if (Object.values(counts).some((count) => count === null)) return null;
+  const hasOperationalFields = ["status", "collection_ok", ...countFields].some((field) =>
+    Object.hasOwn(sample, field),
+  );
+  let operational: Omit<HealthHistorySample, "at" | "exact_review"> = {};
+  if (hasOperationalFields) {
+    const rawStatus = String(sample.status || "");
+    if (!["healthy", "degraded", "stalled", "unknown"].includes(rawStatus)) return null;
+    if (typeof sample.collection_ok !== "boolean") return null;
+    const counts = Object.fromEntries(
+      countFields.map((field) => [field, nonNegativeInteger(sample[field])]),
+    ) as Record<(typeof countFields)[number], number | null>;
+    if (Object.values(counts).some((count) => count === null)) return null;
+    operational = {
+      status: rawStatus as OperationalHealth["status"],
+      queued: counts.queued!,
+      queued_over_30m: counts.queued_over_30m!,
+      oldest_queued_minutes: counts.oldest_queued_minutes!,
+      running: counts.running!,
+      running_over_150m: counts.running_over_150m!,
+      oldest_running_minutes: counts.oldest_running_minutes!,
+      collection_ok: sample.collection_ok,
+    };
+  }
   const exactReview = normalizeExactReviewHistorySample(sample.exact_review);
+  if (!hasOperationalFields && !exactReview) return null;
   return {
     at,
-    status: rawStatus as HealthHistorySample["status"],
-    queued: counts.queued!,
-    queued_over_30m: counts.queued_over_30m!,
-    oldest_queued_minutes: counts.oldest_queued_minutes!,
-    running: counts.running!,
-    running_over_150m: counts.running_over_150m!,
-    oldest_running_minutes: counts.oldest_running_minutes!,
-    collection_ok: sample.collection_ok,
+    ...operational,
     ...(exactReview ? { exact_review: exactReview } : {}),
   };
 }
@@ -144,12 +140,18 @@ export function normalizeHealthHistorySample(value: unknown): HealthHistorySampl
 export function exactReviewHistorySample(value: unknown): ExactReviewHistorySample {
   const lanes = objectValue(objectValue(value).lanes);
   const reviewPending = nonNegativeInteger(objectValue(lanes.review).pending);
-  const publicationPending = nonNegativeInteger(objectValue(lanes.publication).pending);
+  const publicationLane = objectValue(lanes.publication);
+  const publicationPending = nonNegativeInteger(publicationLane.pending);
   if (reviewPending === null || publicationPending === null) return { collection_ok: false };
+  const completedTotal = optionalNonNegativeInteger(publicationLane.completed_total);
+  if (completedTotal === null) return { collection_ok: false };
   return {
     collection_ok: true,
     review: { pending: reviewPending },
-    publication: { pending: publicationPending },
+    publication: {
+      pending: publicationPending,
+      ...(completedTotal === undefined ? {} : { completed_total: completedTotal }),
+    },
   };
 }
 
@@ -160,12 +162,18 @@ function normalizeExactReviewHistorySample(value: unknown): ExactReviewHistorySa
   if (typeof sample.collection_ok !== "boolean") return null;
   if (!sample.collection_ok) return { collection_ok: false };
   const reviewPending = nonNegativeInteger(objectValue(sample.review).pending);
-  const publicationPending = nonNegativeInteger(objectValue(sample.publication).pending);
+  const publication = objectValue(sample.publication);
+  const publicationPending = nonNegativeInteger(publication.pending);
   if (reviewPending === null || publicationPending === null) return null;
+  const completedTotal = optionalNonNegativeInteger(publication.completed_total);
+  if (completedTotal === null) return null;
   return {
     collection_ok: true,
     review: { pending: reviewPending },
-    publication: { pending: publicationPending },
+    publication: {
+      pending: publicationPending,
+      ...(completedTotal === undefined ? {} : { completed_total: completedTotal }),
+    },
   };
 }
 
@@ -202,6 +210,10 @@ function ageMs(value: string | undefined, now: number) {
 function nonNegativeInteger(value: unknown) {
   const number = Number(value);
   return Number.isFinite(number) ? Math.max(0, Math.round(number)) : null;
+}
+
+function optionalNonNegativeInteger(value: unknown) {
+  return value === undefined ? undefined : nonNegativeInteger(value);
 }
 
 function objectValue(value: unknown): Record<string, unknown> {

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -9,7 +9,6 @@ import { summarizeExactReviewHandoff } from "./exact-review-health.ts";
 import {
   HEALTH_HISTORY_RETENTION_DAYS,
   exactReviewHistorySample,
-  healthHistorySample,
   mergeHealthHistorySample,
   normalizeHealthHistorySample,
   summarizeOperationalHealth,
@@ -187,6 +186,7 @@ const EXACT_REVIEW_QUEUE_STATE_KEY = "exact-review-queue";
 const EXACT_REVIEW_QUEUE_META_TABLE = "exact_review_queue_meta";
 const EXACT_REVIEW_QUEUE_ITEM_TABLE = "exact_review_queue_items";
 const EXACT_REVIEW_QUEUE_DELIVERY_TABLE = "exact_review_queue_deliveries";
+const EXACT_REVIEW_QUEUE_METRICS_TABLE = "exact_review_queue_metrics";
 const EXACT_REVIEW_QUEUE_NAME = "global";
 const EXACT_REVIEW_COMMAND_STATUS_MARKER_PATTERN =
   /^<!-- clawsweeper-command-status:[^<>\r\n]{1,200} -->$/;
@@ -875,7 +875,12 @@ export class ExactReviewQueue {
         requestedRetryAt ?? undefined,
         requeueLatest,
       );
-      await this.writeState(state);
+      // A successful workflow can still request requeue_latest after source
+      // drift, but that path publishes no result. Count only publication items
+      // that actually leave the queue on this completion.
+      const completedPublications =
+        outcome === "success" && !requeued && exactReviewQueueIsPublication(item) ? 1 : 0;
+      await this.writeState(state, completedPublications);
       await this.scheduleNext(state, now);
       return json({ ok: true, requeued });
     }
@@ -932,6 +937,7 @@ export class ExactReviewQueue {
       let reconciled = 0;
       let requeued = 0;
       let completed = 0;
+      let completedPublications = 0;
       for (const run of runs) {
         const matches = Object.values(state.items).filter(
           (item) =>
@@ -945,10 +951,15 @@ export class ExactReviewQueue {
         const didRequeue = finishExactReviewQueueItem(state, item, now, run.outcome);
         reconciled += 1;
         if (didRequeue) requeued += 1;
-        else completed += 1;
+        else {
+          completed += 1;
+          if (run.outcome === "success" && exactReviewQueueIsPublication(item)) {
+            completedPublications += 1;
+          }
+        }
       }
       if (reconciled) {
-        await this.writeState(state);
+        await this.writeState(state, completedPublications);
         await this.scheduleNext(state, now);
       }
       return json({ ok: true, reconciled, requeued, completed });
@@ -956,7 +967,7 @@ export class ExactReviewQueue {
 
     if (request.method === "GET" && url.pathname === "/stats") {
       const now = Date.now();
-      const state = this.storage.transactionSync(() => {
+      const snapshot = this.storage.transactionSync(() => {
         this.pruneDeliveryReceiptsSync(now);
         const current = this.readStateSync();
         // Dashboard reads are also the operational heartbeat. Reclaim leases and
@@ -969,21 +980,27 @@ export class ExactReviewQueue {
         );
         if (changed) this.writeStateSync(current);
         else this.syncLegacyCompatibilitySync(current);
-        return current;
+        return { state: current, completedTotal: this.publicationCompletedTotalSync() };
       });
+      const { state, completedTotal } = snapshot;
       await this.scheduleNext(state, now);
+      const stats = exactReviewQueueStats(
+        state,
+        now,
+        exactReviewQueueCapacity(this.env),
+        exactReviewTargetCapacity(this.env),
+        exactReviewPublicationCapacity(this.env),
+        exactReviewDispatchLeaseMs(this.env),
+        exactReviewExecutionLeaseMs(this.env),
+        exactReviewPublicationDispatchLeaseMs(this.env),
+        exactReviewHeartbeatGraceMs(this.env),
+      );
       return json({
-        ...exactReviewQueueStats(
-          state,
-          now,
-          exactReviewQueueCapacity(this.env),
-          exactReviewTargetCapacity(this.env),
-          exactReviewPublicationCapacity(this.env),
-          exactReviewDispatchLeaseMs(this.env),
-          exactReviewExecutionLeaseMs(this.env),
-          exactReviewPublicationDispatchLeaseMs(this.env),
-          exactReviewHeartbeatGraceMs(this.env),
-        ),
+        ...stats,
+        lanes: {
+          ...stats.lanes,
+          publication: { ...stats.lanes.publication, completed_total: completedTotal },
+        },
         delivery_receipts: this.deliveryReceiptCountSync(),
         storage_schema_version: EXACT_REVIEW_QUEUE_STORAGE_SCHEMA_VERSION,
         legacy_rollback_available:
@@ -1251,6 +1268,19 @@ export class ExactReviewQueue {
          received_at INTEGER NOT NULL
        ) STRICT`,
     );
+    // Completion telemetry is independent of queue rollback compatibility. A
+    // separate singleton keeps the cumulative counter monotonic without
+    // changing the normalized queue schema or its legacy shadow contract.
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_QUEUE_METRICS_TABLE} (
+         singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+         publication_completed_total INTEGER NOT NULL CHECK (publication_completed_total >= 0)
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `INSERT OR IGNORE INTO ${EXACT_REVIEW_QUEUE_METRICS_TABLE}
+         (singleton_id, publication_completed_total) VALUES (1, 0)`,
+    );
     this.storage.sql.exec(
       `CREATE INDEX IF NOT EXISTS exact_review_queue_deliveries_received_at
          ON ${EXACT_REVIEW_QUEUE_DELIVERY_TABLE} (received_at, delivery_id)`,
@@ -1481,8 +1511,33 @@ export class ExactReviewQueue {
     return state;
   }
 
-  private writeState(state: ExactReviewQueueState) {
-    this.storage.transactionSync(() => this.writeStateSync(state));
+  private writeState(state: ExactReviewQueueState, completedPublications = 0) {
+    this.storage.transactionSync(() => {
+      this.writeStateSync(state);
+      if (completedPublications > 0)
+        this.incrementPublicationCompletedTotalSync(completedPublications);
+    });
+  }
+
+  private publicationCompletedTotalSync() {
+    const row = Array.from(
+      this.storage.sql.exec(
+        `SELECT publication_completed_total
+           FROM ${EXACT_REVIEW_QUEUE_METRICS_TABLE}
+          WHERE singleton_id = 1`,
+      ),
+    )[0] as { publication_completed_total?: number } | undefined;
+    const total = Number(row?.publication_completed_total);
+    return Number.isSafeInteger(total) && total >= 0 ? total : 0;
+  }
+
+  private incrementPublicationCompletedTotalSync(count: number) {
+    this.storage.sql.exec(
+      `UPDATE ${EXACT_REVIEW_QUEUE_METRICS_TABLE}
+          SET publication_completed_total = publication_completed_total + ?
+        WHERE singleton_id = 1`,
+      count,
+    );
   }
 
   private writeStateSync(state: ExactReviewQueueState) {
@@ -1815,25 +1870,14 @@ async function recordScheduledHealthSample(env) {
     await queueSnapshot;
     return;
   }
-  // The queue snapshot was already part of scheduled maintenance. Folding it
-  // into the same sample preserves one queue read per tick and one time slot.
-  const [health, queue] = await Promise.all([collectOperationalHealth(env), queueSnapshot]);
+  // Current operational health still powers the anomaly alert in /api/status.
+  // Its old chart history had no remaining consumer, so cron persists only the
+  // exact-review queue snapshot and avoids a second GitHub Actions run scan.
+  const queue = await queueSnapshot;
   await appendHealthHistorySample(env, {
-    ...healthHistorySample(health),
+    at: new Date().toISOString(),
     exact_review: exactReviewHistorySample(queue),
   });
-}
-
-async function collectOperationalHealth(env) {
-  const repo = env.CLAWSWEEPER_REPO || "openclaw/clawsweeper";
-  const errors = [];
-  const runs = await activeWorkflowRunCandidates(env, repo, errors, createGithubJsonCache(env));
-  const checkedAt = new Date().toISOString();
-  return summarizeOperationalHealth(
-    runs.filter((run) => !isSupportWorkflowRun(run)),
-    checkedAt,
-    errors.length === 0,
-  );
 }
 
 async function appendHealthHistorySample(env, sample) {
@@ -9235,12 +9279,18 @@ h2::before { content: ""; flex: 0 0 auto; width: 14px; height: 2px; border-radiu
 .exact-trend-status { font-size: 12px; font-weight: 650; }
 .exact-trend-status.growing { color: var(--amber); }
 .exact-trend-status.draining { color: var(--green); }
+.exact-trend-status.speeding { color: var(--green); }
+.exact-trend-status.slowing { color: var(--amber); }
 .exact-trend-status.stable, .exact-trend-status.collecting { color: var(--muted); }
 .exact-trend-svg { display: block; width: 100%; height: 150px; margin-top: 6px; overflow: visible; }
 .trend-grid-line { stroke: var(--line-soft); stroke-width: 1; }
 .trend-axis-label { fill: var(--muted); font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; font-size: 10px; }
 .exact-trend-line { fill: none; stroke: var(--claw); stroke-width: 2.5; vector-effect: non-scaling-stroke; }
 .exact-trend-point { fill: var(--claw); }
+.publication-rate { margin-top: 20px; padding-top: 16px; border-top: 1px solid var(--line-soft); }
+.publication-rate .exact-trend-status { margin-top: 4px; }
+.publication-rate-line { fill: none; stroke: var(--violet); stroke-width: 2.5; vector-effect: non-scaling-stroke; }
+.publication-rate-point { fill: var(--violet); }
 .trend-empty { display: grid; place-items: center; height: 130px; color: var(--muted); font-size: 12px; }
 .overview-shell { margin: 0; padding: 0; border: 0; background: transparent; }
 .overview-head,
@@ -9337,8 +9387,7 @@ h2::before { content: ""; flex: 0 0 auto; width: 14px; height: 2px; border-radiu
   gap: 12px;
   margin-top: 10px;
 }
-.exact-lane,
-.control-plane {
+.exact-lane {
   padding: 14px;
   border: 1px solid var(--line);
   border-radius: 10px;
@@ -9354,10 +9403,6 @@ h2::before { content: ""; flex: 0 0 auto; width: 14px; height: 2px; border-radiu
 .lane-bar { height: 6px; margin-top: 12px; overflow: hidden; border-radius: 999px; background: var(--track); }
 .lane-bar i { display: block; height: 100%; background: var(--claw); }
 .lane-foot { margin-top: 7px; color: var(--muted); font-size: 11px; }
-.control-plane { display: grid; gap: 8px; margin-top: 10px; }
-.control-plane-row { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 12px; font-size: 12px; }
-.control-plane-row span:last-child { color: var(--muted); }
-.control-plane-note { margin-top: 3px; color: var(--muted); font-size: 11px; line-height: 1.45; }
 .exact-handoff {
   margin-top: 18px;
   padding: 14px;
@@ -9995,7 +10040,7 @@ a.pill:hover { color: var(--claw); text-decoration: none; }
   <section class="overview-shell" aria-labelledby="system-overview-title">
     <div class="overview-head">
       <h2 id="system-overview-title">System Overview</h2>
-      <span class="muted" id="overview-note">Live control-plane telemetry</span>
+      <span class="muted" id="overview-note">Live GitHub workflow telemetry</span>
     </div>
     <div class="flow-map" id="flow-map"></div>
     <h3 class="overview-section-title">Codex Capacity</h3>
@@ -10010,8 +10055,6 @@ a.pill:hover { color: var(--claw); text-decoration: none; }
       </div>
     </div>
     <div class="exact-lanes" id="exact-review-lanes" aria-live="polite"></div>
-    <h3 class="overview-section-title">Control Plane · GitHub Actions, not Codex</h3>
-    <div class="control-plane" id="control-plane" aria-live="polite"></div>
     <h3 class="overview-section-title">Handoff Health</h3>
     <div id="exact-review-handoff" aria-live="polite"></div>
     <div id="apply-health"></div>
@@ -10143,12 +10186,42 @@ let healthHistorySamples = [];
 
 function exactReviewHistory(lane) {
   return healthHistorySamples.flatMap(sample => {
-    const pending = sample.exact_review?.collection_ok === true
-      ? Number(sample.exact_review?.[lane]?.pending)
-      : NaN;
+    const laneSample = sample.exact_review?.collection_ok === true
+      ? sample.exact_review?.[lane]
+      : null;
+    const pending = Number(laneSample?.pending);
+    const completedTotal = Number(laneSample?.completed_total);
     return Number.isFinite(Date.parse(sample.at)) && Number.isFinite(pending)
-      ? [{ at: sample.at, pending: Math.max(0, pending) }]
+      ? [{
+          at: sample.at,
+          pending: Math.max(0, pending),
+          ...(Number.isFinite(completedTotal)
+            ? { completedTotal: Math.max(0, completedTotal) }
+            : {})
+        }]
       : [];
+  });
+}
+
+function publicationRateHistory(samples) {
+  const cumulative = samples.filter(sample => Number.isFinite(sample.completedTotal));
+  let segment = [];
+  let previousAt = null;
+  return cumulative.flatMap(sample => {
+    const at = Date.parse(sample.at);
+    if (previousAt !== null && at - previousAt > 12 * 60 * 1000) segment = [];
+    previousAt = at;
+    segment.push(sample);
+    const cutoff = at - 60 * 60 * 1000;
+    const baseline = segment.filter(candidate => Date.parse(candidate.at) <= cutoff).at(-1);
+    if (!baseline || cutoff - Date.parse(baseline.at) > 12 * 60 * 1000) return [];
+    const elapsedHours = (at - Date.parse(baseline.at)) / (60 * 60 * 1000);
+    const completed = sample.completedTotal - baseline.completedTotal;
+    if (elapsedHours <= 0 || completed < 0) {
+      segment = [sample];
+      return [];
+    }
+    return [{ at: sample.at, rate: completed / elapsedHours }];
   });
 }
 
@@ -10228,6 +10301,64 @@ function exactReviewTrend(samples, label) {
   const rangeLabel = activeHealthRange === "7d" ? "7d ago" : activeHealthRange + " ago";
   const axis = '<text class="trend-axis-label" x="' + plot.left + '" y="' + (height - 7) + '">' + rangeLabel + '</text><text class="trend-axis-label" x="' + (plot.left + plot.width) + '" y="' + (height - 7) + '" text-anchor="end">now</text>';
   return '<div class="exact-trend"><div class="exact-trend-status ' + direction.className + '">' + esc(direction.label) + '</div><svg class="exact-trend-svg" viewBox="0 0 ' + width + " " + height + '" role="img" aria-label="' + esc(label + " pending backlog over " + activeHealthRange) + '">' + grid + '<path class="exact-trend-line" d="' + trendPath(geometry) + '"></path>' + points + axis + '</svg></div>';
+}
+
+function publicationRateDirection(samples) {
+  if (!samples.length) return { className: "collecting", label: "Collecting rate trend" };
+  const latest = samples.at(-1);
+  const cutoff = Date.parse(latest.at) - 60 * 60 * 1000;
+  const previous = samples.filter(sample => Date.parse(sample.at) <= cutoff).at(-1);
+  if (!previous || cutoff - Date.parse(previous.at) > 12 * 60 * 1000) {
+    return { className: "collecting", label: "Collecting rate trend" };
+  }
+  const currentRate = Math.round(latest.rate);
+  const previousRate = Math.round(previous.rate);
+  if (currentRate === previousRate) {
+    return { className: "stable", label: "Stable · no change from the previous hour" };
+  }
+  if (previousRate === 0) {
+    return {
+      className: "speeding",
+      label: "Speeding up · from 0 to " + fmt.format(currentRate) + " / hour",
+    };
+  }
+  const percent = Math.round(((currentRate - previousRate) / previousRate) * 100);
+  return percent > 0
+    ? { className: "speeding", label: "Speeding up · +" + fmt.format(percent) + "% vs previous hour" }
+    : { className: "slowing", label: "Slowing down · −" + fmt.format(Math.abs(percent)) + "% vs previous hour" };
+}
+
+function publicationRateTrend(samples) {
+  const rates = publicationRateHistory(samples);
+  const rangeMs = activeHealthRange === "7d" ? 7 * 86400000 : activeHealthRange === "24h" ? 86400000 : 6 * 3600000;
+  const latestAt = rates.length ? Date.parse(rates.at(-1).at) : 0;
+  const toAt = Math.max(Date.now(), latestAt);
+  const fromAt = toAt - rangeMs;
+  const visible = rates.filter(sample => Date.parse(sample.at) >= fromAt && Date.parse(sample.at) <= toAt);
+  const latestVisible = visible.at(-1);
+  const current = latestVisible && toAt - Date.parse(latestVisible.at) <= 12 * 60 * 1000
+    ? latestVisible
+    : null;
+  const headline = current ? fmt.format(Math.round(current.rate)) + " / hour" : "Collecting";
+  if (!visible.length) {
+    return '<div class="publication-rate"><div class="lane-count"><span>Publication speed</span><strong>' + headline + '</strong></div><div class="exact-trend-status collecting">Collecting rate trend</div><div class="trend-empty">No publication speed history in this range.</div></div>';
+  }
+  const width = 600;
+  const height = 150;
+  const plot = { left: 48, top: 8, width: 540, height: 110 };
+  const scale = niceTrendScale(Math.max(1, ...visible.map(sample => sample.rate)), 4);
+  const grid = scale.ticks.map(value => {
+    const y = plot.top + plot.height - value / scale.maximum * plot.height;
+    return '<line class="trend-grid-line" x1="' + plot.left + '" x2="' + (plot.left + plot.width) + '" y1="' + y.toFixed(1) + '" y2="' + y.toFixed(1) + '"></line><text class="trend-axis-label" x="' + (plot.left - 8) + '" y="' + (y + 3).toFixed(1) + '" text-anchor="end">' + esc(formatTrendValue(value)) + '</text>';
+  }).join("");
+  const geometry = trendGeometry(visible, "rate", plot, scale.maximum, fromAt, toAt);
+  const points = geometry.map(point => '<circle class="publication-rate-point" cx="' + point.x.toFixed(1) + '" cy="' + point.y.toFixed(1) + '" r="3"></circle>').join("");
+  const direction = current
+    ? publicationRateDirection(visible)
+    : { className: "collecting", label: "Collecting rate trend" };
+  const rangeLabel = activeHealthRange === "7d" ? "7d ago" : activeHealthRange + " ago";
+  const axis = '<text class="trend-axis-label" x="' + plot.left + '" y="' + (height - 7) + '">' + rangeLabel + '</text><text class="trend-axis-label" x="' + (plot.left + plot.width) + '" y="' + (height - 7) + '" text-anchor="end">now</text>';
+  return '<div class="publication-rate"><div class="lane-count"><span>Publication speed</span><strong>' + headline + '</strong></div><div class="exact-trend-status ' + direction.className + '">' + esc(direction.label) + '</div><svg class="exact-trend-svg" viewBox="0 0 ' + width + " " + height + '" role="img" aria-label="Successful result publications per hour over ' + esc(activeHealthRange) + '">' + grid + '<path class="publication-rate-line" d="' + trendPath(geometry) + '"></path>' + points + axis + '</svg></div>';
 }
 
 function renderExecutionAlert(current) {
@@ -10358,6 +10489,7 @@ function renderExactReviewLanes(queue) {
       const sampledAt = samples.at(-1)?.at;
       return '<div class="exact-lane"><div class="exact-lane-head"><strong>' + esc(label) + '</strong><span>Live snapshot unavailable</span></div>' +
         exactReviewTrend(samples, label) +
+        (laneKey === "publication" ? publicationRateTrend(samples) : "") +
         '<div class="lane-foot">' + (sampledAt ? "Last sampled " + esc(since(sampledAt)) : "History starts with the next five-minute sample") + '</div></div>';
     }
     const capacity = Math.max(0, lane.capacity || 0);
@@ -10369,6 +10501,7 @@ function renderExactReviewLanes(queue) {
     return '<div class="exact-lane"><div class="exact-lane-head"><strong>' + esc(label) + '</strong><span>' + fmt.format(active) + ' of ' + fmt.format(capacity) + ' active</span></div>' +
       '<div class="lane-count"><span>Pending</span><strong>' + fmt.format(lane.pending || 0) + '</strong></div>' +
       exactReviewTrend(samples, label) +
+      (laneKey === "publication" ? publicationRateTrend(samples) : "") +
       '<div class="lane-counts">' +
       '<div class="lane-count"><span>Ready</span><strong>' + fmt.format(lane.ready || 0) + '</strong></div>' +
       '<div class="lane-count"><span>Backoff</span><strong>' + fmt.format(lane.backoff || 0) + '</strong></div>' +
@@ -10377,18 +10510,6 @@ function renderExactReviewLanes(queue) {
       '<div class="lane-bar"><i style="width:' + used + '%"></i></div>' +
       '<div class="lane-foot">' + fmt.format(lane.available_slots || 0) + ' ' + esc(label.toLowerCase()) + ' slots open' + esc(oldest) + '</div></div>';
   }).join("");
-}
-function renderControlPlane(controlPlane, workerBudget) {
-  const target = document.getElementById("control-plane");
-  if (!target) return;
-  const rows = [
-    ["Exact publishers", controlPlane?.publishers],
-    ["Comment routers", controlPlane?.comment_routers],
-    ["Lease reconcilers", controlPlane?.reconcilers]
-  ];
-  target.innerHTML = rows.map(([label, lane]) =>
-    '<div class="control-plane-row"><span>' + esc(label) + '</span><span>' + fmt.format(lane?.running || 0) + ' running · ' + fmt.format(lane?.waiting || 0) + ' waiting</span></div>'
-  ).join("") + '<div class="control-plane-note">These workflows consume GitHub runners but not the ' + fmt.format(workerBudget || 0) + '-slot Codex budget.</div>';
 }
 function renderExactReviewHandoff(queue) {
   const target = document.getElementById("exact-review-handoff");
@@ -10634,7 +10755,6 @@ function renderDashboard(data, note) {
   renderExecutionAlert(data.operational_health);
   renderSystemMap(data);
   renderExactReviewLanes(data.exact_review_queue);
-  renderControlPlane(data.control_plane, fleet.worker_budget);
   renderExactReviewHandoff(data.exact_review_queue);
   renderApplyHealth(data);
   renderAutomaticWork(data.automatic_work || []);

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -131,8 +131,7 @@ checkout, artifact handling, comment sync, and result routing are deterministic
 control-plane work: they consume GitHub runners, but not Codex slots. The
 comment router and the singleton lease reconciler follow the same accounting
 rule. Dashboard Codex capacity therefore counts only jobs whose steps execute
-Codex; it reports these control-plane workflows separately instead of deducting
-them from `workers.max`.
+Codex and does not deduct these control-plane workflows from `workers.max`.
 
 Each dispatched workflow claims its opaque lease before checkout. Protocol v2
 binds claim and completion to the item key, lease revision, run attempt, claim

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -169,13 +169,13 @@ ClawSweeper-owned closes for five minutes because those historical sections do
 not need worker-step freshness. The deployment smoke output includes cache
 state, fetch time, and current diagnostics.
 
-## Operational health history
+## Exact Review history
 
-A Cloudflare Cron Trigger records one aggregate operational-health sample every
-five minutes. The sampler requests only the five actionable GitHub Actions run
-statuses and never fetches job details, so history collection does not repeat
-the dashboard's bounded worker-detail fanout. Missing status responses make the
-sample `unknown` rather than silently healthy.
+A Cloudflare Cron Trigger records one Exact Review queue sample every five
+minutes. It reuses the queue status read that also performs scheduled queue
+maintenance and makes no GitHub Actions request. The sample contains each
+lane's pending backlog and a cumulative count of successfully completed Result
+publication items.
 
 Samples are stored in the existing `StatusStore` Durable Object under daily UTC
 keys named `health-history:YYYY-MM-DD`. Writes replace the current five-minute
@@ -183,34 +183,33 @@ slot, making retries and overlapping triggers idempotent. Buckets expire after
 the seven-day retention window plus one day of boundary margin. No health
 history is written to `openclaw/clawsweeper-state`.
 
-`GET /api/health-history?range=24h` returns the default chart range;
-`range=7d` returns the full retention window. The endpoint and the dashboard are
-read-only. A fresh deployment starts with an empty chart and accumulates its
-first point at the next five-minute trigger.
+`GET /api/health-history?range=6h` returns the dashboard's default chart range;
+`range=24h` and `range=7d` return the longer windows. The endpoint still accepts
+and returns legacy operational samples, but new samples omit those unused chart
+fields. Existing buckets expire naturally; no migration or manual cleanup is
+required.
 
-The operational headline uses the same snapshot as the chart:
+The Result publication speed chart derives a trailing hourly completion rate
+from the durable cumulative counter. Counting happens in the same queue storage
+transaction that terminalizes a successful publication, so retries, failures,
+review-lane work, and replayed completion requests do not inflate throughput.
+Counter history cannot be backfilled: the first rate appears after one hour of
+continuous samples, and comparison with the previous hour needs two hours.
+Telemetry gaps longer than 12 minutes break both backlog and speed lines.
+
+Operational health remains a current-snapshot alert rather than a historical
+chart. `/api/status` classifies the already-fetched active workflow runs as:
 
 - `healthy`: complete telemetry and no over-age runs;
 - `degraded`: at least one queued run is 30 minutes old;
 - `stalled`: at least one in-progress run is 150 minutes old;
 - `unknown`: one or more actionable-status reads failed.
 
-The trend section separates interpretation into two operator signals. Execution
-health is based only on in-progress runs crossing the 150-minute SLO. Queue load
-uses the direction of the over-30-minute backlog, because total queue depth also
-moves with incoming review demand. It reports busy-within-SLO, delayed and
-stable, growing backlog, or recovering without claiming that raw queue depth is
-a component failure.
-
-Every chart renders a labeled, adaptive y-axis. Duration axes switch between
-minutes, hours, and days as the range grows. `Oldest queued` remains a diagnostic
-outlier view rather than the primary queue-health signal: one stale GitHub
-queued record can dominate its scale even while the rest of the backlog drains.
-
-This history is intentionally aggregate and low-cost: at five-minute cadence it
-stores at most 2,016 samples over seven days. Use an external metrics backend
-only if longer retention, ad hoc aggregation, or Grafana-compatible querying is
-required.
+Healthy status stays hidden. A queued run over 30 minutes, an in-progress run
+over 150 minutes, or incomplete Actions telemetry opens the expandable “Work
+execution needs attention” alert. This live diagnostic reuses the status
+snapshot's Actions reads; the history cron no longer stores queue pressure or
+oldest-run values.
 
 ## Boundaries
 
@@ -288,10 +287,9 @@ For capacity displays, `/api/exact-review-queue` also exposes compatible
 `lanes.review` and `lanes.publication` objects. Each lane reports its own
 pending, ready, backoff, dispatching, leased, capacity, active, available-slot,
 oldest-pending, and next-attempt values. The existing top-level aggregate fields
-remain available for older consumers. `/api/status` separately reports active
-exact publishers, comment routers, and lease reconcilers under `control_plane`;
-those are GitHub Actions workflows, not Codex workers, and never reduce the
-128-slot Codex capacity rail.
+remain available for older consumers. The publication lane additionally reports
+`completed_total`. `/api/status` retains its `control_plane` compatibility field,
+but the dashboard no longer renders that low-actionability section.
 
 Executors report the GitHub job outcome from their finalizer. Failure or
 cancellation clears the lease and requeues the item. Finalizer success remains

--- a/test/dashboard-operational-health.test.ts
+++ b/test/dashboard-operational-health.test.ts
@@ -3,7 +3,6 @@ import test from "node:test";
 
 import {
   exactReviewHistorySample,
-  healthHistorySample,
   mergeHealthHistorySample,
   normalizeHealthHistorySample,
   summarizeOperationalHealth,
@@ -13,6 +12,20 @@ const CHECKED_AT = "2026-07-15T14:00:00Z";
 
 function run(status: string, createdAt: string) {
   return { status, created_at: createdAt };
+}
+
+function legacyHistorySample() {
+  return {
+    at: CHECKED_AT,
+    status: "healthy" as const,
+    queued: 0,
+    queued_over_30m: 0,
+    oldest_queued_minutes: 0,
+    running: 0,
+    running_over_150m: 0,
+    oldest_running_minutes: 0,
+    collection_ok: true,
+  };
 }
 
 test("operational health classifies over-age queue pressure and stuck runs", () => {
@@ -75,7 +88,7 @@ test("health history replaces duplicate five-minute slots", () => {
     CHECKED_AT,
     true,
   );
-  const first = healthHistorySample(health);
+  const first = { ...legacyHistorySample(), status: health.status };
   const replacement = { ...first, at: "2026-07-15T14:04:59Z", queued: 2 };
   const next = mergeHealthHistorySample([first], replacement);
   assert.equal(next.length, 1);
@@ -89,17 +102,24 @@ test("health history replaces duplicate five-minute slots", () => {
 });
 
 test("health history preserves legacy samples and normalizes exact-review backlog", () => {
-  const legacy = healthHistorySample(summarizeOperationalHealth([], CHECKED_AT, true));
+  const legacy = legacyHistorySample();
   assert.deepEqual(normalizeHealthHistorySample(legacy), legacy);
 
   const exactReview = exactReviewHistorySample({
-    lanes: { review: { pending: 317 }, publication: { pending: 1502 } },
+    lanes: {
+      review: { pending: 317 },
+      publication: { pending: 1502, completed_total: 42 },
+    },
   });
   const normalized = normalizeHealthHistorySample({ ...legacy, exact_review: exactReview });
   assert.deepEqual(normalized?.exact_review, {
     collection_ok: true,
     review: { pending: 317 },
-    publication: { pending: 1502 },
+    publication: { pending: 1502, completed_total: 42 },
+  });
+  assert.deepEqual(normalizeHealthHistorySample({ at: CHECKED_AT, exact_review: exactReview }), {
+    at: CHECKED_AT,
+    exact_review: exactReview,
   });
   assert.deepEqual(exactReviewHistorySample(null), { collection_ok: false });
   assert.equal(
@@ -112,7 +132,7 @@ test("health history preserves legacy samples and normalizes exact-review backlo
 });
 
 test("health history rejects non-finite or incomplete samples", () => {
-  const sample = healthHistorySample(summarizeOperationalHealth([], CHECKED_AT, true));
+  const sample = legacyHistorySample();
   assert.equal(normalizeHealthHistorySample({ ...sample, queued: "Infinity" }), null);
   const { running, ...incomplete } = sample;
   assert.equal(running, 0);

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -203,6 +203,99 @@ test("signed claimed-run snapshot feeds tuple-safe terminal reconciliation", asy
   });
 });
 
+test("exact-review queue counts only terminal successful publications", async () => {
+  const storage = new MemoryDurableStorage();
+  const directPublication = leasedExactReviewQueueItem(703, "7030");
+  directPublication.decision.sourceAction = "exact_review_artifact_publish";
+  directPublication.leaseDecision.sourceAction = "exact_review_artifact_publish";
+  const reconciledPublication = leasedExactReviewQueueItem(704, "7040");
+  reconciledPublication.decision.sourceAction = "exact_review_artifact_publish";
+  reconciledPublication.leaseDecision.sourceAction = "exact_review_artifact_publish";
+  const failedPublication = leasedExactReviewQueueItem(705, "7050");
+  failedPublication.decision.sourceAction = "exact_review_artifact_publish";
+  failedPublication.leaseDecision.sourceAction = "exact_review_artifact_publish";
+  const driftPublication = leasedExactReviewQueueItem(707, "7070");
+  driftPublication.decision.sourceAction = "exact_review_artifact_publish";
+  driftPublication.leaseDecision.sourceAction = "exact_review_artifact_publish";
+  const review = leasedExactReviewQueueItem(706, "7060");
+  await storage.put("exact-review-queue", {
+    deliveries: {},
+    items: Object.fromEntries(
+      [directPublication, reconciledPublication, failedPublication, driftPublication, review].map(
+        (item) => [item.key, item],
+      ),
+    ),
+  });
+  const queue = new ExactReviewQueue({ storage }, {});
+  const complete = (
+    item: ReturnType<typeof leasedExactReviewQueueItem>,
+    outcome: string,
+    requeueLatest = false,
+  ) =>
+    queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/complete", {
+        method: "POST",
+        body: JSON.stringify({
+          lease_id: item.leaseId,
+          item_key: item.key,
+          lease_revision: item.leaseRevision,
+          claim_generation: item.claimGeneration,
+          run_id: item.claimedRunId,
+          run_attempt: item.claimedRunAttempt,
+          outcome,
+          ...(requeueLatest ? { requeue_latest: true } : {}),
+        }),
+      }),
+    );
+
+  assert.equal((await complete(directPublication, "success")).status, 200);
+  assert.equal((await complete(review, "success")).status, 200);
+  assert.equal((await complete(failedPublication, "failure")).status, 200);
+  assert.equal((await complete(driftPublication, "success", true)).status, 200);
+  assert.equal((await complete(directPublication, "success")).status, 409);
+
+  const reconcileBody = {
+    runs: [
+      {
+        run_id: reconciledPublication.claimedRunId,
+        run_attempt: reconciledPublication.claimedRunAttempt,
+        claimed_run_attempt: reconciledPublication.claimedRunAttempt,
+        claim_generation: reconciledPublication.claimGeneration,
+        outcome: "success",
+      },
+    ],
+  };
+  const reconciled = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/reconcile", {
+      method: "POST",
+      body: JSON.stringify(reconcileBody),
+    }),
+  );
+  assert.deepEqual(await reconciled.json(), {
+    ok: true,
+    reconciled: 1,
+    requeued: 0,
+    completed: 1,
+  });
+  assert.equal(
+    (
+      await queue.fetch(
+        new Request("https://clawsweeper-exact-review-queue/reconcile", {
+          method: "POST",
+          body: JSON.stringify(reconcileBody),
+        }),
+      )
+    ).status,
+    200,
+  );
+
+  const stats = await (
+    await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(stats.lanes.publication.completed_total, 2);
+  assert.equal(stats.lanes.publication.pending, 2);
+});
+
 test("exact-review queue admits and wakes up to 24 publishers", () => {
   const now = 1_000_000;
   const publication = (number: number) => ({
@@ -1640,7 +1733,7 @@ test("dashboard health history persists five-minute samples and serves a bounded
   }
 });
 
-test("dashboard cron records health with status-only GitHub queries", async () => {
+test("dashboard cron records only exact-review history without GitHub queries", async () => {
   const originalFetch = globalThis.fetch;
   const storage = new MemoryDurableStorage();
   const store = new StatusStore({ storage });
@@ -1654,7 +1747,10 @@ test("dashboard cron records health with status-only GitHub queries", async () =
         queueReads += 1;
         return jsonResponse({
           handoff_health: { status: "healthy" },
-          lanes: { review: { pending: 17 }, publication: { pending: 29 } },
+          lanes: {
+            review: { pending: 17 },
+            publication: { pending: 29, completed_total: 123 },
+          },
         });
       },
     }),
@@ -1689,9 +1785,8 @@ test("dashboard cron records health with status-only GitHub queries", async () =
       { waitUntil: (promise) => (recording = promise) },
     );
     await recording;
-    assert.equal(requests.length, 5);
+    assert.equal(requests.length, 0);
     assert.equal(queueReads, 1);
-    assert.ok(requests.every((url) => !url.includes("/jobs")));
 
     const response = await worker.fetch(
       new Request("https://clawsweeper.openclaw.ai/api/health-history?range=24h"),
@@ -1699,12 +1794,12 @@ test("dashboard cron records health with status-only GitHub queries", async () =
     );
     const history = await response.json();
     assert.equal(history.samples.length, 1);
-    assert.equal(history.samples[0].status, "unknown");
-    assert.equal(history.samples[0].queued, 100);
-    assert.equal(history.samples[0].queued_over_30m, 1);
+    assert.equal(history.samples[0].status, undefined);
+    assert.equal(history.samples[0].queued, undefined);
     assert.equal(history.samples[0].exact_review.collection_ok, true);
     assert.equal(history.samples[0].exact_review.review.pending, 17);
     assert.equal(history.samples[0].exact_review.publication.pending, 29);
+    assert.equal(history.samples[0].exact_review.publication.completed_total, 123);
 
     let failureRecording: Promise<unknown> | undefined;
     await worker.scheduled(
@@ -1726,7 +1821,7 @@ test("dashboard cron records health with status-only GitHub queries", async () =
     );
     const failedQueueHistory = await afterFailure.json();
     assert.equal(failedQueueHistory.samples.length, 1);
-    assert.equal(failedQueueHistory.samples[0].queued, 100);
+    assert.equal(failedQueueHistory.samples[0].queued, undefined);
     assert.deepEqual(failedQueueHistory.samples[0].exact_review, { collection_ok: false });
   } finally {
     globalThis.fetch = originalFetch;
@@ -4959,12 +5054,11 @@ test("dashboard HTML preserves UTF-8 emoji labels", async () => {
   assert.match(html, /id="exact-review-lanes"/);
   assert.match(html, /Review admission/);
   assert.match(html, /Result publication/);
-  assert.match(html, /Control Plane · GitHub Actions, not Codex/);
-  assert.match(html, /id="control-plane"/);
+  assert.doesNotMatch(html, /Control Plane · GitHub Actions, not Codex/);
+  assert.doesNotMatch(html, /id="control-plane"/);
   assert.match(html, /\.exact-lanes \{ grid-template-columns: 1fr; \}/);
   assert.ok(html.indexOf("Codex Capacity") < html.indexOf('id="exact-review-lanes"'));
-  assert.ok(html.indexOf('id="exact-review-lanes"') < html.indexOf('id="control-plane"'));
-  assert.ok(html.indexOf('id="control-plane"') < html.indexOf("Handoff Health"));
+  assert.ok(html.indexOf('id="exact-review-lanes"') < html.indexOf("Handoff Health"));
   assert.match(html, /Live terminals/);
   assert.match(html, /href="https:\/\/fleet\.example\.test\/terminal\?view=live&amp;mode=all"/);
   assert.match(html, /Loading pipeline state/);
@@ -5196,9 +5290,6 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
   assert.match(elementFor("exact-review-lanes").innerHTML, /Result publication/);
   assert.match(elementFor("exact-review-lanes").innerHTML, /3 result publication slots open/);
   assert.match(elementFor("exact-review-lanes").innerHTML, /No backlog history in this range/);
-  assert.match(elementFor("control-plane").innerHTML, /2 running · 1 waiting/);
-  assert.match(elementFor("control-plane").innerHTML, /GitHub runners but not the 128-slot/);
-
   status.workers = Array.from({ length: 130 }, (_, id) => ({ id, status: "in_progress" }));
   context.renderSystemMap(status);
   assert.match(elementFor("capacity-rail").innerHTML, /130 running/);
@@ -5280,13 +5371,16 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
 
   let resolve24HourHistory: ((response: unknown) => void) | undefined;
   const now = Date.now();
-  const samples = Array.from({ length: 13 }, (_, index) => ({
-    at: new Date(now - (12 - index) * 5 * 60_000).toISOString(),
+  const samples = Array.from({ length: 25 }, (_, index) => ({
+    at: new Date(now - (24 - index) * 5 * 60_000).toISOString(),
     collection_ok: true,
     exact_review: {
       collection_ok: true,
       review: { pending: 100 + index },
-      publication: { pending: 200 - index },
+      publication: {
+        pending: 200 - index,
+        completed_total: index <= 12 ? index * 5 : 60 + (index - 12) * 10,
+      },
     },
   }));
   context.fetch = async (input: string) => {
@@ -5308,6 +5402,10 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
   const laneHtml = elementFor("exact-review-lanes").innerHTML;
   assert.match(laneHtml, /Growing · \+12 in the last hour/);
   assert.match(laneHtml, /Draining · −12 in the last hour/);
+  assert.match(laneHtml, /Publication speed/);
+  assert.match(laneHtml, /120 \/ hour/);
+  assert.match(laneHtml, /Speeding up · \+100% vs previous hour/);
+  assert.match(laneHtml, /role="img" aria-label="Successful result publications per hour over 7d"/);
   assert.match(laneHtml, /role="img" aria-label="Review admission pending backlog over 7d"/);
   assert.match(laneHtml, /Live snapshot unavailable/);
   assert.match(laneHtml, /Last sampled/);
@@ -5322,6 +5420,14 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
   );
   assert.match(smallAxis, />8<\/text>/);
   assert.match(largeAxis, />2,000<\/text>/);
+  const staleRate = context.publicationRateTrend(
+    Array.from({ length: 13 }, (_, index) => ({
+      at: new Date(now - (80 - index * 5) * 60_000).toISOString(),
+      completedTotal: index * 5,
+    })),
+  );
+  assert.match(staleRate, /Publication speed<\/span><strong>Collecting/);
+  assert.doesNotMatch(staleRate, /60 \/ hour/);
 
   assert.equal(
     context.oneHourTrend(samples.slice(0, 1).map((sample) => ({ at: sample.at, pending: 4 })))
@@ -5331,6 +5437,30 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
   assert.equal(
     context.oneHourTrend(samples.map((sample) => ({ at: sample.at, pending: 9 }))).label,
     "Stable · no change in the last hour",
+  );
+  assert.equal(
+    context.publicationRateDirection([
+      { at: new Date(now - 60 * 60_000).toISOString(), rate: 100 },
+      { at: new Date(now).toISOString(), rate: 50 },
+    ]).label,
+    "Slowing down · −50% vs previous hour",
+  );
+  assert.equal(
+    context.publicationRateDirection([
+      { at: new Date(now - 60 * 60_000).toISOString(), rate: 50 },
+      { at: new Date(now).toISOString(), rate: 50 },
+    ]).label,
+    "Stable · no change from the previous hour",
+  );
+  assert.equal(
+    context.publicationRateHistory([
+      ...Array.from({ length: 13 }, (_, index) => ({
+        at: new Date(now - (130 - index * 5) * 60_000).toISOString(),
+        completedTotal: index * 5,
+      })),
+      { at: new Date(now).toISOString(), completedTotal: 120 },
+    ]).length,
+    1,
   );
   const broken = context.trendGeometry(
     [


### PR DESCRIPTION
## Summary

- add a Result publication speed chart based on durable successful publication completions
- show speeding up, slowing down, stable, collecting, stale, and telemetry-gap states without inferring throughput from backlog movement
- remove the always-visible Control Plane section while keeping its compatibility API field
- stop persisting the retired Health Trends operational fields and remove the five extra scheduled GitHub Actions queries; the live anomaly alert still uses current operational telemetry

## Why

Pending backlog shows net queue movement, but it cannot distinguish arrivals from completed publications. A separate completion-rate series makes publication throttling or throughput regressions visible even when incoming work changes at the same time.

## Design

```text
EXACT REVIEW                                      [ 6h ] [ 24h ] [ 7d ]

┌──────────────────────────────────┬──────────────────────────────────┐
│ REVIEW ADMISSION                 │ RESULT PUBLICATION               │
│                                  │                                  │
│ Pending                      317 │ Pending                    1,502 │
│ Growing · +42 in the last hour   │ Draining · −186 in the last hour │
│ [pending backlog trend]          │ [pending backlog trend]          │
│                                  │                                  │
│                                  │ Publication speed      606 / hour│
│                                  │ Slowing down · −18% vs prev hour │
│                                  │ [successful publications / hour] │
│                                  │                                  │
│ Ready / Backoff / Active counts  │ Ready / Backoff / Active counts  │
└──────────────────────────────────┴──────────────────────────────────┘

HANDOFF HEALTH
```

Mobile remains range controls first, then Review admission and Result publication as a single-column stack.

## Telemetry and compatibility

- the queue stores a monotonic `publication_completed_total` in a dedicated singleton SQL table
- direct completion and terminal reconciliation increment it in the same transaction that removes a successful publication item
- failures, cancellations, review-lane work, retries, source-drift requeues, and replayed completions do not increment it
- five-minute history samples add optional `exact_review.publication.completed_total`; old history samples remain readable
- old operational history buckets expire naturally under the existing seven-day TTL; no migration or manual cleanup is required
- current queued/running age telemetry remains in `/api/status` for the anomaly-only execution alert

## Validation

- Node 24 focused dashboard tests
- `pnpm run check`
- `git diff --check`
- Codex autoreview: clean, no accepted/actionable findings
