### PR TITLE
Show exact review lane speed

### DIFF
--- a/dashboard/operational-health.ts
+++ b/dashboard/operational-health.ts
@@ -40,8 +40,15 @@ export type HealthHistorySample = {
 
 export type ExactReviewHistorySample = {
   collection_ok: boolean;
-  review?: { pending: number };
-  publication?: { pending: number; completed_total?: number };
+  review?: ExactReviewLaneHistorySample;
+  publication?: ExactReviewLaneHistorySample;
+};
+
+export type ExactReviewLaneHistorySample = {
+  pending: number;
+  enqueued_total?: number;
+  completed_total?: number;
+  shed_total?: number;
 };
 
 export function summarizeOperationalHealth(
@@ -139,19 +146,13 @@ export function normalizeHealthHistorySample(value: unknown): HealthHistorySampl
 
 export function exactReviewHistorySample(value: unknown): ExactReviewHistorySample {
   const lanes = objectValue(objectValue(value).lanes);
-  const reviewPending = nonNegativeInteger(objectValue(lanes.review).pending);
-  const publicationLane = objectValue(lanes.publication);
-  const publicationPending = nonNegativeInteger(publicationLane.pending);
-  if (reviewPending === null || publicationPending === null) return { collection_ok: false };
-  const completedTotal = optionalNonNegativeInteger(publicationLane.completed_total);
-  if (completedTotal === null) return { collection_ok: false };
+  const review = queueLaneHistorySample(lanes.review, true);
+  const publication = queueLaneHistorySample(lanes.publication, false);
+  if (!review || !publication) return { collection_ok: false };
   return {
     collection_ok: true,
-    review: { pending: reviewPending },
-    publication: {
-      pending: publicationPending,
-      ...(completedTotal === undefined ? {} : { completed_total: completedTotal }),
-    },
+    review,
+    publication,
   };
 }
 
@@ -161,19 +162,54 @@ function normalizeExactReviewHistorySample(value: unknown): ExactReviewHistorySa
   const sample = value as Record<string, unknown>;
   if (typeof sample.collection_ok !== "boolean") return null;
   if (!sample.collection_ok) return { collection_ok: false };
-  const reviewPending = nonNegativeInteger(objectValue(sample.review).pending);
-  const publication = objectValue(sample.publication);
-  const publicationPending = nonNegativeInteger(publication.pending);
-  if (reviewPending === null || publicationPending === null) return null;
-  const completedTotal = optionalNonNegativeInteger(publication.completed_total);
-  if (completedTotal === null) return null;
+  const review = storedLaneHistorySample(sample.review, true);
+  const publication = storedLaneHistorySample(sample.publication, false);
+  if (!review || !publication) return null;
   return {
     collection_ok: true,
-    review: { pending: reviewPending },
-    publication: {
-      pending: publicationPending,
-      ...(completedTotal === undefined ? {} : { completed_total: completedTotal }),
-    },
+    review,
+    publication,
+  };
+}
+
+function queueLaneHistorySample(value: unknown, includeShed: boolean) {
+  const lane = objectValue(value);
+  return laneHistorySample(
+    lane.pending,
+    lane.enqueued_total,
+    lane.completed_total,
+    includeShed ? lane.shed_since_reset : undefined,
+  );
+}
+
+function storedLaneHistorySample(value: unknown, includeShed: boolean) {
+  const lane = objectValue(value);
+  return laneHistorySample(
+    lane.pending,
+    lane.enqueued_total,
+    lane.completed_total,
+    includeShed ? lane.shed_total : undefined,
+  );
+}
+
+function laneHistorySample(
+  pendingValue: unknown,
+  enqueuedValue: unknown,
+  completedValue: unknown,
+  shedValue: unknown,
+): ExactReviewLaneHistorySample | null {
+  const pending = nonNegativeInteger(pendingValue);
+  const enqueuedTotal = optionalNonNegativeInteger(enqueuedValue);
+  const completedTotal = optionalNonNegativeInteger(completedValue);
+  const shedTotal = optionalNonNegativeInteger(shedValue);
+  if (pending === null || enqueuedTotal === null || completedTotal === null || shedTotal === null) {
+    return null;
+  }
+  return {
+    pending,
+    ...(enqueuedTotal === undefined ? {} : { enqueued_total: enqueuedTotal }),
+    ...(completedTotal === undefined ? {} : { completed_total: completedTotal }),
+    ...(shedTotal === undefined ? {} : { shed_total: shedTotal }),
   };
 }
 

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -127,6 +127,16 @@ type ExactReviewQueueStorageMeta = {
   dispatcher_json: string | null;
   shed_since_reset?: number;
 };
+type ExactReviewQueueMetricTotals = {
+  review: { enqueued: number; completed: number };
+  publication: { enqueued: number; completed: number };
+};
+type ExactReviewQueueMetricDelta = {
+  reviewEnqueued?: number;
+  reviewCompleted?: number;
+  publicationEnqueued?: number;
+  publicationCompleted?: number;
+};
 type DurableObjectStub = { fetch: (request: Request) => Promise<Response> };
 type DurableObjectNamespace = {
   idFromName: (name: string) => unknown;
@@ -911,11 +921,13 @@ export class ExactReviewQueue {
         requeueLatest,
       );
       // A successful workflow can still request requeue_latest after source
-      // drift, but that path publishes no result. Count only publication items
-      // that actually leave the queue on this completion.
-      const completedPublications =
-        outcome === "success" && !requeued && exactReviewQueueIsPublication(item) ? 1 : 0;
-      await this.writeState(state, completedPublications);
+      // drift. That work did not leave its lane, so it must not improve the
+      // operator-facing net speed until a later revision actually completes.
+      const completedLane = outcome === "success" && !requeued ? exactReviewQueueLane(item) : null;
+      await this.writeState(state, {
+        ...(completedLane === "review" ? { reviewCompleted: 1 } : {}),
+        ...(completedLane === "publication" ? { publicationCompleted: 1 } : {}),
+      });
       await this.scheduleNext(state, now);
       return json({ ok: true, requeued });
     }
@@ -972,6 +984,7 @@ export class ExactReviewQueue {
       let reconciled = 0;
       let requeued = 0;
       let completed = 0;
+      let completedReviews = 0;
       let completedPublications = 0;
       for (const run of runs) {
         const matches = Object.values(state.items).filter(
@@ -988,13 +1001,17 @@ export class ExactReviewQueue {
         if (didRequeue) requeued += 1;
         else {
           completed += 1;
-          if (run.outcome === "success" && exactReviewQueueIsPublication(item)) {
-            completedPublications += 1;
+          if (run.outcome === "success") {
+            if (exactReviewQueueIsPublication(item)) completedPublications += 1;
+            else completedReviews += 1;
           }
         }
       }
       if (reconciled) {
-        await this.writeState(state, completedPublications);
+        await this.writeState(state, {
+          reviewCompleted: completedReviews,
+          publicationCompleted: completedPublications,
+        });
         await this.scheduleNext(state, now);
       }
       return json({ ok: true, reconciled, requeued, completed });
@@ -1015,9 +1032,9 @@ export class ExactReviewQueue {
         );
         if (changed) this.writeStateSync(current);
         else this.syncLegacyCompatibilitySync(current);
-        return { state: current, completedTotal: this.publicationCompletedTotalSync() };
+        return { state: current, metrics: this.queueMetricTotalsSync() };
       });
-      const { state, completedTotal } = snapshot;
+      const { state, metrics } = snapshot;
       await this.scheduleNext(state, now);
       const stats = exactReviewQueueStats(
         state,
@@ -1033,8 +1050,16 @@ export class ExactReviewQueue {
       return json({
         ...stats,
         lanes: {
-          ...stats.lanes,
-          publication: { ...stats.lanes.publication, completed_total: completedTotal },
+          review: {
+            ...stats.lanes.review,
+            enqueued_total: metrics.review.enqueued,
+            completed_total: metrics.review.completed,
+          },
+          publication: {
+            ...stats.lanes.publication,
+            enqueued_total: metrics.publication.enqueued,
+            completed_total: metrics.publication.completed,
+          },
         },
         delivery_receipts: this.deliveryReceiptCountSync(),
         storage_schema_version: EXACT_REVIEW_QUEUE_STORAGE_SCHEMA_VERSION,
@@ -1318,15 +1343,38 @@ export class ExactReviewQueue {
          received_at INTEGER NOT NULL
        ) STRICT`,
     );
-    // Completion telemetry is independent of queue rollback compatibility. A
-    // separate singleton keeps the cumulative counter monotonic without
+    // Flow telemetry is independent of queue rollback compatibility. A
+    // separate singleton keeps cumulative lane counters monotonic without
     // changing the normalized queue schema or its legacy shadow contract.
     this.storage.sql.exec(
       `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_QUEUE_METRICS_TABLE} (
          singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+         review_enqueued_total INTEGER NOT NULL DEFAULT 0 CHECK (review_enqueued_total >= 0),
+         review_completed_total INTEGER NOT NULL DEFAULT 0 CHECK (review_completed_total >= 0),
+         publication_enqueued_total INTEGER NOT NULL DEFAULT 0
+           CHECK (publication_enqueued_total >= 0),
          publication_completed_total INTEGER NOT NULL CHECK (publication_completed_total >= 0)
        ) STRICT`,
     );
+    for (const column of [
+      "review_enqueued_total",
+      "review_completed_total",
+      "publication_enqueued_total",
+    ]) {
+      const present = Array.from(
+        this.storage.sql.exec(
+          `SELECT name FROM pragma_table_info('${EXACT_REVIEW_QUEUE_METRICS_TABLE}')
+            WHERE name = ?`,
+          column,
+        ),
+      ).length;
+      if (!present) {
+        this.storage.sql.exec(
+          `ALTER TABLE ${EXACT_REVIEW_QUEUE_METRICS_TABLE}
+             ADD COLUMN ${column} INTEGER NOT NULL DEFAULT 0 CHECK (${column} >= 0)`,
+        );
+      }
+    }
     this.storage.sql.exec(
       `INSERT OR IGNORE INTO ${EXACT_REVIEW_QUEUE_METRICS_TABLE}
          (singleton_id, publication_completed_total) VALUES (1, 0)`,
@@ -1569,42 +1617,76 @@ export class ExactReviewQueue {
     return state;
   }
 
-  private writeState(state: ExactReviewQueueState, completedPublications = 0) {
+  private writeState(state: ExactReviewQueueState, metricDelta: ExactReviewQueueMetricDelta = {}) {
     this.storage.transactionSync(() => {
       this.writeStateSync(state);
-      if (completedPublications > 0)
-        this.incrementPublicationCompletedTotalSync(completedPublications);
+      this.incrementQueueMetricsSync(metricDelta);
     });
   }
 
-  private publicationCompletedTotalSync() {
+  private queueMetricTotalsSync(): ExactReviewQueueMetricTotals {
     const row = Array.from(
       this.storage.sql.exec(
-        `SELECT publication_completed_total
+        `SELECT review_enqueued_total, review_completed_total,
+                publication_enqueued_total, publication_completed_total
            FROM ${EXACT_REVIEW_QUEUE_METRICS_TABLE}
           WHERE singleton_id = 1`,
       ),
-    )[0] as { publication_completed_total?: number } | undefined;
-    const total = Number(row?.publication_completed_total);
-    return Number.isSafeInteger(total) && total >= 0 ? total : 0;
+    )[0] as
+      | {
+          review_enqueued_total?: number;
+          review_completed_total?: number;
+          publication_enqueued_total?: number;
+          publication_completed_total?: number;
+        }
+      | undefined;
+    return {
+      review: {
+        enqueued: exactReviewMetricTotal(row?.review_enqueued_total),
+        completed: exactReviewMetricTotal(row?.review_completed_total),
+      },
+      publication: {
+        enqueued: exactReviewMetricTotal(row?.publication_enqueued_total),
+        completed: exactReviewMetricTotal(row?.publication_completed_total),
+      },
+    };
   }
 
-  private incrementPublicationCompletedTotalSync(count: number) {
+  private incrementQueueMetricsSync(delta: ExactReviewQueueMetricDelta) {
+    const reviewEnqueued = exactReviewMetricDelta(delta.reviewEnqueued);
+    const reviewCompleted = exactReviewMetricDelta(delta.reviewCompleted);
+    const publicationEnqueued = exactReviewMetricDelta(delta.publicationEnqueued);
+    const publicationCompleted = exactReviewMetricDelta(delta.publicationCompleted);
+    if (!reviewEnqueued && !reviewCompleted && !publicationEnqueued && !publicationCompleted) {
+      return;
+    }
     this.storage.sql.exec(
       `UPDATE ${EXACT_REVIEW_QUEUE_METRICS_TABLE}
-          SET publication_completed_total = publication_completed_total + ?
+          SET review_enqueued_total = review_enqueued_total + ?,
+              review_completed_total = review_completed_total + ?,
+              publication_enqueued_total = publication_enqueued_total + ?,
+              publication_completed_total = publication_completed_total + ?
         WHERE singleton_id = 1`,
-      count,
+      reviewEnqueued,
+      reviewCompleted,
+      publicationEnqueued,
+      publicationCompleted,
     );
   }
 
   private writeStateSync(state: ExactReviewQueueState) {
     const baseline = this.baselines.get(state) || this.readStateBaselineSync();
     const nextItems = new Map<string, string>();
+    let reviewEnqueued = 0;
+    let publicationEnqueued = 0;
     for (const [itemKey, item] of Object.entries(state.items)) {
       const itemJson = JSON.stringify(item);
       nextItems.set(itemKey, itemJson);
       if (baseline.items.get(itemKey) === itemJson) continue;
+      if (!baseline.items.has(itemKey)) {
+        if (exactReviewQueueIsPublication(item)) publicationEnqueued += 1;
+        else reviewEnqueued += 1;
+      }
       this.storage.sql.exec(
         `INSERT INTO ${EXACT_REVIEW_QUEUE_ITEM_TABLE} (item_key, item_json)
          VALUES (?, ?)
@@ -1621,6 +1703,10 @@ export class ExactReviewQueue {
         );
       }
     }
+    // Count queue work, not webhook volume. A new key creates one unit of
+    // operator-visible demand; dedupes and merged revisions retain an existing
+    // key and therefore cannot inflate the speed calculation.
+    this.incrementQueueMetricsSync({ reviewEnqueued, publicationEnqueued });
 
     const dispatcherJson = state.dispatcher ? JSON.stringify(state.dispatcher) : null;
     this.storage.sql.exec(
@@ -3323,8 +3409,22 @@ function exactReviewShedSinceReset(state: Pick<ExactReviewQueueState, "shedSince
   return Number.isSafeInteger(value) && value > 0 ? value : 0;
 }
 
+function exactReviewMetricTotal(value: unknown) {
+  const total = Number(value);
+  return Number.isSafeInteger(total) && total >= 0 ? total : 0;
+}
+
+function exactReviewMetricDelta(value: unknown) {
+  const delta = Number(value || 0);
+  return Number.isSafeInteger(delta) && delta > 0 ? delta : 0;
+}
+
 function exactReviewQueueIsPublication(item: ExactReviewQueueItem) {
   return item.decision.sourceAction === EXACT_REVIEW_ARTIFACT_PUBLISH_SOURCE_ACTION;
+}
+
+function exactReviewQueueLane(item: ExactReviewQueueItem) {
+  return exactReviewQueueIsPublication(item) ? "publication" : "review";
 }
 
 function exactReviewQueueActiveReviewCount(state: ExactReviewQueueState) {
@@ -9434,18 +9534,21 @@ h2::before { content: ""; flex: 0 0 auto; width: 14px; height: 2px; border-radiu
 .exact-trend-status { font-size: 12px; font-weight: 650; }
 .exact-trend-status.growing { color: var(--amber); }
 .exact-trend-status.draining { color: var(--green); }
-.exact-trend-status.speeding { color: var(--green); }
-.exact-trend-status.slowing { color: var(--amber); }
-.exact-trend-status.stable, .exact-trend-status.collecting { color: var(--muted); }
+.exact-trend-status.catching-up { color: var(--green); }
+.exact-trend-status.falling-behind { color: var(--amber); }
+.exact-trend-status.stable,
+.exact-trend-status.collecting,
+.exact-trend-status.stale { color: var(--muted); }
 .exact-trend-svg { display: block; width: 100%; height: 150px; margin-top: 6px; overflow: visible; }
 .trend-grid-line { stroke: var(--line-soft); stroke-width: 1; }
+.trend-grid-line.lane-speed-zero { stroke: var(--muted); }
 .trend-axis-label { fill: var(--muted); font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; font-size: 10px; }
 .exact-trend-line { fill: none; stroke: var(--claw); stroke-width: 2.5; vector-effect: non-scaling-stroke; }
 .exact-trend-point { fill: var(--claw); }
-.publication-rate { margin-top: 20px; padding-top: 16px; border-top: 1px solid var(--line-soft); }
-.publication-rate .exact-trend-status { margin-top: 4px; }
-.publication-rate-line { fill: none; stroke: var(--violet); stroke-width: 2.5; vector-effect: non-scaling-stroke; }
-.publication-rate-point { fill: var(--violet); }
+.lane-speed { margin-top: 20px; padding-top: 16px; border-top: 1px solid var(--line-soft); }
+.lane-speed .exact-trend-status { margin-top: 4px; }
+.lane-speed-line { fill: none; stroke: var(--violet); stroke-width: 2.5; vector-effect: non-scaling-stroke; }
+.lane-speed-point { fill: var(--violet); }
 .trend-empty { display: grid; place-items: center; height: 130px; color: var(--muted); font-size: 12px; }
 .overview-shell { margin: 0; padding: 0; border: 0; background: transparent; }
 .overview-head,
@@ -10345,38 +10448,76 @@ function exactReviewHistory(lane) {
       ? sample.exact_review?.[lane]
       : null;
     const pending = Number(laneSample?.pending);
+    const enqueuedTotal = Number(laneSample?.enqueued_total);
     const completedTotal = Number(laneSample?.completed_total);
+    const shedTotal = lane === "review" ? Number(laneSample?.shed_total || 0) : 0;
+    const hasFlowCounters = Number.isFinite(enqueuedTotal) && Number.isFinite(completedTotal) && Number.isFinite(shedTotal);
     return Number.isFinite(Date.parse(sample.at)) && Number.isFinite(pending)
       ? [{
           at: sample.at,
           pending: Math.max(0, pending),
-          ...(Number.isFinite(completedTotal)
-            ? { completedTotal: Math.max(0, completedTotal) }
+          ...(hasFlowCounters
+            ? {
+                enqueuedTotal: Math.max(0, enqueuedTotal),
+                completedTotal: Math.max(0, completedTotal),
+                shedTotal: Math.max(0, shedTotal)
+              }
             : {})
         }]
       : [];
   });
 }
 
-function publicationRateHistory(samples) {
-  const cumulative = samples.filter(sample => Number.isFinite(sample.completedTotal));
+function laneSpeedHistory(samples) {
   let segment = [];
-  let previousAt = null;
-  return cumulative.flatMap(sample => {
+  let previous = null;
+  let segmentId = 0;
+  return samples.flatMap(sample => {
     const at = Date.parse(sample.at);
-    if (previousAt !== null && at - previousAt > 12 * 60 * 1000) segment = [];
-    previousAt = at;
-    segment.push(sample);
-    const cutoff = at - 60 * 60 * 1000;
-    const baseline = segment.filter(candidate => Date.parse(candidate.at) <= cutoff).at(-1);
-    if (!baseline || cutoff - Date.parse(baseline.at) > 12 * 60 * 1000) return [];
-    const elapsedHours = (at - Date.parse(baseline.at)) / (60 * 60 * 1000);
-    const completed = sample.completedTotal - baseline.completedTotal;
-    if (elapsedHours <= 0 || completed < 0) {
-      segment = [sample];
+    const hasFlowCounters =
+      Number.isFinite(at) &&
+      Number.isFinite(sample.enqueuedTotal) &&
+      Number.isFinite(sample.completedTotal) &&
+      Number.isFinite(sample.shedTotal);
+    if (!hasFlowCounters) {
+      // A legacy sample means the counter delta across this interval is
+      // unknowable. Treat it as a boundary so the chart never bridges that
+      // missing demand with a plausible-looking speed line.
+      if (segment.length) segmentId += 1;
+      segment = [];
+      previous = null;
       return [];
     }
-    return [{ at: sample.at, rate: completed / elapsedHours }];
+    const previousAt = previous ? Date.parse(previous.at) : null;
+    const reset = previous && (
+      at <= previousAt ||
+      at - previousAt > 12 * 60 * 1000 ||
+      sample.enqueuedTotal < previous.enqueuedTotal ||
+      sample.completedTotal < previous.completedTotal ||
+      sample.shedTotal < previous.shedTotal
+    );
+    if (reset) {
+      segment = [];
+      segmentId += 1;
+    }
+    previous = sample;
+    segment.push(sample);
+    const cutoff = at - 60 * 60 * 1000;
+    const hourlyBaseline = segment.filter(candidate => Date.parse(candidate.at) <= cutoff).at(-1);
+    const hasHourlyBaseline = hourlyBaseline && cutoff - Date.parse(hourlyBaseline.at) <= 12 * 60 * 1000;
+    const baseline = hasHourlyBaseline ? hourlyBaseline : segment[0];
+    const elapsedHours = (at - Date.parse(baseline.at)) / (60 * 60 * 1000);
+    if (elapsedHours < 4 / 60) return [];
+    const completed = sample.completedTotal - baseline.completedTotal;
+    const incoming =
+      sample.enqueuedTotal - baseline.enqueuedTotal + sample.shedTotal - baseline.shedTotal;
+    return [{
+      at: sample.at,
+      rate: (completed - incoming) / elapsedHours,
+      windowMinutes: elapsedHours * 60,
+      provisional: !hasHourlyBaseline,
+      segmentId
+    }];
   });
 }
 
@@ -10415,8 +10556,41 @@ function niceTrendScale(maximum, tickCount) {
   };
 }
 
+function niceSignedTrendScale(maximum) {
+  const positive = niceTrendScale(Math.max(1, maximum), 2);
+  const step = positive.maximum / 2;
+  return {
+    maximum: positive.maximum,
+    ticks: [-positive.maximum, -step, 0, step, positive.maximum]
+  };
+}
+
 function formatTrendValue(value) {
   return fmt.format(Math.round(value));
+}
+
+function formatSignedTrendValue(value) {
+  const rounded = Math.round(value);
+  if (rounded > 0) return "+" + fmt.format(rounded);
+  if (rounded < 0) return "−" + fmt.format(Math.abs(rounded));
+  return "0";
+}
+
+function speedTrendGeometry(samples, plot, maximum, fromAt, toAt) {
+  if (!samples.length || maximum <= 0) return [];
+  const span = Math.max(1, toAt - fromAt);
+  let previous = null;
+  return samples.map(sample => {
+    const at = Date.parse(sample.at);
+    const x = plot.left + ((at - fromAt) / span) * plot.width;
+    const y = plot.top + ((maximum - sample.rate) / (maximum * 2)) * plot.height;
+    const connected = previous !== null &&
+      sample.segmentId === previous.segmentId &&
+      at - previous.at <= 12 * 60 * 1000;
+    const point = { at, x, y, connected, segmentId: sample.segmentId };
+    previous = point;
+    return point;
+  });
 }
 
 function oneHourTrend(samples) {
@@ -10458,62 +10632,69 @@ function exactReviewTrend(samples, label) {
   return '<div class="exact-trend"><div class="exact-trend-status ' + direction.className + '">' + esc(direction.label) + '</div><svg class="exact-trend-svg" viewBox="0 0 ' + width + " " + height + '" role="img" aria-label="' + esc(label + " pending backlog over " + activeHealthRange) + '">' + grid + '<path class="exact-trend-line" d="' + trendPath(geometry) + '"></path>' + points + axis + '</svg></div>';
 }
 
-function publicationRateDirection(samples) {
-  if (!samples.length) return { className: "collecting", label: "Collecting rate trend" };
-  const latest = samples.at(-1);
-  const cutoff = Date.parse(latest.at) - 60 * 60 * 1000;
-  const previous = samples.filter(sample => Date.parse(sample.at) <= cutoff).at(-1);
-  if (!previous || cutoff - Date.parse(previous.at) > 12 * 60 * 1000) {
-    return { className: "collecting", label: "Collecting rate trend" };
-  }
-  const currentRate = Math.round(latest.rate);
-  const previousRate = Math.round(previous.rate);
-  if (currentRate === previousRate) {
-    return { className: "stable", label: "Stable · no change from the previous hour" };
-  }
-  if (previousRate === 0) {
-    return {
-      className: "speeding",
-      label: "Speeding up · from 0 to " + fmt.format(currentRate) + " / hour",
-    };
-  }
-  const percent = Math.round(((currentRate - previousRate) / previousRate) * 100);
-  return percent > 0
-    ? { className: "speeding", label: "Speeding up · +" + fmt.format(percent) + "% vs previous hour" }
-    : { className: "slowing", label: "Slowing down · −" + fmt.format(Math.abs(percent)) + "% vs previous hour" };
+function laneSpeedStatus(sample) {
+  const rate = Math.round(sample.rate);
+  const window = sample.provisional
+    ? " · provisional " + fmt.format(Math.round(sample.windowMinutes)) + "m window"
+    : "";
+  if (rate > 0) return { className: "catching-up", label: "Catching up" + window };
+  if (rate < 0) return { className: "falling-behind", label: "Falling behind" + window };
+  return { className: "stable", label: "Balanced" + window };
 }
 
-function publicationRateTrend(samples) {
-  const rates = publicationRateHistory(samples);
+function laneSpeedTrend(samples, speedLabel) {
+  const rates = laneSpeedHistory(samples);
   const rangeMs = activeHealthRange === "7d" ? 7 * 86400000 : activeHealthRange === "24h" ? 86400000 : 6 * 3600000;
   const latestAt = rates.length ? Date.parse(rates.at(-1).at) : 0;
-  const toAt = Math.max(Date.now(), latestAt);
+  const latestObservationAt = samples.length ? Date.parse(samples.at(-1).at) : 0;
+  const hasLatestObservation = Number.isFinite(latestObservationAt) && latestObservationAt > 0;
+  const latestSegmentNeedsBaseline = hasLatestObservation && latestObservationAt > latestAt;
+  const toAt = Math.max(Date.now(), latestAt, hasLatestObservation ? latestObservationAt : 0);
+  const latestObservationFresh =
+    hasLatestObservation && toAt - latestObservationAt <= 12 * 60 * 1000;
+  const collectingCurrentSegment = latestSegmentNeedsBaseline && latestObservationFresh;
   const fromAt = toAt - rangeMs;
   const visible = rates.filter(sample => Date.parse(sample.at) >= fromAt && Date.parse(sample.at) <= toAt);
   const latestVisible = visible.at(-1);
-  const current = latestVisible && toAt - Date.parse(latestVisible.at) <= 12 * 60 * 1000
-    ? latestVisible
-    : null;
-  const headline = current ? fmt.format(Math.round(current.rate)) + " / hour" : "Collecting";
+  const current =
+    !latestSegmentNeedsBaseline &&
+    latestVisible &&
+    toAt - Date.parse(latestVisible.at) <= 12 * 60 * 1000
+      ? latestVisible
+      : null;
+  const headline = current
+    ? formatSignedTrendValue(current.rate) + " / hour"
+    : collectingCurrentSegment
+      ? "Collecting"
+    : hasLatestObservation || visible.length
+      ? "Stale"
+      : "Collecting";
   if (!visible.length) {
-    return '<div class="publication-rate"><div class="lane-count"><span>Publication speed</span><strong>' + headline + '</strong></div><div class="exact-trend-status collecting">Collecting rate trend</div><div class="trend-empty">No publication speed history in this range.</div></div>';
+    const emptyClass = headline === "Stale" ? "stale" : "collecting";
+    const emptyLabel = headline === "Stale"
+      ? "Stale · no speed sample in the last 12m"
+      : "Needs two continuous five-minute samples";
+    return '<div class="lane-speed"><div class="lane-count"><span>' + esc(speedLabel) + '</span><strong>' + headline + '</strong></div><div class="exact-trend-status ' + emptyClass + '">' + emptyLabel + '</div><div class="trend-empty">No speed history in this range.</div></div>';
   }
   const width = 600;
   const height = 150;
   const plot = { left: 48, top: 8, width: 540, height: 110 };
-  const scale = niceTrendScale(Math.max(1, ...visible.map(sample => sample.rate)), 4);
+  const scale = niceSignedTrendScale(Math.max(1, ...visible.map(sample => Math.abs(sample.rate))));
   const grid = scale.ticks.map(value => {
-    const y = plot.top + plot.height - value / scale.maximum * plot.height;
-    return '<line class="trend-grid-line" x1="' + plot.left + '" x2="' + (plot.left + plot.width) + '" y1="' + y.toFixed(1) + '" y2="' + y.toFixed(1) + '"></line><text class="trend-axis-label" x="' + (plot.left - 8) + '" y="' + (y + 3).toFixed(1) + '" text-anchor="end">' + esc(formatTrendValue(value)) + '</text>';
+    const y = plot.top + ((scale.maximum - value) / (scale.maximum * 2)) * plot.height;
+    const className = value === 0 ? "trend-grid-line lane-speed-zero" : "trend-grid-line";
+    return '<line class="' + className + '" x1="' + plot.left + '" x2="' + (plot.left + plot.width) + '" y1="' + y.toFixed(1) + '" y2="' + y.toFixed(1) + '"></line><text class="trend-axis-label" x="' + (plot.left - 8) + '" y="' + (y + 3).toFixed(1) + '" text-anchor="end">' + esc(formatSignedTrendValue(value)) + '</text>';
   }).join("");
-  const geometry = trendGeometry(visible, "rate", plot, scale.maximum, fromAt, toAt);
-  const points = geometry.map(point => '<circle class="publication-rate-point" cx="' + point.x.toFixed(1) + '" cy="' + point.y.toFixed(1) + '" r="3"></circle>').join("");
+  const geometry = speedTrendGeometry(visible, plot, scale.maximum, fromAt, toAt);
+  const points = geometry.map(point => '<circle class="lane-speed-point" cx="' + point.x.toFixed(1) + '" cy="' + point.y.toFixed(1) + '" r="3"></circle>').join("");
   const direction = current
-    ? publicationRateDirection(visible)
-    : { className: "collecting", label: "Collecting rate trend" };
+    ? laneSpeedStatus(current)
+    : collectingCurrentSegment
+      ? { className: "collecting", label: "Needs two continuous five-minute samples" }
+    : { className: "stale", label: "Stale · no speed sample in the last 12m" };
   const rangeLabel = activeHealthRange === "7d" ? "7d ago" : activeHealthRange + " ago";
   const axis = '<text class="trend-axis-label" x="' + plot.left + '" y="' + (height - 7) + '">' + rangeLabel + '</text><text class="trend-axis-label" x="' + (plot.left + plot.width) + '" y="' + (height - 7) + '" text-anchor="end">now</text>';
-  return '<div class="publication-rate"><div class="lane-count"><span>Publication speed</span><strong>' + headline + '</strong></div><div class="exact-trend-status ' + direction.className + '">' + esc(direction.label) + '</div><svg class="exact-trend-svg" viewBox="0 0 ' + width + " " + height + '" role="img" aria-label="Successful result publications per hour over ' + esc(activeHealthRange) + '">' + grid + '<path class="publication-rate-line" d="' + trendPath(geometry) + '"></path>' + points + axis + '</svg></div>';
+  return '<div class="lane-speed"><div class="lane-count"><span>' + esc(speedLabel) + '</span><strong>' + headline + '</strong></div><div class="exact-trend-status ' + direction.className + '">' + esc(direction.label) + '</div><svg class="exact-trend-svg" viewBox="0 0 ' + width + " " + height + '" role="img" aria-label="' + esc(speedLabel + ", completed minus incoming, over " + activeHealthRange) + '">' + grid + '<path class="lane-speed-line" d="' + trendPath(geometry) + '"></path>' + points + axis + '</svg></div>';
 }
 
 function renderExecutionAlert(current) {
@@ -10638,13 +10819,13 @@ function renderExactReviewLanes(queue) {
   const target = document.getElementById("exact-review-lanes");
   if (!target) return;
   const lanes = queue?.lanes;
-  target.innerHTML = [["Review admission", "review", lanes?.review], ["Result publication", "publication", lanes?.publication]].map(([label, laneKey, lane]) => {
+  target.innerHTML = [["Review admission", "Review speed", "review", lanes?.review], ["Result publication", "Publication speed", "publication", lanes?.publication]].map(([label, speedLabel, laneKey, lane]) => {
     const samples = exactReviewHistory(laneKey);
     if (!lane) {
       const sampledAt = samples.at(-1)?.at;
       return '<div class="exact-lane"><div class="exact-lane-head"><strong>' + esc(label) + '</strong><span>Live snapshot unavailable</span></div>' +
         exactReviewTrend(samples, label) +
-        (laneKey === "publication" ? publicationRateTrend(samples) : "") +
+        laneSpeedTrend(samples, speedLabel) +
         '<div class="lane-foot">' + (sampledAt ? "Last sampled " + esc(since(sampledAt)) : "History starts with the next five-minute sample") + '</div></div>';
     }
     const capacity = Math.max(0, lane.capacity || 0);
@@ -10656,7 +10837,7 @@ function renderExactReviewLanes(queue) {
     return '<div class="exact-lane"><div class="exact-lane-head"><strong>' + esc(label) + '</strong><span>' + fmt.format(active) + ' of ' + fmt.format(capacity) + ' active</span></div>' +
       '<div class="lane-count"><span>Pending</span><strong>' + fmt.format(lane.pending || 0) + '</strong></div>' +
       exactReviewTrend(samples, label) +
-      (laneKey === "publication" ? publicationRateTrend(samples) : "") +
+      laneSpeedTrend(samples, speedLabel) +
       '<div class="lane-counts">' +
       '<div class="lane-count"><span>Ready</span><strong>' + fmt.format(lane.ready || 0) + '</strong></div>' +
       '<div class="lane-count"><span>Backoff</span><strong>' + fmt.format(lane.backoff || 0) + '</strong></div>' +

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -174,8 +174,9 @@ state, fetch time, and current diagnostics.
 A Cloudflare Cron Trigger records one Exact Review queue sample every five
 minutes. It reuses the queue status read that also performs scheduled queue
 maintenance and makes no GitHub Actions request. The sample contains each
-lane's pending backlog and a cumulative count of successfully completed Result
-publication items.
+lane's pending backlog plus cumulative counts for newly enqueued and
+successfully completed work. Review samples also retain the cumulative shed
+count so overload demand remains visible even when no queue item was admitted.
 
 Samples are stored in the existing `StatusStore` Durable Object under daily UTC
 keys named `health-history:YYYY-MM-DD`. Writes replace the current five-minute
@@ -189,13 +190,24 @@ and returns legacy operational samples, but new samples omit those unused chart
 fields. Existing buckets expire naturally; no migration or manual cleanup is
 required.
 
-The Result publication speed chart derives a trailing hourly completion rate
-from the durable cumulative counter. Counting happens in the same queue storage
-transaction that terminalizes a successful publication, so retries, failures,
-review-lane work, and replayed completion requests do not inflate throughput.
-Counter history cannot be backfilled: the first rate appears after one hour of
-continuous samples, and comparison with the previous hour needs two hours.
-Telemetry gaps longer than 12 minutes break both backlog and speed lines.
+Each lane renders one signed speed value and curve: successfully completed work
+minus newly incoming work, expressed per hour. Positive speed means the lane is
+catching up, negative speed means it is falling behind, and zero is balanced.
+Incoming counts newly created queue work units; review demand also includes
+shed recovery work. Pending merges, delivery replays, retries, and source-drift
+requeues do not create new demand. Completed work is counted only when a
+successful item actually leaves its lane, in the same queue storage transaction
+as the deletion.
+
+After two continuous samples roughly five minutes apart, the dashboard scales
+the observed net change to an hourly rate and labels it provisional with the
+actual window length. Once an hour of continuous counters exists, it uses a
+trailing hourly rate. Zero incoming or zero completed work remains valid data. A
+gap over 12 minutes, a cumulative counter reset, or a legacy sample without flow
+counters starts a new speed segment; a latest speed point older than 12 minutes
+is stale.
+Pre-deployment counter history cannot be backfilled, so the first provisional
+speed appears about five minutes after deployment.
 
 Operational health remains a current-snapshot alert rather than a historical
 chart. `/api/status` classifies the already-fetched active workflow runs as:
@@ -287,9 +299,11 @@ For capacity displays, `/api/exact-review-queue` also exposes compatible
 `lanes.review` and `lanes.publication` objects. Each lane reports its own
 pending, ready, backoff, dispatching, leased, capacity, active, available-slot,
 oldest-pending, and next-attempt values. The existing top-level aggregate fields
-remain available for older consumers. The publication lane additionally reports
-`completed_total`. `/api/status` retains its `control_plane` compatibility field,
-but the dashboard no longer renders that low-actionability section.
+remain available for older consumers. Both lanes additionally report
+`enqueued_total` and `completed_total`; the review lane's existing
+`shed_since_reset` supplies overload demand. `/api/status` retains its
+`control_plane` compatibility field, but the dashboard no longer renders that
+low-actionability section.
 
 Executors report the GitHub job outcome from their finalizer. Failure or
 cancellation clears the lease and requeues the item. Finalizer success remains

--- a/test/dashboard-operational-health.test.ts
+++ b/test/dashboard-operational-health.test.ts
@@ -107,20 +107,40 @@ test("health history preserves legacy samples and normalizes exact-review backlo
 
   const exactReview = exactReviewHistorySample({
     lanes: {
-      review: { pending: 317 },
-      publication: { pending: 1502, completed_total: 42 },
+      review: {
+        pending: 317,
+        enqueued_total: 90,
+        completed_total: 70,
+        shed_since_reset: 3,
+      },
+      publication: { pending: 1502, enqueued_total: 50, completed_total: 42 },
     },
   });
   const normalized = normalizeHealthHistorySample({ ...legacy, exact_review: exactReview });
   assert.deepEqual(normalized?.exact_review, {
     collection_ok: true,
-    review: { pending: 317 },
-    publication: { pending: 1502, completed_total: 42 },
+    review: { pending: 317, enqueued_total: 90, completed_total: 70, shed_total: 3 },
+    publication: { pending: 1502, enqueued_total: 50, completed_total: 42 },
   });
   assert.deepEqual(normalizeHealthHistorySample({ at: CHECKED_AT, exact_review: exactReview }), {
     at: CHECKED_AT,
     exact_review: exactReview,
   });
+  assert.deepEqual(
+    normalizeHealthHistorySample({
+      at: CHECKED_AT,
+      exact_review: {
+        collection_ok: true,
+        review: { pending: 8 },
+        publication: { pending: 13, completed_total: 21 },
+      },
+    })?.exact_review,
+    {
+      collection_ok: true,
+      review: { pending: 8 },
+      publication: { pending: 13, completed_total: 21 },
+    },
+  );
   assert.deepEqual(exactReviewHistorySample(null), { collection_ok: false });
   assert.equal(
     normalizeHealthHistorySample({
@@ -128,6 +148,21 @@ test("health history preserves legacy samples and normalizes exact-review backlo
       exact_review: { collection_ok: true, review: { pending: 1 } },
     })?.exact_review,
     undefined,
+  );
+  assert.deepEqual(
+    normalizeHealthHistorySample({
+      at: CHECKED_AT,
+      exact_review: {
+        collection_ok: true,
+        review: { pending: 1, enqueued_total: -1, completed_total: 0 },
+        publication: { pending: 1, enqueued_total: 0, completed_total: 0 },
+      },
+    })?.exact_review,
+    {
+      collection_ok: true,
+      review: { pending: 1, enqueued_total: 0, completed_total: 0 },
+      publication: { pending: 1, enqueued_total: 0, completed_total: 0 },
+    },
   );
 });
 

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -83,6 +83,11 @@ test("exact-review queue debounces fresh work and caps pending revision extensio
     state = (await storage.get("exact-review-queue")) as typeof state;
     assert.equal(state.items["openclaw/gogcli#750"].nextAttemptAt, 1_001_500);
     assert.equal(state.items["openclaw/gogcli#750"].revision, 3);
+    const stats = await (
+      await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+    ).json();
+    assert.equal(stats.lanes.review.enqueued_total, 1);
+    assert.equal(stats.lanes.publication.enqueued_total, 0);
   } finally {
     Date.now = originalNow;
   }
@@ -132,6 +137,11 @@ test("exact-review queue bypasses debounce for commands and publications", async
     };
     assert.equal(merged.items["openclaw/gogcli#751"].revision, 2);
     assert.equal(merged.items["openclaw/gogcli#751"].nextAttemptAt, 2_000_000);
+    const stats = await (
+      await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+    ).json();
+    assert.equal(stats.lanes.review.enqueued_total, 1);
+    assert.equal(stats.lanes.publication.enqueued_total, 1);
   } finally {
     Date.now = originalNow;
   }
@@ -190,6 +200,28 @@ test("exact-review queue sheds only new recovery work above the pending soft lim
   assert.equal(stats.handoff_health.shed_since_reset, 3);
   assert.equal(stats.lanes.review.pending_depth, 2);
   assert.equal(stats.lanes.review.shed_since_reset, 3);
+  assert.equal(stats.lanes.review.enqueued_total, 2);
+  assert.equal(stats.lanes.publication.enqueued_total, 1);
+});
+
+test("exact-review queue does not count work for a disabled target", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  const response = await queue.fetch(
+    buildExactReviewQueueRequest("disabled-clawhub", 780, "opened", "issue", "openclaw/clawhub"),
+  );
+
+  assert.equal(response.status, 202);
+  assert.deepEqual(await response.json(), {
+    ok: true,
+    accepted: false,
+    reason: "target not enabled",
+  });
+  const stats = await (
+    await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(stats.lanes.review.enqueued_total, 0);
+  assert.equal(stats.lanes.publication.enqueued_total, 0);
 });
 
 test("heartbeated exact-review leases use the heartbeat grace while legacy leases keep execution expiry", () => {
@@ -342,7 +374,7 @@ test("signed claimed-run snapshot feeds tuple-safe terminal reconciliation", asy
   });
 });
 
-test("exact-review queue counts only terminal successful publications", async () => {
+test("exact-review queue counts only work that successfully leaves each lane", async () => {
   const storage = new MemoryDurableStorage();
   const directPublication = leasedExactReviewQueueItem(703, "7030");
   directPublication.decision.sourceAction = "exact_review_artifact_publish";
@@ -431,8 +463,54 @@ test("exact-review queue counts only terminal successful publications", async ()
   const stats = await (
     await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
   ).json();
+  assert.equal(stats.lanes.review.completed_total, 1);
   assert.equal(stats.lanes.publication.completed_total, 2);
   assert.equal(stats.lanes.publication.pending, 2);
+});
+
+test("exact-review completion and lane metrics roll back together", async () => {
+  const storage = new MemoryDurableStorage();
+  const review = leasedExactReviewQueueItem(708, "7080");
+  await storage.put("exact-review-queue", {
+    deliveries: {},
+    items: { [review.key]: review },
+  });
+  const queue = new ExactReviewQueue({ storage }, {});
+  await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"));
+  const complete = () =>
+    queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/complete", {
+        method: "POST",
+        body: JSON.stringify({
+          lease_id: review.leaseId,
+          item_key: review.key,
+          lease_revision: review.leaseRevision,
+          claim_generation: review.claimGeneration,
+          run_id: review.claimedRunId,
+          run_attempt: review.claimedRunAttempt,
+          outcome: "success",
+        }),
+      }),
+    );
+
+  storage.failNextSql(/SET review_enqueued_total = review_enqueued_total \+ \?/);
+  await assert.rejects(complete(), /injected SQL failure/);
+  let state = (await storage.get("exact-review-queue")) as {
+    items: Record<string, unknown>;
+  };
+  assert.ok(state.items[review.key]);
+  let stats = await (
+    await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(stats.lanes.review.completed_total, 0);
+
+  assert.equal((await complete()).status, 200);
+  state = (await storage.get("exact-review-queue")) as typeof state;
+  assert.equal(state.items[review.key], undefined);
+  stats = await (
+    await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(stats.lanes.review.completed_total, 1);
 });
 
 test("exact-review queue admits and wakes up to 24 publishers", () => {
@@ -508,6 +586,10 @@ test("dashboard status reads the exact-review handoff model from the durable que
   assert.equal(status.leased, 2);
   assert.equal(status.handoff_health.status, "healthy");
   assert.equal(status.handoff_health.phases.pending.count, 2);
+  assert.equal(status.lanes.review.enqueued_total, 3);
+  assert.equal(status.lanes.review.completed_total, 0);
+  assert.equal(status.lanes.publication.enqueued_total, 1);
+  assert.equal(status.lanes.publication.completed_total, 0);
   assert.deepEqual(
     {
       pending: status.lanes.review.pending,
@@ -1887,8 +1969,13 @@ test("dashboard cron records only exact-review history without GitHub queries", 
         return jsonResponse({
           handoff_health: { status: "healthy" },
           lanes: {
-            review: { pending: 17 },
-            publication: { pending: 29, completed_total: 123 },
+            review: {
+              pending: 17,
+              enqueued_total: 101,
+              completed_total: 83,
+              shed_since_reset: 5,
+            },
+            publication: { pending: 29, enqueued_total: 157, completed_total: 123 },
           },
         });
       },
@@ -1937,7 +2024,11 @@ test("dashboard cron records only exact-review history without GitHub queries", 
     assert.equal(history.samples[0].queued, undefined);
     assert.equal(history.samples[0].exact_review.collection_ok, true);
     assert.equal(history.samples[0].exact_review.review.pending, 17);
+    assert.equal(history.samples[0].exact_review.review.enqueued_total, 101);
+    assert.equal(history.samples[0].exact_review.review.completed_total, 83);
+    assert.equal(history.samples[0].exact_review.review.shed_total, 5);
     assert.equal(history.samples[0].exact_review.publication.pending, 29);
+    assert.equal(history.samples[0].exact_review.publication.enqueued_total, 157);
     assert.equal(history.samples[0].exact_review.publication.completed_total, 123);
 
     let failureRecording: Promise<unknown> | undefined;
@@ -2281,6 +2372,39 @@ test("exact-review queue coalesces deliveries, dispatches a bound rollout snapsh
   }
 });
 
+test("exact-review queue upgrades flow metrics without losing publication completions", async () => {
+  const storage = new MemoryDurableStorage();
+  storage.sql.exec(
+    `CREATE TABLE exact_review_queue_metrics (
+       singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+       publication_completed_total INTEGER NOT NULL CHECK (publication_completed_total >= 0)
+     ) STRICT`,
+  );
+  storage.sql.exec(
+    `INSERT INTO exact_review_queue_metrics (singleton_id, publication_completed_total)
+     VALUES (1, 42)`,
+  );
+  const queue = new ExactReviewQueue({ storage }, {});
+
+  const stats = await (
+    await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.deepEqual(
+    {
+      review_enqueued: stats.lanes.review.enqueued_total,
+      review_completed: stats.lanes.review.completed_total,
+      publication_enqueued: stats.lanes.publication.enqueued_total,
+      publication_completed: stats.lanes.publication.completed_total,
+    },
+    {
+      review_enqueued: 0,
+      review_completed: 0,
+      publication_enqueued: 0,
+      publication_completed: 42,
+    },
+  );
+});
+
 test("exact-review queue migrates delivery receipts and retains them for seven days", async () => {
   const storage = new MemoryDurableStorage();
   const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
@@ -2354,6 +2478,10 @@ test("exact-review receipt acceptance and queue mutation commit atomically", asy
   };
   assert.deepEqual(state.deliveries, {});
   assert.deepEqual(state.items, {});
+  let stats = await (
+    await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(stats.lanes.review.enqueued_total, 0);
 
   assert.equal(
     (await queue.fetch(buildExactReviewQueueRequest("delivery-atomic", 625, "opened"))).status,
@@ -2365,6 +2493,10 @@ test("exact-review receipt acceptance and queue mutation commit atomically", asy
   };
   assert.deepEqual(Object.keys(state.deliveries), ["delivery-atomic"]);
   assert.deepEqual(Object.keys(state.items), ["openclaw/gogcli#625"]);
+  stats = await (
+    await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(stats.lanes.review.enqueued_total, 1);
 });
 
 test("exact-review re-upgrade imports rollback-era queue mutations and receipts", async () => {
@@ -3492,6 +3624,11 @@ test("exact-review queue keeps publication artifacts durable outside review capa
     );
     assert.equal(staleClaim.status, 409);
     assert.deepEqual(await staleClaim.json(), { error: "lease_not_active" });
+    const stats = await (
+      await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+    ).json();
+    assert.equal(stats.lanes.review.enqueued_total, 4);
+    assert.equal(stats.lanes.publication.enqueued_total, 4);
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -4076,6 +4213,10 @@ test("failed shard recovery does not replace an already-pending ordinary event",
   assert.equal(state.items["openclaw/gogcli#710"].revision, 1);
   assert.equal(state.items["openclaw/gogcli#710"].attempts, 1);
   assert.equal(state.items["openclaw/gogcli#710"].nextAttemptAt, ordinary.nextAttemptAt);
+  const stats = await (
+    await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(stats.lanes.review.enqueued_total, 1);
 });
 
 test("failed shard recovery does not replace an ordinary active lease", async () => {
@@ -5523,10 +5664,16 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
     collection_ok: true,
     exact_review: {
       collection_ok: true,
-      review: { pending: 100 + index },
+      review: {
+        pending: 100 + index,
+        enqueued_total: index * 8,
+        completed_total: index * 5,
+        shed_total: 0,
+      },
       publication: {
         pending: 200 - index,
-        completed_total: index <= 12 ? index * 5 : 60 + (index - 12) * 10,
+        enqueued_total: index * 4,
+        completed_total: index * 10,
       },
     },
   }));
@@ -5549,10 +5696,19 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
   const laneHtml = elementFor("exact-review-lanes").innerHTML;
   assert.match(laneHtml, /Growing · \+12 in the last hour/);
   assert.match(laneHtml, /Draining · −12 in the last hour/);
+  assert.match(laneHtml, /Review speed/);
   assert.match(laneHtml, /Publication speed/);
-  assert.match(laneHtml, /120 \/ hour/);
-  assert.match(laneHtml, /Speeding up · \+100% vs previous hour/);
-  assert.match(laneHtml, /role="img" aria-label="Successful result publications per hour over 7d"/);
+  assert.match(laneHtml, /Review speed<\/span><strong>−36 \/ hour/);
+  assert.match(laneHtml, /Publication speed<\/span><strong>\+72 \/ hour/);
+  assert.match(laneHtml, /Falling behind/);
+  assert.match(laneHtml, /Catching up/);
+  assert.equal(laneHtml.match(/class="lane-speed"/g)?.length, 2);
+  assert.doesNotMatch(laneHtml, /Processed \/ hour|Incoming \/ hour/);
+  assert.match(laneHtml, /role="img" aria-label="Review speed, completed minus incoming, over 7d"/);
+  assert.match(
+    laneHtml,
+    /role="img" aria-label="Publication speed, completed minus incoming, over 7d"/,
+  );
   assert.match(laneHtml, /role="img" aria-label="Review admission pending backlog over 7d"/);
   assert.match(laneHtml, /Live snapshot unavailable/);
   assert.match(laneHtml, /Last sampled/);
@@ -5567,14 +5723,95 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
   );
   assert.match(smallAxis, />8<\/text>/);
   assert.match(largeAxis, />2,000<\/text>/);
-  const staleRate = context.publicationRateTrend(
-    Array.from({ length: 13 }, (_, index) => ({
-      at: new Date(now - (80 - index * 5) * 60_000).toISOString(),
-      completedTotal: index * 5,
-    })),
+  const flowSample = (
+    minutesAgo: number,
+    enqueuedTotal: number,
+    completedTotal: number,
+    shedTotal = 0,
+  ) => ({
+    at: new Date(now - minutesAgo * 60_000).toISOString(),
+    enqueuedTotal,
+    completedTotal,
+    shedTotal,
+  });
+  const provisionalSamples = [flowSample(5, 10, 20), flowSample(0, 12, 25)];
+  const provisionalRates = context.laneSpeedHistory(provisionalSamples);
+  assert.equal(provisionalRates.length, 1);
+  assert.equal(Math.round(provisionalRates[0].rate), 36);
+  assert.equal(provisionalRates[0].provisional, true);
+  assert.equal(Math.round(provisionalRates[0].windowMinutes), 5);
+  const provisionalSpeed = context.laneSpeedTrend(provisionalSamples, "Review speed");
+  assert.match(provisionalSpeed, /Review speed<\/span><strong>\+36 \/ hour/);
+  assert.match(provisionalSpeed, /Catching up · provisional 5m window/);
+
+  const balancedSamples = [flowSample(5, 10, 20), flowSample(0, 10, 20)];
+  const balancedSpeed = context.laneSpeedTrend(balancedSamples, "Review speed");
+  assert.match(balancedSpeed, /Review speed<\/span><strong>0 \/ hour/);
+  assert.match(balancedSpeed, /Balanced · provisional 5m window/);
+  assert.doesNotMatch(balancedSpeed, /Collecting/);
+
+  const shedRates = context.laneSpeedHistory([flowSample(5, 10, 20, 2), flowSample(0, 10, 20, 3)]);
+  assert.equal(Math.round(shedRates[0].rate), -12);
+
+  const matureRates = context.laneSpeedHistory(
+    Array.from({ length: 13 }, (_, index) => flowSample((12 - index) * 5, index * 3, index * 5)),
   );
-  assert.match(staleRate, /Publication speed<\/span><strong>Collecting/);
-  assert.doesNotMatch(staleRate, /60 \/ hour/);
+  assert.equal(Math.round(matureRates.at(-1).rate), 24);
+  assert.equal(matureRates.at(-1).provisional, false);
+  assert.equal(Math.round(matureRates.at(-1).windowMinutes), 60);
+
+  const gapRates = context.laneSpeedHistory([
+    flowSample(40, 0, 0),
+    flowSample(35, 1, 2),
+    flowSample(10, 2, 4),
+    flowSample(5, 3, 6),
+  ]);
+  assert.equal(gapRates.length, 2);
+  assert.notEqual(gapRates[0].segmentId, gapRates[1].segmentId);
+
+  const resetRates = context.laneSpeedHistory([
+    flowSample(20, 10, 10),
+    flowSample(15, 11, 12),
+    flowSample(10, 1, 1),
+    flowSample(5, 2, 3),
+  ]);
+  assert.equal(resetRates.length, 2);
+  assert.notEqual(resetRates[0].segmentId, resetRates[1].segmentId);
+  const resetCollecting = context.laneSpeedTrend(
+    [flowSample(10, 10, 10), flowSample(5, 11, 12), flowSample(0, 1, 1)],
+    "Review speed",
+  );
+  assert.match(resetCollecting, /Review speed<\/span><strong>Collecting/);
+  assert.match(resetCollecting, /Needs two continuous five-minute samples/);
+
+  const legacyBreakRates = context.laneSpeedHistory([
+    flowSample(25, 10, 10),
+    flowSample(20, 11, 12),
+    { at: new Date(now - 15 * 60_000).toISOString(), pending: 1 },
+    flowSample(10, 12, 14),
+    flowSample(5, 13, 16),
+  ]);
+  assert.equal(legacyBreakRates.length, 2);
+  assert.notEqual(legacyBreakRates[0].segmentId, legacyBreakRates[1].segmentId);
+  const speedGeometry = context.speedTrendGeometry(
+    legacyBreakRates,
+    { left: 0, top: 0, width: 100, height: 100 },
+    20,
+    now - 30 * 60_000,
+    now,
+  );
+  assert.equal(speedGeometry[1].connected, false);
+  assert.match(context.trendPath(speedGeometry), /^M.* M/);
+
+  const staleSpeed = context.laneSpeedTrend(
+    [flowSample(25, 0, 0), flowSample(20, 1, 2)],
+    "Publication speed",
+  );
+  assert.match(staleSpeed, /Publication speed<\/span><strong>Stale/);
+  assert.match(staleSpeed, /Stale · no speed sample in the last 12m/);
+  const collectingSpeed = context.laneSpeedTrend([flowSample(0, 0, 0)], "Review speed");
+  assert.match(collectingSpeed, /Review speed<\/span><strong>Collecting/);
+  assert.match(collectingSpeed, /Needs two continuous five-minute samples/);
 
   assert.equal(
     context.oneHourTrend(samples.slice(0, 1).map((sample) => ({ at: sample.at, pending: 4 })))
@@ -5584,30 +5821,6 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
   assert.equal(
     context.oneHourTrend(samples.map((sample) => ({ at: sample.at, pending: 9 }))).label,
     "Stable · no change in the last hour",
-  );
-  assert.equal(
-    context.publicationRateDirection([
-      { at: new Date(now - 60 * 60_000).toISOString(), rate: 100 },
-      { at: new Date(now).toISOString(), rate: 50 },
-    ]).label,
-    "Slowing down · −50% vs previous hour",
-  );
-  assert.equal(
-    context.publicationRateDirection([
-      { at: new Date(now - 60 * 60_000).toISOString(), rate: 50 },
-      { at: new Date(now).toISOString(), rate: 50 },
-    ]).label,
-    "Stable · no change from the previous hour",
-  );
-  assert.equal(
-    context.publicationRateHistory([
-      ...Array.from({ length: 13 }, (_, index) => ({
-        at: new Date(now - (130 - index * 5) * 60_000).toISOString(),
-        completedTotal: index * 5,
-      })),
-      { at: new Date(now).toISOString(), completedTotal: 120 },
-    ]).length,
-    1,
   );
   const broken = context.trendGeometry(
     [


### PR DESCRIPTION
## Summary

- Show one signed Review speed and Publication speed value and curve, defined as successful completions minus incoming work.
- Count genuinely new queue work, successful lane exits, and review shed demand without inflating rates for replays, merges, retries, or requeues.
- Preserve backlog history, migrate durable counters compatibly, and show a provisional hourly rate after two continuous five-minute samples.

## Root cause

[PR #622](https://github.com/openclaw/clawsweeper/pull/622) exposed backlog on both lanes but only publication completion throughput. That left the review lane without a speed signal and could not distinguish increased demand from slower processing.

## Validation

- pnpm run check on Node v24.15.0
- dashboard build plus 130 focused queue and history tests after rebasing onto current main
- autoreview clean with no accepted or actionable findings
- public diff privacy scan found no credentials, private paths, or personal data