### PR TITLE
fix(validation): allow inert install configs

### DIFF
--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -590,10 +590,12 @@ function assertTargetInstallNetworkPolicy(
   };
   for (const [relativeDir, manifest] of manifests) {
     const directory = relativeDir === "." ? cwd : path.join(cwd, relativeDir);
-    for (const configName of [".npmrc", "bunfig.toml"]) {
-      if (fs.existsSync(path.join(directory, configName))) {
-        throw new Error(`target dependency install network config is not allowed: ${configName}`);
-      }
+    for (const configName of [".npmrc", "bunfig.toml"] as const) {
+      assertTargetInstallNetworkConfigIsInert(
+        path.join(directory, configName),
+        configName,
+        deadlineAt,
+      );
     }
     assertManifestDependencyDestinations(manifest, relativeDir, localPolicy, registryOrigin);
   }
@@ -632,6 +634,26 @@ function assertTargetInstallNetworkPolicy(
     throw new Error("target dependency install network policy cannot inspect bun.lockb");
   }
   return installRegistry;
+}
+
+function assertTargetInstallNetworkConfigIsInert(
+  filePath: string,
+  configName: ".npmrc" | "bunfig.toml",
+  deadlineAt: number,
+) {
+  if (!fs.existsSync(filePath)) return;
+  const commentPrefixes = configName === ".npmrc" ? ["#", ";"] : ["#"];
+  const metadata = readTargetInstallMetadataText(filePath, deadlineAt);
+  // Repositories sometimes retain comment-only config files for stable Docker COPY paths.
+  // Permit only text that cannot affect installs; all actual directives stay fail-closed.
+  const hasActiveConfiguration = metadata
+    .split(/[\r\n]+/)
+    .some(
+      (line) => line.trim() && !commentPrefixes.some((prefix) => line.trim().startsWith(prefix)),
+    );
+  if (hasActiveConfiguration) {
+    throw new Error(`target dependency install network config is not allowed: ${configName}`);
+  }
 }
 
 function approvedTargetInstallRegistry(validationEnv: NodeJS.ProcessEnv) {

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -2207,6 +2207,32 @@ test("bun-based target toolchain installs deps and runs configured validation", 
   ]);
 });
 
+test("dependency setup permits inert package-manager config files", () => {
+  for (const [configName, contents] of [
+    [".npmrc", ""],
+    [".npmrc", "# Registry and auth settings belong in the runner environment.\n; npm comment\n"],
+    ["bunfig.toml", "# Install settings belong in the runner environment.\n"],
+  ] as const) {
+    const cwd = gitBunPackageFixture({ check: "bun x tsc --noEmit" });
+    fs.writeFileSync(path.join(cwd, configName), contents);
+    git(cwd, "add", ".");
+    git(cwd, "commit", "-m", "initial");
+    attachOrigin(cwd);
+
+    const { binDir } = fakeBunFixture(cwd);
+    withPathPrefix(binDir, () => {
+      assert.doesNotThrow(() =>
+        prepareTargetToolchain(cwd, {
+          ...validationOptions("openclaw/clawhub", clawhubToolchain()),
+          installTargetDeps: true,
+          installTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
+          setupTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
+        }),
+      );
+    });
+  }
+});
+
 test("dependency setup rejects target-controlled network destinations", () => {
   const cases = [
     {
@@ -2223,6 +2249,44 @@ test("dependency setup rejects target-controlled network destinations", () => {
               changedGate: null,
             },
           }),
+        };
+      },
+    },
+    ...[
+      "//registry.npmjs.org/:_authToken=secret\n",
+      "proxy=http://127.0.0.1:8080/\n",
+      "cafile=./target-controlled-ca.pem\n",
+      "fetch-retries=9\n",
+      "future-network-setting=value\n",
+      "# comment\rregistry=http://attacker.example/\n",
+    ].map((contents) => ({
+      expected: /network config is not allowed: \.npmrc/,
+      prepare() {
+        const cwd = gitPackageFixture({ check: 'node -e ""' });
+        fs.writeFileSync(path.join(cwd, ".npmrc"), contents);
+        return {
+          cwd,
+          options: validationOptions("steipete/example", {
+            toolchain: {
+              packageManager: "pnpm" as const,
+              baseValidationCommands: ["pnpm check"],
+              changedGate: null,
+            },
+          }),
+        };
+      },
+    })),
+    {
+      expected: /network config is not allowed: bunfig\.toml/,
+      prepare() {
+        const cwd = gitBunPackageFixture({ check: 'node -e ""' });
+        fs.writeFileSync(
+          path.join(cwd, "bunfig.toml"),
+          '[install]\nregistry = "http://127.0.0.1:4873/"\n',
+        );
+        return {
+          cwd,
+          options: validationOptions("openclaw/clawhub", clawhubToolchain()),
         };
       },
     },


### PR DESCRIPTION
## Summary

- allow empty or comment-only `.npmrc` and `bunfig.toml` files during target dependency setup
- keep every active or unknown package-manager directive fail-closed
- cover registry, auth, proxy, certificate, fetch, unknown-setting, and bare-CR bypass cases

## Root cause

After the sparse-checkout repair in https://github.com/openclaw/clawsweeper/pull/630, automerge workers reached target toolchain setup but failed because the validation policy rejected the mere presence of `.npmrc`. OpenClaw retains a comment-only `.npmrc` so Docker COPY paths stay stable, as seen in https://github.com/openclaw/clawsweeper/actions/runs/29543195892.

This change permits only text that cannot affect dependency installation. Any real configuration remains rejected, preserving the target-controlled network boundary.

## Impact

OpenClaw automerge jobs can prepare the target toolchain without rejecting the repository's inert `.npmrc`. No service restart is required after merge; affected PRs can be retriggered with `@clawsweeper automerge`.

## Verification

- `pnpm run check`
- focused target-validation regression tests
- `autoreview --mode local` (clean after fixing its bare-CR security finding)
- changed-file `gitleaks` scans (no leaks)
