### PR TITLE
fix(publish): defer close-proof retries to proof lane

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1523,6 +1523,7 @@ jobs:
           MIN_AGE_MINUTES: "0"
           REVIEW_ONLY: ${{ fromJSON(steps.publication-context.outputs.decision).sourceAction == 'failed_review_shard_recovery' && 'true' || 'false' }}
           EXACT_EVENT_PUBLICATION: "true"
+          EXACT_REVIEW_CLOSE_COVERAGE_DEFERRED: "true"
           LIVE_PROCEEDED: ${{ steps.publication-context.outputs.live_proceeded }}
           LIVE_TERMINAL_NOOP: ${{ steps.publication-context.outputs.live_terminal_noop }}
           LIVE_TERMINAL_MISSING: ${{ steps.publication-context.outputs.live_terminal_missing }}
@@ -1776,6 +1777,9 @@ jobs:
           if [ "$POLICY_NOOP" = "true" ]; then
             state="Complete"
             detail="The exact review reached a deterministic policy veto; no action was taken."
+          elif [ "$PUBLISH_COMPLETION_KIND" = "deferred" ] && [ "$PUBLISH_REASON_CODE" = "close_coverage_deferred" ]; then
+            state="Complete"
+            detail="The exact review is complete. Its close recommendation is queued for an independent bounded read-only proof check; no comment, label, or close action will occur unless that proof lane authorizes it."
           elif [ "$LEGACY_TUPLELESS" = "true" ] && [ "${{ steps.queue-source-drift-review.outcome }}" = "success" ]; then
             state="Complete"
             detail="The legacy artifact lacked its durable review lease tuple; one fresh exact review was queued."
@@ -1914,6 +1918,17 @@ jobs:
             outcome=success
             completion_kind=superseded
             reason_code="$PUBLISH_REASON_CODE"
+          elif [ "$PUBLISH_COMPLETION_KIND" = "deferred" ] && [ "$PUBLISH_REASON_CODE" = "close_coverage_deferred" ]; then
+            outcome=success
+            completion_kind=deferred
+            reason_code=close_coverage_deferred
+          elif [ "$PUBLISH_COMPLETION_KIND" = "refresh_required" ] && [ "$PUBLISH_REASON_CODE" = "close_coverage_retry" ]; then
+            # A pre-deployment publisher checked out the new helper but still runs the old
+            # workflow without the deferred-lane opt-in. Preserve its established refresh
+            # completion so the queue can create a fresh proof-capable review.
+            outcome=success
+            completion_kind=refresh_required
+            reason_code=close_coverage_retry
           elif [ "$LEGACY_TUPLELESS" = "true" ] && [ "$SOURCE_DRIFT_OUTCOME" = "success" ]; then
             outcome=success
             completion_kind=superseded
@@ -1931,7 +1946,7 @@ jobs:
               outcome=success
             fi
           fi
-          if [ "$outcome" = "success" ] && [ "$completion_kind" != "superseded" ]; then
+          if [ "$outcome" = "success" ] && [ "$completion_kind" != "superseded" ] && [ "$completion_kind" != "deferred" ] && [ "$completion_kind" != "refresh_required" ]; then
             if [ "$PUBLISH_COMPLETION_KIND" = "published" ] && [ "$PUBLISH_REASON_CODE" = "publication_applied" ]; then
               completion_kind=published
               reason_code=publication_applied
@@ -1995,10 +2010,10 @@ jobs:
             const failureKind = ["github_rate_limit", "github_transient"].includes(process.env.FAILURE_KIND)
               ? process.env.FAILURE_KIND
               : undefined;
-            const completionKind = ["published", "superseded", "retryable_failure", "refresh_required", "permanent_failure"].includes(process.env.COMPLETION_KIND)
+            const completionKind = ["published", "superseded", "deferred", "retryable_failure", "refresh_required", "permanent_failure"].includes(process.env.COMPLETION_KIND)
               ? process.env.COMPLETION_KIND
               : undefined;
-            const reasonCode = ["publication_applied", "remote_newer_tuple", "remote_closed", "live_terminal", "github_rate_limit", "github_transient", "workflow_cancelled", "artifact_unavailable", "artifact_expired", "invalid_artifact", "missing_record_tuple", "tuple_protocol_invalid", "policy_invariant", "unknown_failure", "retry_exhausted"].includes(process.env.REASON_CODE)
+            const reasonCode = ["publication_applied", "remote_newer_tuple", "remote_closed", "live_terminal", "github_rate_limit", "github_transient", "workflow_cancelled", "artifact_unavailable", "artifact_expired", "close_coverage_retry", "close_coverage_deferred", "invalid_artifact", "missing_record_tuple", "tuple_protocol_invalid", "policy_invariant", "unknown_failure", "retry_exhausted"].includes(process.env.REASON_CODE)
               ? process.env.REASON_CODE
               : undefined;
             const errorFingerprint = /^[A-Za-z0-9:._-]{1,200}$/.test(process.env.ERROR_FINGERPRINT || "")

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -77,6 +77,7 @@ type ExactReviewPublicationFailureKind = "github_rate_limit" | "github_transient
 export type ExactReviewPublicationCompletionKind =
   | "published"
   | "superseded"
+  | "deferred"
   | "retryable_failure"
   | "refresh_required"
   | "permanent_failure";
@@ -90,6 +91,8 @@ type ExactReviewPublicationReasonCode =
   | "workflow_cancelled"
   | "artifact_unavailable"
   | "artifact_expired"
+  | "close_coverage_retry"
+  | "close_coverage_deferred"
   | "invalid_artifact"
   | "missing_record_tuple"
   | "tuple_protocol_invalid"
@@ -631,7 +634,9 @@ export class ExactReviewQueue {
       if (
         publicationCompletion &&
         (publicationCompletion.kind === "published" ||
-          publicationCompletion.kind === "superseded") !==
+          publicationCompletion.kind === "superseded" ||
+          publicationCompletion.kind === "refresh_required" ||
+          publicationCompletion.kind === "deferred") !==
           (outcome === "success")
       ) {
         return json({ error: "completion_outcome_mismatch" }, 400);
@@ -2719,6 +2724,7 @@ function exactReviewPublicationCompletionKind(value): ExactReviewPublicationComp
   const normalized = String(value || "");
   return normalized === "published" ||
     normalized === "superseded" ||
+    normalized === "deferred" ||
     normalized === "retryable_failure" ||
     normalized === "refresh_required" ||
     normalized === "permanent_failure"
@@ -2738,6 +2744,8 @@ function exactReviewPublicationReasonCode(value): ExactReviewPublicationReasonCo
     "workflow_cancelled",
     "artifact_unavailable",
     "artifact_expired",
+    "close_coverage_retry",
+    "close_coverage_deferred",
     "invalid_artifact",
     "missing_record_tuple",
     "tuple_protocol_invalid",
@@ -2770,7 +2778,10 @@ function exactReviewPublicationCompletion(
       "artifact_unavailable",
       "unknown_failure",
     ]),
-    refresh_required: new Set(["artifact_unavailable", "artifact_expired"]),
+    // Accept the pre-deployment tuple while an old publisher can still finish.
+    // New publishers use deferred/close_coverage_deferred instead.
+    refresh_required: new Set(["artifact_unavailable", "artifact_expired", "close_coverage_retry"]),
+    deferred: new Set(["close_coverage_deferred"]),
     permanent_failure: new Set([
       "invalid_artifact",
       "missing_record_tuple",
@@ -2961,7 +2972,11 @@ function finishExactReviewPublicationQueueItem({
     };
   }
 
-  if (completion.kind === "published" || completion.kind === "superseded") {
+  if (
+    completion.kind === "published" ||
+    completion.kind === "superseded" ||
+    completion.kind === "deferred"
+  ) {
     return {
       requeued: finishExactReviewQueueItem(state, item, now, "success"),
       retried: false,

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -16200,6 +16200,10 @@ function contextHasNonAutomationActivityAfter(
   options: {
     truncationCountsAsActivity?: boolean;
     ignoreTimelineCommentsThroughMs?: number;
+    ignoreTrustedTimelineComment?: {
+      authors: ReadonlySet<string>;
+      createdAt: string;
+    };
   } = {},
 ): boolean {
   const truncationCountsAsActivity = options.truncationCountsAsActivity ?? true;
@@ -16220,6 +16224,16 @@ function contextHasNonAutomationActivityAfter(
   };
   const hasNonAutomationEvent = (event: unknown): boolean => {
     const record = asRecord(event);
+    const eventActor = (stringOrUndefined(record.actor) ?? "").trim().toLowerCase();
+    const trustedTimelineComment = options.ignoreTrustedTimelineComment;
+    if (
+      stringOrUndefined(record.event) === "commented" &&
+      trustedTimelineComment &&
+      eventTimestampMs(event) === timestampMs(trustedTimelineComment.createdAt) &&
+      trustedTimelineComment.authors.has(eventActor)
+    ) {
+      return false;
+    }
     // Issue comments are checked above with their bodies. Ignore timeline
     // duplicates only through the completed review; later commands are fresh
     // activity and must keep stale labels from being restored.
@@ -27826,8 +27840,68 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
         truncationCountsAsActivity: true,
       }),
     );
+    // A deferred duplicate/superseded close is not eligible to mutate until
+    // apply-proof has produced a new read-only coverage proof. Its publisher
+    // updates the command acknowledgement to make that handoff visible, which
+    // advances issue.updated_at without changing the reviewed source. Admit
+    // only that exact configured ClawSweeper status-comment churn; any human activity still
+    // forces a fresh review before proof or close work proceeds.
+    let retryCloseCoverageCommandStatusComments: Record<string, unknown>[] | undefined;
+    const reviewedSourceRevision = frontMatterValue(
+      markdownBeforeApplyDecisionMutations,
+      "item_source_revision",
+    );
+    const retryCloseCoverageCommandStatusOnlyUpdate = (
+      candidate: typeof item,
+      candidateContext: ItemContext,
+    ): boolean => {
+      if (
+        action !== "retry_pr_close_coverage_proof" ||
+        candidate.updatedAt === storedUpdatedAt ||
+        storedUpdatedAtMs === null ||
+        !reviewedSourceRevision ||
+        reviewedSourceRevision === "unknown" ||
+        candidateContext.sourceRevision !== reviewedSourceRevision
+      ) {
+        return false;
+      }
+      // Command-status comments are deliberately excluded from review context as bot noise.
+      // Read raw comments only for this narrow, trusted handoff and reuse them through the
+      // post-proof freshness check. The source-revision match prevents a human title/body
+      // edit made before this bot comment from being masked; ordinary drift remains fail-closed.
+      const rawComments =
+        retryCloseCoverageCommandStatusComments ??= fetchIssueReviewComments(number);
+      const statusComment = rawComments.find(
+        (comment) =>
+          commentUpdatedAt(comment) === candidate.updatedAt &&
+          CLAWSWEEPER_BOT_AUTHORS.has(
+            (login(asRecord(comment).user) ?? "").trim().toLowerCase(),
+          ) &&
+          (commentBody(comment) ?? "").includes("<!-- clawsweeper-command-status:"),
+      );
+      const statusCreatedAt = statusComment
+        ? stringOrUndefined(statusComment.created_at)
+        : undefined;
+      return Boolean(
+        statusCreatedAt &&
+          !contextHasNonAutomationActivityAfter(candidateContext, storedUpdatedAtMs, {
+            truncationCountsAsActivity: true,
+            ignoreTrustedTimelineComment: {
+              authors: CLAWSWEEPER_BOT_AUTHORS,
+              createdAt: statusCreatedAt,
+            },
+          }),
+      );
+    };
+    const commandStatusOnlyUpdate = retryCloseCoverageCommandStatusOnlyUpdate(
+      item,
+      currentItemContext(),
+    );
     const automationOnlyUpdate =
-      reviewCommentOnlyUpdate || labelSyncOnlyUpdate || ownedIssueReviewLeaseOnlyUpdate;
+      reviewCommentOnlyUpdate ||
+      labelSyncOnlyUpdate ||
+      ownedIssueReviewLeaseOnlyUpdate ||
+      commandStatusOnlyUpdate;
     const labelSyncFreshEnough = (): boolean => {
       if (!storedUpdatedAt) return false;
       if (!updatedSinceReview || automationOnlyUpdate) return true;
@@ -28084,10 +28158,16 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
           currentUpdatedAt: refreshed.item.updatedAt,
         };
       }
-      const refreshedSelfMutationOnlyUpdate = allowedSelfMutationUpdatedAts.has(
-        refreshed.item.updatedAt,
-      );
       let refreshedContext: ItemContext | null = null;
+      const refreshedCommandStatusOnlyUpdate = retryCloseCoverageCommandStatusOnlyUpdate(
+        refreshed.item,
+        (refreshedContext ??= collectItemContext(refreshed.item, {
+          fullTimelineForRelations: true,
+        })),
+      );
+      const refreshedSelfMutationOnlyUpdate =
+        allowedSelfMutationUpdatedAts.has(refreshed.item.updatedAt) ||
+        refreshedCommandStatusOnlyUpdate;
       const selfMutationMaskedNonAutomationActivity = (): boolean => {
         if (prCloseCoverageProofStartedAtMs === null) return true;
         refreshedContext ??= collectItemContext(refreshed.item, {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -27893,10 +27893,9 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
           }),
       );
     };
-    const commandStatusOnlyUpdate = retryCloseCoverageCommandStatusOnlyUpdate(
-      item,
-      currentItemContext(),
-    );
+    const commandStatusOnlyUpdate =
+      action === "retry_pr_close_coverage_proof" &&
+      retryCloseCoverageCommandStatusOnlyUpdate(item, currentItemContext());
     const automationOnlyUpdate =
       reviewCommentOnlyUpdate ||
       labelSyncOnlyUpdate ||
@@ -28159,12 +28158,14 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
         };
       }
       let refreshedContext: ItemContext | null = null;
-      const refreshedCommandStatusOnlyUpdate = retryCloseCoverageCommandStatusOnlyUpdate(
-        refreshed.item,
-        (refreshedContext ??= collectItemContext(refreshed.item, {
-          fullTimelineForRelations: true,
-        })),
-      );
+      const refreshedCommandStatusOnlyUpdate =
+        action === "retry_pr_close_coverage_proof" &&
+        retryCloseCoverageCommandStatusOnlyUpdate(
+          refreshed.item,
+          (refreshedContext ??= collectItemContext(refreshed.item, {
+            fullTimelineForRelations: true,
+          })),
+        );
       const refreshedSelfMutationOnlyUpdate =
         allowedSelfMutationUpdatedAts.has(refreshed.item.updatedAt) ||
         refreshedCommandStatusOnlyUpdate;

--- a/src/repair/event-apply-proof.ts
+++ b/src/repair/event-apply-proof.ts
@@ -87,6 +87,7 @@ export type ExactEventApplyDisposition =
   | "applied"
   | "terminal_policy_noop"
   | "source_drift"
+  | "close_coverage_deferred"
   | "unproven";
 
 export function eventApplyRequeueLatestExpected({
@@ -139,6 +140,15 @@ export function exactEventApplyProof(
         entry.durableReviewSynced ||
         entry.terminalStateVerified,
     );
+  // A close-coverage proof is deliberately retryable, but the immutable
+  // publisher has no Codex/proof credentials. It must leave this lane for the
+  // bounded read-only apply-proof lane, not replay its old review artifact.
+  const closeCoverageDeferred =
+    exactActions.length === 1 &&
+    exactActions[0]?.action === "retry_pr_close_coverage_proof" &&
+    syncedCount === 0 &&
+    terminalCount === 0 &&
+    exactActions[0]?.terminalMissingVerified !== true;
   return {
     exactActions,
     syncedCount,
@@ -160,11 +170,13 @@ export function exactEventApplyProof(
       ? sourceDrift
         ? "source_drift"
         : "unproven"
-      : terminalPolicyNoop
-        ? "terminal_policy_noop"
-        : syncedCount + terminalCount > 0
-          ? "applied"
-          : "unproven",
+      : closeCoverageDeferred
+        ? "close_coverage_deferred"
+        : terminalPolicyNoop
+          ? "terminal_policy_noop"
+          : syncedCount + terminalCount > 0
+            ? "applied"
+            : "unproven",
   };
 }
 

--- a/src/repair/publish-event-result.ts
+++ b/src/repair/publish-event-result.ts
@@ -54,8 +54,12 @@ type EventOptions = {
 };
 
 type PublishedEventSnapshot = {
-  completionKind: "published" | "superseded";
-  reasonCode: "publication_applied" | "remote_newer_tuple" | "remote_closed";
+  completionKind: "published" | "superseded" | "deferred";
+  reasonCode:
+    | "publication_applied"
+    | "remote_newer_tuple"
+    | "remote_closed"
+    | "close_coverage_deferred";
   guardedOpenAction: string | null;
   policyNoop: boolean;
   requeueLatest: boolean;
@@ -208,10 +212,22 @@ async function publishEventResult(options: EventOptions): Promise<void> {
       `Requeueing ${options.targetRepo}#${options.itemNumber}: legacy exact artifact lacks its durable review lease tuple`,
     );
   }
+  const deferredCloseCoverageExpected = applyDisposition === "close_coverage_deferred";
+  const deferredCloseCoverageEnabled = process.env.EXACT_REVIEW_CLOSE_COVERAGE_DEFERRED === "true";
+  if (deferredCloseCoverageExpected) {
+    console.log(
+      `Deferring ${options.targetRepo}#${options.itemNumber}: PR close coverage proof must run in the read-only apply-proof lane`,
+    );
+    if (!deferredCloseCoverageEnabled) {
+      writeLegacyRefreshRequiredOutputs();
+      return;
+    }
+  }
   if (
     syncedCount + closedCount + missingCount === 0 &&
     guardedOpenAction === null &&
-    !requeueLatestExpected
+    !requeueLatestExpected &&
+    !deferredCloseCoverageExpected
   ) {
     const observed =
       exactActions
@@ -246,6 +262,7 @@ async function publishEventResult(options: EventOptions): Promise<void> {
       guardedOpenAction,
       requeueLatestExpected,
       routableSyncExpected,
+      deferredCloseCoverageExpected,
       terminalClosedExpected: closedCount > 0,
       terminalMissingExpected: missingCount > 0,
     });
@@ -267,6 +284,7 @@ async function publishEventResult(options: EventOptions): Promise<void> {
     guardedOpenAction,
     requeueLatestExpected,
     routableSyncExpected,
+    deferredCloseCoverageExpected,
     terminalClosedExpected: closedCount > 0,
     terminalMissingExpected: missingCount > 0,
   });
@@ -323,6 +341,7 @@ function publishSnapshot({
   guardedOpenAction,
   requeueLatestExpected,
   routableSyncExpected,
+  deferredCloseCoverageExpected,
   terminalClosedExpected,
   terminalMissingExpected,
 }: {
@@ -333,6 +352,7 @@ function publishSnapshot({
   guardedOpenAction: string | null;
   requeueLatestExpected: boolean;
   routableSyncExpected: boolean;
+  deferredCloseCoverageExpected: boolean;
   terminalClosedExpected: boolean;
   terminalMissingExpected: boolean;
 }): PublishedEventSnapshot | null {
@@ -363,22 +383,37 @@ function publishSnapshot({
         guardedOpenAction,
         routableSyncExpected,
       });
+      const completionSupersededReason =
+        supersededReason ||
+        (deferredCloseCoverageExpected && !candidateMatchesCurrentTuple
+          ? ("remote_newer_tuple" as const)
+          : undefined);
+      const deferredCloseCoverage = !completionSupersededReason && deferredCloseCoverageExpected;
       const published = {
         ...disposition,
-        completionKind: supersededReason ? ("superseded" as const) : ("published" as const),
-        reasonCode: supersededReason || ("publication_applied" as const),
+        completionKind: completionSupersededReason
+          ? ("superseded" as const)
+          : deferredCloseCoverage
+            ? ("deferred" as const)
+            : ("published" as const),
+        reasonCode:
+          completionSupersededReason ||
+          (deferredCloseCoverage
+            ? ("close_coverage_deferred" as const)
+            : ("publication_applied" as const)),
         policyNoop: disposition.guardedOpenAction === "skipped_same_author_pair",
         requeueLatest:
           requeueLatestExpected && candidateMatchesCurrentTuple && candidateTupleState === "open",
         remoteTupleVerified: candidateMatchesCurrentTuple,
-        routingDeferred: exactEventRoutingDeferred({
-          candidateMatchesCurrentTuple,
-          candidateTupleState,
-          guardedOpenAction,
-          requeueLatestExpected,
-        }),
+        routingDeferred:
+          exactEventRoutingDeferred({
+            candidateMatchesCurrentTuple,
+            candidateTupleState,
+            guardedOpenAction,
+            requeueLatestExpected,
+          }) && !deferredCloseCoverage,
       };
-      if (supersededReason) {
+      if (completionSupersededReason) {
         summary();
         return published;
       }
@@ -564,11 +599,33 @@ function writeEventDispositionOutputs(published: PublishedEventSnapshot): void {
   );
 }
 
+function writeLegacyRefreshRequiredOutputs(): void {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) return;
+  fs.appendFileSync(
+    outputPath,
+    [
+      "completion_kind=refresh_required",
+      "reason_code=close_coverage_retry",
+      "remote_tuple_verified=false",
+      "terminal_missing=false",
+      "terminal_closed=false",
+      "guarded_open=false",
+      "policy_noop=false",
+      "requeue_latest=false",
+      "routing_deferred=false",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
 function writePublicationCompletionOutputs(
-  completionKind: "superseded" | "permanent_failure",
+  completionKind: "superseded" | "deferred" | "permanent_failure",
   reasonCode:
     | "remote_newer_tuple"
     | "remote_closed"
+    | "close_coverage_deferred"
     | "missing_record_tuple"
     | "tuple_protocol_invalid"
     | "policy_invariant"

--- a/test/apply-pr-coverage-proof-close.test.ts
+++ b/test/apply-pr-coverage-proof-close.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import {
   existsSync,
   mkdirSync,
@@ -21,6 +22,19 @@ import {
   withMockCodexProof,
   withMockGh,
 } from "./helpers.ts";
+
+function sourceRevisionForTest(title: string): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        title,
+        body: "Stale PR body.",
+        labels: [],
+        comments: [],
+      }),
+    )
+    .digest("hex");
+}
 
 test("apply-decisions skips stale close reports before duplicate PR coverage proof", () => {
   const root = mkdtempSync(tmpPrefix);
@@ -298,6 +312,235 @@ test("apply-decisions closes existing duplicate PR close proposals when coverage
       report.find((entry) => entry.action === "closed")?.reason ?? "",
       /duplicate or superseded/,
     );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions permits a trusted deferred close-proof command status through post-proof freshness", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const synced = reportWithSyncedReviewComment(
+      lowSignalCloseReport({
+        number: 363,
+        title: "Provider route fallback",
+        action_taken: "retry_pr_close_coverage_proof",
+        item_source_revision: sourceRevisionForTest("Provider route fallback"),
+        close_reason: "duplicate_or_superseded",
+        work_cluster_refs: JSON.stringify([
+          "Superseded by https://github.com/openclaw/openclaw/pull/400",
+        ]),
+      }).replace(
+        "Closing this PR because the branch is not a useful landing base.",
+        "Closing this PR as superseded by https://github.com/openclaw/openclaw/pull/400.",
+      ),
+      363,
+      "duplicate_or_superseded",
+    );
+    writeFileSync(join(itemsDir, "363.md"), synced.report, "utf8");
+
+    withMockGh(
+      root,
+      promotionGhMock({
+        number: 363,
+        title: "Provider route fallback",
+        itemUpdatedAt: "2026-05-01T02:00:00Z",
+        comment: synced.comment,
+        comments: [
+          {
+            id: 9363,
+            html_url: "https://github.com/openclaw/openclaw/pull/363#issuecomment-9363",
+            created_at: "2026-05-01T01:00:00Z",
+            updated_at: "2026-05-01T01:00:00Z",
+            user: { login: "clawsweeper" },
+            body: synced.comment,
+          },
+          {
+            id: 9364,
+            html_url: "https://github.com/openclaw/openclaw/pull/363#issuecomment-9364",
+            created_at: "2026-05-01T01:30:00Z",
+            updated_at: "2026-05-01T02:00:00Z",
+            user: { login: "clawsweeper" },
+            body: "<!-- clawsweeper-command-status: close-coverage-proof-pending -->",
+          },
+        ],
+        timeline: [
+          {
+            event: "commented",
+            created_at: "2026-05-01T01:30:00Z",
+            actor: { login: "clawsweeper" },
+          },
+        ],
+        linkedPulls: {
+          400: {
+            number: 400,
+            title: "Provider cleanup",
+            html_url: "https://github.com/openclaw/openclaw/pull/400",
+            state: "closed",
+            merged_at: "2026-05-02T00:00:00Z",
+            body: "Includes the fallback route behavior from PR 363.",
+            comments: [],
+            labels: [],
+          },
+        },
+      }),
+      () => {
+        withMockCodexProof(
+          root,
+          {
+            type: "decision",
+            decision: "covered",
+            reason: "PR B carries forward PR A's fallback route behavior.",
+          },
+          () => {
+            runApplyDecisionsForTest({
+              itemsDir,
+              closedDir,
+              plansDir,
+              reportPath,
+              extraArgs: [
+                "--target-repo",
+                "openclaw/openclaw",
+                "--dry-run",
+                "--apply-kind",
+                "all",
+                "--processed-limit",
+                "3",
+              ],
+            });
+          },
+        );
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+      action: string;
+      reason: string;
+    }>;
+    assert.equal(
+      report.some((entry) => entry.action === "closed"),
+      true,
+    );
+    assert.match(
+      report.find((entry) => entry.action === "closed")?.reason ?? "",
+      /duplicate or superseded/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions rejects a source edit masked by a deferred close-proof status", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const proofLogPath = join(root, "proof.log");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const reviewedTitle = "Provider route fallback";
+    const synced = reportWithSyncedReviewComment(
+      lowSignalCloseReport({
+        number: 364,
+        title: reviewedTitle,
+        action_taken: "retry_pr_close_coverage_proof",
+        item_source_revision: sourceRevisionForTest(reviewedTitle),
+        close_reason: "duplicate_or_superseded",
+        work_cluster_refs: JSON.stringify([
+          "Superseded by https://github.com/openclaw/openclaw/pull/400",
+        ]),
+      }).replace(
+        "Closing this PR because the branch is not a useful landing base.",
+        "Closing this PR as superseded by https://github.com/openclaw/openclaw/pull/400.",
+      ),
+      364,
+      "duplicate_or_superseded",
+    );
+    writeFileSync(join(itemsDir, "364.md"), synced.report, "utf8");
+
+    withMockGh(
+      root,
+      promotionGhMock({
+        number: 364,
+        title: "Edited provider route fallback",
+        itemUpdatedAt: "2026-05-01T02:00:00Z",
+        comment: synced.comment,
+        comments: [
+          {
+            id: 9365,
+            html_url: "https://github.com/openclaw/openclaw/pull/364#issuecomment-9365",
+            created_at: "2026-05-01T01:00:00Z",
+            updated_at: "2026-05-01T01:00:00Z",
+            user: { login: "clawsweeper[bot]" },
+            body: synced.comment,
+          },
+          {
+            id: 9366,
+            html_url: "https://github.com/openclaw/openclaw/pull/364#issuecomment-9366",
+            created_at: "2026-05-01T02:00:00Z",
+            updated_at: "2026-05-01T02:00:00Z",
+            user: { login: "clawsweeper[bot]" },
+            body: "<!-- clawsweeper-command-status: close-coverage-proof-pending -->",
+          },
+        ],
+        linkedPulls: {
+          400: {
+            number: 400,
+            title: "Provider cleanup",
+            html_url: "https://github.com/openclaw/openclaw/pull/400",
+            state: "closed",
+            merged_at: "2026-05-02T00:00:00Z",
+            body: "Includes the fallback route behavior from PR 364.",
+            comments: [],
+            labels: [],
+          },
+        },
+      }),
+      () => {
+        withMockCodexProof(
+          root,
+          {
+            type: "decision",
+            decision: "covered",
+            reason: "PR B carries forward PR A's fallback route behavior.",
+            invocationLogPath: proofLogPath,
+          },
+          () => {
+            runApplyDecisionsForTest({
+              itemsDir,
+              closedDir,
+              plansDir,
+              reportPath,
+              extraArgs: [
+                "--target-repo",
+                "openclaw/openclaw",
+                "--dry-run",
+                "--apply-kind",
+                "all",
+                "--processed-limit",
+                "3",
+              ],
+            });
+          },
+        );
+      },
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+      action: string;
+      reason: string;
+    }>;
+    assert.equal(report[0]?.action, "skipped_changed_since_review");
+    assert.match(report[0]?.reason ?? "", /updated_at changed/);
+    assert.equal(existsSync(proofLogPath), false);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -4807,6 +4807,42 @@ test("exact-review publication retry budgets ignore earlier dispatch failures", 
   assert.equal(stats.lanes.publication.dead_letters.open, 0);
 });
 
+test("exact-review publication retains one unknown completion for a current-workflow retry", async () => {
+  const storage = new MemoryDurableStorage();
+  const item = leasedExactReviewPublicationItem(7851, "78510");
+  await storage.put("exact-review-queue", { deliveries: {}, items: { [item.key]: item } });
+  const queue = new ExactReviewQueue({ storage }, {});
+
+  const response = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: item.leaseId,
+        item_key: item.key,
+        lease_revision: item.leaseRevision,
+        claim_generation: item.claimGeneration,
+        run_id: item.claimedRunId,
+        run_attempt: item.claimedRunAttempt,
+        outcome: "failure",
+        completion_kind: "permanent_failure",
+        reason_code: "unknown_failure",
+      }),
+    }),
+  );
+
+  assert.deepEqual(await response.json(), { ok: true, requeued: true });
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { state: string; attempts: number; publicationFailureAttempts?: number }>;
+  };
+  assert.equal(state.items[item.key].state, "pending");
+  assert.equal(state.items[item.key].attempts, 1);
+  assert.equal(state.items[item.key].publicationFailureAttempts, 1);
+  const stats = await (
+    await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(stats.lanes.publication.dead_letters.open, 0);
+});
+
 test("ordinary exact-review retries do not increment publication retry telemetry", async () => {
   const storage = new MemoryDurableStorage();
   const item = leasedExactReviewQueueItem(786, "7860");

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -4700,6 +4700,77 @@ test("exact-review publication refreshes an artifact after its third unavailable
   assert.equal(stats.lanes.publication.refreshed_total, 1);
 });
 
+test("exact-review publication completes a close-coverage deferral without refreshing", async () => {
+  const storage = new MemoryDurableStorage();
+  const item = leasedExactReviewPublicationItem(7831, "78310");
+  await storage.put("exact-review-queue", { deliveries: {}, items: { [item.key]: item } });
+  const queue = new ExactReviewQueue({ storage }, { EXACT_REVIEW_DISPATCH_DEBOUNCE_MS: "0" });
+
+  const response = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: item.leaseId,
+        item_key: item.key,
+        lease_revision: item.leaseRevision,
+        claim_generation: item.claimGeneration,
+        run_id: item.claimedRunId,
+        run_attempt: item.claimedRunAttempt,
+        outcome: "success",
+        completion_kind: "deferred",
+        reason_code: "close_coverage_deferred",
+      }),
+    }),
+  );
+
+  assert.deepEqual(await response.json(), { ok: true, requeued: false });
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { decision: { sourceAction: string; publication?: unknown } }>;
+  };
+  assert.equal(state.items[item.key], undefined);
+  assert.equal(state.items["openclaw/openclaw#7831"], undefined);
+  const stats = await (
+    await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(stats.lanes.publication.refreshed_total, 0);
+  assert.equal(stats.lanes.publication.dead_letters.open, 0);
+});
+
+test("exact-review publication accepts the legacy close-coverage refresh during rollout", async () => {
+  const storage = new MemoryDurableStorage();
+  const item = leasedExactReviewPublicationItem(7832, "78320");
+  await storage.put("exact-review-queue", { deliveries: {}, items: { [item.key]: item } });
+  const queue = new ExactReviewQueue({ storage }, { EXACT_REVIEW_DISPATCH_DEBOUNCE_MS: "0" });
+
+  const response = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: item.leaseId,
+        item_key: item.key,
+        lease_revision: item.leaseRevision,
+        claim_generation: item.claimGeneration,
+        run_id: item.claimedRunId,
+        run_attempt: item.claimedRunAttempt,
+        outcome: "success",
+        completion_kind: "refresh_required",
+        reason_code: "close_coverage_retry",
+      }),
+    }),
+  );
+
+  assert.deepEqual(await response.json(), { ok: true, requeued: false });
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { decision: { sourceAction: string; publication?: unknown } }>;
+  };
+  assert.equal(state.items[item.key], undefined);
+  assert.equal(
+    state.items["openclaw/openclaw#7832"].decision.sourceAction,
+    "artifact_retention_recovery",
+  );
+  assert.equal(state.items["openclaw/openclaw#7832"].decision.publication, undefined);
+});
+
 test("exact-review publication retry budgets ignore earlier dispatch failures", async () => {
   const storage = new MemoryDurableStorage();
   const item = leasedExactReviewPublicationItem(785, "7850");

--- a/test/repair/event-apply-proof.test.ts
+++ b/test/repair/event-apply-proof.test.ts
@@ -300,6 +300,23 @@ test("exact event proof accepts only explicit trusted no-action dispositions", (
   assert.equal(sourceDrift.disposition, "source_drift");
   assert.equal(unproven.disposition, "unproven");
 });
+
+test("exact event proof defers a close-coverage retry to the proof-capable apply lane", () => {
+  const proof = exactEventApplyProof(
+    [eventApplyAction({ number: 42, action: "retry_pr_close_coverage_proof" })],
+    42,
+  );
+
+  assert.equal(proof.disposition, "close_coverage_deferred");
+  assert.equal(
+    eventApplyRequeueLatestExpected({
+      disposition: proof.disposition,
+      exactEventPublication: true,
+      legacyTuplelessReviewLease: proof.legacyTuplelessReviewLease,
+    }),
+    false,
+  );
+});
 test("exact event proof completes live-shaped deterministic guarded-open results", () => {
   for (const action of [
     "skipped_same_author_pair",

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -504,6 +504,11 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   assert.equal(status.env?.LIVE_GUARDED_OPEN, undefined);
   assert.match(status.env?.PUBLISH_COMPLETION_KIND ?? "", /publish-event-result/);
   assert.match(status.run ?? "", /PUBLISH_COMPLETION_KIND.*superseded/);
+  const commandComplete = step(publisher, "Mark re-review complete");
+  assert.doesNotMatch(commandComplete.if ?? "", /completion_kind != 'deferred'/);
+  assert.match(commandComplete.run ?? "", /state="Complete"/);
+  assert.match(commandComplete.run ?? "", /independent bounded read-only proof check/);
+  assert.doesNotMatch(commandComplete.run ?? "", /Close coverage proof pending/);
   assert.match(status.run ?? "", /stale result was superseded/);
   assert.doesNotMatch(status.run ?? "", /LIVE_TERMINAL_MISSING|LIVE_GUARDED_OPEN/);
   const reaction = step(publisher, "React to target item completion");
@@ -526,6 +531,7 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   assert.match(releaseUnsuccessful.run ?? "", /\.user\.login == \\"clawsweeper\[bot\]\\"/);
   assert.match(releaseUnsuccessful.run ?? "", /content == "eyes"/);
   assert.match(releaseUnsuccessful.if ?? "", /completion_kind == 'superseded'/);
+  assert.doesNotMatch(releaseUnsuccessful.if ?? "", /completion_kind == 'deferred'/);
   assert.match(publishResult.env?.PRIOR_JOB_STATUS ?? "", /job\.status/);
   assert.match(publishResult.env?.LEGACY_TUPLELESS ?? "", /legacy-exact-artifact/);
   assert.match(publishResult.env?.FAILURE_KIND ?? "", /publish-event-result/);
@@ -542,6 +548,14 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   assert.match(publishResult.run ?? "", /REQUEUE_LATEST.*SOURCE_DRIFT_OUTCOME/);
   assert.match(publishResult.run ?? "", /LEGACY_TUPLELESS.*SOURCE_DRIFT_OUTCOME/);
   assert.match(publishResult.run ?? "", /completion_kind=superseded/);
+  assert.match(publishResult.run ?? "", /completion_kind=deferred/);
+  assert.match(publishResult.run ?? "", /completion_kind=refresh_required/);
+  assert.match(publishResult.run ?? "", /reason_code=close_coverage_retry/);
+  assert.match(publishResult.run ?? "", /reason_code=close_coverage_deferred/);
+  assert.match(
+    publishResult.run ?? "",
+    /completion_kind" != "superseded".*completion_kind" != "deferred".*completion_kind" != "refresh_required"/,
+  );
   assert.match(publishResult.run ?? "", /reason_code=artifact_unavailable/);
   assert.match(publishResult.run ?? "", /reason_code=invalid_artifact/);
   assert.doesNotMatch(publishResult.run ?? "", /LIVE_TERMINAL_NOOP/);
@@ -559,12 +573,23 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   );
   assert.match(publisherSource, /"--exact-event-publication"/);
   assert.match(publisherSource, /legacyTuplelessReviewLease/);
+  assert.match(publisherSource, /applyDisposition === "close_coverage_deferred"/);
+  assert.match(publisherSource, /EXACT_REVIEW_CLOSE_COVERAGE_DEFERRED/);
+  assert.match(publisherSource, /writeLegacyRefreshRequiredOutputs/);
+  assert.match(publisherSource, /read-only apply-proof lane/);
+  assert.match(publisherSource, /deferredCloseCoverageExpected/);
+  assert.match(publisherSource, /deferredCloseCoverageExpected && !candidateMatchesCurrentTuple/);
+  assert.match(publisherSource, /syncPublishPaths\(commitPaths\)/);
+  assert.match(publisherSource, /\}\) && !deferredCloseCoverage/);
   assert.match(publisherSource, /writePublicationCompletionOutputs\(\s*"superseded"/);
-  assert.match(publisherSource, /completionKind: supersededReason/);
+  assert.match(publisherSource, /completionKind: completionSupersededReason/);
   const reviewSource = readText("src/clawsweeper.ts");
   assert.match(reviewSource, /reserveReviewLeaseCommand/);
   assert.match(reviewSource, /suppliedReviewStartLeaseFromArgs/);
   assert.match(reviewSource, /exactEventReviewLeaseDisposition/);
+  assert.match(reviewSource, /retryCloseCoverageCommandStatusOnlyUpdate/);
+  assert.match(reviewSource, /clawsweeper-command-status:/);
+  assert.match(reviewSource, /CLAWSWEEPER_BOT_AUTHORS\.has/);
   const completeStart = publisherSource.indexOf("const complete =");
   assert.ok(publisherSource.indexOf("hardResetToRemoteMain();", completeStart) > completeStart);
   assert.ok(


### PR DESCRIPTION
## Summary

Fixes #635's `retry_pr_close_coverage_proof` publisher loop: an immutable exact-result publisher cannot run the Codex-backed close-coverage proof, so replaying that same artifact repeatedly exhausts publication attempts and dead-letters it.

## Problem

The live incident left close-coverage retry artifacts in the publisher/DLQ path. The publisher has no proof credentials, whereas the bounded read-only `apply-proof` lane does. Replaying the immutable artifact cannot change that capability boundary.

## Implementation

- Persist a durable `deferred / close_coverage_deferred` publisher completion and let the existing proof-capable lane select it.
- Never route a deferred close recommendation directly.
- Preserve the old `refresh_required / close_coverage_retry` completion for an in-flight workflow that has new helper code but lacks the new workflow opt-in.
- Retain the source lease through the proof handoff, complete the command status as a completed review with explicit downstream proof gating, and accept only the exact trusted status-comment churn.
- Fail closed if the reviewed source revision, PR activity, or human activity changed; PATCH-style command-status updates match their raw `updated_at` and timeline `created_at` separately.
- Avoid hydration of issue timeline/status context for every ordinary apply: it is evaluated only for `retry_pr_close_coverage_proof`, fixing the real 20-case mock-GitHub CI regression on the first revision.

The durable queue already retains a first `permanent_failure / unknown_failure` completion as one pending retry. A new regression test pins that rolling-deployment safety: an old workflow YAML that runs newly merged publisher code cannot turn the temporary unknown completion into a dead letter before a current workflow run handles the deferred contract.

## Validation

- `pnpm run build`
- `pnpm run build:repair`
- `pnpm run build:dashboard`
- `pnpm exec oxfmt --check <all touched files>`
- Focused `node --test` coverage for the trusted deferred status, source drift, close-coverage deferral, legacy compatibility, immutable handoff, and proposed-close selection.
- `git diff --check`
- Fresh GitHub Actions `pnpm check` on `d0c28ea6b0` — passed (10m 4s).

Focused checks passed. The regression tests prove both that an unchanged trusted command-status handoff reaches the bounded proof lane and that a title/body source edit is rejected before Codex proof or close work.

The stale first-revision `pnpm check` failure was investigated rather than waived: the new close-proof status helper evaluated `currentItemContext()` for unrelated ordinary applies, adding unexpected timeline calls to 20 mock-GitHub cases. Commit `d0c28ea6b0` guards that evaluation by action and adds the rolling-deploy queue regression test.

## Controlled Linux runtime proof

On 2026-07-17, a clean Docker-backed Crabbox local container (`mcr.microsoft.com/playwright:v1.60.0-noble`, Node `v24.15.0`, pnpm `11.10.0`) installed with `pnpm install --frozen-lockfile`, built the TypeScript/dashboard targets, and ran the exact queue/apply-proof behavior. Lease `cbx_1b61620e9b7b` completed with exit code 0:

- `apply-decisions permits a trusted deferred close-proof command status through post-proof freshness`
- `apply-decisions rejects a source edit masked by a deferred close-proof status`
- `exact-review publication retains one unknown completion for a current-workflow retry`
- `exact event proof defers a close-coverage retry to the proof-capable apply lane`

Result: 4 passed, 0 failed. This is controlled Linux runtime evidence through the real built queue/apply boundaries; it does not claim a live GitHub publication or use a live GitHub write token.

## Persistent completion-contract integration proof

On 2026-07-17, a second clean Docker-backed Crabbox container (`cbx_bad10c4a5823`, `mcr.microsoft.com/playwright:v1.60.0-noble`) built the branch's repair target and started the real `dashboard/worker.ts` under `wrangler@4.107.0 dev --local --persist-to`. Its actual `ExactReviewQueue` Durable Object initialised a SQLite store.

To keep the canary isolated and avoid a GitHub or Cloudflare mutation, a redacted leased publication fixture was inserted into that local Durable Object store while the Worker was stopped. After restart, the real tuple-capability completion endpoint received the publisher wire contract:

```text
outcome=success
completion_kind=deferred
reason_code=close_coverage_deferred
```

It returned `{ ok: true, requeued: false }`. After another Worker restart against the same persisted directory, the live queue statistics were `completed_total: 1`, `retried_total: 0`, and `dead_letters_open: 0`; the publisher item had no remaining live or dead-letter row.

In the same built branch, the actual `event-apply-proof` module classified the sole `retry_pr_close_coverage_proof` outcome as `close_coverage_deferred` without requeueing the immutable publisher, while a verified `skipped_changed_since_review` result classified as `source_drift` and selected a fresh retry.

This is an isolated persisted Worker/queue integration proof of the completion contract and decision boundary. It deliberately does not claim the remaining hosted Actions properties: GitHub App token identity, real status-comment timing, or an actual publisher-to-proof-lane run. GitHub executes `repository_dispatch` from default `main`, and the publisher job explicitly checks out `main`, so an unmerged PR cannot be truthfully exercised by a normal live command.

Codex review closeout:

- `codex review --uncommitted` — clean after the rolling-deploy regression test.
- Final `codex review --base origin/main` at `d0c28ea6b0` — clean: “No actionable correctness issues.”

`actionlint` is not installed on this Windows host. A previous broad local Linux-container suite hit pre-existing CRLF Bash-fixture failures after Windows source sync (`pipefail\r`); this branch does not change `scripts/`, and the fresh native-Linux GitHub CI run passed.

## Risks and rollout

- The deferred path covers only the exact `retry_pr_close_coverage_proof` outcome. It does not automatically replay or alter existing DLQ rows.
- The proof lane remains bounded and read-only until its normal guarded apply step; no close is authorized by the publisher handoff itself.
- This touches `.github/workflows/sweep.yml`; GitHub workflow OAuth/token scope and the normal repository write-token behavior remain an operational risk to verify in a maintainer-owned hosted staging environment or through an explicitly accepted monitored rollout.

## Related

Fixes #635.

Related: #634, #641, and #651 (the separate, explicitly operator-invoked guarded DLQ recovery control). Land this producer-side prevention before using #651 for any recovery.
