### PR TITLE
feat(scheduler): throttle background lanes under exact-review queue pressure

### DIFF
--- a/.github/workflows/commit-review.yml
+++ b/.github/workflows/commit-review.yml
@@ -164,6 +164,11 @@ jobs:
           SOURCE_REF: ${{ github.event.client_payload.ref || 'refs/heads/main' }}
           SETTLE_SECONDS: ${{ vars.CLAWSWEEPER_COMMIT_REVIEW_SETTLE_SECONDS || '60' }}
           PAGE_SIZE: ${{ vars.CLAWSWEEPER_COMMIT_REVIEW_PAGE_SIZE || '' }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          CLAWSWEEPER_QUEUE_PRESSURE_SOFT_PENDING: ${{ vars.CLAWSWEEPER_QUEUE_PRESSURE_SOFT_PENDING || '' }}
+          CLAWSWEEPER_QUEUE_PRESSURE_HARD_PENDING: ${{ vars.CLAWSWEEPER_QUEUE_PRESSURE_HARD_PENDING || '' }}
+          CLAWSWEEPER_QUEUE_PRESSURE_SOFT_AGE_MS: ${{ vars.CLAWSWEEPER_QUEUE_PRESSURE_SOFT_AGE_MS || '' }}
+          CLAWSWEEPER_QUEUE_PRESSURE_HARD_AGE_MS: ${{ vars.CLAWSWEEPER_QUEUE_PRESSURE_HARD_AGE_MS || '' }}
         run: |
           set -euo pipefail
           active_runs_json() {
@@ -251,10 +256,22 @@ jobs:
               | STALE_QUEUED_CUTOFF="$STALE_QUEUED_CUTOFF" jq '[.[] | select(.workflowPath == ".github/workflows/sweep.yml") | select((.status == "in_progress" or ((.status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") and ((.updatedAt // .createdAt // "") >= env.STALE_QUEUED_CUTOFF))) and (.displayTitle | startswith("Review event item ")))] | length' 2>/dev/null \
               || printf '0'
           }
+          # An explicit CLAWSWEEPER_COMMIT_REVIEW_PAGE_SIZE is an operator escape hatch:
+          # it bypasses the derived budget entirely, including active-load yielding and
+          # queue-pressure throttling, exactly like it bypassed load yielding before.
           if [ -z "$PAGE_SIZE" ]; then
             active_critical_workers="$(( $(active_run_count ".github/workflows/repair-cluster-worker.yml") + $(active_sweep_exact_count) ))"
             active_background_workers="$(active_sweep_background_workers)"
-            PAGE_SIZE="$(pnpm --dir clawsweeper run --silent workflow -- worker-limit commit_review --active-critical "$active_critical_workers" --active-background "$active_background_workers")"
+            unpressured_page_size="$(pnpm --dir clawsweeper run --silent workflow -- worker-limit commit_review --active-critical "$active_critical_workers" --active-background "$active_background_workers")"
+            if ! pressure_json="$(pnpm --dir clawsweeper run --silent workflow -- queue-pressure --queue-url "$QUEUE_URL")"; then
+              pressure_json='{"ok":false,"reason":"probe_failed","level":"none"}'
+            fi
+            if ! pressure_level="$(printf '%s' "$pressure_json" | jq -er '.level | select(. == "none" or . == "soft" or . == "hard")' 2>/dev/null)"; then
+              pressure_level="none"
+            fi
+            PAGE_SIZE="$(pnpm --dir clawsweeper run --silent workflow -- worker-limit commit_review --active-critical "$active_critical_workers" --active-background "$active_background_workers" --pressure-level "$pressure_level")"
+            pressure_numbers="$(printf '%s' "$pressure_json" | jq -r 'if .ok then "pending=\(.pendingCount), oldest=\((.oldestPendingAgeMs / 3600000 * 10 | round) / 10)h" else "unavailable=\(.reason)" end' 2>/dev/null || printf 'unavailable=probe_failed')"
+            echo "queue pressure: $pressure_level ($pressure_numbers) — commit_review $unpressured_page_size->$PAGE_SIZE"
           fi
           page_size_hard_cap="$(pnpm --dir clawsweeper run --silent workflow -- limit commit_review.page_size_hard_cap)"
           if [ "$ENABLED" = "false" ]; then

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2104,6 +2104,11 @@ jobs:
       - id: mode
         env:
           GH_TOKEN: ${{ github.token }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          CLAWSWEEPER_QUEUE_PRESSURE_SOFT_PENDING: ${{ vars.CLAWSWEEPER_QUEUE_PRESSURE_SOFT_PENDING || '' }}
+          CLAWSWEEPER_QUEUE_PRESSURE_HARD_PENDING: ${{ vars.CLAWSWEEPER_QUEUE_PRESSURE_HARD_PENDING || '' }}
+          CLAWSWEEPER_QUEUE_PRESSURE_SOFT_AGE_MS: ${{ vars.CLAWSWEEPER_QUEUE_PRESSURE_SOFT_AGE_MS || '' }}
+          CLAWSWEEPER_QUEUE_PRESSURE_HARD_AGE_MS: ${{ vars.CLAWSWEEPER_QUEUE_PRESSURE_HARD_AGE_MS || '' }}
         run: |
           limit() {
             pnpm --dir clawsweeper run --silent workflow -- limit "$1"
@@ -2240,10 +2245,25 @@ jobs:
           commit_page_size="$(limit commit_review.page_size_default)"
           active_critical_workers="$(( $(active_run_count ".github/workflows/repair-cluster-worker.yml") + $(active_sweep_exact_workers) ))"
           active_background_workers="$(( $(active_run_count ".github/workflows/commit-review.yml") * commit_page_size + $(active_sweep_background_workers) ))"
-          hot_intake_shards="$(worker_limit hot_intake --active-critical "$active_critical_workers" --active-background "$active_background_workers")"
-          normal_shards="$(worker_limit normal_review --active-critical "$active_critical_workers" --active-background "$active_background_workers")"
-          hot_intake="${{ ((github.event_name == 'repository_dispatch' && github.event.client_payload.hot_intake == 'true') || (github.event_name == 'workflow_dispatch' && github.event.inputs.hot_intake == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '*/5 * * * *' || github.event.schedule == '2/5 * * * *'))) && 'true' || 'false' }}"
           exact_item="${{ github.event.client_payload.item_number || github.event.inputs.item_number || github.event.inputs.item_numbers || '' }}"
+          pressure_level="none"
+          hot_intake_unpressured="$(worker_limit hot_intake --active-critical "$active_critical_workers" --active-background "$active_background_workers")"
+          normal_unpressured="$(worker_limit normal_review --active-critical "$active_critical_workers" --active-background "$active_background_workers")"
+          if [ -z "$exact_item" ]; then
+            if ! pressure_json="$(pnpm --dir clawsweeper run --silent workflow -- queue-pressure --queue-url "$QUEUE_URL")"; then
+              pressure_json='{"ok":false,"reason":"probe_failed","level":"none"}'
+            fi
+            if ! pressure_level="$(printf '%s' "$pressure_json" | jq -er '.level | select(. == "none" or . == "soft" or . == "hard")' 2>/dev/null)"; then
+              pressure_level="none"
+            fi
+          fi
+          hot_intake_shards="$(worker_limit hot_intake --active-critical "$active_critical_workers" --active-background "$active_background_workers" --pressure-level "$pressure_level")"
+          normal_shards="$(worker_limit normal_review --active-critical "$active_critical_workers" --active-background "$active_background_workers" --pressure-level "$pressure_level")"
+          if [ -z "$exact_item" ]; then
+            pressure_numbers="$(printf '%s' "$pressure_json" | jq -r 'if .ok then "pending=\(.pendingCount), oldest=\((.oldestPendingAgeMs / 3600000 * 10 | round) / 10)h" else "unavailable=\(.reason)" end' 2>/dev/null || printf 'unavailable=probe_failed')"
+            echo "queue pressure: $pressure_level ($pressure_numbers) — hot_intake $hot_intake_unpressured->$hot_intake_shards, normal_review $normal_unpressured->$normal_shards"
+          fi
+          hot_intake="${{ ((github.event_name == 'repository_dispatch' && github.event.client_payload.hot_intake == 'true') || (github.event_name == 'workflow_dispatch' && github.event.inputs.hot_intake == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '*/5 * * * *' || github.event.schedule == '2/5 * * * *'))) && 'true' || 'false' }}"
           target_repo="${{ steps.target.outputs.target_repo }}"
           if [ "$hot_intake" = "true" ] && [ -n "$exact_item" ]; then
             batch_size="1"

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -103,6 +103,33 @@ The scheduler does this for background lanes:
 6. cap the result at the lane's derived quiet-system ceiling
 7. return at least 1 so an enabled lane can still make slow progress
 
+The normal result is then reduced when the exact-review queue is under pressure.
+Each planner reads the public, unauthenticated `GET /api/exact-review-queue`
+endpoint once and uses its top-level pending count and oldest-pending age. A
+failed, timed-out, or malformed response is treated as no pressure so a dashboard
+outage cannot stall reviews.
+
+| Tier   | Trigger, either condition                                          | Background budget                         |
+| ------ | ------------------------------------------------------------------ | ----------------------------------------- |
+| none   | Below both soft thresholds                                         | Normal dynamic budget                     |
+| soft   | At least 150 pending or oldest pending is at least 30 minutes      | `ceil(normal dynamic budget * 0.5)`       |
+| hard   | At least 400 pending or oldest pending is at least 2 hours         | `max(1, floor(normal dynamic budget * 0.1))` |
+
+The thresholds can be overridden with repository variables or process
+environment variables. Values are non-negative counts or millisecond durations;
+unset, empty, or invalid values use the defaults.
+
+| Environment variable                              | Default   |
+| ------------------------------------------------- | --------: |
+| `CLAWSWEEPER_QUEUE_PRESSURE_SOFT_PENDING`          |       150 |
+| `CLAWSWEEPER_QUEUE_PRESSURE_HARD_PENDING`          |       400 |
+| `CLAWSWEEPER_QUEUE_PRESSURE_SOFT_AGE_MS`           |   1800000 |
+| `CLAWSWEEPER_QUEUE_PRESSURE_HARD_AGE_MS`           |   7200000 |
+
+Only normal review, hot intake, and commit review use this pressure multiplier.
+Repair, assist, issue implementation, cluster repair, and exact-item review keep
+their existing priority budgets.
+
 Background planner jobs serialize per target repository. A sweep that is still
 planning, queued, or expanding its matrix reserves its quiet lane size. Once
 its shard jobs exist and all finish, its publish phase counts as zero workers,

--- a/src/limits.ts
+++ b/src/limits.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import type { QueuePressureLevel } from "./queue-pressure.js";
 
 export type WorkerConfig = {
   workers: {
@@ -102,11 +103,13 @@ export function workerLimit(
   {
     activeCritical = 0,
     activeBackground = 0,
+    pressureLevel = "none",
     config = WORKER_CONFIG,
     limits = AUTOMATION_LIMITS,
   }: {
     activeCritical?: number;
     activeBackground?: number;
+    pressureLevel?: QueuePressureLevel;
     config?: WorkerConfig;
     limits?: AutomationLimits;
   } = {},
@@ -148,7 +151,10 @@ export function workerLimit(
     if (rawAvailable <= 0) return 1;
     const withFloor =
       rawAvailable >= config.workers.minimum_background ? rawAvailable : Math.max(1, rawAvailable);
-    return Math.max(1, Math.min(laneMax, withFloor));
+    const normalBudget = Math.max(1, Math.min(laneMax, withFloor));
+    if (pressureLevel === "soft") return Math.ceil(normalBudget * 0.5);
+    if (pressureLevel === "hard") return Math.max(1, Math.floor(normalBudget * 0.1));
+    return normalBudget;
   }
 }
 

--- a/src/queue-pressure.ts
+++ b/src/queue-pressure.ts
@@ -1,0 +1,120 @@
+export const QUEUE_PRESSURE_SOFT_PENDING = 150;
+export const QUEUE_PRESSURE_HARD_PENDING = 400;
+export const QUEUE_PRESSURE_SOFT_AGE_MS = 30 * 60 * 1_000;
+export const QUEUE_PRESSURE_HARD_AGE_MS = 2 * 60 * 60 * 1_000;
+export const QUEUE_PRESSURE_FETCH_TIMEOUT_MS = 5_000;
+
+export type QueuePressureLevel = "none" | "soft" | "hard";
+
+export type ExactReviewQueuePressure =
+  | {
+      ok: true;
+      pendingCount: number;
+      oldestPendingAgeMs: number;
+    }
+  | {
+      ok: false;
+      reason: string;
+    };
+
+type FetchExactReviewQueuePressureOptions = {
+  queueUrl: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+};
+
+export async function fetchExactReviewQueuePressure({
+  queueUrl,
+  fetchImpl = fetch,
+  timeoutMs = QUEUE_PRESSURE_FETCH_TIMEOUT_MS,
+}: FetchExactReviewQueuePressureOptions): Promise<ExactReviewQueuePressure> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(
+      new URL("/api/exact-review-queue", `${queueUrl.replace(/\/+$/, "")}/`),
+      { signal: controller.signal },
+    );
+    if (!response.ok) return { ok: false, reason: `http_${response.status}` };
+
+    const body: unknown = await response.json();
+    if (!isRecord(body)) return malformedPressure();
+    const pendingCount = body.pending;
+    const oldestPendingAgeSeconds = body.oldest_pending_age_seconds;
+    if (!isNonNegativeInteger(pendingCount)) return malformedPressure();
+    if (pendingCount === 0 && oldestPendingAgeSeconds === null) {
+      return { ok: true, pendingCount, oldestPendingAgeMs: 0 };
+    }
+    if (!isNonNegativeNumber(oldestPendingAgeSeconds)) return malformedPressure();
+    const oldestPendingAgeMs = oldestPendingAgeSeconds * 1_000;
+    if (!Number.isFinite(oldestPendingAgeMs)) return malformedPressure();
+    return {
+      ok: true,
+      pendingCount,
+      oldestPendingAgeMs,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      reason: controller.signal.aborted ? "timeout" : errorReason(error),
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function queuePressureLevel(pressure: ExactReviewQueuePressure): QueuePressureLevel {
+  if (!pressure.ok) return "none";
+  const hardPending = envThreshold(
+    "CLAWSWEEPER_QUEUE_PRESSURE_HARD_PENDING",
+    QUEUE_PRESSURE_HARD_PENDING,
+  );
+  const hardAgeMs = envThreshold(
+    "CLAWSWEEPER_QUEUE_PRESSURE_HARD_AGE_MS",
+    QUEUE_PRESSURE_HARD_AGE_MS,
+  );
+  if (pressure.pendingCount >= hardPending || pressure.oldestPendingAgeMs >= hardAgeMs) {
+    return "hard";
+  }
+
+  const softPending = envThreshold(
+    "CLAWSWEEPER_QUEUE_PRESSURE_SOFT_PENDING",
+    QUEUE_PRESSURE_SOFT_PENDING,
+  );
+  const softAgeMs = envThreshold(
+    "CLAWSWEEPER_QUEUE_PRESSURE_SOFT_AGE_MS",
+    QUEUE_PRESSURE_SOFT_AGE_MS,
+  );
+  if (pressure.pendingCount >= softPending || pressure.oldestPendingAgeMs >= softAgeMs) {
+    return "soft";
+  }
+  return "none";
+}
+
+function envThreshold(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function malformedPressure(): ExactReviewQueuePressure {
+  return { ok: false, reason: "malformed_response" };
+}
+
+function errorReason(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) return error.message.trim();
+  return "fetch_failed";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNonNegativeNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return isNonNegativeNumber(value) && Number.isInteger(value);
+}

--- a/src/repair/limits.ts
+++ b/src/repair/limits.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { repoRoot } from "./paths.js";
+import type { QueuePressureLevel } from "../queue-pressure.js";
 
 export type WorkerConfig = {
   workers: {
@@ -119,11 +120,13 @@ export function workerLimit(
   {
     activeCritical = 0,
     activeBackground = 0,
+    pressureLevel = "none",
     config = WORKER_CONFIG,
     limits = AUTOMATION_LIMITS,
   }: {
     activeCritical?: number;
     activeBackground?: number;
+    pressureLevel?: QueuePressureLevel;
     config?: WorkerConfig;
     limits?: AutomationLimits;
   } = {},
@@ -166,7 +169,10 @@ export function workerLimit(
     if (rawAvailable <= 0) return 1;
     const withFloor =
       rawAvailable >= config.workers.minimum_background ? rawAvailable : Math.max(1, rawAvailable);
-    return Math.max(1, Math.min(laneMax, withFloor));
+    const normalBudget = Math.max(1, Math.min(laneMax, withFloor));
+    if (pressureLevel === "soft") return Math.ceil(normalBudget * 0.5);
+    if (pressureLevel === "hard") return Math.max(1, Math.floor(normalBudget * 0.1));
+    return normalBudget;
   }
 }
 

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -6,6 +6,11 @@ import { pathToFileURL } from "node:url";
 import { parseArgs } from "./lib.js";
 import { isJsonObject } from "./json-types.js";
 import { AUTOMATION_LIMITS, WORKER_CONFIG, workerLimit, type WorkerLane } from "./limits.js";
+import {
+  fetchExactReviewQueuePressure,
+  queuePressureLevel,
+  type QueuePressureLevel,
+} from "../queue-pressure.js";
 
 type ApplyAction = {
   action: string;
@@ -153,7 +158,7 @@ type AdaptiveApplyBatchSize = {
 
 const args = parseArgs(process.argv.slice(2));
 
-function runCli(): void {
+async function runCli(): Promise<void> {
   const command = args._[0];
   if (!command) throw new Error("workflow utility command is required");
 
@@ -267,10 +272,20 @@ function runCli(): void {
           workerLimit(requiredWorkerLane(optionalString("lane") || positionalString(1)), {
             activeCritical: numberArg("active-critical", 0),
             activeBackground: numberArg("active-background", 0),
+            pressureLevel: requiredQueuePressureLevel(optionalString("pressure-level") || "none"),
           }),
         ),
       );
       break;
+    case "queue-pressure": {
+      const pressure = await fetchExactReviewQueuePressure({
+        queueUrl: requiredString("queue-url"),
+      });
+      process.stdout.write(
+        `${JSON.stringify({ ...pressure, level: queuePressureLevel(pressure) })}\n`,
+      );
+      break;
+    }
     case "worker-config":
       process.stdout.write(JSON.stringify(WORKER_CONFIG, null, 2));
       break;
@@ -331,6 +346,11 @@ function requiredWorkerLane(value: string): WorkerLane {
   ]);
   if (allowed.has(value as WorkerLane)) return value as WorkerLane;
   throw new Error(`unknown worker lane: ${value}`);
+}
+
+function requiredQueuePressureLevel(value: string): QueuePressureLevel {
+  if (value === "none" || value === "soft" || value === "hard") return value;
+  throw new Error(`unknown queue pressure level: ${value}`);
 }
 
 export function automationLimit(limitPath: string): number {
@@ -2429,4 +2449,4 @@ function isCliEntrypoint(): boolean {
   return Boolean(entrypoint && import.meta.url === pathToFileURL(entrypoint).href);
 }
 
-if (isCliEntrypoint()) runCli();
+if (isCliEntrypoint()) await runCli();

--- a/test/queue-pressure.test.ts
+++ b/test/queue-pressure.test.ts
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { AUTOMATION_LIMITS, workerLimit, type WorkerLane } from "../dist/limits.js";
+import {
+  QUEUE_PRESSURE_HARD_AGE_MS,
+  QUEUE_PRESSURE_HARD_PENDING,
+  QUEUE_PRESSURE_SOFT_AGE_MS,
+  QUEUE_PRESSURE_SOFT_PENDING,
+  fetchExactReviewQueuePressure,
+  queuePressureLevel,
+  type ExactReviewQueuePressure,
+} from "../dist/queue-pressure.js";
+
+const PRESSURE_ENV_NAMES = [
+  "CLAWSWEEPER_QUEUE_PRESSURE_SOFT_PENDING",
+  "CLAWSWEEPER_QUEUE_PRESSURE_HARD_PENDING",
+  "CLAWSWEEPER_QUEUE_PRESSURE_SOFT_AGE_MS",
+  "CLAWSWEEPER_QUEUE_PRESSURE_HARD_AGE_MS",
+] as const;
+
+test("queue pressure levels include threshold boundaries", () => {
+  assert.equal(
+    queuePressureLevel(pressure(QUEUE_PRESSURE_SOFT_PENDING - 1, QUEUE_PRESSURE_SOFT_AGE_MS - 1)),
+    "none",
+  );
+  assert.equal(queuePressureLevel(pressure(QUEUE_PRESSURE_SOFT_PENDING, 0)), "soft");
+  assert.equal(queuePressureLevel(pressure(0, QUEUE_PRESSURE_SOFT_AGE_MS)), "soft");
+  assert.equal(queuePressureLevel(pressure(QUEUE_PRESSURE_HARD_PENDING, 0)), "hard");
+  assert.equal(queuePressureLevel(pressure(0, QUEUE_PRESSURE_HARD_AGE_MS)), "hard");
+  assert.equal(queuePressureLevel({ ok: false, reason: "unavailable" }), "none");
+});
+
+test("queue pressure levels honor environment overrides", () => {
+  withPressureEnv(
+    {
+      CLAWSWEEPER_QUEUE_PRESSURE_SOFT_PENDING: "10",
+      CLAWSWEEPER_QUEUE_PRESSURE_HARD_PENDING: "20",
+      CLAWSWEEPER_QUEUE_PRESSURE_SOFT_AGE_MS: "100",
+      CLAWSWEEPER_QUEUE_PRESSURE_HARD_AGE_MS: "200",
+    },
+    () => {
+      assert.equal(queuePressureLevel(pressure(9, 99)), "none");
+      assert.equal(queuePressureLevel(pressure(10, 0)), "soft");
+      assert.equal(queuePressureLevel(pressure(0, 100)), "soft");
+      assert.equal(queuePressureLevel(pressure(20, 0)), "hard");
+      assert.equal(queuePressureLevel(pressure(0, 200)), "hard");
+    },
+  );
+});
+
+test("queue pressure fetch reads public aggregate stats", async () => {
+  let requestedUrl = "";
+  const result = await fetchExactReviewQueuePressure({
+    queueUrl: "https://clawsweeper.example/base/",
+    fetchImpl: async (input) => {
+      requestedUrl = String(input);
+      return Response.json({ pending: 812, oldest_pending_age_seconds: 15_120 });
+    },
+  });
+
+  assert.equal(requestedUrl, "https://clawsweeper.example/api/exact-review-queue");
+  assert.deepEqual(result, { ok: true, pendingCount: 812, oldestPendingAgeMs: 15_120_000 });
+
+  const empty = await fetchExactReviewQueuePressure({
+    queueUrl: "https://clawsweeper.example",
+    fetchImpl: async () => Response.json({ pending: 0, oldest_pending_age_seconds: null }),
+  });
+  assert.deepEqual(empty, { ok: true, pendingCount: 0, oldestPendingAgeMs: 0 });
+});
+
+test("queue pressure fetch fails open on errors, timeouts, and malformed bodies", async () => {
+  const failed = await fetchExactReviewQueuePressure({
+    queueUrl: "https://clawsweeper.example",
+    fetchImpl: async () => {
+      throw new Error("network unavailable");
+    },
+  });
+  assert.deepEqual(failed, { ok: false, reason: "network unavailable" });
+  assert.equal(queuePressureLevel(failed), "none");
+
+  const timedOut = await fetchExactReviewQueuePressure({
+    queueUrl: "https://clawsweeper.example",
+    timeoutMs: 5,
+    fetchImpl: (_input, init) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+      }),
+  });
+  assert.deepEqual(timedOut, { ok: false, reason: "timeout" });
+  assert.equal(queuePressureLevel(timedOut), "none");
+
+  for (const body of [
+    null,
+    {},
+    { pending: "812", oldest_pending_age_seconds: 60 },
+    { pending: 1.5, oldest_pending_age_seconds: 60 },
+    { pending: 1, oldest_pending_age_seconds: Number.MAX_VALUE },
+  ]) {
+    const malformed = await fetchExactReviewQueuePressure({
+      queueUrl: "https://clawsweeper.example",
+      fetchImpl: async () => Response.json(body),
+    });
+    assert.deepEqual(malformed, { ok: false, reason: "malformed_response" });
+    assert.equal(queuePressureLevel(malformed), "none");
+  }
+});
+
+test("worker limits scale every background lane and leave priority lanes unchanged", () => {
+  const backgroundLanes: WorkerLane[] = ["normal_review", "hot_intake", "commit_review"];
+  for (const lane of backgroundLanes) {
+    const normalBudget = workerLimit(lane, { pressureLevel: "none" });
+    assert.equal(workerLimit(lane, { pressureLevel: "soft" }), Math.ceil(normalBudget * 0.5));
+    assert.equal(
+      workerLimit(lane, { pressureLevel: "hard" }),
+      Math.max(1, Math.floor(normalBudget * 0.1)),
+    );
+  }
+
+  const priorityLanes: WorkerLane[] = [
+    "repair",
+    "automerge_repair",
+    "issue_implementation",
+    "cluster_repair",
+    "exact_item",
+  ];
+  for (const lane of priorityLanes) {
+    assert.equal(workerLimit(lane, { pressureLevel: "hard" }), workerLimit(lane));
+  }
+  assert.equal(workerLimit("normal_review"), AUTOMATION_LIMITS.review_shards.normal_default);
+});
+
+function pressure(pendingCount: number, oldestPendingAgeMs: number): ExactReviewQueuePressure {
+  return { ok: true, pendingCount, oldestPendingAgeMs };
+}
+
+function withPressureEnv(
+  values: Record<(typeof PRESSURE_ENV_NAMES)[number], string>,
+  run: () => void,
+) {
+  const previous = new Map(PRESSURE_ENV_NAMES.map((name) => [name, process.env[name]]));
+  try {
+    for (const name of PRESSURE_ENV_NAMES) process.env[name] = values[name];
+    run();
+  } finally {
+    for (const name of PRESSURE_ENV_NAMES) {
+      const value = previous.get(name);
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  }
+}

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -249,6 +249,27 @@ test("worker scheduler keeps 104 slots available for steady background work", ()
   assert.ok(quietBackgroundCapacity >= Math.floor(WORKER_CONFIG.workers.max * 0.8));
 });
 
+test("workflow worker scheduler applies queue pressure only to background lanes", () => {
+  for (const lane of ["normal_review", "hot_intake", "commit_review"] as const) {
+    const normalBudget = workerLimit(lane);
+    assert.equal(workerLimit(lane, { pressureLevel: "soft" }), Math.ceil(normalBudget * 0.5));
+    assert.equal(
+      workerLimit(lane, { pressureLevel: "hard" }),
+      Math.max(1, Math.floor(normalBudget * 0.1)),
+    );
+  }
+  for (const lane of [
+    "repair",
+    "automerge_repair",
+    "issue_implementation",
+    "cluster_repair",
+    "exact_item",
+    "assist",
+  ] as const) {
+    assert.equal(workerLimit(lane, { pressureLevel: "hard" }), workerLimit(lane));
+  }
+});
+
 test("worker config defaults imported cluster repair capacity for older configs", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-limits-"));
   const configPath = path.join(root, "automation-limits.json");

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -2155,6 +2155,37 @@ test("background review capacity reserves expanding matrices and caps broad manu
   assert.match(commitBlock, /reserved_shards="\$item_count"/);
 });
 
+test("background planners fetch exact-review queue pressure once and pass its level", () => {
+  const sweepWorkflow = readText(".github/workflows/sweep.yml");
+  const sweepBlock = sweepWorkflow.slice(
+    sweepWorkflow.indexOf("- id: mode"),
+    sweepWorkflow.indexOf("- id: select"),
+  );
+  const commitWorkflow = readText(".github/workflows/commit-review.yml");
+  const commitBlock = commitWorkflow.slice(
+    commitWorkflow.indexOf("- name: Select commits"),
+    commitWorkflow.indexOf('if [ "$ENABLED" = "false" ]'),
+  );
+
+  for (const block of [sweepBlock, commitBlock]) {
+    assert.match(
+      block,
+      /QUEUE_URL: \$\{\{ vars\.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL \|\| 'https:\/\/clawsweeper\.openclaw\.ai' \}\}/,
+    );
+    assert.equal(block.match(/queue-pressure --queue-url/g)?.length, 1);
+    assert.match(block, /--pressure-level "\$pressure_level"/);
+    assert.match(block, /queue pressure: \$pressure_level/);
+    assert.match(block, /if ! pressure_json=/);
+    assert.match(block, /unavailable=probe_failed/);
+    assert.match(block, /CLAWSWEEPER_QUEUE_PRESSURE_SOFT_PENDING/);
+    assert.match(block, /CLAWSWEEPER_QUEUE_PRESSURE_HARD_AGE_MS/);
+  }
+  assert.match(sweepBlock, /if \[ -z "\$exact_item" \]; then/);
+  assert.match(sweepBlock, /hot_intake \$hot_intake_unpressured->\$hot_intake_shards/);
+  assert.match(sweepBlock, /normal_review \$normal_unpressured->\$normal_shards/);
+  assert.match(commitBlock, /commit_review \$unpressured_page_size->\$PAGE_SIZE/);
+});
+
 test("review backstops identify sweep runs by stable workflow path", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const block = workflow.slice(workflow.indexOf("- name: Queue review backstops"));


### PR DESCRIPTION
## Why

Maintainer decision (Jul 13, after the exact-review backlog incident): no alerting layer — make the scheduler smart instead. Direct reviews get priority; back-review/backfill work should get less quota when the review queue is busy. Lane budgets today yield to *active* work but are blind to queue depth/age: on Jul 12 and 15 the direct-review queue backed up (>1,400 pending, oldest 15h) while background sweeps kept full quota.

## What

- New `src/queue-pressure.ts`: probes the public queue stats endpoint (`/api/exact-review-queue`, 5s timeout) and classifies pressure — **soft** at pending >= 150 or oldest >= 30 min, **hard** at pending >= 400 or oldest >= 2h (all four thresholds overridable via `CLAWSWEEPER_QUEUE_PRESSURE_*` repo variables). Fail-open at every layer: probe failure, timeout, or malformed body -> level `none` (a dashboard outage can never stall reviews).
- `workerLimit` (src/limits.ts + the src/repair mirror) scales **background lanes only** (normal review, hot intake, commit review): soft -> 50%, hard -> 10% (floor 1, a lane never fully stops). Priority lanes (repair, exact-item) untouched.
- sweep.yml background planning and commit-review.yml probe once per plan and log one clear line, e.g. `queue pressure: hard (pending=1367, oldest=7.5h) — hot_intake 44->4, normal_review 89->8`. Exact-item runs skip the probe. Explicit `CLAWSWEEPER_COMMIT_REVIEW_PAGE_SIZE` remains an operator escape hatch that bypasses derived budgets (same semantics it always had for load yielding; now documented in place).

At current prod state (live probe during development: pending=1367, oldest=7.5h -> hard) this throttle engages immediately on landing and releases as the backlog drains.

## Proof

- `node --test test/queue-pressure.test.ts test/repair/workflow-utils.test.ts test/sweep-workflow.test.ts` — 118 pass (threshold boundaries, env overrides, fail-open on error/timeout/malformed, lane scaling per level, priority lanes unaffected, workflow probe-once + logging + fail-open assertions).
- `pnpm run check:limits` green; docs/limits.md documents tiers and overrides.
- Autoreview (Codex Sol, xhigh): one finding consciously rejected — it asked to pressure-scale the explicit commit-review page-size override, but that override is an operator escape hatch that already bypasses active-load yielding; consistency argues for override-wins (now stated in a comment).
