### PR TITLE
fix(validation): repair workers reject valid workspace installs

### DIFF
--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -2439,8 +2439,7 @@ function worktreeContentSha256(cwd: string, deadlineAt: number) {
       throw error;
     }
     updateIdentityHash(hash, "worktree-path", relativePath);
-    const worktreeMode =
-      trackedPaths.has(relativePath) && stat.isFile() ? trackedFileMode(stat.mode) : stat.mode;
+    const worktreeMode = stat.isFile() ? gitFileMode(stat.mode) : stat.mode;
     updateIdentityHash(hash, "worktree-mode", String(worktreeMode));
     if (stat.isSymbolicLink()) {
       updateIdentityHash(hash, "worktree-symlink", fs.readlinkSync(absolutePath));
@@ -2468,7 +2467,7 @@ function worktreeContentSha256(cwd: string, deadlineAt: number) {
   return hash.digest("hex");
 }
 
-function trackedFileMode(mode: number) {
+function gitFileMode(mode: number) {
   return mode & 0o100 ? 0o100755 : 0o100644;
 }
 

--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -2439,7 +2439,9 @@ function worktreeContentSha256(cwd: string, deadlineAt: number) {
       throw error;
     }
     updateIdentityHash(hash, "worktree-path", relativePath);
-    updateIdentityHash(hash, "worktree-mode", String(stat.mode));
+    const worktreeMode =
+      trackedPaths.has(relativePath) && stat.isFile() ? trackedFileMode(stat.mode) : stat.mode;
+    updateIdentityHash(hash, "worktree-mode", String(worktreeMode));
     if (stat.isSymbolicLink()) {
       updateIdentityHash(hash, "worktree-symlink", fs.readlinkSync(absolutePath));
       updateSymlinkTargetDigest(
@@ -2464,6 +2466,10 @@ function worktreeContentSha256(cwd: string, deadlineAt: number) {
   }
   assertValidationIdentityDeadline(deadlineAt, "worktree digest");
   return hash.digest("hex");
+}
+
+function trackedFileMode(mode: number) {
+  return mode & 0o100 ? 0o100755 : 0o100644;
 }
 
 function validationRuntimeInputsSha256(cwd: string, deadlineAt: number) {
@@ -3244,23 +3250,33 @@ function updateSymlinkTargetDigest(
   }
   assertPathWithin(root, targetPath, logicalPath);
   updateIdentityHash(hash, "symlink-target-path", path.relative(root, targetPath));
-  const workspaceReference = trackedWorkspaceSelfLink(root, symlinkPath, targetPath, trackedPaths);
-  if (workspaceReference) {
-    updateIdentityHash(hash, "symlink-workspace-reference", workspaceReference);
+  const trackedReference = trackedSymlinkTargetReference(
+    root,
+    symlinkPath,
+    targetPath,
+    trackedPaths,
+  );
+  if (trackedReference) {
+    updateIdentityHash(hash, "symlink-tracked-reference", trackedReference);
     return;
   }
   updateResolvedPathDigest(hash, root, targetPath, logicalPath, deadlineAt, new Set());
 }
 
-function trackedWorkspaceSelfLink(
+function trackedSymlinkTargetReference(
   root: string,
   symlinkPath: string,
   targetPath: string,
   trackedPaths: ReadonlySet<string>,
 ) {
-  if (!fs.statSync(targetPath).isDirectory()) return null;
   const relativeLink = path.relative(root, symlinkPath).split(path.sep).join("/");
   if (!trackedPaths.has(relativeLink)) return null;
+  const targetRelative = path.relative(root, targetPath).split(path.sep).join("/");
+  const targetStat = fs.statSync(targetPath);
+  if (targetStat.isFile()) {
+    return trackedPaths.has(targetRelative) ? `file\0${targetRelative}` : null;
+  }
+  if (!targetStat.isDirectory()) return null;
   const linkParts = relativeLink.split("/");
   const nodeModulesIndex = linkParts.lastIndexOf("node_modules");
   const packageParts = linkParts.slice(nodeModulesIndex + 1);
@@ -3272,16 +3288,6 @@ function trackedWorkspaceSelfLink(
         : null;
   if (!packageName) return null;
 
-  const linkFromTarget = path.relative(targetPath, symlinkPath);
-  if (
-    !linkFromTarget ||
-    linkFromTarget.startsWith(`..${path.sep}`) ||
-    path.isAbsolute(linkFromTarget)
-  ) {
-    return null;
-  }
-
-  const targetRelative = path.relative(root, targetPath).split(path.sep).join("/");
   const manifestRelative = targetRelative ? `${targetRelative}/package.json` : "package.json";
   if (!trackedPaths.has(manifestRelative)) return null;
   try {
@@ -3291,9 +3297,9 @@ function trackedWorkspaceSelfLink(
     return null;
   }
   // Source identity already binds tracked/untracked worktree content, ignored runtime inputs,
-  // and Git administrative state. Recording this authenticated back-reference avoids an
-  // infinite walk without allowing mutable target content to disappear from the identity.
-  return `${packageName}\0${targetRelative}`;
+  // and Git administrative state. Recording this authenticated workspace reference avoids
+  // duplicate traversal without allowing mutable target content to disappear from the identity.
+  return `workspace\0${packageName}\0${targetRelative}`;
 }
 
 function updateResolvedPathDigest(

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -5244,6 +5244,127 @@ test(
 );
 
 test(
+  "dependency setup accepts tracked links between workspaces with ignored runtime changes",
+  { skip: process.platform === "win32" },
+  () => {
+    const cwd = gitPackageFixture({ check: 'node -e ""' });
+    const dependencyDir = path.join(cwd, "packages", "dependency");
+    const dependencySource = path.join(dependencyDir, "source.js");
+    fs.mkdirSync(dependencyDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dependencyDir, "package.json"),
+      `${JSON.stringify({ name: "@fixture/dependency" }, null, 2)}\n`,
+    );
+    fs.writeFileSync(dependencySource, "export const value = 1;\n");
+    const dependencyLink = path.join(
+      cwd,
+      "packages",
+      "consumer",
+      "node_modules",
+      "@fixture",
+      "dependency",
+    );
+    fs.mkdirSync(path.dirname(dependencyLink), { recursive: true });
+    fs.symlinkSync(path.relative(path.dirname(dependencyLink), dependencyDir), dependencyLink);
+    git(cwd, "add", "--force", ".");
+    git(cwd, "commit", "-m", "initial");
+
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workspace-install-"));
+    const corepackPath = path.join(binDir, "corepack.js");
+    const pnpmPath = path.join(binDir, "pnpm.js");
+    const runtimeInput = path.join(dependencyDir, "node_modules", "generated", "state.js");
+    fs.writeFileSync(corepackPath, "");
+    fs.writeFileSync(
+      pnpmPath,
+      `const fs = require("node:fs");
+fs.mkdirSync(${JSON.stringify(path.dirname(runtimeInput))}, { recursive: true });
+fs.writeFileSync(${JSON.stringify(runtimeInput)}, "installed\\n");
+`,
+    );
+
+    withMockCommand("corepack", corepackPath, () =>
+      withMockCommand("pnpm", pnpmPath, () =>
+        prepareTargetToolchain(cwd, {
+          ...validationOptions("steipete/example", {
+            toolchain: {
+              packageManager: "pnpm",
+              baseValidationCommands: ["pnpm check"],
+              changedGate: null,
+            },
+          }),
+          installTargetDeps: true,
+          installTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
+          setupTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
+        }),
+      ),
+    );
+
+    const accepted = captureTargetCheckoutBinding(cwd);
+    fs.writeFileSync(dependencySource, "export const value = 2;\n");
+    assert.throws(
+      () => assertTargetCheckoutBinding(cwd, accepted),
+      /target checkout changed after validation/,
+    );
+    fs.writeFileSync(dependencySource, "export const value = 1;\n");
+    fs.writeFileSync(runtimeInput, "mutated\n");
+    assert.throws(
+      () => assertTargetCheckoutBinding(cwd, accepted),
+      /target checkout changed after validation/,
+    );
+  },
+);
+
+test(
+  "dependency setup accepts Git-equivalent tracked executable mode normalization",
+  { skip: process.platform === "win32" },
+  () => {
+    const cwd = gitPackageFixture({ check: 'node -e ""' });
+    const executablePath = path.join(cwd, "cli.js");
+    fs.writeFileSync(executablePath, "#!/usr/bin/env node\n");
+    fs.chmodSync(executablePath, 0o775);
+    const executableLink = path.join(cwd, "node_modules", ".bin", "cli");
+    fs.mkdirSync(path.dirname(executableLink), { recursive: true });
+    fs.symlinkSync(path.relative(path.dirname(executableLink), executablePath), executableLink);
+    git(cwd, "add", ".");
+    git(cwd, "add", "--force", executableLink);
+    git(cwd, "commit", "-m", "initial");
+
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-mode-install-"));
+    const corepackPath = path.join(binDir, "corepack.js");
+    const pnpmPath = path.join(binDir, "pnpm.js");
+    fs.writeFileSync(corepackPath, "");
+    fs.writeFileSync(
+      pnpmPath,
+      `require("node:fs").chmodSync(${JSON.stringify(executablePath)}, 0o755);\n`,
+    );
+
+    withMockCommand("corepack", corepackPath, () =>
+      withMockCommand("pnpm", pnpmPath, () =>
+        prepareTargetToolchain(cwd, {
+          ...validationOptions("steipete/example", {
+            toolchain: {
+              packageManager: "pnpm",
+              baseValidationCommands: ["pnpm check"],
+              changedGate: null,
+            },
+          }),
+          installTargetDeps: true,
+          installTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
+          setupTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
+        }),
+      ),
+    );
+
+    const accepted = captureTargetCheckoutBinding(cwd);
+    fs.chmodSync(executablePath, 0o644);
+    assert.throws(
+      () => assertTargetCheckoutBinding(cwd, accepted),
+      /target checkout changed after validation/,
+    );
+  },
+);
+
+test(
   "validation rejects untracked node_modules workspace self-links",
   { skip: process.platform === "win32" },
   () => {

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -4218,6 +4218,9 @@ test("final checkout binding preserves validated content across host commit", ()
   git(cwd, "commit", "-m", "initial");
   fs.writeFileSync(path.join(cwd, "source.txt"), "validated\n");
   fs.writeFileSync(path.join(cwd, "new.txt"), "validated\n");
+  // A host commit starts tracking new repair files without changing their
+  // working-tree permissions, so both identity captures must use Git modes.
+  fs.chmodSync(path.join(cwd, "new.txt"), 0o664);
   fs.rmSync(path.join(cwd, "deleted.txt"));
   const accepted = captureTargetCheckoutBinding(cwd);
 


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/108974
Failed repair run: https://github.com/openclaw/clawsweeper/actions/runs/29623139111

## What Problem This Solves

Fixes an issue where repair workers could stop with `target dependency setup mutated checkout identity` after a normal dependency install. This occurred when pnpm populated ignored runtime files through tracked workspace links or normalized the non-Git permission bits of a tracked executable.

## Why This Change Was Made

Checkout identity now uses Git's executable/non-executable mode semantics for tracked regular files and records authenticated references for tracked symlinks to tracked files or matching tracked workspaces. Untracked, mismatched, external, and non-`node_modules` workspace links remain fail-closed.

## User Impact

Repair workers can continue past dependency setup when the install only creates expected ignored runtime state or normalizes Git-equivalent executable permissions. Actual tracked source changes, executable-bit changes, later ignored runtime changes, and unsafe symlink targets are still detected.

## Evidence

- Both regression tests failed on `main` with `target dependency setup mutated checkout identity` before the fix and pass after it.
- Focused coverage includes tracked cross-workspace links, Git-equivalent `0775` to `0755` normalization, tracked source mutation, executable-bit removal, later ignored runtime mutation, and the existing untracked/mismatched/external symlink rejection cases.
- Reporter-path proof used OpenClaw PR head `34a3001388bb99fb4a041a73aad98631c4557634` with pnpm `11.2.2`. A real `pnpm install` completed, checkout validation passed, non-runtime identity fields were unchanged, and runtime inputs changed as expected:

  ```text
  PROOF_HEAD=34a3001388bb99fb4a041a73aad98631c4557634
  PROOF_RESULT=PASSED
  PROOF_ELAPSED_SECONDS=318.562
  NON_RUNTIME_CHANGED={}
  RUNTIME_CHANGED=true
  AFTER_RUNTIME_INPUT_SHA256=2224f9e54e02f891c8f533f6609be60dc80527fbc1c588b2b13e380fee6bcdde
  ```

- `pnpm run build:all`, `pnpm run lint`, `pnpm run format:check`, and `git diff --check` passed on Node `v24.16.0`.
- The full target-validation file reported 142 passed, 3 skipped, and 13 local environment failures (Corepack network timeouts, older fixture Git behavior, and deadline-sensitive tests); the new and adjacent safety tests passed.
- `pnpm run check` reached 1327 passed, 1 skipped, and 5 failures caused by `jq` not being installed locally. Build and lint stages passed; formatting was run separately and passed.
- A final `codex review --base origin/main` reported no actionable findings.

Remote Crabbox/Testbox proof was not available in this environment, so the provider boundary is not claimed here.
