### PR TITLE
fix(validation): stop misreading pnpm lockfile integrity as install URLs

### DIFF
--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -915,12 +915,12 @@ function assertTrackedPatchDependency(
 }
 
 function assertApprovedInstallMetadataDestinations(text: string, registryOrigin: string) {
-  const networkTokens = [
-    ...text.matchAll(
-      /(?:^|[\s"'`<>{}\x5b\x5d(),;:=])((?:https?:\/\/|\/\/|git\+[^:\s]+:\/\/|ssh:\/\/)[^\s"'`<>{}\x5b\x5d,]+)/gim,
-    ),
+  const explicitNetworkTokens =
+    text.match(/(?:https?:\/\/|git\+[^:\s]+:\/\/|ssh:\/\/)[^\s"'`<>{}\x5b\x5d,]+/gi) ?? [];
+  const protocolRelativeNetworkTokens = [
+    ...text.matchAll(/(?:^|[\s"'`<>{}\x5b\x5d(),;=])(\/\/[^\s"'`<>{}\x5b\x5d,]+)/gim),
   ].flatMap((match) => (match[1] ? [match[1]] : []));
-  for (const token of networkTokens) {
+  for (const token of [...explicitNetworkTokens, ...protocolRelativeNetworkTokens]) {
     assertApprovedInstallUrl(token.replace(/[);]+$/, ""), registryOrigin);
   }
   if (/(?:^|[\s"'`])(?:git@|github:|gitlab:|bitbucket:)/im.test(text)) {

--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -916,7 +916,7 @@ function assertTrackedPatchDependency(
 
 function assertApprovedInstallMetadataDestinations(text: string, registryOrigin: string) {
   const explicitNetworkTokens =
-    text.match(/(?:https?:\/\/|git\+[^:\s]+:\/\/|ssh:\/\/)[^\s"'`<>{}\x5b\x5d,]+/gi) ?? [];
+    text.match(/[A-Za-z][A-Za-z0-9+.-]*:\/\/[^\s"'`<>{}\x5b\x5d,]+/g) ?? [];
   const protocolRelativeNetworkTokens = [
     ...text.matchAll(/(?:^|[\s"'`<>{}\x5b\x5d(),;=])(\/\/[^\s"'`<>{}\x5b\x5d,]+)/gim),
   ].flatMap((match) => (match[1] ? [match[1]] : []));

--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -917,7 +917,7 @@ function assertTrackedPatchDependency(
 function assertApprovedInstallMetadataDestinations(text: string, registryOrigin: string) {
   const networkTokens = [
     ...text.matchAll(
-      /(?:^|[\s"'`<>{}\x5b\x5d(),:=])((?:https?:\/\/|\/\/|git\+[^:\s]+:\/\/|ssh:\/\/)[^\s"'`<>{}\x5b\x5d,]+)/gim,
+      /(?:^|[\s"'`<>{}\x5b\x5d(),;:=])((?:https?:\/\/|\/\/|git\+[^:\s]+:\/\/|ssh:\/\/)[^\s"'`<>{}\x5b\x5d,]+)/gim,
     ),
   ].flatMap((match) => (match[1] ? [match[1]] : []));
   for (const token of networkTokens) {

--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -915,8 +915,11 @@ function assertTrackedPatchDependency(
 }
 
 function assertApprovedInstallMetadataDestinations(text: string, registryOrigin: string) {
-  const networkTokens =
-    text.match(/(?:https?:\/\/|\/\/|git\+[^:\s]+:\/\/|ssh:\/\/)[^\s"'`<>{}\x5b\x5d,]+/gi) ?? [];
+  const networkTokens = [
+    ...text.matchAll(
+      /(?:^|[\s"'`<>{}\x5b\x5d(),:=])((?:https?:\/\/|\/\/|git\+[^:\s]+:\/\/|ssh:\/\/)[^\s"'`<>{}\x5b\x5d,]+)/gim,
+    ),
+  ].flatMap((match) => (match[1] ? [match[1]] : []));
   for (const token of networkTokens) {
     assertApprovedInstallUrl(token.replace(/[);]+$/, ""), registryOrigin);
   }

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -2490,6 +2490,17 @@ test("dependency setup rejects target-controlled network destinations", () => {
       },
     },
     {
+      expected: /destination is not approved: https:\/\/evil\.example/,
+      prepare() {
+        const cwd = gitBunPackageFixture({ check: 'node -e ""' });
+        fs.writeFileSync(path.join(cwd, "bun.lock"), ";https://evil.example/payload.tgz\n");
+        return {
+          cwd,
+          options: validationOptions("openclaw/clawhub", clawhubToolchain()),
+        };
+      },
+    },
+    {
       expected: /destination is not approved/,
       prepare() {
         const cwd = gitBunPackageFixture({ check: 'node -e ""' });

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -2233,6 +2233,37 @@ test("dependency setup permits inert package-manager config files", () => {
   }
 });
 
+test("dependency setup permits pnpm integrity strings containing double slashes", () => {
+  const cwd = gitBunPackageFixture({ check: "bun x tsc --noEmit" });
+  fs.writeFileSync(
+    path.join(cwd, "pnpm-lock.yaml"),
+    [
+      "lockfileVersion: '9.0'",
+      "",
+      "packages:",
+      "",
+      "  '@mistralai/mistralai@2.4.0':",
+      "    resolution: {integrity: sha512-t6hCx242MTGolB76CI+17jDtPIe/bzLsMdUTMMoMn9Qo1h02N2G5jQYHmKDGU3X//OgR2wvngTD7tO6tPp5poQ==}",
+      "",
+    ].join("\n"),
+  );
+  git(cwd, "add", ".");
+  git(cwd, "commit", "-m", "initial");
+  attachOrigin(cwd);
+
+  const { binDir } = fakeBunFixture(cwd);
+  withPathPrefix(binDir, () => {
+    assert.doesNotThrow(() =>
+      prepareTargetToolchain(cwd, {
+        ...validationOptions("openclaw/clawhub", clawhubToolchain()),
+        installTargetDeps: true,
+        installTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
+        setupTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
+      }),
+    );
+  });
+});
+
 test("dependency setup permits external funding metadata in npm lockfiles", () => {
   for (const lockfile of ["package-lock.json", "npm-shrinkwrap.json"]) {
     const cwd = gitPackageFixture({ check: 'node -e ""' });

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -2501,6 +2501,17 @@ test("dependency setup rejects target-controlled network destinations", () => {
       },
     },
     {
+      expected: /destination is not approved: https:\/\/evil\.example/,
+      prepare() {
+        const cwd = gitBunPackageFixture({ check: 'node -e ""' });
+        fs.writeFileSync(path.join(cwd, "bun.lock"), "@https://evil.example/payload.tgz\n");
+        return {
+          cwd,
+          options: validationOptions("openclaw/clawhub", clawhubToolchain()),
+        };
+      },
+    },
+    {
       expected: /destination is not approved/,
       prepare() {
         const cwd = gitBunPackageFixture({ check: 'node -e ""' });

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -2515,6 +2515,17 @@ test("dependency setup rejects target-controlled network destinations", () => {
       expected: /destination is not approved/,
       prepare() {
         const cwd = gitBunPackageFixture({ check: 'node -e ""' });
+        fs.writeFileSync(path.join(cwd, "bun.lock"), "@git://evil.example/payload.git\n");
+        return {
+          cwd,
+          options: validationOptions("openclaw/clawhub", clawhubToolchain()),
+        };
+      },
+    },
+    {
+      expected: /destination is not approved/,
+      prepare() {
+        const cwd = gitBunPackageFixture({ check: 'node -e ""' });
         const packagePath = path.join(cwd, "package.json");
         const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf8"));
         packageJson.dependencies = { payload: "github:example/payload" };


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/108974

## What Problem This Solves

Fixes an issue where ClawSweeper automerge repairs would stop before validation when a valid pnpm lockfile integrity value contained double slashes.

## Why This Change Was Made

The dependency-install guard now recognizes protocol-relative URLs only when they begin at a URL boundary. This retains the fail-closed network policy for actual install destinations while avoiding false positives from opaque SHA-512 integrity data.

## User Impact

Operators can rerun affected automerge repairs without valid pnpm lockfiles being rejected as unapproved external dependency hosts. Actual non-registry install URLs remain blocked.

## Evidence

- `pnpm run build` and `pnpm run build:repair` passed.
- Focused regression test passed: `dependency setup permits pnpm integrity strings containing double slashes`.
- Focused network-policy tests passed, including semicolon-prefixed HTTPS, HTTPS after a non-boundary character, and `git://` destinations that remain rejected.
- Any explicit `<scheme>://` URL remains detectable at any position; only ambiguous bare protocol-relative `//` tokens require a metadata boundary.
- The regression fixture uses the actual `@mistralai/mistralai@2.4.0` integrity shape that blocked https://github.com/openclaw/openclaw/pull/108974.

### Paired real-behavior proof

Positive path, using the PR's production `prepareTargetToolchain` entry against the exact affected OpenClaw head and lockfile:

```text
PROOF_TARGET=https://github.com/openclaw/openclaw/pull/108974
PROOF_HEAD=34a3001388bb99fb4a041a73aad98631c4557634
PROOF_ENTRY=prepareTargetToolchain
PROOF_INTEGRITY_PRESENT=true
Scope: all 170 workspace projects
Verifying lockfile against supply-chain policies (1410 entries)
PROOF_INSTALL_CHILD_COMPLETED=true
PROOF_TOP_LEVEL_NODE_MODULES_ENTRIES=851
PROOF_MISTRAL_PACKAGE_INSTALLED=true
FORMER_DESTINATION_ERROR_PRESENT=false
```

The isolated pnpm child completed and `prepareTargetToolchain` advanced into its post-install checkout-identity verification. That progression is possible only after the lockfile network guard, supply-chain policy stage, and dependency install succeed. The former false positive did not recur:

```text
target dependency install destination is not approved:
https://ogr2wvngtd7to6tpp5poq==
```

Negative path, through the same production dependency-install guard with a committed `bun.lock` containing `@git://evil.example/payload.git`:

```json
{
  "status": "HOSTILE_URI_REJECTED",
  "message": "target dependency install destination is not approved: null"
}
```

This proves the intended pair: the affected integrity value now proceeds through a real dependency install, while an explicit hostile URI remains fail-closed.

### Remaining limitation

This is not presented as a completed repair-worker run. After the successful install, the local run exceeded its checkout-identity deadline while repeatedly traversing hoisted workspace `node_modules` links. That later timeout is independent of URL classification and occurred only after the behavior changed by this PR had completed successfully.
