### PR TITLE
feat(review): run Codex on the fast service tier without invalidating stored reviews

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -1424,7 +1424,9 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 const RECENT_MISSING_OPEN_MS = DAY_MS;
 const DEFAULT_CODEX_MODEL = PUBLIC_CODEX_MODEL;
 const DEFAULT_REASONING_EFFORT = "high";
-const DEFAULT_SERVICE_TIER = "";
+// Priority service tier for Codex calls (maintainer decision 2026-07-17:
+// "gpt 5.6 sol high fast"). Latency-only; excluded from review-policy hashing.
+const DEFAULT_SERVICE_TIER = "fast";
 const DEFAULT_REVIEW_CODEX_TIMEOUT_MS = 1_200_000;
 const DEFAULT_CODEX_FALLBACK_MIN_BUDGET_MS = 120_000;
 const REVIEW_POLICY_VERSION = "2026-07-09-policy-v24";
@@ -3286,7 +3288,10 @@ function reviewPolicyHash(options: {
       model: options.model ?? DEFAULT_CODEX_MODEL,
       reasoningEffort: options.reasoningEffort ?? DEFAULT_REASONING_EFFORT,
       sandboxMode: options.sandboxMode ?? "read-only",
-      serviceTier: options.serviceTier ?? DEFAULT_SERVICE_TIER,
+      // Service tier changes latency, never decisions. Pinned to the historical
+      // hash value so tier changes cannot mark every stored review policy-stale
+      // and trigger a fleet-wide re-review wave.
+      serviceTier: "",
       targetRepo: targetRepo(),
       repositoryProfile: targetProfile(),
       prompt: reviewPromptTemplate(),


### PR DESCRIPTION
## Why

Maintainer request: run ClawSweeper reviews as "gpt-5.6-sol, high, fast." Investigation showed reasoning effort is ALREADY `high` at every layer (src default, all four sweep.yml invocations, commit-review, and the `CLAWSWEEPER_CODEX_REASONING_EFFORT=high` repo variable for repair — the repair lane even normalizes accidental `xhigh` down to `high`). The actual missing piece was the service tier: review Codex calls ran the standard tier (`DEFAULT_SERVICE_TIER=""`).

## What

- `DEFAULT_SERVICE_TIER` -> `"fast"`: all Codex review/apply invocations that don't pass an explicit `--codex-service-tier` now use the priority tier (local-only runs already forced fast).
- **No re-review wave**: the service tier was an input to `reviewPolicyHash`, so flipping it would have marked every stored review policy-stale and queued ~7k re-reviews for a latency-only change. The hash now pins the tier field to its historical value with a comment stating the invariant (tier changes latency, never decisions). All existing review hashes remain valid.

## Proof

`pnpm run build:all`, focused suites (clawsweeper, review-close-policy, close-reasons — 147 pass), `check:limits`, `format:check`, `lint` green. Autoreview (Codex Sol, xhigh) clean on first pass.
