### PR TITLE
Dashboard: surface automerge reliability

### DIFF
--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -122,6 +122,10 @@ const DEFAULT_WORKER_HEALTH_FETCH_CONCURRENCY = 10;
 const WORKER_TARGET_CACHE_TTL_SECONDS = 900;
 const WORKER_TARGET_BATCH_SIZE = 50;
 const AUTOMERGE_CACHE_TTL_SECONDS = 300;
+const AUTOMERGE_REPAIR_WORKFLOW = "repair-cluster-worker.yml";
+const AUTOMERGE_RELIABILITY_RUN_LIMIT = 100;
+const AUTOMERGE_STALLED_AFTER_MS = 90 * 60 * 1000;
+const AUTOMERGE_FAILURE_DISPLAY_LIMIT = 5;
 const RECENT_CLOSED_CACHE_TTL_SECONDS = 300;
 const DEFAULT_WORKER_DETAIL_RUN_LIMIT = 32;
 const SUPPORT_WORKFLOW_NAMES = new Set([
@@ -1745,61 +1749,77 @@ async function statusSnapshot(env) {
       TERMINAL_BAD_CONCLUSIONS.has(String(run.conclusion)),
   );
   const activeJobs = await activeWorkerSnapshot(env, repo, workerRuns, github);
-  const [workerHealth, pipeline, clusterRepair, applyHealth, automerge, closed, storedEvents] =
-    await Promise.all([
-      withTimeout(
-        recentWorkerHealth(env, repo, completedWorkflowRuns, github),
-        OPTIONAL_SECTION_TIMEOUT_MS * 2,
-        "worker health",
-      ).catch((error) => {
-        errors.push(error.message);
-        return emptyWorkerHealth(generatedAt);
-      }),
-      withTimeout(
-        pipelineItems(env, workerRuns.slice(0, 30), github),
-        OPTIONAL_SECTION_TIMEOUT_MS,
-        "pipeline",
-      ).catch((error) => {
-        errors.push(error.message);
-        return workerRuns.slice(0, 30).map((run) => classifyRun(run));
-      }),
-      withTimeout(
-        clusterRepairStatus(env, repo, targetRepos, activeRuns, github),
-        OPTIONAL_SECTION_TIMEOUT_MS,
-        "cluster repair intake",
-      ).catch((error) => {
-        errors.push(error.message);
-        return emptyClusterRepairStatus(targetRepos);
-      }),
-      withTimeout(
-        applyHealthStatus(env, targetRepos, github),
-        OPTIONAL_SECTION_TIMEOUT_MS,
-        "apply health",
-      ).catch((error) => {
-        errors.push(error.message);
-        return emptyApplyHealthStatus(targetRepos);
-      }),
-      withTimeout(
-        recentAutomerge(env, targetRepos[0] || "openclaw/openclaw", github),
-        OPTIONAL_SECTION_TIMEOUT_MS,
-        "automerge timing",
-      ).catch((error) => {
-        errors.push(error.message);
-        return { average_ms: null, samples: 0, items: [] };
-      }),
-      withTimeout(
-        recentClawsweeperClosed(env, targetRepos, github),
-        OPTIONAL_SECTION_TIMEOUT_MS,
-        "recent closed",
-      ).catch((error) => {
-        errors.push(error.message);
-        return { items: [], stats: emptyClosedStats(generatedAt) };
-      }),
-      readEvents(env).catch((error) => {
-        errors.push(`events: ${error.message}`);
-        return [];
-      }),
-    ]);
+  const [
+    workerHealth,
+    pipeline,
+    clusterRepair,
+    applyHealth,
+    automerge,
+    automergeReliability,
+    closed,
+    storedEvents,
+  ] = await Promise.all([
+    withTimeout(
+      recentWorkerHealth(env, repo, completedWorkflowRuns, github),
+      OPTIONAL_SECTION_TIMEOUT_MS * 2,
+      "worker health",
+    ).catch((error) => {
+      errors.push(error.message);
+      return emptyWorkerHealth(generatedAt);
+    }),
+    withTimeout(
+      pipelineItems(env, workerRuns.slice(0, 30), github),
+      OPTIONAL_SECTION_TIMEOUT_MS,
+      "pipeline",
+    ).catch((error) => {
+      errors.push(error.message);
+      return workerRuns.slice(0, 30).map((run) => classifyRun(run));
+    }),
+    withTimeout(
+      clusterRepairStatus(env, repo, targetRepos, activeRuns, github),
+      OPTIONAL_SECTION_TIMEOUT_MS,
+      "cluster repair intake",
+    ).catch((error) => {
+      errors.push(error.message);
+      return emptyClusterRepairStatus(targetRepos);
+    }),
+    withTimeout(
+      applyHealthStatus(env, targetRepos, github),
+      OPTIONAL_SECTION_TIMEOUT_MS,
+      "apply health",
+    ).catch((error) => {
+      errors.push(error.message);
+      return emptyApplyHealthStatus(targetRepos);
+    }),
+    withTimeout(
+      recentAutomerge(env, targetRepos[0] || "openclaw/openclaw", github),
+      OPTIONAL_SECTION_TIMEOUT_MS,
+      "automerge timing",
+    ).catch((error) => {
+      errors.push(error.message);
+      return { average_ms: null, samples: 0, items: [] };
+    }),
+    withTimeout(
+      recentAutomergeReliability(env, repo, targetRepos, github),
+      OPTIONAL_SECTION_TIMEOUT_MS,
+      "automerge reliability",
+    ).catch((error) => {
+      errors.push(error.message);
+      return emptyAutomergeReliability(generatedAt);
+    }),
+    withTimeout(
+      recentClawsweeperClosed(env, targetRepos, github),
+      OPTIONAL_SECTION_TIMEOUT_MS,
+      "recent closed",
+    ).catch((error) => {
+      errors.push(error.message);
+      return { items: [], stats: emptyClosedStats(generatedAt) };
+    }),
+    readEvents(env).catch((error) => {
+      errors.push(`events: ${error.message}`);
+      return [];
+    }),
+  ]);
   errors.push(...activeJobs.errors);
   errors.push(...workerHealth.errors);
   const terminalBay = await updateBayTerminalState(
@@ -1857,6 +1877,7 @@ async function statusSnapshot(env) {
       cluster_repair: clusterRepair,
       apply_health: applyHealth,
       automerge: automerge.items,
+      automerge_reliability: automergeReliability,
       closed_items: closed.items,
       closed_stats: closed.stats,
       operation_counts: operationEventCounts(storedEvents),
@@ -4072,6 +4093,174 @@ async function attachCiStatus(
     if (!item.ci)
       item.ci = { state: "unknown", source: "live", error: String(error?.message || error) };
   }
+}
+
+function emptyAutomergeReliability(updatedAt) {
+  return {
+    sampled_runs: 0,
+    completed_attempts: 0,
+    failed_attempts: 0,
+    failure_rate_percent: null,
+    active_attempts: 0,
+    stalled_attempts: 0,
+    average_duration_ms: null,
+    longest_duration_ms: null,
+    unresolved_failures: 0,
+    recovered_failures: 0,
+    failures: [],
+    updated_at: updatedAt,
+  };
+}
+
+function automergeRepairTarget(run, targetRepos) {
+  const title = String(run?.display_title || "").toLowerCase();
+  const candidates = targetRepos
+    .map((repository) => ({
+      repository: String(repository).trim(),
+      slug: String(repository).trim().toLowerCase().replaceAll("/", "-"),
+    }))
+    .filter((candidate) => candidate.repository && candidate.slug)
+    .sort((left, right) => right.slug.length - left.slug.length);
+  for (const candidate of candidates) {
+    const marker = `automerge-${candidate.slug}-`;
+    const markerIndex = title.indexOf(marker);
+    if (markerIndex < 0) continue;
+    const suffix = title.slice(markerIndex + marker.length);
+    const match = suffix.match(/^(\d+)\.md(?:\s|$)/);
+    if (!match) continue;
+    const number = Number(match[1]);
+    return {
+      repository: candidate.repository,
+      number,
+      item_url: `https://github.com/${candidate.repository}/pull/${number}`,
+    };
+  }
+  return null;
+}
+
+function automergeRunDurationMs(run, nowMs) {
+  const startedMs = Date.parse(String(run?.created_at || ""));
+  if (!Number.isFinite(startedMs)) return null;
+  const completedMs =
+    run?.status === "completed" ? Date.parse(String(run?.updated_at || "")) : nowMs;
+  if (!Number.isFinite(completedMs) || completedMs < startedMs) return null;
+  return completedMs - startedMs;
+}
+
+export function summarizeAutomergeReliability(runs, targetRepos, now = new Date().toISOString()) {
+  const nowMs = Date.parse(now);
+  const effectiveNowMs = Number.isFinite(nowMs) ? nowMs : Date.now();
+  const attempts = runs
+    .filter((run) => /\bautomerge repair\b/i.test(String(run?.display_title || "")))
+    .map((run) => {
+      const target = automergeRepairTarget(run, targetRepos);
+      if (!target) return null;
+      return {
+        run,
+        target,
+        startedMs: Date.parse(String(run?.created_at || "")),
+        completedMs: Date.parse(String(run?.updated_at || "")),
+        duration_ms: automergeRunDurationMs(run, effectiveNowMs),
+      };
+    })
+    .filter(Boolean);
+  const completed = attempts.filter((attempt) => attempt.run.status === "completed");
+  const failed = completed.filter((attempt) =>
+    TERMINAL_BAD_CONCLUSIONS.has(String(attempt.run.conclusion)),
+  );
+  const successes = completed.filter((attempt) => attempt.run.conclusion === "success");
+  const active = attempts.filter((attempt) => ACTIVE_RUN_STATUSES.has(String(attempt.run.status)));
+  const durations = completed
+    .map((attempt) => attempt.duration_ms)
+    .filter((duration) => Number.isFinite(duration) && duration >= 0);
+  const failureAttempts = failed
+    .map((attempt) => {
+      const recovery = successes.find(
+        (candidate) =>
+          candidate.target.repository === attempt.target.repository &&
+          candidate.target.number === attempt.target.number &&
+          candidate.startedMs >= attempt.completedMs,
+      );
+      return {
+        repository: attempt.target.repository,
+        number: attempt.target.number,
+        item_url: attempt.target.item_url,
+        run_url: attempt.run.html_url,
+        status: recovery ? "recovered" : "unresolved",
+        conclusion: attempt.run.conclusion,
+        started_at: attempt.run.created_at,
+        completed_at: attempt.run.updated_at,
+        duration_ms: attempt.duration_ms,
+        recovered: Boolean(recovery),
+      };
+    })
+    .sort(
+      (left, right) =>
+        Date.parse(String(right.started_at || "")) - Date.parse(String(left.started_at || "")),
+    );
+  const failuresByTarget = new Map();
+  for (const failure of failureAttempts) {
+    const targetKey = `${failure.repository}#${failure.number}`;
+    if (!failuresByTarget.has(targetKey)) failuresByTarget.set(targetKey, failure);
+  }
+  const failures = [...failuresByTarget.values()]
+    // Unresolved targets stay visible even when recovered retries fill the sample.
+    .sort(
+      (left, right) =>
+        Number(left.recovered) - Number(right.recovered) ||
+        Date.parse(String(right.started_at || "")) - Date.parse(String(left.started_at || "")),
+    );
+  const unresolvedFailures = failures.filter((failure) => !failure.recovered).length;
+  const result = emptyAutomergeReliability(new Date(effectiveNowMs).toISOString());
+  return {
+    ...result,
+    sampled_runs: attempts.length,
+    completed_attempts: completed.length,
+    failed_attempts: failed.length,
+    failure_rate_percent: completed.length
+      ? Math.round((failed.length / completed.length) * 1000) / 10
+      : null,
+    active_attempts: active.length,
+    stalled_attempts: active.filter(
+      (attempt) =>
+        Number.isFinite(attempt.duration_ms) && attempt.duration_ms >= AUTOMERGE_STALLED_AFTER_MS,
+    ).length,
+    average_duration_ms: durations.length
+      ? Math.round(durations.reduce((sum, duration) => sum + duration, 0) / durations.length)
+      : null,
+    longest_duration_ms: durations.length ? Math.max(...durations) : null,
+    unresolved_failures: unresolvedFailures,
+    recovered_failures: failures.length - unresolvedFailures,
+    failures: failures.slice(0, AUTOMERGE_FAILURE_DISPLAY_LIMIT),
+  };
+}
+
+async function recentAutomergeReliability(
+  env,
+  repo,
+  targetRepos,
+  github: GithubJsonReader = (path) => githubJson(env, path),
+) {
+  const targetKey = targetRepos
+    .map((target) => target.toLowerCase())
+    .sort()
+    .join(",");
+  const cacheKey = `automerge-reliability:${String(repo).toLowerCase()}:${targetKey}`;
+  const cached = await readStoredJson(env, cacheKey);
+  if (cached && Array.isArray(cached.failures)) return cached;
+
+  const response = await github(
+    `/repos/${repo}/actions/workflows/${AUTOMERGE_REPAIR_WORKFLOW}/runs?per_page=${AUTOMERGE_RELIABILITY_RUN_LIMIT}`,
+  );
+  const runs = Array.isArray(response?.workflow_runs) ? response.workflow_runs : [];
+  const result = summarizeAutomergeReliability(runs, targetRepos);
+  await writeStoredJson(
+    env,
+    cacheKey,
+    result,
+    numberFrom(env.AUTOMERGE_CACHE_TTL_SECONDS, AUTOMERGE_CACHE_TTL_SECONDS),
+  ).catch(() => undefined);
+  return result;
 }
 
 async function recentAutomerge(
@@ -7667,6 +7856,8 @@ a.pill:hover { color: var(--claw); text-decoration: none; }
       </div>
     </div>
     <aside class="side-col">
+      <h2>Automerge Reliability</h2>
+      <div id="automerge-reliability"></div>
       <h2>Automerge Speed</h2>
       <div id="automerge"></div>
       <h2>Closed by ClawSweeper</h2>
@@ -8402,7 +8593,12 @@ function renderDashboard(data, note) {
     handoffTelemetryFailed || handoffStatus === "degraded" || handoffStatus === "stalled";
   const operationalStatus = data.operational_health?.status;
   const operationalAttention = ["degraded", "stalled", "unknown"].includes(operationalStatus);
-  const needsAttention = unresolved || applyAttention || handoffAttention || operationalAttention;
+  const automergeReliability = data.recent?.automerge_reliability;
+  const automergeAttention =
+    (automergeReliability?.unresolved_failures || 0) > 0 ||
+    (automergeReliability?.stalled_attempts || 0) > 0;
+  const needsAttention =
+    unresolved || applyAttention || handoffAttention || operationalAttention || automergeAttention;
   const workerCount = (data.workers || []).length;
   const repoCount = (data.source.target_repositories || []).length;
   document.getElementById("hero-dot").className = "hero-dot " + (handoffStatus === "stalled" || operationalStatus === "stalled" ? "red" : needsAttention ? "amber" : "ok");
@@ -8429,6 +8625,7 @@ function renderDashboard(data, note) {
   openWorkerFromHash();
   renderClusterRepair(data.recent?.cluster_repair);
   renderPipeline(data.pipeline || []);
+  renderAutomergeReliability(data.recent?.automerge_reliability);
   renderAutomerge(data.recent.automerge || []);
   renderClosedStats(data.recent.closed_stats);
   renderClosedItems(data.recent.closed_items || []);
@@ -8798,6 +8995,25 @@ function renderAutomerge(rows) {
     return;
   }
   document.getElementById("automerge").innerHTML = '<div class="side-list">' + rows.map(row => '<article class="side-row"><div class="side-main">' + linkClass(row.url, "#" + row.number, "item-link") + '<div class="muted side-title">' + esc(row.title) + '</div></div><div class="side-meta"><span class="pill violet">' + (row.duration_ms ? elapsed(row.duration_ms) : "unknown") + '</span><span>' + (row.merged_at ? since(row.merged_at) : "") + '</span></div></article>').join("") + '</div>';
+}
+function renderAutomergeReliability(reliability) {
+  const safe = reliability || {
+    sampled_runs: 0,
+    completed_attempts: 0,
+    failed_attempts: 0,
+    failure_rate_percent: null,
+    active_attempts: 0,
+    stalled_attempts: 0,
+    average_duration_ms: null,
+    longest_duration_ms: null,
+    failures: []
+  };
+  const failureRate = safe.failure_rate_percent == null ? "n/a" : safe.failure_rate_percent + "%";
+  const active = fmt.format(safe.active_attempts || 0) + " / " + fmt.format(safe.stalled_attempts || 0);
+  const stats = '<div class="closed-stats"><div class="closed-stat"><span>Failure rate</span><strong>' + esc(failureRate) + '</strong></div><div class="closed-stat"><span>Avg runtime</span><strong>' + elapsed(safe.average_duration_ms) + '</strong></div><div class="closed-stat"><span>Active / stalled</span><strong>' + esc(active) + '</strong></div></div>';
+  const sample = '<div class="muted" style="margin:8px 0">' + fmt.format(safe.sampled_runs || 0) + " runs sampled · " + fmt.format(safe.completed_attempts || 0) + " completed · longest " + elapsed(safe.longest_duration_ms) + '</div>';
+  const rows = (safe.failures || []).map(failure => '<article class="side-row"><div class="side-main"><div class="row-top">' + linkClass(failure.item_url, failure.repository + "#" + failure.number, "item-link") + linkClass(failure.run_url, "run", "pill run-link") + '</div><div class="muted side-title">' + esc(failure.conclusion || "failure") + " · " + elapsed(failure.duration_ms) + " · " + esc(failure.completed_at ? since(failure.completed_at) : "") + '</div></div><div class="side-meta"><span class="pill ' + (failure.recovered ? "" : "red") + '">' + (failure.recovered ? "recovered" : "unresolved") + '</span></div></article>').join("");
+  document.getElementById("automerge-reliability").innerHTML = stats + sample + (rows ? '<div class="side-list">' + rows + '</div>' : '<div class="empty">No automerge worker failures in the recent sample.</div>');
 }
 function renderClosedItems(rows) {
   if (!rows.length) {

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -126,6 +126,10 @@ is absent or a cache event lands in another Cloudflare colo.
   depth, and the oldest queued/running ages
 - job-level worker attempt error rate, recovery rate, and unresolved failures,
   including failures hidden by workflow `continue-on-error`
+- automerge worker reliability from the dedicated repair workflow, including
+  sampled failure rate, average and longest runtime, active or stalled attempts,
+  and the latest failure per target marked as unresolved or recovered by a later
+  successful run
 - active pipeline rows grouped as automerge, repair, exact review, hot review,
   apply, commit review, or background review
 - CI state for active PR rows when available
@@ -164,9 +168,12 @@ set. Other recent activity remains bounded independently.
 Status responses use stale-while-revalidate delivery. After the 20-second fresh
 window expires, the Worker immediately returns the last good snapshot, marks it
 with `X-ClawSweeper-Cache: stale`, and coalesces one background refresh per
-isolate. Recent automerge timing is cached for five minutes and recent
-ClawSweeper-owned closes for five minutes because those historical sections do
-not need worker-step freshness. The deployment smoke output includes cache
+isolate. Recent automerge timing and the latest 100 runs from
+`repair-cluster-worker.yml` are cached for five minutes, as are recent
+ClawSweeper-owned closes, because those historical sections do not need
+worker-step freshness. Reliability sampling filters those workflow runs to
+`automerge repair` titles, so failures remain visible even when a worker exits
+before publishing a status event. The deployment smoke output includes cache
 state, fetch time, and current diagnostics.
 
 ## Exact Review history

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -17,6 +17,7 @@ import worker, {
   mergeBayJourneyState,
   mergeBayTerminalState,
   StatusStore,
+  summarizeAutomergeReliability,
   summarizeBayJourneyTimings,
   workerWorkKind,
 } from "../dashboard/worker.ts";
@@ -35,6 +36,58 @@ test("exact-review queue defaults to 64 of the 128 global workers", () => {
       WORKER_BUDGET: "64",
     }),
     64,
+  );
+});
+
+test("automerge reliability summarizes failures, recovery, duration, and stalled runs", () => {
+  const run = (
+    id: number,
+    number: number,
+    status: string,
+    conclusion: string | null,
+    createdAt: string,
+    updatedAt: string,
+  ) => ({
+    id,
+    display_title: `automerge repair jobs/openclaw/inbox/automerge-openclaw-openclaw-${number}.md`,
+    status,
+    conclusion,
+    html_url: `https://github.com/openclaw/clawsweeper/actions/runs/${id}`,
+    created_at: createdAt,
+    updated_at: updatedAt,
+  });
+  const summary = summarizeAutomergeReliability(
+    [
+      run(1, 107691, "completed", "failure", "2026-07-16T09:00:00Z", "2026-07-16T09:20:00Z"),
+      run(2, 107691, "completed", "success", "2026-07-16T09:30:00Z", "2026-07-16T09:40:00Z"),
+      run(3, 107692, "completed", "failure", "2026-07-16T10:00:00Z", "2026-07-16T10:20:00Z"),
+      run(6, 107692, "completed", "failure", "2026-07-16T08:00:00Z", "2026-07-16T08:05:00Z"),
+      run(4, 107693, "in_progress", null, "2026-07-16T09:30:00Z", "2026-07-16T09:30:00Z"),
+      {
+        ...run(5, 107694, "completed", "failure", "2026-07-16T11:00:00Z", "2026-07-16T11:05:00Z"),
+        display_title: "repair cluster jobs/openclaw/inbox/gitcrawl-55.md",
+      },
+    ],
+    ["openclaw/openclaw"],
+    "2026-07-16T12:00:00Z",
+  );
+
+  assert.equal(summary.sampled_runs, 5);
+  assert.equal(summary.completed_attempts, 4);
+  assert.equal(summary.failed_attempts, 3);
+  assert.equal(summary.failure_rate_percent, 75);
+  assert.equal(summary.average_duration_ms, 825_000);
+  assert.equal(summary.longest_duration_ms, 1_200_000);
+  assert.equal(summary.active_attempts, 1);
+  assert.equal(summary.stalled_attempts, 1);
+  assert.equal(summary.recovered_failures, 1);
+  assert.equal(summary.unresolved_failures, 1);
+  assert.deepEqual(
+    summary.failures.map((failure) => [failure.number, failure.status]),
+    [
+      [107692, "unresolved"],
+      [107691, "recovered"],
+    ],
   );
 });
 
@@ -5532,6 +5585,8 @@ test("dashboard HTML preserves UTF-8 emoji labels", async () => {
   assert.match(html, /Refreshing live status in the background/);
   assert.match(html, /Cluster Intake/);
   assert.match(html, /Active Pipeline/);
+  assert.match(html, /Automerge Reliability/);
+  assert.match(html, /id="automerge-reliability"/);
   assert.match(html, /Closed by ClawSweeper/);
   assert.match(html, /Worker Health/);
   assert.match(html, /Recent Activity/);
@@ -5694,6 +5749,32 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
         ],
       },
       automerge: [],
+      automerge_reliability: {
+        sampled_runs: 3,
+        completed_attempts: 3,
+        failed_attempts: 2,
+        failure_rate_percent: 66.7,
+        active_attempts: 0,
+        stalled_attempts: 0,
+        average_duration_ms: 600_000,
+        longest_duration_ms: 1_200_000,
+        unresolved_failures: 1,
+        recovered_failures: 1,
+        failures: [
+          {
+            repository: "openclaw/openclaw",
+            number: 107691,
+            item_url: "https://github.com/openclaw/openclaw/pull/107691",
+            run_url: "https://github.com/openclaw/clawsweeper/actions/runs/29431617465",
+            status: "unresolved",
+            conclusion: "failure",
+            started_at: "2026-07-05T10:50:00Z",
+            completed_at: "2026-07-05T11:10:00Z",
+            duration_ms: 1_200_000,
+            recovered: false,
+          },
+        ],
+      },
       closed_items: [],
       closed_stats: { issues: 0, prs: 0, total: 0, window_hours: 24 },
       cluster_repair: null,
@@ -5742,6 +5823,9 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
   assert.match(elementFor("exact-review-lanes").innerHTML, /52 review admission slots open/);
   assert.match(elementFor("exact-review-lanes").innerHTML, /Result publication/);
   assert.match(elementFor("exact-review-lanes").innerHTML, /3 result publication slots open/);
+  assert.match(elementFor("automerge-reliability").innerHTML, /66.7%/);
+  assert.match(elementFor("automerge-reliability").innerHTML, /openclaw\/openclaw#107691/);
+  assert.match(elementFor("automerge-reliability").innerHTML, /unresolved/);
   assert.match(
     elementFor("exact-review-lanes").innerHTML,
     /adaptive ceiling 24 after GitHub rate limit/,
@@ -6285,6 +6369,12 @@ test("dashboard exposes active worker jobs and their current steps", async () =>
     ) {
       return jsonResponse({ workflow_runs: [] });
     }
+    if (
+      url.pathname ===
+      "/repos/openclaw/clawsweeper/actions/workflows/repair-cluster-worker.yml/runs"
+    ) {
+      return jsonResponse({ workflow_runs: [] });
+    }
     if (url.pathname === "/search/issues") return jsonResponse({ items: [] });
     if (url.pathname === "/repos/openclaw/openclaw/issues") return jsonResponse([]);
     throw new Error(`unexpected fetch ${url}`);
@@ -6400,6 +6490,12 @@ test("dashboard keeps control-plane workflow fallbacks out of Codex capacity", a
     ) {
       return jsonResponse({ workflow_runs: [] });
     }
+    if (
+      url.pathname ===
+      "/repos/openclaw/clawsweeper/actions/workflows/repair-cluster-worker.yml/runs"
+    ) {
+      return jsonResponse({ workflow_runs: [] });
+    }
     if (url.pathname === "/search/issues") return jsonResponse({ items: [] });
     if (url.pathname === "/repos/openclaw/openclaw/issues") return jsonResponse([]);
     throw new Error(`unexpected fetch ${url}`);
@@ -6508,6 +6604,12 @@ test("dashboard bounds worker job detail request concurrency", async () => {
     if (
       url.pathname ===
       "/repos/openclaw/clawsweeper/actions/workflows/repair-cluster-intake.yml/runs"
+    ) {
+      return jsonResponse({ workflow_runs: [] });
+    }
+    if (
+      url.pathname ===
+      "/repos/openclaw/clawsweeper/actions/workflows/repair-cluster-worker.yml/runs"
     ) {
       return jsonResponse({ workflow_runs: [] });
     }
@@ -7394,6 +7496,104 @@ test("dashboard parallelizes and caches historical GitHub telemetry", async () =
     assert.equal((await second.json()).averages.automerge_samples, 4);
     assert.equal(searchRequests, 1);
     assert.equal(closedRequests, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+    Object.defineProperty(globalThis, "caches", { configurable: true, value: originalCaches });
+  }
+});
+
+test("dashboard reports automerge worker reliability independently of merged PR timing", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalCaches = globalThis.caches;
+  Object.defineProperty(globalThis, "caches", {
+    configurable: true,
+    value: {
+      default: {
+        match: async () => undefined,
+        put: async () => undefined,
+      },
+    },
+  });
+  let reliabilityRequests = 0;
+  globalThis.fetch = async (input) => {
+    const url = new URL(String(input));
+    if (
+      url.pathname ===
+      "/repos/openclaw/clawsweeper/actions/workflows/repair-cluster-worker.yml/runs"
+    ) {
+      reliabilityRequests += 1;
+      const workflowRun = (
+        id: number,
+        number: number,
+        conclusion: "failure" | "success",
+        createdAt: string,
+        updatedAt: string,
+      ) => ({
+        id,
+        display_title: `automerge repair jobs/openclaw/inbox/automerge-openclaw-openclaw-${number}.md`,
+        status: "completed",
+        conclusion,
+        html_url: `https://github.com/openclaw/clawsweeper/actions/runs/${id}`,
+        created_at: createdAt,
+        updated_at: updatedAt,
+      });
+      return jsonResponse({
+        workflow_runs: [
+          workflowRun(
+            29431617465,
+            107691,
+            "failure",
+            "2026-07-15T16:15:04Z",
+            "2026-07-15T16:34:51Z",
+          ),
+          workflowRun(
+            29434021623,
+            107691,
+            "success",
+            "2026-07-15T16:49:45Z",
+            "2026-07-15T16:51:53Z",
+          ),
+          workflowRun(
+            29435000000,
+            107692,
+            "failure",
+            "2026-07-15T17:00:00Z",
+            "2026-07-15T17:10:00Z",
+          ),
+        ],
+      });
+    }
+    if (url.pathname.includes("/actions/")) return jsonResponse({ workflow_runs: [] });
+    if (url.pathname === "/search/issues") return jsonResponse({ items: [] });
+    if (url.pathname === "/repos/openclaw/openclaw/issues") return jsonResponse([]);
+    return new Response(JSON.stringify({ message: "not found" }), { status: 404 });
+  };
+
+  try {
+    const response = await worker.fetch(new Request("https://clawsweeper.openclaw.ai/api/status"), {
+      STATUS_STORE: new MemoryKv(),
+      CLAWSWEEPER_REPO: "openclaw/clawsweeper",
+      TARGET_REPOS: "openclaw/openclaw",
+      CACHE_TTL_SECONDS: "-1",
+    });
+    assert.equal(response.status, 200);
+    const status = await response.json();
+    const reliability = status.recent.automerge_reliability;
+    assert.equal(reliabilityRequests, 1);
+    assert.equal(reliability.sampled_runs, 3);
+    assert.equal(reliability.failure_rate_percent, 66.7);
+    assert.equal(reliability.recovered_failures, 1);
+    assert.equal(reliability.unresolved_failures, 1);
+    assert.deepEqual(
+      reliability.failures.map((failure: { number: number; status: string }) => [
+        failure.number,
+        failure.status,
+      ]),
+      [
+        [107692, "unresolved"],
+        [107691, "recovered"],
+      ],
+    );
   } finally {
     globalThis.fetch = originalFetch;
     Object.defineProperty(globalThis, "caches", { configurable: true, value: originalCaches });
@@ -9615,6 +9815,9 @@ test("dashboard html preserves client compactText regex escapes", async () => {
 
 async function activePrFetch(input: RequestInfo | URL) {
   const url = String(input);
+  if (url.includes("/actions/workflows/repair-cluster-worker.yml/runs")) {
+    return jsonResponse({ workflow_runs: [] });
+  }
   if (url.includes("/repos/openclaw/clawsweeper/actions/runs")) {
     return jsonResponse({
       workflow_runs: [


### PR DESCRIPTION
## Summary

- sample the latest 100 runs from the dedicated `repair-cluster-worker.yml` workflow and isolate `automerge repair` attempts
- show attempt failure rate, average/longest runtime, active/stalled counts, and one latest failure per target PR
- mark failures as recovered when a later successful worker run exists, and make unresolved or stalled automerge work affect the dashboard attention state

## Why

The dashboard previously showed only successful command-to-merge timing and broad worker health. Failures such as https://github.com/openclaw/openclaw/pull/107691 could be recorded in the workflow and status comment without producing a dashboard event, then disappear from the latest broad worker sample.

This reads the workflow run source directly, so it still exposes failures when the worker exits before publishing status artifacts or events. It complements the fix in https://github.com/openclaw/clawsweeper/pull/609 without depending on that event path.

## Validation

- `pnpm run check`
- focused dashboard aggregation, API integration, and client rendering tests
- live sample against the latest 100 workflow runs
- autoreview: clean, no accepted/actionable findings
- production deploy smoke: https://github.com/openclaw/clawsweeper/actions/runs/29497886402