### PR TITLE
fix(queue): make publication capacity recovery reachable under periodic rate-limit bursts

### DIFF
--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -138,7 +138,12 @@ const EXACT_REVIEW_PUBLICATION_READY_PER_SCALE_STEP = 250;
 const EXACT_REVIEW_PUBLICATION_CONCURRENT_SCALE_STEP = 8;
 const EXACT_REVIEW_PUBLICATION_RATE_LIMIT_COOLDOWN_MS = 15 * 60 * 1000;
 const EXACT_REVIEW_PUBLICATION_TRANSIENT_COOLDOWN_MS = 5 * 60 * 1000;
-const EXACT_REVIEW_PUBLICATION_RECOVERY_SUCCESSES = 50;
+// One ceiling step up requires this many consecutive clean publications. The
+// former value of 50 mathematically pinned the lane at minimum under hourly
+// rate-limit bursts (each burst resets the counter and halves the ceiling; 50
+// clean runs never fit between bursts at 4-way concurrency — observed
+// 2026-07-17: 408 pending, ceiling stuck at 4 for hours).
+const DEFAULT_EXACT_REVIEW_PUBLICATION_RECOVERY_SUCCESSES = 10;
 const DEFAULT_EXACT_REVIEW_DISPATCH_LEASE_MS = 6 * 60 * 1000;
 // Exact publications have a dedicated bounded lane. Bound the unclaimed handoff so a run that
 // never reaches its claim step is re-dispatched; stale runs lose the lease tuple safely.
@@ -2560,6 +2565,19 @@ function exactReviewPublicationMinimum(env, maximum = exactReviewPublicationMaxi
   );
 }
 
+function exactReviewPublicationRecoverySuccesses(env) {
+  return Math.max(
+    1,
+    Math.min(
+      1_000,
+      numberFrom(
+        env.EXACT_REVIEW_PUBLICATION_RECOVERY_SUCCESSES,
+        DEFAULT_EXACT_REVIEW_PUBLICATION_RECOVERY_SUCCESSES,
+      ),
+    ),
+  );
+}
+
 function exactReviewPublicationControl(env, value: unknown): ExactReviewPublicationControl {
   const control = objectValue(value);
   const maximum = exactReviewPublicationMaximum(env);
@@ -2617,7 +2635,7 @@ function exactReviewPublicationControlAfterFeedback(
     return { ...control, recoverySuccesses: 0 };
   }
   const recoverySuccesses = control.recoverySuccesses + 1;
-  if (recoverySuccesses < EXACT_REVIEW_PUBLICATION_RECOVERY_SUCCESSES) {
+  if (recoverySuccesses < exactReviewPublicationRecoverySuccesses(env)) {
     return { ...control, recoverySuccesses };
   }
   return {

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -256,6 +256,11 @@ hot intake `14`, and commit review `2`. Existing repair lanes keep their
 
 ## Runtime Overrides
 
+- `EXACT_REVIEW_PUBLICATION_RECOVERY_SUCCESSES` overrides how many consecutive
+  clean publications raise the adaptive publication ceiling by one step; the
+  default is 10 (clamped 1-1000). The former hardcoded 50 pinned the lane at
+  its minimum under hourly rate-limit bursts because the counter resets on
+  every failure.
 - `CLAWSWEEPER_MAINTAINER_LOGINS` (comma-separated) supplements the maintainer
   author-association check in the idea-archive revival watcher — needed where
   GitHub reports an org owner as `CONTRIBUTOR` on app-operated repositories. A

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -4275,7 +4275,9 @@ test("exact-review publication capacity backs off on GitHub pressure and recover
       deliveries: Record<string, number>;
       items: Record<string, ReturnType<typeof leasedExactReviewPublicationItem>>;
     };
-    const recovered = Array.from({ length: 50 }, (_, index) =>
+    // One ceiling step per DEFAULT_EXACT_REVIEW_PUBLICATION_RECOVERY_SUCCESSES
+    // (10) consecutive clean publications.
+    const recovered = Array.from({ length: 10 }, (_, index) =>
       leasedExactReviewPublicationItem(721 + index, String(7210 + index)),
     );
     for (const item of recovered) state.items[item.key] = item;


### PR DESCRIPTION
## Why

Live observation tonight: publication `capacity_control` pinned at `mode=throttled, ceiling=4 (minimum)` for hours while the publication backlog doubled (194 -> 408 pending, oldest >22h). Root cause is the recovery ladder introduced in #626: raising the ceiling one step requires **50 consecutive clean publications**, but every failure resets the counter to zero and halves the ceiling with a cooldown. Under the current environment — a rate-limit failure burst every hour, three days running — 50 clean runs never fit between bursts at 4-way concurrency, so the ceiling is mathematically unable to leave the floor while inflow exceeds drain.

The multiplicative-decrease side is sound; only the additive-increase gate is unreachable under periodic failures.

## What

The gate becomes env-tunable `EXACT_REVIEW_PUBLICATION_RECOVERY_SUCCESSES` (clamped 1-1000) with a default of **10**. Between hourly bursts a healthy lane now re-climbs 4 -> 12 -> 20 -> 24 within minutes of clean throughput, while bursts still throttle it exactly as before. docs/limits.md documents the override and the pinning failure mode.

## Proof

- Updated the gradual-recovery test to the new default (10 successes -> exactly one +8 step, counter resets); with the old fixture the lane correctly climbed to max under the new gate, confirming the ladder works when reachable. 127/127 dashboard-worker tests green; `check:limits`, `format:check`, `lint` green.
- Autoreview (Codex Sol, xhigh) clean on first pass.
- cc @masonxhuang — this tunes #626's recovery gate based on tonight's production observation; the throttle/cooldown behavior is untouched.
