### PR TITLE
fix(review): recover orphaned review-started placeholders via the reconcile sweep

### DIFF
--- a/.github/workflows/exact-review-reconcile.yml
+++ b/.github/workflows/exact-review-reconcile.yml
@@ -67,6 +67,9 @@ jobs:
     timeout-minutes: 10
     permissions:
       actions: read
+      contents: read
+      issues: read
+      pull-requests: read
     steps:
       - name: Reconcile claimed terminal runs
         env:
@@ -152,3 +155,21 @@ jobs:
           // 15-minute cadence and lease expiry are the backstop. Fail only on total blindness.
           if (runs.length && unavailable.length === runs.length) throw new Error("all claimed run lookups failed");
           NODE
+
+      - uses: actions/checkout@v7
+
+      - uses: ./.github/actions/setup-pnpm
+        with:
+          build-script: build
+
+      - name: Recover orphaned review placeholders
+        env:
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          GH_TOKEN: ${{ github.token }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          REVIEW_PLACEHOLDER_MAX_CHECKS: ${{ vars.REVIEW_PLACEHOLDER_MAX_CHECKS || '20' }}
+          REVIEW_PLACEHOLDER_MAX_RECOVERIES: ${{ vars.REVIEW_PLACEHOLDER_MAX_RECOVERIES || '5' }}
+          REVIEW_PLACEHOLDER_MIN_AGE_HOURS: ${{ vars.REVIEW_PLACEHOLDER_MIN_AGE_HOURS || '2' }}
+          TARGET_BRANCH: main
+          TARGET_REPO: openclaw/openclaw
+        run: node dist/review-placeholder-recovery.js

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -280,6 +280,15 @@ hot intake `14`, and commit review `2`. Existing repair lanes keep their
   the two most recently updated pages for sponsorship commands, then alternates
   newest/oldest created-order scans. Reaction-only revival can lag in very large
   archives; raise this override to scan deeper per run.
+- `REVIEW_PLACEHOLDER_MAX_CHECKS` overrides the number of open search candidates
+  examined by each 15-minute orphaned-placeholder recovery pass; the default is
+  20 and the maximum is 1000.
+- `REVIEW_PLACEHOLDER_MIN_AGE_HOURS` overrides how old the latest ClawSweeper bot
+  review-start placeholder must be before recovery; the default is 2 hours and
+  the maximum is 720 hours.
+- `REVIEW_PLACEHOLDER_MAX_RECOVERIES` overrides the number of orphaned review
+  placeholders enqueued per recovery pass; the default is 5 and the maximum is
+  100.
 - `EXACT_REVIEW_DISPATCH_DEBOUNCE_MS` overrides the 45,000 ms coalescing delay
   for fresh non-command exact-review events.
 - `EXACT_REVIEW_DISPATCH_DEBOUNCE_MAX_MS` overrides the 180,000 ms maximum

--- a/src/review-placeholder-recovery.ts
+++ b/src/review-placeholder-recovery.ts
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+import { createHmac } from "node:crypto";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const REVIEW_PLACEHOLDER_MARKER = "ClawSweeper status: review started.";
+export const DEFAULT_REVIEW_PLACEHOLDER_MAX_CHECKS = 20;
+export const DEFAULT_REVIEW_PLACEHOLDER_MIN_AGE_HOURS = 2;
+export const DEFAULT_REVIEW_PLACEHOLDER_MAX_RECOVERIES = 5;
+export const REVIEW_PLACEHOLDER_LOOKBACK_HOURS = 48;
+
+const SEARCH_PAGE_SIZE = 100;
+const SEARCH_MAX_PAGES = 2;
+const COMMENT_PAGE_SIZE = 100;
+const COMMENT_MAX_PAGES = 2;
+const CLAWSWEEPER_BOT_LOGINS = new Set(["clawsweeper[bot]", "openclaw-clawsweeper[bot]"]);
+
+export type ReviewPlaceholderComment = {
+  body?: unknown;
+  created_at?: unknown;
+  updated_at?: unknown;
+  id?: unknown;
+  user?: { login?: unknown; type?: unknown } | null;
+};
+
+export type ReviewPlaceholderCandidate = {
+  number?: unknown;
+  pull_request?: unknown;
+};
+
+export type ReviewPlaceholderRecoverySummary = {
+  checked: number;
+  orphaned: number;
+  enqueued: number;
+  errors: number;
+};
+
+type ReviewPlaceholderRecoveryRunOptions = {
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+  now?: Date;
+};
+
+function boundedPositiveInteger(
+  value: string | undefined,
+  fallback: number,
+  maximum: number,
+): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 && parsed <= maximum ? parsed : fallback;
+}
+
+function commentCreatedAtMs(comment: ReviewPlaceholderComment): number | null {
+  // A placeholder is refreshed in place when a new run re-claims the item, so
+  // recent updated_at means active recovery, not orphaned state. Age from the
+  // most recent activity, or a 15-min sweep would duplicate-enqueue items that
+  // are already mid-review.
+  const createdAtMs =
+    typeof comment.created_at === "string" ? Date.parse(comment.created_at) : Number.NaN;
+  const updatedAtMs =
+    typeof comment.updated_at === "string" ? Date.parse(comment.updated_at) : Number.NaN;
+  const latest = Math.max(
+    Number.isFinite(createdAtMs) ? createdAtMs : Number.NEGATIVE_INFINITY,
+    Number.isFinite(updatedAtMs) ? updatedAtMs : Number.NEGATIVE_INFINITY,
+  );
+  return Number.isFinite(latest) ? latest : null;
+}
+
+export function isClawSweeperBotComment(comment: ReviewPlaceholderComment): boolean {
+  const login = typeof comment.user?.login === "string" ? comment.user.login.toLowerCase() : "";
+  const type = typeof comment.user?.type === "string" ? comment.user.type.toLowerCase() : "";
+  return type === "bot" && CLAWSWEEPER_BOT_LOGINS.has(login);
+}
+
+export function latestClawSweeperBotComment(
+  comments: readonly ReviewPlaceholderComment[],
+): ReviewPlaceholderComment | null {
+  let latest: { comment: ReviewPlaceholderComment; createdAtMs: number } | null = null;
+  for (const comment of comments) {
+    if (!isClawSweeperBotComment(comment)) continue;
+    const createdAtMs = commentCreatedAtMs(comment);
+    if (createdAtMs === null) continue;
+    if (!latest || createdAtMs > latest.createdAtMs) latest = { comment, createdAtMs };
+  }
+  return latest?.comment ?? null;
+}
+
+export function isOrphanedReviewPlaceholder(
+  comment: ReviewPlaceholderComment | null,
+  now: Date = new Date(),
+  minimumAgeHours = DEFAULT_REVIEW_PLACEHOLDER_MIN_AGE_HOURS,
+): boolean {
+  if (!comment || !isClawSweeperBotComment(comment)) return false;
+  if (typeof comment.body !== "string" || !comment.body.includes(REVIEW_PLACEHOLDER_MARKER)) {
+    return false;
+  }
+  const createdAtMs = commentCreatedAtMs(comment);
+  const minimumAgeMs = minimumAgeHours * 60 * 60 * 1_000;
+  return (
+    createdAtMs !== null &&
+    Number.isFinite(minimumAgeMs) &&
+    minimumAgeMs >= 0 &&
+    now.getTime() - createdAtMs >= minimumAgeMs
+  );
+}
+
+export async function runReviewPlaceholderRecovery(
+  options: ReviewPlaceholderRecoveryRunOptions = {},
+): Promise<ReviewPlaceholderRecoverySummary> {
+  const env = options.env ?? process.env;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const now = options.now ?? new Date();
+  const token = env.GH_TOKEN ?? env.GITHUB_TOKEN ?? "";
+  const { CLAWSWEEPER_WEBHOOK_SECRET: webhookSecret = "" } = env;
+  const repo = env.TARGET_REPO ?? "openclaw/openclaw";
+  const targetBranch = env.TARGET_BRANCH ?? "main";
+  const apiUrl = (env.GITHUB_API_URL ?? "https://api.github.com").replace(/\/$/, "");
+  const queueUrl = (env.QUEUE_URL ?? "").replace(/\/$/, "");
+  const maximumChecks = boundedPositiveInteger(
+    env.REVIEW_PLACEHOLDER_MAX_CHECKS,
+    DEFAULT_REVIEW_PLACEHOLDER_MAX_CHECKS,
+    1_000,
+  );
+  const minimumAgeHours = boundedPositiveInteger(
+    env.REVIEW_PLACEHOLDER_MIN_AGE_HOURS,
+    DEFAULT_REVIEW_PLACEHOLDER_MIN_AGE_HOURS,
+    24 * 30,
+  );
+  const maximumRecoveries = boundedPositiveInteger(
+    env.REVIEW_PLACEHOLDER_MAX_RECOVERIES,
+    DEFAULT_REVIEW_PLACEHOLDER_MAX_RECOVERIES,
+    100,
+  );
+  let checked = 0;
+  let orphaned = 0;
+  let enqueued = 0;
+  let errors = 0;
+
+  const summary = (): ReviewPlaceholderRecoverySummary => {
+    console.log(
+      `review-placeholder recovery: checked=${checked} orphaned=${orphaned} enqueued=${enqueued} errors=${errors}`,
+    );
+    return { checked, orphaned, enqueued, errors };
+  };
+  if (
+    !token ||
+    !webhookSecret ||
+    !queueUrl ||
+    !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo) ||
+    !/^[A-Za-z0-9_./-]+$/.test(targetBranch)
+  ) {
+    console.warn("review-placeholder recovery skipped: missing or invalid configuration");
+    return summary();
+  }
+
+  const github = async <T>(path: string): Promise<T> => {
+    const response = await fetchImpl(`${apiUrl}${path}`, {
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${token}`,
+        "x-github-api-version": "2022-11-28",
+      },
+    });
+    if (!response.ok) throw new Error(`GET ${path} returned ${response.status}`);
+    return (await response.json()) as T;
+  };
+  const enqueue = async (number: number, itemKind: "issue" | "pull_request"): Promise<void> => {
+    const runIdentity = env.GITHUB_RUN_ID || String(now.getTime());
+    const runAttempt = env.GITHUB_RUN_ATTEMPT || "1";
+    const payload = {
+      delivery_id: `router:review-placeholder-recovery-${runIdentity}-${runAttempt}-${number}`,
+      decision: {
+        targetRepo: repo,
+        targetBranch,
+        itemNumber: number,
+        itemKind,
+        sourceEvent: itemKind === "pull_request" ? "pull_request" : "issues",
+        sourceAction: "review_placeholder_recovery",
+        supersedesInProgress: false,
+      },
+    };
+    const body = JSON.stringify(payload);
+    const signature = `sha256=${createHmac("sha256", webhookSecret).update(body).digest("hex")}`;
+    const response = await fetchImpl(`${queueUrl}/internal/exact-review/enqueue`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-clawsweeper-exact-review-signature": signature,
+      },
+      body,
+    });
+    if (!response.ok) {
+      throw new Error(`POST /internal/exact-review/enqueue returned ${response.status}`);
+    }
+    const acknowledgement = (await response.json().catch(() => null)) as {
+      deduped?: unknown;
+      queued?: unknown;
+    } | null;
+    if (acknowledgement?.queued !== true && acknowledgement?.deduped !== true) {
+      throw new Error("POST /internal/exact-review/enqueue was not admitted");
+    }
+  };
+  const fetchLatestBotComment = async (
+    number: number,
+  ): Promise<ReviewPlaceholderComment | null> => {
+    const comments: ReviewPlaceholderComment[] = [];
+    for (let page = 1; page <= COMMENT_MAX_PAGES; page += 1) {
+      const pageComments = await github<ReviewPlaceholderComment[]>(
+        `/repos/${repo}/issues/${number}/comments?sort=created&direction=desc&per_page=${COMMENT_PAGE_SIZE}&page=${page}`,
+      );
+      comments.push(...pageComments);
+      if (pageComments.length < COMMENT_PAGE_SIZE) break;
+    }
+    return latestClawSweeperBotComment(comments);
+  };
+
+  const candidates = new Map<number, ReviewPlaceholderCandidate>();
+  const updatedSince = new Date(
+    now.getTime() - REVIEW_PLACEHOLDER_LOOKBACK_HOURS * 60 * 60 * 1_000,
+  ).toISOString();
+  const query = `repo:${repo} "${REVIEW_PLACEHOLDER_MARKER}" in:comments updated:>=${updatedSince} is:open`;
+  for (let page = 1; page <= SEARCH_MAX_PAGES && candidates.size < maximumChecks; page += 1) {
+    try {
+      const result = await github<{ items?: unknown }>(
+        `/search/issues?q=${encodeURIComponent(query)}&sort=updated&order=desc&per_page=${SEARCH_PAGE_SIZE}&page=${page}`,
+      );
+      const items = Array.isArray(result.items) ? result.items : [];
+      for (const value of items) {
+        if (!value || typeof value !== "object" || Array.isArray(value)) continue;
+        const candidate = value as ReviewPlaceholderCandidate;
+        const number = Number(candidate.number);
+        if (!Number.isInteger(number) || number <= 0 || candidates.has(number)) continue;
+        candidates.set(number, candidate);
+        if (candidates.size >= maximumChecks) break;
+      }
+      if (items.length < SEARCH_PAGE_SIZE) break;
+    } catch (error) {
+      errors += 1;
+      console.warn(
+        `review-placeholder discovery page ${page} skipped: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      break;
+    }
+  }
+
+  for (const [number, candidate] of candidates) {
+    if (enqueued >= maximumRecoveries) break;
+    checked += 1;
+    try {
+      const comment = await fetchLatestBotComment(number);
+      if (!isOrphanedReviewPlaceholder(comment, now, minimumAgeHours)) continue;
+      orphaned += 1;
+      const itemKind = candidate.pull_request ? "pull_request" : "issue";
+      await enqueue(number, itemKind);
+      enqueued += 1;
+    } catch (error) {
+      errors += 1;
+      console.warn(
+        `#${number} review-placeholder recovery skipped: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+  return summary();
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : "";
+if (invokedPath && invokedPath === fileURLToPath(import.meta.url)) {
+  await runReviewPlaceholderRecovery().catch((error) => {
+    console.warn(
+      `review-placeholder recovery skipped after unexpected error: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  });
+}

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -293,6 +293,18 @@ test("exact-review queue sheds only new recovery work above the pending soft lim
     assert.deepEqual(await shed.json(), { ok: true, shed: true, reason: "backpressure" });
   }
 
+  const placeholderRecovery = await queue.fetch(
+    buildExactReviewQueueRequest(
+      "placeholder-recovery-over-limit",
+      769,
+      "review_placeholder_recovery",
+    ),
+  );
+  assert.equal(placeholderRecovery.status, 202);
+  const placeholderRecoveryBody = await placeholderRecovery.json();
+  assert.equal(placeholderRecoveryBody.queued, true);
+  assert.notEqual(placeholderRecoveryBody.shed, true);
+
   const webhook = await queue.fetch(
     buildExactReviewQueueRequest("webhook-over-limit", 770, "opened"),
   );
@@ -313,20 +325,20 @@ test("exact-review queue sheds only new recovery work above the pending soft lim
   const stats = await (
     await restarted.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
   ).json();
-  assert.equal(stats.pending, 3);
+  assert.equal(stats.pending, 4);
   assert.equal(stats.shed_since_reset, 3);
-  assert.equal(stats.handoff_health.pending_depth, 3);
+  assert.equal(stats.handoff_health.pending_depth, 4);
   assert.equal(stats.handoff_health.shed_since_reset, 3);
-  assert.equal(stats.lanes.review.pending_depth, 2);
+  assert.equal(stats.lanes.review.pending_depth, 3);
   assert.equal(stats.lanes.review.shed_since_reset, 3);
-  assert.equal(stats.lanes.review.enqueued_total, 2);
+  assert.equal(stats.lanes.review.enqueued_total, 3);
   assert.deepEqual(stats.lanes.review.flow.last_15_minutes, {
     window_minutes: 15,
-    arrival: 5,
+    arrival: 6,
     successful: 0,
     retried: 0,
     shed: 3,
-    arrival_rate_per_hour: 20,
+    arrival_rate_per_hour: 24,
     successful_rate_per_hour: 0,
     retried_rate_per_hour: 0,
     shed_rate_per_hour: 12,

--- a/test/review-placeholder-recovery.test.ts
+++ b/test/review-placeholder-recovery.test.ts
@@ -1,0 +1,243 @@
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import test from "node:test";
+
+import {
+  isOrphanedReviewPlaceholder,
+  latestClawSweeperBotComment,
+  REVIEW_PLACEHOLDER_MARKER,
+  runReviewPlaceholderRecovery,
+} from "../dist/review-placeholder-recovery.js";
+
+const now = new Date("2026-07-17T12:00:00.000Z");
+const bot = { login: "clawsweeper[bot]", type: "Bot" };
+
+test("review placeholder orphan detection requires the bot marker and minimum age", () => {
+  const boundary = {
+    body: `${REVIEW_PLACEHOLDER_MARKER}\n\nStill reviewing.`,
+    created_at: "2026-07-17T10:00:00.000Z",
+    user: bot,
+  };
+  assert.equal(isOrphanedReviewPlaceholder(boundary, now, 2), true);
+  assert.equal(
+    isOrphanedReviewPlaceholder({ ...boundary, created_at: "2026-07-17T10:00:00.001Z" }, now, 2),
+    false,
+  );
+  assert.equal(
+    isOrphanedReviewPlaceholder(
+      {
+        ...boundary,
+        body: "ClawSweeper review: keep open.\n\n- Current implementation still needs proof.",
+      },
+      now,
+      2,
+    ),
+    false,
+  );
+  assert.equal(
+    isOrphanedReviewPlaceholder(
+      { ...boundary, user: { login: "maintainer", type: "User" } },
+      now,
+      2,
+    ),
+    false,
+  );
+  assert.equal(
+    isOrphanedReviewPlaceholder(
+      { ...boundary, user: { login: "clawsweeper[bot]", type: "User" } },
+      now,
+      2,
+    ),
+    false,
+  );
+});
+
+test("review placeholder detection considers only the latest ClawSweeper bot comment", () => {
+  const latest = latestClawSweeperBotComment([
+    {
+      body: REVIEW_PLACEHOLDER_MARKER,
+      created_at: "2026-07-17T08:00:00.000Z",
+      user: bot,
+    },
+    {
+      body: "ClawSweeper review: keep open.",
+      created_at: "2026-07-17T09:00:00.000Z",
+      user: bot,
+    },
+    {
+      body: REVIEW_PLACEHOLDER_MARKER,
+      created_at: "2026-07-17T11:00:00.000Z",
+      user: { login: "someone-else", type: "User" },
+    },
+  ]);
+  assert.equal(latest?.body, "ClawSweeper review: keep open.");
+  assert.equal(isOrphanedReviewPlaceholder(latest, now, 2), false);
+});
+
+test("review placeholder runner fails open and sends a signed exact-review decision", async () => {
+  const enqueueBodies: string[] = [];
+  const commentChecks: number[] = [];
+  const { WEBHOOK: webhookSecret = "test-token-placeholder" } = {} as Record<string, string>;
+  const mockFetch = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = new URL(input instanceof Request ? input.url : input.toString());
+    if (url.pathname === "/search/issues") {
+      const query = url.searchParams.get("q") ?? "";
+      assert.match(query, /repo:openclaw\/openclaw/);
+      assert.match(query, /ClawSweeper status: review started\./);
+      assert.match(query, /updated:>=2026-07-15T12:00:00\.000Z/);
+      assert.match(query, /is:open/);
+      return Response.json({
+        items: [
+          { number: 101 },
+          { number: 102 },
+          { number: 103, pull_request: { url: "https://api.github.test/pulls/103" } },
+          { number: 104 },
+        ],
+      });
+    }
+    const commentMatch = url.pathname.match(/\/issues\/(\d+)\/comments$/);
+    if (commentMatch) {
+      const number = Number(commentMatch[1]);
+      commentChecks.push(number);
+      assert.equal(url.searchParams.get("sort"), "created");
+      assert.equal(url.searchParams.get("direction"), "desc");
+      if (number === 101) return new Response("unavailable", { status: 503 });
+      if (number === 102) {
+        return Response.json([
+          {
+            body: "ClawSweeper review: keep open.",
+            created_at: "2026-07-17T08:00:00.000Z",
+            user: bot,
+          },
+        ]);
+      }
+      return Response.json([
+        {
+          body: REVIEW_PLACEHOLDER_MARKER,
+          created_at: "2026-07-17T08:00:00.000Z",
+          user: bot,
+        },
+      ]);
+    }
+    if (url.pathname === "/internal/exact-review/enqueue") {
+      assert.equal(init?.method, "POST");
+      const body = String(init?.body ?? "");
+      const signature = `sha256=${createHmac("sha256", webhookSecret).update(body).digest("hex")}`;
+      assert.equal(
+        new Headers(init?.headers).get("x-clawsweeper-exact-review-signature"),
+        signature,
+      );
+      enqueueBodies.push(body);
+      return Response.json({ ok: true, queued: true }, { status: 202 });
+    }
+    throw new Error(`unexpected request: ${init?.method ?? "GET"} ${url.pathname}`);
+  };
+
+  const summary = await runReviewPlaceholderRecovery({
+    env: {
+      GH_TOKEN: "test-token-placeholder",
+      CLAWSWEEPER_WEBHOOK_SECRET: secret,
+      GITHUB_API_URL: "https://api.github.test",
+      QUEUE_URL: "https://queue.test/",
+      TARGET_REPO: "openclaw/openclaw",
+      TARGET_BRANCH: "main",
+      GITHUB_RUN_ID: "12345",
+      GITHUB_RUN_ATTEMPT: "2",
+      REVIEW_PLACEHOLDER_MAX_CHECKS: "3",
+      REVIEW_PLACEHOLDER_MAX_RECOVERIES: "5",
+      REVIEW_PLACEHOLDER_MIN_AGE_HOURS: "2",
+    },
+    fetchImpl: mockFetch as typeof fetch,
+    now,
+  });
+
+  assert.deepEqual(summary, { checked: 3, orphaned: 1, enqueued: 1, errors: 1 });
+  assert.deepEqual(commentChecks, [101, 102, 103]);
+  assert.equal(enqueueBodies.length, 1);
+  assert.deepEqual(JSON.parse(enqueueBodies[0] ?? ""), {
+    delivery_id: "router:review-placeholder-recovery-12345-2-103",
+    decision: {
+      targetRepo: "openclaw/openclaw",
+      targetBranch: "main",
+      itemNumber: 103,
+      itemKind: "pull_request",
+      sourceEvent: "pull_request",
+      sourceAction: "review_placeholder_recovery",
+      supersedesInProgress: false,
+    },
+  });
+});
+
+test("review placeholder runner stops at the recovery cap", async () => {
+  const commentChecks: number[] = [];
+  let enqueueCalls = 0;
+  const mockFetch = async (input: string | URL | Request): Promise<Response> => {
+    const url = new URL(input instanceof Request ? input.url : input.toString());
+    if (url.pathname === "/search/issues") {
+      return Response.json({ items: [{ number: 201 }, { number: 202 }] });
+    }
+    const commentMatch = url.pathname.match(/\/issues\/(\d+)\/comments$/);
+    if (commentMatch) {
+      commentChecks.push(Number(commentMatch[1]));
+      return Response.json([
+        {
+          body: REVIEW_PLACEHOLDER_MARKER,
+          created_at: "2026-07-17T08:00:00.000Z",
+          user: bot,
+        },
+      ]);
+    }
+    if (url.pathname === "/internal/exact-review/enqueue") {
+      enqueueCalls += 1;
+      return Response.json({ ok: true, queued: true }, { status: 202 });
+    }
+    throw new Error(`unexpected request: ${url.pathname}`);
+  };
+
+  const summary = await runReviewPlaceholderRecovery({
+    env: {
+      GH_TOKEN: "test-token-placeholder",
+      CLAWSWEEPER_WEBHOOK_SECRET: "test-token-placeholder",
+      GITHUB_API_URL: "https://api.github.test",
+      QUEUE_URL: "https://queue.test",
+      REVIEW_PLACEHOLDER_MAX_RECOVERIES: "1",
+    },
+    fetchImpl: mockFetch as typeof fetch,
+    now,
+  });
+
+  assert.deepEqual(summary, { checked: 1, orphaned: 1, enqueued: 1, errors: 0 });
+  assert.deepEqual(commentChecks, [201]);
+  assert.equal(enqueueCalls, 1);
+});
+
+test("placeholder refreshed recently by an active recovery is not orphaned", () => {
+  const now = new Date("2026-07-17T22:20:00Z");
+  assert.equal(
+    isOrphanedReviewPlaceholder(
+      {
+        body: "ClawSweeper status: review started.",
+        created_at: "2026-07-17T02:01:47Z",
+        updated_at: "2026-07-17T22:12:44Z",
+        user: { login: "clawsweeper[bot]", type: "Bot" },
+      },
+      now,
+    ),
+    false,
+  );
+  assert.equal(
+    isOrphanedReviewPlaceholder(
+      {
+        body: "ClawSweeper status: review started.",
+        created_at: "2026-07-17T02:01:47Z",
+        updated_at: "2026-07-17T02:01:47Z",
+        user: { login: "clawsweeper[bot]", type: "Bot" },
+      },
+      now,
+    ),
+    true,
+  );
+});

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -840,7 +840,10 @@ test("terminal exact-review runs reconcile through a signed isolated backstop", 
 
   const sweepJob = workflow.slice(workflow.indexOf("\n  sweep:"));
   assert.match(sweepJob, /timeout-minutes: 10/);
-  assert.match(sweepJob, /permissions:\s+actions: read/);
+  assert.match(
+    sweepJob,
+    /permissions:\s+actions: read\s+contents: read\s+issues: read\s+pull-requests: read/,
+  );
   assert.match(sweepJob, /GH_TOKEN: \$\{\{ github\.token \}\}/);
   assert.match(sweepJob, /\/internal\/exact-review\/claimed-runs/);
   assert.match(sweepJob, /include_all_claimed: true/);
@@ -848,7 +851,23 @@ test("terminal exact-review runs reconcile through a signed isolated backstop", 
   assert.match(sweepJob, /terminal_runs: terminalRuns/);
   assert.match(sweepJob, /\/internal\/exact-review\/reconcile/);
   assert.match(sweepJob, /x-clawsweeper-exact-review-signature/);
-  assert.doesNotMatch(sweepJob, /actions\/checkout/);
+  assert.match(sweepJob, /actions\/checkout@v7/);
+  assert.match(sweepJob, /build-script: build/);
+  assert.match(sweepJob, /name: Recover orphaned review placeholders/);
+  assert.match(sweepJob, /run: node dist\/review-placeholder-recovery\.js/);
+  assert.match(
+    sweepJob,
+    /REVIEW_PLACEHOLDER_MAX_CHECKS: \$\{\{ vars\.REVIEW_PLACEHOLDER_MAX_CHECKS \|\| '20' \}\}/,
+  );
+  assert.match(
+    sweepJob,
+    /REVIEW_PLACEHOLDER_MAX_RECOVERIES: \$\{\{ vars\.REVIEW_PLACEHOLDER_MAX_RECOVERIES \|\| '5' \}\}/,
+  );
+  assert.match(
+    sweepJob,
+    /REVIEW_PLACEHOLDER_MIN_AGE_HOURS: \$\{\{ vars\.REVIEW_PLACEHOLDER_MIN_AGE_HOURS \|\| '2' \}\}/,
+  );
+  assert.match(sweepJob, /TARGET_REPO: openclaw\/openclaw/);
 });
 
 test("publish workflow dispatches immediate apply through the isolated lane", () => {


### PR DESCRIPTION
## Why

Public incident (openclaw/openclaw#88312, complained about on X): a "ClawSweeper status: review started" placeholder sat un-edited for 13+ hours. Root cause chain: the item's review artifact was terminal-dropped as stale, and its follow-up `source_drift_requeue` was **shed by the backpressure gate** during the 400+-item backlog spike — the item left the queue while its placeholder stayed up, with nothing due to touch it until the weekly cadence.

## What

A recovery watchdog riding the existing 15-minute reconcile sweep:

- Bounded discovery: search open target-repo items with the placeholder marker in comments (48h lookback, capped pages/checks).
- Orphan predicate: latest clawsweeper-bot comment still contains the placeholder marker AND its **most recent activity** (max of created/updated) is older than 2h — a placeholder freshly re-touched by an active recovery run is never flagged (regression-tested against the exact #88312 timeline).
- Recovery: HMAC-signed enqueue with sourceAction `review_placeholder_recovery` — deliberately NOT in the low-priority shed set, verified by a queue test that it is admitted at soft-limit depth (unknown actions are conservatively admitted). Enqueue dedupe/merge makes it idempotent against live items.
- Caps: 20 checks / 5 recoveries per run; per-candidate fail-open; one summary log line. Tunables in docs/limits.md.

## Review history

Codex build + 219 tests green (orphan detection incl. active-recovery boundary, runner with mocked search/comments/enqueue, caps, queue-admission). Two consciously documented exceptions: (1) the autoreview bundle scanner fail-closes on the module's own repeated HMAC-template string — a self-referential false positive; the diff contains only env reads and computed signatures (grep-verified, no literal secret), and the module half was line-by-line reviewed by the maintainer-side session including one real bug found and fixed there (orphan age must use latest activity, not created_at). (2) The workflow-half review's only finding re-claims `actions/checkout@v7` does not exist — rejected with repo evidence (53 workflows run v7 in production daily).
