### PR TITLE
fix: publish bulk-filer labels in write lane

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -424,6 +424,10 @@ type ActionTaken =
   | "skipped_runtime_budget";
 
 const MAINTAINER_AUTHOR_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+// The bulk-filer policy is intentionally narrower than the general maintainer
+// policy: repository owners and members can legitimately create high volumes
+// of coordinated issues, while outside collaborators remain in scope.
+const BULK_FILER_EXEMPT_AUTHOR_ASSOCIATIONS = new Set(["OWNER", "MEMBER"]);
 
 interface GitHubUser {
   login?: string;
@@ -476,19 +480,12 @@ export interface BulkFilerDetectionResult {
 type BulkFilerCountCache = Map<string, number | null>;
 
 interface BulkFilerDetectionOptions {
-  item: Pick<Item, "author" | "createdAt" | "kind" | "labels" | "number">;
+  item: Pick<Item, "author" | "authorAssociation" | "createdAt" | "kind" | "labels" | "number">;
   cache: BulkFilerCountCache;
   now: number;
   env?: Record<string, string | undefined>;
   searchCount: (options: { author: string; windowStart: string }) => number;
   onSearchError?: (error: unknown) => void;
-}
-
-interface BulkFilerActivationOptions {
-  item: Pick<Item, "labels">;
-  detection: BulkFilerDetectionResult;
-  patchTransparency: () => void;
-  applyLabel: () => boolean;
 }
 
 export interface ReviewStartStatusCommentOptions {
@@ -504,7 +501,6 @@ export interface ReviewStartStatusCommentOptions {
   shardIndex?: number;
   shardCount?: number;
   purpose?: "review" | "apply";
-  bulkFilerLabelApplied?: boolean;
 }
 
 type AcquiredReviewStartLease = {
@@ -533,6 +529,20 @@ function suppliedReviewStartLeaseFromArgs(
     throw new UserFacingCommandError("--review-lease-owner contains unsupported characters.");
   }
   return { owner, commentId };
+}
+
+function isSuppliedReviewStartLease(
+  supplied: Pick<AcquiredReviewStartLease, "owner" | "commentId"> | null,
+  lease: Pick<AcquiredReviewStartLease, "owner" | "commentId">,
+): boolean {
+  return supplied?.owner === lease.owner && supplied.commentId === lease.commentId;
+}
+
+export function isSuppliedReviewStartLeaseForTest(
+  supplied: Pick<AcquiredReviewStartLease, "owner" | "commentId"> | null,
+  lease: Pick<AcquiredReviewStartLease, "owner" | "commentId">,
+): boolean {
+  return isSuppliedReviewStartLease(supplied, lease);
 }
 
 function reviewLeaseStillMatchesContext(
@@ -1408,8 +1418,6 @@ const DEFAULT_BULK_FILER_THRESHOLD = 10;
 const DEFAULT_BULK_FILER_WINDOW_DAYS = 7;
 const BULK_FILER_SEARCH_TIMEOUT_MS = 15_000;
 const BULK_FILED_LABEL = "clawsweeper:bulk-filed";
-const BULK_FILER_TRANSPARENCY_LINE =
-  "High filing volume detected, so these issues are batched behind other reviews. Consolidating related reports into fewer issues helps us review everything faster.";
 const BULK_FILED_LABEL_DEFINITION = {
   name: BULK_FILED_LABEL,
   color: "6E7781",
@@ -4128,6 +4136,10 @@ function isMaintainerAuthorAssociation(value: unknown): boolean {
   return MAINTAINER_AUTHOR_ASSOCIATIONS.has(normalizeAuthorAssociation(value));
 }
 
+function isBulkFilerExemptAuthorAssociation(value: unknown): boolean {
+  return BULK_FILER_EXEMPT_AUTHOR_ASSOCIATIONS.has(normalizeAuthorAssociation(value));
+}
+
 function isMaintainerAuthored(item: Pick<Item, "authorAssociation">): boolean {
   return isMaintainerAuthorAssociation(item.authorAssociation);
 }
@@ -6432,6 +6444,9 @@ function detectBulkFiler(options: BulkFilerDetectionOptions): BulkFilerDetection
   if (options.item.kind !== "issue" || !options.item.author.trim()) {
     return { context: null, labelPending: false, labelApplied: false };
   }
+  if (isBulkFilerExemptAuthorAssociation(options.item.authorAssociation)) {
+    return { context: null, labelPending: false, labelApplied: false };
+  }
   const windowDays = bulkFilerWindowDays(options.env);
   const windowStartMs = options.now - windowDays * DAY_MS;
   const itemCreatedAtMs = Date.parse(options.item.createdAt);
@@ -6478,43 +6493,28 @@ function detectBulkFiler(options: BulkFilerDetectionOptions): BulkFilerDetection
   };
 }
 
-function activateBulkFilerAfterReviewLease(options: BulkFilerActivationOptions): boolean {
-  const alreadyLabeled = options.item.labels.some(
-    (label) => label.toLowerCase() === BULK_FILED_LABEL,
-  );
-  if (!options.detection.context || !options.detection.labelPending || alreadyLabeled) {
-    options.detection.labelPending = false;
-    return false;
-  }
-  const labelApplied = options.applyLabel();
-  if (!labelApplied) return false;
-  try {
-    options.patchTransparency();
-  } catch (error) {
-    // The label is the scheduling signal; a failed disclosure patch must not
-    // abort the review. Disclosure reconciliation is tracked as a follow-up.
-    console.warn(
-      `bulk-filer transparency patch failed: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    );
-  }
-  options.item.labels.push(BULK_FILED_LABEL);
-  options.detection.labelPending = false;
-  options.detection.labelApplied = true;
-  return true;
-}
-
 export function detectBulkFilerForTest(
   options: BulkFilerDetectionOptions,
 ): BulkFilerDetectionResult {
   return detectBulkFiler(options);
 }
 
-export function activateBulkFilerAfterReviewLeaseForTest(
-  options: BulkFilerActivationOptions,
-): boolean {
-  return activateBulkFilerAfterReviewLease(options);
+function updateBulkFilerDetectedFrontMatter(
+  markdown: string,
+  detection: BulkFilerDetectionResult,
+): string {
+  return replaceFrontMatterValue(
+    markdown,
+    "bulk_filer_detected",
+    String(detection.context?.detected === true),
+  );
+}
+
+export function updateBulkFilerDetectedFrontMatterForTest(
+  markdown: string,
+  detection: BulkFilerDetectionResult,
+): string {
+  return updateBulkFilerDetectedFrontMatter(markdown, detection);
 }
 
 function authorIssueCountInBulkFilerWindow(author: string, windowStart: string): number {
@@ -14226,13 +14226,49 @@ function ensureBulkFilerLabel(onMutation?: () => void): void {
   }
 }
 
-function applyBulkFilerLabel(number: number, currentLabels: readonly string[]): boolean {
-  ensureBulkFilerLabel();
-  return tryAddOptionalLabel({
-    number,
+function syncBulkFilerLabel(options: {
+  number: number;
+  labels: readonly string[];
+  bulkFilerDetected: boolean;
+  authorAssociation: string;
+  dryRun: boolean;
+  onMutation?: () => void;
+}): { labels: string[]; changed: boolean } {
+  const hasBulkFilerLabel = hasNormalizedLabel(options.labels, BULK_FILED_LABEL);
+  if (isBulkFilerExemptAuthorAssociation(options.authorAssociation)) {
+    if (!hasBulkFilerLabel) return { labels: [...options.labels], changed: false };
+    // This is ClawSweeper policy state, not a human triage label. Remove a
+    // pre-exemption value so owners and members are not still deprioritized.
+    const nextLabels = options.labels.filter(
+      (label) => normalizeLabelName(label) !== normalizeLabelName(BULK_FILED_LABEL),
+    );
+    if (options.dryRun) return { labels: nextLabels, changed: true };
+    removeIssueLabel(options.number, BULK_FILED_LABEL, options.onMutation);
+    return { labels: nextLabels, changed: true };
+  }
+  if (!options.bulkFilerDetected || hasBulkFilerLabel) {
+    return { labels: [...options.labels], changed: false };
+  }
+  const nextLabels = [...options.labels, BULK_FILED_LABEL];
+  if (options.dryRun) return { labels: nextLabels, changed: true };
+  ensureBulkFilerLabel(options.onMutation);
+  const applied = tryAddOptionalLabel({
+    number: options.number,
     label: BULK_FILED_LABEL,
-    currentLabels,
+    currentLabels: options.labels,
+    onMutation: options.onMutation,
   });
+  return { labels: applied ? nextLabels : [...options.labels], changed: applied };
+}
+
+export function syncBulkFilerLabelForTest(options: {
+  number: number;
+  labels: readonly string[];
+  bulkFilerDetected: boolean;
+  authorAssociation: string;
+  dryRun: boolean;
+}): { labels: string[]; changed: boolean } {
+  return syncBulkFilerLabel(options);
 }
 
 function ensureMergeRiskLabel(name: MergeRiskLabelName, onMutation?: () => void): void {
@@ -19682,7 +19718,6 @@ export function renderReviewStartStatusComment(options: ReviewStartStatusComment
     purpose === "apply"
       ? "This transient lease prevents a newer review from overlapping label, comment, or close mutations."
       : "This placeholder means the worker is alive and reading the current context. I will edit this same comment with the actual review when the claws are done clicking.",
-    ...(options.bulkFilerLabelApplied ? ["", BULK_FILER_TRANSPARENCY_LINE] : []),
     "",
     "Crustacean status: shell secured, claws on keyboard, evidence pebbles being sorted.",
     "",
@@ -20455,7 +20490,6 @@ function postReviewStartStatusComment(options: {
   shardIndex: number;
   shardCount: number;
   purpose?: "review" | "apply";
-  bulkFilerLabelApplied?: boolean;
 }): ReviewStartStatusCommentResult {
   const startedAtMs = Date.now();
   const leaseOwner = newReviewStartLeaseOwner();
@@ -20472,7 +20506,6 @@ function postReviewStartStatusComment(options: {
     shardIndex: options.shardIndex,
     shardCount: options.shardCount,
     purpose: options.purpose ?? "review",
-    bulkFilerLabelApplied: options.bulkFilerLabelApplied ?? false,
   };
   const normalizedHead = String(options.headSha ?? "")
     .trim()
@@ -20552,59 +20585,6 @@ function postReviewStartStatusComment(options: {
     lease: { ...acquired, comment: winner.comment },
     didMutate: true,
   };
-}
-
-function patchOwnedBulkFilerReviewStartStatusComment(
-  itemNumber: number,
-  lease: AcquiredReviewStartLease,
-): void {
-  const currentBody = commentBody(lease.comment);
-  if (
-    !currentBody ||
-    commentId(lease.comment) !== lease.commentId ||
-    reviewStartLeaseOwner(lease.comment) !== lease.owner ||
-    !currentBody.includes(`sha=${lease.headSha}`)
-  ) {
-    throw new Error(
-      `cannot add bulk-filer transparency without the owned review lease comment for #${itemNumber}`,
-    );
-  }
-  if (currentBody.includes(BULK_FILER_TRANSPARENCY_LINE)) return;
-  const anchor = "\n\nCrustacean status:";
-  if (!currentBody.includes(anchor)) {
-    throw new Error(`cannot locate the review lease transparency anchor for #${itemNumber}`);
-  }
-  const nextBody = currentBody.replace(anchor, `\n\n${BULK_FILER_TRANSPARENCY_LINE}${anchor}`);
-  const payload = writeCommentPayload(itemNumber, nextBody);
-  const args = [
-    "api",
-    `repos/${targetRepo()}/issues/comments/${lease.commentId}`,
-    "--method",
-    "PATCH",
-    "--input",
-    payload,
-  ];
-  const written = reviewCommentFromMutationResponse(
-    ghObservedMutationCommand({
-      identity: `review_lease_bulk_filer_transparency:${itemNumber}:${lease.commentId}`,
-      args,
-    }),
-    args,
-  );
-  lease.comment = written ?? { ...lease.comment, body: nextBody };
-}
-
-function activateDetectedBulkFilerAfterReviewLease(
-  item: Item,
-  detection: BulkFilerDetectionResult,
-  lease: AcquiredReviewStartLease,
-): boolean {
-  return activateBulkFilerAfterReviewLease({
-    item,
-    detection,
-    patchTransparency: () => patchOwnedBulkFilerReviewStartStatusComment(item.number, lease),
-    applyLabel: () => applyBulkFilerLabel(item.number, item.labels),
-  });
 }
 
 function deleteOwnedDedicatedReviewStartLease(
@@ -21201,6 +21181,7 @@ item_updated_at: ${options.item.updatedAt}
 author: ${options.item.author}
 author_association: ${options.item.authorAssociation}
 labels: ${JSON.stringify(options.item.labels)}
+bulk_filer_detected: ${options.context.bulkFiler?.detected === true}
 reviewed_at: ${reviewedAt}
 review_lease_owner: ${options.reviewLeaseOwner ?? "unknown"}
 review_lease_comment_id: ${options.reviewLeaseCommentId ?? "unknown"}
@@ -22591,6 +22572,12 @@ function reviewCommand(args: Args): void {
   const maintainerRequest = additionalPrompt.trim().length > 0;
   const readonlyModeSnapshots = readonlyOpenclaw ? makeTreeReadOnly(openclawDir) : [];
   const acquiredReviewLeases: Array<{ itemNumber: number; lease: AcquiredReviewStartLease }> = [];
+  const releaseOwnedReviewLease = (itemNumber: number, lease: AcquiredReviewStartLease): boolean =>
+    // The exact-event workflow reserves a supplied lease in its write-token
+    // step and owns cleanup outside this read-token review. Every lease this
+    // command creates itself must still be deleted, even for a read-only checkout.
+    isSuppliedReviewStartLease(suppliedReviewLease, lease) ||
+    deleteOwnedDedicatedReviewStartLease(itemNumber, lease);
   let reviewLedger: ReviewActionLedger | null = null;
   let activeReviewItem: Item | null = null;
   let completed = 0;
@@ -22794,7 +22781,6 @@ function reviewCommand(args: Args): void {
                 total: candidates.length,
                 shardIndex,
                 shardCount,
-                bulkFilerLabelApplied: bulkFilerDetection.labelApplied,
               });
               console.error(
                 `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} structural-cache-start-comment=${startComment.status} #${item.number}`,
@@ -22810,11 +22796,6 @@ function reviewCommand(args: Args): void {
                 );
               }
               acquiredReviewLeases.push({ itemNumber: item.number, lease: acquiredReviewLease });
-              activateDetectedBulkFilerAfterReviewLease(
-                item,
-                bulkFilerDetection,
-                acquiredReviewLease,
-              );
             } catch (error) {
               leaseAcquisitionFailures += 1;
               leaseAcquisitionFailureDetails.push(
@@ -22883,7 +22864,7 @@ function reviewCommand(args: Args): void {
             );
             if (!revalidationDecision.hit || !previousReviewIdentityMatches) {
               const leaseToRelease = acquiredReviewLease!;
-              if (!deleteOwnedDedicatedReviewStartLease(item.number, leaseToRelease)) {
+              if (!releaseOwnedReviewLease(item.number, leaseToRelease)) {
                 leaseAcquisitionFailures += 1;
                 leaseAcquisitionFailureDetails.push(
                   `#${item.number}: could not release structural cache lease after ${revalidationReason}`,
@@ -22923,6 +22904,7 @@ function reviewCommand(args: Args): void {
                 String(acquiredReviewLease.commentId),
               );
               carried = replaceFrontMatterValue(carried, "review_cache_hit", "true");
+              carried = updateBulkFilerDetectedFrontMatter(carried, bulkFilerDetection);
               carried = updateReviewStructuralFrontMatter(carried, structuralRecord, true);
               writeFileSync(reportPath, carried, "utf8");
               finishReviewActionLedgerItem({
@@ -22975,7 +22957,6 @@ function reviewCommand(args: Args): void {
             total: candidates.length,
             shardIndex,
             shardCount,
-            bulkFilerLabelApplied: bulkFilerDetection.labelApplied,
           });
           console.error(
             `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} start-comment=${startComment.status} #${item.number}`,
@@ -23074,7 +23055,6 @@ function reviewCommand(args: Args): void {
         };
         acquiredReviewLease = claimedLease;
         acquiredReviewLeases.push({ itemNumber: item.number, lease: claimedLease });
-        activateDetectedBulkFilerAfterReviewLease(item, bulkFilerDetection, claimedLease);
       }
       if (!localRangeData && contextItemUpdatedAt && preHydrationStructuralRecord) {
         structuralCacheRevalidations += 1;
@@ -23200,7 +23180,6 @@ function reviewCommand(args: Args): void {
             total: candidates.length,
             shardIndex,
             shardCount,
-            bulkFilerLabelApplied: bulkFilerDetection.labelApplied,
           });
           console.error(
             `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} start-comment=${startComment.status} #${item.number}`,
@@ -23216,11 +23195,6 @@ function reviewCommand(args: Args): void {
             );
           }
           acquiredReviewLeases.push({ itemNumber: item.number, lease: acquiredReviewLease });
-          activateDetectedBulkFilerAfterReviewLease(
-            item,
-            bulkFilerDetection,
-            acquiredReviewLease,
-          );
         } catch (error) {
           leaseAcquisitionFailures += 1;
           leaseAcquisitionFailureDetails.push(
@@ -23253,7 +23227,7 @@ function reviewCommand(args: Args): void {
               error instanceof Error ? error.message : String(error)
             }`,
           );
-          if (!deleteOwnedDedicatedReviewStartLease(item.number, leaseToRelease)) {
+          if (!releaseOwnedReviewLease(item.number, leaseToRelease)) {
             leaseAcquisitionFailureDetails.push(
               `#${item.number}: could not release issue review lease after durable review refresh failed`,
             );
@@ -23358,7 +23332,7 @@ function reviewCommand(args: Args): void {
             (semanticCacheRevalidationReasons.get(revalidationReason) ?? 0) + 1,
           );
           const leaseToRelease = acquiredReviewLease!;
-          if (!deleteOwnedDedicatedReviewStartLease(item.number, leaseToRelease)) {
+          if (!releaseOwnedReviewLease(item.number, leaseToRelease)) {
             leaseAcquisitionFailures += 1;
             leaseAcquisitionFailureDetails.push(
               `#${item.number}: could not release semantic cache lease after ${revalidationReason}`,
@@ -23428,7 +23402,7 @@ function reviewCommand(args: Args): void {
         );
         if (!revalidatedStructuralRecord || !semanticRevalidationDecision.hit) {
           const leaseToRelease = acquiredReviewLease!;
-          if (!deleteOwnedDedicatedReviewStartLease(item.number, leaseToRelease)) {
+          if (!releaseOwnedReviewLease(item.number, leaseToRelease)) {
             leaseAcquisitionFailures += 1;
             leaseAcquisitionFailureDetails.push(
               `#${item.number}: could not release semantic cache lease after ${revalidationReason}`,
@@ -23483,6 +23457,7 @@ function reviewCommand(args: Args): void {
         );
         carried = replaceFrontMatterValue(carried, "main_sha", git.mainSha);
         carried = replaceFrontMatterValue(carried, "review_cache_hit", "true");
+        carried = updateBulkFilerDetectedFrontMatter(carried, bulkFilerDetection);
         carried = updateReviewStructuralFrontMatter(carried, structuralRecord, false);
         carried = updateReviewSemanticFrontMatter(carried, semanticRecord, true);
         writeFileSync(reportPath, carried, "utf8");
@@ -23553,6 +23528,7 @@ function reviewCommand(args: Args): void {
           itemSnapshotHash(item, context),
         );
         carried = replaceFrontMatterValue(carried, "review_cache_hit", "true");
+        carried = updateBulkFilerDetectedFrontMatter(carried, bulkFilerDetection);
         carried = structuralRecord
           ? updateReviewStructuralFrontMatter(carried, structuralRecord, false)
           : replaceFrontMatterValue(carried, "review_structural_cache_hit", "false");
@@ -23869,7 +23845,7 @@ function reviewCommand(args: Args): void {
         const previousReviewMutationRunner = activeReviewMutationRunner;
         activeReviewMutationRunner = reviewMutationRunner(reviewLedger, state.item);
         try {
-          deleteOwnedDedicatedReviewStartLease(acquired.itemNumber, acquired.lease);
+          releaseOwnedReviewLease(acquired.itemNumber, acquired.lease);
         } finally {
           activeReviewMutationRunner = previousReviewMutationRunner;
         }
@@ -28354,10 +28330,34 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
         continue;
       }
     }
+    const isCurrentLabelSyncReport = !stalePrReviewHead && labelSyncFreshEnough();
     const isCurrentCompleteReport =
-      frontMatterValue(markdown, "review_status") === "complete" &&
-      !stalePrReviewHead &&
-      labelSyncFreshEnough();
+      frontMatterValue(markdown, "review_status") === "complete" && isCurrentLabelSyncReport;
+    if (state === "open" && isCurrentLabelSyncReport) {
+      const mutationLeaseBlockReason = currentApplyMutationLeaseBlockReason();
+      if (mutationLeaseBlockReason) {
+        if (recordReviewLeaseSkip(mutationLeaseBlockReason, false)) break;
+        continue;
+      }
+      try {
+        const bulkFilerSyncResult = syncBulkFilerLabel({
+          number,
+          labels: item.labels,
+          bulkFilerDetected: frontMatterBoolean(markdown, "bulk_filer_detected"),
+          authorAssociation: item.authorAssociation,
+          dryRun,
+          onMutation: recordMutation,
+        });
+        item.labels = bulkFilerSyncResult.labels;
+        clawSweeperLabelsChanged ||= bulkFilerSyncResult.changed;
+        markdown = replaceFrontMatterValue(markdown, "labels", JSON.stringify(item.labels));
+        if (bulkFilerSyncResult.changed) rememberSelfMutationUpdatedAt();
+      } catch (error) {
+        if (!isGitHubRequiresAuthenticationError(error)) throw error;
+        if (markLabelSyncAuthSkipped("ClawSweeper bulk-filer")) break;
+        continue;
+      }
+    }
     if (state === "open" && isCurrentCompleteReport) {
       const mutationLeaseBlockReason = currentApplyMutationLeaseBlockReason();
       if (mutationLeaseBlockReason) {

--- a/test/apply-label-sync.test.ts
+++ b/test/apply-label-sync.test.ts
@@ -51,6 +51,128 @@ test("command-only timeline activity is ignored only through the completed revie
   );
 });
 
+test("apply-decisions publishes a detected bulk-filer label from a failed exact review artifact", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const logPath = join(root, "gh.log");
+    const number = 74486;
+    const reviewedAt = new Date().toISOString();
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    writeFileSync(
+      join(itemsDir, `${number}.md`),
+      `${reportFrontMatter({
+        repository: "openclaw/clawsweeper",
+        type: "issue",
+        number: String(number),
+        title: "Publish bulk-filer label",
+        url: `https://github.com/openclaw/clawsweeper/issues/${number}`,
+        decision: "keep_open",
+        close_reason: "none",
+        confidence: "high",
+        action_taken: "kept_open",
+        review_status: "failed",
+        local_checkout_access: "verified",
+        author: "contributor",
+        author_association: "CONTRIBUTOR",
+        labels: JSON.stringify([]),
+        bulk_filer_detected: "true",
+        item_snapshot_hash: "snapshot-a",
+        item_updated_at: reviewedAt,
+        reviewed_at: reviewedAt,
+      })}
+
+## Summary
+
+This exact review detected a high recent filing volume before Codex failed.
+`,
+      "utf8",
+    );
+    const ghMock = `
+const { appendFileSync } = require("fs");
+const logPath = ${JSON.stringify(logPath)};
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+appendFileSync(logPath, JSON.stringify(args) + "\\n");
+const path = args[1] || "";
+if (args[0] === "api" && /\\/issues\\/${number}$/.test(path)) {
+  console.log(JSON.stringify({
+    number: ${number},
+    title: "Publish bulk-filer label",
+    html_url: "https://github.com/openclaw/clawsweeper/issues/${number}",
+    created_at: "2026-07-17T00:00:00Z",
+    updated_at: ${JSON.stringify(reviewedAt)},
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "contributor" },
+    labels: [],
+    comments: 0,
+    pull_request: null
+  }));
+} else if (args[0] === "api" && /\\/issues\\/${number}\\/timeline(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/issues\\/${number}\\/comments(?:\\?|$)/.test(path)) {
+  if (args.includes("--method") && args.includes("POST")) {
+    console.log(JSON.stringify({
+      id: 987486,
+      html_url: "https://github.com/openclaw/clawsweeper/issues/${number}#issuecomment-987486"
+    }));
+  } else {
+    console.log(JSON.stringify([[]]));
+  }
+} else if (args[0] === "issue" && args[1] === "view") {
+  console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
+} else if (args[0] === "label" && args[1] === "create") {
+  console.log(JSON.stringify({ name: args[2] }));
+} else if (args[0] === "issue" && args[1] === "edit") {
+  console.log("");
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: ["--sync-comments-only", "--item-numbers", String(number)],
+      });
+    });
+
+    const calls = readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as string[]);
+    assert(
+      calls.some(
+        (args) =>
+          args[0] === "label" && args[1] === "create" && args[2] === "clawsweeper:bulk-filed",
+      ),
+    );
+    assert(
+      calls.some(
+        (args) =>
+          args[0] === "issue" &&
+          args[1] === "edit" &&
+          args.includes("--add-label") &&
+          args.includes("clawsweeper:bulk-filed"),
+      ),
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("exact event source drift includes a revision change while its apply lease is held", () => {
   assert.equal(
     isExactEventSourceRevisionChange(

--- a/test/bulk-filer-policy.test.ts
+++ b/test/bulk-filer-policy.test.ts
@@ -2,11 +2,12 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
-  activateBulkFilerAfterReviewLeaseForTest,
   bulkFilerThreshold,
   bulkFilerWindowDays,
   detectBulkFilerForTest,
   renderReviewStartStatusComment,
+  syncBulkFilerLabelForTest,
+  updateBulkFilerDetectedFrontMatterForTest,
 } from "../dist/clawsweeper.js";
 import { item } from "./helpers.ts";
 
@@ -19,14 +20,11 @@ test("bulk-filer defaults and positive env overrides are bounded", () => {
   assert.equal(bulkFilerWindowDays({ CLAWSWEEPER_BULK_FILER_WINDOW_DAYS: "nope" }), 7);
 });
 
-test("bulk-filer detection includes the threshold boundary and excludes the exact cutoff", () => {
+test("bulk-filer detection includes the threshold boundary and leaves labeling to publication", () => {
   const now = Date.parse("2026-07-16T12:00:00.000Z");
   let searches = 0;
   const cutoffResult = detectBulkFilerForTest({
-    item: item({
-      number: 43,
-      createdAt: "2026-07-09T12:00:00.000Z",
-    }),
+    item: item({ number: 43, createdAt: "2026-07-09T12:00:00.000Z" }),
     cache: new Map(),
     now,
     searchCount: () => {
@@ -41,12 +39,8 @@ test("bulk-filer detection includes the threshold boundary and excludes the exac
   });
   assert.equal(searches, 0);
 
-  const candidate = item({
-    number: 44,
-    createdAt: "2026-07-09T12:00:00.001Z",
-  });
+  const candidate = item({ number: 44, createdAt: "2026-07-09T12:00:00.001Z" });
   let observedWindowStart = "";
-
   const result = detectBulkFilerForTest({
     item: candidate,
     cache: new Map(),
@@ -66,146 +60,46 @@ test("bulk-filer detection includes the threshold boundary and excludes the exac
   assert.equal(result.labelPending, true);
   assert.equal(result.labelApplied, false);
   assert.equal(candidate.labels.includes("clawsweeper:bulk-filed"), false);
-
-  const mutations: string[] = [];
-  assert.equal(
-    activateBulkFilerAfterReviewLeaseForTest({
-      item: candidate,
-      detection: result,
-      patchTransparency: () => mutations.push("transparency"),
-      applyLabel: () => {
-        mutations.push("label");
-        return true;
-      },
-    }),
-    true,
-  );
-  assert.deepEqual(mutations, ["label", "transparency"]);
-  assert.equal(candidate.labels.includes("clawsweeper:bulk-filed"), true);
-
-  const below = detectBulkFilerForTest({
-    item: item({ number: 45, createdAt: "2026-07-16T00:00:00.000Z" }),
-    cache: new Map(),
-    now,
-    searchCount: () => 9,
-  });
-  assert.deepEqual(below, { context: null, labelPending: false, labelApplied: false });
 });
 
-test("bulk-filer eligibility excludes old issues from prolific authors", () => {
+test("bulk-filer policy exempts only owners and members", () => {
   const now = Date.parse("2026-07-16T12:00:00.000Z");
-  let searches = 0;
-  const oldCandidate = item({
-    number: 46,
-    createdAt: "2026-07-09T11:59:59.999Z",
-  });
-  const oldResult = detectBulkFilerForTest({
-    item: oldCandidate,
+  for (const authorAssociation of ["OWNER", "MEMBER"]) {
+    let searches = 0;
+    const result = detectBulkFilerForTest({
+      item: item({ authorAssociation, createdAt: "2026-07-16T11:59:59.999Z" }),
+      cache: new Map(),
+      now,
+      searchCount: () => {
+        searches += 1;
+        return 16;
+      },
+    });
+    assert.deepEqual(result, { context: null, labelPending: false, labelApplied: false });
+    assert.equal(searches, 0, `${authorAssociation} must not consume a bulk-filer search`);
+  }
+
+  let collaboratorSearches = 0;
+  const collaborator = detectBulkFilerForTest({
+    item: item({ authorAssociation: "COLLABORATOR", createdAt: "2026-07-16T11:59:59.999Z" }),
     cache: new Map(),
     now,
     searchCount: () => {
-      searches += 1;
+      collaboratorSearches += 1;
       return 16;
     },
   });
-
-  assert.deepEqual(oldResult, { context: null, labelPending: false, labelApplied: false });
-  assert.equal(searches, 0);
-  assert.equal(
-    activateBulkFilerAfterReviewLeaseForTest({
-      item: oldCandidate,
-      detection: oldResult,
-      patchTransparency: () => {
-        throw new Error("old issues must not receive transparency");
-      },
-      applyLabel: () => {
-        throw new Error("old issues must not be labeled");
-      },
-    }),
-    false,
-  );
-  assert.equal(oldCandidate.labels.includes("clawsweeper:bulk-filed"), false);
-
-  const freshCandidate = item({
-    number: 47,
-    createdAt: "2026-07-16T11:59:59.999Z",
-  });
-  const freshResult = detectBulkFilerForTest({
-    item: freshCandidate,
-    cache: new Map(),
-    now,
-    searchCount: () => {
-      searches += 1;
-      return 16;
-    },
-  });
-  assert.equal(
-    activateBulkFilerAfterReviewLeaseForTest({
-      item: freshCandidate,
-      detection: freshResult,
-      patchTransparency: () => undefined,
-      applyLabel: () => true,
-    }),
-    true,
-  );
-
-  assert.equal(searches, 1);
-  assert.equal(freshResult.context?.detected, true);
-  assert.equal(freshCandidate.labels.includes("clawsweeper:bulk-filed"), true);
+  assert.equal(collaborator.context?.detected, true);
+  assert.equal(collaboratorSearches, 1);
 });
 
-test("bulk-filer activation omits transparency when label application fails", () => {
-  const candidate = item();
-  const detection = detectBulkFilerForTest({
-    item: candidate,
-    cache: new Map(),
-    now: 0,
-    searchCount: () => 16,
-  });
-  const mutations: string[] = [];
-
-  assert.equal(
-    activateBulkFilerAfterReviewLeaseForTest({
-      item: candidate,
-      detection,
-      applyLabel: () => {
-        mutations.push("label");
-        return false;
-      },
-      patchTransparency: () => mutations.push("transparency"),
-    }),
-    false,
-  );
-  assert.deepEqual(mutations, ["label"]);
-  assert.equal(detection.labelPending, true);
-  assert.equal(detection.labelApplied, false);
-  assert.equal(candidate.labels.includes("clawsweeper:bulk-filed"), false);
-
-  assert.equal(
-    activateBulkFilerAfterReviewLeaseForTest({
-      item: candidate,
-      detection,
-      applyLabel: () => {
-        mutations.push("label");
-        return true;
-      },
-      patchTransparency: () => mutations.push("transparency"),
-    }),
-    true,
-  );
-  assert.deepEqual(mutations, ["label", "label", "transparency"]);
-  assert.equal(detection.labelPending, false);
-  assert.equal(detection.labelApplied, true);
-});
-
-test("bulk-filer detection caches counts per author and fails open", () => {
+test("bulk-filer detection caches counts, fails open, and respects an existing label", () => {
   const cache = new Map();
   let searches = 0;
   const searchCount = () => {
     searches += 1;
     throw new Error("search unavailable");
   };
-
   const first = detectBulkFilerForTest({
     item: item({ author: "Reporter", number: 1 }),
     cache,
@@ -218,51 +112,75 @@ test("bulk-filer detection caches counts per author and fails open", () => {
     now: 0,
     searchCount,
   });
-
   assert.deepEqual(first, { context: null, labelPending: false, labelApplied: false });
   assert.deepEqual(second, { context: null, labelPending: false, labelApplied: false });
   assert.equal(searches, 1);
-});
 
-test("bulk-filer labeling is idempotent", () => {
-  const candidate = item({ labels: ["ClawSweeper:Bulk-Filed"] });
-  const result = detectBulkFilerForTest({
-    item: candidate,
+  const existing = detectBulkFilerForTest({
+    item: item({ labels: ["ClawSweeper:Bulk-Filed"] }),
     cache: new Map(),
     now: 0,
     searchCount: () => 16,
   });
-  let mutations = 0;
-  const applied = activateBulkFilerAfterReviewLeaseForTest({
-    item: candidate,
-    detection: result,
-    patchTransparency: () => {
-      mutations += 1;
-    },
-    applyLabel: () => {
-      mutations += 1;
-      return true;
-    },
-  });
-
-  assert.equal(result.context?.detected, true);
-  assert.equal(result.labelPending, false);
-  assert.equal(result.labelApplied, false);
-  assert.equal(applied, false);
-  assert.equal(mutations, 0);
-  assert.deepEqual(candidate.labels, ["ClawSweeper:Bulk-Filed"]);
+  assert.equal(existing.context?.detected, true);
+  assert.equal(existing.labelPending, false);
+  assert.equal(existing.labelApplied, false);
 });
 
-test("first bulk-filer label application adds polite scheduling transparency", () => {
+test("review-start comments stay neutral when a bulk filer is detected", () => {
   const comment = renderReviewStartStatusComment({
     number: 44,
     kind: "issue",
     title: "Templated report",
-    headSha: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-    bulkFilerLabelApplied: true,
+    headSha: "0123456789abcdef0123456789abcdef0123456789abcdef",
   });
 
-  assert.match(comment, /High filing volume detected/);
-  assert.match(comment, /batched behind other reviews/);
-  assert.match(comment, /Consolidating related reports into fewer issues/);
+  assert.doesNotMatch(comment, /High filing volume detected/);
+  assert.match(comment, /ClawSweeper status: review started/);
+});
+
+test("the publisher applies a detected bulk-filer label only for non-exempt authors", () => {
+  assert.deepEqual(
+    syncBulkFilerLabelForTest({
+      number: 44,
+      labels: [],
+      bulkFilerDetected: true,
+      authorAssociation: "MEMBER",
+      dryRun: true,
+    }),
+    { labels: [], changed: false },
+  );
+  assert.deepEqual(
+    syncBulkFilerLabelForTest({
+      number: 44,
+      labels: [],
+      bulkFilerDetected: true,
+      authorAssociation: "COLLABORATOR",
+      dryRun: true,
+    }),
+    { labels: ["clawsweeper:bulk-filed"], changed: true },
+  );
+  assert.deepEqual(
+    syncBulkFilerLabelForTest({
+      number: 44,
+      labels: ["clawsweeper:bulk-filed", "maintainer"],
+      bulkFilerDetected: false,
+      authorAssociation: "OWNER",
+      dryRun: true,
+    }),
+    { labels: ["maintainer"], changed: true },
+  );
+});
+
+test("cached reports refresh the bulk-filer handoff, including legacy reports", () => {
+  const detected = detectBulkFilerForTest({
+    item: item({ createdAt: "2026-07-16T11:59:59.999Z" }),
+    cache: new Map(),
+    now: Date.parse("2026-07-16T12:00:00.000Z"),
+    searchCount: () => 16,
+  });
+  assert.match(
+    updateBulkFilerDetectedFrontMatterForTest("---\nreview_cache_hit: true\n---\n", detected),
+    /^bulk_filer_detected: true$/m,
+  );
 });

--- a/test/clawsweeper-action-ledger.test.ts
+++ b/test/clawsweeper-action-ledger.test.ts
@@ -500,11 +500,15 @@ test("review candidates start lazily and deferred items cannot remain active", (
     source.indexOf("restoreTreeModes(readonlyModeSnapshots)", reviewCatchStart),
   );
   const cleanup = reviewCatch.indexOf(
-    "deleteOwnedDedicatedReviewStartLease(acquired.itemNumber, acquired.lease)",
+    "releaseOwnedReviewLease(acquired.itemNumber, acquired.lease)",
   );
   const finalization = reviewCatch.indexOf("finishReviewActionLedger({");
   assert.ok(cleanup >= 0);
   assert.ok(finalization > cleanup);
+  assert.match(
+    source,
+    /const releaseOwnedReviewLease = \(itemNumber: number, lease: AcquiredReviewStartLease\): boolean =>[\s\S]*isSuppliedReviewStartLease\(suppliedReviewLease, lease\)[\s\S]*deleteOwnedDedicatedReviewStartLease\(itemNumber, lease\)/,
+  );
 });
 
 test("apply receipts start per item and persist mutation observation before finalization", () => {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2205,6 +2205,8 @@ test("sweep workflow executes only durable queue leases without runner-side admi
   assert.match(legacyIntakeBlock, /statusCommentId: payload\.status_comment_id/);
   assert.match(legacyIntakeBlock, /additionalPrompt: payload\.additional_prompt/);
   assert.match(eventReviewBlock, /cancel-in-progress: false/);
+  assert.match(exactReviewStep, /GH_TOKEN: \$\{\{ steps\.target-read-token\.outputs\.token \}\}/);
+  assert.match(exactReviewStep, /--readonly-openclaw/);
   assert.match(exactReviewStep, /--skip-start-comment/);
   assert.ok(claimIndex >= 0);
   assert.ok(setupPnpmIndex > claimIndex);

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -17,6 +17,7 @@ import { fileURLToPath } from "node:url";
 import {
   defaultReviewArtifactDirForTest,
   exactEventReviewLeaseDispositionForTest,
+  isSuppliedReviewStartLeaseForTest,
   prepareManagedLocalReviewCheckoutForTest,
   reviewLeaseStillMatchesContextForTest,
 } from "../dist/clawsweeper.js";
@@ -123,6 +124,19 @@ test("reserved exact-review leases compare a head only for pull requests", () =>
   assert.equal(reviewLeaseStillMatchesContextForTest("pull_request", revision, revision), true);
   assert.equal(
     reviewLeaseStillMatchesContextForTest("pull_request", "f".repeat(40), revision),
+    false,
+  );
+});
+
+test("only the exact supplied lease is externally owned", () => {
+  const supplied = { owner: "exact-issue-123", commentId: 456 };
+  assert.equal(isSuppliedReviewStartLeaseForTest(supplied, supplied), true);
+  assert.equal(
+    isSuppliedReviewStartLeaseForTest(supplied, { owner: supplied.owner, commentId: 457 }),
+    false,
+  );
+  assert.equal(
+    isSuppliedReviewStartLeaseForTest(supplied, { owner: "shard-123", commentId: 456 }),
     false,
   );
 });

--- a/test/review-comment-rendering.test.ts
+++ b/test/review-comment-rendering.test.ts
@@ -253,7 +253,7 @@ test("semantic cache runs after hydration and revalidates under the acquired lea
   );
   assert.match(
     reviewLoop.slice(priorReviewRevalidation, relationRevalidation),
-    /catch \(error\)[\s\S]*durable_review_refresh_failed[\s\S]*deleteOwnedDedicatedReviewStartLease[\s\S]*acquiredReviewLeases\.splice[\s\S]*continue/,
+    /catch \(error\)[\s\S]*durable_review_refresh_failed[\s\S]*releaseOwnedReviewLease[\s\S]*acquiredReviewLeases\.splice[\s\S]*continue/,
   );
   assert.match(
     reviewLoop.slice(semanticRevalidation, semanticWrite),


### PR DESCRIPTION
## Summary

Moves `clawsweeper:bulk-filed` publication out of the read-token exact-review worker and into the deterministic write-token publisher.

It also exempts only GitHub `OWNER` and `MEMBER` associations from the bulk-filer policy. `COLLABORATOR` remains in scope.

## Problem and live evidence

`#592` intentionally made the exact Codex-review job read-only. `#633` later introduced creation/application of `clawsweeper:bulk-filed` in that same review process. That combination caused the live worker to fail with `HTTP 403: Resource not accessible by integration` when a recent, high-volume issue author reached the bulk-filer branch.

- [#592](https://github.com/openclaw/clawsweeper/pull/592) — exact review uses the target read token.
- [#633](https://github.com/openclaw/clawsweeper/pull/633) — added the bulk-filer policy write.
- Reproduced on [openclaw/openclaw#109684](https://github.com/openclaw/openclaw/issues/109684), author association `MEMBER`, in [run 29600573868](https://github.com/openclaw/clawsweeper/actions/runs/29600573868/job/87951415711).
- Reproduced on [openclaw/openclaw#109911](https://github.com/openclaw/openclaw/issues/109911), in [run 29600572520](https://github.com/openclaw/clawsweeper/actions/runs/29600572520/job/87951409308).
- Related publication/backlog incident: [#635](https://github.com/openclaw/clawsweeper/issues/635).

The failing review worker retried the same forbidden label mutation. This was a GitHub App permission-boundary error, not a Codex, Cloudflare, or runner-capacity failure.

## Implementation

- Keep the exact-review job on its existing read token and remove review-time label/comment mutations.
- Store `bulk_filer_detected` in the review artifact, including every structural/semantic/content cache carry-forward path.
- Apply or remove the policy label in `apply-decisions`, the publisher's write-authorized deterministic lane. A confirmed detection is published even if the model review later fails; normal triage labels remain completion-gated.
- Exempt exactly `OWNER` and `MEMBER`; remove an existing ClawSweeper bulk label if a live owner/member association is encountered.
- Treat only the supplied exact-event lease as externally owned. Normal shard-created leases are still deleted during failure cleanup, including when the checkout is read-only.

## Validation

Completed locally:

```text
pnpm run build
pnpm run lint:src
node --test test/command.test.ts test/bulk-filer-policy.test.ts test/apply-label-sync.test.ts
# 41 passing
git diff --check
```

The apply test exercises a failed exact-review artifact with `bulk_filer_detected: true` and proves that the write lane creates and attaches `clawsweeper:bulk-filed`. Policy tests cover owner/member exemption, collaborator inclusion, stale-label removal, and cached-artifact refresh.

Follow-up CI-contract proof after commit `e73071a798`:

```text
node --test test/clawsweeper-action-ledger.test.ts test/review-comment-rendering.test.ts test/command.test.ts test/bulk-filer-policy.test.ts test/apply-label-sync.test.ts
# 90 passing
pnpm run build
git diff --check
```

The two updated source-contract assertions track the new supplied-lease-safe cleanup helper. They fix the earlier `pnpm check` CI failures without altering production behavior.

Native `pnpm run check` was attempted but cannot execute this repository's intended Linux Bash workflow-helper test surface on this Windows host: its WSL relay has no `/bin/bash`. No platform-policy or test-harness change is included; the controlled Linux proof below exercises the changed runtime path.

## Controlled Linux behavior proof

Two isolated Docker-backed Crabbox local-container runs executed the compiled ClawSweeper CLI from this exact worktree (`mcr.microsoft.com/playwright:v1.60.0-noble`). No live GitHub resource, token, endpoint, or label was used; the redacted adapter rejects unexpected mutations and records only command shapes.

1. Read phase — local-container lease `cbx_9aa222436406`: ran `pnpm run review -- --readonly-openclaw --skip-start-comment` against a fresh Git target with a read-token marker. The real review command collected the issue context, detected bulk filing, and persisted its failed-artifact handoff (`bulk_filer_detected: true`) after an intentionally stopped Codex process. The adapter rejects any GitHub mutation; none was attempted.
2. Publisher phase — local-container lease `cbx_ff0fd7cdf125`: ran `pnpm run apply-decisions` against that artifact with an isolated write-token marker. The real compiled publisher created and attached `clawsweeper:bulk-filed`; its normal durable-comment synchronization also completed. The assertion passed only when both expected policy-label calls used the write marker.

The command-level evidence proves the changed read/write handoff and that the formerly forbidden label write is absent from the read worker. It is deliberately a controlled terminal proof, not a claim that a production GitHub App token was issued locally.

`pnpm run test:unit` was also attempted but did not finish within the local two-minute command window; this PR does not claim that broad suite as passing.

Codex review closeout:

```text
codex review --uncommitted
# clean after addressing four accepted findings:
# cached handoff freshness; stale maintainer labels; supplied-lease ownership;
# and failed-artifact publication.

git fetch origin main --prune
codex review --base origin/main
# clean: handoff and supplied-lease ownership are internally consistent.

# Follow-up test-contract commit:
codex review --uncommitted
# clean: expectations correctly track the supplied-lease-safe helper.
codex review --base origin/main
# clean: no actionable correctness defects found.
```

## Risk and rollout

No permission is broadened for Codex review. The only GitHub mutations remain in the publisher's existing write-token lane. Existing queued/retried artifacts carrying `bulk_filer_detected: true` are eligible for label publication on their next deterministic publisher attempt; this does not requeue or rewrite unrelated reviews.
