### PR TITLE
fix(repair): stabilize prepared target runtime identity

### DIFF
--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -367,7 +367,10 @@ function preparePnpmToolchain({
 }) {
   const packageManager = targetPnpmPackageManager(packageJson);
   const corepackBin = path.join(String(validationEnv.COREPACK_HOME), "bin");
-  run("corepack", ["enable", "--install-directory", corepackBin], {
+  // Restrict Corepack to pnpm. Enabling every supported manager also creates
+  // Yarn shims that are outside this pnpm-only runtime's trust boundary and
+  // makes a clean target setup fail while freezing the prepared runtime.
+  run("corepack", ["enable", "--install-directory", corepackBin, "pnpm"], {
     cwd,
     env: validationEnv,
     timeoutMs: targetToolchainCommandTimeout(deadlineAt, setupTimeoutMs, "corepack enable"),
@@ -1143,15 +1146,13 @@ export function runAllowedValidationCommandsWithBinding(
       baseRef,
       Date.now() + validationTimeoutMs,
     );
+    const currentSourceIdentity = sourceIdentityFromCheckout(checkoutIdentity);
     if (
       preparedPnpmRuntime &&
-      !sameValidationSourceIdentity(
-        sourceIdentityFromCheckout(checkoutIdentity),
-        preparedPnpmRuntime.sourceIdentity,
-      )
+      !sameValidationSourceIdentity(currentSourceIdentity, preparedPnpmRuntime.sourceIdentity)
     ) {
       throw new Error(
-        "prepared target pnpm toolchain is stale; refresh dependencies before validation",
+        `prepared target pnpm toolchain is stale; refresh dependencies before validation: ${validationSourceIdentityMismatchFields(currentSourceIdentity, preparedPnpmRuntime.sourceIdentity).join(", ")}`,
       );
     }
     const executed: string[] = [];
@@ -2331,7 +2332,9 @@ function assertValidationSourceIdentity(
 ) {
   const actual = validationSourceIdentity(cwd, deadlineAt);
   if (!sameValidationSourceIdentityExceptRuntime(actual, expected)) {
-    throw new Error("target dependency setup mutated checkout identity");
+    throw new Error(
+      `target dependency setup mutated checkout identity: ${validationSourceIdentityMismatchFields(actual, expected, { ignoreRuntimeInputs: true }).join(", ")}`,
+    );
   }
 }
 
@@ -2384,6 +2387,18 @@ function sameValidationSourceIdentityExceptRuntime(
     actual.treeSha === expected.treeSha &&
     actual.status === expected.status &&
     actual.worktreeSha256 === expected.worktreeSha256
+  );
+}
+
+function validationSourceIdentityMismatchFields(
+  actual: ValidationSourceIdentity,
+  expected: ValidationSourceIdentity,
+  { ignoreRuntimeInputs = false }: { ignoreRuntimeInputs?: boolean } = {},
+) {
+  return (Object.keys(expected) as Array<keyof ValidationSourceIdentity>).filter(
+    (field) =>
+      !(ignoreRuntimeInputs && field === "runtimeInputsSha256") &&
+      actual[field] !== expected[field],
   );
 }
 
@@ -3389,7 +3404,9 @@ function gitAdministrativeSha256(cwd: string, deadlineAt: number) {
       root: gitDir,
       paths: [
         "HEAD",
-        "index",
+        // Index trees and hidden flags are verified semantically elsewhere.
+        // Raw index bytes contain Git's mutable stat cache, so hashing them
+        // makes read-only discovery look like an administrative mutation.
         "ORIG_HEAD",
         "MERGE_HEAD",
         "CHERRY_PICK_HEAD",

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -3271,9 +3271,9 @@ if (args[0] === "enable") {
   assert.equal(fs.existsSync(hostLog), false, "host pnpm must never run");
   const corepackInvocations = fs.readFileSync(corepackLog, "utf8").trim().split(/\r?\n/);
   assert.equal(corepackInvocations.length, 4);
-  assert.match(corepackInvocations[0], /enable --install-directory .*[/\\]corepack[/\\]bin/);
+  assert.match(corepackInvocations[0], /enable --install-directory .*[/\\]corepack[/\\]bin pnpm$/);
   assert.equal(corepackInvocations[1], "prepare pnpm@9.15.0 --activate");
-  assert.match(corepackInvocations[2], /enable --install-directory .*[/\\]corepack[/\\]bin/);
+  assert.match(corepackInvocations[2], /enable --install-directory .*[/\\]corepack[/\\]bin pnpm$/);
   assert.equal(corepackInvocations[3], "prepare pnpm@9.15.0 --activate");
   const targetInvocations = fs.readFileSync(targetLog, "utf8").trim().split(/\r?\n/);
   assert.equal(targetInvocations.filter((line) => line.startsWith("install ")).length, 2);
@@ -4208,6 +4208,23 @@ test("checkout identity capture quarantines transient Git objects", () => {
 
   assert.match(binding.contentTreeSha, /^[0-9a-f]{40,64}$/);
   assert.equal(git(cwd, "count-objects", "-v"), before);
+});
+
+test("checkout identity is stable after ignored runtime discovery refreshes index stats", () => {
+  const cwd = gitPackageFixture({ check: 'node -e ""' });
+  git(cwd, "add", ".");
+  git(cwd, "commit", "-m", "initial");
+
+  const packagePath = path.join(cwd, "package.json");
+  const packageContents = fs.readFileSync(packagePath);
+  fs.writeFileSync(packagePath, packageContents);
+  fs.mkdirSync(path.join(cwd, "node_modules"));
+  fs.writeFileSync(path.join(cwd, "node_modules", ".runtime-state"), "prepared\n");
+
+  const first = captureTargetCheckoutBinding(cwd);
+  const second = captureTargetCheckoutBinding(cwd);
+
+  assert.deepEqual(second, first);
 });
 
 test("final checkout binding preserves validated content across host commit", () => {


### PR DESCRIPTION
## Root cause

Target dependency setup compared Git administrative identity using the raw `.git/index` bytes. Git may refresh only the index stat cache while preserving the HEAD, tree, worktree contents, and hidden index flags, so a safe setup was rejected as `target dependency setup mutated checkout identity`.

The prepared pnpm runtime also ran an unscoped `corepack enable`. That creates Yarn shims beside pnpm; the pnpm-only runtime freezer then rejected the unrelated external Yarn link.

## Changes

- Stop hashing raw index bytes after the semantic index tree and hidden flags have already been validated.
- Keep hooks, config, refs, worktree metadata, and the other administrative surfaces bound.
- Enable only the pnpm Corepack shim in the prepared runtime.
- Include the mismatched identity fields in the failure diagnostic.

## Validation

- `pnpm run build:all`
- all source/repair/script/dashboard lint gates
- repair tests: 924 passed, 3 environment skips
- changed and full coverage gates passed
- local container E2E reconstructs the 2026-07-18 failure against historical ClawSweeper revision `7be2e4915b4b1d9aa953ccfe359cea670a4616ec`, then passes the same Git-index stat mutation with this fix

Stack 1/3. Merge this PR first.
