### PR TITLE
fix(validation): disable implicit pnpm installs

### DIFF
--- a/src/repair/validation-command-utils.ts
+++ b/src/repair/validation-command-utils.ts
@@ -712,9 +712,13 @@ export function validationCommandForExecution(parts: readonly string[]): string[
     return [...envPrefix, "npm", "--ignore-scripts", ...commandParts.slice(1)];
   }
   if (invocation.executable === "pnpm") {
+    // pnpm can otherwise run an implicit install when its disposable validation
+    // profile uses a different store. Dependency setup is a separate reviewed
+    // phase, so validation must execute the requested script without mutation.
     return [
       ...envPrefix,
       "pnpm",
+      "--config.verify-deps-before-run=false",
       "--config.enable-pre-post-scripts=false",
       ...commandParts.slice(1),
     ];

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -802,7 +802,7 @@ test("bun test is treated as the built-in runner instead of a package script", (
   );
 });
 
-test("package validation execution suppresses lifecycle hooks", () => {
+test("package validation execution suppresses lifecycle hooks and implicit installs", () => {
   assert.deepEqual(validationCommandForExecution(["npm", "run", "check"]), [
     "npm",
     "--ignore-scripts",
@@ -811,6 +811,7 @@ test("package validation execution suppresses lifecycle hooks", () => {
   ]);
   assert.deepEqual(validationCommandForExecution(["pnpm", "--filter", "app", "check"]), [
     "pnpm",
+    "--config.verify-deps-before-run=false",
     "--config.enable-pre-post-scripts=false",
     "--fail-if-no-match",
     "--filter",
@@ -819,6 +820,7 @@ test("package validation execution suppresses lifecycle hooks", () => {
   ]);
   assert.deepEqual(validationCommandForExecution(["pnpm", "run", "--filter", "app", "check"]), [
     "pnpm",
+    "--config.verify-deps-before-run=false",
     "--config.enable-pre-post-scripts=false",
     "--fail-if-no-match",
     "run",
@@ -1101,7 +1103,7 @@ if (args.includes("--fail-if-no-match")) {
   );
   assert.equal(
     fs.readFileSync(logPath, "utf8"),
-    "--config.enable-pre-post-scripts=false --fail-if-no-match --filter __clawsweeper_no_such_workspace__ check",
+    "--config.verify-deps-before-run=false --config.enable-pre-post-scripts=false --fail-if-no-match --filter __clawsweeper_no_such_workspace__ check",
   );
 });
 
@@ -3280,8 +3282,8 @@ if (args[0] === "enable") {
   assert.deepEqual(
     targetInvocations.filter((line) => line.endsWith("verify")),
     [
-      "--config.enable-pre-post-scripts=false verify",
-      "--config.enable-pre-post-scripts=false verify",
+      "--config.verify-deps-before-run=false --config.enable-pre-post-scripts=false verify",
+      "--config.verify-deps-before-run=false --config.enable-pre-post-scripts=false verify",
     ],
   );
 });
@@ -3353,8 +3355,8 @@ if (args[0] === "enable") {
     assert.equal(fs.existsSync(maliciousMarker), false);
     assert.deepEqual(fs.readFileSync(logPath, "utf8").trim().split(/\r?\n/), [
       "install --frozen-lockfile --prefer-offline --ignore-scripts --ignore-pnpmfile --config.registry=https://registry.npmjs.org/ --config.engine-strict=false --config.enable-pre-post-scripts=false",
-      "--config.enable-pre-post-scripts=false first",
-      "--config.enable-pre-post-scripts=false second",
+      "--config.verify-deps-before-run=false --config.enable-pre-post-scripts=false first",
+      "--config.verify-deps-before-run=false --config.enable-pre-post-scripts=false second",
     ]);
   },
 );
@@ -3957,7 +3959,7 @@ if (args[0] === "enable") {
     assert.equal(fs.existsSync(maliciousMarker), false);
     assert.deepEqual(fs.readFileSync(logPath, "utf8").trim().split(/\r?\n/), [
       "0.34.0-fixture install --frozen-lockfile --prefer-offline --ignore-scripts --ignore-pnpmfile --config.registry=https://registry.npmjs.org/ --config.engine-strict=false --config.enable-pre-post-scripts=false",
-      "0.34.0-fixture --config.enable-pre-post-scripts=false verify",
+      "0.34.0-fixture --config.verify-deps-before-run=false --config.enable-pre-post-scripts=false verify",
     ]);
   },
 );


### PR DESCRIPTION
## Summary

- disable pnpm's `verifyDepsBeforeRun` behavior for validation commands
- keep the existing lifecycle-hook suppression and workspace filter fail-closed behavior
- update focused command-boundary assertions

## Root cause

Dependency setup and validation intentionally run with separate disposable homes and pnpm stores. With pnpm 11.2.2, `verifyDepsBeforeRun` treats that profile/store change as a stale install and can run an implicit `pnpm install` before `pnpm check:changed`.

That hidden install rewrites runtime metadata such as `node_modules/.modules.yaml` and `.pnpm-workspace-state-v1.json`. ClawSweeper then correctly rejects validation because the checkout identity changed; on a full OpenClaw checkout, pnpm may also purge/reinstall the dependency tree or attempt registry access.

Dependency installation is already a separate reviewed phase. Validation should execute only the requested script, so the production command now passes `--config.verify-deps-before-run=false` alongside `--config.enable-pre-post-scripts=false`.

## Validation

- OpenClaw-shaped container E2E: happy path passed with different setup/validation homes and stores
- OpenClaw-shaped historical CI regression scenario passed
- `node --test --test-name-pattern='package validation execution suppresses lifecycle hooks and implicit installs' test/repair/target-validation.test.ts`
- `pnpm --config.verify-deps-before-run=false run build`
- `pnpm --config.verify-deps-before-run=false run build:repair`
- `pnpm --config.verify-deps-before-run=false run lint`
- focused `oxfmt --check`
- isolated autoreview: no findings, correctness confidence 0.97
