### PR TITLE
Add automerge product health metrics

### DIFF
--- a/.github/workflows/repair-cluster-worker.yml
+++ b/.github/workflows/repair-cluster-worker.yml
@@ -14,6 +14,11 @@ on:
         required: false
         default: ""
         type: string
+      automerge_session_id:
+        description: "Stable automerge product telemetry session"
+        required: false
+        default: ""
+        type: string
       mode:
         description: "Worker mode"
         required: true
@@ -597,6 +602,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.target_write_token.outputs.token }}
           CLAWSWEEPER_ALLOWED_OWNER: ${{ steps.target.outputs.target_owner }}
+          CLAWSWEEPER_AUTOMERGE_SESSION_ID: ${{ inputs.automerge_session_id }}
         run: pnpm run repair:execute-fix -- "${{ inputs.job }}" --latest --defer-publication
 
       - name: Renew target write token for post-flight
@@ -618,6 +624,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.target_post_flight_token.outputs.token }}
           CLAWSWEEPER_ALLOWED_OWNER: ${{ steps.target.outputs.target_owner }}
+          CLAWSWEEPER_AUTOMERGE_SESSION_ID: ${{ inputs.automerge_session_id }}
         run: pnpm run repair:execute-fix -- "${{ inputs.job }}" --latest --publish-report-only
 
       - name: Record deterministic validation phase

--- a/.github/workflows/repair-comment-router.yml
+++ b/.github/workflows/repair-comment-router.yml
@@ -175,6 +175,7 @@ jobs:
           CLAWSWEEPER_DISPATCH_TOKEN: ${{ steps.dispatch-token.outputs.token }}
           CLAWSWEEPER_MUTATION_TOKEN_SOURCE: clawsweeper-app
           CLAWSWEEPER_ALLOW_MERGE: ${{ vars.CLAWSWEEPER_ALLOW_MERGE || '0' }}
+          CLAWSWEEPER_STATUS_INGEST_TOKEN: ${{ secrets.CLAWSWEEPER_STATUS_INGEST_TOKEN }}
           CLAWSWEEPER_ACTION_LEDGER_INVOCATION: initial
         run: |
           set -euo pipefail
@@ -308,6 +309,7 @@ jobs:
           CLAWSWEEPER_DISPATCH_TOKEN: ${{ steps.dispatch-token.outputs.token }}
           CLAWSWEEPER_MUTATION_TOKEN_SOURCE: clawsweeper-app
           CLAWSWEEPER_ALLOW_MERGE: ${{ vars.CLAWSWEEPER_ALLOW_MERGE || '0' }}
+          CLAWSWEEPER_STATUS_INGEST_TOKEN: ${{ secrets.CLAWSWEEPER_STATUS_INGEST_TOKEN }}
           CLAWSWEEPER_ACTION_LEDGER_INVOCATION: retry
         run: |
           set -euo pipefail

--- a/dashboard/automerge-metrics.ts
+++ b/dashboard/automerge-metrics.ts
@@ -1,0 +1,296 @@
+export const AUTOMERGE_METRICS_EVENT_TYPE = "clawsweeper.automerge_metric";
+export const AUTOMERGE_METRICS_STORE_KEY = "automerge-product-metrics:v1";
+export const AUTOMERGE_METRICS_EVENT_KEY_PREFIX = `${AUTOMERGE_METRICS_STORE_KEY}:time:`;
+export const AUTOMERGE_METRICS_EVENT_ID_KEY_PREFIX = `${AUTOMERGE_METRICS_STORE_KEY}:id:`;
+export const AUTOMERGE_METRICS_TTL_SECONDS = 90 * 24 * 60 * 60;
+export const AUTOMERGE_METRICS_EVENT_LIMIT = 20_000;
+
+const RANGE_CONFIG = {
+  "6h": { durationMs: 6 * 60 * 60 * 1000, bucketMs: 30 * 60 * 1000 },
+  "24h": { durationMs: 24 * 60 * 60 * 1000, bucketMs: 2 * 60 * 60 * 1000 },
+  "7d": { durationMs: 7 * 24 * 60 * 60 * 1000, bucketMs: 12 * 60 * 60 * 1000 },
+} as const;
+
+export type AutomergeMetricRange = keyof typeof RANGE_CONFIG;
+export type AutomergeMetricPhase =
+  | "activated"
+  | "repair_dispatched"
+  | "repair_completed"
+  | "state_changed"
+  | "terminal";
+
+export type AutomergeMetricEvent = {
+  event_id: string;
+  session_id: string;
+  phase: AutomergeMetricPhase;
+  occurred_at: string;
+  repository: string;
+  item_number: number;
+  policy_version: string;
+  state?: string | null;
+  outcome?: string | null;
+  reason?: string | null;
+  pr_url?: string | null;
+  run_url?: string | null;
+  base_sync?: boolean;
+};
+
+export type AutomergeMetricLedger = {
+  version: 1;
+  telemetry_since: string | null;
+  events: AutomergeMetricEvent[];
+};
+
+export function normalizeAutomergeMetricEvent(value: unknown): AutomergeMetricEvent | null {
+  if (!value || typeof value !== "object") return null;
+  const row = value as Record<string, unknown>;
+  const phase = String(row.phase ?? "") as AutomergeMetricPhase;
+  if (
+    !(
+      [
+        "activated",
+        "repair_dispatched",
+        "repair_completed",
+        "state_changed",
+        "terminal",
+      ] as string[]
+    ).includes(phase)
+  )
+    return null;
+  const occurredAt = String(row.occurred_at ?? "");
+  const itemNumber = Number(row.item_number);
+  const repository = String(row.repository ?? "").trim();
+  const sessionId = String(row.session_id ?? "").trim();
+  if (
+    !sessionId ||
+    !repository ||
+    !Number.isInteger(itemNumber) ||
+    itemNumber <= 0 ||
+    !Number.isFinite(Date.parse(occurredAt))
+  )
+    return null;
+  const eventId = String(row.event_id ?? "").trim() || `${sessionId}:${phase}:${occurredAt}`;
+  return {
+    event_id: eventId,
+    session_id: sessionId,
+    phase,
+    occurred_at: new Date(occurredAt).toISOString(),
+    repository,
+    item_number: itemNumber,
+    policy_version: String(row.policy_version ?? "immediate-v1").trim() || "immediate-v1",
+    state: nullableText(row.state),
+    outcome: nullableText(row.outcome),
+    reason: nullableText(row.reason),
+    pr_url: nullableText(row.pr_url) ?? `https://github.com/${repository}/pull/${itemNumber}`,
+    run_url: nullableText(row.run_url),
+    base_sync: row.base_sync === true,
+  };
+}
+
+export function mergeAutomergeMetricLedger(
+  current: unknown,
+  incoming: AutomergeMetricEvent,
+  now = Date.now(),
+): AutomergeMetricLedger {
+  const currentEvents = Array.isArray((current as AutomergeMetricLedger | null)?.events)
+    ? (current as AutomergeMetricLedger).events
+    : [];
+  const cutoff = now - AUTOMERGE_METRICS_TTL_SECONDS * 1000;
+  const byId = new Map<string, AutomergeMetricEvent>();
+  for (const event of [...currentEvents, incoming]) {
+    const normalized = normalizeAutomergeMetricEvent(event);
+    if (normalized && Date.parse(normalized.occurred_at) >= cutoff)
+      byId.set(normalized.event_id, normalized);
+  }
+  const events = [...byId.values()]
+    .sort((a, b) => Date.parse(a.occurred_at) - Date.parse(b.occurred_at))
+    .slice(-20_000);
+  return { version: 1, telemetry_since: events[0]?.occurred_at ?? null, events };
+}
+
+export function summarizeAutomergeMetrics(
+  ledger: unknown,
+  options: {
+    range?: string;
+    repo?: string | null;
+    policyVersion?: string | null;
+    now?: string;
+  } = {},
+) {
+  const range = isRange(options.range) ? options.range : "7d";
+  const nowMs = Date.parse(options.now ?? new Date().toISOString());
+  const config = RANGE_CONFIG[range];
+  const rangeStart = nowMs - config.durationMs;
+  const allEvents = Array.isArray((ledger as AutomergeMetricLedger | null)?.events)
+    ? ((ledger as AutomergeMetricLedger).events
+        .map(normalizeAutomergeMetricEvent)
+        .filter(Boolean) as AutomergeMetricEvent[])
+    : [];
+  const filtered = allEvents.filter(
+    (event) =>
+      (!options.repo || event.repository === options.repo) &&
+      (!options.policyVersion || event.policy_version === options.policyVersion),
+  );
+  const sessions = projectSessions(filtered);
+  const terminal = sessions.filter(
+    (session) =>
+      session.terminal_at &&
+      Date.parse(session.terminal_at) >= rangeStart &&
+      Date.parse(session.terminal_at) <= nowMs,
+  );
+  const merged = terminal.filter((session) => session.outcome === "merged");
+  const latencies = merged
+    .map((session) => Date.parse(session.terminal_at!) - Date.parse(session.activated_at ?? ""))
+    .filter((value) => Number.isFinite(value) && value >= 0);
+  const syncCounts = terminal.map((session) => session.base_sync_count);
+  const buckets = [];
+  for (let start = rangeStart; start < nowMs; start += config.bucketMs) {
+    const end = Math.min(start + config.bucketMs, nowMs);
+    const bucketSessions = terminal.filter((session) => {
+      const at = Date.parse(session.terminal_at!);
+      return at >= start && (at < end || (end === nowMs && at === end));
+    });
+    const bucketMerged = bucketSessions.filter((session) => session.outcome === "merged");
+    const bucketLatencies = bucketMerged
+      .map((session) => Date.parse(session.terminal_at!) - Date.parse(session.activated_at ?? ""))
+      .filter((value) => Number.isFinite(value) && value >= 0);
+    buckets.push({
+      start: new Date(start).toISOString(),
+      end: new Date(end).toISOString(),
+      terminal_count: bucketSessions.length,
+      merged_count: bucketMerged.length,
+      success_rate_percent: bucketSessions.length
+        ? percent(bucketMerged.length, bucketSessions.length)
+        : null,
+      command_to_merge_p50_ms: percentile(bucketLatencies, 0.5),
+      command_to_merge_p90_ms: percentile(bucketLatencies, 0.9),
+      low_sample: bucketSessions.length > 0 && bucketSessions.length < 5,
+    });
+  }
+  const outcomes: Record<string, number> = {};
+  for (const session of terminal)
+    outcomes[session.outcome ?? "unknown"] = (outcomes[session.outcome ?? "unknown"] ?? 0) + 1;
+  const active = sessions.filter((session) => {
+    const lastEventAt = Date.parse(session.last_event_at);
+    return !session.terminal_at && lastEventAt >= rangeStart && lastEventAt <= nowMs;
+  });
+  const recentSessions = sessions
+    .filter((session) => Date.parse(session.terminal_at ?? session.last_event_at) >= rangeStart)
+    .sort(
+      (a, b) =>
+        Date.parse(b.terminal_at ?? b.last_event_at) - Date.parse(a.terminal_at ?? a.last_event_at),
+    )
+    .slice(0, 30);
+  const filtersActive = Boolean(options.repo || options.policyVersion);
+  const telemetrySince = filtersActive
+    ? (filtered[0]?.occurred_at ?? null)
+    : ((ledger as AutomergeMetricLedger | null)?.telemetry_since ??
+      allEvents[0]?.occurred_at ??
+      null);
+  return {
+    generated_at: new Date(nowMs).toISOString(),
+    range,
+    range_start: new Date(rangeStart).toISOString(),
+    telemetry_since: telemetrySince,
+    coverage_percent: telemetrySince
+      ? Math.max(
+          0,
+          Math.min(
+            100,
+            Math.round(
+              ((nowMs - Math.max(rangeStart, Date.parse(telemetrySince))) / config.durationMs) *
+                100,
+            ),
+          ),
+        )
+      : 0,
+    filters: {
+      repo: options.repo ?? null,
+      policy_version: options.policyVersion ?? null,
+      repositories: [...new Set(allEvents.map((event) => event.repository))].sort(),
+      policy_versions: [...new Set(allEvents.map((event) => event.policy_version))].sort(),
+    },
+    summary: {
+      terminal_sessions: terminal.length,
+      merged_sessions: merged.length,
+      merge_success_rate_percent: terminal.length ? percent(merged.length, terminal.length) : null,
+      command_to_merge_p50_ms: percentile(latencies, 0.5),
+      command_to_merge_p90_ms: percentile(latencies, 0.9),
+      base_sync_p50: percentile(syncCounts, 0.5),
+      base_sync_p90: percentile(syncCounts, 0.9),
+      multi_rebase_rate_percent: terminal.length
+        ? percent(
+            terminal.filter((session) => session.base_sync_count >= 2).length,
+            terminal.length,
+          )
+        : null,
+      active_sessions: active.length,
+    },
+    buckets,
+    terminal_outcomes: outcomes,
+    repair_efficiency: {
+      zero_base_sync: terminal.filter((session) => session.base_sync_count === 0).length,
+      one_base_sync: terminal.filter((session) => session.base_sync_count === 1).length,
+      multiple_base_sync: terminal.filter((session) => session.base_sync_count >= 2).length,
+    },
+    sessions: recentSessions,
+  };
+}
+
+function projectSessions(events: AutomergeMetricEvent[]) {
+  const grouped = new Map<string, AutomergeMetricEvent[]>();
+  for (const event of events)
+    grouped.set(event.session_id, [...(grouped.get(event.session_id) ?? []), event]);
+  return [...grouped.entries()].map(([sessionId, rows]) => {
+    rows.sort((a, b) => Date.parse(a.occurred_at) - Date.parse(b.occurred_at));
+    const first = rows[0]!;
+    const activation = rows.find((row) => row.phase === "activated");
+    // A session's first terminal event is authoritative. Delivery is asynchronous, and a
+    // later observer can report a lower-fidelity outcome (for example, pr_closed after merged).
+    // Keeping the first terminal makes completed product metrics immutable.
+    const terminal = rows.find((row) => row.phase === "terminal");
+    const last = rows.at(-1)!;
+    return {
+      session_id: sessionId,
+      repository: first.repository,
+      item_number: first.item_number,
+      pr_url: last.pr_url ?? first.pr_url,
+      run_url: [...rows].reverse().find((row) => row.run_url)?.run_url ?? null,
+      policy_version: activation?.policy_version ?? first.policy_version,
+      activated_at: activation?.occurred_at ?? null,
+      terminal_at: terminal?.occurred_at ?? null,
+      outcome: terminal?.outcome ?? null,
+      state: terminal?.outcome ?? last.state ?? phaseState(last.phase),
+      last_reason: last.reason ?? null,
+      last_event_at: last.occurred_at,
+      repairs: rows.filter((row) => row.phase === "repair_completed").length,
+      base_sync_count: rows.filter((row) => row.phase === "repair_completed" && row.base_sync)
+        .length,
+      activation_missing: !activation,
+    };
+  });
+}
+
+export function percentile(values: number[], quantile: number): number | null {
+  if (!values.length) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.max(0, Math.ceil(quantile * sorted.length) - 1)] ?? null;
+}
+
+function phaseState(phase: AutomergeMetricPhase) {
+  if (phase === "repair_dispatched" || phase === "repair_completed") return "repairing";
+  return phase;
+}
+
+function percent(part: number, total: number) {
+  return Math.round((part / total) * 1000) / 10;
+}
+
+function nullableText(value: unknown) {
+  const text = String(value ?? "").trim();
+  return text || null;
+}
+
+function isRange(value: unknown): value is AutomergeMetricRange {
+  return value === "6h" || value === "24h" || value === "7d";
+}

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -28,6 +28,16 @@ import {
   type ExactReviewCompletionOutcome,
   type ExactReviewDecision,
 } from "./exact-review-queue.ts";
+import {
+  AUTOMERGE_METRICS_EVENT_TYPE,
+  AUTOMERGE_METRICS_EVENT_KEY_PREFIX,
+  AUTOMERGE_METRICS_EVENT_ID_KEY_PREFIX,
+  AUTOMERGE_METRICS_EVENT_LIMIT,
+  AUTOMERGE_METRICS_STORE_KEY,
+  AUTOMERGE_METRICS_TTL_SECONDS,
+  normalizeAutomergeMetricEvent,
+  summarizeAutomergeMetrics,
+} from "./automerge-metrics.ts";
 
 export {
   ExactReviewQueue,
@@ -274,6 +284,27 @@ export class StatusStore {
     const key = decodeURIComponent(url.pathname.slice(1));
     if (!key) return new Response("missing key", { status: 400 });
 
+    if (request.method === "GET" && key === AUTOMERGE_METRICS_STORE_KEY) {
+      const entries = (await this.storage.list({
+        prefix: AUTOMERGE_METRICS_EVENT_KEY_PREFIX,
+        limit: AUTOMERGE_METRICS_EVENT_LIMIT,
+        reverse: true,
+      })) as Map<string, StoredValue>;
+      const events = [];
+      for (const [entryKey, stored] of entries) {
+        if (!entryKey.startsWith(AUTOMERGE_METRICS_EVENT_KEY_PREFIX)) continue;
+        if (stored.expires_at && stored.expires_at <= Date.now()) continue;
+        try {
+          const event = normalizeAutomergeMetricEvent(JSON.parse(stored.value));
+          if (event) events.push(event);
+        } catch {
+          // A malformed isolated event must not hide the rest of the metric history.
+        }
+      }
+      events.sort((a, b) => Date.parse(a.occurred_at) - Date.parse(b.occurred_at));
+      return json({ version: 1, telemetry_since: events[0]?.occurred_at ?? null, events });
+    }
+
     if (request.method === "GET") {
       const stored = (await this.storage.get(key)) as StoredValue | undefined;
       if (!stored) return new Response(null, { status: 404 });
@@ -372,6 +403,28 @@ export class StatusStore {
       return json({ ok: true });
     }
 
+    if (request.method === "POST" && key === AUTOMERGE_METRICS_STORE_KEY) {
+      const body = await request.json();
+      const event = normalizeAutomergeMetricEvent(body?.event);
+      if (!event) return new Response("invalid automerge metric event", { status: 400 });
+      const expiresAt = Date.parse(event.occurred_at) + AUTOMERGE_METRICS_TTL_SECONDS * 1000;
+      if (expiresAt <= Date.now()) return json({ ok: true, expired: true });
+      const idKey = `${AUTOMERGE_METRICS_EVENT_ID_KEY_PREFIX}${encodeURIComponent(event.event_id)}`;
+      const existing = (await this.storage.get(idKey)) as StoredValue | undefined;
+      if (existing && (!existing.expires_at || existing.expires_at > Date.now())) {
+        return json({ ok: true, duplicate: true });
+      }
+      const eventKey = `${AUTOMERGE_METRICS_EVENT_KEY_PREFIX}${event.occurred_at}:${encodeURIComponent(event.event_id)}`;
+      // Durable Object multi-key put is atomic, so a retry cannot observe an ID
+      // receipt without its time-ordered event (or vice versa).
+      await this.storage.put({
+        [eventKey]: { value: JSON.stringify(event), expires_at: expiresAt },
+        [idKey]: { value: eventKey, expires_at: expiresAt },
+      });
+      await this.scheduleCleanup(expiresAt);
+      return json({ ok: true });
+    }
+
     if (request.method === "POST" && key === "health-history") {
       const body = await request.json();
       const sample = normalizeHealthHistorySample(body?.sample);
@@ -461,6 +514,8 @@ export default {
       return exactReviewQueueRequest(env, "/stats");
     if (url.pathname === "/api/health-history" && request.method === "GET")
       return healthHistoryJson(request, env);
+    if (url.pathname === "/api/automerge-metrics" && request.method === "GET")
+      return automergeMetricsJson(request, env);
     if (url.pathname === "/api/status") return statusJson(request, env, ctx);
     if (url.pathname === "/api/triage") return triageJson(request, env, ctx);
     if (url.pathname === "/api/pr-proof-triage") return prProofTriageJson(request, env, ctx);
@@ -790,15 +845,46 @@ async function ingestEvent(request, env) {
   if (!env.INGEST_TOKEN || token !== env.INGEST_TOKEN) return json({ error: "unauthorized" }, 401);
   const body = await request.json().catch(() => null);
   if (!body || typeof body !== "object") return json({ error: "invalid_json" }, 400);
+  let metricEvent = null;
+  if (body.event_type === AUTOMERGE_METRICS_EVENT_TYPE) {
+    metricEvent = normalizeAutomergeMetricEvent(body);
+    if (!metricEvent) return json({ error: "invalid_automerge_metric_event" }, 400);
+    if (!isDurableStatusStore(env.STATUS_STORE)) {
+      return json({ error: "automerge_metrics_store_unavailable" }, 503);
+    }
+  }
   const event = normalizeEvent(body);
   const writes = [
     prependStoredEvent(env, event),
     writeStoredJson(env, "latest-event", event, EVENT_STORE_TTL_SECONDS),
   ];
+  if (metricEvent) writes.push(storeAutomergeMetricEvent(env, metricEvent));
   const ci = normalizeCiStatus(body);
   if (ci) writes.push(writeCiStatus(env, ci));
   await Promise.all(writes);
   return json({ ok: true, event });
+}
+
+async function automergeMetricsJson(request, env) {
+  const url = new URL(request.url);
+  const ledger = await readStoredJson(env, AUTOMERGE_METRICS_STORE_KEY);
+  return json(
+    summarizeAutomergeMetrics(ledger, {
+      range: url.searchParams.get("range") ?? "7d",
+      repo: url.searchParams.get("repo"),
+      policyVersion: url.searchParams.get("policy_version"),
+    }),
+  );
+}
+
+async function storeAutomergeMetricEvent(env, event) {
+  const store = env.STATUS_STORE;
+  if (!isDurableStatusStore(store)) throw new Error("automerge metrics require durable storage");
+  const response = await durableStatusStoreStub(store).fetch(
+    statusStoreRequest(AUTOMERGE_METRICS_STORE_KEY, "POST"),
+    { method: "POST", body: JSON.stringify({ event }) },
+  );
+  if (!response.ok) throw new Error(`automerge metric write failed: ${response.status}`);
 }
 
 async function githubWebhook(request, env, ctx) {
@@ -7777,6 +7863,35 @@ a.pill:hover { color: var(--claw); text-decoration: none; }
   text-align: center;
 }
 .empty::before { content: "🦞 "; opacity: 0.5; }
+.automerge-health { margin: 28px 0; padding: 22px; border: 1px solid var(--line); border-radius: 14px; background: var(--panel); }
+.automerge-health-head, .automerge-controls, .automerge-meta, .automerge-tabs { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.automerge-health-head { justify-content: space-between; }
+.automerge-health h2 { margin: 0; }
+.automerge-controls select { max-width: 220px; padding: 6px 9px; border: 1px solid var(--line); border-radius: 8px; color: var(--text); background: var(--panel); font: inherit; font-size: 11px; }
+.automerge-meta { margin-top: 8px; color: var(--muted); font-size: 11px; }
+.automerge-kpis { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); margin-top: 20px; border-block: 1px solid var(--line-soft); }
+.automerge-kpi { padding: 18px; border-left: 1px solid var(--line-soft); }
+.automerge-kpi:first-child { border-left: 0; }
+.automerge-kpi span { display: block; color: var(--muted); font-size: 10px; text-transform: uppercase; letter-spacing: .08em; }
+.automerge-kpi strong { display: block; margin: 8px 0 5px; font-size: 25px; font-weight: 560; }
+.automerge-kpi small { color: var(--muted); }
+.automerge-chart-shell { margin-top: 20px; }
+.automerge-tabs button { border: 0; border-bottom: 2px solid transparent; padding: 7px 2px; background: transparent; color: var(--muted); cursor: pointer; font: inherit; }
+.automerge-tabs button.active { color: var(--text); border-color: var(--claw); }
+.automerge-chart { display: grid; grid-auto-flow: column; grid-auto-columns: minmax(18px, 1fr); align-items: end; gap: 3px; height: 190px; margin-top: 12px; padding: 12px 4px 22px; border-bottom: 1px solid var(--line); background: repeating-linear-gradient(to bottom, var(--line-soft) 0 1px, transparent 1px 42px); overflow-x: auto; }
+.automerge-point { position: relative; height: 100%; min-width: 18px; }
+.automerge-dot { position: absolute; left: 50%; width: 9px; height: 9px; translate: -50% 50%; border-radius: 50%; background: var(--claw); box-shadow: 0 0 0 3px var(--panel); }
+.automerge-dot.low { background: var(--panel); border: 2px solid var(--claw); }
+.automerge-dot.p90 { width: 7px; height: 7px; background: var(--amber); }
+.automerge-n { position: absolute; left: 50%; bottom: -19px; translate: -50% 0; color: var(--muted); font-size: 9px; white-space: nowrap; }
+.automerge-chart-legend { margin-top: 7px; color: var(--muted); font-size: 10px; }
+.automerge-details { display: grid; grid-template-columns: 1fr 1fr; gap: 28px; margin-top: 22px; }
+.automerge-details h3, .automerge-sessions h3 { margin: 0 0 10px; font-size: 12px; text-transform: uppercase; letter-spacing: .08em; }
+.automerge-detail-row { display: flex; justify-content: space-between; padding: 7px 0; border-bottom: 1px solid var(--line-soft); font-size: 12px; }
+.automerge-sessions { margin-top: 22px; overflow-x: auto; }
+.automerge-table { width: 100%; border-collapse: collapse; font-size: 11px; }
+.automerge-table th, .automerge-table td { padding: 9px 8px; border-bottom: 1px solid var(--line-soft); text-align: left; white-space: nowrap; }
+.automerge-table th { color: var(--muted); font-weight: 500; }
 @media (max-width: 1280px) {
   .grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
   .metric { padding: 16px 18px 14px; }
@@ -7797,6 +7912,10 @@ a.pill:hover { color: var(--claw); text-decoration: none; }
   .flow-node::after { top: 5px; }
 }
 @media (max-width: 760px) {
+  .automerge-kpis { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .automerge-kpi:nth-child(3) { border-left: 0; border-top: 1px solid var(--line-soft); }
+  .automerge-kpi:nth-child(4) { border-top: 1px solid var(--line-soft); }
+  .automerge-details { grid-template-columns: 1fr; }
   .grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .metric:nth-child(3n + 1) { border-left: 1px solid var(--line-soft); padding-left: 18px; }
   .metric:nth-child(2n + 1) { border-left: 0; padding-left: 0; }
@@ -7882,6 +8001,22 @@ a.pill:hover { color: var(--claw); text-decoration: none; }
     </div>
     <div id="workers"></div>
   </section>
+  <section class="automerge-health" aria-labelledby="automerge-product-title">
+    <div class="automerge-health-head">
+      <h2 id="automerge-product-title">Automerge Product Health</h2>
+      <div class="automerge-controls">
+        <div class="trend-ranges" id="automerge-ranges" aria-label="Automerge metric range">
+          <button class="trend-range" type="button" data-automerge-range="6h">6h</button>
+          <button class="trend-range" type="button" data-automerge-range="24h">24h</button>
+          <button class="trend-range active" type="button" data-automerge-range="7d">7d</button>
+        </div>
+        <label class="muted">Repo <select id="automerge-repo" aria-label="Filter automerge metrics by repository"><option value="">All</option></select></label>
+        <label class="muted">Policy <select id="automerge-policy" aria-label="Filter automerge metrics by policy"><option value="">All</option></select></label>
+      </div>
+    </div>
+    <div class="automerge-meta" id="automerge-meta">Loading product telemetry…</div>
+    <div id="automerge-product"><div class="empty">Loading automerge product metrics…</div></div>
+  </section>
   <section class="split">
     <div class="left-col">
       <div class="pipeline-col">
@@ -7894,15 +8029,14 @@ a.pill:hover { color: var(--claw); text-decoration: none; }
       </div>
     </div>
     <aside class="side-col">
-      <h2>Automerge Reliability</h2>
-      <div id="automerge-reliability"></div>
-      <h2>Automerge Speed</h2>
-      <div id="automerge"></div>
       <h2>Closed by ClawSweeper</h2>
       <div id="closed-stats"></div>
       <div id="closed"></div>
       <h2>Worker Health</h2>
       <div id="worker-health"></div>
+      <h2>Automerge Reliability</h2>
+      <div id="automerge-reliability"></div>
+      <div id="automerge" hidden></div>
       <h2>Operations</h2>
       <div id="operations"></div>
       <h2>Recent Activity</h2>
@@ -7988,6 +8122,10 @@ function ciBadge(ci) {
 }
 let lastData = null;
 let loading = false;
+let activeAutomergeRange = "7d";
+let activeAutomergeChart = "success";
+let lastAutomergeMetrics = null;
+let automergeMetricsRequestGeneration = 0;
 let activeWorkerFilter = "all";
 let workerIndex = new Map();
 let automaticIndex = new Map();
@@ -8621,6 +8759,7 @@ async function load() {
         : "",
   );
   loadHealthHistory(activeHealthRange, false).catch(() => undefined);
+  loadAutomergeMetrics().catch(() => undefined);
   } catch (error) {
     if (lastData) {
       renderDashboard(lastData, "Live refresh failed; showing last good status.");
@@ -9046,6 +9185,57 @@ function renderAutomerge(rows) {
   }
   document.getElementById("automerge").innerHTML = '<div class="side-list">' + rows.map(row => '<article class="side-row"><div class="side-main">' + linkClass(row.url, "#" + row.number, "item-link") + '<div class="muted side-title">' + esc(row.title) + '</div></div><div class="side-meta"><span class="pill violet">' + (row.duration_ms ? elapsed(row.duration_ms) : "unknown") + '</span><span>' + (row.merged_at ? since(row.merged_at) : "") + '</span></div></article>').join("") + '</div>';
 }
+async function loadAutomergeMetrics() {
+  const generation = ++automergeMetricsRequestGeneration;
+  const params = new URLSearchParams({ range: activeAutomergeRange });
+  const repo = document.getElementById("automerge-repo").value;
+  const policy = document.getElementById("automerge-policy").value;
+  if (repo) params.set("repo", repo);
+  if (policy) params.set("policy_version", policy);
+  const response = await fetch("/api/automerge-metrics?" + params.toString(), { cache: "no-store" });
+  if (!response.ok) throw new Error("automerge metrics returned " + response.status);
+  const metrics = await response.json();
+  if (generation !== automergeMetricsRequestGeneration) return;
+  lastAutomergeMetrics = metrics;
+  renderAutomergeProduct(lastAutomergeMetrics);
+}
+function renderAutomergeProduct(data) {
+  const summary = data.summary || {};
+  const setOptions = (id, values, selected) => {
+    const select = document.getElementById(id);
+    select.innerHTML = '<option value="">All</option>' + (values || []).map(value => '<option value="' + esc(value) + '"' + (value === selected ? ' selected' : '') + '>' + esc(value) + '</option>').join("");
+  };
+  setOptions("automerge-repo", data.filters?.repositories, data.filters?.repo);
+  setOptions("automerge-policy", data.filters?.policy_versions, data.filters?.policy_version);
+  const sinceText = data.telemetry_since ? new Date(data.telemetry_since).toLocaleString() : "not started";
+  document.getElementById("automerge-meta").textContent = "Telemetry since " + sinceText + " · Coverage " + fmt.format(data.coverage_percent || 0) + "% · terminal sample n=" + fmt.format(summary.terminal_sessions || 0) + " · Updated " + since(data.generated_at);
+  const value = (number, suffix) => number == null ? "—" : fmt.format(number) + (suffix || "");
+  const duration = number => number == null ? "—" : elapsed(number);
+  const kpis = '<div class="automerge-kpis">' +
+    '<div class="automerge-kpi"><span>Merge success rate</span><strong>' + value(summary.merge_success_rate_percent, "%") + '</strong><small>merged ' + fmt.format(summary.merged_sessions || 0) + ' / terminal ' + fmt.format(summary.terminal_sessions || 0) + '</small></div>' +
+    '<div class="automerge-kpi"><span>Command → Merge p50</span><strong>' + duration(summary.command_to_merge_p50_ms) + '</strong><small>successful sessions only</small></div>' +
+    '<div class="automerge-kpi"><span>Command → Merge p90</span><strong>' + duration(summary.command_to_merge_p90_ms) + '</strong><small>nearest-rank percentile</small></div>' +
+    '<div class="automerge-kpi"><span>Base sync / session</span><strong>' + value(summary.base_sync_p50) + ' · ' + value(summary.base_sync_p90) + '</strong><small>p50 · p90 · multi-rebase ' + value(summary.multi_rebase_rate_percent, "%") + '</small></div></div>';
+  const maxLatency = Math.max(1, ...(data.buckets || []).flatMap(bucket => [bucket.command_to_merge_p50_ms || 0, bucket.command_to_merge_p90_ms || 0]));
+  const points = (data.buckets || []).map(bucket => {
+    if (activeAutomergeChart === "success") {
+      if (bucket.success_rate_percent == null) return '<div class="automerge-point" title="No terminal samples"></div>';
+      return '<div class="automerge-point" title="' + esc(bucket.start + ' · ' + bucket.success_rate_percent + '% · n=' + bucket.terminal_count) + '"><i class="automerge-dot' + (bucket.low_sample ? ' low' : '') + '" style="bottom:' + bucket.success_rate_percent + '%"></i><span class="automerge-n">n=' + fmt.format(bucket.terminal_count) + '</span></div>';
+    }
+    if (bucket.command_to_merge_p50_ms == null) return '<div class="automerge-point" title="No merged samples"></div>';
+    const p50 = Math.round(bucket.command_to_merge_p50_ms / maxLatency * 100);
+    const p90 = Math.round(bucket.command_to_merge_p90_ms / maxLatency * 100);
+    return '<div class="automerge-point" title="' + esc(bucket.start + ' · p50 ' + duration(bucket.command_to_merge_p50_ms) + ' · p90 ' + duration(bucket.command_to_merge_p90_ms)) + '"><i class="automerge-dot" style="bottom:' + p50 + '%"></i><i class="automerge-dot p90" style="bottom:' + p90 + '%"></i><span class="automerge-n">n=' + fmt.format(bucket.merged_count) + '</span></div>';
+  }).join("");
+  const chart = '<div class="automerge-chart-shell"><div class="automerge-tabs"><button type="button" data-automerge-chart="success" class="' + (activeAutomergeChart === "success" ? "active" : "") + '">Merge success</button><button type="button" data-automerge-chart="latency" class="' + (activeAutomergeChart === "latency" ? "active" : "") + '">Merge latency</button></div><div class="automerge-chart" role="img" aria-label="Automerge ' + esc(activeAutomergeChart) + ' trend over ' + esc(activeAutomergeRange) + '">' + points + '</div><div class="automerge-chart-legend">' + (activeAutomergeChart === "success" ? '● normal sample · ○ fewer than 5 terminal sessions · gaps mean no terminal sample' : '● p50 · amber p90 · gaps mean no merged sample') + '</div></div>';
+  const outcomeLabels = { merged: "Merged", maintainer_stopped: "Maintainer stopped", repair_cap_exhausted: "Repair cap exhausted", pr_closed: "PR closed", automerge_disabled: "Automerge disabled" };
+  const outcomes = Object.entries(outcomeLabels).map(entry => '<div class="automerge-detail-row"><span>' + esc(entry[1]) + '</span><strong>' + fmt.format(data.terminal_outcomes?.[entry[0]] || 0) + '</strong></div>').join("");
+  const efficiency = [['0 base sync sessions', data.repair_efficiency?.zero_base_sync], ['1 base sync session', data.repair_efficiency?.one_base_sync], ['2+ base sync sessions', data.repair_efficiency?.multiple_base_sync], ['Multi-rebase rate', value(summary.multi_rebase_rate_percent, "%")]].map(entry => '<div class="automerge-detail-row"><span>' + esc(entry[0]) + '</span><strong>' + esc(entry[1] ?? 0) + '</strong></div>').join("");
+  const details = '<div class="automerge-details"><div><h3>Terminal outcomes</h3>' + outcomes + '</div><div><h3>Repair efficiency</h3>' + efficiency + '</div></div>';
+  const rows = (data.sessions || []).map(session => '<tr><td>' + linkClass(session.pr_url, session.repository + '#' + session.item_number, "item-link") + '</td><td>' + esc(session.state || 'unknown') + '</td><td>' + esc(session.policy_version) + '</td><td>' + esc(session.activated_at ? since(session.activated_at) : 'missing') + '</td><td>' + esc(session.terminal_at ? since(session.terminal_at) : since(session.last_event_at)) + '</td><td>' + fmt.format(session.base_sync_count || 0) + '</td><td>' + fmt.format(session.repairs || 0) + '</td><td>' + esc(session.last_reason || '') + ' ' + linkClass(session.run_url, 'run', 'pill run-link') + '</td></tr>').join("");
+  const sessions = '<div class="automerge-sessions"><h3>Recent automerge sessions</h3><table class="automerge-table"><thead><tr><th>PR</th><th>State</th><th>Policy</th><th>Activated</th><th>Terminal / age</th><th>Syncs</th><th>Repairs</th><th>Last reason</th></tr></thead><tbody>' + (rows || '<tr><td colspan="8" class="muted">No session telemetry in this range.</td></tr>') + '</tbody></table></div>';
+  document.getElementById("automerge-product").innerHTML = kpis + chart + details + sessions;
+}
 function renderAutomergeReliability(reliability) {
   const safe = reliability || {
     sampled_runs: 0,
@@ -9113,6 +9303,21 @@ document.getElementById("trend-ranges").addEventListener("click", event => {
   document.querySelectorAll("button[data-trend-range]").forEach(item => item.classList.toggle("active", item === button));
   loadHealthHistory(button.dataset.trendRange || "6h", true).catch(() => undefined);
 });
+document.getElementById("automerge-ranges").addEventListener("click", event => {
+  const button = event.target.closest("button[data-automerge-range]");
+  if (!button) return;
+  activeAutomergeRange = button.dataset.automergeRange || "7d";
+  document.querySelectorAll("button[data-automerge-range]").forEach(item => item.classList.toggle("active", item === button));
+  loadAutomergeMetrics().catch(() => undefined);
+});
+document.getElementById("automerge-product").addEventListener("click", event => {
+  const button = event.target.closest("button[data-automerge-chart]");
+  if (!button || !lastAutomergeMetrics) return;
+  activeAutomergeChart = button.dataset.automergeChart || "success";
+  renderAutomergeProduct(lastAutomergeMetrics);
+});
+document.getElementById("automerge-repo").addEventListener("change", () => loadAutomergeMetrics().catch(() => undefined));
+document.getElementById("automerge-policy").addEventListener("change", () => loadAutomergeMetrics().catch(() => undefined));
 document.getElementById("workers").addEventListener("click", event => {
   const button = event.target.closest("button[data-worker-id]");
   if (!button) return;

--- a/src/repair/automerge-product-telemetry.ts
+++ b/src/repair/automerge-product-telemetry.ts
@@ -1,0 +1,144 @@
+import type { LooseRecord } from "./json-types.js";
+
+export const AUTOMERGE_POLICY_VERSION = "immediate-v1";
+const DEFAULT_AUTOMERGE_METRIC_TIMEOUT_MS = 5_000;
+
+export function automergeSessionId(activation: LooseRecord) {
+  const repository = String(activation.repo ?? "").trim();
+  const itemNumber = Number(activation.issue_number);
+  const commentId = String(activation.comment_id ?? "").trim();
+  const updatedAt = String(
+    activation.comment_updated_at ?? activation.comment_created_at ?? "",
+  ).trim();
+  if (!repository || !Number.isInteger(itemNumber) || !commentId || !updatedAt) return null;
+  return `${repository}#${itemNumber}:${commentId}:${updatedAt}`;
+}
+
+export function latestAutomergeActivationForCommand(
+  command: LooseRecord,
+  candidates: LooseRecord[],
+) {
+  const commandAt =
+    Date.parse(String(command.comment_updated_at ?? command.comment_created_at ?? "")) ||
+    Number.POSITIVE_INFINITY;
+  const latestPriorStopAt = candidates.reduce((latest, entry) => {
+    if (
+      entry?.repo !== command.repo ||
+      Number(entry?.issue_number) !== Number(command.issue_number)
+    )
+      return latest;
+    if (entry?.intent !== "stop" || !["ready", "executed"].includes(String(entry?.status ?? "")))
+      return latest;
+    const stoppedAt =
+      Date.parse(String(entry.comment_updated_at ?? entry.comment_created_at ?? "")) || 0;
+    return stoppedAt < commandAt ? Math.max(latest, stoppedAt) : latest;
+  }, 0);
+  return candidates
+    .filter((entry) => {
+      const activationAt =
+        Date.parse(String(entry?.comment_updated_at ?? entry?.comment_created_at ?? "")) || 0;
+      return (
+        entry?.repo === command.repo &&
+        Number(entry?.issue_number) === Number(command.issue_number) &&
+        entry?.intent === "automerge" &&
+        !entry?.trusted_bot &&
+        activationAt > latestPriorStopAt &&
+        activationAt <= commandAt &&
+        ["ready", "executed", "waiting"].includes(String(entry?.status ?? ""))
+      );
+    })
+    .sort(
+      (left, right) =>
+        (Date.parse(String(right.comment_updated_at ?? right.comment_created_at ?? "")) || 0) -
+        (Date.parse(String(left.comment_updated_at ?? left.comment_created_at ?? "")) || 0),
+    )[0];
+}
+
+export function automergeMetricEvent({
+  activation,
+  command,
+  phase,
+  state,
+  outcome,
+  reason,
+  runUrl,
+}: {
+  activation: LooseRecord;
+  command: LooseRecord;
+  phase: "activated" | "repair_dispatched" | "state_changed" | "terminal";
+  state?: string | null;
+  outcome?: string | null;
+  reason?: string | null;
+  runUrl?: string | null;
+}) {
+  const sessionId = automergeSessionId(activation);
+  if (!sessionId) return null;
+  const occurredAt = String(
+    phase === "activated"
+      ? (activation.comment_updated_at ?? activation.comment_created_at)
+      : new Date().toISOString(),
+  );
+  return {
+    event_type: "clawsweeper.automerge_metric",
+    event_id: `${sessionId}:${phase}:${command.comment_id ?? occurredAt}:${outcome ?? state ?? reason ?? "event"}`,
+    session_id: sessionId,
+    phase,
+    occurred_at: occurredAt,
+    repository: String(command.repo),
+    item_number: Number(command.issue_number),
+    policy_version: AUTOMERGE_POLICY_VERSION,
+    state: state ?? null,
+    outcome: outcome ?? null,
+    reason: reason ?? null,
+    pr_url: `https://github.com/${String(command.repo)}/pull/${Number(command.issue_number)}`,
+    run_url: runUrl ?? null,
+  };
+}
+
+// Product telemetry must never become part of the automerge control plane. The
+// caller can await this for bounded delivery, but every transport failure is a skip.
+export async function postAutomergeMetricBestEffort(
+  event: ReturnType<typeof automergeMetricEvent>,
+  env: NodeJS.ProcessEnv = process.env,
+  fetcher: typeof fetch = fetch,
+) {
+  if (!event) return false;
+  const token = String(env.CLAWSWEEPER_STATUS_INGEST_TOKEN ?? "").trim();
+  if (!token) return false;
+  const baseUrl = String(
+    env.CLAWSWEEPER_STATUS_INGEST_URL ??
+      `${String(env.CLAWSWEEPER_STATUS_URL ?? "https://clawsweeper.openclaw.ai").replace(/\/$/, "")}/api/events`,
+  );
+  const timeoutMs = positiveTimeout(
+    env.CLAWSWEEPER_AUTOMERGE_METRIC_TIMEOUT_MS,
+    DEFAULT_AUTOMERGE_METRIC_TIMEOUT_MS,
+  );
+  const controller = new AbortController();
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    const response = await Promise.race([
+      fetcher(baseUrl, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+        body: JSON.stringify(event),
+        signal: controller.signal,
+      }),
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => {
+          controller.abort();
+          reject(new Error("automerge metric ingest timed out"));
+        }, timeoutMs);
+      }),
+    ]);
+    return response.ok;
+  } catch {
+    return false;
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+function positiveTimeout(value: unknown, fallback: number) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.min(parsed, 30_000) : fallback;
+}

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -88,6 +88,13 @@ import {
 } from "./comment-router-core.js";
 import { mergeAutomergeTimelineSection } from "./automerge-status-timeline.js";
 import {
+  automergeSessionId,
+  automergeMetricEvent,
+  latestAutomergeActivationForCommand,
+  postAutomergeMetricBestEffort,
+} from "./automerge-product-telemetry.js";
+
+import {
   SUPERSEDED_RE_REVIEW_REASON,
   appendLedger,
   commentBodySha256,
@@ -139,6 +146,8 @@ import {
   runCommandMutation,
   runCommandMutationWithRetry,
 } from "./command-action-ledger.js";
+
+const automergeMetricWrites: Promise<boolean>[] = [];
 
 const args = parseArgs(process.argv.slice(2));
 const config = readCommentRouterConfig(args);
@@ -389,7 +398,10 @@ if (execute && !exactCommentVersionFastPath.suppress) {
     for (const command of commands) convergePrecreatedCommandAckComments(command);
     for (const command of commands) acknowledgeSkippedMaintainerCommand(command);
     for (const command of commands) {
-      if (command.status !== "ready") recordCommandOutcome(command);
+      if (command.status !== "ready") {
+        recordCommandOutcome(command);
+        queueAutomergeProductMetrics(command);
+      }
     }
     for (const command of actionable) executeCommandWithReceipt(command);
   });
@@ -403,6 +415,7 @@ report.timings = {
 };
 if (writeReport) writeReportFile(repoRoot(), report);
 await flushCommandActionEvents();
+await Promise.allSettled(automergeMetricWrites);
 console.log(JSON.stringify(report, null, 2));
 
 function measure<T>(name: string, fn: () => T): T {
@@ -2336,10 +2349,118 @@ function executeCommandWithReceipt(command: LooseRecord) {
   try {
     executeCommand(command);
     recordCommandOutcome(command);
+    queueAutomergeProductMetrics(command);
   } catch (error) {
     recordCommandFailure(command, error);
     throw error;
   }
+}
+
+function queueAutomergeProductMetrics(command: LooseRecord) {
+  const activation = latestAutomergeActivation(command);
+  if (!activation) return;
+  const events = [];
+  if (command === activation && command.intent === "automerge" && !command.trusted_bot) {
+    events.push(
+      automergeMetricEvent({
+        activation,
+        command,
+        phase: "activated",
+        state: command.status === "waiting" ? "waiting" : "active",
+        reason: command.reason,
+      }),
+    );
+  }
+  const repair = command.actions?.find(
+    (action: JsonValue) =>
+      action.action === "dispatch_repair" && ["executed", "active"].includes(String(action.status)),
+  );
+  if (repair) {
+    events.push(
+      automergeMetricEvent({
+        activation,
+        command,
+        phase: "repair_dispatched",
+        state: "repairing",
+        reason: command.repair_reason ?? repair.reason,
+        runUrl: repair.run_url,
+      }),
+    );
+  }
+  const merge = command.actions?.find(
+    (action: JsonValue) => action.action === "merge" && action.status === "executed",
+  );
+  if (merge) {
+    events.push(
+      automergeMetricEvent({
+        activation,
+        command,
+        phase: "terminal",
+        outcome: "merged",
+        reason: merge.reason,
+        runUrl: merge.run_url,
+      }),
+    );
+  } else if (command.intent === "stop" && command.status === "executed") {
+    events.push(
+      automergeMetricEvent({
+        activation,
+        command,
+        phase: "terminal",
+        outcome: "maintainer_stopped",
+        reason: command.reason ?? "maintainer stopped automerge",
+      }),
+    );
+  } else if (/auto repair already dispatched .* total time/i.test(String(command.reason ?? ""))) {
+    events.push(
+      automergeMetricEvent({
+        activation,
+        command,
+        phase: "terminal",
+        outcome: "repair_cap_exhausted",
+        reason: command.reason,
+      }),
+    );
+  } else if (/\b(?:PR|target) is not open\b/i.test(String(command.reason ?? ""))) {
+    events.push(
+      automergeMetricEvent({
+        activation,
+        command,
+        phase: "terminal",
+        outcome: "pr_closed",
+        reason: command.reason,
+      }),
+    );
+  } else if (/not opted into ClawSweeper automerge/i.test(String(command.reason ?? ""))) {
+    events.push(
+      automergeMetricEvent({
+        activation,
+        command,
+        phase: "terminal",
+        outcome: "automerge_disabled",
+        reason: command.reason,
+      }),
+    );
+  } else if (command.status === "waiting") {
+    events.push(
+      automergeMetricEvent({
+        activation,
+        command,
+        phase: "state_changed",
+        state: "waiting",
+        reason: command.reason,
+      }),
+    );
+  }
+  for (const event of events) automergeMetricWrites.push(postAutomergeMetricBestEffort(event));
+}
+
+function latestAutomergeActivation(command: LooseRecord) {
+  return latestAutomergeActivationForCommand(command, [
+    command,
+    ...(commands ?? []),
+    ...(ledger.commands ?? []),
+  ]);
 }
 
 function runGitHubTextMutation(
@@ -3251,6 +3372,7 @@ function dispatchRepair(command: LooseRecord) {
     };
   }
   dispatchKey = dispatchReceiptKey(command);
+  const sessionId = automergeSessionId(latestAutomergeActivation(command) ?? {});
   const activeRun = activeRepairRunForCommand(command);
   if (activeRun) {
     return {
@@ -3295,6 +3417,7 @@ function dispatchRepair(command: LooseRecord) {
       `execution_runner=${executionRunner}`,
       "-f",
       `model=${model}`,
+      ...(sessionId ? ["-f", `automerge_session_id=${sessionId}`] : []),
     ],
     { env: dispatchTokenEnv() },
   );

--- a/src/repair/execute-fix-artifact.ts
+++ b/src/repair/execute-fix-artifact.ts
@@ -429,6 +429,7 @@ const report: LooseRecord = {
   dry_run: dryRun,
   result_path: path.relative(repoRoot(), resultPath),
   executed_at: new Date().toISOString(),
+  automerge_session_id: process.env.CLAWSWEEPER_AUTOMERGE_SESSION_ID || null,
   policy_override: promotedReplacement
     ? "promoted needs_human uneditable-source fix artifact to replace_uneditable_branch"
     : null,

--- a/src/repair/notify-events.ts
+++ b/src/repair/notify-events.ts
@@ -338,6 +338,14 @@ export async function runClawSweeperEventNotifier(
   const runRecord =
     runRecordPath && fs.existsSync(runRecordPath) ? readJsonFile(runRecordPath) : null;
   const collected = collectClawSweeperEvents({ applyRows, runRecord, ledger, runId });
+  if (!dryRun && dashboardConfig) {
+    await postAutomergeRepairCompletedBestEffort({
+      config: dashboardConfig,
+      fetcher,
+      record: asJsonObject(runRecord),
+      now: now(),
+    });
+  }
   const config = resolveOpenClawHookConfig(env);
   if (!config) {
     const summary = summaryRow(
@@ -434,6 +442,66 @@ export async function runClawSweeperEventNotifier(
   };
   log(JSON.stringify(summary, null, 2));
   return summary;
+}
+
+async function postAutomergeRepairCompletedBestEffort({
+  config,
+  fetcher,
+  record,
+  now,
+}: {
+  config: DashboardIngestConfig;
+  fetcher: typeof fetch;
+  record: JsonObject;
+  now: Date;
+}) {
+  const sessionId = stringOrNull(record.automerge_session_id);
+  const action = (Array.isArray(record.fix_actions) ? record.fix_actions : [])
+    .map(asJsonObject)
+    .find((row) => row.action === "repair_contributor_branch" && row.status === "pushed");
+  const repository = stringOrNull(record.repo);
+  const itemNumber = Number(sessionId?.match(/#(\d+):/)?.[1] ?? 0);
+  if (!sessionId || !action || !repository || !itemNumber) return;
+  const occurredAt = stringOrNull(record.published_at) ?? now.toISOString();
+  const timeoutMs = 5_000;
+  const controller = new AbortController();
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    const response = await Promise.race([
+      fetcher(config.url, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${config.token}`, "Content-Type": "application/json" },
+        signal: controller.signal,
+        body: JSON.stringify({
+          event_type: "clawsweeper.automerge_metric",
+          event_id: `${sessionId}:repair_completed:${stringOrNull(action.commit) ?? occurredAt}`,
+          session_id: sessionId,
+          phase: "repair_completed",
+          occurred_at: occurredAt,
+          repository,
+          item_number: itemNumber,
+          policy_version: "immediate-v1",
+          state: "waiting",
+          reason: stringOrNull(action.reason),
+          pr_url:
+            stringOrNull(action.target) ?? `https://github.com/${repository}/pull/${itemNumber}`,
+          run_url: stringOrNull(record.run_url),
+          base_sync: action.base_sync === true,
+        }),
+      }),
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => {
+          controller.abort();
+          reject(new Error("automerge repair metric ingest timed out"));
+        }, timeoutMs);
+      }),
+    ]);
+    if (!response.ok) return;
+  } catch {
+    // The durable run record remains the retry source; dashboard availability never gates repair.
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
 }
 
 function resolveDashboardIngestConfig(env: NodeJS.ProcessEnv): DashboardIngestConfig | null {

--- a/src/repair/publish-result.ts
+++ b/src/repair/publish-result.ts
@@ -111,6 +111,7 @@ function publishResult(resultPath: string) {
     workflow_updated_at:
       metadata?.updatedAt ?? metadata?.updated_at ?? previousRecord?.workflow_updated_at ?? null,
     result_status: result.status ?? null,
+    automerge_session_id: fixReport.automerge_session_id ?? null,
     source_job: clusterPlan?.source_job ?? null,
     published_at: new Date().toISOString(),
     canonical: result.canonical ?? null,
@@ -460,6 +461,8 @@ function sanitizeFixAction(action: LooseRecord) {
     reason: normalizeNullableText(action.reason),
     title: action.title ?? null,
     url: action.url ?? action.pr_url ?? null,
+    commit: action.commit ?? null,
+    base_sync: Boolean(action.fast_rebase || action.merge_preflight?.final_base_sync),
   };
 }
 

--- a/test/automerge-metrics.test.ts
+++ b/test/automerge-metrics.test.ts
@@ -1,0 +1,270 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  mergeAutomergeMetricLedger,
+  percentile,
+  summarizeAutomergeMetrics,
+  type AutomergeMetricEvent,
+} from "../dashboard/automerge-metrics.ts";
+import {
+  automergeSessionId,
+  latestAutomergeActivationForCommand,
+  postAutomergeMetricBestEffort,
+} from "../src/repair/automerge-product-telemetry.ts";
+
+const now = "2026-07-17T12:00:00.000Z";
+
+function event(
+  session: string,
+  phase: AutomergeMetricEvent["phase"],
+  at: string,
+  extra: Partial<AutomergeMetricEvent> = {},
+): AutomergeMetricEvent {
+  return {
+    event_id: `${session}:${phase}:${at}`,
+    session_id: session,
+    phase,
+    occurred_at: at,
+    repository: "openclaw/openclaw",
+    item_number: Number(session.replace(/\D/g, "")) || 1,
+    policy_version: "immediate-v1",
+    ...extra,
+  };
+}
+
+function ledger(events: AutomergeMetricEvent[]) {
+  return events.reduce(
+    (current, row) => mergeAutomergeMetricLedger(current, row, Date.parse(now)),
+    null as unknown,
+  );
+}
+
+test("success denominator includes only terminal sessions", () => {
+  const data = summarizeAutomergeMetrics(
+    ledger([
+      event("s1", "activated", "2026-07-17T08:00:00Z"),
+      event("s1", "terminal", "2026-07-17T09:00:00Z", { outcome: "merged" }),
+      event("s2", "activated", "2026-07-17T09:00:00Z"),
+      event("s2", "state_changed", "2026-07-17T10:00:00Z", { state: "waiting" }),
+      event("s3", "activated", "2026-07-17T09:30:00Z"),
+      event("s3", "state_changed", "2026-07-17T10:30:00Z", { state: "paused for human" }),
+      event("s4", "terminal", "2026-07-17T11:00:00Z", { outcome: "repair_cap_exhausted" }),
+      event("old-active", "activated", "2026-07-16T12:00:00Z"),
+      event("future-active", "activated", "2026-07-17T13:00:00Z"),
+    ]),
+    { range: "6h", now },
+  );
+  assert.equal(data.summary.terminal_sessions, 2);
+  assert.equal(data.summary.merged_sessions, 1);
+  assert.equal(data.summary.merge_success_rate_percent, 50);
+  assert.equal(data.summary.active_sessions, 2);
+});
+
+test("duplicate and out-of-order events remain idempotent", () => {
+  const terminal = event("s5", "terminal", "2026-07-17T11:00:00Z", { outcome: "merged" });
+  const activation = event("s5", "activated", "2026-07-17T10:00:00Z");
+  let current = mergeAutomergeMetricLedger(null, terminal, Date.parse(now));
+  current = mergeAutomergeMetricLedger(current, activation, Date.parse(now));
+  current = mergeAutomergeMetricLedger(current, terminal, Date.parse(now));
+  const data = summarizeAutomergeMetrics(current, { range: "6h", now });
+  assert.equal(current.events.length, 2);
+  assert.equal(data.summary.command_to_merge_p50_ms, 60 * 60 * 1000);
+});
+
+test("the first terminal outcome remains authoritative", () => {
+  const data = summarizeAutomergeMetrics(
+    ledger([
+      event("stable", "activated", "2026-07-17T09:00:00Z"),
+      event("stable", "terminal", "2026-07-17T10:00:00Z", { outcome: "merged" }),
+      event("stable", "terminal", "2026-07-17T11:00:00Z", {
+        event_id: "stable:later-pr-closed",
+        outcome: "pr_closed",
+      }),
+    ]),
+    { range: "6h", now },
+  );
+  assert.equal(data.summary.terminal_sessions, 1);
+  assert.equal(data.summary.merged_sessions, 1);
+  assert.equal(data.summary.command_to_merge_p50_ms, 60 * 60 * 1000);
+  assert.equal(data.sessions[0]?.outcome, "merged");
+  assert.equal(data.sessions[0]?.terminal_at, "2026-07-17T10:00:00.000Z");
+});
+
+test("empty buckets are gaps and populated buckets under five are low sample", () => {
+  const data = summarizeAutomergeMetrics(
+    ledger([
+      event("s6", "activated", "2026-07-17T10:00:00Z"),
+      event("s6", "terminal", "2026-07-17T10:31:00Z", { outcome: "merged" }),
+    ]),
+    { range: "6h", now },
+  );
+  assert.ok(data.buckets.some((bucket) => bucket.success_rate_percent === null));
+  const populated = data.buckets.find((bucket) => bucket.terminal_count === 1);
+  assert.equal(populated?.success_rate_percent, 100);
+  assert.equal(populated?.low_sample, true);
+  assert.equal(data.buckets.length, 12);
+});
+
+test("a terminal event exactly at the range end belongs to the final bucket", () => {
+  const data = summarizeAutomergeMetrics(
+    ledger([event("edge", "terminal", now, { outcome: "merged" })]),
+    { range: "6h", now },
+  );
+  assert.equal(data.summary.terminal_sessions, 1);
+  assert.equal(data.buckets.at(-1)?.terminal_count, 1);
+});
+
+test("range configuration and policy filters are applied", () => {
+  const rows = [
+    event("s7", "terminal", "2026-07-17T11:00:00Z", { outcome: "merged" }),
+    event("s8", "terminal", "2026-07-17T10:00:00Z", {
+      outcome: "maintainer_stopped",
+      policy_version: "backoff-v1",
+    }),
+  ];
+  assert.equal(summarizeAutomergeMetrics(ledger(rows), { range: "24h", now }).buckets.length, 12);
+  assert.equal(summarizeAutomergeMetrics(ledger(rows), { range: "7d", now }).buckets.length, 14);
+  const filtered = summarizeAutomergeMetrics(ledger(rows), {
+    range: "6h",
+    policyVersion: "backoff-v1",
+    now,
+  });
+  assert.equal(filtered.summary.terminal_sessions, 1);
+  assert.equal(filtered.summary.merge_success_rate_percent, 0);
+  assert.equal(filtered.telemetry_since, "2026-07-17T10:00:00.000Z");
+  assert.equal(filtered.coverage_percent, 33);
+  const missing = summarizeAutomergeMetrics(ledger(rows), {
+    range: "6h",
+    policyVersion: "future-v1",
+    now,
+  });
+  assert.equal(missing.telemetry_since, null);
+  assert.equal(missing.coverage_percent, 0);
+});
+
+test("nearest-rank p90 preserves a long-tail latency", () => {
+  assert.equal(percentile([1, 2, 3, 4, 100], 0.5), 3);
+  assert.equal(percentile([1, 2, 3, 4, 100], 0.9), 100);
+  assert.equal(percentile([], 0.9), null);
+});
+
+test("base sync distribution exposes repeated main chasing", () => {
+  const rows: AutomergeMetricEvent[] = [];
+  for (const [index, syncs] of [0, 1, 2].entries()) {
+    const session = `sync${index + 1}`;
+    rows.push(event(session, "activated", `2026-07-17T0${8 + index}:00:00Z`));
+    for (let count = 0; count < syncs; count += 1) {
+      rows.push(
+        event(session, "repair_completed", `2026-07-17T${10 + count}:0${index}:00Z`, {
+          event_id: `${session}:repair:${count}`,
+          base_sync: true,
+        }),
+      );
+    }
+    rows.push(event(session, "terminal", `2026-07-17T11:${index}0:00Z`, { outcome: "merged" }));
+  }
+  const data = summarizeAutomergeMetrics(ledger(rows), { range: "6h", now });
+  assert.equal(data.summary.base_sync_p50, 1);
+  assert.equal(data.summary.base_sync_p90, 2);
+  assert.equal(data.summary.multi_rebase_rate_percent, 33.3);
+});
+
+test("reactivation creates a new stable session and ingest failure is non-fatal", async () => {
+  const first = automergeSessionId({
+    repo: "openclaw/openclaw",
+    issue_number: 42,
+    comment_id: "100",
+    comment_updated_at: "2026-07-17T10:00:00Z",
+  });
+  const second = automergeSessionId({
+    repo: "openclaw/openclaw",
+    issue_number: 42,
+    comment_id: "200",
+    comment_updated_at: "2026-07-17T11:00:00Z",
+  });
+  assert.notEqual(first, second);
+  const delivered = await postAutomergeMetricBestEffort(
+    {
+      event_type: "clawsweeper.automerge_metric",
+      event_id: "event",
+      session_id: first!,
+      phase: "activated",
+      occurred_at: now,
+      repository: "openclaw/openclaw",
+      item_number: 42,
+      policy_version: "immediate-v1",
+      state: "active",
+      outcome: null,
+      reason: null,
+      pr_url: "https://github.com/openclaw/openclaw/pull/42",
+      run_url: null,
+    },
+    { CLAWSWEEPER_STATUS_INGEST_TOKEN: "token" },
+    async () => {
+      throw new Error("dashboard unavailable");
+    },
+  );
+  assert.equal(delivered, false);
+});
+
+test("batched stop commands bind to the preceding activation, not a future reactivation", () => {
+  const base = { repo: "openclaw/openclaw", issue_number: 42, status: "executed" };
+  const first = {
+    ...base,
+    intent: "automerge",
+    comment_id: "100",
+    comment_updated_at: "2026-07-17T10:00:00Z",
+  };
+  const stop = {
+    ...base,
+    intent: "stop",
+    comment_id: "150",
+    comment_updated_at: "2026-07-17T10:30:00Z",
+  };
+  const second = {
+    ...base,
+    intent: "automerge",
+    comment_id: "200",
+    comment_updated_at: "2026-07-17T11:00:00Z",
+  };
+  assert.equal(latestAutomergeActivationForCommand(stop, [first, stop, second]), first);
+  assert.equal(latestAutomergeActivationForCommand(second, [first, stop, second]), second);
+  const afterStop = {
+    ...base,
+    intent: "clawsweeper_auto_merge",
+    comment_id: "175",
+    comment_updated_at: "2026-07-17T10:45:00Z",
+  };
+  assert.equal(
+    latestAutomergeActivationForCommand(afterStop, [first, stop, afterStop, second]),
+    undefined,
+  );
+});
+
+test("best-effort ingest has a bounded deadline even when fetch never settles", async () => {
+  const startedAt = Date.now();
+  const delivered = await postAutomergeMetricBestEffort(
+    {
+      event_type: "clawsweeper.automerge_metric",
+      event_id: "timeout-event",
+      session_id: "openclaw/openclaw#42:100:2026-07-17T10:00:00Z",
+      phase: "activated",
+      occurred_at: now,
+      repository: "openclaw/openclaw",
+      item_number: 42,
+      policy_version: "immediate-v1",
+      state: "active",
+      outcome: null,
+      reason: null,
+      pr_url: "https://github.com/openclaw/openclaw/pull/42",
+      run_url: null,
+    },
+    {
+      CLAWSWEEPER_STATUS_INGEST_TOKEN: "token",
+      CLAWSWEEPER_AUTOMERGE_METRIC_TIMEOUT_MS: "5",
+    },
+    async () => new Promise<Response>(() => undefined),
+  );
+  assert.equal(delivered, false);
+  assert.ok(Date.now() - startedAt < 500);
+});

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -1626,7 +1626,14 @@ class MemoryDurableStorage {
     return this.values.get(key);
   }
 
-  async put(key: string, value: unknown) {
+  async put(key: string | Record<string, unknown>, value?: unknown) {
+    if (typeof key === "object") {
+      for (const [entryKey, entryValue] of Object.entries(key)) {
+        this.throwPutFailure(entryKey);
+        this.storeRaw(entryKey, entryValue);
+      }
+      return;
+    }
     this.throwPutFailure(key);
     if (key === "exact-review-queue" && this.sql.hasNormalizedQueue()) {
       const normalized = this.sql.readNormalizedQueue();
@@ -1774,6 +1781,115 @@ class MemoryCache {
     this.values.set(request.url, response.clone());
   }
 }
+
+test("automerge metric ingestion validates before writes and requires durable storage", async () => {
+  const statusStore = new MemoryKv();
+  const token = ["test", "token"].join("-");
+  const env = { INGEST_TOKEN: token, STATUS_STORE: statusStore };
+  const request = (body: Record<string, unknown>) =>
+    worker.fetch(
+      new Request("https://clawsweeper.openclaw.ai/api/events", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          event_type: "clawsweeper.automerge_metric",
+          repository: "openclaw/openclaw",
+          item_number: 42,
+          phase: "activated",
+          occurred_at: "2026-07-17T10:00:00Z",
+          ...body,
+        }),
+      }),
+      env,
+    );
+
+  assert.equal((await request({})).status, 400);
+  assert.equal(await statusStore.get("events"), null);
+  assert.equal(await statusStore.get("latest-event"), null);
+
+  assert.equal(
+    (
+      await request({
+        event_id: "activation-42",
+        session_id: "openclaw/openclaw#42:100:2026-07-17T10:00:00Z",
+      })
+    ).status,
+    503,
+  );
+  assert.equal(await statusStore.get("events"), null);
+  assert.equal(await statusStore.get("latest-event"), null);
+});
+
+test("automerge metric events use isolated durable keys and aggregate through the API", async () => {
+  const storage = new MemoryDurableStorage();
+  const store = new StatusStore({ storage });
+  const namespace = new MemoryDurableNamespace({
+    fetch: (request: Request, init?: RequestInit) =>
+      store.fetch(init ? new Request(request, init) : request),
+  });
+  const token = ["test", "token"].join("-");
+  const env = { INGEST_TOKEN: token, STATUS_STORE: namespace };
+  const occurredAt = new Date().toISOString();
+  for (const eventId of ["terminal-1", "terminal-2"]) {
+    const response = await worker.fetch(
+      new Request("https://clawsweeper.openclaw.ai/api/events", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          event_type: "clawsweeper.automerge_metric",
+          event_id: eventId,
+          session_id: `openclaw/openclaw#42:${eventId}:${occurredAt}`,
+          repository: "openclaw/openclaw",
+          item_number: 42,
+          phase: "terminal",
+          outcome: "merged",
+          occurred_at: occurredAt,
+        }),
+      }),
+      env,
+    );
+    assert.equal(response.status, 200);
+  }
+  const duplicate = await worker.fetch(
+    new Request("https://clawsweeper.openclaw.ai/api/events", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        event_type: "clawsweeper.automerge_metric",
+        event_id: "terminal-1",
+        session_id: `openclaw/openclaw#42:terminal-1:${occurredAt}`,
+        repository: "openclaw/openclaw",
+        item_number: 42,
+        phase: "terminal",
+        outcome: "maintainer_stopped",
+        occurred_at: new Date(Date.now() + 60_000).toISOString(),
+      }),
+    }),
+    env,
+  );
+  assert.equal(duplicate.status, 200);
+
+  assert.equal(storage.rawHas("automerge-product-metrics:v1"), false);
+  assert.equal(storage.rawHas("automerge-product-metrics:v1:id:terminal-1"), true);
+  assert.equal(storage.rawHas("automerge-product-metrics:v1:id:terminal-2"), true);
+  const metrics = await (
+    await worker.fetch(
+      new Request("https://clawsweeper.openclaw.ai/api/automerge-metrics?range=6h"),
+      env,
+    )
+  ).json();
+  assert.equal(metrics.summary.terminal_sessions, 2);
+  assert.equal(metrics.summary.merged_sessions, 2);
+});
 
 test("dashboard durable status store persists, expires, and prepends events", async () => {
   const storage = new MemoryDurableStorage();


### PR DESCRIPTION
## Summary

- add stable automerge sessions and emit best-effort product telemetry for activation, repair, state, and terminal transitions
- retain 90 days of validated, idempotent events and expose 6h/24h/7d product-health trends with repository and policy filters
- add merge success, command-to-merge p50/p90, base-sync distribution, multi-rebase rate, terminal outcomes, and recent sessions to the dashboard
- keep workflow reliability under Worker Health so operational failures are not presented as product merge failures

Telemetry starts at deployment time; this does not backfill workflow history.

## Product semantics

- success is `merged / terminal sessions`
- waiting, repairing, and paused sessions stay outside the denominator
- the first terminal event is authoritative and cannot be rewritten by a later observer
- active-session counts follow the selected dashboard range
- all sessions record `policy_version` (`immediate-v1` initially) for future strategy comparisons
- dashboard delivery is bounded and best-effort, so ingest failures do not block automerge

## Validation

- `pnpm run check`
- focused post-review build, lint, metrics/dashboard tests, format check, and `git diff --check`
- final local autoreview: clean (`patch is correct`, no actionable findings)

## Autoreview fixes

Autoreview findings were accepted and fixed, including bounded telemetry requests, stale UI response races, atomic/idempotent durable storage, bounded latest-event reads, post-stop session binding, immutable terminal outcomes, and range-correct active-session counts.