### PR TITLE
test(repair): model OpenClaw in automerge E2E

### DIFF
--- a/.github/workflows/automerge-e2e.yml
+++ b/.github/workflows/automerge-e2e.yml
@@ -72,6 +72,7 @@ jobs:
         run: >-
           node scripts/e2e/automerge-container.mjs
           --scenario all
+          --fixture all
           --output test-results/automerge
           --base-image "$AUTOMERGE_E2E_BASE_IMAGE"
 

--- a/docs/repair/automerge-e2e.md
+++ b/docs/repair/automerge-e2e.md
@@ -22,6 +22,26 @@ clone/fetch/commit/push, a bare target remote, Corepack, the target's pinned
 pnpm, dependency installation, changed-surface validation, artifact handoff,
 and the final squash merge.
 
+The simulated `gh repo clone` always creates a complete, non-local clone and
+asserts that Git does not mark it shallow. A shallow boundary or local-hardlink
+shortcut is not representative of GitHub transport and can turn missing-object
+recovery into repeated Git work. Repository realism belongs in the small
+fixture's tracked files and history shape, not in a full OpenClaw checkout or
+an artificial shallow clone.
+
+Two target fixtures keep different failure signals independent:
+
+- `tiny` proves the generic automerge state machine and precise failure
+  injection with the smallest real Git repository possible.
+- `openclaw-shaped` preserves the production repository contracts that affect
+  repair: OpenClaw's pinned pnpm and Node range, workspace layout and links,
+  changed-surface gate, tracked policy symlink, release-owned changelog, and a
+  contributor branch that is behind current `main`.
+
+Neither fixture clones the full OpenClaw repository. That keeps the required PR
+lane deterministic and bounded while still exercising the `openclaw/openclaw`
+repository profile and strict target validation.
+
 Unrecognized GitHub calls fail closed. This is deliberate: a new production API
 dependency must be represented explicitly instead of silently reducing test
 coverage.
@@ -37,10 +57,15 @@ pnpm e2e:automerge:container
 Run one scenario while iterating:
 
 ```bash
-pnpm e2e:automerge:container -- --scenario planning-head-drift
+pnpm e2e:automerge:container -- \
+  --scenario planning-head-drift \
+  --fixture openclaw-shaped
 ```
 
-Artifacts are retained under `test-results/automerge-container/`. The container
+The container wrapper runs both fixtures by default. Pass `--fixture tiny` for
+the fastest edit loop or `--fixture openclaw-shaped` for the OpenClaw contract.
+Artifacts are retained under
+`test-results/automerge-container/<fixture>/<scenario>/`. The container
 does not reuse the host `node_modules`, Corepack home, pnpm store, repair runs,
 or Git state. The wrapper enables nested user/mount namespaces so the real
 target-validation containment can run; it does not grant the container
@@ -55,7 +80,8 @@ and the wrapper restores artifact ownership to the invoking host UID afterward.
 
 By default, the wrapper builds `Dockerfile.base` from the checked-out repository
 as `clawsweeper-automerge-e2e-base:local`, then passes that exact local tag to
-the application build. The base preinstalls Node 24, Git, Python, CA
+the application build. The base pins Node 24.15.0, which satisfies OpenClaw's
+current Node 24 floor, and preinstalls Git, Python, CA
 certificates, and Corepack. Docker reuses the unchanged OS package layer, while
 the project dependency layer is cached independently by `package.json` and
 `pnpm-lock.yaml`; repeated runs do not reinstall either layer.
@@ -79,7 +105,7 @@ pnpm e2e:automerge:container -- \
 
 ## CI and Crabbox
 
-`.github/workflows/automerge-e2e.yml` runs the lightweight suite for repair,
+`.github/workflows/automerge-e2e.yml` runs every scenario against both fixtures for repair,
 harness, package-manager, and workflow changes. CI calls the repository-owned
 container wrapper on the same production-class Blacksmith runner used by repair
 execution. Pull requests from forks are excluded because untrusted code must not
@@ -97,13 +123,16 @@ pnpm crabbox:run -- \
   --timing-json \
   --capture-on-fail \
   --shell -- \
-  "node scripts/e2e/automerge-container.mjs --scenario all"
+  "node scripts/e2e/automerge-container.mjs --scenario all --fixture all"
 ```
 
-The lightweight scenarios cover the complete success path, a real tracked-file
+Across both target shapes, the scenarios cover the complete success path, a real tracked-file
 dependency-install mutation, planning-to-execution head drift, pending checks
 that later turn green, stale exact-head verdicts, replay idempotency, and the
-reconstructed 2026-07-18 runtime-identity regression.
+reconstructed 2026-07-18 runtime-identity regression. The OpenClaw-shaped runs
+also prove a real workspace install/link graph, `check:changed` package routing,
+base ancestry synchronization, the `CLAUDE.md -> AGENTS.md` symlink, and
+`CHANGELOG.md` preservation.
 
 ## Exact 2026-07-18 CI regression
 
@@ -114,10 +143,11 @@ The regression scenario records the exact revisions from the failed run:
 - OpenClaw base: `977e0b64a12152a2e112634c1c32e8505db08234`
 
 The failure is in ClawSweeper's target-runtime freezer and does not depend on
-OpenClaw's source tree. The harness therefore reconstructs it with a tiny real
-Git repository pinned to the run's pnpm 11.2.2, while the container pins Node
-24.13.0. This avoids downloading and installing the multi-GB OpenClaw graph on
-developer machines. The historical revision also contains an earlier Yarn-shim
+OpenClaw's full source graph. The `tiny` fixture reconstructs it with a real Git
+repository pinned to the run's pnpm 11.2.2; the `openclaw-shaped` fixture reruns
+the same failure injection with OpenClaw's workspace and package-manager
+contract. This avoids downloading and installing the multi-GB OpenClaw graph
+on developer machines. The historical revision also contains an earlier Yarn-shim
 freezer defect. For this scenario only, a Corepack proxy adds the missing
 `pnpm` selector to the old `corepack enable` call so execution reaches the
 linked Git-index identity failure; Corepack and pnpm otherwise execute for
@@ -127,6 +157,7 @@ and run:
 ```bash
 pnpm e2e:automerge:container -- \
   --scenario ci-regression-29623139111 \
+  --fixture tiny \
   --candidate-root /path/to/clawsweeper-at-7be2e491 \
   --expect setup-identity-failure
 ```
@@ -145,7 +176,13 @@ List all scenario names with:
 pnpm e2e:automerge -- --list-scenarios
 ```
 
-Each scenario writes `summary.json` and per-step stdout/stderr logs. Exit zero
+List target fixture names with:
+
+```bash
+pnpm e2e:automerge -- --list-fixtures
+```
+
+Each fixture/scenario pair writes `summary.json` and per-step stdout/stderr logs. Exit zero
 means the selected terminal-state assertions passed; it does not mean that an
 expected safety rejection was bypassed. Failure workspaces are deleted by
 default, while the artifact logs retain the command boundary and error. Use

--- a/scripts/e2e/automerge-container.mjs
+++ b/scripts/e2e/automerge-container.mjs
@@ -2,7 +2,7 @@
 
 /**
  * Definition: build and run the repository-owned automerge E2E image locally.
- * Parameters: --scenario, --expect, --candidate-root, --output, --image,
+ * Parameters: --scenario, --fixture, --expect, --candidate-root, --output, --image,
  * --base-image, and --no-build are optional.
  * Outputs: the harness summary on stdout and retained step logs under --output.
  * Decision: local validation builds its base from repository source and uses a
@@ -26,6 +26,7 @@ Description:
 
 Options:
   --scenario <name>       Scenario name or all (default: all)
+  --fixture <name>        tiny, openclaw-shaped, or all (default: all)
   --expect <outcome>      success or setup-identity-failure (default: success)
   --candidate-root <dir>  Built candidate checkout mounted read-only
   --output <dir>          Host artifact directory (default: test-results/automerge-container)
@@ -40,7 +41,7 @@ Outputs:
 
 Examples:
   pnpm e2e:automerge:container
-  pnpm e2e:automerge:container -- --scenario planning-head-drift
+  pnpm e2e:automerge:container -- --scenario planning-head-drift --fixture openclaw-shaped
   pnpm e2e:automerge:container -- --scenario ci-regression-29623139111 \\
     --candidate-root ../clawsweeper-ci-regression --expect setup-identity-failure
 `);
@@ -52,6 +53,7 @@ const output = path.resolve(String(args.output ?? "test-results/automerge-contai
 const image = String(args.image ?? "clawsweeper-automerge-e2e:local");
 const baseImage = String(args.baseImage ?? "clawsweeper-automerge-e2e-base:local");
 const scenario = String(args.scenario ?? "all");
+const fixture = String(args.fixture ?? "all");
 const expectedOutcome = String(args.expect ?? "success");
 const candidateRoot = args.candidateRoot ? path.resolve(String(args.candidateRoot)) : null;
 if (candidateRoot && !fs.statSync(candidateRoot, { throwIfNoEntry: false })?.isDirectory()) {
@@ -120,6 +122,8 @@ const e2eRun = runResult("docker", [
   "scripts/e2e/automerge.mjs",
   "--scenario",
   scenario,
+  "--fixture",
+  fixture,
   "--output",
   "/e2e-output",
   "--expect",
@@ -170,6 +174,7 @@ function parseArgs(argv) {
     if (arg === "-h" || arg === "--help") parsed.help = true;
     else if (arg === "--no-build") parsed.noBuild = true;
     else if (arg === "--scenario") parsed.scenario = requiredValue(argv, ++index, arg);
+    else if (arg === "--fixture") parsed.fixture = requiredValue(argv, ++index, arg);
     else if (arg === "--expect") parsed.expect = requiredValue(argv, ++index, arg);
     else if (arg === "--candidate-root") parsed.candidateRoot = requiredValue(argv, ++index, arg);
     else if (arg === "--output") parsed.output = requiredValue(argv, ++index, arg);

--- a/scripts/e2e/automerge.mjs
+++ b/scripts/e2e/automerge.mjs
@@ -2,7 +2,7 @@
 
 /**
  * Definition: run the repository-owned ClawSweeper automerge E2E harness.
- * Parameters: --scenario, --candidate-root, --output, and --keep are optional.
+ * Parameters: --scenario, --fixture, --candidate-root, --output, and --keep are optional.
  * Outputs: step logs plus summary.json under test-results/automerge by default;
  * exit 0 means the selected production flow reached its asserted terminal state.
  * Decision: external commands fail closed so newly introduced GitHub dependencies
@@ -11,6 +11,7 @@
 
 import path from "node:path";
 import { AUTOMERGE_E2E_SCENARIOS, runAutomergeE2E } from "../../test/e2e/automerge/run.mjs";
+import { AUTOMERGE_E2E_FIXTURES } from "../../test/e2e/automerge/target-fixtures.mjs";
 
 const args = parseArgs(process.argv.slice(2));
 if (args.help) {
@@ -25,22 +26,23 @@ Description:
 Options:
   --scenario <name>       Scenario to run; use all for the full suite
                           (default: happy-path)
+  --fixture <name>        tiny, openclaw-shaped, or all (default: tiny)
   --expect <outcome>      success or setup-identity-failure (default: success)
   --list-scenarios        Print supported scenario names
+  --list-fixtures         Print supported target fixture names
   --candidate-root <dir>  Built ClawSweeper checkout to validate (default: cwd)
   --output <dir>          Failure and proof artifact root
   --keep                  Keep the temporary scenario workspace
   -h, --help              Show this help
 
 Outputs:
-  <output>/<scenario>/summary.json and one stdout/stderr log per production step.
+  <output>/<fixture>/<scenario>/summary.json and one stdout/stderr log per production step.
   Exit code 0 means all terminal-state and token-boundary assertions passed.
 
 Examples:
   pnpm e2e:automerge
-  pnpm e2e:automerge -- --scenario all --output test-results/automerge
-  pnpm e2e:automerge -- --scenario ci-regression-29623139111 \
-    --candidate-root ../clawsweeper-ci-regression --expect setup-identity-failure
+  pnpm e2e:automerge -- --scenario all --fixture all --output test-results/automerge
+  pnpm e2e:automerge -- --scenario ci-regression-29623139111 --candidate-root ../clawsweeper-ci-regression --expect setup-identity-failure
 `);
   process.exit(0);
 }
@@ -49,23 +51,32 @@ if (args.listScenarios) {
   process.stdout.write(`${AUTOMERGE_E2E_SCENARIOS.join("\n")}\n`);
   process.exit(0);
 }
+if (args.listFixtures) {
+  process.stdout.write(`${AUTOMERGE_E2E_FIXTURES.join("\n")}\n`);
+  process.exit(0);
+}
 
 try {
-  const selected = String(args.scenario ?? "happy-path");
-  const scenarios = selected === "all" ? AUTOMERGE_E2E_SCENARIOS : [selected];
-  const results = scenarios.map((scenario) =>
-    runAutomergeE2E({
-      candidateRoot: path.resolve(String(args.candidateRoot ?? process.cwd())),
-      outputRoot: path.resolve(
-        String(args.output ?? path.join(process.cwd(), "test-results", "automerge")),
-      ),
-      expectedOutcome: String(args.expect ?? "success"),
-      scenario,
-      keep: Boolean(args.keep),
-    }),
+  const selectedScenario = String(args.scenario ?? "happy-path");
+  const selectedFixture = String(args.fixture ?? "tiny");
+  const scenarios = selectedScenario === "all" ? AUTOMERGE_E2E_SCENARIOS : [selectedScenario];
+  const fixtures = selectedFixture === "all" ? AUTOMERGE_E2E_FIXTURES : [selectedFixture];
+  const results = fixtures.flatMap((fixture) =>
+    scenarios.map((scenario) =>
+      runAutomergeE2E({
+        candidateRoot: path.resolve(String(args.candidateRoot ?? process.cwd())),
+        outputRoot: path.resolve(
+          String(args.output ?? path.join(process.cwd(), "test-results", "automerge")),
+        ),
+        expectedOutcome: String(args.expect ?? "success"),
+        fixture,
+        scenario,
+        keep: Boolean(args.keep),
+      }),
+    ),
   );
   process.stdout.write(
-    `${JSON.stringify(selected === "all" ? { status: "passed", results } : results[0], null, 2)}\n`,
+    `${JSON.stringify(results.length === 1 ? results[0] : { status: "passed", results }, null, 2)}\n`,
   );
 } catch (error) {
   process.stderr.write(
@@ -81,8 +92,10 @@ function parseArgs(argv) {
     if (arg === "--") continue;
     if (arg === "-h" || arg === "--help") out.help = true;
     else if (arg === "--list-scenarios") out.listScenarios = true;
+    else if (arg === "--list-fixtures") out.listFixtures = true;
     else if (arg === "--keep") out.keep = true;
     else if (arg === "--scenario") out.scenario = requiredValue(argv, ++index, arg);
+    else if (arg === "--fixture") out.fixture = requiredValue(argv, ++index, arg);
     else if (arg === "--expect") out.expect = requiredValue(argv, ++index, arg);
     else if (arg === "--candidate-root") out.candidateRoot = requiredValue(argv, ++index, arg);
     else if (arg === "--output") out.output = requiredValue(argv, ++index, arg);

--- a/test/e2e/automerge/Dockerfile.base
+++ b/test/e2e/automerge/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM node:24.13.0-bookworm-slim@sha256:4660b1ca8b28d6d1906fd644abe34b2ed81d15434d26d845ef0aced307cf4b6f
+FROM node:24.15.0-bookworm-slim@sha256:4e6b70dd6cbfc88c8157ba19aa3d9f9cce6ba4703576d55459e45efcbc9c5f5d
 
 LABEL org.opencontainers.image.title="ClawSweeper automerge E2E base"
 LABEL org.opencontainers.image.source="https://github.com/openclaw/clawsweeper"

--- a/test/e2e/automerge/fake-codex.mjs
+++ b/test/e2e/automerge/fake-codex.mjs
@@ -54,6 +54,14 @@ function optionValue(name) {
 }
 
 function fixtureEditPath() {
+  const openClawShapedFixture = path.join(
+    process.cwd(),
+    "packages",
+    "fixture-core",
+    "src",
+    "repair-target.txt",
+  );
+  if (fs.existsSync(openClawShapedFixture)) return openClawShapedFixture;
   const minimalFixture = path.join(process.cwd(), "src", "repair-target.txt");
   if (fs.existsSync(minimalFixture)) return minimalFixture;
   const ciRegressionFixture = path.join(process.cwd(), "src", "hooks", "gmail-watcher.ts");

--- a/test/e2e/automerge/fake-gh.mjs
+++ b/test/e2e/automerge/fake-gh.mjs
@@ -22,7 +22,12 @@ if (args[0] === "repo" && args[1] === "clone") {
   assertReadToken();
   const destination = args[3];
   if (args[2] !== state.repo || !destination) fail(`unsupported repo clone: ${args.join(" ")}`);
-  git(["clone", "--depth=1", state.remote, destination]);
+  // Production `gh repo clone` transfers a complete repository. Avoid both a
+  // shallow boundary and Git's local hardlink shortcut: either can make this
+  // fixture exercise object-availability behavior that GitHub never creates.
+  git(["clone", "--no-local", state.remote, destination]);
+  const shallow = gitText(["-C", destination, "rev-parse", "--is-shallow-repository"]);
+  if (shallow !== "false") fail(`target clone unexpectedly shallow: ${destination}`);
   process.exit(0);
 }
 

--- a/test/e2e/automerge/index-stat-mutator.mjs
+++ b/test/e2e/automerge/index-stat-mutator.mjs
@@ -4,11 +4,17 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
-const [targetDir, markerPath] = process.argv.slice(2);
-if (!targetDir || !markerPath) fail("usage: index-stat-mutator.mjs <target-dir> <marker-path>");
+const [targetDir, trackedRelativePath, markerPath] = process.argv.slice(2);
+if (!targetDir || !trackedRelativePath || !markerPath) {
+  fail("usage: index-stat-mutator.mjs <target-dir> <tracked-relative-path> <marker-path>");
+}
 
 const deadline = Date.now() + 60_000;
-const trackedFile = path.join(targetDir, "src", "repair-target.txt");
+const trackedFile = path.resolve(targetDir, trackedRelativePath);
+const relativeTrackedFile = path.relative(path.resolve(targetDir), trackedFile);
+if (relativeTrackedFile.startsWith(`..${path.sep}`) || path.isAbsolute(relativeTrackedFile)) {
+  fail("tracked relative path escapes target directory");
+}
 const installMarker = path.join(targetDir, "node_modules");
 while (!fs.existsSync(trackedFile) || !fs.existsSync(installMarker)) {
   if (Date.now() >= deadline) fail("timed out waiting for target dependency setup");

--- a/test/e2e/automerge/run.mjs
+++ b/test/e2e/automerge/run.mjs
@@ -4,6 +4,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  AUTOMERGE_E2E_FIXTURES,
+  createCiRegressionFixture,
+  createTargetFixture,
+} from "./target-fixtures.mjs";
 
 const helperRoot = path.dirname(fileURLToPath(import.meta.url));
 export const AUTOMERGE_E2E_SCENARIOS = [
@@ -19,11 +24,15 @@ export function runAutomergeE2E({
   candidateRoot = process.cwd(),
   outputRoot = path.join(process.cwd(), "test-results", "automerge"),
   scenario = "happy-path",
+  fixture = "tiny",
   expectedOutcome = "success",
   keep = false,
 } = {}) {
   if (!AUTOMERGE_E2E_SCENARIOS.includes(scenario)) {
     throw new Error(`unsupported scenario: ${scenario}`);
+  }
+  if (!AUTOMERGE_E2E_FIXTURES.includes(fixture)) {
+    throw new Error(`unsupported fixture: ${fixture}`);
   }
   if (!["success", "setup-identity-failure"].includes(expectedOutcome)) {
     throw new Error(`unsupported expected outcome: ${expectedOutcome}`);
@@ -32,23 +41,24 @@ export function runAutomergeE2E({
     throw new Error(`${expectedOutcome} is only valid for ci-regression-29623139111`);
   }
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-automerge-e2e-"));
-  const artifacts = path.resolve(outputRoot, scenario);
+  const artifacts = path.resolve(outputRoot, fixture, scenario);
   fs.rmSync(artifacts, { recursive: true, force: true });
   fs.mkdirSync(artifacts, { recursive: true });
 
   try {
     const runtimeRoot = createCandidateRuntime(root, candidateRoot);
-    const fixture =
+    const targetFixture =
       scenario === "ci-regression-29623139111"
-        ? createCiRegressionFixture(root)
+        ? createCiRegressionFixture(root, { fixture })
         : createTargetFixture(root, {
-            nonCanonicalLockfile: scenario === "dependency-setup-mutation",
+            fixture,
+            dependencySetupMutation: scenario === "dependency-setup-mutation",
           });
     const statePath = path.join(root, "github-state.json");
     const binDir = createCommandBin(root);
     const realCorepack = execFileSync("which", ["corepack"], { encoding: "utf8" }).trim();
-    const jobPath = createJob(root, fixture.headSha);
-    writeJson(statePath, initialGitHubState(fixture));
+    const jobPath = createJob(root, targetFixture.headSha);
+    writeJson(statePath, initialGitHubState(targetFixture));
 
     const baseEnv = {
       ...process.env,
@@ -119,7 +129,7 @@ export function runAutomergeE2E({
       return runCiRegressionFailureScenario({
         artifacts,
         baseEnv,
-        fixture,
+        fixture: targetFixture,
         jobPath,
         resultPath,
         runtimeRoot,
@@ -131,7 +141,7 @@ export function runAutomergeE2E({
       return runPlanningHeadDriftScenario({
         artifacts,
         baseEnv,
-        fixture,
+        fixture: targetFixture,
         jobPath,
         resultPath,
         runtimeRoot,
@@ -144,7 +154,7 @@ export function runAutomergeE2E({
       return runDependencySetupMutationScenario({
         artifacts,
         baseEnv,
-        fixture,
+        fixture: targetFixture,
         jobPath,
         resultPath,
         runtimeRoot,
@@ -155,7 +165,7 @@ export function runAutomergeE2E({
 
     const indexStatMutation =
       scenario === "ci-regression-29623139111"
-        ? startIndexStatMutation(targetDir, artifacts)
+        ? startIndexStatMutation(targetDir, targetFixture.repairTarget, artifacts)
         : null;
     runCli(
       runtimeRoot,
@@ -201,15 +211,16 @@ export function runAutomergeE2E({
       fs.readFileSync(path.join(transferDir, "post-flight-report.json"), "utf8"),
     );
 
-    const repairedHead = currentRef(fixture.remote, fixture.headRef);
+    const repairedHead = currentRef(targetFixture.remote, targetFixture.headRef);
+    assertFixturePostRepair(targetFixture, repairedHead);
     addExactHeadVerdict(statePath, repairedHead);
     if (scenario === "verdict-head-drift") {
-      const driftedHead = advanceRemoteContributorHead(root, fixture, "verdict head drift");
+      const driftedHead = advanceRemoteContributorHead(root, targetFixture, "verdict head drift");
       runCommentRouter(runtimeRoot, baseEnv, artifacts, "08-comment-router-stale-verdict");
       const routerReport = readRouterReport(runtimeRoot);
       const state = JSON.parse(fs.readFileSync(statePath, "utf8"));
       assert.equal(state.pr.mergedAt, null, "a stale exact-head verdict must not merge");
-      assert.equal(currentRef(fixture.remote, fixture.headRef), driftedHead);
+      assert.equal(currentRef(targetFixture.remote, targetFixture.headRef), driftedHead);
       assert.equal(
         state.calls.filter((call) => call.args[0] === "pr" && call.args[1] === "merge").length,
         0,
@@ -221,12 +232,13 @@ export function runAutomergeE2E({
       fs.copyFileSync(statePath, path.join(artifacts, "github-state.json"));
       writeJson(path.join(artifacts, "summary.json"), {
         status: "passed",
+        fixture,
         scenario,
         reviewed_head: repairedHead,
         current_head: driftedHead,
         merge: "blocked before mutation",
       });
-      return { status: "passed", scenario, artifacts };
+      return { status: "passed", fixture, scenario, artifacts };
     }
     if (scenario === "pending-checks") {
       updateGitHubState(statePath, (state) => {
@@ -300,6 +312,7 @@ export function runAutomergeE2E({
     fs.cpSync(transferDir, path.join(artifacts, "run"), { recursive: true });
     writeJson(path.join(artifacts, "summary.json"), {
       status: "passed",
+      fixture,
       scenario,
       target_repo: state.repo,
       target_pr: state.pr.number,
@@ -308,7 +321,7 @@ export function runAutomergeE2E({
       artifact_transfer: "planning run copied into a fresh execution workspace",
       tokens: ["read", "write", "post"],
     });
-    return { status: "passed", scenario, artifacts };
+    return { status: "passed", fixture, scenario, artifacts };
   } catch (error) {
     const deferredRun = path.join(root, "artifact-transfer");
     if (fs.existsSync(deferredRun)) {
@@ -324,6 +337,7 @@ export function runAutomergeE2E({
     }
     writeJson(path.join(artifacts, "failure.json"), {
       status: "failed",
+      fixture,
       scenario,
       error: error instanceof Error ? (error.stack ?? error.message) : String(error),
       retained_root: root,
@@ -423,6 +437,7 @@ function runPlanningHeadDriftScenario({
   fs.copyFileSync(reportPath, path.join(artifacts, "fix-execution-report.json"));
   writeJson(path.join(artifacts, "summary.json"), {
     status: "passed",
+    fixture: fixture.fixture,
     scenario: "planning-head-drift",
     target_repo: state.repo,
     target_pr: state.pr.number,
@@ -430,13 +445,13 @@ function runPlanningHeadDriftScenario({
     current_head: driftedHead,
     mutation: "blocked before target checkout, Codex, or push",
   });
-  return { status: "passed", scenario: "planning-head-drift", artifacts };
+  return { status: "passed", fixture: fixture.fixture, scenario: "planning-head-drift", artifacts };
 }
 
 function advanceContributorHead(fixture, message) {
-  const target = path.join(fixture.seed, "src", "repair-target.txt");
+  const target = path.join(fixture.seed, fixture.repairTarget);
   fs.appendFileSync(target, `${message}\n`);
-  git(["add", "src/repair-target.txt"], fixture.seed);
+  git(["add", fixture.repairTarget], fixture.seed);
   git(["commit", "-m", `test: ${message}`], fixture.seed);
   git(["push", "origin", fixture.headRef], fixture.seed);
   const head = currentRef(fixture.remote, fixture.headRef);
@@ -450,9 +465,9 @@ function advanceRemoteContributorHead(root, fixture, message) {
   git(["config", "user.name", "E2E Contributor"], checkout);
   git(["config", "user.email", "contributor@example.invalid"], checkout);
   git(["checkout", fixture.headRef], checkout);
-  const target = path.join(checkout, "src", "repair-target.txt");
+  const target = path.join(checkout, fixture.repairTarget);
   fs.appendFileSync(target, `${message}\n`);
-  git(["add", "src/repair-target.txt"], checkout);
+  git(["add", fixture.repairTarget], checkout);
   git(["commit", "-m", `test: ${message}`], checkout);
   git(["push", "origin", fixture.headRef], checkout);
   const head = currentRef(fixture.remote, fixture.headRef);
@@ -496,18 +511,24 @@ function runDependencySetupMutationScenario({
     "dependency setup failure must stop before branch push",
   );
   assert.equal(
-    fs.readFileSync(path.join(targetDir, "src", "repair-target.txt"), "utf8"),
+    fs.readFileSync(path.join(targetDir, fixture.repairTarget), "utf8"),
     "broken\n",
     "dependency setup failure must stop before Codex edits",
   );
   fs.copyFileSync(statePath, path.join(artifacts, "github-state.json"));
   writeJson(path.join(artifacts, "summary.json"), {
     status: "passed",
+    fixture: fixture.fixture,
     scenario: "dependency-setup-mutation",
     rejected_error: "target dependency setup mutated checkout identity",
     mutation: "blocked before Codex or push",
   });
-  return { status: "passed", scenario: "dependency-setup-mutation", artifacts };
+  return {
+    status: "passed",
+    fixture: fixture.fixture,
+    scenario: "dependency-setup-mutation",
+    artifacts,
+  };
 }
 
 function runCiRegressionFailureScenario({
@@ -552,13 +573,19 @@ function runCiRegressionFailureScenario({
   assert.equal(currentRef(fixture.remote, fixture.headRef), fixture.headSha);
   writeJson(path.join(artifacts, "summary.json"), {
     status: "passed",
+    fixture: fixture.fixture,
     scenario: "ci-regression-29623139111",
     expected_outcome: "setup-identity-failure",
     clawsweeper_revision: "7be2e4915b4b1d9aa953ccfe359cea670a4616ec",
     target_revision: fixture.headSha,
     reproduced_error: "target dependency setup mutated checkout identity",
   });
-  return { status: "passed", scenario: "ci-regression-29623139111", artifacts };
+  return {
+    status: "passed",
+    fixture: fixture.fixture,
+    scenario: "ci-regression-29623139111",
+    artifacts,
+  };
 }
 
 function runCommentRouter(runtimeRoot, baseEnv, artifacts, label) {
@@ -593,77 +620,6 @@ function updateGitHubState(statePath, update) {
   writeJson(statePath, state);
 }
 
-function createTargetFixture(
-  root,
-  { nonCanonicalLockfile = false, packageManager = "pnpm@11.10.0" } = {},
-) {
-  const remote = path.join(root, "target.git");
-  const seed = path.join(root, "target-seed");
-  git(["init", "--bare", remote]);
-  git(["init", "-b", "main", seed]);
-  git(["config", "user.name", "E2E Contributor"], seed);
-  git(["config", "user.email", "contributor@example.invalid"], seed);
-  fs.mkdirSync(path.join(seed, "scripts"), { recursive: true });
-  fs.mkdirSync(path.join(seed, "src"), { recursive: true });
-  fs.writeFileSync(
-    path.join(seed, "package.json"),
-    `${JSON.stringify(
-      {
-        name: "automerge-e2e-target",
-        private: true,
-        packageManager,
-        scripts: { "check:changed": "node scripts/check.mjs" },
-      },
-      null,
-      2,
-    )}\n`,
-  );
-  // Keep the fixture byte-for-byte canonical for the pinned pnpm. The happy
-  // path should detect production mutations, not manufacture one through a
-  // hand-written lockfile serialization that pnpm immediately normalizes.
-  fs.writeFileSync(
-    path.join(seed, "pnpm-lock.yaml"),
-    nonCanonicalLockfile
-      ? "lockfileVersion: '9.0'\nsettings:\n  autoInstallPeers: true\n  excludeLinksFromLockfile: false\nimporters:\n  .: {}\n"
-      : "lockfileVersion: '9.0'\n\nsettings:\n  autoInstallPeers: true\n  excludeLinksFromLockfile: false\n\nimporters:\n\n  .: {}\n",
-  );
-  fs.writeFileSync(path.join(seed, ".gitignore"), "node_modules/\n");
-  fs.writeFileSync(
-    path.join(seed, "scripts", "check.mjs"),
-    "import fs from 'node:fs';\nif (fs.readFileSync('src/repair-target.txt', 'utf8') !== 'fixed\\n') throw new Error('fixture is not repaired');\n",
-  );
-  fs.writeFileSync(path.join(seed, "src", "repair-target.txt"), "base\n");
-  git(["add", "."], seed);
-  git(["commit", "-m", "chore: seed target"], seed);
-  git(["remote", "add", "origin", remote], seed);
-  git(["push", "-u", "origin", "main"], seed);
-  git(["symbolic-ref", "HEAD", "refs/heads/main"], remote);
-  git(["checkout", "-b", "contributor/change"], seed);
-  fs.writeFileSync(path.join(seed, "src", "repair-target.txt"), "broken\n");
-  git(["add", "."], seed);
-  git(["commit", "-m", "feat: contributor change"], seed);
-  git(["push", "-u", "origin", "contributor/change"], seed);
-  git(["update-ref", "refs/pull/42/head", currentRef(remote, "contributor/change")], remote);
-  return {
-    remote,
-    seed,
-    headRef: "contributor/change",
-    headSha: currentRef(remote, "contributor/change"),
-  };
-}
-
-function createCiRegressionFixture(root) {
-  // The failure depends on ClawSweeper's runtime freezer, Git's index metadata,
-  // and the pinned package manager—not on OpenClaw's source or dependency graph.
-  // A minimal target keeps the production path real while avoiding a multi-GB
-  // checkout/install that can exhaust a developer machine before the assertion.
-  return {
-    ...createTargetFixture(root, { packageManager: "pnpm@11.2.2" }),
-    historicalBaseSha: "977e0b64a12152a2e112634c1c32e8505db08234",
-    historicalHeadSha: "34a3001388bb99fb4a041a73aad98631c4557634",
-  };
-}
-
 function initialGitHubState(fixture) {
   const now = new Date().toISOString();
   return {
@@ -693,6 +649,33 @@ function initialGitHubState(fixture) {
   };
 }
 
+function assertFixturePostRepair(fixture, repairedHead) {
+  if (!fixture.behindMain) return;
+  execFileSync(
+    "/usr/bin/git",
+    ["--git-dir", fixture.remote, "merge-base", "--is-ancestor", fixture.baseSha, repairedHead],
+    { stdio: "ignore" },
+  );
+  assert.equal(
+    execFileSync(
+      "/usr/bin/git",
+      ["--git-dir", fixture.remote, "show", `${repairedHead}:CHANGELOG.md`],
+      { encoding: "utf8" },
+    ),
+    fixture.changelog,
+    "ordinary OpenClaw automerge repair must preserve the release-owned changelog",
+  );
+  assert.match(
+    execFileSync(
+      "/usr/bin/git",
+      ["--git-dir", fixture.remote, "ls-tree", repairedHead, "CLAUDE.md"],
+      { encoding: "utf8" },
+    ),
+    /^120000 blob /,
+    "OpenClaw's tracked CLAUDE.md symlink must survive repair and base sync",
+  );
+}
+
 function createCommandBin(root) {
   const bin = path.join(root, "bin");
   fs.mkdirSync(bin);
@@ -707,11 +690,11 @@ function createCommandBin(root) {
   return bin;
 }
 
-function startIndexStatMutation(targetDir, artifacts) {
+function startIndexStatMutation(targetDir, trackedRelativePath, artifacts) {
   const marker = path.join(artifacts, "index-stat-mutation.txt");
   const child = spawn(
     process.execPath,
-    [path.join(helperRoot, "index-stat-mutator.mjs"), targetDir, marker],
+    [path.join(helperRoot, "index-stat-mutator.mjs"), targetDir, trackedRelativePath, marker],
     { stdio: "ignore" },
   );
   return { child, marker };

--- a/test/e2e/automerge/target-fixtures.mjs
+++ b/test/e2e/automerge/target-fixtures.mjs
@@ -1,0 +1,354 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+export const AUTOMERGE_E2E_FIXTURES = ["tiny", "openclaw-shaped"];
+
+export const OPENCLAW_SHAPED_CONTRACT = Object.freeze({
+  node: ">=22.22.3 <23 || >=24.15.0 <25 || >=25.9.0",
+  packageManager:
+    "pnpm@11.2.2+sha512.36e6621fad506178936455e70247b8808ef4ec25797a9f437a93281a020484e2607f6a469a22e982987c3dbb8866e3071514ab10a4a1749e06edcd1ec118436f",
+  repairTarget: "packages/fixture-core/src/repair-target.txt",
+});
+
+export function createTargetFixture(
+  root,
+  { fixture = "tiny", dependencySetupMutation = false, packageManager = "pnpm@11.10.0" } = {},
+) {
+  assertFixture(fixture);
+  return fixture === "openclaw-shaped"
+    ? createOpenClawShapedFixture(root, { dependencySetupMutation })
+    : createTinyFixture(root, { dependencySetupMutation, packageManager });
+}
+
+export function createCiRegressionFixture(root, { fixture = "tiny" } = {}) {
+  assertFixture(fixture);
+  return {
+    ...createTargetFixture(root, {
+      fixture,
+      packageManager: fixture === "tiny" ? "pnpm@11.2.2" : undefined,
+    }),
+    historicalBaseSha: "977e0b64a12152a2e112634c1c32e8505db08234",
+    historicalHeadSha: "34a3001388bb99fb4a041a73aad98631c4557634",
+  };
+}
+
+function createTinyFixture(root, { dependencySetupMutation, packageManager }) {
+  const repairTarget = "src/repair-target.txt";
+  return initializeRepository(root, {
+    fixture: "tiny",
+    repairTarget,
+    forcedTrackedFiles: dependencySetupMutation ? ["node_modules/.modules.yaml"] : [],
+    files: {
+      ".gitignore": "node_modules/\n",
+      "package.json": `${JSON.stringify(
+        {
+          name: "automerge-e2e-target",
+          private: true,
+          packageManager,
+          scripts: { "check:changed": "node scripts/check.mjs" },
+        },
+        null,
+        2,
+      )}\n`,
+      "pnpm-lock.yaml": tinyLockfile(),
+      ...(dependencySetupMutation ? { "node_modules/.modules.yaml": "stale: true\n" } : {}),
+      "scripts/check.mjs":
+        "import fs from 'node:fs';\nif (fs.readFileSync('src/repair-target.txt', 'utf8') !== 'fixed\\n') throw new Error('fixture is not repaired');\n",
+      [repairTarget]: "base\n",
+    },
+  });
+}
+
+function createOpenClawShapedFixture(root, { dependencySetupMutation }) {
+  const repairTarget = OPENCLAW_SHAPED_CONTRACT.repairTarget;
+  const fixture = initializeRepository(root, {
+    fixture: "openclaw-shaped",
+    repairTarget,
+    forcedTrackedFiles: dependencySetupMutation ? ["node_modules/.modules.yaml"] : [],
+    trackedSymlinks: { "CLAUDE.md": "AGENTS.md" },
+    files: {
+      ".gitignore": [
+        "node_modules/",
+        "**/node_modules/",
+        "dist/",
+        ".turbo/",
+        ".openclaw/runtime/",
+        "test-results/",
+        "",
+      ].join("\n"),
+      ".npmrc":
+        "# pnpm v11 reads project settings from pnpm-workspace.yaml.\n# Keep registry/auth-only settings here.\n",
+      "AGENTS.md":
+        "# OpenClaw-shaped fixture\n\nUse workspace-aware validation. CHANGELOG.md is release-owned and must not be edited by repair automation.\n",
+      "CHANGELOG.md":
+        "# Changelog\n\n## Unreleased\n\nRelease maintainers own this file; automerge repair must preserve it.\n",
+      "package.json": openClawRootPackage(),
+      "pnpm-workspace.yaml": openClawWorkspace(),
+      "pnpm-lock.yaml": openClawLockfile(),
+      ...(dependencySetupMutation ? { "node_modules/.modules.yaml": "stale: true\n" } : {}),
+      "scripts/check-changed.mjs": openClawChangedGate(),
+      "scripts/fixture-gate.mjs": openClawNamedGate(),
+      "ui/package.json": workspacePackage("@openclaw/fixture-ui", {
+        "@openclaw/fixture-core": "workspace:*",
+      }),
+      "ui/src/index.js": "export const uiFixture = true;\n",
+      "packages/fixture-core/package.json": workspacePackage("@openclaw/fixture-core"),
+      "packages/fixture-core/src/index.js": "export const coreFixture = true;\n",
+      [repairTarget]: "base\n",
+      "extensions/fixture-extension/package.json": workspacePackage("@openclaw/fixture-extension", {
+        "@openclaw/fixture-core": "workspace:*",
+      }),
+      "extensions/fixture-extension/src/index.js":
+        "export { coreFixture as extensionFixture } from '@openclaw/fixture-core';\n",
+      "examples/fixture-example/package.json": workspacePackage("openclaw-fixture-example", {
+        "@openclaw/fixture-extension": "workspace:*",
+      }),
+      "examples/fixture-example/index.js":
+        "import { extensionFixture } from '@openclaw/fixture-extension';\nif (!extensionFixture) process.exit(1);\n",
+    },
+  });
+
+  // The production target is often behind a moving OpenClaw main. Advance a
+  // disjoint tracked path after the contributor branch so the real executor,
+  // not the simulator, must synchronize base ancestry before it can push.
+  git(["checkout", "main"], fixture.seed);
+  writeFile(fixture.seed, "docs/main-since-contributor.md", "Main advanced after the PR.\n");
+  git(["add", "docs/main-since-contributor.md"], fixture.seed);
+  git(["commit", "-m", "docs: advance fixture main"], fixture.seed);
+  git(["push", "origin", "main"], fixture.seed);
+  git(["checkout", fixture.headRef], fixture.seed);
+  return { ...fixture, baseSha: currentRef(fixture.remote, "main"), behindMain: true };
+}
+
+function initializeRepository(
+  root,
+  { fixture, files, repairTarget, forcedTrackedFiles = [], trackedSymlinks = {} },
+) {
+  const remote = path.join(root, "target.git");
+  const seed = path.join(root, "target-seed");
+  git(["init", "--bare", remote]);
+  git(["init", "-b", "main", seed]);
+  git(["config", "user.name", "E2E Contributor"], seed);
+  git(["config", "user.email", "contributor@example.invalid"], seed);
+  for (const [relative, contents] of Object.entries(files)) writeFile(seed, relative, contents);
+  for (const [relative, target] of Object.entries(trackedSymlinks)) {
+    fs.symlinkSync(target, path.join(seed, relative));
+  }
+  git(["add", "."], seed);
+  // The mutation scenario deliberately tracks package-manager metadata even
+  // though production repositories ignore node_modules. pnpm must rewrite it,
+  // giving the containment assertion a deterministic real filesystem mutation.
+  for (const relative of forcedTrackedFiles) git(["add", "--force", relative], seed);
+  git(["commit", "-m", "chore: seed target"], seed);
+  git(["remote", "add", "origin", remote], seed);
+  git(["push", "-u", "origin", "main"], seed);
+  git(["symbolic-ref", "HEAD", "refs/heads/main"], remote);
+  git(["checkout", "-b", "contributor/change"], seed);
+  writeFile(seed, repairTarget, "broken\n");
+  git(["add", repairTarget], seed);
+  git(["commit", "-m", "feat: contributor change"], seed);
+  git(["push", "-u", "origin", "contributor/change"], seed);
+  git(["update-ref", "refs/pull/42/head", currentRef(remote, "contributor/change")], remote);
+  return {
+    fixture,
+    remote,
+    seed,
+    repairTarget,
+    files: [repairTarget],
+    headRef: "contributor/change",
+    headSha: currentRef(remote, "contributor/change"),
+    changelog: files["CHANGELOG.md"] ?? null,
+  };
+}
+
+function openClawRootPackage() {
+  return `${JSON.stringify(
+    {
+      name: "openclaw-shaped-automerge-e2e",
+      version: "0.0.0",
+      private: true,
+      type: "module",
+      engines: { node: OPENCLAW_SHAPED_CONTRACT.node },
+      packageManager: OPENCLAW_SHAPED_CONTRACT.packageManager,
+      scripts: {
+        "check:changed": "node scripts/check-changed.mjs",
+        "check:test-types": "node scripts/fixture-gate.mjs test-types",
+        lint: "node scripts/fixture-gate.mjs lint",
+        test: "node scripts/fixture-gate.mjs test",
+      },
+      dependencies: {
+        "@openclaw/fixture-core": "workspace:*",
+        "@openclaw/fixture-extension": "workspace:*",
+      },
+    },
+    null,
+    2,
+  )}\n`;
+}
+
+function workspacePackage(name, dependencies = undefined) {
+  return `${JSON.stringify(
+    {
+      name,
+      version: "0.0.0",
+      private: true,
+      type: "module",
+      ...(dependencies ? { dependencies } : {}),
+    },
+    null,
+    2,
+  )}\n`;
+}
+
+function openClawWorkspace() {
+  return `packages:
+  - .
+  - ui
+  - packages/*
+  - extensions/*
+  - examples/*
+
+minimumReleaseAge: 2880
+
+minimumReleaseAgeExclude:
+  - fixture-overridden
+
+nodeLinker: hoisted
+blockExoticSubdeps: true
+
+overrides:
+  fixture-overridden: 1.0.0
+
+allowBuilds:
+  fixture-native: false
+`;
+}
+
+function openClawLockfile() {
+  const lockfile = `lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+overrides:
+  fixture-overridden: 1.0.0
+
+importers:
+
+  .:
+    dependencies:
+      '@openclaw/fixture-core':
+        specifier: workspace:*
+        version: link:packages/fixture-core
+      '@openclaw/fixture-extension':
+        specifier: workspace:*
+        version: link:extensions/fixture-extension
+
+  examples/fixture-example:
+    dependencies:
+      '@openclaw/fixture-extension':
+        specifier: workspace:*
+        version: link:../../extensions/fixture-extension
+
+  extensions/fixture-extension:
+    dependencies:
+      '@openclaw/fixture-core':
+        specifier: workspace:*
+        version: link:../../packages/fixture-core
+
+  packages/fixture-core: {}
+
+  ui:
+    dependencies:
+      '@openclaw/fixture-core':
+        specifier: workspace:*
+        version: link:../packages/fixture-core
+`;
+  return lockfile;
+}
+
+function openClawChangedGate() {
+  return `/**
+ * Definition: model OpenClaw's changed-surface gate for the E2E fixture.
+ * Parameters: none. Output: one JSON summary; non-zero means routing, links,
+ * the repair result, or release-owned CHANGELOG preservation is wrong.
+ */
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+
+const changed = execFileSync("/usr/bin/git", ["diff", "--name-only", "origin/main...HEAD"], {
+  encoding: "utf8",
+})
+  .trim()
+  .split("\\n")
+  .filter(Boolean);
+const repairTarget = "packages/fixture-core/src/repair-target.txt";
+assert.ok(changed.includes(repairTarget), "check:changed did not select the repaired package");
+assert.ok(!changed.includes("CHANGELOG.md"), "ordinary automerge repair changed CHANGELOG.md");
+assert.equal(fs.readFileSync(repairTarget, "utf8"), "fixed\\n");
+assert.equal(
+  fs.realpathSync("node_modules/@openclaw/fixture-core"),
+  fs.realpathSync("packages/fixture-core"),
+  "pnpm did not create the expected root workspace link",
+);
+assert.equal(
+  fs.realpathSync("extensions/fixture-extension/node_modules/@openclaw/fixture-core"),
+  fs.realpathSync("packages/fixture-core"),
+  "pnpm did not create the expected extension workspace link",
+);
+const scopes = changed.map((file) =>
+  file.startsWith("packages/")
+    ? "package"
+    : file.startsWith("extensions/")
+      ? "extension"
+      : file.startsWith("ui/")
+        ? "ui"
+        : "root",
+);
+process.stdout.write(
+  JSON.stringify({ gate: "check:changed", scopes: [...new Set(scopes)].sort(), changed }) + "\\n",
+);
+`;
+}
+
+function openClawNamedGate() {
+  return `/**
+ * Definition: preserve OpenClaw's stable validation script names in the fixture.
+ * Parameter: gate name. Output: one JSON summary; non-zero rejects unknown gates.
+ */
+const gate = process.argv[2];
+if (!new Set(["lint", "test", "test-types"]).has(gate)) {
+  throw new Error("unsupported fixture gate: " + (gate ?? "missing"));
+}
+process.stdout.write(JSON.stringify({ gate, status: "passed" }) + "\\n");
+`;
+}
+
+function tinyLockfile() {
+  return "lockfileVersion: '9.0'\n\nsettings:\n  autoInstallPeers: true\n  excludeLinksFromLockfile: false\n\nimporters:\n\n  .: {}\n";
+}
+
+function writeFile(root, relative, contents) {
+  const target = path.join(root, relative);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, contents);
+}
+
+function currentRef(remote, ref) {
+  return execFileSync("/usr/bin/git", ["--git-dir", remote, "rev-parse", `refs/heads/${ref}`], {
+    encoding: "utf8",
+  }).trim();
+}
+
+function git(args, cwd = process.cwd()) {
+  execFileSync("/usr/bin/git", args, { cwd, stdio: "ignore" });
+}
+
+function assertFixture(fixture) {
+  if (!AUTOMERGE_E2E_FIXTURES.includes(fixture)) {
+    throw new Error(`unsupported fixture: ${fixture}`);
+  }
+}

--- a/test/repair/automerge-e2e-container.test.ts
+++ b/test/repair/automerge-e2e-container.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 
 const wrapper = fs.readFileSync("scripts/e2e/automerge-container.mjs", "utf8");
 const dockerfile = fs.readFileSync("test/e2e/automerge/Dockerfile", "utf8");
+const baseDockerfile = fs.readFileSync("test/e2e/automerge/Dockerfile.base", "utf8");
 
 test("automerge E2E container preserves nested production containment", () => {
   assert.doesNotMatch(wrapper, /"--user"/);
@@ -26,4 +27,13 @@ test("automerge E2E builds the default base from repository-controlled source", 
   );
   assert.match(wrapper, /`AUTOMERGE_E2E_BASE_IMAGE=\$\{baseImage\}`/);
   assert.doesNotMatch(`${wrapper}\n${dockerfile}`, /masonxhuang\//);
+});
+
+test("automerge E2E runs on OpenClaw's supported Node 24 floor", () => {
+  assert.match(
+    baseDockerfile,
+    /^FROM node:24\.15\.0-bookworm-slim@sha256:4e6b70dd6cbfc88c8157ba19aa3d9f9cce6ba4703576d55459e45efcbc9c5f5d/m,
+  );
+  assert.match(wrapper, /const fixture = String\(args\.fixture \?\? "all"\)/);
+  assert.match(wrapper, /"--fixture",\s*fixture/);
 });

--- a/test/repair/automerge-e2e-workflow.test.ts
+++ b/test/repair/automerge-e2e-workflow.test.ts
@@ -8,6 +8,7 @@ test("automerge E2E uses the production containment runner and container entrypo
   assert.match(workflow, /runs-on: blacksmith-16vcpu-ubuntu-2404/);
   assert.match(workflow, /node scripts\/e2e\/automerge-container\.mjs/);
   assert.match(workflow, /--scenario all/);
+  assert.match(workflow, /--fixture all/);
   assert.match(workflow, /--output test-results\/automerge/);
   assert.doesNotMatch(workflow, /\.\/\.github\/actions\/setup-pnpm/);
 });

--- a/test/repair/automerge-openclaw-shaped-fixture.test.ts
+++ b/test/repair/automerge-openclaw-shaped-fixture.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  createTargetFixture,
+  OPENCLAW_SHAPED_CONTRACT,
+} from "../e2e/automerge/target-fixtures.mjs";
+
+test("openclaw-shaped automerge fixture preserves production repository contracts", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-openclaw-shaped-test-"));
+  try {
+    const fixture = createTargetFixture(root, { fixture: "openclaw-shaped" });
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(fixture.seed, "package.json"), "utf8"),
+    );
+    const workspace = fs.readFileSync(path.join(fixture.seed, "pnpm-workspace.yaml"), "utf8");
+    const lockfile = fs.readFileSync(path.join(fixture.seed, "pnpm-lock.yaml"), "utf8");
+
+    assert.equal(packageJson.engines.node, OPENCLAW_SHAPED_CONTRACT.node);
+    assert.equal(packageJson.packageManager, OPENCLAW_SHAPED_CONTRACT.packageManager);
+    assert.deepEqual(Object.keys(packageJson.scripts).sort(), [
+      "check:changed",
+      "check:test-types",
+      "lint",
+      "test",
+    ]);
+    for (const pattern of ["- .", "- ui", "- packages/*", "- extensions/*", "- examples/*"]) {
+      assert.match(workspace, new RegExp(escapeRegExp(pattern)));
+    }
+    assert.match(workspace, /minimumReleaseAge: 2880/);
+    assert.match(workspace, /nodeLinker: hoisted/);
+    assert.match(workspace, /overrides:/);
+    assert.match(workspace, /allowBuilds:/);
+    assert.match(lockfile, /version: link:packages\/fixture-core/);
+    assert.match(lockfile, /version: link:\.\.\/\.\.\/packages\/fixture-core/);
+    assert.equal(fixture.repairTarget, OPENCLAW_SHAPED_CONTRACT.repairTarget);
+    assert.deepEqual(fixture.files, [OPENCLAW_SHAPED_CONTRACT.repairTarget]);
+    assert.equal(fs.readlinkSync(path.join(fixture.seed, "CLAUDE.md")), "AGENTS.md");
+    assert.equal(fixture.behindMain, true);
+    assert.notEqual(
+      spawnSync(
+        "/usr/bin/git",
+        [
+          "--git-dir",
+          fixture.remote,
+          "merge-base",
+          "--is-ancestor",
+          fixture.baseSha,
+          fixture.headSha,
+        ],
+        { stdio: "ignore" },
+      ).status,
+      0,
+      "the contributor head must start behind the latest fixture main",
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}


### PR DESCRIPTION
## Summary

- retain the tiny automerge fixture for fast state-machine and failure-injection coverage
- add an OpenClaw-shaped target with the real Node/pnpm contract, workspace links, changed-surface validation, repository profile, tracked policy symlink, behind-main history, and release-owned changelog invariant
- run both fixtures across all six automerge scenarios in the local container and trusted CI lane
- pin the reusable E2E base to Node 24.15 and cache the repository-built base image in Actions
- make the simulated GitHub clone complete and non-local, with a fail-closed non-shallow assertion

## Why

The existing tiny fixture proved the automerge state machine but could not show whether OpenClaw's workspace, profile, strict validation, and Git contracts would retrigger a repair failure. This adds those production-shaped contracts without cloning or installing the full OpenClaw repository.

The full-clone invariant is intentional. A shallow local repository is not representative of GitHub transport and can amplify missing-object recovery into repeated Git work. Repository realism now comes from a small tracked fixture and its history shape instead of a large checkout or an artificial shallow boundary.

## Validation

- local container with fixed base image digest: tiny + OpenClaw-shaped, 6 scenarios each, 12/12 passed after the full-clone change
- historical CI regression 29623139111 passes in both fixtures on the current candidate
- `pnpm --config.verify-deps-before-run=false run check`
  - unit: 1334 passed, 1 skipped
  - repair: 942 passed, 3 skipped
  - changed coverage: 100% lines, 88.61% branches, 100% functions
  - full coverage: 77.74% lines, 73.39% branches, 86.01% functions
  - formatting: 415 files clean
- branch-range gitleaks: no leaks
- autoreview: no actionable findings; patch is correct (0.84)

## Runtime boundary

The container remains bounded at 8 GiB memory, no extra swap, and 1024 PIDs. It runs without privileged mode or added capabilities; the production target validator still owns nested containment and capability dropping.
