### PR TITLE
fix(review): exclude the Codex model from review-policy identity

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -3285,7 +3285,14 @@ function reviewPolicyHash(options: {
     stableJson({
       version: REVIEW_POLICY_VERSION,
       freshDays: FRESH_DAYS,
-      model: options.model ?? DEFAULT_CODEX_MODEL,
+      // Maintainer decision 2026-07-17: the model is deliberately NOT part of
+      // review-policy identity. Baking it in made every model change invalidate
+      // all stored reviews (a fleet-wide re-review wave), which makes model
+      // swaps untestable in production. Model changes now roll through the
+      // normal review cadence instead; bump REVIEW_POLICY_VERSION explicitly
+      // when a full re-review is actually wanted. The sentinel migrates all
+      // hashes once, riding the 2026-07 prompt-change wave already in flight.
+      model: "model-excluded-2026-07",
       reasoningEffort: options.reasoningEffort ?? DEFAULT_REASONING_EFFORT,
       sandboxMode: options.sandboxMode ?? "read-only",
       // Service tier changes latency, never decisions. Pinned to the historical


### PR DESCRIPTION
## Why

The Codex model name was part of `reviewPolicyHash`, so ANY model change marked all ~7k stored reviews policy-stale and triggered a fleet-wide re-review wave. Maintainer decision (Peter, 2026-07-17): that coupling makes model swaps untestable in production — a model A/B or rollback should not "trigger everything."

## What

The hash's `model` field is pinned to a fixed sentinel (`model-excluded-2026-07`), same pattern as the service-tier exclusion in #639. Consequences:
- Model changes now roll through the normal review cadence (hourly/daily/weekly per item class) instead of invalidating the fleet — bounded staleness of at most one cadence cycle.
- A deliberate full re-review remains available by bumping `REVIEW_POLICY_VERSION` explicitly.
- The one-time hash migration this causes rides the prompt-change re-review wave already in flight from #631/#632, so it costs nothing extra.

Effort, sandbox mode, prompt, schema, repo profile stay in the hash — those change decision semantics.

## Proof

`pnpm run build:all`; clawsweeper + review-close-policy suites 107 pass; `format:check`, `lint` green. Autoreview (Codex Sol, xhigh) clean on first pass.
