### PR TITLE
fix(validation): require install URL token boundaries

### DIFF
--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -915,8 +915,13 @@ function assertTrackedPatchDependency(
 }
 
 function assertApprovedInstallMetadataDestinations(text: string, registryOrigin: string) {
-  const networkTokens =
-    text.match(/(?:https?:\/\/|\/\/|git\+[^:\s]+:\/\/|ssh:\/\/)[^\s"'`<>{}\x5b\x5d,]+/gi) ?? [];
+  // Network destinations must start at a lexical token boundary. Opaque metadata tokens,
+  // especially SRI/Base64 values, may contain `//` as data without naming a destination.
+  const networkTokens = [
+    ...text.matchAll(
+      /(?:^|[\s"'`(<>{}\x5b\x5d,;=])((?:https?:\/\/|\/\/|git\+[^:\s]+:\/\/|ssh:\/\/)[^\s"'`<>{}\x5b\x5d,]+)/gim,
+    ),
+  ].map((match) => match[1]!);
   for (const token of networkTokens) {
     assertApprovedInstallUrl(token.replace(/[);]+$/, ""), registryOrigin);
   }

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -2299,10 +2299,84 @@ test("dependency setup permits external funding metadata in npm lockfiles", () =
   }
 });
 
-test("dependency setup keeps non-funding npm lockfile URLs fail-closed", () => {
-  for (const metadata of [
-    { resolved: "https://github.com/example/payload.tgz" },
-    { homepage: "https://github.com/example/payload" },
+test("dependency setup permits SRI slash pairs in npm lockfiles", () => {
+  const integrities = [
+    "sha512-/XaS//3lOPwYNFcWNBU0xy4WH6R3XUMmDoGxhdh5A8Bp1AklS4O1WYZdt2y5qxoPacZBqLNtjXdqtzisvPbcQQ==",
+    "sha512-FHpQMTN4e4scgfVeB7J3voHEMKhDfgVCevPBZCoCGS7SvZ+UV3VFfZ//rhK1oHyuHgFAaYhACLMxH53DQCoDew==",
+    "sha512-I5VRcZTnNXDepE747yhFbQ6247eEN/s1ulHquanowSx6PHjnFNyrmYxUjelyAIwT72hh//Eq4oGTmwuoLxAsWA==",
+  ];
+  for (const lockfile of ["package-lock.json", "npm-shrinkwrap.json"]) {
+    const cwd = gitPackageFixture({ check: 'node -e ""' });
+    fs.rmSync(path.join(cwd, "pnpm-lock.yaml"));
+    const packagePath = path.join(cwd, "package.json");
+    const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+    packageJson.packageManager = "npm@11.0.0";
+    fs.writeFileSync(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`);
+    fs.writeFileSync(
+      path.join(cwd, lockfile),
+      `${JSON.stringify(
+        {
+          name: "fixture",
+          lockfileVersion: 3,
+          packages: Object.fromEntries(
+            integrities.map((integrity, index) => [
+              `node_modules/sri-${index}`,
+              {
+                version: "1.0.0",
+                resolved: `https://registry.npmjs.org/sri-${index}/-/sri-${index}-1.0.0.tgz`,
+                integrity,
+              },
+            ]),
+          ),
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    git(cwd, "add", ".");
+    git(cwd, "commit", "-m", "initial");
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-npm-sri-bin-"));
+    const npmPath = path.join(binDir, "npm.js");
+    fs.writeFileSync(
+      npmPath,
+      'require("node:fs").mkdirSync("node_modules", { recursive: true });\n',
+    );
+
+    withMockCommand("npm", npmPath, () =>
+      prepareTargetToolchain(cwd, {
+        ...validationOptions("steipete/example", {
+          toolchain: {
+            packageManager: "npm",
+            baseValidationCommands: [],
+            changedGate: null,
+          },
+        }),
+        installTargetDeps: true,
+        installTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
+        setupTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
+      }),
+    );
+  }
+});
+
+test("dependency setup keeps npm lockfile URL tokens fail-closed", () => {
+  for (const { metadata, expected } of [
+    {
+      metadata: { resolved: "https://github.com/example/payload.tgz" },
+      expected: /destination is not approved: https:\/\/github\.com/,
+    },
+    {
+      metadata: { homepage: "https://github.com/example/payload" },
+      expected: /destination is not approved: https:\/\/github\.com/,
+    },
+    {
+      metadata: { resolved: "//evil.example/pkg.tgz" },
+      expected: /target dependency install/,
+    },
+    {
+      metadata: { integrity: "//evil.example/pkg.tgz" },
+      expected: /target dependency install/,
+    },
   ]) {
     const cwd = gitPackageFixture({ check: 'node -e ""' });
     fs.writeFileSync(
@@ -2329,7 +2403,7 @@ test("dependency setup keeps non-funding npm lockfile URLs fail-closed", () => {
           installTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
           setupTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
         }),
-      /destination is not approved: https:\/\/github\.com/,
+      expected,
     );
   }
 });


### PR DESCRIPTION
## Summary

- Require a real lexical token boundary before treating lockfile text as an HTTP(S), protocol-relative, git+, or SSH install destination.
- Allow valid SHA-512 SRI/Base64 tokens whose opaque payload contains internal `//`, including package-lock v3 and npm-shrinkwrap shapes.
- Keep the validator fail-closed without adding integrity, homepage, funding, URL-field, or origin allowlist exemptions.

## Failure evidence

- https://github.com/openclaw/clawsweeper/pull/647 fixed the earlier `packages.<pkg>.funding` display-metadata false positive, but that was one symptom layer.
- https://github.com/openclaw/clawsweeper/actions/runs/29584730255 then failed target dependency setup because `npm-shrinkwrap.json` contained a legal SHA-512 Base64 integrity payload with `//`; the unbounded regex misread that substring as a protocol-relative URL.
- The affected target workflow was operating on https://github.com/openclaw/openclaw/pull/104054. This PR does not modify that target branch or retrigger its automerge workflow.

## Fail-closed boundary

- Complete or real token forms such as `//evil.example/pkg.tgz` remain rejected.
- External HTTPS origins, git/SSH destinations, auth/proxy/certificate config, local escapes, and workspace/link/resolved/resolution/tarball checks remain rejected or validated by their existing paths.
- `github.com` is not approved as an install origin.

## Verification

- Node `v24.15.0`
- `pnpm run format`
- `pnpm run build`
- `pnpm run build:repair`
- `node --test --test-name-pattern="dependency setup (permits SRI slash pairs|keeps npm lockfile URL tokens)" test/repair/target-validation.test.ts`
- `pnpm run check`
- project autoreview: clean, no accepted/actionable findings
- staged-diff `gitleaks protect --staged --redact --no-banner`: no leaks found

## Follow-up direction

The durable design should move from generic recursive string scanning toward schema-aware lockfile destination adapters, paired with runtime egress enforcement for the install process. That larger architecture change is intentionally outside this recovery patch.
