### PR TITLE
fix(repair): freeze Corepack package metadata

### DIFF
--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -3762,6 +3762,10 @@ function freezePreparedTargetPnpmRuntime(
       if (!copiedDist) {
         const destination = path.join(runtimeContainer, "dist");
         fs.mkdirSync(runtimeContainer, { recursive: true, mode: 0o700 });
+        // Corepack's integrity-pinned package-manager path resolves its own
+        // package.json at runtime. Keep that reviewed package boundary beside
+        // dist instead of letting the frozen shim reach back into the host.
+        fs.copyFileSync(shim.packageJson, path.join(runtimeContainer, "package.json"));
         fs.cpSync(shim.distRoot, destination, {
           recursive: true,
           verbatimSymlinks: true,
@@ -3832,6 +3836,12 @@ function preparedPnpmRuntimeSha256(
               deadlineAt,
               new Set(),
             );
+            updateIdentityHash(
+              hash,
+              "external-corepack-package-json-mode",
+              String(fs.statSync(shim.packageJson).mode & 0o777),
+            );
+            updateFileDigest(hash, shim.packageJson, "external-corepack-package.json", deadlineAt);
           }
         }
         updateIdentityHash(hash, "runtime-type", "symlink");
@@ -3865,10 +3875,15 @@ function externalCorepackShim(runtimeRoot: string, symlinkPath: string) {
     return null;
   }
   const distRoot = path.dirname(resolvedTarget);
+  const packageJson = path.join(path.dirname(distRoot), "package.json");
   const targetName = path.basename(resolvedTarget);
   let corepackRuntimeIsFile = false;
+  let corepackPackageIsValid = false;
   try {
     corepackRuntimeIsFile = fs.statSync(path.join(distRoot, "lib", "corepack.cjs")).isFile();
+    const packageMetadata = JSON.parse(fs.readFileSync(packageJson, "utf8"));
+    corepackPackageIsValid =
+      fs.statSync(packageJson).isFile() && packageMetadata?.name === "corepack";
   } catch {
     // Rejected below as an unrecognized external executable.
   }
@@ -3876,12 +3891,14 @@ function externalCorepackShim(runtimeRoot: string, symlinkPath: string) {
     path.basename(distRoot) !== "dist" ||
     (targetName !== "pnpm.js" && targetName !== "pnpx.js") ||
     !fs.statSync(resolvedTarget).isFile() ||
-    !corepackRuntimeIsFile
+    !corepackRuntimeIsFile ||
+    !corepackPackageIsValid
   ) {
     throw new Error(`prepared target pnpm symlink escapes runtime: ${path.basename(symlinkPath)}`);
   }
   return {
     distRoot,
+    packageJson,
     targetRelative: path.relative(distRoot, resolvedTarget),
   };
 }

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -3870,7 +3870,7 @@ if (args[0] === "enable") {
 );
 
 test(
-  "pnpm setup freezes a runnable external Corepack shim",
+  "pnpm setup freezes runnable external Corepack code and package metadata",
   { skip: process.platform === "win32" },
   () => {
     const cwd = gitPackageFixture({ verify: 'node -e ""' });
@@ -3881,18 +3881,28 @@ test(
     const hostBin = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-corepack-shim-"));
     const distRoot = path.join(hostBin, "corepack-package", "dist");
     const corepackLib = path.join(distRoot, "lib", "corepack.cjs");
+    const corepackPackageJson = path.join(path.dirname(distRoot), "package.json");
     const pnpmEntrypoint = path.join(distRoot, "pnpm.js");
     const logPath = path.join(hostBin, "pnpm.log");
     const maliciousMarker = path.join(hostBin, "external-corepack-ran");
     fs.mkdirSync(path.dirname(corepackLib), { recursive: true });
+    fs.writeFileSync(
+      corepackPackageJson,
+      `${JSON.stringify({
+        name: "corepack",
+        version: "0.34.0-fixture",
+        exports: { "./package.json": "./package.json" },
+      })}\n`,
+    );
     fs.writeFileSync(pnpmEntrypoint, '#!/usr/bin/env node\nrequire("./lib/corepack.cjs");\n', {
       mode: 0o755,
     });
     fs.writeFileSync(
       corepackLib,
       `const fs = require("node:fs");
+const corepack = require("corepack/package.json");
 const args = process.argv.slice(2);
-fs.appendFileSync(${JSON.stringify(logPath)}, args.join(" ") + "\\n");
+fs.appendFileSync(${JSON.stringify(logPath)}, corepack.version + " " + args.join(" ") + "\\n");
 if (args.includes("install")) fs.mkdirSync("node_modules", { recursive: true });
 `,
     );
@@ -3930,6 +3940,14 @@ if (args[0] === "enable") {
           corepackLib,
           `require("node:fs").writeFileSync(${JSON.stringify(maliciousMarker)}, "ran");\n`,
         );
+        fs.writeFileSync(
+          corepackPackageJson,
+          `${JSON.stringify({
+            name: "corepack",
+            version: "mutated-host-package",
+            exports: { "./package.json": "./package.json" },
+          })}\n`,
+        );
         assert.deepEqual(runAllowedValidationCommands(["pnpm verify"], cwd, options), [
           "pnpm verify",
         ]);
@@ -3938,8 +3956,8 @@ if (args[0] === "enable") {
 
     assert.equal(fs.existsSync(maliciousMarker), false);
     assert.deepEqual(fs.readFileSync(logPath, "utf8").trim().split(/\r?\n/), [
-      "install --frozen-lockfile --prefer-offline --ignore-scripts --ignore-pnpmfile --config.registry=https://registry.npmjs.org/ --config.engine-strict=false --config.enable-pre-post-scripts=false",
-      "--config.enable-pre-post-scripts=false verify",
+      "0.34.0-fixture install --frozen-lockfile --prefer-offline --ignore-scripts --ignore-pnpmfile --config.registry=https://registry.npmjs.org/ --config.engine-strict=false --config.enable-pre-post-scripts=false",
+      "0.34.0-fixture --config.enable-pre-post-scripts=false verify",
     ]);
   },
 );


### PR DESCRIPTION
## Summary

- copy Corepack package metadata beside the frozen dist runtime
- validate the external package boundary before accepting the shim
- bind metadata mode and content into the prepared runtime identity
- cover host code and package metadata mutation after prepare

## Root cause

Integrity-pinned package manager execution resolves corepack/package.json at runtime. The prepared-runtime freezer copied only the Corepack dist directory, so OpenClaw-shaped validation failed with Cannot find module corepack/package.json. Reaching back to the host package would also weaken the existing TOCTOU boundary.

## Validation

- Node 24.15.0
- repair TypeScript build
- repair lint
- focused target-validation suite: 157 tests, 154 passed, 3 skipped
- autoreview: clean, no accepted or actionable findings
- patch privacy scan: no credentials, private paths, or local artifacts