### PR TITLE
feat(triage): propose cluster umbrella consolidations in a weekly rolling report

### DIFF
--- a/.github/workflows/umbrella-proposals.yml
+++ b/.github/workflows/umbrella-proposals.yml
@@ -1,0 +1,103 @@
+name: umbrella consolidation proposals
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "23 17 * * 1"
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  CLAWSWEEPER_APP_CLIENT_ID: Iv23liOECG0slfuhz093
+  CLAWSWEEPER_PROPOSAL_AUTHOR_LOGIN: clawsweeper[bot]
+  TARGET_REPO: openclaw/openclaw
+  UMBRELLA_MIN_CLUSTER_SIZE: ${{ vars.UMBRELLA_MIN_CLUSTER_SIZE || '5' }}
+  UMBRELLA_MAX_PROPOSALS: ${{ vars.UMBRELLA_MAX_PROPOSALS || '10' }}
+  UMBRELLA_MAX_MEMBERS_PER_PROPOSAL: ${{ vars.UMBRELLA_MAX_MEMBERS_PER_PROPOSAL || '20' }}
+  UMBRELLA_PROPOSAL_BODY_MAX_CHARS: ${{ vars.UMBRELLA_PROPOSAL_BODY_MAX_CHARS || '60000' }}
+
+concurrency:
+  group: umbrella-consolidation-proposals
+  cancel-in-progress: true
+
+jobs:
+  proposals:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Create gitcrawl-store token
+        id: store-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+          owner: openclaw
+          repositories: gitcrawl-store
+          permission-contents: read
+
+      - name: Create proposal issue token
+        id: proposal-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+          owner: openclaw
+          repositories: clawsweeper
+          permission-issues: write
+
+      - uses: actions/checkout@v7
+        with:
+          repository: openclaw/gitcrawl-store
+          token: ${{ steps.store-token.outputs.token }}
+          path: gitcrawl-store
+          fetch-depth: 1
+
+      - uses: ./.github/actions/setup-pnpm
+        with:
+          build-script: build:repair
+
+      - name: Render read-only proposals
+        run: |
+          set -euo pipefail
+          mkdir -p .artifacts/umbrella
+          db_path="gitcrawl-store/data/openclaw__openclaw.sync.db"
+          manifest_path="${db_path%.db}.db.manifest.json"
+          test -s "$db_path"
+          test -s "$manifest_path"
+          pnpm run --silent workflow -- umbrella-proposals \
+            --repo "$TARGET_REPO" \
+            --db "$db_path" \
+            --min-cluster-size "$UMBRELLA_MIN_CLUSTER_SIZE" \
+            --max-proposals "$UMBRELLA_MAX_PROPOSALS" \
+            --max-members-per-cluster "$UMBRELLA_MAX_MEMBERS_PER_PROPOSAL" \
+            --max-body-chars "$UMBRELLA_PROPOSAL_BODY_MAX_CHARS" \
+            --output .artifacts/umbrella/proposals.md
+
+      - name: Create or update rolling proposal issue
+        env:
+          GH_TOKEN: ${{ steps.proposal-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          gh api "repos/openclaw/clawsweeper/issues?state=open&per_page=100" \
+            --paginate \
+            --slurp > .artifacts/umbrella/open-issue-pages.json
+          jq 'add' .artifacts/umbrella/open-issue-pages.json \
+            > .artifacts/umbrella/open-issues.json
+          issue_number="$(pnpm run --silent workflow -- umbrella-proposal-issue-number \
+            --issues .artifacts/umbrella/open-issues.json \
+            --author-login "$CLAWSWEEPER_PROPOSAL_AUTHOR_LOGIN")"
+          if [ -n "$issue_number" ]; then
+            gh issue edit "$issue_number" \
+              --repo openclaw/clawsweeper \
+              --title "Umbrella consolidation proposals" \
+              --body-file .artifacts/umbrella/proposals.md
+          else
+            gh issue create \
+              --repo openclaw/clawsweeper \
+              --title "Umbrella consolidation proposals" \
+              --body-file .artifacts/umbrella/proposals.md
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ checkpoint, and status-only commits are intentionally omitted.
 ### Added
 
 - Added review-time bulk-filer detection, transparent labeling, duplicate scrutiny, fix-lane suppression, and within-bucket scheduling de-prioritization for high-volume issue authors.
+- Added an app-authenticated weekly, read-only gitcrawl umbrella-consolidation proposal report with deterministic bounded titles, member lists, and issue-body size guards.
 - Added end-to-end exact-review handoff health with phase ages, delayed/stalled claim classification, and a phase-aware operator rail on the live dashboard.
 - Added a maintainer-only two-runner workflow that builds a hash-bound
   crawl-remote release artifact without production credentials, then requires

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -25,7 +25,17 @@ budget:
 | `CLAWSWEEPER_BULK_FILER_THRESHOLD`                |      10 | Recent authored-issue count that marks bulk filing.  |
 | `CLAWSWEEPER_BULK_FILER_WINDOW_DAYS`              |       7 | Lookback window for authored issue filing rate.      |
 | `CLAWSWEEPER_STALE_VERSION_BUG_CLOSE_ENABLED`     | `false` | Enables stale-version bug closes after 120 days.     |
-| `CLAWSWEEPER_OBSOLETE_FIX_PR_CLOSE_ENABLED`       | `false` | Enables obsolete small-fix PR closes after 90 days. |
+| `CLAWSWEEPER_OBSOLETE_FIX_PR_CLOSE_ENABLED`       | `false` | Enables obsolete small-fix PR closes after 90 days.  |
+
+Umbrella consolidation proposals have separate bounded report limits. These do
+not consume Codex worker capacity:
+
+| Environment variable                | Default | Meaning                                                        |
+| ----------------------------------- | ------: | -------------------------------------------------------------- |
+| `UMBRELLA_MIN_CLUSTER_SIZE`         |       5 | Eligible open decision-labeled issues required for a proposal. |
+| `UMBRELLA_MAX_PROPOSALS`            |      10 | Largest eligible clusters rendered in the weekly report.       |
+| `UMBRELLA_MAX_MEMBERS_PER_PROPOSAL` |      20 | Member links rendered for each cluster in the rolling report.  |
+| `UMBRELLA_PROPOSAL_BODY_MAX_CHARS`  |  60,000 | Rolling report body safety limit before cluster sections stop. |
 
 See [`author-pr-budget-close-policy.md`](author-pr-budget-close-policy.md) for
 the rating, proof, inactivity, engagement, and fail-closed gates.

--- a/src/repair/umbrella-consolidation.ts
+++ b/src/repair/umbrella-consolidation.ts
@@ -1,0 +1,363 @@
+import { execFileSync } from "node:child_process";
+
+import type { JsonValue, LooseRecord } from "./json-types.js";
+import { EXACT_REVIEW_CLOSE_GUARD_LABELS } from "./exact-review-guard-labels.js";
+
+export const UMBRELLA_PROPOSAL_MARKER = "<!-- clawsweeper:umbrella-proposals -->";
+export const UMBRELLA_PROPOSAL_TITLE = "Umbrella consolidation proposals";
+export const UMBRELLA_PROPOSAL_AUTHOR_LOGIN = "clawsweeper[bot]";
+export const NEEDS_PRODUCT_DECISION_LABEL = "clawsweeper:needs-product-decision";
+export const IDEA_ARCHIVE_LABEL = "clawsweeper:idea-archive";
+export const DEFAULT_UMBRELLA_MIN_CLUSTER_SIZE = 5;
+export const DEFAULT_UMBRELLA_MAX_PROPOSALS = 10;
+export const DEFAULT_UMBRELLA_MAX_MEMBERS_PER_PROPOSAL = 20;
+export const DEFAULT_UMBRELLA_PROPOSAL_BODY_MAX_CHARS = 60_000;
+export const MAX_SUGGESTED_UMBRELLA_TITLE_LENGTH = 120;
+// Headroom kept while accepting sections so a truncation note can always be
+// appended without slicing accepted content (note text + cluster id + counts).
+export const PROPOSAL_TRUNCATION_NOTE_RESERVE = 220;
+
+const PROTECTED_LABELS = new Set(
+  [...EXACT_REVIEW_CLOSE_GUARD_LABELS, IDEA_ARCHIVE_LABEL].map((label) => label.toLowerCase()),
+);
+const TITLE_STOP_WORDS = new Set([
+  "a",
+  "add",
+  "allow",
+  "an",
+  "and",
+  "for",
+  "feature",
+  "from",
+  "in",
+  "into",
+  "of",
+  "on",
+  "request",
+  "support",
+  "the",
+  "to",
+  "with",
+]);
+
+export type ClusterMember = {
+  clusterId: number;
+  number: number;
+  kind: string;
+  state: string;
+  title: string;
+  author: string;
+  labels: string[];
+};
+
+export type UmbrellaProposal = {
+  clusterId: string;
+  title: string;
+  members: ClusterMember[];
+};
+
+export function readGitcrawlClusterMembers(dbPath: string): ClusterMember[] {
+  const source = detectClusterSource(dbPath);
+  const sql =
+    source === "portable"
+      ? `
+        select cg.id as cluster_id, t.number, t.kind, t.state, t.title,
+               coalesce(t.author_login, '') as author_login, t.labels_json
+        from cluster_groups cg
+        join cluster_memberships cm on cm.cluster_id = cg.id and cm.state = 'active'
+        join threads t on t.id = cm.thread_id
+        where cg.status = 'active'
+        order by cg.id, t.number;
+      `
+      : `
+        select c.id as cluster_id, t.number, t.kind, t.state, t.title,
+               coalesce(t.author_login, '') as author_login, t.labels_json
+        from clusters c
+        join cluster_members cm on cm.cluster_id = c.id
+        join threads t on t.id = cm.thread_id
+        where c.closed_at_local is null
+        order by c.id, t.number;
+      `;
+  return sqliteJson(dbPath, sql).flatMap(normalizeClusterMember);
+}
+
+export function selectUmbrellaProposals(
+  members: ClusterMember[],
+  options: { minClusterSize?: number; maxProposals?: number } = {},
+): UmbrellaProposal[] {
+  const minClusterSize = positiveInteger(options.minClusterSize, DEFAULT_UMBRELLA_MIN_CLUSTER_SIZE);
+  const maxProposals = positiveInteger(options.maxProposals, DEFAULT_UMBRELLA_MAX_PROPOSALS);
+  const byCluster = new Map<number, ClusterMember[]>();
+  for (const member of members) {
+    if (member.kind !== "issue" || member.state !== "open") continue;
+    if (umbrellaMemberBlockReason(member.labels)) continue;
+    const cluster = byCluster.get(member.clusterId) ?? [];
+    cluster.push(member);
+    byCluster.set(member.clusterId, cluster);
+  }
+  return [...byCluster.entries()]
+    .map(([clusterId, eligible]) => ({
+      clusterId: stableClusterId(clusterId),
+      title: suggestedUmbrellaTitle(eligible.map((member) => member.title)),
+      members: eligible.sort((left, right) => left.number - right.number),
+    }))
+    .filter((proposal) => proposal.members.length >= minClusterSize)
+    .sort(
+      (left, right) =>
+        right.members.length - left.members.length ||
+        parseStableClusterId(left.clusterId) - parseStableClusterId(right.clusterId),
+    )
+    .slice(0, maxProposals);
+}
+
+export function suggestedUmbrellaTitle(titles: string[]): string {
+  const counts = new Map<string, number>();
+  for (const title of titles) {
+    const unique = new Set(
+      title
+        .toLowerCase()
+        .match(/[a-z0-9][a-z0-9+._-]*/g)
+        ?.filter((token) => token.length >= 3 && !TITLE_STOP_WORDS.has(token)) ?? [],
+    );
+    for (const token of unique) counts.set(token, (counts.get(token) ?? 0) + 1);
+  }
+  const ranked = [...counts.entries()].sort(
+    ([leftToken, leftCount], [rightToken, rightCount]) =>
+      rightCount - leftCount || leftToken.localeCompare(rightToken),
+  );
+  const repeated = ranked.filter(([, count]) => count > 1);
+  const selected = (repeated.length > 0 ? repeated : ranked).slice(0, 5).map(([token]) => token);
+  const themeTokens =
+    selected.length > 0 ? selected.map(titleCaseToken) : ["Related", "feature", "requests"];
+  return boundedSuggestedTitle(themeTokens);
+}
+
+export function selectAppAuthoredUmbrellaProposalIssue(
+  issues: JsonValue[],
+  authorLogin = UMBRELLA_PROPOSAL_AUTHOR_LOGIN,
+): number | null {
+  const candidates = issues
+    .filter(
+      (issue): issue is LooseRecord =>
+        Boolean(issue) && typeof issue === "object" && !Array.isArray(issue),
+    )
+    .filter(
+      (issue) =>
+        !issue.pull_request &&
+        String(issue.state ?? "").toLowerCase() === "open" &&
+        String(issue.user?.login ?? "") === authorLogin &&
+        (String(issue.body ?? "").includes(UMBRELLA_PROPOSAL_MARKER) ||
+          String(issue.title ?? "") === UMBRELLA_PROPOSAL_TITLE),
+    )
+    .sort((left, right) => {
+      const leftMarked = String(left.body ?? "").includes(UMBRELLA_PROPOSAL_MARKER);
+      const rightMarked = String(right.body ?? "").includes(UMBRELLA_PROPOSAL_MARKER);
+      return Number(rightMarked) - Number(leftMarked) || Number(left.number) - Number(right.number);
+    });
+  const number = Number(candidates[0]?.number);
+  return Number.isSafeInteger(number) && number > 0 ? number : null;
+}
+
+export function renderUmbrellaProposals(
+  proposals: UmbrellaProposal[],
+  options: {
+    targetRepo: string;
+    generatedAt?: string;
+    maxMembersPerCluster?: number;
+    maxBodyChars?: number;
+  } = { targetRepo: "openclaw/openclaw" },
+): string {
+  const generatedAt = options.generatedAt ?? new Date().toISOString();
+  const maxMembersPerCluster = positiveInteger(
+    options.maxMembersPerCluster,
+    DEFAULT_UMBRELLA_MAX_MEMBERS_PER_PROPOSAL,
+  );
+  const maxBodyChars = positiveInteger(
+    options.maxBodyChars,
+    DEFAULT_UMBRELLA_PROPOSAL_BODY_MAX_CHARS,
+  );
+  let body = [
+    UMBRELLA_PROPOSAL_MARKER,
+    "# Umbrella consolidation proposals",
+    "",
+    `Generated ${generatedAt}. Proposal generation is read-only against \`${options.targetRepo}\`.`,
+    "This report does not mutate target issues.",
+  ].join("\n");
+
+  if (proposals.length === 0) {
+    return boundedProposalBody(
+      `${body}\n\nNo eligible clusters met the configured threshold.`,
+      maxBodyChars,
+    );
+  }
+
+  for (const [index, proposal] of proposals.entries()) {
+    const renderedMembers = proposal.members.slice(0, maxMembersPerCluster);
+    const hiddenMembers = proposal.members.length - renderedMembers.length;
+    const section = [
+      `## ${proposal.clusterId}: ${neutralizeProposalText(proposal.title)}`,
+      "",
+      `${proposal.members.length} eligible open issues in \`${options.targetRepo}\`.`,
+      "",
+      "A maintainer can consolidate these manually or wait for the upcoming consolidation command.",
+      "",
+      ...renderedMembers.map(
+        (member) =>
+          `- https://github.com/${options.targetRepo}/issues/${member.number} ${neutralizeProposalText(member.title)}`,
+      ),
+      ...(hiddenMembers > 0 ? [`...and ${hiddenMembers} more eligible member(s).`] : []),
+    ].join("\n");
+    const candidate = `${body}\n\n${section}`;
+    // Reserve room for a possible truncation note whenever later sections
+    // remain, so the note never has to slice an already accepted section.
+    const isLastProposal = index === proposals.length - 1;
+    const fits = isLastProposal
+      ? candidate.length <= maxBodyChars
+      : candidate.length + PROPOSAL_TRUNCATION_NOTE_RESERVE <= maxBodyChars;
+    if (fits) {
+      body = candidate;
+      continue;
+    }
+    const omittedClusters = proposals.length - index;
+    return appendProposalTruncationNote(
+      body,
+      `_Proposal body limit reached; ${omittedClusters} cluster section(s), starting with \`${proposal.clusterId}\`, were omitted._`,
+      maxBodyChars,
+    );
+  }
+  return body;
+}
+
+export function neutralizeProposalText(text: string): string {
+  return text
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/\\/g, "\\\\")
+    .replace(/([`[\]_*~])/g, "\\$1")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/@/g, "@\u200b");
+}
+
+function normalizeClusterMember(row: LooseRecord): ClusterMember[] {
+  const clusterId = Number(row.cluster_id);
+  const number = Number(row.number);
+  if (!Number.isSafeInteger(clusterId) || !Number.isSafeInteger(number)) return [];
+  return [
+    {
+      clusterId,
+      number,
+      kind: String(row.kind ?? ""),
+      state: String(row.state ?? "").toLowerCase(),
+      title: String(row.title ?? "").trim(),
+      author: String(row.author_login ?? "").trim(),
+      labels: jsonStringArray(row.labels_json),
+    },
+  ];
+}
+
+function umbrellaMemberBlockReason(labels: string[]): string | null {
+  const normalized = new Set(labels.map((label) => label.trim().toLowerCase()));
+  if (!normalized.has(NEEDS_PRODUCT_DECISION_LABEL)) {
+    return `missing ${NEEDS_PRODUCT_DECISION_LABEL}`;
+  }
+  const protectedLabel = [...normalized].find((label) => PROTECTED_LABELS.has(label));
+  return protectedLabel ? `protected label: ${protectedLabel}` : null;
+}
+
+function stableClusterId(clusterId: number): string {
+  if (!Number.isSafeInteger(clusterId) || clusterId <= 0)
+    throw new Error("cluster id must be positive");
+  return `gitcrawl-${clusterId}`;
+}
+
+function parseStableClusterId(clusterId: string): number {
+  const match = clusterId.match(/^gitcrawl-([1-9]\d*)$/);
+  const number = Number(match?.[1]);
+  if (!Number.isSafeInteger(number) || number <= 0) throw new Error("invalid cluster id");
+  return number;
+}
+
+function boundedProposalBody(body: string, maxBodyChars: number): string {
+  if (body.length <= maxBodyChars) return body;
+  return appendProposalTruncationNote(
+    body,
+    "_Proposal body limit reached; report content was truncated._",
+    maxBodyChars,
+  );
+}
+
+function appendProposalTruncationNote(body: string, note: string, maxBodyChars: number): string {
+  const suffix = `\n\n${note}`;
+  if (suffix.length >= maxBodyChars) return body.slice(0, maxBodyChars);
+  const prefix = body.slice(0, maxBodyChars - suffix.length).trimEnd();
+  return `${prefix}${suffix}`;
+}
+
+function titleCaseToken(token: string): string {
+  return token.length > 0 ? `${token[0]?.toUpperCase()}${token.slice(1)}` : token;
+}
+
+function boundedSuggestedTitle(themeTokens: string[]): string {
+  const prefix = "Umbrella:";
+  const selected: string[] = [];
+  for (const token of themeTokens) {
+    const candidate = `${prefix} ${[...selected, token].join(" ")}`;
+    if (candidate.length > MAX_SUGGESTED_UMBRELLA_TITLE_LENGTH) break;
+    selected.push(token);
+  }
+  if (selected.length === 0) return "Umbrella: Related feature requests";
+  return `${prefix} ${selected.join(" ")}`;
+}
+
+function detectClusterSource(dbPath: string): "portable" | "legacy" {
+  const legacyTable = Number(
+    sqliteScalar(
+      dbPath,
+      "select count(*) from sqlite_master where type = 'table' and name = 'clusters';",
+    ),
+  );
+  if (legacyTable > 0 && Number(sqliteScalar(dbPath, "select count(*) from clusters;")) > 0) {
+    return "legacy";
+  }
+  const portableTable = Number(
+    sqliteScalar(
+      dbPath,
+      "select count(*) from sqlite_master where type = 'table' and name = 'cluster_groups';",
+    ),
+  );
+  // Schema is detected by table existence: a valid snapshot with zero clusters
+  // must produce the "no eligible clusters" report, not abort the workflow.
+  if (portableTable > 0) return "portable";
+  if (legacyTable > 0) return "legacy";
+  throw new Error("gitcrawl database has no supported cluster tables");
+}
+
+function sqliteJson(dbPath: string, sql: string): LooseRecord[] {
+  const output = execFileSync("sqlite3", ["-json", dbPath, sql], {
+    encoding: "utf8",
+    maxBuffer: 256 * 1024 * 1024,
+  }).trim();
+  const parsed: JsonValue = JSON.parse(output || "[]");
+  return Array.isArray(parsed) ? (parsed as LooseRecord[]) : [];
+}
+
+function sqliteScalar(dbPath: string, sql: string): string {
+  return execFileSync("sqlite3", [dbPath, sql], { encoding: "utf8" }).trim();
+}
+
+function jsonStringArray(value: JsonValue): string[] {
+  try {
+    const parsed: JsonValue = typeof value === "string" ? JSON.parse(value) : value;
+    return Array.isArray(parsed) ? parsed.map((entry) => String(entry)) : [];
+  } catch {
+    return [];
+  }
+}
+
+function positiveInteger(value: number | undefined, fallback: number): number {
+  const number = value ?? fallback;
+  if (!Number.isSafeInteger(number) || number <= 0)
+    throw new Error("limit must be a positive integer");
+  return number;
+}

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -11,6 +11,16 @@ import {
   queuePressureLevel,
   type QueuePressureLevel,
 } from "../queue-pressure.js";
+import {
+  DEFAULT_UMBRELLA_MAX_MEMBERS_PER_PROPOSAL,
+  DEFAULT_UMBRELLA_MAX_PROPOSALS,
+  DEFAULT_UMBRELLA_PROPOSAL_BODY_MAX_CHARS,
+  DEFAULT_UMBRELLA_MIN_CLUSTER_SIZE,
+  readGitcrawlClusterMembers,
+  renderUmbrellaProposals,
+  selectAppAuthoredUmbrellaProposalIssue,
+  selectUmbrellaProposals,
+} from "./umbrella-consolidation.js";
 
 type ApplyAction = {
   action: string;
@@ -289,6 +299,46 @@ async function runCli(): Promise<void> {
     case "worker-config":
       process.stdout.write(JSON.stringify(WORKER_CONFIG, null, 2));
       break;
+    case "umbrella-proposals": {
+      const targetRepo = optionalString("repo") || "openclaw/openclaw";
+      const proposals = selectUmbrellaProposals(readGitcrawlClusterMembers(requiredString("db")), {
+        minClusterSize: umbrellaLimit(
+          "min-cluster-size",
+          "UMBRELLA_MIN_CLUSTER_SIZE",
+          DEFAULT_UMBRELLA_MIN_CLUSTER_SIZE,
+        ),
+        maxProposals: umbrellaLimit(
+          "max-proposals",
+          "UMBRELLA_MAX_PROPOSALS",
+          DEFAULT_UMBRELLA_MAX_PROPOSALS,
+        ),
+      });
+      const body = `${renderUmbrellaProposals(proposals, {
+        targetRepo,
+        maxMembersPerCluster: umbrellaLimit(
+          "max-members-per-cluster",
+          "UMBRELLA_MAX_MEMBERS_PER_PROPOSAL",
+          DEFAULT_UMBRELLA_MAX_MEMBERS_PER_PROPOSAL,
+        ),
+        maxBodyChars: umbrellaLimit(
+          "max-body-chars",
+          "UMBRELLA_PROPOSAL_BODY_MAX_CHARS",
+          DEFAULT_UMBRELLA_PROPOSAL_BODY_MAX_CHARS,
+        ),
+      })}\n`;
+      const output = optionalString("output");
+      if (output) fs.writeFileSync(output, body);
+      else process.stdout.write(body);
+      break;
+    }
+    case "umbrella-proposal-issue-number": {
+      const number = selectAppAuthoredUmbrellaProposalIssue(
+        readJsonArray(requiredString("issues")) as JsonValue[],
+        requiredString("author-login"),
+      );
+      process.stdout.write(number === null ? "" : String(number));
+      break;
+    }
     case "proposed-item-numbers":
       process.stdout.write(proposedItemNumbers(proposedItemOptions()).join(","));
       break;
@@ -2314,6 +2364,15 @@ function requiredString(name: string): string {
 function optionalString(name: string): string {
   const value = args[name];
   return typeof value === "string" ? value : "";
+}
+
+function umbrellaLimit(argName: string, envName: string, fallback: number): number {
+  const raw = args[argName] ?? process.env[envName] ?? fallback;
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`--${argName} must be a positive integer`);
+  }
+  return value;
 }
 
 function positionalString(index: number): string {

--- a/test/repair/umbrella-consolidation.test.ts
+++ b/test/repair/umbrella-consolidation.test.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import {
+  neutralizeProposalText,
+  renderUmbrellaProposals,
+  selectAppAuthoredUmbrellaProposalIssue,
+  selectUmbrellaProposals,
+  suggestedUmbrellaTitle,
+  type ClusterMember,
+} from "../../dist/repair/umbrella-consolidation.js";
+
+const decisionLabel = "clawsweeper:needs-product-decision";
+
+function member(number: number, overrides: Partial<ClusterMember> = {}): ClusterMember {
+  return {
+    clusterId: 42,
+    number,
+    kind: "issue",
+    state: "open",
+    title: `Telegram notification option ${number}`,
+    author: `author${number}`,
+    labels: [decisionLabel],
+    ...overrides,
+  };
+}
+
+test("proposal filtering applies threshold and exclusion gates", () => {
+  const rows = [
+    member(1),
+    member(2),
+    member(3),
+    member(4, { labels: [decisionLabel, "clawsweeper:human-review"] }),
+    member(5, { labels: [decisionLabel, "clawsweeper:idea-archive"] }),
+    member(6, { labels: [] }),
+    member(7, { state: "closed" }),
+    member(8, { kind: "pull_request" }),
+  ];
+  assert.equal(selectUmbrellaProposals(rows, { minClusterSize: 4 }).length, 0);
+  assert.deepEqual(
+    selectUmbrellaProposals(rows, { minClusterSize: 3 })[0]?.members.map((item) => item.number),
+    [1, 2, 3],
+  );
+});
+
+test("title heuristic is deterministic and bounded at a token boundary", () => {
+  const titles = [
+    "Add Telegram notification routing",
+    "Telegram notification filters",
+    "Feature request: Telegram routing rules",
+  ];
+  assert.equal(suggestedUmbrellaTitle(titles), suggestedUmbrellaTitle([...titles].reverse()));
+  assert.equal(suggestedUmbrellaTitle(titles), "Umbrella: Telegram Notification Routing");
+
+  const longTokens = Array.from({ length: 8 }, (_, index) => `token${index}${"x".repeat(80)}`);
+  const bounded = suggestedUmbrellaTitle([
+    longTokens.join(" "),
+    [...longTokens].reverse().join(" "),
+  ]);
+  assert.ok(bounded.length <= 120);
+  assert.equal(bounded.endsWith("…"), false);
+});
+
+test("rolling issue lookup requires the exact app author", () => {
+  const attacker = {
+    number: 7,
+    state: "open",
+    title: "Umbrella consolidation proposals",
+    body: "<!-- clawsweeper:umbrella-proposals -->",
+    user: { login: "someone-else" },
+  };
+  assert.equal(selectAppAuthoredUmbrellaProposalIssue([attacker]), null);
+  assert.equal(
+    selectAppAuthoredUmbrellaProposalIssue([
+      attacker,
+      { ...attacker, number: 8, user: { login: "clawsweeper[bot]" } },
+    ]),
+    8,
+  );
+});
+
+test("proposal rendering caps members, bounds total body, and contains no command", () => {
+  const proposal = {
+    clusterId: "gitcrawl-42",
+    title: "Umbrella: Telegram Notifications",
+    members: Array.from({ length: 7 }, (_, index) => member(index + 1)),
+  };
+  const rendered = renderUmbrellaProposals([proposal], {
+    targetRepo: "openclaw/openclaw",
+    generatedAt: "2026-07-16T00:00:00.000Z",
+    maxMembersPerCluster: 3,
+  });
+  assert.match(rendered, /\.\.\.and 4 more eligible member\(s\)\./);
+  assert.match(
+    rendered,
+    /consolidate these manually or wait for the upcoming consolidation command/,
+  );
+  assert.doesNotMatch(rendered, /@clawsweeper consolidate/);
+  assert.equal((rendered.match(/github\.com\/openclaw\/openclaw\/issues\//g) ?? []).length, 3);
+
+  const bounded = renderUmbrellaProposals([proposal, { ...proposal, clusterId: "gitcrawl-43" }], {
+    targetRepo: "openclaw/openclaw",
+    maxBodyChars: 450,
+  });
+  assert.ok(bounded.length <= 450);
+  assert.match(bounded, /body limit reached|truncated/i);
+});
+
+test("proposal member titles are markdown-neutral and mentions inert", () => {
+  const title = "Try `code` [link](https://example.com) @octocat *bold* <tag>";
+  const neutral = neutralizeProposalText(title);
+  assert.match(neutral, /\\`code\\`/);
+  assert.match(neutral, /\\\[link\\\]/);
+  assert.match(neutral, /@\u200boctocat/);
+  assert.doesNotMatch(neutral, /@octocat/);
+
+  const rendered = renderUmbrellaProposals(
+    [{ clusterId: "gitcrawl-42", title: "Umbrella: Safe", members: [member(1, { title })] }],
+    { targetRepo: "openclaw/openclaw" },
+  );
+  assert.doesNotMatch(rendered, /@octocat/);
+  assert.doesNotMatch(rendered, /@clawsweeper consolidate/);
+});
+
+test("proposal workflow is weekly, app-authenticated, and proposal-only", () => {
+  const workflow = readFileSync(".github/workflows/umbrella-proposals.yml", "utf8");
+  assert.match(workflow, /schedule:/);
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /umbrella-proposals/);
+  assert.match(workflow, /umbrella-proposal-issue-number/);
+  assert.match(workflow, /clawsweeper\[bot\]/);
+  assert.match(workflow, /gh issue create/);
+  assert.match(workflow, /gh issue edit/);
+  assert.doesNotMatch(workflow, /@clawsweeper consolidate/);
+});


### PR DESCRIPTION
## Why

~2,500 `needs-product-decision` feature issues are heavily duplicated. Umbrella consolidation already happens manually (one canonical issue, members closed as duplicates); this systematizes the discovery half. Uses the same gitcrawl-store cluster data that feeds the imported cluster repair lane.

## What

**Proposals only — read-only against the target repo.** A weekly workflow (`umbrella-proposals.yml`, plus `workflow_dispatch`) runs the new `umbrella-proposals` CLI command: reads gitcrawl cluster groups (portable schema with legacy fallback; schema detected by table existence, so an empty snapshot produces a "no eligible clusters" report instead of failing), filters to clusters of >= 5 open `needs-product-decision` issues (protected/idea-archive labels excluded), and posts/updates a single app-authored rolling proposal issue in THIS repo: top 10 clusters, deterministic bounded titles (<= 120 chars), up to 20 members rendered per cluster, body-size-guarded with a whole-section truncation rule (a note can never slice accepted content). All member titles render neutralized (inert markdown, no live @mentions through the bot).

**Deliberately split out:** the execution command (`@clawsweeper consolidate ...` creating umbrellas and duplicate-closing members). Three adversarial review rounds kept finding real defects in the mutation choreography (idempotent umbrella lookup, batch progress without live-check exhaustion, close-before-comment ordering, concurrent-edit safety, control-plane authentication). Rather than land a fourth patch cycle on a bulk-mutation surface, execution moves to its own PR with the accumulated findings as hard requirements — a follow-up task chip exists with the complete list. The proposal issue explicitly tells maintainers consolidation is manual until then.

## Proof

- `pnpm run build:all`, `check:limits`, `format:check`, `lint` green; proposal-surface tests 6/6 (cluster filtering/thresholds/exclusions, title determinism + bound, member cap, body guard incl. reserved-note rule, empty-schema report, app-author authentication).
- Real-data validation: generated 10 proposals (237 lines) from the local gitcrawl store during development.
- Review history: 3 rounds on the full feature (13 findings, all addressed or carried into the execution follow-up), then a clean-scope re-review of this reduced diff with its 2 findings fixed (empty-table schema detection; truncation-note reservation).
