### PR TITLE
fix: honor elevated maintainer roles in bulk-filer policy

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -428,6 +428,11 @@ const MAINTAINER_AUTHOR_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR
 // policy: repository owners and members can legitimately create high volumes
 // of coordinated issues, while outside collaborators remain in scope.
 const BULK_FILER_EXEMPT_AUTHOR_ASSOCIATIONS = new Set(["OWNER", "MEMBER"]);
+// GitHub can redact an organization member's issue author_association to
+// CONTRIBUTOR for an App installation token. Elevated repository roles are a
+// narrow, independently readable fallback for that case; ordinary write
+// collaborators remain subject to the bulk-filer policy.
+const BULK_FILER_EXEMPT_REPOSITORY_PERMISSIONS = new Set(["admin", "maintain"]);
 
 interface GitHubUser {
   login?: string;
@@ -478,6 +483,7 @@ export interface BulkFilerDetectionResult {
 }
 
 type BulkFilerCountCache = Map<string, number | null>;
+type BulkFilerRepositoryPermissionCache = Map<string, string | null>;
 
 interface BulkFilerDetectionOptions {
   item: Pick<Item, "author" | "authorAssociation" | "createdAt" | "kind" | "labels" | "number">;
@@ -4140,6 +4146,13 @@ function isBulkFilerExemptAuthorAssociation(value: unknown): boolean {
   return BULK_FILER_EXEMPT_AUTHOR_ASSOCIATIONS.has(normalizeAuthorAssociation(value));
 }
 
+function isBulkFilerExemptRepositoryPermission(value: unknown): boolean {
+  return (
+    typeof value === "string" &&
+    BULK_FILER_EXEMPT_REPOSITORY_PERMISSIONS.has(value.trim().toLowerCase())
+  );
+}
+
 function isMaintainerAuthored(item: Pick<Item, "authorAssociation">): boolean {
   return isMaintainerAuthorAssociation(item.authorAssociation);
 }
@@ -6517,6 +6530,23 @@ export function updateBulkFilerDetectedFrontMatterForTest(
   return updateBulkFilerDetectedFrontMatter(markdown, detection);
 }
 
+function bulkFilerPolicyInvalidatesCachedReview(
+  markdown: string | null,
+  exemptionApplied: boolean,
+): boolean {
+  if (!exemptionApplied || markdown === null) return false;
+  // Legacy reports predate this field. Refresh them once rather than preserving
+  // a possibly bulk-filer-suppressed cached verdict under the new exemption.
+  return !/^false$/i.test(frontMatterValue(markdown, "last_full_review_bulk_filer_detected") ?? "");
+}
+
+export function bulkFilerPolicyInvalidatesCachedReviewForTest(
+  markdown: string | null,
+  exemptionApplied: boolean,
+): boolean {
+  return bulkFilerPolicyInvalidatesCachedReview(markdown, exemptionApplied);
+}
+
 function authorIssueCountInBulkFilerWindow(author: string, windowStart: string): number {
   const query = [
     `repo:${targetRepo()}`,
@@ -6535,6 +6565,38 @@ function authorIssueCountInBulkFilerWindow(author: string, windowStart: string):
     throw new Error("GitHub bulk-filer search omitted a valid total_count");
   }
   return Number(result.total_count);
+}
+
+function bulkFilerRepositoryPermission(
+  author: string,
+  cache: BulkFilerRepositoryPermissionCache,
+): string | null {
+  const normalizedAuthor = author.trim().toLowerCase();
+  if (!normalizedAuthor) return null;
+  if (cache.has(normalizedAuthor)) return cache.get(normalizedAuthor) ?? null;
+  let permission: string | null = null;
+  try {
+    const result = ghJson<{
+      permission?: unknown;
+      role_name?: unknown;
+      user?: { role_name?: unknown };
+    }>([
+      "api",
+      `repos/${targetRepo()}/collaborators/${encodeURIComponent(normalizedAuthor)}/permission`,
+    ]);
+    const roleName = result.role_name ?? result.user?.role_name;
+    permission =
+      typeof roleName === "string"
+        ? roleName.toLowerCase()
+        : typeof result.permission === "string"
+          ? result.permission.toLowerCase()
+          : null;
+  } catch {
+    // A read-token lookup failure must not broaden the exemption.
+    permission = null;
+  }
+  cache.set(normalizedAuthor, permission);
+  return permission;
 }
 
 function quoteGitHubSearchTerm(term: string): string {
@@ -14231,11 +14293,15 @@ function syncBulkFilerLabel(options: {
   labels: readonly string[];
   bulkFilerDetected: boolean;
   authorAssociation: string;
+  repositoryPermission?: string | null;
   dryRun: boolean;
   onMutation?: () => void;
 }): { labels: string[]; changed: boolean } {
   const hasBulkFilerLabel = hasNormalizedLabel(options.labels, BULK_FILED_LABEL);
-  if (isBulkFilerExemptAuthorAssociation(options.authorAssociation)) {
+  if (
+    isBulkFilerExemptAuthorAssociation(options.authorAssociation) ||
+    isBulkFilerExemptRepositoryPermission(options.repositoryPermission)
+  ) {
     if (!hasBulkFilerLabel) return { labels: [...options.labels], changed: false };
     // This is ClawSweeper policy state, not a human triage label. Remove a
     // pre-exemption value so owners and members are not still deprioritized.
@@ -14266,6 +14332,7 @@ export function syncBulkFilerLabelForTest(options: {
   labels: readonly string[];
   bulkFilerDetected: boolean;
   authorAssociation: string;
+  repositoryPermission?: string | null;
   dryRun: boolean;
 }): { labels: string[]; changed: boolean } {
   return syncBulkFilerLabel(options);
@@ -21219,6 +21286,7 @@ item_snapshot_hash: ${options.snapshotHash}
 review_content_digest: ${options.contentDigest}
 last_full_review_at: ${reviewedAt}
 last_full_review_decision: ${options.decision.decision}
+last_full_review_bulk_filer_detected: ${options.context.bulkFiler?.detected === true}
 review_cache_hit: false
 review_structural_cache_version: ${options.structuralRecord?.version ?? "unknown"}
 review_structural_fingerprint: ${options.structuralRecord?.fingerprint ?? "unknown"}
@@ -22654,6 +22722,7 @@ function reviewCommand(args: Args): void {
     let semanticCacheRevalidationMs = 0;
     let hydrationRuns = 0;
     const bulkFilerCountCache: BulkFilerCountCache = new Map();
+    const bulkFilerRepositoryPermissionCache: BulkFilerRepositoryPermissionCache = new Map();
     const bulkFilerWindowNow = Date.now();
     const structuralCacheReasons = new Map<string, number>();
     const structuralCacheRevalidationReasons = new Map<string, number>();
@@ -22696,7 +22765,30 @@ function reviewCommand(args: Args): void {
         );
       }
       const existingPriorReview = localRangeData ? null : existingReview(item, itemsDir);
-      const priorReview =
+      const lastFullReviewBulkFilerState = frontMatterValue(
+        existingPriorReview?.markdown ?? "",
+        "last_full_review_bulk_filer_detected",
+      );
+      const lastFullReviewBulkFilerStateMayNeedRecheck =
+        existingPriorReview !== null && !/^false$/i.test(lastFullReviewBulkFilerState ?? "");
+      const needsBulkFilerPermissionLookup =
+        !localOnly &&
+        item.kind === "issue" &&
+        !isBulkFilerExemptAuthorAssociation(item.authorAssociation) &&
+        (bulkFilerDetection.context?.detected || lastFullReviewBulkFilerStateMayNeedRecheck);
+      const bulkFilerExemptionApplied =
+        item.kind === "issue" &&
+        (isBulkFilerExemptAuthorAssociation(item.authorAssociation) ||
+          (needsBulkFilerPermissionLookup &&
+            isBulkFilerExemptRepositoryPermission(
+              bulkFilerRepositoryPermission(item.author, bulkFilerRepositoryPermissionCache),
+            )));
+      if (bulkFilerDetection.context?.detected && bulkFilerExemptionApplied) {
+        bulkFilerDetection.context = null;
+        bulkFilerDetection.labelPending = false;
+        bulkFilerDetection.labelApplied = false;
+      }
+      let priorReview =
         item.kind === "pull_request" &&
         existingPriorReview &&
         !isReviewedPrActivityCursor(
@@ -22704,6 +22796,11 @@ function reviewCommand(args: Args): void {
         )
           ? null
           : existingPriorReview;
+      if (bulkFilerPolicyInvalidatesCachedReview(priorReview?.markdown ?? null, bulkFilerExemptionApplied)) {
+        // A prior full review was made under a now-inapplicable bulk-filer policy.
+        // Re-run it instead of refreshing its cached suppression fields.
+        priorReview = null;
+      }
       const expectedPreviousReviewDigest = priorReview
         ? previousClawSweeperReviewDigestFromReport(priorReview.markdown)
         : null;
@@ -26165,6 +26262,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
       : {}),
   };
   const startedAtMs = Date.now();
+  const bulkFilerRepositoryPermissionCache: BulkFilerRepositoryPermissionCache = new Map();
   const requestedItemNumbers = itemNumbersArg(args.item_numbers, args.item_number);
   const requestedItemNumberSet = new Set(requestedItemNumbers);
   const requestedItemOrder = orderedApplyItemNumbers(args.item_numbers, args.item_number);
@@ -28340,11 +28438,19 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
         continue;
       }
       try {
+        const bulkFilerDetected = frontMatterBoolean(markdown, "bulk_filer_detected");
+        const needsBulkFilerPermissionLookup =
+          item.kind === "issue" &&
+          !isBulkFilerExemptAuthorAssociation(item.authorAssociation) &&
+          (bulkFilerDetected || hasNormalizedLabel(item.labels, BULK_FILED_LABEL));
         const bulkFilerSyncResult = syncBulkFilerLabel({
           number,
           labels: item.labels,
-          bulkFilerDetected: frontMatterBoolean(markdown, "bulk_filer_detected"),
+          bulkFilerDetected,
           authorAssociation: item.authorAssociation,
+          repositoryPermission: needsBulkFilerPermissionLookup
+            ? bulkFilerRepositoryPermission(item.author, bulkFilerRepositoryPermissionCache)
+            : null,
           dryRun,
           onMutation: recordMutation,
         });

--- a/test/apply-label-sync.test.ts
+++ b/test/apply-label-sync.test.ts
@@ -129,6 +129,8 @@ if (args[0] === "api" && /\\/issues\\/${number}$/.test(path)) {
   }
 } else if (args[0] === "issue" && args[1] === "view") {
   console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
+} else if (args[0] === "api" && /\\/collaborators\\/contributor\\/permission$/.test(path)) {
+  console.log(JSON.stringify({ permission: "read", role_name: "read" }));
 } else if (args[0] === "label" && args[1] === "create") {
   console.log(JSON.stringify({ name: args[2] }));
 } else if (args[0] === "issue" && args[1] === "edit") {
@@ -167,6 +169,126 @@ if (args[0] === "api" && /\\/issues\\/${number}$/.test(path)) {
           args.includes("--add-label") &&
           args.includes("clawsweeper:bulk-filed"),
       ),
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-decisions clears a stale bulk-filer label for a redacted maintain role", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const logPath = join(root, "gh.log");
+    const number = 74487;
+    const reviewedAt = new Date().toISOString();
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    writeFileSync(
+      join(itemsDir, `${number}.md`),
+      `${reportFrontMatter({
+        repository: "openclaw/clawsweeper",
+        type: "issue",
+        number: String(number),
+        title: "Clear stale bulk-filer label",
+        url: `https://github.com/openclaw/clawsweeper/issues/${number}`,
+        decision: "keep_open",
+        close_reason: "none",
+        confidence: "high",
+        action_taken: "kept_open",
+        review_status: "failed",
+        local_checkout_access: "verified",
+        author: "maintainer",
+        author_association: "CONTRIBUTOR",
+        labels: JSON.stringify(["clawsweeper:bulk-filed"]),
+        bulk_filer_detected: "true",
+        item_snapshot_hash: "snapshot-a",
+        item_updated_at: reviewedAt,
+        reviewed_at: reviewedAt,
+      })}
+
+## Summary
+
+This exact review inherited a stale bulk-filer label.
+`,
+      "utf8",
+    );
+    const ghMock = `
+const { appendFileSync } = require("fs");
+const logPath = ${JSON.stringify(logPath)};
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+appendFileSync(logPath, JSON.stringify(args) + "\\n");
+const path = args[1] || "";
+if (args[0] === "api" && /\\/issues\\/${number}$/.test(path)) {
+  console.log(JSON.stringify({
+    number: ${number},
+    title: "Clear stale bulk-filer label",
+    html_url: "https://github.com/openclaw/clawsweeper/issues/${number}",
+    created_at: "2026-07-17T00:00:00Z",
+    updated_at: ${JSON.stringify(reviewedAt)},
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "maintainer" },
+    labels: ["clawsweeper:bulk-filed"],
+    comments: 0,
+    pull_request: null
+  }));
+} else if (args[0] === "api" && /\\/issues\\/${number}\\/timeline(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/issues\\/${number}\\/comments(?:\\?|$)/.test(path)) {
+  if (args.includes("--method") && args.includes("POST")) {
+    console.log(JSON.stringify({
+      id: 987487,
+      html_url: "https://github.com/openclaw/clawsweeper/issues/${number}#issuecomment-987487"
+    }));
+  } else {
+    console.log(JSON.stringify([[]]));
+  }
+} else if (args[0] === "issue" && args[1] === "view") {
+  console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
+} else if (args[0] === "api" && /\\/collaborators\\/maintainer\\/permission$/.test(path)) {
+  console.log(JSON.stringify({ permission: "write", role_name: "maintain" }));
+} else if (args[0] === "issue" && args[1] === "edit") {
+  console.log("");
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: ["--sync-comments-only", "--item-numbers", String(number)],
+      });
+    });
+
+    const calls = readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as string[]);
+    assert(
+      calls.some(
+        (args) =>
+          args[0] === "issue" &&
+          args[1] === "edit" &&
+          args.includes("--remove-label") &&
+          args.includes("clawsweeper:bulk-filed"),
+      ),
+    );
+    assert.equal(
+      calls.some((args) => args[0] === "label" && args[1] === "create"),
+      false,
     );
   } finally {
     rmSync(root, { recursive: true, force: true });

--- a/test/bulk-filer-policy.test.ts
+++ b/test/bulk-filer-policy.test.ts
@@ -5,6 +5,7 @@ import {
   bulkFilerThreshold,
   bulkFilerWindowDays,
   detectBulkFilerForTest,
+  bulkFilerPolicyInvalidatesCachedReviewForTest,
   renderReviewStartStatusComment,
   syncBulkFilerLabelForTest,
   updateBulkFilerDetectedFrontMatterForTest,
@@ -170,6 +171,39 @@ test("the publisher applies a detected bulk-filer label only for non-exempt auth
     }),
     { labels: ["maintainer"], changed: true },
   );
+  assert.deepEqual(
+    syncBulkFilerLabelForTest({
+      number: 44,
+      labels: ["clawsweeper:bulk-filed", "maintainer"],
+      bulkFilerDetected: true,
+      authorAssociation: "CONTRIBUTOR",
+      repositoryPermission: "maintain",
+      dryRun: true,
+    }),
+    { labels: ["maintainer"], changed: true },
+  );
+  assert.deepEqual(
+    syncBulkFilerLabelForTest({
+      number: 44,
+      labels: ["clawsweeper:bulk-filed", "maintainer"],
+      bulkFilerDetected: true,
+      authorAssociation: "CONTRIBUTOR",
+      repositoryPermission: "admin",
+      dryRun: true,
+    }),
+    { labels: ["maintainer"], changed: true },
+  );
+  assert.deepEqual(
+    syncBulkFilerLabelForTest({
+      number: 44,
+      labels: [],
+      bulkFilerDetected: true,
+      authorAssociation: "CONTRIBUTOR",
+      repositoryPermission: "write",
+      dryRun: true,
+    }),
+    { labels: ["clawsweeper:bulk-filed"], changed: true },
+  );
 });
 
 test("cached reports refresh the bulk-filer handoff, including legacy reports", () => {
@@ -182,5 +216,33 @@ test("cached reports refresh the bulk-filer handoff, including legacy reports", 
   assert.match(
     updateBulkFilerDetectedFrontMatterForTest("---\nreview_cache_hit: true\n---\n", detected),
     /^bulk_filer_detected: true$/m,
+  );
+});
+
+test("a newly exempt maintainer bypasses a cached bulk-filer review", () => {
+  assert.equal(
+    bulkFilerPolicyInvalidatesCachedReviewForTest(
+      "---\nbulk_filer_detected: false\nlast_full_review_bulk_filer_detected: true\nreview_cache_hit: false\n---\n",
+      true,
+    ),
+    true,
+  );
+  assert.equal(
+    bulkFilerPolicyInvalidatesCachedReviewForTest(
+      "---\nbulk_filer_detected: true\nlast_full_review_bulk_filer_detected: false\nreview_cache_hit: false\n---\n",
+      true,
+    ),
+    false,
+  );
+  assert.equal(
+    bulkFilerPolicyInvalidatesCachedReviewForTest("---\nreview_cache_hit: false\n---\n", true),
+    true,
+  );
+  assert.equal(
+    bulkFilerPolicyInvalidatesCachedReviewForTest(
+      "---\nlast_full_review_bulk_filer_detected: true\nreview_cache_hit: false\n---\n",
+      false,
+    ),
+    false,
   );
 });


### PR DESCRIPTION
## Summary

Prevent the bulk-filer policy from incorrectly labelling an organisation maintainer when GitHub's App-token issue payload redacts their `author_association` as `CONTRIBUTOR`.

## Problem

After [#657](https://github.com/openclaw/clawsweeper/pull/657) moved bulk-filer mutation into the write-capable publisher, live evidence for [openclaw/openclaw#109684](https://github.com/openclaw/openclaw/issues/109684) showed a discrepancy:

- the persisted/App-visible item state and an unauthenticated public-equivalent REST response said `CONTRIBUTOR`;
- an authenticated maintainer API response said `MEMBER`;
- the repository collaborator-permission API reported the author as `admin`.

That made a legitimate high-volume maintainer issue eligible for `clawsweeper:bulk-filed`. A normal contributor ([openclaw/openclaw#109911](https://github.com/openclaw/openclaw/issues/109911)) returned `read` and must remain eligible. Historical labels were corrected manually; this PR is preventative only.

## Implementation

- Add a lazy, cached collaborator-permission fallback for only bulk-filer candidate **issues** whose author association is not already owner/member.
- Exempt only `admin` and `maintain`; ordinary `write` collaborators remain within the policy.
- Keep the publisher as the sole label mutator and remove a stale ClawSweeper-owned bulk label when the elevated role is detected.
- Persist the bulk-filer state from the last full review. When the exemption makes a cached, bulk-suppressed review stale, force exactly one new full review rather than reusing that cache entry.
- Fail closed on a permission lookup failure, preserving the existing policy rather than broadening the exemption.

## Validation

```text
pnpm run build
node --test test/bulk-filer-policy.test.ts test/apply-label-sync.test.ts
pnpm run lint:src
pnpm exec oxfmt --check src/clawsweeper.ts test/bulk-filer-policy.test.ts test/apply-label-sync.test.ts
git diff --check
```

All passed: 32 focused tests. The integration proof exercises the write-side publisher removing a stale label for an App-redacted `maintain` role and verifies it does not create a label. Unit proof covers `admin`, `maintain`, and ordinary `write`.

Linux local-container Crabbox proof also passed on lease `cbx_68e92e0efbf3` (`mcr.microsoft.com/playwright:v1.60.0-noble`): `pnpm run build` and all 11 `test/local-range-review.test.ts` tests.

Codex review closeout:

- `codex review --uncommitted` — clean; accepted and corrected the cache-transition, legacy-report, local-only, and issue-only edge cases during the review loop.
- `codex review --base origin/main` — clean: no actionable correctness issues identified.

## Evidence

- [#109684 worker](https://github.com/openclaw/clawsweeper/actions/runs/29609443086) and [publisher](https://github.com/openclaw/clawsweeper/actions/runs/29609574146)
- [#109911 worker](https://github.com/openclaw/clawsweeper/actions/runs/29609548303) and [publisher](https://github.com/openclaw/clawsweeper/actions/runs/29609706238)
- Related: [#657](https://github.com/openclaw/clawsweeper/pull/657)

## Risk / rollout

The additional API read is lazy, cached per author, issue-only, and limited to already eligible bulk-filer candidates. It does not change workflow scopes, gates, or normal contributor treatment. No historical GitHub state is changed by this PR.
