### PR TITLE
test(review): fix stray reference broken by a rename in the placeholder recovery test

### DIFF
--- a/test/review-placeholder-recovery.test.ts
+++ b/test/review-placeholder-recovery.test.ts
@@ -139,7 +139,7 @@ test("review placeholder runner fails open and sends a signed exact-review decis
   const summary = await runReviewPlaceholderRecovery({
     env: {
       GH_TOKEN: "test-token-placeholder",
-      CLAWSWEEPER_WEBHOOK_SECRET: secret,
+      CLAWSWEEPER_WEBHOOK_SECRET: webhookSecret,
       GITHUB_API_URL: "https://api.github.test",
       QUEUE_URL: "https://queue.test/",
       TARGET_REPO: "openclaw/openclaw",


### PR DESCRIPTION
One missed reference from the webhookSecret rename in #661 (ReferenceError: secret is not defined) — broke pnpm check on main. Full test file now 5/5 locally; no behavior change.