### PR TITLE
Clarify exact review net rates

### DIFF
--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -7060,6 +7060,44 @@ h2::before { content: ""; flex: 0 0 auto; width: 14px; height: 2px; border-radiu
 .exact-trend-point { fill: var(--claw); }
 .lane-speed { margin-top: 20px; padding-top: 16px; border-top: 1px solid var(--line-soft); }
 .lane-speed .exact-trend-status { margin-top: 4px; }
+.lane-rate-label { display: flex; align-items: center; gap: 5px; }
+.lane-rate-help {
+  position: relative;
+}
+.lane-rate-help summary {
+  display: inline-grid;
+  place-items: center;
+  width: 13px;
+  height: 13px;
+  border: 1px solid var(--muted);
+  border-radius: 50%;
+  color: var(--muted);
+  cursor: help;
+  font-size: 9px;
+  line-height: 1;
+  list-style: none;
+}
+.lane-rate-help summary::-webkit-details-marker { display: none; }
+.lane-rate-tooltip {
+  display: none;
+  position: absolute;
+  z-index: 20;
+  bottom: calc(100% + 7px);
+  left: -8px;
+  width: min(300px, calc(100vw - 64px));
+  padding: 8px 10px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--panel);
+  box-shadow: 0 8px 24px color-mix(in srgb, #000 20%, transparent);
+  color: var(--text);
+  font-size: 11px;
+  font-weight: 400;
+  line-height: 1.4;
+}
+.lane-rate-help[open] .lane-rate-tooltip,
+.lane-rate-help:hover .lane-rate-tooltip,
+.lane-rate-help:focus-within .lane-rate-tooltip { display: block; }
 .lane-speed-line { fill: none; stroke: var(--violet); stroke-width: 2.5; vector-effect: non-scaling-stroke; }
 .lane-speed-point { fill: var(--violet); }
 .trend-empty { display: grid; place-items: center; height: 130px; color: var(--muted); font-size: 12px; }
@@ -8157,7 +8195,15 @@ function laneSpeedStatus(sample) {
   return { className: "stable", label: "Balanced" + window };
 }
 
-function laneSpeedTrend(samples, speedLabel) {
+function laneRateLabel(speedLabel, helpText) {
+  const helpId = "lane-rate-help-" + String(speedLabel).toLowerCase().replace(/[^a-z0-9]+/g, "-");
+  const help = helpText
+    ? '<details class="lane-rate-help"><summary aria-label="Explain ' + esc(speedLabel) + '" aria-describedby="' + esc(helpId) + '">?</summary><span class="lane-rate-tooltip" id="' + esc(helpId) + '" role="tooltip">' + esc(helpText) + '</span></details>'
+    : "";
+  return '<div class="lane-rate-label"><span>' + esc(speedLabel) + '</span>' + help + '</div>';
+}
+
+function laneSpeedTrend(samples, speedLabel, helpText = "") {
   const rates = laneSpeedHistory(samples);
   const rangeMs = activeHealthRange === "7d" ? 7 * 86400000 : activeHealthRange === "24h" ? 86400000 : 6 * 3600000;
   const latestAt = rates.length ? Date.parse(rates.at(-1).at) : 0;
@@ -8187,9 +8233,9 @@ function laneSpeedTrend(samples, speedLabel) {
   if (!visible.length) {
     const emptyClass = headline === "Stale" ? "stale" : "collecting";
     const emptyLabel = headline === "Stale"
-      ? "Stale · no speed sample in the last 12m"
+      ? "Stale · no rate sample in the last 12m"
       : "Needs two continuous five-minute samples";
-    return '<div class="lane-speed"><div class="lane-count"><span>' + esc(speedLabel) + '</span><strong>' + headline + '</strong></div><div class="exact-trend-status ' + emptyClass + '">' + emptyLabel + '</div><div class="trend-empty">No speed history in this range.</div></div>';
+    return '<div class="lane-speed"><div class="lane-count">' + laneRateLabel(speedLabel, helpText) + '<strong>' + headline + '</strong></div><div class="exact-trend-status ' + emptyClass + '">' + emptyLabel + '</div><div class="trend-empty">No rate history in this range.</div></div>';
   }
   const width = 600;
   const height = 150;
@@ -8206,10 +8252,10 @@ function laneSpeedTrend(samples, speedLabel) {
     ? laneSpeedStatus(current)
     : collectingCurrentSegment
       ? { className: "collecting", label: "Needs two continuous five-minute samples" }
-    : { className: "stale", label: "Stale · no speed sample in the last 12m" };
+    : { className: "stale", label: "Stale · no rate sample in the last 12m" };
   const rangeLabel = activeHealthRange === "7d" ? "7d ago" : activeHealthRange + " ago";
   const axis = '<text class="trend-axis-label" x="' + plot.left + '" y="' + (height - 7) + '">' + rangeLabel + '</text><text class="trend-axis-label" x="' + (plot.left + plot.width) + '" y="' + (height - 7) + '" text-anchor="end">now</text>';
-  return '<div class="lane-speed"><div class="lane-count"><span>' + esc(speedLabel) + '</span><strong>' + headline + '</strong></div><div class="exact-trend-status ' + direction.className + '">' + esc(direction.label) + '</div><svg class="exact-trend-svg" viewBox="0 0 ' + width + " " + height + '" role="img" aria-label="' + esc(speedLabel + ", completed minus incoming, over " + activeHealthRange) + '">' + grid + '<path class="lane-speed-line" d="' + trendPath(geometry) + '"></path>' + points + axis + '</svg></div>';
+  return '<div class="lane-speed"><div class="lane-count">' + laneRateLabel(speedLabel, helpText) + '<strong>' + headline + '</strong></div><div class="exact-trend-status ' + direction.className + '">' + esc(direction.label) + '</div><svg class="exact-trend-svg" viewBox="0 0 ' + width + " " + height + '" role="img" aria-label="' + esc(speedLabel + ", completed minus incoming, over " + activeHealthRange) + '">' + grid + '<path class="lane-speed-line" d="' + trendPath(geometry) + '"></path>' + points + axis + '</svg></div>';
 }
 
 function renderExecutionAlert(current) {
@@ -8334,13 +8380,17 @@ function renderExactReviewLanes(queue) {
   const target = document.getElementById("exact-review-lanes");
   if (!target) return;
   const lanes = queue?.lanes;
-  target.innerHTML = [["Review admission", "Review speed", "review", lanes?.review], ["Result publication", "Publication speed", "publication", lanes?.publication]].map(([label, speedLabel, laneKey, lane]) => {
+  const rateHelp = {
+    review: "Successful completions minus incoming review demand per hour. Incoming includes newly queued work and shed demand. Positive means catching up; negative means falling behind.",
+    publication: "Successful completions minus newly queued publication work per hour. Positive means catching up; negative means falling behind."
+  };
+  target.innerHTML = [["Review admission", "Net review rate", "review", lanes?.review], ["Result publication", "Net publication rate", "publication", lanes?.publication]].map(([label, speedLabel, laneKey, lane]) => {
     const samples = exactReviewHistory(laneKey);
     if (!lane) {
       const sampledAt = samples.at(-1)?.at;
       return '<div class="exact-lane"><div class="exact-lane-head"><strong>' + esc(label) + '</strong><span>Live snapshot unavailable</span></div>' +
         exactReviewTrend(samples, label) +
-        laneSpeedTrend(samples, speedLabel) +
+        laneSpeedTrend(samples, speedLabel, rateHelp[laneKey]) +
         '<div class="lane-foot">' + (sampledAt ? "Last sampled " + esc(since(sampledAt)) : "History starts with the next five-minute sample") + '</div></div>';
     }
     const capacity = Math.max(0, lane.capacity || 0);
@@ -8359,7 +8409,7 @@ function renderExactReviewLanes(queue) {
     return '<div class="exact-lane"><div class="exact-lane-head"><strong>' + esc(label) + '</strong><span>' + fmt.format(active) + ' of ' + fmt.format(capacity) + ' active</span></div>' +
       '<div class="lane-count"><span>Pending</span><strong>' + fmt.format(lane.pending || 0) + '</strong></div>' +
       exactReviewTrend(samples, label) +
-      laneSpeedTrend(samples, speedLabel) +
+      laneSpeedTrend(samples, speedLabel, rateHelp[laneKey]) +
       '<div class="lane-counts">' +
       '<div class="lane-count"><span>Ready</span><strong>' + fmt.format(lane.ready || 0) + '</strong></div>' +
       '<div class="lane-count"><span>Backoff</span><strong>' + fmt.format(lane.backoff || 0) + '</strong></div>' +

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -197,24 +197,27 @@ and returns legacy operational samples, but new samples omit those unused chart
 fields. Existing buckets expire naturally; no migration or manual cleanup is
 required.
 
-Each lane renders one signed speed value and curve: successfully completed work
-minus newly incoming work, expressed per hour. Positive speed means the lane is
-catching up, negative speed means it is falling behind, and zero is balanced.
+Each lane renders one signed net-rate value and curve: successfully completed
+work minus newly incoming work, expressed per hour. A positive rate means the
+lane is catching up, a negative rate means it is falling behind, and zero is
+balanced.
 Incoming counts newly created queue work units; review demand also includes
 shed recovery work. Pending merges, delivery replays, retries, and source-drift
 requeues do not create new demand. Completed work is counted only when a
 successful item actually leaves its lane, in the same queue storage transaction
-as the deletion.
+as the deletion. A help icon beside each net-rate label exposes this definition
+on hover, keyboard focus, or activation; the review explanation explicitly notes
+that incoming demand includes shed work.
 
 After two continuous samples roughly five minutes apart, the dashboard scales
 the observed net change to an hourly rate and labels it provisional with the
 actual window length. Once an hour of continuous counters exists, it uses a
 trailing hourly rate. Zero incoming or zero completed work remains valid data. A
 gap over 12 minutes, a cumulative counter reset, or a legacy sample without flow
-counters starts a new speed segment; a latest speed point older than 12 minutes
+counters starts a new rate segment; a latest rate point older than 12 minutes
 is stale.
 Pre-deployment counter history cannot be backfilled, so the first provisional
-speed appears about five minutes after deployment.
+rate appears about five minutes after deployment.
 
 Operational health remains a current-snapshot alert rather than a historical
 chart. `/api/status` classifies the already-fetched active workflow runs as:

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -5949,18 +5949,30 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
   const laneHtml = elementFor("exact-review-lanes").innerHTML;
   assert.match(laneHtml, /Growing · \+12 in the last hour/);
   assert.match(laneHtml, /Draining · −12 in the last hour/);
-  assert.match(laneHtml, /Review speed/);
-  assert.match(laneHtml, /Publication speed/);
-  assert.match(laneHtml, /Review speed<\/span><strong>−36 \/ hour/);
-  assert.match(laneHtml, /Publication speed<\/span><strong>\+72 \/ hour/);
+  assert.match(laneHtml, /Net review rate/);
+  assert.match(laneHtml, /Net publication rate/);
+  assert.match(laneHtml, /Net review rate.*<\/div><strong>−36 \/ hour/);
+  assert.match(laneHtml, /Net publication rate.*<\/div><strong>\+72 \/ hour/);
+  assert.equal(laneHtml.match(/class="lane-rate-help"/g)?.length, 2);
+  assert.equal(laneHtml.match(/role="tooltip"/g)?.length, 2);
+  assert.match(laneHtml, /aria-describedby="lane-rate-help-net-review-rate"/);
+  assert.match(laneHtml, /aria-describedby="lane-rate-help-net-publication-rate"/);
+  assert.match(
+    laneHtml,
+    /Successful completions minus incoming review demand per hour\. Incoming includes newly queued work and shed demand\./,
+  );
+  assert.match(laneHtml, /Successful completions minus newly queued publication work per hour\./);
   assert.match(laneHtml, /Falling behind/);
   assert.match(laneHtml, /Catching up/);
   assert.equal(laneHtml.match(/class="lane-speed"/g)?.length, 2);
   assert.doesNotMatch(laneHtml, /Processed \/ hour|Incoming \/ hour/);
-  assert.match(laneHtml, /role="img" aria-label="Review speed, completed minus incoming, over 7d"/);
   assert.match(
     laneHtml,
-    /role="img" aria-label="Publication speed, completed minus incoming, over 7d"/,
+    /role="img" aria-label="Net review rate, completed minus incoming, over 7d"/,
+  );
+  assert.match(
+    laneHtml,
+    /role="img" aria-label="Net publication rate, completed minus incoming, over 7d"/,
   );
   assert.match(laneHtml, /role="img" aria-label="Review admission pending backlog over 7d"/);
   assert.match(laneHtml, /Live snapshot unavailable/);
@@ -5993,13 +6005,13 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
   assert.equal(Math.round(provisionalRates[0].rate), 36);
   assert.equal(provisionalRates[0].provisional, true);
   assert.equal(Math.round(provisionalRates[0].windowMinutes), 5);
-  const provisionalSpeed = context.laneSpeedTrend(provisionalSamples, "Review speed");
-  assert.match(provisionalSpeed, /Review speed<\/span><strong>\+36 \/ hour/);
+  const provisionalSpeed = context.laneSpeedTrend(provisionalSamples, "Net review rate");
+  assert.match(provisionalSpeed, /Net review rate<\/span><\/div><strong>\+36 \/ hour/);
   assert.match(provisionalSpeed, /Catching up · provisional 5m window/);
 
   const balancedSamples = [flowSample(5, 10, 20), flowSample(0, 10, 20)];
-  const balancedSpeed = context.laneSpeedTrend(balancedSamples, "Review speed");
-  assert.match(balancedSpeed, /Review speed<\/span><strong>0 \/ hour/);
+  const balancedSpeed = context.laneSpeedTrend(balancedSamples, "Net review rate");
+  assert.match(balancedSpeed, /Net review rate<\/span><\/div><strong>0 \/ hour/);
   assert.match(balancedSpeed, /Balanced · provisional 5m window/);
   assert.doesNotMatch(balancedSpeed, /Collecting/);
 
@@ -6032,9 +6044,9 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
   assert.notEqual(resetRates[0].segmentId, resetRates[1].segmentId);
   const resetCollecting = context.laneSpeedTrend(
     [flowSample(10, 10, 10), flowSample(5, 11, 12), flowSample(0, 1, 1)],
-    "Review speed",
+    "Net review rate",
   );
-  assert.match(resetCollecting, /Review speed<\/span><strong>Collecting/);
+  assert.match(resetCollecting, /Net review rate<\/span><\/div><strong>Collecting/);
   assert.match(resetCollecting, /Needs two continuous five-minute samples/);
 
   const legacyBreakRates = context.laneSpeedHistory([
@@ -6058,12 +6070,12 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
 
   const staleSpeed = context.laneSpeedTrend(
     [flowSample(25, 0, 0), flowSample(20, 1, 2)],
-    "Publication speed",
+    "Net publication rate",
   );
-  assert.match(staleSpeed, /Publication speed<\/span><strong>Stale/);
-  assert.match(staleSpeed, /Stale · no speed sample in the last 12m/);
-  const collectingSpeed = context.laneSpeedTrend([flowSample(0, 0, 0)], "Review speed");
-  assert.match(collectingSpeed, /Review speed<\/span><strong>Collecting/);
+  assert.match(staleSpeed, /Net publication rate<\/span><\/div><strong>Stale/);
+  assert.match(staleSpeed, /Stale · no rate sample in the last 12m/);
+  const collectingSpeed = context.laneSpeedTrend([flowSample(0, 0, 0)], "Net review rate");
+  assert.match(collectingSpeed, /Net review rate<\/span><\/div><strong>Collecting/);
   assert.match(collectingSpeed, /Needs two continuous five-minute samples/);
 
   assert.equal(


### PR DESCRIPTION
## Summary

- rename the signed dashboard metrics to `Net review rate` and `Net publication rate`
- add accessible help controls that explain the formula on hover, keyboard focus, and activation
- clarify that incoming review demand includes newly queued work and shed demand
- align dashboard documentation and regression coverage with the new terminology

## Why

`Review speed` and `Publication speed` sounded like non-negative throughput metrics, while the values intentionally represent successful completions minus incoming demand per hour. Negative values are valid and mean the lane is falling behind, so the old labels made correct data look like a calculation bug.

This PR changes only the presentation and explanation. It does not change counters, sampling windows, or the net-rate calculation.

## Validation

- `pnpm run check`
- `pnpm run build:dashboard`
- `node --test test/dashboard-worker.test.ts` (125 passed)
- `/data/code/openclaw/openclaw/.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` (clean; no accepted/actionable findings)
