### PR TITLE
fix(scheduler): queue pressure counts only Codex-consuming review items

### DIFF
--- a/src/queue-pressure.ts
+++ b/src/queue-pressure.ts
@@ -39,12 +39,25 @@ export async function fetchExactReviewQueuePressure({
 
     const body: unknown = await response.json();
     if (!isRecord(body)) return malformedPressure();
-    const pendingCount = body.pending;
-    const oldestPendingAgeSeconds = body.oldest_pending_age_seconds;
+    // Pressure exists to protect Codex review capacity. Publication items
+    // consume no Codex, so prefer the review lane's numbers when the stats
+    // expose them; totals (which include publications) remain the fallback
+    // for older queue deployments.
+    const reviewLane =
+      isRecord(body.lanes) && isRecord(body.lanes.review) ? body.lanes.review : null;
+    const pendingCount =
+      reviewLane && isNonNegativeInteger(reviewLane.pending) ? reviewLane.pending : body.pending;
+    const oldestPendingAgeSeconds =
+      reviewLane && isNonNegativeInteger(reviewLane.pending)
+        ? reviewLane.oldest_pending_age_seconds
+        : body.oldest_pending_age_seconds;
     if (!isNonNegativeInteger(pendingCount)) return malformedPressure();
-    if (pendingCount === 0 && oldestPendingAgeSeconds === null) {
+    if (pendingCount === 0) {
       return { ok: true, pendingCount, oldestPendingAgeMs: 0 };
     }
+    // A null age with a positive backlog is inconsistent data — fail open
+    // rather than fabricating a zero-age backlog.
+    if (oldestPendingAgeSeconds === null) return malformedPressure();
     if (!isNonNegativeNumber(oldestPendingAgeSeconds)) return malformedPressure();
     const oldestPendingAgeMs = oldestPendingAgeSeconds * 1_000;
     if (!Number.isFinite(oldestPendingAgeMs)) return malformedPressure();

--- a/test/queue-pressure.test.ts
+++ b/test/queue-pressure.test.ts
@@ -69,6 +69,35 @@ test("queue pressure fetch reads public aggregate stats", async () => {
   assert.deepEqual(empty, { ok: true, pendingCount: 0, oldestPendingAgeMs: 0 });
 });
 
+test("queue pressure prefers the review lane over totals that include publications", async () => {
+  // 812 total pending, but only 36 are Codex-consuming review items — pressure
+  // must not throttle review shards because of a publication backlog.
+  const result = await fetchExactReviewQueuePressure({
+    queueUrl: "https://clawsweeper.example",
+    fetchImpl: async () =>
+      Response.json({
+        pending: 812,
+        oldest_pending_age_seconds: 80_000,
+        lanes: {
+          review: { pending: 36, oldest_pending_age_seconds: 120 },
+          publication: { pending: 776, oldest_pending_age_seconds: 80_000 },
+        },
+      }),
+  });
+  assert.deepEqual(result, { ok: true, pendingCount: 36, oldestPendingAgeMs: 120_000 });
+
+  const emptyReviewLane = await fetchExactReviewQueuePressure({
+    queueUrl: "https://clawsweeper.example",
+    fetchImpl: async () =>
+      Response.json({
+        pending: 400,
+        oldest_pending_age_seconds: 70_000,
+        lanes: { review: { pending: 0, oldest_pending_age_seconds: null } },
+      }),
+  });
+  assert.deepEqual(emptyReviewLane, { ok: true, pendingCount: 0, oldestPendingAgeMs: 0 });
+});
+
 test("queue pressure fetch fails open on errors, timeouts, and malformed bodies", async () => {
   const failed = await fetchExactReviewQueuePressure({
     queueUrl: "https://clawsweeper.example",


### PR DESCRIPTION
## Why

Maintainer directive: with a large backlog, Codex parallelism should run at max. The queue-pressure throttle (#623) counts TOTAL queue pending — but publications consume zero Codex. Tonight 224 of 260 pending were publications (the draining stale tail), which held background review lanes at 50% for no Codex-relevant reason.

## What

`fetchExactReviewQueuePressure` prefers `lanes.review.pending` / `lanes.review.oldest_pending_age_seconds` when the stats expose lanes (they have since #632); totals remain the fallback for older deployments. A positive backlog with a null age fails open as malformed rather than fabricating a zero-age reading. With the current queue this moves pressure from `soft` to `none` and restores full background budgets (normal 89, hot 44) while the publication tail finishes draining on its own lane.

## Proof

`pnpm run build:all`; queue-pressure suite 6/6 incl. new cases (review lane preferred over publication-heavy totals; empty review lane => zero pressure; positive-count/null-age => malformed); sweep-workflow suite green; `format:check`, `lint` green. Autoreview finding (null-age widening) accepted and fixed; re-verified.
