### PR TITLE
fix(queue): govern publication backlog

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1409,6 +1409,7 @@ jobs:
       - name: Download exact review artifact bundle
         if: ${{ steps.publication-context.outputs.claimed == 'true' }}
         id: download-exact-review-bundle
+        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
           name: ${{ steps.publication-context.outputs.artifact_name }}
@@ -1418,7 +1419,9 @@ jobs:
           path: .artifacts/exact-review-bundle
 
       - name: Validate exact review artifact bundle
-        if: ${{ steps.publication-context.outputs.claimed == 'true' }}
+        if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.download-exact-review-bundle.outcome == 'success' }}
+        id: validate-exact-review-bundle
+        continue-on-error: true
         env:
           EXACT_REVIEW_BUNDLE_DIR: .artifacts/exact-review-bundle
           EXACT_REVIEW_CLAIM_GENERATION: ${{ steps.publication-context.outputs.claim_generation }}
@@ -1442,7 +1445,7 @@ jobs:
 
       - name: Identify legacy tuple-less exact artifact
         id: legacy-exact-artifact
-        if: ${{ steps.publication-context.outputs.claimed == 'true' }}
+        if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.validate-exact-review-bundle.outcome == 'success' }}
         env:
           REPORT_PATH: .artifacts/exact-review-bundle/review/${{ steps.publication-context.outputs.item_number }}.md
         run: |
@@ -1468,7 +1471,7 @@ jobs:
           NODE
 
       - name: Stage validated exact review artifact
-        if: ${{ steps.publication-context.outputs.claimed == 'true' }}
+        if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.validate-exact-review-bundle.outcome == 'success' }}
         run: |
           set -euo pipefail
           mkdir -p artifacts/event
@@ -1478,7 +1481,7 @@ jobs:
           fi
 
       - name: Create target write token
-        if: ${{ steps.publication-context.outputs.claimed == 'true' }}
+        if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.validate-exact-review-bundle.outcome == 'success' }}
         id: target-write-token
         continue-on-error: true
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -1494,7 +1497,7 @@ jobs:
           permission-statuses: read
 
       - name: Create state token
-        if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.legacy-exact-artifact.outputs.legacy_tupleless != 'true' }}
+        if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.validate-exact-review-bundle.outcome == 'success' && steps.legacy-exact-artifact.outputs.legacy_tupleless != 'true' }}
         id: state-token
         uses: ./.github/actions/create-state-token
         with:
@@ -1502,14 +1505,14 @@ jobs:
           private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
 
       - uses: ./.github/actions/setup-state
-        if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.legacy-exact-artifact.outputs.legacy_tupleless != 'true' }}
+        if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.validate-exact-review-bundle.outcome == 'success' && steps.legacy-exact-artifact.outputs.legacy_tupleless != 'true' }}
         id: setup-state
         with:
           token: ${{ steps.state-token.outputs.token }}
           fetch-depth: 1
 
       - name: Publish event result and apply safe close
-        if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.legacy-exact-artifact.outputs.legacy_tupleless != 'true' }}
+        if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.validate-exact-review-bundle.outcome == 'success' && steps.legacy-exact-artifact.outputs.legacy_tupleless != 'true' }}
         id: publish-event-result
         env:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
@@ -1755,6 +1758,8 @@ jobs:
           STATUS_COMMENT_ID: ${{ fromJSON(steps.publication-context.outputs.decision).statusCommentId || '' }}
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           PUBLISH_OUTCOME: ${{ steps.publish-event-result.outcome }}
+          PUBLISH_COMPLETION_KIND: ${{ steps.publish-event-result.outputs.completion_kind }}
+          PUBLISH_REASON_CODE: ${{ steps.publish-event-result.outputs.reason_code }}
           ROUTE_HANDOFF_OUTCOME: ${{ steps.queue-deferred-verdict-router.outcome }}
           TERMINAL_MISSING: ${{ steps.publish-event-result.outputs.terminal_missing }}
           TERMINAL_CLOSED: ${{ steps.publish-event-result.outputs.terminal_closed }}
@@ -1777,6 +1782,13 @@ jobs:
           elif [ "$REQUEUE_LATEST" = "true" ] && [ "${{ steps.queue-source-drift-review.outcome }}" = "success" ]; then
             state="Complete"
             detail="The item changed after review; one fresh exact review was queued."
+          elif [ "$PUBLISH_COMPLETION_KIND" = "superseded" ]; then
+            state="Complete"
+            if [ "$PUBLISH_REASON_CODE" = "remote_closed" ]; then
+              detail="A newer publication already closed the item; this stale result was superseded."
+            else
+              detail="A newer review tuple already exists; this stale result was superseded."
+            fi
           elif [ "${{ steps.confirm-terminal-item.outputs.confirmed }}" = "true" ]; then
             state="Complete"
             detail="The item is closed; no stale verdict was published."
@@ -1826,8 +1838,8 @@ jobs:
             gh api "repos/$TARGET_REPO/issues/$ITEM_NUMBER/reactions/$reaction_id" --method DELETE || true
           done <<< "$reaction_ids"
 
-      - name: Release unsuccessful publisher-owned review lease
-        if: ${{ always() && steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.live_proceeded == 'true' && (steps.publish-event-result.outcome != 'success' || (steps.publish-event-result.outputs.requeue_latest == 'true' && steps.queue-source-drift-review.outcome != 'success')) }}
+      - name: Release superseded or unsuccessful publisher-owned review lease
+        if: ${{ always() && steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.live_proceeded == 'true' && (steps.publish-event-result.outputs.completion_kind == 'superseded' || steps.publish-event-result.outcome != 'success' || (steps.publish-event-result.outputs.requeue_latest == 'true' && steps.queue-source-drift-review.outcome != 'success')) }}
         env:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
           TARGET_REPO: ${{ steps.publication-context.outputs.target_repo }}
@@ -1887,13 +1899,29 @@ jobs:
           SOURCE_DRIFT_OUTCOME: ${{ steps.queue-source-drift-review.outcome }}
           DEFERRED_ROUTE_OUTCOME: ${{ steps.queue-deferred-verdict-router.outcome }}
           FAILURE_KIND: ${{ steps.publish-event-result.outputs.failure_kind || steps.publication-pressure.outputs.failure_kind }}
+          DOWNLOAD_OUTCOME: ${{ steps.download-exact-review-bundle.outcome }}
+          VALIDATE_OUTCOME: ${{ steps.validate-exact-review-bundle.outcome }}
+          PUBLISH_COMPLETION_KIND: ${{ steps.publish-event-result.outputs.completion_kind }}
+          PUBLISH_REASON_CODE: ${{ steps.publish-event-result.outputs.reason_code }}
+          ERROR_FINGERPRINT: ${{ steps.publish-event-result.outputs.error_fingerprint }}
           REVIEW_ONLY: ${{ fromJSON(steps.publication-context.outputs.decision).sourceAction == 'failed_review_shard_recovery' && 'true' || 'false' }}
         run: |
+          set -euo pipefail
           outcome=failure
-          if [ "$LEGACY_TUPLELESS" = "true" ] && [ "$SOURCE_DRIFT_OUTCOME" = "success" ]; then
+          completion_kind=permanent_failure
+          reason_code=unknown_failure
+          if [ "$PUBLISH_COMPLETION_KIND" = "superseded" ] && { [ "$PUBLISH_REASON_CODE" = "remote_newer_tuple" ] || [ "$PUBLISH_REASON_CODE" = "remote_closed" ]; }; then
             outcome=success
+            completion_kind=superseded
+            reason_code="$PUBLISH_REASON_CODE"
+          elif [ "$LEGACY_TUPLELESS" = "true" ] && [ "$SOURCE_DRIFT_OUTCOME" = "success" ]; then
+            outcome=success
+            completion_kind=superseded
+            reason_code=live_terminal
           elif [ "$PRIOR_JOB_STATUS" = "cancelled" ]; then
             outcome=cancelled
+            completion_kind=retryable_failure
+            reason_code=workflow_cancelled
           elif [ "$PRIOR_JOB_STATUS" = "success" ]; then
             if [ "$PUBLISH_OUTCOME" = "success" ] && [ "$REQUEUE_LATEST" = "true" ] && [ "$SOURCE_DRIFT_OUTCOME" = "success" ]; then
               outcome=success
@@ -1903,7 +1931,33 @@ jobs:
               outcome=success
             fi
           fi
+          if [ "$outcome" = "success" ] && [ "$completion_kind" != "superseded" ]; then
+            if [ "$PUBLISH_COMPLETION_KIND" = "published" ] && [ "$PUBLISH_REASON_CODE" = "publication_applied" ]; then
+              completion_kind=published
+              reason_code=publication_applied
+            else
+              completion_kind=superseded
+              reason_code=live_terminal
+            fi
+          elif [ "$outcome" != "success" ] && { [ "$FAILURE_KIND" = "github_rate_limit" ] || [ "$FAILURE_KIND" = "github_transient" ]; }; then
+            completion_kind=retryable_failure
+            reason_code="$FAILURE_KIND"
+          elif [ "$outcome" != "success" ] && [ "$DOWNLOAD_OUTCOME" = "failure" ]; then
+            completion_kind=retryable_failure
+            reason_code=artifact_unavailable
+          elif [ "$outcome" != "success" ] && [ "$VALIDATE_OUTCOME" = "failure" ]; then
+            completion_kind=permanent_failure
+            reason_code=invalid_artifact
+          elif [ "$outcome" != "success" ] && [ "$PUBLISH_COMPLETION_KIND" = "permanent_failure" ]; then
+            completion_kind=permanent_failure
+            reason_code="${PUBLISH_REASON_CODE:-unknown_failure}"
+          fi
           echo "outcome=$outcome" >> "$GITHUB_OUTPUT"
+          echo "completion_kind=$completion_kind" >> "$GITHUB_OUTPUT"
+          echo "reason_code=$reason_code" >> "$GITHUB_OUTPUT"
+          if [ -n "$ERROR_FINGERPRINT" ]; then
+            echo "error_fingerprint=$ERROR_FINGERPRINT" >> "$GITHUB_OUTPUT"
+          fi
           if [ "$outcome" = "failure" ] && { [ "$FAILURE_KIND" = "github_rate_limit" ] || [ "$FAILURE_KIND" = "github_transient" ]; }; then
             echo "failure_kind=$FAILURE_KIND" >> "$GITHUB_OUTPUT"
           fi
@@ -1918,6 +1972,9 @@ jobs:
           LEASE_REVISION: ${{ steps.publication-context.outputs.publisher_lease_revision }}
           OUTCOME: ${{ steps.exact-review-publication-result.outputs.outcome || 'failure' }}
           FAILURE_KIND: ${{ steps.exact-review-publication-result.outputs.failure_kind }}
+          COMPLETION_KIND: ${{ steps.exact-review-publication-result.outputs.completion_kind }}
+          REASON_CODE: ${{ steps.exact-review-publication-result.outputs.reason_code }}
+          ERROR_FINGERPRINT: ${{ steps.exact-review-publication-result.outputs.error_fingerprint }}
           QUEUE_LEASE_ID: ${{ steps.publication-context.outputs.publisher_lease_id }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
@@ -1938,6 +1995,16 @@ jobs:
             const failureKind = ["github_rate_limit", "github_transient"].includes(process.env.FAILURE_KIND)
               ? process.env.FAILURE_KIND
               : undefined;
+            const completionKind = ["published", "superseded", "retryable_failure", "refresh_required", "permanent_failure"].includes(process.env.COMPLETION_KIND)
+              ? process.env.COMPLETION_KIND
+              : undefined;
+            const reasonCode = ["publication_applied", "remote_newer_tuple", "remote_closed", "live_terminal", "github_rate_limit", "github_transient", "workflow_cancelled", "artifact_unavailable", "artifact_expired", "invalid_artifact", "missing_record_tuple", "tuple_protocol_invalid", "policy_invariant", "unknown_failure", "retry_exhausted"].includes(process.env.REASON_CODE)
+              ? process.env.REASON_CODE
+              : undefined;
+            const errorFingerprint = /^[A-Za-z0-9:._-]{1,200}$/.test(process.env.ERROR_FINGERPRINT || "")
+              ? process.env.ERROR_FINGERPRINT
+              : undefined;
+            if (!completionKind || !reasonCode) process.exit(1);
             process.stdout.write(JSON.stringify({
               lease_id: process.env.QUEUE_LEASE_ID,
               item_key: process.env.ITEM_KEY,
@@ -1946,6 +2013,9 @@ jobs:
               run_id: process.env.GITHUB_RUN_ID,
               run_attempt: runAttempt,
               outcome,
+              completion_kind: completionKind,
+              reason_code: reasonCode,
+              ...(errorFingerprint ? { error_fingerprint: errorFingerprint } : {}),
               ...(outcome === "failure" && failureKind ? { failure_kind: failureKind } : {}),
             }));
           ')"

--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ handles only the selected item, uploads a hash-bound GitHub Actions artifact,
 enqueues a separate durable publication lease, and then releases its review
 lease without checking out or pushing the state repository. The queue retries
 publication independently, so a cancelled publisher does not rerun Codex. A
-Durable Object-bounded publisher lane (24 concurrent publishers by default)
+Durable Object-bounded publisher lane (24 base, adaptively capped at 48)
 validates each artifact's workflow run, queue tuple, target, decision digest,
 file inventory, sizes, and SHA-256 hashes before it receives write tokens.
 Publication leases reserve the bounded publisher lane's maximum queue wait;
@@ -444,10 +444,11 @@ terminal-run reconciliation releases dead dispatches early. The publisher then
 uses the same review and apply paths with only the
 immediate-safe reasons enabled by default:
 `implemented_on_main`, `duplicate_or_superseded`, and
-`low_signal_unmergeable_pr`. Artifacts remain available for 90 days. A
-publication that still cannot finish after 80 days expires its artifact handoff
-and queues one fresh exact review, avoiding an unrecoverable missing-artifact
-loop while leaving a ten-day retention margin.
+`low_signal_unmergeable_pr`. A stale tuple now terminates as `superseded`
+instead of retrying, while permanent failures enter a bounded dead-letter store
+after their confirmation retries. Artifacts remain available for 90 days; three
+confirmed unavailable-artifact attempts queue one fresh exact review instead of
+waiting for the retention deadline.
 
 Deterministic terminal and remain-open outcomes flow through the same publisher.
 Ordinary synced verdicts publish their exact durable comment, then queue an

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -51,7 +51,7 @@ export type ExactReviewQueueItem = {
   key: string;
   decision: ExactReviewDecision;
   leaseDecision?: ExactReviewDecision;
-  state: "pending" | "dispatching" | "leased";
+  state: "pending" | "dispatching" | "leased" | "parked";
   revision: number;
   createdAt: number;
   updatedAt: number;
@@ -67,9 +67,40 @@ export type ExactReviewQueueItem = {
   claimProtocolVersion?: 1 | 2;
   dispatchedAt?: number;
   claimedAt?: number;
+  parkedReason?: "dead_letter_capacity";
+  lastFailureReason?: ExactReviewPublicationReasonCode;
+  firstFailureAt?: number;
+  publicationFailureAttempts?: number;
 };
 export type ExactReviewCompletionOutcome = "success" | "failure" | "cancelled";
 type ExactReviewPublicationFailureKind = "github_rate_limit" | "github_transient";
+export type ExactReviewPublicationCompletionKind =
+  | "published"
+  | "superseded"
+  | "retryable_failure"
+  | "refresh_required"
+  | "permanent_failure";
+type ExactReviewPublicationReasonCode =
+  | "publication_applied"
+  | "remote_newer_tuple"
+  | "remote_closed"
+  | "live_terminal"
+  | "github_rate_limit"
+  | "github_transient"
+  | "workflow_cancelled"
+  | "artifact_unavailable"
+  | "artifact_expired"
+  | "invalid_artifact"
+  | "missing_record_tuple"
+  | "tuple_protocol_invalid"
+  | "policy_invariant"
+  | "unknown_failure"
+  | "retry_exhausted";
+type ExactReviewPublicationCompletion = {
+  kind: ExactReviewPublicationCompletionKind;
+  reasonCode: ExactReviewPublicationReasonCode;
+  errorFingerprint?: string;
+};
 type ExactReviewPublicationFeedback = {
   at: number;
   capacity: number;
@@ -78,8 +109,13 @@ type ExactReviewPublicationFeedback = {
 };
 type ExactReviewPublicationControl = {
   capacityCeiling: number;
+  demandCapacity: number;
   cooldownUntil: number;
   recoverySuccesses: number;
+  demandSamples: number;
+  demandTier: number;
+  lastDemandSampleAt: number;
+  lastScaleAt: number;
   lastFailureAt?: number;
   lastFailureKind?: ExactReviewPublicationFailureKind;
 };
@@ -106,6 +142,22 @@ type ExactReviewQueueBaseline = {
   items: Map<string, string>;
   dispatcherJson: string | null;
 };
+type ExactReviewDeadLetterInsert = {
+  id: string;
+  itemKey: string;
+  revision: number;
+  targetRepo: string;
+  itemNumber: number;
+  producerRunId: string;
+  producerRunAttempt: number;
+  artifactName: string;
+  reasonCode: ExactReviewPublicationReasonCode;
+  attempts: number;
+  firstFailedAt: number;
+  lastFailedAt: number;
+  itemJson: string;
+  errorFingerprint?: string;
+};
 type ExactReviewQueueStorageMeta = {
   schema_version: number;
   migrated_at: number;
@@ -115,13 +167,26 @@ type ExactReviewQueueStorageMeta = {
 };
 type ExactReviewQueueMetricTotals = {
   review: { enqueued: number; completed: number };
-  publication: { enqueued: number; completed: number };
+  publication: {
+    enqueued: number;
+    completed: number;
+    published: number;
+    superseded: number;
+    retried: number;
+    deadLettered: number;
+    refreshed: number;
+  };
 };
 type ExactReviewQueueMetricDelta = {
   reviewEnqueued?: number;
   reviewCompleted?: number;
   publicationEnqueued?: number;
   publicationCompleted?: number;
+  publicationPublished?: number;
+  publicationSuperseded?: number;
+  publicationRetried?: number;
+  publicationDeadLettered?: number;
+  publicationRefreshed?: number;
 };
 export type DurableObjectStub = { fetch: (request: Request) => Promise<Response> };
 export type DurableObjectNamespace = {
@@ -134,7 +199,6 @@ const DEFAULT_EXACT_REVIEW_TARGET_MAX_CONCURRENT = 60;
 const DEFAULT_EXACT_REVIEW_PUBLICATION_MIN_CONCURRENT = 4;
 const DEFAULT_EXACT_REVIEW_PUBLICATION_BASE_CONCURRENT = 24;
 const DEFAULT_EXACT_REVIEW_PUBLICATION_MAX_CONCURRENT = 48;
-const EXACT_REVIEW_PUBLICATION_READY_PER_SCALE_STEP = 250;
 const EXACT_REVIEW_PUBLICATION_CONCURRENT_SCALE_STEP = 8;
 const EXACT_REVIEW_PUBLICATION_RATE_LIMIT_COOLDOWN_MS = 15 * 60 * 1000;
 const EXACT_REVIEW_PUBLICATION_TRANSIENT_COOLDOWN_MS = 5 * 60 * 1000;
@@ -144,6 +208,10 @@ const EXACT_REVIEW_PUBLICATION_TRANSIENT_COOLDOWN_MS = 5 * 60 * 1000;
 // clean runs never fit between bursts at 4-way concurrency — observed
 // 2026-07-17: 408 pending, ceiling stuck at 4 for hours).
 const DEFAULT_EXACT_REVIEW_PUBLICATION_RECOVERY_SUCCESSES = 10;
+const EXACT_REVIEW_PUBLICATION_DEMAND_SAMPLE_MS = 5 * 60 * 1000;
+const EXACT_REVIEW_PUBLICATION_SCALE_UP_MS = 10 * 60 * 1000;
+const EXACT_REVIEW_PUBLICATION_SCALE_DOWN_MS = 15 * 60 * 1000;
+const EXACT_REVIEW_PUBLICATION_ACTIONS_RESERVE = 16;
 const DEFAULT_EXACT_REVIEW_DISPATCH_LEASE_MS = 6 * 60 * 1000;
 // Exact publications have a dedicated bounded lane. Bound the unclaimed handoff so a run that
 // never reaches its claim step is re-dispatched; stale runs lose the lease tuple safely.
@@ -157,6 +225,12 @@ const DEFAULT_EXACT_REVIEW_DISPATCH_DEBOUNCE_MAX_MS = 3 * 60_000;
 const DEFAULT_EXACT_REVIEW_PENDING_SOFT_LIMIT = 300;
 const EXACT_REVIEW_COMPLETION_RETRY_MAX_MS = 2 * 60 * 60 * 1000;
 const EXACT_REVIEW_ARTIFACT_RETRY_MAX_MS = 80 * 24 * 60 * 60 * 1000;
+const EXACT_REVIEW_PUBLICATION_TRANSIENT_RETRY_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const EXACT_REVIEW_PUBLICATION_UNKNOWN_RETRY_MAX_AGE_MS = 60 * 60 * 1000;
+const EXACT_REVIEW_PUBLICATION_TRANSIENT_RETRY_LIMIT = 12;
+const EXACT_REVIEW_PUBLICATION_PERMANENT_RETRY_LIMIT = 3;
+const EXACT_REVIEW_PUBLICATION_UNKNOWN_RETRY_LIMIT = 5;
+const EXACT_REVIEW_PUBLICATION_ARTIFACT_RETRY_LIMIT = 3;
 const EXACT_REVIEW_RECONCILE_RUN_LIMIT = 128;
 const EXACT_REVIEW_RECONCILE_CLAIM_MATCH_LIMIT = EXACT_REVIEW_RECONCILE_RUN_LIMIT * 2;
 export const EXACT_REVIEW_RECONCILE_CONCURRENCY = 8;
@@ -179,6 +253,12 @@ const EXACT_REVIEW_QUEUE_META_TABLE = "exact_review_queue_meta";
 const EXACT_REVIEW_QUEUE_ITEM_TABLE = "exact_review_queue_items";
 const EXACT_REVIEW_QUEUE_DELIVERY_TABLE = "exact_review_queue_deliveries";
 const EXACT_REVIEW_QUEUE_METRICS_TABLE = "exact_review_queue_metrics";
+const EXACT_REVIEW_QUEUE_METRIC_BUCKET_TABLE = "exact_review_queue_metric_buckets";
+const EXACT_REVIEW_QUEUE_DEAD_LETTER_TABLE = "exact_review_queue_dead_letters";
+const EXACT_REVIEW_QUEUE_DEAD_LETTER_LIMIT = 5_000;
+const EXACT_REVIEW_QUEUE_DEAD_LETTER_RESOLVED_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+const EXACT_REVIEW_QUEUE_METRIC_BUCKET_MS = 5 * 60 * 1000;
+const EXACT_REVIEW_QUEUE_METRIC_BUCKET_TTL_MS = 48 * 60 * 60 * 1000;
 const EXACT_REVIEW_PUBLICATION_CONTROL_KEY = "exact-review-publication-control:v1";
 export const EXACT_REVIEW_QUEUE_NAME = "global";
 const EXACT_REVIEW_COMMAND_STATUS_MARKER_PATTERN =
@@ -264,27 +344,31 @@ export class ExactReviewQueue {
           // Ordinary source events retain normal replacement behavior, including the
           // command-context merge for pending items.
           if (!ignoredRecovery) {
-            current.decision =
-              current.state === "pending"
-                ? mergePendingExactReviewDecision(current.decision, decision)
-                : decision;
+            const mergeable = current.state === "pending" || current.state === "parked";
+            current.decision = mergeable
+              ? mergePendingExactReviewDecision(current.decision, decision)
+              : decision;
             current.revision += 1;
             current.updatedAt = now;
             // Immediacy must come from the merged decision: a pending explicit command
             // keeps its command marker through the merge, and a later plain webhook
             // event must not re-debounce it.
-            current.nextAttemptAt =
-              current.state === "pending"
-                ? exactReviewQueueDebouncedAttemptAt(
-                    state,
-                    current.decision,
-                    now,
-                    current.createdAt,
-                    this.env,
-                  )
-                : exactReviewQueueEnqueueAttemptAt(state, now);
-            if (current.state === "pending") {
+            current.nextAttemptAt = mergeable
+              ? exactReviewQueueDebouncedAttemptAt(
+                  state,
+                  current.decision,
+                  now,
+                  current.createdAt,
+                  this.env,
+                )
+              : exactReviewQueueEnqueueAttemptAt(state, now);
+            if (mergeable) {
+              current.state = "pending";
+              current.parkedReason = undefined;
               current.attempts = 0;
+              current.publicationFailureAttempts = 0;
+              current.firstFailureAt = undefined;
+              current.lastFailureReason = undefined;
             }
           }
         } else {
@@ -527,6 +611,36 @@ export class ExactReviewQueue {
       if (failureKind && outcome !== "failure") {
         return json({ error: "failure_kind_without_failure" }, 400);
       }
+      const hasStructuredCompletion =
+        body.completion_kind !== undefined ||
+        body.reason_code !== undefined ||
+        body.error_fingerprint !== undefined;
+      const publicationCompletion = hasStructuredCompletion
+        ? exactReviewPublicationCompletion(
+            body.completion_kind,
+            body.reason_code,
+            body.error_fingerprint,
+          )
+        : undefined;
+      if (hasStructuredCompletion && !publicationCompletion) {
+        return json({ error: "invalid_publication_completion" }, 400);
+      }
+      if (
+        publicationCompletion &&
+        (publicationCompletion.kind === "published" ||
+          publicationCompletion.kind === "superseded") !==
+          (outcome === "success")
+      ) {
+        return json({ error: "completion_outcome_mismatch" }, 400);
+      }
+      if (
+        failureKind &&
+        publicationCompletion &&
+        (publicationCompletion.kind !== "retryable_failure" ||
+          publicationCompletion.reasonCode !== failureKind)
+      ) {
+        return json({ error: "failure_kind_mismatch" }, 400);
+      }
       const requeueLatest = body.requeue_latest === true;
       if (body.requeue_latest !== undefined && typeof body.requeue_latest !== "boolean") {
         return json({ error: "invalid_requeue_latest" }, 400);
@@ -558,13 +672,18 @@ export class ExactReviewQueue {
       if (failureKind && !publicationItem) {
         return json({ error: "failure_kind_outside_publication" }, 400);
       }
+      if (publicationCompletion && !publicationItem) {
+        return json({ error: "completion_kind_outside_publication" }, 400);
+      }
+      const publicationControl = this.publicationControlSync();
       const publicationDesiredCapacity = publicationItem
         ? exactReviewPublicationCapacityForState(
             this.env,
             state,
             now,
-            this.publicationControlSync().capacityCeiling,
+            publicationControl.capacityCeiling,
             false,
+            publicationControl.demandCapacity,
           )
         : 0;
       if (
@@ -577,32 +696,74 @@ export class ExactReviewQueue {
       // The workflow reports success only after every primary review mutation has settled.
       // Complete that revision now so a later auxiliary-step failure cannot make the
       // workflow_run reconciler requeue review work that already succeeded.
-      const requeued = finishExactReviewQueueItem(
-        state,
-        item,
-        now,
-        outcome,
-        requestedRetryAt ?? undefined,
-        requeueLatest,
-      );
+      const completionResult =
+        publicationItem && publicationCompletion
+          ? finishExactReviewPublicationQueueItem({
+              state,
+              item,
+              now,
+              completion: publicationCompletion,
+              requestedRetryAt: requestedRetryAt ?? undefined,
+              requeueLatest,
+              deadLetterCapacityAvailable: this.deadLetterCapacityAvailableSync(
+                exactReviewDeadLetterId(item),
+              ),
+              env: this.env,
+            })
+          : {
+              requeued: finishExactReviewQueueItem(
+                state,
+                item,
+                now,
+                outcome,
+                requestedRetryAt ?? undefined,
+                requeueLatest,
+              ),
+              retried: outcome !== "success",
+              refreshed: false,
+              parked: false,
+              deadLetter: undefined,
+            };
+      const { requeued } = completionResult;
       // A successful workflow can still request requeue_latest after source
       // drift. That work did not leave its lane, so it must not improve the
       // operator-facing net speed until a later revision actually completes.
-      const completedLane = outcome === "success" && !requeued ? exactReviewQueueLane(item) : null;
+      const completedLane =
+        !requeued && !completionResult.parked ? exactReviewQueueLane(item) : null;
+      const structuredTerminal = publicationCompletion && !requeued && !completionResult.parked;
       await this.writeState(
         state,
         {
-          ...(completedLane === "review" ? { reviewCompleted: 1 } : {}),
+          ...(completedLane === "review" && outcome === "success" ? { reviewCompleted: 1 } : {}),
           ...(completedLane === "publication" ? { publicationCompleted: 1 } : {}),
+          ...(structuredTerminal && publicationCompletion.kind === "published"
+            ? { publicationPublished: 1 }
+            : {}),
+          ...(structuredTerminal && publicationCompletion.kind === "superseded"
+            ? { publicationSuperseded: 1 }
+            : {}),
+          ...(publicationItem && completionResult.retried ? { publicationRetried: 1 } : {}),
+          ...(completionResult.deadLetter ? { publicationDeadLettered: 1 } : {}),
+          ...(completionResult.refreshed ? { publicationRefreshed: 1 } : {}),
         },
-        publicationItem && ((outcome === "success" && !requeued) || failureKind)
+        publicationItem &&
+          ((publicationCompletion
+            ? publicationCompletion.kind === "published" && !requeued
+            : outcome === "success" && !requeued) ||
+            failureKind)
           ? {
               at: now,
               capacity: publicationDesiredCapacity,
-              outcome: outcome === "success" ? "success" : "failure",
+              outcome:
+                (publicationCompletion
+                  ? publicationCompletion.kind === "published"
+                  : outcome === "success") && !requeued
+                  ? "success"
+                  : "failure",
               ...(failureKind ? { failureKind } : {}),
             }
           : undefined,
+        completionResult.deadLetter,
       );
       await this.scheduleNext(state, now);
       return json({ ok: true, requeued });
@@ -648,6 +809,78 @@ export class ExactReviewQueue {
         )
         .slice(0, EXACT_REVIEW_RECONCILE_RUN_LIMIT);
       return json({ runs });
+    }
+
+    if (request.method === "POST" && url.pathname === "/dead-letters/list") {
+      return this.listDeadLetters(await request.json().catch(() => null));
+    }
+
+    if (request.method === "POST" && url.pathname === "/dead-letters/replay") {
+      return this.replayDeadLetters(await request.json().catch(() => null));
+    }
+
+    if (request.method === "POST" && url.pathname === "/dead-letters/resolve") {
+      return this.resolveDeadLetters(await request.json().catch(() => null));
+    }
+
+    if (request.method === "POST" && url.pathname === "/publications/list") {
+      return this.listPublicationCandidates(await request.json().catch(() => null));
+    }
+
+    if (request.method === "POST" && url.pathname === "/publications/supersede") {
+      return this.supersedePublicationCandidates(await request.json().catch(() => null));
+    }
+
+    if (request.method === "GET" && url.pathname === "/item-status") {
+      const targetRepo = String(url.searchParams.get("target_repo") || "").trim();
+      const itemNumber = Number(url.searchParams.get("item_number"));
+      if (
+        !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(targetRepo) ||
+        !Number.isInteger(itemNumber) ||
+        itemNumber < 1
+      ) {
+        return json({ error: "invalid_item_identity" }, 400);
+      }
+      const state = this.readStateSync();
+      const matches = Object.values(state.items).filter(
+        (item) =>
+          item.decision.targetRepo === targetRepo && item.decision.itemNumber === itemNumber,
+      );
+      const items = matches.map((item) => ({
+        lane: exactReviewQueueLane(item),
+        state: item.state,
+        revision: item.revision,
+        attempts: item.attempts,
+        created_at: new Date(item.createdAt).toISOString(),
+        next_attempt_at:
+          item.state === "pending" ? new Date(item.nextAttemptAt).toISOString() : null,
+        older_ready_count: Object.values(state.items).filter(
+          (candidate) =>
+            exactReviewQueueLane(candidate) === exactReviewQueueLane(item) &&
+            candidate.state === "pending" &&
+            candidate.nextAttemptAt <= Date.now() &&
+            (candidate.createdAt < item.createdAt ||
+              (candidate.createdAt === item.createdAt && candidate.key < item.key)),
+        ).length,
+      }));
+      const deadLetters = Array.from(
+        this.storage.sql.exec(
+          `SELECT reason_code, first_failed_at, last_failed_at
+             FROM ${EXACT_REVIEW_QUEUE_DEAD_LETTER_TABLE}
+            WHERE target_repo = ? AND item_number = ? AND status = 'open'
+            ORDER BY last_failed_at DESC`,
+          targetRepo,
+          itemNumber,
+        ),
+      );
+      return json({
+        ok: true,
+        target_repo: targetRepo,
+        item_number: itemNumber,
+        items,
+        dead_letters: deadLetters,
+        position_is_approximate: true,
+      });
     }
 
     if (request.method === "POST" && url.pathname === "/reconcile") {
@@ -697,6 +930,7 @@ export class ExactReviewQueue {
       const now = Date.now();
       const snapshot = this.storage.transactionSync(() => {
         this.pruneDeliveryReceiptsSync(now);
+        this.prunePublicationTelemetrySync(now);
         const current = this.readStateSync();
         // Dashboard reads are also the operational heartbeat. Reclaim leases and
         // restore the alarm here so a deploy or lost alarm cannot strand backlog.
@@ -708,11 +942,16 @@ export class ExactReviewQueue {
         );
         if (changed) this.writeStateSync(current);
         else this.syncLegacyCompatibilitySync(current);
-        return { state: current, metrics: this.queueMetricTotalsSync() };
+        return {
+          state: current,
+          metrics: this.queueMetricTotalsSync(),
+          flow: this.publicationFlowSummarySync(now),
+          deadLetters: this.deadLetterStatsSync(),
+        };
       });
-      const { state, metrics } = snapshot;
+      const { state, metrics, flow, deadLetters } = snapshot;
+      const publicationControl = this.refreshPublicationControlSync(state, now);
       await this.scheduleNext(state, now);
-      const publicationControl = this.publicationControlSync();
       const stats = exactReviewQueueStats(
         state,
         now,
@@ -723,6 +962,8 @@ export class ExactReviewQueue {
           state,
           now,
           publicationControl.capacityCeiling,
+          true,
+          publicationControl.demandCapacity,
         ),
         exactReviewDispatchLeaseMs(this.env),
         exactReviewExecutionLeaseMs(this.env),
@@ -741,6 +982,14 @@ export class ExactReviewQueue {
             ...stats.lanes.publication,
             enqueued_total: metrics.publication.enqueued,
             completed_total: metrics.publication.completed,
+            published_total: metrics.publication.published,
+            superseded_total: metrics.publication.superseded,
+            retried_total: metrics.publication.retried,
+            dead_lettered_total: metrics.publication.deadLettered,
+            refreshed_total: metrics.publication.refreshed,
+            flow,
+            dead_letters: deadLetters,
+            health: exactReviewPublicationHealth(stats.lanes.publication, flow, deadLetters),
             capacity_control: exactReviewPublicationControlStatus(this.env, publicationControl),
           },
         },
@@ -775,11 +1024,14 @@ export class ExactReviewQueue {
     const snapshotChanged = reclaimedSnapshot || expiredSnapshot;
     const capacity = exactReviewQueueCapacity(this.env);
     const targetCapacity = exactReviewTargetCapacity(this.env);
+    const snapshotPublicationControl = this.refreshPublicationControlSync(snapshot, startedAt);
     const snapshotPublicationCapacity = exactReviewPublicationCapacityForState(
       this.env,
       snapshot,
       startedAt,
-      this.publicationControlSync().capacityCeiling,
+      snapshotPublicationControl.capacityCeiling,
+      true,
+      snapshotPublicationControl.demandCapacity,
     );
     const snapshotAdmission = exactReviewQueueAdmittedItems(
       snapshot,
@@ -817,11 +1069,14 @@ export class ExactReviewQueue {
     expireExactReviewPublicationItems(state, now, this.env);
     // The preflight fetch releases the input gate, so publication demand may
     // have crossed a scale boundary while the workflow state was checked.
+    const publicationControl = this.refreshPublicationControlSync(state, now);
     const publicationCapacity = exactReviewPublicationCapacityForState(
       this.env,
       state,
       now,
-      this.publicationControlSync().capacityCeiling,
+      publicationControl.capacityCeiling,
+      true,
+      publicationControl.demandCapacity,
     );
     const admitted = exactReviewQueueAdmittedItems(
       state,
@@ -924,6 +1179,222 @@ export class ExactReviewQueue {
     }
     if (currentChanged) await this.writeState(current);
     await this.scheduleNext(current, completedAt);
+  }
+
+  private listDeadLetters(value: unknown) {
+    const body = objectValue(value);
+    const status = String(body.status || "open");
+    if (!["open", "replayed", "resolved", "all"].includes(status)) {
+      return json({ error: "invalid_dead_letter_status" }, 400);
+    }
+    const limit = body.limit === undefined ? 20 : Number(body.limit);
+    if (!Number.isInteger(limit) || limit < 1 || limit > 20) {
+      return json({ error: "invalid_limit" }, 400);
+    }
+    const cursor = String(body.cursor || "");
+    if (cursor && cursor.length > 500) return json({ error: "invalid_cursor" }, 400);
+    this.prunePublicationTelemetrySync(Date.now());
+    const rows = Array.from(
+      this.storage.sql.exec(
+        `SELECT dead_letter_id, item_key, revision, target_repo, item_number,
+                producer_run_id, producer_run_attempt, artifact_name, reason_code,
+                attempts, first_failed_at, last_failed_at, item_json, error_fingerprint,
+                status, replay_key, resolution_note, resolved_at
+           FROM ${EXACT_REVIEW_QUEUE_DEAD_LETTER_TABLE}
+          WHERE dead_letter_id > ? ${status === "all" ? "" : "AND status = ?"}
+          ORDER BY dead_letter_id
+          LIMIT ?`,
+        cursor,
+        ...(status === "all" ? [limit + 1] : [status, limit + 1]),
+      ) as Iterable<Record<string, unknown>>,
+    );
+    const page = rows.slice(0, limit);
+    return json({
+      ok: true,
+      dead_letters: page.map((row) => ({
+        ...row,
+        item: JSON.parse(String(row.item_json || "{}")),
+        item_json: undefined,
+      })),
+      next_cursor: rows.length > limit ? String(page.at(-1)?.dead_letter_id || "") || null : null,
+    });
+  }
+
+  private async replayDeadLetters(value: unknown) {
+    const body = objectValue(value);
+    const ids = exactReviewDeadLetterIds(body.ids);
+    const replayKey = String(body.idempotency_key || "").trim();
+    if (!ids) return json({ error: "invalid_dead_letter_ids" }, 400);
+    if (!/^[A-Za-z0-9:._-]{1,200}$/.test(replayKey)) {
+      return json({ error: "invalid_idempotency_key" }, 400);
+    }
+    const now = Date.now();
+    const result = this.storage.transactionSync(() => {
+      const state = this.readStateSync();
+      let replayed = 0;
+      let deduped = 0;
+      let skipped = 0;
+      for (const id of ids) {
+        const row = Array.from(
+          this.storage.sql.exec(
+            `SELECT status, replay_key, item_json
+               FROM ${EXACT_REVIEW_QUEUE_DEAD_LETTER_TABLE}
+              WHERE dead_letter_id = ?`,
+            id,
+          ),
+        )[0] as { status?: string; replay_key?: string; item_json?: string } | undefined;
+        if (row?.status === "replayed" && row.replay_key === replayKey) {
+          deduped += 1;
+          continue;
+        }
+        if (row?.status !== "open" || !row.item_json) {
+          skipped += 1;
+          continue;
+        }
+        const item = JSON.parse(row.item_json) as ExactReviewQueueItem;
+        if (!item?.key || state.items[item.key]) {
+          skipped += 1;
+          continue;
+        }
+        clearExactReviewLease(item);
+        item.state = "pending";
+        item.parkedReason = undefined;
+        item.attempts = 0;
+        item.publicationFailureAttempts = 0;
+        item.firstFailureAt = undefined;
+        item.lastFailureReason = undefined;
+        item.createdAt = now;
+        item.updatedAt = now;
+        item.nextAttemptAt = now;
+        state.items[item.key] = item;
+        this.storage.sql.exec(
+          `UPDATE ${EXACT_REVIEW_QUEUE_DEAD_LETTER_TABLE}
+              SET status = 'replayed', replay_key = ?, resolution_note = 'replayed', resolved_at = ?
+            WHERE dead_letter_id = ? AND status = 'open'`,
+          replayKey,
+          now,
+          id,
+        );
+        replayed += 1;
+      }
+      const unparked = this.drainParkedDeadLettersSync(state, now);
+      if (replayed) this.writeStateSync(state);
+      else if (unparked) this.writeStateSync(state);
+      else this.syncLegacyCompatibilitySync(state);
+      if (unparked) {
+        this.incrementQueueMetricsSync({
+          publicationCompleted: unparked,
+          publicationDeadLettered: unparked,
+        });
+      }
+      return { state, replayed, deduped, skipped, unparked };
+    });
+    if (result.replayed) await this.scheduleNext(result.state, now);
+    return json({
+      ok: true,
+      replayed: result.replayed,
+      deduped: result.deduped,
+      skipped: result.skipped,
+    });
+  }
+
+  private resolveDeadLetters(value: unknown) {
+    const body = objectValue(value);
+    const ids = exactReviewDeadLetterIds(body.ids);
+    const note = String(body.note || "").trim();
+    if (!ids) return json({ error: "invalid_dead_letter_ids" }, 400);
+    if (!note || note.length > 500) return json({ error: "invalid_resolution_note" }, 400);
+    const now = Date.now();
+    let resolved = 0;
+    let unparked = 0;
+    this.storage.transactionSync(() => {
+      for (const id of ids) {
+        const changed = Array.from(
+          this.storage.sql.exec(
+            `UPDATE ${EXACT_REVIEW_QUEUE_DEAD_LETTER_TABLE}
+                SET status = 'resolved', resolution_note = ?, resolved_at = ?
+              WHERE dead_letter_id = ? AND status = 'open'
+            RETURNING dead_letter_id`,
+            note,
+            now,
+            id,
+          ),
+        );
+        if (changed.length) resolved += 1;
+      }
+      if (resolved) {
+        const state = this.readStateSync();
+        unparked = this.drainParkedDeadLettersSync(state, now);
+        if (unparked) {
+          this.writeStateSync(state);
+          this.incrementQueueMetricsSync({
+            publicationCompleted: unparked,
+            publicationDeadLettered: unparked,
+          });
+        }
+      }
+    });
+    return json({ ok: true, resolved, skipped: ids.length - resolved, unparked });
+  }
+
+  private listPublicationCandidates(value: unknown) {
+    const body = objectValue(value);
+    const cursor = String(body.cursor || "");
+    const limit = body.limit === undefined ? 100 : Number(body.limit);
+    if (!Number.isInteger(limit) || limit < 1 || limit > 100) {
+      return json({ error: "invalid_limit" }, 400);
+    }
+    const state = this.readStateSync();
+    const candidates = Object.values(state.items)
+      .filter(
+        (item) =>
+          item.key > cursor &&
+          exactReviewQueueIsPublication(item) &&
+          (item.state === "pending" || item.state === "parked"),
+      )
+      .sort((left, right) => left.key.localeCompare(right.key));
+    const page = candidates.slice(0, limit);
+    return json({
+      ok: true,
+      publications: page.map((item) => ({
+        item_key: item.key,
+        revision: item.revision,
+        state: item.state,
+        created_at: new Date(item.createdAt).toISOString(),
+        attempts: item.attempts,
+        decision: item.decision,
+      })),
+      next_cursor: candidates.length > limit ? page.at(-1)?.key || null : null,
+    });
+  }
+
+  private async supersedePublicationCandidates(value: unknown) {
+    const body = objectValue(value);
+    const candidates = exactReviewPublicationCandidates(body.items);
+    if (!candidates) return json({ error: "invalid_publication_candidates" }, 400);
+    const state = this.readStateSync();
+    let superseded = 0;
+    for (const candidate of candidates) {
+      const item = state.items[candidate.itemKey];
+      if (
+        !item ||
+        item.revision !== candidate.revision ||
+        !exactReviewQueueIsPublication(item) ||
+        (item.state !== "pending" && item.state !== "parked")
+      ) {
+        continue;
+      }
+      delete state.items[item.key];
+      superseded += 1;
+    }
+    if (superseded) {
+      await this.writeState(state, {
+        publicationCompleted: superseded,
+        publicationSuperseded: superseded,
+      });
+      await this.scheduleNext(state, Date.now());
+    }
+    return json({ ok: true, superseded, skipped: candidates.length - superseded });
   }
 
   private async initializeStorage() {
@@ -1056,6 +1527,11 @@ export class ExactReviewQueue {
       "review_enqueued_total",
       "review_completed_total",
       "publication_enqueued_total",
+      "publication_published_total",
+      "publication_superseded_total",
+      "publication_retried_total",
+      "publication_dead_lettered_total",
+      "publication_refreshed_total",
     ]) {
       const present = Array.from(
         this.storage.sql.exec(
@@ -1065,9 +1541,10 @@ export class ExactReviewQueue {
         ),
       ).length;
       if (!present) {
+        const definition = `${column} INTEGER NOT NULL DEFAULT 0 CHECK (${column} >= 0)`;
         this.storage.sql.exec(
           `ALTER TABLE ${EXACT_REVIEW_QUEUE_METRICS_TABLE}
-             ADD COLUMN ${column} INTEGER NOT NULL DEFAULT 0 CHECK (${column} >= 0)`,
+             ADD COLUMN ${definition}`,
         );
       }
     }
@@ -1078,6 +1555,45 @@ export class ExactReviewQueue {
     this.storage.sql.exec(
       `CREATE INDEX IF NOT EXISTS exact_review_queue_deliveries_received_at
          ON ${EXACT_REVIEW_QUEUE_DELIVERY_TABLE} (received_at, delivery_id)`,
+    );
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_QUEUE_METRIC_BUCKET_TABLE} (
+         bucket_start INTEGER PRIMARY KEY,
+         publication_enqueued INTEGER NOT NULL DEFAULT 0 CHECK (publication_enqueued >= 0),
+         publication_resolved INTEGER NOT NULL DEFAULT 0 CHECK (publication_resolved >= 0),
+         publication_published INTEGER NOT NULL DEFAULT 0 CHECK (publication_published >= 0),
+         publication_superseded INTEGER NOT NULL DEFAULT 0 CHECK (publication_superseded >= 0),
+         publication_retried INTEGER NOT NULL DEFAULT 0 CHECK (publication_retried >= 0),
+         publication_dead_lettered INTEGER NOT NULL DEFAULT 0
+           CHECK (publication_dead_lettered >= 0)
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_QUEUE_DEAD_LETTER_TABLE} (
+         dead_letter_id TEXT PRIMARY KEY,
+         item_key TEXT NOT NULL,
+         revision INTEGER NOT NULL CHECK (revision >= 1),
+         target_repo TEXT NOT NULL,
+         item_number INTEGER NOT NULL CHECK (item_number >= 1),
+         producer_run_id TEXT NOT NULL,
+         producer_run_attempt INTEGER NOT NULL CHECK (producer_run_attempt >= 1),
+         artifact_name TEXT NOT NULL,
+         reason_code TEXT NOT NULL,
+         attempts INTEGER NOT NULL CHECK (attempts >= 1),
+         first_failed_at INTEGER NOT NULL,
+         last_failed_at INTEGER NOT NULL,
+         item_json TEXT NOT NULL,
+         error_fingerprint TEXT,
+         status TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'replayed', 'resolved')),
+         replay_key TEXT,
+         resolution_note TEXT,
+         resolved_at INTEGER
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `CREATE INDEX IF NOT EXISTS exact_review_queue_dead_letters_status
+         ON ${EXACT_REVIEW_QUEUE_DEAD_LETTER_TABLE}
+         (status, last_failed_at, dead_letter_id)`,
     );
   }
 
@@ -1317,11 +1833,13 @@ export class ExactReviewQueue {
     state: ExactReviewQueueState,
     metricDelta: ExactReviewQueueMetricDelta = {},
     publicationFeedback?: ExactReviewPublicationFeedback,
+    deadLetter?: ExactReviewDeadLetterInsert,
   ) {
     this.storage.transactionSync(() => {
       this.writeStateSync(state);
       this.incrementQueueMetricsSync(metricDelta);
       if (publicationFeedback) this.applyPublicationFeedbackSync(publicationFeedback);
+      if (deadLetter) this.insertDeadLetterSync(deadLetter);
     });
   }
 
@@ -1330,6 +1848,27 @@ export class ExactReviewQueue {
       this.env,
       this.storage.kv.get(EXACT_REVIEW_PUBLICATION_CONTROL_KEY),
     );
+  }
+
+  private refreshPublicationControlSync(state: ExactReviewQueueState, now: number) {
+    const current = this.publicationControlSync();
+    const publications = Object.values(state.items).filter(exactReviewQueueIsPublication);
+    const pending = publications.filter((item) => item.state === "pending");
+    const oldestPendingAt = pending.reduce<number | null>(
+      (oldest, item) => (oldest === null ? item.createdAt : Math.min(oldest, item.createdAt)),
+      null,
+    );
+    const flow = this.publicationFlowSummarySync(now).last_15_minutes;
+    const next = exactReviewPublicationControlAfterDemand(this.env, current, {
+      at: now,
+      backlog: pending.length,
+      oldestPendingAgeMs: oldestPendingAt === null ? 0 : Math.max(0, now - oldestPendingAt),
+      netDrainRatePerHour: flow.net_drain_rate_per_hour,
+    });
+    if (stableJson(next) !== stableJson(current)) {
+      this.storage.kv.put(EXACT_REVIEW_PUBLICATION_CONTROL_KEY, next);
+    }
+    return next;
   }
 
   private applyPublicationFeedbackSync(feedback: ExactReviewPublicationFeedback) {
@@ -1342,7 +1881,10 @@ export class ExactReviewQueue {
     const row = Array.from(
       this.storage.sql.exec(
         `SELECT review_enqueued_total, review_completed_total,
-                publication_enqueued_total, publication_completed_total
+                publication_enqueued_total, publication_completed_total,
+                publication_published_total, publication_superseded_total,
+                publication_retried_total, publication_dead_lettered_total,
+                publication_refreshed_total
            FROM ${EXACT_REVIEW_QUEUE_METRICS_TABLE}
           WHERE singleton_id = 1`,
       ),
@@ -1352,6 +1894,11 @@ export class ExactReviewQueue {
           review_completed_total?: number;
           publication_enqueued_total?: number;
           publication_completed_total?: number;
+          publication_published_total?: number;
+          publication_superseded_total?: number;
+          publication_retried_total?: number;
+          publication_dead_lettered_total?: number;
+          publication_refreshed_total?: number;
         }
       | undefined;
     return {
@@ -1362,6 +1909,11 @@ export class ExactReviewQueue {
       publication: {
         enqueued: exactReviewMetricTotal(row?.publication_enqueued_total),
         completed: exactReviewMetricTotal(row?.publication_completed_total),
+        published: exactReviewMetricTotal(row?.publication_published_total),
+        superseded: exactReviewMetricTotal(row?.publication_superseded_total),
+        retried: exactReviewMetricTotal(row?.publication_retried_total),
+        deadLettered: exactReviewMetricTotal(row?.publication_dead_lettered_total),
+        refreshed: exactReviewMetricTotal(row?.publication_refreshed_total),
       },
     };
   }
@@ -1371,7 +1923,22 @@ export class ExactReviewQueue {
     const reviewCompleted = exactReviewMetricDelta(delta.reviewCompleted);
     const publicationEnqueued = exactReviewMetricDelta(delta.publicationEnqueued);
     const publicationCompleted = exactReviewMetricDelta(delta.publicationCompleted);
-    if (!reviewEnqueued && !reviewCompleted && !publicationEnqueued && !publicationCompleted) {
+    const publicationPublished = exactReviewMetricDelta(delta.publicationPublished);
+    const publicationSuperseded = exactReviewMetricDelta(delta.publicationSuperseded);
+    const publicationRetried = exactReviewMetricDelta(delta.publicationRetried);
+    const publicationDeadLettered = exactReviewMetricDelta(delta.publicationDeadLettered);
+    const publicationRefreshed = exactReviewMetricDelta(delta.publicationRefreshed);
+    if (
+      !reviewEnqueued &&
+      !reviewCompleted &&
+      !publicationEnqueued &&
+      !publicationCompleted &&
+      !publicationPublished &&
+      !publicationSuperseded &&
+      !publicationRetried &&
+      !publicationDeadLettered &&
+      !publicationRefreshed
+    ) {
       return;
     }
     this.storage.sql.exec(
@@ -1379,13 +1946,247 @@ export class ExactReviewQueue {
           SET review_enqueued_total = review_enqueued_total + ?,
               review_completed_total = review_completed_total + ?,
               publication_enqueued_total = publication_enqueued_total + ?,
-              publication_completed_total = publication_completed_total + ?
+              publication_completed_total = publication_completed_total + ?,
+              publication_published_total = publication_published_total + ?,
+              publication_superseded_total = publication_superseded_total + ?,
+              publication_retried_total = publication_retried_total + ?,
+              publication_dead_lettered_total = publication_dead_lettered_total + ?,
+              publication_refreshed_total = publication_refreshed_total + ?
         WHERE singleton_id = 1`,
       reviewEnqueued,
       reviewCompleted,
       publicationEnqueued,
       publicationCompleted,
+      publicationPublished,
+      publicationSuperseded,
+      publicationRetried,
+      publicationDeadLettered,
+      publicationRefreshed,
     );
+    this.incrementPublicationMetricBucketSync({
+      publicationEnqueued,
+      publicationCompleted,
+      publicationPublished,
+      publicationSuperseded,
+      publicationRetried,
+      publicationDeadLettered,
+    });
+  }
+
+  private incrementPublicationMetricBucketSync({
+    publicationEnqueued,
+    publicationCompleted,
+    publicationPublished,
+    publicationSuperseded,
+    publicationRetried,
+    publicationDeadLettered,
+  }: {
+    publicationEnqueued: number;
+    publicationCompleted: number;
+    publicationPublished: number;
+    publicationSuperseded: number;
+    publicationRetried: number;
+    publicationDeadLettered: number;
+  }) {
+    if (
+      !publicationEnqueued &&
+      !publicationCompleted &&
+      !publicationPublished &&
+      !publicationSuperseded &&
+      !publicationRetried &&
+      !publicationDeadLettered
+    ) {
+      return;
+    }
+    const bucketStart =
+      Math.floor(Date.now() / EXACT_REVIEW_QUEUE_METRIC_BUCKET_MS) *
+      EXACT_REVIEW_QUEUE_METRIC_BUCKET_MS;
+    this.storage.sql.exec(
+      `INSERT INTO ${EXACT_REVIEW_QUEUE_METRIC_BUCKET_TABLE}
+         (bucket_start, publication_enqueued, publication_resolved, publication_published,
+          publication_superseded, publication_retried, publication_dead_lettered)
+       VALUES (?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(bucket_start) DO UPDATE SET
+         publication_enqueued = publication_enqueued + excluded.publication_enqueued,
+         publication_resolved = publication_resolved + excluded.publication_resolved,
+         publication_published = publication_published + excluded.publication_published,
+         publication_superseded = publication_superseded + excluded.publication_superseded,
+         publication_retried = publication_retried + excluded.publication_retried,
+         publication_dead_lettered =
+           publication_dead_lettered + excluded.publication_dead_lettered`,
+      bucketStart,
+      publicationEnqueued,
+      publicationCompleted,
+      publicationPublished,
+      publicationSuperseded,
+      publicationRetried,
+      publicationDeadLettered,
+    );
+  }
+
+  private deadLetterCapacityAvailableSync(deadLetterId: string) {
+    const existing = Array.from(
+      this.storage.sql.exec(
+        `SELECT 1 AS present
+           FROM ${EXACT_REVIEW_QUEUE_DEAD_LETTER_TABLE}
+          WHERE dead_letter_id = ?`,
+        deadLetterId,
+      ),
+    ).length;
+    if (existing) return true;
+    const row = Array.from(
+      this.storage.sql.exec(
+        `SELECT COUNT(*) AS open_count
+           FROM ${EXACT_REVIEW_QUEUE_DEAD_LETTER_TABLE}
+          WHERE status = 'open'`,
+      ),
+    )[0] as { open_count?: number } | undefined;
+    return Number(row?.open_count || 0) < EXACT_REVIEW_QUEUE_DEAD_LETTER_LIMIT;
+  }
+
+  private insertDeadLetterSync(deadLetter: ExactReviewDeadLetterInsert) {
+    this.storage.sql.exec(
+      `INSERT INTO ${EXACT_REVIEW_QUEUE_DEAD_LETTER_TABLE}
+         (dead_letter_id, item_key, revision, target_repo, item_number, producer_run_id,
+          producer_run_attempt, artifact_name, reason_code, attempts, first_failed_at,
+          last_failed_at, item_json, error_fingerprint, status)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'open')
+       ON CONFLICT(dead_letter_id) DO UPDATE SET
+         reason_code = excluded.reason_code,
+         attempts = excluded.attempts,
+         last_failed_at = excluded.last_failed_at,
+         error_fingerprint = excluded.error_fingerprint,
+         status = 'open', replay_key = NULL, resolution_note = NULL, resolved_at = NULL`,
+      deadLetter.id,
+      deadLetter.itemKey,
+      deadLetter.revision,
+      deadLetter.targetRepo,
+      deadLetter.itemNumber,
+      deadLetter.producerRunId,
+      deadLetter.producerRunAttempt,
+      deadLetter.artifactName,
+      deadLetter.reasonCode,
+      deadLetter.attempts,
+      deadLetter.firstFailedAt,
+      deadLetter.lastFailedAt,
+      deadLetter.itemJson,
+      deadLetter.errorFingerprint || null,
+    );
+  }
+
+  private drainParkedDeadLettersSync(state: ExactReviewQueueState, now: number) {
+    const openRow = Array.from(
+      this.storage.sql.exec(
+        `SELECT COUNT(*) AS open_count
+           FROM ${EXACT_REVIEW_QUEUE_DEAD_LETTER_TABLE}
+          WHERE status = 'open'`,
+      ),
+    )[0] as { open_count?: number } | undefined;
+    let available = Math.max(
+      0,
+      EXACT_REVIEW_QUEUE_DEAD_LETTER_LIMIT - Number(openRow?.open_count || 0),
+    );
+    let moved = 0;
+    for (const item of Object.values(state.items).sort(
+      (left, right) => left.updatedAt - right.updatedAt || left.key.localeCompare(right.key),
+    )) {
+      if (!available || item.state !== "parked" || !exactReviewQueueIsPublication(item)) continue;
+      const deadLetter = exactReviewDeadLetterInsert(
+        item,
+        item.lastFailureReason || "retry_exhausted",
+        Math.max(1, item.attempts),
+        item.firstFailureAt || item.updatedAt,
+        now,
+      );
+      this.insertDeadLetterSync(deadLetter);
+      delete state.items[item.key];
+      available -= 1;
+      moved += 1;
+    }
+    return moved;
+  }
+
+  private prunePublicationTelemetrySync(now: number) {
+    this.storage.sql.exec(
+      `DELETE FROM ${EXACT_REVIEW_QUEUE_METRIC_BUCKET_TABLE} WHERE bucket_start < ?`,
+      now - EXACT_REVIEW_QUEUE_METRIC_BUCKET_TTL_MS,
+    );
+    this.storage.sql.exec(
+      `DELETE FROM ${EXACT_REVIEW_QUEUE_DEAD_LETTER_TABLE}
+        WHERE status != 'open' AND resolved_at < ?`,
+      now - EXACT_REVIEW_QUEUE_DEAD_LETTER_RESOLVED_TTL_MS,
+    );
+  }
+
+  private publicationFlowSummarySync(now: number) {
+    const summarize = (windowMs: number) => {
+      const row = Array.from(
+        this.storage.sql.exec(
+          `SELECT COALESCE(SUM(publication_enqueued), 0) AS enqueued,
+                  COALESCE(SUM(publication_resolved), 0) AS resolved,
+                  COALESCE(SUM(publication_published), 0) AS published,
+                  COALESCE(SUM(publication_superseded), 0) AS superseded,
+                  COALESCE(SUM(publication_retried), 0) AS retried,
+                  COALESCE(SUM(publication_dead_lettered), 0) AS dead_lettered
+             FROM ${EXACT_REVIEW_QUEUE_METRIC_BUCKET_TABLE}
+            WHERE bucket_start >= ?`,
+          now - windowMs,
+        ),
+      )[0] as Record<string, number> | undefined;
+      const multiplier = (60 * 60 * 1000) / windowMs;
+      const enqueued = Number(row?.enqueued || 0);
+      const resolved = Number(row?.resolved || 0);
+      const retried = Number(row?.retried || 0);
+      const published = Number(row?.published || 0);
+      const superseded = Number(row?.superseded || 0);
+      const deadLettered = Number(row?.dead_lettered || 0);
+      return {
+        window_minutes: windowMs / 60_000,
+        enqueued,
+        resolved,
+        published,
+        superseded,
+        retried,
+        dead_lettered: deadLettered,
+        arrival_rate_per_hour: Math.round(enqueued * multiplier * 10) / 10,
+        resolved_rate_per_hour: Math.round(resolved * multiplier * 10) / 10,
+        published_rate_per_hour: Math.round(published * multiplier * 10) / 10,
+        superseded_rate_per_hour: Math.round(superseded * multiplier * 10) / 10,
+        retried_rate_per_hour: Math.round(retried * multiplier * 10) / 10,
+        dead_lettered_rate_per_hour: Math.round(deadLettered * multiplier * 10) / 10,
+        net_drain_rate_per_hour: Math.round((resolved - enqueued) * multiplier * 10) / 10,
+        retry_amplification: resolved > 0 ? Math.round((retried / resolved) * 100) / 100 : null,
+      };
+    };
+    return { last_15_minutes: summarize(15 * 60_000), last_60_minutes: summarize(60 * 60_000) };
+  }
+
+  private deadLetterStatsSync() {
+    const totals = Array.from(
+      this.storage.sql.exec(
+        `SELECT COUNT(*) AS open_count, MIN(first_failed_at) AS oldest_failed_at
+           FROM ${EXACT_REVIEW_QUEUE_DEAD_LETTER_TABLE}
+          WHERE status = 'open'`,
+      ),
+    )[0] as { open_count?: number; oldest_failed_at?: number } | undefined;
+    const reasons = Object.fromEntries(
+      Array.from(
+        this.storage.sql.exec(
+          `SELECT reason_code, COUNT(*) AS reason_count
+             FROM ${EXACT_REVIEW_QUEUE_DEAD_LETTER_TABLE}
+            WHERE status = 'open'
+            GROUP BY reason_code
+            ORDER BY reason_code`,
+        ) as Iterable<{ reason_code: string; reason_count: number }>,
+      ).map((row) => [row.reason_code, Number(row.reason_count)]),
+    );
+    const oldest = Number(totals?.oldest_failed_at || 0);
+    return {
+      open: Number(totals?.open_count || 0),
+      limit: EXACT_REVIEW_QUEUE_DEAD_LETTER_LIMIT,
+      oldest_failed_at: oldest ? new Date(oldest).toISOString() : null,
+      reasons,
+    };
   }
 
   private writeStateSync(state: ExactReviewQueueState) {
@@ -1579,6 +2380,7 @@ export class ExactReviewQueue {
   }
 
   private async scheduleNext(state: ExactReviewQueueState, now: number) {
+    const publicationControl = this.refreshPublicationControlSync(state, now);
     const next = exactReviewQueueNextWakeAt(
       state,
       now,
@@ -1588,7 +2390,9 @@ export class ExactReviewQueue {
         this.env,
         state,
         now,
-        this.publicationControlSync().capacityCeiling,
+        publicationControl.capacityCeiling,
+        true,
+        publicationControl.demandCapacity,
       ),
       exactReviewPublicationDispatchLeaseMs(this.env),
       exactReviewHeartbeatGraceMs(this.env),
@@ -1811,9 +2615,108 @@ function exactReviewPublicationFailureKind(value): ExactReviewPublicationFailure
     : null;
 }
 
+function exactReviewPublicationCompletionKind(value): ExactReviewPublicationCompletionKind | null {
+  const normalized = String(value || "");
+  return normalized === "published" ||
+    normalized === "superseded" ||
+    normalized === "retryable_failure" ||
+    normalized === "refresh_required" ||
+    normalized === "permanent_failure"
+    ? normalized
+    : null;
+}
+
+function exactReviewPublicationReasonCode(value): ExactReviewPublicationReasonCode | null {
+  const normalized = String(value || "");
+  return [
+    "publication_applied",
+    "remote_newer_tuple",
+    "remote_closed",
+    "live_terminal",
+    "github_rate_limit",
+    "github_transient",
+    "workflow_cancelled",
+    "artifact_unavailable",
+    "artifact_expired",
+    "invalid_artifact",
+    "missing_record_tuple",
+    "tuple_protocol_invalid",
+    "policy_invariant",
+    "unknown_failure",
+    "retry_exhausted",
+  ].includes(normalized)
+    ? (normalized as ExactReviewPublicationReasonCode)
+    : null;
+}
+
+function exactReviewPublicationCompletion(
+  kindValue,
+  reasonValue,
+  errorFingerprintValue,
+): ExactReviewPublicationCompletion | null {
+  const kind = exactReviewPublicationCompletionKind(kindValue);
+  const reasonCode = exactReviewPublicationReasonCode(reasonValue);
+  if (!kind || !reasonCode) return null;
+  const allowedReasons: Record<
+    ExactReviewPublicationCompletionKind,
+    ReadonlySet<ExactReviewPublicationReasonCode>
+  > = {
+    published: new Set(["publication_applied"]),
+    superseded: new Set(["remote_newer_tuple", "remote_closed", "live_terminal"]),
+    retryable_failure: new Set([
+      "github_rate_limit",
+      "github_transient",
+      "workflow_cancelled",
+      "artifact_unavailable",
+      "unknown_failure",
+    ]),
+    refresh_required: new Set(["artifact_unavailable", "artifact_expired"]),
+    permanent_failure: new Set([
+      "invalid_artifact",
+      "missing_record_tuple",
+      "tuple_protocol_invalid",
+      "policy_invariant",
+      "unknown_failure",
+      "retry_exhausted",
+    ]),
+  };
+  if (!allowedReasons[kind].has(reasonCode)) return null;
+  const errorFingerprint = String(errorFingerprintValue || "").trim();
+  if (errorFingerprint && !/^[A-Za-z0-9:._-]{1,200}$/.test(errorFingerprint)) return null;
+  return { kind, reasonCode, ...(errorFingerprint ? { errorFingerprint } : {}) };
+}
+
 function exactReviewRunAttempt(value): number | null {
   const runAttempt = Number(value);
   return Number.isInteger(runAttempt) && runAttempt > 0 ? runAttempt : null;
+}
+
+function exactReviewDeadLetterIds(value): string[] | null {
+  if (!Array.isArray(value) || value.length < 1 || value.length > 20) return null;
+  const ids = value.map((entry) => String(entry || "").trim());
+  if (ids.some((id) => !id || id.length > 500) || new Set(ids).size !== ids.length) return null;
+  return ids;
+}
+
+function exactReviewPublicationCandidates(
+  value,
+): Array<{ itemKey: string; revision: number }> | null {
+  if (!Array.isArray(value) || value.length < 1 || value.length > 25) return null;
+  const candidates: Array<{ itemKey: string; revision: number }> = [];
+  const seen = new Set<string>();
+  for (const entry of value) {
+    const candidate = objectValue(entry);
+    const itemKey = String(candidate.item_key || "").trim();
+    const revision = Number(candidate.revision);
+    if (!itemKey || itemKey.length > 500 || !Number.isInteger(revision) || revision < 1) {
+      return null;
+    }
+    const identity = `${itemKey}:${revision}`;
+    if (seen.has(identity)) return null;
+    seen.add(identity);
+    candidates.push({ itemKey, revision });
+  }
+  return candidates;
 }
 
 function exactReviewClaimGeneration(value) {
@@ -1908,6 +2811,210 @@ export function exactReviewClaimedRuns(value): ExactReviewClaimedRun[] | null {
     runs.push({ runId, runAttempt, claimGeneration });
   }
   return runs;
+}
+
+function finishExactReviewPublicationQueueItem({
+  state,
+  item,
+  now,
+  completion,
+  requestedRetryAt = 0,
+  requeueLatest = false,
+  deadLetterCapacityAvailable,
+  env,
+}: {
+  state: ExactReviewQueueState;
+  item: ExactReviewQueueItem;
+  now: number;
+  completion: ExactReviewPublicationCompletion;
+  requestedRetryAt?: number;
+  requeueLatest?: boolean;
+  deadLetterCapacityAvailable: boolean;
+  env: unknown;
+}): {
+  requeued: boolean;
+  retried: boolean;
+  refreshed: boolean;
+  parked: boolean;
+  deadLetter?: ExactReviewDeadLetterInsert;
+} {
+  const hasNewerRevision = item.revision > Number(item.leaseRevision || 0);
+  if (hasNewerRevision || requeueLatest) {
+    const requeued = finishExactReviewQueueItem(
+      state,
+      item,
+      now,
+      "success",
+      requestedRetryAt,
+      requeueLatest,
+    );
+    if (requeued) {
+      item.publicationFailureAttempts = 0;
+      item.firstFailureAt = undefined;
+      item.lastFailureReason = undefined;
+    }
+    return {
+      requeued,
+      retried: false,
+      refreshed: false,
+      parked: false,
+    };
+  }
+
+  if (completion.kind === "published" || completion.kind === "superseded") {
+    return {
+      requeued: finishExactReviewQueueItem(state, item, now, "success"),
+      retried: false,
+      refreshed: false,
+      parked: false,
+    };
+  }
+
+  // Dispatch failures and publisher results have independent budgets. A runner
+  // handoff failure must not make the first deterministic artifact failure look
+  // like its third confirmation attempt.
+  const attempt = Number(item.publicationFailureAttempts || 0) + 1;
+  const firstFailureAt = item.firstFailureAt || now;
+  const artifactRefresh =
+    completion.kind === "refresh_required" ||
+    (completion.reasonCode === "artifact_unavailable" &&
+      attempt >= EXACT_REVIEW_PUBLICATION_ARTIFACT_RETRY_LIMIT);
+  if (artifactRefresh) {
+    refreshExactReviewPublicationItem(state, item, now, env);
+    return { requeued: false, retried: false, refreshed: true, parked: false };
+  }
+
+  const retryExhausted = exactReviewPublicationRetryExhausted(
+    completion,
+    attempt,
+    firstFailureAt,
+    now,
+  );
+  if (retryExhausted) {
+    const deadLetter = exactReviewDeadLetterInsert(
+      item,
+      completion.reasonCode === "unknown_failure" ? "retry_exhausted" : completion.reasonCode,
+      attempt,
+      firstFailureAt,
+      now,
+      completion.errorFingerprint,
+    );
+    if (deadLetterCapacityAvailable) {
+      delete state.items[item.key];
+      return { requeued: false, retried: false, refreshed: false, parked: false, deadLetter };
+    }
+    // A full dead-letter store is an operator-visible circuit breaker. Park the
+    // poison item instead of silently dropping replay context or dispatching it forever.
+    clearExactReviewLease(item);
+    item.state = "parked";
+    item.parkedReason = "dead_letter_capacity";
+    item.attempts = attempt;
+    item.publicationFailureAttempts = attempt;
+    item.firstFailureAt = firstFailureAt;
+    item.lastFailureReason = completion.reasonCode;
+    item.updatedAt = now;
+    return { requeued: false, retried: false, refreshed: false, parked: true };
+  }
+
+  clearExactReviewLease(item);
+  item.state = "pending";
+  item.parkedReason = undefined;
+  item.attempts = attempt;
+  item.publicationFailureAttempts = attempt;
+  item.firstFailureAt = firstFailureAt;
+  item.lastFailureReason = completion.reasonCode;
+  item.nextAttemptAt = Math.max(
+    exactReviewQueueEnqueueAttemptAt(state, now),
+    now + exactReviewPublicationRetryDelayMs(item.key, completion, attempt),
+    requestedRetryAt,
+  );
+  item.updatedAt = now;
+  return { requeued: true, retried: true, refreshed: false, parked: false };
+}
+
+function exactReviewPublicationRetryExhausted(
+  completion: ExactReviewPublicationCompletion,
+  attempt: number,
+  firstFailureAt: number,
+  now: number,
+) {
+  if (completion.kind === "retryable_failure") {
+    if (completion.reasonCode === "artifact_unavailable") return false;
+    if (completion.reasonCode === "unknown_failure") {
+      return (
+        attempt >= EXACT_REVIEW_PUBLICATION_UNKNOWN_RETRY_LIMIT ||
+        now >= firstFailureAt + EXACT_REVIEW_PUBLICATION_UNKNOWN_RETRY_MAX_AGE_MS
+      );
+    }
+    return (
+      attempt >= EXACT_REVIEW_PUBLICATION_TRANSIENT_RETRY_LIMIT ||
+      now >= firstFailureAt + EXACT_REVIEW_PUBLICATION_TRANSIENT_RETRY_MAX_AGE_MS
+    );
+  }
+  if (completion.kind === "permanent_failure") {
+    const limit =
+      completion.reasonCode === "unknown_failure"
+        ? EXACT_REVIEW_PUBLICATION_UNKNOWN_RETRY_LIMIT
+        : EXACT_REVIEW_PUBLICATION_PERMANENT_RETRY_LIMIT;
+    return (
+      attempt >= limit ||
+      (completion.reasonCode === "unknown_failure" &&
+        now >= firstFailureAt + EXACT_REVIEW_PUBLICATION_UNKNOWN_RETRY_MAX_AGE_MS)
+    );
+  }
+  return false;
+}
+
+function exactReviewPublicationRetryDelayMs(
+  itemKey: string,
+  completion: ExactReviewPublicationCompletion,
+  attempt: number,
+) {
+  let delay: number;
+  if (completion.kind === "permanent_failure" || completion.reasonCode === "unknown_failure") {
+    const steps = [60_000, 5 * 60_000, 15 * 60_000, 30 * 60_000];
+    delay = steps[Math.min(attempt - 1, steps.length - 1)];
+  } else {
+    const maximum = completion.reasonCode === "github_rate_limit" ? 60 * 60_000 : 30 * 60_000;
+    delay = Math.min(maximum, 60_000 * 2 ** Math.min(attempt - 1, 6));
+  }
+  const hash = [...`${itemKey}:${attempt}`].reduce(
+    (current, character) => (current * 33 + character.charCodeAt(0)) >>> 0,
+    5381,
+  );
+  return delay + Math.floor(delay * ((hash % 21) / 100));
+}
+
+function exactReviewDeadLetterId(item: ExactReviewQueueItem) {
+  return `${item.key}@revision:${item.leaseRevision || item.revision}`;
+}
+
+function exactReviewDeadLetterInsert(
+  item: ExactReviewQueueItem,
+  reasonCode: ExactReviewPublicationReasonCode,
+  attempts: number,
+  firstFailedAt: number,
+  lastFailedAt: number,
+  errorFingerprint?: string,
+): ExactReviewDeadLetterInsert {
+  const publication = item.decision.publication;
+  if (!publication) throw new Error(`publication metadata missing for ${item.key}`);
+  return {
+    id: exactReviewDeadLetterId(item),
+    itemKey: item.key,
+    revision: Number(item.leaseRevision || item.revision),
+    targetRepo: item.decision.targetRepo,
+    itemNumber: item.decision.itemNumber,
+    producerRunId: publication.producerRunId,
+    producerRunAttempt: publication.producerRunAttempt,
+    artifactName: publication.artifactName,
+    reasonCode,
+    attempts,
+    firstFailedAt,
+    lastFailedAt,
+    itemJson: JSON.stringify(item),
+    ...(errorFingerprint ? { errorFingerprint } : {}),
+  };
 }
 
 function finishExactReviewQueueItem(
@@ -2052,14 +3159,19 @@ function reclaimExpiredExactReviewLease(
   clearExactReviewLease(item);
   item.state = "pending";
   item.nextAttemptAt = now;
-  if (hasNewerRevision) item.attempts = 0;
+  if (hasNewerRevision) {
+    item.attempts = 0;
+    item.publicationFailureAttempts = 0;
+    item.firstFailureAt = undefined;
+    item.lastFailureReason = undefined;
+  }
   item.updatedAt = now;
   return true;
 }
 
 function expireExactReviewPublicationItems(state: ExactReviewQueueState, now: number, env) {
   let changed = false;
-  for (const [key, item] of Object.entries(state.items)) {
+  for (const item of Object.values(state.items)) {
     const publication = item.decision.publication;
     if (
       item.state !== "pending" ||
@@ -2068,53 +3180,66 @@ function expireExactReviewPublicationItems(state: ExactReviewQueueState, now: nu
     ) {
       continue;
     }
-    delete state.items[key];
-    const decision: ExactReviewDecision = {
-      ...publication.producerDecision,
-      sourceAction:
-        publication.producerDecision.sourceAction === FAILED_REVIEW_SHARD_RECOVERY_SOURCE_ACTION
-          ? FAILED_REVIEW_SHARD_RECOVERY_SOURCE_ACTION
-          : EXACT_REVIEW_ARTIFACT_RETENTION_RECOVERY_SOURCE_ACTION,
-      supersedesInProgress: true,
-    };
-    const recoveryKey = exactReviewItemKey(decision);
-    const current = state.items[recoveryKey];
-    if (current?.state === "pending") {
-      current.decision = mergePendingExactReviewDecision(current.decision, decision);
-      current.revision += 1;
-      current.updatedAt = now;
-      // Merged decision, not the raw recovery: a pending explicit command must
-      // keep its immediate attempt time (same rule as the enqueue merge path).
-      current.nextAttemptAt = exactReviewQueueDebouncedAttemptAt(
-        state,
-        current.decision,
-        now,
-        current.createdAt,
-        env,
-      );
-      current.attempts = 0;
-    } else if (!current) {
-      // The expired publication was already deleted above; shedding here only
-      // suppresses creation of its replacement recovery item.
-      if (exactReviewQueuePendingCount(state) >= exactReviewPendingSoftLimit(env)) {
-        state.shedSinceReset = exactReviewShedSinceReset(state) + 1;
-        changed = true;
-        continue;
-      }
-      state.items[recoveryKey] = {
-        key: recoveryKey,
-        decision,
-        state: "pending",
-        revision: 1,
-        createdAt: now,
-        updatedAt: now,
-        nextAttemptAt: exactReviewQueueDebouncedAttemptAt(state, decision, now, now, env),
-        attempts: 0,
-      };
-    }
+    refreshExactReviewPublicationItem(state, item, now, env);
     changed = true;
   }
   return changed;
+}
+
+function refreshExactReviewPublicationItem(
+  state: ExactReviewQueueState,
+  item: ExactReviewQueueItem,
+  now: number,
+  env,
+) {
+  const publication = item.decision.publication;
+  if (!publication) throw new Error(`publication metadata missing for ${item.key}`);
+  delete state.items[item.key];
+  const decision: ExactReviewDecision = {
+    ...publication.producerDecision,
+    sourceAction:
+      publication.producerDecision.sourceAction === FAILED_REVIEW_SHARD_RECOVERY_SOURCE_ACTION
+        ? FAILED_REVIEW_SHARD_RECOVERY_SOURCE_ACTION
+        : EXACT_REVIEW_ARTIFACT_RETENTION_RECOVERY_SOURCE_ACTION,
+    supersedesInProgress: true,
+  };
+  const recoveryKey = exactReviewItemKey(decision);
+  const current = state.items[recoveryKey];
+  if (current) {
+    if (current.state === "pending" || current.state === "parked") {
+      current.decision = mergePendingExactReviewDecision(current.decision, decision);
+      current.state = "pending";
+      current.parkedReason = undefined;
+    } else {
+      return;
+    }
+    current.revision += 1;
+    current.updatedAt = now;
+    current.nextAttemptAt = exactReviewQueueDebouncedAttemptAt(
+      state,
+      current.decision,
+      now,
+      current.createdAt,
+      env,
+    );
+    current.attempts = 0;
+    current.publicationFailureAttempts = 0;
+    current.firstFailureAt = undefined;
+    current.lastFailureReason = undefined;
+    return;
+  }
+  // Refresh is the terminal recovery for an unusable artifact. It must not be
+  // shed after deleting the only durable publication reference.
+  state.items[recoveryKey] = {
+    key: recoveryKey,
+    decision,
+    state: "pending",
+    revision: 1,
+    createdAt: now,
+    updatedAt: now,
+    nextAttemptAt: exactReviewQueueDebouncedAttemptAt(state, decision, now, now, env),
+    attempts: 0,
+  };
 }
 
 function exactReviewQueueEnqueueAttemptAt(state: ExactReviewQueueState, now: number) {
@@ -2246,8 +3371,14 @@ function exactReviewQueueStats(
   heartbeatGraceMs = DEFAULT_EXACT_REVIEW_HEARTBEAT_GRACE_MS,
 ) {
   const items = Object.values(state.items);
+  const handoffItems = items.filter(
+    (item): item is ExactReviewQueueItem & { state: "pending" | "dispatching" | "leased" } =>
+      item.state !== "parked",
+  );
   const handoffHealth = summarizeExactReviewHandoff({
-    items,
+    // Parked poison items are reported by publication health and cannot take a
+    // handoff lease, so they must not be mislabeled as an unknown handoff phase.
+    items: handoffItems,
     dispatcher: state.dispatcher,
     shedSinceReset: exactReviewShedSinceReset(state),
     now,
@@ -2262,6 +3393,7 @@ function exactReviewQueueStats(
       pending: number;
       dispatching: number;
       leased: number;
+      parked: number;
       oldest_pending_at: number | null;
     }
   >();
@@ -2272,6 +3404,7 @@ function exactReviewQueueStats(
       pending: 0,
       dispatching: 0,
       leased: 0,
+      parked: 0,
       oldest_pending_at: null,
     };
     if (item.state === "pending") {
@@ -2282,8 +3415,10 @@ function exactReviewQueueStats(
           : Math.min(current.oldest_pending_at, item.createdAt);
     } else if (item.state === "dispatching") {
       current.dispatching += 1;
-    } else {
+    } else if (item.state === "leased") {
       current.leased += 1;
+    } else {
+      current.parked += 1;
     }
     targets.set(targetRepo, current);
   }
@@ -2359,8 +3494,11 @@ function exactReviewQueueLaneStats(
   shedSinceReset = 0,
 ) {
   const pendingItems = items.filter((item) => item.state === "pending");
+  const readyItems = pendingItems.filter((item) => item.nextAttemptAt <= now);
+  const backoffItems = pendingItems.filter((item) => item.nextAttemptAt > now);
   const dispatchingItems = items.filter((item) => item.state === "dispatching");
   const leasedItems = items.filter((item) => item.state === "leased");
+  const parkedItems = items.filter((item) => item.state === "parked");
   const active = dispatchingItems.length + leasedItems.length;
   const oldestPendingAt = pendingItems.reduce<number | null>(
     (oldest, item) => (oldest === null ? item.createdAt : Math.min(oldest, item.createdAt)),
@@ -2371,6 +3509,14 @@ function exactReviewQueueLaneStats(
     .sort(
       (left, right) => left.createdAt - right.createdAt || left.key.localeCompare(right.key),
     )[0]?.key;
+  const oldestReadyAt = readyItems.reduce<number | null>(
+    (oldest, item) => (oldest === null ? item.createdAt : Math.min(oldest, item.createdAt)),
+    null,
+  );
+  const oldestBackoffAt = backoffItems.reduce<number | null>(
+    (oldest, item) => (oldest === null ? item.createdAt : Math.min(oldest, item.createdAt)),
+    null,
+  );
   const nextAttemptAt = pendingItems.reduce<number | null>(
     (next, item) => (next === null ? item.nextAttemptAt : Math.min(next, item.nextAttemptAt)),
     null,
@@ -2379,10 +3525,11 @@ function exactReviewQueueLaneStats(
     pending: pendingItems.length,
     pending_depth: pendingItems.length,
     shed_since_reset: shedSinceReset,
-    ready: pendingItems.filter((item) => item.nextAttemptAt <= now).length,
-    backoff: pendingItems.filter((item) => item.nextAttemptAt > now).length,
+    ready: readyItems.length,
+    backoff: backoffItems.length,
     dispatching: dispatchingItems.length,
     leased: leasedItems.length,
+    parked: parkedItems.length,
     capacity,
     active,
     available_slots: Math.max(0, capacity - active),
@@ -2390,8 +3537,44 @@ function exactReviewQueueLaneStats(
     oldest_pending_age_seconds:
       oldestPendingAt === null ? null : Math.max(0, Math.floor((now - oldestPendingAt) / 1_000)),
     oldest_pending_key: oldestPendingKey ?? null,
+    oldest_ready_at: oldestReadyAt === null ? null : new Date(oldestReadyAt).toISOString(),
+    oldest_ready_age_seconds:
+      oldestReadyAt === null ? null : Math.max(0, Math.floor((now - oldestReadyAt) / 1_000)),
+    oldest_backoff_at: oldestBackoffAt === null ? null : new Date(oldestBackoffAt).toISOString(),
+    oldest_backoff_age_seconds:
+      oldestBackoffAt === null ? null : Math.max(0, Math.floor((now - oldestBackoffAt) / 1_000)),
     next_attempt_at: nextAttemptAt === null ? null : new Date(nextAttemptAt).toISOString(),
   };
+}
+
+function exactReviewPublicationHealth(
+  lane: ReturnType<typeof exactReviewQueueLaneStats>,
+  flow: { last_15_minutes: { net_drain_rate_per_hour: number } },
+  deadLetters: { open: number },
+) {
+  const oldestAge = Number(lane.oldest_pending_age_seconds || 0);
+  if (lane.parked > 0 || oldestAge >= 6 * 60 * 60) {
+    return {
+      status: "critical",
+      reason: lane.parked > 0 ? "dead_letter_capacity" : "oldest_pending_over_6h",
+    };
+  }
+  if (
+    deadLetters.open > 0 ||
+    oldestAge >= 60 * 60 ||
+    (lane.pending >= 100 && flow.last_15_minutes.net_drain_rate_per_hour <= 0)
+  ) {
+    return {
+      status: "degraded",
+      reason:
+        deadLetters.open > 0
+          ? "open_dead_letters"
+          : oldestAge >= 60 * 60
+            ? "oldest_pending_over_1h"
+            : "not_draining",
+    };
+  }
+  return { status: lane.pending || lane.active ? "healthy" : "idle", reason: null };
 }
 
 export function exactReviewQueueNextWakeAt(
@@ -2456,10 +3639,19 @@ export function exactReviewQueueNextWakeAt(
     if (item.state === "pending") {
       if (dispatcherPaused) return [dispatcherRetryAt];
       if (exactReviewQueueIsPublication(item)) {
-        const blockedUntil =
-          activePublishers.length >= publicationCapacity && activePublisherWakeAt.length
-            ? Math.min(...activePublisherWakeAt)
-            : item.nextAttemptAt;
+        let blockedUntil = item.nextAttemptAt;
+        if (activePublishers.length >= publicationCapacity) {
+          const capacityWakeAt = [...activePublisherWakeAt];
+          if (publicationCapacity <= 0) {
+            // A zero publication budget is normally caused by active reviews
+            // consuming the shared worker budget. Their leases, rather than a
+            // one-second alarm loop, determine when a slot can become available.
+            capacityWakeAt.push(...activeReviewWakeAt);
+          }
+          blockedUntil = capacityWakeAt.length
+            ? Math.min(...capacityWakeAt)
+            : now + DEFAULT_EXACT_REVIEW_RETRY_MS;
+        }
         return [Math.max(item.nextAttemptAt, blockedUntil)];
       }
       const target = item.decision.targetRepo;
@@ -2486,7 +3678,7 @@ export function exactReviewQueueNextWakeAt(
     );
     return leaseExpiresAt ? [leaseExpiresAt] : [];
   });
-  if (!times.length) return now + DEFAULT_EXACT_REVIEW_RETRY_MS;
+  if (!times.length) return null;
   return Math.max(now + 1_000, Math.min(...times));
 }
 
@@ -2502,9 +3694,11 @@ export function exactReviewQueueCapacity(env) {
 
 export function exactReviewPublicationCapacity(
   env,
-  readyBacklog = 0,
+  outstandingBacklog = 0,
   activePublishers = 0,
   capacityCeiling = Number.POSITIVE_INFINITY,
+  oldestPendingAgeMs = 0,
+  netDrainRatePerHour = Number.POSITIVE_INFINITY,
 ) {
   const maximum = exactReviewPublicationMaximum(env);
   const minimum = exactReviewPublicationMinimum(env, maximum);
@@ -2513,9 +3707,18 @@ export function exactReviewPublicationCapacity(
     minimum,
     Math.min(maximum, Number.isFinite(Number(capacityCeiling)) ? Number(capacityCeiling) : maximum),
   );
-  const scaleSteps = Math.floor(
-    Math.max(0, Number(readyBacklog) || 0) / EXACT_REVIEW_PUBLICATION_READY_PER_SCALE_STEP,
-  );
+  const backlog = Math.max(0, Number(outstandingBacklog) || 0);
+  const oldestAge = Math.max(0, Number(oldestPendingAgeMs) || 0);
+  let scaleSteps = 0;
+  if (
+    backlog >= 100 ||
+    oldestAge >= 60 * 60 * 1000 ||
+    (backlog >= 50 && Number(netDrainRatePerHour) <= 0)
+  ) {
+    scaleSteps += 1;
+  }
+  if (backlog >= 250 || oldestAge >= 4 * 60 * 60 * 1000) scaleSteps += 1;
+  if (backlog >= 400 || oldestAge >= 8 * 60 * 60 * 1000) scaleSteps += 1;
   const desired = Math.min(
     adaptiveMaximum,
     base + scaleSteps * EXACT_REVIEW_PUBLICATION_CONCURRENT_SCALE_STEP,
@@ -2583,6 +3786,7 @@ function exactReviewPublicationControl(env, value: unknown): ExactReviewPublicat
   const maximum = exactReviewPublicationMaximum(env);
   const minimum = exactReviewPublicationMinimum(env, maximum);
   const rawCeiling = Number(control.capacityCeiling);
+  const rawDemandCapacity = Number(control.demandCapacity);
   const rawCooldown = Number(control.cooldownUntil);
   const rawRecoverySuccesses = Number(control.recoverySuccesses);
   const rawLastFailureAt = Number(control.lastFailureAt);
@@ -2591,11 +3795,18 @@ function exactReviewPublicationControl(env, value: unknown): ExactReviewPublicat
     capacityCeiling: Number.isSafeInteger(rawCeiling)
       ? Math.max(minimum, Math.min(maximum, rawCeiling))
       : maximum,
+    demandCapacity: Number.isSafeInteger(rawDemandCapacity)
+      ? Math.max(minimum, Math.min(maximum, rawDemandCapacity))
+      : exactReviewPublicationBase(env, maximum),
     cooldownUntil: Number.isSafeInteger(rawCooldown) && rawCooldown > 0 ? rawCooldown : 0,
     recoverySuccesses:
       Number.isSafeInteger(rawRecoverySuccesses) && rawRecoverySuccesses > 0
         ? rawRecoverySuccesses
         : 0,
+    demandSamples: Math.max(0, Number(control.demandSamples) || 0),
+    demandTier: Math.max(0, Number(control.demandTier) || 0),
+    lastDemandSampleAt: Math.max(0, Number(control.lastDemandSampleAt) || 0),
+    lastScaleAt: Math.max(0, Number(control.lastScaleAt) || 0),
     ...(Number.isSafeInteger(rawLastFailureAt) && rawLastFailureAt > 0
       ? { lastFailureAt: rawLastFailureAt }
       : {}),
@@ -2618,6 +3829,7 @@ function exactReviewPublicationControlAfterFeedback(
       ? Math.max(minimum, Math.floor(currentCapacity / 2))
       : Math.max(minimum, currentCapacity - EXACT_REVIEW_PUBLICATION_CONCURRENT_SCALE_STEP);
     return {
+      ...control,
       capacityCeiling: ceiling,
       cooldownUntil: Math.max(
         control.cooldownUntil,
@@ -2648,6 +3860,79 @@ function exactReviewPublicationControlAfterFeedback(
   };
 }
 
+function exactReviewPublicationControlAfterDemand(
+  env,
+  control: ExactReviewPublicationControl,
+  sample: {
+    at: number;
+    backlog: number;
+    oldestPendingAgeMs: number;
+    netDrainRatePerHour: number;
+  },
+) {
+  if (sample.at < control.lastDemandSampleAt + EXACT_REVIEW_PUBLICATION_DEMAND_SAMPLE_MS) {
+    return control;
+  }
+  const maximum = exactReviewPublicationMaximum(env);
+  const base = exactReviewPublicationBase(env, maximum);
+  const desired = exactReviewPublicationCapacity(
+    env,
+    sample.backlog,
+    0,
+    maximum,
+    sample.oldestPendingAgeMs,
+    sample.netDrainRatePerHour,
+  );
+  const desiredTier = Math.max(
+    0,
+    Math.ceil((desired - base) / EXACT_REVIEW_PUBLICATION_CONCURRENT_SCALE_STEP),
+  );
+  const sameDirection = control.demandTier === desiredTier;
+  const demandSamples = sameDirection ? control.demandSamples + 1 : 1;
+  const next = {
+    ...control,
+    demandSamples,
+    demandTier: desiredTier,
+    lastDemandSampleAt: sample.at,
+  };
+  if (
+    desired > control.demandCapacity &&
+    demandSamples >= 2 &&
+    sample.at >= control.lastScaleAt + EXACT_REVIEW_PUBLICATION_SCALE_UP_MS
+  ) {
+    return {
+      ...next,
+      demandCapacity: Math.min(
+        desired,
+        control.demandCapacity + EXACT_REVIEW_PUBLICATION_CONCURRENT_SCALE_STEP,
+      ),
+      demandSamples: 0,
+      lastScaleAt: sample.at,
+    };
+  }
+  const healthyDrain =
+    sample.backlog < 80 &&
+    sample.oldestPendingAgeMs < 30 * 60 * 1000 &&
+    sample.netDrainRatePerHour > 0;
+  if (
+    desired < control.demandCapacity &&
+    healthyDrain &&
+    demandSamples >= 6 &&
+    sample.at >= control.lastScaleAt + EXACT_REVIEW_PUBLICATION_SCALE_DOWN_MS
+  ) {
+    return {
+      ...next,
+      demandCapacity: Math.max(
+        base,
+        control.demandCapacity - EXACT_REVIEW_PUBLICATION_CONCURRENT_SCALE_STEP,
+      ),
+      demandSamples: 0,
+      lastScaleAt: sample.at,
+    };
+  }
+  return next;
+}
+
 function exactReviewPublicationControlStatus(env, control: ExactReviewPublicationControl) {
   const maximum = exactReviewPublicationMaximum(env);
   return {
@@ -2656,6 +3941,10 @@ function exactReviewPublicationControlStatus(env, control: ExactReviewPublicatio
     base: exactReviewPublicationBase(env, maximum),
     maximum,
     ceiling: control.capacityCeiling,
+    demand_capacity: control.demandCapacity,
+    demand_samples: control.demandSamples,
+    demand_tier: control.demandTier,
+    last_scale_at: control.lastScaleAt ? new Date(control.lastScaleAt).toISOString() : null,
     cooldown_until:
       control.cooldownUntil > 0 ? new Date(control.cooldownUntil).toISOString() : null,
     recovery_successes: control.recoverySuccesses,
@@ -2673,20 +3962,41 @@ function exactReviewPublicationCapacityForState(
   now: number,
   capacityCeiling = Number.POSITIVE_INFINITY,
   preserveActive = true,
+  demandCapacity?: number,
 ) {
-  let readyBacklog = 0;
+  let outstandingBacklog = 0;
   let activePublishers = 0;
+  let activeReviews = 0;
+  let oldestPendingAt = Number.POSITIVE_INFINITY;
   for (const item of Object.values(state.items)) {
-    if (!exactReviewQueueIsPublication(item)) continue;
-    if (item.state === "pending" && item.nextAttemptAt <= now) readyBacklog += 1;
-    else if (item.state === "dispatching" || item.state === "leased") activePublishers += 1;
+    if (!exactReviewQueueIsPublication(item)) {
+      if (item.state === "dispatching" || item.state === "leased") activeReviews += 1;
+      continue;
+    }
+    if (item.state === "pending") {
+      outstandingBacklog += 1;
+      oldestPendingAt = Math.min(oldestPendingAt, item.createdAt);
+    } else if (item.state === "dispatching" || item.state === "leased") activePublishers += 1;
   }
-  return exactReviewPublicationCapacity(
-    env,
-    readyBacklog,
-    preserveActive ? activePublishers : 0,
-    capacityCeiling,
+  // Once the hysteresis controller has sampled demand, its target is the
+  // admission decision. Recomputing from backlog alone here would discard the
+  // controller's net-drain signal for the 50-99 item pressure tier.
+  const requested =
+    demandCapacity === undefined
+      ? exactReviewPublicationCapacity(
+          env,
+          outstandingBacklog,
+          preserveActive ? activePublishers : 0,
+          capacityCeiling,
+          Number.isFinite(oldestPendingAt) ? now - oldestPendingAt : 0,
+        )
+      : Math.min(capacityCeiling, demandCapacity);
+  const workerBudget = Math.max(1, numberFrom(env.WORKER_BUDGET, 128));
+  const budgeted = Math.max(
+    0,
+    workerBudget - activeReviews - EXACT_REVIEW_PUBLICATION_ACTIONS_RESERVE,
   );
+  return Math.max(preserveActive ? activePublishers : 0, Math.min(requested, budgeted));
 }
 
 function exactReviewTargetCapacity(env) {

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -455,10 +455,25 @@ export default {
       return exactReviewQueueRequest(env, "/complete", request);
     if (url.pathname === "/internal/exact-review/claimed-runs" && request.method === "POST")
       return authenticatedExactReviewQueueRequest(request, env, "/claimed-runs");
+    if (url.pathname === "/internal/exact-review/dead-letters/list" && request.method === "POST")
+      return authenticatedExactReviewQueueRequest(request, env, "/dead-letters/list");
+    if (url.pathname === "/internal/exact-review/dead-letters/replay" && request.method === "POST")
+      return authenticatedExactReviewQueueRequest(request, env, "/dead-letters/replay");
+    if (url.pathname === "/internal/exact-review/dead-letters/resolve" && request.method === "POST")
+      return authenticatedExactReviewQueueRequest(request, env, "/dead-letters/resolve");
+    if (url.pathname === "/internal/exact-review/publications/list" && request.method === "POST")
+      return authenticatedExactReviewQueueRequest(request, env, "/publications/list");
+    if (
+      url.pathname === "/internal/exact-review/publications/supersede" &&
+      request.method === "POST"
+    )
+      return authenticatedExactReviewQueueRequest(request, env, "/publications/supersede");
     if (url.pathname === "/internal/exact-review/reconcile" && request.method === "POST")
       return authenticatedExactReviewReconcile(request, env);
     if (url.pathname === "/api/exact-review-queue" && request.method === "GET")
       return exactReviewQueueRequest(env, "/stats");
+    if (url.pathname === "/api/exact-review-queue/item" && request.method === "GET")
+      return exactReviewQueueRequest(env, `/item-status?${url.searchParams.toString()}`);
     if (url.pathname === "/api/health-history" && request.method === "GET")
       return healthHistoryJson(request, env);
     if (url.pathname === "/api/status") return statusJson(request, env, ctx);
@@ -8399,24 +8414,51 @@ function renderExactReviewLanes(queue) {
     const oldest = Number.isFinite(lane.oldest_pending_age_seconds)
       ? " · oldest " + elapsed(lane.oldest_pending_age_seconds * 1000)
       : "";
+    const oldestReady = Number.isFinite(lane.oldest_ready_age_seconds)
+      ? " · oldest ready " + elapsed(lane.oldest_ready_age_seconds * 1000)
+      : "";
+    const oldestBackoff = Number.isFinite(lane.oldest_backoff_age_seconds)
+      ? " · oldest backoff " + elapsed(lane.oldest_backoff_age_seconds * 1000)
+      : "";
     const publicationControl = laneKey === "publication" ? lane.capacity_control : null;
+    const cooldown = publicationControl?.cooldown_until
+      ? " · cooldown until " + new Date(publicationControl.cooldown_until).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
+      : "";
     const capacityNote = publicationControl?.mode === "throttled"
-      ? " · adaptive ceiling " + fmt.format(publicationControl.ceiling || capacity) + " after " +
+      ? " · target " + fmt.format(publicationControl.demand_capacity || capacity) + " · pressure ceiling " + fmt.format(publicationControl.ceiling || capacity) + " after " +
         (publicationControl.last_failure_kind === "github_rate_limit" ? "GitHub rate limit" : "GitHub 5xx")
       : laneKey === "publication"
-        ? " · adaptive " + fmt.format(publicationControl?.base || 24) + "–" + fmt.format(publicationControl?.maximum || capacity)
+        ? " · target " + fmt.format(publicationControl?.demand_capacity || capacity) + " · adaptive " + fmt.format(publicationControl?.base || 24) + "–" + fmt.format(publicationControl?.maximum || capacity)
         : "";
+    const flow = laneKey === "publication" ? lane.flow?.last_15_minutes : null;
+    const rate = value => Number.isFinite(Number(value)) ? fmt.format(Number(value)) + "/h" : "n/a";
+    const flowSummary = flow
+      ? '<div class="lane-counts">' +
+        '<div class="lane-count"><span>Arrival</span><strong>' + rate(flow.arrival_rate_per_hour) + '</strong></div>' +
+        '<div class="lane-count"><span>Terminal resolved</span><strong>' + rate(flow.resolved_rate_per_hour) + '</strong></div>' +
+        '<div class="lane-count"><span>Published</span><strong>' + rate(flow.published_rate_per_hour) + '</strong></div>' +
+        '<div class="lane-count"><span>Superseded</span><strong>' + rate(flow.superseded_rate_per_hour) + '</strong></div>' +
+        '<div class="lane-count"><span>Retried</span><strong>' + rate(flow.retried_rate_per_hour) + '</strong></div>' +
+        '<div class="lane-count"><span>Dead-lettered</span><strong>' + rate(flow.dead_lettered_rate_per_hour) + '</strong></div></div>'
+      : '';
+    const deadLetters = laneKey === "publication" ? lane.dead_letters : null;
+    const deadLetterNote = deadLetters
+      ? " · DLQ " + fmt.format(deadLetters.open || 0) +
+        (deadLetters.oldest_failed_at ? " · oldest DLQ " + since(deadLetters.oldest_failed_at) : "") +
+        " · retry amplification " + (flow?.retry_amplification == null ? "n/a" : Number(flow.retry_amplification).toFixed(2))
+      : "";
     return '<div class="exact-lane"><div class="exact-lane-head"><strong>' + esc(label) + '</strong><span>' + fmt.format(active) + ' of ' + fmt.format(capacity) + ' active</span></div>' +
       '<div class="lane-count"><span>Pending</span><strong>' + fmt.format(lane.pending || 0) + '</strong></div>' +
       exactReviewTrend(samples, label) +
       laneSpeedTrend(samples, speedLabel, rateHelp[laneKey]) +
+      flowSummary +
       '<div class="lane-counts">' +
       '<div class="lane-count"><span>Ready</span><strong>' + fmt.format(lane.ready || 0) + '</strong></div>' +
       '<div class="lane-count"><span>Backoff</span><strong>' + fmt.format(lane.backoff || 0) + '</strong></div>' +
       '<div class="lane-count"><span>Dispatching</span><strong>' + fmt.format(lane.dispatching || 0) + '</strong></div>' +
       '<div class="lane-count"><span>Leased</span><strong>' + fmt.format(lane.leased || 0) + '</strong></div></div>' +
       '<div class="lane-bar"><i style="width:' + used + '%"></i></div>' +
-      '<div class="lane-foot">' + fmt.format(lane.available_slots || 0) + ' ' + esc(label.toLowerCase()) + ' slots open' + esc(oldest + capacityNote) + '</div></div>';
+      '<div class="lane-foot">' + fmt.format(lane.available_slots || 0) + ' ' + esc(label.toLowerCase()) + ' slots open' + esc(oldest + oldestReady + oldestBackoff + capacityNote + cooldown + deadLetterNote) + '</div></div>';
   }).join("");
 }
 function renderExactReviewHandoff(queue) {

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -184,8 +184,15 @@ publication work bypass the delay. When pending depth reaches
 `EXACT_REVIEW_PENDING_SOFT_LIMIT` (300 by default), new recovery-only work is
 shed; existing items, webhook events, commands, and publications remain admitted.
 
-Exact-review result publication has a separate 24-workflow Actions lane. Its
-checkout, artifact handling, comment sync, and result routing are deterministic
+Exact-review result publication has a separate adaptive Actions lane. It starts
+at 24 and rises in steps of 8 up to 48 when ready-plus-backoff demand, oldest
+age, or the 15-minute net drain rate shows sustained pressure. Scale-up requires
+two five-minute samples and is limited to one step per ten minutes; healthy
+scale-down requires 30 minutes below 80 pending. GitHub rate limits halve the
+pressure ceiling for at least 15 minutes, while transient GitHub failures reduce
+it by 8 for at least five minutes. Admission also leaves 16 slots inside
+`WORKER_BUDGET` after active exact reviews. Its checkout, artifact handling,
+comment sync, and result routing are deterministic
 control-plane work: they consume GitHub runners, but not Codex slots. The
 comment router and the singleton lease reconciler follow the same accounting
 rule. Dashboard Codex capacity therefore counts only jobs whose steps execute
@@ -217,6 +224,16 @@ heartbeat, `EXACT_REVIEW_HEARTBEAT_GRACE_MS` bounds liveness to 20 minutes by de
 never extending the original 130-minute execution lease. Leases created before heartbeat
 support was deployed retain their original execution expiry. This keeps capacity waiting and
 retry state out of GitHub Actions runners.
+
+Publication completion distinguishes durable publishes from results superseded
+by a newer or closed remote tuple. Superseded publications terminate without a
+GitHub mutation and do not count as successful publishes. GitHub/transient
+failures retry for at most 12 attempts or 24 hours; deterministic permanent
+failures receive two confirmation retries before entering the bounded
+dead-letter store. An artifact unavailable for three attempts atomically queues
+one fresh review. Public queue status reports publish, supersede, retry, refresh,
+and dead-letter totals separately; signed internal endpoints list, replay,
+resolve, and exact-revision supersede records without exposing decisions publicly.
 
 Examples with the current config:
 

--- a/src/repair/publish-event-result.ts
+++ b/src/repair/publish-event-result.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import fs from "node:fs";
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
   applyEventSnapshot,
   applyEventSnapshotIfCurrent,
@@ -53,6 +54,8 @@ type EventOptions = {
 };
 
 type PublishedEventSnapshot = {
+  completionKind: "published" | "superseded";
+  reasonCode: "publication_applied" | "remote_newer_tuple" | "remote_closed";
   guardedOpenAction: string | null;
   policyNoop: boolean;
   requeueLatest: boolean;
@@ -68,9 +71,32 @@ class RoutableSyncPublishRaceError extends Error {}
 class SourceDriftPublishRaceError extends Error {}
 class TerminalClosedPublishRaceError extends Error {}
 class TerminalMissingPublishRaceError extends Error {}
+class PublicationResultError extends Error {
+  constructor(
+    readonly reasonCode:
+      | "missing_record_tuple"
+      | "tuple_protocol_invalid"
+      | "policy_invariant"
+      | "unknown_failure",
+    message: string,
+  ) {
+    super(message);
+  }
+}
 
 const options = eventOptionsFromEnv();
-await publishEventResult(options);
+try {
+  await publishEventResult(options);
+} catch (error) {
+  const reasonCode =
+    error instanceof PublicationResultError
+      ? error.reasonCode
+      : error instanceof RecordTupleError
+        ? "tuple_protocol_invalid"
+        : "unknown_failure";
+  writePublicationCompletionOutputs("permanent_failure", reasonCode, errorFingerprint(error));
+  throw error;
+}
 
 async function publishEventResult(options: EventOptions): Promise<void> {
   validateTargetRepo(options.targetRepo);
@@ -147,6 +173,12 @@ async function publishEventResult(options: EventOptions): Promise<void> {
     // `requeue_latest` hands remote-newer to the source-drift requeue step,
     // which reviews the LATEST revision.
     writeStaleEventDispositionOutputs(disposition);
+    if (preflightResult !== "missing") {
+      writePublicationCompletionOutputs(
+        "superseded",
+        preflightResult === "remote-closed" ? "remote_closed" : "remote_newer_tuple",
+      );
+    }
     return;
   }
 
@@ -311,7 +343,10 @@ function publishSnapshot({
     paths.decisionPacket,
   ];
   try {
-    const complete = (candidateApplied: boolean): PublishedEventSnapshot => {
+    const complete = (
+      candidateApplied: boolean,
+      supersededReason?: "remote_newer_tuple" | "remote_closed",
+    ): PublishedEventSnapshot => {
       // The reconciliation push can succeed just before another publisher
       // advances the same tuple. Refresh from the authoritative remote before
       // emitting any completion output; the workflow never routes an ordinary
@@ -330,6 +365,8 @@ function publishSnapshot({
       });
       const published = {
         ...disposition,
+        completionKind: supersededReason ? ("superseded" as const) : ("published" as const),
+        reasonCode: supersededReason || ("publication_applied" as const),
         policyNoop: disposition.guardedOpenAction === "skipped_same_author_pair",
         requeueLatest:
           requeueLatestExpected && candidateMatchesCurrentTuple && candidateTupleState === "open",
@@ -341,6 +378,10 @@ function publishSnapshot({
           requeueLatestExpected,
         }),
       };
+      if (supersededReason) {
+        summary();
+        return published;
+      }
       if (routableSyncExpected && !published.routableSyncVerified) {
         throw new RoutableSyncPublishRaceError(
           `Durable review sync for ${paths.targetSlug}#${options.itemNumber} lost the publish race; requeue against the latest item revision`,
@@ -381,17 +422,19 @@ function publishSnapshot({
       console.log(
         `Remote already has closed record for ${paths.targetSlug}#${options.itemNumber}; skipping open-record publish`,
       );
-      return complete(false);
+      return complete(false, "remote_closed");
     }
     if (snapshotResult === "remote-newer") {
       console.log(
         `Remote has newer record tuple for ${paths.targetSlug}#${options.itemNumber}; skipping stale event publish`,
       );
-      return complete(false);
+      return complete(false, "remote_newer_tuple");
     }
     if (snapshotResult === "missing") {
-      console.log(`No event record snapshot for ${paths.targetSlug}#${options.itemNumber}`);
-      return complete(false);
+      throw new PublicationResultError(
+        "missing_record_tuple",
+        `No event record snapshot for ${paths.targetSlug}#${options.itemNumber}`,
+      );
     }
 
     syncPublishPaths(commitPaths);
@@ -505,6 +548,8 @@ function writeEventDispositionOutputs(published: PublishedEventSnapshot): void {
   fs.appendFileSync(
     outputPath,
     [
+      `completion_kind=${published.completionKind}`,
+      `reason_code=${published.reasonCode}`,
       `remote_tuple_verified=${published.remoteTupleVerified ? "true" : "false"}`,
       `terminal_missing=${published.terminalMissing ? "true" : "false"}`,
       `terminal_closed=${published.terminalClosed ? "true" : "false"}`,
@@ -517,6 +562,36 @@ function writeEventDispositionOutputs(published: PublishedEventSnapshot): void {
     ].join("\n"),
     "utf8",
   );
+}
+
+function writePublicationCompletionOutputs(
+  completionKind: "superseded" | "permanent_failure",
+  reasonCode:
+    | "remote_newer_tuple"
+    | "remote_closed"
+    | "missing_record_tuple"
+    | "tuple_protocol_invalid"
+    | "policy_invariant"
+    | "unknown_failure",
+  fingerprint?: string,
+): void {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) return;
+  fs.appendFileSync(
+    outputPath,
+    [
+      `completion_kind=${completionKind}`,
+      `reason_code=${reasonCode}`,
+      ...(fingerprint ? [`error_fingerprint=${fingerprint}`] : []),
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
+function errorFingerprint(error: unknown): string {
+  const message = error instanceof Error ? `${error.name}:${error.message}` : String(error);
+  return `sha256:${createHash("sha256").update(message).digest("hex")}`;
 }
 
 function validateTargetRepo(targetRepo: string): void {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -93,15 +93,18 @@ test("automerge reliability summarizes failures, recovery, duration, and stalled
 
 test("exact-review publication scales bounded capacity with ready backlog", () => {
   assert.equal(exactReviewPublicationCapacity({}), 24);
-  assert.equal(exactReviewPublicationCapacity({}, 249), 24);
-  assert.equal(exactReviewPublicationCapacity({}, 250), 32);
-  assert.equal(exactReviewPublicationCapacity({}, 500), 40);
-  assert.equal(exactReviewPublicationCapacity({}, 750), 48);
+  assert.equal(exactReviewPublicationCapacity({}, 99), 24);
+  assert.equal(exactReviewPublicationCapacity({}, 100), 32);
+  assert.equal(exactReviewPublicationCapacity({}, 249), 32);
+  assert.equal(exactReviewPublicationCapacity({}, 250), 40);
+  assert.equal(exactReviewPublicationCapacity({}, 400), 48);
   assert.equal(exactReviewPublicationCapacity({}, 2_000), 48);
   assert.equal(exactReviewPublicationCapacity({}, 0, 40), 40);
-  assert.equal(exactReviewPublicationCapacity({}, 750, 0, 32), 32);
-  assert.equal(exactReviewPublicationCapacity({}, 750, 0, 8), 8);
-  assert.equal(exactReviewPublicationCapacity({}, 750, 40, 24), 40);
+  assert.equal(exactReviewPublicationCapacity({}, 400, 0, 32), 32);
+  assert.equal(exactReviewPublicationCapacity({}, 400, 0, 8), 8);
+  assert.equal(exactReviewPublicationCapacity({}, 400, 40, 24), 40);
+  assert.equal(exactReviewPublicationCapacity({}, 0, 0, 48, 60 * 60_000), 32);
+  assert.equal(exactReviewPublicationCapacity({}, 50, 0, 48, 0, 0), 32);
   assert.equal(
     exactReviewPublicationCapacity({ EXACT_REVIEW_PUBLICATION_MAX_CONCURRENT: "12" }),
     12,
@@ -112,7 +115,7 @@ test("exact-review publication scales bounded capacity with ready backlog", () =
         EXACT_REVIEW_PUBLICATION_BASE_CONCURRENT: "16",
         EXACT_REVIEW_PUBLICATION_MAX_CONCURRENT: "32",
       },
-      500,
+      250,
     ),
     32,
   );
@@ -123,6 +126,49 @@ test("exact-review publication scales bounded capacity with ready backlog", () =
     }),
     16,
   );
+});
+
+test("exact-review publication admission applies the hysteresis controller demand target", async () => {
+  const originalNow = Date.now;
+  const now = Date.parse("2026-07-16T12:00:00.000Z");
+  Date.now = () => now;
+  try {
+    const storage = new MemoryDurableStorage();
+    const queue = new ExactReviewQueue({ storage }, {});
+    for (let index = 0; index < 50; index += 1) {
+      const number = 10_000 + index;
+      const response = await queue.fetch(
+        buildExactReviewQueueRequest(
+          `publication-demand-${number}`,
+          number,
+          "exact_review_artifact_publish",
+          "issue",
+          undefined,
+          exactReviewPublicationOverrides(number, String(number * 10)),
+        ),
+      );
+      assert.equal(response.status, 202);
+    }
+    await storage.put("exact-review-publication-control:v1", {
+      capacityCeiling: 48,
+      demandCapacity: 32,
+      cooldownUntil: 0,
+      recoverySuccesses: 0,
+      demandSamples: 0,
+      demandTier: 1,
+      lastDemandSampleAt: now,
+      lastScaleAt: now,
+    });
+
+    const stats = await (
+      await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+    ).json();
+    assert.equal(stats.lanes.publication.pending, 50);
+    assert.equal(stats.lanes.publication.capacity_control.demand_capacity, 32);
+    assert.equal(stats.lanes.publication.capacity, 32);
+  } finally {
+    Date.now = originalNow;
+  }
 });
 
 test("exact-review queue debounces fresh work and caps pending revision extensions", async () => {
@@ -611,6 +657,22 @@ test("exact-review queue admits and wakes up to 24 publishers", () => {
   const wakeState = { items: { [active.key]: active, [pending.key]: pending } } as never;
   assert.equal(exactReviewQueueNextWakeAt(wakeState, now, 64, 60, 24), now + 1_000);
   assert.equal(exactReviewQueueNextWakeAt(wakeState, now, 64, 60, 1), now + 60_000);
+
+  const activeReview = {
+    key: "openclaw/openclaw#3",
+    state: "leased",
+    nextAttemptAt: now,
+    leaseExpiresAt: now + 45_000,
+    decision: { sourceAction: "opened", targetRepo: "openclaw/openclaw" },
+  };
+  const budgetBlockedState = {
+    items: { [activeReview.key]: activeReview, [pending.key]: pending },
+  } as never;
+  assert.equal(exactReviewQueueNextWakeAt(budgetBlockedState, now, 64, 60, 0), now + 45_000);
+  assert.equal(
+    exactReviewQueueNextWakeAt({ items: { [pending.key]: pending } } as never, now, 64, 60, 0),
+    now + 30_000,
+  );
 });
 
 test("dashboard status reads the exact-review handoff model from the durable queue", async () => {
@@ -4265,6 +4327,10 @@ test("exact-review publication capacity backs off on GitHub pressure and recover
       base: 24,
       maximum: 48,
       ceiling: 12,
+      demand_capacity: 24,
+      demand_samples: 1,
+      demand_tier: 0,
+      last_scale_at: null,
       cooldown_until: "2026-07-16T08:15:00.000Z",
       recovery_successes: 0,
       last_failure_at: "2026-07-16T08:00:00.000Z",
@@ -4312,6 +4378,240 @@ test("exact-review publication capacity backs off on GitHub pressure and recover
   } finally {
     Date.now = originalNow;
   }
+});
+
+test("exact-review publication supersedes stale tuples without counting a publish", async () => {
+  const storage = new MemoryDurableStorage();
+  const item = leasedExactReviewPublicationItem(781, "7810");
+  await storage.put("exact-review-queue", { deliveries: {}, items: { [item.key]: item } });
+  const queue = new ExactReviewQueue({ storage }, {});
+
+  const response = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: item.leaseId,
+        item_key: item.key,
+        lease_revision: item.leaseRevision,
+        claim_generation: item.claimGeneration,
+        run_id: item.claimedRunId,
+        run_attempt: item.claimedRunAttempt,
+        outcome: "success",
+        completion_kind: "superseded",
+        reason_code: "remote_newer_tuple",
+      }),
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { ok: true, requeued: false });
+  const state = (await storage.get("exact-review-queue")) as { items: Record<string, unknown> };
+  assert.equal(state.items[item.key], undefined);
+  const stats = await (
+    await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(stats.lanes.publication.completed_total, 1);
+  assert.equal(stats.lanes.publication.published_total, 0);
+  assert.equal(stats.lanes.publication.superseded_total, 1);
+  assert.equal(stats.lanes.publication.flow.last_15_minutes.published_rate_per_hour, 0);
+  assert.equal(stats.lanes.publication.flow.last_15_minutes.superseded_rate_per_hour, 4);
+  assert.equal(stats.lanes.publication.dead_letters.open, 0);
+});
+
+test("exact-review publication dead-letters exhausted permanent failures and replays idempotently", async () => {
+  const storage = new MemoryDurableStorage();
+  const item = leasedExactReviewPublicationItem(782, "7820");
+  item.attempts = 2;
+  Object.assign(item, { publicationFailureAttempts: 2 });
+  item.firstFailureAt = Date.now() - 6 * 60_000;
+  await storage.put("exact-review-queue", { deliveries: {}, items: { [item.key]: item } });
+  const queue = new ExactReviewQueue({ storage }, {});
+
+  const complete = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: item.leaseId,
+        item_key: item.key,
+        lease_revision: item.leaseRevision,
+        claim_generation: item.claimGeneration,
+        run_id: item.claimedRunId,
+        run_attempt: item.claimedRunAttempt,
+        outcome: "failure",
+        completion_kind: "permanent_failure",
+        reason_code: "invalid_artifact",
+        error_fingerprint: "sha256:deadbeef",
+      }),
+    }),
+  );
+  assert.deepEqual(await complete.json(), { ok: true, requeued: false });
+
+  const listed = await (
+    await queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/dead-letters/list", {
+        method: "POST",
+        body: JSON.stringify({ limit: 10 }),
+      }),
+    )
+  ).json();
+  assert.equal(listed.dead_letters.length, 1);
+  assert.equal(listed.dead_letters[0].reason_code, "invalid_artifact");
+  assert.equal(listed.dead_letters[0].attempts, 3);
+  const id = listed.dead_letters[0].dead_letter_id;
+
+  const replay = () =>
+    queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/dead-letters/replay", {
+        method: "POST",
+        body: JSON.stringify({ ids: [id], idempotency_key: "operator:782:v1" }),
+      }),
+    );
+  assert.deepEqual(await (await replay()).json(), {
+    ok: true,
+    replayed: 1,
+    deduped: 0,
+    skipped: 0,
+  });
+  assert.deepEqual(await (await replay()).json(), {
+    ok: true,
+    replayed: 0,
+    deduped: 1,
+    skipped: 0,
+  });
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { state: string; attempts: number }>;
+  };
+  assert.equal(state.items[item.key].state, "pending");
+  assert.equal(state.items[item.key].attempts, 0);
+});
+
+test("exact-review publication refreshes an artifact after its third unavailable attempt", async () => {
+  const storage = new MemoryDurableStorage();
+  const item = leasedExactReviewPublicationItem(783, "7830");
+  item.attempts = 2;
+  Object.assign(item, { publicationFailureAttempts: 2 });
+  await storage.put("exact-review-queue", { deliveries: {}, items: { [item.key]: item } });
+  const queue = new ExactReviewQueue({ storage }, { EXACT_REVIEW_DISPATCH_DEBOUNCE_MS: "0" });
+
+  const response = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: item.leaseId,
+        item_key: item.key,
+        lease_revision: item.leaseRevision,
+        claim_generation: item.claimGeneration,
+        run_id: item.claimedRunId,
+        run_attempt: item.claimedRunAttempt,
+        outcome: "failure",
+        completion_kind: "retryable_failure",
+        reason_code: "artifact_unavailable",
+      }),
+    }),
+  );
+  assert.deepEqual(await response.json(), { ok: true, requeued: false });
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { decision: { sourceAction: string } }>;
+  };
+  assert.equal(state.items[item.key], undefined);
+  assert.equal(
+    state.items["openclaw/openclaw#783"].decision.sourceAction,
+    "artifact_retention_recovery",
+  );
+  const stats = await (
+    await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(stats.lanes.publication.refreshed_total, 1);
+});
+
+test("exact-review publication retry budgets ignore earlier dispatch failures", async () => {
+  const storage = new MemoryDurableStorage();
+  const item = leasedExactReviewPublicationItem(785, "7850");
+  item.attempts = 2;
+  await storage.put("exact-review-queue", { deliveries: {}, items: { [item.key]: item } });
+  const queue = new ExactReviewQueue({ storage }, {});
+
+  const response = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: item.leaseId,
+        item_key: item.key,
+        lease_revision: item.leaseRevision,
+        claim_generation: item.claimGeneration,
+        run_id: item.claimedRunId,
+        run_attempt: item.claimedRunAttempt,
+        outcome: "failure",
+        completion_kind: "permanent_failure",
+        reason_code: "invalid_artifact",
+      }),
+    }),
+  );
+
+  assert.deepEqual(await response.json(), { ok: true, requeued: true });
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { attempts: number; publicationFailureAttempts?: number }>;
+  };
+  assert.equal(state.items[item.key].attempts, 1);
+  assert.equal(state.items[item.key].publicationFailureAttempts, 1);
+  const stats = await (
+    await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(stats.lanes.publication.dead_letters.open, 0);
+});
+
+test("ordinary exact-review retries do not increment publication retry telemetry", async () => {
+  const storage = new MemoryDurableStorage();
+  const item = leasedExactReviewQueueItem(786, "7860");
+  await storage.put("exact-review-queue", { deliveries: {}, items: { [item.key]: item } });
+  const queue = new ExactReviewQueue({ storage }, {});
+
+  const response = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: item.leaseId,
+        item_key: item.key,
+        lease_revision: item.leaseRevision,
+        claim_generation: item.claimGeneration,
+        run_id: item.claimedRunId,
+        run_attempt: item.claimedRunAttempt,
+        outcome: "failure",
+      }),
+    }),
+  );
+
+  assert.deepEqual(await response.json(), { ok: true, requeued: true });
+  const stats = await (
+    await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(stats.lanes.publication.retried_total, 0);
+  assert.equal(stats.lanes.publication.flow.last_15_minutes.retried, 0);
+});
+
+test("exact-review completion rejects incompatible structured dispositions", async () => {
+  const item = leasedExactReviewPublicationItem(784, "7840");
+  const storage = new MemoryDurableStorage();
+  await storage.put("exact-review-queue", { deliveries: {}, items: { [item.key]: item } });
+  const queue = new ExactReviewQueue({ storage }, {});
+  const response = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: item.leaseId,
+        item_key: item.key,
+        lease_revision: item.leaseRevision,
+        claim_generation: item.claimGeneration,
+        run_id: item.claimedRunId,
+        run_attempt: item.claimedRunAttempt,
+        outcome: "failure",
+        completion_kind: "superseded",
+        reason_code: "remote_closed",
+      }),
+    }),
+  );
+  assert.equal(response.status, 400);
+  assert.deepEqual(await response.json(), { error: "completion_outcome_mismatch" });
 });
 
 test("exact-review publication recovery ignores successful source-drift requeues", async () => {
@@ -5558,6 +5858,8 @@ test("dashboard HTML preserves UTF-8 emoji labels", async () => {
   assert.match(html, /id="exact-review-lanes"/);
   assert.match(html, /Review admission/);
   assert.match(html, /Result publication/);
+  assert.match(html, /Net publication rate/);
+  assert.match(html, /Terminal resolved/);
   assert.doesNotMatch(html, /Control Plane · GitHub Actions, not Codex/);
   assert.doesNotMatch(html, /id="control-plane"/);
   assert.match(html, /\.exact-lanes \{ grid-template-columns: 1fr; \}/);
@@ -5679,11 +5981,30 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
           capacity: 24,
           available_slots: 3,
           oldest_pending_age_seconds: 30,
+          oldest_ready_age_seconds: 30,
+          oldest_backoff_age_seconds: 20,
+          flow: {
+            last_15_minutes: {
+              arrival_rate_per_hour: 12,
+              resolved_rate_per_hour: 20,
+              published_rate_per_hour: 4,
+              superseded_rate_per_hour: 16,
+              retried_rate_per_hour: 8,
+              dead_lettered_rate_per_hour: 0,
+              retry_amplification: 0.4,
+            },
+          },
+          dead_letters: {
+            open: 2,
+            oldest_failed_at: "2026-07-05T10:22:43.934Z",
+          },
           capacity_control: {
             mode: "throttled",
             base: 24,
             maximum: 48,
             ceiling: 24,
+            demand_capacity: 32,
+            cooldown_until: "2026-07-05T12:00:00.000Z",
             last_failure_kind: "github_rate_limit",
           },
         },
@@ -5828,12 +6149,17 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
   assert.match(elementFor("exact-review-lanes").innerHTML, /52 review admission slots open/);
   assert.match(elementFor("exact-review-lanes").innerHTML, /Result publication/);
   assert.match(elementFor("exact-review-lanes").innerHTML, /3 result publication slots open/);
+  assert.match(elementFor("exact-review-lanes").innerHTML, /Terminal resolved/);
+  assert.match(elementFor("exact-review-lanes").innerHTML, /Published<\/span><strong>4\/h/);
+  assert.match(elementFor("exact-review-lanes").innerHTML, /Superseded<\/span><strong>16\/h/);
+  assert.match(elementFor("exact-review-lanes").innerHTML, /DLQ 2/);
+  assert.match(elementFor("exact-review-lanes").innerHTML, /retry amplification 0\.40/);
   assert.match(elementFor("automerge-reliability").innerHTML, /66.7%/);
   assert.match(elementFor("automerge-reliability").innerHTML, /openclaw\/openclaw#107691/);
   assert.match(elementFor("automerge-reliability").innerHTML, /unresolved/);
   assert.match(
     elementFor("exact-review-lanes").innerHTML,
-    /adaptive ceiling 24 after GitHub rate limit/,
+    /target 32 · pressure ceiling 24 after GitHub rate limit/,
   );
   assert.match(elementFor("exact-review-lanes").innerHTML, /No backlog history in this range/);
   status.workers = Array.from({ length: 130 }, (_, id) => ({ id, status: "in_progress" }));
@@ -10016,11 +10342,26 @@ function leasedExactReviewQueueItem(itemNumber: number, runId: string, runAttemp
 function leasedExactReviewPublicationItem(itemNumber: number, runId: string) {
   const item = leasedExactReviewQueueItem(itemNumber, runId);
   const sourceAction = "exact_review_artifact_publish";
+  const publication = {
+    artifactName: `exact-review-${runId}-1`,
+    producerRunId: runId,
+    producerRunAttempt: 1,
+    sourceSha: "a".repeat(40),
+    itemKey: item.key,
+    protocolVersion: 2 as const,
+    leaseRevision: 1,
+    claimGeneration: 1,
+    liveProceeded: true,
+    liveTerminalNoop: false,
+    liveTerminalMissing: false,
+    liveGuardedOpen: false,
+    producerDecision: item.decision,
+  };
   return {
     ...item,
     key: `${item.key}@publish:${runId}:1`,
-    decision: { ...item.decision, sourceAction },
-    leaseDecision: { ...item.leaseDecision, sourceAction },
+    decision: { ...item.decision, sourceAction, publication },
+    leaseDecision: { ...item.leaseDecision, sourceAction, publication },
   };
 }
 

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -452,12 +452,14 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   assert.ok(publisherCheckout);
   assert.equal(publisherCheckout.with?.ref, "main");
   assert.equal(download.uses, "actions/download-artifact@v8");
+  assert.equal(download["continue-on-error"], true);
   assert.equal(download.with?.name, "${{ steps.publication-context.outputs.artifact_name }}");
   assert.equal(
     download.with?.["run-id"],
     "${{ steps.publication-context.outputs.producer_run_id }}",
   );
   assert.match(validate.run ?? "", /repair:exact-review-bundle validate/);
+  assert.equal(validate["continue-on-error"], true);
   assert.match(legacyArtifact.run ?? "", /review_lease_owner/);
   assert.match(legacyArtifact.run ?? "", /review_lease_comment_id/);
   assert.doesNotMatch(create.run ?? "", /repair:exact-review-bundle -- create/);
@@ -500,6 +502,9 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   const status = step(publisher, "Mark re-review complete");
   assert.equal(status.env?.LIVE_TERMINAL_MISSING, undefined);
   assert.equal(status.env?.LIVE_GUARDED_OPEN, undefined);
+  assert.match(status.env?.PUBLISH_COMPLETION_KIND ?? "", /publish-event-result/);
+  assert.match(status.run ?? "", /PUBLISH_COMPLETION_KIND.*superseded/);
+  assert.match(status.run ?? "", /stale result was superseded/);
   assert.doesNotMatch(status.run ?? "", /LIVE_TERMINAL_MISSING|LIVE_GUARDED_OPEN/);
   const reaction = step(publisher, "React to target item completion");
   assert.match(reaction.if ?? "", /requeue_latest != 'true'/);
@@ -512,15 +517,22 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   const publishComplete = step(publisher, "Complete durable exact review publication");
   const publicationPressure = step(publisher, "Probe GitHub pressure after publication failure");
   const releaseTerminal = step(publisher, "Release terminal review leases");
-  const releaseUnsuccessful = step(publisher, "Release unsuccessful publisher-owned review lease");
+  const releaseUnsuccessful = step(
+    publisher,
+    "Release superseded or unsuccessful publisher-owned review lease",
+  );
   assert.doesNotMatch(releaseTerminal.if ?? "", /publication-context.*live_terminal_noop/);
   assert.match(releaseTerminal.if ?? "", /publish-event-result.*terminal_noop/);
   assert.match(releaseUnsuccessful.run ?? "", /\.user\.login == \\"clawsweeper\[bot\]\\"/);
   assert.match(releaseUnsuccessful.run ?? "", /content == "eyes"/);
+  assert.match(releaseUnsuccessful.if ?? "", /completion_kind == 'superseded'/);
   assert.match(publishResult.env?.PRIOR_JOB_STATUS ?? "", /job\.status/);
   assert.match(publishResult.env?.LEGACY_TUPLELESS ?? "", /legacy-exact-artifact/);
   assert.match(publishResult.env?.FAILURE_KIND ?? "", /publish-event-result/);
   assert.match(publishResult.env?.FAILURE_KIND ?? "", /publication-pressure/);
+  assert.match(publishResult.env?.DOWNLOAD_OUTCOME ?? "", /download-exact-review-bundle/);
+  assert.match(publishResult.env?.VALIDATE_OUTCOME ?? "", /validate-exact-review-bundle/);
+  assert.match(publishResult.env?.PUBLISH_COMPLETION_KIND ?? "", /publish-event-result/);
   assert.match(publicationPressure.if ?? "", /failure\(\)/);
   assert.match(publicationPressure.run ?? "", /gh api rate_limit/);
   assert.match(publicationPressure.run ?? "", /failure_kind=github_rate_limit/);
@@ -529,10 +541,15 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   assert.doesNotMatch(publicationPressure.run ?? "", /HTTP \(403\|429\)/);
   assert.match(publishResult.run ?? "", /REQUEUE_LATEST.*SOURCE_DRIFT_OUTCOME/);
   assert.match(publishResult.run ?? "", /LEGACY_TUPLELESS.*SOURCE_DRIFT_OUTCOME/);
+  assert.match(publishResult.run ?? "", /completion_kind=superseded/);
+  assert.match(publishResult.run ?? "", /reason_code=artifact_unavailable/);
+  assert.match(publishResult.run ?? "", /reason_code=invalid_artifact/);
   assert.doesNotMatch(publishResult.run ?? "", /LIVE_TERMINAL_NOOP/);
   assert.match(publishComplete.run ?? "", /internal\/exact-review\/complete/);
   assert.match(publishComplete.env?.FAILURE_KIND ?? "", /exact-review-publication-result/);
   assert.match(publishComplete.run ?? "", /failure_kind: failureKind/);
+  assert.match(publishComplete.run ?? "", /completion_kind: completionKind/);
+  assert.match(publishComplete.run ?? "", /reason_code: reasonCode/);
   assert.ok(publisher.steps.indexOf(publishResult) < publisher.steps.indexOf(publishComplete));
 
   const publisherSource = readText("src/repair/publish-event-result.ts");
@@ -542,6 +559,8 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   );
   assert.match(publisherSource, /"--exact-event-publication"/);
   assert.match(publisherSource, /legacyTuplelessReviewLease/);
+  assert.match(publisherSource, /writePublicationCompletionOutputs\(\s*"superseded"/);
+  assert.match(publisherSource, /completionKind: supersededReason/);
   const reviewSource = readText("src/clawsweeper.ts");
   assert.match(reviewSource, /reserveReviewLeaseCommand/);
   assert.match(reviewSource, /suppliedReviewStartLeaseFromArgs/);


### PR DESCRIPTION
## Summary

- add a backward-compatible structured publication completion protocol so published, superseded, retryable, refresh-required, and permanent outcomes have distinct queue semantics
- terminate remote-newer and remote-closed artifacts without retry amplification, refresh unavailable artifacts after bounded confirmation, and park permanent poison items in an operator-visible SQLite dead-letter queue
- replace ready-only publication scaling with hysteresis driven by ready + backoff depth, oldest age, 15/60-minute net drain, GitHub pressure feedback, and the shared Actions worker budget
- expose separate publish/supersede/retry/dead-letter flow metrics, oldest ready/backoff/DLQ ages, capacity control state, and approximate per-item queue position

## Root cause

Publication work was treated as one success/failure stream. Stale artifacts could repeatedly consume workers, dispatch attempts could exhaust publication-specific retry budgets, and `completed_total` obscured whether work was truly published or merely terminal. Capacity also reacted mostly to ready depth, so the lane could remain at 24 while an old queue was still falling behind.

Current `main` includes two useful partial fixes that this branch preserves:

- #634 terminalizes stale exact-review artifacts
- #638 makes post-rate-limit capacity recovery reachable with 10 clean publications

The live dashboard still showed 226 pending, 213 ready, a 23-hour oldest item, and a -7/hour net publication rate while 23 of 24 slots were active. This change addresses the remaining control-loop and poison-item gaps without adding GitHub polling.

## Safety and operations

- review and apply ownership boundaries are unchanged
- stale/superseded results never count as real publish successes
- GitHub 429 and transient feedback immediately reduce the pressure ceiling and recover gradually
- publication admission preserves 16 Actions slots and honors `WORKER_BUDGET - active_reviews - 16`
- DLQ and stock-classification operations use the existing internal HMAC, exact item revision tuples, bounded pages/batches, and idempotent replay keys
- no live queue cleanup, apply/close, workflow pause, or deployment was performed while preparing this PR

## Validation

- `pnpm run check`
- `node --test test/dashboard-worker.test.ts test/sweep-workflow.test.ts test/repair/stale-event-disposition.test.ts` (203 passed)
- global autoreview: clean, no accepted/actionable findings (`patch is correct`, confidence 0.74)
- `git diff --cached --check`
- staged-diff sensitive-pattern scan: no findings; full-repository gitleaks findings are pre-existing public App client IDs and synthetic test fixtures
