### PR TITLE
fix(validation): prevent identity timeouts in linked pnpm workspaces

### DIFF
--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -2468,6 +2468,7 @@ function validationRuntimeInputsSha256(cwd: string, deadlineAt: number) {
   const root = fs.realpathSync(cwd);
   const runtimePaths = validationRuntimeInputPaths(cwd, deadlineAt);
   updateIdentityHash(hash, "runtime-input-paths", runtimePaths.join("\0"));
+  const coveredEntries = new Map<string, string>();
   for (const relativePath of runtimePaths) {
     assertValidationIdentityDeadline(deadlineAt, relativePath);
     const entryPath = path.join(root, relativePath);
@@ -2479,7 +2480,7 @@ function validationRuntimeInputsSha256(cwd: string, deadlineAt: number) {
       updateIdentityHash(hash, "runtime-state", "absent");
       continue;
     }
-    updateRuntimeInputDigest(hash, root, entryPath, relativePath, deadlineAt, new Map());
+    updateRuntimeInputDigest(hash, root, entryPath, relativePath, deadlineAt, coveredEntries);
   }
   assertValidationIdentityDeadline(deadlineAt, "runtime input digest");
   return hash.digest("hex");

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -3713,6 +3713,44 @@ test(
 );
 
 test(
+  "runtime identity deduplicates shared symlink targets across ignored roots",
+  { skip: process.platform === "win32" },
+  () => {
+    const cwd = gitPackageFixture({ check: 'node -e ""' });
+    fs.appendFileSync(path.join(cwd, ".gitignore"), "runtime-input/\n");
+    const runtimeInput = path.join(cwd, "runtime-input", "state.js");
+    fs.mkdirSync(path.dirname(runtimeInput), { recursive: true });
+    fs.writeFileSync(runtimeInput, "safe\n");
+    for (const dependency of ["first", "second"]) {
+      const dependencyDir = path.join(cwd, "node_modules", dependency);
+      fs.mkdirSync(dependencyDir, { recursive: true });
+      fs.symlinkSync(
+        path.relative(dependencyDir, runtimeInput),
+        path.join(dependencyDir, "state.js"),
+      );
+    }
+    git(cwd, "add", ".");
+    git(cwd, "commit", "-m", "initial");
+
+    const originalOpenSync = fs.openSync;
+    let runtimeInputOpenCount = 0;
+    fs.openSync = ((filePath, flags, mode) => {
+      if (path.resolve(String(filePath)) === runtimeInput && flags === "r") {
+        runtimeInputOpenCount += 1;
+      }
+      return originalOpenSync(filePath, flags, mode);
+    }) as typeof fs.openSync;
+    try {
+      captureTargetCheckoutBinding(cwd);
+    } finally {
+      fs.openSync = originalOpenSync;
+    }
+
+    assert.equal(runtimeInputOpenCount, 1);
+  },
+);
+
+test(
   "pnpm setup rejects prepared executables that escape through symlinks",
   { skip: process.platform === "win32" },
   () => {


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/108974

Follow-up context: https://github.com/openclaw/clawsweeper/pull/649

## What Problem This Solves

Fixes an issue where linked pnpm workspaces could make ClawSweeper's repair/automerge validation time out while proving checkout identity. When multiple ignored runtime roots reached the same real files through workspace symlinks, ClawSweeper repeatedly traversed and hashed those files instead of recognizing that their contents were already covered.

This was the next independent blocker observed while validating the repair path for https://github.com/openclaw/openclaw/pull/108974 after the lockfile-integrity false positive addressed by https://github.com/openclaw/clawsweeper/pull/649.

## Why This Change Was Made

Runtime identity traversal now shares realpath coverage across all ignored runtime roots in one identity calculation. Every logical root and symlink remains represented in the identity hash, while the contents of a shared real target are read once. The change does not alter validation policy, approved destinations, or the checkout identity contract.

## User Impact

Repair and automerge validation can complete for linked pnpm workspaces whose ignored roots overlap through symlinks, instead of exhausting the identity deadline by repeatedly walking the same `node_modules` graph. Mutations to the shared target remain detectable.

## Evidence

The regression, affected tests, and exact reporter path all demonstrate the duplicate traversal before the change and successful identity completion afterward.

### Regression test

The new test creates two ignored dependency paths that both link to the same ignored runtime file and counts actual file opens.

- Before the fix: `AssertionError: 2 !== 1`
- After the fix: the shared target is opened exactly once.

Focused affected tests:

```text
validation binds ignored runtime symlink target contents between commands
runtime identity handles pnpm symlink graphs without duplicate traversal
runtime identity deduplicates shared symlink targets across ignored roots
3 passed
```

### Reporter-path reproduction

Validated against the exact head of https://github.com/openclaw/openclaw/pull/108974:

```text
HEAD=34a3001388bb99fb4a041a73aad98631c4557634
```

Before this change, checkout identity did not finish within the normal 12-minute deadline and still timed out with a 30-minute deadline while repeatedly traversing workspace links into the same root `node_modules` graph.

After this change:

```text
PROOF_TIMEOUT_MS=720000
PROOF_RESULT=PASSED
PROOF_ELAPSED_SECONDS=75.0
PROOF_RUNTIME_INPUT_SHA256=8bce30f8f3b3d3b2201a53856c37230724b3174226e8e20dd349dbe39a62c065
```

### Repository checks

Passed:

- `pnpm run build:all`
- `pnpm run lint`
- `pnpm run format:check`
- Independent `codex review --base origin/main`: no findings

`pnpm run check` was also run once. It reached the unit suite with 1,313 passing and 1 skipped tests, but the local environment reported six unrelated failures: five require the unavailable `jq` executable, and one pre-existing 7ms deadline test timed out in `git rev-parse --git-common-dir` on the host's Git 2.27. The complete `target-validation` test file included the new regression as passing when run with the local Git compatibility wrapper; the focused affected tests above passed.
