### PR TITLE
ci: validate sparse repair checkouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,19 @@ jobs:
       - name: Run check
         run: pnpm run check
 
+  sparse-repair-builds:
+    name: sparse repair build smoke
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: ./.github/actions/setup-pnpm
+
+      - name: Build each sparse repair checkout
+        run: pnpm run test:workflow-sparse-checkout
+
   crawl-remote-toolchain:
     name: crawl-remote toolchain integration
     runs-on: ubuntu-latest

--- a/.github/workflows/repair-comment-router.yml
+++ b/.github/workflows/repair-comment-router.yml
@@ -101,22 +101,7 @@ jobs:
             results
             schema/clawsweeper-pr-close-coverage-proof.schema.json
             scripts/hydrate-state.ts
-            src/clawsweeper-text.ts
-            src/command.ts
-            src/codex-env.ts
-            src/codex-output-capture.ts
-            src/codex-spawn.ts
-            src/codex-process-worker.ts
-            src/codex-process.ts
-            src/codex-transient.ts
-            src/github-json.ts
-            src/github-retry.ts
-            src/pr-close-coverage-proof.ts
-            src/action-ledger-files.ts
-            src/action-ledger-runtime.ts
-            src/action-ledger.ts
-            src/repair
-            src/repository-profiles.ts
+            src
             package.json
             pnpm-lock.yaml
             pnpm-workspace.yaml

--- a/.github/workflows/spam-comment-intake.yml
+++ b/.github/workflows/spam-comment-intake.yml
@@ -55,19 +55,7 @@ jobs:
             config/automation-limits.json
             prompts/pr-close-coverage-proof.md
             schema/clawsweeper-pr-close-coverage-proof.schema.json
-            src/clawsweeper-text.ts
-            src/command.ts
-            src/codex-env.ts
-            src/codex-output-capture.ts
-            src/codex-process-worker.ts
-            src/codex-process.ts
-            src/codex-spawn.ts
-            src/codex-transient.ts
-            src/github-json.ts
-            src/github-retry.ts
-            src/pr-close-coverage-proof.ts
-            src/repair
-            src/repository-profiles.ts
+            src
             package.json
             pnpm-lock.yaml
             pnpm-workspace.yaml

--- a/.github/workflows/spam-scanner.yml
+++ b/.github/workflows/spam-scanner.yml
@@ -78,19 +78,7 @@ jobs:
             results
             schema/clawsweeper-pr-close-coverage-proof.schema.json
             scripts/hydrate-state.ts
-            src/clawsweeper-text.ts
-            src/command.ts
-            src/codex-env.ts
-            src/codex-output-capture.ts
-            src/codex-process-worker.ts
-            src/codex-process.ts
-            src/codex-spawn.ts
-            src/codex-transient.ts
-            src/github-json.ts
-            src/github-retry.ts
-            src/pr-close-coverage-proof.ts
-            src/repair
-            src/repository-profiles.ts
+            src
             package.json
             pnpm-lock.yaml
             pnpm-workspace.yaml

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "test": "pnpm run build:all && node --test test/*.test.ts test/repair/*.test.ts dist/repair/*.test.js",
     "test:unit": "node --test test/*.test.ts",
     "test:repair": "pnpm run build:repair && node --test test/repair/*.test.ts dist/repair/*.test.js",
+    "test:workflow-sparse-checkout": "node --test test/repair/workflow-sparse-checkout.smoke.ts",
     "test:coverage": "pnpm run build:all && node --test --experimental-test-coverage --test-coverage-include='dist/**/*.js' --test-coverage-exclude='dist/repair/*.test.js' --test-coverage-lines=49 --test-coverage-branches=66 --test-coverage-functions=57 test/*.test.ts test/repair/*.test.ts dist/repair/*.test.js",
     "test:coverage:changed": "pnpm run build:all && node --test --experimental-test-coverage --test-coverage-include='dist/repair/fix-prompt-builder.js' --test-coverage-lines=85 --test-coverage-branches=85 --test-coverage-functions=85 test/repair/*.test.ts dist/repair/*.test.js",
     "check:active-surface": "node scripts/check-active-surface.ts",

--- a/test/repair/workflow-sparse-checkout-helpers.ts
+++ b/test/repair/workflow-sparse-checkout-helpers.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+
+import { parse } from "yaml";
+
+import { readText } from "../helpers.ts";
+
+export const SPARSE_REPAIR_BUILD_WORKFLOWS = [
+  ".github/workflows/repair-comment-router.yml",
+  ".github/workflows/spam-comment-intake.yml",
+  ".github/workflows/spam-scanner.yml",
+] as const;
+
+type WorkflowStep = {
+  uses?: unknown;
+  with?: Record<string, unknown>;
+};
+
+type WorkflowJob = {
+  steps?: WorkflowStep[];
+};
+
+type Workflow = {
+  jobs?: Record<string, WorkflowJob>;
+};
+
+export function sourceSparseCheckoutEntries(workflowPath: string): string[] {
+  const workflow = parse(readText(workflowPath)) as Workflow;
+  const checkout = Object.values(workflow.jobs ?? {})
+    .flatMap((job) => job.steps ?? [])
+    .find((step) => String(step.uses ?? "").startsWith("actions/checkout@"));
+  assert.ok(checkout, `${workflowPath} must checkout its source tree`);
+
+  const sparseCheckout = checkout.with?.["sparse-checkout"];
+  assert.equal(typeof sparseCheckout, "string", `${workflowPath} must use sparse checkout`);
+  return sparseCheckout
+    .split(/\r?\n/)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+export function sparseEntriesCover(entries: readonly string[], requiredPath: string): boolean {
+  return entries.some((entry) => requiredPath === entry || requiredPath.startsWith(`${entry}/`));
+}

--- a/test/repair/workflow-sparse-checkout-helpers.ts
+++ b/test/repair/workflow-sparse-checkout-helpers.ts
@@ -1,8 +1,7 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 
 import { parse } from "yaml";
-
-import { readText } from "../helpers.ts";
 
 export const SPARSE_REPAIR_BUILD_WORKFLOWS = [
   ".github/workflows/repair-comment-router.yml",
@@ -24,7 +23,9 @@ type Workflow = {
 };
 
 export function sourceSparseCheckoutEntries(workflowPath: string): string[] {
-  const workflow = parse(readText(workflowPath)) as Workflow;
+  // This helper is loaded before the smoke test builds anything, so it must not import the
+  // general test helper whose production-module imports require an existing dist tree.
+  const workflow = parse(readFileSync(workflowPath, "utf8")) as Workflow;
   const checkout = Object.values(workflow.jobs ?? {})
     .flatMap((job) => job.steps ?? [])
     .find((step) => String(step.uses ?? "").startsWith("actions/checkout@"));

--- a/test/repair/workflow-sparse-checkout.smoke.ts
+++ b/test/repair/workflow-sparse-checkout.smoke.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve, sep } from "node:path";
+import test from "node:test";
+
+import {
+  sourceSparseCheckoutEntries,
+  SPARSE_REPAIR_BUILD_WORKFLOWS,
+} from "./workflow-sparse-checkout-helpers.ts";
+
+const repoRoot = process.cwd();
+
+test("sparse repair workflows install and build in isolation", { timeout: 600_000 }, async (t) => {
+  for (const workflowPath of SPARSE_REPAIR_BUILD_WORKFLOWS) {
+    await t.test(workflowPath, { timeout: 180_000 }, () => {
+      const checkoutRoot = mkdtempSync(join(tmpdir(), "clawsweeper-sparse-repair-"));
+      try {
+        materializeSparseCheckout(workflowPath, checkoutRoot);
+        runPnpm(["install", "--frozen-lockfile"], checkoutRoot, workflowPath);
+        runPnpm(["run", "build:repair"], checkoutRoot, workflowPath);
+      } finally {
+        rmSync(checkoutRoot, { recursive: true, force: true });
+      }
+    });
+  }
+});
+
+function materializeSparseCheckout(workflowPath: string, checkoutRoot: string): void {
+  for (const entry of sourceSparseCheckoutEntries(workflowPath)) {
+    assert.ok(!entry.includes("${{"), `${workflowPath} has a dynamic source checkout entry`);
+    const sourcePath = resolve(repoRoot, entry);
+    assert.ok(
+      sourcePath.startsWith(`${repoRoot}${sep}`),
+      `${workflowPath} checkout entry escapes the repository: ${entry}`,
+    );
+    // Source sparse lists also name generated state paths such as jobs/results. A clean PR
+    // checkout legitimately lacks them, and git sparse-checkout treats those patterns as empty.
+    if (!existsSync(sourcePath)) continue;
+
+    const destinationPath = resolve(checkoutRoot, entry);
+    mkdirSync(dirname(destinationPath), { recursive: true });
+    cpSync(sourcePath, destinationPath, { recursive: true });
+  }
+}
+
+function runPnpm(args: string[], cwd: string, workflowPath: string): void {
+  const result = spawnSync("pnpm", args, {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, CI: "true" },
+    timeout: 180_000,
+  });
+  assert.equal(
+    result.status,
+    0,
+    [`${workflowPath}: pnpm ${args.join(" ")} failed`, result.stdout.trim(), result.stderr.trim()]
+      .filter(Boolean)
+      .join("\n"),
+  );
+}

--- a/test/repair/workflow-sparse-checkout.test.ts
+++ b/test/repair/workflow-sparse-checkout.test.ts
@@ -3,25 +3,21 @@ import fs from "node:fs";
 import test from "node:test";
 
 import { readText } from "../helpers.ts";
+import {
+  sourceSparseCheckoutEntries,
+  sparseEntriesCover,
+  SPARSE_REPAIR_BUILD_WORKFLOWS,
+} from "./workflow-sparse-checkout-helpers.ts";
 
 const REPAIR_RUNTIME_PATHS = [
+  ".github/actions/setup-pnpm",
+  "config/automation-limits.json",
   "prompts/pr-close-coverage-proof.md",
   "schema/clawsweeper-pr-close-coverage-proof.schema.json",
-  "src/clawsweeper-text.ts",
-  "src/codex-env.ts",
-  "src/codex-output-capture.ts",
-  "src/codex-process-worker.ts",
-  "src/codex-process.ts",
-  "src/codex-spawn.ts",
-  "src/codex-transient.ts",
-  "src/github-json.ts",
-  "src/pr-close-coverage-proof.ts",
-] as const;
-
-const SPARSE_REPAIR_BUILD_WORKFLOWS = [
-  ".github/workflows/repair-comment-router.yml",
-  ".github/workflows/spam-comment-intake.yml",
-  ".github/workflows/spam-scanner.yml",
+  "package.json",
+  "pnpm-lock.yaml",
+  "pnpm-workspace.yaml",
+  "tsconfig.repair.json",
 ] as const;
 
 test("sparse repair build workflows include runtime dependencies", () => {
@@ -29,18 +25,38 @@ test("sparse repair build workflows include runtime dependencies", () => {
     const workflow = readText(workflowPath);
     assert.match(workflow, /build-script: build:repair/);
 
-    const entries = sparseCheckoutEntries(workflow);
+    const entries = sourceSparseCheckoutEntries(workflowPath);
+    assert.ok(entries.includes("src"), `${workflowPath} must checkout the complete src tree`);
+    assert.equal(
+      entries.filter((entry) => entry.startsWith("src/")).length,
+      0,
+      `${workflowPath} must not maintain individual src entries`,
+    );
     for (const requiredPath of REPAIR_RUNTIME_PATHS) {
-      assert.ok(entries.has(requiredPath), `${workflowPath} missing ${requiredPath}`);
+      assert.ok(
+        sparseEntriesCover(entries, requiredPath),
+        `${workflowPath} missing ${requiredPath}`,
+      );
     }
   }
 });
 
-test("sparse CI checkout includes pnpm workspace policy", () => {
-  const workflow = readText(".github/workflows/ci.yml");
-  const entries = sparseCheckoutEntries(workflow);
+test("state-hydrating sparse repair workflows keep their hydration script", () => {
+  for (const workflowPath of [
+    ".github/workflows/repair-comment-router.yml",
+    ".github/workflows/spam-scanner.yml",
+  ]) {
+    assert.ok(
+      sparseEntriesCover(sourceSparseCheckoutEntries(workflowPath), "scripts/hydrate-state.ts"),
+      `${workflowPath} missing scripts/hydrate-state.ts`,
+    );
+  }
+});
 
-  assert.ok(entries.has("pnpm-workspace.yaml"));
+test("sparse CI checkout includes pnpm workspace policy", () => {
+  const entries = sourceSparseCheckoutEntries(".github/workflows/ci.yml");
+
+  assert.ok(entries.includes("pnpm-workspace.yaml"));
 });
 
 test("repair build emits the bounded Codex process worker", () => {
@@ -70,15 +86,17 @@ test("repair comment router workflow preserves repository dispatch target branch
 });
 
 test("repair comment router sparse checkout includes action ledger runtime", () => {
-  const workflow = readText(".github/workflows/repair-comment-router.yml");
-  const entries = sparseCheckoutEntries(workflow);
+  const entries = sourceSparseCheckoutEntries(".github/workflows/repair-comment-router.yml");
 
   for (const requiredPath of [
     "src/action-ledger-files.ts",
     "src/action-ledger-runtime.ts",
     "src/action-ledger.ts",
   ]) {
-    assert.ok(entries.has(requiredPath), `repair comment router missing ${requiredPath}`);
+    assert.ok(
+      sparseEntriesCover(entries, requiredPath),
+      `repair comment router missing ${requiredPath}`,
+    );
   }
 });
 
@@ -102,30 +120,3 @@ test("sweep workflow preserves one claimed target branch through exact review", 
   assert.match(workflow, /target_branch="\$CLAIM_TARGET_BRANCH"/);
   assert.match(workflow, /target_branch="\$\{\{ steps\.live-item\.outputs\.target_branch \}\}"/);
 });
-
-function sparseCheckoutEntries(workflow: string): Set<string> {
-  const entries = new Set<string>();
-  const lines = workflow.split(/\r?\n/);
-
-  for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index] ?? "";
-    if (!/^\s+sparse-checkout:\s*\|/.test(line)) continue;
-
-    const blockIndent = leadingSpaces(line);
-    for (index += 1; index < lines.length; index += 1) {
-      const entryLine = lines[index] ?? "";
-      if (!entryLine.trim()) continue;
-      if (leadingSpaces(entryLine) <= blockIndent) {
-        index -= 1;
-        break;
-      }
-      entries.add(entryLine.trim());
-    }
-  }
-
-  return entries;
-}
-
-function leadingSpaces(value: string): number {
-  return value.length - value.trimStart().length;
-}


### PR DESCRIPTION
## Summary

- replace per-file TypeScript sparse-checkout entries with the complete `src` tree in the repair comment router, spam comment intake, and spam scanner workflows
- preserve explicit prompt, schema, config, script, package, and TypeScript configuration resources
- add PR-only isolated install/build smoke coverage driven by each workflow's actual sparse-checkout list
- add structural tests that prevent the workflows from returning to individual `src/...` entries or dropping required runtime resources

## Root cause

The repair workflows maintained their transitive TypeScript build dependencies as hand-written per-file sparse-checkout lists. New source dependencies could therefore compile in a full checkout while being absent from the workflow checkout, causing ClawSweeper automerge repair runs to fail before the self-link fix from https://github.com/openclaw/clawsweeper/pull/609 could be exercised.

Checking out the complete `src` tree removes that fragile dependency inventory. The tree is only about 3.44 MiB, adding less than roughly 1.6 MiB over the previous lists, so the reliability improvement has negligible Actions cost.

## Validation

- autoreview: clean, no accepted/actionable findings
- `node --test test/repair/workflow-sparse-checkout.test.ts`
- `pnpm run test:workflow-sparse-checkout`
- `pnpm run check`
- `git diff --check`

## After merge

No service restart is required. Re-trigger `@clawsweeper automerge` on https://github.com/openclaw/openclaw/pull/107450 and verify that the self-link fix from https://github.com/openclaw/clawsweeper/pull/609 is reached successfully.
