### PR TITLE
Fix automerge terminal telemetry convergence

### DIFF
--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -22,6 +22,8 @@ jobs:
       CLAWSWEEPER_STATUS_INGEST_URL: https://clawsweeper.openclaw.ai/api/events
       CLAWSWEEPER_STATUS_INGEST_TOKEN: ${{ secrets.CLAWSWEEPER_STATUS_INGEST_TOKEN }}
       CLAWSWEEPER_STATUS_CI_LIMIT: "30"
+      CLAWSWEEPER_AUTOMERGE_RECONCILE_LIMIT: "8"
+      CLAWSWEEPER_AUTOMERGE_RECONCILE_TIMEOUT_MS: "15000"
       GITHUB_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v7
@@ -32,3 +34,7 @@ jobs:
 
       - name: Refresh PR CI telemetry
         run: node scripts/dashboard-refresh-ci.mjs
+
+      - name: Reconcile automerge terminal telemetry
+        continue-on-error: true
+        run: node scripts/dashboard-reconcile-automerge.ts

--- a/dashboard/automerge-metrics.ts
+++ b/dashboard/automerge-metrics.ts
@@ -115,6 +115,8 @@ export function summarizeAutomergeMetrics(
     repo?: string | null;
     policyVersion?: string | null;
     now?: string;
+    activeOnly?: boolean;
+    sessionLimit?: number;
   } = {},
 ) {
   const range = isRange(options.range) ? options.range : "7d";
@@ -174,13 +176,22 @@ export function summarizeAutomergeMetrics(
     const lastEventAt = Date.parse(session.last_event_at);
     return !session.terminal_at && lastEventAt >= rangeStart && lastEventAt <= nowMs;
   });
-  const recentSessions = sessions
-    .filter((session) => Date.parse(session.terminal_at ?? session.last_event_at) >= rangeStart)
-    .sort(
-      (a, b) =>
-        Date.parse(b.terminal_at ?? b.last_event_at) - Date.parse(a.terminal_at ?? a.last_event_at),
-    )
-    .slice(0, 30);
+  const sessionLimit = boundedSessionLimit(options.sessionLimit);
+  const recentSessions = (
+    options.activeOnly
+      ? active
+      : sessions.filter(
+          (session) => Date.parse(session.terminal_at ?? session.last_event_at) >= rangeStart,
+        )
+  )
+    .sort((a, b) => {
+      const left = Date.parse(a.terminal_at ?? a.last_event_at);
+      const right = Date.parse(b.terminal_at ?? b.last_event_at);
+      // Reconciliation requests oldest active sessions first so a noisy repository
+      // cannot indefinitely starve an earlier lost terminal delivery.
+      return options.activeOnly ? left - right : right - left;
+    })
+    .slice(0, sessionLimit);
   const filtersActive = Boolean(options.repo || options.policyVersion);
   const telemetrySince = filtersActive
     ? (filtered[0]?.occurred_at ?? null)
@@ -293,4 +304,9 @@ function nullableText(value: unknown) {
 
 function isRange(value: unknown): value is AutomergeMetricRange {
   return value === "6h" || value === "24h" || value === "7d";
+}
+
+function boundedSessionLimit(value: unknown) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? Math.min(parsed, 30) : 30;
 }

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -888,6 +888,8 @@ async function automergeMetricsJson(request, env) {
       range: url.searchParams.get("range") ?? "7d",
       repo: url.searchParams.get("repo"),
       policyVersion: url.searchParams.get("policy_version"),
+      activeOnly: url.searchParams.get("active_only") === "true",
+      sessionLimit: Number(url.searchParams.get("session_limit")),
     }),
   );
 }
@@ -9293,10 +9295,13 @@ function renderAutomergeProduct(data) {
   setOptions("automerge-repo", data.filters?.repositories, data.filters?.repo);
   setOptions("automerge-policy", data.filters?.policy_versions, data.filters?.policy_version);
   const sinceText = data.telemetry_since ? new Date(data.telemetry_since).toLocaleString() : "not started";
-  document.getElementById("automerge-meta").textContent = "Telemetry since " + sinceText + " · Coverage " + fmt.format(data.coverage_percent || 0) + "% · terminal sample n=" + fmt.format(summary.terminal_sessions || 0) + " · Updated " + since(data.generated_at);
+  const terminalSamples = Number(summary.terminal_sessions) || 0;
+  document.getElementById("automerge-meta").textContent = "Telemetry since " + sinceText + " · Time-window coverage " + fmt.format(data.coverage_percent || 0) + "% · Active sessions " + fmt.format(summary.active_sessions || 0) + " · terminal sample n=" + fmt.format(terminalSamples) + " · Updated " + since(data.generated_at);
   const value = (number, suffix) => number == null ? "—" : fmt.format(number) + (suffix || "");
   const duration = number => number == null ? "—" : elapsed(number);
-  const kpis = '<div class="automerge-kpis">' +
+  const kpis = terminalSamples < 1
+    ? '<div class="empty">No terminal samples yet. Active sessions remain outside the success-rate denominator.</div>'
+    : '<div class="automerge-kpis">' +
     '<div class="automerge-kpi"><span>Merge success rate</span><strong>' + value(summary.merge_success_rate_percent, "%") + '</strong><small>merged ' + fmt.format(summary.merged_sessions || 0) + ' / terminal ' + fmt.format(summary.terminal_sessions || 0) + '</small></div>' +
     '<div class="automerge-kpi"><span>Command → Merge p50</span><strong>' + duration(summary.command_to_merge_p50_ms) + '</strong><small>successful sessions only</small></div>' +
     '<div class="automerge-kpi"><span>Command → Merge p90</span><strong>' + duration(summary.command_to_merge_p90_ms) + '</strong><small>nearest-rank percentile</small></div>' +

--- a/scripts/dashboard-reconcile-automerge.ts
+++ b/scripts/dashboard-reconcile-automerge.ts
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const DEFAULT_LIMIT = 8;
+const MAX_LIMIT = 20;
+const DEFAULT_TIMEOUT_MS = 15_000;
+const MAX_TIMEOUT_MS = 30_000;
+const LOOKBACK_MS = 24 * 60 * 60 * 1000;
+
+type ActiveSession = {
+  session_id: string;
+  repository: string;
+  item_number: number;
+  policy_version?: string | null;
+  pr_url?: string | null;
+  run_url?: string | null;
+  last_event_at: string;
+  terminal_at?: string | null;
+};
+
+type ReconcileOptions = {
+  env?: NodeJS.ProcessEnv;
+  fetcher?: typeof fetch;
+  now?: string;
+};
+
+export async function reconcileAutomergeProductMetrics({
+  env = process.env,
+  fetcher = fetch,
+  now = new Date().toISOString(),
+}: ReconcileOptions = {}) {
+  const ingestToken = String(env.CLAWSWEEPER_STATUS_INGEST_TOKEN ?? "").trim();
+  if (!ingestToken) return { ok: true, skipped: "ingest_token_missing", candidates: 0 };
+
+  const statusUrl = trimTrailingSlash(
+    env.CLAWSWEEPER_STATUS_URL || "https://clawsweeper.openclaw.ai",
+  );
+  const ingestUrl = env.CLAWSWEEPER_STATUS_INGEST_URL || `${statusUrl}/api/events`;
+  const githubToken = env.GITHUB_TOKEN || env.GH_TOKEN || "";
+  const limit = boundedInt(env.CLAWSWEEPER_AUTOMERGE_RECONCILE_LIMIT, DEFAULT_LIMIT, MAX_LIMIT);
+  const timeoutMs = boundedInt(
+    env.CLAWSWEEPER_AUTOMERGE_RECONCILE_TIMEOUT_MS,
+    DEFAULT_TIMEOUT_MS,
+    MAX_TIMEOUT_MS,
+  );
+  const nowMs = Date.parse(now);
+  const deadline = AbortSignal.timeout(timeoutMs);
+
+  try {
+    const metricsUrl = new URL("/api/automerge-metrics", `${statusUrl}/`);
+    metricsUrl.searchParams.set("range", "24h");
+    metricsUrl.searchParams.set("active_only", "true");
+    metricsUrl.searchParams.set("session_limit", String(limit));
+    const metrics = await fetchJson(metricsUrl, fetcher, deadline);
+    const candidates = activeSessions(metrics, nowMs).slice(0, limit);
+
+    // Durable active sessions already form the retry queue. Re-reading authoritative
+    // PR state closes both past and future delivery gaps without a second outbox.
+    const results = await Promise.all(
+      candidates.map((session) =>
+        reconcileSession({
+          session,
+          ingestUrl,
+          ingestToken,
+          githubToken,
+          fetcher,
+          signal: deadline,
+        }),
+      ),
+    );
+    return {
+      ok: true,
+      candidates: candidates.length,
+      github_reads: results.filter((result) => result.githubRead).length,
+      terminal: results.filter((result) => result.terminal).length,
+      delivered: results.filter((result) => result.delivered).length,
+      failed: results.filter((result) => result.error).length,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      candidates: 0,
+      error: errorMessage(error),
+    };
+  }
+}
+
+async function reconcileSession({
+  session,
+  ingestUrl,
+  ingestToken,
+  githubToken,
+  fetcher,
+  signal,
+}: {
+  session: ActiveSession;
+  ingestUrl: string;
+  ingestToken: string;
+  githubToken: string;
+  fetcher: typeof fetch;
+  signal: AbortSignal;
+}) {
+  try {
+    const pr = await fetchJson(
+      new URL(
+        `/repos/${encodeURIComponent(session.repository.split("/")[0]!)}/${encodeURIComponent(
+          session.repository.split("/")[1]!,
+        )}/pulls/${session.item_number}`,
+        "https://api.github.com",
+      ),
+      fetcher,
+      signal,
+      {
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "openclaw-clawsweeper-automerge-reconciler",
+        ...(githubToken ? { Authorization: `Bearer ${githubToken}` } : {}),
+      },
+    );
+    const terminal = authoritativeTerminal(pr);
+    if (!terminal) return { githubRead: true, terminal: false, delivered: false };
+    const event = terminalEvent(session, terminal);
+    const response = await fetcher(ingestUrl, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${ingestToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(event),
+      signal,
+    });
+    return {
+      githubRead: true,
+      terminal: true,
+      delivered: response.ok,
+      error: response.ok ? null : `ingest returned ${response.status}`,
+    };
+  } catch (error) {
+    return {
+      githubRead: true,
+      terminal: false,
+      delivered: false,
+      error: errorMessage(error),
+    };
+  }
+}
+
+function activeSessions(value: unknown, nowMs: number): ActiveSession[] {
+  if (!value || typeof value !== "object") return [];
+  const sessions = Array.isArray((value as { sessions?: unknown }).sessions)
+    ? (value as { sessions: unknown[] }).sessions
+    : [];
+  return sessions.filter((value): value is ActiveSession => {
+    if (!value || typeof value !== "object") return false;
+    const session = value as Partial<ActiveSession>;
+    const lastEventAt = Date.parse(String(session.last_event_at ?? ""));
+    return (
+      !session.terminal_at &&
+      typeof session.session_id === "string" &&
+      /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(String(session.repository ?? "")) &&
+      Number.isInteger(session.item_number) &&
+      Number(session.item_number) > 0 &&
+      Number.isFinite(lastEventAt) &&
+      lastEventAt >= nowMs - LOOKBACK_MS &&
+      lastEventAt <= nowMs
+    );
+  });
+}
+
+function authoritativeTerminal(value: unknown) {
+  if (!value || typeof value !== "object") return null;
+  const pr = value as { merged_at?: unknown; closed_at?: unknown; state?: unknown };
+  const mergedAt = isoTimestamp(pr.merged_at);
+  if (mergedAt) return { outcome: "merged", occurredAt: mergedAt } as const;
+  const closedAt = isoTimestamp(pr.closed_at);
+  if (String(pr.state ?? "").toLowerCase() === "closed" && closedAt) {
+    return { outcome: "pr_closed", occurredAt: closedAt } as const;
+  }
+  return null;
+}
+
+function terminalEvent(
+  session: ActiveSession,
+  terminal: { outcome: "merged" | "pr_closed"; occurredAt: string },
+) {
+  return {
+    event_type: "clawsweeper.automerge_metric",
+    event_id: `${session.session_id}:terminal:github-pr:${terminal.outcome}:${terminal.occurredAt}`,
+    session_id: session.session_id,
+    phase: "terminal",
+    occurred_at: terminal.occurredAt,
+    repository: session.repository,
+    item_number: session.item_number,
+    policy_version: session.policy_version || "immediate-v1",
+    state: null,
+    outcome: terminal.outcome,
+    reason: `reconciled from authoritative GitHub PR ${terminal.outcome === "merged" ? "merged_at" : "closed_at"}`,
+    pr_url:
+      session.pr_url || `https://github.com/${session.repository}/pull/${session.item_number}`,
+    run_url: session.run_url || null,
+  };
+}
+
+async function fetchJson(
+  url: URL,
+  fetcher: typeof fetch,
+  signal: AbortSignal,
+  headers: HeadersInit = {},
+) {
+  const response = await fetcher(url, { headers, signal });
+  if (!response.ok) throw new Error(`${url} returned ${response.status}`);
+  return response.json() as Promise<unknown>;
+}
+
+function isoTimestamp(value: unknown) {
+  const timestamp = Date.parse(String(value ?? ""));
+  return Number.isFinite(timestamp) ? new Date(timestamp).toISOString() : null;
+}
+
+function boundedInt(value: unknown, fallback: number, maximum: number) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? Math.min(parsed, maximum) : fallback;
+}
+
+function trimTrailingSlash(value: string) {
+  return String(value).replace(/\/+$/, "");
+}
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : "";
+if (invokedPath === import.meta.url) {
+  const result = await reconcileAutomergeProductMetrics();
+  console.log(JSON.stringify(result, null, 2));
+}

--- a/test/automerge-metrics.test.ts
+++ b/test/automerge-metrics.test.ts
@@ -11,6 +11,7 @@ import {
   latestAutomergeActivationForCommand,
   postAutomergeMetricBestEffort,
 } from "../src/repair/automerge-product-telemetry.ts";
+import { reconcileAutomergeProductMetrics } from "../scripts/dashboard-reconcile-automerge.ts";
 
 const now = "2026-07-17T12:00:00.000Z";
 
@@ -267,4 +268,112 @@ test("best-effort ingest has a bounded deadline even when fetch never settles", 
   );
   assert.equal(delivered, false);
   assert.ok(Date.now() - startedAt < 500);
+});
+
+test("reconciliation retries a lost terminal delivery with a stable merged event", async () => {
+  const posted = [];
+  let ingestAttempts = 0;
+  const fetcher = async (input, init) => {
+    const url = String(input);
+    if (url.includes("/api/automerge-metrics")) {
+      return Response.json({
+        sessions: [
+          {
+            session_id: "openclaw/clawsweeper#648:5003787598:2026-07-17T13:30:27Z",
+            repository: "openclaw/clawsweeper",
+            item_number: 648,
+            policy_version: "immediate-v1",
+            last_event_at: "2026-07-17T13:30:27Z",
+            terminal_at: null,
+          },
+        ],
+      });
+    }
+    if (url.includes("api.github.com/repos/openclaw/clawsweeper/pulls/648")) {
+      return Response.json({
+        state: "closed",
+        closed_at: "2026-07-17T13:39:18Z",
+        merged_at: "2026-07-17T13:39:18Z",
+      });
+    }
+    if (url.endsWith("/api/events")) {
+      posted.push(JSON.parse(String(init?.body)));
+      ingestAttempts += 1;
+      return new Response("", { status: ingestAttempts === 1 ? 503 : 200 });
+    }
+    throw new Error(`unexpected request: ${url}`);
+  };
+  const options = {
+    env: {
+      CLAWSWEEPER_STATUS_URL: "https://status.example.test",
+      CLAWSWEEPER_STATUS_INGEST_TOKEN: "token",
+    },
+    fetcher,
+    now: "2026-07-17T14:00:00Z",
+  };
+
+  const first = await reconcileAutomergeProductMetrics(options);
+  const second = await reconcileAutomergeProductMetrics(options);
+
+  assert.equal(first.delivered, 0);
+  assert.equal(first.failed, 1);
+  assert.equal(second.delivered, 1);
+  assert.equal(posted.length, 2);
+  assert.equal(posted[0].event_id, posted[1].event_id);
+  assert.equal(posted[0].outcome, "merged");
+  assert.equal(posted[0].occurred_at, "2026-07-17T13:39:18.000Z");
+});
+
+test("reconciliation caps active-session and GitHub reads", async () => {
+  const githubReads = [];
+  let metricsUrl = "";
+  const sessions = Array.from({ length: 12 }, (_, index) => ({
+    session_id: `openclaw/openclaw#${index + 1}:100:2026-07-17T13:00:00Z`,
+    repository: "openclaw/openclaw",
+    item_number: index + 1,
+    last_event_at: "2026-07-17T13:00:00Z",
+    terminal_at: null,
+  }));
+  const result = await reconcileAutomergeProductMetrics({
+    env: {
+      CLAWSWEEPER_STATUS_URL: "https://status.example.test",
+      CLAWSWEEPER_STATUS_INGEST_TOKEN: "token",
+      CLAWSWEEPER_AUTOMERGE_RECONCILE_LIMIT: "3",
+      CLAWSWEEPER_AUTOMERGE_RECONCILE_TIMEOUT_MS: "1000",
+    },
+    now: "2026-07-17T14:00:00Z",
+    fetcher: async (input) => {
+      const url = String(input);
+      if (url.includes("/api/automerge-metrics")) {
+        metricsUrl = url;
+        return Response.json({ sessions });
+      }
+      githubReads.push(url);
+      return Response.json({ state: "open", merged_at: null, closed_at: null });
+    },
+  });
+
+  assert.equal(result.candidates, 3);
+  assert.equal(result.github_reads, 3);
+  assert.equal(githubReads.length, 3);
+  assert.match(metricsUrl, /range=24h/);
+  assert.match(metricsUrl, /active_only=true/);
+  assert.match(metricsUrl, /session_limit=3/);
+});
+
+test("active-only metric sessions are bounded and oldest first", () => {
+  const data = summarizeAutomergeMetrics(
+    ledger([
+      event("active-1", "activated", "2026-07-17T08:00:00Z"),
+      event("active-2", "activated", "2026-07-17T09:00:00Z"),
+      event("active-3", "activated", "2026-07-17T10:00:00Z"),
+      event("terminal", "terminal", "2026-07-17T11:00:00Z", { outcome: "merged" }),
+    ]),
+    { range: "24h", now, activeOnly: true, sessionLimit: 2 },
+  );
+
+  assert.deepEqual(
+    data.sessions.map((session) => session.session_id),
+    ["active-1", "active-2"],
+  );
 });

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -6075,6 +6075,9 @@ test("dashboard HTML preserves UTF-8 emoji labels", async () => {
   assert.doesNotMatch(html, /id="automerge-reliability"/);
   assert.match(html, /Automerge worker operations/);
   assert.match(html, /separate from Automerge Product Health success rate/);
+  assert.match(html, /Time-window coverage/);
+  assert.match(html, /Active sessions/);
+  assert.match(html, /No terminal samples yet/);
   assert.match(html, /Closed by ClawSweeper/);
   assert.match(html, /Worker Health/);
   assert.match(html, /Recent Activity/);


### PR DESCRIPTION
## Root cause evidence

- https://github.com/openclaw/clawsweeper/pull/648 merged at `2026-07-17T13:39:18Z` through https://github.com/openclaw/clawsweeper/actions/runs/29584167178.
- That run's report and immutable command action ledger record the `merge` mutation and terminal command completion. The same router batch contained the original automerge activation, so the `terminal: merged` event generation conditions were satisfied.
- The run had the status ingest token configured, but the production metrics API retained only the activation for that session. The durable receiver accepts, atomically stores, deduplicates, and aggregates terminal events, so the missing boundary is the unacknowledged best-effort delivery path rather than automerge control behavior or aggregation.

## What changed

- Add a separate five-minute Product Health reconciliation step to the existing dashboard telemetry workflow.
- Read only durable active sessions from the last 24 hours, oldest first, with an eight-session default and hard maximum of 20.
- Perform at most one authoritative GitHub PR read per candidate under a shared 15-second deadline (hard maximum 30 seconds).
- Emit a stable, retry-safe terminal event. `merged_at` always takes precedence over generic `closed_at`, and the existing first-terminal immutable projection remains unchanged.
- Keep reconciliation best-effort and `continue-on-error`, so GitHub, status API, or ingest failures cannot affect automerge.
- Rename dashboard coverage to `Time-window coverage`, show active-session count explicitly, and render `No terminal samples yet` instead of zero-like KPI cards when the denominator is empty.

## Why reconciliation instead of an outbox

The durable active-session ledger already identifies sessions whose terminal delivery did not converge. Rechecking bounded authoritative PR status repairs both the existing missing terminal for https://github.com/openclaw/clawsweeper/pull/648 and future transport/timeout/response-loss cases. A new outbox would protect only failures after deployment and would still require a second backfill mechanism for already-active merged sessions.

This does not perform broad history backfill: candidates must have activity within 24 hours, the API response and GitHub reads are count-bounded, and open PRs remain active.

## Validation

- `node --test test/automerge-metrics.test.ts` — 14 passed
- `pnpm run build:dashboard` — passed
- `node --test test/dashboard-worker.test.ts` — 136 passed
- `pnpm run check` — passed on Node `v24.15.0`
- `$AUTOREVIEW --mode local --stream-engine-output` — clean, no accepted/actionable findings; `patch is correct` (confidence 0.86)
