### PR TITLE
fix(validation): ignore package funding metadata

### DIFF
--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -931,6 +931,7 @@ function assertStructuredInstallMetadataDestinations(
   localPolicy: TargetInstallLocalPolicy,
   registryOrigin: string,
   fieldName?: string,
+  context: "root" | "package-record" | "nested" = "root",
 ): void {
   if (typeof value === "string") {
     if (
@@ -951,6 +952,7 @@ function assertStructuredInstallMetadataDestinations(
         localPolicy,
         registryOrigin,
         fieldName,
+        "nested",
       );
     }
     return;
@@ -964,7 +966,31 @@ function assertStructuredInstallMetadataDestinations(
       assertLocalPackageDependency(value.resolved.trim(), ".", localPolicy);
     }
     for (const [name, entry] of Object.entries(value)) {
+      // Funding is package display metadata, but a dependency map may also contain a package
+      // named "funding". Exempt only package records so those dependency records stay inspectable.
+      if (context === "package-record" && name === "funding") continue;
       if (workspaceLink && (name === "link" || name === "resolved")) continue;
+      // Only the document root owns the lockfile packages map; a dependency may also be named
+      // "packages", so recursive name matching would incorrectly grant package-record semantics.
+      if (
+        context === "root" &&
+        name === "packages" &&
+        entry &&
+        typeof entry === "object" &&
+        !Array.isArray(entry)
+      ) {
+        for (const [packageName, packageValue] of Object.entries(entry)) {
+          assertStructuredInstallMetadataDestinations(
+            packageValue,
+            ownerDir,
+            localPolicy,
+            registryOrigin,
+            packageName,
+            "package-record",
+          );
+        }
+        continue;
+      }
       if (name === "importers" && entry && typeof entry === "object" && !Array.isArray(entry)) {
         for (const [importer, importerValue] of Object.entries(entry)) {
           const importerDir = resolveTrackedImporterDir(importer, localPolicy);
@@ -973,6 +999,8 @@ function assertStructuredInstallMetadataDestinations(
             importerDir,
             localPolicy,
             registryOrigin,
+            undefined,
+            "nested",
           );
         }
         continue;
@@ -983,6 +1011,7 @@ function assertStructuredInstallMetadataDestinations(
         localPolicy,
         registryOrigin,
         name,
+        "nested",
       );
     }
   }

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -2233,6 +2233,154 @@ test("dependency setup permits inert package-manager config files", () => {
   }
 });
 
+test("dependency setup permits external funding metadata in npm lockfiles", () => {
+  for (const lockfile of ["package-lock.json", "npm-shrinkwrap.json"]) {
+    const cwd = gitPackageFixture({ check: 'node -e ""' });
+    fs.rmSync(path.join(cwd, "pnpm-lock.yaml"));
+    const packagePath = path.join(cwd, "package.json");
+    const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+    packageJson.packageManager = "npm@11.0.0";
+    fs.writeFileSync(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`);
+    fs.writeFileSync(
+      path.join(cwd, lockfile),
+      `${JSON.stringify(
+        {
+          name: "fixture",
+          lockfileVersion: 3,
+          packages: {
+            "": { name: "fixture", version: "1.0.0" },
+            "node_modules/funding-string": {
+              version: "1.0.0",
+              resolved: "https://registry.npmjs.org/funding-string/-/funding-string-1.0.0.tgz",
+              funding: "https://github.com/sponsors/example",
+            },
+            "node_modules/funding-object": {
+              version: "1.0.0",
+              resolved: "https://registry.npmjs.org/funding-object/-/funding-object-1.0.0.tgz",
+              funding: { type: "individual", url: "https://patreon.com/example" },
+            },
+            "node_modules/funding-array": {
+              version: "1.0.0",
+              resolved: "https://registry.npmjs.org/funding-array/-/funding-array-1.0.0.tgz",
+              funding: [
+                { type: "collective", url: "https://opencollective.com/example" },
+                "https://github.com/sponsors/example",
+              ],
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    git(cwd, "add", ".");
+    git(cwd, "commit", "-m", "initial");
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-npm-funding-bin-"));
+    const npmPath = path.join(binDir, "npm.js");
+    fs.writeFileSync(
+      npmPath,
+      'require("node:fs").mkdirSync("node_modules", { recursive: true });\n',
+    );
+
+    withMockCommand("npm", npmPath, () =>
+      prepareTargetToolchain(cwd, {
+        ...validationOptions("steipete/example", {
+          toolchain: {
+            packageManager: "npm",
+            baseValidationCommands: [],
+            changedGate: null,
+          },
+        }),
+        installTargetDeps: true,
+        installTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
+        setupTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
+      }),
+    );
+  }
+});
+
+test("dependency setup keeps non-funding npm lockfile URLs fail-closed", () => {
+  for (const metadata of [
+    { resolved: "https://github.com/example/payload.tgz" },
+    { homepage: "https://github.com/example/payload" },
+  ]) {
+    const cwd = gitPackageFixture({ check: 'node -e ""' });
+    fs.writeFileSync(
+      path.join(cwd, "package-lock.json"),
+      `${JSON.stringify({
+        lockfileVersion: 3,
+        packages: { "node_modules/payload": { version: "1.0.0", ...metadata } },
+      })}\n`,
+    );
+    git(cwd, "add", ".");
+    git(cwd, "commit", "-m", "initial");
+
+    assert.throws(
+      () =>
+        prepareTargetToolchain(cwd, {
+          ...validationOptions("steipete/example", {
+            toolchain: {
+              packageManager: "npm",
+              baseValidationCommands: [],
+              changedGate: null,
+            },
+          }),
+          installTargetDeps: true,
+          installTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
+          setupTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
+        }),
+      /destination is not approved: https:\/\/github\.com/,
+    );
+  }
+});
+
+test("dependency setup rejects install destinations for dependencies named funding", () => {
+  for (const dependencies of [
+    {
+      funding: {
+        version: "1.0.0",
+        resolved: "https://github.com/example/funding.tgz",
+      },
+    },
+    {
+      packages: {
+        version: "1.0.0",
+        dependencies: {
+          funding: {
+            version: "1.0.0",
+            resolved: "https://github.com/example/nested-funding.tgz",
+          },
+        },
+      },
+    },
+  ]) {
+    const cwd = gitPackageFixture({ check: 'node -e ""' });
+    fs.writeFileSync(
+      path.join(cwd, "package-lock.json"),
+      `${JSON.stringify({ lockfileVersion: 2, dependencies })}\n`,
+    );
+    git(cwd, "add", ".");
+    git(cwd, "commit", "-m", "initial");
+
+    assert.throws(
+      () =>
+        prepareTargetToolchain(cwd, {
+          ...validationOptions("steipete/example", {
+            toolchain: {
+              packageManager: "npm",
+              baseValidationCommands: [],
+              changedGate: null,
+            },
+          }),
+          installTargetDeps: true,
+          installTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
+          setupTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
+        }),
+      /destination is not approved: https:\/\/github\.com/,
+    );
+  }
+});
+
 test("dependency setup rejects target-controlled network destinations", () => {
   const cases = [
     {


### PR DESCRIPTION
## Summary

- ignore display-only `funding` metadata while validating npm lockfile package records
- preserve fail-closed validation for every install-relevant and other non-funding field
- cover package-lock and npm-shrinkwrap funding shapes plus adversarial dependency names

## Root cause

https://github.com/openclaw/clawsweeper/pull/642 fixed the preceding comment-only `.npmrc` rejection. After that merged, repair-cluster runs that reached credited-fix execution failed while validating OpenClaw's root `npm-shrinkwrap.json`, for example https://github.com/openclaw/clawsweeper/actions/runs/29566500279.

The lockfile includes external sponsorship links under `packages.<package>.funding`. Those links are package display metadata and do not participate in dependency resolution, but the structured install-metadata walker recursively treated every string as an install destination and rejected `https://github.com`.

## Safety boundary

Only an exact `funding` field on package records inside the document-root `packages` map is skipped. The traversal does not approve GitHub as an install origin, does not exempt arbitrary `url` fields, and continues to reject external values in `resolved`, `resolution`, `tarball`, `homepage`, dependency maps, local paths, workspace/link metadata, and every other traversed field. Tests also prove that dependencies named `funding`, including one nested below a dependency named `packages`, remain inspected.

## Validation

- `pnpm run format`
- `pnpm run build:repair`
- `node --test test/repair/target-validation.test.ts` (154 tests: 151 passed, 3 capability-based skips)
- `pnpm run check` on Node v24.15.0
- change-only `gitleaks detect --pipe --redact --no-banner` (no leaks)
- project `autoreview --mode local` after the final patch (`autoreview clean: no accepted/actionable findings reported`; correctness confidence 0.93)

## Post-merge verification

Re-trigger https://github.com/openclaw/openclaw/pull/107479, confirm target dependency preflight passes `npm-shrinkwrap.json`, confirm Execute is not skipped, and verify merge/post-flight completes successfully. Sending that trigger remains a separately authorized live action.
