### PR TITLE
fix(publish): stale exact-review artifacts complete terminally instead of requeueing forever

### DIFF
--- a/src/repair/publish-event-result.ts
+++ b/src/repair/publish-event-result.ts
@@ -35,6 +35,11 @@ import {
 } from "./git-publish.js";
 import { isJsonObject } from "./json-types.js";
 import { RecordTupleError } from "./record-tuple.js";
+import {
+  staleEventDisposition,
+  staleEventDispositionOutputLines,
+  type StaleEventDisposition,
+} from "./stale-event-disposition.js";
 
 type EventOptions = {
   targetRepo: string;
@@ -115,14 +120,9 @@ async function publishEventResult(options: EventOptions): Promise<void> {
     preflightResult === "remote-newer" ||
     preflightResult === "missing"
   ) {
-    const detail =
-      preflightResult === "remote-closed"
-        ? "current state is already closed"
-        : preflightResult === "remote-newer"
-          ? "current state has a newer tuple"
-          : "the event produced no record tuple";
+    const disposition = staleEventDisposition(preflightResult);
     console.log(
-      `Skipping stale event apply for ${options.targetRepo}#${options.itemNumber}: ${detail}`,
+      `Skipping stale event apply for ${options.targetRepo}#${options.itemNumber}: ${disposition.detail}`,
     );
     refreshSourceAfterStatePublish(
       [
@@ -141,9 +141,13 @@ async function publishEventResult(options: EventOptions): Promise<void> {
       missingCount: 0,
       closeReasons: options.closeReasons,
     });
-    throw new Error(
-      `Event state for ${options.targetRepo}#${options.itemNumber} was not applied because ${detail}; requeue against the latest item revision`,
-    );
+    // A stale artifact can never publish: the state already advanced (or the
+    // event carried no tuple). Failing here would requeue the same artifact
+    // forever, so exit successfully with the terminal disposition instead —
+    // `requeue_latest` hands remote-newer to the source-drift requeue step,
+    // which reviews the LATEST revision.
+    writeStaleEventDispositionOutputs(disposition);
+    return;
   }
 
   const actions = readApplyActions(options.reportPath);
@@ -481,6 +485,16 @@ function writeSummary({
       `- Close reasons enabled: ${closeReasons}`,
       "",
     ].join("\n"),
+    "utf8",
+  );
+}
+
+function writeStaleEventDispositionOutputs(disposition: StaleEventDisposition): void {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) return;
+  fs.appendFileSync(
+    outputPath,
+    `${staleEventDispositionOutputLines(disposition).join("\n")}\n`,
     "utf8",
   );
 }

--- a/src/repair/stale-event-disposition.ts
+++ b/src/repair/stale-event-disposition.ts
@@ -1,0 +1,49 @@
+export type StaleEventPreflightResult = "remote-closed" | "remote-newer" | "missing";
+
+export type StaleEventDisposition = {
+  detail: string;
+  requeueLatest: boolean;
+  terminalClosed: boolean;
+  terminalMissing: boolean;
+};
+
+// A stale publication artifact can never publish: the state already advanced,
+// closed, or the event carried no tuple. Each case maps to a terminal workflow
+// disposition — failing the run instead would requeue the same artifact forever.
+export function staleEventDisposition(result: StaleEventPreflightResult): StaleEventDisposition {
+  if (result === "remote-closed") {
+    return {
+      detail: "current state is already closed",
+      requeueLatest: false,
+      terminalClosed: true,
+      terminalMissing: false,
+    };
+  }
+  if (result === "remote-newer") {
+    return {
+      detail: "current state has a newer tuple",
+      requeueLatest: true,
+      terminalClosed: false,
+      terminalMissing: false,
+    };
+  }
+  return {
+    detail: "the event produced no record tuple",
+    requeueLatest: false,
+    terminalClosed: false,
+    terminalMissing: true,
+  };
+}
+
+export function staleEventDispositionOutputLines(disposition: StaleEventDisposition): string[] {
+  return [
+    "remote_tuple_verified=false",
+    `terminal_missing=${disposition.terminalMissing ? "true" : "false"}`,
+    `terminal_closed=${disposition.terminalClosed ? "true" : "false"}`,
+    "guarded_open=false",
+    "guarded_open_action=",
+    "policy_noop=false",
+    `requeue_latest=${disposition.requeueLatest ? "true" : "false"}`,
+    "routing_deferred=false",
+  ];
+}

--- a/test/repair/stale-event-disposition.test.ts
+++ b/test/repair/stale-event-disposition.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import {
+  staleEventDisposition,
+  staleEventDispositionOutputLines,
+} from "../../dist/repair/stale-event-disposition.js";
+
+test("stale event dispositions are terminal, never retry-the-same-artifact", () => {
+  assert.deepEqual(staleEventDisposition("remote-newer"), {
+    detail: "current state has a newer tuple",
+    requeueLatest: true,
+    terminalClosed: false,
+    terminalMissing: false,
+  });
+  assert.deepEqual(staleEventDisposition("remote-closed"), {
+    detail: "current state is already closed",
+    requeueLatest: false,
+    terminalClosed: true,
+    terminalMissing: false,
+  });
+  assert.deepEqual(staleEventDisposition("missing"), {
+    detail: "the event produced no record tuple",
+    requeueLatest: false,
+    terminalClosed: false,
+    terminalMissing: true,
+  });
+});
+
+test("stale event disposition output lines match the workflow contract", () => {
+  const lines = staleEventDispositionOutputLines(staleEventDisposition("remote-newer"));
+  assert.ok(lines.includes("requeue_latest=true"));
+  assert.ok(lines.includes("terminal_closed=false"));
+  assert.ok(lines.includes("terminal_missing=false"));
+  assert.ok(lines.includes("remote_tuple_verified=false"));
+  const closed = staleEventDispositionOutputLines(staleEventDisposition("remote-closed"));
+  assert.ok(closed.includes("terminal_closed=true"));
+  assert.ok(closed.includes("requeue_latest=false"));
+});
+
+test("publish-event-result exits terminally on a stale preflight instead of throwing", () => {
+  // The workflow classifier treats an unset disposition as failure -> infinite
+  // requeue of the same stale artifact (2026-07-16 poison cohort). Guard the
+  // contract at the source level.
+  const source = readFileSync("src/repair/publish-event-result.ts", "utf8");
+  const preflightBlock = source.slice(
+    source.indexOf('preflightResult === "remote-closed"'),
+    source.indexOf("const actions = readApplyActions"),
+  );
+  assert.ok(preflightBlock.includes("writeStaleEventDispositionOutputs"));
+  assert.ok(!preflightBlock.includes("throw new Error"));
+});


### PR DESCRIPTION
## Why

Monitoring found a poison cohort: `openclaw/agent-skills#100@publish:29455236464:1` retried publication for 21+ hours. Root cause: when the publisher's preflight detects a stale artifact ("current state has a newer tuple" / "already closed" / "no record tuple"), it throws — the workflow fails, the queue requeues the SAME artifact, and the failure is deterministic, so it loops until the 80-day artifact ceiling. The oldest-pending publication cohort (~20h) is this bug.

## What

The preflight-stale branch now writes the workflow's existing disposition outputs and exits successfully instead of throwing:
- `remote-newer` -> `requeue_latest=true`: the existing "Queue fresh review after source drift" step enqueues a review of the LATEST revision (superseding), classifier reports success, queue completes this item.
- `remote-closed` -> `terminal_closed=true`, `missing` -> `terminal_missing=true`: terminal completions the classifier already accepts.

The outcome vocabulary and all consuming steps already existed — the preflight path just never emitted it. Disposition mapping lives in a new pure module (`src/repair/stale-event-disposition.ts`) so it is unit-testable (the publisher script executes at module load).

## Proof

- Unit tests: disposition mapping per preflight result; output lines match the workflow contract; a source-level guard asserts the preflight block writes dispositions and contains no throw (the regression that caused the loop).
- `pnpm run build:all`, `format:check`, `lint` green; autoreview (Codex Sol, xhigh) clean on first pass.
- After deploy, expect the ~20h publication cohort to drain within one retry cycle per item.
