### PR TITLE
fix(apply): preserve runtime yields across coverage proof

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -16991,20 +16991,6 @@ function prCloseCoverageRuntimeBudgetBlock(
   };
 }
 
-function prCloseCoverageRuntimeBudgetErrorBlock(error: unknown): PrCloseCoverageProofGateResult {
-  if (!(error instanceof GitHubRuntimeBudgetError)) return null;
-  // GitHub operations reserve time to publish a resumable report, so they can
-  // exhaust the active budget before the outer wall-clock deadline. Preserve
-  // that yield instead of misclassifying it as a retryable proof read failure.
-  return {
-    status: "blocked",
-    block: {
-      actionTaken: "skipped_runtime_budget",
-      reason: error.reason,
-    },
-  };
-}
-
 function prCloseCoverageRuntime(
   runtime: PrCloseCoverageProofRuntime,
   runtimeBudget: PrCloseCoverageRuntimeBudget | undefined,
@@ -17145,8 +17131,7 @@ function prCloseCoverageProofGateResult(options: {
     try {
       covering = coveringView(linkedNumber);
     } catch (error) {
-      const runtimeBudgetErrorBlock = prCloseCoverageRuntimeBudgetErrorBlock(error);
-      if (runtimeBudgetErrorBlock) return runtimeBudgetErrorBlock;
+      if (error instanceof GitHubRuntimeBudgetError) throw error;
       const hydrationBudgetBlock = prCloseCoverageRuntimeBudgetBlock(
         options.runtimeBudget,
         "while hydrating",
@@ -17247,8 +17232,7 @@ function prCloseCoverageProofGateResult(options: {
         reason: `PR close coverage proof kept this PR open against ${covering.url}: ${closeDecision.reason}`,
       };
     } catch (error) {
-      const runtimeBudgetErrorBlock = prCloseCoverageRuntimeBudgetErrorBlock(error);
-      if (runtimeBudgetErrorBlock) return runtimeBudgetErrorBlock;
+      if (error instanceof GitHubRuntimeBudgetError) throw error;
       const proofBudgetBlock = prCloseCoverageRuntimeBudgetBlock(
         options.runtimeBudget,
         "while running",

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -16843,7 +16843,8 @@ function duplicateCanonicalPullRequestBlockReason(
       }
       const reason = unsafeCanonicalPullRequestReason(linkedPull, options);
       if (reason) return `${reason}; refusing duplicate/superseded auto-close`;
-    } catch {
+    } catch (error) {
+      if (error instanceof GitHubRuntimeBudgetError) throw error;
       if (ref.kind !== "pull_url" && shorthandRefIsIssue(number)) continue;
       return `linked canonical PR #${number} could not be read; refusing duplicate/superseded auto-close`;
     }
@@ -16990,6 +16991,20 @@ function prCloseCoverageRuntimeBudgetBlock(
   };
 }
 
+function prCloseCoverageRuntimeBudgetErrorBlock(error: unknown): PrCloseCoverageProofGateResult {
+  if (!(error instanceof GitHubRuntimeBudgetError)) return null;
+  // GitHub operations reserve time to publish a resumable report, so they can
+  // exhaust the active budget before the outer wall-clock deadline. Preserve
+  // that yield instead of misclassifying it as a retryable proof read failure.
+  return {
+    status: "blocked",
+    block: {
+      actionTaken: "skipped_runtime_budget",
+      reason: error.reason,
+    },
+  };
+}
+
 function prCloseCoverageRuntime(
   runtime: PrCloseCoverageProofRuntime,
   runtimeBudget: PrCloseCoverageRuntimeBudget | undefined,
@@ -17130,6 +17145,8 @@ function prCloseCoverageProofGateResult(options: {
     try {
       covering = coveringView(linkedNumber);
     } catch (error) {
+      const runtimeBudgetErrorBlock = prCloseCoverageRuntimeBudgetErrorBlock(error);
+      if (runtimeBudgetErrorBlock) return runtimeBudgetErrorBlock;
       const hydrationBudgetBlock = prCloseCoverageRuntimeBudgetBlock(
         options.runtimeBudget,
         "while hydrating",
@@ -17230,6 +17247,8 @@ function prCloseCoverageProofGateResult(options: {
         reason: `PR close coverage proof kept this PR open against ${covering.url}: ${closeDecision.reason}`,
       };
     } catch (error) {
+      const runtimeBudgetErrorBlock = prCloseCoverageRuntimeBudgetErrorBlock(error);
+      if (runtimeBudgetErrorBlock) return runtimeBudgetErrorBlock;
       const proofBudgetBlock = prCloseCoverageRuntimeBudgetBlock(
         options.runtimeBudget,
         "while running",


### PR DESCRIPTION
## Summary

- preserve `GitHubRuntimeBudgetError` through coverage-proof hydration and execution
- propagate runtime-budget exhaustion from the post-proof canonical PR safety recheck
- prevent a slow GitHub read from recording a business `kept_open`/retry result before the resumable runtime yield

## Root cause

The apply runtime reserves time to flush a resumable report. Coverage-proof catch blocks and the later canonical-PR recheck could treat that reserved-budget exception as an ordinary GitHub read/proof failure. Under coverage instrumentation, the slow path crossed the reserve boundary and emitted the wrong action before yielding.

## Validation

- `pnpm --config.verify-deps-before-run=false run check`
- target regression repeated 3x normally and 3x with `--experimental-test-coverage`
- commit-range gitleaks: no leaks
- autoreview: clean, no accepted/actionable findings

This is an independent CI/runtime fix discovered while validating #670; it intentionally does not include the automerge E2E fixture changes.