### PR TITLE
feat(intake): label and de-prioritize bulk-filed issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Added
 
+- Added review-time bulk-filer detection, transparent labeling, duplicate scrutiny, fix-lane suppression, and within-bucket scheduling de-prioritization for high-volume issue authors.
 - Added end-to-end exact-review handoff health with phase ages, delayed/stalled claim classification, and a phase-aware operator rail on the live dashboard.
 - Added a maintainer-only two-runner workflow that builds a hash-bound
   crawl-remote release artifact without production credentials, then requires

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -12,15 +12,18 @@ intentionally opens it wider. Safety thresholds such as
 close age floors, apply delays, retry counts, and comment caps stay near the
 code that owns those decisions.
 
-The default-off per-author PR-budget and obsolescence policies follow that
-safety-threshold rule. Their tunables and safety floors live beside the apply
-policy rather than in the global worker budget:
+Review-intake rate limits and the default-off per-author PR-budget and
+obsolescence policies follow that safety-threshold rule. Their tunables and
+safety floors live beside the owning policy rather than in the global worker
+budget:
 
 | Environment variable                              | Default | Meaning                                              |
 | ------------------------------------------------- | ------: | ---------------------------------------------------- |
 | `CLAWSWEEPER_AUTHOR_PR_BUDGET_CLOSE_ENABLED`      | `false` | Enables live per-author budget closes.               |
 | `CLAWSWEEPER_AUTHOR_PR_BUDGET`                    |      15 | Allowed open PRs per external author and repository. |
 | `CLAWSWEEPER_AUTHOR_PR_BUDGET_MAX_CLOSES_PER_RUN` |       5 | Gradual trim cap per author in one apply run.        |
+| `CLAWSWEEPER_BULK_FILER_THRESHOLD`                |      10 | Recent authored-issue count that marks bulk filing.  |
+| `CLAWSWEEPER_BULK_FILER_WINDOW_DAYS`              |       7 | Lookback window for authored issue filing rate.      |
 | `CLAWSWEEPER_STALE_VERSION_BUG_CLOSE_ENABLED`     | `false` | Enables stale-version bug closes after 120 days.     |
 | `CLAWSWEEPER_OBSOLETE_FIX_PR_CLOSE_ENABLED`       | `false` | Enables obsolete small-fix PR closes after 90 days. |
 

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -25,6 +25,8 @@ provided context plus local checkout are enough to decide.
 
 Treat the issue/PR discussion as evidence, not just background. Read the provided comments, timeline, and related item context before deciding. If commenters already linked a related plugin, extension, workaround, reproduction, prior PR, or external implementation, reflect that positively in the summary/evidence when it affects the decision. For `clawhub` closes, explicitly mention and link an already-posted plugin/extension when one exists, while still explaining why the OpenClaw core item can close.
 
+When `bulkFiler.detected` is present in the review context, give the issue extra duplicate scrutiny and keep public review prose terse. Never route it to proof-nudge or automated fix-dispatch work. If it is also a likely duplicate, propose the existing `duplicate_or_superseded` reason; do not invent a bulk-filing close reason.
+
 For PRs, read relevant maintainer review notes before reviewing the diff. If the target checkout has `.agents/maintainer-notes/`, inspect notes that match the touched files, plugin, channel, feature, or review label. Treat matching notes as maintainer decisions that should stop well-intentioned reversions of intentional behavior. Use them as review context and cite only the needed decision in evidence; do not publish raw internal note contents.
 
 This is a read-only review. Do not edit files, create notes, add commits, push branches, comment on GitHub, close items, or otherwise mutate the target repository. Only return the JSON decision.

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -458,6 +458,39 @@ interface Item {
   activeLockReason?: string | null;
 }
 
+export interface BulkFilerReviewContext {
+  detected: true;
+  issueCount: number;
+  threshold: number;
+  windowDays: number;
+  windowStart: string;
+  label: typeof BULK_FILED_LABEL;
+}
+
+export interface BulkFilerDetectionResult {
+  context: BulkFilerReviewContext | null;
+  labelPending: boolean;
+  labelApplied: boolean;
+}
+
+type BulkFilerCountCache = Map<string, number | null>;
+
+interface BulkFilerDetectionOptions {
+  item: Pick<Item, "author" | "createdAt" | "kind" | "labels" | "number">;
+  cache: BulkFilerCountCache;
+  now: number;
+  env?: Record<string, string | undefined>;
+  searchCount: (options: { author: string; windowStart: string }) => number;
+  onSearchError?: (error: unknown) => void;
+}
+
+interface BulkFilerActivationOptions {
+  item: Pick<Item, "labels">;
+  detection: BulkFilerDetectionResult;
+  patchTransparency: () => void;
+  applyLabel: () => boolean;
+}
+
 export interface ReviewStartStatusCommentOptions {
   number: number;
   kind: string;
@@ -471,12 +504,14 @@ export interface ReviewStartStatusCommentOptions {
   shardIndex?: number;
   shardCount?: number;
   purpose?: "review" | "apply";
+  bulkFilerLabelApplied?: boolean;
 }
 
 type AcquiredReviewStartLease = {
   owner: string;
   commentId: number;
   headSha: string;
+  comment?: Record<string, unknown>;
 };
 
 type ReviewStartStatusCommentResult =
@@ -787,6 +822,7 @@ interface ItemContext {
   pullReviewCommentsRevision?: string;
   pullReviewActivityCursor?: string;
   pullChecks?: unknown;
+  bulkFiler?: BulkFilerReviewContext;
   counts?: {
     comments: number;
     commentsHydrated?: number;
@@ -1368,6 +1404,17 @@ const OBSOLETE_FIX_PR_MIN_INACTIVE_DAYS = 30;
 const OBSOLETE_FIX_PR_MAX_CHANGED_FILES = 5;
 const DEFAULT_AUTHOR_PR_BUDGET = 15;
 const DEFAULT_AUTHOR_PR_BUDGET_MAX_CLOSES_PER_RUN = 5;
+const DEFAULT_BULK_FILER_THRESHOLD = 10;
+const DEFAULT_BULK_FILER_WINDOW_DAYS = 7;
+const BULK_FILER_SEARCH_TIMEOUT_MS = 15_000;
+const BULK_FILED_LABEL = "clawsweeper:bulk-filed";
+const BULK_FILER_TRANSPARENCY_LINE =
+  "High filing volume detected, so these issues are batched behind other reviews. Consolidating related reports into fewer issues helps us review everything faster.";
+const BULK_FILED_LABEL_DEFINITION = {
+  name: BULK_FILED_LABEL,
+  color: "6E7781",
+  description: "ClawSweeper detected a high recent issue-filing volume from this author.",
+} as const;
 const STALLED_UNPROVEN_PR_MIN_AGE_DAYS = 14;
 const STALLED_UNPROVEN_PR_MIN_INACTIVE_DAYS = 14;
 const ABANDONED_PR_MIN_AGE_DAYS = 30;
@@ -6359,6 +6406,123 @@ export function authorPrBudgetMaxClosesPerRun(
     env.CLAWSWEEPER_AUTHOR_PR_BUDGET_MAX_CLOSES_PER_RUN,
     DEFAULT_AUTHOR_PR_BUDGET_MAX_CLOSES_PER_RUN,
   );
+}
+
+export function bulkFilerThreshold(env: Record<string, string | undefined> = process.env): number {
+  return positiveIntegerEnv(env.CLAWSWEEPER_BULK_FILER_THRESHOLD, DEFAULT_BULK_FILER_THRESHOLD);
+}
+
+export function bulkFilerWindowDays(env: Record<string, string | undefined> = process.env): number {
+  return positiveIntegerEnv(env.CLAWSWEEPER_BULK_FILER_WINDOW_DAYS, DEFAULT_BULK_FILER_WINDOW_DAYS);
+}
+
+function detectBulkFiler(options: BulkFilerDetectionOptions): BulkFilerDetectionResult {
+  if (options.item.kind !== "issue" || !options.item.author.trim()) {
+    return { context: null, labelPending: false, labelApplied: false };
+  }
+  const windowDays = bulkFilerWindowDays(options.env);
+  const windowStartMs = options.now - windowDays * DAY_MS;
+  const itemCreatedAtMs = Date.parse(options.item.createdAt);
+  if (!Number.isFinite(itemCreatedAtMs) || itemCreatedAtMs <= windowStartMs) {
+    return { context: null, labelPending: false, labelApplied: false };
+  }
+  const threshold = bulkFilerThreshold(options.env);
+  const windowStart = new Date(windowStartMs).toISOString();
+  const cacheKey = options.item.author.trim().toLowerCase();
+  let issueCount = options.cache.get(cacheKey);
+  if (!options.cache.has(cacheKey)) {
+    try {
+      const searchedCount = options.searchCount({
+        author: options.item.author,
+        windowStart,
+      });
+      if (!Number.isInteger(searchedCount) || searchedCount < 0) {
+        throw new Error("GitHub bulk-filer search omitted a valid total_count");
+      }
+      issueCount = searchedCount;
+    } catch (error) {
+      issueCount = null;
+      options.onSearchError?.(error);
+    }
+    options.cache.set(cacheKey, issueCount ?? null);
+  }
+  if (issueCount === undefined || issueCount === null || issueCount < threshold) {
+    return { context: null, labelPending: false, labelApplied: false };
+  }
+  const alreadyLabeled = options.item.labels.some(
+    (label) => label.toLowerCase() === BULK_FILED_LABEL,
+  );
+  return {
+    context: {
+      detected: true,
+      issueCount,
+      threshold,
+      windowDays,
+      windowStart,
+      label: BULK_FILED_LABEL,
+    },
+    labelPending: !alreadyLabeled,
+    labelApplied: false,
+  };
+}
+
+function activateBulkFilerAfterReviewLease(options: BulkFilerActivationOptions): boolean {
+  const alreadyLabeled = options.item.labels.some(
+    (label) => label.toLowerCase() === BULK_FILED_LABEL,
+  );
+  if (!options.detection.context || !options.detection.labelPending || alreadyLabeled) {
+    options.detection.labelPending = false;
+    return false;
+  }
+  const labelApplied = options.applyLabel();
+  if (!labelApplied) return false;
+  try {
+    options.patchTransparency();
+  } catch (error) {
+    // The label is the scheduling signal; a failed disclosure patch must not
+    // abort the review. Disclosure reconciliation is tracked as a follow-up.
+    console.warn(
+      `bulk-filer transparency patch failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+  options.item.labels.push(BULK_FILED_LABEL);
+  options.detection.labelPending = false;
+  options.detection.labelApplied = true;
+  return true;
+}
+
+export function detectBulkFilerForTest(
+  options: BulkFilerDetectionOptions,
+): BulkFilerDetectionResult {
+  return detectBulkFiler(options);
+}
+
+export function activateBulkFilerAfterReviewLeaseForTest(
+  options: BulkFilerActivationOptions,
+): boolean {
+  return activateBulkFilerAfterReviewLease(options);
+}
+
+function authorIssueCountInBulkFilerWindow(author: string, windowStart: string): number {
+  const query = [
+    `repo:${targetRepo()}`,
+    "type:issue",
+    `author:${quoteGitHubSearchTerm(author)}`,
+    `created:>${windowStart}`,
+  ].join(" ");
+  const result = ghJsonOnce<{ total_count?: number; incomplete_results?: boolean }>(
+    ["api", "search/issues", "--method", "GET", "-f", `q=${query}`, "-f", "per_page=1"],
+    BULK_FILER_SEARCH_TIMEOUT_MS,
+  );
+  if (result.incomplete_results === true) {
+    throw new Error("GitHub bulk-filer search returned incomplete results");
+  }
+  if (!Number.isInteger(result.total_count) || Number(result.total_count) < 0) {
+    throw new Error("GitHub bulk-filer search omitted a valid total_count");
+  }
+  return Number(result.total_count);
 }
 
 function quoteGitHubSearchTerm(term: string): string {
@@ -14028,6 +14192,37 @@ function ensureImpactLabel(name: ImpactLabelName, onMutation?: () => void): void
   }
 }
 
+function ensureBulkFilerLabel(onMutation?: () => void): void {
+  try {
+    ghObservedMutationCommand({
+      identity: `label_create:${BULK_FILED_LABEL_DEFINITION.name}`,
+      args: [
+        "label",
+        "create",
+        BULK_FILED_LABEL_DEFINITION.name,
+        "--color",
+        BULK_FILED_LABEL_DEFINITION.color,
+        "--description",
+        BULK_FILED_LABEL_DEFINITION.description,
+      ],
+      attempts: 2,
+      onMutation,
+      knownNoMutation: labelAlreadyExistsError,
+    });
+  } catch (error) {
+    if (!labelAlreadyExistsError(error)) throw error;
+  }
+}
+
+function applyBulkFilerLabel(number: number, currentLabels: readonly string[]): boolean {
+  ensureBulkFilerLabel();
+  return tryAddOptionalLabel({
+    number,
+    label: BULK_FILED_LABEL,
+    currentLabels,
+  });
+}
+
 function ensureMergeRiskLabel(name: MergeRiskLabelName, onMutation?: () => void): void {
   const definition = MERGE_RISK_LABELS.find((label) => label.name === name);
   if (!definition) return;
@@ -14116,6 +14311,7 @@ function isGoodFirstIssue(
     state.hasWorkValidation &&
     !state.goodFirstIssueOptedOut &&
     !state.locked &&
+    !hasNormalizedLabel(currentLabels, BULK_FILED_LABEL) &&
     !currentLabels.some(isSecuritySensitiveLabel) &&
     protectedLabels(currentLabels).length === 0 &&
     !state.hasOpenLinkedPullRequest
@@ -14162,6 +14358,7 @@ function wantedIssueAdvisoryLabels(
 ): Set<string> {
   const labels = new Set<string>();
   if (state.type !== "issue") return labels;
+  const isBulkFiled = hasNormalizedLabel(currentLabels, BULK_FILED_LABEL);
   const issueRatingLabel = issueRatingLabelForState(state);
   if (issueRatingLabel) labels.add(issueRatingLabel);
   if (state.reproductionConfidence === "high") {
@@ -14182,6 +14379,7 @@ function wantedIssueAdvisoryLabels(
     labels.add("clawsweeper:linked-pr-open");
   }
   if (
+    !isBulkFiled &&
     state.workCandidate === "queue_fix_pr" &&
     state.workStatus === "candidate" &&
     state.workConfidence === "high"
@@ -14213,16 +14411,21 @@ function wantedIssueAdvisoryLabels(
     state.workStatus === "manual_review" ||
     state.requiresProductDecision ||
     state.itemCategory === "security" ||
-    state.securityReviewStatus === "needs_attention"
+    state.securityReviewStatus === "needs_attention" ||
+    isBulkFiled
   ) {
     labels.add("clawsweeper:no-new-fix-pr");
   }
   return labels;
 }
 
-function issueAdvisoryStateNeedsStaleProtection(state: IssueAdvisoryLabelState): boolean {
+function issueAdvisoryStateNeedsStaleProtection(
+  state: IssueAdvisoryLabelState,
+  currentLabels: readonly string[],
+): boolean {
   return (
     state.type === "issue" &&
+    !hasNormalizedLabel(currentLabels, BULK_FILED_LABEL) &&
     state.workCandidate === "queue_fix_pr" &&
     state.workStatus === "candidate" &&
     state.workConfidence === "high"
@@ -14238,7 +14441,7 @@ function nextIssueAdvisoryLabels(
   state: IssueAdvisoryLabelState,
 ): string[] {
   const wantedLabels = wantedIssueAdvisoryLabels(state, labels);
-  const needsStaleProtection = issueAdvisoryStateNeedsStaleProtection(state);
+  const needsStaleProtection = issueAdvisoryStateNeedsStaleProtection(state, labels);
   const hadQueueableProtection = issueAdvisoryLabelsHadQueueableProtection(labels);
   const nextLabels = labels.filter(
     (label) =>
@@ -15106,6 +15309,7 @@ function proofNudgeProtectedLabels(labels: readonly string[]): string[] {
       label === "beta-blocker" ||
       label === "release-blocker" ||
       label === "clawsweeper:needs-security-review" ||
+      label === BULK_FILED_LABEL ||
       label.startsWith("release") ||
       label.includes("security")
     );
@@ -19452,6 +19656,7 @@ export function renderReviewStartStatusComment(options: ReviewStartStatusComment
     purpose === "apply"
       ? "This transient lease prevents a newer review from overlapping label, comment, or close mutations."
       : "This placeholder means the worker is alive and reading the current context. I will edit this same comment with the actual review when the claws are done clicking.",
+    ...(options.bulkFilerLabelApplied ? ["", BULK_FILER_TRANSPARENCY_LINE] : []),
     "",
     "Crustacean status: shell secured, claws on keyboard, evidence pebbles being sorted.",
     "",
@@ -20224,6 +20429,7 @@ function postReviewStartStatusComment(options: {
   shardIndex: number;
   shardCount: number;
   purpose?: "review" | "apply";
+  bulkFilerLabelApplied?: boolean;
 }): ReviewStartStatusCommentResult {
   const startedAtMs = Date.now();
   const leaseOwner = newReviewStartLeaseOwner();
@@ -20240,6 +20446,7 @@ function postReviewStartStatusComment(options: {
     shardIndex: options.shardIndex,
     shardCount: options.shardCount,
     purpose: options.purpose ?? "review",
+    bulkFilerLabelApplied: options.bulkFilerLabelApplied ?? false,
   };
   const normalizedHead = String(options.headSha ?? "")
     .trim()
@@ -20301,19 +20508,77 @@ function postReviewStartStatusComment(options: {
     );
   }
   const winner = confirmed[0];
+  if (!winner) {
+    deleteOwnedDedicatedReviewStartLease(options.item.number, acquired);
+    throw new Error(
+      `could not identify the winning review lease for #${options.item.number}; retry required`,
+    );
+  }
   if (
-    commentId(winner?.comment) !== createdCommentId ||
-    reviewStartLeaseOwner(winner?.comment) !== leaseOwner
+    commentId(winner.comment) !== createdCommentId ||
+    reviewStartLeaseOwner(winner.comment) !== leaseOwner
   ) {
     deleteOwnedDedicatedReviewStartLease(options.item.number, acquired);
-    if (!winner) {
-      throw new Error(
-        `could not identify the winning review lease for #${options.item.number}; retry required`,
-      );
-    }
     return heldReviewStartStatusCommentResult(winner.expiresAt, true);
   }
-  return { status: "posted", lease: acquired, didMutate: true };
+  return {
+    status: "posted",
+    lease: { ...acquired, comment: winner.comment },
+    didMutate: true,
+  };
+}
+
+function patchOwnedBulkFilerReviewStartStatusComment(
+  itemNumber: number,
+  lease: AcquiredReviewStartLease,
+): void {
+  const currentBody = commentBody(lease.comment);
+  if (
+    !currentBody ||
+    commentId(lease.comment) !== lease.commentId ||
+    reviewStartLeaseOwner(lease.comment) !== lease.owner ||
+    !currentBody.includes(`sha=${lease.headSha}`)
+  ) {
+    throw new Error(
+      `cannot add bulk-filer transparency without the owned review lease comment for #${itemNumber}`,
+    );
+  }
+  if (currentBody.includes(BULK_FILER_TRANSPARENCY_LINE)) return;
+  const anchor = "\n\nCrustacean status:";
+  if (!currentBody.includes(anchor)) {
+    throw new Error(`cannot locate the review lease transparency anchor for #${itemNumber}`);
+  }
+  const nextBody = currentBody.replace(anchor, `\n\n${BULK_FILER_TRANSPARENCY_LINE}${anchor}`);
+  const payload = writeCommentPayload(itemNumber, nextBody);
+  const args = [
+    "api",
+    `repos/${targetRepo()}/issues/comments/${lease.commentId}`,
+    "--method",
+    "PATCH",
+    "--input",
+    payload,
+  ];
+  const written = reviewCommentFromMutationResponse(
+    ghObservedMutationCommand({
+      identity: `review_lease_bulk_filer_transparency:${itemNumber}:${lease.commentId}`,
+      args,
+    }),
+    args,
+  );
+  lease.comment = written ?? { ...lease.comment, body: nextBody };
+}
+
+function activateDetectedBulkFilerAfterReviewLease(
+  item: Item,
+  detection: BulkFilerDetectionResult,
+  lease: AcquiredReviewStartLease,
+): boolean {
+  return activateBulkFilerAfterReviewLease({
+    item,
+    detection,
+    patchTransparency: () => patchOwnedBulkFilerReviewStartStatusComment(item.number, lease),
+    applyLabel: () => applyBulkFilerLabel(item.number, item.labels),
+  });
 }
 
 function deleteOwnedDedicatedReviewStartLease(
@@ -22375,6 +22640,8 @@ function reviewCommand(args: Args): void {
     let semanticCacheRevalidationFailures = 0;
     let semanticCacheRevalidationMs = 0;
     let hydrationRuns = 0;
+    const bulkFilerCountCache: BulkFilerCountCache = new Map();
+    const bulkFilerWindowNow = Date.now();
     const structuralCacheReasons = new Map<string, number>();
     const structuralCacheRevalidationReasons = new Map<string, number>();
     const semanticCacheReasons = new Map<string, number>();
@@ -22390,6 +22657,23 @@ function reviewCommand(args: Args): void {
       try {
       startReviewActionLedgerItem(reviewLedger, item);
       activeReviewMutationRunner = reviewMutationRunner(reviewLedger, item);
+      const bulkFilerDetection =
+        !localOnly && item.kind === "issue"
+          ? detectBulkFiler({
+              item,
+              cache: bulkFilerCountCache,
+              now: bulkFilerWindowNow,
+              searchCount: ({ author, windowStart }) =>
+                authorIssueCountInBulkFilerWindow(author, windowStart),
+              onSearchError: (error) => {
+                console.error(
+                  `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} bulk-filer-search=failed #${item.number}: ${
+                    error instanceof Error ? error.message : String(error)
+                  }`,
+                );
+              },
+            })
+          : { context: null, labelPending: false, labelApplied: false };
       if (humanLocalReview) {
         console.error("");
         console.error("Collecting GitHub context");
@@ -22484,6 +22768,7 @@ function reviewCommand(args: Args): void {
                 total: candidates.length,
                 shardIndex,
                 shardCount,
+                bulkFilerLabelApplied: bulkFilerDetection.labelApplied,
               });
               console.error(
                 `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} structural-cache-start-comment=${startComment.status} #${item.number}`,
@@ -22499,6 +22784,11 @@ function reviewCommand(args: Args): void {
                 );
               }
               acquiredReviewLeases.push({ itemNumber: item.number, lease: acquiredReviewLease });
+              activateDetectedBulkFilerAfterReviewLease(
+                item,
+                bulkFilerDetection,
+                acquiredReviewLease,
+              );
             } catch (error) {
               leaseAcquisitionFailures += 1;
               leaseAcquisitionFailureDetails.push(
@@ -22659,6 +22949,7 @@ function reviewCommand(args: Args): void {
             total: candidates.length,
             shardIndex,
             shardCount,
+            bulkFilerLabelApplied: bulkFilerDetection.labelApplied,
           });
           console.error(
             `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} start-comment=${startComment.status} #${item.number}`,
@@ -22696,6 +22987,7 @@ function reviewCommand(args: Args): void {
             reviewCacheDigest: true,
             reviewCacheGitDir: openclawDir,
           });
+      if (bulkFilerDetection.context) context.bulkFiler = bulkFilerDetection.context;
       const contextElapsedMs = Date.now() - contextStartedAt;
       const contextItemUpdatedAt = stringOrUndefined(asRecord(context.issue).updatedAt);
       if (contextItemUpdatedAt) item.updatedAt = contextItemUpdatedAt;
@@ -22752,9 +23044,11 @@ function reviewCommand(args: Args): void {
           owner: suppliedReviewLease.owner,
           commentId: suppliedReviewLease.commentId,
           headSha: currentRevision,
+          comment: supplied.comment,
         };
         acquiredReviewLease = claimedLease;
         acquiredReviewLeases.push({ itemNumber: item.number, lease: claimedLease });
+        activateDetectedBulkFilerAfterReviewLease(item, bulkFilerDetection, claimedLease);
       }
       if (!localRangeData && contextItemUpdatedAt && preHydrationStructuralRecord) {
         structuralCacheRevalidations += 1;
@@ -22880,6 +23174,7 @@ function reviewCommand(args: Args): void {
             total: candidates.length,
             shardIndex,
             shardCount,
+            bulkFilerLabelApplied: bulkFilerDetection.labelApplied,
           });
           console.error(
             `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} start-comment=${startComment.status} #${item.number}`,
@@ -22895,6 +23190,11 @@ function reviewCommand(args: Args): void {
             );
           }
           acquiredReviewLeases.push({ itemNumber: item.number, lease: acquiredReviewLease });
+          activateDetectedBulkFilerAfterReviewLease(
+            item,
+            bulkFilerDetection,
+            acquiredReviewLease,
+          );
         } catch (error) {
           leaseAcquisitionFailures += 1;
           leaseAcquisitionFailureDetails.push(

--- a/src/scheduler-policy.ts
+++ b/src/scheduler-policy.ts
@@ -6,6 +6,7 @@ export interface SchedulerItem {
   kind: SchedulerItemKind;
   createdAt: string;
   updatedAt: string;
+  labels?: readonly string[] | undefined;
 }
 
 export interface SchedulerExistingReview {
@@ -47,6 +48,13 @@ const HOURLY_REVIEW_MS = 60 * 60 * 1000;
 const DAILY_REVIEW_DAYS = 1;
 const WEEKLY_REVIEW_DAYS = 7;
 const DAY_MS = 24 * 60 * 60 * 1000;
+const BULK_FILED_LABEL = "clawsweeper:bulk-filed";
+
+function bulkFiledComparison(left: SchedulerDueCandidate, right: SchedulerDueCandidate): number {
+  const isBulkFiled = (item: SchedulerItem): boolean =>
+    item.labels?.some((label) => label.toLowerCase() === BULK_FILED_LABEL) ?? false;
+  return Number(isBulkFiled(left.item)) - Number(isBulkFiled(right.item));
+}
 
 function timestampMs(value: string | undefined): number | null {
   if (!value) return null;
@@ -220,6 +228,7 @@ export function compareDueCandidates<
 ): number {
   return (
     left.priority - right.priority ||
+    bulkFiledComparison(left, right) ||
     left.nextDueAt - right.nextDueAt ||
     left.reviewedAt - right.reviewedAt ||
     left.item.number - right.item.number
@@ -234,6 +243,7 @@ function compareBackfillCandidates<
   right: SchedulerDueCandidate<ItemT, ReviewT>,
 ): number {
   return (
+    bulkFiledComparison(left, right) ||
     left.nextDueAt - right.nextDueAt ||
     left.reviewedAt - right.reviewedAt ||
     left.priority - right.priority ||
@@ -293,7 +303,9 @@ export function selectDueCandidates<
     .filter((candidate) => weeklyReviewDeadlineMs(candidate) <= now)
     .sort(
       (left, right) =>
-        weeklyReviewDeadlineMs(left) - weeklyReviewDeadlineMs(right) || compare(left, right),
+        bulkFiledComparison(left, right) ||
+        weeklyReviewDeadlineMs(left) - weeklyReviewDeadlineMs(right) ||
+        compare(left, right),
     );
   for (const candidate of weeklyOverdue) take(candidate);
   for (const [bucket, candidates] of buckets) {
@@ -356,6 +368,7 @@ export function compareHotIntakeDueCandidates<
 ): number {
   return (
     left.priority - right.priority ||
+    bulkFiledComparison(left, right) ||
     hotIntakeRecencyMs(right.item) - hotIntakeRecencyMs(left.item) ||
     right.item.number - left.item.number
   );

--- a/test/bulk-filer-policy.test.ts
+++ b/test/bulk-filer-policy.test.ts
@@ -1,0 +1,268 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  activateBulkFilerAfterReviewLeaseForTest,
+  bulkFilerThreshold,
+  bulkFilerWindowDays,
+  detectBulkFilerForTest,
+  renderReviewStartStatusComment,
+} from "../dist/clawsweeper.js";
+import { item } from "./helpers.ts";
+
+test("bulk-filer defaults and positive env overrides are bounded", () => {
+  assert.equal(bulkFilerThreshold({}), 10);
+  assert.equal(bulkFilerWindowDays({}), 7);
+  assert.equal(bulkFilerThreshold({ CLAWSWEEPER_BULK_FILER_THRESHOLD: "12" }), 12);
+  assert.equal(bulkFilerWindowDays({ CLAWSWEEPER_BULK_FILER_WINDOW_DAYS: "14" }), 14);
+  assert.equal(bulkFilerThreshold({ CLAWSWEEPER_BULK_FILER_THRESHOLD: "0" }), 10);
+  assert.equal(bulkFilerWindowDays({ CLAWSWEEPER_BULK_FILER_WINDOW_DAYS: "nope" }), 7);
+});
+
+test("bulk-filer detection includes the threshold boundary and excludes the exact cutoff", () => {
+  const now = Date.parse("2026-07-16T12:00:00.000Z");
+  let searches = 0;
+  const cutoffResult = detectBulkFilerForTest({
+    item: item({
+      number: 43,
+      createdAt: "2026-07-09T12:00:00.000Z",
+    }),
+    cache: new Map(),
+    now,
+    searchCount: () => {
+      searches += 1;
+      return 10;
+    },
+  });
+  assert.deepEqual(cutoffResult, {
+    context: null,
+    labelPending: false,
+    labelApplied: false,
+  });
+  assert.equal(searches, 0);
+
+  const candidate = item({
+    number: 44,
+    createdAt: "2026-07-09T12:00:00.001Z",
+  });
+  let observedWindowStart = "";
+
+  const result = detectBulkFilerForTest({
+    item: candidate,
+    cache: new Map(),
+    now,
+    searchCount: ({ windowStart }) => {
+      searches += 1;
+      observedWindowStart = windowStart;
+      return 10;
+    },
+  });
+
+  assert.equal(searches, 1);
+  assert.equal(observedWindowStart, "2026-07-09T12:00:00.000Z");
+  assert.equal(result.context?.issueCount, 10);
+  assert.equal(result.context?.threshold, 10);
+  assert.equal(result.context?.windowDays, 7);
+  assert.equal(result.labelPending, true);
+  assert.equal(result.labelApplied, false);
+  assert.equal(candidate.labels.includes("clawsweeper:bulk-filed"), false);
+
+  const mutations: string[] = [];
+  assert.equal(
+    activateBulkFilerAfterReviewLeaseForTest({
+      item: candidate,
+      detection: result,
+      patchTransparency: () => mutations.push("transparency"),
+      applyLabel: () => {
+        mutations.push("label");
+        return true;
+      },
+    }),
+    true,
+  );
+  assert.deepEqual(mutations, ["label", "transparency"]);
+  assert.equal(candidate.labels.includes("clawsweeper:bulk-filed"), true);
+
+  const below = detectBulkFilerForTest({
+    item: item({ number: 45, createdAt: "2026-07-16T00:00:00.000Z" }),
+    cache: new Map(),
+    now,
+    searchCount: () => 9,
+  });
+  assert.deepEqual(below, { context: null, labelPending: false, labelApplied: false });
+});
+
+test("bulk-filer eligibility excludes old issues from prolific authors", () => {
+  const now = Date.parse("2026-07-16T12:00:00.000Z");
+  let searches = 0;
+  const oldCandidate = item({
+    number: 46,
+    createdAt: "2026-07-09T11:59:59.999Z",
+  });
+  const oldResult = detectBulkFilerForTest({
+    item: oldCandidate,
+    cache: new Map(),
+    now,
+    searchCount: () => {
+      searches += 1;
+      return 16;
+    },
+  });
+
+  assert.deepEqual(oldResult, { context: null, labelPending: false, labelApplied: false });
+  assert.equal(searches, 0);
+  assert.equal(
+    activateBulkFilerAfterReviewLeaseForTest({
+      item: oldCandidate,
+      detection: oldResult,
+      patchTransparency: () => {
+        throw new Error("old issues must not receive transparency");
+      },
+      applyLabel: () => {
+        throw new Error("old issues must not be labeled");
+      },
+    }),
+    false,
+  );
+  assert.equal(oldCandidate.labels.includes("clawsweeper:bulk-filed"), false);
+
+  const freshCandidate = item({
+    number: 47,
+    createdAt: "2026-07-16T11:59:59.999Z",
+  });
+  const freshResult = detectBulkFilerForTest({
+    item: freshCandidate,
+    cache: new Map(),
+    now,
+    searchCount: () => {
+      searches += 1;
+      return 16;
+    },
+  });
+  assert.equal(
+    activateBulkFilerAfterReviewLeaseForTest({
+      item: freshCandidate,
+      detection: freshResult,
+      patchTransparency: () => undefined,
+      applyLabel: () => true,
+    }),
+    true,
+  );
+
+  assert.equal(searches, 1);
+  assert.equal(freshResult.context?.detected, true);
+  assert.equal(freshCandidate.labels.includes("clawsweeper:bulk-filed"), true);
+});
+
+test("bulk-filer activation omits transparency when label application fails", () => {
+  const candidate = item();
+  const detection = detectBulkFilerForTest({
+    item: candidate,
+    cache: new Map(),
+    now: 0,
+    searchCount: () => 16,
+  });
+  const mutations: string[] = [];
+
+  assert.equal(
+    activateBulkFilerAfterReviewLeaseForTest({
+      item: candidate,
+      detection,
+      applyLabel: () => {
+        mutations.push("label");
+        return false;
+      },
+      patchTransparency: () => mutations.push("transparency"),
+    }),
+    false,
+  );
+  assert.deepEqual(mutations, ["label"]);
+  assert.equal(detection.labelPending, true);
+  assert.equal(detection.labelApplied, false);
+  assert.equal(candidate.labels.includes("clawsweeper:bulk-filed"), false);
+
+  assert.equal(
+    activateBulkFilerAfterReviewLeaseForTest({
+      item: candidate,
+      detection,
+      applyLabel: () => {
+        mutations.push("label");
+        return true;
+      },
+      patchTransparency: () => mutations.push("transparency"),
+    }),
+    true,
+  );
+  assert.deepEqual(mutations, ["label", "label", "transparency"]);
+  assert.equal(detection.labelPending, false);
+  assert.equal(detection.labelApplied, true);
+});
+
+test("bulk-filer detection caches counts per author and fails open", () => {
+  const cache = new Map();
+  let searches = 0;
+  const searchCount = () => {
+    searches += 1;
+    throw new Error("search unavailable");
+  };
+
+  const first = detectBulkFilerForTest({
+    item: item({ author: "Reporter", number: 1 }),
+    cache,
+    now: 0,
+    searchCount,
+  });
+  const second = detectBulkFilerForTest({
+    item: item({ author: "reporter", number: 2 }),
+    cache,
+    now: 0,
+    searchCount,
+  });
+
+  assert.deepEqual(first, { context: null, labelPending: false, labelApplied: false });
+  assert.deepEqual(second, { context: null, labelPending: false, labelApplied: false });
+  assert.equal(searches, 1);
+});
+
+test("bulk-filer labeling is idempotent", () => {
+  const candidate = item({ labels: ["ClawSweeper:Bulk-Filed"] });
+  const result = detectBulkFilerForTest({
+    item: candidate,
+    cache: new Map(),
+    now: 0,
+    searchCount: () => 16,
+  });
+  let mutations = 0;
+  const applied = activateBulkFilerAfterReviewLeaseForTest({
+    item: candidate,
+    detection: result,
+    patchTransparency: () => {
+      mutations += 1;
+    },
+    applyLabel: () => {
+      mutations += 1;
+      return true;
+    },
+  });
+
+  assert.equal(result.context?.detected, true);
+  assert.equal(result.labelPending, false);
+  assert.equal(result.labelApplied, false);
+  assert.equal(applied, false);
+  assert.equal(mutations, 0);
+  assert.deepEqual(candidate.labels, ["ClawSweeper:Bulk-Filed"]);
+});
+
+test("first bulk-filer label application adds polite scheduling transparency", () => {
+  const comment = renderReviewStartStatusComment({
+    number: 44,
+    kind: "issue",
+    title: "Templated report",
+    headSha: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    bulkFilerLabelApplied: true,
+  });
+
+  assert.match(comment, /High filing volume detected/);
+  assert.match(comment, /batched behind other reviews/);
+  assert.match(comment, /Consolidating related reports into fewer issues/);
+});

--- a/test/clawsweeper-action-ledger.test.ts
+++ b/test/clawsweeper-action-ledger.test.ts
@@ -613,7 +613,12 @@ test("apply mutation receipts bind every GitHub request attempt and preserve no-
   assert.match(source, /identity: `review_lease_post:/);
   assert.match(source, /identity: `review_lease_delete:/);
   assert.doesNotMatch(source, /identity: `apply_lease_acquire:/);
-  assert.match(source, /return \{ status: "posted", lease: acquired, didMutate: true \}/);
+  // The posted result must carry the acquired lease (now enriched with the
+  // winning comment for bulk-filer transparency patches) and didMutate: true.
+  assert.match(
+    source,
+    /return \{\s*status: "posted",\s*lease: \{ \.\.\.acquired, comment: winner\.comment \},\s*didMutate: true,?\s*\}/,
+  );
   assert.deepEqual(applyPhaseSequenceForTest(6), [2, 3, 4, 5, 6, 7]);
 });
 

--- a/test/pr-label-policy.test.ts
+++ b/test/pr-label-policy.test.ts
@@ -887,6 +887,29 @@ test("ClawSweeper issue advisory labels expose work-lane routing state", () => {
   );
 });
 
+test("bulk-filed issues never enter automated fix dispatch", () => {
+  const labels = issueAdvisoryLabelsForTest(["bug", "clawsweeper:bulk-filed"], {
+    type: "issue",
+    itemCategory: "bug",
+    reproductionStatus: "reproduced",
+    reproductionConfidence: "high",
+    implementationComplexity: "small",
+    autoImplementationCandidate: "strict_bug",
+    workCandidate: "queue_fix_pr",
+    workStatus: "candidate",
+    workConfidence: "high",
+    hasWorkShape: true,
+    hasWorkPrompt: true,
+    hasWorkValidation: true,
+  });
+
+  assert.equal(labels.includes("clawsweeper:bulk-filed"), true);
+  assert.equal(labels.includes("clawsweeper:no-new-fix-pr"), true);
+  assert.equal(labels.includes("clawsweeper:queueable-fix"), false);
+  assert.equal(labels.includes("good first issue"), false);
+  assert.equal(labels.includes("no-stale"), false);
+});
+
 test("ClawSweeper labels only small verified strict bugs as good first issues", () => {
   const eligibleState = {
     type: "issue",

--- a/test/review-close-policy.test.ts
+++ b/test/review-close-policy.test.ts
@@ -46,6 +46,10 @@ test("review prompt documents gated backlog close policies", () => {
   assert.match(prompt, /fresh current-version reproduction/);
   assert.match(prompt, /`obsolete_fix_pr`/);
   assert.match(prompt, /every touched path was substantially rewritten or removed/);
+  assert.match(prompt, /`bulkFiler\.detected`/);
+  assert.match(prompt, /extra duplicate scrutiny/);
+  assert.match(prompt, /Never route it to proof-nudge or automated fix-dispatch work/);
+  assert.match(prompt, /do not invent a bulk-filing close reason/);
   assert.equal(
     [...sweepWorkflow.matchAll(/CLAWSWEEPER_IDEA_REVIVAL_REACTIONS:.*\|\| '5'/g)].length,
     2,

--- a/test/scheduler-policy.test.ts
+++ b/test/scheduler-policy.test.ts
@@ -358,6 +358,105 @@ test("normal scheduler reserves throughput for PR and older buckets", () => {
   assert.deepEqual(selectedNumbers(due, 8, now), [1, 2, 3, 4, 101, 201, 301, 5]);
 });
 
+test("bulk-filed issues sort last while scheduler bucket priority stays intact", () => {
+  const now = Date.parse("2026-07-16T12:00:00Z");
+  const due = [
+    {
+      item: item({
+        number: 1,
+        kind: "issue",
+        createdAt: "2026-07-15T00:00:00Z",
+        labels: ["clawsweeper:bulk-filed"],
+      }),
+      bucket: "hot_issue",
+      priority: 0,
+      nextDueAt: 0,
+    },
+    {
+      item: item({ number: 2, kind: "issue", createdAt: "2026-07-15T00:00:00Z" }),
+      bucket: "hot_issue",
+      priority: 0,
+      nextDueAt: 100,
+    },
+    {
+      item: item({
+        number: 3,
+        kind: "pull_request",
+        createdAt: "2026-07-15T00:00:00Z",
+      }),
+      bucket: "hot_pull_request",
+      priority: 1,
+      nextDueAt: 0,
+    },
+  ];
+
+  assert.deepEqual(selectedNumbers(due, 3, now), [2, 1, 3]);
+  assert.deepEqual(selectedNumbers(due, 1, now), [2]);
+
+  const onlyBulkHotIssue = due.filter((candidate) => candidate.item.number !== 2);
+  assert.deepEqual(selectedNumbers(onlyBulkHotIssue, 1, now), [1]);
+
+  const overdueWeeklyIssues = [
+    {
+      item: item({
+        number: 10,
+        createdAt: "2026-04-01T00:00:00Z",
+        labels: ["clawsweeper:bulk-filed"],
+      }),
+      bucket: "weekly_issue",
+      priority: 6,
+      nextDueAt: 0,
+    },
+    {
+      item: item({ number: 11, createdAt: "2026-05-01T00:00:00Z" }),
+      bucket: "weekly_issue",
+      priority: 6,
+      nextDueAt: 100,
+    },
+  ];
+  assert.deepEqual(selectedNumbers(overdueWeeklyIssues, 1, now), [11]);
+});
+
+test("mixed-bucket weekly-overdue ordering is transitive and globally bulk-last", () => {
+  const now = Date.parse("2026-07-16T12:00:00Z");
+  const due = [
+    {
+      item: item({
+        number: 21,
+        createdAt: "2026-04-01T00:00:00Z",
+        labels: ["clawsweeper:bulk-filed"],
+      }),
+      bucket: "hot_issue",
+      priority: 0,
+    },
+    {
+      item: item({
+        number: 22,
+        createdAt: "2026-05-01T00:00:00Z",
+        labels: ["clawsweeper:bulk-filed"],
+      }),
+      bucket: "weekly_issue",
+      priority: 6,
+    },
+    {
+      item: item({ number: 23, createdAt: "2026-06-01T00:00:00Z" }),
+      bucket: "hot_issue",
+      priority: 0,
+    },
+    {
+      item: item({
+        number: 24,
+        kind: "pull_request",
+        createdAt: "2026-07-01T00:00:00Z",
+      }),
+      bucket: "daily_pull_request",
+      priority: 3,
+    },
+  ];
+
+  assert.deepEqual(selectedNumbers(due, due.length, now), [23, 24, 21, 22]);
+});
+
 test("normal scheduler prioritizes items already breaching weekly freshness", () => {
   const now = Date.parse("2026-06-14T12:00:00Z");
   const due = [


### PR DESCRIPTION
## Why

Agent-driven bulk issue filing is real (16 templated issues in seconds from one account on Jul 12; a handful of accounts dominate close counts). Mass-filed issues crowd review capacity ahead of organic reports. Part of the backlog-strategy batch; pairs with the "do you plan to open a PR?" template field (openclaw/openclaw#109258).

## What

- **Detection** (read-only, review-time): one bounded search per reviewed issue counts the author's issues filed in the last `CLAWSWEEPER_BULK_FILER_WINDOW_DAYS` (7); at >= `CLAWSWEEPER_BULK_FILER_THRESHOLD` (10) the issue is eligible — but only when the issue itself was created inside that window (a years-old issue from a currently-prolific author is never touched), with detector and search agreeing at the exact boundary. Per-author count cached per run; fail-open (search failure -> no label, review proceeds).
- **Mutation discipline**: the `clawsweeper:bulk-filed` label and its one polite transparency line ("issues are batched behind other reviews; consolidating related reports speeds everything up") apply only after the worker owns the review lease; label lands first, disclosure follows, and a failed disclosure patch is logged without aborting the review.
- **Scheduling**: bulk-filed issues sort last via an unconditional (transitive) tie-break — behind others within their bucket in normal selection and behind other weekly-overdue items in the SLO catch-up pass; no bucket promotion/demotion. Prompt guidance adds duplicate scrutiny + terse reviews and keeps bulk-filed issues out of proof-nudge/fix lanes. No new close reason.

## Review history (Codex Sol, xhigh, 3 rounds)

Accepted + fixed: lease-ordering of the label mutation; burst-window scoping (old issues immune); comparator transitivity in the mixed-bucket weekly-overdue sort (regression test asserts no cycle); label-before-disclosure ordering; detector/search boundary agreement; disclosure-failure guard so a comment PATCH failure cannot abort a review. Rejected as designed: classifying before candidate selection — that would add a search call per candidate to the planner (forbidden fan-out); the label intentionally shapes subsequent scheduling while first-pass review handles bulk-filed issues via prompt scrutiny. Follow-up: reconcile a labeled issue that is missing its disclosure line (cosmetic inconsistency only).

## Proof

`pnpm run build:all`, `check:limits`, `format:check`, `lint` green; bulk-filer + scheduler + prompt suites — 92 pass initially, 21 in final focused rerun (threshold/window boundaries, fail-open, idempotency, mutation ordering, old-issue immunity, transitive ordering regression).
