### PR TITLE
Defer duplicate exact-head reviews

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -829,6 +829,14 @@ jobs:
           process.exit(1);
           NODE
 
+      # At-least-once queue delivery can overlap an exact-head review that is already
+      # running. The durable queue owns retry, so lease contention is deferred work.
+      - name: Defer exact review while same-head lease is held
+        if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.reserve-exact-review-lease.outputs.status == 'held' }}
+        env:
+          RETRY_AT: ${{ steps.reserve-exact-review-lease.outputs.retry_at }}
+        run: echo "::notice::Another exact-head review is already active; retry deferred until $RETRY_AT."
+
       - name: Review exact event item
         id: review-exact-event-item
         if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.live-item.outputs.proceed == 'true' && steps.reserve-exact-review-lease.outputs.status == 'posted' }}
@@ -1128,12 +1136,16 @@ jobs:
           STATUS_COMMENT_ID: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).statusCommentId || '' }}
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           REVIEW_OUTCOME: ${{ steps.review-exact-event-item.outcome }}
+          RESERVATION_STATUS: ${{ steps.reserve-exact-review-lease.outputs.status }}
           RETRY_AT: ${{ steps.reserve-exact-review-lease.outputs.retry_at || steps.review-exact-event-item.outputs.retry_at }}
           CLAWSWEEPER_ACTION_LEDGER_DISABLED: "1"
         run: |
           state="Failed"
           detail="The exact review did not produce a publishable artifact. The durable queue will retry it."
-          if [ "$REVIEW_OUTCOME" = "cancelled" ] || [ -n "$RETRY_AT" ]; then
+          if [ "$RESERVATION_STATUS" = "held" ]; then
+            state="Waiting"
+            detail="Another exact-head review is already active. The durable queue will retry after its lease expires."
+          elif [ "$REVIEW_OUTCOME" = "cancelled" ] || [ -n "$RETRY_AT" ]; then
             state="Interrupted"
             detail="The exact review was interrupted. The durable queue will retry it."
           fi
@@ -1233,7 +1245,20 @@ jobs:
           exit 1
 
       - name: Fail unsuccessful exact review generation
-        if: ${{ always() && steps.claim-exact-review-queue.outputs.claimed == 'true' && (steps.exact-review-generation-result.outputs.outcome != 'success' || steps.complete-exact-review-queue.outcome != 'success') }}
+        # A held review lease is a successful deferral only after the durable queue
+        # accepts retry ownership; queue completion failures must remain visible.
+        if: >-
+          ${{
+            always() &&
+            steps.claim-exact-review-queue.outputs.claimed == 'true' &&
+            (
+              steps.complete-exact-review-queue.outcome != 'success' ||
+              (
+                steps.exact-review-generation-result.outputs.outcome != 'success' &&
+                steps.reserve-exact-review-lease.outputs.status != 'held'
+              )
+            )
+          }}
         run: exit 1
 
   event-review-publish:

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -2411,6 +2411,15 @@ function repairDispatchLine(dispatched: LooseRecord, label: string): string {
 }
 
 function reviewDispatchLine(dispatched: LooseRecord, label: string, action: string): string {
+  if (dispatched.coordination_action === "wait_for_active_review") {
+    return `${label}: an exact-head review is already active; no duplicate review was queued.`;
+  }
+  if (dispatched.coordination_action === "reuse_completed_review") {
+    return `${label}: the existing exact-head review result is being reused.`;
+  }
+  if (dispatched.coordination_action === "retry") {
+    return `${label}: exact-head review dispatch deferred while the durable router retries.`;
+  }
   const runUrl = typeof dispatched.run_url === "string" ? dispatched.run_url : "";
   const workflow = String(dispatched.workflow ?? "").trim();
   const event = String(dispatched.event ?? "").trim();

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -146,6 +146,10 @@ import {
   runCommandMutation,
   runCommandMutationWithRetry,
 } from "./command-action-ledger.js";
+import {
+  decideReviewDispatchCoordination,
+  type ReviewDispatchCoordinationDecision,
+} from "./review-dispatch-coordination.js";
 
 const automergeMetricWrites: Promise<boolean>[] = [];
 
@@ -2015,15 +2019,16 @@ function executeCommand(command: LooseRecord) {
     ) {
       const modeLabel = command.intent === "autofix" ? AUTOFIX_LABEL : AUTOMERGE_LABEL;
       const oppositeModeLabel = command.intent === "autofix" ? AUTOMERGE_LABEL : AUTOFIX_LABEL;
-      const preMutationBlock = repairLoopReviewDispatchBlockReason(command);
-      if (preMutationBlock) {
-        const status = preMutationBlock.retryable ? "waiting" : "skipped";
+      const preMutationDecision = repairLoopPreMutationReviewDispatchDecision(command);
+      if (preMutationDecision.action !== "dispatch") {
+        const status = reviewDispatchActionStatus(preMutationDecision);
         command.status = status;
-        command.reason = preMutationBlock.reason;
+        command.reason = preMutationDecision.reason;
         command.actions = command.actions.map((action: JsonValue) => ({
           ...action,
           status,
-          reason: preMutationBlock.reason,
+          reason: preMutationDecision.reason,
+          coordination_action: preMutationDecision.action,
         }));
         return;
       }
@@ -2078,38 +2083,46 @@ function executeCommand(command: LooseRecord) {
         ],
         githubAlreadyExistsNoMutation,
       );
-      const dispatchBlock = repairLoopReviewDispatchBlockReason(command);
-      if (dispatchBlock) {
-        const status = dispatchBlock.retryable ? "waiting" : "skipped";
-        command.status = status;
-        command.reason = dispatchBlock.reason;
-        command.actions = command.actions.map((action: JsonValue) => ({
-          ...action,
-          status,
-          reason: dispatchBlock.reason,
-        }));
-        return;
-      }
-      const clawsweeper = dispatchClawSweeperReview(command);
-      dispatched = { ...dispatched, clawsweeper };
-      command.actions = command.actions.map((action: JsonValue) => {
-        if (action.action === "label")
-          return { ...action, status: "executed", label: action.label ?? modeLabel };
-        if (action.action === "remove_label")
-          return { ...action, status: "executed", label: action.label };
-        if (action.action === "ensure_automerge_job")
-          return { ...action, status: "executed", ...job };
-        if (action.action === "dispatch_clawsweeper") {
-          return {
-            ...action,
-            ...dispatchedActionStatus(clawsweeper),
+      const dispatchDecision = reviewDispatchDecisionForCommand(command);
+      if (dispatchDecision.action !== "dispatch") {
+        const dispatchStatus = markCoordinatedReviewDispatchActions({
+          command,
+          job,
+          modeLabel,
+          decision: dispatchDecision,
+        });
+        if (dispatchDecision.action !== "stop") {
+          dispatched = {
+            ...dispatched,
+            clawsweeper: {
+              status: dispatchStatus,
+              coordination_action: dispatchDecision.action,
+              reason: dispatchDecision.reason,
+            },
           };
         }
-        return action;
-      });
-      if (clawsweeper.status === "claimed") {
-        keepCommandClaimed(command);
-        return;
+      } else {
+        const clawsweeper = dispatchClawSweeperReview(command);
+        dispatched = { ...dispatched, clawsweeper };
+        command.actions = command.actions.map((action: JsonValue) => {
+          if (action.action === "label")
+            return { ...action, status: "executed", label: action.label ?? modeLabel };
+          if (action.action === "remove_label")
+            return { ...action, status: "executed", label: action.label };
+          if (action.action === "ensure_automerge_job")
+            return { ...action, status: "executed", ...job };
+          if (action.action === "dispatch_clawsweeper") {
+            return {
+              ...action,
+              ...dispatchedActionStatus(clawsweeper),
+            };
+          }
+          return action;
+        });
+        if (clawsweeper.status === "claimed") {
+          keepCommandClaimed(command);
+          return;
+        }
       }
     }
     if (
@@ -2337,7 +2350,7 @@ function executeCommand(command: LooseRecord) {
     );
     command.status = commandHasClaimedDispatch(command)
       ? "claimed"
-      : commandHasWaitingRepairDispatch(command)
+      : commandHasWaitingDispatch(command)
         ? "waiting"
         : "executed";
   } finally {
@@ -2941,11 +2954,19 @@ function repairJobModeForCommand(command: LooseRecord) {
 
 type ReviewLeaseGuardBlock = { reason: string; retryable: boolean };
 
-function repairLoopReviewDispatchBlockReason(command: LooseRecord): ReviewLeaseGuardBlock | null {
-  if (command.automation_source !== "repair_loop_label_sweep") return null;
+function repairLoopPreMutationReviewDispatchDecision(
+  command: LooseRecord,
+): ReviewDispatchCoordinationDecision {
+  if (command.automation_source !== "repair_loop_label_sweep") return { action: "dispatch" };
+  return reviewDispatchDecisionForCommand(command);
+}
+
+function reviewDispatchDecisionForCommand(
+  command: LooseRecord,
+): ReviewDispatchCoordinationDecision {
   const number = Number(command.issue_number);
   if (!Number.isInteger(number) || number <= 0) {
-    return { reason: "label sweep target is invalid", retryable: false };
+    return { action: "stop", reason: "review dispatch target is invalid" };
   }
   try {
     const before = fetchPullRequestView(number);
@@ -2953,7 +2974,14 @@ function repairLoopReviewDispatchBlockReason(command: LooseRecord): ReviewLeaseG
       .trim()
       .toLowerCase();
     if (String(before.state ?? "").toUpperCase() !== "OPEN") {
-      return { reason: "label sweep target is no longer an open PR", retryable: false };
+      return decideReviewDispatchCoordination({
+        stateBefore: String(before.state ?? ""),
+        stateAfter: String(before.state ?? ""),
+        headBefore,
+        headAfter: headBefore,
+        activeLeaseExpiresAt: null,
+        completedReviewAt: null,
+      });
     }
     const comments = ghPaged<JsonValue>(
       `repos/${targetRepo}/issues/${number}/comments?per_page=100`,
@@ -2962,16 +2990,6 @@ function repairLoopReviewDispatchBlockReason(command: LooseRecord): ReviewLeaseG
     const headAfter = String(after.headRefOid ?? "")
       .trim()
       .toLowerCase();
-    if (String(after.state ?? "").toUpperCase() !== "OPEN") {
-      return { reason: "label sweep target is no longer an open PR", retryable: false };
-    }
-    if (!headBefore || headBefore !== headAfter) {
-      return {
-        reason:
-          "PR head changed during the dispatch-time review lease check; next sweep will retry",
-        retryable: true,
-      };
-    }
     const activeReviewLease = freshExactHeadReviewStartLease({
       comments: comments as LooseRecord[],
       itemNumber: number,
@@ -2979,33 +2997,72 @@ function repairLoopReviewDispatchBlockReason(command: LooseRecord): ReviewLeaseG
       trustedAuthors: trustedBots,
       nowMs: Date.now(),
     });
-    if (activeReviewLease) {
-      return {
-        reason: `same-head ClawSweeper review is active until ${activeReviewLease.expiresAt}`,
-        retryable: true,
-      };
-    }
-    const sweepStartedAtMs = Date.parse(String(command.comment_created_at ?? ""));
+    const commandStartedAtMs = Date.parse(
+      String(command.comment_updated_at ?? command.comment_created_at ?? ""),
+    );
     const completedReview = trustedExactHeadReviewCompletionSince({
       comments: comments as LooseRecord[],
       headSha: headAfter,
       trustedAuthors: trustedBots,
-      sinceMs: sweepStartedAtMs,
+      sinceMs: commandStartedAtMs,
     });
-    if (completedReview) {
-      const completedAt = completedReview.publishedAt ?? completedReview.reviewedAt ?? "recently";
-      return {
-        reason: `same-head ClawSweeper review completed at ${completedAt}; next router pass will route it`,
-        retryable: false,
-      };
-    }
-    return null;
+    return decideReviewDispatchCoordination({
+      stateBefore: String(before.state ?? ""),
+      stateAfter: String(after.state ?? ""),
+      headBefore,
+      headAfter,
+      activeLeaseExpiresAt: activeReviewLease?.expiresAt ?? null,
+      completedReviewAt:
+        completedReview?.publishedAt ??
+        completedReview?.reviewedAt ??
+        (completedReview ? "recently" : null),
+    });
   } catch (error) {
     return {
+      action: "retry",
       reason: `dispatch-time review lease check failed; next sweep will retry: ${compactGhError(error)}`,
-      retryable: true,
     };
   }
+}
+
+function reviewDispatchActionStatus(decision: ReviewDispatchCoordinationDecision) {
+  return ["wait_for_active_review", "retry"].includes(decision.action) ? "waiting" : "skipped";
+}
+
+function markCoordinatedReviewDispatchActions({
+  command,
+  job,
+  modeLabel,
+  decision,
+}: {
+  command: LooseRecord;
+  job: LooseRecord;
+  modeLabel: string;
+  decision: Exclude<ReviewDispatchCoordinationDecision, { action: "dispatch" }>;
+}) {
+  const dispatchStatus = reviewDispatchActionStatus(decision);
+  command.reason = decision.reason;
+  command.actions = command.actions.map((action: JsonValue) => {
+    if (action.action === "ensure_automerge_job") {
+      return { ...action, status: "executed", ...job };
+    }
+    if (action.action === "label") {
+      return { ...action, status: "executed", label: action.label ?? modeLabel };
+    }
+    if (action.action === "remove_label") {
+      return { ...action, status: "executed", label: action.label };
+    }
+    if (action.action === "dispatch_clawsweeper") {
+      return {
+        ...action,
+        status: dispatchStatus,
+        reason: decision.reason,
+        coordination_action: decision.action,
+      };
+    }
+    return action;
+  });
+  return dispatchStatus;
 }
 
 function trustedAutomationSourceRevisionBlockReason(
@@ -3474,10 +3531,10 @@ function commandHasClaimedDispatch(command: LooseRecord) {
   );
 }
 
-function commandHasWaitingRepairDispatch(command: LooseRecord) {
+function commandHasWaitingDispatch(command: LooseRecord) {
   return command.actions?.some(
     (action: JsonValue) =>
-      action?.action === "dispatch_repair" &&
+      ["dispatch_repair", "dispatch_clawsweeper"].includes(String(action?.action ?? "")) &&
       (action?.status === "waiting" || action?.status === "active"),
   );
 }
@@ -4830,16 +4887,31 @@ function automergeTimelineEvents(command: LooseRecord, body: string) {
   const head = command.target?.head_sha ?? command.expected_head_sha ?? "unknown";
   const commentTime = command.comment_updated_at ?? command.comment_created_at;
   if (["automerge", "autofix"].includes(String(command.intent ?? ""))) {
-    const action = executedAction(command, "dispatch_clawsweeper");
-    events.push({
-      id: `review-queued:${head}:${command.comment_id ?? commentTime ?? "unknown"}`,
-      label: "review queued",
-      at: action?.dispatched_at ?? commentTime ?? new Date().toISOString(),
-      headSha: head,
-      repo: command.repo,
-      status: "queued",
-      runUrl: action?.run_url,
-    });
+    const action = (command.actions ?? []).find(
+      (candidate: JsonValue) => candidate?.action === "dispatch_clawsweeper",
+    );
+    const coordinationAction = String(action?.coordination_action ?? "");
+    const event =
+      coordinationAction === "wait_for_active_review"
+        ? { id: "review-active-reused", label: "active review reused", status: "waiting" }
+        : coordinationAction === "reuse_completed_review"
+          ? { id: "review-result-reused", label: "review result reused", status: "complete" }
+          : coordinationAction === "retry"
+            ? { id: "review-deferred", label: "review dispatch deferred", status: "waiting" }
+            : coordinationAction === "stop"
+              ? null
+              : { id: "review-queued", label: "review queued", status: "queued" };
+    if (event) {
+      events.push({
+        id: `${event.id}:${head}:${command.comment_id ?? commentTime ?? "unknown"}`,
+        label: event.label,
+        at: action?.dispatched_at ?? commentTime ?? new Date().toISOString(),
+        headSha: head,
+        repo: command.repo,
+        status: event.status,
+        runUrl: action?.run_url,
+      });
+    }
   }
   if (
     ["clawsweeper_auto_repair", "clawsweeper_auto_merge"].includes(String(command.intent ?? ""))

--- a/src/repair/review-dispatch-coordination.ts
+++ b/src/repair/review-dispatch-coordination.ts
@@ -1,0 +1,57 @@
+export type ReviewDispatchCoordinationDecision =
+  | { action: "dispatch" }
+  | { action: "wait_for_active_review"; reason: string }
+  | { action: "reuse_completed_review"; reason: string }
+  | { action: "retry"; reason: string }
+  | { action: "stop"; reason: string };
+
+export type ReviewDispatchCoordinationInput = {
+  stateBefore: string;
+  stateAfter: string;
+  headBefore: string;
+  headAfter: string;
+  activeLeaseExpiresAt: string | null;
+  completedReviewAt: string | null;
+};
+
+export function decideReviewDispatchCoordination({
+  stateBefore,
+  stateAfter,
+  headBefore,
+  headAfter,
+  activeLeaseExpiresAt,
+  completedReviewAt,
+}: ReviewDispatchCoordinationInput): ReviewDispatchCoordinationDecision {
+  if (!isOpen(stateBefore) || !isOpen(stateAfter)) {
+    return { action: "stop", reason: "target is no longer an open PR" };
+  }
+  if (!headBefore || !headAfter || headBefore !== headAfter) {
+    return {
+      action: "retry",
+      reason: "PR head changed during the dispatch-time review check; next router pass will retry",
+    };
+  }
+  // At-least-once command delivery makes an active exact-head lease a normal
+  // coordination result. Reuse its eventual verdict instead of creating more work.
+  if (activeLeaseExpiresAt) {
+    return {
+      action: "wait_for_active_review",
+      reason: `same-head ClawSweeper review is active until ${activeLeaseExpiresAt}`,
+    };
+  }
+  if (completedReviewAt) {
+    return {
+      action: "reuse_completed_review",
+      reason: `same-head ClawSweeper review completed at ${completedReviewAt}; its result will be reused`,
+    };
+  }
+  return { action: "dispatch" };
+}
+
+function isOpen(state: string) {
+  return (
+    String(state ?? "")
+      .trim()
+      .toUpperCase() === "OPEN"
+  );
+}

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -1840,7 +1840,7 @@ test("active review comments cannot replay their previous trusted verdict", () =
   );
 });
 
-test("label-sweep classification checks the exact-head review lease before dispatch planning", () => {
+test("review dispatch coordination guards label sweeps and maintainer mode commands", () => {
   const source = readFileSync("src/repair/comment-router.ts", "utf8");
   const activeLease = source.indexOf("freshExactHeadReviewStartLease({");
   const repairPlanning = source.indexOf("const failedChecksRepairReason", activeLease);
@@ -1873,10 +1873,12 @@ test("label-sweep classification checks the exact-head review lease before dispa
   const trustedVerdictCheck = executeCommand.indexOf(
     "trustedAutomationReviewLeaseBlockReason(command)",
   );
-  const preMutationCheck = executeCommand.indexOf("repairLoopReviewDispatchBlockReason(command)");
+  const preMutationCheck = executeCommand.indexOf(
+    "repairLoopPreMutationReviewDispatchDecision(command)",
+  );
   const firstMutation = executeCommand.indexOf("ensureAutomergeJob(command)", preMutationCheck);
   const dispatchRecheck = executeCommand.indexOf(
-    "repairLoopReviewDispatchBlockReason(command)",
+    "reviewDispatchDecisionForCommand(command)",
     preMutationCheck + 1,
   );
   const dispatch = executeCommand.indexOf("dispatchClawSweeperReview(command)", dispatchRecheck);
@@ -1886,17 +1888,31 @@ test("label-sweep classification checks the exact-head review lease before dispa
   assert.ok(firstMutation > preMutationCheck);
   assert.ok(dispatchRecheck > firstMutation);
   assert.ok(dispatch > dispatchRecheck);
+  const postMutationCoordination = executeCommand.slice(dispatchRecheck, dispatch);
+  assert.match(postMutationCoordination, /markCoordinatedReviewDispatchActions\(\{/);
 
   const dispatchGuard = source.slice(
-    source.indexOf("function repairLoopReviewDispatchBlockReason"),
-    source.indexOf("function trustedAutomationReviewLeaseBlockReason"),
+    source.indexOf("function repairLoopPreMutationReviewDispatchDecision"),
+    source.indexOf("function trustedAutomationSourceRevisionBlockReason"),
+  );
+  assert.match(
+    dispatchGuard,
+    /automation_source !== "repair_loop_label_sweep"[\s\S]*?return \{ action: "dispatch" \}/,
   );
   assert.equal(dispatchGuard.match(/fetchPullRequestView\(number\)/g)?.length, 2);
   assert.match(dispatchGuard, /issues\/\$\{number\}\/comments\?per_page=100/);
   assert.match(dispatchGuard, /nowMs:\s*Date\.now\(\)/);
   assert.match(dispatchGuard, /trustedExactHeadReviewCompletionSince\(\{/);
-  assert.match(dispatchGuard, /sinceMs:\s*sweepStartedAtMs/);
-  assert.match(dispatchGuard, /next router pass will route it/);
+  assert.match(dispatchGuard, /sinceMs:\s*commandStartedAtMs/);
+  assert.match(dispatchGuard, /decideReviewDispatchCoordination\(\{/);
+  assert.match(dispatchGuard, /completedReviewAt:/);
+  const coordinatedActions = source.slice(
+    source.indexOf("function markCoordinatedReviewDispatchActions"),
+    source.indexOf("function trustedAutomationSourceRevisionBlockReason"),
+  );
+  assert.match(coordinatedActions, /ensure_automerge_job/);
+  assert.match(coordinatedActions, /status:\s*"executed"/);
+  assert.match(coordinatedActions, /coordination_action:\s*decision\.action/);
   const sourceRevisionGuard = source.slice(
     source.indexOf("function trustedAutomationSourceRevisionBlockReason"),
     source.indexOf("function trustedAutomationReviewLeaseBlockReason"),
@@ -3125,6 +3141,49 @@ test("renderResponse reports autofix repair-only opt-in", () => {
   assert.match(body, /`clawsweeper:autofix`/);
   assert.match(body, /fix-only/);
   assert.doesNotMatch(body, /will merge/);
+});
+
+test("renderResponse reports reuse of an active exact-head review", () => {
+  const body = renderResponse(
+    {
+      comment_id: "460",
+      intent: "automerge",
+      repo: "openclaw/clawsweeper",
+      target: { head_sha: "a".repeat(40) },
+      actions: [{ action: "label", label: "clawsweeper:automerge", status: "executed" }],
+    },
+    {
+      clawsweeper: {
+        coordination_action: "wait_for_active_review",
+        status: "waiting",
+      },
+    },
+  );
+
+  assert.match(body, /ClawSweeper automerge is enabled/);
+  assert.match(body, /exact-head review is already active/);
+  assert.match(body, /no duplicate review was queued/);
+  assert.doesNotMatch(body, /exact-head review queued/);
+});
+
+test("renderResponse reports reuse of a completed exact-head review", () => {
+  const body = renderResponse(
+    {
+      comment_id: "4601",
+      intent: "autofix",
+      repo: "openclaw/clawsweeper",
+      target: { head_sha: "b".repeat(40) },
+    },
+    {
+      clawsweeper: {
+        coordination_action: "reuse_completed_review",
+        status: "skipped",
+      },
+    },
+  );
+
+  assert.match(body, /ClawSweeper autofix is enabled/);
+  assert.match(body, /existing exact-head review result is being reused/);
 });
 
 test("renderResponse reports terminal autofix success without merge", () => {

--- a/test/repair/review-dispatch-coordination.test.ts
+++ b/test/repair/review-dispatch-coordination.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { decideReviewDispatchCoordination } from "../../src/repair/review-dispatch-coordination.ts";
+
+const head = "a".repeat(40);
+
+function decision(overrides: Partial<Parameters<typeof decideReviewDispatchCoordination>[0]> = {}) {
+  return decideReviewDispatchCoordination({
+    stateBefore: "OPEN",
+    stateAfter: "OPEN",
+    headBefore: head,
+    headAfter: head,
+    activeLeaseExpiresAt: null,
+    completedReviewAt: null,
+    ...overrides,
+  });
+}
+
+test("dispatches when the open PR head is stable and has no reusable review", () => {
+  assert.deepEqual(decision(), { action: "dispatch" });
+});
+
+test("stops when the target closes between observations", () => {
+  assert.deepEqual(decision({ stateAfter: "CLOSED" }), {
+    action: "stop",
+    reason: "target is no longer an open PR",
+  });
+});
+
+test("retries when the PR head changes between observations", () => {
+  assert.equal(decision({ headAfter: "b".repeat(40) }).action, "retry");
+});
+
+test("waits for an active exact-head review", () => {
+  const result = decision({ activeLeaseExpiresAt: "2026-07-17T14:13:17.000Z" });
+  assert.equal(result.action, "wait_for_active_review");
+  assert.match(result.reason, /active until 2026-07-17T14:13:17\.000Z/);
+});
+
+test("reuses a same-head review completed since the command", () => {
+  const result = decision({ completedReviewAt: "2026-07-17T14:10:00.000Z" });
+  assert.equal(result.action, "reuse_completed_review");
+  assert.match(result.reason, /result will be reused/);
+});
+
+test("an active lease wins over a completed marker", () => {
+  assert.equal(
+    decision({
+      activeLeaseExpiresAt: "2026-07-17T14:13:17.000Z",
+      completedReviewAt: "2026-07-17T14:10:00.000Z",
+    }).action,
+    "wait_for_active_review",
+  );
+});

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -400,6 +400,8 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   const upload = step(reviewer, "Upload exact review artifact bundle");
   const queuePublication = step(reviewer, "Queue durable exact review publication");
   const complete = step(reviewer, "Complete exact-review queue lease");
+  const deferHeldReview = step(reviewer, "Defer exact review while same-head lease is held");
+  const failGeneration = step(reviewer, "Fail unsuccessful exact review generation");
   const releaseGeneration = step(reviewer, "Release unsuccessful workflow-owned review lease");
   assert.match(create.if ?? "", /review-exact-event-item\.outcome == 'success'/);
   assert.match(create.if ?? "", /review-exact-event-item\.outputs\.retry_at == ''/);
@@ -418,6 +420,10 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   assert.match(queuePublication.run ?? "", /for attempt in 1 2 3/);
   assert.match(queuePublication.run ?? "", /\.queued == true or \.deduped == true/);
   assert.match(complete.env?.PRIMARY_OUTCOME ?? "", /exact-review-generation-result/);
+  assert.match(deferHeldReview.if ?? "", /reserve-exact-review-lease\.outputs\.status == 'held'/);
+  assert.match(deferHeldReview.run ?? "", /retry deferred/);
+  assert.match(failGeneration.if ?? "", /reserve-exact-review-lease\.outputs\.status != 'held'/);
+  assert.match(failGeneration.if ?? "", /complete-exact-review-queue\.outcome != 'success'/);
   assert.match(releaseGeneration.if ?? "", /reserve-exact-review-lease\.outputs\.status != 'held'/);
   assert.match(releaseGeneration.run ?? "", /content == "eyes"/);
   assert.ok(reviewer.steps.indexOf(upload) < reviewer.steps.indexOf(complete));
@@ -1829,7 +1835,7 @@ test("event review completion removes ClawSweeper eyes reaction", () => {
   assert.doesNotMatch(block, /issues\/comments\/\$ITEM_NUMBER\/reactions/);
 });
 
-test("event re-review status lets the durable queue reconcile interruptions", () => {
+test("event re-review status distinguishes lease deferral from interruptions", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const block = workflow.slice(
     workflow.indexOf("- name: Mark unsuccessful re-review"),
@@ -1837,6 +1843,9 @@ test("event re-review status lets the durable queue reconcile interruptions", ()
   );
 
   assert.match(block, /\[ "\$REVIEW_OUTCOME" = "cancelled" \]/);
+  assert.match(block, /\[ "\$RESERVATION_STATUS" = "held" \]/);
+  assert.match(block, /state="Waiting"/);
+  assert.match(block, /Another exact-head review is already active/);
   assert.match(block, /state="Interrupted"/);
   assert.match(block, /The durable queue will retry it/);
   assert.doesNotMatch(block, /CAPACITY_OUTCOME/);


### PR DESCRIPTION
## Root cause

Run https://github.com/openclaw/clawsweeper/actions/runs/29584522882 was a false red for https://github.com/openclaw/clawsweeper/pull/648. A maintainer automerge command dispatched a second exact-head review while the ready-for-review run still held the review lease. Lease reservation correctly returned `held`, and the durable queue recorded `failure + retry_at`, but the workflow then marked the command interrupted and exited 1 even though the original review and publisher completed successfully.

## Changes

- persist automerge/autofix job and label intent before coordinating review dispatch
- add a pure review-dispatch policy for stable-head dispatch, active-review waiting, completed-result reuse, retry, and terminal stop
- reuse an active or newly completed exact-head review instead of dispatching duplicate work
- render coordinated review states in the maintainer response and automerge timeline
- treat a held review lease as deferred work in Actions while preserving durable queue retry ownership
- keep queue completion failures and genuine review failures visible as failed runs

## Safety and impact

The exact-head lease, dispatch claim grace, and automerge gates are unchanged. The workflow reports a held generation as `failure + retry_at` to the durable queue; it becomes a successful Actions deferral only when queue completion succeeds.

## Validation

- `pnpm run check`
- focused coordination, router, and workflow tests
- autoreview: clean, no accepted or actionable findings
- gitleaks: changed diff and new files clean
