### PR TITLE
Collapse publication throughput details by default

### DIFF
--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -180,6 +180,8 @@ type ExactReviewQueueMetricTotals = {
 type ExactReviewQueueMetricDelta = {
   reviewEnqueued?: number;
   reviewCompleted?: number;
+  reviewRetried?: number;
+  reviewShed?: number;
   publicationEnqueued?: number;
   publicationCompleted?: number;
   publicationPublished?: number;
@@ -378,6 +380,7 @@ export class ExactReviewQueue {
           ) {
             state.shedSinceReset = exactReviewShedSinceReset(state) + 1;
             this.writeStateSync(state);
+            this.incrementQueueMetricsSync({ reviewShed: 1 });
             return { shed: true as const };
           }
           state.items[key] = {
@@ -735,6 +738,7 @@ export class ExactReviewQueue {
         state,
         {
           ...(completedLane === "review" && outcome === "success" ? { reviewCompleted: 1 } : {}),
+          ...(!publicationItem && outcome !== "success" && requeued ? { reviewRetried: 1 } : {}),
           ...(completedLane === "publication" ? { publicationCompleted: 1 } : {}),
           ...(structuredTerminal && publicationCompletion.kind === "published"
             ? { publicationPublished: 1 }
@@ -894,6 +898,7 @@ export class ExactReviewQueue {
       let requeued = 0;
       let completed = 0;
       let completedReviews = 0;
+      let retriedReviews = 0;
       let completedPublications = 0;
       for (const run of runs) {
         const matches = Object.values(state.items).filter(
@@ -907,8 +912,12 @@ export class ExactReviewQueue {
         const item = matches[0];
         const didRequeue = finishExactReviewQueueItem(state, item, now, run.outcome);
         reconciled += 1;
-        if (didRequeue) requeued += 1;
-        else {
+        if (didRequeue) {
+          requeued += 1;
+          if (!exactReviewQueueIsPublication(item) && run.outcome !== "success") {
+            retriedReviews += 1;
+          }
+        } else {
           completed += 1;
           if (run.outcome === "success") {
             if (exactReviewQueueIsPublication(item)) completedPublications += 1;
@@ -919,6 +928,7 @@ export class ExactReviewQueue {
       if (reconciled) {
         await this.writeState(state, {
           reviewCompleted: completedReviews,
+          reviewRetried: retriedReviews,
           publicationCompleted: completedPublications,
         });
         await this.scheduleNext(state, now);
@@ -930,7 +940,7 @@ export class ExactReviewQueue {
       const now = Date.now();
       const snapshot = this.storage.transactionSync(() => {
         this.pruneDeliveryReceiptsSync(now);
-        this.prunePublicationTelemetrySync(now);
+        this.pruneQueueTelemetrySync(now);
         const current = this.readStateSync();
         // Dashboard reads are also the operational heartbeat. Reclaim leases and
         // restore the alarm here so a deploy or lost alarm cannot strand backlog.
@@ -945,11 +955,12 @@ export class ExactReviewQueue {
         return {
           state: current,
           metrics: this.queueMetricTotalsSync(),
-          flow: this.publicationFlowSummarySync(now),
+          reviewFlow: this.reviewFlowSummarySync(now),
+          publicationFlow: this.publicationFlowSummarySync(now),
           deadLetters: this.deadLetterStatsSync(),
         };
       });
-      const { state, metrics, flow, deadLetters } = snapshot;
+      const { state, metrics, reviewFlow, publicationFlow, deadLetters } = snapshot;
       const publicationControl = this.refreshPublicationControlSync(state, now);
       await this.scheduleNext(state, now);
       const stats = exactReviewQueueStats(
@@ -977,6 +988,7 @@ export class ExactReviewQueue {
             ...stats.lanes.review,
             enqueued_total: metrics.review.enqueued,
             completed_total: metrics.review.completed,
+            flow: reviewFlow,
           },
           publication: {
             ...stats.lanes.publication,
@@ -987,9 +999,13 @@ export class ExactReviewQueue {
             retried_total: metrics.publication.retried,
             dead_lettered_total: metrics.publication.deadLettered,
             refreshed_total: metrics.publication.refreshed,
-            flow,
+            flow: publicationFlow,
             dead_letters: deadLetters,
-            health: exactReviewPublicationHealth(stats.lanes.publication, flow, deadLetters),
+            health: exactReviewPublicationHealth(
+              stats.lanes.publication,
+              publicationFlow,
+              deadLetters,
+            ),
             capacity_control: exactReviewPublicationControlStatus(this.env, publicationControl),
           },
         },
@@ -1193,7 +1209,7 @@ export class ExactReviewQueue {
     }
     const cursor = String(body.cursor || "");
     if (cursor && cursor.length > 500) return json({ error: "invalid_cursor" }, 400);
-    this.prunePublicationTelemetrySync(Date.now());
+    this.pruneQueueTelemetrySync(Date.now());
     const rows = Array.from(
       this.storage.sql.exec(
         `SELECT dead_letter_id, item_key, revision, target_repo, item_number,
@@ -1559,6 +1575,10 @@ export class ExactReviewQueue {
     this.storage.sql.exec(
       `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_QUEUE_METRIC_BUCKET_TABLE} (
          bucket_start INTEGER PRIMARY KEY,
+         review_enqueued INTEGER NOT NULL DEFAULT 0 CHECK (review_enqueued >= 0),
+         review_completed INTEGER NOT NULL DEFAULT 0 CHECK (review_completed >= 0),
+         review_retried INTEGER NOT NULL DEFAULT 0 CHECK (review_retried >= 0),
+         review_shed INTEGER NOT NULL DEFAULT 0 CHECK (review_shed >= 0),
          publication_enqueued INTEGER NOT NULL DEFAULT 0 CHECK (publication_enqueued >= 0),
          publication_resolved INTEGER NOT NULL DEFAULT 0 CHECK (publication_resolved >= 0),
          publication_published INTEGER NOT NULL DEFAULT 0 CHECK (publication_published >= 0),
@@ -1568,6 +1588,22 @@ export class ExactReviewQueue {
            CHECK (publication_dead_lettered >= 0)
        ) STRICT`,
     );
+    for (const column of ["review_enqueued", "review_completed", "review_retried", "review_shed"]) {
+      const present = Array.from(
+        this.storage.sql.exec(
+          `SELECT name FROM pragma_table_info('${EXACT_REVIEW_QUEUE_METRIC_BUCKET_TABLE}')
+            WHERE name = ?`,
+          column,
+        ),
+      ).length;
+      if (!present) {
+        const definition = `${column} INTEGER NOT NULL DEFAULT 0 CHECK (${column} >= 0)`;
+        this.storage.sql.exec(
+          `ALTER TABLE ${EXACT_REVIEW_QUEUE_METRIC_BUCKET_TABLE}
+             ADD COLUMN ${definition}`,
+        );
+      }
+    }
     this.storage.sql.exec(
       `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_QUEUE_DEAD_LETTER_TABLE} (
          dead_letter_id TEXT PRIMARY KEY,
@@ -1921,6 +1957,8 @@ export class ExactReviewQueue {
   private incrementQueueMetricsSync(delta: ExactReviewQueueMetricDelta) {
     const reviewEnqueued = exactReviewMetricDelta(delta.reviewEnqueued);
     const reviewCompleted = exactReviewMetricDelta(delta.reviewCompleted);
+    const reviewRetried = exactReviewMetricDelta(delta.reviewRetried);
+    const reviewShed = exactReviewMetricDelta(delta.reviewShed);
     const publicationEnqueued = exactReviewMetricDelta(delta.publicationEnqueued);
     const publicationCompleted = exactReviewMetricDelta(delta.publicationCompleted);
     const publicationPublished = exactReviewMetricDelta(delta.publicationPublished);
@@ -1931,6 +1969,8 @@ export class ExactReviewQueue {
     if (
       !reviewEnqueued &&
       !reviewCompleted &&
+      !reviewRetried &&
+      !reviewShed &&
       !publicationEnqueued &&
       !publicationCompleted &&
       !publicationPublished &&
@@ -1963,7 +2003,11 @@ export class ExactReviewQueue {
       publicationDeadLettered,
       publicationRefreshed,
     );
-    this.incrementPublicationMetricBucketSync({
+    this.incrementQueueMetricBucketSync({
+      reviewEnqueued,
+      reviewCompleted,
+      reviewRetried,
+      reviewShed,
       publicationEnqueued,
       publicationCompleted,
       publicationPublished,
@@ -1973,7 +2017,11 @@ export class ExactReviewQueue {
     });
   }
 
-  private incrementPublicationMetricBucketSync({
+  private incrementQueueMetricBucketSync({
+    reviewEnqueued,
+    reviewCompleted,
+    reviewRetried,
+    reviewShed,
     publicationEnqueued,
     publicationCompleted,
     publicationPublished,
@@ -1981,6 +2029,10 @@ export class ExactReviewQueue {
     publicationRetried,
     publicationDeadLettered,
   }: {
+    reviewEnqueued: number;
+    reviewCompleted: number;
+    reviewRetried: number;
+    reviewShed: number;
     publicationEnqueued: number;
     publicationCompleted: number;
     publicationPublished: number;
@@ -1989,6 +2041,10 @@ export class ExactReviewQueue {
     publicationDeadLettered: number;
   }) {
     if (
+      !reviewEnqueued &&
+      !reviewCompleted &&
+      !reviewRetried &&
+      !reviewShed &&
       !publicationEnqueued &&
       !publicationCompleted &&
       !publicationPublished &&
@@ -2003,10 +2059,15 @@ export class ExactReviewQueue {
       EXACT_REVIEW_QUEUE_METRIC_BUCKET_MS;
     this.storage.sql.exec(
       `INSERT INTO ${EXACT_REVIEW_QUEUE_METRIC_BUCKET_TABLE}
-         (bucket_start, publication_enqueued, publication_resolved, publication_published,
+         (bucket_start, review_enqueued, review_completed, review_retried, review_shed,
+          publication_enqueued, publication_resolved, publication_published,
           publication_superseded, publication_retried, publication_dead_lettered)
-       VALUES (?, ?, ?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(bucket_start) DO UPDATE SET
+         review_enqueued = review_enqueued + excluded.review_enqueued,
+         review_completed = review_completed + excluded.review_completed,
+         review_retried = review_retried + excluded.review_retried,
+         review_shed = review_shed + excluded.review_shed,
          publication_enqueued = publication_enqueued + excluded.publication_enqueued,
          publication_resolved = publication_resolved + excluded.publication_resolved,
          publication_published = publication_published + excluded.publication_published,
@@ -2015,6 +2076,10 @@ export class ExactReviewQueue {
          publication_dead_lettered =
            publication_dead_lettered + excluded.publication_dead_lettered`,
       bucketStart,
+      reviewEnqueued,
+      reviewCompleted,
+      reviewRetried,
+      reviewShed,
       publicationEnqueued,
       publicationCompleted,
       publicationPublished,
@@ -2106,7 +2171,42 @@ export class ExactReviewQueue {
     return moved;
   }
 
-  private prunePublicationTelemetrySync(now: number) {
+  private reviewFlowSummarySync(now: number) {
+    const windowMs = 15 * 60_000;
+    const row = Array.from(
+      this.storage.sql.exec(
+        `SELECT COALESCE(SUM(review_enqueued), 0) AS enqueued,
+                COALESCE(SUM(review_completed), 0) AS completed,
+                COALESCE(SUM(review_retried), 0) AS retried,
+                COALESCE(SUM(review_shed), 0) AS shed
+           FROM ${EXACT_REVIEW_QUEUE_METRIC_BUCKET_TABLE}
+          WHERE bucket_start >= ?`,
+        now - windowMs,
+      ),
+    )[0] as Record<string, number> | undefined;
+    const multiplier = (60 * 60 * 1000) / windowMs;
+    const enqueued = Number(row?.enqueued || 0);
+    const successful = Number(row?.completed || 0);
+    const retried = Number(row?.retried || 0);
+    const shed = Number(row?.shed || 0);
+    const arrival = enqueued + shed;
+    return {
+      last_15_minutes: {
+        window_minutes: windowMs / 60_000,
+        arrival,
+        successful,
+        retried,
+        shed,
+        arrival_rate_per_hour: Math.round(arrival * multiplier * 10) / 10,
+        successful_rate_per_hour: Math.round(successful * multiplier * 10) / 10,
+        retried_rate_per_hour: Math.round(retried * multiplier * 10) / 10,
+        shed_rate_per_hour: Math.round(shed * multiplier * 10) / 10,
+        retry_amplification: successful > 0 ? Math.round((retried / successful) * 100) / 100 : null,
+      },
+    };
+  }
+
+  private pruneQueueTelemetrySync(now: number) {
     this.storage.sql.exec(
       `DELETE FROM ${EXACT_REVIEW_QUEUE_METRIC_BUCKET_TABLE} WHERE bucket_start < ?`,
       now - EXACT_REVIEW_QUEUE_METRIC_BUCKET_TTL_MS,

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -7224,6 +7224,21 @@ h2::before { content: ""; flex: 0 0 auto; width: 14px; height: 2px; border-radiu
 .lane-count { display: flex; justify-content: space-between; gap: 12px; color: var(--muted); font-size: 11px; }
 .exact-lane > .lane-count { margin-top: 14px; }
 .lane-count strong { color: var(--text); font-weight: 600; }
+.lane-flow { margin-top: 12px; }
+.lane-flow summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 11px;
+  list-style: none;
+}
+.lane-flow summary::-webkit-details-marker { display: none; }
+.lane-flow summary::after { content: "Details ▾"; }
+.lane-flow[open] summary::after { content: "Hide ▴"; }
+.lane-flow .lane-counts { padding-left: 10px; border-left: 1px solid var(--line-soft); }
 .lane-bar { height: 6px; margin-top: 12px; overflow: hidden; border-radius: 999px; background: var(--track); }
 .lane-bar i { display: block; height: 100%; background: var(--claw); }
 .lane-foot { margin-top: 7px; color: var(--muted); font-size: 11px; }
@@ -8433,13 +8448,13 @@ function renderExactReviewLanes(queue) {
     const flow = laneKey === "publication" ? lane.flow?.last_15_minutes : null;
     const rate = value => Number.isFinite(Number(value)) ? fmt.format(Number(value)) + "/h" : "n/a";
     const flowSummary = flow
-      ? '<div class="lane-counts">' +
+      ? '<details class="lane-flow"><summary>Publication throughput · last 15 minutes</summary><div class="lane-counts">' +
         '<div class="lane-count"><span>Arrival</span><strong>' + rate(flow.arrival_rate_per_hour) + '</strong></div>' +
         '<div class="lane-count"><span>Terminal resolved</span><strong>' + rate(flow.resolved_rate_per_hour) + '</strong></div>' +
         '<div class="lane-count"><span>Published</span><strong>' + rate(flow.published_rate_per_hour) + '</strong></div>' +
         '<div class="lane-count"><span>Superseded</span><strong>' + rate(flow.superseded_rate_per_hour) + '</strong></div>' +
         '<div class="lane-count"><span>Retried</span><strong>' + rate(flow.retried_rate_per_hour) + '</strong></div>' +
-        '<div class="lane-count"><span>Dead-lettered</span><strong>' + rate(flow.dead_lettered_rate_per_hour) + '</strong></div></div>'
+        '<div class="lane-count"><span>Dead-lettered</span><strong>' + rate(flow.dead_lettered_rate_per_hour) + '</strong></div></div></details>'
       : '';
     const deadLetters = laneKey === "publication" ? lane.dead_letters : null;
     const deadLetterNote = deadLetters

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -7241,6 +7241,8 @@ h2::before { content: ""; flex: 0 0 auto; width: 14px; height: 2px; border-radiu
 .lane-flow-title { display: grid; gap: 3px; }
 .lane-flow-title small { max-width: 420px; color: var(--muted); font-size: 10px; line-height: 1.4; }
 .lane-flow .lane-counts { padding-left: 10px; border-left: 1px solid var(--line-soft); }
+.lane-flow-foot { display: flex; justify-content: space-between; gap: 12px; margin-top: 8px; color: var(--muted); font-size: 10px; }
+.lane-flow-foot strong { color: var(--text); font-weight: 600; }
 .lane-bar { height: 6px; margin-top: 12px; overflow: hidden; border-radius: 999px; background: var(--track); }
 .lane-bar i { display: block; height: 100%; background: var(--claw); }
 .lane-foot { margin-top: 7px; color: var(--muted); font-size: 11px; }
@@ -8375,6 +8377,35 @@ function workerTargetTitle(worker) {
   const title = compactText(targets[0].title);
   return targets.length > 1 ? title + " +" + (targets.length - 1) + " more" : title;
 }
+function laneFlowDetails(laneKey, flow) {
+  if (!flow) return "";
+  const rate = value => Number.isFinite(Number(value)) ? fmt.format(Number(value)) + "/h" : "n/a";
+  const amplification = flow.retry_amplification == null
+    ? "n/a"
+    : Number(flow.retry_amplification).toFixed(2);
+  const config = laneKey === "review"
+    ? {
+        title: "Review throughput",
+        rows: [
+          ["Arrival", flow.arrival_rate_per_hour],
+          ["Successful", flow.successful_rate_per_hour],
+          ["Retried", flow.retried_rate_per_hour],
+          ["Shed", flow.shed_rate_per_hour]
+        ]
+      }
+    : {
+        title: "Publication throughput",
+        rows: [
+          ["Arrival", flow.arrival_rate_per_hour],
+          ["Published", flow.published_rate_per_hour],
+          ["Superseded", flow.superseded_rate_per_hour],
+          ["Retried", flow.retried_rate_per_hour]
+        ]
+      };
+  return '<details class="lane-flow"><summary><span class="lane-flow-title">' + esc(config.title) + ' · last 15 minutes<small>15m hourly-equivalent rates respond faster to recent changes but are more burst-sensitive than the up-to-60m net rate above.</small></span></summary><div class="lane-counts">' +
+    config.rows.map(([label, value]) => '<div class="lane-count"><span>' + esc(label) + '</span><strong>' + rate(value) + '</strong></div>').join("") +
+    '</div><div class="lane-flow-foot"><span>Retry amplification</span><strong>' + esc(amplification) + '</strong></div></details>';
+}
 function renderSystemMap(data) {
   const workers = data.workers || [];
   const pipeline = data.pipeline || [];
@@ -8447,22 +8478,12 @@ function renderExactReviewLanes(queue) {
       : laneKey === "publication"
         ? " · target " + fmt.format(publicationControl?.demand_capacity || capacity) + " · adaptive " + fmt.format(publicationControl?.base || 24) + "–" + fmt.format(publicationControl?.maximum || capacity)
         : "";
-    const flow = laneKey === "publication" ? lane.flow?.last_15_minutes : null;
-    const rate = value => Number.isFinite(Number(value)) ? fmt.format(Number(value)) + "/h" : "n/a";
-    const flowSummary = flow
-      ? '<details class="lane-flow"><summary><span class="lane-flow-title">Publication throughput · last 15 minutes<small>15m hourly-equivalent rates respond faster to recent changes but are more burst-sensitive than the up-to-60m net rate above.</small></span></summary><div class="lane-counts">' +
-        '<div class="lane-count"><span>Arrival</span><strong>' + rate(flow.arrival_rate_per_hour) + '</strong></div>' +
-        '<div class="lane-count"><span>Terminal resolved</span><strong>' + rate(flow.resolved_rate_per_hour) + '</strong></div>' +
-        '<div class="lane-count"><span>Published</span><strong>' + rate(flow.published_rate_per_hour) + '</strong></div>' +
-        '<div class="lane-count"><span>Superseded</span><strong>' + rate(flow.superseded_rate_per_hour) + '</strong></div>' +
-        '<div class="lane-count"><span>Retried</span><strong>' + rate(flow.retried_rate_per_hour) + '</strong></div>' +
-        '<div class="lane-count"><span>Dead-lettered</span><strong>' + rate(flow.dead_lettered_rate_per_hour) + '</strong></div></div></details>'
-      : '';
+    const flow = lane.flow?.last_15_minutes;
+    const flowSummary = laneFlowDetails(laneKey, flow);
     const deadLetters = laneKey === "publication" ? lane.dead_letters : null;
     const deadLetterNote = deadLetters
       ? " · DLQ " + fmt.format(deadLetters.open || 0) +
-        (deadLetters.oldest_failed_at ? " · oldest DLQ " + since(deadLetters.oldest_failed_at) : "") +
-        " · retry amplification " + (flow?.retry_amplification == null ? "n/a" : Number(flow.retry_amplification).toFixed(2))
+        (deadLetters.oldest_failed_at ? " · oldest DLQ " + since(deadLetters.oldest_failed_at) : "")
       : "";
     return '<div class="exact-lane"><div class="exact-lane-head"><strong>' + esc(label) + '</strong><span>' + fmt.format(active) + ' of ' + fmt.format(capacity) + ' active</span></div>' +
       '<div class="lane-count"><span>Pending</span><strong>' + fmt.format(lane.pending || 0) + '</strong></div>' +

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -7227,7 +7227,7 @@ h2::before { content: ""; flex: 0 0 auto; width: 14px; height: 2px; border-radiu
 .lane-flow { margin-top: 12px; }
 .lane-flow summary {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 12px;
   color: var(--muted);
@@ -7236,8 +7236,10 @@ h2::before { content: ""; flex: 0 0 auto; width: 14px; height: 2px; border-radiu
   list-style: none;
 }
 .lane-flow summary::-webkit-details-marker { display: none; }
-.lane-flow summary::after { content: "Details ▾"; }
+.lane-flow summary::after { flex: 0 0 auto; content: "Details ▾"; }
 .lane-flow[open] summary::after { content: "Hide ▴"; }
+.lane-flow-title { display: grid; gap: 3px; }
+.lane-flow-title small { max-width: 420px; color: var(--muted); font-size: 10px; line-height: 1.4; }
 .lane-flow .lane-counts { padding-left: 10px; border-left: 1px solid var(--line-soft); }
 .lane-bar { height: 6px; margin-top: 12px; overflow: hidden; border-radius: 999px; background: var(--track); }
 .lane-bar i { display: block; height: 100%; background: var(--claw); }
@@ -8448,7 +8450,7 @@ function renderExactReviewLanes(queue) {
     const flow = laneKey === "publication" ? lane.flow?.last_15_minutes : null;
     const rate = value => Number.isFinite(Number(value)) ? fmt.format(Number(value)) + "/h" : "n/a";
     const flowSummary = flow
-      ? '<details class="lane-flow"><summary>Publication throughput · last 15 minutes</summary><div class="lane-counts">' +
+      ? '<details class="lane-flow"><summary><span class="lane-flow-title">Publication throughput · last 15 minutes<small>15m hourly-equivalent rates respond faster to recent changes but are more burst-sensitive than the up-to-60m net rate above.</small></span></summary><div class="lane-counts">' +
         '<div class="lane-count"><span>Arrival</span><strong>' + rate(flow.arrival_rate_per_hour) + '</strong></div>' +
         '<div class="lane-count"><span>Terminal resolved</span><strong>' + rate(flow.resolved_rate_per_hour) + '</strong></div>' +
         '<div class="lane-count"><span>Published</span><strong>' + rate(flow.published_rate_per_hour) + '</strong></div>' +

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -6151,7 +6151,11 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
   assert.match(elementFor("exact-review-lanes").innerHTML, /3 result publication slots open/);
   assert.match(
     elementFor("exact-review-lanes").innerHTML,
-    /<details class="lane-flow"><summary>Publication throughput · last 15 minutes<\/summary>/,
+    /<details class="lane-flow"><summary><span class="lane-flow-title">Publication throughput · last 15 minutes/,
+  );
+  assert.match(
+    elementFor("exact-review-lanes").innerHTML,
+    /15m hourly-equivalent rates respond faster to recent changes but are more burst-sensitive than the up-to-60m net rate above\./,
   );
   assert.doesNotMatch(
     elementFor("exact-review-lanes").innerHTML,

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -6149,6 +6149,14 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
   assert.match(elementFor("exact-review-lanes").innerHTML, /52 review admission slots open/);
   assert.match(elementFor("exact-review-lanes").innerHTML, /Result publication/);
   assert.match(elementFor("exact-review-lanes").innerHTML, /3 result publication slots open/);
+  assert.match(
+    elementFor("exact-review-lanes").innerHTML,
+    /<details class="lane-flow"><summary>Publication throughput · last 15 minutes<\/summary>/,
+  );
+  assert.doesNotMatch(
+    elementFor("exact-review-lanes").innerHTML,
+    /<details class="lane-flow" open>/,
+  );
   assert.match(elementFor("exact-review-lanes").innerHTML, /Terminal resolved/);
   assert.match(elementFor("exact-review-lanes").innerHTML, /Published<\/span><strong>4\/h/);
   assert.match(elementFor("exact-review-lanes").innerHTML, /Superseded<\/span><strong>16\/h/);

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -259,6 +259,7 @@ test("exact-review queue bypasses debounce for commands and publications", async
       await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
     ).json();
     assert.equal(stats.lanes.review.enqueued_total, 1);
+    assert.equal(stats.lanes.review.flow.last_15_minutes.arrival_rate_per_hour, 4);
     assert.equal(stats.lanes.publication.enqueued_total, 1);
   } finally {
     Date.now = originalNow;
@@ -319,6 +320,18 @@ test("exact-review queue sheds only new recovery work above the pending soft lim
   assert.equal(stats.lanes.review.pending_depth, 2);
   assert.equal(stats.lanes.review.shed_since_reset, 3);
   assert.equal(stats.lanes.review.enqueued_total, 2);
+  assert.deepEqual(stats.lanes.review.flow.last_15_minutes, {
+    window_minutes: 15,
+    arrival: 5,
+    successful: 0,
+    retried: 0,
+    shed: 3,
+    arrival_rate_per_hour: 20,
+    successful_rate_per_hour: 0,
+    retried_rate_per_hour: 0,
+    shed_rate_per_hour: 12,
+    retry_amplification: null,
+  });
   assert.equal(stats.lanes.publication.enqueued_total, 1);
 });
 
@@ -507,12 +520,18 @@ test("exact-review queue counts only work that successfully leaves each lane", a
   driftPublication.decision.sourceAction = "exact_review_artifact_publish";
   driftPublication.leaseDecision.sourceAction = "exact_review_artifact_publish";
   const review = leasedExactReviewQueueItem(706, "7060");
+  const reconciledReviewFailure = leasedExactReviewQueueItem(708, "7080");
   await storage.put("exact-review-queue", {
     deliveries: {},
     items: Object.fromEntries(
-      [directPublication, reconciledPublication, failedPublication, driftPublication, review].map(
-        (item) => [item.key, item],
-      ),
+      [
+        directPublication,
+        reconciledPublication,
+        failedPublication,
+        driftPublication,
+        review,
+        reconciledReviewFailure,
+      ].map((item) => [item.key, item]),
     ),
   });
   const queue = new ExactReviewQueue({ storage }, {});
@@ -552,6 +571,13 @@ test("exact-review queue counts only work that successfully leaves each lane", a
         claim_generation: reconciledPublication.claimGeneration,
         outcome: "success",
       },
+      {
+        run_id: reconciledReviewFailure.claimedRunId,
+        run_attempt: reconciledReviewFailure.claimedRunAttempt,
+        claimed_run_attempt: reconciledReviewFailure.claimedRunAttempt,
+        claim_generation: reconciledReviewFailure.claimGeneration,
+        outcome: "failure",
+      },
     ],
   };
   const reconciled = await queue.fetch(
@@ -562,8 +588,8 @@ test("exact-review queue counts only work that successfully leaves each lane", a
   );
   assert.deepEqual(await reconciled.json(), {
     ok: true,
-    reconciled: 1,
-    requeued: 0,
+    reconciled: 2,
+    requeued: 1,
     completed: 1,
   });
   assert.equal(
@@ -582,6 +608,9 @@ test("exact-review queue counts only work that successfully leaves each lane", a
     await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
   ).json();
   assert.equal(stats.lanes.review.completed_total, 1);
+  assert.equal(stats.lanes.review.flow.last_15_minutes.successful_rate_per_hour, 4);
+  assert.equal(stats.lanes.review.flow.last_15_minutes.retried_rate_per_hour, 4);
+  assert.equal(stats.lanes.review.flow.last_15_minutes.retry_amplification, 1);
   assert.equal(stats.lanes.publication.completed_total, 2);
   assert.equal(stats.lanes.publication.pending, 2);
 });
@@ -2519,6 +2548,24 @@ test("exact-review queue upgrades flow metrics without losing publication comple
     `INSERT INTO exact_review_queue_metrics (singleton_id, publication_completed_total)
      VALUES (1, 42)`,
   );
+  storage.sql.exec(
+    `CREATE TABLE exact_review_queue_metric_buckets (
+       bucket_start INTEGER PRIMARY KEY,
+       publication_enqueued INTEGER NOT NULL DEFAULT 0 CHECK (publication_enqueued >= 0),
+       publication_resolved INTEGER NOT NULL DEFAULT 0 CHECK (publication_resolved >= 0),
+       publication_published INTEGER NOT NULL DEFAULT 0 CHECK (publication_published >= 0),
+       publication_superseded INTEGER NOT NULL DEFAULT 0 CHECK (publication_superseded >= 0),
+       publication_retried INTEGER NOT NULL DEFAULT 0 CHECK (publication_retried >= 0),
+       publication_dead_lettered INTEGER NOT NULL DEFAULT 0
+         CHECK (publication_dead_lettered >= 0)
+     ) STRICT`,
+  );
+  storage.sql.exec(
+    `INSERT INTO exact_review_queue_metric_buckets
+       (bucket_start, publication_enqueued, publication_resolved, publication_published)
+     VALUES (?, 2, 1, 1)`,
+    Date.now(),
+  );
   const queue = new ExactReviewQueue({ storage }, {});
 
   const stats = await (
@@ -2538,6 +2585,19 @@ test("exact-review queue upgrades flow metrics without losing publication comple
       publication_completed: 42,
     },
   );
+  assert.equal(stats.lanes.publication.flow.last_15_minutes.published_rate_per_hour, 4);
+  assert.deepEqual(stats.lanes.review.flow.last_15_minutes, {
+    window_minutes: 15,
+    arrival: 0,
+    successful: 0,
+    retried: 0,
+    shed: 0,
+    arrival_rate_per_hour: 0,
+    successful_rate_per_hour: 0,
+    retried_rate_per_hour: 0,
+    shed_rate_per_hour: 0,
+    retry_amplification: null,
+  });
 });
 
 test("exact-review queue migrates delivery receipts and retains them for seven days", async () => {
@@ -4587,6 +4647,9 @@ test("ordinary exact-review retries do not increment publication retry telemetry
   ).json();
   assert.equal(stats.lanes.publication.retried_total, 0);
   assert.equal(stats.lanes.publication.flow.last_15_minutes.retried, 0);
+  assert.equal(stats.lanes.review.flow.last_15_minutes.retried, 1);
+  assert.equal(stats.lanes.review.flow.last_15_minutes.retried_rate_per_hour, 4);
+  assert.equal(stats.lanes.review.flow.last_15_minutes.retry_amplification, null);
 });
 
 test("exact-review completion rejects incompatible structured dispositions", async () => {
@@ -5859,7 +5922,7 @@ test("dashboard HTML preserves UTF-8 emoji labels", async () => {
   assert.match(html, /Review admission/);
   assert.match(html, /Result publication/);
   assert.match(html, /Net publication rate/);
-  assert.match(html, /Terminal resolved/);
+  assert.match(html, /Review throughput/);
   assert.doesNotMatch(html, /Control Plane · GitHub Actions, not Codex/);
   assert.doesNotMatch(html, /id="control-plane"/);
   assert.match(html, /\.exact-lanes \{ grid-template-columns: 1fr; \}/);
@@ -5970,6 +6033,15 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
           capacity: 64,
           available_slots: 52,
           oldest_pending_age_seconds: 60,
+          flow: {
+            last_15_minutes: {
+              arrival_rate_per_hour: 24,
+              successful_rate_per_hour: 20,
+              retried_rate_per_hour: 4,
+              shed_rate_per_hour: 0,
+              retry_amplification: 0.2,
+            },
+          },
         },
         publication: {
           pending: 2,
@@ -6149,23 +6221,39 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
   assert.match(elementFor("exact-review-lanes").innerHTML, /52 review admission slots open/);
   assert.match(elementFor("exact-review-lanes").innerHTML, /Result publication/);
   assert.match(elementFor("exact-review-lanes").innerHTML, /3 result publication slots open/);
+  const initialLaneHtml = elementFor("exact-review-lanes").innerHTML;
   assert.match(
-    elementFor("exact-review-lanes").innerHTML,
+    initialLaneHtml,
+    /<details class="lane-flow"><summary><span class="lane-flow-title">Review throughput · last 15 minutes/,
+  );
+  assert.match(
+    initialLaneHtml,
     /<details class="lane-flow"><summary><span class="lane-flow-title">Publication throughput · last 15 minutes/,
   );
   assert.match(
-    elementFor("exact-review-lanes").innerHTML,
+    initialLaneHtml,
     /15m hourly-equivalent rates respond faster to recent changes but are more burst-sensitive than the up-to-60m net rate above\./,
   );
-  assert.doesNotMatch(
-    elementFor("exact-review-lanes").innerHTML,
-    /<details class="lane-flow" open>/,
+  assert.equal(initialLaneHtml.match(/class="lane-flow"/g)?.length, 2);
+  assert.equal(initialLaneHtml.match(/class="lane-flow-foot"/g)?.length, 2);
+  assert.doesNotMatch(initialLaneHtml, /<details class="lane-flow" open>/);
+  const flowBlocks = [
+    ...initialLaneHtml.matchAll(/<details class="lane-flow">([\s\S]*?)<\/details>/g),
+  ];
+  assert.equal(flowBlocks.length, 2);
+  assert.deepEqual(
+    flowBlocks.map((match) => match[1].match(/class="lane-count"/g)?.length),
+    [4, 4],
   );
-  assert.match(elementFor("exact-review-lanes").innerHTML, /Terminal resolved/);
-  assert.match(elementFor("exact-review-lanes").innerHTML, /Published<\/span><strong>4\/h/);
-  assert.match(elementFor("exact-review-lanes").innerHTML, /Superseded<\/span><strong>16\/h/);
-  assert.match(elementFor("exact-review-lanes").innerHTML, /DLQ 2/);
-  assert.match(elementFor("exact-review-lanes").innerHTML, /retry amplification 0\.40/);
+  assert.match(initialLaneHtml, /Successful<\/span><strong>20\/h/);
+  assert.match(initialLaneHtml, /Shed<\/span><strong>0\/h/);
+  assert.match(initialLaneHtml, /Published<\/span><strong>4\/h/);
+  assert.match(initialLaneHtml, /Superseded<\/span><strong>16\/h/);
+  assert.doesNotMatch(initialLaneHtml, /Terminal resolved/);
+  assert.doesNotMatch(initialLaneHtml, /Dead-lettered/);
+  assert.match(initialLaneHtml, /DLQ 2/);
+  assert.match(initialLaneHtml, /Retry amplification<\/span><strong>0\.20/);
+  assert.match(initialLaneHtml, /Retry amplification<\/span><strong>0\.40/);
   assert.match(elementFor("automerge-reliability").innerHTML, /66.7%/);
   assert.match(elementFor("automerge-reliability").innerHTML, /openclaw\/openclaw#107691/);
   assert.match(elementFor("automerge-reliability").innerHTML, /unresolved/);


### PR DESCRIPTION
## What changed

- add a collapsed 15-minute throughput disclosure to both review admission and result publication
- keep both disclosures visually aligned with four lane-specific metrics and the same retry-amplification footer
- track review arrival, successful completion, explicit retry, and shed telemetry in additive five-minute metric buckets
- remove the redundant publication Terminal resolved and Dead-lettered rows while keeping DLQ status in the card footer
- explain that the hourly-equivalent 15-minute rates react faster but are more burst-sensitive than the up-to-60-minute net rate

## Why

The publication-only details made the two cards visually uneven, while the review lane lacked a comparable immediate recovery signal. The aligned panels now expose only the most useful lane-specific metrics without duplicating values already represented by the net-rate chart or DLQ footer.

## Metric semantics

- Review Arrival includes admitted work and shed demand, matching the Net review rate incoming definition.
- Review Retried counts explicit failed completions and reconciliation retries; lease-expiry recovery is intentionally excluded to match publication telemetry semantics.
- Existing installations receive additive zero-defaulted bucket columns; no historical data is backfilled.

## Validation

- `node --test test/dashboard-worker.test.ts`
- `pnpm run build:dashboard`
- `pnpm run lint:dashboard`
- `pnpm run check`
- `/data/code/openclaw/openclaw/.agents/skills/autoreview/scripts/autoreview --mode local` (clean)