### PR TITLE
fix(queue): add guarded fresh DLQ recovery

### DIFF
--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -823,6 +823,10 @@ export class ExactReviewQueue {
       return this.replayDeadLetters(await request.json().catch(() => null));
     }
 
+    if (request.method === "POST" && url.pathname === "/dead-letters/recover-fresh") {
+      return this.recoverDeadLettersFresh(await request.json().catch(() => null));
+    }
+
     if (request.method === "POST" && url.pathname === "/dead-letters/resolve") {
       return this.resolveDeadLetters(await request.json().catch(() => null));
     }
@@ -1225,13 +1229,48 @@ export class ExactReviewQueue {
       ) as Iterable<Record<string, unknown>>,
     );
     const page = rows.slice(0, limit);
+    const state = this.readStateSync();
     return json({
       ok: true,
-      dead_letters: page.map((row) => ({
-        ...row,
-        item: JSON.parse(String(row.item_json || "{}")),
-        item_json: undefined,
-      })),
+      dead_letters: page.map((row) => {
+        const item = exactReviewDeadLetterItem(String(row.item_json || ""));
+        const recovery = item ? exactReviewFreshRecoveryFromPublicationItem(item) : null;
+        const activePublication = item ? state.items[item.key] : undefined;
+        const activeRecovery = recovery ? state.items[recovery.key] : undefined;
+        const recoveryReason = !item
+          ? "invalid_dead_letter_item"
+          : !recovery
+            ? "not_an_exact_publication"
+            : activePublication
+              ? "publication_item_active"
+              : activeRecovery
+                ? "fresh_review_already_active"
+                : !isExactReviewQueueTargetEnabled(recovery.decision, this.env)
+                  ? "target_not_enabled"
+                  : "eligible";
+        return {
+          ...row,
+          item,
+          item_json: undefined,
+          diagnostic: {
+            reason_code: String(row.reason_code || "unknown_failure"),
+            attempts: Number(row.attempts || 0),
+            first_failed_at: Number(row.first_failed_at || 0)
+              ? new Date(Number(row.first_failed_at)).toISOString()
+              : null,
+            last_failed_at: Number(row.last_failed_at || 0)
+              ? new Date(Number(row.last_failed_at)).toISOString()
+              : null,
+            error_fingerprint: String(row.error_fingerprint || "") || null,
+          },
+          fresh_recovery: {
+            mode: "fresh_review_only",
+            eligible: recoveryReason === "eligible",
+            reason: recoveryReason,
+            item_key: recovery?.key ?? null,
+          },
+        };
+      }),
       next_cursor: rows.length > limit ? String(page.at(-1)?.dead_letter_id || "") || null : null,
     });
   }
@@ -1311,6 +1350,114 @@ export class ExactReviewQueue {
       replayed: result.replayed,
       deduped: result.deduped,
       skipped: result.skipped,
+    });
+  }
+
+  private async recoverDeadLettersFresh(value: unknown) {
+    const body = objectValue(value);
+    const ids = exactReviewDeadLetterIds(body.ids);
+    const recoveryKey = String(body.idempotency_key || "").trim();
+    if (!ids || ids.length > 10) return json({ error: "invalid_dead_letter_ids" }, 400);
+    if (!/^[A-Za-z0-9:._-]{1,200}$/.test(recoveryKey)) {
+      return json({ error: "invalid_idempotency_key" }, 400);
+    }
+    const now = Date.now();
+    const result = this.storage.transactionSync(() => {
+      const state = this.readStateSync();
+      let recovered = 0;
+      let deduped = 0;
+      let skipped = 0;
+      for (const id of ids) {
+        const row = Array.from(
+          this.storage.sql.exec(
+            `SELECT status, replay_key, resolution_note, item_json
+               FROM ${EXACT_REVIEW_QUEUE_DEAD_LETTER_TABLE}
+              WHERE dead_letter_id = ?`,
+            id,
+          ),
+        )[0] as
+          | {
+              status?: string;
+              replay_key?: string;
+              resolution_note?: string;
+              item_json?: string;
+            }
+          | undefined;
+        if (
+          row?.status === "resolved" &&
+          row.replay_key === recoveryKey &&
+          row.resolution_note === "recovered_fresh"
+        ) {
+          deduped += 1;
+          continue;
+        }
+        if (row?.status !== "open" || !row.item_json) {
+          skipped += 1;
+          continue;
+        }
+        const item = exactReviewDeadLetterItem(row.item_json);
+        const recovery = item ? exactReviewFreshRecoveryFromPublicationItem(item) : null;
+        if (
+          !item ||
+          !recovery ||
+          !isExactReviewQueueTargetEnabled(recovery.decision, this.env) ||
+          state.items[item.key] ||
+          state.items[recovery.key]
+        ) {
+          skipped += 1;
+          continue;
+        }
+        // Never replay the immutable publisher artifact. Create exactly one new ordinary
+        // review item so the current workflow can gather a new artifact and proof. Existing
+        // pending, dispatching, and leased items are all skipped above rather than replaced.
+        state.items[recovery.key] = {
+          key: recovery.key,
+          decision: recovery.decision,
+          state: "pending",
+          revision: 1,
+          createdAt: now,
+          updatedAt: now,
+          nextAttemptAt: exactReviewQueueDebouncedAttemptAt(
+            state,
+            recovery.decision,
+            now,
+            now,
+            this.env,
+          ),
+          attempts: 0,
+        };
+        this.storage.sql.exec(
+          `UPDATE ${EXACT_REVIEW_QUEUE_DEAD_LETTER_TABLE}
+              SET status = 'resolved', replay_key = ?, resolution_note = 'recovered_fresh',
+                  resolved_at = ?
+            WHERE dead_letter_id = ? AND status = 'open'`,
+          recoveryKey,
+          now,
+          id,
+        );
+        recovered += 1;
+      }
+      const unparked = recovered ? this.drainParkedDeadLettersSync(state, now) : 0;
+      if (recovered || unparked) {
+        this.writeStateSync(state);
+        if (unparked) {
+          this.incrementQueueMetricsSync({
+            publicationCompleted: unparked,
+            publicationDeadLettered: unparked,
+          });
+        }
+      } else {
+        this.syncLegacyCompatibilitySync(state);
+      }
+      return { state, recovered, deduped, skipped, unparked };
+    });
+    if (result.recovered || result.unparked) await this.scheduleNext(result.state, now);
+    return json({
+      ok: true,
+      recovered: result.recovered,
+      deduped: result.deduped,
+      skipped: result.skipped,
+      unparked: result.unparked,
     });
   }
 
@@ -2798,6 +2945,36 @@ function exactReviewDeadLetterIds(value): string[] | null {
   return ids;
 }
 
+type ExactReviewDeadLetterItem = Pick<ExactReviewQueueItem, "key" | "decision">;
+
+function exactReviewDeadLetterItem(value: string): ExactReviewDeadLetterItem | null {
+  try {
+    const record = objectValue(JSON.parse(value));
+    const key = String(record.key || "").trim();
+    const decision = exactReviewDecisionFrom(record.decision);
+    if (!key || !decision || key !== exactReviewItemKey(decision)) return null;
+    return { key, decision };
+  } catch {
+    return null;
+  }
+}
+
+function exactReviewFreshRecoveryFromPublicationItem(
+  item: ExactReviewDeadLetterItem,
+): { decision: ExactReviewDecision; key: string } | null {
+  if (!exactReviewQueueIsPublication(item) || !item.decision.publication) return null;
+  const decision = exactReviewDecisionFrom({
+    ...item.decision.publication.producerDecision,
+    sourceAction:
+      item.decision.publication.producerDecision.sourceAction ===
+      FAILED_REVIEW_SHARD_RECOVERY_SOURCE_ACTION
+        ? FAILED_REVIEW_SHARD_RECOVERY_SOURCE_ACTION
+        : EXACT_REVIEW_ARTIFACT_RETENTION_RECOVERY_SOURCE_ACTION,
+    supersedesInProgress: true,
+  });
+  return decision ? { decision, key: exactReviewItemKey(decision) } : null;
+}
+
 function exactReviewPublicationCandidates(
   value,
 ): Array<{ itemKey: string; revision: number }> | null {
@@ -3393,7 +3570,7 @@ function exactReviewMetricDelta(value: unknown) {
   return Number.isSafeInteger(delta) && delta > 0 ? delta : 0;
 }
 
-function exactReviewQueueIsPublication(item: ExactReviewQueueItem) {
+function exactReviewQueueIsPublication(item: Pick<ExactReviewQueueItem, "decision">) {
   return item.decision.sourceAction === EXACT_REVIEW_ARTIFACT_PUBLISH_SOURCE_ACTION;
 }
 

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -512,6 +512,11 @@ export default {
       return authenticatedExactReviewQueueRequest(request, env, "/dead-letters/list");
     if (url.pathname === "/internal/exact-review/dead-letters/replay" && request.method === "POST")
       return authenticatedExactReviewQueueRequest(request, env, "/dead-letters/replay");
+    if (
+      url.pathname === "/internal/exact-review/dead-letters/recover-fresh" &&
+      request.method === "POST"
+    )
+      return authenticatedExactReviewQueueRequest(request, env, "/dead-letters/recover-fresh");
     if (url.pathname === "/internal/exact-review/dead-letters/resolve" && request.method === "POST")
       return authenticatedExactReviewQueueRequest(request, env, "/dead-letters/resolve");
     if (url.pathname === "/internal/exact-review/publications/list" && request.method === "POST")

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -505,6 +505,47 @@ test("signed claimed-run snapshot feeds tuple-safe terminal reconciliation", asy
   });
 });
 
+test("fresh dead-letter recovery is available only through the signed internal route", async () => {
+  const queue = new ExactReviewQueue({ storage: new MemoryDurableStorage() }, {});
+  const env = {
+    CLAWSWEEPER_WEBHOOK_SECRET: "test-token-placeholder",
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+  };
+  const body = JSON.stringify({ ids: ["missing-dead-letter"], idempotency_key: "operator:test" });
+  const unsigned = await worker.fetch(
+    new Request(
+      "https://clawsweeper.openclaw.ai/internal/exact-review/dead-letters/recover-fresh",
+      {
+        method: "POST",
+        body,
+      },
+    ),
+    env,
+  );
+  assert.equal(unsigned.status, 401);
+
+  const signature = `sha256=${createHmac("sha256", "test-token-placeholder").update(body).digest("hex")}`;
+  const signed = await worker.fetch(
+    new Request(
+      "https://clawsweeper.openclaw.ai/internal/exact-review/dead-letters/recover-fresh",
+      {
+        method: "POST",
+        headers: { "x-clawsweeper-exact-review-signature": signature },
+        body,
+      },
+    ),
+    env,
+  );
+  assert.equal(signed.status, 200);
+  assert.deepEqual(await signed.json(), {
+    ok: true,
+    recovered: 0,
+    deduped: 0,
+    skipped: 1,
+    unparked: 0,
+  });
+});
+
 test("exact-review queue counts only work that successfully leaves each lane", async () => {
   const storage = new MemoryDurableStorage();
   const directPublication = leasedExactReviewQueueItem(703, "7030");
@@ -4659,6 +4700,263 @@ test("exact-review publication dead-letters exhausted permanent failures and rep
   };
   assert.equal(state.items[item.key].state, "pending");
   assert.equal(state.items[item.key].attempts, 0);
+});
+
+test("exact-review dead letters expose diagnostics and recover fresh reviews in bounded batches", async () => {
+  const storage = new MemoryDurableStorage();
+  const item = leasedExactReviewPublicationItem(792, "7920");
+  item.attempts = 2;
+  Object.assign(item, { publicationFailureAttempts: 2 });
+  item.firstFailureAt = Date.now() - 6 * 60_000;
+  await storage.put("exact-review-queue", { deliveries: {}, items: { [item.key]: item } });
+  const queue = new ExactReviewQueue({ storage }, {});
+
+  const complete = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: item.leaseId,
+        item_key: item.key,
+        lease_revision: item.leaseRevision,
+        claim_generation: item.claimGeneration,
+        run_id: item.claimedRunId,
+        run_attempt: item.claimedRunAttempt,
+        outcome: "failure",
+        completion_kind: "permanent_failure",
+        reason_code: "invalid_artifact",
+        error_fingerprint: "sha256:fresh-recovery",
+      }),
+    }),
+  );
+  assert.deepEqual(await complete.json(), { ok: true, requeued: false });
+
+  const listed = await (
+    await queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/dead-letters/list", {
+        method: "POST",
+        body: JSON.stringify({ limit: 10 }),
+      }),
+    )
+  ).json();
+  const row = listed.dead_letters[0];
+  assert.equal(row.item.key, item.key);
+  assert.deepEqual(row.diagnostic.reason_code, "invalid_artifact");
+  assert.equal(row.diagnostic.attempts, 3);
+  assert.equal(row.diagnostic.error_fingerprint, "sha256:fresh-recovery");
+  assert.equal(typeof row.diagnostic.first_failed_at, "string");
+  assert.equal(typeof row.diagnostic.last_failed_at, "string");
+  assert.deepEqual(row.fresh_recovery, {
+    mode: "fresh_review_only",
+    eligible: true,
+    reason: "eligible",
+    item_key: "openclaw/openclaw#792",
+  });
+
+  const tooMany = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/dead-letters/recover-fresh", {
+      method: "POST",
+      body: JSON.stringify({
+        ids: Array.from({ length: 11 }, (_, index) => `dead-letter-${index}`),
+        idempotency_key: "operator:792:too-many",
+      }),
+    }),
+  );
+  assert.equal(tooMany.status, 400);
+  assert.deepEqual(await tooMany.json(), { error: "invalid_dead_letter_ids" });
+
+  const recover = () =>
+    queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/dead-letters/recover-fresh", {
+        method: "POST",
+        body: JSON.stringify({ ids: [row.dead_letter_id], idempotency_key: "operator:792:v1" }),
+      }),
+    );
+  assert.deepEqual(await (await recover()).json(), {
+    ok: true,
+    recovered: 1,
+    deduped: 0,
+    skipped: 0,
+    unparked: 0,
+  });
+  assert.deepEqual(await (await recover()).json(), {
+    ok: true,
+    recovered: 0,
+    deduped: 1,
+    skipped: 0,
+    unparked: 0,
+  });
+
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { attempts: number; state: string; decision: { sourceAction: string } }>;
+  };
+  assert.equal(state.items[item.key], undefined);
+  assert.equal(state.items["openclaw/openclaw#792"].state, "pending");
+  assert.equal(state.items["openclaw/openclaw#792"].attempts, 0);
+  assert.equal(
+    state.items["openclaw/openclaw#792"].decision.sourceAction,
+    "artifact_retention_recovery",
+  );
+  assert.equal(Object.hasOwn(state.items["openclaw/openclaw#792"].decision, "publication"), false);
+  const stats = await (
+    await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(stats.lanes.review.enqueued_total, 1);
+  assert.equal(stats.lanes.review.flow.last_15_minutes.arrival, 1);
+
+  const resolved = await (
+    await queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/dead-letters/list", {
+        method: "POST",
+        body: JSON.stringify({ limit: 10, status: "all" }),
+      }),
+    )
+  ).json();
+  assert.equal(resolved.dead_letters[0].status, "resolved");
+  assert.equal(resolved.dead_letters[0].resolution_note, "recovered_fresh");
+  assert.equal(resolved.dead_letters[0].replay_key, "operator:792:v1");
+  assert.equal(resolved.dead_letters[0].fresh_recovery.reason, "fresh_review_already_active");
+});
+
+test("exact-review fresh recovery preserves failed-shard review-only behavior", async () => {
+  const storage = new MemoryDurableStorage();
+  const item = leasedExactReviewPublicationItem(794, "7940");
+  item.attempts = 2;
+  Object.assign(item, { publicationFailureAttempts: 2 });
+  item.decision.publication.producerDecision.sourceAction = "failed_review_shard_recovery";
+  item.leaseDecision.publication.producerDecision.sourceAction = "failed_review_shard_recovery";
+  await storage.put("exact-review-queue", { deliveries: {}, items: { [item.key]: item } });
+  const queue = new ExactReviewQueue({ storage }, {});
+
+  const complete = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: item.leaseId,
+        item_key: item.key,
+        lease_revision: item.leaseRevision,
+        claim_generation: item.claimGeneration,
+        run_id: item.claimedRunId,
+        run_attempt: item.claimedRunAttempt,
+        outcome: "failure",
+        completion_kind: "permanent_failure",
+        reason_code: "invalid_artifact",
+      }),
+    }),
+  );
+  assert.deepEqual(await complete.json(), { ok: true, requeued: false });
+  const listed = await (
+    await queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/dead-letters/list", {
+        method: "POST",
+        body: JSON.stringify({ limit: 10 }),
+      }),
+    )
+  ).json();
+
+  const recover = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/dead-letters/recover-fresh", {
+      method: "POST",
+      body: JSON.stringify({
+        ids: [listed.dead_letters[0].dead_letter_id],
+        idempotency_key: "operator:794:v1",
+      }),
+    }),
+  );
+  assert.deepEqual(await recover.json(), {
+    ok: true,
+    recovered: 1,
+    deduped: 0,
+    skipped: 0,
+    unparked: 0,
+  });
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { decision: { sourceAction: string } }>;
+  };
+  assert.equal(
+    state.items["openclaw/openclaw#794"].decision.sourceAction,
+    "failed_review_shard_recovery",
+  );
+});
+
+test("exact-review fresh recovery leaves an active review item untouched", async () => {
+  const storage = new MemoryDurableStorage();
+  const item = leasedExactReviewPublicationItem(793, "7930");
+  item.attempts = 2;
+  Object.assign(item, { publicationFailureAttempts: 2 });
+  await storage.put("exact-review-queue", { deliveries: {}, items: { [item.key]: item } });
+  const queue = new ExactReviewQueue({ storage }, {});
+
+  const complete = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: item.leaseId,
+        item_key: item.key,
+        lease_revision: item.leaseRevision,
+        claim_generation: item.claimGeneration,
+        run_id: item.claimedRunId,
+        run_attempt: item.claimedRunAttempt,
+        outcome: "failure",
+        completion_kind: "permanent_failure",
+        reason_code: "invalid_artifact",
+      }),
+    }),
+  );
+  assert.deepEqual(await complete.json(), { ok: true, requeued: false });
+  const listed = await (
+    await queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/dead-letters/list", {
+        method: "POST",
+        body: JSON.stringify({ limit: 10 }),
+      }),
+    )
+  ).json();
+  const id = listed.dead_letters[0].dead_letter_id;
+
+  const enqueue = await queue.fetch(
+    buildExactReviewQueueRequest(
+      "fresh-recovery-guard",
+      793,
+      "opened",
+      "issue",
+      "openclaw/openclaw",
+    ),
+  );
+  assert.equal(enqueue.status, 202);
+  const before = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { state: string; attempts: number; decision: { sourceAction: string } }>;
+  };
+  const active = before.items["openclaw/openclaw#793"];
+  assert.equal(active.state, "pending");
+  assert.equal(active.decision.sourceAction, "opened");
+
+  const recover = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/dead-letters/recover-fresh", {
+      method: "POST",
+      body: JSON.stringify({ ids: [id], idempotency_key: "operator:793:v1" }),
+    }),
+  );
+  assert.deepEqual(await recover.json(), {
+    ok: true,
+    recovered: 0,
+    deduped: 0,
+    skipped: 1,
+    unparked: 0,
+  });
+
+  const after = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { state: string; attempts: number; decision: { sourceAction: string } }>;
+  };
+  assert.deepEqual(after.items["openclaw/openclaw#793"], active);
+  const guarded = await (
+    await queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/dead-letters/list", {
+        method: "POST",
+        body: JSON.stringify({ limit: 10 }),
+      }),
+    )
+  ).json();
+  assert.equal(guarded.dead_letters[0].fresh_recovery.reason, "fresh_review_already_active");
 });
 
 test("exact-review publication refreshes an artifact after its third unavailable attempt", async () => {


### PR DESCRIPTION
## Summary

Adds a guarded, operator-invoked fresh-recovery path for exact-review publication dead letters. It is intentionally separate from existing replay: it never reuses the old immutable publisher artifact.

Fixes #635

Related: #650 (future close-coverage handoff) and #641 (publication-backlog controls).

## Problem

The incident left publication dead letters whose stored publisher artifacts must not be replayed blindly. The existing replay operation re-admits that immutable publisher item; it cannot safely reconstruct a current review or prove that an already-active item will remain untouched. Operators also lacked per-row recovery eligibility and concise failure diagnostics.

## Implementation

- Adds the signed internal endpoint `POST /internal/exact-review/dead-letters/recover-fresh`.
- Limits one request to 10 unique dead-letter IDs and requires an idempotency key.
- Validates stored dead-letter JSON and accepts only exact publication rows for enabled targets.
- Skips a row when either its publisher item or its derived ordinary-review item is already present, including pending, dispatching, leased, or parked work.
- Reconstructs one ordinary pending review from the producer decision, without publication metadata or artifact reuse; preserves `failed_review_shard_recovery` so the workflow remains review-only.
- Resolves recovered rows, releases parked publishers made eligible by the freed DLQ capacity, and keeps enqueue telemetry single-counted.
- Extends dead-letter listing with bounded, structured failure diagnostics and explicit fresh-recovery eligibility/reason fields.

## Rollout and safety

This PR does not recover, replay, modify, or delete any live dead letter automatically. A maintainer must first inspect the diagnostic list and then submit a signed, bounded batch. Repeating the same successful request with the same key is a no-op.

The new control-plane route uses the existing HMAC-authenticated forwarding wrapper; no workflow permissions or GitHub write scope changes are introduced.

Landing order: land #650 first to prevent new close-proof publisher poison, then land this recovery control. #651 does not replay artifacts or mutate the existing DLQ backlog by itself.

## Validation

- `pnpm run build:dashboard`
- `node --test --test-name-pattern "signed internal route|dead-letters exhausted|dead letters expose diagnostics|preserves failed-shard|fresh recovery leaves" test/dashboard-worker.test.ts` — 5/5 passed.
- `node --test test/dashboard-worker.test.ts` — 140/140 passed.
- `git diff --check origin/main...HEAD`
- `pnpm exec oxfmt --check dashboard/exact-review-queue.ts dashboard/worker.ts test/dashboard-worker.test.ts`
- `codex review --uncommitted` — initial review found four real gaps (routing, review-only preservation, parked DLQ draining, and telemetry); all were fixed. Final review was clean.
- `codex review --base origin/main` — clean.
- Read-only local ClawSweeper range review of `ea22ada84d..3115ea9ed0` — complete, no findings; `keep_open`, medium confidence.

`pnpm run check` completed active-surface checks, all builds, and linting, but its broad unit stage remains blocked on this Windows host by pre-existing `/bin/bash`-missing WSL, symlink, and `npm.cmd` runtime failures. The changed dashboard surface is fully covered by the passing 140-test dashboard-worker suite above.

## Controlled Linux runtime proof

On 2026-07-17, a clean Docker-backed Crabbox local container (`mcr.microsoft.com/playwright:v1.60.0-noble`, Node `v24.15.0`, pnpm `11.10.0`) installed with `pnpm install --frozen-lockfile`, built the dashboard, and ran the actual queue/worker boundary tests. Lease `cbx_160c66555f67` completed with exit code 0:

- signed recovery route rejects unauthenticated access;
- an eligible dead letter exposes diagnostics, recovers one fresh ordinary review in a bounded batch, and a repeat idempotency key is a no-op;
- failed-shard recovery stays review-only; and
- an active ordinary item prevents recovery from touching it.

The focused command was:

```text
node --test --test-name-pattern 'fresh dead-letter recovery is available only through the signed internal route|exact-review dead letters expose diagnostics and recover fresh reviews in bounded batches|exact-review fresh recovery preserves failed-shard review-only behavior|exact-review fresh recovery leaves an active review item untouched' test/dashboard-worker.test.ts
```

Result: 4 passed, 0 failed. This is controlled Linux runtime evidence, not a live GitHub write or a claim that the current DLQ was automatically changed.

## Persistent Durable Object runtime proof

On 2026-07-17, a second clean Docker-backed Crabbox run (`cbx_c6ca4e1dbdf8`, `mcr.microsoft.com/playwright:v1.60.0-noble`) started the real `dashboard/worker.ts` with `wrangler@4.107.0 dev --local --persist-to`. The actual `ExactReviewQueue` Durable Object initialised its SQLite store (`storage_schema_version: 1`).

To keep the proof isolated and avoid any GitHub or Cloudflare mutation, two redacted synthetic DLQ fixtures were inserted into that generated local DO SQLite store while the Worker was stopped: one eligible publication record and one record whose reconstructed ordinary review was already leased. No production data, token, or target GitHub item was used.

After restarting the Worker, the proof exercised the signed public control-plane endpoints, not an in-memory class:

- `dead-letters/list` reported `invalid_artifact`, three attempts, and an eligible fresh recovery for the first record, while the second reported `fresh_review_already_active`;
- signed `recover-fresh` returned `recovered: 1`, `deduped: 0`, `skipped: 0`; and
- the Worker was stopped and restarted against the same persisted directory.

After the restart, the durable state was still `resolved / recovered_fresh` with its replay key. The identical request returned `deduped: 1`; recovery of the active-item fixture returned `skipped: 1`; and `/api/exact-review-queue/item` showed exactly one ordinary pending review with zero attempts.

This proves persistence across an actual Worker restart, the signed wrapper, bounded fresh recovery, repeat-key idempotency, and the active-item guard. It remains deliberately an isolated local deployment: it does not claim a live Cloudflare deployment or mutate the live DLQ.

## Risks

This is an internal, signed queue recovery path that can re-admit a current review only after explicit operator selection. The bounded batch size, active-item guards, durable idempotency, and separate non-replay path keep the operational blast radius contained.
